### PR TITLE
Added resource path to message about old mesh format conversion

### DIFF
--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -898,7 +898,9 @@ bool ArrayMesh::_set(const StringName &p_name, const Variant &p_value) {
 		return false;
 	}
 
-	WARN_DEPRECATED_MSG("Mesh uses old surface format, which is deprecated (and loads slower). Consider re-importing or re-saving the scene.");
+	WARN_DEPRECATED_MSG(vformat(
+			"Mesh uses old surface format, which is deprecated (and loads slower). Consider re-importing or re-saving the scene. Path: \"%s\"",
+			get_path()));
 
 	int idx = sname.get_slicec('/', 1).to_int();
 	String what = sname.get_slicec('/', 2);


### PR DESCRIPTION
While converting projects to Godot4 I encountered a warning message telling me a mesh was using an old format and was going to get converted:
```
WARNING: Mesh uses old surface format, which is deprecated (and loads slower). Consider re-importing or re-saving the scene.
```
Too bad, conversion went badly and errors ensued. While I don't know how to fix that, I did not know what mesh this was, until I added this extra bit in the message:
```
WARNING: Mesh uses old surface format, which is deprecated (and loads slower). Consider re-importing or re-saving the scene. Path: "res://addons/gdquest.mannequin/src/Player/Mannequiny.tscn::1"
```