### PR TITLE
Fix bad mouse offset with Control::wrap_mouse()

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2590,7 +2590,7 @@ Control *Control::get_focus_owner() const {
 
 void Control::warp_mouse(const Point2 &p_to_pos) {
 	ERR_FAIL_COND(!is_inside_tree());
-	get_viewport()->warp_mouse(get_screen_transform().xform(p_to_pos));
+	get_viewport()->warp_mouse(get_global_transform().xform(p_to_pos));
 }
 
 bool Control::is_text_field() const {


### PR DESCRIPTION
Fix #55705

### Issue description

Right click in the 3D viewport capture the mouse for free look.
After releasing the mouse button, mouse cursor is wrapped at a bad position.

### Identified cause
`get_screen_transform()` need to be reverted to `get_global_transform()` in `Control::warp_mouse()` function.
I've added this changed to my PR about popup offset when including Gil's PR changes but it seems it was a bad idea.

### Before

![bug](https://user-images.githubusercontent.com/3649998/145098989-06b9adb7-8e1e-45e2-be68-4abe1e813d67.gif)

### After

![fix_warp_mouse](https://user-images.githubusercontent.com/3649998/145099007-4cef6dd7-801f-439e-af6a-b0c851f4b527.gif)


