### PR TITLE
[3.x] Add hints and default values to the uniform nodes in visual shader

### DIFF
--- a/doc/classes/VisualShaderNodeBooleanUniform.xml
+++ b/doc/classes/VisualShaderNodeBooleanUniform.xml
@@ -10,6 +10,14 @@
 	</tutorials>
 	<methods>
 	</methods>
+	<members>
+		<member name="default_value" type="bool" setter="set_default_value" getter="get_default_value" default="false">
+			A default value to be assigned within the shader.
+		</member>
+		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">
+			Enables usage of the [member default_value].
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeColorUniform.xml
+++ b/doc/classes/VisualShaderNodeColorUniform.xml
@@ -10,6 +10,14 @@
 	</tutorials>
 	<methods>
 	</methods>
+	<members>
+		<member name="default_value" type="Color" setter="set_default_value" getter="get_default_value" default="Color( 1, 1, 1, 1 )">
+			A default value to be assigned within the shader.
+		</member>
+		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">
+			Enables usage of the [member default_value].
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeScalarUniform.xml
+++ b/doc/classes/VisualShaderNodeScalarUniform.xml
@@ -8,6 +8,38 @@
 	</tutorials>
 	<methods>
 	</methods>
+	<members>
+		<member name="default_value" type="float" setter="set_default_value" getter="get_default_value" default="0.0">
+			A default value to be assigned within the shader.
+		</member>
+		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">
+			Enables usage of the [member default_value].
+		</member>
+		<member name="hint" type="int" setter="set_hint" getter="get_hint" enum="VisualShaderNodeScalarUniform.Hint" default="0">
+			A hint applied to the uniform, which controls the values it can take when set through the inspector.
+		</member>
+		<member name="max" type="float" setter="set_max" getter="get_max" default="1.0">
+			Minimum value for range hints. Used if [member hint] is set to [constant HINT_RANGE] or [constant HINT_RANGE_STEP].
+		</member>
+		<member name="min" type="float" setter="set_min" getter="get_min" default="0.0">
+			Maximum value for range hints. Used if [member hint] is set to [constant HINT_RANGE] or [constant HINT_RANGE_STEP].
+		</member>
+		<member name="step" type="float" setter="set_step" getter="get_step" default="0.1">
+			Step (increment) value for the range hint with step. Used if [member hint] is set to [constant HINT_RANGE_STEP].
+		</member>
+	</members>
 	<constants>
+		<constant name="HINT_NONE" value="0" enum="Hint">
+			No hint used.
+		</constant>
+		<constant name="HINT_RANGE" value="1" enum="Hint">
+			A range hint for scalar value, which limits possible input values between [member min] and [member max]. Translated to [code]hint_range(min, max)[/code] in shader code.
+		</constant>
+		<constant name="HINT_RANGE_STEP" value="2" enum="Hint">
+			A range hint for scalar value with step, which limits possible input values between [member min] and [member max], with a step (increment) of [member step]). Translated to [code]hint_range(min, max, step)[/code] in shader code.
+		</constant>
+		<constant name="HINT_MAX" value="3" enum="Hint">
+			Represents the size of the [enum Hint] enum.
+		</constant>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeTransformUniform.xml
+++ b/doc/classes/VisualShaderNodeTransformUniform.xml
@@ -10,6 +10,14 @@
 	</tutorials>
 	<methods>
 	</methods>
+	<members>
+		<member name="default_value" type="Transform" setter="set_default_value" getter="get_default_value" default="Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0 )">
+			A default value to be assigned within the shader.
+		</member>
+		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">
+			Enables usage of the [member default_value].
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/doc/classes/VisualShaderNodeVec3Uniform.xml
+++ b/doc/classes/VisualShaderNodeVec3Uniform.xml
@@ -10,6 +10,14 @@
 	</tutorials>
 	<methods>
 	</methods>
+	<members>
+		<member name="default_value" type="Vector3" setter="set_default_value" getter="get_default_value" default="Vector3( 0, 0, 0 )">
+			A default value to be assigned within the shader.
+		</member>
+		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">
+			Enables usage of the [member default_value].
+		</member>
+	</members>
 	<constants>
 	</constants>
 </class>

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -589,21 +589,25 @@ void VisualShaderEditor::_update_graph() {
 		}
 
 		Ref<VisualShaderNodeUniform> uniform = vsnode;
