### PR TITLE
Refactor constant suffix parsing in a shader

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -57,6 +57,7 @@ public:
 		TK_FALSE,
 		TK_FLOAT_CONSTANT,
 		TK_INT_CONSTANT,
+		TK_UINT_CONSTANT,
 		TK_TYPE_VOID,
 		TK_TYPE_BOOL,
 		TK_TYPE_BVEC2,
@@ -756,6 +757,9 @@ public:
 		StringName text;
 		double constant;
 		uint16_t line;
+		bool is_integer_constant() const {
+			return type == TK_INT_CONSTANT || type == TK_UINT_CONSTANT;
+		}
 	};
 
 	static String get_operator_text(Operator p_op);
@@ -980,6 +984,8 @@ private:
 	static const BuiltinFuncDef builtin_func_defs[];
 	static const BuiltinFuncOutArgs builtin_func_out_args[];
 	static const BuiltinFuncConstArgs builtin_func_const_args[];
+
+	static bool is_const_suffix_lut_initialized;
 
 	Error _validate_datatype(DataType p_type);
 	bool _compare_datatypes(DataType p_datatype_a, String p_datatype_name_a, int p_array_size_a, DataType p_datatype_b, String p_datatype_name_b, int p_array_size_b);


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/55587 - Prevents using incorrect alphabet symbols after suffix + adds a `u` suffix to handle unsigned integers.
