### PR TITLE
[Net] Fix get_response_body_length for large files.

### DIFF
--- a/core/io/http_client.h
+++ b/core/io/http_client.h
@@ -180,7 +180,7 @@ public:
 	virtual bool is_response_chunked() const = 0;
 	virtual int get_response_code() const = 0;
 	virtual Error get_response_headers(List<String> *r_response) = 0;
-	virtual int get_response_body_length() const = 0;
+	virtual int64_t get_response_body_length() const = 0;
 
 	virtual PackedByteArray read_response_body_chunk() = 0; // Can't get body as partial text because of most encodings UTF8, gzip, etc.
 

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -534,7 +534,7 @@ Error HTTPClientTCP::poll() {
 	return OK;
 }
 
-int HTTPClientTCP::get_response_body_length() const {
+int64_t HTTPClientTCP::get_response_body_length() const {
 	return body_size;
 }
 

--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -87,7 +87,7 @@ public:
 	bool is_response_chunked() const override;
 	int get_response_code() const override;
 	Error get_response_headers(List<String> *r_response) override;
-	int get_response_body_length() const override;
+	int64_t get_response_body_length() const override;
 	PackedByteArray read_response_body_chunk() override;
 	void set_blocking_mode(bool p_enable) override;
 	bool is_blocking_mode_enabled() const override;

--- a/platform/javascript/http_client_javascript.cpp
+++ b/platform/javascript/http_client_javascript.cpp
@@ -143,7 +143,7 @@ Error HTTPClientJavaScript::get_response_headers(List<String> *r_response) {
 	return OK;
 }
 
-int HTTPClientJavaScript::get_response_body_length() const {
+int64_t HTTPClientJavaScript::get_response_body_length() const {
 	return godot_js_fetch_body_length_get(js_id);
 }
 

--- a/platform/javascript/http_client_javascript.h
+++ b/platform/javascript/http_client_javascript.h
@@ -95,7 +95,7 @@ public:
 	bool is_response_chunked() const override;
 	int get_response_code() const override;
 	Error get_response_headers(List<String> *r_response) override;
-	int get_response_body_length() const override;
+	int64_t get_response_body_length() const override;
 	PackedByteArray read_response_body_chunk() override;
 	void set_blocking_mode(bool p_enable) override;
 	bool is_blocking_mode_enabled() const override;


### PR DESCRIPTION
Parsing was fixed, but not the return value for the exposed getter.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
