### PR TITLE
Fix lighting_dirty flag bug

### DIFF
--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -324,7 +324,7 @@ public:
 		List<Instance *> lightmap_captures;
 
 		InstanceGeometryData() {
-			lighting_dirty = false;
+			lighting_dirty = true;
 			reflection_dirty = true;
 			can_cast_shadows = true;
 			material_is_animated = true;


### PR DESCRIPTION
In rare circumstances, changing the geometry data attached to an instance, there was the opportunity for the lighting_dirty flag to get out of sync, which could lead to access to a stale light RID, and warnings or worse.

This PR fixes the problem by ensuring the lighting is always updated on the instance when first adding GeometryData.

Fixes #41360

## Conditions for bug
* On the same iteration, a light is removed, which unpairs the Light and Geometry data, and sets `lighting_dirty` to true
* Before the instance has the opportunity to have its lighting list updated, the GeometryData is deleted and replaced by new GeometryData. The flag defaults to false, and thus the instance lighting is never updated.
* When the instance lighting list is later hit, it reads the RID for the deleted light, and flags warnings etc.

## Notes
* This was _incredibly_ difficult to find for such a simple bug :grin: ... see the issue for details of the debugging process (a good day and half on this).

## Reproduction Project
Run this project before and after the PR (click loads of times with the mouse to add the omni lights):
[OmnilightBug_Cutdown4.zip](https://github.com/godotengine/godot/files/7696910/OmnilightBug_Cutdown4.zip)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
