### PR TITLE
Fix 'unreachable-code' false-positive, fixes #55154

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1813,7 +1813,6 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 #ifdef DEBUG_ENABLED
 	bool all_have_return = true;
 	bool have_wildcard = false;
-	bool wildcard_has_return = false;
 	bool have_wildcard_without_continue = false;
 #endif
 
@@ -1831,9 +1830,6 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 
 		if (branch->has_wildcard) {
 			have_wildcard = true;
-			if (branch->block->has_return) {
-				wildcard_has_return = true;
-			}
 			if (!branch->block->has_continue) {
 				have_wildcard_without_continue = true;
 			}
@@ -1848,7 +1844,7 @@ GDScriptParser::MatchNode *GDScriptParser::parse_match() {
 	consume(GDScriptTokenizer::Token::DEDENT, R"(Expected an indented block after "match" statement.)");
 
 #ifdef DEBUG_ENABLED
-	if (wildcard_has_return || (all_have_return && have_wildcard)) {
+	if (all_have_return && have_wildcard) {
 		current_suite->has_return = true;
 	}
 #endif

--- a/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_after_return_bug_55154.gd
+++ b/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_after_return_bug_55154.gd
@@ -1,0 +1,16 @@
+func test():
+	var foo := "bar"
+	match foo:
+		"baz":
+			return
+		_:
+			pass
+	match foo:
+		"baz":
+			return
+	match foo:
+		"bar":
+			pass
+		_:
+			return
+	print("reached")

--- a/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_after_return_bug_55154.out
+++ b/modules/gdscript/tests/scripts/parser/warnings/unreachable_code_after_return_bug_55154.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+reached


### PR DESCRIPTION
Fixes #55154 
so that the below code won't raise warning about 'unreachable code after return' anymore:
```
func test():
       var foo := "bar"
       match foo:
               "baz":
                       return
               _:
                       pass
       match foo:
               "baz":
                       return
       match foo:
               "bar":
                       pass
               _:
                       return
       print("reached")
```