### PR TITLE
[3.x] Add `Node.get_children_of_type()`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -197,6 +197,16 @@
 				Returns an array of references to node's children.
 			</description>
 		</method>
+		<method name="get_children_of_type" qualifiers="const">
+			<return type="Array" />
+			<argument index="0" name="type" type="String" />
+			<argument index="1" name="recursive" type="bool" default="false" />
+			<description>
+				Returns an array of the node's children that match or inherit from [code]type[/code].
+				[code]type[/code] could be a native type, [code]class_name[/code] type, or [code]resource_path[/code] type, similarly to the [code]extends[/code] keyword.
+				If [code]recursive[/code] is [code]true[/code], then all descendants will be checked.
+			</description>
+		</method>
 		<method name="get_groups" qualifiers="const">
 			<return type="Array" />
 			<description>

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -254,6 +254,7 @@ public:
 
 	int get_child_count() const;
 	Node *get_child(int p_index) const;
+	Array get_children_of_type(const String &p_type, bool p_recursive = false) const;
 	bool has_node(const NodePath &p_path) const;
 	Node *get_node(const NodePath &p_path) const;
 	Node *get_node_or_null(const NodePath &p_path) const;


### PR DESCRIPTION
New `Node` Method: `Array get_children_of_type(String type, bool recursive)`
Returns all children that match or inherit from a given type.

`type`: Can be any native, `class_name`, or `resource_path` type, similarly to the `extends` keyword.
`recursive`: If `true`, will check all descendants, else will only check direct children. (`false` by default)

Master PR: #56032
Closes: godotengine/godot-proposals#3661
Example Project: [GetChildrenOfTypeTest-3.x.zip](https://github.com/godotengine/godot/files/7742387/GetChildrenOfTypeTest-3.x.zip)
