### PR TITLE
Explain what 2D cross product means

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -110,7 +110,9 @@
 			<return type="float" />
 			<argument index="0" name="with" type="Vector2" />
 			<description>
-				Returns the cross product of this vector and [code]with[/code].
+				Returns the 2D analog of the cross product for this vector and [code]with[/code].
+				This is the signed area of the parallelogram formed by the two vectors. If the second vector is clockwise from the first vector, then the cross product is the positive area. If counter-clockwise, the cross product is the negative area.
+				[b]Note:[/b] Cross product is not defined in 2D mathematically. This method embeds the 2D vectors in the XY plane of 3D space and uses their cross product's Z component as the analog.
 			</description>
 		</method>
 		<method name="cubic_interpolate" qualifiers="const">


### PR DESCRIPTION
Cross product is not defined in 2D space, so `Vector2.cross()` causes confusions from time to time.