### PR TITLE
[Android] [3.x] Trunc shader function fixed in GLES2

### DIFF
--- a/drivers/gles2/shaders/stdlib.glsl
+++ b/drivers/gles2/shaders/stdlib.glsl
@@ -259,19 +259,19 @@ bvec4 isnan(highp vec4 x) {
 #if defined(TRUNC_USED)
 
 highp float trunc(highp float x) {
-	return x < 0 ? -floor(-x) : floor(x);
+	return x < 0.0 ? -floor(-x) : floor(x);
 }
 
 highp vec2 trunc(highp vec2 x) {
-	return vec2(x.x < 0 ? -floor(-x.x) : floor(x.x), x.y < 0 ? -floor(-x.y) : floor(x.y));
+	return vec2(x.x < 0.0 ? -floor(-x.x) : floor(x.x), x.y < 0.0 ? -floor(-x.y) : floor(x.y));
 }
 
 highp vec3 trunc(highp vec3 x) {
-	return vec3(x.x < 0 ? -floor(-x.x) : floor(x.x), x.y < 0 ? -floor(-x.y) : floor(x.y), x.z < 0 ? -floor(-x.z) : floor(x.z));
+	return vec3(x.x < 0.0 ? -floor(-x.x) : floor(x.x), x.y < 0.0 ? -floor(-x.y) : floor(x.y), x.z < 0.0 ? -floor(-x.z) : floor(x.z));
 }
 
 highp vec4 trunc(highp vec4 x) {
-	return vec4(x.x < 0 ? -floor(-x.x) : floor(x.x), x.y < 0 ? -floor(-x.y) : floor(x.y), x.z < 0 ? -floor(-x.z) : floor(x.z), x.w < 0 ? -floor(-x.w) : floor(x.w));
+	return vec4(x.x < 0.0 ? -floor(-x.x) : floor(x.x), x.y < 0.0 ? -floor(-x.y) : floor(x.y), x.z < 0.0 ? -floor(-x.z) : floor(x.z), x.w < 0.0 ? -floor(-x.w) : floor(x.w));
 }
 
 #endif


### PR DESCRIPTION
- the 'trunc' function was comparing integers with floats using the '>' operator, which is not supported in Android. This issue is now gone.

Fixes #55973