### PR TITLE
[3.x] Sort and group theme properties in docs, improve formatting for theme and enums

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -59,15 +59,6 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="disabled" data_type="style" type="StyleBox">
-			[StyleBox] used when the [Button] is disabled.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [Button] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the [Button]'s text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [Button].
 		</theme_item>
@@ -83,11 +74,20 @@
 		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [Button] is being pressed.
 		</theme_item>
-		<theme_item name="hover" data_type="style" type="StyleBox">
-			[StyleBox] used when the [Button] is being hovered.
-		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="2">
 			The horizontal space between [Button]'s icon and text.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the [Button]'s text.
+		</theme_item>
+		<theme_item name="disabled" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is disabled.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
+		</theme_item>
+		<theme_item name="hover" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Button] is being hovered.
 		</theme_item>
 		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [Button].

--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -18,24 +18,6 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
-			The vertical offset used when rendering the check icons (in pixels).
-		</theme_item>
-		<theme_item name="checked" data_type="icon" type="Texture">
-			The check icon to display when the [CheckBox] is checked.
-		</theme_item>
-		<theme_item name="checked_disabled" data_type="icon" type="Texture">
-			The check icon to display when the [CheckBox] is checked and disabled.
-		</theme_item>
-		<theme_item name="disabled" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckBox] is disabled.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckBox] is focused.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			The [Font] to use for the [CheckBox] text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			The [CheckBox] text's font color.
 		</theme_item>
@@ -54,20 +36,20 @@
 		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The [CheckBox] text's font color when it's pressed.
 		</theme_item>
-		<theme_item name="hover" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckBox] is hovered.
-		</theme_item>
-		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckBox] is hovered and pressed.
+		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
+			The vertical offset used when rendering the check icons (in pixels).
 		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The separation between the check icon and the text (in pixels).
 		</theme_item>
-		<theme_item name="normal" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background.
+		<theme_item name="font" data_type="font" type="Font">
+			The [Font] to use for the [CheckBox] text.
 		</theme_item>
-		<theme_item name="pressed" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckBox] is pressed.
+		<theme_item name="checked" data_type="icon" type="Texture">
+			The check icon to display when the [CheckBox] is checked.
+		</theme_item>
+		<theme_item name="checked_disabled" data_type="icon" type="Texture">
+			The check icon to display when the [CheckBox] is checked and disabled.
 		</theme_item>
 		<theme_item name="radio_checked" data_type="icon" type="Texture">
 			If the [CheckBox] is configured as a radio button, the icon to display when the [CheckBox] is checked.
@@ -84,6 +66,24 @@
 		</theme_item>
 		<theme_item name="unchecked_disabled" data_type="icon" type="Texture">
 			The check icon to display when the [CheckBox] is unchecked and disabled.
+		</theme_item>
+		<theme_item name="disabled" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckBox] is disabled.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckBox] is focused.
+		</theme_item>
+		<theme_item name="hover" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckBox] is hovered.
+		</theme_item>
+		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckBox] is hovered and pressed.
+		</theme_item>
+		<theme_item name="normal" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background.
+		</theme_item>
+		<theme_item name="pressed" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckBox] is pressed.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -18,18 +18,6 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
-			The vertical offset used when rendering the toggle icons (in pixels).
-		</theme_item>
-		<theme_item name="disabled" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckButton] is disabled.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckButton] is focused.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			The [Font] to use for the [CheckButton] text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			The [CheckButton] text's font color.
 		</theme_item>
@@ -48,17 +36,14 @@
 		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The [CheckButton] text's font color when it's pressed.
 		</theme_item>
-		<theme_item name="hover" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckButton] is hovered.
-		</theme_item>
-		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background when the [CheckButton] is hovered and pressed.
+		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
+			The vertical offset used when rendering the toggle icons (in pixels).
 		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The separation between the toggle icon and the text (in pixels).
 		</theme_item>
-		<theme_item name="normal" data_type="style" type="StyleBox">
-			The [StyleBox] to display as a background.
+		<theme_item name="font" data_type="font" type="Font">
+			The [Font] to use for the [CheckButton] text.
 		</theme_item>
 		<theme_item name="off" data_type="icon" type="Texture">
 			The icon to display when the [CheckButton] is unchecked.
@@ -71,6 +56,21 @@
 		</theme_item>
 		<theme_item name="on_disabled" data_type="icon" type="Texture">
 			The icon to display when the [CheckButton] is checked and disabled.
+		</theme_item>
+		<theme_item name="disabled" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckButton] is disabled.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckButton] is focused.
+		</theme_item>
+		<theme_item name="hover" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckButton] is hovered.
+		</theme_item>
+		<theme_item name="hover_pressed" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background when the [CheckButton] is hovered and pressed.
+		</theme_item>
+		<theme_item name="normal" data_type="style" type="StyleBox">
+			The [StyleBox] to display as a background.
 		</theme_item>
 		<theme_item name="pressed" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckButton] is pressed.

--- a/doc/classes/ColorPicker.xml
+++ b/doc/classes/ColorPicker.xml
@@ -81,14 +81,6 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="add_preset" data_type="icon" type="Texture">
-			The icon for the "Add Preset" button.
-		</theme_item>
-		<theme_item name="color_hue" data_type="icon" type="Texture">
-			Custom texture for the hue selection slider on the right.
-		</theme_item>
-		<theme_item name="color_sample" data_type="icon" type="Texture">
-		</theme_item>
 		<theme_item name="h_width" data_type="constant" type="int" default="30">
 			The width of the hue selection slider.
 		</theme_item>
@@ -97,6 +89,20 @@
 		<theme_item name="margin" data_type="constant" type="int" default="4">
 			The margin around the [ColorPicker].
 		</theme_item>
+		<theme_item name="sv_height" data_type="constant" type="int" default="256">
+			The height of the saturation-value selection box.
+		</theme_item>
+		<theme_item name="sv_width" data_type="constant" type="int" default="256">
+			The width of the saturation-value selection box.
+		</theme_item>
+		<theme_item name="add_preset" data_type="icon" type="Texture">
+			The icon for the "Add Preset" button.
+		</theme_item>
+		<theme_item name="color_hue" data_type="icon" type="Texture">
+			Custom texture for the hue selection slider on the right.
+		</theme_item>
+		<theme_item name="color_sample" data_type="icon" type="Texture">
+		</theme_item>
 		<theme_item name="overbright_indicator" data_type="icon" type="Texture">
 			The indicator used to signalize that the color value is outside the 0-1 range.
 		</theme_item>
@@ -104,12 +110,6 @@
 		</theme_item>
 		<theme_item name="screen_picker" data_type="icon" type="Texture">
 			The icon for the screen color picker button.
-		</theme_item>
-		<theme_item name="sv_height" data_type="constant" type="int" default="256">
-			The height of the saturation-value selection box.
-		</theme_item>
-		<theme_item name="sv_width" data_type="constant" type="int" default="256">
-			The width of the saturation-value selection box.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -58,18 +58,6 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="bg" data_type="icon" type="Texture">
-			The background of the color preview rect on the button.
-		</theme_item>
-		<theme_item name="disabled" data_type="style" type="StyleBox">
-			[StyleBox] used when the [ColorPickerButton] is disabled.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [ColorPickerButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the [ColorPickerButton]'s text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Default text [Color] of the [ColorPickerButton].
 		</theme_item>
@@ -85,11 +73,23 @@
 		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 0.8, 0.8, 0.8, 1 )">
 			Text [Color] used when the [ColorPickerButton] is being pressed.
 		</theme_item>
-		<theme_item name="hover" data_type="style" type="StyleBox">
-			[StyleBox] used when the [ColorPickerButton] is being hovered.
-		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="2">
 			The horizontal space between [ColorPickerButton]'s icon and text.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the [ColorPickerButton]'s text.
