### PR TITLE
Fixes rotation 3D track inspector not using the correct type

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -570,7 +570,7 @@ public:
 				p_list->push_back(PropertyInfo(Variant::VECTOR3, "position"));
 			} break;
 			case Animation::TYPE_ROTATION_3D: {
-				p_list->push_back(PropertyInfo(Variant::VECTOR3, "rotation"));
+				p_list->push_back(PropertyInfo(Variant::QUATERNION, "rotation"));
 			} break;
 			case Animation::TYPE_SCALE_3D: {
 				p_list->push_back(PropertyInfo(Variant::VECTOR3, "scale"));


### PR DESCRIPTION
This make the value property (in the inspector), when clicking on a 3D rotation track keyframe, work again.
It used to display a Vector3(0,0,0) all the time before, now it correclty display a quaternion.

Likely fixes https://github.com/godotengine/godot/issues/55864.
I don't know if the rotation track was backported, but this change could maybe fix -- https://github.com/godotengine/godot/issues/39229 too ? If cherry-picked I mean.
