### PR TITLE
Rename Vector parameters to be consistent

### DIFF
--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -108,10 +108,10 @@ Vector3 Vector3::move_toward(const Vector3 &p_to, const real_t p_delta) const {
 	return len <= p_delta || len < CMP_EPSILON ? p_to : v + vd / len * p_delta;
 }
 
-Basis Vector3::outer(const Vector3 &p_b) const {
-	Vector3 row0(x * p_b.x, x * p_b.y, x * p_b.z);
-	Vector3 row1(y * p_b.x, y * p_b.y, y * p_b.z);
-	Vector3 row2(z * p_b.x, z * p_b.y, z * p_b.z);
+Basis Vector3::outer(const Vector3 &p_with) const {
+	Vector3 row0(x * p_with.x, x * p_with.y, x * p_with.z);
+	Vector3 row1(y * p_with.x, y * p_with.y, y * p_with.z);
+	Vector3 row2(z * p_with.x, z * p_with.y, z * p_with.z);
 
 	return Basis(row0, row1, row2);
 }

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -128,9 +128,9 @@ struct Vector3 {
 		return n.normalized();
 	}
 
-	_FORCE_INLINE_ Vector3 cross(const Vector3 &p_b) const;
-	_FORCE_INLINE_ real_t dot(const Vector3 &p_b) const;
-	Basis outer(const Vector3 &p_b) const;
+	_FORCE_INLINE_ Vector3 cross(const Vector3 &p_with) const;
+	_FORCE_INLINE_ real_t dot(const Vector3 &p_with) const;
+	Basis outer(const Vector3 &p_with) const;
 
 	_FORCE_INLINE_ Vector3 abs() const;
 	_FORCE_INLINE_ Vector3 floor() const;
@@ -199,17 +199,17 @@ struct Vector3 {
 	}
 };
 
-Vector3 Vector3::cross(const Vector3 &p_b) const {
+Vector3 Vector3::cross(const Vector3 &p_with) const {
 	Vector3 ret(
-			(y * p_b.z) - (z * p_b.y),
-			(z * p_b.x) - (x * p_b.z),
-			(x * p_b.y) - (y * p_b.x));
+			(y * p_with.z) - (z * p_with.y),
+			(z * p_with.x) - (x * p_with.z),
+			(x * p_with.y) - (y * p_with.x));
 
 	return ret;
 }
 
