### PR TITLE
Fix usage of "Return" in the docs

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -234,7 +234,7 @@
 		<method name="get_folded_lines" qualifiers="const">
 			<return type="int[]" />
 			<description>
-				Return all lines that are current folded.
+				Returns all lines that are current folded.
 			</description>
 		</method>
 		<method name="get_text_for_code_completion" qualifiers="const">
@@ -288,7 +288,7 @@
 			<argument index="0" name="line" type="int" />
 			<argument index="1" name="column" type="int" default="-1" />
 			<description>
-				Return delimiter index if [code]line[/code] [code]column[/code] is in a comment. If [code]column[/code] is not provided, will return delimiter index if the entire [code]line[/code] is a comment. Otherwise [code]-1[/code].
+				Returns delimiter index if [code]line[/code] [code]column[/code] is in a comment. If [code]column[/code] is not provided, will return delimiter index if the entire [code]line[/code] is a comment. Otherwise [code]-1[/code].
 			</description>
 		</method>
 		<method name="is_in_string" qualifiers="const">
@@ -296,7 +296,7 @@
 			<argument index="0" name="line" type="int" />
 			<argument index="1" name="column" type="int" default="-1" />
 			<description>
-				Return the delimiter index if [code]line[/code] [code]column[/code] is in a string. If [code]column[/code] is not provided, will return the delimiter index if the entire [code]line[/code] is a string. Otherwise [code]-1[/code].
+				Returns the delimiter index if [code]line[/code] [code]column[/code] is in a string. If [code]column[/code] is not provided, will return the delimiter index if the entire [code]line[/code] is a string. Otherwise [code]-1[/code].
 			</description>
 		</method>
 		<method name="is_line_bookmarked" qualifiers="const">

--- a/doc/classes/CodeHighlighter.xml
+++ b/doc/classes/CodeHighlighter.xml
@@ -76,21 +76,21 @@
 			<return type="bool" />
 			<argument index="0" name="start_key" type="String" />
 			<description>
-				Return [code]true[/code] if the start key exists, else [code]false[/code].
+				Returns [code]true[/code] if the start key exists, else [code]false[/code].
 			</description>
 		</method>
 		<method name="has_keyword_color" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="keyword" type="String" />
 			<description>
-				Return [code]true[/code] if the keyword exists, else [code]false[/code].
+				Returns [code]true[/code] if the keyword exists, else [code]false[/code].
 			</description>
 		</method>
 		<method name="has_member_keyword_color" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="member_keyword" type="String" />
 			<description>
-				Return [code]true[/code] if the member keyword exists, else [code]false[/code].
+				Returns [code]true[/code] if the member keyword exists, else [code]false[/code].
 			</description>
 		</method>
 		<method name="remove_color_region">

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -201,7 +201,7 @@
 			<argument index="1" name="text" type="String" />
 			<description>
 				User defined BiDi algorithm override function.
-				Return [code]Array[/code] of [code]Vector2i[/code] text ranges, in the left-to-right order. Ranges should cover full source [code]text[/code] without overlaps. BiDi algorithm will be used on each range separately.
+				Returns [code]Array[/code] of [code]Vector2i[/code] text ranges, in the left-to-right order. Ranges should cover full source [code]text[/code] without overlaps. BiDi algorithm will be used on each range separately.
 			</description>
 		</method>
 		<method name="accept_event">

--- a/doc/classes/CryptoKey.xml
+++ b/doc/classes/CryptoKey.xml
@@ -14,7 +14,7 @@
 		<method name="is_public_only" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Return [code]true[/code] if this CryptoKey only has the public part, and not the private one.
+				Returns [code]true[/code] if this CryptoKey only has the public part, and not the private one.
 			</description>
 		</method>
 		<method name="load">

--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -392,7 +392,7 @@
 		<method name="screen_get_max_scale" qualifiers="const">
 			<return type="float" />
 			<description>
-				Return the greatest scale factor of all screens.
+				Returns the greatest scale factor of all screens.
 				[b]Note:[/b] On macOS returned value is [code]2.0[/code] if there is at least one hiDPI (Retina) screen in the system, and [code]1.0[/code] in all other cases.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>
@@ -413,7 +413,7 @@
 			<return type="float" />
 			<argument index="0" name="screen" type="int" default="-1" />
 			<description>
