### PR TITLE
Fix get_v_scroll() desctiption in ItemList

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -158,7 +158,7 @@
 		<method name="get_v_scroll">
 			<return type="VScrollBar" />
 			<description>
-				Returns the [Object] ID associated with the list.
+				Returns the vertical scrollbar.
 				[b]Warning:[/b] This is a required internal node, removing and freeing it may cause a crash. If you wish to hide it or any of its children, use their [member CanvasItem.visible] property.
 			</description>
 		</method>


### PR DESCRIPTION
The description was changed in #29676, but it doesn't make any sense.