### PR TITLE
[3.x] Add proxy support for `HTTPClient` and the editor

### DIFF
--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -160,8 +160,14 @@ private:
 	Status status;
 	IP::ResolverID resolving;
 	Array ip_candidates;
-	int conn_port;
+	int conn_port; // Server to make requests to.
 	String conn_host;
+	int server_port; // Server to connect to (might be a proxy server).
+	String server_host;
+	int http_proxy_port; // Proxy server for http requests.
+	String http_proxy_host;
+	int https_proxy_port; // Proxy server for https requests.
+	String https_proxy_host;
 	bool ssl;
 	bool ssl_verify_host;
 	bool blocking;
@@ -180,6 +186,7 @@ private:
 
 	Ref<StreamPeerTCP> tcp_connection;
 	Ref<StreamPeer> connection;
+	Ref<HTTPClient> proxy_client;
 
 	int response_num;
 	Vector<String> response_headers;
@@ -226,6 +233,10 @@ public:
 	Error poll();
 
 	String query_string_from_dict(const Dictionary &p_dict);
+
+	// Use empty string or -1 to unset.
+	void set_http_proxy(const String &p_host, int p_port);
+	void set_https_proxy(const String &p_host, int p_port);
 
 	HTTPClient();
 	~HTTPClient();

--- a/doc/classes/HTTPClient.xml
+++ b/doc/classes/HTTPClient.xml
@@ -149,6 +149,24 @@
 				Sends the body data raw, as a byte array and does not encode it in any way.
 			</description>
 		</method>
+		<method name="set_http_proxy">
+			<return type="void" />
+			<argument index="0" name="host" type="String" />
+			<argument index="1" name="port" type="int" />
+			<description>
+				Sets the proxy server for HTTP requests.
+				The proxy server is unset if [code]host[/code] is empty or [code]port[/code] is -1.
+			</description>
+		</method>
+		<method name="set_https_proxy">
+			<return type="void" />
+			<argument index="0" name="host" type="String" />
+			<argument index="1" name="port" type="int" />
+			<description>
+				Sets the proxy server for HTTPS requests.
+				The proxy server is unset if [code]host[/code] is empty or [code]port[/code] is -1.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="blocking_mode_enabled" type="bool" setter="set_blocking_mode" getter="is_blocking_mode_enabled" default="false">

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -121,6 +121,24 @@
 				Returns [constant OK] if request is successfully created. (Does not imply that the server has responded), [constant ERR_UNCONFIGURED] if not in the tree, [constant ERR_BUSY] if still processing previous request, [constant ERR_INVALID_PARAMETER] if given string is not a valid URL format, or [constant ERR_CANT_CONNECT] if not using thread and the [HTTPClient] cannot connect to host.
 			</description>
 		</method>
