### PR TITLE
Stop asuming a default value of NIL means there's no default

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -413,17 +413,21 @@ bool EditorProperty::is_read_only() const {
 	return read_only;
 }
 
-Variant EditorPropertyRevert::get_property_revert_value(Object *p_object, const StringName &p_property) {
+Variant EditorPropertyRevert::get_property_revert_value(Object *p_object, const StringName &p_property, bool *r_is_valid) {
 	if (p_object->has_method("property_can_revert") && p_object->call("property_can_revert", p_property)) {
+		if (r_is_valid) {
+			*r_is_valid = true;
+		}
 		return p_object->call("property_get_revert", p_property);
 	}
 
-	return PropertyUtils::get_property_default_value(p_object, p_property);
+	return PropertyUtils::get_property_default_value(p_object, p_property, r_is_valid);
 }
 
 bool EditorPropertyRevert::can_property_revert(Object *p_object, const StringName &p_property) {
-	Variant revert_value = EditorPropertyRevert::get_property_revert_value(p_object, p_property);
-	if (revert_value.get_type() == Variant::NIL) {
+	bool is_valid_revert = false;
+	Variant revert_value = EditorPropertyRevert::get_property_revert_value(p_object, p_property, &is_valid_revert);
+	if (!is_valid_revert) {
 		return false;
 	}
 	Variant current_value = p_object->get(p_property);
@@ -637,7 +641,9 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 		}
 
 		if (revert_rect.has_point(mpos)) {
-			Variant revert_value = EditorPropertyRevert::get_property_revert_value(object, property);
+			bool is_valid_revert = false;
+			Variant revert_value = EditorPropertyRevert::get_property_revert_value(object, property, &is_valid_revert);
+			ERR_FAIL_COND(!is_valid_revert);
 			emit_changed(property, revert_value);
 			update_property();
 		}
@@ -783,8 +789,9 @@ static bool _is_value_potential_override(Node *p_node, const String &p_property)
 	if (states_stack.size()) {
 		return true;
 	} else {
+		bool is_valid_default = false;
 		bool is_class_default = false;
-		PropertyUtils::get_property_default_value(p_node, p_property, &states_stack, false, nullptr, &is_class_default);
+		PropertyUtils::get_property_default_value(p_node, p_property, &is_valid_default, &states_stack, false, nullptr, &is_class_default);
 		return !is_class_default;
 	}
 }

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -46,7 +46,7 @@ public:
 	static bool get_instantiated_node_original_property(Node *p_node, const StringName &p_prop, Variant &value, bool p_check_class_default = true);
 	static bool is_node_property_different(Node *p_node, const Variant &p_current, const Variant &p_orig);
 	static bool is_property_value_different(const Variant &p_a, const Variant &p_b);
-	static Variant get_property_revert_value(Object *p_object, const StringName &p_property);
+	static Variant get_property_revert_value(Object *p_object, const StringName &p_property, bool *r_is_valid);
 
 	static bool can_property_revert(Object *p_object, const StringName &p_property);
 };

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3157,8 +3157,9 @@ void SceneTreeDock::_create_remap_for_node(Node *p_node, Map<RES, RES> &r_remap)
 					states_stack_ready = true;
 				}
 
-				Variant orig = PropertyUtils::get_property_default_value(p_node, E.name, &states_stack);
-				if (!PropertyUtils::is_property_value_different(v, orig)) {
+				bool is_valid_default = false;
+				Variant orig = PropertyUtils::get_property_default_value(p_node, E.name, &is_valid_default, &states_stack);
+				if (is_valid_default && !PropertyUtils::is_property_value_different(v, orig)) {
 					continue;
 				}
 

--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -50,7 +50,7 @@ bool PropertyUtils::is_property_value_different(const Variant &p_a, const Varian
 	}
 }
 
