### PR TITLE
[3.x] Misc documentation improvements

### DIFF
--- a/doc/classes/InputEventMIDI.xml
+++ b/doc/classes/InputEventMIDI.xml
@@ -30,7 +30,7 @@
 			The instrument of this input event. This value ranges from 0 to 127. Refer to the instrument list on the General MIDI wikipedia article to see a list of instruments, except that this value is 0-index, so subtract one from every number on that chart. A standard piano will have an instrument number of 0.
 		</member>
 		<member name="message" type="int" setter="set_message" getter="get_message" default="0">
-			Returns a value indicating the type of message for this MIDI signal. This is a member of the MidiMessageList enum.
+			Returns a value indicating the type of message for this MIDI signal. This is a member of the [enum @GlobalScope.MidiMessageList] enum.
 			For MIDI messages between 0x80 and 0xEF, only the left half of the bits are returned as this value, as the other part is the channel (ex: 0x94 becomes 0x9). For MIDI messages from 0xF0 to 0xFF, the value is returned as-is.
 			Notes will return [code]MIDI_MESSAGE_NOTE_ON[/code] when activated, but they might not always return [code]MIDI_MESSAGE_NOTE_OFF[/code] when deactivated, therefore your code should treat the input as stopped if some period of time has passed.
 			For more information, see the MIDI message status byte list chart linked above.

--- a/doc/classes/NavigationAgent.xml
+++ b/doc/classes/NavigationAgent.xml
@@ -87,7 +87,7 @@
 			<return type="void" />
 			<argument index="0" name="velocity" type="Vector3" />
 			<description>
-				Sends the given velocity to the collision avoidance algorithm. It will adjust the velocity to avoid collisions. Once the adjustment to the velocity is complete, it will emit the [signal velocity_computed] signal.
+				Sends the passed in velocity to the collision avoidance algorithm. It will adjust the velocity to avoid collisions. Once the adjustment to the velocity is complete, it will emit the [signal velocity_computed] signal.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -18,7 +18,7 @@
 		<method name="get_final_location">
 			<return type="Vector2" />
 			<description>
-				Returns the reachable final location in global coordinates. This can change if the navigation path is altered in any way.
+				Returns the reachable final location in global coordinates. This can change if the navigation path is altered in any way. Because of this, it would be best to check this each frame.
 			</description>
 		</method>
 		<method name="get_nav_path" qualifiers="const">

--- a/doc/classes/NavigationObstacle2D.xml
+++ b/doc/classes/NavigationObstacle2D.xml
@@ -4,7 +4,7 @@
 		2D obstacle used in navigation for collision avoidance.
 	</brief_description>
 	<description>
-		2D obstacle used in navigation for collision avoidance. The obstacle needs navigation data to work correctly. This can be done by having the obstacle as a child of a [Navigation2D] node, or using [method set_navigation]. [NavigationObstacle] is physics safe.
+		2D obstacle used in navigation for collision avoidance. The obstacle needs navigation data to work correctly. This can be done by having the obstacle as a child of a [Navigation2D] node, or using [method set_navigation]. [NavigationObstacle2D] is physics safe.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Found some spots that can be improved when translating the newly updated class reference:

* `NavigationObstacle2D` incorrectly used 3D description.
* Made `MidiMessageList` enum a link, this is essential because the member's type is displayed as `int` on `3.x`.
* Unified two unnecessary function description differences between `NavigationAgent` and `NavigationAgent2D`.