### PR TITLE
Editor: Disallow reparenting inherited nodes

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -361,8 +361,12 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				tree->edit_selected();
 			}
 		} break;
-		case TOOL_NEW:
-		case TOOL_REPARENT_TO_NEW_NODE: {
+		case TOOL_REPARENT_TO_NEW_NODE:
+			if (!_validate_no_foreign()) {
+				break;
+			}
+			[[fallthrough]];
+		case TOOL_NEW: {
 			if (!profile_allow_editing) {
 				break;
 			}
@@ -2603,6 +2607,10 @@ void SceneTreeDock::_script_dropped(String p_file, NodePath p_to) {
 }
 
 void SceneTreeDock::_nodes_dragged(Array p_nodes, NodePath p_to, int p_type) {
+	if (!_validate_no_foreign()) {
+		return;
+	}
+
 	List<Node *> selection = editor_selection->get_selected_node_list();
 
 	if (selection.is_empty()) {


### PR DESCRIPTION
Edit: Fixes this issue for master: #55789 (not checked for 3.4)

This prevents reparenting inherited nodes by dragging them or using the "Reparent to New Node" shortcut.

This also prevents moving inherited nodes up / down by dragging (within the same parent), which is consistent with the current implementation of "Move Up" & "Move Down" shortcuts.

*Bugsquad edit:*
- Fixes #55789