### PR TITLE
Add ALT NUM+ {hex code} character input support for LineEdit, TextEdit and CodeEdit.

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -357,6 +357,11 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 	}
 
 	Ref<InputEventKey> k = p_gui_input;
+	if (TextEdit::alt_input(p_gui_input)) {
+		accept_event();
+		return;
+	}
+
 	bool update_code_completion = false;
 	if (!k.is_valid()) {
 		TextEdit::gui_input(p_gui_input);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -406,7 +406,43 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 
 	if (k.is_valid()) {
 		if (!k->is_pressed()) {
+			if (alt_start && k->get_keycode() == Key::ALT) {
+				alt_start = false;
+				if ((alt_code > 0x31 && alt_code < 0xd800) || (alt_code > 0xdfff && alt_code <= 0x10ffff)) {
+					char32_t ucodestr[2] = { (char32_t)alt_code, 0 };
+					insert_text_at_caret(ucodestr);
+				}
+				accept_event();
+				return;
+			}
 			return;
+		}
+
+		// Alt+ Unicode input:
+		if (k->is_alt_pressed()) {
+			if (!alt_start) {
+				if (k->get_keycode() == Key::KP_ADD) {
+					alt_start = true;
+					alt_code = 0;
+					accept_event();
+					return;
+				}
+			} else {
+				if (k->get_keycode() >= Key::KEY_0 && k->get_keycode() <= Key::KEY_9) {
+					alt_code = alt_code << 4;
+					alt_code += (uint32_t)(k->get_keycode() - Key::KEY_0);
+				}
+				if (k->get_keycode() >= Key::KP_0 && k->get_keycode() <= Key::KP_9) {
+					alt_code = alt_code << 4;
+					alt_code += (uint32_t)(k->get_keycode() - Key::KP_0);
+				}
+				if (k->get_keycode() >= Key::A && k->get_keycode() <= Key::F) {
+					alt_code = alt_code << 4;
+					alt_code += (uint32_t)(k->get_keycode() - Key::A) + 10;
+				}
+				accept_event();
+				return;
+			}
 		}
 
 		if (context_menu_enabled) {

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -77,6 +77,9 @@ private:
 	bool pass = false;
 	bool text_changed_dirty = false;
 
+	bool alt_start = false;
+	uint32_t alt_code = 0;
+
 	String undo_text;
 	String text;
 	String placeholder;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -247,6 +247,9 @@ private:
 
 	bool setting_text = false;
 
+	bool alt_start = false;
+	uint32_t alt_code = 0;
+
 	// Text properties.
 	String ime_text = "";
 	Point2 ime_selection;
@@ -625,6 +628,7 @@ public:
 	/* General overrides. */
 	virtual void unhandled_key_input(const Ref<InputEvent> &p_event) override;
 	virtual void gui_input(const Ref<InputEvent> &p_gui_input) override;
+	bool alt_input(const Ref<InputEvent> &p_gui_input);
 	virtual Size2 get_minimum_size() const override;
 	virtual bool is_text_field() const override;
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos = Point2i()) const override;


### PR DESCRIPTION
Implements #2689

To use, press and hold the `ALT` (`Option`) key, press and release the `numpad plus` key, type a hexadecimal Unicode character code, then release the `ALT` key.