### PR TITLE
Fix http limitation for large "content-length"

### DIFF
--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -58,8 +58,8 @@ private:
 	Vector<uint8_t> chunk;
 	int chunk_left = 0;
 	bool chunk_trailer_part = false;
-	int body_size = -1;
-	int body_left = 0;
+	int64_t body_size = -1;
+	int64_t body_left = 0;
 	bool read_until_eof = false;
 
 	Ref<StreamPeerTCP> tcp_connection;


### PR DESCRIPTION
When a request was issued to a server that returned "content-length" header
whose value was greater than that of an "int" we ran into overflow
problems. The fix for this was rather simple by increasing the data
type to `int64_t`

Fixes #56314 
