### PR TITLE
VS Projects: Don't include `mono_reg` without its module

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -780,9 +780,10 @@ def generate_vs_project(env, num_jobs):
             env.vs_incs.append(str(header))
 
         module_configs = ModuleConfigs()
-        import modules.mono.build_scripts.mono_reg_utils as mono_reg
 
         if env.get("module_mono_enabled"):
+            import modules.mono.build_scripts.mono_reg_utils as mono_reg
+
             mono_root = env.get("mono_prefix") or mono_reg.find_mono_root_dir(env["bits"])
             if mono_root:
                 module_configs.add_mode(


### PR DESCRIPTION
When generating project files for Visual Studio, Scons currently tries to include parts of `modules.mono` **before** checking whether the mono module is even built at all.

This breaks generation without the module:

    scons: Reading SConscript files ...
    Configuring for Windows: target=release_debug, bits=default
    Found MSVC version 14.3, arch amd64, bits=64
    ModuleNotFoundError: No module named 'modules.mono'; 'modules' is not a package:
      File "...\Godot\SConstruct", line 790:
        methods.generate_vs_project(env, GetOption("num_jobs"))
      File "...\Godot\methods.py", line 783:
        import modules.mono.build_scripts.mono_reg_utils as mono_reg

This PR moves the check in front of the import, fixing this issue.

Apparently this was added with 4c2f0a5c94c2f1b813985ee414bcd5e086b9ec5c, but I'm not 100% sure why it only broke today (at least for me). Might have been exposed by 9b781d24c02f1f94deb3ef29e81d5bd68a6b96c1.