### PR TITLE
libogg: Update to upstream 1.3.5

### DIFF
--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -235,14 +235,14 @@ Files extracted from upstream source:
 ## libogg
 
 - Upstream: https://www.xiph.org/ogg
-- Version: git (c8fca6b4a02d695b1ceea39b330d4406001c03ed, 2019)
+- Version: 1.3.5 (e1774cd77f471443541596e09078e78fdc342e4f, 2021)
 - License: BSD-3-Clause
 
 Files extracted from upstream source:
 
 - `src/*.{c,h}`
-- `include/ogg/*.h` in ogg/
-- COPYING
+- `include/ogg/*.h` in `ogg/` (run `configure` to generate `config_types.h`)
+- `COPYING`
 
 
 ## libpng

--- a/thirdparty/libogg/framing.c
+++ b/thirdparty/libogg/framing.c
@@ -597,9 +597,14 @@ char *ogg_sync_buffer(ogg_sync_state *oy, long size){
 
   if(size>oy->storage-oy->fill){
     /* We need to extend the internal buffer */
-    long newsize=size+oy->fill+4096; /* an extra page to be nice */
+    long newsize;
     void *ret;
 
+    if(size>INT_MAX-4096-oy->fill){
+      ogg_sync_clear(oy);
+      return NULL;
+    }
+    newsize=size+oy->fill+4096; /* an extra page to be nice */
     if(oy->data)
       ret=_ogg_realloc(oy->data,newsize);
     else
@@ -1564,7 +1569,7 @@ void test_pack(const int *pl, const int **headers, int byteskip,
             byteskipcount=byteskip;
           }
 
-          ogg_sync_wrote(&oy,next-buf);
+          ogg_sync_wrote(&oy,(long)(next-buf));
 
           while(1){
             int ret=ogg_sync_pageout(&oy,&og_de);

--- a/thirdparty/libogg/ogg/config_types.h
+++ b/thirdparty/libogg/ogg/config_types.h
@@ -1,7 +1,20 @@
 #ifndef __CONFIG_TYPES_H__
 #define __CONFIG_TYPES_H__
 
-#include <stdint.h>
+/* these are filled in by configure or cmake*/
+#define INCLUDE_INTTYPES_H 1
+#define INCLUDE_STDINT_H 1
+#define INCLUDE_SYS_TYPES_H 1
+
+#if INCLUDE_INTTYPES_H
+#  include <inttypes.h>
+#endif
+#if INCLUDE_STDINT_H
+#  include <stdint.h>
+#endif
+#if INCLUDE_SYS_TYPES_H
+#  include <sys/types.h>
+#endif
 
 typedef int16_t ogg_int16_t;
 typedef uint16_t ogg_uint16_t;


### PR DESCRIPTION
Mostly a cosmetic update, we were already on a commit close to what
ended up being tagged as 1.3.5. Adds an extra buffer overflow fix.