### PR TITLE
Fix export_enum does not work with String variable.

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -120,25 +120,25 @@ GDScriptParser::GDScriptParser() {
 	register_annotation(MethodInfo("@icon", PropertyInfo(Variant::STRING, "icon_path")), AnnotationInfo::SCRIPT, &GDScriptParser::icon_annotation);
 	register_annotation(MethodInfo("@onready"), AnnotationInfo::VARIABLE, &GDScriptParser::onready_annotation);
 	// Export annotations.
-	register_annotation(MethodInfo("@export"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_NONE, Variant::NIL>);
-	register_annotation(MethodInfo("@export_enum", PropertyInfo(Variant::STRING, "names")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_ENUM, Variant::INT>, varray(), true);
-	register_annotation(MethodInfo("@export_file", PropertyInfo(Variant::STRING, "filter")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_FILE, Variant::STRING>, varray(""), true);
-	register_annotation(MethodInfo("@export_dir"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_DIR, Variant::STRING>);
-	register_annotation(MethodInfo("@export_global_file", PropertyInfo(Variant::STRING, "filter")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_GLOBAL_FILE, Variant::STRING>, varray(""), true);
-	register_annotation(MethodInfo("@export_global_dir"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_GLOBAL_DIR, Variant::STRING>);
-	register_annotation(MethodInfo("@export_multiline"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_MULTILINE_TEXT, Variant::STRING>);
-	register_annotation(MethodInfo("@export_placeholder"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_PLACEHOLDER_TEXT, Variant::STRING>);
-	register_annotation(MethodInfo("@export_range", PropertyInfo(Variant::FLOAT, "min"), PropertyInfo(Variant::FLOAT, "max"), PropertyInfo(Variant::FLOAT, "step"), PropertyInfo(Variant::STRING, "extra_hints")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_RANGE, Variant::FLOAT>, varray(1.0, ""), true);
-	register_annotation(MethodInfo("@export_exp_easing", PropertyInfo(Variant::STRING, "hints")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_EXP_EASING, Variant::FLOAT>, varray(""), true);
-	register_annotation(MethodInfo("@export_color_no_alpha"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_COLOR_NO_ALPHA, Variant::COLOR>);
-	register_annotation(MethodInfo("@export_node_path", PropertyInfo(Variant::STRING, "type")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_NODE_PATH_VALID_TYPES, Variant::NODE_PATH>, varray(""), true);
-	register_annotation(MethodInfo("@export_flags", PropertyInfo(Variant::STRING, "names")), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_FLAGS, Variant::INT>, varray(), true);
-	register_annotation(MethodInfo("@export_flags_2d_render"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_LAYERS_2D_RENDER, Variant::INT>);
-	register_annotation(MethodInfo("@export_flags_2d_physics"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_LAYERS_2D_PHYSICS, Variant::INT>);
-	register_annotation(MethodInfo("@export_flags_2d_navigation"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_LAYERS_2D_NAVIGATION, Variant::INT>);
-	register_annotation(MethodInfo("@export_flags_3d_render"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_LAYERS_3D_RENDER, Variant::INT>);
-	register_annotation(MethodInfo("@export_flags_3d_physics"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_LAYERS_3D_PHYSICS, Variant::INT>);
-	register_annotation(MethodInfo("@export_flags_3d_navigation"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotations<PROPERTY_HINT_LAYERS_3D_NAVIGATION, Variant::INT>);
+	register_annotation(MethodInfo("@export"), AnnotationInfo::VARIABLE, &GDScriptParser::export_annotation);
+	register_annotation(MethodInfo("@export_enum", PropertyInfo(Variant::STRING, "names")), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_ENUM, Variant::INT, Variant::FLOAT, Variant::STRING>, varray(), true);
+	register_annotation(MethodInfo("@export_file", PropertyInfo(Variant::STRING, "filter")), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_FILE, Variant::STRING>, varray(""), true);
+	register_annotation(MethodInfo("@export_dir"), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_DIR, Variant::STRING>);
+	register_annotation(MethodInfo("@export_global_file", PropertyInfo(Variant::STRING, "filter")), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_GLOBAL_FILE, Variant::STRING>, varray(""), true);
+	register_annotation(MethodInfo("@export_global_dir"), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_GLOBAL_DIR, Variant::STRING>);
+	register_annotation(MethodInfo("@export_multiline"), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_MULTILINE_TEXT, Variant::STRING>);
+	register_annotation(MethodInfo("@export_placeholder"), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_PLACEHOLDER_TEXT, Variant::STRING>);
+	register_annotation(MethodInfo("@export_range", PropertyInfo(Variant::FLOAT, "min"), PropertyInfo(Variant::FLOAT, "max"), PropertyInfo(Variant::FLOAT, "step"), PropertyInfo(Variant::STRING, "extra_hints")), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_RANGE, Variant::FLOAT, Variant::INT>, varray(1.0, ""), true);
+	register_annotation(MethodInfo("@export_exp_easing", PropertyInfo(Variant::STRING, "hints")), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_EXP_EASING, Variant::FLOAT, Variant::INT>, varray(""), true);
+	register_annotation(MethodInfo("@export_color_no_alpha"), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_COLOR_NO_ALPHA, Variant::COLOR>);
+	register_annotation(MethodInfo("@export_node_path", PropertyInfo(Variant::STRING, "type")), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_NODE_PATH_VALID_TYPES, Variant::NODE_PATH>, varray(""), true);
+	register_annotation(MethodInfo("@export_flags", PropertyInfo(Variant::STRING, "names")), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_FLAGS, Variant::INT, Variant::FLOAT>, varray(), true);
+	register_annotation(MethodInfo("@export_flags_2d_render"), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_LAYERS_2D_RENDER, Variant::INT, Variant::FLOAT>);
+	register_annotation(MethodInfo("@export_flags_2d_physics"), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_LAYERS_2D_PHYSICS, Variant::INT, Variant::FLOAT>);
+	register_annotation(MethodInfo("@export_flags_2d_navigation"), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_LAYERS_2D_NAVIGATION, Variant::INT, Variant::FLOAT>);
+	register_annotation(MethodInfo("@export_flags_3d_render"), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_LAYERS_3D_RENDER, Variant::INT, Variant::FLOAT>);
+	register_annotation(MethodInfo("@export_flags_3d_physics"), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_LAYERS_3D_PHYSICS, Variant::INT, Variant::FLOAT>);
+	register_annotation(MethodInfo("@export_flags_3d_navigation"), AnnotationInfo::VARIABLE, &GDScriptParser::typed_export_annotations<PROPERTY_HINT_LAYERS_3D_NAVIGATION, Variant::INT, Variant::FLOAT>);
 	// Export grouping annotations.
 	register_annotation(MethodInfo("@export_category", PropertyInfo(Variant::STRING, "name")), AnnotationInfo::STANDALONE, &GDScriptParser::export_group_annotations<PROPERTY_USAGE_CATEGORY>);
 	register_annotation(MethodInfo("@export_group", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::STRING, "prefix")), AnnotationInfo::STANDALONE, &GDScriptParser::export_group_annotations<PROPERTY_USAGE_GROUP>, varray(""));
@@ -3694,8 +3694,102 @@ bool GDScriptParser::onready_annotation(const AnnotationNode *p_annotation, Node
 	return true;
 }
 
-template <PropertyHint t_hint, Variant::Type t_type>
-bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node *p_node) {
+bool GDScriptParser::export_annotation(const AnnotationNode *p_annotation, Node *p_node) {
+	ERR_FAIL_COND_V_MSG(p_node->type != Node::VARIABLE, false, vformat(R"("%s" annotation can only be applied to variables.)", p_annotation->name));
+
+	VariableNode *variable = static_cast<VariableNode *>(p_node);
+	if (variable->exported) {
+		push_error(vformat(R"(Annotation "%s" cannot be used with another "@export" annotation.)", p_annotation->name), p_annotation);
+		return false;
+	}
+
+	variable->exported = true;
+
+	variable->export_info.type = Variant::NIL;
+	variable->export_info.hint = PROPERTY_HINT_NONE;
+	variable->export_info.hint_string = "";
+
+	// This is called after the analyzer is done finding the type, so this should be set here.
+	DataType export_type = variable->get_datatype();
+
+	if (variable->datatype_specifier == nullptr && variable->initializer == nullptr) {
+		push_error(R"(Cannot use simple "@export" annotation with variable without type or initializer, since type can't be inferred.)", p_annotation);
+		return false;
+	}
+
+	bool is_array = false;
+
+	if (export_type.builtin_type == Variant::ARRAY && export_type.has_container_element_type()) {
+		export_type = export_type.get_container_element_type(); // Use inner type for.
+		is_array = true;
+	}
+
+	if (export_type.is_variant() || export_type.has_no_type()) {
+		push_error(R"(Cannot use simple "@export" annotation because the type of the initialized value can't be inferred.)", p_annotation);
+		return false;
+	}
+
+	switch (export_type.kind) {
+		case GDScriptParser::DataType::BUILTIN:
+			variable->export_info.type = export_type.builtin_type;
+			variable->export_info.hint = PROPERTY_HINT_NONE;
+			variable->export_info.hint_string = Variant::get_type_name(export_type.builtin_type);
+			break;
+		case GDScriptParser::DataType::NATIVE:
+			if (ClassDB::is_parent_class(export_type.native_type, SNAME("Resource"))) {
+				variable->export_info.type = Variant::OBJECT;
+				variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
+				variable->export_info.hint_string = export_type.native_type;
+			} else if (ClassDB::is_parent_class(export_type.native_type, SNAME("Node"))) {
+				variable->export_info.type = Variant::OBJECT;
+				variable->export_info.hint = PROPERTY_HINT_NODE_TYPE;
+				variable->export_info.hint_string = export_type.native_type;
+			} else {
+				push_error(R"(Export type can only be built-in, a resource, a node, or an enum.)", variable);
+				return false;
+			}
+			break;
+		case GDScriptParser::DataType::ENUM: {
+			variable->export_info.type = Variant::INT;
+			variable->export_info.hint = PROPERTY_HINT_ENUM;
+
+			String enum_hint_string;
+			bool first = true;
+			for (const KeyValue<StringName, int> &E : export_type.enum_values) {
+				if (!first) {
+					enum_hint_string += ",";
+				} else {
+					first = false;
+				}
+				enum_hint_string += E.key.operator String().capitalize().xml_escape();
+				enum_hint_string += ":";
+				enum_hint_string += String::num_int64(E.value).xml_escape();
+			}
+
+			variable->export_info.hint_string = enum_hint_string;
+		} break;
+		default:
+			// TODO: Allow custom user resources.
+			push_error(R"(Export type can only be built-in, a resource, or an enum.)", variable);
+			break;
+	}
+
+	if (is_array) {
+		String hint_prefix = itos(variable->export_info.type);
+		if (variable->export_info.hint) {
+			hint_prefix += "/" + itos(variable->export_info.hint);
+		}
+		variable->export_info.hint = PROPERTY_HINT_TYPE_STRING;
+		variable->export_info.hint_string = hint_prefix + ":" + variable->export_info.hint_string;
+		variable->export_info.type = Variant::ARRAY;
+	}
+
+	return true;
+}
+
+// t_type is the expected type, t_convertable_type or t_alternative_type also works, the latter would also be set as export_info.type
+template <PropertyHint t_hint, Variant::Type t_type, Variant::Type t_convertable_type, Variant::Type t_alternative_type>
+bool GDScriptParser::typed_export_annotations(const AnnotationNode *p_annotation, Node *p_node) {
 	ERR_FAIL_COND_V_MSG(p_node->type != Node::VARIABLE, false, vformat(R"("%s" annotation can only be applied to variables.)", p_annotation->name));
 
 	{
@@ -3731,86 +3825,20 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 	// This is called after the analyzer is done finding the type, so this should be set here.
 	DataType export_type = variable->get_datatype();
 
-	if (p_annotation->name == SNAME("@export")) {
-		if (variable->datatype_specifier == nullptr && variable->initializer == nullptr) {
-			push_error(R"(Cannot use simple "@export" annotation with variable without type or initializer, since type can't be inferred.)", p_annotation);
+	// Validate variable type with export.
+	if (!export_type.is_variant() && (export_type.kind != DataType::BUILTIN || export_type.builtin_type != t_type)) {
+		// Check for alternative or convertable types:
+		if (export_type.builtin_type == t_alternative_type) {
+			variable->export_info.type = t_alternative_type;
+		} else if (export_type.builtin_type == t_convertable_type) {
+			// convertable type (usually int <-> float) is ok
+		} else {
+			String alternative = t_alternative_type == Variant::VARIANT_MAX ? "" : vformat(R"( or "%s")", Variant::get_type_name(t_alternative_type));
+			String convertable = t_convertable_type == Variant::VARIANT_MAX ? "" : vformat(R"( or "%s")", Variant::get_type_name(t_convertable_type));
+			push_error(vformat(R"("%s" annotation requires a variable of type "%s"%s%s but type "%s" was given instead.)",
+							   p_annotation->name.operator String(), Variant::get_type_name(t_type), alternative, convertable, export_type.to_string()),
+					variable);
 			return false;
-		}
-
-		bool is_array = false;
-
-		if (export_type.builtin_type == Variant::ARRAY && export_type.has_container_element_type()) {
-			export_type = export_type.get_container_element_type(); // Use inner type for.
-			is_array = true;
-		}
-
-		if (export_type.is_variant() || export_type.has_no_type()) {
-			push_error(R"(Cannot use simple "@export" annotation because the type of the initialized value can't be inferred.)", p_annotation);
-			return false;
-		}
-
-		switch (export_type.kind) {
-			case GDScriptParser::DataType::BUILTIN:
-				variable->export_info.type = export_type.builtin_type;
-				variable->export_info.hint = PROPERTY_HINT_NONE;
-				variable->export_info.hint_string = Variant::get_type_name(export_type.builtin_type);
-				break;
-			case GDScriptParser::DataType::NATIVE:
-				if (ClassDB::is_parent_class(export_type.native_type, SNAME("Resource"))) {
-					variable->export_info.type = Variant::OBJECT;
-					variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
-					variable->export_info.hint_string = export_type.native_type;
-				} else if (ClassDB::is_parent_class(export_type.native_type, SNAME("Node"))) {
-					variable->export_info.type = Variant::OBJECT;
-					variable->export_info.hint = PROPERTY_HINT_NODE_TYPE;
-					variable->export_info.hint_string = export_type.native_type;
-				} else {
-					push_error(R"(Export type can only be built-in, a resource, a node, or an enum.)", variable);
-					return false;
-				}
-				break;
-			case GDScriptParser::DataType::ENUM: {
-				variable->export_info.type = Variant::INT;
-				variable->export_info.hint = PROPERTY_HINT_ENUM;
-
-				String enum_hint_string;
-				bool first = true;
-				for (const KeyValue<StringName, int> &E : export_type.enum_values) {
-					if (!first) {
-						enum_hint_string += ",";
-					} else {
-						first = false;
-					}
-					enum_hint_string += E.key.operator String().capitalize().xml_escape();
-					enum_hint_string += ":";
-					enum_hint_string += String::num_int64(E.value).xml_escape();
-				}
-
-				variable->export_info.hint_string = enum_hint_string;
-			} break;
-			default:
-				// TODO: Allow custom user resources.
-				push_error(R"(Export type can only be built-in, a resource, or an enum.)", variable);
-				break;
-		}
-
-		if (is_array) {
-			String hint_prefix = itos(variable->export_info.type);
-			if (variable->export_info.hint) {
-				hint_prefix += "/" + itos(variable->export_info.hint);
-			}
-			variable->export_info.hint = PROPERTY_HINT_TYPE_STRING;
-			variable->export_info.hint_string = hint_prefix + ":" + variable->export_info.hint_string;
-			variable->export_info.type = Variant::ARRAY;
-		}
-	} else {
-		// Validate variable type with export.
-		if (!export_type.is_variant() && (export_type.kind != DataType::BUILTIN || export_type.builtin_type != t_type)) {
-			// Allow float/int conversion.
-			if ((t_type != Variant::FLOAT || export_type.builtin_type != Variant::INT) && (t_type != Variant::INT || export_type.builtin_type != Variant::FLOAT)) {
-				push_error(vformat(R"("%s" annotation requires a variable of type "%s" but type "%s" was given instead.)", p_annotation->name.operator String(), Variant::get_type_name(t_type), export_type.to_string()), variable);
-				return false;
-			}
 		}
 	}
 

--- a/modules/gdscript/gdscript_parser.h
+++ b/modules/gdscript/gdscript_parser.h
@@ -1365,8 +1365,9 @@ private:
 	bool tool_annotation(const AnnotationNode *p_annotation, Node *p_target);
 	bool icon_annotation(const AnnotationNode *p_annotation, Node *p_target);
 	bool onready_annotation(const AnnotationNode *p_annotation, Node *p_target);
-	template <PropertyHint t_hint, Variant::Type t_type>
-	bool export_annotations(const AnnotationNode *p_annotation, Node *p_target);
+	bool export_annotation(const AnnotationNode *p_annotation, Node *p_target);
+	template <PropertyHint t_hint, Variant::Type t_type, Variant::Type t_convertable_type = Variant::VARIANT_MAX, Variant::Type t_alternative_type = Variant::VARIANT_MAX>
+	bool typed_export_annotations(const AnnotationNode *p_annotation, Node *p_target);
 	template <PropertyUsageFlags t_usage>
 	bool export_group_annotations(const AnnotationNode *p_annotation, Node *p_target);
 	bool warning_annotations(const AnnotationNode *p_annotation, Node *p_target);


### PR DESCRIPTION
Fixes #54828, should accept what is mentioned in the documentation now.

Splits export_annotations into export_annotation (for @export and without template parameters) and typed_export_annotations (for @export_xxx). The latter adds two more template parameters to accept more than the expected variable type: either one that can be converted (like float for int), or one that replaces the default one (like String for int when using export_enum).

The two new template parameters have defaults, so they do not need to be provided. And maybe they should really be lists of types, so there can be several convertable and alternative types not just one? E.g. export_enum could also accept StringName I think? And maybe allowing float instead of int is not always wanted for all export_xxx that accept int?

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
