### PR TITLE
Offsets and Sizes in GraphEdit

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -731,6 +731,14 @@ Vector2 GraphNode::get_position_offset() const {
 	return position_offset;
 }
 
+Vector2 GraphNode::get_position_offset_in_graphedit() const {
+	if (get_parent()->is_class("GraphEdit")) {
+		return position_offset * get_parent()->get_zoom() + get_parent()->get_scroll_ofs();
+	} else {
+		return position_offset;
+	}
+}
+
 void GraphNode::set_selected(bool p_selected) {
 	selected = p_selected;
 	update();
@@ -839,6 +847,14 @@ Vector2 GraphNode::get_connection_input_position(int p_idx) {
 	return pos;
 }
 
+Vector2 GraphNode::get_connection_input_position_in_graphedit(int p_idx) {
+	if (get_parent()->is_class("GraphEdit")) {
+		return get_connection_input_position(p_idx) * get_parent()->get_zoom() + get_parent()->get_scroll_ofs();
+	} else {
+		return get_connection_input_position(p_idx);
+	}
+}
+
 int GraphNode::get_connection_input_type(int p_idx) {
 	if (connpos_dirty) {
 		_connpos_update();
@@ -867,6 +883,14 @@ Vector2 GraphNode::get_connection_output_position(int p_idx) {
 	pos.x *= get_scale().x;
 	pos.y *= get_scale().y;
 	return pos;
+}
+
+Vector2 GraphNode::get_connection_output_position_in_graphedit(int p_idx) {
+	if (get_parent()->is_class("GraphEdit")) {
+		return get_connection_output_position(p_idx) * get_parent()->get_zoom() + get_parent()->get_scroll_ofs();
+	} else {
+		return get_connection_output_position(p_idx);
+	}
 }
 
 int GraphNode::get_connection_output_type(int p_idx) {
@@ -958,6 +982,13 @@ void GraphNode::set_resizable(bool p_enable) {
 bool GraphNode::is_resizable() const {
 	return resizable;
 }
+
+Vector2 GraphNode::get_size_in_graphedit() const {
+	if (get_parent()->is_class("GraphEdit")) {
+		return get_size() * get_parent()->get_zoom();
+	} else {
+		return get_size();
+	}
 
 void GraphNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_title", "title"), &GraphNode::set_title);

--- a/scene/gui/graph_node.h
+++ b/scene/gui/graph_node.h
@@ -152,6 +152,7 @@ public:
 
 	void set_position_offset(const Vector2 &p_offset);
 	Vector2 get_position_offset() const;
+	Vector2 get_position_offset_in_graphedit() const;
 
 	void set_selected(bool p_selected);
 	bool is_selected();
@@ -165,9 +166,11 @@ public:
 	int get_connection_input_count();
 	int get_connection_output_count();
 	Vector2 get_connection_input_position(int p_idx);
+	Vector2 get_connection_input_position_in_graphedit(int p_idx);
 	int get_connection_input_type(int p_idx);
 	Color get_connection_input_color(int p_idx);
 	Vector2 get_connection_output_position(int p_idx);
+	Vector2 get_connection_output_position_in_graphedit(int p_idx);
 	int get_connection_output_type(int p_idx);
 	Color get_connection_output_color(int p_idx);
 
@@ -179,6 +182,7 @@ public:
 
 	void set_resizable(bool p_enable);
 	bool is_resizable() const;
+	Vector2 get_position_offset_in_graphedit() const;
 
 	virtual Size2 get_minimum_size() const override;
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
This PR adds methods to `GraphNode` to get its size, offsets and ports positions after accounting for its parent `GraphEdit`'s panning and zooming.

Getting the right position can be complicated, so these additions would make getting the desired positions more convenient. Especially so when the users wants to [make custom hot zones](https://github.com/godotengine/godot/pull/52015) in the `GraphNode`.

The best names I could think of for the methods are `get_position_offset_in_graphedit()`, `get_position_offset_in_graphedit()`, `get_connection_input_position_in_graphedit(int p_idx)` and `get_connection_output_position_in_graphedit(int p_idx)`. Might need a shorter name.

WIP: See my project https://github.com/mechPenSketch/godot/projects/1