### PR TITLE
Add `DisplayServer.clipboard_has()` to check clipboard content

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -20,6 +20,12 @@
 				[b]Note:[/b] This method is only implemented on Linux.
 			</description>
 		</method>
+		<method name="clipboard_has" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if there is content on the user's clipboard.
+			</description>
+		</method>
 		<method name="clipboard_set">
 			<return type="void" />
 			<argument index="0" name="clipboard" type="String" />

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -95,6 +95,17 @@ String DisplayServerAndroid::clipboard_get() const {
 	}
 }
 
+bool DisplayServerAndroid::clipboard_has() const {
+	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
+	ERR_FAIL_COND_V(!godot_java, false);
+
+	if (godot_java->has_has_clipboard()) {
+		return godot_java->has_clipboard();
+	} else {
+		return DisplayServer::clipboard_has();
+	}
+}
+
 void DisplayServerAndroid::screen_set_keep_on(bool p_enable) {
 	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
 	ERR_FAIL_COND(!godot_java);

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -93,6 +93,7 @@ public:
 
 	virtual void clipboard_set(const String &p_text) override;
 	virtual String clipboard_get() const override;
+	virtual bool clipboard_has() const override;
 
 	virtual void screen_set_keep_on(bool p_enable) override;
 	virtual bool screen_is_kept_on() const override;

--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -660,10 +660,14 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		}
 	}
 
+	public boolean hasClipboard() {
+		return mClipboard.hasPrimaryClip();
+	}
+
 	public String getClipboard() {
 		String copiedText = "";
 
-		if (mClipboard.getPrimaryClip() != null) {
+		if (mClipboard.hasPrimaryClip()) {
 			ClipData.Item item = mClipboard.getPrimaryClip().getItemAt(0);
 			copiedText = item.getText().toString();
 		}

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -66,6 +66,7 @@ GodotJavaWrapper::GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_
 	_get_GLES_version_code = p_env->GetMethodID(godot_class, "getGLESVersionCode", "()I");
 	_get_clipboard = p_env->GetMethodID(godot_class, "getClipboard", "()Ljava/lang/String;");
 	_set_clipboard = p_env->GetMethodID(godot_class, "setClipboard", "(Ljava/lang/String;)V");
+	_has_clipboard = p_env->GetMethodID(godot_class, "hasClipboard", "()Z");
 	_request_permission = p_env->GetMethodID(godot_class, "requestPermission", "(Ljava/lang/String;)Z");
 	_request_permissions = p_env->GetMethodID(godot_class, "requestPermissions", "()Z");
 	_get_granted_permissions = p_env->GetMethodID(godot_class, "getGrantedPermissions", "()[Ljava/lang/String;");
@@ -245,6 +246,21 @@ void GodotJavaWrapper::set_clipboard(const String &p_text) {
 
 		jstring jStr = env->NewStringUTF(p_text.utf8().get_data());
 		env->CallVoidMethod(godot_instance, _set_clipboard, jStr);
+	}
+}
+
+bool GodotJavaWrapper::has_has_clipboard() {
+	return _has_clipboard != 0;
+}
+
+bool GodotJavaWrapper::has_clipboard() {
+	if (_has_clipboard) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, false);
+
+		return env->CallBooleanMethod(godot_instance, _has_clipboard);
+	} else {
+		return false;
 	}
 }
 

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -58,6 +58,7 @@ private:
 	jmethodID _get_GLES_version_code = 0;
 	jmethodID _get_clipboard = 0;
 	jmethodID _set_clipboard = 0;
+	jmethodID _has_clipboard = 0;
 	jmethodID _request_permission = 0;
 	jmethodID _request_permissions = 0;
 	jmethodID _get_granted_permissions = 0;
@@ -92,6 +93,8 @@ public:
 	String get_clipboard();
 	bool has_set_clipboard();
 	void set_clipboard(const String &p_text);
+	bool has_has_clipboard();
+	bool has_clipboard();
 	bool request_permission(const String &p_name);
 	bool request_permissions();
 	Vector<String> get_granted_permissions() const;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -155,6 +155,10 @@ String DisplayServer::clipboard_get() const {
 	ERR_FAIL_V_MSG(String(), "Clipboard is not supported by this display server.");
 }
 
+bool DisplayServer::clipboard_has() const {
+	return !clipboard_get().is_empty();
+}
+
 void DisplayServer::clipboard_set_primary(const String &p_text) {
 	WARN_PRINT("Primary clipboard is not supported by this display server.");
 }
@@ -359,6 +363,7 @@ void DisplayServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("clipboard_set", "clipboard"), &DisplayServer::clipboard_set);
 	ClassDB::bind_method(D_METHOD("clipboard_get"), &DisplayServer::clipboard_get);
+	ClassDB::bind_method(D_METHOD("clipboard_has"), &DisplayServer::clipboard_has);
 	ClassDB::bind_method(D_METHOD("clipboard_set_primary", "clipboard_primary"), &DisplayServer::clipboard_set_primary);
 	ClassDB::bind_method(D_METHOD("clipboard_get_primary"), &DisplayServer::clipboard_get_primary);
 

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -160,6 +160,7 @@ public:
 
 	virtual void clipboard_set(const String &p_text);
 	virtual String clipboard_get() const;
+	virtual bool clipboard_has() const;
 	virtual void clipboard_set_primary(const String &p_text);
 	virtual String clipboard_get_primary() const;
 


### PR DESCRIPTION
The current way to check if there is anything to paste is to compare `clipboard_get()` result with an empty string. However, on Android 12 and higher, the system [usually](https://developer.android.com/guide/topics/text/copy-paste#PastingSystemNotifications) shows a toast message when the app fetches the clipboard content:

> Godot Engine pasted from your clipboard

This is confusing & annoying if the user just want to check if there is anything to paste in order to update the UI.

This PR adds a `clipboard_has()` method that checks clipboard content existence on Android without triggering the toast, and it simply returns `!clipboard_get().is_empty()` on other platforms.