### PR TITLE
[3.x] Fix selection being deleted and indentation not being accounted for

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2983,7 +2983,8 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 
 				// Keep indentation.
 				int space_count = 0;
-				for (int i = 0; i < cursor.column; i++) {
+				int auto_indent_check_column = k->get_command() ? text[cursor.line].length() : cursor.column;
+				for (int i = 0; i < auto_indent_check_column; i++) {
 					if (text[cursor.line][i] == '\t') {
 						if (indent_using_spaces) {
 							ins += space_indent;
@@ -3024,7 +3025,7 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 						char indent_char = ':';
 						char c = text[cursor.line][cursor.column];
 
-						for (int i = 0; i < cursor.column; i++) {
+						for (int i = 0; i < auto_indent_check_column; i++) {
 							c = text[cursor.line][i];
 							switch (c) {
 								case ':':
@@ -3065,6 +3066,8 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				begin_complex_operation();
 				bool first_line = false;
 				if (k->get_command()) {
+					selection.active = false;
+
 					if (k->get_shift()) {
 						if (cursor.line > 0) {
 							cursor_set_line(cursor.line - 1);


### PR DESCRIPTION
Fixes #55855 for the 3.x branch, reimplementing the work done in https://github.com/godotengine/godot/pull/55884.

(GIF has been captured separately for the old pull request and this one. It shows the feature working on 3.5 beta)
![godot windows tools 64 msvc_jrMaGhX032](https://user-images.githubusercontent.com/2719468/150881927-f8d71d45-b17e-4a9b-9a35-e374ae5bd320.gif)
