### PR TITLE
Fix crashes when global named scripts extends an unnamed script

### DIFF
--- a/editor/create_dialog.h
+++ b/editor/create_dialog.h
@@ -41,6 +41,12 @@
 class CreateDialog : public ConfirmationDialog {
 	GDCLASS(CreateDialog, ConfirmationDialog);
 
+	enum TypeCategory {
+		CPP_TYPE,
+		PATH_TYPE,
+		OTHER_TYPE
+	};
+
 	LineEdit *search_box;
 	Tree *search_options;
 
@@ -62,8 +68,8 @@ class CreateDialog : public ConfirmationDialog {
 
 	void _update_search();
 	bool _should_hide_type(const String &p_type) const;
-	void _add_type(const String &p_current, bool p_cpp_type);
-	void _configure_search_option_item(TreeItem *r_item, const String &p_type, const bool p_cpp_type);
+	void _add_type(const String &p_type, const TypeCategory p_type_category);
+	void _configure_search_option_item(TreeItem *r_item, const String &p_type, const TypeCategory p_type_category);
 	String _top_result(const Vector<String> p_candidates, const String &p_search_text) const;
 	float _score_type(const String &p_type, const String &p_search) const;
 	bool _is_type_preferred(const String &p_type) const;


### PR DESCRIPTION
This PR prevents a crash when a script defined with class_name has extended a script without one when opening the 'Create node' window. Before, this instance would result in a stack overflow since script_class_get_base(p_type) would return null and the _add_type method did not have handling for this situation. This change goes further though and even allows unnamed classes to be displayed in the create node window if a named node is inheriting from it (though blanked out and unselectable). Previously, the following situation would crash the editor
![godot windows tools 64_gVQczgz3Rz](https://user-images.githubusercontent.com/12756047/144213189-288c83d0-41a6-4b6c-b6bb-5e20ea533f4a.png)

Changing the class_name of script can still result in a crash when running the documentation search. Originally included a stopgap commit in this PR to prevent this crash, though @fire has a dedicated PR addressing that crash here (#54406). Neither *fully* address the problem, but will at least prevent the editor from outright crashing for now.

Closes #53386