### PR TITLE
stb_vorbis: Add clearer error messages when failing to import OGG file

### DIFF
--- a/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/audio_stream_ogg_vorbis.cpp
@@ -185,8 +185,8 @@ void AudioStreamOGGVorbis::set_data(const PoolVector<uint8_t> &p_data) {
 			w.release();
 			alloc_try *= 2;
 		} else {
-			ERR_FAIL_COND(alloc_try == MAX_TEST_MEM);
-			ERR_FAIL_COND(ogg_stream == nullptr);
+			ERR_FAIL_COND_MSG(alloc_try == MAX_TEST_MEM, "Failed allocating memory for OGG Vorbis stream.");
+			ERR_FAIL_COND_MSG(!ogg_stream, "OGG Vorbis decoding failed. Check that your data is a valid OGG Vorbis audio stream.");
 
 			stb_vorbis_info info = stb_vorbis_get_info(ogg_stream);
 

--- a/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/stb_vorbis/resource_importer_ogg_vorbis.cpp
@@ -91,7 +91,7 @@ Error ResourceImporterOGGVorbis::import(const String &p_source_file, const Strin
 	ogg_stream.instance();
 
 	ogg_stream->set_data(data);
-	ERR_FAIL_COND_V(!ogg_stream->get_data().size(), ERR_FILE_CORRUPT);
+	ERR_FAIL_COND_V_MSG(!ogg_stream->get_data().size(), ERR_FILE_CORRUPT, "Couldn't import file as AudioStreamOGGVorbis: " + p_source_file);
 	ogg_stream->set_loop(loop);
 	ogg_stream->set_loop_offset(loop_offset);
 


### PR DESCRIPTION
This doesn't make the UX perfect of course, like for any failed import of a theoretically supported extension, the editor is going to spam errors every time it gains focus:
```
ERROR: OGG Vorbis decoding failed. Check that your data is a valid OGG Vorbis audio stream.
   at: set_data (modules/stb_vorbis/audio_stream_ogg_vorbis.cpp:189)
ERROR: Couldn't import file as AudioStreamOGGVorbis: res://simplescreenrecorder-2022-01-18_11.13.58.ogg
   at: import (modules/stb_vorbis/resource_importer_ogg_vorbis.cpp:94)
ERROR: Error importing 'res://simplescreenrecorder-2022-01-18_11.13.58.ogg'.
   at: _reimport_file (editor/editor_file_system.cpp:1755)
```

But at least those errors now have messages which should give users a hint that Godot attempts to load their file as an OGG Vorbis audio stream, which is not what they intend.

Not applicable for `master` as is as we moved back from `stb_vorbis` to `libvorbis`... and in `master` the same file actually triggers a crash (#56904).

- Fixes #56895.