### PR TITLE
[3.x] [Net] Fix WebRTC returning packets from peers too early.

### DIFF
--- a/modules/webrtc/webrtc_multiplayer.cpp
+++ b/modules/webrtc/webrtc_multiplayer.cpp
@@ -154,6 +154,10 @@ void WebRTCMultiplayer::_find_next_peer() {
 	}
 	// After last.
 	while (E) {
+		if (!E->get()->connected) {
+			E = E->next();
+			continue;
+		}
 		for (List<Ref<WebRTCDataChannel>>::Element *F = E->get()->channels.front(); F; F = F->next()) {
 			if (F->get()->get_available_packet_count()) {
 				next_packet_peer = E->key();
@@ -165,6 +169,10 @@ void WebRTCMultiplayer::_find_next_peer() {
 	E = peer_map.front();
 	// Before last
 	while (E) {
+		if (!E->get()->connected) {
+			E = E->next();
+			continue;
+		}
 		for (List<Ref<WebRTCDataChannel>>::Element *F = E->get()->channels.front(); F; F = F->next()) {
 			if (F->get()->get_available_packet_count()) {
 				next_packet_peer = E->key();
@@ -357,6 +365,9 @@ int WebRTCMultiplayer::get_available_packet_count() const {
 	}
 	int size = 0;
 	for (Map<int, Ref<ConnectedPeer>>::Element *E = peer_map.front(); E; E = E->next()) {
+		if (!E->get()->connected) {
+			continue;
+		}
 		for (List<Ref<WebRTCDataChannel>>::Element *F = E->get()->channels.front(); F; F = F->next()) {
 			size += F->get()->get_available_packet_count();
 		}


### PR DESCRIPTION
Due to the async nature of WebRTC implementations, the multiplayer peer could end up having queued packets from a given connection before it is able to emit the "peer_added" signal.
This commit ensures that packets from peers which are not notified yet are skipped by `get_packet` and `get_available_packet_count`.

`3.x` version of: #55952