### PR TITLE
Allow disabling the alpha trim on texture atlas creation.

### DIFF
--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -75,6 +75,7 @@ void ResourceImporterTextureAtlas::get_import_options(const String &p_path, List
 	r_options->push_back(ImportOption(PropertyInfo(Variant::STRING, "atlas_file", PROPERTY_HINT_SAVE_FILE, "*.png"), ""));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "import_mode", PROPERTY_HINT_ENUM, "Region,Mesh2D"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "crop_to_region"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "trim_alpha_border_from_region"), true));
 }
 
 String ResourceImporterTextureAtlas::get_option_group_file() const {
@@ -210,14 +211,18 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 		pack_data.is_cropped = options["crop_to_region"];
 
 		int mode = options["import_mode"];
+		bool trim_alpha_border_from_region = options["trim_alpha_border_from_region"];
 
 		if (mode == IMPORT_MODE_REGION) {
 			pack_data.is_mesh = false;
 
 			EditorAtlasPacker::Chart chart;
 
-			//clip a region from the image
-			Rect2 used_rect = image->get_used_rect();
+			Rect2 used_rect = Rect2(Vector2(), image->get_size());
+			if (trim_alpha_border_from_region) {
+				// Clip a region from the image.
+				used_rect = image->get_used_rect();
+			}
 			pack_data.region = used_rect;
 
 			chart.vertices.push_back(used_rect.position);


### PR DESCRIPTION
When creating an AtlasTexture, godot automatically removes unused pixels from the borders of the images. This is unexpected behaviour that changes the size of the texture. In general, if a developer asks for a texture of a specific size with transparent pixels in it, that's what the developer should get. Changing the size and contents of the texture can cause a plethora of issues. 

For our project, this broke all of our styleboxes, as they had region's specified which were invalid because the size of the texture changes.


This PR creates an option for AtlasTexture importers to allow developers to enable the trim on transparent pixels on the borders. It defaults to Off, which I think is better, more expected behaviour. [ Edit - now it default to On to maintain compatibility ]

Related: https://github.com/godotengine/godot/issues/53390

3.x version https://github.com/godotengine/godot/pull/57165