### PR TITLE
Improve 2D editor's right-click menu

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -84,6 +84,8 @@ public:
 	enum AddNodeOption {
 		ADD_NODE,
 		ADD_INSTANCE,
+		ADD_PASTE,
+		ADD_MOVE,
 	};
 
 private:

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3060,6 +3060,10 @@ List<Node *> SceneTreeDock::paste_nodes() {
 	return pasted_nodes;
 }
 
+List<Node *> SceneTreeDock::get_node_clipboard() const {
+	return node_clipboard;
+}
+
 void SceneTreeDock::add_remote_tree_editor(Control *p_remote) {
 	ERR_FAIL_COND(remote_tree != nullptr);
 	add_child(p_remote);

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -315,6 +315,7 @@ public:
 	void open_instance_child_dialog();
 
 	List<Node *> paste_nodes();
+	List<Node *> get_node_clipboard() const;
 
 	ScriptCreateDialog *get_script_create_dialog() { return script_create_dialog; }
 


### PR DESCRIPTION
- adds "Paste Node(s) Here" option (originally requested [here](https://github.com/godotengine/godot/pull/41437#issuecomment-1003607869))
  - available only if there is at least 1 CanvasItem in node clipboard
- adds "Move Node(s) Here" option (I vaguely remember someone mentioning it; the dialog is small anyways, so adding more actions won't hurt)
  - available only if there is at least 1 CanvasItem currently selected
- renames "Instance Scene Here" to "Instantiate Scene Here"
![godot windows tools 64_vZpnTBzyCn](https://user-images.githubusercontent.com/2223172/149848064-70d324e0-2dbb-4bac-924b-440cda30669f.gif)

Putting as draft for now, because global positions don't work correctly.

btw apparently we don't have Paste and Move icons (unless they are named differently), so the new options have no icon. Suggestions for icons appreciated.