### PR TITLE
Add `RenderingServer.get_video_adapter_total_memory()` method

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1441,8 +1441,16 @@
 		<method name="get_video_adapter_name" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the name of the video adapter (e.g. "GeForce GTX 1080/PCIe/SSE2").
+				Returns the name of the video adapter (e.g. "GeForce GTX 1080/PCIe/SSE2"). See also [method get_video_adapter_vendor].
 				[b]Note:[/b] When running a headless or server binary, this function returns an empty string.
+			</description>
+		</method>
+		<method name="get_video_adapter_total_memory" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the total amount of video memory present on the video adapter (in bytes). This method does not distinguish between dedicated video memory (fast) and shared video memory (slow). On dedicated GPUs, the value returned will be equal to the amount of dedicated video memory available (typically between 2 GB and 24 GB on modern GPUs). On integrated GPUs, the value returned will be equal to the shared video memory allocated by the system (typically between 1 and 8 GB). See also [method get_rendering_info].
+				[method get_video_adapter_total_memory] can be used to warn users about features that may not run well on their system due to high VRAM requirements. However, video memory amount is [i]not[/i] an indicator of GPU performance, so this should not be used to automatically configure graphics settings (with the exception of texture quality).
+				[b]Note:[/b] When using the OpenGL backend or when running in headless mode, this function always returns [code]0[/code].
 			</description>
 		</method>
 		<method name="get_video_adapter_type" qualifiers="const">
@@ -1455,7 +1463,8 @@
 		<method name="get_video_adapter_vendor" qualifiers="const">
 			<return type="String" />
 			<description>
-				Returns the vendor of the video adapter (e.g. "NVIDIA Corporation").
+				Returns the vendor of the video adapter. When using Vulkan, the return value will [i]always[/i] be one of the following: [code]AMD[/code], [code]ImgTec[/code], [code]Apple[/code] (M1), [code]NVIDIA[/code], [code]ARM[/code] (Mali), [code]Qualcomm[/code] (Adreno), [code]Intel[/code], [code]Unknown[/code] (fallback if the vendor cannot be determined).
+				See also [method get_video_adapter_name].
 				[b]Note:[/b] When running a headless or server binary, this function returns an empty string.
 			</description>
 		</method>
@@ -5198,22 +5207,22 @@
 			Represents the size of the [enum GlobalShaderParameterType] enum.
 		</constant>
 		<constant name="RENDERING_INFO_TOTAL_OBJECTS_IN_FRAME" value="0" enum="RenderingInfo">
-			Number of objects rendered in the current 3D scene. This varies depending on camera position and rotation.
+			The number of 3D objects drawn in the currently displayed frame. This usually influences [constant RENDERING_INFO_TOTAL_DRAW_CALLS_IN_FRAME]. 2D elements are not included in this metric.
 		</constant>
 		<constant name="RENDERING_INFO_TOTAL_PRIMITIVES_IN_FRAME" value="1" enum="RenderingInfo">
-			Number of vertices/indices rendered in the current 3D scene. This varies depending on camera position and rotation.
+			The number of 3D primitives (lines, points, triangles) drawn in the currently displayed frame. This is usually significantly greater than the number of primitives present in each mesh in the view frustum, since the depth prepass and shadow passes are also included in this metric. 2D elements are not included in this metric.
 		</constant>
 		<constant name="RENDERING_INFO_TOTAL_DRAW_CALLS_IN_FRAME" value="2" enum="RenderingInfo">
-			Number of draw calls performed to render in the current 3D scene. This varies depending on camera position and rotation.
+			The number of 3D draw calls performed in the currently displayed frame. This generally varies depending on [constant RENDERING_INFO_TOTAL_OBJECTS_IN_FRAME]. This is usually significantly greater than the number of meshes present in the view frustum, since the depth prepass and shadow passes are also included in this metric. 2D elements are not included in this metric.
 		</constant>
 		<constant name="RENDERING_INFO_TEXTURE_MEM_USED" value="3" enum="RenderingInfo">
-			Texture memory used (in bytes).
+			The memory currently used by textures in the engine (in bytes). This metric does [i]not[/i] include memory used by other applications on the system.
 		</constant>
 		<constant name="RENDERING_INFO_BUFFER_MEM_USED" value="4" enum="RenderingInfo">
-			Buffer memory used (in bytes).
+			The memory currently used by buffers in the engine (in bytes). This metric does [i]not[/i] include memory used by other applications on the system.
 		</constant>
 		<constant name="RENDERING_INFO_VIDEO_MEM_USED" value="5" enum="RenderingInfo">
