### PR TITLE
Threadsafe RPC Manager for Threaded Network Polling

### DIFF
--- a/core/multiplayer/rpc_manager.cpp
+++ b/core/multiplayer/rpc_manager.cpp
@@ -461,8 +461,7 @@ void RPCManager::_send_rpc(Node *p_from, int p_to, uint16_t p_rpc_id, const Mult
 	}
 }
 
-void RPCManager::rpcp_synced(NodePath path, int uniqueId, bool p_call_local_native, bool p_call_local_script, const StringName &p_method, const Variant **p_arg, int p_argcount){
-
+void RPCManager::rpcp_synced(NodePath path, int uniqueId, bool p_call_local_native, bool p_call_local_script, const StringName &p_method, const Variant **p_arg, int p_argcount) {
 	Node *p_node = multiplayer->get_root_node()->get_node(path);
 
 	if (p_call_local_native) {
@@ -526,10 +525,10 @@ void RPCManager::rpcp(Node *p_node, int p_peer_id, const StringName &p_method, c
 		_send_rpc(p_node, p_peer_id, rpc_id, config, p_method, p_arg, p_argcount);
 	}
 
-	if(Thread::get_caller_id() != Thread::get_main_id()){
-			this->call_deferred("rpcp_synced", p_node->get_path(), peer->get_unique_id(), call_local_native, call_local_script, p_method, p_arg, p_argcount);
+	if (Thread::get_caller_id() != Thread::get_main_id()) {
+		this->call_deferred("rpcp_synced", p_node->get_path(), peer->get_unique_id(), call_local_native, call_local_script, p_method, p_arg, p_argcount);
 	} else {
-			rpcp_synced(p_node->get_path(),peer->get_unique_id(), call_local_native, call_local_script, p_method, p_arg, p_argcount);
+		rpcp_synced(p_node->get_path(), peer->get_unique_id(), call_local_native, call_local_script, p_method, p_arg, p_argcount);
 	}
 
 	ERR_FAIL_COND_MSG(p_peer_id == node_id && !config.call_local, "RPC '" + p_method + "' on yourself is not allowed by selected mode.");

--- a/core/multiplayer/rpc_manager.h
+++ b/core/multiplayer/rpc_manager.h
@@ -81,6 +81,7 @@ public:
 	// Called by Node.rpc
 	void rpcp(Node *p_node, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount);
 	void process_rpc(int p_from, const uint8_t *p_packet, int p_packet_len);
+	void rpcp_synced(NodePath path, int uniqueId,  bool p_call_local_native, bool p_call_local_script, const StringName &p_method, const Variant **p_arg, int p_argcount);
 
 	String get_rpc_md5(const Node *p_node);
 	RPCManager(MultiplayerAPI *p_multiplayer) { multiplayer = p_multiplayer; }

--- a/core/multiplayer/rpc_manager.h
+++ b/core/multiplayer/rpc_manager.h
@@ -81,7 +81,7 @@ public:
 	// Called by Node.rpc
 	void rpcp(Node *p_node, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount);
 	void process_rpc(int p_from, const uint8_t *p_packet, int p_packet_len);
-	void rpcp_synced(NodePath path, int uniqueId,  bool p_call_local_native, bool p_call_local_script, const StringName &p_method, const Variant **p_arg, int p_argcount);
+	void rpcp_synced(NodePath path, int uniqueId, bool p_call_local_native, bool p_call_local_script, const StringName &p_method, const Variant **p_arg, int p_argcount);
 
 	String get_rpc_md5(const Node *p_node);
 	RPCManager(MultiplayerAPI *p_multiplayer) { multiplayer = p_multiplayer; }


### PR DESCRIPTION
This PR makes the RPC Manager threadsafe and allows polling network events inside a thread, to prevent as ex. loose connection when main thread is busy.

We can also integrate a thread inside the engine, but i blv that people can handle it by them self.

Example of an Networking Thread in Mono:
![image](https://user-images.githubusercontent.com/76991284/144725470-976af2c2-4876-4786-b4d3-ef7af005184d.png)
