### PR TITLE
glTF: Cleanup includes and defines, split PackedSceneGLTF to own file

### DIFF
--- a/modules/gltf/SCsub
+++ b/modules/gltf/SCsub
@@ -4,7 +4,6 @@ Import("env")
 Import("env_modules")
 
 env_gltf = env_modules.Clone()
-env_gltf.Prepend(CPPPATH=["."])
 
 # Godot's own source files
 env_gltf.add_source_files(env.modules_sources, "*.cpp")

--- a/modules/gltf/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor_scene_exporter_gltf_plugin.cpp
@@ -28,16 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "editor_scene_exporter_gltf_plugin.h"
-#include "core/object.h"
-#include "core/project_settings.h"
-#include "core/vector.h"
-#include "editor/editor_file_system.h"
-#include "scene/3d/mesh_instance.h"
-#include "scene/gui/check_box.h"
-#include "scene/main/node.h"
+#ifdef TOOLS_ENABLED
 
+#include "editor_scene_exporter_gltf_plugin.h"
+
+#include "editor/editor_file_dialog.h"
+#include "editor/editor_file_system.h"
 #include "editor/editor_node.h"
+#include "scene/main/node.h"
 
 String SceneExporterGLTFPlugin::get_name() const {
 	return "ConvertGLTF2";
@@ -90,6 +88,8 @@ void SceneExporterGLTFPlugin::convert_scene_to_gltf2(Variant p_null) {
 	if (filename.empty()) {
 		filename = root->get_name();
 	}
-	file_export_lib->set_current_file(filename + String(".gltf"));
+	file_export_lib->set_current_file(filename + ".gltf");
 	file_export_lib->popup_centered_ratio();
 }
+
+#endif // TOOLS_ENABLED

--- a/modules/gltf/editor_scene_exporter_gltf_plugin.h
+++ b/modules/gltf/editor_scene_exporter_gltf_plugin.h
@@ -31,8 +31,10 @@
 #ifndef EDITOR_SCENE_EXPORTER_GLTF_PLUGIN_H
 #define EDITOR_SCENE_EXPORTER_GLTF_PLUGIN_H
 
+#include "editor/editor_file_dialog.h"
 #include "editor/editor_plugin.h"
-#include "editor_scene_importer_gltf.h"
+
+#include "packed_scene_gltf.h"
 
 class SceneExporterGLTFPlugin : public EditorPlugin {
 	GDCLASS(SceneExporterGLTFPlugin, EditorPlugin);

--- a/modules/gltf/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor_scene_importer_gltf.cpp
@@ -28,23 +28,13 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "core/crypto/crypto_core.h"
-#include "core/io/json.h"
-#include "core/math/disjoint_set.h"
-#include "core/math/math_defs.h"
-#include "core/os/file_access.h"
-#include "core/os/os.h"
-#include "editor/import/resource_importer_scene.h"
-#include "modules/gltf/gltf_state.h"
-#include "modules/regex/regex.h"
-#include "scene/3d/bone_attachment.h"
-#include "scene/3d/camera.h"
-#include "scene/3d/mesh_instance.h"
-#include "scene/animation/animation_player.h"
-#include "scene/resources/packed_scene.h"
-#include "scene/resources/surface_tool.h"
+#ifdef TOOLS_ENABLED
 
-#include "modules/gltf/editor_scene_importer_gltf.h"
+#include "editor_scene_importer_gltf.h"
+#include "scene/resources/animation.h"
+
+#include "gltf_state.h"
+#include "packed_scene_gltf.h"
 
 uint32_t EditorSceneImporterGLTF::get_import_flags() const {
 	return ImportFlags::IMPORT_SCENE | ImportFlags::IMPORT_ANIMATION;
@@ -70,119 +60,4 @@ Ref<Animation> EditorSceneImporterGLTF::import_animation(const String &p_path,
 	return Ref<Animation>();
 }
 
-void PackedSceneGLTF::_bind_methods() {
-	ClassDB::bind_method(
-			D_METHOD("export_gltf", "node", "path", "flags", "bake_fps"),
-			&PackedSceneGLTF::export_gltf, DEFVAL(0), DEFVAL(1000.0f));
-	ClassDB::bind_method(D_METHOD("pack_gltf", "path", "flags", "bake_fps", "compress_flags", "state"),
-			&PackedSceneGLTF::pack_gltf, DEFVAL(0), DEFVAL(1000.0f), DEFVAL(Mesh::ARRAY_COMPRESS_DEFAULT), DEFVAL(Ref<GLTFState>()));
-	ClassDB::bind_method(D_METHOD("import_gltf_scene", "path", "flags", "bake_fps", "compress_flags", "state"),
-			&PackedSceneGLTF::import_gltf_scene, DEFVAL(0), DEFVAL(1000.0f), DEFVAL(Mesh::ARRAY_COMPRESS_DEFAULT), DEFVAL(Ref<GLTFState>()));
-}
-Node *PackedSceneGLTF::import_gltf_scene(const String &p_path, uint32_t p_flags, float p_bake_fps, uint32_t p_compress_flags, Ref<GLTFState> r_state) {
-	Error err = FAILED;
-	List<String> deps;
-	return import_scene(p_path, p_flags, p_bake_fps, p_compress_flags, &deps, &err, r_state);
-}
-
-Node *PackedSceneGLTF::import_scene(const String &p_path, uint32_t p_flags,
-		int p_bake_fps, uint32_t p_compress_flags,
-		List<String> *r_missing_deps,
-		Error *r_err,
-		Ref<GLTFState> r_state) {
-	if (r_state == Ref<GLTFState>()) {
-		r_state.instance();
-	}
-	r_state->use_named_skin_binds =
-			p_flags & EditorSceneImporter::IMPORT_USE_NAMED_SKIN_BINDS;
-	r_state->use_legacy_names =
-			p_flags & EditorSceneImporter::IMPORT_USE_LEGACY_NAMES;
-	r_state->compress_flags = p_compress_flags;
-
-	Ref<GLTFDocument> gltf_document;
-	gltf_document.instance();
-	Error err = gltf_document->parse(r_state, p_path);
-	*r_err = err;
-	ERR_FAIL_COND_V(err != Error::OK, nullptr);
-
-	Spatial *root = memnew(Spatial);
-	if (r_state->use_legacy_names) {
-		root->set_name(gltf_document->_legacy_validate_node_name(r_state->scene_name));
-	} else {
-		root->set_name(r_state->scene_name);
-	}
-	for (int32_t root_i = 0; root_i < r_state->root_nodes.size(); root_i++) {
-		gltf_document->_generate_scene_node(r_state, root, root, r_state->root_nodes[root_i]);
-	}
-	gltf_document->_process_mesh_instances(r_state, root);
-	if (r_state->animations.size()) {
-		AnimationPlayer *ap = memnew(AnimationPlayer);
-		root->add_child(ap);
-		ap->set_owner(root);
-		for (int i = 0; i < r_state->animations.size(); i++) {
-			gltf_document->_import_animation(r_state, ap, i, p_bake_fps);
-		}
-	}
-
-	return cast_to<Spatial>(root);
-}
-
-void PackedSceneGLTF::pack_gltf(String p_path, int32_t p_flags,
-		real_t p_bake_fps, uint32_t p_compress_flags, Ref<GLTFState> r_state) {
-	Error err = FAILED;
-	List<String> deps;
-	Node *root = import_scene(p_path, p_flags, p_bake_fps, p_compress_flags, &deps, &err, r_state);
-	ERR_FAIL_COND(err != OK);
-	pack(root);
-}
-
-void PackedSceneGLTF::save_scene(Node *p_node, const String &p_path,
-		const String &p_src_path, uint32_t p_flags,
-		int p_bake_fps, List<String> *r_missing_deps,
-		Error *r_err) {
-	Error err = FAILED;
-	if (r_err) {
-		*r_err = err;
-	}
-	Ref<GLTFDocument> gltf_document;
-	gltf_document.instance();
-	Ref<GLTFState> state;
-	state.instance();
-	err = gltf_document->serialize(state, p_node, p_path);
-	if (r_err) {
-		*r_err = err;
-	}
-}
-
-void PackedSceneGLTF::_build_parent_hierachy(Ref<GLTFState> state) {
-	// build the hierarchy
-	for (GLTFNodeIndex node_i = 0; node_i < state->nodes.size(); node_i++) {
-		for (int j = 0; j < state->nodes[node_i]->children.size(); j++) {
-			GLTFNodeIndex child_i = state->nodes[node_i]->children[j];
-			ERR_FAIL_INDEX(child_i, state->nodes.size());
-			if (state->nodes.write[child_i]->parent != -1) {
-				continue;
-			}
-			state->nodes.write[child_i]->parent = node_i;
-		}
-	}
-}
-
-Error PackedSceneGLTF::export_gltf(Node *p_root, String p_path,
-		int32_t p_flags,
-		real_t p_bake_fps) {
-	ERR_FAIL_COND_V(!p_root, FAILED);
-	List<String> deps;
-	Error err;
-	String path = p_path;
-	int32_t flags = p_flags;
-	real_t baked_fps = p_bake_fps;
-	Ref<PackedSceneGLTF> exporter;
-	exporter.instance();
-	exporter->save_scene(p_root, path, "", flags, baked_fps, &deps, &err);
-	int32_t error_code = err;
-	if (error_code != 0) {
-		return Error(error_code);
-	}
-	return OK;
-}
+#endif // TOOLS_ENABLED

--- a/modules/gltf/gltf_accessor.h
+++ b/modules/gltf/gltf_accessor.h
@@ -32,6 +32,7 @@
 #define GLTF_ACCESSOR_H
 
 #include "core/resource.h"
+
 #include "gltf_document.h"
 
 struct GLTFAccessor : public Resource {
@@ -44,8 +45,7 @@ private:
 	int component_type = 0;
 	bool normalized = false;
 	int count = 0;
-	GLTFDocument::GLTFType
-			type = GLTFDocument::TYPE_SCALAR;
+	GLTFDocument::GLTFType type = GLTFDocument::TYPE_SCALAR;
 	PoolVector<float> min;
 	PoolVector<float> max;
 	int sparse_count = 0;
@@ -101,4 +101,5 @@ public:
 	int get_sparse_values_byte_offset();
 	void set_sparse_values_byte_offset(int p_sparse_values_byte_offset);
 };
+
 #endif // GLTF_ACCESSOR_H

--- a/modules/gltf/gltf_animation.h
+++ b/modules/gltf/gltf_animation.h
@@ -71,4 +71,5 @@ private:
 	bool loop = false;
 	Map<int, Track> tracks;
 };
+
 #endif // GLTF_ANIMATION_H

--- a/modules/gltf/gltf_buffer_view.h
+++ b/modules/gltf/gltf_buffer_view.h
@@ -32,6 +32,7 @@
 #define GLTF_BUFFER_VIEW_H
 
 #include "core/resource.h"
+
 #include "gltf_document.h"
 
 class GLTFBufferView : public Resource {
@@ -65,4 +66,5 @@ public:
 	void set_indices(bool p_indices);
 	// matrices need to be transformed to this
 };
+
 #endif // GLTF_BUFFER_VIEW_H

--- a/modules/gltf/gltf_camera.h
+++ b/modules/gltf/gltf_camera.h
@@ -55,4 +55,5 @@ public:
 	float get_znear() const { return znear; }
 	void set_znear(float p_val) { znear = p_val; }
 };
+
 #endif // GLTF_CAMERA_H

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -42,10 +42,8 @@
 #include "gltf_state.h"
 #include "gltf_texture.h"
 
-#include "core/bind/core_bind.h"
+#include "core/bind/core_bind.h" // FIXME: Shouldn't use _Directory but DirAccess.
 #include "core/crypto/crypto_core.h"
-#include "core/error_list.h"
-#include "core/error_macros.h"
 #include "core/io/json.h"
 #include "core/math/disjoint_set.h"
 #include "core/os/file_access.h"
@@ -53,13 +51,10 @@
 #include "core/version.h"
 #include "core/version_hash.gen.h"
 #include "drivers/png/png_driver_common.h"
-#include "editor/import/resource_importer_scene.h"
 #include "scene/2d/node_2d.h"
 #include "scene/3d/bone_attachment.h"
-#include "scene/3d/camera.h"
 #include "scene/3d/mesh_instance.h"
 #include "scene/3d/multimesh_instance.h"
-#include "scene/3d/skeleton.h"
 #include "scene/3d/spatial.h"
 #include "scene/animation/animation_player.h"
 #include "scene/main/node.h"
@@ -76,10 +71,6 @@
 #ifdef MODULE_REGEX_ENABLED
 #include "modules/regex/regex.h"
 #endif // MODULE_REGEX_ENABLED
-
-#include <stdio.h>
-#include <stdlib.h>
-#include <limits>
 
 Error GLTFDocument::serialize(Ref<GLTFState> state, Node *p_root, const String &p_path) {
 	uint64_t begin_time = OS::get_singleton()->get_ticks_usec();

--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -31,9 +31,8 @@
 #ifndef GLTF_DOCUMENT_H
 #define GLTF_DOCUMENT_H
 
-#include "gltf_animation.h"
-#include "scene/2d/node_2d.h"
 #include "scene/3d/bone_attachment.h"
+#include "scene/3d/camera.h"
 #include "scene/3d/light.h"
 #include "scene/3d/mesh_instance.h"
 #include "scene/3d/skeleton.h"
@@ -42,6 +41,8 @@
 #include "scene/resources/material.h"
 #include "scene/resources/texture.h"
 
+#include "gltf_animation.h"
+
 #include "modules/modules_enabled.gen.h" // For csg, gridmap.
 
 class GLTFState;
@@ -49,9 +50,14 @@ class GLTFSkin;
 class GLTFNode;
 class GLTFSpecGloss;
 class GLTFSkeleton;
-class CSGShape;
-class GridMap;
 class MultiMeshInstance;
+
+#ifdef MODULE_CSG_ENABLED
+class CSGShape;
+#endif // MODULE_CSG_ENABLED
+#ifdef MODULE_GRIDMAP_ENABLED
+class GridMap;
+#endif // MODULE_GRIDMAP_ENABLED
 
 using GLTFAccessorIndex = int;
 using GLTFAnimationIndex = int;

--- a/modules/gltf/gltf_light.h
+++ b/modules/gltf/gltf_light.h
@@ -31,7 +31,6 @@
 #ifndef GLTF_LIGHT_H
 #define GLTF_LIGHT_H
 
-#include "core/engine.h"
 #include "core/resource.h"
 
 class GLTFLight : public Resource {

--- a/modules/gltf/gltf_mesh.h
+++ b/modules/gltf/gltf_mesh.h
@@ -32,7 +32,6 @@
 #define GLTF_MESH_H
 
 #include "core/resource.h"
-#include "editor/import/resource_importer_scene.h"
 #include "scene/resources/mesh.h"
 
 class GLTFMesh : public Resource {
@@ -54,4 +53,5 @@ public:
 	Array get_instance_materials();
 	void set_instance_materials(Array p_instance_materials);
 };
+
 #endif // GLTF_MESH_H

--- a/modules/gltf/gltf_node.h
+++ b/modules/gltf/gltf_node.h
@@ -32,6 +32,7 @@
 #define GLTF_NODE_H
 
 #include "core/resource.h"
+
 #include "gltf_document.h"
 
 class GLTFNode : public Resource {
@@ -98,4 +99,5 @@ public:
 	GLTFLightIndex get_light();
 	void set_light(GLTFLightIndex p_light);
 };
+
 #endif // GLTF_NODE_H

--- a/modules/gltf/gltf_skeleton.h
+++ b/modules/gltf/gltf_skeleton.h
@@ -32,6 +32,7 @@
 #define GLTF_SKELETON_H
 
 #include "core/resource.h"
+
 #include "gltf_document.h"
 
 class GLTFSkeleton : public Resource {
@@ -68,34 +69,15 @@ public:
 
 	Skeleton *get_godot_skeleton();
 
-	// Skeleton *get_godot_skeleton() {
-	// 	return this->godot_skeleton;
-	// }
-	// void set_godot_skeleton(Skeleton p_*godot_skeleton) {
-	// 	this->godot_skeleton = p_godot_skeleton;
-	// }
-
 	Array get_unique_names();
 	void set_unique_names(Array p_unique_names);
 
-	//Map<int32_t, GLTFNodeIndex> get_godot_bone_node() {
-	//	return this->godot_bone_node;
-	//}
-	//void set_godot_bone_node(Map<int32_t, GLTFNodeIndex> p_godot_bone_node) {
-	//	this->godot_bone_node = p_godot_bone_node;
-	//}
 	Dictionary get_godot_bone_node();
 	void set_godot_bone_node(Dictionary p_indict);
-
-	//Dictionary get_godot_bone_node() {
-	//	return VariantConversion::to_dict(this->godot_bone_node);
-	//}
-	//void set_godot_bone_node(Dictionary p_indict) {
-	//	VariantConversion::set_from_dict(this->godot_bone_node, p_indict);
-	//}
 
 	BoneAttachment *get_bone_attachment(int idx);
 
 	int32_t get_bone_attachment_count();
 };
+
 #endif // GLTF_SKELETON_H

--- a/modules/gltf/gltf_skin.h
+++ b/modules/gltf/gltf_skin.h
@@ -32,6 +32,7 @@
 #define GLTF_SKIN_H
 
 #include "core/resource.h"
+
 #include "gltf_document.h"
 
 class GLTFSkin : public Resource {
@@ -106,4 +107,5 @@ public:
 	Ref<Skin> get_godot_skin();
 	void set_godot_skin(Ref<Skin> p_godot_skin);
 };
+
 #endif // GLTF_SKIN_H

--- a/modules/gltf/gltf_spec_gloss.h
+++ b/modules/gltf/gltf_spec_gloss.h
@@ -64,4 +64,5 @@ public:
 	Ref<Image> get_spec_gloss_img();
 	void set_spec_gloss_img(Ref<Image> p_spec_gloss_img);
 };
+
 #endif // GLTF_SPEC_GLOSS_H

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -31,9 +31,12 @@
 #ifndef GLTF_STATE_H
 #define GLTF_STATE_H
 
+#include "core/map.h"
 #include "core/resource.h"
 #include "core/vector.h"
-#include "editor_scene_importer_gltf.h"
+#include "scene/animation/animation_player.h"
+#include "scene/resources/texture.h"
+
 #include "gltf_accessor.h"
 #include "gltf_animation.h"
 #include "gltf_buffer_view.h"
@@ -45,13 +48,6 @@
 #include "gltf_skeleton.h"
 #include "gltf_skin.h"
 #include "gltf_texture.h"
-
-#include "core/map.h"
-#include "core/pair.h"
-#include "core/resource.h"
-#include "core/vector.h"
-#include "scene/animation/animation_player.h"
-#include "scene/resources/texture.h"
 
 class GLTFState : public Resource {
 	GDCLASS(GLTFState, Resource);
@@ -176,20 +172,6 @@ public:
 	int get_animation_players_count(int idx);
 
 	AnimationPlayer *get_animation_player(int idx);
-
-	//void set_scene_nodes(Map<GLTFNodeIndex, Node *> p_scene_nodes) {
-	//	this->scene_nodes = p_scene_nodes;
-	//}
-
-	//void set_animation_players(Vector<AnimationPlayer *> p_animation_players) {
-	//	this->animation_players = p_animation_players;
-	//}
-
-	//Map<Ref<Material>, GLTFMaterialIndex> get_material_cache() {
-	//	return this->material_cache;
-	//}
-	//void set_material_cache(Map<Ref<Material>, GLTFMaterialIndex> p_material_cache) {
-	//	this->material_cache = p_material_cache;
-	//}
 };
+
 #endif // GLTF_STATE_H

--- a/modules/gltf/gltf_texture.h
+++ b/modules/gltf/gltf_texture.h
@@ -32,6 +32,7 @@
 #define GLTF_TEXTURE_H
 
 #include "core/resource.h"
+
 #include "gltf_document.h"
 
 class GLTFTexture : public Resource {

--- a/modules/gltf/packed_scene_gltf.cpp
+++ b/modules/gltf/packed_scene_gltf.cpp
@@ -1,0 +1,159 @@
+/*************************************************************************/
+/*  packed_scene_gltf.cpp                                                */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2021 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2021 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifdef TOOLS_ENABLED
+
+#include "packed_scene_gltf.h"
+
+#include "editor/import/resource_importer_scene.h"
+#include "scene/3d/spatial.h"
+#include "scene/animation/animation_player.h"
+#include "scene/resources/mesh.h"
+
+#include "gltf_document.h"
+
+void PackedSceneGLTF::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("export_gltf", "node", "path", "flags", "bake_fps"),
+			&PackedSceneGLTF::export_gltf, DEFVAL(0), DEFVAL(1000.0f));
+	ClassDB::bind_method(D_METHOD("pack_gltf", "path", "flags", "bake_fps", "compress_flags", "state"),
+			&PackedSceneGLTF::pack_gltf, DEFVAL(0), DEFVAL(1000.0f), DEFVAL(Mesh::ARRAY_COMPRESS_DEFAULT), DEFVAL(Ref<GLTFState>()));
+	ClassDB::bind_method(D_METHOD("import_gltf_scene", "path", "flags", "bake_fps", "compress_flags", "state"),
+			&PackedSceneGLTF::import_gltf_scene, DEFVAL(0), DEFVAL(1000.0f), DEFVAL(Mesh::ARRAY_COMPRESS_DEFAULT), DEFVAL(Ref<GLTFState>()));
+}
+
+Node *PackedSceneGLTF::import_gltf_scene(const String &p_path, uint32_t p_flags, float p_bake_fps, uint32_t p_compress_flags, Ref<GLTFState> r_state) {
+	Error err = FAILED;
+	List<String> deps;
+	return import_scene(p_path, p_flags, p_bake_fps, p_compress_flags, &deps, &err, r_state);
+}
+
+Node *PackedSceneGLTF::import_scene(const String &p_path, uint32_t p_flags,
+		int p_bake_fps, uint32_t p_compress_flags,
+		List<String> *r_missing_deps,
+		Error *r_err,
+		Ref<GLTFState> r_state) {
+	if (r_state == Ref<GLTFState>()) {
+		r_state.instance();
+	}
+	r_state->use_named_skin_binds =
+			p_flags & EditorSceneImporter::IMPORT_USE_NAMED_SKIN_BINDS;
+	r_state->use_legacy_names =
+			p_flags & EditorSceneImporter::IMPORT_USE_LEGACY_NAMES;
+	r_state->compress_flags = p_compress_flags;
+
+	Ref<GLTFDocument> gltf_document;
+	gltf_document.instance();
+	Error err = gltf_document->parse(r_state, p_path);
+	*r_err = err;
+	ERR_FAIL_COND_V(err != Error::OK, nullptr);
+
+	Spatial *root = memnew(Spatial);
+	if (r_state->use_legacy_names) {
+		root->set_name(gltf_document->_legacy_validate_node_name(r_state->scene_name));
+	} else {
+		root->set_name(r_state->scene_name);
+	}
+	for (int32_t root_i = 0; root_i < r_state->root_nodes.size(); root_i++) {
+		gltf_document->_generate_scene_node(r_state, root, root, r_state->root_nodes[root_i]);
+	}
+	gltf_document->_process_mesh_instances(r_state, root);
+	if (r_state->animations.size()) {
+		AnimationPlayer *ap = memnew(AnimationPlayer);
+		root->add_child(ap);
+		ap->set_owner(root);
+		for (int i = 0; i < r_state->animations.size(); i++) {
+			gltf_document->_import_animation(r_state, ap, i, p_bake_fps);
+		}
+	}
+
+	return cast_to<Spatial>(root);
+}
+
+void PackedSceneGLTF::pack_gltf(String p_path, int32_t p_flags,
+		real_t p_bake_fps, uint32_t p_compress_flags, Ref<GLTFState> r_state) {
+	Error err = FAILED;
+	List<String> deps;
+	Node *root = import_scene(p_path, p_flags, p_bake_fps, p_compress_flags, &deps, &err, r_state);
+	ERR_FAIL_COND(err != OK);
+	pack(root);
+}
+
+void PackedSceneGLTF::save_scene(Node *p_node, const String &p_path,
+		const String &p_src_path, uint32_t p_flags,
+		int p_bake_fps, List<String> *r_missing_deps,
+		Error *r_err) {
+	Error err = FAILED;
+	if (r_err) {
+		*r_err = err;
+	}
+	Ref<GLTFDocument> gltf_document;
+	gltf_document.instance();
+	Ref<GLTFState> state;
+	state.instance();
+	err = gltf_document->serialize(state, p_node, p_path);
+	if (r_err) {
+		*r_err = err;
+	}
+}
+
+void PackedSceneGLTF::_build_parent_hierachy(Ref<GLTFState> state) {
+	// build the hierarchy
+	for (GLTFNodeIndex node_i = 0; node_i < state->nodes.size(); node_i++) {
+		for (int j = 0; j < state->nodes[node_i]->children.size(); j++) {
+			GLTFNodeIndex child_i = state->nodes[node_i]->children[j];
+			ERR_FAIL_INDEX(child_i, state->nodes.size());
+			if (state->nodes.write[child_i]->parent != -1) {
+				continue;
+			}
+			state->nodes.write[child_i]->parent = node_i;
+		}
+	}
+}
+
+Error PackedSceneGLTF::export_gltf(Node *p_root, String p_path,
+		int32_t p_flags,
+		real_t p_bake_fps) {
+	ERR_FAIL_COND_V(!p_root, FAILED);
+	List<String> deps;
+	Error err;
+	String path = p_path;
+	int32_t flags = p_flags;
+	real_t baked_fps = p_bake_fps;
+	Ref<PackedSceneGLTF> exporter;
+	exporter.instance();
+	exporter->save_scene(p_root, path, "", flags, baked_fps, &deps, &err);
+	int32_t error_code = err;
+	if (error_code != 0) {
+		return Error(error_code);
+	}
+	return OK;
+}
+
+#endif // TOOLS_ENABLED

--- a/modules/gltf/packed_scene_gltf.h
+++ b/modules/gltf/packed_scene_gltf.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  editor_scene_importer_gltf.h                                         */
+/*  packed_scene_gltf.h                                                  */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -30,28 +30,37 @@
 
 #ifdef TOOLS_ENABLED
 
-#ifndef EDITOR_SCENE_IMPORTER_GLTF_H
-#define EDITOR_SCENE_IMPORTER_GLTF_H
+#ifndef PACKED_SCENE_GLTF_H
+#define PACKED_SCENE_GLTF_H
 
-#include "editor/import/resource_importer_scene.h"
+#include "scene/main/node.h"
+#include "scene/resources/packed_scene.h"
 
-#include "gltf_document.h"
 #include "gltf_state.h"
 
-class EditorSceneImporterGLTF : public EditorSceneImporter {
-	GDCLASS(EditorSceneImporterGLTF, EditorSceneImporter);
+class PackedSceneGLTF : public PackedScene {
+	GDCLASS(PackedSceneGLTF, PackedScene);
+
+protected:
+	static void _bind_methods();
 
 public:
-	virtual uint32_t get_import_flags() const;
-	virtual void get_extensions(List<String> *r_extensions) const;
+	virtual void save_scene(Node *p_node, const String &p_path, const String &p_src_path,
+			uint32_t p_flags, int p_bake_fps,
+			List<String> *r_missing_deps, Error *r_err = nullptr);
+	virtual void _build_parent_hierachy(Ref<GLTFState> state);
+	virtual Error export_gltf(Node *p_root, String p_path, int32_t p_flags = 0,
+			real_t p_bake_fps = 1000.0f);
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			int p_bake_fps, uint32_t p_compress_flags,
-			List<String> *r_missing_deps = nullptr,
-			Error *r_err = nullptr);
-	virtual Ref<Animation> import_animation(const String &p_path,
-			uint32_t p_flags, int p_bake_fps);
+			List<String> *r_missing_deps,
+			Error *r_err,
+			Ref<GLTFState> r_state);
+	virtual Node *import_gltf_scene(const String &p_path, uint32_t p_flags, float p_bake_fps, uint32_t p_compress_flags, Ref<GLTFState> r_state = Ref<GLTFState>());
+	virtual void pack_gltf(String p_path, int32_t p_flags = 0,
+			real_t p_bake_fps = 1000.0f, uint32_t p_compress_flags = Mesh::ARRAY_COMPRESS_DEFAULT, Ref<GLTFState> r_state = Ref<GLTFState>());
 };
 
