### PR TITLE
Add 'Open in File Manager' option with no explicit selection

### DIFF
--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2506,6 +2506,7 @@ void FileSystemDock::_file_and_folders_fill_popup(PopupMenu *p_popup, Vector<Str
 		String fpath = p_paths[0];
 		String item_text = fpath.ends_with("/") ? TTR("Open in File Manager") : TTR("Show in File Manager");
 		p_popup->add_icon_item(get_theme_icon(SNAME("Filesystem"), SNAME("EditorIcons")), item_text, FILE_SHOW_IN_EXPLORER);
+		path = fpath;
 	}
 }
 
@@ -2542,6 +2543,9 @@ void FileSystemDock::_tree_rmb_empty(const Vector2 &p_pos) {
 	tree_popup->add_icon_item(get_theme_icon(SNAME("Script"), SNAME("EditorIcons")), TTR("New Script..."), FILE_NEW_SCRIPT);
 	tree_popup->add_icon_item(get_theme_icon(SNAME("Object"), SNAME("EditorIcons")), TTR("New Resource..."), FILE_NEW_RESOURCE);
 	tree_popup->add_icon_item(get_theme_icon(SNAME("TextFile"), SNAME("EditorIcons")), TTR("New TextFile..."), FILE_NEW_TEXTFILE);
+	tree_popup->add_separator();
+	tree_popup->add_icon_item(get_theme_icon(SNAME("Filesystem"), SNAME("EditorIcons")), TTR("Open in File Manager"), FILE_SHOW_IN_EXPLORER);
+
 	tree_popup->set_position(tree->get_screen_position() + p_pos);
 	tree_popup->reset_size();
 	tree_popup->popup();
@@ -2580,6 +2584,8 @@ void FileSystemDock::_file_list_rmb_pressed(const Vector2 &p_pos) {
 	if (searched_string.length() > 0) {
 		return;
 	}
+
+	path = current_path->get_text();
 
 	file_list_popup->clear();
 	file_list_popup->reset_size();


### PR DESCRIPTION
Adds the option 'Open in File Manager' to right click menu in the Filesystem tab even when a file or folder is not explicitly selected. This makes it consistent with the behaviour for options like 'New Folder/Scene/Script/Resource/TextFile', and is a useful convenience shortcut.