### PR TITLE
Remove misleading velocity property from InputEventMouseMotion

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -123,6 +123,7 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_magnetometer", "value"), &Input::set_magnetometer);
 	ClassDB::bind_method(D_METHOD("set_gyroscope", "value"), &Input::set_gyroscope);
 	ClassDB::bind_method(D_METHOD("get_last_mouse_velocity"), &Input::get_last_mouse_velocity);
+	ClassDB::bind_method(D_METHOD("get_last_drag_velocity", "index"), &Input::get_last_drag_velocity);
 	ClassDB::bind_method(D_METHOD("get_mouse_button_mask"), &Input::get_mouse_button_mask);
 	ClassDB::bind_method(D_METHOD("set_mouse_mode", "mode"), &Input::set_mouse_mode);
 	ClassDB::bind_method(D_METHOD("get_mouse_mode"), &Input::get_mouse_mode);
@@ -531,7 +532,6 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 
 			drag_event->set_position(position);
 			drag_event->set_relative(relative);
-			drag_event->set_velocity(get_last_mouse_velocity());
 
 			event_dispatch_function(drag_event);
 		}
@@ -588,7 +588,6 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 	if (sd.is_valid()) {
 		VelocityTrack &track = touch_velocity_track[sd->get_index()];
 		track.update(sd->get_relative());
-		sd->set_velocity(track.velocity);
 
 		if (emulate_mouse_from_touch && sd->get_index() == mouse_from_touch_index) {
 			Ref<InputEventMouseMotion> motion_event;
@@ -598,7 +597,6 @@ void Input::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool p_is_em
 			motion_event->set_position(sd->get_position());
 			motion_event->set_global_position(sd->get_position());
 			motion_event->set_relative(sd->get_relative());
-			motion_event->set_velocity(sd->get_velocity());
 			motion_event->set_button_mask(mouse_button_mask);
 
 			_parse_input_event_impl(motion_event, true);
@@ -721,6 +719,13 @@ Point2 Input::get_mouse_position() const {
 
 Point2 Input::get_last_mouse_velocity() const {
 	return mouse_velocity_track.velocity;
+}
+
+Vector2 Input::get_last_drag_velocity(int p_index) const {
+	if (!touch_velocity_track.has(p_index)) {
+		return Vector2();
+	}
+	return touch_velocity_track[p_index].velocity;
 }
 
 MouseButton Input::get_mouse_button_mask() const {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -271,6 +271,7 @@ public:
 
 	Point2 get_mouse_position() const;
 	Vector2 get_last_mouse_velocity() const;
+	Vector2 get_last_drag_velocity(int p_index) const;
 	MouseButton get_mouse_button_mask() const;
 
 	void warp_mouse_position(const Vector2 &p_to);

--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -739,37 +739,25 @@ Vector2 InputEventMouseMotion::get_relative() const {
 	return relative;
 }
 
-void InputEventMouseMotion::set_velocity(const Vector2 &p_velocity) {
-	velocity = p_velocity;
-}
-
-Vector2 InputEventMouseMotion::get_velocity() const {
-	return velocity;
-}
-
 Ref<InputEvent> InputEventMouseMotion::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
 	Ref<InputEventMouseMotion> mm;
 	mm.instantiate();
 
 	mm->set_device(get_device());
 	mm->set_window_id(get_window_id());
-
 	mm->set_modifiers_from_event(this);
-
 	mm->set_position(p_xform.xform(get_position() + p_local_ofs));
 	mm->set_pressure(get_pressure());
 	mm->set_tilt(get_tilt());
 	mm->set_global_position(get_global_position());
-
 	mm->set_button_mask(get_button_mask());
 	mm->set_relative(p_xform.basis_xform(get_relative()));
-	mm->set_velocity(p_xform.basis_xform(get_velocity()));
 
 	return mm;
 }
 
 String InputEventMouseMotion::as_text() const {
-	return vformat(RTR("Mouse motion at position (%s) with velocity (%s)"), String(get_position()), String(get_velocity()));
+	return vformat(RTR("Mouse motion at position (%s)"), String(get_position()));
 }
 
 String InputEventMouseMotion::to_string() {
@@ -797,7 +785,7 @@ String InputEventMouseMotion::to_string() {
 
 	// Work around the fact vformat can only take 5 substitutions but 6 need to be passed.
 	String mask_and_position = vformat("button_mask=%s, position=(%s)", button_mask_string, String(get_position()));
-	return vformat("InputEventMouseMotion: %s, relative=(%s), velocity=(%s), pressure=%.2f, tilt=(%s)", mask_and_position, String(get_relative()), String(get_velocity()), get_pressure(), String(get_tilt()));
+	return vformat("InputEventMouseMotion: %s, relative=(%s), pressure=%.2f, tilt=(%s)", mask_and_position, String(get_relative()), get_pressure(), String(get_tilt()));
 }
 
 bool InputEventMouseMotion::accumulate(const Ref<InputEvent> &p_event) {
@@ -836,7 +824,6 @@ bool InputEventMouseMotion::accumulate(const Ref<InputEvent> &p_event) {
 
 	set_position(motion->get_position());
 	set_global_position(motion->get_global_position());
-	set_velocity(motion->get_velocity());
 	relative += motion->get_relative();
 
 	return true;
@@ -852,13 +839,9 @@ void InputEventMouseMotion::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_relative", "relative"), &InputEventMouseMotion::set_relative);
 	ClassDB::bind_method(D_METHOD("get_relative"), &InputEventMouseMotion::get_relative);
 
-	ClassDB::bind_method(D_METHOD("set_velocity", "velocity"), &InputEventMouseMotion::set_velocity);
-	ClassDB::bind_method(D_METHOD("get_velocity"), &InputEventMouseMotion::get_velocity);
-
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "tilt"), "set_tilt", "get_tilt");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pressure"), "set_pressure", "get_pressure");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "relative"), "set_relative", "get_relative");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "velocity"), "set_velocity", "get_velocity");
 }
 
 ///////////////////////////////////
@@ -1183,14 +1166,6 @@ Vector2 InputEventScreenDrag::get_relative() const {
 	return relative;
 }
 
-void InputEventScreenDrag::set_velocity(const Vector2 &p_velocity) {
-	velocity = p_velocity;
-}
-
-Vector2 InputEventScreenDrag::get_velocity() const {
-	return velocity;
-}
-
 Ref<InputEvent> InputEventScreenDrag::xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs) const {
 	Ref<InputEventScreenDrag> sd;
 
@@ -1202,17 +1177,16 @@ Ref<InputEvent> InputEventScreenDrag::xformed_by(const Transform2D &p_xform, con
 	sd->set_index(index);
 	sd->set_position(p_xform.xform(pos + p_local_ofs));
 	sd->set_relative(p_xform.basis_xform(relative));
-	sd->set_velocity(p_xform.basis_xform(velocity));
 
 	return sd;
 }
 
 String InputEventScreenDrag::as_text() const {
-	return vformat(RTR("Screen dragged with %s touch points at position (%s) with velocity of (%s)"), itos(index), String(get_position()), String(get_velocity()));
+	return vformat(RTR("Screen dragged with %s touch points at position (%s)"), itos(index), String(get_position()));
 }
 
 String InputEventScreenDrag::to_string() {
-	return vformat("InputEventScreenDrag: index=%d, position=(%s), relative=(%s), velocity=(%s)", index, String(get_position()), String(get_relative()), String(get_velocity()));
+	return vformat("InputEventScreenDrag: index=%d, position=(%s), relative=(%s)", index, String(get_position()), String(get_relative()));
 }
 
 bool InputEventScreenDrag::accumulate(const Ref<InputEvent> &p_event) {
@@ -1225,7 +1199,6 @@ bool InputEventScreenDrag::accumulate(const Ref<InputEvent> &p_event) {
 	}
 
 	set_position(drag->get_position());
-	set_velocity(drag->get_velocity());
 	relative += drag->get_relative();
 
 	return true;
@@ -1241,13 +1214,9 @@ void InputEventScreenDrag::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_relative", "relative"), &InputEventScreenDrag::set_relative);
 	ClassDB::bind_method(D_METHOD("get_relative"), &InputEventScreenDrag::get_relative);
 
-	ClassDB::bind_method(D_METHOD("set_velocity", "velocity"), &InputEventScreenDrag::set_velocity);
-	ClassDB::bind_method(D_METHOD("get_velocity"), &InputEventScreenDrag::get_velocity);
-
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "index"), "set_index", "get_index");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "relative"), "set_relative", "get_relative");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "velocity"), "set_velocity", "get_velocity");
 }
 
 ///////////////////////////////////

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -271,7 +271,6 @@ class InputEventMouseMotion : public InputEventMouse {
 	Vector2 tilt;
 	float pressure = 0;
 	Vector2 relative;
-	Vector2 velocity;
 
 protected:
 	static void _bind_methods();
@@ -285,9 +284,6 @@ public:
 
 	void set_relative(const Vector2 &p_relative);
 	Vector2 get_relative() const;
-
-	void set_velocity(const Vector2 &p_velocity);
-	Vector2 get_velocity() const;
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;
@@ -388,7 +384,6 @@ class InputEventScreenDrag : public InputEventFromWindow {
 	int index = 0;
 	Vector2 pos;
 	Vector2 relative;
-	Vector2 velocity;
 
 protected:
 	static void _bind_methods();
@@ -402,9 +397,6 @@ public:
 
 	void set_relative(const Vector2 &p_relative);
 	Vector2 get_relative() const;
-
-	void set_velocity(const Vector2 &p_velocity);
-	Vector2 get_velocity() const;
 
 	virtual Ref<InputEvent> xformed_by(const Transform2D &p_xform, const Vector2 &p_local_ofs = Vector2()) const override;
 	virtual String as_text() const override;

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -141,10 +141,17 @@
 				Returns the strength of the joypad vibration: x is the strength of the weak motor, and y is the strength of the strong motor.
 			</description>
 		</method>
+		<method name="get_last_drag_velocity" qualifiers="const">
+			<return type="Vector2" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Returns the calculated drag velocity for the specified [code]index[/code] [InputEventScreenDrag] event. To provide a precise and jitter-free velocity, drag velocity is only calculated every 0.1s. Therefore, drag velocity will lag drag movements. Drag velocity is only calculated when the drag is moving. Therefore, when the drag stops moving, this function will still return the value of the last motion.
+			</description>
+		</method>
 		<method name="get_last_mouse_velocity" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the mouse velocity for the last time the cursor was moved, and this until the next frame where the mouse moves. This means that even if the mouse is not moving, this function will still return the value of the last motion.
+				Returns the calculated mouse velocity for the last time the cursor was moved. To provide a precise and jitter-free velocity, mouse velocity is only calculated every 0.1s. Therefore, mouse velocity will lag mouse movements. Mouse velocity is only calculated when the mouse is moving. Therefore, when the mouse stops moving, this function will still return the value of the last motion.
 			</description>
 		</method>
 		<method name="get_magnetometer" qualifiers="const">

--- a/doc/classes/InputEventMouseMotion.xml
+++ b/doc/classes/InputEventMouseMotion.xml
@@ -22,8 +22,5 @@
 		<member name="tilt" type="Vector2" setter="set_tilt" getter="get_tilt" default="Vector2(0, 0)">
 			Represents the angles of tilt of the pen. Positive X-coordinate value indicates a tilt to the right. Positive Y-coordinate value indicates a tilt toward the user. Ranges from [code]-1.0[/code] to [code]1.0[/code] for both axes.
 		</member>
-		<member name="velocity" type="Vector2" setter="set_velocity" getter="get_velocity" default="Vector2(0, 0)">
-			The mouse velocity in pixels per second.
-		</member>
 	</members>
 </class>

--- a/doc/classes/InputEventScreenDrag.xml
+++ b/doc/classes/InputEventScreenDrag.xml
@@ -19,8 +19,5 @@
 		<member name="relative" type="Vector2" setter="set_relative" getter="get_relative" default="Vector2(0, 0)">
 			The drag position relative to the previous position (position at the last frame).
 		</member>
-		<member name="velocity" type="Vector2" setter="set_velocity" getter="get_velocity" default="Vector2(0, 0)">
-			The drag velocity.
-		</member>
 	</members>
 </class>

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -222,12 +222,9 @@ void DisplayServerJavaScript::mouse_move_callback(double p_x, double p_y, double
 	ev.instantiate();
 	dom2godot_mod(ev, p_modifiers);
 	ev->set_button_mask(input_mask);
-
 	ev->set_position(pos);
 	ev->set_global_position(pos);
-
 	ev->set_relative(Vector2(p_rel_x, p_rel_y));
-	ev->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 
 	Input::get_singleton()->parse_input_event(ev);
 }

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -3631,8 +3631,6 @@ void DisplayServerX11::process_events() {
 				mm->set_button_mask((MouseButton)mouse_get_button_state());
 				mm->set_position(pos);
 				mm->set_global_position(pos);
-				mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
-
 				mm->set_relative(rel);
 
 				last_mouse_pos = pos;
@@ -3661,7 +3659,6 @@ void DisplayServerX11::process_events() {
 							mm->set_window_id(E.key);
 							mm->set_position(pos_focused);
 							mm->set_global_position(pos_focused);
-							mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 							Input::get_singleton()->parse_input_event(mm);
 
 							break;

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -782,7 +782,6 @@ static void _mouseDownEvent(DisplayServer::WindowID window_id, NSEvent *event, M
 		mm->set_tilt(Vector2(p.x, p.y));
 	}
 	mm->set_global_position(pos);
-	mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 	const Vector2i relativeMotion = Vector2i(delta.x, delta.y) * DS_OSX->screen_get_max_scale();
 	mm->set_relative(relativeMotion);
 	_get_key_modifier_state([event modifierFlags], mm);

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2072,7 +2072,6 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 				mm->set_position(c);
 				mm->set_global_position(c);
-				mm->set_velocity(Vector2(0, 0));
 
 				if (raw->data.mouse.usFlags == MOUSE_MOVE_RELATIVE) {
 					mm->set_relative(Vector2(raw->data.mouse.lLastX, raw->data.mouse.lLastY));
@@ -2175,8 +2174,6 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 						ClientToScreen(windows[window_id].hWnd, &pos);
 						SetCursorPos(pos.x, pos.y);
 					}
-
-					mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 
 					if (old_invalid) {
 						old_x = mm->get_position().x;
@@ -2317,8 +2314,6 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				SetCursorPos(pos.x, pos.y);
 			}
 
-			mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
-
 			if (old_invalid) {
 				old_x = mm->get_position().x;
 				old_y = mm->get_position().y;
@@ -2416,8 +2411,6 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 				ClientToScreen(windows[window_id].hWnd, &pos);
 				SetCursorPos(pos.x, pos.y);
 			}
-
-			mm->set_velocity(Input::get_singleton()->get_last_mouse_velocity());
 
 			if (old_invalid) {
 				old_x = mm->get_position().x;

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3232,7 +3232,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		if (drag_touching && !drag_touching_deaccel) {
 			drag_accum -= mm->get_relative().y;
 			v_scroll->set_value(drag_from + drag_accum);
-			drag_speed = -mm->get_velocity().y;
+			drag_speed = -Input::get_singleton()->get_last_mouse_velocity().y;
 		}
 	}
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1699,13 +1699,10 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		if (over) {
 			Transform2D localizer = over->get_global_transform_with_canvas().affine_inverse();
 			Size2 pos = localizer.xform(mpos);
-			Vector2 velocity = localizer.basis_xform(mm->get_velocity());
 			Vector2 rel = localizer.basis_xform(mm->get_relative());
 
 			mm = mm->xformed_by(Transform2D()); // Make a copy.
-
 			mm->set_global_position(mpos);
-			mm->set_velocity(velocity);
 			mm->set_relative(rel);
 
 			if (mm->get_button_mask() == MouseButton::NONE) {
@@ -1955,12 +1952,9 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			if (over->can_process()) {
 				Transform2D localizer = over->get_global_transform_with_canvas().affine_inverse();
 				Size2 pos = localizer.xform(drag_event->get_position());
-				Vector2 velocity = localizer.basis_xform(drag_event->get_velocity());
 				Vector2 rel = localizer.basis_xform(drag_event->get_relative());
 
 				drag_event = drag_event->xformed_by(Transform2D()); // Make a copy.
-
-				drag_event->set_velocity(velocity);
 				drag_event->set_relative(rel);
 				drag_event->set_position(pos);
 


### PR DESCRIPTION
As described in godotengine/godot-proposals#3796, [`InputEventMouseMotion`](https://docs.godotengine.org/en/stable/classes/class_inputeventmousemotion.html) (and [`InputEventScreenDrag`](https://docs.godotengine.org/en/stable/classes/class_inputeventscreendrag.html)) has a `velocity` (`speed` in 3.x) property. However, the `velocity` value has nothing to do with the event. It is calculated within the engine and only updated every 0.1 s. It is the same value that can be retrieved using `Input.get_last_mouse_velocity()`. Therefore, adding this value to the event is misleading.

This PR removes the `velocity` property from `InputEventMouseMotion` and `InputEventScreenDrag`, and adds `Input.get_last_drag_velocity(index)` to return the calculated velocity for drag events.

Closes godotengine/godot-proposals#3796