### PR TITLE
Refactor size expression parsing for arrays in the shaders

### DIFF
--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -1045,11 +1045,8 @@ private:
 	bool _validate_varying_assign(ShaderNode::Varying &p_varying, String *r_message);
 	bool _check_node_constness(const Node *p_node) const;
 
-	Node *_parse_array_size(BlockNode *p_block, const FunctionInfo &p_function_info, int &r_array_size);
-	Error _parse_global_array_size(int &r_array_size, const FunctionInfo &p_function_info);
-	Error _parse_local_array_size(BlockNode *p_block, const FunctionInfo &p_function_info, Node *&r_size_expression, int &r_array_size, bool &r_is_unknown_size);
-
 	Node *_parse_expression(BlockNode *p_block, const FunctionInfo &p_function_info);
+	Error _parse_array_size(BlockNode *p_block, const FunctionInfo &p_function_info, bool p_forbid_unknown_size, Node **r_size_expression, int *r_array_size, bool *r_unknown_size);
 	Node *_parse_array_constructor(BlockNode *p_block, const FunctionInfo &p_function_info);
 	Node *_parse_array_constructor(BlockNode *p_block, const FunctionInfo &p_function_info, DataType p_type, const StringName &p_struct_name, int p_array_size);
 	ShaderLanguage::Node *_reduce_expression(BlockNode *p_block, ShaderLanguage::Node *p_node);


### PR DESCRIPTION
Changes:

- Removes duplicated methods for array size expression + replaces it in several new places. For example it's now possible to use it like this:

```
const int size = 3;
vec3[size] foo(vec3[size] v) {
	return v;
}
```

- Allow using constants as size initializers for other global constants eg:

```
shader_type spatial;

const int size = 3;
const float[size] a = {0.0, 1.0, 3.0}, b = {1.0, 0.0, 2.0};

void fragment() {
}
```

- Fixes constant initialization for arrays as I did for standard variables (and struct members) in https://github.com/godotengine/godot/pull/55957 and https://github.com/godotengine/godot/pull/55903 respectively.
