### PR TITLE
Fix GPUParticle2D visibility rect display with particle animation

### DIFF
--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -34,6 +34,82 @@
 
 #ifdef TOOLS_ENABLED
 #include "core/config/engine.h"
+
+void GPUParticles2D::set_material(const Ref<Material> &p_material) {
+	if (get_use_parent_material() && material_in_use.is_valid()) {
+		material_in_use->disconnect("changed", callable_mp(this, &GPUParticles2D::_material_changed));
+		vis_rect_hvframes = Vector2(1, 1);
+	}
+	if (get_material().is_valid()) {
+		get_material()->disconnect("changed", callable_mp(this, &GPUParticles2D::_material_changed));
+		vis_rect_hvframes = Vector2(1, 1);
+	}
+
+	CanvasItem::set_material(p_material);
+
+	if (get_material().is_valid()) {
+		get_material()->connect("changed", callable_mp(this, &GPUParticles2D::_material_changed));
+	}
+	update();
+}
+
+void GPUParticles2D::_material_changed() {
+	if (get_use_parent_material() && material_in_use.is_valid()) {
+		_calc_vis_rect_hvframes(material_in_use);
+	} else if (get_material().is_valid()) {
+		CanvasItemMaterial *mat = Object::cast_to<CanvasItemMaterial>(get_material().ptr());
+		_calc_vis_rect_hvframes(mat);
+	} else {
+		vis_rect_hvframes = Vector2(1, 1);
+	}
+	update();
+}
+
+void GPUParticles2D::_calc_vis_rect_hvframes(Ref<CanvasItemMaterial> p_material) {
+	if (p_material.is_valid() && p_material->get_particles_animation()) {
+		vis_rect_hvframes = Vector2(p_material->get_particles_anim_h_frames(), p_material->get_particles_anim_v_frames());
+	} else {
+		vis_rect_hvframes = Vector2(1, 1);
+	}
+}
+
+void GPUParticles2D::set_use_parent_material(bool p_use_parent_material) {
+	if (p_use_parent_material) {
+		if (get_use_parent_material() && material_in_use.is_valid()) {
+			material_in_use->disconnect("changed", callable_mp(this, &GPUParticles2D::_material_changed));
+			vis_rect_hvframes = Vector2(1, 1);
+		}
+		if (get_material().is_valid()) {
+			get_material()->disconnect("changed", callable_mp(this, &GPUParticles2D::_material_changed));
+			vis_rect_hvframes = Vector2(1, 1);
+		}
+
+		CanvasItem::set_use_parent_material(p_use_parent_material);
+		CanvasItem *ci = this;
+		while (ci && ci->get_use_parent_material()) {
+			Node *n = ci->get_parent();
+			ci = Object::cast_to<CanvasItem>(n);
+		}
+
+		material_in_use = ci->get_material();
+
+		_calc_vis_rect_hvframes(material_in_use);
+		if (material_in_use.is_valid()) {
+			material_in_use->connect("changed", callable_mp(this, &GPUParticles2D::_material_changed));
+		}
+
+		_material_changed();
+
+	} else {
+		CanvasItem::set_use_parent_material(p_use_parent_material);
+		vis_rect_hvframes = Vector2(1, 1);
+		if (get_material().is_valid()) {
+			get_material()->connect("changed", callable_mp(this, &GPUParticles2D::_material_changed));
+			_material_changed();
+		}
+	}
+	update();
+}
 #endif
 
 void GPUParticles2D::set_emitting(bool p_emitting) {
@@ -341,6 +417,11 @@ void GPUParticles2D::restart() {
 }
 
 void GPUParticles2D::_notification(int p_what) {
+#ifdef TOOLS_ENABLED
+	if (p_what == NOTIFICATION_READY && Engine::get_singleton()->is_editor_hint()) {
+		_material_changed();
+	}
+#endif
 	if (p_what == NOTIFICATION_DRAW) {
 		RID texture_rid;
 		Size2 size;
@@ -460,7 +541,10 @@ void GPUParticles2D::_notification(int p_what) {
 
 #ifdef TOOLS_ENABLED
 		if (show_visibility_rect) {
-			draw_rect(visibility_rect, Color(0, 0.7, 0.9, 0.4), false);
+			Rect2 render_visibility_rect;
+			render_visibility_rect.size = visibility_rect.size * vis_rect_hvframes;
+			render_visibility_rect.position = visibility_rect.position * vis_rect_hvframes;
+			draw_rect(render_visibility_rect, Color(0, 0.7, 0.9, 0.4), false);
 		}
 #endif
 	}
@@ -578,6 +662,10 @@ GPUParticles2D::GPUParticles2D() {
 	mesh = RS::get_singleton()->mesh_create();
 	RS::get_singleton()->particles_set_draw_passes(particles, 1);
 	RS::get_singleton()->particles_set_draw_pass_mesh(particles, 0, mesh);
+
+#ifdef TOOLS_ENABLED
+	vis_rect_hvframes = Vector2(1, 1);
+#endif
 
 	one_shot = false; // Needed so that set_emitting doesn't access uninitialized values
 	set_emitting(true);

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -55,6 +55,7 @@ private:
 	real_t randomness_ratio;
 	double speed_scale;
 	Rect2 visibility_rect;
+
 	bool local_coords;
 	int fixed_fps;
 	bool fractional_delta;
@@ -68,6 +69,13 @@ private:
 	Ref<Texture2D> texture;
 
 	void _update_particle_emission_transform();
+
+#ifdef TOOLS_ENABLED
+	Vector2 vis_rect_hvframes;
+	Ref<CanvasItemMaterial> material_in_use;
+	void _calc_vis_rect_hvframes(Ref<CanvasItemMaterial> p_material);
+	void _material_changed();
+#endif
 
 	NodePath sub_emitter;
 	real_t collision_base_size = 1.0;
@@ -86,6 +94,10 @@ protected:
 	void _update_collision_size();
 
 public:
+#ifdef TOOLS_ENABLED
+	virtual void set_material(const Ref<Material> &p_material) override;
+	virtual void set_use_parent_material(bool p_use_parent_material) override;
+#endif
 	void set_emitting(bool p_emitting);
 	void set_amount(int p_amount);
 	void set_lifetime(double p_lifetime);

--- a/scene/resources/canvas_item_material.cpp
+++ b/scene/resources/canvas_item_material.cpp
@@ -175,6 +175,7 @@ bool CanvasItemMaterial::_is_shader_dirty() const {
 void CanvasItemMaterial::set_blend_mode(BlendMode p_blend_mode) {
 	blend_mode = p_blend_mode;
 	_queue_shader_change();
+	emit_changed();
 }
 
 CanvasItemMaterial::BlendMode CanvasItemMaterial::get_blend_mode() const {
@@ -184,6 +185,7 @@ CanvasItemMaterial::BlendMode CanvasItemMaterial::get_blend_mode() const {
 void CanvasItemMaterial::set_light_mode(LightMode p_light_mode) {
 	light_mode = p_light_mode;
 	_queue_shader_change();
+	emit_changed();
 }
 
 CanvasItemMaterial::LightMode CanvasItemMaterial::get_light_mode() const {
@@ -194,6 +196,7 @@ void CanvasItemMaterial::set_particles_animation(bool p_particles_anim) {
 	particles_animation = p_particles_anim;
 	_queue_shader_change();
 	notify_property_list_changed();
+	emit_changed();
 }
 
 bool CanvasItemMaterial::get_particles_animation() const {
@@ -203,6 +206,7 @@ bool CanvasItemMaterial::get_particles_animation() const {
 void CanvasItemMaterial::set_particles_anim_h_frames(int p_frames) {
 	particles_anim_h_frames = p_frames;
 	RS::get_singleton()->material_set_param(_get_material(), shader_names->particles_anim_h_frames, p_frames);
+	emit_changed();
 }
 
 int CanvasItemMaterial::get_particles_anim_h_frames() const {
@@ -212,6 +216,7 @@ int CanvasItemMaterial::get_particles_anim_h_frames() const {
 void CanvasItemMaterial::set_particles_anim_v_frames(int p_frames) {
 	particles_anim_v_frames = p_frames;
 	RS::get_singleton()->material_set_param(_get_material(), shader_names->particles_anim_v_frames, p_frames);
+	emit_changed();
 }
 
 int CanvasItemMaterial::get_particles_anim_v_frames() const {
@@ -221,6 +226,7 @@ int CanvasItemMaterial::get_particles_anim_v_frames() const {
 void CanvasItemMaterial::set_particles_anim_loop(bool p_loop) {
 	particles_anim_loop = p_loop;
 	RS::get_singleton()->material_set_param(_get_material(), shader_names->particles_anim_loop, particles_anim_loop);
+	emit_changed();
 }
 
 bool CanvasItemMaterial::get_particles_anim_loop() const {


### PR DESCRIPTION
This PR fixes #50515 (Wrong Visibility Rect size for 2D particles - Editor display glitch).

![Hb9qOeGn7Z](https://user-images.githubusercontent.com/9423774/143424382-e30849fb-c813-4580-84ec-3e0281eae430.gif)


It required more code than I wanted to add for such a small fix, so if some more experienced c++ coder can have a look over it, it would be appreciated.

I also covered the use case if a Particle2D is having `use parent material` checked. That required even more extra code and there are some special cases where it won't update the visibility rect draw box to the correct size. But those cases are _really_ rare and probably almost never happen in real life ( multiple levels of use_parent_material with stacked children and checking and unchecking the parameter in the middle children... ). 
It can also be always refreshed by checking and unchecking.

There is just no signal to connect to and adding one felt like serious overkill for such a rare situation.

**Modifications to CanvasItemMaterial**
To make this fix possible, I needed to also modify `CanvasItemMaterial` and add the `emit_changed() / changed signals` to it - This only made it coherent to the rest of the Resources, so it makes sense either way.


This fix should and could be pretty easily backported to 3.x.