### PR TITLE
[3.x] Clear pending function states when reloading GDScript

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -112,6 +112,7 @@ class GDScript : public Script {
 	SelfList<GDScript> script_list;
 
 	SelfList<GDScriptFunctionState>::List pending_func_states;
+	void _clear_pending_func_states();
 
 	GDScriptInstance *_create_instance(const Variant **p_args, int p_argcount, Object *p_owner, bool p_isref, Variant::CallError &r_error);
 


### PR DESCRIPTION
Fixes #56116

Since reloading a GDScript frees previous `GDScriptFunction`s, pending `GDScriptFunctionState`s should also be cleared.

The MRP won't crash after this PR. The animations won't be working after reload because they're done via an infinite loop with `yield()` sleeps. I don't think we can remap the function states to resume inside newly created functions, as they could be completely different.