### PR TITLE
Display "Off" next to unchecked checkboxes in the editor

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -659,6 +659,7 @@ void EditorPropertyCheck::_checkbox_pressed() {
 void EditorPropertyCheck::update_property() {
 	bool c = get_edited_property_value();
 	checkbox->set_pressed(c);
+	checkbox->set_text(c ? TTR("On") : TTR("Off"));
 	checkbox->set_disabled(is_read_only());
 }
 
@@ -667,7 +668,7 @@ void EditorPropertyCheck::_bind_methods() {
 
 EditorPropertyCheck::EditorPropertyCheck() {
 	checkbox = memnew(CheckBox);
-	checkbox->set_text(TTR("On"));
+	checkbox->set_text(TTR("Off"));
 	add_child(checkbox);
 	add_focusable(checkbox);
 	checkbox->connect("pressed", callable_mp(this, &EditorPropertyCheck::_checkbox_pressed));

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -744,6 +744,7 @@ void ScriptCreateDialog::_update_dialog() {
 			_path_changed(file_path->get_text());
 		}
 	}
+	internal->set_text(is_built_in ? TTR("On") : TTR("Off"));
 
 	if (!_can_be_built_in()) {
 		internal->set_pressed(false);
@@ -1063,7 +1064,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	/* Built-in Script */
 
 	internal = memnew(CheckBox);
-	internal->set_text(TTR("On"));
+	internal->set_text(TTR("Off"));
 	internal->connect("pressed", callable_mp(this, &ScriptCreateDialog::_built_in_pressed));
 	gc->add_child(memnew(Label(TTR("Built-in Script:"))));
 	gc->add_child(internal);

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -507,6 +507,7 @@ void ShaderCreateDialog::_update_dialog() {
 			_path_changed(file_path->get_text());
 		}
 	}
+	internal->set_text(is_built_in ? TTR("On") : TTR("Off"));
 
 	internal->set_disabled(!built_in_enabled);
 
@@ -652,7 +653,7 @@ ShaderCreateDialog::ShaderCreateDialog() {
 	// Built-in Shader.
 
 	internal = memnew(CheckBox);
-	internal->set_text(TTR("On"));
+	internal->set_text(TTR("Off"));
 	internal->connect("toggled", callable_mp(this, &ShaderCreateDialog::_built_in_toggled));
 	gc->add_child(memnew(Label(TTR("Built-in Shader:"))));
 	gc->add_child(internal);


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/55601.

This makes it more obvious when a property is unchecked/disabled.

This change applies to the inspector, script editor and shader editor creation dialogs.

## Preview

*Previously, all checkboxes would have displayed the text "On".*

![image](https://user-images.githubusercontent.com/180032/144655936-6fbc6dbc-e533-49b9-b017-b33f038c5114.png)