### PR TITLE
[macOS] Fix OpenGL flickering.

### DIFF
--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -78,6 +78,7 @@ public:
 	int key_event_pos;
 
 	bool force_quit;
+	bool is_resizing = false;
 	//  rasterizer seems to no longer be given to visual server, its using GLES3 directly?
 	//Rasterizer *rasterizer;
 	VisualServer *visual_server;


### PR DESCRIPTION
- Fix incorrect context usage for off-screen drawing.
- Remove kCGLCEMPEngine, which is causing flicker on macOS 12.1.
- Disable window redraw during resize, when rendering in the separate thread (window resize is updating GL context from the main thread, which is simultaneously used by the render thread.).

Fixes #56055