### PR TITLE
Scales the horizontal velocity according to the wall slope in 2D

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -1317,6 +1317,17 @@ void CharacterBody2D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 
 	_snap_on_floor(p_was_on_floor, vel_dir_facing_up);
 
+	// Scales the horizontal velocity according to the wall slope.
+	if (is_on_wall_only() && motion_slide_up.dot(motion_results.get(0).collision_normal) < 0) {
+		Vector2 slide_motion = motion_velocity.slide(motion_results.get(0).collision_normal);
+		if (motion_slide_up.dot(slide_motion) < 0) {
+			motion_velocity = up_direction * up_direction.dot(motion_velocity);
+		} else {
+			// Keeps the vertical motion from motion_velocity and add the horizontal motion of the projection.
+			motion_velocity = up_direction * up_direction.dot(motion_velocity) + slide_motion.slide(up_direction);
+		}
+	}
+
 	// Reset the gravity accumulation when touching the ground.
 	if (on_floor && !vel_dir_facing_up) {
 		motion_velocity = motion_velocity.slide(up_direction);


### PR DESCRIPTION
Fix: #55121

The horizontal `motion_velocity` is now scaled proportionally to the slope.

Before:

![before](https://user-images.githubusercontent.com/6397893/142628096-22a4e00b-b1de-4e06-94b9-f2763dfd31d5.gif)

After:

![after](https://user-images.githubusercontent.com/6397893/142628109-e3650ad7-9bab-4095-b8ff-62886881e4a1.gif)


