### PR TITLE
[3.x] Atlas import 1px missing from right side of non-cropped image.

### DIFF
--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -131,7 +131,7 @@ static void _plot_triangle(Vector2 *vertices, const Vector2 &p_offset, bool p_tr
 	int max_y = MIN(y[2], height - p_offset.y - 1);
 	for (int yi = y[0]; yi < max_y; yi++) {
 		if (yi >= 0) {
-			for (int xi = (xf > 0 ? int(xf) : 0); xi < (xt < src_width ? xt : src_width - 1); xi++) {
+			for (int xi = (xf > 0 ? int(xf) : 0); xi < (xt <= src_width ? xt : src_width); xi++) {
 				int px = xi, py = yi;
 				int sx = px, sy = py;
 				sx = CLAMP(sx, 0, src_width - 1);


### PR DESCRIPTION
*Bugsquad edit: `3.x` version of https://github.com/godotengine/godot/pull/55238.*

Fixes edge case mentioned on previous PR https://github.com/godotengine/godot/issues/55095#issuecomment-975005489_

**Problem:**

Put this image in a project, under "Import" settings change "ImportAs:" to "TextureAtlas". Select a location to output the atlas image. Click "Reimport".
![fence_grass](https://user-images.githubusercontent.com/4075314/142903237-d6b0d5fb-0c58-494b-91e3-aca50268efbe.png)

The resulting atlas image is missing 1px from the right of the original texture.
![fence_grass_atlas](https://user-images.githubusercontent.com/4075314/142903519-a50890cc-caa1-4cda-9b4a-829a1c8c71c3.png)

**Fix:**

When looping forwards (xf is less than xt), the loop is 1px too strict.

`xt` is the same as `src_width` in this example, which is 146. The code that constructs the vertices used in this calculation seems to confirm that xt - xf should be the width of the image if no crop is made like in this example.

`chart.vertices.push_back(used_rect.position + Vector2(used_rect.size.x, 0));`

As pixel positions are 0 indexed, the last pixel x-index hit (the value set to `xi`) should be 145. 

Given this, `xt` should be treated similar to a width variable, not a pixel index. `xt` should end up as the index of the last pixel included + 1.

Issue with the current logic should be obvious. It's checking `xt` < `src_width`, which equates to 146 < 146. That check will always fail for no crop. Instead, we want to compare `xt` to `src_width` as if `xt` were a width (exclusive end index). Should be `<=`.

It backs up to `src_width - 1` which results in the loop ending at index 144 as `xi` < `src_width - 1` is false where `xi` is 145 and `src_width` is 146. If the importer function generates a triangle is greater than the source size of the image, this loop should limit to less than `src_width`, not less than `src_width - 1`.

The 2nd loop (the backwards loop) should not be touched as `xf` would correctly be limited to index 145 if it were used in this case. I'm not entirely sure what scenario triggers `xt` to be less than `xf`, but it looks to me like this logic is correct.