### PR TITLE
Print a notice when compiling with `target=debug`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -503,7 +503,6 @@ if selected_platform in platform_list:
             Exit(255)
         suffix += ".opt"
         env.Append(CPPDEFINES=["NDEBUG"])
-
     elif env["target"] == "release_debug":
         if env["tools"]:
             suffix += ".opt.tools"
@@ -511,8 +510,14 @@ if selected_platform in platform_list:
             suffix += ".opt.debug"
     else:
         if env["tools"]:
+            print(
+                "Note: Building a debug binary (which will run slowly). Use `target=release_debug` to build an optimized release binary."
+            )
             suffix += ".tools"
         else:
+            print(
+                "Note: Building a debug binary (which will run slowly). Use `target=release` to build an optimized release binary."
+            )
             suffix += ".debug"
 
     if env["arch"] != "":


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/38972.

Debug builds are considerably slower than release builds or even release_debug builds. `target=debug` is still the default SCons target option, so unsuspecting users may be compiling unoptimized debug builds for their personal use.