### PR TITLE
Allow disabling the depth prepass in the Vulkan Clustered backend

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1556,11 +1556,9 @@
 		<member name="rendering/camera/depth_of_field/depth_of_field_use_jitter" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], jitters DOF samples to make effect slightly blurrier and hide lines created from low sample rates. This can result in a slightly grainy appearance when used with a low number of samples.
 		</member>
-		<member name="rendering/driver/depth_prepass/disable_for_vendors" type="String" setter="" getter="" default="&quot;PowerVR,Mali,Adreno,Apple&quot;">
-			Disables depth pre-pass for some GPU vendors (usually mobile), as their architecture already does this.
-		</member>
 		<member name="rendering/driver/depth_prepass/enable" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], performs a previous depth pass before rendering materials. This increases performance in scenes with high overdraw, when complex materials and lighting are used.
+			If [code]true[/code], performs a previous depth pass before rendering 3D materials. This increases performance significantly in scenes with high overdraw, when complex materials and lighting are used. However, in scenes with few occluded surfaces, the depth prepass may reduce performance. If your game is viewed from a fixed angle that makes it easy to avoid overdraw (such as top-down or side-scrolling perspective), consider disabling the depth prepass to improve performance. This setting can be changed at run-time to optimize performance depending on the scene currently being viewed.
+			[b]Note:[/b] Only supported when using the Vulkan Clustered backend (not Vulkan Mobile or OpenGL). When using Vulkan Mobile or OpenGL, there is no depth prepass performed.
 		</member>
 		<member name="rendering/driver/driver_name" type="String" setter="" getter="" default="&quot;vulkan&quot;">
 			The video driver to use.

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1398,7 +1398,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 	bool debug_voxelgis = get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_VOXEL_GI_ALBEDO || get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_VOXEL_GI_LIGHTING || get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_VOXEL_GI_EMISSION;
 	bool debug_sdfgi_probes = get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_SDFGI_PROBES;
-	bool depth_pre_pass = depth_framebuffer.is_valid();
+	bool depth_pre_pass = bool(GLOBAL_GET("rendering/driver/depth_prepass/enable")) && depth_framebuffer.is_valid();
 
 	bool using_ssao = depth_pre_pass && p_render_data->render_buffers.is_valid() && p_render_data->environment.is_valid() && environment_is_ssao_enabled(p_render_data->environment);
 	bool continue_depth = false;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2873,7 +2873,6 @@ RenderingServer::RenderingServer() {
 	GLOBAL_DEF("rendering/shading/overrides/force_blinn_over_ggx.mobile", true);
 
 	GLOBAL_DEF("rendering/driver/depth_prepass/enable", true);
-	GLOBAL_DEF("rendering/driver/depth_prepass/disable_for_vendors", "PowerVR,Mali,Adreno,Apple");
 
 	GLOBAL_DEF_RST("rendering/textures/default_filters/use_nearest_mipmap_filter", false);
 	GLOBAL_DEF_RST("rendering/textures/default_filters/anisotropic_filtering_level", 2);


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/55289.

In scenes that have little to no overdraw, disabling the depth prepass can give a small performance boost. Nonetheless, in most other scenarios, the depth prepass should be left enabled as it improves performance significantly.

Disabling the depth prepass is already possible in the `3.x` GLES3 renderer, so this brings the Vulkan Clustered renderer to feature parity in this aspect.

## Preview

*Look at the FPS counter in the top-right corner.*

### Simple scene with little overdraw

| Depth prepass enabled | Depth prepass disabled
|-|-|
| ![2021-11-27_17 50 24](https://user-images.githubusercontent.com/180032/143690142-341261a3-cc20-404c-91eb-9b41cef79798.png) | ![2021-11-27_17 50 36](https://user-images.githubusercontent.com/180032/143690145-acca72fb-b987-4377-a116-729fb53427b9.png) |

### Complex scene with lots of overdraw

| Depth prepass enabled | Depth prepass disabled
|-|-|
| ![2021-11-27_17 50 44](https://user-images.githubusercontent.com/180032/143690146-4296542f-37be-4a07-ab19-0da5ff06a320.png) | ![2021-11-27_17 50 51](https://user-images.githubusercontent.com/180032/143690148-dcf4b5ed-7923-4dd8-8d76-2a46440441ae.png) |