### PR TITLE
Added check to get_all_locales to avoid adding duplicate locales to array

### DIFF
--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -1092,9 +1092,12 @@ Array TranslationServer::get_loaded_locales() const {
 		ERR_FAIL_COND_V(t.is_null(), Array());
 		String l = t->get_locale();
 
-		locales.push_back(l);
+		if (!locales.has(l)) {
+			locales.push_back(l);
+		}
 	}
 
+	locales.sort();
 	return locales;
 }
 


### PR DESCRIPTION
Fixes #55746 

Following what was pointed out on issue #55746, I downloaded the godot source code and tried to replicate the issue on the master branch, to avoid having to edit a stable branch(3.4) as recommended by the docs, and the issue appeared to still be happening.

To test the issue I added the following translation files to an empty project, duplicating the last Japanese translation and renaming it as NEWTEST.ja.translation to have 2 same locale translations:
![TranslationFiles](https://user-images.githubusercontent.com/26484801/145635535-d272da9c-9814-4f89-b182-bb4e8ea7ba2f.png)

And proceeded to run ```TranslationServer.get_loaded_locales()``` on a simple script I made, which then returned duplicate locales:
![Test](https://user-images.githubusercontent.com/26484801/145635669-1fea4f90-291e-494e-a834-636b4c6e497d.png)

Altering the translation.cpp file, I added a check that loops through items in the locales array and checks to see if the current locale being added to the array is already present, simply not adding it if it is.

This change required me to make a for loop inside the already existing for loop:
![forloop](https://user-images.githubusercontent.com/26484801/145636472-5c14650a-fb38-43db-9e39-6461b3878277.png)

This change will end up raising the time complexity of this specific function, but since games generally don't have thousands of locales I believe that actual time spent running it won't be much different for most. Still, maybe there is a better and more efficient way to implement this change.

The result was then as follows (using the same project without adding or deleting translation files):
![AfterChange](https://user-images.githubusercontent.com/26484801/145636934-8a3007c5-0f19-45d1-9344-0487bac54528.png)

One more thing to note, everything was compiled using Clang and LLD for faster development.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
