### PR TITLE
Fix saving .tres file with Dictionary/Array containing Resources does not work

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1695,7 +1695,6 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 		takeover_paths = false;
 	}
 
-	// Save resources.
 	_find_resources(p_resource, true);
 
 	if (packed_scene.is_valid()) {


### PR DESCRIPTION
NOTE: Probably superseded by https://github.com/godotengine/godot/pull/62318

Fixes #55885

After some discussion (see comments) and thinking I came to this solution.
The check, if a resource should be saved by checking whether it or its sub-resources have been edited now takes arrays and dictionaries into account.

I also tried changing the logic in the saving done by the `ResourceFormatSaverTextInstance`(`resource_format_text.cpp`), but found some problems/insecurities doing so:
1. The logic in there is a bit different for `PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT` 
and `res->get_path().is_resource_file()`.
2. I'm not sure if `editor_node.cpp` is only calling the save method of `ResourceFormatSaverText`. If not, then other subclasses of the `ResourceFormatSaver` needs to be adjusted as well (e.g. `ResourceFormatSaverBinaryInstance`, logic in here looks very similar).
3. If a subresource was edited, we still need to save the whole main resource, otherwise data will be lost.

Example: A.tres
```
Array (first)
- [0] Array (second)
---- [0] String (edited)
- [1] String
```
Now if we were to save only the edited part, we would save the second array because the string in it was edited, and lose the first array and the file will be corrupt as a result.

So if we want to remove the logic in `editor_node.cpp` and let the `resource_format_text.cpp` do the whole job, it needs to be refactored to save the whole resource when at least one subresource was edited (and of course the other two points need to be clarified).
