### PR TITLE
Mono strongly typed node extensions addition

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
@@ -193,10 +193,9 @@ namespace Godot
             return GetParent() as T;
         }
 
-        /**
-        *   <summary>Finds a Node of type T starting at the root of the tree</summary>
-        */
-        public T FindNodeOfType<T>() where T : class
+        /// <summary>Finds a <see cref="Node"/> of type T starting at the root of the tree. Returns <see langword="null"/> if none is found</summary>
+        /// <typeparam name="T">Any type which inherits from <see cref="Node"/></typeparam>
+        public T FindNodeOfType<T>() where T : Node
         {
             // find the root node
             Node parent = this;
@@ -213,10 +212,10 @@ namespace Godot
             return this.FindNodeOfType(parent);
         }
 
-        /**
-        *   <summary>Finds a Node of type T starting at the root of the specified parent Node</summary>
-        */
-        public T FindNodeOfType<T>(Node parent) where T : class
+        /// <summary>Finds a <see cref="Node"/> of type T starting at the specified parent. Returns <see langword="null"/> if none is found</summary>
+        /// <param name="parent">A object that inherits from <see cref="Node"/></param>
+        /// <typeparam name="T">Any type which inherits from <see cref="Node"/></typeparam>
+        public T FindNodeOfType<T>(Node parent) where T : Node
         {
             Queue<Node> children = new Queue<Node>();
             children.Enqueue(parent);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/NodeExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 
 namespace Godot
 {
@@ -190,6 +191,49 @@ namespace Godot
         public T GetParentOrNull<T>() where T : class
         {
             return GetParent() as T;
+        }
+
+        /**
+        *   <summary>Finds a Node of type T starting at the root of the tree</summary>
+        */
+        public T FindNodeOfType<T>() where T : class
+        {
+            // find the root node
+            Node parent = this;
+            Node tempParent = parent;
+            while (tempParent != null)
+            {
+                tempParent = parent.GetParent();
+                if (tempParent != null)
+                {
+                    parent = tempParent;
+                }
+            }
+
+            return this.FindNodeOfType(parent);
+        }
+
+        /**
+        *   <summary>Finds a Node of type T starting at the root of the specified parent Node</summary>
+        */
+        public T FindNodeOfType<T>(Node parent) where T : class
+        {
+            Queue<Node> children = new Queue<Node>();
+            children.Enqueue(parent);
+            while (children.Count > 0)
+            {
+                var currentNode = children.Dequeue();
+                if (currentNode is T)
+                {
+                    return (T)currentNode;
+                }
+                var nodeChildren = currentNode.GetChildren();
+                foreach (var child in nodeChildren)
+                {
+                    children.Enqueue((Node)child);
+                }
+            }
+            return null;
         }
     }
 }


### PR DESCRIPTION
In an effort to produce more strongly typed C# code, I am proposing either some additional utility methods OR changes to the FindNode methods. Instead of having to search using a string, it would be nice to specify the parent node and search by type instead. If none is found, a return of `null` is still fine IMO.

I have also opted to use iteration vs recursion in these methods as I have found it is faster than recursion at the expense of a minor memory overhead. 