### PR TITLE
Fix CharacterBody3D stuck in some advanced scenario

### DIFF
--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1584,6 +1584,7 @@ void CharacterBody3D::_set_collision_direction(const PhysicsServer3D::MotionResu
 	Vector3 prev_wall_normal = wall_normal;
 	int wall_collision_count = 0;
 	Vector3 combined_wall_normal;
+	Vector3 tmp_wall_col; // Avoid duplicate on average calculation.
 
 	for (int i = p_result.collision_count - 1; i >= 0; i--) {
 		const PhysicsServer3D::MotionCollision &collision = p_result.collisions[i];
@@ -1630,8 +1631,11 @@ void CharacterBody3D::_set_collision_direction(const PhysicsServer3D::MotionResu
 		}
 
 		// Collect normal for calculating average.
-		combined_wall_normal += collision.normal;
-		wall_collision_count++;
+		if (!collision.normal.is_equal_approx(tmp_wall_col)) {
+			tmp_wall_col = collision.normal;
+			combined_wall_normal += collision.normal;
+			wall_collision_count++;
+		}
 	}
 
 	if (r_state.wall) {


### PR DESCRIPTION
Improvement of #52889
Fix #55191

**Before**:

![body stuck](https://user-images.githubusercontent.com/6397893/142780676-4ee404c2-0ad0-4da0-9f3b-e467ae94345d.gif)

**After**:

![after2](https://user-images.githubusercontent.com/6397893/142780683-12683e2f-b3ab-4c2a-8b65-430276155357.gif)


