### PR TITLE
Fixed gizmo bug when `Skeleton3DEditor` is re-generated

### DIFF
--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -964,6 +964,7 @@ void Skeleton3DEditor::select_bone(int p_idx) {
 
 Skeleton3DEditor::~Skeleton3DEditor() {
 	if (skeleton) {
+		select_bone(-1);
 #ifdef TOOLS_ENABLED
 		skeleton->disconnect("show_rest_only_changed", callable_mp(this, &Skeleton3DEditor::_update_gizmo_visible));
 		skeleton->disconnect("bone_enabled_changed", callable_mp(this, &Skeleton3DEditor::_bone_enabled_changed));
@@ -973,6 +974,7 @@ Skeleton3DEditor::~Skeleton3DEditor() {
 #endif
 		handles_mesh_instance->get_parent()->remove_child(handles_mesh_instance);
 	}
+	edit_mode_toggled(false);
 
 	handles_mesh_instance->queue_delete();
 


### PR DESCRIPTION
An inspector is re-generated internally when changing rotation mode is changed (#54084), but Skeleton3DEditor destructor doesn't deselect bone. So I fixed it.

Note:
The bone selection information is held by the `Skeleton3DEditor`, and is synchronized with the `Node3DSubGizmo` selection while the `Skeleton3DEditor` is existing.

Once the `Skeleton3DEditor` is destroyed due to the inspector's re-generating, the synchronization is broken and there is no other way to deselect it. The `Node3DSubGizmo` still contains selection information, but the inspector does not notify what reason it was generated, so it is dangerous for the `Skeleton3DEditor` to revert to edit mode based only on the state of the `Node3DSubGizmo`. Since rotation mode changes are not often done, I think this implementation is not a problem.

~~And, if we want to implement in the future that bones keep their own individual rotation mode, the behavior of re-generating when redrawing the inspector may need to be changed.~~ Probably don't worry about this line, I've discussed and agreed with reduz to implement the element for Quaternion within Inspector.

---

Before:

https://user-images.githubusercontent.com/61938263/143719238-63b401ce-9cba-4e4e-b944-4e07a1320918.mov

After:

https://user-images.githubusercontent.com/61938263/143719246-5f92b9d1-452d-4c84-a127-12756698549e.mov
