### PR TITLE
Skip formatting `.bat` files in `file_format.sh`

### DIFF
--- a/misc/scripts/file_format.sh
+++ b/misc/scripts/file_format.sh
@@ -20,6 +20,8 @@ while IFS= read -rd '' f; do
         continue
     elif [[ "$f" == *"sln" ]]; then
         continue
+    elif [[ "$f" == *".bat" ]]; then
+        continue
     elif [[ "$f" == *".out" ]]; then
         # GDScript integration testing files.
         continue


### PR DESCRIPTION
These are supposed to have CRLF because Windows, so we'll just skip this file type in the script.

This can be cherry-picked but there are conflicts that need resolving.