### PR TITLE
Fixed pre-commit-black file extensions

### DIFF
--- a/misc/hooks/pre-commit-black
+++ b/misc/hooks/pre-commit-black
@@ -14,7 +14,7 @@ DELETE_OLD_PATCHES=false
 
 # File types to parse.
 FILE_NAMES="SConstruct SCsub"
-FILE_EXTS="py"
+FILE_EXTS=".py"
 
 # Use pygmentize instead of cat to parse diff with highlighting.
 # Install it with `pip install pygments` (Linux) or `easy_install Pygments` (Mac)


### PR DESCRIPTION
Git hooks now apply formatting rules to py files.
There seems to be no style violation with current versions of black.

Note: older versions of black might reformat some files.
This is applies for the black version installed with apt on 20.04 Ubuntu LTS.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
