### PR TITLE
[Fix] ResourceBinaryLoader when used in threads

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -756,7 +756,7 @@ Error ResourceLoaderBinary::load() {
 				return error;
 			}
 
-			res->set(name, value);
+			res->set_deferred(name, value);
 		}
 #ifdef TOOLS_ENABLED
 		res->set_edited(false);


### PR DESCRIPTION
This PR fix the ResourceLoader and ResourceBackgroundLoader in the case that threads are used.

Variants such as meshes (buffers) are set "deferred" with this PR. This ensures that there are no errors in the transmission to the rendering server. See detailed error description.

A full description of the error can be found here:
https://github.com/godotengine/godot/issues/54151

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