-Variant PropertyUtils::get_property_default_value(const Object *p_object, const StringName &p_property, const Vector<SceneState::PackState> *p_states_stack_cache, bool p_update_exports, const Node *p_owner, bool *r_is_class_default) {
+Variant PropertyUtils::get_property_default_value(const Object *p_object, const StringName &p_property, bool *r_is_valid, const Vector<SceneState::PackState> *p_states_stack_cache, bool p_update_exports, const Node *p_owner, bool *r_is_class_default) {
 	// This function obeys the way property values are set when an object is instantiated,
 	// which is the following (the latter wins):
 	// 1. Default value from builtin class
@@ -59,6 +59,9 @@ Variant PropertyUtils::get_property_default_value(const Object *p_object, const 
 
 	if (r_is_class_default) {
 		*r_is_class_default = false;
+	}
+	if (r_is_valid) {
+		*r_is_valid = false;
 	}
 
 	Ref<Script> topmost_script;
@@ -71,6 +74,9 @@ Variant PropertyUtils::get_property_default_value(const Object *p_object, const 
 			bool found = false;
 			Variant value_in_ancestor = ia.state->get_property_value(ia.node, p_property, found);
 			if (found) {
+				if (r_is_valid) {
+					*r_is_valid = true;
+				}
 				return value_in_ancestor;
 			}
 			// Save script for later
@@ -97,6 +103,9 @@ Variant PropertyUtils::get_property_default_value(const Object *p_object, const 
 		}
 		Variant default_value;
 		if (topmost_script->get_property_default_value(p_property, default_value)) {
+			if (r_is_valid) {
+				*r_is_valid = true;
+			}
 			return default_value;
 		}
 	}
@@ -105,7 +114,7 @@ Variant PropertyUtils::get_property_default_value(const Object *p_object, const 
 	if (r_is_class_default) {
 		*r_is_class_default = true;
 	}
-	return ClassDB::class_get_default_property_value(p_object->get_class_name(), p_property);
+	return ClassDB::class_get_default_property_value(p_object->get_class_name(), p_property, r_is_valid);
 }
 
 // Like SceneState::PackState, but using a raw pointer to avoid the cost of

--- a/scene/property_utils.h
+++ b/scene/property_utils.h
@@ -38,7 +38,7 @@ class PropertyUtils {
 public:
 	static bool is_property_value_different(const Variant &p_a, const Variant &p_b);
 	// Gets the most pure default value, the one that would be set when the node has just been instantiated
-	static Variant get_property_default_value(const Object *p_object, const StringName &p_property, const Vector<SceneState::PackState> *p_states_stack_cache = nullptr, bool p_update_exports = false, const Node *p_owner = nullptr, bool *r_is_class_default = nullptr);
+	static Variant get_property_default_value(const Object *p_object, const StringName &p_property, bool *r_is_valid = nullptr, const Vector<SceneState::PackState> *p_states_stack_cache = nullptr, bool p_update_exports = false, const Node *p_owner = nullptr, bool *r_is_class_default = nullptr);
 
 	// Gets the instance/inheritance states of this node, in order of precedence,
 	// that is, from the topmost (the most able to override values) to the lowermost

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -501,8 +501,9 @@ Error SceneState::_parse_node(Node *p_owner, Node *p_node, int p_parent_idx, Map
 		Variant value = forced_value.get_type() == Variant::NIL ? p_node->get(name) : forced_value;
 
 		if (!pinned_props.has(name) && forced_value.get_type() == Variant::NIL) {
-			Variant default_value = PropertyUtils::get_property_default_value(p_node, name, &states_stack, true);
-			if (!PropertyUtils::is_property_value_different(value, default_value)) {
+			bool is_valid_default = false;
+			Variant default_value = PropertyUtils::get_property_default_value(p_node, name, &is_valid_default, &states_stack, true);
+			if (is_valid_default && !PropertyUtils::is_property_value_different(value, default_value)) {
 				continue;
 			}
 		}


### PR DESCRIPTION
Fixes #55810.

3.x doesn't show _this_ bug since GDScript works differently, but the correction is good for it regardless.

Since cherry-picking is not trivial, I'm including a patch against 3.x:
[patch_for_3.txt](https://github.com/godotengine/godot/files/7697086/patch_for_3.txt)