-#endif // EDITOR_SCENE_IMPORTER_GLTF_H
+#endif // PACKED_SCENE_GLTF_H
 
 #endif // TOOLS_ENABLED

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -28,11 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef _3D_DISABLED
+
 #include "register_types.h"
 
-#include "editor/editor_node.h"
-#include "editor_scene_exporter_gltf_plugin.h"
-#include "editor_scene_importer_gltf.h"
 #include "gltf_accessor.h"
 #include "gltf_animation.h"
 #include "gltf_buffer_view.h"
@@ -46,8 +45,14 @@
 #include "gltf_spec_gloss.h"
 #include "gltf_state.h"
 #include "gltf_texture.h"
+#include "packed_scene_gltf.h"
 
-#ifndef _3D_DISABLED
+#ifdef TOOLS_ENABLED
+#include "editor/editor_node.h"
+#include "editor_scene_exporter_gltf_plugin.h"
+#include "editor_scene_importer_gltf.h"
+#endif
+
 #ifdef TOOLS_ENABLED
 static void _editor_init() {
 	Ref<EditorSceneImporterGLTF> import_gltf;
@@ -55,10 +60,8 @@ static void _editor_init() {
 	ResourceImporterScene::get_singleton()->add_importer(import_gltf);
 }
 #endif
-#endif
 
 void register_gltf_types() {
-#ifndef _3D_DISABLED
 #ifdef TOOLS_ENABLED
 	ClassDB::APIType prev_api = ClassDB::get_current_api();
 	ClassDB::set_current_api(ClassDB::API_EDITOR);
@@ -68,6 +71,7 @@ void register_gltf_types() {
 	ClassDB::set_current_api(prev_api);
 	EditorNode::add_init_callback(_editor_init);
 #endif
+
 	ClassDB::register_class<GLTFSpecGloss>();
 	ClassDB::register_class<GLTFNode>();
 	ClassDB::register_class<GLTFAnimation>();
@@ -81,8 +85,9 @@ void register_gltf_types() {
 	ClassDB::register_class<GLTFState>();
 	ClassDB::register_class<GLTFDocument>();
 	ClassDB::register_class<PackedSceneGLTF>();
-#endif
 }
 
 void unregister_gltf_types() {
 }
+
+#endif // _3D_DISABLED

--- a/modules/gltf/register_types.h
+++ b/modules/gltf/register_types.h
@@ -28,5 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef GLTF_REGISTER_TYPES_H
+#define GLTF_REGISTER_TYPES_H
+
+#ifndef _3D_DISABLED
+
 void register_gltf_types();
 void unregister_gltf_types();
+
+#endif // _3D_DISABLED
+
+#endif // GLTF_REGISTER_TYPES_H


### PR DESCRIPTION
While working on https://github.com/godotengine/godot/issues/55796#issuecomment-991877226 I noticed a lot of pointless includes in the glTF module (despite having fixed many of those in the past already), so I jumped in the rabbit hole and did a full cleanup.

I'll have a look at porting the same changes to `master` (when relevant) later on.