### PR TITLE
GeometryInstance: Remove unimplemented LOD properties

### DIFF
--- a/doc/classes/GeometryInstance.xml
+++ b/doc/classes/GeometryInstance.xml
@@ -45,22 +45,6 @@
 		<member name="lightmap_scale" type="int" setter="set_lightmap_scale" getter="get_lightmap_scale" enum="GeometryInstance.LightmapScale" default="0">
 			Scale factor for the generated baked lightmap. Useful for adding detail to certain mesh instances.
 		</member>
-		<member name="lod_max_distance" type="float" setter="set_lod_max_distance" getter="get_lod_max_distance" default="0.0">
-			The GeometryInstance's max LOD distance.
-			[b]Note:[/b] This property currently has no effect.
-		</member>
-		<member name="lod_max_hysteresis" type="float" setter="set_lod_max_hysteresis" getter="get_lod_max_hysteresis" default="0.0">
-			The GeometryInstance's max LOD margin.
-			[b]Note:[/b] This property currently has no effect.
-		</member>
-		<member name="lod_min_distance" type="float" setter="set_lod_min_distance" getter="get_lod_min_distance" default="0.0">
-			The GeometryInstance's min LOD distance.
-			[b]Note:[/b] This property currently has no effect.
-		</member>
-		<member name="lod_min_hysteresis" type="float" setter="set_lod_min_hysteresis" getter="get_lod_min_hysteresis" default="0.0">
-			The GeometryInstance's min LOD margin.
-			[b]Note:[/b] This property currently has no effect.
-		</member>
 		<member name="material_overlay" type="Material" setter="set_material_overlay" getter="get_material_overlay">
 			The material overlay for the whole geometry.
 			If a material is assigned to this property, it will be rendered on top of any other active material for all the surfaces.

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -1338,31 +1338,12 @@
 				Once finished with your RID, you will want to free the RID using the VisualServer's [method free_rid] static method.
 			</description>
 		</method>
-		<method name="instance_geometry_set_as_instance_lod">
-			<return type="void" />
-			<argument index="0" name="instance" type="RID" />
-			<argument index="1" name="as_lod_of_instance" type="RID" />
-			<description>
-				Not implemented in Godot 3.x.
-			</description>
-		</method>
 		<method name="instance_geometry_set_cast_shadows_setting">
 			<return type="void" />
 			<argument index="0" name="instance" type="RID" />
 			<argument index="1" name="shadow_casting_setting" type="int" enum="VisualServer.ShadowCastingSetting" />
 			<description>
 				Sets the shadow casting setting to one of [enum ShadowCastingSetting]. Equivalent to [member GeometryInstance.cast_shadow].
-			</description>
-		</method>
-		<method name="instance_geometry_set_draw_range">
-			<return type="void" />
-			<argument index="0" name="instance" type="RID" />
-			<argument index="1" name="min" type="float" />
-			<argument index="2" name="max" type="float" />
-			<argument index="3" name="min_margin" type="float" />
-			<argument index="4" name="max_margin" type="float" />
-			<description>
-				Not implemented in Godot 3.x.
 			</description>
 		</method>
 		<method name="instance_geometry_set_flag">

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -201,42 +201,6 @@ GeometryInstance::LightmapScale GeometryInstance::get_lightmap_scale() const {
 	return lightmap_scale;
 }
 
-void GeometryInstance::set_lod_min_distance(float p_dist) {
-	lod_min_distance = p_dist;
-	VS::get_singleton()->instance_geometry_set_draw_range(get_instance(), lod_min_distance, lod_max_distance, lod_min_hysteresis, lod_max_hysteresis);
-}
-
-float GeometryInstance::get_lod_min_distance() const {
-	return lod_min_distance;
-}
-
-void GeometryInstance::set_lod_max_distance(float p_dist) {
-	lod_max_distance = p_dist;
-	VS::get_singleton()->instance_geometry_set_draw_range(get_instance(), lod_min_distance, lod_max_distance, lod_min_hysteresis, lod_max_hysteresis);
-}
-
-float GeometryInstance::get_lod_max_distance() const {
-	return lod_max_distance;
-}
-
-void GeometryInstance::set_lod_min_hysteresis(float p_dist) {
-	lod_min_hysteresis = p_dist;
-	VS::get_singleton()->instance_geometry_set_draw_range(get_instance(), lod_min_distance, lod_max_distance, lod_min_hysteresis, lod_max_hysteresis);
-}
-
-float GeometryInstance::get_lod_min_hysteresis() const {
-	return lod_min_hysteresis;
-}
-
-void GeometryInstance::set_lod_max_hysteresis(float p_dist) {
-	lod_max_hysteresis = p_dist;
-	VS::get_singleton()->instance_geometry_set_draw_range(get_instance(), lod_min_distance, lod_max_distance, lod_min_hysteresis, lod_max_hysteresis);
-}
-
-float GeometryInstance::get_lod_max_hysteresis() const {
-	return lod_max_hysteresis;
-}
-
 void GeometryInstance::_notification(int p_what) {
 }
 
