### PR TITLE
Fix Asset Library UX when an asset is being downloaded

### DIFF
--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -275,7 +275,7 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 		asset_contents->set_text(vformat(TTR("Contents of asset \"%s\" - No files conflict with your project:"), asset_name));
 	}
 
-	popup_centered_ratio();
+	popup_centered_ratio(0.5);
 	updating = false;
 }
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -374,7 +374,7 @@ void EditorAssetLibraryItemDownload::_http_download_completed(int p_status, int 
 	}
 
 	install_button->set_disabled(false);
-	status->set_text(TTR("Success!"));
+	status->set_text(TTR("Ready to install!"));
 	// Make the progress bar invisible but don't reflow other Controls around it.
 	progress->set_modulate(Color(0, 0, 0, 0));
 
@@ -460,6 +460,10 @@ void EditorAssetLibraryItemDownload::_close() {
 	// Clean up downloaded file.
 	DirAccess::remove_file_or_error(download->get_download_file());
 	queue_delete();
+}
+
+bool EditorAssetLibraryItemDownload::can_install() const {
+	return !install_button->is_disabled();
 }
 
 void EditorAssetLibraryItemDownload::install() {
@@ -1265,9 +1269,16 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 
 			EditorAssetLibraryItemDownload *download_item = _get_asset_in_progress(description->get_asset_id());
 			if (download_item) {
-				description->get_ok_button()->set_text(TTR("Install"));
+				if (download_item->can_install()) {
+					description->get_ok_button()->set_text(TTR("Install"));
+					description->get_ok_button()->set_disabled(false);
+				} else {
+					description->get_ok_button()->set_text(TTR("Downloading..."));
+					description->get_ok_button()->set_disabled(true);
+				}
 			} else {
 				description->get_ok_button()->set_text(TTR("Download"));
+				description->get_ok_button()->set_disabled(false);
 			}
 
 			if (r.has("icon_url") && !r["icon_url"].operator String().is_empty()) {

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -164,7 +164,10 @@ public:
 	void set_external_install(bool p_enable) { external_install = p_enable; }
 	int get_asset_id() { return asset_id; }
 	void configure(const String &p_title, int p_asset_id, const Ref<Texture2D> &p_preview, const String &p_download_url, const String &p_sha256_hash);
+
+	bool can_install() const;
 	void install();
+
 	EditorAssetLibraryItemDownload();
 };
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/56929. It was 5 am and I forgot to account for assets in progress. It wasn't erring or anything, but the state was not handled correctly. So this aims to remedy the problem by locking the popup button and giving it "Downloading..." for text.

![godot windows tools 64_2022-01-19_19-11-24](https://user-images.githubusercontent.com/11782833/150171339-0b260c6c-a56a-446d-97a4-ecc0ce7d49b8.png)

I've also changed "Success!" status message to a more directing "Ready to install!", and made the installer dialog a bit smaller (it would probably benefit from some reasonable fixed size though).

![godot windows tools 64_2022-01-19_19-11-56](https://user-images.githubusercontent.com/11782833/150171357-4684b481-1d48-4989-be9a-ff0233c5e867.png)
