### PR TITLE
[3.x] Add maximum roughness cutoff to SSR to improve performance

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -248,6 +248,9 @@
 		<member name="ss_reflections_fade_out" type="float" setter="set_ssr_fade_out" getter="get_ssr_fade_out" default="2.0">
 			The fade-out distance for screen-space reflections. Affects the area from the screen-space reflection to the "global" reflection.
 		</member>
+		<member name="ss_reflections_max_roughness" type="float" setter="set_ssr_max_roughness" getter="get_ssr_max_roughness" default="0.75">
+			The roughness cutoff value for screen-space reflections. Screen pixels with roughness greater than [member ss_reflections_max_roughness] will not compute screen-space reflections. Higher values result in more visible screen-space reflections and less artifacting, at the cost of GPU performance. The default value is tuned to keep nearly all visible reflections while improving performance compared to not using a roughness cutoff ([member ss_reflections_max_roughness] = [code]1.0[/code]).
+		</member>
 		<member name="ss_reflections_max_steps" type="int" setter="set_ssr_max_steps" getter="get_ssr_max_steps" default="64">
 			The maximum number of steps for screen-space reflections. Higher values are slower.
 		</member>

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -942,6 +942,7 @@
 			<argument index="4" name="fade_out" type="float" />
 			<argument index="5" name="depth_tolerance" type="float" />
 			<argument index="6" name="roughness" type="bool" />
+			<argument index="7" name="max_roughness" type="float" default="0.75" />
 			<description>
 				Sets the variables to be used with the "screen space reflections" post-process effect. See [Environment] for more details.
 			</description>

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -69,7 +69,7 @@ public:
 
 	void environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture) {}
 
-	void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance, bool p_roughness) {}
+	void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance, bool p_roughness, float p_max_roughness = 0.7) {}
 	void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness) {}
 
 	void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale) {}

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -852,7 +852,7 @@ void RasterizerSceneGLES2::environment_set_fog(RID p_env, bool p_enable, float p
 	ERR_FAIL_COND(!env);
 }
 
-void RasterizerSceneGLES2::environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness) {
+void RasterizerSceneGLES2::environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness, float p_max_roughness) {
 	Environment *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
 }

--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -486,7 +486,7 @@ public:
 	virtual void environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_bloom_threshold, VS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, bool p_bicubic_upscale, bool p_high_quality);
 	virtual void environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture);
 
-	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness);
+	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness, float p_max_roughness = 0.7);
 	virtual void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness);
 
 	virtual void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -886,7 +886,7 @@ void RasterizerSceneGLES3::environment_set_glow(RID p_env, bool p_enable, int p_
 void RasterizerSceneGLES3::environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture) {
 }
 
-void RasterizerSceneGLES3::environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness) {
+void RasterizerSceneGLES3::environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness, float p_max_roughness) {
 	Environment *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
 
@@ -896,6 +896,7 @@ void RasterizerSceneGLES3::environment_set_ssr(RID p_env, bool p_enable, int p_m
 	env->ssr_fade_out = p_fade_out;
 	env->ssr_depth_tolerance = p_depth_tolerance;
 	env->ssr_roughness = p_roughness;
+	env->ssr_max_roughness = p_max_roughness;
 }
 
 void RasterizerSceneGLES3::environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VisualServer::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness) {
@@ -3506,6 +3507,7 @@ void RasterizerSceneGLES3::_render_mrts(Environment *env, const CameraMatrix &p_
 		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::DEPTH_TOLERANCE, env->ssr_depth_tolerance);
 		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::DISTANCE_FADE, env->ssr_fade_out);
 		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::CURVE_FADE_IN, env->ssr_fade_in);
+		state.ssr_shader.set_uniform(ScreenSpaceReflectionShaderGLES3::MAX_ROUGHNESS, env->ssr_max_roughness);
 
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, storage->frame.current_rt->effects.mip_maps[0].color);

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -387,6 +387,7 @@ public:
 		float ssr_fade_out;
 		float ssr_depth_tolerance;
 		bool ssr_roughness;
+		float ssr_max_roughness;
 
 		bool ssao_enabled;
 		float ssao_intensity;
@@ -552,7 +553,7 @@ public:
 	virtual void environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_bloom_threshold, VS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, bool p_bicubic_upscale, bool p_high_quality);
 	virtual void environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture);
 
