### PR TITLE
Improve error when attempting to build with `tools=yes target=release`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -583,7 +583,8 @@ if selected_platform in platform_list:
 
     if env["target"] == "release":
         if env["tools"]:
-            print("Error: The editor can only be built with `target=debug` or `target=release_debug`.")
+            print("ERROR: The editor can only be built with `target=debug` or `target=release_debug`.")
+            print("       Use `tools=no target=release` to build a release export template.")
             Exit(255)
         suffix += ".opt"
         env.Append(CPPDEFINES=["NDEBUG"])


### PR DESCRIPTION
This points to using `tools=no` to build a release export template.