### PR TITLE
Add a project setting to adjust VoxelGI dynamic oversampling

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -3045,6 +3045,10 @@
 			The number of rays to throw per frame when computing signed distance field global illumination. Higher values lead to a less noisy result, at the cost of performance. See also [member rendering/global_illumination/sdfgi/frames_to_converge] and [member rendering/global_illumination/sdfgi/frames_to_update_lights].
 			[b]Note:[/b] This property is only read when the project starts. To control SDFGI quality at runtime, call [method RenderingServer.environment_set_sdfgi_ray_count] instead.
 		</member>
+		<member name="rendering/global_illumination/voxel_gi/dynamic_oversampling" type="int" setter="" getter="" default="0">
+			The [VoxelGI] oversampling to perform for [GeometryInstance3D]s that use [constant GeometryInstance3D.GI_MODE_DYNAMIC]. Higher values improve the appearance of lighting emitted by [i]moving[/i] dynamic objects and their appearance in reflections. The difference is most noticeable in small and slow-moving dynamic objects. Enabling oversampling has a significant performance cost, so it's recommended to keep it disabled until it's needed.
+			[b]Note:[/b] This setting is only read when the project starts. It currently cannot be changed at run-time.
+		</member>
 		<member name="rendering/global_illumination/voxel_gi/quality" type="int" setter="" getter="" default="0">
 			The VoxelGI quality to use. High quality leads to more precise lighting and better reflections, but is slower to render. This setting does not affect the baked data and doesn't require baking the [VoxelGI] again to apply.
 			[b]Note:[/b] This property is only read when the project starts. To control VoxelGI quality at runtime, call [method RenderingServer.voxel_gi_set_quality] instead.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -4566,7 +4566,7 @@
 			<param index="0" name="voxel_gi" type="RID" />
 			<param index="1" name="baked_exposure" type="float" />
 			<description>
-				Used to inform the renderer what exposure normalization value was used while baking the voxel gi. This value will be used and modulated at run time to ensure that the voxel gi maintains a consistent level of exposure even if the scene-wide exposure normalization is changed at run time. For more information see [method camera_attributes_set_exposure].
+				Used to inform the renderer what exposure normalization value was used while baking a [VoxelGI]. This value will be used and modulated at run time to ensure that the [VoxelGI] maintains a consistent level of exposure even if the scene-wide exposure normalization is changed at run time. For more information see [method camera_attributes_set_exposure].
 			</description>
 		</method>
 		<method name="voxel_gi_set_bias">
@@ -4575,6 +4575,14 @@
 			<param index="1" name="bias" type="float" />
 			<description>
 				Sets the [member VoxelGIData.bias] value to use on the specified [param voxel_gi]'s [RID].
+			</description>
+		</method>
+		<method name="voxel_gi_set_dynamic_oversampling">
+			<return type="void" />
+			<param index="0" name="dynamic_oversampling" type="int" enum="RenderingServer.VoxelGIDynamicOversampling" />
+			<description>
+				Sets the [VoxelGI] oversampling to perform for [GeometryInstance3D]s that use [constant GeometryInstance3D.GI_MODE_DYNAMIC]. Higher values improve the temporal stability of lighting emitted by [i]moving[/i] dynamic objects and their appearance in reflections. The difference is most noticeable in small and slow-moving dynamic objects. Enabling oversampling has a significant performance cost, so it's recommended to keep it disabled until it's needed.
+				[b]Note:[/b] This method currently has no effect when called at run-time.
 			</description>
 		</method>
 		<method name="voxel_gi_set_dynamic_range">
@@ -5163,6 +5171,24 @@
 		</constant>
 		<constant name="VOXEL_GI_QUALITY_HIGH" value="1" enum="VoxelGIQuality">
 			High [VoxelGI] rendering quality using 6 cones.
