### PR TITLE
Fix Tween pause behavior

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -303,16 +303,19 @@
 	</signals>
 	<constants>
 		<constant name="TWEEN_PROCESS_PHYSICS" value="0" enum="TweenProcessMode">
-			The [Tween] updates during physics frame.
+			The [Tween] updates during the physics frame.
 		</constant>
 		<constant name="TWEEN_PROCESS_IDLE" value="1" enum="TweenProcessMode">
-			The [Tween] updates during idle
+			The [Tween] updates during the idle frame.
 		</constant>
 		<constant name="TWEEN_PAUSE_BOUND" value="0" enum="TweenPauseMode">
+			If the [Tween] has a bound node, it will process when that node can process (see [member Node.process_mode]). Otherwise it's the same as [constant TWEEN_PAUSE_STOP].
 		</constant>
 		<constant name="TWEEN_PAUSE_STOP" value="1" enum="TweenPauseMode">
+			If [SceneTree] is paused, the [Tween] will also pause.
 		</constant>
 		<constant name="TWEEN_PAUSE_PROCESS" value="2" enum="TweenPauseMode">
+			The [Tween] will process regardless of whether [SceneTree] is paused.
 		</constant>
 		<constant name="TRANS_LINEAR" value="0" enum="TransitionType">
 		</constant>

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -260,10 +260,8 @@ bool Tween::step(float p_delta) {
 	}
 
 	if (is_bound) {
-		Object *bound_instance = ObjectDB::get_instance(bound_node);
-		if (bound_instance) {
-			Node *bound_node = Object::cast_to<Node>(bound_instance);
-			// This can't by anything else than Node, so we can omit checking if casting succeeded.
+		Node *bound_node = get_bound_node();
+		if (bound_node) {
 			if (!bound_node->is_inside_tree()) {
 				return true;
 			}
@@ -320,16 +318,23 @@ bool Tween::step(float p_delta) {
 	return true;
 }
 
-bool Tween::should_pause() {
+bool Tween::can_process(bool p_tree_paused) const {
 	if (is_bound && pause_mode == TWEEN_PAUSE_BOUND) {
-		Object *bound_instance = ObjectDB::get_instance(bound_node);
-		if (bound_instance) {
-			Node *bound_node = Object::cast_to<Node>(bound_instance);
-			return !bound_node->can_process();
+		Node *bound_node = get_bound_node();
+		if (bound_node) {
+			return bound_node->can_process();
 		}
 	}
 
-	return pause_mode != TWEEN_PAUSE_PROCESS;
+	return !p_tree_paused || pause_mode == TWEEN_PAUSE_PROCESS;
+}
+
+Node *Tween::get_bound_node() const {
+	if (is_bound) {
+		return Object::cast_to<Node>(ObjectDB::get_instance(bound_node));
+	} else {
+		return nullptr;
+	}
 }
 
 real_t Tween::run_equation(TransitionType p_trans_type, EaseType p_ease_type, real_t p_time, real_t p_initial, real_t p_delta, real_t p_duration) {

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -97,7 +97,7 @@ public:
 
 private:
 	TweenProcessMode process_mode = TweenProcessMode::TWEEN_PROCESS_IDLE;
-	TweenPauseMode pause_mode = TweenPauseMode::TWEEN_PAUSE_STOP;
+	TweenPauseMode pause_mode = TweenPauseMode::TWEEN_PAUSE_BOUND;
 	TransitionType default_transition = TransitionType::TRANS_LINEAR;
 	EaseType default_ease = EaseType::EASE_IN_OUT;
 	ObjectID bound_node;
@@ -164,7 +164,8 @@ public:
 	Variant calculate_delta_value(Variant p_intial_val, Variant p_final_val);
 
 	bool step(float p_delta);
-	bool should_pause();
+	bool can_process(bool p_tree_paused) const;
+	Node *get_bound_node() const;
 
 	Tween() {}
 };

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -535,7 +535,7 @@ void SceneTree::process_tweens(float p_delta, bool p_physics) {
 	for (List<Ref<Tween>>::Element *E = tweens.front(); E;) {
 		List<Ref<Tween>>::Element *N = E->next();
 		// Don't process if paused or process mode doesn't match.
-		if ((paused && E->get()->should_pause()) || (p_physics == (E->get()->get_process_mode() == Tween::TWEEN_PROCESS_IDLE))) {
+		if (!E->get()->can_process(paused) || (p_physics == (E->get()->get_process_mode() == Tween::TWEEN_PROCESS_IDLE))) {
 			if (E == L) {
 				break;
 			}


### PR DESCRIPTION
Seems like Tween didn't use bound node's pause mode properly. Also the pause mode wrongly defaulted to `TWEEN_PAUSE_STOP`. I fixed that and simplified some code.
Fixes #56642

I also added description for pause mode constants. Not sure why were they missing, I'm fairly sure I wrote them already at some point 🙃