### PR TITLE
Make assets in progress open the next step instead of erring

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1442,6 +1442,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_info_3d_viewport->set_border_width_all(0);
 	theme->set_stylebox("Information3dViewport", "EditorStyles", style_info_3d_viewport);
 
+	// Asset Library.
+	theme->set_stylebox("panel", "AssetLib", style_content_panel);
+	theme->set_color("status_color", "AssetLib", Color(0.5, 0.5, 0.5));
+	theme->set_icon("dismiss", "AssetLib", theme->get_icon("Close", "EditorIcons"));
+
 	// Theme editor.
 	theme->set_color("preview_picker_overlay_color", "ThemeEditor", Color(0.1, 0.1, 0.1, 0.25));
 	Color theme_preview_picker_bg_color = accent_color;

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -39,6 +39,7 @@
 #include "scene/gui/grid_container.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/link_button.h"
+#include "scene/gui/margin_container.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/progress_bar.h"
@@ -126,16 +127,16 @@ public:
 	EditorAssetLibraryItemDescription();
 };
 
-class EditorAssetLibraryItemDownload : public Control {
-	GDCLASS(EditorAssetLibraryItemDownload, Control);
+class EditorAssetLibraryItemDownload : public MarginContainer {
+	GDCLASS(EditorAssetLibraryItemDownload, MarginContainer);
 
 	PanelContainer *panel;
 	TextureRect *icon;
 	Label *title;
 	ProgressBar *progress;
-	Button *install;
-	Button *retry;
-	TextureButton *dismiss;
+	Button *install_button;
+	Button *retry_button;
+	TextureButton *dismiss_button;
 
 	AcceptDialog *download_error;
 	HTTPRequest *download;
@@ -152,7 +153,6 @@ class EditorAssetLibraryItemDownload : public Control {
 	EditorAssetInstaller *asset_installer;
 
 	void _close();
-	void _install();
 	void _make_request();
 	void _http_download_completed(int p_status, int p_code, const PackedStringArray &headers, const PackedByteArray &p_data);
 
@@ -164,6 +164,7 @@ public:
 	void set_external_install(bool p_enable) { external_install = p_enable; }
 	int get_asset_id() { return asset_id; }
 	void configure(const String &p_title, int p_asset_id, const Ref<Texture2D> &p_preview, const String &p_download_url, const String &p_sha256_hash);
+	void install();
 	EditorAssetLibraryItemDownload();
 };
 
@@ -287,6 +288,7 @@ class EditorAssetLibrary : public PanelContainer {
 	void _api_request(const String &p_request, RequestType p_request_type, const String &p_arguments = "");
 	void _http_request_completed(int p_status, int p_code, const PackedStringArray &headers, const PackedByteArray &p_data);
 	void _filter_debounce_timer_timeout();
+	EditorAssetLibraryItemDownload *_get_asset_in_progress(int p_asset_id) const;
 
 	void _repository_changed(int p_repository_id);
 	void _support_toggled(int p_support);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/56928, a regression that I missed from https://github.com/godotengine/godot/pull/56842.

Furthermore, I've fixed an issue with the asset icon ([picture in the linked report](https://user-images.githubusercontent.com/11782833/150044734-8d7222fc-ed8a-425c-8c16-7c58c08ee58c.png)), and improved the UX slightly. Instead of erring when the asset has already been downloaded we just go straight to installing it. And the button reflects it and all:

![image](https://user-images.githubusercontent.com/11782833/150047309-1859dbcf-c4f8-4ef5-9bdd-bff0e8020e25.png)
