### PR TITLE
Improve Visual Script editor to suggest the proper visual script nodes.

### DIFF
--- a/modules/visual_script/editor/visual_script_editor.h
+++ b/modules/visual_script/editor/visual_script_editor.h
@@ -85,55 +85,55 @@ class VisualScriptEditor : public ScriptEditorBase {
 		MEMBER_SIGNAL
 	};
 
-	VBoxContainer *members_section;
-	MenuButton *edit_menu;
+	VBoxContainer *members_section = nullptr;
+	MenuButton *edit_menu = nullptr;
 
 	Ref<VisualScript> script;
 
-	Button *base_type_select;
+	Button *base_type_select = nullptr;
 
-	LineEdit *func_name_box;
-	ScrollContainer *func_input_scroll;
-	VBoxContainer *func_input_vbox;
-	ConfirmationDialog *function_create_dialog;
+	LineEdit *func_name_box = nullptr;
+	ScrollContainer *func_input_scroll = nullptr;
+	VBoxContainer *func_input_vbox = nullptr;
+	ConfirmationDialog *function_create_dialog = nullptr;
 
-	GraphEdit *graph;
-	HBoxContainer *status_bar;
-	Button *toggle_scripts_button;
+	GraphEdit *graph = nullptr;
+	HBoxContainer *status_bar = nullptr;
+	Button *toggle_scripts_button = nullptr;
 
-	VisualScriptEditorSignalEdit *signal_editor;
+	VisualScriptEditorSignalEdit *signal_editor = nullptr;
 
-	AcceptDialog *edit_signal_dialog;
-	EditorInspector *edit_signal_edit;
+	AcceptDialog *edit_signal_dialog = nullptr;
+	EditorInspector *edit_signal_edit = nullptr;
 
-	VisualScriptPropertySelector *method_select;
-	VisualScriptPropertySelector *new_connect_node_select;
-	VisualScriptPropertySelector *new_virtual_method_select;
+	VisualScriptPropertySelector *method_select = nullptr;
+	VisualScriptPropertySelector *new_connect_node_select = nullptr;
+	VisualScriptPropertySelector *new_virtual_method_select = nullptr;
 
-	VisualScriptEditorVariableEdit *variable_editor;
+	VisualScriptEditorVariableEdit *variable_editor = nullptr;
 
-	AcceptDialog *edit_variable_dialog;
-	EditorInspector *edit_variable_edit;
+	AcceptDialog *edit_variable_dialog = nullptr;
+	EditorInspector *edit_variable_edit = nullptr;
 
-	CustomPropertyEditor *default_value_edit;
+	CustomPropertyEditor *default_value_edit = nullptr;
 
-	UndoRedo *undo_redo;
+	UndoRedo *undo_redo = nullptr;
 
-	Tree *members;
-	AcceptDialog *function_name_edit;
-	LineEdit *function_name_box;
+	Tree *members = nullptr;
+	AcceptDialog *function_name_edit = nullptr;
+	LineEdit *function_name_box = nullptr;
 
-	Label *hint_text;
-	Timer *hint_text_timer;
+	Label *hint_text = nullptr;
+	Timer *hint_text_timer = nullptr;
 
-	Label *select_func_text;
+	Label *select_func_text = nullptr;
 
 	bool updating_graph = false;
 
 	void _show_hint(const String &p_hint);
 	void _hide_timer();
 
