### PR TITLE
Replicate load-as-placeholder state on node duplication

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1986,6 +1986,7 @@ Node *Node::_duplicate(int p_flags, Map<const Node *, Node *> *r_duplimap) const
 #endif
 		node = res->instantiate(ges);
 		ERR_FAIL_COND_V(!node, nullptr);
+		node->set_scene_instance_load_placeholder(get_scene_instance_load_placeholder());
 
 		instantiated = true;
 


### PR DESCRIPTION
Fixes #18431

Was once implemented in #7670, but later lost during #13041 refactoring.