### PR TITLE
Skip Draco-compressed glTF 3d format files.

### DIFF
--- a/modules/gltf/gltf_document.h
+++ b/modules/gltf/gltf_document.h
@@ -392,6 +392,7 @@ public:
 
 public:
 	Error _parse_gltf_state(Ref<GLTFState> state, const String &p_search_path, float p_bake_fps);
+	Error _parse_gltf_extensions(Ref<GLTFState> state);
 	void _process_mesh_instances(Ref<GLTFState> state, Node *scene_root);
 	void _generate_scene_node(Ref<GLTFState> state, Node *scene_parent,
 			Node3D *scene_root,


### PR DESCRIPTION
Stage 0 of adding Draco is don't crash with Draco files.

https://github.com/KhronosGroup/glTF/tree/main/extensions/2.0/Khronos/KHR_draco_mesh_compression

Stage 1 is to implement the entire gltf extensions standard.

Stage 2 is to sketch a proposal for adding draco and then putting the proposal into the pile.

Fixes: https://github.com/godotengine/godot/issues/47822