### PR TITLE
[GDNative] Add missing `join` method for PoolStringArray class

### DIFF
--- a/modules/gdnative/gdnative/pool_arrays.cpp
+++ b/modules/gdnative/gdnative/pool_arrays.cpp
@@ -381,6 +381,17 @@ void GDAPI godot_pool_string_array_invert(godot_pool_string_array *p_self) {
 	self->invert();
 }
 
+godot_string GDAPI godot_pool_string_array_join(godot_pool_string_array *p_self, const godot_string *p_delimiter) {
+	PoolVector<String> *self = (PoolVector<String> *)p_self;
+	String &delimiter = *(String *)p_delimiter;
+
+	godot_string str;
+	String *s = (String *)&str;
+	memnew_placement(s, String);
+	*s = self->join(delimiter);
+	return str;
+}
+
 void GDAPI godot_pool_string_array_push_back(godot_pool_string_array *p_self, const godot_string *p_data) {
 	PoolVector<String> *self = (PoolVector<String> *)p_self;
 	String &s = *(String *)p_data;

--- a/modules/gdnative/gdnative_api.json
+++ b/modules/gdnative/gdnative_api.json
@@ -17,7 +17,24 @@
           "major": 1,
           "minor": 2
         },
-        "next": null,
+        "next": {
+          "type": "CORE",
+          "version": {
+            "major": 1,
+            "minor": 3
+          },
+          "next": null,
+          "api": [
+            {
+              "name": "godot_pool_string_array_join",
+              "return_type": "godot_string",
+              "arguments": [
+                ["godot_pool_string_array *", "p_self"],
+                ["const godot_string *", "p_delimiter"]
+              ]
+            }
+          ]
+        },
         "api": [
           {
             "name": "godot_dictionary_duplicate",

--- a/modules/gdnative/include/gdnative/pool_arrays.h
+++ b/modules/gdnative/include/gdnative/pool_arrays.h
@@ -275,6 +275,8 @@ godot_error GDAPI godot_pool_string_array_insert(godot_pool_string_array *p_self
 
 void GDAPI godot_pool_string_array_invert(godot_pool_string_array *p_self);
 
+godot_string GDAPI godot_pool_string_array_join(godot_pool_string_array *p_self, const godot_string *p_delimiter);
+
 void GDAPI godot_pool_string_array_push_back(godot_pool_string_array *p_self, const godot_string *p_data);
 
 void GDAPI godot_pool_string_array_remove(godot_pool_string_array *p_self, const godot_int p_idx);


### PR DESCRIPTION
The class PoolStringArray in GDScript has `join` method, and it even has documentation.
However, the corresponding definition of this method in GDNative headers were missing.

In this PR, the missing GDNative definition of `join` method has been added to the corresponding source files.

This PR fixes #53116

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
