### PR TITLE
Fix visible background line in intersections in screen-space reflections (3.x)

### DIFF
--- a/drivers/gles3/shaders/screen_space_reflection.glsl
+++ b/drivers/gles3/shaders/screen_space_reflection.glsl
@@ -186,8 +186,7 @@ void main() {
 		}
 
 		vec2 final_pos;
-		float grad;
-		grad = steps_taken / float(num_steps);
+		float grad = (steps_taken + 1.0) / float(num_steps);
 		float initial_fade = curve_fade_in == 0.0 ? 1.0 : pow(clamp(grad, 0.0, 1.0), curve_fade_in);
 		float fade = pow(clamp(1.0 - grad, 0.0, 1.0), distance_fade) * initial_fade;
 		final_pos = pos;


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/56844.

Adjusting the step grading by one resolves the issue without affecting performance or introducing adverse artifacts.

This bug has been around since Godot 3.0, and I finally managed to find a good fix for it :slightly_smiling_face:

## Preview

### Before

![2022-01-16_17 56 24](https://user-images.githubusercontent.com/180032/149669953-c5966056-b9e0-4306-9de9-a067167bd56f.png)

### After

![2022-01-16_17 55 35](https://user-images.githubusercontent.com/180032/149669956-5e48ae0b-c040-412b-aa74-c34d62868464.png)