### PR TITLE
Add `make unique` and `revert to default` buttons on inherited animations

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -61,7 +61,8 @@ class AnimationPlayerEditor : public VBoxContainer {
 		TOOL_COPY_ANIM,
 		TOOL_PASTE_ANIM,
 		TOOL_PASTE_ANIM_REF,
-		TOOL_EDIT_RESOURCE
+		TOOL_EDIT_RESOURCE,
+		TOOL_TOGGLE_UNIQUE,
 	};
 
 	enum {
@@ -110,6 +111,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	Ref<ImageTexture> autoplay_reset_icon;
 	bool last_active;
 	float timeline_position;
+	bool inherits;
 
 	EditorFileDialog *file;
 	ConfirmationDialog *delete_dialog;
@@ -169,6 +171,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _play_bw_from_pressed();
 	void _autoplay_pressed();
 	void _stop_pressed();
+	void _update_inherited(const String current);
 	void _animation_selected(int p_which);
 	void _animation_new();
 	void _animation_rename();
@@ -184,6 +187,8 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _animation_blend();
 	void _animation_edit();
 	void _animation_duplicate();
+	void _animation_make_unique();
+	void _animation_revert_parent();
 	Ref<Animation> _animation_clone(const Ref<Animation> p_anim);
 	void _animation_paste(const Ref<Animation> p_anim);
 	void _animation_resource_edit();


### PR DESCRIPTION
Implements godotengine/godot-proposals#3824

Not sure if this is desirable, as the proposal didn't get much attention, but was a nice to get acquainted with the code anyway :). If not needed, PR can be closed.

Implements a Make Unique button in the Animation drop-down and it's inverse. Currently the implementation is a bit disorganized, and I would appreciate pointers on how to make the button replacement logic fit nicely.

When the user presses the Unique button, the animation property is made a built-in resource of the current animation player which can be modified without affecting the parent's. 
![Screenshot from 2022-01-24 14-29-57](https://user-images.githubusercontent.com/97912854/150834110-c9ed9b71-437d-4475-97a1-e9a7c09b7406.png)

Then, when the Revert button is pressed, the unique animation is deleted and replaced with a reference to the parent's animation.
![Screenshot from 2022-01-24 14-13-54](https://user-images.githubusercontent.com/97912854/150833562-e91fcdf4-4d37-4769-9d3c-536ddbe1102d.png)

_Production edit: This closes https://github.com/godotengine/godot-proposals/issues/3824_