### PR TITLE
Fix visible background line in intersections in screen-space reflections

### DIFF
--- a/servers/rendering/renderer_rd/shaders/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/screen_space_reflection.glsl
@@ -190,8 +190,7 @@ void main() {
 		}
 
 		vec2 final_pos;
-		float grad;
-		grad = steps_taken / float(params.num_steps);
+		float grad = (steps_taken + 1.0) / float(params.num_steps);
 		float initial_fade = params.curve_fade_in == 0.0 ? 1.0 : pow(clamp(grad, 0.0, 1.0), params.curve_fade_in);
 		float fade = pow(clamp(1.0 - grad, 0.0, 1.0), params.distance_fade) * initial_fade;
 		final_pos = pos;


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/56843.

Adjusting the step grading by one resolves the issue without affecting performance ~~or introducing adverse artifacts~~.

**Note:** [The above note about artifacts is currently not true due to a bug in the `master` SSR implementation that causes visible artifacts with the first step.](https://github.com/godotengine/godot/issues/56845) This does not happen in `3.x` and can be reproduced by setting **Fade In** to the Zero preset (right-click the value in the inspector).

This closes https://github.com/godotengine/godot/issues/50916.

## Preview

### Before

![2022-01-16_17 29 01](https://user-images.githubusercontent.com/180032/149670275-bfdc7ef9-6a68-44ea-b885-997a816a32f1.png)

### After

![2022-01-16_17 31 40](https://user-images.githubusercontent.com/180032/149670278-4fd6e6bc-4a50-4aaa-81f8-70a68934ce0f.png)