### PR TITLE
[3.x] Add `[[nodiscard]]` to core math classes to catch c++ errors.

### DIFF
--- a/core/color.h
+++ b/core/color.h
@@ -34,7 +34,7 @@
 #include "core/math/math_funcs.h"
 #include "core/ustring.h"
 
-struct Color {
+struct _NO_DISCARD_CLASS_ Color {
 	union {
 		struct {
 			float r;

--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -40,7 +40,7 @@
  * This is implemented by a point (position) and the box size
  */
 
-class AABB {
+class _NO_DISCARD_CLASS_ AABB {
 public:
 	Vector3 position;
 	Vector3 size;

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -34,7 +34,7 @@
 #include "core/math/quat.h"
 #include "core/math/vector3.h"
 
-class Basis {
+class _NO_DISCARD_CLASS_ Basis {
 public:
 	Vector3 elements[3] = {
 		Vector3(1, 0, 0),

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -36,7 +36,7 @@
 #include "core/math/transform.h"
 #include "core/math/vector3.h"
 
-class Face3 {
+class _NO_DISCARD_CLASS_ Face3 {
 public:
 	enum Side {
 		SIDE_OVER,

--- a/core/math/plane.h
+++ b/core/math/plane.h
@@ -33,7 +33,7 @@
 
 #include "core/math/vector3.h"
 
-class Plane {
+class _NO_DISCARD_CLASS_ Plane {
 public:
 	Vector3 normal;
 	real_t d;

--- a/core/math/quat.h
+++ b/core/math/quat.h
@@ -36,7 +36,7 @@
 #include "core/math/vector3.h"
 #include "core/ustring.h"
 
-class Quat {
+class _NO_DISCARD_CLASS_ Quat {
 public:
 	real_t x, y, z, w;
 
@@ -127,7 +127,7 @@ public:
 			w(p_q.w) {
 	}
 
-	Quat operator=(const Quat &p_q) {
+	Quat &operator=(const Quat &p_q) {
 		x = p_q.x;
 		y = p_q.y;
 		z = p_q.z;

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -35,7 +35,7 @@
 
 struct Transform2D;
 
-struct Rect2 {
+struct _NO_DISCARD_CLASS_ Rect2 {
 	Point2 position;
 	Size2 size;
 
@@ -259,7 +259,7 @@ struct Rect2 {
 	}
 };
 
-struct Rect2i {
+struct _NO_DISCARD_CLASS_ Rect2i {
 	Point2i position;
 	Size2i size;
 

--- a/core/math/transform.h
+++ b/core/math/transform.h
@@ -36,7 +36,7 @@
 #include "core/math/plane.h"
 #include "core/pool_vector.h"
 
-class Transform {
+class _NO_DISCARD_CLASS_ Transform {
 public:
 	Basis basis;
 	Vector3 origin;

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -34,7 +34,7 @@
 #include "core/math/rect2.h" // also includes vector2, math_funcs, and ustring
 #include "core/pool_vector.h"
 
-struct Transform2D {
+struct _NO_DISCARD_CLASS_ Transform2D {
 	// Warning #1: basis of Transform2D is stored differently from Basis. In terms of elements array, the basis matrix looks like "on paper":
 	// M = (elements[0][0] elements[1][0])
 	//     (elements[0][1] elements[1][1])

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -36,7 +36,7 @@
 
 struct Vector2i;
 
-struct Vector2 {
+struct _NO_DISCARD_CLASS_ Vector2 {
 	static const int AXIS_COUNT = 2;
 
 	enum Axis {
@@ -269,7 +269,7 @@ typedef Vector2 Point2;
 
 /* INTEGER STUFF */
 
-struct Vector2i {
+struct _NO_DISCARD_CLASS_ Vector2i {
 	enum Axis {
 		AXIS_X,
 		AXIS_Y,

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -36,7 +36,7 @@
 
 class Basis;
 
-struct Vector3 {
+struct _NO_DISCARD_CLASS_ Vector3 {
 	static const int AXIS_COUNT = 3;
 
 	enum Axis {

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -69,6 +69,47 @@
 
 #endif
 
+// No discard allows the compiler to flag warnings if we don't use the return value of functions / classes
+#ifndef _NO_DISCARD_
+// c++ 17 onwards
+#if __cplusplus >= 201703L
+#define _NO_DISCARD_ [[nodiscard]]
+#else
+// __warn_unused_result__ supported on clang and GCC
+#if (defined(__clang__) || defined(__GNUC__)) && defined(__has_attribute)
+#if __has_attribute(__warn_unused_result__)
+#define _NO_DISCARD_ __attribute__((__warn_unused_result__))
+#endif
+#endif
+
+// Visual Studio 2012 onwards
+#if _MSC_VER >= 1700
+#define _NO_DISCARD_ _Check_return_
+#endif
+
+// If nothing supported, just noop the macro
+#ifndef _NO_DISCARD_
+#define _NO_DISCARD_
+#endif
+#endif // not c++ 17
+#endif // not defined _NO_DISCARD_
+
+// In some cases _NO_DISCARD_ will get false positives,
+// we can prevent the warning in specific cases by preceding the call with a cast.
+#ifndef _ALLOW_DISCARD_
+#define _ALLOW_DISCARD_ (void)
+#endif
+
+// GCC (prior to c++ 17) Does not seem to support no discard with classes, only functions.
+// So we will use a specific macro for classes.
+#ifndef _NO_DISCARD_CLASS_
+#if (defined(__clang__) || defined(_MSC_VER))
+#define _NO_DISCARD_CLASS_ _NO_DISCARD_
+#else
+#define _NO_DISCARD_CLASS_
+#endif
+#endif
+
 //custom, gcc-safe offsetof, because gcc complains a lot.
 template <class T>
 T *_nullptr() {

--- a/modules/bullet/cone_twist_joint_bullet.cpp
+++ b/modules/bullet/cone_twist_joint_bullet.cpp
@@ -43,14 +43,14 @@
 ConeTwistJointBullet::ConeTwistJointBullet(RigidBodyBullet *rbA, RigidBodyBullet *rbB, const Transform &rbAFrame, const Transform &rbBFrame) :
 		JointBullet() {
 	Transform scaled_AFrame(rbAFrame.scaled(rbA->get_body_scale()));
-	scaled_AFrame.basis.rotref_posscale_decomposition(scaled_AFrame.basis);
+	_ALLOW_DISCARD_ scaled_AFrame.basis.rotref_posscale_decomposition(scaled_AFrame.basis);
 
 	btTransform btFrameA;
 	G_TO_B(scaled_AFrame, btFrameA);
 
 	if (rbB) {
 		Transform scaled_BFrame(rbBFrame.scaled(rbB->get_body_scale()));
-		scaled_BFrame.basis.rotref_posscale_decomposition(scaled_BFrame.basis);
+		_ALLOW_DISCARD_ scaled_BFrame.basis.rotref_posscale_decomposition(scaled_BFrame.basis);
 
 		btTransform btFrameB;
 		G_TO_B(scaled_BFrame, btFrameB);

--- a/modules/bullet/generic_6dof_joint_bullet.cpp
+++ b/modules/bullet/generic_6dof_joint_bullet.cpp
@@ -44,7 +44,7 @@ Generic6DOFJointBullet::Generic6DOFJointBullet(RigidBodyBullet *rbA, RigidBodyBu
 		JointBullet() {
 	Transform scaled_AFrame(frameInA.scaled(rbA->get_body_scale()));
 
-	scaled_AFrame.basis.rotref_posscale_decomposition(scaled_AFrame.basis);
+	_ALLOW_DISCARD_ scaled_AFrame.basis.rotref_posscale_decomposition(scaled_AFrame.basis);
 
 	btTransform btFrameA;
 	G_TO_B(scaled_AFrame, btFrameA);
@@ -52,7 +52,7 @@ Generic6DOFJointBullet::Generic6DOFJointBullet(RigidBodyBullet *rbA, RigidBodyBu
 	if (rbB) {
 		Transform scaled_BFrame(frameInB.scaled(rbB->get_body_scale()));
 
-		scaled_BFrame.basis.rotref_posscale_decomposition(scaled_BFrame.basis);
+		_ALLOW_DISCARD_ scaled_BFrame.basis.rotref_posscale_decomposition(scaled_BFrame.basis);
 
 		btTransform btFrameB;
 		G_TO_B(scaled_BFrame, btFrameB);

--- a/modules/bullet/hinge_joint_bullet.cpp
+++ b/modules/bullet/hinge_joint_bullet.cpp
@@ -43,14 +43,14 @@
 HingeJointBullet::HingeJointBullet(RigidBodyBullet *rbA, RigidBodyBullet *rbB, const Transform &frameA, const Transform &frameB) :
 		JointBullet() {
 	Transform scaled_AFrame(frameA.scaled(rbA->get_body_scale()));
-	scaled_AFrame.basis.rotref_posscale_decomposition(scaled_AFrame.basis);
+	_ALLOW_DISCARD_ scaled_AFrame.basis.rotref_posscale_decomposition(scaled_AFrame.basis);
 
 	btTransform btFrameA;
 	G_TO_B(scaled_AFrame, btFrameA);
 
 	if (rbB) {
 		Transform scaled_BFrame(frameB.scaled(rbB->get_body_scale()));
-		scaled_BFrame.basis.rotref_posscale_decomposition(scaled_BFrame.basis);
+		_ALLOW_DISCARD_ scaled_BFrame.basis.rotref_posscale_decomposition(scaled_BFrame.basis);
 
 		btTransform btFrameB;
 		G_TO_B(scaled_BFrame, btFrameB);

--- a/modules/bullet/slider_joint_bullet.cpp
+++ b/modules/bullet/slider_joint_bullet.cpp
@@ -43,14 +43,14 @@
 SliderJointBullet::SliderJointBullet(RigidBodyBullet *rbA, RigidBodyBullet *rbB, const Transform &frameInA, const Transform &frameInB) :
 		JointBullet() {
 	Transform scaled_AFrame(frameInA.scaled(rbA->get_body_scale()));
-	scaled_AFrame.basis.rotref_posscale_decomposition(scaled_AFrame.basis);
+	_ALLOW_DISCARD_ scaled_AFrame.basis.rotref_posscale_decomposition(scaled_AFrame.basis);
 
 	btTransform btFrameA;
 	G_TO_B(scaled_AFrame, btFrameA);
 
 	if (rbB) {
 		Transform scaled_BFrame(frameInB.scaled(rbB->get_body_scale()));
-		scaled_BFrame.basis.rotref_posscale_decomposition(scaled_BFrame.basis);
+		_ALLOW_DISCARD_ scaled_BFrame.basis.rotref_posscale_decomposition(scaled_BFrame.basis);
 
 		btTransform btFrameB;
 		G_TO_B(scaled_BFrame, btFrameB);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -426,7 +426,7 @@ static NSCursor *cursorFromSelector(SEL selector, SEL fallback = nil) {
 
 - (void)windowDidBecomeKey:(NSNotification *)notification {
 	if (OS_OSX::singleton->get_main_loop()) {
-		get_mouse_pos([OS_OSX::singleton->window_object mouseLocationOutsideOfEventStream]);
+		_ALLOW_DISCARD_ get_mouse_pos([OS_OSX::singleton->window_object mouseLocationOutsideOfEventStream]);
 		OS_OSX::singleton->input->set_mouse_position(Point2(mouse_x, mouse_y));
 
 		OS_OSX::singleton->get_main_loop()->notification(MainLoop::NOTIFICATION_WM_FOCUS_IN);
@@ -1370,7 +1370,7 @@ inline void sendPanEvent(double dx, double dy, int modifierFlags) {
 - (void)scrollWheel:(NSEvent *)event {
 	double deltaX, deltaY;
 
-	get_mouse_pos([event locationInWindow]);
+	_ALLOW_DISCARD_ get_mouse_pos([event locationInWindow]);
 
 	deltaX = [event scrollingDeltaX];
 	deltaY = [event scrollingDeltaY];
@@ -2167,7 +2167,7 @@ void OS_OSX::warp_mouse_position(const Point2 &p_to) {
 }
 
 void OS_OSX::update_real_mouse_position() {
-	get_mouse_pos([window_object mouseLocationOutsideOfEventStream]);
+	_ALLOW_DISCARD_ get_mouse_pos([window_object mouseLocationOutsideOfEventStream]);
 	input->set_mouse_position(Point2(mouse_x, mouse_y));
 }
 

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -1247,7 +1247,7 @@ void CanvasItem::set_notify_transform(bool p_enable) {
 
 	if (notify_transform && is_inside_tree()) {
 		//this ensures that invalid globals get resolved, so notifications can be received
-		get_global_transform();
+		_ALLOW_DISCARD_ get_global_transform();
 	}
 }
 


### PR DESCRIPTION
A common source of errors is to call functions (such as round()) expecting them to work in place, but them actually being designed only to return the processed value. Not using the return value in this case in indicative of a bug, and can be flagged as a warning by using the [[nodiscard]] attribute.

3.x version of #56972

As before there may be some "false positives" where it reports a warning where you actively _do_ want to ignore the return value. These are easy enough to fix, just use the macro `_ALLOW_DISCARD_` before the function name when you call it. e.g.
```
Vector3 pt;
_ALLOW_DISCARD_ pt.normalized();
```
## Some differences from 56972
As Godot 3.x is before c++ 17, we have to use compiler specific extensions rather than `[[nodiscard]]` directly. This causes some small differences:

* Although clang and GCC both support `__warn_unused_result__` attribute, it turns out that the particular usage with a _class_ rather than a _function_ only seems to be supported by clang.
* Microsoft compiler (after 2012) does support their equivalent attribute with classes.
* This means that the warnings are operational in clang and visual studio, but not with GCC.
* This implies that a PR that compiles fine locally on GCC could fail CI. However in practice the cases where `_ALLOW_DISCARD_` are needed seem to be very rare (6 or so in Godot 3 and 4) that it doesn't seem worth worrying unduly about.
An alternative would be to compile a version using c++ 17, but that seems like using a sledgehammer to crack a walnut. But it is an option in future I guess.

Due to the difference in compiler behaviour with the attribute with functions and with classes, this 3.x PR uses a separate macro `_NO_DISCARD_CLASS_` for classes. The `_NO_DISCARD_` macro is still available even in GCC for function calls, just not for classes.

## Quaternion
Interesting - when I tried applying `_NO_DISCARD_CLASS_` to `Quat`, unlike all the other classes, I was getting a bunch of error messages from the `MAKE_PTRARG` macro. On investigation it turned out that the `operator=` overload for `Quat` was non-standard, it was returning by value, instead of by reference.

Old:
```
Quat operator=(const Quat &p_q) {
x = p_q.x;
y = p_q.y;
z = p_q.z;
w = p_q.w;
return *this;
}
```

I had a look in Godot 4.0 to see why that compiled fine, and there the operator is defined:
```
void operator=(const Quaternion &p_q) {
x = p_q.x;
y = p_q.y;
z = p_q.z;
w = p_q.w;
}
```
It turns out the errors could be fixed either by changing the overload to the version used in 4.x, or to the recommended overload for assignment operator:
https://en.cppreference.com/w/cpp/language/operators

```
Quat &operator=(const Quat &p_q) {
x = p_q.x;
y = p_q.y;
z = p_q.z;
w = p_q.w;
return *this;
}
```
So I've gone with the latter as it was closest. I think this came up in a PR meeting recently, I think it is to do with whether you can chain several assignments together in the same expression, so I'm assuming either should be okay, but the old version does seem to be an error.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
