### PR TITLE
Add drag start/end signals for `Slider`

### DIFF
--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -25,4 +25,17 @@
 			If [code]true[/code], the slider will display ticks for minimum and maximum values.
 		</member>
 	</members>
+	<signals>
+		<signal name="drag_ended">
+			<argument index="0" name="value_changed" type="bool" />
+			<description>
+				Emitted when dragging stops. If [code]value_changed[/code] is true, [member Range.value] is different from the value when you started the dragging.
+			</description>
+		</signal>
+		<signal name="drag_started">
+			<description>
+				Emitted when dragging is started.
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -70,8 +70,13 @@ void Slider::gui_input(const Ref<InputEvent> &p_event) {
 				}
 				grab.active = true;
 				grab.uvalue = get_as_ratio();
+
+				emit_signal(SNAME("drag_started"));
 			} else {
 				grab.active = false;
+
+				const bool value_changed = !Math::is_equal_approx((double)grab.uvalue, get_as_ratio());
+				emit_signal(SNAME("drag_ended"), value_changed);
 			}
 		} else if (scrollable) {
 			if (mb->is_pressed() && mb->get_button_index() == MouseButton::WHEEL_UP) {
@@ -263,6 +268,9 @@ void Slider::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_editable"), &Slider::is_editable);
 	ClassDB::bind_method(D_METHOD("set_scrollable", "scrollable"), &Slider::set_scrollable);
 	ClassDB::bind_method(D_METHOD("is_scrollable"), &Slider::is_scrollable);
+
+	ADD_SIGNAL(MethodInfo("drag_started"));
+	ADD_SIGNAL(MethodInfo("drag_ended", PropertyInfo(Variant::BOOL, "value_changed")));
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "editable"), "set_editable", "is_editable");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scrollable"), "set_scrollable", "is_scrollable");


### PR DESCRIPTION
Resolves #6007

Also provided a `value_changed` parameter for `drag_ended()` signal so the user won't need to keep track of the old value manually.