### PR TITLE
Tweak the display order of CLI arguments in `--help` for consistency

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -319,9 +319,8 @@ void Main::print_help(const char *p_binary) {
 
 	OS::get_singleton()->print("  --rendering-driver <driver>                  Rendering driver (depends on display driver).\n");
 	OS::get_singleton()->print("  --gpu-index <device_index>                   Use a specific GPU (run with --verbose to get available device list).\n");
-
 	OS::get_singleton()->print("  --text-driver <driver>                       Text driver (Fonts, BiDi, shaping)\n");
-
+	OS::get_singleton()->print("  --tablet-driver <driver>                     Pen tablet input driver.\n");
 	OS::get_singleton()->print("  --headless                                   Enable headless mode (--display-driver headless --audio-driver Dummy). Useful for servers and with --script.\n");
 
 	OS::get_singleton()->print("\n");
@@ -334,15 +333,15 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --resolution <W>x<H>                         Request window resolution.\n");
 	OS::get_singleton()->print("  --position <X>,<Y>                           Request window position.\n");
 	OS::get_singleton()->print("  --single-window                              Use a single window (no separate subwindows).\n");
-	OS::get_singleton()->print("  --tablet-driver                              Pen tablet input driver.\n");
 	OS::get_singleton()->print("\n");
 
 	OS::get_singleton()->print("Debug options:\n");
 	OS::get_singleton()->print("  -d, --debug                                  Debug (local stdout debugger).\n");
 	OS::get_singleton()->print("  -b, --breakpoints                            Breakpoint list as source::line comma-separated pairs, no spaces (use %%20 instead).\n");
 	OS::get_singleton()->print("  --profiling                                  Enable profiling in the script debugger.\n");
-	OS::get_singleton()->print("  --vk-layers                                  Enable Vulkan Validation layers for debugging.\n");
-#ifdef DEBUG_ENABLED
+	OS::get_singleton()->print("  --gpu-profile                                Show a GPU profile of the tasks that took the most time during frame rendering.\n");
+	OS::get_singleton()->print("  --vk-layers                                  Enable Vulkan validation layers for debugging.\n");
+#if DEBUG_ENABLED
 	OS::get_singleton()->print("  --gpu-abort                                  Abort on GPU errors (usually validation layer errors), may help see the problem if your system freezes.\n");
 #endif
 	OS::get_singleton()->print("  --remote-debug <uri>                         Remote debug (<protocol>://<host/IP>[:<port>], e.g. tcp://127.0.0.1:6007).\n");
@@ -356,7 +355,6 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  --disable-crash-handler                      Disable crash handler when supported by the platform code.\n");
 	OS::get_singleton()->print("  --fixed-fps <fps>                            Force a fixed number of frames per second. This setting disables real-time synchronization.\n");
 	OS::get_singleton()->print("  --print-fps                                  Print the frames per second to the stdout.\n");
-	OS::get_singleton()->print("  --profile-gpu                                Show a simple profile of the tasks that took more time during frame rendering.\n");
 	OS::get_singleton()->print("\n");
 
 	OS::get_singleton()->print("Standalone tools:\n");
@@ -787,7 +785,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				Engine::singleton->gpu_idx = I->next()->get().to_int();
 				N = I->next()->next();
 			} else {
-				OS::get_singleton()->print("Missing gpu index argument, aborting.\n");
+				OS::get_singleton()->print("Missing GPU index argument, aborting.\n");
 				goto error;
 			}
 		} else if (I->get() == "--vk-layers") {

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -33,6 +33,7 @@ _arguments \
   '--quiet[quiet mode, silences stdout messages (errors are still displayed)]' \
   '(-e --editor)'{-e,--editor}'[start the editor instead of running the scene]' \
   '(-p --project-manager)'{-p,--project-manager}'[start the project manager, even if a project is auto-detected]' \
+  '--debug-server[start the editor debug server]:editor debugger listen address' \
   '(-q --quit)'{-q,--quit}'[quit after the first iteration]' \
   '(-l --language)'{-l,--language}'[use a specific locale (<locale> being a two-letter code)]:two-letter locale code' \
   "--path[path to a project (<directory> must contain a 'project.godot' file)]:path to directory with 'project.godot' file:_dirs" \
@@ -42,7 +43,12 @@ _arguments \
   '--remote-fs[use a remote filesystem]:remote filesystem address' \
   '--remote-fs-password[password for remote filesystem]:remote filesystem password' \
   '--audio-driver[set the audio driver]:audio driver name' \
-  "--video-driver[set the video driver]:video driver name:((Vulkan\:'Vulkan renderer' GLES2\:'OpenGL ES 2.0 renderer'))" \
+  '--display-driver[set the display driver]:display driver name' \
+  "--rendering-driver[set the rendering driver]:rendering driver name:((vulkan\:'Vulkan renderer' opengl3\:'OpenGL ES 3.0 renderer' dummy\:'Dummy renderer'))" \
+  "--gpu-index[use a specific GPU (run with --verbose to get available device list)]:device index" \
+  '--text-driver[set the text driver]:text driver name' \
+  '--tablet-driver[set the pen tablet input driver]:tablet driver name' \
+  '--headless[enable headless mode (--display-driver headless --audio-driver Dummy), useful for servers and with --script]' \
   '(-f --fullscreen)'{-f,--fullscreen}'[request fullscreen mode]' \
   '(-m --maximized)'{-m,--maximized}'[request a maximized window]' \
   '(-w --windowed)'{-w,--windowed}'[request windowed mode]' \
@@ -50,9 +56,13 @@ _arguments \
   '--resolution[request window resolution]:resolution in WxH format' \
   '--position[request window position]:position in X,Y format' \
   '--headless[enable headless mode (--display-driver headless --audio-driver Dummy). Useful for servers and with --script]' \
+  '--single-window[use a single window (no separate subwindows)]' \
   '(-d --debug)'{-d,--debug}'[debug (local stdout debugger)]' \
   '(-b --breakpoints)'{-b,--breakpoints}'[specify the breakpoint list as source::line comma-separated pairs, no spaces (use %20 instead)]:breakpoint list' \
   '--profiling[enable profiling in the script debugger]' \
+  '--gpu-profile[show a GPU profile of the tasks that took the most time during frame rendering]' \
+  '--vk-layers[enable Vulkan validation layers for debugging]' \
+  '--gpu-abort[abort on GPU errors (usually validation layer errors)]' \
   '--remote-debug[enable remote debugging]:remote debugger address' \
   '--debug-collisions[show collision shapes when running the scene]' \
   '--debug-navigation[show navigation polygons when running the scene]' \
@@ -64,10 +74,11 @@ _arguments \
   '--print-fps[print the frames per second to the stdout]' \
   '(-s, --script)'{-s,--script}'[run a script]:path to script:_files' \
   '--check-only[only parse for errors and quit (use with --script)]' \
-  '--export[export the project using the given preset and matching release template]:export preset name' \
-  '--export-debug[same as --export, but using the debug template]:export preset name' \
-  '--export-pack[same as --export, but only export the game pack for the given preset]:export preset name' \
-  '--doctool[dump the engine API reference to the given path in XML format, merging if existing files are found]:path to base Godot build directory:_dirs' \
+  '--export[export the project using the given preset and matching release template]:export preset name then path' \
+  '--export-debug[same as --export, but using the debug template]:export preset name then path' \
+  '--export-pack[same as --export, but only export the game pack for the given preset]:export preset name then path' \
+  '--doctool[dump the engine API reference to the given path in XML format, merging if existing files are found]:path to base Godot build directory (optional):_dirs' \
   '--no-docbase[disallow dumping the base types (used with --doctool)]' \
   '--build-solutions[build the scripting solutions (e.g. for C# projects)]' \
-  '--test[run a unit test]:unit test name'
+  '--dump-extension-api[generate JSON dump of the Godot API for GDExtension bindings named "extension_api.json" in the current folder]' \
+  '--test[run all unit tests; run with "--test --help" for more information]'

--- a/misc/dist/shell/godot.bash-completion
+++ b/misc/dist/shell/godot.bash-completion
@@ -45,7 +45,12 @@ _complete_godot_options() {
 --remote-fs
 --remote-fs-password
 --audio-driver
---video-driver
+--display-driver
+--rendering-driver
+--gpu-index
+--text-driver
+--tablet-driver
+--headless
 --fullscreen
 --maximized
 --windowed
@@ -53,9 +58,13 @@ _complete_godot_options() {
 --resolution
 --position
 --headless
+--single-window
 --debug
 --breakpoints
 --profiling
+--gpu-profile
+--vk-layers
+--gpu-abort
 --remote-debug
 --debug-collisions
 --debug-navigation
@@ -73,6 +82,7 @@ _complete_godot_options() {
 --doctool
 --no-docbase
 --build-solutions
+--dump-extension-api
 --test
 " -- "$1"))
 }
@@ -98,10 +108,10 @@ _complete_godot_bash() {
     local IFS=$' \n\t'
     # shellcheck disable=SC2207
     COMPREPLY=($(compgen -W "unsafe safe separate" -- "$cur"))
-  elif [[ $prev == "--video-driver" ]]; then
+  elif [[ $prev == "--rendering-driver" ]]; then
     local IFS=$' \n\t'
     # shellcheck disable=SC2207
-    COMPREPLY=($(compgen -W "Vulkan GLES2" -- "$cur"))
+    COMPREPLY=($(compgen -W "vulkan opengl3 dummy" -- "$cur"))
   elif [[ $prev == "--path" || $prev == "--doctool" ]]; then
     local IFS=$'\n\t'
     # shellcheck disable=SC2207

--- a/misc/dist/shell/godot.fish
+++ b/misc/dist/shell/godot.fish
@@ -23,10 +23,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-function godot_video_driver_args
+function godot_rendering_driver_args
     # Use a function instead of a fixed string to customize the argument descriptions.
-    echo -e "Vulkan\tVulkan renderer"
-    echo -e "GLES2\tOpenGL ES 2.0 renderer"
+    echo -e "vulkan\tVulkan renderer"
+    echo -e "opengl3\tOpenGL ES 3.0 renderer"
+    echo -e "dummy\tDummy renderer"
 end
 
 # Erase existing completions for Godot.
@@ -50,7 +51,12 @@ complete -c godot -l render-thread -d "Set the render thread mode" -x -a "unsafe
 complete -c godot -l remote-fs -d "Use a remote filesystem (<host/IP>[:<port>] address)" -x
 complete -c godot -l remote-fs-password -d "Password for remote filesystem" -x
 complete -c godot -l audio-driver -d "Set the audio driver" -x
-complete -c godot -l video-driver -d "Set the video driver" -x -a "(godot_video_driver_args)"
+complete -c godot -l display-driver -d "Set the display driver" -x
+complete -c godot -l rendering-driver -d "Set the rendering driver" -x -a "(godot_rendering_driver_args)"
+complete -c godot -l gpu-index -d "Use a specific GPU (run with --verbose to get available device list)" -x
+complete -c godot -l text-driver -d "Set the text driver" -x
+complete -c godot -l tablet-driver -d "Set the pen tablet input driver" -x
+complete -c godot -l headless -d "Enable headless mode (--display-driver headless --audio-driver Dummy). Useful for servers and with --script"
 
 # Display options:
 complete -c godot -s f -l fullscreen -d "Request fullscreen mode"
@@ -60,11 +66,15 @@ complete -c godot -s t -l always-on-top -d "Request an always-on-top window"
 complete -c godot -l resolution -d "Request window resolution" -x
 complete -c godot -l position -d "Request window position" -x
 complete -c godot -l headless -d "Enable headless mode (--display-driver headless --audio-driver Dummy). Useful for servers and with --script"
+complete -c godot -l single-window -d "Use a single window (no separate subwindows)"
 
 # Debug options:
 complete -c godot -s d -l debug -d "Debug (local stdout debugger)"
 complete -c godot -s b -l breakpoints -d "Specify the breakpoint list as source::line comma-separated pairs, no spaces (use %20 instead)" -x
 complete -c godot -l profiling -d "Enable profiling in the script debugger"
+complete -c godot -l gpu-profile -d "Show a GPU profile of the tasks that took the most time during frame rendering"
+complete -c godot -l vk-layers -d "Enable Vulkan validation layers for debugging"
+complete -c godot -l gpu-abort -d "Abort on GPU errors (usually validation layer errors)"
 complete -c godot -l remote-debug -d "Enable remote debugging"
 complete -c godot -l debug-collisions -d "Show collision shapes when running the scene"
 complete -c godot -l debug-navigation -d "Show navigation polygons when running the scene"
@@ -84,4 +94,5 @@ complete -c godot -l export-pack -d "Same as --export, but only export the game 
 complete -c godot -l doctool -d "Dump the engine API reference to the given path in XML format, merging if existing files are found" -r
 complete -c godot -l no-docbase -d "Disallow dumping the base types (used with --doctool)"
 complete -c godot -l build-solutions -d "Build the scripting solutions (e.g. for C# projects)"
-complete -c godot -l test -d "Run a unit test" -x
+complete -c godot -l dump-extension-api -d "Generate JSON dump of the Godot API for GDExtension bindings named 'extension_api.json' in the current folder"
+complete -c godot -l test -d "Run all unit tests; run with '--test --help' for more information" -x


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/55696.

`--profile-gpu` was renamed to `--gpu-profile` for consistency with `--gpu-abort`. (This doesn't break compatibility with existing projects since this CLI argument is only in `master`.)

This also updates the shell completion files to the latest `master` branch. I tested all 3 shell completion files on Fedora 34 and made sure they still work as expected :slightly_smiling_face: 