### PR TITLE
Unify similar method descriptions

### DIFF
--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -363,7 +363,7 @@
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the size of the array.
+				Returns the number of elements in the array.
 			</description>
 		</method>
 		<method name="slice" qualifiers="const">

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -126,7 +126,7 @@
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the size of the array.
+				Returns the number of elements in the array.
 			</description>
 		</method>
 		<method name="slice" qualifiers="const">

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -127,7 +127,7 @@
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the size of the array.
+				Returns the number of elements in the array.
 			</description>
 		</method>
 		<method name="slice" qualifiers="const">

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -127,7 +127,7 @@
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the size of the array.
+				Returns the number of elements in the array.
 			</description>
 		</method>
 		<method name="slice" qualifiers="const">

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -127,7 +127,7 @@
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the array size.
+				Returns the number of elements in the array.
 			</description>
 		</method>
 		<method name="slice" qualifiers="const">

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -127,7 +127,7 @@
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the array size.
+				Returns the number of elements in the array.
 			</description>
 		</method>
 		<method name="slice" qualifiers="const">

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -127,7 +127,7 @@
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the size of the array.
+				Returns the number of elements in the array.
 			</description>
 		</method>
 		<method name="slice" qualifiers="const">

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -127,7 +127,7 @@
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the size of the array.
+				Returns the number of elements in the array.
 			</description>
 		</method>
 		<method name="slice" qualifiers="const">

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -126,7 +126,7 @@
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the size of the array.
+				Returns the number of elements in the array.
 			</description>
 		</method>
 		<method name="slice" qualifiers="const">

--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -38,8 +38,7 @@
 		<method name="force_raycast_update">
 			<return type="void" />
 			<description>
-				Updates the collision information for the ray.
-				Use this method to update the collision information immediately instead of waiting for the next [code]_physics_process[/code] call, for example if the ray or its parent has changed state.
+				Updates the collision information for the ray. Use this method to update the collision information immediately instead of waiting for the next [code]_physics_process[/code] call, for example if the ray or its parent has changed state.
 				[b]Note:[/b] [member enabled] does not need to be [code]true[/code] for this to work.
 			</description>
 		</method>

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -60,13 +60,13 @@
 			<argument index="0" name="xform" type="Transform3D" />
 			<argument index="1" name="weight" type="float" />
 			<description>
-				Interpolates the transform to other Transform3D by weight amount (on the range of 0.0 to 1.0).
+				Returns a transform interpolated between this transform and another by a given [code]weight[/code] (on the range of 0.0 to 1.0).
 			</description>
 		</method>
 		<method name="inverse" qualifiers="const">
 			<return type="Transform3D" />
 			<description>
-				Returns the inverse of the transform, under the assumption that the transformation is composed of rotation and translation (no scaling, use affine_inverse for transforms with scaling).
+				Returns the inverse of the transform, under the assumption that the transformation is composed of rotation and translation (no scaling, use [method affine_inverse] for transforms with scaling).
 			</description>
 		</method>
 		<method name="is_equal_approx" qualifiers="const">
@@ -88,7 +88,7 @@
 		<method name="orthonormalized" qualifiers="const">
 			<return type="Transform3D" />
 			<description>
-				Returns the transform with the basis orthogonal (90 degrees), and normalized axis vectors.
+				Returns the transform with the basis orthogonal (90 degrees), and normalized axis vectors (scale of 1 or -1).
 			</description>
 		</method>
 		<method name="rotated" qualifiers="const">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -95,7 +95,7 @@
 		<method name="ceil" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the vector with all components rounded up (towards positive infinity).
+				Returns a new vector with all components rounded up (towards positive infinity).
 			</description>
 		</method>
 		<method name="clamp" qualifiers="const">
@@ -158,7 +158,7 @@
 		<method name="floor" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the vector with all components rounded down (towards negative infinity).
+				Returns a new vector with all components rounded down (towards negative infinity).
 			</description>
 		</method>
 		<method name="from_angle" qualifiers="static">
@@ -231,7 +231,7 @@
 			<argument index="0" name="to" type="Vector2" />
 			<argument index="1" name="delta" type="float" />
 			<description>
-				Moves the vector toward [code]to[/code] by the fixed [code]delta[/code] amount. Will not go past the final value.
+				Returns a new vector moved toward [code]to[/code] by the fixed [code]delta[/code] amount. Will not go past the final value.
 			</description>
 		</method>
 		<method name="normalized" qualifiers="const">
