### PR TITLE
Unify bits, arch, and android_arch into env["arch"]

### DIFF
--- a/.github/workflows/android_builds.yml
+++ b/.github/workflows/android_builds.yml
@@ -38,19 +38,19 @@ jobs:
       - name: Setup python and scons
         uses: ./.github/actions/godot-deps
 
-      - name: Compilation (armv7)
+      - name: Compilation (arm32)
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} android_arch=armv7
+          sconsflags: ${{ env.SCONSFLAGS }} arch=arm32
           platform: android
           target: release
           tools: false
           tests: false
 
-      - name: Compilation (arm64v8)
+      - name: Compilation (arm64)
         uses: ./.github/actions/godot-build
         with:
-          sconsflags: ${{ env.SCONSFLAGS }} android_arch=arm64v8
+          sconsflags: ${{ env.SCONSFLAGS }} arch=arm64
           platform: android
           target: release
           tools: false

--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup python and scons
         uses: ./.github/actions/godot-deps
 
-      - name: Compilation (arm64v8)
+      - name: Compilation (arm64)
         uses: ./.github/actions/godot-build
         with:
           sconsflags: ${{ env.SCONSFLAGS }}

--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -28,7 +28,7 @@ jobs:
             tests: false # Disabled due freeze caused by mix Mono build and CI
             sconsflags: module_mono_enabled=yes
             doc-test: true
-            bin: "./bin/godot.linuxbsd.opt.tools.64.mono"
+            bin: "./bin/godot.linuxbsd.opt.tools.x86_64.mono"
             build-mono: true
             proj-conv: true
             artifact: true
@@ -43,7 +43,7 @@ jobs:
             # Can be turned off for PRs that intentionally break compat with godot-cpp,
             # until both the upstream PR and the matching godot-cpp changes are merged.
             godot-cpp-test: true
-            bin: "./bin/godot.linuxbsd.double.tools.64.san"
+            bin: "./bin/godot.linuxbsd.double.tools.x86_64.san"
             build-mono: false
             # Skip 2GiB artifact speeding up action.
             artifact: false
@@ -54,7 +54,7 @@ jobs:
             tools: true
             tests: true
             sconsflags: use_asan=yes use_ubsan=yes use_llvm=yes linker=lld
-            bin: "./bin/godot.linuxbsd.tools.64.llvm.san"
+            bin: "./bin/godot.linuxbsd.tools.x86_64.llvm.san"
             build-mono: false
             # Skip 2GiB artifact speeding up action.
             artifact: false

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -24,7 +24,7 @@ jobs:
             target: release_debug
             tools: true
             tests: true
-            bin: "./bin/godot.macos.opt.tools.64"
+            bin: "./bin/godot.macos.opt.tools.x86_64"
 
           - name: Template (target=release, tools=no)
             cache-name: macos-template

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -29,7 +29,7 @@ jobs:
             tests: true
             # Skip debug symbols, they're way too big with MSVC.
             sconsflags: debug_symbols=no
-            bin: "./bin/godot.windows.opt.tools.64.exe"
+            bin: "./bin/godot.windows.opt.tools.x86_64.exe"
 
           - name: Template (target=release, tools=no)
             cache-name: windows-template

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Godot runs on a large variety of platforms and operating systems and devices.
 
 For bugs that are likely OS-specific and/or graphics-related, please also specify:
 
-- Device (CPU model including architecture, e.g. x86, x86_64, ARM, etc.)
+- Device (CPU model including architecture, e.g. x86_64, arm64, etc.)
 - GPU model (and the driver version in use if you know it)
 
 **Bug reports not including the required information may be closed at the

--- a/drivers/png/SCsub
+++ b/drivers/png/SCsub
@@ -37,7 +37,7 @@ if env["builtin_libpng"]:
     import os
 
     # Enable ARM NEON instructions on 32-bit Android to compile more optimized code.
