### PR TITLE
Fix wrong internal children usage in BoxContainer

### DIFF
--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -351,11 +351,11 @@ MarginContainer *VBoxContainer::add_margin_child(const String &p_label, Control 
 	Label *l = memnew(Label);
 	l->set_theme_type_variation("HeaderSmall");
 	l->set_text(p_label);
-	add_child(l, false, INTERNAL_MODE_FRONT);
+	add_child(l);
 	MarginContainer *mc = memnew(MarginContainer);
 	mc->add_theme_constant_override("margin_left", 0);
 	mc->add_child(p_control, true);
-	add_child(mc, false, INTERNAL_MODE_FRONT);
+	add_child(mc);
 	if (p_expand) {
 		mc->set_v_size_flags(SIZE_EXPAND_FILL);
 	}


### PR DESCRIPTION
Fixes this bug:
![image](https://user-images.githubusercontent.com/2223172/145614099-645820a1-51bc-482b-9386-02c254c5a892.png)
The method isn't used outside of editor (except the FileDialog, where it shouldn't use internal nodes). I wonder how it didn't break anything else 🤔