### PR TITLE
Prevent renaming to an unkown extension from FileSystem dock.

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1604,6 +1604,10 @@ void EditorFileSystem::update_file(const String &p_file) {
 	_queue_update_script_classes();
 }
 
+Set<String> EditorFileSystem::get_valid_extensions() const {
+	return valid_extensions;
+}
+
 Error EditorFileSystem::_reimport_group(const String &p_group_file, const Vector<String> &p_files) {
 	String importer_name;
 

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -272,6 +272,7 @@ public:
 	void scan();
 	void scan_changes();
 	void update_file(const String &p_file);
+	Set<String> get_valid_extensions() const;
 
 	EditorFileSystemDirectory *get_filesystem_path(const String &p_path);
 	String get_file_type(const String &p_file) const;

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1472,12 +1472,18 @@ void FileSystemDock::_folder_removed(String p_folder) {
 
 void FileSystemDock::_rename_operation_confirm() {
 	String new_name = rename_dialog_text->get_text().strip_edges();
+	String old_name = tree->get_selected()->get_text(0);
 	if (new_name.length() == 0) {
 		EditorNode::get_singleton()->show_warning(TTR("No name provided."));
 		return;
 	} else if (new_name.find("/") != -1 || new_name.find("\\") != -1 || new_name.find(":") != -1) {
 		EditorNode::get_singleton()->show_warning(TTR("Name contains invalid characters."));
 		return;
+	} else if (to_rename.is_file && old_name.get_extension() != new_name.get_extension()) {
+		if (!EditorFileSystem::get_singleton()->get_valid_extensions().find(new_name.get_extension())) {
+			EditorNode::get_singleton()->show_warning(TTR("This file extension is not recognized by the editor.\nIf you want to rename it anyway, use your operating system's file manager.\nAfter renaming to an unknown extension, the file won't be shown in the editor anymore."));
+			return;
+		}
 	}
 
 	String old_path = to_rename.path.ends_with("/") ? to_rename.path.substr(0, to_rename.path.length() - 1) : to_rename.path;


### PR DESCRIPTION
Fixes #56805

### Issue description

Renaming a file in FileSystem dock to an unrecognized extension hides the file in editor.
No warning. Just a file that disapears. Can't be undone from editor FileSystem dock.

### Fix proposal

Prevent doing such a thing because it is probably a mistake and it can't be undone from the editor which may be quite misleading.
Instead of renaming, show a warning explaining the situation.
Invite user to use system file explorer to do such a rename on purpose.

![image](https://user-images.githubusercontent.com/3649998/149672507-fc8c2990-3f94-4bc1-ac1d-6bc083e77790.png)

As english is not my native language, you are invited to provide me a better message if you think it's needed.

