### PR TITLE
Fix files_dropped in HTML5 export mono builds.

### DIFF
--- a/platform/javascript/js/libs/library_godot_input.js
+++ b/platform/javascript/js/libs/library_godot_input.js
@@ -262,7 +262,7 @@ const GodotInputDragDrop = {
 				const DROP = `/tmp/drop-${parseInt(Math.random() * (1 << 30), 10)}/`;
 				const drops = [];
 				const files = [];
-				FS.mkdir(DROP);
+				FS.mkdir(DROP.slice(0, -1)); // Without trailing slash
 				GodotInputDragDrop.pending_files.forEach((elem) => {
 					const path = elem['path'];
 					GodotFS.copy_to_fs(DROP + path, elem['data']);


### PR DESCRIPTION
This PR fixes #55593

(There was an exception thrown on FS.mkdir() because the path ends with a trailing slash)