### PR TITLE
Transferring the calculations of the results of the impulse to a RigidDynamicBody2D object into separate methods. 

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -797,6 +797,18 @@ int RigidDynamicBody2D::get_max_contacts_reported() const {
 	return max_contacts_reported;
 }
 
+Vector2 RigidDynamicBody2D::calculate_central_impulse_result(const Vector2 &p_impulse) const {
+	return PhysicsServer2D::get_singleton()->body_calculate_central_impulse_result(get_rid(), p_impulse);
+}
+
+real_t RigidDynamicBody2D::calculate_torque_impulse_result(real_t p_torque) const {
+	return PhysicsServer2D::get_singleton()->body_calculate_torque_impulse_result(get_rid(), p_torque);
+}
+
+real_t RigidDynamicBody2D::calculate_bias_torque_impulse_result(const Vector2 &p_impulse, const Vector2 &p_position) const {
+	return PhysicsServer2D::get_singleton()->body_calculate_bias_torque_impulse_result(get_rid(), p_impulse, p_position);
+}
+
 void RigidDynamicBody2D::apply_central_impulse(const Vector2 &p_impulse) {
 	PhysicsServer2D::get_singleton()->body_apply_central_impulse(get_rid(), p_impulse);
 }
@@ -973,6 +985,10 @@ void RigidDynamicBody2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_continuous_collision_detection_mode", "mode"), &RigidDynamicBody2D::set_continuous_collision_detection_mode);
 	ClassDB::bind_method(D_METHOD("get_continuous_collision_detection_mode"), &RigidDynamicBody2D::get_continuous_collision_detection_mode);
+
+	ClassDB::bind_method(D_METHOD("calculate_central_impulse_result", "impulse"), &RigidDynamicBody2D::calculate_central_impulse_result);
+	ClassDB::bind_method(D_METHOD("calculate_torque_impulse_result", "torque"), &RigidDynamicBody2D::calculate_torque_impulse_result);
+	ClassDB::bind_method(D_METHOD("calculate_bias_torque_impulse_result", "impulse", "position"), &RigidDynamicBody2D::calculate_bias_torque_impulse_result);
 
 	ClassDB::bind_method(D_METHOD("set_axis_velocity", "axis_velocity"), &RigidDynamicBody2D::set_axis_velocity);
 	ClassDB::bind_method(D_METHOD("apply_central_impulse", "impulse"), &RigidDynamicBody2D::apply_central_impulse, Vector2());

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -288,6 +288,10 @@ public:
 	void set_continuous_collision_detection_mode(CCDMode p_mode);
 	CCDMode get_continuous_collision_detection_mode() const;
 
+	Vector2 calculate_central_impulse_result(const Vector2 &p_impulse) const;
+	real_t calculate_torque_impulse_result(real_t p_torque) const;
+	real_t calculate_bias_torque_impulse_result(const Vector2 &p_impulse, const Vector2 &p_position) const;
+
 	void apply_central_impulse(const Vector2 &p_impulse);
 	void apply_impulse(const Vector2 &p_impulse, const Vector2 &p_position = Vector2());
 	void apply_torque_impulse(real_t p_torque);

--- a/servers/physics_2d/godot_physics_server_2d.cpp
+++ b/servers/physics_2d/godot_physics_server_2d.cpp
@@ -782,6 +782,27 @@ real_t GodotPhysicsServer2D::body_get_applied_torque(RID p_body) const {
 	return body->get_applied_torque();
 };
 
+Vector2 GodotPhysicsServer2D::body_calculate_central_impulse_result(RID p_body, const Vector2 &p_impulse) const {
+	GodotBody2D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_COND_V(!body, Vector2());
+
+	return body->calculate_central_impulse_result(p_impulse);
+}
+
+real_t GodotPhysicsServer2D::body_calculate_torque_impulse_result(RID p_body, real_t p_torque) const {
+	GodotBody2D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_COND_V(!body, 0);
+
+	return body->calculate_torque_impulse_result(p_torque);
+}
+
+real_t GodotPhysicsServer2D::body_calculate_bias_torque_impulse_result(RID p_body, const Vector2 &p_impulse, const Vector2 &p_position) const {
+	GodotBody2D* body = body_owner.get_or_null(p_body);
+	ERR_FAIL_COND_V(!body, 0);
+
+	return body->calculate_bias_torque_impulse_result(p_impulse, p_position);
+};
+
 void GodotPhysicsServer2D::body_apply_central_impulse(RID p_body, const Vector2 &p_impulse) {
 	GodotBody2D *body = body_owner.get_or_null(p_body);
 	ERR_FAIL_COND(!body);

--- a/servers/physics_2d/godot_physics_server_2d.h
+++ b/servers/physics_2d/godot_physics_server_2d.h
@@ -217,6 +217,10 @@ public:
 	virtual void body_add_force(RID p_body, const Vector2 &p_force, const Vector2 &p_position = Vector2()) override;
 	virtual void body_add_torque(RID p_body, real_t p_torque) override;
 
+	virtual Vector2 body_calculate_central_impulse_result(RID p_body, const Vector2 &p_impulse) const override;
+	virtual real_t body_calculate_torque_impulse_result(RID p_body, real_t p_torque) const override;
+	virtual real_t body_calculate_bias_torque_impulse_result(RID p_body, const Vector2 &p_impulse, const Vector2 &p_position) const override;
+
 	virtual void body_apply_central_impulse(RID p_body, const Vector2 &p_impulse) override;
 	virtual void body_apply_torque_impulse(RID p_body, real_t p_torque) override;
 	virtual void body_apply_impulse(RID p_body, const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) override;

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -685,6 +685,10 @@ void PhysicsServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("body_set_state", "body", "state", "value"), &PhysicsServer2D::body_set_state);
 	ClassDB::bind_method(D_METHOD("body_get_state", "body", "state"), &PhysicsServer2D::body_get_state);
 
