### PR TITLE
Remove redundant check and move second dynamic_cast where it belongs in SceneState::instantiate

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -175,14 +175,12 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 #endif
 			}
 		} else {
-			Object *obj = nullptr;
+			//node belongs to this scene and must be created
+			Object *obj = ClassDB::instantiate(snames[n.type]);
 
-			if (ClassDB::is_class_enabled(snames[n.type])) {
-				//node belongs to this scene and must be created
-				obj = ClassDB::instantiate(snames[n.type]);
-			}
+			node = Object::cast_to<Node>(obj);
 
-			if (!Object::cast_to<Node>(obj)) {
+			if (!node) {
 				if (obj) {
 					memdelete(obj);
 					obj = nullptr;
@@ -203,9 +201,9 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 				if (!obj) {
 					obj = memnew(Node);
 				}
-			}
 
-			node = Object::cast_to<Node>(obj);
+				node = Object::cast_to<Node>(obj);
+			}
 		}
 
 		if (node) {


### PR DESCRIPTION
`ClassDB::is_class_enabled(snames[n.type])` check is reduntant because `ClassDB::instantiate(snames[n.type])` already handles exact same checks and even more (so we have less rwlock creations, less `if` checks and one less function call in cases where is_class_enabled returns true).

Rearranging `cast_to` (`dynamic_cast`) let's us calling it only once in best case scenarios (so in most cases without warnings) instead of twice every time.