### PR TITLE
[macOS] Fix OpenGL color space on HDR displays.

### DIFF
--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -3575,6 +3575,7 @@ DisplayServerOSX::WindowID DisplayServerOSX::_create_window(WindowMode p_mode, V
 		[wd.window_object setDelegate:wd.window_delegate];
 		[wd.window_object setAcceptsMouseMovedEvents:YES];
 		[wd.window_object setRestorable:NO];
+		[wd.window_object setColorSpace:[NSColorSpace sRGBColorSpace]];
 
 		if ([wd.window_object respondsToSelector:@selector(setTabbingMode:)]) {
 			[wd.window_object setTabbingMode:NSWindowTabbingModeDisallowed];


### PR DESCRIPTION
![hdr_opengl](https://user-images.githubusercontent.com/7645683/149094616-c2b1fee9-0866-46d6-867a-6b2a0317a37c.png)
