### PR TITLE
Fix crash if font fails loading when generating a preview

### DIFF
--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -824,6 +824,7 @@ bool EditorFontPreviewPlugin::handles(const String &p_type) const {
 
 Ref<Texture2D> EditorFontPreviewPlugin::generate_from_path(const String &p_path, const Size2 &p_size) const {
 	RES res = ResourceLoader::load(p_path);
+	ERR_FAIL_COND_V(res.is_null(), Ref<Texture2D>());
 	Ref<Font> sampled_font;
 	if (res->is_class("Font")) {
 		sampled_font = res->duplicate();


### PR DESCRIPTION
After #56023, still on my way converting projects to Godot4, found some fonts failing to load, which caused a crash in the preview generator because it does not check for that eventuality.

Historical crash log:
```
ERROR: No loader found for resource: res://addons/gdquest.mannequin/assets/theme/fonts/montserrat/Montserrat-Medium.ttf.
   at: (core\io\resource_loader.cpp:213)
ERROR: res://addons/gdquest.mannequin/assets/theme/fonts/default_font.tres:8 - Parse Error: [ext_resource] referenced non-loaded resource at: res://addons/gdquest.mannequin/assets/theme/fonts/montserrat/Montserrat-Medium.ttf
   at: ResourceLoaderText::_parse_ext_resource (scene\resources\resource_format_text.cpp:170)
ERROR: res://addons/gdquest.mannequin/assets/theme/fonts/default_font.tres:8 - Parse Error: [ext_resource] referenced non-loaded resource at: res://addons/gdquest.mannequin/assets/theme/fonts/montserrat/Montserrat-Medium.ttf
   at: ResourceLoaderText::load (scene\resources\resource_format_text.cpp:649)
ERROR: Failed loading resource: res://addons/gdquest.mannequin/assets/theme/fonts/default_font.tres. Make sure resources have been imported by opening the project in the editor at least once.
   at: (core\io\resource_loader.cpp:206)
```
