### PR TITLE
Check if action name exists before adding it or renaming an action to it

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -760,9 +760,23 @@ void ActionMapEditor::_add_action_pressed() {
 	_add_action(add_edit->get_text());
 }
 
+bool ActionMapEditor::_has_action(const String &p_name) const {
+	for (const ActionInfo &action_info : actions_cache) {
+		if (p_name == action_info.name) {
+			return true;
+		}
+	}
+	return false;
+}
+
 void ActionMapEditor::_add_action(const String &p_name) {
 	if (p_name.is_empty() || !_is_action_name_valid(p_name)) {
 		show_message(TTR("Invalid action name. It cannot be empty nor contain '/', ':', '=', '\\' or '\"'"));
+		return;
+	}
+
+	if (_has_action(p_name)) {
+		show_message(vformat(TTR("An action with the name '%s' already exists."), p_name));
 		return;
 	}
 
@@ -788,6 +802,12 @@ void ActionMapEditor::_action_edited() {
 		if (new_name.is_empty() || !_is_action_name_valid(new_name)) {
 			ti->set_text(0, old_name);
 			show_message(TTR("Invalid action name. It cannot be empty nor contain '/', ':', '=', '\\' or '\"'"));
+			return;
+		}
+
+		if (_has_action(new_name)) {
+			ti->set_text(0, old_name);
+			show_message(vformat(TTR("An action with the name '%s' already exists."), new_name));
 			return;
 		}
 

--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -168,6 +168,7 @@ private:
 	void _event_config_confirmed();
 
 	void _add_action_pressed();
+	bool _has_action(const String &p_name) const;
 	void _add_action(const String &p_name);
 	void _action_edited();
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -275,10 +275,8 @@ void ProjectSettingsEditor::_editor_restart_close() {
 void ProjectSettingsEditor::_action_added(const String &p_name) {
 	String name = "input/" + p_name;
 
-	if (ProjectSettings::get_singleton()->has_setting(name)) {
-		action_map->show_message(vformat(TTR("An action with the name '%s' already exists."), name));
-		return;
-	}
+	ERR_FAIL_COND_MSG(ProjectSettings::get_singleton()->has_setting(name),
+			"An action with this name already exists.");
 
 	Dictionary action;
 	action["events"] = Array();
@@ -351,10 +349,8 @@ void ProjectSettingsEditor::_action_renamed(const String &p_old_name, const Stri
 	const String old_property_name = "input/" + p_old_name;
 	const String new_property_name = "input/" + p_new_name;
 
-	if (ProjectSettings::get_singleton()->has_setting(new_property_name)) {
-		action_map->show_message(vformat(TTR("An action with the name '%s' already exists."), new_property_name));
-		return;
-	}
+	ERR_FAIL_COND_MSG(ProjectSettings::get_singleton()->has_setting(new_property_name),
+			"An action with this name already exists.");
 
 	int order = ProjectSettings::get_singleton()->get_order(old_property_name);
 	Dictionary action = ProjectSettings::get_singleton()->get(old_property_name);


### PR DESCRIPTION
Currently, the check whether or not an action name already exists is only done when trying to change the project setting. This prevents any corrective action being taken. As identified by @SpiceyWolf in #54698, this will leave a renamed Action with the invalid duplicate name in the Input Map editor.

This PR performs the check before trying to change the project setting and, in the case of a rename, sets the name back to the old name.

Fixes: #54698