### PR TITLE
Prevent other inputs while dragging

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1435,6 +1435,18 @@ bool Viewport::_gui_drop(Control *p_at_control, Point2 p_at_pos, bool p_just_che
 void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
+	Ref<InputEventKey> k = p_event;
+	if (gui.dragging && k.is_valid()) {
+		if (!k->is_pressed()) {
+			return;
+		}
+
+		// Exclude CTRL, it is used for drag-copy
+		if (k->get_keycode() != Key::CTRL) {
+			return;
+		}
+	}
+
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid()) {
 		gui.key_event_accepted = false;
@@ -1463,6 +1475,13 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					gui.drag_accum = Vector2();
 					gui.drag_attempted = false;
 				}
+			}
+
+			if (gui.dragging) {
+				gui.mouse_focus = nullptr;
+				gui.forced_mouse_focus = false;
+				gui.mouse_focus_mask = MouseButton::NONE;
+				return;
 			}
 
 			mb = mb->xformed_by(Transform2D()); // Make a copy of the event.


### PR DESCRIPTION
This commit prevent other inputs to interfere with dragging operation.