### PR TITLE
Fix leaking environment RIDs in GLES2

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -3875,6 +3875,7 @@ bool RasterizerSceneGLES2::free(RID p_rid) {
 		shadow_atlas_set_size(p_rid, 0);
 		shadow_atlas_owner.free(p_rid);
 		memdelete(shadow_atlas);
+
 	} else if (reflection_probe_instance_owner.owns(p_rid)) {
 		ReflectionProbeInstance *reflection_instance = reflection_probe_instance_owner.get(p_rid);
 
@@ -3891,6 +3892,12 @@ bool RasterizerSceneGLES2::free(RID p_rid) {
 		reflection_probe_release_atlas_index(p_rid);
 		reflection_probe_instance_owner.free(p_rid);
 		memdelete(reflection_instance);
+
+	} else if (environment_owner.owns(p_rid)) {
+		Environment *environment = environment_owner.get(p_rid);
+
+		environment_owner.free(p_rid);
+		memdelete(environment);
 
 	} else {
 		return false;


### PR DESCRIPTION
This PR adds the code necessary to correctly free environments in GLES2, which was previously missing causing them to leak.

## Notes
* This was showing up in the `tracked_handles` build (#54907)
* On tracking this down, it turned out although the client code was correctly calling free, the freeing code in RasterizerScene had been forgotten
* These will have been leaking during the editor and particularly during gameplay with multiple levels

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
