### PR TITLE
Fix `BaseButton`'s localization for tooltip text with shortcut

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -356,7 +356,7 @@ String BaseButton::get_tooltip(const Point2 &p_pos) const {
 	if (shortcut_in_tooltip && shortcut.is_valid() && shortcut->has_valid_event()) {
 		String text = shortcut->get_name() + " (" + shortcut->get_as_text() + ")";
 		if (!tooltip.is_empty() && shortcut->get_name().nocasecmp_to(tooltip) != 0) {
-			text += "\n" + tooltip;
+			text += "\n" + atr(tooltip);
 		}
 		tooltip = text;
 	}


### PR DESCRIPTION
Fix #56100