### PR TITLE
[3.x] Fix a crash in editor's script parent class check

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -869,8 +869,13 @@ bool EditorData::script_class_is_parent(const String &p_class, const String &p_i
 	if (!ScriptServer::is_global_class(p_class)) {
 		return false;
 	}
-	String base = script_class_get_base(p_class);
+
 	Ref<Script> script = script_class_load_script(p_class);
+	if (script.is_null()) {
+		return false;
+	}
+
+	String base = script_class_get_base(p_class);
 	Ref<Script> base_script = script->get_base_script();
 
 	while (p_inherits != base) {


### PR DESCRIPTION
`3.x.` version of https://github.com/godotengine/godot/pull/55477.
