### PR TITLE
fixed bug causing particles to freeze

### DIFF
--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -4911,6 +4911,7 @@ void RendererStorageRD::particles_request_process(RID p_particles) {
 
 	if (!particles->dirty) {
 		particles->dirty = true;
+        particles->inactive_time = 0;
 		particles->update_list = particle_update_list;
 		particle_update_list = particles;
 	}


### PR DESCRIPTION
one line change to reset the particles life time when a new particle is emitted. closes #56886