### PR TITLE
Fix make_rst.py on Windows

### DIFF
--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -438,7 +438,7 @@ def main():  # type: () -> None
 
     for path in args.path:
         # Cut off trailing slashes so os.path.basename doesn't choke.
-        if path.endswith(os.sep):
+        if path.endswith("/") or path.endswith("\\"):
             path = path[:-1]
 
         if os.path.basename(path) == "modules":


### PR DESCRIPTION
`make_rst.py` needs to remove trailing slashes, but actually checks `os.sep`, which is `\` on Windows.
As paths are actually hardcoded with `/` (e.g. in the Makefile), this is not properly detected and removed on Windows, as it is compared against a backslash.

This results in `make_rst.py` currently ignoring `modules` docs on Windows. This fixes that. :)