### PR TITLE
[HTML5] Fix multi-touch input handling.

### DIFF
--- a/platform/javascript/js/libs/library_godot_input.js
+++ b/platform/javascript/js/libs/library_godot_input.js
@@ -424,9 +424,9 @@ const GodotInput = {
 			for (let i = 0; i < touches.length; i++) {
 				const touch = touches[i];
 				const pos = GodotInput.computePosition(touch, rect);
-				GodotRuntime.setHeapValue(coords + (i * 2), pos[0], 'double');
-				GodotRuntime.setHeapValue(coords + (i * 2 + 8), pos[1], 'double');
-				GodotRuntime.setHeapValue(ids + i, touch.identifier, 'i32');
+				GodotRuntime.setHeapValue(coords + (i * 2) * 8, pos[0], 'double');
+				GodotRuntime.setHeapValue(coords + (i * 2 + 1) * 8, pos[1], 'double');
+				GodotRuntime.setHeapValue(ids + i * 4, touch.identifier, 'i32');
 			}
 			func(type, touches.length);
 			if (evt.cancelable) {


### PR DESCRIPTION
The code to populate the input data for WebAssembly was incorrectly overriding values when multiple touches were present due to wrong indexing.

Fixes #54135 .