### PR TITLE
[4.x] Add ACTION_MODE_HYBRID to BaseButton and make it the default

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -44,7 +44,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" enum="BaseButton.ActionMode" default="1">
+		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" enum="BaseButton.ActionMode" default="2">
 			Determines when the button is considered clicked, one of the [enum ActionMode] constants.
 		</member>
 		<member name="button_group" type="ButtonGroup" setter="set_button_group" getter="get_button_group">
@@ -124,6 +124,9 @@
 		</constant>
 		<constant name="ACTION_MODE_BUTTON_RELEASE" value="1" enum="ActionMode">
 			Require a press and a subsequent release before considering the button clicked.
+		</constant>
+		<constant name="ACTION_MODE_HYBRID" value="2" enum="ActionMode">
+			Acts like [constant ACTION_MODE_BUTTON_RELEASE] for mouse-based inputs, but like [constant ACTION_MODE_BUTTON_PRESS] for other inputs.
 		</constant>
 	</constants>
 </class>

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -140,12 +140,21 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 	}
 
 	if (status.press_attempt && status.pressing_inside) {
-		if (toggle_mode) {
-			bool is_pressed = p_event->is_pressed();
-			if (Object::cast_to<InputEventShortcut>(*p_event)) {
-				is_pressed = false;
+		bool is_pressed = p_event->is_pressed();
+		if (toggle_mode && Object::cast_to<InputEventShortcut>(*p_event)) {
+			is_pressed = false;
+		}
+		bool activate = is_pressed == (action_mode == ACTION_MODE_BUTTON_PRESS);
+		if (action_mode == ACTION_MODE_HYBRID) {
+			Ref<InputEventMouseButton> mouse_button = p_event;
+			if (mouse_button.is_valid()) {
+				activate = !is_pressed;
+			} else {
+				activate = is_pressed;
 			}
-			if ((is_pressed && action_mode == ACTION_MODE_BUTTON_PRESS) || (!is_pressed && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
+		}
+		if (toggle_mode) {
+			if (activate) {
 				if (action_mode == ACTION_MODE_BUTTON_PRESS) {
 					status.press_attempt = false;
 					status.pressing_inside = false;
@@ -159,7 +168,7 @@ void BaseButton::on_action_event(Ref<InputEvent> p_event) {
 				_pressed();
 			}
 		} else {
-			if ((p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_PRESS) || (!p_event->is_pressed() && action_mode == ACTION_MODE_BUTTON_RELEASE)) {
+			if (activate) {
 				_pressed();
 			}
 		}
@@ -445,7 +454,7 @@ void BaseButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "toggle_mode"), "set_toggle_mode", "is_toggle_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shortcut_in_tooltip"), "set_shortcut_in_tooltip", "is_shortcut_in_tooltip_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "button_pressed"), "set_pressed", "is_pressed");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "action_mode", PROPERTY_HINT_ENUM, "Button Press,Button Release"), "set_action_mode", "get_action_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "action_mode", PROPERTY_HINT_ENUM, "Button Press, Button Release, Hybrid"), "set_action_mode", "get_action_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_mask", PROPERTY_HINT_FLAGS, "Mouse Left, Mouse Right, Mouse Middle"), "set_button_mask", "get_button_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_pressed_outside"), "set_keep_pressed_outside", "is_keep_pressed_outside");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "shortcut", PROPERTY_HINT_RESOURCE_TYPE, "Shortcut"), "set_shortcut", "get_shortcut");
@@ -460,6 +469,7 @@ void BaseButton::_bind_methods() {
 
 	BIND_ENUM_CONSTANT(ACTION_MODE_BUTTON_PRESS);
 	BIND_ENUM_CONSTANT(ACTION_MODE_BUTTON_RELEASE);
+	BIND_ENUM_CONSTANT(ACTION_MODE_HYBRID);
 }
 
 BaseButton::BaseButton() {

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -42,6 +42,7 @@ public:
 	enum ActionMode {
 		ACTION_MODE_BUTTON_PRESS,
 		ACTION_MODE_BUTTON_RELEASE,
+		ACTION_MODE_HYBRID,
 	};
 
 private:
@@ -52,7 +53,7 @@ private:
 	Ref<Shortcut> shortcut;
 	ObjectID shortcut_context;
 
-	ActionMode action_mode = ACTION_MODE_BUTTON_RELEASE;
+	ActionMode action_mode = ACTION_MODE_HYBRID;
 	struct Status {
 		bool pressed = false;
 		bool hovering = false;


### PR DESCRIPTION
4.x version of #56419. Implements https://github.com/godotengine/godot-proposals/issues/3234 .

Unlike #56419, this PR **makes the new ACTION_MODE_HYBRID mode the default**.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/3234.*