### PR TITLE
Fix mouse position not being scaled when window size is changed

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -790,7 +790,7 @@ void Viewport::update_canvas_items() {
 }
 
 void Viewport::_set_size(const Size2i &p_size, const Size2i &p_size_2d_override, const Rect2i &p_to_screen_rect, const Transform2D &p_stretch_transform, bool p_allocated) {
-	if (size == p_size && size_allocated == p_allocated && stretch_transform == p_stretch_transform && p_size_2d_override == size_2d_override && to_screen_rect != p_to_screen_rect) {
+	if (size == p_size && size_allocated == p_allocated && stretch_transform == p_stretch_transform && p_size_2d_override == size_2d_override && to_screen_rect == p_to_screen_rect) {
 		return;
 	}
 
@@ -1090,7 +1090,7 @@ Transform2D Viewport::_get_input_pre_xform() const {
 
 	if (to_screen_rect.size.x != 0 && to_screen_rect.size.y != 0) {
 		pre_xf.elements[2] = -to_screen_rect.position;
-		pre_xf.scale(size / to_screen_rect.size);
+		pre_xf.scale(Vector2(size) / to_screen_rect.size);
 	}
 
 	return pre_xf;


### PR DESCRIPTION
Currently, when the window size is changed, the `Viewport`'s `to_screen_rect` variable is not updated. Furthermore, when it is updated, the ratio of windows size to viewport size is calculated using integer division, which generally results in a value of 0 or 1 for each dimension. This PR fixes both issues.

Fixes #44915
Fixes #50802
Fixes #52295
