### PR TITLE
Deprecate redundant `fract_delta` property in GPUParticles

### DIFF
--- a/doc/classes/GPUParticles2D.xml
+++ b/doc/classes/GPUParticles2D.xml
@@ -75,7 +75,7 @@
 		<member name="fixed_fps" type="int" setter="set_fixed_fps" getter="get_fixed_fps" default="30">
 			The particle system's frame rate is fixed to a value. For example, changing the value to 2 will make the particles render at 2 frames per second. Note this does not slow down the simulation of the particle system itself.
 		</member>
-		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" default="true">
+		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" default="true" deprecated="Fractional delta is now always enabled and hidden in the inspector, as disabling it had no tangible effect.">
 			If [code]true[/code], results in fractional delta calculation which has a smoother particles display effect.
 		</member>
 		<member name="interp_to_end" type="float" setter="set_interp_to_end" getter="get_interp_to_end" default="0.0">

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -106,7 +106,7 @@
 		<member name="fixed_fps" type="int" setter="set_fixed_fps" getter="get_fixed_fps" default="30">
 			The particle system's frame rate is fixed to a value. For example, changing the value to 2 will make the particles render at 2 frames per second. Note this does not slow down the simulation of the particle system itself.
 		</member>
-		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" default="true">
+		<member name="fract_delta" type="bool" setter="set_fractional_delta" getter="get_fractional_delta" default="true" deprecated="Fractional delta is now always enabled and hidden in the inspector, as disabling it had no tangible effect.">
 			If [code]true[/code], results in fractional delta calculation which has a smoother particles display effect.
 		</member>
 		<member name="interp_to_end" type="float" setter="set_interp_to_end" getter="get_interp_to_end" default="0.0">

--- a/drivers/gles3/shaders/particles.glsl
+++ b/drivers/gles3/shaders/particles.glsl
@@ -162,7 +162,6 @@ uniform sampler2D height_field_texture; //texunit:0
 uniform float lifetime;
 uniform bool clear;
 uniform uint total_particles;
-uniform bool use_fractional_delta;
 
 uint hash(uint x) {
 	x = ((x >> uint(16)) ^ x) * uint(0x45d9f3b);
@@ -276,23 +275,17 @@ void main() {
 
 			if (restart_phase >= prev_system_phase && restart_phase < system_phase) {
 				restart = true;
-				if (use_fractional_delta) {
-					local_delta = (system_phase - restart_phase) * lifetime;
-				}
+				local_delta = (system_phase - restart_phase) * lifetime;
 			}
 
 		} else if (delta > 0.0) {
 			if (restart_phase >= prev_system_phase) {
 				restart = true;
-				if (use_fractional_delta) {
-					local_delta = (1.0 - restart_phase + system_phase) * lifetime;
-				}
+				local_delta = (1.0 - restart_phase + system_phase) * lifetime;
 
 			} else if (restart_phase < system_phase) {
 				restart = true;
-				if (use_fractional_delta) {
-					local_delta = (system_phase - restart_phase) * lifetime;
-				}
+				local_delta = (system_phase - restart_phase) * lifetime;
 			}
 		}
 

--- a/drivers/gles3/storage/particles_storage.cpp
+++ b/drivers/gles3/storage/particles_storage.cpp
@@ -756,7 +756,6 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 	material_storage->shaders.particles_process_shader.version_set_uniform(ParticlesShaderGLES3::LIFETIME, p_particles->lifetime, version, variant, specialization);
 	material_storage->shaders.particles_process_shader.version_set_uniform(ParticlesShaderGLES3::CLEAR, p_particles->clear, version, variant, specialization);
 	material_storage->shaders.particles_process_shader.version_set_uniform(ParticlesShaderGLES3::TOTAL_PARTICLES, uint32_t(p_particles->amount), version, variant, specialization);
-	material_storage->shaders.particles_process_shader.version_set_uniform(ParticlesShaderGLES3::USE_FRACTIONAL_DELTA, p_particles->fractional_delta, version, variant, specialization);
 
 	p_particles->clear = false;
 

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -831,7 +831,7 @@ void GPUParticles2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "randomness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_randomness_ratio", "get_randomness_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fixed_fps", PROPERTY_HINT_RANGE, "0,1000,1,suffix:FPS"), "set_fixed_fps", "get_fixed_fps");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "interpolate"), "set_interpolate", "get_interpolate");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fract_delta"), "set_fractional_delta", "get_fractional_delta");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fract_delta", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_fractional_delta", "get_fractional_delta");
 	ADD_GROUP("Collision", "collision_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_base_size", PROPERTY_HINT_RANGE, "0,128,0.01,or_greater"), "set_collision_base_size", "get_collision_base_size");
 	ADD_GROUP("Drawing", "");

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -757,7 +757,7 @@ void GPUParticles3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "randomness", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_randomness_ratio", "get_randomness_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "fixed_fps", PROPERTY_HINT_RANGE, "0,1000,1,suffix:FPS"), "set_fixed_fps", "get_fixed_fps");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "interpolate"), "set_interpolate", "get_interpolate");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fract_delta"), "set_fractional_delta", "get_fractional_delta");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fract_delta", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_fractional_delta", "get_fractional_delta");
 	ADD_GROUP("Collision", "collision_");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "collision_base_size", PROPERTY_HINT_RANGE, "0,128,0.01,or_greater,suffix:m"), "set_collision_base_size", "get_collision_base_size");
 	ADD_GROUP("Drawing", "");