-	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness);
+	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness, float p_max_roughness = 0.7);
 	virtual void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness);
 
 	virtual void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale);

--- a/drivers/gles3/shaders/screen_space_reflection.glsl
+++ b/drivers/gles3/shaders/screen_space_reflection.glsl
@@ -40,6 +40,7 @@ uniform int num_steps;
 uniform float depth_tolerance;
 uniform float distance_fade;
 uniform float curve_fade_in;
+uniform float max_roughness;
 
 layout(location = 0) out vec4 frag_color;
 
@@ -61,6 +62,13 @@ void main() {
 	normal = normal_roughness.xyz * 2.0 - 1.0;
 
 	float roughness = normal_roughness.w;
+
+	if (roughness > 0.7) {
+		// Do not compute SSR for rough materials to improve performance at the cost of
+		// subtle artifacting.
+		frag_color = vec4(0.0);
+		return;
+	}
 
 	float depth_tex = texture(source_depth, uv_interp).r;
 
@@ -189,6 +197,9 @@ void main() {
 		float grad = (steps_taken + 1.0) / float(num_steps);
 		float initial_fade = curve_fade_in == 0.0 ? 1.0 : pow(clamp(grad, 0.0, 1.0), curve_fade_in);
 		float fade = pow(clamp(1.0 - grad, 0.0, 1.0), distance_fade) * initial_fade;
+		// This is an ad-hoc term to fade out the SSR as roughness increases. Values used
+		// are meant to match the visual appearance of a ReflectionProbe.
+		float roughness_fade = smoothstep(0.4, 0.7, 1.0 - normal_roughness.w);
 		final_pos = pos;
 
 #ifdef REFLECT_ROUGHNESS
@@ -269,10 +280,10 @@ void main() {
 			final_color = textureLod(source_diffuse, final_pos * pixel_size, 0.0);
 		}
 
-		frag_color = vec4(final_color.rgb, fade * margin_blend);
+		frag_color = vec4(final_color.rgb, fade * margin_blend * roughness_fade);
 
 #else
-		frag_color = vec4(textureLod(source_diffuse, final_pos * pixel_size, 0.0).rgb, fade * margin_blend);
+		frag_color = vec4(textureLod(source_diffuse, final_pos * pixel_size, 0.0).rgb, fade * margin_blend * roughness_fade);
 #endif
 
 	} else {

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -346,7 +346,7 @@ void Environment::_validate_property(PropertyInfo &property) const {
 
 void Environment::set_ssr_enabled(bool p_enable) {
 	ssr_enabled = p_enable;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, ssr_max_roughness);
 	_change_notify();
 }
 
@@ -356,7 +356,7 @@ bool Environment::is_ssr_enabled() const {
 
 void Environment::set_ssr_max_steps(int p_steps) {
 	ssr_max_steps = p_steps;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, ssr_max_roughness);
 }
 int Environment::get_ssr_max_steps() const {
 	return ssr_max_steps;
@@ -364,7 +364,7 @@ int Environment::get_ssr_max_steps() const {
 
 void Environment::set_ssr_fade_in(float p_fade_in) {
 	ssr_fade_in = p_fade_in;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, ssr_max_roughness);
 }
 float Environment::get_ssr_fade_in() const {
 	return ssr_fade_in;
@@ -372,7 +372,7 @@ float Environment::get_ssr_fade_in() const {
 
 void Environment::set_ssr_fade_out(float p_fade_out) {
 	ssr_fade_out = p_fade_out;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, ssr_max_roughness);
 }
 float Environment::get_ssr_fade_out() const {
 	return ssr_fade_out;
@@ -380,7 +380,7 @@ float Environment::get_ssr_fade_out() const {
 
 void Environment::set_ssr_depth_tolerance(float p_depth_tolerance) {
 	ssr_depth_tolerance = p_depth_tolerance;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, ssr_max_roughness);
 }
 float Environment::get_ssr_depth_tolerance() const {
 	return ssr_depth_tolerance;
@@ -388,10 +388,19 @@ float Environment::get_ssr_depth_tolerance() const {
 
 void Environment::set_ssr_rough(bool p_enable) {
 	ssr_roughness = p_enable;
-	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness);
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, ssr_max_roughness);
 }
 bool Environment::is_ssr_rough() const {
 	return ssr_roughness;
+}
+
+void Environment::set_ssr_max_roughness(float p_max_roughness) {
+	ssr_max_roughness = p_max_roughness;
+	VS::get_singleton()->environment_set_ssr(environment, ssr_enabled, ssr_max_steps, ssr_fade_in, ssr_fade_out, ssr_depth_tolerance, ssr_roughness, ssr_max_roughness);
+}
+
+float Environment::get_ssr_max_roughness() const {
+	return ssr_max_roughness;
 }
 
 void Environment::set_ssao_enabled(bool p_enable) {
@@ -965,6 +974,9 @@ void Environment::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_ssr_rough", "rough"), &Environment::set_ssr_rough);
 	ClassDB::bind_method(D_METHOD("is_ssr_rough"), &Environment::is_ssr_rough);
 
+	ClassDB::bind_method(D_METHOD("set_ssr_max_roughness", "max_roughness"), &Environment::set_ssr_max_roughness);
+	ClassDB::bind_method(D_METHOD("get_ssr_max_roughness"), &Environment::get_ssr_max_roughness);
+
 	ADD_GROUP("SS Reflections", "ss_reflections_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ss_reflections_enabled"), "set_ssr_enabled", "is_ssr_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ss_reflections_max_steps", PROPERTY_HINT_RANGE, "1,512,1"), "set_ssr_max_steps", "get_ssr_max_steps");
@@ -972,6 +984,7 @@ void Environment::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "ss_reflections_fade_out", PROPERTY_HINT_EXP_EASING), "set_ssr_fade_out", "get_ssr_fade_out");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "ss_reflections_depth_tolerance", PROPERTY_HINT_RANGE, "0.1,128,0.1"), "set_ssr_depth_tolerance", "get_ssr_depth_tolerance");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ss_reflections_roughness"), "set_ssr_rough", "is_ssr_rough");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "ss_reflections_max_roughness", PROPERTY_HINT_RANGE, "0.2,1,0.001"), "set_ssr_max_roughness", "get_ssr_max_roughness");
 
 	ClassDB::bind_method(D_METHOD("set_ssao_enabled", "enabled"), &Environment::set_ssao_enabled);
 	ClassDB::bind_method(D_METHOD("is_ssao_enabled"), &Environment::is_ssao_enabled);
