### PR TITLE
Expose BitMap's `convert_to_image` and `resize` methods to GDScript

### DIFF
--- a/doc/classes/BitMap.xml
+++ b/doc/classes/BitMap.xml
@@ -9,6 +9,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="convert_to_image" qualifiers="const">
+			<return type="Image" />
+			<description>
+				Returns an image of the same size as the bitmap and with a [enum Image.Format] of type [code]FORMAT_L8[/code]. [code]true[/code] bits of the bitmap are being converted into white pixels, and [code]false[/code] bits into black.
+			</description>
+		</method>
 		<method name="create">
 			<return type="void" />
 			<argument index="0" name="size" type="Vector2" />
@@ -62,6 +68,13 @@
 				Rect2(Vector2(), get_size())
 				[/codeblock]
 				[code]epsilon[/code] is passed to RDP to control how accurately the polygons cover the bitmap: a lower [code]epsilon[/code] corresponds to more points in the polygons.
+			</description>
+		</method>
+		<method name="resize">
+			<return type="void" />
+			<argument index="0" name="new_size" type="Vector2" />
+			<description>
+				Resizes the image to [code]new_size[/code].
 			</description>
 		</method>
 		<method name="set_bit">

--- a/scene/resources/bit_map.cpp
+++ b/scene/resources/bit_map.cpp
@@ -667,11 +667,13 @@ void BitMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_true_bit_count"), &BitMap::get_true_bit_count);
 
 	ClassDB::bind_method(D_METHOD("get_size"), &BitMap::get_size);
+	ClassDB::bind_method(D_METHOD("resize", "new_size"), &BitMap::resize);
 
 	ClassDB::bind_method(D_METHOD("_set_data"), &BitMap::_set_data);
 	ClassDB::bind_method(D_METHOD("_get_data"), &BitMap::_get_data);
 
 	ClassDB::bind_method(D_METHOD("grow_mask", "pixels", "rect"), &BitMap::grow_mask);
+	ClassDB::bind_method(D_METHOD("convert_to_image"), &BitMap::convert_to_image);
 	ClassDB::bind_method(D_METHOD("opaque_to_polygons", "rect", "epsilon"), &BitMap::_opaque_to_polygons_bind, DEFVAL(2.0));
 
 	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "data", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_data", "_get_data");


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/3660 if it's desired. I _think_ this should be cherry-pickable for 3.x as well.
