### PR TITLE
`EditorAtlasPacker` Fix incorrectly deducing zero height in some cases

### DIFF
--- a/editor/editor_atlas_packer.cpp
+++ b/editor/editor_atlas_packer.cpp
@@ -233,12 +233,12 @@ void EditorAtlasPacker::chart_pack(Vector<Chart> &charts, int &r_width, int &r_h
 			const int *top_heights = bitmaps[i].top_heights.ptr();
 			const int *bottom_heights = bitmaps[i].bottom_heights.ptr();
 
-			for (int j = 0; j < atlas_w - w; j++) {
+			for (int j = 0; j <= atlas_w - w; j++) {
 				int height = 0;
 
 				for (int k = 0; k < w; k++) {
 					int pixmap_h = bottom_heights[k];
-					if (pixmap_h == -1) {
+					if (pixmap_h == 0x7FFFFFFF) {
 						continue; //no pixel here, anything is fine
 					}
 


### PR DESCRIPTION
Prior to this PR for images with width equal to the resulting atlas width the "tetris"/fitting part of the packing algorithm wouldn't be performed. As a result such images would be (possibly incorrectly) deducted to take zero height in the atlas.

Fixes #55998.

Not 100% sure it fixes packing for all cases but it seems to fix every test case provided in #55998.