### PR TITLE
Improved some editor checkboxes

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6882,10 +6882,12 @@ EditorNode::EditorNode() {
 	file_export_lib->connect("file_selected", callable_mp(this, &EditorNode::_dialog_action));
 	file_export_lib_merge = memnew(CheckBox);
 	file_export_lib_merge->set_text(TTR("Merge With Existing"));
+	file_export_lib_merge->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
 	file_export_lib_merge->set_pressed(true);
 	file_export_lib->get_vbox()->add_child(file_export_lib_merge);
 	file_export_lib_apply_xforms = memnew(CheckBox);
 	file_export_lib_apply_xforms->set_text(TTR("Apply MeshInstance Transforms"));
+	file_export_lib_apply_xforms->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
 	file_export_lib_apply_xforms->set_pressed(false);
 	file_export_lib->get_vbox()->add_child(file_export_lib_apply_xforms);
 	gui_base->add_child(file_export_lib);

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1277,11 +1277,13 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_debug = memnew(CheckBox);
 	export_debug->set_text(TTR("Export With Debug"));
 	export_debug->set_pressed(true);
+	export_debug->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
 	export_project->get_vbox()->add_child(export_debug);
 
 	export_pck_zip_debug = memnew(CheckBox);
 	export_pck_zip_debug->set_text(TTR("Export With Debug"));
 	export_pck_zip_debug->set_pressed(true);
+	export_pck_zip_debug->set_h_size_flags(Control::SIZE_SHRINK_CENTER);
 	export_pck_zip->get_vbox()->add_child(export_pck_zip_debug);
 
 	set_hide_on_ok(false);


### PR DESCRIPTION
Adresses #25359
![image](https://user-images.githubusercontent.com/2223172/142777832-06daf739-cc09-4d0b-81af-51361036cdb3.png)
It makes the checkbox more noticeable. The problem with it was that the text and checkbox were very long apart. Could be left-aligned instead of centered too, but this way it's more difficult to miss. I did the same for editor export dialog (Export With Debug). Not a perfect solution, but it's better.

Are there any other dialogs that could use such treatment?