### PR TITLE
Some improvements to the SceneTreeTimer

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -59,8 +59,14 @@
 			<return type="SceneTreeTimer" />
 			<argument index="0" name="time_sec" type="float" />
 			<argument index="1" name="process_always" type="bool" default="true" />
+			<argument index="2" name="process_in_physics" type="bool" default="false" />
+			<argument index="3" name="ignore_time_scale" type="bool" default="false" />
 			<description>
-				Returns a [SceneTreeTimer] which will [signal SceneTreeTimer.timeout] after the given time in seconds elapsed in this [SceneTree]. If [code]process_always[/code] is set to [code]false[/code], pausing the [SceneTree] will also pause the timer.
+				Returns a [SceneTreeTimer] which will [signal SceneTreeTimer.timeout] after the given time in seconds elapsed in this [SceneTree]. 
+				If [code]process_always[/code] is set to [code]false[/code], pausing the [SceneTree] will also pause the timer.
+				If [code]process_in_physics[/code] is set to [code]true[/code], will update the [SceneTreeTimer] during the physics frame instead of the process frame (fixed framerate processing).
+				If [code]ignore_time_scale[/code] is set to [code]true[/code], will ignore [member Engine.time_scale] and update the [SceneTreeTimer] with the actual frame delta.
+				
 				Commonly used to create a one-shot delay timer as in the following example:
 				[codeblocks]
 				[gdscript]

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -82,6 +82,14 @@ bool SceneTreeTimer::is_process_always() {
 	return process_always;
 }
 
+void SceneTreeTimer::set_process_in_physics(bool p_process_in_physics) {
+	process_in_physics = p_process_in_physics;
+}
+
+bool SceneTreeTimer::is_process_in_physics() {
+	return process_in_physics;
+}
+
 void SceneTreeTimer::set_ignore_time_scale(bool p_ignore) {
 	ignore_time_scale = p_ignore;
 }
