### PR TITLE
`SpriteFramesEditor` Incorrect texture type fix

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -821,7 +821,7 @@ void SpriteFramesEditor::_update_library(bool p_skip_selector) {
 
 	for (int i = 0; i < frames->get_frame_count(edited_anim); i++) {
 		String name;
-		Ref<Texture> frame = frames->get_frame(edited_anim, i);
+		Ref<Texture2D> frame = frames->get_frame(edited_anim, i);
 
 		if (frame.is_null()) {
 			name = itos(i) + ": " + TTR("(empty)");


### PR DESCRIPTION
Fixes incorrect type changed in my previous PR, see https://github.com/godotengine/godot/pull/57063#discussion_r791946638.