### PR TITLE
Re-implement support for the keep 3d linear flag

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3158,6 +3158,14 @@
 				Sets the viewport's global transformation matrix.
 			</description>
 		</method>
+		<method name="viewport_set_keep_3d_linear">
+			<return type="void" />
+			<argument index="0" name="viewport" type="RID" />
+			<argument index="1" name="enabled" type="bool" />
+			<description>
+				Sets the viewport's keep 3D linear setting, this skips the linear to sRGB conversion which happens after rendering 3D content.
+			</description>
+		</method>
 		<method name="viewport_set_measure_render_time">
 			<return type="void" />
 			<argument index="0" name="viewport" type="RID" />

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -215,6 +215,9 @@
 		</member>
 		<member name="handle_input_locally" type="bool" setter="set_handle_input_locally" getter="is_handling_input_locally" default="true">
 		</member>
+		<member name="keep_3d_linear" type="bool" setter="set_keep_3d_linear" getter="keeps_3d_linear" default="false">
+			This disabled the linear to sRGB color conversion that happens in the viewport after 3D content has been rendered. This can be needed if the end result needs to be sent to a secondary system such as an XR runtime. If the viewport is shown on screen the linear to sRGB conversion will be performed at the time of copying the render to screen.
+		</member>
 		<member name="mesh_lod_threshold" type="float" setter="set_mesh_lod_threshold" getter="get_mesh_lod_threshold" default="1.0">
 			The automatic LOD bias to use for meshes rendered within the [Viewport] (this is analogous to [member ReflectionProbe.mesh_lod_threshold]). Higher values will use less detailed versions of meshes that have LOD variations generated. If set to [code]0.0[/code], automatic LOD is disabled. Increase [member mesh_lod_threshold] to improve performance at the cost of geometry detail.
 			To control this property on the root viewport, set the [member ProjectSettings.rendering/mesh_lod/lod_change/threshold_pixels] project setting.

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -3543,6 +3543,13 @@ void RasterizerStorageGLES3::render_target_set_flag(RID p_render_target, RenderT
 	}
 }
 
+bool RasterizerStorageGLES3::render_target_get_flag(RID p_render_target, RenderTargetFlags p_flag) {
+	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_COND_V(!rt, false);
+
+	return rt->flags[p_flag];
+}
+
 bool RasterizerStorageGLES3::render_target_was_used(RID p_render_target) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_COND_V(!rt, false);

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1272,6 +1272,7 @@ public:
 	void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) override;
 
 	void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value) override;
+	bool render_target_get_flag(RID p_render_target, RenderTargetFlags p_flag) override;
 	bool render_target_was_used(RID p_render_target) override;
 	void render_target_clear_used(RID p_render_target);
 	void render_target_set_msaa(RID p_render_target, RS::ViewportMSAA p_msaa);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -959,6 +959,15 @@ bool Viewport::has_transparent_background() const {
 	return transparent_bg;
 }
 
+void Viewport::set_keep_3d_linear(bool p_enable) {
+	keep_3d_linear = p_enable;
+	RS::get_singleton()->viewport_set_keep_3d_linear(viewport, p_enable);
+}
+
+bool Viewport::keeps_3d_linear() const {
+	return keep_3d_linear;
+}
+
 void Viewport::set_world_2d(const Ref<World2D> &p_world_2d) {
 	if (world_2d == p_world_2d) {
 		return;
@@ -3549,6 +3558,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_transparent_background", "enable"), &Viewport::set_transparent_background);
 	ClassDB::bind_method(D_METHOD("has_transparent_background"), &Viewport::has_transparent_background);
 
+	ClassDB::bind_method(D_METHOD("set_keep_3d_linear", "enable"), &Viewport::set_keep_3d_linear);
+	ClassDB::bind_method(D_METHOD("keeps_3d_linear"), &Viewport::keeps_3d_linear);
+
 	ClassDB::bind_method(D_METHOD("set_msaa", "msaa"), &Viewport::set_msaa);
 	ClassDB::bind_method(D_METHOD("get_msaa"), &Viewport::get_msaa);
 
@@ -3676,6 +3688,7 @@ void Viewport::_bind_methods() {
 #endif // _3D_DISABLED
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "world_2d", PROPERTY_HINT_RESOURCE_TYPE, "World2D", PROPERTY_USAGE_NONE), "set_world_2d", "get_world_2d");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "transparent_bg"), "set_transparent_background", "has_transparent_background");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_3d_linear"), "set_keep_3d_linear", "keeps_3d_linear");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "handle_input_locally"), "set_handle_input_locally", "is_handling_input_locally");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "snap_2d_transforms_to_pixel"), "set_snap_2d_transforms_to_pixel", "is_snap_2d_transforms_to_pixel_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "snap_2d_vertices_to_pixel"), "set_snap_2d_vertices_to_pixel", "is_snap_2d_vertices_to_pixel_enabled");

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -230,6 +230,7 @@ private:
 	Rect2 last_vp_rect;
 
 	bool transparent_bg = false;
