### PR TITLE
Make TextEdit new_line user override-able.

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -16,12 +16,6 @@
 				Override this method to define what happens when the user presses the backspace key.
 			</description>
 		</method>
-		<method name="_new_line" qualifiers="virtual">
-			<return type="void" />
-			<description>
-				Override this method to define what happens when the user presses the new line key.
-			</description>
-		</method>
 		<method name="_copy" qualifiers="virtual">
 			<return type="void" />
 			<description>
@@ -39,6 +33,12 @@
 			<argument index="0" name="unicode_char" type="int" />
 			<description>
 				Override this method to define what happens when the types in the provided key [code]unicode[/code].
+			</description>
+		</method>
+		<method name="_new_line" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Override this method to define what happens when the user presses the new line key.
 			</description>
 		</method>
 		<method name="_paste" qualifiers="virtual">
@@ -71,12 +71,6 @@
 			<return type="void" />
 			<description>
 				Called when the user presses the backspace key. Can be overridden with [method _backspace].
-			</description>
-		</method>
-		<method name="new_line">
-			<return type="void" />
-			<description>
-				Called when the user presses the new line key. Can be overridden with [method _new_line].
 			</description>
 		</method>
 		<method name="begin_complex_operation">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -16,6 +16,12 @@
 				Override this method to define what happens when the user presses the backspace key.
 			</description>
 		</method>
+		<method name="_new_line" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Override this method to define what happens when the user presses the new line key.
+			</description>
+		</method>
 		<method name="_copy" qualifiers="virtual">
 			<return type="void" />
 			<description>
@@ -65,6 +71,12 @@
 			<return type="void" />
 			<description>
 				Called when the user presses the backspace key. Can be overridden with [method _backspace].
+			</description>
+		</method>
+		<method name="new_line">
+			<return type="void" />
+			<description>
+				Called when the user presses the new line key. Can be overridden with [method _new_line].
 			</description>
 		</method>
 		<method name="begin_complex_operation">

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -620,6 +620,12 @@
 				Merge the gutters from [code]from_line[/code] into [code]to_line[/code]. Only overwritable gutters will be copied.
 			</description>
 		</method>
+		<method name="new_line">
+			<return type="void" />
+			<description>
+				Called when the user presses the new line key. Can be overridden with [method _new_line].
+			</description>
+		</method>
 		<method name="paste">
 			<return type="void" />
 			<description>

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1037,6 +1037,10 @@ void CodeEdit::_do_new_line(bool p_split_current_line, bool p_above) {
 	end_complex_operation();
 }
 
