### PR TITLE
Move functionality automatically setting roughness/metallic on texture assignment to editor callback

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -53,7 +53,6 @@
 			<argument index="1" name="texture" type="Texture2D" />
 			<description>
 				Sets the texture for the slot specified by [code]param[/code]. See [enum TextureParam] for available slots.
-				[b]Note:[/b] When setting a roughness or metallic texture on a material that has no texture assigned to those slots, [member roughness] or [member metallic] will automatically be set to [code]1.0[/code] to ensure correct appearance.
 			</description>
 		</method>
 	</methods>
@@ -233,7 +232,6 @@
 		</member>
 		<member name="metallic" type="float" setter="set_metallic" getter="get_metallic" default="0.0">
 			A high value makes the material appear more like a metal. Non-metals use their albedo as the diffuse color and add diffuse to the specular reflection. With non-metals, the reflection appears on top of the albedo color. Metals use their albedo as a multiplier to the specular reflection and set the diffuse color to black resulting in a tinted reflection. Materials work better when fully metal or fully non-metal, values between [code]0[/code] and [code]1[/code] should only be used for blending between metal and non-metal sections. To alter the amount of reflection use [member roughness].
-			[b]Note:[/b] [member metallic] is automatically set to [code]1.0[/code] when assigning a metallic texture using [method set_texture].
 		</member>
 		<member name="metallic_specular" type="float" setter="set_specular" getter="get_specular" default="0.5">
 			Sets the size of the specular lobe. The specular lobe is the bright spot that is reflected from light sources.
@@ -306,7 +304,6 @@
 		</member>
 		<member name="roughness" type="float" setter="set_roughness" getter="get_roughness" default="1.0">
 			Surface reflection. A value of [code]0[/code] represents a perfect mirror while a value of [code]1[/code] completely blurs the reflection. See also [member metallic].
-			[b]Note:[/b] [member roughness] is automatically set to [code]1.0[/code] when assigning a roughness texture using [method set_texture].
 		</member>
 		<member name="roughness_texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			Texture used to control the roughness per-pixel. Multiplied by [member roughness].

--- a/editor/plugins/material_editor_plugin.h
+++ b/editor/plugins/material_editor_plugin.h
@@ -92,6 +92,8 @@ public:
 	virtual bool can_handle(Object *p_object) override;
 	virtual void parse_begin(Object *p_object) override;
 
+	void _undo_redo_inspector_callback(Object *p_undo_redo, Object *p_edited, String p_property, Variant p_new_value);
+
 	EditorInspectorPluginMaterial();
 };
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1659,18 +1659,6 @@ bool BaseMaterial3D::get_feature(Feature p_feature) const {
 void BaseMaterial3D::set_texture(TextureParam p_param, const Ref<Texture2D> &p_texture) {
 	ERR_FAIL_INDEX(p_param, TEXTURE_MAX);
 
-	if (get_texture(TEXTURE_ROUGHNESS).is_null() && p_texture.is_valid() && p_param == TEXTURE_ROUGHNESS) {
-		// If no roughness texture is currently set, automatically set the recommended value
-		// for roughness when using a roughness map.
-		set_roughness(1.0);
-	}
-
-	if (get_texture(TEXTURE_METALLIC).is_null() && p_texture.is_valid() && p_param == TEXTURE_METALLIC) {
-		// If no metallic texture is currently set, automatically set the recommended value
-		// for metallic when using a metallic map.
-		set_metallic(1.0);
-	}
-
 	textures[p_param] = p_texture;
 	RID rid = p_texture.is_valid() ? p_texture->get_rid() : RID();
 	RS::get_singleton()->material_set_param(_get_material(), shader_names->texture_names[p_param], rid);


### PR DESCRIPTION
This PR changes the hardcoded behaviour in BaseTexture3D where if you set assign a roughness of metallic texture to the material when one hasn't already been set, it will also set the corresponding roughness/metallic factor to 1.0 as a convenience feature to the user. However, setting it here introduces several problems. Due to the order of the properties, any time a material is loaded, since the roughness/metallic texture is loaded after its respective factor, any changes to this factor will be lost and will permenantly stuck as 1.0 regardless as what it's set at. This can introduce problems for things such as the GLTF importer, where Blender will sometimes create ORM maps for materials without metal, and make the ORM map's metallic channel white, but the corresponding metallic factor as 0.0. This gets ignored due to this bug and results in non-metallic objects becoming metallic.

In order to keep the same functionality while fixing bugs in the material loader, the code to automatically set the roughness/metallic factor to 1.0 if a new texture is added, has been moved to an UndoRedo inspector callback, so it will only change the factors if textures are explicitly assigned by the user via the inspector.

This PR must also be merged to avoid a bug which is caused by queing up both a texture and generic uniform update together (#56563).