### PR TITLE
Fix rigid body ray cast CCD in 2D and 3D Godot Physics

### DIFF
--- a/servers/physics_2d/godot_body_pair_2d.h
+++ b/servers/physics_2d/godot_body_pair_2d.h
@@ -79,10 +79,11 @@ class GodotBodyPair2D : public GodotConstraint2D {
 	Contact contacts[MAX_CONTACTS];
 	int contact_count = 0;
 	bool collided = false;
+	bool check_ccd = false;
 	bool oneway_disabled = false;
 	bool report_contacts_only = false;
 
-	bool _test_ccd(real_t p_step, GodotBody2D *p_A, int p_shape_A, const Transform2D &p_xform_A, GodotBody2D *p_B, int p_shape_B, const Transform2D &p_xform_B, bool p_swap_result = false);
+	bool _test_ccd(real_t p_step, GodotBody2D *p_A, int p_shape_A, const Transform2D &p_xform_A, GodotBody2D *p_B, int p_shape_B, const Transform2D &p_xform_B);
 	void _validate_contacts();
 	static void _add_contact(const Vector2 &p_point_A, const Vector2 &p_point_B, void *p_self);
 	_FORCE_INLINE_ void _contact_added_callback(const Vector2 &p_point_A, const Vector2 &p_point_B);

--- a/servers/physics_3d/godot_body_pair_3d.h
+++ b/servers/physics_3d/godot_body_pair_3d.h
@@ -60,6 +60,7 @@ protected:
 
 	Vector3 sep_axis;
 	bool collided = false;
+	bool check_ccd = false;
 
 	GodotSpace3D *space = nullptr;
 


### PR DESCRIPTION
For 2D:
Raycast CCD now works the same as in 3D, it changes the body's velocity to place it at the position of impact instead of generating a contact point that causes a wrong push back.

For both 2D and 3D:
The raycast CCD process reads and modifies body velocities, so it needs to be moved to `pre_solve()` (processed on the main thread linearly) instead of `setup()` (processed on multiple threads in parallel), otherwise multithreading can cause some CCD results to be randomly lost when multiple collisions occur involving the same body.

Fixes the raycast CCD part of #9071
In 2D, shapecast CCD is still not working correctly.