### PR TITLE
Fixed an invalidation of sets and out of range for an alignment

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1692,7 +1692,7 @@ int GraphEdit::_set_operations(SET_OPERATIONS p_operation, Set<StringName> &r_u,
 					r_u.insert(E->get());
 				}
 			}
-			return r_v.size();
+			return r_u.size();
 		} break;
 		default:
 			break;
@@ -1787,8 +1787,8 @@ void GraphEdit::_horizontal_alignment(Dictionary &r_root, Dictionary &r_align, c
 				}
 			}
 
-			int start = up.size() / 2;
-			int end = up.size() % 2 ? start : start + 1;
+			int start = (up.size() - 1) / 2;
+			int end = (up.size() - 1) % 2 ? start + 1 : start;
 			for (int p = start; p <= end; p++) {
 				StringName Align = r_align[current_node];
 				if (Align == current_node && r < up[p].first) {


### PR DESCRIPTION
Fixes #56276 and _set_operations return value with a possible invalidation

Result:
![image](https://user-images.githubusercontent.com/12952093/147775944-f3546f3c-94c9-4f35-b73a-3ca723bdf6af.png)
