### PR TITLE
Fix debugger errors when visual script has been attached to the remote resource

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -645,7 +645,11 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 							Ref<Script> script(var);
 							if (!script.is_null()) {
 								ScriptInstance *script_instance = script->placeholder_instance_create(debugObj);
-								debugObj->set_script_and_instance(var, script_instance);
+
+                                // fix: VisualScript resource
+                                if (script_instance) {
+                                    debugObj->set_script_and_instance(var, script_instance);
+                                }
 							}
 						}
 					}


### PR DESCRIPTION
**error in editor debug remote:**
![godot](https://user-images.githubusercontent.com/8493573/142733332-c60c2863-92d5-4f5d-994d-cea7ee2a5968.png)

**Only in option remote in editor play**
![godot2](https://user-images.githubusercontent.com/8493573/142733380-2c0a9b3b-4583-4d2e-abe0-c747e1ba1b22.png)


