### PR TITLE
Improve XRInterface hooks into rendering

### DIFF
--- a/doc/classes/XRInterfaceExtension.xml
+++ b/doc/classes/XRInterfaceExtension.xml
@@ -9,46 +9,52 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="_commit_views" qualifiers="virtual">
+		<method name="_end_frame" qualifiers="virtual">
 			<return type="void" />
-			<argument index="0" name="render_target" type="RID" />
-			<argument index="1" name="screen_rect" type="Rect2" />
 			<description>
+				Called if interface is active and queues have been submitted.
 			</description>
 		</method>
 		<method name="_get_anchor_detection_is_enabled" qualifiers="virtual const">
 			<return type="bool" />
 			<description>
+				Return [code]true[/code] if anchor detection is enabled for this interface.
 			</description>
 		</method>
 		<method name="_get_camera_feed_id" qualifiers="virtual const">
 			<return type="int" />
 			<description>
+				Returns the camera feed id for the [CameraFeed] registered with the [CameraServer] that should be presented as the background on an AR capable device (if applicable).
 			</description>
 		</method>
 		<method name="_get_camera_transform" qualifiers="virtual">
 			<return type="Transform3D" />
 			<description>
+				Returns the [Transform3D] that positions the [XRCamera3D] in the world.
 			</description>
 		</method>
 		<method name="_get_capabilities" qualifiers="virtual const">
 			<return type="int" />
 			<description>
+				Returns the capabilities of this interface.
 			</description>
 		</method>
 		<method name="_get_name" qualifiers="virtual const">
 			<return type="StringName" />
 			<description>
+				Returns the name of this interface.
 			</description>
 		</method>
 		<method name="_get_play_area" qualifiers="virtual const">
 			<return type="PackedVector3Array" />
 			<description>
+				Returns an [PackedVector3Array] that denotes the play areas boundaries (if applicable).
 			</description>
 		</method>
 		<method name="_get_play_area_mode" qualifiers="virtual const">
 			<return type="int" />
 			<description>
+				Returns the [enum XRInterface.PlayAreaMode] that sets up our play area.
 			</description>
 		</method>
 		<method name="_get_projection_for_view" qualifiers="virtual">
@@ -58,27 +64,32 @@
 			<argument index="2" name="z_near" type="float" />
 			<argument index="3" name="z_far" type="float" />
 			<description>
+				Returns the projection matrix for the given view as a [PackedFloat64Array].
 			</description>
 		</method>
 		<method name="_get_render_target_size" qualifiers="virtual">
 			<return type="Vector2" />
 			<description>
+				Returns the size of our render target for this interface, this overrides the size of the [Viewport] marked as the xr viewport.
 			</description>
 		</method>
 		<method name="_get_suggested_pose_names" qualifiers="virtual const">
 			<return type="PackedStringArray" />
 			<argument index="0" name="tracker_name" type="StringName" />
 			<description>
+				Returns a [PackedStringArray] with pose names configured by this interface. Note that user configuration can override this list.
 			</description>
 		</method>
 		<method name="_get_suggested_tracker_names" qualifiers="virtual const">
 			<return type="PackedStringArray" />
 			<description>
+				Returns a [PackedStringArray] with tracker names configured by this interface. Note that user configuration can override this list.
 			</description>
 		</method>
 		<method name="_get_tracking_status" qualifiers="virtual const">
 			<return type="int" />
 			<description>
+				Returns a [enum XRInterface.TrackingStatus] specifying the current status of our tracking.
 			</description>
 		</method>
 		<method name="_get_transform_for_view" qualifiers="virtual">
@@ -86,50 +97,80 @@
 			<argument index="0" name="view" type="int" />
 			<argument index="1" name="cam_transform" type="Transform3D" />
 			<description>
+				Returns a [Transform3D] for a given view.
 			</description>
 		</method>
 		<method name="_get_view_count" qualifiers="virtual">
 			<return type="int" />
 			<description>
+				Returns the number of views this interface requires, 1 for mono, 2 for stereoscopic.
 			</description>
 		</method>
 		<method name="_initialize" qualifiers="virtual">
 			<return type="bool" />
 			<description>
