### PR TITLE
Tweak default fog settings for better appearance

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -97,7 +97,7 @@
 			Blend factor between the fog's color and the color of the background [Sky]. Must have [member background_mode] set to [constant BG_SKY].
 			This is useful to simulate [url=https://en.wikipedia.org/wiki/Aerial_perspective]aerial perspective[/url] in large scenes with low density fog. However, it is not very useful for high-density fog, as the sky will shine through. When set to [code]1.0[/code], the fog color comes completely from the [Sky]. If set to [code]0.0[/code], aerial perspective is disabled.
 		</member>
-		<member name="fog_density" type="float" setter="set_fog_density" getter="get_fog_density" default="0.001">
+		<member name="fog_density" type="float" setter="set_fog_density" getter="get_fog_density" default="0.01">
 			The exponential fog density to use. Higher values result in a more dense fog.
 		</member>
 		<member name="fog_enabled" type="bool" setter="set_fog_enabled" getter="is_fog_enabled" default="false">
@@ -109,7 +109,7 @@
 		<member name="fog_height_density" type="float" setter="set_fog_height_density" getter="get_fog_height_density" default="0.0">
 			The density used to increase fog as height decreases. To make fog increase as height increases, use a negative value.
 		</member>
-		<member name="fog_light_color" type="Color" setter="set_fog_light_color" getter="get_fog_light_color" default="Color(0.5, 0.6, 0.7, 1)">
+		<member name="fog_light_color" type="Color" setter="set_fog_light_color" getter="get_fog_light_color" default="Color(0.518, 0.553, 0.608, 1)">
 			The fog's color.
 		</member>
 		<member name="fog_light_energy" type="float" setter="set_fog_light_energy" getter="get_fog_light_energy" default="1.0">
@@ -320,8 +320,9 @@
 		<member name="volumetric_fog_enabled" type="bool" setter="set_volumetric_fog_enabled" getter="is_volumetric_fog_enabled" default="false">
 			Enables the volumetric fog effect. Volumetric fog uses a screen-aligned froxel buffer to calculate accurate volumetric scattering in the short to medium range. Volumetric fog interacts with [FogVolume]s and lights to calculate localized and global fog. Volumetric fog uses a PBR single-scattering model based on extinction, scattering, and emission which it exposes to users as density, albedo, and emission.
 		</member>
-		<member name="volumetric_fog_gi_inject" type="float" setter="set_volumetric_fog_gi_inject" getter="get_volumetric_fog_gi_inject" default="0.0">
-			Scales the strength of Global Illumination used in the volumetric fog. A value of [code]0[/code] means that Global Illumination will not impact the volumetric fog.
+		<member name="volumetric_fog_gi_inject" type="float" setter="set_volumetric_fog_gi_inject" getter="get_volumetric_fog_gi_inject" default="1.0">
+			Scales the strength of Global Illumination used in the volumetric fog. A value of [code]0.0[/code] means that Global Illumination will not impact the volumetric fog.
+			[b]Note:[/b] Only [VoxelGI] and SDFGI ([member Environment.sdfgi_enabled]) are taken into account when using [member volumetric_fog_gi_inject]. Global illumination from [LightmapGI], [ReflectionProbe] and SSIL (see [member ssil_enabled]) will be ignored by volumetric fog.
 		</member>
 		<member name="volumetric_fog_length" type="float" setter="set_volumetric_fog_length" getter="get_volumetric_fog_length" default="64.0">
 			The distance over which the volumetric fog is computed. Increase to compute fog over a greater range, decrease to add more detail when a long range is not needed. For best quality fog, keep this as low as possible.

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -175,10 +175,10 @@ private:
 
 	// Fog
 	bool fog_enabled = false;
-	Color fog_light_color = Color(0.5, 0.6, 0.7);
+	Color fog_light_color = Color(0.518, 0.553, 0.608);
 	float fog_light_energy = 1.0;
 	float fog_sun_scatter = 0.0;
-	float fog_density = 0.001;
+	float fog_density = 0.01;
 	float fog_height = 0.0;
 	float fog_height_density = 0.0; //can be negative to invert effect
 	float fog_aerial_perspective = 0.0;
@@ -194,8 +194,8 @@ private:
 	float volumetric_fog_anisotropy = 0.2;
 	float volumetric_fog_length = 64.0;
 	float volumetric_fog_detail_spread = 2.0;
-	float volumetric_fog_gi_inject = 0.0;
-	float volumetric_fog_ambient_inject = false;
+	float volumetric_fog_gi_inject = 1.0;
+	float volumetric_fog_ambient_inject = 0.0;
 	bool volumetric_fog_temporal_reproject = true;
 	float volumetric_fog_temporal_reproject_amount = 0.9;
 	void _update_volumetric_fog();

--- a/servers/rendering/storage/environment_storage.h
+++ b/servers/rendering/storage/environment_storage.h
@@ -67,10 +67,10 @@ private:
 
 		// Fog
 		bool fog_enabled = false;
-		Color fog_light_color = Color(0.5, 0.6, 0.7);
+		Color fog_light_color = Color(0.518, 0.553, 0.608);
 		float fog_light_energy = 1.0;
 		float fog_sun_scatter = 0.0;
-		float fog_density = 0.001;
+		float fog_density = 0.01;
 		float fog_height = 0.0;
 		float fog_height_density = 0.0; //can be negative to invert effect
 		float fog_aerial_perspective = 0.0;
@@ -84,10 +84,10 @@ private:
 		float volumetric_fog_anisotropy = 0.2;
 		float volumetric_fog_length = 64.0;
 		float volumetric_fog_detail_spread = 2.0;
-		float volumetric_fog_gi_inject = 0.0;
+		float volumetric_fog_gi_inject = 1.0;
+		float volumetric_fog_ambient_inject = 0.0;
 		bool volumetric_fog_temporal_reprojection = true;
 		float volumetric_fog_temporal_reprojection_amount = 0.9;
-		float volumetric_fog_ambient_inject = 0.0;
 
 		// Glow
 		bool glow_enabled = false;


### PR DESCRIPTION
- Increase the default non-volumetric fog density to 0.01 to make adjustments more visible.
- Use a less saturated non-volumetric fog color by default (a mix of the sky and horizon colors of the new default ProceduralSkyMaterial).
- Set Volumetric Fog Gi Inject to 1.0 by default. Injecting GI results in more realistic appearance of volumetric fog, at a very low performance cost. This has no performance cost if no GI technique is used in the current scene.

This also clarifies the GI techniques `volumetric_fog_gi_inject` works with.

**Note:** Doesn't break compatibility with `3.x` projects as fog settings were already changed in `master`.

**Testing project:** [test_fog_settings.zip](https://github.com/godotengine/godot/files/8128073/test_fog_settings.zip)

## Preview

*The test scene uses SDFGI to provide global illumination, which volumetric fog supports.*

### No fog

![2022-02-23_22 46 53_no_fog_720p](https://user-images.githubusercontent.com/180032/155414918-4971ce3b-1376-4023-9ee4-3a79d8a49822.png)

### Non-volumetric fog

*Aerial Perspective and Sun Scatter are still not enabled by default, since they have a non-negligible performance cost, especially when both are enabled.*

| Before | After |
|-|-|
| ![2022-02-23_22 35 13_fog_old_720p](https://user-images.githubusercontent.com/180032/155414906-34a7a9ed-122b-4d08-aa4f-dd354685acd2.png) | ![2022-02-23_22 35 00_fog_new_720p](https://user-images.githubusercontent.com/180032/155414900-56affbe0-46de-4930-98f3-c983b1131566.png) |

### Volumetric fog

| Before | After |
|-|-|
| ![2022-02-23_22 36 16_volumetric_fog_old_720p](https://user-images.githubusercontent.com/180032/155414908-2682835b-b4f8-420d-a7ed-031c414603e6.png) | ![2022-02-23_22 38 35_volumetric_fog_new_720p](https://user-images.githubusercontent.com/180032/155414909-4262b812-0874-4e4d-8c52-07e4aced0edc.png) |

### Non-volumetric fog + Volumetric fog

| Before | After |
|-|-|
| ![2022-02-23_22 39 30_both_old_720p](https://user-images.githubusercontent.com/180032/155414917-31f3ebcf-0b06-4900-864b-ec0c30fa54a3.png) | ![2022-02-23_22 39 18_both_new_720p](https://user-images.githubusercontent.com/180032/155414913-75f10325-c252-40a9-8b48-8d2d88099b03.png) |