### PR TITLE
Sort and group theme properties in docs, improve formatting for theme and enums

### DIFF
--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -135,7 +135,11 @@ public:
 		String description;
 		String default_value;
 		bool operator<(const ThemeItemDoc &p_theme_item) const {
-			return name < p_theme_item.name;
+			// First sort by the data type, then by name.
+			if (data_type == p_theme_item.data_type) {
+				return name < p_theme_item.name;
+			}
+			return data_type < p_theme_item.data_type;
 		}
 	};
 

--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -105,15 +105,6 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="disabled" data_type="style" type="StyleBox">
-			[StyleBox] used when the [Button] is disabled.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [Button] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the [Button]'s text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the [Button].
 		</theme_item>
@@ -135,15 +126,6 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [Button] is being pressed.
 		</theme_item>
-		<theme_item name="font_size" data_type="font_size" type="int">
-			Font size of the [Button]'s text.
-		</theme_item>
-		<theme_item name="hover" data_type="style" type="StyleBox">
-			[StyleBox] used when the [Button] is being hovered.
-		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="2">
-			The horizontal space between [Button]'s icon and text.
-		</theme_item>
 		<theme_item name="icon_disabled_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Icon modulate [Color] used when the [Button] is disabled.
 		</theme_item>
@@ -162,11 +144,29 @@
 		<theme_item name="icon_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Icon modulate [Color] used when the [Button] is being pressed.
 		</theme_item>
-		<theme_item name="normal" data_type="style" type="StyleBox">
-			Default [StyleBox] for the [Button].
+		<theme_item name="hseparation" data_type="constant" type="int" default="2">
+			The horizontal space between [Button]'s icon and text.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the [Button]'s text.
+		</theme_item>
+		<theme_item name="font_size" data_type="font_size" type="int">
+			Font size of the [Button]'s text.
+		</theme_item>
+		<theme_item name="disabled" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is disabled.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
+		</theme_item>
+		<theme_item name="hover" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is being hovered.
+		</theme_item>
+		<theme_item name="normal" data_type="style" type="StyleBox">
+			Default [StyleBox] for the [Button].
 		</theme_item>
 		<theme_item name="pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the [Button] is being pressed.

--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -14,24 +14,6 @@
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" override="true" default="true" />
 	</members>
 	<theme_items>
-		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
-			The vertical offset used when rendering the check icons (in pixels).
-		</theme_item>
-		<theme_item name="checked" data_type="icon" type="Texture2D">
-			The check icon to display when the [CheckBox] is checked.
-		</theme_item>
-		<theme_item name="checked_disabled" data_type="icon" type="Texture2D">
-			The check icon to display when the [CheckBox] is checked and disabled.
-		</theme_item>
-		<theme_item name="disabled" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckBox] is disabled.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckBox] is focused.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			The [Font] to use for the [CheckBox] text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			The [CheckBox] text's font color.
 		</theme_item>
@@ -53,26 +35,26 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckBox] text's font color when it's pressed.
 		</theme_item>
-		<theme_item name="font_size" data_type="font_size" type="int">
-			Font size of the [CheckBox]'s text.
-		</theme_item>
-		<theme_item name="hover" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckBox] is hovered.
-		</theme_item>
-		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckBox] is hovered and pressed.
+		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
+			The vertical offset used when rendering the check icons (in pixels).
 		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The separation between the check icon and the text (in pixels).
 		</theme_item>
-		<theme_item name="normal" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background.
-		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="pressed" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckBox] is pressed.
+		<theme_item name="font" data_type="font" type="Font">
+			The [Font] to use for the [CheckBox] text.
+		</theme_item>
+		<theme_item name="font_size" data_type="font_size" type="int">
+			Font size of the [CheckBox]'s text.
+		</theme_item>
+		<theme_item name="checked" data_type="icon" type="Texture2D">
+			The check icon to display when the [CheckBox] is checked.
+		</theme_item>
+		<theme_item name="checked_disabled" data_type="icon" type="Texture2D">
+			The check icon to display when the [CheckBox] is checked and disabled.
 		</theme_item>
 		<theme_item name="radio_checked" data_type="icon" type="Texture2D">
 			If the [CheckBox] is configured as a radio button, the icon to display when the [CheckBox] is checked.
@@ -89,6 +71,24 @@
 		</theme_item>
 		<theme_item name="unchecked_disabled" data_type="icon" type="Texture2D">
 			The check icon to display when the [CheckBox] is unchecked and disabled.
+		</theme_item>
+		<theme_item name="disabled" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckBox] is disabled.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckBox] is focused.
+		</theme_item>
+		<theme_item name="hover" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckBox] is hovered.
+		</theme_item>
+		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckBox] is hovered and pressed.
+		</theme_item>
+		<theme_item name="normal" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background.
+		</theme_item>
+		<theme_item name="pressed" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckBox] is pressed.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -14,18 +14,6 @@
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" override="true" default="true" />
 	</members>
 	<theme_items>
-		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
-			The vertical offset used when rendering the toggle icons (in pixels).
-		</theme_item>
-		<theme_item name="disabled" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckButton] is disabled.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckButton] is focused.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			The [Font] to use for the [CheckButton] text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			The [CheckButton] text's font color.
 		</theme_item>
@@ -47,20 +35,20 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckButton] text's font color when it's pressed.
 		</theme_item>
-		<theme_item name="font_size" data_type="font_size" type="int">
-			Font size of the [CheckButton]'s text.
-		</theme_item>
-		<theme_item name="hover" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckButton] is hovered.
-		</theme_item>
-		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckButton] is hovered and pressed.
+		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
+			The vertical offset used when rendering the toggle icons (in pixels).
 		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The separation between the toggle icon and the text (in pixels).
 		</theme_item>
-		<theme_item name="normal" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background.
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
+			The size of the text outline.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			The [Font] to use for the [CheckButton] text.
+		</theme_item>
+		<theme_item name="font_size" data_type="font_size" type="int">
+			Font size of the [CheckButton]'s text.
 		</theme_item>
 		<theme_item name="off" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is unchecked (for left-to-right layouts).
@@ -86,8 +74,20 @@
 		<theme_item name="on_mirrored" data_type="icon" type="Texture2D">
 			The icon to display when the [CheckButton] is checked (for right-to-left layouts).
 		</theme_item>
-		<theme_item name="outline_size" data_type="constant" type="int" default="0">
-			The size of the text outline.
+		<theme_item name="disabled" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckButton] is disabled.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckButton] is focused.
+		</theme_item>
+		<theme_item name="hover" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckButton] is hovered.
+		</theme_item>
+		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckButton] is hovered and pressed.
+		</theme_item>
+		<theme_item name="normal" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background.
 		</theme_item>
 		<theme_item name="pressed" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckButton] is pressed.

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -562,23 +562,14 @@
 		<theme_item name="background_color" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			Sets the background [Color].
 		</theme_item>
-		<theme_item name="bookmark" data_type="icon" type="Texture2D">
-			Sets a custom [Texture2D] to draw in the bookmark gutter for bookmarked lines.
-		</theme_item>
 		<theme_item name="bookmark_color" data_type="color" type="Color" default="Color(0.5, 0.64, 1, 0.8)">
 			[Color] of the bookmark icon for bookmarked lines.
 		</theme_item>
 		<theme_item name="brace_mismatch_color" data_type="color" type="Color" default="Color(1, 0.2, 0.2, 1)">
 			[Color] of the text to highlight mismatched braces.
 		</theme_item>
-		<theme_item name="breakpoint" data_type="icon" type="Texture2D">
-			Sets a custom [Texture2D] to draw in the breakpoint gutter for breakpointed lines.
-		</theme_item>
 		<theme_item name="breakpoint_color" data_type="color" type="Color" default="Color(0.9, 0.29, 0.3, 1)">
 			[Color] of the breakpoint icon for bookmarked lines.
-		</theme_item>
-		<theme_item name="can_fold" data_type="icon" type="Texture2D">
-			Sets a custom [Texture2D] to draw in the line folding gutter when a line can be folded.
 		</theme_item>
 		<theme_item name="caret_background_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			[Color] of the text behind the caret when block caret is enabled.
@@ -589,9 +580,6 @@
 		<theme_item name="code_folding_color" data_type="color" type="Color" default="Color(0.8, 0.8, 0.8, 0.8)">
 			[Color] for all icons related to line folding.
 		</theme_item>
-		<theme_item name="completion" data_type="style" type="StyleBox">
-			[StyleBox] for the code completion popup.
-		</theme_item>
 		<theme_item name="completion_background_color" data_type="color" type="Color" default="Color(0.17, 0.16, 0.2, 1)">
 			Sets the background [Color] for the code completion popup.
 		</theme_item>
@@ -601,17 +589,8 @@
 		<theme_item name="completion_font_color" data_type="color" type="Color" default="Color(0.67, 0.67, 0.67, 1)">
 			Font [Color] for the code completion popup.
 		</theme_item>
-		<theme_item name="completion_lines" data_type="constant" type="int" default="7">
-			Max number of options to display in the code completion popup at any one time.
-		</theme_item>
-		<theme_item name="completion_max_width" data_type="constant" type="int" default="50">
-			Max width of options in the code completion popup. Options longer then this will be cut off.
-		</theme_item>
 		<theme_item name="completion_scroll_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			[Color] of the scrollbar in the code completion popup.
-		</theme_item>
-		<theme_item name="completion_scroll_width" data_type="constant" type="int" default="3">
-			Width of the scrollbar in the code completion popup.
 		</theme_item>
 		<theme_item name="completion_selected_color" data_type="color" type="Color" default="Color(0.26, 0.26, 0.27, 1)">
 			Background highlight [Color] for the current selected option item in the code completion popup.
