### PR TITLE
[3.x] Improve `Navigation2D` default settings

### DIFF
--- a/doc/classes/Navigation2D.xml
+++ b/doc/classes/Navigation2D.xml
@@ -41,10 +41,10 @@
 		</method>
 	</methods>
 	<members>
-		<member name="cell_size" type="float" setter="set_cell_size" getter="get_cell_size" default="10.0">
+		<member name="cell_size" type="float" setter="set_cell_size" getter="get_cell_size" default="1.0">
 			The XY plane cell size to use for fields.
 		</member>
-		<member name="edge_connection_margin" type="float" setter="set_edge_connection_margin" getter="get_edge_connection_margin" default="100.0">
+		<member name="edge_connection_margin" type="float" setter="set_edge_connection_margin" getter="get_edge_connection_margin" default="1.0">
 			This value is used to detect the near edges to connect compatible regions.
 		</member>
 	</members>

--- a/scene/2d/navigation_2d.cpp
+++ b/scene/2d/navigation_2d.cpp
@@ -84,8 +84,8 @@ RID Navigation2D::get_closest_point_owner(const Vector2 &p_point) const {
 
 Navigation2D::Navigation2D() {
 	map = Navigation2DServer::get_singleton()->map_create();
-	set_cell_size(10); // Ten pixels
-	set_edge_connection_margin(100);
+	set_cell_size(1); // One pixel
+	set_edge_connection_margin(1);
 }
 
 Navigation2D::~Navigation2D() {


### PR DESCRIPTION
Fixes #56852 (main issue of it - another things should be extracted to another issue)

This commit reduces `cell_size` and `edge_connection_margin` default
values so that `Navigation2D` behaves more like in Godot <= `3.4` by default.

This way people coming from Godot <= `3.4` will not experience non-obvious errors.
