### PR TITLE
Add exclusive window handling to DisplayServer (on macOS and Windows).

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -638,6 +638,16 @@
 			<description>
 			</description>
 		</method>
+		<method name="window_set_exclusive">
+			<return type="void" />
+			<argument index="0" name="window_id" type="int" />
+			<argument index="1" name="exclusive" type="bool" />
+			<description>
+				If set to [code]true[/code], this window will always stay on top of its parent window, parent window will ignore input while this window is opened.
+				[b]Note:[/b] On macOS, exclusive windows are confined to the same space (virtual desktop or screen) as the parent window.
+				[b]Note:[/b] This method is implemented on macOS and Windows.
+			</description>
+		</method>
 		<method name="window_set_flag">
 			<return type="void" />
 			<argument index="0" name="flag" type="int" enum="DisplayServer.WindowFlags" />

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -95,6 +95,7 @@ public:
 		ObjectID instance_id;
 
 		WindowID transient_parent = INVALID_WINDOW_ID;
+		bool exclusive = false;
 		Set<WindowID> transient_children;
 
 		bool layered_window = false;
@@ -274,6 +275,7 @@ public:
 	virtual void window_set_position(const Point2i &p_position, WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual void window_set_transient(WindowID p_window, WindowID p_parent) override;
+	virtual void window_set_exclusive(WindowID p_window, bool p_exclusive) override;
 
 	virtual void window_set_max_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual Size2i window_get_max_size(WindowID p_window = MAIN_WINDOW_ID) const override;

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -339,6 +339,7 @@ class DisplayServerWindows : public DisplayServer {
 		bool always_on_top = false;
 		bool no_focus = false;
 		bool window_has_focus = false;
+		bool exclusive = false;
 
 		// Used to transfer data between events using timer.
 		WPARAM saved_wparam;
@@ -499,6 +500,7 @@ public:
 	virtual void window_set_position(const Point2i &p_position, WindowID p_window = MAIN_WINDOW_ID) override;
 
 	virtual void window_set_transient(WindowID p_window, WindowID p_parent) override;
+	virtual void window_set_exclusive(WindowID p_window, bool p_exclusive) override;
 
 	virtual void window_set_max_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) override;
 	virtual Size2i window_get_max_size(WindowID p_window = MAIN_WINDOW_ID) const override;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -254,6 +254,7 @@ void Window::_make_window() {
 #endif
 	DisplayServer::get_singleton()->window_set_title(tr_title, window_id);
 	DisplayServer::get_singleton()->window_attach_instance_id(get_instance_id(), window_id);
+	DisplayServer::get_singleton()->window_set_exclusive(window_id, exclusive);
 
 	_update_window_size();
 
@@ -521,6 +522,10 @@ void Window::set_exclusive(bool p_exclusive) {
 	}
 
 	exclusive = p_exclusive;
+
+	if (!embedder && window_id != DisplayServer::INVALID_WINDOW_ID) {
+		DisplayServer::get_singleton()->window_set_exclusive(window_id, exclusive);
+	}
 
 	if (transient_parent) {
 		if (p_exclusive && is_inside_tree() && is_visible()) {

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -204,6 +204,10 @@ void DisplayServer::delete_sub_window(WindowID p_id) {
 	ERR_FAIL_MSG("Sub-windows not supported by this display server.");
 }
 
+void DisplayServer::window_set_exclusive(WindowID p_window, bool p_exclusive) {
+	// Do nothing, if not supported.
+}
+
 void DisplayServer::window_set_mouse_passthrough(const Vector<Vector2> &p_region, WindowID p_window) {
 	ERR_FAIL_MSG("Mouse passthrough not supported by this display server.");
 }
@@ -436,6 +440,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("window_can_draw", "window_id"), &DisplayServer::window_can_draw, DEFVAL(MAIN_WINDOW_ID));
 
 	ClassDB::bind_method(D_METHOD("window_set_transient", "window_id", "parent_window_id"), &DisplayServer::window_set_transient);
+	ClassDB::bind_method(D_METHOD("window_set_exclusive", "window_id", "exclusive"), &DisplayServer::window_set_exclusive);
 
 	ClassDB::bind_method(D_METHOD("window_set_ime_active", "active", "window_id"), &DisplayServer::window_set_ime_active, DEFVAL(MAIN_WINDOW_ID));
 	ClassDB::bind_method(D_METHOD("window_set_ime_position", "position", "window_id"), &DisplayServer::window_set_ime_position, DEFVAL(MAIN_WINDOW_ID));

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -277,6 +277,7 @@ public:
 	virtual void window_set_position(const Point2i &p_position, WindowID p_window = MAIN_WINDOW_ID) = 0;
 
 	virtual void window_set_transient(WindowID p_window, WindowID p_parent) = 0;
+	virtual void window_set_exclusive(WindowID p_window, bool p_exclusive);
 
 	virtual void window_set_max_size(const Size2i p_size, WindowID p_window = MAIN_WINDOW_ID) = 0;
 	virtual Size2i window_get_max_size(WindowID p_window = MAIN_WINDOW_ID) const = 0;


### PR DESCRIPTION
I'm not entirely sure if this is the intended way to handle it.

I assume `exclusive` window should stay on top of it's parent and prevent focusing of the parent, and `transient` just mean it won't exist longer than a parent.

There's a limitation with macOS windowing system which (in some configs) prevents "child window" (which always stay on top of the parent) to be on the other screen (or virtual desktop) than its parent window.
Which should be OK for the `exclusive` dialogs (like file open), but is not OK for `transient` windows (e.g., undocked property inspector, etc.).

This PR adds function to set `exclusive` mode to the `DisplayServer`, changes behavior on Windows to keep only `exclusive` children windows on top of the parent (instead of all `transient`), and adds the same functionality to the macOS.

Fixes #57152
Fixes #57831