### PR TITLE
Fix subviewports receiving gui input too early

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -129,20 +129,34 @@
 			<description>
 			</description>
 		</method>
-		<method name="push_gui_input">
-			<return type="void" />
-			<argument index="0" name="event" type="InputEvent" />
-			<argument index="1" name="in_local_coords" type="bool" default="false" />
-			<description>
-				Pushes an input event to [method Control._gui_input]
-			</description>
-		</method>
 		<method name="push_input">
 			<return type="void" />
 			<argument index="0" name="event" type="InputEvent" />
 			<argument index="1" name="in_local_coords" type="bool" default="false" />
 			<description>
-				Pushes an input event to [method Node._input]
+				Pushes an input event.
+			</description>
+		</method>
+		<method name="push_local_gui_input">
+			<return type="void" />
+			<argument index="0" name="event" type="InputEvent" />
+			<argument index="1" name="in_local_coords" type="bool" default="false" />
+			<description>
+			</description>
+		</method>
+		<method name="push_local_input">
+			<return type="void" />
+			<argument index="0" name="event" type="InputEvent" />
+			<argument index="1" name="in_local_coords" type="bool" default="false" />
+			<description>
+				The three push_local_*_input functions push an event to the three event passes respectively. Unlike push_input, they do not forward events to subwindows.
+			</description>
+		</method>
+		<method name="push_local_unhandled_input">
+			<return type="void" />
+			<argument index="0" name="event" type="InputEvent" />
+			<argument index="1" name="in_local_coords" type="bool" default="false" />
+			<description>
 			</description>
 		</method>
 		<method name="push_text_input">
@@ -150,14 +164,6 @@
 			<argument index="0" name="text" type="String" />
 			<description>
 				Returns [code]true[/code] if the viewport is currently embedding windows.
-			</description>
-		</method>
-		<method name="push_unhandled_input">
-			<return type="void" />
-			<argument index="0" name="event" type="InputEvent" />
-			<argument index="1" name="in_local_coords" type="bool" default="false" />
-			<description>
-				Pushes an input event to [method Node._unhandled_input]
 			</description>
 		</method>
 		<method name="set_input_as_handled">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -134,6 +134,7 @@
 			<argument index="0" name="event" type="InputEvent" />
 			<argument index="1" name="in_local_coords" type="bool" default="false" />
 			<description>
+				Pushes an input event to [method Control._gui_input]
 			</description>
 		</method>
 		<method name="push_input">
@@ -141,6 +142,7 @@
 			<argument index="0" name="event" type="InputEvent" />
 			<argument index="1" name="in_local_coords" type="bool" default="false" />
 			<description>
+				Pushes an input event to [method Node._input]
 			</description>
 		</method>
 		<method name="push_text_input">
@@ -155,6 +157,7 @@
 			<argument index="0" name="event" type="InputEvent" />
 			<argument index="1" name="in_local_coords" type="bool" default="false" />
 			<description>
+				Pushes an input event to [method Node._unhandled_input]
 			</description>
 		</method>
 		<method name="set_input_as_handled">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -143,6 +143,13 @@
 				Returns [code]true[/code] if the viewport is currently embedding windows.
 			</description>
 		</method>
+		<method name="push_gui_input">
+			<return type="void" />
+			<argument index="0" name="event" type="InputEvent" />
+			<argument index="1" name="in_local_coords" type="bool" default="false" />
+			<description>
+			</description>
+		</method>
 		<method name="push_unhandled_input">
 			<return type="void" />
 			<argument index="0" name="event" type="InputEvent" />

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -129,6 +129,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="push_gui_input">
+			<return type="void" />
+			<argument index="0" name="event" type="InputEvent" />
+			<argument index="1" name="in_local_coords" type="bool" default="false" />
+			<description>
+			</description>
+		</method>
 		<method name="push_input">
 			<return type="void" />
 			<argument index="0" name="event" type="InputEvent" />
@@ -141,13 +148,6 @@
 			<argument index="0" name="text" type="String" />
 			<description>
 				Returns [code]true[/code] if the viewport is currently embedding windows.
