### PR TITLE
Expose Transform3D::sphere_interpolate_with()

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1789,6 +1789,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform3D, scaled, sarray("scale"), varray());
 	bind_method(Transform3D, translated, sarray("offset"), varray());
 	bind_method(Transform3D, looking_at, sarray("target", "up"), varray(Vector3(0, 1, 0)));
+	bind_method(Transform3D, sphere_interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform3D, interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform3D, is_equal_approx, sarray("xform"), varray());
 

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -106,6 +106,14 @@
 				Scales basis and origin of the transform by the given scale factor, using matrix multiplication.
 			</description>
 		</method>
+		<method name="sphere_interpolate_with" qualifiers="const">
+			<return type="Transform3D" />
+			<argument index="0" name="xform" type="Transform3D" />
+			<argument index="1" name="weight" type="float" />
+			<description>
+				Returns a transform spherically interpolated between this transform and another by a given [code]weight[/code] (on the range of 0.0 to 1.0).
+			</description>
+		</method>
 		<method name="translated" qualifiers="const">
 			<return type="Transform3D" />
 			<argument index="0" name="offset" type="Vector3" />


### PR DESCRIPTION
This exposes `Transform3D::sphere_interpolate_with()` to GDScript to make the pre-4.0 behaviour accessible again (it was formerly accessible as `Transform3D::interpolate_with()`, but that is now regular linear interpolation).

Note that this seemingly was discussed on contributors chat as recently as January 13th (global search for `slerp`), and the consensus seem to be:
- To expose this
- To rename these to `lerp()` and `slerp()` respectively for consistency with other places in Godots API (`Basis` etc)

However, I could find no open PRs/changes for this. As alpha 1 is now out and users are actively missing this (see Reddit discussion below), I decided to do the minimally invasive thing and just expose it for now.

If we indeed want to rename these, I'm happy to do that in a further PR.

Fixes https://github.com/godotengine/godot/issues/57272
Also see discussion on [Reddit](https://www.reddit.com/r/godot/comments/sdaqfm/godot_40_should_transforminterpolate_with_be/?sort=confidence)