### PR TITLE
Fix `RichTextLabel` tables shrinking expanded columns when there is not enough space

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -254,7 +254,12 @@ void RichTextLabel::_resize_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 				for (int i = 0; i < col_count; i++) {
 					remaining_width -= table->columns[i].min_width;
 					if (table->columns[i].max_width > table->columns[i].min_width) {
+						// If the column can grow, allow it to grow.
 						table->columns.write[i].expand = true;
+					} else {
+						// Otherwise make it shrink as much as possible, so that other columns can grow if needs be.
+						// We keep the max width as is to spread the remaining space between the columns later.
+						table->columns.write[i].min_width = 0;
 					}
 					if (table->columns[i].expand) {
 						total_ratio += table->columns[i].expand_ratio;
@@ -264,7 +269,7 @@ void RichTextLabel::_resize_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 				// Assign actual widths.
 				for (int i = 0; i < col_count; i++) {
 					table->columns.write[i].width = table->columns[i].min_width;
-					if (table->columns[i].expand && total_ratio > 0) {
+					if (table->columns[i].expand && total_ratio > 0 && remaining_width > 0) {
 						table->columns.write[i].width += table->columns[i].expand_ratio * remaining_width / total_ratio;
 					}
 					table->total_width += table->columns[i].width + hseparation;
@@ -502,7 +507,12 @@ void RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> 
 				for (int i = 0; i < col_count; i++) {
 					remaining_width -= table->columns[i].min_width;
 					if (table->columns[i].max_width > table->columns[i].min_width) {
+						// If the column can grow, allow it to grow.
 						table->columns.write[i].expand = true;
+					} else {
+						// Otherwise make it shrink as much as possible, so that other columns can grow if needs be.
+						// We keep the max width as is to spread the remaining space between the columns later.
+						table->columns.write[i].min_width = 0;
 					}
 					if (table->columns[i].expand) {
 						total_ratio += table->columns[i].expand_ratio;
@@ -512,7 +522,7 @@ void RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> 
 				// Assign actual widths.
 				for (int i = 0; i < col_count; i++) {
 					table->columns.write[i].width = table->columns[i].min_width;
-					if (table->columns[i].expand && total_ratio > 0) {
+					if (table->columns[i].expand && total_ratio > 0 && remaining_width > 0) {
 						table->columns.write[i].width += table->columns[i].expand_ratio * remaining_width / total_ratio;
 					}
 					table->total_width += table->columns[i].width + hseparation;


### PR DESCRIPTION
While working on improving the look of the built-in class reference, I've noticed that the column that is marked to expand (in hopes to take priority space) is actually the one that gets shrunk first. Investigating the issue I figured out that the following happens.

![godot windows tools 64_2022-01-18_22-54-35](https://user-images.githubusercontent.com/11782833/150024494-e9260517-8b44-4bf7-a4c9-58ae8461b5b2.png)

Expanded logic implemented in such a way, that the excess width is shared between all expanded columns, proportional to their expand ratio. When the table gets too wide and can no longer fit into the space provided to it, this excess width gets negative. However, expanded columns still share that negative excess between each other, and get proportionally smaller. This seems very counter-intuitive.

So I've made sure that negative space is never applied. And to account for the space lost we instead make every not expanded column to have minimal size of 0. This means that they will shrink to the absolute minimum they can, while still sharing the remaining space if there are no expanded columns. This also removes any overflow that happened before, and keeps the table to its allowed size.

![godot windows tools 64_2022-01-19_00-21-20](https://user-images.githubusercontent.com/11782833/150024506-2d3323c5-f5c0-44cf-933b-6e9d54cad9a0.png)

This behavior was introduce back in 2018 by https://github.com/godotengine/godot/pull/17612, but I doubt it was intentional.
However, I hope that wise words from the comments can be applied here as well...

> RichTextLabel is always hit and miss, so let's merge and see what happens :)