### PR TITLE
Print time taken and request attention when lightmaps are done baking

### DIFF
--- a/editor/plugins/lightmap_gi_editor_plugin.h
+++ b/editor/plugins/lightmap_gi_editor_plugin.h
@@ -47,7 +47,7 @@ class LightmapGIEditorPlugin : public EditorPlugin {
 	EditorFileDialog *file_dialog;
 	static EditorProgress *tmp_progress;
 	static bool bake_func_step(float p_progress, const String &p_description, void *, bool p_refresh);
-	static void bake_func_end();
+	static void bake_func_end(uint64_t p_time_started);
 
 	void _bake_select_file(const String &p_file);
 	void _bake();


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/49915. Despite the GPU lightmapper being much faster than the CPU lightmapper, it can still take several minutes on complex scenes when using many bounces.  

Since lightmap baking can take a very long time, printing the time spent can be useful for users tweaking the lightmap settings to optimize bake times. The message printed is visible in the editor's Output dialog and looks like this:

```
Done baking lightmaps in 00:01:33.
```

Completing lightmap baking will also request attention, which is useful if you're doing something else while waiting for lightmaps to bake.