### PR TITLE
Fix add_line width being too wide

### DIFF
--- a/servers/visual/visual_server_canvas.cpp
+++ b/servers/visual/visual_server_canvas.cpp
@@ -476,7 +476,7 @@ void VisualServerCanvas::canvas_item_add_line(RID p_item, const Point2 &p_from, 
 
 		// 90 degrees
 		side = Vector2(-side.y, side.x);
-		side *= p_width;
+		side *= p_width * 0.5;
 
 		points.set(0, p_from + side);
 		points.set(1, p_from - side);


### PR DESCRIPTION
The line width of thick lines was being applied on both sides of the line, resulting in a line that was twice as thick as requested.

This PR fixes this embarrassing oversight.

Fixes #55920

## Notes
* Bug introduced by yours truly in #54377

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
