### PR TITLE
Fixed a typo in BakedLightmap documentation

### DIFF
--- a/doc/classes/BakedLightmap.xml
+++ b/doc/classes/BakedLightmap.xml
@@ -45,7 +45,7 @@
 			When enabled, an octree containing the scene's lighting information will be computed. This octree will then be used to light dynamic objects in the scene.
 		</member>
 		<member name="capture_propagation" type="float" setter="set_capture_propagation" getter="get_capture_propagation" default="1.0">
-			Bias value to reduce the amount of light proagation in the captured octree.
+			Bias value to reduce the amount of light propagation in the captured octree.
 		</member>
 		<member name="capture_quality" type="int" setter="set_capture_quality" getter="get_capture_quality" enum="BakedLightmap.BakeQuality" default="1">
 			Bake quality of the capture data.


### PR DESCRIPTION
"capture_propagation" member documentation description was missing the second 'p' in "propagation". Fixed this minor typo
Also resubmitting pull request to 3.x branch as per @Calinou 's recommendation.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
