### PR TITLE
Add missing 'theme_changed' signal to Window class

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -368,6 +368,10 @@
 			<description>
 			</description>
 		</signal>
+		<signal name="theme_changed">
+			<description>
+			</description>
+		</signal>
 		<signal name="visibility_changed">
 			<description>
 			</description>

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1574,6 +1574,7 @@ void Window::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("go_back_requested"));
 	ADD_SIGNAL(MethodInfo("visibility_changed"));
 	ADD_SIGNAL(MethodInfo("about_to_popup"));
+	ADD_SIGNAL(MethodInfo("theme_changed"));
 
 	BIND_CONSTANT(NOTIFICATION_VISIBILITY_CHANGED);
 


### PR DESCRIPTION
Control::_propagate_theme_changed tries to emit the signal 'theme_changed' on windows, but since it does not exist, an error is thrown. This PR adds the missing signal.