### PR TITLE
Rename all methods that return `ScrollBar` nodes to `get_*_scroll_bar()`

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -155,7 +155,7 @@
 				Returns an array with the indexes of the selected items.
 			</description>
 		</method>
-		<method name="get_v_scroll">
+		<method name="get_v_scroll_bar">
 			<return type="VScrollBar" />
 			<description>
 				Returns the [Object] ID associated with the list.

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -97,7 +97,7 @@
 				Returns the total number of characters from text tags. Does not include BBCodes.
 			</description>
 		</method>
-		<method name="get_v_scroll">
+		<method name="get_v_scroll_bar">
 			<return type="VScrollBar" />
 			<description>
 				Returns the vertical scrollbar.

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -18,14 +18,14 @@
 				Ensures the given [code]control[/code] is visible (must be a direct or indirect child of the ScrollContainer). Used by [member follow_focus].
 			</description>
 		</method>
-		<method name="get_h_scrollbar">
+		<method name="get_h_scroll_bar">
 			<return type="HScrollBar" />
 			<description>
 				Returns the horizontal scrollbar [HScrollBar] of this [ScrollContainer].
 				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to disable the horizontal scrollbar, use [member scroll_horizontal_enabled]. If you want to only hide it instead, use [member scroll_horizontal_visible].
 			</description>
 		</method>
-		<method name="get_v_scrollbar">
+		<method name="get_v_scroll_bar">
 			<return type="VScrollBar" />
 			<description>
 				Returns the vertical scrollbar [VScrollBar] of this [ScrollContainer].

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3380,7 +3380,7 @@ Dictionary AnimationTrackEditor::get_state() const {
 	state["fps_mode"] = timeline->is_using_fps();
 	state["zoom"] = zoom->get_value();
 	state["offset"] = timeline->get_value();
-	state["v_scroll"] = scroll->get_v_scrollbar()->get_value();
+	state["v_scroll"] = scroll->get_v_scroll_bar()->get_value();
 	return state;
 }
 
@@ -3408,9 +3408,9 @@ void AnimationTrackEditor::set_state(const Dictionary &p_state) {
 		timeline->set_value(0);
 	}
 	if (p_state.has("v_scroll")) {
-		scroll->get_v_scrollbar()->set_value(p_state["v_scroll"]);
+		scroll->get_v_scroll_bar()->set_value(p_state["v_scroll"]);
 	} else {
-		scroll->get_v_scrollbar()->set_value(0);
+		scroll->get_v_scroll_bar()->set_value(0);
 	}
 }
 
@@ -6031,7 +6031,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	scroll = memnew(ScrollContainer);
 	timeline_vbox->add_child(scroll);
 	scroll->set_v_size_flags(SIZE_EXPAND_FILL);
