### PR TITLE
Print requested V-Sync mode when Print Fps is enabled (3.x)

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1312,6 +1312,22 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	}
 #endif
 
+	if (GLOBAL_GET("debug/settings/stdout/print_fps") || print_fps) {
+		// Print requested V-Sync mode at startup to diagnose the printed FPS not going above the monitor refresh rate.
+		if (OS::get_singleton()->_use_vsync && OS::get_singleton()->_vsync_via_compositor) {
+#ifdef WINDOWS_ENABLED
+			// V-Sync via compositor is only supported on Windows.
+			print_line("Requested V-Sync mode: Enabled (via compositor) - FPS will likely be capped to the monitor refresh rate.");
+#else
+			print_line("Requested V-Sync mode: Enabled - FPS will likely be capped to the monitor refresh rate.");
+#endif
+		} else if (OS::get_singleton()->_use_vsync) {
+			print_line("Requested V-Sync mode: Enabled - FPS will likely be capped to the monitor refresh rate.");
+		} else {
+			print_line("Requested V-Sync mode: Disabled");
+		}
+	}
+
 #ifdef UNIX_ENABLED
 	// Print warning before initializing audio.
 	if (OS::get_singleton()->get_environment("USER") == "root" && !OS::get_singleton()->has_environment("GODOT_SILENCE_ROOT_WARNING")) {


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/56106.
Note that the OS may still override the actual V-Sync mode, but this should provide first steps for troubleshooting already.

This can be used to diagnose why the printed FPS is locked to the monitor refresh rate.