### PR TITLE
Enforce mult-of-4 requirements on etcpak input.

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -1434,12 +1434,11 @@ int Image::_get_dst_image_size(int p_width, int p_height, Format p_format, int &
 		}
 
 		// Set mipmap size.
-		// It might be necessary to put this after the minimum mipmap size check because of the possible occurrence of "1 >> 1".
 		if (r_mm_width) {
-			*r_mm_width = bw >> 1;
+			*r_mm_width = w;
 		}
 		if (r_mm_height) {
-			*r_mm_height = bh >> 1;
+			*r_mm_height = h;
 		}
 
 		// Reach target mipmap.


### PR DESCRIPTION
Re: https://github.com/godotengine/godot/issues/49981

Adds back a variation old code from modules/etc/image_compress_etc.cpp to enforce ~~power-of-two (mipmapped) and~~ multiple of 4 ~~(non-mipmapped)~~ on compressed textures.

Here is the original code from before etcpak was added:
https://github.com/godotengine/godot/pull/47370/files#diff-d43a3b757699a828b4602b39b53ce14bc22f35556ed7ea2d3943608f90bf4d34

There was something else [added by reduz in February, 2019](https://github.com/godotengine/godot/commit/74d0ed2236b333d0a292e15b9c2a9380c2c122a1#diff-4949ecbffc5fadfd3ef6ff61bcc12d88c51ea8fd1bc17d586f624b9b56685fa6R422-R427) to enforce power-of-two, but it was only intended for GLES2 and doesn't seem to be in the right place in the code to solve this particular issue.

Intermediate mipmap levels need to be resized to Nx4 or 4xN accordingly, since etcpak is stricter about padding.

Not doing so causes the following artifact when sampling the 2x2 or 1x1 mipmap levels:
![image](https://user-images.githubusercontent.com/39946030/150064709-4d3ab9bc-147b-4730-9163-efb59491cef4.png)
It looks normal when samplihg 4x4 or higher:
![image](https://user-images.githubusercontent.com/39946030/150064758-18e73672-a5bc-4d44-99a9-fbb0410dc64e.png)
Here is what I think is happening before this PR.
```
		8x8 data...
		4x4 data...
		2x2 data...
		1x1 data...
		8888888888888888..8888844444444444444422221xxxxxxxxxxxxxxxxxx <-- current state.
last two mipmap levels sample out-of-bounds
possible idea: resize Nx2 and 2xN and lower to multiple of 4, using a temporary buffer
		8888888888888888..8888844444444444444422222222222222221111111111111111
```
I have now implemented the above.

*Bugsquad edit:*
- Fixes #49981