### PR TITLE
Show tile set editor bottom panel button when creating a tile set for a tile map

### DIFF
--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -157,6 +157,17 @@ void TilesEditorPlugin::_update_editors() {
 
 	// Update the viewport.
 	CanvasItemEditor::get_singleton()->update_viewport();
+
+	// Update visibility of bottom panel buttons.
+	if (tileset_editor_button->is_pressed() && !tile_set.is_valid()) {
+		if (tile_map) {
+			editor_node->make_bottom_panel_item_visible(tilemap_editor);
+		} else {
+			editor_node->hide_bottom_panel();
+		}
+	}
+	tileset_editor_button->set_visible(tile_set.is_valid());
+	tilemap_editor_button->set_visible(tile_map);
 }
 
 void TilesEditorPlugin::_notification(int p_what) {


### PR DESCRIPTION
Fixes #56413

In `TilesEditorPlugin::_update_editors`, which is connected to the `changed` signal of a `TileMap`, the bottom panel buttons `tileset_editor_button` and `tilemap_editor_button` are correctly hidden or shown. Also this fix switches to another bottom panel if the `TileSetEditor` panel is displayed while there is no active `TileSet`.