### PR TITLE
Bring `TabBar` to full parity with the `TabContainer` implementation.

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -43,10 +43,11 @@
 				Returns the previously active tab index.
 			</description>
 		</method>
-		<method name="get_select_with_rmb" qualifiers="const">
-			<return type="bool" />
+		<method name="get_tab_button_icon" qualifiers="const">
+			<return type="Texture2D" />
+			<argument index="0" name="tab_idx" type="int" />
 			<description>
-				Returns [code]true[/code] if select with right mouse button is enabled.
+				Returns the [Texture2D] for the right button of the tab at index [code]tab_idx[/code] or [code]null[/code] if the button has no [Texture2D].
 			</description>
 		</method>
 		<method name="get_tab_icon" qualifiers="const">
@@ -111,6 +112,13 @@
 				Returns [code]true[/code] if the tab at index [code]tab_idx[/code] is disabled.
 			</description>
 		</method>
+		<method name="is_tab_hidden" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="tab_idx" type="int" />
+			<description>
+				Returns [code]true[/code] if the tab at index [code]tab_idx[/code] is hidden.
+			</description>
+		</method>
 		<method name="move_tab">
 			<return type="void" />
 			<argument index="0" name="from" type="int" />
@@ -126,11 +134,12 @@
 				Removes the tab at index [code]tab_idx[/code].
 			</description>
 		</method>
-		<method name="set_select_with_rmb">
+		<method name="set_tab_button_icon">
 			<return type="void" />
-			<argument index="0" name="enabled" type="bool" />
+			<argument index="0" name="tab_idx" type="int" />
+			<argument index="1" name="icon" type="Texture2D" />
 			<description>
-				If [code]true[/code], enables selecting a tab with the right mouse button.
+				Sets an [code]icon[/code] for the button of the tab at index [code]tab_idx[/code] (located to the right, before the close button), making it visible and clickable (See [signal tab_button_pressed]). Giving it a [code]null[/code] value will hide the button.
 			</description>
 		</method>
 		<method name="set_tab_disabled">
@@ -139,6 +148,14 @@
 			<argument index="1" name="disabled" type="bool" />
 			<description>
 				If [code]disabled[/code] is [code]true[/code], disables the tab at index [code]tab_idx[/code], making it non-interactable.
+			</description>
+		</method>
+		<method name="set_tab_hidden">
+			<return type="void" />
+			<argument index="0" name="tab_idx" type="int" />
+			<argument index="1" name="hidden" type="bool" />
+			<description>
+				If [code]hidden[/code] is [code]true[/code], hides the tab at index [code]tab_idx[/code], making it disappear from the tab area.
 			</description>
 		</method>
 		<method name="set_tab_icon">
@@ -200,10 +217,17 @@
 		<member name="drag_to_rearrange_enabled" type="bool" setter="set_drag_to_rearrange_enabled" getter="get_drag_to_rearrange_enabled" default="false">
 			If [code]true[/code], tabs can be rearranged with mouse drag.
 		</member>
+		<member name="scroll_to_selected" type="bool" setter="set_scroll_to_selected" getter="get_scroll_to_selected" default="true">
+			If [code]true[/code], the tab offset will be changed to keep the the currently selected tab visible.
+		</member>
 		<member name="scrolling_enabled" type="bool" setter="set_scrolling_enabled" getter="get_scrolling_enabled" default="true">
 			if [code]true[/code], the mouse's scroll wheel can be used to navigate the scroll view.
 		</member>
+		<member name="select_with_rmb" type="bool" setter="set_select_with_rmb" getter="get_select_with_rmb" default="false">
+			If [code]true[/code], enables selecting a tab with the right mouse button.
+		</member>
 		<member name="tab_alignment" type="int" setter="set_tab_alignment" getter="get_tab_alignment" enum="TabBar.AlignmentMode" default="1">
+			Sets the position at which tabs will be placed. See [enum AlignmentMode] for details.
 		</member>
 		<member name="tab_close_display_policy" type="int" setter="set_tab_close_display_policy" getter="get_tab_close_display_policy" enum="TabBar.CloseButtonDisplayPolicy" default="0">
 			Sets when the close button will appear on the tabs. See [enum CloseButtonDisplayPolicy] for details.
@@ -217,6 +241,12 @@
 			<argument index="0" name="idx_to" type="int" />
 			<description>
 				Emitted when the active tab is rearranged via mouse drag. See [member drag_to_rearrange_enabled].
+			</description>
+		</signal>
+		<signal name="tab_button_pressed">
+			<argument index="0" name="tab" type="int" />
+			<description>
+				Emitted when a tab's right button is pressed. See [method set_tab_button_icon].
 			</description>
 		</signal>
 		<signal name="tab_changed">
@@ -255,18 +285,28 @@
 		<signal name="tab_rmb_clicked">
 			<argument index="0" name="tab" type="int" />
 			<description>
