### PR TITLE
Rename web editor root files to `index`

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -343,7 +343,7 @@
 			}
 		}
 	</script>
-	<script src="godot.tools.js"></script>
+	<script src="index.js"></script>
 	<script>//<![CDATA[
 
 		var editor = null;
@@ -638,7 +638,7 @@
 				displayFailureNotice('WebGL not available');
 			} else {
 				setStatusMode('indeterminate');
-				editor.init('godot.tools').then(function() {
+				editor.init('index').then(function() {
 					if (zip) {
 						editor.copyToFS("/tmp/preload.zip", zip);
 					}

--- a/misc/dist/html/manifest.json
+++ b/misc/dist/html/manifest.json
@@ -3,7 +3,7 @@
   "short_name": "Godot",
   "description": "Multi-platform 2D and 3D game engine with a feature-rich editor (Web edition)",
   "lang": "en",
-  "start_url": "./godot.tools.html",
+  "start_url": "./index.html",
   "display": "standalone",
   "orientation": "landscape",
   "theme_color": "#478cbf",

--- a/platform/javascript/emscripten_helpers.py
+++ b/platform/javascript/emscripten_helpers.py
@@ -38,7 +38,7 @@ def create_engine_file(env, target, source, externs):
 
 
 def create_template_zip(env, js, wasm, extra):
-    binary_name = "godot.tools" if env["tools"] else "godot"
+    binary_name = "index" if env["tools"] else "godot"
     zip_dir = env.Dir("#bin/.javascript_zip")
     in_files = [
         js,
@@ -63,15 +63,15 @@ def create_template_zip(env, js, wasm, extra):
         # HTML
         html = "#misc/dist/html/editor.html"
         cache = [
-            "godot.tools.html",
+            "index.html",
             "offline.html",
-            "godot.tools.js",
-            "godot.tools.worker.js",
-            "godot.tools.audio.worklet.js",
+            "index.js",
+            "index.worker.js",
+            "index.audio.worklet.js",
             "logo.svg",
             "favicon.png",
         ]
-        opt_cache = ["godot.tools.wasm"]
+        opt_cache = ["index.wasm"]
         subst_dict = {
             "@GODOT_VERSION@": get_build_version(),
             "@GODOT_NAME@": "GodotEngine",


### PR DESCRIPTION
Can be merged independently of https://github.com/godotengine/godot/pull/56977.

Most web servers serve `index.html` by default without requiring any specific configuration. Local web server testing is therefore sped up since you don't have to browse to `godot.tools.html` manually anymore.