### PR TITLE
[TextServer] Improve ligature cursor handling.

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -115,7 +115,7 @@
 			<argument index="4" name="outline" type="float" default="0.0" />
 			<argument index="5" name="pixel_range" type="float" default="4.0" />
 			<description>
-				Draws a textured rectangle region of the multi-channel signed distance field texture at a given position, optionally modulated by a color. See [method FontData.set_multichannel_signed_distance_field] for more information and caveats about MSDF font rendering.
+				Draws a textured rectangle region of the multi-channel signed distance field texture at a given position, optionally modulated by a color. See [member FontData.multichannel_signed_distance_field] for more information and caveats about MSDF font rendering.
 				If [code]outline[/code] is positive, each alpha channel value of pixel in region is set to maximum value of true distance in the [code]outline[/code] radius.
 				Value of the [code]pixel_range[/code] should the same that was used during distance field texture generation.
 			</description>

--- a/doc/classes/FontData.xml
+++ b/doc/classes/FontData.xml
@@ -79,42 +79,12 @@
 				Returns text server font cache entry resource id.
 			</description>
 		</method>
-		<method name="get_data" qualifiers="const">
-			<return type="PackedByteArray" />
-			<description>
-				Returns contents of the dynamic font source file.
-			</description>
-		</method>
 		<method name="get_descent" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="cache_index" type="int" />
 			<argument index="1" name="size" type="int" />
 			<description>
 				Returns font descent (number of pixels below the baseline).
-			</description>
-		</method>
-		<method name="get_fixed_size" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns font fixed size.
-			</description>
-		</method>
-		<method name="get_font_name" qualifiers="const">
-			<return type="String" />
-			<description>
-				Returns font family name.
-			</description>
-		</method>
-		<method name="get_font_style" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns font style flags, see [enum TextServer.FontStyle].
-			</description>
-		</method>
-		<method name="get_font_style_name" qualifiers="const">
-			<return type="String" />
-			<description>
-				Returns font style name.
 			</description>
 		</method>
 		<method name="get_glyph_advance" qualifiers="const">
@@ -180,12 +150,6 @@
 				Returns rectangle in the cache texture containing the glyph.
 			</description>
 		</method>
-		<method name="get_hinting" qualifiers="const">
-			<return type="int" enum="TextServer.Hinting" />
-			<description>
-				Returns the font hinting mode. Used by dynamic fonts only.
-			</description>
-		</method>
 		<method name="get_kerning" qualifiers="const">
 			<return type="Vector2" />
 			<argument index="0" name="cache_index" type="int" />
@@ -214,24 +178,6 @@
 			<return type="PackedStringArray" />
 			<description>
 				Returns list of language support overrides.
-			</description>
-		</method>
-		<method name="get_msdf_pixel_range" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns the width of the range around the shape between the minimum and maximum representable signed distance.
-			</description>
-		</method>
-		<method name="get_msdf_size" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns source font size used to generate MSDF textures.
-			</description>
-		</method>
-		<method name="get_oversampling" qualifiers="const">
-			<return type="float" />
-			<description>
-				Returns font oversampling factor, if set to [code]0.0[/code] global oversampling factor is used instead. Used by dynamic fonts only.
 			</description>
 		</method>
 		<method name="get_scale" qualifiers="const">
@@ -346,29 +292,11 @@
 				Returns [code]true[/code] if a Unicode [code]char[/code] is available in the font.
 			</description>
 		</method>
