### PR TITLE
[3.x] Add methods to get position from column and line in `TextEdit`

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -137,10 +137,45 @@
 				Returns the text of a specific line.
 			</description>
 		</method>
+		<method name="get_line_column_at_pos" qualifiers="const">
+			<return type="Vector2" />
+			<argument index="0" name="position" type="Vector2" />
+			<description>
+				Returns the line and column at the given position. In the returned vector, [code]x[/code] is the column, [code]y[/code] is the line.
+			</description>
+		</method>
 		<method name="get_line_count" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns the amount of total lines in the text.
+			</description>
+		</method>
+		<method name="get_line_height" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the height of a largest line.
+			</description>
+		</method>
+		<method name="get_line_width" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="line" type="int" />
+			<argument index="1" name="wrap_index" type="int" default="-1" />
+			<description>
+				Returns the width in pixels of the [code]wrap_index[/code] on [code]line[/code].
+			</description>
+		</method>
+		<method name="get_line_wrap_count" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="line" type="int" />
+			<description>
+				Returns the number of times the given line is wrapped.
+			</description>
+		</method>
+		<method name="get_line_wrapped_text" qualifiers="const">
+			<return type="PoolStringArray" />
+			<argument index="0" name="line" type="int" />
+			<description>
+				Returns an array of [String]s representing each wrapped index.
 			</description>
 		</method>
 		<method name="get_menu" qualifiers="const">
@@ -148,6 +183,24 @@
 			<description>
 				Returns the [PopupMenu] of this [TextEdit]. By default, this menu is displayed when right-clicking on the [TextEdit].
 				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
+			</description>
+		</method>
+		<method name="get_pos_at_line_column" qualifiers="const">
+			<return type="Vector2" />
+			<argument index="0" name="line" type="int" />
+			<argument index="1" name="column" type="int" />
+			<description>
+				Returns the local position for the given [code]line[/code] and [code]column[/code]. If [code]x[/code] or [code]y[/code] of the returned vector equal [code]-1[/code], the position is outside of the viewable area of the control.
+				[b]Note:[/b] The Y position corresponds to the bottom side of the line. Use [method get_rect_at_line_column] to get the top side position.
+			</description>
+		</method>
+		<method name="get_rect_at_line_column" qualifiers="const">
+			<return type="Rect2" />
+			<argument index="0" name="line" type="int" />
+			<argument index="1" name="column" type="int" />
+			<description>
+				Returns the local position and size for the grapheme at the given [code]line[/code] and [code]column[/code]. If [code]x[/code] or [code]y[/code] position of the returned rect equal [code]-1[/code], the position is outside of the viewable area of the control.
+				[b]Note:[/b] The Y position of the returned rect corresponds to the top side of the line, unlike [method get_pos_at_line_column] which returns the bottom side.
 			</description>
 		</method>
 		<method name="get_selection_from_column" qualifiers="const">
@@ -178,6 +231,12 @@
 			<return type="int" />
 			<description>
 				Returns the selection end line.
+			</description>
+		</method>
+		<method name="get_total_gutter_width" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the total width of all gutters and internal padding.
 			</description>
 		</method>
 		<method name="get_word_under_cursor" qualifiers="const">
@@ -245,6 +304,13 @@
 			<argument index="0" name="line" type="int" />
 			<description>
 				Returns [code]true[/code] when the specified [code]line[/code] is marked as safe.
+			</description>
+		</method>
+		<method name="is_line_wrapped" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="line" type="int" />
+			<description>
+				Returns if the given line is wrapped.
 			</description>
 		</method>
 		<method name="is_selection_active" qualifiers="const">

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -109,12 +109,14 @@ public:
 		void set_indent_size(int p_indent_size);
 		void set_font(const Ref<Font> &p_font);
 		void set_color_regions(const Vector<ColorRegion> *p_regions) { color_regions = p_regions; }
+
 		int get_line_width(int p_line) const;
 		int get_max_width(bool p_exclude_hidden = false) const;
 		int get_char_width(CharType c, CharType next_c, int px) const;
 		void set_line_wrap_amount(int p_line, int p_wrap_amount) const;
 		int get_line_wrap_amount(int p_line) const;
 		const Map<int, ColorRegionInfo> &get_color_region_info(int p_line) const;
