### PR TITLE
Handle splash screen stretch modes for Android/iOS

### DIFF
--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -320,62 +320,8 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 	storage._texture_allocate_internal(texture, p_image->get_width(), p_image->get_height(), 0, p_image->get_format(), RenderingDevice::TEXTURE_TYPE_2D);
 	storage.texture_set_data(texture, p_image);
 
-	// Stretch code synced with RendererCompositorRD.
-	Rect2 imgrect(0, 0, p_image->get_width(), p_image->get_height());
-	Rect2 screenrect;
-	switch (p_stretch_mode) {
-		case RenderingServer::SPLASH_STRETCH_MODE_DISABLED: {
-			screenrect = imgrect;
-			screenrect.position += ((window_size - screenrect.size) / 2.0).floor();
-		} break;
-		case RenderingServer::SPLASH_STRETCH_MODE_KEEP: {
-			if (window_size.width > window_size.height) {
-				// Scale horizontally.
-				screenrect.size.y = window_size.height;
-				screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
-				screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
-			} else {
-				// Scale vertically.
-				screenrect.size.x = window_size.width;
-				screenrect.size.y = imgrect.size.y * window_size.width / imgrect.size.x;
-				screenrect.position.y = (window_size.height - screenrect.size.y) / 2;
-			}
-		} break;
-		case RenderingServer::SPLASH_STRETCH_MODE_KEEP_WIDTH: {
-			// Scale vertically.
-			screenrect.size.x = window_size.width;
-			screenrect.size.y = imgrect.size.y * window_size.width / imgrect.size.x;
-			screenrect.position.y = (window_size.height - screenrect.size.y) / 2;
-		} break;
-		case RenderingServer::SPLASH_STRETCH_MODE_KEEP_HEIGHT: {
-			// Scale horizontally.
-			screenrect.size.y = window_size.height;
-			screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
-			screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
-		} break;
-		case RenderingServer::SPLASH_STRETCH_MODE_COVER: {
-			double window_aspect = (double)window_size.width / window_size.height;
-			double img_aspect = imgrect.size.x / imgrect.size.y;
-
-			if (window_aspect > img_aspect) {
-				// Scale vertically.
-				screenrect.size.x = window_size.width;
-				screenrect.size.y = imgrect.size.y * window_size.width / imgrect.size.x;
-				screenrect.position.y = (window_size.height - screenrect.size.y) / 2;
-			} else {
-				// Scale horizontally.
-				screenrect.size.y = window_size.height;
-				screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
-				screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
-			}
-		} break;
-		case RenderingServer::SPLASH_STRETCH_MODE_EXPAND: {
-			screenrect.size.x = window_size.width;
-			screenrect.size.y = window_size.height;
-		} break;
-	}
-
 	// FIXME: Actually draw the image after binding it, using screenrect for scaling.
+	//Rect2 screenrect = RenderingServer::get_splash_stretched_screen_rect(p_image->get_size(), window_size, p_stretch_mode);
 
 	RasterizerStorageGLES3::Texture *t = storage.texture_owner.get_or_null(texture);
 	glActiveTexture(GL_TEXTURE0 + storage.config.max_texture_image_units - 1);

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -179,61 +179,7 @@ void RendererCompositorRD::set_boot_image(const Ref<Image> &p_image, const Color
 	}
 
 	Size2 window_size = DisplayServer::get_singleton()->window_get_size();
-
-	Rect2 imgrect(0, 0, p_image->get_width(), p_image->get_height());
-	Rect2 screenrect;
-	switch (p_stretch_mode) {
-		case RenderingServer::SPLASH_STRETCH_MODE_DISABLED: {
-			screenrect = imgrect;
-			screenrect.position += ((window_size - screenrect.size) / 2.0).floor();
-		} break;
-		case RenderingServer::SPLASH_STRETCH_MODE_KEEP: {
-			if (window_size.width > window_size.height) {
-				// Scale horizontally.
-				screenrect.size.y = window_size.height;
-				screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
-				screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
-			} else {
-				// Scale vertically.
-				screenrect.size.x = window_size.width;
-				screenrect.size.y = imgrect.size.y * window_size.width / imgrect.size.x;
-				screenrect.position.y = (window_size.height - screenrect.size.y) / 2;
-			}
-		} break;
-		case RenderingServer::SPLASH_STRETCH_MODE_KEEP_WIDTH: {
-			// Scale vertically.
-			screenrect.size.x = window_size.width;
-			screenrect.size.y = imgrect.size.y * window_size.width / imgrect.size.x;
-			screenrect.position.y = (window_size.height - screenrect.size.y) / 2;
-		} break;
-		case RenderingServer::SPLASH_STRETCH_MODE_KEEP_HEIGHT: {
-			// Scale horizontally.
-			screenrect.size.y = window_size.height;
-			screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
-			screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
-		} break;
-		case RenderingServer::SPLASH_STRETCH_MODE_COVER: {
-			double window_aspect = (double)window_size.width / window_size.height;
-			double img_aspect = imgrect.size.x / imgrect.size.y;
-
-			if (window_aspect > img_aspect) {
-				// Scale vertically.
-				screenrect.size.x = window_size.width;
-				screenrect.size.y = imgrect.size.y * window_size.width / imgrect.size.x;
-				screenrect.position.y = (window_size.height - screenrect.size.y) / 2;
-			} else {
-				// Scale horizontally.
-				screenrect.size.y = window_size.height;
-				screenrect.size.x = imgrect.size.x * window_size.height / imgrect.size.y;
-				screenrect.position.x = (window_size.width - screenrect.size.x) / 2;
-			}
-		} break;
-		case RenderingServer::SPLASH_STRETCH_MODE_EXPAND: {
-			screenrect.size.x = window_size.width;
-			screenrect.size.y = window_size.height;
-		} break;
-	}
-
+	Rect2 screenrect = RenderingServer::get_splash_stretched_screen_rect(p_image->get_size(), window_size, p_stretch_mode);
 	screenrect.position /= window_size;
 	screenrect.size /= window_size;
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1475,6 +1475,63 @@ int RenderingServer::global_variable_type_get_shader_datatype(GlobalVariableType
 	}
 }
 
