### PR TITLE
Clean preview node of all nodes which are not derived from VisualInstances [3.x]

### DIFF
--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -443,6 +443,9 @@ private:
 
 	Vector3 _get_instance_position(const Point2 &p_pos) const;
 	static AABB _calculate_spatial_bounds(const Spatial *p_parent, bool p_exclude_toplevel_transform = true);
+
+	Node *_sanitize_preview_node(Node *p_node) const;
+
 	void _create_preview(const Vector<String> &files) const;
 	void _remove_preview();
 	bool _cyclical_dependency_exists(const String &p_target_scene_path, Node *p_desired_node);


### PR DESCRIPTION
Should fix issues relating to the subscenes being dragged into a 3D scene when they have problematic nodes, such as issues caused by the preview node having colliders in it. Closes #56361

*Bugsquad edit: `3.x` version of https://github.com/godotengine/godot/pull/56362.*