### PR TITLE
[3.x] Fix return type for the exposed `EditorResourcePicker` method

### DIFF
--- a/doc/classes/EditorResourcePicker.xml
+++ b/doc/classes/EditorResourcePicker.xml
@@ -40,7 +40,7 @@
 			</description>
 		</method>
 		<method name="handle_menu_selected" qualifiers="virtual">
-			<return type="void" />
+			<return type="bool" />
 			<argument index="0" name="id" type="int" />
 			<description>
 				This virtual method can be implemented to handle context menu items not handled by default. See [method set_create_options].

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -687,7 +687,7 @@ void EditorResourcePicker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_editable"), &EditorResourcePicker::is_editable);
 
 	ClassDB::add_virtual_method(get_class_static(), MethodInfo("set_create_options", PropertyInfo(Variant::OBJECT, "menu_node")));
-	ClassDB::add_virtual_method(get_class_static(), MethodInfo("handle_menu_selected", PropertyInfo(Variant::INT, "id")));
+	ClassDB::add_virtual_method(get_class_static(), MethodInfo(Variant::BOOL, "handle_menu_selected", PropertyInfo(Variant::INT, "id")));
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "base_type"), "set_base_type", "get_base_type");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "edited_resource", PROPERTY_HINT_RESOURCE_TYPE, "Resource", 0), "set_edited_resource", "get_edited_resource");


### PR DESCRIPTION
While working on https://github.com/godotengine/godot/pull/56321 I noticed that this one method wasn't properly exposed, it was missing its expected return type, which would lead to issues. Fixed it for master in the aforementioned PR, and this is the same fix for 3.x, because the rest of that PR is not relevant here.