@@ -264,7 +264,7 @@
 			<return type="Vector2" />
 			<argument index="0" name="b" type="Vector2" />
 			<description>
-				Returns the vector projected onto the vector [code]b[/code].
+				Returns this vector projected onto the vector [code]b[/code].
 			</description>
 		</method>
 		<method name="reflect" qualifiers="const">
@@ -284,13 +284,13 @@
 		<method name="round" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the vector with all components rounded to the nearest integer, with halfway cases rounded away from zero.
+				Returns a new vector with all components rounded to the nearest integer, with halfway cases rounded away from zero.
 			</description>
 		</method>
 		<method name="sign" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the vector with each component set to one or negative one, depending on the signs of the components, or zero if the component is zero, by calling [method @GlobalScope.sign] on each component.
+				Returns a new vector with each component set to one or negative one, depending on the signs of the components, or zero if the component is zero, by calling [method @GlobalScope.sign] on each component.
 			</description>
 		</method>
 		<method name="slerp" qualifiers="const">

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -53,7 +53,7 @@
 		<method name="aspect" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the ratio of [member x] to [member y].
+				Returns the aspect ratio of this vector, the ratio of [member x] to [member y].
 			</description>
 		</method>
 		<method name="clamp" qualifiers="const">
@@ -79,7 +79,7 @@
 		<method name="sign" qualifiers="const">
 			<return type="Vector2i" />
 			<description>
-				Returns the vector with each component set to one or negative one, depending on the signs of the components.
+				Returns a new vector with each component set to one or negative one, depending on the signs of the components, or zero if the component is zero, by calling [method @GlobalScope.sign] on each component.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -96,7 +96,7 @@
 			<argument index="2" name="post_b" type="Vector3" />
 			<argument index="3" name="weight" type="float" />
 			<description>
-				Performs a cubic interpolation between vectors [code]pre_a[/code], [code]a[/code], [code]b[/code], [code]post_b[/code] ([code]a[/code] is current), by the given amount [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
+				Performs a cubic interpolation between this vector and [code]b[/code] using [code]pre_a[/code] and [code]post_b[/code] as handles, and returns the result at position [code]weight[/code]. [code]weight[/code] is on the range of 0.0 to 1.0, representing the amount of interpolation.
 			</description>
 		</method>
 		<method name="direction_to" qualifiers="const">
@@ -201,7 +201,7 @@
 			<argument index="0" name="to" type="Vector3" />
 			<argument index="1" name="delta" type="float" />
 			<description>
-				Moves this vector toward [code]to[/code] by the fixed [code]delta[/code] amount. Will not go past the final value.
+				Returns a new vector moved toward [code]to[/code] by the fixed [code]delta[/code] amount. Will not go past the final value.
 			</description>
 		</method>
 		<method name="normalized" qualifiers="const">
@@ -246,7 +246,7 @@
 			<return type="Vector3" />
 			<argument index="0" name="b" type="Vector3" />
 			<description>
-				Returns this vector projected onto another vector [code]b[/code].
+				Returns this vector projected onto the vector [code]b[/code].
 			</description>
 		</method>
 		<method name="reflect" qualifiers="const">
@@ -267,13 +267,13 @@
 		<method name="round" qualifiers="const">
 			<return type="Vector3" />
 			<description>
-				Returns this vector with all components rounded to the nearest integer, with halfway cases rounded away from zero.
+				Returns a new vector with all components rounded to the nearest integer, with halfway cases rounded away from zero.
 			</description>
 		</method>
 		<method name="sign" qualifiers="const">
 			<return type="Vector3" />
 			<description>
-				Returns a vector with each component set to one or negative one, depending on the signs of this vector's components, or zero if the component is zero, by calling [method @GlobalScope.sign] on each component.
+				Returns a new vector with each component set to one or negative one, depending on the signs of the components, or zero if the component is zero, by calling [method @GlobalScope.sign] on each component.
 			</description>
 		</method>
 		<method name="signed_angle_to" qualifiers="const">


### PR DESCRIPTION
Notably:

* `Packed*Array.size()` and `Array.size()`.
* Shared methods of `Transform2D` and `Transform3D`.
* Shared methods of `Vector2`, `Vector3`, and `Vector2i`.

This reduces the Deja Vu when translating the class reference :)

p.s. Also changed both `Vector{2,3}.move_toward()` from `Moves the vector toward...` to `Returns a new vector moved toward...` as the method does not change the original vector.