### PR TITLE
Fix viewport gui input order for 3.x

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -113,6 +113,12 @@
 				Returns [code]true[/code] if there are visible modals on-screen.
 			</description>
 		</method>
+		<method name="gui_input">
+			<return type="void" />
+			<argument index="0" name="local_event" type="InputEvent" />
+			<description>
+			</description>
+		</method>
 		<method name="gui_is_dragging" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -166,6 +166,33 @@ void ViewportContainer::_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
+void ViewportContainer::_gui_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(p_event.is_null());
+
+	if (Engine::get_singleton()->is_editor_hint()) {
+		return;
+	}
+
+	Transform2D xform = get_global_transform();
+
+	if (stretch) {
+		Transform2D scale_xf;
+		scale_xf.scale(Vector2(shrink, shrink));
+		xform *= scale_xf;
+	}
+
+	Ref<InputEvent> ev = p_event;
+
+	for (int i = 0; i < get_child_count(); i++) {
+		Viewport *c = Object::cast_to<Viewport>(get_child(i));
+		if (!c || c->is_input_disabled()) {
+			continue;
+		}
+
+		c->gui_input(ev);
+	}
+}
+
 void ViewportContainer::_unhandled_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
@@ -195,6 +222,7 @@ void ViewportContainer::_unhandled_input(const Ref<InputEvent> &p_event) {
 
 void ViewportContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_unhandled_input", "event"), &ViewportContainer::_unhandled_input);
+	ClassDB::bind_method(D_METHOD("_gui_input", "event"), &ViewportContainer::_gui_input);
 	ClassDB::bind_method(D_METHOD("_input", "event"), &ViewportContainer::_input);
 	ClassDB::bind_method(D_METHOD("set_stretch", "enable"), &ViewportContainer::set_stretch);
 	ClassDB::bind_method(D_METHOD("is_stretch_enabled"), &ViewportContainer::is_stretch_enabled);

--- a/scene/gui/viewport_container.h
+++ b/scene/gui/viewport_container.h
@@ -48,6 +48,7 @@ public:
 	bool is_stretch_enabled() const;
 
 	void _input(const Ref<InputEvent> &p_event);
+	void _gui_input(const Ref<InputEvent> &p_event);
 	void _unhandled_input(const Ref<InputEvent> &p_event);
 	void set_stretch_shrink(int p_shrink);
 	int get_stretch_shrink() const;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1409,6 +1409,7 @@ void Viewport::_vp_input(const Ref<InputEvent> &p_ev) {
 
 	Ref<InputEvent> ev = _make_input_local(p_ev);
 	input(ev);
+	gui_input(ev);
 }
 
 void Viewport::_vp_unhandled_input(const Ref<InputEvent> &p_ev) {
@@ -2801,13 +2802,20 @@ void Viewport::input(const Ref<InputEvent> &p_event) {
 	local_input_handled = false;
 
 	if (!is_input_handled()) {
-		get_tree()->_call_input_pause(input_group, "_input", p_event); //not a bug, must happen before GUI, order is _input -> gui input -> _unhandled input
+		get_tree()->_call_input_pause(input_group, "_input", p_event);
 	}
+
+	//get_tree()->call_group(SceneTree::GROUP_CALL_REVERSE|SceneTree::GROUP_CALL_REALTIME|SceneTree::GROUP_CALL_MULIILEVEL,gui_input_group,"_gui_input",p_event); //special one for GUI, as controls use their own process check
+}
+
+void Viewport::gui_input(const Ref<InputEvent> &p_event) {
+	ERR_FAIL_COND(!is_inside_tree());
+
+	local_input_handled = false;
 
 	if (!is_input_handled()) {
 		_gui_input_event(p_event);
 	}
-	//get_tree()->call_group(SceneTree::GROUP_CALL_REVERSE|SceneTree::GROUP_CALL_REALTIME|SceneTree::GROUP_CALL_MULIILEVEL,gui_input_group,"_gui_input",p_event); //special one for GUI, as controls use their own process check
 }
 
 void Viewport::unhandled_input(const Ref<InputEvent> &p_event) {
@@ -3178,6 +3186,7 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_viewport_rid"), &Viewport::get_viewport_rid);
 	ClassDB::bind_method(D_METHOD("input", "local_event"), &Viewport::input);
+	ClassDB::bind_method(D_METHOD("gui_input", "local_event"), &Viewport::gui_input);
 	ClassDB::bind_method(D_METHOD("unhandled_input", "local_event"), &Viewport::unhandled_input);
 
 	ClassDB::bind_method(D_METHOD("update_worlds"), &Viewport::update_worlds);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -524,6 +524,7 @@ public:
 	bool is_using_own_world() const;
 
 	void input(const Ref<InputEvent> &p_event);
+	void gui_input(const Ref<InputEvent> &p_event);
 	void unhandled_input(const Ref<InputEvent> &p_event);
 
 	void set_disable_input(bool p_disable);


### PR DESCRIPTION
Backport #55300 to 3.x to fix #48401.

This creates a new public function `Viewport::gui_input` and changes the behavior of `Viewport::input` which will no longer handle gui inputs. This might be considered as a breaking change.

For pojects using subviewports with GUI this bug is terrible, as no GUI Control node over the viewport can receive any gui_input, such as menus, popup dialogs, etc.



