### PR TITLE
[Editor] Disable contextual alternates (coding ligatures) outside of code editor.

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -270,6 +270,9 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	/* Hack */
 
 	Ref<FontData> dfmono = load_cached_internal_font(_font_JetBrainsMono_Regular, _font_JetBrainsMono_Regular_size, font_hinting, font_antialiased, true);
+	Dictionary opentype_features;
+	opentype_features["calt"] = 0;
+	dfmono->set_opentype_feature_overrides(opentype_features); // Disable contextual alternates (coding ligatures).
 
 	// Default font
 	MAKE_DEFAULT_FONT(df, String());


### PR DESCRIPTION
Add override for the default JetBrains Mono OT features. Code editor have its own OpenType feature set, controlled from the editor settings, and is not affected by the change.

![Screenshot 2022-01-23 at 11 22 26](https://user-images.githubusercontent.com/7645683/150672259-53e2410f-9581-4212-8858-954dff6c89c4.png)

