### PR TITLE
Fix shader crash when assigned array from struct to a variable by index

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -576,7 +576,7 @@ public:
 
 		virtual DataType get_datatype() const override { return datatype; }
 		virtual String get_datatype_name() const override { return String(struct_name); }
-		virtual int get_array_size() const override { return array_size; }
+		virtual int get_array_size() const override { return (index_expression || call_expression) ? 0 : array_size; }
 		virtual bool is_indexed() const override { return index_expression != nullptr || call_expression != nullptr; }
 
 		MemberNode() :


### PR DESCRIPTION
Fixes the compiling of the following code:

```
struct Test{
	vec3 v[2];
};

void fragment() {
	Test t;
	vec3 v[2] = t.v[0]; // FIX 1 (CRASH)
	int l = t.v.length(); // FIX 2
}
```