### PR TITLE
[3.x] Fix `Color.v` integer assignment

### DIFF
--- a/core/variant_op.cpp
+++ b/core/variant_op.cpp
@@ -1486,7 +1486,7 @@ void Variant::set_named(const StringName &p_index, const Variant &p_value, bool 
 					v->set_hsv(v->get_h(), p_value._data._int, v->get_v(), v->a);
 					valid = true;
 				} else if (p_index == CoreStringNames::singleton->v) {
-					v->set_hsv(v->get_h(), v->get_v(), p_value._data._int, v->a);
+					v->set_hsv(v->get_h(), v->get_s(), p_value._data._int, v->a);
 					valid = true;
 				}
 			} else if (p_value.type == Variant::REAL) {


### PR DESCRIPTION
`get_v()` was provided for the S parameter of `set_hsv()`.

So assigning `Color.v` with an integer value would also set S to the old V:

```gdscript
extends SceneTree

func _init():
	var c = Color.from_hsv(0.58, 0.5, 0.79, 0.8)
	print("H:%.2f  S:%.2f  V:%.2f" % [c.h, c.s, c.v])

	c.v = 1
	print("H:%.2f  S:%.2f  V:%.2f" % [c.h, c.s, c.v])

	quit()

# Prints:
# H:0.58  S:0.50  V:0.79
# H:0.58  S:0.79  V:1.00
```