### PR TITLE
Fix a node reparenting warning in the editor debugger

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1778,7 +1778,6 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		inspector->register_text_enter(search);
 		inspector->set_use_filter(true);
 		inspector_vbox->add_child(inspector);
-		sc->add_child(inspector);
 
 		breakpoints_tree = memnew(Tree);
 		breakpoints_tree->set_h_size_flags(SIZE_EXPAND_FILL);


### PR DESCRIPTION
A small mistake, probably from a bad rebase, introduced by https://github.com/godotengine/godot/pull/53546. Caused the editor to complain about bad reparenting.