### PR TITLE
Add note on when tween methods return false (3.x)

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -17,6 +17,7 @@
 		Many methods require a property name, such as [code]"position"[/code] above. You can find the correct property name by hovering over the property in the Inspector. You can also provide the components of a property directly by using [code]"property:component"[/code] (e.g. [code]position:x[/code]), where it would only apply to that particular component.
 		Many of the methods accept [code]trans_type[/code] and [code]ease_type[/code]. The first accepts an [enum TransitionType] constant, and refers to the way the timing of the animation is handled (see [url=https://easings.net/]easings.net[/url] for some examples). The second accepts an [enum EaseType] constant, and controls where the [code]trans_type[/code] is applied to the interpolation (in the beginning, the end, or both). If you don't know which transition and easing to pick, you can try different [enum TransitionType] constants with [constant EASE_IN_OUT], and use the one that looks best.
 		[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/tween_cheatsheet.png]Tween easing and transition types cheatsheet[/url]
+		[b]Note:[/b] Tween methods will return [code]false[/code] if the requested operation cannot be completed.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Adds a note that tween methods return false when the operation can't be completed. There is no master branch version of this PR because now these methods return nothing (PR #36844). Closes https://github.com/godotengine/godot-docs/issues/5091.