### PR TITLE
Fix "Lookup Symbol" on global class members not switching to the class' script

### DIFF
--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -2810,6 +2810,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 						r_result.type = ScriptLanguage::LookupResult::RESULT_SCRIPT_LOCATION;
 						r_result.location = base_type.class_type->get_member(p_symbol).get_line();
 						r_result.class_path = base_type.script_path;
+						r_result.script = GDScriptCache::get_shallow_script(r_result.class_path);
 						return OK;
 					}
 					base_type = base_type.class_type->base_type;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes #55644

It seems that with `RESULT_SCRIPT_LOCATION`, a script reference is needed in order to jump to the relevant script. https://github.com/godotengine/godot/issues/55644#issuecomment-987542809

With this change, using "Lookup Symbol" on global class members now does switch to the relevant script.