### PR TITLE
Add mouse input interaction to `GridMap`

### DIFF
--- a/doc/classes/CollisionObject3D.xml
+++ b/doc/classes/CollisionObject3D.xml
@@ -179,7 +179,7 @@
 		<member name="disable_mode" type="int" setter="set_disable_mode" getter="get_disable_mode" enum="CollisionObject3D.DisableMode" default="0">
 			Defines the behavior in physics when [member Node.process_mode] is set to [constant Node.PROCESS_MODE_DISABLED]. See [enum DisableMode] for more details about the different modes.
 		</member>
-		<member name="input_capture_on_drag" type="bool" setter="set_capture_input_on_drag" getter="get_capture_input_on_drag" default="false">
+		<member name="input_capture_on_drag" type="bool" setter="set_capture_input_on_drag" getter="is_capturing_input_on_drag" default="false">
 			If [code]true[/code], the [CollisionObject3D] will continue to receive input events as the mouse is dragged across its shapes.
 		</member>
 		<member name="input_ray_pickable" type="bool" setter="set_ray_pickable" getter="is_ray_pickable" default="true">

--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -16,6 +16,23 @@
 		<link title="3D Kinematic Character Demo">https://godotengine.org/asset-library/asset/126</link>
 	</tutorials>
 	<methods>
