### PR TITLE
Fix invalid read when using LightOccluder2D

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1440,7 +1440,7 @@ void RendererCanvasCull::canvas_light_occluder_set_polygon(RID p_occluder, RID p
 	ERR_FAIL_COND(!occluder);
 
 	if (occluder->polygon.is_valid()) {
-		LightOccluderPolygon *occluder_poly = canvas_light_occluder_polygon_owner.get_or_null(p_polygon);
+		LightOccluderPolygon *occluder_poly = canvas_light_occluder_polygon_owner.get_or_null(occluder->polygon);
 		if (occluder_poly) {
 			occluder_poly->owners.erase(occluder);
 		}


### PR DESCRIPTION
Fixes #41127

The code is supposed to remove the occluder from the old polygon's owner set, but actually used the new polygon by mistake.

The issue exists on `master` too, but AddressSanitizer does not catch the invalid read on my machine :(

For `3.x` cherry-pick: `RendererCanvasCull` → `VisualServerCanvas`.