-				Return the scale factor of the specified screen by index.
+				Returns the scale factor of the specified screen by index.
 				[b]Note:[/b] On macOS returned value is [code]2.0[/code] for hiDPI (Retina) screen, and [code]1.0[/code] for all other cases.
 				[b]Note:[/b] This method is implemented on macOS.
 			</description>

--- a/doc/classes/EditorImportPlugin.xml
+++ b/doc/classes/EditorImportPlugin.xml
@@ -163,7 +163,7 @@
 				}
 				[/csharp]
 				[/codeblocks]
-				Return [code]true[/code] to make all options always visible.
+				Returns [code]true[/code] to make all options always visible.
 			</description>
 		</method>
 		<method name="_get_preset_count" qualifiers="virtual const">

--- a/doc/classes/Font.xml
+++ b/doc/classes/Font.xml
@@ -222,7 +222,7 @@
 			<return type="float" />
 			<argument index="0" name="size" type="int" default="16" />
 			<description>
-				Return average pixel offset of the underline below the baseline.
+				Returns average pixel offset of the underline below the baseline.
 				[b]Note:[/b] Real underline position of the string is context-dependent and can be significantly different from the value returned by this function. Use it only as rough estimate.
 			</description>
 		</method>
@@ -230,7 +230,7 @@
 			<return type="float" />
 			<argument index="0" name="size" type="int" default="16" />
 			<description>
-				Return average thickness of the underline.
+				Returns average thickness of the underline.
 				[b]Note:[/b] Real underline thickness of the string is context-dependent and can be significantly different from the value returned by this function. Use it only as rough estimate.
 			</description>
 		</method>
@@ -238,7 +238,7 @@
 			<return type="bool" />
 			<argument index="0" name="char" type="int" />
 			<description>
-				Return [code]true[/code] if a Unicode [code]char[/code] is available in the font.
+				Returns [code]true[/code] if a Unicode [code]char[/code] is available in the font.
 			</description>
 		</method>
 		<method name="remove_data">

--- a/doc/classes/FontData.xml
+++ b/doc/classes/FontData.xml
@@ -259,7 +259,7 @@
 			<return type="Array" />
 			<argument index="0" name="cache_index" type="int" />
 			<description>
-				Return list of the font sizes in the cache. Each size is [code]Vector2i[/code] with font size and outline size.
+				Returns list of the font sizes in the cache. Each size is [code]Vector2i[/code] with font size and outline size.
 			</description>
 		</method>
 		<method name="get_spacing" qualifiers="const">
@@ -343,7 +343,7 @@
 			<return type="bool" />
 			<argument index="0" name="char" type="int" />
 			<description>
-				Return [code]true[/code] if a Unicode [code]char[/code] is available in the font.
+				Returns [code]true[/code] if a Unicode [code]char[/code] is available in the font.
 			</description>
 		</method>
 		<method name="is_antialiased" qualifiers="const">

--- a/doc/classes/ParticlesMaterial.xml
+++ b/doc/classes/ParticlesMaterial.xml
@@ -15,14 +15,14 @@
 			<return type="float" />
 			<argument index="0" name="param" type="int" enum="ParticlesMaterial.Parameter" />
 			<description>
-				Return the maximum value range for the given parameter.
+				Returns the maximum value range for the given parameter.
 			</description>
 		</method>
 		<method name="get_param_min" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="param" type="int" enum="ParticlesMaterial.Parameter" />
 			<description>
-				Return the minimum value range for the given parameter.
+				Returns the minimum value range for the given parameter.
 			</description>
 		</method>
 		<method name="get_param_texture" qualifiers="const">

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -340,7 +340,7 @@
 			<return type="String" />
 			<argument index="0" name="parts" type="PackedStringArray" />
 			<description>
-				Return a [String] which is the concatenation of the [code]parts[/code]. The separator between elements is the string providing this method.
+				Returns a [String] which is the concatenation of the [code]parts[/code]. The separator between elements is the string providing this method.
 				Example:
 				[codeblocks]
 				[gdscript]

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -201,7 +201,7 @@
 		<method name="get_last_full_visible_line" qualifiers="const">
 			<return type="int" />
 			<description>
-				Return the last visible line. Use [method get_last_full_visible_line_wrap_index] for the wrap index.
+				Returns the last visible line. Use [method get_last_full_visible_line_wrap_index] for the wrap index.
 			</description>
 		</method>
 		<method name="get_last_full_visible_line_wrap_index" qualifiers="const">

