### PR TITLE
Fix crash when exiting the editor

### DIFF
--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -2661,7 +2661,7 @@ Ref<Texture2D> VisualScriptEditor::get_theme_icon() {
 	}
 
 	if (Control::has_theme_icon(icon_name, "EditorIcons")) {
-		return get_parent_control()->get_theme_icon(icon_name, "EditorIcons");
+		return Control::get_theme_icon(icon_name, SNAME("EditorIcons"));
 	}
 
 	return Control::get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons"));


### PR DESCRIPTION
The editor crashes when exiting after recent update. `get_parent_control()->` was used but it'll return null at exit, thus a null pointer access.

IINM, this block is choosing icon "VisualScript" or "VisualScriptInternal" according to script type, but fallback to "VisualScript" when the icon does not exist. `Control::get_theme_icon()` seems to do the same job.

CC @KoBeWi 

<details><summary>Backtrace</summary>

```
#0  0x000055555908e197 in Object::get_class_name (this=0x0) at ./core/object/object.h:717
#1  0x000055555eed6785 in Control::get_theme_icon (this=0x0, p_name=..., p_theme_type=...) at scene/gui/control.cpp:965
#2  0x00005555597f1342 in VisualScriptEditor::get_theme_icon (this=0x61d000de9490) at modules/visual_script/editor/visual_script_editor.cpp:2664
#3  0x000055555d945a2b in ScriptEditor::_update_script_names (this=0x61d0006b1c90) at editor/plugins/script_editor_plugin.cpp:1949
#4  0x000055555d95187d in ScriptEditor::save_all_scripts (this=0x61d0006b1c90) at editor/plugins/script_editor_plugin.cpp:2527
#5  0x000055555d97eb30 in ScriptEditorPlugin::save_external_data (this=0x61a000785490) at editor/plugins/script_editor_plugin.cpp:3950
#6  0x000055555c50abeb in EditorData::save_editor_external_data (this=0x61f0000342e8) at editor/editor_data.cpp:382
#7  0x000055555c7b6312 in EditorNode::_notification (this=0x61f000033a90, p_what=11) at editor/editor_node.cpp:621
#8  0x000055555c8811c2 in EditorNode::_notificationv (this=0x61f000033a90, p_notification=11, p_reversed=true) at editor/editor_node.h:99
#9  0x0000555563176404 in Object::notification (this=0x61f000033a90, p_notification=11, p_reversed=true) at core/object/object.cpp:846
#10 0x000055555eba097a in Node::_propagate_exit_tree (this=0x61f000033a90) at scene/main/node.cpp:279
#11 0x000055555eba06d2 in Node::_propagate_exit_tree (this=0x61d000247290) at scene/main/node.cpp:270
#12 0x000055555ebbfaa7 in Node::_set_tree (this=0x61d000247290, p_tree=0x0) at scene/main/node.cpp:2472
#13 0x000055555ec2beaa in SceneTree::finalize (this=0x617000031e90) at scene/main/scene_tree.cpp:567
#14 0x000055555894d147 in OS_LinuxBSD::run (this=0x7fffffffdff0) at platform/linuxbsd/os_linuxbsd.cpp:347
#15 0x000055555894467f in main (argc=4, argv=0x7fffffffe5b8) at platform/linuxbsd/godot_linuxbsd.cpp:58
```

</details>