### PR TITLE
Fix undo after non-last port removal in `VisualShaderNodeExpression`

### DIFF
--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -3402,7 +3402,6 @@ bool VisualShaderNodeGroupBase::is_valid_port_name(const String &p_name) const {
 }
 
 void VisualShaderNodeGroupBase::add_input_port(int p_id, int p_type, const String &p_name) {
-	ERR_FAIL_COND(has_input_port(p_id));
 	ERR_FAIL_INDEX(p_type, int(PORT_TYPE_MAX));
 	ERR_FAIL_COND(!is_valid_port_name(p_name));
 
@@ -3478,7 +3477,6 @@ bool VisualShaderNodeGroupBase::has_input_port(int p_id) const {
 }
 
 void VisualShaderNodeGroupBase::add_output_port(int p_id, int p_type, const String &p_name) {
-	ERR_FAIL_COND(has_output_port(p_id));
 	ERR_FAIL_INDEX(p_type, int(PORT_TYPE_MAX));
 	ERR_FAIL_COND(!is_valid_port_name(p_name));
 


### PR DESCRIPTION
Before:
![vs_fix_expression_undo](https://user-images.githubusercontent.com/3036176/150510866-c1244001-1a40-496a-98d8-f2d74802f430.gif)
 
After:
![vs_fix_expression_undo2](https://user-images.githubusercontent.com/3036176/150511414-74a03e93-94a1-4c47-bf83-5bf17dbcce52.gif)

