### PR TITLE
Rework Node::get_node to omit is_absolute() check in best case scenario

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1316,12 +1316,14 @@ Node *Node::get_node_or_null(const NodePath &p_path) const {
 Node *Node::get_node(const NodePath &p_path) const {
 	Node *node = get_node_or_null(p_path);
 
-	if (p_path.is_absolute()) {
-		ERR_FAIL_COND_V_MSG(!node, nullptr,
-				vformat(R"(Node not found: "%s" (absolute path attempted from "%s").)", p_path, get_path()));
-	} else {
-		ERR_FAIL_COND_V_MSG(!node, nullptr,
-				vformat(R"(Node not found: "%s" (relative to "%s").)", p_path, get_path()));
+	if (unlikely(!node)) {
+		if (p_path.is_absolute()) {
+			ERR_FAIL_V_MSG(nullptr,
+					vformat(R"(Node not found: "%s" (absolute path attempted from "%s").)", p_path, get_path()));
+		} else {
+			ERR_FAIL_V_MSG(nullptr,
+					vformat(R"(Node not found: "%s" (relative to "%s").)", p_path, get_path()));
+		}
 	}
 
 	return node;


### PR DESCRIPTION
It's more likely that the `node` pointer won't be the `nullptr` so we can omit checking if path `is_absolute()` in most cases (it's only needed to show proper error message).