### PR TITLE
Fix code folding when end of block is unindented delimiter

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1419,40 +1419,23 @@ void CodeEdit::fold_line(int p_line) {
 		/* End line is the same therefore we have a block of single line delimiters. */
 		if (end_line == p_line) {
 			for (int i = p_line + 1; i <= line_count; i++) {
-				if (i == line_count) {
-					end_line = line_count;
-					break;
-				}
-
 				if ((in_string != -1 && is_in_string(i) == -1) || (in_comment != -1 && is_in_comment(i) == -1)) {
-					end_line = i - 1;
 					break;
 				}
+				end_line = i;
 			}
 		}
 	} else {
 		int start_indent = get_indent_level(p_line);
 		for (int i = p_line + 1; i <= line_count; i++) {
-			if (get_line(p_line).strip_edges().size() == 0 || is_in_string(i) != -1 || is_in_comment(i) != -1) {
+			if (get_line(i).strip_edges().size() == 0) {
+				continue;
+			}
+			if (get_indent_level(i) > start_indent) {
 				end_line = i;
 				continue;
 			}
-
-			if (i == line_count) {
-				/* Do not fold empty last line of script if any */
-				end_line = i;
-				if (get_line(i).strip_edges().size() == 0) {
-					end_line--;
-				}
-				break;
-			}
-
-			if ((get_indent_level(i) <= start_indent && get_line(i).strip_edges().size() != 0)) {
-				/* Keep an empty line unfolded if any */
-				end_line = i - 1;
-				if (get_line(i - 1).strip_edges().size() == 0 && i - 2 > p_line) {
-					end_line = i - 2;
-				}
+			if (is_in_string(i) == -1 && is_in_comment(i) == -1) {
 				break;
 			}
 		}


### PR DESCRIPTION
Fix #55023

I may be misunderstanding how Godot's code folding is supposed to work, but the behaviour implemented here seems fine to me:
- String and comment folding is unchanged apart from a small bug fix (folds from first character to terminating line)
- If not a string or comment, fold until the last line with a greater indent level, before a line with a less than or equal indent level
  - Comments and strings with a less than or equal indent level are ignored
  - Lines only containing whitespace are always ignored

I've tested this in several normal and weird situations, and all of these rules were followed correctly, although of course I could have missed one or two edge-case scenarios.

Please have a look at my description of the behaviour to make sure I'm not messing up Godot code folding, thanks  (;