### PR TITLE
Refactor render_mode in shaders, forbid declaring duplicates

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -138,8 +138,18 @@ void ShaderTextEditor::_load_theme_settings() {
 			}
 		}
 
-		for (int i = 0; i < ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(shader->get_mode())).size(); i++) {
-			built_ins.push_back(ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(shader->get_mode()))[i]);
+		const Vector<ShaderLanguage::ModeInfo> &modes = ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(shader->get_mode()));
+
+		for (int i = 0; i < modes.size(); i++) {
+			const ShaderLanguage::ModeInfo &info = modes[i];
+
+			if (!info.options.is_empty()) {
+				for (int j = 0; j < info.options.size(); j++) {
+					built_ins.push_back(String(info.name) + "_" + String(info.options[j]));
+				}
+			} else {
+				built_ins.push_back(String(info.name));
+			}
 		}
 	}
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -102,8 +102,6 @@ private:
 	HashMap<String, int> modes;
 	Set<StringName> flags;
 
-	static RenderModeEnums render_mode_enums[];
-
 	mutable SafeFlag dirty;
 	void _queue_update();
 

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -819,6 +819,57 @@ public:
 		DataType return_type = TYPE_VOID;
 	};
 
+	struct ModeInfo {
+		StringName name;
+		Vector<StringName> options;
+
+		ModeInfo() {}
+
+		ModeInfo(const StringName &p_name) :
+				name(p_name) {
+		}
+
+		ModeInfo(const StringName &p_name, const StringName &p_arg1, const StringName &p_arg2) :
+				name(p_name) {
+			options.push_back(p_arg1);
+			options.push_back(p_arg2);
+		}
+
+		ModeInfo(const StringName &p_name, const StringName &p_arg1, const StringName &p_arg2, const StringName &p_arg3) :
+				name(p_name) {
+			options.push_back(p_arg1);
+			options.push_back(p_arg2);
+			options.push_back(p_arg3);
+		}
+
+		ModeInfo(const StringName &p_name, const StringName &p_arg1, const StringName &p_arg2, const StringName &p_arg3, const StringName &p_arg4) :
+				name(p_name) {
+			options.push_back(p_arg1);
+			options.push_back(p_arg2);
+			options.push_back(p_arg3);
+			options.push_back(p_arg4);
+		}
+
+		ModeInfo(const StringName &p_name, const StringName &p_arg1, const StringName &p_arg2, const StringName &p_arg3, const StringName &p_arg4, const StringName &p_arg5) :
+				name(p_name) {
+			options.push_back(p_arg1);
+			options.push_back(p_arg2);
+			options.push_back(p_arg3);
+			options.push_back(p_arg4);
+			options.push_back(p_arg5);
+		}
+
+		ModeInfo(const StringName &p_name, const StringName &p_arg1, const StringName &p_arg2, const StringName &p_arg3, const StringName &p_arg4, const StringName &p_arg5, const StringName &p_arg6) :
+				name(p_name) {
+			options.push_back(p_arg1);
+			options.push_back(p_arg2);
+			options.push_back(p_arg3);
+			options.push_back(p_arg4);
+			options.push_back(p_arg5);
+			options.push_back(p_arg6);
+		}
+	};
+
 	struct FunctionInfo {
 		Map<StringName, BuiltInInfo> built_ins;
 		Map<StringName, StageFunctionInfo> stage_functions;
@@ -1013,7 +1064,7 @@ private:
 	String _get_shader_type_list(const Set<String> &p_shader_types) const;
 	String _get_qualifier_str(ArgumentQualifier p_qualifier) const;
 
-	Error _parse_shader(const Map<StringName, FunctionInfo> &p_functions, const Vector<StringName> &p_render_modes, const Set<String> &p_shader_types);
+	Error _parse_shader(const Map<StringName, FunctionInfo> &p_functions, const Vector<ModeInfo> &p_render_modes, const Set<String> &p_shader_types);
 
 	Error _find_last_flow_op_in_block(BlockNode *p_block, FlowOperation p_op);
 	Error _find_last_flow_op_in_op(ControlFlowNode *p_flow, FlowOperation p_op);
@@ -1037,7 +1088,7 @@ public:
 
 	struct ShaderCompileInfo {
 		Map<StringName, FunctionInfo> functions;
-		Vector<StringName> render_modes;
+		Vector<ModeInfo> render_modes;
 		VaryingFunctionNames varying_function_names = VaryingFunctionNames();
 		Set<String> shader_types;
 		GlobalVariableGetTypeFunc global_variable_type_func = nullptr;

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -35,7 +35,7 @@ const Map<StringName, ShaderLanguage::FunctionInfo> &ShaderTypes::get_functions(
 	return shader_modes[p_mode].functions;
 }
 
-const Vector<StringName> &ShaderTypes::get_modes(RS::ShaderMode p_mode) const {
+const Vector<ShaderLanguage::ModeInfo> &ShaderTypes::get_modes(RS::ShaderMode p_mode) const {
 	return shader_modes[p_mode].modes;
 }
 
@@ -190,53 +190,29 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].can_discard = true;
 	shader_modes[RS::SHADER_SPATIAL].functions["light"].main_function = true;
 
-	//order used puts first enum mode (default) first
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("blend_mix");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("blend_add");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("blend_sub");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("blend_mul");
-
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("depth_draw_opaque");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("depth_draw_always");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("depth_draw_never");
-
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("depth_prepass_alpha");
-
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("depth_test_disabled");
-
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("sss_mode_skin");
-
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("cull_back");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("cull_front");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("cull_disabled");
-
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("unshaded");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("wireframe");
-
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("diffuse_lambert");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("diffuse_lambert_wrap");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("diffuse_burley");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("diffuse_toon");
-
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("specular_schlick_ggx");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("specular_blinn");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("specular_phong");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("specular_toon");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("specular_disabled");
-
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("skip_vertex_transform");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("world_vertex_coords");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("ensure_correct_normals");
-
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("shadows_disabled");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("ambient_light_disabled");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("shadow_to_opacity");
-
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("vertex_lighting");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("particle_trails");
-
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("alpha_to_coverage");
-	shader_modes[RS::SHADER_SPATIAL].modes.push_back("alpha_to_coverage_and_one");
+	// spatial render modes
+	{
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "blend", "mix", "add", "sub", "mul" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "depth_draw", "opaque", "always", "never" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "depth_prepass_alpha" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "depth_test_disabled" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "sss_mode_skin" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "cull", "back", "front", "disabled" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "unshaded" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "wireframe" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "diffuse", "lambert", "lambert_wrap", "burley", "toon" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "specular", "schlick_ggx", "blinn", "phong", "toon", "disabled" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "skip_vertex_transform" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "world_vertex_coords" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "ensure_correct_normals" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "shadows_disabled" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "ambient_light_disabled" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "shadow_to_opacity" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "vertex_lighting" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "particle_trails" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "alpha_to_coverage" });
+		shader_modes[RS::SHADER_SPATIAL].modes.push_back({ "alpha_to_coverage_and_one" });
+	}
 
 	/************ CANVAS ITEM **************************/
 
