### PR TITLE
Prevent a crash when comparing `Control` to `CanvasItem`

### DIFF
--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -155,6 +155,9 @@ public:
 private:
 	struct CComparator {
 		bool operator()(const Control *p_a, const Control *p_b) const {
+			if (!p_a || !p_b) { // The node is not a control node.
+				return false;
+			}
 			if (p_a->get_canvas_layer() == p_b->get_canvas_layer()) {
 				return p_b->is_greater_than(p_a);
 			}


### PR DESCRIPTION
Comparison of CanvasItem crashes.