-real_t Vector3::dot(const Vector3 &p_b) const {
-	return x * p_b.x + y * p_b.y + z * p_b.z;
+real_t Vector3::dot(const Vector3 &p_with) const {
+	return x * p_with.x + y * p_with.y + z * p_with.z;
 }
 
 Vector3 Vector3::abs() const {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1471,7 +1471,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector2, angle, sarray(), varray());
 	bind_method(Vector2, angle_to, sarray("to"), varray());
 	bind_method(Vector2, angle_to_point, sarray("to"), varray());
-	bind_method(Vector2, direction_to, sarray("b"), varray());
+	bind_method(Vector2, direction_to, sarray("to"), varray());
 	bind_method(Vector2, distance_to, sarray("to"), varray());
 	bind_method(Vector2, distance_squared_to, sarray("to"), varray());
 	bind_method(Vector2, length, sarray(), varray());
@@ -1551,9 +1551,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(Vector3, max_axis, sarray(), varray());
 	bind_method(Vector3, angle_to, sarray("to"), varray());
 	bind_method(Vector3, signed_angle_to, sarray("to", "axis"), varray());
-	bind_method(Vector3, direction_to, sarray("b"), varray());
-	bind_method(Vector3, distance_to, sarray("b"), varray());
-	bind_method(Vector3, distance_squared_to, sarray("b"), varray());
+	bind_method(Vector3, direction_to, sarray("to"), varray());
+	bind_method(Vector3, distance_to, sarray("to"), varray());
+	bind_method(Vector3, distance_squared_to, sarray("to"), varray());
 	bind_method(Vector3, length, sarray(), varray());
 	bind_method(Vector3, length_squared, sarray(), varray());
 	bind_method(Vector3, limit_length, sarray("length"), varray(1.0));

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -125,16 +125,16 @@
 		</method>
 		<method name="direction_to" qualifiers="const">
 			<return type="Vector2" />
-			<argument index="0" name="b" type="Vector2" />
+			<argument index="0" name="to" type="Vector2" />
 			<description>
-				Returns the normalized vector pointing from this vector to [code]b[/code]. This is equivalent to using [code](b - a).normalized()[/code].
+				Returns the normalized vector pointing from this vector to [code]to[/code]. This is equivalent to using [code](b - a).normalized()[/code].
 			</description>
 		</method>
 		<method name="distance_squared_to" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="to" type="Vector2" />
 			<description>
-				Returns the squared distance between this vector and [code]b[/code].
+				Returns the squared distance between this vector and [code]to[/code].
 				This method runs faster than [method distance_to], so prefer it if you need to compare vectors or need the squared distance for some formula.
 			</description>
 		</method>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -86,7 +86,7 @@
 			<return type="Vector3" />
 			<argument index="0" name="with" type="Vector3" />
 			<description>
-				Returns the cross product of this vector and [code]b[/code].
+				Returns the cross product of this vector and [code]with[/code].
 			</description>
 		</method>
 		<method name="cubic_interpolate" qualifiers="const">
@@ -101,31 +101,31 @@
 		</method>
 		<method name="direction_to" qualifiers="const">
 			<return type="Vector3" />
-			<argument index="0" name="b" type="Vector3" />
+			<argument index="0" name="to" type="Vector3" />
 			<description>
-				Returns the normalized vector pointing from this vector to [code]b[/code]. This is equivalent to using [code](b - a).normalized()[/code].
+				Returns the normalized vector pointing from this vector to [code]to[/code]. This is equivalent to using [code](b - a).normalized()[/code].
 			</description>
 		</method>
 		<method name="distance_squared_to" qualifiers="const">
 			<return type="float" />
-			<argument index="0" name="b" type="Vector3" />
+			<argument index="0" name="to" type="Vector3" />
 			<description>
-				Returns the squared distance between this vector and [code]b[/code].
+				Returns the squared distance between this vector and [code]to[/code].
 				This method runs faster than [method distance_to], so prefer it if you need to compare vectors or need the squared distance for some formula.
 			</description>
 		</method>
 		<method name="distance_to" qualifiers="const">
 			<return type="float" />
-			<argument index="0" name="b" type="Vector3" />
+			<argument index="0" name="to" type="Vector3" />
 			<description>
-				Returns the distance between this vector and [code]b[/code].
+				Returns the distance between this vector and [code]to[/code].
 			</description>
 		</method>
 		<method name="dot" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="with" type="Vector3" />
 			<description>
-				Returns the dot product of this vector and [code]b[/code]. This can be used to compare the angle between two vectors. For example, this can be used to determine whether an enemy is facing the player.
+				Returns the dot product of this vector and [code]with[/code]. This can be used to compare the angle between two vectors. For example, this can be used to determine whether an enemy is facing the player.
 				The dot product will be [code]0[/code] for a straight angle (90 degrees), greater than 0 for angles narrower than 90 degrees and lower than 0 for angles wider than 90 degrees.
 				When using unit (normalized) vectors, the result will always be between [code]-1.0[/code] (180 degree angle) when the vectors are facing opposite directions, and [code]1.0[/code] (0 degree angle) when the vectors are aligned.
 				[b]Note:[/b] [code]a.dot(b)[/code] is equivalent to [code]b.dot(a)[/code].
@@ -225,7 +225,7 @@
 			<return type="Basis" />
 			<argument index="0" name="with" type="Vector3" />
 			<description>
-				Returns the outer product with [code]b[/code].
+				Returns the outer product with [code]with[/code].
 			</description>
 		</method>
 		<method name="posmod" qualifiers="const">

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2.cs
@@ -184,13 +184,13 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the cross product of this vector and <paramref name="b"/>.
+        /// Returns the cross product of this vector and <paramref name="with"/>.
         /// </summary>
-        /// <param name="b">The other vector.</param>
+        /// <param name="with">The other vector.</param>
         /// <returns>The cross product value.</returns>
-        public real_t Cross(Vector2 b)
+        public real_t Cross(Vector2 with)
         {
-            return (x * b.y) - (y * b.x);
+            return (x * with.y) - (y * with.x);
         }
 
         /// <summary>
@@ -222,13 +222,13 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the normalized vector pointing from this vector to <paramref name="b"/>.
+        /// Returns the normalized vector pointing from this vector to <paramref name="to"/>.
         /// </summary>
-        /// <param name="b">The other vector to point towards.</param>
-        /// <returns>The direction from this vector to <paramref name="b"/>.</returns>
-        public Vector2 DirectionTo(Vector2 b)
+        /// <param name="to">The other vector to point towards.</param>
+        /// <returns>The direction from this vector to <paramref name="to"/>.</returns>
+        public Vector2 DirectionTo(Vector2 to)
         {
-            return new Vector2(b.x - x, b.y - y).Normalized();
+            return new Vector2(to.x - x, to.y - y).Normalized();
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector2i.cs
@@ -149,45 +149,45 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the cross product of this vector and <paramref name="b"/>.
+        /// Returns the cross product of this vector and <paramref name="with"/>.
         /// </summary>
-        /// <param name="b">The other vector.</param>
+        /// <param name="with">The other vector.</param>
         /// <returns>The cross product vector.</returns>
-        public int Cross(Vector2i b)
+        public int Cross(Vector2i with)
         {
-            return x * b.y - y * b.x;
+            return x * with.y - y * with.x;
         }
 
         /// <summary>
-        /// Returns the squared distance between this vector and <paramref name="b"/>.
+        /// Returns the squared distance between this vector and <paramref name="to"/>.
         /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
         /// you need to compare vectors or need the squared distance for some formula.
         /// </summary>
-        /// <param name="b">The other vector to use.</param>
+        /// <param name="to">The other vector to use.</param>
         /// <returns>The squared distance between the two vectors.</returns>
-        public int DistanceSquaredTo(Vector2i b)
+        public int DistanceSquaredTo(Vector2i to)
         {
-            return (b - this).LengthSquared();
+            return (to - this).LengthSquared();
         }
 
         /// <summary>
-        /// Returns the distance between this vector and <paramref name="b"/>.
+        /// Returns the distance between this vector and <paramref name="to"/>.
         /// </summary>
-        /// <param name="b">The other vector to use.</param>
+        /// <param name="to">The other vector to use.</param>
         /// <returns>The distance between the two vectors.</returns>
-        public real_t DistanceTo(Vector2i b)
+        public real_t DistanceTo(Vector2i to)
         {
-            return (b - this).Length();
+            return (to - this).Length();
         }
 
         /// <summary>
-        /// Returns the dot product of this vector and <paramref name="b"/>.
+        /// Returns the dot product of this vector and <paramref name="with"/>.
         /// </summary>
-        /// <param name="b">The other vector to use.</param>
+        /// <param name="with">The other vector to use.</param>
         /// <returns>The dot product of the two vectors.</returns>
-        public int Dot(Vector2i b)
+        public int Dot(Vector2i with)
         {
-            return x * b.x + y * b.y;
+            return x * with.x + y * with.y;
         }
 
         /// <summary>

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3.cs
@@ -170,17 +170,17 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the cross product of this vector and <paramref name="b"/>.
+        /// Returns the cross product of this vector and <paramref name="with"/>.
         /// </summary>
-        /// <param name="b">The other vector.</param>
+        /// <param name="with">The other vector.</param>
         /// <returns>The cross product vector.</returns>
-        public Vector3 Cross(Vector3 b)
+        public Vector3 Cross(Vector3 with)
         {
             return new Vector3
             (
-                (y * b.z) - (z * b.y),
-                (z * b.x) - (x * b.z),
-                (x * b.y) - (y * b.x)
+                (y * with.z) - (z * with.y),
+                (z * with.x) - (x * with.z),
+                (x * with.y) - (y * with.x)
             );
         }
 
@@ -212,46 +212,46 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the normalized vector pointing from this vector to <paramref name="b"/>.
+        /// Returns the normalized vector pointing from this vector to <paramref name="to"/>.
         /// </summary>
-        /// <param name="b">The other vector to point towards.</param>
-        /// <returns>The direction from this vector to <paramref name="b"/>.</returns>
-        public Vector3 DirectionTo(Vector3 b)
+        /// <param name="to">The other vector to point towards.</param>
+        /// <returns>The direction from this vector to <paramref name="to"/>.</returns>
+        public Vector3 DirectionTo(Vector3 to)
         {
-            return new Vector3(b.x - x, b.y - y, b.z - z).Normalized();
+            return new Vector3(to.x - x, to.y - y, to.z - z).Normalized();
         }
 
         /// <summary>
-        /// Returns the squared distance between this vector and <paramref name="b"/>.
+        /// Returns the squared distance between this vector and <paramref name="to"/>.
         /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
         /// you need to compare vectors or need the squared distance for some formula.
         /// </summary>
-        /// <param name="b">The other vector to use.</param>
+        /// <param name="to">The other vector to use.</param>
         /// <returns>The squared distance between the two vectors.</returns>
-        public real_t DistanceSquaredTo(Vector3 b)
+        public real_t DistanceSquaredTo(Vector3 to)
         {
-            return (b - this).LengthSquared();
+            return (to - this).LengthSquared();
         }
 
         /// <summary>
-        /// Returns the distance between this vector and <paramref name="b"/>.
+        /// Returns the distance between this vector and <paramref name="to"/>.
         /// </summary>
         /// <seealso cref="DistanceSquaredTo(Vector3)"/>
-        /// <param name="b">The other vector to use.</param>
+        /// <param name="to">The other vector to use.</param>
         /// <returns>The distance between the two vectors.</returns>
-        public real_t DistanceTo(Vector3 b)
+        public real_t DistanceTo(Vector3 to)
         {
-            return (b - this).Length();
+            return (to - this).Length();
         }
 
         /// <summary>
-        /// Returns the dot product of this vector and <paramref name="b"/>.
+        /// Returns the dot product of this vector and <paramref name="with"/>.
         /// </summary>
-        /// <param name="b">The other vector to use.</param>
+        /// <param name="with">The other vector to use.</param>
         /// <returns>The dot product of the two vectors.</returns>
-        public real_t Dot(Vector3 b)
+        public real_t Dot(Vector3 with)
         {
-            return (x * b.x) + (y * b.y) + (z * b.z);
+            return (x * with.x) + (y * with.y) + (z * with.z);
         }
 
         /// <summary>
@@ -412,16 +412,16 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the outer product with <paramref name="b"/>.
+        /// Returns the outer product with <paramref name="with"/>.
         /// </summary>
-        /// <param name="b">The other vector.</param>
+        /// <param name="with">The other vector.</param>
         /// <returns>A <see cref="Basis"/> representing the outer product matrix.</returns>
-        public Basis Outer(Vector3 b)
+        public Basis Outer(Vector3 with)
         {
             return new Basis(
-                x * b.x, x * b.y, x * b.z,
-                y * b.x, y * b.y, y * b.z,
-                z * b.x, z * b.y, z * b.z
+                x * with.x, x * with.y, x * with.z,
+                y * with.x, y * with.y, y * with.z,
+                z * with.x, z * with.y, z * with.z
             );
         }
 

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Vector3i.cs
@@ -124,36 +124,36 @@ namespace Godot
         }
 
         /// <summary>
-        /// Returns the squared distance between this vector and <paramref name="b"/>.
+        /// Returns the squared distance between this vector and <paramref name="to"/>.
         /// This method runs faster than <see cref="DistanceTo"/>, so prefer it if
         /// you need to compare vectors or need the squared distance for some formula.
         /// </summary>
-        /// <param name="b">The other vector to use.</param>
+        /// <param name="to">The other vector to use.</param>
         /// <returns>The squared distance between the two vectors.</returns>
-        public int DistanceSquaredTo(Vector3i b)
+        public int DistanceSquaredTo(Vector3i to)
         {
-            return (b - this).LengthSquared();
+            return (to - this).LengthSquared();
         }
 
         /// <summary>
-        /// Returns the distance between this vector and <paramref name="b"/>.
+        /// Returns the distance between this vector and <paramref name="to"/>.
         /// </summary>
         /// <seealso cref="DistanceSquaredTo(Vector3i)"/>
-        /// <param name="b">The other vector to use.</param>
+        /// <param name="to">The other vector to use.</param>
         /// <returns>The distance between the two vectors.</returns>
-        public real_t DistanceTo(Vector3i b)
+        public real_t DistanceTo(Vector3i to)
         {
-            return (b - this).Length();
+            return (to - this).Length();
         }
 
         /// <summary>
-        /// Returns the dot product of this vector and <paramref name="b"/>.
+        /// Returns the dot product of this vector and <paramref name="with"/>.
         /// </summary>
-        /// <param name="b">The other vector to use.</param>
+        /// <param name="with">The other vector to use.</param>
         /// <returns>The dot product of the two vectors.</returns>
-        public int Dot(Vector3i b)
+        public int Dot(Vector3i with)
         {
-            return x * b.x + y * b.y + z * b.z;
+            return x * with.x + y * with.y + z * with.z;
         }
 
         /// <summary>


### PR DESCRIPTION
I noticed while reviewing #53618 that sometimes the name of the parameter in some `Vector2`/`Vector3` methods was inconsistent with their documentation.

This PR renames parameters that were named differently across different scripting languages or their documentation to use the same name everywhere.