### PR TITLE
Remove incorrect items from completion of main functions in shader

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -9060,6 +9060,19 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 		} break;
 		case COMPLETION_MAIN_FUNCTION: {
 			for (const KeyValue<StringName, FunctionInfo> &E : p_info.functions) {
+				if (!E.value.main_function) {
+					continue;
+				}
+				bool found = false;
+				for (int i = 0; i < shader->functions.size(); i++) {
+					if (shader->functions[i].name == E.key) {
+						found = true;
+						break;
+					}
+				}
+				if (found) {
+					continue;
+				}
 				ScriptCodeCompletionOption option(E.key, ScriptCodeCompletionOption::KIND_FUNCTION);
 				r_options->push_back(option);
 			}


### PR DESCRIPTION
Removes `global` and `constants` from completion:

![image](https://user-images.githubusercontent.com/3036176/150736514-ab3dc359-0b07-4b4e-9def-75f28b8341bf.png)

and prevents showing it in autocompletion after declaration.