### PR TITLE
SceneTree: Document font oversampling, remove warnings

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -261,7 +261,9 @@
 			The [SceneTree]'s root [Viewport].
 		</member>
 		<member name="use_font_oversampling" type="bool" setter="set_use_font_oversampling" getter="is_using_font_oversampling" default="false">
-			If [code]true[/code], font oversampling is used.
+			If [code]true[/code], font oversampling is enabled. This means that [DynamicFont]s will be rendered at higher or lower size than configured based on the viewport's scaling ratio. For example, in a viewport scaled with a factor 1.5, a font configured with size 14 would be rendered with size 21 ([code]14 * 1.5[/code]).
+			[b]Note:[/b] Font oversampling is only used if the viewport stretch mode is [constant STRETCH_MODE_VIEWPORT], and if the stretch aspect mode is different from [constant STRETCH_ASPECT_IGNORE].
+			[b]Note:[/b] This property is set automatically for the active [SceneTree] when the project starts based on the configuration of [code]rendering/quality/dynamic_fonts/use_oversampling[/code] in [ProjectSettings]. The property can however be overridden at runtime as needed.
 		</member>
 	</members>
 	<signals>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1142,10 +1142,6 @@ void SceneTree::_update_root_rect() {
 	float viewport_aspect = desired_res.aspect();
 	float video_mode_aspect = video_mode.aspect();
 
-	if (use_font_oversampling && stretch_aspect == STRETCH_ASPECT_IGNORE) {
-		WARN_PRINT("Font oversampling only works with the stretch modes \"Keep Width\", \"Keep Height\" and \"Expand\", not \"Ignore\". To remove this warning, disable Rendering > Quality > Dynamic Fonts > Use Oversampling in the Project Settings.");
-	}
-
 	if (stretch_aspect == STRETCH_ASPECT_IGNORE || Math::is_equal_approx(viewport_aspect, video_mode_aspect)) {
 		//same aspect or ignore aspect
 		viewport_size = desired_res;
@@ -1219,10 +1215,6 @@ void SceneTree::_update_root_rect() {
 			root->set_size_override_stretch(false);
 			root->set_size_override(false, Size2());
 			root->update_canvas_items(); //force them to update just in case
-
-			if (use_font_oversampling) {
-				WARN_PRINT("Font oversampling does not work in \"Viewport\" stretch mode, only \"2D\". To remove this warning, disable Rendering > Quality > Dynamic Fonts > Use Oversampling in the Project Settings.");
-			}
 
 		} break;
 	}


### PR DESCRIPTION
Alternative to and closes #51013.

There's still the issue that the `rendering/quality/dynamic_fonts/use_oversampling` doesn't appear in the `ProjectSettings` docs, but some other settings are affected and this should be tracked in a new issue.

`SceneTree` docs could use some more love given how critical they are, for example the core method `set_screen_stretch` is very undocumented. (It should state what gets updated exactly when it's called, etc.)