### PR TITLE
Verify custom HTTP headers, fix off by one error

### DIFF
--- a/core/io/http_client.cpp
+++ b/core/io/http_client.cpp
@@ -96,6 +96,17 @@ String HTTPClient::query_string_from_dict(const Dictionary &p_dict) {
 	return query.substr(1);
 }
 
+Error HTTPClient::verify_headers(const Vector<String> &p_headers) {
+	for (int i = 0; i < p_headers.size(); i++) {
+		String sanitized = p_headers[i].strip_edges();
+		ERR_FAIL_COND_V_MSG(sanitized.is_empty(), ERR_INVALID_PARAMETER, "Invalid HTTP header at index " + itos(i) + ": empty.");
+		ERR_FAIL_COND_V_MSG(sanitized.find(":") < 1, ERR_INVALID_PARAMETER,
+				"Invalid HTTP header at index " + itos(i) + ": String must contain header-value pair, delimited by ':', but was: " + p_headers[i]);
+	}
+
+	return OK;
+}
+
 Dictionary HTTPClient::_get_response_headers_as_dictionary() {
 	List<String> rh;
 	get_response_headers(&rh);

--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -165,6 +165,7 @@ public:
 	static HTTPClient *create();
 
 	String query_string_from_dict(const Dictionary &p_dict);
+	Error verify_headers(const Vector<String> &p_headers);
 
 	virtual Error request(Method p_method, const String &p_url, const Vector<String> &p_headers, const uint8_t *p_body, int p_body_size) = 0;
 	virtual Error connect_to_host(const String &p_host, int p_port = -1, bool p_ssl = false, bool p_verify_host = true) = 0;

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -146,6 +146,11 @@ Error HTTPClientTCP::request(Method p_method, const String &p_url, const Vector<
 	ERR_FAIL_COND_V(status != STATUS_CONNECTED, ERR_INVALID_PARAMETER);
 	ERR_FAIL_COND_V(connection.is_null(), ERR_INVALID_DATA);
 
+	Error err = verify_headers(p_headers);
+	if (err) {
+		return err;
+	}
+
 	String uri = p_url;
 	if (!ssl && http_proxy_port != -1) {
 		uri = vformat("http://%s:%d%s", conn_host, conn_port, p_url);

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -71,7 +71,7 @@ Error HTTPClientTCP::connect_to_host(const String &p_host, int p_port, bool p_ss
 	connection = tcp_connection;
 
 	if (ssl && https_proxy_port != -1) {
-		proxy_client.instantiate(); // Needs proxy negotiation
+		proxy_client.instantiate(); // Needs proxy negotiation.
 		server_host = https_proxy_host;
 		server_port = https_proxy_port;
 	} else if (!ssl && http_proxy_port != -1) {
@@ -83,7 +83,7 @@ Error HTTPClientTCP::connect_to_host(const String &p_host, int p_port, bool p_ss
 	}
 
 	if (server_host.is_valid_ip_address()) {
-		// Host contains valid IP
+		// Host contains valid IP.
 		Error err = tcp_connection->connect_to_host(IPAddress(server_host), server_port);
 		if (err) {
 			status = STATUS_CANT_CONNECT;
@@ -92,7 +92,7 @@ Error HTTPClientTCP::connect_to_host(const String &p_host, int p_port, bool p_ss
 
 		status = STATUS_CONNECTING;
 	} else {
-		// Host contains hostname and needs to be resolved to IP
+		// Host contains hostname and needs to be resolved to IP.
 		resolving = IP::get_singleton()->resolve_hostname_queue_item(server_host);
 		status = STATUS_RESOLVING;
 	}
@@ -124,7 +124,7 @@ Ref<StreamPeer> HTTPClientTCP::get_connection() const {
 static bool _check_request_url(HTTPClientTCP::Method p_method, const String &p_url) {
 	switch (p_method) {
 		case HTTPClientTCP::METHOD_CONNECT: {
-			// Authority in host:port format, as in RFC7231
+			// Authority in host:port format, as in RFC7231.
 			int pos = p_url.find_char(':');
 			return 0 < pos && pos < p_url.length() - 1;
 		}
@@ -135,7 +135,7 @@ static bool _check_request_url(HTTPClientTCP::Method p_method, const String &p_u
 			[[fallthrough]];
 		}
 		default:
-			// Absolute path or absolute URL
+			// Absolute path or absolute URL.
 			return p_url.begins_with("/") || p_url.begins_with("http://") || p_url.begins_with("https://");
 	}
 }
@@ -173,7 +173,7 @@ Error HTTPClientTCP::request(Method p_method, const String &p_url, const Vector<
 	}
 	if (add_host) {
 		if ((ssl && conn_port == PORT_HTTPS) || (!ssl && conn_port == PORT_HTTP)) {
-			// Don't append the standard ports
+			// Don't append the standard ports.
 			request += "Host: " + conn_host + "\r\n";
 		} else {
 			request += "Host: " + conn_host + ":" + itos(conn_port) + "\r\n";
@@ -199,8 +199,7 @@ Error HTTPClientTCP::request(Method p_method, const String &p_url, const Vector<
 		memcpy(data.ptrw() + cs.length(), p_body, p_body_size);
 	}
 
-	// TODO Implement non-blocking requests.
-	Error err = connection->put_data(data.ptr(), data.size());
+	err = connection->put_data(data.ptr(), data.size());
 
 	if (err) {
 		close();
@@ -274,7 +273,7 @@ Error HTTPClientTCP::poll() {
 			IP::ResolverStatus rstatus = IP::get_singleton()->get_resolve_item_status(resolving);
 			switch (rstatus) {
 				case IP::RESOLVER_STATUS_WAITING:
-					return OK; // Still resolving
+					return OK; // Still resolving.
 
 				case IP::RESOLVER_STATUS_DONE: {
 					ip_candidates = IP::get_singleton()->get_resolve_item_addresses(resolving);
@@ -356,7 +355,7 @@ Error HTTPClientTCP::poll() {
 					} else if (ssl) {
 						Ref<StreamPeerSSL> ssl;
 						if (!handshaking) {
-							// Connect the StreamPeerSSL and start handshaking
+							// Connect the StreamPeerSSL and start handshaking.
 							ssl = Ref<StreamPeerSSL>(StreamPeerSSL::create());
 							ssl->set_blocking_handshake_enabled(false);
 							Error err = ssl->connect_to_stream(tcp_connection, ssl_verify_host, conn_host);
@@ -368,7 +367,7 @@ Error HTTPClientTCP::poll() {
 							connection = ssl;
 							handshaking = true;
 						} else {
-							// We are already handshaking, which means we can use your already active SSL connection
+							// We are already handshaking, which means we can use your already active SSL connection.
 							ssl = static_cast<Ref<StreamPeerSSL>>(connection);
 							if (ssl.is_null()) {
 								close();
@@ -376,22 +375,22 @@ Error HTTPClientTCP::poll() {
 								return ERR_CANT_CONNECT;
 							}
 
-							ssl->poll(); // Try to finish the handshake
+							ssl->poll(); // Try to finish the handshake.
 						}
 
 						if (ssl->get_status() == StreamPeerSSL::STATUS_CONNECTED) {
-							// Handshake has been successful
+							// Handshake has been successful.
 							handshaking = false;
 							ip_candidates.clear();
 							status = STATUS_CONNECTED;
 							return OK;
 						} else if (ssl->get_status() != StreamPeerSSL::STATUS_HANDSHAKING) {
-							// Handshake has failed
+							// Handshake has failed.
 							close();
 							status = STATUS_SSL_HANDSHAKE_ERROR;
 							return ERR_CANT_CONNECT;
 						}
-						// ... we will need to poll more for handshake to finish
+						// ... we will need to poll more for handshake to finish.
 					} else {
 						ip_candidates.clear();
 						status = STATUS_CONNECTED;
@@ -416,7 +415,7 @@ Error HTTPClientTCP::poll() {
 		} break;
 		case STATUS_BODY:
 		case STATUS_CONNECTED: {
-			// Check if we are still connected
+			// Check if we are still connected.
 			if (ssl) {
 				Ref<StreamPeerSSL> tmp = connection;
 				tmp->poll();
@@ -428,7 +427,7 @@ Error HTTPClientTCP::poll() {
 				status = STATUS_CONNECTION_ERROR;
 				return ERR_CONNECTION_ERROR;
 			}
-			// Connection established, requests can now be made
+			// Connection established, requests can now be made.
 			return OK;
 		} break;
 		case STATUS_REQUESTING: {
@@ -547,7 +546,7 @@ PackedByteArray HTTPClientTCP::read_response_body_chunk() {
 	if (chunked) {
 		while (true) {
 			if (chunk_trailer_part) {
-				// We need to consume the trailer part too or keep-alive will break
+				// We need to consume the trailer part too or keep-alive will break.
 				uint8_t b;
 				int rec = 0;
 				err = _get_http_data(&b, 1, rec);
@@ -560,18 +559,18 @@ PackedByteArray HTTPClientTCP::read_response_body_chunk() {
 				int cs = chunk.size();
 				if ((cs >= 2 && chunk[cs - 2] == '\r' && chunk[cs - 1] == '\n')) {
 					if (cs == 2) {
-						// Finally over
+						// Finally over.
 						chunk_trailer_part = false;
 						status = STATUS_CONNECTED;
 						chunk.clear();
 						break;
 					} else {
-						// We do not process nor return the trailer data
+						// We do not process nor return the trailer data.
 						chunk.clear();
 					}
 				}
 			} else if (chunk_left == 0) {
-				// Reading length
+				// Reading length.
 				uint8_t b;
 				int rec = 0;
 				err = _get_http_data(&b, 1, rec);
@@ -658,7 +657,7 @@ PackedByteArray HTTPClientTCP::read_response_body_chunk() {
 				uint8_t *w = ret.ptrw();
 				err = _get_http_data(w + _offset, to_read, rec);
 			}
-			if (rec <= 0) { // Ended up reading less
+			if (rec <= 0) { // Ended up reading less.
 				ret.resize(_offset);
 				break;
 			} else {
@@ -679,7 +678,7 @@ PackedByteArray HTTPClientTCP::read_response_body_chunk() {
 		close();
 
 		if (err == ERR_FILE_EOF) {
-			status = STATUS_DISCONNECTED; // Server disconnected
+			status = STATUS_DISCONNECTED; // Server disconnected.
 		} else {
 			status = STATUS_CONNECTION_ERROR;
 		}

--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -38,13 +38,13 @@ private:
 	Status status = STATUS_DISCONNECTED;
 	IP::ResolverID resolving = IP::RESOLVER_INVALID_ID;
 	Array ip_candidates;
-	int conn_port = -1; // Server to make requests to
+	int conn_port = -1; // Server to make requests to.
 	String conn_host;
-	int server_port = -1; // Server to connect to (might be a proxy server)
+	int server_port = -1; // Server to connect to (might be a proxy server).
 	String server_host;
-	int http_proxy_port = -1; // Proxy server for http requests
+	int http_proxy_port = -1; // Proxy server for http requests.
 	String http_proxy_host;
-	int https_proxy_port = -1; // Proxy server for https requests
+	int https_proxy_port = -1; // Proxy server for https requests.
 	String https_proxy_host;
 	bool ssl = false;
 	bool ssl_verify_host = false;
@@ -64,7 +64,7 @@ private:
 
 	Ref<StreamPeerTCP> tcp_connection;
 	Ref<StreamPeer> connection;
-	Ref<HTTPClientTCP> proxy_client; // Negotiate with proxy server
+	Ref<HTTPClientTCP> proxy_client; // Negotiate with proxy server.
 
 	int response_num = 0;
 	Vector<String> response_headers;

--- a/platform/javascript/http_client_javascript.cpp
+++ b/platform/javascript/http_client_javascript.cpp
@@ -87,6 +87,11 @@ Error HTTPClientJavaScript::request(Method p_method, const String &p_url, const 
 	ERR_FAIL_COND_V(port < 0, ERR_UNCONFIGURED);
 	ERR_FAIL_COND_V(!p_url.begins_with("/"), ERR_INVALID_PARAMETER);
 
+	Error err = verify_headers(p_headers);
+	if (err) {
+		return err;
+	}
+
 	String url = (use_tls ? "https://" : "http://") + host + ":" + itos(port) + p_url;
 	Vector<CharString> keeper;
 	Vector<const char *> c_strings;

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -86,9 +86,9 @@ String HTTPRequest::get_header_value(const PackedStringArray &p_headers, const S
 
 	String lowwer_case_header_name = p_header_name.to_lower();
 	for (int i = 0; i < p_headers.size(); i++) {
-		if (p_headers[i].find(":", 0) >= 0) {
+		if (p_headers[i].find(":") > 0) {
 			Vector<String> parts = p_headers[i].split(":", false, 1);
-			if (parts[0].strip_edges().to_lower() == lowwer_case_header_name) {
+			if (parts.size() > 1 && parts[0].strip_edges().to_lower() == lowwer_case_header_name) {
 				value = parts[1].strip_edges();
 				break;
 			}
@@ -134,7 +134,7 @@ Error HTTPRequest::request_raw(const String &p_url, const Vector<String> &p_cust
 	headers = p_custom_headers;
 
 	if (accept_gzip) {
-		// If the user has specified a Accept-Encoding header, don't overwrite it.
+		// If the user has specified an Accept-Encoding header, don't overwrite it.
 		if (!has_header(headers, "Accept-Encoding")) {
 			headers.push_back("Accept-Encoding: gzip, deflate");
 		}


### PR DESCRIPTION
Add `HTTPClient::verify_headers()` to verify user provided custom headers to fix https://github.com/godotengine/godot/issues/35956.
This is added as a check in HTTPClient implementations, i.e. HTTPClientTCP and HTTPClientJavaScript, inside their respective `request()` functions.

Also fixes a off by one error in the HTTPRequest node that could rarely lead to crashes.
And finally this formats comments in all touched files to be consistent with the current style in a separate commit.