### PR TITLE
Decrease the default number of max clustered elements to 128

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1727,7 +1727,9 @@
 		</member>
 		<member name="rendering/lightmapping/probe_capture/update_speed" type="float" setter="" getter="" default="15">
 		</member>
-		<member name="rendering/limits/cluster_builder/max_clustered_elements" type="float" setter="" getter="" default="512">
+		<member name="rendering/limits/cluster_builder/max_clustered_elements" type="float" setter="" getter="" default="128">
+			When using the Vulkan Clustered backend, the maximum number of [OmniLight3D]s, [SpotLight3D]s, [Decal]s and [ReflectionProbe]s that can be rendered at a given time on screen. If this limit is exceeded, these elements will flicker as not all of them will be rendered at the same time. This value should be set as low as possible to improve performance, as higher values will use up GPU time even if the limit is not reached.
+			[b]Note:[/b] Ignored when using the Vulkan Mobile and OpenGL backends.
 		</member>
 		<member name="rendering/limits/forward_renderer/threaded_render_minimum_instances" type="int" setter="" getter="" default="500">
 		</member>

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3001,7 +3001,7 @@ RenderingServer::RenderingServer() {
 	GLOBAL_DEF("rendering/limits/forward_renderer/threaded_render_minimum_instances", 500);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/forward_renderer/threaded_render_minimum_instances", PropertyInfo(Variant::INT, "rendering/limits/forward_renderer/threaded_render_minimum_instances", PROPERTY_HINT_RANGE, "32,65536,1"));
 
-	GLOBAL_DEF("rendering/limits/cluster_builder/max_clustered_elements", 512);
+	GLOBAL_DEF("rendering/limits/cluster_builder/max_clustered_elements", 128);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/cluster_builder/max_clustered_elements", PropertyInfo(Variant::FLOAT, "rendering/limits/cluster_builder/max_clustered_elements", PROPERTY_HINT_RANGE, "32,8192,1"));
 
 	GLOBAL_DEF_RST("rendering/xr/enabled", false);


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/55289 (can be merged independently).

This improves performance without affecting the visual appearance of scenes that have less than 128 OmniLights + SpotLights + Decals + ReflectionProbes present in the view frustum.

This setting will need to be increased by the user if rendering a more complex scene, but it's fair to say that a majority of scenes will not exceed 128 clustered elements.

**Testing project:** [test_cluster_size.zip](https://github.com/godotengine/godot/files/7597214/test_cluster_size.zip)

## Preview

**OS:** Fedora 34
**CPU:** Intel Core i7-6700K
**GPU:** NVIDIA GeForce GTX 1080

### Before

![2022-01-09_00 35 54](https://user-images.githubusercontent.com/180032/148663722-5434392b-eb7b-4edf-9994-e6ed953ada4a.png)

### After

![2022-01-09_00 36 25](https://user-images.githubusercontent.com/180032/148663724-425e3723-993f-4eba-99b6-ceefd716025a.png)