### PR TITLE
Bind column_titles_visible as property

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -35,12 +35,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="are_column_titles_visible" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if the column titles are being shown.
-			</description>
-		</method>
 		<method name="clear">
 			<return type="void" />
 			<description>
@@ -313,13 +307,6 @@
 				Sets OpenType feature [code]tag[/code] for the column title.
 			</description>
 		</method>
-		<method name="set_column_titles_visible">
-			<return type="void" />
-			<argument index="0" name="visible" type="bool" />
-			<description>
-				If [code]true[/code], column titles are visible.
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="allow_reselect" type="bool" setter="set_allow_reselect" getter="get_allow_reselect" default="false">
@@ -327,6 +314,9 @@
 		</member>
 		<member name="allow_rmb_select" type="bool" setter="set_allow_rmb_select" getter="get_allow_rmb_select" default="false">
 			If [code]true[/code], a right mouse button click can select items.
+		</member>
+		<member name="column_titles_visible" type="bool" setter="set_column_titles_visible" getter="are_column_titles_visible" default="false">
+			If [code]true[/code], column titles are visible.
 		</member>
 		<member name="columns" type="int" setter="set_columns" getter="get_columns" default="1">
 			The number of columns.

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4830,6 +4830,7 @@ void Tree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_allow_reselect"), &Tree::get_allow_reselect);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "columns"), "set_columns", "get_columns");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "column_titles_visible"), "set_column_titles_visible", "are_column_titles_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_reselect"), "set_allow_reselect", "get_allow_reselect");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_rmb_select"), "set_allow_rmb_select", "get_allow_rmb_select");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_folding"), "set_hide_folding", "is_folding_hidden");


### PR DESCRIPTION
Spotted it randomly today. I don't see any reason why it wasn't a property.