### PR TITLE
[3.x] Revert #55997 "Fixed event spam when using the Nintendo Switch controller"

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -811,10 +811,7 @@ void InputDefault::joy_axis(int p_device, int p_axis, const JoyAxis &p_value) {
 
 	Joypad &joy = joy_names[p_device];
 
-	// Make sure that we don't generate events for up to 5% jitter
-	// This is needed for Nintendo Switch Pro controllers, which jitter at rest
-	const float MIN_AXIS_CHANGE = 0.05f;
-	if (fabs(joy.last_axis[p_axis] - p_value.value) < MIN_AXIS_CHANGE) {
+	if (joy.last_axis[p_axis] == p_value.value) {
 		return;
 	}
 


### PR DESCRIPTION
3.x version of #56028.