### PR TITLE
[3.x] Backport method `get_rid` for NavigationAgent

### DIFF
--- a/doc/classes/NavigationAgent.xml
+++ b/doc/classes/NavigationAgent.xml
@@ -45,6 +45,12 @@
 				Returns a [Vector3] in global coordinates, that can be moved to, making sure that there are no static objects in the way. If the agent does not have a navigation path, it will return the origin of the agent's parent.
 			</description>
 		</method>
+		<method name="get_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the object's [RID].
+			</description>
+		</method>
 		<method name="get_target_location" qualifiers="const">
 			<return type="Vector3" />
 			<description>

--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -45,6 +45,12 @@
 				Returns a [Vector2] in global coordinates, that can be moved to, making sure that there are no static objects in the way. If the agent does not have a navigation path, it will return the position of the agent's parent.
 			</description>
 		</method>
+		<method name="get_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the object's [RID].
+			</description>
+		</method>
 		<method name="get_target_location" qualifiers="const">
 			<return type="Vector2" />
 			<description>

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -35,6 +35,8 @@
 #include "servers/navigation_2d_server.h"
 
 void NavigationAgent2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationAgent2D::get_rid);
+
 	ClassDB::bind_method(D_METHOD("set_target_desired_distance", "desired_distance"), &NavigationAgent2D::set_target_desired_distance);
 	ClassDB::bind_method(D_METHOD("get_target_desired_distance"), &NavigationAgent2D::get_target_desired_distance);
 

--- a/scene/3d/navigation_agent.cpp
+++ b/scene/3d/navigation_agent.cpp
@@ -35,6 +35,8 @@
 #include "servers/navigation_server.h"
 
 void NavigationAgent::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationAgent::get_rid);
+
 	ClassDB::bind_method(D_METHOD("set_target_desired_distance", "desired_distance"), &NavigationAgent::set_target_desired_distance);
 	ClassDB::bind_method(D_METHOD("get_target_desired_distance"), &NavigationAgent::get_target_desired_distance);
 


### PR DESCRIPTION
For some reason, the method is in the master branch, but not in 3.x:
https://github.com/godotengine/godot/blob/880855264fdaf7b0a2ead6cf76a3722c4af43257/scene/3d/navigation_agent_3d.cpp#L36

Since the RID constructor [seems to be broken](https://github.com/godotengine/godot/issues/57010), this is the only way to obtain the object RID to call NavigationServer `agent_set_*` functions.

P.S. I needed the `NavigationServer.agent_set_velocity` function because `NavigationAgent.set_velocity` implies that I listen to his advice and change the speed, and I wanted the agent to stand still and others to avoid it.