### PR TITLE
Fix script editor unexpected scroll upon resize

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4226,7 +4226,10 @@ double TextEdit::get_scroll_pos_for_line(int p_line, int p_wrap_index) const {
 		return p_line;
 	}
 
-	double new_line_scroll_pos = get_visible_line_count_in_range(0, CLAMP(p_line, 0, text.size() - 1));
+	double new_line_scroll_pos = 0.0;
+	if (p_line > 0) {
+		new_line_scroll_pos = get_visible_line_count_in_range(0, MIN(p_line - 1, text.size() - 1));
+	}
 	new_line_scroll_pos += p_wrap_index;
 	return new_line_scroll_pos;
 }
@@ -4290,7 +4293,7 @@ int TextEdit::get_visible_line_count_in_range(int p_from_line, int p_to_line) co
 
 	/* Returns the total number of (lines + wrapped - hidden). */
 	if (!_is_hiding_enabled() && get_line_wrapping_mode() == LineWrappingMode::LINE_WRAPPING_NONE) {
-		return p_to_line - p_from_line;
+		return (p_to_line - p_from_line) + 1;
 	}
 
 	int total_rows = 0;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes #55691

PS: The root cause of this bug seems to be the discrepancy in `get_visible_line_count_in_range`, where it considers `p_to_line` either inclusive or exclusive depending on whether wrapping is enabled etc. This seems to cause confusion about what the callers of the function should expect for it to return. It might be a good idea to make it consistent, though it's out of the scope of this PR.

https://github.com/godotengine/godot/blob/e8082003f19ad8d98b6b2f74f64f4eaa7fe86353/scene/gui/text_edit.cpp#L4286-L4304