### PR TITLE
Expose RenderingServer SSIL quality setter methods

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1068,7 +1068,7 @@
 			<argument index="8" name="light_affect" type="float" />
 			<argument index="9" name="ao_channel_affect" type="float" />
 			<description>
-				Sets the variables to be used with the "screen space ambient occlusion" post-process effect. See [Environment] for more details.
+				Sets the variables to be used with the screen-space ambient occlusion (SSAO) post-process effect. See [Environment] for more details.
 			</description>
 		</method>
 		<method name="environment_set_ssao_quality">
@@ -1080,6 +1080,19 @@
 			<argument index="4" name="fadeout_from" type="float" />
 			<argument index="5" name="fadeout_to" type="float" />
 			<description>
+				Sets the quality level of the screen-space ambient occlusion (SSAO) post-process effect. See [Environment] for more details.
+			</description>
+		</method>
+		<method name="environment_set_ssil_quality">
+			<return type="void" />
+			<argument index="0" name="quality" type="int" enum="RenderingServer.EnvironmentSSILQuality" />
+			<argument index="1" name="half_size" type="bool" />
+			<argument index="2" name="adaptive_target" type="float" />
+			<argument index="3" name="blur_passes" type="int" />
+			<argument index="4" name="fadeout_from" type="float" />
+			<argument index="5" name="fadeout_to" type="float" />
+			<description>
+				Sets the quality level of the screen-space indirect lighting (SSIL) post-process effect. See [Environment] for more details.
 			</description>
 		</method>
 		<method name="environment_set_ssr">
@@ -4131,19 +4144,34 @@
 		<constant name="ENV_SSR_ROUGNESS_QUALITY_HIGH" value="3" enum="EnvironmentSSRRoughnessQuality">
 		</constant>
 		<constant name="ENV_SSAO_QUALITY_VERY_LOW" value="0" enum="EnvironmentSSAOQuality">
-			Lowest quality of screen space ambient occlusion.
+			Lowest quality of screen-space ambient occlusion.
 		</constant>
 		<constant name="ENV_SSAO_QUALITY_LOW" value="1" enum="EnvironmentSSAOQuality">
-			Low quality screen space ambient occlusion.
+			Low quality screen-space ambient occlusion.
 		</constant>
 		<constant name="ENV_SSAO_QUALITY_MEDIUM" value="2" enum="EnvironmentSSAOQuality">
-			Medium quality screen space ambient occlusion.
+			Medium quality screen-space ambient occlusion.
 		</constant>
 		<constant name="ENV_SSAO_QUALITY_HIGH" value="3" enum="EnvironmentSSAOQuality">
-			High quality screen space ambient occlusion.
+			High quality screen-space ambient occlusion.
 		</constant>
 		<constant name="ENV_SSAO_QUALITY_ULTRA" value="4" enum="EnvironmentSSAOQuality">
-			Highest quality screen space ambient occlusion. Uses the adaptive setting which can be dynamically adjusted to smoothly balance performance and visual quality.
+			Highest quality screen-space ambient occlusion. Uses the adaptive target setting which can be dynamically adjusted to smoothly balance performance and visual quality.
+		</constant>
+		<constant name="ENV_SSIL_QUALITY_VERY_LOW" value="0" enum="EnvironmentSSILQuality">
+			Lowest quality of screen-space indirect lighting.
+		</constant>
+		<constant name="ENV_SSIL_QUALITY_LOW" value="1" enum="EnvironmentSSILQuality">
+			Low quality screen-space indirect lighting.
+		</constant>
+		<constant name="ENV_SSIL_QUALITY_MEDIUM" value="2" enum="EnvironmentSSILQuality">
+			High quality screen-space indirect lighting.
+		</constant>
+		<constant name="ENV_SSIL_QUALITY_HIGH" value="3" enum="EnvironmentSSILQuality">
+			High quality screen-space indirect lighting.
+		</constant>
+		<constant name="ENV_SSIL_QUALITY_ULTRA" value="4" enum="EnvironmentSSILQuality">
+			Highest quality screen-space indirect lighting. Uses the adaptive target setting which can be dynamically adjusted to smoothly balance performance and visual quality.
 		</constant>
 		<constant name="ENV_SDFGI_CASCADES_4" value="0" enum="EnvironmentSDFGICascades">
 		</constant>

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2325,6 +2325,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("environment_glow_set_use_high_quality", "enable"), &RenderingServer::environment_glow_set_use_high_quality);
 	ClassDB::bind_method(D_METHOD("environment_set_ssr_roughness_quality", "quality"), &RenderingServer::environment_set_ssr_roughness_quality);
 	ClassDB::bind_method(D_METHOD("environment_set_ssao_quality", "quality", "half_size", "adaptive_target", "blur_passes", "fadeout_from", "fadeout_to"), &RenderingServer::environment_set_ssao_quality);
