### PR TITLE
Rename buttons in disk_changed dialog

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6926,10 +6926,12 @@ EditorNode::EditorNode() {
 
 		disk_changed->connect("confirmed", callable_mp(this, &EditorNode::_reload_modified_scenes));
 		disk_changed->connect("confirmed", callable_mp(this, &EditorNode::_reload_project_settings));
-		disk_changed->get_ok_button()->set_text(TTR("Reload"));
+		disk_changed->get_ok_button()->set_text(TTR("Reload From Disk (Discard Local Changes)"));
 
-		disk_changed->add_button(TTR("Resave"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
+		disk_changed->add_button(TTR("Save Local Changes"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
 		disk_changed->connect("custom_action", callable_mp(this, &EditorNode::_resave_scenes));
+
+		disk_changed->get_cancel_button()->set_text(TTR("Do Nothing"))
 	}
 
 	gui_base->add_child(disk_changed);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6931,7 +6931,7 @@ EditorNode::EditorNode() {
 		disk_changed->add_button(TTR("Save Local Changes"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
 		disk_changed->connect("custom_action", callable_mp(this, &EditorNode::_resave_scenes));
 
-		disk_changed->get_cancel_button()->set_text(TTR("Do Nothing"))
+		disk_changed->get_cancel_button()->set_text(TTR("Do Nothing"));
 	}
 
 	gui_base->add_child(disk_changed);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3848,10 +3848,12 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 		disk_changed_list->set_v_size_flags(SIZE_EXPAND_FILL);
 
 		disk_changed->connect("confirmed", callable_mp(this, &ScriptEditor::_reload_scripts));
-		disk_changed->get_ok_button()->set_text(TTR("Reload"));
+		disk_changed->get_ok_button()->set_text(TTR("Reload From Disk (Discard Local Changes)"));
 
-		disk_changed->add_button(TTR("Resave"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
+		disk_changed->add_button(TTR("Save Local Changes"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
 		disk_changed->connect("custom_action", callable_mp(this, &ScriptEditor::_resave_scripts));
+
+		disk_changed->get_cancel_button()->set_text(TTR("Do Nothing"))
 	}
 
 	add_child(disk_changed);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3853,7 +3853,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 		disk_changed->add_button(TTR("Save Local Changes"), !DisplayServer::get_singleton()->get_swap_cancel_ok(), "resave");
 		disk_changed->connect("custom_action", callable_mp(this, &ScriptEditor::_resave_scripts));
 
-		disk_changed->get_cancel_button()->set_text(TTR("Do Nothing"))
+		disk_changed->get_cancel_button()->set_text(TTR("Do Nothing"));
 	}
 
 	add_child(disk_changed);


### PR DESCRIPTION
"The following files are newer on disk" dialog buttons:
Resave → Save Local Changes
Reload → Reload From Disk (Discard Local Changes)
Cancel → Do Nothing

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/3456.*