### PR TITLE
Portals - fix gameplay monitor unloading

### DIFF
--- a/servers/visual/portals/portal_gameplay_monitor.h
+++ b/servers/visual/portals/portal_gameplay_monitor.h
@@ -43,6 +43,8 @@ class PortalGameplayMonitor {
 public:
 	PortalGameplayMonitor();
 
+	void unload(PortalRenderer &p_portal_renderer);
+
 	// entering and exiting gameplay notifications (requires PVS)
 	void update_gameplay(PortalRenderer &p_portal_renderer, const int *p_source_room_ids, int p_num_source_rooms);
 	void set_params(bool p_use_secondary_pvs, bool p_use_signals);

--- a/servers/visual/portals/portal_renderer.cpp
+++ b/servers/visual/portals/portal_renderer.cpp
@@ -996,6 +996,7 @@ void PortalRenderer::sprawl_roaming(uint32_t p_mover_pool_id, MovingBase &r_movi
 void PortalRenderer::_ensure_unloaded(String p_reason) {
 	if (_loaded) {
 		_loaded = false;
+		_gameplay_monitor.unload(*this);
 
 		String str;
 		if (p_reason != String()) {
@@ -1014,6 +1015,17 @@ void PortalRenderer::_ensure_unloaded(String p_reason) {
 
 void PortalRenderer::rooms_and_portals_clear() {
 	_loaded = false;
+
+	// N.B. We want to make sure all the tick counters on movings rooms etc to zero,
+	// so that on loading the next level gameplay entered signals etc will be
+	// correctly sent and everything is fresh.
+	// This is mostly done by the gameplay_monitor, but rooms_and_portals_clear()
+	// will also clear tick counters where possible
+	// (there is no TrackedList for the RoomGroup pool for example).
+	// This could be made neater by moving everything to TrackedPooledLists, but this
+	// may be overkill.
+	_gameplay_monitor.unload(*this);
+
 	_statics.clear();
 	_static_ghosts.clear();
 

--- a/servers/visual/portals/portal_renderer.h
+++ b/servers/visual/portals/portal_renderer.h
@@ -87,6 +87,9 @@ public:
 		void destroy() {
 			_rooms.clear();
 			room_id = -1;
+
+			last_tick_hit = 0;
+			last_gameplay_tick_hit = 0;
 		}
 
 		// the expanded aabb allows objects to move on most frames

--- a/servers/visual/portals/portal_types.h
+++ b/servers/visual/portals/portal_types.h
@@ -257,6 +257,7 @@ struct VSRoom {
 		_secondary_pvs_size = 0;
 		_priority = 0;
 		_contains_internal_rooms = false;
+		last_gameplay_tick_hit = 0;
 	}
 
 	void cleanup_after_conversion() {


### PR DESCRIPTION
The gameplay monitor wasn't being unloaded correctly in between levels. This meant that exit signals were not being sent, and entered signals for the new level were being missed.

This PR sends appropriate exit signals on unloading, and clear the data.

Fixes #56494

## Notes
* I completely forgot to unload this data. Probably because `RoomManager` does get deleted usually between levels, _however_ the actual `PortalRenderer` acts more like a global, so needs explicit deletion of data between levels.

## Testing
Run the MRP in the linked issue.
Output is now correctly:
```
Room conversion complete. 3 rooms, 0 portals.
Gameplay entered signal
Gameplay exited signal
Room conversion complete. 3 rooms, 0 portals.
Gameplay entered signal
Gameplay exited signal
Room conversion complete. 3 rooms, 0 portals.
Gameplay entered signal
Portal system unloaded ( deleting STATIC or DYNAMIC ).
```