### PR TITLE
Let MultiMeshInstances affect NavigationMeshes

### DIFF
--- a/modules/navigation/navigation_mesh_generator.cpp
+++ b/modules/navigation/navigation_mesh_generator.cpp
@@ -36,6 +36,7 @@
 #include "core/os/thread.h"
 #include "scene/3d/collision_shape_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
+#include "scene/3d/multimesh_instance_3d.h"
 #include "scene/3d/physics_body_3d.h"
 #include "scene/resources/box_shape_3d.h"
 #include "scene/resources/capsule_shape_3d.h"
@@ -145,6 +146,21 @@ void NavigationMeshGenerator::_parse_geometry(Transform3D p_accumulated_transfor
 		Ref<Mesh> mesh = mesh_instance->get_mesh();
 		if (mesh.is_valid()) {
 			_add_mesh(mesh, p_accumulated_transform * mesh_instance->get_transform(), p_verticies, p_indices);
+		}
+	}
+
+	if (Object::cast_to<MultiMeshInstance3D>(p_node) && p_generate_from != NavigationMesh::PARSED_GEOMETRY_STATIC_COLLIDERS) {
+		MultiMeshInstance3D *multimesh_instance = Object::cast_to<MultiMeshInstance3D>(p_node);
+		Ref<MultiMesh> multimesh = multimesh_instance->get_multimesh();
+		Ref<Mesh> mesh = multimesh->get_mesh();
+		if (mesh.is_valid()) {
+			int n = multimesh->get_visible_instance_count();
+			if (n == -1) {
+				n = multimesh->get_instance_count();
+			}
+			for (int i = 0; i < n; i++) {
+				_add_mesh(mesh, p_accumulated_transform * multimesh->get_instance_transform(i), p_verticies, p_indices);
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR updates the navmesh generator to take MultiMeshInstances into account when baking the navmesh. Hopefully this can make it into the 3.5 backport too (https://github.com/godotengine/godot/pull/48395).