### PR TITLE
Add clarification to tile_set_modulate

### DIFF
--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -427,6 +427,7 @@
 			<argument index="1" name="color" type="Color" />
 			<description>
 				Sets the tile's modulation color.
+				[b]Note:[/b] Modulation is performed by setting the tile's vertex color. To access this in a shader, use [code]COLOR[/code] rather than [code]MODULATE[/code] (which instead accesses the [TileMap]'s [member CanvasItem.modulate] property).
 			</description>
 		</method>
 		<method name="tile_set_name">

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -427,7 +427,7 @@
 			<argument index="1" name="color" type="Color" />
 			<description>
 				Sets the tile's modulation color.
-				[b]Note:[/b] Modulation is performed by setting the tile's vertex color. To access this in a shader, use [code]COLOR[/code] rather than [code]MODULATE[/code] (which instead accesses the [TileMap]'s [member TileMap.modulate] property).
+				[b]Note:[/b] Modulation is performed by setting the tile's vertex color. To access this in a shader, use [code]COLOR[/code] rather than [code]MODULATE[/code] (which instead accesses the [TileMap]'s [member CanvasItem.modulate] property).
 			</description>
 		</method>
 		<method name="tile_set_name">

--- a/doc/classes/TileSet.xml
+++ b/doc/classes/TileSet.xml
@@ -427,6 +427,7 @@
 			<argument index="1" name="color" type="Color" />
 			<description>
 				Sets the tile's modulation color.
+				[b]Note:[/b] Modulation is performed by setting the tile's vertex color. To access this in a shader, use [code]COLOR[/code] rather than [code]MODULATE[/code] (which instead accesses the [TileMap]'s [member TileMap.modulate] property).
 			</description>
 		</method>
 		<method name="tile_set_name">

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -373,7 +373,7 @@ def main():  # type: () -> None
 
     for path in args.path:
         # Cut off trailing slashes so os.path.basename doesn't choke.
-        if path.endswith(os.sep):
+        if path.endswith("/") or path.endswith("\\"):
             path = path[:-1]
 
         if os.path.basename(path) == "modules":