-    use_neon = "android_arch" in env and env["android_arch"] == "armv7" and os.name != "nt"
+    use_neon = env["platform"] == "android" and env["arch"] == "arm32" and os.name != "nt"
     if use_neon:
         env_png.Append(CPPDEFINES=[("PNG_ARM_NEON_OPT", 2)])
     else:

--- a/methods.py
+++ b/methods.py
@@ -540,7 +540,7 @@ def detect_visual_c_compiler_version(tools_env):
     # and not scons setup environment (env)... so make sure you call the right environment on it or it will fail to detect
     # the proper vc version that will be called
 
-    # There is no flag to give to visual c compilers to set the architecture, i.e. scons bits argument (32,64,ARM etc)
+    # There is no flag to give to visual c compilers to set the architecture, i.e. scons arch argument (x86_32, x86_64, arm64, etc.).
     # There are many different cl.exe files that are run, and each one compiles & links to a different architecture
     # As far as I know, the only way to figure out what compiler will be run when Scons calls cl.exe via Program()
     # is to check the PATH variable and figure out which one will be called first. Code below does that and returns:

--- a/modules/denoise/config.py
+++ b/modules/denoise/config.py
@@ -5,14 +5,7 @@ def can_build(env, platform):
     # as doing lightmap generation and denoising on Android or HTML5
     # would be a bit far-fetched.
     desktop_platforms = ["linuxbsd", "macos", "windows"]
-    supported_arch = env["bits"] == "64"
-    if env["arch"] == "arm64":
-        supported_arch = False
-    if env["arch"].startswith("ppc"):
-        supported_arch = False
-    if env["arch"].startswith("rv"):
-        supported_arch = False
-    return env["tools"] and platform in desktop_platforms and supported_arch
+    return env["tools"] and platform in desktop_platforms and env["arch"] == "x86_64"
 
 
 def configure(env):

--- a/modules/mono/build_scripts/mono_configure.py
+++ b/modules/mono/build_scripts/mono_configure.py
@@ -18,7 +18,7 @@ def configure(env, env_mono):
     # is_android = env["platform"] == "android"
     # is_javascript = env["platform"] == "javascript"
     # is_ios = env["platform"] == "ios"
-    # is_ios_sim = is_ios and env["arch"] in ["x86", "x86_64"]
+    # is_ios_sim = is_ios and env["arch"] in ["x86_32", "x86_64"]
 
     tools_enabled = env["tools"]
 
@@ -128,26 +128,22 @@ def find_dotnet_app_host_dir(env):
 
 
 def determine_runtime_identifier(env):
+    # The keys are Godot's names, the values are the Microsoft's names.
+    # List: https://docs.microsoft.com/en-us/dotnet/core/rid-catalog
     names_map = {
         "windows": "win",
         "macos": "osx",
         "linuxbsd": "linux",
     }
-
-    # .NET RID architectures: x86, x64, arm, or arm64
-
+    arch_map = {
+        "x86_64": "x64",
+        "x86_32": "x86",
+        "arm64": "arm64",
+        "arm32": "arm",
+    }
     platform = env["platform"]
-
     if is_desktop(platform):
-        if env["arch"] in ["arm", "arm32"]:
-            rid = "arm"
-        elif env["arch"] == "arm64":
-            rid = "arm64"
-        else:
-            bits = env["bits"]
-            bit_arch_map = {"64": "x64", "32": "x86"}
-            rid = bit_arch_map[bits]
-        return "%s-%s" % (names_map[platform], rid)
+        return "%s-%s" % (names_map[platform], arch_map[env["arch"]])
     else:
         raise NotImplementedError()
 

--- a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
@@ -75,8 +75,17 @@ namespace GodotTools.Export
             }
             else
             {
-                string bits = features.Contains("64") ? "64" : features.Contains("32") ? "32" : null;
-                CompileAssembliesForDesktop(exporter, platform, isDebug, bits, aotOpts, aotTempDir, outputDataDir, assembliesPrepared, bclDir);
+                string arch = "";
+                if (features.Contains("x86_64")) {
+                    arch = "x86_64";
+                } else if (features.Contains("x86_32")) {
+                    arch = "x86_32";
+                } else if (features.Contains("arm64")) {
+                    arch = "arm64";
+                } else if (features.Contains("arm32")) {
+                    arch = "arm32";
+                }
+                CompileAssembliesForDesktop(exporter, platform, isDebug, arch, aotOpts, aotTempDir, outputDataDir, assembliesPrepared, bclDir);
             }
         }
 
