### PR TITLE
Rename speed to velocity when it's a directional Vector

### DIFF
--- a/core/input/input.h
+++ b/core/input/input.h
@@ -117,9 +117,9 @@ private:
 
 	int mouse_from_touch_index = -1;
 
-	struct SpeedTrack {
+	struct VelocityTrack {
 		uint64_t last_tick;
-		Vector2 speed;
+		Vector2 velocity;
 		Vector2 accum;
 		float accum_t;
 		float min_ref_frame;
@@ -127,7 +127,7 @@ private:
 
 		void update(const Vector2 &p_delta_p);
 		void reset();
-		SpeedTrack();
+		VelocityTrack();
 	};
 
 	struct Joypad {
@@ -141,8 +141,8 @@ private:
 		int hat_current = 0;
 	};
 
-	SpeedTrack mouse_speed_track;
-	Map<int, SpeedTrack> touch_speed_track;
+	VelocityTrack mouse_velocity_track;
+	Map<int, VelocityTrack> touch_velocity_track;
 	Map<int, Joypad> joy_names;
 	int fallback_mapping = -1;
 
@@ -274,7 +274,7 @@ public:
 	Vector3 get_gyroscope() const;
 
 	Point2 get_mouse_position() const;
-	Point2 get_last_mouse_speed() const;
+	Vector2 get_last_mouse_velocity() const;
 	MouseButton get_mouse_button_mask() const;
 
 	void warp_mouse_position(const Vector2 &p_to);

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -739,20 +739,15 @@ Vector2 InputEventMouseMotion::get_relative() const {
 	return relative;
 }
 
-void InputEventMouseMotion::set_speed(const Vector2 &p_speed) {
-	speed = p_speed;
+void InputEventMouseMotion::set_velocity(const Vector2 &p_velocity) {
+	velocity = p_velocity;
 }
 
-Vector2 InputEventMouseMotion::get_speed() const {
-	return speed;
+Vector2 InputEventMouseMotion::get_velocity() const {
+	return velocity;
 }
 
 Ref<InputEvent> InputEventMouseMotion::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
-	Vector2 g = get_global_position();
-	Vector2 l = p_xform.xform(get_position() + p_local_ofs);
-	Vector2 r = p_xform.basis_xform(get_relative());
-	Vector2 s = p_xform.basis_xform(get_speed());
-
 	Ref<InputEventMouseMotion> mm;
 	mm.instantiate();
 
@@ -761,20 +756,20 @@ Ref<InputEvent> InputEventMouseMotion::xformed_by(const Transform2D &p_xform, co
 
 	mm->set_modifiers_from_event(this);
 
-	mm->set_position(l);
+	mm->set_position(p_xform.xform(get_position() + p_local_ofs));
 	mm->set_pressure(get_pressure());
 	mm->set_tilt(get_tilt());
-	mm->set_global_position(g);
+	mm->set_global_position(get_global_position());
 
 	mm->set_button_mask(get_button_mask());
-	mm->set_relative(r);
-	mm->set_speed(s);
+	mm->set_relative(p_xform.basis_xform(get_relative()));
+	mm->set_velocity(p_xform.basis_xform(get_velocity()));
 
 	return mm;
 }
 
 String InputEventMouseMotion::as_text() const {
-	return vformat(RTR("Mouse motion at position (%s) with speed (%s)"), String(get_position()), String(get_speed()));
+	return vformat(RTR("Mouse motion at position (%s) with velocity (%s)"), String(get_position()), String(get_velocity()));
 }
 
 String InputEventMouseMotion::to_string() {
@@ -802,7 +797,7 @@ String InputEventMouseMotion::to_string() {
 
 	// Work around the fact vformat can only take 5 substitutions but 6 need to be passed.
 	String mask_and_position = vformat("button_mask=%s, position=(%s)", button_mask_string, String(get_position()));
-	return vformat("InputEventMouseMotion: %s, relative=(%s), speed=(%s), pressure=%.2f, tilt=(%s)", mask_and_position, String(get_relative()), String(get_speed()), get_pressure(), String(get_tilt()));
+	return vformat("InputEventMouseMotion: %s, relative=(%s), velocity=(%s), pressure=%.2f, tilt=(%s)", mask_and_position, String(get_relative()), String(get_velocity()), get_pressure(), String(get_tilt()));
 }
 
 bool InputEventMouseMotion::accumulate(const Ref<InputEvent> &p_event) {
@@ -841,7 +836,7 @@ bool InputEventMouseMotion::accumulate(const Ref<InputEvent> &p_event) {
 
 	set_position(motion->get_position());
 	set_global_position(motion->get_global_position());
-	set_speed(motion->get_speed());
+	set_velocity(motion->get_velocity());
 	relative += motion->get_relative();
 
 	return true;
@@ -857,13 +852,13 @@ void InputEventMouseMotion::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_relative", "relative"), &InputEventMouseMotion::set_relative);
 	ClassDB::bind_method(D_METHOD("get_relative"), &InputEventMouseMotion::get_relative);
 
-	ClassDB::bind_method(D_METHOD("set_speed", "speed"), &InputEventMouseMotion::set_speed);
-	ClassDB::bind_method(D_METHOD("get_speed"), &InputEventMouseMotion::get_speed);
+	ClassDB::bind_method(D_METHOD("set_velocity", "velocity"), &InputEventMouseMotion::set_velocity);
+	ClassDB::bind_method(D_METHOD("get_velocity"), &InputEventMouseMotion::get_velocity);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "tilt"), "set_tilt", "get_tilt");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pressure"), "set_pressure", "get_pressure");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "relative"), "set_relative", "get_relative");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "speed"), "set_speed", "get_speed");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "velocity"), "set_velocity", "get_velocity");
 }
 
 ///////////////////////////////////
@@ -1188,12 +1183,12 @@ Vector2 InputEventScreenDrag::get_relative() const {
 	return relative;
 }
 
-void InputEventScreenDrag::set_speed(const Vector2 &p_speed) {
-	speed = p_speed;
+void InputEventScreenDrag::set_velocity(const Vector2 &p_velocity) {
+	velocity = p_velocity;
 }
 
-Vector2 InputEventScreenDrag::get_speed() const {
-	return speed;
+Vector2 InputEventScreenDrag::get_velocity() const {
+	return velocity;
 }
 
 Ref<InputEvent> InputEventScreenDrag::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
@@ -1207,17 +1202,17 @@ Ref<InputEvent> InputEventScreenDrag::xformed_by(const Transform2D &p_xform, con
 	sd->set_index(index);
 	sd->set_position(p_xform.xform(pos + p_local_ofs));
 	sd->set_relative(p_xform.basis_xform(relative));
-	sd->set_speed(p_xform.basis_xform(speed));
+	sd->set_velocity(p_xform.basis_xform(velocity));
 
 	return sd;
 }
 
 String InputEventScreenDrag::as_text() const {
-	return vformat(RTR("Screen dragged with %s touch points at position (%s) with speed of (%s)"), itos(index), String(get_position()), String(get_speed()));
+	return vformat(RTR("Screen dragged with %s touch points at position (%s) with velocity of (%s)"), itos(index), String(get_position()), String(get_velocity()));
 }
 
 String InputEventScreenDrag::to_string() {
-	return vformat("InputEventScreenDrag: index=%d, position=(%s), relative=(%s), speed=(%s)", index, String(get_position()), String(get_relative()), String(get_speed()));
+	return vformat("InputEventScreenDrag: index=%d, position=(%s), relative=(%s), velocity=(%s)", index, String(get_position()), String(get_relative()), String(get_velocity()));
 }
 
 bool InputEventScreenDrag::accumulate(const Ref<InputEvent> &p_event) {
@@ -1230,7 +1225,7 @@ bool InputEventScreenDrag::accumulate(const Ref<InputEvent> &p_event) {
 	}
 
 	set_position(drag->get_position());
-	set_speed(drag->get_speed());
+	set_velocity(drag->get_velocity());
 	relative += drag->get_relative();
 
 	return true;
@@ -1246,13 +1241,13 @@ void InputEventScreenDrag::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_relative", "relative"), &InputEventScreenDrag::set_relative);
 	ClassDB::bind_method(D_METHOD("get_relative"), &InputEventScreenDrag::get_relative);
 
-	ClassDB::bind_method(D_METHOD("set_speed", "speed"), &InputEventScreenDrag::set_speed);
-	ClassDB::bind_method(D_METHOD("get_speed"), &InputEventScreenDrag::get_speed);
+	ClassDB::bind_method(D_METHOD("set_velocity", "velocity"), &InputEventScreenDrag::set_velocity);
+	ClassDB::bind_method(D_METHOD("get_velocity"), &InputEventScreenDrag::get_velocity);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "index"), "set_index", "get_index");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "relative"), "set_relative", "get_relative");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "speed"), "set_speed", "get_speed");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "velocity"), "set_velocity", "get_velocity");
 }
 
 ///////////////////////////////////

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -271,7 +271,7 @@ class InputEventMouseMotion : public InputEventMouse {
 	Vector2 tilt;
 	float pressure = 0;
 	Vector2 relative;
-	Vector2 speed;
+	Vector2 velocity;
 
 protected:
 	static void _bind_methods();
@@ -286,8 +286,8 @@ public:
 	void set_relative(const Vector2 &p_relative);
 	Vector2 get_relative() const;
 
-	void set_speed(const Vector2 &p_speed);
-	Vector2 get_speed() const;
+	void set_velocity(const Vector2 &p_velocity);
+	Vector2 get_velocity() const;
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
@@ -388,7 +388,7 @@ class InputEventScreenDrag : public InputEventFromWindow {
 	int index = 0;
 	Vector2 pos;
 	Vector2 relative;
-	Vector2 speed;
+	Vector2 velocity;
 
 protected:
 	static void _bind_methods();
@@ -403,8 +403,8 @@ public:
 	void set_relative(const Vector2 &p_relative);
 	Vector2 get_relative() const;
 
-	void set_speed(const Vector2 &p_speed);
-	Vector2 get_speed() const;
+	void set_velocity(const Vector2 &p_velocity);
+	Vector2 get_velocity() const;
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -141,10 +141,10 @@
 				Returns the strength of the joypad vibration: x is the strength of the weak motor, and y is the strength of the strong motor.
 			</description>
 		</method>
-		<method name="get_last_mouse_speed" qualifiers="const">
+		<method name="get_last_mouse_velocity" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the mouse speed for the last time the cursor was moved, and this until the next frame where the mouse moves. This means that even if the mouse is not moving, this function will still return the value of the last motion.
+				Returns the mouse velocity for the last time the cursor was moved, and this until the next frame where the mouse moves. This means that even if the mouse is not moving, this function will still return the value of the last motion.
 			</description>
 		</method>
 		<method name="get_magnetometer" qualifiers="const">

--- a/doc/classes/InputEventMouseMotion.xml
+++ b/doc/classes/InputEventMouseMotion.xml
@@ -4,7 +4,7 @@
 		Input event type for mouse motion events.
 	</brief_description>
 	<description>
-		Contains mouse and pen motion information. Supports relative, absolute positions and speed. See [method Node._input].
+		Contains mouse and pen motion information. Supports relative, absolute positions and velocity. See [method Node._input].
 		[b]Note:[/b] By default, this event is only emitted once per frame rendered at most. If you need more precise input reporting, call [method Input.set_use_accumulated_input] with [code]false[/code] to make events emitted as often as possible. If you use InputEventMouseMotion to draw lines, consider implementing [url=https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm]Bresenham's line algorithm[/url] as well to avoid visible gaps in lines if the user is moving the mouse quickly.
 	</description>
 	<tutorials>
@@ -19,11 +19,11 @@
 			The mouse position relative to the previous position (position at the last frame).
 			[b]Note:[/b] Since [InputEventMouseMotion] is only emitted when the mouse moves, the last event won't have a relative position of [code]Vector2(0, 0)[/code] when the user stops moving the mouse.
 		</member>
-		<member name="speed" type="Vector2" setter="set_speed" getter="get_speed" default="Vector2(0, 0)">
-			The mouse speed in pixels per second.
-		</member>
 		<member name="tilt" type="Vector2" setter="set_tilt" getter="get_tilt" default="Vector2(0, 0)">
 			Represents the angles of tilt of the pen. Positive X-coordinate value indicates a tilt to the right. Positive Y-coordinate value indicates a tilt toward the user. Ranges from [code]-1.0[/code] to [code]1.0[/code] for both axes.
+		</member>
+		<member name="velocity" type="Vector2" setter="set_velocity" getter="get_velocity" default="Vector2(0, 0)">
+			The mouse velocity in pixels per second.
 		</member>
 	</members>
 </class>

--- a/doc/classes/InputEventScreenDrag.xml
+++ b/doc/classes/InputEventScreenDrag.xml
@@ -19,8 +19,8 @@
 		<member name="relative" type="Vector2" setter="set_relative" getter="get_relative" default="Vector2(0, 0)">
 			The drag position relative to the previous position (position at the last frame).
 		</member>
-		<member name="speed" type="Vector2" setter="set_speed" getter="get_speed" default="Vector2(0, 0)">
-			The drag speed.
+		<member name="velocity" type="Vector2" setter="set_velocity" getter="get_velocity" default="Vector2(0, 0)">
+			The drag velocity.
 		</member>
 	</members>
 </class>

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -230,7 +230,7 @@ void DisplayServerJavaScript::mouse_move_callback(double p_x, double p_y, double
 
 	ev->set_relative(Vector2(p_rel_x, p_rel_y));
 	Input::get_singleton()->set_mouse_position(ev->get_position());
-	ev->set_speed(Input::get_singleton()->get_last_mouse_speed());
+	ev->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 
 	Input::get_singleton()->parse_input_event(ev);
 }

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -3644,7 +3644,7 @@ void DisplayServerX11::process_events() {
 				mm->set_position(pos);
 				mm->set_global_position(pos);
 				Input::get_singleton()->set_mouse_position(pos);
-				mm->set_speed(Input::get_singleton()->get_last_mouse_speed());
+				mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 
 				mm->set_relative(rel);
 
@@ -3674,7 +3674,7 @@ void DisplayServerX11::process_events() {
 							mm->set_window_id(E.key);
 							mm->set_position(pos_focused);
 							mm->set_global_position(pos_focused);
-							mm->set_speed(Input::get_singleton()->get_last_mouse_speed());
+							mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 							Input::get_singleton()->parse_input_event(mm);
 
 							break;

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -787,7 +787,7 @@ static void _mouseDownEvent(DisplayServer::WindowID window_id, NSEvent *event, M
 		mm->set_tilt(Vector2(p.x, p.y));
 	}
 	mm->set_global_position(pos);
-	mm->set_speed(Input::get_singleton()->get_last_mouse_speed());
+	mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 	const Vector2i relativeMotion = Vector2i(delta.x, delta.y) * DS_OSX->screen_get_max_scale();
 	mm->set_relative(relativeMotion);
 	_get_key_modifier_state([event modifierFlags], mm);

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2067,7 +2067,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				mm->set_position(c);
 				mm->set_global_position(c);
 				Input::get_singleton()->set_mouse_position(c);
-				mm->set_speed(Vector2(0, 0));
+				mm->set_velocity(Vector2(0, 0));
 
 				if (raw->data.mouse.usFlags == MOUSE_MOVE_RELATIVE) {
 					mm->set_relative(Vector2(raw->data.mouse.lLastX, raw->data.mouse.lLastY));
@@ -2172,7 +2172,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					}
 
 					Input::get_singleton()->set_mouse_position(mm->get_position());
-					mm->set_speed(Input::get_singleton()->get_last_mouse_speed());
+					mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 
 					if (old_invalid) {
 						old_x = mm->get_position().x;
@@ -2319,7 +2319,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			}
 
 			Input::get_singleton()->set_mouse_position(mm->get_position());
-			mm->set_speed(Input::get_singleton()->get_last_mouse_speed());
+			mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 
 			if (old_invalid) {
 				old_x = mm->get_position().x;
@@ -2425,7 +2425,7 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 			}
 
 			Input::get_singleton()->set_mouse_position(mm->get_position());
-			mm->set_speed(Input::get_singleton()->get_last_mouse_speed());
+			mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 
 			if (old_invalid) {
 				old_x = mm->get_position().x;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3172,7 +3172,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		if (drag_touching && !drag_touching_deaccel) {
 			drag_accum -= mm->get_relative().y;
 			v_scroll->set_value(drag_from + drag_accum);
-			drag_speed = -mm->get_speed().y;
+			drag_speed = -mm->get_velocity().y;
 		}
 	}
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1700,13 +1700,13 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		if (over) {
 			Transform2D localizer = over->get_global_transform_with_canvas().affine_inverse();
 			Size2 pos = localizer.xform(mpos);
-			Vector2 speed = localizer.basis_xform(mm->get_speed());
+			Vector2 velocity = localizer.basis_xform(mm->get_velocity());
 			Vector2 rel = localizer.basis_xform(mm->get_relative());
 
 			mm = mm->xformed_by(Transform2D()); // Make a copy.
 
 			mm->set_global_position(mpos);
-			mm->set_speed(speed);
+			mm->set_velocity(velocity);
 			mm->set_relative(rel);
 
 			if (mm->get_button_mask() == MouseButton::NONE) {
@@ -1956,12 +1956,12 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			if (over->can_process()) {
 				Transform2D localizer = over->get_global_transform_with_canvas().affine_inverse();
 				Size2 pos = localizer.xform(drag_event->get_position());
-				Vector2 speed = localizer.basis_xform(drag_event->get_speed());
+				Vector2 velocity = localizer.basis_xform(drag_event->get_velocity());
 				Vector2 rel = localizer.basis_xform(drag_event->get_relative());
 
 				drag_event = drag_event->xformed_by(Transform2D()); // Make a copy.
 
-				drag_event->set_speed(speed);
+				drag_event->set_velocity(velocity);
 				drag_event->set_relative(rel);
 				drag_event->set_position(pos);
 


### PR DESCRIPTION
As identified by @EricEzaM in #42450, _"speed is a scalar quantity, and is the magnitude of velocity. In godot, when speed is represented as a vector, it is actually a velocity since it represents both magnitude and direction."_

This PR changes those instances of `speed` to `velocity` when they refer to a directional `Vector`.

Closes #42450.