### PR TITLE
Implement AnimationPlayer pause() and resume()

### DIFF
--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -103,7 +103,7 @@
 		<method name="get_playing_speed" qualifiers="const">
 			<return type="float" />
 			<description>
-				Gets the actual playing speed of current animation or 0 if not playing. This speed is the [member playback_speed] property multiplied by [code]custom_speed[/code] argument specified when calling the [method play] method.
+				Gets the actual playing speed of current animation or 0 if not playing. This speed is the [member playback_speed] property multiplied by [code]custom_speed[/code] argument specified when calling the [method start] method.
 			</description>
 		</method>
 		<method name="get_queue">
@@ -138,26 +138,6 @@
 				[b]Note:[/b] Has no effect if the animation is not playing. See [method is_playing]
 			</description>
 		</method>
-		<method name="play">
-			<return type="void" />
-			<argument index="0" name="name" type="StringName" default="&quot;&quot;" />
-			<argument index="1" name="custom_blend" type="float" default="-1" />
-			<argument index="2" name="custom_speed" type="float" default="1.0" />
-			<argument index="3" name="from_end" type="bool" default="false" />
-			<description>
-				Plays the currently assigned animation or the animation with key [code]name[/code] from the beginning. Custom blend times and speed can be set. If [code]custom_speed[/code] is negative and [code]from_end[/code] is [code]true[/code], the animation will play backwards (which is equivalent to calling [method play_backwards]).
-				[b]Note:[/b] The animation will be updated the next time the [AnimationPlayer] is processed. If other variables are updated at the same time this is called, they may be updated too early. To perform the update immediately, call [code]advance(0)[/code].
-			</description>
-		</method>
-		<method name="play_backwards">
-			<return type="void" />
-			<argument index="0" name="name" type="StringName" default="&quot;&quot;" />
-			<argument index="1" name="custom_blend" type="float" default="-1" />
-			<description>
-				Plays the animation with key [code]name[/code] in reverse.
-				This method is a shorthand for [method play] with [code]custom_speed = -1.0[/code] and [code]from_end = true[/code], so see its description for more information.
-			</description>
-		</method>
 		<method name="queue">
 			<return type="void" />
 			<argument index="0" name="name" type="StringName" />
@@ -183,7 +163,7 @@
 			<return type="void" />
 			<description>
 				Resumes an animation that was paused. See [method pause].
-				[b]Note:[/b] Has no effect if the animation is not paused. It will not start an animation that was not playing or is finished. See [method play].
+				[b]Note:[/b] Has no effect if the animation is not paused. It will not start an animation that was not playing or is finished. See [method start].
 			</description>
 		</method>
 		<method name="seek">
@@ -204,6 +184,16 @@
 				Specifies a blend time (in seconds) between two animations, referenced by their names.
 			</description>
 		</method>
+		<method name="start">
+			<return type="void" />
+			<argument index="0" name="name" type="StringName" default="&quot;&quot;" />
+			<argument index="1" name="custom_blend_time" type="float" default="-1" />
+			<argument index="2" name="custom_speed" type="float" default="1.0" />
+			<description>
+				Starts playing the currently assigned animation or the animation with key [code]name[/code] from the beginning. A custom blend time and speed can be set. If [code]custom_speed[/code] is negative, the animation will play backwards from the end.
+				[b]Note:[/b] The animation will be updated the next time the [AnimationPlayer] is processed. If other variables are updated at the same time this is called, they may be updated too early. To perform the update immediately, call [code]advance(0)[/code].
+			</description>
+		</method>
 		<method name="stop">
 			<return type="void" />
 			<description>
@@ -219,7 +209,7 @@
 			The name of the animation to play when the scene loads.
 		</member>
 		<member name="current_animation" type="String" setter="set_current_animation" getter="get_current_animation" default="&quot;&quot;">
-			The name of the currently playing animation. If no animation is playing, the property's value is an empty string. Changing this value does not restart the animation. See [method play] for more information on playing animations.
+			The name of the currently playing animation. If no animation is playing, the property's value is an empty string. Changing this value does not start the animation. See [method start] for more information on starting the animation.
 			[b]Note:[/b] while this property appears in the inspector, it's not meant to be edited, and it's not saved in the scene. This property is mainly used to get the currently playing animation, and internally for animation playback tracks. For more information, see [Animation].
 		</member>
 		<member name="current_animation_length" type="float" setter="" getter="get_current_animation_length">
@@ -254,7 +244,7 @@
 			<argument index="1" name="new_name" type="StringName" />
 			<description>
 				Emitted when a queued animation plays after the previous animation was finished. See [method queue].
