### PR TITLE
Add ViewPanner to 2D editor

### DIFF
--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -128,7 +128,7 @@ class AnimationBezierTrackEdit : public Control {
 	Ref<ViewPanner> panner;
 	void _scroll_callback(Vector2 p_scroll_vec);
 	void _pan_callback(Vector2 p_scroll_vec);
-	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin);
+	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt);
 
 	void _draw_line_clipped(const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, int p_clip_left, int p_clip_right);
 	void _draw_track(int p_track, const Color &p_color);

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1459,7 +1459,7 @@ int AnimationTimelineEdit::get_name_limit() const {
 
 void AnimationTimelineEdit::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		panner->set_control_scheme((ViewPanner::ControlScheme)EDITOR_GET("interface/editors/animation_editors_panning_scheme").operator int());
+		panner->setup((ViewPanner::ControlScheme)EDITOR_GET("interface/editors/animation_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
 	}
 
 	if (p_what == NOTIFICATION_ENTER_TREE) {
@@ -1843,7 +1843,7 @@ void AnimationTimelineEdit::_pan_callback(Vector2 p_scroll_vec) {
 	set_value(get_value() - p_scroll_vec.x / get_zoom_scale());
 }
 
-void AnimationTimelineEdit::_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin) {
+void AnimationTimelineEdit::_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt) {
 	if (p_scroll_vec.y < 0) {
 		get_zoom()->set_value(get_zoom()->get_value() * 1.05);
 	} else {
@@ -1932,8 +1932,6 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 
 	panner.instantiate();
 	panner->set_callbacks(callable_mp(this, &AnimationTimelineEdit::_scroll_callback), callable_mp(this, &AnimationTimelineEdit::_pan_callback), callable_mp(this, &AnimationTimelineEdit::_zoom_callback));
-	panner->set_disable_rmb(true);
-	panner->set_control_scheme(ViewPanner::SCROLL_PANS);
 
 	set_layout_direction(Control::LAYOUT_DIRECTION_LTR);
 }
@@ -4512,7 +4510,7 @@ MenuButton *AnimationTrackEditor::get_edit_menu() {
 
 void AnimationTrackEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		panner->set_control_scheme((ViewPanner::ControlScheme)EDITOR_GET("interface/editors/animation_editors_panning_scheme").operator int());
+		panner->setup((ViewPanner::ControlScheme)EDITOR_GET("interface/editors/animation_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
 	}
 
 	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
@@ -5315,7 +5313,7 @@ void AnimationTrackEditor::_pan_callback(Vector2 p_scroll_vec) {
 	scroll->set_v_scroll(scroll->get_v_scroll() - p_scroll_vec.y);
 }
 
-void AnimationTrackEditor::_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin) {
+void AnimationTrackEditor::_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt) {
 	if (p_scroll_vec.y < 0) {
 		timeline->get_zoom()->set_value(timeline->get_zoom()->get_value() * 1.05);
 	} else {
@@ -6111,8 +6109,6 @@ AnimationTrackEditor::AnimationTrackEditor() {
 
 	panner.instantiate();
 	panner->set_callbacks(callable_mp(this, &AnimationTrackEditor::_scroll_callback), callable_mp(this, &AnimationTrackEditor::_pan_callback), callable_mp(this, &AnimationTrackEditor::_zoom_callback));
-	panner->set_disable_rmb(true);
-	panner->set_control_scheme(ViewPanner::SCROLL_PANS);
 
 	scroll = memnew(ScrollContainer);
 	timeline_vbox->add_child(scroll);
@@ -6120,7 +6116,9 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	VScrollBar *sb = scroll->get_v_scroll_bar();
 	scroll->remove_child(sb);
 	timeline_scroll->add_child(sb); // Move here so timeline and tracks are always aligned.
+	scroll->set_focus_mode(FOCUS_CLICK);
 	scroll->connect("gui_input", callable_mp(this, &AnimationTrackEditor::_scroll_input));
+	scroll->connect("focus_exited", callable_mp(panner.ptr(), &ViewPanner::release_pan_key));
 
 	bezier_edit = memnew(AnimationBezierTrackEdit);
 	timeline_vbox->add_child(bezier_edit);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -84,7 +84,7 @@ class AnimationTimelineEdit : public Range {
 	Ref<ViewPanner> panner;
 	void _scroll_callback(Vector2 p_scroll_vec);
 	void _pan_callback(Vector2 p_scroll_vec);
-	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin);
+	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt);
 
 	bool dragging_timeline;
 	bool dragging_hsize;
@@ -379,7 +379,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	Ref<ViewPanner> panner;
 	void _scroll_callback(Vector2 p_scroll_vec);
 	void _pan_callback(Vector2 p_scroll_vec);
-	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin);
+	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt);
 
 	void _timeline_value_changed(double);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6043,11 +6043,8 @@ EditorNode::EditorNode() {
 	EDITOR_DEF("interface/inspector/default_color_picker_shape", (int32_t)ColorPicker::SHAPE_VHS_CIRCLE);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/inspector/default_color_picker_shape", PROPERTY_HINT_ENUM, "HSV Rectangle,HSV Rectangle Wheel,VHS Circle", PROPERTY_USAGE_DEFAULT));
 	EDITOR_DEF("run/auto_save/save_before_running", true);
-	EDITOR_DEF("interface/editors/sub_editor_panning_scheme", 0);
-	EDITOR_DEF("interface/editors/animation_editors_panning_scheme", 1);
-	// Should be in sync with ControlScheme in ViewPanner.
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/editors/sub_editor_panning_scheme", PROPERTY_HINT_ENUM, "Scroll Zooms,Scroll Pans", PROPERTY_USAGE_DEFAULT));
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/editors/animation_editors_panning_scheme", PROPERTY_HINT_ENUM, "Scroll Zooms,Scroll Pans", PROPERTY_USAGE_DEFAULT));
+
+	ED_SHORTCUT("canvas_item_editor/pan_view", TTR("Pan View"), Key::SPACE);
 
 	const Vector<String> textfile_ext = ((String)(EditorSettings::get_singleton()->get("docks/filesystem/textfile_extensions"))).split(",", false);
 	for (const String &E : textfile_ext) {

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -643,10 +643,15 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/2d/bone_outline_size", 2);
 	_initial_set("editors/2d/viewport_border_color", Color(0.4, 0.4, 1.0, 0.4));
 	_initial_set("editors/2d/constrain_editor_view", true);
-	_initial_set("editors/2d/warped_mouse_panning", true);
-	_initial_set("editors/2d/simple_panning", false);
-	_initial_set("editors/2d/scroll_to_pan", false);
-	_initial_set("editors/2d/pan_speed", 20);
+
+	// Panning
+	// Enum should be in sync with ControlScheme in ViewPanner.
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/panning/2d_editor_panning_scheme", 0, "Scroll Zooms,Scroll Pans");
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/panning/sub_editor_panning_scheme", 0, "Scroll Zooms,Scroll Pans");
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "editors/panning/animation_editors_panning_scheme", 1, "Scroll Zooms,Scroll Pans");
+	_initial_set("editors/panning/simple_panning", false);
+	_initial_set("editors/panning/warped_mouse_panning", true);
+	_initial_set("editors/panning/2d_editor_pan_speed", 20);
 
 	// Tiles editor
 	_initial_set("editors/tiles_editor/display_grid", true);

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -40,6 +40,7 @@
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel.h"
 #include "scene/gui/progress_bar.h"
+#include "scene/gui/view_panner.h"
 #include "scene/main/window.h"
 
 void AnimationNodeBlendTreeEditor::add_custom_type(const String &p_name, const Ref<Script> &p_script) {
@@ -733,7 +734,8 @@ void AnimationNodeBlendTreeEditor::_removed_from_graph() {
 
 void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		graph->set_panning_scheme((GraphEdit::PanningScheme)EDITOR_GET("interface/editors/sub_editor_panning_scheme").operator int());
+		graph->get_panner()->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editor_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
+		graph->set_warped_panning(bool(EditorSettings::get_singleton()->get("editors/panning/warped_mouse_panning")));
 	}
 
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -42,6 +42,7 @@
 #include "scene/main/canvas_item.h"
 
 class CanvasItemEditorViewport;
+class ViewPanner;
 
 class CanvasItemEditorSelectedItem : public Object {
 	GDCLASS(CanvasItemEditorSelectedItem, Object);
@@ -276,7 +277,6 @@ private:
 	bool key_pos;
 	bool key_rot;
 	bool key_scale;
-	bool panning;
 	bool pan_pressed;
 
 	bool ruler_tool_active;
@@ -402,7 +402,13 @@ private:
 	Ref<Shortcut> set_pivot_shortcut;
 	Ref<Shortcut> multiply_grid_step_shortcut;
 	Ref<Shortcut> divide_grid_step_shortcut;
-	Ref<Shortcut> pan_view_shortcut;
+
+	Ref<ViewPanner> panner;
+	bool warped_panning = true;
+	int pan_speed = 20;
+	void _scroll_callback(Vector2 p_scroll_vec);
+	void _pan_callback(Vector2 p_scroll_vec);
+	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt);
 
 	bool _is_node_locked(const Node *p_node);
 	bool _is_node_movable(const Node *p_node, bool p_popup_warning = false);

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -83,7 +83,7 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	Ref<ViewPanner> uv_panner;
 	void _uv_scroll_callback(Vector2 p_scroll_vec);
 	void _uv_pan_callback(Vector2 p_scroll_vec);
-	void _uv_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin);
+	void _uv_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt);
 
 	VBoxContainer *bone_scroll_main_vb;
 	ScrollContainer *bone_scroll;

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -40,6 +40,8 @@
 #include "scene/resources/style_box.h"
 #include "scene/resources/texture.h"
 
+class ViewPanner;
+
 class TextureRegionEditor : public VBoxContainer {
 	GDCLASS(TextureRegionEditor, VBoxContainer);
 
@@ -97,6 +99,11 @@ class TextureRegionEditor : public VBoxContainer {
 	bool creating;
 	Vector2 drag_from;
 	int drag_index;
+
+	Ref<ViewPanner> panner;
+	void _scroll_callback(Vector2 p_scroll_vec);
+	void _pan_callback(Vector2 p_scroll_vec);
+	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt);
 
 	void _set_snap_mode(int p_mode);
 	void _set_snap_off_x(float p_val);

--- a/editor/plugins/tiles/tile_atlas_view.h
+++ b/editor/plugins/tiles/tile_atlas_view.h
@@ -69,7 +69,7 @@ private:
 	Ref<ViewPanner> panner;
 	void _scroll_callback(Vector2 p_scroll_vec);
 	void _pan_callback(Vector2 p_scroll_vec);
-	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin);
+	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt);
 
 	Map<Vector2, Map<int, Rect2i>> alternative_tiles_rect_cache;
 	void _update_alternative_tiles_rect_cache();

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -42,6 +42,7 @@
 #include "scene/animation/animation_player.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel.h"
+#include "scene/gui/view_panner.h"
 #include "scene/main/window.h"
 #include "scene/resources/visual_shader_nodes.h"
 #include "scene/resources/visual_shader_particle_nodes.h"
@@ -3222,7 +3223,8 @@ void VisualShaderEditor::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		graph->set_panning_scheme((GraphEdit::PanningScheme)EDITOR_GET("interface/editors/sub_editor_panning_scheme").operator int());
+		graph->get_panner()->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editor_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
+		graph->set_warped_panning(bool(EditorSettings::get_singleton()->get("editors/panning/warped_mouse_panning")));
 	}
 
 	if (p_what == NOTIFICATION_DRAG_BEGIN) {

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -42,6 +42,7 @@
 #include "editor/editor_node.h"
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_scale.h"
+#include "scene/gui/view_panner.h"
 #include "scene/main/window.h"
 
 #ifdef TOOLS_ENABLED
@@ -3782,7 +3783,8 @@ void VisualScriptEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			graph->set_panning_scheme((GraphEdit::PanningScheme)EDITOR_GET("interface/editors/sub_editor_panning_scheme").operator int());
+			graph->get_panner()->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editor_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
+			graph->set_warped_panning(bool(EditorSettings::get_singleton()->get("editors/panning/warped_mouse_panning")));
 		} break;
 
 		case NOTIFICATION_READY: {

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -130,9 +130,10 @@ private:
 	float port_grab_distance_vertical;
 
 	Ref<ViewPanner> panner;
+	bool warped_panning = true;
 	void _scroll_callback(Vector2 p_scroll_vec);
 	void _pan_callback(Vector2 p_scroll_vec);
-	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin);
+	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt);
 
 	bool connecting = false;
 	String connecting_from;
@@ -348,6 +349,8 @@ public:
 	bool is_connection_lines_antialiased() const;
 
 	HBoxContainer *get_zoom_hbox();
+	Ref<ViewPanner> get_panner();
+	void set_warped_panning(bool p_warped);
 
 	void arrange_nodes();
 

--- a/scene/gui/view_panner.h
+++ b/scene/gui/view_panner.h
@@ -34,6 +34,7 @@
 #include "core/object/ref_counted.h"
 
 class InputEvent;
+class Shortcut;
 
 class ViewPanner : public RefCounted {
 	GDCLASS(ViewPanner, RefCounted);
@@ -46,23 +47,34 @@ public:
 
 private:
 	bool is_dragging = false;
-	bool disable_rmb = false;
+	bool pan_key_pressed = false;
+	bool enable_rmb = false;
+	bool simple_panning_enabled = false;
+
+	Ref<Shortcut> pan_view_shortcut;
 
 	Callable scroll_callback;
 	Callable pan_callback;
 	Callable zoom_callback;
 
-	void callback_helper(Callable p_callback, Vector2 p_arg1, Vector2 p_arg2 = Vector2());
+	void callback_helper(Callable p_callback, Vector<Variant> p_args);
 	ControlScheme control_scheme = SCROLL_ZOOMS;
 
 public:
 	void set_callbacks(Callable p_scroll_callback, Callable p_pan_callback, Callable p_zoom_callback);
 	void set_control_scheme(ControlScheme p_scheme);
-	void set_disable_rmb(bool p_disable);
+	void set_enable_rmb(bool p_enable);
+	void set_pan_shortcut(Ref<Shortcut> p_shortcut);
+	void set_simple_panning_enabled(bool p_enabled);
 
-	bool is_panning() const { return is_dragging; }
+	void setup(ControlScheme p_scheme, Ref<Shortcut> p_shortcut, bool p_simple_panning);
+
+	bool is_panning() const;
 
 	bool gui_input(const Ref<InputEvent> &p_ev, Rect2 p_canvas_rect = Rect2());
+	void release_pan_key();
+
+	ViewPanner();
 };
 
 #endif // VIEW_PANNER_H


### PR DESCRIPTION
Summary of changes:
- Added ViewPanner to 2D editor
  - as a result, in default control scheme Ctrl+Wheel will scroll the view instead of zooming. But it duplicated the no-Ctrl wheel, so whatevs
- Added ViewPanner to TextureRegionEditor (I missed it in the last PR; some more editors could still be changed probably)

ViewPanner:
- added customizable panning shortcut, instead of hard-coded Space
- changed "disable RMB" to "enable RMB". RMB panning is now disabled by default as only 1 out of 8 editors uses it lol
- zoom callback got a new `p_alt` parameter, as some editors used "alternate zoom", so I simplified it
- simplified the callback helper method
- added "simple panning" support, i.e. spacebar panning without LMB
- added a `setup()` method that setups multiple common properties from editor
- I adjusted various editors due to these changes

Editor Settings:
- moved all panning-related settings to a dedicated "Panning" category
- `editors/2d/warped_mouse_panning` changed to `editors/panning/warped_mouse_panning`
  - now used by all GraphEdit-based editors
- `editors/2d/simple_panning` changed to `editors/panning/simple_panning`
  - now used by every editor with ViewPanner
- `editors/2d/pan_speed` changed to `interface/editors/2d_editor_pan_speed`
- `editors/2d/scroll_to_pan` changed to `interface/editors/2d_editor_panning_scheme`
- `canvas_item_editor/pan_view` shortcut is now supported by every editor with ViewPanner (maybe it could be moved?)

![image](https://user-images.githubusercontent.com/2223172/150358769-d68c0bed-f89c-474e-8bf9-7a151e00f2e3.png)

GraphEdit:
- restored mouse warping (forgot to add it in the first PR)
- added two unexposed methods: `get_panner()` and `set_warped_panning()`, used by editor

EDIT:
After most recent changes, it fixes #34278