### PR TITLE
Fix issue with external textures being freed by Godot

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5264,6 +5264,7 @@ void RasterizerStorageGLES2::_render_target_clear(RenderTarget *rt) {
 
 		// clean up our texture
 		Texture *t = texture_owner.get(rt->external.texture);
+		t->tex_id = 0;
 		t->alloc_height = 0;
 		t->alloc_width = 0;
 		t->width = 0;
@@ -5428,6 +5429,7 @@ void RasterizerStorageGLES2::render_target_set_external_texture(RID p_render_tar
 
 			// clean up our texture
 			Texture *t = texture_owner.get(rt->external.texture);
+			t->tex_id = 0;
 			t->alloc_height = 0;
 			t->alloc_width = 0;
 			t->width = 0;

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -6850,6 +6850,7 @@ void RasterizerStorageGLES3::_render_target_clear(RenderTarget *rt) {
 
 		// clean up our texture
 		Texture *t = texture_owner.get(rt->external.texture);
+		t->tex_id = 0;
 		t->alloc_height = 0;
 		t->alloc_width = 0;
 		t->width = 0;
@@ -7359,6 +7360,7 @@ void RasterizerStorageGLES3::render_target_set_external_texture(RID p_render_tar
 
 			// clean up our texture
 			Texture *t = texture_owner.get(rt->external.texture);
+			t->tex_id = 0;
 			t->alloc_height = 0;
 			t->alloc_width = 0;
 			t->width = 0;


### PR DESCRIPTION
This fix applies to Godot 3.x only.

I'm not sure what changed or when but this issue was around for awhile. I think this originally worked because the allocation size was checked as part of the cleanup.

Anyway, the situation here is when an XR Interface supplies the textures into which a viewport is rendered instead of us using Godots own textures. A texture object is created that wraps around the supplier OpenGL texture id so we can do stuff like using the texture to render out a preview.

During cleanup of a render target this texture object is destroyed and it destroys it's OpenGL texture alongside it. In this case it shouldn't because this texture was never created by Godot, it was created by the XR interface. If the render target is cleaned up because settings on the viewport change that require re-creating it with different settings, the result is flashing inside of the headset as one of the textures in the texture chain has gone byebye.  

The fix here is really simple, in the two places in each driver where this texture is destroyed, we set the `tex_id` value to zero preventing it being destroyed by Godot (it will be cleaned up by the plugin when required).