### PR TITLE
Remove unused `inherits_static` from GDCLASS

### DIFF
--- a/core/object/object.h
+++ b/core/object/object.h
@@ -359,9 +359,6 @@ public:                                                                         
 		}                                                                                                                                        \
 		return category;                                                                                                                         \
 	}                                                                                                                                            \
-	static String inherits_static() {                                                                                                            \
-		return String(#m_inherits);                                                                                                              \
-	}                                                                                                                                            \
 	virtual bool is_class(const String &p_class) const override {                                                                                \
 		if (_get_extension() && _get_extension()->is_class(p_class)) {                                                                           \
 			return true;                                                                                                                         \


### PR DESCRIPTION
Removed `inherits_static` from the `GDCLASS` macro.

- This function is redundant, because `get_parent_class_static` exists already and does the same thing.
- It was stringifying `#m_inherits`, which would return a wrong result if `m_inherits` contains a namespace. `get_parent_class_static` does not have this issue.
- It was not used. I was unable to find any reference to `inherits_static` in the whole codebase.
