### PR TITLE
Fix editor layout settings not saved properly.

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4485,8 +4485,6 @@ void EditorNode::_save_docks() {
 	}
 	Ref<ConfigFile> config;
 	config.instantiate();
-	// Load and amend existing config if it exists.
-	config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
 
 	_save_docks_to_config(config, "docks");
 	_save_open_scenes_to_config(config, "EditorNode");


### PR DESCRIPTION
Fixes #54806. No need to load the previous settings before saving with the new ones. 