+	ClassDB::bind_method(D_METHOD("body_calculate_central_impulse_result", "body", "impulse"), &PhysicsServer2D::body_calculate_central_impulse_result);
+	ClassDB::bind_method(D_METHOD("body_calculate_torque_impulse_result", "body", "torque"), &PhysicsServer2D::body_calculate_torque_impulse_result);
+	ClassDB::bind_method(D_METHOD("body_calculate_bias_torque_impulse_result", "body", "impulse", "position"), &PhysicsServer2D::body_calculate_bias_torque_impulse_result);
+
 	ClassDB::bind_method(D_METHOD("body_apply_central_impulse", "body", "impulse"), &PhysicsServer2D::body_apply_central_impulse);
 	ClassDB::bind_method(D_METHOD("body_apply_torque_impulse", "body", "impulse"), &PhysicsServer2D::body_apply_torque_impulse);
 	ClassDB::bind_method(D_METHOD("body_apply_impulse", "body", "impulse", "position"), &PhysicsServer2D::body_apply_impulse, Vector2());

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -430,6 +430,10 @@ public:
 	virtual void body_add_force(RID p_body, const Vector2 &p_force, const Vector2 &p_position = Vector2()) = 0;
 	virtual void body_add_torque(RID p_body, real_t p_torque) = 0;
 
+	virtual Vector2 body_calculate_central_impulse_result(RID p_body, const Vector2 &p_impulse) const = 0;
+	virtual real_t body_calculate_torque_impulse_result(RID p_body, real_t p_torque) const = 0;
+	virtual real_t body_calculate_bias_torque_impulse_result(RID p_body, const Vector2 &p_impulse, const Vector2 &p_position) const = 0;
+
 	virtual void body_apply_central_impulse(RID p_body, const Vector2 &p_impulse) = 0;
 	virtual void body_apply_torque_impulse(RID p_body, real_t p_torque) = 0;
 	virtual void body_apply_impulse(RID p_body, const Vector2 &p_impulse, const Vector2 &p_position = Vector2()) = 0;

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -222,6 +222,11 @@ public:
 	FUNC2(body_add_central_force, RID, const Vector2 &);
 	FUNC3(body_add_force, RID, const Vector2 &, const Vector2 &);
 	FUNC2(body_add_torque, RID, real_t);
+
+	FUNC2RC(Vector2, body_calculate_central_impulse_result, RID, const Vector2 &);
+	FUNC2RC(real_t, body_calculate_torque_impulse_result, RID, real_t);
+	FUNC3RC(real_t, body_calculate_bias_torque_impulse_result, RID, const Vector2 &, const Vector2 &);
+
 	FUNC2(body_apply_central_impulse, RID, const Vector2 &);
 	FUNC2(body_apply_torque_impulse, RID, real_t);
 	FUNC3(body_apply_impulse, RID, const Vector2 &, const Vector2 &);


### PR DESCRIPTION
Transferring the calculations of the results of the impulse to a RigidDynamicBody2D object into separate methods. Added 3 methods:
- calculate_central_impulse_result(Vector2 impulse)
- calculate_torque_impulse_result(float torque)
- calculate_bias_torque_impulse_result(Vector2 impulse, Vector2 position)

This opportunity is needed to find out the acceleration that the engine can provide. In my case, I am developing an AI for a game like Asteroids. And I need to find out how fast the ship can accelerate or slow down with the current engine and the current mass of the ship. But I haven't found any working way to do this. 

As a bonus, several code duplications were removed in the `godot_body_2d.h` file. 