### PR TITLE
[Editor] Fix inspector keying signals argument count.

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -33,6 +33,8 @@
 		</signal>
 		<signal name="property_keyed">
 			<argument index="0" name="property" type="String" />
+			<argument index="1" name="value" type="Variant" />
+			<argument index="2" name="advance" type="bool" />
 			<description>
 				Emitted when a property is keyed in the inspector. Properties can be keyed by clicking the "key" icon next to a property when the Animation panel is toggled.
 			</description>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3205,7 +3205,10 @@ void EditorInspector::_property_keyed(const String &p_path, bool p_advance) {
 		return;
 	}
 
-	emit_signal(SNAME("property_keyed"), p_path, object->get(p_path), p_advance); //second param is deprecated
+	// The second parameter could be null, causing the event to fire with less arguments, so use the pointer call which preserves it.
+	const Variant args[3] = { p_path, object->get(p_path), p_advance };
+	const Variant *argp[3] = { &args[0], &args[1], &args[2] };
+	emit_signal(SNAME("property_keyed"), argp, 3);
 }
 
 void EditorInspector::_property_deleted(const String &p_path) {
@@ -3213,7 +3216,7 @@ void EditorInspector::_property_deleted(const String &p_path) {
 		return;
 	}
 
-	emit_signal(SNAME("property_deleted"), p_path); //second param is deprecated
+	emit_signal(SNAME("property_deleted"), p_path);
 }
 
 void EditorInspector::_property_keyed_with_value(const String &p_path, const Variant &p_value, bool p_advance) {
@@ -3221,7 +3224,10 @@ void EditorInspector::_property_keyed_with_value(const String &p_path, const Var
 		return;
 	}
 
-	emit_signal(SNAME("property_keyed"), p_path, p_value, p_advance); //second param is deprecated
+	// The second parameter could be null, causing the event to fire with less arguments, so use the pointer call which preserves it.
+	const Variant args[3] = { p_path, p_value, p_advance };
+	const Variant *argp[3] = { &args[0], &args[1], &args[2] };
+	emit_signal(SNAME("property_keyed"), argp, 3);
 }
 
 void EditorInspector::_property_checked(const String &p_path, bool p_checked) {
@@ -3531,7 +3537,7 @@ void EditorInspector::_bind_methods() {
 	ClassDB::bind_method("_edit_request_change", &EditorInspector::_edit_request_change);
 
 	ADD_SIGNAL(MethodInfo("property_selected", PropertyInfo(Variant::STRING, "property")));
-	ADD_SIGNAL(MethodInfo("property_keyed", PropertyInfo(Variant::STRING, "property")));
+	ADD_SIGNAL(MethodInfo("property_keyed", PropertyInfo(Variant::STRING, "property"), PropertyInfo(Variant::NIL, "value", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NIL_IS_VARIANT), PropertyInfo(Variant::BOOL, "advance")));
 	ADD_SIGNAL(MethodInfo("property_deleted", PropertyInfo(Variant::STRING, "property")));
 	ADD_SIGNAL(MethodInfo("resource_selected", PropertyInfo(Variant::OBJECT, "res"), PropertyInfo(Variant::STRING, "prop")));
 	ADD_SIGNAL(MethodInfo("object_id_selected", PropertyInfo(Variant::INT, "id")));

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2909,8 +2909,11 @@ void EditorPropertyResource::_resource_changed(const RES &p_resource) {
 	}
 }
 
-void EditorPropertyResource::_sub_inspector_property_keyed(const String &p_property, const Variant &p_value, bool) {
-	emit_signal(SNAME("property_keyed_with_value"), String(get_edited_property()) + ":" + p_property, p_value, false);
+void EditorPropertyResource::_sub_inspector_property_keyed(const String &p_property, const Variant &p_value, bool p_advance) {
+	// The second parameter could be null, causing the event to fire with less arguments, so use the pointer call which preserves it.
+	const Variant args[3] = { String(get_edited_property()) + ":" + p_property, p_value, p_advance };
+	const Variant *argp[3] = { &args[0], &args[1], &args[2] };
+	emit_signal(SNAME("property_keyed_with_value"), argp, 3);
 }
 
 void EditorPropertyResource::_sub_inspector_resource_selected(const RES &p_resource, const String &p_property) {

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -666,7 +666,7 @@ class EditorPropertyResource : public EditorProperty {
 
 	void _viewport_selected(const NodePath &p_path);
 
-	void _sub_inspector_property_keyed(const String &p_property, const Variant &p_value, bool);
+	void _sub_inspector_property_keyed(const String &p_property, const Variant &p_value, bool p_advance);
 	void _sub_inspector_resource_selected(const RES &p_resource, const String &p_property);
 	void _sub_inspector_object_id_selected(int p_id);
 


### PR DESCRIPTION
The second parameter of the signals `EditorInspector.property_keyed` and `EditorProperty.property_keyed_with_value` can be NIL, causing the event to fire with less arguments when using `emit_signal` that accepts Variant arguments, so we use the pointer version instead.