### PR TITLE
Improve Groups dock panel and the Group Editor

### DIFF
--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -211,6 +211,10 @@ void GroupDialog::_add_group(String p_name) {
 	groups->ensure_cursor_is_visible();
 }
 
+void GroupDialog::_add_group_text_changed(const String &p_new_text) {
+	add_group_button->set_disabled(p_new_text.strip_edges().is_empty());
+}
+
 void GroupDialog::_group_renamed() {
 	TreeItem *renamed_group = groups->get_edited();
 	if (!renamed_group) {
@@ -457,8 +461,9 @@ GroupDialog::GroupDialog() {
 	chbc->add_child(add_group_text);
 	add_group_text->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	add_group_text->connect("text_submitted", callable_mp(this, &GroupDialog::_add_group_pressed));
+	add_group_text->connect("text_changed", callable_mp(this, &GroupDialog::_add_group_text_changed));
 
-	Button *add_group_button = memnew(Button);
+	add_group_button = memnew(Button);
 	add_group_button->set_text(TTR("Add"));
 	chbc->add_child(add_group_button);
 	add_group_button->connect("pressed", callable_mp(this, &GroupDialog::_add_group_pressed), varray(String()));
@@ -557,6 +562,8 @@ GroupDialog::GroupDialog() {
 	error = memnew(ConfirmationDialog);
 	add_child(error);
 	error->get_ok_button()->set_text(TTR("Close"));
+
+	_add_group_text_changed("");
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -571,6 +578,7 @@ void GroupsEditor::_add_group(const String &p_group) {
 		return;
 	}
 
+	group_name->clear();
 	if (node->is_in_group(name)) {
 		return;
 	}
@@ -587,8 +595,6 @@ void GroupsEditor::_add_group(const String &p_group) {
 	undo_redo->add_undo_method(SceneTreeDock::get_singleton()->get_tree_editor(), "update_tree");
 
 	undo_redo->commit_action();
-
-	group_name->clear();
 }
 
 void GroupsEditor::_modify_group(Object *p_item, int p_column, int p_id) {
@@ -620,6 +626,10 @@ void GroupsEditor::_modify_group(Object *p_item, int p_column, int p_id) {
 			DisplayServer::get_singleton()->clipboard_set(ti->get_text(p_column));
 		} break;
 	}
+}
+
+void GroupsEditor::_group_name_changed(const String &p_new_text) {
+	add->set_disabled(p_new_text.strip_edges().is_empty());
 }
 
 struct _GroupInfoComparator {
@@ -711,6 +721,7 @@ GroupsEditor::GroupsEditor() {
 	group_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hbc->add_child(group_name);
 	group_name->connect("text_submitted", callable_mp(this, &GroupsEditor::_add_group));
+	group_name->connect("text_changed", callable_mp(this, &GroupsEditor::_group_name_changed));
 
 	add = memnew(Button);
 	add->set_text(TTR("Add"));
@@ -724,6 +735,8 @@ GroupsEditor::GroupsEditor() {
 	tree->connect("button_pressed", callable_mp(this, &GroupsEditor::_modify_group));
 	tree->add_theme_constant_override("draw_guides", 1);
 	add_theme_constant_override("separation", 3 * EDSCALE);
+
+	_group_name_changed("");
 }
 
 GroupsEditor::~GroupsEditor() {

--- a/editor/groups_editor.h
+++ b/editor/groups_editor.h
@@ -49,6 +49,7 @@ class GroupDialog : public AcceptDialog {
 	TreeItem *groups_root;
 
 	LineEdit *add_group_text;
+	Button *add_group_button;
 
 	Tree *groups;
 
@@ -77,6 +78,7 @@ class GroupDialog : public AcceptDialog {
 	void _add_pressed();
 	void _removed_pressed();
 	void _add_group_pressed(const String &p_name);
+	void _add_group_text_changed(const String &p_new_text);
 
 	void _group_renamed();
 	void _rename_group_item(const String &p_old_name, const String &p_new_name);
@@ -122,6 +124,7 @@ class GroupsEditor : public VBoxContainer {
 	void update_tree();
 	void _add_group(const String &p_group = "");
 	void _modify_group(Object *p_item, int p_column, int p_id);
+	void _group_name_changed(const String &p_new_text);
 
 	void _show_group_dialog();
 


### PR DESCRIPTION
Redo of my old #36293 :smile: 

For the Groups dock panel and Group Editor dialog:

* Disables the "Add" group button when nothing is entered in the `LineEdit`.
    * Before: the button is always available and does nothing when pressed with empty name.
* Clears the group name `LineEdit` when trying to add an existing group.
    * Before: "Add" button on the Groups dock panel does nothing. 
    * This behavior is already used by the Group Editor.