### PR TITLE
i18n: Add `--lang` option to `make_rst.py` to write translated headings

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -3,6 +3,8 @@ CLASSES = $(BASEDIR)/classes/ $(BASEDIR)/../modules/
 OUTPUTDIR = $(BASEDIR)/_build
 TOOLSDIR = $(BASEDIR)/tools
 JSDIR = $(BASEDIR)/../platform/javascript
+LANGARG ?= en
+LANGCMD = -l $(LANGARG)
 
 .ONESHELL:
 
@@ -17,7 +19,7 @@ doxygen:
 rst:
 	rm -rf $(OUTPUTDIR)/rst
 	mkdir -p $(OUTPUTDIR)/rst
-	python3 $(TOOLSDIR)/make_rst.py -o $(OUTPUTDIR)/rst $(CLASSES)
+	python3 $(TOOLSDIR)/make_rst.py -o $(OUTPUTDIR)/rst $(LANGCMD) $(CLASSES)
 
 rstjs:
 	rm -rf $(OUTPUTDIR)/rstjs

--- a/doc/translations/extract.py
+++ b/doc/translations/extract.py
@@ -26,17 +26,22 @@ msgstr ""
 """
 # Some strings used by make_rst.py are normally part of the editor translations,
 # so we need to include them manually here for the online docs.
-BASE_STRINGS = [
+HEADINGS = [
     "Description",
     "Tutorials",
     "Properties",
+    "Constructors",
     "Methods",
+    "Operators",
     "Theme Properties",
     "Signals",
     "Enumerations",
     "Constants",
     "Property Descriptions",
+    "Constructor Descriptions",
     "Method Descriptions",
+    "Operator Descriptions",
+    "Theme Property Descriptions",
 ]
 
 ## <xml-line-number-hack from="https://stackoverflow.com/a/36430270/10846399">
@@ -224,12 +229,12 @@ def _make_translation_catalog(classes):
 def _generate_translation_catalog_file(unique_msgs, output):
     with open(output, "w", encoding="utf8") as f:
         f.write(HEADER)
-        for msg in BASE_STRINGS:
+        for msg in HEADINGS:
             f.write("#: doc/tools/make_rst.py\n")
             f.write('msgid "{}"\n'.format(msg))
             f.write('msgstr ""\n\n')
         for msg in unique_msgs:
-            if len(msg) == 0 or msg in BASE_STRINGS:
+            if len(msg) == 0 or msg in HEADINGS:
                 continue
 
             f.write("#:")


### PR DESCRIPTION
Add a few missing headings to the translation templates.

Note: Adds a dependency on [`polib`](https://pypi.org/project/polib/), but only for using the new option.
It can be used like this:
```
cd doc
make rst LANGARG=zh_CN
```
or manually by passing `--lang zh_CN` or similar to the `make_rst.py` call.