### PR TITLE
GPULightmapper: cube to panorama copy function flip y based on flag

### DIFF
--- a/servers/rendering/renderer_rd/shaders/copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/copy.glsl
@@ -256,7 +256,9 @@ void main() {
 
 	const float PI = 3.14159265359;
 	vec2 uv = vec2(pos) / vec2(params.section.zw);
-	uv.y = 1.0 - uv.y;
+	if (bool(params.flags & FLAG_FLIP_Y)) {
+		uv.y = 1.0 - uv.y;
+	}
 	float phi = uv.x * 2.0 * PI;
 	float theta = uv.y * PI;
 


### PR DESCRIPTION
Cube to panorama copy function unconditionally flipped y, while other copy functions flipped y base on FLAG_FLIP_Y. Condition is added.

This fixes #56079.
