### PR TITLE
Fix descriptions of set_cell and set_cellv in TileMap.xml

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -133,7 +133,7 @@
 			<argument index="5" name="transpose" type="bool" default="false" />
 			<argument index="6" name="autotile_coord" type="Vector2" default="Vector2( 0, 0 )" />
 			<description>
-				Sets the tile index for the cell given by a Vector2.
+				Sets the tile index for the given cell.
 				An index of [code]-1[/code] clears the cell.
 				Optionally, the tile can also be flipped, transposed, or given autotile coordinates. The autotile coordinate refers to the column and row of the subtile.
 				[b]Note:[/b] Data such as navigation polygons and collision shapes are not immediately updated for performance reasons.
@@ -155,7 +155,7 @@
 			<argument index="3" name="flip_y" type="bool" default="false" />
 			<argument index="4" name="transpose" type="bool" default="false" />
 			<description>
-				Sets the tile index for the given cell.
+				Sets the tile index for the cell given by a Vector2.
 				An index of [code]-1[/code] clears the cell.
 				Optionally, the tile can also be flipped or transposed.
 				[b]Note:[/b] Data such as navigation polygons and collision shapes are not immediately updated for performance reasons.


### PR DESCRIPTION
Swap the first lines of the descriptions for set_cell and set_cellv to correctly describe which accepts a Vector2 as an argument and which accepts x and y as separate arguments.

Fix not relevant to master branch due to changes to TileMap.