### PR TITLE
[3.x] Fix the importer dock being blank when selecting multiple files

### DIFF
--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -279,6 +279,8 @@ void ImportDock::set_edit_multiple_paths(const Vector<String> &p_paths) {
 	_set_dirty(false);
 	import_as->set_disabled(false);
 	preset->set_disabled(false);
+	content->show();
+	select_a_resource->hide();
 
 	imported->set_text(vformat(TTR("%d Files"), p_paths.size()));
 }


### PR DESCRIPTION
Broken in 0adc1ebf41a65b6049b5bb9fb96b9b26da71ff40

If multiple files were selected, the import dock just said "Select a resource file in the filesystem or in the inspector to adjust import settings."