### PR TITLE
Enable minimal SteamAPI integration for usage time tracking (editor only).

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -207,6 +207,7 @@ opts.Add(BoolVariable("modules_enabled_by_default", "If no, disable all modules 
 opts.Add(BoolVariable("no_editor_splash", "Don't use the custom splash screen for the editor", True))
 opts.Add("system_certs_path", "Use this path as SSL certificates default for editor (for package maintainers)", "")
 opts.Add(BoolVariable("use_precise_math_checks", "Math checks use very precise epsilon (debug option)", False))
+opts.Add(BoolVariable("steamapi", "Enable minimal SteamAPI integration for usage time tracking (editor only)", False))
 
 # Thirdparty libraries
 opts.Add(BoolVariable("builtin_certs", "Use the built-in SSL certificates bundles", True))

--- a/main/SCsub
+++ b/main/SCsub
@@ -10,6 +10,9 @@ env_main = env.Clone()
 
 env_main.add_source_files(env.main_sources, "*.cpp")
 
+if env["steamapi"] and env.editor_build:
+    env_main.Append(CPPDEFINES=["STEAMAPI_ENABLED"])
+
 if env["tests"]:
     env_main.Append(CPPDEFINES=["TESTS_ENABLED"])
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -101,6 +101,10 @@
 #endif
 #endif
 
+#if defined(STEAMAPI_ENABLED)
+#include "main/steam_tracker.h"
+#endif
+
 #include "modules/modules_enabled.gen.h" // For mono.
 
 /* Static members */
@@ -121,6 +125,10 @@ static ZipArchive *zip_packed_data = nullptr;
 #endif
 static FileAccessNetworkClient *file_access_network_client = nullptr;
 static MessageQueue *message_queue = nullptr;
+
+#if defined(STEAMAPI_ENABLED)
+static SteamTracker *steam_tracker = nullptr;
+#endif
 
 // Initialized in setup2()
 static AudioServer *audio_server = nullptr;
@@ -1844,6 +1852,12 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	engine->startup_benchmark_end_measure(); // core
 
+#if defined(STEAMAPI_ENABLED)
+	if (editor || project_manager) {
+		steam_tracker = memnew(SteamTracker);
+	}
+#endif
+
 	if (p_second_phase) {
 		return setup2();
 	}
@@ -1903,6 +1917,13 @@ error:
 	if (message_queue) {
 		memdelete(message_queue);
 	}
+
+#if defined(STEAMAPI_ENABLED)
+	if (steam_tracker) {
+		memdelete(steam_tracker);
+	}
+#endif
+
 	OS::get_singleton()->finalize_core();
 	locale = String();
 
@@ -3380,6 +3401,12 @@ void Main::cleanup(bool p_force) {
 	// Now should be safe to delete MessageQueue (famous last words).
 	message_queue->flush();
 	memdelete(message_queue);
+
+#if defined(STEAMAPI_ENABLED)
+	if (steam_tracker) {
+		memdelete(steam_tracker);
+	}
+#endif
 
 	unregister_core_driver_types();
 	unregister_core_extensions();

--- a/main/steam_tracker.cpp
+++ b/main/steam_tracker.cpp
@@ -1,0 +1,102 @@
+/**************************************************************************/
+/*  steam_tracker.cpp                                                     */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#if defined(STEAMAPI_ENABLED)
+
+#include "steam_tracker.h"
+
+// https://partner.steamgames.com/doc/sdk/api#initialization_and_shutdown
+
+SteamTracker::SteamTracker() {
+	String path;
+	if (OS::get_singleton()->has_feature("linuxbsd")) {
+		path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("libsteam_api.so");
+		if (!FileAccess::exists(path)) {
+			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("../lib").path_join("libsteam_api.so");
+			if (!FileAccess::exists(path)) {
+				return;
+			}
+		}
+	} else if (OS::get_singleton()->has_feature("windows")) {
+		if (OS::get_singleton()->has_feature("64")) {
+			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("steam_api64.dll");
+		} else {
+			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("steam_api.dll");
+		}
+		if (!FileAccess::exists(path)) {
+			return;
+		}
+	} else if (OS::get_singleton()->has_feature("macos")) {
+		path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("libsteam_api.dylib");
+		if (!FileAccess::exists(path)) {
+			path = OS::get_singleton()->get_executable_path().get_base_dir().path_join("../Frameworks").path_join("libsteam_api.dylib");
+			if (!FileAccess::exists(path)) {
+				return;
+			}
+		}
+	} else {
+		return;
+	}
+
+	Error err = OS::get_singleton()->open_dynamic_library(path, steam_library_handle);
+	if (err != OK) {
+		steam_library_handle = nullptr;
+		return;
+	}
+	print_verbose("Loaded SteamAPI library");
+
+	void *symbol_handle = nullptr;
+	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamAPI_Init", symbol_handle);
+	if (err != OK) {
+		return;
+	}
+	steam_init_function = (SteamAPI_InitFunction)symbol_handle;
+
+	err = OS::get_singleton()->get_dynamic_library_symbol_handle(steam_library_handle, "SteamAPI_Shutdown", symbol_handle);
+	if (err != OK) {
+		return;
+	}
+	steam_shutdown_function = (SteamAPI_ShutdownFunction)symbol_handle;
+
+	if (steam_init_function) {
+		steam_initalized = steam_init_function();
+	}
+}
+
+SteamTracker::~SteamTracker() {
+	if (steam_shutdown_function && steam_initalized) {
+		steam_shutdown_function();
+	}
+	if (steam_library_handle) {
+		OS::get_singleton()->close_dynamic_library(steam_library_handle);
+	}
+}
+
+#endif // STEAMAPI_ENABLED

--- a/main/steam_tracker.h
+++ b/main/steam_tracker.h
@@ -1,0 +1,65 @@
+/**************************************************************************/
+/*  steam_tracker.h                                                       */
+/**************************************************************************/
+/*                         This file is part of:                          */
+/*                             GODOT ENGINE                               */
+/*                        https://godotengine.org                         */
+/**************************************************************************/
+/* Copyright (c) 2014-present Godot Engine contributors (see AUTHORS.md). */
+/* Copyright (c) 2007-2014 Juan Linietsky, Ariel Manzur.                  */
+/*                                                                        */
+/* Permission is hereby granted, free of charge, to any person obtaining  */
+/* a copy of this software and associated documentation files (the        */
+/* "Software"), to deal in the Software without restriction, including    */
+/* without limitation the rights to use, copy, modify, merge, publish,    */
+/* distribute, sublicense, and/or sell copies of the Software, and to     */
+/* permit persons to whom the Software is furnished to do so, subject to  */
+/* the following conditions:                                              */
+/*                                                                        */
+/* The above copyright notice and this permission notice shall be         */
+/* included in all copies or substantial portions of the Software.        */
+/*                                                                        */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,        */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF     */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. */
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY   */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,   */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE      */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                 */
+/**************************************************************************/
+
+#ifndef STEAM_TRACKER_H
+#define STEAM_TRACKER_H
+
+#if defined(STEAMAPI_ENABLED)
+
+#include "core/os/os.h"
+
+// SteamTracker is used to load SteamAPI dynamic library and initialize
+// the interface, this notifies Steam that Godot editor is running and
+// allow tracking of the usage time of child instances of the engine
+// (e.g., opened projects).
+//
+// Currently, SteamAPI is not used by the engine in any way, and is not
+// exposed to the scripting APIs.
+
+// https://partner.steamgames.com/doc/api/steam_api#SteamAPI_Init
+typedef bool (*SteamAPI_InitFunction)();
+
+// https://partner.steamgames.com/doc/api/steam_api#SteamAPI_Shutdown
+typedef void (*SteamAPI_ShutdownFunction)();
+
+class SteamTracker {
+	void *steam_library_handle = nullptr;
+	SteamAPI_InitFunction steam_init_function = nullptr;
+	SteamAPI_ShutdownFunction steam_shutdown_function = nullptr;
+	bool steam_initalized = false;
+
+public:
+	SteamTracker();
+	~SteamTracker();
+};
+
+#endif // STEAMAPI_ENABLED
+
+#endif // STEAM_TRACKER_H


### PR DESCRIPTION
Disabled by default, can be enabled with (`steamapi=yes` build option), ~`steam_appid.txt`~ (it's only needed when running executable outside of Steam download) and `steam_api` library from the SDK should be added to distribution for this feature to work.

It initializes Steam API to inform Steam that Godot editor is running, but not using it in any way.

Fixes #18233