### PR TITLE
Revert "Expose Variant operator= to GDNative"

### DIFF
--- a/modules/gdnative/gdnative/variant.cpp
+++ b/modules/gdnative/gdnative/variant.cpp
@@ -62,12 +62,6 @@ godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_self) {
 	return (godot_variant_type)self->get_type();
 }
 
-void GDAPI godot_variant_operator_assign(godot_variant *r_dest, const godot_variant *p_v) {
-	Variant *dest = (Variant *)r_dest;
-	Variant *v = (Variant *)p_v;
-	*dest = *v;
-}
-
 void GDAPI godot_variant_new_copy(godot_variant *p_dest, const godot_variant *p_src) {
 	Variant *dest = (Variant *)p_dest;
 	Variant *src = (Variant *)p_src;

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -4394,14 +4394,6 @@
         ]
       },
       {
-        "name": "godot_variant_operator_assign",
-        "return_type": "void",
-        "arguments": [
-          ["godot_variant *", "r_dest"],
-          ["const godot_variant *", "p_v"]
-        ]
-      },
-      {
         "name": "godot_variant_new_copy",
         "return_type": "void",
         "arguments": [

--- a/modules/gdnative/include/gdnative/variant.h
+++ b/modules/gdnative/include/gdnative/variant.h
@@ -170,8 +170,6 @@ extern "C" {
 
 godot_variant_type GDAPI godot_variant_get_type(const godot_variant *p_v);
 
-void GDAPI godot_variant_operator_assign(godot_variant *r_dest, const godot_variant *p_v);
-
 void GDAPI godot_variant_new_copy(godot_variant *r_dest, const godot_variant *p_src);
 
 void GDAPI godot_variant_new_nil(godot_variant *r_dest);


### PR DESCRIPTION
Reverts godotengine/godot#54508

See the PR for rationale. The PR can be redone (it's a good change) with the proper structure and cherry-picked again for `3.4`.