### PR TITLE
Fix C# `Godot.SourceGenerators` for generic classes

### DIFF
--- a/modules/mono/SdkPackageVersions.props
+++ b/modules/mono/SdkPackageVersions.props
@@ -1,6 +1,7 @@
 <Project>
   <PropertyGroup>
-    <PackageVersion_Godot_NET_Sdk>4.0.0-dev5</PackageVersion_Godot_NET_Sdk>
-    <PackageVersion_Godot_SourceGenerators>4.0.0-dev2</PackageVersion_Godot_SourceGenerators>
+    <PackageFloatingVersion_Godot>4.0.*-*</PackageFloatingVersion_Godot>
+    <PackageVersion_Godot_NET_Sdk>4.0.0-dev6</PackageVersion_Godot_NET_Sdk>
+    <PackageVersion_Godot_SourceGenerators>4.0.0-dev3</PackageVersion_Godot_SourceGenerators>
   </PropertyGroup>
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.NET.Sdk/Sdk/Sdk.targets
@@ -17,6 +17,6 @@
 
   <!-- C# source generators -->
   <ItemGroup Condition=" '$(DisableImplicitGodotGeneratorReferences)' != 'true' ">
-    <PackageReference Include="Godot.SourceGenerators" Version="$(PackageVersion_Godot_SourceGenerators)" />
+    <PackageReference Include="Godot.SourceGenerators" Version="$(PackageFloatingVersion_Godot)" />
   </ItemGroup>
 </Project>

--- a/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Generic.cs
+++ b/modules/mono/editor/Godot.NET.Sdk/Godot.SourceGenerators.Sample/Generic.cs
@@ -1,0 +1,16 @@
+namespace Godot.SourceGenerators.Sample
+{
+    partial class Generic<T> : Godot.Object
+    {
+    }
+
+    // Generic again but different generic parameters
+    partial class Generic<T, R> : Godot.Object
+    {
+    }
+
+    // Generic again but without generic parameters
+    partial class Generic : Godot.Object
+    {
+    }
+}


### PR DESCRIPTION
Fix invalid C# generated by source generators for generic classes and add generic classes to the Sample project for testing.

The modified source generators were tested with the `Godot.SourceGenerators.Sample` project as I couldn't find a way to test them in a real Godot project (seems to always use the old ones).
