### PR TITLE
[macOS] Fix self-contained mode.

### DIFF
--- a/editor/editor_paths.cpp
+++ b/editor/editor_paths.cpp
@@ -91,6 +91,11 @@ EditorPaths::EditorPaths() {
 
 	// Self-contained mode if a `._sc_` or `_sc_` file is present in executable dir.
 	String exe_path = OS::get_singleton()->get_executable_path().get_base_dir();
+
+	// On macOS, look outside .app bundle, since .app bundle is read-only.
+	if (OS::get_singleton()->has_feature("macos") && exe_path.ends_with("MacOS") && exe_path.plus_file("..").simplify_path().ends_with("Contents")) {
+		exe_path = exe_path.plus_file("../../..").simplify_path();
+	}
 	{
 		DirAccessRef d = DirAccess::create_for_path(exe_path);
 

--- a/modules/mono/godotsharp_dirs.cpp
+++ b/modules/mono/godotsharp_dirs.cpp
@@ -68,7 +68,14 @@ String _get_mono_user_dir() {
 	} else {
 		String settings_path;
 
+		// Self-contained mode if a `._sc_` or `_sc_` file is present in executable dir.
 		String exe_dir = OS::get_singleton()->get_executable_path().get_base_dir();
+
+		// On macOS, look outside .app bundle, since .app bundle is read-only.
+		if (OS::get_singleton()->has_feature("macos") && exe_dir.ends_with("MacOS") && exe_dir.plus_file("..").simplify_path().ends_with("Contents")) {
+			exe_dir = exe_dir.plus_file("../../..").simplify_path();
+		}
+
 		DirAccessRef d = DirAccess::create_for_path(exe_dir);
 
 		if (d->file_exists("._sc_") || d->file_exists("_sc_")) {


### PR DESCRIPTION
macOS .app bundle is usually signed, and it's impossible to write config/cache to the executable directory without breaking a signature. And it's impossible to sign a bundle with the non-executable files (like `._sc_`) in the executable directory.

This PR change `._sc_` lookup path and config/cache path in self-contained mode to the bundle location instead.