### PR TITLE
Add DynamicFontData oversampling override property.

### DIFF
--- a/doc/classes/DynamicFontData.xml
+++ b/doc/classes/DynamicFontData.xml
@@ -21,6 +21,9 @@
 		<member name="hinting" type="int" setter="set_hinting" getter="get_hinting" enum="DynamicFontData.Hinting" default="2">
 			The font hinting mode used by FreeType. See [enum Hinting] for options.
 		</member>
+		<member name="override_oversampling" type="float" setter="set_override_oversampling" getter="get_override_oversampling" default="0.0">
+			If set to a value greater than [code]0.0[/code], it will override default font oversampling, ignoring [member SceneTree.use_font_oversampling] value and viewport stretch mode.
+		</member>
 	</members>
 	<constants>
 		<constant name="HINTING_NONE" value="0" enum="Hinting">

--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -55,6 +55,7 @@ Ref<DynamicFontAtSize> DynamicFontData::_get_dynamic_font_at_size(CacheID p_cach
 	dfas.instance();
 
 	dfas->font = Ref<DynamicFontData>(this);
+	dfas->oversampling = (override_oversampling > 0) ? override_oversampling : DynamicFontAtSize::font_oversampling;
 
 	size_cache[p_cache_id] = dfas.ptr();
 	dfas->id = p_cache_id;
@@ -80,6 +81,19 @@ void DynamicFontData::set_force_autohinter(bool p_force) {
 	force_autohinter = p_force;
 }
 
+float DynamicFontData::get_override_oversampling() const {
+	return override_oversampling;
+}
+
+void DynamicFontData::set_override_oversampling(float p_oversampling) {
+	if (override_oversampling == p_oversampling) {
+		return;
+	}
+
+	override_oversampling = p_oversampling;
+	DynamicFont::update_oversampling();
+}
+
 void DynamicFontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_antialiased", "antialiased"), &DynamicFontData::set_antialiased);
 	ClassDB::bind_method(D_METHOD("is_antialiased"), &DynamicFontData::is_antialiased);
@@ -88,8 +102,12 @@ void DynamicFontData::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_hinting", "mode"), &DynamicFontData::set_hinting);
 	ClassDB::bind_method(D_METHOD("get_hinting"), &DynamicFontData::get_hinting);
 
+	ClassDB::bind_method(D_METHOD("get_override_oversampling"), &DynamicFontData::get_override_oversampling);
+	ClassDB::bind_method(D_METHOD("set_override_oversampling", "oversampling"), &DynamicFontData::set_override_oversampling);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "antialiased"), "set_antialiased", "is_antialiased");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hinting", PROPERTY_HINT_ENUM, "None,Light,Normal"), "set_hinting", "get_hinting");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "override_oversampling"), "set_override_oversampling", "get_override_oversampling");
 
 	BIND_ENUM_CONSTANT(HINTING_NONE);
 	BIND_ENUM_CONSTANT(HINTING_LIGHT);
@@ -105,6 +123,7 @@ DynamicFontData::DynamicFontData() {
 	hinting = DynamicFontData::HINTING_NORMAL;
 	font_mem = nullptr;
 	font_mem_size = 0;
+	override_oversampling = 0.0;
 }
 
 DynamicFontData::~DynamicFontData() {
@@ -662,14 +681,18 @@ void DynamicFontAtSize::_update_char(int32_t p_char) {
 }
 
 void DynamicFontAtSize::update_oversampling() {
-	if (oversampling == font_oversampling || !valid) {
+	if (!valid) {
+		return;
+	}
+	float new_oversampling = (font.is_valid() && font->override_oversampling > 0) ? font->override_oversampling : font_oversampling;
+	if (oversampling == new_oversampling) {
 		return;
 	}
 
 	FT_Done_FreeType(library);
 	textures.clear();
 	char_map.clear();
-	oversampling = font_oversampling;
+	oversampling = new_oversampling;
 	valid = false;
 	_load();
 }

--- a/scene/resources/dynamic_font.h
+++ b/scene/resources/dynamic_font.h
@@ -85,6 +85,7 @@ private:
 	bool force_autohinter;
 	Hinting hinting;
 	Vector<uint8_t> _fontdata;
+	float override_oversampling;
 
 	String font_path;
 	Map<CacheID, DynamicFontAtSize *> size_cache;
@@ -103,6 +104,9 @@ public:
 	void set_font_path(const String &p_path);
 	String get_font_path() const;
 	void set_force_autohinter(bool p_force);
+
+	float get_override_oversampling() const;
+	void set_override_oversampling(float p_oversampling);
 
 	DynamicFontData();
 	~DynamicFontData();


### PR DESCRIPTION
Alternative to #52881, setting `override_oversampling` to the value `> 0.0` force oversampling for the `DynamicFontData` and trigger font oversampling update.

Note: due to the know bug with the font data not saving extra properties, `DynamicFontData` should be saved as `tres` to keep this setting, or it can be set from the code.