### PR TITLE
Only print message for `get_modified_time()` failure when in verbose mode

### DIFF
--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -307,7 +307,8 @@ uint64_t FileAccessUnix::_get_modified_time(const String &p_file) {
 	if (!err) {
 		return flags.st_mtime;
 	} else {
-		ERR_FAIL_V_MSG(0, "Failed to get modified time for: " + p_file + ".");
+		print_verbose("Failed to get modified time for: " + p_file + "");
+		return 0;
 	};
 }
 

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -335,7 +335,8 @@ uint64_t FileAccessWindows::_get_modified_time(const String &p_file) {
 	if (rv == 0) {
 		return st.st_mtime;
 	} else {
-		ERR_FAIL_V_MSG(0, "Failed to get modified time for: " + file + ".");
+		print_verbose("Failed to get modified time for: " + p_file + "");
+		return 0;
 	}
 }
 


### PR DESCRIPTION
This error message was often displayed for no good reason when PCK files were loaded in the editor.

Since file modification dates are secondary metadata, it's not very important if it can't be retrieved successfully anyway.

This closes https://github.com/godotengine/godot/issues/25318.