### PR TITLE
Fix dialog opening from visual shader context menu

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4159,7 +4159,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	popup_menu->add_item(TTR("Delete"), NodeMenuOptions::DELETE);
 	popup_menu->add_item(TTR("Duplicate"), NodeMenuOptions::DUPLICATE);
 	popup_menu->add_item(TTR("Clear Copy Buffer"), NodeMenuOptions::CLEAR_COPY_BUFFER);
-	popup_menu->connect("id_pressed", callable_mp(this, &VisualShaderEditor::_node_menu_id_pressed));
+	popup_menu->connect("id_pressed", callable_mp(this, &VisualShaderEditor::_node_menu_id_pressed), varray(), CONNECT_DEFERRED);
 
 	///////////////////////////////////////
 	// SHADER NODES TREE


### PR DESCRIPTION
Without this it would close immediately:

![vs_fix](https://user-images.githubusercontent.com/3036176/150337668-f82ca262-9931-46f1-a20a-e8f804b91bfc.gif)

probably a regression from one of the recent @bruvzg commits - popup dialog opened from menu dialog would close immediately if the signal does not connect deferred (I think because mouse click event passes to it).
