### PR TITLE
Camera2D: Fix condition on 'jump to limits' logic

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -176,7 +176,7 @@ Transform2D Camera2D::get_camera_transform() {
 
 	Rect2 screen_rect(-screen_offset + ret_camera_pos, screen_size * zoom);
 
-	if (!limit_smoothing_enabled) {
+	if (!smoothing_enabled || !limit_smoothing_enabled) {
 		if (screen_rect.position.x < limit[SIDE_LEFT]) {
 			screen_rect.position.x = limit[SIDE_LEFT];
 		}


### PR DESCRIPTION
Pull request #49409 (which was created for #32596) introduced a regression where if a user has `smoothing_enabled = false` and `limit_smoothed = true` on a `Camera2D`, and the camera is pointing outside any defined limits, the camera would simply be stuck until `reset_smoothing()` was called.

This change updates the logic that decides whether to smooth into bounds to be effective only if `smoothing_enabled && limit_smoothing_enabled`.

(For anyone needing a workaround prior to this being merged, either set `limit_smoothed` to `false` or invoke `reset_smoothing()` manually.)

Fixes #54856.