### PR TITLE
Fix Theme Editor crash when clicking the element picker

### DIFF
--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -71,6 +71,9 @@ void ThemeEditorPreview::_preview_visibility_changed() {
 
 void ThemeEditorPreview::_picker_button_cbk() {
 	picker_overlay->set_visible(picker_button->is_pressed());
+	if (picker_button->is_pressed()) {
+		_reset_picker_overlay();
+	}
 }
 
 Control *ThemeEditorPreview::_find_hovered_control(Control *p_parent, Vector2 p_mouse_position) {


### PR DESCRIPTION
Fixes #54772

`picker_button` was not reset when starting a new pick, so it would still point to the control node that was freed by clicking "reload" button.