### PR TITLE
BVH - fix typename compiler warning

### DIFF
--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -104,7 +104,7 @@ struct BVH_ABB {
 		return (get_proximity_to(p_a) < get_proximity_to(p_b) ? 0 : 1);
 	}
 
-	uint32_t find_cutting_planes(const BVH_ABB::ConvexHull &p_hull, uint32_t *p_plane_ids) const {
+	uint32_t find_cutting_planes(const typename BVH_ABB::ConvexHull &p_hull, uint32_t *p_plane_ids) const {
 		uint32_t count = 0;
 
 		for (int n = 0; n < p_hull.num_planes; n++) {


### PR DESCRIPTION
Some versions of microsoft compiler flag a warning that they want a typename keyword in templates in more places than clang / gcc.

Fixes #55069

## Notes
* Curious that no one else has reported this despite the code having been present for sometime, it may be down to some particular build of the compiler
* There's no harm adding it afaik, as it is just for removing ambiguity, so I don't see a downside to fixing it.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
