### PR TITLE
Fix theming for floating window docks

### DIFF
--- a/doc/classes/Panel.xml
+++ b/doc/classes/Panel.xml
@@ -11,16 +11,6 @@
 		<link title="2D Finite State Machine Demo">https://godotengine.org/asset-library/asset/516</link>
 		<link title="3D Inverse Kinematics Demo">https://godotengine.org/asset-library/asset/523</link>
 	</tutorials>
-	<members>
-		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="Panel.Mode" default="0">
-		</member>
-	</members>
-	<constants>
-		<constant name="MODE_BACKGROUND" value="0" enum="Mode">
-		</constant>
-		<constant name="MODE_FOREGROUND" value="1" enum="Mode">
-		</constant>
-	</constants>
 	<theme_items>
 		<theme_item name="panel" data_type="style" type="StyleBox">
 			The style of this [Panel].

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4236,8 +4236,9 @@ void EditorNode::_dock_make_float() {
 	Control *dock = dock_slot[dock_popup_selected]->get_current_tab_control();
 	ERR_FAIL_COND(!dock);
 
-	const Size2i borders = Size2i(4, 4) * EDSCALE;
-	Size2 dock_size = dock->get_size() + borders * 2; // remember size
+	Size2 borders = Size2(4, 4) * EDSCALE;
+	// Remember size and position before removing it from the main window.
+	Size2 dock_size = dock->get_size() + borders * 2;
 	Point2 dock_screen_pos = dock->get_global_position() + get_tree()->get_root()->get_position() - borders;
 
 	int dock_index = dock->get_index();
@@ -4246,7 +4247,7 @@ void EditorNode::_dock_make_float() {
 	Window *window = memnew(Window);
 	window->set_title(dock->get_name());
 	Panel *p = memnew(Panel);
-	p->set_mode(Panel::MODE_FOREGROUND);
+	p->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("PanelForeground"), SNAME("EditorStyles")));
 	p->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	window->add_child(p);
 	MarginContainer *margin = memnew(MarginContainer);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1279,7 +1279,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// Panel
 	theme->set_stylebox(SNAME("panel"), SNAME("Panel"), make_flat_stylebox(dark_color_1, 6, 4, 6, 4, corner_width));
-	theme->set_stylebox(SNAME("panel_fg"), SNAME("Panel"), style_default);
+	theme->set_stylebox(SNAME("PanelForeground"), SNAME("EditorStyles"), style_default);
 
 	// Label
 	theme->set_stylebox(SNAME("normal"), SNAME("Label"), style_empty);

--- a/scene/gui/panel.cpp
+++ b/scene/gui/panel.cpp
@@ -30,33 +30,12 @@
 
 #include "panel.h"
 
-#include "core/string/print_string.h"
-
 void Panel::_notification(int p_what) {
 	if (p_what == NOTIFICATION_DRAW) {
 		RID ci = get_canvas_item();
-		Ref<StyleBox> style = mode == MODE_BACKGROUND ? get_theme_stylebox(SNAME("panel")) : get_theme_stylebox(SNAME("panel_fg"));
+		Ref<StyleBox> style = get_theme_stylebox(SNAME("panel"));
 		style->draw(ci, Rect2(Point2(), get_size()));
 	}
-}
-
-void Panel::set_mode(Mode p_mode) {
-	mode = p_mode;
-	update();
-}
-
-Panel::Mode Panel::get_mode() const {
-	return mode;
-}
-
-void Panel::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_mode", "mode"), &Panel::set_mode);
-	ClassDB::bind_method(D_METHOD("get_mode"), &Panel::get_mode);
-
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "mode", PROPERTY_HINT_ENUM, "Background,Foreground"), "set_mode", "get_mode");
-
-	BIND_ENUM_CONSTANT(MODE_BACKGROUND);
-	BIND_ENUM_CONSTANT(MODE_FOREGROUND);
 }
 
 Panel::Panel() {

--- a/scene/gui/panel.h
+++ b/scene/gui/panel.h
@@ -36,26 +36,11 @@
 class Panel : public Control {
 	GDCLASS(Panel, Control);
 
-public:
-	enum Mode {
-		MODE_BACKGROUND,
-		MODE_FOREGROUND,
-	};
-
-private:
-	Mode mode = MODE_BACKGROUND;
-
 protected:
 	void _notification(int p_what);
-	static void _bind_methods();
 
 public:
-	void set_mode(Mode p_mode);
-	Mode get_mode() const;
-
 	Panel();
 };
-
-VARIANT_ENUM_CAST(Panel::Mode)
 
 #endif // PANEL_H


### PR DESCRIPTION
- Fix no borders when the editor scale is inferior to 100%.
- Apply floating dock theming directly to the panel. Which allows to:
  - Remove unnecessary back/foreground system from the `Panel` node.