### PR TITLE
CI: Update SwiftShader to 2021-10-02 build

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -127,8 +127,8 @@ jobs:
       - name: Download SwiftShader
         if: ${{ matrix.tests }}
         run: |
-          wget https://github.com/godotengine/regression-test-project/releases/download/_ci-deps/swiftshader-ubuntu20.04-20210728.zip
-          unzip swiftshader-ubuntu20.04-20210728.zip
+          wget https://github.com/godotengine/regression-test-project/releases/download/_ci-deps/swiftshader-ubuntu20.04-20211002.zip
+          unzip swiftshader-ubuntu20.04-20211002.zip
           curr="$(pwd)/libvk_swiftshader.so"
           sed -i "s|PATH_TO_CHANGE|$curr|" vk_swiftshader_icd.json
 


### PR DESCRIPTION
No specific reason that I know of aside from it being available in our
prebuilt CI dependencies.

Only affects the Linux editor + sanitizers build, if it passes it's fine.