+		<method name="set_http_proxy">
+			<return type="void" />
+			<argument index="0" name="host" type="String" />
+			<argument index="1" name="port" type="int" />
+			<description>
+				Sets the proxy server for HTTP requests.
+				The proxy server is unset if [code]host[/code] is empty or [code]port[/code] is -1.
+			</description>
+		</method>
+		<method name="set_https_proxy">
+			<return type="void" />
+			<argument index="0" name="host" type="String" />
+			<argument index="1" name="port" type="int" />
+			<description>
+				Sets the proxy server for HTTPS requests.
+				The proxy server is unset if [code]host[/code] is empty or [code]port[/code] is -1.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="body_size_limit" type="int" setter="set_body_size_limit" getter="get_body_size_limit" default="-1">

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -150,6 +150,11 @@ void ExportTemplateManager::_download_template(const String &p_url, bool p_skip_
 	download_templates->set_download_file(EditorSettings::get_singleton()->get_cache_dir().plus_file("tmp_templates.tpz"));
 	download_templates->set_use_threads(true);
 
+	const String proxy_host = EDITOR_DEF("network/http_proxy/host", "");
+	const int proxy_port = EDITOR_DEF("network/http_proxy/port", -1);
+	download_templates->set_http_proxy(proxy_host, proxy_port);
+	download_templates->set_https_proxy(proxy_host, proxy_port);
+
 	Error err = download_templates->request(p_url);
 	if (err != OK) {
 		_set_current_progress_status(TTR("Error requesting URL:") + " " + p_url, true);

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -37,6 +37,15 @@
 #include "editor/editor_settings.h"
 #include "editor/project_settings_editor.h"
 
+static inline void setup_http_request(HTTPRequest *request) {
+	request->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
+
+	const String proxy_host = EDITOR_DEF("network/http_proxy/host", "");
+	const int proxy_port = EDITOR_DEF("network/http_proxy/port", -1);
+	request->set_http_proxy(proxy_host, proxy_port);
+	request->set_https_proxy(proxy_host, proxy_port);
+}
+
 void EditorAssetLibraryItem::configure(const String &p_title, int p_asset_id, const String &p_category, int p_category_id, const String &p_author, int p_author_id, const String &p_cost) {
 	title->set_text(p_title);
 	asset_id = p_asset_id;
@@ -543,7 +552,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 	download = memnew(HTTPRequest);
 	add_child(download);
 	download->connect("request_completed", this, "_http_download_completed");
-	download->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
+	setup_http_request(download);
 
 	download_error = memnew(AcceptDialog);
 	add_child(download_error);
@@ -863,7 +872,7 @@ void EditorAssetLibrary::_request_image(ObjectID p_for, String p_image_url, Imag
 	iq.image_index = p_image_index;
 	iq.image_type = p_type;
 	iq.request = memnew(HTTPRequest);
-	iq.request->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
+	setup_http_request(iq.request);
 
 	iq.target = p_for;
 	iq.queue_id = ++last_queue_id;
@@ -1482,7 +1491,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	request = memnew(HTTPRequest);
 	add_child(request);
-	request->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
+	setup_http_request(request);
 	request->connect("request_completed", this, "_http_request_completed");
 
 	last_queue_id = 0;

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -463,6 +463,14 @@ int HTTPRequest::get_body_size() const {
 	return body_len;
 }
 
+void HTTPRequest::set_http_proxy(const String &p_host, int p_port) {
+	client->set_http_proxy(p_host, p_port);
+}
+
+void HTTPRequest::set_https_proxy(const String &p_host, int p_port) {
+	client->set_https_proxy(p_host, p_port);
+}
+
 void HTTPRequest::set_timeout(int p_timeout) {
 	ERR_FAIL_COND(p_timeout < 0);
 	timeout = p_timeout;
@@ -507,6 +515,9 @@ void HTTPRequest::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_download_chunk_size"), &HTTPRequest::set_download_chunk_size);
 	ClassDB::bind_method(D_METHOD("get_download_chunk_size"), &HTTPRequest::get_download_chunk_size);
+
+	ClassDB::bind_method(D_METHOD("set_http_proxy", "host", "port"), &HTTPRequest::set_http_proxy);
+	ClassDB::bind_method(D_METHOD("set_https_proxy", "host", "port"), &HTTPRequest::set_https_proxy);
 
 	ClassDB::bind_method(D_METHOD("_timeout"), &HTTPRequest::_timeout);
 

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -146,6 +146,10 @@ public:
 	int get_downloaded_bytes() const;
 	int get_body_size() const;
 
+	// Use empty string or -1 to unset.
+	void set_http_proxy(const String &p_host, int p_port);
+	void set_https_proxy(const String &p_host, int p_port);
+
 	HTTPRequest();
 	~HTTPRequest();
 };


### PR DESCRIPTION
`3.x` backport of #47257 and #55747.

* Adds proxy related methods for `HTTPClient` and `HTTPRequest`
* Adds `network/http_proxy/{host,port}` editor settings
* Makes AssetLib and Export Template Manager proxy aware

<details>
<summary>Test code for HTTPClient</summary>

```gdscript
extends SceneTree

func _init():
	var err = 0
	var http = HTTPClient.new() # Create the Client.

	http.set_http_proxy("localhost", 7890)
	http.set_https_proxy("127.0.0.1", 7890)

	print("----- http with proxy -----")
	err = http.connect_to_host("httpbin.org", -1, false) # Connect to host/port.
	assert(err == OK) # Make sure connection was OK.
	do_http(http)
	http.close()

	print("----- https with proxy -----")
	err = http.connect_to_host("httpbin.org", -1, true) # Connect to host/port.
	assert(err == OK) # Make sure connection was OK.
	do_http(http)
	http.close()

	http.set_http_proxy("127.0.0.1", -1)
	http.set_https_proxy("127.0.0.1", -1)

	print("----- http without proxy -----")
	err = http.connect_to_host("httpbin.org", -1, false) # Connect to host/port.
	assert(err == OK) # Make sure connection was OK.
	do_http(http)
	http.close()

	print("----- https without proxy -----")
	err = http.connect_to_host("httpbin.org", -1, true) # Connect to host/port.
	assert(err == OK) # Make sure connection was OK.
	do_http(http)
	http.close()

	quit()


func do_http(http):
	var err = 0
	# Wait until resolved and connected.
	while http.get_status() == HTTPClient.STATUS_CONNECTING or http.get_status() == HTTPClient.STATUS_RESOLVING:
		http.poll()
		print("Connecting...")
		OS.delay_msec(500)

	assert(http.get_status() == HTTPClient.STATUS_CONNECTED) # Could not connect

	# Some headers
	var headers = [
			"User-Agent: Pirulo/1.0 (Godot)",
			"Accept: */*"
			]

	err = http.request(HTTPClient.METHOD_GET, "/get", headers) # Request a page from the site (this one was chunked..)
	assert(err == OK) # Make sure all is OK.

	while http.get_status() == HTTPClient.STATUS_REQUESTING:
		# Keep polling for as long as the request is being processed.
		http.poll()
		print("Requesting...")
		OS.delay_msec(500)

	assert(http.get_status() == HTTPClient.STATUS_BODY or http.get_status() == HTTPClient.STATUS_CONNECTED) # Make sure request finished well.

	print("response? ", http.has_response()) # Site might not have a response.

	if http.has_response():
		# If there is a response...

		headers = http.get_response_headers_as_dictionary() # Get response headers.
		print("code: ", http.get_response_code()) # Show response code.
		print("**headers:\\n", headers) # Show headers.

		# Getting the HTTP Body

		if http.is_response_chunked():
			# Does it use chunks?
			print("Response is Chunked!")
		else:
			# Or just plain Content-Length
			var bl = http.get_response_body_length()
			print("Response Length: ", bl)

		# This method works for both anyway

		var rb = PoolByteArray() # Array that will hold the data.

		while http.get_status() == HTTPClient.STATUS_BODY:
			# Get a chunk.
			var chunk = http.read_response_body_chunk()
			if chunk.size() == 0:
				OS.delay_usec(1000)
			else:
				rb = rb + chunk # Append to read buffer.
			http.poll()

		print("bytes got: ", rb.size())
		var text = rb.get_string_from_ascii()
		print("Text: ", text)
```

</details>