-	CreateDialog *select_base_type;
+	CreateDialog *select_base_type = nullptr;
 
 	struct VirtualInMenu {
 		String name;
@@ -241,7 +241,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	bool node_has_sequence_connections(int p_id);
 
-	void _generic_search(String p_base_type = "", Vector2 pos = Vector2(), bool node_centered = false);
+	void _generic_search(Vector2 pos = Vector2(), bool node_centered = false);
 
 	virtual void input(const Ref<InputEvent> &p_event) override;
 	void _graph_gui_input(const Ref<InputEvent> &p_event);

--- a/modules/visual_script/editor/visual_script_property_selector.cpp
+++ b/modules/visual_script/editor/visual_script_property_selector.cpp
@@ -37,13 +37,28 @@
 #include "../visual_script_nodes.h"
 #include "core/os/keyboard.h"
 #include "editor/doc_tools.h"
+#include "editor/editor_feature_profile.h"
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 #include "scene/main/node.h"
 #include "scene/main/window.h"
 
-void VisualScriptPropertySelector::_text_changed(const String &p_newtext) {
-	_update_search();
+void VisualScriptPropertySelector::_update_icons() {
+	search_box->set_right_icon(results_tree->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
+	search_box->set_clear_button_enabled(true);
+	search_box->add_theme_icon_override("right_icon", results_tree->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
+
+	search_visual_script_nodes->set_icon(results_tree->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons")));
+	search_classes->set_icon(results_tree->get_theme_icon(SNAME("Object"), SNAME("EditorIcons")));
+	search_methods->set_icon(results_tree->get_theme_icon(SNAME("MemberMethod"), SNAME("EditorIcons")));
+	search_operators->set_icon(results_tree->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+	search_signals->set_icon(results_tree->get_theme_icon(SNAME("MemberSignal"), SNAME("EditorIcons")));
+	search_constants->set_icon(results_tree->get_theme_icon(SNAME("MemberConstant"), SNAME("EditorIcons")));
+	search_properties->set_icon(results_tree->get_theme_icon(SNAME("MemberProperty"), SNAME("EditorIcons")));
+	search_theme_items->set_icon(results_tree->get_theme_icon(SNAME("MemberTheme"), SNAME("EditorIcons")));
+
+	case_sensitive_button->set_icon(results_tree->get_theme_icon(SNAME("MatchCase"), SNAME("EditorIcons")));
+	hierarchy_button->set_icon(results_tree->get_theme_icon(SNAME("ClassList"), SNAME("EditorIcons")));
 }
 
 void VisualScriptPropertySelector::_sbox_input(const Ref<InputEvent> &p_ie) {
@@ -55,24 +70,8 @@ void VisualScriptPropertySelector::_sbox_input(const Ref<InputEvent> &p_ie) {
 			case Key::DOWN:
 			case Key::PAGEUP:
 			case Key::PAGEDOWN: {
-				search_options->gui_input(k);
+				results_tree->gui_input(k);
 				search_box->accept_event();
-
-				TreeItem *root = search_options->get_root();
-				if (!root->get_first_child()) {
-					break;
-				}
-
-				TreeItem *current = search_options->get_selected();
-
-				TreeItem *item = search_options->get_next_selected(root);
-				while (item) {
-					item->deselect(0);
-					item = search_options->get_next_selected(item);
-				}
-
-				current->select(0);
-
 			} break;
 			default:
 				break;
@@ -80,452 +79,35 @@ void VisualScriptPropertySelector::_sbox_input(const Ref<InputEvent> &p_ie) {
 	}
 }
 
-void VisualScriptPropertySelector::_update_search() {
-	set_title(TTR("Search VisualScript"));
-
-	search_options->clear();
-	help_bit->set_text("");
-
-	TreeItem *root = search_options->create_item();
-	bool found = false;
-	StringName base = base_type;
-	List<StringName> base_list;
-	while (base) {
-		base_list.push_back(base);
-		base = ClassDB::get_parent_class_nocheck(base);
-	}
-
-	for (const StringName &E : base_list) {
-		List<MethodInfo> methods;
-		List<PropertyInfo> props;
-		TreeItem *category = nullptr;
-		Ref<Texture2D> type_icons[Variant::VARIANT_MAX] = {
-			vbc->get_theme_icon(SNAME("Variant"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("String"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Vector2i"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Rect2"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Rect2i"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Vector3i"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Transform2D"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Plane"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Quaternion"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("AABB"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Basis"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("StringName"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("NodePath"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("RID"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("MiniObject"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Callable"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Signal"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Dictionary"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedByteArray"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedInt32Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedInt64Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedFloat32Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedFloat64Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedStringArray"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedVector2Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedVector3Array"), SNAME("EditorIcons")),
-			vbc->get_theme_icon(SNAME("PackedColorArray"), SNAME("EditorIcons"))
-		};
-		{
-			String b = String(E);
-			category = search_options->create_item(root);
-			if (category) {
-				category->set_text(0, b.replace_first("*", ""));
-				category->set_selectable(0, false);
-				Ref<Texture2D> icon;
-				String rep = b.replace("*", "");
-				icon = EditorNode::get_singleton()->get_class_icon(rep);
-				category->set_icon(0, icon);
-			}
-		}
-		if (properties || seq_connect) {
-			if (instance) {
-				instance->get_property_list(&props, true);
-			} else {
-				Object *obj = ObjectDB::get_instance(script);
-				if (Object::cast_to<Script>(obj)) {
-					Object::cast_to<Script>(obj)->get_script_property_list(&props);
-				} else {
-					ClassDB::get_property_list(E, &props, true);
-				}
-			}
-			for (const PropertyInfo &F : props) {
-				if (!(F.usage & PROPERTY_USAGE_EDITOR) && !(F.usage & PROPERTY_USAGE_SCRIPT_VARIABLE)) {
-					continue;
-				}
-
-				if (type_filter.size() && type_filter.find(F.type) == -1) {
-					continue;
-				}
-
-				// capitalize() also converts underscore to space, we'll match again both possible styles
-				String get_text_raw = String(vformat(TTR("Get %s"), F.name));
-				String get_text = get_text_raw.capitalize();
-				String set_text_raw = String(vformat(TTR("Set %s"), F.name));
-				String set_text = set_text_raw.capitalize();
-				String input = search_box->get_text().capitalize();
-
-				if (input.is_empty() || get_text_raw.findn(input) != -1 || get_text.findn(input) != -1) {
-					TreeItem *item = search_options->create_item(category ? category : root);
-					item->set_text(0, get_text);
-					item->set_metadata(0, F.name);
-					item->set_icon(0, type_icons[F.type]);
-					item->set_metadata(1, "get");
-					item->set_collapsed(true);
-					item->set_selectable(0, true);
-					item->set_selectable(1, false);
-					item->set_selectable(2, false);
-					item->set_metadata(2, connecting);
-				}
-
-				if (input.is_empty() || set_text_raw.findn(input) != -1 || set_text.findn(input) != -1) {
-					TreeItem *item = search_options->create_item(category ? category : root);
-					item->set_text(0, set_text);
-					item->set_metadata(0, F.name);
-					item->set_icon(0, type_icons[F.type]);
-					item->set_metadata(1, "set");
-					item->set_selectable(0, true);
-					item->set_selectable(1, false);
-					item->set_selectable(2, false);
-					item->set_metadata(2, connecting);
-				}
-			}
-		}
-		{
-			if (type != Variant::NIL) {
-				Variant v;
-				Callable::CallError ce;
-				Variant::construct(type, v, nullptr, 0, ce);
-				v.get_method_list(&methods);
-			} else {
-				Object *obj = ObjectDB::get_instance(script);
-				if (Object::cast_to<Script>(obj)) {
-					Object::cast_to<Script>(obj)->get_script_method_list(&methods);
-				}
-
-				ClassDB::get_method_list(E, &methods, true, true);
-			}
-		}
-		for (List<MethodInfo>::Element *M = methods.front(); M; M = M->next()) {
-			String name = M->get().name.get_slice(":", 0);
-			if (name.begins_with("_") && !(M->get().flags & METHOD_FLAG_VIRTUAL)) {
-				continue;
-			}
-
-			if (virtuals_only && !(M->get().flags & METHOD_FLAG_VIRTUAL)) {
-				continue;
-			}
-
-			if (!virtuals_only && (M->get().flags & METHOD_FLAG_VIRTUAL)) {
-				continue;
-			}
-
-			MethodInfo mi = M->get();
-			String desc_arguments;
-			if (mi.arguments.size() > 0) {
-				desc_arguments = "(";
-				for (int i = 0; i < mi.arguments.size(); i++) {
-					if (i > 0) {
-						desc_arguments += ", ";
-					}
-					if (mi.arguments[i].type == Variant::NIL) {
-						desc_arguments += "var";
-					} else if (mi.arguments[i].name.find(":") != -1) {
-						desc_arguments += mi.arguments[i].name.get_slice(":", 1);
-						mi.arguments[i].name = mi.arguments[i].name.get_slice(":", 0);
-					} else {
-						desc_arguments += Variant::get_type_name(mi.arguments[i].type);
-					}
-				}
-				desc_arguments += ")";
-			}
-			String desc_raw = mi.name + desc_arguments;
-			String desc = desc_raw.capitalize().replace("( ", "(");
-
-			if (!search_box->get_text().is_empty() &&
-					name.findn(search_box->get_text()) == -1 &&
-					desc.findn(search_box->get_text()) == -1 &&
-					desc_raw.findn(search_box->get_text()) == -1) {
-				continue;
-			}
-
-			TreeItem *item = search_options->create_item(category ? category : root);
-			item->set_text(0, desc);
-			item->set_icon(0, vbc->get_theme_icon(SNAME("MemberMethod"), SNAME("EditorIcons")));
-			item->set_metadata(0, name);
-			item->set_selectable(0, true);
-
-			item->set_metadata(1, "method");
-			item->set_collapsed(true);
-			item->set_selectable(1, false);
-
-			item->set_selectable(2, false);
-			item->set_metadata(2, connecting);
-		}
-
-		if (category && category->get_first_child() == nullptr) {
-			memdelete(category); //old category was unused
-		}
-	}
-	if (properties) {
-		if (!seq_connect && !visual_script_generic) {
-			get_visual_node_names("flow_control/type_cast", Set<String>(), found, root, search_box);
-			get_visual_node_names("functions/built_in/print", Set<String>(), found, root, search_box);
-			get_visual_node_names("functions/by_type/" + Variant::get_type_name(type), Set<String>(), found, root, search_box);
-			get_visual_node_names("functions/deconstruct/" + Variant::get_type_name(type), Set<String>(), found, root, search_box);
-			get_visual_node_names("operators/compare/", Set<String>(), found, root, search_box);
-			if (type == Variant::INT) {
-				get_visual_node_names("operators/bitwise/", Set<String>(), found, root, search_box);
-			}
-			if (type == Variant::BOOL) {
-				get_visual_node_names("operators/logic/", Set<String>(), found, root, search_box);
-			}
-			if (type == Variant::BOOL || type == Variant::INT || type == Variant::FLOAT || type == Variant::VECTOR2 || type == Variant::VECTOR3) {
-				get_visual_node_names("operators/math/", Set<String>(), found, root, search_box);
-			}
-		}
-	}
-
-	if (seq_connect && !visual_script_generic) {
-		String text = search_box->get_text();
-		create_visualscript_item(String("VisualScriptCondition"), root, text, String("Condition"));
-		create_visualscript_item(String("VisualScriptSwitch"), root, text, String("Switch"));
-		create_visualscript_item(String("VisualScriptSequence"), root, text, String("Sequence"));
-		create_visualscript_item(String("VisualScriptIterator"), root, text, String("Iterator"));
-		create_visualscript_item(String("VisualScriptWhile"), root, text, String("While"));
-		create_visualscript_item(String("VisualScriptReturn"), root, text, String("Return"));
-		get_visual_node_names("flow_control/type_cast", Set<String>(), found, root, search_box);
-		get_visual_node_names("functions/built_in/print", Set<String>(), found, root, search_box);
-	}
-
-	if ((properties || seq_connect) && visual_script_generic) {
-		get_visual_node_names("", Set<String>(), found, root, search_box);
-	}
-
-	TreeItem *selected_item = search_options->search_item_text(search_box->get_text());
-	if (!found && selected_item != nullptr) {
-		selected_item->select(0);
-		found = true;
-	}
-
-	get_ok_button()->set_disabled(root->get_first_child() == nullptr);
+void VisualScriptPropertySelector::_update_results_i(int p_int) {
+	_update_results();
 }
 
-void VisualScriptPropertySelector::create_visualscript_item(const String &name, TreeItem *const root, const String &search_input, const String &text) {
-	if (search_input.is_empty() || text.findn(search_input) != -1) {
-		TreeItem *item = search_options->create_item(root);
-		item->set_text(0, text);
-		item->set_icon(0, vbc->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons")));
-		item->set_metadata(0, name);
-		item->set_metadata(1, "action");
-		item->set_selectable(0, true);
-		item->set_collapsed(true);
-		item->set_selectable(1, false);
-		item->set_selectable(2, false);
-		item->set_metadata(2, connecting);
-	}
+void VisualScriptPropertySelector::_update_results_s(String p_string) {
+	_update_results();
 }
 
-void VisualScriptPropertySelector::get_visual_node_names(const String &root_filter, const Set<String> &p_modifiers, bool &found, TreeItem *const root, LineEdit *const search_box) {
-	Map<String, TreeItem *> path_cache;
-
-	List<String> fnodes;
-	VisualScriptLanguage::singleton->get_registered_node_names(&fnodes);
-
-	for (const String &E : fnodes) {
-		if (!E.begins_with(root_filter)) {
-			continue;
-		}
-		Vector<String> path = E.split("/");
-
-		// check if the name has the filter
-		bool in_filter = false;
-		Vector<String> tx_filters = search_box->get_text().split(" ");
-		for (int i = 0; i < tx_filters.size(); i++) {
-			if (tx_filters[i].is_empty()) {
-				in_filter = true;
-			} else {
-				in_filter = false;
-			}
-			if (E.findn(tx_filters[i]) != -1) {
-				in_filter = true;
-				break;
-			}
-		}
-		if (!in_filter) {
-			continue;
-		}
-
-		bool in_modifier = p_modifiers.is_empty();
-		for (Set<String>::Element *F = p_modifiers.front(); F && in_modifier; F = F->next()) {
-			if (E.findn(F->get()) != -1) {
-				in_modifier = true;
-			}
-		}
-		if (!in_modifier) {
-			continue;
-		}
-
-		TreeItem *item = search_options->create_item(root);
-		Ref<VisualScriptNode> vnode = VisualScriptLanguage::singleton->create_node_from_name(E);
-		Ref<VisualScriptOperator> vnode_operator = vnode;
-		String type_name;
-		if (vnode_operator.is_valid()) {
-			String type;
-			if (path.size() >= 2) {
-				type = path[1];
-			}
-			type_name = type.capitalize() + " ";
-		}
-		Ref<VisualScriptFunctionCall> vnode_function_call = vnode;
-		if (vnode_function_call.is_valid()) {
-			String basic_type = Variant::get_type_name(vnode_function_call->get_basic_type());
-			type_name = basic_type.capitalize() + " ";
-		}
-		Ref<VisualScriptConstructor> vnode_constructor = vnode;
-		if (vnode_constructor.is_valid()) {
-			type_name = "Construct ";
-		}
-		Ref<VisualScriptDeconstruct> vnode_deconstruct = vnode;
-		if (vnode_deconstruct.is_valid()) {
-			type_name = "Deconstruct ";
-		}
-		Vector<String> desc = path[path.size() - 1].replace("(", " ").replace(")", " ").replace(",", " ").split(" ");
-		for (int i = 0; i < desc.size(); i++) {
-			desc.write[i] = desc[i].capitalize();
-			if (desc[i].ends_with(",")) {
-				desc.write[i] = desc[i].replace(",", ", ");
-			}
-		}
-
-		item->set_text(0, type_name + String("").join(desc));
-		item->set_icon(0, vbc->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons")));
-		item->set_selectable(0, true);
-		item->set_metadata(0, E);
-		item->set_selectable(0, true);
-		item->set_metadata(1, "visualscript");
-		item->set_selectable(1, false);
-		item->set_selectable(2, false);
-		item->set_metadata(2, connecting);
-	}
+void VisualScriptPropertySelector::_update_results() {
+	_update_icons();
+	search_runner = Ref<SearchRunner>(memnew(SearchRunner(this, results_tree)));
+	set_process(true);
 }
 
 void VisualScriptPropertySelector::_confirmed() {
-	TreeItem *ti = search_options->get_selected();
+	TreeItem *ti = results_tree->get_selected();
 	if (!ti) {
 		return;
 	}
-	emit_signal(SNAME("selected"), ti->get_metadata(0), ti->get_metadata(1), ti->get_metadata(2));
+	emit_signal(SNAME("selected"), ti->get_metadata(0), ti->get_metadata(1), connecting);
 	set_visible(false);
 }
 
 void VisualScriptPropertySelector::_item_selected() {
-	help_bit->set_text("");
-
-	TreeItem *item = search_options->get_selected();
-	if (!item) {
-		return;
-	}
-	String name = item->get_metadata(0);
-
-	String class_type;
-	if (type != Variant::NIL) {
-		class_type = Variant::get_type_name(type);
-
+	if (results_tree->get_selected()->has_meta("description")) {
+		help_bit->set_text(results_tree->get_selected()->get_meta("description"));
 	} else {
-		class_type = base_type;
+		help_bit->set_text("No description available");
 	}
-
-	DocTools *dd = EditorHelp::get_doc_data();
-	String text;
-
-	String at_class = class_type;
-
-	while (!at_class.is_empty()) {
-		Map<String, DocData::ClassDoc>::Element *E = dd->class_list.find(at_class);
-		if (E) {
-			for (int i = 0; i < E->get().properties.size(); i++) {
-				if (E->get().properties[i].name == name) {
-					text = DTR(E->get().properties[i].description);
-				}
-			}
-		}
-
-		at_class = ClassDB::get_parent_class_nocheck(at_class);
-	}
-	at_class = class_type;
-
-	while (!at_class.is_empty()) {
-		Map<String, DocData::ClassDoc>::Element *C = dd->class_list.find(at_class);
-		if (C) {
-			for (int i = 0; i < C->get().methods.size(); i++) {
-				if (C->get().methods[i].name == name) {
-					text = DTR(C->get().methods[i].description);
-				}
-			}
-		}
-
-		at_class = ClassDB::get_parent_class_nocheck(at_class);
-	}
-	Vector<String> functions = name.rsplit("/", false);
-	at_class = functions.size() > 3 ? functions[functions.size() - 2] : class_type;
-	Map<String, DocData::ClassDoc>::Element *T = dd->class_list.find(at_class);
-	if (T) {
-		for (int i = 0; i < T->get().methods.size(); i++) {
-			if (T->get().methods[i].name == functions[functions.size() - 1]) {
-				text = DTR(T->get().methods[i].description);
-			}
-		}
-	}
-
-	List<String> *names = memnew(List<String>);
-	VisualScriptLanguage::singleton->get_registered_node_names(names);
-	if (names->find(name) != nullptr) {
-		Ref<VisualScriptOperator> operator_node = VisualScriptLanguage::singleton->create_node_from_name(name);
-		if (operator_node.is_valid()) {
-			Map<String, DocData::ClassDoc>::Element *F = dd->class_list.find(operator_node->get_class_name());
-			if (F) {
-				text = Variant::get_operator_name(operator_node->get_operator());
-			}
-		}
-		Ref<VisualScriptTypeCast> typecast_node = VisualScriptLanguage::singleton->create_node_from_name(name);
-		if (typecast_node.is_valid()) {
-			Map<String, DocData::ClassDoc>::Element *F = dd->class_list.find(typecast_node->get_class_name());
-			if (F) {
-				text = DTR(F->get().description);
-			}
-		}
-
-		Ref<VisualScriptBuiltinFunc> builtin_node = VisualScriptLanguage::singleton->create_node_from_name(name);
-		if (builtin_node.is_valid()) {
-			Map<String, DocData::ClassDoc>::Element *F = dd->class_list.find(builtin_node->get_class_name());
-			if (F) {
-				for (int i = 0; i < F->get().constants.size(); i++) {
-					if (F->get().constants[i].value.to_int() == int(builtin_node->get_func())) {
-						text = DTR(F->get().constants[i].description);
-					}
-				}
-			}
-		}
-	}
-
-	memdelete(names);
-
-	if (text.is_empty()) {
-		return;
-	}
-
-	help_bit->set_text(text);
 }
 
 void VisualScriptPropertySelector::_hide_requested() {
@@ -533,167 +115,259 @@ void VisualScriptPropertySelector::_hide_requested() {
 }
 
 void VisualScriptPropertySelector::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		connect("confirmed", callable_mp(this, &VisualScriptPropertySelector::_confirmed));
+	switch (p_what) {
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			_update_icons();
+		} break;
+		case NOTIFICATION_ENTER_TREE: {
+			connect("confirmed", callable_mp(this, &VisualScriptPropertySelector::_confirmed));
+		} break;
+		case NOTIFICATION_PROCESS: {
+			// Update background search.
+			if (search_runner.is_valid()) {
+				if (search_runner->work()) {
+					// Search done.
+					get_ok_button()->set_disabled(!results_tree->get_selected());
+
+					search_runner = Ref<SearchRunner>();
+					set_process(false);
+				}
+			} else {
+				// if one is valid
+				set_process(false);
+			}
+		} break;
 	}
 }
 
-void VisualScriptPropertySelector::select_method_from_base_type(const String &p_base, const String &p_current, const bool p_virtuals_only, const bool p_connecting, bool clear_text) {
+void VisualScriptPropertySelector::select_method_from_base_type(const String &p_base, const bool p_virtuals_only, const bool p_connecting, bool clear_text) {
+	set_title(TTR("Select method from base type"));
 	base_type = p_base;
-	selected = p_current;
+	base_script = "";
 	type = Variant::NIL;
-	properties = false;
-	instance = nullptr;
-	virtuals_only = p_virtuals_only;
-
-	show_window(.5f);
-	if (clear_text) {
-		search_box->set_text("");
-	} else {
-		search_box->select_all();
-	}
-	search_box->grab_focus();
 	connecting = p_connecting;
 
-	_update_search();
-}
-
-void VisualScriptPropertySelector::set_type_filter(const Vector<Variant::Type> &p_type_filter) {
-	type_filter = p_type_filter;
-}
-
-void VisualScriptPropertySelector::select_from_base_type(const String &p_base, const String &p_current, bool p_virtuals_only, bool p_seq_connect, const bool p_connecting, bool clear_text) {
-	base_type = p_base;
-	selected = p_current;
-	type = Variant::NIL;
-	properties = true;
-	visual_script_generic = false;
-	instance = nullptr;
-	virtuals_only = p_virtuals_only;
-
-	show_window(.5f);
 	if (clear_text) {
-		search_box->set_text("");
-	} else {
-		search_box->select_all();
+		if (p_virtuals_only) {
+			search_box->set_text("._"); // show all _methods
+			search_box->set_caret_column(2);
+		} else {
+			search_box->set_text("."); // show all methods
+			search_box->set_caret_column(1);
+		}
 	}
+
+	search_visual_script_nodes->set_pressed(false);
+	search_classes->set_pressed(false);
+	search_methods->set_pressed(true);
+	search_operators->set_pressed(false);
+	search_signals->set_pressed(false);
+	search_constants->set_pressed(false);
+	search_properties->set_pressed(false);
+	search_theme_items->set_pressed(false);
+
+	scope_combo->select(2); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated"
+
+	results_tree->clear();
+	show_window(.5f);
 	search_box->grab_focus();
-	seq_connect = p_seq_connect;
+
+	_update_results();
+}
+
+void VisualScriptPropertySelector::select_from_base_type(const String &p_base, const String &p_base_script, bool p_virtuals_only, const bool p_connecting, bool clear_text) {
+	set_title(TTR("Select from base type"));
+	base_type = p_base;
+	base_script = p_base_script.lstrip("res://").quote(); // filepath to EditorHelp::get_doc_data().name
+	type = Variant::NIL;
 	connecting = p_connecting;
 
-	_update_search();
+	if (clear_text) {
+		if (p_virtuals_only) {
+			search_box->set_text("_");
+		} else {
+			search_box->set_text(" ");
+		}
+	}
+	search_box->select_all();
+
+	search_visual_script_nodes->set_pressed(false);
+	search_classes->set_pressed(false);
+	search_methods->set_pressed(true);
+	search_operators->set_pressed(false);
+	search_signals->set_pressed(true);
+	search_constants->set_pressed(false);
+	search_properties->set_pressed(true);
+	search_theme_items->set_pressed(false);
+
+	// When class is Input only show inheritors
+	scope_combo->select(0); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated"
+
+	results_tree->clear();
+	show_window(.5f);
+	search_box->grab_focus();
+	_update_results();
 }
 
-void VisualScriptPropertySelector::select_from_script(const Ref<Script> &p_script, const String &p_current, const bool p_connecting, bool clear_text) {
+void VisualScriptPropertySelector::select_from_script(const Ref<Script> &p_script, const bool p_connecting, bool clear_text) {
+	set_title(TTR("Select from script"));
 	ERR_FAIL_COND(p_script.is_null());
 
 	base_type = p_script->get_instance_base_type();
-	selected = p_current;
+	base_script = p_script->get_path().lstrip("res://").quote(); // filepath to EditorHelp::get_doc_data().name
 	type = Variant::NIL;
 	script = p_script->get_instance_id();
-	properties = true;
-	visual_script_generic = false;
-	instance = nullptr;
-	virtuals_only = false;
-
-	show_window(.5f);
-	if (clear_text) {
-		search_box->set_text("");
-	} else {
-		search_box->select_all();
-	}
-	search_box->grab_focus();
-	seq_connect = false;
 	connecting = p_connecting;
 
-	_update_search();
+	if (clear_text) {
+		search_box->set_text("");
+	}
+	search_box->select_all();
+
+	search_visual_script_nodes->set_pressed(false);
+	search_classes->set_pressed(true);
+	search_methods->set_pressed(true);
+	search_operators->set_pressed(true);
+	search_signals->set_pressed(true);
+	search_constants->set_pressed(true);
+	search_properties->set_pressed(true);
+	search_theme_items->set_pressed(false);
+
+	scope_combo->select(2); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated"
+
+	results_tree->clear();
+	show_window(.5f);
+	search_box->grab_focus();
+	_update_results();
 }
 
-void VisualScriptPropertySelector::select_from_basic_type(Variant::Type p_type, const String &p_current, const bool p_connecting, bool clear_text) {
+void VisualScriptPropertySelector::select_from_basic_type(Variant::Type p_type, const bool p_connecting, bool clear_text) {
+	set_title(TTR("Select from basic type"));
 	ERR_FAIL_COND(p_type == Variant::NIL);
-	base_type = "";
-	selected = p_current;
+	base_type = Variant::get_type_name(p_type);
+	base_script = "";
 	type = p_type;
-	properties = true;
-	visual_script_generic = false;
-	instance = nullptr;
-	virtuals_only = false;
-
-	show_window(.5f);
-	if (clear_text) {
-		search_box->set_text("");
-	} else {
-		search_box->select_all();
-	}
-	search_box->grab_focus();
-	seq_connect = false;
 	connecting = p_connecting;
 
-	_update_search();
+	if (clear_text) {
+		search_box->set_text(" ");
+	}
+	search_box->select_all();
+
+	search_visual_script_nodes->set_pressed(false);
+	search_classes->set_pressed(false);
+	search_methods->set_pressed(true);
+	search_operators->set_pressed(true);
+	search_signals->set_pressed(false);
+	search_constants->set_pressed(true);
+	search_properties->set_pressed(true);
+	search_theme_items->set_pressed(false);
+
+	scope_combo->select(2); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated" //id5 "Search All"
+
+	results_tree->clear();
+	show_window(.5f);
+	search_box->grab_focus();
+
+	_update_results();
 }
 
-void VisualScriptPropertySelector::select_from_action(const String &p_type, const String &p_current, const bool p_connecting, bool clear_text) {
+void VisualScriptPropertySelector::select_from_action(const String &p_type, const bool p_connecting, bool clear_text) {
+	set_title(TTR("Select from action"));
 	base_type = p_type;
-	selected = p_current;
+	base_script = "";
 	type = Variant::NIL;
-	properties = false;
-	visual_script_generic = false;
-	instance = nullptr;
-	virtuals_only = false;
-
-	show_window(.5f);
-	if (clear_text) {
-		search_box->set_text("");
-	} else {
-		search_box->select_all();
-	}
-	search_box->grab_focus();
-	seq_connect = true;
 	connecting = p_connecting;
 
-	_update_search();
+	if (clear_text) {
+		search_box->set_text("");
+	}
+	search_box->select_all();
+
+	search_visual_script_nodes->set_pressed(true);
+	search_classes->set_pressed(false);
+	search_methods->set_pressed(false);
+	search_operators->set_pressed(false);
+	search_signals->set_pressed(false);
+	search_constants->set_pressed(false);
+	search_properties->set_pressed(false);
+	search_theme_items->set_pressed(false);
+
+	scope_combo->select(0); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated" //id5 "Search All"
+
+	results_tree->clear();
+	show_window(.5f);
+	search_box->grab_focus();
+	_update_results();
 }
 
-void VisualScriptPropertySelector::select_from_instance(Object *p_instance, const String &p_current, const bool p_connecting, const String &p_basetype, bool clear_text) {
-	base_type = p_basetype;
-	selected = p_current;
-	type = Variant::NIL;
-	properties = true;
-	visual_script_generic = false;
-	instance = p_instance;
-	virtuals_only = false;
+void VisualScriptPropertySelector::select_from_instance(Object *p_instance, const bool p_connecting, bool clear_text) {
+	set_title(TTR("Select from instance"));
+	base_type = p_instance->get_class();
 
-	show_window(.5f);
-	if (clear_text) {
-		search_box->set_text("");
+	const Ref<Script> &p_script = p_instance->get_script();
+	if (p_script == nullptr) {
+		base_script = "";
 	} else {
-		search_box->select_all();
+		base_script = p_script->get_path().lstrip("res://").quote(); // filepath to EditorHelp::get_doc_data().name
 	}
-	search_box->grab_focus();
-	seq_connect = false;
+
+	type = Variant::NIL;
 	connecting = p_connecting;
 
-	_update_search();
+	if (clear_text) {
+		search_box->set_text(" ");
+	}
+	search_box->select_all();
+
+	search_visual_script_nodes->set_pressed(false);
+	search_classes->set_pressed(false);
+	search_methods->set_pressed(true);
+	search_operators->set_pressed(false);
+	search_signals->set_pressed(true);
+	search_constants->set_pressed(true);
+	search_properties->set_pressed(true);
+	search_theme_items->set_pressed(false);
+
+	scope_combo->select(2); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated" //id5 "Search All"
+
+	results_tree->clear();
+	show_window(.5f);
+	search_box->grab_focus();
+	_update_results();
 }
 
-void VisualScriptPropertySelector::select_from_visual_script(const String &p_base, const bool p_connecting, bool clear_text) {
-	base_type = p_base;
-	selected = "";
-	type = Variant::NIL;
-	properties = true;
-	visual_script_generic = true;
-	instance = nullptr;
-	virtuals_only = false;
-	show_window(.5f);
-	if (clear_text) {
-		search_box->set_text("");
+void VisualScriptPropertySelector::select_from_visual_script(const Ref<Script> &p_script, bool clear_text) {
+	set_title(TTR("Select from visual script"));
+	base_type = p_script->get_instance_base_type();
+	if (p_script == nullptr) {
+		base_script = "";
 	} else {
-		search_box->select_all();
+		base_script = p_script->get_path().lstrip("res://").quote(); // filepath to EditorHelp::get_doc_data().name
 	}
-	search_box->grab_focus();
-	connecting = p_connecting;
+	type = Variant::NIL;
+	connecting = false;
 
-	_update_search();
+	if (clear_text) {
+		search_box->set_text(" ");
+	}
+	search_box->select_all();
+
+	search_visual_script_nodes->set_pressed(true);
+	search_classes->set_pressed(false);
+	search_methods->set_pressed(true);
+	search_operators->set_pressed(false);
+	search_signals->set_pressed(true);
+	search_constants->set_pressed(true);
+	search_properties->set_pressed(true);
+	search_theme_items->set_pressed(false);
+
+	scope_combo->select(2); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated" //id5 "Search All"
+
+	results_tree->clear();
+	show_window(.5f);
+	search_box->grab_focus();
+	_update_results();
 }
 
 void VisualScriptPropertySelector::show_window(float p_screen_ratio) {
@@ -705,29 +379,891 @@ void VisualScriptPropertySelector::_bind_methods() {
 }
 
 VisualScriptPropertySelector::VisualScriptPropertySelector() {
-	vbc = memnew(VBoxContainer);
-	add_child(vbc);
-	//set_child_rect(vbc);
+	virtuals_only = false;
+
+	vbox = memnew(VBoxContainer);
+	add_child(vbox);
+
+	HBoxContainer *hbox = memnew(HBoxContainer);
+	hbox->set_alignment(hbox->ALIGNMENT_CENTER);
+	vbox->add_child(hbox);
+
+	case_sensitive_button = memnew(Button);
+	case_sensitive_button->set_flat(true);
+	case_sensitive_button->set_tooltip(TTR("Case Sensitive"));
+	case_sensitive_button->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_results));
+	case_sensitive_button->set_toggle_mode(true);
+	case_sensitive_button->set_focus_mode(Control::FOCUS_NONE);
+	hbox->add_child(case_sensitive_button);
+
+	hierarchy_button = memnew(Button);
+	hierarchy_button->set_flat(true);
+	hierarchy_button->set_tooltip(TTR("Show Hierarchy"));
+	hierarchy_button->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_results));
+	hierarchy_button->set_toggle_mode(true);
+	hierarchy_button->set_pressed(true);
+	hierarchy_button->set_focus_mode(Control::FOCUS_NONE);
+	hbox->add_child(hierarchy_button);
+
+	hbox->add_child(memnew(VSeparator));
+
+	search_visual_script_nodes = memnew(Button);
+	search_visual_script_nodes->set_flat(true);
+	search_visual_script_nodes->set_tooltip(TTR("Search Visual Script Nodes"));
+	search_visual_script_nodes->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_results));
+	search_visual_script_nodes->set_toggle_mode(true);
+	search_visual_script_nodes->set_pressed(true);
+	search_visual_script_nodes->set_focus_mode(Control::FOCUS_NONE);
+	hbox->add_child(search_visual_script_nodes);
+
+	search_classes = memnew(Button);
+	search_classes->set_flat(true);
+	search_classes->set_tooltip(TTR("Search Classes"));
+	search_classes->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_results));
+	search_classes->set_toggle_mode(true);
+	search_classes->set_pressed(true);
+	search_classes->set_focus_mode(Control::FOCUS_NONE);
+	hbox->add_child(search_classes);
+
+	search_operators = memnew(Button);
+	search_operators->set_flat(true);
+	search_operators->set_tooltip(TTR("Search Operators"));
+	search_operators->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_results));
+	search_operators->set_toggle_mode(true);
+	search_operators->set_pressed(true);
+	search_operators->set_focus_mode(Control::FOCUS_NONE);
+	hbox->add_child(search_operators);
+
+	hbox->add_child(memnew(VSeparator));
+
+	search_methods = memnew(Button);
+	search_methods->set_flat(true);
+	search_methods->set_tooltip(TTR("Search Methods"));
+	search_methods->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_results));
+	search_methods->set_toggle_mode(true);
+	search_methods->set_pressed(true);
+	search_methods->set_focus_mode(Control::FOCUS_NONE);
+	hbox->add_child(search_methods);
+
+	search_signals = memnew(Button);
+	search_signals->set_flat(true);
+	search_signals->set_tooltip(TTR("Search Signals"));
+	search_signals->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_results));
+	search_signals->set_toggle_mode(true);
+	search_signals->set_pressed(true);
+	search_signals->set_focus_mode(Control::FOCUS_NONE);
+	hbox->add_child(search_signals);
+
+	search_constants = memnew(Button);
+	search_constants->set_flat(true);
+	search_constants->set_tooltip(TTR("Search Constants"));
+	search_constants->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_results));
+	search_constants->set_toggle_mode(true);
+	search_constants->set_pressed(true);
+	search_constants->set_focus_mode(Control::FOCUS_NONE);
+	hbox->add_child(search_constants);
+
+	search_properties = memnew(Button);
+	search_properties->set_flat(true);
+	search_properties->set_tooltip(TTR("Search Properties"));
+	search_properties->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_results));
+	search_properties->set_toggle_mode(true);
+	search_properties->set_pressed(true);
+	search_properties->set_focus_mode(Control::FOCUS_NONE);
+	hbox->add_child(search_properties);
+
+	search_theme_items = memnew(Button);
+	search_theme_items->set_flat(true);
+	search_theme_items->set_tooltip(TTR("Search Theme Items"));
+	search_theme_items->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_results));
+	search_theme_items->set_toggle_mode(true);
+	search_theme_items->set_pressed(true);
+	search_theme_items->set_focus_mode(Control::FOCUS_NONE);
+	hbox->add_child(search_theme_items);
+
+	scope_combo = memnew(OptionButton);
+	scope_combo->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
+	scope_combo->set_tooltip(TTR("Select the search limits"));
+	scope_combo->set_stretch_ratio(0); // Fixed width.
+	scope_combo->add_item(TTR("Search Related"), SCOPE_RELATED);
+	scope_combo->add_separator();
+	scope_combo->add_item(TTR("Search Base"), SCOPE_BASE);
+	scope_combo->add_item(TTR("Search Inheriters"), SCOPE_INHERITERS);
+	scope_combo->add_item(TTR("Search Unrelated"), SCOPE_UNRELATED);
+	scope_combo->add_item(TTR("Search All"), SCOPE_ALL);
+	scope_combo->connect("item_selected", callable_mp(this, &VisualScriptPropertySelector::_update_results_i));
+	hbox->add_child(scope_combo);
+
 	search_box = memnew(LineEdit);
-	vbc->add_margin_child(TTR("Search:"), search_box);
-	search_box->connect("text_changed", callable_mp(this, &VisualScriptPropertySelector::_text_changed));
+	search_box->set_tooltip(TTR("Enter \" \" to show all filterd options\nEnter \".\" to show all filterd methods, operators and constructors\nUse CTRL_KEY to drop property setters"));
+	search_box->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
+	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	search_box->connect("text_changed", callable_mp(this, &VisualScriptPropertySelector::_update_results_s));
 	search_box->connect("gui_input", callable_mp(this, &VisualScriptPropertySelector::_sbox_input));
-	search_options = memnew(Tree);
-	vbc->add_margin_child(TTR("Matches:"), search_options, true);
+	register_text_enter(search_box);
+	vbox->add_child(search_box);
+
+	results_tree = memnew(Tree);
+	results_tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	results_tree->set_hide_root(true);
+	results_tree->set_hide_folding(false);
+	results_tree->set_columns(2);
+	results_tree->set_column_title(0, TTR("Name"));
+	results_tree->set_column_clip_content(0, true);
+	results_tree->set_column_title(1, TTR("Member Type"));
+	results_tree->set_column_expand(1, false);
+	results_tree->set_column_custom_minimum_width(1, 150 * EDSCALE);
+	results_tree->set_column_clip_content(1, true);
+	results_tree->set_custom_minimum_size(Size2(0, 100) * EDSCALE);
+	results_tree->set_select_mode(Tree::SELECT_ROW);
+	results_tree->connect("item_activated", callable_mp(this, &VisualScriptPropertySelector::_confirmed));
+	results_tree->connect("item_selected", callable_mp(this, &VisualScriptPropertySelector::_item_selected));
+	vbox->add_child(results_tree);
+
+	help_bit = memnew(EditorHelpBit);
+	vbox->add_child(help_bit);
+	help_bit->connect("request_hide", callable_mp(this, &VisualScriptPropertySelector::_hide_requested));
 	get_ok_button()->set_text(TTR("Open"));
 	get_ok_button()->set_disabled(true);
-	register_text_enter(search_box);
 	set_hide_on_ok(false);
-	search_options->connect("item_activated", callable_mp(this, &VisualScriptPropertySelector::_confirmed));
-	search_options->connect("cell_selected", callable_mp(this, &VisualScriptPropertySelector::_item_selected));
-	search_options->set_hide_root(true);
-	search_options->set_hide_folding(true);
-	virtuals_only = false;
-	seq_connect = false;
-	help_bit = memnew(EditorHelpBit);
-	vbc->add_margin_child(TTR("Description:"), help_bit);
-	help_bit->connect("request_hide", callable_mp(this, &VisualScriptPropertySelector::_hide_requested));
-	search_options->set_columns(3);
-	search_options->set_column_expand(1, false);
-	search_options->set_column_expand(2, false);
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_is_class_disabled_by_feature_profile(const StringName &p_class) {
+	Ref<EditorFeatureProfile> profile = EditorFeatureProfileManager::get_singleton()->get_current_profile();
+	if (profile.is_null()) {
+		return false;
+	}
+
+	StringName class_name = p_class;
+	while (class_name != StringName()) {
+		if (!ClassDB::class_exists(class_name)) {
+			return false;
+		}
+
+		if (profile->is_class_disabled(class_name)) {
+			return true;
+		}
+		class_name = ClassDB::get_parent_class(class_name);
+	}
+
+	return false;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_is_class_disabled_by_scope(const StringName &p_class) {
+	bool is_base_script = false;
+	if (p_class == selector_ui->base_script) {
+		is_base_script = true;
+	}
+	bool is_base = false;
+	if (selector_ui->base_type == p_class) {
+		is_base = true;
+	}
+	bool is_parent = false;
+	if ((ClassDB::is_parent_class(selector_ui->base_type, p_class)) && !is_base) {
+		is_parent = true;
+	}
+
+	bool is_inheriter = false;
+	List<StringName> inheriters;
+	ClassDB::get_inheriters_from_class(selector_ui->base_type, &inheriters);
+	if (inheriters.find(p_class)) {
+		is_inheriter = true;
+	}
+
+	if (scope_flags & SCOPE_BASE) {
+		if (is_base_script || is_base || is_parent) {
+			return false;
+		}
+	}
+	if (scope_flags & SCOPE_INHERITERS) {
+		if (is_base_script || is_base || is_inheriter) {
+			return false;
+		}
+	}
+	//	if (scope_flags & SCOPE_RELATED) {
+	//		/* code */
+	//	}
+	if (scope_flags & SCOPE_UNRELATED) {
+		if (!is_base_script && !is_base && !is_inheriter) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_slice() {
+	bool phase_done = false;
+	switch (phase) {
+		case PHASE_INIT:
+			phase_done = _phase_init();
+			break;
+		case PHASE_MATCH_CLASSES_INIT:
+			phase_done = _phase_match_classes_init();
+			break;
+		case PHASE_NODE_CLASSES_INIT:
+			phase_done = _phase_node_classes_init();
+			break;
+		case PHASE_NODE_CLASSES_BUILD:
+			phase_done = _phase_node_classes_build();
+			break;
+		case PHASE_MATCH_CLASSES:
+			phase_done = _phase_match_classes();
+			break;
+		case PHASE_CLASS_ITEMS_INIT:
+			phase_done = _phase_class_items_init();
+			break;
+		case PHASE_CLASS_ITEMS:
+			phase_done = _phase_class_items();
+			break;
+		case PHASE_MEMBER_ITEMS_INIT:
+			phase_done = _phase_member_items_init();
+			break;
+		case PHASE_MEMBER_ITEMS:
+			phase_done = _phase_member_items();
+			break;
+		case PHASE_SELECT_MATCH:
+			phase_done = _phase_select_match();
+			break;
+		case PHASE_MAX:
+			return true;
+		default:
+			WARN_PRINT("Invalid or unhandled phase in EditorHelpSearch::Runner, aborting search.");
+			return true;
+	};
+
+	if (phase_done) {
+		phase++;
+	}
+	return false;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_phase_init() {
+	search_flags = 0; // selector_ui->filter_combo->get_selected_id();
+	if (selector_ui->search_visual_script_nodes->is_pressed()) {
+		search_flags |= SEARCH_VISUAL_SCRIPT_NODES;
+	}
+	if (selector_ui->search_classes->is_pressed()) {
+		search_flags |= SEARCH_CLASSES;
+	}
+	//	if (selector_ui->search_constructors->is_pressed()) {
+	search_flags |= SEARCH_CONSTRUCTORS;
+	//	}
+	if (selector_ui->search_methods->is_pressed()) {
+		search_flags |= SEARCH_METHODS;
+	}
+	if (selector_ui->search_operators->is_pressed()) {
+		search_flags |= SEARCH_OPERATORS;
+	}
+	if (selector_ui->search_signals->is_pressed()) {
+		search_flags |= SEARCH_SIGNALS;
+	}
+	if (selector_ui->search_constants->is_pressed()) {
+		search_flags |= SEARCH_CONSTANTS;
+	}
+	if (selector_ui->search_properties->is_pressed()) {
+		search_flags |= SEARCH_PROPERTIES;
+	}
+	if (selector_ui->search_theme_items->is_pressed()) {
+		search_flags |= SEARCH_THEME_ITEMS;
+	}
+	if (selector_ui->case_sensitive_button->is_pressed()) {
+		search_flags |= SEARCH_CASE_SENSITIVE;
+	}
+	if (selector_ui->hierarchy_button->is_pressed()) {
+		search_flags |= SEARCH_SHOW_HIERARCHY;
+	}
+	scope_flags = selector_ui->scope_combo->get_selected_id();
+
+	return true;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_phase_match_classes_init() {
+	combined_docs = EditorHelp::get_doc_data()->class_list;
+	matches.clear();
+	matched_item = nullptr;
+	match_highest_score = 0;
+
+	if (
+			(selector_ui->base_script.unquote() != "") &&
+			(selector_ui->base_script.unquote() != ".") &&
+			!combined_docs.has(selector_ui->base_script)) {
+		String file_path = "res://" + selector_ui->base_script.unquote(); // EditorHelp::get_doc_data().name to filepath
+		Ref<Script> script;
+		script = ResourceLoader::load(file_path);
+		if (!script.is_null()) {
+			DocData::ClassDoc class_doc = DocData::ClassDoc();
+
+			class_doc.name = selector_ui->base_script;
+
+			class_doc.inherits = script->get_instance_base_type();
+			class_doc.brief_description = ".vs files not suported by EditorHelp::get_doc_data()";
+			class_doc.description = "";
+
+			Object *obj = ObjectDB::get_instance(script->get_instance_id());
+			if (Object::cast_to<Script>(obj)) {
+				List<MethodInfo> methods;
+				Object::cast_to<Script>(obj)->get_script_method_list(&methods);
+				for (List<MethodInfo>::Element *M = methods.front(); M; M = M->next()) {
+					class_doc.methods.push_back(_get_method_doc(M->get()));
+				}
+
+				List<MethodInfo> signals;
+				Object::cast_to<Script>(obj)->get_script_signal_list(&signals);
+				for (List<MethodInfo>::Element *S = signals.front(); S; S = S->next()) {
+					class_doc.signals.push_back(_get_method_doc(S->get()));
+				}
+
+				List<PropertyInfo> propertys;
+				Object::cast_to<Script>(obj)->get_script_property_list(&propertys);
+				for (List<PropertyInfo>::Element *P = propertys.front(); P; P = P->next()) {
+					DocData::PropertyDoc pd = DocData::PropertyDoc();
+					pd.name = P->get().name;
+					pd.type = Variant::get_type_name(P->get().type);
+					class_doc.properties.push_back(pd);
+				}
+			}
+			combined_docs.insert(class_doc.name, class_doc);
+		}
+	}
+	iterator_doc = combined_docs.front();
+	return true;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_phase_node_classes_init() {
+	VisualScriptLanguage::singleton->get_registered_node_names(&vs_nodes);
+	_add_class_doc("functions", "", "");
+	_add_class_doc("operators", "", "");
+	return true;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_phase_node_classes_build() {
+	if (vs_nodes.is_empty()) {
+		return true;
+	}
+	String registerd_node_name = vs_nodes[0];
+	vs_nodes.pop_front();
+
+	Vector<String> path = registerd_node_name.split("/");
+	if (path[0] == "constants") {
+		_add_class_doc(registerd_node_name, "", "constants");
+	} else if (path[0] == "custom") {
+		_add_class_doc(registerd_node_name, "", "custom");
+	} else if (path[0] == "data") {
+		_add_class_doc(registerd_node_name, "", "data");
+	} else if (path[0] == "flow_control") {
+		_add_class_doc(registerd_node_name, "", "flow_control");
+	} else if (path[0] == "functions") {
+		if (path[1] == "built_in") {
+			_add_class_doc(registerd_node_name, "functions", "built_in");
+		} else if (path[1] == "by_type") {
+			if (search_flags & SEARCH_CLASSES) {
+				_add_class_doc(registerd_node_name, path[2], "by_type_class");
+			}
+		} else if (path[1] == "constructors") {
+			if (search_flags & SEARCH_CLASSES) {
+				_add_class_doc(registerd_node_name, path[2].substr(0, path[2].find_char('(')), "constructors_class");
+			}
+		} else if (path[1] == "deconstruct") {
+			_add_class_doc(registerd_node_name, "", "deconstruct");
+		} else if (path[1] == "wait") {
+			_add_class_doc(registerd_node_name, "functions", "yield");
+		} else {
+			_add_class_doc(registerd_node_name, "functions", "");
+		}
+	} else if (path[0] == "index") {
+		_add_class_doc(registerd_node_name, "", "index");
+	} else if (path[0] == "operators") {
+		if (path[1] == "bitwise") {
+			_add_class_doc(registerd_node_name, "operators", "bitwise");
+		} else if (path[1] == "compare") {
+			_add_class_doc(registerd_node_name, "operators", "compare");
+		} else if (path[1] == "logic") {
+			_add_class_doc(registerd_node_name, "operators", "logic");
+		} else if (path[1] == "math") {
+			_add_class_doc(registerd_node_name, "operators", "math");
+		} else {
+			_add_class_doc(registerd_node_name, "operators", "");
+		}
+	}
+	return false;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_phase_match_classes() {
+	DocData::ClassDoc &class_doc = iterator_doc->value();
+	if (
+			(!_is_class_disabled_by_feature_profile(class_doc.name) && !_is_class_disabled_by_scope(class_doc.name)) ||
+			_match_visual_script(class_doc)) {
+		if (class_doc.inherits == "VisualScriptCustomNode") {
+			class_doc.script_path = "res://" + class_doc.name.unquote();
+			Ref<Script> script = ResourceLoader::load(class_doc.script_path);
+			Ref<VisualScriptCustomNode> vsn;
+			vsn.instantiate();
+			vsn->set_script(script);
+			class_doc.name = vsn->get_caption();
+			if (combined_docs.has(vsn->get_category())) {
+				class_doc.inherits = vsn->get_category();
+			} else if (combined_docs.has("VisualScriptNode/" + vsn->get_category())) {
+				class_doc.inherits = "VisualScriptNode/" + vsn->get_category();
+			} else if (combined_docs.has("VisualScriptCustomNode/" + vsn->get_category())) {
+				class_doc.inherits = "VisualScriptCustomNode/" + vsn->get_category();
+			} else {
+				class_doc.inherits = "";
+			}
+			class_doc.category = "VisualScriptCustomNode/" + vsn->get_category();
+			class_doc.brief_description = "";
+			class_doc.constructors.clear();
+			class_doc.methods.clear();
+			class_doc.operators.clear();
+			class_doc.signals.clear();
+			class_doc.constants.clear();
+			class_doc.enums.clear();
+			class_doc.properties.clear();
+			class_doc.theme_properties.clear();
+		}
+
+		matches[class_doc.name] = ClassMatch();
+		ClassMatch &match = matches[class_doc.name];
+
+		match.category = class_doc.category;
+		match.doc = &class_doc;
+		// Match class name.
+		if (search_flags & SEARCH_CLASSES || _match_visual_script(class_doc)) {
+			if (term == "") {
+				match.name = !_match_is_hidden(class_doc);
+			} else {
+				match.name = _match_string(term, class_doc.name);
+			}
+			//	match.name = term == "" || _match_string(term, class_doc.name);
+		}
+
+		// Match members if the term is long enough.
+		if (term.length() >= 0) {
+			if (search_flags & SEARCH_CONSTRUCTORS) {
+				for (int i = 0; i < class_doc.constructors.size(); i++) {
+					String method_name = (search_flags & SEARCH_CASE_SENSITIVE) ? class_doc.constructors[i].name : class_doc.constructors[i].name.to_lower();
+					if (method_name.find(term) > -1 ||
+							term == " " ||
+							(term.begins_with(".") && method_name.begins_with(term.substr(1))) ||
+							(term.ends_with("(") && method_name.ends_with(term.left(term.length() - 1).strip_edges())) ||
+							(term.begins_with(".") && term.ends_with("(") && method_name == term.substr(1, term.length() - 2).strip_edges())) {
+						match.constructors.push_back(const_cast<DocData::MethodDoc *>(&class_doc.constructors[i]));
+					}
+				}
+			}
+			if (search_flags & SEARCH_METHODS) {
+				for (int i = 0; i < class_doc.methods.size(); i++) {
+					String method_name = (search_flags & SEARCH_CASE_SENSITIVE) ? class_doc.methods[i].name : class_doc.methods[i].name.to_lower();
+					if (method_name.find(term) > -1 ||
+							term == " " ||
+							(term.begins_with(".") && method_name.begins_with(term.substr(1))) ||
+							(term.ends_with("(") && method_name.ends_with(term.left(term.length() - 1).strip_edges())) ||
+							(term.begins_with(".") && term.ends_with("(") && method_name == term.substr(1, term.length() - 2).strip_edges())) {
+						match.methods.push_back(const_cast<DocData::MethodDoc *>(&class_doc.methods[i]));
+					}
+				}
+			}
+			if (search_flags & SEARCH_OPERATORS) {
+				for (int i = 0; i < class_doc.operators.size(); i++) {
+					String method_name = (search_flags & SEARCH_CASE_SENSITIVE) ? class_doc.operators[i].name : class_doc.operators[i].name.to_lower();
+					if (method_name.find(term) > -1 ||
+							term == " " ||
+							(term.begins_with(".") && method_name.begins_with(term.substr(1))) ||
+							(term.ends_with("(") && method_name.ends_with(term.left(term.length() - 1).strip_edges())) ||
+							(term.begins_with(".") && term.ends_with("(") && method_name == term.substr(1, term.length() - 2).strip_edges())) {
+						match.operators.push_back(const_cast<DocData::MethodDoc *>(&class_doc.operators[i]));
+					}
+				}
+			}
+			if (search_flags & SEARCH_SIGNALS) {
+				for (int i = 0; i < class_doc.signals.size(); i++) {
+					if (_match_string(term, class_doc.signals[i].name) ||
+							term == " ") {
+						match.signals.push_back(const_cast<DocData::MethodDoc *>(&class_doc.signals[i]));
+					}
+				}
+			}
+			if (search_flags & SEARCH_CONSTANTS) {
+				for (int i = 0; i < class_doc.constants.size(); i++) {
+					if (_match_string(term, class_doc.constants[i].name) ||
+							term == " ") {
+						match.constants.push_back(const_cast<DocData::ConstantDoc *>(&class_doc.constants[i]));
+					}
+				}
+			}
+			if (search_flags & SEARCH_PROPERTIES) {
+				for (int i = 0; i < class_doc.properties.size(); i++) {
+					if (_match_string(term, class_doc.properties[i].name) ||
+							term == " " ||
+							_match_string(term, class_doc.properties[i].getter) ||
+							_match_string(term, class_doc.properties[i].setter)) {
+						match.properties.push_back(const_cast<DocData::PropertyDoc *>(&class_doc.properties[i]));
+					}
+				}
+			}
+			if (search_flags & SEARCH_THEME_ITEMS) {
+				for (int i = 0; i < class_doc.theme_properties.size(); i++) {
+					if (_match_string(term, class_doc.theme_properties[i].name) ||
+							term == " ") {
+						match.theme_properties.push_back(const_cast<DocData::ThemeItemDoc *>(&class_doc.theme_properties[i]));
+					}
+				}
+			}
+		}
+	}
+
+	iterator_doc = iterator_doc->next();
+	return !iterator_doc;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_phase_class_items_init() {
+	results_tree->clear();
+	iterator_match = matches.front();
+
+	root_item = results_tree->create_item();
+	class_items.clear();
+
+	return true;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_phase_class_items() {
+	if (!iterator_match) {
+		return true;
+	}
+
+	ClassMatch &match = iterator_match->value();
+
+	if (search_flags & SEARCH_SHOW_HIERARCHY) {
+		if (match.required()) {
+			_create_class_hierarchy(match);
+		}
+	} else {
+		if (match.name) {
+			_create_class_item(root_item, match.doc, true);
+		}
+	}
+
+	iterator_match = iterator_match->next();
+	return !iterator_match;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_phase_member_items_init() {
+	iterator_match = matches.front();
+
+	return true;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_phase_member_items() {
+	if (!iterator_match) {
+		return true;
+	}
+
+	ClassMatch &match = iterator_match->value();
+
+	TreeItem *parent = (search_flags & SEARCH_SHOW_HIERARCHY) ? class_items[match.doc->name] : root_item;
+	bool constructor_created = false;
+	for (int i = 0; i < match.methods.size(); i++) {
+		String text = match.methods[i]->name;
+		if (!constructor_created) {
+			if (match.doc->name == match.methods[i]->name) {
+				text += " " + TTR("(constructors)");
+				constructor_created = true;
+			}
+		} else {
+			if (match.doc->name == match.methods[i]->name) {
+				continue;
+			}
+		}
+		_create_method_item(parent, match.doc, text, match.methods[i]);
+	}
+	for (int i = 0; i < match.signals.size(); i++) {
+		_create_signal_item(parent, match.doc, match.signals[i]);
+	}
+	for (int i = 0; i < match.constants.size(); i++) {
+		_create_constant_item(parent, match.doc, match.constants[i]);
+	}
+	for (int i = 0; i < match.properties.size(); i++) {
+		_create_property_item(parent, match.doc, match.properties[i]);
+	}
+	for (int i = 0; i < match.theme_properties.size(); i++) {
+		_create_theme_property_item(parent, match.doc, match.theme_properties[i]);
+	}
+
+	iterator_match = iterator_match->next();
+	return !iterator_match;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_phase_select_match() {
+	if (matched_item) {
+		matched_item->select(0);
+	}
+	return true;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_match_string(const String &p_term, const String &p_string) const {
+	if (search_flags & SEARCH_CASE_SENSITIVE) {
+		return p_string.find(p_term) > -1;
+	} else {
+		return p_string.findn(p_term) > -1;
+	}
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_match_visual_script(DocData::ClassDoc &class_doc) {
+	if (class_doc.category.ends_with("_class")) {
+		if (class_doc.category.begins_with("VisualScript") && search_flags & SEARCH_CLASSES) {
+			if (matches.has(class_doc.inherits)) {
+				return true;
+			}
+		}
+		return false;
+	}
+	if (class_doc.category.begins_with("VisualScript") && search_flags & SEARCH_VISUAL_SCRIPT_NODES) {
+		return true;
+	}
+	if (class_doc.name.begins_with("operators") && search_flags & SEARCH_OPERATORS) {
+		return true;
+	}
+	if (class_doc.category.begins_with("VisualScriptNode/deconstruct")) {
+		if (class_doc.name.find(selector_ui->base_type, 0) > -1) {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::_match_is_hidden(DocData::ClassDoc &class_doc) {
+	if (class_doc.category.begins_with("VisualScript")) {
+		if (class_doc.name.begins_with("flow_control")) {
+			return false;
+		} else if (class_doc.name.begins_with("operators")) {
+			return !(search_flags & SEARCH_OPERATORS);
+		} else if (class_doc.name.begins_with("functions/built_in/print")) {
+			return false;
+		}
+		return true;
+	}
+	return false;
+}
+
+void VisualScriptPropertySelector::SearchRunner::_match_item(TreeItem *p_item, const String &p_text) {
+	float inverse_length = 1.f / float(p_text.length());
+
+	// Favor types where search term is a substring close to the start of the type.
+	float w = 0.5f;
+	int pos = p_text.findn(term);
+	float score = (pos > -1) ? 1.0f - w * MIN(1, 3 * pos * inverse_length) : MAX(0.f, .9f - w);
+
+	// Favor shorter items: they resemble the search term more.
+	w = 0.1f;
+	score *= (1 - w) + w * (term.length() * inverse_length);
+
+	if (match_highest_score == 0 || score > match_highest_score) {
+		matched_item = p_item;
+		match_highest_score = score;
+	}
+}
+
+void VisualScriptPropertySelector::SearchRunner::_add_class_doc(String class_name, String inherits, String category) {
+	DocData::ClassDoc class_doc = DocData::ClassDoc();
+	class_doc.name = class_name;
+	class_doc.inherits = inherits;
+	class_doc.category = "VisualScriptNode/" + category;
+	class_doc.brief_description = category;
+	combined_docs.insert(class_doc.name, class_doc);
+}
+
+DocData::MethodDoc VisualScriptPropertySelector::SearchRunner::_get_method_doc(MethodInfo method_info) {
+	DocData::MethodDoc method_doc = DocData::MethodDoc();
+	method_doc.name = method_info.name;
+	method_doc.return_type = Variant::get_type_name(method_info.return_val.type);
+	method_doc.description = "No description available";
+	for (List<PropertyInfo>::Element *P = method_info.arguments.front(); P; P = P->next()) {
+		DocData::ArgumentDoc argument_doc = DocData::ArgumentDoc();
+		argument_doc.name = P->get().name;
+		argument_doc.type = Variant::get_type_name(P->get().type);
+		method_doc.arguments.push_back(argument_doc);
+	}
+	return method_doc;
+}
+
+TreeItem *VisualScriptPropertySelector::SearchRunner::_create_class_hierarchy(const ClassMatch &p_match) {
+	if (class_items.has(p_match.doc->name)) {
+		return class_items[p_match.doc->name];
+	}
+
+	// Ensure parent nodes are created first.
+	TreeItem *parent = root_item;
+	if (p_match.doc->inherits != "") {
+		if (class_items.has(p_match.doc->inherits)) {
+			parent = class_items[p_match.doc->inherits];
+		} else if (matches.has(p_match.doc->inherits)) {
+			ClassMatch &base_match = matches[p_match.doc->inherits];
+			parent = _create_class_hierarchy(base_match);
+		}
+	}
+
+	TreeItem *class_item = _create_class_item(parent, p_match.doc, !p_match.name);
+	class_items[p_match.doc->name] = class_item;
+	return class_item;
+}
+
+TreeItem *VisualScriptPropertySelector::SearchRunner::_create_class_item(TreeItem *p_parent, const DocData::ClassDoc *p_doc, bool p_gray) {
+	Ref<Texture2D> icon = empty_icon;
+	String text_0 = p_doc->name;
+	String text_1 = "Class";
+
+	String what = "Class";
+	String details = p_doc->name;
+	if (p_doc->category.begins_with("VisualScriptCustomNode/")) {
+		Vector<String> path = p_doc->name.split("/");
+		icon = ui_service->get_theme_icon("VisualScript", "EditorIcons");
+		text_0 = path[path.size() - 1];
+		text_1 = "VisualScriptCustomNode";
+		what = "VisualScriptCustomNode";
+		details = "CustomNode";
+	} else if (p_doc->category.begins_with("VisualScriptNode/")) {
+		Vector<String> path = p_doc->name.split("/");
+		icon = ui_service->get_theme_icon("VisualScript", "EditorIcons");
+		text_0 = path[path.size() - 1];
+		if (p_doc->category.begins_with("VisualScriptNode/deconstruct")) {
+			text_0 = "deconstruct " + text_0;
+		}
+		text_1 = "VisualScriptNode";
+		what = "VisualScriptNode";
+		details = p_doc->name;
+
+		if (path.size() == 1) {
+			if (path[0] == "functions" || path[0] == "operators") {
+				text_1 = "VisualScript";
+				p_gray = true;
+				what = "no_result";
+				details = "";
+			}
+		}
+
+	} else {
+		if (p_doc->name.is_quoted()) {
+			text_0 = p_doc->name.unquote().get_file();
+			if (ui_service->has_theme_icon(p_doc->inherits, "EditorIcons")) {
+				icon = ui_service->get_theme_icon(p_doc->inherits, "EditorIcons");
+			}
+		} else if (ui_service->has_theme_icon(p_doc->name, "EditorIcons")) {
+			icon = ui_service->get_theme_icon(p_doc->name, "EditorIcons");
+		} else if (ClassDB::class_exists(p_doc->name) && ClassDB::is_parent_class(p_doc->name, "Object")) {
+			icon = ui_service->get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
+		}
+	}
+	String tooltip = p_doc->brief_description.strip_edges();
+
+	TreeItem *item = results_tree->create_item(p_parent);
+	item->set_icon(0, icon);
+	item->set_text(0, text_0);
+	item->set_text(1, TTR(text_1));
+	item->set_tooltip(0, tooltip);
+	item->set_tooltip(1, tooltip);
+	item->set_metadata(0, details);
+	item->set_metadata(1, what);
+	if (p_gray) {
+		item->set_custom_color(0, disabled_color);
+		item->set_custom_color(1, disabled_color);
+	}
+
+	_match_item(item, p_doc->name);
+
+	return item;
+}
+
+TreeItem *VisualScriptPropertySelector::SearchRunner::_create_method_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const String &p_text, const DocData::MethodDoc *p_doc) {
+	String tooltip = p_doc->return_type + " " + p_class_doc->name + "." + p_doc->name + "(";
+	for (int i = 0; i < p_doc->arguments.size(); i++) {
+		const DocData::ArgumentDoc &arg = p_doc->arguments[i];
+		tooltip += arg.type + " " + arg.name;
+		if (arg.default_value != "") {
+			tooltip += " = " + arg.default_value;
+		}
+		if (i < p_doc->arguments.size() - 1) {
+			tooltip += ", ";
+		}
+	}
+	tooltip += ")";
+	return _create_member_item(p_parent, p_class_doc->name, "MemberMethod", p_doc->name, p_text, TTRC("Method"), "method", tooltip, p_doc->description);
+}
+
+TreeItem *VisualScriptPropertySelector::SearchRunner::_create_signal_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::MethodDoc *p_doc) {
+	String tooltip = p_doc->return_type + " " + p_class_doc->name + "." + p_doc->name + "(";
+	for (int i = 0; i < p_doc->arguments.size(); i++) {
+		const DocData::ArgumentDoc &arg = p_doc->arguments[i];
+		tooltip += arg.type + " " + arg.name;
+		if (arg.default_value != "") {
+			tooltip += " = " + arg.default_value;
+		}
+		if (i < p_doc->arguments.size() - 1) {
+			tooltip += ", ";
+		}
+	}
+	tooltip += ")";
+	return _create_member_item(p_parent, p_class_doc->name, "MemberSignal", p_doc->name, p_doc->name, TTRC("Signal"), "signal", tooltip, p_doc->description);
+}
+
+TreeItem *VisualScriptPropertySelector::SearchRunner::_create_constant_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::ConstantDoc *p_doc) {
+	String tooltip = p_class_doc->name + "." + p_doc->name;
+	return _create_member_item(p_parent, p_class_doc->name, "MemberConstant", p_doc->name, p_doc->name, TTRC("Constant"), "constant", tooltip, p_doc->description);
+}
+
+TreeItem *VisualScriptPropertySelector::SearchRunner::_create_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::PropertyDoc *p_doc) {
+	String tooltip = p_doc->type + " " + p_class_doc->name + "." + p_doc->name;
+	tooltip += "\n    " + p_class_doc->name + "." + p_doc->setter + "(value) setter";
+	tooltip += "\n    " + p_class_doc->name + "." + p_doc->getter + "() getter";
+	return _create_member_item(p_parent, p_class_doc->name, "MemberProperty", p_doc->name, p_doc->name, TTRC("Property"), "property", tooltip, p_doc->description);
+}
+
+TreeItem *VisualScriptPropertySelector::SearchRunner::_create_theme_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::ThemeItemDoc *p_doc) {
+	String tooltip = p_doc->type + " " + p_class_doc->name + "." + p_doc->name;
+	return _create_member_item(p_parent, p_class_doc->name, "MemberTheme", p_doc->name, p_doc->name, TTRC("Theme Property"), "theme_item", tooltip, p_doc->description);
+}
+
+TreeItem *VisualScriptPropertySelector::SearchRunner::_create_member_item(TreeItem *p_parent, const String &p_class_name, const String &p_icon, const String &p_name, const String &p_text, const String &p_type, const String &p_metatype, const String &p_tooltip, const String &p_description) {
+	Ref<Texture2D> icon;
+	String text;
+	if (search_flags & SEARCH_SHOW_HIERARCHY) {
+		icon = ui_service->get_theme_icon(p_icon, SNAME("EditorIcons"));
+		text = p_text;
+	} else {
+		icon = ui_service->get_theme_icon(p_icon, SNAME("EditorIcons"));
+		text = p_class_name + "." + p_text;
+	}
+
+	TreeItem *item = results_tree->create_item(p_parent);
+	item->set_icon(0, icon);
+	item->set_text(0, text);
+	item->set_text(1, TTRGET(p_type));
+	item->set_tooltip(0, p_tooltip);
+	item->set_tooltip(1, p_tooltip);
+	item->set_metadata(0, p_class_name + ":" + p_name);
+	item->set_metadata(1, "class_" + p_metatype);
+	item->set_meta("description", p_description);
+
+	_match_item(item, p_name);
+
+	return item;
+}
+
+bool VisualScriptPropertySelector::SearchRunner::work(uint64_t slot) {
+	// Return true when the search has been completed, otherwise false.
+	const uint64_t until = OS::get_singleton()->get_ticks_usec() + slot;
+	while (!_slice()) {
+		if (OS::get_singleton()->get_ticks_usec() > until) {
+			return false;
+		}
+	}
+	return true;
+}
+
+VisualScriptPropertySelector::SearchRunner::SearchRunner(VisualScriptPropertySelector *p_selector_ui, Tree *p_results_tree) :
+		selector_ui(p_selector_ui),
+		ui_service(p_selector_ui->vbox),
+		results_tree(p_results_tree),
+		term(p_selector_ui->search_box->get_text()),
+		empty_icon(ui_service->get_theme_icon(SNAME("ArrowRight"), SNAME("EditorIcons"))),
+		disabled_color(ui_service->get_theme_color(SNAME("disabled_font_color"), SNAME("Editor"))) {
 }

--- a/modules/visual_script/editor/visual_script_property_selector.h
+++ b/modules/visual_script/editor/visual_script_property_selector.h
@@ -31,6 +31,7 @@
 #ifndef VISUALSCRIPT_PROPERTYSELECTOR_H
 #define VISUALSCRIPT_PROPERTYSELECTOR_H
 
+#include "../visual_script.h"
 #include "editor/editor_help.h"
 #include "editor/property_editor.h"
 #include "scene/gui/rich_text_label.h"
@@ -38,15 +39,56 @@
 class VisualScriptPropertySelector : public ConfirmationDialog {
 	GDCLASS(VisualScriptPropertySelector, ConfirmationDialog);
 
+	enum SearchFlags {
+		SEARCH_CLASSES = 1 << 0,
+		SEARCH_CONSTRUCTORS = 1 << 1,
+		SEARCH_METHODS = 1 << 2,
+		SEARCH_OPERATORS = 1 << 3,
+		SEARCH_SIGNALS = 1 << 4,
+		SEARCH_CONSTANTS = 1 << 5,
+		SEARCH_PROPERTIES = 1 << 6,
+		SEARCH_THEME_ITEMS = 1 << 7,
+		SEARCH_VISUAL_SCRIPT_NODES = 1 << 8,
+		SEARCH_ALL = SEARCH_CLASSES | SEARCH_CONSTRUCTORS | SEARCH_METHODS | SEARCH_OPERATORS | SEARCH_SIGNALS | SEARCH_CONSTANTS | SEARCH_PROPERTIES | SEARCH_THEME_ITEMS,
+		SEARCH_CASE_SENSITIVE = 1 << 29,
+		SEARCH_SHOW_HIERARCHY = 1 << 30,
+	};
+
+	enum ScopeFlags {
+		SCOPE_BASE = 1 << 0,
+		SCOPE_INHERITERS = 1 << 1,
+		SCOPE_UNRELATED = 1 << 2,
+		SCOPE_RELATED = SCOPE_BASE | SCOPE_INHERITERS,
+		SCOPE_ALL = SCOPE_BASE | SCOPE_INHERITERS | SCOPE_UNRELATED
+	};
+
 	LineEdit *search_box;
-	Tree *search_options;
 
-	void _text_changed(const String &p_newtext);
+	Button *case_sensitive_button;
+	Button *hierarchy_button;
+
+	Button *search_visual_script_nodes;
+	Button *search_classes;
+	Button *search_operators;
+
+	Button *search_methods;
+	Button *search_signals;
+	Button *search_constants;
+	Button *search_properties;
+	Button *search_theme_items;
+
+	OptionButton *scope_combo;
+	Tree *results_tree;
+
+	class SearchRunner;
+	Ref<SearchRunner> search_runner;
+
+	void _update_icons();
+
 	void _sbox_input(const Ref<InputEvent> &p_ie);
-	void _update_search();
-
-	void create_visualscript_item(const String &name, TreeItem *const root, const String &search_input, const String &text);
-	void get_visual_node_names(const String &root_filter, const Set<String> &p_modifiers, bool &found, TreeItem *const root, LineEdit *const search_box);
+	void _update_results_i(int p_int);
+	void _update_results_s(String p_string);
+	void _update_results();
 
 	void _confirmed();
 	void _item_selected();
@@ -60,32 +102,118 @@ class VisualScriptPropertySelector : public ConfirmationDialog {
 	String selected;
 	Variant::Type type;
 	String base_type;
+	String base_script;
 	ObjectID script;
 	Object *instance;
 	bool virtuals_only;
-	bool seq_connect;
-	VBoxContainer *vbc;
-
-	Vector<Variant::Type> type_filter;
+	VBoxContainer *vbox;
 
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
-	void select_method_from_base_type(const String &p_base, const String &p_current = "", const bool p_virtuals_only = false, const bool p_connecting = true, bool clear_text = true);
-	void select_from_base_type(const String &p_base, const String &p_current = "", bool p_virtuals_only = false, bool p_seq_connect = false, const bool p_connecting = true, bool clear_text = true);
-	void select_from_script(const Ref<Script> &p_script, const String &p_current = "", const bool p_connecting = true, bool clear_text = true);
-	void select_from_basic_type(Variant::Type p_type, const String &p_current = "", const bool p_connecting = true, bool clear_text = true);
-	void select_from_action(const String &p_type, const String &p_current = "", const bool p_connecting = true, bool clear_text = true);
-	void select_from_instance(Object *p_instance, const String &p_current = "", const bool p_connecting = true, const String &p_basetype = "", bool clear_text = true);
-	void select_from_visual_script(const String &p_base, const bool p_connecting = true, bool clear_text = true);
+	void select_method_from_base_type(const String &p_base, const bool p_virtuals_only = false, const bool p_connecting = true, bool clear_text = true);
+	void select_from_base_type(const String &p_base, const String &p_base_script = "", bool p_virtuals_only = false, const bool p_connecting = true, bool clear_text = true);
+	void select_from_script(const Ref<Script> &p_script, const bool p_connecting = true, bool clear_text = true);
+	void select_from_basic_type(Variant::Type p_type, const bool p_connecting = true, bool clear_text = true);
+	void select_from_action(const String &p_type, const bool p_connecting = true, bool clear_text = true);
+	void select_from_instance(Object *p_instance, const bool p_connecting = true, bool clear_text = true);
+	void select_from_visual_script(const Ref<Script> &p_script, bool clear_text = true);
 
 	void show_window(float p_screen_ratio);
 
-	void set_type_filter(const Vector<Variant::Type> &p_type_filter);
-
 	VisualScriptPropertySelector();
+};
+
+class VisualScriptPropertySelector::SearchRunner : public RefCounted {
+	enum Phase {
+		PHASE_INIT,
+		PHASE_MATCH_CLASSES_INIT,
+		PHASE_NODE_CLASSES_INIT,
+		PHASE_NODE_CLASSES_BUILD,
+		PHASE_MATCH_CLASSES,
+		PHASE_CLASS_ITEMS_INIT,
+		PHASE_CLASS_ITEMS,
+		PHASE_MEMBER_ITEMS_INIT,
+		PHASE_MEMBER_ITEMS,
+		PHASE_SELECT_MATCH,
+		PHASE_MAX
+	};
+	int phase = 0;
+
+	struct ClassMatch {
+		DocData::ClassDoc *doc;
+		bool name = false;
+		String category = "";
+		Vector<DocData::MethodDoc *> constructors;
+		Vector<DocData::MethodDoc *> methods;
+		Vector<DocData::MethodDoc *> operators;
+		Vector<DocData::MethodDoc *> signals;
+		Vector<DocData::ConstantDoc *> constants;
+		Vector<DocData::PropertyDoc *> properties;
+		Vector<DocData::ThemeItemDoc *> theme_properties;
+
+		bool required() {
+			return name || methods.size() || signals.size() || constants.size() || properties.size() || theme_properties.size();
+		}
+	};
+
+	VisualScriptPropertySelector *selector_ui;
+	Control *ui_service;
+	Tree *results_tree;
+	String term;
+	int search_flags;
+	int scope_flags;
+
+	Ref<Texture2D> empty_icon;
+	Color disabled_color;
+
+	Map<String, DocData::ClassDoc>::Element *iterator_doc = nullptr;
+	Map<String, ClassMatch> matches;
+	Map<String, ClassMatch>::Element *iterator_match = nullptr;
+	TreeItem *root_item = nullptr;
+	Map<String, TreeItem *> class_items;
+	TreeItem *matched_item = nullptr;
+	float match_highest_score = 0;
+
+	Map<String, DocData::ClassDoc> combined_docs;
+	List<String> vs_nodes;
+
+	bool _is_class_disabled_by_feature_profile(const StringName &p_class);
+	bool _is_class_disabled_by_scope(const StringName &p_class);
+
+	bool _slice();
+	bool _phase_init();
+	bool _phase_match_classes_init();
+	bool _phase_node_classes_init();
+	bool _phase_node_classes_build();
+	bool _phase_match_classes();
+	bool _phase_class_items_init();
+	bool _phase_class_items();
+	bool _phase_member_items_init();
+	bool _phase_member_items();
+	bool _phase_select_match();
+
+	bool _match_string(const String &p_term, const String &p_string) const;
+	bool _match_visual_script(DocData::ClassDoc &class_doc);
+	bool _match_is_hidden(DocData::ClassDoc &class_doc);
+	void _match_item(TreeItem *p_item, const String &p_text);
+	void _add_class_doc(String class_name, String inherits, String category);
+	DocData::MethodDoc _get_method_doc(MethodInfo method_info);
+	TreeItem *_create_class_hierarchy(const ClassMatch &p_match);
+	TreeItem *_create_class_item(TreeItem *p_parent, const DocData::ClassDoc *p_doc, bool p_gray);
+	TreeItem *_create_method_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const String &p_text, const DocData::MethodDoc *p_doc);
+	TreeItem *_create_signal_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::MethodDoc *p_doc);
+	TreeItem *_create_constant_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::ConstantDoc *p_doc);
+	TreeItem *_create_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::PropertyDoc *p_doc);
+	TreeItem *_create_theme_property_item(TreeItem *p_parent, const DocData::ClassDoc *p_class_doc, const DocData::ThemeItemDoc *p_doc);
+	TreeItem *_create_member_item(TreeItem *p_parent, const String &p_class_name, const String &p_icon, const String &p_name, const String &p_text, const String &p_type, const String &p_metatype, const String &p_tooltip, const String &p_description);
+
+public:
+	bool work(uint64_t slot = 100000);
+
+	SearchRunner(VisualScriptPropertySelector *p_selector_ui, Tree *p_results_tree);
 };
 
 #endif // VISUALSCRIPT_PROPERTYSELECTOR_H


### PR DESCRIPTION
# proposal [#3528](https://github.com/godotengine/godot-proposals/issues/3528)

While filters are preset they are fully editable while searching.
The base is set relative to what input the editor gives.

- It is way easier to use constants.
- Its is possible to find content, not inside the base.

![image](https://user-images.githubusercontent.com/20573784/147412844-bf924dec-9320-4d09-93ca-2b3c437e2fc3.png)
![image](https://user-images.githubusercontent.com/20573784/147413106-95785e7c-0d3a-4d7c-b7dc-aa3c3685a167.png)

https://user-images.githubusercontent.com/20573784/147594930-b8daf8bb-67a0-4fe2-90c8-9a33177e07d5.mp4

Fixes: https://github.com/godotengine/godot-proposals/issues/3528
