### PR TITLE
Add "/" to the unix shortcut drive list

### DIFF
--- a/doc/classes/Directory.xml
+++ b/doc/classes/Directory.xml
@@ -119,13 +119,19 @@
 			<return type="String" />
 			<argument index="0" name="idx" type="int" />
 			<description>
-				On Windows, returns the name of the drive (partition) passed as an argument (e.g. [code]C:[/code]). On other platforms, or if the requested drive does not exist, the method returns an empty String.
+				On Windows, returns the name of the drive (partition) passed as an argument (e.g. [code]C:[/code]).
+				On macOS, returns the path to the mounted volume passed as an argument.
+				On Linux, returns the path to the mounted volume or GTK 3 bookmark passed as an argument.
+				On other platforms, or if the requested drive does not exist, the method returns an empty String.
 			</description>
 		</method>
 		<method name="get_drive_count">
 			<return type="int" />
 			<description>
-				On Windows, returns the number of drives (partitions) mounted on the current filesystem. On other platforms, the method returns 0.
+				On Windows, returns the number of drives (partitions) mounted on the current filesystem.
+				On macOS, returns the number of mounted volumes.
+				On Linux, returns the number of mounted volumes and GTK 3 bookmarks.
+				On other platforms, the method returns 0.
 			</description>
 		</method>
 		<method name="get_files">

--- a/drivers/unix/dir_access_unix.cpp
+++ b/drivers/unix/dir_access_unix.cpp
@@ -216,6 +216,8 @@ static bool _filter_drive(struct mntent *mnt) {
 #endif
 
 static void _get_drives(List<String> *list) {
+	list->push_back("/");
+
 #if defined(HAVE_MNTENT) && defined(X11_ENABLED)
 	// Check /etc/mtab for the list of mounted partitions
 	FILE *mtab = setmntent("/etc/mtab", "r");
@@ -284,6 +286,20 @@ String DirAccessUnix::get_drive(int p_drive) {
 	ERR_FAIL_INDEX_V(p_drive, list.size(), "");
 
 	return list[p_drive];
+}
+
+int DirAccessUnix::get_current_drive() {
+	int drive = 0;
+	int max_length = -1;
+	const String path = get_current_dir().to_lower();
+	for (int i = 0; i < get_drive_count(); i++) {
+		const String d = get_drive(i).to_lower();
+		if (max_length < d.length() && path.begins_with(d)) {
+			max_length = d.length();
+			drive = i;
+		}
+	}
+	return drive;
 }
 
 bool DirAccessUnix::drives_are_shortcuts() {

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -63,6 +63,7 @@ public:
 
 	virtual int get_drive_count();
 	virtual String get_drive(int p_drive);
+	virtual int get_current_drive();
 	virtual bool drives_are_shortcuts();
 
 	virtual Error change_dir(String p_dir); ///< can be relative or absolute, return false on success


### PR DESCRIPTION
`DirAccessUnix` uses shortcuts as drives on Linux. It currently only uses mounted file systems, the home directory, and bookmarks. So it is usually a list like:

* `/home/user`
* `/home/user/Downloads`
* `/home/user/Videos`

As `/` is missing, `Directory.get_current_drive()` almost always reports `/home/user` even when it's currently outside the home directory. (So does `FileDialog`'s "drive" dropdown.)

`/` will always be reported as current drive instead of `/home/user` after this PR.