### PR TITLE
Add context menu to visual script editor

### DIFF
--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -1973,7 +1973,7 @@ void VisualScriptEditor::input(const Ref<InputEvent> &p_event) {
 	// GUI input for VS Editor Plugin
 	Ref<InputEventMouseButton> key = p_event;
 
-	if (key.is_valid() && !key->is_pressed()) {
+	if (key.is_valid() && key->is_pressed()) {
 		mouse_up_position = get_screen_position() + get_local_mouse_position();
 	}
 }
@@ -1982,10 +1982,28 @@ void VisualScriptEditor::_graph_gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseButton> key = p_event;
 
 	if (key.is_valid() && key->is_pressed() && key->get_button_mask() == MouseButton::RIGHT) {
-		saved_position = graph->get_local_mouse_position();
+		bool is_empty_selection = true;
 
-		Point2 gpos = get_screen_position() + get_local_mouse_position();
-		_generic_search(script->get_instance_base_type(), gpos);
+		for (int i = 0; i < graph->get_child_count(); i++) {
+			GraphNode *gn = Object::cast_to<GraphNode>(graph->get_child(i));
+			if (gn && gn->is_selected()) {
+				is_empty_selection = false;
+				break;
+			}
+		}
+		if (is_empty_selection && clipboard->nodes.is_empty()) {
+			_generic_search(script->get_instance_base_type(), mouse_up_position);
+		} else {
+			popup_menu->set_item_disabled(int(EDIT_CUT_NODES), is_empty_selection);
+			popup_menu->set_item_disabled(int(EDIT_COPY_NODES), is_empty_selection);
+			popup_menu->set_item_disabled(int(EDIT_PASTE_NODES), clipboard->nodes.is_empty());
+			popup_menu->set_item_disabled(int(EDIT_DELETE_NODES), is_empty_selection);
+			popup_menu->set_item_disabled(int(EDIT_DUPLICATE_NODES), is_empty_selection);
+			popup_menu->set_item_disabled(int(EDIT_CLEAR_COPY_BUFFER), clipboard->nodes.is_empty());
+
+			popup_menu->set_position(mouse_up_position);
+			popup_menu->popup();
+		}
 	}
 }
 
@@ -3868,6 +3886,9 @@ void VisualScriptEditor::_comment_node_resized(const Vector2 &p_new_size, int p_
 
 void VisualScriptEditor::_menu_option(int p_what) {
 	switch (p_what) {
+		case EDIT_ADD_NODE: {
+			_generic_search(script->get_instance_base_type(), mouse_up_position);
+		} break;
 		case EDIT_DELETE_NODES: {
 			_on_nodes_delete();
 		} break;
@@ -3907,6 +3928,9 @@ void VisualScriptEditor::_menu_option(int p_what) {
 		} break;
 		case EDIT_PASTE_NODES: {
 			_on_nodes_paste();
+		} break;
+		case EDIT_DUPLICATE_NODES: {
+			_on_nodes_duplicate();
 		} break;
 		case EDIT_CREATE_FUNCTION: {
 			// Create Function.
@@ -4135,6 +4159,12 @@ void VisualScriptEditor::_menu_option(int p_what) {
 		case REFRESH_GRAPH: {
 			_update_graph();
 		} break;
+		case EDIT_CLEAR_COPY_BUFFER: {
+			clipboard->nodes.clear();
+			clipboard->nodes_positions.clear();
+			clipboard->data_connections.clear();
+			clipboard->sequence_connections.clear();
+		} break;
 	}
 }
 
@@ -4322,9 +4352,6 @@ VisualScriptEditor::VisualScriptEditor() {
 	if (!clipboard) {
 		clipboard = memnew(Clipboard);
 	}
-	updating_graph = false;
-	saved_pos_dirty = false;
-	saved_position = Vector2(0, 0);
 
 	edit_menu = memnew(MenuButton);
 	edit_menu->set_shortcut_context(this);
@@ -4556,6 +4583,18 @@ VisualScriptEditor::VisualScriptEditor() {
 	new_virtual_method_select = memnew(VisualScriptPropertySelector);
 	add_child(new_virtual_method_select);
 	new_virtual_method_select->connect("selected", callable_mp(this, &VisualScriptEditor::_selected_new_virtual_method));
+
+	popup_menu = memnew(PopupMenu);
+	add_child(popup_menu);
+	popup_menu->add_item(TTR("Add Node"), EDIT_ADD_NODE);
+	popup_menu->add_separator();
+	popup_menu->add_item(TTR("Cut"), EDIT_CUT_NODES);
+	popup_menu->add_item(TTR("Copy"), EDIT_COPY_NODES);
+	popup_menu->add_item(TTR("Paste"), EDIT_PASTE_NODES);
+	popup_menu->add_item(TTR("Delete"), EDIT_DELETE_NODES);
+	popup_menu->add_item(TTR("Duplicate"), EDIT_DUPLICATE_NODES);
+	popup_menu->add_item(TTR("Clear Copy Buffer"), EDIT_CLEAR_COPY_BUFFER);
+	popup_menu->connect("id_pressed", callable_mp(this, &VisualScriptEditor::_menu_option));
 }
 
 VisualScriptEditor::~VisualScriptEditor() {

--- a/modules/visual_script/editor/visual_script_editor.h
+++ b/modules/visual_script/editor/visual_script_editor.h
@@ -54,13 +54,18 @@ class VisualScriptEditor : public ScriptEditorBase {
 	};
 
 	enum {
+		EDIT_ADD_NODE,
+		EDIT_SEPARATOR, // popup menu separator - ignored
+		EDIT_CUT_NODES,
+		EDIT_COPY_NODES,
+		EDIT_PASTE_NODES,
 		EDIT_DELETE_NODES,
+		EDIT_DUPLICATE_NODES,
+		EDIT_CLEAR_COPY_BUFFER,
+
+		EDIT_CREATE_FUNCTION,
 		EDIT_TOGGLE_BREAKPOINT,
 		EDIT_FIND_NODE_TYPE,
-		EDIT_COPY_NODES,
-		EDIT_CUT_NODES,
-		EDIT_PASTE_NODES,
-		EDIT_CREATE_FUNCTION,
 		REFRESH_GRAPH,
 	};
 
@@ -123,7 +128,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	Label *select_func_text;
 
-	bool updating_graph;
+	bool updating_graph = false;
 
 	void _show_hint(const String &p_hint);
 	void _hide_timer();
@@ -162,7 +167,8 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	static Clipboard *clipboard;
 
-	PopupMenu *member_popup;
+	PopupMenu *popup_menu = nullptr;
+	PopupMenu *member_popup = nullptr;
 	MemberType member_type;
 	String member_name;
 
@@ -172,8 +178,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 	Vector2 port_action_pos;
 	int port_action_new_node;
 
-	bool saved_pos_dirty;
-	Vector2 saved_position;
+	bool saved_pos_dirty = false;
 
 	Vector2 mouse_up_position;
 


### PR DESCRIPTION
Adds a menu similar to the existing one in VisualShader:

![vst_context_menu](https://user-images.githubusercontent.com/3036176/148690683-524254f7-e53f-4c3a-8528-c39a7e9bd8d6.gif)

