### PR TITLE
Improve rotation in the 3D transform gizmo

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -311,6 +311,7 @@ private:
 		Point2 mouse_pos;
 		Point2 original_mouse_pos;
 		bool snap = false;
+		bool show_rotation_line = false;
 		Ref<EditorNode3DGizmo> gizmo;
 		int gizmo_handle = 0;
 		bool gizmo_handle_secondary = false;


### PR DESCRIPTION
The current implementation for rotation transforms has some issues when the rotation axis gets close to being orthogonal with the camera's forward direction.  I changed the way rotation angles are computed and added some special cases for orthogonal rotation axes.

Before:

https://user-images.githubusercontent.com/4402304/150139704-d2008b27-2fcd-4ad8-9f43-fba955151194.mp4




After:

https://user-images.githubusercontent.com/4402304/150139714-86e5923b-1b40-4017-9f05-329f91403a38.mp4


Changes include:
* Get rid of deadzones. Fixes #56582.
* Make it easier to select rotation handles at very oblique angles.
* Handle rotation for axes that are perpendicular to the camera.

Note: This PR will probably create conflicts with #56543. I would merge the other one first, and I can handle the rebase on top of it.

