### PR TITLE
[3.x] Fix texture atlas generation when source sprite is larger than generated atlas

### DIFF
--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -131,7 +131,7 @@ static void _plot_triangle(Vector2 *vertices, const Vector2 &p_offset, bool p_tr
 	int max_y = MIN(y[2], height - p_offset.y - 1);
 	for (int yi = y[0]; yi < max_y; yi++) {
 		if (yi >= 0) {
-			for (int xi = (xf > 0 ? int(xf) : 0); xi < (xt < width ? xt : width - 1); xi++) {
+			for (int xi = (xf > 0 ? int(xf) : 0); xi < (xt < src_width ? xt : src_width - 1); xi++) {
 				int px = xi, py = yi;
 				int sx = px, sy = py;
 				sx = CLAMP(sx, 0, src_width - 1);
@@ -153,7 +153,7 @@ static void _plot_triangle(Vector2 *vertices, const Vector2 &p_offset, bool p_tr
 				p_image->set_pixel(px, py, color);
 			}
 
-			for (int xi = (xf < width ? int(xf) : width - 1); xi >= (xt > 0 ? xt : 0); xi--) {
+			for (int xi = (xf < src_width ? int(xf) : src_width - 1); xi >= (xt > 0 ? xt : 0); xi--) {
 				int px = xi, py = yi;
 				int sx = px, sy = py;
 				sx = CLAMP(sx, 0, src_width - 1);


### PR DESCRIPTION
Fixes #41414

**The problem:** atlas images getting cut off.

![image](https://user-images.githubusercontent.com/4075314/142350983-4f34331c-0040-4ad7-8d03-1f5a87baed9c.png)

https://github.com/godotengine/godot/blob/3.4/editor/import/resource_importer_texture_atlas.cpp#L134

In this line, "xf" starts at the left margin in the original sprite frame (source) image. Which in my case is a 512x512 image with the eyeball in the middle and a lot of empty space around it. This 512x512 dimension is set to the `src_width` and `src_height` variables respectively.

![image](https://user-images.githubusercontent.com/4075314/142348662-0770be02-8d24-4bda-aae0-7944a273a5b6.png)

The variables `width` and `height` in this function refer to the final atlas texture's width and height, which is 256x252 in this case. So the entire generated texture atlas (256x252) is smaller than a single source animation frame (512x512). That exposes this bug.

It looks like in this loop it's limiting by the generated atlas's width when it's actually looping through the source image's pixels.

`for (int xi = (xf > 0 ? int(xf) : 0); xi < (xt < width ? xt : width - 1); xi++) {`

So instead it should limit by the source image's width.

`for (int xi = (xf > 0 ? int(xf) : 0); xi < (xt < src_width ? xt : src_width - 1); xi++) {`

This indeed produces the correct results. And it makes sense why the images were getting cut off before.

![image](https://user-images.githubusercontent.com/4075314/142349072-f8a3335a-cbaa-405c-a64c-baad29d9a530.png)

There's already code that guarantees you're not drawing outside of the destination atlas texture's dimensions.

https://github.com/godotengine/godot/blob/3.4/editor/import/resource_importer_texture_atlas.cpp#L147

This width/src_width variable swap seems to have been a type-o. I don't think the same coding problem is present on the y axis, because my sprites would have been clipped off vertically as well.