-			</description>
-		</method>
-		<method name="push_gui_input">
-			<return type="void" />
-			<argument index="0" name="event" type="InputEvent" />
-			<argument index="1" name="in_local_coords" type="bool" default="false" />
-			<description>
 			</description>
 		</method>
 		<method name="push_unhandled_input">

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -238,7 +238,7 @@ void EditorCommandPalette::register_shortcuts_as_command() {
 		ev.instantiate();
 		ev->set_shortcut(shortcut);
 		String shortcut_text = String(shortcut->get_as_text());
-		add_command(command_name, *key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_unhandled_input), varray(ev, false), shortcut_text);
+		add_command(command_name, *key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_local_unhandled_input), varray(ev, false), shortcut_text);
 		key = unregistered_shortcuts.next(key);
 	}
 	unregistered_shortcuts.clear();
@@ -260,7 +260,7 @@ Ref<Shortcut> EditorCommandPalette::add_shortcut_command(const String &p_command
 		ev.instantiate();
 		ev->set_shortcut(p_shortcut);
 		String shortcut_text = String(p_shortcut->get_as_text());
-		add_command(p_command, p_key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_unhandled_input), varray(ev, false), shortcut_text);
+		add_command(p_command, p_key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_local_unhandled_input), varray(ev, false), shortcut_text);
 	} else {
 		const String key_name = String(p_key);
 		const String command_name = String(p_command);

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -289,6 +289,7 @@ void TouchScreenButton::_press(int p_finger_pressed) {
 		iea->set_action(action);
 		iea->set_pressed(true);
 		get_viewport()->push_input(iea, true);
+		get_viewport()->push_gui_input(iea, true);
 	}
 
 	emit_signal(SNAME("pressed"));
@@ -306,6 +307,7 @@ void TouchScreenButton::_release(bool p_exiting_tree) {
 			iea->set_action(action);
 			iea->set_pressed(false);
 			get_viewport()->push_input(iea, true);
+			get_viewport()->push_gui_input(iea, true);
 		}
 	}
 

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -289,7 +289,6 @@ void TouchScreenButton::_press(int p_finger_pressed) {
 		iea->set_action(action);
 		iea->set_pressed(true);
 		get_viewport()->push_input(iea, true);
-		get_viewport()->push_gui_input(iea, true);
 	}
 
 	emit_signal(SNAME("pressed"));
@@ -307,7 +306,6 @@ void TouchScreenButton::_release(bool p_exiting_tree) {
 			iea->set_action(action);
 			iea->set_pressed(false);
 			get_viewport()->push_input(iea, true);
-			get_viewport()->push_gui_input(iea, true);
 		}
 	}
 

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -166,6 +166,33 @@ void SubViewportContainer::input(const Ref<InputEvent> &p_event) {
 	}
 }
 
+void SubViewportContainer::gui_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+
+	Transform2D xform = get_global_transform();
+
+	if (stretch) {
+		Transform2D scale_xf;
+		scale_xf.scale(Vector2(shrink, shrink));
+		xform *= scale_xf;
+	}
+
+	Ref<InputEvent> ev = p_event; // already transformed
+
+	for (int i = 0; i < get_child_count(); i++) {
+		SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+		if (!c || c->is_input_disabled()) {
+			continue;
+		}
+
+		c->push_gui_input(ev);
+	}
+}
+
 void SubViewportContainer::unhandled_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -162,7 +162,7 @@ void SubViewportContainer::input(const Ref<InputEvent> &p_event) {
 			continue;
 		}
 
-		c->push_input(ev);
+		c->push_local_input(ev);
 	}
 }
 
@@ -189,7 +189,7 @@ void SubViewportContainer::gui_input(const Ref<InputEvent> &p_event) {
 			continue;
 		}
 
-		c->push_gui_input(ev);
+		c->push_local_gui_input(ev);
 	}
 }
 
@@ -216,7 +216,7 @@ void SubViewportContainer::unhandled_input(const Ref<InputEvent> &p_event) {
 			continue;
 		}
 
