### PR TITLE
[3.x] Rationalize Node removals and deletions

### DIFF
--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -162,7 +162,6 @@ private:
 	void _propagate_ready();
 	void _propagate_exit_tree();
 	void _propagate_after_exit_tree();
-	void _propagate_validate_owner();
 	void _print_stray_nodes();
 	void _propagate_pause_owner(Node *p_owner);
 	Array _get_node_and_resource(const NodePath &p_path);


### PR DESCRIPTION
Version of #55512 for 3.x.

It's the same, less the `tree_exited` comes in the same order as `tree_exiting` part, to avoid compat breakage. Otherwise it should be fine.