### PR TITLE
Fix ProceduralSkyMaterial colors due to double sRGB -> linear conversion

### DIFF
--- a/scene/resources/sky_material.cpp
+++ b/scene/resources/sky_material.cpp
@@ -37,7 +37,7 @@ RID ProceduralSkyMaterial::shader;
 
 void ProceduralSkyMaterial::set_sky_top_color(const Color &p_sky_top) {
 	sky_top_color = p_sky_top;
-	RS::get_singleton()->material_set_param(_get_material(), "sky_top_color", sky_top_color.to_linear());
+	RS::get_singleton()->material_set_param(_get_material(), "sky_top_color", sky_top_color);
 }
 
 Color ProceduralSkyMaterial::get_sky_top_color() const {
@@ -46,7 +46,7 @@ Color ProceduralSkyMaterial::get_sky_top_color() const {
 
 void ProceduralSkyMaterial::set_sky_horizon_color(const Color &p_sky_horizon) {
 	sky_horizon_color = p_sky_horizon;
-	RS::get_singleton()->material_set_param(_get_material(), "sky_horizon_color", sky_horizon_color.to_linear());
+	RS::get_singleton()->material_set_param(_get_material(), "sky_horizon_color", sky_horizon_color);
 }
 
 Color ProceduralSkyMaterial::get_sky_horizon_color() const {
@@ -73,7 +73,7 @@ float ProceduralSkyMaterial::get_sky_energy() const {
 
 void ProceduralSkyMaterial::set_ground_bottom_color(const Color &p_ground_bottom) {
 	ground_bottom_color = p_ground_bottom;
-	RS::get_singleton()->material_set_param(_get_material(), "ground_bottom_color", ground_bottom_color.to_linear());
+	RS::get_singleton()->material_set_param(_get_material(), "ground_bottom_color", ground_bottom_color);
 }
 
 Color ProceduralSkyMaterial::get_ground_bottom_color() const {
@@ -82,7 +82,7 @@ Color ProceduralSkyMaterial::get_ground_bottom_color() const {
 
 void ProceduralSkyMaterial::set_ground_horizon_color(const Color &p_ground_horizon) {
 	ground_horizon_color = p_ground_horizon;
-	RS::get_singleton()->material_set_param(_get_material(), "ground_horizon_color", ground_horizon_color.to_linear());
+	RS::get_singleton()->material_set_param(_get_material(), "ground_horizon_color", ground_horizon_color);
 }
 
 Color ProceduralSkyMaterial::get_ground_horizon_color() const {


### PR DESCRIPTION
The issue with PhysicalSkyMaterial's colors being incorrect remains. I don't know how that one should be fixed, since I removed all uses of `Color.to_linear()` within `sky_material.cpp` (which also includes the code for PhysicalSkyMaterial).

Thanks to @clayjohn for providing the fix :slightly_smiling_face: 

This partially addresses https://github.com/godotengine/godot/issues/55143.

## Preview

### Before

![2021-11-20_17 25 34](https://user-images.githubusercontent.com/180032/142733767-f638df7f-ebb3-4869-a26e-ee1c83136b2a.png)

### After

![2021-11-20_17 25 46](https://user-images.githubusercontent.com/180032/142733768-8226f853-0ca1-4312-89f1-62c7bbf64559.png)