### PR TITLE
Tweak theme color to match the Godot editor's background color

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -9,8 +9,8 @@
 	<meta name="apple-mobile-web-app-capable" content="yes" />
 	<meta name="application-name" content="Godot" />
 	<meta name="apple-mobile-web-app-title" content="Godot" />
-	<meta name="theme-color" content="#478cbf" />
-	<meta name="msapplication-navbutton-color" content="#478cbf" />
+	<meta name="theme-color" content="#202531" />
+	<meta name="msapplication-navbutton-color" content="#202531" />
 	<meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 	<meta name="msapplication-starturl" content="/latest" />
 	<meta property="og:site_name" content="Godot Engine Web Editor" />

--- a/misc/dist/html/manifest.json
+++ b/misc/dist/html/manifest.json
@@ -6,7 +6,7 @@
   "start_url": "./godot.tools.html",
   "display": "standalone",
   "orientation": "landscape",
-  "theme_color": "#478cbf",
+  "theme_color": "#202531",
   "icons": [
     {
       "src": "favicon.png",

--- a/misc/dist/html/offline.html
+++ b/misc/dist/html/offline.html
@@ -4,6 +4,8 @@
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge" />
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<meta name="theme-color" content="#202531" />
+	<meta name="msapplication-navbutton-color" content="#202531" />
 	<title>You are offline</title>
 	<style>
 		html {


### PR DESCRIPTION
This makes for a more seamless-looking address bar/status bar when using the web editor on a mobile device, either directly in the brower or installed as a progressive web app.

The previous theme color also caused the Android task switcher icon to have a bright blue background (the same as the logo), which looked strange.

This also specifies a theme color for the web editor's offline fallback.

## Preview

| Before | After |
|-|-|
| ![Screenshot_20220119-202225_Bromite](https://user-images.githubusercontent.com/180032/150199766-dd27a14b-99ed-4e3d-8cd8-e87bdcd99e82.png) | ![Screenshot_20220119-201754_Bromite](https://user-images.githubusercontent.com/180032/150199941-95f64647-d655-4930-83c1-0e3a56758441.png) |

| Before | After |
|-|-|
| ![Screenshot_20220119-171943_One UI Home](https://user-images.githubusercontent.com/180032/150199780-3d1a3b88-28bd-4196-817c-dc91e449ab28.png) | ![Screenshot_20220119-202109_One UI Home](https://user-images.githubusercontent.com/180032/150199804-eb1c0b4d-3842-4a45-aefc-952b23628517.png) |