### PR TITLE
Added material preview window to a shader/visual shader

### DIFF
--- a/editor/plugins/material_editor_plugin.h
+++ b/editor/plugins/material_editor_plugin.h
@@ -39,12 +39,15 @@
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
+#include "scene/gui/color_rect.h"
+#include "scene/main/window.h"
 #include "scene/resources/material.h"
 
 class SubViewportContainer;
 
 class MaterialEditor : public Control {
 	GDCLASS(MaterialEditor, Control);
+	ColorRect *rect_instance;
 
 	SubViewportContainer *vc;
 	SubViewport *viewport;
@@ -57,9 +60,11 @@ class MaterialEditor : public Control {
 	Ref<SphereMesh> sphere_mesh;
 	Ref<BoxMesh> box_mesh;
 
+	VBoxContainer *vb_shape;
 	TextureButton *sphere_switch;
 	TextureButton *box_switch;
 
+	VBoxContainer *vb_light;
 	TextureButton *light_1_switch;
 	TextureButton *light_2_switch;
 
@@ -76,6 +81,31 @@ protected:
 public:
 	void edit(Ref<Material> p_material, const Ref<Environment> &p_env);
 	MaterialEditor();
+};
+
+class MaterialEditorPreview : public Window {
+	GDCLASS(MaterialEditorPreview, Window);
+
+	MaterialEditor *editor = nullptr;
+	bool is_first_open = true;
+	bool is_open = false;
+
+	Button *open_button = nullptr;
+	Ref<ShaderMaterial> material_preview;
+	Ref<Environment> material_env;
+	Ref<Shader> shader;
+
+	void _open_button_pressed();
+
+protected:
+	void _notification(int p_what);
+
+public:
+	void set_shader(Ref<Shader> &p_shader);
+	void register_open_button(Button *p_button);
+
+public:
+	MaterialEditorPreview();
 };
 
 class EditorInspectorPluginMaterial : public EditorInspectorPlugin {

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -394,8 +394,15 @@ void ShaderEditor::_menu_option(int p_option) {
 }
 
 void ShaderEditor::_notification(int p_what) {
-	if (p_what == NOTIFICATION_WM_WINDOW_FOCUS_IN) {
-		_check_for_external_edit();
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+			[[fallthrough]];
+		case NOTIFICATION_THEME_CHANGED: {
+			material_preview_button->set_icon(Control::get_theme_icon(SNAME("SubViewport"), SNAME("EditorIcons")));
+		} break;
+		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
+			_check_for_external_edit();
+		} break;
 	}
 }
 
@@ -545,6 +552,7 @@ void ShaderEditor::apply_shaders() {
 		if (shader_code != editor_code) {
 			shader->set_code(editor_code);
 			shader->set_edited(true);
+			material_preview_window->set_shader(shader);
 		}
 	}
 }
@@ -742,13 +750,24 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	help_menu->get_popup()->add_icon_item(p_node->get_gui_base()->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), TTR("Online Docs"), HELP_DOCS);
 	help_menu->get_popup()->connect("id_pressed", callable_mp(this, &ShaderEditor::_menu_option));
 
+	material_preview_button = memnew(Button);
+	material_preview_button->set_flat(true);
+	material_preview_button->set_toggle_mode(true);
+	material_preview_button->set_tooltip(TTR("Show material preview."));
+
 	add_child(main_container);
 	main_container->add_child(hbc);
 	hbc->add_child(search_menu);
 	hbc->add_child(edit_menu);
 	hbc->add_child(goto_menu);
 	hbc->add_child(help_menu);