@@ -619,23 +598,8 @@
 		<theme_item name="current_line_color" data_type="color" type="Color" default="Color(0.25, 0.25, 0.26, 0.8)">
 			Background [Color] of the line containing the caret.
 		</theme_item>
-		<theme_item name="executing_line" data_type="icon" type="Texture2D">
-			Icon to draw in the executing gutter for executing lines.
-		</theme_item>
 		<theme_item name="executing_line_color" data_type="color" type="Color" default="Color(0.98, 0.89, 0.27, 1)">
 			[Color] of the executing icon for executing lines.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			Sets the [StyleBox] when in focus.
-		</theme_item>
-		<theme_item name="folded" data_type="icon" type="Texture2D">
-			Sets a custom [Texture2D] to draw in the line folding gutter when a line is folded and can be unfolded.
-		</theme_item>
-		<theme_item name="folded_eol_icon" data_type="icon" type="Texture2D">
-			Sets a custom [Texture2D] to draw at the end of a folded line.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			Sets the default [Font].
 		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Sets the font [Color].
@@ -649,26 +613,11 @@
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			Sets the [Color] of the selected text. [member TextEdit.override_selected_font_color] has to be enabled.
 		</theme_item>
-		<theme_item name="font_size" data_type="font_size" type="int">
-			Sets default font size.
-		</theme_item>
 		<theme_item name="line_length_guideline_color" data_type="color" type="Color" default="Color(0.3, 0.5, 0.8, 0.1)">
 			[Color] of the main line length guideline, secondary guidelines will have 50% alpha applied.
 		</theme_item>
 		<theme_item name="line_number_color" data_type="color" type="Color" default="Color(0.67, 0.67, 0.67, 0.4)">
 			Sets the [Color] of line numbers.
-		</theme_item>
-		<theme_item name="line_spacing" data_type="constant" type="int" default="4">
-			Sets the spacing between the lines.
-		</theme_item>
-		<theme_item name="normal" data_type="style" type="StyleBox">
-			Sets the [StyleBox].
-		</theme_item>
-		<theme_item name="outline_size" data_type="constant" type="int" default="0">
-			The size of the text outline.
-		</theme_item>
-		<theme_item name="read_only" data_type="style" type="StyleBox">
-			Sets the [StyleBox] when [member TextEdit.editable] is disabled.
 		</theme_item>
 		<theme_item name="search_result_border_color" data_type="color" type="Color" default="Color(0.3, 0.3, 0.3, 0.4)">
 			[Color] of the border around text that matches the search query.
@@ -679,14 +628,65 @@
 		<theme_item name="selection_color" data_type="color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
 			Sets the highlight [Color] of text selections.
 		</theme_item>
+		<theme_item name="word_highlighted_color" data_type="color" type="Color" default="Color(0.8, 0.9, 0.9, 0.15)">
+			Sets the highlight [Color] of multiple occurrences. [member TextEdit.highlight_all_occurrences] has to be enabled.
+		</theme_item>
+		<theme_item name="completion_lines" data_type="constant" type="int" default="7">
+			Max number of options to display in the code completion popup at any one time.
+		</theme_item>
+		<theme_item name="completion_max_width" data_type="constant" type="int" default="50">
+			Max width of options in the code completion popup. Options longer then this will be cut off.
+		</theme_item>
+		<theme_item name="completion_scroll_width" data_type="constant" type="int" default="3">
+			Width of the scrollbar in the code completion popup.
+		</theme_item>
+		<theme_item name="line_spacing" data_type="constant" type="int" default="4">
+			Sets the spacing between the lines.
+		</theme_item>
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
+			The size of the text outline.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			Sets the default [Font].
+		</theme_item>
+		<theme_item name="font_size" data_type="font_size" type="int">
+			Sets default font size.
+		</theme_item>
+		<theme_item name="bookmark" data_type="icon" type="Texture2D">
+			Sets a custom [Texture2D] to draw in the bookmark gutter for bookmarked lines.
+		</theme_item>
+		<theme_item name="breakpoint" data_type="icon" type="Texture2D">
+			Sets a custom [Texture2D] to draw in the breakpoint gutter for breakpointed lines.
+		</theme_item>
+		<theme_item name="can_fold" data_type="icon" type="Texture2D">
+			Sets a custom [Texture2D] to draw in the line folding gutter when a line can be folded.
+		</theme_item>
+		<theme_item name="executing_line" data_type="icon" type="Texture2D">
+			Icon to draw in the executing gutter for executing lines.
+		</theme_item>
+		<theme_item name="folded" data_type="icon" type="Texture2D">
+			Sets a custom [Texture2D] to draw in the line folding gutter when a line is folded and can be unfolded.
+		</theme_item>
+		<theme_item name="folded_eol_icon" data_type="icon" type="Texture2D">
+			Sets a custom [Texture2D] to draw at the end of a folded line.
+		</theme_item>
 		<theme_item name="space" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] for space text characters.
 		</theme_item>
 		<theme_item name="tab" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] for tab text characters.
 		</theme_item>
-		<theme_item name="word_highlighted_color" data_type="color" type="Color" default="Color(0.8, 0.9, 0.9, 0.15)">
-			Sets the highlight [Color] of multiple occurrences. [member TextEdit.highlight_all_occurrences] has to be enabled.
+		<theme_item name="completion" data_type="style" type="StyleBox">
+			[StyleBox] for the code completion popup.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			Sets the [StyleBox] when in focus.
+		</theme_item>
+		<theme_item name="normal" data_type="style" type="StyleBox">
+			Sets the [StyleBox].
+		</theme_item>
+		<theme_item name="read_only" data_type="style" type="StyleBox">
+			Sets the [StyleBox] when [member TextEdit.editable] is disabled.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -93,6 +93,20 @@
 		</constant>
 	</constants>
 	<theme_items>
+		<theme_item name="h_width" data_type="constant" type="int" default="30">
+			The width of the hue selection slider.
+		</theme_item>
+		<theme_item name="label_width" data_type="constant" type="int" default="10">
+		</theme_item>
+		<theme_item name="margin" data_type="constant" type="int" default="4">
+			The margin around the [ColorPicker].
+		</theme_item>
+		<theme_item name="sv_height" data_type="constant" type="int" default="256">
+			The height of the saturation-value selection box.
+		</theme_item>
+		<theme_item name="sv_width" data_type="constant" type="int" default="256">
+			The width of the saturation-value selection box.
+		</theme_item>
 		<theme_item name="add_preset" data_type="icon" type="Texture2D">
 			The icon for the "Add Preset" button.
 		</theme_item>
@@ -104,14 +118,6 @@
 		</theme_item>
 		<theme_item name="color_sample" data_type="icon" type="Texture2D">
 		</theme_item>
-		<theme_item name="h_width" data_type="constant" type="int" default="30">
-			The width of the hue selection slider.
-		</theme_item>
-		<theme_item name="label_width" data_type="constant" type="int" default="10">
-		</theme_item>
-		<theme_item name="margin" data_type="constant" type="int" default="4">
-			The margin around the [ColorPicker].
-		</theme_item>
 		<theme_item name="overbright_indicator" data_type="icon" type="Texture2D">
 			The indicator used to signalize that the color value is outside the 0-1 range.
 		</theme_item>
@@ -121,12 +127,6 @@
 		</theme_item>
 		<theme_item name="screen_picker" data_type="icon" type="Texture2D">
 			The icon for the screen color picker button.
-		</theme_item>
-		<theme_item name="sv_height" data_type="constant" type="int" default="256">
-			The height of the saturation-value selection box.
-		</theme_item>
-		<theme_item name="sv_width" data_type="constant" type="int" default="256">
-			The width of the saturation-value selection box.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -56,18 +56,6 @@
 		</signal>
 	</signals>
 	<theme_items>
