### PR TITLE
Fix crash after renaming an animation node

### DIFF
--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -898,6 +898,9 @@ void AnimationNodeBlendTreeEditor::_node_renamed(const String &p_text, Ref<Anima
 }
 
 void AnimationNodeBlendTreeEditor::_node_renamed_focus_out(Node *le, Ref<AnimationNode> p_node) {
+	if (le == nullptr) {
+		return; // The text_submitted signal triggered the graph update and freed the LineEdit.
+	}
 	_node_renamed(le->call("get_text"), p_node);
 }
 


### PR DESCRIPTION
Fixes #56546

https://github.com/godotengine/godot/blob/3102660512e2808e2f133a6edc1c3d74202e76c4/editor/plugins/animation_blend_tree_editor_plugin.cpp#L148-L149

Hitting enter to confirm renaming triggers `text_submitted` which will call `_update_graph()` to recreate the nodes. And the `LineEdit` is then recreated which will trigger `focus_exited` before its death.

Because the signal is connected using `CONNECT_DEFERRED`, when `_node_renamed_focus_out` is actually called, the `LineEdit` is already gone, so the first argument will be null.

