### PR TITLE
i18n: Make VisualScript node caption & text translatable

### DIFF
--- a/modules/visual_script/visual_script_expression.cpp
+++ b/modules/visual_script/visual_script_expression.cpp
@@ -176,7 +176,7 @@ PropertyInfo VisualScriptExpression::get_output_value_port_info(int p_idx) const
 }
 
 String VisualScriptExpression::get_caption() const {
-	return "Expression";
+	return TTR("Expression");
 }
 
 String VisualScriptExpression::get_text() const {

--- a/modules/visual_script/visual_script_flow_control.cpp
+++ b/modules/visual_script/visual_script_flow_control.cpp
@@ -70,7 +70,7 @@ PropertyInfo VisualScriptReturn::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptReturn::get_caption() const {
-	return "Return";
+	return TTR("Return");
 }
 
 String VisualScriptReturn::get_text() const {
@@ -201,11 +201,11 @@ PropertyInfo VisualScriptCondition::get_output_value_port_info(int p_idx) const 
 }
 
 String VisualScriptCondition::get_caption() const {
-	return "Condition";
+	return TTR("Condition");
 }
 
 String VisualScriptCondition::get_text() const {
-	return "if (cond) is:  ";
+	return TTR("if (cond) is:");
 }
 
 void VisualScriptCondition::_bind_methods() {
@@ -281,11 +281,11 @@ PropertyInfo VisualScriptWhile::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptWhile::get_caption() const {
-	return "While";
+	return TTR("While");
 }
 
 String VisualScriptWhile::get_text() const {
-	return "while (cond): ";
+	return TTR("while (cond):");
 }
 
 void VisualScriptWhile::_bind_methods() {
@@ -364,11 +364,11 @@ PropertyInfo VisualScriptIterator::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptIterator::get_caption() const {
-	return "Iterator";
+	return TTR("Iterator");
 }
 
 String VisualScriptIterator::get_text() const {
-	return "for (elem) in (input): ";
+	return TTR("for (elem) in (input):");
 }
 
 void VisualScriptIterator::_bind_methods() {
@@ -478,11 +478,11 @@ PropertyInfo VisualScriptSequence::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptSequence::get_caption() const {
-	return "Sequence";
+	return TTR("Sequence");
 }
 
 String VisualScriptSequence::get_text() const {
-	return "in order: ";
+	return TTR("in order:");
 }
 
 void VisualScriptSequence::set_steps(int p_steps) {
@@ -587,11 +587,11 @@ PropertyInfo VisualScriptSwitch::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptSwitch::get_caption() const {
-	return "Switch";
+	return TTR("Switch");
 }
 
 String VisualScriptSwitch::get_text() const {
-	return "'input' is:";
+	return TTR("'input' is:");
 }
 
 class VisualScriptNodeInstanceSwitch : public VisualScriptNodeInstance {
@@ -720,14 +720,14 @@ PropertyInfo VisualScriptTypeCast::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptTypeCast::get_caption() const {
-	return "Type Cast";
+	return TTR("Type Cast");
 }
 
 String VisualScriptTypeCast::get_text() const {
 	if (!script.is_empty()) {
-		return "Is " + script.get_file() + "?";
+		return vformat(TTR("Is %s?"), script.get_file());
 	} else {
-		return "Is " + base_type + "?";
+		return vformat(TTR("Is %s?"), base_type);
 	}
 }
 

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -261,13 +261,13 @@ String VisualScriptFunctionCall::get_text() const {
 	String text;
 
 	if (call_mode == CALL_MODE_BASIC_TYPE) {
-		text = String("On ") + Variant::get_type_name(basic_type);
+		text = vformat(TTR("On %s"), Variant::get_type_name(basic_type));
 	} else if (call_mode == CALL_MODE_INSTANCE) {
-		text = String("On ") + base_type;
+		text = vformat(TTR("On %s"), base_type);
 	} else if (call_mode == CALL_MODE_NODE_PATH) {
 		text = "[" + String(base_path.simplified()) + "]";
 	} else if (call_mode == CALL_MODE_SELF) {
-		text = "On Self";
+		text = TTR("On Self");
 	} else if (call_mode == CALL_MODE_SINGLETON) {
 		text = String(singleton) + ":" + String(function) + "()";
 	}
@@ -1033,15 +1033,25 @@ PropertyInfo VisualScriptPropertySet::get_output_value_port_info(int p_idx) cons
 
 String VisualScriptPropertySet::get_caption() const {
 	static const char *opname[ASSIGN_OP_MAX] = {
-		"Set", "Add", "Subtract", "Multiply", "Divide", "Mod", "ShiftLeft", "ShiftRight", "BitAnd", "BitOr", "BitXor"
+		TTRC("Set %s"),
+		TTRC("Add %s"),
+		TTRC("Subtract %s"),
+		TTRC("Multiply %s"),
+		TTRC("Divide %s"),
+		TTRC("Mod %s"),
+		TTRC("ShiftLeft %s"),
+		TTRC("ShiftRight %s"),
+		TTRC("BitAnd %s"),
+		TTRC("BitOr %s"),
+		TTRC("BitXor %s")
 	};
 
-	String prop = String(opname[assign_op]) + " " + property;
+	String prop = property;
 	if (index != StringName()) {
 		prop += "." + String(index);
 	}
 
-	return prop;
+	return vformat(TTRGET(opname[assign_op]), prop);
 }
 
 String VisualScriptPropertySet::get_text() const {
@@ -1049,13 +1059,13 @@ String VisualScriptPropertySet::get_text() const {
 		return "";
 	}
 	if (call_mode == CALL_MODE_BASIC_TYPE) {
-		return String("On ") + Variant::get_type_name(basic_type);
+		return vformat(TTR("On %s"), Variant::get_type_name(basic_type));
 	} else if (call_mode == CALL_MODE_INSTANCE) {
-		return String("On ") + base_type;
+		return vformat(TTR("On %s"), base_type);
 	} else if (call_mode == CALL_MODE_NODE_PATH) {
 		return " [" + String(base_path.simplified()) + "]";
 	} else {
-		return "On Self";
+		return TTR("On Self");
 	}
 }
 
@@ -1761,23 +1771,23 @@ PropertyInfo VisualScriptPropertyGet::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptPropertyGet::get_caption() const {
-	String prop = String("Get ") + property;
+	String prop = property;
 	if (index != StringName()) {
 		prop += "." + String(index);
 	}
 
-	return prop;
+	return vformat(TTR("Get %s"), prop);
 }
 
 String VisualScriptPropertyGet::get_text() const {
 	if (call_mode == CALL_MODE_BASIC_TYPE) {
-		return String("On ") + Variant::get_type_name(basic_type);
+		return vformat(TTR("On %s"), Variant::get_type_name(basic_type));
 	} else if (call_mode == CALL_MODE_INSTANCE) {
-		return String("On ") + base_type;
+		return vformat(TTR("On %s"), base_type);
 	} else if (call_mode == CALL_MODE_NODE_PATH) {
 		return " [" + String(base_path.simplified()) + "]";
 	} else {
-		return "On Self";
+		return TTR("On Self");
 	}
 }
 
@@ -2293,7 +2303,7 @@ PropertyInfo VisualScriptEmitSignal::get_output_value_port_info(int p_idx) const
 }
 
 String VisualScriptEmitSignal::get_caption() const {
-	return "Emit " + String(name);
+	return vformat(TTR("Emit %s"), name);
 }
 
 void VisualScriptEmitSignal::set_signal(const StringName &p_type) {

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -204,7 +204,7 @@ PropertyInfo VisualScriptFunction::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptFunction::get_caption() const {
-	return "Function";
+	return TTR("Function");
 }
 
 String VisualScriptFunction::get_text() const {
@@ -767,7 +767,7 @@ PropertyInfo VisualScriptComposeArray::get_output_value_port_info(int p_idx) con
 }
 
 String VisualScriptComposeArray::get_caption() const {
-	return "Compose Array";
+	return TTR("Compose Array");
 }
 
 String VisualScriptComposeArray::get_text() const {
@@ -1186,11 +1186,11 @@ PropertyInfo VisualScriptSelect::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptSelect::get_caption() const {
-	return "Select";
+	return TTR("Select");
 }
 
 String VisualScriptSelect::get_text() const {
-	return "a if cond, else b";
+	return TTR("a if cond, else b");
 }
 
 void VisualScriptSelect::set_typed(Variant::Type p_op) {
@@ -1284,7 +1284,7 @@ PropertyInfo VisualScriptVariableGet::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptVariableGet::get_caption() const {
-	return "Get " + variable;
+	return vformat(TTR("Get %s"), variable);
 }
 
 void VisualScriptVariableGet::set_variable(StringName p_variable) {
@@ -1394,7 +1394,7 @@ PropertyInfo VisualScriptVariableSet::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptVariableSet::get_caption() const {
-	return "Set " + variable;
+	return vformat(TTR("Set %s"), variable);
 }
 
 void VisualScriptVariableSet::set_variable(StringName p_variable) {
@@ -1501,7 +1501,7 @@ PropertyInfo VisualScriptConstant::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptConstant::get_caption() const {
-	return "Constant";
+	return TTR("Constant");
 }
 
 void VisualScriptConstant::set_constant_type(Variant::Type p_type) {
@@ -1628,7 +1628,7 @@ PropertyInfo VisualScriptPreload::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptPreload::get_caption() const {
-	return "Preload";
+	return TTR("Preload");
 }
 
 void VisualScriptPreload::set_preload(const Ref<Resource> &p_preload) {
@@ -1708,7 +1708,7 @@ PropertyInfo VisualScriptIndexGet::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptIndexGet::get_caption() const {
-	return "Get Index";
+	return TTR("Get Index");
 }
 
 class VisualScriptNodeInstanceIndexGet : public VisualScriptNodeInstance {
@@ -1775,7 +1775,7 @@ PropertyInfo VisualScriptIndexSet::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptIndexSet::get_caption() const {
-	return "Set Index";
+	return TTR("Set Index");
 }
 
 class VisualScriptNodeInstanceIndexSet : public VisualScriptNodeInstance {
@@ -1839,7 +1839,7 @@ PropertyInfo VisualScriptGlobalConstant::get_output_value_port_info(int p_idx) c
 }
 
 String VisualScriptGlobalConstant::get_caption() const {
-	return "Global Constant";
+	return TTR("Global Constant");
 }
 
 void VisualScriptGlobalConstant::set_global_constant(int p_which) {
@@ -1925,7 +1925,7 @@ PropertyInfo VisualScriptClassConstant::get_output_value_port_info(int p_idx) co
 }
 
 String VisualScriptClassConstant::get_caption() const {
-	return "Class Constant";
+	return TTR("Class Constant");
 }
 
 void VisualScriptClassConstant::set_class_constant(const StringName &p_which) {
@@ -2050,7 +2050,7 @@ PropertyInfo VisualScriptBasicTypeConstant::get_output_value_port_info(int p_idx
 }
 
 String VisualScriptBasicTypeConstant::get_caption() const {
-	return "Basic Constant";
+	return TTR("Basic Constant");
 }
 
 String VisualScriptBasicTypeConstant::get_text() const {
@@ -2215,7 +2215,7 @@ PropertyInfo VisualScriptMathConstant::get_output_value_port_info(int p_idx) con
 }
 
 String VisualScriptMathConstant::get_caption() const {
-	return "Math Constant";
+	return TTR("Math Constant");
 }
 
 void VisualScriptMathConstant::set_math_constant(MathConstant p_which) {
@@ -2307,7 +2307,7 @@ PropertyInfo VisualScriptEngineSingleton::get_output_value_port_info(int p_idx) 
 }
 
 String VisualScriptEngineSingleton::get_caption() const {
-	return "Get Engine Singleton";
+	return TTR("Get Engine Singleton");
 }
 
 void VisualScriptEngineSingleton::set_singleton(const String &p_string) {
@@ -2417,7 +2417,7 @@ PropertyInfo VisualScriptSceneNode::get_output_value_port_info(int p_idx) const 
 }
 
 String VisualScriptSceneNode::get_caption() const {
-	return "Get Scene Node";
+	return TTR("Get Scene Node");
 }
 
 void VisualScriptSceneNode::set_node_path(const NodePath &p_path) {
@@ -2608,7 +2608,7 @@ PropertyInfo VisualScriptSceneTree::get_output_value_port_info(int p_idx) const 
 }
 
 String VisualScriptSceneTree::get_caption() const {
-	return "Get Scene Tree";
+	return TTR("Get Scene Tree");
 }
 
 class VisualScriptNodeInstanceSceneTree : public VisualScriptNodeInstance {
@@ -2695,7 +2695,7 @@ PropertyInfo VisualScriptResourcePath::get_output_value_port_info(int p_idx) con
 }
 
 String VisualScriptResourcePath::get_caption() const {
-	return "Resource Path";
+	return TTR("Resource Path");
 }
 
 void VisualScriptResourcePath::set_resource_path(const String &p_path) {
@@ -2777,7 +2777,7 @@ PropertyInfo VisualScriptSelf::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptSelf::get_caption() const {
-	return "Get Self";
+	return TTR("Get Self");
 }
 
 class VisualScriptNodeInstanceSelf : public VisualScriptNodeInstance {
@@ -2947,7 +2947,7 @@ String VisualScriptCustomNode::get_caption() const {
 	if (GDVIRTUAL_CALL(_get_caption, ret)) {
 		return ret;
 	}
-	return "CustomNode";
+	return TTR("CustomNode");
 }
 
 String VisualScriptCustomNode::get_text() const {
@@ -3141,7 +3141,7 @@ PropertyInfo VisualScriptSubCall::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptSubCall::get_caption() const {
-	return "SubCall";
+	return TTR("SubCall");
 }
 
 String VisualScriptSubCall::get_text() const {
@@ -3352,7 +3352,7 @@ PropertyInfo VisualScriptConstructor::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptConstructor::get_caption() const {
-	return "Construct " + Variant::get_type_name(type);
+	return vformat(TTR("Construct %s"), Variant::get_type_name(type));
 }
 
 String VisualScriptConstructor::get_category() const {
@@ -3469,7 +3469,7 @@ PropertyInfo VisualScriptLocalVar::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptLocalVar::get_caption() const {
-	return "Get Local Var";
+	return TTR("Get Local Var");
 }
 
 String VisualScriptLocalVar::get_category() const {
@@ -3572,7 +3572,7 @@ PropertyInfo VisualScriptLocalVarSet::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptLocalVarSet::get_caption() const {
-	return "Set Local Var";
+	return TTR("Set Local Var");
 }
 
 String VisualScriptLocalVarSet::get_text() const {
@@ -3696,7 +3696,7 @@ PropertyInfo VisualScriptInputAction::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptInputAction::get_caption() const {
-	return "Action " + name;
+	return vformat(TTR("Action %s"), name);
 }
 
 String VisualScriptInputAction::get_category() const {
@@ -3850,7 +3850,7 @@ PropertyInfo VisualScriptDeconstruct::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptDeconstruct::get_caption() const {
-	return "Deconstruct " + Variant::get_type_name(type);
+	return vformat(TTR("Deconstruct %s"), Variant::get_type_name(type));
 }
 
 String VisualScriptDeconstruct::get_category() const {

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -68,7 +68,7 @@ PropertyInfo VisualScriptYield::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptYield::get_caption() const {
-	return yield_mode == YIELD_RETURN ? "Yield" : "Wait";
+	return yield_mode == YIELD_RETURN ? TTR("Yield") : TTR("Wait");
 }
 
 String VisualScriptYield::get_text() const {
@@ -77,13 +77,13 @@ String VisualScriptYield::get_text() const {
 			return "";
 			break;
 		case YIELD_FRAME:
-			return "Next Frame";
+			return TTR("Next Frame");
 			break;
 		case YIELD_PHYSICS_FRAME:
-			return "Next Physics Frame";
+			return TTR("Next Physics Frame");
 			break;
 		case YIELD_WAIT:
-			return rtos(wait_time) + " sec(s)";
+			return vformat(TTR("%s sec(s)"), rtos(wait_time));
 			break;
 	}
 
@@ -336,12 +336,12 @@ PropertyInfo VisualScriptYieldSignal::get_output_value_port_info(int p_idx) cons
 
 String VisualScriptYieldSignal::get_caption() const {
 	static const char *cname[3] = {
-		"WaitSignal",
-		"WaitNodeSignal",
-		"WaitInstanceSigna;",
+		TTRC("WaitSignal"),
+		TTRC("WaitNodeSignal"),
+		TTRC("WaitInstanceSignal"),
 	};
 
-	return cname[call_mode];
+	return TTRGET(cname[call_mode]);
 }
 
 String VisualScriptYieldSignal::get_text() const {


### PR DESCRIPTION
Using `TTR()` because nodes' caption & text are only used in editor IINM.

Most names in the node creation dialog are deduced and assembled from a "path", like how the Inspector shows property names. They are left as-is, for now.

For a VisualScript like this:

![ksnip_20220111-204925](https://user-images.githubusercontent.com/372476/148951276-696705f4-e2ce-4d4e-9b38-46a5b66c5922.png)

This PR makes it possible to look like this (screenshot with ad-hoc translations in `zh_CN.po`):

![ksnip_20220111-215845](https://user-images.githubusercontent.com/372476/148956244-a4f83fd9-9dc8-47e7-95f4-03dd85207394.png)

