### PR TITLE
Undo redo cumulative anim

### DIFF
--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -77,6 +77,7 @@ private:
 
 	Vector<Action> actions;
 	int current_action = -1;
+	List<Pair<Object *, Map<String, Variant>>> _list_object_info;
 	bool force_keep_in_merge_ends = false;
 	int action_level = 0;
 	MergeMode merge_mode = MERGE_DISABLE;
@@ -103,6 +104,7 @@ protected:
 
 public:
 	void create_action(const String &p_name = "", MergeMode p_mode = MERGE_DISABLE);
+	void create_action_cumulative(Object *p_object, const String &p_name = "", MergeMode p_mode = MERGE_DISABLE);
 
 	void add_do_method(Object *p_object, const StringName &p_method, VARIANT_ARG_LIST);
 	void add_undo_method(Object *p_object, const StringName &p_method, VARIANT_ARG_LIST);
@@ -116,6 +118,7 @@ public:
 
 	bool is_committing_action() const;
 	void commit_action(bool p_execute = true);
+	void commit_action_cumulative();
 
 	bool redo();
 	bool undo();

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -277,6 +277,8 @@ public:
 	AnimationTrackEditGroup();
 };
 
+class AnimationKeyPosCalculator;
+
 class AnimationTrackEditor : public VBoxContainer {
 	GDCLASS(AnimationTrackEditor, VBoxContainer);
 
@@ -380,6 +382,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	int insert_key_from_track_call_track;
 	void _insert_key_from_track(float p_ofs, int p_track);
 	void _add_method_key(const String &p_method);
+	_FORCE_INLINE_ void _move_keys(const String &p_action, const AnimationKeyPosCalculator &calculate_key_pos);
 
 	void _clear_selection(bool p_update = false);
 	void _clear_selection_for_anim(const Ref<Animation> &p_anim);

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -241,6 +241,7 @@ private:
 
 	void _node_removed(Node *p_node);
 	void _stop_playing_caches();
+	void _update_editor();
 
 	// bind helpers
 	Vector<String> _get_animation_list() const {

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1492,6 +1492,9 @@ bool ItemList::_set(const StringName &p_name, const Variant &p_value) {
 		} else if (components[1] == "disabled") {
 			set_item_disabled(item_index, p_value);
 			return true;
+		} else if (components[1] == "selectable") {
+			set_item_selectable(item_index, p_value);
+			return true;
 		}
 	}
 #ifndef DISABLE_DEPRECATED
@@ -1528,6 +1531,9 @@ bool ItemList::_get(const StringName &p_name, Variant &r_ret) const {
 		} else if (components[1] == "disabled") {
 			r_ret = is_item_disabled(item_index);
 			return true;
+		} else if (components[1] == "selectable") {
+			r_ret = is_item_selectable(item_index);
+			return true;
 		}
 	}
 	return false;
