### PR TITLE
Unify theme item lookup in Controls and respect default font

### DIFF
--- a/doc/classes/Theme.xml
+++ b/doc/classes/Theme.xml
@@ -126,7 +126,7 @@
 			<argument index="0" name="name" type="String" />
 			<argument index="1" name="node_type" type="String" />
 			<description>
-				Returns the [Font] at [code]name[/code] if the theme has [code]node_type[/code].
+				Returns the [Font] at [code]name[/code] if the theme has [code]node_type[/code]. If such item does not exist and [member default_font] is set on the theme, the default font will be returned.
 			</description>
 		</method>
 		<method name="get_font_list" qualifiers="const">

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -239,6 +239,11 @@ private:
 
 	void _update_minimum_size_cache();
 
+	template <class T>
+	static T get_theme_item_in_types(Control *p_theme_owner, Theme::DataType p_data_type, const StringName &p_name, List<StringName> p_theme_types);
+	static bool has_theme_item_in_types(Control *p_theme_owner, Theme::DataType p_data_type, const StringName &p_name, List<StringName> p_theme_types);
+	_FORCE_INLINE_ void _get_theme_type_dependencies(const StringName &p_theme_type, List<StringName> *p_list) const;
+
 protected:
 	virtual void add_child_notify(Node *p_child);
 	virtual void remove_child_notify(Node *p_child);

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -470,7 +470,7 @@ Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_node_typ
 }
 
 bool Theme::has_font(const StringName &p_name, const StringName &p_node_type) const {
-	return (font_map.has(p_node_type) && font_map[p_node_type].has(p_name) && font_map[p_node_type][p_name].is_valid());
+	return ((font_map.has(p_node_type) && font_map[p_node_type].has(p_name) && font_map[p_node_type][p_name].is_valid()) || has_default_theme_font());
 }
 
 bool Theme::has_font_nocheck(const StringName &p_name, const StringName &p_node_type) const {
@@ -921,6 +921,17 @@ void Theme::get_type_list(List<StringName> *p_list) const {
 
 	for (Set<StringName>::Element *E = types.front(); E; E = E->next()) {
 		p_list->push_back(E->get());
+	}
+}
+
+void Theme::get_type_dependencies(const StringName &p_base_type, List<StringName> *p_list) {
+	ERR_FAIL_NULL(p_list);
+
+	// Build the dependency chain using native class hierarchy.
+	StringName class_name = p_base_type;
+	while (class_name != StringName()) {
+		p_list->push_back(class_name);
+		class_name = ClassDB::get_parent_class_nocheck(class_name);
 	}
 }
 

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -189,6 +189,7 @@ public:
 	void get_theme_item_types(DataType p_data_type, List<StringName> *p_list) const;
 
 	void get_type_list(List<StringName> *p_list) const;
+	void get_type_dependencies(const StringName &p_base_type, List<StringName> *p_list);
 
 	void copy_default_theme();
 	void copy_theme(const Ref<Theme> &p_other);


### PR DESCRIPTION
Okay, let's try this. This is `3.x` only. Fixes https://github.com/godotengine/godot/issues/36614.

The problem was that the default font defined on any theme is never respected when looking up theme items from controls. The only way to receive the default font is to either directly fetch it from the Theme or to ask that Theme for an item that doesn't exist without checking with `has_...` first. This means that you can never, realistically, hit it for controls automatically. And that means, you can never get it from the custom project theme.

Now, this change is a fix for this behavior, and it matches the behavior currently present in `master` (added in https://github.com/godotengine/godot/pull/41100). This fix means that if any theme in the lookup chain has a default font, it will be used (as fallback), and no further lookup will be performed. This breaks current behavior, but I don't think that the impact of that change outweighs the benefit. In fact, since the default font never worked as expected, I doubt anyone actually used it. So I think this change is justified for `3.5`.

-----

While at it I've also unified the theme item lookup to match what we have in `master`. This can probably fix a few issues as well, since the old behavior was arbitrary for each theme item type. I excluded shaders from this change, since they are already deprecated and I don't want to add a shader type to the `DataType` enum and possibly create problems for the theme editor and other stuff.

This change is rather exciting, as it lays the groundwork for a backport of theme type variations (https://github.com/godotengine/godot/pull/50169). If this is accepted, theme type variations can be added without any compatibility breakage and can be a very cool feature for 3.5.