### PR TITLE
Fix PopupMenu bad item offset with custom vseparation

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -78,9 +78,7 @@ Size2 PopupMenu::get_minimum_size() const {
 
 		String text = items[i].xl_text;
 		size.width += font->get_string_size(text).width;
-		if (i > 0) {
-			size.height += vseparation;
-		}
+		size.height += vseparation;
 
 		if (items[i].accel || (items[i].shortcut.is_valid() && items[i].shortcut->is_valid())) {
 			int accel_w = hseparation * 2;
@@ -522,7 +520,9 @@ void PopupMenu::_notification(int p_what) {
 			}
 
 			for (int i = 0; i < items.size(); i++) {
-				if (i > 0) {
+				if (i == 0) {
+					ofs.y += vseparation / 2;
+				} else {
 					ofs.y += vseparation;
 				}
 				Point2 item_ofs = ofs;


### PR DESCRIPTION
Fix #56455

### Issue description : 

In 3.x branch, customized values in PopupMenu theme for ``vseparation`` lead to bad item offset.
Master isn't concerned.

### Identified cause : 
Miscalculation concerning ``vseparation`` in PopupMenu height and items offset.

### Before (with vseparation = 100)

![bug](https://user-images.githubusercontent.com/3649998/147981684-3db2fe82-d9d7-4302-89f1-eb2719cf7cf3.gif)

### After (with vseparation = 100)

![fix](https://user-images.githubusercontent.com/3649998/147981709-7c931c07-cd8b-4b9f-be22-1fff308b23ce.gif)


