### PR TITLE
Fix physics 2D/3D contact points rendering

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -396,14 +396,15 @@ void Viewport::_notification(int p_what) {
 #ifndef _3D_DISABLED
 				PhysicsServer3D::get_singleton()->space_set_debug_contacts(find_world_3d()->get_space(), get_tree()->get_collision_debug_contact_count());
 				contact_3d_debug_multimesh = RenderingServer::get_singleton()->multimesh_create();
-				RenderingServer::get_singleton()->multimesh_allocate_data(contact_3d_debug_multimesh, get_tree()->get_collision_debug_contact_count(), RS::MULTIMESH_TRANSFORM_3D, true);
+				RenderingServer::get_singleton()->multimesh_allocate_data(contact_3d_debug_multimesh, get_tree()->get_collision_debug_contact_count(), RS::MULTIMESH_TRANSFORM_3D, false);
 				RenderingServer::get_singleton()->multimesh_set_visible_instances(contact_3d_debug_multimesh, 0);
 				RenderingServer::get_singleton()->multimesh_set_mesh(contact_3d_debug_multimesh, get_tree()->get_debug_contact_mesh()->get_rid());
 				contact_3d_debug_instance = RenderingServer::get_singleton()->instance_create();
 				RenderingServer::get_singleton()->instance_set_base(contact_3d_debug_instance, contact_3d_debug_multimesh);
 				RenderingServer::get_singleton()->instance_set_scenario(contact_3d_debug_instance, find_world_3d()->get_scenario());
-				//RenderingServer::get_singleton()->instance_geometry_set_flag(contact_3d_debug_instance, RS::INSTANCE_FLAG_VISIBLE_IN_ALL_ROOMS, true);
+				RenderingServer::get_singleton()->instance_geometry_set_flag(contact_3d_debug_instance, RS::INSTANCE_FLAG_DRAW_NEXT_FRAME_IF_VISIBLE, true);
 #endif // _3D_DISABLED
+				set_physics_process_internal(true);
 			}
 
 		} break;


### PR DESCRIPTION
Physics internal process was removed by mistake, it's needed for contact points to be updated each frame.

Fixes the 4.x specific part of #53486 (contact points not rendering at all in 2D).
Fixes a part of #45862 (contact points not rendering at all in 3D).

Fixed some multimesh parameters to allow 3D contact points to be drawn, although it's still not working well in 3D because of an issue with multimesh rendering. Only some of the visible instances are drawn, and some of them keep being drawn when the number of visible instances drops to 0 instead of hiding them all.

Current state in 3D:
![contact_points_3d](https://user-images.githubusercontent.com/1075032/144090052-09b86132-94b9-4acb-9d9a-183aa71322a5.gif)
Not all contact points appear, and they don't disappear as they should at the end.
