### PR TITLE
Import assets before loading editor plugins

### DIFF
--- a/doc/classes/EditorFileSystem.xml
+++ b/doc/classes/EditorFileSystem.xml
@@ -69,6 +69,11 @@
 		</method>
 	</methods>
 	<signals>
+		<signal name="addons_scanned">
+			<description>
+				Emitted on the first scan of the filesystem, after the addons folder has been scanned, but before [signal filesystem_changed] is emitted.
+			</description>
+		</signal>
 		<signal name="filesystem_changed">
 			<description>
 				Emitted if the filesystem changed.

--- a/editor/editor_file_system.h
+++ b/editor/editor_file_system.h
@@ -256,6 +256,8 @@ class EditorFileSystem : public Node {
 
 	static ResourceUID::ID _resource_saver_get_resource_id_for_path(const String &p_path, bool p_generate);
 
+	HashMap<String, EditorFileSystemDirectory *> addon_root_directories;
+
 	bool _scan_extensions();
 
 protected:

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -625,19 +625,6 @@ void EditorNode::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_READY: {
-			{
-				_initializing_addons = true;
-				Vector<String> addons;
-				if (ProjectSettings::get_singleton()->has_setting("editor_plugins/enabled")) {
-					addons = ProjectSettings::get_singleton()->get("editor_plugins/enabled");
-				}
-
-				for (int i = 0; i < addons.size(); i++) {
-					set_addon_plugin_enabled(addons[i], true);
-				}
-				_initializing_addons = false;
-			}
-
 			RenderingServer::get_singleton()->viewport_set_disable_2d(get_scene_root()->get_viewport_rid(), true);
 			RenderingServer::get_singleton()->viewport_set_disable_environment(get_viewport()->get_viewport_rid(), true);
 
@@ -4120,6 +4107,19 @@ void EditorNode::progress_end_task_bg(const String &p_task) {
 	singleton->progress_hb->end_task(p_task);
 }
 
+void EditorNode::_initialize_addons() {
+	_initializing_addons = true;
+	Vector<String> addons;
+	if (ProjectSettings::get_singleton()->has_setting("editor_plugins/enabled")) {
+		addons = ProjectSettings::get_singleton()->get("editor_plugins/enabled");
+	}
+
+	for (int i = 0; i < addons.size(); i++) {
+		set_addon_plugin_enabled(addons[i], true);
+	}
+	_initializing_addons = false;
+}
+
 Ref<Texture2D> EditorNode::_file_dialog_get_icon(const String &p_path) {
 	EditorFileSystemDirectory *efsd = EditorFileSystem::get_singleton()->get_filesystem_path(p_path.get_base_dir());
 	if (efsd) {
@@ -7134,6 +7134,7 @@ EditorNode::EditorNode() {
 	EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorNode::_fs_changed));
 	EditorFileSystem::get_singleton()->connect("resources_reimported", callable_mp(this, &EditorNode::_resources_reimported));
 	EditorFileSystem::get_singleton()->connect("resources_reload", callable_mp(this, &EditorNode::_resources_changed));
+	EditorFileSystem::get_singleton()->connect("addons_scanned", callable_mp(this, &EditorNode::_initialize_addons));
 
 	_build_icon_type_cache();
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -551,6 +551,7 @@ private:
 
 	bool _initializing_addons;
 	Map<String, EditorPlugin *> plugin_addons;
+	void _initialize_addons();
 
 	static Ref<Texture2D> _file_dialog_get_icon(const String &p_path);
 	static void _file_dialog_register(FileDialog *p_dialog);


### PR DESCRIPTION
Hopefully fixes #36713!
This time, the addons folder is scanned first by the EditorFileSystem, then addons (including import plugins) are loaded, then the EditorFileSystem is updated and scans the rest of the project. This approach should prevent the regressions present in #52344: #52968 and #52995. I've tested this with an admittedly thrown together project, and I'm not experiencing them. I don't have an MRP for #36713 that works in 4.0 alpha, so I'm marking this PR as draft since I haven't tested whether it fixes what it's supposed to fix 😕 . If someone can test it, that would be great, but I probably should be keeping a separate 3.x clone on my computer anyways to use.