### PR TITLE
Add GodotBody2D/GodotBody3D conditional wakeup when setting gravity_scale param

### DIFF
--- a/servers/physics_2d/godot_body_2d.cpp
+++ b/servers/physics_2d/godot_body_2d.cpp
@@ -185,6 +185,9 @@ void GodotBody2D::set_param(PhysicsServer2D::BodyParameter p_param, const Varian
 			_update_transform_dependent();
 		} break;
 		case PhysicsServer2D::BODY_PARAM_GRAVITY_SCALE: {
+			if (Math::is_zero_approx(gravity_scale)) {
+				wakeup();
+			}
 			gravity_scale = p_value;
 		} break;
 		case PhysicsServer2D::BODY_PARAM_LINEAR_DAMP_MODE: {

--- a/servers/physics_3d/godot_body_3d.cpp
+++ b/servers/physics_3d/godot_body_3d.cpp
@@ -227,6 +227,9 @@ void GodotBody3D::set_param(PhysicsServer3D::BodyParameter p_param, const Varian
 			_update_transform_dependent();
 		} break;
 		case PhysicsServer3D::BODY_PARAM_GRAVITY_SCALE: {
+			if (Math::is_zero_approx(gravity_scale)) {
+				wakeup();
+			}
 			gravity_scale = p_value;
 		} break;
 		case PhysicsServer3D::BODY_PARAM_LINEAR_DAMP_MODE: {


### PR DESCRIPTION
In #55047 @pouleyKetchoupp recommended that the solution be implemented in `GodotBody2D::set_param` and `GodotBody3D::set_param`. My solution is to conditionally check if gravity_scale is zero prior to changing it, if it is, call `wakeup()` and then set the new gravity_scale.

In test, I can no longer reproduce the bug @nabfrew noted in the issue with his provided minimal project with these changes.

Fixes #55047