### PR TITLE
[3.x] Store `ObjectID` instead of `Object *` for Shape Owners

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -170,7 +170,7 @@ uint32_t CollisionObject2D::create_shape_owner(Object *p_owner) {
 		id = shapes.back()->key() + 1;
 	}
 
-	sd.owner = p_owner;
+	sd.owner_id = p_owner ? p_owner->get_instance_id() : 0;
 
 	shapes[id] = sd;
 
@@ -283,7 +283,7 @@ Transform2D CollisionObject2D::shape_owner_get_transform(uint32_t p_owner) const
 Object *CollisionObject2D::shape_owner_get_owner(uint32_t p_owner) const {
 	ERR_FAIL_COND_V(!shapes.has(p_owner), nullptr);
 
-	return shapes[p_owner].owner;
+	return ObjectDB::get_instance(shapes[p_owner].owner_id);
 }
 
 void CollisionObject2D::shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2D> &p_shape) {

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -45,7 +45,7 @@ class CollisionObject2D : public Node2D {
 	bool pickable;
 
 	struct ShapeData {
-		Object *owner;
+		ObjectID owner_id;
 		Transform2D xform;
 		struct Shape {
 			Ref<Shape2D> shape;
@@ -61,7 +61,7 @@ class CollisionObject2D : public Node2D {
 			disabled = false;
 			one_way_collision = false;
 			one_way_collision_margin = 0;
-			owner = nullptr;
+			owner_id = 0;
 		}
 	};
 

--- a/scene/3d/collision_object.cpp
+++ b/scene/3d/collision_object.cpp
@@ -363,7 +363,7 @@ uint32_t CollisionObject::create_shape_owner(Object *p_owner) {
 		id = shapes.back()->key() + 1;
 	}
 
-	sd.owner = p_owner;
+	sd.owner_id = p_owner ? p_owner->get_instance_id() : 0;
 
 	shapes[id] = sd;
 
@@ -442,7 +442,7 @@ Transform CollisionObject::shape_owner_get_transform(uint32_t p_owner) const {
 Object *CollisionObject::shape_owner_get_owner(uint32_t p_owner) const {
 	ERR_FAIL_COND_V(!shapes.has(p_owner), nullptr);
 
-	return shapes[p_owner].owner;
+	return ObjectDB::get_instance(shapes[p_owner].owner_id);
 }
 
 void CollisionObject::shape_owner_add_shape(uint32_t p_owner, const Ref<Shape> &p_shape) {

--- a/scene/3d/collision_object.h
+++ b/scene/3d/collision_object.h
@@ -45,7 +45,7 @@ class CollisionObject : public Spatial {
 	RID rid;
 
 	struct ShapeData {
-		Object *owner;
+		ObjectID owner_id;
 		Transform xform;
 		struct ShapeBase {
 			RID debug_shape;
@@ -58,7 +58,7 @@ class CollisionObject : public Spatial {
 
 		ShapeData() {
 			disabled = false;
-			owner = nullptr;
+			owner_id = 0;
 		}
 	};
 


### PR DESCRIPTION
`3.x` version of #57182