### PR TITLE
Add BBCode escape sequences for left/right brackets

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3064,6 +3064,12 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 			push_strikethrough();
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
+		} else if (tag == "lb") {
+			add_text("[");
+			pos = brk_end + 1;
+		} else if (tag == "rb") {
+			add_text("]");
+			pos = brk_end + 1;
 		} else if (tag == "lrm") {
 			add_text(String::chr(0x200E));
 			pos = brk_end + 1;


### PR DESCRIPTION
This PR adds `[lb]` and `[rb]` BBCodes, which are displayed as `[` and `]` respectively. This solution is consistent with the existing ones `[lrm]`, `[rlm]`, etc. BBCodes for Unicode control characters.

<table>
<tr>
<td><code>[b]text[/b]</code></td>
<td><b>text</b></td>
</tr>
<tr>
<td><code>[lb]b[rb]text[lb]/b[rb]</code></td>
<td>[b]text[/b]</td>
</tr>
</table>

Resolves #56556.