### PR TITLE
Filesystem dock duplicated files fix

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1190,6 +1190,7 @@ void EditorFileSystem::_notification(int p_what) {
 			if (use_threads) {
 				if (scanning_changes) {
 					if (scanning_changes_done) {
+						scanning_changes_done = false; //reset this variable to prevent multiple code execution
 						scanning_changes = false;
 
 						set_process(false);

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1190,7 +1190,7 @@ void EditorFileSystem::_notification(int p_what) {
 			if (use_threads) {
 				if (scanning_changes) {
 					if (scanning_changes_done) {
-						scanning_changes_done = false; //reset this variable to prevent multiple code execution						
+						scanning_changes_done = false; //reset this variable to prevent multiple code execution
 
 						set_process(false);
 

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1190,8 +1190,7 @@ void EditorFileSystem::_notification(int p_what) {
 			if (use_threads) {
 				if (scanning_changes) {
 					if (scanning_changes_done) {
-						scanning_changes_done = false; //reset this variable to prevent multiple code execution
-						scanning_changes = false;
+						scanning_changes_done = false; //reset this variable to prevent multiple code execution						
 
 						set_process(false);
 
@@ -1199,6 +1198,7 @@ void EditorFileSystem::_notification(int p_what) {
 						if (_update_scan_actions()) {
 							emit_signal(SNAME("filesystem_changed"));
 						}
+						scanning_changes = false;
 						emit_signal(SNAME("sources_changed"), sources_changed.size() > 0);
 						_queue_update_script_classes();
 						first_scan = false;


### PR DESCRIPTION
On windows 10/11, files dragged to FileSystem dock appear twice. This issue caused by multiple execution of code after **EditorFileSystem::scan_changes()** threaded task is done and by setting **scanning_changes** variable before **_update_scan_actions** executed. Suggested fix resets **scanning_changes_done** variable to prevent multiple execution of code and moves **scanning_changes** variable to be consistent with non-threaded version.
This fix addresses issue #48456.
Both drag & drop and removing of just imported file work as expected on windows 10/11
![godot-issue-duplicated](https://user-images.githubusercontent.com/7414151/143798611-ebb97ae2-9bd8-4738-bdfa-473d115dc7c7.gif)