-			Video memory used (in bytes). This is always greater than the sum of [constant RENDERING_INFO_TEXTURE_MEM_USED] and [constant RENDERING_INFO_BUFFER_MEM_USED], since there is miscellaneous data not accounted for by those two metrics.
+			The video memory currently used by the engine (in bytes). This metric does [i]not[/i] include video memory used by other applications on the system. This is always greater than the sum of [constant RENDERING_INFO_TEXTURE_MEM_USED] and [constant RENDERING_INFO_BUFFER_MEM_USED], since there is miscellaneous data not accounted for by those two metrics.
 		</constant>
 		<constant name="FEATURE_SHADERS" value="0" enum="Features">
 			Hardware supports shaders. This enum is currently unused in Godot 3.x.

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -352,4 +352,9 @@ Size2i Utilities::get_maximum_viewport_size() const {
 	return Size2i(config->max_viewport_size[0], config->max_viewport_size[1]);
 }
 
+uint64_t Utilities::get_video_adapter_total_memory() const {
+	// Not supported with standard extensions in OpenGL.
+	return 0;
+}
+
 #endif // GLES3_ENABLED

--- a/drivers/gles3/storage/utilities.h
+++ b/drivers/gles3/storage/utilities.h
@@ -125,6 +125,7 @@ public:
 	virtual String get_video_adapter_api_version() const override;
 
 	virtual Size2i get_maximum_viewport_size() const override;
+	virtual uint64_t get_video_adapter_total_memory() const override;
 };
 
 } // namespace GLES3

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -8478,12 +8478,12 @@ void RenderingDeviceVulkan::draw_command_end_label() {
 	context->command_end_label(frames[frame].draw_command_buffer);
 }
 
