### PR TITLE
Document sampling a TextureArray with sRGB -> linear conversion

### DIFF
--- a/doc/classes/Texture3D.xml
+++ b/doc/classes/Texture3D.xml
@@ -4,7 +4,8 @@
 		Texture with 3 dimensions.
 	</brief_description>
 	<description>
-		Texture3D is a 3-dimensional texture that has a width, height, and depth.
+		Texture3D is a 3-dimensional [Texture] that has a width, height, and depth. See also [TextureArray].
+		[b]Note:[/b] [Texture3D]s can only be sampled in shaders in the GLES3 backend. In GLES2, their data can be accessed via scripting, but there is no way to render them in a hardware-accelerated manner.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/TextureArray.xml
+++ b/doc/classes/TextureArray.xml
@@ -4,8 +4,8 @@
 		Array of textures stored in a single primitive.
 	</brief_description>
 	<description>
-		[TextureArray]s store an array of [Image]s in a single [Texture] primitive. Each layer of the texture array has its own mipmap chain. This makes it is a good alternative to texture atlases.
-		[TextureArray]s must be displayed using shaders. After importing your file as a [TextureArray] and setting the appropriate Horizontal and Vertical Slices, display it by setting it as a uniform to a shader, for example:
+		[TextureArray]s store an array of [Image]s in a single [Texture] primitive. Each layer of the texture array has its own mipmap chain. This makes it is a good alternative to texture atlases. See also [Texture3D].
+		[TextureArray]s must be displayed using shaders. After importing your file as a [TextureArray] and setting the appropriate Horizontal and Vertical Slices, display it by setting it as a uniform to a shader, for example (2D):
 		[codeblock]
 		shader_type canvas_item;
 
@@ -17,6 +17,18 @@
 		}
 		[/codeblock]
 		Set the integer uniform "index" to show a particular part of the texture as defined by the Horizontal and Vertical Slices in the importer.
+		[b]Note:[/b] When sampling an albedo texture from a texture array in 3D, the sRGB -&gt; linear conversion hint ([code]hint_albedo[/code]) should be used to prevent colors from looking washed out:
+		[codeblock]
+		shader_type spatial;
+
+		uniform sampler2DArray tex : hint_albedo;
+		uniform int index;
+
+		void fragment() {
+		    ALBEDO = texture(tex, vec3(UV.x, UV.y, float(index)));
+		}
+		[/codeblock]
+		[b]Note:[/b] [TextureArray]s can only be sampled in shaders in the GLES3 backend. In GLES2, their data can be accessed via scripting, but there is no way to render them in a hardware-accelerated manner.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
This is required when sampling an albedo map from a texture array in 3D. Otherwise, colors will look washed out.

This also adds a mention that Texture3D and TextureArray sampling is only supported in GLES3. (Is this actually correct? I remember the CPU lightmapper only being able to use texture arrays in GLES3.)

This closes https://github.com/godotengine/godot/issues/55751.