### PR TITLE
Document how to autoscroll ScrollContainer.

### DIFF
--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -14,6 +14,12 @@
 			<argument index="0" name="control" type="Control" />
 			<description>
 				Ensures the given [code]control[/code] is visible (must be a direct or indirect child of the ScrollContainer). Used by [member follow_focus].
+				[b]Note:[/b] This will not work on a node that was just added during the same frame. If you want to scroll to a newly added child, you must wait until the next frame using [signal SceneTree.idle_frame]:
+				[codeblock]
+				add_child(child_node)
+				yield(get_tree(), "idle_frame")
+				ensure_control_visible(child_node)
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_h_scrollbar">


### PR DESCRIPTION
It is not uncommon to want to scroll to the most recently added child of
a ScrollContainer (e.g. a chat box or activity log). This is a little
tricky, since `ensure_control_visible` will not work on a node on the
same frame as you add it. Let's at least document that you need to wait
until the next frame.

Relates to https://github.com/godotengine/godot-proposals/issues/3629.

Backport of https://github.com/godotengine/godot/pull/55609.

Co-authored-by: Yuri Sizov <pycbouh@users.noreply.github.com>
