### PR TITLE
[3.x] Fix touch events when using smartphone AR with WebXR

### DIFF
--- a/modules/webxr/doc_classes/WebXRInterface.xml
+++ b/modules/webxr/doc_classes/WebXRInterface.xml
@@ -109,6 +109,14 @@
 				- [signal squeezestart]
 			</description>
 		</method>
+		<method name="get_controller_target_ray_mode" qualifiers="const">
+			<return type="int" enum="WebXRInterface.TargetRayMode" />
+			<argument index="0" name="controller_id" type="int" />
+			<description>
+				Returns the target ray mode for the given [code]controller_id[/code].
+				This can help interpret the input coming from that controller. See [url=https://developer.mozilla.org/en-US/docs/Web/API/XRInputSource/targetRayMode]XRInputSource.targetRayMode[/url] for more information.
+			</description>
+		</method>
 		<method name="is_session_supported">
 			<return type="void" />
 			<argument index="0" name="session_mode" type="String" />
@@ -240,5 +248,17 @@
 		</signal>
 	</signals>
 	<constants>
+		<constant name="TARGET_RAY_MODE_UNKNOWN" value="0" enum="TargetRayMode">
+			We don't know the the target ray mode.
+		</constant>
+		<constant name="TARGET_RAY_MODE_GAZE" value="1" enum="TargetRayMode">
+			Target ray originates at the viewer's eyes and points in the direction they are looking.
+		</constant>
+		<constant name="TARGET_RAY_MODE_TRACKED_POINTER" value="2" enum="TargetRayMode">
+			Target ray from a handheld pointer, most likely a VR touch controller.
+		</constant>
+		<constant name="TARGET_RAY_MODE_SCREEN" value="3" enum="TargetRayMode">
+			Target ray from touch screen, mouse or other tactile input device.
+		</constant>
 	</constants>
 </class>

--- a/modules/webxr/godot_webxr.h
+++ b/modules/webxr/godot_webxr.h
@@ -37,12 +37,21 @@ extern "C" {
 
 #include "stddef.h"
 
+enum WebXRInputEvent {
+	WEBXR_INPUT_EVENT_SELECTSTART,
+	WEBXR_INPUT_EVENT_SELECTEND,
+	WEBXR_INPUT_EVENT_SELECT,
+	WEBXR_INPUT_EVENT_SQUEEZESTART,
+	WEBXR_INPUT_EVENT_SQUEEZEEND,
+	WEBXR_INPUT_EVENT_SQUEEZE,
+};
+
 typedef void (*GodotWebXRSupportedCallback)(char *p_session_mode, int p_supported);
 typedef void (*GodotWebXRStartedCallback)(char *p_reference_space_type);
 typedef void (*GodotWebXREndedCallback)();
 typedef void (*GodotWebXRFailedCallback)(char *p_message);
 typedef void (*GodotWebXRControllerCallback)();
-typedef void (*GodotWebXRInputEventCallback)(char *p_signal_name, int p_controller_id);
+typedef void (*GodotWebXRInputEventCallback)(int p_event_type, int p_controller_id);
 typedef void (*GodotWebXRSimpleEventCallback)(char *p_signal_name);
 
 extern int godot_webxr_is_supported();
@@ -73,6 +82,7 @@ extern int godot_webxr_is_controller_connected(int p_controller);
 extern float *godot_webxr_get_controller_transform(int p_controller);
 extern int *godot_webxr_get_controller_buttons(int p_controller);
 extern int *godot_webxr_get_controller_axes(int p_controller);
+extern int godot_webxr_get_controller_target_ray_mode(int p_controller);
 
 extern char *godot_webxr_get_visibility_state();
 extern int *godot_webxr_get_bounds_geometry();

--- a/modules/webxr/native/library_godot_webxr.js
+++ b/modules/webxr/native/library_godot_webxr.js
@@ -186,7 +186,7 @@ const GodotWebXR = {
 		// the first element, and the right hand is the second element, and any
 		// others placed at the 3rd position and up.
 		sampleControllers: () => {
-			if (!GodotWebXR.session || !GodotWebXR.frame) {
+			if (!GodotWebXR.session) {
 				return;
 			}
 
@@ -279,11 +279,12 @@ const GodotWebXR = {
 				}
 			});
 
-			['selectstart', 'select', 'selectend', 'squeezestart', 'squeeze', 'squeezeend'].forEach((input_event) => {
+			['selectstart', 'selectend', 'select', 'squeezestart', 'squeezeend', 'squeeze'].forEach((input_event, index) => {
 				session.addEventListener(input_event, function (evt) {
-					const c_str = GodotRuntime.allocString(input_event);
-					oninputevent(c_str, GodotWebXR.getControllerId(evt.inputSource));
-					GodotRuntime.free(c_str);
+					// Some controllers won't exist until an event occurs,
+					// for example, with "screen" input sources (touch).
+					GodotWebXR.sampleControllers();
+					oninputevent(index, GodotWebXR.getControllerId(evt.inputSource));
 				});
 			});
 
@@ -570,6 +571,35 @@ const GodotWebXR = {
 			GodotRuntime.setHeapValue(buf + 4 + (i * 4), value, 'float');
 		}
 		return buf;
+	},
+
+	godot_webxr_get_controller_target_ray_mode__proxy: 'sync',
+	godot_webxr_get_controller_target_ray_mode__sig: 'ii',
+	godot_webxr_get_controller_target_ray_mode: function (p_controller) {
+		if (p_controller < 0 || p_controller >= GodotWebXR.controllers.length) {
+			return 0;
+		}
+
+		const controller = GodotWebXR.controllers[p_controller];
+		if (!controller) {
+			return 0;
+		}
+
+		switch (controller.targetRayMode) {
+		case 'gaze':
+			return 1;
+
+		case 'tracked-pointer':
+			return 2;
+
+		case 'screen':
+			return 3;
+
+		default:
+			break;
+		}
+
+		return 0;
 	},
 
 	godot_webxr_get_visibility_state__proxy: 'sync',

--- a/modules/webxr/webxr_interface.cpp
+++ b/modules/webxr/webxr_interface.cpp
@@ -43,6 +43,7 @@ void WebXRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_requested_reference_space_types", "requested_reference_space_types"), &WebXRInterface::set_requested_reference_space_types);
 	ClassDB::bind_method(D_METHOD("get_requested_reference_space_types"), &WebXRInterface::get_requested_reference_space_types);
 	ClassDB::bind_method(D_METHOD("get_controller", "controller_id"), &WebXRInterface::get_controller);
+	ClassDB::bind_method(D_METHOD("get_controller_target_ray_mode", "controller_id"), &WebXRInterface::get_controller_target_ray_mode);
 	ClassDB::bind_method(D_METHOD("get_visibility_state"), &WebXRInterface::get_visibility_state);
 	ClassDB::bind_method(D_METHOD("get_bounds_geometry"), &WebXRInterface::get_bounds_geometry);
 
@@ -68,4 +69,9 @@ void WebXRInterface::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("visibility_state_changed"));
 	ADD_SIGNAL(MethodInfo("reference_space_reset"));
+
+	BIND_ENUM_CONSTANT(TARGET_RAY_MODE_UNKNOWN);
+	BIND_ENUM_CONSTANT(TARGET_RAY_MODE_GAZE);
+	BIND_ENUM_CONSTANT(TARGET_RAY_MODE_TRACKED_POINTER);
+	BIND_ENUM_CONSTANT(TARGET_RAY_MODE_SCREEN);
 }

--- a/modules/webxr/webxr_interface.h
+++ b/modules/webxr/webxr_interface.h
@@ -47,6 +47,13 @@ protected:
 	static void _bind_methods();
 
 public:
+	enum TargetRayMode {
+		TARGET_RAY_MODE_UNKNOWN,
+		TARGET_RAY_MODE_GAZE,
+		TARGET_RAY_MODE_TRACKED_POINTER,
+		TARGET_RAY_MODE_SCREEN,
+	};
+
 	virtual void is_session_supported(const String &p_session_mode) = 0;
 	virtual void set_session_mode(String p_session_mode) = 0;
 	virtual String get_session_mode() const = 0;
@@ -58,8 +65,11 @@ public:
 	virtual String get_requested_reference_space_types() const = 0;
 	virtual String get_reference_space_type() const = 0;
 	virtual Ref<ARVRPositionalTracker> get_controller(int p_controller_id) const = 0;
+	virtual TargetRayMode get_controller_target_ray_mode(int p_controller_id) const = 0;
 	virtual String get_visibility_state() const = 0;
 	virtual PoolVector3Array get_bounds_geometry() const = 0;
 };
+
+VARIANT_ENUM_CAST(WebXRInterface::TargetRayMode);
 
 #endif // WEBXR_INTERFACE_H

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -54,10 +54,15 @@ private:
 	String reference_space_type;
 
 	bool controllers_state[2];
+	bool touching[5];
 	Size2 render_targetsize;
 
 	Transform _js_matrix_to_transform(float *p_js_matrix);
 	void _update_tracker(int p_controller_id);
+
+	Vector2 _get_joy_vector_from_axes(int *p_axes);
+	int _get_touch_index(int p_input_source);
+	Vector2 _get_screen_position_from_joy_vector(const Vector2 &p_joy_vector);
 
 public:
 	virtual void is_session_supported(const String &p_session_mode);
@@ -72,6 +77,7 @@ public:
 	void _set_reference_space_type(String p_reference_space_type);
 	virtual String get_reference_space_type() const;
 	virtual Ref<ARVRPositionalTracker> get_controller(int p_controller_id) const;
+	virtual TargetRayMode get_controller_target_ray_mode(int p_controller_id) const;
 	virtual String get_visibility_state() const;
 	virtual PoolVector3Array get_bounds_geometry() const;
 
@@ -92,6 +98,7 @@ public:
 	virtual void notification(int p_what);
 
 	void _on_controller_changed();
+	void _on_input_event(int p_event_type, int p_input_source);
 
 	WebXRInterfaceJS();
 	~WebXRInterfaceJS();


### PR DESCRIPTION
After https://github.com/godotengine/godot/pull/55869, `Control`'s on a `CanvasLayer` will actually be shown on the screen when using smartphone AR. However, the `Control`s don't recognize any screen touch or drag events.

This PR will generate `InputEventScreenTouch` and `InputEventScreenDrag` events when using smartphone AR, so the `Control`s will actually work!

To implement this, I needed to use a piece of information from WebXR ([XRInputSource.targetRayMode](https://developer.mozilla.org/en-US/docs/Web/API/XRInputSource/targetRayMode)) that I think would also be useful for game developers, so this also adds a new method to the API: `WebXRInterface.get_controller_target_ray_mode()`

Discussed briefly on RocketChat with @akien-mga that this could be done only for 3.x for now, until we're actually able to test WebXR on 4.x.