### PR TITLE
Prevent error emitting when clicking on error in code text editor

### DIFF
--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1548,7 +1548,9 @@ void CodeTextEditor::set_error_pos(int p_line, int p_column) {
 
 void CodeTextEditor::goto_error() {
 	if (!error->get_text().is_empty()) {
-		text_editor->unfold_line(error_line);
+		if (text_editor->get_line_count() != error_line) {
+			text_editor->unfold_line(error_line);
+		}
 		text_editor->set_caret_line(error_line);
 		text_editor->set_caret_column(error_column);
 		text_editor->center_viewport_to_caret();


### PR DESCRIPTION
Fixes error on clicking goto label when the error_line is equal to the line count of CodeEdit:

![error](https://user-images.githubusercontent.com/3036176/148167839-8fc2211d-1254-40ac-a184-217c7b489bcc.gif)

(does not exist on 3.x - should not be cherrypicked)