### PR TITLE
Fix conflicting module import in template generation python file

### DIFF
--- a/modules/gdscript/editor_templates/SCsub
+++ b/modules/gdscript/editor_templates/SCsub
@@ -2,7 +2,13 @@
 
 Import("env")
 
-import editor.template_builders as build_template_gd
+# Using importlib package and relative path to prevent conflicts with other external
+# python packages named "editor" while trying to import template_builders.
+import importlib.util
+
+spec = importlib.util.spec_from_file_location("editor.template_builders", "../../../editor/template_builders.py")
+build_template_gd = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(build_template_gd)
 
 env["BUILDERS"]["MakeGDTemplateBuilder"] = Builder(
     action=env.Run(build_template_gd.make_templates, "Generating GDScript templates header."),

--- a/modules/mono/editor_templates/SCsub
+++ b/modules/mono/editor_templates/SCsub
@@ -2,7 +2,13 @@
 
 Import("env")
 
-import editor.template_builders as build_template_cs
+# Using importlib package and relative path to prevent conflicts with other external
+# python packages named "editor" while trying to import template_builders.
+import importlib.util
+
+spec = importlib.util.spec_from_file_location("editor.template_builders", "../../../editor/template_builders.py")
+build_template_cs = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(build_template_cs)
 
 env["BUILDERS"]["MakeCSharpTemplateBuilder"] = Builder(
     action=env.Run(build_template_cs.make_templates, "Generating C# templates header."),


### PR DESCRIPTION
Fixes #56652

### Issue description

While compiling with scons and building template header file, an error occurs if the user has a python module named editor.py in his configuration.

### Fix proposal

Use the relative path of the file that we really want to import.

### Before

![image](https://user-images.githubusercontent.com/3649998/148930293-cc556300-0eed-4965-853c-c8054205d9c5.png)

### After

![image](https://user-images.githubusercontent.com/3649998/148930368-309e2a3a-36a1-4a81-8712-8fe36bb88590.png)