+		</constant>
+		<constant name="VOXEL_GI_DYNAMIC_OVERSAMPLING_DISABLED" value="0" enum="VoxelGIDynamicOversampling">
+			[VoxelGI] oversampling for dynamic objects is disabled.
+		</constant>
+		<constant name="VOXEL_GI_DYNAMIC_OVERSAMPLING_2X" value="1" enum="VoxelGIDynamicOversampling">
+			[VoxelGI] oversampling for dynamic objects is enabled at 2× quality (moderate performance cost).
+		</constant>
+		<constant name="VOXEL_GI_DYNAMIC_OVERSAMPLING_4X" value="2" enum="VoxelGIDynamicOversampling">
+			[VoxelGI] oversampling for dynamic objects is enabled at 4× quality (high performance cost).
+		</constant>
+		<constant name="VOXEL_GI_DYNAMIC_OVERSAMPLING_8X" value="3" enum="VoxelGIDynamicOversampling">
+			[VoxelGI] oversampling for dynamic objects is enabled at 8× quality (very high performance cost).
+		</constant>
+		<constant name="VOXEL_GI_DYNAMIC_OVERSAMPLING_16X" value="4" enum="VoxelGIDynamicOversampling">
+			[VoxelGI] oversampling for dynamic objects is enabled at 16× quality (extreme performance cost).
+		</constant>
+		<constant name="VOXEL_GI_DYNAMIC_OVERSAMPLING_MAX" value="5" enum="VoxelGIDynamicOversampling">
+			Represents the size of the [enum VoxelGIDynamicOversampling] enum.
 		</constant>
 		<constant name="PARTICLES_MODE_2D" value="0" enum="ParticlesMode">
 			2D particles.

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1252,7 +1252,10 @@ bool RasterizerSceneGLES3::voxel_gi_needs_update(RID p_probe) const {
 void RasterizerSceneGLES3::voxel_gi_update(RID p_probe, bool p_update_light_instances, const Vector<RID> &p_light_instances, const PagedArray<RenderGeometryInstance *> &p_dynamic_objects) {
 }
 
-void RasterizerSceneGLES3::voxel_gi_set_quality(RS::VoxelGIQuality) {
+void RasterizerSceneGLES3::voxel_gi_set_quality(RS::VoxelGIQuality p_quality) {
+}
+
+void RasterizerSceneGLES3::voxel_gi_set_dynamic_oversampling(RS::VoxelGIDynamicOversampling p_dynamic_oversampling) {
 }
 
 _FORCE_INLINE_ static uint32_t _indices_to_primitives(RS::PrimitiveType p_primitive, uint32_t p_indices) {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -923,7 +923,8 @@ public:
 	bool voxel_gi_needs_update(RID p_probe) const override;
 	void voxel_gi_update(RID p_probe, bool p_update_light_instances, const Vector<RID> &p_light_instances, const PagedArray<RenderGeometryInstance *> &p_dynamic_objects) override;
 
-	void voxel_gi_set_quality(RS::VoxelGIQuality) override;
+	void voxel_gi_set_quality(RS::VoxelGIQuality p_quality) override;
+	void voxel_gi_set_dynamic_oversampling(RS::VoxelGIDynamicOversampling p_dynamic_oversampling) override;
 
 	void render_scene(const Ref<RenderSceneBuffers> &p_render_buffers, const CameraData *p_camera_data, const CameraData *p_prev_camera_data, const PagedArray<RenderGeometryInstance *> &p_instances, const PagedArray<RID> &p_lights, const PagedArray<RID> &p_reflection_probes, const PagedArray<RID> &p_voxel_gi_instances, const PagedArray<RID> &p_decals, const PagedArray<RID> &p_lightmaps, const PagedArray<RID> &p_fog_volumes, RID p_environment, RID p_camera_attributes, RID p_compositor, RID p_shadow_atlas, RID p_occluder_debug_tex, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, const RenderShadowData *p_render_shadows, int p_render_shadow_count, const RenderSDFGIData *p_render_sdfgi_regions, int p_render_sdfgi_region_count, const RenderSDFGIUpdateData *p_sdfgi_update_data = nullptr, RenderingMethod::RenderInfo *r_render_info = nullptr) override;
 	void render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) override;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -501,6 +501,8 @@ void EditorNode::_update_from_settings() {
 	RS::get_singleton()->environment_set_sdfgi_ray_count(ray_count);
 	RS::VoxelGIQuality voxel_gi_quality = RS::VoxelGIQuality(int(GLOBAL_GET("rendering/global_illumination/voxel_gi/quality")));
 	RS::get_singleton()->voxel_gi_set_quality(voxel_gi_quality);
+	RS::VoxelGIDynamicOversampling voxel_gi_dynamic_oversampling = RS::VoxelGIDynamicOversampling(int(GLOBAL_GET("rendering/global_illumination/voxel_gi/dynamic_oversampling")));
+	RS::get_singleton()->voxel_gi_set_dynamic_oversampling(voxel_gi_dynamic_oversampling);
 	RS::get_singleton()->environment_set_volumetric_fog_volume_size(GLOBAL_GET("rendering/environment/volumetric_fog/volume_size"), GLOBAL_GET("rendering/environment/volumetric_fog/volume_depth"));
 	RS::get_singleton()->environment_set_volumetric_fog_filter_active(bool(GLOBAL_GET("rendering/environment/volumetric_fog/use_filter")));
 	RS::get_singleton()->canvas_set_shadow_texture_size(GLOBAL_GET("rendering/2d/shadow_atlas/size"));

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -155,6 +155,7 @@ public:
 	void voxel_gi_update(RID p_probe, bool p_update_light_instances, const Vector<RID> &p_light_instances, const PagedArray<RenderGeometryInstance *> &p_dynamic_objects) override {}
 
 	void voxel_gi_set_quality(RS::VoxelGIQuality) override {}
+	void voxel_gi_set_dynamic_oversampling(RS::VoxelGIDynamicOversampling p_dynamic_oversampling) override {}
 
 	void render_scene(const Ref<RenderSceneBuffers> &p_render_buffers, const CameraData *p_camera_data, const CameraData *p_prev_camera_data, const PagedArray<RenderGeometryInstance *> &p_instances, const PagedArray<RID> &p_lights, const PagedArray<RID> &p_reflection_probes, const PagedArray<RID> &p_voxel_gi_instances, const PagedArray<RID> &p_decals, const PagedArray<RID> &p_lightmaps, const PagedArray<RID> &p_fog_volumes, RID p_environment, RID p_camera_attributes, RID p_compositor, RID p_shadow_atlas, RID p_occluder_debug_tex, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, const RenderShadowData *p_render_shadows, int p_render_shadow_count, const RenderSDFGIData *p_render_sdfgi_regions, int p_render_sdfgi_region_count, const RenderSDFGIUpdateData *p_sdfgi_update_data = nullptr, RenderingMethod::RenderInfo *r_info = nullptr) override {}
 	void render_material(const Transform3D &p_cam_transform, const Projection &p_cam_projection, bool p_cam_orthogonal, const PagedArray<RenderGeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) override {}

--- a/servers/rendering/renderer_rd/environment/gi.cpp
+++ b/servers/rendering/renderer_rd/environment/gi.cpp
@@ -2659,7 +2659,7 @@ void GI::VoxelGIInstance::update(bool p_update_light_instances, const Vector<RID
 
 			{
 				uint32_t dynamic_map_size = MAX(MAX(octree_size.x, octree_size.y), octree_size.z);
-				uint32_t oversample = nearest_power_of_2_templated(4);
+				uint32_t oversample = gi->voxel_gi_dynamic_oversampling;
 				int mipmap_index = 0;
 
 				while (mipmap_index < mipmaps.size()) {
@@ -3442,6 +3442,7 @@ void GI::init(SkyRD *p_sky) {
 		voxel_gi_lights = memnew_arr(VoxelGILight, voxel_gi_max_lights);
 		voxel_gi_lights_uniform = RD::get_singleton()->uniform_buffer_create(voxel_gi_max_lights * sizeof(VoxelGILight));
 		voxel_gi_quality = RS::VoxelGIQuality(CLAMP(int(GLOBAL_GET("rendering/global_illumination/voxel_gi/quality")), 0, 1));
+		voxel_gi_dynamic_oversampling = RS::VoxelGIDynamicOversampling(CLAMP(int(GLOBAL_GET("rendering/global_illumination/voxel_gi/dynamic_oversampling")), 0, 4));
 
 		String defines = "\n#define MAX_LIGHTS " + itos(voxel_gi_max_lights) + "\n";
 

--- a/servers/rendering/renderer_rd/environment/gi.h
+++ b/servers/rendering/renderer_rd/environment/gi.h
@@ -542,6 +542,7 @@ public:
 	void voxel_gi_instance_free(RID p_rid);
 
 	RS::VoxelGIQuality voxel_gi_quality = RS::VOXEL_GI_QUALITY_LOW;
+	RS::VoxelGIDynamicOversampling voxel_gi_dynamic_oversampling = RS::VOXEL_GI_DYNAMIC_OVERSAMPLING_DISABLED;
 
 	/* SDFGI */
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -234,6 +234,7 @@ public:
 	virtual bool voxel_gi_needs_update(RID p_probe) const override;
 	virtual void voxel_gi_update(RID p_probe, bool p_update_light_instances, const Vector<RID> &p_light_instances, const PagedArray<RenderGeometryInstance *> &p_dynamic_objects) override;
 	virtual void voxel_gi_set_quality(RS::VoxelGIQuality p_quality) override { gi.voxel_gi_quality = p_quality; }
+	virtual void voxel_gi_set_dynamic_oversampling(RS::VoxelGIDynamicOversampling p_dynamic_oversampling) override { gi.voxel_gi_dynamic_oversampling = p_dynamic_oversampling; }
 
 	/* render buffers */
 	virtual RD::DataFormat _render_buffers_get_preferred_color_format();

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1175,6 +1175,7 @@ public:
 #define PASSBASE scene_render
 
 	PASS1(voxel_gi_set_quality, RS::VoxelGIQuality)
+	PASS1(voxel_gi_set_dynamic_oversampling, RS::VoxelGIDynamicOversampling)
 
 	/* SKY API */
 

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -278,7 +278,8 @@ public:
 	virtual bool voxel_gi_needs_update(RID p_probe) const = 0;
 	virtual void voxel_gi_update(RID p_probe, bool p_update_light_instances, const Vector<RID> &p_light_instances, const PagedArray<RenderGeometryInstance *> &p_dynamic_objects) = 0;
 
-	virtual void voxel_gi_set_quality(RS::VoxelGIQuality) = 0;
+	virtual void voxel_gi_set_quality(RS::VoxelGIQuality p_quality) = 0;
+	virtual void voxel_gi_set_dynamic_oversampling(RS::VoxelGIDynamicOversampling p_dynamic_oversampling) = 0;
 
 	struct RenderShadowData {
 		RID light;

--- a/servers/rendering/rendering_method.h
+++ b/servers/rendering/rendering_method.h
@@ -339,6 +339,7 @@ public:
 
 	virtual TypedArray<Image> bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size) = 0;
 	virtual void voxel_gi_set_quality(RS::VoxelGIQuality) = 0;
+	virtual void voxel_gi_set_dynamic_oversampling(RS::VoxelGIDynamicOversampling p_dynamic_oversampling) = 0;
 
 	virtual void sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) = 0;
 

--- a/servers/rendering/rendering_server.cpp
+++ b/servers/rendering/rendering_server.cpp
@@ -2742,9 +2742,17 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("voxel_gi_set_use_two_bounces", "voxel_gi", "enable"), &RenderingServer::voxel_gi_set_use_two_bounces);
 
 	ClassDB::bind_method(D_METHOD("voxel_gi_set_quality", "quality"), &RenderingServer::voxel_gi_set_quality);
+	ClassDB::bind_method(D_METHOD("voxel_gi_set_dynamic_oversampling", "dynamic_oversampling"), &RenderingServer::voxel_gi_set_dynamic_oversampling);
 
 	BIND_ENUM_CONSTANT(VOXEL_GI_QUALITY_LOW);
 	BIND_ENUM_CONSTANT(VOXEL_GI_QUALITY_HIGH);
+
+	BIND_ENUM_CONSTANT(VOXEL_GI_DYNAMIC_OVERSAMPLING_DISABLED);
+	BIND_ENUM_CONSTANT(VOXEL_GI_DYNAMIC_OVERSAMPLING_2X);
+	BIND_ENUM_CONSTANT(VOXEL_GI_DYNAMIC_OVERSAMPLING_4X);
+	BIND_ENUM_CONSTANT(VOXEL_GI_DYNAMIC_OVERSAMPLING_8X);
+	BIND_ENUM_CONSTANT(VOXEL_GI_DYNAMIC_OVERSAMPLING_16X);
+	BIND_ENUM_CONSTANT(VOXEL_GI_DYNAMIC_OVERSAMPLING_MAX);
 
 	/* LIGHTMAP */
 
@@ -3751,6 +3759,7 @@ void RenderingServer::init() {
 	GLOBAL_DEF("rendering/global_illumination/gi/use_half_resolution", false);
 
 	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/global_illumination/voxel_gi/quality", PROPERTY_HINT_ENUM, "Low (4 Cones - Fast),High (6 Cones - Slow)"), 0);
+	GLOBAL_DEF(PropertyInfo(Variant::INT, "rendering/global_illumination/voxel_gi/dynamic_oversampling", PROPERTY_HINT_ENUM, String::utf8("Disabled (Fast),2× (Average),4× (Slow),8× (Slower),16× (Slowest)")), 0);
 
 	GLOBAL_DEF_RST("rendering/shading/overrides/force_vertex_shading", false);
 	GLOBAL_DEF("rendering/shading/overrides/force_lambert_over_burley", false);

--- a/servers/rendering/rendering_server.h
+++ b/servers/rendering/rendering_server.h
@@ -753,7 +753,17 @@ public:
 		VOXEL_GI_QUALITY_HIGH,
 	};
 
-	virtual void voxel_gi_set_quality(VoxelGIQuality) = 0;
+	enum VoxelGIDynamicOversampling {
+		VOXEL_GI_DYNAMIC_OVERSAMPLING_DISABLED,
+		VOXEL_GI_DYNAMIC_OVERSAMPLING_2X,
+		VOXEL_GI_DYNAMIC_OVERSAMPLING_4X,
+		VOXEL_GI_DYNAMIC_OVERSAMPLING_8X,
+		VOXEL_GI_DYNAMIC_OVERSAMPLING_16X,
+		VOXEL_GI_DYNAMIC_OVERSAMPLING_MAX,
+	};
+
+	virtual void voxel_gi_set_quality(VoxelGIQuality p_quality) = 0;
+	virtual void voxel_gi_set_dynamic_oversampling(VoxelGIDynamicOversampling p_dynamic_oversampling) = 0;
 
 	virtual void sdfgi_reset() = 0;
 
@@ -1981,6 +1991,7 @@ VARIANT_ENUM_CAST(RenderingServer::LightProjectorFilter);
 VARIANT_ENUM_CAST(RenderingServer::ReflectionProbeUpdateMode);
 VARIANT_ENUM_CAST(RenderingServer::ReflectionProbeAmbientMode);
 VARIANT_ENUM_CAST(RenderingServer::VoxelGIQuality);
+VARIANT_ENUM_CAST(RenderingServer::VoxelGIDynamicOversampling);
 VARIANT_ENUM_CAST(RenderingServer::DecalTexture);
 VARIANT_ENUM_CAST(RenderingServer::DecalFilter);
 VARIANT_ENUM_CAST(RenderingServer::ParticlesMode);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -821,6 +821,7 @@ public:
 	/* ENVIRONMENT API */
 
 	FUNC1(voxel_gi_set_quality, VoxelGIQuality)
+	FUNC1(voxel_gi_set_dynamic_oversampling, VoxelGIDynamicOversampling)
 
 	/* SKY API */
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/55418.

The default is now to have oversampling disabled, as it brings a very significant performance boost (going from 42 FPS to 137 FPS in a complex test scene with a dozen dynamic objects).

It's recommended to enable oversampling only when it brings a noticeable benefit (such as with small, slow-moving objects that have emissive materials).

**Note:** The setting currently can't be changed at run-time, as I couldn't figure out how to force a VoxelGI update when the setting changes.

This closes https://github.com/godotengine/godot/issues/55359.

**Testing project:** [test_voxelgi_performance_complex.zip](https://github.com/godotengine/godot/files/7614218/test_voxelgi_performance_complex.zip)

## Performance

With the test scene linked above, a GTX 1080 and 2560×1440 resolution:

| Mode | Performance |
|-|-|
| Oversampling disabled | 130 FPS (7.69 mspf) |
| 2× oversampling | 125 FPS (8.00 mspf) |
| 4× oversampling | 111 FPS (9.01 mspf) |
| 8× oversampling | 82 FPS (12.20 mspf) |
| 16× oversampling | 40 FPS (25.00 mspf) |

Note that this was measured without https://github.com/godotengine/godot/pull/55418 included. When https://github.com/godotengine/godot/pull/55418 is included, overall performance is slightly higher on all oversampling levels (including disabled). The benefit of https://github.com/godotengine/godot/pull/55418 is greater at higher oversampling levels, still.

## Preview

### Oversampling disabled (new default, fast)

https://user-images.githubusercontent.com/180032/143783108-397079f6-f5b1-4b73-a2e1-5b5b555cdf12.mp4

### 2× oversampling (average)

https://user-images.githubusercontent.com/180032/143783099-7fa066e9-7d65-465a-a74b-8df8c7b8a7f5.mp4

### 4× oversampling (slow)

https://user-images.githubusercontent.com/180032/143783102-d43d3542-af5e-4abb-847c-1094a5c48429.mp4

### 8× oversampling (slower)

https://user-images.githubusercontent.com/180032/143783105-86d6e09d-74c8-495e-8ad8-7a89ab69e216.mp4

### 16× oversampling (current default, slowest)

https://user-images.githubusercontent.com/180032/143783107-f30dc9ee-de9e-4e2e-b1f3-78670d9df325.mp4