### PR TITLE
Expose `ScriptEditor::edit` to scripting

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -21,7 +21,17 @@
 			<return type="void" />
 			<argument index="0" name="resource" type="Resource" />
 			<description>
-				Edits the given [Resource].
+				Edits the given [Resource]. If the resource is a [Script] you can also edit it with [method edit_script] to specify the line and column position.
+			</description>
+		</method>
+		<method name="edit_script">
+			<return type="void" />
+			<argument index="0" name="script" type="Script" />
+			<argument index="1" name="line" type="int" default="-1" />
+			<argument index="2" name="column" type="int" default="0" />
+			<argument index="3" name="grab_focus" type="bool" default="true" />
+			<description>
+				Edits the given [Script]. The line and column on which to open the script can also be specified. The script will be open with the user-configured editor for the script's language which may be an external editor.
 			</description>
 		</method>
 		<method name="get_base_control">

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -166,6 +166,10 @@ void EditorInterface::edit_node(Node *p_node) {
 	EditorNode::get_singleton()->edit_node(p_node);
 }
 
+void EditorInterface::edit_script(const Ref<Script> &p_script, int p_line, int p_col, bool p_grab_focus) {
+	ScriptEditor::get_singleton()->edit(p_script, p_line, p_col, p_grab_focus);
+}
+
 void EditorInterface::open_scene_from_path(const String &scene_path) {
 	if (EditorNode::get_singleton()->is_changing_scene()) {
 		return;
@@ -326,6 +330,7 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_scale"), &EditorInterface::get_editor_scale);
 	ClassDB::bind_method(D_METHOD("edit_resource", "resource"), &EditorInterface::edit_resource);
 	ClassDB::bind_method(D_METHOD("edit_node", "node"), &EditorInterface::edit_node);
+	ClassDB::bind_method(D_METHOD("edit_script", "script", "line", "column", "grab_focus"), &EditorInterface::edit_script, DEFVAL(-1), DEFVAL(0), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("open_scene_from_path", "scene_filepath"), &EditorInterface::open_scene_from_path);
 	ClassDB::bind_method(D_METHOD("reload_scene_from_path", "scene_filepath"), &EditorInterface::reload_scene_from_path);
 	ClassDB::bind_method(D_METHOD("play_main_scene"), &EditorInterface::play_main_scene);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -74,6 +74,7 @@ public:
 	Control *get_editor_main_control();
 	void edit_resource(const Ref<Resource> &p_resource);
 	void edit_node(Node *p_node);
+	void edit_script(const Ref<Script> &p_script, int p_line = -1, int p_col = 0, bool p_grab_focus = true);
 	void open_scene_from_path(const String &scene_path);
 	void reload_scene_from_path(const String &scene_path);
 


### PR DESCRIPTION
Exposes a method in `EditorInterface` to open scripts on a specified line and column.
This method handles if the internal or the external editor should be used.

Without this method, users can only use `EditorInterface::edit_resource` to open scripts but can't specify a line and/or column position.

Closes #52294.
