### PR TITLE
[3.x] Fix incorrect RID cleanup in Rasterizers

### DIFF
--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -537,5 +537,8 @@ RasterizerGLES2::RasterizerGLES2() {
 RasterizerGLES2::~RasterizerGLES2() {
 	memdelete(scene);
 	memdelete(canvas);
+
+	// Storage needs to be deleted after canvas as canvas destructor frees RIDs
+	// stored in storage RID owners.
 	memdelete(storage);
 }

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -4077,3 +4077,28 @@ void RasterizerSceneGLES2::finalize() {
 RasterizerSceneGLES2::RasterizerSceneGLES2() {
 	_light_counter = 0;
 }
+
+RasterizerSceneGLES2::~RasterizerSceneGLES2() {
+	storage->free(default_material);
+	default_material = RID();
+	storage->free(default_material_twosided);
+	default_material_twosided = RID();
+	storage->free(default_shader);
+	default_shader = RID();
+	storage->free(default_shader_twosided);
+	default_shader_twosided = RID();
+
+	storage->free(default_worldcoord_material);
+	default_worldcoord_material = RID();
+	storage->free(default_worldcoord_material_twosided);
+	default_worldcoord_material_twosided = RID();
+	storage->free(default_worldcoord_shader);
+	default_worldcoord_shader = RID();
+	storage->free(default_worldcoord_shader_twosided);
+	default_worldcoord_shader_twosided = RID();
+
+	storage->free(default_overdraw_material);
+	default_overdraw_material = RID();
+	storage->free(default_overdraw_shader);
+	default_overdraw_shader = RID();
+}

--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -773,6 +773,7 @@ public:
 	void initialize();
 	void finalize();
 	RasterizerSceneGLES2();
+	~RasterizerSceneGLES2();
 };
 
 #endif // RASTERIZERSCENEGLES2_H

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -499,5 +499,8 @@ RasterizerGLES3::RasterizerGLES3() {
 RasterizerGLES3::~RasterizerGLES3() {
 	memdelete(scene);
 	memdelete(canvas);
+
+	// storage must be deleted last,
+	// because it contains RID_owners that are used by scene and canvas destructors
 	memdelete(storage);
 }

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -5282,18 +5282,28 @@ RasterizerSceneGLES3::RasterizerSceneGLES3() {
 }
 
 RasterizerSceneGLES3::~RasterizerSceneGLES3() {
-	memdelete(storage->material_owner.getptr(default_material));
-	memdelete(storage->material_owner.getptr(default_material_twosided));
-	memdelete(storage->shader_owner.getptr(default_shader));
-	memdelete(storage->shader_owner.getptr(default_shader_twosided));
+	storage->free(default_material);
+	default_material = RID();
+	storage->free(default_material_twosided);
+	default_material_twosided = RID();
+	storage->free(default_shader);
+	default_shader = RID();
+	storage->free(default_shader_twosided);
+	default_shader_twosided = RID();
 
-	memdelete(storage->material_owner.getptr(default_worldcoord_material));
-	memdelete(storage->material_owner.getptr(default_worldcoord_material_twosided));
-	memdelete(storage->shader_owner.getptr(default_worldcoord_shader));
-	memdelete(storage->shader_owner.getptr(default_worldcoord_shader_twosided));
+	storage->free(default_worldcoord_material);
+	default_worldcoord_material = RID();
+	storage->free(default_worldcoord_material_twosided);
+	default_worldcoord_material_twosided = RID();
+	storage->free(default_worldcoord_shader);
+	default_worldcoord_shader = RID();
+	storage->free(default_worldcoord_shader_twosided);
+	default_worldcoord_shader_twosided = RID();
 
-	memdelete(storage->material_owner.getptr(default_overdraw_material));
-	memdelete(storage->shader_owner.getptr(default_overdraw_shader));
+	storage->free(default_overdraw_material);
+	default_overdraw_material = RID();
+	storage->free(default_overdraw_shader);
+	default_overdraw_shader = RID();
 
 	memfree(state.spot_array_tmp);
 	memfree(state.omni_array_tmp);


### PR DESCRIPTION
Proper cleanup for GLES3 RIDs (preventing leak reports), and added missing destructor for RasterizerSceneGLES2.

## Notes
* Followup to #54907
* There was previously no cleanup for RasterizerSceneGLES2(!)
* RasterizerSceneGLES2 destructor is not complete but its a start, and prevents the RID leaks.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
