### PR TITLE
Fix incorrect format and buffer used for bone weights.

### DIFF
--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -281,7 +281,7 @@ RendererCanvasRender::PolygonID RendererCanvasRenderRD::request_polygon(const Ve
 			vd.stride = 0;
 
 			descriptions.write[4] = vd;
-			buffers.write[4] = storage->mesh_get_default_rd_buffer(RendererStorageRD::DEFAULT_RD_BUFFER_BONES);
+			buffers.write[4] = storage->mesh_get_default_rd_buffer(RendererStorageRD::DEFAULT_RD_BUFFER_WEIGHTS);
 		}
 
 		//check that everything is as it should be

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -3878,7 +3878,7 @@ void RendererStorageRD::_mesh_surface_generate_version_for_input_mask(Mesh::Surf
 				} break;
 				case RS::ARRAY_WEIGHTS: {
 					//assumed weights too
-					vd.format = RD::DATA_FORMAT_R32G32B32A32_UINT;
+					vd.format = RD::DATA_FORMAT_R32G32B32A32_SFLOAT;
 				} break;
 			}
 		} else {


### PR DESCRIPTION
Fix incorrectly copy-pasted attribute format and buffer index for bones weights.

Format is set here, and shaders use `vec4` not int:
https://github.com/godotengine/godot/blob/3a5a3473beda4e5f195bdb3e492f90119802385f/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp#L277-L281

Buffer is set here:
https://github.com/godotengine/godot/blob/3a5a3473beda4e5f195bdb3e492f90119802385f/servers/rendering/renderer_rd/renderer_storage_rd.cpp#L9991-L10002

Fixes #53670 and similar issue with the `Polygon2D`.