### PR TITLE
[Windows, 4.0] Detect new Windows Terminal and disable unsupported set_console_visible code.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1204,8 +1204,11 @@ void DisplayServerWindows::console_set_visible(bool p_enabled) {
 	if (console_visible == p_enabled) {
 		return;
 	}
-	ShowWindow(GetConsoleWindow(), p_enabled ? SW_SHOW : SW_HIDE);
-	console_visible = p_enabled;
+	if (!((OS_Windows *)OS::get_singleton())->_is_win11_terminal()) {
+		// GetConsoleWindow is not supported by the Windows Terminal.
+		ShowWindow(GetConsoleWindow(), p_enabled ? SW_SHOW : SW_HIDE);
+		console_visible = p_enabled;
+	}
 }
 
 bool DisplayServerWindows::is_console_visible() const {

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -157,6 +157,7 @@ public:
 
 	void run();
 
+	bool _is_win11_terminal() const;
 	virtual bool _check_internal_feature_support(const String &p_feature) override;
 
 	virtual void disable_crash_handler() override;


### PR DESCRIPTION
- Improves #55924, new terminal will be opened only when using new Windows Terminal.
- Disables unsupported `set_console_visible` / `Toggle System Console` when using new Windows Terminal.

Tested on Windows 11 21H1(22000.348) with:
- Windows Console Host (Old terminal)
- ConEmu 210912
- Windows Terminal 1.11.2921.0

*Bugsquad edit:* Closes #55971.