### PR TITLE
Circle&CapsuleShape2D: Fix outlines missing line. 

### DIFF
--- a/scene/resources/capsule_shape_2d.cpp
+++ b/scene/resources/capsule_shape_2d.cpp
@@ -84,13 +84,11 @@ real_t CapsuleShape2D::get_height() const {
 
 void CapsuleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Vector2> points = _get_points();
-	Vector<Color> col;
-	col.push_back(p_color);
+	Vector<Color> col = { p_color };
 	RenderingServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
 	if (is_collision_outline_enabled()) {
+		points.push_back(points[0]);
 		RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
-		// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
-		RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color);
 	}
 }
 

--- a/scene/resources/circle_shape_2d.cpp
+++ b/scene/resources/circle_shape_2d.cpp
@@ -71,18 +71,19 @@ real_t CircleShape2D::get_enclosing_radius() const {
 
 void CircleShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 	Vector<Vector2> points;
+	points.resize(24);
+
 	const real_t turn_step = Math_TAU / 24.0;
 	for (int i = 0; i < 24; i++) {
-		points.push_back(Vector2(Math::cos(i * turn_step), Math::sin(i * turn_step)) * get_radius());
+		points.write[i] = Vector2(Math::cos(i * turn_step), Math::sin(i * turn_step)) * get_radius();
 	}
 
-	Vector<Color> col;
-	col.push_back(p_color);
+	Vector<Color> col = { p_color };
 	RenderingServer::get_singleton()->canvas_item_add_polygon(p_to_rid, points, col);
+
 	if (is_collision_outline_enabled()) {
+		points.push_back(points[0]);
 		RenderingServer::get_singleton()->canvas_item_add_polyline(p_to_rid, points, col);
-		// Draw the last segment as it's not drawn by `canvas_item_add_polyline()`.
-		RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color);
 	}
 }
 


### PR DESCRIPTION
I don't see anything wrong with the previous code, but last line for the outline was missing.
It occurs in both Circle and CapsuleShape2D,so it might be something to do with 
`RenderingServer::get_singleton()->canvas_item_add_line(p_to_rid, points[points.size() - 1], points[0], p_color);`

The new logic seems better,and we have one less `draw_line` code and pre-allocate `points ` Vector.

The BUG:
![bug-pic](https://user-images.githubusercontent.com/17506575/149981495-05c66489-6c35-4e09-9efd-f654a28a856a.png)

https://user-images.githubusercontent.com/17506575/149981525-b41d96d2-33ba-421a-a8b5-e6b3f1f822f8.mp4
