### PR TITLE
Don't show errors when getting nonexistent settings

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -926,13 +926,13 @@ Error ProjectSettings::_save_custom_bnd(const String &p_file) { // add other par
 Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_custom, const Vector<String> &p_custom_features, bool p_merge_with_current) {
 	ERR_FAIL_COND_V_MSG(p_path == "", ERR_INVALID_PARAMETER, "Project settings save path cannot be empty.");
 
-	PackedStringArray project_features = get("application/config/features");
+	PackedStringArray project_features = has_setting("application/config/features") ? (PackedStringArray)get_setting("application/config/features") : PackedStringArray();
 	// If there is no feature list currently present, force one to generate.
 	if (project_features.is_empty()) {
 		project_features = ProjectSettings::get_required_features();
 	}
 	// Check the rendering API.
-	const String rendering_api = get("rendering/quality/driver/driver_name");
+	const String rendering_api = has_setting("rendering/quality/driver/driver_name") ? (String)get_setting("rendering/quality/driver/driver_name") : String();
 	if (rendering_api != "") {
 		// Add the rendering API as a project feature if it doesn't already exist.
 		if (!project_features.has(rendering_api)) {
@@ -952,7 +952,7 @@ Error ProjectSettings::save_custom(const String &p_path, const CustomMap &p_cust
 		}
 	}
 	project_features = _trim_to_supported_features(project_features);
-	set("application/config/features", project_features);
+	set_setting("application/config/features", project_features);
 
 	Set<_VCSort> vclist;
 


### PR DESCRIPTION
Follow-up fix to #31171 and #55303. I was focused on getting it working last night but I forgot to check the console for errors. The current master does work except for the fact that it shows these errors:

```
ERROR: Property not found: application/config/features
   at: _get (core/config/project_settings.cpp:320)
ERROR: Property not found: rendering/quality/driver/driver_name
   at: _get (core/config/project_settings.cpp:320)
```

(btw, get_setting and set_setting seem to just be simple wrappers for get and set, but it's definitely good to use these for consistency with has_setting since there is no "has" without "_setting").