--- a/doc/classes/TextParagraph.xml
+++ b/doc/classes/TextParagraph.xml
@@ -113,7 +113,7 @@
 		<method name="get_dropcap_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
-				Return drop cap text buffer RID.
+				Returns drop cap text buffer RID.
 			</description>
 		</method>
 		<method name="get_dropcap_size" qualifiers="const">

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -244,7 +244,7 @@
 			<return type="int" />
 			<argument index="0" name="font_rid" type="RID" />
 			<description>
-				Return the width of the range around the shape between the minimum and maximum representable signed distance.
+				Returns the width of the range around the shape between the minimum and maximum representable signed distance.
 			</description>
 		</method>
 		<method name="font_get_msdf_size" qualifiers="const">
@@ -295,7 +295,7 @@
 			<return type="Array" />
 			<argument index="0" name="font_rid" type="RID" />
 			<description>
-				Return list of the font sizes in the cache. Each size is [code]Vector2i[/code] with font size and outline size.
+				Returns list of the font sizes in the cache. Each size is [code]Vector2i[/code] with font size and outline size.
 			</description>
 		</method>
 		<method name="font_get_spacing" qualifiers="const">
@@ -382,7 +382,7 @@
 			<argument index="0" name="font_rid" type="RID" />
 			<argument index="1" name="char" type="int" />
 			<description>
-				Return [code]true[/code] if a Unicode [code]char[/code] is available in the font.
+				Returns [code]true[/code] if a Unicode [code]char[/code] is available in the font.
 			</description>
 		</method>
 		<method name="font_is_antialiased" qualifiers="const">

--- a/doc/classes/UndoRedo.xml
+++ b/doc/classes/UndoRedo.xml
@@ -162,7 +162,7 @@
 		<method name="get_history_count">
 			<return type="int" />
 			<description>
-				Return how many elements are in the history.
+				Returns how many elements are in the history.
 			</description>
 		</method>
 		<method name="get_version" qualifiers="const">

--- a/modules/enet/doc_classes/ENetMultiplayerPeer.xml
+++ b/modules/enet/doc_classes/ENetMultiplayerPeer.xml
@@ -62,7 +62,7 @@
 			<return type="ENetPacketPeer" />
 			<argument index="0" name="id" type="int" />
 			<description>
-				Return the [ENetPacketPeer] associated to the given [code]id[/code].
+				Returns the [ENetPacketPeer] associated to the given [code]id[/code].
 			</description>
 		</method>
 		<method name="set_bind_ip">

--- a/modules/visual_script/doc_classes/VisualScriptBuiltinFunc.xml
+++ b/modules/visual_script/doc_classes/VisualScriptBuiltinFunc.xml
@@ -16,85 +16,85 @@
 	</members>
 	<constants>
 		<constant name="MATH_SIN" value="0" enum="BuiltinFunc">
-			Return the sine of the input.
+			Returns the sine of the input.
 		</constant>
 		<constant name="MATH_COS" value="1" enum="BuiltinFunc">
-			Return the cosine of the input.
+			Returns the cosine of the input.
 		</constant>
 		<constant name="MATH_TAN" value="2" enum="BuiltinFunc">
-			Return the tangent of the input.
+			Returns the tangent of the input.
 		</constant>
 		<constant name="MATH_SINH" value="3" enum="BuiltinFunc">
-			Return the hyperbolic sine of the input.
+			Returns the hyperbolic sine of the input.
 		</constant>
 		<constant name="MATH_COSH" value="4" enum="BuiltinFunc">
-			Return the hyperbolic cosine of the input.
+			Returns the hyperbolic cosine of the input.
 		</constant>
 		<constant name="MATH_TANH" value="5" enum="BuiltinFunc">
-			Return the hyperbolic tangent of the input.
+			Returns the hyperbolic tangent of the input.
 		</constant>
 		<constant name="MATH_ASIN" value="6" enum="BuiltinFunc">
-			Return the arc sine of the input.
+			Returns the arc sine of the input.
 		</constant>
 		<constant name="MATH_ACOS" value="7" enum="BuiltinFunc">
