### PR TITLE
GDScript: Fix parsing default parameter values from function calls

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -2019,7 +2019,7 @@ GDScriptFunction *GDScriptCompiler::_parse_function(Error &r_error, GDScript *p_
 			codegen.generator->start_parameters();
 			for (int i = p_func->parameters.size() - optional_parameters; i < p_func->parameters.size(); i++) {
 				const GDScriptParser::ParameterNode *parameter = p_func->parameters[i];
-				GDScriptCodeGenerator::Address src_addr = _parse_expression(codegen, r_error, parameter->default_value, true);
+				GDScriptCodeGenerator::Address src_addr = _parse_expression(codegen, r_error, parameter->default_value);
 				if (r_error) {
 					memdelete(codegen.generator);
 					return nullptr;

--- a/modules/gdscript/tests/scripts/analyzer/errors/params_default_forward_reference.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/params_default_forward_reference.gd
@@ -1,0 +1,9 @@
+# https://github.com/godotengine/godot/issues/56702
+
+func test():
+	# somewhat obscure feature: referencing parameters in defaults, but only earlier ones!
+	ref_default("non-optional")
+
+
+func ref_default(nondefault1, defa=nondefault1, defb=defc, defc=1):
+	prints(nondefault1, nondefault2, defa, defb, defc)

--- a/modules/gdscript/tests/scripts/analyzer/errors/params_default_forward_reference.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/params_default_forward_reference.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Identifier "defc" not declared in the current scope.

--- a/modules/gdscript/tests/scripts/runtime/features/params_default_values.gd
+++ b/modules/gdscript/tests/scripts/runtime/features/params_default_values.gd
@@ -1,0 +1,35 @@
+# https://github.com/godotengine/godot/issues/56702
+
+func test():
+	const_default()
+	func_result_default()
+	# calling again will run the initializer again,
+	# as the default is not evaluated at time of defining the function (as in python)
+	# but every time the function is called (as in C++)
+	func_result_default()
+	lots_of_defaults("non-optional")
+	# somewhat obscure feature: referencing earlier parameters
+	ref_default("non-optional", 42)
+
+
+func const_default(param=42):
+	print(param)
+
+
+var default_val := 0
+
+func get_default():
+	default_val += 1
+	return default_val
+
+
+func func_result_default(param=get_default()):
+	print(param)
+
+
+func lots_of_defaults(nondefault, one=1, two=2, three=get_default()):
+	prints(nondefault, one, two, three)
+
+
+func ref_default(nondefault1, nondefault2, defa=nondefault1, defb=nondefault2 - 1):
+	prints(nondefault1, nondefault2, defa, defb)

--- a/modules/gdscript/tests/scripts/runtime/features/params_default_values.out
+++ b/modules/gdscript/tests/scripts/runtime/features/params_default_values.out
@@ -1,0 +1,6 @@
+GDTEST_OK
+42
+1
+2
+non-optional 1 2 3
+non-optional 42 non-optional 41


### PR DESCRIPTION
If root is true, the result of a function call is thrown out.
It did work for constant values though, so I am not sure this is the right solution. 

*Bugsauqd edit:* FIxes #56702.