### PR TITLE
Add an `OS.crash()` method for testing system crash handler

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -207,6 +207,10 @@ void OS::alert(const String &p_alert, const String &p_title) {
 	::OS::get_singleton()->alert(p_alert, p_title);
 }
 
+void OS::crash(const String &p_message) {
+	CRASH_NOW_MSG(p_message);
+}
+
 String OS::get_executable_path() const {
 	return ::OS::get_singleton()->get_executable_path();
 }
@@ -542,6 +546,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("close_midi_inputs"), &OS::close_midi_inputs);
 
 	ClassDB::bind_method(D_METHOD("alert", "text", "title"), &OS::alert, DEFVAL("Alert!"));
+	ClassDB::bind_method(D_METHOD("crash", "message"), &OS::crash);
 
 	ClassDB::bind_method(D_METHOD("set_low_processor_usage_mode", "enable"), &OS::set_low_processor_usage_mode);
 	ClassDB::bind_method(D_METHOD("is_in_low_processor_usage_mode"), &OS::is_in_low_processor_usage_mode);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -161,6 +161,7 @@ public:
 	int get_low_processor_usage_mode_sleep_usec() const;
 
 	void alert(const String &p_alert, const String &p_title = "ALERT!");
+	void crash(const String &p_message);
 
 	String get_executable_path() const;
 	int execute(const String &p_path, const Vector<String> &p_arguments, Array r_output = Array(), bool p_read_stderr = false);

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -31,6 +31,13 @@
 				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
 			</description>
 		</method>
+		<method name="crash">
+			<return type="void" />
+			<argument index="0" name="message" type="String" />
+			<description>
+				Crashes the engine (or the editor if called within a [code]@tool[/code] script). This should [i]only[/i] be used for testing the system's crash handler, not for any other purpose. For general error reporting, use (in order of preference) [method @GDScript.assert], [method @GlobalScope.push_error] or [method alert]. See also [method kill].
+			</description>
+		</method>
 		<method name="create_instance">
 			<return type="int" />
 			<argument index="0" name="arguments" type="PackedStringArray" />
@@ -374,7 +381,7 @@
 			<return type="int" enum="Error" />
 			<argument index="0" name="pid" type="int" />
 			<description>
-				Kill (terminate) the process identified by the given process ID ([code]pid[/code]), e.g. the one returned by [method execute] in non-blocking mode.
+				Kill (terminate) the process identified by the given process ID ([code]pid[/code]), e.g. the one returned by [method execute] in non-blocking mode. See also [method crash].
 				[b]Note:[/b] This method can also be used to kill processes that were not spawned by the game.
 				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
 			</description>


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/55614.

This makes it possible to test the system's crash handler without having to modify engine code or exploit an engine bug.

This will come handy for developing features such as https://github.com/godotengine/godot/pull/55565, https://github.com/godotengine/godot/pull/33505 and https://github.com/godotengine/godot-proposals/issues/1896.

## Preview

```gdscript
extends Node


func _ready():
	OS.crash("Testing crash handler.")
```

Results in:

```
ERROR: Testing crash handler.
   at: crash (core/core_bind.cpp:211)

================================================================
handle_crash: Program crashed with signal 4
Engine version: Godot Engine v4.0.dev.custom_build (ea66ea9060272d67fbf0c4264acb76a7bedfc4af)
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[1] /lib64/libc.so.6(+0x3d320) [0x7f3d643f0320] (??:0)
[2] core_bind::OS::crash(String const&) (/home/hugo/Documents/Git/godotengine/godot/core/core_bind.cpp:211)
[3] void call_with_ptr_args_helper<__UnexistingClass, String const&, 0ul>(__UnexistingClass*, void (__UnexistingClass::*)(String const&), void const**, IndexSequence<0ul>) (/home/hugo/Documents/Git/godotengine/godot/./core/variant/binder_common.h:244)
[4] void call_with_ptr_args<__UnexistingClass, String const&>(__UnexistingClass*, void (__UnexistingClass::*)(String const&), void const**) (/home/hugo/Documents/Git/godotengine/godot/./core/variant/binder_common.h:493)
[5] MethodBindT<String const&>::ptrcall(Object*, void const**, void*) (/home/hugo/Documents/Git/godotengine/godot/./core/object/method_bind.h:291)
[6] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Callable::CallError&, GDScriptFunction::CallState*) (/home/hugo/Documents/Git/godotengine/godot/modules/gdscript/gdscript_vm.cpp:1869)
[7] GDScriptInstance::call(StringName const&, Variant const**, int, Callable::CallError&) (/home/hugo/Documents/Git/godotengine/godot/modules/gdscript/gdscript.cpp:1511)
[8] Node::_gdvirtual__ready_call() (/home/hugo/Documents/Git/godotengine/godot/./scene/main/node.h:236)
[9] Node::_notification(int) (/home/hugo/Documents/Git/godotengine/godot/scene/main/node.cpp:143)
[10] Node::_notificationv(int, bool) (/home/hugo/Documents/Git/godotengine/godot/./scene/main/node.h:48)
[11] CanvasItem::_notificationv(int, bool) (/home/hugo/Documents/Git/godotengine/godot/./scene/main/canvas_item.h:?)
[12] Node2D::_notificationv(int, bool) (/home/hugo/Documents/Git/godotengine/godot/./scene/2d/node_2d.h:?)
[13] Object::notification(int, bool) (/home/hugo/Documents/Git/godotengine/godot/core/object/object.cpp:846)
[14] Node::_propagate_ready() (/home/hugo/Documents/Git/godotengine/godot/scene/main/node.cpp:188)
[15] Node::_propagate_ready() (/home/hugo/Documents/Git/godotengine/godot/scene/main/node.cpp:179)
[16] Node::_set_tree(SceneTree*) (/home/hugo/Documents/Git/godotengine/godot/scene/main/node.cpp:?)
[17] SceneTree::initialize() (/home/hugo/Documents/Git/godotengine/godot/scene/main/scene_tree.cpp:402)
[18] OS_LinuxBSD::run() (/home/hugo/Documents/Git/godotengine/godot/platform/linuxbsd/os_linuxbsd.cpp:?)
[19] /home/hugo/Documents/Git/godotengine/godot/bin/godot.linuxbsd.tools.64.llvm(main+0x1c6) [0x462e7f6] (/home/hugo/Documents/Git/godotengine/godot/platform/linuxbsd/godot_linuxbsd.cpp:58)
[20] /lib64/libc.so.6(__libc_start_main+0xd5) [0x7f3d643dab75] (??:0)
[21] /home/hugo/Documents/Git/godotengine/godot/bin/godot.linuxbsd.tools.64.llvm(_start+0x2e) [0x462e56e] (??:?)
-- END OF BACKTRACE --
================================================================
```