### PR TITLE
Enchance descriptions of @GlobalScope/@GDScript

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="@GlobalScope" version="4.0">
 	<brief_description>
-		Global scope constants and variables.
+		Global scope constants and functions.
 	</brief_description>
 	<description>
-		Global scope constants and variables. This is all that resides in the globals, constants regarding error codes, keycodes, property hints, etc.
+		A list of global scope enumerated constants and built-in functions. This is all that resides in the globals, constants regarding error codes, keycodes, property hints, etc.
 		Singletons are also documented here, since they can be accessed from anywhere.
+		For the entries related to GDScript which can be accessed in any script see [@GDScript].
 	</description>
 	<tutorials>
+		<link title="Random number generation">$DOCS_URL/tutorials/math/random_number_generation.html</link>
 	</tutorials>
 	<methods>
 		<method name="abs">

--- a/modules/gdscript/doc_classes/@GDScript.xml
+++ b/modules/gdscript/doc_classes/@GDScript.xml
@@ -4,10 +4,10 @@
 		Built-in GDScript functions.
 	</brief_description>
 	<description>
-		List of core built-in GDScript functions. Math functions and other utilities. Everything else is provided by objects. (Keywords: builtin, built in, global functions.)
+		A list of GDScript-specific utility functions accessed in any script.
+		For the list of the global functions and constants see [@GlobalScope].
 	</description>
 	<tutorials>
-		<link title="Random number generation">$DOCS_URL/tutorials/math/random_number_generation.html</link>
 	</tutorials>
 	<methods>
 		<method name="Color8">


### PR DESCRIPTION
- I think there are no "variables" in the global scope so I've changed it to "functions" - it's more important to notice. 
- Added a cross-link to GDScript. 
- Removed keywords from description of GDScript (I'm not sure why it was introduced in https://github.com/godotengine/godot/pull/19622 - I think it's useless)
- Replaced a link for Random Number Generator from GDScript to GlobalScope.