### PR TITLE
[4.x] Faster Path2D drawing with polyline

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -100,16 +100,18 @@ void Path2D::_notification(int p_what) {
 #endif
 		const Color color = Color(0.5, 0.6, 1.0, 0.7);
 
-		for (int i = 0; i < curve->get_point_count(); i++) {
-			Vector2 prev_p = curve->get_point_position(i);
+		_cached_draw_pts.resize(curve->get_point_count() * 8);
+		int count = 0;
 
-			for (int j = 1; j <= 8; j++) {
-				real_t frac = j / 8.0;
+		for (int i = 0; i < curve->get_point_count(); i++) {
+			for (int j = 0; j < 8; j++) {
+				real_t frac = j * (1.0 / 8.0);
 				Vector2 p = curve->interpolate(i, frac);
-				draw_line(prev_p, p, color, line_width);
-				prev_p = p;
+				_cached_draw_pts.set(count++, p);
 			}
 		}
+
+		draw_polyline(_cached_draw_pts, color, line_width, true);
 	}
 }
 

--- a/scene/2d/path_2d.h
+++ b/scene/2d/path_2d.h
@@ -38,6 +38,7 @@ class Path2D : public Node2D {
 	GDCLASS(Path2D, Node2D);
 
 	Ref<Curve2D> curve;
+	Vector<Vector2> _cached_draw_pts;
 
 	void _curve_changed();
 


### PR DESCRIPTION
Changes the Path2D drawing to use POLYLINE instead of thick lines.

## Notes
* Part version of #54377 for Godot 4. There was interest in the PR meeting to port this to master.
* The drawing lines as polygons part of the original PR is not done here because there is no batching in master
*  The anti-aliasing option seems to actually produce feathered polylines rather than anti-aliased at the borders. So it may be worth waiting for that to get fixed before merging this. Alternatively merging this may cause the anti-aliasing to get fixed.
* I did try without anti-aliasing, but the lines didn't look very good at low scales. EDIT: Actually the existing code doesn't look good at low scale either so maybe that is an option...

### Before this PR
Before zoomed out:
![Screenshot from 2021-12-01 15-35-07](https://user-images.githubusercontent.com/21999379/144264426-d0adcfe4-f496-42c6-8b28-d154b6921014.png)

Before zoomed in:
![Screenshot from 2021-12-01 15-35-25](https://user-images.githubusercontent.com/21999379/144264470-03fcf33a-49cc-4ca7-bbe2-5a22c4f3eaf5.png)

### This is the result of the PR with anti-aliasing on (the current pushed state):
After zoomed out:
![Screenshot from 2021-12-01 15-31-53](https://user-images.githubusercontent.com/21999379/144264509-55487ea8-e182-4942-9990-ec22c8b2a17f.png)

After zoomed in:
![Screenshot from 2021-12-01 15-31-29](https://user-images.githubusercontent.com/21999379/144264595-8c0edb32-3d96-40bf-ae75-2b6ac42ab96e.png)

### Also for comparison, this PR with anti-aliasing switched to off (let me know if this is preferred and I can change it):
![Screenshot from 2021-12-01 15-42-55](https://user-images.githubusercontent.com/21999379/144265777-c5a45c3b-4e61-44e3-be7c-1ccdd82fc6da.png)
![Screenshot from 2021-12-01 15-43-07](https://user-images.githubusercontent.com/21999379/144265796-e0495262-d33f-4613-ada8-2a8c2b145152.png)