+	bool keep_3d_linear = false;
 	bool filter;
 	bool gen_mipmaps = false;
 
@@ -497,6 +498,9 @@ public:
 
 	void set_transparent_background(bool p_enable);
 	bool has_transparent_background() const;
+
+	void set_keep_3d_linear(bool p_enable);
+	bool keeps_3d_linear() const;
 
 	Ref<ViewportTexture> get_texture() const;
 

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -667,6 +667,7 @@ public:
 	RID render_target_get_texture(RID p_render_target) override { return RID(); }
 	void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) override {}
 	void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value) override {}
+	bool render_target_get_flag(RID p_render_target, RenderTargetFlags p_flag) override { return false; }
 	bool render_target_was_used(RID p_render_target) override { return false; }
 	void render_target_set_as_unused(RID p_render_target) override {}
 

--- a/servers/rendering/renderer_rd/effects_rd.cpp
+++ b/servers/rendering/renderer_rd/effects_rd.cpp
@@ -858,6 +858,8 @@ void EffectsRD::tonemapper(RID p_source_color, RID p_dst_framebuffer, const Tone
 	tonemap.push_constant.pixel_size[0] = 1.0 / p_settings.texture_size.x;
 	tonemap.push_constant.pixel_size[1] = 1.0 / p_settings.texture_size.y;
 
+	tonemap.push_constant.linear_to_srgb = p_settings.linear_to_srgb;
+
 	if (p_settings.view_count > 1) {
 		// Use MULTIVIEW versions
 		mode += 6;
@@ -903,6 +905,8 @@ void EffectsRD::tonemapper(RD::DrawListID p_subpass_draw_list, RID p_source_colo
 
 	tonemap.push_constant.use_debanding = p_settings.use_debanding;
 	tonemap.push_constant.luminance_multiplier = p_settings.luminance_multiplier;
+
+	tonemap.push_constant.linear_to_srgb = p_settings.linear_to_srgb;
 
 	RD::get_singleton()->draw_list_bind_render_pipeline(p_subpass_draw_list, tonemap.pipelines[mode].get_render_pipeline(RD::INVALID_ID, p_dst_format_id, false, RD::get_singleton()->draw_list_get_current_pass()));
 	RD::get_singleton()->draw_list_bind_uniform_set(p_subpass_draw_list, _get_uniform_set_for_input(p_source_color), 0);

--- a/servers/rendering/renderer_rd/effects_rd.h
+++ b/servers/rendering/renderer_rd/effects_rd.h
@@ -274,7 +274,7 @@ private:
 
 		uint32_t glow_texture_size[2]; //  8 - 40
 		float glow_intensity; //  4 - 44
-		uint32_t pad3; //  4 - 48
+		uint32_t linear_to_srgb; //  4 - 48
 
 		uint32_t glow_mode; //  4 - 52
 		float glow_levels[7]; // 28 - 80
@@ -970,6 +970,8 @@ public:
 		bool use_debanding = false;
 		Vector2i texture_size;
 		uint32_t view_count = 1;
+
+		bool linear_to_srgb;
 	};
 
 	struct SSAOSettings {

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -65,7 +65,7 @@ protected:
 		float upscale;
 		float aspect_ratio;
 		uint32_t layer;
-		uint32_t pad1;
+		uint32_t linear_to_srgb;
 	};
 
 	struct Blit {

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -2536,6 +2536,8 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 		tonemap.luminance_multiplier = _render_buffers_get_luminance_multiplier();
 		tonemap.view_count = p_render_data->view_count;
 
+		tonemap.linear_to_srgb = !storage->render_target_get_flag(rb->render_target, RendererStorage::RENDER_TARGET_KEEP_3D_LINEAR);
+
 		storage->get_effects()->tonemapper(rb->internal_texture, storage->render_target_get_rd_framebuffer(rb->render_target), tonemap);
 
 		RD::get_singleton()->draw_command_end_label();
@@ -2614,6 +2616,7 @@ void RendererSceneRenderRD::_post_process_subpass(RID p_source_texture, RID p_fr
 
 	tonemap.luminance_multiplier = _render_buffers_get_luminance_multiplier();
 	tonemap.view_count = p_render_data->view_count;
+	tonemap.linear_to_srgb = storage->render_target_get_flag(rb->render_target, RendererStorage::RENDER_TARGET_KEEP_3D_LINEAR);
 
 	storage->get_effects()->tonemapper(draw_list, p_source_texture, RD::get_singleton()->framebuffer_get_format(p_framebuffer), tonemap);
 

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -7724,6 +7724,13 @@ void RendererStorageRD::render_target_set_flag(RID p_render_target, RenderTarget
 	_update_render_target(rt);
 }
 
+bool RendererStorageRD::render_target_get_flag(RID p_render_target, RenderTargetFlags p_flag) {
+	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_COND_V(!rt, false);
+
+	return rt->flags[p_flag];
+}
+
 bool RendererStorageRD::render_target_was_used(RID p_render_target) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_COND_V(!rt, false);

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -2339,6 +2339,7 @@ public:
 	RID render_target_get_texture(RID p_render_target);
 	void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id);
 	void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value);
+	bool render_target_get_flag(RID p_render_target, RenderTargetFlags p_flag);
 	bool render_target_was_used(RID p_render_target);
 	void render_target_set_as_unused(RID p_render_target);
 	void render_target_copy_to_back_buffer(RID p_render_target, const Rect2i &p_region, bool p_gen_mipmaps);

--- a/servers/rendering/renderer_rd/shaders/blit.glsl
+++ b/servers/rendering/renderer_rd/shaders/blit.glsl
@@ -15,7 +15,7 @@ layout(push_constant, binding = 0, std140) uniform Pos {
 	float upscale;
 	float aspect_ratio;
 	uint layer;
-	uint pad1;
+	bool linear_to_srgb;
 }
 data;
 
@@ -45,7 +45,7 @@ layout(push_constant, binding = 0, std140) uniform Pos {
 	float upscale;
 	float aspect_ratio;
 	uint layer;
-	uint pad1;
+	bool linear_to_srgb;
 }
 data;
 
@@ -58,6 +58,13 @@ layout(binding = 0) uniform sampler2DArray src_rt;
 #else
 layout(binding = 0) uniform sampler2D src_rt;
 #endif
+
+vec3 linear_to_srgb(vec3 color) {
+	//if going to srgb, clamp from 0 to 1.
+	color = clamp(color, vec3(0.0), vec3(1.0));
+	const vec3 a = vec3(0.055f);
+	return mix((vec3(1.0f) + a) * pow(color.rgb, vec3(1.0f / 2.4f)) - a, 12.92f * color.rgb, lessThan(color.rgb, vec3(0.0031308f)));
+}
 
 void main() {
 #ifdef APPLY_LENS_DISTORTION
@@ -94,4 +101,8 @@ void main() {
 #else
 	color = texture(src_rt, uv);
 #endif
+
+	if (data.linear_to_srgb) {
+		color.rgb = linear_to_srgb(color.rgb);
+	}
 }

--- a/servers/rendering/renderer_rd/shaders/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/tonemap.glsl
@@ -63,7 +63,7 @@ layout(push_constant, binding = 1, std430) uniform Params {
 
 	uvec2 glow_texture_size;
 	float glow_intensity;
-	uint pad3;
+	bool linear_to_srgb;
 
 	uint glow_mode;
 	float glow_levels[7];
@@ -421,7 +421,9 @@ void main() {
 
 	color = apply_tonemapping(color, params.white);
 
-	color = linear_to_srgb(color); // regular linear -> SRGB conversion
+	if (!params.linear_to_srgb) {
+		color = linear_to_srgb(color); // regular linear -> SRGB conversion
+	}
 
 #ifndef SUBPASS
 	// Glow

--- a/servers/rendering/renderer_storage.h
+++ b/servers/rendering/renderer_storage.h
@@ -584,6 +584,7 @@ public:
 	enum RenderTargetFlags {
 		RENDER_TARGET_TRANSPARENT,
 		RENDER_TARGET_DIRECT_TO_SCREEN,
+		RENDER_TARGET_KEEP_3D_LINEAR,
 		RENDER_TARGET_FLAG_MAX
 	};
 
@@ -593,6 +594,7 @@ public:
 	virtual RID render_target_get_texture(RID p_render_target) = 0;
 	virtual void render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) = 0;
 	virtual void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value) = 0;
+	virtual bool render_target_get_flag(RID p_render_target, RenderTargetFlags p_flag) = 0;
 	virtual bool render_target_was_used(RID p_render_target) = 0;
 	virtual void render_target_set_as_unused(RID p_render_target) = 0;
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -993,6 +993,14 @@ void RendererViewport::viewport_set_transparent_background(RID p_viewport, bool 
 	viewport->transparent_bg = p_enabled;
 }
 
+void RendererViewport::viewport_set_keep_3d_linear(RID p_viewport, bool p_enabled) {
+	Viewport *viewport = viewport_owner.get_or_null(p_viewport);
+	ERR_FAIL_COND(!viewport);
+
+	RSG::storage->render_target_set_flag(viewport->render_target, RendererStorage::RENDER_TARGET_KEEP_3D_LINEAR, p_enabled);
+	viewport->transparent_bg = p_enabled;
+}
+
 void RendererViewport::viewport_set_global_canvas_transform(RID p_viewport, const Transform2D &p_transform) {
 	Viewport *viewport = viewport_owner.get_or_null(p_viewport);
 	ERR_FAIL_COND(!viewport);

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -243,6 +243,7 @@ public:
 	void viewport_remove_canvas(RID p_viewport, RID p_canvas);
 	void viewport_set_canvas_transform(RID p_viewport, RID p_canvas, const Transform2D &p_offset);
 	void viewport_set_transparent_background(RID p_viewport, bool p_enabled);
+	void viewport_set_keep_3d_linear(RID p_viewport, bool p_enabled);
 
 	void viewport_set_global_canvas_transform(RID p_viewport, const Transform2D &p_transform);
 	void viewport_set_canvas_stacking(RID p_viewport, RID p_canvas, int p_layer, int p_sublayer);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -558,6 +558,7 @@ public:
 	FUNC2(viewport_remove_canvas, RID, RID)
 	FUNC3(viewport_set_canvas_transform, RID, RID, const Transform2D &)
 	FUNC2(viewport_set_transparent_background, RID, bool)
+	FUNC2(viewport_set_keep_3d_linear, RID, bool)
 	FUNC2(viewport_set_snap_2d_transforms_to_pixel, RID, bool)
 	FUNC2(viewport_set_snap_2d_vertices_to_pixel, RID, bool)
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2198,6 +2198,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_canvas_stacking", "viewport", "canvas", "layer", "sublayer"), &RenderingServer::viewport_set_canvas_stacking);
 
 	ClassDB::bind_method(D_METHOD("viewport_set_transparent_background", "viewport", "enabled"), &RenderingServer::viewport_set_transparent_background);
+	ClassDB::bind_method(D_METHOD("viewport_set_keep_3d_linear", "viewport", "enabled"), &RenderingServer::viewport_set_keep_3d_linear);
 	ClassDB::bind_method(D_METHOD("viewport_set_global_canvas_transform", "viewport", "transform"), &RenderingServer::viewport_set_global_canvas_transform);
 
 	ClassDB::bind_method(D_METHOD("viewport_set_sdf_oversize_and_scale", "viewport", "oversize", "scale"), &RenderingServer::viewport_set_sdf_oversize_and_scale);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -821,6 +821,7 @@ public:
 	virtual void viewport_remove_canvas(RID p_viewport, RID p_canvas) = 0;
 	virtual void viewport_set_canvas_transform(RID p_viewport, RID p_canvas, const Transform2D &p_offset) = 0;
 	virtual void viewport_set_transparent_background(RID p_viewport, bool p_enabled) = 0;
+	virtual void viewport_set_keep_3d_linear(RID p_viewport, bool p_enabled) = 0;
 	virtual void viewport_set_snap_2d_transforms_to_pixel(RID p_viewport, bool p_enabled) = 0;
 	virtual void viewport_set_snap_2d_vertices_to_pixel(RID p_viewport, bool p_enabled) = 0;
 


### PR DESCRIPTION
This PR re-introduced the `keep_3d_linear` flag on our viewports.

This flag is needed in two scenarios:
- when rendering 3D content to a viewport that is then used as a texture, the linear -> sRGB conversion is doubled and that texture will appear to bright
- many XR interfaces require data submitted in linear color space

Only todo left:
The format for our render buffer as RGBA8 will lead to color banding, need to look into using R10G10B10A2 when keep 3d transparent is on but it's not using this correctly.