### PR TITLE
[Crypto] ResourceUID works without crypto.

### DIFF
--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -92,10 +92,22 @@ Crypto *Crypto::create() {
 	ERR_FAIL_V_MSG(nullptr, "Crypto is not available when the mbedtls module is disabled.");
 }
 
+bool Crypto::is_available() {
+	return _create != nullptr;
+}
+
 void Crypto::load_default_certificates(String p_path) {
 	if (_load_default_certificates) {
 		_load_default_certificates(p_path);
 	}
+}
+
+PackedByteArray Crypto::generate_random_bytes(int p_bytes) {
+	PackedByteArray out;
+	out.resize(p_bytes);
+	Error err = random_fill(out.ptrw(), out.size());
+	ERR_FAIL_COND_V(err != OK, PackedByteArray());
+	return out;
 }
 
 PackedByteArray Crypto::hmac_digest(HashingContext::HashType p_hash_type, PackedByteArray p_key, PackedByteArray p_msg) {

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -94,10 +94,11 @@ protected:
 	static void (*_load_default_certificates)(String p_path);
 
 public:
+	static bool is_available();
 	static Crypto *create();
 	static void load_default_certificates(String p_path);
 
-	virtual PackedByteArray generate_random_bytes(int p_bytes) = 0;
+	virtual Error random_fill(uint8_t *r_dst, int p_dst_size) = 0;
 	virtual Ref<CryptoKey> generate_rsa(int p_bytes) = 0;
 	virtual Ref<X509Certificate> generate_self_signed_certificate(Ref<CryptoKey> p_key, String p_issuer_name, String p_not_before, String p_not_after) = 0;
 
@@ -105,6 +106,8 @@ public:
 	virtual bool verify(HashingContext::HashType p_hash_type, Vector<uint8_t> p_hash, Vector<uint8_t> p_signature, Ref<CryptoKey> p_key) = 0;
 	virtual Vector<uint8_t> encrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_plaintext) = 0;
 	virtual Vector<uint8_t> decrypt(Ref<CryptoKey> p_key, Vector<uint8_t> p_ciphertext) = 0;
+
+	PackedByteArray generate_random_bytes(int p_bytes);
 
 	PackedByteArray hmac_digest(HashingContext::HashType p_hash_type, PackedByteArray p_key, PackedByteArray p_msg);
 

--- a/core/crypto/crypto_core.h
+++ b/core/crypto/crypto_core.h
@@ -31,13 +31,25 @@
 #ifndef CRYPTO_CORE_H
 #define CRYPTO_CORE_H
 
