### PR TITLE
Hideable Tree Items

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -488,6 +488,9 @@
 		<member name="disable_folding" type="bool" setter="set_disable_folding" getter="is_folding_disabled">
 			If [code]true[/code], folding is disabled for this TreeItem.
 		</member>
+		<member name="visible" type="bool" setter="set_visible" getter="get_visible">
+			If [code]false[/code], the TreeItem is not displayed.
+		</member>
 	</members>
 	<constants>
 		<constant name="CELL_MODE_STRING" value="0" enum="TreeCellMode">

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -136,6 +136,7 @@ private:
 	Vector<Cell> cells;
 
 	bool collapsed; // won't show children
+	bool visible;
 	bool disable_folding;
 	int custom_min_height;
 
@@ -146,6 +147,7 @@ private:
 
 	TreeItem(Tree *p_tree);
 
+	TreeItem *_get_prev_sibling_visible();
 	void _changed_notify(int p_cell);
 	void _changed_notify();
 	void _cell_selected(int p_cell);
@@ -235,6 +237,8 @@ public:
 	TreeItem *get_parent();
 	TreeItem *get_children();
 
+	void set_visible(bool p_visible);
+	bool get_visible();
 	TreeItem *get_prev_visible(bool p_wrap = false);
 	TreeItem *get_next_visible(bool p_wrap = false);
 


### PR DESCRIPTION
This PR introduces a `visible` property for TreeItems within Tree controls. The primary purpose I foresee for this is to be able to hide/show individual items for searching, although there are probably other usecases.

When trying to do this for my game, I ended up looking at `create_dialog.cpp`, to see how the task was handled in Godot itself. From looking there, it seemed like currently the way to search a tree is to build a whole new Tree from scratch each time the search parameters change. I feel that this is much less intuitive than just being able to hide/show items, and it can also be a performance bottleneck when trying to build large, complicated trees from GDScript.