### PR TITLE
Remove mistakenly added author info

### DIFF
--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -51,9 +51,6 @@
 #endif
 
 #include <stdio.h>
-/**
-	@author Juan Linietsky <reduzio@gmail.com>
-*/
 
 class ShaderGLES3 {
 protected:


### PR DESCRIPTION
Mistakenly added in https://github.com/godotengine/godot/pull/55656

https://github.com/godotengine/godot/pull/56492 removed @author attributions, so this should never have been added