### PR TITLE
[3.x] Fix BaseButton's localization for tooltip text with shortcut

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -363,7 +363,7 @@ String BaseButton::get_tooltip(const Point2 &p_pos) const {
 	if (shortcut_in_tooltip && shortcut.is_valid() && shortcut->is_valid()) {
 		String text = shortcut->get_name() + " (" + shortcut->get_as_text() + ")";
 		if (shortcut->get_name().nocasecmp_to(tooltip) != 0) {
-			text += "\n" + tooltip;
+			text += "\n" + tr(tooltip);
 		}
 		tooltip = text;
 	}


### PR DESCRIPTION

#56105 for 3.x