-			Return the arc cosine of the input.
+			Returns the arc cosine of the input.
 		</constant>
 		<constant name="MATH_ATAN" value="8" enum="BuiltinFunc">
-			Return the arc tangent of the input.
+			Returns the arc tangent of the input.
 		</constant>
 		<constant name="MATH_ATAN2" value="9" enum="BuiltinFunc">
-			Return the arc tangent of the input, using the signs of both parameters to determine the exact angle.
+			Returns the arc tangent of the input, using the signs of both parameters to determine the exact angle.
 		</constant>
 		<constant name="MATH_SQRT" value="10" enum="BuiltinFunc">
-			Return the square root of the input.
+			Returns the square root of the input.
 		</constant>
 		<constant name="MATH_FMOD" value="11" enum="BuiltinFunc">
-			Return the remainder of one input divided by the other, using floating-point numbers.
+			Returns the remainder of one input divided by the other, using floating-point numbers.
 		</constant>
 		<constant name="MATH_FPOSMOD" value="12" enum="BuiltinFunc">
-			Return the positive remainder of one input divided by the other, using floating-point numbers.
+			Returns the positive remainder of one input divided by the other, using floating-point numbers.
 		</constant>
 		<constant name="MATH_FLOOR" value="13" enum="BuiltinFunc">
-			Return the input rounded down.
+			Returns the input rounded down.
 		</constant>
 		<constant name="MATH_CEIL" value="14" enum="BuiltinFunc">
-			Return the input rounded up.
+			Returns the input rounded up.
 		</constant>
 		<constant name="MATH_ROUND" value="15" enum="BuiltinFunc">
-			Return the input rounded to the nearest integer.
+			Returns the input rounded to the nearest integer.
 		</constant>
 		<constant name="MATH_ABS" value="16" enum="BuiltinFunc">
-			Return the absolute value of the input.
+			Returns the absolute value of the input.
 		</constant>
 		<constant name="MATH_SIGN" value="17" enum="BuiltinFunc">
-			Return the sign of the input, turning it into 1, -1, or 0. Useful to determine if the input is positive or negative.
+			Returns the sign of the input, turning it into 1, -1, or 0. Useful to determine if the input is positive or negative.
 		</constant>
 		<constant name="MATH_POW" value="18" enum="BuiltinFunc">
-			Return the input raised to a given power.
+			Returns the input raised to a given power.
 		</constant>
 		<constant name="MATH_LOG" value="19" enum="BuiltinFunc">
-			Return the natural logarithm of the input. Note that this is not the typical base-10 logarithm function calculators use.
+			Returns the natural logarithm of the input. Note that this is not the typical base-10 logarithm function calculators use.
 		</constant>
 		<constant name="MATH_EXP" value="20" enum="BuiltinFunc">
-			Return the mathematical constant [b]e[/b] raised to the specified power of the input. [b]e[/b] has an approximate value of 2.71828.
+			Returns the mathematical constant [b]e[/b] raised to the specified power of the input. [b]e[/b] has an approximate value of 2.71828.
 		</constant>
 		<constant name="MATH_ISNAN" value="21" enum="BuiltinFunc">
-			Return whether the input is NaN (Not a Number) or not. NaN is usually produced by dividing 0 by 0, though other ways exist.
+			Returns whether the input is NaN (Not a Number) or not. NaN is usually produced by dividing 0 by 0, though other ways exist.
 		</constant>
 		<constant name="MATH_ISINF" value="22" enum="BuiltinFunc">
-			Return whether the input is an infinite floating-point number or not. Infinity is usually produced by dividing a number by 0, though other ways exist.
+			Returns whether the input is an infinite floating-point number or not. Infinity is usually produced by dividing a number by 0, though other ways exist.
 		</constant>
 		<constant name="MATH_EASE" value="23" enum="BuiltinFunc">
 			Easing function, based on exponent. 0 is constant, 1 is linear, 0 to 1 is ease-in, 1+ is ease out. Negative values are in-out/out in.
 		</constant>
 		<constant name="MATH_STEP_DECIMALS" value="24" enum="BuiltinFunc">
-			Return the number of digit places after the decimal that the first non-zero digit occurs.
+			Returns the number of digit places after the decimal that the first non-zero digit occurs.
 		</constant>
 		<constant name="MATH_SNAPPED" value="25" enum="BuiltinFunc">
