### PR TITLE
Improve language lists in localization editor

### DIFF
--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -497,7 +497,7 @@ void LocalizationEditor::update_translations() {
 
 			TreeItem *t = translation_filter->create_item(root);
 			t->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
-			t->set_text(0, n);
+			t->set_text(0, vformat("[%s] %s", l, n));
 			t->set_editable(0, true);
 			t->set_tooltip(0, l);
 			t->set_checked(0, is_checked);
@@ -537,7 +537,7 @@ void LocalizationEditor::update_translations() {
 					if (langnames.length() > 0) {
 						langnames += ",";
 					}
-					langnames += names[i];
+					langnames += vformat("[%s] %s", langs[i], names[i]);
 					translation_locales_idxs_remap.write[l_idx] = i;
 					l_idx++;
 				}
@@ -546,7 +546,7 @@ void LocalizationEditor::update_translations() {
 			if (i > 0) {
 				langnames += ",";
 			}
-			langnames += names[i];
+			langnames += vformat("[%s] %s", langs[i], names[i]);
 		}
 	}
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2743,7 +2743,7 @@ ProjectManager::ProjectManager() {
 		for (int i = 0; i < editor_languages.size(); i++) {
 			String lang = editor_languages[i];
 			String lang_name = TranslationServer::get_singleton()->get_locale_name(lang);
-			language_btn->add_item(lang_name + " [" + lang + "]", i);
+			language_btn->add_item(vformat("[%s] %s", lang, lang_name), i);
 			language_btn->set_item_metadata(i, lang);
 			if (current_lang == lang) {
 				language_btn->select(i);


### PR DESCRIPTION
The list of languages in the remap menu is sorted by locale code, but displays language names, which is not really good usability.

Instead, I made it display both
![image](https://user-images.githubusercontent.com/2223172/144045645-02324659-8be4-4edc-bc6d-7d76642cdc6b.png)
![image](https://user-images.githubusercontent.com/2223172/144045655-adb018db-73a7-44d9-9548-cba708373d65.png)