@@ -1220,6 +1233,7 @@ Environment::Environment() :
 	ssr_fade_out = 2.0;
 	ssr_depth_tolerance = 0.2;
 	ssr_roughness = true;
+	ssr_max_roughness = 0.7;
 
 	ssao_enabled = false;
 	ssao_radius = 1;

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -122,6 +122,7 @@ private:
 	float ssr_fade_out;
 	float ssr_depth_tolerance;
 	bool ssr_roughness;
+	float ssr_max_roughness;
 
 	bool ssao_enabled;
 	float ssao_radius;
@@ -267,6 +268,9 @@ public:
 
 	void set_ssr_rough(bool p_enable);
 	bool is_ssr_rough() const;
+
+	void set_ssr_max_roughness(float p_max_roughness);
+	float get_ssr_max_roughness() const;
 
 	void set_ssao_enabled(bool p_enable);
 	bool is_ssao_enabled() const;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -68,7 +68,7 @@ public:
 	virtual void environment_set_glow(RID p_env, bool p_enable, int p_level_flags, float p_intensity, float p_strength, float p_bloom_threshold, VS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, bool p_bicubic_upscale, bool p_high_quality) = 0;
 	virtual void environment_set_fog(RID p_env, bool p_enable, float p_begin, float p_end, RID p_gradient_texture) = 0;
 
-	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance, bool p_roughness) = 0;
+	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance, bool p_roughness, float p_max_roughness = 0.7) = 0;
 	virtual void environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_radius2, float p_intensity2, float p_bias, float p_light_affect, float p_ao_channel_affect, const Color &p_color, VS::EnvironmentSSAOQuality p_quality, VS::EnvironmentSSAOBlur p_blur, float p_bilateral_sharpness) = 0;
 
 	virtual void environment_set_tonemap(RID p_env, VS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale) = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -541,7 +541,7 @@ public:
 	BIND2(environment_set_canvas_max_layer, RID, int)
 	BIND4(environment_set_ambient_light, RID, const Color &, float, float)
 	BIND2(environment_set_camera_feed_id, RID, int)