-			Return the input snapped to a given step.
+			Returns the input snapped to a given step.
 		</constant>
 		<constant name="MATH_LERP" value="26" enum="BuiltinFunc">
-			Return a number linearly interpolated between the first two inputs, based on the third input. Uses the formula [code]a + (a - b) * t[/code].
+			Returns a number linearly interpolated between the first two inputs, based on the third input. Uses the formula [code]a + (a - b) * t[/code].
 		</constant>
 		<constant name="MATH_INVERSE_LERP" value="27" enum="BuiltinFunc">
 		</constant>
@@ -107,16 +107,16 @@
 			Randomize the seed (or the internal state) of the random number generator. Current implementation reseeds using a number based on time.
 		</constant>
 		<constant name="MATH_RANDI" value="31" enum="BuiltinFunc">
-			Return a random 32 bits integer value. To obtain a random value between 0 to N (where N is smaller than 2^32 - 1), you can use it with the remainder function.
+			Returns a random 32 bits integer value. To obtain a random value between 0 to N (where N is smaller than 2^32 - 1), you can use it with the remainder function.
 		</constant>
 		<constant name="MATH_RANDF" value="32" enum="BuiltinFunc">
-			Return a random floating-point value between 0 and 1. To obtain a random value between 0 to N, you can use it with multiplication.
+			Returns a random floating-point value between 0 and 1. To obtain a random value between 0 to N, you can use it with multiplication.
 		</constant>
 		<constant name="MATH_RANDI_RANGE" value="33" enum="BuiltinFunc">
-			Return a random 32-bit integer value between the two inputs.
+			Returns a random 32-bit integer value between the two inputs.
 		</constant>
 		<constant name="MATH_RANDF_RANGE" value="34" enum="BuiltinFunc">
-			Return a random floating-point value between the two inputs.
+			Returns a random floating-point value between the two inputs.
 		</constant>
 		<constant name="MATH_RANDFN" value="35" enum="BuiltinFunc">
 			Returns a normally-distributed pseudo-random number, using Box-Muller transform with the specified mean and a standard deviation. This is also called Gaussian distribution.
@@ -125,7 +125,7 @@
 			Set the seed for the random number generator.
 		</constant>
 		<constant name="MATH_RANDSEED" value="37" enum="BuiltinFunc">
-			Return a random value from the given seed, along with the new seed.
+			Returns a random value from the given seed, along with the new seed.
 		</constant>
 		<constant name="MATH_DEG2RAD" value="38" enum="BuiltinFunc">
 			Convert the input from degrees to radians.
@@ -144,19 +144,19 @@
 		<constant name="MATH_WRAPF" value="43" enum="BuiltinFunc">
 		</constant>
 		<constant name="MATH_PINGPONG" value="44" enum="BuiltinFunc">
-			Return the [code]value[/code] wrapped between [code]0[/code] and the [code]length[/code]. If the limit is reached, the next value the function returned is decreased to the [code]0[/code] side or increased to the [code]length[/code] side (like a triangle wave). If [code]length[/code] is less than zero, it becomes positive.
+			Returns the [code]value[/code] wrapped between [code]0[/code] and the [code]length[/code]. If the limit is reached, the next value the function returned is decreased to the [code]0[/code] side or increased to the [code]length[/code] side (like a triangle wave). If [code]length[/code] is less than zero, it becomes positive.
 		</constant>
 		<constant name="LOGIC_MAX" value="45" enum="BuiltinFunc">
-			Return the greater of the two numbers, also known as their maximum.
+			Returns the greater of the two numbers, also known as their maximum.
 		</constant>
 		<constant name="LOGIC_MIN" value="46" enum="BuiltinFunc">
-			Return the lesser of the two numbers, also known as their minimum.
+			Returns the lesser of the two numbers, also known as their minimum.
 		</constant>
 		<constant name="LOGIC_CLAMP" value="47" enum="BuiltinFunc">
-			Return the input clamped inside the given range, ensuring the result is never outside it. Equivalent to [code]min(max(input, range_low), range_high)[/code].
+			Returns the input clamped inside the given range, ensuring the result is never outside it. Equivalent to [code]min(max(input, range_low), range_high)[/code].
 		</constant>
 		<constant name="LOGIC_NEAREST_PO2" value="48" enum="BuiltinFunc">
