### PR TITLE
Fix some more wrong node names

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -726,7 +726,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 				dup->set_name(parent->validate_child_name(dup));
 
-				editor_data->get_undo_redo().add_do_method(add_below_node, "add_sibling", dup);
+				editor_data->get_undo_redo().add_do_method(add_below_node, "add_sibling", dup, true);
 
 				for (Node *F : owned) {
 					if (!duplimap.has(F)) {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6851,7 +6851,7 @@ Node *GLTFDocument::generate_scene(Ref<GLTFState> state, int32_t p_bake_fps) {
 	_process_mesh_instances(state, root);
 	if (state->animations.size()) {
 		AnimationPlayer *ap = memnew(AnimationPlayer);
-		root->add_child(ap);
+		root->add_child(ap, true);
 		ap->set_owner(root);
 		for (int i = 0; i < state->animations.size(); i++) {
 			_import_animation(state, ap, i, p_bake_fps);


### PR DESCRIPTION
I just discovered that when you duplicate nodes, you get garbage on conflicting names (happens mostly when there is multiple of them), so I fixed that.
Also fixed #56545 while I'm at it, but I don't have GLTF file to test if it works.