### PR TITLE
Prevent crashes on exported project relating to Skin resource

### DIFF
--- a/scene/resources/skin.h
+++ b/scene/resources/skin.h
@@ -67,23 +67,17 @@ public:
 	void set_bind_name(int p_index, const StringName &p_name);
 
 	inline int get_bind_bone(int p_index) const {
-#ifdef DEBUG_ENABLED
 		ERR_FAIL_INDEX_V(p_index, bind_count, -1);
-#endif
 		return binds_ptr[p_index].bone;
 	}
 
 	inline StringName get_bind_name(int p_index) const {
-#ifdef DEBUG_ENABLED
 		ERR_FAIL_INDEX_V(p_index, bind_count, StringName());
-#endif
 		return binds_ptr[p_index].name;
 	}
 
 	inline Transform3D get_bind_pose(int p_index) const {
-#ifdef DEBUG_ENABLED
 		ERR_FAIL_INDEX_V(p_index, bind_count, Transform3D());
-#endif
 		return binds_ptr[p_index].pose;
 	}
 


### PR DESCRIPTION
Prevents crashes in the release build of an exported project when calling Skin::get_bind_bone, Skin::get_bind_name, and Skin::get_bind_pose

Resolves #47358