### PR TITLE
[3.x] Improve user communication in the Add Item Type dialog

### DIFF
--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef THEME_EDITOR_PLUGIN_H
 #define THEME_EDITOR_PLUGIN_H
 
+#include "scene/gui/dialogs.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/scroll_container.h"
@@ -256,6 +257,42 @@ public:
 	ThemeItemEditorDialog();
 };
 
+class ThemeTypeDialog : public ConfirmationDialog {
+	GDCLASS(ThemeTypeDialog, ConfirmationDialog);
+
+	Ref<Theme> edited_theme;
+	bool include_own_types = false;
+
+	String pre_submitted_value;
+
+	LineEdit *add_type_filter;
+	ItemList *add_type_options;
+	ConfirmationDialog *add_type_confirmation;
+
+	void _dialog_about_to_show();
+	void ok_pressed();
+
+	void _update_add_type_options(const String &p_filter = "");
+
+	void _add_type_filter_cbk(const String &p_value);
+	void _add_type_options_cbk(int p_index);
+	void _add_type_dialog_entered(const String &p_value);
+	void _add_type_dialog_activated(int p_index);
+
+	void _add_type_selected(const String &p_type_name);
+	void _add_type_confirmed();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void set_edited_theme(const Ref<Theme> &p_theme);
+	void set_include_own_types(bool p_enable);
+
+	ThemeTypeDialog();
+};
+
 class ThemeTypeEditor : public MarginContainer {
 	GDCLASS(ThemeTypeEditor, MarginContainer);
 
@@ -274,9 +311,6 @@ class ThemeTypeEditor : public MarginContainer {
 
 	OptionButton *theme_type_list;
 	Button *add_type_button;
-	ConfirmationDialog *add_type_dialog;
-	LineEdit *add_type_filter;
-	ItemList *add_type_options;
 
 	CheckButton *show_default_items_button;
 
@@ -287,13 +321,14 @@ class ThemeTypeEditor : public MarginContainer {
 	VBoxContainer *icon_items_list;
 	VBoxContainer *stylebox_items_list;
 
+	ThemeTypeDialog *add_type_dialog;
+
 	Vector<Control *> focusables;
 	Timer *update_debounce_timer;
 
 	VBoxContainer *_create_item_list(Theme::DataType p_data_type);
 	void _update_type_list();
 	void _update_type_list_debounced();
-	void _update_add_type_options(const String &p_filter = "");
 	OrderedHashMap<StringName, bool> _get_type_items(String p_type_name, void (Theme::*get_list_func)(StringName, List<StringName> *) const, bool include_default);
 	HBoxContainer *_create_property_control(Theme::DataType p_data_type, String p_item_name, bool p_editable);
 	void _add_focusable(Control *p_control);
@@ -301,11 +336,6 @@ class ThemeTypeEditor : public MarginContainer {
 
 	void _list_type_selected(int p_index);
 	void _add_type_button_cbk();
-	void _add_type_filter_cbk(const String &p_value);
-	void _add_type_options_cbk(int p_index);
-	void _add_type_dialog_confirmed();
-	void _add_type_dialog_entered(const String &p_value);
-	void _add_type_dialog_activated(int p_index);
 	void _add_default_type_items();
 
 	void _item_add_cbk(int p_data_type, Control *p_control);
@@ -326,6 +356,8 @@ class ThemeTypeEditor : public MarginContainer {
 	void _pin_leading_stylebox(Control *p_editor, String p_item_name);
 	void _unpin_leading_stylebox();
 	void _update_stylebox_from_leading();
+
+	void _add_type_dialog_selected(const String p_type_name);
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/55927. It's bigger than the `master` PR because I took this opportunity to sync up some code that was different due to different featureset in 4.0. But this way it's easier to maintain and pick fixes/enhancements, so it makes sense to have parity.

Should be okay for 3.4, though it's not really a fix of any kind.