### PR TITLE
Enchance `VisualShaderNodeMeshEmitter`, add more ports and fix bugs

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -1835,6 +1835,7 @@ void VisualShader::_update_shader() const {
 			code += "	float __scalar_buff1;\n";
 			code += "	float __scalar_buff2;\n";
 			code += "	int __scalar_ibuff;\n";
+			code += "	vec4 __vec4_buff;\n";
 			code += "	vec3 __ndiff = normalize(__diff);\n\n";
 		}
 		if (has_start) {

--- a/scene/resources/visual_shader_particle_nodes.h
+++ b/scene/resources/visual_shader_particle_nodes.h
@@ -115,6 +115,16 @@ class VisualShaderNodeParticleMeshEmitter : public VisualShaderNodeParticleEmitt
 
 	Ref<ImageTexture> position_texture;
 	Ref<ImageTexture> normal_texture;
+	Ref<ImageTexture> color_texture;
+	Ref<ImageTexture> uv_texture;
+	Ref<ImageTexture> uv2_texture;
+
+	String _generate_code(VisualShader::Type p_type, int p_id, const String *p_output_vars, int p_index, const String &p_texture_name, bool p_ignore_mode2d = false) const;
+
+	void _update_texture(const Vector<Vector2> &p_array, Ref<ImageTexture> &r_texture);
+	void _update_texture(const Vector<Vector3> &p_array, Ref<ImageTexture> &r_texture);
+	void _update_texture(const Vector<Color> &p_array, Ref<ImageTexture> &r_texture);
+	void _update_textures();
 
 protected:
 	static void _bind_methods();
@@ -130,10 +140,8 @@ public:
 	virtual PortType get_input_port_type(int p_port) const override;
 	virtual String get_input_port_name(int p_port) const override;
 
-	virtual String generate_global_per_node(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
+	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
-
-	void update_texture();
 
 	void set_mesh(Ref<Mesh> p_mesh);
 	Ref<Mesh> get_mesh() const;


### PR DESCRIPTION
- Added more output ports for color, UV, and UV2.

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/3036176/142402523-c4f26030-18b3-4aed-90b1-15949e44d205.png)

</details>

- Makes all ports generate code only when they are connected.
- Fixed a bug that incorrectly transfers vertex position instead of normal if Use All Surfaces is enabled.
- Fixed a bug that prevents you create more MeshEmitter (it overrides the global uniforms of each other).