### PR TITLE
[HTML5] Fix focus (again) in Firefox's iframes.

### DIFF
--- a/platform/javascript/js/libs/library_godot_input.js
+++ b/platform/javascript/js/libs/library_godot_input.js
@@ -393,7 +393,9 @@ const GodotInput = {
 			const rect = canvas.getBoundingClientRect();
 			const pos = GodotInput.computePosition(evt, rect);
 			const modifiers = GodotInput.getModifiers(evt);
-			if (p_pressed && document.activeElement !== GodotConfig.canvas) {
+			// Since the event is consumed, focus manually.
+			// NOTE: The iframe container may not have focus yet, so focus even when already active.
+			if (p_pressed) {
 				GodotConfig.canvas.focus();
 			}
 			if (func(p_pressed, evt.button, pos[0], pos[1], modifiers)) {
@@ -412,7 +414,9 @@ const GodotInput = {
 		const func = GodotRuntime.get_func(callback);
 		const canvas = GodotConfig.canvas;
 		function touch_cb(type, evt) {
-			if (type === 0 && document.activeElement !== GodotConfig.canvas) {
+			// Since the event is consumed, focus manually.
+			// NOTE: The iframe container may not have focus yet, so focus even when already active.
+			if (type === 0) {
 				GodotConfig.canvas.focus();
 			}
 			const rect = canvas.getBoundingClientRect();


### PR DESCRIPTION
This actually makes sense(?), when running inside an iframe the active element might be our canvas, while the iframe itself is not active in the parent window. Since we consume the event, the iframe does not get focused in Firefox (but does in Chromium-based browsers), so we must always call focus to handle such occasions.

Fixes #55248