### PR TITLE
Fix volumetric fog in combination with spotlights

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -4417,9 +4417,9 @@ void RendererSceneRenderRD::_update_volumetric_fog(RID p_render_buffers, RID p_e
 
 		uint32_t cluster_screen_width = (rb->width - 1) / cluster_size + 1;
 		uint32_t cluster_screen_height = (rb->height - 1) / cluster_size + 1;
-		params.cluster_type_size = cluster_screen_width * cluster_screen_height * (32 + 32);
-		params.cluster_width = cluster_screen_width;
 		params.max_cluster_element_count_div_32 = max_cluster_elements / 32;
+		params.cluster_type_size = cluster_screen_width * cluster_screen_height * (params.max_cluster_element_count_div_32 + 32);
+		params.cluster_width = cluster_screen_width;
 
 		params.screen_size[0] = rb->width;
 		params.screen_size[1] = rb->height;


### PR DESCRIPTION
This PR fixes the artifacts which show up when using spotlights in combination with volumetric fog. 
Fixes both artifacts described in #55527.
(#41357 might be fixed as well for spotlights, needs testing)

![Screenshot 2021-12-08 013220](https://user-images.githubusercontent.com/50084500/145127363-5bdc7fc8-efbc-4056-a9cc-1a14258e8f0c.png)

![fix-spotlights-fog](https://user-images.githubusercontent.com/50084500/145126549-81f519b5-4c47-4054-abed-1d69354d43a1.gif)
