### PR TITLE
[Headless] Workaround texture load failure.

### DIFF
--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -692,7 +692,9 @@ public:
 	virtual void update_memory_info() override {}
 	virtual uint64_t get_rendering_info(RS::RenderingInfo p_info) override { return 0; }
 
-	bool has_os_feature(const String &p_feature) const override { return false; }
+	bool has_os_feature(const String &p_feature) const override {
+		return p_feature == "rgtc" || p_feature == "bptc" || p_feature == "s3tc" || p_feature == "etc" || p_feature == "etc2";
+	}
 
 	void update_dirty_resources() override {}
 


### PR DESCRIPTION
Some assets are loaded based on OS/server feature detection, namely textures (but potentially others).
The ResourceImporter will fail to load a texture if the OS reports not supporting it.
The OS, in turn, checks texture format support via the RenderingServer.
This commit makes the dummy rasterizer report known texture formats as supported (although unused), so that scenes can be correctly loaded when they include references to imported textures.

Fixes #55628 although this feels more like a workaround.
I'm not sure what a proper fix would look like, will probably have a better picture once we take a crack at: godotengine/godot-proposals#2756 (so we can re-export the assets in a dedicated format).
CC @akien-mga since I know you worked on the GL/OS texture format madness :)