### PR TITLE
Fix wrong comparison with default values

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -511,7 +511,7 @@ void PlaceHolderScriptInstance::update(const List<PropertyInfo> &p_properties, c
 		Variant defval;
 		if (script->get_property_default_value(E->key(), defval)) {
 			//remove because it's the same as the default value
-			if (defval == E) {
+			if (defval == E->get()) {
 				to_remove.push_back(E->key());
 			}
 		}


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes #55321

It was changed with the range iterators refactoring (#50511)
