### PR TITLE
Fix Shape2D ignoring collision outline project setting

### DIFF
--- a/scene/resources/shape_2d.cpp
+++ b/scene/resources/shape_2d.cpp
@@ -112,7 +112,7 @@ void Shape2D::_bind_methods() {
 bool Shape2D::is_collision_outline_enabled() {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
-		return true;
+		return ProjectSettings::get_singleton()->get("debug/shapes/collision/draw_2d_outlines");
 	}
 #endif
 	return GLOBAL_DEF("debug/shapes/collision/draw_2d_outlines", true);


### PR DESCRIPTION
Shape2D does not honor the project setting to disable collision outlines while in the editor, however it does while in game. I assume it's just an oversight. Mentioned in #56320
Closes #56986