### PR TITLE
Fix queueing a texture and regular uniform update in RD backend

### DIFF
--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -1639,14 +1639,14 @@ void RendererStorageRD::material_initialize(RID p_rid) {
 }
 
 void RendererStorageRD::_material_queue_update(Material *material, bool p_uniform, bool p_texture) {
+	material->uniform_dirty = material->uniform_dirty || p_uniform;
+	material->texture_dirty = material->texture_dirty || p_texture;
+
 	if (material->update_element.in_list()) {
 		return;
 	}
 
 	material_update_list.add(&material->update_element);
-
-	material->uniform_dirty = material->uniform_dirty || p_uniform;
-	material->texture_dirty = material->texture_dirty || p_texture;
 }
 
 void RendererStorageRD::material_set_shader(RID p_material, RID p_shader) {


### PR DESCRIPTION
Fixes bug in the RD renderer where if a texture update has been queued, and then a generic uniform update is also requested, this update would be lost due to the texture update still being queued. This should be fixed by simply allowing you to always update the material dirty flags before checking if a material is queued rather than after. This bugfix is nessecary for this PR to work (#56145) since it can trigger this behaviour. It likely fixes other similar bugs too.