+Rect2 RenderingServer::get_splash_stretched_screen_rect(const Size2 &p_image_size, const Size2 &p_window_size, SplashStretchMode p_stretch_mode) {
+	Size2 imgsize = p_image_size;
+	Rect2 screenrect;
+	switch (p_stretch_mode) {
+		case RenderingServer::SPLASH_STRETCH_MODE_DISABLED: {
+			screenrect.size = imgsize;
+			screenrect.position = ((p_window_size - screenrect.size) / 2.0).floor();
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_KEEP: {
+			if (p_window_size.width > p_window_size.height) {
+				// Scale horizontally.
+				screenrect.size.y = p_window_size.height;
+				screenrect.size.x = imgsize.width * p_window_size.height / imgsize.height;
+				screenrect.position.x = (p_window_size.width - screenrect.size.x) / 2;
+			} else {
+				// Scale vertically.
+				screenrect.size.x = p_window_size.width;
+				screenrect.size.y = imgsize.height * p_window_size.width / imgsize.width;
+				screenrect.position.y = (p_window_size.height - screenrect.size.y) / 2;
+			}
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_KEEP_WIDTH: {
+			// Scale vertically.
+			screenrect.size.x = p_window_size.width;
+			screenrect.size.y = imgsize.height * p_window_size.width / imgsize.width;
+			screenrect.position.y = (p_window_size.height - screenrect.size.y) / 2;
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_KEEP_HEIGHT: {
+			// Scale horizontally.
+			screenrect.size.y = p_window_size.height;
+			screenrect.size.x = imgsize.width * p_window_size.height / imgsize.height;
+			screenrect.position.x = (p_window_size.width - screenrect.size.x) / 2;
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_COVER: {
+			double window_aspect = (double)p_window_size.width / p_window_size.height;
+			double img_aspect = imgsize.width / imgsize.height;
+
+			if (window_aspect > img_aspect) {
+				// Scale vertically.
+				screenrect.size.x = p_window_size.width;
+				screenrect.size.y = imgsize.height * p_window_size.width / imgsize.width;
+				screenrect.position.y = (p_window_size.height - screenrect.size.y) / 2;
+			} else {
+				// Scale horizontally.
+				screenrect.size.y = p_window_size.height;
+				screenrect.size.x = imgsize.width * p_window_size.height / imgsize.height;
+				screenrect.position.x = (p_window_size.width - screenrect.size.x) / 2;
+			}
+		} break;
+		case RenderingServer::SPLASH_STRETCH_MODE_EXPAND: {
+			screenrect.size.x = p_window_size.width;
+			screenrect.size.y = p_window_size.height;
+		} break;
+	}
+	return screenrect;
+}
+
 RenderingDevice *RenderingServer::get_rendering_device() const {
 	// Return the rendering device we're using globally.
 	return RenderingDevice::get_singleton();

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1520,6 +1520,7 @@ public:
 	};
 
 	virtual void set_boot_image(const Ref<Image> &p_image, const Color &p_color, RenderingServer::SplashStretchMode p_stretch_mode, bool p_use_filter = true) = 0;
+	static Rect2 get_splash_stretched_screen_rect(const Size2 &p_image_size, const Size2 &p_window_size, SplashStretchMode p_stretch_mode); // Helper for splash screen stretch handling.
 	virtual void set_default_clear_color(const Color &p_color) = 0;
 
 	enum Features {


### PR DESCRIPTION
Follow-up to #22488 (CC @samuelpedrajas)

In #22488 multiple stretch modes were added for the splash screen, and implemented at the renderer level in `RenderingServer::set_boot_splash()`.

Mobile devices seem to use their own OS-specific logic for the boot splash, and had not been updated to reflect the replacement of `application/boot_splash/fullsize` by `application/boot_splash/stretch_mode`.

This is an untested WIP to try to address that. It might very well not work at all right now as I didn't test and I'm not sure the used logic is valid. For iOS we're also currently always stretching with `scaleAspectFit` but there might be other values in the iOS API that could match our enum.

I wasn't sure where to put the helper method which I currently put in `RenderingServer::get_splash_stretched_screen_rect()` (since `set_boot_splash` is also there). If there's a better location, I'm happy to move it.