### PR TITLE
Save clear action of TextEdit in history when used from context menu

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2812,6 +2812,17 @@ void TextEdit::clear() {
 }
 
 void TextEdit::_clear() {
+	if (editable && undo_enabled) {
+		_move_caret_document_start(false);
+		begin_complex_operation();
+
+		_remove_text(0, 0, MAX(0, get_line_count() - 1), MAX(get_line(MAX(get_line_count() - 1, 0)).size() - 1, 0));
+		insert_text_at_caret("");
+		text.clear();
+
+		end_complex_operation();
+		return;
+	}
 	clear_undo_history();
 	text.clear();
 	caret.column = 0;


### PR DESCRIPTION
Fixes #56274

![Tfz1VmvcQ8](https://user-images.githubusercontent.com/79299300/149135047-e1940f14-6a67-4121-b9e8-a16712a62202.gif)
