### PR TITLE
Fix editor freezing and eventually crashing when importing resources per drag & drop

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -529,7 +529,8 @@ bool EditorFileSystem::_update_scan_actions() {
 	Vector<String> reimports;
 	Vector<String> reloads;
 
-	for (const ItemAction &ia : scan_actions) {
+	while (scan_actions.size() > 0) {
+		const ItemAction &ia = scan_actions[0];
 		switch (ia.action) {
 			case ItemAction::ACTION_NONE: {
 			} break;
@@ -608,6 +609,7 @@ bool EditorFileSystem::_update_scan_actions() {
 
 			} break;
 		}
+		scan_actions.pop_front();
 	}
 
 	if (_scan_extensions()) {
@@ -639,7 +641,6 @@ bool EditorFileSystem::_update_scan_actions() {
 	if (reloads.size()) {
 		emit_signal(SNAME("resources_reload"), reloads);
 	}
-	scan_actions.clear();
 
 	return fs_changed;
 }
@@ -979,7 +980,7 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, const 
 				int idx = p_dir->find_file_index(f);
 
 				if (idx == -1) {
-					//never seen this file, add actition to add it
+					//never seen this file, add action to add it
 					EditorFileSystemDirectory::FileInfo *fi = memnew(EditorFileSystemDirectory::FileInfo);
 					fi->file = f;
 
@@ -1000,15 +1001,6 @@ void EditorFileSystem::_scan_fs_changes(EditorFileSystemDirectory *p_dir, const 
 						ia.dir = p_dir;
 						ia.file = f;
 						ia.new_file = fi;
-						scan_actions.push_back(ia);
-					}
-
-					if (import_extensions.has(ext)) {
-						//if it can be imported, and it was added, it needs to be reimported
-						ItemAction ia;
-						ia.action = ItemAction::ACTION_FILE_TEST_REIMPORT;
-						ia.dir = p_dir;
-						ia.file = f;
 						scan_actions.push_back(ia);
 					}
 


### PR DESCRIPTION
Fixes #53871

When scanning for new and modified resource files, the `EditorFileSystem` class creates duplicate item actions when assets are imported via drag & drop. This causes the import process to fail with an error dialog that freezes the engine. Closing the dialog finally crashes the editor. This PR prevents duplicate file actions to be created.

Might also fix #55087, but more information from OP is necessary to be sure.

## Details
The `EditorFileSystem` class checks the file system for changes due to importing, modifying and deleting resources. This is done on multiple threads that fill the `scan_actions` list with actions to perform on the affected files. It gets processed in `EditorFileSystem::_update_scan_actions`. After all actions have been processed, the list is reset at the end of that function.

The problem arises because the function can get called again before it reaches the part that clears `scan_actions`, leaving all the actions that have *already* been processed in `scan_actions`, adding new actions on top, and running the function again. This will perform the actions from the previous run again along with the new ones. This causes numerous problems, the most visible ones are the reported issue and the fact that newly imported resources appear to have been imported twice. This is also mentioned in the issue above.

The PR does two things:
1. An unnecessary item action was removed from the piece of code that reacts to newly imported assets. The same action is already created immediately after and the way it works now seems more consistent to me.
2. `EditorFileSystem::_update_scan_actions` handles the processing of `scan_actions` like a FIFO queue and removes a scanned action from the list as soon as it is done with it. This way, no action will be proccessed twice even if there are new actions added to the end of the queue before the function is done running.