### PR TITLE
Implement blender-style 3D transform tools.

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -247,6 +247,7 @@ private:
 	Point2 _point_to_screen(const Vector3 &p_point);
 	Transform3D _get_camera_transform() const;
 	int get_selected_count() const;
+	void cancel_transform();
 
 	Vector3 _get_camera_position() const;
 	Vector3 _get_camera_normal() const;
@@ -314,6 +315,8 @@ private:
 		int gizmo_handle = 0;
 		bool gizmo_handle_secondary = false;
 		Variant gizmo_initial_value;
+		bool original_local;
+		bool instant;
 	} _edit;
 
 	struct Cursor {
@@ -347,7 +350,7 @@ private:
 	real_t zoom_indicator_delay;
 	int zoom_failed_attempts_count = 0;
 
-	RID move_gizmo_instance[3], move_plane_gizmo_instance[3], rotate_gizmo_instance[4], scale_gizmo_instance[3], scale_plane_gizmo_instance[3];
+	RID move_gizmo_instance[3], move_plane_gizmo_instance[3], rotate_gizmo_instance[4], scale_gizmo_instance[3], scale_plane_gizmo_instance[3], axis_gizmo_instance[3];
 
 	String last_message;
 	String message;
@@ -401,6 +404,10 @@ private:
 	void _project_settings_changed();
 
 	Transform3D _compute_transform(TransformMode p_mode, const Transform3D &p_original, const Transform3D &p_original_local, Vector3 p_motion, double p_extra, bool p_local, bool p_orthogonal);
+
+	void begin_transform(TransformMode p_mode, bool instant);
+	void commit_transform();
+	void update_transform(Point2 p_mousepos, bool p_shift);
 
 protected:
 	void _notification(int p_what);
@@ -545,7 +552,7 @@ private:
 	Camera3D::Projection grid_camera_last_update_perspective = Camera3D::PROJECTION_PERSPECTIVE;
 	Vector3 grid_camera_last_update_position = Vector3();
 
-	Ref<ArrayMesh> move_gizmo[3], move_plane_gizmo[3], rotate_gizmo[4], scale_gizmo[3], scale_plane_gizmo[3];
+	Ref<ArrayMesh> move_gizmo[3], move_plane_gizmo[3], rotate_gizmo[4], scale_gizmo[3], scale_plane_gizmo[3], axis_gizmo[3];
 	Ref<StandardMaterial3D> gizmo_color[3];
 	Ref<StandardMaterial3D> plane_gizmo_color[3];
 	Ref<ShaderMaterial> rotate_gizmo_color[3];
@@ -772,12 +779,14 @@ public:
 
 	ToolMode get_tool_mode() const { return tool_mode; }
 	bool are_local_coords_enabled() const { return tool_option_button[Node3DEditor::TOOL_OPT_LOCAL_COORDS]->is_pressed(); }
+	void set_local_coords_enabled(bool on) const { tool_option_button[Node3DEditor::TOOL_OPT_LOCAL_COORDS]->set_pressed(on); }
 	bool is_snap_enabled() const { return snap_enabled ^ snap_key_enabled; }
 	double get_translate_snap() const;
 	double get_rotate_snap() const;
 	double get_scale_snap() const;
 
 	Ref<ArrayMesh> get_move_gizmo(int idx) const { return move_gizmo[idx]; }
+	Ref<ArrayMesh> get_axis_gizmo(int idx) const { return axis_gizmo[idx]; }
 	Ref<ArrayMesh> get_move_plane_gizmo(int idx) const { return move_plane_gizmo[idx]; }
 	Ref<ArrayMesh> get_rotate_gizmo(int idx) const { return rotate_gizmo[idx]; }
 	Ref<ArrayMesh> get_scale_gizmo(int idx) const { return scale_gizmo[idx]; }


### PR DESCRIPTION
Fixes godotengine/godot-proposals#1215.

This adds shortcuts for blender-inspired transforms, where you can press
the key and immediately be transforming an object without holding the
mouse. Clicking commits the transformation, ESC aborts it.

This is inspired by Blender's G(rab)/R(otate)/S(cale) shortcuts, but I
decided not to add default bindings as `S` is already bound to the
regular scale tool, and it might be confusing to only bind some of them.

While actively using a transform tool, you can press X/Y/Z to lock the
transform to an axis or (shift)+X/Y/Z to constrain the transform to a
plane. These keys are only processed if you have a transform tool
(translate/rotate/scale) active _and_ the mouse button is held.

Pressing XX/YY/ZZ will lock the transform to a local (rather than
global) axis.

This is achieved by temporarily toggling the local transform button. I
did this (vs handling it in the transform functions) for 3 reasons:

- Transform logic for translate/rotate (but not scale) appears to be
  tightly coupled to the gizmo
- This ensures the gizmo changes to indicate we're transforming
  locally/globally
- Toggling the button state in the UI also gives the user feedback about
  the nature of the transform.

The original state of the button is reset when the transform completes.

Pressing the `spatial_editor/cancel_transform` shortcut key during a
transform operation will cancel the transform and reset the objects back
to their original transforms.

This functionality was already accessible by pressing RMB during a
transform, however:

- ESC is more familiar to blender users, and a more common "cancel" key
  in general.
- Given you must hold LMB during a transform, pressing RMB as well is
  clumsy if not impossible (on a laptop trackpad).

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

https://user-images.githubusercontent.com/2496231/148322370-cb4d7cf7-f2cd-4597-80c4-36df471f484b.mp4

