### PR TITLE
Fix wrong ColorPicker shape with GradientEdit

### DIFF
--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -118,6 +118,9 @@ void EditorInspectorPluginGradient::parse_begin(Object *p_object) {
 	editor->set_gradient(g);
 	add_custom_control(editor);
 
+	int picker_shape = EDITOR_GET("interface/inspector/default_color_picker_shape");
+	editor->get_picker()->set_picker_shape((ColorPicker::PickerShapeType)picker_shape);
+
 	reverse_btn = memnew(GradientReverseButton);
 
 	gradient_tools_hbox = memnew(HBoxContainer);

--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -432,6 +432,10 @@ Gradient::InterpolationMode GradientEdit::get_interpolation_mode() {
 	return interpolation_mode;
 }
 
+ColorPicker *GradientEdit::get_picker() {
+	return picker;
+}
+
 void GradientEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("ramp_changed"));
 }

--- a/scene/gui/gradient_edit.h
+++ b/scene/gui/gradient_edit.h
@@ -75,6 +75,7 @@ public:
 	Vector<Gradient::Point> &get_points();
 	void set_interpolation_mode(Gradient::InterpolationMode p_interp_mode);
 	Gradient::InterpolationMode get_interpolation_mode();
+	ColorPicker *get_picker();
 
 	virtual Size2 get_minimum_size() const override;
 


### PR DESCRIPTION
Fixes #56081

### Issue description

ColorPicker shown in editor for GradientEdit doesn't have the same shape as other inspector ColorPicker (when editing Modulate property for instance)

### Identified cause

Contrary to ColorPickerButtons, GradientEdit doesn't have a get_picker() method.
This method is used in /editor code to set the picker shape from editor settings.

### Fix proposal

Add a public GradientEdit::get_picker() method.
Call this method from GradientEditorPlugin which has access to editor settings.

### Before (VHS Circle is set in setting but not taken into account for Gradient edit)

![image](https://user-images.githubusercontent.com/3649998/146799283-cb380866-fd20-4085-afdd-86493364d062.png)

### After (Picker shape editor setting is taken into account for Gradient edit)

![image](https://user-images.githubusercontent.com/3649998/146799406-252ad474-5801-4e9c-b289-16ae46499cb5.png)