-				[b]Note:[/b] The signal is not emitted when the animation is changed via [method play] or from [AnimationTree].
+				[b]Note:[/b] The signal is not emitted when the animation is changed via [method start] or from [AnimationTree].
 			</description>
 		</signal>
 		<signal name="animation_finished">

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -231,9 +231,6 @@
 		<member name="method_call_mode" type="int" setter="set_method_call_mode" getter="get_method_call_mode" enum="AnimationPlayer.AnimationMethodCallMode" default="0">
 			The call mode to use for Call Method tracks.
 		</member>
-		<member name="playback_active" type="bool" setter="set_active" getter="is_active">
-			If [code]true[/code], updates animations in response to process-related notifications.
-		</member>
 		<member name="playback_default_blend_time" type="float" setter="set_default_blend_time" getter="get_default_blend_time" default="0.0">
 			The default time in which to blend animations. Ranges from 0 to 4096 with 0.01 precision.
 		</member>

--- a/doc/classes/AnimationPlayer.xml
+++ b/doc/classes/AnimationPlayer.xml
@@ -128,7 +128,14 @@
 		<method name="is_playing" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if playing an animation.
+				Returns [code]true[/code] if an animation is playing. An animation is playing if it has started, but not finished or been paused.
+			</description>
+		</method>
+		<method name="pause">
+			<return type="void" />
+			<description>
+				Pauses the currently playing animation. To resume the animation again use [method resume]. To stop and reset an animation use [method stop].
+				[b]Note:[/b] Has no effect if the animation is not playing. See [method is_playing]
 			</description>
 		</method>
 		<method name="play">
@@ -138,8 +145,7 @@
 			<argument index="2" name="custom_speed" type="float" default="1.0" />
 			<argument index="3" name="from_end" type="bool" default="false" />
 			<description>
-				Plays the animation with key [code]name[/code]. Custom blend times and speed can be set. If [code]custom_speed[/code] is negative and [code]from_end[/code] is [code]true[/code], the animation will play backwards (which is equivalent to calling [method play_backwards]).
-				The [AnimationPlayer] keeps track of its current or last played animation with [member assigned_animation]. If this method is called with that same animation [code]name[/code], or with no [code]name[/code] parameter, the assigned animation will resume playing if it was paused, or restart if it was stopped (see [method stop] for both pause and stop). If the animation was already playing, it will keep playing.
+				Plays the currently assigned animation or the animation with key [code]name[/code] from the beginning. Custom blend times and speed can be set. If [code]custom_speed[/code] is negative and [code]from_end[/code] is [code]true[/code], the animation will play backwards (which is equivalent to calling [method play_backwards]).
 				[b]Note:[/b] The animation will be updated the next time the [AnimationPlayer] is processed. If other variables are updated at the same time this is called, they may be updated too early. To perform the update immediately, call [code]advance(0)[/code].
 			</description>
 		</method>
@@ -173,6 +179,13 @@
 			<description>
 			</description>
 		</method>
+		<method name="resume">
+			<return type="void" />
+			<description>
+				Resumes an animation that was paused. See [method pause].
+				[b]Note:[/b] Has no effect if the animation is not paused. It will not start an animation that was not playing or is finished. See [method play].
+			</description>
+		</method>
 		<method name="seek">
 			<return type="void" />
 			<argument index="0" name="seconds" type="float" />
@@ -193,10 +206,8 @@
 		</method>
 		<method name="stop">
 			<return type="void" />
-			<argument index="0" name="reset" type="bool" default="true" />
 			<description>
-				Stops or pauses the currently playing animation. If [code]reset[/code] is [code]true[/code], the animation position is reset to [code]0[/code] and the playback speed is reset to [code]1.0[/code].
-				If [code]reset[/code] is [code]false[/code], the [member current_animation_position] will be kept and calling [method play] or [method play_backwards] without arguments or with the same animation name as [member assigned_animation] will resume the animation.
+				Stops and resets the currently playing animation. To keep the animation at its current position, use [method pause].
 			</description>
 		</method>
 	</methods>

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -265,7 +265,7 @@ void AnimationPlayerEditor::_stop_pressed() {
 		return;
 	}
 
-	player->stop(false);
+	player->pause();
 	play->set_pressed(false);
 	stop->set_pressed(true);
 }
