### PR TITLE
[3.x] Fix XR Android manifest metadata

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -987,14 +987,14 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 
 					if (tname == "meta-data" && attrname == "name" && value == "xr_mode_metadata_name") {
 						// Update the meta-data 'android:name' attribute based on the selected XR mode.
-						if (xr_mode_index == XR_MODE_OVR || xr_mode_index == XR_MODE_OPENXR) {
+						if (xr_mode_index == XR_MODE_OVR) {
 							string_table.write[attr_value] = "com.samsung.android.vr.application.mode";
 						}
 					}
 
 					if (tname == "meta-data" && attrname == "value" && value == "xr_mode_metadata_value") {
 						// Update the meta-data 'android:value' attribute based on the selected XR mode.
-						if (xr_mode_index == XR_MODE_OVR || xr_mode_index == XR_MODE_OPENXR) {
+						if (xr_mode_index == XR_MODE_OVR) {
 							string_table.write[attr_value] = "vr_only";
 						}
 					}

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -287,7 +287,9 @@ String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_
 			bool_to_string(p_has_storage_permission));
 
 	if (uses_xr) {
-		manifest_application_text += "        <meta-data tools:node=\"replace\" android:name=\"com.samsung.android.vr.application.mode\" android:value=\"vr_only\" />\n";
+		if (xr_mode_index == XR_MODE_OVR) {
+			manifest_application_text += "        <meta-data tools:node=\"replace\" android:name=\"com.samsung.android.vr.application.mode\" android:value=\"vr_only\" />\n";
+		}
 
 		bool hand_tracking_enabled = (int)(p_preset->get("xr_features/hand_tracking")) > XR_HAND_TRACKING_NONE;
 		if (hand_tracking_enabled) {
@@ -297,6 +299,8 @@ String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_
 					"        <meta-data tools:node=\"replace\" android:name=\"com.oculus.handtracking.frequency\" android:value=\"%s\" />\n",
 					hand_tracking_frequency);
 		}
+	} else {
+		manifest_application_text += "        <meta-data tools:node=\"remove\" android:name=\"com.oculus.supportedDevices\" />\n";
 	}
 	manifest_application_text += _get_activity_tag(p_preset);
 	manifest_application_text += "    </application>\n";

--- a/platform/android/java/app/AndroidManifest.xml
+++ b/platform/android/java/app/AndroidManifest.xml
@@ -50,6 +50,12 @@
             android:name="xr_hand_tracking_metadata_name"
             android:value="xr_hand_tracking_metadata_value"/>
 
+        <!-- Supported Meta devices -->
+        <!-- This is removed by the exporter if the xr mode is not VR. -->
+        <meta-data
+            android:name="com.oculus.supportedDevices"
+            android:value="all" />
+
         <activity
             android:name=".GodotApp"
             android:label="@string/godot_project_name_string"


### PR DESCRIPTION
- Adds the parameters for supported Meta devices, which is required to access some device specific capabilities
- Remove the `com.samsung.android.vr.application.mode` metadata when we're not using the VrApi plugin

Fixes https://github.com/GodotVR/godot_openxr/issues/158

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
