### PR TITLE
Add note for get_total_character_count: it updates on next frame

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -95,6 +95,7 @@
 			<return type="int" />
 			<description>
 				Returns the total number of characters from text tags. Does not include BBCodes.
+				[b]Note:[/b] This method is asynchronous. After modifying the RichTextLabel's text tags, wait one frame before calling this method. For example, use [code]yield(get_tree(), "idle_frame")[/code].
 			</description>
 		</method>
 		<method name="get_v_scroll">


### PR DESCRIPTION
This method does not behave as expected. After updating a RichTextLabel's text tags in the current frame, we expect to call this method in the same frame and get back the updated total character count. But the count is not updated until the next frame. This doc update makes that clear.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
