### PR TITLE
Correctly use fallback Theme values as last resort

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -273,8 +273,8 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	// Default font
 	MAKE_DEFAULT_FONT(df, String());
-	p_theme->set_default_theme_font(df); // Default theme font
-	p_theme->set_default_theme_font_size(default_font_size);
+	p_theme->set_default_font(df); // Default theme font
+	p_theme->set_default_font_size(default_font_size);
 
 	p_theme->set_font_size("main_size", "EditorFonts", default_font_size);
 	p_theme->set_font("main", "EditorFonts", df);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -294,7 +294,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<Theme> theme = Ref<Theme>(memnew(Theme));
 
 	// Controls may rely on the scale for their internal drawing logic.
-	theme->set_default_theme_base_scale(EDSCALE);
+	theme->set_default_base_scale(EDSCALE);
 
 	// Theme settings
 	Color accent_color = EDITOR_GET("interface/theme/accent_color");

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1148,12 +1148,12 @@ float Control::fetch_theme_default_base_scale(Control *p_theme_owner, Window *p_
 	Window *theme_owner_window = p_theme_owner_window;
 
 	while (theme_owner || theme_owner_window) {
-		if (theme_owner && theme_owner->data.theme->has_default_theme_base_scale()) {
-			return theme_owner->data.theme->get_default_theme_base_scale();
+		if (theme_owner && theme_owner->data.theme->has_default_base_scale()) {
+			return theme_owner->data.theme->get_default_base_scale();
 		}
 
-		if (theme_owner_window && theme_owner_window->theme->has_default_theme_base_scale()) {
-			return theme_owner_window->theme->get_default_theme_base_scale();
+		if (theme_owner_window && theme_owner_window->theme->has_default_base_scale()) {
+			return theme_owner_window->theme->get_default_base_scale();
 		}
 
 		Node *parent = theme_owner ? theme_owner->get_parent() : theme_owner_window->get_parent();
@@ -1175,13 +1175,16 @@ float Control::fetch_theme_default_base_scale(Control *p_theme_owner, Window *p_
 
 	// Secondly, check the project-defined Theme resource.
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_default_theme_base_scale()) {
-			return Theme::get_project_default()->get_default_theme_base_scale();
+		if (Theme::get_project_default()->has_default_base_scale()) {
+			return Theme::get_project_default()->get_default_base_scale();
 		}
 	}
 
 	// Lastly, fall back on the default Theme.
-	return Theme::get_default()->get_default_theme_base_scale();
+	if (Theme::get_default()->has_default_base_scale()) {
+		return Theme::get_default()->get_default_base_scale();
+	}
+	return Theme::get_fallback_base_scale();
 }
 
 float Control::get_theme_default_base_scale() const {
@@ -1196,12 +1199,12 @@ Ref<Font> Control::fetch_theme_default_font(Control *p_theme_owner, Window *p_th
 	Window *theme_owner_window = p_theme_owner_window;
 
 	while (theme_owner || theme_owner_window) {
-		if (theme_owner && theme_owner->data.theme->has_default_theme_font()) {
-			return theme_owner->data.theme->get_default_theme_font();
+		if (theme_owner && theme_owner->data.theme->has_default_font()) {
+			return theme_owner->data.theme->get_default_font();
 		}
 
-		if (theme_owner_window && theme_owner_window->theme->has_default_theme_font()) {
-			return theme_owner_window->theme->get_default_theme_font();
+		if (theme_owner_window && theme_owner_window->theme->has_default_font()) {
+			return theme_owner_window->theme->get_default_font();
 		}
 
 		Node *parent = theme_owner ? theme_owner->get_parent() : theme_owner_window->get_parent();
@@ -1223,13 +1226,16 @@ Ref<Font> Control::fetch_theme_default_font(Control *p_theme_owner, Window *p_th
 
 	// Secondly, check the project-defined Theme resource.
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_default_theme_font()) {
-			return Theme::get_project_default()->get_default_theme_font();
+		if (Theme::get_project_default()->has_default_font()) {
+			return Theme::get_project_default()->get_default_font();
 		}
 	}
 
 	// Lastly, fall back on the default Theme.
-	return Theme::get_default()->get_default_theme_font();
+	if (Theme::get_default()->has_default_font()) {
+		return Theme::get_default()->get_default_font();
+	}
+	return Theme::get_fallback_font();
 }
 
 Ref<Font> Control::get_theme_default_font() const {
@@ -1244,12 +1250,12 @@ int Control::fetch_theme_default_font_size(Control *p_theme_owner, Window *p_the
 	Window *theme_owner_window = p_theme_owner_window;
 
 	while (theme_owner || theme_owner_window) {
-		if (theme_owner && theme_owner->data.theme->has_default_theme_font_size()) {
-			return theme_owner->data.theme->get_default_theme_font_size();
+		if (theme_owner && theme_owner->data.theme->has_default_font_size()) {
+			return theme_owner->data.theme->get_default_font_size();
 		}
 
-		if (theme_owner_window && theme_owner_window->theme->has_default_theme_font_size()) {
-			return theme_owner_window->theme->get_default_theme_font_size();
+		if (theme_owner_window && theme_owner_window->theme->has_default_font_size()) {
+			return theme_owner_window->theme->get_default_font_size();
 		}
 
 		Node *parent = theme_owner ? theme_owner->get_parent() : theme_owner_window->get_parent();
@@ -1271,13 +1277,16 @@ int Control::fetch_theme_default_font_size(Control *p_theme_owner, Window *p_the
 
 	// Secondly, check the project-defined Theme resource.
 	if (Theme::get_project_default().is_valid()) {
-		if (Theme::get_project_default()->has_default_theme_font_size()) {
-			return Theme::get_project_default()->get_default_theme_font_size();
+		if (Theme::get_project_default()->has_default_font_size()) {
+			return Theme::get_project_default()->get_default_font_size();
 		}
 	}
 
 	// Lastly, fall back on the default Theme.
-	return Theme::get_default()->get_default_theme_font_size();
+	if (Theme::get_default()->has_default_font_size()) {
+		return Theme::get_default()->get_default_font_size();
+	}
+	return Theme::get_fallback_font_size();
 }
 
 int Control::get_theme_default_font_size() const {

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1071,7 +1071,7 @@ void initialize_theme() {
 		if (theme.is_valid()) {
 			Theme::set_project_default(theme);
 			if (font.is_valid()) {
-				Theme::set_default_font(font);
+				Theme::set_fallback_font(font);
 			}
 		} else {
 			ERR_PRINT("Error loading custom theme '" + theme_path + "'");

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -1053,17 +1053,17 @@ void make_default_theme(bool p_hidpi, Ref<Font> p_font) {
 	fill_default_theme(t, default_font, large_font, default_icon, default_style, default_scale);
 
 	Theme::set_default(t);
-	Theme::set_default_base_scale(default_scale);
-	Theme::set_default_icon(default_icon);
-	Theme::set_default_style(default_style);
-	Theme::set_default_font(default_font);
-	Theme::set_default_font_size(default_font_size);
+	Theme::set_fallback_base_scale(default_scale);
+	Theme::set_fallback_icon(default_icon);
+	Theme::set_fallback_style(default_style);
+	Theme::set_fallback_font(default_font);
+	Theme::set_fallback_font_size(default_font_size);
 }
 
 void clear_default_theme() {
 	Theme::set_project_default(nullptr);
 	Theme::set_default(nullptr);
-	Theme::set_default_icon(nullptr);
-	Theme::set_default_style(nullptr);
-	Theme::set_default_font(nullptr);
+	Theme::set_fallback_icon(nullptr);
+	Theme::set_fallback_style(nullptr);
+	Theme::set_fallback_font(nullptr);
 }

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -36,11 +36,11 @@ Ref<Theme> Theme::default_theme;
 Ref<Theme> Theme::project_default_theme;
 
 // Universal default values, final fallback for every theme.
-float Theme::default_base_scale = 1.0;
-Ref<Texture2D> Theme::default_icon;
-Ref<StyleBox> Theme::default_style;
-Ref<Font> Theme::default_font;
-int Theme::default_font_size = 16;
+float Theme::fallback_base_scale = 1.0;
+Ref<Texture2D> Theme::fallback_icon;
+Ref<StyleBox> Theme::fallback_style;
+Ref<Font> Theme::fallback_font;
+int Theme::fallback_font_size = 16;
 
 // Dynamic properties.
 bool Theme::_set(const StringName &p_name, const Variant &p_value) {
@@ -220,87 +220,107 @@ void Theme::set_project_default(const Ref<Theme> &p_project_default) {
 }
 
 // Universal fallback values for theme item types.
-void Theme::set_default_base_scale(float p_base_scale) {
-	default_base_scale = p_base_scale;
+void Theme::set_fallback_base_scale(float p_base_scale) {
+	fallback_base_scale = p_base_scale;
 }
 
-void Theme::set_default_icon(const Ref<Texture2D> &p_icon) {
-	default_icon = p_icon;
+void Theme::set_fallback_icon(const Ref<Texture2D> &p_icon) {
+	fallback_icon = p_icon;
 }
 
-void Theme::set_default_style(const Ref<StyleBox> &p_style) {
-	default_style = p_style;
+void Theme::set_fallback_style(const Ref<StyleBox> &p_style) {
+	fallback_style = p_style;
 }
 
-void Theme::set_default_font(const Ref<Font> &p_font) {
-	default_font = p_font;
+void Theme::set_fallback_font(const Ref<Font> &p_font) {
+	fallback_font = p_font;
 }
 
-void Theme::set_default_font_size(int p_font_size) {
-	default_font_size = p_font_size;
+void Theme::set_fallback_font_size(int p_font_size) {
+	fallback_font_size = p_font_size;
+}
+
+float Theme::get_fallback_base_scale() {
+	return fallback_base_scale;
+}
+
+Ref<Texture2D> Theme::get_fallback_icon() {
+	return fallback_icon;
+}
+
+Ref<StyleBox> Theme::get_fallback_style() {
+	return fallback_style;
+}
+
+Ref<Font> Theme::get_fallback_font() {
+	return fallback_font;
+}
+
+int Theme::get_fallback_font_size() {
+	return fallback_font_size;
 }
 
 // Fallback values for theme item types, configurable per theme.
-void Theme::set_default_theme_base_scale(float p_base_scale) {
-	if (default_theme_base_scale == p_base_scale) {
+void Theme::set_default_base_scale(float p_base_scale) {
+	if (default_base_scale == p_base_scale) {
 		return;
 	}
 
-	default_theme_base_scale = p_base_scale;
+	default_base_scale = p_base_scale;
 
 	_emit_theme_changed();
 }
 
-float Theme::get_default_theme_base_scale() const {
-	return default_theme_base_scale;
+float Theme::get_default_base_scale() const {
+	return default_base_scale;
 }
 
-bool Theme::has_default_theme_base_scale() const {
-	return default_theme_base_scale > 0.0;
+bool Theme::has_default_base_scale() const {
+	return default_base_scale > 0.0;
 }
 
-void Theme::set_default_theme_font(const Ref<Font> &p_default_font) {
-	if (default_theme_font == p_default_font) {
+void Theme::set_default_font(const Ref<Font> &p_default_font) {
+	if (default_font == p_default_font) {
 		return;
 	}
 
-	if (default_theme_font.is_valid()) {
-		default_theme_font->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
+	if (default_font.is_valid()) {
+		default_font->disconnect("changed", callable_mp(this, &Theme::_emit_theme_changed));
 	}
 
-	default_theme_font = p_default_font;
+	default_font = p_default_font;
 
-	if (default_theme_font.is_valid()) {
-		default_theme_font->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(false), CONNECT_REFERENCE_COUNTED);
+	if (default_font.is_valid()) {
+		default_font->connect("changed", callable_mp(this, &Theme::_emit_theme_changed), varray(false), CONNECT_REFERENCE_COUNTED);
 	}
 
 	_emit_theme_changed();
 }
 
-Ref<Font> Theme::get_default_theme_font() const {
-	return default_theme_font;
+Ref<Font> Theme::get_default_font() const {
+	return default_font;
 }
 
-bool Theme::has_default_theme_font() const {
-	return default_theme_font.is_valid();
+bool Theme::has_default_font() const {
+	return default_font.is_valid();
 }
 
-void Theme::set_default_theme_font_size(int p_font_size) {
-	if (default_theme_font_size == p_font_size) {
+void Theme::set_default_font_size(int p_font_size) {
+	if (default_font_size == p_font_size) {
 		return;
 	}
 
-	default_theme_font_size = p_font_size;
+	default_font_size = p_font_size;
 
 	_emit_theme_changed();
 }
 
-int Theme::get_default_theme_font_size() const {
-	return default_theme_font_size;
+int Theme::get_default_font_size() const {
+	return default_font_size;
 }
 
-bool Theme::has_default_theme_font_size() const {
-	return default_theme_font_size > 0;
+bool Theme::has_default_font_size() const {
+	return default_font_size > 0;
 }
 
 // Icons.
@@ -324,7 +344,7 @@ Ref<Texture2D> Theme::get_icon(const StringName &p_name, const StringName &p_the
 	if (icon_map.has(p_theme_type) && icon_map[p_theme_type].has(p_name) && icon_map[p_theme_type][p_name].is_valid()) {
 		return icon_map[p_theme_type][p_name];
 	} else {
-		return default_icon;
+		return fallback_icon;
 	}
 }
 
@@ -411,7 +431,7 @@ Ref<StyleBox> Theme::get_stylebox(const StringName &p_name, const StringName &p_
 	if (style_map.has(p_theme_type) && style_map[p_theme_type].has(p_name) && style_map[p_theme_type][p_name].is_valid()) {
 		return style_map[p_theme_type][p_name];
 	} else {
-		return default_style;
+		return fallback_style;
 	}
 }
 
@@ -497,15 +517,15 @@ void Theme::set_font(const StringName &p_name, const StringName &p_theme_type, c
 Ref<Font> Theme::get_font(const StringName &p_name, const StringName &p_theme_type) const {
 	if (font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name) && font_map[p_theme_type][p_name].is_valid()) {
 		return font_map[p_theme_type][p_name];
-	} else if (has_default_theme_font()) {
-		return default_theme_font;
-	} else {
+	} else if (has_default_font()) {
 		return default_font;
+	} else {
+		return fallback_font;
 	}
 }
 
 bool Theme::has_font(const StringName &p_name, const StringName &p_theme_type) const {
-	return ((font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name) && font_map[p_theme_type][p_name].is_valid()) || has_default_theme_font());
+	return ((font_map.has(p_theme_type) && font_map[p_theme_type].has(p_name) && font_map[p_theme_type][p_name].is_valid()) || has_default_font());
 }
 
 bool Theme::has_font_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
@@ -577,15 +597,15 @@ void Theme::set_font_size(const StringName &p_name, const StringName &p_theme_ty
 int Theme::get_font_size(const StringName &p_name, const StringName &p_theme_type) const {
 	if (font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name) && (font_size_map[p_theme_type][p_name] > 0)) {
 		return font_size_map[p_theme_type][p_name];
-	} else if (has_default_theme_font_size()) {
-		return default_theme_font_size;
-	} else {
+	} else if (has_default_font_size()) {
 		return default_font_size;
+	} else {
+		return fallback_font_size;
 	}
 }
 
 bool Theme::has_font_size(const StringName &p_name, const StringName &p_theme_type) const {
-	return ((font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name) && (font_size_map[p_theme_type][p_name] > 0)) || has_default_theme_font_size());
+	return ((font_size_map.has(p_theme_type) && font_size_map[p_theme_type].has(p_name) && (font_size_map[p_theme_type][p_name] > 0)) || has_default_font_size());
 }
 
 bool Theme::has_font_size_nocheck(const StringName &p_name, const StringName &p_theme_type) const {
@@ -1622,17 +1642,17 @@ void Theme::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_constant_list", "theme_type"), &Theme::_get_constant_list);
 	ClassDB::bind_method(D_METHOD("get_constant_type_list"), &Theme::_get_constant_type_list);
 
-	ClassDB::bind_method(D_METHOD("set_default_base_scale", "font_size"), &Theme::set_default_theme_base_scale);
-	ClassDB::bind_method(D_METHOD("get_default_base_scale"), &Theme::get_default_theme_base_scale);
-	ClassDB::bind_method(D_METHOD("has_default_base_scale"), &Theme::has_default_theme_base_scale);
+	ClassDB::bind_method(D_METHOD("set_default_base_scale", "base_scale"), &Theme::set_default_base_scale);
+	ClassDB::bind_method(D_METHOD("get_default_base_scale"), &Theme::get_default_base_scale);
+	ClassDB::bind_method(D_METHOD("has_default_base_scale"), &Theme::has_default_base_scale);
 
-	ClassDB::bind_method(D_METHOD("set_default_font", "font"), &Theme::set_default_theme_font);
-	ClassDB::bind_method(D_METHOD("get_default_font"), &Theme::get_default_theme_font);
-	ClassDB::bind_method(D_METHOD("has_default_font"), &Theme::has_default_theme_font);
+	ClassDB::bind_method(D_METHOD("set_default_font", "font"), &Theme::set_default_font);
+	ClassDB::bind_method(D_METHOD("get_default_font"), &Theme::get_default_font);
+	ClassDB::bind_method(D_METHOD("has_default_font"), &Theme::has_default_font);
 
-	ClassDB::bind_method(D_METHOD("set_default_font_size", "font_size"), &Theme::set_default_theme_font_size);
-	ClassDB::bind_method(D_METHOD("get_default_font_size"), &Theme::get_default_theme_font_size);
-	ClassDB::bind_method(D_METHOD("has_default_font_size"), &Theme::has_default_theme_font_size);
+	ClassDB::bind_method(D_METHOD("set_default_font_size", "font_size"), &Theme::set_default_font_size);
+	ClassDB::bind_method(D_METHOD("get_default_font_size"), &Theme::get_default_font_size);
+	ClassDB::bind_method(D_METHOD("has_default_font_size"), &Theme::has_default_font_size);
 
 	ClassDB::bind_method(D_METHOD("set_theme_item", "data_type", "name", "theme_type", "value"), &Theme::set_theme_item);
 	ClassDB::bind_method(D_METHOD("get_theme_item", "data_type", "name", "theme_type"), &Theme::get_theme_item);

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -101,16 +101,16 @@ protected:
 	static Ref<Theme> project_default_theme;
 
 	// Universal default values, final fallback for every theme.
-	static float default_base_scale;
-	static Ref<Texture2D> default_icon;
-	static Ref<StyleBox> default_style;
-	static Ref<Font> default_font;
-	static int default_font_size;
+	static float fallback_base_scale;
+	static Ref<Texture2D> fallback_icon;
+	static Ref<StyleBox> fallback_style;
+	static Ref<Font> fallback_font;
+	static int fallback_font_size;
 
 	// Default values configurable for each individual theme.
-	float default_theme_base_scale = 0.0;
-	Ref<Font> default_theme_font;
-	int default_theme_font_size = -1;
+	float default_base_scale = 0.0;
+	Ref<Font> default_font;
+	int default_font_size = -1;
 
 	static void _bind_methods();
 
@@ -126,23 +126,29 @@ public:
 	static Ref<Theme> get_project_default();
 	static void set_project_default(const Ref<Theme> &p_project_default);
 
-	static void set_default_base_scale(float p_base_scale);
-	static void set_default_icon(const Ref<Texture2D> &p_icon);
-	static void set_default_style(const Ref<StyleBox> &p_style);
-	static void set_default_font(const Ref<Font> &p_font);
-	static void set_default_font_size(int p_font_size);
+	static void set_fallback_base_scale(float p_base_scale);
+	static void set_fallback_icon(const Ref<Texture2D> &p_icon);
+	static void set_fallback_style(const Ref<StyleBox> &p_style);
+	static void set_fallback_font(const Ref<Font> &p_font);
+	static void set_fallback_font_size(int p_font_size);
 
-	void set_default_theme_base_scale(float p_base_scale);
-	float get_default_theme_base_scale() const;
-	bool has_default_theme_base_scale() const;
+	static float get_fallback_base_scale();
+	static Ref<Texture2D> get_fallback_icon();
+	static Ref<StyleBox> get_fallback_style();
+	static Ref<Font> get_fallback_font();
+	static int get_fallback_font_size();
 
-	void set_default_theme_font(const Ref<Font> &p_default_font);
-	Ref<Font> get_default_theme_font() const;
-	bool has_default_theme_font() const;
+	void set_default_base_scale(float p_base_scale);
+	float get_default_base_scale() const;
+	bool has_default_base_scale() const;
 
-	void set_default_theme_font_size(int p_font_size);
-	int get_default_theme_font_size() const;
-	bool has_default_theme_font_size() const;
+	void set_default_font(const Ref<Font> &p_default_font);
+	Ref<Font> get_default_font() const;
+	bool has_default_font() const;
+
+	void set_default_font_size(int p_font_size);
+	int get_default_font_size() const;
+	bool has_default_font_size() const;
 
 	void set_icon(const StringName &p_name, const StringName &p_theme_type, const Ref<Texture2D> &p_icon);
 	Ref<Texture2D> get_icon(const StringName &p_name, const StringName &p_theme_type) const;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/54955. Same issue could also be witnessed with ColorPicker color sliders.

This PR also renames some properties and methods in the Theme resource to finally get rid of confusing and conflicting naming scheme where public methods were bound to differently named private methods, yet there were still private methods of the same name as those public methods, making navigating that class ridiculously convoluted. Note, that public API doesn't change with this PR, so I'd consider this non-breaking (not that it matters in master at the moment).