### PR TITLE
Fix crash when undoing node creation of BlendTree editor

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -103,7 +103,7 @@ void AnimationNodeBlendTreeEditor::_property_changed(const StringName &p_propert
 }
 
 void AnimationNodeBlendTreeEditor::_update_graph() {
-	if (updating) {
+	if (updating || blend_tree.is_null()) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #37385

`AnimationNodeBlendTreeEditor::_update_graph()` will be called when undoing node creation in BlendTree editor to force update the graph view.

But `AnimationNodeBlendTreeEditor` won't be editing anything when you're in another editor (e.g. the BlendSpace2D editor mentioned in the issue). So pressing undo results in accessing `blend_tree` which is a null pointer access.