### PR TITLE
Make sequence ports selectable on all VisualScriptNodes (FAILD)

### DIFF
--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -50,6 +50,7 @@ class VisualScriptNode : public Resource {
 
 	Array default_input_values;
 	bool breakpoint = false;
+	bool invert_sequenced;
 
 	void _set_default_input_values(Array p_values);
 	Array _get_default_input_values() const;
@@ -58,13 +59,18 @@ class VisualScriptNode : public Resource {
 
 protected:
 	void ports_changed_notify();
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
 	static void _bind_methods();
 
 public:
 	Ref<VisualScript> get_visual_script() const;
 
 	virtual int get_output_sequence_port_count() const = 0;
+	int get_sequenced_output_port_count() const;
 	virtual bool has_input_sequence_port() const = 0;
+	bool is_sequenced() const;
 
 	virtual String get_output_sequence_port_text(int p_port) const = 0;
 

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -94,12 +94,6 @@ bool VisualScriptFunction::_set(const StringName &p_name, const Variant &p_value
 		return true;
 	}
 
-	if (p_name == "sequenced/sequenced") {
-		sequenced = p_value;
-		ports_changed_notify();
-		return true;
-	}
-
 	return false;
 }
 
@@ -137,11 +131,6 @@ bool VisualScriptFunction::_get(const StringName &p_name, Variant &r_ret) const 
 		return true;
 	}
 
-	if (p_name == "sequenced/sequenced") {
-		r_ret = sequenced;
-		return true;
-	}
-
 	return false;
 }
 
@@ -156,8 +145,6 @@ void VisualScriptFunction::_get_property_list(List<PropertyInfo> *p_list) const 
 		p_list->push_back(PropertyInfo(Variant::INT, "argument_" + itos(i + 1) + "/type", PROPERTY_HINT_ENUM, argt));
 		p_list->push_back(PropertyInfo(Variant::STRING, "argument_" + itos(i + 1) + "/name"));
 	}
-
-	p_list->push_back(PropertyInfo(Variant::BOOL, "sequenced/sequenced"));
 
 	if (!stack_less) {
 		p_list->push_back(PropertyInfo(Variant::INT, "stack/size", PROPERTY_HINT_RANGE, "1,100000"));
@@ -310,14 +297,12 @@ void VisualScriptFunction::reset_state() {
 	arguments.clear();
 	stack_size = 256;
 	stack_less = false;
-	sequenced = true;
 	rpc_mode = Multiplayer::RPC_MODE_DISABLED;
 }
 
 VisualScriptFunction::VisualScriptFunction() {
 	stack_size = 256;
 	stack_less = false;
-	sequenced = true;
 	rpc_mode = Multiplayer::RPC_MODE_DISABLED;
 }
 
@@ -328,14 +313,6 @@ void VisualScriptFunction::set_stack_less(bool p_enable) {
 
 bool VisualScriptFunction::is_stack_less() const {
 	return stack_less;
-}
-
-void VisualScriptFunction::set_sequenced(bool p_enable) {
-	sequenced = p_enable;
-}
-
-bool VisualScriptFunction::is_sequenced() const {
-	return sequenced;
 }
 
 void VisualScriptFunction::set_stack_size(int p_size) {
@@ -352,14 +329,11 @@ int VisualScriptFunction::get_stack_size() const {
 //////////////////////////////////////////
 
 int VisualScriptLists::get_output_sequence_port_count() const {
-	if (sequenced) {
-		return 1;
-	}
-	return 0;
+	return 1;
 }
 
 bool VisualScriptLists::has_input_sequence_port() const {
-	return sequenced;
+	return true;
 }
 
 String VisualScriptLists::get_output_sequence_port_text(int p_port) const {
@@ -490,12 +464,6 @@ bool VisualScriptLists::_set(const StringName &p_name, const Variant &p_value) {
 		}
 	}
 
-	if (p_name == "sequenced/sequenced") {
-		sequenced = p_value;
-		ports_changed_notify();
-		return true;
-	}
-
 	return false;
 }
 
@@ -536,11 +504,6 @@ bool VisualScriptLists::_get(const StringName &p_name, Variant &r_ret) const {
 		}
 	}
 
-	if (p_name == "sequenced/sequenced") {
-		r_ret = sequenced;
-		return true;
-	}
-
 	return false;
 }
 
@@ -570,7 +533,6 @@ void VisualScriptLists::_get_property_list(List<PropertyInfo> *p_list) const {
 			p_list->push_back(PropertyInfo(Variant::STRING, "output_" + itos(i + 1) + "/name"));
 		}
 	}
