### PR TITLE
Avoid crash when editor attempts to access members of null node

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -320,7 +320,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 		// we only want to deal with pinned flag if instancing as pure main (no instance, no inheriting)
 		if (p_edit_state == GEN_EDIT_STATE_MAIN) {
 			_sanitize_node_pinned_properties(node);
-		} else {
+		} else if (node != nullptr) {
 			node->remove_meta("_edit_pinned_properties_");
 		}
 


### PR DESCRIPTION
I did not investigate the exact cause of this crash, since i was porting a project from 3.x to 4.0, but in any case the safety check is worth having.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
