### PR TITLE
Fix getting properties state when reloading C#

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -1762,7 +1762,16 @@ void CSharpInstance::get_properties_state_for_reloading(List<Pair<StringName, Va
 
 		ManagedType managedType;
 
-		GDMonoField *field = script->script_class->get_field(state_pair.first);
+		GDMonoField *field = nullptr;
+		GDMonoClass *top = script->script_class;
+		while (top && top != script->native) {
+			field = top->get_field(state_pair.first);
+			if (field) {
+				break;
+			}
+
+			top = top->get_parent_class();
+		}
 		if (!field) {
 			continue; // Properties ignored. We get the property baking fields instead.
 		}


### PR DESCRIPTION
When reloading C# classes and keep their properties values they are retrieved and stored in a state list.
Retrieving the properties was only getting the fields of the C# class and not inherited fields so those properties values were lost on reload.
Now we also try to find the field in the parent classes. This mirrors what methods `get` and `set` do when retrieving a field.

Closes #37812
