### PR TITLE
Release focus of Control Node when exiting tree

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -589,6 +589,7 @@ void Control::_notification(int p_notification) {
 			_size_changed();
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
+			release_focus();
 			get_viewport()->_gui_remove_control(this);
 		} break;
 		case NOTIFICATION_READY: {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes #56247

`Control::release_focus` is called when `NOTIFICATION_EXIT_TREE` is recieved in `Control::_notification`.