### PR TITLE
Wrong call for create_offscreen_gl

### DIFF
--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -144,7 +144,7 @@ bool GodotJavaWrapper::create_offscreen_gl(JNIEnv *p_env) {
 
 void GodotJavaWrapper::destroy_offscreen_gl(JNIEnv *p_env) {
 	if (_destroy_offscreen_gl) {
-		p_env->CallBooleanMethod(godot_instance, _destroy_offscreen_gl);
+		p_env->CallVoidMethod(godot_instance, _destroy_offscreen_gl);
 	}
 }
 


### PR DESCRIPTION
We need to use `CallVoidMethod` instead of `CallBooleanMethod` to call `create_offscreen_gl`. Ran into this error in my ARCore test application.

Does not apply on master.