### PR TITLE
Document how to erase project settings with set_setting

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -188,6 +188,7 @@
 				ProjectSettings.SetSetting("application/config/name", "Example");
 				[/csharp]
 				[/codeblocks]
+				This can also be used to erase custom project settings. To do this change the setting value to [code]null[/code].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
``set_setting`` can be used to erase custom project settings by changing the value of a setting to null. Closes https://github.com/godotengine/godot-docs/issues/5497.