### PR TITLE
Document the engine's use of internal groups in Node

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -233,6 +233,14 @@
 			<description>
 				Returns an array listing the groups that the node is a member of.
 				[b]Note:[/b] For performance reasons, the order of node groups is [i]not[/i] guaranteed. The order of node groups should not be relied upon as it can vary across project runs.
+				[b]Note:[/b] The engine uses some group names internally (all starting with an underscore). To avoid conflicts with internal groups, do not add custom groups whose name starts with an underscore. To exclude internal groups while looping over [method get_groups], use the following snippet:
+				[codeblock]
+				# Stores the node's non-internal groups only (as an array of Strings).
+				var non_internal_groups = []
+				for group in get_groups():
+				    if not group.begins_with("_"):
+				        non_internal_groups.push_back(group)
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_index" qualifiers="const">


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-docs/issues/2230.

PS: We should look at making `Node.get_groups()` return `TypedArray<String>` instead of a generic `Array` internally, but this can only be done in `master`.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->