### PR TITLE
Add state transition signals to AnimationNodeStateMachinePlayback

### DIFF
--- a/doc/classes/AnimationNodeStateMachinePlayback.xml
+++ b/doc/classes/AnimationNodeStateMachinePlayback.xml
@@ -16,6 +16,32 @@
 		stateMachine.Travel("some_state");
 		[/csharp]
 		[/codeblocks]
+
+		State transitions emit signals, in a specific order:
+		- [signal state_exit] emits when a state is exited
+		- [signal state_changed] emits before the new state is entered
+		- [signal state_enter] emits when the new state is entered
+		[codeblocks]
+		[gdscript]
+		var state_machine: AnimationNodeStateMachinePlayback = $AnimationTree.get("parameters/playback")
+		state_machine.state_changed.connect(on_state_changed)
+
+		func on_state_changed(prev: String, next: String) -&gt; void:
+		print(prev, " -&gt; ", next)
+		[/gdscript]
+		[csharp]
+		public override void _Ready()
+		{
+		    var stateMachine = GetNode&lt;AnimationTree&gt;("AnimationTree").Get("parameters/playback") as AnimationNodeStateMachinePlayback;
+		    stateMachine.Connect("state_changed", new Callable(this, nameof(OnStateChanged)));
+		}
+
+		private void OnStateChanged(string previous, string next)
+		{
+		    GD.Print(previous, " -&gt; ", next);
+		}
+		[/csharp]
+		[/codeblocks]
 	</description>
 	<tutorials>
 		<link title="AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>
@@ -74,4 +100,25 @@
 	<members>
 		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="true" />
 	</members>
+	<signals>
+		<signal name="state_changed">
+			<argument index="0" name="previous_state" type="String" />
+			<argument index="1" name="next_state" type="String" />
+			<description>
+				Notified when a state transition occurs. Emitted before [signal state_enter]. Not emitted for the first state.
+			</description>
+		</signal>
+		<signal name="state_enter">
+			<argument index="0" name="state" type="String" />
+			<description>
+				Notifies when a state is entered.
+			</description>
+		</signal>
+		<signal name="state_exit">
+			<argument index="0" name="state" type="String" />
+			<description>
+				Notifies when a state is exited.
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/scene/scene_string_names.cpp
+++ b/scene/scene_string_names.cpp
@@ -215,4 +215,5 @@ SceneStringNames::SceneStringNames() {
 	use_in_baked_light = StaticCString::create("use_in_baked_light");
 	use_dynamic_gi = StaticCString::create("use_dynamic_gi");
 #endif
+
 }

--- a/scene/scene_string_names.h
+++ b/scene/scene_string_names.h
@@ -224,6 +224,7 @@ public:
 	StringName use_in_baked_light;
 	StringName use_dynamic_gi;
 #endif
+
 };
 
 #endif // SCENE_STRING_NAMES_H


### PR DESCRIPTION
Adds signals to the `AnimationNodeStateMachinePlayback` which allow user-level scripts to react to transitions between the various states. 

What this means in practice is that it allows users to know when an animation/blend/sub-machine has stopped or started playing inside an `AnimationNodeStateMachine`. This can be used to solve problems presented in https://github.com/godotengine/godot-proposals/issues/1462, #28311 and #41771

[Example project using this PR](https://github.com/godotengine/godot/files/7614452/animation_state_machine_test.zip)

This fix can also be easily backported to `3.x` , there seem to be no conflicts.

The current ways to do the same thing on a user level are:
- create call method tracks in animations to notify scripts of completion. This is not a scalable solution for games with lots of animations as it's prone to user error.
- apply a special script to every `AnimationTree` node which manually checks for state changes every idle or physics frame, depending on settings.  This is also very prone to user error.