### PR TITLE
Make default/project theme wait for modules before initializing

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -442,6 +442,9 @@ Error Main::test_setup() {
 	register_module_types();
 	register_driver_types();
 
+	// Theme needs modules to be initialized so that sub-resources can be loaded.
+	initialize_theme();
+
 	ERR_FAIL_COND_V(TextServerManager::get_singleton()->get_interface_count() == 0, ERR_CANT_CREATE);
 	TextServerManager::get_singleton()->set_primary_interface(TextServerManager::get_singleton()->get_interface(0));
 
@@ -1881,6 +1884,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	register_platform_apis();
 	register_module_types();
+
+	// Theme needs modules to be initialized so that sub-resources can be loaded.
+	initialize_theme();
 
 	GLOBAL_DEF("display/mouse_cursor/custom_image", String());
 	GLOBAL_DEF("display/mouse_cursor/custom_image_hotspot", Vector2());

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1031,6 +1031,16 @@ void register_scene_types() {
 		GLOBAL_DEF_BASIC(vformat("layer_names/3d_navigation/layer_%d", i + 1), "");
 	}
 
+	if (RenderingServer::get_singleton()) {
+		ColorPicker::init_shaders(); // RenderingServer needs to exist for this to succeed.
+	}
+
+	SceneDebugger::initialize();
+
+	NativeExtensionManager::get_singleton()->initialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SCENE);
+}
+
+void initialize_theme() {
 	bool default_theme_hidpi = GLOBAL_DEF("gui/theme/use_hidpi", false);
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/use_hidpi", PropertyInfo(Variant::BOOL, "gui/theme/use_hidpi", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
 	String theme_path = GLOBAL_DEF_RST("gui/theme/custom", "");
@@ -1049,7 +1059,6 @@ void register_scene_types() {
 	// Always make the default theme to avoid invalid default font/icon/style in the given theme.
 	if (RenderingServer::get_singleton()) {
 		make_default_theme(default_theme_hidpi, font);
-		ColorPicker::init_shaders(); // RenderingServer needs to exist for this to succeed.
 	}
 
 	if (theme_path != String()) {
@@ -1063,9 +1072,6 @@ void register_scene_types() {
 			ERR_PRINT("Error loading custom theme '" + theme_path + "'");
 		}
 	}
-	SceneDebugger::initialize();
-
-	NativeExtensionManager::get_singleton()->initialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SCENE);
 }
 
 void unregister_scene_types() {

--- a/scene/register_scene_types.h
+++ b/scene/register_scene_types.h
@@ -34,4 +34,6 @@
 void register_scene_types();
 void unregister_scene_types();
 
+void initialize_theme();
+
 #endif


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/54752. Fixes https://github.com/godotengine/godot/issues/55008.

I'm not sure if it's okay to add a new method to `register_scene_types.h/cpp`, but only other option I see immediately is moving this code to `main.cpp`, like so many other things. But that sounds way worse (it's crowded as is). As such, I've decided that the best approach is to keep the code in the same file.

The problem is that theme needs some modules to be loaded before it can attempt to be loaded itself, at least this is true for custom themes. But I've moved all related code to keep it all together (it shouldn't affect anything else, other than fix the issue at hand).