### PR TITLE
Fix docs links in 3.x after docs reorg

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -295,7 +295,7 @@
 				<br />
 				<button class="btn" onclick="clearPersistence()" style="margin-bottom: 1.5rem">Clear persistent data</button>
 				<br />
-				<a href="https://docs.godotengine.org/en/3.4/getting_started/editor/using_the_web_editor.html">Web editor documentation</a>
+				<a href="https://docs.godotengine.org/en/3.4/tutorials/editor/using_the_web_editor.html">Web editor documentation</a>
 			</div>
 		</div>
 		<div id="tab-editor" style="display: none;">

--- a/modules/gdnative/doc_classes/GDNativeLibrary.xml
+++ b/modules/gdnative/doc_classes/GDNativeLibrary.xml
@@ -7,8 +7,8 @@
 		A GDNative library can implement [NativeScript]s, global functions to call with the [GDNative] class, or low-level engine extensions through interfaces such as [ARVRInterfaceGDNative]. The library must be compiled for each platform and architecture that the project will run on.
 	</description>
 	<tutorials>
-		<link>$DOCS_URL/tutorials/plugins/gdnative/gdnative-c-example.html</link>
-		<link>$DOCS_URL/tutorials/plugins/gdnative/gdnative-cpp-example.html</link>
+		<link>$DOCS_URL/tutorials/scripting/gdnative/gdnative-c-example.html</link>
+		<link>$DOCS_URL/tutorials/scripting/gdnative/gdnative-cpp-example.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_current_dependencies" qualifiers="const">

--- a/modules/gdscript/doc_classes/GDScript.xml
+++ b/modules/gdscript/doc_classes/GDScript.xml
@@ -8,7 +8,7 @@
 		[method new] creates a new instance of the script. [method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
 	</description>
 	<tutorials>
-		<link>$DOCS_URL/getting_started/scripting/gdscript/index.html</link>
+		<link>$DOCS_URL/tutorials/scripting/gdscript/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_as_byte_code" qualifiers="const">

--- a/modules/mono/doc_classes/CSharpScript.xml
+++ b/modules/mono/doc_classes/CSharpScript.xml
@@ -8,7 +8,7 @@
 		See also [GodotSharp].
 	</description>
 	<tutorials>
-		<link>$DOCS_URL/getting_started/scripting/c_sharp/index.html</link>
+		<link>$DOCS_URL/tutorials/scripting/c_sharp/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="new" qualifiers="vararg">

--- a/modules/visual_script/doc_classes/VisualScript.xml
+++ b/modules/visual_script/doc_classes/VisualScript.xml
@@ -9,7 +9,7 @@
 		You are most likely to use this class via the Visual Script editor or when writing plugins for it.
 	</description>
 	<tutorials>
-		<link>$DOCS_URL/getting_started/scripting/visual_script/index.html</link>
+		<link>$DOCS_URL/tutorials/scripting/visual_script/index.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_custom_signal">


### PR DESCRIPTION
This fixes some outdated links after we backported the docs reorg to the 3.4 branch (https://github.com/godotengine/godot-docs/pull/5412) and should fix the docs build for that branch after a sync.

The build broke in  https://github.com/godotengine/godot-docs/commit/0c0e652bd77ed0b90bbdda6ac08228ccd9264e96:
```
...
Warning, treated as error:
/home/runner/work/godot-docs/godot-docs/classes/class_csharpscript.rst:26:unknown document: ../getting_started/scripting/c_sharp/index
Error: Process completed with exit code 2.
```