### PR TITLE
Fix OGG Vorbis playback with more than one channel

### DIFF
--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -110,7 +110,7 @@ int AudioStreamPlaybackOGGVorbis::_mix_frames_vorbis(AudioFrame *p_buffer, int p
 	if (info.channels > 1) {
 		for (int frame = 0; frame < frames; frame++) {
 			p_buffer[frame].l = pcm[0][frame];
-			p_buffer[frame].r = pcm[0][frame];
+			p_buffer[frame].r = pcm[1][frame];
 		}
 	} else {
 		for (int frame = 0; frame < frames; frame++) {


### PR DESCRIPTION
When an OGG Vorbis file has more than one channel we accidentily were
assigning only the left channel to both the L and R channels of the
AudioFrame output buffer

Fixes #56371

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