@@ -122,6 +130,44 @@ void SceneTree::node_removed(Node *p_node) {
 
 void SceneTree::node_renamed(Node *p_node) {
 	emit_signal(node_renamed_name, p_node);
+}
+
+void SceneTree::process_timers(float p_delta, bool p_physics_frame) {
+	List<Ref<SceneTreeTimer>>::Element *L = timers.back(); //last element
+
+	for (List<Ref<SceneTreeTimer>>::Element *E = timers.front(); E;) {
+
+		//Check whether the timer should be process in this type of frame
+		if (!(E->get()->is_process_in_physics() == p_physics_frame)) {
+			continue;
+		}
+
+		List<Ref<SceneTreeTimer>>::Element *N = E->next();
+		if (paused && !E->get()->is_process_always()) {
+			if (E == L) {
+				break; //break on last, so if new timers were added during list traversal, ignore them.
+			}
+			E = N;
+			continue;
+		}
+
+		double time_left = E->get()->get_time_left();
+		if (E->get()->is_ignore_time_scale()) {
+			time_left -= Engine::get_singleton()->get_process_step();
+		} else {
+			time_left -= p_delta;
+		}
+		E->get()->set_time_left(time_left);
+
+		if (time_left < 0) {
+			E->get()->emit_signal(SNAME("timeout"));
+			timers.erase(E);
+		}
+		if (E == L) {
+			break; //break on last, so if new timers were added during list traversal, ignore them.
+		}
+		E = N;
+	}
 }
 
 SceneTree::Group *SceneTree::add_to_group(const StringName &p_group, Node *p_node) {
@@ -421,6 +467,8 @@ bool SceneTree::physics_process(double p_time) {
 	_flush_ugc();
 	MessageQueue::get_singleton()->flush(); //small little hack
 
+	process_timers(p_time, true); //go through timers
+
 	process_tweens(p_time, true);
 
 	flush_transform_notifications();
@@ -460,37 +508,7 @@ bool SceneTree::process(double p_time) {
 
 	_flush_delete_queue();
 
-	//go through timers
-
-	List<Ref<SceneTreeTimer>>::Element *L = timers.back(); //last element
-
-	for (List<Ref<SceneTreeTimer>>::Element *E = timers.front(); E;) {
-		List<Ref<SceneTreeTimer>>::Element *N = E->next();
-		if (paused && !E->get()->is_process_always()) {
-			if (E == L) {
-				break; //break on last, so if new timers were added during list traversal, ignore them.
-			}
-			E = N;
-			continue;
-		}
-
-		double time_left = E->get()->get_time_left();
-		if (E->get()->is_ignore_time_scale()) {
-			time_left -= Engine::get_singleton()->get_process_step();
-		} else {
-			time_left -= p_time;
-		}
-		E->get()->set_time_left(time_left);
-
-		if (time_left < 0) {
-			E->get()->emit_signal(SNAME("timeout"));
-			timers.erase(E);
-		}
-		if (E == L) {
-			break; //break on last, so if new timers were added during list traversal, ignore them.
-		}
-		E = N;
-	}
+	process_timers(p_time, false); //go through timers
 
 	process_tweens(p_time, false);
 
@@ -1118,11 +1136,13 @@ void SceneTree::add_current_scene(Node *p_current) {
 	root->add_child(p_current);
 }
 
-Ref<SceneTreeTimer> SceneTree::create_timer(double p_delay_sec, bool p_process_always) {
+Ref<SceneTreeTimer> SceneTree::create_timer(double p_delay_sec, bool p_process_always, bool p_process_in_physics, bool p_ignore_time_scale) {
 	Ref<SceneTreeTimer> stt;
 	stt.instantiate();
 	stt->set_process_always(p_process_always);
 	stt->set_time_left(p_delay_sec);
+	stt->set_process_in_physics(p_process_in_physics);
+	stt->set_ignore_time_scale(p_ignore_time_scale);
 	timers.push_back(stt);
 	return stt;
 }
@@ -1185,7 +1205,7 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_pause", "enable"), &SceneTree::set_pause);
 	ClassDB::bind_method(D_METHOD("is_paused"), &SceneTree::is_paused);
 
-	ClassDB::bind_method(D_METHOD("create_timer", "time_sec", "process_always"), &SceneTree::create_timer, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("create_timer", "time_sec", "process_always", "process_in_physics", "ignore_time_scale"), &SceneTree::create_timer, DEFVAL(true), DEFVAL(false), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("create_tween"), &SceneTree::create_tween);
 	ClassDB::bind_method(D_METHOD("get_processed_tweens"), &SceneTree::get_processed_tweens);
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -54,6 +54,7 @@ class SceneTreeTimer : public RefCounted {
 
 	double time_left = 0.0;
 	bool process_always = true;
+	bool process_in_physics = false;
 	bool ignore_time_scale = false;
 
 protected:
@@ -65,6 +66,9 @@ public:
 
 	void set_process_always(bool p_process_always);
 	bool is_process_always();
+
+	void set_process_in_physics(bool p_process_in_physics);
+	bool is_process_in_physics();
 
 	void set_ignore_time_scale(bool p_ignore);
 	bool is_ignore_time_scale();
@@ -169,6 +173,7 @@ private:
 	void node_added(Node *p_node);
 	void node_removed(Node *p_node);
 	void node_renamed(Node *p_node);
+	void process_timers(float p_delta, bool p_physics_frame);
 	void process_tweens(float p_delta, bool p_physics_frame);
 
 	Group *add_to_group(const StringName &p_group, Node *p_node);
@@ -319,7 +324,7 @@ public:
 	Error change_scene_to(const Ref<PackedScene> &p_scene);
 	Error reload_current_scene();
 
-	Ref<SceneTreeTimer> create_timer(double p_delay_sec, bool p_process_always = true);
+	Ref<SceneTreeTimer> create_timer(double p_delay_sec, bool p_process_always = true, bool p_process_in_physics = false, bool p_ignore_time_scale = false);
 	Ref<Tween> create_tween();
 	Array get_processed_tweens();
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Some improvements to the SceneTreeTimer:

- Added a new parameter `process_in_physics` to `SceneTree.create_timer()` to update the SceneTreeTimer during the physics frame instead of the process frame.

- Added a new parameter `ignore_time_scale` to `SceneTree.create_timer()` to ignore Engine.time_scale and update the SceneTreeTimer with the actual frame delta.

- Code cleanup, moved the code that handles SceneTreeTimer to `process_timers()`

This should not break any compatibility, so maybe it can be cherrypick to 3.x?