### PR TITLE
Move container warning to the toaster

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -235,11 +235,6 @@ private:
 	PanelContainer *context_menu_container;
 	HBoxContainer *hbc_context_menu;
 
-	Map<Control *, Timer *> popup_temporarily_timers;
-
-	Label *warning_child_of_container;
-	VBoxContainer *info_overlay;
-
 	Transform2D transform;
 	bool show_grid;
 	bool show_rulers;
@@ -536,8 +531,6 @@ private:
 	VSplitContainer *bottom_split;
 
 	void _update_context_menu_stylebox();
-	void _popup_warning_temporarily(Control *p_control, const double p_duration);
-	void _popup_warning_depop(Control *p_control);
 
 	void _set_owner_for_node_and_children(Node *p_node, Node *p_owner);
 
@@ -577,9 +570,6 @@ public:
 
 	void add_control_to_menu_panel(Control *p_control);
 	void remove_control_from_menu_panel(Control *p_control);
-
-	void add_control_to_info_overlay(Control *p_control);
-	void remove_control_from_info_overlay(Control *p_control);
 
 	HSplitContainer *get_palette_split();
 	VSplitContainer *get_bottom_split();


### PR DESCRIPTION
![TldusN91eL](https://user-images.githubusercontent.com/2223172/143051596-47e29b06-7280-465e-88e7-55877f7ec40e.gif)
The PR also removes `info_overlay`, which was only used for this single thing and basically duplicates toaster functionality.