### PR TITLE
Document SceneTreeTimer being freed automatically when elapsed

### DIFF
--- a/doc/classes/SceneTreeTimer.xml
+++ b/doc/classes/SceneTreeTimer.xml
@@ -22,12 +22,13 @@
 		}
 		[/csharp]
 		[/codeblocks]
+		The timer will be automatically freed after its time elapses.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="time_left" type="float" setter="set_time_left" getter="get_time_left">
-			The time remaining.
+			The time remaining (in seconds).
 		</member>
 	</members>
 	<signals>


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/55643.

The note was present in the SceneTree `create_timer()` class documentation, but not in the SceneTreeTimer class documentation.