### PR TITLE
Use inspector warning colour on properties in inherited scenes.

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2339,9 +2339,10 @@ void EditorInspector::update_tree() {
 	if (is_inside_tree()) {
 		Node *nod = Object::cast_to<Node>(object);
 		Node *es = EditorNode::get_singleton()->get_edited_scene();
-		if (nod && es != nod && nod->get_owner() != es) {
+		if (nod && ((es != nod && nod->get_owner() != es) || (es->get_scene_inherited_state().is_valid() && es->get_scene_inherited_state()->find_node_by_path(es->get_path_to(nod)) >= 0))) {
 			// Draw in warning color edited nodes that are not in the currently edited scene,
-			// as changes may be lost in the future.
+			// or when the edited scene is inherited from another scene, as changes may be
+			// lost in the future.
 			draw_warning = true;
 		}
 	}


### PR DESCRIPTION
According to comments, the inspector uses the warning colour on the editable children of instanced scenes to warn that the changes to the properties could be lost. This PR applies the same rule to inherited scenes for consistency.