### PR TITLE
Add shortcut_cell double click functionality

### DIFF
--- a/editor/editor_settings_dialog.h
+++ b/editor/editor_settings_dialog.h
@@ -104,6 +104,7 @@ class EditorSettingsDialog : public AcceptDialog {
 
 	void _update_shortcuts();
 	void _shortcut_button_pressed(Object *p_item, int p_column, int p_idx);
+	void _shortcut_cell_double_clicked();
 
 	void _builtin_action_popup_index_pressed(int p_index);
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2490,7 +2490,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 			/* process selection */
 
 			if (p_double_click && (!c.editable || c.mode == TreeItem::CELL_MODE_CUSTOM || c.mode == TreeItem::CELL_MODE_ICON /*|| c.mode==TreeItem::CELL_MODE_CHECK*/)) { //it's confusing for check
-
+				// Emits the "item_activated" signal.
 				propagate_mouse_activated = true;
 
 				incr_search.clear();


### PR DESCRIPTION
Implementation of enhancement in #56407

![image](https://user-images.githubusercontent.com/16630400/148162884-b35fc5ed-532b-4b8b-b831-3ef2f0fce260.png)

When a shortcut cell is double clicked,

- If the cell has children and in the `bindings` column, check if first child is editable, if so uncollapse the cell and edit the first child if it is the only child.
- If the cell is in the `bindings` column and can be edited, edit it.
- If the cell is in the `name` column, toggle collapse.

*Bugsquad edit:* Fixes #56407.