### PR TITLE
Patch `MultiplayerPeerExtension` to allow derived classes

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -199,7 +199,7 @@ void register_core_types() {
 	ResourceLoader::add_resource_format_loader(resource_format_loader_crypto);
 
 	GDREGISTER_VIRTUAL_CLASS(MultiplayerPeer);
-	GDREGISTER_VIRTUAL_CLASS(MultiplayerPeerExtension);
+	GDREGISTER_CLASS(MultiplayerPeerExtension);
 	GDREGISTER_VIRTUAL_CLASS(MultiplayerReplicator);
 	GDREGISTER_CLASS(MultiplayerAPI);
 	GDREGISTER_CLASS(MainLoop);


### PR DESCRIPTION
This registers `MultiplayerPeerExtension` as a base class instead of a virtual one.
It seems to fall in line with how `PacketPeerExtension` and `StreamPeerExtension` are registered in `register_core_types.cpp`.

I'm not very familiar with the new GDExtension system yet, but it seems that deriving any virtual class will lead to being unable to instantiate. This is a workaround for the `MultiplayerPeerExtension` class.

Fixes #55635.