### PR TITLE
Fix glyph index for bitmap fonts and glyph positions in the TextEdit.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2573,7 +2573,7 @@ int32_t TextServerAdvanced::font_get_glyph_index(RID p_font_rid, int p_size, cha
 			return FT_Get_Char_Index(fd->cache[size]->face, p_char);
 		}
 	} else {
-		return 0;
+		return (int32_t)p_char;
 	}
 #else
 	return (int32_t)p_char;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1135,7 +1135,7 @@ void TextEdit::_notification(int p_what) {
 					int first_visible_char = TS->shaped_text_get_range(rid).y;
 					int last_visible_char = TS->shaped_text_get_range(rid).x;
 
-					int char_ofs = 0;
+					float char_ofs = 0;
 					if (outline_size > 0 && outline_color.a > 0) {
 						for (int j = 0; j < gl_size; j++) {
 							for (int k = 0; k < glyphs[j].repeat; k++) {
@@ -1170,7 +1170,7 @@ void TextEdit::_notification(int p_what) {
 							}
 						}
 
-						int char_pos = char_ofs + char_margin + ofs_x;
+						float char_pos = char_ofs + char_margin + ofs_x;
 						if (char_pos >= xmargin_beg) {
 							if (highlight_matching_braces_enabled) {
 								if ((brace_open_match_line == line && brace_open_match_column == glyphs[j].start) ||


### PR DESCRIPTION
- Fix glyph index for bitmap fonts (#56348).
- Fix TextEdit glyph position rounding (follow up #55905, makes TextEdit to use `float` glyph positions).
To keep glyphs sharp, `draw_glyph` do rounding in some cases (we probably should use FreeType sub-pixel positioning, since rounding can cause uneven spacing with some fonts/scales). But in general glyph positions can be non-integer because of hinting and oversampling, also there's no need to round positions for MSDF fonts, and it should be taken ito account when calculating next glyph position.

Fixes #56607, fixes #55996, fixes #56348

