### PR TITLE
[3.x] ImageLoader: Remove references to unsupported svgz extension

### DIFF
--- a/drivers/dummy/texture_loader_dummy.cpp
+++ b/drivers/dummy/texture_loader_dummy.cpp
@@ -77,7 +77,6 @@ void ResourceFormatDummyTexture::get_recognized_extensions(List<String> *p_exten
 	p_extensions->push_back("png");
 	p_extensions->push_back("pvr");
 	p_extensions->push_back("svg");
-	p_extensions->push_back("svgz");
 	p_extensions->push_back("tga");
 	p_extensions->push_back("webp");
 }
@@ -99,7 +98,6 @@ String ResourceFormatDummyTexture::get_resource_type(const String &p_path) const
 			extension == "png" ||
 			extension == "pvr" ||
 			extension == "svg" ||
-			extension == "svgz" ||
 			extension == "tga" ||
 			extension == "webp") {
 		return "ImageTexture";

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -140,7 +140,6 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 		extension_guess["jpeg"] = tree->get_icon("ImageTexture", "EditorIcons");
 		extension_guess["png"] = tree->get_icon("ImageTexture", "EditorIcons");
 		extension_guess["svg"] = tree->get_icon("ImageTexture", "EditorIcons");
-		extension_guess["svgz"] = tree->get_icon("ImageTexture", "EditorIcons");
 		extension_guess["tga"] = tree->get_icon("ImageTexture", "EditorIcons");
 		extension_guess["webp"] = tree->get_icon("ImageTexture", "EditorIcons");
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1471,7 +1471,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	GLOBAL_DEF("application/config/icon", String());
 	ProjectSettings::get_singleton()->set_custom_property_info("application/config/icon",
 			PropertyInfo(Variant::STRING, "application/config/icon",
-					PROPERTY_HINT_FILE, "*.png,*.webp,*.svg,*.svgz"));
+					PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"));
 
 	GLOBAL_DEF("application/config/macos_native_icon", String());
 	ProjectSettings::get_singleton()->set_custom_property_info("application/config/macos_native_icon", PropertyInfo(Variant::STRING, "application/config/macos_native_icon", PROPERTY_HINT_FILE, "*.icns"));

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -152,7 +152,6 @@ Error ImageLoaderSVG::load_image(Ref<Image> p_image, FileAccess *f, bool p_force
 
 void ImageLoaderSVG::get_recognized_extensions(List<String> *p_extensions) const {
 	p_extensions->push_back("svg");
-	p_extensions->push_back("svgz");
 }
 
 ImageLoaderSVG::ImageLoaderSVG() {

--- a/platform/javascript/export/export.cpp
+++ b/platform/javascript/export/export.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#include "export.h"
+
 #include "core/io/image_loader.h"
 #include "core/io/json.h"
 #include "core/io/stream_peer_ssl.h"
@@ -658,9 +660,9 @@ void EditorExportPlatformJavaScript::get_export_options(List<ExportOption> *r_op
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "progressive_web_app/offline_page", PROPERTY_HINT_FILE, "*.html"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "progressive_web_app/display", PROPERTY_HINT_ENUM, "Fullscreen,Standalone,Minimal Ui,Browser"), 1));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "progressive_web_app/orientation", PROPERTY_HINT_ENUM, "Any,Landscape,Portrait"), 0));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "progressive_web_app/icon_144x144", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg,*.svgz"), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "progressive_web_app/icon_180x180", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg,*.svgz"), ""));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "progressive_web_app/icon_512x512", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg,*.svgz"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "progressive_web_app/icon_144x144", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "progressive_web_app/icon_180x180", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), ""));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "progressive_web_app/icon_512x512", PROPERTY_HINT_FILE, "*.png,*.webp,*.svg"), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::COLOR, "progressive_web_app/background_color", PROPERTY_HINT_COLOR_NO_ALPHA), Color()));
 }
 

--- a/platform/windows/export/export.cpp
+++ b/platform/windows/export/export.cpp
@@ -28,6 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#include "export.h"
+
 #include "core/os/file_access.h"
 #include "core/os/os.h"
 #include "editor/editor_export.h"


### PR DESCRIPTION
I don't see any reference to gzip/svgz supported in the nanosvg library,
and the handful of test gzip compressed svgz files I tried failed loading.

Also cleaning a couple missing includes in platform export code.

See discussion in #56850.

- Fixes #54700.

`master` equivalent: #56863