### PR TITLE
Propagate previously unused `NOTIFICATION_WORLD_2D_CHANGED`, make CanvasItem/CollisionObject2D use it

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -653,6 +653,9 @@
 		<constant name="NOTIFICATION_EXIT_CANVAS" value="33">
 			The [CanvasItem] has exited the canvas.
 		</constant>
+		<constant name="NOTIFICATION_WORLD_2D_CHANGED" value="36">
+			The [CanvasItem]'s active [World2D] changed.
+		</constant>
 		<constant name="TEXTURE_FILTER_PARENT_NODE" value="0" enum="TextureFilter">
 			The [CanvasItem] will inherit the filter from its parent.
 		</constant>

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -118,6 +118,15 @@ void CollisionObject2D::_notification(int p_what) {
 			}
 		} break;
 
+		case NOTIFICATION_WORLD_2D_CHANGED: {
+			RID space = get_world_2d()->get_space();
+			if (area) {
+				PhysicsServer2D::get_singleton()->area_set_space(rid, space);
+			} else {
+				PhysicsServer2D::get_singleton()->body_set_space(rid, space);
+			}
+		} break;
+
 		case NOTIFICATION_DISABLED: {
 			_apply_disabled();
 		} break;

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -336,6 +336,10 @@ void CanvasItem::_notification(int p_what) {
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			emit_signal(SceneStringNames::get_singleton()->visibility_changed);
 		} break;
+		case NOTIFICATION_WORLD_2D_CHANGED: {
+			_exit_canvas();
+			_enter_canvas();
+		}
 	}
 }
 
@@ -1108,6 +1112,7 @@ void CanvasItem::_bind_methods() {
 	BIND_CONSTANT(NOTIFICATION_VISIBILITY_CHANGED);
 	BIND_CONSTANT(NOTIFICATION_ENTER_CANVAS);
 	BIND_CONSTANT(NOTIFICATION_EXIT_CANVAS);
+	BIND_CONSTANT(NOTIFICATION_WORLD_2D_CHANGED);
 
 	BIND_ENUM_CONSTANT(TEXTURE_FILTER_PARENT_NODE);
 	BIND_ENUM_CONSTANT(TEXTURE_FILTER_NEAREST);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -729,6 +729,8 @@ public:
 	bool is_using_xr();
 #endif // _3D_DISABLED
 
+	void _propagate_world_2d_changed(Node *p_node);
+
 	void _validate_property(PropertyInfo &p_property) const;
 	Viewport();
 	~Viewport();


### PR DESCRIPTION
(Master version of #52761)

I took into account the feedback on the previous PR (and put one comment there, since a suggested change didn't work).

New test project (converted one from #52423): [LocationTest.zip](https://github.com/godotengine/godot/files/7930291/LocationTest.zip) (One small difference is I had to change the default environment background color for the 3D test so you could actually see things, since for some reason with master it doesn't render correctly, and everything is black instead. Not sure what the deal with that is.)

*Bugsquad edit:*
- Fixes #52423

