### PR TITLE
Fix first-click handle not showing upon creating collision polygon on tileset editor (resolves #55005)

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -2885,7 +2885,6 @@ void TileSetEditor::draw_polygon_shapes() {
 		}
 		workspace->draw_line(current_shape[current_shape.size() - 1], snap_point(workspace->get_local_mouse_position()), Color(0, 1, 1), 1, true);
 	}
-	
 	if (creating_shape) {
 		draw_handles = true;
 	}

--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -2884,6 +2884,9 @@ void TileSetEditor::draw_polygon_shapes() {
 			workspace->draw_line(current_shape[j], current_shape[j + 1], Color(0, 1, 1), 1, true);
 		}
 		workspace->draw_line(current_shape[current_shape.size() - 1], snap_point(workspace->get_local_mouse_position()), Color(0, 1, 1), 1, true);
+	}
+	
+	if (creating_shape) {
 		draw_handles = true;
 	}
 }


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fix first handle not showing upon creating collision polygon on tileset.

This pull need advice for variable assignment redundancy on:
 - [#L2697](https://github.com/HanzCEO/fix-dot-appearance/blob/bd84c010fbd3db38609529793ebd7dba8c9df815/editor/plugins/tile_set_editor_plugin.cpp#L2697)
 - [#L2734](https://github.com/HanzCEO/fix-dot-appearance/blob/bd84c010fbd3db38609529793ebd7dba8c9df815/editor/plugins/tile_set_editor_plugin.cpp#L2734)
 - [#L2782](https://github.com/HanzCEO/fix-dot-appearance/blob/bd84c010fbd3db38609529793ebd7dba8c9df815/editor/plugins/tile_set_editor_plugin.cpp#L2782)
 - [#L2822](https://github.com/HanzCEO/fix-dot-appearance/blob/bd84c010fbd3db38609529793ebd7dba8c9df815/editor/plugins/tile_set_editor_plugin.cpp#L2822)
 - [#L2871](https://github.com/HanzCEO/fix-dot-appearance/blob/bd84c010fbd3db38609529793ebd7dba8c9df815/editor/plugins/tile_set_editor_plugin.cpp#L2871)

Because it will be overwritten by [#L2890](https://github.com/HanzCEO/fix-dot-appearance/blob/3.x/editor/plugins/tile_set_editor_plugin.cpp#L2890)