### PR TITLE
Fixes TileMap editor never disappearing

### DIFF
--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -166,8 +166,6 @@ void TilesEditorPlugin::_update_editors() {
 			editor_node->hide_bottom_panel();
 		}
 	}
-	tileset_editor_button->set_visible(tile_set.is_valid());
-	tilemap_editor_button->set_visible(tile_map);
 }
 
 void TilesEditorPlugin::_notification(int p_what) {


### PR DESCRIPTION
Fixes #57236

`TilesEditorPlugin::_update_editors()` was called after `TilesEditorPlugin::make_visible(false)` which caused the tile map editor to not disappear because it would always make `tileset_editor_button` and `tilemap_editor_button` visible again.
