### PR TITLE
Allow scrolling theme preview when the control picker is active

### DIFF
--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -157,6 +157,7 @@ void ThemeEditorPreview::_gui_input_picker_overlay(const Ref<InputEvent> &p_even
 			emit_signal(SNAME("control_picked"), theme_type);
 			picker_button->set_pressed(false);
 			picker_overlay->set_visible(false);
+			return;
 		}
 	}
 
@@ -167,6 +168,9 @@ void ThemeEditorPreview::_gui_input_picker_overlay(const Ref<InputEvent> &p_even
 		hovered_control = _find_hovered_control(preview_content, mp);
 		picker_overlay->update();
 	}
+
+	// Forward input to the scroll container underneath to allow scrolling.
+	preview_container->gui_input(p_event);
 }
 
 void ThemeEditorPreview::_reset_picker_overlay() {
@@ -223,7 +227,7 @@ ThemeEditorPreview::ThemeEditorPreview() {
 	preview_body->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(preview_body);
 
-	ScrollContainer *preview_container = memnew(ScrollContainer);
+	preview_container = memnew(ScrollContainer);
 	preview_container->set_enable_v_scroll(true);
 	preview_container->set_enable_h_scroll(true);
 	preview_body->add_child(preview_container);

--- a/editor/plugins/theme_editor_preview.h
+++ b/editor/plugins/theme_editor_preview.h
@@ -55,6 +55,7 @@
 class ThemeEditorPreview : public VBoxContainer {
 	GDCLASS(ThemeEditorPreview, VBoxContainer);
 
+	ScrollContainer *preview_container;
 	ColorRect *preview_bg;
 	MarginContainer *preview_overlay;
 	Control *picker_overlay;

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -68,7 +68,6 @@ class ScrollContainer : public Container {
 protected:
 	Size2 get_minimum_size() const override;
 
-	virtual void gui_input(const Ref<InputEvent> &p_gui_input) override;
 	void _gui_focus_changed(Control *p_control);
 	void _update_dimensions();
 	void _notification(int p_what);
@@ -80,6 +79,8 @@ protected:
 	void _update_scrollbar_position();
 
 public:
+	virtual void gui_input(const Ref<InputEvent> &p_gui_input) override;
+
 	void set_h_scroll(int p_pos);
 	int get_h_scroll() const;
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/54778.

I'm not sure if there are any considerations about moving `gui_input()` override of `ScrollContainer` to public methods, but some other controls also have it like so for similar reasons (namely, `ItemList`).