-	VScrollBar *sb = scroll->get_v_scrollbar();
+	VScrollBar *sb = scroll->get_v_scroll_bar();
 	scroll->remove_child(sb);
 	timeline_scroll->add_child(sb); // Move here so timeline and tracks are always aligned.
 	scroll->connect("gui_input", callable_mp(this, &AnimationTrackEditor::_scroll_input));

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -721,7 +721,7 @@ void EditorFileDialog::update_file_list() {
 	item_list->clear();
 
 	// Scroll back to the top after opening a directory
-	item_list->get_v_scroll()->set_value(0);
+	item_list->get_v_scroll_bar()->set_value(0);
 
 	if (display_mode == DISPLAY_THUMBNAILS) {
 		item_list->set_max_columns(0);

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1740,11 +1740,11 @@ void EditorHelp::search_again(bool p_search_previous) {
 }
 
 int EditorHelp::get_scroll() const {
-	return class_desc->get_v_scroll()->get_value();
+	return class_desc->get_v_scroll_bar()->get_value();
 }
 
 void EditorHelp::set_scroll(int p_scroll) {
-	class_desc->get_v_scroll()->set_value(p_scroll);
+	class_desc->get_v_scroll_bar()->set_value(p_scroll);
 }
 
 void EditorHelp::update_toggle_scripts_button() {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3345,7 +3345,7 @@ void EditorInspector::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_PROCESS) {
 		if (update_scroll_request >= 0) {
-			get_v_scrollbar()->call_deferred(SNAME("set_value"), update_scroll_request);
+			get_v_scroll_bar()->call_deferred(SNAME("set_value"), update_scroll_request);
 			update_scroll_request = -1;
 		}
 		if (refresh_countdown > 0) {
@@ -3567,7 +3567,7 @@ EditorInspector::EditorInspector() {
 	deletable_properties = false;
 	property_clipboard = Variant();
 
-	get_v_scrollbar()->connect("value_changed", callable_mp(this, &EditorInspector::_vscroll_changed));
+	get_v_scroll_bar()->connect("value_changed", callable_mp(this, &EditorInspector::_vscroll_changed));
 	update_scroll_request = -1;
 	if (EditorSettings::get_singleton()) {
 		refresh_countdown = float(EditorSettings::get_singleton()->get("docks/property_editor/auto_refresh_interval"));

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -528,7 +528,7 @@ void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_fa
 	_update_tree(_compute_uncollapsed_paths(), false, p_select_in_favorites, true);
 	if (display_mode == DISPLAY_MODE_SPLIT) {
 		_update_file_list(false);
-		files->get_v_scroll()->set_value(0);
+		files->get_v_scroll_bar()->set_value(0);
 	}
 
 	String file_name = p_path.get_file();

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1791,8 +1791,8 @@ void ProjectList::erase_selected_projects(bool p_delete_project_contents) {
 void ProjectList::_panel_draw(Node *p_hb) {
 	Control *hb = Object::cast_to<Control>(p_hb);
 
-	if (is_layout_rtl() && get_v_scrollbar()->is_visible_in_tree()) {
-		hb->draw_line(Point2(get_v_scrollbar()->get_minimum_size().x, hb->get_size().y + 1), Point2(hb->get_size().x, hb->get_size().y + 1), get_theme_color(SNAME("guide_color"), SNAME("Tree")));
+	if (is_layout_rtl() && get_v_scroll_bar()->is_visible_in_tree()) {
+		hb->draw_line(Point2(get_v_scroll_bar()->get_minimum_size().x, hb->get_size().y + 1), Point2(hb->get_size().x, hb->get_size().y + 1), get_theme_color(SNAME("guide_color"), SNAME("Tree")));
 	} else {
 		hb->draw_line(Point2(0, hb->get_size().y + 1), Point2(hb->get_size().x, hb->get_size().y + 1), get_theme_color(SNAME("guide_color"), SNAME("Tree")));
 	}

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1652,7 +1652,7 @@ void ItemList::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("ensure_current_is_visible"), &ItemList::ensure_current_is_visible);
 
-	ClassDB::bind_method(D_METHOD("get_v_scroll"), &ItemList::get_v_scroll);
+	ClassDB::bind_method(D_METHOD("get_v_scroll_bar"), &ItemList::get_v_scroll_bar);
 
 	ClassDB::bind_method(D_METHOD("set_text_overrun_behavior", "overrun_behavior"), &ItemList::set_text_overrun_behavior);
 	ClassDB::bind_method(D_METHOD("get_text_overrun_behavior"), &ItemList::get_text_overrun_behavior);

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -255,7 +255,7 @@ public:
 
 	void set_autoscroll_to_bottom(const bool p_enable);
 
-	VScrollBar *get_v_scroll() { return scroll_bar; }
+	VScrollBar *get_v_scroll_bar() { return scroll_bar; }
 
 	ItemList();
 	~ItemList();

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -50,7 +50,7 @@ Size2 PopupMenu::_get_contents_minimum_size() const {
 	int hseparation = get_theme_constant(SNAME("hseparation"));
 
 	Size2 minsize = get_theme_stylebox(SNAME("panel"))->get_minimum_size(); // Accounts for margin in the margin container
-	minsize.x += scroll_container->get_v_scrollbar()->get_size().width * 2; // Adds a buffer so that the scrollbar does not render over the top of content
+	minsize.x += scroll_container->get_v_scroll_bar()->get_size().width * 2; // Adds a buffer so that the scrollbar does not render over the top of content
 
 	float max_w = 0.0;
 	float icon_w = 0.0;
@@ -343,11 +343,11 @@ void PopupMenu::gui_input(const Ref<InputEvent> &p_event) {
 
 	// Make an area which does not include v scrollbar, so that items are not activated when dragging scrollbar.
 	Rect2 item_clickable_area = scroll_container->get_rect();
-	if (scroll_container->get_v_scrollbar()->is_visible_in_tree()) {
+	if (scroll_container->get_v_scroll_bar()->is_visible_in_tree()) {
 		if (is_layout_rtl()) {
-			item_clickable_area.position.x += scroll_container->get_v_scrollbar()->get_size().width;
+			item_clickable_area.position.x += scroll_container->get_v_scroll_bar()->get_size().width;
 		} else {
-			item_clickable_area.size.width -= scroll_container->get_v_scrollbar()->get_size().width;
+			item_clickable_area.size.width -= scroll_container->get_v_scroll_bar()->get_size().width;
 		}
 	}
 
@@ -508,7 +508,7 @@ void PopupMenu::_draw_items() {
 	Color font_hover_color = get_theme_color(SNAME("font_hover_color"));
 	Color font_separator_color = get_theme_color(SNAME("font_separator_color"));
 
-	float scroll_width = scroll_container->get_v_scrollbar()->is_visible_in_tree() ? scroll_container->get_v_scrollbar()->get_size().width : 0;
+	float scroll_width = scroll_container->get_v_scroll_bar()->is_visible_in_tree() ? scroll_container->get_v_scroll_bar()->get_size().width : 0;
 	float display_width = control->get_size().width - scroll_width;
 
 	// Find the widest icon and whether any items have a checkbox, and store the offsets for each.

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4105,7 +4105,7 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_scroll_follow", "follow"), &RichTextLabel::set_scroll_follow);
 	ClassDB::bind_method(D_METHOD("is_scroll_following"), &RichTextLabel::is_scroll_following);
 
-	ClassDB::bind_method(D_METHOD("get_v_scroll"), &RichTextLabel::get_v_scroll);
+	ClassDB::bind_method(D_METHOD("get_v_scroll_bar"), &RichTextLabel::get_v_scroll_bar);
 
 	ClassDB::bind_method(D_METHOD("scroll_to_line", "line"), &RichTextLabel::scroll_to_line);
 	ClassDB::bind_method(D_METHOD("scroll_to_paragraph", "paragraph"), &RichTextLabel::scroll_to_paragraph);

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -542,7 +542,7 @@ public:
 
 	int get_content_height() const;
 
-	VScrollBar *get_v_scroll() { return vscroll; }
+	VScrollBar *get_v_scroll_bar() { return vscroll; }
 
 	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -558,11 +558,11 @@ TypedArray<String> ScrollContainer::get_configuration_warnings() const {
 	return warnings;
 }
 
-HScrollBar *ScrollContainer::get_h_scrollbar() {
+HScrollBar *ScrollContainer::get_h_scroll_bar() {
 	return h_scroll;
 }
 
-VScrollBar *ScrollContainer::get_v_scrollbar() {
+VScrollBar *ScrollContainer::get_v_scroll_bar() {
 	return v_scroll;
 }
 
@@ -593,8 +593,8 @@ void ScrollContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_follow_focus", "enabled"), &ScrollContainer::set_follow_focus);
 	ClassDB::bind_method(D_METHOD("is_following_focus"), &ScrollContainer::is_following_focus);
 
-	ClassDB::bind_method(D_METHOD("get_h_scrollbar"), &ScrollContainer::get_h_scrollbar);
-	ClassDB::bind_method(D_METHOD("get_v_scrollbar"), &ScrollContainer::get_v_scrollbar);
+	ClassDB::bind_method(D_METHOD("get_h_scroll_bar"), &ScrollContainer::get_h_scroll_bar);
+	ClassDB::bind_method(D_METHOD("get_v_scroll_bar"), &ScrollContainer::get_v_scroll_bar);
 	ClassDB::bind_method(D_METHOD("ensure_control_visible", "control"), &ScrollContainer::ensure_control_visible);
 
 	ADD_SIGNAL(MethodInfo("scroll_started"));

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -104,8 +104,8 @@ public:
 	bool is_following_focus() const;
 	void set_follow_focus(bool p_follow);
 
-	HScrollBar *get_h_scrollbar();
-	VScrollBar *get_v_scrollbar();
+	HScrollBar *get_h_scroll_bar();
+	VScrollBar *get_v_scroll_bar();
 	void ensure_control_visible(Control *p_control);
 
 	TypedArray<String> get_configuration_warnings() const override;


### PR DESCRIPTION
Before, some nodes would have the methods be named `get_*_scroll()` or `get_*_scrollbar()`. This PR renames them to the consistent `get_*_scroll_bar()`, as the node's name is two words combined (`ScrollBar`).