### PR TITLE
Prevent redefinition of main functions in shader

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -8774,6 +8774,13 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 					}
 				}
 
+				for (int i = 0; i < shader->functions.size(); i++) {
+					if (!shader->functions[i].callable && shader->functions[i].name == name) {
+						_set_error("Redefinition of '" + String(name) + "'");
+						return ERR_PARSE_ERROR;
+					}
+				}
+
 				ShaderNode::Function function;
 
 				function.callable = !p_functions.has(name);


### PR DESCRIPTION
Prevent writing such code:
```
shader_types spatial;

void fragment() {
}

void fragment() {
}
```

Note, that due to `vertex`/`fragment`/`light` technically are not functions, but just code fragments inserted into the main function parser must not prevent writing code like this: 

```
void fragment() {
}

const vec3 fragment = vec3(1, 0, 0);

```
so I did not modify a `_find_identifier` for this.