### PR TITLE
Fix unexpected Packed Array copying when parameter is typed

### DIFF
--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -488,7 +488,12 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 				memnew_placement(&stack[i + 3], Variant(*p_args[i]));
 				continue;
 			}
-
+			// If types already match, don't call Variant::construct(). Constructors of some types
+			// (e.g. packed arrays) do copies, whereas they pass by reference when inside a Variant.
+			if (argument_types[i].is_type(*p_args[i], false)) {
+				memnew_placement(&stack[i + 3], Variant(*p_args[i]));
+				continue;
+			}
 			if (!argument_types[i].is_type(*p_args[i], true)) {
 				r_err.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 				r_err.argument = i;


### PR DESCRIPTION
Fixes #56388

This is my suggested fix.

My understanding of this comment https://github.com/godotengine/godot/pull/36492#issue-569558185 is that packed array copying is intended, but only for parameters of functions in the C++ API. This PR shouldn't affect that, as it only changes the behavior regarding parameters of GDScript functions, making them consistent with the rest of Packed Array usage in GDScript.