### PR TITLE
Disallow saving branches of foreign scene child nodes  [3.x]

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -948,6 +948,18 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				break;
 			}
 
+			if (tocopy->get_owner() != scene) {
+				accept->set_text(TTR("Can't sSavave a branch which is a child of an already instantiated scene.\nTo save this branch into its own scene, open the original scene, right click on this branch, and select \"Save Branch as Scene\"."));
+				accept->popup_centered();
+				break;
+			}
+
+			if (scene->get_scene_inherited_state().is_valid() && scene->get_scene_inherited_state()->find_node_by_path(scene->get_path_to(tocopy)) >= 0) {
+				accept->set_text(TTR("Can't save a branch which is part of an inherited scene.\nTo save this branch into its own scene, open the original scene, right click on this branch, and select \"Save Branch as Scene\"."));
+				accept->popup_centered();
+				break;
+			}
+
 			new_scene_from_dialog->set_mode(EditorFileDialog::MODE_SAVE_FILE);
 
 			List<String> extensions;


### PR DESCRIPTION
Pops up an error if attempting to save a branch as a new scene if it is the child node of either an instanced or inherited scene. 3.x backport of #56425