-		<theme_item name="bg" data_type="icon" type="Texture2D">
-			The background of the color preview rect on the button.
-		</theme_item>
-		<theme_item name="disabled" data_type="style" type="StyleBox">
-			[StyleBox] used when the [ColorPickerButton] is disabled.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [ColorPickerButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the [ColorPickerButton]'s text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Default text [Color] of the [ColorPickerButton].
 		</theme_item>
@@ -86,20 +74,32 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(0.8, 0.8, 0.8, 1)">
 			Text [Color] used when the [ColorPickerButton] is being pressed.
 		</theme_item>
+		<theme_item name="hseparation" data_type="constant" type="int" default="2">
+			The horizontal space between [ColorPickerButton]'s icon and text.
+		</theme_item>
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
+			The size of the text outline.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the [ColorPickerButton]'s text.
+		</theme_item>
 		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the [ColorPickerButton]'s text.
+		</theme_item>
+		<theme_item name="bg" data_type="icon" type="Texture2D">
+			The background of the color preview rect on the button.
+		</theme_item>
+		<theme_item name="disabled" data_type="style" type="StyleBox">
+			[StyleBox] used when the [ColorPickerButton] is disabled.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [ColorPickerButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
 		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ColorPickerButton] is being hovered.
 		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="2">
-			The horizontal space between [ColorPickerButton]'s icon and text.
-		</theme_item>
 		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [ColorPickerButton].
-		</theme_item>
-		<theme_item name="outline_size" data_type="constant" type="int" default="0">
-			The size of the text outline.
 		</theme_item>
 		<theme_item name="pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the [ColorPickerButton] is being pressed.

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -125,23 +125,23 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="back_folder" data_type="icon" type="Texture2D">
-			Custom icon for the back arrow.
-		</theme_item>
-		<theme_item name="file" data_type="icon" type="Texture2D">
-			Custom icon for files.
-		</theme_item>
 		<theme_item name="file_icon_modulate" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The color modulation applied to the file icon.
 		</theme_item>
 		<theme_item name="files_disabled" data_type="color" type="Color" default="Color(0, 0, 0, 0.7)">
 			The color tint for disabled files (when the [FileDialog] is used in open folder mode).
 		</theme_item>
-		<theme_item name="folder" data_type="icon" type="Texture2D">
-			Custom icon for folders.
-		</theme_item>
 		<theme_item name="folder_icon_modulate" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The color modulation applied to the folder icon.
+		</theme_item>
+		<theme_item name="back_folder" data_type="icon" type="Texture2D">
+			Custom icon for the back arrow.
+		</theme_item>
+		<theme_item name="file" data_type="icon" type="Texture2D">
+			Custom icon for files.
+		</theme_item>
+		<theme_item name="folder" data_type="icon" type="Texture2D">
+			Custom icon for folders.
 		</theme_item>
 		<theme_item name="forward_folder" data_type="icon" type="Texture2D">
 			Custom icon for the forward arrow.

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -290,18 +290,27 @@
 	<theme_items>
 		<theme_item name="activity" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 		</theme_item>
-		<theme_item name="bezier_len_neg" data_type="constant" type="int" default="160">
-		</theme_item>
-		<theme_item name="bezier_len_pos" data_type="constant" type="int" default="80">
-		</theme_item>
-		<theme_item name="bg" data_type="style" type="StyleBox">
-			The background drawn under the grid.
-		</theme_item>
 		<theme_item name="grid_major" data_type="color" type="Color" default="Color(1, 1, 1, 0.2)">
 			Color of major grid lines.
 		</theme_item>
 		<theme_item name="grid_minor" data_type="color" type="Color" default="Color(1, 1, 1, 0.05)">
 			Color of minor grid lines.
+		</theme_item>
+		<theme_item name="selection_fill" data_type="color" type="Color" default="Color(1, 1, 1, 0.3)">
+			The fill color of the selection rectangle.
+		</theme_item>
+		<theme_item name="selection_stroke" data_type="color" type="Color" default="Color(1, 1, 1, 0.8)">
+			The outline color of the selection rectangle.
+		</theme_item>
+		<theme_item name="bezier_len_neg" data_type="constant" type="int" default="160">
+		</theme_item>
+		<theme_item name="bezier_len_pos" data_type="constant" type="int" default="80">
+		</theme_item>
+		<theme_item name="port_grab_distance_horizontal" data_type="constant" type="int" default="24">
+			The horizontal range within which a port can be grabbed (on both sides).
+		</theme_item>
+		<theme_item name="port_grab_distance_vertical" data_type="constant" type="int" default="6">
+			The vertical range within which a port can be grabbed (on both sides).
 		</theme_item>
 		<theme_item name="layout" data_type="icon" type="Texture2D">
 		</theme_item>
@@ -313,23 +322,14 @@
 		<theme_item name="more" data_type="icon" type="Texture2D">
 			The icon for the zoom in button.
 		</theme_item>
-		<theme_item name="port_grab_distance_horizontal" data_type="constant" type="int" default="24">
-			The horizontal range within which a port can be grabbed (on both sides).
-		</theme_item>
-		<theme_item name="port_grab_distance_vertical" data_type="constant" type="int" default="6">
-			The vertical range within which a port can be grabbed (on both sides).
-		</theme_item>
 		<theme_item name="reset" data_type="icon" type="Texture2D">
 			The icon for the zoom reset button.
 		</theme_item>
-		<theme_item name="selection_fill" data_type="color" type="Color" default="Color(1, 1, 1, 0.3)">
-			The fill color of the selection rectangle.
-		</theme_item>
-		<theme_item name="selection_stroke" data_type="color" type="Color" default="Color(1, 1, 1, 0.8)">
-			The outline color of the selection rectangle.
-		</theme_item>
 		<theme_item name="snap" data_type="icon" type="Texture2D">
 			The icon for the snap toggle button.
+		</theme_item>
+		<theme_item name="bg" data_type="style" type="StyleBox">
+			The background drawn under the grid.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -292,17 +292,41 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="breakpoint" data_type="style" type="StyleBox">
-			The background used when [member overlay] is set to [constant OVERLAY_BREAKPOINT].
+		<theme_item name="close_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
+			The color modulation applied to the close button icon.
+		</theme_item>
+		<theme_item name="resizer_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
+			The color modulation applied to the resizer icon.
+		</theme_item>
+		<theme_item name="title_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
+			Color of the title text.
+		</theme_item>
+		<theme_item name="close_offset" data_type="constant" type="int" default="18">
+			The vertical offset of the close button.
+		</theme_item>
+		<theme_item name="port_offset" data_type="constant" type="int" default="3">
+			Horizontal offset for the ports.
+		</theme_item>
+		<theme_item name="separation" data_type="constant" type="int" default="1">
+			The vertical distance between ports.
+		</theme_item>
+		<theme_item name="title_offset" data_type="constant" type="int" default="20">
+			Vertical offset of the title text.
+		</theme_item>
+		<theme_item name="title_font" data_type="font" type="Font">
+			Font used for the title text.
 		</theme_item>
 		<theme_item name="close" data_type="icon" type="Texture2D">
 			The icon for the close button, visible when [member show_close] is enabled.
 		</theme_item>
-		<theme_item name="close_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
-			The color modulation applied to the close button icon.
+		<theme_item name="port" data_type="icon" type="Texture2D">
+			The icon used for representing ports.
 		</theme_item>
-		<theme_item name="close_offset" data_type="constant" type="int" default="18">
-			The vertical offset of the close button.
+		<theme_item name="resizer" data_type="icon" type="Texture2D">
+			The icon used for resizer, visible when [member resizable] is enabled.
+		</theme_item>
+		<theme_item name="breakpoint" data_type="style" type="StyleBox">
+			The background used when [member overlay] is set to [constant OVERLAY_BREAKPOINT].
 		</theme_item>
 		<theme_item name="comment" data_type="style" type="StyleBox">
 			The [StyleBox] used when [member comment] is enabled.
@@ -317,35 +341,11 @@
 		<theme_item name="frame" data_type="style" type="StyleBox">
 			The default background for [GraphNode].
 		</theme_item>
-		<theme_item name="port" data_type="icon" type="Texture2D">
-			The icon used for representing ports.
-		</theme_item>
-		<theme_item name="port_offset" data_type="constant" type="int" default="3">
-			Horizontal offset for the ports.
-		</theme_item>
 		<theme_item name="position" data_type="style" type="StyleBox">
 			The background used when [member overlay] is set to [constant OVERLAY_POSITION].
 		</theme_item>
-		<theme_item name="resizer" data_type="icon" type="Texture2D">
-			The icon used for resizer, visible when [member resizable] is enabled.
-		</theme_item>
-		<theme_item name="resizer_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
-			The color modulation applied to the resizer icon.
-		</theme_item>
 		<theme_item name="selectedframe" data_type="style" type="StyleBox">
 			The background used when the [GraphNode] is selected.
-		</theme_item>
-		<theme_item name="separation" data_type="constant" type="int" default="1">
-			The vertical distance between ports.
-		</theme_item>
-		<theme_item name="title_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
-			Color of the title text.
-		</theme_item>
-		<theme_item name="title_font" data_type="font" type="Font">
-			Font used for the title text.
-		</theme_item>
-		<theme_item name="title_offset" data_type="constant" type="int" default="20">
-			Vertical offset of the title text.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/HScrollBar.xml
+++ b/doc/classes/HScrollBar.xml
@@ -18,15 +18,6 @@
 		<theme_item name="decrement_pressed" data_type="icon" type="Texture2D">
 			Displayed when the decrement button is being pressed.
 		</theme_item>
-		<theme_item name="grabber" data_type="style" type="StyleBox">
-			Used as texture for the grabber, the draggable element representing current scroll.
-		</theme_item>
-		<theme_item name="grabber_highlight" data_type="style" type="StyleBox">
-			Used when the mouse hovers over the grabber.
-		</theme_item>
-		<theme_item name="grabber_pressed" data_type="style" type="StyleBox">
-			Used when the grabber is being dragged.
-		</theme_item>
 		<theme_item name="increment" data_type="icon" type="Texture2D">
 			Icon used as a button to scroll the [ScrollBar] right. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
@@ -35,6 +26,15 @@
 		</theme_item>
 		<theme_item name="increment_pressed" data_type="icon" type="Texture2D">
 			Displayed when the increment button is being pressed.
+		</theme_item>
+		<theme_item name="grabber" data_type="style" type="StyleBox">
+			Used as texture for the grabber, the draggable element representing current scroll.
+		</theme_item>
+		<theme_item name="grabber_highlight" data_type="style" type="StyleBox">
+			Used when the mouse hovers over the grabber.
+		</theme_item>
+		<theme_item name="grabber_pressed" data_type="style" type="StyleBox">
+			Used when the grabber is being dragged.
 		</theme_item>
 		<theme_item name="scroll" data_type="style" type="StyleBox">
 			Used as background of this [ScrollBar].

--- a/doc/classes/HSlider.xml
+++ b/doc/classes/HSlider.xml
@@ -13,22 +13,22 @@
 		<theme_item name="grabber" data_type="icon" type="Texture2D">
 			The texture for the grabber (the draggable element).
 		</theme_item>
-		<theme_item name="grabber_area" data_type="style" type="StyleBox">
-			The background of the area to the left of the grabber.
-		</theme_item>
-		<theme_item name="grabber_area_highlight" data_type="style" type="StyleBox">
-		</theme_item>
 		<theme_item name="grabber_disabled" data_type="icon" type="Texture2D">
 			The texture for the grabber when it's disabled.
 		</theme_item>
 		<theme_item name="grabber_highlight" data_type="icon" type="Texture2D">
 			The texture for the grabber when it's focused.
 		</theme_item>
-		<theme_item name="slider" data_type="style" type="StyleBox">
-			The background for the whole slider. Determines the height of the [code]grabber_area[/code].
-		</theme_item>
 		<theme_item name="tick" data_type="icon" type="Texture2D">
 			The texture for the ticks, visible when [member Slider.tick_count] is greater than 0.
+		</theme_item>
+		<theme_item name="grabber_area" data_type="style" type="StyleBox">
+			The background of the area to the left of the grabber.
+		</theme_item>
+		<theme_item name="grabber_area_highlight" data_type="style" type="StyleBox">
+		</theme_item>
+		<theme_item name="slider" data_type="style" type="StyleBox">
+			The background for the whole slider. Determines the height of the [code]grabber_area[/code].
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/HSplitContainer.xml
+++ b/doc/classes/HSplitContainer.xml
@@ -12,13 +12,13 @@
 		<theme_item name="autohide" data_type="constant" type="int" default="1">
 			Boolean value. If 1 ([code]true[/code]), the grabber will hide automatically when it isn't under the cursor. If 0 ([code]false[/code]), it's always visible.
 		</theme_item>
-		<theme_item name="bg" data_type="style" type="StyleBox">
+		<theme_item name="separation" data_type="constant" type="int" default="12">
+			The space between sides of the container.
 		</theme_item>
 		<theme_item name="grabber" data_type="icon" type="Texture2D">
 			The icon used for the grabber drawn in the middle area.
 		</theme_item>
-		<theme_item name="separation" data_type="constant" type="int" default="12">
-			The space between sides of the container.
+		<theme_item name="bg" data_type="style" type="StyleBox">
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -463,21 +463,6 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="bg" data_type="style" type="StyleBox">
-			Default [StyleBox] for the [ItemList], i.e. used when the control is not being focused.
-		</theme_item>
-		<theme_item name="bg_focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [ItemList] is being focused.
-		</theme_item>
-		<theme_item name="cursor" data_type="style" type="StyleBox">
-			[StyleBox] used for the cursor, when the [ItemList] is being focused.
-		</theme_item>
-		<theme_item name="cursor_unfocused" data_type="style" type="StyleBox">
-			[StyleBox] used for the cursor, when the [ItemList] is not being focused.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the item's text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.63, 0.63, 0.63, 1)">
 			Default text [Color] of the item.
 		</theme_item>
@@ -486,9 +471,6 @@
 		</theme_item>
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the item is selected.
-		</theme_item>
-		<theme_item name="font_size" data_type="font_size" type="int">
-			Font size of the item's text.
 		</theme_item>
 		<theme_item name="guide_color" data_type="color" type="Color" default="Color(0, 0, 0, 0.1)">
 			[Color] of the guideline. The guideline is a line drawn between each row of items.
@@ -505,14 +487,32 @@
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the item text outline.
 		</theme_item>
+		<theme_item name="vseparation" data_type="constant" type="int" default="2">
+			The vertical spacing between items.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the item's text.
+		</theme_item>
+		<theme_item name="font_size" data_type="font_size" type="int">
+			Font size of the item's text.
+		</theme_item>
+		<theme_item name="bg" data_type="style" type="StyleBox">
+			Default [StyleBox] for the [ItemList], i.e. used when the control is not being focused.
+		</theme_item>
+		<theme_item name="bg_focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [ItemList] is being focused.
+		</theme_item>
+		<theme_item name="cursor" data_type="style" type="StyleBox">
+			[StyleBox] used for the cursor, when the [ItemList] is being focused.
+		</theme_item>
+		<theme_item name="cursor_unfocused" data_type="style" type="StyleBox">
+			[StyleBox] used for the cursor, when the [ItemList] is not being focused.
+		</theme_item>
 		<theme_item name="selected" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [ItemList] is not being focused.
 		</theme_item>
 		<theme_item name="selected_focus" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [ItemList] is being focused.
-		</theme_item>
-		<theme_item name="vseparation" data_type="constant" type="int" default="2">
-			The vertical spacing between items.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -163,9 +163,6 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] used for the [Label]'s text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Default text [Color] of the [Label].
 		</theme_item>
