### PR TITLE
Add support for OpenXR export configurations.

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -751,9 +751,9 @@ void EditorExportPlatformAndroid::_get_permissions(const Ref<EditorExportPreset>
 	}
 
 	int xr_mode_index = p_preset->get("xr_features/xr_mode");
-	if (xr_mode_index == 1 /* XRMode.OVR */) {
+	if (xr_mode_index == XR_MODE_OPENXR) {
 		int hand_tracking_index = p_preset->get("xr_features/hand_tracking"); // 0: none, 1: optional, 2: required
-		if (hand_tracking_index > 0) {
+		if (hand_tracking_index > XR_HAND_TRACKING_NONE) {
 			if (r_permissions.find("com.oculus.permission.HAND_TRACKING") == -1) {
 				r_permissions.push_back("com.oculus.permission.HAND_TRACKING");
 			}
@@ -964,6 +964,20 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 						}
 					}
 
+					if (tname == "meta-data" && attrname == "name" && value == "xr_mode_metadata_name") {
+						// Update the meta-data 'android:name' attribute based on the selected XR mode.
+						if (xr_mode_index == XR_MODE_OPENXR) {
+							string_table.write[attr_value] = "com.samsung.android.vr.application.mode";
+						}
+					}
+
+					if (tname == "meta-data" && attrname == "value" && value == "xr_mode_metadata_value") {
+						// Update the meta-data 'android:value' attribute based on the selected XR mode.
+						if (xr_mode_index == XR_MODE_OPENXR) {
+							string_table.write[attr_value] = "vr_only";
+						}
+					}
+
 					iofs += 20;
 				}
 
@@ -978,7 +992,7 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 					Vector<bool> feature_required_list;
 					Vector<int> feature_versions;
 
-					if (xr_mode_index == 1 /* XRMode.OVR */) {
+					if (xr_mode_index == XR_MODE_OPENXR) {
 						// Set degrees of freedom
 						feature_names.push_back("android.hardware.vr.headtracking");
 						feature_required_list.push_back(true);
@@ -986,10 +1000,18 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 
 						// Check for hand tracking
 						int hand_tracking_index = p_preset->get("xr_features/hand_tracking"); // 0: none, 1: optional, 2: required
-						if (hand_tracking_index > 0) {
+						if (hand_tracking_index > XR_HAND_TRACKING_NONE) {
 							feature_names.push_back("oculus.software.handtracking");
-							feature_required_list.push_back(hand_tracking_index == 2);
+							feature_required_list.push_back(hand_tracking_index == XR_HAND_TRACKING_REQUIRED);
 							feature_versions.push_back(-1); // no version attribute should be added.
+						}
+
+						// Check for passthrough
+						int passthrough_mode = p_preset->get("xr_features/passthrough");
+						if (passthrough_mode > XR_PASSTHROUGH_NONE) {
+							feature_names.push_back("com.oculus.feature.PASSTHROUGH");
+							feature_required_list.push_back(passthrough_mode == XR_PASSTHROUGH_REQUIRED);
+							feature_versions.push_back(-1);
 						}
 					}
 
@@ -1669,8 +1691,9 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "graphics/opengl_debug"), false));
 
