### PR TITLE
Add reference assign callback to GDExtensions

### DIFF
--- a/core/extension/gdnative_interface.cpp
+++ b/core/extension/gdnative_interface.cpp
@@ -855,6 +855,14 @@ static GDObjectInstanceID gdnative_object_get_instance_id(const GDNativeObjectPt
 	return (GDObjectInstanceID)o->get_instance_id();
 }
 
+static void gdnative_reference_assign(GDNativeObjectPtr p_ref, GDNativeObjectPtr p_object) {
+	ERR_FAIL_NULL(p_ref);
+
+	Ref<RefCounted> *ref = (Ref<RefCounted> *)p_ref;
+
+	ref->__internal_assign((Object *)p_object);
+}
+
 static GDNativeMethodBindPtr gdnative_classdb_get_method_bind(const char *p_classname, const char *p_methodname, GDNativeInt p_hash) {
 	MethodBind *mb = ClassDB::get_method(StringName(p_classname), StringName(p_methodname));
 	ERR_FAIL_COND_V(!mb, nullptr);
@@ -1030,6 +1038,10 @@ void gdnative_setup_interface(GDNativeInterface *p_interface) {
 	gdni.object_cast_to = gdnative_object_cast_to;
 	gdni.object_get_instance_from_id = gdnative_object_get_instance_from_id;
 	gdni.object_get_instance_id = gdnative_object_get_instance_id;
+
+	/* REFERENCE */
+
+	gdni.reference_assign = gdnative_reference_assign;
 
 	/* CLASSDB */
 

--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -435,6 +435,10 @@ typedef struct {
 	GDNativeObjectPtr (*object_get_instance_from_id)(GDObjectInstanceID p_instance_id);
 	GDObjectInstanceID (*object_get_instance_id)(const GDNativeObjectPtr p_object);
 
+	/* REFERENCE */
+
+	void (*reference_assign)(GDNativeObjectPtr p_ref, GDNativeObjectPtr p_object);
+
 	/* CLASSDB */
 
 	GDNativeClassConstructor (*classdb_get_constructor)(const char *p_classname, GDNativeExtensionPtr *r_extension);

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -232,6 +232,25 @@ public:
 	~Ref() {
 		unref();
 	}
+
+	// Used exclusively for assigning an object pointer sourced from GDextensions
+	inline void __internal_assign(Object *p_obj) {
+		RefCounted *refb = const_cast<RefCounted *>(static_cast<const RefCounted *>(p_obj));
+		if (!refb) {
+			unref();
+			return;
+		}
+
+		// We don't have a way to safely directly assign our reference so use a temporary variable
+		Ref<T> r; 
+		r.reference = Object::cast_to<T>(refb);
+
+		// Now assign to our actual reference so we properly unreference any existing object and reference our new object.
+		ref(r);
+
+		// clear so we don't unref what we haved referenced.
+		r.reference = nullptr;
+	}
 };
 
 typedef Ref<RefCounted> REF;


### PR DESCRIPTION
Add reference assign function to improve the solution in https://github.com/godotengine/godot-cpp/pull/660

The problem here is that `Ref<T>` on the Godot side and `Ref<T>` on the godot-cpp side are not interchangeable so when assignments cross the API border we are exchanging pointers to the object referenced within. This is causing issues with updating the proper refcount of the reference object. The current "solution" simply ignores this all together and just sets the reference without worrying about refcount. Any current object isn't de-referenced, any new object isn't referenced resulting in leaking or prematurely destructing objects, 

This ensures the proper logic is run when changing the object a reference points to with code run on the extensions side.
