### PR TITLE
Assume that non registered properties default to null

### DIFF
--- a/scene/property_utils.cpp
+++ b/scene/property_utils.cpp
@@ -114,7 +114,12 @@ Variant PropertyUtils::get_property_default_value(const Object *p_object, const 
 	if (r_is_class_default) {
 		*r_is_class_default = true;
 	}
-	return ClassDB::class_get_default_property_value(p_object->get_class_name(), p_property, r_is_valid);
+	// This is saying that properties not registered in the class DB are considered to have a default value of null
+	// (that covers cases like synthetic properties in the style of whatever/0, whatever/1, which may not have a value in any ancestor).
+	if (r_is_valid) {
+		*r_is_valid = true;
+	}
+	return ClassDB::class_get_default_property_value(p_object->get_class_name(), p_property);
 }
 
 // Like SceneState::PackState, but using a raw pointer to avoid the cost of


### PR DESCRIPTION
I've found that mesh instances in a scene derived from an imported glTF were getting all the relevant `surface_material_override/*` properties saved to the .tscn file, despite being `null`. That was caused by the last change that introduced the separation between the meaning of null as 'no default found' and null as the actual default value. That was good for the kind of cases fixed by such change, but was also affecting the cases where no default value is found at all for a property, where we are happy considering null is a reasonable default.