### PR TITLE
Added get_image_z() to OpenSimplexNoise

### DIFF
--- a/modules/opensimplex/open_simplex_noise.cpp
+++ b/modules/opensimplex/open_simplex_noise.cpp
@@ -180,6 +180,7 @@ void OpenSimplexNoise::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_lacunarity"), &OpenSimplexNoise::get_lacunarity);
 
 	ClassDB::bind_method(D_METHOD("get_image", "width", "height", "noise_offset"), &OpenSimplexNoise::get_image, DEFVAL(Vector2()));
+	ClassDB::bind_method(D_METHOD("get_image_z", "z", "width", "height", "noise_offset"), &OpenSimplexNoise::get_image_z, DEFVAL(Vector2()));
 	ClassDB::bind_method(D_METHOD("get_seamless_image", "size"), &OpenSimplexNoise::get_seamless_image);
 
 	ClassDB::bind_method(D_METHOD("get_noise_1d", "x"), &OpenSimplexNoise::get_noise_1d);

--- a/modules/opensimplex/open_simplex_noise.cpp
+++ b/modules/opensimplex/open_simplex_noise.cpp
@@ -122,7 +122,7 @@ Ref<Image> OpenSimplexNoise::get_image_z(float z, int p_width, int p_height, con
 
 	for (int i = 0; i < p_height; i++) {
 		for (int j = 0; j < p_width; j++) {
-			float v = get_noise_2d(float(j) + p_noise_offset.x, float(i) + p_noise_offset.y, z);
+			float v = get_noise_3d(float(j) + p_noise_offset.x, float(i) + p_noise_offset.y, z);
 			v = v * 0.5 + 0.5; // Normalize [0..1]
 			wd8[(i * p_width + j)] = uint8_t(CLAMP(v * 255.0, 0, 255));
 		}

--- a/modules/opensimplex/open_simplex_noise.cpp
+++ b/modules/opensimplex/open_simplex_noise.cpp
@@ -114,6 +114,24 @@ Ref<Image> OpenSimplexNoise::get_image(int p_width, int p_height, const Vector2 
 	return image;
 }
 
+Ref<Image> OpenSimplexNoise::get_image_z(float z, int p_width, int p_height, const Vector2 &p_noise_offset) const {
+	Vector<uint8_t> data;
+	data.resize(p_width * p_height);
+
+	uint8_t *wd8 = data.ptrw();
+
+	for (int i = 0; i < p_height; i++) {
+		for (int j = 0; j < p_width; j++) {
+			float v = get_noise_2d(float(j) + p_noise_offset.x, float(i) + p_noise_offset.y, z);
+			v = v * 0.5 + 0.5; // Normalize [0..1]
+			wd8[(i * p_width + j)] = uint8_t(CLAMP(v * 255.0, 0, 255));
+		}
+	}
+
+	Ref<Image> image = memnew(Image(p_width, p_height, false, Image::FORMAT_L8, data));
+	return image;
+}
+
 Ref<Image> OpenSimplexNoise::get_seamless_image(int p_size) const {
 	Vector<uint8_t> data;
 	data.resize(p_size * p_size);

--- a/modules/opensimplex/open_simplex_noise.h
+++ b/modules/opensimplex/open_simplex_noise.h
@@ -76,6 +76,7 @@ public:
 	float get_lacunarity() const { return lacunarity; }
 
 	Ref<Image> get_image(int p_width, int p_height, const Vector2 &p_noise_offset = Vector2()) const;
+	Ref<Image> get_image_z(float z, int p_width, int p_height, const Vector2 &p_noise_offset = Vector2()) const;
 	Ref<Image> get_seamless_image(int p_size) const;
 
 	float get_noise_1d(float x) const;


### PR DESCRIPTION
I was looking to make a noise texture smoothly evolve over time, and I knew that the way to do that in Blender is to use 3D noise and animate the Z parameter. To my disappointment, the get_image() function has no Z parameter, so I was out of luck. However, adding this function was relatively trivial, because it is the same function as get_image(), except it has a z parameter which simply gets passed directly into get_noise_3d() instead of calling get_noise_2d().

This is my first pull request here and I not know much C++ so I am not sure where the unit tests are, nor how to write them in this project. I also do not know what else may be necessary to expose this function to GDScript and the other supported scripting languages.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
