### PR TITLE
[3.x] Fix potential infinite loop when connecting HTTPClient

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -337,7 +337,7 @@ Error HTTPClient::poll() {
 
 					Error err = ERR_BUG; // Should be at least one entry.
 					while (ip_candidates.size() > 0) {
-						err = tcp_connection->connect_to_host(ip_candidates.front(), conn_port);
+						err = tcp_connection->connect_to_host(ip_candidates.pop_front(), conn_port);
 						if (err == OK) {
 							break;
 						}


### PR DESCRIPTION
Fixes a typo in the previous PR. It would be infinite loop when the host is resolved but `connect_to_host` failed.

`master` version is included in #47257. I'll make a separate PR if that's inappropriate.