+		HBoxContainer *uniform_hbox = nullptr;
+
 		if (uniform.is_valid()) {
 			graph->add_child(node);
 			_update_created_node(node);
 
 			LineEdit *uniform_name = memnew(LineEdit);
+			uniform_name->set_h_size_flags(SIZE_EXPAND_FILL);
 			uniform_name->set_text(uniform->get_uniform_name());
-			node->add_child(uniform_name);
 			uniform_name->connect("text_entered", this, "_line_edit_changed", varray(uniform_name, nodes[n_i]));
 			uniform_name->connect("focus_exited", this, "_line_edit_focus_out", varray(uniform_name, nodes[n_i]));
 
-			if (vsnode->get_input_port_count() == 0 && vsnode->get_output_port_count() == 1 && vsnode->get_output_port_name(0) == "") {
-				//shortcut
-				VisualShaderNode::PortType port_right = vsnode->get_output_port_type(0);
-				node->set_slot(0, false, VisualShaderNode::PORT_TYPE_SCALAR, Color(), true, port_right, type_color[port_right]);
-				continue;
+			if (vsnode->get_output_port_count() == 1 && vsnode->get_output_port_name(0) == "") {
+				uniform_hbox = memnew(HBoxContainer);
+				uniform_hbox->add_constant_override("separation", 7 * EDSCALE);
+				uniform_hbox->add_child(uniform_name);
+				node->add_child(uniform_hbox);
+			} else {
+				node->add_child(uniform_name);
 			}
 			port_offset++;
 		}
@@ -615,12 +619,14 @@ void VisualShaderEditor::_update_graph() {
 			}
 		}
 
-		if (custom_editor && vsnode->get_output_port_count() > 0 && vsnode->get_output_port_name(0) == "" && (vsnode->get_input_port_count() == 0 || vsnode->get_input_port_name(0) == "")) {
-			//will be embedded in first port
-		} else if (custom_editor) {
-			port_offset++;
-			node->add_child(custom_editor);
-			custom_editor = nullptr;
+		if (custom_editor) {
+			if (uniform_hbox == nullptr && vsnode->get_output_port_count() > 0 && vsnode->get_output_port_name(0) == "" && (vsnode->get_input_port_count() == 0 || vsnode->get_input_port_name(0) == "")) {
+				//will be embedded in first port
+			} else {
+				port_offset++;
+				node->add_child(custom_editor);
+				custom_editor = nullptr;
+			}
 		}
 
 		if (is_group) {
@@ -675,8 +681,15 @@ void VisualShaderEditor::_update_graph() {
 				port_right = vsnode->get_output_port_type(i);
 			}
 
-			HBoxContainer *hb = memnew(HBoxContainer);
-			hb->add_constant_override("separation", 7 * EDSCALE);
+			HBoxContainer *hb = nullptr;
+			bool is_uniform_hbox = false;
+			if (i == 0 && uniform_hbox != nullptr) {
+				hb = uniform_hbox;
+				is_uniform_hbox = true;
+			} else {
+				hb = memnew(HBoxContainer);
+				hb->add_constant_override("separation", 7 * EDSCALE);
+			}
 
 			Variant default_value;
 
@@ -756,7 +769,7 @@ void VisualShaderEditor::_update_graph() {
 					}
 				}
 
-				if (!is_group) {
+				if (!is_group && !is_uniform_hbox) {
 					hb->add_spacer();
 				}
 
@@ -786,10 +799,12 @@ void VisualShaderEditor::_update_graph() {
 						type_box->set_custom_minimum_size(Size2(100 * EDSCALE, 0));
 						type_box->connect("item_selected", this, "_change_output_port_type", varray(nodes[n_i], i), CONNECT_DEFERRED);
 					} else {
-						Label *label = memnew(Label);
-						label->set_text(name_right);
-						label->add_style_override("normal", label_style); //more compact
-						hb->add_child(label);
+						if (name_right != "") {
+							Label *label = memnew(Label);
+							label->set_text(name_right);
+							label->add_style_override("normal", label_style); //more compact
+							hb->add_child(label);
+						}
 					}
 				}
 			}
@@ -816,9 +831,12 @@ void VisualShaderEditor::_update_graph() {
 				port_offset++;
 			}
 
-			node->add_child(hb);
-
-			node->set_slot(i + port_offset, valid_left, port_left, type_color[port_left], valid_right, port_right, type_color[port_right]);
+			int idx = 0;
+			if (!is_uniform_hbox) {
+				node->add_child(hb);
+				idx = i + port_offset;
+			}
+			node->set_slot(idx, valid_left, port_left, type_color[port_left], valid_right, port_right, type_color[port_right]);
 		}
 
 		if (vsnode->get_output_port_for_preview() >= 0) {
@@ -3046,9 +3064,9 @@ public:
 			} else {
 				undo_redo->add_undo_method(this, "_open_inspector", (RES)parent_resource.ptr());
 			}
