### PR TITLE
glTF animation parsing: Changed the 'loop' and 'cycle' animation name keywords to be case-insensitive

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -4889,7 +4889,8 @@ Error GLTFDocument::_parse_animations(Ref<GLTFState> state) {
 
 		if (d.has("name")) {
 			const String name = d["name"];
-			if (name.begins_with("loop") || name.ends_with("loop") || name.begins_with("cycle") || name.ends_with("cycle")) {
+			const String name_lower = name.to_lower();
+			if (name_lower.begins_with("loop") || name_lower.ends_with("loop") || name_lower.begins_with("cycle") || name_lower.ends_with("cycle")) {
 				animation->set_loop(true);
 			}
 			animation->set_name(_gen_unique_animation_name(state, name));


### PR DESCRIPTION
You can add the keyword 'loop' or 'cycle' to the beginning or end of your animation names when importing glTF 2.0 files. Animations that include one of these keywords in their names will be set with `loop_mode` to true.

However these keywords are case-sensitive currently. I propose for this to be case-insensitive so we can use any naming convention (e.g. WALKING_LOOP, Running Cycle) while preserving this functionality.