### PR TITLE
Fix Android `get_screen_orientation()` not returning valid values

### DIFF
--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -119,7 +119,9 @@ DisplayServer::ScreenOrientation DisplayServerAndroid::screen_get_orientation(in
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
 	ERR_FAIL_COND_V(!godot_io_java, SCREEN_LANDSCAPE);
 
-	return (ScreenOrientation)godot_io_java->get_screen_orientation();
+	const int orientation = godot_io_java->get_screen_orientation();
+	ERR_FAIL_INDEX_V_MSG(orientation, 7, SCREEN_LANDSCAPE, "Unrecognized screen orientation");
+	return (ScreenOrientation)orientation;
 }
 
 int DisplayServerAndroid::get_screen_count() const {

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -288,7 +288,34 @@ public class GodotIO {
 	}
 
 	public int getScreenOrientation() {
-		return activity.getRequestedOrientation();
+		int orientation = activity.getRequestedOrientation();
+		switch (orientation) {
+			case ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE:
+				return SCREEN_LANDSCAPE;
+			case ActivityInfo.SCREEN_ORIENTATION_PORTRAIT:
+				return SCREEN_PORTRAIT;
+			case ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE:
+				return SCREEN_REVERSE_LANDSCAPE;
+			case ActivityInfo.SCREEN_ORIENTATION_REVERSE_PORTRAIT:
+				return SCREEN_REVERSE_PORTRAIT;
+			case ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE:
+			case ActivityInfo.SCREEN_ORIENTATION_USER_LANDSCAPE:
+				return SCREEN_SENSOR_LANDSCAPE;
+			case ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT:
+			case ActivityInfo.SCREEN_ORIENTATION_USER_PORTRAIT:
+				return SCREEN_SENSOR_PORTRAIT;
+			case ActivityInfo.SCREEN_ORIENTATION_SENSOR:
+			case ActivityInfo.SCREEN_ORIENTATION_FULL_SENSOR:
+			case ActivityInfo.SCREEN_ORIENTATION_FULL_USER:
+				return SCREEN_SENSOR;
+			case ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED:
+			case ActivityInfo.SCREEN_ORIENTATION_USER:
+			case ActivityInfo.SCREEN_ORIENTATION_BEHIND:
+			case ActivityInfo.SCREEN_ORIENTATION_NOSENSOR:
+			case ActivityInfo.SCREEN_ORIENTATION_LOCKED:
+			default:
+				return -1;
+		}
 	}
 
 	public void setEdit(GodotEditText _edit) {


### PR DESCRIPTION
Godot and Android's screen orientation enums don't match one to one. Currently, on Android, the `get_screen_orientation()` method simply returns the Android enum instead of mapping it to an equivalent Godot one.

This PR maps the Android screen orientation enums to equivalent Godot one's where possible and reports an error if it's not possible.

Fixes #55208