### PR TITLE
Fix locale always selecting translation instead of "en", when no match found.

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -820,7 +820,7 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 			}
 			String l = res_remaps[i].substr(split + 1).strip_edges();
 			int score = TranslationServer::get_singleton()->compare_locales(locale, l);
-			if (score >= best_score) {
+			if (score > best_score) {
 				new_path = res_remaps[i].left(split);
 				best_score = score;
 				if (score == 10) {

--- a/core/string/translation.cpp
+++ b/core/string/translation.cpp
@@ -544,7 +544,7 @@ Ref<Translation> TranslationServer::get_translation_object(const String &p_local
 		String l = t->get_locale();
 
 		int score = compare_locales(p_locale, l);
-		if (score >= best_score) {
+		if (score > best_score) {
 			res = t;
 			best_score = score;
 			if (score == 10) {
@@ -617,7 +617,7 @@ StringName TranslationServer::_get_message_from_translations(const StringName &p
 		String l = t->get_locale();
 
 		int score = compare_locales(p_locale, l);
-		if (score >= best_score) {
+		if (score > best_score) {
 			StringName r;
 			if (!plural) {
 				res = t->get_message(p_message, p_context);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -377,7 +377,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 			lang_hint += locale;
 
 			int score = TranslationServer::get_singleton()->compare_locales(host_lang, locale);
-			if (score >= best_score) {
+			if (score > best_score) {
 				best = locale;
 				best_score = score;
 				if (score == 10) {


### PR DESCRIPTION
Regression from #52969, I have missed the case when there's no translation and source `en` strings should be used.

Fixes #56945
