### PR TITLE
Add compatibility class handlers for portal and room occlusion culling

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -882,6 +882,14 @@ void register_scene_types() {
 	ClassDB::add_compatibility_class("GIProbeData", "VoxelGIData");
 	ClassDB::add_compatibility_class("BakedLightmap", "LightmapGI");
 	ClassDB::add_compatibility_class("BakedLightmapData", "LightmapGIData");
+	// Portal and room occlusion was replaced by raster occlusion (OccluderInstance3D node).
+	ClassDB::add_compatibility_class("Portal", "Node3D");
+	ClassDB::add_compatibility_class("Room", "Node3D");
+	ClassDB::add_compatibility_class("RoomManager", "Node3D");
+	ClassDB::add_compatibility_class("RoomGroup", "Node3D");
+	ClassDB::add_compatibility_class("Occluder", "Node3D");
+	// The OccluderShapeSphere resource (used in the old Occluder node) is not present anymore.
+	ClassDB::add_compatibility_class("OccluderShapeSphere", "Resource");
 
 	// Renamed in 4.0.
 	// Keep alphabetical ordering to easily locate classes and avoid duplicates.


### PR DESCRIPTION
Portal and room occlusion culling is replaced by raster occlusion in 4.0, which undergoes an entirely different setup process. Therefore, we can only convert those nodes to Node3Ds to allow loading `3.x` scenes while keeping transforms valid.

I tested this on a small project that also had OccluderShapeSphere resources and conversion works as expected.

To test this PR, create a project in `3.x` then try opening it in `master` with this PR compiled in.