### PR TITLE
Fix NavigationObstacle errors

### DIFF
--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -53,9 +53,9 @@ void NavigationObstacle2D::_validate_property(PropertyInfo &p_property) const {
 
 void NavigationObstacle2D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_READY: {
-			initialize_agent();
+		case NOTIFICATION_ENTER_TREE: {
 			parent_node2d = Object::cast_to<Node2D>(get_parent());
+			reevaluate_agent_radius();
 			if (parent_node2d != nullptr) {
 				// place agent on navigation map first or else the RVO agent callback creation fails silently later
 				NavigationServer2D::get_singleton()->agent_set_map(get_rid(), parent_node2d->get_world_2d()->get_navigation_map());
@@ -83,6 +83,7 @@ void NavigationObstacle2D::_notification(int p_what) {
 
 NavigationObstacle2D::NavigationObstacle2D() {
 	agent = NavigationServer2D::get_singleton()->agent_create();
+	initialize_agent();
 }
 
 NavigationObstacle2D::~NavigationObstacle2D() {
@@ -110,7 +111,7 @@ void NavigationObstacle2D::initialize_agent() {
 void NavigationObstacle2D::reevaluate_agent_radius() {
 	if (!estimate_radius) {
 		NavigationServer2D::get_singleton()->agent_set_radius(agent, radius);
-	} else if (parent_node2d) {
+	} else if (parent_node2d && parent_node2d->is_inside_tree()) {
 		NavigationServer2D::get_singleton()->agent_set_radius(agent, estimate_agent_radius());
 	}
 }

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -54,9 +54,9 @@ void NavigationObstacle3D::_validate_property(PropertyInfo &p_property) const {
 
 void NavigationObstacle3D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_READY: {
-			initialize_agent();
+		case NOTIFICATION_ENTER_TREE: {
 			parent_node3d = Object::cast_to<Node3D>(get_parent());
+			reevaluate_agent_radius();
 			if (parent_node3d != nullptr) {
 				// place agent on navigation map first or else the RVO agent callback creation fails silently later
 				NavigationServer3D::get_singleton()->agent_set_map(get_rid(), parent_node3d->get_world_3d()->get_navigation_map());
@@ -91,6 +91,7 @@ void NavigationObstacle3D::_notification(int p_what) {
 
 NavigationObstacle3D::NavigationObstacle3D() {
 	agent = NavigationServer3D::get_singleton()->agent_create();
+	initialize_agent();
 }
 
 NavigationObstacle3D::~NavigationObstacle3D() {
@@ -118,7 +119,7 @@ void NavigationObstacle3D::initialize_agent() {
 void NavigationObstacle3D::reevaluate_agent_radius() {
 	if (!estimate_radius) {
 		NavigationServer3D::get_singleton()->agent_set_radius(agent, radius);
-	} else if (parent_node3d) {
+	} else if (parent_node3d && parent_node3d->is_inside_tree()) {
 		NavigationServer3D::get_singleton()->agent_set_radius(agent, estimate_agent_radius());
 	}
 }


### PR DESCRIPTION
* `NavigationObstacle2D` premature radius estimation (before entering the tree)
* `NavigationObstacle3D` premature radius estimation (before entering the tree)

This PR is a subset of `3.x` change: #56600
