### PR TITLE
Fix right alignment in RichTextLabel

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -222,7 +222,7 @@ int RichTextLabel::_process_line(ItemFrame *p_frame, const Vector2 &p_ofs, int &
 			if (align != ALIGN_FILL)                                                                                                                                        \
 				wofs += line_ofs;                                                                                                                                           \
 		} else {                                                                                                                                                            \
-			int used = wofs - margin;                                                                                                                                       \
+			float used = wofs - margin;                                                                                                                                     \
 			switch (align) {                                                                                                                                                \
 				case ALIGN_LEFT:                                                                                                                                            \
 					l.offset_caches.push_back(0);                                                                                                                           \


### PR DESCRIPTION
Fixes #54764