+		</theme_item>
+		<theme_item name="bg" data_type="icon" type="Texture">
+			The background of the color preview rect on the button.
+		</theme_item>
+		<theme_item name="disabled" data_type="style" type="StyleBox">
+			[StyleBox] used when the [ColorPickerButton] is disabled.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [ColorPickerButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
+		</theme_item>
+		<theme_item name="hover" data_type="style" type="StyleBox">
+			[StyleBox] used when the [ColorPickerButton] is being hovered.
 		</theme_item>
 		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [ColorPickerButton].

--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -125,20 +125,20 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="file" data_type="icon" type="Texture">
-			Custom icon for files.
-		</theme_item>
 		<theme_item name="file_icon_modulate" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The color modulation applied to the file icon.
 		</theme_item>
 		<theme_item name="files_disabled" data_type="color" type="Color" default="Color( 0, 0, 0, 0.7 )">
 			The color tint for disabled files (when the [FileDialog] is used in open folder mode).
 		</theme_item>
-		<theme_item name="folder" data_type="icon" type="Texture">
-			Custom icon for folders.
-		</theme_item>
 		<theme_item name="folder_icon_modulate" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The color modulation applied to the folder icon.
+		</theme_item>
+		<theme_item name="file" data_type="icon" type="Texture">
+			Custom icon for files.
+		</theme_item>
+		<theme_item name="folder" data_type="icon" type="Texture">
+			Custom icon for folders.
 		</theme_item>
 		<theme_item name="parent_folder" data_type="icon" type="Texture">
 			Custom icon for the parent folder arrow.

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -264,18 +264,27 @@
 	<theme_items>
 		<theme_item name="activity" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 		</theme_item>
-		<theme_item name="bezier_len_neg" data_type="constant" type="int" default="160">
-		</theme_item>
-		<theme_item name="bezier_len_pos" data_type="constant" type="int" default="80">
-		</theme_item>
-		<theme_item name="bg" data_type="style" type="StyleBox">
-			The background drawn under the grid.
-		</theme_item>
 		<theme_item name="grid_major" data_type="color" type="Color" default="Color( 1, 1, 1, 0.2 )">
 			Color of major grid lines.
 		</theme_item>
 		<theme_item name="grid_minor" data_type="color" type="Color" default="Color( 1, 1, 1, 0.05 )">
 			Color of minor grid lines.
+		</theme_item>
+		<theme_item name="selection_fill" data_type="color" type="Color" default="Color( 1, 1, 1, 0.3 )">
+			The fill color of the selection rectangle.
+		</theme_item>
+		<theme_item name="selection_stroke" data_type="color" type="Color" default="Color( 1, 1, 1, 0.8 )">
+			The outline color of the selection rectangle.
+		</theme_item>
+		<theme_item name="bezier_len_neg" data_type="constant" type="int" default="160">
+		</theme_item>
+		<theme_item name="bezier_len_pos" data_type="constant" type="int" default="80">
+		</theme_item>
+		<theme_item name="port_grab_distance_horizontal" data_type="constant" type="int" default="24">
+			The horizontal range within which a port can be grabbed (on both sides).
+		</theme_item>
+		<theme_item name="port_grab_distance_vertical" data_type="constant" type="int" default="6">
+			The vertical range within which a port can be grabbed (on both sides).
 		</theme_item>
 		<theme_item name="minimap" data_type="icon" type="Texture">
 		</theme_item>
@@ -285,23 +294,14 @@
 		<theme_item name="more" data_type="icon" type="Texture">
 			The icon for the zoom in button.
 		</theme_item>
-		<theme_item name="port_grab_distance_horizontal" data_type="constant" type="int" default="24">
-			The horizontal range within which a port can be grabbed (on both sides).
-		</theme_item>
-		<theme_item name="port_grab_distance_vertical" data_type="constant" type="int" default="6">
-			The vertical range within which a port can be grabbed (on both sides).
-		</theme_item>
 		<theme_item name="reset" data_type="icon" type="Texture">
 			The icon for the zoom reset button.
 		</theme_item>
-		<theme_item name="selection_fill" data_type="color" type="Color" default="Color( 1, 1, 1, 0.3 )">
-			The fill color of the selection rectangle.
-		</theme_item>
-		<theme_item name="selection_stroke" data_type="color" type="Color" default="Color( 1, 1, 1, 0.8 )">
-			The outline color of the selection rectangle.
-		</theme_item>
 		<theme_item name="snap" data_type="icon" type="Texture">
 			The icon for the snap toggle button.
+		</theme_item>
+		<theme_item name="bg" data_type="style" type="StyleBox">
+			The background drawn under the grid.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -264,17 +264,41 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="breakpoint" data_type="style" type="StyleBox">
-			The background used when [member overlay] is set to [constant OVERLAY_BREAKPOINT].
+		<theme_item name="close_color" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
+			The color modulation applied to the close button icon.
+		</theme_item>
+		<theme_item name="resizer_color" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
+			The color modulation applied to the resizer icon.
+		</theme_item>
+		<theme_item name="title_color" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
+			Color of the title text.
+		</theme_item>
+		<theme_item name="close_offset" data_type="constant" type="int" default="18">
+			The vertical offset of the close button.
+		</theme_item>
+		<theme_item name="port_offset" data_type="constant" type="int" default="3">
+			Horizontal offset for the ports.
+		</theme_item>
+		<theme_item name="separation" data_type="constant" type="int" default="1">
+			The vertical distance between ports.
+		</theme_item>
+		<theme_item name="title_offset" data_type="constant" type="int" default="20">
+			Vertical offset of the title text.
+		</theme_item>
+		<theme_item name="title_font" data_type="font" type="Font">
+			Font used for the title text.
 		</theme_item>
 		<theme_item name="close" data_type="icon" type="Texture">
 			The icon for the close button, visible when [member show_close] is enabled.
 		</theme_item>
-		<theme_item name="close_color" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
-			The color modulation applied to the close button icon.
+		<theme_item name="port" data_type="icon" type="Texture">
+			The icon used for representing ports.
 		</theme_item>
-		<theme_item name="close_offset" data_type="constant" type="int" default="18">
-			The vertical offset of the close button.
+		<theme_item name="resizer" data_type="icon" type="Texture">
+			The icon used for resizer, visible when [member resizable] is enabled.
+		</theme_item>
+		<theme_item name="breakpoint" data_type="style" type="StyleBox">
+			The background used when [member overlay] is set to [constant OVERLAY_BREAKPOINT].
 		</theme_item>
 		<theme_item name="comment" data_type="style" type="StyleBox">
 			The [StyleBox] used when [member comment] is enabled.
@@ -289,35 +313,11 @@
 		<theme_item name="frame" data_type="style" type="StyleBox">
 			The default background for [GraphNode].
 		</theme_item>
-		<theme_item name="port" data_type="icon" type="Texture">
-			The icon used for representing ports.
-		</theme_item>
-		<theme_item name="port_offset" data_type="constant" type="int" default="3">
-			Horizontal offset for the ports.
-		</theme_item>
 		<theme_item name="position" data_type="style" type="StyleBox">
 			The background used when [member overlay] is set to [constant OVERLAY_POSITION].
 		</theme_item>
-		<theme_item name="resizer" data_type="icon" type="Texture">
-			The icon used for resizer, visible when [member resizable] is enabled.
-		</theme_item>
-		<theme_item name="resizer_color" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
-			The color modulation applied to the resizer icon.
-		</theme_item>
 		<theme_item name="selectedframe" data_type="style" type="StyleBox">
 			The background used when the [GraphNode] is selected.
-		</theme_item>
-		<theme_item name="separation" data_type="constant" type="int" default="1">
-			The vertical distance between ports.
-		</theme_item>
-		<theme_item name="title_color" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
-			Color of the title text.
-		</theme_item>
-		<theme_item name="title_font" data_type="font" type="Font">
-			Font used for the title text.
-		</theme_item>
-		<theme_item name="title_offset" data_type="constant" type="int" default="20">
-			Vertical offset of the title text.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/HScrollBar.xml
+++ b/doc/classes/HScrollBar.xml
@@ -22,15 +22,6 @@
 		<theme_item name="decrement_pressed" data_type="icon" type="Texture">
 			Displayed when the decrement button is being pressed.
 		</theme_item>
-		<theme_item name="grabber" data_type="style" type="StyleBox">
-			Used as texture for the grabber, the draggable element representing current scroll.
-		</theme_item>
-		<theme_item name="grabber_highlight" data_type="style" type="StyleBox">
-			Used when the mouse hovers over the grabber.
-		</theme_item>
-		<theme_item name="grabber_pressed" data_type="style" type="StyleBox">
-			Used when the grabber is being dragged.
-		</theme_item>
 		<theme_item name="increment" data_type="icon" type="Texture">
 			Icon used as a button to scroll the [ScrollBar] right. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
@@ -39,6 +30,15 @@
 		</theme_item>
 		<theme_item name="increment_pressed" data_type="icon" type="Texture">
 			Displayed when the increment button is being pressed.
+		</theme_item>
+		<theme_item name="grabber" data_type="style" type="StyleBox">
+			Used as texture for the grabber, the draggable element representing current scroll.
+		</theme_item>
+		<theme_item name="grabber_highlight" data_type="style" type="StyleBox">
+			Used when the mouse hovers over the grabber.
+		</theme_item>
+		<theme_item name="grabber_pressed" data_type="style" type="StyleBox">
+			Used when the grabber is being dragged.
 		</theme_item>
 		<theme_item name="scroll" data_type="style" type="StyleBox">
 			Used as background of this [ScrollBar].

--- a/doc/classes/HSlider.xml
+++ b/doc/classes/HSlider.xml
@@ -17,22 +17,22 @@
 		<theme_item name="grabber" data_type="icon" type="Texture">
 			The texture for the grabber (the draggable element).
 		</theme_item>
-		<theme_item name="grabber_area" data_type="style" type="StyleBox">
-			The background of the area to the left of the grabber.
-		</theme_item>
-		<theme_item name="grabber_area_highlight" data_type="style" type="StyleBox">
-		</theme_item>
 		<theme_item name="grabber_disabled" data_type="icon" type="Texture">
 			The texture for the grabber when it's disabled.
 		</theme_item>
 		<theme_item name="grabber_highlight" data_type="icon" type="Texture">
 			The texture for the grabber when it's focused.
 		</theme_item>
-		<theme_item name="slider" data_type="style" type="StyleBox">
-			The background for the whole slider. Determines the height of the [code]grabber_area[/code].
-		</theme_item>
 		<theme_item name="tick" data_type="icon" type="Texture">
 			The texture for the ticks, visible when [member Slider.tick_count] is greater than 0.
+		</theme_item>
+		<theme_item name="grabber_area" data_type="style" type="StyleBox">
+			The background of the area to the left of the grabber.
+		</theme_item>
+		<theme_item name="grabber_area_highlight" data_type="style" type="StyleBox">
+		</theme_item>
+		<theme_item name="slider" data_type="style" type="StyleBox">
+			The background for the whole slider. Determines the height of the [code]grabber_area[/code].
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/HSplitContainer.xml
+++ b/doc/classes/HSplitContainer.xml
@@ -16,13 +16,13 @@
 		<theme_item name="autohide" data_type="constant" type="int" default="1">
 			Boolean value. If 1 ([code]true[/code]), the grabber will hide automatically when it isn't under the cursor. If 0 ([code]false[/code]), it's always visible.
 		</theme_item>
-		<theme_item name="bg" data_type="style" type="StyleBox">
+		<theme_item name="separation" data_type="constant" type="int" default="12">
+			The space between sides of the container.
 		</theme_item>
 		<theme_item name="grabber" data_type="icon" type="Texture">
 			The icon used for the grabber drawn in the middle area.
 		</theme_item>
-		<theme_item name="separation" data_type="constant" type="int" default="12">
-			The space between sides of the container.
+		<theme_item name="bg" data_type="style" type="StyleBox">
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -408,21 +408,6 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="bg" data_type="style" type="StyleBox">
-			Default [StyleBox] for the [ItemList], i.e. used when the control is not being focused.
-		</theme_item>
-		<theme_item name="bg_focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [ItemList] is being focused.
-		</theme_item>
-		<theme_item name="cursor" data_type="style" type="StyleBox">
-			[StyleBox] used for the cursor, when the [ItemList] is being focused.
-		</theme_item>
-		<theme_item name="cursor_unfocused" data_type="style" type="StyleBox">
-			[StyleBox] used for the cursor, when the [ItemList] is not being focused.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the item's text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.63, 0.63, 0.63, 1 )">
 			Default text [Color] of the item.
 		</theme_item>
@@ -441,14 +426,29 @@
 		<theme_item name="line_separation" data_type="constant" type="int" default="2">
 			The vertical spacing between each line of text.
 		</theme_item>
+		<theme_item name="vseparation" data_type="constant" type="int" default="2">
+			The vertical spacing between items.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the item's text.
+		</theme_item>
+		<theme_item name="bg" data_type="style" type="StyleBox">
+			Default [StyleBox] for the [ItemList], i.e. used when the control is not being focused.
+		</theme_item>
+		<theme_item name="bg_focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [ItemList] is being focused.
+		</theme_item>
+		<theme_item name="cursor" data_type="style" type="StyleBox">
+			[StyleBox] used for the cursor, when the [ItemList] is being focused.
+		</theme_item>
+		<theme_item name="cursor_unfocused" data_type="style" type="StyleBox">
+			[StyleBox] used for the cursor, when the [ItemList] is not being focused.
+		</theme_item>
 		<theme_item name="selected" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [ItemList] is not being focused.
 		</theme_item>
 		<theme_item name="selected_focus" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [ItemList] is being focused.
-		</theme_item>
-		<theme_item name="vseparation" data_type="constant" type="int" default="2">
-			The vertical spacing between items.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -98,9 +98,6 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] used for the [Label]'s text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Default text [Color] of the [Label].
 		</theme_item>