-		<method name="is_antialiased" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if font 8-bit anitialiased glyph rendering is supported and enabled.
-			</description>
-		</method>
-		<method name="is_force_autohinter" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if auto-hinting is supported and preferred over font built-in hinting. Used by dynamic fonts only.
-			</description>
-		</method>
 		<method name="is_language_supported" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="language" type="String" />
 			<description>
 				Returns [code]true[/code], if font supports given language ([url=https://en.wikipedia.org/wiki/ISO_639-1]ISO 639[/url] code).
-			</description>
-		</method>
-		<method name="is_multichannel_signed_distance_field" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if glyphs of all sizes are rendered using single multichannel signed distance field generated from the dynamic font vector data.
 			</description>
 		</method>
 		<method name="is_script_supported" qualifiers="const">
@@ -455,13 +383,6 @@
 				Renders the range of characters to the font cache texture.
 			</description>
 		</method>
-		<method name="set_antialiased">
-			<return type="void" />
-			<argument index="0" name="antialiased" type="bool" />
-			<description>
-				If set to [code]true[/code], 8-bit antialiased glyph rendering is used, otherwise 1-bit rendering is used. Used by dynamic fonts only.
-			</description>
-		</method>
 		<method name="set_ascent">
 			<return type="void" />
 			<argument index="0" name="cache_index" type="int" />
@@ -471,13 +392,6 @@
 				Sets the font ascent (number of pixels above the baseline).
 			</description>
 		</method>
-		<method name="set_data">
-			<return type="void" />
-			<argument index="0" name="data" type="PackedByteArray" />
-			<description>
-				Sets font source data, e.g contents of the dynamic font source file.
-			</description>
-		</method>
 		<method name="set_descent">
 			<return type="void" />
 			<argument index="0" name="cache_index" type="int" />
@@ -485,41 +399,6 @@
 			<argument index="2" name="descent" type="float" />
 			<description>
 				Sets the font descent (number of pixels below the baseline).
-			</description>
-		</method>
-		<method name="set_fixed_size">
-			<return type="void" />
-			<argument index="0" name="fixed_size" type="int" />
-			<description>
-				Sets the fixed size for the font.
-			</description>
-		</method>
-		<method name="set_font_name">
-			<return type="void" />
-			<argument index="0" name="name" type="String" />
-			<description>
-				Sets the font family name.
-			</description>
-		</method>
-		<method name="set_font_style">
-			<return type="void" />
-			<argument index="0" name="style" type="int" />
-			<description>
-				Sets the font style flags, see [enum TextServer.FontStyle].
-			</description>
-		</method>
-		<method name="set_font_style_name">
-			<return type="void" />
-			<argument index="0" name="name" type="String" />
-			<description>
-				Sets the font style name.
-			</description>
-		</method>
-		<method name="set_force_autohinter">
-			<return type="void" />
-			<argument index="0" name="force_autohinter" type="bool" />
-			<description>
-				If set to [code]true[/code] auto-hinting is preferred over font built-in hinting.
 			</description>
 		</method>
 		<method name="set_glyph_advance">
@@ -573,13 +452,6 @@
 				Sets rectangle in the cache texture containing the glyph.
 			</description>
 		</method>
-		<method name="set_hinting">
-			<return type="void" />
-			<argument index="0" name="hinting" type="int" enum="TextServer.Hinting" />
-			<description>
-				Sets font hinting mode. Used by dynamic fonts only.
-			</description>
-		</method>
 		<method name="set_kerning">
 			<return type="void" />
 			<argument index="0" name="cache_index" type="int" />
@@ -596,35 +468,6 @@
 			<argument index="1" name="supported" type="bool" />
 			<description>
 				Adds override for [method is_language_supported].
-			</description>
-		</method>
-		<method name="set_msdf_pixel_range">
-			<return type="void" />
-			<argument index="0" name="msdf_pixel_range" type="int" />
-			<description>
-				Sets the width of the range around the shape between the minimum and maximum representable signed distance.
-			</description>
-		</method>
-		<method name="set_msdf_size">
-			<return type="void" />
-			<argument index="0" name="msdf_size" type="int" />
-			<description>
-				Sets source font size used to generate MSDF textures.
-			</description>
-		</method>
-		<method name="set_multichannel_signed_distance_field">
-			<return type="void" />
-			<argument index="0" name="msdf" type="bool" />
-			<description>
-				If set to [code]true[/code], glyphs of all sizes are rendered using single multichannel signed distance field (MSDF) generated from the dynamic font vector data. MSDF rendering allows displaying the font at any scaling factor without blurriness, and without incurring a CPU cost when the font size changes (since the font no longer needs to be rasterized on the CPU). As a downside, font hinting is not available with MSDF. The lack of font hinting may result in less crisp and less readable fonts at small sizes.
-				[b]Note:[/b] MSDF font rendering does not render glyphs with overlapping shapes correctly. Overlapping shapes are not valid per the OpenType standard, but are still commonly found in many font files, especially those converted by Google Fonts. To avoid issues with overlapping glyphs, consider downloading the font file directly from the type foundry instead of relying on Google Fonts.
-			</description>
-		</method>
-		<method name="set_oversampling">
-			<return type="void" />
-			<argument index="0" name="oversampling" type="float" />
-			<description>
-				Sets font oversampling factor, if set to [code]0.0[/code] global oversampling factor is used instead. Used by dynamic fonts only.
 			</description>
 		</method>
 		<method name="set_scale">
@@ -701,4 +544,45 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="antialiased" type="bool" setter="set_antialiased" getter="is_antialiased" default="true">
+			If set to [code]true[/code], font 8-bit anitialiased glyph rendering is supported and enabled.
+		</member>
+		<member name="data" type="PackedByteArray" setter="set_data" getter="get_data" default="PackedByteArray()">
+			Contents of the dynamic font source file.
+		</member>
+		<member name="fixed_size" type="int" setter="set_fixed_size" getter="get_fixed_size" default="0">
+			Font size, used only for the bitmap fonts.
+		</member>
+		<member name="font_name" type="String" setter="set_font_name" getter="get_font_name" default="&quot;&quot;">
+			Font family name.
+		</member>
+		<member name="font_style" type="int" setter="set_font_style" getter="get_font_style" default="0">
+			Font style flags, see [enum TextServer.FontStyle].
+		</member>
+		<member name="force_autohinter" type="bool" setter="set_force_autohinter" getter="is_force_autohinter" default="false">
+			If set to [code]true[/code], auto-hinting is supported and preffered over font built-in hinting. Used by dynamic fonts only.
+		</member>
+		<member name="hinting" type="int" setter="set_hinting" getter="get_hinting" enum="TextServer.Hinting" default="1">
+			Font hinting mode. Used by dynamic fonts only.
+		</member>
+		<member name="msdf_pixel_range" type="int" setter="set_msdf_pixel_range" getter="get_msdf_pixel_range" default="16">
+			The width of the range around the shape between the minimum and maximum representable signed distance.
+		</member>
+		<member name="msdf_size" type="int" setter="set_msdf_size" getter="get_msdf_size" default="48">
+			Source font size used to generate MSDF textures.
+		</member>
+		<member name="multichannel_signed_distance_field" type="bool" setter="set_multichannel_signed_distance_field" getter="is_multichannel_signed_distance_field" default="false">
+			If set to [code]true[/code], glyphs of all sizes are rendered using single multichannel signed distance field generated from the dynamic font vector data.
+		</member>
+		<member name="opentype_feature_overrides" type="Dictionary" setter="set_opentype_feature_overrides" getter="get_opentype_feature_overrides" default="{}">
+			Font OpenType feature set override.
+		</member>
+		<member name="oversampling" type="float" setter="set_oversampling" getter="get_oversampling" default="0.0">
+			Font oversampling factor, if set to [code]0.0[/code] global oversampling factor is used instead. Used by dynamic fonts only.
+		</member>
+		<member name="style_name" type="String" setter="set_font_style_name" getter="get_font_style_name" default="&quot;&quot;">
+			Font style name.
+		</member>
+	</members>
 </class>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -174,7 +174,7 @@
 		<member name="caret_force_displayed" type="bool" setter="set_caret_force_displayed" getter="is_caret_force_displayed" default="false">
 			If [code]true[/code], the [LineEdit] will always show the caret, even if focus is lost.
 		</member>
-		<member name="caret_mid_grapheme" type="bool" setter="set_caret_mid_grapheme_enabled" getter="is_caret_mid_grapheme_enabled" default="false">
+		<member name="caret_mid_grapheme" type="bool" setter="set_caret_mid_grapheme_enabled" getter="is_caret_mid_grapheme_enabled" default="true">
 			Allow moving caret, selecting and removing the individual composite character components.
 			[b]Note:[/b] [kbd]Backspace[/kbd] is always removing individual composite character components.
 		</member>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -942,7 +942,7 @@
 		<member name="caret_blink_speed" type="float" setter="set_caret_blink_speed" getter="get_caret_blink_speed" default="0.65">
 			Duration (in seconds) of a caret's blinking cycle.
 		</member>
-		<member name="caret_mid_grapheme" type="bool" setter="set_caret_mid_grapheme_enabled" getter="is_caret_mid_grapheme_enabled" default="false">
+		<member name="caret_mid_grapheme" type="bool" setter="set_caret_mid_grapheme_enabled" getter="is_caret_mid_grapheme_enabled" default="true">
 			Allow moving caret, selecting and removing the individual composite character components.
 			[b]Note:[/b] [kbd]Backspace[/kbd] is always removing individual composite character components.
 		</member>

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -261,6 +261,13 @@
 				Returns font family name.
 			</description>
 		</method>
+		<method name="font_get_opentype_feature_overrides" qualifiers="const">
+			<return type="Dictionary" />
+			<argument index="0" name="font_rid" type="RID" />
+			<description>
+				Returns font OpenType feature set override.
+			</description>
+		</method>
 		<method name="font_get_oversampling" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="font_rid" type="RID" />
@@ -661,6 +668,14 @@
 			<argument index="1" name="name" type="String" />
 			<description>
 				Sets the font family name.
+			</description>
+		</method>
+		<method name="font_set_opentype_feature_overrides">
+			<return type="void" />
+			<argument index="0" name="font_rid" type="RID" />
+			<argument index="1" name="overrides" type="Dictionary" />
+			<description>
+				Sets font OpenType feature set override.
 			</description>
 		</method>
 		<method name="font_set_oversampling">

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -261,6 +261,13 @@
 				Returns font family name.
 			</description>
 		</method>
+		<method name="_font_get_opentype_feature_overrides" qualifiers="virtual const">
+			<return type="Dictionary" />
+			<argument index="0" name="font_rid" type="RID" />
+			<description>
+				Returns font OpenType feature set override.
+			</description>
+		</method>
 		<method name="_font_get_oversampling" qualifiers="virtual const">
 			<return type="float" />
 			<argument index="0" name="font_rid" type="RID" />
@@ -550,6 +557,7 @@
 			<argument index="0" name="font_rid" type="RID" />
 			<argument index="1" name="force_autohinter" type="bool" />
 			<description>
+				If set to [code]true[/code] auto-hinting is preffered over font built-in hinting.
 			</description>
 		</method>
 		<method name="_font_set_global_oversampling" qualifiers="virtual">
@@ -668,6 +676,14 @@
 			<argument index="1" name="name" type="String" />
 			<description>
 				Sets the font family name.
+			</description>
+		</method>
+		<method name="_font_set_opentype_feature_overrides" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="font_rid" type="RID" />
+			<argument index="1" name="overrides" type="Dictionary" />
+			<description>
+				Sets font OpenType feature set override.
 			</description>
 		</method>
 		<method name="_font_set_oversampling" qualifiers="virtual">

--- a/editor/import/dynamicfont_import_settings.h
+++ b/editor/import/dynamicfont_import_settings.h
@@ -120,17 +120,26 @@ class DynamicFontImportSettings : public ConfirmationDialog {
 	Label *page5_description = nullptr;
 	Button *add_lang = nullptr;
 	Button *add_script = nullptr;
+	Button *add_ot = nullptr;
 
 	PopupMenu *menu_langs = nullptr;
 	PopupMenu *menu_scripts = nullptr;
+	PopupMenu *menu_ot = nullptr;
+	PopupMenu *menu_ot_ss = nullptr;
+	PopupMenu *menu_ot_cv = nullptr;
+	PopupMenu *menu_ot_cu = nullptr;
 
 	Tree *lang_list = nullptr;
 	TreeItem *lang_list_root = nullptr;
+	Label *label_langs = nullptr;
 
 	Tree *script_list = nullptr;
 	TreeItem *script_list_root = nullptr;
-	Label *label_langs = nullptr;
 	Label *label_script = nullptr;
+
+	Tree *ot_list = nullptr;
+	TreeItem *ot_list_root = nullptr;
+	Label *label_ot = nullptr;
 
 	void _lang_add();
 	void _lang_add_item(int p_option);
@@ -139,6 +148,10 @@ class DynamicFontImportSettings : public ConfirmationDialog {
 	void _script_add();
 	void _script_add_item(int p_option);
 	void _script_remove(Object *p_item, int p_column, int p_id);
+
+	void _ot_add();
+	void _ot_add_item(int p_option);
+	void _ot_remove(Object *p_item, int p_column, int p_id);
 
 	// Common
 

--- a/editor/import/resource_importer_dynamicfont.cpp
+++ b/editor/import/resource_importer_dynamicfont.cpp
@@ -107,6 +107,7 @@ void ResourceImporterDynamicFont::get_import_options(const String &p_path, List<
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "oversampling", PROPERTY_HINT_RANGE, "0,10,0.1"), 0.0));
 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "compress"), true));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::DICTIONARY, "opentype_feature_overrides"), Dictionary()));
 
 	r_options->push_back(ImportOption(PropertyInfo(Variant::PACKED_STRING_ARRAY, "preload/char_ranges"), Vector<String>()));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::PACKED_STRING_ARRAY, "preload/glyph_ranges"), Vector<String>()));
