### PR TITLE
Fix shortcut collapse after edit

### DIFF
--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -327,13 +327,15 @@ void EditorSettingsDialog::_update_shortcuts() {
 
 			// Try go down tree
 			TreeItem *ti_next = ti->get_first_child();
-			// Try go across tree
+			// Try go to the next node via in-order traversal
 			if (!ti_next) {
-				ti_next = ti->get_next();
-			}
-			// Try go up tree, to next node
-			if (!ti_next) {
-				ti_next = ti->get_parent()->get_next();
+				ti_next = ti;
+				while (ti_next && !ti_next->get_next()) {
+					ti_next = ti_next->get_parent();
+				}
+				if (ti_next) {
+					ti_next = ti_next->get_next();
+				}
 			}
 
 			ti = ti_next;


### PR DESCRIPTION
Partial fix for #56407

The shortcut tree is of depth 3, hence if the current node is at depth 3 and the parent node does not have a sibling, the original code does not check for the existence of a sibling of the grandparent.

This fix ensures that the collapse status is properly recorded for all nodes.