### PR TITLE
[GDScript] Add 'sort' and 'has' methods to pooled arrays

### DIFF
--- a/core/pool_vector.h
+++ b/core/pool_vector.h
@@ -501,6 +501,7 @@ public:
 	Error resize(int p_size);
 
 	void invert();
+	void sort();
 
 	void operator=(const PoolVector &p_pool_vector) { _reference(p_pool_vector); }
 	PoolVector() { alloc = nullptr; }
@@ -680,6 +681,18 @@ void PoolVector<T>::invert() {
 		w[i] = w[s - i - 1];
 		w[s - i - 1] = temp;
 	}
+}
+
+template <class T>
+void PoolVector<T>::sort() {
+	int len = size();
+	if (len == 0) {
+		return;
+	}
+
+	Write w = write();
+	SortArray<T> sorter;
+	sorter.sort(w.ptr(), len);
 }
 
 #endif // POOL_VECTOR_H

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -706,6 +706,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM2R(PoolByteArray, rfind);
 	VCALL_LOCALMEM1R(PoolByteArray, count);
 	VCALL_LOCALMEM1R(PoolByteArray, has);
+	VCALL_LOCALMEM0(PoolByteArray, sort);
 
 	VCALL_LOCALMEM0R(PoolIntArray, size);
 	VCALL_LOCALMEM0R(PoolIntArray, empty);
@@ -723,6 +724,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM2R(PoolIntArray, rfind);
 	VCALL_LOCALMEM1R(PoolIntArray, count);
 	VCALL_LOCALMEM1R(PoolIntArray, has);
+	VCALL_LOCALMEM0(PoolIntArray, sort);
 
 	VCALL_LOCALMEM0R(PoolRealArray, size);
 	VCALL_LOCALMEM0R(PoolRealArray, empty);
@@ -740,6 +742,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM2R(PoolRealArray, rfind);
 	VCALL_LOCALMEM1R(PoolRealArray, count);
 	VCALL_LOCALMEM1R(PoolRealArray, has);
+	VCALL_LOCALMEM0(PoolRealArray, sort);
 
 	VCALL_LOCALMEM0R(PoolStringArray, size);
 	VCALL_LOCALMEM0R(PoolStringArray, empty);
@@ -758,6 +761,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM2R(PoolStringArray, rfind);
 	VCALL_LOCALMEM1R(PoolStringArray, count);
 	VCALL_LOCALMEM1R(PoolStringArray, has);
+	VCALL_LOCALMEM0(PoolStringArray, sort)
 
 	VCALL_LOCALMEM0R(PoolVector2Array, size);
 	VCALL_LOCALMEM0R(PoolVector2Array, empty);
@@ -775,6 +779,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM2R(PoolVector2Array, rfind);
 	VCALL_LOCALMEM1R(PoolVector2Array, count);
 	VCALL_LOCALMEM1R(PoolVector2Array, has);
+	VCALL_LOCALMEM0(PoolVector2Array, sort);
 
 	VCALL_LOCALMEM0R(PoolVector3Array, size);
 	VCALL_LOCALMEM0R(PoolVector3Array, empty);
@@ -792,6 +797,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM2R(PoolVector3Array, rfind);
 	VCALL_LOCALMEM1R(PoolVector3Array, count);
 	VCALL_LOCALMEM1R(PoolVector3Array, has);
+	VCALL_LOCALMEM0(PoolVector3Array, sort);
 
 	VCALL_LOCALMEM0R(PoolColorArray, size);
 	VCALL_LOCALMEM0R(PoolColorArray, empty);
