### PR TITLE
Fix validated version of array addition

### DIFF
--- a/core/variant/variant_op.h
+++ b/core/variant/variant_op.h
@@ -775,6 +775,7 @@ public:
 		r_valid = true;
 	}
 	static inline void validated_evaluate(const Variant *left, const Variant *right, Variant *r_ret) {
+		*r_ret = Array();
 		_add_arrays(*VariantGetInternalPtr<Array>::get_ptr(r_ret), *VariantGetInternalPtr<Array>::get_ptr(left), *VariantGetInternalPtr<Array>::get_ptr(right));
 	}
 	static void ptr_evaluate(const void *left, const void *right, void *r_ret) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes #53984
Fixes #52485 (except the part about `append_array`, but that's already tracked by #54939)

The issue only happens when the validated version of array addition is performed. 

The following should output `[] [a, b]`, but instead outputs `[a, b] [a, b]`:
```gd
var arr1 = []
var arr2 = ['a'] + ['b'] # validated AddArray
prints(arr1, arr2)
```
But the one below works correctly, since the compiler considers `a` and `b` to be `Variant`s, and the non-validated version ends up being called:
```gd
var a = ['a']
var b = ['b']
var arr1 = []
var arr2 = a + b # non-validated AddArray
prints(arr1, arr2)
```
The buggy behavior can be restored by making `a` and `b` typed:
```gd
var a := ['a']
var b := ['b']
var arr1 = []
var arr2 = a + b # validated AddArray
prints(arr1, arr2)
```

Relevant section of code:
https://github.com/godotengine/godot/blob/3d05b94212d1f587cea72a298027b9330c965236/core/variant/variant_op.h#L758-L768
Note that `sum` is expected to be a valid `Array` reference when `_add_arrays` is called.

https://github.com/godotengine/godot/blob/3d05b94212d1f587cea72a298027b9330c965236/core/variant/variant_op.h#L769-L779
In both cases, `r_ret` points to uninitialized / reused memory on VM stack, so it shouldn't be used directly with `_add_arrays`. This is accounted for in `evaluate`, but not in `validated_evaluate`.
