### PR TITLE
Avoid a crash in the gdscript analyser

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -484,7 +484,7 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 			result = parser->head->get_datatype();
 		} else {
 			Ref<GDScriptParserRef> ref = get_parser_for(ScriptServer::get_global_class_path(first));
-			if (ref->raise_status(GDScriptParserRef::INTERFACE_SOLVED) != OK) {
+			if (!ref.is_valid() || ref->raise_status(GDScriptParserRef::INTERFACE_SOLVED) != OK) {
 				push_error(vformat(R"(Could not parse global class "%s" from "%s".)", first, ScriptServer::get_global_class_path(first)), p_type);
 				return GDScriptParser::DataType();
 			}
@@ -3956,7 +3956,9 @@ Ref<GDScriptParserRef> GDScriptAnalyzer::get_parser_for(const String &p_path) {
 	} else {
 		Error err = OK;
 		ref = GDScriptCache::get_parser(p_path, GDScriptParserRef::EMPTY, err, parser->script_path);
-		depended_parsers[p_path] = ref;
+		if (ref.is_valid()) {
+			depended_parsers[p_path] = ref;
+		}
 	}
 
 	return ref;


### PR DESCRIPTION
I used to have a crash in the following situation:
- Created a `room.gd` file with `class_name Room`
- In another script, constrained a variable to this class type `var room : Room`
- Deleted `room.gd`
This caused a crash at statup or at a reaload of the FileSystem it seems.

This fix adds a check for the `ref` variable validity, and only set `depended_parsers[p_path] = ref;` if ref is valid too (I am not sure about that last part but it seemed logical).

Related to https://github.com/godotengine/godot/issues/55476, but not sure if it fixes it.
Most likely fixes https://github.com/godotengine/godot/issues/54971.
Fixes https://github.com/godotengine/godot/issues/53250.