+				Initializes the interface, returns [code]true[/code] on success.
 			</description>
 		</method>
 		<method name="_is_initialized" qualifiers="virtual const">
 			<return type="bool" />
 			<description>
+				Returns [code]true[/code] if this interface has been initialised.
 			</description>
 		</method>
 		<method name="_notification" qualifiers="virtual">
 			<return type="void" />
 			<argument index="0" name="what" type="int" />
 			<description>
+				Informs the interface of an applicable system notification.
+			</description>
+		</method>
+		<method name="_post_draw_viewport" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="render_target" type="RID" />
+			<argument index="1" name="screen_rect" type="Rect2" />
+			<description>
+				Called after the XR [Viewport] draw logic has completed.
+			</description>
+		</method>
+		<method name="_pre_draw_viewport" qualifiers="virtual">
+			<return type="bool" />
+			<argument index="0" name="render_target" type="RID" />
+			<description>
+				Called if this is our primary [XRInterfaceExtension] before we start processing a [Viewport] for every active XR [Viewport], returns [code]true[/code] if that viewport should be rendered. An XR interface may return [code]false[/code] if the user has taken off their headset and we can pause rendering.
+			</description>
+		</method>
+		<method name="_pre_render" qualifiers="virtual">
+			<return type="void" />
+			<description>
+				Called if this [XRInterfaceExtension] is active before rendering starts, most XR interfaces will sync tracking at this point in time.
 			</description>
 		</method>
 		<method name="_process" qualifiers="virtual">
 			<return type="void" />
 			<description>
+				Called if this [XRInterfaceExtension] is active before our physics and game process is called. most XR interfaces will update its [XRPositionalTracker]s at this point in time.
 			</description>
 		</method>
 		<method name="_set_anchor_detection_is_enabled" qualifiers="virtual">
 			<return type="void" />
 			<argument index="0" name="enabled" type="bool" />
 			<description>
+				Enables anchor detection on this interface if supported.
 			</description>
 		</method>
 		<method name="_set_play_area_mode" qualifiers="virtual const">
 			<return type="bool" />
 			<argument index="0" name="mode" type="int" />
 			<description>
+				Set the play area mode for this interface.
 			</description>
 		</method>
 		<method name="_supports_play_area_mode" qualifiers="virtual const">
 			<return type="bool" />
 			<argument index="0" name="mode" type="int" enum="XRInterface.PlayAreaMode" />
 			<description>
+				Returns [code]true[/code] if this interface supports this play area mode.
 			</description>
 		</method>
 		<method name="_trigger_haptic_pulse" qualifiers="virtual">
@@ -141,11 +182,13 @@
 			<argument index="4" name="duration_sec" type="float" />
 			<argument index="5" name="delay_sec" type="float" />
 			<description>
+				Triggers a haptic pulse to be emitted on the specified tracker.
 			</description>
 		</method>
 		<method name="_uninitialize" qualifiers="virtual">
 			<return type="void" />
 			<description>
+				Uninitialize the interface.
 			</description>
 		</method>
 		<method name="add_blit">
@@ -169,6 +212,7 @@
 			<return type="RID" />
 			<argument index="0" name="render_target" type="RID" />
 			<description>
+				Returns a valid [RID] for a texture to which we should render the current frame if supported by the interface.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/XRServer.xml
+++ b/doc/classes/XRServer.xml
@@ -69,24 +69,6 @@
 				Returns a list of available interfaces the ID and name of each interface.
 			</description>
 		</method>
-		<method name="get_last_commit_usec">
-			<return type="int" />
-			<description>
-				Returns the absolute timestamp (in μs) of the last [XRServer] commit of the AR/VR eyes to [RenderingServer]. The value comes from an internal call to [method Time.get_ticks_usec].
-			</description>
-		</method>
-		<method name="get_last_frame_usec">
-			<return type="int" />
-			<description>
-				Returns the duration (in μs) of the last frame. This is computed as the difference between [method get_last_commit_usec] and [method get_last_process_usec] when committing.
-			</description>
-		</method>
-		<method name="get_last_process_usec">
-			<return type="int" />
-			<description>
-				Returns the absolute timestamp (in μs) of the last [XRServer] process callback. The value comes from an internal call to [method Time.get_ticks_usec].
-			</description>
-		</method>
 		<method name="get_reference_frame" qualifiers="const">
 			<return type="Transform3D" />
 			<description>

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -463,7 +463,7 @@ CameraMatrix MobileVRInterface::get_projection_for_view(uint32_t p_view, double 
 	return eye;
 };
 
