### PR TITLE
Add node path drag from remote tree

### DIFF
--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -225,6 +225,39 @@ void EditorDebuggerTree::update_scene_tree(const SceneDebuggerTree *p_tree, int 
 	updating_scene_tree = false;
 }
 
+Variant EditorDebuggerTree::get_drag_data(const Point2 &p_point) {
+	if (get_button_id_at_position(p_point) != -1) {
+		return Variant();
+	}
+
+	TreeItem *selected = get_selected();
+	if (!selected) {
+		return Variant();
+	}
+
+	String path = selected->get_text(0);
+
+	HBoxContainer *hb = memnew(HBoxContainer);
+	TextureRect *tf = memnew(TextureRect);
+	tf->set_texture(selected->get_icon(0));
+	tf->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
+	hb->add_child(tf);
+	Label *label = memnew(Label(path));
+	hb->add_child(label);
+	set_drag_preview(hb);
+
+	if (!selected->get_parent() || !selected->get_parent()->get_parent()) {
+		path = ".";
+	} else {
+		while (selected->get_parent()->get_parent() != get_root()) {
+			selected = selected->get_parent();
+			path = selected->get_text(0) + "/" + path;
+		}
+	}
+
+	return vformat("\"%s\"", path);
+}
+
 String EditorDebuggerTree::get_selected_path() {
 	if (!get_selected()) {
 		return "";

--- a/editor/debugger/editor_debugger_tree.h
+++ b/editor/debugger/editor_debugger_tree.h
@@ -65,6 +65,8 @@ protected:
 	void _notification(int p_what);
 
 public:
+	virtual Variant get_drag_data(const Point2 &p_point) override;
+
 	String get_selected_path();
 	ObjectID get_selected_object();
 	int get_current_debugger(); // Would love to have one tree for every debugger.


### PR DESCRIPTION
Closes #23768
![b3PELa6QWu](https://user-images.githubusercontent.com/2223172/146657734-93550351-f3e8-48cf-9520-5ce532ec0725.gif)

Due to nature of remote tree, there are a couple of limitations compared to local node dragging:
- You can't drag multiple nodes. Only the first selected will be dragged
- The drop data isn't real node path, but a plain text relative to root
