### PR TITLE
[HTML5] Use compatibility function for glGetBufferSubData.

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -45,11 +45,6 @@
 #include "shaders/cubemap_filter.glsl.gen.h"
 #include "shaders/particles.glsl.gen.h"
 
-// WebGL 2.0 has no MapBufferRange/UnmapBuffer, but offers a non-ES style BufferSubData API via glGetBufferSubData instead.
-#ifdef __EMSCRIPTEN__
-#include <webgl/webgl2.h>
-#endif
-
 template <class K>
 class ThreadedCallableQueue;
 class RasterizerCanvasGLES3;

--- a/platform/javascript/SCsub
+++ b/platform/javascript/SCsub
@@ -4,6 +4,7 @@ Import("env")
 
 javascript_files = [
     "audio_driver_javascript.cpp",
+    "godot_webgl2.cpp",
     "http_client_javascript.cpp",
     "javascript_singleton.cpp",
     "javascript_main.cpp",

--- a/platform/javascript/godot_webgl2.cpp
+++ b/platform/javascript/godot_webgl2.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  platform_config.h                                                    */
+/*  godot_webgl2.cpp                                                     */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,6 +28,12 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include <alloca.h>
+#include "godot_webgl2.h"
 
-#define GLES3_INCLUDE_H "platform/javascript/godot_webgl2.h"
+extern "C" {
+extern void godot_js_display_glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid *data);
+}
+
+void glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid *data) {
+	godot_js_display_glGetBufferSubData(target, offset, size, data);
+}

--- a/platform/javascript/godot_webgl2.h
+++ b/platform/javascript/godot_webgl2.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  platform_config.h                                                    */
+/*  godot_webgl2.h                                                       */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,6 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include <alloca.h>
+#ifndef GODOT_WEBGL2_H
+#include "GLES3/gl3.h"
 
-#define GLES3_INCLUDE_H "platform/javascript/godot_webgl2.h"
+// We could include "webgl/webgl2.h", but old (< 2.0.17) emscripten versions do not have it, so use our own wrapper instead.
+void glGetBufferSubData(GLenum target, GLintptr offset, GLsizeiptr size, GLvoid *data);
+
+#endif

--- a/platform/javascript/js/libs/library_godot_display.js
+++ b/platform/javascript/js/libs/library_godot_display.js
@@ -320,6 +320,18 @@ const GodotDisplay = {
 		},
 	},
 
+	// This is implemented as "glGetBufferSubData" in new emscripten versions.
+	// Since we have to support older (pre 2.0.17) emscripten versions, we add this wrapper function instead.
+	godot_js_display_glGetBufferSubData__sig: 'viiii',
+	godot_js_display_glGetBufferSubData__deps: ['$GL', 'emscripten_webgl_get_current_context'],
+	godot_js_display_glGetBufferSubData: function (target, offset, size, data) {
+		const gl_context_handle = _emscripten_webgl_get_current_context(); // eslint-disable-line no-undef
+		const gl = GL.getContext(gl_context_handle);
+		if (gl) {
+			gl.GLctx['getBufferSubData'](target, offset, HEAPU8, data, size);
+		}
+	},
+
 	godot_js_display_is_swap_ok_cancel__sig: 'i',
 	godot_js_display_is_swap_ok_cancel: function () {
 		const win = (['Windows', 'Win64', 'Win32', 'WinCE']);


### PR DESCRIPTION
The "webgl/webgl2.h" include provides that function, but it's not available in emscripten versions < 2.0.17 .

Since we need to support emscripten 1.39.9 (mono builds), this commit adds a JS function in library_godot_display.js as a compatibility layer for it, and implement glGetBufferSubData by funneling the call to that function (so we don't have name collisions JS-side with recent emcc).

All those hacks are now moved to the platform directory instead of being ifdefs inside the drivers implementations.

~Draft while I try the mono build.~ Edit: Built fine, ready for review.