### PR TITLE
Fixed event spam when using the Nintendo Switch controller

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -811,7 +811,8 @@ void InputDefault::joy_axis(int p_device, int p_axis, const JoyAxis &p_value) {
 
 	Joypad &joy = joy_names[p_device];
 
-	if (joy.last_axis[p_axis] == p_value.value) {
+	const float MIN_AXIS_CHANGE = 0.05f;
+	if (fabs(joy.last_axis[p_axis] - p_value.value) <= MIN_AXIS_CHANGE) {
 		return;
 	}
 


### PR DESCRIPTION
There is no filtering on the Nintendo Switch Pro controller thumbstick, so there will frequently be events with very slight change. These are turned into "not pressed" events, which cancel "pressed" events from keys and buttons.

This change filters out up to 5% jitter, but it might be worth revisiting whether "not pressed" events should cancel "pressed" events.

I'm submitting a separate pull request for the 3.4 branch because the code has moved to a different file in master, and this is a bug fix for a game developer trying to ship a game on Steam.