-				Emitted when a tab is right-clicked.
+				Emitted when a tab is right-clicked. [member select_with_rmb] must be enabled.
+			</description>
+		</signal>
+		<signal name="tab_selected">
+			<argument index="0" name="tab" type="int" />
+			<description>
+				Emitted when a tab is selected via click or script, even if it is the current tab.
 			</description>
 		</signal>
 	</signals>
 	<constants>
 		<constant name="ALIGNMENT_LEFT" value="0" enum="AlignmentMode">
+			Places tabs to the left.
 		</constant>
 		<constant name="ALIGNMENT_CENTER" value="1" enum="AlignmentMode">
+			Places tabs in the middle.
 		</constant>
 		<constant name="ALIGNMENT_RIGHT" value="2" enum="AlignmentMode">
+			Places tabs to the right.
 		</constant>
 		<constant name="ALIGNMENT_MAX" value="3" enum="AlignmentMode">
+			Represents the size of the [enum AlignmentMode] enum.
 		</constant>
 		<constant name="CLOSE_BUTTON_SHOW_NEVER" value="0" enum="CloseButtonDisplayPolicy">
 			Never show the close buttons.
@@ -321,11 +361,11 @@
 		<theme_item name="increment_highlight" data_type="icon" type="Texture2D">
 			Icon for the right arrow button that appears when there are too many tabs to fit in the container width. Used when the button is being hovered with the cursor.
 		</theme_item>
-		<theme_item name="close_bg_highlight" data_type="style" type="StyleBox">
-			Background of the close button when it's being hovered with the cursor.
+		<theme_item name="button_highlight" data_type="style" type="StyleBox">
+			Background of the tab and close buttons when they're being hovered with the cursor.
 		</theme_item>
-		<theme_item name="close_bg_pressed" data_type="style" type="StyleBox">
-			Background of the close button when it's being pressed.
+		<theme_item name="button_pressed" data_type="style" type="StyleBox">
+			Background of the tab and close buttons when it's being pressed.
 		</theme_item>
 		<theme_item name="tab_disabled" data_type="style" type="StyleBox">
 			The style of disabled tabs.

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -340,7 +340,7 @@ void EditorNode::_update_scene_tabs() {
 		}
 
 		if (show_rb && editor_data.get_scene_root_script(i).is_valid()) {
-			scene_tabs->set_tab_right_button(i, script_icon);
+			scene_tabs->set_tab_button_icon(i, script_icon);
 		}
 	}
 
@@ -6233,7 +6233,7 @@ EditorNode::EditorNode() {
 	scene_tabs->set_min_width(int(EDITOR_DEF("interface/scene_tabs/minimum_width", 50)) * EDSCALE);
 	scene_tabs->set_drag_to_rearrange_enabled(true);
 	scene_tabs->connect("tab_changed", callable_mp(this, &EditorNode::_scene_tab_changed));
-	scene_tabs->connect("tab_rmb_clicked", callable_mp(this, &EditorNode::_scene_tab_script_edited));
+	scene_tabs->connect("tab_button_pressed", callable_mp(this, &EditorNode::_scene_tab_script_edited));
 	scene_tabs->connect("tab_close_pressed", callable_mp(this, &EditorNode::_scene_tab_closed), varray(SCENE_TAB_CLOSE));
 	scene_tabs->connect("tab_hovered", callable_mp(this, &EditorNode::_scene_tab_hovered));
 	scene_tabs->connect("mouse_exited", callable_mp(this, &EditorNode::_scene_tab_exit));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1016,8 +1016,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("SceneTabFG", "EditorStyles", style_tab_selected);
 	theme->set_stylebox("SceneTabBG", "EditorStyles", style_tab_unselected);
 	theme->set_icon("close", "TabBar", theme->get_icon("GuiClose", "EditorIcons"));
-	theme->set_stylebox("close_bg_pressed", "TabBar", style_menu);
-	theme->set_stylebox("close_bg_highlight", "TabBar", style_menu);
+	theme->set_stylebox("button_pressed", "TabBar", style_menu);
+	theme->set_stylebox("button_highlight", "TabBar", style_menu);
 	theme->set_icon("increment", "TabContainer", theme->get_icon("GuiScrollArrowRight", "EditorIcons"));
 	theme->set_icon("decrement", "TabContainer", theme->get_icon("GuiScrollArrowLeft", "EditorIcons"));
 	theme->set_icon("increment", "TabBar", theme->get_icon("GuiScrollArrowRight", "EditorIcons"));

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3469,7 +3469,7 @@ void ThemeEditor::_add_preview_tab(ThemeEditorPreview *p_preview_tab, const Stri
 
 	preview_tabs->add_tab(p_preview_name, p_icon);
 	preview_tabs_content->add_child(p_preview_tab);
-	preview_tabs->set_tab_right_button(preview_tabs->get_tab_count() - 1, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("close"), SNAME("TabBar")));
+	preview_tabs->set_tab_button_icon(preview_tabs->get_tab_count() - 1, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("close"), SNAME("TabBar")));
 	p_preview_tab->connect("control_picked", callable_mp(this, &ThemeEditor::_preview_control_picked));
 
 	preview_tabs->set_current_tab(preview_tabs->get_tab_count() - 1);
