### PR TITLE
Print requested V-Sync mode when Print Fps is enabled

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1603,6 +1603,24 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		display_server->screen_set_orientation(window_orientation);
 	}
 
+	if (GLOBAL_GET("debug/settings/stdout/print_fps") || print_fps) {
+		// Print requested V-Sync mode at startup to diagnose the printed FPS not going above the monitor refresh rate.
+		switch (window_vsync_mode) {
+			case DisplayServer::VSyncMode::VSYNC_DISABLED:
+				print_line("Requested V-Sync mode: Disabled");
+				break;
+			case DisplayServer::VSyncMode::VSYNC_ENABLED:
+				print_line("Requested V-Sync mode: Enabled - FPS will likely be capped to the monitor refresh rate.");
+				break;
+			case DisplayServer::VSyncMode::VSYNC_ADAPTIVE:
+				print_line("Requested V-Sync mode: Adaptive");
+				break;
+			case DisplayServer::VSyncMode::VSYNC_MAILBOX:
+				print_line("Requested V-Sync mode: Mailbox");
+				break;
+		}
+	}
+
 	/* Initialize Pen Tablet Driver */
 
 	{


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/56110.

This can be used to diagnose why the printed FPS is locked to the monitor refresh rate.
Note that the OS may still override the actual V-Sync mode, but this should provide first steps for troubleshooting already.

See https://github.com/godotengine/godot/issues/56089#issuecomment-998144899.