### PR TITLE
Fixes broken scene shader compile due to undefined 'diffuse_color' variable with Oren Nayar + Vertex Lighting

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -212,7 +212,7 @@ void light_compute(vec3 N, vec3 L, vec3 V, vec3 light_color, float roughness, in
 		float t = mix(1.0, max(NdotL, NdotV), step(0.0, s));
 
 		float sigma2 = roughness * roughness; // TODO: this needs checking
-		vec3 A = 1.0 + sigma2 * (-0.5 / (sigma2 + 0.33) + 0.17 * diffuse_color / (sigma2 + 0.13));
+		vec3 A = 1.0 + sigma2 * (-0.5 / (sigma2 + 0.33) + 0.17 * diffuse / (sigma2 + 0.13));
 		float B = 0.45 * sigma2 / (sigma2 + 0.09);
 
 		diffuse_brdf_NL = cNdotL * (A + vec3(B) * s / t) * (1.0 / M_PI);


### PR DESCRIPTION
This is a 3.x specific issue, and this patch should fix #56799. Both `diffuse_color` and `diffuse` are used as argument and variable names throughout the shader, so I don't know what the preferred naming conventions are here. This seemed the more straightforward change as it fixes it in one spot, but if you'd prefer renaming the argument to something else that should still be a small change.

Before fix (on 3.5-beta1):
<img src="https://user-images.githubusercontent.com/1297988/149589978-767e1e83-b22c-40cd-a918-52b8512f0335.png">

After fix (custom build on 3.5-beta1 commit with this commit):
<img src="https://user-images.githubusercontent.com/1297988/149590014-4db1a25d-6c70-463a-9387-7d420b85ed72.png">