### PR TITLE
[3.x] Make the theme editor correctly stop updating after it was hidden

### DIFF
--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -36,6 +36,8 @@
 
 #include "editor/editor_scale.h"
 
+constexpr double REFRESH_TIMER = 1.5;
+
 void ThemeEditorPreview::set_preview_theme(const Ref<Theme> &p_theme) {
 	preview_content->set_theme(p_theme);
 }
@@ -66,7 +68,7 @@ void ThemeEditorPreview::_refresh_interval() {
 }
 
 void ThemeEditorPreview::_preview_visibility_changed() {
-	set_process(is_visible());
+	set_process(is_visible_in_tree());
 }
 
 void ThemeEditorPreview::_picker_button_cbk() {
@@ -192,7 +194,7 @@ void ThemeEditorPreview::_notification(int p_what) {
 		case NOTIFICATION_PROCESS: {
 			time_left -= get_process_delta_time();
 			if (time_left < 0) {
-				time_left = 1.5;
+				time_left = REFRESH_TIMER;
 				_refresh_interval();
 			}
 		} break;


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/56327.
