### PR TITLE
Add OS.set_custom_features() method

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1202,6 +1202,19 @@ ProjectSettings::ProjectSettings() {
 
 	singleton = this;
 
+#ifdef TOOLS_ENABLED
+	// Available only at runtime in editor builds. Needs to be processed before anything else to work properly.
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		String editor_features = OS::get_singleton()->get_environment("__EDITOR_CUSTOM_FEATURES__");
+		if (!editor_features.is_empty()) {
+			PackedStringArray feature_list = editor_features.split(",");
+			for (const String &s : feature_list) {
+				custom_features.insert(s);
+			}
+		}
+	}
+#endif
+
 	GLOBAL_DEF_BASIC("application/config/name", "");
 	GLOBAL_DEF_BASIC("application/config/description", "");
 	custom_prop_info["application/config/description"] = PropertyInfo(Variant::STRING, "application/config/description", PROPERTY_HINT_MULTILINE_TEXT);

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -322,6 +322,10 @@ Error OS::set_thread_name(const String &p_name) {
 	return ::Thread::get_main_id();
 };
 
+void OS::set_custom_features(const PackedStringArray &p_features) {
+	::OS::get_singleton()->set_environment("__EDITOR_CUSTOM_FEATURES__", String(",").join(p_features));
+}
+
 bool OS::has_feature(const String &p_feature) const {
 	return ::OS::get_singleton()->has_feature(p_feature);
 }
@@ -611,6 +615,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_thread_caller_id"), &OS::get_thread_caller_id);
 	ClassDB::bind_method(D_METHOD("get_main_thread_id"), &OS::get_main_thread_id);
 
+	ClassDB::bind_method(D_METHOD("set_custom_features", "features"), &OS::set_custom_features);
 	ClassDB::bind_method(D_METHOD("has_feature", "tag_name"), &OS::has_feature);
 
 	ClassDB::bind_method(D_METHOD("request_permission", "name"), &OS::request_permission);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -241,6 +241,7 @@ public:
 	Thread::ID get_thread_caller_id() const;
 	Thread::ID get_main_thread_id() const;
 
+	void set_custom_features(const PackedStringArray &p_features);
 	bool has_feature(const String &p_feature) const;
 
 	bool request_permission(const String &p_name);

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -496,6 +496,27 @@
 				[b]Note:[/b] This method is implemented on Android.
 			</description>
 		</method>
+		<method name="set_custom_features">
+			<return type="void" />
+			<argument index="0" name="features" type="PackedStringArray" />
+			<description>
+				Sets a list of additional custom features to use with [method has_feature]. These features will also be used for overrides set in [ProjectSettings].
+				To use this method, call it inside editor (from a plugin, [EditorScript] or any tool script) and it will have effect when running the project from the editor. The features will remain available until editor is restarted or the method is called again.
+				Example usage:
+				[codeblock]
+				@tool
+				extends EditorScript
+
+				func _run():
+				    OS.set_custom_features(["test"])
+				[/codeblock]
+				Make sure to run this script. Then in another script:
+				[codeblock]
+				func _ready():
+				    print(OS.has_feature("Test")) # true
+				[/codeblock]
+			</description>
+		</method>
 		<method name="set_environment" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="variable" type="String" />


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/373

The method needs to be called by a tool script in the editor and will take effect when running project. It will store the features in `__EDITOR_CUSTOM_FEATURES__` environment variable, which is then loaded when ProjectSettings are constructed. This way any override you set in ProjectSettings will also have effect if you set correct features.

Example usage:
```
@tool
extends EditorScript

func _run():
    OS.set_custom_features(["test"])
```
(run it)
```
func _ready():
   print(OS.has_feature("test")) # true
```