### PR TITLE
Misc build system fixes

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -37,7 +37,7 @@ jobs:
             sconsflags: float=64 use_asan=yes use_ubsan=yes
             proj-test: true
             godot-cpp-test: true
-            bin: "./bin/godot.linuxbsd.double.tools.64s"
+            bin: "./bin/godot.linuxbsd.double.tools.64.san"
             build-mono: false
             # Skip 2GiB artifact speeding up action.
             artifact: false

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4606,7 +4606,7 @@ Error GLTFDocument::_parse_lights(Ref<GLTFState> state) {
 			light->outer_cone_angle = spot["outerConeAngle"];
 			ERR_CONTINUE_MSG(light->inner_cone_angle >= light->outer_cone_angle, "The inner angle must be smaller than the outer angle.");
 		} else if (type != "point" && type != "directional") {
-			ERR_CONTINUE_MSG(ERR_PARSE_ERROR, "Light type is unknown.");
+			ERR_CONTINUE_MSG(true, "Light type is unknown.");
 		}
 
 		state->lights.push_back(light);

--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -152,7 +152,7 @@ def configure(env):
         abi_subpath = "i686-linux-android"
         arch_subpath = "x86"
         env["x86_libtheora_opt_gcc"] = True
-    if env["android_arch"] == "x86_64":
+    elif env["android_arch"] == "x86_64":
         if get_platform(env["ndk_platform"]) < 21:
             print(
                 "WARNING: android_arch=x86_64 is not supported by ndk_platform lower than android-21; setting"

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -161,7 +161,7 @@ def configure(env):
         env.Append(LINKFLAGS=["-ftest-coverage", "-fprofile-arcs"])
 
     if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"] or env["use_msan"]:
-        env.extra_suffix += "s"
+        env.extra_suffix += ".san"
 
         if env["use_ubsan"]:
             env.Append(

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -124,7 +124,7 @@ def configure(env):
         env["AS"] = basecmd + "as"
 
     if env["use_ubsan"] or env["use_asan"] or env["use_tsan"]:
-        env.extra_suffix += "s"
+        env.extra_suffix += ".san"
 
         if env["use_ubsan"]:
             env.Append(

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -308,7 +308,7 @@ def configure_msvc(env, manual_msvc_config):
 
     # Sanitizers
     if env["use_asan"]:
-        env.extra_suffix += ".s"
+        env.extra_suffix += ".san"
         env.Append(LINKFLAGS=["/INFERASANLIBS"])
         env.Append(CCFLAGS=["/fsanitize=address"])
 

--- a/thirdparty/vhacd/0004-fix-uwp-arm-build.patch
+++ b/thirdparty/vhacd/0004-fix-uwp-arm-build.patch
@@ -9,7 +9,7 @@ index 3999a71521..4c9e0cf7ab 100644
 -#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION))
 +// -- GODOT start --
 +//#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION))
-+#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION)) && (!defined(_M_ARM))
++#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION)) && (!defined(_M_ARM)) && (!defined(_M_ARM64))
 +// -- GODOT end --
  #define BT_USE_SSE
  #include <emmintrin.h>

--- a/thirdparty/vhacd/inc/btScalar.h
+++ b/thirdparty/vhacd/inc/btScalar.h
@@ -74,7 +74,7 @@ inline int32_t btGetVersion()
 
 // -- GODOT start --
 //#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION))
-#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION)) && (!defined(_M_ARM))
+#if (defined(_WIN32) && (_MSC_VER) && _MSC_VER >= 1400) && (!defined(BT_USE_DOUBLE_PRECISION)) && (!defined(_M_ARM)) && (!defined(_M_ARM64))
 // -- GODOT end --
 #define BT_USE_SSE
 #include <emmintrin.h>


### PR DESCRIPTION
* Fix a bug in GLTF that only showed up on 32-bit x86 Linux but it's applicable to other platforms too. An enum value was given where a bool was expected.
* Fix sanitizer suffixes being inconsistent. Windows had `.s` and macOS/Linux had `s`, now they're all `.san`.
* Fix a bug in vhacd that causes it to not build on 64-bit ARM.
* Fix an `if` in Android that should be `elif`.