### PR TITLE
Fix OGG streams never ending playback

### DIFF
--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -56,7 +56,7 @@ int AudioStreamPlaybackOGGVorbis::_mix_internal(AudioFrame *p_buffer, int p_fram
 		todo -= mixed;
 		frames_mixed += mixed;
 		start_buffer += mixed;
-		if (!have_packets_left) {
+		if (!have_packets_left && !have_samples_left) {
 			//end of file!
 			bool is_not_empty = mixed > 0 || vorbis_stream->get_length() > 0;
 			if (vorbis_stream->loop && is_not_empty) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes #54821

This was caused by improper detection of the end of an OGG stream.

This method needs a refactor though, I honestly can't explain why this solves the issue. Conceptually I understand that the stream isn't over until we're both out of packets and out of samples in the last packet, but my head is spinning trying to understand what's going on in the big picture. Not the best code I've ever written, that's for sure.