### PR TITLE
Decrease the default dynamic range in VoxelGIData to 2.0

### DIFF
--- a/doc/classes/VoxelGIData.xml
+++ b/doc/classes/VoxelGIData.xml
@@ -60,7 +60,7 @@
 		<member name="bias" type="float" setter="set_bias" getter="get_bias" default="1.5">
 			The normal bias to use for indirect lighting and reflections. Higher values reduce self-reflections visible in non-rough materials, at the cost of more visible light leaking and flatter-looking indirect lighting. To prioritize hiding self-reflections over lighting quality, set [member bias] to [code]0.0[/code] and [member normal_bias] to a value between [code]1.0[/code] and [code]2.0[/code].
 		</member>
-		<member name="dynamic_range" type="float" setter="set_dynamic_range" getter="get_dynamic_range" default="4.0">
+		<member name="dynamic_range" type="float" setter="set_dynamic_range" getter="get_dynamic_range" default="2.0">
 			The dynamic range to use ([code]1.0[/code] represents a low dynamic range scene brightness). Higher values can be used to provide brighter indirect lighting, at the cost of more visible color banding in dark areas (both in indirect lighting and reflections). To avoid color banding, it's recommended to use the lowest value that does not result in visible light clipping.
 		</member>
 		<member name="energy" type="float" setter="set_energy" getter="get_energy" default="1.0">

--- a/scene/3d/voxel_gi.h
+++ b/scene/3d/voxel_gi.h
@@ -45,7 +45,7 @@ class VoxelGIData : public Resource {
 	AABB bounds;
 	Vector3 octree_size;
 
-	float dynamic_range = 4.0;
+	float dynamic_range = 2.0;
 	float energy = 1.0;
 	float bias = 1.5;
 	float normal_bias = 0.0;

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -1099,7 +1099,7 @@ private:
 		AABB bounds;
 		Vector3i octree_size;
 
-		float dynamic_range = 4.0;
+		float dynamic_range = 2.0;
 		float energy = 1.0;
 		float bias = 1.4;
 		float normal_bias = 0.0;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/55331.

This reduces visible banding in indirect lighting and reflections. Sharp reflections now match more closely the original scene.
This change has no performance impact.

The downside of this change is that clipping may appear in reflections in *extremely* bright scenes, but this should not be a concern in most scenes.

**Testing project:** [test_gi_texture.zip](https://github.com/godotengine/godot/files/7605443/test_gi_texture.zip)

## Preview

### Before

*Noticeable banding in VoxelGI reflections.*

![2021-11-26_00 49 16](https://user-images.githubusercontent.com/180032/143508581-ac7cc523-8576-42c1-b1f8-251e2a7a3f88.png)

### After

*Less noticeable banding in VoxelGI reflections.*

![2021-11-26_00 49 21](https://user-images.githubusercontent.com/180032/143508584-5c0b79f5-b37a-4acb-8829-9f9080600bb4.png)