### PR TITLE
Add ViewPanner to more editors

### DIFF
--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -33,6 +33,8 @@
 
 #include "animation_track_editor.h"
 
+class ViewPanner;
+
 class AnimationBezierTrackEdit : public Control {
 	GDCLASS(AnimationBezierTrackEdit, Control);
 
@@ -123,9 +125,10 @@ class AnimationBezierTrackEdit : public Control {
 
 	Set<int> selection;
 
-	bool panning_timeline = false;
-	float panning_timeline_from;
-	float panning_timeline_at;
+	Ref<ViewPanner> panner;
+	void _scroll_callback(Vector2 p_scroll_vec);
+	void _pan_callback(Vector2 p_scroll_vec);
+	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin);
 
 	void _draw_line_clipped(const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, int p_clip_left, int p_clip_right);
 	void _draw_track(int p_track, const Color &p_color);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -48,8 +48,8 @@
 #include "scene_tree_editor.h"
 
 class AnimationPlayer;
-
 class AnimationTrackEdit;
+class ViewPanner;
 
 class AnimationTimelineEdit : public Range {
 	GDCLASS(AnimationTimelineEdit, Range);
@@ -81,9 +81,11 @@ class AnimationTimelineEdit : public Range {
 	bool editing;
 	bool use_fps;
 
-	bool panning_timeline;
-	float panning_timeline_from;
-	float panning_timeline_at;
+	Ref<ViewPanner> panner;
+	void _scroll_callback(Vector2 p_scroll_vec);
+	void _pan_callback(Vector2 p_scroll_vec);
+	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin);
+
 	bool dragging_timeline;
 	bool dragging_hsize;
 	float dragging_hsize_from;
@@ -373,6 +375,11 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _root_removed(Node *p_root);
 
 	PropertyInfo _find_hint_for_track(int p_idx, NodePath &r_base_path, Variant *r_current_val = nullptr);
+
+	Ref<ViewPanner> panner;
+	void _scroll_callback(Vector2 p_scroll_vec);
+	void _pan_callback(Vector2 p_scroll_vec);
+	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin);
 
 	void _timeline_value_changed(double);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6039,8 +6039,10 @@ EditorNode::EditorNode() {
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/inspector/default_color_picker_shape", PROPERTY_HINT_ENUM, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle", PROPERTY_USAGE_DEFAULT));
 	EDITOR_DEF("run/auto_save/save_before_running", true);
 	EDITOR_DEF("interface/editors/sub_editor_panning_scheme", 0);
+	EDITOR_DEF("interface/editors/animation_editors_panning_scheme", 1);
 	// Should be in sync with ControlScheme in ViewPanner.
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/editors/sub_editor_panning_scheme", PROPERTY_HINT_ENUM, "Scroll Zooms,Scroll Pans", PROPERTY_USAGE_DEFAULT));
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/editors/animation_editors_panning_scheme", PROPERTY_HINT_ENUM, "Scroll Zooms,Scroll Pans", PROPERTY_USAGE_DEFAULT));
 
 	const Vector<String> textfile_ext = ((String)(EditorSettings::get_singleton()->get("docks/filesystem/textfile_extensions"))).split(",", false);
 	for (const String &E : textfile_ext) {

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -732,6 +732,10 @@ void AnimationNodeBlendTreeEditor::_removed_from_graph() {
 }
 
 void AnimationNodeBlendTreeEditor::_notification(int p_what) {
+	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
+		graph->set_panning_scheme((GraphEdit::PanningScheme)EDITOR_GET("interface/editors/sub_editor_panning_scheme").operator int());
+	}
+
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
 		error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -32,7 +32,9 @@
 #define POLYGON_2D_EDITOR_PLUGIN_H
 
 #include "editor/plugins/abstract_polygon_2d_editor.h"
-#include "scene/gui/scroll_container.h"
+
+class ViewPanner;
+class ScrollContainer;
 
 class Polygon2DEditor : public AbstractPolygon2DEditor {
 	GDCLASS(Polygon2DEditor, AbstractPolygon2DEditor);
@@ -77,6 +79,11 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	VScrollBar *uv_vscroll;
 	MenuButton *uv_menu;
 	TextureRect *uv_icon_zoom;
+
+	Ref<ViewPanner> uv_panner;
+	void _uv_scroll_callback(Vector2 p_scroll_vec);
+	void _uv_pan_callback(Vector2 p_scroll_vec);
+	void _uv_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin);
 
 	VBoxContainer *bone_scroll_main_vb;
 	ScrollContainer *bone_scroll;

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -36,11 +36,18 @@
 bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) {
 	Ref<InputEventMouseButton> mb = p_event;
 	if (mb.is_valid()) {
+		// Alt modifier is unused, so ignore such events.
+		if (mb->is_alt_pressed()) {
+			return false;
+		}
+
 		Vector2i scroll_vec = Vector2((mb->get_button_index() == MouseButton::WHEEL_RIGHT) - (mb->get_button_index() == MouseButton::WHEEL_LEFT), (mb->get_button_index() == MouseButton::WHEEL_DOWN) - (mb->get_button_index() == MouseButton::WHEEL_UP));
 		if (scroll_vec != Vector2()) {
 			if (control_scheme == SCROLL_PANS) {
 				if (mb->is_ctrl_pressed()) {
+					scroll_vec.y *= mb->get_factor();
 					callback_helper(zoom_callback, scroll_vec, mb->get_position());
+					return true;
 				} else {
 					Vector2 panning;
 					if (mb->is_shift_pressed()) {
@@ -51,7 +58,6 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 						panning.x += mb->get_factor() * scroll_vec.x;
 					}
 					callback_helper(scroll_callback, panning);
-
 					return true;
 				}
 			} else {
@@ -65,16 +71,16 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 						panning.x += mb->get_factor() * scroll_vec.x;
 					}
 					callback_helper(scroll_callback, panning);
-
 					return true;
 				} else if (!mb->is_shift_pressed()) {
+					scroll_vec.y *= mb->get_factor();
 					callback_helper(zoom_callback, scroll_vec, mb->get_position());
 					return true;
 				}
 			}
 		}
 
