### PR TITLE
[3.x] Hide non-working SpatialMaterial properties when Unshaded flag is enabled

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -493,7 +493,9 @@ void SpatialMaterial::_update_shader() {
 	if (flags[FLAG_ENSURE_CORRECT_NORMALS]) {
 		code += ",ensure_correct_normals";
 	}
-	if (flags[FLAG_USE_SHADOW_TO_OPACITY]) {
+	if (!flags[FLAG_UNSHADED] && flags[FLAG_USE_SHADOW_TO_OPACITY]) {
+		// Unshaded flag does not behave correctly with the Use Shadow To Opacity flag
+		// (it lowers the entire object's opacity in an uniform manner).
 		code += ",shadow_to_opacity";
 	}
 	code += ";\n";
@@ -541,7 +543,7 @@ void SpatialMaterial::_update_shader() {
 		code += "uniform float emission_energy;\n";
 	}
 
-	if (features[FEATURE_REFRACTION]) {
+	if (!flags[FLAG_UNSHADED] && features[FEATURE_REFRACTION]) {
 		code += "uniform sampler2D texture_refraction;\n";
 		code += "uniform float refraction : hint_range(-16,16);\n";
 		code += "uniform vec4 refraction_texture_channel;\n";
@@ -863,7 +865,7 @@ void SpatialMaterial::_update_shader() {
 		}
 	}
 
-	if (features[FEATURE_REFRACTION]) {
+	if (!flags[FLAG_UNSHADED] && features[FEATURE_REFRACTION]) {
 		if (features[FEATURE_NORMAL_MAPPING]) {
 			code += "\tvec3 unpacked_normal = NORMALMAP;\n";
 			code += "\tunpacked_normal.xy = unpacked_normal.xy * 2.0 - 1.0;\n";
@@ -1441,6 +1443,11 @@ void SpatialMaterial::_validate_property(PropertyInfo &property) const {
 	}
 
 	if (flags[FLAG_UNSHADED]) {
+		// Hide properties that have no effect when the Unshaded flag is enabled.
+		if (property.name == "flags_vertex_lighting" || property.name == "diffuse_mode" || property.name == "specular_mode" || property.name == "flags_disable_ambient_light" || property.name == "flags_do_not_receive_shadows" || property.name == "flags_use_shadow_to_opacity") {
+			property.usage = 0;
+		}
+
 		if (property.name.begins_with("anisotropy")) {
 			property.usage = 0;
 		}
@@ -1478,6 +1485,10 @@ void SpatialMaterial::_validate_property(PropertyInfo &property) const {
 		}
 
 		if (property.name.begins_with("transmission")) {
+			property.usage = 0;
+		}
+
+		if (property.name.begins_with("refraction")) {
 			property.usage = 0;
 		}
 	}


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/55907.

Refraction is also disabled in the generated shader when the shading mode is set to Unshaded. Otherwise, turning a per-pixel shaded material into an unshaded material caused the material to become opaque if refraction was enabled (even if it was previously transparent).

The Shadow to Opacity flag is no longer added to unshaded materials as well, since it didn't behave correctly there:

### Unshaded

![2021-12-13_18 37 14](https://user-images.githubusercontent.com/180032/145861266-824a9f67-60f5-4b49-93cf-89d39e734fd5.png)

### Unshaded + Use Shadow To Opacity

*Albedo is fully opaque (and there is an object casting a shadow on the sphere outside the camera frustum), but the material appears partially transparent on the whole surface.*

![2021-12-13_18 37 11](https://user-images.githubusercontent.com/180032/145861261-8b6ee00a-166f-4506-9c9e-405d9c57b680.png)