-String RenderingDeviceVulkan::get_device_vendor_name() const {
-	return context->get_device_vendor_name();
-}
-
 String RenderingDeviceVulkan::get_device_name() const {
 	return context->get_device_name();
+}
+
+String RenderingDeviceVulkan::get_device_vendor_name() const {
+	return context->get_device_vendor_name();
 }
 
 RenderingDevice::DeviceType RenderingDeviceVulkan::get_device_type() const {
@@ -8492,6 +8492,10 @@ RenderingDevice::DeviceType RenderingDeviceVulkan::get_device_type() const {
 
 String RenderingDeviceVulkan::get_device_api_version() const {
 	return context->get_device_api_version();
+}
+
+uint64_t RenderingDeviceVulkan::get_device_total_memory() const {
+	return context->get_device_total_memory();
 }
 
 String RenderingDeviceVulkan::get_device_pipeline_cache_uuid() const {

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -1240,10 +1240,11 @@ public:
 	virtual void draw_command_insert_label(String p_label_name, const Color p_color = Color(1, 1, 1, 1));
 	virtual void draw_command_end_label();
 
-	virtual String get_device_vendor_name() const;
 	virtual String get_device_name() const;
+	virtual String get_device_vendor_name() const;
 	virtual RenderingDevice::DeviceType get_device_type() const;
 	virtual String get_device_api_version() const;
+	virtual uint64_t get_device_total_memory() const;
 	virtual String get_device_pipeline_cache_uuid() const;
 
 	virtual uint64_t get_driver_resource(DriverResource p_resource, RID p_rid = RID(), uint64_t p_index = 0);

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -2687,12 +2687,12 @@ void VulkanContext::set_object_name(VkObjectType p_object_type, uint64_t p_objec
 	SetDebugUtilsObjectNameEXT(device, &name_info);
 }
 
-String VulkanContext::get_device_vendor_name() const {
-	return device_vendor;
-}
-
 String VulkanContext::get_device_name() const {
 	return device_name;
+}
+
+String VulkanContext::get_device_vendor_name() const {
+	return device_vendor;
 }
 
 RenderingDevice::DeviceType VulkanContext::get_device_type() const {
@@ -2701,6 +2701,44 @@ RenderingDevice::DeviceType VulkanContext::get_device_type() const {
 
 String VulkanContext::get_device_api_version() const {
 	return vformat("%d.%d.%d", VK_API_VERSION_MAJOR(device_api_version), VK_API_VERSION_MINOR(device_api_version), VK_API_VERSION_PATCH(device_api_version));
+}
+
+uint64_t VulkanContext::get_device_total_memory() const {
+	// See <https://www.asawicki.info/news_1740_vulkan_memory_types_on_pc_and_how_to_use_them>.
+	uint64_t result = UINT64_MAX;
+	uint64_t smallest_non_device_local = UINT64_MAX;
+	for (uint32_t i = 0; i < memory_properties.memoryHeapCount; i++) {
+		if (memory_properties.memoryHeaps[i].size < 300'000'000) {
+			// Heaps that are 256 MB or smaller (with some margin) are ignored as they usually represent the BAR size.
+			// All GPUs that support Vulkan will report at least 512 MB of *actual* video memory (or system memory) in practice.
+			continue;
+		}
+
+		if (memory_properties.memoryHeaps[i].flags & VK_MEMORY_HEAP_DEVICE_LOCAL_BIT) {
+			// Take the smallest memory heap that isn't too small (see above) and has the "device-local" flag
+			// (i.e. present on the graphics device itself).
+			result = MIN(result, memory_properties.memoryHeaps[i].size);
+		} else {
+			// Not device-local. This is usually system memory.
+			// Required for AMD APUs, as they report two heaps (system memory and BAR size).
+			// Only the second heap is device-local, but it's too small and is therefore ignored.
+			// As a result, we need to fallback to non-device local memory heap size.
+			smallest_non_device_local = MIN(smallest_non_device_local, memory_properties.memoryHeaps[i].size);
+		}
+	}
+
+	if (result != UINT64_MAX) {
+		// Suitable device-local value found.
+		return result;
+	} else {
+		if (smallest_non_device_local != UINT64_MAX) {
+			// No suitable device local-value found. Return the smallest suitable non-device local value as a fallback.
+			return smallest_non_device_local;
+		}
+
+		// No value found, return the "erronerous" value.
+		return 0;
+	}
 }
 
 String VulkanContext::get_device_pipeline_cache_uuid() const {

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -331,10 +331,11 @@ public:
 	void command_end_label(VkCommandBuffer p_command_buffer);
 	void set_object_name(VkObjectType p_object_type, uint64_t p_object_handle, String p_object_name);
 
-	String get_device_vendor_name() const;
 	String get_device_name() const;
+	String get_device_vendor_name() const;
 	RenderingDevice::DeviceType get_device_type() const;
 	String get_device_api_version() const;
+	uint64_t get_device_total_memory() const;
 	String get_device_pipeline_cache_uuid() const;
 
 	void set_vsync_mode(DisplayServer::WindowID p_window, DisplayServer::VSyncMode p_mode);

--- a/servers/rendering/dummy/storage/utilities.h
+++ b/servers/rendering/dummy/storage/utilities.h
@@ -111,6 +111,7 @@ public:
 	virtual String get_video_adapter_api_version() const override { return String(); }
 
 	virtual Size2i get_maximum_viewport_size() const override { return Size2i(); };
+	virtual uint64_t get_video_adapter_total_memory() const override { return 0; }
 };
 
 } // namespace RendererDummy

--- a/servers/rendering/renderer_rd/storage_rd/utilities.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/utilities.cpp
@@ -333,3 +333,7 @@ Size2i Utilities::get_maximum_viewport_size() const {
 	int max_y = device->limit_get(RenderingDevice::LIMIT_MAX_VIEWPORT_DIMENSIONS_Y);
 	return Size2i(max_x, max_y);
 }
+
+uint64_t Utilities::get_video_adapter_total_memory() const {
+	return RenderingDevice::get_singleton()->get_device_total_memory();
+}

--- a/servers/rendering/renderer_rd/storage_rd/utilities.h
+++ b/servers/rendering/renderer_rd/storage_rd/utilities.h
@@ -117,6 +117,7 @@ public:
 	virtual String get_video_adapter_api_version() const override;
 
 	virtual Size2i get_maximum_viewport_size() const override;
+	virtual uint64_t get_video_adapter_total_memory() const override;
 };
 
 } // namespace RendererRD

--- a/servers/rendering/rendering_device.cpp
+++ b/servers/rendering/rendering_device.cpp
@@ -822,8 +822,8 @@ void RenderingDevice::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("draw_command_insert_label", "name", "color"), &RenderingDevice::draw_command_insert_label);
 	ClassDB::bind_method(D_METHOD("draw_command_end_label"), &RenderingDevice::draw_command_end_label);
 
-	ClassDB::bind_method(D_METHOD("get_device_vendor_name"), &RenderingDevice::get_device_vendor_name);
 	ClassDB::bind_method(D_METHOD("get_device_name"), &RenderingDevice::get_device_name);
+	ClassDB::bind_method(D_METHOD("get_device_vendor_name"), &RenderingDevice::get_device_vendor_name);
 	ClassDB::bind_method(D_METHOD("get_device_pipeline_cache_uuid"), &RenderingDevice::get_device_pipeline_cache_uuid);
 
 	ClassDB::bind_method(D_METHOD("get_memory_usage", "type"), &RenderingDevice::get_memory_usage);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1293,10 +1293,11 @@ public:
 	virtual void draw_command_insert_label(String p_label_name, const Color p_color = Color(1, 1, 1, 1)) = 0;
 	virtual void draw_command_end_label() = 0;
 
-	virtual String get_device_vendor_name() const = 0;
 	virtual String get_device_name() const = 0;
+	virtual String get_device_vendor_name() const = 0;
 	virtual RenderingDevice::DeviceType get_device_type() const = 0;
 	virtual String get_device_api_version() const = 0;
+	virtual uint64_t get_device_total_memory() const = 0;
 	virtual String get_device_pipeline_cache_uuid() const = 0;
 
 	virtual uint64_t get_driver_resource(DriverResource p_resource, RID p_rid = RID(), uint64_t p_index = 0) = 0;

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -274,6 +274,10 @@ String RenderingServerDefault::get_video_adapter_api_version() const {
 	return RSG::utilities->get_video_adapter_api_version();
 }
 
+uint64_t RenderingServerDefault::get_video_adapter_total_memory() const {
+	return RSG::utilities->get_video_adapter_total_memory();
+}
+
 void RenderingServerDefault::set_frame_profiling_enabled(bool p_enable) {
 	RSG::utilities->capturing_timestamps = p_enable;
 }

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -977,6 +977,7 @@ public:
 	virtual String get_video_adapter_vendor() const override;
 	virtual RenderingDevice::DeviceType get_video_adapter_type() const override;
 	virtual String get_video_adapter_api_version() const override;
+	virtual uint64_t get_video_adapter_total_memory() const override;
 
 	virtual void set_frame_profiling_enabled(bool p_enable) override;
 	virtual Vector<FrameProfileArea> get_frame_profile() override;

--- a/servers/rendering/storage/utilities.h
+++ b/servers/rendering/storage/utilities.h
@@ -183,6 +183,7 @@ public:
 	virtual String get_video_adapter_api_version() const = 0;
 
 	virtual Size2i get_maximum_viewport_size() const = 0;
+	virtual uint64_t get_video_adapter_total_memory() const = 0;
 };
 
 #endif // RENDERER_UTILITIES_H

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2768,6 +2768,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_video_adapter_vendor"), &RenderingServer::get_video_adapter_vendor);
 	ClassDB::bind_method(D_METHOD("get_video_adapter_type"), &RenderingServer::get_video_adapter_type);
 	ClassDB::bind_method(D_METHOD("get_video_adapter_api_version"), &RenderingServer::get_video_adapter_api_version);
