### PR TITLE
Fix font preview text color on light background

### DIFF
--- a/core/math/color.h
+++ b/core/math/color.h
@@ -94,6 +94,10 @@ struct Color {
 	void invert();
 	Color inverted() const;
 
+	_FORCE_INLINE_ float get_luminance() const {
+		return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+	}
+
 	_FORCE_INLINE_ Color lerp(const Color &p_to, float p_weight) const {
 		Color res = *this;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1644,6 +1644,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Color, lightened, sarray("amount"), varray());
 	bind_method(Color, darkened, sarray("amount"), varray());
 	bind_method(Color, blend, sarray("over"), varray());
+	bind_method(Color, get_luminance, sarray(), varray());
 
 	bind_method(Color, is_equal_approx, sarray("to"), varray());
 

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -178,6 +178,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="get_luminance" qualifiers="const">
+			<return type="float" />
+			<description>
+				Returns the luminance of the color in the [code][0.0, 1.0][/code] range.
+				This is useful when determining light or dark color. Colors with a luminance smaller than 0.5 can be generally considered dark.
+			</description>
+		</method>
 		<method name="get_named_color" qualifiers="static">
 			<return type="Color" />
 			<argument index="0" name="idx" type="int" />

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1190,7 +1190,7 @@ bool EditorSettings::is_dark_theme() {
 	int LIGHT_COLOR = 2;
 	Color base_color = get("interface/theme/base_color");
 	int icon_font_color_setting = get("interface/theme/icon_and_font_color");
-	return (icon_font_color_setting == AUTO_COLOR && ((base_color.r + base_color.g + base_color.b) / 3.0) < 0.5) || icon_font_color_setting == LIGHT_COLOR;
+	return (icon_font_color_setting == AUTO_COLOR && base_color.get_luminance() < 0.5) || icon_font_color_setting == LIGHT_COLOR;
 }
 
 void EditorSettings::list_text_editor_themes() {

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -851,7 +851,9 @@ Ref<Texture2D> EditorFontPreviewPlugin::generate_from_path(const String &p_path,
 
 	Ref<Font> font = sampled_font;
 
-	font->draw_string(canvas_item, pos, sample, HORIZONTAL_ALIGNMENT_LEFT, -1.f, 50, Color(1, 1, 1));
+	const Color c = GLOBAL_GET("rendering/environment/defaults/default_clear_color");
+	const float fg = c.get_luminance() < 0.5 ? 1.0 : 0.0;
+	font->draw_string(canvas_item, pos, sample, HORIZONTAL_ALIGNMENT_LEFT, -1.f, 50, Color(fg, fg, fg));
 
 	RS::get_singleton()->connect(SNAME("frame_pre_draw"), callable_mp(const_cast<EditorFontPreviewPlugin *>(this), &EditorFontPreviewPlugin::_generate_frame_started), Vector<Variant>(), Object::CONNECT_ONESHOT);
 


### PR DESCRIPTION
Pick white/black text color based on the luminance of background.

| Before | After |
|----------|--------|
| ![before-1](https://user-images.githubusercontent.com/372476/146317063-2e3e2dcf-26b1-4a00-9514-c61e6f38dbcc.png) | ![after-1](https://user-images.githubusercontent.com/372476/146317090-c6dffc34-e356-491f-bef8-ff4de1314501.png) |
| ![before-2](https://user-images.githubusercontent.com/372476/146317110-b74f4c50-bcf1-4271-ab03-5947e85c9649.png) | ![after-2](https://user-images.githubusercontent.com/372476/146317154-5ee35acc-c05a-42a9-a07b-553c7886c8d4.png) |
| ![before-3](https://user-images.githubusercontent.com/372476/146317194-b2428878-3d95-477d-ab68-8aa6f2916c30.png) | ![after-3](https://user-images.githubusercontent.com/372476/146317204-d0f50b70-f8f1-4335-a2e8-da75b482c027.png) |
| ![before-4](https://user-images.githubusercontent.com/372476/146317227-1b29bd20-bb22-4a60-bcfc-f631ef7e13b0.png) | ![after-4](https://user-images.githubusercontent.com/372476/146317236-eb293afe-0872-4855-a9ab-382b02229a67.png) |
 