### PR TITLE
Expose `FontData::{set,get}_fixed_size` methods

### DIFF
--- a/doc/classes/FontData.xml
+++ b/doc/classes/FontData.xml
@@ -93,6 +93,12 @@
 				Returns font descent (number of pixels below the baseline).
 			</description>
 		</method>
+		<method name="get_fixed_size" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns font fixed size.
+			</description>
+		</method>
 		<method name="get_font_name" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -479,6 +485,13 @@
 			<argument index="2" name="descent" type="float" />
 			<description>
 				Sets the font descent (number of pixels below the baseline).
+			</description>
+		</method>
+		<method name="set_fixed_size">
+			<return type="void" />
+			<argument index="0" name="fixed_size" type="int" />
+			<description>
+				Sets the fixed size for the font.
 			</description>
 		</method>
 		<method name="set_font_name">

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -88,6 +88,9 @@ void FontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_msdf_size", "msdf_size"), &FontData::set_msdf_size);
 	ClassDB::bind_method(D_METHOD("get_msdf_size"), &FontData::get_msdf_size);
 
+	ClassDB::bind_method(D_METHOD("set_fixed_size", "fixed_size"), &FontData::set_fixed_size);
+	ClassDB::bind_method(D_METHOD("get_fixed_size"), &FontData::get_fixed_size);
+
 	ClassDB::bind_method(D_METHOD("set_force_autohinter", "force_autohinter"), &FontData::set_force_autohinter);
 	ClassDB::bind_method(D_METHOD("is_force_autohinter"), &FontData::is_force_autohinter);
 


### PR DESCRIPTION
I think these methods were accidentally overlooked.

![](https://user-images.githubusercontent.com/47700418/142736283-b89a202a-a89f-46a9-aa09-fdd2fa4698f7.png)

https://github.com/godotengine/godot/blob/ed02b8af59fceb48798c857306335fe0f7ff6a8a/scene/resources/font.cpp#L193-L232

Is that how it should be? Shouldn't `ADD_PROPERTY` be used here instead?