### PR TITLE
Fix particles freezing by resetting particle timer

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -540,11 +540,8 @@ void ParticlesStorage::particles_emit(RID p_particles, const Transform3D &p_tran
 		_particles_allocate_emission_buffer(particles);
 	}
 
-	if (particles->inactive) {
-		//in case it was inactive, make active again
-		particles->inactive = false;
-		particles->inactive_time = 0;
-	}
+	particles->inactive = false;
+	particles->inactive_time = 0;
 
 	int32_t idx = particles->emission_buffer->particle_count;
 	if (idx < particles->emission_buffer->particle_max) {


### PR DESCRIPTION
one line change, resets particle lifetime when new particle is emitted. closes #56886