### PR TITLE
Draw the filled part of the slider on float EditorSpinSliders (3.x)

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -310,17 +310,24 @@ void EditorSpinSlider::_draw_spin_slider() {
 			grabber->hide();
 		}
 	} else if (!hide_slider) {
-		int grabber_w = 4 * EDSCALE;
-		int width = get_size().width - sb->get_minimum_size().width - grabber_w;
-		int ofs = sb->get_offset().x;
-		int svofs = (get_size().height + vofs) / 2 - 1;
+		const int grabber_w = 4 * EDSCALE;
+		const int width = get_size().width - sb->get_minimum_size().width - grabber_w;
+		const int ofs = sb->get_offset().x;
+		const int svofs = (get_size().height + vofs) / 2 - 1;
 		Color c = fc;
-		c.a = 0.2;
 
+		// Draw the horizontal slider's background.
+		c.a = 0.2;
 		draw_rect(Rect2(ofs, svofs + 1, width, 2 * EDSCALE), c);
-		int gofs = get_as_ratio() * width;
+
+		// Draw the horizontal slider's filled part on the left.
+		const int gofs = get_as_ratio() * width;
+		c.a = 0.45;
+		draw_rect(Rect2(ofs, svofs + 1, gofs, 2 * EDSCALE), c);
+
+		// Draw the horizontal slider's grabber.
 		c.a = 0.9;
-		Rect2 grabber_rect = Rect2(ofs + gofs, svofs + 1, grabber_w, 2 * EDSCALE);
+		const Rect2 grabber_rect = Rect2(ofs + gofs, svofs + 1, grabber_w, 2 * EDSCALE);
 		draw_rect(grabber_rect, c);
 
 		bool display_grabber = (mouse_over_spin || mouse_over_grabber) && !grabbing_spinner && !value_input->is_visible();


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/55519.

This makes it more obvious that the slider has a "filled" part on the left, which improves visibility especially in wider inspectors (such as the Project Settings and Editor Settings).

## Preview

| Before | After |
|-|-|
| ![2021-12-01_19 03 21](https://user-images.githubusercontent.com/180032/144289811-71f117bc-7021-41a5-86de-77d887648280.png) | ![image](https://user-images.githubusercontent.com/180032/144289853-835ff9aa-b81a-4259-aff3-967c79cc3e04.png) |