### PR TITLE
Refactored `bone_pose_override` in `Skeleton3D`

### DIFF
--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -16,12 +16,6 @@
 				Returns the [NodePath] to the external [Skeleton3D] node, if one has been set.
 			</description>
 		</method>
-		<method name="get_override_mode" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns the override mode for the BoneAttachment3D node.
-			</description>
-		</method>
 		<method name="get_override_pose" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -46,13 +40,6 @@
 			<argument index="0" name="external_skeleton" type="NodePath" />
 			<description>
 				Sets the [NodePath] to the external skeleton that the BoneAttachment3D node should use. The external [Skeleton3D] node is only used when [code]use_external_skeleton[/code] is set to [code]true[/code].
-			</description>
-		</method>
-		<method name="set_override_mode">
-			<return type="void" />
-			<argument index="0" name="override_mode" type="int" />
-			<description>
-				Sets the override mode for the BoneAttachment3D node. The override mode defines which of the bone poses the BoneAttachment3D node will override.
 			</description>
 		</method>
 		<method name="set_override_pose">

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -29,22 +29,23 @@
 				This is useful for using the bone transform in calculations with transforms from [Node3D]-based nodes.
 			</description>
 		</method>
+		<method name="clear_bone_pose_override">
+			<return type="void" />
+			<argument index="0" name="bone_idx" type="int" />
+			<description>
+				Removes the pose override on the bone at [code]bone_idx[/code].
+			</description>
+		</method>
+		<method name="clear_bone_pose_overrides">
+			<return type="void" />
+			<description>
+				Removes the pose override on all bones in the skeleton.
+			</description>
+		</method>
 		<method name="clear_bones">
 			<return type="void" />
 			<description>
 				Clear all the bones in this skeleton.
-			</description>
-		</method>
-		<method name="clear_bones_global_pose_override">
-			<return type="void" />
-			<description>
-				Removes the global pose override on all bones in the skeleton.
-			</description>
-		</method>
-		<method name="clear_bones_local_pose_override">
-			<return type="void" />
-			<description>
-				Removes the local pose override on all bones in the skeleton.
 			</description>
 		</method>
 		<method name="create_skin_from_rest_transforms">
@@ -113,13 +114,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="get_bone_local_pose_override" qualifiers="const">
-			<return type="Transform3D" />
-			<argument index="0" name="bone_idx" type="int" />
-			<description>
-				Returns the local pose override transform for [code]bone_idx[/code].
-			</description>
-		</method>
 		<method name="get_bone_name" qualifiers="const">
 			<return type="String" />
 			<argument index="0" name="bone_idx" type="int" />
@@ -140,6 +134,20 @@
 			<argument index="0" name="bone_idx" type="int" />
 			<description>
 				Returns the pose transform of the specified bone. Pose is applied on top of the custom pose, which is applied on top the rest pose.
+			</description>
+		</method>
+		<method name="get_bone_pose_no_override" qualifiers="const">
+			<return type="Transform3D" />
+			<argument index="0" name="bone_idx" type="int" />
+			<description>
+				Returns the pose without override transform for [code]bone_idx[/code].
+			</description>
+		</method>
+		<method name="get_bone_pose_override" qualifiers="const">
+			<return type="Transform3D" />
+			<argument index="0" name="bone_idx" type="int" />
+			<description>
+				Returns the pose override transform for [code]bone_idx[/code].
 			</description>
 		</method>
 		<method name="get_bone_pose_position" qualifiers="const">
@@ -185,7 +193,7 @@
 			<argument index="1" name="global_pose" type="Transform3D" />
 			<description>
 				Takes the passed-in global pose and converts it to local pose transform.
-				This can be used to easily convert a global pose from [method get_bone_global_pose] to a global transform in [method set_bone_local_pose_override].
+				This can be used to easily convert a global pose from [method get_bone_global_pose] to a global transform in [method set_bone_pose_override].
 			</description>
 		</method>
 		<method name="global_pose_to_world_transform">
