### PR TITLE
[3.x] Fix incompatible addition in auto exposure shader

### DIFF
--- a/drivers/gles3/shaders/exposure.glsl
+++ b/drivers/gles3/shaders/exposure.glsl
@@ -39,7 +39,7 @@ void main() {
 
 #if 1
 	//more precise and expensive, but less jittery
-	ivec2 next_pos = ivec2(gl_FragCoord.xy + ivec2(1)) * source_render_size / target_size;
+	ivec2 next_pos = (ivec2(gl_FragCoord.xy) + ivec2(1)) * source_render_size / target_size;
 	next_pos = max(next_pos, src_pos + ivec2(1)); //so it at least reads one pixel
 	highp vec3 source_color = vec3(0.0);
 	for (int i = src_pos.x; i < next_pos.x; i++) {


### PR DESCRIPTION
After turning on auto exposure on my Android device, it produces a shader compilation error:

```
E 0:00:02.057   _display_error_with_code: ExposureShaderGLES3: Fragment Program Compilation Failed:
ERROR: 0:38: '+' :  wrong operand types  no operation '+' exists that takes a left-hand operand of type '2-component vector of float' and a right operand of type 'const 2-component vector of int' (or there is no acceptable conversion)
ERROR: 1 compilation errors.  No code generated.
```

It complains about `gl_FragCoord.xy + ivec2(1)` operands being incompatible, and auto exposure fails to work even if I change framebuffer allocation type to 3D.