### PR TITLE
[3.x] Fix detected leaks/heap-use-after-free by AddressSanitizer at startup

### DIFF
--- a/platform/x11/detect_prime.cpp
+++ b/platform/x11/detect_prime.cpp
@@ -175,7 +175,7 @@ int detect_prime() {
 			close(fdset[0]);
 
 		} else {
-			// In child, exit() here will not quit the engine.
+			// In child, killing this process will not quit the engine.
 
 			char string[201];
 
@@ -203,7 +203,7 @@ int detect_prime() {
 				print_verbose("Couldn't write vendor/renderer string.");
 			}
 			close(fdset[1]);
-			exit(0);
+			raise(SIGINT);
 		}
 	}
 


### PR DESCRIPTION
When building the engine with `optimize=speed target=release_debug use_asan=yes`, AddressSanitizer will report the same heap-user-after-free twice.

These reports are caused by this `fork` system call:
https://github.com/godotengine/godot/blob/ab10fa0439742877289efdd46be2b4e9062a6c32/platform/x11/detect_prime.cpp#L152

And the associated exit handlers executed on the associated forked process:
https://github.com/godotengine/godot/blob/ab10fa0439742877289efdd46be2b4e9062a6c32/platform/x11/detect_prime.cpp#L206

The memory gets properly freed by the engine, but the exit handlers mess around with `ObjectDB::instances` by calling `ObjectDB::remove_instance(Object*)`, which later down the road causes a use-after-free:
```
==164732==ERROR: AddressSanitizer: heap-use-after-free on address 0x60d0000833d0 at pc 0x0000089431a0 bp 0x7fffffff6da0 sp 0x7fffffff6d90
READ of size 8 at 0x60d0000833d0 thread T0
    #0 0x894319f in HashMap<unsigned long, Object*, HashMapHasherDefault, HashMapComparatorDefault<unsigned long>, (unsigned char)3, (unsigned char)8>::erase(unsigned long const&) cor
    #1 0x894319f in ObjectDB::remove_instance(Object*) core/object.cpp:2021
    #2 0x8953e4d in Object::~Object() core/object.cpp:1981
    #3 0x2c77bb4 in void memdelete<ResourceSaverPNG>(ResourceSaverPNG*) core/os/memory.h:114
    #4 0x2c77bb4 in void memdelete<ResourceSaverPNG>(ResourceSaverPNG*) core/os/memory.h:109
    #5 0x2c77bb4 in Ref<ResourceSaverPNG>::unref() core/reference.h:258
    #6 0x2c77bb4 in Ref<ResourceSaverPNG>::~Ref() core/reference.h:272
    #7 0x7ffff672e4a6 in __run_exit_handlers (/usr/lib/libc.so.6+0x3f4a6)
    #8 0x7ffff672e64d in exit (/usr/lib/libc.so.6+0x3f64d)
    #9 0xfc5fe7 in detect_prime() platform/x11/detect_prime.cpp:206
```

On builds configured with `optimize=none target=debug use_asan=yes`, you'll see memory leaks caused by bogus memory management due to the exit handlers.

This patch prevents the exit handlers from executing, in turn letting the engine handle the memory deallocation as intended during PRIME detection.

After this patch, opening and closing the editor on an empty project should not yield any reports from AddressSanitizer in Linux.

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/29844