### PR TITLE
VehicleWheel can now return the surface it's colliding with.

### DIFF
--- a/doc/classes/VehicleWheel3D.xml
+++ b/doc/classes/VehicleWheel3D.xml
@@ -11,6 +11,13 @@
 		<link title="3D Truck Town Demo">https://godotengine.org/asset-library/asset/524</link>
 	</tutorials>
 	<methods>
+		<method name="get_contact_body" qualifiers="const">
+			<return type="Node3D" />
+			<description>
+				Returns the contacting body node if valid in the tree, as [Node3D]. At the moment, [GridMap] is not supported so the node will be always of type [PhysicsBody3D].
+				Returns [code]null[/code] if the wheel is not in contact with a surface, or the contact body is not a [PhysicsBody3D].
+			</description>
+		</method>
 		<method name="get_rpm" qualifiers="const">
 			<return type="float" />
 			<description>

--- a/scene/3d/vehicle_body_3d.cpp
+++ b/scene/3d/vehicle_body_3d.cpp
@@ -225,6 +225,10 @@ bool VehicleWheel3D::is_in_contact() const {
 	return m_raycastInfo.m_isInContact;
 }
 
+Node3D *VehicleWheel3D::get_contact_body() const {
+	return m_raycastInfo.m_groundObject;
+}
+
 void VehicleWheel3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_radius", "length"), &VehicleWheel3D::set_radius);
 	ClassDB::bind_method(D_METHOD("get_radius"), &VehicleWheel3D::get_radius);
@@ -257,6 +261,7 @@ void VehicleWheel3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_friction_slip"), &VehicleWheel3D::get_friction_slip);
 
 	ClassDB::bind_method(D_METHOD("is_in_contact"), &VehicleWheel3D::is_in_contact);
+	ClassDB::bind_method(D_METHOD("get_contact_body"), &VehicleWheel3D::get_contact_body);
 
 	ClassDB::bind_method(D_METHOD("set_roll_influence", "roll_influence"), &VehicleWheel3D::set_roll_influence);
 	ClassDB::bind_method(D_METHOD("get_roll_influence"), &VehicleWheel3D::get_roll_influence);
@@ -413,9 +418,8 @@ real_t VehicleBody3D::_ray_cast(int p_idx, PhysicsDirectBodyState3D *s) {
 	ray_params.exclude = exclude;
 	ray_params.collision_mask = get_collision_mask();
 
-	bool col = ss->intersect_ray(ray_params, rr);
-
 	wheel.m_raycastInfo.m_groundObject = nullptr;
+	bool col = ss->intersect_ray(ray_params, rr);
 
 	if (col) {
 		param = source.distance_to(rr.position) / source.distance_to(target);

--- a/scene/3d/vehicle_body_3d.h
+++ b/scene/3d/vehicle_body_3d.h
@@ -129,6 +129,8 @@ public:
 
 	bool is_in_contact() const;
 
+	Node3D *get_contact_body() const;
+
 	void set_roll_influence(real_t p_value);
 	real_t get_roll_influence() const;
 


### PR DESCRIPTION
As per [this](https://github.com/godotengine/godot-proposals/issues/3640) proposed change I implemented the functionality to have give the ability to VehicleWheel to return the surface it's colliding with.


In this picture the two Blue and White bodies' ID's are returned by two VehicleWheels to the console.
![image](https://user-images.githubusercontent.com/16015783/145200292-667195a8-a374-4bc3-9aa8-01d41dfcef6d.png)

*Bugsquad edit:* Implements https://github.com/godotengine/godot-proposals/issues/3640