### PR TITLE
Fix size of the default property popup after opening a Color property

### DIFF
--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -810,7 +810,7 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				//late init for performance
 				color_picker = memnew(ColorPicker);
 				color_picker->set_deferred_mode(true);
-				add_child(color_picker);
+				value_vbox->add_child(color_picker);
 				color_picker->hide();
 				color_picker->connect("color_changed", callable_mp(this, &CustomPropertyEditor::_color_changed));
 


### PR DESCRIPTION
Fix incorrect property editor popup size:

<details>
<summary>Details</summary>

![image](https://user-images.githubusercontent.com/3036176/147417632-429d3387-9c1a-404d-bf63-696ff2c7a419.png)

</details>

 
This happens after first open a Color property:

<details>
<summary>Details</summary>

![fix_prop_popup_size](https://user-images.githubusercontent.com/3036176/147417624-8b21eba4-95e2-4f72-9981-7901d9a94138.gif)

</details>

