### PR TITLE
Replace use of `OS::set_exit_code()` by `SceneTree::quit()` in `EditorNode`

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -295,6 +295,9 @@ public:
 	virtual void debug_break();
 
 	virtual int get_exit_code() const;
+	// `set_exit_code` should only be used from `SceneTree` (or from a similar
+	// level, e.g. from the `Main::start` if leaving without creating a `SceneTree`).
+	// For other components, `SceneTree.quit()` should be used instead.
 	virtual void set_exit_code(int p_code);
 
 	virtual int get_processor_count() const;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -957,9 +957,10 @@ void EditorNode::_fs_changed() {
 
 		if (!export_error.is_empty()) {
 			ERR_PRINT(export_error);
-			OS::get_singleton()->set_exit_code(EXIT_FAILURE);
+			_exit_editor(EXIT_FAILURE);
+		} else {
+			_exit_editor(EXIT_SUCCESS);
 		}
-		_exit_editor();
 	}
 }
 
@@ -1775,7 +1776,7 @@ void EditorNode::restart_editor() {
 		to_reopen = get_tree()->get_edited_scene_root()->get_scene_file_path();
 	}
 
-	_exit_editor();
+	_exit_editor(EXIT_SUCCESS);
 
 	List<String> args;
 	args.push_back("--path");
@@ -2992,7 +2993,7 @@ int EditorNode::_next_unsaved_scene(bool p_valid_filename, int p_start) {
 	return -1;
 }
 
-void EditorNode::_exit_editor() {
+void EditorNode::_exit_editor(int p_exit_code) {
 	exiting = true;
 	resource_preview->stop(); // stop early to avoid crashes
 	_save_docks();
@@ -3000,7 +3001,7 @@ void EditorNode::_exit_editor() {
 	// Dim the editor window while it's quitting to make it clearer that it's busy
 	dim_editor(true);
 
-	get_tree()->quit();
+	get_tree()->quit(p_exit_code);
 }
 
 void EditorNode::_discard_changes(const String &p_str) {
@@ -3050,12 +3051,12 @@ void EditorNode::_discard_changes(const String &p_str) {
 		} break;
 		case FILE_QUIT: {
 			_menu_option_confirm(RUN_STOP, true);
-			_exit_editor();
+			_exit_editor(EXIT_SUCCESS);
 
 		} break;
 		case RUN_PROJECT_MANAGER: {
 			_menu_option_confirm(RUN_STOP, true);
-			_exit_editor();
+			_exit_editor(EXIT_SUCCESS);
 			String exec = OS::get_singleton()->get_executable_path();
 
 			List<String> args;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -529,7 +529,7 @@ private:
 	void _add_dropped_files_recursive(const Vector<String> &p_files, String to_path);
 	String _recent_scene;
 
-	void _exit_editor();
+	void _exit_editor(int p_exit_code);
 
 	bool convert_old;
 


### PR DESCRIPTION
see https://github.com/godotengine/godot/pull/56877#issuecomment-1015254892