### PR TITLE
Fix size issue for ARVR managed viewport

### DIFF
--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -288,6 +288,17 @@ void VisualServerViewport::draw_viewports() {
 
 		ERR_CONTINUE(!vp->render_target.is_valid());
 
+		if (vp->use_arvr) {
+			// In ARVR mode it is our interface that controls our size
+			if (arvr_interface.is_valid()) {
+				// override our size, make sure it matches our required size
+				vp->size = arvr_interface->get_render_targetsize();
+			} else {
+				// reset this, we can't render the output without a valid interface (this will likely be so when we're in the editor)
+				vp->size = Vector2(0, 0);
+			}
+		}
+
 		bool visible = vp->viewport_to_screen_rect != Rect2() || vp->update_mode == VS::VIEWPORT_UPDATE_ALWAYS || vp->update_mode == VS::VIEWPORT_UPDATE_ONCE || (vp->update_mode == VS::VIEWPORT_UPDATE_WHEN_VISIBLE && VSG::storage->render_target_was_used(vp->render_target));
 		visible = visible && vp->size.x > 1 && vp->size.y > 1;
 
@@ -298,8 +309,6 @@ void VisualServerViewport::draw_viewports() {
 		VSG::storage->render_target_clear_used(vp->render_target);
 
 		if (vp->use_arvr && arvr_interface.is_valid()) {
-			// override our size, make sure it matches our required size
-			vp->size = arvr_interface->get_render_targetsize();
 			VSG::storage->render_target_set_size(vp->render_target, vp->size.x, vp->size.y);
 
 			// render mono or left eye first


### PR DESCRIPTION
This fix applies to 3.x only.

This fixes an issue around an ARVR `Viewport` not rendering if its size is `0, 0` even though the size is managed by the `ARVRInterface`.
It also fixes an issue around Godot getting stuck when attempting to render a `Viewport` not properly initialized because there is no `ARVRInterface` that has been initialized (a likely scenario when running the editor)

It simply moves the size check to slightly earlier in the rendering process, and set the size to `0, 0` if no `ARVRInterface` is initialized.

fixes #56069