### PR TITLE
Warn when using GPU-based particles on macOS due to low performance

### DIFF
--- a/doc/classes/Particles.xml
+++ b/doc/classes/Particles.xml
@@ -7,6 +7,7 @@
 		3D particle node used to create a variety of particle systems and effects. [Particles] features an emitter that generates some number of particles at a given rate.
 		Use the [code]process_material[/code] property to add a [ParticlesMaterial] to configure particle appearance and behavior. Alternatively, you can add a [ShaderMaterial] which will be applied to all particles.
 		[b]Note:[/b] [Particles] only work when using the GLES3 renderer. If using the GLES2 renderer, use [CPUParticles] instead. You can convert [Particles] to [CPUParticles] by selecting the node, clicking the [b]Particles[/b] menu at the top of the 3D editor viewport then choosing [b]Convert to CPUParticles[/b].
+		[b]Note:[/b] On macOS, [Particles] rendering is much slower than [CPUParticles] due to transform feedback being implemented on the CPU instead of the GPU. Consider using [CPUParticles] instead when targeting macOS.
 		[b]Note:[/b] After working on a Particles node, remember to update its [member visibility_aabb] by selecting it, clicking the [b]Particles[/b] menu at the top of the 3D editor viewport then choose [b]Generate Visibility AABB[/b]. Otherwise, particles may suddenly disappear depending on the camera position and angle.
 	</description>
 	<tutorials>

--- a/doc/classes/Particles2D.xml
+++ b/doc/classes/Particles2D.xml
@@ -7,6 +7,7 @@
 		2D particle node used to create a variety of particle systems and effects. [Particles2D] features an emitter that generates some number of particles at a given rate.
 		Use the [code]process_material[/code] property to add a [ParticlesMaterial] to configure particle appearance and behavior. Alternatively, you can add a [ShaderMaterial] which will be applied to all particles.
 		[b]Note:[/b] [Particles2D] only work when using the GLES3 renderer. If using the GLES2 renderer, use [CPUParticles2D] instead. You can convert [Particles2D] to [CPUParticles2D] by selecting the node, clicking the [b]Particles[/b] menu at the top of the 2D editor viewport then choosing [b]Convert to CPUParticles2D[/b].
+		[b]Note:[/b] On macOS, [Particles2D] rendering is much slower than [CPUParticles2D] due to transform feedback being implemented on the CPU instead of the GPU. Consider using [CPUParticles2D] instead when targeting macOS.
 		[b]Note:[/b] After working on a Particles node, remember to update its [member visibility_rect] by selecting it, clicking the [b]Particles[/b] menu at the top of the 2D editor viewport then choose [b]Generate Visibility Rect[/b]. Otherwise, particles may suddenly disappear depending on the camera position and angle.
 		[b]Note:[/b] Unlike [CPUParticles2D], [Particles2D] currently ignore the texture region defined in [AtlasTexture]s.
 	</description>

--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -212,13 +212,22 @@ bool Particles2D::get_fractional_delta() const {
 
 String Particles2D::get_configuration_warning() const {
 	String warning = Node2D::get_configuration_warning();
+
 	if (OS::get_singleton()->get_current_video_driver() == OS::VIDEO_DRIVER_GLES2) {
 		if (warning != String()) {
 			warning += "\n\n";
 		}
-		warning += TTR("GPU-based particles are not supported by the GLES2 video driver.\nUse the CPUParticles2D node instead. You can use the \"Convert to CPUParticles\" option for this purpose.");
+		warning += "- " + TTR("GPU-based particles are not supported by the GLES2 video driver.\nUse the CPUParticles2D node instead. You can use the \"Convert to CPUParticles2D\" toolbar option for this purpose.");
 		return warning;
 	}
+
+#ifdef OSX_ENABLED
+	if (warning != String()) {
+		warning += "\n\n";
+	}
+
+	warning += "- " + TTR("On macOS, Particles2D rendering is much slower than CPUParticles2D due to transform feedback being implemented on the CPU instead of the GPU.\nConsider using CPUParticles2D instead when targeting macOS.\nYou can use the \"Convert to CPUParticles2D\" toolbar option for this purpose.");
+#endif
 
 	if (process_material.is_null()) {
 		if (warning != String()) {

--- a/scene/3d/particles.cpp
+++ b/scene/3d/particles.cpp
@@ -212,11 +212,23 @@ bool Particles::get_fractional_delta() const {
 }
 
 String Particles::get_configuration_warning() const {
+	String warnings = GeometryInstance::get_configuration_warning();
+
 	if (OS::get_singleton()->get_current_video_driver() == OS::VIDEO_DRIVER_GLES2) {
-		return TTR("GPU-based particles are not supported by the GLES2 video driver.\nUse the CPUParticles node instead. You can use the \"Convert to CPUParticles\" option for this purpose.");
+		if (warnings != String()) {
+			warnings += "\n\n";
+		}
+		warnings += "- " + TTR("GPU-based particles are not supported by the GLES2 video driver.\nUse the CPUParticles node instead. You can use the \"Convert to CPUParticles\" toolbar option for this purpose.");
+		return warnings;
 	}
 
-	String warnings = GeometryInstance::get_configuration_warning();
+#ifdef OSX_ENABLED
+	if (warnings != String()) {
+		warnings += "\n\n";
+	}
+
+	warnings += "- " + TTR("On macOS, Particles rendering is much slower than CPUParticles due to transform feedback being implemented on the CPU instead of the GPU.\nConsider using CPUParticles instead when targeting macOS.\nYou can use the \"Convert to CPUParticles\" toolbar option for this purpose.");
+#endif
 
 	bool meshes_found = false;
 	bool anim_material_found = false;


### PR DESCRIPTION
On macOS, Particles rendering is much slower than CPUParticles due to transform feedback being implemented on the CPU instead of the GPU.

This closes https://github.com/godotengine/godot/issues/54052.