+void CodeEdit::_new_line_internal() {
+	_do_new_line();
+}
+
 /* Auto brace completion */
 void CodeEdit::set_auto_brace_completion_enabled(bool p_enabled) {
 	auto_brace_completion_enabled = p_enabled;

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -503,17 +503,17 @@ void CodeEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 	// Override new line actions, for auto indent
 	if (k->is_action("ui_text_newline_above", true)) {
-		_new_line(false, true);
+		_do_new_line(false, true);
 		accept_event();
 		return;
 	}
 	if (k->is_action("ui_text_newline_blank", true)) {
-		_new_line(false);
+		_do_new_line(false);
 		accept_event();
 		return;
 	}
 	if (k->is_action("ui_text_newline", true)) {
-		_new_line();
+		new_line();
 		accept_event();
 		return;
 	}
@@ -932,7 +932,7 @@ int CodeEdit::_calculate_spaces_till_next_right_indent(int p_column) const {
 	return indent_size - p_column % indent_size;
 }
 
-void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
+void CodeEdit::_do_new_line(bool p_split_current_line, bool p_above) {
 	if (!is_editable()) {
 		return;
 	}

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -64,7 +64,7 @@ private:
 	int _calculate_spaces_till_next_left_indent(int p_column) const;
 	int _calculate_spaces_till_next_right_indent(int p_column) const;
 
-	void _new_line(bool p_split_current_line = true, bool p_above = false);
+	void _do_new_line(bool p_split_current_line = true, bool p_above = false);
 
 	/* Auto brace completion */
 	bool auto_brace_completion_enabled = false;

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -258,6 +258,7 @@ protected:
 	// Overridable actions
 	virtual void _handle_unicode_input_internal(const uint32_t p_unicode) override;
 	virtual void _backspace_internal() override;
+	virtual void _new_line_internal() override;
 
 	GDVIRTUAL1(_confirm_code_completion, bool)
 	GDVIRTUAL1(_request_code_completion, bool)

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1816,17 +1816,17 @@ void TextEdit::gui_input(const Ref<InputEvent> &p_gui_input) {
 
 		// NEWLINES.
 		if (k->is_action("ui_text_newline_above", true)) {
-			_new_line(false, true);
+			_do_new_line(false, true);
 			accept_event();
 			return;
 		}
 		if (k->is_action("ui_text_newline_blank", true)) {
-			_new_line(false);
+			_do_new_line(false);
 			accept_event();
 			return;
 		}
 		if (k->is_action("ui_text_newline", true)) {
-			_new_line();
+			new_line();
 			accept_event();
 			return;
 		}
@@ -2036,7 +2036,7 @@ void TextEdit::_swap_current_input_direction() {
 	update();
 }
 
-void TextEdit::_new_line(bool p_split_current_line, bool p_above) {
+void TextEdit::_do_new_line(bool p_split_current_line, bool p_above) {
 	if (!editable) {
 		return;
 	}
@@ -3109,6 +3109,13 @@ void TextEdit::backspace() {
 		return;
 	}
 	_backspace_internal();
+}
+
+void TextEdit::new_line() {
+	if (GDVIRTUAL_CALL(_new_line)) {
+		return;
+	}
+	_new_line_internal();
 }
 
 void TextEdit::cut() {
@@ -4880,6 +4887,7 @@ void TextEdit::_bind_methods() {
 
 	GDVIRTUAL_BIND(_handle_unicode_input, "unicode_char")
 	GDVIRTUAL_BIND(_backspace)
+	GDVIRTUAL_BIND(_new_line)
 	GDVIRTUAL_BIND(_cut)
 	GDVIRTUAL_BIND(_copy)
 	GDVIRTUAL_BIND(_paste)
@@ -5379,6 +5387,14 @@ void TextEdit::_backspace_internal() {
 
 	set_caret_line(prev_line, false, true);
 	set_caret_column(prev_column);
+}
+
+void TextEdit::_new_line_internal() {
+	if (!editable) {
+		return;
+	}
+
+	_do_new_line();
 }
 
 void TextEdit::_cut_internal() {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4880,6 +4880,7 @@ void TextEdit::_bind_methods() {
 
 	// Overridable actions
 	ClassDB::bind_method(D_METHOD("backspace"), &TextEdit::backspace);
+	ClassDB::bind_method(D_METHOD("new_line"), &TextEdit::new_line);
 
 	ClassDB::bind_method(D_METHOD("cut"), &TextEdit::cut);
 	ClassDB::bind_method(D_METHOD("copy"), &TextEdit::copy);

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -546,7 +546,7 @@ private:
 
 	/* Input actions. */
 	void _swap_current_input_direction();
-	void _new_line(bool p_split_current = true, bool p_above = false);
+	void _do_new_line(bool p_split_current = true, bool p_above = false);
 	void _move_caret_left(bool p_select, bool p_move_by_word = false);
 	void _move_caret_right(bool p_select, bool p_move_by_word = false);
 	void _move_caret_up(bool p_select);
@@ -597,6 +597,7 @@ protected:
 	// Overridable actions
 	virtual void _handle_unicode_input_internal(const uint32_t p_unicode);
 	virtual void _backspace_internal();
+	virtual void _new_line_internal();
 
 	virtual void _cut_internal();
 	virtual void _copy_internal();
@@ -605,6 +606,7 @@ protected:
 
 	GDVIRTUAL1(_handle_unicode_input, int)
 	GDVIRTUAL0(_backspace)
+	GDVIRTUAL0(_new_line)
 	GDVIRTUAL0(_cut)
 	GDVIRTUAL0(_copy)
 	GDVIRTUAL0(_paste)
@@ -693,6 +695,7 @@ public:
 	// Overridable actions
 	void handle_unicode_input(const uint32_t p_unicode);
 	void backspace();
+	void new_line();
 
 	void cut();
 	void copy();


### PR DESCRIPTION
Apologies, I know I should talk to somebody before working on such a change, but had already made this change before reading the contributing page. Additionally this change is small enough, and seems inline with existing features of the engine.

My current problem is that I'm using the new `backspace` and `handle_unicode_input` functions of `TextEdit` to add readonly sections within a `TextEdit`/`CodeEdit`. The issue here is that I still want users to be able to add newlines by pressing enter, provided the caret is in an editable position.

This pull request makes very similar to changes to `_new_line` that have already been done to `backspace`, allowing the action associated with `ui_text_newline` to be overwritten by the user.