@@ -809,6 +815,7 @@ struct _VariantCall {
 	VCALL_LOCALMEM2R(PoolColorArray, rfind);
 	VCALL_LOCALMEM1R(PoolColorArray, count);
 	VCALL_LOCALMEM1R(PoolColorArray, has);
+	VCALL_LOCALMEM0(PoolColorArray, sort);
 
 #define VCALL_PTR0(m_type, m_method) \
 	static void _call_##m_type##_##m_method(Variant &r_ret, Variant &p_self, const Variant **p_args) { reinterpret_cast<m_type *>(p_self._data._ptr)->m_method(); }
@@ -1980,6 +1987,7 @@ void register_variant_methods() {
 	ADDFUNC2R(POOL_BYTE_ARRAY, INT, PoolByteArray, rfind, INT, "value", INT, "from", varray(-1));
 	ADDFUNC1R(POOL_BYTE_ARRAY, INT, PoolByteArray, count, INT, "value", varray());
 	ADDFUNC1R(POOL_BYTE_ARRAY, BOOL, PoolByteArray, has, INT, "value", varray());
+	ADDFUNC0(POOL_BYTE_ARRAY, NIL, PoolByteArray, sort, varray());
 
 	ADDFUNC0R(POOL_BYTE_ARRAY, STRING, PoolByteArray, get_string_from_ascii, varray());
 	ADDFUNC0R(POOL_BYTE_ARRAY, STRING, PoolByteArray, get_string_from_utf8, varray());
@@ -2003,6 +2011,7 @@ void register_variant_methods() {
 	ADDFUNC2R(POOL_INT_ARRAY, INT, PoolIntArray, rfind, INT, "value", INT, "from", varray(-1));
 	ADDFUNC1R(POOL_INT_ARRAY, INT, PoolIntArray, count, INT, "value", varray());
 	ADDFUNC1R(POOL_INT_ARRAY, BOOL, PoolIntArray, has, INT, "value", varray());
+	ADDFUNC0(POOL_INT_ARRAY, NIL, PoolIntArray, sort, varray());
 
 	ADDFUNC0R(POOL_REAL_ARRAY, INT, PoolRealArray, size, varray());
 	ADDFUNC0R(POOL_REAL_ARRAY, BOOL, PoolRealArray, empty, varray());
@@ -2019,6 +2028,7 @@ void register_variant_methods() {
 	ADDFUNC2R(POOL_REAL_ARRAY, INT, PoolRealArray, rfind, REAL, "value", INT, "from", varray(-1));
 	ADDFUNC1R(POOL_REAL_ARRAY, INT, PoolRealArray, count, REAL, "value", varray());
 	ADDFUNC1R(POOL_REAL_ARRAY, BOOL, PoolRealArray, has, REAL, "value", varray());
+	ADDFUNC0(POOL_REAL_ARRAY, NIL, PoolRealArray, sort, varray());
 
 	ADDFUNC0R(POOL_STRING_ARRAY, INT, PoolStringArray, size, varray());
 	ADDFUNC0R(POOL_STRING_ARRAY, BOOL, PoolStringArray, empty, varray());
@@ -2036,6 +2046,7 @@ void register_variant_methods() {
 	ADDFUNC2R(POOL_STRING_ARRAY, INT, PoolStringArray, rfind, STRING, "value", INT, "from", varray(-1));
 	ADDFUNC1R(POOL_STRING_ARRAY, INT, PoolStringArray, count, STRING, "value", varray());
 	ADDFUNC1R(POOL_STRING_ARRAY, BOOL, PoolStringArray, has, STRING, "value", varray());
+	ADDFUNC0(POOL_STRING_ARRAY, NIL, PoolStringArray, sort, varray());
 
 	ADDFUNC0R(POOL_VECTOR2_ARRAY, INT, PoolVector2Array, size, varray());
 	ADDFUNC0R(POOL_VECTOR2_ARRAY, BOOL, PoolVector2Array, empty, varray());
@@ -2052,6 +2063,7 @@ void register_variant_methods() {
 	ADDFUNC2R(POOL_VECTOR2_ARRAY, INT, PoolVector2Array, rfind, VECTOR2, "value", INT, "from", varray(-1));
 	ADDFUNC1R(POOL_VECTOR2_ARRAY, INT, PoolVector2Array, count, VECTOR2, "value", varray());
 	ADDFUNC1R(POOL_VECTOR2_ARRAY, BOOL, PoolVector2Array, has, VECTOR2, "value", varray());
+	ADDFUNC0(POOL_VECTOR2_ARRAY, NIL, PoolVector2Array, sort, varray());
 
 	ADDFUNC0R(POOL_VECTOR3_ARRAY, INT, PoolVector3Array, size, varray());
 	ADDFUNC0R(POOL_VECTOR3_ARRAY, BOOL, PoolVector3Array, empty, varray());
@@ -2068,6 +2080,7 @@ void register_variant_methods() {
 	ADDFUNC2R(POOL_VECTOR3_ARRAY, INT, PoolVector3Array, rfind, VECTOR3, "value", INT, "from", varray(-1));
 	ADDFUNC1R(POOL_VECTOR3_ARRAY, INT, PoolVector3Array, count, VECTOR3, "value", varray());
 	ADDFUNC1R(POOL_VECTOR3_ARRAY, BOOL, PoolVector3Array, has, VECTOR3, "value", varray());
+	ADDFUNC0(POOL_VECTOR3_ARRAY, NIL, PoolVector3Array, sort, varray());
 
 	ADDFUNC0R(POOL_COLOR_ARRAY, INT, PoolColorArray, size, varray());
 	ADDFUNC0R(POOL_COLOR_ARRAY, BOOL, PoolColorArray, empty, varray());
@@ -2084,6 +2097,7 @@ void register_variant_methods() {
 	ADDFUNC2R(POOL_COLOR_ARRAY, INT, PoolColorArray, rfind, COLOR, "value", INT, "from", varray(-1));
 	ADDFUNC1R(POOL_COLOR_ARRAY, INT, PoolColorArray, count, COLOR, "value", varray());
 	ADDFUNC1R(POOL_COLOR_ARRAY, BOOL, PoolColorArray, has, COLOR, "value", varray());
+	ADDFUNC0(POOL_COLOR_ARRAY, NIL, PoolColorArray, sort, varray());
 
 	//pointerbased
 

--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -178,6 +178,11 @@
 				Returns the number of elements in the array.
 			</description>
 		</method>
+		<method name="sort">
+			<description>
+				Sorts the elements of the array in ascending order.
+			</description>
+		</method>
 		<method name="subarray">
 			<return type="PoolByteArray" />
 			<argument index="0" name="from" type="int" />

--- a/doc/classes/PoolColorArray.xml
+++ b/doc/classes/PoolColorArray.xml
@@ -129,6 +129,11 @@
 				Returns the number of elements in the array.
 			</description>
 		</method>
+		<method name="sort">
+			<description>
+				Sorts the elements of the array in ascending order.
+			</description>
+		</method>
 	</methods>
 	<constants>
 	</constants>

--- a/doc/classes/PoolIntArray.xml
+++ b/doc/classes/PoolIntArray.xml
@@ -131,6 +131,11 @@
 				Returns the number of elements in the array.
 			</description>
 		</method>
+		<method name="sort">
+			<description>
+				Sorts the elements of the array in ascending order.
+			</description>
+		</method>
 	</methods>
 	<constants>
 	</constants>

--- a/doc/classes/PoolRealArray.xml
+++ b/doc/classes/PoolRealArray.xml
@@ -131,6 +131,11 @@
 				Returns the number of elements in the array.
 			</description>
 		</method>
+		<method name="sort">
+			<description>
+				Sorts the elements of the array in ascending order.
+			</description>
+		</method>
 	</methods>
 	<constants>
 	</constants>

--- a/doc/classes/PoolStringArray.xml
+++ b/doc/classes/PoolStringArray.xml
@@ -137,6 +137,11 @@
 				Returns the number of elements in the array.
 			</description>
 		</method>
+		<method name="sort">
+			<description>
+				Sorts the elements of the array in ascending order.
+			</description>
+		</method>
 	</methods>
 	<constants>
 	</constants>

--- a/doc/classes/PoolVector2Array.xml
+++ b/doc/classes/PoolVector2Array.xml
@@ -130,6 +130,11 @@
 				Returns the number of elements in the array.
 			</description>
 		</method>
+		<method name="sort">
+			<description>
+				Sorts the elements of the array in ascending order.
+			</description>
+		</method>
 	</methods>
 	<constants>
 	</constants>

--- a/doc/classes/PoolVector3Array.xml
+++ b/doc/classes/PoolVector3Array.xml
@@ -129,6 +129,11 @@
 				Returns the number of elements in the array.
 			</description>
 		</method>
+		<method name="sort">
+			<description>
+				Sorts the elements of the array in ascending order.
+			</description>
+		</method>
 	</methods>
 	<constants>
 	</constants>

--- a/modules/gdnative/gdnative/pool_arrays.cpp
+++ b/modules/gdnative/gdnative/pool_arrays.cpp
@@ -112,6 +112,11 @@ void GDAPI godot_pool_byte_array_resize(godot_pool_byte_array *p_self, const god
 	self->resize(p_size);
 }
 
+void GDAPI godot_pool_byte_array_sort(godot_pool_byte_array *p_self) {
+	PoolVector<uint8_t> *self = (PoolVector<uint8_t> *)p_self;
+	self->sort();
+}
+
 godot_pool_byte_array_read_access GDAPI *godot_pool_byte_array_read(const godot_pool_byte_array *p_self) {
 	const PoolVector<uint8_t> *self = (const PoolVector<uint8_t> *)p_self;
 	return (godot_pool_byte_array_read_access *)memnew(PoolVector<uint8_t>::Read(self->read()));
@@ -140,6 +145,11 @@ godot_int GDAPI godot_pool_byte_array_size(const godot_pool_byte_array *p_self) 
 godot_bool GDAPI godot_pool_byte_array_empty(const godot_pool_byte_array *p_self) {
 	const PoolVector<uint8_t> *self = (const PoolVector<uint8_t> *)p_self;
 	return self->empty();
+}
+
+godot_bool GDAPI godot_pool_byte_array_has(godot_pool_byte_array *p_self, const uint8_t p_data) {
+	const PoolVector<uint8_t> *self = (const PoolVector<uint8_t> *)p_self;
+	return self->has(p_data);
 }
 
 void GDAPI godot_pool_byte_array_destroy(godot_pool_byte_array *p_self) {
@@ -206,6 +216,11 @@ void GDAPI godot_pool_int_array_resize(godot_pool_int_array *p_self, const godot
 	self->resize(p_size);
 }
 
+void GDAPI godot_pool_int_array_sort(godot_pool_int_array *p_self) {
+	PoolVector<godot_int> *self = (PoolVector<godot_int> *)p_self;
+	self->sort();
+}
+
 godot_pool_int_array_read_access GDAPI *godot_pool_int_array_read(const godot_pool_int_array *p_self) {
 	const PoolVector<godot_int> *self = (const PoolVector<godot_int> *)p_self;
 	return (godot_pool_int_array_read_access *)memnew(PoolVector<godot_int>::Read(self->read()));
@@ -234,6 +249,11 @@ godot_int GDAPI godot_pool_int_array_size(const godot_pool_int_array *p_self) {
 godot_bool GDAPI godot_pool_int_array_empty(const godot_pool_int_array *p_self) {
 	const PoolVector<godot_int> *self = (const PoolVector<godot_int> *)p_self;
 	return self->empty();
+}
+
+godot_bool GDAPI godot_pool_int_array_has(godot_pool_int_array *p_self, const godot_int p_data) {
+	const PoolVector<godot_int> *self = (const PoolVector<godot_int> *)p_self;
+	return self->has(p_data);
 }
 
 void GDAPI godot_pool_int_array_destroy(godot_pool_int_array *p_self) {
@@ -300,6 +320,11 @@ void GDAPI godot_pool_real_array_resize(godot_pool_real_array *p_self, const god
 	self->resize(p_size);
 }
 
+void GDAPI godot_pool_real_array_sort(godot_pool_real_array *p_self) {
+	PoolVector<godot_real> *self = (PoolVector<godot_real> *)p_self;
+	self->sort();
+}
+
 godot_pool_real_array_read_access GDAPI *godot_pool_real_array_read(const godot_pool_real_array *p_self) {
 	const PoolVector<godot_real> *self = (const PoolVector<godot_real> *)p_self;
 	return (godot_pool_real_array_read_access *)memnew(PoolVector<godot_real>::Read(self->read()));
@@ -328,6 +353,11 @@ godot_int GDAPI godot_pool_real_array_size(const godot_pool_real_array *p_self) 
 godot_bool GDAPI godot_pool_real_array_empty(const godot_pool_real_array *p_self) {
 	const PoolVector<godot_real> *self = (const PoolVector<godot_real> *)p_self;
 	return self->empty();
+}
+
+godot_bool GDAPI godot_pool_real_array_has(godot_pool_real_array *p_self, const godot_real p_data) {
+	const PoolVector<godot_real> *self = (const PoolVector<godot_real> *)p_self;
+	return self->has(p_data);
 }
 
 void GDAPI godot_pool_real_array_destroy(godot_pool_real_array *p_self) {
@@ -408,6 +438,11 @@ void GDAPI godot_pool_string_array_resize(godot_pool_string_array *p_self, const
 	self->resize(p_size);
 }
 
+void GDAPI godot_pool_string_array_sort(godot_pool_string_array *p_self) {
+	PoolVector<String> *self = (PoolVector<String> *)p_self;
+	self->sort();
+}
+
 godot_pool_string_array_read_access GDAPI *godot_pool_string_array_read(const godot_pool_string_array *p_self) {
 	const PoolVector<String> *self = (const PoolVector<String> *)p_self;
 	return (godot_pool_string_array_read_access *)memnew(PoolVector<String>::Read(self->read()));
@@ -441,6 +476,12 @@ godot_int GDAPI godot_pool_string_array_size(const godot_pool_string_array *p_se
 godot_bool GDAPI godot_pool_string_array_empty(const godot_pool_string_array *p_self) {
 	const PoolVector<String> *self = (const PoolVector<String> *)p_self;
 	return self->empty();
+}
+
+godot_bool GDAPI godot_pool_string_array_has(godot_pool_string_array *p_self, const godot_string *p_data) {
+	const PoolVector<String> *self = (const PoolVector<String> *)p_self;
+	String &s = *(String *)p_data;
+	return self->has(s);
 }
 
 void GDAPI godot_pool_string_array_destroy(godot_pool_string_array *p_self) {
@@ -510,6 +551,11 @@ void GDAPI godot_pool_vector2_array_resize(godot_pool_vector2_array *p_self, con
 	self->resize(p_size);
 }
 
+void GDAPI godot_pool_vector2_array_sort(godot_pool_vector2_array *p_self) {
+	PoolVector<Vector2> *self = (PoolVector<Vector2> *)p_self;
+	self->sort();
+}
+
 godot_pool_vector2_array_read_access GDAPI *godot_pool_vector2_array_read(const godot_pool_vector2_array *p_self) {
 	const PoolVector<Vector2> *self = (const PoolVector<Vector2> *)p_self;
 	return (godot_pool_vector2_array_read_access *)memnew(PoolVector<Vector2>::Read(self->read()));
@@ -542,6 +588,12 @@ godot_int GDAPI godot_pool_vector2_array_size(const godot_pool_vector2_array *p_
 godot_bool GDAPI godot_pool_vector2_array_empty(const godot_pool_vector2_array *p_self) {
 	const PoolVector<Vector2> *self = (const PoolVector<Vector2> *)p_self;
 	return self->empty();
+}
+
+godot_bool GDAPI godot_pool_vector2_array_has(godot_pool_vector2_array *p_self, const godot_vector2 *p_data) {
+	const PoolVector<Vector2> *self = (const PoolVector<Vector2> *)p_self;
+	Vector2 &s = *(Vector2 *)p_data;
+	return self->has(s);
 }
 
 void GDAPI godot_pool_vector2_array_destroy(godot_pool_vector2_array *p_self) {
@@ -611,6 +663,11 @@ void GDAPI godot_pool_vector3_array_resize(godot_pool_vector3_array *p_self, con
 	self->resize(p_size);
 }
 
+void GDAPI godot_pool_vector3_array_sort(godot_pool_vector3_array *p_self) {
+	PoolVector<Vector3> *self = (PoolVector<Vector3> *)p_self;
+	self->sort();
+}
+
 godot_pool_vector3_array_read_access GDAPI *godot_pool_vector3_array_read(const godot_pool_vector3_array *p_self) {
 	const PoolVector<Vector3> *self = (const PoolVector<Vector3> *)p_self;
 	return (godot_pool_vector3_array_read_access *)memnew(PoolVector<Vector3>::Read(self->read()));
@@ -643,6 +700,12 @@ godot_int GDAPI godot_pool_vector3_array_size(const godot_pool_vector3_array *p_
 godot_bool GDAPI godot_pool_vector3_array_empty(const godot_pool_vector3_array *p_self) {
 	const PoolVector<Vector3> *self = (const PoolVector<Vector3> *)p_self;
 	return self->empty();
+}
+
+godot_bool GDAPI godot_pool_vector3_array_has(godot_pool_vector3_array *p_self, const godot_vector3 *p_data) {
+	const PoolVector<Vector3> *self = (const PoolVector<Vector3> *)p_self;
+	Vector3 &s = *(Vector3 *)p_data;
+	return self->has(s);
 }
 
 void GDAPI godot_pool_vector3_array_destroy(godot_pool_vector3_array *p_self) {
@@ -712,6 +775,11 @@ void GDAPI godot_pool_color_array_resize(godot_pool_color_array *p_self, const g
 	self->resize(p_size);
 }
 
+void GDAPI godot_pool_color_array_sort(godot_pool_color_array *p_self) {
+	PoolVector<Color> *self = (PoolVector<Color> *)p_self;
+	self->sort();
+}
+
 godot_pool_color_array_read_access GDAPI *godot_pool_color_array_read(const godot_pool_color_array *p_self) {
 	const PoolVector<Color> *self = (const PoolVector<Color> *)p_self;
 	return (godot_pool_color_array_read_access *)memnew(PoolVector<Color>::Read(self->read()));
@@ -744,6 +812,12 @@ godot_int GDAPI godot_pool_color_array_size(const godot_pool_color_array *p_self
 godot_bool GDAPI godot_pool_color_array_empty(const godot_pool_color_array *p_self) {
 	const PoolVector<Color> *self = (const PoolVector<Color> *)p_self;
 	return self->empty();
+}
+
+godot_bool GDAPI godot_pool_color_array_has(godot_pool_color_array *p_self, const godot_color *p_data) {
+	const PoolVector<Color> *self = (const PoolVector<Color> *)p_self;
+	Color &s = *(Color *)p_data;
+	return self->has(s);
 }
 
 void GDAPI godot_pool_color_array_destroy(godot_pool_color_array *p_self) {

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -26,11 +26,116 @@
           "next": null,
           "api": [
             {
+              "name": "godot_pool_byte_array_has",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["godot_pool_byte_array *", "p_self"],
+                ["const uint8_t", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_pool_byte_array_sort",
+              "return_type": "void",
+              "arguments": [
+                ["godot_pool_byte_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_pool_int_array_has",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["godot_pool_int_array *", "p_self"],
+                ["const godot_int", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_pool_int_array_sort",
+              "return_type": "void",
+              "arguments": [
+                ["godot_pool_int_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_pool_real_array_has",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["godot_pool_real_array *", "p_self"],
+                ["const godot_real", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_pool_real_array_sort",
+              "return_type": "void",
+              "arguments": [
+                ["godot_pool_real_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_pool_string_array_has",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["godot_pool_string_array *", "p_self"],
+                ["const godot_string *", "p_data"]
+              ]
+            },
+            {
               "name": "godot_pool_string_array_join",
               "return_type": "godot_string",
               "arguments": [
                 ["godot_pool_string_array *", "p_self"],
                 ["const godot_string *", "p_delimiter"]
+              ]
+            },
+            {
+              "name": "godot_pool_string_array_sort",
+              "return_type": "void",
+              "arguments": [
+                ["godot_pool_string_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_pool_vector2_array_has",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["godot_pool_vector2_array *", "p_self"],
+                ["const godot_vector2 *", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_pool_vector2_array_sort",
+              "return_type": "void",
+              "arguments": [
+                ["godot_pool_vector2_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_pool_vector3_array_has",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["godot_pool_vector3_array *", "p_self"],
+                ["const godot_vector3 *", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_pool_vector3_array_sort",
+              "return_type": "void",
+              "arguments": [
+                ["godot_pool_vector3_array *", "p_self"]
+              ]
+            },
+            {
+              "name": "godot_pool_color_array_has",
+              "return_type": "godot_bool",
+              "arguments": [
+                ["godot_pool_color_array *", "p_self"],
+                ["const godot_color *", "p_data"]
+              ]
+            },
+            {
+              "name": "godot_pool_color_array_sort",
+              "return_type": "void",
+              "arguments": [
+                ["godot_pool_color_array *", "p_self"]
               ]
             }
           ]

--- a/modules/gdnative/include/gdnative/pool_arrays.h
+++ b/modules/gdnative/include/gdnative/pool_arrays.h
@@ -182,6 +182,8 @@ void GDAPI godot_pool_byte_array_remove(godot_pool_byte_array *p_self, const god
 
 void GDAPI godot_pool_byte_array_resize(godot_pool_byte_array *p_self, const godot_int p_size);
 
+void GDAPI godot_pool_byte_array_sort(godot_pool_byte_array *p_self);
+
 godot_pool_byte_array_read_access GDAPI *godot_pool_byte_array_read(const godot_pool_byte_array *p_self);
 
 godot_pool_byte_array_write_access GDAPI *godot_pool_byte_array_write(godot_pool_byte_array *p_self);
@@ -192,6 +194,8 @@ uint8_t GDAPI godot_pool_byte_array_get(const godot_pool_byte_array *p_self, con
 godot_int GDAPI godot_pool_byte_array_size(const godot_pool_byte_array *p_self);
 
 godot_bool GDAPI godot_pool_byte_array_empty(const godot_pool_byte_array *p_self);
+
+godot_bool GDAPI godot_pool_byte_array_has(godot_pool_byte_array *p_self, const uint8_t p_data);
 
 void GDAPI godot_pool_byte_array_destroy(godot_pool_byte_array *p_self);
 
@@ -215,6 +219,8 @@ void GDAPI godot_pool_int_array_remove(godot_pool_int_array *p_self, const godot
 
 void GDAPI godot_pool_int_array_resize(godot_pool_int_array *p_self, const godot_int p_size);
 
+void GDAPI godot_pool_int_array_sort(godot_pool_int_array *p_self);
+
 godot_pool_int_array_read_access GDAPI *godot_pool_int_array_read(const godot_pool_int_array *p_self);
 
 godot_pool_int_array_write_access GDAPI *godot_pool_int_array_write(godot_pool_int_array *p_self);
@@ -225,6 +231,8 @@ godot_int GDAPI godot_pool_int_array_get(const godot_pool_int_array *p_self, con
 godot_int GDAPI godot_pool_int_array_size(const godot_pool_int_array *p_self);
 
 godot_bool GDAPI godot_pool_int_array_empty(const godot_pool_int_array *p_self);
+
+godot_bool GDAPI godot_pool_int_array_has(godot_pool_int_array *p_self, const godot_int p_data);
 
 void GDAPI godot_pool_int_array_destroy(godot_pool_int_array *p_self);
 
@@ -248,6 +256,8 @@ void GDAPI godot_pool_real_array_remove(godot_pool_real_array *p_self, const god
 
 void GDAPI godot_pool_real_array_resize(godot_pool_real_array *p_self, const godot_int p_size);
 
+void GDAPI godot_pool_real_array_sort(godot_pool_real_array *p_self);
+
 godot_pool_real_array_read_access GDAPI *godot_pool_real_array_read(const godot_pool_real_array *p_self);
 
 godot_pool_real_array_write_access GDAPI *godot_pool_real_array_write(godot_pool_real_array *p_self);
@@ -258,6 +268,8 @@ godot_real GDAPI godot_pool_real_array_get(const godot_pool_real_array *p_self, 
 godot_int GDAPI godot_pool_real_array_size(const godot_pool_real_array *p_self);
 
 godot_bool GDAPI godot_pool_real_array_empty(const godot_pool_real_array *p_self);
+
+godot_bool GDAPI godot_pool_real_array_has(godot_pool_real_array *p_self, const godot_real p_data);
 
 void GDAPI godot_pool_real_array_destroy(godot_pool_real_array *p_self);
 
@@ -283,6 +295,8 @@ void GDAPI godot_pool_string_array_remove(godot_pool_string_array *p_self, const
 
 void GDAPI godot_pool_string_array_resize(godot_pool_string_array *p_self, const godot_int p_size);
 
+void GDAPI godot_pool_string_array_sort(godot_pool_string_array *p_self);
+
 godot_pool_string_array_read_access GDAPI *godot_pool_string_array_read(const godot_pool_string_array *p_self);
 
 godot_pool_string_array_write_access GDAPI *godot_pool_string_array_write(godot_pool_string_array *p_self);
@@ -293,6 +307,8 @@ godot_string GDAPI godot_pool_string_array_get(const godot_pool_string_array *p_
 godot_int GDAPI godot_pool_string_array_size(const godot_pool_string_array *p_self);
 
 godot_bool GDAPI godot_pool_string_array_empty(const godot_pool_string_array *p_self);
+
+godot_bool GDAPI godot_pool_string_array_has(godot_pool_string_array *p_self, const godot_string *p_data);
 
 void GDAPI godot_pool_string_array_destroy(godot_pool_string_array *p_self);
 
@@ -316,6 +332,8 @@ void GDAPI godot_pool_vector2_array_remove(godot_pool_vector2_array *p_self, con
 
 void GDAPI godot_pool_vector2_array_resize(godot_pool_vector2_array *p_self, const godot_int p_size);
 
+void GDAPI godot_pool_vector2_array_sort(godot_pool_vector2_array *p_self);
+
 godot_pool_vector2_array_read_access GDAPI *godot_pool_vector2_array_read(const godot_pool_vector2_array *p_self);
 
 godot_pool_vector2_array_write_access GDAPI *godot_pool_vector2_array_write(godot_pool_vector2_array *p_self);
@@ -326,6 +344,8 @@ godot_vector2 GDAPI godot_pool_vector2_array_get(const godot_pool_vector2_array 
 godot_int GDAPI godot_pool_vector2_array_size(const godot_pool_vector2_array *p_self);
 
 godot_bool GDAPI godot_pool_vector2_array_empty(const godot_pool_vector2_array *p_self);
+
+godot_bool GDAPI godot_pool_vector2_array_has(godot_pool_vector2_array *p_self, const godot_vector2 *p_data);
 
 void GDAPI godot_pool_vector2_array_destroy(godot_pool_vector2_array *p_self);
 
@@ -349,6 +369,8 @@ void GDAPI godot_pool_vector3_array_remove(godot_pool_vector3_array *p_self, con
 
 void GDAPI godot_pool_vector3_array_resize(godot_pool_vector3_array *p_self, const godot_int p_size);
 
+void GDAPI godot_pool_vector3_array_sort(godot_pool_vector3_array *p_self);
+
 godot_pool_vector3_array_read_access GDAPI *godot_pool_vector3_array_read(const godot_pool_vector3_array *p_self);
 
 godot_pool_vector3_array_write_access GDAPI *godot_pool_vector3_array_write(godot_pool_vector3_array *p_self);
@@ -359,6 +381,8 @@ godot_vector3 GDAPI godot_pool_vector3_array_get(const godot_pool_vector3_array 
 godot_int GDAPI godot_pool_vector3_array_size(const godot_pool_vector3_array *p_self);
 
 godot_bool GDAPI godot_pool_vector3_array_empty(const godot_pool_vector3_array *p_self);
+
+godot_bool GDAPI godot_pool_vector3_array_has(godot_pool_vector3_array *p_self, const godot_vector3 *p_data);
 
 void GDAPI godot_pool_vector3_array_destroy(godot_pool_vector3_array *p_self);
 
@@ -382,6 +406,8 @@ void GDAPI godot_pool_color_array_remove(godot_pool_color_array *p_self, const g
 
 void GDAPI godot_pool_color_array_resize(godot_pool_color_array *p_self, const godot_int p_size);
 
+void GDAPI godot_pool_color_array_sort(godot_pool_color_array *p_self);
+
 godot_pool_color_array_read_access GDAPI *godot_pool_color_array_read(const godot_pool_color_array *p_self);
 
 godot_pool_color_array_write_access GDAPI *godot_pool_color_array_write(godot_pool_color_array *p_self);
@@ -392,6 +418,8 @@ godot_color GDAPI godot_pool_color_array_get(const godot_pool_color_array *p_sel
 godot_int GDAPI godot_pool_color_array_size(const godot_pool_color_array *p_self);
 
 godot_bool GDAPI godot_pool_color_array_empty(const godot_pool_color_array *p_self);
+
+godot_bool GDAPI godot_pool_color_array_has(godot_pool_color_array *p_self, const godot_color *p_data);
 
 void GDAPI godot_pool_color_array_destroy(godot_pool_color_array *p_self);
 


### PR DESCRIPTION
This is a backport from 4.0 to 3.x that adds 'sort' and 'has' methods to the following types in _GDScript_ and _GDNative_:
- `PoolByteArray`
- `PoolIntArray`
- `PoolRealArray`
- `PoolStringArray`
- `PoolVector2Array`
- `PoolVector3Array`
- `PoolColorArray`

The method `has` was already implemented in GDScript before (see #60856), so in this PR it has been only exposed to GDNative API.

The method `sort` is implemented using the existing class `Sorter`.

The both `has` and `sort` methods of the Pooled Array classes are exposed to the GDNative CORE API 1.3

The classes documentation is updated.


Pooled arrays in 4.0 are rewritten, that's why this backport is not completely identical to the original PR made for 4.0 (see #32144).

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/5202.*
