### PR TITLE
Make `-q` CLI argument toggle quiet stdout instead of quitting

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Open and close editor
         if: ${{ matrix.proj-test }}
         run: |
-          VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run ${{ matrix.bin }} --audio-driver Dummy -e -q --path test_project 2>&1 | tee sanitizers_log.txt || true
+          VK_ICD_FILENAMES=$(pwd)/vk_swiftshader_icd.json DRI_PRIME=0 xvfb-run ${{ matrix.bin }} --audio-driver Dummy --editor --quit --path test_project 2>&1 | tee sanitizers_log.txt || true
           misc/scripts/check_ci_log.py sanitizers_log.txt
 
       # Run test project

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -273,7 +273,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  -h, --help                                   Display this help message.\n");
 	OS::get_singleton()->print("  --version                                    Display the version string.\n");
 	OS::get_singleton()->print("  -v, --verbose                                Use verbose stdout mode.\n");
-	OS::get_singleton()->print("  --quiet                                      Quiet mode, silences stdout messages. Errors are still displayed.\n");
+	OS::get_singleton()->print("  -q, --quiet                                  Quiet mode, silences stdout messages. Errors are still displayed.\n");
 	OS::get_singleton()->print("\n");
 
 	OS::get_singleton()->print("Run options:\n");
@@ -282,7 +282,7 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  -p, --project-manager                        Start the project manager, even if a project is auto-detected.\n");
 	OS::get_singleton()->print("  --debug-server <uri>                         Start the editor debug server (<protocol>://<host/IP>[:<port>], e.g. tcp://127.0.0.1:6007)\n");
 #endif
-	OS::get_singleton()->print("  -q, --quit                                   Quit after the first iteration.\n");
+	OS::get_singleton()->print("  --quit                                       Quit after the first iteration.\n");
 	OS::get_singleton()->print("  -l, --language <locale>                      Use a specific locale (<locale> being a two-letter code).\n");
 	OS::get_singleton()->print("  --path <directory>                           Path to a project (<directory> must contain a 'project.godot' file).\n");
 	OS::get_singleton()->print("  -u, --upwards                                Scan folders upwards for project.godot file.\n");
@@ -642,7 +642,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (I->get() == "-v" || I->get() == "--verbose") { // verbose output
 
 			OS::get_singleton()->_verbose_stdout = true;
-		} else if (I->get() == "--quiet") { // quieter output
+		} else if (I->get() == "-q" || I->get() == "--quiet") { // quieter output
 
 			quiet_stdout = true;
 
@@ -976,7 +976,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			}
 		} else if (I->get() == "-u" || I->get() == "--upwards") { // scan folders upwards
 			upwards = true;
-		} else if (I->get() == "-q" || I->get() == "--quit") { // Auto quit at the end of the first main loop iteration
+		} else if (I->get() == "--quit") { // Auto quit at the end of the first main loop iteration
 			auto_quit = true;
 		} else if (I->get().ends_with("project.godot")) {
 			String path;

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -30,11 +30,11 @@ _arguments \
   '(-h --help)'{-h,--help}'[display the full help message]' \
   '--version[display the version string]' \
   '(-v --verbose)'{-v,--verbose}'[use verbose stdout mode]' \
-  '--quiet[quiet mode, silences stdout messages (errors are still displayed)]' \
+  '(-q --quiet)'{-q,--quiet}'[quiet mode, silences stdout messages (errors are still displayed)]' \
   '(-e --editor)'{-e,--editor}'[start the editor instead of running the scene]' \
   '(-p --project-manager)'{-p,--project-manager}'[start the project manager, even if a project is auto-detected]' \
   '--debug-server[start the editor debug server]:editor debugger listen address' \
-  '(-q --quit)'{-q,--quit}'[quit after the first iteration]' \
+  '--quit[quit after the first iteration]' \
   '(-l --language)'{-l,--language}'[use a specific locale (<locale> being a two-letter code)]:two-letter locale code' \
   "--path[path to a project (<directory> must contain a 'project.godot' file)]:path to directory with 'project.godot' file:_dirs" \
   '(-u --upwards)'{-u,--upwards}'[scan folders upwards for project.godot file]' \

--- a/misc/dist/shell/godot.bash-completion
+++ b/misc/dist/shell/godot.bash-completion
@@ -36,6 +36,7 @@ _complete_godot_options() {
 --quiet
 --editor
 --project-manager
+--debug-server
 --quit
 --language
 --path

--- a/misc/dist/shell/godot.fish
+++ b/misc/dist/shell/godot.fish
@@ -37,12 +37,13 @@ complete -c godot -e
 complete -c godot -s h -l help -d "Display the full help message"
 complete -c godot -l version -d "Display the version string"
 complete -c godot -s v -l verbose -d "Use verbose stdout mode"
-complete -c godot -l quiet -d "Quiet mode, silences stdout messages (errors are still displayed)"
+complete -c godot -s q -l quiet -d "Quiet mode, silences stdout messages (errors are still displayed)"
 
 # Run options:
 complete -c godot -s e -l editor -d "Start the editor instead of running the scene"
 complete -c godot -s p -l project-manager -d "Start the project manager, even if a project is auto-detected"
-complete -c godot -s q -l quit -d "Quit after the first iteration"
+complete -c godot -l debug-server -d "Start the editor debug server (<protocol>://<host/IP>[:<port>] address)" -x
+complete -c godot -l quit -d "Quit after the first iteration"
 complete -c godot -s l -l language -d "Use a specific locale (<locale> being a two-letter code)" -x
 complete -c godot -l path -d "Path to a project (<directory> must contain a 'project.godot' file)" -r
 complete -c godot -s u -l upwards -d "Scan folders upwards for project.godot file"


### PR DESCRIPTION
`-q` is a common toggle in a command line applications for quiet mode (see apt or dnf for examples). In contrast, `--quit` isn't needed as often.

See https://github.com/godotengine/godot/issues/27963#issuecomment-595217143.