### PR TITLE
Automatically fade to Z far in environment depth fog

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -167,6 +167,7 @@
 		</member>
 		<member name="far" type="float" setter="set_far" getter="get_far" default="4000.0">
 			The distance to the far culling boundary for this camera relative to its local Z axis.
+			[b]Note:[/b] When [member Environment.fog_enabled] is [code]true[/code], this is used as a base for open world fog fading (with fog starting at 50% of the Z far distance).
 		</member>
 		<member name="fov" type="float" setter="set_fov" getter="get_fov" default="75.0">
 			The camera's field of view angle (in degrees). Only applicable in perspective mode. Since [member keep_aspect] locks one axis, [code]fov[/code] sets the other axis' field of view angle.

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -99,6 +99,7 @@
 		</member>
 		<member name="fog_enabled" type="bool" setter="set_fog_enabled" getter="is_fog_enabled" default="false">
 			If [code]true[/code], fog effects are enabled.
+			[b]Note:[/b] Enabling fog automatically fades starting from 50% of the [member Camera3D.far] distance, regardless of [member fog_depth_density]. This is used for open world fog fading. To disable this, increase the camera's [member Camera3D.far] property.
 		</member>
 		<member name="fog_height" type="float" setter="set_fog_height" getter="get_fog_height" default="0.0">
 			The height at which the height fog effect begins.


### PR DESCRIPTION
This is useful for open world games to smoothly fade out distant scenery in the fog. Exponential fog cannot do this on its own, so quadratic fog is combined with exponential fog using a `max()` function. The quadratic fog start distance is automatically set at 50% of the camera's Z far distance, which I've found to be the best compromise between visibility and smoothness.

If you don't want quadratic fog, you can increase the Camera's Z far property enough so that the linear fog starts outside the play area.

This closes https://github.com/godotengine/godot-proposals/issues/3429.

**Testing project:** [test_fog_fade.zip](https://github.com/godotengine/godot/files/7612224/test_fog_fade.zip)
Set the editor camera's Z far distance to 50 in the **View** menu at the top of the 3D editor.

## Preview

### No fog

![2021-11-27_19 00 50](https://user-images.githubusercontent.com/180032/143691988-8ff68259-e94a-403e-b386-ff7bf8931616.png)

### Exponential fog (current)

![2021-11-27_19 01 29](https://user-images.githubusercontent.com/180032/143691991-67564e24-0ca8-4cc3-bac0-44d79bc71b68.png)

### Exponential fog + quadratic fog (new)

![2021-11-27_19 12 22](https://user-images.githubusercontent.com/180032/143698419-937af182-7990-4cfd-aa3c-0315033b1af2.png)

### Quadratic fog only (exponential density = 0)

*This can be used for pure quadratic fog when having fog up close is undesired.*

![2021-11-27_19 12 30](https://user-images.githubusercontent.com/180032/143698456-67e295e7-c254-4f00-bbde-67f1a97dbffd.png)