### PR TITLE
Use tooltips instead of labels for VoxelGI and GPUParticlesCollisionSDF

### DIFF
--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -68,32 +68,36 @@ void GPUParticlesCollisionSDFEditorPlugin::_notification(int p_what) {
 			return;
 		}
 
+		// Set information tooltip on the Bake button. This information is useful
+		// to optimize performance (video RAM size) and reduce collision tunneling (individual cell size).
+
 		const Vector3i size = col_sdf->get_estimated_cell_size();
-		String text = vformat(String::utf8("%d × %d × %d"), size.x, size.y, size.z);
+
+		const Vector3 extents = col_sdf->get_extents();
+
 		int data_size = 2;
-
 		const double size_mb = size.x * size.y * size.z * data_size / (1024.0 * 1024.0);
-		text += " - " + vformat(TTR("VRAM Size: %s MB"), String::num(size_mb, 2));
+		// Add a qualitative measurement to help the user assess whether a GPUParticlesCollisionSDF node is using a lot of VRAM.
+		String size_quality;
+		if (size_mb < 8.0) {
+			size_quality = TTR("Low");
+		} else if (size_mb < 32.0) {
+			size_quality = TTR("Moderate");
+		} else {
+			size_quality = TTR("High");
+		}
 
-		if (bake_info->get_text() == text) {
+		String text;
+		text += vformat(TTR("Subdivisions: %s"), vformat(String::utf8("%d × %d × %d"), size.x, size.y, size.z)) + "\n";
+		text += vformat(TTR("Cell size: %s"), vformat(String::utf8("%.3f × %.3f × %.3f"), extents.x / size.x, extents.y / size.y, extents.z / size.z)) + "\n";
+		text += vformat(TTR("Video RAM size: %s MB (%s)"), String::num(size_mb, 2), size_quality);
+
+		// Only update the tooltip when needed to avoid constant redrawing.
+		if (bake->get_tooltip(Point2()) == text) {
 			return;
 		}
 
-		// Color the label depending on the estimated performance level.
-		Color color;
-		if (size_mb <= 16.0 + CMP_EPSILON) {
-			// Fast.
-			color = bake_info->get_theme_color(SNAME("success_color"), SNAME("Editor"));
-		} else if (size_mb <= 64.0 + CMP_EPSILON) {
-			// Medium.
-			color = bake_info->get_theme_color(SNAME("warning_color"), SNAME("Editor"));
-		} else {
-			// Slow.
-			color = bake_info->get_theme_color(SNAME("error_color"), SNAME("Editor"));
-		}
-		bake_info->add_theme_color_override("font_color", color);
-
-		bake_info->set_text(text);
+		bake->set_tooltip(text);
 	}
 }
 
@@ -178,10 +182,6 @@ GPUParticlesCollisionSDFEditorPlugin::GPUParticlesCollisionSDFEditorPlugin(Edito
 	bake->set_text(TTR("Bake SDF"));
 	bake->connect("pressed", callable_mp(this, &GPUParticlesCollisionSDFEditorPlugin::_bake));
 	bake_hb->add_child(bake);
-	bake_info = memnew(Label);
-	bake_info->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-	bake_info->set_clip_text(true);
-	bake_hb->add_child(bake_info);
 
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, bake_hb);
 	col_sdf = nullptr;

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
@@ -42,7 +42,6 @@ class GPUParticlesCollisionSDFEditorPlugin : public EditorPlugin {
 	GPUParticlesCollisionSDF *col_sdf;
 
 	HBoxContainer *bake_hb;
-	Label *bake_info;
 	Button *bake;
 	EditorNode *editor;
 

--- a/editor/plugins/voxel_gi_editor_plugin.h
+++ b/editor/plugins/voxel_gi_editor_plugin.h
@@ -42,7 +42,6 @@ class VoxelGIEditorPlugin : public EditorPlugin {
 	VoxelGI *voxel_gi;
 
 	HBoxContainer *bake_hb;
-	Label *bake_info;
 	Button *bake;
 	EditorNode *editor;
 


### PR DESCRIPTION
This fixes the issue with labels being cut off (or becoming too long when not clipped).

This also adds a mention of the individual cell size, which is useful information to have when trying to avoid light leaking or particle collision tunneling.

The indicative GPUParticlesCollisionSDF video RAM thresholds were also divided by two. This is because particle collision should arguably be using less VRAM than VoxelGI, since particle collision is a less "important" visual feature. (See also https://github.com/godotengine/godot/issues/55641.)

This closes https://github.com/godotengine/godot/issues/53529.

## Preview

### VoxelGI

*Extents are (500, 64, 500).*

![2021-12-05_20 05 55](https://user-images.githubusercontent.com/180032/144766036-61330a71-e5c2-406f-a620-eb5689b723b4.png)

### GPUParticlesCollisionSDF

*Extents are (20, 7, 20).*

![2021-12-05_23 13 12](https://user-images.githubusercontent.com/180032/144766035-68710739-2836-4fa1-968b-086bc6c35138.png)