### PR TITLE
[3.x] Add ACTION_MODE_HYBRID to BaseButton

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -125,5 +125,8 @@
 		<constant name="ACTION_MODE_BUTTON_RELEASE" value="1" enum="ActionMode">
 			Require a press and a subsequent release before considering the button clicked.
 		</constant>
+		<constant name="ACTION_MODE_HYBRID" value="2" enum="ActionMode">
+			Acts like [constant ACTION_MODE_BUTTON_RELEASE] for mouse-based inputs, but like [constant ACTION_MODE_BUTTON_PRESS] for other inputs.
+		</constant>
 	</constants>
 </class>

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -144,8 +144,17 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 	}
 
 	if (status.press_attempt && status.pressing_inside) {
+		bool activate = p_event->is_pressed() == (action_mode == ACTION_MODE_BUTTON_PRESS);
+		if (action_mode == ACTION_MODE_HYBRID) {
+			Ref<InputEventMouseButton> mouse_button = p_event;
+			if (mouse_button.is_valid()) {
+				activate = !p_event->is_pressed();
+			} else {
+				activate = p_event->is_pressed();
+			}
+		}
 		if (toggle_mode) {
-			if ((p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_PRESS) || (!p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
+			if (activate) {
 				if (action_mode == ACTION_MODE_BUTTON_PRESS) {
 					status.press_attempt = false;
 					status.pressing_inside = false;
@@ -159,7 +168,7 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 				_pressed();
 			}
 		} else {
-			if ((p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_PRESS) || (!p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
+			if (activate) {
 				_pressed();
 			}
 		}
@@ -428,7 +437,7 @@ void BaseButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "toggle_mode"), "set_toggle_mode", "is_toggle_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shortcut_in_tooltip"), "set_shortcut_in_tooltip", "is_shortcut_in_tooltip_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "action_mode", PROPERTY_HINT_ENUM, "Button Press,Button Release"), "set_action_mode", "get_action_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "action_mode", PROPERTY_HINT_ENUM, "Button Press, Button Release, Hybrid"), "set_action_mode", "get_action_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_mask", PROPERTY_HINT_FLAGS, "Mouse Left, Mouse Right, Mouse Middle"), "set_button_mask", "get_button_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "enabled_focus_mode", PROPERTY_HINT_ENUM, "None,Click,All"), "set_enabled_focus_mode", "get_enabled_focus_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_pressed_outside"), "set_keep_pressed_outside", "is_keep_pressed_outside");
@@ -443,6 +452,7 @@ void BaseButton::_bind_methods() {
 
 	BIND_ENUM_CONSTANT(ACTION_MODE_BUTTON_PRESS);
 	BIND_ENUM_CONSTANT(ACTION_MODE_BUTTON_RELEASE);
+	BIND_ENUM_CONSTANT(ACTION_MODE_HYBRID);
 }
 
 BaseButton::BaseButton() {

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -42,6 +42,7 @@ public:
 	enum ActionMode {
 		ACTION_MODE_BUTTON_PRESS,
 		ACTION_MODE_BUTTON_RELEASE,
+		ACTION_MODE_HYBRID,
 	};
 
 private:


### PR DESCRIPTION
This is an implementation of https://github.com/godotengine/godot-proposals/issues/3234 . If it's satisfactory, I can make the same PR for master too.

This PR adds a third action mode to buttons that behaves how desktop applications and PC games *usually* behave - mouse inputs trigger buttons on release, and other inputs (keyboards, gamepads) trigger them on press.

This PR doesn't make the new mode the default. The 4.x PR does. I can change this if the new mode is desired as the default.