### PR TITLE
Fix crash when `update()` is called inside `_draw()`

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -275,9 +275,6 @@ void CanvasItem::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			ERR_FAIL_COND(!is_inside_tree());
-			_update_texture_filter_changed(false);
-			_update_texture_repeat_changed(false);
-
 			first_draw = true;
 			Node *parent = get_parent();
 			if (parent) {
@@ -306,6 +303,10 @@ void CanvasItem::_notification(int p_what) {
 				}
 			}
 			_enter_canvas();
+
+			_update_texture_filter_changed(false);
+			_update_texture_repeat_changed(false);
+
 			if (!block_transform_notify && !xform_change.in_list()) {
 				get_tree()->xform_change_list.add(&xform_change);
 			}


### PR DESCRIPTION
Fixes #55645

The `_update_texture_*_changed()` functions are called before `_enter_canvas()`. This causes the message queue to grow indefinitely when flushing if `update()` is called inside `_draw()`.

---

* `_update_texture_*_changed()` functions will call `update()`, inserting a draw call if not pending.
* `_enter_canvas()` always force insert a draw call to the message queue.

This results in two draw calls in the message queue, which is unexpected.

`CanvasItem::pending_update` can prevent the first draw call from enqueueing another draw call. But it's set to `false` when the first draw call finished. So the second draw call is able to enqueue another one.

The message queue can't be modified when flushing, it only resets the queue size after consuming _all_ the messages. So doing something that calls `update()` in `_draw()` causes the message queue to grow indefinitely.

Godot crashes when trying to report exhausted message queue with `MessageQueue::statistics()`. Because previous handled messages are already destructed.