### PR TITLE
Allow pass varyings as out param to the function, when it's possible

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -938,14 +938,6 @@ private:
 
 	VaryingFunctionNames varying_function_names;
 
-	struct VaryingUsage {
-		ShaderNode::Varying *var;
-		int line;
-	};
-	List<VaryingUsage> unknown_varying_usages;
-
-	bool _check_varying_usages(int *r_error_line, String *r_error_message) const;
-
 	TkPos _get_tkpos() {
 		TkPos tkp;
 		tkp.char_idx = char_idx;
@@ -1047,7 +1039,6 @@ private:
 	bool _propagate_function_call_sampler_uniform_settings(StringName p_name, int p_argument, TextureFilter p_filter, TextureRepeat p_repeat);
 	bool _propagate_function_call_sampler_builtin_reference(StringName p_name, int p_argument, const StringName &p_builtin);
 	bool _validate_varying_assign(ShaderNode::Varying &p_varying, String *r_message);
-	bool _validate_varying_using(ShaderNode::Varying &p_varying, String *r_message);
 	bool _check_node_constness(const Node *p_node) const;
 
 	Node *_parse_array_size(BlockNode *p_block, const FunctionInfo &p_function_info, int &r_array_size);


### PR DESCRIPTION
I think it makes sense to allow user pass varying to the functions for writing, but only in a certain context:

![image](https://user-images.githubusercontent.com/3036176/147231896-d6fe21b7-f632-49f1-b777-a2d3505be811.png)

In the following example 't' belongs to STAGE_VERTEX_TO_FRAGMENT_LIGHT varyings so it may be modified by the function call placed in the vertex function.

Fix #56189

UPDATED:

Also fixed shader crash when varying has been passed (even when it is `in` parameter) but in incorrect context eg:

```
vec3 foo(in vec3 test){
	return test;
}

void fragment(){
	t = vec3(0, 0, 1);
	vec3 v = foo(t);
}
void vertex() {
	vec3 v = foo(t); // CRASH
}

void light() {
}
```
