### PR TITLE
Fix "Convert to MeshLibrary" not respecting collision transforms

### DIFF
--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -136,9 +136,11 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 					continue;
 				}
 
-				//Transform3D shape_transform = sb->shape_owner_get_transform(E);
-
-				//shape_transform.set_origin(shape_transform.get_origin() - phys_offset);
+				Transform3D shape_transform;
+				if (p_apply_xforms) {
+					shape_transform = mi->get_transform();
+				}
+				shape_transform *= sb->get_transform() * sb->shape_owner_get_transform(E);
 
 				for (int k = 0; k < sb->shape_owner_get_shape_count(E); k++) {
 					Ref<Shape3D> collision = sb->shape_owner_get_shape(E, k);
@@ -147,7 +149,7 @@ void MeshLibraryEditor::_import_scene(Node *p_scene, Ref<MeshLibrary> p_library,
 					}
 					MeshLibrary::ShapeData shape_data;
 					shape_data.shape = collision;
-					shape_data.local_transform = sb->get_transform() * sb->shape_owner_get_transform(E);
+					shape_data.local_transform = shape_transform;
 					collisions.push_back(shape_data);
 				}
 			}


### PR DESCRIPTION
When doing Scene → Convert To... → MeshLibrary... there is an option "Apply MeshInstance Transforms" that prevents the zeroing of the transform of each MeshInstance. Unfortunately this option did not respect the transform of the collision shapes of StaticBody children, so effectively the mesh would be moved away from its "left behind" collision shapes. Now the transforms are respected. Fixes https://github.com/godotengine/godot/issues/56172.

Before:

![meshlibexport_before](https://user-images.githubusercontent.com/229837/149969177-140eba3d-b1c6-4292-aaeb-2250ba715a59.png)

After:

![meshlibexport_after](https://user-images.githubusercontent.com/229837/149969204-20ebdfb4-274a-4169-a560-ce517d6d109b.png)

cc @DeleteSystem32 