+	ClassDB::bind_method(D_METHOD("environment_set_ssil_quality", "quality", "half_size", "adaptive_target", "blur_passes", "fadeout_from", "fadeout_to"), &RenderingServer::environment_set_ssil_quality);
 	ClassDB::bind_method(D_METHOD("environment_set_sdfgi_ray_count", "ray_count"), &RenderingServer::environment_set_sdfgi_ray_count);
 	ClassDB::bind_method(D_METHOD("environment_set_sdfgi_frames_to_converge", "frames"), &RenderingServer::environment_set_sdfgi_frames_to_converge);
 	ClassDB::bind_method(D_METHOD("environment_set_sdfgi_frames_to_update_light", "frames"), &RenderingServer::environment_set_sdfgi_frames_to_update_light);
@@ -2375,6 +2376,12 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(ENV_SSAO_QUALITY_MEDIUM);
 	BIND_ENUM_CONSTANT(ENV_SSAO_QUALITY_HIGH);
 	BIND_ENUM_CONSTANT(ENV_SSAO_QUALITY_ULTRA);
+
+	BIND_ENUM_CONSTANT(ENV_SSIL_QUALITY_VERY_LOW);
+	BIND_ENUM_CONSTANT(ENV_SSIL_QUALITY_LOW);
+	BIND_ENUM_CONSTANT(ENV_SSIL_QUALITY_MEDIUM);
+	BIND_ENUM_CONSTANT(ENV_SSIL_QUALITY_HIGH);
+	BIND_ENUM_CONSTANT(ENV_SSIL_QUALITY_ULTRA);
 
 	BIND_ENUM_CONSTANT(ENV_SDFGI_CASCADES_4);
 	BIND_ENUM_CONSTANT(ENV_SDFGI_CASCADES_6);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1608,6 +1608,7 @@ VARIANT_ENUM_CAST(RenderingServer::EnvironmentGlowBlendMode);
 VARIANT_ENUM_CAST(RenderingServer::EnvironmentToneMapper);
 VARIANT_ENUM_CAST(RenderingServer::EnvironmentSSRRoughnessQuality);
 VARIANT_ENUM_CAST(RenderingServer::EnvironmentSSAOQuality);
+VARIANT_ENUM_CAST(RenderingServer::EnvironmentSSILQuality);
 VARIANT_ENUM_CAST(RenderingServer::EnvironmentSDFGICascades);
 VARIANT_ENUM_CAST(RenderingServer::EnvironmentSDFGIFramesToConverge);
 VARIANT_ENUM_CAST(RenderingServer::EnvironmentSDFGIRayCount);


### PR DESCRIPTION
This allows changing SSIL quality at run-time in a project.

In my [photo mode](https://github.com/Calinou/godot-photo-mode-demo) add-on, I added a way to maximize SSIL quality thanks to the newly exposed setter:[^1]

### Before

![2022-01-06_02 32 28](https://user-images.githubusercontent.com/180032/148314024-bd90f318-46cd-41ec-b3b7-215bfe7fd7fe.png)

### After

![2022-01-06_02 33 15](https://user-images.githubusercontent.com/180032/148314028-bf59fa71-a0db-4d5a-a4f9-4fc5d2a5d2ba.png)

[^1]: The change isn't pushed to that repository yet.