--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -180,10 +180,11 @@ layout(push_constant, std430) uniform Params {
 	bool clear;
 	uint total_particles;
 	uint trail_size;
-	bool use_fractional_delta;
+
 	bool sub_emitter_mode;
 	bool can_emit;
 	bool trail_pass;
+	uint pad;
 }
 params;
 
@@ -406,23 +407,17 @@ void main() {
 
 			if (restart_phase >= FRAME.prev_system_phase && restart_phase < FRAME.system_phase) {
 				restart = true;
-				if (params.use_fractional_delta) {
-					local_delta = (FRAME.system_phase - restart_phase) * params.lifetime;
-				}
+				local_delta = (FRAME.system_phase - restart_phase) * params.lifetime;
 			}
 
 		} else if (FRAME.delta > 0.0) {
 			if (restart_phase >= FRAME.prev_system_phase) {
 				restart = true;
-				if (params.use_fractional_delta) {
-					local_delta = (1.0 - restart_phase + FRAME.system_phase) * params.lifetime;
-				}
+				local_delta = (1.0 - restart_phase + FRAME.system_phase) * params.lifetime;
 
 			} else if (restart_phase < FRAME.system_phase) {
 				restart = true;
-				if (params.use_fractional_delta) {
-					local_delta = (FRAME.system_phase - restart_phase) * params.lifetime;
-				}
+				local_delta = (FRAME.system_phase - restart_phase) * params.lifetime;
 			}
 		}
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1094,7 +1094,6 @@ void ParticlesStorage::_particles_process(Particles *p_particles, double p_delta
 	push_constant.total_particles = p_particles->amount;
 	push_constant.lifetime = p_particles->lifetime;
 	push_constant.trail_size = p_particles->trail_params.size();
-	push_constant.use_fractional_delta = p_particles->fractional_delta;
 	push_constant.sub_emitter_mode = !p_particles->emitting && p_particles->emission_buffer && (p_particles->emission_buffer->particle_count > 0 || p_particles->force_sub_emit);
 	push_constant.trail_pass = false;
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -276,10 +276,10 @@ private:
 			uint32_t total_particles;
 			uint32_t trail_size;
 
-			uint32_t use_fractional_delta;
 			uint32_t sub_emitter_mode;
 			uint32_t can_emit;
 			uint32_t trail_pass;
+			uint32_t pad;
 		};
 
 		ParticlesShaderRD shader;


### PR DESCRIPTION
This property was made redundant by the addition of interpolation in GPUParticles. It's now always enabled.

CPUParticles still features a `fract_delta` property for now. Should we remove it as well?

See [discussion on the Godot Contributors Chat](https://chat.godotengine.org/channel/rendering?msg=G8cNTJHiDcnEwQbuy).