### PR TITLE
Improve the default size of 3D shapes and meshes (Box, Capsule, and Cylinder)

### DIFF
--- a/doc/classes/BoxMesh.xml
+++ b/doc/classes/BoxMesh.xml
@@ -11,7 +11,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(2, 2, 2)">
+		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(1, 1, 1)">
 			The box's width, height and depth.
 		</member>
 		<member name="subdivide_depth" type="int" setter="set_subdivide_depth" getter="get_subdivide_depth" default="0">

--- a/doc/classes/BoxShape3D.xml
+++ b/doc/classes/BoxShape3D.xml
@@ -12,7 +12,7 @@
 		<link title="3D Platformer Demo">https://godotengine.org/asset-library/asset/125</link>
 	</tutorials>
 	<members>
-		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(2, 2, 2)">
+		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(1, 1, 1)">
 			The box's width, height and depth.
 		</member>
 	</members>

--- a/doc/classes/CapsuleMesh.xml
+++ b/doc/classes/CapsuleMesh.xml
@@ -9,13 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="height" type="float" setter="set_height" getter="get_height" default="3.0">
+		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
 			Total height of the capsule mesh (including the hemispherical ends).
 		</member>
 		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments" default="64">
 			Number of radial segments on the capsule mesh.
 		</member>
-		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
 			Radius of the capsule mesh.
 		</member>
 		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="8">

--- a/doc/classes/CapsuleShape3D.xml
+++ b/doc/classes/CapsuleShape3D.xml
@@ -10,10 +10,10 @@
 		<link title="3D Physics Tests Demo">https://godotengine.org/asset-library/asset/675</link>
 	</tutorials>
 	<members>
-		<member name="height" type="float" setter="set_height" getter="get_height" default="3.0">
+		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
 			The capsule's height.
 		</member>
-		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
 			The capsule's radius.
 		</member>
 	</members>

--- a/doc/classes/CylinderMesh.xml
+++ b/doc/classes/CylinderMesh.xml
@@ -9,7 +9,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="bottom_radius" type="float" setter="set_bottom_radius" getter="get_bottom_radius" default="1.0">
+		<member name="bottom_radius" type="float" setter="set_bottom_radius" getter="get_bottom_radius" default="0.5">
 			Bottom radius of the cylinder. If set to [code]0.0[/code], the bottom faces will not be generated, resulting in a conic shape.
 		</member>
 		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
@@ -21,7 +21,7 @@
 		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="4">
 			Number of edge rings along the height of the cylinder. Changing [member rings] does not have any visual impact unless a shader or procedural mesh tool is used to alter the vertex data. Higher values result in more subdivisions, which can be used to create smoother-looking effects with shaders or procedural mesh tools (at the cost of performance). When not altering the vertex data using a shader or procedural mesh tool, [member rings] should be kept to its default value.
 		</member>
-		<member name="top_radius" type="float" setter="set_top_radius" getter="get_top_radius" default="1.0">
+		<member name="top_radius" type="float" setter="set_top_radius" getter="get_top_radius" default="0.5">
 			Top radius of the cylinder. If set to [code]0.0[/code], the top faces will not be generated, resulting in a conic shape.
 		</member>
 	</members>

--- a/doc/classes/CylinderShape3D.xml
+++ b/doc/classes/CylinderShape3D.xml
@@ -15,7 +15,7 @@
 		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
 			The cylinder's height.
 		</member>
