### PR TITLE
Fix memory leak when move to trash fails on Linux

### DIFF
--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -448,7 +448,7 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 
 	// Create needed directories for decided trash can location.
 	{
-		DirAccess *dir_access = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		DirAccessRef dir_access = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 		Error err = dir_access->make_dir_recursive(trash_path);
 
 		// Issue an error if trash can is not created properly.
@@ -457,7 +457,6 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Could not create the trash path \"" + trash_path + "\"/files");
 		err = dir_access->make_dir_recursive(trash_path + "/info");
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Could not create the trash path \"" + trash_path + "\"/info");
-		memdelete(dir_access);
 	}
 
 	// The trash can is successfully created, now we check that we don't exceed our file name length limit.
@@ -497,16 +496,15 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 	String trash_info = "[Trash Info]\nPath=" + p_path.uri_encode() + "\nDeletionDate=" + timestamp + "\n";
 	{
 		Error err;
-		FileAccess *file = FileAccess::open(trash_path + "/info/" + file_name + ".trashinfo", FileAccess::WRITE, &err);
+		FileAccessRef file = FileAccess::open(trash_path + "/info/" + file_name + ".trashinfo", FileAccess::WRITE, &err);
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Can't create trashinfo file:" + trash_path + "/info/" + file_name + ".trashinfo");
 		file->store_string(trash_info);
 		file->close();
 
 		// Rename our resource before moving it to the trash can.
-		DirAccess *dir_access = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		DirAccessRef dir_access = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 		err = dir_access->rename(p_path, p_path.get_base_dir() + "/" + file_name);
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Can't rename file \"" + p_path + "\"");
-		memdelete(dir_access);
 	}
 
 	// Move the given resource to the trash can.


### PR DESCRIPTION
In the non-happy path, some `memdelete`s are missing and some are skipped by `ERR_FAIL_*`. This PR uses the `{Dir,File}AccessRef` wrapper to delete the object via RAII.

For cherry-pick: `platform/linuxbsd/os_linuxbsd.cpp` → `platform/x11/os_x11.cpp`