### PR TITLE
[3.x] Don't show tooltips for paused controls

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2232,7 +2232,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				}
 			}
 
-			if (can_tooltip && !is_tooltip_shown) {
+			if (can_tooltip && !is_tooltip_shown && over->can_process()) {
 				if (gui.tooltip_timer.is_valid()) {
 					gui.tooltip_timer->release_connections();
 					gui.tooltip_timer = Ref<SceneTreeTimer>();


### PR DESCRIPTION
Backport of #55437