@@ -210,6 +218,12 @@
 			<argument index="0" name="bone_idx" type="int" />
 			<description>
 				Returns whether the bone pose for the bone at [code]bone_idx[/code] is enabled.
+			</description>
+		</method>
+		<method name="is_bone_pose_overridden" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="bone_idx" type="int" />
+			<description>
 			</description>
 		</method>
 		<method name="local_pose_to_global_pose">
@@ -294,23 +308,9 @@
 			<argument index="0" name="bone_idx" type="int" />
 			<argument index="1" name="pose" type="Transform3D" />
 			<argument index="2" name="amount" type="float" />
-			<argument index="3" name="persistent" type="bool" default="false" />
 			<description>
 				Sets the global pose transform, [code]pose[/code], for the bone at [code]bone_idx[/code].
-				[code]amount[/code] is the interpolation strength that will be used when applying the pose, and [code]persistent[/code] determines if the applied pose will remain.
 				[b]Note:[/b] The pose transform needs to be a global pose! Use [method world_transform_to_global_pose] to convert a world transform, like one you can get from a [Node3D], to a global pose.
-			</description>
-		</method>
-		<method name="set_bone_local_pose_override">
-			<return type="void" />
-			<argument index="0" name="bone_idx" type="int" />
-			<argument index="1" name="pose" type="Transform3D" />
-			<argument index="2" name="amount" type="float" />
-			<argument index="3" name="persistent" type="bool" default="false" />
-			<description>
-				Sets the local pose transform, [code]pose[/code], for the bone at [code]bone_idx[/code].
-				[code]amount[/code] is the interpolation strength that will be used when applying the pose, and [code]persistent[/code] determines if the applied pose will remain.
-				[b]Note:[/b] The pose transform needs to be a local pose! Use [method global_pose_to_local_pose] to convert a global pose to a local pose.
 			</description>
 		</method>
 		<method name="set_bone_name">
@@ -327,6 +327,16 @@
 			<description>
 				Sets the bone index [code]parent_idx[/code] as the parent of the bone at [code]bone_idx[/code]. If -1, then bone has no parent.
 				[b]Note:[/b] [code]parent_idx[/code] must be less than [code]bone_idx[/code].
+			</description>
+		</method>
+		<method name="set_bone_pose_override">
+			<return type="void" />
+			<argument index="0" name="bone_idx" type="int" />
+			<argument index="1" name="pose" type="Transform3D" />
+			<argument index="2" name="amount" type="float" />
+			<description>
+				Sets the local pose transform, [code]pose[/code], for the bone at [code]bone_idx[/code].
+				[b]Note:[/b] The pose transform needs to be a local pose! Use [method global_pose_to_local_pose] to convert a global pose to a local pose.
 			</description>
 		</method>
 		<method name="set_bone_pose_position">

