### PR TITLE
Fix crash on importing FBX file

### DIFF
--- a/core/templates/set.h
+++ b/core/templates/set.h
@@ -582,6 +582,9 @@ public:
 	}
 
 	Element *lower_bound(const T &p_value) const {
+		if (!_data._root) {
+			return nullptr;
+		}
 		return _lower_bound(p_value);
 	}
 

--- a/modules/fbx/data/fbx_mesh_data.cpp
+++ b/modules/fbx/data/fbx_mesh_data.cpp
@@ -1092,7 +1092,7 @@ HashMap<int, R> FBXMeshData::extract_per_vertex_data(
 					const int vertex_index = get_vertex_from_polygon_vertex(p_mesh_indices, polygon_vertex_index);
 					ERR_FAIL_COND_V_MSG(vertex_index < 0, (HashMap<int, R>()), "FBX file corrupted: #ERR05");
 					ERR_FAIL_COND_V_MSG(vertex_index >= p_vertex_count, (HashMap<int, R>()), "FBX file corrupted: #ERR06");
-					const int index_to_direct = p_mapping_data.index[polygon_vertex_index];
+					const int index_to_direct = get_vertex_from_polygon_vertex(p_mapping_data.index, polygon_vertex_index);
 					T value = p_mapping_data.data[index_to_direct];
 					aggregate_vertex_data[vertex_index].push_back({ polygon_id, value });
 				}
@@ -1297,7 +1297,7 @@ HashMap<int, T> FBXMeshData::extract_per_polygon(
 					} else {
 						ERR_FAIL_INDEX_V_MSG(polygon_index, (int)p_fbx_data.index.size(), (HashMap<int, T>()), "FBX file is corrupted: #ERR62");
 
-						const int index_to_direct = p_fbx_data.index[polygon_index];
+						const int index_to_direct = get_vertex_from_polygon_vertex(p_fbx_data.index, polygon_index);
 						T value = p_fbx_data.data[index_to_direct];
 						aggregate_polygon_data[polygon_index].push_back(value);
 					}


### PR DESCRIPTION
Fixes #51373

* Null pointer access when calling `Set::lower_bound` on empty sets.
* Some branches did not handle negative polygon index.