### PR TITLE
[3.x] Add support for OpenXR export configurations.

### DIFF
--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -211,15 +211,23 @@ String _get_screen_sizes_tag(const Ref<EditorExportPreset> &p_preset) {
 
 String _get_xr_features_tag(const Ref<EditorExportPreset> &p_preset) {
 	String manifest_xr_features;
-	bool uses_xr = (int)(p_preset->get("xr_features/xr_mode")) == 1;
+	int xr_mode_index = (int)(p_preset->get("xr_features/xr_mode"));
+	bool uses_xr = xr_mode_index == XR_MODE_OVR || xr_mode_index == XR_MODE_OPENXR;
 	if (uses_xr) {
 		manifest_xr_features += "    <uses-feature tools:node=\"replace\" android:name=\"android.hardware.vr.headtracking\" android:required=\"true\" android:version=\"1\" />\n";
 
 		int hand_tracking_index = p_preset->get("xr_features/hand_tracking"); // 0: none, 1: optional, 2: required
-		if (hand_tracking_index == 1) {
+		if (hand_tracking_index == XR_HAND_TRACKING_OPTIONAL) {
 			manifest_xr_features += "    <uses-feature tools:node=\"replace\" android:name=\"oculus.software.handtracking\" android:required=\"false\" />\n";
-		} else if (hand_tracking_index == 2) {
+		} else if (hand_tracking_index == XR_HAND_TRACKING_REQUIRED) {
 			manifest_xr_features += "    <uses-feature tools:node=\"replace\" android:name=\"oculus.software.handtracking\" android:required=\"true\" />\n";
+		}
+
+		int passthrough_mode = p_preset->get("xr_features/passthrough");
+		if (passthrough_mode == XR_PASSTHROUGH_OPTIONAL) {
+			manifest_xr_features += "    <uses-feature tools:node=\"replace\" android:name=\"com.oculus.feature.PASSTHROUGH\" android:required=\"false\" />\n";
+		} else if (passthrough_mode == XR_PASSTHROUGH_REQUIRED) {
+			manifest_xr_features += "    <uses-feature tools:node=\"replace\" android:name=\"com.oculus.feature.PASSTHROUGH\" android:required=\"true\" />\n";
 		}
 	}
 	return manifest_xr_features;
@@ -239,7 +247,8 @@ String _get_instrumentation_tag(const Ref<EditorExportPreset> &p_preset) {
 }
 
 String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
-	bool uses_xr = (int)(p_preset->get("xr_features/xr_mode")) == 1;
+	int xr_mode_index = (int)(p_preset->get("xr_features/xr_mode"));
+	bool uses_xr = xr_mode_index == XR_MODE_OVR || xr_mode_index == XR_MODE_OPENXR;
 	String orientation = _get_android_orientation_label(
 			OS::get_singleton()->get_screen_orientation_from_string(GLOBAL_GET("display/window/handheld/orientation")));
 	String manifest_activity_text = vformat(
@@ -257,7 +266,8 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 }
 
 String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_storage_permission) {
-	bool uses_xr = (int)(p_preset->get("xr_features/xr_mode")) == 1;
+	int xr_mode_index = (int)(p_preset->get("xr_features/xr_mode"));
+	bool uses_xr = xr_mode_index == XR_MODE_OVR || xr_mode_index == XR_MODE_OPENXR;
 	String manifest_application_text = vformat(
 			"    <application android:label=\"@string/godot_project_name_string\"\n"
 			"        android:allowBackup=\"%s\"\n"

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -44,6 +44,22 @@ const String godot_project_name_xml_string = R"(<?xml version="1.0" encoding="ut
 </resources>
 )";
 
+// Supported XR modes.
+// This should match the entries in 'platform/android/java/lib/src/org/godotengine/godot/xr/XRMode.java'
+static const int XR_MODE_REGULAR = 0;
+static const int XR_MODE_OVR = 1;
+static const int XR_MODE_OPENXR = 2;
+
+// Supported XR hand tracking modes.
+static const int XR_HAND_TRACKING_NONE = 0;
+static const int XR_HAND_TRACKING_OPTIONAL = 1;
+static const int XR_HAND_TRACKING_REQUIRED = 2;
+
+// Supported XR passthrough modes.
+static const int XR_PASSTHROUGH_NONE = 0;
+static const int XR_PASSTHROUGH_OPTIONAL = 1;
+static const int XR_PASSTHROUGH_REQUIRED = 2;
+
 struct CustomExportData {
 	String assets_directory;
 	bool debug;

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -620,6 +620,8 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 				xrMode = XRMode.REGULAR;
 			} else if (command_line[i].equals(XRMode.OVR.cmdLineArg)) {
 				xrMode = XRMode.OVR;
+			} else if (command_line[i].equals(XRMode.OPENXR.cmdLineArg)) {
+				xrMode = XRMode.OPENXR;
 			} else if (command_line[i].equals("--debug_opengl")) {
 				use_debug_opengl = true;
 			} else if (command_line[i].equals("--translucent")) {

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotView.java
@@ -128,6 +128,7 @@ public class GodotView extends GLSurfaceView {
 		setFocusableInTouchMode(true);
 		switch (xrMode) {
 			case OVR:
+			case OPENXR:
 				// Replace the default egl config chooser.
 				eglConfigChooser = new OvrConfigChooser();
 

--- a/platform/android/java/lib/src/org/godotengine/godot/xr/XRMode.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/xr/XRMode.java
@@ -35,7 +35,8 @@ package org.godotengine.godot.xr;
  */
 public enum XRMode {
 	REGULAR(0, "Regular", "--xr_mode_regular", "Default Android Gamepad"), // Regular/flatscreen
-	OVR(1, "Oculus Mobile VR", "--xr_mode_ovr", "");
+	OVR(1, "Oculus Mobile VrApi (Deprecated)", "--xr_mode_ovr", ""),
+	OPENXR(2, "OpenXR", "--xr_mode_openxr", "");
 
 	final int index;
 	final String label;


### PR DESCRIPTION
The Oculus mobile VrApi SDK has been [deprecated by Meta in favor of OpenXR](https://developer.oculus.com/blog/oculus-all-in-on-openxr-deprecates-proprietary-apis/). 

This PR updates the labels to reflect the deprecation, and adds support for selecting and configuring Godot's OpenXR implementation.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
