### PR TITLE
4.0 Fix "!material" error on exit

### DIFF
--- a/scene/resources/sky_material.cpp
+++ b/scene/resources/sky_material.cpp
@@ -292,7 +292,6 @@ ProceduralSkyMaterial::ProceduralSkyMaterial() {
 }
 
 ProceduralSkyMaterial::~ProceduralSkyMaterial() {
-	RS::get_singleton()->material_set_shader(_get_material(), RID());
 }
 
 /////////////////////////////////////////
@@ -389,7 +388,6 @@ PanoramaSkyMaterial::PanoramaSkyMaterial() {
 }
 
 PanoramaSkyMaterial::~PanoramaSkyMaterial() {
-	RS::get_singleton()->material_set_shader(_get_material(), RID());
 }
 
 //////////////////////////////////


### PR DESCRIPTION
This should fix #50152 (at least it does so in my test project).

All SkyMaterials have a method called cleaup_shaders() that deletes their shaders. This is done by calling `RS::get_singleton()->free(shader);`, which in turn automatically executes `material_set_shader(shader->owners.front()->get()->self, RID());`.

The problem was that the procedural and panorama sky manually called `material_set_shader(_get_material(), RID());` in their destructors. Funnily enough, this line of code has already been removed from the PhysicalSkyMaterial two years ago.

Can I have the promised Godot pin now? :grin: