### PR TITLE
Fix incorrect default transform values on foreign 3D nodes

### DIFF
--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -134,6 +134,20 @@
 				Resets this node's transformations (like scale, skew and taper) preserving its rotation and translation by performing Gram-Schmidt orthonormalization on this node's [Transform3D].
 			</description>
 		</method>
+		<method name="property_can_revert">
+			<return type="bool" />
+			<argument index="0" name="name" type="String" />
+			<description>
+				Returns [code]true[/code] if the property identified by [code]name[/code] can be reverted to a default value.
+			</description>
+		</method>
+		<method name="property_get_revert">
+			<return type="Variant" />
+			<argument index="0" name="name" type="String" />
+			<description>
+				Returns the default value of the Node3D property with given [code]name[/code].
+			</description>
+		</method>
 		<method name="rotate">
 			<return type="void" />
 			<argument index="0" name="axis" type="Vector3" />

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -137,6 +137,9 @@ protected:
 
 	virtual void _validate_property(PropertyInfo &property) const override;
 
+	bool property_can_revert(const String &p_name);
+	Variant property_get_revert(const String &p_name);
+
 public:
 	enum {
 		NOTIFICATION_TRANSFORM_CHANGED = SceneTree::NOTIFICATION_TRANSFORM_CHANGED,


### PR DESCRIPTION
Closes #56434
Introduces property_can_revert and property_get_revert methods to Node3D to work around the problem described in the issue. Does this by getting the default value for "transform" then converting it to the desired editor property.