### PR TITLE
Add global_position/rotation/scale properties to Node3d

### DIFF
--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -56,28 +56,6 @@
 				Returns the current [World3D] resource this [Node3D] node is registered to.
 			</description>
 		</method>
-		<method name="global_rotate">
-			<return type="void" />
-			<argument index="0" name="axis" type="Vector3" />
-			<argument index="1" name="angle" type="float" />
-			<description>
-				Rotates the global (world) transformation around axis, a unit [Vector3], by specified angle in radians. The rotation axis is in global coordinate system.
-			</description>
-		</method>
-		<method name="global_scale">
-			<return type="void" />
-			<argument index="0" name="scale" type="Vector3" />
-			<description>
-				Scales the global (world) transformation by the given [Vector3] scale factors.
-			</description>
-		</method>
-		<method name="global_translate">
-			<return type="void" />
-			<argument index="0" name="offset" type="Vector3" />
-			<description>
-				Moves the global (world) transformation by [Vector3] offset. The offset is in global coordinate system.
-			</description>
-		</method>
 		<method name="hide">
 			<return type="void" />
 			<description>
@@ -142,6 +120,14 @@
 				Rotates the local transformation around axis, a unit [Vector3], by specified angle in radians.
 			</description>
 		</method>
+		<method name="rotate_object_global">
+			<return type="void" />
+			<argument index="0" name="axis" type="Vector3" />
+			<argument index="1" name="angle" type="float" />
+			<description>
+				Rotates the global transformation around axis, a unit [Vector3], by specified angle in radians. The rotation axis is in global coordinate system.
+			</description>
+		</method>
 		<method name="rotate_object_local">
 			<return type="void" />
 			<argument index="0" name="axis" type="Vector3" />
@@ -169,6 +155,13 @@
 			<argument index="0" name="angle" type="float" />
 			<description>
 				Rotates the local transformation around the Z axis by angle in radians.
+			</description>
+		</method>
+		<method name="scale_object_global">
+			<return type="void" />
+			<argument index="0" name="scale" type="Vector3" />
+			<description>
+				Scales the global transformation by given 3D scale factors in global coordinate system.
 			</description>
 		</method>
 		<method name="scale_object_local">
@@ -249,6 +242,13 @@
 				Note that the translation [code]offset[/code] is affected by the node's scale, so if scaled by e.g. [code](10, 1, 1)[/code], a translation by an offset of [code](2, 0, 0)[/code] would actually add 20 ([code]2 * 10[/code]) to the X coordinate.
 			</description>
 		</method>
+		<method name="translate_object_global">
+			<return type="void" />
+			<argument index="0" name="offset" type="Vector3" />
+			<description>
+				Changes the node's position by the given offset [Vector3] in global space.
+			</description>
+		</method>
 		<method name="translate_object_local">
 			<return type="void" />
 			<argument index="0" name="offset" type="Vector3" />
@@ -266,6 +266,15 @@
 	<members>
 		<member name="basis" type="Basis" setter="set_basis" getter="get_basis">
 			Direct access to the 3x3 basis of the [Transform3D] property.
+		</member>
+		<member name="global_position" type="Vector3" setter="set_global_position" getter="get_global_position" default="Vector3(0, 0, 0)">
+			Global position or translation of this node. This is equivalent to [code]global_transform.origin[/code].
+		</member>
+		<member name="global_rotation" type="Vector3" setter="set_global_rotation" getter="get_global_rotation" default="Vector3(0, 0, 0)">
+			Rotation part of the global transformation in radians, specified in terms of Euler angles. The angles construct a rotaton in the order specified by the [member rotation_order] property.
+		</member>
+		<member name="global_scale" type="Vector3" setter="set_global_scale" getter="get_global_scale" default="Vector3(1, 1, 1)">
+			Scale part of the global transformation.
 		</member>
 		<member name="global_transform" type="Transform3D" setter="set_global_transform" getter="get_global_transform">
 			World3D space (global) [Transform3D] of this node.

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -409,6 +409,36 @@ Vector3 Node3D::get_scale() const {
 	return data.scale;
 }
 
