### PR TITLE
Fix shader crashing when declaring matrix or array varyings

### DIFF
--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -692,17 +692,36 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 				vcode += _prestr(varying.precision, ShaderLanguage::is_float_type(varying.type));
 				vcode += _typestr(varying.type);
 				vcode += " " + _mkid(varying_name);
+				uint32_t inc = 1U;
+
 				if (varying.array_size > 0) {
+					inc = (uint32_t)varying.array_size;
+
 					vcode += "[";
 					vcode += itos(varying.array_size);
 					vcode += "]";
 				}
+
+				switch (varying.type) {
+					case SL::TYPE_MAT2:
+						inc *= 2U;
+						break;
+					case SL::TYPE_MAT3:
+						inc *= 3U;
+						break;
+					case SL::TYPE_MAT4:
+						inc *= 4U;
+						break;
+					default:
+						break;
+				}
+
 				vcode += ";\n";
 
 				r_gen_code.stage_globals[STAGE_VERTEX] += "layout(location=" + itos(index) + ") " + interp_mode + "out " + vcode;
 				r_gen_code.stage_globals[STAGE_FRAGMENT] += "layout(location=" + itos(index) + ") " + interp_mode + "in " + vcode;
 
-				index++;
+				index += inc;
 			}
 
 			if (var_frag_to_light.size() > 0) {


### PR DESCRIPTION
I've detected shader crashing (due to overlapping location) when using code like this:
```
varying mat4 m;
varying float f; // cause shader compiler crash
```
or 
```
varying vec4 m[2];
varying float f;  // cause shader compiler crash
```
I've tested it with ShadeRED and found these cases need to be properly handled by adding offsets:

![image](https://user-images.githubusercontent.com/3036176/149467763-a949c66f-fade-4a4c-a18d-69eeafc86d84.png)
