### PR TITLE
Adds tonemapping to GLES2 render path via forward shader

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -378,6 +378,10 @@ public:
 		bool glow_bicubic_upscale;
 		bool glow_high_quality;
 
+		VS::EnvironmentToneMapper tone_mapper;
+		float tone_mapper_exposure;
+		float tone_mapper_exposure_white;
+    
 		bool dof_blur_far_enabled;
 		float dof_blur_far_distance;
 		float dof_blur_far_transition;

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -300,7 +300,6 @@ void Environment::_validate_property(PropertyInfo &property) const {
 
 	static const char *high_end_prefixes[] = {
 		"auto_exposure_",
-		"tonemap_",
 		"ss_reflections_",
 		"ssao_",
 		nullptr


### PR DESCRIPTION
(No postprocess necessary.)

* WILL change appearance of existing scenes
* WILL change behavior of glow and other GLES2 postprocessing effects
* WILL NOT be physically correct because the GLES2 pipeline treats all data as sRGB, not linear

(Note: bring up the white point a bit to see the tonemapping.)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