@@ -113,9 +110,6 @@
 		<theme_item name="line_spacing" data_type="constant" type="int" default="3">
 			Vertical space between lines in multiline [Label].
 		</theme_item>
-		<theme_item name="normal" data_type="style" type="StyleBox">
-			Background [StyleBox] for the [Label].
-		</theme_item>
 		<theme_item name="shadow_as_outline" data_type="constant" type="int" default="0">
 			Boolean value. If set to 1 ([code]true[/code]), the shadow will be displayed around the whole text as an outline.
 		</theme_item>
@@ -124,6 +118,12 @@
 		</theme_item>
 		<theme_item name="shadow_offset_y" data_type="constant" type="int" default="1">
 			The vertical offset of the text's shadow.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] used for the [Label]'s text.
+		</theme_item>
+		<theme_item name="normal" data_type="style" type="StyleBox">
+			Background [StyleBox] for the [Label].
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -232,9 +232,6 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="clear" data_type="icon" type="Texture">
-			Texture for the clear button. See [member clear_button_enabled].
-		</theme_item>
 		<theme_item name="clear_button_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Color used as default tint for the clear button.
 		</theme_item>
@@ -243,12 +240,6 @@
 		</theme_item>
 		<theme_item name="cursor_color" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Color of the [LineEdit]'s visual cursor (caret).
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			Background used when [LineEdit] has GUI focus.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			Font used for the text.
 		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default font color.
@@ -259,17 +250,26 @@
 		<theme_item name="font_color_uneditable" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 0.5 )">
 			Font color when editing is disabled.
 		</theme_item>
+		<theme_item name="selection_color" data_type="color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
+			Color of the selection rectangle.
+		</theme_item>
 		<theme_item name="minimum_spaces" data_type="constant" type="int" default="12">
 			Minimum horizontal space for the text (not counting the clear button and content margins). This value is measured in count of space characters (i.e. this amount of space characters can be displayed without scrolling).
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			Font used for the text.
+		</theme_item>
+		<theme_item name="clear" data_type="icon" type="Texture">
+			Texture for the clear button. See [member clear_button_enabled].
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			Background used when [LineEdit] has GUI focus.
 		</theme_item>
 		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default background for the [LineEdit].
 		</theme_item>
 		<theme_item name="read_only" data_type="style" type="StyleBox">
 			Background used when [LineEdit] is in read-only mode ([member editable] is set to [code]false[/code]).