@@ -3600,7 +3600,7 @@ ThemeEditor::ThemeEditor() {
 	preview_tabs->set_h_size_flags(SIZE_EXPAND_FILL);
 	preview_tabbar_hb->add_child(preview_tabs);
 	preview_tabs->connect("tab_changed", callable_mp(this, &ThemeEditor::_change_preview_tab));
-	preview_tabs->connect("tab_rmb_clicked", callable_mp(this, &ThemeEditor::_remove_preview_tab));
+	preview_tabs->connect("tab_button_pressed", callable_mp(this, &ThemeEditor::_remove_preview_tab));
 
 	HBoxContainer *add_preview_button_hb = memnew(HBoxContainer);
 	preview_tabbar_hb->add_child(add_preview_button_hb);

--- a/scene/gui/tab_bar.h
+++ b/scene/gui/tab_bar.h
@@ -63,12 +63,11 @@ private:
 
 		Ref<TextLine> text_buf;
 		Ref<Texture2D> icon;
-		int ofs_cache = 0;
 		bool disabled = false;
+		bool hidden = false;
+		int ofs_cache = 0;
 		int size_cache = 0;
 		int size_text = 0;
-		int x_cache = 0;
-		int x_size_cache = 0;
 
 		Ref<Texture2D> right_button;
 		Rect2 rb_rect;
@@ -102,6 +101,7 @@ private:
 	int min_width = 0;
 	bool scrolling_enabled = true;
 	bool drag_to_rearrange_enabled = false;
+	bool scroll_to_selected = true;
 	int tabs_rearrange_group = -1;
 
 	int get_tab_width(int p_idx) const;
@@ -150,8 +150,11 @@ public:
 	void set_tab_disabled(int p_tab, bool p_disabled);
 	bool is_tab_disabled(int p_tab) const;
 
-	void set_tab_right_button(int p_tab, const Ref<Texture2D> &p_right_button);
-	Ref<Texture2D> get_tab_right_button(int p_tab) const;
+	void set_tab_hidden(int p_tab, bool p_hidden);
+	bool is_tab_hidden(int p_tab) const;
+
+	void set_tab_button_icon(int p_tab, const Ref<Texture2D> &p_icon);
+	Ref<Texture2D> get_tab_button_icon(int p_tab) const;
 
 	void set_tab_alignment(AlignmentMode p_alignment);
 	AlignmentMode get_tab_alignment() const;
@@ -186,6 +189,9 @@ public:
 	bool get_drag_to_rearrange_enabled() const;
 	void set_tabs_rearrange_group(int p_group_id);
 	int get_tabs_rearrange_group() const;
+
+	void set_scroll_to_selected(bool p_enabled);
+	bool get_scroll_to_selected() const;
 
 	void set_select_with_rmb(bool p_enabled);
 	bool get_select_with_rmb() const;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -817,8 +817,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 	theme->set_stylebox("tab_selected", "TabBar", style_tab_selected);
 	theme->set_stylebox("tab_unselected", "TabBar", style_tab_unselected);
 	theme->set_stylebox("tab_disabled", "TabBar", style_tab_disabled);
-	theme->set_stylebox("close_bg_pressed", "TabBar", button_pressed);
-	theme->set_stylebox("close_bg_highlight", "TabBar", button_normal);
+	theme->set_stylebox("button_pressed", "TabBar", button_pressed);
+	theme->set_stylebox("button_highlight", "TabBar", button_normal);
 
 	theme->set_icon("increment", "TabBar", icons["scroll_button_right"]);
 	theme->set_icon("increment_highlight", "TabBar", icons["scroll_button_right_hl"]);


### PR DESCRIPTION
### What this PR does:
- Adds the ability to hide tabs.
- Adds an option to turn off the behavior of always keeping the selected tab visible.
- Fixes error spam when setting the tab count below the index of the selected tab.
- Fixes `tab_rmb_clicked` signal being fired by clicking the right tab button (which was not even exposed!) instead of when the tab is right clicked.
- Fixes some regressions related to RTL mode.
- Fixes #57181.
- Renames the following theme properties: `close_bg_highlight` -> `button_highlight`; `close_bg_pressed` -> `button_pressed`.
- Exposes `set/get_tab_right_button()` and renames them to `set/get_tab_button_icon()`.
- Adds a proper signal for when the right button is pressed (`tab_button_pressed`).
- Adds a `tab_selected` signal.
- Adds missing documentation.

### What this PR does NOT do:
- Expose `min_width`, behavior that lets tabs shrink to a certain size if there's not enough space.

As much as this would be nice to have, the behavior is broken before, and is broken now. It's only used by the scene tabs, and it only "works" there because of the weird implementation of clearing all tabs after doing pretty much anything. Maybe me or someone else can salvage that one day.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/3846.*