### PR TITLE
[3.x] `TileSetEditor` Fix selecting next/previous subtile

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -213,6 +213,7 @@ private:
 	void _select_previous_tile();
 	Array _get_tiles_in_current_texture(bool sorted = false);
 	bool _sort_tiles(Variant p_a, Variant p_b);
+	Vector2 _get_subtiles_count(int p_tile_id);
 	void _select_next_subtile();
 	void _select_previous_subtile();
 	void _select_next_shape();


### PR DESCRIPTION
Fixes #55187.

Kinda reverts #42313 and should properly fix #42290.

The changes made in #42313 were completely incorrect. The logic changed in #42313 was correct in the first place. The cause of issue in #42290 seemed to be a non-zero subtile spacing ([visible in the included GIF](https://github.com/godotengine/godot/issues/42290#issue-707801978)) which resulted in incorrectly calculating subtile counts (maybe region selected by the user was too small too but the calculations weren't correct nonetheless).

So in this PR the previous logic (prior to #42313) is restored and calculating subtile counts is changed. It allows the last subtile row/column to exceed the tile region to match the behavior for the mouse clicks (the changed code isn't involved in mouse selection and you can select exceeding subtiles with the mouse). Example showing allowed subtiles:

![Godot_v3 4-stable_win64_VVYuToxI39](https://user-images.githubusercontent.com/9283098/142781629-4984603b-af12-409c-bcc6-671f7bede041.png)

![eWbIXtMeFo](https://user-images.githubusercontent.com/9283098/142781607-f24a66c8-c6f4-4f88-9c04-4a7c2e39ad9a.png)![iX1LgMXgEY](https://user-images.githubusercontent.com/9283098/142781619-42632b08-32aa-4036-b622-74f7a2e79d95.png)
![r9VoBpkxY4](https://user-images.githubusercontent.com/9283098/142781609-245fc418-5693-421b-a8bb-dda636a1f6ce.png)![Godot_v3 4-stable_win64_34Hkg6fqV9](https://user-images.githubusercontent.com/9283098/142781625-27b46deb-5985-4c7c-985c-5ce29439065e.png)
