### PR TITLE
Fix `EditorPlugin.remove_inspector_plugin()` instance cleanup

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2194,10 +2194,7 @@ void EditorInspector::remove_inspector_plugin(const Ref<EditorInspectorPlugin> &
 	for (int i = idx; i < inspector_plugin_count - 1; i++) {
 		inspector_plugins[i] = inspector_plugins[i + 1];
 	}
-
-	if (idx == inspector_plugin_count - 1) {
-		inspector_plugins[idx] = Ref<EditorInspectorPlugin>();
-	}
+	inspector_plugins[inspector_plugin_count - 1] = Ref<EditorInspectorPlugin>();
 
 	inspector_plugin_count--;
 }


### PR DESCRIPTION
Fixes #55648

https://github.com/godotengine/godot/blob/b8ebe3b0bfabab4790f94e7cc9bf2869746a0454/editor/editor_inspector.cpp#L2194-L2202

It's safe only if you remove inspector plugins in a LIFO fashion.

Since all elements after `idx` are moved forward by one, we should always unreference the last element in use.