### PR TITLE
[3.x] Bugfix - Fix tween.tell() returning 0 at end of tween

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -795,8 +795,7 @@ void Tween::_tween_process(float p_delta) {
 			Variant final_val = _get_final_val(data);
 			_apply_tween_value(data, final_val);
 
-			// Mark the tween as completed and emit the signal
-			data.elapsed = 0;
+			// Emit the signal
 			emit_signal("tween_completed", object, NodePath(Vector<StringName>(), data.key, false));
 
 			// If we are not repeating the tween, remove it


### PR DESCRIPTION
Currently, in godot 3.x, tween.tell() returns 0.0 on the final iteration of the tween. This means that on that iteration, there is actually no way for the client to know how much time is left on the tween.

eg)


```
func _ready():
tween.interpolate_property(self, "tweened_property", 0.0, 1.0, 1.0, Tween.TRANS_LINEAR, Tween.EASE_IN, 1.0)
	tween.interpolate_property(self, "tweened_property", 0.0, 1.0, 3.0, Tween.TRANS_LINEAR, Tween.EASE_IN, 0.5)
	tween.start()

func _process(delta: float) -> void:
	if tween.is_active():
		print("tween.tell %f tween.runtime %f" % [tween.tell(), tween.get_runtime()])
```

will output

```
tween.tell 1.983497 tween.runtime 2.000000
tween.tell 1.999786 tween.runtime 2.000000
tween.tell 0 tween.runtime 2.000000
```

This implies that tell() returning 0 could either mean the tween hasnt ran its first iteration yet or its ran its final iteration. tell() also never returns the actual final runtime. This is a bug because it means tween.tell() requires very careful and special handling by the user to actually determine what tell() == 0 means.

This PR fixes this by simply not setting elapsed to 0 when the tween is finished. Elapsed is clamped to the final runtime of the tween earlier in this same function.

This has been tested and there are no bugs introduced into repeating tweens or non-repeating tweens or delays, as all the internal code for those scenarios uses 'tween.finished' to determine the state of the tween.

Tween is different on master and doesn't have this bug, so there is no corresponding PR to master.