### PR TITLE
Fix `RichTextLabel` not respecting line separation in several cases

### DIFF
--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -126,17 +126,21 @@ class EditorHelp : public VBoxContainer {
 
 	String base_path;
 
-	Color title_color;
 	Color text_color;
+	Color title_color;
 	Color headline_color;
-	Color base_type_color;
-	Color type_color;
 	Color comment_color;
 	Color symbol_color;
 	Color value_color;
 	Color qualifier_color;
+	Color type_color;
 
-	void _init_colors();
+	Ref<Font> doc_font;
+	Ref<Font> doc_bold_font;
+	Ref<Font> doc_title_font;
+	Ref<Font> doc_code_font;
+
+	void _update_theme();
 	void _help_callback(const String &p_topic);
 
 	void _add_text(const String &p_bbcode);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1219,7 +1219,22 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("focus", "RichTextLabel", make_empty_stylebox());
 	theme->set_stylebox("normal", "RichTextLabel", style_tree_bg);
 
+	// Editor help.
+	theme->set_color("title_color", "EditorHelp", accent_color);
 	theme->set_color("headline_color", "EditorHelp", mono_color);
+	theme->set_color("text_color", "EditorHelp", font_color);
+	theme->set_color("comment_color", "EditorHelp", font_color * Color(1, 1, 1, 0.6));
+	theme->set_color("symbol_color", "EditorHelp", font_color * Color(1, 1, 1, 0.6));
+	theme->set_color("value_color", "EditorHelp", font_color * Color(1, 1, 1, 0.6));
+	theme->set_color("qualifier_color", "EditorHelp", font_color * Color(1, 1, 1, 0.8));
+	theme->set_color("type_color", "EditorHelp", accent_color.lerp(font_color, 0.5));
+	theme->set_color("selection_color", "EditorHelp", accent_color * Color(1, 1, 1, 0.4));
+	theme->set_color("link_color", "EditorHelp", accent_color.lerp(mono_color, 0.8));
+	theme->set_color("code_color", "EditorHelp", accent_color.lerp(mono_color, 0.6));
+	theme->set_color("kbd_color", "EditorHelp", accent_color.lerp(property_color, 0.6));
+	theme->set_constant("line_separation", "EditorHelp", Math::round(6 * EDSCALE));
+	theme->set_constant("table_hseparation", "EditorHelp", 16 * EDSCALE);
+	theme->set_constant("table_vseparation", "EditorHelp", 6 * EDSCALE);
 
 	// Panel
 	theme->set_stylebox("panel", "Panel", make_flat_stylebox(dark_color_1, 6, 4, 6, 4, corner_width));

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -325,13 +325,16 @@ void RichTextLabel::_resize_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 						table->columns.write[column].width = MAX(table->columns.write[column].width, ceil(frame->lines[i].text_buf->get_size().x));
 
 						if (i > 0) {
-							frame->lines.write[i].offset.y = frame->lines[i - 1].offset.y + frame->lines[i - 1].text_buf->get_size().y;
+							frame->lines.write[i].offset.y = frame->lines[i - 1].offset.y + frame->lines[i - 1].text_buf->get_size().y + get_theme_constant(SNAME("line_separation"));
 						} else {
 							frame->lines.write[i].offset.y = 0;
 						}
 						frame->lines.write[i].offset += offset;
 
-						float h = frame->lines[i].text_buf->get_size().y;
+						float h = frame->lines[i].text_buf->get_size().y + (frame->lines[i].text_buf->get_line_count() - 1) * get_theme_constant(SNAME("line_separation"));
+						if (i > 0) {
+							h += get_theme_constant(SNAME("line_separation"));
+						}
 						if (frame->min_size_over.y > 0) {
 							h = MAX(h, frame->min_size_over.y);
 						}
@@ -570,13 +573,16 @@ void RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> 
 						table->columns.write[column].width = MAX(table->columns.write[column].width, ceil(frame->lines[i].text_buf->get_size().x));
 
 						if (i > 0) {
-							frame->lines.write[i].offset.y = frame->lines[i - 1].offset.y + frame->lines[i - 1].text_buf->get_size().y;
+							frame->lines.write[i].offset.y = frame->lines[i - 1].offset.y + frame->lines[i - 1].text_buf->get_size().y + get_theme_constant(SNAME("line_separation"));
 						} else {
 							frame->lines.write[i].offset.y = 0;
 						}
 						frame->lines.write[i].offset += offset;
 
-						float h = frame->lines[i].text_buf->get_size().y;
+						float h = frame->lines[i].text_buf->get_size().y + (frame->lines[i].text_buf->get_line_count() - 1) * get_theme_constant(SNAME("line_separation"));
+						if (i > 0) {
+							h += get_theme_constant(SNAME("line_separation"));
+						}
 						if (frame->min_size_over.y > 0) {
 							h = MAX(h, frame->min_size_over.y);
 						}
@@ -622,10 +628,11 @@ void RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> 
 }
 
 int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_ofs, int p_width, const Color &p_base_color, int p_outline_size, const Color &p_outline_color, const Color &p_font_shadow_color, int p_shadow_outline_size, const Point2 &p_shadow_ofs, int &r_processed_glyphs) {
-	Vector2 off;
-
 	ERR_FAIL_COND_V(p_frame == nullptr, 0);
 	ERR_FAIL_COND_V(p_line < 0 || p_line >= p_frame->lines.size(), 0);
+
+	Vector2 off;
+	int line_spacing = get_theme_constant(SNAME("line_separation"));
 
 	Line &l = p_frame->lines.write[p_line];
 
@@ -712,6 +719,10 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 	Size2 ctrl_size = get_size();
 	// Draw text.
 	for (int line = 0; line < l.text_buf->get_line_count(); line++) {
+		if (line > 0) {
+			off.y += line_spacing;
+		}
+
 		RID rid = l.text_buf->get_line_rid(line);
 		if (p_ofs.y + off.y >= ctrl_size.height) {
 			break;


### PR DESCRIPTION
I wanted to work on styling for the built-in help a bit, but in the process discovered that `RichTextLabel` didn't utilize the line separation constant for tables and within wrapped paragraphs, which was affecting the docs. So this PR fixes RTL, and it also contains some clean up and tune up for the built-in help.

**Game**
[Before](https://user-images.githubusercontent.com/11782833/149980688-769b1565-2e3e-495f-a7a9-79f6b6c6027a.png) | [After](https://user-images.githubusercontent.com/11782833/149980778-3419d980-aa54-401a-a04f-34ad0209feef.png)

**Docs**
[Before](https://user-images.githubusercontent.com/11782833/149980893-d173b6f1-f8ab-45e4-83d9-8cc11694bde1.png) | [After](https://user-images.githubusercontent.com/11782833/149980933-8bb17d9a-1c79-4f31-bf1e-5bc42872fbe6.png)