### PR TITLE
Fix android low processor usage mode flicker 3.x

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2117,7 +2117,7 @@ bool Main::start() {
 uint64_t Main::last_ticks = 0;
 uint32_t Main::frames = 0;
 uint32_t Main::frame = 0;
-bool Main::force_redraw_requested = false;
+uint32_t Main::force_redraw_frames = 0;
 int Main::iterating = 0;
 bool Main::agile_input_event_flushing = false;
 
@@ -2177,6 +2177,8 @@ bool Main::iteration() {
 
 	uint64_t physics_process_ticks = 0;
 	uint64_t idle_process_ticks = 0;
+
+	bool draw = false;
 
 	frame += ticks_elapsed;
 
@@ -2240,15 +2242,25 @@ bool Main::iteration() {
 	VisualServer::get_singleton()->sync(); //sync if still drawing from previous frames.
 
 	if (OS::get_singleton()->can_draw() && VisualServer::get_singleton()->is_render_loop_enabled()) {
-		if ((!force_redraw_requested) && OS::get_singleton()->is_in_low_processor_usage_mode()) {
+		draw = true;
+		if (OS::get_singleton()->is_in_low_processor_usage_mode()) {
 			if (VisualServer::get_singleton()->has_changed()) {
-				VisualServer::get_singleton()->draw(true, scaled_step); // flush visual commands
-				Engine::get_singleton()->frames_drawn++;
+				draw = true;
+#ifdef ANDROID_ENABLED
+				// On Android in low_processor_usage_mode there can be horrible flickering when it stops drawing
+				// Fix by force drawing 2 more frames after last changed frame.
+				force_redraw_frames = 3; // needs to be 3 to draw 2 more after this frame
+#endif
+			} else {
+				draw = false;
 			}
-		} else {
+		}
+
+		if (draw || force_redraw_frames > 0) {
 			VisualServer::get_singleton()->draw(true, scaled_step); // flush visual commands
 			Engine::get_singleton()->frames_drawn++;
-			force_redraw_requested = false;
+			if (force_redraw_frames > 0)
+				force_redraw_frames--;
 		}
 	}
 
@@ -2328,8 +2340,8 @@ bool Main::iteration() {
 	return exit || auto_quit;
 }
 
-void Main::force_redraw() {
-	force_redraw_requested = true;
+void Main::force_redraw(uint32_t frames) {
+	force_redraw_frames = frames;
 }
 
 /* Engine deinitialization

--- a/main/main.h
+++ b/main/main.h
@@ -40,7 +40,7 @@ class Main {
 	static uint64_t last_ticks;
 	static uint32_t frames;
 	static uint32_t frame;
-	static bool force_redraw_requested;
+	static uint32_t force_redraw_frames;
 	static int iterating;
 	static bool agile_input_event_flushing;
 
@@ -52,7 +52,7 @@ public:
 	static bool start();
 
 	static bool iteration();
-	static void force_redraw();
+	static void force_redraw(uint32_t frames = 1);
 
 	static bool is_iterating();
 

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -386,6 +386,7 @@ void OS_Android::init_video_mode(int p_video_width, int p_video_height) {
 void OS_Android::set_display_size(Size2 p_size) {
 	default_videomode.width = p_size.x;
 	default_videomode.height = p_size.y;
+	Main::force_redraw(3); // fix flicker if in low_processor_mode
 }
 
 Error OS_Android::shell_open(String p_uri) {


### PR DESCRIPTION
This fixes https://github.com/godotengine/godot/issues/19304
The fix is to draw 2 more frames after VisualServer::has_changed returns false.
The next problem this also fixes is if the gl surface is lost (for example turning screen off/on, app switching, rotating device) then the screen sometimes would be black, or flicker between a rendered frame and a black frame. The fix for this is to draw 3 frames after any gl surface changed notifications from android

Master does not seem to have the original flicker problem, but the screen does stay black after app switching or screen off/on. So submitting a pull request for 3.x for now.