### PR TITLE
Dictionary: Serialize empty dict as `{}` instead of `{\n}`, improve docs formatting

### DIFF
--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -1649,12 +1649,13 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				dict.get_key_list(&keys);
 				keys.sort();
 
+				if (keys.is_empty()) { // Avoid unnecessary line break.
+					p_store_string_func(p_store_string_ud, "{}");
+					break;
+				}
+
 				p_store_string_func(p_store_string_ud, "{\n");
 				for (List<Variant>::Element *E = keys.front(); E; E = E->next()) {
-					/*
-					if (!_check_type(dict[E->get()]))
-						continue;
-					*/
 					write(E->get(), p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, recursion_count);
 					p_store_string_func(p_store_string_ud, ": ");
 					write(dict[E->get()], p_store_string_func, p_store_string_ud, p_encode_res_func, p_encode_res_ud, recursion_count);

--- a/doc/classes/ArrayMesh.xml
+++ b/doc/classes/ArrayMesh.xml
@@ -62,8 +62,7 @@
 			<argument index="0" name="primitive" type="int" enum="Mesh.PrimitiveType" />
 			<argument index="1" name="arrays" type="Array" />
 			<argument index="2" name="blend_shapes" type="Array" default="[]" />
-			<argument index="3" name="lods" type="Dictionary" default="{
-}" />
+			<argument index="3" name="lods" type="Dictionary" default="{}" />
 			<argument index="4" name="compress_flags" type="int" default="0" />
 			<description>
 				Creates a new surface.

--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -442,7 +442,7 @@
 		<member name="auto_brace_completion_highlight_matching" type="bool" setter="set_highlight_matching_braces_enabled" getter="is_highlight_matching_braces_enabled" default="false">
 			Highlight mismatching brace pairs.
 		</member>
-		<member name="auto_brace_completion_pairs" type="Dictionary" setter="set_auto_brace_completion_pairs" getter="get_auto_brace_completion_pairs" default="{&quot;\&quot;&quot;: &quot;\&quot;&quot;,&quot;&apos;&quot;: &quot;&apos;&quot;,&quot;(&quot;: &quot;)&quot;,&quot;[&quot;: &quot;]&quot;,&quot;{&quot;: &quot;}&quot;}">
+		<member name="auto_brace_completion_pairs" type="Dictionary" setter="set_auto_brace_completion_pairs" getter="get_auto_brace_completion_pairs" default="{ &quot;\&quot;&quot;: &quot;\&quot;&quot;, &quot;&apos;&quot;: &quot;&apos;&quot;, &quot;(&quot;: &quot;)&quot;, &quot;[&quot;: &quot;]&quot;, &quot;{&quot;: &quot;}&quot; }">
 			Sets the brace pairs to be autocompleted.
 		</member>
 		<member name="code_completion_enabled" type="bool" setter="set_code_completion_enabled" getter="is_code_completion_enabled" default="false">

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -452,7 +452,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" default="{&quot;data&quot;: PackedByteArray(),&quot;format&quot;: &quot;Lum8&quot;,&quot;height&quot;: 0,&quot;mipmaps&quot;: false,&quot;width&quot;: 0}">
+		<member name="data" type="Dictionary" setter="_set_data" getter="_get_data" default="{ &quot;data&quot;: PackedByteArray(), &quot;format&quot;: &quot;Lum8&quot;, &quot;height&quot;: 0, &quot;mipmaps&quot;: false, &quot;width&quot;: 0 }">
 			Holds all the image's color data in a given format. See [enum Format] constants.
 		</member>
 	</members>

--- a/doc/classes/ImporterMesh.xml
+++ b/doc/classes/ImporterMesh.xml
@@ -23,8 +23,7 @@
 			<argument index="0" name="primitive" type="int" enum="Mesh.PrimitiveType" />
 			<argument index="1" name="arrays" type="Array" />
 			<argument index="2" name="blend_shapes" type="Array" default="[]" />
-			<argument index="3" name="lods" type="Dictionary" default="{
-}" />
+			<argument index="3" name="lods" type="Dictionary" default="{}" />
 			<argument index="4" name="material" type="Material" default="null" />
 			<argument index="5" name="name" type="String" default="&quot;&quot;" />
 			<argument index="6" name="flags" type="int" default="0" />
@@ -178,7 +177,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="_data" type="Dictionary" setter="_set_data" getter="_get_data" default="{&quot;surfaces&quot;: []}">
+		<member name="_data" type="Dictionary" setter="_set_data" getter="_get_data" default="{ &quot;surfaces&quot;: [] }">
 		</member>
 	</members>
 </class>