@@ -175,14 +172,8 @@
 		<theme_item name="font_shadow_color" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			[Color] of the text's shadow effect.
 		</theme_item>
-		<theme_item name="font_size" data_type="font_size" type="int">
-			Font size of the [Label]'s text.
-		</theme_item>
 		<theme_item name="line_spacing" data_type="constant" type="int" default="3">
 			Vertical space between lines in multiline [Label].
-		</theme_item>
-		<theme_item name="normal" data_type="style" type="StyleBox">
-			Background [StyleBox] for the [Label].
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			Text outline size.
@@ -195,6 +186,15 @@
 		</theme_item>
 		<theme_item name="shadow_outline_size" data_type="constant" type="int" default="1">
 			The size of the shadow outline.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] used for the [Label]'s text.
+		</theme_item>
+		<theme_item name="font_size" data_type="font_size" type="int">
+			Font size of the [Label]'s text.
+		</theme_item>
+		<theme_item name="normal" data_type="style" type="StyleBox">
+			Background [StyleBox] for the [Label].
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -397,20 +397,11 @@
 		<theme_item name="caret_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Color of the [LineEdit]'s caret (text cursor).
 		</theme_item>
-		<theme_item name="clear" data_type="icon" type="Texture2D">
-			Texture for the clear button. See [member clear_button_enabled].
-		</theme_item>
 		<theme_item name="clear_button_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Color used as default tint for the clear button.
 		</theme_item>
 		<theme_item name="clear_button_color_pressed" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Color used for the clear button when it's pressed.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			Background used when [LineEdit] has GUI focus.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			Font used for the text.
 		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default font color.
@@ -421,26 +412,35 @@
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			Font color for selected text (inside the selection rectangle).
 		</theme_item>
-		<theme_item name="font_size" data_type="font_size" type="int">
-			Font size of the [LineEdit]'s text.
-		</theme_item>
 		<theme_item name="font_uneditable_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 0.5)">
 			Font color when editing is disabled.
+		</theme_item>
+		<theme_item name="selection_color" data_type="color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
+			Color of the selection rectangle.
 		</theme_item>
 		<theme_item name="minimum_character_width" data_type="constant" type="int" default="4">
 			Minimum horizontal space for the text (not counting the clear button and content margins). This value is measured in count of 'M' characters (i.e. this amount of 'M' characters can be displayed without scrolling).
 		</theme_item>
-		<theme_item name="normal" data_type="style" type="StyleBox">
-			Default background for the [LineEdit].
-		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			Font used for the text.
+		</theme_item>
+		<theme_item name="font_size" data_type="font_size" type="int">
+			Font size of the [LineEdit]'s text.
+		</theme_item>
+		<theme_item name="clear" data_type="icon" type="Texture2D">
+			Texture for the clear button. See [member clear_button_enabled].
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			Background used when [LineEdit] has GUI focus.
+		</theme_item>
+		<theme_item name="normal" data_type="style" type="StyleBox">
+			Default background for the [LineEdit].
+		</theme_item>
 		<theme_item name="read_only" data_type="style" type="StyleBox">
 			Background used when [LineEdit] is in read-only mode ([member editable] is set to [code]false[/code]).
