### PR TITLE
Add texture filtering properties to `VisualShaderNodeTextureUniform`

### DIFF
--- a/doc/classes/VisualShaderNodeTextureUniform.xml
+++ b/doc/classes/VisualShaderNodeTextureUniform.xml
@@ -12,6 +12,12 @@
 		<member name="color_default" type="int" setter="set_color_default" getter="get_color_default" enum="VisualShaderNodeTextureUniform.ColorDefault" default="0">
 			Sets the default color if no texture is assigned to the uniform.
 		</member>
+		<member name="texture_filter" type="int" setter="set_texture_filter" getter="get_texture_filter" enum="VisualShaderNodeTextureUniform.TextureFilter" default="0">
+			Sets the texture filtering mode. See [enum TextureFilter] for options.
+		</member>
+		<member name="texture_repeat" type="int" setter="set_texture_repeat" getter="get_texture_repeat" enum="VisualShaderNodeTextureUniform.TextureRepeat" default="0">
+			Sets the texture repeating mode. See [enum TextureRepeat] for options.
+		</member>
 		<member name="texture_type" type="int" setter="set_texture_type" getter="get_texture_type" enum="VisualShaderNodeTextureUniform.TextureType" default="0">
 			Defines the type of data provided by the source texture. See [enum TextureType] for options.
 		</member>
@@ -40,6 +46,32 @@
 		</constant>
 		<constant name="COLOR_DEFAULT_MAX" value="2" enum="ColorDefault">
 			Represents the size of the [enum ColorDefault] enum.
+		</constant>
+		<constant name="FILTER_DEFAULT" value="0" enum="TextureFilter">
+		</constant>
+		<constant name="FILTER_NEAREST" value="1" enum="TextureFilter">
+		</constant>
+		<constant name="FILTER_LINEAR" value="2" enum="TextureFilter">
+		</constant>
+		<constant name="FILTER_NEAREST_MIPMAP" value="3" enum="TextureFilter">
+		</constant>
+		<constant name="FILTER_LINEAR_MIPMAP" value="4" enum="TextureFilter">
+		</constant>
+		<constant name="FILTER_NEAREST_MIPMAP_ANISOTROPIC" value="5" enum="TextureFilter">
+		</constant>
+		<constant name="FILTER_LINEAR_MIPMAP_ANISOTROPIC" value="6" enum="TextureFilter">
+		</constant>
+		<constant name="FILTER_MAX" value="7" enum="TextureFilter">
+			Represents the size of the [enum TextureFilter] enum.
+		</constant>
+		<constant name="REPEAT_DEFAULT" value="0" enum="TextureRepeat">
+		</constant>
+		<constant name="REPEAT_ENABLED" value="1" enum="TextureRepeat">
+		</constant>
+		<constant name="REPEAT_DISABLED" value="2" enum="TextureRepeat">
+		</constant>
+		<constant name="REPEAT_MAX" value="3" enum="TextureRepeat">
+			Represents the size of the [enum TextureRepeat] enum.
 		</constant>
 	</constants>
 </class>

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -1953,9 +1953,29 @@ public:
 		COLOR_DEFAULT_MAX,
 	};
 
+	enum TextureFilter {
+		FILTER_DEFAULT,
+		FILTER_NEAREST,
+		FILTER_LINEAR,
+		FILTER_NEAREST_MIPMAP,
+		FILTER_LINEAR_MIPMAP,
+		FILTER_NEAREST_MIPMAP_ANISOTROPIC,
+		FILTER_LINEAR_MIPMAP_ANISOTROPIC,
+		FILTER_MAX,
+	};
+
+	enum TextureRepeat {
+		REPEAT_DEFAULT,
+		REPEAT_ENABLED,
+		REPEAT_DISABLED,
+		REPEAT_MAX,
+	};
+
 protected:
 	TextureType texture_type = TYPE_DATA;
 	ColorDefault color_default = COLOR_DEFAULT_WHITE;
+	TextureFilter texture_filter = FILTER_DEFAULT;
+	TextureRepeat texture_repeat = REPEAT_DEFAULT;
 
 protected:
 	static void _bind_methods();
@@ -1975,6 +1995,8 @@ public:
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
+	virtual Map<StringName, String> get_editable_properties_names() const override;
+	virtual bool is_show_prop_names() const override;
 	virtual bool is_code_generated() const override;
 
 	Vector<StringName> get_editable_properties() const override;
@@ -1985,6 +2007,12 @@ public:
 	void set_color_default(ColorDefault p_default);
 	ColorDefault get_color_default() const;
 
+	void set_texture_filter(TextureFilter p_filter);
+	TextureFilter get_texture_filter() const;
+
+	void set_texture_repeat(TextureRepeat p_repeat);
+	TextureRepeat get_texture_repeat() const;
+
 	bool is_qualifier_supported(Qualifier p_qual) const override;
 	bool is_convertible_to_constant() const override;
 
@@ -1993,6 +2021,8 @@ public:
 
 VARIANT_ENUM_CAST(VisualShaderNodeTextureUniform::TextureType)
 VARIANT_ENUM_CAST(VisualShaderNodeTextureUniform::ColorDefault)
+VARIANT_ENUM_CAST(VisualShaderNodeTextureUniform::TextureFilter)
+VARIANT_ENUM_CAST(VisualShaderNodeTextureUniform::TextureRepeat)
 
 ///////////////////////////////////////
 


### PR DESCRIPTION
This enhancement adds filtering and repeat options to the texture uniform in the visual shaders. ![image](https://user-images.githubusercontent.com/3036176/146337721-dbbed13b-da78-48dd-92ed-9356b4db9c02.png)
