### PR TITLE
Fix leak when function returning self type

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2069,7 +2069,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 	if (p_func) {
 		// if no return statement -> return type is void not unresolved Variant
 		if (p_func->body->has_return) {
-			gd_function->return_type = _gdtype_from_datatype(p_func->get_datatype());
+			gd_function->return_type = _gdtype_from_datatype(p_func->get_datatype(), p_script);
 		} else {
 			gd_function->return_type = GDScriptDataType();
 			gd_function->return_type.has_type = true;


### PR DESCRIPTION
Fixes #56576

Leak is caused by cyclic reference.

Passing `p_script` into `_gdtype_from_datatype` enables a check to disable references if the data type is the same as `p_script`.

