### PR TITLE
Implement a stable objective UndoRedo layer

### DIFF
--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -79,6 +79,7 @@ private:
 	int current_action = -1;
 	bool force_keep_in_merge_ends = false;
 	int action_level = 0;
+	Map<int, Pair<Object *, Map<String, Variant>>> action_cumulative_cache;
 	MergeMode merge_mode = MERGE_DISABLE;
 	bool merging = false;
 	uint64_t version = 1;
@@ -103,6 +104,7 @@ protected:
 
 public:
 	void create_action(const String &p_name = "", MergeMode p_mode = MERGE_DISABLE);
+	void create_action_cumulative(Object *p_object, const String &p_name = "", MergeMode p_mode = MERGE_DISABLE);
 
 	void add_do_method(Object *p_object, const StringName &p_method, VARIANT_ARG_LIST);
 	void add_undo_method(Object *p_object, const StringName &p_method, VARIANT_ARG_LIST);
@@ -116,6 +118,7 @@ public:
 
 	bool is_committing_action() const;
 	void commit_action(bool p_execute = true);
+	void commit_action_cumulative();
 
 	bool redo();
 	bool undo();


### PR DESCRIPTION
TLDR:
* Normal `create/commit_action` methods introduce crashes, inconsistency and lost time; new optional `create/commit_action_cumulative` methods work automatically to speed up development and enable reliable UndoRedo.
* Cumulative UndoRedo works on what actually happened, not what was meant to happen.

Implement godotengine/godot-proposals#3714 to provide a stable base for godotengine/godot-proposals#2109

On its own this PR does not change engine operation, since it only provides an abstraction layer for the UndoRedo system and doesn't add any use cases. However, my test PR #56770 utilises the new layer. By using it, **many** problems and open issues with Animation editing are fixed by _simplifying_ the code in most places.

This is because I designed the system to 'automatically' work. Contributors using `create_action_cumulative` no longer need to log arbitrary action methods/properties - which creates edge cases, broken functionality and crashes all over the place - instead only needing to add two lines to their code (to create+commit the action). 

For example, in 4.0 and even 3.x, it's currently difficult to do undos/redos in the Animation editor without at some point having keys go missing, get duplicated or break, often resulting in an engine crash; other types of issues are present as well. This is because the methods used don't work the same forwards as backwards, with contributors having to put a lot of effort into finding functions that seem correct and applying them in an order that 'works', with undo and redo being _completely independent_. The smallest change to a method _used by undo or redo_ can introduce inconsistency or crashes, meaning that a lot of development time has to be put into maintaining undo; and yet, as long as Godot is in development it can never work perfectly or even well.

On the other hand, this 'cumulative' UndoRedo system will always revert to the exact same state (as long as `get` and `set` are maintained) requiring next to no contributor effort and eliminating a major cause of crashes/issues slowing down 4.0 development. Even if something unexpected happens - e.g. a malfunction in the editor code breaks something made by the user - UndoRedo can always save the affected object from being lost, because it works on what _actually_ happened, not what was meant to happen.

It's true that in a few places the changes to Animation-editing were larger. However, this is a minority of cases caused by the systems being designed to work with the normal UndoRedo methods, so in some areas a minor redesign was necessary. In some ways this is a benefit though, because I think cumulative-undo encourages better code practices and reusability. In any case, if some area of the engine is too difficult or impractical to use cumulative undo in, it can just continue using the normal system.