### PR TITLE
[3.4] Cutdown version of RID fixes to sync with 3.5 RID handles

### DIFF
--- a/drivers/gles2/rasterizer_gles2.cpp
+++ b/drivers/gles2/rasterizer_gles2.cpp
@@ -535,6 +535,7 @@ RasterizerGLES2::RasterizerGLES2() {
 }
 
 RasterizerGLES2::~RasterizerGLES2() {
-	memdelete(storage);
+	memdelete(scene);
 	memdelete(canvas);
+	memdelete(storage);
 }

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -396,7 +396,7 @@ void RasterizerCanvasGLES3::_legacy_canvas_render_item(Item *p_ci, RenderItemSta
 					}
 				}
 
-				glBindBufferBase(GL_UNIFORM_BUFFER, 1, static_cast<LightInternal *>(light->light_internal.get_data())->ubo);
+				glBindBufferBase(GL_UNIFORM_BUFFER, 1, static_cast<LightInternal *>(light_internal_owner.get(light->light_internal))->ubo);
 
 				if (has_shadow) {
 					RasterizerStorageGLES3::CanvasLightShadow *cls = storage->canvas_light_shadow_owner.get(light->shadow_buffer);
@@ -1500,7 +1500,7 @@ void RasterizerCanvasGLES3::render_joined_item(const BItemJoined &p_bij, RenderI
 					}
 				}
 
-				glBindBufferBase(GL_UNIFORM_BUFFER, 1, static_cast<LightInternal *>(light->light_internal.get_data())->ubo);
+				glBindBufferBase(GL_UNIFORM_BUFFER, 1, static_cast<LightInternal *>(light_internal_owner.get(light->light_internal))->ubo);
 
 				if (has_shadow) {
 					RasterizerStorageGLES3::CanvasLightShadow *cls = storage->canvas_light_shadow_owner.get(light->shadow_buffer);

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -490,7 +490,7 @@ RasterizerGLES3::RasterizerGLES3() {
 }
 
 RasterizerGLES3::~RasterizerGLES3() {
-	memdelete(storage);
-	memdelete(canvas);
 	memdelete(scene);
+	memdelete(canvas);
+	memdelete(storage);
 }

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -5256,18 +5256,18 @@ RasterizerSceneGLES3::RasterizerSceneGLES3() {
 }
 
 RasterizerSceneGLES3::~RasterizerSceneGLES3() {
-	memdelete(default_material.get_data());
-	memdelete(default_material_twosided.get_data());
-	memdelete(default_shader.get_data());
-	memdelete(default_shader_twosided.get_data());
+	memdelete(storage->material_owner.getptr(default_material));
+	memdelete(storage->material_owner.getptr(default_material_twosided));
+	memdelete(storage->shader_owner.getptr(default_shader));
+	memdelete(storage->shader_owner.getptr(default_shader_twosided));
 
-	memdelete(default_worldcoord_material.get_data());
-	memdelete(default_worldcoord_material_twosided.get_data());
-	memdelete(default_worldcoord_shader.get_data());
-	memdelete(default_worldcoord_shader_twosided.get_data());
+	memdelete(storage->material_owner.getptr(default_worldcoord_material));
+	memdelete(storage->material_owner.getptr(default_worldcoord_material_twosided));
+	memdelete(storage->shader_owner.getptr(default_worldcoord_shader));
+	memdelete(storage->shader_owner.getptr(default_worldcoord_shader_twosided));
 
-	memdelete(default_overdraw_material.get_data());
-	memdelete(default_overdraw_shader.get_data());
+	memdelete(storage->material_owner.getptr(default_overdraw_material));
+	memdelete(storage->shader_owner.getptr(default_overdraw_shader));
 
 	memfree(state.spot_array_tmp);
 	memfree(state.omni_array_tmp);


### PR DESCRIPTION
The RID Handles PR introduced a couple of bug fixes, they are added here without the RID handles functionality in order to keep 3.4 and 3.x roughly in sync, allowing further fixes to RID lifetimes to be backported.

## Notes
* See #54907 for the full RID handles PR, this is just the RID fixes part of that PR.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
