### PR TITLE
Fix 'Compiler bug: unresolved assign' errors on member setters

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -1094,6 +1094,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					is_in_setter = has_setter && setter_function == codegen.function_name;
 					member.mode = GDScriptCodeGenerator::Address::MEMBER;
 					member.address = codegen.script->member_indices[var_name].index;
+					member.type = codegen.script->member_indices[var_name].data_type;
 				}
 
 				GDScriptCodeGenerator::Address target;


### PR DESCRIPTION
Closes #54450

Alternative approach to fixing this problem. Derives the data type from the corresponding member for setters. Requesting review from @vnen to see if this is a more appropriate way to fix this bug.