### PR TITLE
Use mouse event relative motion to calculate mouse velocity

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -504,18 +504,20 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	Ref<InputEventMouseMotion> mm = p_event;
 
 	if (mm.is_valid()) {
-		Point2 pos = mm->get_global_position();
-		if (mouse_pos != pos) {
-			set_mouse_position(pos);
+		Point2 position = mm->get_global_position();
+		if (mouse_pos != position) {
+			set_mouse_position(position);
 		}
+		Vector2 relative = mm->get_relative();
+		mouse_velocity_track.update(relative);
 
 		if (event_dispatch_function && emulate_touch_from_mouse && !p_is_emulated && (mm->get_button_mask() & MouseButton::LEFT) != MouseButton::NONE) {
 			Ref<InputEventScreenDrag> drag_event;
 			drag_event.instantiate();
 
-			drag_event->set_position(mm->get_position());
-			drag_event->set_relative(mm->get_relative());
-			drag_event->set_velocity(mm->get_velocity());
+			drag_event->set_position(position);
+			drag_event->set_relative(relative);
+			drag_event->set_velocity(get_last_mouse_velocity());
 
 			event_dispatch_function(drag_event);
 		}
@@ -696,7 +698,6 @@ void Input::set_gyroscope(const Vector3 &p_gyroscope) {
 }
 
 void Input::set_mouse_position(const Point2 &p_posf) {
-	mouse_velocity_track.update(p_posf - mouse_pos);
 	mouse_pos = p_posf;
 }
 

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -137,7 +137,6 @@ int DisplayServerJavaScript::mouse_button_callback(int p_pressed, int p_button, 
 	DisplayServerJavaScript *ds = get_singleton();
 
 	Point2 pos(p_x, p_y);
-	Input::get_singleton()->set_mouse_position(pos);
 	Ref<InputEventMouseButton> ev;
 	ev.instantiate();
 	ev->set_position(pos);
@@ -219,7 +218,6 @@ void DisplayServerJavaScript::mouse_move_callback(double p_x, double p_y, double
 	}
 
 	Point2 pos(p_x, p_y);
-	Input::get_singleton()->set_mouse_position(pos);
 	Ref<InputEventMouseMotion> ev;
 	ev.instantiate();
 	dom2godot_mod(ev, p_modifiers);
@@ -229,7 +227,6 @@ void DisplayServerJavaScript::mouse_move_callback(double p_x, double p_y, double
 	ev->set_global_position(pos);
 
 	ev->set_relative(Vector2(p_rel_x, p_rel_y));
-	Input::get_singleton()->set_mouse_position(ev->get_position());
 	ev->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 
 	Input::get_singleton()->parse_input_event(ev);

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -3647,7 +3647,6 @@ void DisplayServerX11::process_events() {
 				mm->set_button_mask((MouseButton)mouse_get_button_state());
 				mm->set_position(pos);
 				mm->set_global_position(pos);
-				Input::get_singleton()->set_mouse_position(pos);
 				mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 
 				mm->set_relative(rel);

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -792,7 +792,6 @@ static void _mouseDownEvent(DisplayServer::WindowID window_id, NSEvent *event, M
 	mm->set_relative(relativeMotion);
 	_get_key_modifier_state([event modifierFlags], mm);
 
-	Input::get_singleton()->set_mouse_position(wd.mouse_pos);
 	Input::get_singleton()->parse_input_event(mm);
 }
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2078,7 +2078,6 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 				mm->set_position(c);
 				mm->set_global_position(c);
-				Input::get_singleton()->set_mouse_position(c);
 				mm->set_velocity(Vector2(0, 0));
 
 				if (raw->data.mouse.usFlags == MOUSE_MOVE_RELATIVE) {
@@ -2183,7 +2182,6 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 						SetCursorPos(pos.x, pos.y);
 					}
 
-					Input::get_singleton()->set_mouse_position(mm->get_position());
 					mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 
 					if (old_invalid) {
@@ -2325,7 +2323,6 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				SetCursorPos(pos.x, pos.y);
 			}
 
-			Input::get_singleton()->set_mouse_position(mm->get_position());
 			mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 
 			if (old_invalid) {
@@ -2426,7 +2423,6 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				SetCursorPos(pos.x, pos.y);
 			}
 
-			Input::get_singleton()->set_mouse_position(mm->get_position());
 			mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 
 			if (old_invalid) {


### PR DESCRIPTION
Currently, mouse velocity is updated when `set_mouse_position()` is called. This has two side effects:
1. Mouse velocity is updated every time `set_mouse_position()` is called even when the mouse hasn't moved. This results in large mouse velocities when, for example, the mouse is warped.
2. Mouse velocity is not updated when the mouse moves, but the mouse position doesn't change. This results in mouse velocities being zero when using `MOUSE_MODE_CAPTURED`.

This PR uses `InputEventMouseMotion`'s relative motion to update the mouse's velocity instead of calls to `set_mouse_position()`. This ensures that mouse velocities are updated when the mouse is captured.

Note: `set_mouse_position()` tends to be called to update the velocity before setting a `InputEventMouseMotion`'s `velocity` property using `get_last_mouse_velocity()`. With this change the velocity (and position) aren't updated until the event is parsed. So calling `set_mouse_position()` to update the velocity is no longer meaningful. Therefore, these lines have been removed. Although it would appear that this would make the velocity value used in `InputEventMouseMotion` out of date, the reality is that, to ensure the velocity is precise and not jittery, the velocity is only updated every 0.1 seconds. This is far less frequent than `InputEventMouseMotion` events are generated (around every 0.008 seconds). Therefore, calling `set_mouse_position()` to update the velocity before setting a `InputEventMouseMotion`'s `velocity` property, was ineffective anyway.

Note2: This change doesn't fix mouse warping from setting the mouse velocity. Mouse warping events should be filtered. However, at least on Linux, this is not happening. See [#8414](https://github.com/godotengine/godot/issues/8414#issuecomment-492793051), which is still happening even though the issue has been closed.

Note3: #45592, reports a different issue, which highlighted a different problem: mouse velocities are not properly clearing old residual movements. However, #45592 arose, because of trying to find a workaround to mouse speeds being zero, when using `MOUSE_MODE_CAPTURED`.