-		</theme_item>
-		<theme_item name="selection_color" data_type="color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
-			Color of the selection rectangle.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -66,12 +66,6 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [LinkButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the [LinkButton]'s text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the [LinkButton].
 		</theme_item>
@@ -87,14 +81,20 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [LinkButton] is being pressed.
 		</theme_item>
-		<theme_item name="font_size" data_type="font_size" type="int">
-			Font size of the [LinkButton]'s text.
-		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
 		<theme_item name="underline_spacing" data_type="constant" type="int" default="2">
 			The vertical space between the baseline of text and the underline.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the [LinkButton]'s text.
+		</theme_item>
+		<theme_item name="font_size" data_type="font_size" type="int">
+			Font size of the [LinkButton]'s text.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [LinkButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -46,15 +46,6 @@
 		</signal>
 	</signals>
 	<theme_items>
-		<theme_item name="disabled" data_type="style" type="StyleBox">
-			[StyleBox] used when the [MenuButton] is disabled.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [MenuButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the [MenuButton]'s text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the [MenuButton].
 		</theme_item>
@@ -73,20 +64,29 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [MenuButton] is being pressed.
 		</theme_item>
+		<theme_item name="hseparation" data_type="constant" type="int" default="3">
+			The horizontal space between [MenuButton]'s icon and text.
+		</theme_item>
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
+			The size of the text outline.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the [MenuButton]'s text.
+		</theme_item>
 		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the [MenuButton]'s text.
+		</theme_item>
+		<theme_item name="disabled" data_type="style" type="StyleBox">
+			[StyleBox] used when the [MenuButton] is disabled.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [MenuButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
 		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [MenuButton] is being hovered.
 		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="3">
-			The horizontal space between [MenuButton]'s icon and text.
-		</theme_item>
 		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [MenuButton].
-		</theme_item>
-		<theme_item name="outline_size" data_type="constant" type="int" default="0">
-			The size of the text outline.
 		</theme_item>
 		<theme_item name="pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the [MenuButton] is being pressed.

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -185,24 +185,6 @@
 		</signal>
 	</signals>
 	<theme_items>
-		<theme_item name="arrow" data_type="icon" type="Texture2D">
-			The arrow icon to be drawn on the right end of the button.
-		</theme_item>
-		<theme_item name="arrow_margin" data_type="constant" type="int" default="2">
-			The horizontal space between the arrow icon and the right edge of the button.
-		</theme_item>
-		<theme_item name="disabled" data_type="style" type="StyleBox">
-			[StyleBox] used when the [OptionButton] is disabled (for left-to-right layouts).
-		</theme_item>
-		<theme_item name="disabled_mirrored" data_type="style" type="StyleBox">
-			[StyleBox] used when the [OptionButton] is disabled (for right-to-left layouts).
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [OptionButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the [OptionButton]'s text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Default text [Color] of the [OptionButton].
 		</theme_item>
@@ -221,8 +203,32 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [OptionButton] is being pressed.
 		</theme_item>
+		<theme_item name="arrow_margin" data_type="constant" type="int" default="2">
+			The horizontal space between the arrow icon and the right edge of the button.
+		</theme_item>
+		<theme_item name="hseparation" data_type="constant" type="int" default="2">
+			The horizontal space between [OptionButton]'s icon and text.
+		</theme_item>
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
+			The size of the text outline.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the [OptionButton]'s text.
+		</theme_item>
 		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the [OptionButton]'s text.
+		</theme_item>
+		<theme_item name="arrow" data_type="icon" type="Texture2D">
+			The arrow icon to be drawn on the right end of the button.
+		</theme_item>
+		<theme_item name="disabled" data_type="style" type="StyleBox">
+			[StyleBox] used when the [OptionButton] is disabled (for left-to-right layouts).
+		</theme_item>
+		<theme_item name="disabled_mirrored" data_type="style" type="StyleBox">
+			[StyleBox] used when the [OptionButton] is disabled (for right-to-left layouts).
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [OptionButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
 		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is being hovered (for left-to-right layouts).
@@ -230,17 +236,11 @@
 		<theme_item name="hover_mirrored" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is being hovered (for right-to-left layouts).
 		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="2">
-			The horizontal space between [OptionButton]'s icon and text.
-		</theme_item>
 		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [OptionButton] (for left-to-right layouts).
 		</theme_item>
 		<theme_item name="normal_mirrored" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [OptionButton] (for right-to-left layouts).
-		</theme_item>
-		<theme_item name="outline_size" data_type="constant" type="int" default="0">
-			The size of the text outline.
 		</theme_item>
 		<theme_item name="pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the [OptionButton] is being pressed (for left-to-right layouts).

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -533,12 +533,6 @@
 		</signal>
 	</signals>
 	<theme_items>
-		<theme_item name="checked" data_type="icon" type="Texture2D">
-			[Texture2D] icon for the checked checkbox items.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] used for the menu items.
-		</theme_item>
 		<theme_item name="font_accelerator_color" data_type="color" type="Color" default="Color(0.7, 0.7, 0.7, 0.8)">
 			The text [Color] used for shortcuts and accelerators that show next to the menu item name when defined. See [method get_item_accelerator] for more info on accelerators.
 		</theme_item>
@@ -557,12 +551,6 @@
 		<theme_item name="font_separator_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			[Color] used for labeled separators' text. See [method add_separator].
 		</theme_item>
-		<theme_item name="font_size" data_type="font_size" type="int">
-			Font size of the menu items.
-		</theme_item>
-		<theme_item name="hover" data_type="style" type="StyleBox">
-			[StyleBox] displayed when the [PopupMenu] item is hovered.
-		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal space between the item's name and the shortcut text/submenu arrow.
 		</theme_item>
@@ -570,29 +558,26 @@
 		</theme_item>
 		<theme_item name="item_start_padding" data_type="constant" type="int" default="2">
 		</theme_item>
-		<theme_item name="labeled_separator_left" data_type="style" type="StyleBox">
-			[StyleBox] for the left side of labeled separator. See [method add_separator].
-		</theme_item>
-		<theme_item name="labeled_separator_right" data_type="style" type="StyleBox">
-			[StyleBox] for the right side of labeled separator. See [method add_separator].
-		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the item text outline.
 		</theme_item>
-		<theme_item name="panel" data_type="style" type="StyleBox">
-			Default [StyleBox] of the [PopupMenu] items.
+		<theme_item name="vseparation" data_type="constant" type="int" default="4">
+			The vertical space between each menu item.
 		</theme_item>
-		<theme_item name="panel_disabled" data_type="style" type="StyleBox">
-			[StyleBox] used when the [PopupMenu] item is disabled.
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] used for the menu items.
+		</theme_item>
+		<theme_item name="font_size" data_type="font_size" type="int">
+			Font size of the menu items.
+		</theme_item>
+		<theme_item name="checked" data_type="icon" type="Texture2D">
+			[Texture2D] icon for the checked checkbox items.
 		</theme_item>
 		<theme_item name="radio_checked" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the checked radio button items.
 		</theme_item>
 		<theme_item name="radio_unchecked" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the unchecked radio button items.
-		</theme_item>
-		<theme_item name="separator" data_type="style" type="StyleBox">
-			[StyleBox] used for the separators. See [method add_separator].
 		</theme_item>
 		<theme_item name="submenu" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the submenu arrow (for left-to-right layouts).
@@ -603,8 +588,23 @@
 		<theme_item name="unchecked" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the unchecked checkbox items.
 		</theme_item>
-		<theme_item name="vseparation" data_type="constant" type="int" default="4">
-			The vertical space between each menu item.
+		<theme_item name="hover" data_type="style" type="StyleBox">
+			[StyleBox] displayed when the [PopupMenu] item is hovered.
+		</theme_item>
+		<theme_item name="labeled_separator_left" data_type="style" type="StyleBox">
+			[StyleBox] for the left side of labeled separator. See [method add_separator].
+		</theme_item>
+		<theme_item name="labeled_separator_right" data_type="style" type="StyleBox">
+			[StyleBox] for the right side of labeled separator. See [method add_separator].
+		</theme_item>
+		<theme_item name="panel" data_type="style" type="StyleBox">
+			Default [StyleBox] of the [PopupMenu] items.
+		</theme_item>
+		<theme_item name="panel_disabled" data_type="style" type="StyleBox">
+			[StyleBox] used when the [PopupMenu] item is disabled.
+		</theme_item>
+		<theme_item name="separator" data_type="style" type="StyleBox">
+			[StyleBox] used for the separators. See [method add_separator].
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -16,15 +16,6 @@
 		<member name="step" type="float" setter="set_step" getter="get_step" override="true" default="0.01" />
 	</members>
 	<theme_items>
-		<theme_item name="bg" data_type="style" type="StyleBox">
-			The style of the background.
-		</theme_item>
-		<theme_item name="fg" data_type="style" type="StyleBox">
-			The style of the progress (i.e. the part that fills the bar).
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			Font used to draw the fill percentage if [member percent_visible] is [code]true[/code].
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			The color of the text.
 		</theme_item>
@@ -34,11 +25,20 @@
 		<theme_item name="font_shadow_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			The color of the text's shadow.
 		</theme_item>
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
+			The size of the text outline.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			Font used to draw the fill percentage if [member percent_visible] is [code]true[/code].
+		</theme_item>
 		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size used to draw the fill percentage if [member percent_visible] is [code]true[/code].
 		</theme_item>
-		<theme_item name="outline_size" data_type="constant" type="int" default="0">
-			The size of the text outline.
+		<theme_item name="bg" data_type="style" type="StyleBox">
+			The style of the background.
+		</theme_item>
+		<theme_item name="fg" data_type="style" type="StyleBox">
+			The style of the progress (i.e. the part that fills the bar).
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -529,23 +529,8 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="bold_font" data_type="font" type="Font">
-			The font used for bold text.
-		</theme_item>
-		<theme_item name="bold_font_size" data_type="font_size" type="int">
-			The font size used for bold text.
-		</theme_item>
-		<theme_item name="bold_italics_font" data_type="font" type="Font">
-			The font used for bold italics text.
-		</theme_item>
-		<theme_item name="bold_italics_font_size" data_type="font_size" type="int">
-			The font size used for bold italics text.
-		</theme_item>
 		<theme_item name="default_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The default text color.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			The background The background used when the [RichTextLabel] is focused.
 		</theme_item>
 		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The default tint of text outline.
@@ -556,35 +541,23 @@
 		<theme_item name="font_shadow_color" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
 			The color of the font's shadow.
 		</theme_item>
-		<theme_item name="italics_font" data_type="font" type="Font">
-			The font used for italics text.
+		<theme_item name="selection_color" data_type="color" type="Color" default="Color(0.1, 0.1, 1, 0.8)">
+			The color of the selection box.
 		</theme_item>
-		<theme_item name="italics_font_size" data_type="font_size" type="int">
-			The font size used for italics text.
+		<theme_item name="table_border" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
+			The default cell border color.
+		</theme_item>
+		<theme_item name="table_even_row_bg" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
+			The default background color for even rows.
+		</theme_item>
+		<theme_item name="table_odd_row_bg" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
+			The default background color for odd rows.
 		</theme_item>
 		<theme_item name="line_separation" data_type="constant" type="int" default="0">
 			The vertical space between lines.
 		</theme_item>
-		<theme_item name="mono_font" data_type="font" type="Font">
-			The font used for monospace text.
-		</theme_item>
-		<theme_item name="mono_font_size" data_type="font_size" type="int">
-			The font size used for monospace text.
-		</theme_item>
-		<theme_item name="normal" data_type="style" type="StyleBox">
-			The normal background for the [RichTextLabel].
-		</theme_item>
-		<theme_item name="normal_font" data_type="font" type="Font">
-			The default text font.
-		</theme_item>
-		<theme_item name="normal_font_size" data_type="font_size" type="int">
-			The default text font size.
-		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
-		</theme_item>
-		<theme_item name="selection_color" data_type="color" type="Color" default="Color(0.1, 0.1, 1, 0.8)">
-			The color of the selection box.
 		</theme_item>
 		<theme_item name="shadow_offset_x" data_type="constant" type="int" default="1">
 			The horizontal offset of the font's shadow.
@@ -595,20 +568,47 @@
 		<theme_item name="shadow_outline_size" data_type="constant" type="int" default="1">
 			The size of the shadow outline.
 		</theme_item>
-		<theme_item name="table_border" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
-			The default cell border color.
-		</theme_item>
-		<theme_item name="table_even_row_bg" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
-			The default background color for even rows.
-		</theme_item>
 		<theme_item name="table_hseparation" data_type="constant" type="int" default="3">
 			The horizontal separation of elements in a table.
 		</theme_item>
-		<theme_item name="table_odd_row_bg" data_type="color" type="Color" default="Color(0, 0, 0, 0)">
-			The default background color for odd rows.
-		</theme_item>
 		<theme_item name="table_vseparation" data_type="constant" type="int" default="3">
 			The vertical separation of elements in a table.
+		</theme_item>
+		<theme_item name="bold_font" data_type="font" type="Font">
+			The font used for bold text.
+		</theme_item>
+		<theme_item name="bold_italics_font" data_type="font" type="Font">
+			The font used for bold italics text.
+		</theme_item>
+		<theme_item name="italics_font" data_type="font" type="Font">
+			The font used for italics text.
+		</theme_item>
+		<theme_item name="mono_font" data_type="font" type="Font">
+			The font used for monospace text.
+		</theme_item>
+		<theme_item name="normal_font" data_type="font" type="Font">
+			The default text font.
+		</theme_item>
+		<theme_item name="bold_font_size" data_type="font_size" type="int">
+			The font size used for bold text.
+		</theme_item>
+		<theme_item name="bold_italics_font_size" data_type="font_size" type="int">
+			The font size used for bold italics text.
+		</theme_item>
+		<theme_item name="italics_font_size" data_type="font_size" type="int">
+			The font size used for italics text.
+		</theme_item>
+		<theme_item name="mono_font_size" data_type="font_size" type="int">
+			The font size used for monospace text.
+		</theme_item>
+		<theme_item name="normal_font_size" data_type="font_size" type="int">
+			The default text font size.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			The background The background used when the [RichTextLabel] is focused.
+		</theme_item>
+		<theme_item name="normal" data_type="style" type="StyleBox">
+			The normal background for the [RichTextLabel].
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -290,24 +290,6 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="close" data_type="icon" type="Texture2D">
-			The icon for the close button (see [member tab_close_display_policy]).
-		</theme_item>
-		<theme_item name="close_bg_highlight" data_type="style" type="StyleBox">
-			Background of the close button when it's being hovered with the cursor.
-		</theme_item>
-		<theme_item name="close_bg_pressed" data_type="style" type="StyleBox">
-			Background of the close button when it's being pressed.
-		</theme_item>
-		<theme_item name="decrement" data_type="icon" type="Texture2D">
-			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the first tab is visible), it appears semi-transparent.
-		</theme_item>
-		<theme_item name="decrement_highlight" data_type="icon" type="Texture2D">
-			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			The font used to draw tab names.
-		</theme_item>
 		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			Font color of disabled tabs.
 		</theme_item>
@@ -317,14 +299,29 @@
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Font color of the currently selected tab.
 		</theme_item>
-		<theme_item name="font_size" data_type="font_size" type="int">
-			Font size of the tab names.
-		</theme_item>
 		<theme_item name="font_unselected_color" data_type="color" type="Color" default="Color(0.69, 0.69, 0.69, 1)">
 			Font color of the other, unselected tabs.
 		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal separation between the elements inside tabs.
+		</theme_item>
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
+			The size of the tab text outline.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			The font used to draw tab names.
+		</theme_item>
+		<theme_item name="font_size" data_type="font_size" type="int">
+			Font size of the tab names.
+		</theme_item>
+		<theme_item name="close" data_type="icon" type="Texture2D">
+			The icon for the close button (see [member tab_close_display_policy]).
+		</theme_item>
+		<theme_item name="decrement" data_type="icon" type="Texture2D">
+			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the first tab is visible), it appears semi-transparent.
+		</theme_item>
+		<theme_item name="decrement_highlight" data_type="icon" type="Texture2D">
+			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
 		<theme_item name="increment" data_type="icon" type="Texture2D">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the last tab is visible) it appears semi-transparent.
