### PR TITLE
Set correct `_NET_WM_WINDOW_TYPE` for dialog windows

### DIFF
--- a/platform/linuxbsd/x11/display_server_x11.cpp
+++ b/platform/linuxbsd/x11/display_server_x11.cpp
@@ -1620,6 +1620,14 @@ void DisplayServerX11::window_set_transient(WindowID p_window, WindowID p_parent
 			}
 		}
 	} else {
+		if (!wd_window.is_popup || !wd_window.no_focus) {
+			Atom type_atom = XInternAtom(x11_display, "_NET_WM_WINDOW_TYPE_DIALOG", False);
+			Atom wt_atom = XInternAtom(x11_display, "_NET_WM_WINDOW_TYPE", False);
+
+			if (wt_atom != None && type_atom != None) {
+				XChangeProperty(x11_display, wd_window.x11_window, wt_atom, XA_ATOM, 32, PropModeReplace, (unsigned char *)&type_atom, 1);
+			}
+		}
 		ERR_FAIL_COND(!windows.has(p_parent));
 		ERR_FAIL_COND_MSG(prev_parent != INVALID_WINDOW_ID, "Window already has a transient parent");
 		WindowData &wd_parent = windows[p_parent];


### PR DESCRIPTION
This should fix #55415 for tiling window managers (what has sane defaults).

## Currently windows are created with `_NET_WM_WINDOW_TYPE_NORMAL` atom and it causes some jarring behavior with tiling window manager.

![image](https://user-images.githubusercontent.com/10142805/143886940-fd40f147-ccae-42c6-bd10-b3db77a1226e.png)

## After the change tiling window managers can read info about window type and set default to floating.
![image](https://user-images.githubusercontent.com/10142805/143886556-b7a62269-7d07-4328-bd29-9e8218310d61.png)

Most, if not all Tiling Window Managers will look into `_NET_WM_WINDOW_TYPE` value to determine if it's floating window.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
