### PR TITLE
fix update mode not refreshing visually on undo

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -2715,6 +2715,7 @@ void Animation::value_track_set_update_mode(int p_track, UpdateMode p_mode) {
 
 	ValueTrack *vt = static_cast<ValueTrack *>(t);
 	vt->update_mode = p_mode;
+	emit_changed();
 }
 
 Animation::UpdateMode Animation::value_track_get_update_mode(int p_track) const {


### PR DESCRIPTION
Fixes #55941

There was a missing `emit_changed()` for `value_track_set_update_mode()` that was present in `track_set_interpolation_type()` and `track_set_interpolation_loop_wrap()`.

Now properly updates the update mode icon for tracks on undo.