### PR TITLE
Path2D: Check points count before rendering.

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -93,6 +93,10 @@ void Path2D::_notification(int p_what) {
 			return;
 		}
 
+		if (curve->get_point_count() < 2) {
+			return;
+		}
+
 #ifdef TOOLS_ENABLED
 		const real_t line_width = 2 * EDSCALE;
 #else


### PR DESCRIPTION
**The Bug:** 
Add a empty Path2D to the scene. The following error message is shown.

![image](https://user-images.githubusercontent.com/17506575/148676430-c2232146-67d9-4d87-9264-646c93c3077b.png)

Likely an issue from https://github.com/godotengine/godot/pull/55516, where Path2D is drawn using `draw_polyline` whatever the number of points in the curve.
