### PR TITLE
Fix wrong RGBA channel mapping when saving OpenEXR.

### DIFF
--- a/modules/tinyexr/image_saver_tinyexr.cpp
+++ b/modules/tinyexr/image_saver_tinyexr.cpp
@@ -173,7 +173,7 @@ Error save_exr(const String &p_path, const Ref<Image> &p_img, bool p_grayscale) 
 		{ 0 }, // R
 		{ 1, 0 }, // GR
 		{ 2, 1, 0 }, // BGR
-		{ 2, 1, 0, 3 } // BGRA
+		{ 3, 2, 1, 0 } // ABGR
 	};
 
 	int channel_count = get_channel_count(format);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/55472

This is not broken in Godot Engine 4.0.