### PR TITLE
Center the indeterminate spinner on HTML5 page

### DIFF
--- a/misc/dist/html/full-size.html
+++ b/misc/dist/html/full-size.html
@@ -80,6 +80,7 @@
 		}
 
 		#status-indeterminate {
+			height: 42px;
 			visibility: visible;
 			position: relative;
 		}


### PR DESCRIPTION
The indeterminate spinner was not centered vertically on the page.

| | screenshot with all three states visible |
|-|-|
| before | ![before](https://user-images.githubusercontent.com/372476/145422800-3f274eb6-6fd5-451e-892a-cd437cd105eb.png) |
| after | ![after](https://user-images.githubusercontent.com/372476/145422858-0e9b15ad-45b4-4436-af00-5920a4f4049a.png) |

42 is ~~the Answer to the Ultimate Question of Life, the Universe, and Everything~~ double of the spin radius:

https://github.com/godotengine/godot/blob/012b2b53854f49b5bd4f60a2a056f71a3ccb2e1c/misc/dist/html/full-size.html#L93