### PR TITLE
Fix instantiate custom class

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -134,7 +134,12 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 					result.native_type = script->get_instance_base_type();
 				} else {
 					result.kind = GDScriptDataType::GDSCRIPT;
-					result.script_type_ref = GDScriptCache::get_shallow_script(p_datatype.script_path, main_script->path);
+					Error err = OK;
+					result.script_type_ref = GDScriptCache::get_full_script(p_datatype.script_path, err, main_script->path);
+					if (err != OK) {
+						ERR_PRINT("Parser bug: cannot get data type script.");
+						return GDScriptDataType();
+					}
 					result.script_type = result.script_type_ref.ptr();
 					result.native_type = p_datatype.native_type;
 				}


### PR DESCRIPTION
Fix #51538

When the GDScript compiler checks if the class contains the "new" method, it retrieve the class from the resource loader, but the latter contains a shallow script not yet parsed (loaded previously using get_shallow_script), hence making the "new" method not found.

This PR makes sure the script is parsed, however it is using a cast, which might not be correct.
Might need a check and advise from @vnen.