@@ -299,18 +263,6 @@ void GeometryInstance::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_lightmap_scale", "scale"), &GeometryInstance::set_lightmap_scale);
 	ClassDB::bind_method(D_METHOD("get_lightmap_scale"), &GeometryInstance::get_lightmap_scale);
 
-	ClassDB::bind_method(D_METHOD("set_lod_max_hysteresis", "mode"), &GeometryInstance::set_lod_max_hysteresis);
-	ClassDB::bind_method(D_METHOD("get_lod_max_hysteresis"), &GeometryInstance::get_lod_max_hysteresis);
-
-	ClassDB::bind_method(D_METHOD("set_lod_max_distance", "mode"), &GeometryInstance::set_lod_max_distance);
-	ClassDB::bind_method(D_METHOD("get_lod_max_distance"), &GeometryInstance::get_lod_max_distance);
-
-	ClassDB::bind_method(D_METHOD("set_lod_min_hysteresis", "mode"), &GeometryInstance::set_lod_min_hysteresis);
-	ClassDB::bind_method(D_METHOD("get_lod_min_hysteresis"), &GeometryInstance::get_lod_min_hysteresis);
-
-	ClassDB::bind_method(D_METHOD("set_lod_min_distance", "mode"), &GeometryInstance::set_lod_min_distance);
-	ClassDB::bind_method(D_METHOD("get_lod_min_distance"), &GeometryInstance::get_lod_min_distance);
-
 	ClassDB::bind_method(D_METHOD("set_extra_cull_margin", "margin"), &GeometryInstance::set_extra_cull_margin);
 	ClassDB::bind_method(D_METHOD("get_extra_cull_margin"), &GeometryInstance::get_extra_cull_margin);
 
@@ -329,14 +281,6 @@ void GeometryInstance::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "generate_lightmap"), "set_generate_lightmap", "get_generate_lightmap");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "lightmap_scale", PROPERTY_HINT_ENUM, "1x,2x,4x,8x"), "set_lightmap_scale", "get_lightmap_scale");
 
