### PR TITLE
Fix export errors not setting exit code correctly

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3000,7 +3000,7 @@ void EditorNode::_exit_editor() {
 	// Dim the editor window while it's quitting to make it clearer that it's busy
 	dim_editor(true);
 
-	get_tree()->quit();
+	get_tree()->quit(OS::get_singleton()->get_exit_code());
 }
 
 void EditorNode::_discard_changes(const String &p_str) {


### PR DESCRIPTION
When exporting a project, there are a lot of errors checked and emitted in EditorNode's `_fs_changed()` function: https://github.com/godotengine/godot/blob/master/editor/editor_node.cpp#L877-L964 (as a comment rightfully points out, this is a bit messy and should probably be moved out of there eventually).

That code takes a lot of care to set the OS exit code for Godot at the end if any export error was detected:
https://github.com/godotengine/godot/blob/master/editor/editor_node.cpp#L877-L964

However, it then immediately afterwards call `_exit_editor()`, which just calls `tree->quit()` without the exit code parameter, which then uses a default of 0, sets that and exits Godot, effectively overriding the previous value and ensuring Godot's export always exits with exit code 0, whether it encountered any errors or not.

This properly retains the current exit code when exiting from the export code. FWIW, I searched for similar errors in the code base but found no other instances.