### PR TITLE
Enable GDExtension libraries from absolute paths

### DIFF
--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -405,7 +405,7 @@ RES NativeExtensionResourceLoader::load(const String &p_path, const String &p_or
 		return RES();
 	}
 
-	if (!library_path.is_resource_file()) {
+	if (!library_path.is_resource_file() && !library_path.is_absolute_path()) {
 		library_path = p_path.get_base_dir().plus_file(library_path);
 	}
 


### PR DESCRIPTION
If a gdextension library filepath is an absolute path do not attempt to append the base directory on top of that. While this is a uncommon if not unused case for a release version it is helpful for development builds. It may be worth macro-ing this so only debug builds have this functionality.

