### PR TITLE
Fix mouse velocity not changing fast enough

### DIFF
--- a/core/input/input.h
+++ b/core/input/input.h
@@ -274,7 +274,7 @@ public:
 	Vector3 get_gyroscope() const;
 
 	Point2 get_mouse_position() const;
-	Vector2 get_last_mouse_velocity() const;
+	Vector2 get_last_mouse_velocity();
 	MouseButton get_mouse_button_mask() const;
 
 	void warp_mouse_position(const Vector2 &p_to);

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -141,10 +141,10 @@
 				Returns the strength of the joypad vibration: x is the strength of the weak motor, and y is the strength of the strong motor.
 			</description>
 		</method>
-		<method name="get_last_mouse_velocity" qualifiers="const">
+		<method name="get_last_mouse_velocity">
 			<return type="Vector2" />
 			<description>
-				Returns the mouse velocity for the last time the cursor was moved, and this until the next frame where the mouse moves. This means that even if the mouse is not moving, this function will still return the value of the last motion.
+				Returns the last mouse velocity. To provide a precise and jitter-free velocity, mouse velocity is only calculated every 0.1s. Therefore, mouse velocity will lag mouse movements.
 			</description>
 		</method>
 		<method name="get_magnetometer" qualifiers="const">


### PR DESCRIPTION
Currently, the way mouse velocity is calculated is weird and leads to bizarre results:
1. When the mouse velocity is calculated only ⅔ of the accumulated change is used (unless a long time has passed since the last calculation, in which case, for every 0.1&nbsp;s since the last update, another ⅔ of the remainder are used).
2. Subsequent changes are then added to the remaining ⅓ of the accumulated change. This results in inaccurate velocities, because a portion of all the historic changes will keep being used. This is most noticeable when switching to `MOUSE_MODE_CAPTURED`: the mouse position is not updated, but the velocity remains non-zero for over a 100 subsequent frames (#45592)!
3. Old accumulated movements are not discarded; instead the time taken to make the movement is reduced, which actually makes an old change more relevant instead of less.
4. Mouse velocity is only updated when mouse events are received, resulting in `get_last_mouse_velocity()` never going to zero (#1355).

This PR addresses the above issues by:
- Using all accumulated movements and discarding old accumulated movements when calculating mouse velocity.
- Also updating the mouse velocity when `get_last_mouse_speed()` is called, which will enable mouse velocity to go to zero when there is no movement.

Properly fixes #1355
Fixes #45592
