### PR TITLE
Fix link to the supported image formats in the Image class

### DIFF
--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -286,7 +286,7 @@
 			<return type="int" enum="Error" />
 			<argument index="0" name="path" type="String" />
 			<description>
-				Loads an image from file [code]path[/code]. See [url=$DOCS_URL/getting_started/workflow/assets/importing_images.html#supported-image-formats]Supported image formats[/url] for a list of supported image formats and limitations.
+				Loads an image from file [code]path[/code]. See [url=$DOCS_URL/tutorials/assets_pipeline/importing_images.html#supported-image-formats]Supported image formats[/url] for a list of supported image formats and limitations.
 				[b]Warning:[/b] This method should only be used in the editor or in cases when you need to load external images at run-time, such as images located at the [code]user://[/code] directory, and may not work in exported projects.
 				See also [ImageTexture] description for usage examples.
 			</description>


### PR DESCRIPTION
It previously linked to this [page](https://docs.godotengine.org/en/latest/getting_started/workflow/assets/importing_images.html#supported-image-formats) which doesn't exist. Now, it should link [here](https://docs.godotengine.org/en/latest/tutorials/assets_pipeline/importing_images.html#supported-image-formats).

I hope I did it the right way. I am assuming the correct workflow is to edit the class xml files in this repository and they automatically get synced with godot-docs?

This should also get cherry-picked to 3.x. I first encountered the issue in Godot 3.4.