@@ -1103,7 +1103,7 @@ void AnimationPlayerEditor::_seek_value_changed(float p_value, bool p_set, bool 
 
 			player->seek_delta(pos, pos - cpos);
 		} else {
-			player->stop(true);
+			player->stop();
 			player->seek(pos, true);
 		}
 	}

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -198,7 +198,7 @@ void AnimationPlayerEditor::_play_pressed() {
 		if (current == player->get_assigned_animation()) {
 			player->stop(); //so it won't blend with itself
 		}
-		player->play(current);
+		player->start(current);
 	}
 
 	//unstop
@@ -215,7 +215,7 @@ void AnimationPlayerEditor::_play_from_pressed() {
 			player->stop(); //so it won't blend with itself
 		}
 
-		player->play(current);
+		player->start(current);
 		player->seek(time);
 	}
 
@@ -236,7 +236,7 @@ void AnimationPlayerEditor::_play_bw_pressed() {
 		if (current == player->get_assigned_animation()) {
 			player->stop(); //so it won't blend with itself
 		}
-		player->play(current, -1, -1, true);
+		player->start(current, -1, -1);
 	}
 
 	//unstop
@@ -252,7 +252,7 @@ void AnimationPlayerEditor::_play_bw_from_pressed() {
 			player->stop(); //so it won't blend with itself
 		}
 
-		player->play(current, -1, -1, true);
+		player->start(current, -1, -1);
 		player->seek(time);
 	}
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1821,19 +1821,6 @@ void AnimationPlayer::clear_caches() {
 	cache_update_bezier_size = 0;
 }
 
-void AnimationPlayer::set_active(bool p_active) {
-	if (active == p_active) {
-		return;
-	}
-
-	active = p_active;
-	_set_process(processing, true);
-}
-
-bool AnimationPlayer::is_active() const {
-	return active;
-}
-
 StringName AnimationPlayer::find_animation(const Ref<Animation> &p_animation) const {
 	for (const KeyValue<StringName, AnimationData> &E : animation_set) {
 		if (E.value.animation == p_animation) {
@@ -1900,17 +1887,17 @@ AnimationPlayer::AnimationMethodCallMode AnimationPlayer::get_method_call_mode()
 	return method_call_mode;
 }
 
-void AnimationPlayer::_set_process(bool p_process, bool p_force) {
-	if (processing == p_process && !p_force) {
+void AnimationPlayer::_set_process(bool p_process) {
+	if (processing == p_process) {
 		return;
 	}
 
 	switch (process_callback) {
 		case ANIMATION_PROCESS_PHYSICS:
-			set_physics_process_internal(p_process && active);
+			set_physics_process_internal(p_process);
 			break;
 		case ANIMATION_PROCESS_IDLE:
-			set_process_internal(p_process && active);
+			set_process_internal(p_process);
 			break;
 		case ANIMATION_PROCESS_MANUAL:
 			break;
@@ -2095,9 +2082,6 @@ void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_queue"), &AnimationPlayer::get_queue);
 	ClassDB::bind_method(D_METHOD("clear_queue"), &AnimationPlayer::clear_queue);
 
-	ClassDB::bind_method(D_METHOD("set_active", "active"), &AnimationPlayer::set_active);
-	ClassDB::bind_method(D_METHOD("is_active"), &AnimationPlayer::is_active);
-
 	ClassDB::bind_method(D_METHOD("set_speed_scale", "speed"), &AnimationPlayer::set_speed_scale);
 	ClassDB::bind_method(D_METHOD("get_speed_scale"), &AnimationPlayer::get_speed_scale);
 	ClassDB::bind_method(D_METHOD("get_playing_speed"), &AnimationPlayer::get_playing_speed);
@@ -2139,7 +2123,6 @@ void AnimationPlayer::_bind_methods() {
 	ADD_GROUP("Playback Options", "playback_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "playback_process_mode", PROPERTY_HINT_ENUM, "Physics,Idle,Manual"), "set_process_callback", "get_process_callback");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_default_blend_time", PROPERTY_HINT_RANGE, "0,4096,0.01,suffix:s"), "set_default_blend_time", "get_default_blend_time");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "playback_active", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_active", "is_active");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_speed", PROPERTY_HINT_RANGE, "-64,64,0.01"), "set_speed_scale", "get_speed_scale");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "method_call_mode", PROPERTY_HINT_ENUM, "Deferred,Immediate"), "set_method_call_mode", "get_method_call_mode");
 

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1592,24 +1592,10 @@ void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float
 		}
 	}
 
-	if (get_current_animation() != p_name) {
-		_stop_playing_caches();
-	}
+	_stop_playing_caches();
 
 	c.current.from = &animation_set[name];