-Vector<BlitToScreen> MobileVRInterface::commit_views(RID p_render_target, const Rect2 &p_screen_rect) {
+Vector<BlitToScreen> MobileVRInterface::post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) {
 	_THREAD_SAFE_METHOD_
 
 	Vector<BlitToScreen> blit_to_screen;

--- a/modules/mobile_vr/mobile_vr_interface.h
+++ b/modules/mobile_vr/mobile_vr_interface.h
@@ -151,7 +151,7 @@ public:
 	virtual Transform3D get_camera_transform() override;
 	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override;
 	virtual CameraMatrix get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
-	virtual Vector<BlitToScreen> commit_views(RID p_render_target, const Rect2 &p_screen_rect) override;
+	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) override;
 
 	virtual void process() override;
 

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -385,7 +385,7 @@ CameraMatrix WebXRInterfaceJS::get_projection_for_view(uint32_t p_view, double p
 	return eye;
 }
 
-Vector<BlitToScreen> WebXRInterfaceJS::commit_views(RID p_render_target, const Rect2 &p_screen_rect) {
+Vector<BlitToScreen> WebXRInterfaceJS::post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) {
 	Vector<BlitToScreen> blit_to_screen;
 
 	if (!initialized) {

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -88,7 +88,7 @@ public:
 	virtual Transform3D get_camera_transform() override;
 	virtual Transform3D get_transform_for_view(uint32_t p_view, const Transform3D &p_cam_transform) override;
 	virtual CameraMatrix get_projection_for_view(uint32_t p_view, double p_aspect, double p_z_near, double p_z_far) override;
-	virtual Vector<BlitToScreen> commit_views(RID p_render_target, const Rect2 &p_screen_rect) override;
+	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) override;
 
 	virtual void process() override;
 

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -93,6 +93,12 @@ void RenderingServerDefault::_draw(bool p_swap_buffers, double frame_step) {
 
 	RSG::rasterizer->end_frame(p_swap_buffers);
 
+	XRServer *xr_server = XRServer::get_singleton();
+	if (xr_server != nullptr) {
+		// let our XR server know we're done so we can get our frame timing
+		xr_server->end_frame();
+	}
+
 	RSG::canvas->update_visibility_notifiers();
 	RSG::scene->update_visibility_notifiers();
 

--- a/servers/xr/xr_interface.cpp
+++ b/servers/xr/xr_interface.cpp
@@ -168,8 +168,5 @@ XRInterface::TrackingStatus XRInterface::get_tracking_status() const {
 	return XR_UNKNOWN_TRACKING;
 }
 
-void XRInterface::notification(int p_what) {
-}
-
 void XRInterface::trigger_haptic_pulse(const String &p_action_name, const StringName &p_tracker_name, double p_frequency, double p_amplitude, double p_duration_sec, double p_delay_sec) {
 }

--- a/servers/xr/xr_interface.h
+++ b/servers/xr/xr_interface.h
@@ -123,10 +123,13 @@ public:
 
 	// note, external color/depth/vrs texture support will be added here soon.
 
-	virtual Vector<BlitToScreen> commit_views(RID p_render_target, const Rect2 &p_screen_rect) = 0; /* commit rendered views to the XR interface */
-
 	virtual void process() = 0;
-	virtual void notification(int p_what);
+	virtual void pre_render(){};
+	virtual bool pre_draw_viewport(RID p_render_target) { return true; }; /* inform XR interface we are about to start our viewport draw process */
+	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) = 0; /* inform XR interface we finished our viewport draw process */
+	virtual void end_frame(){};
+
+	virtual void notification(int p_what){};
 
 	XRInterface();
 	~XRInterface();

--- a/servers/xr/xr_interface_extension.h
+++ b/servers/xr/xr_interface_extension.h
@@ -109,13 +109,20 @@ public:
 	GDVIRTUAL4R(PackedFloat64Array, _get_projection_for_view, uint32_t, double, double, double);
 
 	void add_blit(RID p_render_target, Rect2 p_src_rect, Rect2i p_dst_rect, bool p_use_layer = false, uint32_t p_layer = 0, bool p_apply_lens_distortion = false, Vector2 p_eye_center = Vector2(), double p_k1 = 0.0, double p_k2 = 0.0, double p_upscale = 1.0, double p_aspect_ratio = 1.0);
-	virtual Vector<BlitToScreen> commit_views(RID p_render_target, const Rect2 &p_screen_rect) override;
-	GDVIRTUAL2(_commit_views, RID, const Rect2 &);
 
 	virtual void process() override;
+	virtual void pre_render() override;
+	virtual bool pre_draw_viewport(RID p_render_target) override;
+	virtual Vector<BlitToScreen> post_draw_viewport(RID p_render_target, const Rect2 &p_screen_rect) override;
+	virtual void end_frame() override;
 	virtual void notification(int p_what) override;
 
 	GDVIRTUAL0(_process);
+	GDVIRTUAL0(_pre_render);
+	GDVIRTUAL1R(bool, _pre_draw_viewport, RID);
+	GDVIRTUAL2(_post_draw_viewport, RID, const Rect2 &);
+	GDVIRTUAL0(_end_frame);
+
 	GDVIRTUAL1(_notification, int);
 
 	/* access to some internals we need */

--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -65,10 +65,6 @@ void XRServer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "primary_interface"), "set_primary_interface", "get_primary_interface");
 
