### PR TITLE
[iOS] Fix iOS export with manually specified signing/provisioning data.

### DIFF
--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -308,6 +308,7 @@
 				CODE_SIGN_ENTITLEMENTS = "$binary/$binary.entitlements";
 				CODE_SIGN_IDENTITY = "$code_sign_identity_debug";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "$code_sign_identity_debug";
+				CODE_SIGN_STYLE = "$code_sign_style_debug";
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				DEVELOPMENT_TEAM = $team_id;
 				INFOPLIST_FILE = "$binary/$binary-Info.plist";
@@ -338,6 +339,7 @@
 				CODE_SIGN_ENTITLEMENTS = "$binary/$binary.entitlements";
 				CODE_SIGN_IDENTITY = "$code_sign_identity_release";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "$code_sign_identity_release";
+				CODE_SIGN_STYLE = "$code_sign_style_release";
 				CONFIGURATION_BUILD_DIR = "$(BUILD_DIR)/$(CONFIGURATION)$(EFFECTIVE_PLATFORM_NAME)";
 				DEVELOPMENT_TEAM = $team_id;
 				INFOPLIST_FILE = "$binary/$binary-Info.plist";


### PR DESCRIPTION
Seems like Xcode now defaults to the `Automatic` signing mode unless `Manual` signing style is set in the project.

- For automatic signing mode only `App Store Team ID` should be set, the rest can be left blank.
- For manual signing, `Provisioning Profile UUID` and `Codesign Identity` should be also set.

Note: I do not have an Apple Developer account, and can't fully test it, but it seems to be working at least for the ad-hoc mode.

Fixes #57195
