### PR TITLE
Tweak logo max width on the web editor

### DIFF
--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -270,7 +270,7 @@
 		<div id="tab-loader">
 			<div style="color: #e0e0e0;" id="persistence">
 				<br />
-				<img src="logo.svg" alt="Godot Engine logo" width="1024" height="414" style="width: auto; height: auto; max-width: 85%; max-height: 250px" />
+				<img src="logo.svg" alt="Godot Engine logo" width="1024" height="414" style="width: auto; height: auto; max-width: min(85%, 50vh); max-height: 250px" />
 				<br />
 				@GODOT_VERSION@
 				<br />


### PR DESCRIPTION
The logo's maximum width is now dependent on the viewport height in addition to the page width. This prevents the "Start Godot editor" button from overflowing the page on mobile devices (although the "Clear persistent data" and "Web editor documentation" buttons will still overflow for now).

A full solution will likely need to enable overflow while on the welcome page, and disable it on the Editor and Game tabs.

This partially addresses https://github.com/godotengine/godot/issues/56960.

## Preview

*Test device is Samsung Galaxy S20 (a relatively small flagship device) on Firefox 96.*

### Landscape mode

*[CSS `min()`](https://caniuse.com/css-math-functions) doing its job.*

| Before | After |
|-|-|
| ![Screen Shot 2022-01-20 at 17 02 37](https://user-images.githubusercontent.com/180032/150376240-68cf6d34-d12a-42cd-b819-a20285078b38.png) | ![Screen Shot 2022-01-20 at 17 02 30](https://user-images.githubusercontent.com/180032/150376232-a79beabd-0c0d-4a02-a279-aa161fd75d61.png) |

### Portrait mode

*Same as before.*

| Before | After |
|-|-|
| ![Screen Shot 2022-01-20 at 17 02 28](https://user-images.githubusercontent.com/180032/150376226-a548e00e-fc37-437a-a587-9d92c2865931.png) | ![Screen Shot 2022-01-20 at 17 02 36](https://user-images.githubusercontent.com/180032/150376236-ff3594b0-8c4e-41d7-bbe1-6d16d49a161a.png) |