### PR TITLE
[3.x] Fix NavigationObstacle errors

### DIFF
--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -57,9 +57,9 @@ void NavigationObstacle2D::_validate_property(PropertyInfo &p_property) const {
 
 void NavigationObstacle2D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_READY: {
-			initialize_agent();
+		case NOTIFICATION_ENTER_TREE: {
 			parent_node2d = Object::cast_to<Node2D>(get_parent());
+			reevaluate_agent_radius();
 
 			// Search the navigation node and set it
 			{
@@ -104,6 +104,7 @@ NavigationObstacle2D::NavigationObstacle2D() :
 		navigation(nullptr),
 		agent(RID()) {
 	agent = Navigation2DServer::get_singleton()->agent_create();
+	initialize_agent();
 }
 
 NavigationObstacle2D::~NavigationObstacle2D() {
@@ -148,7 +149,7 @@ void NavigationObstacle2D::initialize_agent() {
 void NavigationObstacle2D::reevaluate_agent_radius() {
 	if (!estimate_agent_radius()) {
 		Navigation2DServer::get_singleton()->agent_set_radius(agent, radius);
-	} else if (parent_node2d) {
+	} else if (parent_node2d && parent_node2d->is_inside_tree()) {
 		Navigation2DServer::get_singleton()->agent_set_radius(agent, estimate_agent_radius());
 	}
 }

--- a/scene/3d/navigation_obstacle.cpp
+++ b/scene/3d/navigation_obstacle.cpp
@@ -57,9 +57,9 @@ void NavigationObstacle::_validate_property(PropertyInfo &p_property) const {
 
 void NavigationObstacle::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_READY: {
-			initialize_agent();
+		case NOTIFICATION_ENTER_TREE: {
 			parent_spatial = Object::cast_to<Spatial>(get_parent());
+			reevaluate_agent_radius();
 
 			// Search the navigation node and set it
 			{
@@ -111,6 +111,7 @@ NavigationObstacle::NavigationObstacle() :
 		navigation(nullptr),
 		agent(RID()) {
 	agent = NavigationServer::get_singleton()->agent_create();
+	initialize_agent();
 }
 
 NavigationObstacle::~NavigationObstacle() {
@@ -129,7 +130,7 @@ void NavigationObstacle::set_navigation(Navigation *p_nav) {
 
 void NavigationObstacle::set_navigation_node(Node *p_nav) {
 	Navigation *nav = Object::cast_to<Navigation>(p_nav);
-	ERR_FAIL_COND(nav);
+	ERR_FAIL_NULL(nav);
 	set_navigation(nav);
 }
 
@@ -155,7 +156,7 @@ void NavigationObstacle::initialize_agent() {
 void NavigationObstacle::reevaluate_agent_radius() {
 	if (!estimate_radius) {
 		NavigationServer::get_singleton()->agent_set_radius(agent, radius);
-	} else if (parent_spatial) {
+	} else if (parent_spatial && parent_spatial->is_inside_tree()) {
 		NavigationServer::get_singleton()->agent_set_radius(agent, estimate_agent_radius());
 	}
 }


### PR DESCRIPTION
Fixes part of #57254

* Typo in error print leading to false-positive message
* `NavigationObstacle` premature radius estimation (before entering the tree)
* `NavigationObstacle2D` premature radius estimation (before entering the tree)

Which are the problems introduced in navigation backport: #48395