-	ADD_GROUP("LOD", "lod_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "lod_min_distance", PROPERTY_HINT_RANGE, "0,32768,0.01"), "set_lod_min_distance", "get_lod_min_distance");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "lod_min_hysteresis", PROPERTY_HINT_RANGE, "0,32768,0.01"), "set_lod_min_hysteresis", "get_lod_min_hysteresis");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "lod_max_distance", PROPERTY_HINT_RANGE, "0,32768,0.01"), "set_lod_max_distance", "get_lod_max_distance");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "lod_max_hysteresis", PROPERTY_HINT_RANGE, "0,32768,0.01"), "set_lod_max_hysteresis", "get_lod_max_hysteresis");
-
-	//ADD_SIGNAL( MethodInfo("visibility_changed"));
-
 	BIND_ENUM_CONSTANT(LIGHTMAP_SCALE_1X);
 	BIND_ENUM_CONSTANT(LIGHTMAP_SCALE_2X);
 	BIND_ENUM_CONSTANT(LIGHTMAP_SCALE_4X);
@@ -354,11 +298,6 @@ void GeometryInstance::_bind_methods() {
 }
 
 GeometryInstance::GeometryInstance() {
-	lod_min_distance = 0;
-	lod_max_distance = 0;
-	lod_min_hysteresis = 0;
-	lod_max_hysteresis = 0;
-
 	for (int i = 0; i < FLAG_MAX; i++) {
 		flags[i] = false;
 	}

--- a/scene/3d/visual_instance.h
+++ b/scene/3d/visual_instance.h
@@ -111,10 +111,6 @@ private:
 	ShadowCastingSetting shadow_casting_setting;
 	Ref<Material> material_override;
 	Ref<Material> material_overlay;
-	float lod_min_distance;
-	float lod_max_distance;
-	float lod_min_hysteresis;
-	float lod_max_hysteresis;
 
 	float extra_cull_margin;
 
@@ -134,18 +130,6 @@ public:
 
 	void set_lightmap_scale(LightmapScale p_scale);
 	LightmapScale get_lightmap_scale() const;
-
-	void set_lod_min_distance(float p_dist);
-	float get_lod_min_distance() const;
-
-	void set_lod_max_distance(float p_dist);
-	float get_lod_max_distance() const;
-
-	void set_lod_min_hysteresis(float p_dist);
-	float get_lod_min_hysteresis() const;
-
-	void set_lod_max_hysteresis(float p_dist);
-	float get_lod_max_hysteresis() const;
 
 	virtual void set_material_override(const Ref<Material> &p_material);
 	Ref<Material> get_material_override() const;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -621,9 +621,6 @@ public:
 	BIND2(instance_geometry_set_material_override, RID, RID)
 	BIND2(instance_geometry_set_material_overlay, RID, RID)
 
-	BIND5(instance_geometry_set_draw_range, RID, float, float, float, float)
-	BIND2(instance_geometry_set_as_instance_lod, RID, RID)
-
 #undef BINDBASE
 //from now on, calls forwarded to this singleton
 #define BINDBASE VSG::canvas

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -1569,11 +1569,6 @@ void VisualServerScene::instance_geometry_set_material_overlay(RID p_instance, R
 	}
 }
 
-void VisualServerScene::instance_geometry_set_draw_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin) {
-}
-void VisualServerScene::instance_geometry_set_as_instance_lod(RID p_instance, RID p_as_lod_of_instance) {
-}
-
 void VisualServerScene::_update_instance(Instance *p_instance) {
 	p_instance->version++;
 

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -748,9 +748,6 @@ public:
 	virtual void instance_geometry_set_material_override(RID p_instance, RID p_material);
 	virtual void instance_geometry_set_material_overlay(RID p_instance, RID p_material);
 
-	virtual void instance_geometry_set_draw_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin);
-	virtual void instance_geometry_set_as_instance_lod(RID p_instance, RID p_as_lod_of_instance);
-
 	_FORCE_INLINE_ void _update_instance(Instance *p_instance);
 	_FORCE_INLINE_ void _update_instance_aabb(Instance *p_instance);
 	_FORCE_INLINE_ void _update_dirty_instance(Instance *p_instance);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -544,9 +544,6 @@ public:
 	FUNC2(instance_geometry_set_material_override, RID, RID)
 	FUNC2(instance_geometry_set_material_overlay, RID, RID)
 
-	FUNC5(instance_geometry_set_draw_range, RID, float, float, float, float)
-	FUNC2(instance_geometry_set_as_instance_lod, RID, RID)
-
 	/* CANVAS (2D) */
 
 	FUNCRID(canvas)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2145,8 +2145,6 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_cast_shadows_setting", "instance", "shadow_casting_setting"), &VisualServer::instance_geometry_set_cast_shadows_setting);
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_material_override", "instance", "material"), &VisualServer::instance_geometry_set_material_override);
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_material_overlay", "instance", "material"), &VisualServer::instance_geometry_set_material_overlay);
-	ClassDB::bind_method(D_METHOD("instance_geometry_set_draw_range", "instance", "min", "max", "min_margin", "max_margin"), &VisualServer::instance_geometry_set_draw_range);
-	ClassDB::bind_method(D_METHOD("instance_geometry_set_as_instance_lod", "instance", "as_lod_of_instance"), &VisualServer::instance_geometry_set_as_instance_lod);
 
 	ClassDB::bind_method(D_METHOD("instances_cull_aabb", "aabb", "scenario"), &VisualServer::_instances_cull_aabb_bind, DEFVAL(RID()));
 	ClassDB::bind_method(D_METHOD("instances_cull_ray", "from", "to", "scenario"), &VisualServer::_instances_cull_ray_bind, DEFVAL(RID()));

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -964,9 +964,6 @@ public:
 	virtual void instance_geometry_set_material_override(RID p_instance, RID p_material) = 0;
 	virtual void instance_geometry_set_material_overlay(RID p_instance, RID p_material) = 0;
 
-	virtual void instance_geometry_set_draw_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin) = 0;
-	virtual void instance_geometry_set_as_instance_lod(RID p_instance, RID p_as_lod_of_instance) = 0;
-
 	/* CANVAS (2D) */
 
 	virtual RID canvas_create() = 0;


### PR DESCRIPTION
And remove matching unimplemented VisualServer functions.

Fixes #40784.

**Breaks compat** because it removes methods from the API, so any code that was using them will now raise an error. But these methods did nothing, so there should be no logic regression in user games, the only impact is that some users mistakenly calling these methods might have to remove these no-op calls from their scripts.