### PR TITLE
Improve description of mouse_exited signal

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1113,6 +1113,12 @@
 			<description>
 				Emitted when the mouse leaves the control's [code]Rect[/code] area, provided its [member mouse_filter] lets the event reach it.
 				[b]Note:[/b] [signal mouse_exited] will be emitted if the mouse enters a child [Control] node, even if the mouse cursor is still inside the parent's [code]Rect[/code] area.
+				If you want to check whether the mouse truly left the area, ignoring any top nodes, you can use code like this:
+				[codeblock]
+				func _on_mouse_exited():
+				    if not Rect2(Vector2(), rect_size).has_point(get_local_mouse_position()):
+				        # Not hovering over area.
+				[/codeblock]
 			</description>
 		</signal>
 		<signal name="resized">


### PR DESCRIPTION
Resolves #16854

When mouse moves, viewport will look for a control under the cursor. If it's different than the currently hovered one, the signal will be emitted. Given this, there is no way to improve this signal without hurting performance. Thus documenting a simple workaround should be enough to solve the issue.