-		</theme_item>
-		<theme_item name="selection_color" data_type="color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
-			Color of the selection rectangle.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -33,12 +33,6 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [LinkButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the [LinkButton]'s text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [LinkButton].
 		</theme_item>
@@ -53,6 +47,12 @@
 		</theme_item>
 		<theme_item name="underline_spacing" data_type="constant" type="int" default="2">
 			The vertical space between the baseline of text and the underline.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the [LinkButton]'s text.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [LinkButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -45,15 +45,6 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="disabled" data_type="style" type="StyleBox">
-			[StyleBox] used when the [MenuButton] is disabled.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [MenuButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the [MenuButton]'s text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [MenuButton].
 		</theme_item>
@@ -69,11 +60,20 @@
 		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [MenuButton] is being pressed.
 		</theme_item>
-		<theme_item name="hover" data_type="style" type="StyleBox">
-			[StyleBox] used when the [MenuButton] is being hovered.
-		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="3">
 			The horizontal space between [MenuButton]'s icon and text.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the [MenuButton]'s text.
+		</theme_item>
+		<theme_item name="disabled" data_type="style" type="StyleBox">
+			[StyleBox] used when the [MenuButton] is disabled.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [MenuButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
+		</theme_item>
+		<theme_item name="hover" data_type="style" type="StyleBox">
+			[StyleBox] used when the [MenuButton] is being hovered.
 		</theme_item>
 		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [MenuButton].

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -187,21 +187,6 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="arrow" data_type="icon" type="Texture">
-			The arrow icon to be drawn on the right end of the button.
-		</theme_item>
-		<theme_item name="arrow_margin" data_type="constant" type="int" default="2">
-			The horizontal space between the arrow icon and the right edge of the button.
-		</theme_item>
-		<theme_item name="disabled" data_type="style" type="StyleBox">
-			[StyleBox] used when the [OptionButton] is disabled.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [OptionButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the [OptionButton]'s text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [OptionButton].
 		</theme_item>
@@ -217,11 +202,26 @@
 		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [OptionButton] is being pressed.
 		</theme_item>
-		<theme_item name="hover" data_type="style" type="StyleBox">
-			[StyleBox] used when the [OptionButton] is being hovered.
+		<theme_item name="arrow_margin" data_type="constant" type="int" default="2">
+			The horizontal space between the arrow icon and the right edge of the button.
 		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="2">
 			The horizontal space between [OptionButton]'s icon and text.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the [OptionButton]'s text.
+		</theme_item>
+		<theme_item name="arrow" data_type="icon" type="Texture">
+			The arrow icon to be drawn on the right end of the button.
+		</theme_item>
+		<theme_item name="disabled" data_type="style" type="StyleBox">
+			[StyleBox] used when the [OptionButton] is disabled.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [OptionButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
+		</theme_item>
+		<theme_item name="hover" data_type="style" type="StyleBox">
+			[StyleBox] used when the [OptionButton] is being hovered.
 		</theme_item>
 		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [OptionButton].

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -496,12 +496,6 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="checked" data_type="icon" type="Texture">
-			[Texture] icon for the checked checkbox items.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] used for the menu items.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			The default text [Color] for menu items' names.
 		</theme_item>
@@ -517,11 +511,32 @@
 		<theme_item name="font_color_separator" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			[Color] used for labeled separators' text. See [method add_separator].
 		</theme_item>
-		<theme_item name="hover" data_type="style" type="StyleBox">
-			[StyleBox] displayed when the [PopupMenu] item is hovered.
-		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal space between the item's name and the shortcut text/submenu arrow.
+		</theme_item>
+		<theme_item name="vseparation" data_type="constant" type="int" default="4">
+			The vertical space between each menu item.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] used for the menu items.
+		</theme_item>
+		<theme_item name="checked" data_type="icon" type="Texture">
+			[Texture] icon for the checked checkbox items.
+		</theme_item>
+		<theme_item name="radio_checked" data_type="icon" type="Texture">
+			[Texture] icon for the checked radio button items.
+		</theme_item>
+		<theme_item name="radio_unchecked" data_type="icon" type="Texture">
+			[Texture] icon for the unchecked radio button items.
+		</theme_item>
+		<theme_item name="submenu" data_type="icon" type="Texture">
+			[Texture] icon for the submenu arrow.
+		</theme_item>
+		<theme_item name="unchecked" data_type="icon" type="Texture">
+			[Texture] icon for the unchecked checkbox items.
+		</theme_item>
+		<theme_item name="hover" data_type="style" type="StyleBox">
+			[StyleBox] displayed when the [PopupMenu] item is hovered.
 		</theme_item>
 		<theme_item name="labeled_separator_left" data_type="style" type="StyleBox">
 			[StyleBox] for the left side of labeled separator. See [method add_separator].
@@ -535,23 +550,8 @@
 		<theme_item name="panel_disabled" data_type="style" type="StyleBox">
 			[StyleBox] used when the [PopupMenu] item is disabled.
 		</theme_item>
-		<theme_item name="radio_checked" data_type="icon" type="Texture">
-			[Texture] icon for the checked radio button items.
-		</theme_item>
-		<theme_item name="radio_unchecked" data_type="icon" type="Texture">
-			[Texture] icon for the unchecked radio button items.
-		</theme_item>
 		<theme_item name="separator" data_type="style" type="StyleBox">
 			[StyleBox] used for the separators. See [method add_separator].
-		</theme_item>
-		<theme_item name="submenu" data_type="icon" type="Texture">
-			[Texture] icon for the submenu arrow.
-		</theme_item>
-		<theme_item name="unchecked" data_type="icon" type="Texture">
-			[Texture] icon for the unchecked checkbox items.
-		</theme_item>
-		<theme_item name="vseparation" data_type="constant" type="int" default="4">
-			The vertical space between each menu item.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -20,20 +20,20 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="bg" data_type="style" type="StyleBox">
-			The style of the background.
-		</theme_item>
-		<theme_item name="fg" data_type="style" type="StyleBox">
-			The style of the progress (i.e. the part that fills the bar).
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			Font used to draw the fill percentage if [member percent_visible] is [code]true[/code].
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			The color of the text.
 		</theme_item>
 		<theme_item name="font_color_shadow" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
 			The color of the text's shadow.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			Font used to draw the fill percentage if [member percent_visible] is [code]true[/code].
+		</theme_item>
+		<theme_item name="bg" data_type="style" type="StyleBox">
+			The style of the background.
+		</theme_item>
+		<theme_item name="fg" data_type="style" type="StyleBox">
+			The style of the progress (i.e. the part that fills the bar).
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -367,17 +367,8 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="bold_font" data_type="font" type="Font">
-			The font used for bold text.
-		</theme_item>
-		<theme_item name="bold_italics_font" data_type="font" type="Font">
-			The font used for bold italics text.
-		</theme_item>
 		<theme_item name="default_color" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			The default text color.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			The background The background used when the [RichTextLabel] is focused.
 		</theme_item>
 		<theme_item name="font_color_selected" data_type="color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
 			The color of selected text, used when [member selection_enabled] is [code]true[/code].
@@ -385,23 +376,11 @@
 		<theme_item name="font_color_shadow" data_type="color" type="Color" default="Color( 0, 0, 0, 0 )">
 			The color of the font's shadow.
 		</theme_item>
-		<theme_item name="italics_font" data_type="font" type="Font">
-			The font used for italics text.
+		<theme_item name="selection_color" data_type="color" type="Color" default="Color( 0.1, 0.1, 1, 0.8 )">
+			The color of the selection box.
 		</theme_item>
 		<theme_item name="line_separation" data_type="constant" type="int" default="1">
 			The vertical space between lines.
-		</theme_item>
-		<theme_item name="mono_font" data_type="font" type="Font">
-			The font used for monospace text.
-		</theme_item>
-		<theme_item name="normal" data_type="style" type="StyleBox">
-			The normal background for the [RichTextLabel].
-		</theme_item>
-		<theme_item name="normal_font" data_type="font" type="Font">
-			The default text font.
-		</theme_item>
-		<theme_item name="selection_color" data_type="color" type="Color" default="Color( 0.1, 0.1, 1, 0.8 )">
-			The color of the selection box.
 		</theme_item>
 		<theme_item name="shadow_as_outline" data_type="constant" type="int" default="0">
 			Boolean value. If 1 ([code]true[/code]), the shadow will be displayed around the whole text as an outline.
@@ -417,6 +396,27 @@
 		</theme_item>
 		<theme_item name="table_vseparation" data_type="constant" type="int" default="3">
 			The vertical separation of elements in a table.
+		</theme_item>
+		<theme_item name="bold_font" data_type="font" type="Font">
+			The font used for bold text.
+		</theme_item>
+		<theme_item name="bold_italics_font" data_type="font" type="Font">
+			The font used for bold italics text.
+		</theme_item>
+		<theme_item name="italics_font" data_type="font" type="Font">
+			The font used for italics text.
+		</theme_item>
+		<theme_item name="mono_font" data_type="font" type="Font">
+			The font used for monospace text.
+		</theme_item>
+		<theme_item name="normal_font" data_type="font" type="Font">
+			The default text font.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			The background The background used when the [RichTextLabel] is focused.
+		</theme_item>
+		<theme_item name="normal" data_type="style" type="StyleBox">
+			The normal background for the [RichTextLabel].
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -182,15 +182,6 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="decrement" data_type="icon" type="Texture">
-			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the first tab is visible), it appears semi-transparent.
-		</theme_item>
-		<theme_item name="decrement_highlight" data_type="icon" type="Texture">
-			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			The font used to draw tab names.
-		</theme_item>
 		<theme_item name="font_color_bg" data_type="color" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
 			Font color of inactive tabs.
 		</theme_item>
@@ -203,15 +194,29 @@
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			Horizontal separation between tabs.
 		</theme_item>
+		<theme_item name="label_valign_bg" data_type="constant" type="int" default="2">
+		</theme_item>
+		<theme_item name="label_valign_fg" data_type="constant" type="int" default="0">
+		</theme_item>
+		<theme_item name="side_margin" data_type="constant" type="int" default="8">
+			The space at the left and right edges of the tab bar.
+		</theme_item>
+		<theme_item name="top_margin" data_type="constant" type="int" default="24">
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			The font used to draw tab names.
+		</theme_item>
+		<theme_item name="decrement" data_type="icon" type="Texture">
+			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the first tab is visible), it appears semi-transparent.
+		</theme_item>
+		<theme_item name="decrement_highlight" data_type="icon" type="Texture">
+			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
+		</theme_item>
 		<theme_item name="increment" data_type="icon" type="Texture">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the last tab is visible) it appears semi-transparent.
 		</theme_item>
 		<theme_item name="increment_highlight" data_type="icon" type="Texture">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
