### PR TITLE
Use correct #include for time.h on FreeBSD

### DIFF
--- a/thirdparty/basis_universal/encoder/basisu_enc.cpp
+++ b/thirdparty/basis_universal/encoder/basisu_enc.cpp
@@ -195,7 +195,7 @@ namespace basisu
 	{
 		QueryPerformanceFrequency(reinterpret_cast<LARGE_INTEGER*>(pTicks));
 	}
-#elif defined(__APPLE__)
+#elif defined(__APPLE__) || defined(__FreeBSD__)
 #include <sys/time.h>
 	inline void query_counter(timer_ticks* pTicks)
 	{


### PR DESCRIPTION
Use correct #include for time.h on FreeBSD

Module basis_universal uses linux <sys/timex.h> header instead
FreeBSD <sys/time.h> due to missing preprocessor comparison.

Fixes  #55138