### PR TITLE
Optimise TextEdit base operations

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2597,7 +2597,7 @@ bool Control::is_text_field() const {
 	return false;
 }
 
-Array Control::structured_text_parser(StructuredTextParser p_theme_type, const Array &p_args, const String p_text) const {
+Array Control::structured_text_parser(StructuredTextParser p_theme_type, const Array &p_args, const String &p_text) const {
 	Array ret;
 	switch (p_theme_type) {
 		case STRUCTURED_TEXT_URI: {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -279,7 +279,7 @@ protected:
 
 	//virtual void _window_gui_input(InputEvent p_event);
 
-	virtual Array structured_text_parser(StructuredTextParser p_theme_type, const Array &p_args, const String p_text) const;
+	virtual Array structured_text_parser(StructuredTextParser p_theme_type, const Array &p_args, const String &p_text) const;
 
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -159,6 +159,7 @@ private:
 		mutable Vector<Line> text;
 		Ref<Font> font;
 		int font_size = -1;
+		int font_height = 0;
 
 		Dictionary opentype_features;
 		String language;
@@ -204,8 +205,8 @@ private:
 			}
 		}
 		bool is_hidden(int p_line) const { return text[p_line].hidden; }
-		void insert(int p_at, const String &p_text, const Array &p_bidi_override);
-		void remove_at(int p_index);
+		void insert(int p_at, const Vector<String> &p_text, const Vector<Array> &p_bidi_override);
+		void remove_range(int p_from_line, int p_to_line);
 		int size() const { return text.size(); }
 		void clear();
 


### PR DESCRIPTION
Significantly increased the performance of base `TextEdit` operations, not sure we can get much more out of these now, unless we move away from using `vector`. The remaining costly operations seem to now be tied up in `TextServer`.

Some benchmarks during my testing:

- Load time for a `21k` script as been reduced from `10.5s` to `1.3s`. 
- Deleting `21k` lines has been decreased from `95s` to `90ms`.
- Inserting `21k` lines has been reduced by around `300ms`

As for the changes, previously for both insert and remove we were going line by line causing a `vector` resize each time, now it operates on a range so we only need to resize and shuffle the `vector` once. 

During load we called `invalidate_all` which updated line by line, however with the cached values not matching the line, we would excessively call  `_calculate_line_height` and `_calculate_max_line_width` to check if they are valid, which would be the case until the last line had been updated. This has been updated to clear both values where we can.

Made some smaller adjustments to reduce string operations, such as `_base_get_text` now uses the string builder.

closes #42496