### PR TITLE
Make delete_lines work correctly regardless of the selection

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1314,10 +1314,10 @@ void CodeTextEditor::delete_lines() {
 		int count = Math::abs(to_line - from_line) + 1;
 
 		text_editor->set_caret_line(from_line, false);
+		text_editor->deselect();
 		for (int i = 0; i < count; i++) {
 			_delete_line(from_line);
 		}
-		text_editor->deselect();
 	} else {
 		_delete_line(text_editor->get_caret_line());
 	}


### PR DESCRIPTION
Fix #54766
This turned out to be a surprisingly simple fix once I found what was causing the issue (selection remained while deleting lines, so the internal delete functions detected a selection and removed that in addition to the intended amount). I can't find a particular reason for deselect() needing to be after the loop, so hopefully this doesn't cause any problems - it didn't seem to in any of my tests though.