-		c->push_unhandled_input(ev);
+		c->push_local_unhandled_input(ev);
 	}
 }
 

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -48,6 +48,7 @@ public:
 	bool is_stretch_enabled() const;
 
 	virtual void input(const Ref<InputEvent> &p_event) override;
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual void unhandled_input(const Ref<InputEvent> &p_event) override;
 	void set_stretch_shrink(int p_shrink);
 	int get_stretch_shrink() const;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3603,6 +3603,7 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_viewport_rid"), &Viewport::get_viewport_rid);
 	ClassDB::bind_method(D_METHOD("push_text_input", "text"), &Viewport::push_text_input);
 	ClassDB::bind_method(D_METHOD("push_input", "event", "in_local_coords"), &Viewport::push_input, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("push_gui_input", "event", "in_local_coords"), &Viewport::push_gui_input, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("push_unhandled_input", "event", "in_local_coords"), &Viewport::push_unhandled_input, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("get_camera_2d"), &Viewport::get_camera_2d);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -541,6 +541,7 @@ public:
 
 	void push_text_input(const String &p_text);
 	void push_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
+	void push_gui_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
 	void push_unhandled_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
 
 	void set_disable_input(bool p_disable);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -541,8 +541,9 @@ public:
 
 	void push_text_input(const String &p_text);
 	void push_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
-	void push_gui_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
-	void push_unhandled_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
+	void push_local_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
+	void push_local_gui_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
+	void push_local_unhandled_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
 
 	void set_disable_input(bool p_disable);
 	bool is_input_disabled() const;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -921,6 +921,7 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 	emit_signal(SceneStringNames::get_singleton()->window_input, p_ev);
 
 	push_input(p_ev);
+	push_gui_input(p_ev);
 	if (!is_input_handled()) {
 		push_unhandled_input(p_ev);
 	}

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -920,11 +920,7 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 
 	emit_signal(SceneStringNames::get_singleton()->window_input, p_ev);
 
