### PR TITLE
Fix crash when exporting meshes to gltf that have no skin.

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6115,7 +6115,10 @@ void GLTFDocument::_convert_mesh_instances(Ref<GLTFState> state) {
 			int bone_cnt = skeleton->get_bone_count();
 			ERR_FAIL_COND(bone_cnt != gltf_skeleton->joints.size());
 
-			ObjectID gltf_skin_key = skin->get_instance_id();
+			ObjectID gltf_skin_key;
+			if (skin.is_valid()) {
+				gltf_skin_key = skin->get_instance_id();
+			}
 			ObjectID gltf_skel_key = godot_skeleton->get_instance_id();
 			GLTFSkinIndex skin_gltf_i = -1;
 			GLTFNodeIndex root_gltf_i = -1;


### PR DESCRIPTION
This is to fix this crash: https://github.com/godotengine/godot/issues/54701

Will be doing a separate 3.x pull request, as the ObjectID has been changed from an int64 to an actual class, so this fix will result in an uninitialized variable in 3.x.

*Bugsquad edit:* Fixes #54701.