### PR TITLE
Add `[[nodiscard]]` to core math classes to catch c++ errors

### DIFF
--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -41,7 +41,7 @@
  */
 class Variant;
 
-class AABB {
+class _NO_DISCARD_ AABB {
 public:
 	Vector3 position;
 	Vector3 size;

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -34,7 +34,7 @@
 #include "core/math/quaternion.h"
 #include "core/math/vector3.h"
 
-class Basis {
+class _NO_DISCARD_ Basis {
 private:
 	void _set_diagonal(const Vector3 &p_diag);
 

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -34,7 +34,7 @@
 #include "core/math/math_funcs.h"
 #include "core/string/ustring.h"
 
-struct Color {
+struct _NO_DISCARD_ Color {
 	union {
 		struct {
 			float r;

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -36,7 +36,7 @@
 #include "core/math/transform_3d.h"
 #include "core/math/vector3.h"
 
-class Face3 {
+class _NO_DISCARD_ Face3 {
 public:
 	enum Side {
 		SIDE_OVER,

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -35,7 +35,7 @@
 
 class Variant;
 
-class Plane {
+class _NO_DISCARD_ Plane {
 public:
 	Vector3 normal;
 	real_t d = 0;

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -36,7 +36,7 @@
 #include "core/math/vector3.h"
 #include "core/string/ustring.h"
 
-class Quaternion {
+class _NO_DISCARD_ Quaternion {
 public:
 	union {
 		struct {

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -35,7 +35,7 @@
 
 struct Transform2D;
 
-struct Rect2 {
+struct _NO_DISCARD_ Rect2 {
 	Point2 position;
 	Size2 size;
 
@@ -363,7 +363,7 @@ struct Rect2 {
 	}
 };
 
-struct Rect2i {
+struct _NO_DISCARD_ Rect2i {
 	Point2i position;
 	Size2i size;
 

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -33,7 +33,7 @@
 
 #include "core/math/rect2.h" // also includes vector2, math_funcs, and ustring
 
-struct Transform2D {
+struct _NO_DISCARD_ Transform2D {
 	// Warning #1: basis of Transform2D is stored differently from Basis. In terms of elements array, the basis matrix looks like "on paper":
 	// M = (elements[0][0] elements[1][0])
 	//     (elements[0][1] elements[1][1])

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -35,7 +35,7 @@
 #include "core/math/basis.h"
 #include "core/math/plane.h"
 
-class Transform3D {
+class _NO_DISCARD_ Transform3D {
 public:
 	Basis basis;
 	Vector3 origin;

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -36,7 +36,7 @@
 
 struct Vector2i;
 
-struct Vector2 {
+struct _NO_DISCARD_ Vector2 {
 	static const int AXIS_COUNT = 2;
 
 	enum Axis {
@@ -284,7 +284,7 @@ typedef Vector2 Point2;
 
 /* INTEGER STUFF */
 
-struct Vector2i {
+struct _NO_DISCARD_ Vector2i {
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -37,7 +37,7 @@
 #include "core/string/ustring.h"
 class Basis;
 
-struct Vector3 {
+struct _NO_DISCARD_ Vector3 {
 	static const int AXIS_COUNT = 3;
 
 	enum Axis {

--- a/core/math/vector3i.h
+++ b/core/math/vector3i.h
@@ -35,7 +35,7 @@
 #include "core/string/ustring.h"
 #include "core/typedefs.h"
 
-struct Vector3i {
+struct _NO_DISCARD_ Vector3i {
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -71,6 +71,17 @@
 #endif
 #endif
 
+// No discard allows the compiler to flag warnings if we don't use the return value of functions / classes
+#ifndef _NO_DISCARD_
+#define _NO_DISCARD_ [[nodiscard]]
+#endif
+
+// In some cases _NO_DISCARD_ will get false positives,
+// we can prevent the warning in specific cases by preceding the call with a cast.
+#ifndef _ALLOW_DISCARD_
+#define _ALLOW_DISCARD_ (void)
+#endif
+
 // Windows badly defines a lot of stuff we'll never use. Undefine it.
 #ifdef _WIN32
 #undef min // override standard definition

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1776,7 +1776,8 @@ void ResourceImporterScene::_optimize_track_usage(AnimationPlayer *p_player, Ani
 						if (bone_idx == -1) {
 							continue;
 						}
-						skel->get_bone_pose(bone_idx);
+						// Note that this is using get_bone_pose to update the bone pose cache.
+						_ALLOW_DISCARD_ skel->get_bone_pose(bone_idx);
 						loc = skel->get_bone_pose_position(bone_idx);
 						rot = skel->get_bone_pose_rotation(bone_idx);
 						scale = skel->get_bone_pose_scale(bone_idx);

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -316,7 +316,7 @@ static NSCursor *_cursorFromSelector(SEL selector, SEL fallback = nil) {
 		CGPoint lMouseWarpPos = { pointOnScreen.x, CGDisplayBounds(CGMainDisplayID()).size.height - pointOnScreen.y };
 		CGWarpMouseCursorPosition(lMouseWarpPos);
 	} else {
-		_get_mouse_pos(wd, [wd.window_object mouseLocationOutsideOfEventStream]);
+		_ALLOW_DISCARD_ _get_mouse_pos(wd, [wd.window_object mouseLocationOutsideOfEventStream]);
 		Input::get_singleton()->set_mouse_position(wd.mouse_pos);
 	}
 
@@ -1391,7 +1391,7 @@ inline void sendPanEvent(DisplayServer::WindowID window_id, double dx, double dy
 
 	double deltaX, deltaY;
 
-	_get_mouse_pos(wd, [event locationInWindow]);
+	_ALLOW_DISCARD_ _get_mouse_pos(wd, [event locationInWindow]);
 
 	deltaX = [event scrollingDeltaX];
 	deltaY = [event scrollingDeltaY];
@@ -2463,7 +2463,7 @@ void DisplayServerOSX::window_set_position(const Point2i &p_position, WindowID p
 	[wd.window_object setFrameTopLeftPoint:NSMakePoint(position.x - offset.x, position.y - offset.y)];
 
 	_update_window(wd);
-	_get_mouse_pos(wd, [wd.window_object mouseLocationOutsideOfEventStream]);
+	_ALLOW_DISCARD_ _get_mouse_pos(wd, [wd.window_object mouseLocationOutsideOfEventStream]);
 }
 
 void DisplayServerOSX::window_set_max_size(const Size2i p_size, WindowID p_window) {

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1017,8 +1017,8 @@ void CanvasItem::set_notify_transform(bool p_enable) {
 	notify_transform = p_enable;
 
 	if (notify_transform && is_inside_tree()) {
-		//this ensures that invalid globals get resolved, so notifications can be received
-		get_global_transform();
+		// This ensures that invalid globals get resolved, so notifications can be received.
+		_ALLOW_DISCARD_ get_global_transform();
 	}
 }
 

--- a/scene/resources/immediate_mesh.cpp
+++ b/scene/resources/immediate_mesh.cpp
@@ -382,7 +382,7 @@ AABB ImmediateMesh::get_aabb() const {
 		if (i == 0) {
 			aabb = surfaces[i].aabb;
 		} else {
-			aabb.merge(surfaces[i].aabb);
+			aabb = aabb.merge(surfaces[i].aabb);
 		}
 	}
 	return aabb;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -514,7 +514,7 @@ Ref<Image> RendererSceneRenderRD::environment_bake_panorama(RID p_env, bool p_ba
 		ambient_color_sky_mix = env->ambient_sky_contribution;
 		const float ambient_energy = env->ambient_light_energy;
 		ambient_color = env->ambient_light;
-		ambient_color.to_linear();
+		ambient_color = ambient_color.to_linear();
 		ambient_color.r *= ambient_energy;
 		ambient_color.g *= ambient_energy;
 		ambient_color.b *= ambient_energy;
@@ -533,7 +533,7 @@ Ref<Image> RendererSceneRenderRD::environment_bake_panorama(RID p_env, bool p_ba
 	} else {
 		const float bg_energy = env->bg_energy;
 		Color panorama_color = ((environment_background == RS::ENV_BG_CLEAR_COLOR) ? storage->get_default_clear_color() : env->bg_color);
-		panorama_color.to_linear();
+		panorama_color = panorama_color.to_linear();
 		panorama_color.r *= bg_energy;
 		panorama_color.g *= bg_energy;
 		panorama_color.b *= bg_energy;


### PR DESCRIPTION
A common source of errors is to call functions (such as round()) expecting them to work in place, but them actually being designed only to return the processed value. Not using the return value in this case in indicative of a bug, and can be flagged as a warning by using the `[[nodiscard]]` attribute.

There may be rare "false positives" where it reports a warning where you actively _do_ want to ignore the return value. These are easy enough to fix, just use the macro `_ALLOW_DISCARD_` before the function name when you call it. e.g.
```
Vector3 pt;
_ALLOW_DISCARD_ pt.normalized();
```

Also fixes 3 bugs it found:
1) AABBs for `ImmediateMesh` were incorrectly calculated
2) Use of `Color::to_linear()` is not an in place function, wrongly done in `panorama_color`
3) and `ambient_color`.

## Introduction
As a result of a small discussion on twitter:
https://twitter.com/lawnjelly/status/1483789213049004033
A few of us discussed that a common bug in Godot is that many of the functions have slightly confusing names, and return values but _do not_ change the underlying object.

For instance `Vector3::round()` returns a rounded Vector3 but does not round the called object.

Thus:
```
// This is valid
Vector3 test = myvec.round();

// This is a confusing bug
myvec.round();
```
Ideally an alternative would be a name like `rounded()` instead of `round()`, but given that losing backward compatibility is a bit of a potential problem, we wondered if we could instead flag the errors. There is a mechanism already in gdscript but I had a look for solutions in c++.

It turns out after some investigation that there are some extensions in c++17, and in clang and GCC which can catch these errors:

`[[nodiscard]]` - c++17 onwards
`__attribute__((__warn_unused_result__))` - gcc and clang

Although these are normally applied to each function individually, @akien-mga noticed they can be applied to whole classes - whenever the class is returned in a function it will emit the nodiscard warning in this case. This is much less verbose and enables us to catch errors in the main classes, at the cost of some possible false positives.

### False positives
It turns out that when the function returns the class but you do want to ignore it, you can disable the warning in a specific case by using casting, to e.g. a (void). I have done this in the PR for the few cases of false positives.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
