### PR TITLE
Fix default input port hints for some modes in visual shader

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -351,6 +351,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 	if (!graph_plugin) {
 		return;
 	}
+	Shader::Mode mode = visual_shader->get_mode();
 
 	Control *offset;
 
@@ -707,9 +708,9 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 					label->add_theme_style_override("normal", label_style); //more compact
 					hb->add_child(label);
 
-					if (vsnode->get_input_port_default_hint(i) != "" && !port_left_used) {
+					if (vsnode->is_input_port_default(i, mode) && !port_left_used) {
 						Label *hint_label = memnew(Label);
-						hint_label->set_text("[" + vsnode->get_input_port_default_hint(i) + "]");
+						hint_label->set_text(TTR("[default]"));
 						hint_label->add_theme_color_override("font_color", editor->get_theme_color(SNAME("font_readonly_color"), SNAME("TextEdit")));
 						hint_label->add_theme_style_override("normal", label_style);
 						hb->add_child(hint_label);
@@ -840,7 +841,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 	offset->set_custom_minimum_size(Size2(0, 4 * EDSCALE));
 	node->add_child(offset);
 
-	String error = vsnode->get_warning(visual_shader->get_mode(), p_type);
+	String error = vsnode->get_warning(mode, p_type);
 	if (!error.is_empty()) {
 		Label *error_label = memnew(Label);
 		error_label->add_theme_color_override("font_color", editor->get_theme_color(SNAME("error_color"), SNAME("Editor")));

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -231,8 +231,8 @@ String VisualShaderNode::get_warning(Shader::Mode p_mode, VisualShader::Type p_t
 	return String();
 }
 
-String VisualShaderNode::get_input_port_default_hint(int p_port) const {
-	return "";
+bool VisualShaderNode::is_input_port_default(int p_port, Shader::Mode p_mode) const {
+	return false;
 }
 
 void VisualShaderNode::_bind_methods() {

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -240,7 +240,7 @@ public:
 	virtual PortType get_output_port_type(int p_port) const = 0;
 	virtual String get_output_port_name(int p_port) const = 0;
 
-	virtual String get_input_port_default_hint(int p_port) const;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const;
 
 	void set_output_port_for_preview(int p_index);
 	int get_output_port_for_preview() const;

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -487,11 +487,13 @@ bool VisualShaderNodeTexture::is_output_port_expandable(int p_port) const {
 	return false;
 }
 
-String VisualShaderNodeTexture::get_input_port_default_hint(int p_port) const {
-	if (p_port == 0) {
-		return "default";
+bool VisualShaderNodeTexture::is_input_port_default(int p_port, Shader::Mode p_mode) const {
+	if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
+		if (p_port == 0) {
+			return true;
+		}
 	}
-	return "";
+	return false;
 }
 
 Vector<VisualShader::DefaultTextureParam> VisualShaderNodeTexture::get_default_texture_parameters(VisualShader::Type p_type, int p_id) const {
@@ -526,7 +528,7 @@ String VisualShaderNodeTexture::generate_global(Shader::Mode p_mode, VisualShade
 
 String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String default_uv;
-	if (p_mode != Shader::MODE_PARTICLES && p_mode != Shader::MODE_SKY) {
+	if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
 		default_uv = "UV.xy";
 	} else {
 		default_uv = "vec2(0.0)";
@@ -1052,16 +1054,18 @@ bool VisualShaderNodeSample3D::is_output_port_expandable(int p_port) const {
 	return false;
 }
 
-String VisualShaderNodeSample3D::get_input_port_default_hint(int p_port) const {
-	if (p_port == 0) {
-		return "default";
+bool VisualShaderNodeSample3D::is_input_port_default(int p_port, Shader::Mode p_mode) const {
+	if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
+		if (p_port == 0) {
+			return true;
+		}
 	}
-	return "";
+	return false;
 }
 
 String VisualShaderNodeSample3D::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String default_uv;
-	if (p_mode != Shader::MODE_PARTICLES && p_mode != Shader::MODE_SKY) {
+	if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
 		default_uv = "vec3(UV, 0.0)";
 	} else {
 		default_uv = "vec3(0.0)";
@@ -1346,7 +1350,7 @@ String VisualShaderNodeCubemap::generate_global(Shader::Mode p_mode, VisualShade
 
 String VisualShaderNodeCubemap::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String default_uv;
-	if (p_mode != Shader::MODE_PARTICLES && p_mode != Shader::MODE_SKY) {
+	if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
 		default_uv = "vec3(UV, 0.0)";
 	} else {
 		default_uv = "vec3(0.0)";
@@ -1393,11 +1397,13 @@ String VisualShaderNodeCubemap::generate_code(Shader::Mode p_mode, VisualShader:
 	return code;
 }
 
-String VisualShaderNodeCubemap::get_input_port_default_hint(int p_port) const {
-	if (p_port == 0) {
-		return "default";
+bool VisualShaderNodeCubemap::is_input_port_default(int p_port, Shader::Mode p_mode) const {
+	if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
+		if (p_port == 0) {
+			return true;
+		}
 	}
-	return "";
+	return false;
 }
 
 void VisualShaderNodeCubemap::set_source(Source p_source) {
@@ -2781,11 +2787,13 @@ String VisualShaderNodeUVFunc::get_input_port_name(int p_port) const {
 	return "";
 }
 
-String VisualShaderNodeUVFunc::get_input_port_default_hint(int p_port) const {
-	if (p_port == 0) {
-		return "UV";
+bool VisualShaderNodeUVFunc::is_input_port_default(int p_port, Shader::Mode p_mode) const {
+	if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
+		if (p_port == 0) {
+			return true;
+		}
 	}
-	return "";
+	return false;
 }
 
 int VisualShaderNodeUVFunc::get_output_port_count() const {
@@ -2809,7 +2817,11 @@ String VisualShaderNodeUVFunc::generate_code(Shader::Mode p_mode, VisualShader::
 
 	String uv;
 	if (p_input_vars[0].is_empty()) {
-		uv = "vec3(UV.xy, 0.0)";
+		if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
+			uv = "vec3(UV.xy, 0.0)";
+		} else {
+			uv = "vec3(0.0)";
+		}
 	} else {
 		uv = vformat("%s", p_input_vars[0]);
 	}
@@ -4966,7 +4978,7 @@ bool VisualShaderNodeTextureUniform::is_code_generated() const {
 
 String VisualShaderNodeTextureUniform::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String default_uv;
-	if (p_mode != Shader::MODE_PARTICLES && p_mode != Shader::MODE_SKY) {
+	if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
 		default_uv = "UV.xy";
 	} else {
 		default_uv = "vec2(0.0)";
@@ -5112,11 +5124,13 @@ void VisualShaderNodeTextureUniform::_bind_methods() {
 	BIND_ENUM_CONSTANT(REPEAT_MAX);
 }
 
-String VisualShaderNodeTextureUniform::get_input_port_default_hint(int p_port) const {
-	if (p_port == 0) {
-		return "default";
+bool VisualShaderNodeTextureUniform::is_input_port_default(int p_port, Shader::Mode p_mode) const {
+	if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
+		if (p_port == 0) {
+			return true;
+		}
 	}
-	return "";
+	return false;
 }
 
 bool VisualShaderNodeTextureUniform::is_qualifier_supported(Qualifier p_qual) const {
@@ -5224,13 +5238,13 @@ String VisualShaderNodeTextureUniformTriplanar::generate_code(Shader::Mode p_mod
 	return code;
 }
 
-String VisualShaderNodeTextureUniformTriplanar::get_input_port_default_hint(int p_port) const {
+bool VisualShaderNodeTextureUniformTriplanar::is_input_port_default(int p_port, Shader::Mode p_mode) const {
 	if (p_port == 0) {
-		return "default";
+		return true;
 	} else if (p_port == 1) {
-		return "default";
+		return true;
 	}
-	return "";
+	return false;
 }
 
 VisualShaderNodeTextureUniformTriplanar::VisualShaderNodeTextureUniformTriplanar() {
@@ -5266,8 +5280,8 @@ String VisualShaderNodeTexture2DArrayUniform::get_input_port_name(int p_port) co
 	return "";
 }
 
-String VisualShaderNodeTexture2DArrayUniform::get_input_port_default_hint(int p_port) const {
-	return "";
+bool VisualShaderNodeTexture2DArrayUniform::is_input_port_default(int p_port, Shader::Mode p_mode) const {
+	return false;
 }
 
 String VisualShaderNodeTexture2DArrayUniform::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
@@ -5339,8 +5353,8 @@ String VisualShaderNodeTexture3DUniform::get_input_port_name(int p_port) const {
 	return "";
 }
 
-String VisualShaderNodeTexture3DUniform::get_input_port_default_hint(int p_port) const {
-	return "";
+bool VisualShaderNodeTexture3DUniform::is_input_port_default(int p_port, Shader::Mode p_mode) const {
+	return false;
 }
 
 String VisualShaderNodeTexture3DUniform::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
@@ -5412,8 +5426,8 @@ String VisualShaderNodeCubemapUniform::get_input_port_name(int p_port) const {
 	return "";
 }
 
-String VisualShaderNodeCubemapUniform::get_input_port_default_hint(int p_port) const {
-	return "";
+bool VisualShaderNodeCubemapUniform::is_input_port_default(int p_port, Shader::Mode p_mode) const {
+	return false;
 }
 
 String VisualShaderNodeCubemapUniform::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
@@ -5738,12 +5752,20 @@ String VisualShaderNodeFresnel::generate_code(Shader::Mode p_mode, VisualShader:
 	String normal;
 	String view;
 	if (p_input_vars[0].is_empty()) {
-		normal = "NORMAL";
+		if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
+			normal = "NORMAL";
+		} else {
+			normal = "vec3(0.0)";
+		}
 	} else {
 		normal = p_input_vars[0];
 	}
 	if (p_input_vars[1].is_empty()) {
-		view = "VIEW";
+		if (p_mode == Shader::MODE_SPATIAL) {
+			view = "VIEW";
+		} else {
+			view = "vec3(0.0)";
+		}
 	} else {
 		view = p_input_vars[1];
 	}
@@ -5759,13 +5781,17 @@ String VisualShaderNodeFresnel::generate_code(Shader::Mode p_mode, VisualShader:
 	}
 }
 
-String VisualShaderNodeFresnel::get_input_port_default_hint(int p_port) const {
+bool VisualShaderNodeFresnel::is_input_port_default(int p_port, Shader::Mode p_mode) const {
 	if (p_port == 0) {
-		return "default";
+		if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
+			return true;
+		}
 	} else if (p_port == 1) {
-		return "default";
+		if (p_mode == Shader::MODE_SPATIAL) {
+			return true;
+		}
 	}
-	return "";
+	return false;
 }
 
 VisualShaderNodeFresnel::VisualShaderNodeFresnel() {

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -280,7 +280,7 @@ public:
 	virtual String get_output_port_name(int p_port) const override;
 	virtual bool is_output_port_expandable(int p_port) const override;
 
-	virtual String get_input_port_default_hint(int p_port) const override;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const override;
 
 	virtual Vector<VisualShader::DefaultTextureParam> get_default_texture_parameters(VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
@@ -392,7 +392,7 @@ public:
 	virtual int get_input_port_count() const override;
 	virtual PortType get_input_port_type(int p_port) const override;
 	virtual String get_input_port_name(int p_port) const override;
-	virtual String get_input_port_default_hint(int p_port) const override;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const override;
 
 	virtual int get_output_port_count() const override;
 	virtual PortType get_output_port_type(int p_port) const override;
@@ -488,7 +488,7 @@ public:
 	virtual int get_input_port_count() const override;
 	virtual PortType get_input_port_type(int p_port) const override;
 	virtual String get_input_port_name(int p_port) const override;
-	virtual String get_input_port_default_hint(int p_port) const override;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const override;
 
 	virtual int get_output_port_count() const override;
 	virtual PortType get_output_port_type(int p_port) const override;
@@ -1103,7 +1103,7 @@ public:
 	virtual int get_input_port_count() const override;
 	virtual PortType get_input_port_type(int p_port) const override;
 	virtual String get_input_port_name(int p_port) const override;
-	virtual String get_input_port_default_hint(int p_port) const override;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const override;
 
 	virtual int get_output_port_count() const override;
 	virtual PortType get_output_port_type(int p_port) const override;
@@ -1986,7 +1986,7 @@ public:
 	virtual int get_input_port_count() const override;
 	virtual PortType get_input_port_type(int p_port) const override;
 	virtual String get_input_port_name(int p_port) const override;
-	virtual String get_input_port_default_hint(int p_port) const override;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const override;
 
 	virtual int get_output_port_count() const override;
 	virtual PortType get_output_port_type(int p_port) const override;
@@ -2036,7 +2036,7 @@ public:
 	virtual PortType get_input_port_type(int p_port) const override;
 	virtual String get_input_port_name(int p_port) const override;
 
-	virtual String get_input_port_default_hint(int p_port) const override;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const override;
 
 	virtual String generate_global_per_node(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_global_per_func(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
@@ -2061,7 +2061,7 @@ public:
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
 
-	virtual String get_input_port_default_hint(int p_port) const override;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const override;
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
@@ -2084,7 +2084,7 @@ public:
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
 
-	virtual String get_input_port_default_hint(int p_port) const override;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const override;
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
@@ -2107,7 +2107,7 @@ public:
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
 
-	virtual String get_input_port_default_hint(int p_port) const override;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const override;
 	virtual String generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
@@ -2200,7 +2200,7 @@ public:
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
 
-	virtual String get_input_port_default_hint(int p_port) const override;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const override;
 	virtual bool is_generate_input_var(int p_port) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -1448,22 +1448,22 @@ bool VisualShaderNodeParticleEmit::is_generate_input_var(int p_port) const {
 	return true;
 }
 
-String VisualShaderNodeParticleEmit::get_input_port_default_hint(int p_port) const {
+bool VisualShaderNodeParticleEmit::is_input_port_default(int p_port, Shader::Mode p_mode) const {
 	switch (p_port) {
 		case 1:
-			return "default";
+			return true;
 		case 2:
-			return "default";
+			return true;
 		case 3:
-			return "default";
+			return true;
 		case 4:
-			return "default";
+			return true;
 		case 5:
-			return "default";
+			return true;
 		case 6:
-			return "default";
+			return true;
 	}
-	return String();
+	return false;
 }
 
 String VisualShaderNodeParticleEmit::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {

--- a/scene/resources/visual_shader_particle_nodes.h
+++ b/scene/resources/visual_shader_particle_nodes.h
@@ -342,7 +342,7 @@ public:
 
 	virtual bool is_show_prop_names() const override;
 	virtual bool is_generate_input_var(int p_port) const override;
-	virtual String get_input_port_default_hint(int p_port) const override;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
 	VisualShaderNodeParticleEmit();

--- a/scene/resources/visual_shader_sdf_nodes.cpp
+++ b/scene/resources/visual_shader_sdf_nodes.cpp
@@ -97,11 +97,11 @@ String VisualShaderNodeScreenUVToSDF::get_output_port_name(int p_port) const {
 	return "";
 }
 
-String VisualShaderNodeScreenUVToSDF::get_input_port_default_hint(int p_port) const {
+bool VisualShaderNodeScreenUVToSDF::is_input_port_default(int p_port, Shader::Mode p_mode) const {
 	if (p_port == 0) {
-		return "default";
+		return true;
 	}
-	return "";
+	return false;
 }
 
 String VisualShaderNodeScreenUVToSDF::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {

--- a/scene/resources/visual_shader_sdf_nodes.h
+++ b/scene/resources/visual_shader_sdf_nodes.h
@@ -66,7 +66,7 @@ public:
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
 
-	virtual String get_input_port_default_hint(int p_port) const override;
+	virtual bool is_input_port_default(int p_port, Shader::Mode p_mode) const override;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 
 	VisualShaderNodeScreenUVToSDF();


### PR DESCRIPTION
Renamed internal method `get_input_port_default_hint` to `is_input_port_default`, changed it's type to boolean for unification, fixes more places with incorrect default hints on certain modes.
