### PR TITLE
OSX: Add signing of directory structure when exporting for OSX

### DIFF
--- a/doc/classes/EditorExportPlugin.xml
+++ b/doc/classes/EditorExportPlugin.xml
@@ -96,12 +96,22 @@
 				Adds a static lib from the given [code]path[/code] to the iOS project.
 			</description>
 		</method>
+		<method name="add_osx_plugin_file">
+			<return type="void" />
+			<argument index="0" name="path" type="String" />
+			<description>
+				Adds file or directory matching [code]path[/code] to [code]PlugIns[/code] directory of macOS app bundle.
+				[b]Note:[/b] This is useful only for macOS exports.
+			</description>
+		</method>
 		<method name="add_shared_object">
 			<return type="void" />
 			<argument index="0" name="path" type="String" />
 			<argument index="1" name="tags" type="PackedStringArray" />
 			<description>
-				Adds a shared object with the given [code]tags[/code] and destination [code]path[/code].
+				Adds a shared object or a directory containing only shared objects with the given [code]tags[/code] and destination [code]path[/code].
+				[b]Note:[/b] In case of macOS exports, those shared objects will be added to [code]Frameworks[/code] directory of app bundle.
+				In case of a directory code-sign will error if you place non code object in directory.
 			</description>
 		</method>
 		<method name="skip">

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -620,6 +620,14 @@ String EditorExportPlugin::get_ios_cpp_code() const {
 	return ios_cpp_code;
 }
 
+void EditorExportPlugin::add_osx_plugin_file(const String &p_path) {
+	osx_plugin_files.push_back(p_path);
+}
+
+const Vector<String> &EditorExportPlugin::get_osx_plugin_files() const {
+	return osx_plugin_files;
+}
+
 void EditorExportPlugin::add_ios_project_static_lib(const String &p_path) {
 	ios_project_static_libs.push_back(p_path);
 }
@@ -660,6 +668,7 @@ void EditorExportPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_ios_linker_flags", "flags"), &EditorExportPlugin::add_ios_linker_flags);
 	ClassDB::bind_method(D_METHOD("add_ios_bundle_file", "path"), &EditorExportPlugin::add_ios_bundle_file);
 	ClassDB::bind_method(D_METHOD("add_ios_cpp_code", "code"), &EditorExportPlugin::add_ios_cpp_code);
+	ClassDB::bind_method(D_METHOD("add_osx_plugin_file", "path"), &EditorExportPlugin::add_osx_plugin_file);
 	ClassDB::bind_method(D_METHOD("skip"), &EditorExportPlugin::skip);
 
 	GDVIRTUAL_BIND(_export_file, "path", "type", "features");

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -308,6 +308,8 @@ class EditorExportPlugin : public RefCounted {
 	Vector<String> ios_bundle_files;
 	String ios_cpp_code;
 
+	Vector<String> osx_plugin_files;
+
 	_FORCE_INLINE_ void _clear() {
 		shared_objects.clear();
 		extra_files.clear();
@@ -321,6 +323,7 @@ class EditorExportPlugin : public RefCounted {
 		ios_plist_content = "";
 		ios_linker_flags = "";
 		ios_cpp_code = "";
+		osx_plugin_files.clear();
 	}
 
 	void _export_file_script(const String &p_path, const String &p_type, const Vector<String> &p_features);
@@ -341,6 +344,7 @@ protected:
 	void add_ios_linker_flags(const String &p_flags);
 	void add_ios_bundle_file(const String &p_path);
 	void add_ios_cpp_code(const String &p_code);
+	void add_osx_plugin_file(const String &p_path);
 
 	void skip();
 
@@ -361,6 +365,7 @@ public:
 	String get_ios_linker_flags() const;
 	Vector<String> get_ios_bundle_files() const;
 	String get_ios_cpp_code() const;
+	const Vector<String> &get_osx_plugin_files() const;
 
 	EditorExportPlugin();
 };

--- a/platform/osx/export/export_plugin.h
+++ b/platform/osx/export/export_plugin.h
@@ -58,6 +58,13 @@ class EditorExportPlatformOSX : public EditorExportPlatform {
 
 	Error _notarize(const Ref<EditorExportPreset> &p_preset, const String &p_path);
 	Error _code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path, const String &p_ent_path);
+	Error _code_sign_directory(const Ref<EditorExportPreset> &p_preset, const String &p_path, const String &p_ent_path, bool p_should_error_on_non_code = true);
+	Error _copy_and_sign_files(DirAccessRef &dir_access, const String &p_src_path, const String &p_in_app_path,
+			bool p_sign_enabled, const Ref<EditorExportPreset> &p_preset, const String &p_ent_path,
+			bool p_should_error_on_non_code_sign);
+	Error _export_osx_plugins_for(Ref<EditorExportPlugin> p_editor_export_plugin, const String &p_app_path_name,
+			DirAccessRef &dir_access, bool p_sign_enabled, const Ref<EditorExportPreset> &p_preset,
+			const String &p_ent_path);
 	Error _create_dmg(const String &p_dmg_path, const String &p_pkg_name, const String &p_app_path_name);
 	void _zip_folder_recursive(zipFile &p_zip, const String &p_root_path, const String &p_folder, const String &p_pkg_name);
 


### PR DESCRIPTION
This enable to sign all dylib and framework in a directory added as shared objects.  
This is useful when you need a dependency that contains several dylib, taking care of directory structure (as an example an unsigned JVM build.  

This checks if shared object is a directory.  
If it is, it will call new method `EditorExportPlatformOSX::_code_sign_directory` to explore folder, find all dylib and framework in it and sign them.  
If it is not a directory, this will call `EditorExportPlatformOSX::_code_sign` as before.  

Changes can be easily added to `3.4`.

This resolves #52184