-#include "core/object/ref_counted.h"
+#include "core/string/ustring.h"
 
 class CryptoCore {
 public:
+	class EntropyContext {
+	private:
+		void *ctx = nullptr;
+		bool is_strong = false;
+
+	public:
+		EntropyContext();
+		~EntropyContext();
+
+		Error random_fill(uint8_t *r_dst, int p_dst_size);
+	};
+
 	class MD5Context {
 	private:
-		void *ctx = nullptr; // To include, or not to include...
+		void *ctx = nullptr;
 
 	public:
 		MD5Context();
@@ -50,7 +62,7 @@ public:
 
 	class SHA1Context {
 	private:
-		void *ctx = nullptr; // To include, or not to include...
+		void *ctx = nullptr;
 
 	public:
 		SHA1Context();
@@ -63,7 +75,7 @@ public:
 
 	class SHA256Context {
 	private:
-		void *ctx = nullptr; // To include, or not to include...
+		void *ctx = nullptr;
 
 	public:
 		SHA256Context();
@@ -76,7 +88,7 @@ public:
 
 	class AESContext {
 	private:
-		void *ctx = nullptr; // To include, or not to include...
+		void *ctx = nullptr;
 
 	public:
 		AESContext();

--- a/core/io/resource_uid.h
+++ b/core/io/resource_uid.h
@@ -35,7 +35,6 @@
 #include "core/string/string_name.h"
 #include "core/templates/ordered_hash_map.h"
 
-class Crypto;
 class ResourceUID : public Object {
 	GDCLASS(ResourceUID, Object)
 public:
@@ -47,7 +46,7 @@ public:
 	static String get_cache_file();
 
 private:
-	mutable Ref<Crypto> crypto;
+	void *entropy = nullptr;
 	Mutex mutex;
 	struct Cache {
 		CharString cs;
@@ -67,7 +66,7 @@ public:
 	String id_to_text(ID p_id) const;
 	ID text_to_id(const String &p_text) const;
 
-	ID create_id() const;
+	ID create_id();
 	bool has_id(ID p_id) const;
 	void add_id(ID p_id, const String &p_path);
 	void set_id(ID p_id, const String &p_path);

--- a/doc/classes/ResourceUID.xml
+++ b/doc/classes/ResourceUID.xml
@@ -14,7 +14,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="create_id" qualifiers="const">
+		<method name="create_id">
 			<return type="int" />
 			<description>
 			</description>

--- a/modules/mbedtls/crypto_mbedtls.cpp
+++ b/modules/mbedtls/crypto_mbedtls.cpp
@@ -378,11 +378,10 @@ Ref<X509Certificate> CryptoMbedTLS::generate_self_signed_certificate(Ref<CryptoK
 	return out;
 }
 
-PackedByteArray CryptoMbedTLS::generate_random_bytes(int p_bytes) {
-	PackedByteArray out;
-	out.resize(p_bytes);
-	mbedtls_ctr_drbg_random(&ctr_drbg, out.ptrw(), p_bytes);
-	return out;
+Error CryptoMbedTLS::random_fill(uint8_t *r_dst, int p_dst_size) {
+	int ret = mbedtls_ctr_drbg_random(&ctr_drbg, r_dst, p_dst_size);
+	ERR_FAIL_COND_V_MSG(ret != 0, FAILED, "Failed to generate random bytes: " + itos(ret));
+	return OK;
 }
 
 mbedtls_md_type_t CryptoMbedTLS::md_type_from_hashtype(HashingContext::HashType p_hash_type, int &r_size) {

--- a/modules/mbedtls/crypto_mbedtls.h
+++ b/modules/mbedtls/crypto_mbedtls.h
@@ -136,7 +136,7 @@ public:
 	static void load_default_certificates(String p_path);
 	static mbedtls_md_type_t md_type_from_hashtype(HashingContext::HashType p_hash_type, int &r_size);
 
-	virtual PackedByteArray generate_random_bytes(int p_bytes);
+	virtual Error random_fill(uint8_t *r_dst, int p_dst_size);
 	virtual Ref<CryptoKey> generate_rsa(int p_bytes);
 	virtual Ref<X509Certificate> generate_self_signed_certificate(Ref<CryptoKey> p_key, String p_issuer_name, String p_not_before, String p_not_after);
 	virtual Vector<uint8_t> sign(HashingContext::HashType p_hash_type, Vector<uint8_t> p_hash, Ref<CryptoKey> p_key);

--- a/tests/core/test_crypto.h
+++ b/tests/core/test_crypto.h
@@ -37,7 +37,7 @@
 namespace TestCrypto {
 
 class _MockCrypto : public Crypto {
-	virtual PackedByteArray generate_random_bytes(int p_bytes) { return PackedByteArray(); }
+	virtual Error random_fill(uint8_t *p_dst, int p_dst_size) { return ERR_UNAVAILABLE; }
 	virtual Ref<CryptoKey> generate_rsa(int p_bytes) { return nullptr; }
 	virtual Ref<X509Certificate> generate_self_signed_certificate(Ref<CryptoKey> p_key, String p_issuer_name, String p_not_before, String p_not_after) { return nullptr; }
 


### PR DESCRIPTION
A new EntropyContext is added to CryptoCore for generating random bytes.

Preferring a high entropy source (Crypto module) if available, and falling back to simple RNG otherwise.

This should probably use entropy sources implemented at OS-level in the future.

Also fixes a race condition when accessing the crypto module from ResourceUID.

Note: ID creation is still not really unique, i.e., we might have (unlikely) collisions when calling `create_id` because the ID is checked for existence, but not inserted immediately. I believe it should also be inserted into the cache (with a special "pending" state maybe?) but I've left that for a follow up PR. (cc @reduz)