### PR TITLE
[3.x] Fix `AtlasTexture` nesting

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -222,28 +222,14 @@ void SpriteFramesEditor::_sheet_add_frames() {
 
 	int fc = frames->get_frame_count(edited_anim);
 
-	Point2 src_origin;
-	Rect2 src_region(Point2(), texture_size);
-
-	AtlasTexture *src_atlas = Object::cast_to<AtlasTexture>(*split_sheet_preview->get_texture());
-	if (src_atlas && src_atlas->get_atlas().is_valid()) {
-		src_origin = src_atlas->get_region().position - src_atlas->get_margin().position;
-		src_region = src_atlas->get_region();
-	}
-
 	for (Set<int>::Element *E = frames_selected.front(); E; E = E->next()) {
 		int idx = E->get();
 		Point2 frame_coords(idx % frame_count_x, idx / frame_count_x);
 
-		Rect2 frame(frame_coords * frame_size + src_origin, frame_size);
-		Rect2 region = frame.clip(src_region);
-		Rect2 margin(region == Rect2() ? Point2() : region.position - frame.position, frame.size - region.size);
-
 		Ref<AtlasTexture> at;
 		at.instance();
 		at->set_atlas(split_sheet_preview->get_texture());
-		at->set_region(region);
-		at->set_margin(margin);
+		at->set_region(Rect2(frame_coords * frame_size, frame_size));
 
 		undo_redo->add_do_method(frames, "add_frame", edited_anim, at, -1);
 		undo_redo->add_undo_method(frames, "remove_frame", edited_anim, fc);

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1005,8 +1005,7 @@ void AtlasTexture::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_m
 		rc.size.height = atlas->get_height();
 	}
 
-	RID normal_rid = p_normal_map.is_valid() ? p_normal_map->get_rid() : RID();
-	VS::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, Rect2(p_pos + margin.position, rc.size), atlas->get_rid(), rc, p_modulate, p_transpose, normal_rid, filter_clip);
+	atlas->draw_rect_region(p_canvas_item, Rect2(p_pos + margin.position, rc.size), rc, p_modulate, p_transpose, p_normal_map);
 }
 
 void AtlasTexture::draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose, const Ref<Texture> &p_normal_map) const {
@@ -1027,8 +1026,7 @@ void AtlasTexture::draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile
 	Vector2 scale = p_rect.size / (region.size + margin.size);
 	Rect2 dr(p_rect.position + margin.position * scale, rc.size * scale);
 
-	RID normal_rid = p_normal_map.is_valid() ? p_normal_map->get_rid() : RID();
-	VS::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, dr, atlas->get_rid(), rc, p_modulate, p_transpose, normal_rid, filter_clip);
+	atlas->draw_rect_region(p_canvas_item, dr, rc, p_modulate, p_transpose, p_normal_map);
 }
 void AtlasTexture::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, const Ref<Texture> &p_normal_map, bool p_clip_uv) const {
 	//this might not necessarily work well if using a rect, needs to be fixed properly
@@ -1040,8 +1038,7 @@ void AtlasTexture::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, cons
 	Rect2 src_c;
 	get_rect_region(p_rect, p_src_rect, dr, src_c);
 
-	RID normal_rid = p_normal_map.is_valid() ? p_normal_map->get_rid() : RID();
-	VS::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, dr, atlas->get_rid(), src_c, p_modulate, p_transpose, normal_rid, filter_clip);
+	atlas->draw_rect_region(p_canvas_item, dr, src_c, p_modulate, p_transpose, p_normal_map);
 }
 
 bool AtlasTexture::get_rect_region(const Rect2 &p_rect, const Rect2 &p_src_rect, Rect2 &r_rect, Rect2 &r_src_rect) const {


### PR DESCRIPTION
When drawing an `AtlasTexture` it was directly calling the `VisualServer` by itself instead of just forwarding the draw request to the source `atlas` texture (with the proper rect/region passed in). As a result an `AtlasTexture` being a source `atlas` of another `AtlasTexture` could have resulted in incorrect rendering. This should be fixed now (assuming other methods work as they're supposed to).

With this being fixed it means that pretty much nothing external should care if some `Texture` is actually an `AtlasTexture` as there should be no need to treat it as some special case where `AtlasTexture`'s `region` and/or `margin` needs to be manually taken into account or something like that. If there's such special casing somewhere then it's very likely there's something wrong conceptually in there (as `AtlasTexture` should probably be handling this stuff by itself).

So for example fix in #37939 was conceptually wrong, the same as my fix in #51030 on top of it. I've kind of reverted them as such special casing is not needed in there (it was never needed in there, the bug was elsewhere). Now it should work properly.
Fixes #42806.
Fixes #56767.
Just note that for the frames already saved with the incorrect data above issues still hold.