### PR TITLE
Improve embedded PCK loading and exporting.

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -237,6 +237,11 @@ String OS::get_locale_language() const {
 	return get_locale().left(3).replace("_", "");
 }
 
+// Embedded PCK offset.
+uint64_t OS::get_embedded_pck_offset() const {
+	return 0;
+}
+
 // Helper function to ensure that a dir name/path will be valid on the OS
 String OS::get_safe_dir_name(const String &p_dir_name, bool p_allow_dir_separator) const {
 	Vector<String> invalid_chars = String(": * ? \" < > |").split(" ");

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -264,6 +264,8 @@ public:
 	virtual String get_locale() const;
 	String get_locale_language() const;
 
+	virtual uint64_t get_embedded_pck_offset() const;
+
 	String get_safe_dir_name(const String &p_dir_name, bool p_allow_dir_separator = false) const;
 	virtual String get_godot_dir_name() const;
 

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -442,6 +442,10 @@ public:
 	virtual Error sign_shared_object(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path);
 	virtual String get_template_file_name(const String &p_target, const String &p_arch) const = 0;
 
+	Error prepare_template(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags);
+	Error export_project_data(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags);
+
+	void set_extension(const String &p_extension, const String &p_feature_key = "default");
 	void set_name(const String &p_name);
 	void set_os_name(const String &p_name);
 

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -242,6 +242,91 @@ bool OS_LinuxBSD::_check_internal_feature_support(const String &p_feature) {
 	return p_feature == "pc";
 }
 
+uint64_t OS_LinuxBSD::get_embedded_pck_offset() const {
+	Ref<FileAccess> f = FileAccess::open(get_executable_path(), FileAccess::READ);
+	if (f.is_null()) {
+		return 0;
+	}
+
+	// Read and check ELF magic number.
+	{
+		uint32_t magic = f->get_32();
+		if (magic != 0x464c457f) { // 0x7F + "ELF"
+			return 0;
+		}
+	}
+
+	// Read program architecture bits from class field.
+	int bits = f->get_8() * 32;
+
+	// Get info about the section header table.
+	int64_t section_table_pos;
+	int64_t section_header_size;
+	if (bits == 32) {
+		section_header_size = 40;
+		f->seek(0x20);
+		section_table_pos = f->get_32();
+		f->seek(0x30);
+	} else { // 64
+		section_header_size = 64;
+		f->seek(0x28);
+		section_table_pos = f->get_64();
+		f->seek(0x3c);
+	}
+	int num_sections = f->get_16();
+	int string_section_idx = f->get_16();
+
+	// Load the strings table.
+	uint8_t *strings;
+	{
+		// Jump to the strings section header.
+		f->seek(section_table_pos + string_section_idx * section_header_size);
+
+		// Read strings data size and offset.
+		int64_t string_data_pos;
+		int64_t string_data_size;
+		if (bits == 32) {
+			f->seek(f->get_position() + 0x10);
+			string_data_pos = f->get_32();
+			string_data_size = f->get_32();
+		} else { // 64
+			f->seek(f->get_position() + 0x18);
+			string_data_pos = f->get_64();
+			string_data_size = f->get_64();
+		}
+
+		// Read strings data.
+		f->seek(string_data_pos);
+		strings = (uint8_t *)memalloc(string_data_size);
+		if (!strings) {
+			return 0;
+		}
+		f->get_buffer(strings, string_data_size);
+	}
+
+	// Search for the "pck" section.
+	int64_t off = 0;
+	for (int i = 0; i < num_sections; ++i) {
+		int64_t section_header_pos = section_table_pos + i * section_header_size;
+		f->seek(section_header_pos);
+
+		uint32_t name_offset = f->get_32();
+		if (strcmp((char *)strings + name_offset, "pck") == 0) {
+			if (bits == 32) {
+				f->seek(section_header_pos + 0x10);
+				off = f->get_32();
+			} else { // 64
+				f->seek(section_header_pos + 0x18);
+				off = f->get_64();
+			}
+			break;
+		}
+	}
+	memfree(strings);
+
+	return off;
+}
+
 String OS_LinuxBSD::get_config_path() const {
 	if (has_environment("XDG_CONFIG_HOME")) {
 		if (get_environment("XDG_CONFIG_HOME").is_absolute_path()) {

--- a/platform/linuxbsd/os_linuxbsd.h
+++ b/platform/linuxbsd/os_linuxbsd.h
@@ -78,6 +78,8 @@ public:
 
 	virtual MainLoop *get_main_loop() const override;
 
+	virtual uint64_t get_embedded_pck_offset() const override;
+
 	virtual String get_config_path() const override;
 	virtual String get_data_path() const override;
 	virtual String get_cache_path() const override;

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -54,16 +54,23 @@ Error EditorExportPlatformWindows::_export_debug_script(const Ref<EditorExportPr
 }
 
 Error EditorExportPlatformWindows::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
-	Error err = EditorExportPlatformPC::export_project(p_preset, p_debug, p_path, p_flags);
-
-	if (err != OK) {
-		return err;
+	String pck_path = p_path;
+	if (p_preset->get("binary_format/embed_pck")) {
+		pck_path = p_path.get_basename() + ".tmp";
 	}
-
-	_rcedit_add_data(p_preset, p_path);
-
+	Error err = EditorExportPlatformPC::prepare_template(p_preset, p_debug, pck_path, p_flags);
+	if (p_preset->get("application/modify_resources") && err == OK) {
+		err = _rcedit_add_data(p_preset, pck_path);
+	}
+	if (err == OK) {
+		err = EditorExportPlatformPC::export_project_data(p_preset, p_debug, pck_path, p_flags);
+	}
 	if (p_preset->get("codesign/enable") && err == OK) {
-		err = _code_sign(p_preset, p_path);
+		err = _code_sign(p_preset, pck_path);
+	}
+	if (p_preset->get("binary_format/embed_pck") && err == OK) {
+		Ref<DirAccess> tmp_dir = DirAccess::create_for_path(p_path.get_base_dir());
+		err = tmp_dir->rename(pck_path, p_path);
 	}
 
 	String app_name;
@@ -117,6 +124,7 @@ void EditorExportPlatformWindows::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "codesign/description"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::PACKED_STRING_ARRAY, "codesign/custom_options"), PackedStringArray()));
 
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "application/modify_resources"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/icon", PROPERTY_HINT_FILE, "*.ico"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/file_version", PROPERTY_HINT_PLACEHOLDER_TEXT, "1.0.0.0"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/product_version", PROPERTY_HINT_PLACEHOLDER_TEXT, "1.0.0.0"), ""));
@@ -127,17 +135,20 @@ void EditorExportPlatformWindows::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "application/trademarks"), ""));
 }
 
