### PR TITLE
 [3.x] Fix relative keystore paths on android exporter with custom build

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2985,6 +2985,13 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 					debug_password = EditorSettings::get_singleton()->get("export/android/debug_keystore_pass");
 					debug_user = EditorSettings::get_singleton()->get("export/android/debug_keystore_user");
 				}
+				if (debug_keystore.is_rel_path()) {
+					debug_keystore = OS::get_singleton()->get_resource_dir().plus_file(debug_keystore).simplify_path();
+				}
+				if (!FileAccess::exists(debug_keystore)) {
+					EditorNode::add_io_error(TTR("Could not find keystore, unable to export."));
+					return ERR_FILE_CANT_OPEN;
+				}
 
 				cmdline.push_back("-Pdebug_keystore_file=" + debug_keystore); // argument to specify the debug keystore file.
 				cmdline.push_back("-Pdebug_keystore_alias=" + debug_user); // argument to specify the debug keystore alias.
@@ -2994,6 +3001,9 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 				String release_keystore = p_preset->get("keystore/release");
 				String release_username = p_preset->get("keystore/release_user");
 				String release_password = p_preset->get("keystore/release_password");
+				if (release_keystore.is_rel_path()) {
+					release_keystore = OS::get_singleton()->get_resource_dir().plus_file(release_keystore).simplify_path();
+				}
 				if (!FileAccess::exists(release_keystore)) {
 					EditorNode::add_io_error(TTR("Could not find keystore, unable to export."));
 					return ERR_FILE_CANT_OPEN;


### PR DESCRIPTION
Cherry pick of #56673

If you use a relative path for the release and debug keystores in an Android exporter with 'custom build' enabled, godot will pass those relative paths to gradlew, which interprets them as being relative to res://android/build, but godot's export window itself thinks those paths are relative to res://. This means godot's UI will say you cannot export, but if you run godot --export, it will actually succeed, OR godot will think the paths are correct, but then gradle will fail to find the keystores.

This pull request converts relative paths to absolute paths before sending them to gradlew.