### PR TITLE
Remove redundant SpriteBase3D `opacity` property

### DIFF
--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -65,9 +65,6 @@
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
 			The texture's drawing offset.
 		</member>
-		<member name="opacity" type="float" setter="set_opacity" getter="get_opacity" default="1.0">
-			The objects' visibility on a scale from [code]0[/code] fully invisible to [code]1[/code] fully visible.
-		</member>
 		<member name="pixel_size" type="float" setter="set_pixel_size" getter="get_pixel_size" default="0.01">
 			The size of one pixel's width on the sprite to scale it in 3D.
 		</member>

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -141,15 +141,6 @@ real_t SpriteBase3D::get_pixel_size() const {
 	return pixel_size;
 }
 
-void SpriteBase3D::set_opacity(float p_amount) {
-	opacity = p_amount;
-	_queue_update();
-}
-
-float SpriteBase3D::get_opacity() const {
-	return opacity;
-}
-
 void SpriteBase3D::set_axis(Vector3::Axis p_axis) {
 	ERR_FAIL_INDEX(p_axis, 3);
 	axis = p_axis;
@@ -295,9 +286,6 @@ void SpriteBase3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_modulate", "modulate"), &SpriteBase3D::set_modulate);
 	ClassDB::bind_method(D_METHOD("get_modulate"), &SpriteBase3D::get_modulate);
 
-	ClassDB::bind_method(D_METHOD("set_opacity", "opacity"), &SpriteBase3D::set_opacity);
-	ClassDB::bind_method(D_METHOD("get_opacity"), &SpriteBase3D::get_opacity);
-
 	ClassDB::bind_method(D_METHOD("set_pixel_size", "pixel_size"), &SpriteBase3D::set_pixel_size);
 	ClassDB::bind_method(D_METHOD("get_pixel_size"), &SpriteBase3D::get_pixel_size);
 
@@ -324,7 +312,6 @@ void SpriteBase3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "modulate"), "set_modulate", "get_modulate");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "opacity", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_opacity", "get_opacity");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pixel_size", PROPERTY_HINT_RANGE, "0.0001,128,0.0001"), "set_pixel_size", "get_pixel_size");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "axis", PROPERTY_HINT_ENUM, "X-Axis,Y-Axis,Z-Axis"), "set_axis", "get_axis");
 	ADD_GROUP("Flags", "");
@@ -468,7 +455,6 @@ void Sprite3D::_draw() {
 	}
 
 	Color color = _get_color_accum();
-	color.a *= get_opacity();
 
 	real_t pixel_size = get_pixel_size();
 
@@ -835,7 +821,6 @@ void AnimatedSprite3D::_draw() {
 	}
 
 	Color color = _get_color_accum();
-	color.a *= get_opacity();
 
 	real_t pixel_size = get_pixel_size();
 

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -69,7 +69,6 @@ private:
 	bool vflip = false;
 
 	Color modulate = Color(1, 1, 1, 1);
-	float opacity = 1.0;
 
 	Vector3::Axis axis = Vector3::AXIS_Z;
 	real_t pixel_size = 0.01;
@@ -120,9 +119,6 @@ public:
 
 	void set_modulate(const Color &p_color);
 	Color get_modulate() const;
-
-	void set_opacity(float p_amount);
-	float get_opacity() const;
 
 	void set_pixel_size(real_t p_amount);
 	real_t get_pixel_size() const;


### PR DESCRIPTION
The `opacity` property is superseded by the GeometryInstance3D `transparency` property. It works the opposite way (0.0 is opaque, 1.0 is fully transparent), but provides the same behavior in a more universal manner. Alternatively, you can set the alpha channel on the `modulate` property (as long as the material is configured to use vertex color as albedo).

I tested GeometryInstance3D's `transparency` property on Sprite3D and can confirm it works:

https://user-images.githubusercontent.com/180032/143893728-8c3e613c-42df-4ec4-9370-8da0ae89e41d.mp4
