### PR TITLE
Add Input.is_physical_key_pressed method.

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -91,6 +91,7 @@ Input::MouseMode Input::get_mouse_mode() const {
 
 void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_key_pressed", "keycode"), &Input::is_key_pressed);
+	ClassDB::bind_method(D_METHOD("is_physical_key_pressed", "keycode"), &Input::is_physical_key_pressed);
 	ClassDB::bind_method(D_METHOD("is_mouse_button_pressed", "button"), &Input::is_mouse_button_pressed);
 	ClassDB::bind_method(D_METHOD("is_joy_button_pressed", "device", "button"), &Input::is_joy_button_pressed);
 	ClassDB::bind_method(D_METHOD("is_action_pressed", "action", "exact_match"), &Input::is_action_pressed, DEFVAL(false));
@@ -221,6 +222,11 @@ Input::SpeedTrack::SpeedTrack() {
 bool Input::is_key_pressed(Key p_keycode) const {
 	_THREAD_SAFE_METHOD_
 	return keys_pressed.has(p_keycode);
+}
+
+bool Input::is_physical_key_pressed(Key p_keycode) const {
+	_THREAD_SAFE_METHOD_
+	return physical_keys_pressed.has(p_keycode);
 }
 
 bool Input::is_mouse_button_pressed(MouseButton p_button) const {
@@ -463,6 +469,13 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			keys_pressed.insert(k->get_keycode());
 		} else {
 			keys_pressed.erase(k->get_keycode());
+		}
+	}
+	if (k.is_valid() && !k->is_echo() && k->get_physical_keycode() != Key::NONE) {
+		if (k->is_pressed()) {
+			physical_keys_pressed.insert(k->get_physical_keycode());
+		} else {
+			physical_keys_pressed.erase(k->get_physical_keycode());
 		}
 	}
 
@@ -862,6 +875,7 @@ void Input::release_pressed_events() {
 	flush_buffered_events(); // this is needed to release actions strengths
 
 	keys_pressed.clear();
+	physical_keys_pressed.clear();
 	joy_buttons_pressed.clear();
 	_joy_axis.clear();
 

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -87,6 +87,7 @@ public:
 private:
 	MouseButton mouse_button_mask = MouseButton::NONE;
 
+	Set<Key> physical_keys_pressed;
 	Set<Key> keys_pressed;
 	Set<JoyButton> joy_buttons_pressed;
 	Map<JoyAxis, float> _joy_axis;
@@ -247,6 +248,7 @@ public:
 	static Input *get_singleton();
 
 	bool is_key_pressed(Key p_keycode) const;
+	bool is_physical_key_pressed(Key p_keycode) const;
 	bool is_mouse_button_pressed(MouseButton p_button) const;
 	bool is_joy_button_pressed(int p_device, JoyButton p_button) const;
 	bool is_action_pressed(const StringName &p_action, bool p_exact = false) const;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -236,6 +236,13 @@
 				Returns [code]true[/code] if you are pressing the mouse button specified with [enum MouseButton].
 			</description>
 		</method>
+		<method name="is_physical_key_pressed" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="keycode" type="int" enum="Key" />
+			<description>
+				Returns [code]true[/code] if you are pressing the key in the physical location on the 101/102-key US QWERTY keyboard. You can pass a [enum Key] constant.
+			</description>
+		</method>
 		<method name="joy_connection_changed">
 			<return type="void" />
 			<argument index="0" name="device" type="int" />


### PR DESCRIPTION
Adds `Input.is_key_pressed()` equivalent for physical key codes.

Fixes #55244