-		if (mb->get_button_index() == MouseButton::MIDDLE || (mb->get_button_index() == MouseButton::RIGHT && !disable_rmb) || (mb->get_button_index() == MouseButton::LEFT && (Input::get_singleton()->is_key_pressed(Key::SPACE) || !mb->is_pressed()))) {
+		if (mb->get_button_index() == MouseButton::MIDDLE || (mb->get_button_index() == MouseButton::RIGHT && !disable_rmb) || (mb->get_button_index() == MouseButton::LEFT && (Input::get_singleton()->is_key_pressed(Key::SPACE) || (is_dragging && !mb->is_pressed())))) {
 			if (mb->is_pressed()) {
 				is_dragging = true;
 			} else {

--- a/scene/gui/view_panner.h
+++ b/scene/gui/view_panner.h
@@ -38,6 +38,13 @@ class InputEvent;
 class ViewPanner : public RefCounted {
 	GDCLASS(ViewPanner, RefCounted);
 
+public:
+	enum ControlScheme {
+		SCROLL_ZOOMS,
+		SCROLL_PANS,
+	};
+
+private:
 	bool is_dragging = false;
 	bool disable_rmb = false;
 
@@ -46,17 +53,15 @@ class ViewPanner : public RefCounted {
 	Callable zoom_callback;
 
 	void callback_helper(Callable p_callback, Vector2 p_arg1, Vector2 p_arg2 = Vector2());
-
-public:
-	enum ControlScheme {
-		SCROLL_ZOOMS,
-		SCROLL_PANS,
-	};
 	ControlScheme control_scheme = SCROLL_ZOOMS;
 
+public:
 	void set_callbacks(Callable p_scroll_callback, Callable p_pan_callback, Callable p_zoom_callback);
 	void set_control_scheme(ControlScheme p_scheme);
 	void set_disable_rmb(bool p_disable);
+
+	bool is_panning() const { return is_dragging; }
+
 	bool gui_input(const Ref<InputEvent> &p_ev, Rect2 p_canvas_rect = Rect2());
 };
 


### PR DESCRIPTION
Follow-up to #53471 (there will be one more at least)

This adds ViewPanner to Polygon UV Editor, Animation Bezier editor and Animation Track Editor. This unifies the controls in these editors, which results in these changes:
- Animation Bezier Editor had an alternate zoom, which conflicted with the ViewPanner, so it was changed from <kbd>wheel</kbd> to <kbd>Alt + wheel</kbd>
- Animation timeline now supports scrolling
- Animation Track Editor now supports vertical panning, so now you can do this
![godot windows tools 64_BN0VasUpNm](https://user-images.githubusercontent.com/2223172/149372314-280fbfc4-36da-4188-a8b1-398afaf5a4e2.gif)
- All 3 editors now support horizontal and vertical scrolling
- All 3 editors now support <kbd>Space + LMB</kbd> panning
- All 3 editors now support <kbd>WHEEL_LEFT</kbd>/<kbd>WHEEL_RIGHT</kbd> buttons

I also did some fixes to the ViewPanner itself.

Putting as draft, because I still need to support the panning scheme editor setting. I'm planning to add separately configurable scheme for animation editors.

EDIT:
One more thing. I noticed some gestures in the code, but left them as is. Maybe I can try adding gesture support to ViewPanner, but it might require more callbacks, which is meh.