### PR TITLE
Rename C# `Quaternion()` -> `GetQuaternion()`

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Quaternion.cs
@@ -377,7 +377,7 @@ namespace Godot
         /// <param name="basis">The <see cref="Basis"/> to construct from.</param>
         public Quaternion(Basis basis)
         {
-            this = basis.Quaternion();
+            this = basis.GetQuaternion();
         }
 
         /// <summary>


### PR DESCRIPTION
As described in https://github.com/godotengine/godot/pull/55672#discussion_r763205951:

- The method `Quaternion()` was renamed to `GetQuaternion()` like in GDScript.
- ~The method is kept **public** like in C++, but since it's not exposed to GDScript we could make it **private**/**internal** instead.~ (The method was made **internal**. See https://github.com/godotengine/godot/pull/55675#discussion_r763296815)

Kind of a follow-up to #51008 since that one renames `RotationQuaternion()` to `GetRotationQuaternion()`.