-void EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset> &p_preset, const String &p_path) {
+Error EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset> &p_preset, const String &p_path) {
 	String rcedit_path = EditorSettings::get_singleton()->get("export/windows/rcedit");
 
 	if (rcedit_path.is_empty()) {
 		WARN_PRINT("The rcedit tool is not configured in the Editor Settings (Export > Windows > Rcedit). No custom icon or app information data will be embedded in the exported executable.");
-		return;
+		return ERR_FILE_NOT_FOUND;
 	}
 
 	if (!FileAccess::exists(rcedit_path)) {
 		ERR_PRINT("Could not find rcedit executable at " + rcedit_path + ", no icon or app information data will be included.");
-		return;
+		return ERR_FILE_NOT_FOUND;
+	}
+	if (rcedit_path.is_empty()) {
+		rcedit_path = "rcedit"; // try to run signtool from PATH
 	}
 
 #ifndef WINDOWS_ENABLED
@@ -146,7 +157,7 @@ void EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset>
 
 	if (!wine_path.is_empty() && !FileAccess::exists(wine_path)) {
 		ERR_PRINT("Could not find wine executable at " + wine_path + ", no icon or app information data will be included.");
-		return;
+		return ERR_FILE_NOT_FOUND;
 	}
 
 	if (wine_path.is_empty()) {
@@ -204,13 +215,22 @@ void EditorExportPlatformWindows::_rcedit_add_data(const Ref<EditorExportPreset>
 		args.push_back(trademarks);
 	}
 
-#ifdef WINDOWS_ENABLED
-	OS::get_singleton()->execute(rcedit_path, args);
-#else
+#ifndef WINDOWS_ENABLED
 	// On non-Windows we need WINE to run rcedit
 	args.push_front(rcedit_path);
-	OS::get_singleton()->execute(wine_path, args);
+	rcedit_path = wine_path;
 #endif
+
+	String str;
+	Error err = OS::get_singleton()->execute(rcedit_path, args, &str, nullptr, true);
+	ERR_FAIL_COND_V(err != OK, err);
+	print_line("rcedit (" + p_path + "): " + str);
+
+	if (str.find("Fatal error") != -1) {
+		return FAILED;
+	}
+
+	return OK;
 }
 
 Error EditorExportPlatformWindows::_code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path) {
@@ -416,6 +436,10 @@ bool EditorExportPlatformWindows::can_export(const Ref<EditorExportPreset> &p_pr
 
 Error EditorExportPlatformWindows::fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) const {
 	// Patch the header of the "pck" section in the PE file so that it corresponds to the embedded data
+
+	if (p_embedded_size + p_embedded_start >= 0x100000000) { // Check for total executable size
+		ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Windows executables cannot be >= 4 GiB.");
+	}
 
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ_WRITE);
 	if (f.is_null()) {

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -38,7 +38,7 @@
 #include "platform/windows/logo.gen.h"
 
 class EditorExportPlatformWindows : public EditorExportPlatformPC {
-	void _rcedit_add_data(const Ref<EditorExportPreset> &p_preset, const String &p_path);
+	Error _rcedit_add_data(const Ref<EditorExportPreset> &p_preset, const String &p_path);
 	Error _code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path);
 	Error _export_debug_script(const Ref<EditorExportPreset> &p_preset, const String &p_app_name, const String &p_pkg_name, const String &p_path);
 

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -39,7 +39,18 @@
 #ifndef TOOLS_ENABLED
 #if defined _MSC_VER
 #pragma section("pck", read)
-__declspec(allocate("pck")) static const char dummy[8] = { 0 };
+__declspec(allocate("pck")) static char dummy[8] = { 0 };
+
+// Dummy function to prevent LTO from discarding "pck" section.
+extern "C" char *__cdecl pck_section_dummy_call() {
+	return &dummy[0];
+};
+#if defined _AMD64_
+#pragma comment(linker, "/include:pck_section_dummy_call")
+#elif defined _X86_
+#pragma comment(linker, "/include:_pck_section_dummy_call")
+#endif
+
 #elif defined __GNUC__
 static const char dummy[8] __attribute__((section("pck"), used)) = { 0 };
 #endif
@@ -139,11 +150,6 @@ int widechar_main(int argc, wchar_t **argv) {
 	OS_Windows os(nullptr);
 
 	setlocale(LC_CTYPE, "");
-
-#ifndef TOOLS_ENABLED
-	// Workaround to prevent LTCG (MSVC LTO) from removing "pck" section
-	const char *dummy_guard = dummy;
-#endif
 
 	char **argv_utf8 = new char *[argc];
 

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -144,6 +144,8 @@ public:
 	virtual int get_processor_count() const override;
 	virtual String get_processor_name() const override;
 
+	virtual uint64_t get_embedded_pck_offset() const override;
+
 	virtual String get_config_path() const override;
 	virtual String get_data_path() const override;
 	virtual String get_cache_path() const override;


### PR DESCRIPTION
#### [Windows export]
- Limit total executable size to `4 GB - 1`.
- Use "rcedit" before embedding PCK.
- Capture and process "rcedit" errors.

Fixes #56051

#### [Windows and Linux] Add support for PCK loading from executable "pck" section.

- Exported projects now read back executable section information and attempt to load PCK from the section in addition to looking at the end of the file. This allows to modify and sign executable after embedding PCK.

Note: need testing with different build configurations, some might strip "pck" section stub and prevent it from loading.

Fixes #32310, fixes #33466.