### PR TITLE
Fix Array and Dictionary id(), and a bug in dictionary tests

### DIFF
--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -627,7 +627,7 @@ Variant Array::max() const {
 }
 
 const void *Array::id() const {
-	return _p->array.ptr();
+	return _p;
 }
 
 Array::Array(const Array &p_from, uint32_t p_type, const StringName &p_class_name, const Variant &p_script) {

--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -350,7 +350,7 @@ void Dictionary::operator=(const Dictionary &p_dictionary) {
 }
 
 const void *Dictionary::id() const {
-	return _p->variant_map.id();
+	return _p;
 }
 
 Dictionary::Dictionary(const Dictionary &p_from) {

--- a/tests/core/variant/test_dictionary.h
+++ b/tests/core/variant/test_dictionary.h
@@ -196,7 +196,7 @@ TEST_CASE("[Dictionary] Duplicate dictionary") {
 	Dictionary shallow_d = d.duplicate(false);
 	CHECK_MESSAGE(shallow_d.id() != d.id(), "Should create a new array");
 	CHECK_MESSAGE(Dictionary(shallow_d[1]).id() == Dictionary(d[1]).id(), "Should keep nested dictionary");
-	CHECK_MESSAGE(Array(shallow_d[2]).id() == Array(d[2]).id(), "Should keep nested array");
+	CHECK_MESSAGE(Array(shallow_d[k2]).id() == Array(d[k2]).id(), "Should keep nested array");
 	CHECK_EQ(shallow_d, d);
 	shallow_d[0] = 0;
 	CHECK_NE(shallow_d, d);


### PR DESCRIPTION
There are some issues with the way the `id()` function in Arrays and Dictionaries work. There is also a typo-caused bug in test_dictionary.h, which became apparent after fixing `id()`.

Currently, there is no way to distinguish from outside whether 2 Arrays (or 2 Dictionaries) are the same if they are empty. `Array::id()` and `Dictionary::id()` both return `nullptr` if nothing has been put inside the container. As a result, even if 2 Arrays are completely non-related, as long as they are empty, they'll return the same id value. Similar situation with Dictionaries.

Arrays are actually shared via their `ArrayPrivate *_p;`, and this pointer always holds a value uniquely associated with the actual shared array (never nullptr). Thus, it's a suitable option for the return value of `id()`. Similar situation with Dictionaries.

In test_dictionary.h, there is a test that has a typo. Neither `d` nor `shallow_d` has a key equal to `2`. How has this test been passing all this time? I'm guessing the `Array(...).id()` parts probably returned nullptr in both sides. But there is a `CRASH_COND` in `const V &OrderedHashMap::operator[](const K &p_key) const` for the case it doesn't find the key, so it should've been crashing. Maybe for some reason the compiler decided to call the non-const version instead (which doesn't have a crash condition). Maybe this needs to be investigated. Anyways, the typo bug has been fixed :slightly_smiling_face: 
