### PR TITLE
Update AssetLib network settings when Editor Settings change

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -612,6 +612,7 @@ void EditorAssetLibrary::_notification(int p_what) {
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			_update_repository_options();
+			setup_http_request(request);
 		} break;
 	}
 }


### PR DESCRIPTION
In `EditorAssetLibrary`, the main `HTTPRequest` object updates its settings only in the constructor. So later setting changes (e.g. proxy, use threads) won't have any effect when fetching AssetLib pages.