-	push_input(p_ev);
-	push_gui_input(p_ev);
-	if (!is_input_handled()) {
-		push_unhandled_input(p_ev);
-	}
+	push_input(p_ev, false);
 }
 
 void Window::_window_input_text(const String &p_text) {

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -166,7 +166,7 @@ int register_test_command(String p_command, TestFunc p_function);
 #define SEND_GUI_MOUSE_EVENT(m_object, m_local_pos, m_input, m_mask)     \
 	{                                                                    \
 		_CREATE_GUI_MOUSE_EVENT(m_object, m_local_pos, m_input, m_mask); \
-		m_object->get_viewport()->push_gui_input(event);                     \
+		m_object->get_viewport()->push_gui_input(event);                 \
 		MessageQueue::get_singleton()->flush();                          \
 	}
 
@@ -174,7 +174,7 @@ int register_test_command(String p_command, TestFunc p_function);
 	{                                                                                         \
 		_CREATE_GUI_MOUSE_EVENT(m_object, m_local_pos, MouseButton::LEFT, MouseButton::LEFT); \
 		event->set_double_click(true);                                                        \
-		m_object->get_viewport()->push_gui_input(event);                                          \
+		m_object->get_viewport()->push_gui_input(event);                                      \
 		MessageQueue::get_singleton()->flush();                                               \
 	}
 

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -166,7 +166,7 @@ int register_test_command(String p_command, TestFunc p_function);
 #define SEND_GUI_MOUSE_EVENT(m_object, m_local_pos, m_input, m_mask)     \
 	{                                                                    \
 		_CREATE_GUI_MOUSE_EVENT(m_object, m_local_pos, m_input, m_mask); \
-		m_object->get_viewport()->push_input(event);                     \
+		m_object->get_viewport()->push_gui_input(event);                     \
 		MessageQueue::get_singleton()->flush();                          \
 	}
 
@@ -174,7 +174,7 @@ int register_test_command(String p_command, TestFunc p_function);
 	{                                                                                         \
 		_CREATE_GUI_MOUSE_EVENT(m_object, m_local_pos, MouseButton::LEFT, MouseButton::LEFT); \
 		event->set_double_click(true);                                                        \
-		m_object->get_viewport()->push_input(event);                                          \
+		m_object->get_viewport()->push_gui_input(event);                                          \
 		MessageQueue::get_singleton()->flush();                                               \
 	}
 

--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -166,7 +166,7 @@ int register_test_command(String p_command, TestFunc p_function);
 #define SEND_GUI_MOUSE_EVENT(m_object, m_local_pos, m_input, m_mask)     \
 	{                                                                    \
 		_CREATE_GUI_MOUSE_EVENT(m_object, m_local_pos, m_input, m_mask); \
-		m_object->get_viewport()->push_gui_input(event);                 \
+		m_object->get_viewport()->push_local_gui_input(event);           \
 		MessageQueue::get_singleton()->flush();                          \
 	}
 
@@ -174,7 +174,7 @@ int register_test_command(String p_command, TestFunc p_function);
 	{                                                                                         \
 		_CREATE_GUI_MOUSE_EVENT(m_object, m_local_pos, MouseButton::LEFT, MouseButton::LEFT); \
 		event->set_double_click(true);                                                        \
-		m_object->get_viewport()->push_gui_input(event);                                      \
+		m_object->get_viewport()->push_local_gui_input(event);                                \
 		MessageQueue::get_singleton()->flush();                                               \
 	}
 


### PR DESCRIPTION
## Issue
Fixes #48401 for 4.0, the wrong order that subviewports handle input events.

Testing project: 
[viewport_gui_input_fix.zip](https://github.com/godotengine/godot/files/7600539/viewport_gui_input_fix.zip)

Before this fix the order was
1. Main input (nodes before and including subviewport container)
2. Subviewport input 
3. Subviewport **gui_input**
4. Main input (after subviewport container)
5. Main gui_input (including subviewport container)
6. All unhandled_input

One consequence is that no control over a viewport can receive gui_input, as #48401
The root of the problem is that `Viewport::push_input` handles input and gui_input in succession.
This is alright for the main viewport but not  for subviewports.

```c++
void Viewport::push_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
  // ...
  if (!is_input_handled()) {
	  get_tree()->_call_input_pause(input_group, SceneTree::CALL_INPUT_TYPE_INPUT, ev, this);
  }
  
  if (!is_input_handled()) {
	  _gui_input_event(ev);
  }
}
```

## Fix

My solution is to split `push_input` into two functions `push_input` and `push_gui_input` (as there has been a `push_unhandled_input`). They are almost identical to the original `push_input` except that one only calls `_call_input_pause` and the other one calls `_gui_input_event`.

The main viewport enters this function from `Window::_window_input`
```c++
void Window::_window_input(const Ref<InputEvent> &p_ev) {
	// ...
	push_input(p_ev);
	if (!is_input_handled()) {
		push_unhandled_input(p_ev);
	}
}
```
I added `push_gui_input(p_ev);` after `push_input(p_ev);` so the logic remains the same.

Subviewports enter this function from `SubViewportContainer::input`
```c++
void SubViewportContainer::input(const Ref<InputEvent> &p_event) {
	ERR_FAIL_COND(p_event.is_null());

	if (Engine::get_singleton()->is_editor_hint()) {
		return;
	}

	Transform2D xform = get_global_transform();

	if (stretch) {
		Transform2D scale_xf;
		scale_xf.scale(Vector2(shrink, shrink));
		xform *= scale_xf;
	}

	Ref<InputEvent> ev = p_event->xformed_by(xform.affine_inverse());

	for (int i = 0; i < get_child_count(); i++) {
		SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
		if (!c || c->is_input_disabled()) {
			continue;
		}

		c->push_input(ev);
	}
}
```

I overrode `void SubViewportContainer::gui_input` which copied the content of `SubViewportContainer::input` except that
1. It calls `c->push_gui_input(ev)` instead at the end.
2. No `p_event->xformed_by(xform.affine_inverse())` as the gui event has been transformed.

After the fix the event order becomes

1. Main input (before and including viewport container)
2. Subviewport input 
3. Main input (after)
4. Main gui_input (before and including viewport container)
5. Subviewport gui_input
6. Main gui_input (after)
7. All unhandled_input

## Other concerns

`Viewport::push_input` has an `event_count++` at the end.
I removed it from `Viewport::push_gui_input` to avoid an event being counted twice.
So only `Viewport::push_input` counts the events, `Viewport::push_gui_input` does not (same as `Viewport::push_unhandled_input`).

I saw `TouchScreenButton` in `scene/2d/touch_screen_button.cpp` calls `push_input` as well.
I have no clue why a button needs to call viewport directly.
I simply added a `push_gui_input` call after every `push_input` so the logic should remain the same as before, which means it may still suffer from this bug.
I don't have the environment to test it though.

The doc [Using InputEvent](https://docs.godotengine.org/en/stable/tutorials/inputs/inputevent.html) is wrong about the viewport order, as it says viewports process events one after another. Hopefully someone will update it before 4.0.


*Bugsquad edit:*
- Fixes #39666