### PR TITLE
SCons: Do not print a warning when passing `profile` to command-line

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -303,9 +303,17 @@ Help(opts.GenerateHelpText(env_base))
 # Detect and print a warning listing unknown SCons variables to ease troubleshooting.
 unknown = opts.UnknownVariables()
 if unknown:
-    print("WARNING: Unknown SCons variables were passed and will be ignored:")
+    ignored = []
     for item in unknown.items():
-        print("    " + item[0] + "=" + item[1])
+        # Some options are expected to be unrecognized when
+        # passed to the argument list, so we simply skip those.
+        if item[0] == "profile":
+            continue
+        ignored.append(item)
+    if ignored:
+        print("WARNING: Unknown SCons variables were passed and will be ignored:")
+        for item in ignored:
+            print("    " + item[0] + "=" + item[1])
 
 # add default include paths
 


### PR DESCRIPTION
The `profile` option is used to specify default SCons options via file. However, after #55203, this prints a warning when the option is used, because it's unrecognized by SCons.

**Warning**: Adding `profile` as an actual SCons option is not a solution, because it's used as a base for `Variables()`. therefore ignoring this option when printing a warning is enough.

For those not familiar with `profile`, see also #38821.

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/56359.*