### PR TITLE
Fix Android Studio builds

### DIFF
--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -124,8 +124,11 @@ task zipCustomBuild(type: Zip) {
 def templateExcludedBuildTask() {
     // We exclude these gradle tasks so we can run the scons command manually.
     def excludedTasks = []
-    for (String buildType : supportedTargets) {
-        excludedTasks += ":lib:" + getSconsTaskName(buildType)
+    if (!isAndroidStudio()) {
+        logger.lifecycle("Excluding Android studio build tasks")
+        for (String buildType : supportedTargets) {
+            excludedTasks += ":lib:" + getSconsTaskName(buildType)
+        }
     }
     return excludedTasks
 }
@@ -153,6 +156,11 @@ def templateBuildTasks() {
     }
 
     return tasks
+}
+
+def isAndroidStudio() {
+    def sysProps = System.getProperties()
+    return sysProps != null && sysProps['idea.platform.prefix'] != null
 }
 
 /**


### PR DESCRIPTION
The previous logic excluded tasks that are necessary when building from within Android Studio. 
With this update, we only exclude these tasks when we detect we're building outside of Android Studio.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
