### PR TITLE
Fix "flip faces" description

### DIFF
--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -34,7 +34,7 @@
 		</member>
 		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces" default="false">
 			If set, the order of the vertices in each triangle are reversed resulting in the backside of the mesh being drawn.
-			This gives the same result as using [constant BaseMaterial3D.CULL_BACK] in [member BaseMaterial3D.cull_mode].
+			This gives the same result as using [constant BaseMaterial3D.CULL_FRONT] in [member BaseMaterial3D.cull_mode].
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			The current [Material] of the primitive mesh.


### PR DESCRIPTION
flip faces gives the same result as `CULL_FRONT` not `CULL_BACK`. Closes https://github.com/godotengine/godot-docs/issues/5060
