### PR TITLE
Fix transparency state initialization

### DIFF
--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -644,6 +644,7 @@ void RendererSceneCull::instance_set_base(RID p_instance, RID p_base) {
 				scene_render->geometry_instance_set_use_dynamic_gi(geom->geometry_instance, instance->dynamic_gi);
 				scene_render->geometry_instance_set_cast_double_sided_shadows(geom->geometry_instance, instance->cast_shadows == RS::SHADOW_CASTING_SETTING_DOUBLE_SIDED);
 				scene_render->geometry_instance_set_use_lightmap(geom->geometry_instance, RID(), instance->lightmap_uv_scale, instance->lightmap_slice_index);
+				scene_render->geometry_instance_set_transparency(geom->geometry_instance, instance->transparency);
 				if (instance->lightmap_sh.size() == 9) {
 					scene_render->geometry_instance_set_lightmap_capture(geom->geometry_instance, instance->lightmap_sh.ptr());
 				}
@@ -838,6 +839,8 @@ void RendererSceneCull::instance_set_layer_mask(RID p_instance, uint32_t p_mask)
 void RendererSceneCull::instance_geometry_set_transparency(RID p_instance, float p_transparency) {
 	Instance *instance = instance_owner.get_or_null(p_instance);
 	ERR_FAIL_COND(!instance);
+
+	instance->transparency = p_transparency;
 
 	if ((1 << instance->base_type) & RS::INSTANCE_GEOMETRY_MASK && instance->base_data) {
 		InstanceGeometryData *geom = static_cast<InstanceGeometryData *>(instance->base_data);

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -439,17 +439,18 @@ public:
 		RID self;
 		//scenario stuff
 		DynamicBVH::ID indexer_id;
-		int32_t array_index;
+		int32_t array_index = -1;
 		int32_t visibility_index = -1;
-		float visibility_range_begin;
-		float visibility_range_end;
-		float visibility_range_begin_margin;
-		float visibility_range_end_margin;
+		float visibility_range_begin = 0.0f;
+		float visibility_range_end = 0.0f;
+		float visibility_range_begin_margin = 0.0f;
+		float visibility_range_end_margin = 0.0f;
 		RS::VisibilityRangeFadeMode visibility_range_fade_mode = RS::VISIBILITY_RANGE_FADE_DISABLED;
 		Instance *visibility_parent = nullptr;
 		Set<Instance *> visibility_dependencies;
-		uint32_t visibility_dependencies_depth;
-		Scenario *scenario;
+		uint32_t visibility_dependencies_depth = 0;
+		float transparency = 0.0f;
+		Scenario *scenario = nullptr;
 		SelfList<Instance> scenario_item;
 
 		//aabb stuff


### PR DESCRIPTION
Initialize some `Instance` members and store transparency so it's not lost when the instance doesn't have a base.