### PR TITLE
Add a double-precision editor build to CI

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -29,15 +29,15 @@ jobs:
             build-mono: true
             artifact: true
 
-          - name: Editor and sanitizers (target=debug, tools=yes, tests=yes, use_asan=yes, use_ubsan=yes)
-            cache-name: linux-editor-sanitizers
+          - name: Editor with doubles and sanitizers (target=debug, tools=yes, float=64, tests=yes, use_asan=yes, use_ubsan=yes)
+            cache-name: linux-editor-double-sanitizers
             target: debug
             tools: true
             tests: true
-            sconsflags: use_asan=yes use_ubsan=yes
+            sconsflags: float=64 use_asan=yes use_ubsan=yes
             proj-test: true
             godot-cpp-test: true
-            bin: "./bin/godot.linuxbsd.tools.64s"
+            bin: "./bin/godot.linuxbsd.double.tools.64s"
             build-mono: false
             # Skip 2GiB artifact speeding up action.
             artifact: false

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -791,10 +791,10 @@ void ShaderGLES3::use_material(void *p_material) {
 					Transform2D tr = V->get();
 					GLfloat matrix[4] = {
 						/* build a 16x16 matrix */
-						tr.elements[0][0],
-						tr.elements[0][1],
-						tr.elements[1][0],
-						tr.elements[1][1],
+						(GLfloat)tr.elements[0][0],
+						(GLfloat)tr.elements[0][1],
+						(GLfloat)tr.elements[1][0],
+						(GLfloat)tr.elements[1][1],
 					};
 					glUniformMatrix2fv(location, 1, GL_FALSE, matrix);
 
@@ -804,15 +804,15 @@ void ShaderGLES3::use_material(void *p_material) {
 					Basis val = V->get();
 
 					GLfloat mat[9] = {
-						val.elements[0][0],
-						val.elements[1][0],
-						val.elements[2][0],
-						val.elements[0][1],
-						val.elements[1][1],
-						val.elements[2][1],
-						val.elements[0][2],
-						val.elements[1][2],
-						val.elements[2][2],
+						(GLfloat)val.elements[0][0],
+						(GLfloat)val.elements[1][0],
+						(GLfloat)val.elements[2][0],
+						(GLfloat)val.elements[0][1],
+						(GLfloat)val.elements[1][1],
+						(GLfloat)val.elements[2][1],
+						(GLfloat)val.elements[0][2],
+						(GLfloat)val.elements[1][2],
+						(GLfloat)val.elements[2][2],
 					};
 
 					glUniformMatrix3fv(location, 1, GL_FALSE, mat);
@@ -822,22 +822,22 @@ void ShaderGLES3::use_material(void *p_material) {
 				case ShaderLanguage::TYPE_MAT4: {
 					Transform2D tr = V->get();
 					GLfloat matrix[16] = { /* build a 16x16 matrix */
-						tr.elements[0][0],
-						tr.elements[0][1],
-						0,
-						0,
-						tr.elements[1][0],
-						tr.elements[1][1],
-						0,
-						0,
-						0,
-						0,
-						1,
-						0,
-						tr.elements[2][0],
-						tr.elements[2][1],
-						0,
-						1
+						(GLfloat)tr.elements[0][0],
+						(GLfloat)tr.elements[0][1],
+						(GLfloat)0,
+						(GLfloat)0,
+						(GLfloat)tr.elements[1][0],
+						(GLfloat)tr.elements[1][1],
+						(GLfloat)0,
+						(GLfloat)0,
+						(GLfloat)0,
+						(GLfloat)0,
+						(GLfloat)1,
+						(GLfloat)0,
+						(GLfloat)tr.elements[2][0],
+						(GLfloat)tr.elements[2][1],
+						(GLfloat)0,
+						(GLfloat)1
 					};
 
 					glUniformMatrix4fv(location, 1, GL_FALSE, matrix);

--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -267,13 +267,13 @@ def build_legacygl_header(filename, include, class_suffix, output_attribs):
         "\t_FORCE_INLINE_ void set_uniform(Uniforms p_uniform, const Color& p_color) { _FU GLfloat col[4]={p_color.r,p_color.g,p_color.b,p_color.a}; glUniform4fv(get_uniform(p_uniform),1,col); }\n\n"
     )
     fd.write(
-        "\t_FORCE_INLINE_ void set_uniform(Uniforms p_uniform, const Vector2& p_vec2) { _FU GLfloat vec2[2]={p_vec2.x,p_vec2.y}; glUniform2fv(get_uniform(p_uniform),1,vec2); }\n\n"
+        "\t_FORCE_INLINE_ void set_uniform(Uniforms p_uniform, const Vector2& p_vec2) { _FU GLfloat vec2[2]={(GLfloat)p_vec2.x,(GLfloat)p_vec2.y}; glUniform2fv(get_uniform(p_uniform),1,vec2); }\n\n"
     )
     fd.write(
-        "\t_FORCE_INLINE_ void set_uniform(Uniforms p_uniform, const Size2i& p_vec2) { _FU GLint vec2[2]={p_vec2.x,p_vec2.y}; glUniform2iv(get_uniform(p_uniform),1,vec2); }\n\n"
+        "\t_FORCE_INLINE_ void set_uniform(Uniforms p_uniform, const Size2i& p_vec2) { _FU GLint vec2[2]={(GLint)p_vec2.x,(GLint)p_vec2.y}; glUniform2iv(get_uniform(p_uniform),1,vec2); }\n\n"
     )
     fd.write(
-        "\t_FORCE_INLINE_ void set_uniform(Uniforms p_uniform, const Vector3& p_vec3) { _FU GLfloat vec3[3]={p_vec3.x,p_vec3.y,p_vec3.z}; glUniform3fv(get_uniform(p_uniform),1,vec3); }\n\n"
+        "\t_FORCE_INLINE_ void set_uniform(Uniforms p_uniform, const Vector3& p_vec3) { _FU GLfloat vec3[3]={(GLfloat)p_vec3.x,(GLfloat)p_vec3.y,(GLfloat)p_vec3.z}; glUniform3fv(get_uniform(p_uniform),1,vec3); }\n\n"
     )
     fd.write(
         "\t_FORCE_INLINE_ void set_uniform(Uniforms p_uniform, float p_a, float p_b) { _FU glUniform2f(get_uniform(p_uniform),p_a,p_b); }\n\n"
@@ -291,22 +291,22 @@ def build_legacygl_header(filename, include, class_suffix, output_attribs):
         const Transform3D &tr = p_transform;
 
         GLfloat matrix[16]={ /* build a 16x16 matrix */
-            tr.basis.elements[0][0],
-            tr.basis.elements[1][0],
-            tr.basis.elements[2][0],
-            0,
-            tr.basis.elements[0][1],
-            tr.basis.elements[1][1],
-            tr.basis.elements[2][1],
-            0,
-            tr.basis.elements[0][2],
-            tr.basis.elements[1][2],
-            tr.basis.elements[2][2],
-            0,
-            tr.origin.x,
-            tr.origin.y,
-            tr.origin.z,
-            1
+            (GLfloat)tr.basis.elements[0][0],
+            (GLfloat)tr.basis.elements[1][0],
+            (GLfloat)tr.basis.elements[2][0],
+            (GLfloat)0,
+            (GLfloat)tr.basis.elements[0][1],
+            (GLfloat)tr.basis.elements[1][1],
+            (GLfloat)tr.basis.elements[2][1],
+            (GLfloat)0,
+            (GLfloat)tr.basis.elements[0][2],
+            (GLfloat)tr.basis.elements[1][2],
+            (GLfloat)tr.basis.elements[2][2],
+            (GLfloat)0,
+            (GLfloat)tr.origin.x,
+            (GLfloat)tr.origin.y,
+            (GLfloat)tr.origin.z,
+            (GLfloat)1
         };
 
 
@@ -324,22 +324,22 @@ def build_legacygl_header(filename, include, class_suffix, output_attribs):
         const Transform2D &tr = p_transform;
 
         GLfloat matrix[16]={ /* build a 16x16 matrix */
-            tr.elements[0][0],
-            tr.elements[0][1],
-            0,
-            0,
-            tr.elements[1][0],
-            tr.elements[1][1],
-            0,
-            0,
-            0,
-            0,
-            1,
-            0,
-            tr.elements[2][0],
-            tr.elements[2][1],
-            0,
-            1
+            (GLfloat)tr.elements[0][0],
+            (GLfloat)tr.elements[0][1],
+            (GLfloat)0,
+            (GLfloat)0,
+            (GLfloat)tr.elements[1][0],
+            (GLfloat)tr.elements[1][1],
+            (GLfloat)0,
+            (GLfloat)0,
+            (GLfloat)0,
+            (GLfloat)0,
+            (GLfloat)1,
+            (GLfloat)0,
+            (GLfloat)tr.elements[2][0],
+            (GLfloat)tr.elements[2][1],
+            (GLfloat)0,
+            (GLfloat)1
         };
 
 

--- a/modules/gltf/gltf_animation.h
+++ b/modules/gltf/gltf_animation.h
@@ -50,7 +50,7 @@ public:
 	template <class T>
 	struct Channel {
 		Interpolation interpolation;
-		Vector<float> times;
+		Vector<real_t> times;
 		Vector<T> values;
 	};
 
@@ -58,7 +58,7 @@ public:
 		Channel<Vector3> position_track;
 		Channel<Quaternion> rotation_track;
 		Channel<Vector3> scale_track;
-		Vector<Channel<float>> weight_tracks;
+		Vector<Channel<real_t>> weight_tracks;
 	};
 
 public:

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4804,7 +4804,7 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> state) {
 					bool last = false;
 					Vector<real_t> weight_track;
 					while (true) {
-						float weight = _interpolate_track<float>(track.weight_tracks[track_idx].times,
+						float weight = _interpolate_track<real_t>(track.weight_tracks[track_idx].times,
 								track.weight_tracks[track_idx].values,
 								time,
 								track.weight_tracks[track_idx].interpolation);
@@ -4828,7 +4828,7 @@ Error GLTFDocument::_serialize_animations(Ref<GLTFState> state) {
 				int32_t weight_tracks_size = track.weight_tracks.size();
 				all_track_values.resize(weight_tracks_size * values_size);
 				for (int k = 0; k < track.weight_tracks.size(); k++) {
-					Vector<float> wdata = track.weight_tracks[k].values;
+					Vector<real_t> wdata = track.weight_tracks[k].values;
 					for (int l = 0; l < wdata.size(); l++) {
 						int32_t index = l * weight_tracks_size + k;
 						ERR_BREAK(index >= all_track_values.size());
@@ -4979,10 +4979,10 @@ Error GLTFDocument::_parse_animations(Ref<GLTFState> state) {
 
 				const int wlen = weights.size() / wc;
 				for (int k = 0; k < wc; k++) { //separate tracks, having them together is not such a good idea
-					GLTFAnimation::Channel<float> cf;
+					GLTFAnimation::Channel<real_t> cf;
 					cf.interpolation = interp;
 					cf.times = Variant(times);
-					Vector<float> wdata;
+					Vector<real_t> wdata;
 					wdata.resize(wlen);
 					for (int l = 0; l < wlen; l++) {
 						wdata.write[l] = weights[l * wc + k];
@@ -5772,7 +5772,7 @@ struct EditorSceneFormatImporterGLTFInterpolate<Quaternion> {
 };
 
 template <class T>
-T GLTFDocument::_interpolate_track(const Vector<float> &p_times, const Vector<T> &p_values, const float p_time, const GLTFAnimation::Interpolation p_interp) {
+T GLTFDocument::_interpolate_track(const Vector<real_t> &p_times, const Vector<T> &p_values, const float p_time, const GLTFAnimation::Interpolation p_interp) {
 	ERR_FAIL_COND_V(!p_values.size(), T());
 	if (p_times.size() != (p_values.size() / (p_interp == GLTFAnimation::INTERP_CUBIC_SPLINE ? 3 : 1))) {
 		ERR_PRINT_ONCE("The interpolated values are not corresponding to its times.");
@@ -6052,7 +6052,7 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 				double time = 0.0;
 				bool last = false;
 				while (true) {
-					float blend = _interpolate_track<float>(track.weight_tracks[i].times, track.weight_tracks[i].values, time, gltf_interp);
+					real_t blend = _interpolate_track<real_t>(track.weight_tracks[i].times, track.weight_tracks[i].values, time, gltf_interp);
 					animation->blend_shape_track_insert_key(track_idx, time, blend);
 					if (last) {
 						break;
@@ -6246,7 +6246,7 @@ GLTFAnimation::Track GLTFDocument::_convert_animation_track(Ref<GLTFState> state
 	}
 	Animation::TrackType track_type = p_animation->track_get_type(p_track_i);
 	int32_t key_count = p_animation->track_get_key_count(p_track_i);
-	Vector<float> times;
+	Vector<real_t> times;
 	times.resize(key_count);
 	String path = p_animation->track_get_path(p_track_i);
 	for (int32_t key_i = 0; key_i < key_count; key_i++) {
@@ -6352,7 +6352,7 @@ GLTFAnimation::Track GLTFDocument::_convert_animation_track(Ref<GLTFState> state
 		if (path.find("/scale") != -1) {
 			const int32_t keys = p_animation->track_get_key_time(p_track_i, key_count - 1) * BAKE_FPS;
 			if (!p_track.scale_track.times.size()) {
-				Vector<float> new_times;
+				Vector<real_t> new_times;
 				new_times.resize(keys);
 				for (int32_t key_i = 0; key_i < keys; key_i++) {
 					new_times.write[key_i] = key_i / BAKE_FPS;
@@ -6382,7 +6382,7 @@ GLTFAnimation::Track GLTFDocument::_convert_animation_track(Ref<GLTFState> state
 		} else if (path.find("/position") != -1) {
 			const int32_t keys = p_animation->track_get_key_time(p_track_i, key_count - 1) * BAKE_FPS;
 			if (!p_track.position_track.times.size()) {
-				Vector<float> new_times;
+				Vector<real_t> new_times;
 				new_times.resize(keys);
 				for (int32_t key_i = 0; key_i < keys; key_i++) {
 					new_times.write[key_i] = key_i / BAKE_FPS;
@@ -6503,7 +6503,7 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 					NodePath shape_path = String(path) + ":" + shape_name;
 					int32_t shape_track_i = animation->find_track(shape_path, Animation::TYPE_BLEND_SHAPE);
 					if (shape_track_i == -1) {
-						GLTFAnimation::Channel<float> weight;
+						GLTFAnimation::Channel<real_t> weight;
 						weight.interpolation = GLTFAnimation::INTERP_LINEAR;
 						weight.times.push_back(0.0f);
 						weight.times.push_back(0.0f);
@@ -6522,7 +6522,7 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 						gltf_interpolation = GLTFAnimation::INTERP_CUBIC_SPLINE;
 					}
 					int32_t key_count = animation->track_get_key_count(shape_track_i);
-					GLTFAnimation::Channel<float> weight;
+					GLTFAnimation::Channel<real_t> weight;
 					weight.interpolation = gltf_interpolation;
 					weight.times.resize(key_count);
 					for (int32_t time_i = 0; time_i < key_count; time_i++) {

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -293,7 +293,7 @@ private:
 	Node3D *_generate_spatial(Ref<GLTFState> state, Node *parent_node, const GLTFNodeIndex node_index);
 	void _assign_scene_names(Ref<GLTFState> state);
 	template <class T>
-	T _interpolate_track(const Vector<float> &p_times, const Vector<T> &p_values,
+	T _interpolate_track(const Vector<real_t> &p_times, const Vector<T> &p_values,
 			const float p_time,
 			const GLTFAnimation::Interpolation p_interp);
 	GLTFAccessorIndex _encode_accessor_as_quaternions(Ref<GLTFState> state,

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -729,7 +729,7 @@ void CPUParticles2D::_particles_process(double p_delta) {
 
 			real_t angle1_rad = direction.angle() + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
 			Vector2 rot = Vector2(Math::cos(angle1_rad), Math::sin(angle1_rad));
-			p.velocity = rot * Math::lerp(parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], Math::randf());
+			p.velocity = rot * Math::lerp(parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], (real_t)Math::randf());
 
 			real_t base_angle = tex_angle * Math::lerp(parameters_min[PARAM_ANGLE], parameters_max[PARAM_ANGLE], p.angle_rand);
 			p.rotation = Math::deg2rad(base_angle);

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -751,7 +751,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 			if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 				real_t angle1_rad = Math::atan2(direction.y, direction.x) + Math::deg2rad((Math::randf() * 2.0 - 1.0) * spread);
 				Vector3 rot = Vector3(Math::cos(angle1_rad), Math::sin(angle1_rad), 0.0);
-				p.velocity = rot * Math::lerp(parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], parameters_max[PARAM_INITIAL_LINEAR_VELOCITY], Math::randf());
+				p.velocity = rot * Math::lerp(parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], parameters_max[PARAM_INITIAL_LINEAR_VELOCITY], (real_t)Math::randf());
 			} else {
 				//initiate velocity spread in 3D
 				real_t angle1_rad = Math::deg2rad((Math::randf() * (real_t)2.0 - (real_t)1.0) * spread);
@@ -775,7 +775,7 @@ void CPUParticles3D::_particles_process(double p_delta) {
 				binormal.normalize();
 				Vector3 normal = binormal.cross(direction_nrm);
 				spread_direction = binormal * spread_direction.x + normal * spread_direction.y + direction_nrm * spread_direction.z;
-				p.velocity = spread_direction * Math::lerp(parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], parameters_max[PARAM_INITIAL_LINEAR_VELOCITY], float(Math::randf()));
+				p.velocity = spread_direction * Math::lerp(parameters_min[PARAM_INITIAL_LINEAR_VELOCITY], parameters_max[PARAM_INITIAL_LINEAR_VELOCITY], (real_t)Math::randf());
 			}
 
 			real_t base_angle = tex_angle * Math::lerp(parameters_min[PARAM_ANGLE], parameters_max[PARAM_ANGLE], p.angle_rand);

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -736,7 +736,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 					ba->bezier_accum = bezier;
 					ba->accum_pass = accum_pass;
 				} else {
-					ba->bezier_accum = Math::lerp(ba->bezier_accum, bezier, p_interp);
+					ba->bezier_accum = Math::lerp(ba->bezier_accum, (float)bezier, p_interp);
 				}
 
 			} break;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1239,8 +1239,7 @@ void AnimationTree::_process_graph(real_t p_delta) {
 							continue;
 						}
 
-						t->value = Math::lerp(t->value, value, blend);
-
+						t->value = Math::lerp(t->value, value, (float)blend);
 #endif // _3D_DISABLED
 					} break;
 					case Animation::TYPE_VALUE: {

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -3998,13 +3998,12 @@ bool Animation::_blend_shape_track_optimize_key(const TKey<float> &t0, const TKe
 	float v1 = t1.value;
 	float v2 = t2.value;
 
-	if (Math::is_equal_approx(v1, v2, p_allowed_unit_error)) {
+	if (Math::is_equal_approx(v1, v2, (float)p_allowed_unit_error)) {
 		//0 and 2 are close, let's see if 1 is close
-		if (!Math::is_equal_approx(v0, v1, p_allowed_unit_error)) {
+		if (!Math::is_equal_approx(v0, v1, (float)p_allowed_unit_error)) {
 			//not close, not optimizable
 			return false;
 		}
-
 	} else {
 		/*
 		TODO eventually discuss a way to optimize these better.

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -1449,7 +1449,7 @@ real_t Font::get_underline_thickness(int p_size) const {
 	return ret;
 }
 
-Size2 Font::get_string_size(const String &p_text, int p_size, HorizontalAlignment p_alignment, real_t p_width, uint16_t p_flags) const {
+Size2 Font::get_string_size(const String &p_text, int p_size, HorizontalAlignment p_alignment, float p_width, uint16_t p_flags) const {
 	ERR_FAIL_COND_V(data.is_empty(), Size2());
 
 	for (int i = 0; i < data.size(); i++) {
@@ -1474,7 +1474,7 @@ Size2 Font::get_string_size(const String &p_text, int p_size, HorizontalAlignmen
 	return buffer->get_size();
 }
 
-Size2 Font::get_multiline_string_size(const String &p_text, real_t p_width, int p_size, uint16_t p_flags) const {
+Size2 Font::get_multiline_string_size(const String &p_text, float p_width, int p_size, uint16_t p_flags) const {
 	ERR_FAIL_COND_V(data.is_empty(), Size2());
 
 	for (int i = 0; i < data.size(); i++) {
@@ -1511,7 +1511,7 @@ Size2 Font::get_multiline_string_size(const String &p_text, real_t p_width, int 
 	return ret;
 }
 
-void Font::draw_string(RID p_canvas_item, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, real_t p_width, int p_size, const Color &p_modulate, int p_outline_size, const Color &p_outline_modulate, uint16_t p_flags) const {
+void Font::draw_string(RID p_canvas_item, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment, float p_width, int p_size, const Color &p_modulate, int p_outline_size, const Color &p_outline_modulate, uint16_t p_flags) const {
 	ERR_FAIL_COND(data.is_empty());
 
 	for (int i = 0; i < data.size(); i++) {

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -273,11 +273,11 @@ public:
 	virtual real_t get_underline_thickness(int p_size = DEFAULT_FONT_SIZE) const;
 
 	// Drawing string.
-	virtual Size2 get_string_size(const String &p_text, int p_size = DEFAULT_FONT_SIZE, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, real_t p_width = -1, uint16_t p_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND) const;
-	virtual Size2 get_multiline_string_size(const String &p_text, real_t p_width = -1, int p_size = DEFAULT_FONT_SIZE, uint16_t p_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND) const;
+	virtual Size2 get_string_size(const String &p_text, int p_size = DEFAULT_FONT_SIZE, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, uint16_t p_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND) const;
+	virtual Size2 get_multiline_string_size(const String &p_text, float p_width = -1, int p_size = DEFAULT_FONT_SIZE, uint16_t p_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND) const;
 
-	virtual void draw_string(RID p_canvas_item, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, real_t p_width = -1, int p_size = DEFAULT_FONT_SIZE, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, const Color &p_outline_modulate = Color(1, 1, 1, 0), uint16_t p_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND) const;
-	virtual void draw_multiline_string(RID p_canvas_item, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, real_t p_width = -1, int p_max_lines = -1, int p_size = DEFAULT_FONT_SIZE, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, const Color &p_outline_modulate = Color(1, 1, 1, 0), uint16_t p_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND) const;
+	virtual void draw_string(RID p_canvas_item, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_size = DEFAULT_FONT_SIZE, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, const Color &p_outline_modulate = Color(1, 1, 1, 0), uint16_t p_flags = TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND) const;
+	virtual void draw_multiline_string(RID p_canvas_item, const Point2 &p_pos, const String &p_text, HorizontalAlignment p_alignment = HORIZONTAL_ALIGNMENT_LEFT, float p_width = -1, int p_max_lines = -1, int p_size = DEFAULT_FONT_SIZE, const Color &p_modulate = Color(1, 1, 1), int p_outline_size = 0, const Color &p_outline_modulate = Color(1, 1, 1, 0), uint16_t p_flags = TextServer::BREAK_MANDATORY | TextServer::BREAK_WORD_BOUND | TextServer::JUSTIFICATION_KASHIDA | TextServer::JUSTIFICATION_WORD_BOUND) const;
 
 	// Helper functions.
 	virtual bool has_char(char32_t p_char) const;

--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -485,7 +485,7 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 				raycaster->intersect(rays);
 
 				LocalVector<Vector3> ray_normals;
-				LocalVector<float> ray_normal_weights;
+				LocalVector<real_t> ray_normal_weights;
 
 				ray_normals.resize(new_index_count);
 				ray_normal_weights.resize(new_index_count);
@@ -517,10 +517,10 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 					Vector3 normal = n0 * w + n1 * u + n2 * v;
 
 					Vector2 orig_uv = ray_uvs[j];
-					float orig_bary[3] = { 1.0f - orig_uv.x - orig_uv.y, orig_uv.x, orig_uv.y };
+					real_t orig_bary[3] = { 1.0f - orig_uv.x - orig_uv.y, orig_uv.x, orig_uv.y };
 					for (int k = 0; k < 3; k++) {
 						int idx = orig_tri_id * 3 + k;
-						float weight = orig_bary[k];
+						real_t weight = orig_bary[k];
 						ray_normals[idx] += normal * weight;
 						ray_normal_weights[idx] += weight;
 					}

--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -786,7 +786,7 @@ void RendererCanvasCull::canvas_item_add_texture_rect(RID p_item, const Rect2 &p
 	if (p_tile) {
 		rect->flags |= RendererCanvasRender::CANVAS_RECT_TILE;
 		rect->flags |= RendererCanvasRender::CANVAS_RECT_REGION;
-		rect->source = Rect2(0, 0, fabsf(p_rect.size.width), fabsf(p_rect.size.height));
+		rect->source = Rect2(0, 0, ABS(p_rect.size.width), ABS(p_rect.size.height));
 	}
 
 	if (p_rect.size.x < 0) {

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -649,13 +649,13 @@ PackedInt32Array TextServer::shaped_text_get_line_breaks_adv(RID p_shaped, const
 	return lines;
 }
 
-PackedInt32Array TextServer::shaped_text_get_line_breaks(RID p_shaped, real_t p_width, int p_start, uint16_t /*TextBreakFlag*/ p_break_flags) const {
+PackedInt32Array TextServer::shaped_text_get_line_breaks(RID p_shaped, float p_width, int p_start, uint16_t /*TextBreakFlag*/ p_break_flags) const {
 	PackedInt32Array lines;
 
 	const_cast<TextServer *>(this)->shaped_text_update_breaks(p_shaped);
 	const Vector2i &range = shaped_text_get_range(p_shaped);
 
-	real_t width = 0.f;
+	float width = 0.f;
 	int line_start = MAX(p_start, range.x);
 	int last_safe_break = -1;
 	int word_count = 0;
@@ -1035,9 +1035,9 @@ Vector<Vector2> TextServer::shaped_text_get_selection(RID p_shaped, int p_start,
 	return ranges;
 }
 
-int TextServer::shaped_text_hit_test_grapheme(RID p_shaped, real_t p_coords) const {
+int TextServer::shaped_text_hit_test_grapheme(RID p_shaped, float p_coords) const {
 	// Exact grapheme hit test, return -1 if missed.
-	real_t off = 0.0f;
+	float off = 0.0f;
 
 	int v_size = shaped_text_get_glyph_count(p_shaped);
 	const Glyph *glyphs = shaped_text_get_glyphs(p_shaped);
@@ -1053,7 +1053,7 @@ int TextServer::shaped_text_hit_test_grapheme(RID p_shaped, real_t p_coords) con
 	return -1;
 }
 
-int TextServer::shaped_text_hit_test_position(RID p_shaped, real_t p_coords) const {
+int TextServer::shaped_text_hit_test_position(RID p_shaped, float p_coords) const {
 	int v_size = shaped_text_get_glyph_count(p_shaped);
 	const Glyph *glyphs = shaped_text_get_glyphs(p_shaped);
 
@@ -1165,7 +1165,7 @@ int TextServer::shaped_text_prev_grapheme_pos(RID p_shaped, int p_pos) const {
 	return p_pos;
 }
 
-void TextServer::shaped_text_draw(RID p_shaped, RID p_canvas, const Vector2 &p_pos, real_t p_clip_l, real_t p_clip_r, const Color &p_color) const {
+void TextServer::shaped_text_draw(RID p_shaped, RID p_canvas, const Vector2 &p_pos, float p_clip_l, float p_clip_r, const Color &p_color) const {
 	TextServer::Orientation orientation = shaped_text_get_orientation(p_shaped);
 	bool hex_codes = shaped_text_get_preserve_control(p_shaped) || shaped_text_get_preserve_invalid(p_shaped);
 
@@ -1262,7 +1262,7 @@ void TextServer::shaped_text_draw(RID p_shaped, RID p_canvas, const Vector2 &p_p
 	}
 }
 
-void TextServer::shaped_text_draw_outline(RID p_shaped, RID p_canvas, const Vector2 &p_pos, real_t p_clip_l, real_t p_clip_r, int p_outline_size, const Color &p_color) const {
+void TextServer::shaped_text_draw_outline(RID p_shaped, RID p_canvas, const Vector2 &p_pos, float p_clip_l, float p_clip_r, int p_outline_size, const Color &p_color) const {
 	TextServer::Orientation orientation = shaped_text_get_orientation(p_shaped);
 
 	bool rtl = (shaped_text_get_direction(p_shaped) == DIRECTION_RTL);


### PR DESCRIPTION
This PR fixes enough of Godot's code so that it compiles with `float=64` again and adds a double-precision editor build to the CI. Some of the code changes are for the OpenGL support, some are in the text server, and some are in GLTF. Once this is in CI, this will check `float=64` for every commit so that it will keep compiling.