### PR TITLE
[Fix] ResourceBinaryLoader & ResourceFormatLoaderCSharpScript when used in threads 

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -35,6 +35,7 @@
 #include "core/io/file_access_compressed.h"
 #include "core/io/image.h"
 #include "core/io/marshalls.h"
+#include "core/os/thread.h"
 #include "core/version.h"
 
 //#define print_bl(m_what) print_line(m_what)
@@ -756,7 +757,11 @@ Error ResourceLoaderBinary::load() {
 				return error;
 			}
 
-			res->set(name, value);
+			if (Thread::get_caller_id() != Thread::get_main_id()) {
+				res->set_deferred(name, value);
+			} else {
+				res->set(name, value);
+			}
 		}
 #ifdef TOOLS_ENABLED
 		res->set_edited(false);

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -3614,7 +3614,11 @@ RES ResourceFormatLoaderCSharpScript::load(const String &p_path, const String &p
 
 	script->set_path(p_original_path);
 
-	script->reload();
+	if (Thread::get_caller_id() != Thread::get_main_id()) {
+		script->call_deferred("reload");
+	} else {
+		script->reload();
+	}
 
 	if (r_error) {
 		*r_error = OK;


### PR DESCRIPTION
This PR fix the ResourceLoader and ResourceBackgroundLoader (p_use_threads) in the case that threads are used.

Variants such as meshes (buffers) are set "deferred" with this PR. This ensures that there are no errors in the transmission to the rendering server or some other thread safe methods. See detailed error description.

A full description of the error can be found here:
#54151