### PR TITLE
Fix array variant reuse in constructor

### DIFF
--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -344,7 +344,7 @@ public:
 			return;
 		}
 
-		VariantTypeChanger<Array>::change(&r_ret);
+		r_ret = Array();
 		Array &dst_arr = *VariantGetInternalPtr<Array>::get_ptr(&r_ret);
 		const T &src_arr = *VariantGetInternalPtr<T>::get_ptr(p_args[0]);
 
@@ -356,7 +356,7 @@ public:
 	}
 
 	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {
-		VariantTypeChanger<Array>::change(r_ret);
+		*r_ret = Array();
 		Array &dst_arr = *VariantGetInternalPtr<Array>::get_ptr(r_ret);
 		const T &src_arr = *VariantGetInternalPtr<T>::get_ptr(p_args[0]);
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes #55093
Similar to  #55939

Issue Summary:
```gd
var packed_a := PackedVector3Array()
packed_a.append(Vector3(1, 2, 3))
var packed_b := PackedVector3Array()
packed_b.append(Vector3(4, 5, 6))
var a = Array(packed_a)
print('a: ', a)
print('b: ', 'doesn\'t exist yet')
var b = Array(packed_b)
print('a: ', a)
print('b: ', b)
```
```
a: [(1, 2, 3)]
b: doesn't exist yet
a: [(4, 5, 6)]
b: [(4, 5, 6)]
```

The issue occurs because `VariantConstructorToArray::validated_construct` operates on the existing `Array` of the destination variant.

Calling `VariantTypeChanger<Array>::change` isn't enough because the variant retains its `Array` if its current type is already `ARRAY`.

PS: A similar issue could have happened in the special constructors of `Packed*Array` (`VariantConstructorFromArray`) but doesn't happen due to the behavior of `VariantTypeChanger::change`, where it re-initializes `PACKED_T_ARRAY` types regardless of the current type, which I find weird.