### PR TITLE
Reorganize scene tree dock buttons

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2709,6 +2709,7 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 			menu->add_icon_shortcut(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/add_child_node"), TOOL_NEW);
 			menu->add_icon_shortcut(get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/instance_scene"), TOOL_INSTANTIATE);
 		}
+		menu->add_icon_shortcut(get_theme_icon(SNAME("Collapse"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/expand_collapse_all"), TOOL_EXPAND_COLLAPSE);
 		menu->add_separator();
 
 		existing_script = selected->get_script();
@@ -2849,7 +2850,6 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 void SceneTreeDock::_open_tree_menu() {
 	menu->clear();
 
-	menu->add_icon_shortcut(get_theme_icon(SNAME("Collapse"), SNAME("EditorIcons")), ED_GET_SHORTCUT("scene_tree/expand_collapse_all"), TOOL_EXPAND_COLLAPSE);
 	menu->add_check_item(TTR("Auto Expand to Selected"), TOOL_AUTO_EXPAND);
 	menu->set_item_checked(menu->get_item_idx_from_text(TTR("Auto Expand to Selected")), EditorSettings::get_singleton()->get("docks/scene_tree/auto_expand_to_selected"));
 
@@ -3248,7 +3248,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 
 	ED_SHORTCUT("scene_tree/add_child_node", TTR("Add Child Node"), KeyModifierMask::CMD | Key::A);
 	ED_SHORTCUT("scene_tree/instance_scene", TTR("Instantiate Child Scene"), KeyModifierMask::CMD | KeyModifierMask::SHIFT | Key::A);
-	ED_SHORTCUT("scene_tree/expand_collapse_all", TTR("Expand/Collapse All"));
+	ED_SHORTCUT("scene_tree/expand_collapse_all", TTR("Expand/Collapse Branch"));
 	ED_SHORTCUT("scene_tree/cut_node", TTR("Cut"), KeyModifierMask::CMD | Key::X);
 	ED_SHORTCUT("scene_tree/copy_node", TTR("Copy"), KeyModifierMask::CMD | Key::C);
 	ED_SHORTCUT("scene_tree/paste_node", TTR("Paste"), KeyModifierMask::CMD | Key::V);


### PR DESCRIPTION
This PR moves the "Expand/Collapse All" option back to right-click menu, after it was moved in #51413
The reason is that this option actually works on the selected node, so it can be used to expand or collapse branches selectively. Thus I renamed this option to "Expand/Collapse Branch" (the shortcut path stays the same), so it's more clear what it does.

For a more controversial change, I moved the "Instantiate Child Scene" button into the popup menu:
![image](https://user-images.githubusercontent.com/2223172/144516948-44999b24-d431-475c-be43-8a4b62a70a6b.png)
From my experience, it's the least used top button in the scene tree dock. And removing it allows to restore the lost space for search box.

Before:
![image](https://user-images.githubusercontent.com/2223172/144517035-38ae020a-c518-4a8a-bdbe-a32a7765d141.png)

After:
![image](https://user-images.githubusercontent.com/2223172/144518903-272b9bed-58d1-4ed7-90ea-ee008270ae4a.png)
