### PR TITLE
Give example of one-liner for Array natural sort

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -470,6 +470,12 @@
 				// There is no sort support for Godot.Collections.Array
 				[/csharp]
 				[/codeblocks]
+				To perform natural order sorting, you can use [method sort_custom] with [method String.naturalnocasecmp_to] as follows:
+				[codeblock]
+				var strings = ["string1", "string2", "string10", "string11"]
+				strings.sort_custom(func(a, b): return a.naturalnocasecmp_to(b) &lt; 0)
+				print(strings) # Prints [string1, string2, string10, string11]
+				[/codeblock]
 			</description>
 		</method>
 		<method name="sort_custom">


### PR DESCRIPTION
The documentation for the sort method warns the user that it doesn't do natural sort but fails to provide a solution when it's just a one liner thanks to String.naturalnocasecmp_to() and lambda support

This suggests exactly the same algorithm as used by the filesystem dock for file sorting.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