-			Return the nearest power of 2 to the input.
+			Returns the nearest power of 2 to the input.
 		</constant>
 		<constant name="OBJ_WEAKREF" value="49" enum="BuiltinFunc">
 			Create a [WeakRef] from the input.
@@ -165,13 +165,13 @@
 			Convert between types.
 		</constant>
 		<constant name="TYPE_OF" value="51" enum="BuiltinFunc">
-			Return the type of the input as an integer. Check [enum Variant.Type] for the integers that might be returned.
+			Returns the type of the input as an integer. Check [enum Variant.Type] for the integers that might be returned.
 		</constant>
 		<constant name="TYPE_EXISTS" value="52" enum="BuiltinFunc">
 			Checks if a type is registered in the [ClassDB].
 		</constant>
 		<constant name="TEXT_CHAR" value="53" enum="BuiltinFunc">
-			Return a character with the given ascii value.
+			Returns a character with the given ascii value.
 		</constant>
 		<constant name="TEXT_STR" value="54" enum="BuiltinFunc">
 			Convert the input to a string.
@@ -200,7 +200,7 @@
 			Deserialize a [Variant] from a [PackedByteArray] serialized using [constant VAR_TO_BYTES].
 		</constant>
 		<constant name="MATH_SMOOTHSTEP" value="63" enum="BuiltinFunc">
-			Return a number smoothly interpolated between the first two inputs, based on the third input. Similar to [constant MATH_LERP], but interpolates faster at the beginning and slower at the end. Using Hermite interpolation formula:
+			Returns a number smoothly interpolated between the first two inputs, based on the third input. Similar to [constant MATH_LERP], but interpolates faster at the beginning and slower at the end. Using Hermite interpolation formula:
 			[codeblock]
 			var t = clamp((weight - from) / (to - from), 0.0, 1.0)
 			return t * t * (3.0 - 2.0 * t)

--- a/modules/visual_script/doc_classes/VisualScriptCustomNode.xml
+++ b/modules/visual_script/doc_classes/VisualScriptCustomNode.xml
@@ -12,112 +12,112 @@
 		<method name="_get_caption" qualifiers="virtual const">
 			<return type="String" />
 			<description>
-				Return the node's title.
+				Returns the node's title.
 			</description>
 		</method>
 		<method name="_get_category" qualifiers="virtual const">
 			<return type="String" />
 			<description>
-				Return the node's category.
+				Returns the node's category.
 			</description>
 		</method>
 		<method name="_get_input_value_port_count" qualifiers="virtual const">
 			<return type="int" />
 			<description>
-				Return the count of input value ports.
+				Returns the count of input value ports.
 			</description>
 		</method>
 		<method name="_get_input_value_port_hint" qualifiers="virtual const">
 			<return type="int" />
 			<argument index="0" name="input_idx" type="int" />
 			<description>
-				Return the specified input port's hint. See the [enum @GlobalScope.PropertyHint] hints.
+				Returns the specified input port's hint. See the [enum @GlobalScope.PropertyHint] hints.
 			</description>
 		</method>
 		<method name="_get_input_value_port_hint_string" qualifiers="virtual const">
 			<return type="String" />
 			<argument index="0" name="input_idx" type="int" />
 			<description>
-				Return the specified input port's hint string.
+				Returns the specified input port's hint string.
 			</description>
 		</method>
 		<method name="_get_input_value_port_name" qualifiers="virtual const">
 			<return type="String" />
 			<argument index="0" name="input_idx" type="int" />
 			<description>
-				Return the specified input port's name.
+				Returns the specified input port's name.
 			</description>
 		</method>
 		<method name="_get_input_value_port_type" qualifiers="virtual const">
 			<return type="int" />
 			<argument index="0" name="input_idx" type="int" />
 			<description>
-				Return the specified input port's type. See the [enum Variant.Type] values.
+				Returns the specified input port's type. See the [enum Variant.Type] values.
 			</description>
 		</method>
 		<method name="_get_output_sequence_port_count" qualifiers="virtual const">
 			<return type="int" />
 			<description>
-				Return the amount of output [b]sequence[/b] ports.
+				Returns the amount of output [b]sequence[/b] ports.
 			</description>
 		</method>
 		<method name="_get_output_sequence_port_text" qualifiers="virtual const">
 			<return type="String" />
 			<argument index="0" name="seq_idx" type="int" />
 			<description>
