### PR TITLE
Fix for RegEx.search() memory leak on Windows

### DIFF
--- a/modules/regex/regex.cpp
+++ b/modules/regex/regex.cpp
@@ -246,6 +246,8 @@ Ref<RegExMatch> RegEx::search(const String &p_subject, int p_offset, int p_end) 
 
 		if (res < 0) {
 			pcre2_match_data_free_16(match);
+			pcre2_match_context_free_16(mctx);
+
 			return nullptr;
 		}
 


### PR DESCRIPTION
Fix for memory leak on Windows when RegEx.search() is called as described in GitHub issue [#50811](https://github.com/godotengine/godot/issues/50811).

As I checked mentioned issue shouldn't reproduce on master branch, so fix is necessary only for 3.x versions.