### PR TITLE
Fix buggy behavior of the "Add tab" button in the scene tabs

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -384,6 +384,7 @@ private:
 	HBoxContainer *tabbar_container;
 	Button *distraction_free;
 	Button *scene_tab_add;
+	Control *scene_tab_add_ph;
 
 	bool scene_distraction;
 	bool script_distraction;


### PR DESCRIPTION
- Fix error message related to reposition the button when the tabs get out of their clipped state.
- Fix the button intersectioning with the offset tab buttons when tabs are clipped. 
- Make that when the tabs are clipped the button goes to a fixed point to the right instead of the left.