### PR TITLE
More time parameters change type `float` to `double` in animation features

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -854,10 +854,10 @@ void AnimationNodeStateMachineEditor::_state_machine_pos_draw() {
 	}
 	to.y = from.y;
 
-	float len = MAX(0.0001, current_length);
+	double len = MAX(0.0001, current_length);
 
-	float pos = CLAMP(play_pos, 0, len);
-	float c = pos / len;
+	double pos = CLAMP(play_pos, 0, len);
+	double c = pos / len;
 	Color fg = get_theme_color(SNAME("font_color"), SNAME("Label"));
 	Color bg = fg;
 	bg.a *= 0.3;

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -159,11 +159,11 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	StringName last_blend_from_node;
 	StringName last_current_node;
 	Vector<StringName> last_travel_path;
-	float last_play_pos;
-	float play_pos;
-	float current_length;
+	double last_play_pos;
+	double play_pos;
+	double current_length;
 
-	float error_time;
+	double error_time;
 	String error_text;
 
 	EditorFileDialog *open_file;

--- a/scene/animation/animation_blend_space_1d.cpp
+++ b/scene/animation/animation_blend_space_1d.cpp
@@ -292,10 +292,10 @@ double AnimationNodeBlendSpace1D::process(double p_time, bool p_seek) {
 
 	// actually blend the animations now
 
-	float max_time_remaining = 0.0;
+	double max_time_remaining = 0.0;
 
 	for (int i = 0; i < blend_points_used; i++) {
-		float remaining = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, weights[i], FILTER_IGNORE, false);
+		double remaining = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, weights[i], FILTER_IGNORE, false);
 
 		max_time_remaining = MAX(max_time_remaining, remaining);
 	}

--- a/scene/animation/animation_blend_space_2d.cpp
+++ b/scene/animation/animation_blend_space_2d.cpp
@@ -438,7 +438,7 @@ double AnimationNodeBlendSpace2D::process(double p_time, bool p_seek) {
 	Vector2 blend_pos = get_parameter(blend_position);
 	int closest = get_parameter(this->closest);
 	double length_internal = get_parameter(this->length_internal);
-	float mind = 0.0; //time of min distance point
+	double mind = 0.0; //time of min distance point
 
 	if (blend_mode == BLEND_MODE_INTERPOLATED) {
 		if (triangles.size() == 0) {
@@ -502,7 +502,7 @@ double AnimationNodeBlendSpace2D::process(double p_time, bool p_seek) {
 			for (int j = 0; j < 3; j++) {
 				if (i == triangle_points[j]) {
 					//blend with the given weight
-					float t = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, blend_weights[j], FILTER_IGNORE, false);
+					double t = blend_node(blend_points[i].name, blend_points[i].node, p_time, p_seek, blend_weights[j], FILTER_IGNORE, false);
 					if (first || t < mind) {
 						mind = t;
 						first = false;
@@ -530,7 +530,7 @@ double AnimationNodeBlendSpace2D::process(double p_time, bool p_seek) {
 		}
 
 		if (new_closest != closest && new_closest != -1) {
-			float from = 0.0;
+			double from = 0.0;
 			if (blend_mode == BLEND_MODE_DISCRETE_CARRY && closest != -1) {
 				//for ping-pong loop
 				Ref<AnimationNodeAnimation> na_c = static_cast<Ref<AnimationNodeAnimation>>(blend_points[closest].node);

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -750,7 +750,7 @@ double AnimationNodeTransition::process(double p_time, bool p_seek) {
 		return 0;
 	}
 
-	float rem = 0.0;
+	double rem = 0.0;
 
 	if (prev < 0) { // process current animation, check for transition
 


### PR DESCRIPTION
Fixed #57274.

The cause is that some of the time parameters in BlendSpace2D were `float`, and the time parameter `rem` in the process of `AnimationBlendTree` was `float`.