@@ -332,8 +329,11 @@
 		<theme_item name="increment_highlight" data_type="icon" type="Texture2D">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
-		<theme_item name="outline_size" data_type="constant" type="int" default="0">
-			The size of the tab text outline.
+		<theme_item name="close_bg_highlight" data_type="style" type="StyleBox">
+			Background of the close button when it's being hovered with the cursor.
+		</theme_item>
+		<theme_item name="close_bg_pressed" data_type="style" type="StyleBox">
+			Background of the close button when it's being pressed.
 		</theme_item>
 		<theme_item name="tab_disabled" data_type="style" type="StyleBox">
 			The style of disabled tabs.

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -182,15 +182,6 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="decrement" data_type="icon" type="Texture2D">
-			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the first tab is visible), it appears semi-transparent.
-		</theme_item>
-		<theme_item name="decrement_highlight" data_type="icon" type="Texture2D">
-			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			The font used to draw tab names.
-		</theme_item>
 		<theme_item name="font_disabled_color" data_type="color" type="Color" default="Color(0.9, 0.9, 0.9, 0.2)">
 			Font color of disabled tabs.
 		</theme_item>
@@ -200,14 +191,29 @@
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Font color of the currently selected tab.
 		</theme_item>
-		<theme_item name="font_size" data_type="font_size" type="int">
-			Font size of the tab names.
-		</theme_item>
 		<theme_item name="font_unselected_color" data_type="color" type="Color" default="Color(0.69, 0.69, 0.69, 1)">
 			Font color of the other, unselected tabs.
 		</theme_item>
 		<theme_item name="icon_separation" data_type="constant" type="int" default="4">
 			Space between tab's name and its icon.
+		</theme_item>
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
+			The size of the tab text outline.
+		</theme_item>
+		<theme_item name="side_margin" data_type="constant" type="int" default="8">
+			The space at the left and right edges of the tab bar.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			The font used to draw tab names.
+		</theme_item>
+		<theme_item name="font_size" data_type="font_size" type="int">
+			Font size of the tab names.
+		</theme_item>
+		<theme_item name="decrement" data_type="icon" type="Texture2D">
+			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the first tab is visible), it appears semi-transparent.
+		</theme_item>
+		<theme_item name="decrement_highlight" data_type="icon" type="Texture2D">
+			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
 		<theme_item name="increment" data_type="icon" type="Texture2D">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the last tab is visible) it appears semi-transparent.
@@ -221,14 +227,8 @@
 		<theme_item name="menu_highlight" data_type="icon" type="Texture2D">
 			The icon for the menu button (see [method set_popup]) when it's being hovered with the cursor.
 		</theme_item>
-		<theme_item name="outline_size" data_type="constant" type="int" default="0">
-			The size of the tab text outline.
-		</theme_item>
 		<theme_item name="panel" data_type="style" type="StyleBox">
 			The style for the background fill.
-		</theme_item>
-		<theme_item name="side_margin" data_type="constant" type="int" default="8">
-			The space at the left and right edges of the tab bar.
 		</theme_item>
 		<theme_item name="tab_disabled" data_type="style" type="StyleBox">
 			The style of disabled tabs.

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -1221,12 +1221,6 @@
 		<theme_item name="current_line_color" data_type="color" type="Color" default="Color(0.25, 0.25, 0.26, 0.8)">
 			Background [Color] of the line containing the caret.
 		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			Sets the [StyleBox] when in focus.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			Sets the default [Font].
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
 			Sets the font [Color].
 		</theme_item>
@@ -1239,21 +1233,6 @@
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
 			Sets the [Color] of the selected text. [member override_selected_font_color] has to be enabled.
 		</theme_item>
-		<theme_item name="font_size" data_type="font_size" type="int">
-			Sets default font size.
-		</theme_item>
-		<theme_item name="line_spacing" data_type="constant" type="int" default="4">
-			Sets the spacing between the lines.
-		</theme_item>
-		<theme_item name="normal" data_type="style" type="StyleBox">
-			Sets the [StyleBox] of this [TextEdit].
-		</theme_item>
-		<theme_item name="outline_size" data_type="constant" type="int" default="0">
-			The size of the text outline.
-		</theme_item>
-		<theme_item name="read_only" data_type="style" type="StyleBox">
-			Sets the [StyleBox] of this [TextEdit] when [member editable] is disabled.
-		</theme_item>
 		<theme_item name="search_result_border_color" data_type="color" type="Color" default="Color(0.3, 0.3, 0.3, 0.4)">
 			[Color] of the border around text that matches the search query.
 		</theme_item>
@@ -1263,14 +1242,35 @@
 		<theme_item name="selection_color" data_type="color" type="Color" default="Color(0.49, 0.49, 0.49, 1)">
 			Sets the highlight [Color] of text selections.
 		</theme_item>
+		<theme_item name="word_highlighted_color" data_type="color" type="Color" default="Color(0.8, 0.9, 0.9, 0.15)">
+			Sets the highlight [Color] of multiple occurrences. [member highlight_all_occurrences] has to be enabled.
+		</theme_item>
+		<theme_item name="line_spacing" data_type="constant" type="int" default="4">
+			Sets the spacing between the lines.
+		</theme_item>
+		<theme_item name="outline_size" data_type="constant" type="int" default="0">
+			The size of the text outline.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			Sets the default [Font].
+		</theme_item>
+		<theme_item name="font_size" data_type="font_size" type="int">
+			Sets default font size.
+		</theme_item>
 		<theme_item name="space" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] for space text characters.
 		</theme_item>
 		<theme_item name="tab" data_type="icon" type="Texture2D">
 			Sets a custom [Texture2D] for tab text characters.
 		</theme_item>
