### PR TITLE
Document caveats of high attenuation in OmniLight3D and SpotLight3D

### DIFF
--- a/doc/classes/OmniLight3D.xml
+++ b/doc/classes/OmniLight3D.xml
@@ -11,7 +11,8 @@
 	</tutorials>
 	<members>
 		<member name="omni_attenuation" type="float" setter="set_param" getter="get_param" default="1.0">
-			The light's attenuation (drop-off) curve. A number of presets are available in the [b]Inspector[/b] by right-clicking the curve.
+			The light's attenuation (drop-off) curve. A number of presets are available in the [b]Inspector[/b] by right-clicking the curve. Zero and negative values are allowed but can produce unusual effects.
+			[b]Note:[/b] Very high [member omni_attenuation] values (typically above 10) can impact performance negatively if the light is made to use a larger [member omni_range] to compensate. This is because culling opportunities will become less common and shading costs will be increased (as the light will cover more pixels on screen while resulting in the same amount of brightness). To improve performance, use the lowest [member omni_attenuation] value possible for the visuals you're trying to achieve.
 		</member>
 		<member name="omni_range" type="float" setter="set_param" getter="get_param" default="5.0">
 			The light's radius. Note that the effectively lit area may appear to be smaller depending on the [member omni_attenuation] in use. No matter the [member omni_attenuation] in use, the light will never reach anything outside this radius.

--- a/doc/classes/SpotLight3D.xml
+++ b/doc/classes/SpotLight3D.xml
@@ -16,10 +16,11 @@
 			The spotlight's angle in degrees.
 		</member>
 		<member name="spot_angle_attenuation" type="float" setter="set_param" getter="get_param" default="1.0">
-			The spotlight's angular attenuation curve.
+			The spotlight's [i]angular[/i] attenuation curve. See also [member spot_attenuation].
 		</member>
 		<member name="spot_attenuation" type="float" setter="set_param" getter="get_param" default="1.0">
-			The spotlight's light energy attenuation curve.
+			The spotlight's light energy (drop-off) attenuation curve. A number of presets are available in the [b]Inspector[/b] by right-clicking the curve. Zero and negative values are allowed but can produce unusual effects. See also [member spot_angle_attenuation].
+			[b]Note:[/b] Very high [member spot_attenuation] values (typically above 10) can impact performance negatively if the light is made to use a larger [member spot_range] to compensate. This is because culling opportunities will become less common and shading costs will be increased (as the light will cover more pixels on screen while resulting in the same amount of brightness). To improve performance, use the lowest [member spot_attenuation] value possible for the visuals you're trying to achieve.
 		</member>
 		<member name="spot_range" type="float" setter="set_param" getter="get_param" default="5.0">
 			The maximal range that can be reached by the spotlight. Note that the effectively lit area may appear to be smaller depending on the [member spot_attenuation] in use. No matter the [member spot_attenuation] in use, the light will never reach anything outside this range.


### PR DESCRIPTION
High attenuation values will negatively impact performance for 2 reasons:

- The light won't be culled as often.
- The light will cover more pixels, which have to be shaded individually.

Therefore, lower attenuation values (with a lower range to compensate) should be preferred whenever possible.

With the `master` branch's physical light attenuation, I've found that there is barely any visual change to going above 10 with the light attenuation, regardless of the light range. However, the amount of "wasted space" proportionally increases a lot when the attenuation is further increased.
Therefore, we may want to consider adding a hard cap (perhaps 15 or 20) so this warning isn't needed.

This can be backported to `3.x` once we agree on the design (minus the hard cap if we go for that route here).

See https://github.com/godotengine/godot/issues/54596.