### PR TITLE
ScrollContainer's scrollbar visibility is now enum

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -10,7 +10,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="scroll_horizontal_enabled" type="bool" setter="set_enable_h_scroll" getter="is_h_scroll_enabled" overrides="ScrollContainer" default="false" />
+		<member name="horizontal_scroll_mode" type="int" setter="set_horizontal_scroll_mode" getter="get_horizontal_scroll_mode" overrides="ScrollContainer" enum="ScrollContainer.ScrollMode" default="0" />
 	</members>
 	<signals>
 		<signal name="object_id_selected">

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -22,14 +22,14 @@
 			<return type="HScrollBar" />
 			<description>
 				Returns the horizontal scrollbar [HScrollBar] of this [ScrollContainer].
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to disable the horizontal scrollbar, use [member scroll_horizontal_enabled]. If you want to only hide it instead, use [member scroll_horizontal_visible].
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to disable or hide a scrollbar, you can use [member horizontal_scroll_mode].
 			</description>
 		</method>
 		<method name="get_v_scrollbar">
 			<return type="VScrollBar" />
 			<description>
 				Returns the vertical scrollbar [VScrollBar] of this [ScrollContainer].
-				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to disable the vertical scrollbar, use [member scroll_vertical_enabled]. If you want to only hide it instead, use [member scroll_vertical_visible].
+				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to disable or hide a scrollbar, you can use [member vertical_scroll_mode].
 			</description>
 		</method>
 	</methods>
@@ -37,26 +37,20 @@
 		<member name="follow_focus" type="bool" setter="set_follow_focus" getter="is_following_focus" default="false">
 			If [code]true[/code], the ScrollContainer will automatically scroll to focused children (including indirect children) to make sure they are fully visible.
 		</member>
+		<member name="horizontal_scroll_mode" type="int" setter="set_horizontal_scroll_mode" getter="get_horizontal_scroll_mode" enum="ScrollContainer.ScrollMode" default="1">
+			Controls whether horizontal scrollbar can be used and when it should be visible. See [enum ScrollMode] for options.
+		</member>
 		<member name="rect_clip_content" type="bool" setter="set_clip_contents" getter="is_clipping_contents" overrides="Control" default="true" />
 		<member name="scroll_deadzone" type="int" setter="set_deadzone" getter="get_deadzone" default="0">
 		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
 			The current horizontal scroll value.
 		</member>
-		<member name="scroll_horizontal_enabled" type="bool" setter="set_enable_h_scroll" getter="is_h_scroll_enabled" default="true">
-			If [code]true[/code], enables horizontal scrolling.
-		</member>
-		<member name="scroll_horizontal_visible" type="bool" setter="set_h_scroll_visible" getter="is_h_scroll_visible" default="true">
-			If [code]false[/code], hides the horizontal scrollbar.
-		</member>
 		<member name="scroll_vertical" type="int" setter="set_v_scroll" getter="get_v_scroll" default="0">
 			The current vertical scroll value.
 		</member>
-		<member name="scroll_vertical_enabled" type="bool" setter="set_enable_v_scroll" getter="is_v_scroll_enabled" default="true">
-			If [code]true[/code], enables vertical scrolling.
-		</member>
-		<member name="scroll_vertical_visible" type="bool" setter="set_v_scroll_visible" getter="is_v_scroll_visible" default="true">
-			If [code]false[/code], hides the vertical scrollbar.
+		<member name="vertical_scroll_mode" type="int" setter="set_vertical_scroll_mode" getter="get_vertical_scroll_mode" enum="ScrollContainer.ScrollMode" default="1">
+			Controls whether vertical scrollbar can be used and when it should be visible. See [enum ScrollMode] for options.
 		</member>
 	</members>
 	<signals>
@@ -71,6 +65,20 @@
 			</description>
 		</signal>
 	</signals>
+	<constants>
+		<constant name="SCROLL_MODE_DISABLED" value="0" enum="ScrollMode">
+			Scrolling disabled, scrollbar will be invisible.
+		</constant>
+		<constant name="SCROLL_MODE_AUTO" value="1" enum="ScrollMode">
+			Scrolling enabled, scrollbar will be visible only if necessary, i.e. container's content is bigger than the container.
+		</constant>
+		<constant name="SCROLL_MODE_SHOW_ALWAYS" value="2" enum="ScrollMode">
+			Scrolling enabled, scrollbar will be always visible.
+		</constant>
+		<constant name="SCROLL_MODE_SHOW_NEVER" value="3" enum="ScrollMode">
+			Scrolling enabled, scrollbar will be hidden.
+		</constant>
+	</constants>
 	<theme_items>
 		<theme_item name="bg" data_type="style" type="StyleBox">
 			The background [StyleBox] of the [ScrollContainer].

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -6117,8 +6117,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	track_vbox = memnew(VBoxContainer);
 	scroll->add_child(track_vbox);
 	track_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