-		<theme_item name="word_highlighted_color" data_type="color" type="Color" default="Color(0.8, 0.9, 0.9, 0.15)">
-			Sets the highlight [Color] of multiple occurrences. [member highlight_all_occurrences] has to be enabled.
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			Sets the [StyleBox] when in focus.
+		</theme_item>
+		<theme_item name="normal" data_type="style" type="StyleBox">
+			Sets the [StyleBox] of this [TextEdit].
+		</theme_item>
+		<theme_item name="read_only" data_type="style" type="StyleBox">
+			Sets the [StyleBox] of this [TextEdit] when [member editable] is disabled.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -474,65 +474,14 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="arrow" data_type="icon" type="Texture2D">
-			The arrow icon used when a foldable item is not collapsed.
-		</theme_item>
-		<theme_item name="arrow_collapsed" data_type="icon" type="Texture2D">
-			The arrow icon used when a foldable item is collapsed (for left-to-right layouts).
-		</theme_item>
-		<theme_item name="arrow_collapsed_mirrored" data_type="icon" type="Texture2D">
-			The arrow icon used when a foldable item is collapsed (for right-to-left layouts).
-		</theme_item>
-		<theme_item name="bg" data_type="style" type="StyleBox">
-			Default [StyleBox] for the [Tree], i.e. used when the control is not being focused.
-		</theme_item>
-		<theme_item name="bg_focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [Tree] is being focused.
-		</theme_item>
-		<theme_item name="button_margin" data_type="constant" type="int" default="4">
-			The horizontal space between each button in a cell.
-		</theme_item>
-		<theme_item name="button_pressed" data_type="style" type="StyleBox">
-			[StyleBox] used when a button in the tree is pressed.
-		</theme_item>
-		<theme_item name="checked" data_type="icon" type="Texture2D">
-			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is checked.
-		</theme_item>
 		<theme_item name="children_hl_line_color" data_type="color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
 			The [Color] of the relationship lines between the selected [TreeItem] and its children.
