### PR TITLE
Bring reusable variables out of while loop

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -523,6 +523,13 @@ void Viewport::_process_picking() {
 
 	_drop_physics_mouseover(true);
 
+#ifndef _3D_DISABLED
+	Vector2 last_pos(1e20, 1e20);
+	CollisionObject3D *last_object = nullptr;
+	ObjectID last_id;
+	PhysicsDirectSpaceState3D::RayResult result;
+#endif // _3D_DISABLED
+
 	PhysicsDirectSpaceState2D *ss2d = PhysicsServer2D::get_singleton()->space_get_direct_state(find_world_2d()->get_space());
 
 	if (physics_has_last_mousepos) {
@@ -690,10 +697,6 @@ void Viewport::_process_picking() {
 		}
 
 #ifndef _3D_DISABLED
-		Vector2 last_pos(1e20, 1e20);
-		CollisionObject3D *last_object = nullptr;
-		ObjectID last_id;
-		PhysicsDirectSpaceState3D::RayResult result;
 		bool captured = false;
 
 		if (physics_object_capture.is_valid()) {


### PR DESCRIPTION
In Viewport `_process_picking` reusable variables for 3D collision object input detection, are declared inside while loop, so their values are re-set on each cycle. These variables used to be declared outside the loop but changed by #50147
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