--- a/doc/classes/PackedScene.xml
+++ b/doc/classes/PackedScene.xml
@@ -104,7 +104,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="_bundled" type="Dictionary" setter="_set_bundled_scene" getter="_get_bundled_scene" default="{&quot;conn_count&quot;: 0,&quot;conns&quot;: PackedInt32Array(),&quot;editable_instances&quot;: [],&quot;names&quot;: PackedStringArray(),&quot;node_count&quot;: 0,&quot;node_paths&quot;: [],&quot;nodes&quot;: PackedInt32Array(),&quot;variants&quot;: [],&quot;version&quot;: 2}">
+		<member name="_bundled" type="Dictionary" setter="_set_bundled_scene" getter="_get_bundled_scene" default="{ &quot;conn_count&quot;: 0, &quot;conns&quot;: PackedInt32Array(), &quot;editable_instances&quot;: [], &quot;names&quot;: PackedStringArray(), &quot;node_count&quot;: 0, &quot;node_paths&quot;: [], &quot;nodes&quot;: PackedInt32Array(), &quot;variants&quot;: [], &quot;version&quot;: 2 }">
 			A dictionary representation of the scene contents.
 			Available keys include "rnames" and "variants" for resources, "node_count", "nodes", "node_paths" for nodes, "editable_instances" for base scene children overrides, "conn_count" and "conns" for signal connections, and "version" for the format style of the PackedScene.
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1838,8 +1838,7 @@
 			<argument index="1" name="primitive" type="int" enum="RenderingServer.PrimitiveType" />
 			<argument index="2" name="arrays" type="Array" />
 			<argument index="3" name="blend_shapes" type="Array" default="[]" />
-			<argument index="4" name="lods" type="Dictionary" default="{
-}" />
+			<argument index="4" name="lods" type="Dictionary" default="{}" />
 			<argument index="5" name="compress_format" type="int" default="0" />
 			<description>
 			</description>

--- a/doc/classes/TextLine.xml
+++ b/doc/classes/TextLine.xml
@@ -24,8 +24,7 @@
 			<argument index="0" name="text" type="String" />
 			<argument index="1" name="fonts" type="Font" />
 			<argument index="2" name="size" type="int" />
-			<argument index="3" name="opentype_features" type="Dictionary" default="{
-}" />
+			<argument index="3" name="opentype_features" type="Dictionary" default="{}" />
 			<argument index="4" name="language" type="String" default="&quot;&quot;" />
 			<description>
 				Adds text span and font to draw it.

--- a/doc/classes/TextParagraph.xml
+++ b/doc/classes/TextParagraph.xml
@@ -24,8 +24,7 @@
 			<argument index="0" name="text" type="String" />
 			<argument index="1" name="fonts" type="Font" />
 			<argument index="2" name="size" type="int" />
-			<argument index="3" name="opentype_features" type="Dictionary" default="{
-}" />
+			<argument index="3" name="opentype_features" type="Dictionary" default="{}" />
 			<argument index="4" name="language" type="String" default="&quot;&quot;" />
 			<description>
 				Adds text span and font to draw it.
@@ -259,8 +258,7 @@
 			<argument index="1" name="fonts" type="Font" />
 			<argument index="2" name="size" type="int" />
 			<argument index="3" name="dropcap_margins" type="Rect2" default="Rect2(0, 0, 0, 0)" />
-			<argument index="4" name="opentype_features" type="Dictionary" default="{
-}" />
+			<argument index="4" name="opentype_features" type="Dictionary" default="{}" />
 			<argument index="5" name="language" type="String" default="&quot;&quot;" />
 			<description>
 				Sets drop cap, overrides previously set drop cap. Drop cap (dropped capital) is a decorative element at the beginning of a paragraph that is larger than the rest of the text.

--- a/doc/classes/TextServer.xml
+++ b/doc/classes/TextServer.xml
@@ -913,8 +913,7 @@
 			<argument index="1" name="text" type="String" />
 			<argument index="2" name="fonts" type="Array" />
 			<argument index="3" name="size" type="int" />
