### PR TITLE
Fix translation with multiple sources for the same language.

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -820,7 +820,7 @@ String ResourceLoader::_path_remap(const String &p_path, bool *r_translation_rem
 			}
 			String l = res_remaps[i].substr(split + 1).strip_edges();
 			int score = TranslationServer::get_singleton()->compare_locales(locale, l);
-			if (score > best_score) {
+			if (score > 0 && score >= best_score) {
 				new_path = res_remaps[i].left(split);
 				best_score = score;
 				if (score == 10) {

--- a/core/string/locales.h
+++ b/core/string/locales.h
@@ -42,6 +42,7 @@ static const char *locale_renames[][2] = {
 	{ "in", "id" }, //  Indonesian
 	{ "iw", "he" }, //  Hebrew
 	{ "no", "nb" }, //  Norwegian Bokmål
+	{ "C", "en" }, // Locale is not set, fallback to English.
 	{ nullptr, nullptr }
 };
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -377,7 +377,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 			lang_hint += locale;
 
 			int score = TranslationServer::get_singleton()->compare_locales(host_lang, locale);
-			if (score > best_score) {
+			if (score > 0 && score >= best_score) {
 				best = locale;
 				best_score = score;
 				if (score == 10) {


### PR DESCRIPTION
Also removes unnecessary locale length checks, and add `C` → `en` locale remap (since there's no valid language check anymore, `LANG=C` was considered valid and causing error prints).

Fixes #57125
