### PR TITLE
Fix `'` in file name gets incorrectly escaped when dragged to script editor

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3767,7 +3767,7 @@ String String::c_unescape() const {
 	return escaped;
 }
 
-String String::c_escape() const {
+String String::c_escape(bool escape_single_quotes) const {
 	String escaped = *this;
 	escaped = escaped.replace("\\", "\\\\");
 	escaped = escaped.replace("\a", "\\a");
@@ -3777,7 +3777,8 @@ String String::c_escape() const {
 	escaped = escaped.replace("\r", "\\r");
 	escaped = escaped.replace("\t", "\\t");
 	escaped = escaped.replace("\v", "\\v");
-	escaped = escaped.replace("\'", "\\'");
+	if (escape_single_quotes == true)
+		escaped = escaped.replace("\'", "\\'");
 	escaped = escaped.replace("\?", "\\?");
 	escaped = escaped.replace("\"", "\\\"");
 

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -410,7 +410,7 @@ public:
 	String xml_unescape() const;
 	String uri_encode() const;
 	String uri_decode() const;
-	String c_escape() const;
+	String c_escape(bool escape_single_quotes = true) const;
 	String c_escape_multiline() const;
 	String c_unescape() const;
 	String json_escape() const;

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -70,8 +70,9 @@
 		</method>
 		<method name="c_escape" qualifiers="const">
 			<return type="String" />
+			<argument index="0" name="escape_single_quotes" type="bool" />
 			<description>
-				Returns a copy of the string with special characters escaped using the C language standard.
+				Returns a copy of the string with special characters escaped using the C language standard. Does not escape single quotes if argument [code]is_single_quotes[/code] is false.
 			</description>
 		</method>
 		<method name="c_unescape" qualifiers="const">

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1430,6 +1430,10 @@ static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const
 void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
 	const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
 
+	bool is_single_quotes = false;
+	if (quote_style == "'")
+		is_single_quotes = true;
+
 	Dictionary d = p_data;
 
 	CodeEdit *te = code_editor->get_text_editor();
@@ -1464,9 +1468,9 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			}
 
 			if (preload) {
-				text_to_drop += "preload(" + String(files[i]).c_escape().quote(quote_style) + ")";
+				text_to_drop += "preload(" + String(files[i]).c_escape(is_single_quotes).quote(quote_style) + ")";
 			} else {
-				text_to_drop += String(files[i]).c_escape().quote(quote_style);
+				text_to_drop += String(files[i]).c_escape(is_single_quotes).quote(quote_style);
 			}
 		}
 
@@ -1497,7 +1501,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 			}
 
 			String path = sn->get_path_to(node);
-			text_to_drop += path.c_escape().quote(quote_style);
+			text_to_drop += path.c_escape(is_single_quotes).quote(quote_style);
 		}
 
 		te->set_caret_line(row);
@@ -1506,7 +1510,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 	}
 
 	if (d.has("type") && String(d["type"]) == "obj_property") {
-		const String text_to_drop = String(d["property"]).c_escape().quote(quote_style);
+		const String text_to_drop = String(d["property"]).c_escape(is_single_quotes).quote(quote_style);
 
 		te->set_caret_line(row);
 		te->set_caret_column(col);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

This is a potential fix for issue #56263 (' in file name gets incorrectly escaped when dragged to script editor). This modifies the c_escape function to take in a parameter "escape_single_quotes" that is true by default. It is now possible to manually specify that single quotes should not be escaped if the "escape_single_quotes" argument is false.

This is my first ever contribution to an open-source project, so apologies for any mistakes.

<i>Bugsquad edit:</i>
- Fix https://github.com/godotengine/godot/issues/56263