### PR TITLE
Revert #55978 "Fixed event spam when using the Nintendo Switch controller"

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -922,10 +922,7 @@ void Input::joy_axis(int p_device, JoyAxis p_axis, const JoyAxisValue &p_value) 
 
 	Joypad &joy = joy_names[p_device];
 
-	// Make sure that we don't generate events for up to 5% jitter
-	// This is needed for Nintendo Switch Pro controllers, which jitter at rest
-	const float MIN_AXIS_CHANGE = 0.05f;
-	if (fabs(joy.last_axis[(size_t)p_axis] - p_value.value) < MIN_AXIS_CHANGE) {
+	if (joy.last_axis[(size_t)p_axis] == p_value.value) {
 		return;
 	}
 


### PR DESCRIPTION
#55978 will reintroduce #42876. As discussed in #43674, instead of imposing a fixed limit on the sensitivity of the joystick, we need a user configurable project settings with Godot defaults for both the joystick sensitivity and the joystick deadzone.