### PR TITLE
[3.x] Fix `LineEdit` center and right alignment

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -684,8 +684,8 @@ bool LineEdit::_is_over_clear_button(const Point2 &p_pos) const {
 
 void LineEdit::_notification(int p_what) {
 	switch (p_what) {
-#ifdef TOOLS_ENABLED
 		case NOTIFICATION_ENTER_TREE: {
+#ifdef TOOLS_ENABLED
 			if (Engine::get_singleton()->is_editor_hint() && !get_tree()->is_node_being_edited(this)) {
 				cursor_set_blink_enabled(EDITOR_DEF("text_editor/cursor/caret_blink", false));
 				cursor_set_blink_speed(EDITOR_DEF("text_editor/cursor/caret_blink_speed", 0.65));
@@ -694,8 +694,15 @@ void LineEdit::_notification(int p_what) {
 					EditorSettings::get_singleton()->connect("settings_changed", this, "_editor_settings_changed");
 				}
 			}
-		} break;
 #endif
+			update_cached_width();
+			update_placeholder_width();
+		} break;
+		case NOTIFICATION_THEME_CHANGED: {
+			update_cached_width();
+			update_placeholder_width();
+			update();
+		} break;
 		case NOTIFICATION_RESIZED: {
 			scroll_offset = 0;
 			set_cursor_position(get_cursor_position());


### PR DESCRIPTION
Fixes #18184

Updates text size cache when entering tree and when the theme changes.

`master` uses `TextServer` directly and does not do such caching, so the issue is not reproducible there.