### PR TITLE
Misc improvements to various docs

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -123,13 +123,13 @@
 			If [code]true[/code], draws the camera's screen rectangle in the editor.
 		</member>
 		<member name="limit_bottom" type="int" setter="set_limit" getter="get_limit" default="10000000">
-			Bottom scroll limit in pixels. The camera stops moving when reaching this value.
+			Bottom scroll limit in pixels. The camera stops moving when reaching this value, but [member offset] can push the view past the limit.
 		</member>
 		<member name="limit_left" type="int" setter="set_limit" getter="get_limit" default="-10000000">
-			Left scroll limit in pixels. The camera stops moving when reaching this value.
+			Left scroll limit in pixels. The camera stops moving when reaching this value, but [member offset] can push the view past the limit.
 		</member>
 		<member name="limit_right" type="int" setter="set_limit" getter="get_limit" default="10000000">
-			Right scroll limit in pixels. The camera stops moving when reaching this value.
+			Right scroll limit in pixels. The camera stops moving when reaching this value, but [member offset] can push the view past the limit.
 		</member>
 		<member name="limit_smoothed" type="bool" setter="set_limit_smoothing_enabled" getter="is_limit_smoothing_enabled" default="false">
 			If [code]true[/code], the camera smoothly stops when reaches its limits.
@@ -137,10 +137,10 @@
 			[b]Note:[/b] To immediately update the camera's position to be within limits without smoothing, even with this setting enabled, invoke [method reset_smoothing].
 		</member>
 		<member name="limit_top" type="int" setter="set_limit" getter="get_limit" default="-10000000">
-			Top scroll limit in pixels. The camera stops moving when reaching this value.
+			Top scroll limit in pixels. The camera stops moving when reaching this value, but [member offset] can push the view past the limit.
 		</member>
 		<member name="offset" type="Vector2" setter="set_offset" getter="get_offset" default="Vector2(0, 0)">
-			The camera's offset, useful for looking around or camera shake animations.
+			The camera's relative offset. Useful for looking around or camera shake animations. The offseted camera can go past the limits defined in [member limit_top], [member limit_bottom], [member limit_left] and [member limit_right].
 		</member>
 		<member name="process_callback" type="int" setter="set_process_callback" getter="get_process_callback" enum="Camera2D.Camera2DProcessCallback" default="1">
 			The camera's process callback. See [enum Camera2DProcessCallback].

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -15,7 +15,7 @@
 			The touch index in the case of a multi-touch event. One index = one finger.
 		</member>
 		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
-			The touch position.
+			The touch position, in screen (global) coordinates.
 		</member>
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
 			If [code]true[/code], the touch's state is pressed. If [code]false[/code], the touch's state is released.

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -726,7 +726,7 @@
 	<signals>
 		<signal name="ready">
 			<description>
-				Emitted when the node is ready.
+				Emitted when the node is ready. Comes after [method _ready] callback and follows the same rules.
 			</description>
 		</signal>
 		<signal name="renamed">

--- a/doc/classes/ParticlesMaterial.xml
+++ b/doc/classes/ParticlesMaterial.xml
@@ -6,7 +6,7 @@
 	<description>
 		ParticlesMaterial defines particle properties and behavior. It is used in the [code]process_material[/code] of [GPUParticles3D] and [GPUParticles2D] emitter nodes.
 		Some of this material's properties are applied to each particle when emitted, while others can have a [CurveTexture] applied to vary values over the lifetime of the particle.
-		When a randomness ratio is applied to a property it is used to scale that property by a random amount. The random ratio is used to interpolate between [code]1.0[/code] and a random number less than one, the result is multiplied by the property to obtain the randomized property. For example a random ratio of [code]0.4[/code] would scale the original property between [code]0.4-1.0[/code] of its original value.
+		Particle animation is available only in [GPUParticles2D]. To use it, attach a [CanvasItemMaterial], with [member CanvasItemMaterial.particles_animation] enabled, to the particles node.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -104,7 +104,8 @@
 			Each particle's animation speed will vary along this [CurveTexture].
 		</member>
 		<member name="anim_speed_max" type="float" setter="set_param_max" getter="get_param_max" default="0.0">
-			Maximum particle animation speed.
+			Maximum particle animation speed. Animation speed of [code]1[/code] means that the particles will make full [code]0[/code] to [code]1[/code] offset cycle during lifetime, [code]2[/code] means [code]2[/code] cycles etc.
+			With animation speed greater than [code]1[/code], remember to enable [member CanvasItemMaterial.particles_anim_loop] property if you want the animation to repeat.
 		</member>
 		<member name="anim_speed_min" type="float" setter="set_param_min" getter="get_param_min" default="0.0">
 			Minimum particle animation speed.
@@ -195,7 +196,7 @@
 			Minimum initial velocity.
 		</member>
 		<member name="lifetime_randomness" type="float" setter="set_lifetime_randomness" getter="get_lifetime_randomness" default="0.0">
-			Particle lifetime randomness ratio.
+			Particle lifetime randomness ratio. The lifetime will be multipled by a value interpolated between [code]1.0[/code] and a random number less than one. For example a random ratio of [code]0.4[/code] would scale the original lifetime between [code]0.4-1.0[/code] of its original value.
 		</member>
 		<member name="linear_accel_curve" type="Texture2D" setter="set_param_texture" getter="get_param_texture">
 			Each particle's linear acceleration will vary along this [CurveTexture].

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -219,7 +219,7 @@
 			<argument index="0" name="to" type="Vector2" />
 			<argument index="1" name="delta" type="float" />
 			<description>
-				Moves the vector toward [code]to[/code] by the fixed [code]delta[/code] amount.
+				Moves the vector toward [code]to[/code] by the fixed [code]delta[/code] amount. Will not go past the final value.
 			</description>
 		</method>
 		<method name="normalized" qualifiers="const">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -201,7 +201,7 @@
 			<argument index="0" name="to" type="Vector3" />
 			<argument index="1" name="delta" type="float" />
 			<description>
-				Moves this vector toward [code]to[/code] by the fixed [code]delta[/code] amount.
+				Moves this vector toward [code]to[/code] by the fixed [code]delta[/code] amount. Will not go past the final value.
 			</description>
 		</method>
 		<method name="normalized" qualifiers="const">


### PR DESCRIPTION
Just some random stuff that I came across once and thought it could be improved.

As for the ParticlesMaterial changes, the ratio description looks like leftover from before the min-max were introduced. I rephrased it a bit and moved to the `lifetime_randomness` property (I assume it uses the same old formula).