### PR TITLE
Upgrade code should change classes if `deprecate=no`.

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -867,7 +867,6 @@ void register_scene_types() {
 	GDREGISTER_CLASS(SceneTree);
 	GDREGISTER_VIRTUAL_CLASS(SceneTreeTimer); // sorry, you can't create it
 
-#ifndef DISABLE_DEPRECATED
 	// Dropped in 4.0, near approximation.
 	ClassDB::add_compatibility_class("AnimationTreePlayer", "AnimationTree");
 	ClassDB::add_compatibility_class("BitmapFont", "Font");
@@ -1010,8 +1009,6 @@ void register_scene_types() {
 	ClassDB::add_compatibility_class("Light2D", "PointLight2D");
 	ClassDB::add_compatibility_class("VisibilityNotifier2D", "VisibleOnScreenNotifier2D");
 	ClassDB::add_compatibility_class("VisibilityNotifier3D", "VisibleOnScreenNotifier3D");
-
-#endif /* DISABLE_DEPRECATED */
 
 	OS::get_singleton()->yield(); // may take time to init
 


### PR DESCRIPTION
When scons `deprecate=no` keeping the conversion to load old content so the resource can be upgraded was helpful.

Part of a series of pull requests extracted from our branch.

Fixes: https://github.com/godotengine/godot-proposals/issues/3623