### PR TITLE
Add bounds to keying Sprite frame

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -623,14 +623,17 @@ void EditorProperty::gui_input(const Ref<InputEvent> &p_event) {
 				if (property == "frame_coords" && (object->is_class("Sprite2D") || object->is_class("Sprite3D"))) {
 					Vector2i new_coords = object->get(property);
 					new_coords.x++;
-					if (new_coords.x >= object->get("hframes").operator int64_t()) {
+					if (new_coords.x >= int64_t(object->get("hframes"))) {
 						new_coords.x = 0;
 						new_coords.y++;
 					}
-
-					call_deferred(SNAME("emit_changed"), property, new_coords, "", false);
+					if (new_coords.x < int64_t(object->get("hframes")) && new_coords.y < int64_t(object->get("vframes"))) {
+						call_deferred(SNAME("emit_changed"), property, new_coords, "", false);
+					}
 				} else {
-					call_deferred(SNAME("emit_changed"), property, object->get(property).operator int64_t() + 1, "", false);
+					if (int64_t(object->get(property)) + 1 < (int64_t(object->get("hframes")) * int64_t(object->get("vframes")))) {
+						call_deferred(SNAME("emit_changed"), property, object->get(property).operator int64_t() + 1, "", false);
+					}
 				}
 
 				call_deferred(SNAME("update_property"));


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Add bounds to Sprite 2/3D next keying for sprite frame.

Checks if the next frame is within the bounds before emitting the incremented value.

Fixes #56412