### PR TITLE
[3.x] Prevent writing incorrect shader hints

### DIFF
--- a/servers/visual/shader_language.cpp
+++ b/servers/visual/shader_language.cpp
@@ -6006,6 +6006,7 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 
 						} else {
 							_set_error("Expected valid type hint after ':'.");
+							return ERR_PARSE_ERROR;
 						}
 
 						if (uniform2.hint != ShaderNode::Uniform::HINT_RANGE && uniform2.hint != ShaderNode::Uniform::HINT_NONE && uniform2.hint != ShaderNode::Uniform::HINT_COLOR && type <= TYPE_MAT4) {


### PR DESCRIPTION
Prevents writing incorrect hints eg.

`uniform sampler2D test : test;`

This bug has been fixed in master(by #55763) but not on 3.x.