### PR TITLE
Fix bad mouse offset to show tooltips in Tree

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1183,7 +1183,7 @@ void Viewport::_gui_show_tooltip() {
 	Control *tooltip_owner = nullptr;
 	String tooltip_text = _gui_get_tooltip(
 			gui.tooltip_control,
-			gui.tooltip_control->get_screen_transform().xform_inv(gui.last_mouse_pos),
+			gui.tooltip_control->get_global_transform().xform_inv(gui.last_mouse_pos),
 			&tooltip_owner);
 	tooltip_text = tooltip_text.strip_edges();
 	if (tooltip_text.is_empty()) {
@@ -1712,7 +1712,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 
 				if (gui.tooltip_popup) {
 					if (gui.tooltip_control) {
-						String tooltip = _gui_get_tooltip(over, gui.tooltip_control->get_screen_transform().xform_inv(mpos));
+						String tooltip = _gui_get_tooltip(over, gui.tooltip_control->get_global_transform().xform_inv(mpos));
 
 						if (tooltip.length() == 0) {
 							_gui_cancel_tooltip();


### PR DESCRIPTION
Fixes #55817

81efebb3a170dd6194905599361c38ae4246c434 introduces a bug with some tooltips : mouse position to show tooltip is offseted by the window position on screen.

### Fix proposal : 
Revert the modification done in my guilty PR. It shouldn't have been modified as it's not dealing with popups but tooltips.

### Before
![bug](https://user-images.githubusercontent.com/3649998/145705629-9c86d9ec-296c-487f-b152-98eca0c28f60.png)

### After
![fix](https://user-images.githubusercontent.com/3649998/145705633-6a26a0d7-884d-43eb-ade0-b961d67118e0.png)

