### PR TITLE
Added `reset_size` method to `Control` and `Window` classes

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -714,6 +714,12 @@
 				Removes a local override for a theme [StyleBox] with the specified [code]name[/code] previously added by [method add_theme_stylebox_override] or via the Inspector dock.
 			</description>
 		</method>
+		<method name="reset_size">
+			<return type="void" />
+			<description>
+				Resets the size to [method get_combined_minimum_size]. This is equivalent to calling [code]set_size(Vector2())[/code] (or any size below the minimum).
+			</description>
+		</method>
 		<method name="set_anchor">
 			<return type="void" />
 			<argument index="0" name="side" type="int" enum="Side" />

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -230,6 +230,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="reset_size">
+			<return type="void" />
+			<description>
+				Resets the size to the minimum size, which is the max of [member min_size] and (if [member wrap_controls] is enabled) [method get_contents_minimum_size]. This is equivalent to calling [code]set_size(Vector2i())[/code] (or any size below the minimum).
+			</description>
+		</method>
 		<method name="set_flag">
 			<return type="void" />
 			<argument index="0" name="flag" type="int" enum="Window.Flags" />

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -378,7 +378,7 @@ void ConnectDialog::_advanced_pressed() {
 		error_label->hide();
 	} else {
 		set_min_size(Size2(600, 500) * EDSCALE);
-		set_size(Size2());
+		reset_size();
 		connect_to_label->set_text(TTR("Connect to Script:"));
 		tree->set_connect_to_script_mode(true);
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1420,7 +1420,7 @@ void ScriptEditorDebugger::_clear_errors_list() {
 // Right click on specific file(s) or folder(s).
 void ScriptEditorDebugger::_error_tree_item_rmb_selected(const Vector2 &p_pos) {
 	item_menu->clear();
-	item_menu->set_size(Size2(1, 1));
+	item_menu->reset_size();
 
 	if (error_tree->is_anything_selected()) {
 		item_menu->add_icon_item(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")), TTR("Copy Error"), ACTION_COPY_ERROR);

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -270,7 +270,7 @@ DependencyEditor::DependencyEditor() {
 /////////////////////////////////////
 void DependencyEditorOwners::_list_rmb_select(int p_item, const Vector2 &p_pos) {
 	file_options->clear();
-	file_options->set_size(Size2(1, 1));
+	file_options->reset_size();
 	if (p_item >= 0) {
 		file_options->add_item(TTR("Open"), FILE_OPEN);
 	}
@@ -464,7 +464,7 @@ void DependencyRemoveDialog::show(const Vector<String> &p_folders, const Vector<
 	if (removed_deps.is_empty()) {
 		owners->hide();
 		text->set_text(TTR("Remove the selected files from the project? (Cannot be undone.)\nDepending on your filesystem configuration, the files will either be moved to the system trash or deleted permanently."));
-		set_size(Size2());
+		reset_size();
 		popup_centered();
 	} else {
 		_build_removed_dependency_tree(removed_deps);

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -576,7 +576,7 @@ void EditorFileDialog::_item_dc_selected(int p_item) {
 void EditorFileDialog::_item_list_item_rmb_selected(int p_item, const Vector2 &p_pos) {
 	// Right click on specific file(s) or folder(s).
 	item_menu->clear();
-	item_menu->set_size(Size2(1, 1));
+	item_menu->reset_size();
 
 	// Allow specific actions only on one item.
 	bool single_item_selected = item_list->get_selected_items().size() == 1;
@@ -620,7 +620,7 @@ void EditorFileDialog::_item_list_rmb_clicked(const Vector2 &p_pos) {
 	}
 
 	item_menu->clear();
-	item_menu->set_size(Size2(1, 1));
+	item_menu->reset_size();
 
 	if (can_create_dir) {
 		item_menu->add_icon_item(item_list->get_theme_icon(SNAME("folder"), SNAME("FileDialog")), TTR("New Folder..."), ITEM_MENU_NEW_FOLDER, KeyModifierMask::CMD | Key::N);
@@ -1117,7 +1117,7 @@ void EditorFileDialog::_delete_items() {
 		}
 	}
 	if (folders.size() + files.size() > 0) {
-		remove_dialog->set_size(Size2(1, 1));
+		remove_dialog->reset_size();
 		remove_dialog->show(folders, files);
 	}
 }

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -650,7 +650,7 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 	} else if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT) {
 		_update_popup();
 		menu->set_position(get_screen_position() + get_local_mouse_position());
-		menu->set_size(Vector2(1, 1));
+		menu->reset_size();
 		menu->popup();
 		select();
 		return;
@@ -1556,7 +1556,7 @@ void EditorInspectorArray::_panel_gui_input(Ref<InputEvent> p_event, int p_index
 			rmb_popup->set_item_disabled(OPTION_MOVE_UP, popup_array_index_pressed == 0);
 			rmb_popup->set_item_disabled(OPTION_MOVE_DOWN, popup_array_index_pressed == count - 1);
 			rmb_popup->set_position(mb->get_global_position());
-			rmb_popup->set_size(Vector2());
+			rmb_popup->reset_size();
 			rmb_popup->popup();
 		}
 	}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4903,7 +4903,7 @@ void EditorNode::_update_layouts_menu() {
 	editor_layouts->clear();
 	overridden_default_layout = -1;
 
-	editor_layouts->set_size(Vector2());
+	editor_layouts->reset_size();
 	editor_layouts->add_shortcut(ED_SHORTCUT("layout/save", TTR("Save Layout")), SETTINGS_LAYOUT_SAVE);
 	editor_layouts->add_shortcut(ED_SHORTCUT("layout/delete", TTR("Delete Layout")), SETTINGS_LAYOUT_DELETE);
 	editor_layouts->add_separator();
@@ -5030,7 +5030,7 @@ void EditorNode::_scene_tab_input(const Ref<InputEvent> &p_input) {
 		if (mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
 			// context menu
 			scene_tabs_context_menu->clear();
-			scene_tabs_context_menu->set_size(Size2(1, 1));
+			scene_tabs_context_menu->reset_size();
 
 			scene_tabs_context_menu->add_shortcut(ED_GET_SHORTCUT("editor/new_scene"), FILE_NEW_SCENE);
 			if (scene_tabs->get_hovered_tab() >= 0) {

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -409,7 +409,7 @@ void EditorSpinSlider::_draw_spin_slider() {
 
 			Vector2 scale = get_global_transform_with_canvas().get_scale();
 			grabber->set_scale(scale);
-			grabber->set_size(Size2(0, 0));
+			grabber->reset_size();
 			grabber->set_position(get_global_position() + (grabber_rect.get_center() - grabber->get_size() * 0.5) * scale);
 
 			if (mousewheel_over_grabber) {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2507,7 +2507,7 @@ void FileSystemDock::_tree_rmb_select(const Vector2 &p_pos) {
 
 	// Popup.
 	if (!paths.is_empty()) {
-		tree_popup->set_size(Size2(1, 1));
+		tree_popup->reset_size();
 		_file_and_folders_fill_popup(tree_popup, paths);
 		tree_popup->set_position(tree->get_screen_position() + p_pos);
 		tree_popup->popup();
@@ -2518,7 +2518,7 @@ void FileSystemDock::_tree_rmb_empty(const Vector2 &p_pos) {
 	// Right click is pressed in the empty space of the tree.
 	path = "res://";
 	tree_popup->clear();
-	tree_popup->set_size(Size2(1, 1));
+	tree_popup->reset_size();
 	tree_popup->add_icon_item(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")), TTR("New Folder..."), FILE_NEW_FOLDER);
 	tree_popup->add_icon_item(get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons")), TTR("New Scene..."), FILE_NEW_SCENE);
 	tree_popup->add_icon_item(get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), TTR("New Script..."), FILE_NEW_SCRIPT);
@@ -2549,7 +2549,7 @@ void FileSystemDock::_file_list_rmb_select(int p_item, const Vector2 &p_pos) {
 	// Popup.
 	if (!paths.is_empty()) {
 		file_list_popup->clear();
-		file_list_popup->set_size(Size2(1, 1));
+		file_list_popup->reset_size();
 		_file_and_folders_fill_popup(file_list_popup, paths, searched_string.length() == 0);
 		file_list_popup->set_position(files->get_global_position() + p_pos);
 		file_list_popup->popup();
@@ -2563,7 +2563,7 @@ void FileSystemDock::_file_list_rmb_pressed(const Vector2 &p_pos) {
 	}
 
 	file_list_popup->clear();
-	file_list_popup->set_size(Size2(1, 1));
+	file_list_popup->reset_size();
 
 	file_list_popup->add_icon_item(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")), TTR("New Folder..."), FILE_NEW_FOLDER);
 	file_list_popup->add_icon_item(get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons")), TTR("New Scene..."), FILE_NEW_SCENE);

--- a/editor/import/dynamicfont_import_settings.cpp
+++ b/editor/import/dynamicfont_import_settings.cpp
@@ -1160,7 +1160,7 @@ void DynamicFontImportSettings::_range_update(int32_t p_start, int32_t p_end) {
 
 void DynamicFontImportSettings::_lang_add() {
 	menu_langs->set_position(lang_list->get_screen_transform().xform(lang_list->get_local_mouse_position()));
-	menu_langs->set_size(Vector2(1, 1));
+	menu_langs->reset_size();
 	menu_langs->popup();
 }
 
@@ -1187,7 +1187,7 @@ void DynamicFontImportSettings::_lang_remove(Object *p_item, int p_column, int p
 
 void DynamicFontImportSettings::_script_add() {
 	menu_scripts->set_position(script_list->get_screen_transform().xform(script_list->get_local_mouse_position()));
-	menu_scripts->set_size(Vector2(1, 1));
+	menu_scripts->reset_size();
 	menu_scripts->popup();
 }
 

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -68,7 +68,7 @@ void AnimationNodeBlendTreeEditor::remove_custom_type(const Ref<Script> &p_scrip
 
 void AnimationNodeBlendTreeEditor::_update_options_menu(bool p_has_input_ports) {
 	add_node->get_popup()->clear();
-	add_node->get_popup()->set_size(Size2i(-1, -1));
+	add_node->get_popup()->reset_size();
 	for (int i = 0; i < add_options.size(); i++) {
 		if (p_has_input_ports && add_options[i].input_port_count == 0) {
 			continue;

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -877,7 +877,7 @@ void CanvasItemEditor::_selection_result_pressed(int p_result) {
 void CanvasItemEditor::_selection_menu_hide() {
 	selection_results.clear();
 	selection_menu->clear();
-	selection_menu->set_size(Vector2(0, 0));
+	selection_menu->reset_size();
 }
 
 void CanvasItemEditor::_add_node_pressed(int p_result) {
@@ -2265,7 +2265,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 		}
 
 		if (b.is_valid() && b->is_pressed() && b->get_button_index() == MouseButton::RIGHT) {
-			add_node_menu->set_size(Vector2(1, 1));
+			add_node_menu->reset_size();
 			add_node_menu->set_position(get_screen_position() + b->get_position());
 			add_node_menu->popup();
 			node_create_position = transform.affine_inverse().xform((get_local_mouse_position()));

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -383,7 +383,7 @@ void CurveEditor::open_context_menu(Vector2 pos) {
 
 	_context_menu->add_submenu_item(TTR("Load Preset"), _presets_menu->get_name());
 
-	_context_menu->set_size(Size2(0, 0));
+	_context_menu->reset_size();
 	_context_menu->popup();
 }
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -860,7 +860,7 @@ void Node3DEditorViewport::_update_name() {
 	}
 
 	view_menu->set_text(name);
-	view_menu->set_size(Vector2(0, 0)); // resets the button size
+	view_menu->reset_size();
 }
 
 void Node3DEditorViewport::_compute_edit(const Point2 &p_point) {
@@ -3620,7 +3620,7 @@ void Node3DEditorViewport::_selection_result_pressed(int p_result) {
 void Node3DEditorViewport::_selection_menu_hide() {
 	selection_results.clear();
 	selection_menu->clear();
-	selection_menu->set_size(Vector2(0, 0));
+	selection_menu->reset_size();
 }
 
 void Node3DEditorViewport::set_can_preview(Camera3D *p_preview) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3052,7 +3052,7 @@ void ScriptEditor::_make_script_list_context_menu() {
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_editor/toggle_scripts_panel"), TOGGLE_SCRIPTS_PANEL);
 
 	context_menu->set_position(get_global_transform().xform(get_local_mouse_position()));
-	context_menu->set_size(Vector2(1, 1));
+	context_menu->reset_size();
 	context_menu->popup();
 }
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -550,7 +550,7 @@ void ScriptTextEditor::_validate_script() {
 
 void ScriptTextEditor::_update_bookmark_list() {
 	bookmarks_menu->clear();
-	bookmarks_menu->set_size(Size2(1, 1));
+	bookmarks_menu->reset_size();
 
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_bookmark"), BOOKMARK_TOGGLE);
 	bookmarks_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_bookmarks"), BOOKMARK_REMOVE_ALL);
@@ -702,7 +702,7 @@ void ScriptTextEditor::_code_complete_script(const String &p_code, List<ScriptCo
 
 void ScriptTextEditor::_update_breakpoint_list() {
 	breakpoints_menu->clear();
-	breakpoints_menu->set_size(Size2(1, 1));
+	breakpoints_menu->reset_size();
 
 	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_breakpoint"), DEBUG_TOGGLE_BREAKPOINT);
 	breakpoints_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/remove_all_breakpoints"), DEBUG_REMOVE_ALL_BREAKPOINTS);
@@ -1689,7 +1689,7 @@ void ScriptTextEditor::_make_context_menu(bool p_selection, bool p_color, bool p
 	context_menu->set_item_disabled(context_menu->get_item_index(EDIT_REDO), !tx->has_redo());
 
 	context_menu->set_position(get_global_transform().xform(p_pos));
-	context_menu->set_size(Vector2(1, 1));
+	context_menu->reset_size();
 	context_menu->popup();
 }
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -646,7 +646,7 @@ void ShaderEditor::_make_context_menu(bool p_selection, Vector2 p_position) {
 	context_menu->add_shortcut(ED_GET_SHORTCUT("script_text_editor/toggle_bookmark"), BOOKMARK_TOGGLE);
 
 	context_menu->set_position(get_global_transform().xform(p_position));
-	context_menu->set_size(Vector2(1, 1));
+	context_menu->reset_size();
 	context_menu->popup();
 }
 

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -508,7 +508,7 @@ void TextEditor::_make_context_menu(bool p_selection, bool p_can_fold, bool p_is
 	context_menu->set_item_disabled(context_menu->get_item_index(EDIT_REDO), !tx->has_redo());
 
 	context_menu->set_position(get_global_transform().xform(p_position));
-	context_menu->set_size(Vector2(1, 1));
+	context_menu->reset_size();
 	context_menu->popup();
 }
 

--- a/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
+++ b/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
@@ -34,7 +34,7 @@
 
 void TileProxiesManagerDialog::_right_clicked(int p_item, Vector2 p_local_mouse_pos, Object *p_item_list) {
 	ItemList *item_list = Object::cast_to<ItemList>(p_item_list);
-	popup_menu->set_size(Vector2(1, 1));
+	popup_menu->reset_size();
 	popup_menu->set_position(get_position() + item_list->get_global_mouse_position());
 	popup_menu->popup();
 }

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -132,7 +132,7 @@ void VisualShaderGraphPlugin::show_port_preview(VisualShader::Type p_type, int p
 		if (links[p_node_id].preview_visible && !is_dirty() && links[p_node_id].preview_box != nullptr) {
 			links[p_node_id].graph_node->remove_child(links[p_node_id].preview_box);
 			memdelete(links[p_node_id].preview_box);
-			links[p_node_id].graph_node->set_size(Vector2(-1, -1));
+			links[p_node_id].graph_node->reset_size();
 			links[p_node_id].preview_visible = false;
 		}
 
@@ -256,7 +256,7 @@ void VisualShaderGraphPlugin::update_node_size(int p_node_id) {
 	if (!links.has(p_node_id)) {
 		return;
 	}
-	links[p_node_id].graph_node->set_size(Size2(-1, -1));
+	links[p_node_id].graph_node->reset_size();
 }
 
 void VisualShaderGraphPlugin::register_default_input_button(int p_node_id, int p_port_id, Button *p_button) {
@@ -1976,7 +1976,7 @@ void VisualShaderEditor::_set_node_size(int p_type, int p_node, const Vector2 &p
 		}
 
 		gn->set_custom_minimum_size(size);
-		gn->set_size(Size2(1, 1));
+		gn->reset_size();
 
 		if (!expression_node.is_null() && text_box) {
 			Size2 box_size = size;
@@ -1990,7 +1990,7 @@ void VisualShaderEditor::_set_node_size(int p_type, int p_node, const Vector2 &p
 			box_size.y -= text_box->get_offset(SIDE_TOP);
 			box_size.y -= 28 * EDSCALE;
 			text_box->set_custom_minimum_size(box_size);
-			text_box->set_size(Size2(1, 1));
+			text_box->reset_size();
 		}
 	}
 }
@@ -2038,8 +2038,8 @@ void VisualShaderEditor::_comment_title_popup_show(const Point2 &p_position, int
 }
 
 void VisualShaderEditor::_comment_title_text_changed(const String &p_new_text) {
-	comment_title_change_edit->set_size(Size2(-1, -1));
-	comment_title_change_popup->set_size(Size2(-1, -1));
+	comment_title_change_edit->reset_size();
+	comment_title_change_popup->reset_size();
 }
 
 void VisualShaderEditor::_comment_title_text_submitted(const String &p_new_text) {
@@ -2083,8 +2083,8 @@ void VisualShaderEditor::_comment_desc_popup_show(const Point2 &p_position, int 
 }
 
 void VisualShaderEditor::_comment_desc_text_changed() {
-	comment_desc_change_edit->set_size(Size2(-1, -1));
-	comment_desc_change_popup->set_size(Size2(-1, -1));
+	comment_desc_change_edit->reset_size();
+	comment_desc_change_popup->reset_size();
 }
 
 void VisualShaderEditor::_comment_desc_confirm() {
@@ -3167,7 +3167,7 @@ void VisualShaderEditor::_graph_gui_input(const Ref<InputEvent> &p_event) {
 			menu_point = graph->get_local_mouse_position();
 			Point2 gpos = Input::get_singleton()->get_mouse_position();
 			popup_menu->set_position(gpos);
-			popup_menu->set_size(Size2(-1, -1));
+			popup_menu->reset_size();
 			popup_menu->popup();
 		}
 	}
@@ -4258,8 +4258,8 @@ VisualShaderEditor::VisualShaderEditor() {
 	comment_title_change_edit->connect("text_changed", callable_mp(this, &VisualShaderEditor::_comment_title_text_changed));
 	comment_title_change_edit->connect("text_submitted", callable_mp(this, &VisualShaderEditor::_comment_title_text_submitted));
 	comment_title_change_popup->add_child(comment_title_change_edit);
-	comment_title_change_edit->set_size(Size2(-1, -1));
-	comment_title_change_popup->set_size(Size2(-1, -1));
+	comment_title_change_edit->reset_size();
+	comment_title_change_popup->reset_size();
 	comment_title_change_popup->connect("focus_exited", callable_mp(this, &VisualShaderEditor::_comment_title_popup_focus_out));
 	comment_title_change_popup->connect("popup_hide", callable_mp(this, &VisualShaderEditor::_comment_title_popup_hide));
 	add_child(comment_title_change_popup);
@@ -4271,8 +4271,8 @@ VisualShaderEditor::VisualShaderEditor() {
 	comment_desc_change_edit->connect("text_changed", callable_mp(this, &VisualShaderEditor::_comment_desc_text_changed));
 	comment_desc_vbox->add_child(comment_desc_change_edit);
 	comment_desc_change_edit->set_custom_minimum_size(Size2(300 * EDSCALE, 150 * EDSCALE));
-	comment_desc_change_edit->set_size(Size2(-1, -1));
-	comment_desc_change_popup->set_size(Size2(-1, -1));
+	comment_desc_change_edit->reset_size();
+	comment_desc_change_popup->reset_size();
 	comment_desc_change_popup->connect("focus_exited", callable_mp(this, &VisualShaderEditor::_comment_desc_confirm));
 	comment_desc_change_popup->connect("popup_hide", callable_mp(this, &VisualShaderEditor::_comment_desc_popup_hide));
 	Button *comment_desc_confirm_button = memnew(Button);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -312,7 +312,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 	spinbox->hide();
 	slider->hide();
 	menu->clear();
-	menu->set_size(Size2(1, 1) * EDSCALE);
+	menu->reset_size();
 
 	for (int i = 0; i < MAX_VALUE_EDITORS; i++) {
 		if (i < MAX_VALUE_EDITORS / 4) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -899,7 +899,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				// Resize the dialog to its minimum size.
 				// This prevents the dialog from being too wide after displaying
 				// a deletion confirmation for a node with a long name.
-				delete_dialog->set_size(Size2());
+				delete_dialog->reset_size();
 				delete_dialog->popup_centered();
 			}
 
@@ -2575,7 +2575,7 @@ void SceneTreeDock::_files_dropped(Vector<String> p_files, NodePath p_to, int p_
 				menu_properties->set_item_metadata(menu_properties->get_item_count() - 1, p);
 			}
 
-			menu_properties->set_size(Size2(1, 1));
+			menu_properties->reset_size();
 			menu_properties->set_position(get_screen_position() + get_local_mouse_position());
 			menu_properties->popup();
 		} else if (!valid_properties.is_empty()) {
@@ -2667,7 +2667,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			menu->add_icon_shortcut(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/instance_scene"), TOOL_INSTANTIATE);
 		}
 
-		menu->set_size(Size2(1, 1));
+		menu->reset_size();
 		menu->set_position(get_screen_position() + p_menu_pos);
 		menu->popup();
 		return;
@@ -2690,7 +2690,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		if (profile_allow_editing) {
 			subresources.clear();
 			menu_subresources->clear();
-			menu_subresources->set_size(Size2(1, 1));
+			menu_subresources->reset_size();
 			_add_children_to_popup(selection.front()->get(), 0);
 			if (menu->get_item_count() > 0) {
 				menu->add_separator();
@@ -2831,7 +2831,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 		menu->add_separator();
 		menu->add_icon_shortcut(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), ED_SHORTCUT("scene_tree/delete", TTR("Delete Node(s)"), Key::KEY_DELETE), TOOL_ERASE);
 	}
-	menu->set_size(Size2(1, 1));
+	menu->reset_size();
 	menu->set_position(p_menu_pos);
 	menu->popup();
 }
@@ -2843,7 +2843,7 @@ void SceneTreeDock::_open_tree_menu() {
 	menu->add_check_item(TTR("Auto Expand to Selected"), TOOL_AUTO_EXPAND);
 	menu->set_item_checked(menu->get_item_idx_from_text(TTR("Auto Expand to Selected")), EditorSettings::get_singleton()->get("docks/scene_tree/auto_expand_to_selected"));
 
-	menu->set_size(Size2(1, 1));
+	menu->reset_size();
 	menu->set_position(get_screen_position() + get_local_mouse_position());
 	menu->popup();
 }

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -998,7 +998,7 @@ void VisualScriptEditor::_change_port_type(int p_select, int p_id, int p_port, b
 void VisualScriptEditor::_update_node_size(int p_id) {
 	Node *node = graph->get_node(itos(p_id));
 	if (Object::cast_to<Control>(node)) {
-		Object::cast_to<Control>(node)->set_size(Vector2(1, 1)); // Shrink if text is smaller.
+		Object::cast_to<Control>(node)->reset_size(); // Shrink if text is smaller.
 	}
 }
 
@@ -1616,7 +1616,7 @@ void VisualScriptEditor::_expression_text_changed(const String &p_text, int p_id
 
 	Node *node = graph->get_node(itos(p_id));
 	if (Object::cast_to<Control>(node)) {
-		Object::cast_to<Control>(node)->set_size(Vector2(1, 1)); // Shrink if text is smaller.
+		Object::cast_to<Control>(node)->reset_size(); // Shrink if text is smaller.
 	}
 
 	updating_graph = false;
@@ -3676,7 +3676,7 @@ void VisualScriptEditor::_default_value_edited(Node *p_button, int p_id, int p_i
 	}
 
 	default_value_edit->set_position(Object::cast_to<Control>(p_button)->get_global_position() + Vector2(0, Object::cast_to<Control>(p_button)->get_size().y));
-	default_value_edit->set_size(Size2(1, 1));
+	default_value_edit->reset_size();
 
 	if (pinfo.type == Variant::NODE_PATH) {
 		Node *edited_scene = get_tree()->get_edited_scene_root();
@@ -3832,7 +3832,7 @@ void VisualScriptEditor::_comment_node_resized(const Vector2 &p_new_size, int p_
 	undo_redo->commit_action();
 
 	gn->set_custom_minimum_size(new_size);
-	gn->set_size(Size2(1, 1));
+	gn->reset_size();
 	graph->set_block_minimum_size_adjust(false);
 	updating_graph = false;
 }
@@ -4132,10 +4132,10 @@ void VisualScriptEditor::_member_rmb_selected(const Vector2 &p_pos) {
 
 	member_popup->clear();
 	member_popup->set_position(members->get_global_position() + p_pos);
-	member_popup->set_size(Vector2());
+	member_popup->reset_size();
 
 	function_name_edit->set_position(members->get_global_position() + p_pos);
-	function_name_edit->set_size(Vector2());
+	function_name_edit->reset_size();
 
 	TreeItem *root = members->get_root();
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1821,6 +1821,10 @@ Size2 Control::get_size() const {
 	return data.size_cache;
 }
 
+void Control::reset_size() {
+	set_size(Size2());
+}
+
 Rect2 Control::get_global_rect() const {
 	return Rect2(get_global_position(), get_size());
 }
@@ -2841,6 +2845,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_position", "position", "keep_offsets"), &Control::set_position, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("_set_position", "position"), &Control::_set_position);
 	ClassDB::bind_method(D_METHOD("set_size", "size", "keep_offsets"), &Control::set_size, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("reset_size"), &Control::reset_size);
 	ClassDB::bind_method(D_METHOD("_set_size", "size"), &Control::_set_size);
 	ClassDB::bind_method(D_METHOD("set_custom_minimum_size", "size"), &Control::set_custom_minimum_size);
 	ClassDB::bind_method(D_METHOD("set_global_position", "position", "keep_offsets"), &Control::set_global_position, DEFVAL(false));

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -400,6 +400,7 @@ public:
 
 	void set_size(const Size2 &p_size, bool p_keep_offsets = false);
 	Size2 get_size() const;
+	void reset_size();
 
 	Rect2 get_rect() const;
 	Rect2 get_global_rect() const;

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -228,7 +228,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 		if (b->is_pressed() && b->get_button_index() == MouseButton::RIGHT && context_menu_enabled) {
 			_ensure_menu();
 			menu->set_position(get_screen_transform().xform(get_local_mouse_position()));
-			menu->set_size(Vector2(1, 1));
+			menu->reset_size();
 			menu->popup();
 			grab_focus();
 			accept_event();
@@ -383,7 +383,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 				_ensure_menu();
 				Point2 pos = Point2(get_caret_pixel_pos().x, (get_size().y + get_theme_font(SNAME("font"))->get_height(get_theme_font_size(SNAME("font_size")))) / 2);
 				menu->set_position(get_global_transform().xform(pos));
-				menu->set_size(Vector2(1, 1));
+				menu->reset_size();
 				menu->popup();
 				menu->grab_focus();
 			}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1569,7 +1569,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				_generate_context_menu();
 				menu->set_position(get_screen_transform().xform(mpos));
-				menu->set_size(Vector2(1, 1));
+				menu->reset_size();
 				menu->popup();
 				grab_focus();
 			}
@@ -1802,7 +1802,7 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 				_generate_context_menu();
 				adjust_viewport_to_caret();
 				menu->set_position(get_screen_transform().xform(get_caret_draw_pos()));
-				menu->set_size(Vector2(1, 1));
+				menu->reset_size();
 				menu->popup();
 				menu->grab_focus();
 			}

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -88,6 +88,10 @@ Size2i Window::get_size() const {
 	return size;
 }
 
+void Window::reset_size() {
+	set_size(Size2i());
+}
+
 Size2i Window::get_real_size() const {
 	if (window_id != DisplayServer::INVALID_WINDOW_ID) {
 		return DisplayServer::get_singleton()->window_get_real_size(window_id);
@@ -1410,6 +1414,7 @@ void Window::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_size", "size"), &Window::set_size);
 	ClassDB::bind_method(D_METHOD("get_size"), &Window::get_size);
+	ClassDB::bind_method(D_METHOD("reset_size"), &Window::reset_size);
 
 	ClassDB::bind_method(D_METHOD("get_real_size"), &Window::get_real_size);
 

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -178,6 +178,7 @@ public:
 
 	void set_size(const Size2i &p_size);
 	Size2i get_size() const;
+	void reset_size();
 
 	Size2i get_real_size() const;
 


### PR DESCRIPTION
There are a lot of places in the engine code where the size of Control (or Window) nodes reset like: foo->set_size(Size2(-1, -1)), foo->set_size(Size2(1, 1) or foo->set_size(Size2()). I think all these cases may simply be replaced by `reset_size` method.
