### PR TITLE
Rename TextureRect.expand to ignore_texture_size

### DIFF
--- a/doc/classes/TextureRect.xml
+++ b/doc/classes/TextureRect.xml
@@ -10,14 +10,14 @@
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/676</link>
 	</tutorials>
 	<members>
-		<member name="expand" type="bool" setter="set_expand" getter="has_expand" default="false">
-			If [code]true[/code], the texture scales to fit its bounding rectangle.
-		</member>
 		<member name="flip_h" type="bool" setter="set_flip_h" getter="is_flipped_h" default="false">
 			If [code]true[/code], texture is flipped horizontally.
 		</member>
 		<member name="flip_v" type="bool" setter="set_flip_v" getter="is_flipped_v" default="false">
 			If [code]true[/code], texture is flipped vertically.
+		</member>
+		<member name="ignore_texture_size" type="bool" setter="set_ignore_texture_size" getter="get_ignore_texture_size" default="false">
+			If [code]true[/code], the size of the texture won't be considered for minimum size calculation, so the [TextureRect] can be shrunk down past the texture size. Useful for preventing [TextureRect]s from breaking GUI layout regardless of their texture size.
 		</member>
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" overrides="Control" enum="Control.MouseFilter" default="1" />
 		<member name="stretch_mode" type="int" setter="set_stretch_mode" getter="get_stretch_mode" enum="TextureRect.StretchMode" default="0">
@@ -28,28 +28,25 @@
 		</member>
 	</members>
 	<constants>
-		<constant name="STRETCH_SCALE_ON_EXPAND" value="0" enum="StretchMode">
-			Scale to fit the node's bounding rectangle, only if [code]expand[/code] is [code]true[/code]. Default [code]stretch_mode[/code], for backwards compatibility. Until you set [code]expand[/code] to [code]true[/code], the texture will behave like [constant STRETCH_KEEP].
-		</constant>
-		<constant name="STRETCH_SCALE" value="1" enum="StretchMode">
+		<constant name="STRETCH_SCALE" value="0" enum="StretchMode">
 			Scale to fit the node's bounding rectangle.
 		</constant>
-		<constant name="STRETCH_TILE" value="2" enum="StretchMode">
+		<constant name="STRETCH_TILE" value="1" enum="StretchMode">
 			Tile inside the node's bounding rectangle.
 		</constant>
-		<constant name="STRETCH_KEEP" value="3" enum="StretchMode">
+		<constant name="STRETCH_KEEP" value="2" enum="StretchMode">
 			The texture keeps its original size and stays in the bounding rectangle's top-left corner.
 		</constant>
-		<constant name="STRETCH_KEEP_CENTERED" value="4" enum="StretchMode">
+		<constant name="STRETCH_KEEP_CENTERED" value="3" enum="StretchMode">
 			The texture keeps its original size and stays centered in the node's bounding rectangle.
 		</constant>
-		<constant name="STRETCH_KEEP_ASPECT" value="5" enum="StretchMode">
+		<constant name="STRETCH_KEEP_ASPECT" value="4" enum="StretchMode">
 			Scale the texture to fit the node's bounding rectangle, but maintain the texture's aspect ratio.
 		</constant>
-		<constant name="STRETCH_KEEP_ASPECT_CENTERED" value="6" enum="StretchMode">
+		<constant name="STRETCH_KEEP_ASPECT_CENTERED" value="5" enum="StretchMode">
 			Scale the texture to fit the node's bounding rectangle, center it and maintain its aspect ratio.
 		</constant>
