### PR TITLE
Fix EditorToaster popup causing crash

### DIFF
--- a/core/error/error_macros.cpp
+++ b/core/error/error_macros.cpp
@@ -37,9 +37,16 @@
 static ErrorHandlerList *error_handler_list = nullptr;
 
 void add_error_handler(ErrorHandlerList *p_handler) {
+	// If p_handler is already in error_handler_list
+	// we'd better remove it first then we can add it.
+	// This prevent cyclic redundancy.
+	remove_error_handler(p_handler);
+
 	_global_lock();
+
 	p_handler->next = error_handler_list;
 	error_handler_list = p_handler;
+
 	_global_unlock();
 }
 

--- a/editor/editor_toaster.h
+++ b/editor/editor_toaster.h
@@ -94,9 +94,11 @@ private:
 
 	void _set_notifications_enabled(bool p_enabled);
 	void _repop_old();
+	void _popup_str(String p_message, Severity p_severity, String p_tooltip);
 
 protected:
 	static EditorToaster *singleton;
+	static void _bind_methods();
 
 	void _notification(int p_what);
 


### PR DESCRIPTION
Refactor of the editor's toaster popup lead to a random crash when Godot encounters an error while starting.
Deferring the instantiation of the toaster popup fixes the crash.

To test it, I checkout this commit 7f9a82b944724c0228301ded5fbb8efee12eac4d
Then I reproduced that exact issue: https://github.com/godotengine/godot/issues/55895
And those changes fix that issue.

Note:
This should also fix crashes due to error handling.

Not tested, but it might fix this issue:
https://github.com/godotengine/godot/issues/54515
