### PR TITLE
Improve user communication in the Add Item Type dialog in Theme Editor

### DIFF
--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef THEME_EDITOR_PLUGIN_H
 #define THEME_EDITOR_PLUGIN_H
 
+#include "scene/gui/dialogs.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/scroll_container.h"
@@ -270,8 +271,11 @@ class ThemeTypeDialog : public ConfirmationDialog {
 	Ref<Theme> edited_theme;
 	bool include_own_types = false;
 
+	String pre_submitted_value;
+
 	LineEdit *add_type_filter;
 	ItemList *add_type_options;
+	ConfirmationDialog *add_type_confirmation;
 
 	void _dialog_about_to_show();
 	void ok_pressed() override;
@@ -282,6 +286,9 @@ class ThemeTypeDialog : public ConfirmationDialog {
 	void _add_type_options_cbk(int p_index);
 	void _add_type_dialog_entered(const String &p_value);
 	void _add_type_dialog_activated(int p_index);
+
+	void _add_type_selected(const String &p_type_name);
+	void _add_type_confirmed();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
This makes the purpose of the dialog a bit clearer and informs users that they in fact can create new theme types through it. This also adds a warning when you try to add an empty type, as that can happen by accident and is unlikely to be the desired outcome for most.

![godot windows tools 64_2021-12-14_16-58-32](https://user-images.githubusercontent.com/11782833/146012698-028f013e-5f56-4c76-9be4-3b8fc1e741fd.png)
