### PR TITLE
Portals - Fix gameplay monitor ticking

### DIFF
--- a/servers/visual/portals/portal_gameplay_monitor.h
+++ b/servers/visual/portals/portal_gameplay_monitor.h
@@ -52,9 +52,16 @@ public:
 private:
 	void _update_gameplay_room(PortalRenderer &p_portal_renderer, int p_room_id, bool p_source_rooms_changed);
 	bool _source_rooms_changed(const int *p_source_room_ids, int p_num_source_rooms);
-	void _swap();
+	void _swap(bool p_source_rooms_changed);
 
+	// gameplay ticks happen every physics tick
 	uint32_t _gameplay_tick = 1;
+
+	// Room ticks only happen when the rooms the cameras are within change.
+	// This is an optimization. This tick needs to be maintained separately from _gameplay_tick
+	// because testing against the previous tick is used to determine whether to send enter or exit
+	// gameplay notifications, and this must be synchronized differently for rooms, roomgroups and static ghosts.
+	uint32_t _room_tick = 1;
 
 	// we need two version, current and previous
 	LocalVector<uint32_t, int32_t> _active_moving_pool_ids[2];

--- a/servers/visual/portals/portal_renderer.h
+++ b/servers/visual/portals/portal_renderer.h
@@ -68,7 +68,7 @@ struct VSStaticGhost {
 	ObjectID object_id;
 
 	uint32_t last_tick_hit = 0;
-	uint32_t last_gameplay_tick_hit = 0;
+	uint32_t last_room_tick_hit = 0;
 };
 
 class PortalRenderer {

--- a/servers/visual/portals/portal_types.h
+++ b/servers/visual/portals/portal_types.h
@@ -227,7 +227,7 @@ struct VSRoomGroup {
 	}
 
 	// used for calculating gameplay notifications
-	uint32_t last_gameplay_tick_hit = 0;
+	uint32_t last_room_tick_hit = 0;
 
 	ObjectID _godot_instance_ID = 0;
 
@@ -257,7 +257,7 @@ struct VSRoom {
 		_secondary_pvs_size = 0;
 		_priority = 0;
 		_contains_internal_rooms = false;
-		last_gameplay_tick_hit = 0;
+		last_room_tick_hit = 0;
 	}
 
 	void cleanup_after_conversion() {
@@ -354,7 +354,7 @@ struct VSRoom {
 	uint16_t _secondary_pvs_size = 0;
 
 	// used for calculating gameplay notifications
-	uint32_t last_gameplay_tick_hit = 0;
+	uint32_t last_room_tick_hit = 0;
 
 	// convex hull of the room, either determined by geometry or manual bound
 	LocalVector<Plane, int32_t> _planes;


### PR DESCRIPTION
Due to an optimization to prevent processing except when camera rooms changed, the ticking synchronization and updating of previous and current lists could get out of sync for affected objects, leading to missing gameplay notifications.

This PR adds new paths to properly support and synchronize objects in this "room based" path.

Fixes #56494
(multiple issues mentioned, but this fixes https://github.com/godotengine/godot/issues/56494#issuecomment-1020489971 )

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
