### PR TITLE
Fix main window title translation.

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1328,6 +1328,8 @@ SceneTree::SceneTree() {
 	root = memnew(Window);
 	root->set_process_mode(Node::PROCESS_MODE_PAUSABLE);
 	root->set_name("root");
+	root->set_title(ProjectSettings::get_singleton()->get("application/config/name"));
+
 #ifndef _3D_DISABLED
 	if (!root->get_world_3d().is_valid()) {
 		root->set_world_3d(Ref<World3D>(memnew(World3D)));

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -41,7 +41,16 @@ void Window::set_title(const String &p_title) {
 	if (embedder) {
 		embedder->_sub_window_update(this);
 	} else if (window_id != DisplayServer::INVALID_WINDOW_ID) {
-		DisplayServer::get_singleton()->window_set_title(atr(p_title), window_id);
+		String tr_title = atr(p_title);
+#ifdef DEBUG_ENABLED
+		if (window_id == DisplayServer::MAIN_WINDOW_ID) {
+			// Append a suffix to the window title to denote that the project is running
+			// from a debug build (including the editor). Since this results in lower performance,
+			// this should be clearly presented to the user.
+			tr_title = vformat("%s (DEBUG)", tr_title);
+		}
+#endif
+		DisplayServer::get_singleton()->window_set_title(tr_title, window_id);
 	}
 }
 
@@ -234,7 +243,16 @@ void Window::_make_window() {
 	DisplayServer::get_singleton()->window_set_current_screen(current_screen, window_id);
 	DisplayServer::get_singleton()->window_set_max_size(max_size, window_id);
 	DisplayServer::get_singleton()->window_set_min_size(min_size, window_id);
-	DisplayServer::get_singleton()->window_set_title(atr(title), window_id);
+	String tr_title = atr(title);
+#ifdef DEBUG_ENABLED
+	if (window_id == DisplayServer::MAIN_WINDOW_ID) {
+		// Append a suffix to the window title to denote that the project is running
+		// from a debug build (including the editor). Since this results in lower performance,
+		// this should be clearly presented to the user.
+		tr_title = vformat("%s (DEBUG)", tr_title);
+	}
+#endif
+	DisplayServer::get_singleton()->window_set_title(tr_title, window_id);
 	DisplayServer::get_singleton()->window_attach_instance_id(get_instance_id(), window_id);
 
 	_update_window_size();
@@ -773,7 +791,16 @@ void Window::_notification(int p_what) {
 			if (embedder) {
 				embedder->_sub_window_update(this);
 			} else if (window_id != DisplayServer::INVALID_WINDOW_ID) {
-				DisplayServer::get_singleton()->window_set_title(atr(title), window_id);
+				String tr_title = atr(title);
+#ifdef DEBUG_ENABLED
+				if (window_id == DisplayServer::MAIN_WINDOW_ID) {
+					// Append a suffix to the window title to denote that the project is running
+					// from a debug build (including the editor). Since this results in lower performance,
+					// this should be clearly presented to the user.
+					tr_title = vformat("%s (DEBUG)", tr_title);
+				}
+#endif
+				DisplayServer::get_singleton()->window_set_title(tr_title, window_id);
 			}
 
 			child_controls_changed();


### PR DESCRIPTION
Title for the main window was set directly using `DisplayServer`.
`Window` object `title` property was never set, and an empty string was used when localization is changed.