-				Return the specified [b]sequence[/b] output's name.
+				Returns the specified [b]sequence[/b] output's name.
 			</description>
 		</method>
 		<method name="_get_output_value_port_count" qualifiers="virtual const">
 			<return type="int" />
 			<description>
-				Return the amount of output value ports.
+				Returns the amount of output value ports.
 			</description>
 		</method>
 		<method name="_get_output_value_port_hint" qualifiers="virtual const">
 			<return type="int" />
 			<argument index="0" name="output_idx" type="int" />
 			<description>
-				Return the specified output port's hint. See the [enum @GlobalScope.PropertyHint] hints.
+				Returns the specified output port's hint. See the [enum @GlobalScope.PropertyHint] hints.
 			</description>
 		</method>
 		<method name="_get_output_value_port_hint_string" qualifiers="virtual const">
 			<return type="String" />
 			<argument index="0" name="output_idx" type="int" />
 			<description>
-				Return the specified output port's hint string.
+				Returns the specified output port's hint string.
 			</description>
 		</method>
 		<method name="_get_output_value_port_name" qualifiers="virtual const">
 			<return type="String" />
 			<argument index="0" name="output_idx" type="int" />
 			<description>
-				Return the specified output port's name.
+				Returns the specified output port's name.
 			</description>
 		</method>
 		<method name="_get_output_value_port_type" qualifiers="virtual const">
 			<return type="int" />
 			<argument index="0" name="output_idx" type="int" />
 			<description>
-				Return the specified output port's type. See the [enum Variant.Type] values.
+				Returns the specified output port's type. See the [enum Variant.Type] values.
 			</description>
 		</method>
 		<method name="_get_text" qualifiers="virtual const">
 			<return type="String" />
 			<description>
-				Return the custom node's text, which is shown right next to the input [b]sequence[/b] port (if there is none, on the place that is usually taken by it).
+				Returns the custom node's text, which is shown right next to the input [b]sequence[/b] port (if there is none, on the place that is usually taken by it).
 			</description>
 		</method>
 		<method name="_get_working_memory_size" qualifiers="virtual const">
 			<return type="int" />
 			<description>
-				Return the size of the custom node's working memory. See [method _step] for more details.
+				Returns the size of the custom node's working memory. See [method _step] for more details.
 			</description>
 		</method>
 		<method name="_has_input_sequence_port" qualifiers="virtual const">
 			<return type="bool" />
 			<description>
-				Return whether the custom node has an input [b]sequence[/b] port.
+				Returns whether the custom node has an input [b]sequence[/b] port.
 			</description>
 		</method>
 		<method name="_step" qualifiers="virtual const">

--- a/modules/webrtc/doc_classes/WebRTCMultiplayerPeer.xml
+++ b/modules/webrtc/doc_classes/WebRTCMultiplayerPeer.xml
@@ -32,7 +32,7 @@
 			<return type="Dictionary" />
 			<argument index="0" name="peer_id" type="int" />
 			<description>
-				Return a dictionary representation of the peer with given [code]peer_id[/code] with three keys. [code]connection[/code] containing the [WebRTCPeerConnection] to this peer, [code]channels[/code] an array of three [WebRTCDataChannel], and [code]connected[/code] a boolean representing if the peer connection is currently connected (all three channels are open).
+				Returns a dictionary representation of the peer with given [code]peer_id[/code] with three keys. [code]connection[/code] containing the [WebRTCPeerConnection] to this peer, [code]channels[/code] an array of three [WebRTCDataChannel], and [code]connected[/code] a boolean representing if the peer connection is currently connected (all three channels are open).
 			</description>
 		</method>
 		<method name="get_peers">

--- a/modules/websocket/doc_classes/WebSocketClient.xml
+++ b/modules/websocket/doc_classes/WebSocketClient.xml
@@ -39,13 +39,13 @@
 		<method name="get_connected_host" qualifiers="const">
 			<return type="String" />
 			<description>
-				Return the IP address of the currently connected host.
+				Returns the IP address of the currently connected host.
 			</description>
 		</method>
 		<method name="get_connected_port" qualifiers="const">
 			<return type="int" />
 			<description>
-				Return the IP port of the currently connected host.
+				Returns the IP port of the currently connected host.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
The PR changes "Return" to the correct "Returns", which isn't used consistently.