-			undo_redo->add_do_method(this, "_refresh_request");
-			undo_redo->add_undo_method(this, "_refresh_request");
 		}
+		undo_redo->add_do_method(this, "_refresh_request");
+		undo_redo->add_undo_method(this, "_refresh_request");
 		undo_redo->commit_action();
 
 		updating = false;
@@ -3086,7 +3104,18 @@ public:
 		properties = p_properties;
 
 		for (int i = 0; i < p_properties.size(); i++) {
-			add_child(p_properties[i]);
+			HBoxContainer *hbox = memnew(HBoxContainer);
+			hbox->set_h_size_flags(SIZE_EXPAND_FILL);
+			add_child(hbox);
+
+			if (p_node->is_show_prop_names()) {
+				Label *prop_name = memnew(Label);
+				prop_name->set_text(String(p_names[i]).capitalize() + ":");
+				hbox->add_child(prop_name);
+			}
+
+			p_properties[i]->set_h_size_flags(SIZE_EXPAND_FILL);
+			hbox->add_child(p_properties[i]);
 
 			bool res_prop = Object::cast_to<EditorPropertyResource>(p_properties[i]);
 			if (res_prop) {

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -96,6 +96,10 @@ bool VisualShaderNode::is_code_generated() const {
 	return true;
 }
 
+bool VisualShaderNode::is_show_prop_names() const {
+	return false;
+}
+
 Vector<VisualShader::DefaultTextureParam> VisualShaderNode::get_default_texture_parameters(VisualShader::Type p_type, int p_id) const {
 	return Vector<VisualShader::DefaultTextureParam>();
 }
@@ -2332,6 +2336,10 @@ void VisualShaderNodeUniform::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_uniform_name"), &VisualShaderNodeUniform::get_uniform_name);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "uniform_name"), "set_uniform_name", "get_uniform_name");
+}
+
+bool VisualShaderNodeUniform::is_show_prop_names() const {
+	return true;
 }
 
 VisualShaderNodeUniform::VisualShaderNodeUniform() {

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -221,6 +221,7 @@ public:
 	virtual bool is_generate_input_var(int p_port) const;
 
 	virtual bool is_code_generated() const;
+	virtual bool is_show_prop_names() const;
 
 	virtual Vector<StringName> get_editable_properties() const;
 
@@ -387,6 +388,8 @@ protected:
 public:
 	void set_global_code_generated(bool p_enabled);
 	bool is_global_code_generated() const;
+
+	virtual bool is_show_prop_names() const;
 
 	void set_uniform_name(const String &p_name);
 	String get_uniform_name() const;

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -1302,26 +1302,23 @@ class VisualShaderNodeScalarUniform : public VisualShaderNodeUniform {
 	GDCLASS(VisualShaderNodeScalarUniform, VisualShaderNodeUniform);
 
 public:
-	virtual String get_caption() const;
+	enum Hint {
+		HINT_NONE,
+		HINT_RANGE,
+		HINT_RANGE_STEP,
+		HINT_MAX,
+	};
 
-	virtual int get_input_port_count() const;
-	virtual PortType get_input_port_type(int p_port) const;
-	virtual String get_input_port_name(int p_port) const;
+private:
+	Hint hint = HINT_NONE;
+	float hint_range_min;
+	float hint_range_max;
+	float hint_range_step;
+	bool default_value_enabled;
+	float default_value;
 
-	virtual int get_output_port_count() const;
-	virtual PortType get_output_port_type(int p_port) const;
-	virtual String get_output_port_name(int p_port) const;
-
-	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;
-	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
-
-	VisualShaderNodeScalarUniform();
-};
-
-///////////////////////////////////////
-
-class VisualShaderNodeBooleanUniform : public VisualShaderNodeUniform {
-	GDCLASS(VisualShaderNodeBooleanUniform, VisualShaderNodeUniform);
+protected:
+	static void _bind_methods();
 
 public:
 	virtual String get_caption() const;
@@ -1336,6 +1333,65 @@ public:
 
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
+
+	void set_hint(Hint p_hint);
+	Hint get_hint() const;
+
+	void set_min(float p_value);
+	float get_min() const;
+
+	void set_max(float p_value);
+	float get_max() const;
+
+	void set_step(float p_value);
+	float get_step() const;
+
+	void set_default_value_enabled(bool p_enabled);
+	bool is_default_value_enabled() const;
+
+	void set_default_value(float p_value);
+	float get_default_value() const;
+
+	virtual Vector<StringName> get_editable_properties() const;
+
+	VisualShaderNodeScalarUniform();
+};
+
+VARIANT_ENUM_CAST(VisualShaderNodeScalarUniform::Hint)
+
+///////////////////////////////////////
+
+class VisualShaderNodeBooleanUniform : public VisualShaderNodeUniform {
+	GDCLASS(VisualShaderNodeBooleanUniform, VisualShaderNodeUniform);
+
+private:
+	bool default_value_enabled;
+	bool default_value;
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual String get_caption() const;
+
+	virtual int get_input_port_count() const;
+	virtual PortType get_input_port_type(int p_port) const;
+	virtual String get_input_port_name(int p_port) const;
+
+	virtual int get_output_port_count() const;
+	virtual PortType get_output_port_type(int p_port) const;
+	virtual String get_output_port_name(int p_port) const;
+
+	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;
+	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
+
+	void set_default_value_enabled(bool p_enabled);
+	bool is_default_value_enabled() const;
+
+	void set_default_value(bool p_value);
+	bool get_default_value() const;
+
+	virtual Vector<StringName> get_editable_properties() const;
 
 	VisualShaderNodeBooleanUniform();
 };
@@ -1345,6 +1401,13 @@ public:
 class VisualShaderNodeColorUniform : public VisualShaderNodeUniform {
 	GDCLASS(VisualShaderNodeColorUniform, VisualShaderNodeUniform);
 
+private:
+	bool default_value_enabled;
+	Color default_value;
+
+protected:
+	static void _bind_methods();
+
 public:
 	virtual String get_caption() const;
 
@@ -1358,6 +1421,14 @@ public:
 
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
+
+	void set_default_value_enabled(bool p_enabled);
+	bool is_default_value_enabled() const;
+
+	void set_default_value(const Color &p_value);
+	Color get_default_value() const;
+
+	virtual Vector<StringName> get_editable_properties() const;
 
 	VisualShaderNodeColorUniform();
 };
@@ -1367,6 +1438,13 @@ public:
 class VisualShaderNodeVec3Uniform : public VisualShaderNodeUniform {
 	GDCLASS(VisualShaderNodeVec3Uniform, VisualShaderNodeUniform);
 
+private:
+	bool default_value_enabled;
+	Vector3 default_value;
+
+protected:
+	static void _bind_methods();
+
 public:
 	virtual String get_caption() const;
 
@@ -1380,6 +1458,14 @@ public:
 
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
+
+	void set_default_value_enabled(bool p_enabled);
+	bool is_default_value_enabled() const;
+
+	void set_default_value(const Vector3 &p_value);
+	Vector3 get_default_value() const;
+
+	virtual Vector<StringName> get_editable_properties() const;
 
 	VisualShaderNodeVec3Uniform();
 };
@@ -1389,6 +1475,13 @@ public:
 class VisualShaderNodeTransformUniform : public VisualShaderNodeUniform {
 	GDCLASS(VisualShaderNodeTransformUniform, VisualShaderNodeUniform);
 
+private:
+	bool default_value_enabled;
+	Transform default_value;
+
+protected:
+	static void _bind_methods();
+
 public:
 	virtual String get_caption() const;
 
@@ -1402,6 +1495,14 @@ public:
 
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
+
+	void set_default_value_enabled(bool p_enabled);
+	bool is_default_value_enabled() const;
+
+	void set_default_value(const Transform &p_value);
+	Transform get_default_value() const;
+
+	virtual Vector<StringName> get_editable_properties() const;
 
 	VisualShaderNodeTransformUniform();
 };
@@ -1447,6 +1548,7 @@ public:
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const; //if no output is connected, the output var passed will be empty. if no input is connected and input is NIL, the input var passed will be empty
 
 	virtual bool is_code_generated() const;
+	virtual bool is_show_prop_names() const;
 
 	Vector<StringName> get_editable_properties() const;
 


### PR DESCRIPTION
Backports #40754 and #35950 to 3.x
Closes #55571

![image](https://user-images.githubusercontent.com/3036176/147970343-2c130beb-58a1-4db0-b5af-b452a96ae8df.png)
