### PR TITLE
Fix button multiline text alignment.

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -302,6 +302,8 @@ void Button::_notification(int p_what) {
 
 			Point2 text_ofs = (size - style->get_minimum_size() - icon_ofs - text_buf->get_size() - Point2(_internal_margin[SIDE_RIGHT] - _internal_margin[SIDE_LEFT], 0)) / 2.0;
 
+			text_buf->set_alignment(align_rtl_checked);
+			text_buf->set_width(text_width);
 			switch (align_rtl_checked) {
 				case HORIZONTAL_ALIGNMENT_FILL:
 				case HORIZONTAL_ALIGNMENT_LEFT: {


### PR DESCRIPTION
<img width="191" alt="Screenshot 2022-01-09 at 21 24 45" src="https://user-images.githubusercontent.com/7645683/148697563-6c42cf1a-420d-4e0f-b373-8b2aaf3d64a6.png">


Fixes #56653