### PR TITLE
Make EditorSpinSlider grabbers thicker to be more noticeable

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -388,7 +388,7 @@ void EditorSpinSlider::_draw_spin_slider() {
 
 		// Draw the horizontal slider's grabber.
 		c.a = 0.9;
-		const Rect2 grabber_rect = Rect2(ofs + gofs, svofs + 1, grabber_w, 2 * EDSCALE);
+		const Rect2 grabber_rect = Rect2(ofs + gofs, svofs, grabber_w, 4 * EDSCALE);
 		draw_rect(grabber_rect, c);
 
 		grabbing_spinner_mouse_pos = get_global_position() + grabber_rect.get_center();


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/55962.

Follow-up to https://github.com/godotengine/godot/pull/55519.

See https://twitter.com/xafier/status/1470522992719728640 for context.

## Preview

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/180032/144289853-835ff9aa-b81a-4259-aff3-967c79cc3e04.png) | ![image](https://user-images.githubusercontent.com/180032/146097102-9729efb7-bc76-4dd9-a3ec-7e7e51c97db0.png) |