### PR TITLE
Clear only owners that are no longer in the same tree

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -229,15 +229,32 @@ void Node::_propagate_enter_tree() {
 }
 
 void Node::_propagate_after_exit_tree() {
+	// Clear owner if it was not part of the pruned branch
 	if (data.owner) {
-		data.owner->data.owned.erase(data.OW);
-		data.owner = nullptr;
+		bool found = false;
+		Node *parent = data.parent;
+
+		while (parent) {
+			if (parent == data.owner) {
+				found = true;
+				break;
+			}
+
+			parent = parent->data.parent;
+		}
+
+		if (!found) {
+			data.owner->data.owned.erase(data.OW);
+			data.owner = nullptr;
+		}
 	}
+
 	data.blocked++;
 	for (int i = data.children.size() - 1; i >= 0; i--) {
 		data.children[i]->_propagate_after_exit_tree();
 	}
 	data.blocked--;
+
 	emit_signal(SceneStringNames::get_singleton()->tree_exited);
 }
 


### PR DESCRIPTION
The changes in #55512 were too eager to reset owners to null. This PR restores the part of the removed logic that will reset owners unless they are still reachable in the pruned branch.

As a result, by the tree exited signals some nodes still keep a reference to their owners (similarly to what happened before #55512):
```
exited C [Object:null]
exited B2 B:[Node2D:29276242403]
exited B [Object:null]
exited Node A:[Node2D:29242687975]
exited A [Object:null]
```

Fixes #56515.