### PR TITLE
[3.x] Fix crash when `is` keyword is tested against a String variable

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -473,7 +473,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					err_text = "Left operand of 'is' was already freed.";
 					OPCODE_BREAK;
 				}
-				if (b->is_invalid_object()) {
+				if (b->get_type() != Variant::OBJECT || b->is_invalid_object()) {
 					err_text = "Right operand of 'is' is not a class.";
 					OPCODE_BREAK;
 				}


### PR DESCRIPTION
Fixes #55547

`is_invalid_object()` only checks for objects that are invalid, but we need to exclude non-Object values too.

This has already been done on `master`:
https://github.com/godotengine/godot/blob/8866c365829896bf6b4c8ec4be25c161ccaf7282/modules/gdscript/gdscript_vm.cpp#L669-L672