### PR TITLE
ported particle sub-emission to 2D

### DIFF
--- a/doc/classes/GPUParticles2D.xml
+++ b/doc/classes/GPUParticles2D.xml
@@ -18,6 +18,17 @@
 				Returns a rectangle containing the positions of all existing particles.
 			</description>
 		</method>
+		<method name="emit_particle">
+			<return type="void" />
+			<argument index="0" name="xform" type="Transform2D" />
+			<argument index="1" name="velocity" type="Vector2" />
+			<argument index="2" name="color" type="Color" />
+			<argument index="3" name="custom" type="Color" />
+			<argument index="4" name="flags" type="int" />
+			<description>
+				Emits a single particle. Whether [code]xform[/code], [code]velocity[/code], [code]color[/code] and [code]custom[/code] are applied depends on the value of [code]flags[/code]. See [enum EmitFlags].
+			</description>
+		</method>
 		<method name="restart">
 			<return type="void" />
 			<description>
@@ -67,6 +78,9 @@
 		<member name="speed_scale" type="float" setter="set_speed_scale" getter="get_speed_scale" default="1.0">
 			Particle system's running speed scaling ratio. A value of [code]0[/code] can be used to pause the particles.
 		</member>
+		<member name="sub_emitter" type="NodePath" setter="set_sub_emitter" getter="get_sub_emitter" default="NodePath(&quot;&quot;)">
+			The [NodePath] to the [GPUParticles2D] used for sub-emissions.
+		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			Particle texture. If [code]null[/code], particles will be squares.
 		</member>
@@ -91,6 +105,21 @@
 			Particles are drawn in order of remaining lifetime.
 		</constant>
 		<constant name="DRAW_ORDER_REVERSE_LIFETIME" value="2" enum="DrawOrder">
+		</constant>
+		<constant name="EMIT_FLAG_POSITION" value="1" enum="EmitFlags">
+			Particle starts at the specified position.
+		</constant>
+		<constant name="EMIT_FLAG_ROTATION_SCALE" value="2" enum="EmitFlags">
+			Particle starts with specified rotation and scale.
+		</constant>
+		<constant name="EMIT_FLAG_VELOCITY" value="4" enum="EmitFlags">
+			Particle starts with the specified velocity vector, which defines the emission direction and speed.
+		</constant>
+		<constant name="EMIT_FLAG_COLOR" value="8" enum="EmitFlags">
+			Particle starts with specified color.
+		</constant>
+		<constant name="EMIT_FLAG_CUSTOM" value="16" enum="EmitFlags">
+			Particle starts with specificed [code]CUSTOM[/code] data.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -26,6 +26,7 @@
 			<argument index="3" name="custom" type="Color" />
 			<argument index="4" name="flags" type="int" />
 			<description>
+				Emits a single particle. Whether [code]xform[/code], [code]velocity[/code], [code]color[/code] and [code]custom[/code] are applied depends on the value of [code]flags[/code]. See [enum EmitFlags].
 			</description>
 		</method>
 		<method name="get_draw_pass_mesh" qualifiers="const">
@@ -137,14 +138,19 @@
 			Particles are drawn in order of depth.
 		</constant>
 		<constant name="EMIT_FLAG_POSITION" value="1" enum="EmitFlags">
+			Particle starts at the specified position.
 		</constant>
 		<constant name="EMIT_FLAG_ROTATION_SCALE" value="2" enum="EmitFlags">
+			Particle starts with specified rotation and scale.
 		</constant>
 		<constant name="EMIT_FLAG_VELOCITY" value="4" enum="EmitFlags">
+			Particle starts with the specified velocity vector, which defines the emission direction and speed.
 		</constant>
 		<constant name="EMIT_FLAG_COLOR" value="8" enum="EmitFlags">
+			Particle starts with specified color.
 		</constant>
 		<constant name="EMIT_FLAG_CUSTOM" value="16" enum="EmitFlags">
+			Particle starts with specificed [code]CUSTOM[/code] data.
 		</constant>
 		<constant name="MAX_DRAW_PASSES" value="4">
 			Maximum number of draw passes supported.

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -79,6 +79,8 @@ private:
 
 	RID mesh;
 
+	void _attach_sub_emitter();
+
 protected:
 	static void _bind_methods();
 	virtual void _validate_property(PropertyInfo &property) const override;
@@ -139,6 +141,19 @@ public:
 
 	TypedArray<String> get_configuration_warnings() const override;
 
+	void set_sub_emitter(const NodePath &p_path);
+	NodePath get_sub_emitter() const;
+
+	enum EmitFlags {
+		EMIT_FLAG_POSITION = RS::PARTICLES_EMIT_FLAG_POSITION,
+		EMIT_FLAG_ROTATION_SCALE = RS::PARTICLES_EMIT_FLAG_ROTATION_SCALE,
+		EMIT_FLAG_VELOCITY = RS::PARTICLES_EMIT_FLAG_VELOCITY,
+		EMIT_FLAG_COLOR = RS::PARTICLES_EMIT_FLAG_COLOR,
+		EMIT_FLAG_CUSTOM = RS::PARTICLES_EMIT_FLAG_CUSTOM
+	};
+
+	void emit_particle(const Transform2D &p_transform, const Vector2 &p_velocity, const Color &p_color, const Color &p_custom, uint32_t p_emit_flags);
+
 	void restart();
 	Rect2 capture_rect() const;
 	GPUParticles2D();
@@ -146,5 +161,6 @@ public:
 };
 
 VARIANT_ENUM_CAST(GPUParticles2D::DrawOrder)
+VARIANT_ENUM_CAST(GPUParticles2D::EmitFlags)
 
 #endif // PARTICLES_2D_H


### PR DESCRIPTION
Was much simpler than expected, and seems to be working mostly perfectly.  The bug described in #56886 is also present in 2D, but I'm not currently familiar enough with glsl to fix it right now.

Edit: Forgot to add, I wasn't sure if the z axis of the Transform3D required for particle emission had any effect in 2D, so I made the registered function take in a Transform2D and a Vector2. I can change that as soon as possible if required.