### PR TITLE
[3.x] Add BLEND_MODE_DISABLED for spatial shaders.

### DIFF
--- a/doc/classes/SpatialMaterial.xml
+++ b/doc/classes/SpatialMaterial.xml
@@ -486,6 +486,9 @@
 		<constant name="BLEND_MODE_MUL" value="3" enum="BlendMode">
 			The color of the object is multiplied by the background.
 		</constant>
+		<constant name="BLEND_MODE_DISABLED" value="4" enum="BlendMode">
+			Blending is disabled, leaving the object's color untouched.
+		</constant>
 		<constant name="DEPTH_DRAW_OPAQUE_ONLY" value="0" enum="DepthDrawMode">
 			Default depth draw mode. Depth is drawn only for opaque objects.
 		</constant>

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -2046,14 +2046,28 @@ void RasterizerSceneGLES3::_render_list(RenderList::Element **p_elements, int p_
 
 			if (p_alpha_pass || p_directional_add) {
 				int desired_blend_mode;
+
 				if (p_directional_add) {
 					desired_blend_mode = RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_ADD;
 				} else {
 					desired_blend_mode = material->shader->spatial.blend_mode;
 				}
 
+				if (desired_blend_mode == RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_DISABLED && (!storage->frame.current_rt || !storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT])) {
+					desired_blend_mode = RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_MIX;
+				}
+
 				if (desired_blend_mode != current_blend_mode) {
+					if (current_blend_mode == RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_DISABLED) {
+						// re-enable it
+						glEnable(GL_BLEND);
+					} else if (desired_blend_mode == RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_DISABLED) {
+						// disable it
+						glDisable(GL_BLEND);
+					}
 					switch (desired_blend_mode) {
+						case RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_DISABLED: {
+						} break;
 						case RasterizerStorageGLES3::Shader::Spatial::BLEND_MODE_MIX: {
 							glBlendEquation(GL_FUNC_ADD);
 							if (storage->frame.current_rt && storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT]) {

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2241,6 +2241,7 @@ void RasterizerStorageGLES3::_update_shader(Shader *p_shader) const {
 			shaders.actions_scene.render_mode_values["blend_mix"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_MIX);
 			shaders.actions_scene.render_mode_values["blend_sub"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_SUB);
 			shaders.actions_scene.render_mode_values["blend_mul"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_MUL);
+			shaders.actions_scene.render_mode_values["blend_disabled"] = Pair<int *, int>(&p_shader->spatial.blend_mode, Shader::Spatial::BLEND_MODE_DISABLED);
 
 			shaders.actions_scene.render_mode_values["depth_draw_opaque"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_OPAQUE);
 			shaders.actions_scene.render_mode_values["depth_draw_always"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, Shader::Spatial::DEPTH_DRAW_ALWAYS);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -480,6 +480,7 @@ public:
 				BLEND_MODE_ADD,
 				BLEND_MODE_SUB,
 				BLEND_MODE_MUL,
+				BLEND_MODE_DISABLED,
 			};
 
 			int blend_mode;

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -404,6 +404,9 @@ void SpatialMaterial::_update_shader() {
 		case BLEND_MODE_MUL:
 			code += "blend_mul";
 			break;
+		case BLEND_MODE_DISABLED:
+			code += "blend_disabled";
+			break;
 	}
 
 	DepthDrawMode ddm = depth_draw_mode;
@@ -1035,6 +1038,9 @@ void SpatialMaterial::_update_shader() {
 			} break;
 			case BLEND_MODE_MUL: {
 				code += "\tvec3 detail = mix(ALBEDO.rgb,ALBEDO.rgb*detail_tex.rgb,detail_tex.a);\n";
+			} break;
+			case BLEND_MODE_DISABLED: {
+				code += "\tvec3 detail = ALBEDO.rgb;\n";
 			} break;
 		}
 
@@ -2040,7 +2046,7 @@ void SpatialMaterial::_bind_methods() {
 	ADD_GROUP("Parameters", "params_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_diffuse_mode", PROPERTY_HINT_ENUM, "Burley,Lambert,Lambert Wrap,Oren Nayar,Toon"), "set_diffuse_mode", "get_diffuse_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_specular_mode", PROPERTY_HINT_ENUM, "SchlickGGX,Blinn,Phong,Toon,Disabled"), "set_specular_mode", "get_specular_mode");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Sub,Mul"), "set_blend_mode", "get_blend_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Sub,Mul,Disabled"), "set_blend_mode", "get_blend_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_cull_mode", PROPERTY_HINT_ENUM, "Back,Front,Disabled"), "set_cull_mode", "get_cull_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "params_depth_draw_mode", PROPERTY_HINT_ENUM, "Opaque Only,Always,Never,Opaque Pre-Pass"), "set_depth_draw_mode", "get_depth_draw_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "params_line_width", PROPERTY_HINT_RANGE, "0.1,128,0.1"), "set_line_width", "get_line_width");
@@ -2137,7 +2143,7 @@ void SpatialMaterial::_bind_methods() {
 	ADD_GROUP("Detail", "detail_");
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "detail_enabled"), "set_feature", "get_feature", FEATURE_DETAIL);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "detail_mask", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_texture", "get_texture", TEXTURE_DETAIL_MASK);
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "detail_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Sub,Mul"), "set_detail_blend_mode", "get_detail_blend_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "detail_blend_mode", PROPERTY_HINT_ENUM, "Mix,Add,Sub,Mul,Disabled"), "set_detail_blend_mode", "get_detail_blend_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "detail_uv_layer", PROPERTY_HINT_ENUM, "UV1,UV2"), "set_detail_uv", "get_detail_uv");
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "detail_albedo", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_texture", "get_texture", TEXTURE_DETAIL_ALBEDO);
 	ADD_PROPERTYI(PropertyInfo(Variant::OBJECT, "detail_normal", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_texture", "get_texture", TEXTURE_DETAIL_NORMAL);
@@ -2203,6 +2209,7 @@ void SpatialMaterial::_bind_methods() {
 	BIND_ENUM_CONSTANT(BLEND_MODE_ADD);
 	BIND_ENUM_CONSTANT(BLEND_MODE_SUB);
 	BIND_ENUM_CONSTANT(BLEND_MODE_MUL);
+	BIND_ENUM_CONSTANT(BLEND_MODE_DISABLED);
 
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_OPAQUE_ONLY);
 	BIND_ENUM_CONSTANT(DEPTH_DRAW_ALWAYS);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -155,6 +155,7 @@ public:
 		BLEND_MODE_ADD,
 		BLEND_MODE_SUB,
 		BLEND_MODE_MUL,
+		BLEND_MODE_DISABLED,
 	};
 
 	enum DepthDrawMode {

--- a/servers/visual/shader_types.cpp
+++ b/servers/visual/shader_types.cpp
@@ -161,6 +161,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("blend_add");
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("blend_sub");
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("blend_mul");
+	shader_modes[VS::SHADER_SPATIAL].modes.push_back("blend_disabled");
 
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("depth_draw_opaque");
 	shader_modes[VS::SHADER_SPATIAL].modes.push_back("depth_draw_always");


### PR DESCRIPTION
I made this pull request by manually reviewing the changes in [35278](https://github.com/godotengine/godot/pull/35278) for use in the `3.x` branch, and added relevant documentation for the new `BlendMode` enum value.

As is stated in the original PR, this is a really useful feature for multi-pass compute involving tightly packed data in color channels. For my use case, I need a solution (implemented via render mode in this case) that i can pair with the `unshaded` render mode to be able to modify the alpha channel to a value other than 1 without the graphics driver subsequently modifying the values in the albedo channels, so that i can use the alpha channel for data transfer as well as the albedo ones.