-		</theme_item>
-		<theme_item name="label_valign_bg" data_type="constant" type="int" default="2">
-		</theme_item>
-		<theme_item name="label_valign_fg" data_type="constant" type="int" default="0">
 		</theme_item>
 		<theme_item name="menu" data_type="icon" type="Texture">
 			The icon for the menu button (see [method set_popup]).
@@ -222,9 +227,6 @@
 		<theme_item name="panel" data_type="style" type="StyleBox">
 			The style for the background fill.
 		</theme_item>
-		<theme_item name="side_margin" data_type="constant" type="int" default="8">
-			The space at the left and right edges of the tab bar.
-		</theme_item>
 		<theme_item name="tab_bg" data_type="style" type="StyleBox">
 			The style of inactive tabs.
 		</theme_item>
@@ -233,8 +235,6 @@
 		</theme_item>
 		<theme_item name="tab_fg" data_type="style" type="StyleBox">
 			The style of the currently selected tab.
-		</theme_item>
-		<theme_item name="top_margin" data_type="constant" type="int" default="24">
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/Tabs.xml
+++ b/doc/classes/Tabs.xml
@@ -224,24 +224,6 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="button" data_type="style" type="StyleBox">
-			Background of the close button when it's being hovered with the cursor.
-		</theme_item>
-		<theme_item name="button_pressed" data_type="style" type="StyleBox">
-			Background of the close button when it's being pressed.
-		</theme_item>
-		<theme_item name="close" data_type="icon" type="Texture">
-			The icon for the close button (see [member tab_close_display_policy]).
-		</theme_item>
-		<theme_item name="decrement" data_type="icon" type="Texture">
-			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the first tab is visible), it appears semi-transparent.
-		</theme_item>
-		<theme_item name="decrement_highlight" data_type="icon" type="Texture">
-			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			The font used to draw tab names.
-		</theme_item>
 		<theme_item name="font_color_bg" data_type="color" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
 			Font color of inactive tabs.
 		</theme_item>
@@ -254,15 +236,35 @@
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal separation between the tabs.
 		</theme_item>
+		<theme_item name="label_valign_bg" data_type="constant" type="int" default="2">
+		</theme_item>
+		<theme_item name="label_valign_fg" data_type="constant" type="int" default="0">
+		</theme_item>
+		<theme_item name="top_margin" data_type="constant" type="int" default="24">
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			The font used to draw tab names.
+		</theme_item>
+		<theme_item name="close" data_type="icon" type="Texture">
+			The icon for the close button (see [member tab_close_display_policy]).
+		</theme_item>
+		<theme_item name="decrement" data_type="icon" type="Texture">
+			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the first tab is visible), it appears semi-transparent.
+		</theme_item>
+		<theme_item name="decrement_highlight" data_type="icon" type="Texture">
+			Icon for the left arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
+		</theme_item>
 		<theme_item name="increment" data_type="icon" type="Texture">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. When the button is disabled (i.e. the last tab is visible) it appears semi-transparent.
 		</theme_item>
 		<theme_item name="increment_highlight" data_type="icon" type="Texture">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
-		<theme_item name="label_valign_bg" data_type="constant" type="int" default="2">
+		<theme_item name="button" data_type="style" type="StyleBox">
+			Background of the close button when it's being hovered with the cursor.
 		</theme_item>
-		<theme_item name="label_valign_fg" data_type="constant" type="int" default="0">
+		<theme_item name="button_pressed" data_type="style" type="StyleBox">
+			Background of the close button when it's being pressed.
 		</theme_item>
 		<theme_item name="tab_bg" data_type="style" type="StyleBox">
 			The style of an inactive tab.
@@ -272,8 +274,6 @@
 		</theme_item>
 		<theme_item name="tab_fg" data_type="style" type="StyleBox">
 			The style of the currently selected tab.
-		</theme_item>
-		<theme_item name="top_margin" data_type="constant" type="int" default="24">
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -635,21 +635,13 @@
 		</theme_item>
 		<theme_item name="code_folding_color" data_type="color" type="Color" default="Color( 0.8, 0.8, 0.8, 0.8 )">
 		</theme_item>
-		<theme_item name="completion" data_type="style" type="StyleBox">
-		</theme_item>
 		<theme_item name="completion_background_color" data_type="color" type="Color" default="Color( 0.17, 0.16, 0.2, 1 )">
 		</theme_item>
 		<theme_item name="completion_existing_color" data_type="color" type="Color" default="Color( 0.87, 0.87, 0.87, 0.13 )">
 		</theme_item>
 		<theme_item name="completion_font_color" data_type="color" type="Color" default="Color( 0.67, 0.67, 0.67, 1 )">
 		</theme_item>
-		<theme_item name="completion_lines" data_type="constant" type="int" default="7">
-		</theme_item>
-		<theme_item name="completion_max_width" data_type="constant" type="int" default="50">
-		</theme_item>
 		<theme_item name="completion_scroll_color" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
-		</theme_item>
-		<theme_item name="completion_scroll_width" data_type="constant" type="int" default="3">
 		</theme_item>
 		<theme_item name="completion_selected_color" data_type="color" type="Color" default="Color( 0.26, 0.26, 0.27, 1 )">
 		</theme_item>
@@ -657,15 +649,6 @@
 			Sets the [Color] of the breakpoints. [member breakpoint_gutter] has to be enabled.
 		</theme_item>
 		<theme_item name="executing_line_color" data_type="color" type="Color" default="Color( 0.2, 0.8, 0.2, 0.4 )">
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-		</theme_item>
-		<theme_item name="fold" data_type="icon" type="Texture">
-		</theme_item>
-		<theme_item name="folded" data_type="icon" type="Texture">
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			Sets the default [Font].
 		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Sets the font [Color].
@@ -680,36 +663,53 @@
 		<theme_item name="line_number_color" data_type="color" type="Color" default="Color( 0.67, 0.67, 0.67, 0.4 )">
 			Sets the [Color] of the line numbers. [member show_line_numbers] has to be enabled.
 		</theme_item>
-		<theme_item name="line_spacing" data_type="constant" type="int" default="4">
-			Sets the spacing between the lines.
-		</theme_item>
 		<theme_item name="mark_color" data_type="color" type="Color" default="Color( 1, 0.4, 0.4, 0.4 )">
 			Sets the [Color] of marked text.
 		</theme_item>
 		<theme_item name="member_variable_color" data_type="color" type="Color" default="Color( 0.9, 0.31, 0.35, 1 )">
 		</theme_item>
-		<theme_item name="normal" data_type="style" type="StyleBox">
-			Sets the [StyleBox] of this [TextEdit].
-		</theme_item>
 		<theme_item name="number_color" data_type="color" type="Color" default="Color( 0.92, 0.58, 0.2, 1 )">
-		</theme_item>
-		<theme_item name="read_only" data_type="style" type="StyleBox">
-			Sets the [StyleBox] of this [TextEdit] when [member readonly] is enabled.
 		</theme_item>
 		<theme_item name="safe_line_number_color" data_type="color" type="Color" default="Color( 0.67, 0.78, 0.67, 0.6 )">
 		</theme_item>
 		<theme_item name="selection_color" data_type="color" type="Color" default="Color( 0.49, 0.49, 0.49, 1 )">
 			Sets the highlight [Color] of text selections.
 		</theme_item>
-		<theme_item name="space" data_type="icon" type="Texture">
-		</theme_item>
 		<theme_item name="symbol_color" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
+		</theme_item>
+		<theme_item name="word_highlighted_color" data_type="color" type="Color" default="Color( 0.8, 0.9, 0.9, 0.15 )">
+			Sets the highlight [Color] of multiple occurrences. [member highlight_all_occurrences] has to be enabled.
+		</theme_item>
+		<theme_item name="completion_lines" data_type="constant" type="int" default="7">
+		</theme_item>
+		<theme_item name="completion_max_width" data_type="constant" type="int" default="50">
+		</theme_item>
+		<theme_item name="completion_scroll_width" data_type="constant" type="int" default="3">
+		</theme_item>
+		<theme_item name="line_spacing" data_type="constant" type="int" default="4">
+			Sets the spacing between the lines.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			Sets the default [Font].
+		</theme_item>
+		<theme_item name="fold" data_type="icon" type="Texture">
+		</theme_item>
+		<theme_item name="folded" data_type="icon" type="Texture">
+		</theme_item>
+		<theme_item name="space" data_type="icon" type="Texture">
 		</theme_item>
 		<theme_item name="tab" data_type="icon" type="Texture">
 			Sets a custom [Texture] for tab text characters.
 		</theme_item>