-	BIND7(environment_set_ssr, RID, bool, int, float, float, float, bool)
+	BIND8(environment_set_ssr, RID, bool, int, float, float, float, bool, float)
 	BIND13(environment_set_ssao, RID, bool, float, float, float, float, float, float, float, const Color &, EnvironmentSSAOQuality, EnvironmentSSAOBlur, float)
 
 	BIND6(environment_set_dof_blur_near, RID, bool, float, float, float, EnvironmentDOFBlurQuality)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -449,7 +449,7 @@ public:
 	FUNC2(environment_set_canvas_max_layer, RID, int)
 	FUNC4(environment_set_ambient_light, RID, const Color &, float, float)
 	FUNC2(environment_set_camera_feed_id, RID, int)
-	FUNC7(environment_set_ssr, RID, bool, int, float, float, float, bool)
+	FUNC8(environment_set_ssr, RID, bool, int, float, float, float, bool, float)
 	FUNC13(environment_set_ssao, RID, bool, float, float, float, float, float, float, float, const Color &, EnvironmentSSAOQuality, EnvironmentSSAOBlur, float)
 
 	FUNC6(environment_set_dof_blur_near, RID, bool, float, float, float, EnvironmentDOFBlurQuality)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2120,7 +2120,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("environment_set_glow", "env", "enable", "level_flags", "intensity", "strength", "bloom_threshold", "blend_mode", "hdr_bleed_threshold", "hdr_bleed_scale", "hdr_luminance_cap", "bicubic_upscale", "high_quality"), &VisualServer::environment_set_glow);
 	ClassDB::bind_method(D_METHOD("environment_set_tonemap", "env", "tone_mapper", "exposure", "white", "auto_exposure", "min_luminance", "max_luminance", "auto_exp_speed", "auto_exp_grey"), &VisualServer::environment_set_tonemap);
 	ClassDB::bind_method(D_METHOD("environment_set_adjustment", "env", "enable", "brightness", "contrast", "saturation", "ramp"), &VisualServer::environment_set_adjustment);
-	ClassDB::bind_method(D_METHOD("environment_set_ssr", "env", "enable", "max_steps", "fade_in", "fade_out", "depth_tolerance", "roughness"), &VisualServer::environment_set_ssr);
+	ClassDB::bind_method(D_METHOD("environment_set_ssr", "env", "enable", "max_steps", "fade_in", "fade_out", "depth_tolerance", "roughness", "max_roughness"), &VisualServer::environment_set_ssr, DEFVAL(0.75));
 	ClassDB::bind_method(D_METHOD("environment_set_ssao", "env", "enable", "radius", "intensity", "radius2", "intensity2", "bias", "light_affect", "ao_channel_affect", "color", "quality", "blur", "bilateral_sharpness"), &VisualServer::environment_set_ssao);
 	ClassDB::bind_method(D_METHOD("environment_set_fog", "env", "enable", "color", "sun_color", "sun_amount"), &VisualServer::environment_set_fog);
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -804,7 +804,7 @@ public:
 	virtual void environment_set_tonemap(RID p_env, EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_grey) = 0;
 	virtual void environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, RID p_ramp) = 0;
 
-	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness) = 0;
+	virtual void environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_in, float p_fade_out, float p_depth_tolerance, bool p_roughness, float p_max_roughness = 0.7) = 0;
 
 	enum EnvironmentSSAOQuality {
 		ENV_SSAO_QUALITY_LOW,


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/56804.

In a test scene with mixed rough and non-rough materials, this saves 0.2 ms of GPU time with very little visual artifacting (GeForce RTX 4090, 3840×2160). This also incorporates the roughness fadeout from https://github.com/godotengine/godot/pull/69828, which can help hide visual artifacts on rough surfaces and generally make SSR look more stable.

~~The roughness cutoff can be adjusted in the Environment properties. Setting it to `1.0` will result in the previous behavior being used.~~
**Edit (June 2023):** This is no longer present for now. We need to discuss whether we should add this setting, as it's not in 4.x and probably won't be added there.

**Testing project (`3.x`):** [test_ssr_performance-3.x.zip](https://github.com/godotengine/godot/files/7875340/test_ssr_performance-3.x.zip)

## Preview

### No roughness cutoff (previous behavior)

![before webp](https://github.com/godotengine/godot/assets/180032/633104f6-e8c7-4de3-ae5f-b0f083ec6c57)

### Roughness cutoff = 0.7 (new default)

![after webp](https://github.com/godotengine/godot/assets/180032/748260a2-16ec-4e11-8c18-a7a7adaee003)