+	ClassDB::bind_method(D_METHOD("get_video_adapter_total_memory"), &RenderingServer::get_video_adapter_total_memory);
 
 	ClassDB::bind_method(D_METHOD("make_sphere_mesh", "latitudes", "longitudes", "radius"), &RenderingServer::make_sphere_mesh);
 	ClassDB::bind_method(D_METHOD("get_test_cube"), &RenderingServer::get_test_cube);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1541,6 +1541,7 @@ public:
 	virtual String get_video_adapter_vendor() const = 0;
 	virtual RenderingDevice::DeviceType get_video_adapter_type() const = 0;
 	virtual String get_video_adapter_api_version() const = 0;
+	virtual uint64_t get_video_adapter_total_memory() const = 0;
 
 	struct FrameProfileArea {
 		String name;


### PR DESCRIPTION
This can be used to warn users about graphics features that may not run well (or at all) on their system, due to high VRAM requirements.

This also improves documentation related to RenderingServer video adapter getter methods.

This closes https://github.com/godotengine/godot-proposals/issues/4871.

## Preview

```gdscript
extends Node


func _ready():
	print("Name: " + RenderingServer.get_video_adapter_name())
	print("Vendor: " + RenderingServer.get_video_adapter_vendor())
	print("Video memory (total): " + String().humanize_size(RenderingServer.get_video_adapter_total_memory()))
```

Results in:

```
Name: NVIDIA GeForce GTX 1080
Vendor: NVIDIA
Video memory (total): 8.00 GiB
```