### PR TITLE
[3.x] Expose `Image.COMPRESS_SOURCE_LAYERED` to scripting

### DIFF
--- a/core/image.cpp
+++ b/core/image.cpp
@@ -3020,6 +3020,7 @@ void Image::_bind_methods() {
 	BIND_ENUM_CONSTANT(COMPRESS_SOURCE_GENERIC);
 	BIND_ENUM_CONSTANT(COMPRESS_SOURCE_SRGB);
 	BIND_ENUM_CONSTANT(COMPRESS_SOURCE_NORMAL);
+	BIND_ENUM_CONSTANT(COMPRESS_SOURCE_LAYERED);
 }
 
 void Image::set_compress_bc_func(void (*p_compress_func)(Image *, float, CompressSource)) {

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -611,5 +611,8 @@
 		<constant name="COMPRESS_SOURCE_NORMAL" value="2" enum="CompressSource">
 			Source texture (before compression) is a normal texture (e.g. it can be compressed into two channels).
 		</constant>
+		<constant name="COMPRESS_SOURCE_LAYERED" value="3" enum="CompressSource">
+			Source texture (before compression) is a [TextureLayered].
+		</constant>
 	</constants>
 </class>


### PR DESCRIPTION
Fixes #43387

This targets `3.x` because the enumerator is removed on `master` during the Vulkan update.