### PR TITLE
Clarify that replace_by keeps child nodes in tree

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -571,7 +571,8 @@
 			<description>
 				Replaces a node in a scene by the given one. Subscriptions that pass through this node will be lost.
 				If [code]keep_groups[/code] is [code]true[/code], the [code]node[/code] is added to the same groups that the replaced node is in.
-				Note that the replaced node is not automatically freed, so you either need to keep it in a variable for later use or free it using [method Object.free].
+				[b]Note:[/b] The given node will become the new parent of any child nodes that the replaced node had.
+				[b]Note:[/b] The replaced node is not automatically freed, so you either need to keep it in a variable for later use or free it using [method Object.free].
 			</description>
 		</method>
 		<method name="request_ready">


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Closes #28746
Related: #55710

The name of this function seems to cause confusion. It can sound as if it would be replacing a whole subtree, or as if it replaces a single node with another single node. In truth it's neither: A single node is removed from the tree, while a subtree is added to the tree. The children of the replaced node are reparented to the new node, resulting in a merged list of child nodes.

Mentioning this behavior in the documentation could help prevent misuse / unexpected behavior.