@@ -1539,6 +1545,10 @@ void ItemList::_get_property_list(List<PropertyInfo> *p_list) const {
 
 		PropertyInfo pi = PropertyInfo(Variant::OBJECT, vformat("item_%d/icon", i), PROPERTY_HINT_RESOURCE_TYPE, "Texture2D");
 		pi.usage &= ~(get_item_icon(i).is_null() ? PROPERTY_USAGE_STORAGE : 0);
+		p_list->push_back(pi);
+
+		pi = PropertyInfo(Variant::BOOL, vformat("item_%d/selectable", i));
+		pi.usage &= ~(is_item_selectable(i) ? PROPERTY_USAGE_STORAGE : 0);
 		p_list->push_back(pi);
 
 		pi = PropertyInfo(Variant::BOOL, vformat("item_%d/disabled", i));

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -62,7 +62,7 @@ private:
 		String language;
 		TextDirection text_direction = TEXT_DIRECTION_AUTO;
 
-		bool selectable = false;
+		bool selectable = true;
 		bool selected = false;
 		bool disabled = false;
 		bool tooltip_enabled = true;

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -184,7 +184,7 @@ void MenuButton::_get_property_list(List<PropertyInfo> *p_list) const {
 		pi.usage &= ~(!popup->is_item_checked(i) ? PROPERTY_USAGE_STORAGE : 0);
 		p_list->push_back(pi);
 
-		pi = PropertyInfo(Variant::INT, vformat("popup/item_%d/id", i), PROPERTY_HINT_RANGE, "1,10,1,or_greater");
+		pi = PropertyInfo(Variant::INT, vformat("popup/item_%d/id", i), PROPERTY_HINT_RANGE, "0,10,1,or_greater");
 		p_list->push_back(pi);
 
 		pi = PropertyInfo(Variant::BOOL, vformat("popup/item_%d/disabled", i));

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1275,7 +1275,15 @@ int PopupMenu::get_current_index() const {
 
 void PopupMenu::set_item_count(int p_count) {
 	ERR_FAIL_COND(p_count < 0);
+	int prev_size = items.size();
 	items.resize(p_count);
+
+	if (prev_size < p_count) {
+		for (int i = prev_size; i < p_count; i++) {
+			items.write[i].id = i;
+		}
+	}
+
 	control->update();
 	child_controls_changed();
 	notify_property_list_changed();
@@ -1658,7 +1666,7 @@ void PopupMenu::_get_property_list(List<PropertyInfo> *p_list) const {
 		pi.usage &= ~(!is_item_checked(i) ? PROPERTY_USAGE_STORAGE : 0);
 		p_list->push_back(pi);
 
-		pi = PropertyInfo(Variant::INT, vformat("item_%d/id", i), PROPERTY_HINT_RANGE, "1,10,1,or_greater");
+		pi = PropertyInfo(Variant::INT, vformat("item_%d/id", i), PROPERTY_HINT_RANGE, "0,10,1,or_greater");
 		p_list->push_back(pi);
 
 		pi = PropertyInfo(Variant::BOOL, vformat("item_%d/disabled", i));

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -36,6 +36,8 @@
 
 #define ANIM_MIN_LENGTH 0.001
 
+class AnimationTrackEditor;
+
 class Animation : public Resource {
 	GDCLASS(Animation, Resource);
 	RES_BASE_EXTENSION("anim");
@@ -376,6 +378,7 @@ public:
 
 	int get_track_count() const;
 	TrackType track_get_type(int p_track) const;
+	void track_set_type(int p_track, TrackType p_type);
 
 	void track_set_path(int p_track, const NodePath &p_path);
 	NodePath track_get_path(int p_track) const;


### PR DESCRIPTION
Tests out my UndoRedo abstraction layer ('objective' cumulative UndoRedo); I'm PR'ing this to make it easier for contributors to see how my proposed changes work in practice.

Several open issues and other problems I've noticed are fixed 'automatically', yet in most cases the code has been considerably simplified; as is the main intention of my proposal, contributors would no longer have to mess around with fiddly undo-related functions that have to be called in exactly the 'right' order all the time.

For example, everything visually refreshes at the correct time such as the track playback/easing settings; without adding refresh functions to the undo stack, contributors would be encouraged to integrate this into the main subroutines where necessary, meaning they'll always work correctly instead of in specific situations. I'm aware this may not always be desired though, and there are other good ways of implementing it if needed.

By far the best improvement though is the reliability. Using the old UndoRedo system, keys moved and manipulated would rarely end up in the same state after being undone/redone, with duplicated/missing keys and even crashes being very easy to come by. Yes this could have been fixed by 'just' changing the subroutines added (or their order) on the undo stack, but some cases are so complex I wouldn't even know where to start; and anyway, editing would likely only work for a few more months before being broken by an arbitrary modification. Using this system, all state is guaranteed to end up where it started.

Bonus: I implemented undo/redo for two very complex operations, Cleanup and Optimize Anim, simply by adding 2 lines to each (`create/commit_action_cumulative`) (;