### PR TITLE
Fix various misused code tag in classref

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -218,10 +218,10 @@
 			Disables [url=https://en.wikipedia.org/wiki/Doppler_effect]Doppler effect[/url] simulation (default).
 		</constant>
 		<constant name="DOPPLER_TRACKING_IDLE_STEP" value="1" enum="DopplerTracking">
-			Simulate [url=https://en.wikipedia.org/wiki/Doppler_effect]Doppler effect[/url] by tracking positions of objects that are changed in [code]_process[/code]. Changes in the relative velocity of this camera compared to those objects affect how Audio is perceived (changing the Audio's [code]pitch shift[/code]).
+			Simulate [url=https://en.wikipedia.org/wiki/Doppler_effect]Doppler effect[/url] by tracking positions of objects that are changed in [code]_process[/code]. Changes in the relative velocity of this camera compared to those objects affect how audio is perceived (changing the audio's [member AudioStreamPlayer3D.pitch_scale]).
 		</constant>
 		<constant name="DOPPLER_TRACKING_PHYSICS_STEP" value="2" enum="DopplerTracking">
-			Simulate [url=https://en.wikipedia.org/wiki/Doppler_effect]Doppler effect[/url] by tracking positions of objects that are changed in [code]_physics_process[/code]. Changes in the relative velocity of this camera compared to those objects affect how Audio is perceived (changing the Audio's [code]pitch shift[/code]).
+			Simulate [url=https://en.wikipedia.org/wiki/Doppler_effect]Doppler effect[/url] by tracking positions of objects that are changed in [code]_physics_process[/code]. Changes in the relative velocity of this camera compared to those objects affect how audio is perceived (changing the audio's [member AudioStreamPlayer3D.pitch_scale]).
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/Line2D.xml
+++ b/doc/classes/Line2D.xml
@@ -82,7 +82,7 @@
 			The smoothness of the rounded joints and caps. This is only used if a cap or joint is set as round.
 		</member>
 		<member name="sharp_limit" type="float" setter="set_sharp_limit" getter="get_sharp_limit" default="2.0">
-			The direction difference in radians between vector points. This value is only used if [code]joint mode[/code] is set to [constant LINE_JOINT_SHARP].
+			The direction difference in radians between vector points. This value is only used if [member joint_mode] is set to [constant LINE_JOINT_SHARP].
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			The texture used for the line's texture. Uses [code]texture_mode[/code] for drawing style.

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -261,7 +261,7 @@
 			<return type="Node" />
 			<argument index="0" name="path" type="NodePath" />
 			<description>
-				Fetches a node. The [NodePath] can be either a relative path (from the current node) or an absolute path (in the scene tree) to a node. If the path does not exist, a [code]null instance[/code] is returned and an error is logged. Attempts to access methods on the return value will result in an "Attempt to call &lt;method&gt; on a null instance." error.
+				Fetches a node. The [NodePath] can be either a relative path (from the current node) or an absolute path (in the scene tree) to a node. If the path does not exist, [code]null[/code] is returned and an error is logged. Attempts to access methods on the return value will result in an "Attempt to call &lt;method&gt; on a null instance." error.
 				[b]Note:[/b] Fetching absolute paths only works when the node is inside the scene tree (see [method is_inside_tree]).
 				[b]Example:[/b] Assume your current node is Character and the following tree:
 				[codeblock]
@@ -322,7 +322,7 @@
 		<method name="get_parent" qualifiers="const">
 			<return type="Node" />
 			<description>
-				Returns the parent node of the current node, or a [code]null instance[/code] if the node lacks a parent.
+				Returns the parent node of the current node, or [code]null[/code] if the node lacks a parent.
 			</description>
 		</method>
 		<method name="get_path" qualifiers="const">

--- a/doc/classes/PhysicsServer3D.xml
+++ b/doc/classes/PhysicsServer3D.xml
@@ -1152,16 +1152,16 @@
 			Maximum acceleration for the motor at the axes.
 		</constant>
 		<constant name="G6DOF_JOINT_FLAG_ENABLE_LINEAR_LIMIT" value="0" enum="G6DOFJointAxisFlag">
-			If [code]set[/code] there is linear motion possible within the given limits.
+			If set, linear motion is possible within the given limits.
 		</constant>
 		<constant name="G6DOF_JOINT_FLAG_ENABLE_ANGULAR_LIMIT" value="1" enum="G6DOFJointAxisFlag">
-			If [code]set[/code] there is rotational motion possible.
+			If set, rotational motion is possible.
 		</constant>
 		<constant name="G6DOF_JOINT_FLAG_ENABLE_MOTOR" value="4" enum="G6DOFJointAxisFlag">
-			If [code]set[/code] there is a rotational motor across these axes.
+			If set, there is a rotational motor across these axes.
 		</constant>
 		<constant name="G6DOF_JOINT_FLAG_ENABLE_LINEAR_MOTOR" value="5" enum="G6DOFJointAxisFlag">
-			If [code]set[/code] there is a linear motor on this axis that targets a specific velocity.
+			If set, there is a linear motor on this axis that targets a specific velocity.
 		</constant>
 		<constant name="SHAPE_WORLD_BOUNDARY" value="0" enum="ShapeType">
 			The [Shape3D] is a [WorldBoundaryShape3D].

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -49,7 +49,7 @@
 			<argument index="0" name="locale" type="String" />
 			<description>
 				Returns the [Translation] instance based on the [code]locale[/code] passed in.
-				It will return a [code]nullptr[/code] if there is no [Translation] instance that matches the [code]locale[/code].
+				It will return [code]null[/code] if there is no [Translation] instance that matches the [code]locale[/code].
 			</description>
 		</method>
 		<method name="pseudolocalize" qualifiers="const">


### PR DESCRIPTION
Saw some misused `[code]` tag in classref when checking the translation.

* Descriptive text that's not code:
    * `pitch shift`: changed to the affected `pitch_scale` property of `AudioStreamPlayer3D`
    * `joint mode`: changed to the `joint_mode` property
    * a `null instance`: changed to `null`.
    * if `set`: removed the `[code]` tag.
* `nullptr` should be `null`, as it's not C++ documentation.