### PR TITLE
[Editor] Move some animation specific keying logic out of inspector.

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -13,6 +13,11 @@
 		<member name="horizontal_scroll_mode" type="int" setter="set_horizontal_scroll_mode" getter="get_horizontal_scroll_mode" overrides="ScrollContainer" enum="ScrollContainer.ScrollMode" default="0" />
 	</members>
 	<signals>
+		<signal name="edited_object_changed">
+			<description>
+				Emitted when the object being edited by the inspector has changed.
+			</description>
+		</signal>
 		<signal name="object_id_selected">
 			<argument index="0" name="id" type="int" />
 			<description>

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3375,7 +3375,13 @@ Node *AnimationTrackEditor::get_root() const {
 }
 
 void AnimationTrackEditor::update_keying() {
-	bool keying_enabled = is_visible_in_tree() && animation.is_valid();
+	bool keying_enabled = false;
+
+	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
+	if (is_visible_in_tree() && animation.is_valid() && editor_history->get_path_size() > 0) {
+		Object *obj = ObjectDB::get_instance(editor_history->get_path_object(0));
+		keying_enabled = Object::cast_to<Node>(obj) != nullptr;
+	}
 
 	if (keying_enabled == keying) {
 		return;
@@ -4525,8 +4531,6 @@ void AnimationTrackEditor::_notification(int p_what) {
 
 	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
 		update_keying();
-		EditorNode::get_singleton()->update_keying();
-		emit_signal(SNAME("keying_changed"));
 	}
 }
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2905,6 +2905,7 @@ void EditorInspector::edit(Object *p_object) {
 		object->connect("property_list_changed", callable_mp(this, &EditorInspector::_changed_callback));
 		update_tree();
 	}
+	emit_signal("edited_object_changed");
 }
 
 void EditorInspector::set_keying(bool p_active) {
@@ -3543,6 +3544,7 @@ void EditorInspector::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("object_id_selected", PropertyInfo(Variant::INT, "id")));
 	ADD_SIGNAL(MethodInfo("property_edited", PropertyInfo(Variant::STRING, "property")));
 	ADD_SIGNAL(MethodInfo("property_toggled", PropertyInfo(Variant::STRING, "property"), PropertyInfo(Variant::BOOL, "checked")));
+	ADD_SIGNAL(MethodInfo("edited_object_changed"));
 	ADD_SIGNAL(MethodInfo("restart_requested"));
 }
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2307,7 +2307,6 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 	}
 
 	inspector_dock->update(current_obj);
-	inspector_dock->update_keying();
 }
 
 void EditorNode::_run(bool p_current, const String &p_custom) {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -884,7 +884,6 @@ public:
 
 	void edit_current() { _edit_current(); };
 
-	void update_keying() const { inspector_dock->update_keying(); };
 	bool has_scenes_in_session();
 
 	int execute_and_show_output(const String &p_title, const String &p_path, const List<String> &p_arguments, bool p_close_on_ok = true, bool p_close_on_errors = false);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -382,20 +382,6 @@ void InspectorDock::_menu_expandall() {
 	inspector->expand_all_folding();
 }
 
-void InspectorDock::_property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance) {
-	AnimationPlayerEditor::get_singleton()->get_track_editor()->insert_value_key(p_keyed, p_value, p_advance);
-}
-
-void InspectorDock::_transform_keyed(Object *sp, const String &p_sub, const Transform3D &p_key) {
-	Node3D *s = Object::cast_to<Node3D>(sp);
-	if (!s) {
-		return;
-	}
-	AnimationPlayerEditor::get_singleton()->get_track_editor()->insert_transform_key(s, p_sub, Animation::TYPE_POSITION_3D, p_key.origin);
-	AnimationPlayerEditor::get_singleton()->get_track_editor()->insert_transform_key(s, p_sub, Animation::TYPE_ROTATION_3D, p_key.basis.get_rotation_quaternion());
-	AnimationPlayerEditor::get_singleton()->get_track_editor()->insert_transform_key(s, p_sub, Animation::TYPE_SCALE_3D, p_key.basis.get_scale());
-}
-
 void InspectorDock::_warning_pressed() {
 	warning_dialog->popup_centered();
 }