@@ -174,6 +175,7 @@ Error ResourceImporterDynamicFont::import(const String &p_source_file, const Str
 	bool msdf = p_options["multichannel_signed_distance_field"];
 	int px_range = p_options["msdf_pixel_range"];
 	int px_size = p_options["msdf_size"];
+	Dictionary ot_ov = p_options["opentype_feature_overrides"];
 
 	bool autohinter = p_options["force_autohinter"];
 	int hinting = p_options["hinting"];
@@ -190,6 +192,7 @@ Error ResourceImporterDynamicFont::import(const String &p_source_file, const Str
 	font->set_multichannel_signed_distance_field(msdf);
 	font->set_msdf_pixel_range(px_range);
 	font->set_msdf_size(px_size);
+	font->set_opentype_feature_overrides(ot_ov);
 	font->set_fixed_size(0);
 	font->set_force_autohinter(autohinter);
 	font->set_hinting((TextServer::Hinting)hinting);

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2841,6 +2841,24 @@ Vector<String> TextServerAdvanced::font_get_script_support_overrides(RID p_font_
 	return out;
 }
 
+void TextServerAdvanced::font_set_opentype_feature_overrides(RID p_font_rid, const Dictionary &p_overrides) {
+	FontDataAdvanced *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND(!fd);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	fd->feature_overrides = p_overrides;
+}
+
+Dictionary TextServerAdvanced::font_get_opentype_feature_overrides(RID p_font_rid) const {
+	FontDataAdvanced *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND_V(!fd, Dictionary());
+
+	MutexLock lock(fd->mutex);
+	return fd->feature_overrides;
+}
+
 Dictionary TextServerAdvanced::font_supported_feature_list(RID p_font_rid) const {
 	FontDataAdvanced *fd = font_owner.get_or_null(p_font_rid);
 	ERR_FAIL_COND_V(!fd, Dictionary());
@@ -4231,6 +4249,24 @@ Glyph TextServerAdvanced::_shape_single_glyph(ShapedTextDataAdvanced *p_sd, char
 	return gl;
 }
 
+_FORCE_INLINE_ void TextServerAdvanced::_add_featuers(const Dictionary &p_source, Vector<hb_feature_t> &r_ftrs) {
+	for (const Variant *ftr = p_source.next(nullptr); ftr != nullptr; ftr = p_source.next(ftr)) {
+		int32_t values = p_source[*ftr];
+		if (values >= 0) {
+			hb_feature_t feature;
+			if (ftr->get_type() == Variant::STRING) {
+				feature.tag = name_to_tag(*ftr);
+			} else {
+				feature.tag = *ftr;
+			}
+			feature.value = values;
+			feature.start = 0;
+			feature.end = -1;
+			r_ftrs.push_back(feature);
+		}
+	}
+}
+
 void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_start, int32_t p_end, hb_script_t p_script, hb_direction_t p_direction, Vector<RID> p_fonts, int p_span, int p_fb_index) {
 	int fs = p_sd->spans[p_span].font_size;
 	if (p_fb_index >= p_fonts.size()) {
@@ -4287,17 +4323,9 @@ void TextServerAdvanced::_shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_star
 	hb_buffer_add_utf32(p_sd->hb_buffer, (const uint32_t *)p_sd->text.ptr(), p_sd->text.length(), p_start, p_end - p_start);
 
 	Vector<hb_feature_t> ftrs;
-	for (const Variant *ftr = p_sd->spans[p_span].features.next(nullptr); ftr != nullptr; ftr = p_sd->spans[p_span].features.next(ftr)) {
-		double values = p_sd->spans[p_span].features[*ftr];
-		if (values >= 0) {
-			hb_feature_t feature;
-			feature.tag = *ftr;
-			feature.value = values;
-			feature.start = 0;
-			feature.end = -1;
-			ftrs.push_back(feature);
-		}
-	}
+	_add_featuers(font_get_opentype_feature_overrides(f), ftrs);
+	_add_featuers(p_sd->spans[p_span].features, ftrs);
+
 	hb_shape(hb_font, p_sd->hb_buffer, ftrs.is_empty() ? nullptr : &ftrs[0], ftrs.size());
 
 	unsigned int glyph_count = 0;

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -187,6 +187,7 @@ class TextServerAdvanced : public TextServer {
 		Set<uint32_t> supported_scripts;
 		Dictionary supported_features;
 		Dictionary supported_varaitions;
+		Dictionary feature_overrides;
 
 		// Language/script support override.
 		Map<String, bool> language_support_overrides;
@@ -272,6 +273,7 @@ class TextServerAdvanced : public TextServer {
 	bool _shape_substr(ShapedTextDataAdvanced *p_new_sd, const ShapedTextDataAdvanced *p_sd, int p_start, int p_length) const;
 	void _shape_run(ShapedTextDataAdvanced *p_sd, int32_t p_start, int32_t p_end, hb_script_t p_script, hb_direction_t p_direction, Vector<RID> p_fonts, int p_span, int p_fb_index);
 	Glyph _shape_single_glyph(ShapedTextDataAdvanced *p_sd, char32_t p_char, hb_script_t p_script, hb_direction_t p_direction, RID p_font, int p_font_size);
+	_FORCE_INLINE_ void _add_featuers(const Dictionary &p_source, Vector<hb_feature_t> &r_ftrs);
 
 	// HarfBuzz bitmap font interface.
 
@@ -446,6 +448,9 @@ public:
 	virtual bool font_get_script_support_override(RID p_font_rid, const String &p_script) override;
 	virtual void font_remove_script_support_override(RID p_font_rid, const String &p_script) override;
 	virtual Vector<String> font_get_script_support_overrides(RID p_font_rid) override;
+
+	virtual void font_set_opentype_feature_overrides(RID p_font_rid, const Dictionary &p_overrides) override;
+	virtual Dictionary font_get_opentype_feature_overrides(RID p_font_rid) const override;
 
 	virtual Dictionary font_supported_feature_list(RID p_font_rid) const override;
 	virtual Dictionary font_supported_variation_list(RID p_font_rid) const override;

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -1995,6 +1995,24 @@ Vector<String> TextServerFallback::font_get_script_support_overrides(RID p_font_
 	return out;
 }
 
+void TextServerFallback::font_set_opentype_feature_overrides(RID p_font_rid, const Dictionary &p_overrides) {
+	FontDataFallback *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND(!fd);
+
+	MutexLock lock(fd->mutex);
+	Vector2i size = _get_size(fd, 16);
+	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+	fd->feature_overrides = p_overrides;
+}
+
+Dictionary TextServerFallback::font_get_opentype_feature_overrides(RID p_font_rid) const {
+	FontDataFallback *fd = font_owner.get_or_null(p_font_rid);
+	ERR_FAIL_COND_V(!fd, Dictionary());
+
+	MutexLock lock(fd->mutex);
+	return fd->feature_overrides;
+}
+
 Dictionary TextServerFallback::font_supported_feature_list(RID p_font_rid) const {
 	return Dictionary();
 }

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -150,6 +150,7 @@ class TextServerFallback : public TextServer {
 
 		bool face_init = false;
 		Dictionary supported_varaitions;
+		Dictionary feature_overrides;
 
 		// Language/script support override.
 		Map<String, bool> language_support_overrides;
@@ -356,6 +357,9 @@ public:
 	virtual bool font_get_script_support_override(RID p_font_rid, const String &p_script) override;
 	virtual void font_remove_script_support_override(RID p_font_rid, const String &p_script) override;
 	virtual Vector<String> font_get_script_support_overrides(RID p_font_rid) override;
+
+	virtual void font_set_opentype_feature_overrides(RID p_font_rid, const Dictionary &p_overrides) override;
+	virtual Dictionary font_get_opentype_feature_overrides(RID p_font_rid) const override;
 
 	virtual Dictionary font_supported_feature_list(RID p_font_rid) const override;
 	virtual Dictionary font_supported_variation_list(RID p_font_rid) const override;

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -497,7 +497,7 @@ bool Button::_set(const StringName &p_name, const Variant &p_value) {
 	if (str.begins_with("opentype_features/")) {
 		String name = str.get_slicec('/', 1);
 		int32_t tag = TS->name_to_tag(name);
-		double value = p_value;
+		int value = p_value;
 		if (value == -1) {
 			if (opentype_features.has(tag)) {
 				opentype_features.erase(tag);
@@ -505,7 +505,7 @@ bool Button::_set(const StringName &p_name, const Variant &p_value) {
 				update();
 			}
 		} else {
-			if ((double)opentype_features[tag] != value) {
+			if (!opentype_features.has(tag) || (int)opentype_features[tag] != value) {
 				opentype_features[tag] = value;
 				_shape();
 				update();
@@ -537,7 +537,7 @@ bool Button::_get(const StringName &p_name, Variant &r_ret) const {
 void Button::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (const Variant *ftr = opentype_features.next(nullptr); ftr != nullptr; ftr = opentype_features.next(ftr)) {
 		String name = TS->tag_to_name(*ftr);
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features/" + name));
+		p_list->push_back(PropertyInfo(Variant::INT, "opentype_features/" + name));
 	}
 	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 }

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -46,7 +46,7 @@ bool GraphNode::_set(const StringName &p_name, const Variant &p_value) {
 	if (str.begins_with("opentype_features/")) {
 		String name = str.get_slicec('/', 1);
 		int32_t tag = TS->name_to_tag(name);
-		double value = p_value;
+		int value = p_value;
 		if (value == -1) {
 			if (opentype_features.has(tag)) {
 				opentype_features.erase(tag);
@@ -54,7 +54,7 @@ bool GraphNode::_set(const StringName &p_name, const Variant &p_value) {
 				update();
 			}
 		} else {
-			if ((double)opentype_features[tag] != value) {
+			if (!opentype_features.has(tag) || (int)opentype_features[tag] != value) {
 				opentype_features[tag] = value;
 				_shape();
 				update();
@@ -153,7 +153,7 @@ bool GraphNode::_get(const StringName &p_name, Variant &r_ret) const {
 void GraphNode::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (const Variant *ftr = opentype_features.next(nullptr); ftr != nullptr; ftr = opentype_features.next(ftr)) {
 		String name = TS->tag_to_name(*ftr);
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features/" + name));
+		p_list->push_back(PropertyInfo(Variant::INT, "opentype_features/" + name));
 	}
 	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -811,7 +811,7 @@ bool Label::_set(const StringName &p_name, const Variant &p_value) {
 	if (str.begins_with("opentype_features/")) {
 		String name = str.get_slicec('/', 1);
 		int32_t tag = TS->name_to_tag(name);
-		double value = p_value;
+		int value = p_value;
 		if (value == -1) {
 			if (opentype_features.has(tag)) {
 				opentype_features.erase(tag);
@@ -819,7 +819,7 @@ bool Label::_set(const StringName &p_name, const Variant &p_value) {
 				update();
 			}
 		} else {
-			if ((double)opentype_features[tag] != value) {
+			if (!opentype_features.has(tag) || (int)opentype_features[tag] != value) {
 				opentype_features[tag] = value;
 				dirty = true;
 				update();
@@ -851,7 +851,7 @@ bool Label::_get(const StringName &p_name, Variant &r_ret) const {
 void Label::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (const Variant *ftr = opentype_features.next(nullptr); ftr != nullptr; ftr = opentype_features.next(ftr)) {
 		String name = TS->tag_to_name(*ftr);
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features/" + name));
+		p_list->push_back(PropertyInfo(Variant::INT, "opentype_features/" + name));
 	}
 	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 }

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2164,7 +2164,7 @@ bool LineEdit::_set(const StringName &p_name, const Variant &p_value) {
 	if (str.begins_with("opentype_features/")) {
 		String name = str.get_slicec('/', 1);
 		int32_t tag = TS->name_to_tag(name);
-		double value = p_value;
+		int value = p_value;
 		if (value == -1) {
 			if (opentype_features.has(tag)) {
 				opentype_features.erase(tag);
@@ -2172,7 +2172,7 @@ bool LineEdit::_set(const StringName &p_name, const Variant &p_value) {
 				update();
 			}
 		} else {
-			if ((double)opentype_features[tag] != value) {
+			if (!opentype_features.has(tag) || (int)opentype_features[tag] != value) {
 				opentype_features[tag] = value;
 				_shape();
 				update();
@@ -2204,7 +2204,7 @@ bool LineEdit::_get(const StringName &p_name, Variant &r_ret) const {
 void LineEdit::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (const Variant *ftr = opentype_features.next(nullptr); ftr != nullptr; ftr = opentype_features.next(ftr)) {
 		String name = TS->tag_to_name(*ftr);
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features/" + name));
+		p_list->push_back(PropertyInfo(Variant::INT, "opentype_features/" + name));
 	}
 	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 }

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -97,7 +97,7 @@ private:
 	PopupMenu *menu_dir = nullptr;
 	PopupMenu *menu_ctl = nullptr;
 
-	bool caret_mid_grapheme_enabled = false;
+	bool caret_mid_grapheme_enabled = true;
 
 	int caret_column = 0;
 	int scroll_offset = 0;

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -240,7 +240,7 @@ bool LinkButton::_set(const StringName &p_name, const Variant &p_value) {
 	if (str.begins_with("opentype_features/")) {
 		String name = str.get_slicec('/', 1);
 		int32_t tag = TS->name_to_tag(name);
-		double value = p_value;
+		int value = p_value;
 		if (value == -1) {
 			if (opentype_features.has(tag)) {
 				opentype_features.erase(tag);
@@ -248,7 +248,7 @@ bool LinkButton::_set(const StringName &p_name, const Variant &p_value) {
 				update();
 			}
 		} else {
-			if ((double)opentype_features[tag] != value) {
+			if (!opentype_features.has(tag) || (int)opentype_features[tag] != value) {
 				opentype_features[tag] = value;
 				_shape();
 				update();
@@ -280,7 +280,7 @@ bool LinkButton::_get(const StringName &p_name, Variant &r_ret) const {
 void LinkButton::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (const Variant *ftr = opentype_features.next(nullptr); ftr != nullptr; ftr = opentype_features.next(ftr)) {
 		String name = TS->tag_to_name(*ftr);
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features/" + name));
+		p_list->push_back(PropertyInfo(Variant::INT, "opentype_features/" + name));
 	}
 	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5228,7 +5228,7 @@ bool TextEdit::_set(const StringName &p_name, const Variant &p_value) {
 	if (str.begins_with("opentype_features/")) {
 		String name = str.get_slicec('/', 1);
 		int32_t tag = TS->name_to_tag(name);
-		double value = p_value;
+		int value = p_value;
 		if (value == -1) {
 			if (opentype_features.has(tag)) {
 				opentype_features.erase(tag);
@@ -5237,7 +5237,7 @@ bool TextEdit::_set(const StringName &p_name, const Variant &p_value) {
 				update();
 			}
 		} else {
-			if ((double)opentype_features[tag] != value) {
+			if (!opentype_features.has(tag) || (int)opentype_features[tag] != value) {
 				opentype_features[tag] = value;
 				text.set_font_features(opentype_features);
 				text.invalidate_all();
@@ -5270,7 +5270,7 @@ bool TextEdit::_get(const StringName &p_name, Variant &r_ret) const {
 void TextEdit::_get_property_list(List<PropertyInfo> *p_list) const {
 	for (const Variant *ftr = opentype_features.next(nullptr); ftr != nullptr; ftr = opentype_features.next(ftr)) {
 		String name = TS->tag_to_name(*ftr);
-		p_list->push_back(PropertyInfo(Variant::FLOAT, "opentype_features/" + name));
+		p_list->push_back(PropertyInfo(Variant::INT, "opentype_features/" + name));
 	}
 	p_list->push_back(PropertyInfo(Variant::NIL, "opentype_features/_new", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_EDITOR));
 }

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -374,7 +374,7 @@ private:
 
 	bool move_caret_on_right_click = true;
 
-	bool caret_mid_grapheme_enabled = false;
+	bool caret_mid_grapheme_enabled = true;
 
 	bool drag_action = false;
 	bool drag_caret_force_displayed = false;

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -184,6 +184,9 @@ void FontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_script_support_override", "script"), &FontData::remove_script_support_override);
 	ClassDB::bind_method(D_METHOD("get_script_support_overrides"), &FontData::get_script_support_overrides);
 
+	ClassDB::bind_method(D_METHOD("set_opentype_feature_overrides", "overrides"), &FontData::set_opentype_feature_overrides);
+	ClassDB::bind_method(D_METHOD("get_opentype_feature_overrides"), &FontData::get_opentype_feature_overrides);
+
 	ClassDB::bind_method(D_METHOD("has_char", "char"), &FontData::has_char);
 	ClassDB::bind_method(D_METHOD("get_supported_chars"), &FontData::get_supported_chars);
 
@@ -191,49 +194,25 @@ void FontData::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_supported_feature_list"), &FontData::get_supported_feature_list);
 	ClassDB::bind_method(D_METHOD("get_supported_variation_list"), &FontData::get_supported_variation_list);
+
+	ADD_PROPERTY(PropertyInfo(Variant::PACKED_BYTE_ARRAY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_data", "get_data");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "antialiased", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_antialiased", "is_antialiased");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "font_name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_font_name", "get_font_name");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "style_name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_font_style_name", "get_font_style_name");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "font_style", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_font_style", "get_font_style");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "multichannel_signed_distance_field", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_multichannel_signed_distance_field", "is_multichannel_signed_distance_field");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "msdf_pixel_range", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_msdf_pixel_range", "get_msdf_pixel_range");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "msdf_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_msdf_size", "get_msdf_size");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "force_autohinter", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_force_autohinter", "is_force_autohinter");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal", PROPERTY_USAGE_STORAGE), "set_hinting", "get_hinting");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "oversampling", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_oversampling", "get_oversampling");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "fixed_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_fixed_size", "get_fixed_size");
+	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "opentype_feature_overrides", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE), "set_opentype_feature_overrides", "get_opentype_feature_overrides");
 }
 
 bool FontData::_set(const StringName &p_name, const Variant &p_value) {
 	Vector<String> tokens = p_name.operator String().split("/");
-	if (tokens.size() == 1) {
-		if (tokens[0] == "data") {
-			set_data(p_value);
-			return true;
-		} else if (tokens[0] == "antialiased") {
-			set_antialiased(p_value);
-			return true;
-		} else if (tokens[0] == "font_name") {
-			set_font_name(p_value);
-			return true;
-		} else if (tokens[0] == "style_name") {
-			set_font_style_name(p_value);
-			return true;
-		} else if (tokens[0] == "font_style") {
-			set_font_style(p_value);
-			return true;
-		} else if (tokens[0] == "multichannel_signed_distance_field") {
-			set_multichannel_signed_distance_field(p_value);
-			return true;
-		} else if (tokens[0] == "msdf_pixel_range") {
-			set_msdf_pixel_range(p_value);
-			return true;
-		} else if (tokens[0] == "msdf_size") {
-			set_msdf_size(p_value);
-			return true;
-		} else if (tokens[0] == "fixed_size") {
-			set_fixed_size(p_value);
-			return true;
-		} else if (tokens[0] == "hinting") {
-			set_hinting((TextServer::Hinting)p_value.operator int());
-			return true;
-		} else if (tokens[0] == "force_autohinter") {
-			set_force_autohinter(p_value);
-			return true;
-		} else if (tokens[0] == "oversampling") {
-			set_oversampling(p_value);
-			return true;
-		}
-	} else if (tokens.size() == 2 && tokens[0] == "language_support_override") {
+	if (tokens.size() == 2 && tokens[0] == "language_support_override") {
 		String lang = tokens[1];
 		set_language_support_override(lang, p_value);
 		return true;
@@ -309,45 +288,7 @@ bool FontData::_set(const StringName &p_name, const Variant &p_value) {
 
 bool FontData::_get(const StringName &p_name, Variant &r_ret) const {
 	Vector<String> tokens = p_name.operator String().split("/");
-	if (tokens.size() == 1) {
-		if (tokens[0] == "data") {
-			r_ret = get_data();
-			return true;
-		} else if (tokens[0] == "antialiased") {
-			r_ret = is_antialiased();
-			return true;
-		} else if (tokens[0] == "font_name") {
-			r_ret = get_font_name();
-			return true;
-		} else if (tokens[0] == "style_name") {
-			r_ret = get_font_style_name();
-			return true;
-		} else if (tokens[0] == "font_style") {
-			r_ret = get_font_style();
-			return true;
-		} else if (tokens[0] == "multichannel_signed_distance_field") {
-			r_ret = is_multichannel_signed_distance_field();
-			return true;
-		} else if (tokens[0] == "msdf_pixel_range") {
-			r_ret = get_msdf_pixel_range();
-			return true;
-		} else if (tokens[0] == "msdf_size") {
-			r_ret = get_msdf_size();
-			return true;
-		} else if (tokens[0] == "fixed_size") {
-			r_ret = get_fixed_size();
-			return true;
-		} else if (tokens[0] == "hinting") {
-			r_ret = get_hinting();
-			return true;
-		} else if (tokens[0] == "force_autohinter") {
-			r_ret = is_force_autohinter();
-			return true;
-		} else if (tokens[0] == "oversampling") {
-			r_ret = get_oversampling();
-			return true;
-		}
-	} else if (tokens.size() == 2 && tokens[0] == "language_support_override") {
+	if (tokens.size() == 2 && tokens[0] == "language_support_override") {
 		String lang = tokens[1];
 		r_ret = get_language_support_override(lang);
 		return true;
@@ -422,20 +363,6 @@ bool FontData::_get(const StringName &p_name, Variant &r_ret) const {
 }
 
 void FontData::_get_property_list(List<PropertyInfo> *p_list) const {
-	p_list->push_back(PropertyInfo(Variant::PACKED_BYTE_ARRAY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
-
-	p_list->push_back(PropertyInfo(Variant::STRING, "font_name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
-	p_list->push_back(PropertyInfo(Variant::STRING, "style_name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
-	p_list->push_back(PropertyInfo(Variant::INT, "font_style", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
-	p_list->push_back(PropertyInfo(Variant::BOOL, "antialiased", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
-	p_list->push_back(PropertyInfo(Variant::BOOL, "multichannel_signed_distance_field", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
-	p_list->push_back(PropertyInfo(Variant::INT, "msdf_pixel_range", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
-	p_list->push_back(PropertyInfo(Variant::INT, "msdf_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
-	p_list->push_back(PropertyInfo(Variant::INT, "fixed_size", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
-	p_list->push_back(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal", PROPERTY_USAGE_STORAGE));
-	p_list->push_back(PropertyInfo(Variant::BOOL, "force_autohinter", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
-	p_list->push_back(PropertyInfo(Variant::FLOAT, "oversampling", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
-
 	Vector<String> lang_over = get_language_support_overrides();
 	for (int i = 0; i < lang_over.size(); i++) {
 		p_list->push_back(PropertyInfo(Variant::BOOL, "language_support_override/" + lang_over[i], PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE));
@@ -1075,6 +1002,16 @@ void FontData::remove_script_support_override(const String &p_script) {
 Vector<String> FontData::get_script_support_overrides() const {
 	_ensure_rid(0);
 	return TS->font_get_script_support_overrides(cache[0]);
+}
+
+void FontData::set_opentype_feature_overrides(const Dictionary &p_overrides) {
+	_ensure_rid(0);
+	TS->font_set_opentype_feature_overrides(cache[0], p_overrides);
+}
+
+Dictionary FontData::get_opentype_feature_overrides() const {
+	_ensure_rid(0);
+	return TS->font_get_opentype_feature_overrides(cache[0]);
 }
 
 bool FontData::has_char(char32_t p_char) const {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -198,6 +198,9 @@ public:
 	virtual void remove_script_support_override(const String &p_script);
 	virtual Vector<String> get_script_support_overrides() const;
 
+	virtual void set_opentype_feature_overrides(const Dictionary &p_overrides);
+	virtual Dictionary get_opentype_feature_overrides() const;
+
 	// Base font properties.
 	virtual bool has_char(char32_t p_char) const;
 	virtual String get_supported_chars() const;

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -174,6 +174,9 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_font_remove_script_support_override, "font_rid", "script");
 	GDVIRTUAL_BIND(_font_get_script_support_overrides, "font_rid");
 
+	GDVIRTUAL_BIND(_font_set_opentype_feature_overrides, "font_rid", "overrides");
+	GDVIRTUAL_BIND(_font_get_opentype_feature_overrides, "font_rid");
+
 	GDVIRTUAL_BIND(_font_supported_feature_list, "font_rid");
 	GDVIRTUAL_BIND(_font_supported_variation_list, "font_rid");
 
@@ -867,6 +870,18 @@ Vector<String> TextServerExtension::font_get_script_support_overrides(RID p_font
 		return ret;
 	}
 	return Vector<String>();
+}
+
+void TextServerExtension::font_set_opentype_feature_overrides(RID p_font_rid, const Dictionary &p_overrides) {
+	GDVIRTUAL_CALL(_font_set_opentype_feature_overrides, p_font_rid, p_overrides);
+}
+
+Dictionary TextServerExtension::font_get_opentype_feature_overrides(RID p_font_rid) const {
+	Dictionary ret;
+	if (GDVIRTUAL_CALL(_font_get_opentype_feature_overrides, p_font_rid, ret)) {
+		return ret;
+	}
+	return Dictionary();
 }
 
 Dictionary TextServerExtension::font_supported_feature_list(RID p_font_rid) const {

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -285,6 +285,11 @@ public:
 	GDVIRTUAL2(_font_remove_script_support_override, RID, const String &);
 	GDVIRTUAL1R(Vector<String>, _font_get_script_support_overrides, RID);
 
+	virtual void font_set_opentype_feature_overrides(RID p_font_rid, const Dictionary &p_overrides) override;
+	virtual Dictionary font_get_opentype_feature_overrides(RID p_font_rid) const override;
+	GDVIRTUAL2(_font_set_opentype_feature_overrides, RID, const Dictionary &);
+	GDVIRTUAL1RC(Dictionary, _font_get_opentype_feature_overrides, RID);
+
 	virtual Dictionary font_supported_feature_list(RID p_font_rid) const override;
 	virtual Dictionary font_supported_variation_list(RID p_font_rid) const override;
 	GDVIRTUAL1RC(Dictionary, _font_supported_feature_list, RID);

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -350,6 +350,9 @@ public:
 	virtual void font_remove_script_support_override(RID p_font_rid, const String &p_script) = 0;
 	virtual Vector<String> font_get_script_support_overrides(RID p_font_rid) = 0;
 
+	virtual void font_set_opentype_feature_overrides(RID p_font_rid, const Dictionary &p_overrides) = 0;
+	virtual Dictionary font_get_opentype_feature_overrides(RID p_font_rid) const = 0;
+
 	virtual Dictionary font_supported_feature_list(RID p_font_rid) const = 0;
 	virtual Dictionary font_supported_variation_list(RID p_font_rid) const = 0;
 


### PR DESCRIPTION
Fix mid-grapheme hit test.
Fix OpenType features property handling, add default features override option.
Enable mid-grapheme cursor by default.

Fixes #55100
