### PR TITLE
Clarify usage of TabContainer

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -4,8 +4,9 @@
 		Tabbed container.
 	</brief_description>
 	<description>
-		Sets the active tab's [code]visible[/code] property to the value [code]true[/code]. Sets all other children's to [code]false[/code].
+		Arranges [Control] children into a tabbed view, creating a tab for each one. The active tab's corresponding [Control] has its [code]visible[/code] property set to [code]true[/code], and all other children's to [code]false[/code].
 		Ignores non-[Control] children.
+		[b]Note:[/b] The drawing of the clickable tabs themselves is handled by this node. Adding [TabBar]s as children is not needed.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
resolves https://github.com/godotengine/godot-docs/issues/4682

Makes it more clear that `TabBar` is separate from `TabContainer`, and that the container draws the tabs itself.
Also specifies that the `Control` children are arranged into a tabbed view, as simply stating "Sets the active tab" may have lead to some of the confusion referred to in the issue.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
