### PR TITLE
List `AnimatedSprite3D` in `SpriteFrames` description

### DIFF
--- a/doc/classes/SpriteFrames.xml
+++ b/doc/classes/SpriteFrames.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="SpriteFrames" inherits="Resource" version="4.0">
 	<brief_description>
-		Sprite frame library for AnimatedSprite2D.
+		Sprite frame library for AnimatedSprite2D and AnimatedSprite3D.
 	</brief_description>
 	<description>
-		Sprite frame library for [AnimatedSprite2D]. Contains frames and animation data for playback.
+		Sprite frame library for an [AnimatedSprite2D] or [AnimatedSprite3D] node. Contains frames and animation data for playback.
 		[b]Note:[/b] You can associate a set of normal or specular maps by creating additional [SpriteFrames] resources with a [code]_normal[/code] or [code]_specular[/code] suffix. For example, having 3 [SpriteFrames] resources [code]run[/code], [code]run_normal[/code], and [code]run_specular[/code] will make it so the [code]run[/code] animation uses normal and specular maps.
 	</description>
 	<tutorials>


### PR DESCRIPTION
Both `AnimatedSprite2D` and `AnimatedSprite3D` use a `SpriteFrames` resource, but the `SpriteFrames`
class description currently only lists being used with the 2D variant.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