--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -355,18 +355,20 @@ void InputDefault::_parse_input_event_impl(const Ref<InputEvent> &p_event, bool 
 	Ref<InputEventMouseMotion> mm = p_event;
 
 	if (mm.is_valid()) {
-		Point2 pos = mm->get_global_position();
-		if (mouse_pos != pos) {
-			set_mouse_position(pos);
+		Point2 position = mm->get_global_position();
+		if (mouse_pos != position) {
+			set_mouse_position(position);
 		}
+		Vector2 relative = mm->get_relative();
+		mouse_speed_track.update(relative);
 
 		if (main_loop && emulate_touch_from_mouse && !p_is_emulated && mm->get_button_mask() & 1) {
 			Ref<InputEventScreenDrag> drag_event;
 			drag_event.instance();
 
-			drag_event->set_position(mm->get_position());
-			drag_event->set_relative(mm->get_relative());
-			drag_event->set_speed(mm->get_speed());
+			drag_event->set_position(position);
+			drag_event->set_relative(relative);
+			drag_event->set_speed(get_last_mouse_speed());
 
 			main_loop->input_event(drag_event);
 		}
@@ -552,7 +554,6 @@ void InputDefault::set_main_loop(MainLoop *p_main_loop) {
 }
 
 void InputDefault::set_mouse_position(const Point2 &p_posf) {
-	mouse_speed_track.update(p_posf - mouse_pos);
 	mouse_pos = p_posf;
 }
 

--- a/modules/gdnative/doc_classes/GDNativeLibrary.xml
+++ b/modules/gdnative/doc_classes/GDNativeLibrary.xml
@@ -7,8 +7,8 @@
 		A GDNative library can implement [NativeScript]s, global functions to call with the [GDNative] class, or low-level engine extensions through interfaces such as [ARVRInterfaceGDNative]. The library must be compiled for each platform and architecture that the project will run on.
 	</description>
 	<tutorials>
-		<link>$DOCS_URL/tutorials/scripting/gdnative/gdnative-c-example.html</link>
-		<link>$DOCS_URL/tutorials/scripting/gdnative/gdnative-cpp-example.html</link>
+		<link>$DOCS_URL/tutorials/scripting/gdnative/gdnative_c_example.html</link>
+		<link>$DOCS_URL/tutorials/scripting/gdnative/gdnative_cpp_example.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_current_dependencies" qualifiers="const">

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -316,7 +316,6 @@ void OS_JavaScript::mouse_move_callback(double p_x, double p_y, double p_rel_x, 
 	ev->set_global_position(ev->get_position());
 
 	ev->set_relative(Vector2(p_rel_x, p_rel_y));
-	os->input->set_mouse_position(ev->get_position());
 	ev->set_speed(os->input->get_last_mouse_speed());
 
 	os->input->parse_input_event(ev);

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -806,7 +806,6 @@ static void _mouseDownEvent(NSEvent *event, int index, int mask, bool pressed) {
 	mm->set_relative(relativeMotion);
 	get_key_modifier_state([event modifierFlags], mm);
 
-	OS_OSX::singleton->input->set_mouse_position(Point2(mouse_x, mouse_y));
 	OS_OSX::singleton->push_input(mm);
 }
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -401,7 +401,6 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 
 				mm->set_position(c);
 				mm->set_global_position(c);
-				input->set_mouse_position(c);
 				mm->set_speed(Vector2(0, 0));
 
 				if (raw->data.mouse.usFlags == MOUSE_MOVE_RELATIVE) {
@@ -508,7 +507,6 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 						SetCursorPos(pos.x, pos.y);
 					}
 
-					input->set_mouse_position(mm->get_position());
 					mm->set_speed(input->get_last_mouse_speed());
 
 					if (old_invalid) {
@@ -652,7 +650,6 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 				SetCursorPos(pos.x, pos.y);
 			}
 
-			input->set_mouse_position(mm->get_position());
 			mm->set_speed(input->get_last_mouse_speed());
 
 			if (old_invalid) {
@@ -754,7 +751,6 @@ LRESULT OS_Windows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam) 
 				SetCursorPos(pos.x, pos.y);
 			}
 
-			input->set_mouse_position(mm->get_position());
 			mm->set_speed(input->get_last_mouse_speed());
 
 			if (old_invalid) {

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2828,7 +2828,6 @@ void OS_X11::process_xevents() {
 				mm->set_button_mask(get_mouse_button_state());
 				mm->set_position(posi);
 				mm->set_global_position(posi);
-				input->set_mouse_position(posi);
 				mm->set_speed(input->get_last_mouse_speed());
 
 				mm->set_relative(rel);

--- a/scene/3d/baked_lightmap.cpp
+++ b/scene/3d/baked_lightmap.cpp
@@ -389,7 +389,7 @@ void BakedLightmap::_find_meshes_and_lights(Node *p_at_node, Vector<MeshesFound>
 
 			GeometryInstance *gi = Object::cast_to<GeometryInstance>(p_at_node);
 			if (gi) {
-				all_override = mi->get_material_override();
+				all_override = gi->get_material_override();
 			}
 
 			for (int i = 0; i < bmeshes.size(); i += 2) {
@@ -414,8 +414,8 @@ void BakedLightmap::_find_meshes_and_lights(Node *p_at_node, Vector<MeshesFound>
 				mf.mesh = mesh;
 
 				if (gi) {
-					mf.cast_shadows = mi->get_cast_shadows_setting() != GeometryInstance::SHADOW_CASTING_SETTING_OFF;
-					mf.generate_lightmap = mi->get_generate_lightmap();
+					mf.cast_shadows = gi->get_cast_shadows_setting() != GeometryInstance::SHADOW_CASTING_SETTING_OFF;
+					mf.generate_lightmap = gi->get_generate_lightmap();
 				} else {
 					mf.cast_shadows = true;
 					mf.generate_lightmap = true;


### PR DESCRIPTION
To resolve confusion described in #45677, adds a note to tile_set_modulate clarifying how to use tile_modulate in shaders.

Not relevant to master, due to changes to TileSet.

*Bugsquad edit:*
- Fixes #45677