### PR TITLE
Use asynchronous shader compilation and cache in the editor if requested

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1284,8 +1284,8 @@
 			That means that when a shader is first used under some new rendering situation, the game won't stall while such shader is being compiled. Instead, a fallback will be used and the real shader will be compiled in the background. Once the actual shader is compiled, it will be used the next times it's used to draw a frame.
 			Depending on the async mode configured for a given material/shader, the fallback will be an "ubershader" (the default) or just skip rendering any item it is applied to.
 			An ubershader is a very complex shader, slow but suited to any rendering situation, that the engine generates internally so it can be used from the beginning while the traditional conditioned, optimized version of it is being compiled.
-			In order to save some loading time, you can use [code]Asynchronous + Cache[/code], which also causes the ubershaders to be cached into storage so they can be ready faster next time they are used (provided the platform provides support for it).
-			[b]Warning:[/b] Async. compilation is currently only supported for spatial and particle materials/shaders.
+			To reduce loading times after the project has been launched at least once, you can use [code]Asynchronous + Cache[/code]. This also causes the ubershaders to be cached into storage so they can be ready faster next time they are used (provided the platform provides support for it).
+			[b]Note:[/b] Asynchronous compilation is currently only supported for spatial (3D) and particle materials/shaders. CanvasItem (2D) shaders will not use asynchronous compilation even if this setting is set to [code]Asynchronous[/code] or [code]Asynchronous + Cache[/code].
 		</member>
 		<member name="rendering/limits/buffers/blend_shape_max_buffer_size_kb" type="int" setter="" getter="" default="4096">
 			Max buffer size for blend shapes. Any blend shape bigger than this will not work.

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -8116,14 +8116,11 @@ void RasterizerStorageGLES3::initialize() {
 #endif
 	config.parallel_shader_compile_supported = config.extensions.has("GL_KHR_parallel_shader_compile") || config.extensions.has("GL_ARB_parallel_shader_compile");
 #endif
-	if (Engine::get_singleton()->is_editor_hint()) {
-		config.async_compilation_enabled = false;
-		config.shader_cache_enabled = false;
-	} else {
-		int compilation_mode = ProjectSettings::get_singleton()->get("rendering/gles3/shaders/shader_compilation_mode");
-		config.async_compilation_enabled = compilation_mode >= 1;
-		config.shader_cache_enabled = compilation_mode == 2;
-	}
+
+	const int compilation_mode = ProjectSettings::get_singleton()->get("rendering/gles3/shaders/shader_compilation_mode");
+	config.async_compilation_enabled = compilation_mode >= 1;
+	config.shader_cache_enabled = compilation_mode == 2;
+
 	if (config.async_compilation_enabled) {
 		ShaderGLES3::max_simultaneous_compiles = MAX(1, (int)ProjectSettings::get_singleton()->get("rendering/gles3/shaders/max_simultaneous_compiles"));
 #ifdef GLES_OVER_GL


### PR DESCRIPTION
This provides more consistent behavior between the editor and running project. Documentation for the project setting was also improved.

This closes https://github.com/godotengine/godot-proposals/issues/3594.