### PR TITLE
Windows: Use `/bigobj` only for debug builds, breaks GCC LTO

### DIFF
--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -206,6 +206,8 @@ def configure_msvc(env, manual_msvc_config):
 
     elif env["target"] == "debug":
         env.AppendUnique(CCFLAGS=["/Zi", "/FS", "/Od", "/EHsc"])
+        # Allow big objects. Only needed for debug, see MinGW branch for rationale.
+        env.AppendUnique(CCFLAGS=["/bigobj"])
         env.Append(LINKFLAGS=["/DEBUG"])
 
     if env["debug_symbols"]:
@@ -227,7 +229,6 @@ def configure_msvc(env, manual_msvc_config):
 
     env.AppendUnique(CCFLAGS=["/Gd", "/GR", "/nologo"])
     env.AppendUnique(CCFLAGS=["/utf-8"])  # Force to use Unicode encoding.
-    env.AppendUnique(CCFLAGS=["/bigobj"])  # Allow big objects, no drawbacks.
     env.AppendUnique(CXXFLAGS=["/TP"])  # assume all sources are C++
 
     if manual_msvc_config:  # should be automatic if SCons found it
@@ -359,6 +360,10 @@ def configure_mingw(env):
 
     elif env["target"] == "debug":
         env.Append(CCFLAGS=["-g3"])
+        # Allow big objects. It's supposed not to have drawbacks but seems to break
+        # GCC LTO, so enabling for debug builds only (which are not built with LTO
+        # and are the only ones with too big objects).
+        env.Append(CCFLAGS=["-Wa,-mbig-obj"])
 
     if env["windows_subsystem"] == "gui":
         env.Append(LINKFLAGS=["-Wl,--subsystem,windows"])
@@ -422,7 +427,6 @@ def configure_mingw(env):
     ## Compile flags
 
     env.Append(CCFLAGS=["-mwindows"])
-    env.Append(CCFLAGS=["-Wa,-mbig-obj"])  # Allow big objects, no drawbacks.
 
     env.Append(CPPDEFINES=["WINDOWS_ENABLED", "WASAPI_ENABLED", "WINMIDI_ENABLED"])
     env.Append(CPPDEFINES=[("WINVER", env["target_win_version"]), ("_WIN32_WINNT", env["target_win_version"])])


### PR DESCRIPTION
Building `target=release` and `target=release_debug` builds with MinGW-GCC
errors when linking with LTO.

Since it's only needed for `target=debug` builds anyway (bigger objects), which
we don't build with LTO, this works around the issue.

Follow-up to #54837.

Solves these errors:
```
/usr/lib/gcc/x86_64-w64-mingw32/10.3.1/../../../../x86_64-w64-mingw32/bin/ld: platform/windows/godot_windows.windows.opt.tools.64.o: plugin needed to handle lto object
/usr/lib/gcc/x86_64-w64-mingw32/10.3.1/../../../../x86_64-w64-mingw32/bin/ld: platform/windows/crash_handler_windows.windows.opt.tools.64.o: plugin needed to handle lto object
/usr/lib/gcc/x86_64-w64-mingw32/10.3.1/../../../../x86_64-w64-mingw32/bin/ld: platform/windows/os_windows.windows.opt.tools.64.o: plugin needed to handle lto object
/usr/lib/gcc/x86_64-w64-mingw32/10.3.1/../../../../x86_64-w64-mingw32/bin/ld: platform/windows/display_server_windows.windows.opt.tools.64.o: plugin needed to handle lto object
/usr/lib/gcc/x86_64-w64-mingw32/10.3.1/../../../../x86_64-w64-mingw32/bin/ld: platform/windows/key_mapping_windows.windows.opt.tools.64.o: plugin needed to handle lto object
/usr/lib/gcc/x86_64-w64-mingw32/10.3.1/../../../../x86_64-w64-mingw32/bin/ld: platform/windows/joypad_windows.windows.opt.tools.64.o: plugin needed to handle lto object
/usr/lib/gcc/x86_64-w64-mingw32/10.3.1/../../../../x86_64-w64-mingw32/bin/ld: platform/windows/windows_terminal_logger.windows.opt.tools.64.o: plugin needed to handle lto object
/usr/lib/gcc/x86_64-w64-mingw32/10.3.1/../../../../x86_64-w64-mingw32/bin/ld: platform/windows/vulkan_context_win.windows.opt.tools.64.o: plugin needed to handle lto object
/usr/lib/gcc/x86_64-w64-mingw32/10.3.1/../../../../x86_64-w64-mingw32/bin/ld: platform/windows/gl_manager_windows.windows.opt.tools.64.o: plugin needed to handle lto object
/usr/lib/gcc/x86_64-w64-mingw32/10.3.1/../../../../x86_64-w64-mingw32/bin/ld: /usr/x86_64-w64-mingw32/sys-root/mingw/lib/../lib/libmingw32.a(lib64_libmingw32_a-crt0_c.o):(.text.startup+0x2e): undefined reference to `WinMain'
collect2: error: ld returned 1 exit status
```