### PR TITLE
Tweak shadow bias defaults for DirectionalLight3D and OmniLight3D

### DIFF
--- a/doc/classes/Light3D.xml
+++ b/doc/classes/Light3D.xml
@@ -114,7 +114,7 @@
 		<member name="shadow_enabled" type="bool" setter="set_shadow" getter="has_shadow" default="false">
 			If [code]true[/code], the light will cast real-time shadows. This has a significant performance cost. Only enable shadow rendering when it makes a noticeable difference in the scene's appearance, and consider using [member distance_fade_enabled] to hide the light when far away from the [Camera3D].
 		</member>
-		<member name="shadow_normal_bias" type="float" setter="set_param" getter="get_param" default="1.0">
+		<member name="shadow_normal_bias" type="float" setter="set_param" getter="get_param" default="2.0">
 			Offsets the lookup into the shadow map by the object's normal. This can be used to reduce self-shadowing artifacts without using [member shadow_bias]. In practice, this value should be tweaked along with [member shadow_bias] to reduce artifacts as much as possible.
 		</member>
 		<member name="shadow_opacity" type="float" setter="set_param" getter="get_param" default="1.0">

--- a/doc/classes/OmniLight3D.xml
+++ b/doc/classes/OmniLight3D.xml
@@ -20,7 +20,7 @@
 		<member name="omni_shadow_mode" type="int" setter="set_shadow_mode" getter="get_shadow_mode" enum="OmniLight3D.ShadowMode" default="1">
 			See [enum ShadowMode].
 		</member>
-		<member name="shadow_bias" type="float" setter="set_param" getter="get_param" overrides="Light3D" default="0.2" />
+		<member name="shadow_normal_bias" type="float" setter="set_param" getter="get_param" overrides="Light3D" default="1.0" />
 	</members>
 	<constants>
 		<constant name="SHADOW_DUAL_PARABOLOID" value="0" enum="ShadowMode">

--- a/doc/classes/SpotLight3D.xml
+++ b/doc/classes/SpotLight3D.xml
@@ -12,6 +12,7 @@
 	</tutorials>
 	<members>
 		<member name="shadow_bias" type="float" setter="set_param" getter="get_param" overrides="Light3D" default="0.03" />
+		<member name="shadow_normal_bias" type="float" setter="set_param" getter="get_param" overrides="Light3D" default="1.0" />
 		<member name="spot_angle" type="float" setter="set_param" getter="get_param" default="45.0">
 			The spotlight's angle in degrees.
 			[b]Note:[/b] [member spot_angle] is not affected by [member Node3D.scale] (the light's scale or its parent's scale).

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -461,7 +461,7 @@ Light3D::Light3D(RenderingServer::LightType p_type) {
 	set_param(PARAM_SHADOW_PANCAKE_SIZE, 20.0);
 	set_param(PARAM_SHADOW_OPACITY, 1.0);
 	set_param(PARAM_SHADOW_BLUR, 1.0);
-	set_param(PARAM_SHADOW_BIAS, 0.03);
+	set_param(PARAM_SHADOW_BIAS, 0.1);
 	set_param(PARAM_SHADOW_NORMAL_BIAS, 1.0);
 	set_param(PARAM_TRANSMITTANCE_BIAS, 0.05);
 	set_param(PARAM_SHADOW_FADE_START, 1);
@@ -571,8 +571,8 @@ DirectionalLight3D::DirectionalLight3D() :
 		Light3D(RenderingServer::LIGHT_DIRECTIONAL) {
 	set_param(PARAM_SHADOW_MAX_DISTANCE, 100);
 	set_param(PARAM_SHADOW_FADE_START, 0.8);
-	// Increase the default shadow bias to better suit most scenes.
-	set_param(PARAM_SHADOW_BIAS, 0.1);
+	// Increase the default shadow normal bias to better suit most scenes.
+	set_param(PARAM_SHADOW_NORMAL_BIAS, 2.0);
 	set_param(PARAM_INTENSITY, 100000.0); // Specified in Lux, approximate mid-day sun.
 	set_shadow_mode(SHADOW_PARALLEL_4_SPLITS);
 	blend_splits = false;
@@ -614,8 +614,6 @@ void OmniLight3D::_bind_methods() {
 OmniLight3D::OmniLight3D() :
 		Light3D(RenderingServer::LIGHT_OMNI) {
 	set_shadow_mode(SHADOW_CUBE);
-	// Increase the default shadow biases to better suit most scenes.
-	set_param(PARAM_SHADOW_BIAS, 0.2);
 }
 
 PackedStringArray SpotLight3D::get_configuration_warnings() const {
@@ -638,4 +636,10 @@ void SpotLight3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "spot_attenuation", PROPERTY_HINT_EXP_EASING, "attenuation"), "set_param", "get_param", PARAM_ATTENUATION);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "spot_angle", PROPERTY_HINT_RANGE, "0,180,0.01,degrees"), "set_param", "get_param", PARAM_SPOT_ANGLE);
 	ADD_PROPERTYI(PropertyInfo(Variant::FLOAT, "spot_angle_attenuation", PROPERTY_HINT_EXP_EASING, "attenuation"), "set_param", "get_param", PARAM_SPOT_ATTENUATION);
+}
+
+SpotLight3D::SpotLight3D() :
+		Light3D(RenderingServer::LIGHT_SPOT) {
+	// Decrease the default shadow bias to better suit most scenes.
+	set_param(PARAM_SHADOW_BIAS, 0.03);
 }

--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -233,8 +233,7 @@ protected:
 public:
 	PackedStringArray get_configuration_warnings() const override;
 
-	SpotLight3D() :
-			Light3D(RenderingServer::LIGHT_SPOT) {}
+	SpotLight3D();
 };
 
 #endif // LIGHT_3D_H


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/51335.

Light3D now uses a normal bias of 2 (instead of 1) to better combat shadow acne, without introducing more peter-panning.

The new values behave fairly well at increased blur values (between 1 and 2.5), but extreme blur values still don't look good out of the box. We can further improve reduce acne/peter-panning at high blur values by multiplying the shadow bias by the blur value (when it's above 1), but I think this is better to do in a separate PR.
**Edit:** Done in https://github.com/godotengine/godot/pull/55758 :slightly_smiling_face: 

This closes https://github.com/godotengine/godot/issues/54523.

**Testing project:** [test_shadows.zip](https://github.com/godotengine/godot/files/7686674/test_shadows.zip)

## Preview

*Click to view at full size.*

***Note:** Debanding is enabled to ensure that color banding doesn't get confused for shadow acne. Lights also have their Specular property set to 0.0.*

### DirectionalLight3D

| Before | After |
|-|-|
| ![2021-12-09_16 42 20](https://user-images.githubusercontent.com/180032/145432269-eac13b41-27b3-417c-a188-02f3f8d6c1a7.png) | ![2021-12-09_16 42 35](https://user-images.githubusercontent.com/180032/145432278-840d97b0-770a-4406-8a75-b3d041f9cad0.png) |

### OmniLight3D

| Before | After |
|-|-|
| ![2021-12-09_16 44 07](https://user-images.githubusercontent.com/180032/145432280-9cad5601-b576-4771-802c-ed8d807500fe.png) | ![2021-12-09_16 44 16](https://user-images.githubusercontent.com/180032/145432284-46c960a2-bcda-4f0b-b9b1-2414c2cff67f.png) |