+
 		void set(int p_line, const String &p_text);
 		void set_marked(int p_line, bool p_marked) { text.write[p_line].marked = p_marked; }
 		bool is_marked(int p_line) const { return text[p_line].marked; }
@@ -138,14 +140,19 @@ public:
 		bool has_info_icon(int p_line) const { return text[p_line].has_info; }
 		const Ref<Texture> &get_info_icon(int p_line) const { return text[p_line].info_icon; }
 		const String &get_info(int p_line) const { return text[p_line].info; }
+
 		void insert(int p_at, const String &p_text);
 		void remove(int p_at);
+
 		int size() const { return text.size(); }
+
 		void clear();
 		void clear_width_cache();
 		void clear_wrap_cache();
 		void clear_info_icons();
+
 		_FORCE_INLINE_ const String &operator[](int p_line) const { return text[p_line].data; }
+
 		Text() { indent_size = 4; }
 	};
 
@@ -504,6 +511,15 @@ private:
 
 	void _push_current_op();
 
+	/* Line and character position. */
+	struct LineDrawingCache {
+		int y_offset = 0;
+		Vector<int> first_visible_char;
+		Vector<int> last_visible_char;
+	};
+
+	Map<int, LineDrawingCache> line_drawing_cache;
+
 	/* super internal api, undo/redo builds on it */
 
 	void _base_insert_text(int p_line, int p_char, const String &p_text, int &r_end_line, int &r_end_column);
@@ -586,21 +602,29 @@ public:
 	void set_text(String p_text);
 	void insert_text_at_cursor(const String &p_text);
 	void insert_at(const String &p_text, int at);
+
 	int get_line_count() const;
+
+	int get_line_width(int p_line, int p_wrap_index = -1) const;
+	int get_line_height() const;
+
 	void set_line_as_marked(int p_line, bool p_marked);
 	void set_line_as_bookmark(int p_line, bool p_bookmark);
 	bool is_line_set_as_bookmark(int p_line) const;
 	void get_bookmarks(List<int> *p_bookmarks) const;
 	Array get_bookmarks_array() const;
+
 	void set_line_as_breakpoint(int p_line, bool p_breakpoint);
 	bool is_line_set_as_breakpoint(int p_line) const;
-	void set_executing_line(int p_line);
-	void clear_executing_line();
-	void set_line_as_safe(int p_line, bool p_safe);
-	bool is_line_set_as_safe(int p_line) const;
 	void get_breakpoints(List<int> *p_breakpoints) const;
 	Array get_breakpoints_array() const;
 	void remove_breakpoints();
+
+	void set_executing_line(int p_line);
+	void clear_executing_line();
+
+	void set_line_as_safe(int p_line, bool p_safe);
+	bool is_line_set_as_safe(int p_line) const;
 
 	void set_line_info_icon(int p_line, Ref<Texture> p_icon, String p_info = "");
 	void clear_info_icons();
@@ -703,6 +727,11 @@ public:
 	String get_word_under_cursor() const;
 	String get_word_at_pos(const Vector2 &p_pos) const;
 
+	/* Line and character position. */
+	Point2 get_pos_at_line_column(int p_line, int p_column) const;
+	Rect2 get_rect_at_line_column(int p_line, int p_column) const;
+	Point2 get_line_column_at_pos(const Point2 &p_pos) const;
+
 	bool search(const String &p_key, uint32_t p_search_flags, int p_from_line, int p_from_column, int &r_line, int &r_column) const;
 
 	bool has_undo() const;
@@ -787,6 +816,8 @@ public:
 
 	void set_info_gutter_width(int p_gutter_width);
 	int get_info_gutter_width() const;
+
+	int get_total_gutter_width() const;
 
 	void set_draw_minimap(bool p_draw);
 	bool is_drawing_minimap() const;


### PR DESCRIPTION
A `3.x` compatible version of https://github.com/godotengine/godot/pull/55102, which also exposes several additional methods that are useful together with the newly added. Names of all newly exposed methods are exactly the same as they are in the `master` branch.

-----
This PR doesn't change anything about rendering, it just collects and exposes additional information. As such, I would appreciate if it made it into a 3.4.x release as well.