### PR TITLE
RID tracked handles better error messages for dangling RIDs

### DIFF
--- a/core/rid_handle.h
+++ b/core/rid_handle.h
@@ -119,9 +119,14 @@ class RID_Database {
 		RID_Data *data;
 		uint32_t revision;
 #ifdef RID_HANDLE_ALLOCATION_TRACKING_ENABLED
+		// current allocation
 		uint16_t line_number;
 		uint16_t owner_name_id;
 		const char *filename;
+
+		// previous allocation (allows identifying dangling RID source allocations)
+		const char *previous_filename;
+		uint32_t previous_line_number;
 #endif
 	};
 


### PR DESCRIPTION
Keeps track of previous allocations as well as current allocations, as the previous allocation will be the one of interest in many cases for dangling RIDs.

Prints the file / line number in the error message, instead of using print_verbose.

Error message now contains:
* Type of error, possible reason for error
* Details of the RID, id and revision for the passed revision and the database entry revision (PE)
* Short filenames for the current allocation and previous allocation (if present)

## Notes
* Now I've used this in practice to track down a danging RID bug (#44642) this gives an opportunity to make the error message more useful
* The error message contains a lot of info, and is admittedly not super beginner friendly, but can be pasted in issues and will lead us directly to the source of the bug in many situations
* The alternative I used before was to use `print_verbose` for the detailed info, but that is of little use with rare errors, because you may not have had verbose output on when it occurred.
* The old error message wasn't super useful without the extra verbose output.
* We can perhaps make this more beginner friendly in time, but it should hopefully be a rare error once we fix the engine bugs.

## Example output
```
RID get_or_null, revision is incorrect, possible dangling RID. RID id=12204 [ rev 6 ], PE [ rev 7 ] canvas_item.cpp line 1268 ( prev spatial_editor_plugin.cpp line 5840 )
```
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
