### PR TITLE
[3.x] Display "Off" next to unchecked checkboxes in the editor

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -448,8 +448,9 @@ void EditorPropertyCheck::_checkbox_pressed() {
 }
 
 void EditorPropertyCheck::update_property() {
-	bool c = get_edited_object()->get(get_edited_property());
+	const bool c = get_edited_object()->get(get_edited_property());
 	checkbox->set_pressed(c);
+	checkbox->set_text(c ? TTR("On") : TTR("Off"));
 	checkbox->set_disabled(is_read_only());
 }
 
@@ -459,7 +460,7 @@ void EditorPropertyCheck::_bind_methods() {
 
 EditorPropertyCheck::EditorPropertyCheck() {
 	checkbox = memnew(CheckBox);
-	checkbox->set_text(TTR("On"));
+	checkbox->set_text(TTR("Off"));
 	add_child(checkbox);
 	add_focusable(checkbox);
 	checkbox->connect("pressed", this, "_checkbox_pressed");

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -676,6 +676,7 @@ void ScriptCreateDialog::_update_dialog() {
 			_path_changed(file_path->get_text());
 		}
 	}
+	internal->set_text(is_built_in ? TTR("On") : TTR("Off"));
 
 	if (!_can_be_built_in()) {
 		internal->set_pressed(false);
@@ -873,7 +874,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	/* Built-in Script */
 
 	internal = memnew(CheckBox);
-	internal->set_text(TTR("On"));
+	internal->set_text(TTR("Off"));
 	internal->connect("pressed", this, "_built_in_pressed");
 	gc->add_child(memnew(Label(TTR("Built-in Script:"))));
 	gc->add_child(internal);


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/55598.

This makes it more obvious when a property is unchecked/disabled.

This change applies to the inspector and the script editor creation dialog.