### PR TITLE
Add width and height to sprite frames editor

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -82,6 +82,8 @@ class SpriteFramesEditor : public HSplitContainer {
 	TextureRect *split_sheet_preview;
 	SpinBox *split_sheet_h;
 	SpinBox *split_sheet_v;
+	SpinBox *split_sheet_height;
+	SpinBox *split_sheet_width;
 	Button *split_sheet_zoom_out;
 	Button *split_sheet_zoom_reset;
 	Button *split_sheet_zoom_in;
@@ -135,6 +137,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _prepare_sprite_sheet(const String &p_file);
 	int _sheet_preview_position_to_frame_index(const Vector2 &p_position);
 	void _sheet_preview_draw();
+	void _sheet_spin_wh_changed(double);
 	void _sheet_spin_changed(double);
 	void _sheet_preview_input(const Ref<InputEvent> &p_event);
 	void _sheet_scroll_input(const Ref<InputEvent> &p_event);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Added slice width and height settings to the sprite frame animation editor.

The old implementation can easily slice according to the number of rows and columns, but it assumes that the entire texture is valid. But sometimes there are blank areas in the atlas that are not divisible by the target slice size. If you simply cut according to the rows and columns, it will cause errors in the size and position of each slice, and there is no way to adjust it. In addition, sometimes when I get a new texture resource, I know the specifications of sprite drawing, but I don't know how many sprites are in each row and column. In the old implementation, I still need to count the number of sprites, which is more troublesome.

Therefore, I added the width and height settings, you can directly set the size of each slice, and then automatically calculate the number of rows and columns. You can also set the number of rows and columns, and automatically calculate the size of each slice, just like before. 