### PR TITLE
HTML5: Add cache buster for html export

### DIFF
--- a/platform/javascript/js/engine/engine.js
+++ b/platform/javascript/js/engine/engine.js
@@ -121,6 +121,10 @@ const Engine = (function () {
 					});
 				}
 				preloader.setProgressFunc(this.config.onProgress);
+				if (typeof this.config.cacheBuster === 'string') {
+					this.preloader.setCacheBuster(this.config.cacheBuster);
+				}
+
 				initPromise = doInit(loadPromise);
 				return initPromise;
 			},

--- a/platform/javascript/js/engine/preloader.js
+++ b/platform/javascript/js/engine/preloader.js
@@ -1,4 +1,5 @@
 const Preloader = /** @constructor */ function () { // eslint-disable-line no-unused-vars
+
 	function getTrackedResponse(response, load_status) {
 		function onloadprogress(reader, controller) {
 			return reader.read().then(function (result) {
@@ -32,7 +33,8 @@ const Preloader = /** @constructor */ function () { // eslint-disable-line no-un
 			loaded: 0,
 			done: false,
 		};
-		return fetch(file).then(function (response) {
+
+		return fetch(file + cacheBuster).then(function (response) {
 			if (!response.ok) {
 				return Promise.reject(new Error(`Failed loading file '${file}'`));
 			}
@@ -62,6 +64,7 @@ const Preloader = /** @constructor */ function () { // eslint-disable-line no-un
 	const loadingFiles = {};
 	const lastProgress = { loaded: 0, total: 0 };
 	let progressFunc = null;
+	let cacheBuster = "";
 
 	const animateProgress = function () {
 		let loaded = 0;
@@ -98,6 +101,10 @@ const Preloader = /** @constructor */ function () { // eslint-disable-line no-un
 
 	this.setProgressFunc = function (callback) {
 		progressFunc = callback;
+	};
+
+	this.setCacheBuster = function (initCacheBuster) {
+		cacheBuster = initCacheBuster;
 	};
 
 	this.loadPromise = function (file, fileSize, raw = false) {


### PR DESCRIPTION
Html export works fine for the first time. You can use this for publishing your game on a webserver. But when you publish the game for a second time on your website the end users will not get your new game, instead it just loads the old version from the cache (even if you refresh the page) This is often something which you do not notice during development because during debugging the browser is configured to hard refresh your website.  For this problem I have implemented a cache buster. It is a simple change which adds a parameter with a timestamp of the export moment to the javascript and wasm urls. This way the game is updated when you  place a new version on your website. The fix is for normal html exports and not for progressive web app exports