### PR TITLE
[Master] Fix compilation error (ALIGN_CENTER)

### DIFF
--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -125,7 +125,7 @@ MaterialEditor::MaterialEditor() {
 	// canvas item
 
 	layout_2d = memnew(HBoxContainer);
-	layout_2d->set_alignment(BoxContainer::ALIGN_CENTER);
+	layout_2d->set_alignment(BoxContainer::ALIGNMENT_CENTER);
 	add_child(layout_2d);
 	layout_2d->set_anchors_and_offsets_preset(PRESET_WIDE);
 


### PR DESCRIPTION
Compiling the editor on linux is broken (commit: 41e5f9227c3da58df2efbdf9819594cfa66a3294 )
```
editor/plugins/material_editor_plugin.cpp: In constructor 'MaterialEditor::MaterialEditor()':
editor/plugins/material_editor_plugin.cpp:128:48: error: 'ALIGN_CENTER' is not a member of 'BoxContainer'
  128 |         layout_2d->set_alignment(BoxContainer::ALIGN_CENTER);
```