### PR TITLE
Fix editor crash when expanding/collapsing empty scene tree

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -419,6 +419,9 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 			if (!selected_item) {
 				selected_item = tree->get_root();
+				if (!selected_item) {
+					break;
+				}
 			}
 
 			bool collapsed = _is_collapsed_recursive(selected_item);


### PR DESCRIPTION
Fixes #55523

The scene tree dock performs an additional check to see if the tree contains any children. If not, it just stops.
