### PR TITLE
[3.x] [Mono] Add support for file-scoped namespace declaration.

### DIFF
--- a/modules/mono/editor/script_class_parser.cpp
+++ b/modules/mono/editor/script_class_parser.cpp
@@ -483,6 +483,9 @@ Error ScriptClassParser::_parse_namespace_name(String &r_name, int &r_curly_stac
 	} else if (tk == TK_CURLY_BRACKET_OPEN) {
 		r_curly_stack++;
 		return OK;
+	} else if (tk == TK_SYMBOL && String(value) == ";") {
+		// for file-scoped namespace declaration
+		return OK;
 	} else {
 		error_str = "Unexpected token: " + get_token_name(tk);
 		error = true;


### PR DESCRIPTION
Support for parsing C# scripts with [file-scoped namespace declaration](https://docs.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-10#file-scoped-namespace-declaration):

```csharp
using Godot;

namespace MyGame;

public class Main : Node2D
{
    // ...
}
```