--- a/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
@@ -46,7 +46,6 @@ void SkeletonIK3DEditorPlugin::_play() {
 		skeleton_ik->start();
 	} else {
 		skeleton_ik->stop();
-		skeleton_ik->get_parent_skeleton()->clear_bones_global_pose_override();
 	}
 }
 

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -65,8 +65,6 @@ void BoneAttachment3D::_validate_property(PropertyInfo &property) const {
 bool BoneAttachment3D::_set(const StringName &p_path, const Variant &p_value) {
 	if (p_path == SNAME("override_pose")) {
 		set_override_pose(p_value);
-	} else if (p_path == SNAME("override_mode")) {
-		set_override_mode(p_value);
 	} else if (p_path == SNAME("use_external_skeleton")) {
 		set_use_external_skeleton(p_value);
 	} else if (p_path == SNAME("external_skeleton")) {
@@ -79,8 +77,6 @@ bool BoneAttachment3D::_set(const StringName &p_path, const Variant &p_value) {
 bool BoneAttachment3D::_get(const StringName &p_path, Variant &r_ret) const {
 	if (p_path == SNAME("override_pose")) {
 		r_ret = get_override_pose();
-	} else if (p_path == SNAME("override_mode")) {
-		r_ret = get_override_mode();
 	} else if (p_path == SNAME("use_external_skeleton")) {
 		r_ret = get_use_external_skeleton();
 	} else if (p_path == SNAME("external_skeleton")) {
@@ -92,9 +88,6 @@ bool BoneAttachment3D::_get(const StringName &p_path, Variant &r_ret) const {
 
 void BoneAttachment3D::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::BOOL, "override_pose", PROPERTY_HINT_NONE, ""));
-	if (override_pose) {
-		p_list->push_back(PropertyInfo(Variant::INT, "override_mode", PROPERTY_HINT_ENUM, "Global Pose Override, Local Pose Override, Custom Pose"));
-	}
 
 	p_list->push_back(PropertyInfo(Variant::BOOL, "use_external_skeleton", PROPERTY_HINT_NONE, ""));
 	if (use_external_skeleton) {
@@ -213,11 +206,7 @@ void BoneAttachment3D::_transform_changed() {
 			our_trans = sk->world_transform_to_global_pose(get_global_transform());
 		}
 
-		if (override_mode == OVERRIDE_MODES::MODE_GLOBAL_POSE) {
-			sk->set_bone_global_pose_override(bone_idx, our_trans, 1.0, true);
-		} else if (override_mode == OVERRIDE_MODES::MODE_LOCAL_POSE) {
-			sk->set_bone_local_pose_override(bone_idx, sk->global_pose_to_local_pose(bone_idx, our_trans), 1.0, true);
-		}
+		sk->set_bone_global_pose_override(bone_idx, our_trans, 1);
 	}
 }
 
@@ -269,11 +258,7 @@ void BoneAttachment3D::set_override_pose(bool p_override) {
 	if (!override_pose) {
 		Skeleton3D *sk = _get_skeleton3d();
 		if (sk) {
-			if (override_mode == OVERRIDE_MODES::MODE_GLOBAL_POSE) {
-				sk->set_bone_global_pose_override(bone_idx, Transform3D(), 0.0, false);
-			} else if (override_mode == OVERRIDE_MODES::MODE_LOCAL_POSE) {
-				sk->set_bone_local_pose_override(bone_idx, Transform3D(), 0.0, false);
-			}
+			sk->clear_bone_pose_override(bone_idx);
 		}
 		_transform_changed();
 	}
@@ -282,27 +267,6 @@ void BoneAttachment3D::set_override_pose(bool p_override) {
 
 bool BoneAttachment3D::get_override_pose() const {
 	return override_pose;
-}
-
-void BoneAttachment3D::set_override_mode(int p_mode) {
-	if (override_pose) {
-		Skeleton3D *sk = _get_skeleton3d();
-		if (sk) {
-			if (override_mode == OVERRIDE_MODES::MODE_GLOBAL_POSE) {
-				sk->set_bone_global_pose_override(bone_idx, Transform3D(), 0.0, false);
-			} else if (override_mode == OVERRIDE_MODES::MODE_LOCAL_POSE) {
-				sk->set_bone_local_pose_override(bone_idx, Transform3D(), 0.0, false);
-			}
-		}
-		override_mode = p_mode;
-		_transform_changed();
-		return;
-	}
-	override_mode = p_mode;
-}
-
-int BoneAttachment3D::get_override_mode() const {
-	return override_mode;
 }
 
 void BoneAttachment3D::set_use_external_skeleton(bool p_use_external) {
@@ -391,8 +355,6 @@ void BoneAttachment3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_override_pose", "override_pose"), &BoneAttachment3D::set_override_pose);
 	ClassDB::bind_method(D_METHOD("get_override_pose"), &BoneAttachment3D::get_override_pose);
-	ClassDB::bind_method(D_METHOD("set_override_mode", "override_mode"), &BoneAttachment3D::set_override_mode);
-	ClassDB::bind_method(D_METHOD("get_override_mode"), &BoneAttachment3D::get_override_mode);
 
 	ClassDB::bind_method(D_METHOD("set_use_external_skeleton", "use_external_skeleton"), &BoneAttachment3D::set_use_external_skeleton);
 	ClassDB::bind_method(D_METHOD("get_use_external_skeleton"), &BoneAttachment3D::get_use_external_skeleton);

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -41,13 +41,7 @@ class BoneAttachment3D : public Node3D {
 	int bone_idx = -1;
 
 	bool override_pose = false;
-	int override_mode = 0;
 	bool _override_dirty = false;
-
-	enum OVERRIDE_MODES {
-		MODE_GLOBAL_POSE,
-		MODE_LOCAL_POSE,
-	};
 
 	bool use_external_skeleton = false;
 	NodePath external_skeleton_node;
@@ -80,8 +74,6 @@ public:
 
 	void set_override_pose(bool p_override);
 	bool get_override_pose() const;
-	void set_override_mode(int p_mode);
-	int get_override_mode() const;
 
 	void set_use_external_skeleton(bool p_external_skeleton);
 	bool get_use_external_skeleton() const;

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -2915,7 +2915,7 @@ void PhysicalBone3D::_body_state_changed(PhysicsDirectBodyState3D *p_state) {
 	// Update skeleton
 	if (parent_skeleton) {
 		if (-1 != bone_id) {
-			parent_skeleton->set_bone_global_pose_override(bone_id, parent_skeleton->get_global_transform().affine_inverse() * (global_transform * body_offset_inverse), 1.0, true);
+			parent_skeleton->set_bone_global_pose_override(bone_id, parent_skeleton->get_global_transform().affine_inverse() * (global_transform * body_offset_inverse), 1);
 		}
 	}
 }
@@ -3429,7 +3429,7 @@ void PhysicalBone3D::_stop_physics_simulation() {
 	}
 	if (_internal_simulate_physics) {
 		PhysicsServer3D::get_singleton()->body_set_state_sync_callback(get_rid(), nullptr, nullptr);
-		parent_skeleton->set_bone_global_pose_override(bone_id, Transform3D(), 0.0, false);
+		parent_skeleton->clear_bone_pose_override(bone_id);
 		set_as_top_level(false);
 		_internal_simulate_physics = false;
 	}

--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -254,7 +254,7 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 		// Before skipping, make sure we undo the global pose overrides
 		ChainItem *ci(&p_task->chain.chain_root);
 		while (ci) {
-			p_task->skeleton->set_bone_global_pose_override(ci->bone, ci->initial_transform, 0.0, false);
+			p_task->skeleton->clear_bone_pose_override(ci->bone);
 
 			if (!ci->children.is_empty()) {
 				ci = &ci->children.write[0];
@@ -269,7 +269,7 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 	// Update the initial root transform so its synced with any animation changes
 	_update_chain(p_task->skeleton, &p_task->chain.chain_root);
 
-	p_task->skeleton->set_bone_global_pose_override(p_task->chain.chain_root.bone, Transform3D(), 0.0, false);
+	p_task->skeleton->clear_bone_pose_override(p_task->chain.chain_root.bone);
 	Vector3 origin_pos = p_task->skeleton->get_bone_global_pose(p_task->chain.chain_root.bone).origin;
 
 	make_goal(p_task, p_task->skeleton->get_global_transform().affine_inverse(), blending_delta);
@@ -305,7 +305,7 @@ void FabrikInverseKinematic::solve(Task *p_task, real_t blending_delta, bool ove
 		new_bone_pose.basis.orthonormalize();
 		new_bone_pose.basis.scale(p_task->skeleton->get_bone_global_pose(ci->bone).basis.get_scale());
 
-		p_task->skeleton->set_bone_global_pose_override(ci->bone, new_bone_pose, 1.0, true);
+		p_task->skeleton->set_bone_global_pose_override(ci->bone, new_bone_pose, 1);
 
 		if (!ci->children.is_empty()) {
 			ci = &ci->children.write[0];
@@ -527,7 +527,7 @@ void SkeletonIK3D::start(bool p_one_time) {
 void SkeletonIK3D::stop() {
 	set_process_internal(false);
 	if (skeleton) {
-		skeleton->clear_bones_global_pose_override();
+		skeleton->clear_bone_pose_overrides();
 	}
 }
 

--- a/scene/resources/skeleton_modification_3d_ccdik.cpp
+++ b/scene/resources/skeleton_modification_3d_ccdik.cpp
@@ -129,9 +129,7 @@ void SkeletonModification3DCCDIK::_execute(real_t p_delta) {
 
 	// Reset the local bone overrides for CCDIK affected nodes
 	for (uint32_t i = 0; i < ccdik_data_chain.size(); i++) {
-		stack->skeleton->set_bone_local_pose_override(ccdik_data_chain[i].bone_idx,
-				stack->skeleton->get_bone_local_pose_override(ccdik_data_chain[i].bone_idx),
-				0.0, false);
+		stack->skeleton->clear_bone_pose_override(ccdik_data_chain[i].bone_idx);
 	}
 
 	Node3D *node_target = Object::cast_to<Node3D>(ObjectDB::get_instance(target_node_cache));
@@ -228,7 +226,7 @@ void SkeletonModification3DCCDIK::_execute_ccdik_joint(int p_joint_idx, Node3D *
 		bone_trans.basis.set_axis_angle(rotation_axis, rotation_angle);
 	}
 
-	stack->skeleton->set_bone_local_pose_override(ccdik_data.bone_idx, bone_trans, stack->strength, true);
+	stack->skeleton->set_bone_pose_override(ccdik_data.bone_idx, bone_trans, stack->strength);
 	stack->skeleton->force_update_bone_children_transforms(ccdik_data.bone_idx);
 }
 

--- a/scene/resources/skeleton_modification_3d_fabrik.cpp
+++ b/scene/resources/skeleton_modification_3d_fabrik.cpp
@@ -285,7 +285,7 @@ void SkeletonModification3DFABRIK::chain_apply() {
 			current_trans.basis.rotate_to_align(forward_vector, current_trans.origin.direction_to(next_trans.origin));
 			current_trans.basis.rotate_local(forward_vector, fabrik_data_chain[i].roll);
 		}
-		stack->skeleton->set_bone_local_pose_override(current_bone_idx, stack->skeleton->global_pose_to_local_pose(current_bone_idx, current_trans), stack->strength, true);
+		stack->skeleton->set_bone_global_pose_override(current_bone_idx, current_trans, stack->strength);
 	}
 
 	// Update all the bones so the next modification has up-to-date data.

--- a/scene/resources/skeleton_modification_3d_jiggle.cpp
+++ b/scene/resources/skeleton_modification_3d_jiggle.cpp
@@ -172,7 +172,7 @@ void SkeletonModification3DJiggle::_execute_jiggle_joint(int p_joint_idx, Node3D
 		return;
 	}
 
-	Transform3D bone_local_pos = stack->skeleton->get_bone_local_pose_override(jiggle_data_chain[p_joint_idx].bone_idx);
+	Transform3D bone_local_pos = stack->skeleton->get_bone_pose_override(jiggle_data_chain[p_joint_idx].bone_idx);
 	if (bone_local_pos == Transform3D()) {
 		bone_local_pos = stack->skeleton->get_bone_pose(jiggle_data_chain[p_joint_idx].bone_idx);
 	}
@@ -237,7 +237,7 @@ void SkeletonModification3DJiggle::_execute_jiggle_joint(int p_joint_idx, Node3D
 	new_bone_trans.basis.rotate_local(forward_vector, jiggle_data_chain[p_joint_idx].roll);
 
 	new_bone_trans = stack->skeleton->global_pose_to_local_pose(jiggle_data_chain[p_joint_idx].bone_idx, new_bone_trans);
-	stack->skeleton->set_bone_local_pose_override(jiggle_data_chain[p_joint_idx].bone_idx, new_bone_trans, stack->strength, true);
+	stack->skeleton->set_bone_pose_override(jiggle_data_chain[p_joint_idx].bone_idx, new_bone_trans, stack->strength);
 	stack->skeleton->force_update_bone_children_transforms(jiggle_data_chain[p_joint_idx].bone_idx);
 }
 
@@ -264,7 +264,7 @@ void SkeletonModification3DJiggle::_setup_modification(SkeletonModificationStack
 			for (uint32_t i = 0; i < jiggle_data_chain.size(); i++) {
 				int bone_idx = jiggle_data_chain[i].bone_idx;
 				if (bone_idx > 0 && bone_idx < stack->skeleton->get_bone_count()) {
-					jiggle_data_chain[i].dynamic_position = stack->skeleton->local_pose_to_global_pose(bone_idx, stack->skeleton->get_bone_local_pose_override(bone_idx)).origin;
+					jiggle_data_chain[i].dynamic_position = stack->skeleton->get_bone_global_pose_override(bone_idx).origin;
 				}
 			}
 		}

--- a/scene/resources/skeleton_modification_3d_lookat.cpp
+++ b/scene/resources/skeleton_modification_3d_lookat.cpp
@@ -96,7 +96,7 @@ void SkeletonModification3DLookAt::_execute(real_t p_delta) {
 	if (_print_execution_error(bone_idx <= -1, "Bone index is invalid. Cannot execute modification!")) {
 		return;
 	}
-	Transform3D new_bone_trans = stack->skeleton->get_bone_local_pose_override(bone_idx);
+	Transform3D new_bone_trans = stack->skeleton->get_bone_pose_override(bone_idx);
 	if (new_bone_trans == Transform3D()) {
 		new_bone_trans = stack->skeleton->get_bone_pose(bone_idx);
 	}
@@ -124,7 +124,7 @@ void SkeletonModification3DLookAt::_execute(real_t p_delta) {
 	new_bone_trans.basis.rotate_local(Vector3(0, 1, 0), additional_rotation.y);
 	new_bone_trans.basis.rotate_local(Vector3(0, 0, 1), additional_rotation.z);
 
-	stack->skeleton->set_bone_local_pose_override(bone_idx, new_bone_trans, stack->strength, true);
+	stack->skeleton->set_bone_pose_override(bone_idx, new_bone_trans, stack->strength);
 	stack->skeleton->force_update_bone_children_transforms(bone_idx);
 
 	// If we completed it successfully, then we can set execution_error_found to false

--- a/scene/resources/skeleton_modification_3d_twoboneik.cpp
+++ b/scene/resources/skeleton_modification_3d_twoboneik.cpp
@@ -178,11 +178,11 @@ void SkeletonModification3DTwoBoneIK::_execute(real_t p_delta) {
 		}
 		Transform3D pole_trans = stack->skeleton->world_transform_to_global_pose(pole->get_global_transform());
 
-		Transform3D bone_one_local_pos = stack->skeleton->get_bone_local_pose_override(joint_one_bone_idx);
+		Transform3D bone_one_local_pos = stack->skeleton->get_bone_pose_override(joint_one_bone_idx);
 		if (bone_one_local_pos == Transform3D()) {
 			bone_one_local_pos = stack->skeleton->get_bone_pose(joint_one_bone_idx);
 		}
-		Transform3D bone_two_local_pos = stack->skeleton->get_bone_local_pose_override(joint_two_bone_idx);
+		Transform3D bone_two_local_pos = stack->skeleton->get_bone_pose_override(joint_two_bone_idx);
 		if (bone_two_local_pos == Transform3D()) {
 			bone_two_local_pos = stack->skeleton->get_bone_pose(joint_two_bone_idx);
 		}
@@ -192,7 +192,7 @@ void SkeletonModification3DTwoBoneIK::_execute(real_t p_delta) {
 		bone_one_trans.basis = stack->skeleton->global_pose_z_forward_to_bone_forward(joint_one_bone_idx, bone_one_trans.basis);
 		stack->skeleton->update_bone_rest_forward_vector(joint_one_bone_idx);
 		bone_one_trans.basis.rotate_local(stack->skeleton->get_bone_axis_forward_vector(joint_one_bone_idx), joint_one_roll);
-		stack->skeleton->set_bone_local_pose_override(joint_one_bone_idx, stack->skeleton->global_pose_to_local_pose(joint_one_bone_idx, bone_one_trans), stack->strength, true);
+		stack->skeleton->set_bone_global_pose_override(joint_one_bone_idx, bone_one_trans, stack->strength);
 		stack->skeleton->force_update_bone_children_transforms(joint_one_bone_idx);
 
 		bone_two_trans = stack->skeleton->local_pose_to_global_pose(joint_two_bone_idx, bone_two_local_pos);
@@ -200,14 +200,14 @@ void SkeletonModification3DTwoBoneIK::_execute(real_t p_delta) {
 		bone_two_trans.basis = stack->skeleton->global_pose_z_forward_to_bone_forward(joint_two_bone_idx, bone_two_trans.basis);
 		stack->skeleton->update_bone_rest_forward_vector(joint_two_bone_idx);
 		bone_two_trans.basis.rotate_local(stack->skeleton->get_bone_axis_forward_vector(joint_two_bone_idx), joint_two_roll);
-		stack->skeleton->set_bone_local_pose_override(joint_two_bone_idx, stack->skeleton->global_pose_to_local_pose(joint_two_bone_idx, bone_two_trans), stack->strength, true);
+		stack->skeleton->set_bone_global_pose_override(joint_two_bone_idx, bone_two_trans, stack->strength);
 		stack->skeleton->force_update_bone_children_transforms(joint_two_bone_idx);
 	} else {
-		Transform3D bone_one_local_pos = stack->skeleton->get_bone_local_pose_override(joint_one_bone_idx);
+		Transform3D bone_one_local_pos = stack->skeleton->get_bone_pose_override(joint_one_bone_idx);
 		if (bone_one_local_pos == Transform3D()) {
 			bone_one_local_pos = stack->skeleton->get_bone_pose(joint_one_bone_idx);
 		}
-		Transform3D bone_two_local_pos = stack->skeleton->get_bone_local_pose_override(joint_two_bone_idx);
+		Transform3D bone_two_local_pos = stack->skeleton->get_bone_pose_override(joint_two_bone_idx);
 		if (bone_two_local_pos == Transform3D()) {
 			bone_two_local_pos = stack->skeleton->get_bone_pose(joint_two_bone_idx);
 		}
@@ -269,12 +269,12 @@ void SkeletonModification3DTwoBoneIK::_execute(real_t p_delta) {
 	// Apply the rotation to the first joint
 	bone_one_trans = stack->skeleton->global_pose_to_local_pose(joint_one_bone_idx, bone_one_trans);
 	bone_one_trans.origin = Vector3(0, 0, 0);
-	stack->skeleton->set_bone_local_pose_override(joint_one_bone_idx, bone_one_trans, stack->strength, true);
+	stack->skeleton->set_bone_pose_override(joint_one_bone_idx, bone_one_trans, stack->strength);
 	stack->skeleton->force_update_bone_children_transforms(joint_one_bone_idx);
 
 	if (use_pole_node) {
 		// Update bone_two_trans so its at the latest position, with the rotation of bone_one_trans taken into account, then look at the target.
-		bone_two_trans = stack->skeleton->local_pose_to_global_pose(joint_two_bone_idx, stack->skeleton->get_bone_local_pose_override(joint_two_bone_idx));
+		bone_two_trans = stack->skeleton->local_pose_to_global_pose(joint_two_bone_idx, stack->skeleton->get_bone_pose_override(joint_two_bone_idx));
 		stack->skeleton->update_bone_rest_forward_vector(joint_two_bone_idx);
 		Vector3 forward_vector = stack->skeleton->get_bone_axis_forward_vector(joint_two_bone_idx);
 		bone_two_trans.basis.rotate_to_align(forward_vector, bone_two_trans.origin.direction_to(target_trans.origin));
@@ -283,7 +283,7 @@ void SkeletonModification3DTwoBoneIK::_execute(real_t p_delta) {
 		bone_two_trans.basis.rotate_local(stack->skeleton->get_bone_axis_forward_vector(joint_two_bone_idx), joint_two_roll);
 
 		bone_two_trans = stack->skeleton->global_pose_to_local_pose(joint_two_bone_idx, bone_two_trans);
-		stack->skeleton->set_bone_local_pose_override(joint_two_bone_idx, bone_two_trans, stack->strength, true);
+		stack->skeleton->set_bone_pose_override(joint_two_bone_idx, bone_two_trans, stack->strength);
 		stack->skeleton->force_update_bone_children_transforms(joint_two_bone_idx);
 	} else {
 		// Calculate the angles for the second joint using the law of cosigns, make a quaternion with the delta rotation needed to rotate the joint into
@@ -299,7 +299,7 @@ void SkeletonModification3DTwoBoneIK::_execute(real_t p_delta) {
 
 		bone_two_trans = stack->skeleton->global_pose_to_local_pose(joint_two_bone_idx, bone_two_trans);
 		bone_two_trans.origin = Vector3(0, 0, 0);
-		stack->skeleton->set_bone_local_pose_override(joint_two_bone_idx, bone_two_trans, stack->strength, true);
+		stack->skeleton->set_bone_pose_override(joint_two_bone_idx, bone_two_trans, stack->strength);
 		stack->skeleton->force_update_bone_children_transforms(joint_two_bone_idx);
 	}
 }

--- a/scene/resources/skeleton_modification_stack_3d.cpp
+++ b/scene/resources/skeleton_modification_stack_3d.cpp
@@ -174,7 +174,7 @@ void SkeletonModificationStack3D::set_enabled(bool p_enabled) {
 	enabled = p_enabled;
 
 	if (!enabled && is_setup && skeleton != nullptr) {
-		skeleton->clear_bones_local_pose_override();
+		skeleton->clear_bone_pose_overrides();
 	}
 }
 


### PR DESCRIPTION
Currently, the bone stores three pose values: `bone_pose`, `bone_global_pose_override` and `bone_local_pose_override`. However, it is not possible to get which of those values is used and how much. In other words we can't get the correct pose that the Skeleton is finally displaying. Moreover, `global_pose_override` and `local_pose_override` are not tied together so it looks mess.

I'm working on implementing RetargetNode (https://github.com/godotengine/godot-proposals/issues/3379) but due to these factors, it is difficult to get the final bone pose, and we can't retarget the modifier transforms.

This will do some refactoring.

- We should have two readable pose values, `bone_pose` and `bone_pose_override`
- Remove `bool president` and `float amount`, then implement `bool is_override_enabled` instead (if amount is needed, use `interpolate_with()` before passing the pose to `set_bone_pose_override()`; president should be managed in modifier's priority)
- Caching the value of `global_pose` is fine for performance reasons, but it is a value used for conversion between local <-> global and we should not apply it directly as a pose
- `get_bone_pose()` returns the final displayed pose, `get_bone_pose_no_override()` returns the value without the override for the bone

If this is approved, the same changes may need to be made to `Skeleton2D` for consistency.