### PR TITLE
State that get static memory usage only works in debug

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -348,7 +348,7 @@
 		<method name="get_static_memory_usage" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the amount of static memory being used by the program in bytes.
+				Returns the amount of static memory being used by the program in bytes (only works in debug).
 			</description>
 		</method>
 		<method name="get_system_dir" qualifiers="const">


### PR DESCRIPTION
Does what the title says. Closes https://github.com/godotengine/godot-docs/issues/5473
