### PR TITLE
Fix description of Viewport `find_world_2d()` method.

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -25,13 +25,13 @@
 		<method name="find_world_2d" qualifiers="const">
 			<return type="World2D" />
 			<description>
-				Returns the 2D world of the viewport.
+				Returns the first valid [World2D] for this viewport, searching the [member world_2d] property of itself and any Viewport ancestor.
 			</description>
 		</method>
 		<method name="find_world_3d" qualifiers="const">
 			<return type="World3D" />
 			<description>
-				Returns the 3D world of the viewport, or if none the world of the parent viewport.
+				Returns the first valid [World3D] for this viewport, searching the [member world_3d] property of itself and any Viewport ancestor.
 			</description>
 		</method>
 		<method name="get_camera_2d" qualifiers="const">


### PR DESCRIPTION
The doc now states that the method searches for a World2D among ancestor Viewports as well, differentiating it from the get_world_2d() getter.

Resolves https://github.com/godotengine/godot-docs/issues/5403
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
