### PR TITLE
Rename minimum_size_changed() method

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -666,12 +666,6 @@
 				Returns [code]true[/code] if layout is right-to-left.
 			</description>
 		</method>
-		<method name="minimum_size_changed">
-			<return type="void" />
-			<description>
-				Invalidates the size cache in this node and in parent nodes up to top_level. Intended to be used with [method get_minimum_size] when the return value is changed. Setting [member rect_min_size] directly calls this method automatically.
-			</description>
-		</method>
 		<method name="release_focus">
 			<return type="void" />
 			<description>
@@ -931,6 +925,12 @@
 			<description>
 				Sets the size (see [member rect_size]).
 				If [code]keep_offsets[/code] is [code]true[/code], control's anchors will be updated instead of offsets.
+			</description>
+		</method>
+		<method name="update_minimum_size">
+			<return type="void" />
+			<description>
+				Invalidates the size cache in this node and in parent nodes up to top level. Intended to be used with [method get_minimum_size] when the return value is changed. Setting [member rect_min_size] directly calls this method automatically.
 			</description>
 		</method>
 		<method name="warp_mouse">

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3241,7 +3241,7 @@ void AnimationTrackEditGroup::set_type_and_name(const Ref<Texture2D> &p_type, co
 	node_name = p_name;
 	node = p_node;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 Size2 AnimationTrackEditGroup::get_minimum_size() const {

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1144,7 +1144,7 @@ void EditorInspectorSection::_test_unfold() {
 void EditorInspectorSection::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			minimum_size_changed();
+			update_minimum_size();
 		} break;
 		case NOTIFICATION_SORT_CHILDREN: {
 			if (!vbox_added) {
@@ -1995,7 +1995,7 @@ void EditorInspectorArray::_notification(int p_what) {
 			prev_page_button->set_icon(get_theme_icon(SNAME("PagePrevious"), SNAME("EditorIcons")));
 			next_page_button->set_icon(get_theme_icon(SNAME("PageNext"), SNAME("EditorIcons")));
 			last_page_button->set_icon(get_theme_icon(SNAME("PageLast"), SNAME("EditorIcons")));
-			minimum_size_changed();
+			update_minimum_size();
 		} break;
 		case NOTIFICATION_DRAG_BEGIN: {
 			Dictionary dict = get_viewport()->gui_get_drag_data();

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -832,7 +832,7 @@ public:
 				update();
 			} else if (expand_hovered) {
 				expanded = !expanded;
-				minimum_size_changed();
+				update_minimum_size();
 				update();
 			}
 		}
@@ -935,7 +935,7 @@ public:
 				}
 
 				if ((expansion_rows != prev_expansion_rows) && expanded) {
-					minimum_size_changed();
+					update_minimum_size();
 				}
 
 				if ((expansion_rows == 0) && (layer_index == layer_count)) {

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -47,7 +47,7 @@ void ThemeEditorPreview::add_preview_overlay(Control *p_overlay) {
 
 void ThemeEditorPreview::_propagate_redraw(Control *p_at) {
 	p_at->notification(NOTIFICATION_THEME_CHANGED);
-	p_at->minimum_size_changed();
+	p_at->update_minimum_size();
 	p_at->update();
 	for (int i = 0; i < p_at->get_child_count(); i++) {
 		Control *a = Object::cast_to<Control>(p_at->get_child(i));

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -295,7 +295,7 @@ void BoxContainer::_notification(int p_what) {
 			_resort();
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
-			minimum_size_changed();
+			update_minimum_size();
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -82,13 +82,13 @@ void Button::_notification(int p_what) {
 			xl_text = atr(text);
 			_shape();
 
-			minimum_size_changed();
+			update_minimum_size();
 			update();
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			_shape();
 
-			minimum_size_changed();
+			update_minimum_size();
 			update();
 		} break;
 		case NOTIFICATION_DRAW: {
@@ -368,7 +368,7 @@ void Button::set_text(const String &p_text) {
 		_shape();
 
 		update();
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 
@@ -428,7 +428,7 @@ void Button::set_icon(const Ref<Texture2D> &p_icon) {
 	if (icon != p_icon) {
 		icon = p_icon;
 		update();
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 
@@ -440,7 +440,7 @@ void Button::set_expand_icon(bool p_enabled) {
 	if (expand_icon != p_enabled) {
 		expand_icon = p_enabled;
 		update();
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 
@@ -463,7 +463,7 @@ void Button::set_clip_text(bool p_enabled) {
 	if (clip_text != p_enabled) {
 		clip_text = p_enabled;
 		update();
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 
@@ -484,7 +484,7 @@ Button::TextAlign Button::get_text_align() const {
 
 void Button::set_icon_align(TextAlign p_align) {
 	icon_align = p_align;
-	minimum_size_changed();
+	update_minimum_size();
 	update();
 }
 

--- a/scene/gui/center_container.cpp
+++ b/scene/gui/center_container.cpp
@@ -61,7 +61,7 @@ void CenterContainer::set_use_top_left(bool p_enable) {
 
 	use_top_left = p_enable;
 
-	minimum_size_changed();
+	update_minimum_size();
 	queue_sort();
 }
 

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -35,7 +35,7 @@
 void Container::_child_minsize_changed() {
 	//Size2 ms = get_combined_minimum_size();
 	//if (ms.width > get_size().width || ms.height > get_size().height) {
-	minimum_size_changed();
+	update_minimum_size();
 	queue_sort();
 }
 
@@ -51,7 +51,7 @@ void Container::add_child_notify(Node *p_child) {
 	control->connect(SNAME("minimum_size_changed"), callable_mp(this, &Container::_child_minsize_changed));
 	control->connect(SNAME("visibility_changed"), callable_mp(this, &Container::_child_minsize_changed));
 
-	minimum_size_changed();
+	update_minimum_size();
 	queue_sort();
 }
 
@@ -62,7 +62,7 @@ void Container::move_child_notify(Node *p_child) {
 		return;
 	}
 
-	minimum_size_changed();
+	update_minimum_size();
 	queue_sort();
 }
 
@@ -78,7 +78,7 @@ void Container::remove_child_notify(Node *p_child) {
 	control->disconnect("minimum_size_changed", callable_mp(this, &Container::_child_minsize_changed));
 	control->disconnect("visibility_changed", callable_mp(this, &Container::_child_minsize_changed));
 
-	minimum_size_changed();
+	update_minimum_size();
 	queue_sort();
 }
 

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -192,7 +192,7 @@ void Control::set_custom_minimum_size(const Size2 &p_custom) {
 		return;
 	}
 	data.custom_minimum_size = p_custom;
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 Size2 Control::get_custom_minimum_size() const {
@@ -213,7 +213,7 @@ void Control::_update_minimum_size_cache() {
 	data.minimum_size_valid = true;
 
 	if (size_changed) {
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 
@@ -713,7 +713,7 @@ void Control::_notification(int p_notification) {
 			update();
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
-			minimum_size_changed();
+			update_minimum_size();
 			update();
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -2534,7 +2534,7 @@ void Control::grab_click_focus() {
 	get_viewport()->_gui_grab_click_focus(this);
 }
 
-void Control::minimum_size_changed() {
+void Control::update_minimum_size() {
 	if (!is_inside_tree() || data.block_minimum_size_adjust) {
 		return;
 	}
@@ -2696,7 +2696,7 @@ real_t Control::get_rotation() const {
 void Control::_override_changed() {
 	notification(NOTIFICATION_THEME_CHANGED);
 	emit_signal(SceneStringNames::get_singleton()->theme_changed);
-	minimum_size_changed(); // overrides are likely to affect minimum size
+	update_minimum_size(); // Overrides are likely to affect minimum size.
 }
 
 void Control::set_pivot_offset(const Vector2 &p_pivot) {
@@ -2977,7 +2977,7 @@ void Control::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("warp_mouse", "to_position"), &Control::warp_mouse);
 
-	ClassDB::bind_method(D_METHOD("minimum_size_changed"), &Control::minimum_size_changed);
+	ClassDB::bind_method(D_METHOD("update_minimum_size"), &Control::update_minimum_size);
 
 	ClassDB::bind_method(D_METHOD("set_layout_direction", "direction"), &Control::set_layout_direction);
 	ClassDB::bind_method(D_METHOD("get_layout_direction"), &Control::get_layout_direction);

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -441,7 +441,7 @@ public:
 	void set_stretch_ratio(real_t p_ratio);
 	real_t get_stretch_ratio() const;
 
-	void minimum_size_changed();
+	void update_minimum_size();
 
 	/* FOCUS */
 

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -442,7 +442,7 @@ void GraphNode::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			_shape();
 
-			minimum_size_changed();
+			update_minimum_size();
 			update();
 		} break;
 	}
@@ -666,7 +666,7 @@ void GraphNode::set_title(const String &p_title) {
 	_shape();
 
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 String GraphNode::get_title() const {

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -182,7 +182,7 @@ void GridContainer::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
-			minimum_size_changed();
+			update_minimum_size();
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
@@ -195,7 +195,7 @@ void GridContainer::set_columns(int p_columns) {
 	ERR_FAIL_COND(p_columns < 1);
 	columns = p_columns;
 	queue_sort();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 int GridContainer::get_columns() const {

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1037,7 +1037,7 @@ void ItemList::_notification(int p_what) {
 				}
 			}
 
-			minimum_size_changed();
+			update_minimum_size();
 			shape_changed = false;
 		}
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -44,7 +44,7 @@ void Label::set_autowrap_mode(Label::AutowrapMode p_mode) {
 	update();
 
 	if (clip || overrun_behavior != OVERRUN_NO_TRIMMING) {
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 
@@ -207,7 +207,7 @@ void Label::_shape() {
 	_update_visible();
 
 	if (autowrap_mode == AUTOWRAP_OFF || !clip || overrun_behavior == OVERRUN_NO_TRIMMING) {
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 
@@ -592,7 +592,7 @@ void Label::set_text(const String &p_string) {
 		visible_chars = get_total_character_count() * percent_visible;
 	}
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 void Label::set_text_direction(Control::TextDirection p_text_direction) {
@@ -668,7 +668,7 @@ String Label::get_language() const {
 void Label::set_clip_text(bool p_clip) {
 	clip = p_clip;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 bool Label::is_clipping_text() const {
@@ -682,7 +682,7 @@ void Label::set_text_overrun_behavior(Label::OverrunBehavior p_behavior) {
 	}
 	update();
 	if (clip || overrun_behavior != OVERRUN_NO_TRIMMING) {
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1718,7 +1718,7 @@ void LineEdit::set_editable(bool p_editable) {
 
 	editable = p_editable;
 
-	minimum_size_changed();
+	update_minimum_size();
 	update();
 }
 
@@ -1948,7 +1948,7 @@ void LineEdit::_editor_settings_changed() {
 
 void LineEdit::set_expand_to_text_length_enabled(bool p_enabled) {
 	expand_to_text_length = p_enabled;
-	minimum_size_changed();
+	update_minimum_size();
 	set_caret_column(caret_column);
 }
 
@@ -1962,7 +1962,7 @@ void LineEdit::set_clear_button_enabled(bool p_enabled) {
 	}
 	clear_button_enabled = p_enabled;
 	_fit_to_width();
-	minimum_size_changed();
+	update_minimum_size();
 	update();
 }
 
@@ -2023,7 +2023,7 @@ void LineEdit::set_right_icon(const Ref<Texture2D> &p_icon) {
 	}
 	right_icon = p_icon;
 	_fit_to_width();
-	minimum_size_changed();
+	update_minimum_size();
 	update();
 }
 
@@ -2087,7 +2087,7 @@ void LineEdit::_shape() {
 	Size2 size = TS->shaped_text_get_size(text_rid);
 
 	if ((expand_to_text_length && old_size.x != size.x) || (old_size.y != size.y)) {
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -52,7 +52,7 @@ void LinkButton::set_text(const String &p_text) {
 	text = p_text;
 	xl_text = atr(text);
 	_shape();
-	minimum_size_changed();
+	update_minimum_size();
 	update();
 }
 
@@ -149,7 +149,7 @@ void LinkButton::_notification(int p_what) {
 			xl_text = atr(text);
 			_shape();
 
-			minimum_size_changed();
+			update_minimum_size();
 			update();
 		} break;
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
@@ -157,7 +157,7 @@ void LinkButton::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
 			_shape();
-			minimum_size_changed();
+			update_minimum_size();
 			update();
 		} break;
 		case NOTIFICATION_DRAW: {

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -90,7 +90,7 @@ void MarginContainer::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
-			minimum_size_changed();
+			update_minimum_size();
 		} break;
 	}
 }

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -97,7 +97,7 @@ void NinePatchRect::set_texture(const Ref<Texture2D> &p_tex) {
 	if (texture.is_valid())
 		texture->set_flags(texture->get_flags()&(~Texture::FLAG_REPEAT)); //remove repeat from texture, it looks bad in sprites
 	*/
-	minimum_size_changed();
+	update_minimum_size();
 	emit_signal(SceneStringNames::get_singleton()->texture_changed);
 }
 
@@ -109,7 +109,7 @@ void NinePatchRect::set_patch_margin(Side p_side, int p_size) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 	margin[p_side] = p_size;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 int NinePatchRect::get_patch_margin(Side p_side) const {

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2190,7 +2190,7 @@ void RichTextLabel::_validate_line_caches(ItemFrame *p_frame) {
 		updating_scroll = false;
 
 		if (fit_content_height) {
-			minimum_size_changed();
+			update_minimum_size();
 		}
 		return;
 	}
@@ -2227,7 +2227,7 @@ void RichTextLabel::_validate_line_caches(ItemFrame *p_frame) {
 	updating_scroll = false;
 
 	if (fit_content_height) {
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 
@@ -2324,7 +2324,7 @@ void RichTextLabel::_add_item(Item *p_item, bool p_enter, bool p_ensure_newline)
 	_invalidate_current_line(current_frame);
 
 	if (fixed_width != -1) {
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 
@@ -2755,7 +2755,7 @@ void RichTextLabel::clear() {
 	}
 
 	if (fixed_width != -1) {
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 
@@ -2772,7 +2772,7 @@ int RichTextLabel::get_tab_size() const {
 void RichTextLabel::set_fit_content_height(bool p_enabled) {
 	if (p_enabled != fit_content_height) {
 		fit_content_height = p_enabled;
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 
@@ -4268,7 +4268,7 @@ int RichTextLabel::get_total_character_count() const {
 
 void RichTextLabel::set_fixed_size_to_width(int p_width) {
 	fixed_width = p_width;
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 Size2 RichTextLabel::get_minimum_size() const {

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -467,7 +467,7 @@ void ScrollContainer::set_enable_h_scroll(bool p_enable) {
 	}
 
 	scroll_h = p_enable;
-	minimum_size_changed();
+	update_minimum_size();
 	queue_sort();
 }
 
@@ -481,7 +481,7 @@ void ScrollContainer::set_enable_v_scroll(bool p_enable) {
 	}
 
 	scroll_v = p_enable;
-	minimum_size_changed();
+	update_minimum_size();
 	queue_sort();
 }
 

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -142,7 +142,7 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 void Slider::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
-			minimum_size_changed();
+			update_minimum_size();
 			update();
 		} break;
 		case NOTIFICATION_MOUSE_ENTER: {

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -220,8 +220,8 @@ void SpinBox::_notification(int p_what) {
 	} else if (p_what == NOTIFICATION_TRANSLATION_CHANGED) {
 		_value_changed(0);
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
-		call_deferred(SNAME("minimum_size_changed"));
-		get_line_edit()->call_deferred(SNAME("minimum_size_changed"));
+		call_deferred(SNAME("update_minimum_size"));
+		get_line_edit()->call_deferred(SNAME("update_minimum_size"));
 	} else if (p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED || p_what == NOTIFICATION_TRANSLATION_CHANGED) {
 		update();
 	}

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -201,7 +201,7 @@ void SplitContainer::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
-			minimum_size_changed();
+			update_minimum_size();
 		} break;
 	}
 }

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -285,7 +285,7 @@ void TabBar::_notification(int p_what) {
 				_shape(i);
 			}
 			_update_cache();
-			minimum_size_changed();
+			update_minimum_size();
 			update();
 		} break;
 		case NOTIFICATION_RESIZED: {
@@ -554,7 +554,7 @@ void TabBar::set_tab_title(int p_tab, const String &p_title) {
 	tabs.write[p_tab].text = p_title;
 	_shape(p_tab);
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 String TabBar::get_tab_title(int p_tab) const {
@@ -621,7 +621,7 @@ void TabBar::set_tab_icon(int p_tab, const Ref<Texture2D> &p_icon) {
 	ERR_FAIL_INDEX(p_tab, tabs.size());
 	tabs.write[p_tab].icon = p_icon;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 Ref<Texture2D> TabBar::get_tab_icon(int p_tab) const {
@@ -645,7 +645,7 @@ void TabBar::set_tab_right_button(int p_tab, const Ref<Texture2D> &p_right_butto
 	tabs.write[p_tab].right_button = p_right_button;
 	_update_cache();
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 Ref<Texture2D> TabBar::get_tab_right_button(int p_tab) const {
@@ -777,7 +777,7 @@ void TabBar::add_tab(const String &p_str, const Ref<Texture2D> &p_icon) {
 	_update_cache();
 	call_deferred(SNAME("_update_hover"));
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 void TabBar::clear_tabs() {
@@ -797,7 +797,7 @@ void TabBar::remove_tab(int p_idx) {
 	_update_cache();
 	call_deferred(SNAME("_update_hover"));
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 
 	if (current < 0) {
 		current = 0;
@@ -945,7 +945,7 @@ void TabBar::set_clip_tabs(bool p_clip_tabs) {
 	}
 	clip_tabs = p_clip_tabs;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 bool TabBar::get_clip_tabs() const {

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -600,7 +600,7 @@ void TabContainer::_on_theme_changed() {
 
 	_refresh_texts();
 
-	minimum_size_changed();
+	update_minimum_size();
 	if (get_tab_count() > 0) {
 		_repaint();
 		update();
@@ -995,7 +995,7 @@ void TabContainer::set_tabs_visible(bool p_visible) {
 	}
 
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 bool TabContainer::are_tabs_visible() const {

--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -289,19 +289,19 @@ void TextureButton::_bind_methods() {
 void TextureButton::set_normal_texture(const Ref<Texture2D> &p_normal) {
 	normal = p_normal;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 void TextureButton::set_pressed_texture(const Ref<Texture2D> &p_pressed) {
 	pressed = p_pressed;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 void TextureButton::set_hover_texture(const Ref<Texture2D> &p_hover) {
 	hover = p_hover;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 void TextureButton::set_disabled_texture(const Ref<Texture2D> &p_disabled) {
@@ -312,7 +312,7 @@ void TextureButton::set_disabled_texture(const Ref<Texture2D> &p_disabled) {
 void TextureButton::set_click_mask(const Ref<BitMap> &p_click_mask) {
 	click_mask = p_click_mask;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 Ref<Texture2D> TextureButton::get_normal_texture() const {
@@ -349,7 +349,7 @@ bool TextureButton::get_expand() const {
 
 void TextureButton::set_expand(bool p_expand) {
 	expand = p_expand;
-	minimum_size_changed();
+	update_minimum_size();
 	update();
 }
 

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -35,7 +35,7 @@
 void TextureProgressBar::set_under_texture(const Ref<Texture2D> &p_texture) {
 	under = p_texture;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 Ref<Texture2D> TextureProgressBar::get_under_texture() const {
@@ -46,7 +46,7 @@ void TextureProgressBar::set_over_texture(const Ref<Texture2D> &p_texture) {
 	over = p_texture;
 	update();
 	if (under.is_null()) {
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 
@@ -58,7 +58,7 @@ void TextureProgressBar::set_stretch_margin(Side p_side, int p_size) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 	stretch_margin[p_side] = p_size;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 int TextureProgressBar::get_stretch_margin(Side p_side) const {
@@ -69,7 +69,7 @@ int TextureProgressBar::get_stretch_margin(Side p_side) const {
 void TextureProgressBar::set_nine_patch_stretch(bool p_stretch) {
 	nine_patch_stretch = p_stretch;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 bool TextureProgressBar::get_nine_patch_stretch() const {
@@ -93,7 +93,7 @@ Size2 TextureProgressBar::get_minimum_size() const {
 void TextureProgressBar::set_progress_texture(const Ref<Texture2D> &p_texture) {
 	progress = p_texture;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 Ref<Texture2D> TextureProgressBar::get_progress_texture() const {

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -152,7 +152,7 @@ void TextureRect::_bind_methods() {
 void TextureRect::_texture_changed() {
 	if (texture.is_valid()) {
 		update();
-		minimum_size_changed();
+		update_minimum_size();
 	}
 }
 
@@ -172,7 +172,7 @@ void TextureRect::set_texture(const Ref<Texture2D> &p_tex) {
 	}
 
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 Ref<Texture2D> TextureRect::get_texture() const {
@@ -182,7 +182,7 @@ Ref<Texture2D> TextureRect::get_texture() const {
 void TextureRect::set_expand(bool p_expand) {
 	expand = p_expand;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 bool TextureRect::has_expand() const {

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4370,7 +4370,7 @@ void Tree::scroll_to_item(TreeItem *p_item) {
 
 void Tree::set_h_scroll_enabled(bool p_enable) {
 	h_scroll_enabled = p_enable;
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 bool Tree::is_h_scroll_enabled() const {
@@ -4379,7 +4379,7 @@ bool Tree::is_h_scroll_enabled() const {
 
 void Tree::set_v_scroll_enabled(bool p_enable) {
 	v_scroll_enabled = p_enable;
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 bool Tree::is_v_scroll_enabled() const {

--- a/scene/gui/video_player.cpp
+++ b/scene/gui/video_player.cpp
@@ -191,7 +191,7 @@ Size2 VideoPlayer::get_minimum_size() const {
 void VideoPlayer::set_expand(bool p_expand) {
 	expand = p_expand;
 	update();
-	minimum_size_changed();
+	update_minimum_size();
 }
 
 bool VideoPlayer::has_expand() const {
@@ -241,7 +241,7 @@ void VideoPlayer::set_stream(const Ref<VideoStream> &p_stream) {
 	update();
 
 	if (!expand) {
-		minimum_size_changed();
+		update_minimum_size();
 	}
 };
 


### PR DESCRIPTION
Part of #38937
The new name, `update_minimum_size()`, is consistent with internal method `_update_minimum_size()`.