### PR TITLE
Switch WebXRInterface from using external textures to using the render targets from Godot

### DIFF
--- a/modules/webxr/godot_webxr.h
+++ b/modules/webxr/godot_webxr.h
@@ -65,8 +65,7 @@ extern int godot_webxr_get_view_count();
 extern int *godot_webxr_get_render_targetsize();
 extern float *godot_webxr_get_transform_for_eye(int p_eye);
 extern float *godot_webxr_get_projection_for_eye(int p_eye);
-extern int godot_webxr_get_external_texture_for_eye(int p_eye);
-extern void godot_webxr_commit_for_eye(int p_eye);
+extern void godot_webxr_commit_for_eye(int p_eye, unsigned int p_texture_id);
 
 extern void godot_webxr_sample_controller_data();
 extern int godot_webxr_get_controller_count();

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -349,18 +349,15 @@ CameraMatrix WebXRInterfaceJS::get_projection_for_eye(ARVRInterface::Eyes p_eye,
 	return eye;
 }
 
-unsigned int WebXRInterfaceJS::get_external_texture_for_eye(ARVRInterface::Eyes p_eye) {
-	if (!initialized) {
-		return 0;
-	}
-	return godot_webxr_get_external_texture_for_eye(p_eye);
-}
-
 void WebXRInterfaceJS::commit_for_eye(ARVRInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect) {
 	if (!initialized) {
 		return;
 	}
-	godot_webxr_commit_for_eye(p_eye);
+
+	RID texture = VSG::storage->render_target_get_texture(p_render_target);
+	uint32_t texture_id = VSG::storage->texture_get_texid(texture);
+
+	godot_webxr_commit_for_eye(p_eye, texture_id);
 };
 
 void WebXRInterfaceJS::process() {

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -86,7 +86,6 @@ public:
 	virtual bool is_stereo();
 	virtual Transform get_transform_for_eye(ARVRInterface::Eyes p_eye, const Transform &p_cam_transform);
 	virtual CameraMatrix get_projection_for_eye(ARVRInterface::Eyes p_eye, real_t p_aspect, real_t p_z_near, real_t p_z_far);
-	virtual unsigned int get_external_texture_for_eye(ARVRInterface::Eyes p_eye);
 	virtual void commit_for_eye(ARVRInterface::Eyes p_eye, RID p_render_target, const Rect2 &p_screen_rect);
 
 	virtual void process();


### PR DESCRIPTION
This has two positive effects:

1. 2D controls on a CanvasLayer will actually render, which is useful for smartphone AR
2. There's less code - deleting lines is always good :-)

This PR is only for 3.x - I tried to make a 4.x version, but it really doesn't make sense. The primary change here is that we are taking an OpenGL texture ID for a texture that Godot created and passing it into the WebXR JS code (rather than the texture being created on the JS end). But in 4.x, there is no OpenGL texture ID to pass in, since we're still waiting for 3D and XR support to be added to the OpenGL renderer in 4.x. I asked @BastiaanOlij on RocketChat and he thought it would be OK to make this 3.x only.