-			<argument index="4" name="opentype_features" type="Dictionary" default="{
-}" />
+			<argument index="4" name="opentype_features" type="Dictionary" default="{}" />
 			<argument index="5" name="language" type="String" default="&quot;&quot;" />
 			<description>
 				Adds text span and font to draw it to the text buffer.

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -410,7 +410,7 @@ void DocTools::generate(bool p_basic_types) {
 			//used to track uninitialized values using valgrind
 			//print_line("getting default value for " + String(name) + "." + String(E.name));
 			if (default_value_valid && default_value.get_type() != Variant::OBJECT) {
-				prop.default_value = default_value.get_construct_string().replace("\n", "");
+				prop.default_value = default_value.get_construct_string().replace("\n", " ");
 			}
 
 			StringName setter = ClassDB::get_property_setter(name, E.name);
@@ -522,7 +522,7 @@ void DocTools::generate(bool p_basic_types) {
 					int darg_idx = i - (E.arguments.size() - E.default_arguments.size());
 					if (darg_idx >= 0) {
 						Variant default_arg = E.default_arguments[darg_idx];
-						argument.default_value = default_arg.get_construct_string();
+						argument.default_value = default_arg.get_construct_string().replace("\n", " ");
 					}
 
 					method.arguments.push_back(argument);
@@ -585,7 +585,7 @@ void DocTools::generate(bool p_basic_types) {
 				tid.name = E;
 				tid.type = "Color";
 				tid.data_type = "color";
-				tid.default_value = Variant(Theme::get_default()->get_color(E, cname)).get_construct_string();
+				tid.default_value = Variant(Theme::get_default()->get_color(E, cname)).get_construct_string().replace("\n", " ");
 				c.theme_properties.push_back(tid);
 			}
 
@@ -757,7 +757,7 @@ void DocTools::generate(bool p_basic_types) {
 				int darg_idx = mi.default_arguments.size() - mi.arguments.size() + j;
 				if (darg_idx >= 0) {
 					Variant default_arg = mi.default_arguments[darg_idx];
-					ad.default_value = default_arg.get_construct_string();
+					ad.default_value = default_arg.get_construct_string().replace("\n", " ");
 				}
 
 				method.arguments.push_back(ad);
@@ -801,7 +801,7 @@ void DocTools::generate(bool p_basic_types) {
 			DocData::PropertyDoc property;
 			property.name = pi.name;
 			property.type = Variant::get_type_name(pi.type);
-			property.default_value = v.get(pi.name).get_construct_string();
+			property.default_value = v.get(pi.name).get_construct_string().replace("\n", " ");
 
 			c.properties.push_back(property);
 		}
@@ -813,7 +813,7 @@ void DocTools::generate(bool p_basic_types) {
 			DocData::ConstantDoc constant;
 			constant.name = E;
 			Variant value = Variant::get_constant_value(Variant::Type(i), E);
-			constant.value = value.get_type() == Variant::INT ? itos(value) : value.get_construct_string();
+			constant.value = value.get_type() == Variant::INT ? itos(value) : value.get_construct_string().replace("\n", " ");
 			constant.is_value_valid = true;
 			c.constants.push_back(constant);
 		}
@@ -930,7 +930,7 @@ void DocTools::generate(bool p_basic_types) {
 					int darg_idx = j - (mi.arguments.size() - mi.default_arguments.size());
 					if (darg_idx >= 0) {
 						Variant default_arg = mi.default_arguments[darg_idx];
-						ad.default_value = default_arg.get_construct_string();
+						ad.default_value = default_arg.get_construct_string().replace("\n", " ");
 					}
 
 					md.arguments.push_back(ad);

--- a/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
+++ b/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
@@ -33,8 +33,7 @@
 		<method name="create_data_channel">
 			<return type="WebRTCDataChannel" />
 			<argument index="0" name="label" type="String" />
-			<argument index="1" name="options" type="Dictionary" default="{
-}" />
+			<argument index="1" name="options" type="Dictionary" default="{}" />
 			<description>
 				Returns a new [WebRTCDataChannel] (or [code]null[/code] on failure) with given [code]label[/code] and optionally configured via the [code]options[/code] dictionary. This method can only be called when the connection is in state [constant STATE_NEW].
 				There are two ways to create a working data channel: either call [method create_data_channel] on only one of the peer and listen to [signal data_channel_received] on the other, or call [method create_data_channel] on both peers, with the same values, and the [code]negotiated[/code] option set to [code]true[/code].
@@ -70,8 +69,7 @@
 		</method>
 		<method name="initialize">
 			<return type="int" enum="Error" />
-			<argument index="0" name="configuration" type="Dictionary" default="{
-}" />
+			<argument index="0" name="configuration" type="Dictionary" default="{}" />
 			<description>
 				Re-initialize this peer connection, closing any previously active connection, and going back to state [constant STATE_NEW]. A dictionary of [code]options[/code] can be passed to configure the peer connection.
 				Valid [code]options[/code] are:


### PR DESCRIPTION
**Note:** This affects serialization of empty Dictionaries in `.tscn`/`.tres`/`ConfigFile`/`var2str`.

Example in `project.godot`:
```
[test]

dict1={}
dict2={
"hello": 1,
"world": 2
}
```

So technically this can be seen as compat breaking for people who might be parsing `VariantWriter` output manually instead of using `VariantParser` / `str2var`.

Also make sure to always convert multiline dictionaries to a single line for
its EditorHelp representation, as multiline values break formatting.

This fixes broken overlap and improves readability a bit (adding spaces on inline dicts):

### Before

![image](https://user-images.githubusercontent.com/4701338/149921058-895fec7e-40c9-4c1f-b007-6c1d1e0bf722.png)
![image](https://user-images.githubusercontent.com/4701338/149921815-61ff3722-e939-4f0b-8af1-f0ceb1fe192a.png)

### After

![image](https://user-images.githubusercontent.com/4701338/149921473-137cce6d-9d35-41db-9938-e8b3c0db6cee.png)
![image](https://user-images.githubusercontent.com/4701338/149921862-afea17cd-48d0-402a-9e43-6a873eb3ca75.png)

I considered keeping the `size() > 1` dictionaries multiline in the docs, but that doesn't work well:

![image](https://user-images.githubusercontent.com/4701338/149921560-29166ef0-0139-418a-801a-f1e06a9361db.png)
![image](https://user-images.githubusercontent.com/4701338/149921662-c708e51a-af06-407e-a389-f80657d9e7b7.png)

I sprinkled `replace("\n", " ")` everywhere where `get_construct_string()` is used in the docs for good measure, though there's currently no other multiline dictionary exposed in the docs that those would affect.