### PR TITLE
Fix incorrect unused local var warning in shader blocks

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -5208,9 +5208,15 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 #ifdef DEBUG_ENABLED
 				if (check_warnings) {
 					StringName func_name;
+					BlockNode *b = p_block;
 
-					if (p_block && p_block->parent_function) {
-						func_name = p_block->parent_function->name;
+					while (b) {
+						if (b->parent_function) {
+							func_name = b->parent_function->name;
+							break;
+						} else {
+							b = b->parent_block;
+						}
 					}
 
 					_parse_used_identifier(identifier, ident_type, func_name);


### PR DESCRIPTION
Fix incorrect warnings in volumetric cloud demo shader: 
![image](https://user-images.githubusercontent.com/3036176/150690212-7edb3944-c435-4854-9f24-566d95e4b47b.png)

