### PR TITLE
Sort class properties in the built-in docs

### DIFF
--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -350,7 +350,7 @@ void DocTools::generate(bool p_basic_types) {
 		List<PropertyInfo> properties;
 		List<PropertyInfo> own_properties;
 		if (name == "ProjectSettings") {
-			//special case for project settings, so settings can be documented
+			// Special case for project settings, so settings can be documented.
 			ProjectSettings::get_singleton()->get_property_list(&properties);
 			own_properties = properties;
 		} else {
@@ -358,9 +358,12 @@ void DocTools::generate(bool p_basic_types) {
 			ClassDB::get_property_list(name, &own_properties, true);
 		}
 
+		properties.sort();
+		own_properties.sort();
+
 		List<PropertyInfo>::Element *EO = own_properties.front();
 		for (const PropertyInfo &E : properties) {
-			bool inherited = EO == nullptr;
+			bool inherited = true;
 			if (EO && EO->get() == E) {
 				inherited = false;
 				EO = EO->next();


### PR DESCRIPTION
Online docs are already sorted alphabetically, but the built-in help used the default order (similar to the one you see in the inspector). This made it harder to navigate the help when you were looking for specific properties, as they may be anywhere in that flat list.

We also sort pretty much every other documentation item, so it makes sense to do this here.