### PR TITLE
Change translation remaps of LocalizationEditor when performing file system actions

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -819,6 +819,12 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 		if (r_translation_remapped) {
 			*r_translation_remapped = true;
 		}
+
+		// Fallback to p_path if new_path does not exist.
+		if (!FileAccess::exists(new_path)) {
+			WARN_PRINT(vformat("Translation remap '%s' does not exist. Falling back to '%s'.", new_path, p_path));
+			new_path = p_path;
+		}
 	}
 
 	if (path_remaps.has(new_path)) {

--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -119,6 +119,7 @@ class DependencyRemoveDialog : public ConfirmationDialog {
 
 	void _find_files_in_removed_folder(EditorFileSystemDirectory *efsd, const String &p_folder);
 	void _find_all_removed_dependencies(EditorFileSystemDirectory *efsd, Vector<RemovedDependency> &p_removed);
+	void _find_localization_remaps_of_removed_files(Vector<RemovedDependency> &p_removed);
 	void _build_removed_dependency_tree(const Vector<RemovedDependency> &p_removed);
 
 	void ok_pressed() override;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6877,6 +6877,7 @@ EditorNode::EditorNode() {
 	filesystem_dock->connect("inherit", callable_mp(this, &EditorNode::_inherit_request));
 	filesystem_dock->connect("instance", callable_mp(this, &EditorNode::_instantiate_request));
 	filesystem_dock->connect("display_mode_changed", callable_mp(this, &EditorNode::_save_docks));
+	project_settings->connect_filesystem_dock_signals(filesystem_dock);
 
 	// Scene: Top left.
 	dock_slot[DOCK_SLOT_LEFT_UR]->add_child(SceneTreeDock::get_singleton());

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6877,7 +6877,7 @@ EditorNode::EditorNode() {
 	filesystem_dock->connect("inherit", callable_mp(this, &EditorNode::_inherit_request));
 	filesystem_dock->connect("instance", callable_mp(this, &EditorNode::_instantiate_request));
 	filesystem_dock->connect("display_mode_changed", callable_mp(this, &EditorNode::_save_docks));
-	project_settings->connect_filesystem_dock_signals(filesystem_dock);
+	get_project_settings()->connect_filesystem_dock_signals(filesystem_dock);
 
 	// Scene: Top left.
 	dock_slot[DOCK_SLOT_LEFT_UR]->add_child(SceneTreeDock::get_singleton());

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -551,6 +551,12 @@ void LocalizationEditor::update_translations() {
 					t2->set_editable(1, true);
 					t2->set_metadata(1, path);
 					t2->set_tooltip(1, locale);
+
+					// Display that it has been removed if this is the case.
+					if (!FileAccess::exists(path)) {
+						t2->set_text(0, t2->get_text(0) + vformat(" (%s)", TTR("Removed")));
+						t2->set_tooltip(0, vformat(TTR("%s cannot be found."), t2->get_tooltip(0)));
+					}
 				}
 			}
 		}

--- a/editor/localization_editor.cpp
+++ b/editor/localization_editor.cpp
@@ -489,6 +489,13 @@ void LocalizationEditor::update_translations() {
 			t->set_tooltip(0, keys[i]);
 			t->set_metadata(0, keys[i]);
 			t->add_button(0, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), 0, false, TTR("Remove"));
+
+			// Display that it has been removed if this is the case.
+			if (!FileAccess::exists(keys[i])) {
+				t->set_text(0, t->get_text(0) + vformat(" (%s)", TTR("Removed")));
+				t->set_tooltip(0, vformat(TTR("%s cannot be found."), t->get_tooltip(0)));
+			}
+
 			if (keys[i] == remap_selected) {
 				t->select(0);
 				translation_res_option_add_button->set_disabled(false);

--- a/editor/localization_editor.h
+++ b/editor/localization_editor.h
@@ -36,6 +36,7 @@
 #include "scene/gui/tree.h"
 
 class EditorFileDialog;
+class FileSystemDock;
 
 class LocalizationEditor : public VBoxContainer {
 	GDCLASS(LocalizationEditor, VBoxContainer);
@@ -81,6 +82,8 @@ class LocalizationEditor : public VBoxContainer {
 	void _pot_generate(const String &p_file);
 	void _update_pot_file_extensions();
 
+	void _filesystem_files_moved(const String &p_old_file, const String &p_new_file);
+
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -88,6 +91,7 @@ protected:
 public:
 	void add_translation(const String &p_translation);
 	void update_translations();
+	void connect_filesystem_dock_signals(FileSystemDock *p_fs_dock);
 
 	LocalizationEditor();
 };

--- a/editor/localization_editor.h
+++ b/editor/localization_editor.h
@@ -83,6 +83,7 @@ class LocalizationEditor : public VBoxContainer {
 	void _update_pot_file_extensions();
 
 	void _filesystem_files_moved(const String &p_old_file, const String &p_new_file);
+	void _filesystem_file_removed(const String &p_file);
 
 protected:
 	void _notification(int p_what);

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -39,6 +39,10 @@
 
 ProjectSettingsEditor *ProjectSettingsEditor::singleton = nullptr;
 
+void ProjectSettingsEditor::connect_filesystem_dock_signals(FileSystemDock *p_fs_dock) {
+	localization_editor->connect_filesystem_dock_signals(p_fs_dock);
+}
+
 void ProjectSettingsEditor::popup_project_settings() {
 	// Restore valid window bounds or pop up at default size.
 	Rect2 saved_size = EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "project_settings", Rect2());

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -43,6 +43,8 @@
 #include "editor/shader_globals_editor.h"
 #include "scene/gui/tab_container.h"
 
+class FileSystemDock;
+
 class ProjectSettingsEditor : public AcceptDialog {
 	GDCLASS(ProjectSettingsEditor, AcceptDialog);
 
@@ -120,6 +122,7 @@ public:
 	TabContainer *get_tabs() { return tab_container; }
 
 	void queue_save();
+	void connect_filesystem_dock_signals(FileSystemDock *p_fs_dock);
 
 	ProjectSettingsEditor(EditorData *p_data);
 };


### PR DESCRIPTION
Fixes #56418

+ [x] React to moving of files
+ [x] React to moving of folders
+ [x] React to removing of files
  + [x] Show warning when removing file of remaps
  + [x] Display removed state in remap tab
  + [x] Fallback to normal resource when remapped one is missing (May not be trivial)
+ [x] React to removing of folders

This PR does the following things

1. `LocalizationEditor` connects to the `files_moved` signal of the `FileSystemDock` and changes the remaps accordingly.
2. `LocalizationEditor` connects to the `file_removed` signal of the `FileSystemDock` and updates the translations if remaps are affected.

![2022-01-04_19-14](https://user-images.githubusercontent.com/25499721/148105113-f20133c2-3166-40e8-aff8-865e402ea25e.png)

3. Shows a dependency warning if someone tries to delete a translation remap.

![2022-01-04_19-13_1](https://user-images.githubusercontent.com/25499721/148105181-63d2f914-fe44-4456-9d0c-934c42d7c016.png)

![2022-01-04_19-13](https://user-images.githubusercontent.com/25499721/148105214-008ae191-d58b-47e0-985e-7c8ace529581.png)

4. Falls back to the normal resource if the translation remap does not exist and shows a warning.