### PR TITLE
Rename TubeTrailMesh's `radius` to `size` and act as a diameter

### DIFF
--- a/doc/classes/TubeTrailMesh.xml
+++ b/doc/classes/TubeTrailMesh.xml
@@ -11,13 +11,14 @@
 		</member>
 		<member name="radial_steps" type="int" setter="set_radial_steps" getter="get_radial_steps" default="8">
 		</member>
-		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
-		</member>
 		<member name="section_length" type="float" setter="set_section_length" getter="get_section_length" default="0.2">
 		</member>
 		<member name="section_rings" type="int" setter="set_section_rings" getter="get_section_rings" default="3">
 		</member>
 		<member name="sections" type="int" setter="set_sections" getter="get_sections" default="5">
+		</member>
+		<member name="size" type="float" setter="set_size" getter="get_size" default="1.0">
+			The tube's diameter (in 3D units). This is multiplied by the value in [member curve] if present.
 		</member>
 	</members>
 </class>

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -1580,12 +1580,12 @@ PointMesh::PointMesh() {
 }
 // TUBE TRAIL
 
-void TubeTrailMesh::set_radius(const float p_radius) {
-	radius = p_radius;
+void TubeTrailMesh::set_size(const float p_size) {
+	size = p_size;
 	_request_update();
 }
-float TubeTrailMesh::get_radius() const {
-	return radius;
+float TubeTrailMesh::get_size() const {
+	return size;
 }
 
 void TubeTrailMesh::set_radial_steps(const int p_radial_steps) {
@@ -1694,7 +1694,7 @@ void TubeTrailMesh::_create_mesh_array(Array &p_arr) const {
 			float u = i;
 			u /= radial_steps;
 
-			float r = radius;
+			float r = size * 0.5;
 			if (curve.is_valid() && curve->get_point_count() > 0) {
 				r *= curve->interpolate_baked(v);
 			}
@@ -1760,7 +1760,7 @@ void TubeTrailMesh::_create_mesh_array(Array &p_arr) const {
 		bone_weights.push_back(0);
 		bone_weights.push_back(0);
 
-		float rm = radius * scale_pos;
+		float rm = size * 0.5 * scale_pos;
 
 		for (int i = 0; i <= radial_steps; i++) {
 			float r = i;
@@ -1823,7 +1823,7 @@ void TubeTrailMesh::_create_mesh_array(Array &p_arr) const {
 		bone_weights.push_back(0);
 		bone_weights.push_back(0);
 
-		float rm = radius * scale_neg;
+		float rm = size * 0.5 * scale_neg;
 
 		for (int i = 0; i <= radial_steps; i++) {
 			float r = i;
@@ -1870,8 +1870,8 @@ void TubeTrailMesh::_create_mesh_array(Array &p_arr) const {
 }
 
 void TubeTrailMesh::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_radius", "radius"), &TubeTrailMesh::set_radius);
-	ClassDB::bind_method(D_METHOD("get_radius"), &TubeTrailMesh::get_radius);
+	ClassDB::bind_method(D_METHOD("set_size", "size"), &TubeTrailMesh::set_size);
+	ClassDB::bind_method(D_METHOD("get_size"), &TubeTrailMesh::get_size);
 
 	ClassDB::bind_method(D_METHOD("set_radial_steps", "radial_steps"), &TubeTrailMesh::set_radial_steps);
 	ClassDB::bind_method(D_METHOD("get_radial_steps"), &TubeTrailMesh::get_radial_steps);
@@ -1888,7 +1888,7 @@ void TubeTrailMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_curve", "curve"), &TubeTrailMesh::set_curve);
 	ClassDB::bind_method(D_METHOD("get_curve"), &TubeTrailMesh::get_curve);
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "radius", PROPERTY_HINT_RANGE, "0.001,100.0,0.001,or_greater"), "set_radius", "get_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "size", PROPERTY_HINT_RANGE, "0.001,100.0,0.001,or_greater"), "set_size", "get_size");
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "radial_steps", PROPERTY_HINT_RANGE, "3,128,1"), "set_radial_steps", "get_radial_steps");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sections", PROPERTY_HINT_RANGE, "2,128,1"), "set_sections", "get_sections");

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -349,7 +349,7 @@ class TubeTrailMesh : public PrimitiveMesh {
 	GDCLASS(TubeTrailMesh, PrimitiveMesh);
 
 private:
-	float radius = 1.0;
+	float size = 1.0;
 	int radial_steps = 8;
 	int sections = 5;
 	float section_length = 0.2;
@@ -364,8 +364,8 @@ protected:
 	virtual void _create_mesh_array(Array &p_arr) const override;
 
 public:
-	void set_radius(const float p_radius);
-	float get_radius() const;
+	void set_size(const float p_size);
+	float get_size() const;
 
 	void set_radial_steps(const int p_radial_steps);
 	int get_radial_steps() const;


### PR DESCRIPTION
This makes TubeTrailMesh's `size` property behave like RibbonTrailMesh's. The default value is still 1.0, but since it's now a diameter instead of a radius, TubeTrailMesh is twice as thin by default.

This makes the default width identical between TubeTrailMesh and RibbonTrailMesh.

This change could also be considered for other primitive meshes, since [we are moving towards defining *sizes* rather than half-extents in 2D/3D nodes in 4.0](https://github.com/godotengine/godot/issues/54449).

**Note:** Doesn't break compatibility with `3.x` projects as TubeTrailMesh is not present in `3.x`.

**Testing project:** [test_ribbon_tube_trail_mesh.zip](https://github.com/godotengine/godot/files/7909477/test_ribbon_tube_trail_mesh.zip)

## Preview

### Before

![2022-01-21_01 37 00](https://user-images.githubusercontent.com/180032/150446200-73319950-2596-492f-983b-a3bf665125db.png)

### After

![2022-01-21_01 53 09](https://user-images.githubusercontent.com/180032/150446203-5839d8e5-ff33-4bf9-aac8-44a499eea823.png)