### PR TITLE
Revert "Print a warning with unknown SCons variables to ease troubleshooting"

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -300,13 +300,6 @@ opts.Update(env_base)
 env_base["platform"] = selected_platform  # Must always be re-set after calling opts.Update().
 Help(opts.GenerateHelpText(env_base))
 
-# Detect and print a warning listing unknown SCons variables to ease troubleshooting.
-unknown = opts.UnknownVariables()
-if unknown:
-    print("WARNING: Unknown SCons variables were passed and will be ignored:")
-    for item in unknown.items():
-        print("    " + item[0] + "=" + item[1])
-
 # add default include paths
 
 env_base.Prepend(CPPPATH=["#"])


### PR DESCRIPTION
Reverts #55203.
The feature is good but there are false positives, so it needs more work to be really useful.

See also #53030 which was another attempt at doing this, apparently without the false positive, but with significantly more changes.

Fixes #56359.
Fixes #56372.
Supersedes and closes #55698.