### PR TITLE
Fix false reporting unclaimed StringName at exit due to static refs

### DIFF
--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -84,12 +84,15 @@ void StringName::cleanup() {
 	for (int i = 0; i < STRING_TABLE_LEN; i++) {
 		while (_table[i]) {
 			_Data *d = _table[i];
-			lost_strings++;
-			if (d->static_count.get() != d->refcount.get() && OS::get_singleton()->is_stdout_verbose()) {
-				if (d->cname) {
-					print_line("Orphan StringName: " + String(d->cname));
-				} else {
-					print_line("Orphan StringName: " + String(d->name));
+			if (d->static_count.get() != d->refcount.get()) {
+				lost_strings++;
+
+				if (OS::get_singleton()->is_stdout_verbose()) {
+					if (d->cname) {
+						print_line("Orphan StringName: " + String(d->cname));
+					} else {
+						print_line("Orphan StringName: " + String(d->name));
+					}
 				}
 			}
 


### PR DESCRIPTION
**I don't know if this change is correct!** It needs to be reviewed by @reduz or someone else that knows this part well.

Static string names were introduced in #50566. I think there's a mistake there that makes static string names cause the `unclaimed string names at exit` message at exit when running in verbose mode.
The `d->static_count.get() != d->refcount.get()` condition is correctly used to avoid printing the `Orphan StringName:` message when only static references are left. However, `lost_strings` is still being incremented, resulting in the other message.