-		<constant name="STRETCH_KEEP_ASPECT_COVERED" value="7" enum="StretchMode">
+		<constant name="STRETCH_KEEP_ASPECT_COVERED" value="6" enum="StretchMode">
 			Scale the texture so that the shorter side fits the bounding rectangle. The other side clips to the node's limits.
 		</constant>
 	</constants>

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -645,7 +645,7 @@ EditorProfiler::EditorProfiler() {
 	variables->connect("item_edited", callable_mp(this, &EditorProfiler::_item_edited));
 
 	graph = memnew(TextureRect);
-	graph->set_expand(true);
+	graph->set_ignore_texture_size(true);
 	graph->set_mouse_filter(MOUSE_FILTER_STOP);
 	graph->connect("draw", callable_mp(this, &EditorProfiler::_graph_tex_draw));
 	graph->connect("gui_input", callable_mp(this, &EditorProfiler::_graph_tex_input));

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -786,7 +786,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	variables->connect("cell_selected", callable_mp(this, &EditorVisualProfiler::_item_selected));
 
 	graph = memnew(TextureRect);
-	graph->set_expand(true);
+	graph->set_ignore_texture_size(true);
 	graph->set_mouse_filter(MOUSE_FILTER_STOP);
 	//graph->set_ignore_mouse(false);
 	graph->connect("draw", callable_mp(this, &EditorVisualProfiler::_graph_tex_draw));

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -874,7 +874,7 @@ EditorResourcePicker::EditorResourcePicker() {
 	assign_button->connect("gui_input", callable_mp(this, &EditorResourcePicker::_button_input));
 
 	preview_rect = memnew(TextureRect);
-	preview_rect->set_expand(true);
+	preview_rect->set_ignore_texture_size(true);
 	preview_rect->set_anchors_and_offsets_preset(PRESET_WIDE);
 	preview_rect->set_offset(SIDE_TOP, 1);
 	preview_rect->set_offset(SIDE_BOTTOM, -1);

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -288,7 +288,7 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 
 	preview = memnew(TextureRect);
 	previews_vbox->add_child(preview);
-	preview->set_expand(true);
+	preview->set_ignore_texture_size(true);
 	preview->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 	preview->set_custom_minimum_size(Size2(640 * EDSCALE, 345 * EDSCALE));
 

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1232,7 +1232,7 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_vb->add_child(split_sheet_panel);
 
 	split_sheet_preview = memnew(TextureRect);
-	split_sheet_preview->set_expand(true);
+	split_sheet_preview->set_ignore_texture_size(true);
 	split_sheet_preview->set_mouse_filter(MOUSE_FILTER_PASS);
 	split_sheet_preview->connect("draw", callable_mp(this, &SpriteFramesEditor::_sheet_preview_draw));
 	split_sheet_preview->connect("gui_input", callable_mp(this, &SpriteFramesEditor::_sheet_preview_input));

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -84,7 +84,7 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 	texture_display->set_texture(p_texture);
 	texture_display->set_anchors_preset(TextureRect::PRESET_WIDE);
 	texture_display->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
-	texture_display->set_expand(true);
+	texture_display->set_ignore_texture_size(true);
 	add_child(texture_display);
 
 	if (p_show_metadata) {

--- a/editor/plugins/tiles/atlas_merging_dialog.cpp
+++ b/editor/plugins/tiles/atlas_merging_dialog.cpp
@@ -301,7 +301,7 @@ AtlasMergingDialog::AtlasMergingDialog() {
 	preview = memnew(TextureRect);
 	preview->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	preview->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	preview->set_expand(true);
+	preview->set_ignore_texture_size(true);
 	preview->hide();
 	preview->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
 	atlas_merging_right_panel->add_child(preview);

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -44,9 +44,6 @@ void TextureRect::_notification(int p_what) {
 		bool tile = false;
 
 		switch (stretch_mode) {
-			case STRETCH_SCALE_ON_EXPAND: {
-				size = expand ? get_size() : texture->get_size();
-			} break;
 			case STRETCH_SCALE: {
 				size = get_size();
 			} break;
@@ -114,7 +111,7 @@ void TextureRect::_notification(int p_what) {
 }
 
 Size2 TextureRect::get_minimum_size() const {
-	if (!expand && !texture.is_null()) {
+	if (!ignore_texture_size && !texture.is_null()) {
 		return texture->get_size();
 	} else {
 		return Size2();
@@ -124,8 +121,8 @@ Size2 TextureRect::get_minimum_size() const {
 void TextureRect::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture", "texture"), &TextureRect::set_texture);
 	ClassDB::bind_method(D_METHOD("get_texture"), &TextureRect::get_texture);
-	ClassDB::bind_method(D_METHOD("set_expand", "enable"), &TextureRect::set_expand);
-	ClassDB::bind_method(D_METHOD("has_expand"), &TextureRect::has_expand);
+	ClassDB::bind_method(D_METHOD("set_ignore_texture_size", "ignore"), &TextureRect::set_ignore_texture_size);
+	ClassDB::bind_method(D_METHOD("get_ignore_texture_size"), &TextureRect::get_ignore_texture_size);
 	ClassDB::bind_method(D_METHOD("set_flip_h", "enable"), &TextureRect::set_flip_h);
 	ClassDB::bind_method(D_METHOD("is_flipped_h"), &TextureRect::is_flipped_h);
 	ClassDB::bind_method(D_METHOD("set_flip_v", "enable"), &TextureRect::set_flip_v);
@@ -134,12 +131,11 @@ void TextureRect::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_stretch_mode"), &TextureRect::get_stretch_mode);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_texture", "get_texture");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "expand"), "set_expand", "has_expand");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "stretch_mode", PROPERTY_HINT_ENUM, "Scale On Expand (Compat),Scale,Tile,Keep,Keep Centered,Keep Aspect,Keep Aspect Centered,Keep Aspect Covered"), "set_stretch_mode", "get_stretch_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_texture_size"), "set_ignore_texture_size", "get_ignore_texture_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "stretch_mode", PROPERTY_HINT_ENUM, "Scale,Tile,Keep,Keep Centered,Keep Aspect,Keep Aspect Centered,Keep Aspect Covered"), "set_stretch_mode", "get_stretch_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_h"), "set_flip_h", "is_flipped_h");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "flip_v"), "set_flip_v", "is_flipped_v");
 
-	BIND_ENUM_CONSTANT(STRETCH_SCALE_ON_EXPAND);
 	BIND_ENUM_CONSTANT(STRETCH_SCALE);
 	BIND_ENUM_CONSTANT(STRETCH_TILE);
 	BIND_ENUM_CONSTANT(STRETCH_KEEP);
@@ -179,14 +175,14 @@ Ref<Texture2D> TextureRect::get_texture() const {
 	return texture;
 }
 
-void TextureRect::set_expand(bool p_expand) {
-	expand = p_expand;
+void TextureRect::set_ignore_texture_size(bool p_ignore) {
+	ignore_texture_size = p_ignore;
 	update();
 	update_minimum_size();
 }
 
-bool TextureRect::has_expand() const {
-	return expand;
+bool TextureRect::get_ignore_texture_size() const {
+	return ignore_texture_size;
 }
 
 void TextureRect::set_stretch_mode(StretchMode p_mode) {

--- a/scene/gui/texture_rect.h
+++ b/scene/gui/texture_rect.h
@@ -38,7 +38,6 @@ class TextureRect : public Control {
 
 public:
 	enum StretchMode {
-		STRETCH_SCALE_ON_EXPAND, //default, for backwards compatibility
 		STRETCH_SCALE,
 		STRETCH_TILE,
 		STRETCH_KEEP,
@@ -49,11 +48,11 @@ public:
 	};
 
 private:
-	bool expand = false;
+	bool ignore_texture_size = false;
 	bool hflip = false;
 	bool vflip = false;
 	Ref<Texture2D> texture;
-	StretchMode stretch_mode = STRETCH_SCALE_ON_EXPAND;
+	StretchMode stretch_mode = STRETCH_SCALE;
 
 	void _texture_changed();
 
@@ -66,8 +65,8 @@ public:
 	void set_texture(const Ref<Texture2D> &p_tex);
 	Ref<Texture2D> get_texture() const;
 
-	void set_expand(bool p_expand);
-	bool has_expand() const;
+	void set_ignore_texture_size(bool p_ignore);
+	bool get_ignore_texture_size() const;
 
 	void set_stretch_mode(StretchMode p_mode);
 	StretchMode get_stretch_mode() const;


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/54161#issuecomment-982102618
- removed `Scale On Expand (Compat)` stretch option
- renamed `expand` to `ignore_texture_size`, which is more descriptive

Seems like the `expand` property has changed its function during development and the compat enum value was added to keep compatibility. We can take the chance to clean it up - remove the compat value and rename the property to better describe its new purpose.

`expand` property exists in a few other controls, so not sure if we should aim for consistency and try to pick an universal name or handle it individually. AFAIK other `expand` properties don't work exactly the same.