-	scroll->set_enable_h_scroll(false);
-	scroll->set_enable_v_scroll(true);
+	scroll->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	track_vbox->add_theme_constant_override("separation", 0);
 
 	HBoxContainer *bottom_hb = memnew(HBoxContainer);

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1854,7 +1854,7 @@ CodeTextEditor::CodeTextEditor() {
 	ScrollContainer *scroll = memnew(ScrollContainer);
 	scroll->set_h_size_flags(SIZE_EXPAND_FILL);
 	scroll->set_v_size_flags(SIZE_EXPAND_FILL);
-	scroll->set_enable_v_scroll(false);
+	scroll->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	status_bar->add_child(scroll);
 
 	error = memnew(Label);

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1298,8 +1298,7 @@ EditorAudioBuses::EditorAudioBuses() {
 
 	bus_scroll = memnew(ScrollContainer);
 	bus_scroll->set_v_size_flags(SIZE_EXPAND_FILL);
-	bus_scroll->set_enable_h_scroll(true);
-	bus_scroll->set_enable_v_scroll(false);
+	bus_scroll->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	add_child(bus_scroll);
 	bus_hb = memnew(HBoxContainer);
 	bus_hb->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3540,8 +3540,7 @@ EditorInspector::EditorInspector() {
 	main_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
 	main_vbox->add_theme_constant_override("separation", 0);
 	add_child(main_vbox);
-	set_enable_h_scroll(false);
-	set_enable_v_scroll(true);
+	set_horizontal_scroll_mode(SCROLL_MODE_DISABLED);
 
 	wide_editors = false;
 	show_categories = false;

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3065,7 +3065,7 @@ void EditorPropertyResource::update_property() {
 		if (res.is_valid() && get_edited_object()->editor_is_section_unfolded(get_edited_property())) {
 			if (!sub_inspector) {
 				sub_inspector = memnew(EditorInspector);
-				sub_inspector->set_enable_v_scroll(false);
+				sub_inspector->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 				sub_inspector->set_use_doc_hints(true);
 
 				sub_inspector->set_sub_inspector(true);

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -226,8 +226,7 @@ AnimationTreeEditor::AnimationTreeEditor() {
 	AnimationNodeAnimation::get_editable_animation_list = get_animation_list;
 	path_edit = memnew(ScrollContainer);
 	add_child(path_edit);
-	path_edit->set_enable_h_scroll(true);
-	path_edit->set_enable_v_scroll(false);
+	path_edit->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	path_hb = memnew(HBoxContainer);
 	path_edit->add_child(path_hb);
 	path_hb->add_child(memnew(Label(TTR("Path:"))));

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -288,8 +288,7 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 
 	previews = memnew(ScrollContainer);
 	previews_bg->add_child(previews);
-	previews->set_enable_v_scroll(false);
-	previews->set_enable_h_scroll(true);
+	previews->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	preview_hb = memnew(HBoxContainer);
 	preview_hb->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
@@ -1431,8 +1430,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	library_scroll_bg->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	library_scroll = memnew(ScrollContainer);
-	library_scroll->set_enable_v_scroll(true);
-	library_scroll->set_enable_h_scroll(false);
+	library_scroll->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 
 	library_scroll_bg->add_child(library_scroll);
 
@@ -1499,8 +1497,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	set_process_unhandled_key_input(true); // Global shortcuts since there is no main element to be focused.
 
 	downloads_scroll = memnew(ScrollContainer);
-	downloads_scroll->set_enable_h_scroll(true);
-	downloads_scroll->set_enable_v_scroll(false);
+	downloads_scroll->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	library_main->add_child(downloads_scroll);
 	downloads_hb = memnew(HBoxContainer);
 	downloads_scroll->add_child(downloads_hb);

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -526,8 +526,6 @@ Sprite2DEditor::Sprite2DEditor() {
 	debug_uv_dialog->add_child(vb);
 	ScrollContainer *scroll = memnew(ScrollContainer);
 	scroll->set_custom_minimum_size(Size2(800, 500) * EDSCALE);
-	scroll->set_enable_h_scroll(true);
-	scroll->set_enable_v_scroll(true);
 	vb->add_margin_child(TTR("Preview:"), scroll, true);
 	debug_uv = memnew(Control);
 	debug_uv->connect("draw", callable_mp(this, &Sprite2DEditor::_debug_uv_draw));

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1238,8 +1238,6 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_preview->connect("gui_input", callable_mp(this, &SpriteFramesEditor::_sheet_preview_input));
 
 	split_sheet_scroll = memnew(ScrollContainer);
-	split_sheet_scroll->set_enable_h_scroll(true);
-	split_sheet_scroll->set_enable_v_scroll(true);
 	split_sheet_scroll->connect("gui_input", callable_mp(this, &SpriteFramesEditor::_sheet_scroll_input));
 	split_sheet_panel->add_child(split_sheet_scroll);
 	CenterContainer *cc = memnew(CenterContainer);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -941,7 +941,7 @@ ThemeItemImportTree::ThemeItemImportTree() {
 
 	ScrollContainer *import_bulk_sc = memnew(ScrollContainer);
 	import_bulk_sc->set_custom_minimum_size(Size2(260.0, 0.0) * EDSCALE);
-	import_bulk_sc->set_enable_h_scroll(false);
+	import_bulk_sc->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	import_main_hb->add_child(import_bulk_sc);
 	VBoxContainer *import_bulk_vb = memnew(VBoxContainer);
 	import_bulk_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
@@ -2113,7 +2113,7 @@ VBoxContainer *ThemeTypeEditor::_create_item_list(Theme::DataType p_data_type) {
 
 	ScrollContainer *items_sc = memnew(ScrollContainer);
 	items_sc->set_v_size_flags(SIZE_EXPAND_FILL);
-	items_sc->set_enable_h_scroll(false);
+	items_sc->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	items_tab->add_child(items_sc);
 	VBoxContainer *items_list = memnew(VBoxContainer);
 	items_list->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -3102,7 +3102,7 @@ ThemeTypeEditor::ThemeTypeEditor() {
 
 	ScrollContainer *type_settings_sc = memnew(ScrollContainer);
 	type_settings_sc->set_v_size_flags(SIZE_EXPAND_FILL);
-	type_settings_sc->set_enable_h_scroll(false);
+	type_settings_sc->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	type_settings_tab->add_child(type_settings_sc);
 	VBoxContainer *type_settings_list = memnew(VBoxContainer);
 	type_settings_list->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -228,8 +228,6 @@ ThemeEditorPreview::ThemeEditorPreview() {
 	add_child(preview_body);
 
 	preview_container = memnew(ScrollContainer);
-	preview_container->set_enable_v_scroll(true);
-	preview_container->set_enable_h_scroll(true);
 	preview_body->add_child(preview_container);
 
 	MarginContainer *preview_root = memnew(MarginContainer);

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2321,7 +2321,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 
 	// Middle panel.
 	ScrollContainer *middle_panel = memnew(ScrollContainer);
-	middle_panel->set_enable_h_scroll(false);
+	middle_panel->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	middle_panel->set_custom_minimum_size(Size2i(200, 0) * EDSCALE);
 	split_container_right_side->add_child(middle_panel);
 
@@ -2339,7 +2339,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 
 	tile_inspector = memnew(EditorInspector);
 	tile_inspector->set_undo_redo(undo_redo);
-	tile_inspector->set_enable_v_scroll(false);
+	tile_inspector->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	tile_inspector->edit(tile_proxy_object);
 	tile_inspector->set_use_folding(true);
 	tile_inspector->connect("property_selected", callable_mp(this, &TileSetAtlasSourceEditor::_inspector_property_selected));
@@ -2385,7 +2385,7 @@ TileSetAtlasSourceEditor::TileSetAtlasSourceEditor() {
 
 	atlas_source_inspector = memnew(EditorInspector);
 	atlas_source_inspector->set_undo_redo(undo_redo);
-	atlas_source_inspector->set_enable_v_scroll(false);
+	atlas_source_inspector->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	atlas_source_inspector->edit(atlas_source_proxy_object);
 	middle_vbox_container->add_child(atlas_source_inspector);
 

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -459,7 +459,7 @@ TileSetScenesCollectionSourceEditor::TileSetScenesCollectionSourceEditor() {
 
 	// Middle panel.
 	ScrollContainer *middle_panel = memnew(ScrollContainer);
-	middle_panel->set_enable_h_scroll(false);
+	middle_panel->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	middle_panel->set_custom_minimum_size(Size2i(200, 0) * EDSCALE);
 	split_container_right_side->add_child(middle_panel);
 
@@ -477,7 +477,7 @@ TileSetScenesCollectionSourceEditor::TileSetScenesCollectionSourceEditor() {
 
 	scenes_collection_source_inspector = memnew(EditorInspector);
 	scenes_collection_source_inspector->set_undo_redo(undo_redo);
-	scenes_collection_source_inspector->set_enable_v_scroll(false);
+	scenes_collection_source_inspector->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	scenes_collection_source_inspector->edit(scenes_collection_source_proxy_object);
 	middle_vbox_container->add_child(scenes_collection_source_inspector);
 
@@ -493,7 +493,7 @@ TileSetScenesCollectionSourceEditor::TileSetScenesCollectionSourceEditor() {
 
 	tile_inspector = memnew(EditorInspector);
 	tile_inspector->set_undo_redo(undo_redo);
-	tile_inspector->set_enable_v_scroll(false);
+	tile_inspector->set_vertical_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 	tile_inspector->edit(tile_proxy_object);
 	tile_inspector->set_use_folding(true);
 	middle_vbox_container->add_child(tile_inspector);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2595,7 +2595,7 @@ ProjectManager::ProjectManager() {
 		_project_list = memnew(ProjectList);
 		_project_list->connect(ProjectList::SIGNAL_SELECTION_CHANGED, callable_mp(this, &ProjectManager::_update_project_buttons));
 		_project_list->connect(ProjectList::SIGNAL_PROJECT_ASK_OPEN, callable_mp(this, &ProjectManager::_open_selected_projects_ask));
-		_project_list->set_enable_h_scroll(false);
+		_project_list->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
 		pc->add_child(_project_list);
 	}
 

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -38,6 +38,15 @@
 class ScrollContainer : public Container {
 	GDCLASS(ScrollContainer, Container);
 
+public:
+	enum ScrollMode {
+		SCROLL_MODE_DISABLED = 0,
+		SCROLL_MODE_AUTO,
+		SCROLL_MODE_SHOW_ALWAYS,
+		SCROLL_MODE_SHOW_NEVER,
+	};
+
+private:
 	HScrollBar *h_scroll;
 	VScrollBar *v_scroll;
 
@@ -54,11 +63,8 @@ class ScrollContainer : public Container {
 	bool drag_touching_deaccel = false;
 	bool beyond_deadzone = false;
 
-	bool scroll_h = true;
-	bool scroll_v = true;
-
-	bool h_scroll_visible = true;
-	bool v_scroll_visible = true;
+	ScrollMode horizontal_scroll_mode = SCROLL_MODE_AUTO;
+	ScrollMode vertical_scroll_mode = SCROLL_MODE_AUTO;
 
 	int deadzone = 0;
 	bool follow_focus = false;
@@ -87,17 +93,11 @@ public:
 	void set_v_scroll(int p_pos);
 	int get_v_scroll() const;
 
-	void set_enable_h_scroll(bool p_enable);
-	bool is_h_scroll_enabled() const;
+	void set_horizontal_scroll_mode(ScrollMode p_mode);
+	ScrollMode get_horizontal_scroll_mode() const;
 
-	void set_enable_v_scroll(bool p_enable);
-	bool is_v_scroll_enabled() const;
-
-	void set_h_scroll_visible(bool p_visible);
-	bool is_h_scroll_visible() const;
-
-	void set_v_scroll_visible(bool p_visible);
-	bool is_v_scroll_visible() const;
+	void set_vertical_scroll_mode(ScrollMode p_mode);
+	ScrollMode get_vertical_scroll_mode() const;
 
 	int get_deadzone() const;
 	void set_deadzone(int p_deadzone);
@@ -113,5 +113,7 @@ public:
 
 	ScrollContainer();
 };
+
+VARIANT_ENUM_CAST(ScrollContainer::ScrollMode);
 
 #endif


### PR DESCRIPTION
As discussed in #48008, this PR changes ScrollContainer's scroll bar visibility and enabled to an enum:
![image](https://user-images.githubusercontent.com/2223172/145066749-abc84939-c2c7-452c-8640-821f531883b9.png)

Also I cleaned up some code. I don't know why in some places the scroll bars were explicitly set to enabled, even though that's a default.