### PR TITLE
Remove `&&` and `||` in favor of `and` and `or` in GDScript

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2339,12 +2339,10 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_binary_operator(Expression
 			operation->variant_op = Variant::OP_BIT_XOR;
 			break;
 		case GDScriptTokenizer::Token::AND:
-		case GDScriptTokenizer::Token::AMPERSAND_AMPERSAND:
 			operation->operation = BinaryOpNode::OP_LOGIC_AND;
 			operation->variant_op = Variant::OP_AND;
 			break;
 		case GDScriptTokenizer::Token::OR:
-		case GDScriptTokenizer::Token::PIPE_PIPE:
 			operation->operation = BinaryOpNode::OP_LOGIC_OR;
 			operation->variant_op = Variant::OP_OR;
 			break;
@@ -3241,8 +3239,6 @@ GDScriptParser::ParseRule *GDScriptParser::get_rule(GDScriptTokenizer::Token::Ty
 		{ nullptr,                                          &GDScriptParser::parse_binary_operator,      	PREC_LOGIC_AND }, // AND,
 		{ nullptr,                                          &GDScriptParser::parse_binary_operator,      	PREC_LOGIC_OR }, // OR,
 		{ &GDScriptParser::parse_unary_operator,         	&GDScriptParser::parse_binary_not_in_operator,	PREC_CONTENT_TEST }, // NOT,
-		{ nullptr,                                          &GDScriptParser::parse_binary_operator,			PREC_LOGIC_AND }, // AMPERSAND_AMPERSAND,
-		{ nullptr,                                          &GDScriptParser::parse_binary_operator,			PREC_LOGIC_OR }, // PIPE_PIPE,
 		{ &GDScriptParser::parse_unary_operator,			nullptr,                                        PREC_NONE }, // BANG,
 		// Bitwise
 		{ nullptr,                                          &GDScriptParser::parse_binary_operator,      	PREC_BIT_AND }, // AMPERSAND,

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -53,8 +53,6 @@ static const char *token_names[] = {
 	"and", // AND,
 	"or", // OR,
 	"not", // NOT,
-	"&&", // AMPERSAND_AMPERSAND,
-	"||", // PIPE_PIPE,
 	"!", // BANG,
 	// Bitwise
 	"&", // AMPERSAND,
@@ -1387,10 +1385,7 @@ GDScriptTokenizer::Token GDScriptTokenizer::scan() {
 				return make_token(Token::CARET);
 			}
 		case '&':
-			if (_peek() == '&') {
-				_advance();
-				return make_token(Token::AMPERSAND_AMPERSAND);
-			} else if (_peek() == '=') {
+			if (_peek() == '=') {
 				_advance();
 				return make_token(Token::AMPERSAND_EQUAL);
 			} else if (_peek() == '"' || _peek() == '\'') {
@@ -1400,10 +1395,7 @@ GDScriptTokenizer::Token GDScriptTokenizer::scan() {
 				return make_token(Token::AMPERSAND);
 			}
 		case '|':
-			if (_peek() == '|') {
-				_advance();
-				return make_token(Token::PIPE_PIPE);
-			} else if (_peek() == '=') {
+			if (_peek() == '=') {
 				_advance();
 				return make_token(Token::PIPE_EQUAL);
 			} else {

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -64,8 +64,6 @@ public:
 			AND,
 			OR,
 			NOT,
-			AMPERSAND_AMPERSAND,
-			PIPE_PIPE,
 			BANG,
 			// Bitwise
 			AMPERSAND,


### PR DESCRIPTION
`&&` and `||` have been supported as alternative syntax for `and` and `or` since the dawn of GDScript. These operators had the same precedence and behaved exactly the same.

However, since there is no practical benefit to using those operators, it's better to stick to a single operator for consistency.

When porting a project from Godot 3.x, this removal can be handled with relative ease by automated script conversion tools (or even good old search-and-replace).

This closes https://github.com/godotengine/godot-proposals/issues/3763.

**Please discuss the feature itself in https://github.com/godotengine/godot-proposals/issues/3763**, and keep the comments here about the *implementation* only.