+	hbc->add_spacer();
+	hbc->add_child(material_preview_button);
 	hbc->add_theme_style_override("panel", p_node->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditorPanel"), SNAME("EditorStyles")));
+
+	material_preview_window = memnew(MaterialEditorPreview);
+	material_preview_window->register_open_button(material_preview_button);
+	add_child(material_preview_window);
 
 	VSplitContainer *editor_box = memnew(VSplitContainer);
 	main_container->add_child(editor_box);

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -33,6 +33,7 @@
 
 #include "editor/code_editor.h"
 #include "editor/editor_plugin.h"
+#include "editor/plugins/material_editor_plugin.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/rich_text_label.h"
@@ -110,6 +111,7 @@ class ShaderEditor : public PanelContainer {
 	MenuButton *search_menu;
 	PopupMenu *bookmarks_menu;
 	MenuButton *help_menu;
+	Button *material_preview_button = nullptr;
 	PopupMenu *context_menu;
 	RichTextLabel *warnings_panel = nullptr;
 	uint64_t idle;
@@ -117,6 +119,8 @@ class ShaderEditor : public PanelContainer {
 	GotoLineDialog *goto_line_dialog;
 	ConfirmationDialog *erase_tab_confirm;
 	ConfirmationDialog *disk_changed;
+
+	MaterialEditorPreview *material_preview_window = nullptr;
 
 	ShaderTextEditor *shader_editor;
 

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -34,6 +34,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_plugin.h"
 #include "editor/plugins/curve_editor_plugin.h"
+#include "editor/plugins/material_editor_plugin.h"
 #include "editor/property_editor.h"
 #include "scene/gui/button.h"
 #include "scene/gui/graph_edit.h"
@@ -138,7 +139,8 @@ class VisualShaderEditor : public VBoxContainer {
 	Ref<VisualShader> visual_shader;
 	GraphEdit *graph;
 	Button *add_node;
-	Button *preview_shader;
+	Button *shader_preview_button;
+	Button *material_preview_button;
 
 	OptionButton *edit_type = nullptr;
 	OptionButton *edit_type_standard;
@@ -150,12 +152,14 @@ class VisualShaderEditor : public VBoxContainer {
 
 	bool pending_update_preview;
 	bool shader_error;
-	Window *preview_window;
-	VBoxContainer *preview_vbox;
-	CodeEdit *preview_text;
+	Window *shader_preview_window = nullptr;
+	VBoxContainer *shader_preview_vbox = nullptr;
+	CodeEdit *shader_preview_text = nullptr;
 	Ref<CodeHighlighter> syntax_highlighter;
-	PanelContainer *error_panel;
-	Label *error_label;
+	PanelContainer *shader_error_panel = nullptr;
+	Label *shader_error_label = nullptr;
+
+	MaterialEditorPreview *material_preview_window = nullptr;
 
 	UndoRedo *undo_redo;
 	Point2 saved_node_pos;
@@ -174,8 +178,8 @@ class VisualShaderEditor : public VBoxContainer {
 	PopupPanel *comment_desc_change_popup = nullptr;
 	TextEdit *comment_desc_change_edit = nullptr;
 
-	bool preview_first = true;
-	bool preview_showed = false;
+	bool shader_preview_first = true;
+	bool shader_preview_showed = false;
 
 	enum ShaderModeFlags {
 		MODE_FLAGS_SPATIAL_CANVASITEM = 1,
@@ -312,10 +316,11 @@ class VisualShaderEditor : public VBoxContainer {
 	void _update_options_menu();
 	void _set_mode(int p_which);
 
-	void _show_preview_text();
-	void _preview_close_requested();
-	void _preview_size_changed();
-	void _update_preview();
+	void _shader_preview_button_pressed();
+	void _shader_preview_close_requested();
+	void _shader_preview_size_changed();
+	void _update_shader_preview();
+	void _update_material_preview();
 	String _get_description(int p_idx);
 
 	static VisualShaderEditor *singleton;


### PR DESCRIPTION
I've decided to fix https://github.com/godotengine/godot/issues/55575, by adding a window with MaterialEditor inside, called by 
pressing preview buttons (similar to code preview inside visual shader currently)

<details>
<summary>Shader</summary>

![shader_preview](https://user-images.githubusercontent.com/3036176/144903093-9ac21070-eb1c-4045-ad53-17c9084a0df9.gif)

</details>

<details>
<summary>VisualShader</summary>

![image](https://user-images.githubusercontent.com/3036176/144903248-46fc29a7-994d-4882-99d6-e09a1c2e8784.png)

</details>

<details>
<summary>I've also added CanvasItem mode support to MaterialEditor to make it useful for looking at 2d shaders.</summary>

![image](https://user-images.githubusercontent.com/3036176/144904003-1b799c4b-ccb1-427d-a055-8263bd7bc0da.png)

</details>

I've decided to re-use the already existed MaterialEditor class (extended by a few methods) just to prevent over-complication of the code. In the future, I think, the MaterialEditor could be extended to support more types of shaders and would be possible to add an option to look at the scene itself too.
