### PR TITLE
Enable LSP to parse outside scripts

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -428,9 +428,6 @@ GDScriptTextDocument::~GDScriptTextDocument() {
 
 void GDScriptTextDocument::sync_script_content(const String &p_path, const String &p_content) {
 	String path = GDScriptLanguageProtocol::get_singleton()->get_workspace()->get_file_path(p_path);
-	if (!path.begins_with("res://")) {
-		return;
-	}
 	GDScriptLanguageProtocol::get_singleton()->get_workspace()->parse_script(path, p_content);
 
 	EditorFileSystem::get_singleton()->update_file(path);


### PR DESCRIPTION
#53308 was added as a potential fix for Godot crashing when opening scripts outside of res://, but since the last couple months, the crash no longer occurs even without the fix.

At least, not in any manner that I managed to trigger it. If someone still can, I'd like to know the specifics, but as of my testing, it's perfectly capable to handle non-res scripts just with #51332/#51333.

The fix, however, introduced the (admittedly niche, but existing often enough that we at GDQuest ran into it) issue of not being able to analyze scripts that aren't in res://, so this PR looks to revert that part of the patch.