### PR TITLE
[Windows] Fix pop-up dialogs instantly closing.

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1403,12 +1403,12 @@ void PopupMenu::activate_item(int p_item) {
 		need_hide = false;
 	}
 
-	emit_signal(SNAME("id_pressed"), id);
-	emit_signal(SNAME("index_pressed"), p_item);
-
 	if (need_hide) {
 		hide();
 	}
+
+	emit_signal(SNAME("id_pressed"), id);
+	emit_signal(SNAME("index_pressed"), p_item);
 }
 
 void PopupMenu::remove_item(int p_idx) {


### PR DESCRIPTION
Hide the pop-up menu before sending the item activation signal, to avoid newly opened pop-ups fighting for focus with the menu parent.

Note: Marked it as `Windows` fix, since I can't reproduce the issue on macOS or Linux, but it's probably related to the speed of the window getting focus and might depend on the DE and settings.

Fixes #56998