### PR TITLE
Unexpose joy_connection_changed method

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -103,7 +103,6 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_vector", "negative_x", "positive_x", "negative_y", "positive_y", "deadzone"), &Input::get_vector, DEFVAL(-1.0f));
 	ClassDB::bind_method(D_METHOD("add_joy_mapping", "mapping", "update_existing"), &Input::add_joy_mapping, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_joy_mapping", "guid"), &Input::remove_joy_mapping);
-	ClassDB::bind_method(D_METHOD("joy_connection_changed", "device", "connected", "name", "guid"), &Input::joy_connection_changed);
 	ClassDB::bind_method(D_METHOD("is_joy_known", "device"), &Input::is_joy_known);
 	ClassDB::bind_method(D_METHOD("get_joy_axis", "device", "axis"), &Input::get_joy_axis);
 	ClassDB::bind_method(D_METHOD("get_joy_name", "device"), &Input::get_joy_name);

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -243,17 +243,6 @@
 				Returns [code]true[/code] if you are pressing the key in the physical location on the 101/102-key US QWERTY keyboard. You can pass a [enum Key] constant.
 			</description>
 		</method>
-		<method name="joy_connection_changed">
-			<return type="void" />
-			<argument index="0" name="device" type="int" />
-			<argument index="1" name="connected" type="bool" />
-			<argument index="2" name="name" type="String" />
-			<argument index="3" name="guid" type="String" />
-			<description>
-				Notifies the [Input] singleton that a connection has changed, to update the state for the [code]device[/code] index.
-				This is used internally and should not have to be called from user scripts. See [signal joy_connection_changed] for the signal emitted when this is triggered internally.
-			</description>
-		</method>
 		<method name="parse_input_event">
 			<return type="void" />
 			<argument index="0" name="event" type="InputEvent" />


### PR DESCRIPTION
Part of #38937
The method isn't even called anywhere, so the binding is useless.