### PR TITLE
[macOS export] Improve code signing/notarization options validation.

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -265,10 +265,25 @@ void ProjectExportDialog::_edit_preset(int p_index) {
 			export_templates_error->hide();
 		}
 
+		export_warning->hide();
 		export_button->set_disabled(true);
 		get_ok_button()->set_disabled(true);
-
 	} else {
+		if (error != String()) {
+			Vector<String> items = error.split("\n", false);
+			error = "";
+			for (int i = 0; i < items.size(); i++) {
+				if (i > 0) {
+					error += "\n";
+				}
+				error += " - " + items[i];
+			}
+			export_warning->set_text(error);
+			export_warning->show();
+		} else {
+			export_warning->hide();
+		}
+
 		export_error->hide();
 		export_templates_error->hide();
 		export_button->set_disabled(false);
@@ -1246,6 +1261,11 @@ ProjectExportDialog::ProjectExportDialog() {
 	main_vb->add_child(export_error);
 	export_error->hide();
 	export_error->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
+
+	export_warning = memnew(Label);
+	main_vb->add_child(export_warning);
+	export_warning->hide();
+	export_warning->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 
 	export_templates_error = memnew(HBoxContainer);
 	main_vb->add_child(export_templates_error);

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -99,6 +99,7 @@ private:
 	Label *script_key_error;
 
 	Label *export_error;
+	Label *export_warning;
 	HBoxContainer *export_templates_error;
 
 	String default_filename;


### PR DESCRIPTION
Adds warning for incompatible and non-optimal configs.
Automatically ignore hardened runtime and timestamp when using ad-hoc signature.

![Screenshot 2022-01-10 at 13 16 23](https://user-images.githubusercontent.com/7645683/148758074-2d35dbb8-59b6-4066-99a5-5c351d757b51.png)

Fixes #56392