### PR TITLE
Print a warning with unknown SCons variables to ease troubleshooting (reverted)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -300,6 +300,13 @@ opts.Update(env_base)
 env_base["platform"] = selected_platform  # Must always be re-set after calling opts.Update().
 Help(opts.GenerateHelpText(env_base))
 
+# Detect and print a warning listing unknown SCons variables to ease troubleshooting.
+unknown = opts.UnknownVariables()
+if unknown:
+    print("WARNING: Unknown SCons variables were passed and will be ignored:")
+    for item in unknown.items():
+        print("    " + item[0] + "=" + item[1])
+
 # add default include paths
 
 env_base.Prepend(CPPPATH=["#"])


### PR DESCRIPTION
When disabling specific modules, misspellings can occur. Additionally, when switching between the `3.x` and `master` branches frequently, it's possible to forget about renamed modules such as `lightmapper_cpu` versus `lightmapper_rd`.

This was implemented by following the [SCons documentation](https://scons.org/doc/production/HTML/scons-user/ch10s02.html#idm46358241214592). I tested this change on SCons 4.2.0 and it works as expected.

See https://github.com/godotengine/godot/issues/55192.

## Preview

```
❯ scons platform=linuxbsd target=release_debug module_lightmapper_rd_enabled=no module_embree_enabled=no
scons: Reading SConscript files ...
WARNING: Unknown SCons variables were passed and will be ignored:
    module_embree_enabled=no
...
```