### PR TITLE
Prevent adding `script` property in `Object` again

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -622,6 +622,16 @@ Variant Object::get_indexed(const Vector<StringName> &p_names, bool *r_valid) co
 	return current_value;
 }
 
+bool has_script_property(const List<PropertyInfo> &p_list) {
+	for (const PropertyInfo &pi : p_list) {
+		if (pi.name == "script") {
+			return true;
+		}
+	}
+
+	return false;
+}
+
 void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) const {
 	if (script_instance && p_reversed) {
 		p_list->push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));
@@ -646,7 +656,7 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 
 	_get_property_listv(p_list, p_reversed);
 
-	if (!is_class("Script")) { // can still be set, but this is for user-friendliness
+	if (!is_class("Script") && !has_script_property(*p_list)) { // Can still be set, but this is for user-friendliness.
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT));
 	}
 	if (!metadata.is_empty()) {

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -48,10 +48,6 @@ class AnimationTrackKeyEdit : public Object {
 public:
 	bool setting = false;
 
-	bool _hide_script_from_inspector() {
-		return true;
-	}
-
 	bool _dont_undo_redo() {
 		return true;
 	}
@@ -59,7 +55,6 @@ public:
 	static void _bind_methods() {
 		ClassDB::bind_method("_update_obj", &AnimationTrackKeyEdit::_update_obj);
 		ClassDB::bind_method("_key_ofs_changed", &AnimationTrackKeyEdit::_key_ofs_changed);
-		ClassDB::bind_method("_hide_script_from_inspector", &AnimationTrackKeyEdit::_hide_script_from_inspector);
 		ClassDB::bind_method("get_root_path", &AnimationTrackKeyEdit::get_root_path);
 		ClassDB::bind_method("_dont_undo_redo", &AnimationTrackKeyEdit::_dont_undo_redo);
 	}
@@ -554,6 +549,9 @@ public:
 			return;
 		}
 
+		// Hide script property.
+		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_NONE));
+
 		ERR_FAIL_INDEX(track, animation->get_track_count());
 		int key = animation->track_find_key(track, key_ofs, true);
 		ERR_FAIL_COND(key == -1);
@@ -704,10 +702,6 @@ class AnimationMultiTrackKeyEdit : public Object {
 public:
 	bool setting = false;
 
-	bool _hide_script_from_inspector() {
-		return true;
-	}
-
 	bool _dont_undo_redo() {
 		return true;
 	}
@@ -715,7 +709,6 @@ public:
 	static void _bind_methods() {
 		ClassDB::bind_method("_update_obj", &AnimationMultiTrackKeyEdit::_update_obj);
 		ClassDB::bind_method("_key_ofs_changed", &AnimationMultiTrackKeyEdit::_key_ofs_changed);
-		ClassDB::bind_method("_hide_script_from_inspector", &AnimationMultiTrackKeyEdit::_hide_script_from_inspector);
 		ClassDB::bind_method("get_root_path", &AnimationMultiTrackKeyEdit::get_root_path);
 		ClassDB::bind_method("_dont_undo_redo", &AnimationMultiTrackKeyEdit::_dont_undo_redo);
 	}
@@ -1194,6 +1187,9 @@ public:
 		if (animation.is_null()) {
 			return;
 		}
+
+		// Hide script property.
+		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_NONE));
 
 		int first_track = -1;
 		float first_key = -1.0;

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -55,13 +55,8 @@ bool EditorDebuggerRemoteObject::_get(const StringName &p_name, Variant &r_ret) 
 }
 
 void EditorDebuggerRemoteObject::_get_property_list(List<PropertyInfo> *p_list) const {
-	p_list->clear(); // Sorry, no want category.
+	p_list->clear(); // Clear list to get rid of categories.
 	for (const PropertyInfo &prop : prop_list) {
-		if (prop.name == "script") {
-			// Skip the script property, it's always added by the non-virtual method.
-			continue;
-		}
-
 		p_list->push_back(prop);
 	}
 }

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2492,7 +2492,7 @@ void EditorInspector::update_tree() {
 			continue;
 		}
 
-		if (p.name == "script" && (hide_script || bool(object->call("_hide_script_from_inspector")))) {
+		if (p.name == "script" && hide_script) {
 			// Hide script variables from inspector if required.
 			continue;
 		}

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -152,7 +152,8 @@ void MultiNodeEdit::_get_property_list(List<PropertyInfo> *p_list) const {
 
 		for (const PropertyInfo &F : plist) {
 			if (F.name == "script") {
-				continue; //added later manually, since this is intercepted before being set (check Variant Object::get() )
+				// Added later manually, since this is intercepted before being set (check Variant Object::get()).
+				continue;
 			}
 			if (!usage.has(F.name)) {
 				PLData pld;
@@ -162,7 +163,7 @@ void MultiNodeEdit::_get_property_list(List<PropertyInfo> *p_list) const {
 				data_list.push_back(usage.getptr(F.name));
 			}
 
-			// Make sure only properties with the same exact PropertyInfo data will appear
+			// Make sure only properties with the same exact PropertyInfo data will appear.
 			if (usage[F.name].info == F) {
 				usage[F.name].uses++;
 			}
@@ -170,6 +171,9 @@ void MultiNodeEdit::_get_property_list(List<PropertyInfo> *p_list) const {
 
 		nc++;
 	}
+
+	// Hide script property in favor of the scripts property.
+	p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_NONE));
 
 	for (const PLData *E : data_list) {
 		if (nc == E->uses) {


### PR DESCRIPTION
Prevents duplicate `script` properties appearing in the inspector:
 - `Object` checks if a `script` property already exists before adding it.
 - Removes `_hide_script_from_inspector()` and instead classes add the `script` property with `PROPERTY_USAGE_NONE` to hide it.

This is option 2 described in https://github.com/godotengine/godot/issues/51077#issuecomment-984028025.
Reverts https://github.com/godotengine/godot/pull/55530 (this was option 1, now no longer needed).
Supersedes https://github.com/godotengine/godot/pull/34474.

Even though option 1 was already merged, I decided to implement option 2 because it might be preferred (context: this comment by @KoBeWi: https://github.com/godotengine/godot/pull/34474#issuecomment-999668525).
