### PR TITLE
Don't replace RootMotionView with Node in a running project

### DIFF
--- a/doc/classes/RootMotionView.xml
+++ b/doc/classes/RootMotionView.xml
@@ -5,25 +5,25 @@
 	</brief_description>
 	<description>
 		[i]Root motion[/i] refers to an animation technique where a mesh's skeleton is used to give impulse to a character. When working with 3D animations, a popular technique is for animators to use the root skeleton bone to give motion to the rest of the skeleton. This allows animating characters in a way where steps actually match the floor below. It also allows precise interaction with objects during cinematics. See also [AnimationTree].
-		[b]Note:[/b] [RootMotionView] is only visible in the editor. It will be hidden automatically in the running project, and will also be converted to a plain [Node] in the running project. This means a script attached to a [RootMotionView] node [i]must[/i] have [code]extends Node[/code] instead of [code]extends RootMotionView[/code]. Additionally, it must not be a [code]@tool[/code] script.
+		[b]Note:[/b] [RootMotionView] is only visible in the editor. It will be hidden automatically in the running project.
 	</description>
 	<tutorials>
 		<link title="Using AnimationTree - Root motion">$DOCS_URL/tutorials/animation/animation_tree.html#root-motion</link>
 	</tutorials>
 	<members>
-		<member name="animation_path" type="NodePath" setter="set_animation_path" getter="get_animation_path">
+		<member name="animation_path" type="NodePath" setter="set_animation_path" getter="get_animation_path" default="NodePath(&quot;&quot;)">
 			Path to an [AnimationTree] node to use as a basis for root motion.
 		</member>
-		<member name="cell_size" type="float" setter="set_cell_size" getter="get_cell_size">
+		<member name="cell_size" type="float" setter="set_cell_size" getter="get_cell_size" default="1.0">
 			The grid's cell size in 3D units.
 		</member>
-		<member name="color" type="Color" setter="set_color" getter="get_color">
+		<member name="color" type="Color" setter="set_color" getter="get_color" default="Color(0.5, 0.5, 1, 1)">
 			The grid's color.
 		</member>
-		<member name="radius" type="float" setter="set_radius" getter="get_radius">
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="10.0">
 			The grid's radius in 3D units. The grid's opacity will fade gradually as the distance from the origin increases until this [member radius] is reached.
 		</member>
-		<member name="zero_y" type="bool" setter="set_zero_y" getter="get_zero_y">
+		<member name="zero_y" type="bool" setter="set_zero_y" getter="get_zero_y" default="true">
 			If [code]true[/code], the grid's points will all be on the same Y coordinate ([i]local[/i] Y = 0). If [code]false[/code], the points' original Y coordinate is preserved.
 		</member>
 	</members>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6157,8 +6157,6 @@ EditorNode::EditorNode() {
 
 	register_exporters();
 
-	ClassDB::set_class_enabled("RootMotionView", true);
-
 	EDITOR_DEF("interface/editor/save_on_focus_loss", false);
 	EDITOR_DEF("interface/editor/show_update_spinner", false);
 	EDITOR_DEF("interface/editor/update_continuously", false);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -523,9 +523,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(GPUParticlesAttractorVectorField3D);
 	GDREGISTER_CLASS(CPUParticles3D);
 	GDREGISTER_CLASS(Position3D);
-
 	GDREGISTER_CLASS(RootMotionView);
-	ClassDB::set_class_enabled("RootMotionView", false); // disabled by default, enabled by editor
 
 	OS::get_singleton()->yield(); // may take time to init
 


### PR DESCRIPTION
This behavior was inconsistent with other editor-only nodes such as Position3D, Position2D and ReferenceRect. It also caused issues when a script extended RootMotionView as it ceased to work when the project was run. This also prevents a warning message from appearing when you run the project.

This technically breaks compatibility with existing projects, so it's probably wiser not to cherry-pick this for `3.x`.

This closes https://github.com/godotengine/godot/issues/58811.

**Testing project:** [test_rootmotionview.zip](https://github.com/godotengine/godot/files/7799890/test_rootmotionview.zip)

## Preview

![2022-01-02_23 39 44](https://user-images.githubusercontent.com/180032/147891324-aa362ef6-3b5c-44b6-bd16-cdf5be4202af.png)