### PR TITLE
Update InspectorDock when moving files via FileSystemDock

### DIFF
--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -93,6 +93,8 @@ class InspectorDock : public VBoxContainer {
 	ConfirmationDialog *unique_resources_confirmation;
 	Tree *unique_resources_list_tree;
 
+	float refresh_countdown;
+
 	void _menu_option(int p_option);
 	void _menu_confirm_current();
 	void _menu_option_confirm(int p_option, bool p_confirmed);


### PR DESCRIPTION
Fixes #56803
The bug was initially reported for `v3.4.1.stable.official` but it's also relevant for `master` 

![2GA476T4jl](https://user-images.githubusercontent.com/79299300/151128460-9e586b8c-f231-4ea6-874e-71ae42e97d97.gif)

