### PR TITLE
Fix `--test gdscript-parser` crash

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4221,7 +4221,11 @@ void GDScriptParser::TreePrinter::print_get_node(GetNodeNode *p_get_node) {
 }
 
 void GDScriptParser::TreePrinter::print_identifier(IdentifierNode *p_identifier) {
-	push_text(p_identifier->name);
+	if (p_identifier != nullptr) {
+		push_text(p_identifier->name);
+	} else {
+		push_text("<invalid identifier>");
+	}
 }
 
 void GDScriptParser::TreePrinter::print_if(IfNode *p_if, bool p_is_elif) {


### PR DESCRIPTION
Edit: Since there was an earlier PR that had the same fix as one part of this PR, I removed that part. Currently, only the gdscript-parser crash fix remains in this PR. Below is the original message, part of it folded. (Issue intentionally unlinked)

---

Fixes # 55553

First, while the parser is currently tolerant to printing non-existent expression nodes in [`GDScriptParser::TreePrinter::print_expression`](https://github.com/godotengine/godot/blob/2a9dd654bc0197dd864df61b5b37e302022c2871/modules/gdscript/gdscript_parser.cpp#L4090), [`print_identifier`](https://github.com/godotengine/godot/blob/2a9dd654bc0197dd864df61b5b37e302022c2871/modules/gdscript/gdscript_parser.cpp#L4223) can still be called from outside this function, such as from [`print_subscript`](https://github.com/godotengine/godot/blob/2a9dd654bc0197dd864df61b5b37e302022c2871/modules/gdscript/gdscript_parser.cpp#L4409) (which also handles "attributes"). This leads to crash when the identifier is omitted: e.g. `var x = a.`, `var x = a-.`, etc. This makes it hard to debug the relevant issue using `godot --test gdscript-parser`.

After making `print_identifier` handle nullptr, this is what we get for `var x = a-.`:

```
Class <unnamed> Extends Node3D :
|   Function _ready(  ) :
|   |   Variable x : Variant
|   |   |   = (a - <invalid expression>).<invalid identifier>
```
<details><summary>The outdated part about # 55553</summary>
The actual editor crash, however isn't due to the missing identifier.

When [`GDScriptLanguage::complete_code`](https://github.com/godotengine/godot/blob/2a9dd654bc0197dd864df61b5b37e302022c2871/modules/gdscript/gdscript_editor.cpp#L2395) is called and the `completion_context.type` is `COMPLETION_ATTRIBUTE`, it tries to guess the type of LHS of the `.`. So it calls [`_guess_expression_type`](https://github.com/godotengine/godot/blob/2a9dd654bc0197dd864df61b5b37e302022c2871/modules/gdscript/gdscript_editor.cpp#L1182) for the `(a - <invalid expression>)` part. The guessing logic for [`GDScriptParser::Node::BINARY_OPERATOR`](https://github.com/godotengine/godot/blob/2a9dd654bc0197dd864df61b5b37e302022c2871/modules/gdscript/gdscript_editor.cpp#L1567) currently doesn't check whether both its LHS and RHS are valid, and recursively tries to guess their types.

The crash doesn't happen (in the editor) with `var x = -.`, as opposed to the title of the original issue. The difference is that without anything before `-`, it is parsed as a unary operator which doesn't follow this code path. In fact the type guessing logic for unary operators seems to be missing(?).

As an easy fix, a null check can be added at the beginning of `GDScriptLanguage::_guess_expression_type`, which is currently the solution implemented in this PR. Though, this removes the assumption that the argument `p_expression` of `_guess_expression_type` must be non-null.
</details>