### PR TITLE
Mention that replace_by doesn't free the node

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -571,6 +571,7 @@
 			<description>
 				Replaces a node in a scene by the given one. Subscriptions that pass through this node will be lost.
 				If [code]keep_groups[/code] is [code]true[/code], the [code]node[/code] is added to the same groups that the replaced node is in.
+				Note that the replaced node is not automatically freed, so you either need to keep it in a variable for later use or free it using [method Object.free].
 			</description>
 		</method>
 		<method name="request_ready">


### PR DESCRIPTION
I wondered about it last time I used this method.