-		</theme_item>
-		<theme_item name="children_hl_line_width" data_type="constant" type="int" default="1">
-			The width of the relationship lines between the selected [TreeItem] and its children.
-		</theme_item>
-		<theme_item name="cursor" data_type="style" type="StyleBox">
-			[StyleBox] used for the cursor, when the [Tree] is being focused.
-		</theme_item>
-		<theme_item name="cursor_unfocused" data_type="style" type="StyleBox">
-			[StyleBox] used for the cursor, when the [Tree] is not being focused.
-		</theme_item>
-		<theme_item name="custom_button" data_type="style" type="StyleBox">
-			Default [StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell.
 		</theme_item>
 		<theme_item name="custom_button_font_highlight" data_type="color" type="Color" default="Color(0.94, 0.94, 0.94, 1)">
 			Text [Color] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's hovered.
 		</theme_item>
-		<theme_item name="custom_button_hover" data_type="style" type="StyleBox">
-			[StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's hovered.
-		</theme_item>
-		<theme_item name="custom_button_pressed" data_type="style" type="StyleBox">
-			[StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's pressed.
-		</theme_item>
-		<theme_item name="draw_guides" data_type="constant" type="int" default="1">
-			Draws the guidelines if not zero, this acts as a boolean. The guideline is a horizontal line drawn at the bottom of each item.
-		</theme_item>
-		<theme_item name="draw_relationship_lines" data_type="constant" type="int" default="0">
-			Draws the relationship lines if not zero, this acts as a boolean. Relationship lines are drawn at the start of child items to show hierarchy.
-		</theme_item>
 		<theme_item name="drop_position_color" data_type="color" type="Color" default="Color(1, 0.3, 0.2, 1)">
 			[Color] used to draw possible drop locations. See [enum DropModeFlags] constants for further description of drop locations.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the item's text.
 		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.69, 0.69, 0.69, 1)">
 			Default text [Color] of the item.
@@ -543,17 +492,32 @@
 		<theme_item name="font_selected_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the item is selected.
 		</theme_item>
-		<theme_item name="font_size" data_type="font_size" type="int">
-			Font size of the item's text.
-		</theme_item>
 		<theme_item name="guide_color" data_type="color" type="Color" default="Color(0, 0, 0, 0.1)">
 			[Color] of the guideline.
 		</theme_item>
+		<theme_item name="parent_hl_line_color" data_type="color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
+			The [Color] of the relationship lines between the selected [TreeItem] and its parents.
+		</theme_item>
+		<theme_item name="relationship_line_color" data_type="color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
+			The default [Color] of the relationship lines.
+		</theme_item>
+		<theme_item name="title_button_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
+			Default text [Color] of the title button.
+		</theme_item>
+		<theme_item name="button_margin" data_type="constant" type="int" default="4">
+			The horizontal space between each button in a cell.
+		</theme_item>
+		<theme_item name="children_hl_line_width" data_type="constant" type="int" default="1">
+			The width of the relationship lines between the selected [TreeItem] and its children.
+		</theme_item>
+		<theme_item name="draw_guides" data_type="constant" type="int" default="1">
+			Draws the guidelines if not zero, this acts as a boolean. The guideline is a horizontal line drawn at the bottom of each item.
+		</theme_item>
+		<theme_item name="draw_relationship_lines" data_type="constant" type="int" default="0">
+			Draws the relationship lines if not zero, this acts as a boolean. Relationship lines are drawn at the start of child items to show hierarchy.
+		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal space between item cells. This is also used as the margin at the start of an item when folding is disabled.
-		</theme_item>
-		<theme_item name="indeterminate" data_type="icon" type="Texture2D">
-			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is indeterminate.
 		</theme_item>
 		<theme_item name="item_margin" data_type="constant" type="int" default="12">
 			The horizontal margin at the start of an item. This is used when folding is enabled for the item.
@@ -561,17 +525,11 @@
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.
 		</theme_item>
-		<theme_item name="parent_hl_line_color" data_type="color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
-			The [Color] of the relationship lines between the selected [TreeItem] and its parents.
-		</theme_item>
 		<theme_item name="parent_hl_line_margin" data_type="constant" type="int" default="0">
 			The space between the parent relationship lines for the selected [TreeItem] and the relationship lines to its siblings that are not selected.
 		</theme_item>
 		<theme_item name="parent_hl_line_width" data_type="constant" type="int" default="1">
 			The width of the relationship lines between the selected [TreeItem] and its parents.
-		</theme_item>
-		<theme_item name="relationship_line_color" data_type="color" type="Color" default="Color(0.27, 0.27, 0.27, 1)">
-			The default [Color] of the relationship lines.
 		</theme_item>
 		<theme_item name="relationship_line_width" data_type="constant" type="int" default="1">
 			The default width of the relationship lines.
@@ -582,20 +540,71 @@
 		<theme_item name="scroll_speed" data_type="constant" type="int" default="12">
 			The speed of border scrolling.
 		</theme_item>
+		<theme_item name="vseparation" data_type="constant" type="int" default="4">
+			The vertical padding inside each item, i.e. the distance between the item's content and top/bottom border.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the item's text.
+		</theme_item>
+		<theme_item name="title_button_font" data_type="font" type="Font">
+			[Font] of the title button's text.
+		</theme_item>
+		<theme_item name="font_size" data_type="font_size" type="int">
+			Font size of the item's text.
+		</theme_item>
+		<theme_item name="arrow" data_type="icon" type="Texture2D">
+			The arrow icon used when a foldable item is not collapsed.
+		</theme_item>
+		<theme_item name="arrow_collapsed" data_type="icon" type="Texture2D">
+			The arrow icon used when a foldable item is collapsed (for left-to-right layouts).
+		</theme_item>
+		<theme_item name="arrow_collapsed_mirrored" data_type="icon" type="Texture2D">
+			The arrow icon used when a foldable item is collapsed (for right-to-left layouts).
+		</theme_item>
+		<theme_item name="checked" data_type="icon" type="Texture2D">
+			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is checked.
+		</theme_item>
+		<theme_item name="indeterminate" data_type="icon" type="Texture2D">
+			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is indeterminate.
+		</theme_item>
 		<theme_item name="select_arrow" data_type="icon" type="Texture2D">
 			The arrow icon to display for the [constant TreeItem.CELL_MODE_RANGE] mode cell.
+		</theme_item>
+		<theme_item name="unchecked" data_type="icon" type="Texture2D">
+			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is unchecked.
+		</theme_item>
+		<theme_item name="updown" data_type="icon" type="Texture2D">
+			The updown arrow icon to display for the [constant TreeItem.CELL_MODE_RANGE] mode cell.
+		</theme_item>
+		<theme_item name="bg" data_type="style" type="StyleBox">
+			Default [StyleBox] for the [Tree], i.e. used when the control is not being focused.
+		</theme_item>
+		<theme_item name="bg_focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Tree] is being focused.
+		</theme_item>
+		<theme_item name="button_pressed" data_type="style" type="StyleBox">
+			[StyleBox] used when a button in the tree is pressed.
+		</theme_item>
+		<theme_item name="cursor" data_type="style" type="StyleBox">
+			[StyleBox] used for the cursor, when the [Tree] is being focused.
+		</theme_item>
+		<theme_item name="cursor_unfocused" data_type="style" type="StyleBox">
+			[StyleBox] used for the cursor, when the [Tree] is not being focused.
+		</theme_item>
+		<theme_item name="custom_button" data_type="style" type="StyleBox">
+			Default [StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell.
+		</theme_item>
+		<theme_item name="custom_button_hover" data_type="style" type="StyleBox">
+			[StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's hovered.
+		</theme_item>
+		<theme_item name="custom_button_pressed" data_type="style" type="StyleBox">
+			[StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's pressed.
 		</theme_item>
 		<theme_item name="selected" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [Tree] is not being focused.
 		</theme_item>
 		<theme_item name="selected_focus" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [Tree] is being focused.
-		</theme_item>
-		<theme_item name="title_button_color" data_type="color" type="Color" default="Color(0.88, 0.88, 0.88, 1)">
-			Default text [Color] of the title button.
-		</theme_item>
-		<theme_item name="title_button_font" data_type="font" type="Font">
-			[Font] of the title button's text.
 		</theme_item>
 		<theme_item name="title_button_hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the title button is being hovered.
@@ -605,15 +614,6 @@
 		</theme_item>
 		<theme_item name="title_button_pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the title button is being pressed.
-		</theme_item>
-		<theme_item name="unchecked" data_type="icon" type="Texture2D">
-			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is unchecked.
-		</theme_item>
-		<theme_item name="updown" data_type="icon" type="Texture2D">
-			The updown arrow icon to display for the [constant TreeItem.CELL_MODE_RANGE] mode cell.
-		</theme_item>
-		<theme_item name="vseparation" data_type="constant" type="int" default="4">
-			The vertical padding inside each item, i.e. the distance between the item's content and top/bottom border.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/VScrollBar.xml
+++ b/doc/classes/VScrollBar.xml
@@ -22,15 +22,6 @@
 		<theme_item name="decrement_pressed" data_type="icon" type="Texture2D">
 			Displayed when the decrement button is being pressed.
 		</theme_item>
-		<theme_item name="grabber" data_type="style" type="StyleBox">
-			Used as texture for the grabber, the draggable element representing current scroll.
-		</theme_item>
-		<theme_item name="grabber_highlight" data_type="style" type="StyleBox">
-			Used when the mouse hovers over the grabber.
-		</theme_item>
-		<theme_item name="grabber_pressed" data_type="style" type="StyleBox">
-			Used when the grabber is being dragged.
-		</theme_item>
 		<theme_item name="increment" data_type="icon" type="Texture2D">
 			Icon used as a button to scroll the [ScrollBar] down. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
@@ -39,6 +30,15 @@
 		</theme_item>
 		<theme_item name="increment_pressed" data_type="icon" type="Texture2D">
 			Displayed when the increment button is being pressed.
+		</theme_item>
+		<theme_item name="grabber" data_type="style" type="StyleBox">
+			Used as texture for the grabber, the draggable element representing current scroll.
+		</theme_item>
+		<theme_item name="grabber_highlight" data_type="style" type="StyleBox">
+			Used when the mouse hovers over the grabber.
+		</theme_item>
+		<theme_item name="grabber_pressed" data_type="style" type="StyleBox">
+			Used when the grabber is being dragged.
 		</theme_item>
 		<theme_item name="scroll" data_type="style" type="StyleBox">
 			Used as background of this [ScrollBar].

--- a/doc/classes/VSlider.xml
+++ b/doc/classes/VSlider.xml
@@ -17,22 +17,22 @@
 		<theme_item name="grabber" data_type="icon" type="Texture2D">
 			The texture for the grabber (the draggable element).
 		</theme_item>
-		<theme_item name="grabber_area" data_type="style" type="StyleBox">
-			The background of the area below the grabber.
-		</theme_item>
-		<theme_item name="grabber_area_highlight" data_type="style" type="StyleBox">
-		</theme_item>
 		<theme_item name="grabber_disabled" data_type="icon" type="Texture2D">
 			The texture for the grabber when it's disabled.
 		</theme_item>
 		<theme_item name="grabber_highlight" data_type="icon" type="Texture2D">
 			The texture for the grabber when it's focused.
 		</theme_item>
-		<theme_item name="slider" data_type="style" type="StyleBox">
-			The background for the whole slider. Determines the width of the [code]grabber_area[/code].
-		</theme_item>
 		<theme_item name="tick" data_type="icon" type="Texture2D">
 			The texture for the ticks, visible when [member Slider.tick_count] is greater than 0.
+		</theme_item>
+		<theme_item name="grabber_area" data_type="style" type="StyleBox">
+			The background of the area below the grabber.
+		</theme_item>
+		<theme_item name="grabber_area_highlight" data_type="style" type="StyleBox">
+		</theme_item>
+		<theme_item name="slider" data_type="style" type="StyleBox">
+			The background for the whole slider. Determines the width of the [code]grabber_area[/code].
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/VSplitContainer.xml
+++ b/doc/classes/VSplitContainer.xml
@@ -12,13 +12,13 @@
 		<theme_item name="autohide" data_type="constant" type="int" default="1">
 			Boolean value. If 1 ([code]true[/code]), the grabber will hide automatically when it isn't under the cursor. If 0 ([code]false[/code]), it's always visible.
 		</theme_item>
-		<theme_item name="bg" data_type="style" type="StyleBox">
+		<theme_item name="separation" data_type="constant" type="int" default="12">
+			The space between sides of the container.
 		</theme_item>
 		<theme_item name="grabber" data_type="icon" type="Texture2D">
 			The icon used for the grabber drawn in the middle area.
 		</theme_item>
-		<theme_item name="separation" data_type="constant" type="int" default="12">
-			The space between sides of the container.
+		<theme_item name="bg" data_type="style" type="StyleBox">
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -437,34 +437,34 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="close" data_type="icon" type="Texture2D">
+		<theme_item name="title_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
+		</theme_item>
+		<theme_item name="title_outline_modulate" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			The color of the title outline.
 		</theme_item>
 		<theme_item name="close_h_ofs" data_type="constant" type="int" default="18">
 		</theme_item>
-		<theme_item name="close_pressed" data_type="icon" type="Texture2D">
-		</theme_item>
 		<theme_item name="close_v_ofs" data_type="constant" type="int" default="18">
-		</theme_item>
-		<theme_item name="embedded_border" data_type="style" type="StyleBox">
 		</theme_item>
 		<theme_item name="resize_margin" data_type="constant" type="int" default="4">
 		</theme_item>
 		<theme_item name="scaleborder_size" data_type="constant" type="int" default="4">
 		</theme_item>
-		<theme_item name="title_color" data_type="color" type="Color" default="Color(0, 0, 0, 1)">
+		<theme_item name="title_height" data_type="constant" type="int" default="20">
+		</theme_item>
+		<theme_item name="title_outline_size" data_type="constant" type="int" default="0">
+			The size of the title outline.
 		</theme_item>
 		<theme_item name="title_font" data_type="font" type="Font">
 		</theme_item>
 		<theme_item name="title_font_size" data_type="font_size" type="int">
 			The size of the title font.
 		</theme_item>
-		<theme_item name="title_height" data_type="constant" type="int" default="20">
+		<theme_item name="close" data_type="icon" type="Texture2D">
 		</theme_item>
-		<theme_item name="title_outline_modulate" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
-			The color of the title outline.
+		<theme_item name="close_pressed" data_type="icon" type="Texture2D">
 		</theme_item>
-		<theme_item name="title_outline_size" data_type="constant" type="int" default="0">
-			The size of the title outline.
+		<theme_item name="embedded_border" data_type="style" type="StyleBox">
 		</theme_item>
 	</theme_items>
 </class>

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -603,6 +603,8 @@ void DocTools::generate(bool p_basic_types) {
 				tid.data_type = "style";
 				c.theme_properties.push_back(tid);
 			}
+
+			c.theme_properties.sort();
 		}
 
 		classes.pop_front();

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -145,6 +145,8 @@ class EditorHelp : public VBoxContainer {
 	void _add_type(const String &p_type, const String &p_enum = String());
 	void _add_method(const DocData::MethodDoc &p_method, bool p_overview = true);
 
+	void _add_bulletpoint();
+
 	void _class_list_select(const String &p_select);
 	void _class_desc_select(const String &p_select);
 	void _class_desc_input(const Ref<InputEvent> &p_input);


### PR DESCRIPTION
This PR makes sure that theme properties in the documentation always follow the same order: they are grouped and ordered by their data type (color, icon, stylebox), and then sorted by name. This affects both the built-in help and the online docs (because order in the XMLs have also been updated).

Additionally, both theme properties and enums/constants have received an update to their look and their description is now on a new line. This is required because a lot of those entries have rather large descriptions which are hard to read otherwise.

Here's how the theme properties look now:
![godot windows tools 64_2021-12-01_21-00-45](https://user-images.githubusercontent.com/11782833/144289074-fe3c088b-1243-477a-b371-73c75ec4224d.png)

A good example of why it's needed for enums as well:
![godot windows tools 64_2021-12-01_20-59-41](https://user-images.githubusercontent.com/11782833/144289217-baa50e7a-52a8-4d63-8c2f-1e37151969d2.png)

And a few comparisons:

* A short enum: [Before](https://user-images.githubusercontent.com/11782833/144289302-4aa905ba-76b3-4783-8428-d28c42d1c082.png) | [After](https://user-images.githubusercontent.com/11782833/144289350-248c9329-e77b-44d0-89a1-fa2abd3c8942.png)
* A mixed bag: [Before](https://user-images.githubusercontent.com/11782833/144289386-4fa387c4-ed4d-4245-b48f-087d49095f84.png) | [After](https://user-images.githubusercontent.com/11782833/144289427-c83fa5d6-5051-4416-8c2c-2ef5565ccc77.png)
* A very long but succinct list: [Before](https://user-images.githubusercontent.com/11782833/144289568-898421a4-e33b-4ffc-b8f6-efe8f9b05ea5.png) | [After 1](https://user-images.githubusercontent.com/11782833/144289601-847ea319-791e-4fec-a4cf-e1adf473cd2a.png), [After 2](https://user-images.githubusercontent.com/11782833/144289615-dfce8b18-5597-4d22-9cff-78cfafcb778d.png)

