### PR TITLE
Reverse Camera2D zoom

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -155,7 +155,7 @@
 			Speed in pixels per second of the camera's smoothing effect when [member smoothing_enabled] is [code]true[/code].
 		</member>
 		<member name="zoom" type="Vector2" setter="set_zoom" getter="get_zoom" default="Vector2(1, 1)">
-			The camera's zoom relative to the viewport. Values larger than [code]Vector2(1, 1)[/code] zoom out and smaller values zoom in. For an example, use [code]Vector2(0.5, 0.5)[/code] for a 2× zoom-in, and [code]Vector2(4, 4)[/code] for a 4× zoom-out.
+			The camera's zoom relative to the viewport. Values larger than [code]Vector2(1, 1)[/code] zoom in and smaller values zoom out. For an example, use [code]Vector2(4, 4)[/code] for a 4× zoom-in, and [code]Vector2(0.5, 0.5)[/code] for a 2× zoom-out.
 		</member>
 	</members>
 	<constants>

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -77,14 +77,15 @@ void Camera2D::set_zoom(const Vector2 &p_zoom) {
 	// Setting zoom to zero causes 'affine_invert' issues
 	ERR_FAIL_COND_MSG(Math::is_zero_approx(p_zoom.x) || Math::is_zero_approx(p_zoom.y), "Zoom level must be different from 0 (can be negative).");
 
-	zoom = p_zoom;
+	// Store the zoom in reverse, so greater zoom is a proper zoom in.
+	zoom = Vector2(1, 1) / p_zoom;
 	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
 	_update_scroll();
 	smoothed_camera_pos = old_smoothed_camera_pos;
 };
 
 Vector2 Camera2D::get_zoom() const {
-	return zoom;
+	return Vector2(1, 1) / zoom;
 };
 
 Transform2D Camera2D::get_camera_transform() {


### PR DESCRIPTION
*Bugsquad edit:* Implements and closes https://github.com/godotengine/godot-proposals/issues/3888

This PR changes how `zoom` property of Camera2D works, so e.g. "zoom = 2" is now "zoom-in 2x", which is much more intuitive (previously it would zoom out).

Alternatively we could rename the property to `view_rect_scale` or similar, because that's what it actually does right now.