### PR TITLE
Increase joystick max button number and fix crash.

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -892,7 +892,8 @@ void Input::set_event_dispatch_function(EventDispatchFunc p_function) {
 void Input::joy_button(int p_device, JoyButton p_button, bool p_pressed) {
 	_THREAD_SAFE_METHOD_;
 	Joypad &joy = joy_names[p_device];
-	//printf("got button %i, mapping is %i\n", p_button, joy.mapping);
+	ERR_FAIL_INDEX((int)p_button, (int)JoyButton::MAX);
+
 	if (joy.last_buttons[(size_t)p_button] == p_pressed) {
 		return;
 	}

--- a/core/input/input_enums.h
+++ b/core/input/input_enums.h
@@ -83,7 +83,7 @@ enum class JoyButton {
 	PADDLE4 = 19,
 	TOUCHPAD = 20,
 	SDL_MAX = 21,
-	MAX = 36, // Android supports up to 36 buttons.
+	MAX = 128, // Android supports up to 36 buttons. DirectInput supports up to 128 buttons.
 };
 
 enum class MIDIMessage {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -2134,8 +2134,11 @@
 		<constant name="JOY_BUTTON_SDL_MAX" value="21" enum="JoyButton">
 			The number of SDL game controller buttons.
 		</constant>
-		<constant name="JOY_BUTTON_MAX" value="36" enum="JoyButton">
-			The maximum number of game controller buttons: Android supports up to 36 buttons.
+		<constant name="JOY_BUTTON_MAX" value="128" enum="JoyButton">
+			The maximum number of game controller buttons supported by the engine. The actual limit may be lower on specific platforms:
+			- Android: Up to 36 buttons.
+			- Linux: Up to 80 buttons.
+			- Windows and macOS: Up to 128 buttons.
 		</constant>
 		<constant name="JOY_AXIS_INVALID" value="-1" enum="JoyAxis">
 			An invalid game controller axis.


### PR DESCRIPTION
- Add joystick button index boundary check. 
- Increase max. button number to 128 (max. buttons supported by DirectInput).

Notes: 
- macOS joystick API do not have a defined button/axis limit.
- Linux apparently is limited to 80 (see [this kernel patch for 104 button device](https://patchwork.kernel.org/project/linux-input/patch/CACa7zykn0q9XJAUvrqnNATr4DUv3Kc7XujF3vm6sfRB5pE6YNQ@mail.gmail.com/)).
- It's unlikely any device will have more buttons than supported on Windows.

Fixes #56203