+		<method name="_input_event" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="camera" type="Camera3D" />
+			<argument index="1" name="event" type="InputEvent" />
+			<argument index="2" name="collision" type="Dictionary" />
+			<description>
+				Receives unhandled [InputEvent]s. Requires [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set. The [code]collision[/code] dictionary contains the following field:
+				[code]position[/code]: The location in world space of the mouse pointer on the surface of the collided shape.
+				[code]normal[/code]: Normal vector of the surface at the collision point.
+				[code]rid[/code]: The RID identifier of the static body that owns the collided shape. Each octant in the grid has its own static body. So a [GridMap] can have multiple static bodies.
+				[code]shape_idx[/code]: The index of the collided shape.
+				[code]cell[/code]: The cell in the grid where the shape is located.
+				[code]item_shape[/code]: The shape index within the cell. This index is taken according to the shapes order in the [member mesh_library] for the item present in that cell.
+				Connecting to the [signal input_event] signal allows to easily pick up these events.
+				[b]Note:[/b] If the mouse is being dragged after entering one of the shapes, and [member input_capture_on_drag] is [code]true[/code], this function will continue to be called, but the values in the [code]collision[/code] dictionary won't be valid.
+			</description>
+		</method>
 		<method name="clear">
 			<return type="void" />
 			<description>
@@ -169,11 +186,17 @@
 			This does not affect the size of the meshes. See [member cell_scale].
 		</member>
 		<member name="collision_layer" type="int" setter="set_collision_layer" getter="get_collision_layer" default="1">
-			The physics layers this GridMap is in.
+			The physics layers this [GridMap] is in.
 			GridMaps act as static bodies, meaning they aren't affected by gravity or other forces. They only affect other physics bodies that collide with them.
 		</member>
 		<member name="collision_mask" type="int" setter="set_collision_mask" getter="get_collision_mask" default="1">
-			The physics layers this GridMap detects collisions in. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
+			The physics layers this [GridMap] detects collisions in. See [url=$DOCS_URL/tutorials/physics/physics_introduction.html#collision-layers-and-masks]Collision layers and masks[/url] in the documentation for more information.
+		</member>
+		<member name="input_capture_on_drag" type="bool" setter="set_capture_input_on_drag" getter="is_capturing_input_on_drag" default="false">
+			If [code]true[/code], the [GridMap] will continue to receive input events as the mouse is dragged across its shapes.
+		</member>
+		<member name="input_ray_pickable" type="bool" setter="set_ray_pickable" getter="is_ray_pickable" default="true">
+			If [code]true[/code], this object is pickable. A pickable object can detect the mouse pointer entering/leaving, and if the mouse is inside it, report input events. Requires at least one [member collision_layer] bit to be set.
 		</member>
 		<member name="mesh_library" type="MeshLibrary" setter="set_mesh_library" getter="get_mesh_library">
 			The assigned [MeshLibrary].
@@ -190,6 +213,28 @@
 			<argument index="0" name="cell_size" type="Vector3" />
 			<description>
 				Emitted when [member cell_size] changes.
+			</description>
+		</signal>
+		<signal name="input_event">
+			<argument index="0" name="camera" type="Node" />
+			<argument index="1" name="event" type="InputEvent" />
+			<argument index="2" name="collision" type="Dictionary" />
+			<description>
+				Emitted when the object receives an unhandled [InputEvent]. See the [method _input_event] method for more information about the input parameters.
+			</description>
+		</signal>
+		<signal name="mouse_entered">
+			<argument index="0" name="cell" type="Vector3i" />
+			<argument index="1" name="item_shape" type="int" />
+			<description>
+				Emitted when the mouse pointer enters any of this object's shapes or moves from one shape to another. The shape that the mouse is interacting with is located at [code]cell[/code] and has the index [code]item_shape[/code] within that cell. Requires [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
+			</description>
+		</signal>
+		<signal name="mouse_exited">
+			<argument index="0" name="cell" type="Vector3i" />
+			<argument index="1" name="item_shape" type="int" />
+			<description>
+				Emitted when the mouse pointer exits any of this object's shapes or moves from one shape to another. The shape that the mouse is interacting with is located at [code]cell[/code] and has the index [code]item_shape[/code] within that cell. Requires [member input_ray_pickable] to be [code]true[/code] and at least one [member collision_layer] bit to be set.
 			</description>
 		</signal>
 	</signals>

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -198,6 +198,46 @@ bool GridMap::get_collision_mask_value(int p_layer_number) const {
 	return get_collision_mask() & (1 << (p_layer_number - 1));
 }
 
+void GridMap::set_ray_pickable(bool p_ray_pickable) {
+	ray_pickable = p_ray_pickable;
+	_update_pickable();
+}
+
+bool GridMap::is_ray_pickable() const {
+	return ray_pickable;
+}
+
+void GridMap::set_capture_input_on_drag(bool p_capture) {
+	capture_input_on_drag = p_capture;
+}
+
+bool GridMap::is_capturing_input_on_drag() const {
+	return capture_input_on_drag;
+}
+
+Vector3i GridMap::static_body_get_shape_cell(RID p_body, int p_shape) const {
+	return _get_staticbody_shape_data(p_body, p_shape).first;
+}
+
+int GridMap::static_body_get_item_shape_index(RID p_body, int p_shape) const {
+	return _get_staticbody_shape_data(p_body, p_shape).second;
+}
+
+Pair<GridMap::IndexKey, int> GridMap::_get_staticbody_shape_data(RID p_body, int p_shape) const {
+	const Map<RID, Map<int, Pair<IndexKey, int>> *>::Element *SM = bodies_map.find(p_body);
+	if (!SM) {
+		Pair<IndexKey, int> p = Pair<IndexKey, int>(IndexKey(), 0);
+		ERR_FAIL_V_MSG(p, "Static body RID not owned by GridMap.");
+	}
+	Map<int, Pair<IndexKey, int>> *shapes_map = SM->get();
+	Map<int, Pair<IndexKey, int>>::Element *P = shapes_map->find(p_shape);
+	if (!P) {
+		Pair<IndexKey, int> p = Pair<IndexKey, int>(IndexKey(), 0);
+		ERR_FAIL_V_MSG(p, "Incorrect shape index for GridMap static body.");
+	}
+	return P->get();
+}
+
 Array GridMap::get_collision_shapes() const {
 	Array shapes;
 	for (const KeyValue<OctantKey, Octant *> &E : octant_map) {
@@ -357,6 +397,7 @@ void GridMap::set_cell_item(const Vector3i &p_position, int p_item, int p_rot) {
 			RenderingServer::get_singleton()->instance_set_base(g->collision_debug_instance, g->collision_debug);
 		}
 
+		bodies_map[g->static_body] = &g->shapes_map;
 		octant_map[octantkey] = g;
 
 		if (is_inside_world()) {
@@ -481,6 +522,8 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 	 */
 
 	Map<int, List<Pair<Transform3D, IndexKey>>> multimesh_items;
+	int shapeidx = 0;
+	g.shapes_map.clear();
 
 	for (Set<IndexKey>::Element *E = g.cells.front(); E; E = E->next()) {
 		ERR_CONTINUE(!cell_map.has(E->get()));
@@ -519,6 +562,9 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 				continue;
 			}
 			PhysicsServer3D::get_singleton()->body_add_shape(g.static_body, shapes[i].shape->get_rid(), xform * shapes[i].local_transform);
+			g.shapes_map[shapeidx] = Pair<IndexKey, int>(E->get(), i);
+			shapeidx++;
+
 			if (g.collision_debug.is_valid()) {
 				shapes.write[i].shape->add_vertices_to_array(col_debug, xform * shapes[i].local_transform);
 			}
@@ -673,7 +719,9 @@ void GridMap::_octant_clean_up(const OctantKey &p_key) {
 		RS::get_singleton()->free(g.collision_debug_instance);
 	}
 
+	bodies_map.erase(g.static_body);
 	PhysicsServer3D::get_singleton()->free(g.static_body);
+	g.shapes_map.clear();
 
 	// Erase navigation
 	for (const KeyValue<IndexKey, Octant::NavMesh> &E : g.navmesh_ids) {
@@ -704,6 +752,7 @@ void GridMap::_notification(int p_what) {
 				RS::get_singleton()->instance_set_transform(baked_meshes[i].instance, get_global_transform());
 			}
 
+			_update_pickable();
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			Transform3D new_xform = get_global_transform();
@@ -736,6 +785,7 @@ void GridMap::_notification(int p_what) {
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			_update_visibility();
+			_update_pickable();
 		} break;
 	}
 }
@@ -789,6 +839,7 @@ void GridMap::_clear_internal() {
 
 	octant_map.clear();
 	cell_map.clear();
+	bodies_map.clear();
 }
 
 void GridMap::clear() {
@@ -818,7 +869,59 @@ void GridMap::_update_octants_callback() {
 	}
 
 	_update_visibility();
+	_update_pickable();
 	awaiting_update = false;
+}
+
+void GridMap::_update_pickable() {
+	if (!is_inside_tree()) {
+		return;
+	}
+
+	bool pickable = ray_pickable && is_visible_in_tree();
+	for (KeyValue<OctantKey, Octant *> &E : octant_map) {
+		Octant *o = E.value;
+		PhysicsServer3D::get_singleton()->body_set_ray_pickable(o->static_body, pickable);
+	}
+}
+
+void GridMap::_input_event_call(Camera3D *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, RID p_rid, int p_shape) {
+	Vector3i cell = Vector3i();
+	int item_shape = 0;
+	if (p_rid != RID()) {
+		Pair<IndexKey, int> p = _get_staticbody_shape_data(p_rid, p_shape);
+		cell = p.first;
+		item_shape = p.second;
+	}
+	Dictionary collision;
+	collision["position"] = p_pos;
+	collision["normal"] = p_normal;
+	collision["rid"] = p_rid;
+	collision["shape_idx"] = p_shape;
+	collision["cell"] = cell;
+	collision["item_shape"] = item_shape;
+	GDVIRTUAL_CALL(_input_event, p_camera, p_input_event, collision);
+	emit_signal(SceneStringNames::get_singleton()->input_event, p_camera, p_input_event, collision);
+}
+
+void GridMap::_mouse_enter(RID p_rid, int p_shape) {
+	Pair<IndexKey, int> p = _get_staticbody_shape_data(p_rid, p_shape);
+	Vector3i cell = p.first;
+	int item_shape = p.second;
+	if (get_script_instance()) {
+		get_script_instance()->call(SceneStringNames::get_singleton()->_mouse_enter, cell, item_shape);
+	}
+	emit_signal(SceneStringNames::get_singleton()->mouse_entered, cell, item_shape);
+}
+
+void GridMap::_mouse_exit(RID p_rid, int p_shape) {
+	Pair<IndexKey, int> p = _get_staticbody_shape_data(p_rid, p_shape);
+	Vector3i cell = p.first;
+	int item_shape = p.second;
+	if (get_script_instance()) {
+		get_script_instance()->call(SceneStringNames::get_singleton()->_mouse_exit, cell, item_shape);
+	}
+	emit_signal(SceneStringNames::get_singleton()->mouse_exited, cell, item_shape);
 }
 
 void GridMap::_bind_methods() {
@@ -836,6 +939,11 @@ void GridMap::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_physics_material", "material"), &GridMap::set_physics_material);
 	ClassDB::bind_method(D_METHOD("get_physics_material"), &GridMap::get_physics_material);
+
+	ClassDB::bind_method(D_METHOD("set_ray_pickable", "ray_pickable"), &GridMap::set_ray_pickable);
+	ClassDB::bind_method(D_METHOD("is_ray_pickable"), &GridMap::is_ray_pickable);
+	ClassDB::bind_method(D_METHOD("set_capture_input_on_drag", "enable"), &GridMap::set_capture_input_on_drag);
+	ClassDB::bind_method(D_METHOD("is_capturing_input_on_drag"), &GridMap::is_capturing_input_on_drag);
 
 	ClassDB::bind_method(D_METHOD("set_bake_navigation", "bake_navigation"), &GridMap::set_bake_navigation);
 	ClassDB::bind_method(D_METHOD("is_baking_navigation"), &GridMap::is_baking_navigation);
@@ -897,13 +1005,21 @@ void GridMap::_bind_methods() {
 	ADD_GROUP("Collision", "collision_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_layer", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_layer", "get_collision_layer");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "collision_mask", PROPERTY_HINT_LAYERS_3D_PHYSICS), "set_collision_mask", "get_collision_mask");
+	ADD_GROUP("Input", "input_");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "input_ray_pickable"), "set_ray_pickable", "is_ray_pickable");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "input_capture_on_drag"), "set_capture_input_on_drag", "is_capturing_input_on_drag");
 	ADD_GROUP("Navigation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "bake_navigation"), "set_bake_navigation", "is_baking_navigation");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigation_layers", PROPERTY_HINT_LAYERS_3D_NAVIGATION), "set_navigation_layers", "get_navigation_layers");
 
+	GDVIRTUAL_BIND(_input_event, "camera", "event", "collision");
+
 	BIND_CONSTANT(INVALID_CELL_ITEM);
 
 	ADD_SIGNAL(MethodInfo("cell_size_changed", PropertyInfo(Variant::VECTOR3, "cell_size")));
+	ADD_SIGNAL(MethodInfo("input_event", PropertyInfo(Variant::OBJECT, "camera", PROPERTY_HINT_RESOURCE_TYPE, "Node"), PropertyInfo(Variant::OBJECT, "event", PROPERTY_HINT_RESOURCE_TYPE, "InputEvent"), PropertyInfo(Variant::DICTIONARY, "collision")));
+	ADD_SIGNAL(MethodInfo("mouse_entered", PropertyInfo(Variant::VECTOR3I, "cell"), PropertyInfo(Variant::INT, "item_shape")));
+	ADD_SIGNAL(MethodInfo("mouse_exited", PropertyInfo(Variant::VECTOR3I, "cell"), PropertyInfo(Variant::INT, "item_shape")));
 }
 
 void GridMap::set_clip(bool p_enabled, bool p_clip_above, int p_floor, Vector3::Axis p_axis) {

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -31,6 +31,7 @@
 #ifndef GRID_MAP_H
 #define GRID_MAP_H
 
+#include "scene/3d/camera_3d.h"
 #include "scene/3d/node_3d.h"
 #include "scene/resources/mesh_library.h"
 #include "scene/resources/multimesh.h"
@@ -113,6 +114,7 @@ class GridMap : public Node3D {
 
 		bool dirty = false;
 		RID static_body;
+		Map<int, Pair<IndexKey, int>> shapes_map;
 		Map<IndexKey, NavMesh> navmesh_ids;
 	};
 
@@ -137,6 +139,10 @@ class GridMap : public Node3D {
 	uint32_t collision_layer = 1;
 	uint32_t collision_mask = 1;
 	Ref<PhysicsMaterial> physics_material;
+	bool capture_input_on_drag = false;
+	bool ray_pickable = true;
+	Map<RID, Map<int, Pair<IndexKey, int>> *> bodies_map;
+
 	bool bake_navigation = false;
 	uint32_t navigation_layers = 1;
 
@@ -186,12 +192,15 @@ class GridMap : public Node3D {
 
 	void _queue_octants_dirty();
 	void _update_octants_callback();
+	void _update_pickable();
 
 	void resource_changed(const RES &p_res);
 
 	void _clear_internal();
 
 	Vector3 _get_offset() const;
+
+	Pair<IndexKey, int> _get_staticbody_shape_data(RID p_body, int p_shape) const;
 
 	struct BakedMesh {
 		Ref<Mesh> mesh;
@@ -209,6 +218,12 @@ protected:
 	void _update_visibility();
 	static void _bind_methods();
 
+	friend class Viewport;
+	virtual void _input_event_call(Camera3D *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, RID p_rid, int p_shape);
+	virtual void _mouse_enter(RID p_rid, int p_shape);
+	virtual void _mouse_exit(RID p_rid, int p_shape);
+
+	GDVIRTUAL3(_input_event, Camera3D *, Ref<InputEvent>, Dictionary)
 public:
 	enum {
 		INVALID_CELL_ITEM = -1
@@ -228,6 +243,15 @@ public:
 
 	void set_physics_material(Ref<PhysicsMaterial> p_material);
 	Ref<PhysicsMaterial> get_physics_material() const;
+
+	void set_ray_pickable(bool p_ray_pickable);
+	bool is_ray_pickable() const;
+
+	void set_capture_input_on_drag(bool p_capture);
+	bool is_capturing_input_on_drag() const;
+
+	Vector3i static_body_get_shape_cell(RID p_body, int p_shape) const;
+	int static_body_get_item_shape_index(RID p_body, int p_shape) const;
 
 	Array get_collision_shapes() const;
 

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -435,7 +435,7 @@ void CollisionObject3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_ray_pickable", "ray_pickable"), &CollisionObject3D::set_ray_pickable);
 	ClassDB::bind_method(D_METHOD("is_ray_pickable"), &CollisionObject3D::is_ray_pickable);
 	ClassDB::bind_method(D_METHOD("set_capture_input_on_drag", "enable"), &CollisionObject3D::set_capture_input_on_drag);
-	ClassDB::bind_method(D_METHOD("get_capture_input_on_drag"), &CollisionObject3D::get_capture_input_on_drag);
+	ClassDB::bind_method(D_METHOD("is_capturing_input_on_drag"), &CollisionObject3D::is_capturing_input_on_drag);
 	ClassDB::bind_method(D_METHOD("get_rid"), &CollisionObject3D::get_rid);
 	ClassDB::bind_method(D_METHOD("create_shape_owner", "owner"), &CollisionObject3D::create_shape_owner);
 	ClassDB::bind_method(D_METHOD("remove_shape_owner", "owner_id"), &CollisionObject3D::remove_shape_owner);
@@ -467,7 +467,7 @@ void CollisionObject3D::_bind_methods() {
 
 	ADD_GROUP("Input", "input_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "input_ray_pickable"), "set_ray_pickable", "is_ray_pickable");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "input_capture_on_drag"), "set_capture_input_on_drag", "get_capture_input_on_drag");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "input_capture_on_drag"), "set_capture_input_on_drag", "is_capturing_input_on_drag");
 
 	BIND_ENUM_CONSTANT(DISABLE_MODE_REMOVE);
 	BIND_ENUM_CONSTANT(DISABLE_MODE_MAKE_STATIC);
@@ -681,7 +681,7 @@ void CollisionObject3D::set_capture_input_on_drag(bool p_capture) {
 	capture_input_on_drag = p_capture;
 }
 
-bool CollisionObject3D::get_capture_input_on_drag() const {
+bool CollisionObject3D::is_capturing_input_on_drag() const {
 	return capture_input_on_drag;
 }
 

--- a/scene/3d/collision_object_3d.h
+++ b/scene/3d/collision_object_3d.h
@@ -154,7 +154,7 @@ public:
 	bool is_ray_pickable() const;
 
 	void set_capture_input_on_drag(bool p_capture);
-	bool get_capture_input_on_drag() const;
+	bool is_capturing_input_on_drag() const;
 
 	_FORCE_INLINE_ RID get_rid() const { return rid; }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -58,6 +58,10 @@
 #include "servers/audio_server.h"
 #include "servers/rendering/rendering_server_globals.h"
 
+#ifdef MODULE_GRIDMAP_ENABLED
+#include "modules/gridmap/grid_map.h"
+#endif
+
 void ViewportTexture::setup_local_to_scene() {
 	Node *local_scene = get_local_scene();
 	if (!local_scene) {
@@ -523,13 +527,6 @@ void Viewport::_process_picking() {
 
 	_drop_physics_mouseover(true);
 
-#ifndef _3D_DISABLED
-	Vector2 last_pos(1e20, 1e20);
-	CollisionObject3D *last_object = nullptr;
-	ObjectID last_id;
-	PhysicsDirectSpaceState3D::RayResult result;
-#endif // _3D_DISABLED
-
 	PhysicsDirectSpaceState2D *ss2d = PhysicsServer2D::get_singleton()->space_get_direct_state(find_world_2d()->get_space());
 
 	if (physics_has_last_mousepos) {
@@ -559,6 +556,16 @@ void Viewport::_process_picking() {
 			physics_picking_events.push_back(mm);
 		}
 	}
+
+#ifndef _3D_DISABLED
+	Vector2 last_pos(1e20, 1e20);
+	CollisionObject3D *last_object = nullptr;
+	ObjectID last_id;
+	PhysicsDirectSpaceState3D::RayResult result;
+#ifdef MODULE_GRIDMAP_ENABLED
+	GridMap *last_gridmap = nullptr;
+#endif
+#endif // _3D_DISABLED
 
 	while (physics_picking_events.size()) {
 		Ref<InputEvent> ev = physics_picking_events.front()->get();
@@ -707,9 +714,21 @@ void Viewport::_process_picking() {
 				if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed()) {
 					physics_object_capture = ObjectID();
 				}
-
 			} else {
+#ifdef MODULE_GRIDMAP_ENABLED
+				GridMap *gm = Object::cast_to<GridMap>(ObjectDB::get_instance(physics_object_capture));
+				if (gm && camera_3d) {
+					_gridmap_input_event(gm, camera_3d, ev, Vector3(), Vector3(), RID(), 0);
+					captured = true;
+					if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && !mb->is_pressed()) {
+						physics_object_capture = ObjectID();
+					}
+				} else {
+					physics_object_capture = ObjectID();
+				}
+#else
 				physics_object_capture = ObjectID();
+#endif
 			}
 		}
 
@@ -717,11 +736,21 @@ void Viewport::_process_picking() {
 			// None.
 		} else if (pos == last_pos) {
 			if (last_id.is_valid()) {
-				if (ObjectDB::get_instance(last_id) && last_object) {
-					// Good, exists.
-					_collision_object_3d_input_event(last_object, camera_3d, ev, result.position, result.normal, result.shape);
-					if (last_object->get_capture_input_on_drag() && mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
-						physics_object_capture = last_id;
+				if (ObjectDB::get_instance(last_id)) {
+					if (last_object) {
+						// Collider is a CollisionObject3D.
+						_collision_object_3d_input_event(last_object, camera_3d, ev, result.position, result.normal, result.shape);
+						if (last_object->is_capturing_input_on_drag() && mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
+							physics_object_capture = last_id;
+						}
+#ifdef MODULE_GRIDMAP_ENABLED
+					} else if (last_gridmap) {
+						// Collider is a GridMap.
+						_gridmap_input_event(last_gridmap, camera_3d, ev, result.position, result.normal, result.rid, result.shape);
+						if (last_gridmap->is_capturing_input_on_drag() && mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
+							physics_object_capture = last_id;
+						}
+#endif // MODULE_GRIDMAP_ENABLED
 					}
 				}
 			}
@@ -741,24 +770,63 @@ void Viewport::_process_picking() {
 
 					bool col = space->intersect_ray(ray_params, result);
 					ObjectID new_collider;
+#ifdef MODULE_GRIDMAP_ENABLED
+					int new_shape = -1;
+					RID new_rid;
+#endif
 					if (col) {
 						CollisionObject3D *co = Object::cast_to<CollisionObject3D>(result.collider);
-						if (co && co->can_process()) {
-							_collision_object_3d_input_event(co, camera_3d, ev, result.position, result.normal, result.shape);
-							last_object = co;
-							last_id = result.collider_id;
-							new_collider = last_id;
-							if (co->get_capture_input_on_drag() && mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
-								physics_object_capture = last_id;
+						if (co) {
+							if (co->can_process()) {
+								_collision_object_3d_input_event(co, camera_3d, ev, result.position, result.normal, result.shape);
+								last_object = co;
+								last_id = result.collider_id;
+								new_collider = last_id;
+#ifdef MODULE_GRIDMAP_ENABLED
+								last_gridmap = nullptr;
+								new_shape = -1;
+								new_rid = RID();
+#endif
+								if (co->is_capturing_input_on_drag() && mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
+									physics_object_capture = last_id;
+								}
+							}
+#ifdef MODULE_GRIDMAP_ENABLED
+						} else {
+							GridMap *gm = Object::cast_to<GridMap>(result.collider);
+							if (gm && gm->can_process()) {
+								_gridmap_input_event(gm, camera_3d, ev, result.position, result.normal, result.rid, result.shape);
+								last_gridmap = gm;
+								last_id = result.collider_id;
+								new_collider = last_id;
+								new_rid = result.rid;
+								new_shape = result.shape;
+								last_object = nullptr;
+								if (gm->is_capturing_input_on_drag() && mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed()) {
+									physics_object_capture = last_id;
+								}
 							}
 						}
 					}
 
+					if (is_mouse && (new_collider != physics_object_over || new_rid != physics_rid_over || new_shape != physics_shape_over)) {
+#else
+						}
+					}
+
 					if (is_mouse && new_collider != physics_object_over) {
+#endif
 						if (physics_object_over.is_valid()) {
 							CollisionObject3D *co = Object::cast_to<CollisionObject3D>(ObjectDB::get_instance(physics_object_over));
 							if (co) {
 								co->_mouse_exit();
+#ifdef MODULE_GRIDMAP_ENABLED
+							} else {
+								GridMap *gm = Object::cast_to<GridMap>(ObjectDB::get_instance(physics_object_over));
+								if (gm) {
+									gm->_mouse_exit(physics_rid_over, physics_shape_over);
+								}
+#endif // MODULE_GRIDMAP_ENABLED
 							}
 						}
 
@@ -766,10 +834,21 @@ void Viewport::_process_picking() {
 							CollisionObject3D *co = Object::cast_to<CollisionObject3D>(ObjectDB::get_instance(new_collider));
 							if (co) {
 								co->_mouse_enter();
+#ifdef MODULE_GRIDMAP_ENABLED
+							} else {
+								GridMap *gm = Object::cast_to<GridMap>(ObjectDB::get_instance(new_collider));
+								if (gm) {
+									gm->_mouse_enter(new_rid, new_shape);
+								}
+#endif // MODULE_GRIDMAP_ENABLED
 							}
 						}
 
 						physics_object_over = new_collider;
+#ifdef MODULE_GRIDMAP_ENABLED
+						physics_rid_over = new_rid;
+						physics_shape_over = new_shape;
+#endif
 					}
 				}
 
@@ -2215,11 +2294,35 @@ void Viewport::_drop_physics_mouseover(bool p_paused_only) {
 			if (!co->is_inside_tree()) {
 				physics_object_over = ObjectID();
 				physics_object_capture = ObjectID();
+#ifdef MODULE_GRIDMAP_ENABLED
+				physics_rid_over = RID();
+				physics_shape_over = -1;
+#endif
 			} else if (!(p_paused_only && co->can_process())) {
 				co->_mouse_exit();
 				physics_object_over = ObjectID();
 				physics_object_capture = ObjectID();
+#ifdef MODULE_GRIDMAP_ENABLED
+				physics_rid_over = RID();
+				physics_shape_over = -1;
+#endif
 			}
+#ifdef MODULE_GRIDMAP_ENABLED
+		} else {
+			GridMap *gm = Object::cast_to<GridMap>(ObjectDB::get_instance(physics_object_over));
+			if (gm) {
+				if (!gm->is_inside_tree()) {
+					physics_object_over = ObjectID();
+					physics_object_capture = ObjectID();
+					physics_rid_over = RID();
+					physics_shape_over = -1;
+				} else if (!(p_paused_only && gm->can_process())) {
+					gm->_mouse_exit(physics_rid_over, physics_shape_over);
+					physics_rid_over = RID();
+					physics_shape_over = -1;
+				}
+			}
+#endif // MODULE_GRIDMAP_ENABLED
 		}
 	}
 #endif // _3D_DISABLED
@@ -3167,6 +3270,26 @@ void Viewport::_collision_object_3d_input_event(CollisionObject3D *p_object, Cam
 	physics_last_camera_transform = camera_transform;
 	physics_last_id = id;
 }
+
+#ifdef MODULE_GRIDMAP_ENABLED
+void Viewport::_gridmap_input_event(GridMap *p_gridmap, Camera3D *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, RID p_rid, int p_shape) {
+	Transform3D gridmap_transform = p_gridmap->get_global_transform();
+	Transform3D camera_transform = p_camera->get_global_transform();
+	ObjectID id = p_gridmap->get_instance_id();
+
+	// Avoid sending the fake event unnecessarily if nothing really changed in the context.
+	if (gridmap_transform == physics_last_object_transform && camera_transform == physics_last_camera_transform && physics_last_id == id) {
+		Ref<InputEventMouseMotion> mm = p_input_event;
+		if (mm.is_valid() && mm->get_device() == InputEvent::DEVICE_ID_INTERNAL) {
+			return; // Discarded.
+		}
+	}
+	p_gridmap->_input_event_call(camera_3d, p_input_event, p_pos, p_normal, p_rid, p_shape);
+	physics_last_object_transform = gridmap_transform;
+	physics_last_camera_transform = camera_transform;
+	physics_last_id = id;
+}
+#endif // MODULE_GRIDMAP_ENABLED
 
 Camera3D *Viewport::get_camera_3d() const {
 	return camera_3d;

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -34,12 +34,18 @@
 #include "scene/main/node.h"
 #include "scene/resources/texture.h"
 
+#include "modules/modules_enabled.gen.h" // For gridmap.
+
 #ifndef _3D_DISABLED
 class Camera3D;
 class CollisionObject3D;
 class AudioListener3D;
 class World3D;
 #endif // _3D_DISABLED
+
+#ifdef MODULE_GRIDMAP_ENABLED
+class GridMap;
+#endif
 
 class AudioListener2D;
 class Camera2D;
@@ -241,6 +247,10 @@ private:
 	List<Ref<InputEvent>> physics_picking_events;
 	ObjectID physics_object_capture;
 	ObjectID physics_object_over;
+#ifdef MODULE_GRIDMAP_ENABLED
+	int physics_shape_over = -1;
+	RID physics_rid_over = RID();
+#endif
 	Transform3D physics_last_object_transform;
 	Transform3D physics_last_camera_transform;
 	ObjectID physics_last_id;
@@ -625,6 +635,9 @@ public:
 	void _audio_listener_3d_make_next_current(AudioListener3D *p_exclude);
 
 	void _collision_object_3d_input_event(CollisionObject3D *p_object, Camera3D *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, int p_shape);
+#ifdef MODULE_GRIDMAP_ENABLED
+	void _gridmap_input_event(GridMap *p_gridmap, Camera3D *p_camera, const Ref<InputEvent> &p_input_event, const Vector3 &p_pos, const Vector3 &p_normal, RID p_rid, int p_shape);
+#endif
 
 	struct Camera3DOverrideData {
 		Transform3D transform;


### PR DESCRIPTION
Based on this proposal godotengine/godot-proposals#3818. `input_event`, `mouse_entered` and `mouse_exited` signals are implemented. 
This can avoid the trouble found when raycasting on GridMap's shapes (see #46561).
With this implementation it becomes much easier to do things like this:
![GridMapsSignals](https://user-images.githubusercontent.com/29492561/151276879-5d02a936-b5ec-43c4-b145-f1cfc1c81a9a.gif)
I include the project I used for testing.
[GridMapTest.zip](https://github.com/godotengine/godot/files/7946887/GridMapTest.zip)

***Bugsquad edit:** This closes https://github.com/godotengine/godot-proposals/issues/3818.*