### PR TITLE
Visibility Notifier / Enabler classref mention Portals

### DIFF
--- a/doc/classes/VisibilityEnabler.xml
+++ b/doc/classes/VisibilityEnabler.xml
@@ -6,7 +6,7 @@
 	<description>
 		The VisibilityEnabler will disable [RigidBody] and [AnimationPlayer] nodes when they are not visible. It will only affect other nodes within the same scene as the VisibilityEnabler itself.
 		If you just want to receive notifications, use [VisibilityNotifier] instead.
-		[b]Note:[/b] VisibilityEnabler uses an approximate heuristic for performance reasons. It doesn't take walls and other occlusion into account. The heuristic is an implementation detail and may change in future versions. If you need precise visibility checking, use another method such as adding an [Area] node as a child of a [Camera] node and/or [method Vector3.dot].
+		[b]Note:[/b] VisibilityEnabler uses an approximate heuristic for performance reasons. It doesn't take walls and other occlusion into account (unless you are using [Portal]s). The heuristic is an implementation detail and may change in future versions. If you need precise visibility checking, use another method such as adding an [Area] node as a child of a [Camera] node and/or [method Vector3.dot].
 		[b]Note:[/b] VisibilityEnabler will not affect nodes added after scene initialization.
 	</description>
 	<tutorials>

--- a/doc/classes/VisibilityNotifier.xml
+++ b/doc/classes/VisibilityNotifier.xml
@@ -6,7 +6,7 @@
 	<description>
 		The VisibilityNotifier detects when it is visible on the screen. It also notifies when its bounding rectangle enters or exits the screen or a [Camera]'s view.
 		If you want nodes to be disabled automatically when they exit the screen, use [VisibilityEnabler] instead.
-		[b]Note:[/b] VisibilityNotifier uses an approximate heuristic for performance reasons. It doesn't take walls and other occlusion into account. The heuristic is an implementation detail and may change in future versions. If you need precise visibility checking, use another method such as adding an [Area] node as a child of a [Camera] node and/or [method Vector3.dot].
+		[b]Note:[/b] VisibilityNotifier uses an approximate heuristic for performance reasons. It doesn't take walls and other occlusion into account (unless you are using [Portal]s). The heuristic is an implementation detail and may change in future versions. If you need precise visibility checking, use another method such as adding an [Area] node as a child of a [Camera] node and/or [method Vector3.dot].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Fixes the classref to show that these do not take account of occlusion _except_ when using Portals.

## Notes
* Saw someone mention this on discord, the classref is now inconsistent now Portals are available, as occlusion culling will be respected:
https://docs.godotengine.org/en/stable/tutorials/3d/portals/advanced_room_and_portal_usage.html#visbilitynotifiers-visibilityenablers
* The gameplay monitor does have to be on in the `RoomManager` for this to take effect, but this seemed too much detail to add here.
* We could alternatively link to the rooms & portals doc, is this possible in the classref?

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
