### PR TITLE
Add a GDScript template for `VisualShaderNodeCustom`

### DIFF
--- a/doc/classes/VisualShaderNodeCustom.xml
+++ b/doc/classes/VisualShaderNodeCustom.xml
@@ -25,7 +25,7 @@
 		</method>
 		<method name="_get_code" qualifiers="virtual const">
 			<return type="String" />
-			<argument index="0" name="input_vars" type="PackedStringArray" />
+			<argument index="0" name="input_vars" type="String[]" />
 			<argument index="1" name="output_vars" type="String[]" />
 			<argument index="2" name="mode" type="int" enum="Shader.Mode" />
 			<argument index="3" name="type" type="int" enum="VisualShader.Type" />

--- a/modules/gdscript/editor_templates/VisualShaderNodeCustom/basic.gd
+++ b/modules/gdscript/editor_templates/VisualShaderNodeCustom/basic.gd
@@ -1,0 +1,41 @@
+# meta-description: Visual shader's node plugin template
+
+@tool
+extends _BASE_
+class_name VisualShaderNode_CLASS_
+
+func _get_name() -> String:
+	return "_CLASS_"
+
+func _get_category() -> String:
+	return ""
+
+func _get_description() -> String:
+	return ""
+
+func _get_return_icon_type() -> int:
+	return PORT_TYPE_SCALAR
+
+func _get_input_port_count() -> int:
+	return 0
+
+func _get_input_port_name(port: int) -> String:
+	return ""
+
+func _get_input_port_type(port: int) -> int:
+	return PORT_TYPE_SCALAR
+
+func _get_output_port_count() -> int:
+	return 1
+
+func _get_output_port_name(port: int) -> String:
+	return "result"
+
+func _get_output_port_type(port: int) -> int:
+	return PORT_TYPE_SCALAR
+
+func _get_global_code(mode: Shader.Mode) -> String:
+	return ""
+
+func _get_code(input_vars: Array[String], output_vars: Array[String], mode: Shader.Mode, type: VisualShader.Type) -> String:
+	return output_vars[0] + " = 0.0;"

--- a/modules/mono/editor_templates/VisualShaderNodeCustom/basic.cs
+++ b/modules/mono/editor_templates/VisualShaderNodeCustom/basic.cs
@@ -1,0 +1,67 @@
+// meta-description: Visual shader's node plugin template
+
+using _BINDINGS_NAMESPACE_;
+using System;
+
+public partial class VisualShaderNode_CLASS_ : _BASE_
+{
+    public override string _GetName()
+    {
+        return "_CLASS_";
+    }
+
+    public override string _GetCategory()
+    {
+        return "";
+    }
+
+    public override string _GetDescription()
+    {
+        return "";
+    }
+
+    public override int _GetReturnIconType()
+    {
+        return 0;
+    }
+
+    public override int _GetInputPortCount()
+    {
+        return 0;
+    }
+
+    public override string _GetInputPortName(int port)
+    {
+        return "";
+    }
+
+    public override int _GetInputPortType(int port)
+    {
+        return 0;
+    }
+
+    public override int _GetOutputPortCount()
+    {
+        return 1;
+    }
+
+    public override string _GetOutputPortName(int port)
+    {
+        return "result";
+    }
+
+    public override int _GetOutputPortType(int port)
+    {
+        return 0;
+    }
+
+    public override string _GetGlobalCode(Shader.Mode mode)
+    {
+        return "";
+    }
+
+    public override string _GetCode(Godot.Collections.Array inputVars, Godot.Collections.Array outputVars, Shader.Mode mode, VisualShader.Type type)
+    {
+        return "";
+    }
+}

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -349,11 +349,11 @@ String VisualShaderNodeCustom::get_output_port_name(int p_port) const {
 
 String VisualShaderNodeCustom::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	ERR_FAIL_COND_V(!GDVIRTUAL_IS_OVERRIDDEN(_get_code), "");
-	Vector<String> input_vars;
+	TypedArray<String> input_vars;
 	for (int i = 0; i < get_input_port_count(); i++) {
 		input_vars.push_back(p_input_vars[i]);
 	}
-	Array output_vars;
+	TypedArray<String> output_vars;
 	for (int i = 0; i < get_output_port_count(); i++) {
 		output_vars.push_back(p_output_vars[i]);
 	}

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -326,7 +326,7 @@ protected:
 	GDVIRTUAL0RC(int, _get_output_port_count)
 	GDVIRTUAL1RC(int, _get_output_port_type, int)
 	GDVIRTUAL1RC(String, _get_output_port_name, int)
-	GDVIRTUAL4RC(String, _get_code, Vector<String>, TypedArray<String>, Shader::Mode, VisualShader::Type)
+	GDVIRTUAL4RC(String, _get_code, TypedArray<String>, TypedArray<String>, Shader::Mode, VisualShader::Type)
 	GDVIRTUAL1RC(String, _get_global_code, Shader::Mode)
 	GDVIRTUAL0RC(bool, _is_highend)
 


### PR DESCRIPTION
As a continuation of #53957 I think it's not bad to add such a template for the visual shader plugin.
