### PR TITLE
[3.x] Set default priority on PRIME detection vendor struct.

### DIFF
--- a/platform/x11/detect_prime.cpp
+++ b/platform/x11/detect_prime.cpp
@@ -56,7 +56,7 @@ typedef GLXContext (*GLXCREATECONTEXTATTRIBSARBPROC)(Display *, GLXFBConfig, GLX
 
 struct vendor {
 	const char *glxvendor;
-	int priority;
+	int priority = 0;
 };
 
 vendor vendormap[] = {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

The vendor map already includes a priority value:
https://github.com/Rubonnek/godot/blob/1b8a9d56b338306f7244e2b02cdc0b3b7af64ef3/platform/x11/detect_prime.cpp#L62-L71

Keeping a default value doesn't hurt for future PRIME detection changes.