### PR TITLE
[macOS / iOS] Fix SDFGI shared compilation errors.

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
@@ -1757,7 +1757,11 @@ void main() {
 			}
 		}
 
+#ifdef MOLTENVK_USED
+		imageStore(geom_facing_grid, grid_pos, uvec4(imageLoad(geom_facing_grid, grid_pos).r | facing_bits)); //store facing bits
+#else
 		imageAtomicOr(geom_facing_grid, grid_pos, facing_bits); //store facing bits
+#endif
 
 		if (length(emission) > 0.001) {
 			float lumas[6];


### PR DESCRIPTION
Use non-atomic operation to store facing bits on MoltenVK.

Since facing_grid image is used as an actual texture, the same treatment as in #55281 won't work, but the same shader is using `imageStore` to write another 3 images of the same type and size, and I was not able to measure any difference in performance. So it should be good enough, at least as the temporary solution.

https://user-images.githubusercontent.com/7645683/143438481-d89b5fa5-e72b-4b9e-868d-df8ad86cddec.mov

