### PR TITLE
Update default port_grab_distance_vertical

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -346,7 +346,7 @@
 		<theme_item name="port_grab_distance_horizontal" data_type="constant" type="int" default="24">
 			The horizontal range within which a port can be grabbed (on both sides).
 		</theme_item>
-		<theme_item name="port_grab_distance_vertical" data_type="constant" type="int" default="6">
+		<theme_item name="port_grab_distance_vertical" data_type="constant" type="int" default="26">
 			The vertical range within which a port can be grabbed (on both sides).
 		</theme_item>
 		<theme_item name="layout" data_type="icon" type="Texture2D">

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -994,7 +994,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// Visual Node Ports
 
 	theme->set_constant("port_grab_distance_horizontal", "GraphEdit", 24 * scale);
-	theme->set_constant("port_grab_distance_vertical", "GraphEdit", 6 * scale);
+	theme->set_constant("port_grab_distance_vertical", "GraphEdit", 26 * scale);
 
 	theme->set_stylebox("bg", "GraphEditMinimap", make_flat_stylebox(Color(0.24, 0.24, 0.24), 0, 0, 0, 0));
 	Ref<StyleBoxFlat> style_minimap_camera = make_flat_stylebox(Color(0.65, 0.65, 0.65, 0.2), 0, 0, 0, 0);


### PR DESCRIPTION
Implement proposal [#3652](https://github.com/godotengine/godot-proposals/issues/3652)
default port_grab_distance_vertical now is 26 to increase usability.

This is back portable to 3.x