### PR TITLE
Add the function add_child_deferred.

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -135,6 +135,15 @@
 				[b]Note:[/b] If you want a child to be persisted to a [PackedScene], you must set [member owner] in addition to calling [method add_child]. This is typically relevant for [url=https://godot.readthedocs.io/en/latest/tutorials/misc/running_code_in_the_editor.html]tool scripts[/url] and [url=https://godot.readthedocs.io/en/latest/tutorials/plugins/editor/index.html]editor plugins[/url]. If [method add_child] is called without setting [member owner], the newly added [Node] will not be visible in the scene tree, though it will be visible in the 2D/3D view.
 			</description>
 		</method>
+		<method name="add_child_deferred">
+			<return type="void" />
+			<argument index="0" name="node" type="Node" />
+			<argument index="1" name="legible_unique_name" type="bool" default="false" />
+			<argument index="2" name="internal" type="int" enum="Node.InternalMode" default="0" />
+			<description>
+				Adds a child node in a thread-safe manner. Analogous to using [method add_child] with [method Object.call_deferred], more efficient.
+			</description>
+		</method>
 		<method name="add_sibling">
 			<return type="void" />
 			<argument index="0" name="sibling" type="Node" />

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1104,6 +1104,10 @@ void Node::_add_child_nocheck(Node *p_child, const StringName &p_name) {
 	add_child_notify(p_child);
 }
 
+void Node::add_child_deferred(Node *p_child, bool p_legible_unique_name, InternalMode p_internal) {
+	return call_deferred(SNAME("add_child"), p_child, p_legible_unique_name, p_internal);
+}
+
 void Node::add_child(Node *p_child, bool p_legible_unique_name, InternalMode p_internal) {
 	ERR_FAIL_NULL(p_child);
 	ERR_FAIL_COND_MSG(p_child == this, vformat("Can't add child '%s' to itself.", p_child->get_name())); // adding to itself!
@@ -2698,6 +2702,7 @@ void Node::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_name", "name"), &Node::set_name);
 	ClassDB::bind_method(D_METHOD("get_name"), &Node::get_name);
+	ClassDB::bind_method(D_METHOD("add_child_deferred", "node", "legible_unique_name", "internal"), &Node::add_child_deferred, DEFVAL(false), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("add_child", "node", "legible_unique_name", "internal"), &Node::add_child, DEFVAL(false), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("remove_child", "node"), &Node::remove_child);
 	ClassDB::bind_method(D_METHOD("get_child_count", "include_internal"), &Node::get_child_count, DEFVAL(false)); // Note that the default value bound for include_internal is false, while the method is declared with true. This is because internal nodes are irrelevant for GDSCript.

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -295,6 +295,7 @@ public:
 	StringName get_name() const;
 	void set_name(const String &p_name);
 
+	void add_child_deferred(Node *p_child, bool p_legible_unique_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
 	void add_child(Node *p_child, bool p_legible_unique_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
 	void add_sibling(Node *p_sibling, bool p_legible_unique_name = false);
 	void remove_child(Node *p_child);


### PR DESCRIPTION
This function acts as `call_deferred("add_child", node)`, however it is a handy thread safe method.
This handy shortcut outperform the use of `call_deferred("add_child", node)`.

```gdscript
func _ready():
    # Thread safe
    add_child(node)

func set_data(data):
    # Not thread safe
    add_child_deferred(load('res://my_scene.tscn'))
```

It would be better to rewrite that part of the documentation to use this shortcut:
https://docs.godotengine.org/en/stable/tutorials/threads/thread_safe_apis.html?#scene-tree