+void Node3D::set_global_position(const Vector3 &p_position) {
+	Transform3D t = get_global_transform();
+	t.origin = p_position;
+	set_global_transform(t);
+}
+
+void Node3D::set_global_rotation(const Vector3 &p_euler_rad) {
+	Transform3D t = get_global_transform();
+	t.basis = Basis::from_euler(p_euler_rad).scaled(t.basis.get_scale());
+	set_global_transform(t);
+}
+
+void Node3D::set_global_scale(const Vector3 &p_scale) {
+	Transform3D t = get_global_transform();
+	t.basis = Basis::from_scale(p_scale).rotated(t.basis.get_euler_normalized());
+	set_global_transform(t);
+}
+
+Vector3 Node3D::get_global_position() const {
+	return data.global_transform.origin;
+}
+
+Vector3 Node3D::get_global_rotation() const {
+	return data.global_transform.basis.get_euler_normalized(data.rotation_order);
+}
+
+Vector3 Node3D::get_global_scale() const {
+	return data.global_transform.basis.get_scale();
+}
+
 void Node3D::update_gizmos() {
 #ifdef TOOLS_ENABLED
 	if (!is_inside_world()) {
@@ -705,19 +735,19 @@ void Node3D::scale_object_local(const Vector3 &p_scale) {
 	set_transform(t);
 }
 
-void Node3D::global_rotate(const Vector3 &p_axis, real_t p_angle) {
+void Node3D::rotate_object_global(const Vector3 &p_axis, real_t p_angle) {
 	Transform3D t = get_global_transform();
 	t.basis.rotate(p_axis, p_angle);
 	set_global_transform(t);
 }
 
-void Node3D::global_scale(const Vector3 &p_scale) {
+void Node3D::scale_object_global(const Vector3 &p_scale) {
 	Transform3D t = get_global_transform();
 	t.basis.scale(p_scale);
 	set_global_transform(t);
 }
 
-void Node3D::global_translate(const Vector3 &p_offset) {
+void Node3D::translate_object_global(const Vector3 &p_offset) {
 	Transform3D t = get_global_transform();
 	t.origin += p_offset;
 	set_global_transform(t);
@@ -858,6 +888,12 @@ void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_rotation_edit_mode"), &Node3D::get_rotation_edit_mode);
 	ClassDB::bind_method(D_METHOD("set_scale", "scale"), &Node3D::set_scale);
 	ClassDB::bind_method(D_METHOD("get_scale"), &Node3D::get_scale);
+	ClassDB::bind_method(D_METHOD("set_global_position", "position"), &Node3D::set_global_position);
+	ClassDB::bind_method(D_METHOD("get_global_position"), &Node3D::get_global_position);
+	ClassDB::bind_method(D_METHOD("set_global_rotation", "euler"), &Node3D::set_global_rotation);
+	ClassDB::bind_method(D_METHOD("get_global_rotation"), &Node3D::get_global_rotation);
+	ClassDB::bind_method(D_METHOD("set_global_scale", "scale"), &Node3D::set_global_scale);
+	ClassDB::bind_method(D_METHOD("get_global_scale"), &Node3D::get_global_scale);
 	ClassDB::bind_method(D_METHOD("set_quaternion", "quaternion"), &Node3D::set_quaternion);
 	ClassDB::bind_method(D_METHOD("get_quaternion"), &Node3D::get_quaternion);
 	ClassDB::bind_method(D_METHOD("set_basis", "basis"), &Node3D::set_basis);
@@ -897,9 +933,9 @@ void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_transform_notification_enabled"), &Node3D::is_transform_notification_enabled);
 
 	ClassDB::bind_method(D_METHOD("rotate", "axis", "angle"), &Node3D::rotate);
-	ClassDB::bind_method(D_METHOD("global_rotate", "axis", "angle"), &Node3D::global_rotate);
-	ClassDB::bind_method(D_METHOD("global_scale", "scale"), &Node3D::global_scale);
-	ClassDB::bind_method(D_METHOD("global_translate", "offset"), &Node3D::global_translate);
+	ClassDB::bind_method(D_METHOD("rotate_object_global", "axis", "angle"), &Node3D::rotate_object_global);
+	ClassDB::bind_method(D_METHOD("scale_object_global", "scale"), &Node3D::scale_object_global);
+	ClassDB::bind_method(D_METHOD("translate_object_global", "offset"), &Node3D::translate_object_global);
 	ClassDB::bind_method(D_METHOD("rotate_object_local", "axis", "angle"), &Node3D::rotate_object_local);
 	ClassDB::bind_method(D_METHOD("scale_object_local", "scale"), &Node3D::scale_object_local);
 	ClassDB::bind_method(D_METHOD("translate_object_local", "offset"), &Node3D::translate_object_local);
@@ -940,6 +976,9 @@ void Node3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::QUATERNION, "quaternion", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_quaternion", "get_quaternion");
 	ADD_PROPERTY(PropertyInfo(Variant::BASIS, "basis", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_basis", "get_basis");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR), "set_scale", "get_scale");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_position", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_global_position", "get_global_position");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_rotation", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_global_rotation", "get_global_rotation");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "global_scale", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_global_scale", "get_global_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "rotation_edit_mode", PROPERTY_HINT_ENUM, "Euler,Quaternion,Basis"), "set_rotation_edit_mode", "get_rotation_edit_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "rotation_order", PROPERTY_HINT_ENUM, "XYZ,XZY,YXZ,YZX,ZXY,ZYX"), "set_rotation_order", "get_rotation_order");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "top_level"), "set_as_top_level", "is_set_as_top_level");

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -165,6 +165,13 @@ public:
 	Vector3 get_rotation() const;
 	Vector3 get_scale() const;
 
+	void set_global_position(const Vector3 &p_position);
+	void set_global_rotation(const Vector3 &p_euler_rad);
+	void set_global_scale(const Vector3 &p_scale);
+	Vector3 get_global_position() const;
+	Vector3 get_global_rotation() const;
+	Vector3 get_global_scale() const;
+
 	void set_transform(const Transform3D &p_transform);
 	void set_basis(const Basis &p_basis);
 	void set_quaternion(const Quaternion &p_quaternion);
@@ -213,9 +220,9 @@ public:
 	void scale_object_local(const Vector3 &p_scale);
 	void translate_object_local(const Vector3 &p_offset);
 
-	void global_rotate(const Vector3 &p_axis, real_t p_angle);
-	void global_scale(const Vector3 &p_scale);
-	void global_translate(const Vector3 &p_offset);
+	void rotate_object_global(const Vector3 &p_axis, real_t p_angle);
+	void scale_object_global(const Vector3 &p_scale);
+	void translate_object_global(const Vector3 &p_offset);
 
 	void look_at(const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));
 	void look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up = Vector3(0, 1, 0));


### PR DESCRIPTION
This adds global counterparts to the local position/rotation/scale properties of **Node3d**. It was made after googling "how to set global rotation godot" and finding dozens of other people asking the same question (the official answer seems to be 'there is no built-in way of doing this.')

It resolves a namespace collision with the **global_scale** *method* by renaming **global_translate**, **global_rotate** and **global_scale** methods to **translate_object_global**, **rotate_object_global** and **scale_object_global** in order to match the already-existing **translate_object_local**, **rotate_object_local** and **scale_object_local**. I think that's the best solution given godot 4 is a compatibility-breaking change but am open to other ideas.

There's a [linked proposal](https://github.com/godotengine/godot-proposals/issues/3581).