### PR TITLE
Change `find_node` to `find_nodes` and Add an `type` parameter.

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -181,16 +181,19 @@
 				[b]Note:[/b] It will not work properly if the node contains a script with constructor arguments (i.e. needs to supply arguments to [method Object._init] method). In that case, the node will be duplicated without a script.
 			</description>
 		</method>
-		<method name="find_node" qualifiers="const">
-			<return type="Node" />
+		<method name="find_nodes" qualifiers="const">
+			<return type="Node[]" />
 			<argument index="0" name="mask" type="String" />
-			<argument index="1" name="recursive" type="bool" default="true" />
-			<argument index="2" name="owned" type="bool" default="true" />
+			<argument index="1" name="type" type="String" default="&quot;&quot;" />
+			<argument index="2" name="recursive" type="bool" default="true" />
+			<argument index="3" name="owned" type="bool" default="true" />
 			<description>
-				Finds a descendant of this node whose name matches [code]mask[/code] as in [method String.match] (i.e. case-sensitive, but [code]"*"[/code] matches zero or more characters and [code]"?"[/code] matches any single character except [code]"."[/code]). Returns [code]null[/code] if no matching [Node] is found.
-				[b]Note:[/b] It does not match against the full path, just against individual node names.
+				Finds descendants of this node whose, name matches [code]mask[/code] as in [method String.match], and/or type matches [code]type[/code] as in [method Object.is_class].
+				[code]mask[/code] does not match against the full path, just against individual node names. It is case-sensitive, with [code]"*"[/code] matching zero or more characters and [code]"?"[/code] matching any single character except [code]"."[/code]).
+				[code]type[/code] will check equality or inheritance. It is case-sensitive, [code]"Object"[/code] will match a node whose type is [code]"Node"[/code] but not the other way around.
 				If [code]owned[/code] is [code]true[/code], this method only finds nodes whose owner is this node. This is especially important for scenes instantiated through a script, because those scenes don't have an owner.
-				[b]Note:[/b] As this method walks through all the descendants of the node, it is the slowest way to get a reference to another node. Whenever possible, consider using [method get_node] instead. To avoid using [method find_node] too often, consider caching the node reference into a variable.
+				Returns an empty array, if no matching nodes are found.
+				[b]Note:[/b] As this method walks through all the descendants of the node, it is the slowest way to get references to other nodes. To avoid using [method find_nodes] too often, consider caching the node references into variables.
 			</description>
 		</method>
 		<method name="find_parent" qualifiers="const">

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -377,9 +377,10 @@ void SceneImportSettings::_update_view_gizmos() {
 			continue;
 		}
 
-		MeshInstance3D *collider_view = static_cast<MeshInstance3D *>(mesh_node->find_node("collider_view"));
-		CRASH_COND_MSG(collider_view == nullptr, "This is unreachable, since the collider view is always created even when the collision is not used! If this is triggered there is a bug on the function `_fill_scene`.");
+		TypedArray<Node> descendants = mesh_node->find_nodes("collider_view", "MeshInstance3D");
+		CRASH_COND_MSG(descendants.is_empty(), "This is unreachable, since the collider view is always created even when the collision is not used! If this is triggered there is a bug on the function `_fill_scene`.");
 
+		MeshInstance3D *collider_view = static_cast<MeshInstance3D *>(descendants[0].operator Object *());
 		collider_view->set_visible(generate_collider);
 		if (generate_collider) {
 			// This collider_view doesn't have a mesh so we need to generate a new one.

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -299,7 +299,7 @@ public:
 	bool has_node(const NodePath &p_path) const;
 	Node *get_node(const NodePath &p_path) const;
 	Node *get_node_or_null(const NodePath &p_path) const;
-	Node *find_node(const String &p_mask, bool p_recursive = true, bool p_owned = true) const;
+	TypedArray<Node> find_nodes(const String &p_mask, const String &p_type = "", bool p_recursive = true, bool p_owned = true) const;
 	bool has_node_and_resource(const NodePath &p_path) const;
 	Node *get_node_and_resource(const NodePath &p_path, RES &r_res, Vector<StringName> &r_leftover_subpath, bool p_last_is_property = true) const;
 


### PR DESCRIPTION
Changed `find_node` to `find_nodes` which now returns an `TypedArray<Node>`, and Added an `type` parameter to match against specific node types, which supports inheritance. `find_nodes` can be used with just `mask` or just `type` or both.

`type`: Can be any `native`, `class_name`, or `resource_path` type, similarly to the `extends` keyword. (supports inheritance)

3.x PR: #56085
Closes: godotengine/godot-proposals#3661
Example Project: [FindNodesTest.zip](https://github.com/godotengine/godot/files/8063763/FindNodesTest.zip)


