### PR TITLE
Replace String::num_real code with a wrapper around String::num

### DIFF
--- a/tests/core/math/test_vector2.h
+++ b/tests/core/math/test_vector2.h
@@ -246,6 +246,25 @@ TEST_CASE("[Vector2] Operators") {
 	CHECK_MESSAGE(
 			Vector2(Vector2i(1, 2)) == Vector2(1, 2),
 			"Vector2 constructed from Vector2i should work as expected.");
+
+	CHECK_MESSAGE(
+			((String)decimal1) == "(2.3, 4.9)",
+			"Vector2 cast to String should work as expected.");
+	CHECK_MESSAGE(
+			((String)decimal2) == "(1.2, 3.4)",
+			"Vector2 cast to String should work as expected.");
+	CHECK_MESSAGE(
+			((String)Vector2(9.8, 9.9)) == "(9.8, 9.9)",
+			"Vector2 cast to String should work as expected.");
+#ifdef REAL_T_IS_DOUBLE
+	CHECK_MESSAGE(
+			((String)Vector2(Math_PI, Math_TAU)) == "(3.14159265358979, 6.28318530717959)",
+			"Vector2 cast to String should print the correct amount of digits for real_t = double.");
+#else
+	CHECK_MESSAGE(
+			((String)Vector2(Math_PI, Math_TAU)) == "(3.141593, 6.283185)",
+			"Vector2 cast to String should print the correct amount of digits for real_t = float.");
+#endif // REAL_T_IS_DOUBLE
 }
 
 TEST_CASE("[Vector2] Other methods") {

--- a/tests/core/math/test_vector3.h
+++ b/tests/core/math/test_vector3.h
@@ -271,6 +271,25 @@ TEST_CASE("[Vector3] Operators") {
 	CHECK_MESSAGE(
 			Vector3(Vector3i(1, 2, 3)) == Vector3(1, 2, 3),
 			"Vector3 constructed from Vector3i should work as expected.");
+
+	CHECK_MESSAGE(
+			((String)decimal1) == "(2.3, 4.9, 7.8)",
+			"Vector3 cast to String should work as expected.");
+	CHECK_MESSAGE(
+			((String)decimal2) == "(1.2, 3.4, 5.6)",
+			"Vector3 cast to String should work as expected.");
+	CHECK_MESSAGE(
+			((String)Vector3(9.7, 9.8, 9.9)) == "(9.7, 9.8, 9.9)",
+			"Vector3 cast to String should work as expected.");
+#ifdef REAL_T_IS_DOUBLE
+	CHECK_MESSAGE(
+			((String)Vector3(Math_E, Math_SQRT2, Math_SQRT3)) == "(2.71828182845905, 1.4142135623731, 1.73205080756888)",
+			"Vector3 cast to String should print the correct amount of digits for real_t = double.");
+#else
+	CHECK_MESSAGE(
+			((String)Vector3(Math_E, Math_SQRT2, Math_SQRT3)) == "(2.718282, 1.414214, 1.732051)",
+			"Vector3 cast to String should print the correct amount of digits for real_t = float.");
+#endif // REAL_T_IS_DOUBLE
 }
 
 TEST_CASE("[Vector3] Other methods") {

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -355,11 +355,17 @@ TEST_CASE("[String] Number to string") {
 	CHECK(String::num(42.100023, 4) == "42.1"); // No trailing zeros.
 
 	// String::num_real tests.
+	CHECK(String::num_real(1.0) == "1.0");
+	CHECK(String::num_real(1.0, false) == "1");
+	CHECK(String::num_real(9.9) == "9.9");
+	CHECK(String::num_real(9.99) == "9.99");
+	CHECK(String::num_real(9.999) == "9.999");
+	CHECK(String::num_real(9.9999) == "9.9999");
 	CHECK(String::num_real(3.141593) == "3.141593");
 	CHECK(String::num_real(3.141) == "3.141"); // No trailing zeros.
 #ifdef REAL_T_IS_DOUBLE
 	CHECK_MESSAGE(String::num_real(Math_PI) == "3.14159265358979", "Prints the appropriate amount of digits for real_t = double.");
-	CHECK_MESSAGE(String::num_real(3.1415f) == "3.14149999618530", "Prints more digits of 32-bit float when real_t = double (ones that would be reliable for double).");
+	CHECK_MESSAGE(String::num_real(3.1415f) == "3.1414999961853", "Prints more digits of 32-bit float when real_t = double (ones that would be reliable for double) and no trailing zero.");
 #else
 	CHECK_MESSAGE(String::num_real(Math_PI) == "3.141593", "Prints the appropriate amount of digits for real_t = float.");
 	CHECK_MESSAGE(String::num_real(3.1415f) == "3.1415", "Prints only reliable digits of 32-bit float when real_t = float.");


### PR DESCRIPTION
When I created some test cases for Vector2/Vector3 string operators, I noticed that the output was not as expected. Both before and after the improvements I made in #51864 there are edge cases where trailing zeros will print.

This PR adds some more test cases and changes the String::num_real code so that it's a wrapper around String::num but still does the expected things for String::num_real such as printing the correct amount of digits.

Without the String change, the added test cases will not work, for example:

```
./tests/core/math/test_vector3.h:276: ERROR: CHECK( ((String)decimal1) == "(2.3, 4.9, 7.8)" ) is NOT correct!
  values: CHECK( "(2.300000, 4.9, 7.800000)" == (2.3, 4.9, 7.8) )
  logged: Vector3 cast to String should work as expected.

./tests/core/math/test_vector3.h:279: ERROR: CHECK( ((String)decimal2) == "(1.2, 3.4, 5.6)" ) is NOT correct!
  values: CHECK( "(1.2, 3.4, 5.600000)" == (1.2, 3.4, 5.6) )
  logged: Vector3 cast to String should work as expected.

./tests/core/math/test_vector3.h:282: ERROR: CHECK( ((String)Vector3(9.7, 9.8, 9.9)) == "(9.7, 9.8, 9.9)" ) is NOT correct!
  values: CHECK( "(9.700000, 9.800000, 9.900000)" == (9.7, 9.8, 9.9) )
  logged: Vector3 cast to String should work as expected.
```

(similar problems happen with float=64, but with more trailing zeros)

This also made me realize that one of the existing test cases was wrong (there was a trailing zero that shouldn't be there)