### PR TITLE
Tweak VoxelGI defaults for better quality

### DIFF
--- a/doc/classes/VoxelGIData.xml
+++ b/doc/classes/VoxelGIData.xml
@@ -72,10 +72,10 @@
 		<member name="normal_bias" type="float" setter="set_normal_bias" getter="get_normal_bias" default="0.0">
 			The normal bias to use for indirect lighting and reflections. Higher values reduce self-reflections visible in non-rough materials, at the cost of more visible light leaking and flatter-looking indirect lighting. See also [member bias]. To prioritize hiding self-reflections over lighting quality, set [member bias] to [code]0.0[/code] and [member normal_bias] to a value between [code]1.0[/code] and [code]2.0[/code].
 		</member>
-		<member name="propagation" type="float" setter="set_propagation" getter="get_propagation" default="0.7">
-			If indirect lighting looks too flat, try decreasing [member propagation] while increasing [member energy] at the same time. See also [member use_two_bounces] which influences the indirect lighting's effective brightness.
+		<member name="propagation" type="float" setter="set_propagation" getter="get_propagation" default="0.5">
+			The multiplier to use when light bounces off a surface. Higher values result in brighter indirect lighting. If indirect lighting looks too flat, try decreasing [member propagation] while increasing [member energy] at the same time. See also [member use_two_bounces] which influences the indirect lighting's effective brightness.
 		</member>
-		<member name="use_two_bounces" type="bool" setter="set_use_two_bounces" getter="is_using_two_bounces" default="false">
+		<member name="use_two_bounces" type="bool" setter="set_use_two_bounces" getter="is_using_two_bounces" default="true">
 			If [code]true[/code], performs two bounces of indirect lighting instead of one. This makes indirect lighting look more natural and brighter at a small performance cost. The second bounce is also visible in reflections. If the scene appears too bright after enabling [member use_two_bounces], adjust [member propagation] and [member energy].
 		</member>
 	</members>

--- a/scene/3d/voxel_gi.h
+++ b/scene/3d/voxel_gi.h
@@ -49,9 +49,9 @@ class VoxelGIData : public Resource {
 	float energy = 1.0;
 	float bias = 1.5;
 	float normal_bias = 0.0;
-	float propagation = 0.7;
+	float propagation = 0.5;
 	bool interior = false;
-	bool use_two_bounces = false;
+	bool use_two_bounces = true;
 
 protected:
 	static void _bind_methods();

--- a/servers/rendering/renderer_rd/environment/gi.h
+++ b/servers/rendering/renderer_rd/environment/gi.h
@@ -78,9 +78,9 @@ public:
 		float energy = 1.0;
 		float bias = 1.4;
 		float normal_bias = 0.0;
-		float propagation = 0.7;
+		float propagation = 0.5;
 		bool interior = false;
-		bool use_two_bounces = false;
+		bool use_two_bounces = true;
 
 		uint32_t version = 1;
 		uint32_t data_version = 1;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/55332 (can be merged independently).

Overall brightness is similar to the previous settings, but lighting now fades off more naturally and reflections feature indirect lighting. Performance is identical.

- Enable **Use Two Bounces** by default.
- Decrease **Propagation** to `0.5` to compensate for the second bounce.

This PR doesn't break compatibility with existing `3.x` projects, since VoxelGI is new in 4.0 and has different settings by design.

**Testing project:** [test_voxelgi_large_1.zip](https://github.com/godotengine/godot/files/7656776/test_voxelgi_large_1.zip)

## Preview

*Look at the reflective spheres for improvements in reflections.*

### Before

![2021-12-05_21 24 35](https://user-images.githubusercontent.com/180032/144762833-d04450dc-1fce-4bb7-b092-9627333aea5e.png)

### After

![2021-12-05_21 24 49](https://user-images.githubusercontent.com/180032/144762835-f0928b19-b466-4fba-8b60-157a867f4d73.png)