### PR TITLE
[3.x] Add a project setting to use an OpenGL 3 context for the GLES2 backend

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1238,6 +1238,10 @@
 			If [code]true[/code] and available on the target Android device, enables high floating point precision for all shader computations in GLES2.
 			[b]Warning:[/b] High floating point precision can be extremely slow on older devices and is often not available at all. Use with caution.
 		</member>
+		<member name="rendering/gles2/compatibility/use_opengl_3_context" type="bool" setter="" getter="" default="false">
+			If [code]true[/code] and OpenGL 3.3 Compatibility Profile support is available, uses an OpenGL 3.3 Compatibility Profile to run the GLES2 rendering backend. This can be useful to diagnose the GLES2 renderer with OpenGL 3.2+ tools such as [url=https://renderdoc.org/]RenderDoc[/url]. Enabling this option generally does not affect performance, but it may cause unexpected behavior on certain GPU drivers. If in doubt, leave this to [code]false[/code].
+			[b]Note:[/b] Only effective on Linux and when using the GLES2 rendering backend.
+		</member>
 		<member name="rendering/gles3/shaders/log_active_async_compiles_count" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], every time an asynchronous shader compilation or an asynchronous shader reconstruction from cache starts or finishes, a line will be logged telling how many of those are happening.
 			If the platform doesn't support parallel shader compile, but only the compile queue via a secondary GL context, what the message will tell is the number of shader compiles currently queued.

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1037,6 +1037,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	}
 
 	GLOBAL_DEF("rendering/quality/driver/fallback_to_gles2", false);
+	GLOBAL_DEF("rendering/gles2/compatibility/use_opengl_3_context", false);
 
 	// Assigning here, to be sure that it appears in docs
 	GLOBAL_DEF("rendering/2d/options/use_nvidia_rect_flicker_workaround", false);

--- a/platform/x11/context_gl_x11.h
+++ b/platform/x11/context_gl_x11.h
@@ -61,6 +61,10 @@ private:
 	bool use_vsync;
 	ContextType context_type;
 
+	// If `true`, uses an OpenGL 3.3 Compatibility Profile context to run the GLES2 rendering backend.
+	// If `false`, an OpenGL 2.1 or OpenGL ES 2.0 context is used instead (depending on the system graphics driver).
+	bool gles2_use_opengl_3_context;
+
 public:
 	void release_current();
 	void make_current();
@@ -78,7 +82,7 @@ public:
 	void set_use_vsync(bool p_use);
 	bool is_using_vsync() const;
 
-	ContextGL_X11(::Display *p_x11_display, ::Window &p_x11_window, const OS::VideoMode &p_default_video_mode, ContextType p_context_type);
+	ContextGL_X11(::Display *p_x11_display, ::Window &p_x11_window, const OS::VideoMode &p_default_video_mode, ContextType p_context_type, bool p_gles2_use_opengl_3_context = false);
 	~ContextGL_X11();
 };
 

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -304,7 +304,12 @@ Error OS_X11::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 
 	context_gl = nullptr;
 	while (!context_gl) {
-		context_gl = memnew(ContextGL_X11(x11_display, x11_window, current_videomode, opengl_api_type));
+		context_gl = memnew(ContextGL_X11(
+				x11_display,
+				x11_window,
+				current_videomode,
+				opengl_api_type,
+				GLOBAL_GET("rendering/gles2/compatibility/use_opengl_3_context")));
 
 		if (context_gl->initialize() != OK) {
 			memdelete(context_gl);


### PR DESCRIPTION
This is useful to use tools such as [RenderDoc](https://renderdoc.org/) with the GLES2 renderer. RenderDoc requires the use of OpenGL 3.2 or greater for capture to be usable. There will be a warning on screen due to the use of a compatibility profile (instead of core profile), so not all features may work as expected.

This PR is only relevant for `3.x` as the `master` branch doesn't have a GLES2 rendering backend.

**Testing project:** [test_gles2_opengl_3_context.zip](https://github.com/godotengine/godot/files/7572959/test_gles2_opengl_3_context.zip)

## Preview

### Before

![2021-11-19_22 07 46](https://user-images.githubusercontent.com/180032/142692582-359c4388-60f0-4d2f-82a7-8c6dfa800a8d.png)

### After

![2021-11-19_22 06 05](https://user-images.githubusercontent.com/180032/142692578-c134888e-0457-4864-bc92-9d9fbf3d70f3.png)

![2021-11-19_22 06 42](https://user-images.githubusercontent.com/180032/142692580-2afa9243-7c6f-42e2-911a-0f6f7b7b4154.png)


## TODO

- [ ] Add Windows support.
- [ ] Add a command-line argument to enable the use of OpenGL 3 context without having to modify `project.godot` (`--gles2-use-opengl3-context`?).