### PR TITLE
Fix detected leaks/heap-use-after-free by AddressSanitizer at OpenGL startup

### DIFF
--- a/platform/linuxbsd/detect_prime_x11.cpp
+++ b/platform/linuxbsd/detect_prime_x11.cpp
@@ -173,7 +173,7 @@ int detect_prime() {
 			close(fdset[0]);
 
 		} else {
-			// In child, exit() here will not quit the engine.
+			// In child, killing this process will not quit the engine.
 
 			char string[201];
 
@@ -200,7 +200,7 @@ int detect_prime() {
 				print_verbose("Couldn't write vendor/renderer string.");
 			}
 			close(fdset[1]);
-			exit(0);
+			raise(SIGINT);
 		}
 	}
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

`master` version of #56036.

This code seems unused in `master` due to missing GLES3 support, but once it's supported this patch will take care of the memory issues described in #56036.

Edit: Marked as draft since #56036 has been reverted.