### PR TITLE
Fix completion for global constants in shaders

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -9383,6 +9383,9 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 						}
 					}
 
+					for (const KeyValue<StringName, ShaderNode::Constant> &E : shader->constants) {
+						matches.insert(E.key, ScriptCodeCompletionOption::KIND_CONSTANT);
+					}
 					for (const KeyValue<StringName, ShaderNode::Varying> &E : shader->varyings) {
 						matches.insert(E.key, ScriptCodeCompletionOption::KIND_VARIABLE);
 					}


### PR DESCRIPTION
Currently, it does not show. After this fix:
![image](https://user-images.githubusercontent.com/3036176/149373345-e18500bc-6e86-404d-94c8-e0679f6d7384.png)

