### PR TITLE
Optimize include files to improve `shader_language.h` compilation speed

### DIFF
--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -205,7 +205,7 @@ void ShaderTextEditor::_check_shader_mode() {
 
 static ShaderLanguage::DataType _get_global_variable_type(const StringName &p_variable) {
 	RS::GlobalVariableType gvt = RS::get_singleton()->global_variable_get_type(p_variable);
-	return RS::global_variable_type_get_shader_datatype(gvt);
+	return (ShaderLanguage::DataType)RS::global_variable_type_get_shader_datatype(gvt);
 }
 
 void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptCodeCompletionOption> *r_options) {

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -40,7 +40,7 @@
 #include "scene/gui/text_edit.h"
 #include "scene/main/timer.h"
 #include "scene/resources/shader.h"
-#include "servers/rendering/shader_language.h"
+#include "servers/rendering/shader_warnings.h"
 
 class ShaderTextEditor : public CodeTextEditor {
 	GDCLASS(ShaderTextEditor, CodeTextEditor);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -3914,7 +3914,7 @@ void VisualShaderEditor::_preview_size_changed() {
 
 static ShaderLanguage::DataType _get_global_variable_type(const StringName &p_variable) {
 	RS::GlobalVariableType gvt = RS::get_singleton()->global_variable_get_type(p_variable);
-	return RS::global_variable_type_get_shader_datatype(gvt);
+	return (ShaderLanguage::DataType)RS::global_variable_type_get_shader_datatype(gvt);
 }
 
 void VisualShaderEditor::_update_preview() {

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -30,6 +30,7 @@
 
 #include "shader_globals_editor.h"
 #include "editor_node.h"
+#include "servers/rendering/shader_language.h"
 
 static const char *global_var_type_names[RS::GLOBAL_VAR_TYPE_MAX] = {
 	"bool",

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -35,7 +35,6 @@
 #include "core/templates/self_list.h"
 #include "scene/resources/shader.h"
 #include "scene/resources/texture.h"
-#include "servers/rendering/shader_language.h"
 #include "servers/rendering_server.h"
 
 class Material : public Resource {

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
+#include "servers/rendering/shader_types.h"
 #include "servers/rendering_server.h"
 
 #define SL ShaderLanguage
@@ -1333,7 +1334,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 
 ShaderLanguage::DataType ShaderCompiler::_get_variable_type(const StringName &p_type) {
 	RS::GlobalVariableType gvt = RS::get_singleton()->global_variable_get_type(p_type);
-	return RS::global_variable_type_get_shader_datatype(gvt);
+	return (ShaderLanguage::DataType)RS::global_variable_type_get_shader_datatype(gvt);
 }
 
 Error ShaderCompiler::compile(RS::ShaderMode p_mode, const String &p_code, IdentifierActions *p_actions, const String &p_path, GeneratedCode &r_gen_code) {

--- a/servers/rendering/shader_compiler.h
+++ b/servers/rendering/shader_compiler.h
@@ -33,7 +33,6 @@
 
 #include "core/templates/pair.h"
 #include "servers/rendering/shader_language.h"
-#include "servers/rendering/shader_types.h"
 #include "servers/rendering_server.h"
 
 class ShaderCompiler {

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -32,6 +32,7 @@
 
 #include "core/config/project_settings.h"
 #include "servers/rendering/rendering_server_globals.h"
+#include "servers/rendering/shader_language.h"
 
 RenderingServer *RenderingServer::singleton = nullptr;
 RenderingServer *(*RenderingServer::create_func)() = nullptr;
@@ -1411,7 +1412,7 @@ Array RenderingServer::_mesh_surface_get_skeleton_aabb_bind(RID p_mesh, int p_su
 }
 #endif
 
-ShaderLanguage::DataType RenderingServer::global_variable_type_get_shader_datatype(GlobalVariableType p_type) {
+int RenderingServer::global_variable_type_get_shader_datatype(GlobalVariableType p_type) {
 	switch (p_type) {
 		case RS::GLOBAL_VAR_TYPE_BOOL:
 			return ShaderLanguage::TYPE_BOOL;

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -41,7 +41,6 @@
 #include "servers/display_server.h"
 #include "servers/rendering/renderer_thread_pool.h"
 #include "servers/rendering/rendering_device.h"
-#include "servers/rendering/shader_language.h"
 
 class RenderingServer : public Object {
 	GDCLASS(RenderingServer, Object);
@@ -1456,7 +1455,7 @@ public:
 	virtual void global_variables_load_settings(bool p_load_textures) = 0;
 	virtual void global_variables_clear() = 0;
 
-	static ShaderLanguage::DataType global_variable_type_get_shader_datatype(GlobalVariableType p_type);
+	static int global_variable_type_get_shader_datatype(GlobalVariableType p_type);
 
 	/* FREE */
 


### PR DESCRIPTION
This will remove the inclusion of the `shader_language.h` from `rendering_server.h` which only used it in `global_variable_type_get_shader_datatype`  and also from `material.h`. ~To prevent errors I've separated `DataType` from `ShaderLanguage` into a new file.~

Time build on my PC (Win10, Corei7-5930k) after simple change in `shader_language.h`,
Before:
![image](https://user-images.githubusercontent.com/3036176/148822128-a94f30bc-01ce-4488-b68f-98c96556381f.png)

After:
![image](https://user-images.githubusercontent.com/3036176/148822240-38927ffd-7d5d-4c5f-a2e5-101b0ba0d4cd.png)
which is +62.84% faster than before. I am really tired of doing even a small change to this header takes so much time.