### PR TITLE
Fix GraphEdit's minimap doesn't show using `minimap_enabled`

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1637,6 +1637,7 @@ float GraphEdit::get_minimap_opacity() const {
 
 void GraphEdit::set_minimap_enabled(bool p_enable) {
 	minimap_button->set_pressed(p_enable);
+	_minimap_toggled();
 	minimap->update();
 }
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes the issue where the Button does not restore the minimap after toggling off with GraphEdit

![animation](https://user-images.githubusercontent.com/39199936/151093187-480461c2-1d89-45c9-a5db-9c40c55d63ab.gif)

<i>Bugsquad edit:</i>
- Fix #53831