### PR TITLE
`SpriteFramesEditor` Show `AtlasTexture`'s source texture path in the frame's tooltip

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -821,19 +821,30 @@ void SpriteFramesEditor::_update_library(bool p_skip_selector) {
 
 	for (int i = 0; i < frames->get_frame_count(edited_anim); i++) {
 		String name;
-		Ref<Texture2D> icon;
+		Ref<Texture> frame = frames->get_frame(edited_anim, i);
 
-		if (frames->get_frame(edited_anim, i).is_null()) {
+		if (frame.is_null()) {
 			name = itos(i) + ": " + TTR("(empty)");
-
 		} else {
-			name = itos(i) + ": " + frames->get_frame(edited_anim, i)->get_name();
-			icon = frames->get_frame(edited_anim, i);
+			name = itos(i) + ": " + frame->get_name();
 		}
 
-		tree->add_item(name, icon);
-		if (frames->get_frame(edited_anim, i).is_valid()) {
-			tree->set_item_tooltip(tree->get_item_count() - 1, frames->get_frame(edited_anim, i)->get_path());
+		tree->add_item(name, frame);
+		if (frame.is_valid()) {
+			String tooltip = frame->get_path();
+
+			// Frame is often saved as an AtlasTexture subresource within a scene/resource file,
+			// thus its path might be not what the user is looking for. So we're also showing
+			// subsequent source texture paths.
+			String prefix = String::utf8("┖╴");
+			Ref<AtlasTexture> at = frame;
+			while (at.is_valid() && at->get_atlas().is_valid()) {
+				tooltip += "\n" + prefix + at->get_atlas()->get_path();
+				prefix = "    " + prefix;
+				at = at->get_atlas();
+			}
+
+			tree->set_item_tooltip(tree->get_item_count() - 1, tooltip);
 		}
 		if (sel == i) {
 			tree->select(tree->get_item_count() - 1);


### PR DESCRIPTION
Resolves #57059.

In `SpriteFramesEditor` the texture path shown in the frame's tooltip was correct but since frame is often saved as an `AtlasTexture` subresource within a scene/resource file its path might be not what the user is looking for. So now also subsequent source texture paths are being shown. Only for `AtlasTexture` though (won't work for `ProxyTexture` etc.) but that's the most common case as `AtlasTexture`s are generated when adding frames using _Add Frames from a Sprite Sheet_ dialog. So should be good enough.

I made tooltip look/formatting similar to the output of `Node::print_tree_pretty()`.

- Before (`3.4.2.stable`):

![GY5uaj7VnU](https://user-images.githubusercontent.com/9283098/150646523-018132f6-71c9-4d3e-8d7f-dea9959936b9.png)

- After (`3.x` build):

![Ku2zBesPaS](https://user-images.githubusercontent.com/9283098/150646529-c2a56ba6-95e3-4735-8c39-6248ddaed4e0.png)
With subsequent `AtlasTexture`:
![ozStNwBtGt](https://user-images.githubusercontent.com/9283098/150646532-15d07ad5-ac52-4a09-b711-05b11ced9ac5.png)

