### PR TITLE
Rename GraphEdit `connection_drag_begun` to `connection_drag_started`

### DIFF
--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -113,7 +113,7 @@
 			<return type="void" />
 			<description>
 				Ends the creation of the current connection. In other words, if you are dragging a connection you can use this method to abort the process and remove the line that followed your cursor.
-				This is best used together with [signal connection_drag_begun] and [signal connection_drag_ended] to add custom behavior like node addition through shortcuts.
+				This is best used together with [signal connection_drag_started] and [signal connection_drag_ended] to add custom behavior like node addition through shortcuts.
 				[b]Note:[/b] This method suppresses any other connection request signals apart from [signal connection_drag_ended].
 			</description>
 		</method>
@@ -249,17 +249,17 @@
 				Emitted at the beginning of a GraphNode movement.
 			</description>
 		</signal>
-		<signal name="connection_drag_begun">
+		<signal name="connection_drag_ended">
+			<description>
+				Emitted at the end of a connection drag.
+			</description>
+		</signal>
+		<signal name="connection_drag_started">
 			<argument index="0" name="from" type="String" />
 			<argument index="1" name="slot" type="String" />
 			<argument index="2" name="is_output" type="bool" />
 			<description>
 				Emitted at the beginning of a connection drag.
-			</description>
-		</signal>
-		<signal name="connection_drag_ended">
-			<description>
-				Emitted at the end of a connection drag.
 			</description>
 		</signal>
 		<signal name="connection_from_empty">

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -600,7 +600,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 									to = get_node(String(connecting_from)); //maybe it was erased
 									if (Object::cast_to<GraphNode>(to)) {
 										connecting = true;
-										emit_signal(SNAME("connection_drag_begun"), connecting_from, connecting_index, false);
+										emit_signal(SNAME("connection_drag_started"), connecting_from, connecting_index, false);
 									}
 									return;
 								}
@@ -617,7 +617,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 					connecting_target = false;
 					connecting_to = pos;
 					just_disconnected = false;
-					emit_signal(SNAME("connection_drag_begun"), connecting_from, connecting_index, true);
+					emit_signal(SNAME("connection_drag_started"), connecting_from, connecting_index, true);
 					return;
 				}
 			}
@@ -644,7 +644,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 									fr = get_node(String(connecting_from)); //maybe it was erased
 									if (Object::cast_to<GraphNode>(fr)) {
 										connecting = true;
-										emit_signal(SNAME("connection_drag_begun"), connecting_from, connecting_index, true);
+										emit_signal(SNAME("connection_drag_started"), connecting_from, connecting_index, true);
 									}
 									return;
 								}
@@ -661,7 +661,7 @@ void GraphEdit::_top_layer_input(const Ref<InputEvent> &p_ev) {
 					connecting_target = false;
 					connecting_to = pos;
 					just_disconnected = false;
-					emit_signal(SNAME("connection_drag_begun"), connecting_from, connecting_index, false);
+					emit_signal(SNAME("connection_drag_started"), connecting_from, connecting_index, false);
 					return;
 				}
 			}
@@ -2273,7 +2273,7 @@ void GraphEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("begin_node_move"));
 	ADD_SIGNAL(MethodInfo("end_node_move"));
 	ADD_SIGNAL(MethodInfo("scroll_offset_changed", PropertyInfo(Variant::VECTOR2, "ofs")));
-	ADD_SIGNAL(MethodInfo("connection_drag_begun", PropertyInfo(Variant::STRING, "from"), PropertyInfo(Variant::STRING, "slot"), PropertyInfo(Variant::BOOL, "is_output")));
+	ADD_SIGNAL(MethodInfo("connection_drag_started", PropertyInfo(Variant::STRING, "from"), PropertyInfo(Variant::STRING, "slot"), PropertyInfo(Variant::BOOL, "is_output")));
 	ADD_SIGNAL(MethodInfo("connection_drag_ended"));
 }
 


### PR DESCRIPTION
Fixup to #50896 renaming `connection_drag_begun` to `connection_drag_started`