### PR TITLE
[Windows, 3.x] Detect new Windows Terminal and disable unsupported set_console_visible code.

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2247,11 +2247,25 @@ bool OS_Windows::is_window_focused() const {
 	return window_focused;
 }
 
+bool OS_Windows::_is_win11_terminal() const {
+	HANDLE hStdOut = GetStdHandle(STD_OUTPUT_HANDLE);
+	DWORD dwMode = 0;
+	if (GetConsoleMode(hStdOut, &dwMode)) {
+		return ((dwMode & ENABLE_VIRTUAL_TERMINAL_PROCESSING) == ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+	} else {
+		return false;
+	}
+}
+
 void OS_Windows::set_console_visible(bool p_enabled) {
 	if (console_visible == p_enabled)
 		return;
-	ShowWindow(GetConsoleWindow(), p_enabled ? SW_SHOW : SW_HIDE);
-	console_visible = p_enabled;
+
+	if (!_is_win11_terminal()) {
+		// GetConsoleWindow is not supported by the Windows Terminal.
+		ShowWindow(GetConsoleWindow(), p_enabled ? SW_SHOW : SW_HIDE);
+		console_visible = p_enabled;
+	}
 }
 
 bool OS_Windows::is_console_visible() const {
@@ -2858,7 +2872,8 @@ Error OS_Windows::execute(const String &p_path, const List<String> &p_arguments,
 	}
 
 	DWORD creation_flags = NORMAL_PRIORITY_CLASS & CREATE_NO_WINDOW;
-	if (p_path == get_executable_path() && GetConsoleWindow() != NULL) {
+	if (p_path == get_executable_path() && GetConsoleWindow() != NULL && _is_win11_terminal()) {
+		// Open a new terminal as a workaround for Windows Terminal bug.
 		creation_flags |= CREATE_NEW_CONSOLE;
 	}
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -371,6 +371,8 @@ class OS_Windows : public OS {
 
 	CrashHandler crash_handler;
 
+	bool _is_win11_terminal() const;
+
 	void _drag_event(float p_x, float p_y, int idx);
 	void _touch_event(bool p_pressed, float p_x, float p_y, int idx);
 


### PR DESCRIPTION
Same as #55966 for 3.x

- Improves #55925, new terminal will be opened only when using new Windows Terminal.
- Disables unsupported `set_console_visible` / `Toggle System Console` when using new Windows Terminal.

Tested on Windows 11 21H1(22000.348) with:
- Windows Console Host (Old terminal)
- ConEmu 210912
- Windows Terminal 1.11.2921.0