### PR TITLE
Add [theme_item] tag to editor help

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -78,7 +78,7 @@
 		</member>
 		<member name="icon" type="Texture2D" setter="set_button_icon" getter="get_button_icon">
 			Button's icon, if text is present the icon will be placed before the text.
-			To edit margin and spacing of the icon, use [code]hseparation[/code] theme property of [Button] and [code]content_margin_*[/code] properties of the used [StyleBox]es.
+			To edit margin and spacing of the icon, use [theme_item hseparation] theme property and [code]content_margin_*[/code] properties of the used [StyleBox]es.
 		</member>
 		<member name="icon_align" type="int" setter="set_icon_align" getter="get_icon_align" enum="Button.TextAlign" default="0">
 			Specifies if the icon should be aligned to the left, right, or center of a button. Uses the same [enum TextAlign] constants as the text alignment. If centered, text will draw on top of the icon.

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -141,7 +141,7 @@
 			<argument index="3" name="to_port" type="int" />
 			<argument index="4" name="amount" type="float" />
 			<description>
-				Sets the coloration of the connection between [code]from[/code]'s [code]from_port[/code] and [code]to[/code]'s [code]to_port[/code] with the color provided in the [code]activity[/code] theme property.
+				Sets the coloration of the connection between [code]from[/code]'s [code]from_port[/code] and [code]to[/code]'s [code]to_port[/code] with the color provided in the [theme_item activity] theme property.
 			</description>
 		</method>
 		<method name="set_selected">

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -285,10 +285,10 @@
 			No overlay is shown.
 		</constant>
 		<constant name="OVERLAY_BREAKPOINT" value="1" enum="Overlay">
-			Show overlay set in the [code]breakpoint[/code] theme property.
+			Show overlay set in the [theme_item breakpoint] theme property.
 		</constant>
 		<constant name="OVERLAY_POSITION" value="2" enum="Overlay">
-			Show overlay set in the [code]position[/code] theme property.
+			Show overlay set in the [theme_item position] theme property.
 		</constant>
 	</constants>
 	<theme_items>

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -328,7 +328,7 @@ class State:
                     theme_item.text,
                     default_value,
                 )
-                class_def.theme_items[theme_item_id] = theme_item_def
+                class_def.theme_items[theme_item_name] = theme_item_def
 
         tutorials = class_root.find("tutorials")
         if tutorials is not None:
@@ -905,6 +905,7 @@ def rstize_text(text, state):  # type: (str, State) -> str
                 or cmd.startswith("member")
                 or cmd.startswith("signal")
                 or cmd.startswith("constant")
+                or cmd.startswith("theme_item")
             ):
                 param = tag_text[space_pos + 1 :]
 
@@ -940,6 +941,13 @@ def rstize_text(text, state):  # type: (str, State) -> str
                         if method_param not in class_def.properties:
                             print_error("Unresolved member '{}', file: {}".format(param, state.current_class), state)
                         ref_type = "_property"
+
+                    elif cmd.startswith("theme_item"):
+                        if method_param not in class_def.theme_items:
+                            print_error(
+                                "Unresolved theme item '{}', file: {}".format(param, state.current_class), state
+                            )
+                        ref_type = "_theme_item"
 
                     elif cmd.startswith("signal"):
                         if method_param not in class_def.signals:

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -109,6 +109,9 @@ void EditorHelp::_class_desc_select(const String &p_select) {
 		} else if (tag == "constant") {
 			topic = "class_constant";
 			table = &this->constant_line;
+		} else if (tag == "theme_item") {
+			topic = "theme_item";
+			table = &this->theme_property_line;
 		} else {
 			return;
 		}
@@ -1538,7 +1541,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt) {
 			p_rt->add_text("[");
 			pos = brk_pos + 1;
 
-		} else if (tag.begins_with("method ") || tag.begins_with("member ") || tag.begins_with("signal ") || tag.begins_with("enum ") || tag.begins_with("constant ")) {
+		} else if (tag.begins_with("method ") || tag.begins_with("member ") || tag.begins_with("signal ") || tag.begins_with("enum ") || tag.begins_with("constant ") || tag.begins_with("theme_item ")) {
 			int tag_end = tag.find(" ");
 
 			String link_tag = tag.substr(0, tag_end);


### PR DESCRIPTION
This allows for clickable references to theme properties. I checked the docs for some obvious references, but there might be more of them.

This probably needs to be implemented for online docs too.