### PR TITLE
Remove zero size checks from Rect2(i) grow methods

### DIFF
--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -207,11 +207,6 @@ struct Rect2 {
 	bool operator!=(const Rect2 &p_rect) const { return position != p_rect.position || size != p_rect.size; }
 
 	inline Rect2 grow(real_t p_amount) const {
-#ifdef MATH_CHECKS
-		if (unlikely(size.x < 0 || size.y < 0)) {
-			ERR_PRINT("Rect2 size is negative, this is not supported. Use Rect2.abs() to get a Rect2 with a positive size.");
-		}
-#endif
 		Rect2 g = *this;
 		g.grow_by(p_amount);
 		return g;
@@ -238,11 +233,6 @@ struct Rect2 {
 	}
 
 	inline Rect2 grow_individual(real_t p_left, real_t p_top, real_t p_right, real_t p_bottom) const {
-#ifdef MATH_CHECKS
-		if (unlikely(size.x < 0 || size.y < 0)) {
-			ERR_PRINT("Rect2 size is negative, this is not supported. Use Rect2.abs() to get a Rect2 with a positive size.");
-		}
-#endif
 		Rect2 g = *this;
 		g.position.x -= p_left;
 		g.position.y -= p_top;
@@ -488,11 +478,6 @@ struct Rect2i {
 	bool operator!=(const Rect2i &p_rect) const { return position != p_rect.position || size != p_rect.size; }
 
 	Rect2i grow(int p_amount) const {
-#ifdef MATH_CHECKS
-		if (unlikely(size.x < 0 || size.y < 0)) {
-			ERR_PRINT("Rect2i size is negative, this is not supported. Use Rect2i.abs() to get a Rect2i with a positive size.");
-		}
-#endif
 		Rect2i g = *this;
 		g.position.x -= p_amount;
 		g.position.y -= p_amount;
@@ -515,11 +500,6 @@ struct Rect2i {
 	}
 
 	inline Rect2i grow_individual(int p_left, int p_top, int p_right, int p_bottom) const {
-#ifdef MATH_CHECKS
-		if (unlikely(size.x < 0 || size.y < 0)) {
-			ERR_PRINT("Rect2i size is negative, this is not supported. Use Rect2i.abs() to get a Rect2i with a positive size.");
-		}
-#endif
 		Rect2i g = *this;
 		g.position.x -= p_left;
 		g.position.y -= p_top;


### PR DESCRIPTION
Fixes #56007 at least for the toast system to stop throwing warnings, reverts part of #37626.

For more details see [this comment](https://github.com/godotengine/godot/issues/56007#issuecomment-1001718852). My analysis, in order of importance:

1. The logic in this method doesn't actually depend on the Rect2 having a positive size, even if the method ends up producing a bad-for-some-cases value as an output. So we shouldn't have the warning here.
2. This method is used fine as it is for its current uses, so we don't need to change the behavior.
3. If the behavior was modified, there is no obvious answer to what the behavior should be.
    - If it clamped the size to a minimum of zero, then it could still move the position by moving around the left/top lines aka the top-left/start corner, which would be weird.
    - If it clamped the size to zero but then also put the position at the center, that apparently breaks things. It could also still move the position if the shrinking is not the same on both sides.
    - If it took the absolute value, this would also be weird. Imagine code that shrinks a Rect2 with a height of 5 by 10 on the top and bottom. Then it would alternate between a height of 5 and 15, which is strange.
4. Any place using this method will just have to be aware that this can return negative size rects when shrinking.