-		<theme_item name="word_highlighted_color" data_type="color" type="Color" default="Color( 0.8, 0.9, 0.9, 0.15 )">
-			Sets the highlight [Color] of multiple occurrences. [member highlight_all_occurrences] has to be enabled.
+		<theme_item name="completion" data_type="style" type="StyleBox">
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+		</theme_item>
+		<theme_item name="normal" data_type="style" type="StyleBox">
+			Sets the [StyleBox] of this [TextEdit].
+		</theme_item>
+		<theme_item name="read_only" data_type="style" type="StyleBox">
+			Sets the [StyleBox] of this [TextEdit] when [member readonly] is enabled.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/ToolButton.xml
+++ b/doc/classes/ToolButton.xml
@@ -20,15 +20,6 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="disabled" data_type="style" type="StyleBox">
-			[StyleBox] used when the [ToolButton] is disabled.
-		</theme_item>
-		<theme_item name="focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [ToolButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the [ToolButton]'s text.
-		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
 			Default text [Color] of the [ToolButton].
 		</theme_item>
@@ -44,11 +35,20 @@
 		<theme_item name="font_color_pressed" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
 			Text [Color] used when the [ToolButton] is being pressed.
 		</theme_item>
-		<theme_item name="hover" data_type="style" type="StyleBox">
-			[StyleBox] used when the [ToolButton] is being hovered.
-		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="3">
 			The horizontal space between [ToolButton]'s icon and text.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the [ToolButton]'s text.
+		</theme_item>
+		<theme_item name="disabled" data_type="style" type="StyleBox">
+			[StyleBox] used when the [ToolButton] is disabled.
+		</theme_item>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [ToolButton] is focused. It is displayed over the current [StyleBox], so using [StyleBoxEmpty] will just disable the focus visual effect.
+		</theme_item>
+		<theme_item name="hover" data_type="style" type="StyleBox">
+			[StyleBox] used when the [ToolButton] is being hovered.
 		</theme_item>
 		<theme_item name="normal" data_type="style" type="StyleBox">
 			Default [StyleBox] for the [ToolButton].

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -355,56 +355,11 @@
 		</constant>
 	</constants>
 	<theme_items>
