### PR TITLE
Make Scene dock menu button an actual `MenuButton`

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2809,15 +2809,9 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 	menu->popup();
 }
 
-void SceneTreeDock::_open_tree_menu() {
-	menu->clear();
-
-	menu->add_check_item(TTR("Auto Expand to Selected"), TOOL_AUTO_EXPAND);
-	menu->set_item_checked(menu->get_item_idx_from_text(TTR("Auto Expand to Selected")), EditorSettings::get_singleton()->get("docks/scene_tree/auto_expand_to_selected"));
-
-	menu->reset_size();
-	menu->set_position(get_screen_position() + get_local_mouse_position());
-	menu->popup();
+void SceneTreeDock::_update_tree_menu() {
+	PopupMenu *tree_menu = button_tree_menu->get_popup();
+	tree_menu->set_item_checked(tree_menu->get_item_idx_from_text(TTR("Auto Expand to Selected")), EditorSettings::get_singleton()->get("docks/scene_tree/auto_expand_to_selected"));
 }
 
 void SceneTreeDock::_filter_changed(const String &p_filter) {
@@ -3370,10 +3364,14 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	filter_hbc->add_child(button_detach_script);
 	button_detach_script->hide();
 
-	button_tree_menu = memnew(Button);
+	button_tree_menu = memnew(MenuButton);
 	button_tree_menu->set_flat(true);
-	button_tree_menu->connect("pressed", callable_mp(this, &SceneTreeDock::_open_tree_menu));
+	button_tree_menu->connect("about_to_popup", callable_mp(this, &SceneTreeDock::_update_tree_menu));
 	filter_hbc->add_child(button_tree_menu);
+
+	PopupMenu *tree_menu = button_tree_menu->get_popup();
+	tree_menu->add_check_item(TTR("Auto Expand to Selected"), TOOL_AUTO_EXPAND);
+	tree_menu->connect("id_pressed", callable_mp(this, &SceneTreeDock::_tool_selected), make_binds(false));
 
 	button_hb = memnew(HBoxContainer);
 	vbc->add_child(button_hb);

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -117,7 +117,7 @@ class SceneTreeDock : public VBoxContainer {
 	Button *button_instance;
 	Button *button_create_script;
 	Button *button_detach_script;
-	Button *button_tree_menu;
+	MenuButton *button_tree_menu;
 
 	Button *button_2d;
 	Button *button_3d;
@@ -242,7 +242,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _quick_open();
 
 	void _tree_rmb(const Vector2 &p_menu_pos);
-	void _open_tree_menu();
+	void _update_tree_menu();
 
 	void _filter_changed(const String &p_filter);
 


### PR DESCRIPTION
Before the button borrowed the right-click menu to use it for itself, that appeared where the mouse was instead for right below it. This PR turns it into an actual `MenuButton` with a menu of its own.