### PR TITLE
[3.x] Particles2D visibility rect - only show on selected nodes

### DIFF
--- a/editor/plugins/particles_2d_editor_plugin.cpp
+++ b/editor/plugins/particles_2d_editor_plugin.cpp
@@ -57,6 +57,28 @@ void Particles2DEditorPlugin::_file_selected(const String &p_file) {
 	emission_mask->popup_centered_minsize();
 }
 
+void Particles2DEditorPlugin::_selection_changed() {
+	List<Node *> selected_nodes = editor->get_editor_selection()->get_selected_node_list();
+
+	if (selected_particles.empty() && selected_nodes.empty()) {
+		return;
+	}
+
+	for (int i = 0; i < selected_particles.size(); i++) {
+		selected_particles[i]->set_show_visibility_rect(false);
+	}
+
+	selected_particles.clear();
+
+	for (int i = 0; i < selected_nodes.size(); i++) {
+		Particles2D *selected_particle = Object::cast_to<Particles2D>(selected_nodes[i]);
+		if (selected_particle != nullptr) {
+			selected_particle->set_show_visibility_rect(true);
+			selected_particles.push_back(selected_particle);
+		}
+	}
+}
+
 void Particles2DEditorPlugin::_menu_callback(int p_idx) {
 	switch (p_idx) {
 		case MENU_GENERATE_VISIBILITY_RECT: {
@@ -331,12 +353,14 @@ void Particles2DEditorPlugin::_notification(int p_what) {
 		menu->get_popup()->connect("id_pressed", this, "_menu_callback");
 		menu->set_icon(menu->get_popup()->get_icon("Particles2D", "EditorIcons"));
 		file->connect("file_selected", this, "_file_selected");
+		EditorNode::get_singleton()->get_editor_selection()->connect("selection_changed", this, "_selection_changed");
 	}
 }
 
 void Particles2DEditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_menu_callback"), &Particles2DEditorPlugin::_menu_callback);
 	ClassDB::bind_method(D_METHOD("_file_selected"), &Particles2DEditorPlugin::_file_selected);
+	ClassDB::bind_method(D_METHOD("_selection_changed"), &Particles2DEditorPlugin::_selection_changed);
 	ClassDB::bind_method(D_METHOD("_generate_visibility_rect"), &Particles2DEditorPlugin::_generate_visibility_rect);
 	ClassDB::bind_method(D_METHOD("_generate_emission_mask"), &Particles2DEditorPlugin::_generate_emission_mask);
 }

--- a/editor/plugins/particles_2d_editor_plugin.h
+++ b/editor/plugins/particles_2d_editor_plugin.h
@@ -57,6 +57,7 @@ class Particles2DEditorPlugin : public EditorPlugin {
 	};
 
 	Particles2D *particles;
+	List<Particles2D *> selected_particles;
 
 	EditorFileDialog *file;
 	EditorNode *editor;
@@ -80,6 +81,7 @@ class Particles2DEditorPlugin : public EditorPlugin {
 	void _menu_callback(int p_idx);
 	void _generate_visibility_rect();
 	void _generate_emission_mask();
+	void _selection_changed();
 
 protected:
 	void _notification(int p_what);

--- a/scene/2d/particles_2d.cpp
+++ b/scene/2d/particles_2d.cpp
@@ -140,6 +140,13 @@ void Particles2D::set_speed_scale(float p_scale) {
 	VS::get_singleton()->particles_set_speed_scale(particles, p_scale);
 }
 
+#ifdef TOOLS_ENABLED
+void Particles2D::set_show_visibility_rect(bool p_show_visibility_rect) {
+	show_visibility_rect = p_show_visibility_rect;
+	update();
+}
+#endif
+
 bool Particles2D::is_emitting() const {
 	return VS::get_singleton()->particles_get_emitting(particles);
 }
@@ -287,7 +294,7 @@ void Particles2D::_notification(int p_what) {
 		VS::get_singleton()->canvas_item_add_particles(get_canvas_item(), particles, texture_rid, normal_rid);
 
 #ifdef TOOLS_ENABLED
-		if (Engine::get_singleton()->is_editor_hint() && (this == get_tree()->get_edited_scene_root() || get_tree()->get_edited_scene_root()->is_a_parent_of(this))) {
+		if (show_visibility_rect) {
 			draw_rect(visibility_rect, Color(0, 0.7, 0.9, 0.4), false);
 		}
 #endif
@@ -397,6 +404,9 @@ Particles2D::Particles2D() {
 	set_use_local_coordinates(true);
 	set_draw_order(DRAW_ORDER_INDEX);
 	set_speed_scale(1);
+#ifdef TOOLS_ENABLED
+	show_visibility_rect = false;
+#endif
 }
 
 Particles2D::~Particles2D() {

--- a/scene/2d/particles_2d.h
+++ b/scene/2d/particles_2d.h
@@ -60,6 +60,10 @@ private:
 	int fixed_fps;
 	bool fractional_delta;
 
+#ifdef TOOLS_ENABLED
+	bool show_visibility_rect;
+#endif
+
 	Ref<Material> process_material;
 
 	DrawOrder draw_order;
@@ -86,6 +90,10 @@ public:
 	void set_use_local_coordinates(bool p_enable);
 	void set_process_material(const Ref<Material> &p_material);
 	void set_speed_scale(float p_scale);
+
+#ifdef TOOLS_ENABLED
+	void set_show_visibility_rect(bool p_show_visibility_rect);
+#endif
 
 	bool is_emitting() const;
 	int get_amount() const;


### PR DESCRIPTION
This PR is a 3.x backport of #55052 with a small change compared to the 4.0 PR.
I left out the changes on the 3D gizmo alpha as I think it would be better handled in a separate PR for 3.x.