### PR TITLE
Allow selection in asset description

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -231,6 +231,7 @@ void EditorAssetLibraryItemDescription::configure(const String &p_title, int p_a
 	description->pop();
 	description->add_text("\n" + TTR("Description:") + "\n\n");
 	description->append_text(p_description);
+	description->set_selection_enabled(true);
 	set_title(p_title);
 }
 


### PR DESCRIPTION
Many assets include links in the description.
This change enables selection for the links,
and other information such as version numbers,
to be copied/pasted.