### PR TITLE
Ignore layout and translation changes in Controls outside of tree

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -733,8 +733,10 @@ void Control::_notification(int p_notification) {
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
-			data.is_rtl_dirty = true;
-			_size_changed();
+			if (is_inside_tree()) {
+				data.is_rtl_dirty = true;
+				_size_changed();
+			}
 		} break;
 	}
 }


### PR DESCRIPTION
Control will be recalculated upon entering the tree anyway.

While working on the new default project theme (https://github.com/godotengine/godot/pull/51159) I've run into a weird behavior where `CodeEdit` would report its `rect_size` to the docs, which no other control does, and shouldn't really happen. Not even it's parent, `TextEdit`, was behaving like that. Turned out that `CodeEdit` was setting layout direction in its constructor, which triggered a resize in this code, which made `CodeEdit` change its size the moment it was instantiated, making docs unstable.

After investigating I found no reason for these notifications to be handled outside of the tree. As mentioned above, the same computations are performed regardless after the control had entered the tree. So the overall behavior for the size remains the same, and we have clean docs.