### PR TITLE
Move logic for saving project features to ProjectSettings save_custom

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -151,6 +151,7 @@ public:
 	String get_project_data_dir_name() const;
 	String get_project_data_path() const;
 	String get_resource_path() const;
+	String get_safe_project_name() const;
 	String get_imported_files_path() const;
 
 	static ProjectSettings *get_singleton();

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1233,46 +1233,6 @@ ProjectList::Item ProjectList::load_project_data(const String &p_property_key, b
 	const String main_scene = cf->get_value("application", "run/main_scene", "");
 
 	PackedStringArray project_features = cf->get_value("application", "config/features", PackedStringArray());
-	bool project_features_dirty = false;
-	// If there is no feature list currently present, force one to generate.
-	if (project_features.is_empty()) {
-		project_features = ProjectSettings::get_required_features();
-		project_features_dirty = true;
-	}
-	// Check the rendering API.
-	const String rendering_api = cf->get_value("rendering", "quality/driver/driver_name", "");
-	if (rendering_api != "") {
-		// Add the rendering API as a project feature if it doesn't already exist.
-		if (!project_features.has(rendering_api)) {
-			project_features.append(rendering_api);
-			project_features_dirty = true;
-		}
-	}
-	// Check for the existence of a csproj file.
-	if (FileAccess::exists(path.plus_file(project_name + ".csproj"))) {
-		// If there is a csproj file, add the C# feature if it doesn't already exist.
-		if (!project_features.has("C#")) {
-			project_features.append("C#");
-			project_features_dirty = true;
-		}
-	} else {
-		// If there isn't a csproj file, remove the C# feature if it exists.
-		if (project_features.has("C#")) {
-			project_features.remove_at(project_features.find("C#"));
-			project_features_dirty = true;
-		}
-	}
-	if (project_features_dirty) {
-		project_features.sort();
-		// Write the updated feature list, but only if the project config version is the same.
-		// Never write to project files with a different config version!
-		if (config_version == ProjectSettings::CONFIG_VERSION) {
-			ProjectSettings *ps = ProjectSettings::get_singleton();
-			ps->load_custom(conf);
-			ps->set("application/config/features", project_features);
-			ps->save_custom(conf);
-		}
-	}
 	PackedStringArray unsupported_features = ProjectSettings::get_unsupported_features(project_features);
 
 	uint64_t last_edited = 0;
@@ -1470,7 +1430,7 @@ void ProjectList::create_project_item_control(int p_index) {
 		int length = unsupported_features_str.length();
 		if (length > 0) {
 			Label *unsupported_label = memnew(Label(unsupported_features_str));
-			unsupported_label->set_custom_minimum_size(Size2(length * 15, 10));
+			unsupported_label->set_custom_minimum_size(Size2(length * 15, 10) * EDSCALE);
 			unsupported_label->add_theme_font_override("font", get_theme_font(SNAME("title"), SNAME("EditorFonts")));
 			unsupported_label->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 			unsupported_label->set_clip_text(true);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -788,11 +788,7 @@ bool CSharpLanguage::is_assembly_reloading_needed() {
 
 	GDMonoAssembly *proj_assembly = gdmono->get_project_assembly();
 
-	String appname = ProjectSettings::get_singleton()->get("application/config/name");
-	String appname_safe = OS::get_singleton()->get_safe_dir_name(appname);
-	if (appname_safe.is_empty()) {
-		appname_safe = "UnnamedProject";
-	}
+	String appname_safe = ProjectSettings::get_singleton()->get_safe_project_name();
 
 	appname_safe += ".dll";
 


### PR DESCRIPTION
Hotfix for #31171 that only showed up on at-least-somewhat-complex projects.

The old code written by over-2-years-ago-me was just badly designed code. It was saving on load, and there were two places where it tried to do this. I shouldn't have trusted myself. #31171 appears fine if it's only tested for a short time, but breaks down in any complex situation. This PR should make it work much better. Testing appreciated.

<i>Bugsquad edit:</i> Fix #55302