### PR TITLE
Correct the doc about ease()

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -248,9 +248,9 @@
 				- 1.0: Linear
 				- Between -1.0 and 0.0 (exclusive): Ease out-in
 				- 0.0: Constant
-				- Between 0.0 to 1.0 (exclusive): Ease in
+				- Between 0.0 to 1.0 (exclusive): Ease out
 				- 1.0: Linear
-				- Greater than 1.0 (exclusive): Ease out
+				- Greater than 1.0 (exclusive): Ease in
 				[/codeblock]
 				[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/ease_cheatsheet.png]ease() curve values cheatsheet[/url]
 				See also [method smoothstep]. If you need to perform more advanced transitions, use [Tween] or [AnimationPlayer].


### PR DESCRIPTION
Pretty minor change, but ease in and out were swapped.

According to cheat sheet this is ease in:
![image](https://user-images.githubusercontent.com/2223172/143033403-95358c5e-bfee-4005-bf00-7e03c7805783.png)

But in Curve editor:
![image](https://user-images.githubusercontent.com/2223172/143033551-3b639061-5eef-4197-8cad-e1ba2da13f85.png)
