### PR TITLE
Expose input interaction virtual functions in CollisionObject

### DIFF
--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -20,6 +20,32 @@
 				[b]Note:[/b] [method _input_event] requires [member input_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
 			</description>
 		</method>
+		<method name="_mouse_enter" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the mouse pointer enters any of this object's shapes. Requires [member input_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set. Note that moving between different shapes within a single [CollisionObject2D] won't cause this function to be called.
+			</description>
+		</method>
+		<method name="_mouse_exit" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the mouse pointer exits all this object's shapes. Requires [member input_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set. Note that moving between different shapes within a single [CollisionObject2D] won't cause this function to be called.
+			</description>
+		</method>
+		<method name="_mouse_shape_enter" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="shape_idx" type="int" />
+			<description>
+				Called when the mouse pointer enters any of this object's shapes or moves from one shape to another. [param shape_idx] is the child index of the newly entered [Shape2D]. Requires [member input_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be called.
+			</description>
+		</method>
+		<method name="_mouse_shape_exit" qualifiers="virtual">
+			<return type="void" />
+			<param index="0" name="shape_idx" type="int" />
+			<description>
+				Called when the mouse pointer exits any of this object's shapes. [param shape_idx] is the child index of the exited [Shape2D]. Requires [member input_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be called.
+			</description>
+		</method>
 		<method name="create_shape_owner">
 			<return type="int" />
 			<param index="0" name="owner" type="Object" />

--- a/doc/classes/CollisionObject3D.xml
+++ b/doc/classes/CollisionObject3D.xml
@@ -21,6 +21,18 @@
 				[b]Note:[/b] [method _input_event] requires [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
 			</description>
 		</method>
+		<method name="_mouse_enter" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the mouse pointer enters any of this object's shapes. Requires [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set. Note that moving between different shapes within a single [CollisionObject3D] won't cause this function to be called.
+			</description>
+		</method>
+		<method name="_mouse_exit" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called when the mouse pointer exits all this object's shapes. Requires [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set. Note that moving between different shapes within a single [CollisionObject3D] won't cause this function to be called.
+			</description>
+		</method>
 		<method name="create_shape_owner">
 			<return type="int" />
 			<param index="0" name="owner" type="Object" />

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -612,6 +612,10 @@ void CollisionObject2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shape_find_owner", "shape_index"), &CollisionObject2D::shape_find_owner);
 
 	GDVIRTUAL_BIND(_input_event, "viewport", "event", "shape_idx");
+	GDVIRTUAL_BIND(_mouse_enter);
+	GDVIRTUAL_BIND(_mouse_exit);
+	GDVIRTUAL_BIND(_mouse_shape_enter, "shape_idx");
+	GDVIRTUAL_BIND(_mouse_shape_exit, "shape_idx");
 
 	ADD_SIGNAL(MethodInfo("input_event", PropertyInfo(Variant::OBJECT, "viewport", PROPERTY_HINT_RESOURCE_TYPE, "Node"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), PropertyInfo(Variant::INT, "shape_idx")));
 	ADD_SIGNAL(MethodInfo("mouse_entered"));

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -103,6 +103,10 @@ protected:
 	void set_body_mode(PhysicsServer2D::BodyMode p_mode);
 
 	GDVIRTUAL3(_input_event, Viewport *, Ref<InputEvent>, int)
+	GDVIRTUAL0(_mouse_enter)
+	GDVIRTUAL0(_mouse_exit)
+	GDVIRTUAL1(_mouse_shape_enter, int)
+	GDVIRTUAL1(_mouse_shape_exit, int)
 public:
 	void set_collision_layer(uint32_t p_layer);
 	uint32_t get_collision_layer() const;

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -469,6 +469,8 @@ void CollisionObject3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shape_find_owner", "shape_index"), &CollisionObject3D::shape_find_owner);
 
 	GDVIRTUAL_BIND(_input_event, "camera", "event", "position", "normal", "shape_idx");
+	GDVIRTUAL_BIND(_mouse_enter);
+	GDVIRTUAL_BIND(_mouse_exit);
 
 	ADD_SIGNAL(MethodInfo("input_event", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Node"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), PropertyInfo(Variant::VECTOR3, "position"), PropertyInfo(Variant::VECTOR3, "normal"), PropertyInfo(Variant::INT, "shape_idx")));
 	ADD_SIGNAL(MethodInfo("mouse_entered"));

--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -113,6 +113,8 @@ protected:
 	bool is_only_update_transform_changes_enabled() const;
 
 	GDVIRTUAL5(_input_event, Camera3D *, Ref<InputEvent>, Vector3, Vector3, int)
+	GDVIRTUAL0(_mouse_enter)
+	GDVIRTUAL0(_mouse_exit)
 public:
 	void set_collision_layer(uint32_t p_layer);
 	uint32_t get_collision_layer() const;


### PR DESCRIPTION
Functions like `_mouse_enter` and `_mouse_exit` were actually already exposed to GDScript. Just not documented and I think some lines of code were missing to make it properly.

This considers both 3D and 2D cases.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