-		<theme_item name="arrow" data_type="icon" type="Texture">
-			The arrow icon used when a foldable item is not collapsed.
-		</theme_item>
-		<theme_item name="arrow_collapsed" data_type="icon" type="Texture">
-			The arrow icon used when a foldable item is collapsed.
-		</theme_item>
-		<theme_item name="bg" data_type="style" type="StyleBox">
-			Default [StyleBox] for the [Tree], i.e. used when the control is not being focused.
-		</theme_item>
-		<theme_item name="bg_focus" data_type="style" type="StyleBox">
-			[StyleBox] used when the [Tree] is being focused.
-		</theme_item>
-		<theme_item name="button_margin" data_type="constant" type="int" default="4">
-			The horizontal space between each button in a cell.
-		</theme_item>
-		<theme_item name="button_pressed" data_type="style" type="StyleBox">
-			[StyleBox] used when a button in the tree is pressed.
-		</theme_item>
-		<theme_item name="checked" data_type="icon" type="Texture">
-			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is checked.
-		</theme_item>
-		<theme_item name="cursor" data_type="style" type="StyleBox">
-			[StyleBox] used for the cursor, when the [Tree] is being focused.
-		</theme_item>
-		<theme_item name="cursor_unfocused" data_type="style" type="StyleBox">
-			[StyleBox] used for the cursor, when the [Tree] is not being focused.
-		</theme_item>
-		<theme_item name="custom_button" data_type="style" type="StyleBox">
-			Default [StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell.
-		</theme_item>
 		<theme_item name="custom_button_font_highlight" data_type="color" type="Color" default="Color( 0.94, 0.94, 0.94, 1 )">
 			Text [Color] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's hovered.
 		</theme_item>
-		<theme_item name="custom_button_hover" data_type="style" type="StyleBox">
-			[StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's hovered.
-		</theme_item>
-		<theme_item name="custom_button_pressed" data_type="style" type="StyleBox">
-			[StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's pressed.
-		</theme_item>
-		<theme_item name="draw_guides" data_type="constant" type="int" default="1">
-			Draws the guidelines if not zero, this acts as a boolean. The guideline is a horizontal line drawn at the bottom of each item.
-		</theme_item>
-		<theme_item name="draw_relationship_lines" data_type="constant" type="int" default="0">
-			Draws the relationship lines if not zero, this acts as a boolean. Relationship lines are drawn at the start of child items to show hierarchy.
-		</theme_item>
 		<theme_item name="drop_position_color" data_type="color" type="Color" default="Color( 1, 0.3, 0.2, 1 )">
 			[Color] used to draw possible drop locations. See [enum DropModeFlags] constants for further description of drop locations.
-		</theme_item>
-		<theme_item name="font" data_type="font" type="Font">
-			[Font] of the item's text.
 		</theme_item>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color( 0.69, 0.69, 0.69, 1 )">
 			Default text [Color] of the item.
@@ -415,14 +370,26 @@
 		<theme_item name="guide_color" data_type="color" type="Color" default="Color( 0, 0, 0, 0.1 )">
 			[Color] of the guideline.
 		</theme_item>
+		<theme_item name="relationship_line_color" data_type="color" type="Color" default="Color( 0.27, 0.27, 0.27, 1 )">
+			[Color] of the relationship lines.
+		</theme_item>
+		<theme_item name="title_button_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
+			Default text [Color] of the title button.
+		</theme_item>
+		<theme_item name="button_margin" data_type="constant" type="int" default="4">
+			The horizontal space between each button in a cell.
+		</theme_item>
+		<theme_item name="draw_guides" data_type="constant" type="int" default="1">
+			Draws the guidelines if not zero, this acts as a boolean. The guideline is a horizontal line drawn at the bottom of each item.
+		</theme_item>
+		<theme_item name="draw_relationship_lines" data_type="constant" type="int" default="0">
+			Draws the relationship lines if not zero, this acts as a boolean. Relationship lines are drawn at the start of child items to show hierarchy.
+		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal space between item cells. This is also used as the margin at the start of an item when folding is disabled.
 		</theme_item>
 		<theme_item name="item_margin" data_type="constant" type="int" default="12">
 			The horizontal margin at the start of an item. This is used when folding is enabled for the item.
-		</theme_item>
-		<theme_item name="relationship_line_color" data_type="color" type="Color" default="Color( 0.27, 0.27, 0.27, 1 )">
-			[Color] of the relationship lines.
 		</theme_item>
 		<theme_item name="scroll_border" data_type="constant" type="int" default="4">
 			The maximum distance between the mouse cursor and the control's border to trigger border scrolling when dragging.
@@ -430,20 +397,62 @@
 		<theme_item name="scroll_speed" data_type="constant" type="int" default="12">
 			The speed of border scrolling.
 		</theme_item>
+		<theme_item name="vseparation" data_type="constant" type="int" default="4">
+			The vertical padding inside each item, i.e. the distance between the item's content and top/bottom border.
+		</theme_item>
+		<theme_item name="font" data_type="font" type="Font">
+			[Font] of the item's text.
+		</theme_item>
+		<theme_item name="title_button_font" data_type="font" type="Font">
+			[Font] of the title button's text.
+		</theme_item>
+		<theme_item name="arrow" data_type="icon" type="Texture">
+			The arrow icon used when a foldable item is not collapsed.
+		</theme_item>
+		<theme_item name="arrow_collapsed" data_type="icon" type="Texture">
+			The arrow icon used when a foldable item is collapsed.
+		</theme_item>
+		<theme_item name="checked" data_type="icon" type="Texture">
+			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is checked.
+		</theme_item>
 		<theme_item name="select_arrow" data_type="icon" type="Texture">
 			The arrow icon to display for the [constant TreeItem.CELL_MODE_RANGE] mode cell.
+		</theme_item>
+		<theme_item name="unchecked" data_type="icon" type="Texture">
+			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is unchecked.
+		</theme_item>
+		<theme_item name="updown" data_type="icon" type="Texture">
+			The updown arrow icon to display for the [constant TreeItem.CELL_MODE_RANGE] mode cell.
+		</theme_item>
+		<theme_item name="bg" data_type="style" type="StyleBox">
+			Default [StyleBox] for the [Tree], i.e. used when the control is not being focused.
+		</theme_item>
+		<theme_item name="bg_focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [Tree] is being focused.
+		</theme_item>
+		<theme_item name="button_pressed" data_type="style" type="StyleBox">
+			[StyleBox] used when a button in the tree is pressed.
+		</theme_item>
+		<theme_item name="cursor" data_type="style" type="StyleBox">
+			[StyleBox] used for the cursor, when the [Tree] is being focused.
+		</theme_item>
+		<theme_item name="cursor_unfocused" data_type="style" type="StyleBox">
+			[StyleBox] used for the cursor, when the [Tree] is not being focused.
+		</theme_item>
+		<theme_item name="custom_button" data_type="style" type="StyleBox">
+			Default [StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell.
+		</theme_item>
+		<theme_item name="custom_button_hover" data_type="style" type="StyleBox">
+			[StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's hovered.
+		</theme_item>
+		<theme_item name="custom_button_pressed" data_type="style" type="StyleBox">
+			[StyleBox] for a [constant TreeItem.CELL_MODE_CUSTOM] mode cell when it's pressed.
 		</theme_item>
 		<theme_item name="selected" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [Tree] is not being focused.
 		</theme_item>
 		<theme_item name="selected_focus" data_type="style" type="StyleBox">
 			[StyleBox] for the selected items, used when the [Tree] is being focused.
-		</theme_item>
-		<theme_item name="title_button_color" data_type="color" type="Color" default="Color( 0.88, 0.88, 0.88, 1 )">
-			Default text [Color] of the title button.
-		</theme_item>
-		<theme_item name="title_button_font" data_type="font" type="Font">
-			[Font] of the title button's text.
 		</theme_item>
 		<theme_item name="title_button_hover" data_type="style" type="StyleBox">
 			[StyleBox] used when the title button is being hovered.
@@ -453,15 +462,6 @@
 		</theme_item>
 		<theme_item name="title_button_pressed" data_type="style" type="StyleBox">
 			[StyleBox] used when the title button is being pressed.
-		</theme_item>
-		<theme_item name="unchecked" data_type="icon" type="Texture">
-			The check icon to display when the [constant TreeItem.CELL_MODE_CHECK] mode cell is unchecked.
-		</theme_item>
-		<theme_item name="updown" data_type="icon" type="Texture">
-			The updown arrow icon to display for the [constant TreeItem.CELL_MODE_RANGE] mode cell.
-		</theme_item>
-		<theme_item name="vseparation" data_type="constant" type="int" default="4">
-			The vertical padding inside each item, i.e. the distance between the item's content and top/bottom border.
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/VScrollBar.xml
+++ b/doc/classes/VScrollBar.xml
@@ -26,15 +26,6 @@
 		<theme_item name="decrement_pressed" data_type="icon" type="Texture">
 			Displayed when the decrement button is being pressed.
 		</theme_item>
-		<theme_item name="grabber" data_type="style" type="StyleBox">
-			Used as texture for the grabber, the draggable element representing current scroll.
-		</theme_item>
-		<theme_item name="grabber_highlight" data_type="style" type="StyleBox">
-			Used when the mouse hovers over the grabber.
-		</theme_item>
-		<theme_item name="grabber_pressed" data_type="style" type="StyleBox">
-			Used when the grabber is being dragged.
-		</theme_item>
 		<theme_item name="increment" data_type="icon" type="Texture">
 			Icon used as a button to scroll the [ScrollBar] down. Supports custom step using the [member ScrollBar.custom_step] property.
 		</theme_item>
@@ -43,6 +34,15 @@
 		</theme_item>
 		<theme_item name="increment_pressed" data_type="icon" type="Texture">
 			Displayed when the increment button is being pressed.
+		</theme_item>
+		<theme_item name="grabber" data_type="style" type="StyleBox">
+			Used as texture for the grabber, the draggable element representing current scroll.
+		</theme_item>
+		<theme_item name="grabber_highlight" data_type="style" type="StyleBox">
+			Used when the mouse hovers over the grabber.
+		</theme_item>
+		<theme_item name="grabber_pressed" data_type="style" type="StyleBox">
+			Used when the grabber is being dragged.
 		</theme_item>
 		<theme_item name="scroll" data_type="style" type="StyleBox">
 			Used as background of this [ScrollBar].

--- a/doc/classes/VSlider.xml
+++ b/doc/classes/VSlider.xml
@@ -21,22 +21,22 @@
 		<theme_item name="grabber" data_type="icon" type="Texture">
 			The texture for the grabber (the draggable element).
 		</theme_item>
-		<theme_item name="grabber_area" data_type="style" type="StyleBox">
-			The background of the area below the grabber.
-		</theme_item>
-		<theme_item name="grabber_area_highlight" data_type="style" type="StyleBox">
-		</theme_item>
 		<theme_item name="grabber_disabled" data_type="icon" type="Texture">
 			The texture for the grabber when it's disabled.
 		</theme_item>
 		<theme_item name="grabber_highlight" data_type="icon" type="Texture">
 			The texture for the grabber when it's focused.
 		</theme_item>
-		<theme_item name="slider" data_type="style" type="StyleBox">
-			The background for the whole slider. Determines the width of the [code]grabber_area[/code].
-		</theme_item>
 		<theme_item name="tick" data_type="icon" type="Texture">
 			The texture for the ticks, visible when [member Slider.tick_count] is greater than 0.
+		</theme_item>
+		<theme_item name="grabber_area" data_type="style" type="StyleBox">
+			The background of the area below the grabber.
+		</theme_item>
+		<theme_item name="grabber_area_highlight" data_type="style" type="StyleBox">
+		</theme_item>
+		<theme_item name="slider" data_type="style" type="StyleBox">
+			The background for the whole slider. Determines the width of the [code]grabber_area[/code].
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/VSplitContainer.xml
+++ b/doc/classes/VSplitContainer.xml
@@ -16,13 +16,13 @@
 		<theme_item name="autohide" data_type="constant" type="int" default="1">
 			Boolean value. If 1 ([code]true[/code]), the grabber will hide automatically when it isn't under the cursor. If 0 ([code]false[/code]), it's always visible.
 		</theme_item>
-		<theme_item name="bg" data_type="style" type="StyleBox">
+		<theme_item name="separation" data_type="constant" type="int" default="12">
+			The space between sides of the container.
 		</theme_item>
 		<theme_item name="grabber" data_type="icon" type="Texture">
 			The icon used for the grabber drawn in the middle area.
 		</theme_item>
-		<theme_item name="separation" data_type="constant" type="int" default="12">
-			The space between sides of the container.
+		<theme_item name="bg" data_type="style" type="StyleBox">
 		</theme_item>
 	</theme_items>
 </class>

--- a/doc/classes/WindowDialog.xml
+++ b/doc/classes/WindowDialog.xml
@@ -28,32 +28,32 @@
 	<constants>
 	</constants>
 	<theme_items>
-		<theme_item name="close" data_type="icon" type="Texture">
-			The icon for the close button.
+		<theme_item name="title_color" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
+			The color of the title text.
 		</theme_item>
 		<theme_item name="close_h_ofs" data_type="constant" type="int" default="18">
 			The horizontal offset of the close button.
 		</theme_item>
-		<theme_item name="close_highlight" data_type="icon" type="Texture">
-			The icon used for the close button when it's hovered with the mouse cursor.
-		</theme_item>
 		<theme_item name="close_v_ofs" data_type="constant" type="int" default="18">
 			The vertical offset of the close button.
-		</theme_item>
-		<theme_item name="panel" data_type="style" type="StyleBox">
-			The style for both the content background of the [WindowDialog] and the title bar. The title bar is created with a top border and an expand margin using the [code]panel[/code] stylebox.
 		</theme_item>
 		<theme_item name="scaleborder_size" data_type="constant" type="int" default="4">
 			The thickness of the border that can be dragged when scaling the window (if [member resizable] is enabled).
 		</theme_item>
-		<theme_item name="title_color" data_type="color" type="Color" default="Color( 0, 0, 0, 1 )">
-			The color of the title text.
+		<theme_item name="title_height" data_type="constant" type="int" default="20">
+			The vertical offset of the title text.
 		</theme_item>
 		<theme_item name="title_font" data_type="font" type="Font">
 			The font used to draw the title.
 		</theme_item>
-		<theme_item name="title_height" data_type="constant" type="int" default="20">
-			The vertical offset of the title text.
+		<theme_item name="close" data_type="icon" type="Texture">
+			The icon for the close button.
+		</theme_item>
+		<theme_item name="close_highlight" data_type="icon" type="Texture">
+			The icon used for the close button when it's hovered with the mouse cursor.
+		</theme_item>
+		<theme_item name="panel" data_type="style" type="StyleBox">
+			The style for both the content background of the [WindowDialog] and the title bar. The title bar is created with a top border and an expand margin using the [code]panel[/code] stylebox.
 		</theme_item>
 	</theme_items>
 </class>

--- a/editor/doc/doc_data.cpp
+++ b/editor/doc/doc_data.cpp
@@ -511,6 +511,8 @@ void DocData::generate(bool p_basic_types) {
 				tid.data_type = "style";
 				c.theme_properties.push_back(tid);
 			}
+
+			c.theme_properties.sort();
 		}
 
 		classes.pop_front();

--- a/editor/doc/doc_data.h
+++ b/editor/doc/doc_data.h
@@ -87,7 +87,11 @@ public:
 		String description;
 		String default_value;
 		bool operator<(const ThemeItemDoc &p_theme_item) const {
-			return name < p_theme_item.name;
+			// First sort by the data type, then by name.
+			if (data_type == p_theme_item.data_type) {
+				return name < p_theme_item.name;
+			}
+			return data_type < p_theme_item.data_type;
 		}
 	};
 

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -234,8 +234,7 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 		class_desc->push_cell();
 		class_desc->push_align(RichTextLabel::ALIGN_RIGHT);
 	} else {
-		static const CharType prefix[3] = { 0x25CF /* filled circle */, ' ', 0 };
-		class_desc->add_text(String(prefix));
+		_add_bulletpoint();
 	}
 
 	_add_type(p_method.return_type, p_method.return_enum);
@@ -309,6 +308,11 @@ void EditorHelp::_add_method(const DocData::MethodDoc &p_method, bool p_overview
 	if (p_overview) {
 		class_desc->pop(); //cell
 	}
+}
+
+void EditorHelp::_add_bulletpoint() {
+	static const CharType prefix[3] = { 0x25CF /* filled circle */, ' ', 0 };
+	class_desc->add_text(String(prefix));
 }
 
 Error EditorHelp::_goto_desc(const String &p_class, int p_vscr) {
@@ -677,27 +681,53 @@ void EditorHelp::_update_doc() {
 		class_desc->pop();
 		class_desc->pop();
 
+		class_desc->add_newline();
+		class_desc->add_newline();
+
 		class_desc->push_indent(1);
-		class_desc->push_table(2);
-		class_desc->set_table_column_expand(1, true);
+
+		String theme_data_type;
+		Map<String, String> data_type_names;
+		data_type_names["color"] = TTR("Colors");
+		data_type_names["constant"] = TTR("Constants");
+		data_type_names["font"] = TTR("Fonts");
+		data_type_names["icon"] = TTR("Icons");
+		data_type_names["style"] = TTR("Styles");
 
 		for (int i = 0; i < cd.theme_properties.size(); i++) {
 			theme_property_line[cd.theme_properties[i].name] = class_desc->get_line_count() - 2; //gets overridden if description
 
-			class_desc->push_cell();
-			class_desc->push_align(RichTextLabel::ALIGN_RIGHT);
-			class_desc->push_font(doc_code_font);
-			_add_type(cd.theme_properties[i].type);
-			class_desc->pop();
-			class_desc->pop();
-			class_desc->pop();
+			if (theme_data_type != cd.theme_properties[i].data_type) {
+				theme_data_type = cd.theme_properties[i].data_type;
 
-			class_desc->push_cell();
+				class_desc->push_color(title_color);
+				class_desc->push_font(doc_bold_font);
+				if (data_type_names.has(theme_data_type)) {
+					class_desc->add_text(data_type_names[theme_data_type]);
+				} else {
+					class_desc->add_text("");
+				}
+				class_desc->pop();
+				class_desc->pop();
+
+				class_desc->add_newline();
+				class_desc->add_newline();
+			}
+
+			// Theme item header.
 			class_desc->push_font(doc_code_font);
+			_add_bulletpoint();
+
+			// Theme item object type.
+			_add_type(cd.theme_properties[i].type);
+
+			// Theme item name.
 			class_desc->push_color(headline_color);
+			class_desc->add_text(" ");
 			_add_text(cd.theme_properties[i].name);
 			class_desc->pop();
 
+			// Theme item default value.
 			if (cd.theme_properties[i].default_value != "") {
 				class_desc->push_color(symbol_color);
 				class_desc->add_text(" [" + TTR("default:") + " ");
@@ -710,22 +740,24 @@ void EditorHelp::_update_doc() {
 				class_desc->pop();
 			}
 
-			class_desc->pop();
+			class_desc->pop(); // monofont
 
+			// Theme item description.
 			if (cd.theme_properties[i].description != "") {
 				class_desc->push_font(doc_font);
-				class_desc->add_text("  ");
 				class_desc->push_color(comment_color);
+				class_desc->push_indent(1);
 				_add_text(DTR(cd.theme_properties[i].description));
-				class_desc->pop();
-				class_desc->pop();
+				class_desc->pop(); // indent
+				class_desc->pop(); // color
+				class_desc->pop(); // font
 			}
-			class_desc->pop(); // cell
+
+			class_desc->add_newline();
+			class_desc->add_newline();
 		}
 
-		class_desc->pop(); // table
 		class_desc->pop();
-		class_desc->add_newline();
 		class_desc->add_newline();
 	}
 
@@ -749,10 +781,10 @@ void EditorHelp::_update_doc() {
 
 		for (int i = 0; i < cd.signals.size(); i++) {
 			signal_line[cd.signals[i].name] = class_desc->get_line_count() - 2; //gets overridden if description
+
 			class_desc->push_font(doc_code_font); // monofont
 			class_desc->push_color(headline_color);
-			static const CharType prefix[3] = { 0x25CF /* filled circle */, ' ', 0 };
-			class_desc->add_text(String(prefix));
+			_add_bulletpoint();
 			_add_text(cd.signals[i].name);
 			class_desc->pop();
 			class_desc->push_color(symbol_color);
@@ -866,8 +898,7 @@ void EditorHelp::_update_doc() {
 
 					class_desc->push_font(doc_code_font);
 					class_desc->push_color(headline_color);
-					static const CharType prefix[3] = { 0x25CF /* filled circle */, ' ', 0 };
-					class_desc->add_text(String(prefix));
+					_add_bulletpoint();
 					_add_text(enum_list[i].name);
 					class_desc->pop();
 					class_desc->push_color(symbol_color);
@@ -877,11 +908,12 @@ void EditorHelp::_update_doc() {
 					_add_text(_fix_constant(enum_list[i].value));
 					class_desc->pop();
 					class_desc->pop();
-					if (enum_list[i].description != "") {
+
+					class_desc->add_newline();
+
+					if (enum_list[i].description.strip_edges() != "") {
 						class_desc->push_font(doc_font);
 						class_desc->push_color(comment_color);
-						static const CharType dash[6] = { ' ', ' ', 0x2013 /* en dash */, ' ', ' ', 0 };
-						class_desc->add_text(String(dash));
 						_add_text(DTR(enum_list[i].description));
 						class_desc->pop();
 						class_desc->pop();
@@ -927,13 +959,11 @@ void EditorHelp::_update_doc() {
 					Vector<float> color = stripped.split_floats(",");
 					if (color.size() >= 3) {
 						class_desc->push_color(Color(color[0], color[1], color[2]));
-						static const CharType prefix[3] = { 0x25CF /* filled circle */, ' ', 0 };
-						class_desc->add_text(String(prefix));
+						_add_bulletpoint();
 						class_desc->pop();
 					}
 				} else {
-					static const CharType prefix[3] = { 0x25CF /* filled circle */, ' ', 0 };
-					class_desc->add_text(String(prefix));
+					_add_bulletpoint();
 				}
 
 				class_desc->push_color(headline_color);
@@ -947,11 +977,12 @@ void EditorHelp::_update_doc() {
 				class_desc->pop();
 
 				class_desc->pop();
+
+				class_desc->add_newline();
+
 				if (constants[i].description != "") {
 					class_desc->push_font(doc_font);
 					class_desc->push_color(comment_color);
-					static const CharType dash[6] = { ' ', ' ', 0x2013 /* en dash */, ' ', ' ', 0 };
-					class_desc->add_text(String(dash));
 					_add_text(DTR(constants[i].description));
 					class_desc->pop();
 					class_desc->pop();
@@ -992,8 +1023,7 @@ void EditorHelp::_update_doc() {
 
 			class_desc->push_cell();
 			class_desc->push_font(doc_code_font);
-			static const CharType prefix[3] = { 0x25CF /* filled circle */, ' ', 0 };
-			class_desc->add_text(String(prefix));
+			_add_bulletpoint();
 
 			_add_type(cd.properties[i].type, cd.properties[i].enumeration);
 			class_desc->add_text(" ");

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -144,6 +144,8 @@ class EditorHelp : public VBoxContainer {
 	void _add_type(const String &p_type, const String &p_enum = String());
 	void _add_method(const DocData::MethodDoc &p_method, bool p_overview = true);
 
+	void _add_bulletpoint();
+
 	void _class_list_select(const String &p_select);
 	void _class_desc_select(const String &p_select);
 	void _class_desc_input(const Ref<InputEvent> &p_input);


### PR DESCRIPTION
A backport of https://github.com/godotengine/godot/pull/55520, adjusted for `3.x`.

It's mostly the same, differences are mostly because of a different theme and different text rendering logic in some places.

![godot windows tools 64_2021-12-01_22-43-24](https://user-images.githubusercontent.com/11782833/144303450-73c6f22a-e18e-4c11-ae8c-ce68400d3c46.png)
![godot windows tools 64_2021-12-01_22-43-37](https://user-images.githubusercontent.com/11782833/144303456-f4f78be5-8685-4198-8465-f7c64d97d930.png)
