### PR TITLE
[GDScript] Raise a warning when overriding a function.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -372,8 +372,11 @@
 		<member name="debug/gdscript/warnings/return_value_discarded" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], enables warnings when calling a function without using its return value (by assigning it to a variable or using it as a function argument). Such return values are sometimes used to denote possible errors using the [enum Error] enum.
 		</member>
+		<member name="debug/gdscript/warnings/shadowed_function" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], enables warnings when defining a function that would shadow a function at an upper level (such as a member variable).
+		</member>
 		<member name="debug/gdscript/warnings/shadowed_global_identifier" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], enables warnings when defining a local or subclass member variable, signal, or enum that would have the same name as a built-in function or global class name, which possibly shadow it.
+			If [code]true[/code], enables warnings when defining a local or subclass member variable, signal or enum that would have the same name as a built-in function or global class name, which possibly shadow it.
 		</member>
 		<member name="debug/gdscript/warnings/shadowed_variable" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], enables warnings when defining a local or subclass member variable that would shadow a variable at an upper level (such as a member variable).

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -47,8 +47,8 @@ class GDScriptAnalyzer {
 	// Tests for detecting invalid overloading of script members
 	static _FORCE_INLINE_ bool has_member_name_conflict_in_script_class(const StringName &p_name, const GDScriptParser::ClassNode *p_current_class_node);
 	static _FORCE_INLINE_ bool has_member_name_conflict_in_native_type(const StringName &p_name, const StringName &p_native_type_string);
-	Error check_native_member_name_conflict(const StringName &p_member_name, const GDScriptParser::Node *p_member_node, const StringName &p_native_type_string);
-	Error check_class_member_name_conflict(const GDScriptParser::ClassNode *p_class_node, const StringName &p_member_name, const GDScriptParser::Node *p_member_node);
+	Error check_native_member_name_conflict(const StringName &p_member_name, const GDScriptParser::Node *p_member_node, const StringName &p_native_type_string, GDScriptParser::ClassNode::Member::Type p_member_type);
+	Error check_class_member_name_conflict(const GDScriptParser::ClassNode *p_class_node, const StringName &p_member_name, const GDScriptParser::Node *p_member_node, GDScriptParser::ClassNode::Member::Type p_member_type);
 
 	Error resolve_inheritance(GDScriptParser::ClassNode *p_class, bool p_recursive = true);
 	GDScriptParser::DataType resolve_datatype(GDScriptParser::TypeNode *p_type);

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -152,6 +152,10 @@ String GDScriptWarning::get_message() const {
 			CHECK_SYMBOLS(3);
 			return vformat(R"(The %s '%s' has the same name as a %s.)", symbols[0], symbols[1], symbols[2]);
 		}
+		case SHADOWED_FUNCTION: {
+			CHECK_SYMBOLS(2);
+			return vformat(R"(The function '%s' has the same name as a %s.)", symbols[0], symbols[1]);
+		}
 		case WARNING_MAX:
 			break; // Can't happen, but silences warning
 	}
@@ -199,6 +203,7 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"REDUNDANT_AWAIT",
 		"EMPTY_FILE",
 		"SHADOWED_GLOBAL_IDENTIFIER",
+		"SHADOWED_FUNCTION",
 	};
 
 	static_assert((sizeof(names) / sizeof(*names)) == WARNING_MAX, "Amount of warning types don't match the amount of warning names.");

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -70,6 +70,7 @@ public:
 		REDUNDANT_AWAIT, // await is used but expression is synchronous (not a signal nor a coroutine).
 		EMPTY_FILE, // A script file is empty.
 		SHADOWED_GLOBAL_IDENTIFIER, // A global class or function has the same name as variable.
+		SHADOWED_FUNCTION, // A global class or function has the same name as function.
 		WARNING_MAX,
 	};
 

--- a/modules/gdscript/tests/scripts/parser/features/super.out
+++ b/modules/gdscript/tests/scripts/parser/features/super.out
@@ -1,4 +1,20 @@
 GDTEST_OK
+>> WARNING
+>> Line: 16
+>> SHADOWED_FUNCTION
+>> The function 'greet' has the same name as a parent class.
+>> WARNING
+>> Line: 20
+>> SHADOWED_FUNCTION
+>> The function 'say' has the same name as a parent class.
+>> WARNING
+>> Line: 28
+>> SHADOWED_FUNCTION
+>> The function 'greet' has the same name as a parent class.
+>> WARNING
+>> Line: 38
+>> SHADOWED_FUNCTION
+>> The function 'say' has the same name as a parent class.
 hello
 S Greeted say something foo
 


### PR DESCRIPTION
Raise a warning when a function name is already defined by an upper parent (could be a variable, class name, function name, a signal or even an enum). Add `SHADOWED_FUNCTION` to project settings, so this can be deactivated without deactivating the `SHADOWED_GLOBAL_IDENTIFIER`.

Fix https://github.com/godotengine/godot/issues/55024

```gdscript
extends Node

func _ready():
  # No error when parsing
  pass

func set():
  # Raise a WARNING since 'set' is already defined
  pass

func my_custom_function(name):
  # Note: Behavior unchanged
  # Raise a WARNING because name is already an attribute of the Node class.
  pass
```