-
-	if (c.assigned != name) { // reset
-		c.current.pos = p_from_end ? c.current.from->animation->get_length() : 0;
-	} else {
-		if (p_from_end && c.current.pos == 0) {
-			// Animation reset BUT played backwards, set position to the end
-			c.current.pos = c.current.from->animation->get_length();
-		} else if (!p_from_end && c.current.pos == c.current.from->animation->get_length()) {
-			// Animation resumed but already ended, set position to the beginning
-			c.current.pos = 0;
-		}
-	}
-
+	c.current.pos = p_from_end ? c.current.from->animation->get_length() : 0;
 	c.current.speed_scale = p_custom_scale;
 	c.assigned = name;
 	c.seeked = false;
@@ -1620,6 +1606,7 @@ void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float
 	}
 	_set_process(true); // always process when starting an animation
 	playing = true;
+	paused = false;
 
 	emit_signal(SceneStringNames::get_singleton()->animation_started, c.assigned);
 
@@ -1666,18 +1653,37 @@ String AnimationPlayer::get_assigned_animation() const {
 	return playback.assigned;
 }
 
-void AnimationPlayer::stop(bool p_reset) {
-	_stop_playing_caches();
-	Playback &c = playback;
-	c.blend.clear();
-	if (p_reset) {
-		c.current.from = nullptr;
-		c.current.speed_scale = 1;
-		c.current.pos = 0;
+void AnimationPlayer::pause() {
+	if (!playing) {
+		return;
 	}
+	_pause_playing_caches();
+	_set_process(false);
+	playing = false;
+	paused = true;
+}
+
+void AnimationPlayer::resume() {
+	if (!paused) {
+		return;
+	}
+	_resume_playing_caches();
+	_set_process(true);
+	playing = true;
+	paused = false;
+}
+
+void AnimationPlayer::stop() {
+	playback.blend.clear();
+	playback.current.pos = 0;
+	_animation_process(0);
+	_stop_playing_caches();
+	playback.current.from = nullptr;
+	playback.current.speed_scale = 1;
 	_set_process(false);
 	queued.clear();
 	playing = false;
+	paused = false;
 }
 
 void AnimationPlayer::set_speed_scale(float p_speed) {
@@ -1747,6 +1753,36 @@ void AnimationPlayer::_animation_changed() {
 	emit_signal(SNAME("caches_cleared"));
 	if (is_playing()) {
 		playback.seeked = true; //need to restart stuff, like audio
+	}
+}
+
+void AnimationPlayer::_pause_playing_caches() {
+	for (TrackNodeCache *E : playing_caches) {
+		if (E->node && E->audio_playing) {
+			E->node->call("stop");
+		}
+		if (E->node && E->animation_playing) {
+			AnimationPlayer *player = Object::cast_to<AnimationPlayer>(E->node);
+			if (!player) {
+				continue;
+			}
+			player->pause();
+		}
+	}
+}
+
+void AnimationPlayer::_resume_playing_caches() {
+	for (TrackNodeCache *E : playing_caches) {
+		if (E->node && E->audio_playing) {
+			E->node->call("play", playback.current.pos);
+		}
+		if (E->node && E->animation_playing) {
+			AnimationPlayer *player = Object::cast_to<AnimationPlayer>(E->node);
+			if (!player) {
+				continue;
+			}
+			player->resume();
+		}
 	}
 }
 
@@ -2046,7 +2082,9 @@ void AnimationPlayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("play", "name", "custom_blend", "custom_speed", "from_end"), &AnimationPlayer::play, DEFVAL(""), DEFVAL(-1), DEFVAL(1.0), DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("play_backwards", "name", "custom_blend"), &AnimationPlayer::play_backwards, DEFVAL(""), DEFVAL(-1));
-	ClassDB::bind_method(D_METHOD("stop", "reset"), &AnimationPlayer::stop, DEFVAL(true));
+	ClassDB::bind_method(D_METHOD("pause"), &AnimationPlayer::pause);
+	ClassDB::bind_method(D_METHOD("resume"), &AnimationPlayer::resume);
+	ClassDB::bind_method(D_METHOD("stop"), &AnimationPlayer::stop);
 	ClassDB::bind_method(D_METHOD("is_playing"), &AnimationPlayer::is_playing);
 
 	ClassDB::bind_method(D_METHOD("set_current_animation", "anim"), &AnimationPlayer::set_current_animation);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -260,7 +260,6 @@ private:
 	AnimationProcessCallback process_callback = ANIMATION_PROCESS_IDLE;
 	AnimationMethodCallMode method_call_mode = ANIMATION_METHOD_CALL_DEFERRED;
 	bool processing = false;
-	bool active = true;
 
 	NodePath root;
 
@@ -293,7 +292,7 @@ private:
 	void _ref_anim(const Ref<Animation> &p_anim);
 	void _unref_anim(const Ref<Animation> &p_anim);
 
-	void _set_process(bool p_process, bool p_force = false);
+	void _set_process(bool p_process);
 
 	bool playing = false;
 	bool paused = false;
@@ -353,8 +352,6 @@ public:
 	void set_current_animation(const String &p_anim);
 	String get_assigned_animation() const;
 	void set_assigned_animation(const String &p_anim);
-	void set_active(bool p_active);
-	bool is_active() const;
 	bool is_valid() const;
 
 	void set_speed_scale(float p_speed);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -273,6 +273,8 @@ private:
 	void _animation_process(double p_delta);
 
 	void _node_removed(Node *p_node);
+	void _pause_playing_caches();
+	void _resume_playing_caches();
 	void _stop_playing_caches();
 
 	// bind helpers
@@ -294,6 +296,7 @@ private:
 	void _set_process(bool p_process, bool p_force = false);
 
 	bool playing = false;
+	bool paused = false;
 
 	uint64_t animation_set_update_pass = 1;
 	void _animation_set_cache_update();
@@ -342,7 +345,9 @@ public:
 	void queue(const StringName &p_name);
 	Vector<String> get_queue();
 	void clear_queue();
-	void stop(bool p_reset = true);
+	void pause();
+	void resume();
+	void stop();
 	bool is_playing() const;
 	String get_current_animation() const;
 	void set_current_animation(const String &p_anim);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -339,8 +339,7 @@ public:
 	void set_default_blend_time(float p_default);
 	float get_default_blend_time() const;
 
-	void play(const StringName &p_name = StringName(), float p_custom_blend = -1, float p_custom_scale = 1.0, bool p_from_end = false);
-	void play_backwards(const StringName &p_name = StringName(), float p_custom_blend = -1);
+	void start(const StringName &p_name = StringName(), float p_custom_blend_time = -1, float p_custom_scale = 1.0);
 	void queue(const StringName &p_name);
 	Vector<String> get_queue();
 	void clear_queue();

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1553,7 +1553,7 @@ void AnimationTree::_process_graph(double p_delta) {
 							}
 
 							if (player2->is_playing() || seeked) {
-								player2->play(anim_name);
+								player2->start(anim_name);
 								player2->seek(at_anim_pos);
 								t->playing = true;
 								playing_caches.insert(t);
@@ -1576,7 +1576,7 @@ void AnimationTree::_process_graph(double p_delta) {
 										t->playing = false;
 									}
 								} else {
-									player2->play(anim_name);
+									player2->start(anim_name);
 									t->playing = true;
 									playing_caches.insert(t);
 								}


### PR DESCRIPTION
Salvage of #44345. #44345 was closed, because it was considered _"redundant given #46191 has been merged"_. However, #46191 does not implement godotengine/godot-proposals#287, fix #27499 or fix #36279. Furthermore, pausing (and unpausing) the entire `SceneTree` is not a convenient or even realistic way of pausing and resuming an `AnimationPlayer`'s playing animation.

As originally identified in #34125 and elaborated on in godotengine/godot-proposals#287, in AnimationPlayer:
> Currently play() method doesn't adhere to single responsibility principle. If user calls play() while there is no animation playing it acts as start_animation() where as when user calls it when animation is already playing it acts as resume_animation(). This dual behaviour is not desired by users as it requires a condition statement in order to use start_animation functionality of play(). It is also inconstant across the engine as for example AudioStreamPlayer method play() method has only singular functionality of start_playing(). This is confusing to understand and breaks intuitiveness of the engine.

Similarly, `AnimationPlayer:stop()` has a parameter that defaults to `true` to either stop and reset the animation or just pause the animation. However, as identified in #27499, although `stop(true)` resets the playback position it doesn't reset the animation.

This PR:
- Implements two new functions in AnimationPlayer: pause() and resume(). pause() will pause a currently playing animation, and resume() will resume a paused() animation.
- Removes the redundant `AnimationPlayer` `playback_active` property.
- Renames AnimationPlayer::play() to start(), and also removes the play_backwards() method and the from_end parameter (uses a negative speed to determine this).
- Ensures that start() always plays the specified (or current animation) from the beginning regardless of whether or not the requested animation is the same as the current animation.
- Ensures that stop() also resets the animation.
- Updates the relevant documentation.

Closes godotengine/godot-proposals#287
Fixes #27499
Fixes #36279
Supersedes #33733