### PR TITLE
Add annotation to ignore warnings

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -238,10 +238,6 @@ void ScriptTextEditor::_show_warnings_panel(bool p_show) {
 void ScriptTextEditor::_warning_clicked(Variant p_line) {
 	if (p_line.get_type() == Variant::INT) {
 		goto_line_centered(p_line.operator int64_t());
-	} else if (p_line.get_type() == Variant::DICTIONARY) {
-		Dictionary meta = p_line.operator Dictionary();
-		code_editor->get_text_editor()->insert_line_at(meta["line"].operator int64_t() - 1, "# warning-ignore:" + meta["code"].operator String());
-		_validate_script();
 	}
 }
 
@@ -468,20 +464,8 @@ void ScriptTextEditor::_validate_script() {
 	}
 
 	// Add script warnings.
-	warnings_panel->push_table(3);
+	warnings_panel->push_table(2);
 	for (const ScriptLanguage::Warning &w : warnings) {
-		Dictionary ignore_meta;
-		ignore_meta["line"] = w.start_line;
-		ignore_meta["code"] = w.string_code.to_lower();
-		warnings_panel->push_cell();
-		warnings_panel->push_meta(ignore_meta);
-		warnings_panel->push_color(
-				warnings_panel->get_theme_color(SNAME("accent_color"), SNAME("Editor")).lerp(warnings_panel->get_theme_color(SNAME("mono_color"), SNAME("Editor")), 0.5));
-		warnings_panel->add_text(TTR("[Ignore]"));
-		warnings_panel->pop(); // Color.
-		warnings_panel->pop(); // Meta ignore.
-		warnings_panel->pop(); // Cell.
-
 		warnings_panel->push_cell();
 		warnings_panel->push_meta(w.start_line - 1);
 		warnings_panel->push_color(warnings_panel->get_theme_color(SNAME("warning_color"), SNAME("Editor")));

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -669,6 +669,11 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 			ScriptCodeCompletionOption option(E, ScriptCodeCompletionOption::KIND_CLASS);
 			r_result.insert(option.display, option);
 		}
+	} else if (p_annotation->name == "@warning_ignore") {
+		for (int warning_code = 0; warning_code < GDScriptWarning::WARNING_MAX; warning_code++) {
+			ScriptCodeCompletionOption warning(GDScriptWarning::get_name_from_code((GDScriptWarning::Code)warning_code).to_lower(), ScriptCodeCompletionOption::KIND_PLAIN_TEXT);
+			r_result.insert(warning.display, warning);
+		}
 	}
 }
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -297,6 +297,7 @@ public:
 		int leftmost_column = 0, rightmost_column = 0;
 		Node *next = nullptr;
 		List<AnnotationNode *> annotations;
+		Vector<uint32_t> ignored_warnings;
 
 		DataType datatype;
 
@@ -1204,6 +1205,7 @@ private:
 #ifdef DEBUG_ENABLED
 	List<GDScriptWarning> warnings;
 	Set<String> ignored_warnings;
+	Set<uint32_t> ignored_warning_codes;
 	Set<int> unsafe_lines;
 #endif
 

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -213,7 +213,7 @@ GDScriptWarning::Code GDScriptWarning::get_code_from_name(const String &p_name) 
 		}
 	}
 
-	ERR_FAIL_V_MSG(WARNING_MAX, "Invalid GDScript warning name: " + p_name);
+	return WARNING_MAX;
 }
 
 #endif // DEBUG_ENABLED

--- a/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_annotation.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_annotation.gd
@@ -1,0 +1,15 @@
+@warning_ignore(unused_private_class_variable)
+var _unused = 2
+
+@warning_ignore(unused_variable)
+func test():
+	print("test")
+	var unused = 3
+
+	@warning_ignore(redundant_await)
+	print(await regular_func())
+
+	print("done")
+
+func regular_func():
+	return 0

--- a/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_annotation.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/warning_ignore_annotation.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+test
+0
+done


### PR DESCRIPTION
The annotation can be used in any scope of the script. If you add this to a function it applies to the whole function body.

Usage examples:

```
@warning_ignore(unused_private_class_variable)
var _unused = 2
var shadow

@warning_ignore(unused_variable, shadowed_variable)
func test():
	var unused = 1
	var shadow = 0

	@warning_ignore(redundant_await)
	await regular_func()

func regular_func():
	return 0
```

This also removes the link to ignore warnings in the script editor, since now it's a bit more complex to implement. Ideally clicking that would add the warning type to the list if there's already an annotation instead of just adding another annotation. It also needs to respect indentation.