@@ -112,7 +121,7 @@ namespace GodotTools.Export
             }
         }
 
-        public static void CompileAssembliesForDesktop(ExportPlugin exporter, string platform, bool isDebug, string bits, AotOptions aotOpts, string aotTempDir, string outputDataDir, IDictionary<string, string> assemblies, string bclDir)
+        public static void CompileAssembliesForDesktop(ExportPlugin exporter, string platform, bool isDebug, string arch, AotOptions aotOpts, string aotTempDir, string outputDataDir, IDictionary<string, string> assemblies, string bclDir)
         {
             foreach (var assembly in assemblies)
             {
@@ -126,9 +135,9 @@ namespace GodotTools.Export
                 string outputFileName = assemblyName + ".dll" + outputFileExtension;
                 string tempOutputFilePath = Path.Combine(aotTempDir, outputFileName);
 
-                var compilerArgs = GetAotCompilerArgs(platform, isDebug, bits, aotOpts, assemblyPath, tempOutputFilePath);
+                var compilerArgs = GetAotCompilerArgs(platform, isDebug, arch, aotOpts, assemblyPath, tempOutputFilePath);
 
-                string compilerDirPath = GetMonoCrossDesktopDirName(platform, bits);
+                string compilerDirPath = GetMonoCrossDesktopDirName(platform, arch);
 
                 ExecuteCompiler(FindCrossCompiler(compilerDirPath), compilerArgs, bclDir);
 
@@ -432,9 +441,9 @@ MONO_AOT_MODE_LAST = 1000,
 
                 var androidToolPrefixes = new Dictionary<string, string>
                 {
-                    ["armeabi-v7a"] = "arm-linux-androideabi-",
-                    ["arm64-v8a"] = "aarch64-linux-android-",
-                    ["x86"] = "i686-linux-android-",
+                    ["arm32"] = "arm-linux-androideabi-",
+                    ["arm64"] = "aarch64-linux-android-",
+                    ["x86_32"] = "i686-linux-android-",
                     ["x86_64"] = "x86_64-linux-android-"
                 };
 
@@ -547,9 +556,9 @@ MONO_AOT_MODE_LAST = 1000,
         {
             var androidAbis = new[]
             {
-                "armeabi-v7a",
-                "arm64-v8a",
-                "x86",
+                "arm32",
+                "arm64",
+                "x86_32",
                 "x86_64"
             };
 
@@ -560,9 +569,9 @@ MONO_AOT_MODE_LAST = 1000,
         {
             var abiArchs = new Dictionary<string, string>
             {
-                ["armeabi-v7a"] = "armv7",
-                ["arm64-v8a"] = "aarch64-v8a",
-                ["x86"] = "i686",
+                ["arm32"] = "armv7",
+                ["arm64"] = "aarch64-v8a",
+                ["x86_32"] = "i686",
                 ["x86_64"] = "x86_64"
             };
 
@@ -571,30 +580,25 @@ MONO_AOT_MODE_LAST = 1000,
             return $"{arch}-linux-android";
         }
 
-        private static string GetMonoCrossDesktopDirName(string platform, string bits)
+        private static string GetMonoCrossDesktopDirName(string platform, string arch)
         {
             switch (platform)
             {
                 case OS.Platforms.Windows:
                 case OS.Platforms.UWP:
                 {
-                    string arch = bits == "64" ? "x86_64" : "i686";
                     return $"windows-{arch}";
                 }
                 case OS.Platforms.MacOS:
                 {
-                    Debug.Assert(bits == null || bits == "64");
-                    string arch = "x86_64";
                     return $"{platform}-{arch}";
                 }
                 case OS.Platforms.LinuxBSD:
                 {
-                    string arch = bits == "64" ? "x86_64" : "i686";
                     return $"linux-{arch}";
                 }
                 case OS.Platforms.Haiku:
                 {
-                    string arch = bits == "64" ? "x86_64" : "i686";
                     return $"{platform}-{arch}";
                 }
                 default:

--- a/modules/raycast/SCsub
+++ b/modules/raycast/SCsub
@@ -66,7 +66,7 @@ if env["builtin_embree"]:
     env_raycast.Append(CPPDEFINES=["EMBREE_TARGET_SSE2", "EMBREE_LOWEST_ISA", "TASKING_INTERNAL", "NDEBUG"])
 
     if not env.msvc:
-        if env["arch"] in ["x86", "x86_64"]:
+        if env["arch"] == "x86_64":
             env_raycast.Append(CPPFLAGS=["-msse2", "-mxsave"])
 
         if env["platform"] == "windows":
@@ -83,7 +83,7 @@ if env["builtin_embree"]:
     env_thirdparty.disable_warnings()
     env_thirdparty.add_source_files(thirdparty_obj, thirdparty_sources)
 
-    if not env["arch"] in ["x86", "x86_64"] or env.msvc:
+    if env["arch"] == "arm64" or env.msvc:
         # Embree needs those, it will automatically use SSE2NEON in ARM
         env_thirdparty.Append(CPPDEFINES=["__SSE2__", "__SSE__"])
 

--- a/modules/raycast/config.py
+++ b/modules/raycast/config.py
@@ -1,18 +1,6 @@
 def can_build(env, platform):
-    # Depends on Embree library, which only supports x86_64 and aarch64.
-    if env["arch"].startswith("rv") or env["arch"].startswith("ppc"):
-        return False
-
-    if platform == "android":
-        return env["android_arch"] in ["arm64v8", "x86_64"]
-
-    if platform == "javascript":
-        return False  # No SIMD support yet
-
-    if env["bits"] == "32":
-        return False
-
-    return True
+    # Depends on Embree library, which only supports x86_64 and arm64.
+    return env["arch"] in ["x86_64", "arm64"]
 
 
 def configure(env):

--- a/platform/android/SCsub
+++ b/platform/android/SCsub
@@ -41,13 +41,13 @@ lib = env_android.add_shared_library("#bin/libgodot", [android_objects], SHLIBSU
 env.Depends(lib, thirdparty_obj)
 
 lib_arch_dir = ""
-if env["android_arch"] == "armv7":
+if env["arch"] == "arm32":
     lib_arch_dir = "armeabi-v7a"
-elif env["android_arch"] == "arm64v8":
+elif env["arch"] == "arm64":
     lib_arch_dir = "arm64-v8a"
-elif env["android_arch"] == "x86":
+elif env["arch"] == "x86_32":
     lib_arch_dir = "x86"
-elif env["android_arch"] == "x86_64":
+elif env["arch"] == "x86_64":
     lib_arch_dir = "x86_64"
 else:
     print("WARN: Architecture not suitable for embedding into APK; keeping .so at \\bin")

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -588,9 +588,9 @@ zip_fileinfo EditorExportPlatformAndroid::get_zip_fileinfo() {
 
 Vector<String> EditorExportPlatformAndroid::get_abis() {
 	Vector<String> abis;
-	abis.push_back("armeabi-v7a");
-	abis.push_back("arm64-v8a");
-	abis.push_back("x86");
+	abis.push_back("arm32");
+	abis.push_back("arm64");
+	abis.push_back("x86_32");
 	abis.push_back("x86_64");
 	return abis;
 }
@@ -1710,7 +1710,7 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 		const String abi = abis[i];
 		// All Android devices supporting Vulkan run 64-bit Android,
 		// so there is usually no point in exporting for 32-bit Android.
-		const bool is_default = abi == "arm64-v8a";
+		const bool is_default = abi == "arm64";
 		r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, vformat("%s/%s", PNAME("architectures"), abi)), is_default));
 	}
 

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -28,7 +28,7 @@ allprojects {
 }
 
 ext {
-    supportedAbis = ["armv7", "arm64v8", "x86", "x86_64"]
+    supportedAbis = ["arm32", "arm64", "x86_32", "x86_64"]
     supportedTargetsMap = [release: "release", dev: "debug", debug: "release_debug"]
     supportedFlavors = ["editor", "template"]
 
@@ -37,7 +37,7 @@ ext {
     // If building manually on the command line, it's recommended to use the
     // `./gradlew generateGodotTemplates` build command instead after running the `scons` command(s).
     // The {selectedAbis} values must be from the {supportedAbis} values.
-    selectedAbis = ["arm64v8"]
+    selectedAbis = ["arm64"]
 }
 
 def rootDir = "../../.."

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -159,7 +159,7 @@ android {
             def taskName = getSconsTaskName(flavorName, buildType, selectedAbi)
             tasks.create(name: taskName, type: Exec) {
                 executable sconsExecutableFile.absolutePath
-                args "--directory=${pathToRootDir}", "platform=android", "tools=${toolsFlag}", "target=${sconsTarget}", "android_arch=${selectedAbi}", "-j" + Runtime.runtime.availableProcessors()
+                args "--directory=${pathToRootDir}", "platform=android", "tools=${toolsFlag}", "target=${sconsTarget}", "arch=${selectedAbi}", "-j" + Runtime.runtime.availableProcessors()
             }
 
             // Schedule the tasks so the generated libs are present before the aar file is packaged.

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -370,15 +370,15 @@ bool OS_Android::_check_internal_feature_support(const String &p_feature) {
 		return true;
 	}
 #if defined(__aarch64__)
-	if (p_feature == "arm64-v8a") {
+	if (p_feature == "arm64-v8a" || p_feature == "arm64") {
 		return true;
 	}
 #elif defined(__ARM_ARCH_7A__)
-	if (p_feature == "armeabi-v7a" || p_feature == "armeabi") {
+	if (p_feature == "armeabi-v7a" || p_feature == "armeabi" || p_feature == "arm32") {
 		return true;
 	}
 #elif defined(__arm__)
-	if (p_feature == "armeabi") {
+	if (p_feature == "armeabi" || p_feature == "arm") {
 		return true;
 	}
 #endif

--- a/platform/ios/detect.py
+++ b/platform/ios/detect.py
@@ -36,12 +36,22 @@ def get_opts():
 
 def get_flags():
     return [
+        ("arch", "arm64"),  # Default for convenience.
         ("tools", False),
         ("use_volk", False),
     ]
 
 
 def configure(env):
+    # Validate arch.
+    supported_arches = ["x86_64", "arm64"]
+    if env["arch"] not in supported_arches:
+        print(
+            'Unsupported CPU architecture "%s" for iOS. Supported architectures are: %s.'
+            % (env["arch"], ", ".join(supported_arches))
+        )
+        sys.exit()
+
     ## Build type
 
     if env["target"].startswith("release"):
@@ -63,11 +73,6 @@ def configure(env):
     if env["use_lto"]:
         env.Append(CCFLAGS=["-flto"])
         env.Append(LINKFLAGS=["-flto"])
-
-    ## Architecture
-    env["bits"] = "64"
-    if env["arch"] != "x86_64":
-        env["arch"] = "arm64"
 
     ## Compiler configuration
 

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -46,6 +46,7 @@ def get_opts():
 
 def get_flags():
     return [
+        ("arch", "wasm32"),
         ("tools", False),
         ("builtin_pcre2_with_jit", False),
         ("vulkan", False),
@@ -53,6 +54,15 @@ def get_flags():
 
 
 def configure(env):
+    # Validate arch.
+    supported_arches = ["wasm32"]
+    if env["arch"] not in supported_arches:
+        print(
+            'Unsupported CPU architecture "%s" for iOS. Supported architectures are: %s.'
+            % (env["arch"], ", ".join(supported_arches))
+        )
+        sys.exit()
+
     try:
         env["initial_memory"] = int(env["initial_memory"])
     except Exception:

--- a/platform/uwp/detect.py
+++ b/platform/uwp/detect.py
@@ -1,6 +1,7 @@
 import methods
 import os
 import sys
+from platform_methods import detect_arch
 
 
 def is_active():
@@ -31,6 +32,7 @@ def get_opts():
 
 def get_flags():
     return [
+        ("arch", detect_arch()),
         ("tools", False),
         ("xaudio2", True),
         ("builtin_pcre2_with_jit", False),
@@ -38,18 +40,16 @@ def get_flags():
 
 
 def configure(env):
-    env.msvc = True
-
-    if env["bits"] != "default":
-        print("Error: bits argument is disabled for MSVC")
+    # Validate arch.
+    supported_arches = ["x86_32", "x86_64", "arm32"]
+    if env["arch"] not in supported_arches:
         print(
-            """
-            Bits argument is not supported for MSVC compilation. Architecture depends on the Native/Cross Compile Tools Prompt/Developer Console
-            (or Visual Studio settings) that is being used to run SCons. As a consequence, bits argument is disabled. Run scons again without bits
-            argument (example: scons p=uwp) and SCons will attempt to detect what MSVC compiler will be executed and inform you.
-            """
+            'Unsupported CPU architecture "%s" for UWP. Supported architectures are: %s.'
+            % (env["arch"], ", ".join(supported_arches))
         )
         sys.exit()
+
+    env.msvc = True
 
     ## Build type
 
@@ -101,11 +101,10 @@ def configure(env):
 
     arch = ""
     if str(os.getenv("Platform")).lower() == "arm":
-
-        print("Compiled program architecture will be an ARM executable. (forcing bits=32).")
+        print("Compiled program architecture will be an ARM executable (forcing arch=arm32).")
 
         arch = "arm"
-        env["bits"] = "32"
+        env["arch"] = "arm32"
         env.Append(LINKFLAGS=["/MACHINE:ARM"])
         env.Append(LIBPATH=[vc_base_path + "lib/store/arm"])
 
@@ -117,20 +116,20 @@ def configure(env):
         compiler_version_str = methods.detect_visual_c_compiler_version(env["ENV"])
 
         if compiler_version_str == "amd64" or compiler_version_str == "x86_amd64":
-            env["bits"] = "64"
-            print("Compiled program architecture will be a x64 executable (forcing bits=64).")
+            env["arch"] = "x86_64"
+            print("Compiled program architecture will be a x64 executable (forcing arch=x86_64).")
         elif compiler_version_str == "x86" or compiler_version_str == "amd64_x86":
-            env["bits"] = "32"
-            print("Compiled program architecture will be a x86 executable. (forcing bits=32).")
+            env["arch"] = "x86_32"
+            print("Compiled program architecture will be a x86 executable (forcing arch=x86_32).")
         else:
             print(
-                "Failed to detect MSVC compiler architecture version... Defaulting to 32-bit executable settings"
-                " (forcing bits=32). Compilation attempt will continue, but SCons can not detect for what architecture"
+                "Failed to detect MSVC compiler architecture version... Defaulting to x86 32-bit executable settings"
+                " (forcing arch=x86_32). Compilation attempt will continue, but SCons can not detect for what architecture"
                 " this build is compiled for. You should check your settings/compilation setup."
             )
-            env["bits"] = "32"
+            env["arch"] = "x86_32"
 
-        if env["bits"] == "32":
+        if env["arch"] == "x86_32":
             arch = "x86"
 
             angle_build_cmd += "Win32"

--- a/platform/windows/platform_windows_builders.py
+++ b/platform/windows/platform_windows_builders.py
@@ -9,7 +9,7 @@ from platform_methods import subprocess_main
 
 def make_debug_mingw(target, source, env):
     mingw_prefix = ""
-    if env["bits"] == "32":
+    if env["arch"] == "x86_32":
         mingw_prefix = env["mingw_prefix_32"]
     else:
         mingw_prefix = env["mingw_prefix_64"]

--- a/platform_methods.py
+++ b/platform_methods.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import json
+import platform
 import uuid
 import functools
 import subprocess
@@ -71,9 +72,42 @@ def run_in_subprocess(builder_function):
 
 
 def subprocess_main(namespace):
-
     with open(sys.argv[1]) as json_file:
         data = json.load(json_file)
 
     fn = namespace[data["fn"]]
     fn(*data["args"])
+
+
+# CPU architecture options.
+architectures = ["x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32"]
+architecture_aliases = {
+    "x86": "x86_32",
+    "x64": "x86_64",
+    "amd64": "x86_64",
+    "armv7": "arm32",
+    "armv8": "arm64",
+    "arm64v8": "arm64",
+    "aarch64": "arm64",
+    "rv": "rv64",
+    "riscv": "rv64",
+    "riscv64": "rv64",
+    "ppcle": "ppc32",
+    "ppc": "ppc32",
+    "ppc64le": "ppc64",
+}
+
+
+def detect_arch():
+    host_machine = platform.machine().lower()
+    if host_machine in architectures:
+        return host_machine
+    elif host_machine in architecture_aliases.keys():
+        return architecture_aliases[host_machine]
+    elif "86" in host_machine:
+        # Catches x86, i386, i486, i586, i686, etc.
+        return "x86_32"
+    else:
+        print("Unsupported CPU architecture: " + host_machine)
+        print("Falling back to x86_64.")
+        return "x86_64"


### PR DESCRIPTION
This PR addresses part of https://github.com/godotengine/godot-proposals/issues/1416

In the master branch before this PR, we have several arguments for specifying the architecture: `bits`, `arch`, and `android_arch`. This is a bit of a mess, so this PR replaces all three of these with a single unified `arch`. Note that `env["bits"]` still exists internally for now (or it could be kept forever).

The list of valid architectures is `["auto", "x86_32", "x86_64", "arm32", "arm64", "rv64", "ppc32", "ppc64", "wasm32"]`. The names were chosen to be explicit such that each architecture always includes the bitness in the name (except for "auto").

If `"auto"`, then it will automatically determine the architecture. It will use arm64 for Android and iOS, wasm32 for JavaScript, and otherwise it will use the host architecture, so arm64 on modern ARM devices, x86_64 on a typical modern desktop, and x86_32 on an old 32-bit desktop.

For macOS, iOS, JavaScript, and Android, it will throw an error if trying to build for an invalid architecture. The same should be done for Windows and Linux but I'm not sure how to get cross-compiling working in all cases where it should exist or how to show an error when the necessary libs etc are missing. There's also several places in both Windows and Linux that are hard-coded for x86. I left some TODOs in the Windows and Linux code for future PRs.

I've tested this PR compiling on an arm64 macOS host for x86_64 and arm64 macOS and for arm64 iOS, on an arm64 Ubuntu VM for arm64 Linux, on a rv64 Ubuntu VM for rv64 Linux, on an x86_64 Ubuntu host for x86_64 Linux, on an x86_32 Ubuntu VM for x86_32 Linux (fails linking, but happens on master too), on an x86_64 Windows host for x86_32 and x86_64 Windows using MSVC and x86_64 using MinGW, on both an x86_64 Windows and x86_64 Ubuntu host for x86_32, x86_64, arm32, and arm64 Android (x86 Android fails linking on Ubuntu but this happens on master too, and I only tested if the arm64 Android build runs), and on an x86_64 Windows host for wasm32 JavaScript. Still, it needs further testing. Most of the platforms I've tested on have revealed bugs (some of which exist on master too).

This PR also simplifies a lot of architecture checks (such as the ones in the denoise module).

@q66 Can you test if this works as expected on PowerPC?