### PR TITLE
Fix error emitting when called new shader dialog from resource dialog

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -339,8 +339,10 @@ void CreateDialog::_confirmed() {
 		memdelete(f);
 	}
 
-	emit_signal(SNAME("create"));
+	// To prevent, emitting an error from the transient window (shader dialog for example) hide this dialog before emitting the "create" signal.
 	hide();
+
+	emit_signal(SNAME("create"));
 	_cleanup();
 }
 


### PR DESCRIPTION
Fix "Transient parent has another exclusive child." error when creating a shader from `Create New Resource` dialog.

