### PR TITLE
Improve node pasting

### DIFF
--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -123,6 +123,7 @@ class SceneTreeDock : public VBoxContainer {
 	Button *button_3d;
 	Button *button_ui;
 	Button *button_custom;
+	Button *button_clipboard;
 
 	HBoxContainer *button_hb;
 	Button *edit_local, *edit_remote;
@@ -307,6 +308,8 @@ public:
 
 	void open_add_child_dialog();
 	void open_instance_child_dialog();
+
+	List<Node *> paste_nodes();
 
 	ScriptCreateDialog *get_script_create_dialog() { return script_create_dialog; }
 


### PR DESCRIPTION
The PR adds icons for Copy/Cut/Paste operations in scene tree (apparently we always had them, but they are named `Action*`)
![image](https://user-images.githubusercontent.com/2223172/149967293-e23b73d9-f78c-4f83-823b-7d207ceedc62.png)

Also I moved paste operation to a separate method that also returns the node that were pasted (so now it can be called anywhere in the editor, I need it for another PR).
The pasting itself was improved. Now you can paste into empty scene and the node will be pasted as root. If there are multiple, the first one will be root. Also if there are copied nodes, a new "Paste From Clipboard" button appears.
![godot windows tools 64_KXan9vjDs7](https://user-images.githubusercontent.com/2223172/149967659-a1a5f21f-56cd-4207-8bea-e3df692beafe.gif)

