### PR TITLE
Fixed completion showing for class members

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -805,6 +805,8 @@ void GDScriptParser::parse_class_body(bool p_is_multiline) {
 				class_end = true;
 				break;
 			default:
+				// Display a completion with identifiers.
+				make_completion_context(COMPLETION_IDENTIFIER, nullptr);
 				push_error(vformat(R"(Unexpected "%s" in class body.)", current.get_name()));
 				advance();
 				break;


### PR DESCRIPTION
For classes the error showed when token type is unknown, but a list with identifiers for a completion wasn't shown.
This pull request fix this issue #56270

*Bugsquad edit:*
- Fixes #56270.