### PR TITLE
[3.x] fix incorrect include in Viewport

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -35,7 +35,7 @@
 #include "core/os/os.h"
 #include "core/project_settings.h"
 #include "scene/2d/collision_object_2d.h"
-#include "scene/2d/listener_2d.cpp"
+#include "scene/2d/listener_2d.h"
 #include "scene/3d/camera.h"
 #include "scene/3d/collision_object.h"
 #include "scene/3d/listener.h"


### PR DESCRIPTION
Had included the .cpp instead of .h by mistake, leading to a linker warning.