### PR TITLE
Ensure that NavMesh baking updates the inspector

### DIFF
--- a/modules/navigation/navigation_mesh_generator.cpp
+++ b/modules/navigation/navigation_mesh_generator.cpp
@@ -657,6 +657,8 @@ void NavigationMeshGenerator::bake(Ref<NavigationMesh> p_nav_mesh, Node *p_node)
 	if (ep)
 		memdelete(ep);
 #endif
+
+	p_nav_mesh->property_list_changed_notify();
 }
 
 void NavigationMeshGenerator::clear(Ref<NavigationMesh> p_nav_mesh) {

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -34,9 +34,12 @@
 #include "scene/resources/mesh.h"
 
 class Mesh;
+class NavigationMeshGenerator;
 
 class NavigationMesh : public Resource {
 	GDCLASS(NavigationMesh, Resource);
+
+	friend class NavigationMeshGenerator;
 
 	PoolVector<Vector3> vertices;
 	struct Polygon {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/41899. Doesn't seem to happen in `master`, probably due to the changes to the way Inspector pulls updates.

The cause of the problem is in EditorProgress, as described in the comment https://github.com/godotengine/godot/issues/41899#issuecomment-1021605906. If wanted for earlier 3.x version, a dedicated PR is likely required due to Navigation changes in 3.5.