### PR TITLE
Add Placeholder to TextEdit

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -992,6 +992,12 @@
 		<member name="override_selected_font_color" type="bool" setter="set_override_selected_font_color" getter="is_overriding_selected_font_color" default="false">
 			If [code]true[/code], custom [code]font_selected_color[/code] will be used for selected text.
 		</member>
+		<member name="placeholder_alpha" type="float" setter="set_placeholder_alpha" getter="get_placeholder_alpha" default="0.6">
+			Opacity of the [member placeholder_text]. From [code]0[/code] to [code]1[/code].
+		</member>
+		<member name="placeholder_text" type="String" setter="set_placeholder" getter="get_placeholder" default="&quot;&quot;">
+			Text shown when the [TextEdit] is empty. It is [b]not[/b] the [TextEdit]'s default value (see [member text]).
+		</member>
 		<member name="scroll_horizontal" type="int" setter="set_h_scroll" getter="get_h_scroll" default="0">
 			If there is a horizontal scrollbar, this determines the current horizontal scroll value in pixels.
 		</member>

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -189,6 +189,7 @@ private:
 		int get_max_width() const;
 
 		void set_width(float p_width);
+		float get_width() const;
 		int get_line_wrap_amount(int p_line) const;
 
 		Vector<Vector2i> get_line_wrap_ranges(int p_line) const;
@@ -248,6 +249,19 @@ private:
 	// Text properties.
 	String ime_text = "";
 	Point2 ime_selection;
+
+	// Placeholder
+	float placeholder_alpha = 0.6;
+
+	String placeholder_text = "";
+	Array placeholder_bidi_override;
+	Ref<TextParagraph> placeholder_data_buf;
+	int placeholder_line_height = -1;
+	int placeholder_max_width = -1;
+
+	Vector<String> placeholder_wraped_rows;
+
+	void _update_placeholder();
 
 	/* Initialise to opposite first, so we get past the early-out in set_editable. */
 	bool editable = false;
@@ -666,6 +680,12 @@ public:
 	void set_text(const String &p_text);
 	String get_text() const;
 	int get_line_count() const;
+
+	void set_placeholder(const String &p_text);
+	String get_placeholder() const;
+
+	void set_placeholder_alpha(float p_alpha);
+	float get_placeholder_alpha() const;
 
 	void set_line(int p_line, const String &p_new_text);
 	String get_line(int p_line) const;


### PR DESCRIPTION
Adds a placeholder to `TextEdit` following the same naming scheme in `LineEdit`. Supports wrapping, newlines and scrolling. 

Uses the same draw loop thanks to the `TextServer` abstractions, though does not appear on the minimap.

closes godotengine/godot-proposals/issues/1995