### PR TITLE
Improvements to EditorResourcePicker

### DIFF
--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -49,6 +49,7 @@ void EditorResourcePicker::_update_resource() {
 	if (edited_resource == RES()) {
 		assign_button->set_icon(Ref<Texture2D>());
 		assign_button->set_text(TTR("[empty]"));
+		assign_button->set_tooltip("");
 	} else {
 		assign_button->set_icon(EditorNode::get_singleton()->get_object_icon(edited_resource.operator->(), "Object"));
 
@@ -56,14 +57,15 @@ void EditorResourcePicker::_update_resource() {
 			assign_button->set_text(edited_resource->get_name());
 		} else if (edited_resource->get_path().is_resource_file()) {
 			assign_button->set_text(edited_resource->get_path().get_file());
-			assign_button->set_tooltip(edited_resource->get_path());
 		} else {
 			assign_button->set_text(edited_resource->get_class());
 		}
 
+		String resource_path;
 		if (edited_resource->get_path().is_resource_file()) {
-			assign_button->set_tooltip(edited_resource->get_path());
+			resource_path = edited_resource->get_path() + "\n";
 		}
+		assign_button->set_tooltip(resource_path + TTR("Type:") + " " + edited_resource->get_class());
 
 		// Preview will override the above, so called at the end.
 		EditorResourcePreview::get_singleton()->queue_edited_resource_preview(edited_resource, this, "_update_resource_preview", edited_resource->get_instance_id());
@@ -514,12 +516,14 @@ void EditorResourcePicker::_get_allowed_types(bool p_with_convert, Set<String> *
 		}
 
 		if (p_with_convert) {
-			if (base == "StandardMaterial3D") {
+			if (base == "BaseMaterial3D") {
 				p_vector->insert("Texture2D");
 			} else if (base == "ShaderMaterial") {
 				p_vector->insert("Shader");
 			} else if (base == "Font") {
 				p_vector->insert("FontData");
+			} else if (base == "Texture2D") {
+				p_vector->insert("Image");
 			}
 		}
 	}
@@ -636,24 +640,44 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 			for (Set<String>::Element *E = allowed_types.front(); E; E = E->next()) {
 				String at = E->get().strip_edges();
 
-				if (at == "StandardMaterial3D" && ClassDB::is_parent_class(dropped_resource->get_class(), "Texture2D")) {
-					Ref<StandardMaterial3D> mat = memnew(StandardMaterial3D);
+				if (at == "BaseMaterial3D" && ClassDB::is_parent_class(dropped_resource->get_class(), "Texture2D")) {
+					// Use existing resource if possible and only replace its data.
+					Ref<StandardMaterial3D> mat = edited_resource;
+					if (!mat.is_valid()) {
+						mat.instantiate();
+					}
 					mat->set_texture(StandardMaterial3D::TextureParam::TEXTURE_ALBEDO, dropped_resource);
 					dropped_resource = mat;
 					break;
 				}
 
 				if (at == "ShaderMaterial" && ClassDB::is_parent_class(dropped_resource->get_class(), "Shader")) {
-					Ref<ShaderMaterial> mat = memnew(ShaderMaterial);
+					Ref<ShaderMaterial> mat = edited_resource;
+					if (!mat.is_valid()) {
+						mat.instantiate();
+					}
 					mat->set_shader(dropped_resource);
 					dropped_resource = mat;
 					break;
 				}
 
 				if (at == "Font" && ClassDB::is_parent_class(dropped_resource->get_class(), "FontData")) {
-					Ref<Font> font = memnew(Font);
+					Ref<Font> font = edited_resource;
+					if (!font.is_valid()) {
+						font.instantiate();
+					}
 					font->add_data(dropped_resource);
 					dropped_resource = font;
+					break;
+				}
+
+				if (at == "Texture2D" && ClassDB::is_parent_class(dropped_resource->get_class(), "Image")) {
+					Ref<ImageTexture> texture = edited_resource;
+					if (!texture.is_valid()) {
+						texture.instantiate();
+					}
+					texture->create_from_image(dropped_resource);
+					dropped_resource = texture;
 					break;
 				}
 			}


### PR DESCRIPTION
The PR does various improvements to EditorResourcePicker
- added support for Image -> ImageTexture conversion (part of #55727)
- when doing conversion and a matching resource already exists, don't create new resource, but replace data instead (this is somewhat similar to #50517, e.g. you can drop a texture on an existing StandardMaterial3D to replace current texture instead of creating new material)
- fixed a bug where clearing resource wouldn't clear the tooltip
- fixed Texture -> StandardMaterial3D not working
- added resource type to tooltip (similar to scene tree dock)
![image](https://user-images.githubusercontent.com/2223172/147850968-28bf3dcc-5dc5-4fb9-b575-296903041328.png)