### PR TITLE
Fixed PlaybackData in AnimationPlayer

### DIFF
--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -198,7 +198,7 @@ private:
 
 	struct PlaybackData {
 		AnimationData *from = nullptr;
-		float pos = 0.0;
+		double pos = 0.0;
 		float speed_scale = 1.0;
 	};
 


### PR DESCRIPTION
Fixed #54815.

AnimationPlayer's Playback time/position should be stored with type of `double`.

Before:

https://user-images.githubusercontent.com/61938263/143660334-584c3952-154b-4a30-bf61-b416626c2432.mov

After:

https://user-images.githubusercontent.com/61938263/143660184-a245cd84-4f3f-4b91-99bb-37a02c0c7253.mov

[animation_player_bug.zip](https://github.com/godotengine/godot/files/7610877/animation_player_bug.zip)