@@ -319,17 +295,13 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_CANVAS_ITEM].functions["light"].can_discard = true;
 	shader_modes[RS::SHADER_CANVAS_ITEM].functions["light"].main_function = true;
 
-	shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back("skip_vertex_transform");
-
-	shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back("blend_mix");
-	shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back("blend_add");
-	shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back("blend_sub");
-	shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back("blend_mul");
-	shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back("blend_premul_alpha");
-	shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back("blend_disabled");
-
-	shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back("unshaded");
-	shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back("light_only");
+	// canvasitem render modes
+	{
+		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ "skip_vertex_transform" });
+		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ "blend", "mix", "add", "sub", "mul", "premul_alpha", "disabled" });
+		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ "unshaded" });
+		shader_modes[RS::SHADER_CANVAS_ITEM].modes.push_back({ "light_only" });
+	}
 
 	/************ PARTICLES **************************/
 
@@ -392,10 +364,13 @@ ShaderTypes::ShaderTypes() {
 		shader_modes[RS::SHADER_PARTICLES].functions["process"].stage_functions["emit_subparticle"] = emit_vertex_func;
 	}
 
-	shader_modes[RS::SHADER_PARTICLES].modes.push_back("collision_use_scale");
-	shader_modes[RS::SHADER_PARTICLES].modes.push_back("disable_force");
-	shader_modes[RS::SHADER_PARTICLES].modes.push_back("disable_velocity");
-	shader_modes[RS::SHADER_PARTICLES].modes.push_back("keep_data");
+	// particles render modes
+	{
+		shader_modes[RS::SHADER_PARTICLES].modes.push_back({ "collision_use_scale" });
+		shader_modes[RS::SHADER_PARTICLES].modes.push_back({ "disable_force" });
+		shader_modes[RS::SHADER_PARTICLES].modes.push_back({ "disable_velocity" });
+		shader_modes[RS::SHADER_PARTICLES].modes.push_back({ "keep_data" });
+	}
 
 	/************ SKY **************************/
 
