### PR TITLE
Issue 56488 fail when image and texture size are different

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2353,6 +2353,9 @@ void TextureLayered::create(uint32_t p_width, uint32_t p_height, uint32_t p_dept
 void TextureLayered::set_layer_data(const Ref<Image> &p_image, int p_layer) {
 	ERR_FAIL_COND(!texture.is_valid());
 	ERR_FAIL_COND(!p_image.is_valid());
+	ERR_FAIL_COND_MSG(
+			p_image->get_size() != Size2(width, height),
+			"Image and texture need to have the same width and height");
 	VS::get_singleton()->texture_set_data(texture, p_image, p_layer);
 }
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
This should fix #56488 . The commit goes to 3.4 since I couldn't find the corresponding `set_layer-data` method in `master`.