### PR TITLE
Add option to filter the stack variables of GDScript debugger

### DIFF
--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -262,11 +262,18 @@ void EditorDebuggerInspector::add_stack_variable(const Array &p_array) {
 	variables->prop_values[type + n] = v;
 	variables->update();
 	edit(variables);
+
+	// To prevent constantly resizing when using filtering.
+	int size_x = get_size().x;
+	if (size_x > get_custom_minimum_size().x) {
+		set_custom_minimum_size(Size2(size_x, 0));
+	}
 }
 
 void EditorDebuggerInspector::clear_stack_variables() {
 	variables->clear();
 	variables->update();
+	set_custom_minimum_size(Size2(0, 0));
 }
 
 String EditorDebuggerInspector::get_stack_variable(const String &p_var) {

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -790,6 +790,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			error_tree->connect("item_activated", callable_mp(this, &ScriptEditorDebugger::_error_activated));
 			vmem_refresh->set_icon(get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
 			vmem_export->set_icon(get_theme_icon(SNAME("Save"), SNAME("EditorIcons")));
+			search->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 
 			reason->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
@@ -864,6 +865,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			docontinue->set_icon(get_theme_icon(SNAME("DebugContinue"), SNAME("EditorIcons")));
 			vmem_refresh->set_icon(get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
 			vmem_export->set_icon(get_theme_icon(SNAME("Save"), SNAME("EditorIcons")));
+			search->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 		} break;
 	}
 }
@@ -1658,14 +1660,29 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		stack_dump->connect("cell_selected", callable_mp(this, &ScriptEditorDebugger::_stack_dump_frame_selected));
 		sc->add_child(stack_dump);
 
+		VBoxContainer *inspector_vbox = memnew(VBoxContainer);
+		sc->add_child(inspector_vbox);
+
+		HBoxContainer *tools_hb = memnew(HBoxContainer);
+		inspector_vbox->add_child(tools_hb);
+
+		search = memnew(LineEdit);
+		search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		search->set_placeholder(TTR("Filter stack variables"));
+		search->set_clear_button_enabled(true);
+		tools_hb->add_child(search);
+
 		inspector = memnew(EditorDebuggerInspector);
 		inspector->set_h_size_flags(SIZE_EXPAND_FILL);
+		inspector->set_v_size_flags(SIZE_EXPAND_FILL);
 		inspector->set_enable_capitalize_paths(false);
 		inspector->set_read_only(true);
 		inspector->connect("object_selected", callable_mp(this, &ScriptEditorDebugger::_remote_object_selected));
 		inspector->connect("object_edited", callable_mp(this, &ScriptEditorDebugger::_remote_object_edited));
 		inspector->connect("object_property_updated", callable_mp(this, &ScriptEditorDebugger::_remote_object_property_updated));
-		sc->add_child(inspector);
+		inspector->register_text_enter(search);
+		inspector->set_use_filter(true);
+		inspector_vbox->add_child(inspector);
 		tabs->add_child(dbg);
 	}
 

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -134,6 +134,7 @@ private:
 	LineEdit *vmem_total;
 
 	Tree *stack_dump;
+	LineEdit *search = nullptr;
 	EditorDebuggerInspector *inspector;
 	SceneDebuggerTree *scene_tree;
 


### PR DESCRIPTION
This is QoL enhancement which adds a search box that allows filtering the debugger stack variables names in the debugger inspector. I found it very useful especially when a script has a lot of variables and you only need a specific one to be shown.

![gds_debugger_filter](https://user-images.githubusercontent.com/3036176/149136801-63e906d4-e598-4fda-983b-c4c534cbe516.gif)

