### PR TITLE
Rename request_code_completion signal

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -345,7 +345,7 @@
 			<return type="void" />
 			<argument index="0" name="force" type="bool" default="false" />
 			<description>
-				Emits [signal request_code_completion], if [code]force[/code] is true will bypass all checks. Otherwise will check that the caret is in a word or in front of a prefix. Will ignore the request if all current options are of type file path, node path or signal.
+				Emits [signal code_completion_requested], if [code]force[/code] is true will bypass all checks. Otherwise will check that the caret is in a word or in front of a prefix. Will ignore the request if all current options are of type file path, node path or signal.
 			</description>
 		</method>
 		<method name="set_code_completion_selected_index">
@@ -506,7 +506,7 @@
 				Emitted when a breakpoint is added or removed from a line. If the line is moved via backspace a removed is emitted at the old line.
 			</description>
 		</signal>
-		<signal name="request_code_completion">
+		<signal name="code_completion_requested">
 			<description>
 				Emitted when the user requests code completion.
 			</description>

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -1909,7 +1909,7 @@ CodeTextEditor::CodeTextEditor() {
 	text_editor->connect("gui_input", callable_mp(this, &CodeTextEditor::_text_editor_gui_input));
 	text_editor->connect("caret_changed", callable_mp(this, &CodeTextEditor::_line_col_changed));
 	text_editor->connect("text_changed", callable_mp(this, &CodeTextEditor::_text_changed));
-	text_editor->connect("request_code_completion", callable_mp(this, &CodeTextEditor::_complete_request));
+	text_editor->connect("code_completion_requested", callable_mp(this, &CodeTextEditor::_complete_request));
 	TypedArray<String> cs;
 	cs.push_back(".");
 	cs.push_back(",");

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1793,7 +1793,7 @@ void CodeEdit::request_code_completion(bool p_force) {
 	}
 
 	if (p_force) {
-		emit_signal(SNAME("request_code_completion"));
+		emit_signal(SNAME("code_completion_requested"));
 		return;
 	}
 
@@ -1801,9 +1801,9 @@ void CodeEdit::request_code_completion(bool p_force) {
 	int ofs = CLAMP(get_caret_column(), 0, line.length());
 
 	if (ofs > 0 && (is_in_string(get_caret_line(), ofs) != -1 || _is_char(line[ofs - 1]) || code_completion_prefixes.has(line[ofs - 1]))) {
-		emit_signal(SNAME("request_code_completion"));
+		emit_signal(SNAME("code_completion_requested"));
 	} else if (ofs > 1 && line[ofs - 1] == ' ' && code_completion_prefixes.has(line[ofs - 2])) {
-		emit_signal(SNAME("request_code_completion"));
+		emit_signal(SNAME("code_completion_requested"));
 	}
 }
 
@@ -2261,7 +2261,7 @@ void CodeEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("breakpoint_toggled", PropertyInfo(Variant::INT, "line")));
 
 	/* Code Completion */
-	ADD_SIGNAL(MethodInfo("request_code_completion"));
+	ADD_SIGNAL(MethodInfo("code_completion_requested"));
 
 	/* Symbol lookup */
 	ADD_SIGNAL(MethodInfo("symbol_lookup", PropertyInfo(Variant::STRING, "symbol"), PropertyInfo(Variant::INT, "line"), PropertyInfo(Variant::INT, "column")));

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -2812,7 +2812,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 	}
 
 	SUBCASE("[CodeEdit] autocomplete request") {
-		SIGNAL_WATCH(code_edit, "request_code_completion");
+		SIGNAL_WATCH(code_edit, "code_completion_requested");
 		code_edit->set_code_completion_enabled(true);
 
 		Array signal_args;
@@ -2820,13 +2820,13 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 		/* Force request. */
 		code_edit->request_code_completion();
-		SIGNAL_CHECK_FALSE("request_code_completion");
+		SIGNAL_CHECK_FALSE("code_completion_requested");
 		code_edit->request_code_completion(true);
-		SIGNAL_CHECK("request_code_completion", signal_args);
+		SIGNAL_CHECK("code_completion_requested", signal_args);
 
 		/* Manual request should force. */
 		SEND_GUI_ACTION(code_edit, "ui_text_completion_query");
-		SIGNAL_CHECK("request_code_completion", signal_args);
+		SIGNAL_CHECK("code_completion_requested", signal_args);
 
 		/* Insert prefix. */
 		TypedArray<String> completion_prefixes;
@@ -2835,12 +2835,12 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 
 		code_edit->insert_text_at_caret(".");
 		code_edit->request_code_completion();
-		SIGNAL_CHECK("request_code_completion", signal_args);
+		SIGNAL_CHECK("code_completion_requested", signal_args);
 
 		/* Should work with space too. */
 		code_edit->insert_text_at_caret(" ");
 		code_edit->request_code_completion();
-		SIGNAL_CHECK("request_code_completion", signal_args);
+		SIGNAL_CHECK("code_completion_requested", signal_args);
 
 		/* Should work when complete ends with prefix. */
 		code_edit->clear();
@@ -2849,9 +2849,9 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 		code_edit->update_code_completion_options();
 		code_edit->confirm_code_completion();
 		CHECK(code_edit->get_line(0) == "test.");
-		SIGNAL_CHECK("request_code_completion", signal_args);
+		SIGNAL_CHECK("code_completion_requested", signal_args);
 
-		SIGNAL_UNWATCH(code_edit, "request_code_completion");
+		SIGNAL_UNWATCH(code_edit, "code_completion_requested");
 	}
 
 	SUBCASE("[CodeEdit] autocomplete completion") {


### PR DESCRIPTION
The signal clashed with method name.
I renamed it to `code_completion_requested`, but feel free to suggest a better name.