### PR TITLE
TextureProgress: `progress_offset` now added to relative center

### DIFF
--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -501,6 +501,7 @@ void TextureProgressBar::_notification(int p_what) {
 								}
 
 								p *= get_relative_center();
+								p += progress_offset;
 								p = p.floor();
 								draw_line(p - Point2(8, 0), p + Point2(8, 0), Color(0.9, 0.5, 0.5), 2);
 								draw_line(p - Point2(0, 8), p + Point2(0, 8), Color(0.9, 0.5, 0.5), 2);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

`progress_offset` of TextureProgress wasn't moving the reference cross. Hopefully this would fix it.

fixes #55338 