### PR TITLE
Don't sort printed Dictionary

### DIFF
--- a/core/variant/variant.cpp
+++ b/core/variant/variant.cpp
@@ -1692,8 +1692,6 @@ String Variant::stringify(int recursion_count) const {
 				pairs.push_back(sp);
 			}
 
-			pairs.sort();
-
 			for (int i = 0; i < pairs.size(); i++) {
 				if (i > 0) {
 					str += ", ";

--- a/modules/gdscript/tests/scripts/parser/features/dictionary_lua_style.out
+++ b/modules/gdscript/tests/scripts/parser/features/dictionary_lua_style.out
@@ -1,2 +1,2 @@
 GDTEST_OK
-{2:4, a:1, b:2, with spaces:3}
+{a:1, b:2, with spaces:3, 2:4}


### PR DESCRIPTION
This code:
```GDScript
func _ready():
	var dict1 = {test = 1, other = 2}
	var dict2 = {other = 2, test = 1}
	prints(dict1, dict2, dict1.hash() == dict2.hash())
```
Gives interesting result:
```
{other:2, test:1} {other:2, test:1} false
```
You print dictionaries, you see them to be the same, but hash isn't equal. Why would that be? Because they are **sorted for printing wtf**

I don't know why it was like that, but as seen in the code above, it can be confusing and lead to time wasted debugging "same dictionaries" with different hash (hence this PR). Order is important.

After this change:
```
{test:1, other:2} {other:2, test:1} false
```