### PR TITLE
Add type icons to Project Settings, Array, and Dictionary editors

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -502,6 +502,16 @@ void EditorPropertyArray::drop_data_fw(const Point2 &p_point, const Variant &p_d
 }
 
 void EditorPropertyArray::_notification(int p_what) {
+	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
+		change_type->clear();
+		for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+			String type = Variant::get_type_name(Variant::Type(i));
+			change_type->add_icon_item(get_theme_icon(type, SNAME("EditorIcons")), type, i);
+		}
+		change_type->add_separator();
+		change_type->add_icon_item(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), TTR("Remove Item"), Variant::VARIANT_MAX);
+	}
+
 	if (p_what == NOTIFICATION_DRAG_BEGIN) {
 		if (is_visible_in_tree()) {
 			if (_is_drop_valid(get_viewport()->gui_get_drag_data())) {
@@ -691,13 +701,6 @@ EditorPropertyArray::EditorPropertyArray() {
 	change_type = memnew(PopupMenu);
 	add_child(change_type);
 	change_type->connect("id_pressed", callable_mp(this, &EditorPropertyArray::_change_type_menu));
-
-	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
-		String type = Variant::get_type_name(Variant::Type(i));
-		change_type->add_item(type, i);
-	}
-	change_type->add_separator();
-	change_type->add_item(TTR("Remove Item"), Variant::VARIANT_MAX);
 	changing_type_index = -1;
 
 	subtype = Variant::NIL;
@@ -1119,10 +1122,11 @@ void EditorPropertyDictionary::update_property() {
 			prop->update_property();
 
 			if (i == amount + 1) {
-				Button *butt_add_item = memnew(Button);
-				butt_add_item->set_text(TTR("Add Key/Value Pair"));
-				butt_add_item->connect("pressed", callable_mp(this, &EditorPropertyDictionary::_add_key_value));
-				add_vbox->add_child(butt_add_item);
+				button_add_item = memnew(Button);
+				button_add_item->set_text(TTR("Add Key/Value Pair"));
+				button_add_item->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+				button_add_item->connect("pressed", callable_mp(this, &EditorPropertyDictionary::_add_key_value));
+				add_vbox->add_child(button_add_item);
 			}
 		}
 
@@ -1142,6 +1146,19 @@ void EditorPropertyDictionary::_object_id_selected(const StringName &p_property,
 }
 
 void EditorPropertyDictionary::_notification(int p_what) {
+	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
+		change_type->clear();
+		for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+			String type = Variant::get_type_name(Variant::Type(i));
+			change_type->add_icon_item(get_theme_icon(type, SNAME("EditorIcons")), type, i);
+		}
+		change_type->add_separator();
+		change_type->add_icon_item(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), TTR("Remove Item"), Variant::VARIANT_MAX);
+
+		if (Object::cast_to<Button>(button_add_item)) {
+			button_add_item->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+		}
+	}
 }
 
 void EditorPropertyDictionary::_edit_pressed() {
@@ -1179,16 +1196,10 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 	add_focusable(edit);
 	vbox = nullptr;
 	page_slider = nullptr;
+	button_add_item = nullptr;
 	updating = false;
 	change_type = memnew(PopupMenu);
 	add_child(change_type);
 	change_type->connect("id_pressed", callable_mp(this, &EditorPropertyDictionary::_change_type_menu));
-
-	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
-		String type = Variant::get_type_name(Variant::Type(i));
-		change_type->add_item(type, i);
-	}
-	change_type->add_separator();
-	change_type->add_item(TTR("Remove Item"), Variant::VARIANT_MAX);
 	changing_type_index = -1;
 }

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -147,6 +147,7 @@ class EditorPropertyDictionary : public EditorProperty {
 	EditorSpinSlider *size_slider;
 	EditorSpinSlider *page_slider;
 	HBoxContainer *page_hbox;
+	Button *button_add_item;
 
 	void _page_changed(double p_page);
 	void _edit_pressed();

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -472,6 +472,16 @@ void ProjectSettingsEditor::_update_theme() {
 	restart_container->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 	restart_icon->set_texture(get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
 	restart_label->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+
+	type_box->clear();
+	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+		// There's no point in adding Nil types, and Object types
+		// can't be serialized correctly in the project settings.
+		if (i != Variant::NIL && i != Variant::OBJECT) {
+			String type = Variant::get_type_name(Variant::Type(i));
+			type_box->add_icon_item(get_theme_icon(type, SNAME("EditorIcons")), type, i);
+		}
+	}
 }
 
 void ProjectSettingsEditor::_notification(int p_what) {
@@ -486,9 +496,9 @@ void ProjectSettingsEditor::_notification(int p_what) {
 			_update_action_map_editor();
 			_update_theme();
 		} break;
-		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
 			_update_theme();
-			break;
+		} break;
 	}
 }
 
@@ -548,14 +558,6 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	type_box = memnew(OptionButton);
 	type_box->set_custom_minimum_size(Size2(120, 0) * EDSCALE);
 	header->add_child(type_box);
-
-	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
-		// There's no point in adding Nil types, and Object types
-		// can't be serialized correctly in the project settings.
-		if (i != Variant::NIL && i != Variant::OBJECT) {
-			type_box->add_item(Variant::get_type_name(Variant::Type(i)), i);
-		}
-	}
 
 	add_button = memnew(Button);
 	add_button->set_text(TTR("Add"));


### PR DESCRIPTION
This PR adds type icons to the Array editor, Dictionary editor, and Project Settings, and adds a plus icon to the "Add Key/Value Pair" button in the Dictionary editor.

![image](https://user-images.githubusercontent.com/67974470/152411370-bbe16cc5-fcdc-4c8d-b4c8-a29b1a7ae032.png)
![image](https://user-images.githubusercontent.com/67974470/152411479-cdea0707-f0d6-4060-83b2-65b935dc57fd.png)
![image](https://user-images.githubusercontent.com/67974470/150898299-8418be8b-5fb2-47a7-8971-84806b897404.png)

