### PR TITLE
Enable sorting of operator methods in class documentation.

### DIFF
--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -70,18 +70,29 @@ public:
 		Vector<int> errors_returned;
 		bool operator<(const MethodDoc &p_method) const {
 			if (name == p_method.name) {
-				// Must be a constructor since there is no overloading.
-				// We want this arbitrary order for a class "Foo":
-				// - 1. Default constructor: Foo()
-				// - 2. Copy constructor: Foo(Foo)
-				// - 3+. Other constructors Foo(Bar, ...) based on first argument's name
-				if (arguments.size() == 0 || p_method.arguments.size() == 0) { // 1.
+				// Must be an operator or a constructor since there is no other overloading
+				if (name.left(8) == "operator") {
+					if (arguments.size() == p_method.arguments.size()) {
+						if (arguments.size() == 0) {
+							return false;
+						}
+						return arguments[0].type < p_method.arguments[0].type;
+					}
 					return arguments.size() < p_method.arguments.size();
+				} else {
+					// Must be a constructor
+					// We want this arbitrary order for a class "Foo":
+					// - 1. Default constructor: Foo()
+					// - 2. Copy constructor: Foo(Foo)
+					// - 3+. Other constructors Foo(Bar, ...) based on first argument's name
+					if (arguments.size() == 0 || p_method.arguments.size() == 0) { // 1.
+						return arguments.size() < p_method.arguments.size();
+					}
+					if (arguments[0].type == return_type || p_method.arguments[0].type == p_method.return_type) { // 2.
+						return (arguments[0].type == return_type) || (p_method.arguments[0].type != p_method.return_type);
+					}
+					return arguments[0] < p_method.arguments[0];
 				}
-				if (arguments[0].type == return_type || p_method.arguments[0].type == p_method.return_type) { // 2.
-					return (arguments[0].type == return_type) || (p_method.arguments[0].type != p_method.return_type);
-				}
-				return arguments[0] < p_method.arguments[0];
 			}
 			return name < p_method.name;
 		}

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -225,17 +225,17 @@
 			</description>
 		</operator>
 		<operator name="operator *">
-			<return type="Transform2D" />
-			<argument index="0" name="right" type="Transform2D" />
-			<description>
-				Composes these two transformation matrices by multiplying them together. This has the effect of transforming the second transform (the child) by the first transform (the parent).
-			</description>
-		</operator>
-		<operator name="operator *">
 			<return type="Rect2" />
 			<argument index="0" name="right" type="Rect2" />
 			<description>
 				Transforms (multiplies) the [Rect2] by the given [Transform2D] matrix.
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Transform2D" />
+			<argument index="0" name="right" type="Transform2D" />
+			<description>
+				Composes these two transformation matrices by multiplying them together. This has the effect of transforming the second transform (the child) by the first transform (the parent).
 			</description>
 		</operator>
 		<operator name="operator *">

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -152,6 +152,13 @@
 			</description>
 		</operator>
 		<operator name="operator *">
+			<return type="AABB" />
+			<argument index="0" name="right" type="AABB" />
+			<description>
+				Transforms (multiplies) the [AABB] by the given [Transform3D] matrix.
+			</description>
+		</operator>
+		<operator name="operator *">
 			<return type="PackedVector3Array" />
 			<argument index="0" name="right" type="PackedVector3Array" />
 			<description>
@@ -163,13 +170,6 @@
 			<argument index="0" name="right" type="Transform3D" />
 			<description>
 				Composes these two transformation matrices by multiplying them together. This has the effect of transforming the second transform (the child) by the first transform (the parent).
-			</description>
-		</operator>
-		<operator name="operator *">
-			<return type="AABB" />
-			<argument index="0" name="right" type="AABB" />
-			<description>
-				Transforms (multiplies) the [AABB] by the given [Transform3D] matrix.
 			</description>
 		</operator>
 		<operator name="operator *">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -358,19 +358,19 @@
 		</operator>
 		<operator name="operator *">
 			<return type="Vector2" />
+			<argument index="0" name="right" type="Transform2D" />
+			<description>
+				Inversely transforms (multiplies) the [Vector2] by the given [Transform2D] transformation matrix.
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector2" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
 				Multiplies each component of the [Vector2] by the components of the given [Vector2].
 				[codeblock]
 				print(Vector2(10, 20) * Vector2(3, 4)) # Prints "(30, 80)"
 				[/codeblock]
-			</description>
-		</operator>
-		<operator name="operator *">
-			<return type="Vector2" />
-			<argument index="0" name="right" type="Transform2D" />
-			<description>
-				Inversely transforms (multiplies) the [Vector2] by the given [Transform2D] transformation matrix.
 			</description>
 		</operator>
 		<operator name="operator *">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -373,16 +373,6 @@
 		</operator>
 		<operator name="operator *">
 			<return type="Vector3" />
-			<argument index="0" name="right" type="Vector3" />
-			<description>
-				Multiplies each component of the [Vector3] by the components of the given [Vector3].
-				[codeblock]
-				print(Vector3(10, 20, 30) * Vector3(3, 4, 5)) # Prints "(30, 80, 150)"
-				[/codeblock]
-			</description>
-		</operator>
-		<operator name="operator *">
-			<return type="Vector3" />
 			<argument index="0" name="right" type="Basis" />
 			<description>
 				Inversely transforms (multiplies) the [Vector3] by the given [Basis] matrix.
@@ -400,6 +390,16 @@
 			<argument index="0" name="right" type="Transform3D" />
 			<description>
 				Inversely transforms (multiplies) the [Vector3] by the given [Transform3D] transformation matrix.
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="Vector3" />
+			<argument index="0" name="right" type="Vector3" />
+			<description>
+				Multiplies each component of the [Vector3] by the components of the given [Vector3].
+				[codeblock]
+				print(Vector3(10, 20, 30) * Vector3(3, 4, 5)) # Prints "(30, 80, 150)"
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator *">

--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -62,10 +62,13 @@
 			</description>
 		</operator>
 		<operator name="operator *">
-			<return type="float" />
-			<argument index="0" name="right" type="float" />
+			<return type="Color" />
+			<argument index="0" name="right" type="Color" />
 			<description>
-				Multiplies two [float]s.
+				Multiplies each component of the [Color] by the given [float].
+				[codeblock]
+				print(1.5 * Color(0.5, 0.5, 0.5)) # Color(0.75, 0.75, 0.75)
+				[/codeblock]
 			</description>
 		</operator>
 		<operator name="operator *">
@@ -113,13 +116,10 @@
 			</description>
 		</operator>
 		<operator name="operator *">
-			<return type="Color" />
-			<argument index="0" name="right" type="Color" />
+			<return type="float" />
+			<argument index="0" name="right" type="float" />
 			<description>
-				Multiplies each component of the [Color] by the given [float].
-				[codeblock]
-				print(1.5 * Color(0.5, 0.5, 0.5)) # Color(0.75, 0.75, 0.75)
-				[/codeblock]
+				Multiplies two [float]s.
 			</description>
 		</operator>
 		<operator name="operator *">

--- a/doc/classes/int.xml
+++ b/doc/classes/int.xml
@@ -132,20 +132,6 @@
 			</description>
 		</operator>
 		<operator name="operator *">
-			<return type="int" />
-			<argument index="0" name="right" type="int" />
-			<description>
-				Multiplies two [int]s.
-			</description>
-		</operator>
-		<operator name="operator *">
-			<return type="float" />
-			<argument index="0" name="right" type="float" />
-			<description>
-				Multiplies an [int] and a [float]. The result is a [float].
-			</description>
-		</operator>
-		<operator name="operator *">
 			<return type="Vector2" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
@@ -174,6 +160,20 @@
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
 				Multiplies each component of the [Vector3i] by the given [int].
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="float" />
+			<argument index="0" name="right" type="float" />
+			<description>
+				Multiplies an [int] and a [float]. The result is a [float].
+			</description>
+		</operator>
+		<operator name="operator *">
+			<return type="int" />
+			<argument index="0" name="right" type="int" />
+			<description>
+				Multiplies two [int]s.
 			</description>
 		</operator>
 		<operator name="operator +">


### PR DESCRIPTION
Currently, when sorting methods in the documentation, it is assumed that, except for constructors, there is no method overloading. However, this is not true, because operator methods are overloaded. For example, the documentation of maths operators includes, adding a `float` to a `float` and a `float` to an `int`. Overloaded operators are currently being sorted by the overloaded constructors logic, which sometimes fails.

This PR enables detecting and sorting of overloaded operator methods by:
1. name
2. whether or not they have an argument
3. by argument type

Note: It assumes that operators either have no or only one argument. It also deals with #52788, which allows equality operators to also have no arguments.

Fixes #54517.