@@ -440,9 +426,6 @@ void InspectorDock::_notification(int p_what) {
 }
 
 void InspectorDock::_bind_methods() {
-	ClassDB::bind_method("update_keying", &InspectorDock::update_keying);
-	ClassDB::bind_method("_transform_keyed", &InspectorDock::_transform_keyed); // Still used by some connect_compat.
-
 	ClassDB::bind_method("_unref_resource", &InspectorDock::_unref_resource);
 	ClassDB::bind_method("_paste_resource", &InspectorDock::_paste_resource);
 	ClassDB::bind_method("_copy_resource", &InspectorDock::_copy_resource);
@@ -545,22 +528,6 @@ void InspectorDock::update(Object *p_object) {
 
 void InspectorDock::go_back() {
 	_edit_back();
-}
-
-void InspectorDock::update_keying() {
-	bool valid = false;
-
-	if (AnimationPlayerEditor::get_singleton()->get_track_editor()->has_keying()) {
-		EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
-		if (editor_history->get_path_size() >= 1) {
-			Object *obj = ObjectDB::get_instance(editor_history->get_path_object(0));
-			if (Object::cast_to<Node>(obj)) {
-				valid = true;
-			}
-		}
-	}
-
-	inspector->set_keying(valid);
 }
 
 InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
@@ -716,7 +683,6 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	inspector->set_use_filter(true); // TODO: check me
 
 	inspector->connect("resource_selected", callable_mp(this, &InspectorDock::_resource_selected));
-	inspector->connect("property_keyed", callable_mp(this, &InspectorDock::_property_keyed));
 }
 
 InspectorDock::~InspectorDock() {

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -117,16 +117,12 @@ class InspectorDock : public VBoxContainer {
 	void _select_history(int p_idx);
 	void _prepare_history();
 
-	void _property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance);
-	void _transform_keyed(Object *sp, const String &p_sub, const Transform3D &p_key);
-
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
 
 public:
 	void go_back();
-	void update_keying();
 	void edit_resource(const Ref<Resource> &p_resource);
 	void open_resource(const String &p_type);
 	void clear();

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -255,6 +255,10 @@ class AnimationPlayerEditorPlugin : public EditorPlugin {
 protected:
 	void _notification(int p_what);
 
+	void _property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance);
+	void _transform_key_request(Object *sp, const String &p_sub, const Transform3D &p_key);
+	void _update_keying();
+
 public:
 	virtual Dictionary get_state() const override { return anim_editor->get_state(); }
 	virtual void set_state(const Dictionary &p_state) override { anim_editor->set_state(p_state); }

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -8043,7 +8043,6 @@ Node3DEditorPlugin::Node3DEditorPlugin(EditorNode *p_node) {
 	editor->get_main_control()->add_child(spatial_editor);
 
 	spatial_editor->hide();
-	spatial_editor->connect("transform_key_request", Callable(editor->get_inspector_dock(), "_transform_keyed"));
 }
 
 Node3DEditorPlugin::~Node3DEditorPlugin() {

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -149,6 +149,9 @@ void BoneTransformEditor::set_target(const String &p_prop) {
 
 void BoneTransformEditor::_property_keyed(const String &p_path, bool p_advance) {
 	AnimationTrackEditor *te = AnimationPlayerEditor::get_singleton()->get_track_editor();
+	if (!te->has_keying()) {
+		return;
+	}
 	PackedStringArray split = p_path.split("/");
 	if (split.size() == 3 && split[0] == "bones") {
 		int bone_idx = split[1].to_int();


### PR DESCRIPTION
Most of the custom logic to handle special keying cases is now inside the AnimationPlayerEditorPlugin.

The EditorInspector now emits a signal when inspecting a new object.