### PR TITLE
Fix highlight for completion options match (rebased)

### DIFF
--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -227,6 +227,7 @@ struct ScriptCodeCompletionOption {
 	Color font_color;
 	RES icon;
 	Variant default_value;
+	Vector<Pair<int, int>> matches;
 
 	ScriptCodeCompletionOption() {}
 


### PR DESCRIPTION
A rebased version of https://github.com/godotengine/godot/pull/43552 (seems author abandoned it), Fix #43551

![image](https://user-images.githubusercontent.com/3036176/145704655-fe263610-fa1b-4c2b-a95b-cc823ce1733f.png)