@@ -439,9 +414,12 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SKY].functions["sky"].built_ins["FOG"] = ShaderLanguage::TYPE_VEC4;
 	shader_modes[RS::SHADER_SKY].functions["sky"].main_function = true;
 
-	shader_modes[RS::SHADER_SKY].modes.push_back("use_half_res_pass");
-	shader_modes[RS::SHADER_SKY].modes.push_back("use_quarter_res_pass");
-	shader_modes[RS::SHADER_SKY].modes.push_back("disable_fog");
+	// sky render modes
+	{
+		shader_modes[RS::SHADER_SKY].modes.push_back({ "use_half_res_pass" });
+		shader_modes[RS::SHADER_SKY].modes.push_back({ "use_quarter_res_pass" });
+		shader_modes[RS::SHADER_SKY].modes.push_back({ "disable_fog" });
+	}
 
 	/************ FOG **************************/
 

--- a/servers/rendering/shader_types.h
+++ b/servers/rendering/shader_types.h
@@ -38,7 +38,7 @@
 class ShaderTypes {
 	struct Type {
 		Map<StringName, ShaderLanguage::FunctionInfo> functions;
-		Vector<StringName> modes;
+		Vector<ShaderLanguage::ModeInfo> modes;
 	};
 
 	Map<RS::ShaderMode, Type> shader_modes;
@@ -52,7 +52,7 @@ public:
 	static ShaderTypes *get_singleton() { return singleton; }
 
 	const Map<StringName, ShaderLanguage::FunctionInfo> &get_functions(RS::ShaderMode p_mode) const;
-	const Vector<StringName> &get_modes(RS::ShaderMode p_mode) const;
+	const Vector<ShaderLanguage::ModeInfo> &get_modes(RS::ShaderMode p_mode) const;
 	const Set<String> &get_types() const;
 	const List<String> &get_types_list() const;
 

--- a/tests/servers/test_shader_lang.cpp
+++ b/tests/servers/test_shader_lang.cpp
@@ -341,8 +341,8 @@ MainLoop *test() {
 	dt["fragment"].built_ins["ALBEDO"] = SL::TYPE_VEC3;
 	dt["fragment"].can_discard = true;
 
-	Vector<StringName> rm;
-	rm.push_back("popo");
+	Vector<SL::ModeInfo> rm;
+	rm.push_back({ "popo" });
 	Set<String> types;
 	types.insert("spatial");
 


### PR DESCRIPTION
Currently, users can declare multiple (self-exclusive) render modes in the shader which I think is not good (it's confusing and error-prone).

After this refactoring it's no longer possible:

![image](https://user-images.githubusercontent.com/3036176/146965253-d2a3b8cc-8425-4ddf-8815-2acb0174de4f.png)
