### PR TITLE
Use 16-bit depth to improve dynamic VoxelGI performance

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
@@ -2182,8 +2182,9 @@ void RendererSceneGIRD::VoxelGIInstance::update(bool p_update_light_instances, c
 					dmap.texture = RD::get_singleton()->texture_create(dtf, RD::TextureView());
 
 					if (dynamic_maps.size() == 0) {
-						//render depth for first one
-						dtf.format = RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_D32_SFLOAT, RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) ? RD::DATA_FORMAT_D32_SFLOAT : RD::DATA_FORMAT_X8_D24_UNORM_PACK32;
+						// Render depth for first one.
+						// Use 16-bit depth when supported to improve performance.
+						dtf.format = RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_D16_UNORM, RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT) ? RD::DATA_FORMAT_D16_UNORM : RD::DATA_FORMAT_X8_D24_UNORM_PACK32;
 						dtf.usage_bits = RD::TEXTURE_USAGE_DEPTH_STENCIL_ATTACHMENT_BIT;
 						dmap.fb_depth = RD::get_singleton()->texture_create(dtf, RD::TextureView());
 					}


### PR DESCRIPTION
In a complex scene with several dynamic emissive objects, this saves over 1 ms of GPU time on a GTX 1080 in 2560×1440. The savings in GPU time are proportional to the amount of dynamic VoxelGI objects present in the scene. There is no visual difference in the scenes I've tested so far.

This partially addresses https://github.com/godotengine/godot/issues/55359.

## Preview

### Before

![2021-11-28_18 53 21](https://user-images.githubusercontent.com/180032/143779902-af94d77f-6eb3-4ffb-86f0-7730dcf2b65d.png)

### After

![2021-11-28_18 52 56](https://user-images.githubusercontent.com/180032/143779900-c464616a-7bba-4c09-9d7f-1e1d7492df6b.png)

### Difference ([dssim](https://github.com/kornelski/dssim))

*Only the FPS counter on screen has visual difference.*

![diff png-0](https://user-images.githubusercontent.com/180032/143779895-f79865df-bbea-4b81-801a-5afd80b58968.png)