### PR TITLE
Store panels and docks instances in their classes

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -5012,7 +5012,7 @@ struct _AnimMoveRestore {
 void AnimationTrackEditor::_clear_key_edit() {
 	if (key_edit) {
 		// If key edit is the object being inspected, remove it first.
-		if (EditorNode::get_singleton()->get_inspector()->get_edited_object() == key_edit) {
+		if (InspectorDock::get_inspector_singleton()->get_edited_object() == key_edit) {
 			EditorNode::get_singleton()->push_item(nullptr);
 		}
 
@@ -5022,7 +5022,7 @@ void AnimationTrackEditor::_clear_key_edit() {
 	}
 
 	if (multi_key_edit) {
-		if (EditorNode::get_singleton()->get_inspector()->get_edited_object() == multi_key_edit) {
+		if (InspectorDock::get_inspector_singleton()->get_edited_object() == multi_key_edit) {
 			EditorNode::get_singleton()->push_item(nullptr);
 		}
 

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -649,8 +649,8 @@ void ConnectionsDock::_connect(ConnectDialog::ConnectionData p_cd) {
 	undo_redo->add_undo_method(source, "disconnect", p_cd.signal, callable);
 	undo_redo->add_do_method(this, "update_tree");
 	undo_redo->add_undo_method(this, "update_tree");
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); // To force redraw of scene tree.
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree"); // To force redraw of scene tree.
+	undo_redo->add_undo_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -671,8 +671,8 @@ void ConnectionsDock::_disconnect(TreeItem &p_item) {
 	undo_redo->add_undo_method(selected_node, "connect", cd.signal, callable, cd.binds, cd.flags);
 	undo_redo->add_do_method(this, "update_tree");
 	undo_redo->add_undo_method(this, "update_tree");
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree"); // To force redraw of scene tree.
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree"); // To force redraw of scene tree.
+	undo_redo->add_undo_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -702,8 +702,8 @@ void ConnectionsDock::_disconnect_all() {
 
 	undo_redo->add_do_method(this, "update_tree");
 	undo_redo->add_undo_method(this, "update_tree");
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -75,8 +75,8 @@ EditorDebuggerNode::EditorDebuggerNode() {
 	remote_scene_tree = memnew(EditorDebuggerTree);
 	remote_scene_tree->connect("object_selected", callable_mp(this, &EditorDebuggerNode::_remote_object_requested));
 	remote_scene_tree->connect("save_node", callable_mp(this, &EditorDebuggerNode::_save_node_requested));
-	EditorNode::get_singleton()->get_scene_tree_dock()->add_remote_tree_editor(remote_scene_tree);
-	EditorNode::get_singleton()->get_scene_tree_dock()->connect("remote_tree_selected", callable_mp(this, &EditorDebuggerNode::request_remote_tree));
+	SceneTreeDock::get_singleton()->add_remote_tree_editor(remote_scene_tree);
+	SceneTreeDock::get_singleton()->connect("remote_tree_selected", callable_mp(this, &EditorDebuggerNode::request_remote_tree));
 
 	remote_scene_tree_timeout = EDITOR_DEF("debugger/remote_scene_tree_refresh_interval", 1.0);
 	inspect_edited_object_timeout = EDITOR_DEF("debugger/remote_inspect_refresh_interval", 0.2);
@@ -332,10 +332,10 @@ void EditorDebuggerNode::_notification(int p_what) {
 		// Switch to remote tree view if so desired.
 		auto_switch_remote_scene_tree = (bool)EditorSettings::get_singleton()->get("debugger/auto_switch_to_remote_scene_tree");
 		if (auto_switch_remote_scene_tree) {
-			EditorNode::get_singleton()->get_scene_tree_dock()->show_remote_tree();
+			SceneTreeDock::get_singleton()->show_remote_tree();
 		}
 		// Good to go.
-		EditorNode::get_singleton()->get_scene_tree_dock()->show_tab_buttons();
+		SceneTreeDock::get_singleton()->show_tab_buttons();
 		debugger->set_editor_remote_tree(remote_scene_tree);
 		debugger->start(server->take_connection());
 		// Send breakpoints.
@@ -361,8 +361,8 @@ void EditorDebuggerNode::_debugger_stopped(int p_id) {
 	if (!found) {
 		EditorNode::get_singleton()->get_pause_button()->set_pressed(false);
 		EditorNode::get_singleton()->get_pause_button()->set_disabled(true);
-		EditorNode::get_singleton()->get_scene_tree_dock()->hide_remote_tree();
-		EditorNode::get_singleton()->get_scene_tree_dock()->hide_tab_buttons();
+		SceneTreeDock::get_singleton()->hide_remote_tree();
+		SceneTreeDock::get_singleton()->hide_tab_buttons();
 		EditorNode::get_singleton()->notify_all_debug_sessions_exited();
 	}
 }
@@ -576,7 +576,7 @@ void EditorDebuggerNode::_remote_object_property_updated(ObjectID p_id, const St
 		if (obj->remote_object_id != p_id) {
 			return;
 		}
-		EditorNode::get_singleton()->get_inspector()->update_property(p_property);
+		InspectorDock::get_inspector_singleton()->update_property(p_property);
 	}
 }
 

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -128,7 +128,7 @@ void EditorDebuggerTree::_scene_tree_rmb_selected(const Vector2 &p_position) {
 void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int p_debugger) {
 	updating_scene_tree = true;
 	const String last_path = get_selected_path();
-	const String filter = EditorNode::get_singleton()->get_scene_tree_dock()->get_filter();
+	const String filter = SceneTreeDock::get_singleton()->get_filter();
 	bool filter_changed = filter != last_filter;
 	TreeItem *scroll_item = nullptr;
 

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1163,7 +1163,7 @@ void EditorAudioBuses::_server_save() {
 }
 
 void EditorAudioBuses::_select_layout() {
-	EditorNode::get_singleton()->get_filesystem_dock()->select_file(edited_path);
+	FileSystemDock::get_singleton()->select_file(edited_path);
 }
 
 void EditorAudioBuses::_save_as_layout() {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -861,10 +861,10 @@ String EditorProperty::get_tooltip_text() const {
 void EditorProperty::menu_option(int p_option) {
 	switch (p_option) {
 		case MENU_COPY_PROPERTY: {
-			EditorNode::get_singleton()->get_inspector()->set_property_clipboard(object->get(property));
+			InspectorDock::get_inspector_singleton()->set_property_clipboard(object->get(property));
 		} break;
 		case MENU_PASTE_PROPERTY: {
-			emit_changed(property, EditorNode::get_singleton()->get_inspector()->get_property_clipboard());
+			emit_changed(property, InspectorDock::get_inspector_singleton()->get_property_clipboard());
 		} break;
 		case MENU_COPY_PROPERTY_PATH: {
 			DisplayServer::get_singleton()->clipboard_set(property);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -429,7 +429,7 @@ void EditorNode::unhandled_input(const Ref<InputEvent> &p_event) {
 			_scene_tab_changed(next_tab);
 		}
 		if (ED_IS_SHORTCUT("editor/filter_files", p_event)) {
-			filesystem_dock->focus_on_filter();
+			FileSystemDock::get_singleton()->focus_on_filter();
 		}
 
 		if (ED_IS_SHORTCUT("editor/editor_2d", p_event)) {
@@ -1100,8 +1100,8 @@ void EditorNode::_version_button_pressed() {
 }
 
 void EditorNode::_node_renamed() {
-	if (get_inspector()) {
-		get_inspector()->update_tree();
+	if (InspectorDock::get_inspector_singleton()) {
+		InspectorDock::get_inspector_singleton()->update_tree();
 	}
 }
 
@@ -1162,7 +1162,7 @@ Error EditorNode::load_resource(const String &p_resource, bool p_ignore_broken_d
 		return ERR_FILE_MISSING_DEPENDENCIES;
 	}
 
-	inspector_dock->edit_resource(res);
+	InspectorDock::get_singleton()->edit_resource(res);
 	return OK;
 }
 
@@ -2070,10 +2070,10 @@ void EditorNode::edit_item(Object *p_object) {
 
 void EditorNode::push_item(Object *p_object, const String &p_property, bool p_inspector_only) {
 	if (!p_object) {
-		get_inspector()->edit(nullptr);
-		node_dock->set_node(nullptr);
-		scene_tree_dock->set_selected(nullptr);
-		inspector_dock->update(nullptr);
+		InspectorDock::get_inspector_singleton()->edit(nullptr);
+		NodeDock::get_singleton()->set_node(nullptr);
+		SceneTreeDock::get_singleton()->set_selected(nullptr);
+		InspectorDock::get_singleton()->update(nullptr);
 		_display_top_editors(false);
 		return;
 	}
@@ -2146,17 +2146,17 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 	this->current = current_obj;
 
 	if (!current_obj) {
-		scene_tree_dock->set_selected(nullptr);
-		get_inspector()->edit(nullptr);
-		node_dock->set_node(nullptr);
-		inspector_dock->update(nullptr);
+		SceneTreeDock::get_singleton()->set_selected(nullptr);
+		InspectorDock::get_inspector_singleton()->edit(nullptr);
+		NodeDock::get_singleton()->set_node(nullptr);
+		InspectorDock::get_singleton()->update(nullptr);
 
 		_display_top_editors(false);
 
 		return;
 	}
 
-	Object *prev_inspected_object = get_inspector()->get_edited_object();
+	Object *prev_inspected_object = InspectorDock::get_inspector_singleton()->get_edited_object();
 
 	bool disable_folding = bool(EDITOR_GET("interface/inspector/disable_folding"));
 	bool is_resource = current_obj->is_class("Resource");
@@ -2167,11 +2167,11 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 	if (is_resource) {
 		Resource *current_res = Object::cast_to<Resource>(current_obj);
 		ERR_FAIL_COND(!current_res);
-		get_inspector()->edit(current_res);
-		scene_tree_dock->set_selected(nullptr);
-		node_dock->set_node(nullptr);
-		inspector_dock->update(nullptr);
-		EditorNode::get_singleton()->get_import_dock()->set_edit_path(current_res->get_path());
+		InspectorDock::get_inspector_singleton()->edit(current_res);
+		SceneTreeDock::get_singleton()->set_selected(nullptr);
+		NodeDock::get_singleton()->set_node(nullptr);
+		InspectorDock::get_singleton()->update(nullptr);
+		ImportDock::get_singleton()->set_edit_path(current_res->get_path());
 
 		int subr_idx = current_res->get_path().find("::");
 		if (subr_idx != -1) {
@@ -2192,15 +2192,15 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 		Node *current_node = Object::cast_to<Node>(current_obj);
 		ERR_FAIL_COND(!current_node);
 
-		get_inspector()->edit(current_node);
+		InspectorDock::get_inspector_singleton()->edit(current_node);
 		if (current_node->is_inside_tree()) {
-			node_dock->set_node(current_node);
-			scene_tree_dock->set_selected(current_node);
-			inspector_dock->update(current_node);
+			NodeDock::get_singleton()->set_node(current_node);
+			SceneTreeDock::get_singleton()->set_selected(current_node);
+			InspectorDock::get_singleton()->update(current_node);
 		} else {
-			node_dock->set_node(nullptr);
-			scene_tree_dock->set_selected(nullptr);
-			inspector_dock->update(nullptr);
+			NodeDock::get_singleton()->set_node(nullptr);
+			SceneTreeDock::get_singleton()->set_selected(nullptr);
+			InspectorDock::get_singleton()->update(nullptr);
 		}
 
 		if (get_edited_scene() && !get_edited_scene()->get_scene_file_path().is_empty()) {
@@ -2238,21 +2238,21 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 			}
 		}
 
-		get_inspector()->edit(current_obj);
-		node_dock->set_node(nullptr);
-		scene_tree_dock->set_selected(selected_node);
-		inspector_dock->update(nullptr);
+		InspectorDock::get_inspector_singleton()->edit(current_obj);
+		NodeDock::get_singleton()->set_node(nullptr);
+		SceneTreeDock::get_singleton()->set_selected(selected_node);
+		InspectorDock::get_singleton()->update(nullptr);
 	}
 
 	if (current_obj == prev_inspected_object) {
 		// Make sure inspected properties are restored.
-		get_inspector()->update_tree();
+		InspectorDock::get_inspector_singleton()->update_tree();
 	}
 
-	inspector_dock->set_warning(editable_warning);
+	InspectorDock::get_singleton()->set_warning(editable_warning);
 
-	if (get_inspector()->is_using_folding() == disable_folding) {
-		get_inspector()->set_use_folding(!disable_folding);
+	if (InspectorDock::get_inspector_singleton()->is_using_folding() == disable_folding) {
+		InspectorDock::get_inspector_singleton()->set_use_folding(!disable_folding);
 	}
 
 	/* Take care of PLUGIN EDITOR */
@@ -2306,7 +2306,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 		}
 	}
 
-	inspector_dock->update(current_obj);
+	InspectorDock::get_singleton()->update(current_obj);
 }
 
 void EditorNode::_run(bool p_current, const String &p_custom) {
@@ -2764,7 +2764,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case FILE_SHOW_IN_FILESYSTEM: {
 			String path = editor_data.get_scene_path(editor_data.get_edited_scene());
 			if (!path.is_empty()) {
-				filesystem_dock->navigate_to_path(path);
+				FileSystemDock::get_singleton()->navigate_to_path(path);
 			}
 		} break;
 
@@ -3361,7 +3361,7 @@ void EditorNode::set_edited_scene(Node *p_scene) {
 	if (Object::cast_to<Popup>(p_scene)) {
 		Object::cast_to<Popup>(p_scene)->show(); // show popups
 	}
-	scene_tree_dock->set_edited_scene(p_scene);
+	SceneTreeDock::get_singleton()->set_edited_scene(p_scene);
 	if (get_tree()) {
 		get_tree()->set_edited_scene_root(p_scene);
 	}
@@ -3386,10 +3386,10 @@ int EditorNode::_get_current_main_editor() {
 Dictionary EditorNode::_get_main_scene_state() {
 	Dictionary state;
 	state["main_tab"] = _get_current_main_editor();
-	state["scene_tree_offset"] = scene_tree_dock->get_tree_editor()->get_scene_tree()->get_vscroll_bar()->get_value();
-	state["property_edit_offset"] = get_inspector()->get_scroll_offset();
+	state["scene_tree_offset"] = SceneTreeDock::get_singleton()->get_tree_editor()->get_scene_tree()->get_vscroll_bar()->get_value();
+	state["property_edit_offset"] = InspectorDock::get_inspector_singleton()->get_scroll_offset();
 	state["saved_version"] = saved_version;
-	state["node_filter"] = scene_tree_dock->get_filter();
+	state["node_filter"] = SceneTreeDock::get_singleton()->get_filter();
 	return state;
 }
 
@@ -3431,14 +3431,14 @@ void EditorNode::_set_main_scene_state(Dictionary p_state, Node *p_for_scene) {
 	}
 
 	if (p_state.has("scene_tree_offset")) {
-		scene_tree_dock->get_tree_editor()->get_scene_tree()->get_vscroll_bar()->set_value(p_state["scene_tree_offset"]);
+		SceneTreeDock::get_singleton()->get_tree_editor()->get_scene_tree()->get_vscroll_bar()->set_value(p_state["scene_tree_offset"]);
 	}
 	if (p_state.has("property_edit_offset")) {
-		get_inspector()->set_scroll_offset(p_state["property_edit_offset"]);
+		InspectorDock::get_inspector_singleton()->set_scroll_offset(p_state["property_edit_offset"]);
 	}
 
 	if (p_state.has("node_filter")) {
-		scene_tree_dock->set_filter(p_state["node_filter"]);
+		SceneTreeDock::get_singleton()->set_filter(p_state["node_filter"]);
 	}
 
 	// this should only happen at the very end
@@ -3493,7 +3493,7 @@ void EditorNode::set_current_scene(int p_idx) {
 		Object::cast_to<Popup>(new_scene)->show(); // show popups
 	}
 
-	scene_tree_dock->set_edited_scene(new_scene);
+	SceneTreeDock::get_singleton()->set_edited_scene(new_scene);
 	if (get_tree()) {
 		get_tree()->set_edited_scene_root(new_scene);
 	}
@@ -3673,7 +3673,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 
 	prev_scene->set_disabled(previous_scenes.size() == 0);
 	opening_prev = false;
-	scene_tree_dock->set_selected(new_scene);
+	SceneTreeDock::get_singleton()->set_selected(new_scene);
 
 	EditorDebuggerNode::get_singleton()->update_live_edit_root();
 
@@ -3698,27 +3698,11 @@ void EditorNode::open_request(const String &p_path) {
 }
 
 void EditorNode::request_instance_scene(const String &p_path) {
-	scene_tree_dock->instantiate(p_path);
+	SceneTreeDock::get_singleton()->instantiate(p_path);
 }
 
 void EditorNode::request_instantiate_scenes(const Vector<String> &p_files) {
-	scene_tree_dock->instantiate_scenes(p_files);
-}
-
-ImportDock *EditorNode::get_import_dock() {
-	return import_dock;
-}
-
-FileSystemDock *EditorNode::get_filesystem_dock() {
-	return filesystem_dock;
-}
-
-SceneTreeDock *EditorNode::get_scene_tree_dock() {
-	return scene_tree_dock;
-}
-
-InspectorDock *EditorNode::get_inspector_dock() {
-	return inspector_dock;
+	SceneTreeDock::get_singleton()->instantiate_scenes(p_files);
 }
 
 void EditorNode::_inherit_request(String p_file) {
@@ -4514,10 +4498,10 @@ void EditorNode::_save_docks_to_config(Ref<ConfigFile> p_layout, const String &p
 		}
 	}
 
-	p_layout->set_value(p_section, "dock_filesystem_split", filesystem_dock->get_split_offset());
-	p_layout->set_value(p_section, "dock_filesystem_display_mode", filesystem_dock->get_display_mode());
-	p_layout->set_value(p_section, "dock_filesystem_file_sort", filesystem_dock->get_file_sort());
-	p_layout->set_value(p_section, "dock_filesystem_file_list_display_mode", filesystem_dock->get_file_list_display_mode());
+	p_layout->set_value(p_section, "dock_filesystem_split", FileSystemDock::get_singleton()->get_split_offset());
+	p_layout->set_value(p_section, "dock_filesystem_display_mode", FileSystemDock::get_singleton()->get_display_mode());
+	p_layout->set_value(p_section, "dock_filesystem_file_sort", FileSystemDock::get_singleton()->get_file_sort());
+	p_layout->set_value(p_section, "dock_filesystem_file_list_display_mode", FileSystemDock::get_singleton()->get_file_list_display_mode());
 
 	for (int i = 0; i < vsplits.size(); i++) {
 		if (vsplits[i]->is_visible_in_tree()) {
@@ -4703,22 +4687,22 @@ void EditorNode::_load_docks_from_config(Ref<ConfigFile> p_layout, const String 
 
 	if (p_layout->has_section_key(p_section, "dock_filesystem_split")) {
 		int fs_split_ofs = p_layout->get_value(p_section, "dock_filesystem_split");
-		filesystem_dock->set_split_offset(fs_split_ofs);
+		FileSystemDock::get_singleton()->set_split_offset(fs_split_ofs);
 	}
 
 	if (p_layout->has_section_key(p_section, "dock_filesystem_display_mode")) {
 		FileSystemDock::DisplayMode dock_filesystem_display_mode = FileSystemDock::DisplayMode(int(p_layout->get_value(p_section, "dock_filesystem_display_mode")));
-		filesystem_dock->set_display_mode(dock_filesystem_display_mode);
+		FileSystemDock::get_singleton()->set_display_mode(dock_filesystem_display_mode);
 	}
 
 	if (p_layout->has_section_key(p_section, "dock_filesystem_file_sort")) {
 		FileSystemDock::FileSortOption dock_filesystem_file_sort = FileSystemDock::FileSortOption(int(p_layout->get_value(p_section, "dock_filesystem_file_sort")));
-		filesystem_dock->set_file_sort(dock_filesystem_file_sort);
+		FileSystemDock::get_singleton()->set_file_sort(dock_filesystem_file_sort);
 	}
 
 	if (p_layout->has_section_key(p_section, "dock_filesystem_file_list_display_mode")) {
 		FileSystemDock::FileListDisplayMode dock_filesystem_file_list_display_mode = FileSystemDock::FileListDisplayMode(int(p_layout->get_value(p_section, "dock_filesystem_file_list_display_mode")));
-		filesystem_dock->set_file_list_display_mode(dock_filesystem_file_list_display_mode);
+		FileSystemDock::get_singleton()->set_file_list_display_mode(dock_filesystem_file_list_display_mode);
 	}
 
 	for (int i = 0; i < vsplits.size(); i++) {
@@ -4972,7 +4956,7 @@ void EditorNode::_layout_menu_option(int p_id) {
 void EditorNode::_scene_tab_script_edited(int p_tab) {
 	Ref<Script> script = editor_data.get_scene_root_script(p_tab);
 	if (script.is_valid()) {
-		inspector_dock->edit_resource(script);
+		InspectorDock::get_singleton()->edit_resource(script);
 	}
 }
 
@@ -5437,7 +5421,7 @@ void EditorNode::_global_menu_new_window(const Variant &p_tag) {
 }
 
 void EditorNode::_dropped_files(const Vector<String> &p_files, int p_screen) {
-	String to_path = ProjectSettings::get_singleton()->globalize_path(get_filesystem_dock()->get_selected_path());
+	String to_path = ProjectSettings::get_singleton()->globalize_path(FileSystemDock::get_singleton()->get_selected_path());
 
 	_add_dropped_files_recursive(p_files, to_path);
 
@@ -5643,15 +5627,15 @@ void EditorNode::_resource_loaded(RES p_resource, const String &p_path) {
 
 void EditorNode::_feature_profile_changed() {
 	Ref<EditorFeatureProfile> profile = feature_profile_manager->get_current_profile();
-	TabContainer *import_tabs = cast_to<TabContainer>(import_dock->get_parent());
-	TabContainer *node_tabs = cast_to<TabContainer>(node_dock->get_parent());
-	TabContainer *fs_tabs = cast_to<TabContainer>(filesystem_dock->get_parent());
+	TabContainer *import_tabs = cast_to<TabContainer>(ImportDock::get_singleton()->get_parent());
+	TabContainer *node_tabs = cast_to<TabContainer>(NodeDock::get_singleton()->get_parent());
+	TabContainer *fs_tabs = cast_to<TabContainer>(FileSystemDock::get_singleton()->get_parent());
 	if (profile.is_valid()) {
-		node_tabs->set_tab_hidden(node_dock->get_index(), profile->is_feature_disabled(EditorFeatureProfile::FEATURE_NODE_DOCK));
+		node_tabs->set_tab_hidden(NodeDock::get_singleton()->get_index(), profile->is_feature_disabled(EditorFeatureProfile::FEATURE_NODE_DOCK));
 		// The Import dock is useless without the FileSystem dock. Ensure the configuration is valid.
 		bool fs_dock_disabled = profile->is_feature_disabled(EditorFeatureProfile::FEATURE_FILESYSTEM_DOCK);
-		fs_tabs->set_tab_hidden(filesystem_dock->get_index(), fs_dock_disabled);
-		import_tabs->set_tab_hidden(import_dock->get_index(), fs_dock_disabled || profile->is_feature_disabled(EditorFeatureProfile::FEATURE_IMPORT_DOCK));
+		fs_tabs->set_tab_hidden(FileSystemDock::get_singleton()->get_index(), fs_dock_disabled);
+		import_tabs->set_tab_hidden(ImportDock::get_singleton()->get_index(), fs_dock_disabled || profile->is_feature_disabled(EditorFeatureProfile::FEATURE_IMPORT_DOCK));
 
 		main_editor_buttons[EDITOR_3D]->set_visible(!profile->is_feature_disabled(EditorFeatureProfile::FEATURE_3D));
 		main_editor_buttons[EDITOR_SCRIPT]->set_visible(!profile->is_feature_disabled(EditorFeatureProfile::FEATURE_SCRIPT));
@@ -5664,12 +5648,12 @@ void EditorNode::_feature_profile_changed() {
 			_editor_select(EDITOR_2D);
 		}
 	} else {
-		import_tabs->set_tab_hidden(import_dock->get_index(), false);
-		node_tabs->set_tab_hidden(node_dock->get_index(), false);
-		fs_tabs->set_tab_hidden(filesystem_dock->get_index(), false);
-		import_dock->set_visible(true);
-		node_dock->set_visible(true);
-		filesystem_dock->set_visible(true);
+		import_tabs->set_tab_hidden(ImportDock::get_singleton()->get_index(), false);
+		node_tabs->set_tab_hidden(NodeDock::get_singleton()->get_index(), false);
+		fs_tabs->set_tab_hidden(FileSystemDock::get_singleton()->get_index(), false);
+		ImportDock::get_singleton()->set_visible(true);
+		NodeDock::get_singleton()->set_visible(true);
+		FileSystemDock::get_singleton()->set_visible(true);
 		main_editor_buttons[EDITOR_3D]->set_visible(true);
 		main_editor_buttons[EDITOR_SCRIPT]->set_visible(true);
 		if (StreamPeerSSL::is_available()) {
@@ -5696,8 +5680,6 @@ void EditorNode::_bind_methods() {
 	ClassDB::bind_method("_show_messages", &EditorNode::_show_messages);
 
 	ClassDB::bind_method("stop_child_process", &EditorNode::stop_child_process);
-
-	ClassDB::bind_method("get_script_create_dialog", &EditorNode::get_script_create_dialog);
 
 	ClassDB::bind_method("set_current_scene", &EditorNode::set_current_scene);
 	ClassDB::bind_method("set_current_version", &EditorNode::set_current_version);
@@ -6701,35 +6683,35 @@ EditorNode::EditorNode() {
 
 	// Instantiate and place editor docks
 
-	scene_tree_dock = memnew(SceneTreeDock(this, scene_root, editor_selection, editor_data));
-	inspector_dock = memnew(InspectorDock(this, editor_data));
-	import_dock = memnew(ImportDock);
-	node_dock = memnew(NodeDock);
+	memnew(SceneTreeDock(this, scene_root, editor_selection, editor_data));
+	memnew(InspectorDock(this, editor_data));
+	memnew(ImportDock);
+	memnew(NodeDock);
 
-	filesystem_dock = memnew(FileSystemDock(this));
+	FileSystemDock *filesystem_dock = memnew(FileSystemDock(this));
 	filesystem_dock->connect("inherit", callable_mp(this, &EditorNode::_inherit_request));
 	filesystem_dock->connect("instance", callable_mp(this, &EditorNode::_instantiate_request));
 	filesystem_dock->connect("display_mode_changed", callable_mp(this, &EditorNode::_save_docks));
 
 	// Scene: Top left
-	dock_slot[DOCK_SLOT_LEFT_UR]->add_child(scene_tree_dock);
-	dock_slot[DOCK_SLOT_LEFT_UR]->set_tab_title(scene_tree_dock->get_index(), TTR("Scene"));
+	dock_slot[DOCK_SLOT_LEFT_UR]->add_child(SceneTreeDock::get_singleton());
+	dock_slot[DOCK_SLOT_LEFT_UR]->set_tab_title(SceneTreeDock::get_singleton()->get_index(), TTR("Scene"));
 
 	// Import: Top left, behind Scene
-	dock_slot[DOCK_SLOT_LEFT_UR]->add_child(import_dock);
-	dock_slot[DOCK_SLOT_LEFT_UR]->set_tab_title(import_dock->get_index(), TTR("Import"));
+	dock_slot[DOCK_SLOT_LEFT_UR]->add_child(ImportDock::get_singleton());
+	dock_slot[DOCK_SLOT_LEFT_UR]->set_tab_title(ImportDock::get_singleton()->get_index(), TTR("Import"));
 
 	// FileSystem: Bottom left
-	dock_slot[DOCK_SLOT_LEFT_BR]->add_child(filesystem_dock);
-	dock_slot[DOCK_SLOT_LEFT_BR]->set_tab_title(filesystem_dock->get_index(), TTR("FileSystem"));
+	dock_slot[DOCK_SLOT_LEFT_BR]->add_child(FileSystemDock::get_singleton());
+	dock_slot[DOCK_SLOT_LEFT_BR]->set_tab_title(FileSystemDock::get_singleton()->get_index(), TTR("FileSystem"));
 
 	// Inspector: Full height right
-	dock_slot[DOCK_SLOT_RIGHT_UL]->add_child(inspector_dock);
-	dock_slot[DOCK_SLOT_RIGHT_UL]->set_tab_title(inspector_dock->get_index(), TTR("Inspector"));
+	dock_slot[DOCK_SLOT_RIGHT_UL]->add_child(InspectorDock::get_singleton());
+	dock_slot[DOCK_SLOT_RIGHT_UL]->set_tab_title(InspectorDock::get_singleton()->get_index(), TTR("Inspector"));
 
 	// Node: Full height right, behind Inspector
-	dock_slot[DOCK_SLOT_RIGHT_UL]->add_child(node_dock);
-	dock_slot[DOCK_SLOT_RIGHT_UL]->set_tab_title(node_dock->get_index(), TTR("Node"));
+	dock_slot[DOCK_SLOT_RIGHT_UL]->add_child(NodeDock::get_singleton());
+	dock_slot[DOCK_SLOT_RIGHT_UL]->set_tab_title(NodeDock::get_singleton()->get_index(), TTR("Node"));
 
 	// Hide unused dock slots and vsplits
 	dock_slot[DOCK_SLOT_LEFT_UL]->hide();
@@ -7173,7 +7155,7 @@ EditorNode::EditorNode() {
 	editor_data.set_edited_scene(0);
 	_update_scene_tabs();
 
-	import_dock->initialize_import_options();
+	ImportDock::get_singleton()->initialize_import_options();
 
 	FileAccess::set_file_close_fail_notify_callback(_file_access_close_error_notify);
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -302,11 +302,6 @@ private:
 	Ref<Theme> theme;
 
 	PopupMenu *recent_scenes;
-	SceneTreeDock *scene_tree_dock;
-	InspectorDock *inspector_dock;
-	NodeDock *node_dock;
-	ImportDock *import_dock;
-	FileSystemDock *filesystem_dock;
 	EditorRunNative *run_native;
 
 	ConfirmationDialog *confirmation;
@@ -717,9 +712,6 @@ public:
 	EditorPluginList *get_editor_plugins_over() { return editor_plugins_over; }
 	EditorPluginList *get_editor_plugins_force_over() { return editor_plugins_force_over; }
 	EditorPluginList *get_editor_plugins_force_input_forwarding() { return editor_plugins_force_input_forwarding; }
-	EditorInspector *get_inspector() { return inspector_dock->get_inspector(); }
-	Container *get_inspector_dock_addon_area() { return inspector_dock->get_addon_area(); }
-	ScriptCreateDialog *get_script_create_dialog() { return scene_tree_dock->get_script_create_dialog(); }
 
 	ProjectSettingsEditor *get_project_settings() { return project_settings; }
 
@@ -743,8 +735,7 @@ public:
 	bool is_addon_plugin_enabled(const String &p_addon) const;
 
 	void edit_node(Node *p_node);
-	void edit_resource(const Ref<Resource> &p_resource) { inspector_dock->edit_resource(p_resource); };
-	void open_resource(const String &p_type) { inspector_dock->open_resource(p_type); };
+	void edit_resource(const Ref<Resource> &p_resource) { InspectorDock::get_singleton()->edit_resource(p_resource); };
 
 	void save_resource_in_path(const Ref<Resource> &p_resource, const String &p_path);
 	void save_resource(const Ref<Resource> &p_resource);
@@ -795,10 +786,6 @@ public:
 
 	void request_instance_scene(const String &p_path);
 	void request_instantiate_scenes(const Vector<String> &p_files);
-	FileSystemDock *get_filesystem_dock();
-	ImportDock *get_import_dock();
-	SceneTreeDock *get_scene_tree_dock();
-	InspectorDock *get_inspector_dock();
 	static UndoRedo *get_undo_redo() { return &singleton->editor_data.get_undo_redo(); }
 
 	EditorSelection *get_editor_selection() { return editor_selection; }

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -233,15 +233,15 @@ ScriptEditor *EditorInterface::get_script_editor() {
 }
 
 void EditorInterface::select_file(const String &p_file) {
-	EditorNode::get_singleton()->get_filesystem_dock()->select_file(p_file);
+	FileSystemDock::get_singleton()->select_file(p_file);
 }
 
 String EditorInterface::get_selected_path() const {
-	return EditorNode::get_singleton()->get_filesystem_dock()->get_selected_path();
+	return FileSystemDock::get_singleton()->get_selected_path();
 }
 
 String EditorInterface::get_current_path() const {
-	return EditorNode::get_singleton()->get_filesystem_dock()->get_current_path();
+	return FileSystemDock::get_singleton()->get_current_path();
 }
 
 void EditorInterface::inspect_object(Object *p_obj, const String &p_for_property, bool p_inspector_only) {
@@ -253,7 +253,7 @@ EditorFileSystem *EditorInterface::get_resource_file_system() {
 }
 
 FileSystemDock *EditorInterface::get_file_system_dock() {
-	return EditorNode::get_singleton()->get_filesystem_dock();
+	return FileSystemDock::get_singleton();
 }
 
 EditorSelection *EditorInterface::get_selection() {
@@ -288,7 +288,7 @@ bool EditorInterface::is_plugin_enabled(const String &p_plugin) const {
 }
 
 EditorInspector *EditorInterface::get_inspector() const {
-	return EditorNode::get_singleton()->get_inspector();
+	return InspectorDock::get_inspector_singleton();
 }
 
 Error EditorInterface::save_scene() {
@@ -445,7 +445,7 @@ void EditorPlugin::add_control_to_container(CustomControlContainer p_location, C
 
 		} break;
 		case CONTAINER_PROPERTY_EDITOR_BOTTOM: {
-			EditorNode::get_singleton()->get_inspector_dock_addon_area()->add_child(p_control);
+			InspectorDock::get_singleton()->get_addon_area()->add_child(p_control);
 
 		} break;
 		case CONTAINER_PROJECT_SETTING_TAB_LEFT: {
@@ -498,7 +498,7 @@ void EditorPlugin::remove_control_from_container(CustomControlContainer p_locati
 
 		} break;
 		case CONTAINER_PROPERTY_EDITOR_BOTTOM: {
-			EditorNode::get_singleton()->get_inspector_dock_addon_area()->remove_child(p_control);
+			InspectorDock::get_singleton()->get_addon_area()->remove_child(p_control);
 
 		} break;
 		case CONTAINER_PROJECT_SETTING_TAB_LEFT:
@@ -833,7 +833,7 @@ EditorInterface *EditorPlugin::get_editor_interface() {
 }
 
 ScriptCreateDialog *EditorPlugin::get_script_create_dialog() {
-	return EditorNode::get_singleton()->get_script_create_dialog();
+	return SceneTreeDock::get_singleton()->get_script_create_dialog();
 }
 
 void EditorPlugin::add_debugger_plugin(const Ref<Script> &p_script) {

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -627,7 +627,7 @@ void EditorPropertyArray::_reorder_button_gui_input(const Ref<InputEvent> &p_eve
 			}
 			vbox->move_child(reorder_selected_element_hbox, reorder_to_index % page_length + 2);
 			// Ensure the moving element is visible.
-			EditorNode::get_singleton()->get_inspector()->ensure_control_visible(reorder_selected_element_hbox);
+			InspectorDock::get_inspector_singleton()->ensure_control_visible(reorder_selected_element_hbox);
 		}
 	}
 }

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -328,7 +328,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 		} break;
 
 		case OBJ_MENU_SHOW_IN_FILE_SYSTEM: {
-			FileSystemDock *file_system_dock = EditorNode::get_singleton()->get_filesystem_dock();
+			FileSystemDock *file_system_dock = FileSystemDock::get_singleton();
 			file_system_dock->navigate_to_path(edited_resource->get_path());
 
 			// Ensure that the FileSystem dock is visible.
@@ -862,6 +862,7 @@ void EditorResourcePicker::_ensure_resource_menu() {
 	edit_menu->connect("id_pressed", callable_mp(this, &EditorResourcePicker::_edit_menu_cbk));
 	edit_menu->connect("popup_hide", callable_mp((BaseButton *)edit_button, &BaseButton::set_pressed), varray(false));
 }
+
 EditorResourcePicker::EditorResourcePicker() {
 	assign_button = memnew(Button);
 	assign_button->set_flat(true);
@@ -906,14 +907,14 @@ bool EditorScriptPicker::handle_menu_selected(int p_which) {
 	switch (p_which) {
 		case OBJ_MENU_NEW_SCRIPT: {
 			if (script_owner) {
-				EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(script_owner, false);
+				SceneTreeDock::get_singleton()->open_script_dialog(script_owner, false);
 			}
 			return true;
 		}
 
 		case OBJ_MENU_EXTEND_SCRIPT: {
 			if (script_owner) {
-				EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(script_owner, true);
+				SceneTreeDock::get_singleton()->open_script_dialog(script_owner, true);
 			}
 			return true;
 		}
@@ -958,7 +959,7 @@ bool EditorShaderPicker::handle_menu_selected(int p_which) {
 	switch (p_which) {
 		case OBJ_MENU_NEW_SHADER: {
 			if (material.is_valid()) {
-				EditorNode::get_singleton()->get_scene_tree_dock()->open_shader_dialog(material, preferred_mode);
+				SceneTreeDock::get_singleton()->open_shader_dialog(material, preferred_mode);
 				return true;
 			}
 		} break;

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -48,6 +48,8 @@
 #include "servers/display_server.h"
 #include "shader_create_dialog.h"
 
+FileSystemDock *FileSystemDock::singleton = nullptr;
+
 Ref<Texture2D> FileSystemDock::_get_tree_item_icon(bool p_is_valid, String p_file_type) {
 	Ref<Texture2D> file_icon;
 	if (!p_is_valid) {
@@ -2335,7 +2337,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 		String to_dir;
 		bool favorite;
 		_get_drag_target_folder(to_dir, favorite, p_point, p_from);
-		EditorNode::get_singleton()->get_scene_tree_dock()->save_branch_to_file(to_dir);
+		SceneTreeDock::get_singleton()->save_branch_to_file(to_dir);
 	}
 }
 
@@ -2743,11 +2745,11 @@ void FileSystemDock::_update_import_dock() {
 	}
 
 	if (imports.size() == 0) {
-		EditorNode::get_singleton()->get_import_dock()->clear();
+		ImportDock::get_singleton()->clear();
 	} else if (imports.size() == 1) {
-		EditorNode::get_singleton()->get_import_dock()->set_edit_path(imports[0]);
+		ImportDock::get_singleton()->set_edit_path(imports[0]);
 	} else {
-		EditorNode::get_singleton()->get_import_dock()->set_edit_multiple_paths(imports);
+		ImportDock::get_singleton()->set_edit_multiple_paths(imports);
 	}
 
 	import_dock_needs_update = false;
@@ -2816,6 +2818,7 @@ void FileSystemDock::_bind_methods() {
 }
 
 FileSystemDock::FileSystemDock(EditorNode *p_editor) {
+	singleton = this;
 	set_name("FileSystem");
 	editor = p_editor;
 	path = "res://";
@@ -3051,4 +3054,5 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 }
 
 FileSystemDock::~FileSystemDock() {
+	singleton = nullptr;
 }

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -304,6 +304,12 @@ private:
 	void _feature_profile_changed();
 	Vector<String> _remove_self_included_paths(Vector<String> selected_strings);
 
+private:
+	static FileSystemDock *singleton;
+
+public:
+	static FileSystemDock *get_singleton() { return singleton; }
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -144,8 +144,8 @@ void GroupDialog::_add_pressed() {
 	undo_redo->add_undo_method(this, "emit_signal", "group_edited");
 
 	// To force redraw of scene tree.
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -173,8 +173,8 @@ void GroupDialog::_removed_pressed() {
 	undo_redo->add_undo_method(this, "emit_signal", "group_edited");
 
 	// To force redraw of scene tree.
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 }
@@ -333,8 +333,8 @@ void GroupDialog::_modify_group_pressed(Object *p_item, int p_column, int p_id) 
 			undo_redo->add_undo_method(this, "emit_signal", "group_edited");
 
 			// To force redraw of scene tree.
-			undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-			undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+			undo_redo->add_do_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
+			undo_redo->add_undo_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
 
 			undo_redo->commit_action();
 		} break;
@@ -583,8 +583,8 @@ void GroupsEditor::_add_group(const String &p_group) {
 	undo_redo->add_undo_method(this, "update_tree");
 
 	// To force redraw of scene tree.
-	undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-	undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+	undo_redo->add_do_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
+	undo_redo->add_undo_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
 
@@ -611,8 +611,8 @@ void GroupsEditor::_modify_group(Object *p_item, int p_column, int p_id) {
 			undo_redo->add_undo_method(this, "update_tree");
 
 			// To force redraw of scene tree.
-			undo_redo->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
-			undo_redo->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor(), "update_tree");
+			undo_redo->add_do_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
+			undo_redo->add_undo_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
 
 			undo_redo->commit_action();
 		} break;

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -91,6 +91,8 @@ public:
 	}
 };
 
+ImportDock *ImportDock::singleton = nullptr;
+
 void ImportDock::set_edit_path(const String &p_path) {
 	Ref<ConfigFile> config;
 	config.instantiate();
@@ -606,6 +608,7 @@ void ImportDock::initialize_import_options() const {
 }
 
 ImportDock::ImportDock() {
+	singleton = this;
 	set_name("Import");
 
 	content = memnew(VBoxContainer);
@@ -687,5 +690,6 @@ ImportDock::ImportDock() {
 }
 
 ImportDock::~ImportDock() {
+	singleton = nullptr;
 	memdelete(params);
 }

--- a/editor/import_dock.h
+++ b/editor/import_dock.h
@@ -85,6 +85,12 @@ class ImportDock : public VBoxContainer {
 		ITEM_CLEAR_DEFAULT,
 	};
 
+private:
+	static ImportDock *singleton;
+
+public:
+	static ImportDock *get_singleton() { return singleton; }
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -33,6 +33,8 @@
 #include "editor/editor_scale.h"
 #include "editor/plugins/animation_player_editor_plugin.h"
 
+InspectorDock *InspectorDock::singleton = nullptr;
+
 void InspectorDock::_menu_option(int p_option) {
 	_menu_option_confirm(p_option, false);
 }
@@ -156,7 +158,7 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 									res = duplicates[res];
 
 									current->set(prop_info.name, res);
-									editor->get_inspector()->update_property(prop_info.name);
+									get_inspector_singleton()->update_property(prop_info.name);
 								}
 							}
 						}
@@ -531,6 +533,7 @@ void InspectorDock::go_back() {
 }
 
 InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
+	singleton = this;
 	set_name("Inspector");
 
 	editor = p_editor;
@@ -686,4 +689,5 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 }
 
 InspectorDock::~InspectorDock() {
+	singleton = nullptr;
 }

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -117,6 +117,13 @@ class InspectorDock : public VBoxContainer {
 	void _select_history(int p_idx);
 	void _prepare_history();
 
+private:
+	static InspectorDock *singleton;
+
+public:
+	static InspectorDock *get_singleton() { return singleton; }
+	static EditorInspector *get_inspector_singleton() { return singleton->inspector; }
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -87,8 +87,8 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 
 		ur->add_undo_property(n, name, n->get(name));
 	}
-	ur->add_do_method(EditorNode::get_singleton()->get_inspector(), "refresh");
-	ur->add_undo_method(EditorNode::get_singleton()->get_inspector(), "refresh");
+	ur->add_do_method(InspectorDock::get_inspector_singleton(), "refresh");
+	ur->add_undo_method(InspectorDock::get_inspector_singleton(), "refresh");
 
 	ur->commit_action();
 	return true;

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -134,3 +134,7 @@ NodeDock::NodeDock() {
 	select_a_node->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
 	add_child(select_a_node);
 }
+
+NodeDock::~NodeDock() {
+	singleton = nullptr;
+}

--- a/editor/node_dock.h
+++ b/editor/node_dock.h
@@ -48,13 +48,17 @@ class NodeDock : public VBoxContainer {
 
 	Label *select_a_node;
 
+private:
+	static NodeDock *singleton;
+
+public:
+	static NodeDock *get_singleton() { return singleton; }
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 
 public:
-	static NodeDock *singleton;
-
 	void set_node(Node *p_node);
 
 	void show_groups();
@@ -63,6 +67,7 @@ public:
 	void update_lists();
 
 	NodeDock();
+	~NodeDock();
 };
 
 #endif // NODE_DOCK_H

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1505,7 +1505,7 @@ void AnimationPlayerEditor::_stop_onion_skinning() {
 }
 
 void AnimationPlayerEditor::_pin_pressed() {
-	EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->update_tree();
+	SceneTreeDock::get_singleton()->get_tree_editor()->update_tree();
 }
 
 void AnimationPlayerEditor::_bind_methods() {
@@ -1794,9 +1794,9 @@ void AnimationPlayerEditorPlugin::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			Node3DEditor::get_singleton()->connect("transform_key_request", callable_mp(this, &AnimationPlayerEditorPlugin::_transform_key_request));
-			editor->get_inspector()->connect("property_keyed", callable_mp(this, &AnimationPlayerEditorPlugin::_property_keyed));
+			InspectorDock::get_singleton()->connect("property_keyed", callable_mp(this, &AnimationPlayerEditorPlugin::_property_keyed));
 			anim_editor->get_track_editor()->connect("keying_changed", callable_mp(this, &AnimationPlayerEditorPlugin::_update_keying));
-			editor->get_inspector()->connect("edited_object_changed", callable_mp(anim_editor->get_track_editor(), &AnimationTrackEditor::update_keying));
+			InspectorDock::get_singleton()->connect("edited_object_changed", callable_mp(anim_editor->get_track_editor(), &AnimationTrackEditor::update_keying));
 			set_force_draw_over_forwarding_enabled();
 		} break;
 	}
@@ -1823,7 +1823,7 @@ void AnimationPlayerEditorPlugin::_transform_key_request(Object *sp, const Strin
 }
 
 void AnimationPlayerEditorPlugin::_update_keying() {
-	editor->get_inspector()->set_keying(anim_editor->get_track_editor()->has_keying());
+	InspectorDock::get_inspector_singleton()->set_keying(anim_editor->get_track_editor()->has_keying());
 }
 
 void AnimationPlayerEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -882,9 +882,9 @@ void CanvasItemEditor::_selection_menu_hide() {
 
 void CanvasItemEditor::_add_node_pressed(int p_result) {
 	if (p_result == AddNodeOption::ADD_NODE) {
-		editor->get_scene_tree_dock()->open_add_child_dialog();
+		SceneTreeDock::get_singleton()->open_add_child_dialog();
 	} else if (p_result == AddNodeOption::ADD_INSTANCE) {
-		editor->get_scene_tree_dock()->open_instance_child_dialog();
+		SceneTreeDock::get_singleton()->open_instance_child_dialog();
 	}
 }
 
@@ -5221,8 +5221,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	editor_selection->connect("selection_changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
 	editor_selection->connect("selection_changed", callable_mp(this, &CanvasItemEditor::_selection_changed));
 
-	editor->get_scene_tree_dock()->connect("node_created", callable_mp(this, &CanvasItemEditor::_node_created));
-	editor->get_scene_tree_dock()->connect("add_node_used", callable_mp(this, &CanvasItemEditor::_reset_create_position));
+	SceneTreeDock::get_singleton()->connect("node_created", callable_mp(this, &CanvasItemEditor::_node_created));
+	SceneTreeDock::get_singleton()->connect("add_node_used", callable_mp(this, &CanvasItemEditor::_reset_create_position));
 
 	editor->call_deferred(SNAME("connect"), "play_pressed", Callable(this, "_update_override_camera_button"), make_binds(true));
 	editor->call_deferred(SNAME("connect"), "stop_pressed", Callable(this, "_update_override_camera_button"), make_binds(false));
@@ -5618,8 +5618,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 
 	add_node_menu = memnew(PopupMenu);
 	add_child(add_node_menu);
-	add_node_menu->add_icon_item(editor->get_scene_tree_dock()->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), TTR("Add Node Here"));
-	add_node_menu->add_icon_item(editor->get_scene_tree_dock()->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), TTR("Instance Scene Here"));
+	add_node_menu->add_icon_item(SceneTreeDock::get_singleton()->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), TTR("Add Node Here"));
+	add_node_menu->add_icon_item(SceneTreeDock::get_singleton()->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), TTR("Instance Scene Here"));
 	add_node_menu->connect("id_pressed", callable_mp(this, &CanvasItemEditor::_add_node_pressed));
 
 	multiply_grid_step_shortcut = ED_SHORTCUT("canvas_item_editor/multiply_grid_step", TTR("Multiply grid step by 2"), Key::KP_MULTIPLY);
@@ -6130,7 +6130,7 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 
 	target_node = nullptr;
 	editor = p_node;
-	editor_data = editor->get_scene_tree_dock()->get_editor_data();
+	editor_data = SceneTreeDock::get_singleton()->get_editor_data();
 	canvas_item_editor = p_canvas_item_editor;
 	preview_node = memnew(Control);
 

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -110,9 +110,9 @@ void GPUParticles2DEditorPlugin::_menu_callback(int p_idx) {
 
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 			ur->create_action(TTR("Convert to CPUParticles2D"));
-			ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", particles, cpu_particles, true, false);
+			ur->add_do_method(SceneTreeDock::get_singleton(), "replace_node", particles, cpu_particles, true, false);
 			ur->add_do_reference(cpu_particles);
-			ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, particles, false, false);
+			ur->add_undo_method(SceneTreeDock::get_singleton(), "replace_node", cpu_particles, particles, false, false);
 			ur->add_undo_reference(particles);
 			ur->commit_action();
 

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -269,9 +269,9 @@ void GPUParticles3DEditor::_menu_option(int p_option) {
 
 			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 			ur->create_action(TTR("Convert to CPUParticles3D"));
-			ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, cpu_particles, true, false);
+			ur->add_do_method(SceneTreeDock::get_singleton(), "replace_node", node, cpu_particles, true, false);
 			ur->add_do_reference(cpu_particles);
-			ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", cpu_particles, node, false, false);
+			ur->add_undo_method(SceneTreeDock::get_singleton(), "replace_node", cpu_particles, node, false, false);
 			ur->add_undo_reference(node);
 			ur->commit_action();
 

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -228,7 +228,7 @@ void MeshLibraryEditor::_menu_cbk(int p_option) {
 			mesh_library->create_item(mesh_library->get_last_unused_item_id());
 		} break;
 		case MENU_OPTION_REMOVE_ITEM: {
-			String p = editor->get_inspector()->get_selected_path();
+			String p = InspectorDock::get_inspector_singleton()->get_selected_path();
 			if (p.begins_with("/MeshLibrary/item") && p.get_slice_count("/") >= 3) {
 				to_erase = p.get_slice("/", 3).to_int();
 				cd_remove->set_text(vformat(TTR("Remove item %d?"), to_erase));

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2733,7 +2733,7 @@ void Node3DEditorViewport::_notification(int p_what) {
 
 		_update_freelook(delta);
 
-		Node *scene_root = editor->get_scene_tree_dock()->get_editor_data()->get_edited_scene_root();
+		Node *scene_root = SceneTreeDock::get_singleton()->get_editor_data()->get_edited_scene_root();
 		if (previewing_cinema && scene_root != nullptr) {
 			Camera3D *cam = scene_root->get_viewport()->get_camera_3d();
 			if (cam != nullptr && cam != previewing) {
@@ -4284,7 +4284,7 @@ void Node3DEditorViewport::drop_data_fw(const Point2 &p_point, const Variant &p_
 			target_node = root_node;
 		} else {
 			// Create a root node so we can add child nodes to it.
-			EditorNode::get_singleton()->get_scene_tree_dock()->add_root_node(memnew(Node3D));
+			SceneTreeDock::get_singleton()->add_root_node(memnew(Node3D));
 			target_node = get_tree()->get_edited_scene_root();
 		}
 	} else {
@@ -4311,7 +4311,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 
 	index = p_index;
 	editor = p_editor;
-	editor_data = editor->get_scene_tree_dock()->get_editor_data();
+	editor_data = SceneTreeDock::get_singleton()->get_editor_data();
 	editor_selection = editor->get_editor_selection();
 	undo_redo = editor->get_undo_redo();
 
@@ -6704,7 +6704,7 @@ void Node3DEditor::_add_sun_to_scene(bool p_already_added_environment) {
 	Node *base = get_tree()->get_edited_scene_root();
 	if (!base) {
 		// Create a root node so we can add child nodes to it.
-		EditorNode::get_singleton()->get_scene_tree_dock()->add_root_node(memnew(Node3D));
+		SceneTreeDock::get_singleton()->add_root_node(memnew(Node3D));
 		base = get_tree()->get_edited_scene_root();
 	}
 	ERR_FAIL_COND(!base);
@@ -6732,7 +6732,7 @@ void Node3DEditor::_add_environment_to_scene(bool p_already_added_sun) {
 	Node *base = get_tree()->get_edited_scene_root();
 	if (!base) {
 		// Create a root node so we can add child nodes to it.
-		EditorNode::get_singleton()->get_scene_tree_dock()->add_root_node(memnew(Node3D));
+		SceneTreeDock::get_singleton()->add_root_node(memnew(Node3D));
 		base = get_tree()->get_edited_scene_root();
 	}
 	ERR_FAIL_COND(!base);
@@ -6790,7 +6790,7 @@ void Node3DEditor::_notification(int p_what) {
 
 			get_tree()->connect("node_removed", callable_mp(this, &Node3DEditor::_node_removed));
 			get_tree()->connect("node_added", callable_mp(this, &Node3DEditor::_node_added));
-			EditorNode::get_singleton()->get_scene_tree_dock()->get_tree_editor()->connect("node_changed", callable_mp(this, &Node3DEditor::_refresh_menu_icons));
+			SceneTreeDock::get_singleton()->get_tree_editor()->connect("node_changed", callable_mp(this, &Node3DEditor::_refresh_menu_icons));
 			editor_selection->connect("selection_changed", callable_mp(this, &Node3DEditor::_selection_changed));
 
 			editor->connect("stop_pressed", callable_mp(this, &Node3DEditor::_update_camera_override_button), make_binds(false));

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1421,7 +1421,7 @@ void ScriptEditor::_menu_option(int p_option) {
 						path = path.get_slice("::", 0); // Show the scene instead.
 					}
 
-					FileSystemDock *file_system_dock = EditorNode::get_singleton()->get_filesystem_dock();
+					FileSystemDock *file_system_dock = FileSystemDock::get_singleton();
 					file_system_dock->navigate_to_path(path);
 					// Ensure that the FileSystem dock is visible.
 					TabContainer *tab_container = (TabContainer *)file_system_dock->get_parent_control();
@@ -1551,8 +1551,8 @@ void ScriptEditor::_notification(int p_what) {
 			editor->connect("script_add_function_request", callable_mp(this, &ScriptEditor::_add_callback));
 			editor->connect("resource_saved", callable_mp(this, &ScriptEditor::_res_saved_callback));
 			editor->connect("scene_saved", callable_mp(this, &ScriptEditor::_scene_saved_callback));
-			editor->get_filesystem_dock()->connect("files_moved", callable_mp(this, &ScriptEditor::_files_moved));
-			editor->get_filesystem_dock()->connect("file_removed", callable_mp(this, &ScriptEditor::_file_removed));
+			FileSystemDock::get_singleton()->connect("files_moved", callable_mp(this, &ScriptEditor::_files_moved));
+			FileSystemDock::get_singleton()->connect("file_removed", callable_mp(this, &ScriptEditor::_file_removed));
 			script_list->connect("item_selected", callable_mp(this, &ScriptEditor::_script_selected));
 
 			members_overview->connect("item_selected", callable_mp(this, &ScriptEditor::_members_overview_selected));
@@ -1595,7 +1595,7 @@ void ScriptEditor::_notification(int p_what) {
 
 		case NOTIFICATION_READY: {
 			get_tree()->connect("tree_changed", callable_mp(this, &ScriptEditor::_tree_changed));
-			editor->get_inspector_dock()->connect("request_help", callable_mp(this, &ScriptEditor::_help_class_open));
+			InspectorDock::get_singleton()->connect("request_help", callable_mp(this, &ScriptEditor::_help_class_open));
 			editor->connect("request_help_search", callable_mp(this, &ScriptEditor::_help_search));
 		} break;
 
@@ -3455,7 +3455,7 @@ void ScriptEditor::register_create_script_editor_function(CreateScriptEditorFunc
 }
 
 void ScriptEditor::_script_changed() {
-	NodeDock::singleton->update_lists();
+	NodeDock::get_singleton()->update_lists();
 }
 
 void ScriptEditor::_on_find_in_files_requested(String text) {

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -337,9 +337,9 @@ void Sprite2DEditor::_convert_to_mesh_2d_node() {
 
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Convert to Mesh2D"));
-	ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, mesh_instance, true, false);
+	ur->add_do_method(SceneTreeDock::get_singleton(), "replace_node", node, mesh_instance, true, false);
 	ur->add_do_reference(mesh_instance);
-	ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", mesh_instance, node, false, false);
+	ur->add_undo_method(SceneTreeDock::get_singleton(), "replace_node", mesh_instance, node, false, false);
 	ur->add_undo_reference(node);
 	ur->commit_action();
 }
@@ -395,9 +395,9 @@ void Sprite2DEditor::_convert_to_polygon_2d_node() {
 
 	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Convert to Polygon2D"));
-	ur->add_do_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", node, polygon_2d_instance, true, false);
+	ur->add_do_method(SceneTreeDock::get_singleton(), "replace_node", node, polygon_2d_instance, true, false);
 	ur->add_do_reference(polygon_2d_instance);
-	ur->add_undo_method(EditorNode::get_singleton()->get_scene_tree_dock(), "replace_node", polygon_2d_instance, node, false, false);
+	ur->add_undo_method(SceneTreeDock::get_singleton(), "replace_node", polygon_2d_instance, node, false, false);
 	ur->add_undo_reference(node);
 	ur->commit_action();
 }

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4967,7 +4967,7 @@ public:
 	}
 
 	void _open_inspector(RES p_resource) {
-		EditorNode::get_singleton()->get_inspector()->edit(p_resource.ptr());
+		InspectorDock::get_inspector_singleton()->edit(p_resource.ptr());
 	}
 
 	bool updating;

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -208,19 +208,19 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 				} break;
 				case OBJ_MENU_NEW_SCRIPT: {
 					if (Object::cast_to<Node>(owner)) {
-						EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(Object::cast_to<Node>(owner), false);
+						SceneTreeDock::get_singleton()->open_script_dialog(Object::cast_to<Node>(owner), false);
 					}
 
 				} break;
 				case OBJ_MENU_EXTEND_SCRIPT: {
 					if (Object::cast_to<Node>(owner)) {
-						EditorNode::get_singleton()->get_scene_tree_dock()->open_script_dialog(Object::cast_to<Node>(owner), true);
+						SceneTreeDock::get_singleton()->open_script_dialog(Object::cast_to<Node>(owner), true);
 					}
 
 				} break;
 				case OBJ_MENU_SHOW_IN_FILE_SYSTEM: {
 					RES r = v;
-					FileSystemDock *file_system_dock = EditorNode::get_singleton()->get_filesystem_dock();
+					FileSystemDock *file_system_dock = FileSystemDock::get_singleton();
 					file_system_dock->navigate_to_path(r->get_path());
 					// Ensure that the FileSystem dock is visible.
 					TabContainer *tab_container = (TabContainer *)file_system_dock->get_parent_control();
@@ -1256,7 +1256,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 				if (owner->is_class("Node") && (v.get_type() == Variant::NODE_PATH) && Object::cast_to<Node>(owner)->has_node(v)) {
 					Node *target_node = Object::cast_to<Node>(owner)->get_node(v);
 					EditorNode::get_singleton()->get_editor_selection()->clear();
-					EditorNode::get_singleton()->get_scene_tree_dock()->set_selected(target_node);
+					SceneTreeDock::get_singleton()->set_selected(target_node);
 				}
 
 				hide();

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1043,7 +1043,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				if (node) {
 					node->set_scene_inherited_state(Ref<SceneState>());
 					scene_tree->update_tree();
-					EditorNode::get_singleton()->get_inspector()->update_tree();
+					InspectorDock::get_inspector_singleton()->update_tree();
 				}
 			}
 		} break;
@@ -2067,7 +2067,7 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 	// Fixes the EditorHistory from still offering deleted notes
 	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
 	editor_history->cleanup_history();
-	EditorNode::get_singleton()->get_inspector_dock()->call("_prepare_history");
+	InspectorDock::get_singleton()->call("_prepare_history");
 }
 
 void SceneTreeDock::_update_script_button() {

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -264,11 +264,16 @@ class SceneTreeDock : public VBoxContainer {
 	bool profile_allow_editing;
 	bool profile_allow_script_editing;
 
-	static SceneTreeDock *singleton;
 	static void _update_configuration_warning();
 
 	bool _update_node_path(Node *p_root_node, NodePath &r_node_path, Map<Node *, NodePath> *p_renames) const;
 	bool _check_node_path_recursive(Node *p_root_node, Variant &r_variant, Map<Node *, NodePath> *p_renames) const;
+
+private:
+	static SceneTreeDock *singleton;
+
+public:
+	static SceneTreeDock *get_singleton() { return singleton; }
 
 protected:
 	void _notification(int p_what);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -133,8 +133,8 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 
 		set_selected(n);
 
-		NodeDock::singleton->get_parent()->call("set_current_tab", NodeDock::singleton->get_index());
-		NodeDock::singleton->show_connections();
+		NodeDock::get_singleton()->get_parent()->call("set_current_tab", NodeDock::get_singleton()->get_index());
+		NodeDock::get_singleton()->show_connections();
 
 	} else if (p_id == BUTTON_GROUPS) {
 		editor_selection->clear();
@@ -142,8 +142,8 @@ void SceneTreeEditor::_cell_button_pressed(Object *p_item, int p_column, int p_i
 
 		set_selected(n);
 
-		NodeDock::singleton->get_parent()->call("set_current_tab", NodeDock::singleton->get_index());
-		NodeDock::singleton->show_groups();
+		NodeDock::get_singleton()->get_parent()->call("set_current_tab", NodeDock::get_singleton()->get_index());
+		NodeDock::get_singleton()->show_groups();
 	}
 }
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1168,8 +1168,8 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 #ifdef TOOLS_ENABLED
 	// FIXME: Hack to refresh editor in order to display new properties and signals. See if there is a better alternative.
 	if (Engine::get_singleton()->is_editor_hint()) {
-		EditorNode::get_singleton()->get_inspector()->update_tree();
-		NodeDock::singleton->update_lists();
+		InspectorDock::get_inspector_singleton()->update_tree();
+		NodeDock::get_singleton()->update_lists();
 	}
 #endif
 }

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -271,7 +271,7 @@ protected:
 
 		if (String(p_name) == "export") {
 			script->set_variable_export(var, p_value);
-			EditorNode::get_singleton()->get_inspector()->update_tree();
+			InspectorDock::get_inspector_singleton()->update_tree();
 			return true;
 		}
 


### PR DESCRIPTION
Based on the work in #47520

This is a cleanup PR that reduces a bit the editor code dependencies to EditorNode.
It moves all the panel and dock instances, currently stored in EditorNode in their classes as a singleton.

This is one approach (IMO the simplest). The other approach is to store the node instances in a dedicated class called EditorSingletons or something like that (closer to what I did in #47520).
