### PR TITLE
Allow GridMap to be excluded from RayCast collisions

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -73,6 +73,12 @@
 				Returns an array of [Transform3D] and [Mesh] references corresponding to the non-empty cells in the grid. The transforms are specified in world space.
 			</description>
 		</method>
+		<method name="get_static_bodies_rids" qualifiers="const">
+			<return type="Array" />
+			<description>
+				Returns an array of [RID]s corresponding to the static bodies in each octant of the grid.
+			</description>
+		</method>
 		<method name="get_used_cells" qualifiers="const">
 			<return type="Array" />
 			<description>

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -866,6 +866,8 @@ void GridMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_baked_meshes"), &GridMap::clear_baked_meshes);
 	ClassDB::bind_method(D_METHOD("make_baked_meshes", "gen_lightmap_uv", "lightmap_uv_texel_size"), &GridMap::make_baked_meshes, DEFVAL(false), DEFVAL(0.1));
 
+	ClassDB::bind_method(D_METHOD("get_static_bodies_rids"), &GridMap::get_static_bodies_rids);
+
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh_library", PROPERTY_HINT_RESOURCE_TYPE, "MeshLibrary"), "set_mesh_library", "get_mesh_library");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "physics_material", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsMaterial"), "set_physics_material", "get_physics_material");
 	ADD_GROUP("Cell", "cell_");
@@ -1084,6 +1086,15 @@ Array GridMap::get_bake_meshes() {
 RID GridMap::get_bake_mesh_instance(int p_idx) {
 	ERR_FAIL_INDEX_V(p_idx, baked_meshes.size(), RID());
 	return baked_meshes[p_idx].instance;
+}
+
+Vector<RID> GridMap::get_static_bodies_rids() const {
+	Vector<RID> rids;
+	for (const KeyValue<OctantKey, Octant *> &E : octant_map) {
+		rids.push_back(E.value->static_body);
+	}
+
+	return rids;
 }
 
 GridMap::GridMap() {

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -275,6 +275,8 @@ public:
 	Array get_bake_meshes();
 	RID get_bake_mesh_instance(int p_idx);
 
+	Vector<RID> get_static_bodies_rids() const;
+
 	GridMap();
 	~GridMap();
 };

--- a/scene/3d/ray_cast_3d.cpp
+++ b/scene/3d/ray_cast_3d.cpp
@@ -33,6 +33,11 @@
 #include "collision_object_3d.h"
 #include "mesh_instance_3d.h"
 
+#include "modules/modules_enabled.gen.h" // For gridmap.
+#ifdef MODULE_GRIDMAP_ENABLED
+#include "modules/gridmap/grid_map.h"
+#endif
+
 void RayCast3D::set_target_position(const Vector3 &p_point) {
 	target_position = p_point;
 	update_gizmos();
@@ -246,10 +251,17 @@ void RayCast3D::add_exception_rid(const RID &p_rid) {
 void RayCast3D::add_exception(const Object *p_object) {
 	ERR_FAIL_NULL(p_object);
 	const CollisionObject3D *co = Object::cast_to<CollisionObject3D>(p_object);
-	if (!co) {
-		return;
+	if (co) {
+		add_exception_rid(co->get_rid());
+#ifdef MODULE_GRIDMAP_ENABLED
+	} else if (Object::cast_to<GridMap>(p_object)) {
+		const GridMap *gm = Object::cast_to<GridMap>(p_object);
+		Vector<RID> rids = gm->get_static_bodies_rids();
+		for (int i = 0; i < rids.size(); i++) {
+			add_exception_rid(rids[i]);
+		}
+#endif
 	}
-	add_exception_rid(co->get_rid());
 }
 
 void RayCast3D::remove_exception_rid(const RID &p_rid) {


### PR DESCRIPTION
Fixes: #27282
RayCast3D will exclude static bodies from GridMap when added as an exception. The problem with PhysicsDirectSpaceState3D is also solved by using the following code:
```gdscript
var state := PhysicsServer3D.space_get_direct_state(get_world_3d().space)
var query := PhysicsRayQueryParameters3D.new()
query.from = from_vector
query.to = to_vector
query.exclude = gridmap.get_static_bodies_rids() 
var result := state.intersect_ray(query)
```
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
