### PR TITLE
[3.x] Make default/project theme wait for modules before initializing

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1485,6 +1485,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	register_platform_apis();
 	register_module_types();
 
+	// Theme needs modules to be initialized so that sub-resources can be loaded.
+	initialize_theme();
+
 	GLOBAL_DEF("display/mouse_cursor/custom_image", String());
 	GLOBAL_DEF("display/mouse_cursor/custom_image_hotspot", Vector2());
 	GLOBAL_DEF("display/mouse_cursor/tooltip_position_offset", Point2(10, 10));

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -767,7 +767,9 @@ void register_scene_types() {
 		GLOBAL_DEF("layer_names/2d_physics/layer_" + itos(i + 1), "");
 		GLOBAL_DEF("layer_names/3d_physics/layer_" + itos(i + 1), "");
 	}
+}
 
+void initialize_theme() {
 	bool default_theme_hidpi = GLOBAL_DEF("gui/theme/use_hidpi", false);
 	ProjectSettings::get_singleton()->set_custom_property_info("gui/theme/use_hidpi", PropertyInfo(Variant::BOOL, "gui/theme/use_hidpi", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED));
 	String theme_path = GLOBAL_DEF_RST("gui/theme/custom", "");

--- a/scene/register_scene_types.h
+++ b/scene/register_scene_types.h
@@ -34,4 +34,6 @@
 void register_scene_types();
 void unregister_scene_types();
 
+void initialize_theme();
+
 #endif


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/55483. Same considerations apply.
