### PR TITLE
Add an `OS.crash()` method for testing system crash handler (3.x)

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -1182,6 +1182,10 @@ void _OS::alert(const String &p_alert, const String &p_title) {
 	OS::get_singleton()->alert(p_alert, p_title);
 }
 
+void _OS::crash(const String &p_message) {
+	CRASH_NOW_MSG(p_message);
+}
+
 bool _OS::request_permission(const String &p_name) {
 	return OS::get_singleton()->request_permission(p_name);
 }
@@ -1399,6 +1403,7 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_use_file_access_save_and_swap", "enabled"), &_OS::set_use_file_access_save_and_swap);
 
 	ClassDB::bind_method(D_METHOD("alert", "text", "title"), &_OS::alert, DEFVAL("Alert!"));
+	ClassDB::bind_method(D_METHOD("crash", "message"), &_OS::crash);
 
 	ClassDB::bind_method(D_METHOD("set_thread_name", "name"), &_OS::set_thread_name);
 	ClassDB::bind_method(D_METHOD("get_thread_caller_id"), &_OS::get_thread_caller_id);

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -356,6 +356,7 @@ public:
 	String get_cache_dir() const;
 
 	void alert(const String &p_alert, const String &p_title = "ALERT!");
+	void crash(const String &p_message);
 
 	void set_screen_orientation(ScreenOrientation p_orientation);
 	ScreenOrientation get_screen_orientation() const;

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -43,6 +43,13 @@
 				[b]Note:[/b] This method is implemented on Linux, macOS and Windows.
 			</description>
 		</method>
+		<method name="crash">
+			<return type="void" />
+			<argument index="0" name="message" type="String" />
+			<description>
+				Crashes the engine (or the editor if called within a [code]tool[/code] script). This should [i]only[/i] be used for testing the system's crash handler, not for any other purpose. For general error reporting, use (in order of preference) [method @GDScript.assert], [method @GDScript.push_error] or [method alert]. See also [method kill].
+			</description>
+		</method>
 		<method name="delay_msec" qualifiers="const">
 			<return type="void" />
 			<argument index="0" name="msec" type="int" />
@@ -714,7 +721,7 @@
 			<return type="int" enum="Error" />
 			<argument index="0" name="pid" type="int" />
 			<description>
-				Kill (terminate) the process identified by the given process ID ([code]pid[/code]), e.g. the one returned by [method execute] in non-blocking mode.
+				Kill (terminate) the process identified by the given process ID ([code]pid[/code]), e.g. the one returned by [method execute] in non-blocking mode. See also [method crash].
 				[b]Note:[/b] This method can also be used to kill processes that were not spawned by the game.
 				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
 			</description>


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/55603.

This makes it possible to test the system's crash handler without having to modify engine code or exploit an engine bug.

## Preview (`3.x`)

```gdscript
extends Node


func _ready():
	OS.crash("Testing crash handler.")
```

Results in:

```
ERROR: Testing crash handler.
   at: crash (core/bind/core_bind.cpp:1186)

================================================================
handle_crash: Program crashed with signal 4
Engine version: Godot Engine v3.5.beta.custom_build (ade0e700f1407e92414484d96f20f57bf63cc4d2)
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[1] /lib64/libc.so.6(+0x3d320) [0x7fd0dbded320] (??:0)
[2] _OS::crash(String const&) (/home/hugo/Documents/Git/godotengine/godot/core/bind/core_bind.cpp:1186)
[3] MethodBind1<String const&>::call(Object*, Variant const**, int, Variant::CallError&) (/home/hugo/Documents/Git/godotengine/godot/./core/method_bind.gen.inc:775)
[4] Object::call(StringName const&, Variant const**, int, Variant::CallError&) (/home/hugo/Documents/Git/godotengine/godot/core/object.cpp:918)
[5] Variant::call_ptr(StringName const&, Variant const**, int, Variant*, Variant::CallError&) (/home/hugo/Documents/Git/godotengine/godot/core/variant_call.cpp:1180)
[6] GDScriptFunction::call(GDScriptInstance*, Variant const**, int, Variant::CallError&, GDScriptFunction::CallState*) (/home/hugo/Documents/Git/godotengine/godot/modules/gdscript/gdscript_function.cpp:1046)
[7] GDScriptInstance::_ml_call_reversed(GDScript*, StringName const&, Variant const**, int) (/home/hugo/Documents/Git/godotengine/godot/modules/gdscript/gdscript.cpp:1209)
[8] GDScriptInstance::call_multilevel_reversed(StringName const&, Variant const**, int) (/home/hugo/Documents/Git/godotengine/godot/modules/gdscript/gdscript.cpp:1217)
[9] Node::_notification(int) (/home/hugo/Documents/Git/godotengine/godot/scene/main/node.cpp:149)
[10] Node::_notificationv(int, bool) (/home/hugo/Documents/Git/godotengine/godot/./scene/main/node.h:45)
[11] CanvasItem::_notificationv(int, bool) (/home/hugo/Documents/Git/godotengine/godot/./scene/2d/canvas_item.h:?)
[12] Node2D::_notificationv(int, bool) (/home/hugo/Documents/Git/godotengine/godot/./scene/2d/node_2d.h:?)
[13] Object::notification(int, bool) (/home/hugo/Documents/Git/godotengine/godot/core/object.cpp:927)
[14] Node::_propagate_ready() (/home/hugo/Documents/Git/godotengine/godot/scene/main/node.cpp:187)
[15] Node::_propagate_ready() (/home/hugo/Documents/Git/godotengine/godot/scene/main/node.cpp:178)
[16] Node::_set_tree(SceneTree*) (/home/hugo/Documents/Git/godotengine/godot/scene/main/node.cpp:?)
[17] SceneTree::init() (/home/hugo/Documents/Git/godotengine/godot/scene/main/scene_tree.cpp:472)
[18] OS_X11::run() (/home/hugo/Documents/Git/godotengine/godot/platform/x11/os_x11.cpp:?)
[19] /home/hugo/Documents/Git/godotengine/godot/bin/godot.x11.tools.64.llvm(main+0x173) [0x2e06663] (/home/hugo/Documents/Git/godotengine/godot/platform/x11/godot_x11.cpp:55)
[20] /lib64/libc.so.6(__libc_start_main+0xd5) [0x7fd0dbdd7b75] (??:0)
[21] /home/hugo/Documents/Git/godotengine/godot/bin/godot.x11.tools.64.llvm(_start+0x2e) [0x2e0642e] (??:?)
-- END OF BACKTRACE --
================================================================
```