### PR TITLE
Revert "Fix particles emitting at old location"

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -6142,9 +6142,6 @@ void RasterizerStorageGLES3::particles_set_emitting(RID p_particles, bool p_emit
 	Particles *particles = particles_owner.getornull(p_particles);
 	ERR_FAIL_COND(!particles);
 
-	if (p_emitting && !particles->emitting) {
-		particles_request_process(p_particles);
-	}
 	particles->emitting = p_emitting;
 }
 


### PR DESCRIPTION
Reverts godotengine/godot#54733, see https://github.com/godotengine/godot/issues/20160#issuecomment-987752246 for details on the regression it caused.

Reopens #20160.