-		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
 			The cylinder's radius.
 		</member>
 	</members>

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1451,8 +1451,8 @@ Ref<Material> CSGCylinder3D::get_material() const {
 
 CSGCylinder3D::CSGCylinder3D() {
 	// defaults
-	radius = 1.0;
-	height = 1.0;
+	radius = 0.5;
+	height = 2.0;
 	sides = 8;
 	cone = false;
 	smooth_faces = true;
@@ -1671,8 +1671,8 @@ Ref<Material> CSGTorus3D::get_material() const {
 
 CSGTorus3D::CSGTorus3D() {
 	// defaults
-	inner_radius = 2.0;
-	outer_radius = 3.0;
+	inner_radius = 0.5;
+	outer_radius = 1.0;
 	sides = 8;
 	ring_sides = 6;
 	smooth_faces = true;

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -239,7 +239,7 @@ class CSGBox3D : public CSGPrimitive3D {
 	virtual CSGBrush *_build_brush() override;
 
 	Ref<Material> material;
-	Vector3 size = Vector3(2, 2, 2);
+	Vector3 size = Vector3(1, 1, 1);
 
 protected:
 	static void _bind_methods();

--- a/modules/csg/doc_classes/CSGBox3D.xml
+++ b/modules/csg/doc_classes/CSGBox3D.xml
@@ -12,7 +12,7 @@
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			The material used to render the box.
 		</member>
-		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(2, 2, 2)">
+		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(1, 1, 1)">
 			The box's width, height and depth.
 		</member>
 	</members>

--- a/modules/csg/doc_classes/CSGCylinder3D.xml
+++ b/modules/csg/doc_classes/CSGCylinder3D.xml
@@ -12,13 +12,13 @@
 		<member name="cone" type="bool" setter="set_cone" getter="is_cone" default="false">
 			If [code]true[/code] a cone is created, the [member radius] will only apply to one side.
 		</member>
-		<member name="height" type="float" setter="set_height" getter="get_height" default="1.0">
+		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
 			The height of the cylinder.
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			The material used to render the cylinder.
 		</member>
-		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
 			The radius of the cylinder.
 		</member>
 		<member name="sides" type="int" setter="set_sides" getter="get_sides" default="8">

--- a/modules/csg/doc_classes/CSGTorus3D.xml
+++ b/modules/csg/doc_classes/CSGTorus3D.xml
@@ -9,13 +9,13 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="inner_radius" type="float" setter="set_inner_radius" getter="get_inner_radius" default="2.0">
+		<member name="inner_radius" type="float" setter="set_inner_radius" getter="get_inner_radius" default="0.5">
 			The inner radius of the torus.
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			The material used to render the torus.
 		</member>
-		<member name="outer_radius" type="float" setter="set_outer_radius" getter="get_outer_radius" default="3.0">
+		<member name="outer_radius" type="float" setter="set_outer_radius" getter="get_outer_radius" default="1.0">
 			The outer radius of the torus.
 		</member>
 		<member name="ring_sides" type="int" setter="set_ring_sides" getter="get_ring_sides" default="6">

--- a/scene/resources/box_shape_3d.cpp
+++ b/scene/resources/box_shape_3d.cpp
@@ -95,5 +95,5 @@ void BoxShape3D::_bind_methods() {
 
 BoxShape3D::BoxShape3D() :
 		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_BOX)) {
-	set_size(Vector3(2, 2, 2));
+	set_size(Vector3(1, 1, 1));
 }

--- a/scene/resources/capsule_shape_3d.h
+++ b/scene/resources/capsule_shape_3d.h
@@ -35,8 +35,8 @@
 
 class CapsuleShape3D : public Shape3D {
 	GDCLASS(CapsuleShape3D, Shape3D);
-	float radius = 1.0;
-	float height = 3.0;
+	float radius = 0.5;
+	float height = 2.0;
 
 protected:
 	static void _bind_methods();

--- a/scene/resources/cylinder_shape_3d.h
+++ b/scene/resources/cylinder_shape_3d.h
@@ -35,7 +35,7 @@
 
 class CylinderShape3D : public Shape3D {
 	GDCLASS(CylinderShape3D, Shape3D);
-	float radius = 1.0;
+	float radius = 0.5;
 	float height = 2.0;
 
 protected:

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -106,8 +106,8 @@ class CapsuleMesh : public PrimitiveMesh {
 	GDCLASS(CapsuleMesh, PrimitiveMesh);
 
 private:
-	float radius = 1.0;
-	float height = 3.0;
+	float radius = 0.5;
+	float height = 2.0;
 	int radial_segments = 64;
 	int rings = 8;
 
@@ -138,7 +138,7 @@ class BoxMesh : public PrimitiveMesh {
 	GDCLASS(BoxMesh, PrimitiveMesh);
 
 private:
-	Vector3 size = Vector3(2.0, 2.0, 2.0);
+	Vector3 size = Vector3(1, 1, 1);
 	int subdivide_w = 0;
 	int subdivide_h = 0;
 	int subdivide_d = 0;
@@ -171,8 +171,8 @@ class CylinderMesh : public PrimitiveMesh {
 	GDCLASS(CylinderMesh, PrimitiveMesh);
 
 private:
-	float top_radius = 1.0;
-	float bottom_radius = 1.0;
+	float top_radius = 0.5;
+	float bottom_radius = 0.5;
 	float height = 2.0;
 	int radial_segments = 64;
 	int rings = 4;


### PR DESCRIPTION
Implements and closes https://github.com/godotengine/godot-proposals/issues/3732

The specific values are up for discussion in the above proposal, but I think what's currently in this PR is quite good.

I don't really have an opinion on the CSGTorus3D changes, they were copied from https://github.com/godotengine/godot/pull/49729/files#diff-a81f2e3a53dfacfdb0037de9538db28d5646ae0c3a11a52eca1caa5d665dfd1cR1676-R1678

Breaks compat, but we have already broken compatibility with these shapes for 4.0 so changing this is not a big deal.