-	p_list->push_back(PropertyInfo(Variant::BOOL, "sequenced/sequenced"));
 }
 
 // input data port interaction
@@ -685,29 +647,14 @@ void VisualScriptLists::remove_output_data_port(int p_argidx) {
 	notify_property_list_changed();
 }
 
-// sequences
-void VisualScriptLists::set_sequenced(bool p_enable) {
-	if (sequenced == p_enable) {
-		return;
-	}
-	sequenced = p_enable;
-	ports_changed_notify();
-}
-
-bool VisualScriptLists::is_sequenced() const {
-	return sequenced;
-}
-
 void VisualScriptLists::reset_state() {
 	inputports.clear();
 	outputports.clear();
-	sequenced = false;
 	flags = 0;
 }
 
 VisualScriptLists::VisualScriptLists() {
 	// initialize
-	sequenced = false;
 	flags = 0;
 }
 
@@ -728,14 +675,11 @@ void VisualScriptLists::_bind_methods() {
 //////////////////////////////////////////
 
 int VisualScriptComposeArray::get_output_sequence_port_count() const {
-	if (sequenced) {
-		return 1;
-	}
-	return 0;
+	return 1;
 }
 
 bool VisualScriptComposeArray::has_input_sequence_port() const {
-	return sequenced;
+	return true;
 }
 
 String VisualScriptComposeArray::get_output_sequence_port_text(int p_port) const {
@@ -802,7 +746,6 @@ VisualScriptNodeInstance *VisualScriptComposeArray::instantiate(VisualScriptInst
 
 VisualScriptComposeArray::VisualScriptComposeArray() {
 	// initialize stuff here
-	sequenced = false;
 	flags = INPUT_EDITABLE;
 }
 

--- a/modules/visual_script/visual_script_nodes.h
+++ b/modules/visual_script/visual_script_nodes.h
@@ -50,7 +50,6 @@ class VisualScriptFunction : public VisualScriptNode {
 	bool stack_less;
 	int stack_size;
 	Multiplayer::RPCMode rpc_mode;
-	bool sequenced;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -83,9 +82,6 @@ public:
 
 	void set_stack_less(bool p_enable);
 	bool is_stack_less() const;
-
-	void set_sequenced(bool p_enable);
-	bool is_sequenced() const;
 
 	void set_stack_size(int p_size);
 	int get_stack_size() const;
@@ -122,8 +118,6 @@ protected:
 	};
 
 	int flags;
-
-	bool sequenced;
 
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
@@ -162,9 +156,6 @@ public:
 	void set_output_data_port_type(int p_idx, Variant::Type p_type);
 	void set_output_data_port_name(int p_idx, const String &p_name);
 	void remove_output_data_port(int p_argidx);
-
-	void set_sequenced(bool p_enable);
-	bool is_sequenced() const;
 
 	VisualScriptLists();
 };


### PR DESCRIPTION
I tried implementing the first approach of [proposal 3544](https://github.com/godotengine/godot-visual-script/issues/10).
And wanted to post the code for prosperity and guidance.

1. The sequenced option already available must be removed.
 - [X] `VisualScriptFunction`
 - [X] `VisualScriptLists`
 - [X]  `VisualScriptComposeArray`
 - [ ]  `VisualScriptExpresion`
2. `VisualScriptNode` must support sequenced.
3. `VisualScriptEditor` must be able to intersept exceptions and the new sequenced.

It is this last one I think that breaks the actual running of logic.