### PR TITLE
BaseButton: Rename `pressed` property to `button_pressed`

### DIFF
--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -38,7 +38,7 @@
 			<return type="void" />
 			<argument index="0" name="pressed" type="bool" />
 			<description>
-				Changes the [member pressed] state of the button, without emitting [signal toggled]. Use when you just want to change the state of the button without sending the pressed event (e.g. when initializing scene). Only works if [member toggle_mode] is [code]true[/code].
+				Changes the [member button_pressed] state of the button, without emitting [signal toggled]. Use when you just want to change the state of the button without sending the pressed event (e.g. when initializing scene). Only works if [member toggle_mode] is [code]true[/code].
 				[b]Note:[/b] This method doesn't unpress other buttons in [member button_group].
 			</description>
 		</method>
@@ -54,6 +54,10 @@
 			Binary mask to choose which mouse buttons this button will respond to.
 			To allow both left-click and right-click, use [code]MOUSE_BUTTON_MASK_LEFT | MOUSE_BUTTON_MASK_RIGHT[/code].
 		</member>
+		<member name="button_pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
+			If [code]true[/code], the button's state is pressed. Means the button is pressed down or toggled (if [member toggle_mode] is active). Only works if [member toggle_mode] is [code]true[/code].
+			[b]Note:[/b] Setting [member button_pressed] will result in [signal toggled] to be emitted. If you want to change the pressed state without emitting that signal, use [method set_pressed_no_signal].
+		</member>
 		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
 			If [code]true[/code], the button is in disabled state and can't be clicked or toggled.
 		</member>
@@ -61,10 +65,6 @@
 		<member name="keep_pressed_outside" type="bool" setter="set_keep_pressed_outside" getter="is_keep_pressed_outside" default="false">
 			If [code]true[/code], the button stays pressed when moving the cursor outside the button while pressing it.
 			[b]Note:[/b] This property only affects the button's visual appearance. Signals will be emitted at the same moment regardless of this property's value.
-		</member>
-		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
-			If [code]true[/code], the button's state is pressed. Means the button is pressed down or toggled (if [member toggle_mode] is active). Only works if [member toggle_mode] is [code]true[/code].
-			[b]Note:[/b] Setting [member pressed] will result in [signal toggled] to be emitted. If you want to change the pressed state without emitting that signal, use [method set_pressed_no_signal].
 		</member>
 		<member name="shortcut" type="Shortcut" setter="set_shortcut" getter="get_shortcut">
 			[Shortcut] associated to the button.

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MSBuildPanel.cs
@@ -147,7 +147,7 @@ namespace GodotTools.Build
                 Icon = GetThemeIcon("StatusError", "EditorIcons"),
                 ExpandIcon = false,
                 ToggleMode = true,
-                Pressed = true,
+                ButtonPressed = true,
                 FocusMode = FocusModeEnum.None
             };
             _errorsBtn.Toggled += ErrorsToggled;
@@ -159,7 +159,7 @@ namespace GodotTools.Build
                 Icon = GetThemeIcon("NodeWarning", "EditorIcons"),
                 ExpandIcon = false,
                 ToggleMode = true,
-                Pressed = true,
+                ButtonPressed = true,
                 FocusMode = FocusModeEnum.None
             };
             _warningsBtn.Toggled += WarningsToggled;
@@ -169,7 +169,7 @@ namespace GodotTools.Build
             {
                 Text = "Show Output".TTR(),
                 ToggleMode = true,
-                Pressed = true,
+                ButtonPressed = true,
                 FocusMode = FocusModeEnum.None
             };
             _viewLogBtn.Toggled += ViewLogToggled;

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -428,7 +428,7 @@ namespace GodotTools
                 Shortcut = buildSolutionShortcut,
                 ShortcutInTooltip = true
             };
-            _toolBarBuildButton.PressedSignal += BuildSolutionPressed;
+            _toolBarBuildButton.Pressed += BuildSolutionPressed;
             AddControlToContainer(CustomControlContainer.Toolbar, _toolBarBuildButton);
 
             if (File.Exists(GodotSharpDirs.ProjectSlnPath) && File.Exists(GodotSharpDirs.ProjectCsProjPath))

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -444,7 +444,7 @@ void BaseButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "disabled"), "set_disabled", "is_disabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "toggle_mode"), "set_toggle_mode", "is_toggle_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shortcut_in_tooltip"), "set_shortcut_in_tooltip", "is_shortcut_in_tooltip_enabled");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "button_pressed"), "set_pressed", "is_pressed");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "action_mode", PROPERTY_HINT_ENUM, "Button Press,Button Release"), "set_action_mode", "get_action_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_mask", PROPERTY_HINT_FLAGS, "Mouse Left, Mouse Right, Mouse Middle"), "set_button_mask", "get_button_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_pressed_outside"), "set_keep_pressed_outside", "is_keep_pressed_outside");


### PR DESCRIPTION
This fixes a conflict with the `pressed` signal.

The new name is temporary and only intended to solve the conflict for upcoming
alpha builds. Discussions are still ongoing regarding the BaseButton API and
how to rename and refactor more of its properties, signals and methods to have
a clearer API in 4.0.

Fixes the last remaining issue in #38937.

Related to #48193 where there was significant discussion on what to rename to what, but no consensus yet. This much simpler rename here was agreed upon with @pycbouh and @KoBeWi as a temporary workaround for 4.0 alpha 1. A proposal will be open to continue the discussion from #48193 and find a consensus.

**Note:** Mono was special casing this by renaming the `pressed` signal to `PressedSignal` to avoid the conflict with the `Pressed` property. [This is done automatically in case of conflict](https://github.com/godotengine/godot/blob/81c28dd706913e66288e847772d5ea0e64e7c80c/modules/mono/editor/bindings_generator.cpp#L2893-L2900), so this rename also automatically changed this (the signal is now `Pressed`, the property is `ButtonPressed`).