-	ClassDB::bind_method(D_METHOD("get_last_process_usec"), &XRServer::get_last_process_usec);
-	ClassDB::bind_method(D_METHOD("get_last_commit_usec"), &XRServer::get_last_commit_usec);
-	ClassDB::bind_method(D_METHOD("get_last_frame_usec"), &XRServer::get_last_frame_usec);
-
 	BIND_ENUM_CONSTANT(TRACKER_HEAD);
 	BIND_ENUM_CONSTANT(TRACKER_CONTROLLER);
 	BIND_ENUM_CONSTANT(TRACKER_BASESTATION);
@@ -351,23 +347,8 @@ PackedStringArray XRServer::get_suggested_pose_names(const StringName &p_tracker
 	return arr;
 }
 
-uint64_t XRServer::get_last_process_usec() {
-	return last_process_usec;
-};
-
-uint64_t XRServer::get_last_commit_usec() {
-	return last_commit_usec;
-};
-
-uint64_t XRServer::get_last_frame_usec() {
-	return last_frame_usec;
-};
-
 void XRServer::_process() {
 	/* called from renderer_viewport.draw_viewports right before we start drawing our viewports */
-
-	/* mark for our frame timing */
-	last_process_usec = OS::get_singleton()->get_ticks_usec();
 
 	/* process all active interfaces */
 	for (int i = 0; i < interfaces.size(); i++) {
@@ -379,13 +360,32 @@ void XRServer::_process() {
 	};
 };
 
-void XRServer::_mark_commit() {
-	/* time this */
-	last_commit_usec = OS::get_singleton()->get_ticks_usec();
+void XRServer::pre_render() {
+	// called from RendererViewport.draw_viewports right before we start drawing our viewports
+	// note that we can have multiple interfaces active if we have interfaces that purely handle tracking
 
-	/* now store our difference as we may overwrite last_process_usec before this is accessed */
-	last_frame_usec = last_commit_usec - last_process_usec;
-};
+	// process all active interfaces
+	for (int i = 0; i < interfaces.size(); i++) {
+		if (!interfaces[i].is_valid()) {
+			// ignore, not a valid reference
+		} else if (interfaces[i]->is_initialized()) {
+			interfaces.write[i]->pre_render();
+		};
+	};
+}
+
+void XRServer::end_frame() {
+	// called from RenderingServerDefault after Vulkan queues have been submitted
+
+	// process all active interfaces
+	for (int i = 0; i < interfaces.size(); i++) {
+		if (!interfaces[i].is_valid()) {
+			// ignore, not a valid reference
+		} else if (interfaces[i]->is_initialized()) {
+			interfaces.write[i]->end_frame();
+		};
+	};
+}
 
 XRServer::XRServer() {
 	singleton = this;

--- a/servers/xr_server.h
+++ b/servers/xr_server.h
@@ -84,10 +84,6 @@ private:
 	Transform3D world_origin; /* our world origin point, maps a location in our virtual world to the origin point in our real world tracking volume */
 	Transform3D reference_frame; /* our reference frame */
 
-	uint64_t last_process_usec; /* for frame timing, usec when we did our processing */
-	uint64_t last_commit_usec; /* for frame timing, usec when we finished committing both eyes */
-	uint64_t last_frame_usec; /* time it took between process and committing, we should probably average this over the last x frames */
-
 protected:
 	static XRServer *singleton;
 
@@ -175,12 +171,16 @@ public:
 	PackedStringArray get_suggested_pose_names(const StringName &p_tracker_name) const;
 	// Q: Should we add get_suggested_input_names and get_suggested_haptic_names even though we don't use them for the IDE?
 
-	uint64_t get_last_process_usec();
-	uint64_t get_last_commit_usec();
-	uint64_t get_last_frame_usec();
-
+	// Process is called before we handle our physics process and game process. This is where our interfaces will update controller data and such.
 	void _process();
-	void _mark_commit();
+
+	// Pre-render is called right before we're rendering our viewports.
+	// This is where interfaces such as OpenVR and OpenXR will update positioning data.
+	// Many of these interfaces will also do a predictive sync which ensures we run at a steady framerate.
+	void pre_render();
+
+	// End-frame is called right after Godot has finished its rendering bits.
+	void end_frame();
 
 	XRServer();
 	~XRServer();


### PR DESCRIPTION
This PR extracts some of the changes in #56394 that improve the entry points into the XR interface related to rendering a frame.
I'm pulling these into their own PR as they also impact some of the plugin based XR interfaces such as our OpenVR plugin.

The main one is the introduction of `end_frame` which is called much later in the process as `vkSubmitQueue` has to have been called before we can submit our images to the XR compositor. `vkSubmitQueue` is called inside of `RendererCompositor::end_frame` which also handles presenting the images on screen. Ideally our `XRInterface.end_frame` should be called after `vkSubmitQueue` but before processing our presentation. That is an improvement for later as we can then also look into skipping presentation all together if our XR compositor already handles this as is the case with hand held and stand alone devices.

After this PR the following entry points will exist that control the flow of the XR process (some of these exist already and/or have been renamed, I'm listing them for completeness sake):
- `XRInterface.process()` is called on all active XR interfaces at the start of processing a frame. This happens before physics and game logic is handled and allow us to update the tracking status of tracked nodes. 
- `XRInterface.pre_render()` is called on all active XR interfaces at the start of our draw viewports logic. This is where XR interfaces will update their tracking data and stuff like that
- `XRInterface.pre_draw_viewport(p_render_target)` is called on the primary XR interface for each active viewport marked as an XR viewport. This function can return false if the XR interface wants to skip rendering, this allows us to pause rendering of a viewport when the user takes off their headset.   
- `XRInterface.post_draw_viewport(p_render_target, p_screen_rect)` is called when drawing of a viewport marked as an XR viewport is finished and allow the XR interface to do any further processing. Note that queues have not been submitted yet so no actual rendering has taken place.
- `XRInterface.end_frame()` is called on all active XR interfaces after all our rendering commands have been committed to the GPU (GPU might still take awhile to actually finish rendering but that's ok).

I've also removed some of the timing kept in the XRServer. The only interface that used this is the old leap motion hand tracking. First, that system now has an OpenXR implementation removing the need for a custom plugin.
Second, with Vulkan this current implementation is meaningless and the new entry points allow a plugin to implement timing correctly.
