### PR TITLE
Fix applied gravity on soft bodies

### DIFF
--- a/servers/physics_3d/godot_soft_body_3d.cpp
+++ b/servers/physics_3d/godot_soft_body_3d.cpp
@@ -964,12 +964,6 @@ void GodotSoftBody3D::apply_forces(const LocalVector<GodotArea3D *> &p_wind_area
 	}
 }
 
-void GodotSoftBody3D::_compute_area_gravity(const GodotArea3D *p_area) {
-	Vector3 area_gravity;
-	p_area->compute_gravity(get_transform().get_origin(), area_gravity);
-	gravity += area_gravity;
-}
-
 Vector3 GodotSoftBody3D::_compute_area_windforce(const GodotArea3D *p_area, const Face *p_face) {
 	real_t wfm = p_area->get_wind_force_magnitude();
 	real_t waf = p_area->get_wind_attenuation_factor();
@@ -987,12 +981,12 @@ void GodotSoftBody3D::predict_motion(real_t p_delta) {
 
 	ERR_FAIL_COND(!get_space());
 
-	int ac = areas.size();
-
 	bool gravity_done = false;
+	Vector3 gravity;
 
 	LocalVector<GodotArea3D *> wind_areas;
 
+	int ac = areas.size();
 	if (ac) {
 		areas.sort();
 		const AreaCMP *aa = &areas[0];

--- a/servers/physics_3d/godot_soft_body_3d.h
+++ b/servers/physics_3d/godot_soft_body_3d.h
@@ -101,8 +101,6 @@ class GodotSoftBody3D : public GodotCollisionObject3D {
 	real_t drag_coefficient = 0.0; // [0,1]
 	LocalVector<int> pinned_vertices;
 
-	Vector3 gravity;
-
 	SelfList<GodotSoftBody3D> active_list;
 
 	Set<GodotConstraint3D *> constraints;
@@ -113,7 +111,6 @@ class GodotSoftBody3D : public GodotCollisionObject3D {
 
 	uint64_t island_step = 0;
 
-	_FORCE_INLINE_ void _compute_area_gravity(const GodotArea3D *p_area);
 	_FORCE_INLINE_ Vector3 _compute_area_windforce(const GodotArea3D *p_area, const Face *p_face);
 
 public:


### PR DESCRIPTION
Regression fix (from #54810), gravity was accumulated between frames after some changes around area gravity calculation.

Also got rid of unused member and method in soft body class.