-	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "xr_features/xr_mode", PROPERTY_HINT_ENUM, "Regular,Oculus Mobile VR"), 0));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "xr_features/xr_mode", PROPERTY_HINT_ENUM, "Regular,OpenXR"), 0));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "xr_features/hand_tracking", PROPERTY_HINT_ENUM, "None,Optional,Required"), 0));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "xr_features/passthrough", PROPERTY_HINT_ENUM, "None,Optional,Required"), 0));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/immersive_mode"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/support_small"), true));
@@ -2137,10 +2160,17 @@ bool EditorExportPlatformAndroid::can_export(const Ref<EditorExportPreset> &p_pr
 	// Validate the Xr features are properly populated
 	int xr_mode_index = p_preset->get("xr_features/xr_mode");
 	int hand_tracking = p_preset->get("xr_features/hand_tracking");
-	if (xr_mode_index != /* XRMode.OVR*/ 1) {
-		if (hand_tracking > 0) {
+	int passthrough_mode = p_preset->get("xr_features/passthrough");
+	if (xr_mode_index != XR_MODE_OPENXR) {
+		if (hand_tracking > XR_HAND_TRACKING_NONE) {
 			valid = false;
-			err += TTR("\"Hand Tracking\" is only valid when \"Xr Mode\" is \"Oculus Mobile VR\".");
+			err += TTR("\"Hand Tracking\" is only valid when \"Xr Mode\" is \"OpenXR\".");
+			err += "\n";
+		}
+
+		if (passthrough_mode > XR_PASSTHROUGH_NONE) {
+			valid = false;
+			err += TTR("\"Passthrough\" is only valid when \"Xr Mode\" is \"OpenXR\".");
 			err += "\n";
 		}
 	}
@@ -2202,8 +2232,8 @@ void EditorExportPlatformAndroid::get_command_line_flags(const Ref<EditorExportP
 	}
 
 	int xr_mode_index = p_preset->get("xr_features/xr_mode");
-	if (xr_mode_index == 1) {
-		command_line_strings.push_back("--xr_mode_ovr");
+	if (xr_mode_index == XR_MODE_OPENXR) {
+		command_line_strings.push_back("--xr_mode_openxr");
 	} else { // XRMode.REGULAR is the default.
 		command_line_strings.push_back("--xr_mode_regular");
 	}

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -44,6 +44,21 @@ const String godot_project_name_xml_string = R"(<?xml version="1.0" encoding="ut
 </resources>
 )";
 
+// Supported XR modes.
+// This should match the entries in 'platform/android/java/lib/src/org/godotengine/godot/xr/XRMode.java'
+static const int XR_MODE_REGULAR = 0;
+static const int XR_MODE_OPENXR = 1;
+
+// Supported XR hand tracking modes.
+static const int XR_HAND_TRACKING_NONE = 0;
+static const int XR_HAND_TRACKING_OPTIONAL = 1;
+static const int XR_HAND_TRACKING_REQUIRED = 2;
+
+// Supported XR passthrough modes.
+static const int XR_PASSTHROUGH_NONE = 0;
+static const int XR_PASSTHROUGH_OPTIONAL = 1;
+static const int XR_PASSTHROUGH_REQUIRED = 2;
+
 struct CustomExportData {
 	String assets_directory;
 	bool debug;

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -33,6 +33,11 @@
         <!-- The following metadata values are replaced when Godot exports, modifying them here has no effect. -->
         <!-- Do these changes in the export preset. Adding new ones is fine. -->
 
+        <!-- XR mode metadata. This is modified by the exporter based on the selected xr mode. DO NOT CHANGE the values here. -->
+        <meta-data
+            android:name="xr_mode_metadata_name"
+            android:value="xr_mode_metadata_value" />
+
         <activity
             android:name=".GodotApp"
             android:label="@string/godot_project_name_string"

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -502,8 +502,8 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 			boolean has_extra = i < command_line.length - 1;
 			if (command_line[i].equals(XRMode.REGULAR.cmdLineArg)) {
 				xrMode = XRMode.REGULAR;
-			} else if (command_line[i].equals(XRMode.OVR.cmdLineArg)) {
-				xrMode = XRMode.OVR;
+			} else if (command_line[i].equals(XRMode.OPENXR.cmdLineArg)) {
+				xrMode = XRMode.OPENXR;
 			} else if (command_line[i].equals("--debug_opengl")) {
 				use_debug_opengl = true;
 			} else if (command_line[i].equals("--use_immersive")) {

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotGLRenderView.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotGLRenderView.java
@@ -174,7 +174,7 @@ public class GodotGLRenderView extends GLSurfaceView implements GodotRenderView 
 		setPreserveEGLContextOnPause(true);
 		setFocusableInTouchMode(true);
 		switch (xrMode) {
-			case OVR:
+			case OPENXR:
 				// Replace the default egl config chooser.
 				setEGLConfigChooser(new OvrConfigChooser());
 

--- a/platform/android/java/lib/src/org/godotengine/godot/xr/XRMode.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/xr/XRMode.java
@@ -35,7 +35,7 @@ package org.godotengine.godot.xr;
  */
 public enum XRMode {
 	REGULAR(0, "Regular", "--xr_mode_regular", "Default Android Gamepad"), // Regular/flatscreen
-	OVR(1, "Oculus Mobile VR", "--xr_mode_ovr", "");
+	OPENXR(1, "OpenXR", "--xr_mode_openxr", "");
 
 	final int index;
 	final String label;


### PR DESCRIPTION
The Oculus mobile VrApi SDK has been [deprecated by Meta in favor of OpenXR](https://developer.oculus.com/blog/oculus-all-in-on-openxr-deprecates-proprietary-apis/). 

Accordingly, this PR drops support for the Oculus mobile VrApi SDK in `master` and replaces it with the OpenXR SDK.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
