### PR TITLE
Allow using the web editor on any device orientation

### DIFF
--- a/misc/dist/html/manifest.json
+++ b/misc/dist/html/manifest.json
@@ -5,7 +5,6 @@
   "lang": "en",
   "start_url": "./godot.tools.html",
   "display": "standalone",
-  "orientation": "landscape",
   "theme_color": "#202531",
   "icons": [
     {


### PR DESCRIPTION
On tablets and foldable phones, the editor can remain usable while in portrait mode thanks to the wide display. The default value allows using any orientation (at least according to [this generator](https://manifest-gen.netlify.app/)).

This partially addresses https://github.com/godotengine/godot/issues/56960.