### PR TITLE
Fix scene tree dock icon not switching colors on theme change

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1306,6 +1306,7 @@ void SceneTreeDock::_notification(int p_what) {
 			button_instance->set_icon(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")));
 			button_create_script->set_icon(get_theme_icon(SNAME("ScriptCreate"), SNAME("EditorIcons")));
 			button_detach_script->set_icon(get_theme_icon(SNAME("ScriptRemove"), SNAME("EditorIcons")));
+			button_tree_menu->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 			button_2d->set_icon(get_theme_icon(SNAME("Node2D"), SNAME("EditorIcons")));
 			button_3d->set_icon(get_theme_icon(SNAME("Node3D"), SNAME("EditorIcons")));
 			button_ui->set_icon(get_theme_icon(SNAME("Control"), SNAME("EditorIcons")));


### PR DESCRIPTION
This fixes the "three vertical dots" button at the right of the scene tree dock when switching from a dark theme to a light theme or vice versa.

This icon doesn't exist in `3.x`, so this PR can't be cherry-picked.

## Preview

![image](https://user-images.githubusercontent.com/180032/143924773-c675a2db-1e24-4c88-b58d-188264941d9c.png)