### PR TITLE
Remove most EditorNode constructor parameters and fields

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -640,7 +640,7 @@ void ConnectionsDock::_make_or_edit_connection() {
 	it = nullptr;
 
 	if (add_script_function) {
-		editor->emit_signal(SNAME("script_add_function_request"), target, cd.method, script_function_args);
+		EditorNode::get_singleton()->emit_signal(SNAME("script_add_function_request"), target, cd.method, script_function_args);
 		hide();
 	}
 
@@ -852,7 +852,7 @@ void ConnectionsDock::_go_to_script(TreeItem &p_item) {
 	}
 
 	if (script.is_valid() && ScriptEditor::get_singleton()->script_goto_method(script, cd.method)) {
-		editor->call("_editor_select", EditorNode::EDITOR_SCRIPT);
+		EditorNode::get_singleton()->call("_editor_select", EditorNode::EDITOR_SCRIPT);
 	}
 }
 
@@ -1147,8 +1147,7 @@ void ConnectionsDock::update_tree() {
 	connect_button->set_disabled(true);
 }
 
-ConnectionsDock::ConnectionsDock(EditorNode *p_editor) {
-	editor = p_editor;
+ConnectionsDock::ConnectionsDock() {
 	set_name(TTR("Signals"));
 
 	VBoxContainer *vbc = this;

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -182,7 +182,6 @@ class ConnectionsDock : public VBoxContainer {
 
 	Node *selected_node;
 	ConnectionsDockTree *tree;
-	EditorNode *editor;
 
 	ConfirmationDialog *disconnect_all_dialog;
 	ConnectDialog *connect_dialog;
@@ -224,7 +223,7 @@ public:
 	void set_node(Node *p_node);
 	void update_tree();
 
-	ConnectionsDock(EditorNode *p_editor = nullptr);
+	ConnectionsDock();
 	~ConnectionsDock();
 };
 

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -89,7 +89,7 @@ EditorDebuggerNode::EditorDebuggerNode() {
 }
 
 ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
-	ScriptEditorDebugger *node = memnew(ScriptEditorDebugger(EditorNode::get_singleton()));
+	ScriptEditorDebugger *node = memnew(ScriptEditorDebugger);
 
 	int id = tabs->get_tab_count();
 	node->connect("stop_requested", callable_mp(this, &EditorDebuggerNode::_debugger_wants_stop), varray(id));

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -803,9 +803,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 				peer->poll();
 
 				if (camera_override == CameraOverride::OVERRIDE_2D) {
-					CanvasItemEditor *editor = CanvasItemEditor::get_singleton();
-
-					Dictionary state = editor->get_state();
+					Dictionary state = CanvasItemEditor::get_singleton()->get_state();
 					float zoom = state["zoom"];
 					Point2 offset = state["ofs"];
 					Transform2D transform;
@@ -861,7 +859,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (tabs->has_theme_stylebox_override("panel")) {
-				tabs->add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
+				tabs->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
 			}
 
 			copy->set_icon(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")));
@@ -1066,7 +1064,7 @@ int ScriptEditorDebugger::_get_res_path_cache(const String &p_path) {
 }
 
 void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_name, VARIANT_ARG_DECLARE) {
-	if (!p_base || !live_debug || !is_session_active() || !editor->get_edited_scene()) {
+	if (!p_base || !live_debug || !is_session_active() || !EditorNode::get_singleton()->get_edited_scene()) {
 		return;
 	}
 
@@ -1082,7 +1080,7 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
 	}
 
 	if (node) {
-		NodePath path = editor->get_edited_scene()->get_path_to(node);
+		NodePath path = EditorNode::get_singleton()->get_edited_scene()->get_path_to(node);
 		int pathid = _get_node_path_cache(path);
 
 		Array msg;
@@ -1117,14 +1115,14 @@ void ScriptEditorDebugger::_method_changed(Object *p_base, const StringName &p_n
 }
 
 void ScriptEditorDebugger::_property_changed(Object *p_base, const StringName &p_property, const Variant &p_value) {
-	if (!p_base || !live_debug || !editor->get_edited_scene()) {
+	if (!p_base || !live_debug || !EditorNode::get_singleton()->get_edited_scene()) {
 		return;
 	}
 
 	Node *node = Object::cast_to<Node>(p_base);
 
 	if (node) {
-		NodePath path = editor->get_edited_scene()->get_path_to(node);
+		NodePath path = EditorNode::get_singleton()->get_edited_scene()->get_path_to(node);
 		int pathid = _get_node_path_cache(path);
 
 		if (p_value.is_ref_counted()) {
@@ -1242,25 +1240,25 @@ void ScriptEditorDebugger::_live_edit_set() {
 
 	NodePath np = path;
 
-	editor->get_editor_data().set_edited_scene_live_edit_root(np);
+	EditorNode::get_singleton()->get_editor_data().set_edited_scene_live_edit_root(np);
 
 	update_live_edit_root();
 }
 
 void ScriptEditorDebugger::_live_edit_clear() {
 	NodePath np = NodePath("/root");
-	editor->get_editor_data().set_edited_scene_live_edit_root(np);
+	EditorNode::get_singleton()->get_editor_data().set_edited_scene_live_edit_root(np);
 
 	update_live_edit_root();
 }
 
 void ScriptEditorDebugger::update_live_edit_root() {
-	NodePath np = editor->get_editor_data().get_edited_scene_live_edit_root();
+	NodePath np = EditorNode::get_singleton()->get_editor_data().get_edited_scene_live_edit_root();
 
 	Array msg;
 	msg.push_back(np);
-	if (editor->get_edited_scene()) {
-		msg.push_back(editor->get_edited_scene()->get_scene_file_path());
+	if (EditorNode::get_singleton()->get_edited_scene()) {
+		msg.push_back(EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path());
 	} else {
 		msg.push_back("");
 	}
@@ -1657,12 +1655,10 @@ bool ScriptEditorDebugger::has_capture(const StringName &p_name) {
 	return captures.has(p_name);
 }
 
-ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
-	editor = p_editor;
-
+ScriptEditorDebugger::ScriptEditorDebugger() {
 	tabs = memnew(TabContainer);
 	tabs->set_tab_alignment(TabContainer::ALIGNMENT_LEFT);
-	tabs->add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
+	tabs->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
 	tabs->connect("tab_changed", callable_mp(this, &ScriptEditorDebugger::_tab_changed));
 
 	add_child(tabs);

--- a/editor/debugger/script_editor_debugger.h
+++ b/editor/debugger/script_editor_debugger.h
@@ -155,8 +155,6 @@ private:
 	EditorNetworkProfiler *network_profiler;
 	EditorPerformanceProfiler *performance_profiler;
 
-	EditorNode *editor;
-
 	OS::ProcessID remote_pid = 0;
 	bool breaked = false;
 	bool can_debug = false;
@@ -298,7 +296,7 @@ public:
 	void unregister_message_capture(const StringName &p_name);
 	bool has_capture(const StringName &p_name);
 
-	ScriptEditorDebugger(EditorNode *p_editor = nullptr);
+	ScriptEditorDebugger();
 	~ScriptEditorDebugger();
 };
 

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -287,7 +287,7 @@ void DependencyEditorOwners::_select_file(int p_idx) {
 	String fpath = owners->get_item_text(p_idx);
 
 	if (ResourceLoader::get_resource_type(fpath) == "PackedScene") {
-		editor->open_request(fpath);
+		EditorNode::get_singleton()->open_request(fpath);
 		hide();
 		emit_signal(SNAME("confirmed"));
 	}
@@ -345,9 +345,7 @@ void DependencyEditorOwners::show(const String &p_path) {
 	set_title(TTR("Owners Of:") + " " + p_path.get_file());
 }
 
-DependencyEditorOwners::DependencyEditorOwners(EditorNode *p_editor) {
-	editor = p_editor;
-
+DependencyEditorOwners::DependencyEditorOwners() {
 	file_options = memnew(PopupMenu);
 	add_child(file_options);
 	file_options->connect("id_pressed", callable_mp(this, &DependencyEditorOwners::_file_option));

--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -38,7 +38,6 @@
 
 class EditorFileDialog;
 class EditorFileSystemDirectory;
-class EditorNode;
 
 class DependencyEditor : public AcceptDialog {
 	GDCLASS(DependencyEditor, AcceptDialog);
@@ -74,7 +73,6 @@ class DependencyEditorOwners : public AcceptDialog {
 
 	ItemList *owners;
 	PopupMenu *file_options;
-	EditorNode *editor;
 	String editing;
 
 	void _fill_owners(EditorFileSystemDirectory *efsd);
@@ -91,7 +89,7 @@ private:
 
 public:
 	void show(const String &p_path);
-	DependencyEditorOwners(EditorNode *p_editor);
+	DependencyEditorOwners();
 };
 
 class DependencyRemoveDialog : public ConfirmationDialog {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6701,12 +6701,12 @@ EditorNode::EditorNode() {
 
 	// Instantiate and place editor docks
 
-	memnew(SceneTreeDock(this, scene_root, editor_selection, editor_data));
-	memnew(InspectorDock(this, editor_data));
+	memnew(SceneTreeDock(scene_root, editor_selection, editor_data));
+	memnew(InspectorDock(editor_data));
 	memnew(ImportDock);
 	memnew(NodeDock);
 
-	FileSystemDock *filesystem_dock = memnew(FileSystemDock(this));
+	FileSystemDock *filesystem_dock = memnew(FileSystemDock);
 	filesystem_dock->connect("inherit", callable_mp(this, &EditorNode::_inherit_request));
 	filesystem_dock->connect("instance", callable_mp(this, &EditorNode::_instantiate_request));
 	filesystem_dock->connect("display_mode_changed", callable_mp(this, &EditorNode::_save_docks));
@@ -6926,7 +6926,7 @@ EditorNode::EditorNode() {
 	preview_gen = memnew(AudioStreamPreviewGenerator);
 	add_child(preview_gen);
 
-	add_editor_plugin(memnew(DebuggerEditorPlugin(this, debug_menu)));
+	add_editor_plugin(memnew(DebuggerEditorPlugin(debug_menu)));
 	add_editor_plugin(memnew(DebugAdapterServer()));
 
 	disk_changed = memnew(ConfirmationDialog);
@@ -6952,10 +6952,10 @@ EditorNode::EditorNode() {
 
 	gui_base->add_child(disk_changed);
 
-	add_editor_plugin(memnew(AnimationPlayerEditorPlugin(this)));
-	add_editor_plugin(memnew(CanvasItemEditorPlugin(this)));
-	add_editor_plugin(memnew(Node3DEditorPlugin(this)));
-	add_editor_plugin(memnew(ScriptEditorPlugin(this)));
+	add_editor_plugin(memnew(AnimationPlayerEditorPlugin));
+	add_editor_plugin(memnew(CanvasItemEditorPlugin));
+	add_editor_plugin(memnew(Node3DEditorPlugin));
+	add_editor_plugin(memnew(ScriptEditorPlugin));
 
 	EditorAudioBuses *audio_bus_editor = EditorAudioBuses::register_editor();
 
@@ -6963,7 +6963,7 @@ EditorNode::EditorNode() {
 	TextEditor::register_editor();
 
 	if (StreamPeerSSL::is_available()) {
-		add_editor_plugin(memnew(AssetLibraryEditorPlugin(this)));
+		add_editor_plugin(memnew(AssetLibraryEditorPlugin));
 	} else {
 		WARN_PRINT("Asset Library not available, as it requires SSL to work.");
 	}
@@ -6975,62 +6975,62 @@ EditorNode::EditorNode() {
 
 	// more visually meaningful to have this later
 	raise_bottom_panel_item(AnimationPlayerEditor::get_singleton());
-	add_editor_plugin(memnew(ReplicationEditorPlugin(this)));
+	add_editor_plugin(memnew(ReplicationEditorPlugin));
 
 	add_editor_plugin(VersionControlEditorPlugin::get_singleton());
-	add_editor_plugin(memnew(ShaderEditorPlugin(this)));
-	add_editor_plugin(memnew(ShaderFileEditorPlugin(this)));
-	add_editor_plugin(memnew(VisualShaderEditorPlugin(this)));
+	add_editor_plugin(memnew(ShaderEditorPlugin));
+	add_editor_plugin(memnew(ShaderFileEditorPlugin));
+	add_editor_plugin(memnew(VisualShaderEditorPlugin));
 
-	add_editor_plugin(memnew(Camera3DEditorPlugin(this)));
-	add_editor_plugin(memnew(ThemeEditorPlugin(this)));
-	add_editor_plugin(memnew(MultiMeshEditorPlugin(this)));
-	add_editor_plugin(memnew(MeshInstance3DEditorPlugin(this)));
-	add_editor_plugin(memnew(AnimationTreeEditorPlugin(this)));
-	add_editor_plugin(memnew(MeshLibraryEditorPlugin(this)));
-	add_editor_plugin(memnew(StyleBoxEditorPlugin(this)));
-	add_editor_plugin(memnew(Sprite2DEditorPlugin(this)));
-	add_editor_plugin(memnew(Skeleton2DEditorPlugin(this)));
-	add_editor_plugin(memnew(GPUParticles2DEditorPlugin(this)));
-	add_editor_plugin(memnew(GPUParticles3DEditorPlugin(this)));
-	add_editor_plugin(memnew(CPUParticles2DEditorPlugin(this)));
-	add_editor_plugin(memnew(CPUParticles3DEditorPlugin(this)));
-	add_editor_plugin(memnew(ResourcePreloaderEditorPlugin(this)));
-	add_editor_plugin(memnew(Polygon3DEditorPlugin(this)));
-	add_editor_plugin(memnew(CollisionPolygon2DEditorPlugin(this)));
-	add_editor_plugin(memnew(TilesEditorPlugin(this)));
-	add_editor_plugin(memnew(SpriteFramesEditorPlugin(this)));
-	add_editor_plugin(memnew(TextureRegionEditorPlugin(this)));
-	add_editor_plugin(memnew(VoxelGIEditorPlugin(this)));
-	add_editor_plugin(memnew(LightmapGIEditorPlugin(this)));
-	add_editor_plugin(memnew(OccluderInstance3DEditorPlugin(this)));
-	add_editor_plugin(memnew(Path2DEditorPlugin(this)));
-	add_editor_plugin(memnew(Path3DEditorPlugin(this)));
-	add_editor_plugin(memnew(Line2DEditorPlugin(this)));
-	add_editor_plugin(memnew(Polygon2DEditorPlugin(this)));
-	add_editor_plugin(memnew(LightOccluder2DEditorPlugin(this)));
-	add_editor_plugin(memnew(NavigationPolygonEditorPlugin(this)));
-	add_editor_plugin(memnew(GradientEditorPlugin(this)));
-	add_editor_plugin(memnew(CollisionShape2DEditorPlugin(this)));
-	add_editor_plugin(memnew(CurveEditorPlugin(this)));
-	add_editor_plugin(memnew(FontEditorPlugin(this)));
-	add_editor_plugin(memnew(OpenTypeFeaturesEditorPlugin(this)));
-	add_editor_plugin(memnew(TextureEditorPlugin(this)));
-	add_editor_plugin(memnew(TextureLayeredEditorPlugin(this)));
-	add_editor_plugin(memnew(Texture3DEditorPlugin(this)));
-	add_editor_plugin(memnew(AudioStreamEditorPlugin(this)));
-	add_editor_plugin(memnew(AudioStreamRandomizerEditorPlugin(this)));
+	add_editor_plugin(memnew(Camera3DEditorPlugin));
+	add_editor_plugin(memnew(ThemeEditorPlugin));
+	add_editor_plugin(memnew(MultiMeshEditorPlugin));
+	add_editor_plugin(memnew(MeshInstance3DEditorPlugin));
+	add_editor_plugin(memnew(AnimationTreeEditorPlugin));
+	add_editor_plugin(memnew(MeshLibraryEditorPlugin));
+	add_editor_plugin(memnew(StyleBoxEditorPlugin));
+	add_editor_plugin(memnew(Sprite2DEditorPlugin));
+	add_editor_plugin(memnew(Skeleton2DEditorPlugin));
+	add_editor_plugin(memnew(GPUParticles2DEditorPlugin));
+	add_editor_plugin(memnew(GPUParticles3DEditorPlugin));
+	add_editor_plugin(memnew(CPUParticles2DEditorPlugin));
+	add_editor_plugin(memnew(CPUParticles3DEditorPlugin));
+	add_editor_plugin(memnew(ResourcePreloaderEditorPlugin));
+	add_editor_plugin(memnew(Polygon3DEditorPlugin));
+	add_editor_plugin(memnew(CollisionPolygon2DEditorPlugin));
+	add_editor_plugin(memnew(TilesEditorPlugin));
+	add_editor_plugin(memnew(SpriteFramesEditorPlugin));
+	add_editor_plugin(memnew(TextureRegionEditorPlugin));
+	add_editor_plugin(memnew(VoxelGIEditorPlugin));
+	add_editor_plugin(memnew(LightmapGIEditorPlugin));
+	add_editor_plugin(memnew(OccluderInstance3DEditorPlugin));
+	add_editor_plugin(memnew(Path2DEditorPlugin));
+	add_editor_plugin(memnew(Path3DEditorPlugin));
+	add_editor_plugin(memnew(Line2DEditorPlugin));
+	add_editor_plugin(memnew(Polygon2DEditorPlugin));
+	add_editor_plugin(memnew(LightOccluder2DEditorPlugin));
+	add_editor_plugin(memnew(NavigationPolygonEditorPlugin));
+	add_editor_plugin(memnew(GradientEditorPlugin));
+	add_editor_plugin(memnew(CollisionShape2DEditorPlugin));
+	add_editor_plugin(memnew(CurveEditorPlugin));
+	add_editor_plugin(memnew(FontEditorPlugin));
+	add_editor_plugin(memnew(OpenTypeFeaturesEditorPlugin));
+	add_editor_plugin(memnew(TextureEditorPlugin));
+	add_editor_plugin(memnew(TextureLayeredEditorPlugin));
+	add_editor_plugin(memnew(Texture3DEditorPlugin));
+	add_editor_plugin(memnew(AudioStreamEditorPlugin));
+	add_editor_plugin(memnew(AudioStreamRandomizerEditorPlugin));
 	add_editor_plugin(memnew(AudioBusesEditorPlugin(audio_bus_editor)));
-	add_editor_plugin(memnew(Skeleton3DEditorPlugin(this)));
-	add_editor_plugin(memnew(SkeletonIK3DEditorPlugin(this)));
-	add_editor_plugin(memnew(PhysicalBone3DEditorPlugin(this)));
-	add_editor_plugin(memnew(MeshEditorPlugin(this)));
-	add_editor_plugin(memnew(MaterialEditorPlugin(this)));
-	add_editor_plugin(memnew(GPUParticlesCollisionSDF3DEditorPlugin(this)));
-	add_editor_plugin(memnew(InputEventEditorPlugin(this)));
-	add_editor_plugin(memnew(SubViewportPreviewEditorPlugin(this)));
-	add_editor_plugin(memnew(TextControlEditorPlugin(this)));
-	add_editor_plugin(memnew(ControlEditorPlugin(this)));
+	add_editor_plugin(memnew(Skeleton3DEditorPlugin));
+	add_editor_plugin(memnew(SkeletonIK3DEditorPlugin));
+	add_editor_plugin(memnew(PhysicalBone3DEditorPlugin));
+	add_editor_plugin(memnew(MeshEditorPlugin));
+	add_editor_plugin(memnew(MaterialEditorPlugin));
+	add_editor_plugin(memnew(GPUParticlesCollisionSDF3DEditorPlugin));
+	add_editor_plugin(memnew(InputEventEditorPlugin));
+	add_editor_plugin(memnew(SubViewportPreviewEditorPlugin));
+	add_editor_plugin(memnew(TextControlEditorPlugin));
+	add_editor_plugin(memnew(ControlEditorPlugin));
 
 	for (int i = 0; i < EditorPlugins::get_plugin_count(); i++) {
 		add_editor_plugin(EditorPlugins::create(i, this));

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -114,7 +114,6 @@ private:
 	VSplitContainer *split_box;
 	VBoxContainer *file_list_vb;
 
-	EditorNode *editor;
 	Set<String> favorites;
 
 	Button *button_toggle_display_mode;
@@ -336,7 +335,7 @@ public:
 	void set_file_list_display_mode(FileListDisplayMode p_mode);
 	FileListDisplayMode get_file_list_display_mode() { return file_list_display_mode; };
 
-	FileSystemDock(EditorNode *p_editor);
+	FileSystemDock();
 	~FileSystemDock();
 };
 

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -77,7 +77,7 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		case OBJECT_REQUEST_HELP: {
 			if (current) {
-				editor->set_visible_editor(EditorNode::EDITOR_SCRIPT);
+				EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
 				emit_signal(SNAME("request_help"), current->get_class());
 			}
 		} break;
@@ -169,8 +169,8 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 				editor_data->get_undo_redo().clear_history();
 
-				editor->get_editor_plugins_over()->edit(nullptr);
-				editor->get_editor_plugins_over()->edit(current);
+				EditorNode::get_singleton()->get_editor_plugins_over()->edit(nullptr);
+				EditorNode::get_singleton()->get_editor_plugins_over()->edit(current);
 			}
 
 		} break;
@@ -232,7 +232,7 @@ void InspectorDock::_resource_file_selected(String p_file) {
 		return;
 	};
 
-	editor->push_item(res.operator->());
+	EditorNode::get_singleton()->push_item(res.operator->());
 }
 
 void InspectorDock::_save_resource(bool save_as) {
@@ -244,9 +244,9 @@ void InspectorDock::_save_resource(bool save_as) {
 	RES current_res = RES(Object::cast_to<Resource>(current_obj));
 
 	if (save_as) {
-		editor->save_resource_as(current_res);
+		EditorNode::get_singleton()->save_resource_as(current_res);
 	} else {
-		editor->save_resource(current_res);
+		EditorNode::get_singleton()->save_resource(current_res);
 	}
 }
 
@@ -258,7 +258,7 @@ void InspectorDock::_unref_resource() {
 
 	RES current_res = RES(Object::cast_to<Resource>(current_obj));
 	current_res->set_path("");
-	editor->edit_current();
+	EditorNode::get_singleton()->edit_current();
 }
 
 void InspectorDock::_copy_resource() {
@@ -275,7 +275,7 @@ void InspectorDock::_copy_resource() {
 void InspectorDock::_paste_resource() {
 	RES r = EditorSettings::get_singleton()->get_resource_clipboard();
 	if (r.is_valid()) {
-		editor->push_item(EditorSettings::get_singleton()->get_resource_clipboard().ptr(), String());
+		EditorNode::get_singleton()->push_item(EditorSettings::get_singleton()->get_resource_clipboard().ptr(), String());
 	}
 }
 
@@ -343,7 +343,7 @@ void InspectorDock::_select_history(int p_idx) {
 	if (!obj) {
 		return;
 	}
-	editor->push_item(obj);
+	EditorNode::get_singleton()->push_item(obj);
 }
 
 void InspectorDock::_resource_created() {
@@ -353,7 +353,7 @@ void InspectorDock::_resource_created() {
 	Resource *r = Object::cast_to<Resource>(c);
 	ERR_FAIL_COND(!r);
 
-	editor->push_item(r);
+	EditorNode::get_singleton()->push_item(r);
 }
 
 void InspectorDock::_resource_selected(const RES &p_res, const String &p_property) {
@@ -362,19 +362,19 @@ void InspectorDock::_resource_selected(const RES &p_res, const String &p_propert
 	}
 
 	RES r = p_res;
-	editor->push_item(r.operator->(), p_property);
+	EditorNode::get_singleton()->push_item(r.operator->(), p_property);
 }
 
 void InspectorDock::_edit_forward() {
 	if (EditorNode::get_singleton()->get_editor_history()->next()) {
-		editor->edit_current();
+		EditorNode::get_singleton()->edit_current();
 	}
 }
 
 void InspectorDock::_edit_back() {
 	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
 	if ((current && editor_history->previous()) || editor_history->get_path_size() == 1) {
-		editor->edit_current();
+		EditorNode::get_singleton()->edit_current();
 	}
 }
 
@@ -400,7 +400,7 @@ void InspectorDock::_notification(int p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			set_theme(editor->get_gui_base()->get_theme());
+			set_theme(EditorNode::get_singleton()->get_gui_base()->get_theme());
 
 			resource_new_button->set_icon(get_theme_icon(SNAME("New"), SNAME("EditorIcons")));
 			resource_load_button->set_icon(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")));
@@ -534,11 +534,10 @@ void InspectorDock::go_back() {
 	_edit_back();
 }
 
-InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
+InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	singleton = this;
 	set_name("Inspector");
 
-	editor = p_editor;
 	editor_data = &p_editor_data;
 
 	HBoxContainer *general_options_hb = memnew(HBoxContainer);
@@ -603,7 +602,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 
 	HBoxContainer *subresource_hb = memnew(HBoxContainer);
 	add_child(subresource_hb);
-	editor_path = memnew(EditorPath(editor->get_editor_history()));
+	editor_path = memnew(EditorPath(EditorNode::get_singleton()->get_editor_history()));
 	editor_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	subresource_hb->add_child(editor_path);
 
@@ -616,7 +615,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	open_docs_button->connect("pressed", callable_mp(this, &InspectorDock::_menu_option), varray(OBJECT_REQUEST_HELP));
 
 	new_resource_dialog = memnew(CreateDialog);
-	editor->get_gui_base()->add_child(new_resource_dialog);
+	EditorNode::get_singleton()->get_gui_base()->add_child(new_resource_dialog);
 	new_resource_dialog->set_base_type("Resource");
 	new_resource_dialog->connect("create", callable_mp(this, &InspectorDock::_resource_created));
 
@@ -666,7 +665,7 @@ InspectorDock::InspectorDock(EditorNode *p_editor, EditorData &p_editor_data) {
 	unique_resources_confirmation->connect("confirmed", callable_mp(this, &InspectorDock::_menu_confirm_current));
 
 	warning_dialog = memnew(AcceptDialog);
-	editor->get_gui_base()->add_child(warning_dialog);
+	EditorNode::get_singleton()->get_gui_base()->add_child(warning_dialog);
 
 	load_resource_dialog = memnew(EditorFileDialog);
 	add_child(load_resource_dialog);

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -63,7 +63,6 @@ class InspectorDock : public VBoxContainer {
 		OBJECT_METHOD_BASE = 500
 	};
 
-	EditorNode *editor;
 	EditorData *editor_data;
 
 	EditorInspector *inspector;
@@ -138,7 +137,7 @@ public:
 	Container *get_addon_area();
 	EditorInspector *get_inspector() { return inspector; }
 
-	InspectorDock(EditorNode *p_editor, EditorData &p_editor_data);
+	InspectorDock(EditorData &p_editor_data);
 	~InspectorDock();
 };
 

--- a/editor/node_dock.cpp
+++ b/editor/node_dock.cpp
@@ -113,7 +113,7 @@ NodeDock::NodeDock() {
 	mode_hb->add_child(groups_button);
 	groups_button->connect("pressed", callable_mp(this, &NodeDock::show_groups));
 
-	connections = memnew(ConnectionsDock(EditorNode::get_singleton()));
+	connections = memnew(ConnectionsDock);
 	connections->set_undoredo(EditorNode::get_undo_redo());
 	add_child(connections);
 	connections->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -702,9 +702,8 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_edge_point(c
 	return closest;
 }
 
-AbstractPolygon2DEditor::AbstractPolygon2DEditor(EditorNode *p_editor, bool p_wip_destructive) {
+AbstractPolygon2DEditor::AbstractPolygon2DEditor(bool p_wip_destructive) {
 	canvas_item_editor = nullptr;
-	editor = p_editor;
 	undo_redo = EditorNode::get_undo_redo();
 
 	wip_active = false;
@@ -758,9 +757,8 @@ void AbstractPolygon2DEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-AbstractPolygon2DEditorPlugin::AbstractPolygon2DEditorPlugin(EditorNode *p_node, AbstractPolygon2DEditor *p_polygon_editor, String p_class) :
+AbstractPolygon2DEditorPlugin::AbstractPolygon2DEditorPlugin(AbstractPolygon2DEditor *p_polygon_editor, String p_class) :
 		polygon_editor(p_polygon_editor),
-		editor(p_node),
 		klass(p_class) {
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(polygon_editor);
 	polygon_editor->hide();

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -87,7 +87,6 @@ class AbstractPolygon2DEditor : public HBoxContainer {
 	bool _polygon_editing_enabled;
 
 	CanvasItemEditor *canvas_item_editor;
-	EditorNode *editor;
 	Panel *panel;
 	ConfirmationDialog *create_resource;
 
@@ -145,14 +144,13 @@ public:
 	void forward_canvas_draw_over_viewport(Control *p_overlay);
 
 	void edit(Node *p_polygon);
-	AbstractPolygon2DEditor(EditorNode *p_editor, bool p_wip_destructive = true);
+	AbstractPolygon2DEditor(bool p_wip_destructive = true);
 };
 
 class AbstractPolygon2DEditorPlugin : public EditorPlugin {
 	GDCLASS(AbstractPolygon2DEditorPlugin, EditorPlugin);
 
 	AbstractPolygon2DEditor *polygon_editor;
-	EditorNode *editor;
 	String klass;
 
 public:
@@ -165,7 +163,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	AbstractPolygon2DEditorPlugin(EditorNode *p_node, AbstractPolygon2DEditor *p_polygon_editor, String p_class);
+	AbstractPolygon2DEditorPlugin(AbstractPolygon2DEditor *p_polygon_editor, String p_class);
 	~AbstractPolygon2DEditorPlugin();
 };
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -104,10 +104,10 @@ void AnimationPlayerEditor::_notification(int p_what) {
 
 			get_tree()->connect("node_removed", callable_mp(this, &AnimationPlayerEditor::_node_removed));
 
-			add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
+			add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
+			add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
@@ -376,7 +376,7 @@ void AnimationPlayerEditor::_animation_save_in_path(const Ref<Resource> &p_resou
 	}
 
 	((Resource *)p_resource.ptr())->set_path(path);
-	editor->emit_signal(SNAME("resource_saved"), p_resource);
+	EditorNode::get_singleton()->emit_signal(SNAME("resource_saved"), p_resource);
 }
 
 void AnimationPlayerEditor::_animation_save(const Ref<Resource> &p_resource) {
@@ -677,7 +677,7 @@ void AnimationPlayerEditor::set_state(const Dictionary &p_state) {
 		if (Object::cast_to<AnimationPlayer>(n) && EditorNode::get_singleton()->get_editor_selection()->is_selected(n)) {
 			player = Object::cast_to<AnimationPlayer>(n);
 			_update_player();
-			editor->make_bottom_panel_item_visible(this);
+			EditorNode::get_singleton()->make_bottom_panel_item_visible(this);
 			set_process(true);
 			ensure_visibility();
 
@@ -700,7 +700,7 @@ void AnimationPlayerEditor::_animation_resource_edit() {
 	if (animation->get_item_count()) {
 		String current = animation->get_item_text(animation->get_selected());
 		Ref<Animation> anim = player->get_animation(current);
-		editor->edit_resource(anim);
+		EditorNode::get_singleton()->edit_resource(anim);
 	}
 }
 
@@ -1191,7 +1191,7 @@ void AnimationPlayerEditor::_animation_tool_menu(int p_option) {
 
 			String current2 = animation->get_item_text(animation->get_selected());
 			Ref<Animation> anim2 = player->get_animation(current2);
-			editor->edit_resource(anim2);
+			EditorNode::get_singleton()->edit_resource(anim2);
 		} break;
 	}
 }
@@ -1535,8 +1535,7 @@ AnimationPlayer *AnimationPlayerEditor::get_player() const {
 	return player;
 }
 
-AnimationPlayerEditor::AnimationPlayerEditor(EditorNode *p_editor, AnimationPlayerEditorPlugin *p_plugin) {
-	editor = p_editor;
+AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plugin) {
 	plugin = p_plugin;
 	singleton = this;
 
@@ -1843,17 +1842,16 @@ bool AnimationPlayerEditorPlugin::handles(Object *p_object) const {
 
 void AnimationPlayerEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		editor->make_bottom_panel_item_visible(anim_editor);
+		EditorNode::get_singleton()->make_bottom_panel_item_visible(anim_editor);
 		anim_editor->set_process(true);
 		anim_editor->ensure_visibility();
 	}
 }
 
-AnimationPlayerEditorPlugin::AnimationPlayerEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
-	anim_editor = memnew(AnimationPlayerEditor(editor, this));
+AnimationPlayerEditorPlugin::AnimationPlayerEditorPlugin() {
+	anim_editor = memnew(AnimationPlayerEditor(this));
 	anim_editor->set_undo_redo(EditorNode::get_undo_redo());
-	editor->add_bottom_panel_item(TTR("Animation"), anim_editor);
+	EditorNode::get_singleton()->add_bottom_panel_item(TTR("Animation"), anim_editor);
 }
 
 AnimationPlayerEditorPlugin::~AnimationPlayerEditorPlugin() {

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -47,7 +47,6 @@ class AnimationPlayerEditorPlugin;
 class AnimationPlayerEditor : public VBoxContainer {
 	GDCLASS(AnimationPlayerEditor, VBoxContainer);
 
-	EditorNode *editor;
 	AnimationPlayerEditorPlugin *plugin;
 	AnimationPlayer *player;
 
@@ -245,14 +244,13 @@ public:
 	void edit(AnimationPlayer *p_player);
 	void forward_force_draw_over_viewport(Control *p_overlay);
 
-	AnimationPlayerEditor(EditorNode *p_editor, AnimationPlayerEditorPlugin *p_plugin);
+	AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plugin);
 };
 
 class AnimationPlayerEditorPlugin : public EditorPlugin {
 	GDCLASS(AnimationPlayerEditorPlugin, EditorPlugin);
 
 	AnimationPlayerEditor *anim_editor;
-	EditorNode *editor;
 
 protected:
 	void _notification(int p_what);
@@ -274,7 +272,7 @@ public:
 	virtual void forward_canvas_force_draw_over_viewport(Control *p_overlay) override { anim_editor->forward_force_draw_over_viewport(p_overlay); }
 	virtual void forward_spatial_force_draw_over_viewport(Control *p_overlay) override { anim_editor->forward_force_draw_over_viewport(p_overlay); }
 
-	AnimationPlayerEditorPlugin(EditorNode *p_node);
+	AnimationPlayerEditorPlugin();
 	~AnimationPlayerEditorPlugin();
 };
 

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -259,23 +259,22 @@ void AnimationTreeEditorPlugin::make_visible(bool p_visible) {
 		//editor->hide_animation_player_editors();
 		//editor->animation_panel_make_visible(true);
 		button->show();
-		editor->make_bottom_panel_item_visible(anim_tree_editor);
+		EditorNode::get_singleton()->make_bottom_panel_item_visible(anim_tree_editor);
 		anim_tree_editor->set_process(true);
 	} else {
 		if (anim_tree_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorNode::get_singleton()->hide_bottom_panel();
 		}
 		button->hide();
 		anim_tree_editor->set_process(false);
 	}
 }
 
-AnimationTreeEditorPlugin::AnimationTreeEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+AnimationTreeEditorPlugin::AnimationTreeEditorPlugin() {
 	anim_tree_editor = memnew(AnimationTreeEditor);
 	anim_tree_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
 
-	button = editor->add_bottom_panel_item(TTR("AnimationTree"), anim_tree_editor);
+	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("AnimationTree"), anim_tree_editor);
 	button->hide();
 }
 

--- a/editor/plugins/animation_tree_editor_plugin.h
+++ b/editor/plugins/animation_tree_editor_plugin.h
@@ -97,7 +97,6 @@ class AnimationTreeEditorPlugin : public EditorPlugin {
 	GDCLASS(AnimationTreeEditorPlugin, EditorPlugin);
 
 	AnimationTreeEditor *anim_tree_editor;
-	EditorNode *editor;
 	Button *button;
 
 public:
@@ -107,7 +106,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	AnimationTreeEditorPlugin(EditorNode *p_node);
+	AnimationTreeEditorPlugin();
 	~AnimationTreeEditorPlugin();
 };
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1562,11 +1562,10 @@ void AssetLibraryEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-AssetLibraryEditorPlugin::AssetLibraryEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+AssetLibraryEditorPlugin::AssetLibraryEditorPlugin() {
 	addon_library = memnew(EditorAssetLibrary);
 	addon_library->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	editor->get_main_control()->add_child(addon_library);
+	EditorNode::get_singleton()->get_main_control()->add_child(addon_library);
 	addon_library->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	addon_library->hide();
 }

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -316,7 +316,6 @@ class AssetLibraryEditorPlugin : public EditorPlugin {
 	GDCLASS(AssetLibraryEditorPlugin, EditorPlugin);
 
 	EditorAssetLibrary *addon_library;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "AssetLib"; }
@@ -328,7 +327,7 @@ public:
 	//virtual Dictionary get_state() const;
 	//virtual void set_state(const Dictionary& p_state);
 
-	AssetLibraryEditorPlugin(EditorNode *p_node);
+	AssetLibraryEditorPlugin();
 	~AssetLibraryEditorPlugin();
 };
 

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -272,8 +272,7 @@ void AudioStreamEditorPlugin::make_visible(bool p_visible) {
 	audio_editor->set_visible(p_visible);
 }
 
-AudioStreamEditorPlugin::AudioStreamEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+AudioStreamEditorPlugin::AudioStreamEditorPlugin() {
 	audio_editor = memnew(AudioStreamEditor);
 	add_control_to_container(CONTAINER_PROPERTY_EDITOR_BOTTOM, audio_editor);
 	audio_editor->hide();

--- a/editor/plugins/audio_stream_editor_plugin.h
+++ b/editor/plugins/audio_stream_editor_plugin.h
@@ -77,7 +77,6 @@ class AudioStreamEditorPlugin : public EditorPlugin {
 	GDCLASS(AudioStreamEditorPlugin, EditorPlugin);
 
 	AudioStreamEditor *audio_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "Audio"; }
@@ -86,7 +85,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	AudioStreamEditorPlugin(EditorNode *p_node);
+	AudioStreamEditorPlugin();
 	~AudioStreamEditorPlugin();
 };
 

--- a/editor/plugins/audio_stream_randomizer_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_randomizer_editor_plugin.cpp
@@ -112,7 +112,7 @@ void AudioStreamRandomizerEditorPlugin::_move_stream_array_element(Object *p_und
 	}
 }
 
-AudioStreamRandomizerEditorPlugin::AudioStreamRandomizerEditorPlugin(EditorNode *p_node) {
+AudioStreamRandomizerEditorPlugin::AudioStreamRandomizerEditorPlugin() {
 	EditorNode::get_singleton()->get_editor_data().add_move_array_element_function(SNAME("AudioStreamRandomizer"), callable_mp(this, &AudioStreamRandomizerEditorPlugin::_move_stream_array_element));
 }
 

--- a/editor/plugins/audio_stream_randomizer_editor_plugin.h
+++ b/editor/plugins/audio_stream_randomizer_editor_plugin.h
@@ -38,8 +38,6 @@
 class AudioStreamRandomizerEditorPlugin : public EditorPlugin {
 	GDCLASS(AudioStreamRandomizerEditorPlugin, EditorPlugin);
 
-	EditorNode *editor;
-
 private:
 	void _move_stream_array_element(Object *p_undo_redo, Object *p_edited, String p_array_prefix, int p_from_index, int p_to_pos);
 
@@ -50,7 +48,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	AudioStreamRandomizerEditorPlugin(EditorNode *p_node);
+	AudioStreamRandomizerEditorPlugin();
 	~AudioStreamRandomizerEditorPlugin();
 };
 

--- a/editor/plugins/camera_3d_editor_plugin.cpp
+++ b/editor/plugins/camera_3d_editor_plugin.cpp
@@ -96,10 +96,9 @@ void Camera3DEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-Camera3DEditorPlugin::Camera3DEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+Camera3DEditorPlugin::Camera3DEditorPlugin() {
 	/*	camera_editor = memnew( CameraEditor );
-	editor->get_main_control()->add_child(camera_editor);
+	EditorNode::get_singleton()->get_main_control()->add_child(camera_editor);
 
 	camera_editor->set_anchor(SIDE_LEFT,Control::ANCHOR_END);
 	camera_editor->set_anchor(SIDE_RIGHT,Control::ANCHOR_END);

--- a/editor/plugins/camera_3d_editor_plugin.h
+++ b/editor/plugins/camera_3d_editor_plugin.h
@@ -58,7 +58,6 @@ class Camera3DEditorPlugin : public EditorPlugin {
 	GDCLASS(Camera3DEditorPlugin, EditorPlugin);
 
 	//CameraEditor *camera_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "Camera3D"; }
@@ -67,7 +66,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	Camera3DEditorPlugin(EditorNode *p_node);
+	Camera3DEditorPlugin();
 	~Camera3DEditorPlugin();
 };
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -625,7 +625,7 @@ void CanvasItemEditor::_find_canvas_items_at_pos(const Point2 &p_pos, Node *p_no
 }
 
 void CanvasItemEditor::_get_canvas_items_at_pos(const Point2 &p_pos, Vector<_SelectResult> &r_items, bool p_allow_locked) {
-	Node *scene = editor->get_edited_scene();
+	Node *scene = EditorNode::get_singleton()->get_edited_scene();
 
 	_find_canvas_items_at_pos(p_pos, scene, r_items);
 
@@ -678,7 +678,7 @@ void CanvasItemEditor::_find_canvas_items_in_rect(const Rect2 &p_rect, Node *p_n
 	}
 
 	CanvasItem *canvas_item = Object::cast_to<CanvasItem>(p_node);
-	Node *scene = editor->get_edited_scene();
+	Node *scene = EditorNode::get_singleton()->get_edited_scene();
 
 	bool editable = p_node == scene || p_node->get_owner() == scene || p_node == scene->get_deepest_editable_node(p_node);
 	bool lock_children = p_node->has_meta("_edit_group_") && p_node->get_meta("_edit_group_");
@@ -727,7 +727,7 @@ bool CanvasItemEditor::_select_click_on_item(CanvasItem *item, Point2 p_click_po
 			still_selected = false;
 
 			if (editor_selection->get_selected_node_list().size() == 1) {
-				editor->push_item(editor_selection->get_selected_node_list()[0]);
+				EditorNode::get_singleton()->push_item(editor_selection->get_selected_node_list()[0]);
 			}
 		} else {
 			// Add the item to the selection
@@ -741,7 +741,7 @@ bool CanvasItemEditor::_select_click_on_item(CanvasItem *item, Point2 p_click_po
 			// Reselect
 			if (Engine::get_singleton()->is_editor_hint()) {
 				selected_from_canvas = true;
-				editor->call("edit_node", item);
+				EditorNode::get_singleton()->edit_node(item);
 			}
 		}
 	}
@@ -1411,8 +1411,8 @@ bool CanvasItemEditor::_gui_input_open_scene_on_double_click(const Ref<InputEven
 		List<CanvasItem *> selection = _get_edited_canvas_items();
 		if (selection.size() == 1) {
 			CanvasItem *canvas_item = selection[0];
-			if (!canvas_item->get_scene_file_path().is_empty() && canvas_item != editor->get_edited_scene()) {
-				editor->open_request(canvas_item->get_scene_file_path());
+			if (!canvas_item->get_scene_file_path().is_empty() && canvas_item != EditorNode::get_singleton()->get_edited_scene()) {
+				EditorNode::get_singleton()->open_request(canvas_item->get_scene_file_path());
 				return true;
 			}
 		}
@@ -2192,7 +2192,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 					if (_is_node_locked(item)) {
 						locked = 1;
 					} else {
-						Node *scene = editor->get_edited_scene();
+						Node *scene = EditorNode::get_singleton()->get_edited_scene();
 						Node *node = item;
 
 						while (node && node != scene->get_parent()) {
@@ -2252,7 +2252,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 			// Single item selection
 			Point2 click = transform.affine_inverse().xform(b->get_position());
 
-			Node *scene = editor->get_edited_scene();
+			Node *scene = EditorNode::get_singleton()->get_edited_scene();
 			if (!scene) {
 				return true;
 			}
@@ -2326,7 +2326,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 	if (drag_type == DRAG_BOX_SELECTION) {
 		if (b.is_valid() && !b->is_pressed() && b->get_button_index() == MouseButton::LEFT) {
 			// Confirms box selection
-			Node *scene = editor->get_edited_scene();
+			Node *scene = EditorNode::get_singleton()->get_edited_scene();
 			if (scene) {
 				List<CanvasItem *> selitems;
 
@@ -2341,7 +2341,7 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 
 				_find_canvas_items_in_rect(Rect2(bsfrom, bsto - bsfrom), scene, &selitems);
 				if (selitems.size() == 1 && editor_selection->get_selected_node_list().is_empty()) {
-					editor->push_item(selitems[0]);
+					EditorNode::get_singleton()->push_item(selitems[0]);
 				}
 				for (CanvasItem *E : selitems) {
 					editor_selection->add_node(E);
@@ -2471,7 +2471,7 @@ void CanvasItemEditor::_gui_input_viewport(const Ref<InputEvent> &p_event) {
 	if (EditorSettings::get_singleton()->get("editors/panning/simple_panning") || !pan_pressed || release_lmb) {
 		if ((accepted = _gui_input_rulers_and_guides(p_event))) {
 			// print_line("Rulers and guides");
-		} else if ((accepted = editor->get_editor_plugins_over()->forward_gui_input(p_event))) {
+		} else if ((accepted = EditorNode::get_singleton()->get_editor_plugins_over()->forward_gui_input(p_event))) {
 			// print_line("Plugin");
 		} else if ((accepted = _gui_input_open_scene_on_double_click(p_event))) {
 			// print_line("Open scene on double click");
@@ -3505,7 +3505,7 @@ void CanvasItemEditor::_draw_axis() {
 void CanvasItemEditor::_draw_invisible_nodes_positions(Node *p_node, const Transform2D &p_parent_xform, const Transform2D &p_canvas_xform) {
 	ERR_FAIL_COND(!p_node);
 
-	Node *scene = editor->get_edited_scene();
+	Node *scene = EditorNode::get_singleton()->get_edited_scene();
 	if (p_node != scene && p_node->get_owner() != scene && !scene->is_editable_instance(p_node->get_owner())) {
 		return;
 	}
@@ -3575,7 +3575,7 @@ void CanvasItemEditor::_draw_hover() {
 void CanvasItemEditor::_draw_locks_and_groups(Node *p_node, const Transform2D &p_parent_xform, const Transform2D &p_canvas_xform) {
 	ERR_FAIL_COND(!p_node);
 
-	Node *scene = editor->get_edited_scene();
+	Node *scene = EditorNode::get_singleton()->get_edited_scene();
 	if (p_node != scene && p_node->get_owner() != scene && !scene->is_editable_instance(p_node->get_owner())) {
 		return;
 	}
@@ -3622,7 +3622,7 @@ void CanvasItemEditor::_draw_viewport() {
 	transform = Transform2D();
 	transform.scale_basis(Size2(zoom, zoom));
 	transform.elements[2] = -view_offset * zoom;
-	editor->get_scene_root()->set_global_canvas_transform(transform);
+	EditorNode::get_singleton()->get_scene_root()->set_global_canvas_transform(transform);
 
 	// hide/show buttons depending on the selection
 	bool all_locked = true;
@@ -3656,20 +3656,20 @@ void CanvasItemEditor::_draw_viewport() {
 	_draw_grid();
 	_draw_ruler_tool();
 	_draw_axis();
-	if (editor->get_edited_scene()) {
-		_draw_locks_and_groups(editor->get_edited_scene());
-		_draw_invisible_nodes_positions(editor->get_edited_scene());
+	if (EditorNode::get_singleton()->get_edited_scene()) {
+		_draw_locks_and_groups(EditorNode::get_singleton()->get_edited_scene());
+		_draw_invisible_nodes_positions(EditorNode::get_singleton()->get_edited_scene());
 	}
 	_draw_selection();
 
 	RID ci = viewport->get_canvas_item();
 	RenderingServer::get_singleton()->canvas_item_add_set_transform(ci, Transform2D());
 
-	EditorPluginList *over_plugin_list = editor->get_editor_plugins_over();
+	EditorPluginList *over_plugin_list = EditorNode::get_singleton()->get_editor_plugins_over();
 	if (!over_plugin_list->is_empty()) {
 		over_plugin_list->forward_canvas_draw_over_viewport(viewport);
 	}
-	EditorPluginList *force_over_plugin_list = editor->get_editor_plugins_force_over();
+	EditorPluginList *force_over_plugin_list = EditorNode::get_singleton()->get_editor_plugins_force_over();
 	if (!force_over_plugin_list->is_empty()) {
 		force_over_plugin_list->forward_canvas_force_draw_over_viewport(viewport);
 	}
@@ -3887,8 +3887,8 @@ void CanvasItemEditor::_update_scrollbars() {
 
 	// Calculate scrollable area.
 	Rect2 canvas_item_rect = Rect2(Point2(), screen_rect);
-	if (editor->is_inside_tree() && editor->get_edited_scene()) {
-		Rect2 content_rect = _get_encompassing_rect(editor->get_edited_scene());
+	if (EditorNode::get_singleton()->is_inside_tree() && EditorNode::get_singleton()->get_edited_scene()) {
+		Rect2 content_rect = _get_encompassing_rect(EditorNode::get_singleton()->get_edited_scene());
 		canvas_item_rect.expand_to(content_rect.position);
 		canvas_item_rect.expand_to(content_rect.position + content_rect.size);
 	}
@@ -4555,7 +4555,7 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 
 	if (p_op == VIEW_CENTER_TO_SELECTION) {
 		center = rect.get_center();
-		Vector2 offset = viewport->get_size() / 2 - editor->get_scene_root()->get_global_canvas_transform().xform(center);
+		Vector2 offset = viewport->get_size() / 2 - EditorNode::get_singleton()->get_scene_root()->get_global_canvas_transform().xform(center);
 		view_offset -= (offset / zoom).round();
 		update_viewport();
 
@@ -4828,7 +4828,7 @@ void CanvasItemEditor::focus_selection() {
 	_focus_selection(VIEW_CENTER_TO_SELECTION);
 }
 
-CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
+CanvasItemEditor::CanvasItemEditor() {
 	zoom = 1.0 / MAX(1, EDSCALE);
 	view_offset = Point2(-150 - RULER_WIDTH, -95 - RULER_WIDTH);
 	previous_update_view_offset = view_offset; // Moves the view a little bit to the left so that (0,0) is visible. The values a relative to a 16/10 screen
@@ -4844,9 +4844,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	snap_target[0] = SNAP_TARGET_NONE;
 	snap_target[1] = SNAP_TARGET_NONE;
 
-	undo_redo = p_editor->get_undo_redo();
-	editor = p_editor;
-	editor_selection = p_editor->get_editor_selection();
+	undo_redo = EditorNode::get_singleton()->get_undo_redo();
+	editor_selection = EditorNode::get_singleton()->get_editor_selection();
 	editor_selection->add_editor_plugin(this);
 	editor_selection->connect("selection_changed", callable_mp((CanvasItem *)this, &CanvasItem::update));
 	editor_selection->connect("selection_changed", callable_mp(this, &CanvasItemEditor::_selection_changed));
@@ -4854,8 +4853,8 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	SceneTreeDock::get_singleton()->connect("node_created", callable_mp(this, &CanvasItemEditor::_node_created));
 	SceneTreeDock::get_singleton()->connect("add_node_used", callable_mp(this, &CanvasItemEditor::_reset_create_position));
 
-	editor->call_deferred(SNAME("connect"), "play_pressed", Callable(this, "_update_override_camera_button"), make_binds(true));
-	editor->call_deferred(SNAME("connect"), "stop_pressed", Callable(this, "_update_override_camera_button"), make_binds(false));
+	EditorNode::get_singleton()->call_deferred(SNAME("connect"), "play_pressed", Callable(this, "_update_override_camera_button"), make_binds(true));
+	EditorNode::get_singleton()->call_deferred(SNAME("connect"), "stop_pressed", Callable(this, "_update_override_camera_button"), make_binds(false));
 
 	hb = memnew(HBoxContainer);
 	add_child(hb);
@@ -4885,7 +4884,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	viewport_scrollable->add_child(scene_tree);
 	scene_tree->set_stretch(true);
 	scene_tree->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
-	scene_tree->add_child(p_editor->get_scene_root());
+	scene_tree->add_child(EditorNode::get_singleton()->get_scene_root());
 
 	controls_vb = memnew(VBoxContainer);
 	controls_vb->set_begin(Point2(5, 5));
@@ -4898,7 +4897,7 @@ CanvasItemEditor::CanvasItemEditor(EditorNode *p_editor) {
 	panner.instantiate();
 	panner->set_callbacks(callable_mp(this, &CanvasItemEditor::_scroll_callback), callable_mp(this, &CanvasItemEditor::_pan_callback), callable_mp(this, &CanvasItemEditor::_zoom_callback));
 
-	viewport = memnew(CanvasItemEditorViewport(p_editor, this));
+	viewport = memnew(CanvasItemEditorViewport(this));
 	viewport_scrollable->add_child(viewport);
 	viewport->set_mouse_filter(MOUSE_FILTER_PASS);
 	viewport->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
@@ -5275,12 +5274,12 @@ void CanvasItemEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		canvas_item_editor->show();
 		canvas_item_editor->set_physics_process(true);
-		RenderingServer::get_singleton()->viewport_set_disable_2d(editor->get_scene_root()->get_viewport_rid(), false);
+		RenderingServer::get_singleton()->viewport_set_disable_2d(EditorNode::get_singleton()->get_scene_root()->get_viewport_rid(), false);
 
 	} else {
 		canvas_item_editor->hide();
 		canvas_item_editor->set_physics_process(false);
-		RenderingServer::get_singleton()->viewport_set_disable_2d(editor->get_scene_root()->get_viewport_rid(), true);
+		RenderingServer::get_singleton()->viewport_set_disable_2d(EditorNode::get_singleton()->get_scene_root()->get_viewport_rid(), true);
 	}
 }
 
@@ -5292,11 +5291,10 @@ void CanvasItemEditorPlugin::set_state(const Dictionary &p_state) {
 	canvas_item_editor->set_state(p_state);
 }
 
-CanvasItemEditorPlugin::CanvasItemEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
-	canvas_item_editor = memnew(CanvasItemEditor(editor));
+CanvasItemEditorPlugin::CanvasItemEditorPlugin() {
+	canvas_item_editor = memnew(CanvasItemEditor);
 	canvas_item_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	editor->get_main_control()->add_child(canvas_item_editor);
+	EditorNode::get_singleton()->get_main_control()->add_child(canvas_item_editor);
 	canvas_item_editor->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	canvas_item_editor->hide();
 }
@@ -5364,7 +5362,7 @@ void CanvasItemEditorViewport::_create_preview(const Vector<String> &files) cons
 	}
 
 	if (add_preview) {
-		editor->get_scene_root()->add_child(preview_node);
+		EditorNode::get_singleton()->get_scene_root()->add_child(preview_node);
 	}
 }
 
@@ -5375,7 +5373,7 @@ void CanvasItemEditorViewport::_remove_preview() {
 			node->queue_delete();
 			preview_node->remove_child(node);
 		}
-		editor->get_scene_root()->remove_child(preview_node);
+		EditorNode::get_singleton()->get_scene_root()->remove_child(preview_node);
 
 		label->hide();
 		label_desc->hide();
@@ -5418,21 +5416,21 @@ void CanvasItemEditorViewport::_create_nodes(Node *parent, Node *child, String &
 
 	if (parent) {
 		editor_data->get_undo_redo().add_do_method(parent, "add_child", child, true);
-		editor_data->get_undo_redo().add_do_method(child, "set_owner", editor->get_edited_scene());
+		editor_data->get_undo_redo().add_do_method(child, "set_owner", EditorNode::get_singleton()->get_edited_scene());
 		editor_data->get_undo_redo().add_do_reference(child);
 		editor_data->get_undo_redo().add_undo_method(parent, "remove_child", child);
 	} else { // If no parent is selected, set as root node of the scene.
-		editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", child);
-		editor_data->get_undo_redo().add_do_method(child, "set_owner", editor->get_edited_scene());
+		editor_data->get_undo_redo().add_do_method(EditorNode::get_singleton(), "set_edited_scene", child);
+		editor_data->get_undo_redo().add_do_method(child, "set_owner", EditorNode::get_singleton()->get_edited_scene());
 		editor_data->get_undo_redo().add_do_reference(child);
-		editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", (Object *)nullptr);
+		editor_data->get_undo_redo().add_undo_method(EditorNode::get_singleton(), "set_edited_scene", (Object *)nullptr);
 	}
 
 	if (parent) {
 		String new_name = parent->validate_child_name(child);
 		EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-		editor_data->get_undo_redo().add_do_method(ed, "live_debug_create_node", editor->get_edited_scene()->get_path_to(parent), child->get_class(), new_name);
-		editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
+		editor_data->get_undo_redo().add_do_method(ed, "live_debug_create_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(parent), child->get_class(), new_name);
+		editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(EditorNode::get_singleton()->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
 	}
 
 	if (Object::cast_to<TouchScreenButton>(child) || Object::cast_to<TextureButton>(child)) {
@@ -5476,8 +5474,10 @@ bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, cons
 		return false;
 	}
 
-	if (!editor->get_edited_scene()->get_scene_file_path().is_empty()) { // cyclical instancing
-		if (_cyclical_dependency_exists(editor->get_edited_scene()->get_scene_file_path(), instantiated_scene)) {
+	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
+
+	if (!edited_scene->get_scene_file_path().is_empty()) { // cyclical instancing
+		if (_cyclical_dependency_exists(edited_scene->get_scene_file_path(), instantiated_scene)) {
 			memdelete(instantiated_scene);
 			return false;
 		}
@@ -5486,14 +5486,14 @@ bool CanvasItemEditorViewport::_create_instance(Node *parent, String &path, cons
 	instantiated_scene->set_scene_file_path(ProjectSettings::get_singleton()->localize_path(path));
 
 	editor_data->get_undo_redo().add_do_method(parent, "add_child", instantiated_scene, true);
-	editor_data->get_undo_redo().add_do_method(instantiated_scene, "set_owner", editor->get_edited_scene());
+	editor_data->get_undo_redo().add_do_method(instantiated_scene, "set_owner", edited_scene);
 	editor_data->get_undo_redo().add_do_reference(instantiated_scene);
 	editor_data->get_undo_redo().add_undo_method(parent, "remove_child", instantiated_scene);
 
 	String new_name = parent->validate_child_name(instantiated_scene);
 	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-	editor_data->get_undo_redo().add_do_method(ed, "live_debug_instance_node", editor->get_edited_scene()->get_path_to(parent), path, new_name);
-	editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
+	editor_data->get_undo_redo().add_do_method(ed, "live_debug_instance_node", edited_scene->get_path_to(parent), path, new_name);
+	editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(parent)) + "/" + new_name));
 
 	CanvasItem *parent_ci = Object::cast_to<CanvasItem>(parent);
 	if (parent_ci) {
@@ -5650,8 +5650,8 @@ void CanvasItemEditorViewport::drop_data(const Point2 &p_point, const Variant &p
 		return;
 	}
 
-	List<Node *> selected_nodes = editor->get_editor_selection()->get_selected_node_list();
-	Node *root_node = editor->get_edited_scene();
+	List<Node *> selected_nodes = EditorNode::get_singleton()->get_editor_selection()->get_selected_node_list();
+	Node *root_node = EditorNode::get_singleton()->get_edited_scene();
 	if (selected_nodes.size() > 0) {
 		Node *selected_node = selected_nodes[0];
 		target_node = root_node;
@@ -5731,7 +5731,7 @@ void CanvasItemEditorViewport::_notification(int p_what) {
 void CanvasItemEditorViewport::_bind_methods() {
 }
 
-CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasItemEditor *p_canvas_item_editor) {
+CanvasItemEditorViewport::CanvasItemEditorViewport(CanvasItemEditor *p_canvas_item_editor) {
 	default_texture_node_type = "Sprite2D";
 	// Node2D
 	texture_node_types.push_back("Sprite2D");
@@ -5746,16 +5746,15 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 	texture_node_types.push_back("NinePatchRect");
 
 	target_node = nullptr;
-	editor = p_node;
 	editor_data = SceneTreeDock::get_singleton()->get_editor_data();
 	canvas_item_editor = p_canvas_item_editor;
 	preview_node = memnew(Control);
 
 	accept = memnew(AcceptDialog);
-	editor->get_gui_base()->add_child(accept);
+	EditorNode::get_singleton()->get_gui_base()->add_child(accept);
 
 	selector = memnew(AcceptDialog);
-	editor->get_gui_base()->add_child(selector);
+	EditorNode::get_singleton()->get_gui_base()->add_child(selector);
 	selector->set_title(TTR("Change Default Type"));
 	selector->connect("confirmed", callable_mp(this, &CanvasItemEditorViewport::_on_change_type_confirmed));
 	selector->connect("cancelled", callable_mp(this, &CanvasItemEditorViewport::_on_change_type_closed));

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -92,8 +92,6 @@ public:
 	};
 
 private:
-	EditorNode *editor;
-
 	enum SnapTarget {
 		SNAP_TARGET_NONE = 0,
 		SNAP_TARGET_PARENT,
@@ -549,14 +547,13 @@ public:
 
 	EditorSelection *editor_selection;
 
-	CanvasItemEditor(EditorNode *p_editor);
+	CanvasItemEditor();
 };
 
 class CanvasItemEditorPlugin : public EditorPlugin {
 	GDCLASS(CanvasItemEditorPlugin, EditorPlugin);
 
 	CanvasItemEditor *canvas_item_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "2D"; }
@@ -569,7 +566,7 @@ public:
 
 	CanvasItemEditor *get_canvas_item_editor() { return canvas_item_editor; }
 
-	CanvasItemEditorPlugin(EditorNode *p_node);
+	CanvasItemEditorPlugin();
 	~CanvasItemEditorPlugin();
 };
 
@@ -585,7 +582,6 @@ class CanvasItemEditorViewport : public Control {
 	Node *target_node;
 	Point2 drop_pos;
 
-	EditorNode *editor;
 	EditorData *editor_data;
 	CanvasItemEditor *canvas_item_editor;
 	Control *preview_node;
@@ -622,7 +618,7 @@ public:
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
 
-	CanvasItemEditorViewport(EditorNode *p_node, CanvasItemEditor *p_canvas_item_editor);
+	CanvasItemEditorViewport(CanvasItemEditor *p_canvas_item_editor);
 	~CanvasItemEditorViewport();
 };
 

--- a/editor/plugins/collision_polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_polygon_2d_editor_plugin.cpp
@@ -38,11 +38,11 @@ void CollisionPolygon2DEditor::_set_node(Node *p_polygon) {
 	node = Object::cast_to<CollisionPolygon2D>(p_polygon);
 }
 
-CollisionPolygon2DEditor::CollisionPolygon2DEditor(EditorNode *p_editor) :
-		AbstractPolygon2DEditor(p_editor) {
+CollisionPolygon2DEditor::CollisionPolygon2DEditor() :
+		AbstractPolygon2DEditor() {
 	node = nullptr;
 }
 
-CollisionPolygon2DEditorPlugin::CollisionPolygon2DEditorPlugin(EditorNode *p_node) :
-		AbstractPolygon2DEditorPlugin(p_node, memnew(CollisionPolygon2DEditor(p_node)), "CollisionPolygon2D") {
+CollisionPolygon2DEditorPlugin::CollisionPolygon2DEditorPlugin() :
+		AbstractPolygon2DEditorPlugin(memnew(CollisionPolygon2DEditor), "CollisionPolygon2D") {
 }

--- a/editor/plugins/collision_polygon_2d_editor_plugin.h
+++ b/editor/plugins/collision_polygon_2d_editor_plugin.h
@@ -44,14 +44,14 @@ protected:
 	virtual void _set_node(Node *p_polygon) override;
 
 public:
-	CollisionPolygon2DEditor(EditorNode *p_editor);
+	CollisionPolygon2DEditor();
 };
 
 class CollisionPolygon2DEditorPlugin : public AbstractPolygon2DEditorPlugin {
 	GDCLASS(CollisionPolygon2DEditorPlugin, AbstractPolygon2DEditorPlugin);
 
 public:
-	CollisionPolygon2DEditorPlugin(EditorNode *p_node);
+	CollisionPolygon2DEditorPlugin();
 };
 
 #endif // COLLISION_POLYGON_2D_EDITOR_PLUGIN_H

--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -583,12 +583,11 @@ void CollisionShape2DEditor::_bind_methods() {
 	ClassDB::bind_method("_get_current_shape_type", &CollisionShape2DEditor::_get_current_shape_type);
 }
 
-CollisionShape2DEditor::CollisionShape2DEditor(EditorNode *p_editor) {
+CollisionShape2DEditor::CollisionShape2DEditor() {
 	node = nullptr;
 	canvas_item_editor = nullptr;
-	editor = p_editor;
 
-	undo_redo = p_editor->get_undo_redo();
+	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 	edit_handle = -1;
 	pressed = false;
@@ -610,11 +609,9 @@ void CollisionShape2DEditorPlugin::make_visible(bool visible) {
 	}
 }
 
-CollisionShape2DEditorPlugin::CollisionShape2DEditorPlugin(EditorNode *p_editor) {
-	editor = p_editor;
-
-	collision_shape_2d_editor = memnew(CollisionShape2DEditor(p_editor));
-	p_editor->get_gui_base()->add_child(collision_shape_2d_editor);
+CollisionShape2DEditorPlugin::CollisionShape2DEditorPlugin() {
+	collision_shape_2d_editor = memnew(CollisionShape2DEditor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(collision_shape_2d_editor);
 }
 
 CollisionShape2DEditorPlugin::~CollisionShape2DEditorPlugin() {

--- a/editor/plugins/collision_shape_2d_editor_plugin.h
+++ b/editor/plugins/collision_shape_2d_editor_plugin.h
@@ -63,7 +63,6 @@ class CollisionShape2DEditor : public Control {
 		Point2(1, -1),
 	};
 
-	EditorNode *editor;
 	UndoRedo *undo_redo;
 	CanvasItemEditor *canvas_item_editor;
 	CollisionShape2D *node;
@@ -93,14 +92,13 @@ public:
 	void forward_canvas_draw_over_viewport(Control *p_overlay);
 	void edit(Node *p_node);
 
-	CollisionShape2DEditor(EditorNode *p_editor);
+	CollisionShape2DEditor();
 };
 
 class CollisionShape2DEditorPlugin : public EditorPlugin {
 	GDCLASS(CollisionShape2DEditorPlugin, EditorPlugin);
 
 	CollisionShape2DEditor *collision_shape_2d_editor;
-	EditorNode *editor;
 
 public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return collision_shape_2d_editor->forward_canvas_gui_input(p_event); }
@@ -112,7 +110,7 @@ public:
 	virtual bool handles(Object *p_obj) const override;
 	virtual void make_visible(bool visible) override;
 
-	CollisionShape2DEditorPlugin(EditorNode *p_editor);
+	CollisionShape2DEditorPlugin();
 	~CollisionShape2DEditorPlugin();
 };
 

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -941,7 +941,7 @@ void ControlEditorToolbar::_notification(int p_what) {
 	}
 }
 
-ControlEditorToolbar::ControlEditorToolbar(EditorNode *p_editor) {
+ControlEditorToolbar::ControlEditorToolbar() {
 	anchor_layouts_icon = memnew(TextureRect);
 	anchor_layouts_icon->set_stretch_mode(TextureRect::StretchMode::STRETCH_KEEP_CENTERED);
 	add_child(anchor_layouts_icon);
@@ -1000,8 +1000,8 @@ ControlEditorToolbar::ControlEditorToolbar(EditorNode *p_editor) {
 	p = container_v_presets_menu->get_popup();
 	p->connect("id_pressed", callable_mp(this, &ControlEditorToolbar::_popup_callback));
 
-	undo_redo = p_editor->get_undo_redo();
-	editor_selection = p_editor->get_editor_selection();
+	undo_redo = EditorNode::get_singleton()->get_undo_redo();
+	editor_selection = EditorNode::get_singleton()->get_editor_selection();
 	editor_selection->add_editor_plugin(this);
 	editor_selection->connect("selection_changed", callable_mp(this, &ControlEditorToolbar::_selection_changed));
 
@@ -1010,10 +1010,8 @@ ControlEditorToolbar::ControlEditorToolbar(EditorNode *p_editor) {
 
 ControlEditorToolbar *ControlEditorToolbar::singleton = nullptr;
 
-ControlEditorPlugin::ControlEditorPlugin(EditorNode *p_editor) {
-	editor = p_editor;
-
-	toolbar = memnew(ControlEditorToolbar(editor));
+ControlEditorPlugin::ControlEditorPlugin() {
+	toolbar = memnew(ControlEditorToolbar);
 	toolbar->hide();
 	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, toolbar);
 

--- a/editor/plugins/control_editor_plugin.h
+++ b/editor/plugins/control_editor_plugin.h
@@ -237,19 +237,18 @@ public:
 
 	static ControlEditorToolbar *get_singleton() { return singleton; }
 
-	ControlEditorToolbar(EditorNode *p_editor);
+	ControlEditorToolbar();
 };
 
 class ControlEditorPlugin : public EditorPlugin {
 	GDCLASS(ControlEditorPlugin, EditorPlugin);
 
-	EditorNode *editor;
 	ControlEditorToolbar *toolbar;
 
 public:
 	virtual String get_name() const override { return "Control"; }
 
-	ControlEditorPlugin(EditorNode *p_editor);
+	ControlEditorPlugin();
 };
 
 #endif //CONTROL_EDITOR_PLUGIN_H

--- a/editor/plugins/cpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.cpp
@@ -234,10 +234,9 @@ void CPUParticles2DEditorPlugin::_notification(int p_what) {
 void CPUParticles2DEditorPlugin::_bind_methods() {
 }
 
-CPUParticles2DEditorPlugin::CPUParticles2DEditorPlugin(EditorNode *p_node) {
+CPUParticles2DEditorPlugin::CPUParticles2DEditorPlugin() {
 	particles = nullptr;
-	editor = p_node;
-	undo_redo = editor->get_undo_redo();
+	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 	toolbar = memnew(HBoxContainer);
 	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, toolbar);

--- a/editor/plugins/cpu_particles_2d_editor_plugin.h
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.h
@@ -59,7 +59,6 @@ class CPUParticles2DEditorPlugin : public EditorPlugin {
 	CPUParticles2D *particles;
 
 	EditorFileDialog *file;
-	EditorNode *editor;
 
 	HBoxContainer *toolbar;
 	MenuButton *menu;
@@ -88,7 +87,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	CPUParticles2DEditorPlugin(EditorNode *p_node);
+	CPUParticles2DEditorPlugin();
 	~CPUParticles2DEditorPlugin();
 };
 

--- a/editor/plugins/cpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_3d_editor_plugin.cpp
@@ -122,10 +122,9 @@ void CPUParticles3DEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-CPUParticles3DEditorPlugin::CPUParticles3DEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+CPUParticles3DEditorPlugin::CPUParticles3DEditorPlugin() {
 	particles_editor = memnew(CPUParticles3DEditor);
-	editor->get_main_control()->add_child(particles_editor);
+	EditorNode::get_singleton()->get_main_control()->add_child(particles_editor);
 
 	particles_editor->hide();
 }

--- a/editor/plugins/cpu_particles_3d_editor_plugin.h
+++ b/editor/plugins/cpu_particles_3d_editor_plugin.h
@@ -68,7 +68,6 @@ class CPUParticles3DEditorPlugin : public EditorPlugin {
 	GDCLASS(CPUParticles3DEditorPlugin, EditorPlugin);
 
 	CPUParticles3DEditor *particles_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "CPUParticles3D"; }
@@ -77,7 +76,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	CPUParticles3DEditorPlugin(EditorNode *p_node);
+	CPUParticles3DEditorPlugin();
 	~CPUParticles3DEditorPlugin();
 };
 

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -774,7 +774,7 @@ void EditorInspectorPluginCurve::parse_begin(Object *p_object) {
 	add_custom_control(editor);
 }
 
-CurveEditorPlugin::CurveEditorPlugin(EditorNode *p_node) {
+CurveEditorPlugin::CurveEditorPlugin() {
 	Ref<EditorInspectorPluginCurve> curve_plugin;
 	curve_plugin.instantiate();
 	EditorInspector::add_inspector_plugin(curve_plugin);

--- a/editor/plugins/curve_editor_plugin.h
+++ b/editor/plugins/curve_editor_plugin.h
@@ -130,7 +130,7 @@ class CurveEditorPlugin : public EditorPlugin {
 	GDCLASS(CurveEditorPlugin, EditorPlugin);
 
 public:
-	CurveEditorPlugin(EditorNode *p_node);
+	CurveEditorPlugin();
 
 	virtual String get_name() const override { return "Curve"; }
 };

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -38,7 +38,7 @@
 #include "editor/fileserver/editor_file_server.h"
 #include "scene/gui/menu_button.h"
 
-DebuggerEditorPlugin::DebuggerEditorPlugin(EditorNode *p_editor, MenuButton *p_debug_menu) {
+DebuggerEditorPlugin::DebuggerEditorPlugin(MenuButton *p_debug_menu) {
 	EditorDebuggerServer::initialize();
 
 	ED_SHORTCUT("debugger/step_into", TTR("Step Into"), Key::F11);

--- a/editor/plugins/debugger_editor_plugin.h
+++ b/editor/plugins/debugger_editor_plugin.h
@@ -64,7 +64,7 @@ public:
 	virtual String get_name() const override { return "Debugger"; }
 	bool has_main_screen() const override { return false; }
 
-	DebuggerEditorPlugin(EditorNode *p_node, MenuButton *p_menu);
+	DebuggerEditorPlugin(MenuButton *p_menu);
 	~DebuggerEditorPlugin();
 };
 

--- a/editor/plugins/font_editor_plugin.cpp
+++ b/editor/plugins/font_editor_plugin.cpp
@@ -98,7 +98,7 @@ bool EditorInspectorPluginFont::parse_property(Object *p_object, const Variant::
 
 /*************************************************************************/
 
-FontEditorPlugin::FontEditorPlugin(EditorNode *p_node) {
+FontEditorPlugin::FontEditorPlugin() {
 	Ref<EditorInspectorPluginFont> fd_plugin;
 	fd_plugin.instantiate();
 	EditorInspector::add_inspector_plugin(fd_plugin);

--- a/editor/plugins/font_editor_plugin.h
+++ b/editor/plugins/font_editor_plugin.h
@@ -71,7 +71,7 @@ class FontEditorPlugin : public EditorPlugin {
 	GDCLASS(FontEditorPlugin, EditorPlugin);
 
 public:
-	FontEditorPlugin(EditorNode *p_node);
+	FontEditorPlugin();
 
 	virtual String get_name() const override { return "Font"; }
 };

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -61,7 +61,7 @@ void GPUParticles2DEditorPlugin::_file_selected(const String &p_file) {
 }
 
 void GPUParticles2DEditorPlugin::_selection_changed() {
-	List<Node *> selected_nodes = editor->get_editor_selection()->get_selected_node_list();
+	List<Node *> selected_nodes = EditorNode::get_singleton()->get_editor_selection()->get_selected_node_list();
 
 	if (selected_particles.is_empty() && selected_nodes.is_empty()) {
 		return;
@@ -365,10 +365,9 @@ void GPUParticles2DEditorPlugin::_notification(int p_what) {
 void GPUParticles2DEditorPlugin::_bind_methods() {
 }
 
-GPUParticles2DEditorPlugin::GPUParticles2DEditorPlugin(EditorNode *p_node) {
+GPUParticles2DEditorPlugin::GPUParticles2DEditorPlugin() {
 	particles = nullptr;
-	editor = p_node;
-	undo_redo = editor->get_undo_redo();
+	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 	toolbar = memnew(HBoxContainer);
 	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, toolbar);

--- a/editor/plugins/gpu_particles_2d_editor_plugin.h
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.h
@@ -61,7 +61,6 @@ class GPUParticles2DEditorPlugin : public EditorPlugin {
 	List<GPUParticles2D *> selected_particles;
 
 	EditorFileDialog *file;
-	EditorNode *editor;
 
 	HBoxContainer *toolbar;
 	MenuButton *menu;
@@ -95,7 +94,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	GPUParticles2DEditorPlugin(EditorNode *p_node);
+	GPUParticles2DEditorPlugin();
 	~GPUParticles2DEditorPlugin();
 };
 

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -457,10 +457,9 @@ void GPUParticles3DEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-GPUParticles3DEditorPlugin::GPUParticles3DEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+GPUParticles3DEditorPlugin::GPUParticles3DEditorPlugin() {
 	particles_editor = memnew(GPUParticles3DEditor);
-	editor->get_main_control()->add_child(particles_editor);
+	EditorNode::get_singleton()->get_main_control()->add_child(particles_editor);
 
 	particles_editor->hide();
 }

--- a/editor/plugins/gpu_particles_3d_editor_plugin.h
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.h
@@ -103,7 +103,6 @@ class GPUParticles3DEditorPlugin : public EditorPlugin {
 	GDCLASS(GPUParticles3DEditorPlugin, EditorPlugin);
 
 	GPUParticles3DEditor *particles_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "GPUParticles3D"; }
@@ -112,7 +111,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	GPUParticles3DEditorPlugin(EditorNode *p_node);
+	GPUParticles3DEditorPlugin();
 	~GPUParticles3DEditorPlugin();
 };
 

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -174,14 +174,13 @@ void GPUParticlesCollisionSDF3DEditorPlugin::_sdf_save_path_and_bake(const Strin
 void GPUParticlesCollisionSDF3DEditorPlugin::_bind_methods() {
 }
 
-GPUParticlesCollisionSDF3DEditorPlugin::GPUParticlesCollisionSDF3DEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+GPUParticlesCollisionSDF3DEditorPlugin::GPUParticlesCollisionSDF3DEditorPlugin() {
 	bake_hb = memnew(HBoxContainer);
 	bake_hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	bake_hb->hide();
 	bake = memnew(Button);
 	bake->set_flat(true);
-	bake->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
+	bake->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake SDF"));
 	bake->connect("pressed", callable_mp(this, &GPUParticlesCollisionSDF3DEditorPlugin::_bake));
 	bake_hb->add_child(bake);

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
@@ -46,7 +46,6 @@ class GPUParticlesCollisionSDF3DEditorPlugin : public EditorPlugin {
 
 	HBoxContainer *bake_hb;
 	Button *bake;
-	EditorNode *editor;
 
 	EditorFileDialog *probe_file;
 
@@ -69,7 +68,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	GPUParticlesCollisionSDF3DEditorPlugin(EditorNode *p_node);
+	GPUParticlesCollisionSDF3DEditorPlugin();
 	~GPUParticlesCollisionSDF3DEditorPlugin();
 };
 

--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -137,7 +137,7 @@ void EditorInspectorPluginGradient::_reverse_button_pressed() {
 	editor->reverse_gradient();
 }
 
-GradientEditorPlugin::GradientEditorPlugin(EditorNode *p_node) {
+GradientEditorPlugin::GradientEditorPlugin() {
 	Ref<EditorInspectorPluginGradient> plugin;
 	plugin.instantiate();
 	add_inspector_plugin(plugin);

--- a/editor/plugins/gradient_editor_plugin.h
+++ b/editor/plugins/gradient_editor_plugin.h
@@ -84,7 +84,7 @@ class GradientEditorPlugin : public EditorPlugin {
 public:
 	virtual String get_name() const override { return "Gradient"; }
 
-	GradientEditorPlugin(EditorNode *p_node);
+	GradientEditorPlugin();
 };
 
 #endif // GRADIENT_EDITOR_PLUGIN_H

--- a/editor/plugins/input_event_editor_plugin.cpp
+++ b/editor/plugins/input_event_editor_plugin.cpp
@@ -117,7 +117,7 @@ void EditorInspectorPluginInputEvent::parse_begin(Object *p_object) {
 	add_custom_control(picker_controls);
 }
 
-InputEventEditorPlugin::InputEventEditorPlugin(EditorNode *p_node) {
+InputEventEditorPlugin::InputEventEditorPlugin() {
 	Ref<EditorInspectorPluginInputEvent> plugin;
 	plugin.instantiate();
 	add_inspector_plugin(plugin);

--- a/editor/plugins/input_event_editor_plugin.h
+++ b/editor/plugins/input_event_editor_plugin.h
@@ -74,7 +74,7 @@ class InputEventEditorPlugin : public EditorPlugin {
 public:
 	virtual String get_name() const override { return "InputEvent"; }
 
-	InputEventEditorPlugin(EditorNode *p_node);
+	InputEventEditorPlugin();
 };
 
 #endif // INPUT_EVENT_EDITOR_PLUGIN_H

--- a/editor/plugins/light_occluder_2d_editor_plugin.cpp
+++ b/editor/plugins/light_occluder_2d_editor_plugin.cpp
@@ -102,11 +102,11 @@ void LightOccluder2DEditor::_create_resource() {
 	_menu_option(MODE_CREATE);
 }
 
-LightOccluder2DEditor::LightOccluder2DEditor(EditorNode *p_editor) :
-		AbstractPolygon2DEditor(p_editor) {
+LightOccluder2DEditor::LightOccluder2DEditor() :
+		AbstractPolygon2DEditor() {
 	node = nullptr;
 }
 
-LightOccluder2DEditorPlugin::LightOccluder2DEditorPlugin(EditorNode *p_node) :
-		AbstractPolygon2DEditorPlugin(p_node, memnew(LightOccluder2DEditor(p_node)), "LightOccluder2D") {
+LightOccluder2DEditorPlugin::LightOccluder2DEditorPlugin() :
+		AbstractPolygon2DEditorPlugin(memnew(LightOccluder2DEditor), "LightOccluder2D") {
 }

--- a/editor/plugins/light_occluder_2d_editor_plugin.h
+++ b/editor/plugins/light_occluder_2d_editor_plugin.h
@@ -56,14 +56,14 @@ protected:
 	virtual void _create_resource() override;
 
 public:
-	LightOccluder2DEditor(EditorNode *p_editor);
+	LightOccluder2DEditor();
 };
 
 class LightOccluder2DEditorPlugin : public AbstractPolygon2DEditorPlugin {
 	GDCLASS(LightOccluder2DEditorPlugin, AbstractPolygon2DEditorPlugin);
 
 public:
-	LightOccluder2DEditorPlugin(EditorNode *p_node);
+	LightOccluder2DEditorPlugin();
 };
 
 #endif // LIGHT_OCCLUDER_2D_EDITOR_PLUGIN_H

--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -126,11 +126,10 @@ void LightmapGIEditorPlugin::_bind_methods() {
 	ClassDB::bind_method("_bake", &LightmapGIEditorPlugin::_bake);
 }
 
-LightmapGIEditorPlugin::LightmapGIEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+LightmapGIEditorPlugin::LightmapGIEditorPlugin() {
 	bake = memnew(Button);
 	bake->set_flat(true);
-	bake->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
+	bake->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake Lightmaps"));
 	bake->hide();
 	bake->connect("pressed", Callable(this, "_bake"));

--- a/editor/plugins/lightmap_gi_editor_plugin.h
+++ b/editor/plugins/lightmap_gi_editor_plugin.h
@@ -45,7 +45,6 @@ class LightmapGIEditorPlugin : public EditorPlugin {
 	LightmapGI *lightmap;
 
 	Button *bake;
-	EditorNode *editor;
 
 	EditorFileDialog *file_dialog;
 	static EditorProgress *tmp_progress;
@@ -65,7 +64,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	LightmapGIEditorPlugin(EditorNode *p_node);
+	LightmapGIEditorPlugin();
 	~LightmapGIEditorPlugin();
 };
 

--- a/editor/plugins/line_2d_editor_plugin.cpp
+++ b/editor/plugins/line_2d_editor_plugin.cpp
@@ -56,11 +56,11 @@ void Line2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, con
 	undo_redo->add_undo_method(node, "set_points", p_previous);
 }
 
-Line2DEditor::Line2DEditor(EditorNode *p_editor) :
-		AbstractPolygon2DEditor(p_editor) {
+Line2DEditor::Line2DEditor() :
+		AbstractPolygon2DEditor() {
 	node = nullptr;
 }
 
-Line2DEditorPlugin::Line2DEditorPlugin(EditorNode *p_node) :
-		AbstractPolygon2DEditorPlugin(p_node, memnew(Line2DEditor(p_node)), "Line2D") {
+Line2DEditorPlugin::Line2DEditorPlugin() :
+		AbstractPolygon2DEditorPlugin(memnew(Line2DEditor), "Line2D") {
 }

--- a/editor/plugins/line_2d_editor_plugin.h
+++ b/editor/plugins/line_2d_editor_plugin.h
@@ -49,14 +49,14 @@ protected:
 	virtual void _action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) override;
 
 public:
-	Line2DEditor(EditorNode *p_editor);
+	Line2DEditor();
 };
 
 class Line2DEditorPlugin : public AbstractPolygon2DEditorPlugin {
 	GDCLASS(Line2DEditorPlugin, AbstractPolygon2DEditorPlugin);
 
 public:
-	Line2DEditorPlugin(EditorNode *p_node);
+	Line2DEditorPlugin();
 };
 
 #endif // LINE_2D_EDITOR_PLUGIN_H

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -303,7 +303,7 @@ EditorInspectorPluginMaterial::EditorInspectorPluginMaterial() {
 	EditorNode::get_singleton()->get_editor_data().add_undo_redo_inspector_hook_callback(callable_mp(this, &EditorInspectorPluginMaterial::_undo_redo_inspector_callback));
 }
 
-MaterialEditorPlugin::MaterialEditorPlugin(EditorNode *p_node) {
+MaterialEditorPlugin::MaterialEditorPlugin() {
 	Ref<EditorInspectorPluginMaterial> plugin;
 	plugin.instantiate();
 	add_inspector_plugin(plugin);

--- a/editor/plugins/material_editor_plugin.h
+++ b/editor/plugins/material_editor_plugin.h
@@ -103,7 +103,7 @@ class MaterialEditorPlugin : public EditorPlugin {
 public:
 	virtual String get_name() const override { return "Material"; }
 
-	MaterialEditorPlugin(EditorNode *p_node);
+	MaterialEditorPlugin();
 };
 
 class StandardMaterial3DConversionPlugin : public EditorResourceConversionPlugin {

--- a/editor/plugins/mesh_editor_plugin.cpp
+++ b/editor/plugins/mesh_editor_plugin.cpp
@@ -177,7 +177,7 @@ void EditorInspectorPluginMesh::parse_begin(Object *p_object) {
 	add_custom_control(editor);
 }
 
-MeshEditorPlugin::MeshEditorPlugin(EditorNode *p_node) {
+MeshEditorPlugin::MeshEditorPlugin() {
 	Ref<EditorInspectorPluginMesh> plugin;
 	plugin.instantiate();
 	add_inspector_plugin(plugin);

--- a/editor/plugins/mesh_editor_plugin.h
+++ b/editor/plugins/mesh_editor_plugin.h
@@ -86,7 +86,7 @@ class MeshEditorPlugin : public EditorPlugin {
 public:
 	virtual String get_name() const override { return "Mesh"; }
 
-	MeshEditorPlugin(EditorNode *p_node);
+	MeshEditorPlugin();
 };
 
 #endif

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -516,10 +516,9 @@ void MeshInstance3DEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-MeshInstance3DEditorPlugin::MeshInstance3DEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+MeshInstance3DEditorPlugin::MeshInstance3DEditorPlugin() {
 	mesh_editor = memnew(MeshInstance3DEditor);
-	editor->get_main_control()->add_child(mesh_editor);
+	EditorNode::get_singleton()->get_main_control()->add_child(mesh_editor);
 
 	mesh_editor->options->hide();
 }

--- a/editor/plugins/mesh_instance_3d_editor_plugin.h
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.h
@@ -87,7 +87,6 @@ class MeshInstance3DEditorPlugin : public EditorPlugin {
 	GDCLASS(MeshInstance3DEditorPlugin, EditorPlugin);
 
 	MeshInstance3DEditor *mesh_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "MeshInstance3D"; }
@@ -96,7 +95,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	MeshInstance3DEditorPlugin(EditorNode *p_node);
+	MeshInstance3DEditorPlugin();
 	~MeshInstance3DEditorPlugin();
 };
 

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -254,7 +254,7 @@ void MeshLibraryEditor::_menu_cbk(int p_option) {
 void MeshLibraryEditor::_bind_methods() {
 }
 
-MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
+MeshLibraryEditor::MeshLibraryEditor() {
 	file = memnew(EditorFileDialog);
 	file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	//not for now?
@@ -283,7 +283,6 @@ MeshLibraryEditor::MeshLibraryEditor(EditorNode *p_editor) {
 	menu->get_popup()->connect("id_pressed", callable_mp(this, &MeshLibraryEditor::_menu_cbk));
 	menu->hide();
 
-	editor = p_editor;
 	cd_remove = memnew(ConfirmationDialog);
 	add_child(cd_remove);
 	cd_remove->get_ok_button()->connect("pressed", callable_mp(this, &MeshLibraryEditor::_menu_remove_confirm));
@@ -317,14 +316,12 @@ void MeshLibraryEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-MeshLibraryEditorPlugin::MeshLibraryEditorPlugin(EditorNode *p_node) {
+MeshLibraryEditorPlugin::MeshLibraryEditorPlugin() {
 	EDITOR_DEF("editors/grid_map/preview_size", 64);
-	mesh_library_editor = memnew(MeshLibraryEditor(p_node));
+	mesh_library_editor = memnew(MeshLibraryEditor);
 
-	p_node->get_main_control()->add_child(mesh_library_editor);
+	EditorNode::get_singleton()->get_main_control()->add_child(mesh_library_editor);
 	mesh_library_editor->set_anchors_and_offsets_preset(Control::PRESET_TOP_WIDE);
 	mesh_library_editor->set_end(Point2(0, 22));
 	mesh_library_editor->hide();
-
-	editor = nullptr;
 }

--- a/editor/plugins/mesh_library_editor_plugin.h
+++ b/editor/plugins/mesh_library_editor_plugin.h
@@ -44,7 +44,6 @@ class MeshLibraryEditor : public Control {
 
 	Ref<MeshLibrary> mesh_library;
 
-	EditorNode *editor;
 	MenuButton *menu;
 	ConfirmationDialog *cd_remove;
 	ConfirmationDialog *cd_update;
@@ -77,14 +76,13 @@ public:
 	void edit(const Ref<MeshLibrary> &p_mesh_library);
 	static Error update_library_file(Node *p_base_scene, Ref<MeshLibrary> ml, bool p_merge = true, bool p_apply_xforms = false);
 
-	MeshLibraryEditor(EditorNode *p_editor);
+	MeshLibraryEditor();
 };
 
 class MeshLibraryEditorPlugin : public EditorPlugin {
 	GDCLASS(MeshLibraryEditorPlugin, EditorPlugin);
 
 	MeshLibraryEditor *mesh_library_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "MeshLibrary"; }
@@ -93,7 +91,7 @@ public:
 	virtual bool handles(Object *p_node) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	MeshLibraryEditorPlugin(EditorNode *p_node);
+	MeshLibraryEditorPlugin();
 };
 
 #endif // MESH_LIBRARY_EDITOR_PLUGIN_H

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -377,10 +377,9 @@ void MultiMeshEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-MultiMeshEditorPlugin::MultiMeshEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+MultiMeshEditorPlugin::MultiMeshEditorPlugin() {
 	multimesh_editor = memnew(MultiMeshEditor);
-	editor->get_main_control()->add_child(multimesh_editor);
+	EditorNode::get_singleton()->get_main_control()->add_child(multimesh_editor);
 
 	multimesh_editor->options->hide();
 }

--- a/editor/plugins/multimesh_editor_plugin.h
+++ b/editor/plugins/multimesh_editor_plugin.h
@@ -87,7 +87,6 @@ class MultiMeshEditorPlugin : public EditorPlugin {
 	GDCLASS(MultiMeshEditorPlugin, EditorPlugin);
 
 	MultiMeshEditor *multimesh_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "MultiMesh"; }
@@ -96,7 +95,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	MultiMeshEditorPlugin(EditorNode *p_node);
+	MultiMeshEditorPlugin();
 	~MultiMeshEditorPlugin();
 };
 

--- a/editor/plugins/navigation_polygon_editor_plugin.cpp
+++ b/editor/plugins/navigation_polygon_editor_plugin.cpp
@@ -112,11 +112,11 @@ void NavigationPolygonEditor::_create_resource() {
 	_menu_option(MODE_CREATE);
 }
 
-NavigationPolygonEditor::NavigationPolygonEditor(EditorNode *p_editor) :
-		AbstractPolygon2DEditor(p_editor) {
+NavigationPolygonEditor::NavigationPolygonEditor() :
+		AbstractPolygon2DEditor() {
 	node = nullptr;
 }
 
-NavigationPolygonEditorPlugin::NavigationPolygonEditorPlugin(EditorNode *p_node) :
-		AbstractPolygon2DEditorPlugin(p_node, memnew(NavigationPolygonEditor(p_node)), "NavigationRegion2D") {
+NavigationPolygonEditorPlugin::NavigationPolygonEditorPlugin() :
+		AbstractPolygon2DEditorPlugin(memnew(NavigationPolygonEditor), "NavigationRegion2D") {
 }

--- a/editor/plugins/navigation_polygon_editor_plugin.h
+++ b/editor/plugins/navigation_polygon_editor_plugin.h
@@ -57,14 +57,14 @@ protected:
 	virtual void _create_resource() override;
 
 public:
-	NavigationPolygonEditor(EditorNode *p_editor);
+	NavigationPolygonEditor();
 };
 
 class NavigationPolygonEditorPlugin : public AbstractPolygon2DEditorPlugin {
 	GDCLASS(NavigationPolygonEditorPlugin, AbstractPolygon2DEditorPlugin);
 
 public:
-	NavigationPolygonEditorPlugin(EditorNode *p_node);
+	NavigationPolygonEditorPlugin();
 };
 
 #endif // NAVIGATIONPOLYGONEDITORPLUGIN_H

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -473,7 +473,7 @@ void Node3DEditorViewport::_select_clicked(bool p_allow_locked) {
 
 	if (!p_allow_locked) {
 		// Replace the node by the group if grouped
-		while (node && node != editor->get_edited_scene()->get_parent()) {
+		while (node && node != EditorNode::get_singleton()->get_edited_scene()->get_parent()) {
 			Node3D *selected_tmp = Object::cast_to<Node3D>(node);
 			if (selected_tmp && node->has_meta("_edit_group_")) {
 				selected = selected_tmp;
@@ -493,12 +493,12 @@ void Node3DEditorViewport::_select_clicked(bool p_allow_locked) {
 			if (!editor_selection->is_selected(selected)) {
 				editor_selection->clear();
 				editor_selection->add_node(selected);
-				editor->edit_node(selected);
+				EditorNode::get_singleton()->edit_node(selected);
 			}
 		}
 
 		if (editor_selection->get_selected_node_list().size() == 1) {
-			editor->edit_node(editor_selection->get_selected_node_list()[0]);
+			EditorNode::get_singleton()->edit_node(editor_selection->get_selected_node_list()[0]);
 		}
 	}
 }
@@ -784,7 +784,7 @@ void Node3DEditorViewport::_select_region() {
 		// Replace the node by the group if grouped
 		if (item->is_class("Node3D")) {
 			Node3D *sel = Object::cast_to<Node3D>(item);
-			while (item && item != editor->get_edited_scene()->get_parent()) {
+			while (item && item != EditorNode::get_singleton()->get_edited_scene()->get_parent()) {
 				Node3D *selected_tmp = Object::cast_to<Node3D>(item);
 				if (selected_tmp && item->has_meta("_edit_group_")) {
 					sel = selected_tmp;
@@ -818,7 +818,7 @@ void Node3DEditorViewport::_select_region() {
 	}
 
 	if (editor_selection->get_selected_node_list().size() == 1) {
-		editor->edit_node(editor_selection->get_selected_node_list()[0]);
+		EditorNode::get_singleton()->edit_node(editor_selection->get_selected_node_list()[0]);
 	}
 }
 
@@ -1266,7 +1266,7 @@ bool Node3DEditorViewport ::_is_node_locked(const Node *p_node) {
 void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 	_find_items_at_pos(b->get_position(), selection_results, spatial_editor->get_tool_mode() == Node3DEditor::TOOL_MODE_SELECT);
 
-	Node *scene = editor->get_edited_scene();
+	Node *scene = EditorNode::get_singleton()->get_edited_scene();
 
 	for (int i = 0; i < selection_results.size(); i++) {
 		Node3D *item = selection_results[i].item;
@@ -1301,7 +1301,7 @@ void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {
 			if (_is_node_locked(spat)) {
 				locked = 1;
 			} else {
-				Node *ed_scene = editor->get_edited_scene();
+				Node *ed_scene = EditorNode::get_singleton()->get_edited_scene();
 				Node *node = spat;
 
 				while (node && node != ed_scene->get_parent()) {
@@ -1338,7 +1338,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 	EditorPlugin::AfterGUIInput after = EditorPlugin::AFTER_GUI_INPUT_PASS;
 	{
-		EditorNode *en = editor;
+		EditorNode *en = EditorNode::get_singleton();
 		EditorPluginList *force_input_forwarding_list = en->get_editor_plugins_force_input_forwarding();
 		if (!force_input_forwarding_list->is_empty()) {
 			EditorPlugin::AfterGUIInput discard = force_input_forwarding_list->forward_spatial_gui_input(camera, p_event, true);
@@ -1351,7 +1351,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		}
 	}
 	{
-		EditorNode *en = editor;
+		EditorNode *en = EditorNode::get_singleton();
 		EditorPluginList *over_plugin_list = en->get_editor_plugins_over();
 		if (!over_plugin_list->is_empty()) {
 			EditorPlugin::AfterGUIInput discard = over_plugin_list->forward_spatial_gui_input(camera, p_event, false);
@@ -2666,29 +2666,30 @@ void Node3DEditorViewport::_notification(int p_what) {
 	if (p_what == NOTIFICATION_THEME_CHANGED) {
 		view_menu->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 		preview_camera->set_icon(get_theme_icon(SNAME("Camera3D"), SNAME("EditorIcons")));
+		Control *gui_base = EditorNode::get_singleton()->get_gui_base();
 
-		view_menu->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		view_menu->add_theme_style_override("hover", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		view_menu->add_theme_style_override("pressed", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		view_menu->add_theme_style_override("focus", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		view_menu->add_theme_style_override("disabled", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("normal", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("pressed", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("focus", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("disabled", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
 
-		preview_camera->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		preview_camera->add_theme_style_override("hover", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		preview_camera->add_theme_style_override("pressed", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		preview_camera->add_theme_style_override("focus", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		preview_camera->add_theme_style_override("disabled", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("normal", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("pressed", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("focus", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("disabled", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
 
 		frame_time_gradient->set_color(0, get_theme_color(SNAME("success_color"), SNAME("Editor")));
 		frame_time_gradient->set_color(1, get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 		frame_time_gradient->set_color(2, get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
-		info_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		cpu_time_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		gpu_time_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		fps_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		cinema_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		locked_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		info_label->add_theme_style_override("normal", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		cpu_time_label->add_theme_style_override("normal", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		gpu_time_label->add_theme_style_override("normal", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		fps_label->add_theme_style_override("normal", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		cinema_label->add_theme_style_override("normal", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		locked_label->add_theme_style_override("normal", gui_base->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
 	}
 }
 
@@ -2721,7 +2722,7 @@ void Node3DEditorViewport::_draw() {
 		over_plugin_list->forward_spatial_draw_over_viewport(surface);
 	}
 
-	EditorPluginList *force_over_plugin_list = editor->get_editor_plugins_force_over();
+	EditorPluginList *force_over_plugin_list = EditorNode::get_singleton()->get_editor_plugins_force_over();
 	if (!force_over_plugin_list->is_empty()) {
 		force_over_plugin_list->forward_spatial_force_draw_over_viewport(surface);
 	}
@@ -3787,7 +3788,7 @@ void Node3DEditorViewport::_create_preview(const Vector<String> &files) const {
 					}
 				}
 			}
-			editor->get_scene_root()->add_child(preview_node);
+			EditorNode::get_singleton()->get_scene_root()->add_child(preview_node);
 		}
 	}
 	*preview_bounds = _calculate_spatial_bounds(preview_node);
@@ -3800,7 +3801,7 @@ void Node3DEditorViewport::_remove_preview() {
 			node->queue_delete();
 			preview_node->remove_child(node);
 		}
-		editor->get_scene_root()->remove_child(preview_node);
+		EditorNode::get_singleton()->get_scene_root()->remove_child(preview_node);
 	}
 }
 
@@ -3863,8 +3864,8 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 		return false;
 	}
 
-	if (!editor->get_edited_scene()->get_scene_file_path().is_empty()) { // cyclical instancing
-		if (_cyclical_dependency_exists(editor->get_edited_scene()->get_scene_file_path(), instantiated_scene)) {
+	if (!EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path().is_empty()) { // cyclical instancing
+		if (_cyclical_dependency_exists(EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path(), instantiated_scene)) {
 			memdelete(instantiated_scene);
 			return false;
 		}
@@ -3875,14 +3876,14 @@ bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Po
 	}
 
 	editor_data->get_undo_redo().add_do_method(parent, "add_child", instantiated_scene, true);
-	editor_data->get_undo_redo().add_do_method(instantiated_scene, "set_owner", editor->get_edited_scene());
+	editor_data->get_undo_redo().add_do_method(instantiated_scene, "set_owner", EditorNode::get_singleton()->get_edited_scene());
 	editor_data->get_undo_redo().add_do_reference(instantiated_scene);
 	editor_data->get_undo_redo().add_undo_method(parent, "remove_child", instantiated_scene);
 
 	String new_name = parent->validate_child_name(instantiated_scene);
 	EditorDebuggerNode *ed = EditorDebuggerNode::get_singleton();
-	editor_data->get_undo_redo().add_do_method(ed, "live_debug_instance_node", editor->get_edited_scene()->get_path_to(parent), path, new_name);
-	editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(editor->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
+	editor_data->get_undo_redo().add_do_method(ed, "live_debug_instance_node", EditorNode::get_singleton()->get_edited_scene()->get_path_to(parent), path, new_name);
+	editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(EditorNode::get_singleton()->get_edited_scene()->get_path_to(parent)) + "/" + new_name));
 
 	Node3D *node3d = Object::cast_to<Node3D>(instantiated_scene);
 	if (node3d) {
@@ -3999,8 +4000,8 @@ void Node3DEditorViewport::drop_data_fw(const Point2 &p_point, const Variant &p_
 		selected_files = d["files"];
 	}
 
-	List<Node *> selected_nodes = editor->get_editor_selection()->get_selected_node_list();
-	Node *root_node = editor->get_edited_scene();
+	List<Node *> selected_nodes = EditorNode::get_singleton()->get_editor_selection()->get_selected_node_list();
+	Node *root_node = EditorNode::get_singleton()->get_edited_scene();
 	if (selected_nodes.size() == 1) {
 		Node *selected_node = selected_nodes[0];
 		target_node = root_node;
@@ -4415,7 +4416,7 @@ void Node3DEditorViewport::finish_transform() {
 	surface->update();
 }
 
-Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, EditorNode *p_editor, int p_index) {
+Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p_index) {
 	cpu_time_history_index = 0;
 	gpu_time_history_index = 0;
 
@@ -4428,10 +4429,9 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 	_edit.gizmo_handle_secondary = false;
 
 	index = p_index;
-	editor = p_editor;
 	editor_data = SceneTreeDock::get_singleton()->get_editor_data();
-	editor_selection = editor->get_editor_selection();
-	undo_redo = editor->get_undo_redo();
+	editor_selection = EditorNode::get_singleton()->get_editor_selection();
+	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 	orthogonal = false;
 	auto_orthogonal = false;
@@ -6937,8 +6937,8 @@ void Node3DEditor::_notification(int p_what) {
 			SceneTreeDock::get_singleton()->get_tree_editor()->connect("node_changed", callable_mp(this, &Node3DEditor::_refresh_menu_icons));
 			editor_selection->connect("selection_changed", callable_mp(this, &Node3DEditor::_selection_changed));
 
-			editor->connect("stop_pressed", callable_mp(this, &Node3DEditor::_update_camera_override_button), make_binds(false));
-			editor->connect("play_pressed", callable_mp(this, &Node3DEditor::_update_camera_override_button), make_binds(true));
+			EditorNode::get_singleton()->connect("stop_pressed", callable_mp(this, &Node3DEditor::_update_camera_override_button), make_binds(false));
+			EditorNode::get_singleton()->connect("play_pressed", callable_mp(this, &Node3DEditor::_update_camera_override_button), make_binds(true));
 
 			_update_preview_environment();
 
@@ -7074,7 +7074,8 @@ void Node3DEditor::_request_gizmo(Object *p_obj) {
 
 	bool is_selected = (sp == selected);
 
-	if (editor->get_edited_scene() && (sp == editor->get_edited_scene() || (sp->get_owner() && editor->get_edited_scene()->is_ancestor_of(sp)))) {
+	Node *edited_scene = EditorNode::get_singleton()->get_edited_scene();
+	if (edited_scene && (sp == edited_scene || (sp->get_owner() && edited_scene->is_ancestor_of(sp)))) {
 		for (int i = 0; i < gizmo_plugins_by_priority.size(); ++i) {
 			Ref<EditorNode3DGizmo> seg = gizmo_plugins_by_priority.write[i]->get_gizmo(sp);
 
@@ -7441,18 +7442,17 @@ void Node3DEditor::_sun_direction_angle_set() {
 	_preview_settings_changed();
 }
 
-Node3DEditor::Node3DEditor(EditorNode *p_editor) {
+Node3DEditor::Node3DEditor() {
 	gizmo.visible = true;
 	gizmo.scale = 1.0;
 
 	viewport_environment = Ref<Environment>(memnew(Environment));
-	undo_redo = p_editor->get_undo_redo();
+	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 	VBoxContainer *vbc = this;
 
 	custom_camera = nullptr;
 	singleton = this;
-	editor = p_editor;
-	editor_selection = editor->get_editor_selection();
+	editor_selection = EditorNode::get_singleton()->get_editor_selection();
 	editor_selection->add_editor_plugin(this);
 
 	snap_enabled = false;
@@ -7684,7 +7684,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	p->set_hide_on_checkable_item_selection(false);
 
 	accept = memnew(AcceptDialog);
-	editor->get_gui_base()->add_child(accept);
+	EditorNode::get_singleton()->get_gui_base()->add_child(accept);
 
 	p->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/1_viewport", TTR("1 Viewport"), KeyModifierMask::CMD + Key::KEY_1), MENU_VIEW_USE_1_VIEWPORT);
 	p->add_radio_check_shortcut(ED_SHORTCUT("spatial_editor/2_viewports", TTR("2 Viewports"), KeyModifierMask::CMD + Key::KEY_2), MENU_VIEW_USE_2_VIEWPORTS);
@@ -7731,7 +7731,7 @@ Node3DEditor::Node3DEditor(EditorNode *p_editor) {
 	shader_split->add_child(viewport_base);
 	viewport_base->set_v_size_flags(SIZE_EXPAND_FILL);
 	for (uint32_t i = 0; i < VIEWPORTS_COUNT; i++) {
-		viewports[i] = memnew(Node3DEditorViewport(this, editor, i));
+		viewports[i] = memnew(Node3DEditorViewport(this, i));
 		viewports[i]->connect("toggle_maximize_view", callable_mp(this, &Node3DEditor::_toggle_maximize_view));
 		viewports[i]->connect("clicked", callable_mp(this, &Node3DEditor::_update_camera_override_viewport));
 		viewports[i]->assign_pending_data_pointers(preview_node, &preview_bounds, accept);
@@ -8180,11 +8180,10 @@ void Node3DEditor::remove_gizmo_plugin(Ref<EditorNode3DGizmoPlugin> p_plugin) {
 	_update_gizmos_menu();
 }
 
-Node3DEditorPlugin::Node3DEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
-	spatial_editor = memnew(Node3DEditor(p_node));
+Node3DEditorPlugin::Node3DEditorPlugin() {
+	spatial_editor = memnew(Node3DEditor);
 	spatial_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	editor->get_main_control()->add_child(spatial_editor);
+	EditorNode::get_singleton()->get_main_control()->add_child(spatial_editor);
 
 	spatial_editor->hide();
 }

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -199,7 +199,6 @@ private:
 	Node *target_node;
 	Point2 drop_pos;
 
-	EditorNode *editor;
 	EditorData *editor_data;
 	EditorSelection *editor_selection;
 	UndoRedo *undo_redo;
@@ -441,7 +440,7 @@ public:
 	SubViewport *get_viewport_node() { return viewport; }
 	Camera3D *get_camera_3d() { return camera; } // return the default camera object.
 
-	Node3DEditorViewport(Node3DEditor *p_spatial_editor, EditorNode *p_editor, int p_index);
+	Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p_index);
 	~Node3DEditorViewport();
 };
 
@@ -536,7 +535,6 @@ public:
 	};
 
 private:
-	EditorNode *editor;
 	EditorSelection *editor_selection;
 
 	Node3DEditorViewportContainer *viewport_base;
@@ -861,7 +859,7 @@ public:
 	void edit(Node3D *p_spatial);
 	void clear();
 
-	Node3DEditor(EditorNode *p_editor);
+	Node3DEditor();
 	~Node3DEditor();
 };
 
@@ -869,7 +867,6 @@ class Node3DEditorPlugin : public EditorPlugin {
 	GDCLASS(Node3DEditorPlugin, EditorPlugin);
 
 	Node3DEditor *spatial_editor;
-	EditorNode *editor;
 
 public:
 	Node3DEditor *get_spatial_editor() { return spatial_editor; }
@@ -885,7 +882,7 @@ public:
 
 	virtual void edited_scene_changed() override;
 
-	Node3DEditorPlugin(EditorNode *p_node);
+	Node3DEditorPlugin();
 	~Node3DEditorPlugin();
 };
 

--- a/editor/plugins/occluder_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/occluder_instance_3d_editor_plugin.cpp
@@ -101,11 +101,10 @@ void OccluderInstance3DEditorPlugin::_bind_methods() {
 	ClassDB::bind_method("_bake", &OccluderInstance3DEditorPlugin::_bake);
 }
 
-OccluderInstance3DEditorPlugin::OccluderInstance3DEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+OccluderInstance3DEditorPlugin::OccluderInstance3DEditorPlugin() {
 	bake = memnew(Button);
 	bake->set_flat(true);
-	bake->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
+	bake->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake Occluders"));
 	bake->hide();
 	bake->connect("pressed", Callable(this, "_bake"));

--- a/editor/plugins/occluder_instance_3d_editor_plugin.h
+++ b/editor/plugins/occluder_instance_3d_editor_plugin.h
@@ -45,7 +45,6 @@ class OccluderInstance3DEditorPlugin : public EditorPlugin {
 	OccluderInstance3D *occluder_instance;
 
 	Button *bake;
-	EditorNode *editor;
 
 	EditorFileDialog *file_dialog;
 
@@ -62,7 +61,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	OccluderInstance3DEditorPlugin(EditorNode *p_node);
+	OccluderInstance3DEditorPlugin();
 	~OccluderInstance3DEditorPlugin();
 };
 

--- a/editor/plugins/ot_features_plugin.cpp
+++ b/editor/plugins/ot_features_plugin.cpp
@@ -202,7 +202,7 @@ bool EditorInspectorPluginOpenTypeFeatures::parse_property(Object *p_object, con
 
 /*************************************************************************/
 
-OpenTypeFeaturesEditorPlugin::OpenTypeFeaturesEditorPlugin(EditorNode *p_node) {
+OpenTypeFeaturesEditorPlugin::OpenTypeFeaturesEditorPlugin() {
 	Ref<EditorInspectorPluginOpenTypeFeatures> ftr_plugin;
 	ftr_plugin.instantiate();
 	EditorInspector::add_inspector_plugin(ftr_plugin);

--- a/editor/plugins/ot_features_plugin.h
+++ b/editor/plugins/ot_features_plugin.h
@@ -96,7 +96,7 @@ class OpenTypeFeaturesEditorPlugin : public EditorPlugin {
 	GDCLASS(OpenTypeFeaturesEditorPlugin, EditorPlugin);
 
 public:
-	OpenTypeFeaturesEditorPlugin(EditorNode *p_node);
+	OpenTypeFeaturesEditorPlugin();
 
 	virtual String get_name() const override { return "OpenTypeFeatures"; }
 };

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -516,10 +516,9 @@ void Path2DEditor::_handle_option_pressed(int p_option) {
 	}
 }
 
-Path2DEditor::Path2DEditor(EditorNode *p_editor) {
+Path2DEditor::Path2DEditor() {
 	canvas_item_editor = nullptr;
-	editor = p_editor;
-	undo_redo = editor->get_undo_redo();
+	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 	mirror_handle_angle = true;
 	mirror_handle_length = true;
 	on_edge = false;
@@ -610,9 +609,8 @@ void Path2DEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-Path2DEditorPlugin::Path2DEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
-	path2d_editor = memnew(Path2DEditor(p_node));
+Path2DEditorPlugin::Path2DEditorPlugin() {
+	path2d_editor = memnew(Path2DEditor);
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(path2d_editor);
 	path2d_editor->hide();
 }

--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -44,7 +44,6 @@ class Path2DEditor : public HBoxContainer {
 	UndoRedo *undo_redo;
 
 	CanvasItemEditor *canvas_item_editor;
-	EditorNode *editor;
 	Panel *panel;
 	Path2D *node;
 
@@ -106,14 +105,13 @@ public:
 	bool forward_gui_input(const Ref<InputEvent> &p_event);
 	void forward_canvas_draw_over_viewport(Control *p_overlay);
 	void edit(Node *p_path2d);
-	Path2DEditor(EditorNode *p_editor);
+	Path2DEditor();
 };
 
 class Path2DEditorPlugin : public EditorPlugin {
 	GDCLASS(Path2DEditorPlugin, EditorPlugin);
 
 	Path2DEditor *path2d_editor;
-	EditorNode *editor;
 
 public:
 	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) override { return path2d_editor->forward_gui_input(p_event); }
@@ -125,7 +123,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	Path2DEditorPlugin(EditorNode *p_node);
+	Path2DEditorPlugin();
 	~Path2DEditorPlugin();
 };
 

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -379,7 +379,7 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_spatial_gui_input(Camera
 				}
 			}
 
-			UndoRedo *ur = editor->get_undo_redo();
+			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 			if (closest_seg != -1) {
 				//subdivide
 
@@ -421,21 +421,21 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_spatial_gui_input(Camera
 				// Find the offset and point index of the place to break up.
 				// Also check for the control points.
 				if (dist_to_p < click_dist) {
-					UndoRedo *ur = editor->get_undo_redo();
+					UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 					ur->create_action(TTR("Remove Path Point"));
 					ur->add_do_method(c.ptr(), "remove_point", i);
 					ur->add_undo_method(c.ptr(), "add_point", c->get_point_position(i), c->get_point_in(i), c->get_point_out(i), i);
 					ur->commit_action();
 					return EditorPlugin::AFTER_GUI_INPUT_STOP;
 				} else if (dist_to_p_out < click_dist) {
-					UndoRedo *ur = editor->get_undo_redo();
+					UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 					ur->create_action(TTR("Remove Out-Control Point"));
 					ur->add_do_method(c.ptr(), "set_point_out", i, Vector3());
 					ur->add_undo_method(c.ptr(), "set_point_out", i, c->get_point_out(i));
 					ur->commit_action();
 					return EditorPlugin::AFTER_GUI_INPUT_STOP;
 				} else if (dist_to_p_in < click_dist) {
-					UndoRedo *ur = editor->get_undo_redo();
+					UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 					ur->create_action(TTR("Remove In-Control Point"));
 					ur->add_do_method(c.ptr(), "set_point_in", i, Vector3());
 					ur->add_undo_method(c.ptr(), "set_point_in", i, c->get_point_in(i));
@@ -514,7 +514,7 @@ void Path3DEditorPlugin::_close_curve() {
 	if (c->get_point_position(0) == c->get_point_position(c->get_point_count() - 1)) {
 		return;
 	}
-	UndoRedo *ur = editor->get_undo_redo();
+	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 	ur->create_action(TTR("Close Curve"));
 	ur->add_do_method(c.ptr(), "add_point", c->get_point_position(0), c->get_point_in(0), c->get_point_out(0), -1);
 	ur->add_undo_method(c.ptr(), "remove_point", c->get_point_count());
@@ -571,9 +571,8 @@ void Path3DEditorPlugin::_bind_methods() {
 
 Path3DEditorPlugin *Path3DEditorPlugin::singleton = nullptr;
 
-Path3DEditorPlugin::Path3DEditorPlugin(EditorNode *p_node) {
+Path3DEditorPlugin::Path3DEditorPlugin() {
 	path = nullptr;
-	editor = p_node;
 	singleton = this;
 	mirror_handle_angle = true;
 	mirror_handle_length = true;

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -79,8 +79,6 @@ class Path3DEditorPlugin : public EditorPlugin {
 	Button *curve_close;
 	MenuButton *handle_menu;
 
-	EditorNode *editor;
-
 	Path3D *path;
 
 	void _update_theme();
@@ -118,7 +116,7 @@ public:
 	bool is_handle_clicked() { return handle_clicked; }
 	void set_handle_clicked(bool clicked) { handle_clicked = clicked; }
 
-	Path3DEditorPlugin(EditorNode *p_node);
+	Path3DEditorPlugin();
 	~Path3DEditorPlugin();
 };
 

--- a/editor/plugins/physical_bone_3d_editor_plugin.cpp
+++ b/editor/plugins/physical_bone_3d_editor_plugin.cpp
@@ -48,8 +48,7 @@ void PhysicalBone3DEditor::_set_move_joint() {
 	}
 }
 
-PhysicalBone3DEditor::PhysicalBone3DEditor(EditorNode *p_editor) :
-		editor(p_editor) {
+PhysicalBone3DEditor::PhysicalBone3DEditor() {
 	spatial_editor_hb = memnew(HBoxContainer);
 	spatial_editor_hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	spatial_editor_hb->set_alignment(BoxContainer::ALIGNMENT_BEGIN);
@@ -85,9 +84,8 @@ void PhysicalBone3DEditor::show() {
 	spatial_editor_hb->show();
 }
 
-PhysicalBone3DEditorPlugin::PhysicalBone3DEditorPlugin(EditorNode *p_editor) :
-		editor(p_editor),
-		physical_bone_editor(editor) {}
+PhysicalBone3DEditorPlugin::PhysicalBone3DEditorPlugin() :
+		physical_bone_editor() {}
 
 void PhysicalBone3DEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {

--- a/editor/plugins/physical_bone_3d_editor_plugin.h
+++ b/editor/plugins/physical_bone_3d_editor_plugin.h
@@ -41,7 +41,6 @@ class EditorNode;
 class PhysicalBone3DEditor : public Object {
 	GDCLASS(PhysicalBone3DEditor, Object);
 
-	EditorNode *editor;
 	HBoxContainer *spatial_editor_hb;
 	Button *button_transform_joint;
 
@@ -55,7 +54,7 @@ private:
 	void _set_move_joint();
 
 public:
-	PhysicalBone3DEditor(EditorNode *p_editor);
+	PhysicalBone3DEditor();
 	~PhysicalBone3DEditor() {}
 
 	void set_selected(PhysicalBone3D *p_pb);
@@ -67,7 +66,6 @@ public:
 class PhysicalBone3DEditorPlugin : public EditorPlugin {
 	GDCLASS(PhysicalBone3DEditorPlugin, EditorPlugin);
 
-	EditorNode *editor;
 	PhysicalBone3D *selected = nullptr;
 	PhysicalBone3DEditor physical_bone_editor;
 
@@ -77,7 +75,7 @@ public:
 	virtual void make_visible(bool p_visible) override;
 	virtual void edit(Object *p_node) override;
 
-	PhysicalBone3DEditorPlugin(EditorNode *p_editor);
+	PhysicalBone3DEditorPlugin();
 };
 
 #endif

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -1228,8 +1228,8 @@ Vector2 Polygon2DEditor::snap_point(Vector2 p_target) const {
 	return p_target;
 }
 
-Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
-		AbstractPolygon2DEditor(p_editor) {
+Polygon2DEditor::Polygon2DEditor() :
+		AbstractPolygon2DEditor() {
 	node = nullptr;
 	snap_offset = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "snap_offset", Vector2());
 	snap_step = EditorSettings::get_singleton()->get_project_metadata("polygon_2d_uv_editor", "snap_step", Vector2(10, 10));
@@ -1489,6 +1489,6 @@ Polygon2DEditor::Polygon2DEditor(EditorNode *p_editor) :
 	uv_edit_draw->set_clip_contents(true);
 }
 
-Polygon2DEditorPlugin::Polygon2DEditorPlugin(EditorNode *p_node) :
-		AbstractPolygon2DEditorPlugin(p_node, memnew(Polygon2DEditor(p_node)), "Polygon2D") {
+Polygon2DEditorPlugin::Polygon2DEditorPlugin() :
+		AbstractPolygon2DEditorPlugin(memnew(Polygon2DEditor), "Polygon2D") {
 }

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -170,14 +170,14 @@ protected:
 	Vector2 snap_point(Vector2 p_target) const;
 
 public:
-	Polygon2DEditor(EditorNode *p_editor);
+	Polygon2DEditor();
 };
 
 class Polygon2DEditorPlugin : public AbstractPolygon2DEditorPlugin {
 	GDCLASS(Polygon2DEditorPlugin, AbstractPolygon2DEditorPlugin);
 
 public:
-	Polygon2DEditorPlugin(EditorNode *p_node);
+	Polygon2DEditorPlugin();
 };
 
 #endif // POLYGON_2D_EDITOR_PLUGIN_H

--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -523,9 +523,8 @@ void Polygon3DEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_polygon_draw"), &Polygon3DEditor::_polygon_draw);
 }
 
-Polygon3DEditor::Polygon3DEditor(EditorNode *p_editor) {
+Polygon3DEditor::Polygon3DEditor() {
 	node = nullptr;
-	editor = p_editor;
 	undo_redo = EditorNode::get_undo_redo();
 
 	add_child(memnew(VSeparator));
@@ -561,7 +560,7 @@ Polygon3DEditor::Polygon3DEditor(EditorNode *p_editor) {
 	handle_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
 	handle_material->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 	handle_material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
-	Ref<Texture2D> handle = editor->get_gui_base()->get_theme_icon(SNAME("Editor3DHandle"), SNAME("EditorIcons"));
+	Ref<Texture2D> handle = EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Editor3DHandle"), SNAME("EditorIcons"));
 	handle_material->set_point_size(handle->get_width());
 	handle_material->set_texture(StandardMaterial3D::TEXTURE_ALBEDO, handle);
 
@@ -595,9 +594,8 @@ void Polygon3DEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-Polygon3DEditorPlugin::Polygon3DEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
-	polygon_editor = memnew(Polygon3DEditor(p_node));
+Polygon3DEditorPlugin::Polygon3DEditorPlugin() {
+	polygon_editor = memnew(Polygon3DEditor);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(polygon_editor);
 
 	polygon_editor->hide();

--- a/editor/plugins/polygon_3d_editor_plugin.h
+++ b/editor/plugins/polygon_3d_editor_plugin.h
@@ -57,7 +57,6 @@ class Polygon3DEditor : public HBoxContainer {
 	Ref<StandardMaterial3D> line_material;
 	Ref<StandardMaterial3D> handle_material;
 
-	EditorNode *editor;
 	Panel *panel;
 	Node3D *node;
 	Ref<Resource> node_resource;
@@ -93,7 +92,7 @@ protected:
 public:
 	virtual EditorPlugin::AfterGUIInput forward_spatial_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event);
 	void edit(Node *p_node);
-	Polygon3DEditor(EditorNode *p_editor);
+	Polygon3DEditor();
 	~Polygon3DEditor();
 };
 
@@ -101,7 +100,6 @@ class Polygon3DEditorPlugin : public EditorPlugin {
 	GDCLASS(Polygon3DEditorPlugin, EditorPlugin);
 
 	Polygon3DEditor *polygon_editor;
-	EditorNode *editor;
 
 public:
 	virtual EditorPlugin::AfterGUIInput forward_spatial_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override { return polygon_editor->forward_spatial_gui_input(p_camera, p_event); }
@@ -112,7 +110,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	Polygon3DEditorPlugin(EditorNode *p_node);
+	Polygon3DEditorPlugin();
 	~Polygon3DEditorPlugin();
 };
 

--- a/editor/plugins/replication_editor_plugin.cpp
+++ b/editor/plugins/replication_editor_plugin.cpp
@@ -37,8 +37,7 @@
 #include "scene/multiplayer/multiplayer_synchronizer.h"
 
 /// ReplicationEditor
-ReplicationEditor::ReplicationEditor(EditorNode *p_editor) {
-	editor = p_editor;
+ReplicationEditor::ReplicationEditor() {
 	set_v_size_flags(SIZE_EXPAND_FILL);
 	set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 
@@ -95,7 +94,7 @@ void ReplicationEditor::_bind_methods() {
 
 void ReplicationEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
+		add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
 	} else if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
 		update_keying();
 	}
@@ -120,7 +119,7 @@ void ReplicationEditor::_add_pressed() {
 	if (prop.is_empty()) {
 		return;
 	}
-	UndoRedo *undo_redo = editor->get_undo_redo();
+	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 	undo_redo->create_action(TTR("Add property"));
 	config = current->get_replication_config();
 	if (config.is_null()) {
@@ -145,7 +144,7 @@ void ReplicationEditor::_tree_item_edited() {
 	int column = tree->get_edited_column();
 	ERR_FAIL_COND(column < 1 || column > 2);
 	const NodePath prop = ti->get_metadata(0);
-	UndoRedo *undo_redo = editor->get_undo_redo();
+	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 	bool value = ti->is_checked(column);
 	String method;
 	if (column == 1) {
@@ -181,7 +180,7 @@ void ReplicationEditor::_dialog_closed(bool p_confirmed) {
 		int idx = config->property_get_index(prop);
 		bool spawn = config->property_get_spawn(prop);
 		bool sync = config->property_get_sync(prop);
-		UndoRedo *undo_redo = editor->get_undo_redo();
+		UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 		undo_redo->create_action(TTR("Remove Property"));
 		undo_redo->add_do_method(config.ptr(), "remove_property", prop);
 		undo_redo->add_undo_method(config.ptr(), "add_property", prop, idx);
@@ -300,7 +299,7 @@ void ReplicationEditor::property_keyed(const String &p_property) {
 	ERR_FAIL_COND(!current || config.is_null());
 	Node *root = current->get_node(current->get_root_path());
 	ERR_FAIL_COND(!root);
-	EditorHistory *history = editor->get_editor_history();
+	EditorHistory *history = EditorNode::get_singleton()->get_editor_history();
 	ERR_FAIL_COND(history->get_path_size() == 0);
 	Node *node = Object::cast_to<Node>(ObjectDB::get_instance(history->get_path_object(0)));
 	ERR_FAIL_COND(!node);
@@ -324,7 +323,7 @@ void ReplicationEditor::property_keyed(const String &p_property) {
 	path += ":" + p_property;
 
 	NodePath prop = path;
-	UndoRedo *undo_redo = editor->get_undo_redo();
+	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 	undo_redo->create_action(TTR("Add property"));
 	undo_redo->add_do_method(config.ptr(), "add_property", prop);
 	undo_redo->add_undo_method(config.ptr(), "remove_property", prop);
@@ -334,10 +333,9 @@ void ReplicationEditor::property_keyed(const String &p_property) {
 }
 
 /// ReplicationEditorPlugin
-ReplicationEditorPlugin::ReplicationEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
-	repl_editor = memnew(ReplicationEditor(editor));
-	editor->add_bottom_panel_item(TTR("Replication"), repl_editor);
+ReplicationEditorPlugin::ReplicationEditorPlugin() {
+	repl_editor = memnew(ReplicationEditor);
+	EditorNode::get_singleton()->add_bottom_panel_item(TTR("Replication"), repl_editor);
 }
 
 ReplicationEditorPlugin::~ReplicationEditorPlugin() {
@@ -370,7 +368,7 @@ void ReplicationEditorPlugin::_node_removed(Node *p_node) {
 	if (p_node && p_node == repl_editor->get_current()) {
 		repl_editor->edit(nullptr);
 		if (repl_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorNode::get_singleton()->hide_bottom_panel();
 		}
 	}
 }
@@ -385,6 +383,6 @@ bool ReplicationEditorPlugin::handles(Object *p_object) const {
 
 void ReplicationEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
-		editor->make_bottom_panel_item_visible(repl_editor);
+		EditorNode::get_singleton()->make_bottom_panel_item_visible(repl_editor);
 	}
 }

--- a/editor/plugins/replication_editor_plugin.h
+++ b/editor/plugins/replication_editor_plugin.h
@@ -43,7 +43,6 @@ class ReplicationEditor : public VBoxContainer {
 	GDCLASS(ReplicationEditor, VBoxContainer);
 
 private:
-	EditorNode *editor;
 	MultiplayerSynchronizer *current = nullptr;
 
 	AcceptDialog *error_dialog = nullptr;
@@ -78,7 +77,7 @@ public:
 	MultiplayerSynchronizer *get_current() const { return current; }
 	void property_keyed(const String &p_property);
 
-	ReplicationEditor(EditorNode *p_node);
+	ReplicationEditor();
 	~ReplicationEditor() {}
 };
 
@@ -86,7 +85,6 @@ class ReplicationEditorPlugin : public EditorPlugin {
 	GDCLASS(ReplicationEditorPlugin, EditorPlugin);
 
 private:
-	EditorNode *editor;
 	ReplicationEditor *repl_editor;
 
 	void _node_removed(Node *p_node);
@@ -101,7 +99,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	ReplicationEditorPlugin(EditorNode *p_node);
+	ReplicationEditorPlugin();
 	~ReplicationEditorPlugin();
 };
 

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -404,11 +404,11 @@ void ResourcePreloaderEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		//preloader_editor->show();
 		button->show();
-		editor->make_bottom_panel_item_visible(preloader_editor);
+		EditorNode::get_singleton()->make_bottom_panel_item_visible(preloader_editor);
 		//preloader_editor->set_process(true);
 	} else {
 		if (preloader_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorNode::get_singleton()->hide_bottom_panel();
 		}
 		button->hide();
 		//preloader_editor->hide();
@@ -416,12 +416,11 @@ void ResourcePreloaderEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-ResourcePreloaderEditorPlugin::ResourcePreloaderEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+ResourcePreloaderEditorPlugin::ResourcePreloaderEditorPlugin() {
 	preloader_editor = memnew(ResourcePreloaderEditor);
 	preloader_editor->set_custom_minimum_size(Size2(0, 250) * EDSCALE);
 
-	button = editor->add_bottom_panel_item(TTR("ResourcePreloader"), preloader_editor);
+	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("ResourcePreloader"), preloader_editor);
 	button->hide();
 
 	//preloader_editor->set_anchor( MARGIN_TOP, Control::ANCHOR_END);

--- a/editor/plugins/resource_preloader_editor_plugin.h
+++ b/editor/plugins/resource_preloader_editor_plugin.h
@@ -90,7 +90,6 @@ class ResourcePreloaderEditorPlugin : public EditorPlugin {
 	GDCLASS(ResourcePreloaderEditorPlugin, EditorPlugin);
 
 	ResourcePreloaderEditor *preloader_editor;
-	EditorNode *editor;
 	Button *button;
 
 public:
@@ -100,7 +99,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	ResourcePreloaderEditorPlugin(EditorNode *p_node);
+	ResourcePreloaderEditorPlugin();
 	~ResourcePreloaderEditorPlugin();
 };
 

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -416,7 +416,7 @@ void ScriptEditor::_breaked(bool p_breaked, bool p_can_debug) {
 }
 
 void ScriptEditor::_script_created(Ref<Script> p_script) {
-	editor->push_item(p_script.operator->());
+	EditorNode::get_singleton()->push_item(p_script.operator->());
 }
 
 void ScriptEditor::_goto_script_line2(int p_line) {
@@ -430,7 +430,7 @@ void ScriptEditor::_goto_script_line(REF p_script, int p_line) {
 	Ref<Script> script = Object::cast_to<Script>(*p_script);
 	if (script.is_valid() && (script->has_source_code() || script->get_path().is_resource_file())) {
 		if (edit(p_script, p_line, 0)) {
-			editor->push_item(p_script.ptr());
+			EditorNode::get_singleton()->push_item(p_script.ptr());
 
 			ScriptEditorBase *current = _get_current_editor();
 			if (ScriptTextEditor *script_text_editor = Object::cast_to<ScriptTextEditor>(current)) {
@@ -930,7 +930,7 @@ void ScriptEditor::_resave_scripts(const String &p_str) {
 			_save_text_file(text_file, text_file->get_path());
 			break;
 		} else {
-			editor->save_resource(script);
+			EditorNode::get_singleton()->save_resource(script);
 		}
 		se->tag_saved_version();
 	}
@@ -1091,7 +1091,7 @@ void ScriptEditor::_file_dialog_action(String p_file) {
 			Error err;
 			FileAccess *file = FileAccess::open(p_file, FileAccess::WRITE, &err);
 			if (err) {
-				editor->show_warning(TTR("Error writing TextFile:") + "\n" + p_file, TTR("Error!"));
+				EditorNode::get_singleton()->show_warning(TTR("Error writing TextFile:") + "\n" + p_file, TTR("Error!"));
 				break;
 			}
 			file->close();
@@ -1120,7 +1120,7 @@ void ScriptEditor::_file_dialog_action(String p_file) {
 				Error err = _save_text_file(resource, path);
 
 				if (err != OK) {
-					editor->show_accept(TTR("Error saving file!"), TTR("OK"));
+					EditorNode::get_singleton()->show_accept(TTR("Error saving file!"), TTR("OK"));
 					return;
 				}
 
@@ -1130,12 +1130,12 @@ void ScriptEditor::_file_dialog_action(String p_file) {
 		} break;
 		case THEME_SAVE_AS: {
 			if (!EditorSettings::get_singleton()->save_text_editor_theme_as(p_file)) {
-				editor->show_warning(TTR("Error while saving theme."), TTR("Error Saving"));
+				EditorNode::get_singleton()->show_warning(TTR("Error while saving theme."), TTR("Error Saving"));
 			}
 		} break;
 		case THEME_IMPORT: {
 			if (!EditorSettings::get_singleton()->import_text_editor_theme(p_file)) {
-				editor->show_warning(TTR("Error importing theme."), TTR("Error Importing"));
+				EditorNode::get_singleton()->show_warning(TTR("Error importing theme."), TTR("Error Importing"));
 			}
 		} break;
 	}
@@ -1241,7 +1241,7 @@ void ScriptEditor::_menu_option(int p_option) {
 
 				Ref<Script> scr = ResourceLoader::load(path);
 				if (!scr.is_valid()) {
-					editor->show_warning(TTR("Could not load file at:") + "\n\n" + path, TTR("Error!"));
+					EditorNode::get_singleton()->show_warning(TTR("Could not load file at:") + "\n\n" + path, TTR("Error!"));
 					file_dialog_option = -1;
 					return;
 				}
@@ -1253,7 +1253,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				Error error;
 				Ref<TextFile> text_file = _load_text_file(path, &error);
 				if (error != OK) {
-					editor->show_warning(TTR("Could not load file at:") + "\n\n" + path, TTR("Error!"));
+					EditorNode::get_singleton()->show_warning(TTR("Could not load file at:") + "\n\n" + path, TTR("Error!"));
 				}
 
 				if (text_file.is_valid()) {
@@ -1355,8 +1355,8 @@ void ScriptEditor::_menu_option(int p_option) {
 					}
 				}
 
-				editor->push_item(resource.ptr());
-				editor->save_resource_as(resource);
+				EditorNode::get_singleton()->push_item(resource.ptr());
+				EditorNode::get_singleton()->save_resource_as(resource);
 
 				if (script != nullptr) {
 					const Vector<DocData::ClassDoc> &documentations = script->get_documentation();
@@ -1522,7 +1522,7 @@ void ScriptEditor::_theme_option(int p_option) {
 			if (EditorSettings::get_singleton()->is_default_text_editor_theme()) {
 				ScriptEditor::_show_save_theme_as_dialog();
 			} else if (!EditorSettings::get_singleton()->save_text_editor_theme()) {
-				editor->show_warning(TTR("Error while saving theme"), TTR("Error saving"));
+				EditorNode::get_singleton()->show_warning(TTR("Error while saving theme"), TTR("Error saving"));
 			}
 		} break;
 		case THEME_SAVE_AS: {
@@ -1594,10 +1594,10 @@ void ScriptEditor::_tab_changed(int p_which) {
 void ScriptEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			editor->connect("stop_pressed", callable_mp(this, &ScriptEditor::_editor_stop));
-			editor->connect("script_add_function_request", callable_mp(this, &ScriptEditor::_add_callback));
-			editor->connect("resource_saved", callable_mp(this, &ScriptEditor::_res_saved_callback));
-			editor->connect("scene_saved", callable_mp(this, &ScriptEditor::_scene_saved_callback));
+			EditorNode::get_singleton()->connect("stop_pressed", callable_mp(this, &ScriptEditor::_editor_stop));
+			EditorNode::get_singleton()->connect("script_add_function_request", callable_mp(this, &ScriptEditor::_add_callback));
+			EditorNode::get_singleton()->connect("resource_saved", callable_mp(this, &ScriptEditor::_res_saved_callback));
+			EditorNode::get_singleton()->connect("scene_saved", callable_mp(this, &ScriptEditor::_scene_saved_callback));
 			FileSystemDock::get_singleton()->connect("files_moved", callable_mp(this, &ScriptEditor::_files_moved));
 			FileSystemDock::get_singleton()->connect("file_removed", callable_mp(this, &ScriptEditor::_file_removed));
 			script_list->connect("item_selected", callable_mp(this, &ScriptEditor::_script_selected));
@@ -1631,7 +1631,7 @@ void ScriptEditor::_notification(int p_what) {
 			filter_scripts->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			filter_methods->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 
-			filename->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
+			filename->add_theme_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
 
 			recent_scripts->set_as_minsize();
 
@@ -1644,11 +1644,11 @@ void ScriptEditor::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			get_tree()->connect("tree_changed", callable_mp(this, &ScriptEditor::_tree_changed));
 			InspectorDock::get_singleton()->connect("request_help", callable_mp(this, &ScriptEditor::_help_class_open));
-			editor->connect("request_help_search", callable_mp(this, &ScriptEditor::_help_search));
+			EditorNode::get_singleton()->connect("request_help_search", callable_mp(this, &ScriptEditor::_help_search));
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			editor->disconnect("stop_pressed", callable_mp(this, &ScriptEditor::_editor_stop));
+			EditorNode::get_singleton()->disconnect("stop_pressed", callable_mp(this, &ScriptEditor::_editor_stop));
 		} break;
 
 		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
@@ -1661,7 +1661,7 @@ void ScriptEditor::_notification(int p_what) {
 				find_in_files_button->show();
 			} else {
 				if (find_in_files->is_visible_in_tree()) {
-					editor->hide_bottom_panel();
+					EditorNode::get_singleton()->hide_bottom_panel();
 				}
 				find_in_files_button->hide();
 			}
@@ -2480,10 +2480,10 @@ void ScriptEditor::save_current_script() {
 		if (!scene_path.is_empty()) {
 			Vector<String> scene_to_save;
 			scene_to_save.push_back(scene_path);
-			editor->save_scene_list(scene_to_save);
+			EditorNode::get_singleton()->save_scene_list(scene_to_save);
 		}
 	} else {
-		editor->save_resource(resource);
+		EditorNode::get_singleton()->save_resource(resource);
 	}
 
 	if (script != nullptr) {
@@ -2547,7 +2547,7 @@ void ScriptEditor::save_all_scripts() {
 				}
 			}
 
-			editor->save_resource(edited_res); //external script, save it
+			EditorNode::get_singleton()->save_resource(edited_res); //external script, save it
 
 			if (script != nullptr) {
 				const Vector<DocData::ClassDoc> &documentations = script->get_documentation();
@@ -2567,7 +2567,7 @@ void ScriptEditor::save_all_scripts() {
 	}
 
 	if (!scenes_to_save.is_empty()) {
-		editor->save_scene_list(scenes_to_save);
+		EditorNode::get_singleton()->save_scene_list(scenes_to_save);
 	}
 
 	_update_script_names();
@@ -2602,7 +2602,7 @@ RES ScriptEditor::open_file(const String &p_file) {
 	if (extensions.find(p_file.get_extension())) {
 		Ref<Script> scr = ResourceLoader::load(p_file);
 		if (!scr.is_valid()) {
-			editor->show_warning(TTR("Could not load file at:") + "\n\n" + p_file, TTR("Error!"));
+			EditorNode::get_singleton()->show_warning(TTR("Could not load file at:") + "\n\n" + p_file, TTR("Error!"));
 			return RES();
 		}
 
@@ -2613,7 +2613,7 @@ RES ScriptEditor::open_file(const String &p_file) {
 	Error error;
 	Ref<TextFile> text_file = _load_text_file(p_file, &error);
 	if (error != OK) {
-		editor->show_warning(TTR("Could not load file at:") + "\n\n" + p_file, TTR("Error!"));
+		EditorNode::get_singleton()->show_warning(TTR("Could not load file at:") + "\n\n" + p_file, TTR("Error!"));
 		return RES();
 	}
 
@@ -2640,7 +2640,7 @@ void ScriptEditor::_add_callback(Object *p_obj, const String &p_function, const 
 	Ref<Script> script = p_obj->get_script();
 	ERR_FAIL_COND(!script.is_valid());
 
-	editor->push_item(script.ptr());
+	EditorNode::get_singleton()->push_item(script.ptr());
 
 	for (int i = 0; i < tab_container->get_child_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_child(i));
@@ -2685,7 +2685,7 @@ void ScriptEditor::_save_layout() {
 		return;
 	}
 
-	editor->save_layout();
+	EditorNode::get_singleton()->save_layout();
 }
 
 void ScriptEditor::_editor_settings_changed() {
@@ -3540,7 +3540,7 @@ void ScriptEditor::_on_find_in_files_result_selected(String fpath, int line_numb
 			shader_editor->get_shader_editor()->goto_line_selection(line_number - 1, begin, end);
 			return;
 		} else if (fpath.get_extension() == "tscn") {
-			editor->load_scene(fpath);
+			EditorNode::get_singleton()->load_scene(fpath);
 			return;
 		} else {
 			Ref<Script> script = res;
@@ -3582,7 +3582,7 @@ void ScriptEditor::_start_find_in_files(bool with_replace) {
 	find_in_files->set_replace_text(find_in_files_dialog->get_replace_text());
 	find_in_files->start_search();
 
-	editor->make_bottom_panel_item_visible(find_in_files);
+	EditorNode::get_singleton()->make_bottom_panel_item_visible(find_in_files);
 }
 
 void ScriptEditor::_on_find_in_files_modified_files(PackedStringArray paths) {
@@ -3630,7 +3630,7 @@ void ScriptEditor::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("script_close", PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script")));
 }
 
-ScriptEditor::ScriptEditor(EditorNode *p_editor) {
+ScriptEditor::ScriptEditor() {
 	current_theme = "";
 
 	script_editor_cache.instantiate();
@@ -3643,7 +3643,6 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	auto_reload_running_scripts = true;
 	members_overview_enabled = EditorSettings::get_singleton()->get("text_editor/script_list/show_members_overview");
 	help_overview_enabled = EditorSettings::get_singleton()->get("text_editor/help/show_help_index");
-	editor = p_editor;
 
 	VBoxContainer *main_container = memnew(VBoxContainer);
 	add_child(main_container);
@@ -3933,7 +3932,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	find_in_files_dialog->connect(FindInFilesDialog::SIGNAL_REPLACE_REQUESTED, callable_mp(this, &ScriptEditor::_start_find_in_files), varray(true));
 	add_child(find_in_files_dialog);
 	find_in_files = memnew(FindInFilesPanel);
-	find_in_files_button = editor->add_bottom_panel_item(TTR("Search Results"), find_in_files);
+	find_in_files_button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Search Results"), find_in_files);
 	find_in_files->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 	find_in_files->connect(FindInFilesPanel::SIGNAL_RESULT_SELECTED, callable_mp(this, &ScriptEditor::_on_find_in_files_result_selected));
 	find_in_files->connect(FindInFilesPanel::SIGNAL_FILES_MODIFIED, callable_mp(this, &ScriptEditor::_on_find_in_files_modified_files));
@@ -3949,8 +3948,8 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	ScriptServer::edit_request_func = _open_script_request;
 
-	add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditorPanel"), SNAME("EditorStyles")));
-	tab_container->add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditor"), SNAME("EditorStyles")));
+	add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditorPanel"), SNAME("EditorStyles")));
+	tab_container->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditor"), SNAME("EditorStyles")));
 }
 
 ScriptEditor::~ScriptEditor() {
@@ -4034,10 +4033,9 @@ void ScriptEditorPlugin::edited_scene_changed() {
 	script_editor->edited_scene_changed();
 }
 
-ScriptEditorPlugin::ScriptEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
-	script_editor = memnew(ScriptEditor(p_node));
-	editor->get_main_control()->add_child(script_editor);
+ScriptEditorPlugin::ScriptEditorPlugin() {
+	script_editor = memnew(ScriptEditor);
+	EditorNode::get_singleton()->get_main_control()->add_child(script_editor);
 	script_editor->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	script_editor->hide();

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -190,7 +190,6 @@ class FindInFilesPanel;
 class ScriptEditor : public PanelContainer {
 	GDCLASS(ScriptEditor, PanelContainer);
 
-	EditorNode *editor;
 	enum {
 		FILE_NEW,
 		FILE_NEW_TEXTFILE,
@@ -524,7 +523,7 @@ public:
 
 	static void register_create_script_editor_function(CreateScriptEditorFunc p_func);
 
-	ScriptEditor(EditorNode *p_editor);
+	ScriptEditor();
 	~ScriptEditor();
 };
 
@@ -532,7 +531,6 @@ class ScriptEditorPlugin : public EditorPlugin {
 	GDCLASS(ScriptEditorPlugin, EditorPlugin);
 
 	ScriptEditor *script_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "Script"; }
@@ -555,7 +553,7 @@ public:
 
 	virtual void edited_scene_changed() override;
 
-	ScriptEditorPlugin(EditorNode *p_node);
+	ScriptEditorPlugin();
 	~ScriptEditorPlugin();
 };
 

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -691,7 +691,7 @@ void ShaderEditor::_make_context_menu(bool p_selection, Vector2 p_position) {
 	context_menu->popup();
 }
 
-ShaderEditor::ShaderEditor(EditorNode *p_node) {
+ShaderEditor::ShaderEditor() {
 	GLOBAL_DEF("debug/shader_language/warnings/enable", true);
 	GLOBAL_DEF("debug/shader_language/warnings/treat_warnings_as_errors", false);
 	for (int i = 0; i < (int)ShaderWarning::WARNING_MAX; i++) {
@@ -780,7 +780,7 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	help_menu = memnew(MenuButton);
 	help_menu->set_text(TTR("Help"));
 	help_menu->set_switch_on_hover(true);
-	help_menu->get_popup()->add_icon_item(p_node->get_gui_base()->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), TTR("Online Docs"), HELP_DOCS);
+	help_menu->get_popup()->add_icon_item(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Instance"), SNAME("EditorIcons")), TTR("Online Docs"), HELP_DOCS);
 	help_menu->get_popup()->connect("id_pressed", callable_mp(this, &ShaderEditor::_menu_option));
 
 	add_child(main_container);
@@ -789,7 +789,7 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	hbc->add_child(edit_menu);
 	hbc->add_child(goto_menu);
 	hbc->add_child(help_menu);
-	hbc->add_theme_style_override("panel", p_node->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditorPanel"), SNAME("EditorStyles")));
+	hbc->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditorPanel"), SNAME("EditorStyles")));
 
 	VSplitContainer *editor_box = memnew(VSplitContainer);
 	main_container->add_child(editor_box);
@@ -849,12 +849,12 @@ bool ShaderEditorPlugin::handles(Object *p_object) const {
 void ShaderEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		button->show();
-		editor->make_bottom_panel_item_visible(shader_editor);
+		EditorNode::get_singleton()->make_bottom_panel_item_visible(shader_editor);
 
 	} else {
 		button->hide();
 		if (shader_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorNode::get_singleton()->hide_bottom_panel();
 		}
 		shader_editor->apply_shaders();
 	}
@@ -872,12 +872,11 @@ void ShaderEditorPlugin::apply_changes() {
 	shader_editor->apply_shaders();
 }
 
-ShaderEditorPlugin::ShaderEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
-	shader_editor = memnew(ShaderEditor(p_node));
+ShaderEditorPlugin::ShaderEditorPlugin() {
+	shader_editor = memnew(ShaderEditor);
 
 	shader_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
-	button = editor->add_bottom_panel_item(TTR("Shader"), shader_editor);
+	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Shader"), shader_editor);
 	button->hide();
 
 	_2d = false;

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -154,7 +154,7 @@ public:
 	virtual Size2 get_minimum_size() const override { return Size2(0, 200); }
 	void save_external_data(const String &p_str = "");
 
-	ShaderEditor(EditorNode *p_node);
+	ShaderEditor();
 };
 
 class ShaderEditorPlugin : public EditorPlugin {
@@ -162,7 +162,6 @@ class ShaderEditorPlugin : public EditorPlugin {
 
 	bool _2d;
 	ShaderEditor *shader_editor;
-	EditorNode *editor;
 	Button *button;
 
 public:
@@ -178,7 +177,7 @@ public:
 	virtual void save_external_data() override;
 	virtual void apply_changes() override;
 
-	ShaderEditorPlugin(EditorNode *p_node);
+	ShaderEditorPlugin();
 	~ShaderEditorPlugin();
 };
 

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -245,7 +245,7 @@ void ShaderFileEditor::_shader_changed() {
 
 ShaderFileEditor *ShaderFileEditor::singleton = nullptr;
 
-ShaderFileEditor::ShaderFileEditor(EditorNode *p_node) {
+ShaderFileEditor::ShaderFileEditor() {
 	singleton = this;
 	HSplitContainer *main_hs = memnew(HSplitContainer);
 
@@ -301,22 +301,21 @@ bool ShaderFileEditorPlugin::handles(Object *p_object) const {
 void ShaderFileEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		button->show();
-		editor->make_bottom_panel_item_visible(shader_editor);
+		EditorNode::get_singleton()->make_bottom_panel_item_visible(shader_editor);
 
 	} else {
 		button->hide();
 		if (shader_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorNode::get_singleton()->hide_bottom_panel();
 		}
 	}
 }
 
-ShaderFileEditorPlugin::ShaderFileEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
-	shader_editor = memnew(ShaderFileEditor(p_node));
+ShaderFileEditorPlugin::ShaderFileEditorPlugin() {
+	shader_editor = memnew(ShaderFileEditor);
 
 	shader_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
-	button = editor->add_bottom_panel_item(TTR("ShaderFile"), shader_editor);
+	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("ShaderFile"), shader_editor);
 	button->hide();
 }
 

--- a/editor/plugins/shader_file_editor_plugin.h
+++ b/editor/plugins/shader_file_editor_plugin.h
@@ -68,14 +68,13 @@ public:
 	static ShaderFileEditor *singleton;
 	void edit(const Ref<RDShaderFile> &p_shader);
 
-	ShaderFileEditor(EditorNode *p_node);
+	ShaderFileEditor();
 };
 
 class ShaderFileEditorPlugin : public EditorPlugin {
 	GDCLASS(ShaderFileEditorPlugin, EditorPlugin);
 
 	ShaderFileEditor *shader_editor;
-	EditorNode *editor;
 	Button *button;
 
 public:
@@ -87,7 +86,7 @@ public:
 
 	ShaderFileEditor *get_shader_editor() const { return shader_editor; }
 
-	ShaderFileEditorPlugin(EditorNode *p_node);
+	ShaderFileEditorPlugin();
 	~ShaderFileEditorPlugin();
 };
 

--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -128,10 +128,9 @@ void Skeleton2DEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-Skeleton2DEditorPlugin::Skeleton2DEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+Skeleton2DEditorPlugin::Skeleton2DEditorPlugin() {
 	sprite_editor = memnew(Skeleton2DEditor);
-	editor->get_main_control()->add_child(sprite_editor);
+	EditorNode::get_singleton()->get_main_control()->add_child(sprite_editor);
 	make_visible(false);
 
 	//sprite_editor->options->hide();

--- a/editor/plugins/skeleton_2d_editor_plugin.h
+++ b/editor/plugins/skeleton_2d_editor_plugin.h
@@ -68,7 +68,6 @@ class Skeleton2DEditorPlugin : public EditorPlugin {
 	GDCLASS(Skeleton2DEditorPlugin, EditorPlugin);
 
 	Skeleton2DEditor *sprite_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "Skeleton2D"; }
@@ -77,7 +76,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	Skeleton2DEditorPlugin(EditorNode *p_node);
+	Skeleton2DEditorPlugin();
 	~Skeleton2DEditorPlugin();
 };
 

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -787,8 +787,7 @@ void Skeleton3DEditor::edit_mode_toggled(const bool pressed) {
 	_update_gizmo_visible();
 }
 
-Skeleton3DEditor::Skeleton3DEditor(EditorInspectorPluginSkeleton *e_plugin, EditorNode *p_editor, Skeleton3D *p_skeleton) :
-		editor(p_editor),
+Skeleton3DEditor::Skeleton3DEditor(EditorInspectorPluginSkeleton *e_plugin, Skeleton3D *p_skeleton) :
 		editor_plugin(e_plugin),
 		skeleton(p_skeleton) {
 	singleton = this;
@@ -822,7 +821,7 @@ void fragment() {
 }
 )");
 	handle_material->set_shader(handle_shader);
-	Ref<Texture2D> handle = editor->get_gui_base()->get_theme_icon(SNAME("EditorBoneHandle"), SNAME("EditorIcons"));
+	Ref<Texture2D> handle = EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("EditorBoneHandle"), SNAME("EditorIcons"));
 	handle_material->set_shader_param("point_size", handle->get_width());
 	handle_material->set_shader_param("texture_albedo", handle);
 
@@ -1013,15 +1012,12 @@ void EditorInspectorPluginSkeleton::parse_begin(Object *p_object) {
 	Skeleton3D *skeleton = Object::cast_to<Skeleton3D>(p_object);
 	ERR_FAIL_COND(!skeleton);
 
-	skel_editor = memnew(Skeleton3DEditor(this, editor, skeleton));
+	skel_editor = memnew(Skeleton3DEditor(this, skeleton));
 	add_custom_control(skel_editor);
 }
 
-Skeleton3DEditorPlugin::Skeleton3DEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
-
+Skeleton3DEditorPlugin::Skeleton3DEditorPlugin() {
 	skeleton_plugin = memnew(EditorInspectorPluginSkeleton);
-	skeleton_plugin->editor = editor;
 
 	EditorInspector::add_inspector_plugin(skeleton_plugin);
 

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -109,7 +109,6 @@ class Skeleton3DEditor : public VBoxContainer {
 		Transform3D relative_rest; // Relative to skeleton node.
 	};
 
-	EditorNode *editor;
 	EditorInspectorPluginSkeleton *editor_plugin;
 
 	Skeleton3D *skeleton;
@@ -213,7 +212,7 @@ public:
 	Quaternion get_bone_original_rotation() const { return bone_original_rotation; };
 	Vector3 get_bone_original_scale() const { return bone_original_scale; };
 
-	Skeleton3DEditor(EditorInspectorPluginSkeleton *e_plugin, EditorNode *p_editor, Skeleton3D *skeleton);
+	Skeleton3DEditor(EditorInspectorPluginSkeleton *e_plugin, Skeleton3D *skeleton);
 	~Skeleton3DEditor();
 };
 
@@ -223,7 +222,6 @@ class EditorInspectorPluginSkeleton : public EditorInspectorPlugin {
 	friend class Skeleton3DEditorPlugin;
 
 	Skeleton3DEditor *skel_editor;
-	EditorNode *editor;
 
 public:
 	virtual bool can_handle(Object *p_object) override;
@@ -234,7 +232,6 @@ class Skeleton3DEditorPlugin : public EditorPlugin {
 	GDCLASS(Skeleton3DEditorPlugin, EditorPlugin);
 
 	EditorInspectorPluginSkeleton *skeleton_plugin;
-	EditorNode *editor;
 
 public:
 	virtual EditorPlugin::AfterGUIInput forward_spatial_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event) override;
@@ -244,7 +241,7 @@ public:
 
 	virtual String get_name() const override { return "Skeleton3D"; }
 
-	Skeleton3DEditorPlugin(EditorNode *p_node);
+	Skeleton3DEditorPlugin();
 };
 
 class Skeleton3DGizmoPlugin : public EditorNode3DGizmoPlugin {

--- a/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
@@ -81,10 +81,9 @@ void SkeletonIK3DEditorPlugin::make_visible(bool p_visible) {
 void SkeletonIK3DEditorPlugin::_bind_methods() {
 }
 
-SkeletonIK3DEditorPlugin::SkeletonIK3DEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+SkeletonIK3DEditorPlugin::SkeletonIK3DEditorPlugin() {
 	play_btn = memnew(Button);
-	play_btn->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
+	play_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
 	play_btn->set_text(TTR("Play IK"));
 	play_btn->set_toggle_mode(true);
 	play_btn->hide();

--- a/editor/plugins/skeleton_ik_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_ik_3d_editor_plugin.h
@@ -42,7 +42,6 @@ class SkeletonIK3DEditorPlugin : public EditorPlugin {
 	SkeletonIK3D *skeleton_ik;
 
 	Button *play_btn;
-	EditorNode *editor;
 
 	void _play();
 
@@ -56,7 +55,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	SkeletonIK3DEditorPlugin(EditorNode *p_node);
+	SkeletonIK3DEditorPlugin();
 	~SkeletonIK3DEditorPlugin();
 };
 

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -585,10 +585,9 @@ void Sprite2DEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-Sprite2DEditorPlugin::Sprite2DEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+Sprite2DEditorPlugin::Sprite2DEditorPlugin() {
 	sprite_editor = memnew(Sprite2DEditor);
-	editor->get_main_control()->add_child(sprite_editor);
+	EditorNode::get_singleton()->get_main_control()->add_child(sprite_editor);
 	make_visible(false);
 
 	//sprite_editor->options->hide();

--- a/editor/plugins/sprite_2d_editor_plugin.h
+++ b/editor/plugins/sprite_2d_editor_plugin.h
@@ -100,7 +100,6 @@ class Sprite2DEditorPlugin : public EditorPlugin {
 	GDCLASS(Sprite2DEditorPlugin, EditorPlugin);
 
 	Sprite2DEditor *sprite_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "Sprite2D"; }
@@ -109,7 +108,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	Sprite2DEditorPlugin(EditorNode *p_node);
+	Sprite2DEditorPlugin();
 	~Sprite2DEditorPlugin();
 };
 

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1329,20 +1329,19 @@ bool SpriteFramesEditorPlugin::handles(Object *p_object) const {
 void SpriteFramesEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		button->show();
-		editor->make_bottom_panel_item_visible(frames_editor);
+		EditorNode::get_singleton()->make_bottom_panel_item_visible(frames_editor);
 	} else {
 		button->hide();
 		if (frames_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorNode::get_singleton()->hide_bottom_panel();
 		}
 	}
 }
 
-SpriteFramesEditorPlugin::SpriteFramesEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+SpriteFramesEditorPlugin::SpriteFramesEditorPlugin() {
 	frames_editor = memnew(SpriteFramesEditor);
 	frames_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
-	button = editor->add_bottom_panel_item(TTR("SpriteFrames"), frames_editor);
+	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("SpriteFrames"), frames_editor);
 	button->hide();
 }
 

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -166,7 +166,6 @@ class SpriteFramesEditorPlugin : public EditorPlugin {
 	GDCLASS(SpriteFramesEditorPlugin, EditorPlugin);
 
 	SpriteFramesEditor *frames_editor;
-	EditorNode *editor;
 	Button *button;
 
 public:
@@ -176,7 +175,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	SpriteFramesEditorPlugin(EditorNode *p_node);
+	SpriteFramesEditorPlugin();
 	~SpriteFramesEditorPlugin();
 };
 

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -85,7 +85,7 @@ StyleBoxPreview::StyleBoxPreview() {
 	add_margin_child(TTR("Preview:"), preview);
 }
 
-StyleBoxEditorPlugin::StyleBoxEditorPlugin(EditorNode *p_node) {
+StyleBoxEditorPlugin::StyleBoxEditorPlugin() {
 	Ref<EditorInspectorPluginStyleBox> inspector_plugin;
 	inspector_plugin.instantiate();
 	add_inspector_plugin(inspector_plugin);

--- a/editor/plugins/style_box_editor_plugin.h
+++ b/editor/plugins/style_box_editor_plugin.h
@@ -71,7 +71,7 @@ class StyleBoxEditorPlugin : public EditorPlugin {
 public:
 	virtual String get_name() const override { return "StyleBox"; }
 
-	StyleBoxEditorPlugin(EditorNode *p_node);
+	StyleBoxEditorPlugin();
 };
 
 #endif // STYLE_BOX_EDITOR_PLUGIN_H

--- a/editor/plugins/sub_viewport_preview_editor_plugin.cpp
+++ b/editor/plugins/sub_viewport_preview_editor_plugin.cpp
@@ -45,7 +45,7 @@ void EditorInspectorPluginSubViewportPreview::parse_begin(Object *p_object) {
 	add_custom_control(sub_viewport_preview);
 }
 
-SubViewportPreviewEditorPlugin::SubViewportPreviewEditorPlugin(EditorNode *p_node) {
+SubViewportPreviewEditorPlugin::SubViewportPreviewEditorPlugin() {
 	Ref<EditorInspectorPluginSubViewportPreview> plugin;
 	plugin.instantiate();
 	add_inspector_plugin(plugin);

--- a/editor/plugins/sub_viewport_preview_editor_plugin.h
+++ b/editor/plugins/sub_viewport_preview_editor_plugin.h
@@ -51,7 +51,7 @@ class SubViewportPreviewEditorPlugin : public EditorPlugin {
 public:
 	virtual String get_name() const override { return "SubViewportPreview"; }
 
-	SubViewportPreviewEditorPlugin(EditorNode *p_node);
+	SubViewportPreviewEditorPlugin();
 };
 
 #endif // SUB_VIEWPORT_PREVIEW_EDITOR_PLUGIN_H

--- a/editor/plugins/text_control_editor_plugin.cpp
+++ b/editor/plugins/text_control_editor_plugin.cpp
@@ -653,8 +653,7 @@ void TextControlEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-TextControlEditorPlugin::TextControlEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+TextControlEditorPlugin::TextControlEditorPlugin() {
 	text_ctl_editor = memnew(TextControlEditor);
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(text_ctl_editor);
 

--- a/editor/plugins/text_control_editor_plugin.h
+++ b/editor/plugins/text_control_editor_plugin.h
@@ -103,7 +103,6 @@ class TextControlEditorPlugin : public EditorPlugin {
 	GDCLASS(TextControlEditorPlugin, EditorPlugin);
 
 	TextControlEditor *text_ctl_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "TextControlFontEditor"; }
@@ -112,7 +111,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	TextControlEditorPlugin(EditorNode *p_node);
+	TextControlEditorPlugin();
 };
 
 #endif // TEXT_CONTROL_EDITOR_PLUGIN_H

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -205,7 +205,7 @@ void EditorInspectorPlugin3DTexture::parse_begin(Object *p_object) {
 	add_custom_control(editor);
 }
 
-Texture3DEditorPlugin::Texture3DEditorPlugin(EditorNode *p_node) {
+Texture3DEditorPlugin::Texture3DEditorPlugin() {
 	Ref<EditorInspectorPlugin3DTexture> plugin;
 	plugin.instantiate();
 	add_inspector_plugin(plugin);

--- a/editor/plugins/texture_3d_editor_plugin.h
+++ b/editor/plugins/texture_3d_editor_plugin.h
@@ -90,7 +90,7 @@ class Texture3DEditorPlugin : public EditorPlugin {
 public:
 	virtual String get_name() const override { return "Texture3D"; }
 
-	Texture3DEditorPlugin(EditorNode *p_node);
+	Texture3DEditorPlugin();
 };
 
 #endif // TEXTURE_EDITOR_PLUGIN_H

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -120,7 +120,7 @@ void EditorInspectorPluginTexture::parse_begin(Object *p_object) {
 	add_custom_control(memnew(TexturePreview(texture, true)));
 }
 
-TextureEditorPlugin::TextureEditorPlugin(EditorNode *p_node) {
+TextureEditorPlugin::TextureEditorPlugin() {
 	Ref<EditorInspectorPluginTexture> plugin;
 	plugin.instantiate();
 	add_inspector_plugin(plugin);

--- a/editor/plugins/texture_editor_plugin.h
+++ b/editor/plugins/texture_editor_plugin.h
@@ -69,7 +69,7 @@ class TextureEditorPlugin : public EditorPlugin {
 public:
 	virtual String get_name() const override { return "Texture2D"; }
 
-	TextureEditorPlugin(EditorNode *p_node);
+	TextureEditorPlugin();
 };
 
 #endif // TEXTURE_EDITOR_PLUGIN_H

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -278,7 +278,7 @@ void EditorInspectorPluginLayeredTexture::parse_begin(Object *p_object) {
 	add_custom_control(editor);
 }
 
-TextureLayeredEditorPlugin::TextureLayeredEditorPlugin(EditorNode *p_node) {
+TextureLayeredEditorPlugin::TextureLayeredEditorPlugin() {
 	Ref<EditorInspectorPluginLayeredTexture> plugin;
 	plugin.instantiate();
 	add_inspector_plugin(plugin);

--- a/editor/plugins/texture_layered_editor_plugin.h
+++ b/editor/plugins/texture_layered_editor_plugin.h
@@ -92,7 +92,7 @@ class TextureLayeredEditorPlugin : public EditorPlugin {
 public:
 	virtual String get_name() const override { return "TextureLayered"; }
 
-	TextureLayeredEditorPlugin(EditorNode *p_node);
+	TextureLayeredEditorPlugin();
 };
 
 #endif // TEXTURE_EDITOR_PLUGIN_H

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -981,14 +981,13 @@ Vector2 TextureRegionEditor::snap_point(Vector2 p_target) const {
 	return p_target;
 }
 
-TextureRegionEditor::TextureRegionEditor(EditorNode *p_editor) {
+TextureRegionEditor::TextureRegionEditor() {
 	node_sprite_2d = nullptr;
 	node_sprite_3d = nullptr;
 	node_ninepatch = nullptr;
 	obj_styleBox = Ref<StyleBoxTexture>(nullptr);
 	atlas_tex = Ref<AtlasTexture>(nullptr);
-	editor = p_editor;
-	undo_redo = editor->get_undo_redo();
+	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 	snap_step = Vector2(10, 10);
 	snap_separation = Vector2(0, 0);
@@ -1146,11 +1145,11 @@ void TextureRegionEditorPlugin::make_visible(bool p_visible) {
 		is_node_configured |= region_editor->get_sprite_2d() && region_editor->get_sprite_2d()->is_region_enabled();
 		is_node_configured |= region_editor->get_sprite_3d() && region_editor->get_sprite_3d()->is_region_enabled();
 		if ((is_node_configured && !manually_hidden) || texture_region_button->is_pressed()) {
-			editor->make_bottom_panel_item_visible(region_editor);
+			EditorNode::get_singleton()->make_bottom_panel_item_visible(region_editor);
 		}
 	} else {
 		if (region_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorNode::get_singleton()->hide_bottom_panel();
 			manually_hidden = false;
 		}
 		texture_region_button->hide();
@@ -1199,15 +1198,14 @@ void TextureRegionEditorPlugin::set_state(const Dictionary &p_state) {
 void TextureRegionEditorPlugin::_bind_methods() {
 }
 
-TextureRegionEditorPlugin::TextureRegionEditorPlugin(EditorNode *p_node) {
+TextureRegionEditorPlugin::TextureRegionEditorPlugin() {
 	manually_hidden = false;
-	editor = p_node;
 
-	region_editor = memnew(TextureRegionEditor(p_node));
+	region_editor = memnew(TextureRegionEditor);
 	region_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 	region_editor->hide();
 	region_editor->connect("visibility_changed", callable_mp(this, &TextureRegionEditorPlugin::_editor_visiblity_changed));
 
-	texture_region_button = p_node->add_bottom_panel_item(TTR("TextureRegion"), region_editor);
+	texture_region_button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("TextureRegion"), region_editor);
 	texture_region_button->hide();
 }

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -69,7 +69,6 @@ class TextureRegionEditor : public VBoxContainer {
 	VScrollBar *vscroll;
 	HScrollBar *hscroll;
 
-	EditorNode *editor;
 	UndoRedo *undo_redo;
 
 	Vector2 draw_ofs;
@@ -141,7 +140,7 @@ public:
 	Sprite3D *get_sprite_3d();
 
 	void edit(Object *p_obj);
-	TextureRegionEditor(EditorNode *p_editor);
+	TextureRegionEditor();
 };
 
 class TextureRegionEditorPlugin : public EditorPlugin {
@@ -150,7 +149,6 @@ class TextureRegionEditorPlugin : public EditorPlugin {
 	bool manually_hidden;
 	Button *texture_region_button;
 	TextureRegionEditor *region_editor;
-	EditorNode *editor;
 
 protected:
 	static void _bind_methods();
@@ -166,7 +164,7 @@ public:
 	void set_state(const Dictionary &p_state) override;
 	Dictionary get_state() const override;
 
-	TextureRegionEditorPlugin(EditorNode *p_node);
+	TextureRegionEditorPlugin();
 };
 
 #endif // TEXTURE_REGION_EDITOR_PLUGIN_H

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3757,21 +3757,20 @@ bool ThemeEditorPlugin::handles(Object *p_node) const {
 void ThemeEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		button->show();
-		editor->make_bottom_panel_item_visible(theme_editor);
+		EditorNode::get_singleton()->make_bottom_panel_item_visible(theme_editor);
 	} else {
 		if (theme_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorNode::get_singleton()->hide_bottom_panel();
 		}
 
 		button->hide();
 	}
 }
 
-ThemeEditorPlugin::ThemeEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+ThemeEditorPlugin::ThemeEditorPlugin() {
 	theme_editor = memnew(ThemeEditor);
 	theme_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 
-	button = editor->add_bottom_panel_item(TTR("Theme"), theme_editor);
+	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Theme"), theme_editor);
 	button->hide();
 }

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -454,7 +454,6 @@ class ThemeEditorPlugin : public EditorPlugin {
 	GDCLASS(ThemeEditorPlugin, EditorPlugin);
 
 	ThemeEditor *theme_editor;
-	EditorNode *editor;
 	Button *button;
 
 public:
@@ -464,7 +463,7 @@ public:
 	virtual bool handles(Object *p_node) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	ThemeEditorPlugin(EditorNode *p_node);
+	ThemeEditorPlugin();
 };
 
 #endif // THEME_EDITOR_PLUGIN_H

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -161,9 +161,9 @@ void TilesEditorPlugin::_update_editors() {
 	// Update visibility of bottom panel buttons.
 	if (tileset_editor_button->is_pressed() && !tile_set.is_valid()) {
 		if (tile_map) {
-			editor_node->make_bottom_panel_item_visible(tilemap_editor);
+			EditorNode::get_singleton()->make_bottom_panel_item_visible(tilemap_editor);
 		} else {
-			editor_node->hide_bottom_panel();
+			EditorNode::get_singleton()->hide_bottom_panel();
 		}
 	}
 }
@@ -190,15 +190,15 @@ void TilesEditorPlugin::make_visible(bool p_visible) {
 		tileset_editor_button->set_visible(tile_set.is_valid());
 		tilemap_editor_button->set_visible(tile_map);
 		if (tile_map) {
-			editor_node->make_bottom_panel_item_visible(tilemap_editor);
+			EditorNode::get_singleton()->make_bottom_panel_item_visible(tilemap_editor);
 		} else {
-			editor_node->make_bottom_panel_item_visible(tileset_editor);
+			EditorNode::get_singleton()->make_bottom_panel_item_visible(tileset_editor);
 		}
 
 	} else {
 		tileset_editor_button->hide();
 		tilemap_editor_button->hide();
-		editor_node->hide_bottom_panel();
+		EditorNode::get_singleton()->hide_bottom_panel();
 	}
 }
 
@@ -353,7 +353,7 @@ void TilesEditorPlugin::edit(Object *p_object) {
 			tile_map_id = p_object->get_instance_id();
 			tile_map = Object::cast_to<TileMap>(ObjectDB::get_instance(tile_map_id));
 			tile_set = tile_map->get_tileset();
-			editor_node->make_bottom_panel_item_visible(tilemap_editor);
+			EditorNode::get_singleton()->make_bottom_panel_item_visible(tilemap_editor);
 		} else if (p_object->is_class("TileSet")) {
 			tile_set = Ref<TileSet>(p_object);
 			if (tile_map) {
@@ -362,7 +362,7 @@ void TilesEditorPlugin::edit(Object *p_object) {
 					tile_map_id = ObjectID();
 				}
 			}
-			editor_node->make_bottom_panel_item_visible(tileset_editor);
+			EditorNode::get_singleton()->make_bottom_panel_item_visible(tileset_editor);
 		}
 	}
 
@@ -379,13 +379,11 @@ bool TilesEditorPlugin::handles(Object *p_object) const {
 	return p_object->is_class("TileMap") || p_object->is_class("TileSet");
 }
 
-TilesEditorPlugin::TilesEditorPlugin(EditorNode *p_node) {
+TilesEditorPlugin::TilesEditorPlugin() {
 	set_process_internal(true);
 
 	// Update the singleton.
 	singleton = this;
-
-	editor_node = p_node;
 
 	// Tileset editor.
 	tileset_editor = memnew(TileSetEditor);
@@ -405,9 +403,9 @@ TilesEditorPlugin::TilesEditorPlugin(EditorNode *p_node) {
 	pattern_preview_thread.start(_thread_func, this);
 
 	// Bottom buttons.
-	tileset_editor_button = p_node->add_bottom_panel_item(TTR("TileSet"), tileset_editor);
+	tileset_editor_button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("TileSet"), tileset_editor);
 	tileset_editor_button->hide();
-	tilemap_editor_button = p_node->add_bottom_panel_item(TTR("TileMap"), tilemap_editor);
+	tilemap_editor_button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("TileMap"), tilemap_editor);
 	tilemap_editor_button->hide();
 
 	// Initialization.

--- a/editor/plugins/tiles/tiles_editor_plugin.h
+++ b/editor/plugins/tiles/tiles_editor_plugin.h
@@ -53,8 +53,6 @@ public:
 	};
 
 private:
-	EditorNode *editor_node;
-
 	bool tile_map_changed_needs_update = false;
 	ObjectID tile_map_id;
 	Ref<TileSet> tile_set;
@@ -127,7 +125,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	TilesEditorPlugin(EditorNode *p_node);
+	TilesEditorPlugin();
 	~TilesEditorPlugin();
 };
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -5018,13 +5018,13 @@ void VisualShaderEditorPlugin::make_visible(bool p_visible) {
 		//editor->hide_animation_player_editors();
 		//editor->animation_panel_make_visible(true);
 		button->show();
-		editor->make_bottom_panel_item_visible(visual_shader_editor);
+		EditorNode::get_singleton()->make_bottom_panel_item_visible(visual_shader_editor);
 		visual_shader_editor->update_custom_nodes();
 		visual_shader_editor->set_process_input(true);
 		//visual_shader_editor->set_process(true);
 	} else {
 		if (visual_shader_editor->is_visible_in_tree()) {
-			editor->hide_bottom_panel();
+			EditorNode::get_singleton()->hide_bottom_panel();
 		}
 		button->hide();
 		visual_shader_editor->set_process_input(false);
@@ -5032,12 +5032,11 @@ void VisualShaderEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-VisualShaderEditorPlugin::VisualShaderEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+VisualShaderEditorPlugin::VisualShaderEditorPlugin() {
 	visual_shader_editor = memnew(VisualShaderEditor);
 	visual_shader_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
 
-	button = editor->add_bottom_panel_item(TTR("VisualShader"), visual_shader_editor);
+	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("VisualShader"), visual_shader_editor);
 	button->hide();
 }
 

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -463,7 +463,6 @@ class VisualShaderEditorPlugin : public EditorPlugin {
 	GDCLASS(VisualShaderEditorPlugin, EditorPlugin);
 
 	VisualShaderEditor *visual_shader_editor = nullptr;
-	EditorNode *editor = nullptr;
 	Button *button = nullptr;
 
 public:
@@ -473,7 +472,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	VisualShaderEditorPlugin(EditorNode *p_node);
+	VisualShaderEditorPlugin();
 	~VisualShaderEditorPlugin();
 };
 

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -144,14 +144,13 @@ void VoxelGIEditorPlugin::_voxel_gi_save_path_and_bake(const String &p_path) {
 void VoxelGIEditorPlugin::_bind_methods() {
 }
 
-VoxelGIEditorPlugin::VoxelGIEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+VoxelGIEditorPlugin::VoxelGIEditorPlugin() {
 	bake_hb = memnew(HBoxContainer);
 	bake_hb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	bake_hb->hide();
 	bake = memnew(Button);
 	bake->set_flat(true);
-	bake->set_icon(editor->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
+	bake->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake VoxelGI"));
 	bake->connect("pressed", callable_mp(this, &VoxelGIEditorPlugin::_bake));
 	bake_hb->add_child(bake);

--- a/editor/plugins/voxel_gi_editor_plugin.h
+++ b/editor/plugins/voxel_gi_editor_plugin.h
@@ -46,7 +46,6 @@ class VoxelGIEditorPlugin : public EditorPlugin {
 
 	HBoxContainer *bake_hb;
 	Button *bake;
-	EditorNode *editor;
 
 	EditorFileDialog *probe_file;
 
@@ -69,7 +68,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	VoxelGIEditorPlugin(EditorNode *p_node);
+	VoxelGIEditorPlugin();
 	~VoxelGIEditorPlugin();
 };
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -255,7 +255,7 @@ void SceneTreeDock::_replace_with_branch_scene(const String &p_file, Node *base)
 		return;
 	}
 
-	UndoRedo *undo_redo = editor->get_undo_redo();
+	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 	undo_redo->create_action(TTR("Replace with Branch Scene"));
 
 	Node *parent = base->get_parent();
@@ -452,7 +452,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			} else {
 				was_empty = true;
 			}
-			clipboard_source_scene = editor->get_edited_scene()->get_scene_file_path();
+			clipboard_source_scene = EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path();
 
 			selection.sort_custom<Node::Comparator>();
 
@@ -522,7 +522,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			}
 
 			editor_data->get_undo_redo().create_action(TTR("Detach Script"));
-			editor_data->get_undo_redo().add_do_method(editor, "push_item", (Script *)nullptr);
+			editor_data->get_undo_redo().add_do_method(EditorNode::get_singleton(), "push_item", (Script *)nullptr);
 
 			for (int i = 0; i < selection.size(); i++) {
 				Node *n = Object::cast_to<Node>(selection[i]);
@@ -758,7 +758,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 			editor_data->get_undo_redo().create_action(TTR("Make node as Root"));
 			editor_data->get_undo_redo().add_do_method(node->get_parent(), "remove_child", node);
-			editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", node);
+			editor_data->get_undo_redo().add_do_method(EditorNode::get_singleton(), "set_edited_scene", node);
 			editor_data->get_undo_redo().add_do_method(node, "add_child", root, true);
 			editor_data->get_undo_redo().add_do_method(node, "set_scene_file_path", root->get_scene_file_path());
 			editor_data->get_undo_redo().add_do_method(root, "set_scene_file_path", String());
@@ -769,7 +769,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			editor_data->get_undo_redo().add_undo_method(root, "set_scene_file_path", root->get_scene_file_path());
 			editor_data->get_undo_redo().add_undo_method(node, "set_scene_file_path", String());
 			editor_data->get_undo_redo().add_undo_method(node, "remove_child", root);
-			editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", root);
+			editor_data->get_undo_redo().add_undo_method(EditorNode::get_singleton(), "set_edited_scene", root);
 			editor_data->get_undo_redo().add_undo_method(node->get_parent(), "add_child", node, true);
 			editor_data->get_undo_redo().add_undo_method(node->get_parent(), "move_child", node, node->get_index());
 			editor_data->get_undo_redo().add_undo_method(root, "set_owner", (Object *)nullptr);
@@ -1100,7 +1100,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 
 			add_root_node(new_node);
 
-			editor->edit_node(new_node);
+			EditorNode::get_singleton()->edit_node(new_node);
 			editor_selection->clear();
 			editor_selection->add_node(new_node);
 
@@ -1137,10 +1137,10 @@ void SceneTreeDock::_perform_property_drop(Node *p_node, String p_property, RES 
 
 void SceneTreeDock::add_root_node(Node *p_node) {
 	editor_data->get_undo_redo().create_action(TTR("New Scene Root"));
-	editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", p_node);
+	editor_data->get_undo_redo().add_do_method(EditorNode::get_singleton(), "set_edited_scene", p_node);
 	editor_data->get_undo_redo().add_do_method(scene_tree, "update_tree");
 	editor_data->get_undo_redo().add_do_reference(p_node);
-	editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", (Object *)nullptr);
+	editor_data->get_undo_redo().add_undo_method(EditorNode::get_singleton(), "set_edited_scene", (Object *)nullptr);
 	editor_data->get_undo_redo().commit_action();
 }
 
@@ -1326,16 +1326,16 @@ void SceneTreeDock::_node_replace_owner(Node *p_base, Node *p_node, Node *p_root
 }
 
 void SceneTreeDock::_load_request(const String &p_path) {
-	editor->open_request(p_path);
+	EditorNode::get_singleton()->open_request(p_path);
 }
 
 void SceneTreeDock::_script_open_request(const Ref<Script> &p_script) {
-	editor->edit_resource(p_script);
+	EditorNode::get_singleton()->edit_resource(p_script);
 }
 
 void SceneTreeDock::_push_item(Object *p_object) {
 	if (!Input::get_singleton()->is_key_pressed(Key::ALT)) {
-		editor->push_item(p_object);
+		EditorNode::get_singleton()->push_item(p_object);
 	}
 }
 
@@ -1998,7 +1998,7 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 		return;
 	}
 
-	editor->get_editor_plugins_over()->make_visible(false);
+	EditorNode::get_singleton()->get_editor_plugins_over()->make_visible(false);
 
 	if (p_cut) {
 		editor_data->get_undo_redo().create_action(TTR("Cut Node(s)"));
@@ -2015,8 +2015,8 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 	}
 
 	if (entire_scene) {
-		editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", (Object *)nullptr);
-		editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", edited_scene);
+		editor_data->get_undo_redo().add_do_method(EditorNode::get_singleton(), "set_edited_scene", (Object *)nullptr);
+		editor_data->get_undo_redo().add_undo_method(EditorNode::get_singleton(), "set_edited_scene", edited_scene);
 		editor_data->get_undo_redo().add_undo_method(edited_scene, "set_owner", edited_scene->get_owner());
 		editor_data->get_undo_redo().add_undo_method(scene_tree, "update_tree");
 		editor_data->get_undo_redo().add_undo_reference(edited_scene);
@@ -2144,10 +2144,10 @@ void SceneTreeDock::_do_create(Node *p_parent) {
 		editor_data->get_undo_redo().add_undo_method(ed, "live_debug_remove_node", NodePath(String(edited_scene->get_path_to(p_parent)).plus_file(new_name)));
 
 	} else {
-		editor_data->get_undo_redo().add_do_method(editor, "set_edited_scene", child);
+		editor_data->get_undo_redo().add_do_method(EditorNode::get_singleton(), "set_edited_scene", child);
 		editor_data->get_undo_redo().add_do_method(scene_tree, "update_tree");
 		editor_data->get_undo_redo().add_do_reference(child);
-		editor_data->get_undo_redo().add_undo_method(editor, "set_edited_scene", (Object *)nullptr);
+		editor_data->get_undo_redo().add_undo_method(EditorNode::get_singleton(), "set_edited_scene", (Object *)nullptr);
 	}
 
 	editor_data->get_undo_redo().commit_action();
@@ -2339,7 +2339,7 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_prop
 
 	if (n == edited_scene) {
 		edited_scene = newnode;
-		editor->set_edited_scene(newnode);
+		EditorNode::get_singleton()->set_edited_scene(newnode);
 	}
 
 	//small hack to make collisionshapes and other kind of nodes to work
@@ -3034,7 +3034,7 @@ List<Node *> SceneTreeDock::paste_nodes() {
 		if (!paste_parent) {
 			paste_parent = dup;
 			owner = dup;
-			ur.add_do_method(editor, "set_edited_scene", dup);
+			ur.add_do_method(EditorNode::get_singleton(), "set_edited_scene", dup);
 		} else {
 			ur.add_do_method(paste_parent, "add_child", dup, true);
 		}
@@ -3052,14 +3052,14 @@ List<Node *> SceneTreeDock::paste_nodes() {
 		ur.add_do_method(editor_selection, "add_node", dup);
 
 		if (dup == paste_parent) {
-			ur.add_undo_method(editor, "set_edited_scene", (Object *)nullptr);
+			ur.add_undo_method(EditorNode::get_singleton(), "set_edited_scene", (Object *)nullptr);
 		} else {
 			ur.add_undo_method(paste_parent, "remove_child", dup);
 		}
 		ur.add_do_reference(dup);
 
 		if (node_clipboard.size() == 1) {
-			ur.add_do_method(editor, "push_item", dup);
+			ur.add_do_method(EditorNode::get_singleton(), "push_item", dup);
 		}
 	}
 
@@ -3297,10 +3297,9 @@ void SceneTreeDock::_update_configuration_warning() {
 	}
 }
 
-SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSelection *p_editor_selection, EditorData &p_editor_data) {
+SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selection, EditorData &p_editor_data) {
 	singleton = this;
 	set_name("Scene");
-	editor = p_editor;
 	edited_scene = nullptr;
 	editor_data = &p_editor_data;
 	editor_selection = p_editor_selection;

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -171,7 +171,6 @@ class SceneTreeDock : public VBoxContainer {
 	void _do_create(Node *p_parent);
 	Node *scene_root;
 	Node *edited_scene;
-	EditorNode *editor;
 
 	VBoxContainer *create_root_dialog;
 	String selected_favorite_root;
@@ -319,7 +318,7 @@ public:
 
 	ScriptCreateDialog *get_script_create_dialog() { return script_create_dialog; }
 
-	SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSelection *p_editor_selection, EditorData &p_editor_data);
+	SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selection, EditorData &p_editor_data);
 	~SceneTreeDock();
 };
 

--- a/modules/csg/csg_gizmos.cpp
+++ b/modules/csg/csg_gizmos.cpp
@@ -421,7 +421,7 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 }
 
-EditorPluginCSG::EditorPluginCSG(EditorNode *p_editor) {
+EditorPluginCSG::EditorPluginCSG(EditorNode *_p_editor) {
 	Ref<CSGShape3DGizmoPlugin> gizmo_plugin = Ref<CSGShape3DGizmoPlugin>(memnew(CSGShape3DGizmoPlugin));
 	Node3DEditor::get_singleton()->add_gizmo_plugin(gizmo_plugin);
 }

--- a/modules/csg/csg_gizmos.h
+++ b/modules/csg/csg_gizmos.h
@@ -57,7 +57,7 @@ class EditorPluginCSG : public EditorPlugin {
 	GDCLASS(EditorPluginCSG, EditorPlugin);
 
 public:
-	EditorPluginCSG(EditorNode *p_editor);
+	EditorPluginCSG(EditorNode *_p_editor);
 };
 
 #endif // CSG_GIZMOS_H

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -408,10 +408,10 @@ void GDNativeLibraryEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-GDNativeLibraryEditorPlugin::GDNativeLibraryEditorPlugin(EditorNode *p_node) {
+GDNativeLibraryEditorPlugin::GDNativeLibraryEditorPlugin() {
 	library_editor = memnew(GDNativeLibraryEditor);
 	library_editor->set_custom_minimum_size(Size2(0, 250 * EDSCALE));
-	button = p_node->add_bottom_panel_item(TTR("GDNativeLibrary"), library_editor);
+	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("GDNativeLibrary"), library_editor);
 	button->hide();
 }
 

--- a/modules/gdnative/gdnative_library_editor_plugin.h
+++ b/modules/gdnative/gdnative_library_editor_plugin.h
@@ -103,7 +103,6 @@ class GDNativeLibraryEditorPlugin : public EditorPlugin {
 	GDCLASS(GDNativeLibraryEditorPlugin, EditorPlugin);
 
 	GDNativeLibraryEditor *library_editor = nullptr;
-	EditorNode *editor = nullptr;
 	Button *button = nullptr;
 
 public:
@@ -113,7 +112,7 @@ public:
 	virtual bool handles(Object *p_node) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	GDNativeLibraryEditorPlugin(EditorNode *p_node);
+	GDNativeLibraryEditorPlugin();
 };
 #endif
 #endif // GDNATIVE_LIBRARY_EDITOR_PLUGIN_H

--- a/modules/gdnative/register_types.cpp
+++ b/modules/gdnative/register_types.cpp
@@ -226,7 +226,7 @@ static void editor_init_callback() {
 
 	EditorExport::get_singleton()->add_export_plugin(export_plugin);
 
-	EditorNode::get_singleton()->add_editor_plugin(memnew(GDNativeLibraryEditorPlugin(EditorNode::get_singleton())));
+	EditorNode::get_singleton()->add_editor_plugin(memnew(GDNativeLibraryEditorPlugin));
 }
 
 #endif

--- a/modules/gltf/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor_scene_exporter_gltf_plugin.cpp
@@ -53,10 +53,9 @@ bool SceneExporterGLTFPlugin::has_main_screen() const {
 	return false;
 }
 
-SceneExporterGLTFPlugin::SceneExporterGLTFPlugin(EditorNode *p_node) {
-	editor = p_node;
+SceneExporterGLTFPlugin::SceneExporterGLTFPlugin(EditorNode *_p_node) {
 	file_export_lib = memnew(EditorFileDialog);
-	editor->get_gui_base()->add_child(file_export_lib);
+	EditorNode::get_singleton()->get_gui_base()->add_child(file_export_lib);
 	file_export_lib->connect("file_selected", callable_mp(this, &SceneExporterGLTFPlugin::_gltf2_dialog_action));
 	file_export_lib->set_title(TTR("Export Library"));
 	file_export_lib->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
@@ -70,9 +69,9 @@ SceneExporterGLTFPlugin::SceneExporterGLTFPlugin(EditorNode *p_node) {
 }
 
 void SceneExporterGLTFPlugin::_gltf2_dialog_action(String p_file) {
-	Node *root = editor->get_tree()->get_edited_scene_root();
+	Node *root = EditorNode::get_singleton()->get_tree()->get_edited_scene_root();
 	if (!root) {
-		editor->show_accept(TTR("This operation can't be done without a scene."), TTR("OK"));
+		EditorNode::get_singleton()->show_accept(TTR("This operation can't be done without a scene."), TTR("OK"));
 		return;
 	}
 	List<String> deps;
@@ -93,9 +92,9 @@ void SceneExporterGLTFPlugin::_gltf2_dialog_action(String p_file) {
 }
 
 void SceneExporterGLTFPlugin::convert_scene_to_gltf2() {
-	Node *root = editor->get_tree()->get_edited_scene_root();
+	Node *root = EditorNode::get_singleton()->get_tree()->get_edited_scene_root();
 	if (!root) {
-		editor->show_accept(TTR("This operation can't be done without a scene."), TTR("OK"));
+		EditorNode::get_singleton()->show_accept(TTR("This operation can't be done without a scene."), TTR("OK"));
 		return;
 	}
 	String filename = String(root->get_scene_file_path().get_file().get_basename());

--- a/modules/gltf/editor_scene_exporter_gltf_plugin.h
+++ b/modules/gltf/editor_scene_exporter_gltf_plugin.h
@@ -38,7 +38,6 @@
 class SceneExporterGLTFPlugin : public EditorPlugin {
 	GDCLASS(SceneExporterGLTFPlugin, EditorPlugin);
 
-	EditorNode *editor = nullptr;
 	EditorFileDialog *file_export_lib = nullptr;
 	void _gltf2_dialog_action(String p_file);
 	void convert_scene_to_gltf2();
@@ -46,7 +45,7 @@ class SceneExporterGLTFPlugin : public EditorPlugin {
 public:
 	virtual String get_name() const override;
 	bool has_main_screen() const override;
-	SceneExporterGLTFPlugin(class EditorNode *p_node);
+	SceneExporterGLTFPlugin(EditorNode *_p_node);
 };
 #endif // TOOLS_ENABLED
 #endif // EDITOR_SCENE_EXPORTER_GLTF_PLUGIN_H

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -924,7 +924,7 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 	_update_selection_transform();
 	_update_paste_indicator();
 
-	spatial_editor = Object::cast_to<Node3DEditorPlugin>(editor->get_editor_plugin_screen());
+	spatial_editor = Object::cast_to<Node3DEditorPlugin>(EditorNode::get_singleton()->get_editor_plugin_screen());
 
 	if (!node) {
 		set_process(false);
@@ -1160,9 +1160,8 @@ void GridMapEditor::_bind_methods() {
 	ClassDB::bind_method("_set_selection", &GridMapEditor::_set_selection);
 }
 
-GridMapEditor::GridMapEditor(EditorNode *p_editor) {
-	editor = p_editor;
-	undo_redo = p_editor->get_undo_redo();
+GridMapEditor::GridMapEditor() {
+	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 	int mw = EDITOR_DEF("editors/grid_map/palette_min_width", 230);
 	Control *ec = memnew(Control);
@@ -1490,13 +1489,11 @@ void GridMapEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-GridMapEditorPlugin::GridMapEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
-
+GridMapEditorPlugin::GridMapEditorPlugin(EditorNode *_p_node) {
 	EDITOR_DEF("editors/grid_map/editor_side", 1);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "editors/grid_map/editor_side", PROPERTY_HINT_ENUM, "Left,Right"));
 
-	grid_map_editor = memnew(GridMapEditor(editor));
+	grid_map_editor = memnew(GridMapEditor);
 	switch ((int)EditorSettings::get_singleton()->get("editors/grid_map/editor_side")) {
 		case 0: { // Left.
 			Node3DEditor::get_singleton()->add_control_to_left_panel(grid_map_editor);

--- a/modules/gridmap/grid_map_editor_plugin.h
+++ b/modules/gridmap/grid_map_editor_plugin.h
@@ -192,8 +192,6 @@ class GridMapEditor : public VBoxContainer {
 	ItemList *mesh_library_palette;
 	Label *info_message;
 
-	EditorNode *editor;
-
 	void update_grid(); // Change which and where the grid is displayed
 	void _draw_grids(const Vector3 &cell_size);
 	void _configure();
@@ -239,8 +237,7 @@ public:
 	EditorPlugin::AfterGUIInput forward_spatial_input_event(Camera3D *p_camera, const Ref<InputEvent> &p_event);
 
 	void edit(GridMap *p_gridmap);
-	GridMapEditor() {}
-	GridMapEditor(EditorNode *p_editor);
+	GridMapEditor();
 	~GridMapEditor();
 };
 
@@ -248,7 +245,6 @@ class GridMapEditorPlugin : public EditorPlugin {
 	GDCLASS(GridMapEditorPlugin, EditorPlugin);
 
 	GridMapEditor *grid_map_editor;
-	EditorNode *editor;
 
 protected:
 	void _notification(int p_what);
@@ -261,7 +257,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	GridMapEditorPlugin(EditorNode *p_node);
+	GridMapEditorPlugin(EditorNode *_p_node);
 	~GridMapEditorPlugin();
 };
 

--- a/platform/javascript/api/javascript_tools_editor_plugin.cpp
+++ b/platform/javascript/api/javascript_tools_editor_plugin.cpp
@@ -46,14 +46,14 @@ extern void godot_js_os_download_buffer(const uint8_t *p_buf, int p_buf_size, co
 }
 
 static void _javascript_editor_init_callback() {
-	EditorNode::get_singleton()->add_editor_plugin(memnew(JavaScriptToolsEditorPlugin(EditorNode::get_singleton())));
+	EditorNode::get_singleton()->add_editor_plugin(memnew(JavaScriptToolsEditorPlugin));
 }
 
 void JavaScriptToolsEditorPlugin::initialize() {
 	EditorNode::add_init_callback(_javascript_editor_init_callback);
 }
 
-JavaScriptToolsEditorPlugin::JavaScriptToolsEditorPlugin(EditorNode *p_editor) {
+JavaScriptToolsEditorPlugin::JavaScriptToolsEditorPlugin() {
 	add_tool_menu_item("Download Project Source", callable_mp(this, &JavaScriptToolsEditorPlugin::_download_zip));
 }
 

--- a/platform/javascript/api/javascript_tools_editor_plugin.h
+++ b/platform/javascript/api/javascript_tools_editor_plugin.h
@@ -46,7 +46,7 @@ private:
 public:
 	static void initialize();
 
-	JavaScriptToolsEditorPlugin(EditorNode *p_editor);
+	JavaScriptToolsEditorPlugin();
 };
 #else
 class JavaScriptToolsEditorPlugin {


### PR DESCRIPTION
Follow up of #55066

Remove most EditorNode parameters and class attributes.
The only missing EditorNode references are:
- EditorScript.
- Plugins registered with `EditorPlugins::add_by_type` (only in some modules). 
  Any reference to the given parameter is gone, and they were renamed to `_p_editor`.
- `EditorPlugins::creator`, because, is a more important change that deserves its PR.

In some cases, I create local variables to shorten lines (since `EditorNode::get_singleton()` it's bigger than `editor`).

<hr/>

This PR has tons of changed files, Here's a summary of the changes to them:
- InspectorDock, FileSystemDock, SceneTreeDock, CanvasItemEditor, Node3DEditor and related classes has notable changes due to several usages of EditorNode.
- Some classes had from 1 to 4 usages of EditorNode.
- Some classes use EditorNode only in the constructor and in the `make_visible` method (if it's a bottom panel plugin).
- Some classes use EditorNode only in the constructor by calling `EditorNode::add_bottom_panel_item`.
- Few classes don't use EditorNode at all.
- AbstractPolygon2DEditor and subclasses no longer has the EditorNode parameter,
- Module's editor plugins no longer use the EditorNode parameter, and that parameter was renamed from `p_editor` to `_p_editor`.
- Removed the EditorNode reference in all headers (excluding EditorScript).

<hr/>

This PR increases the `EditorNode::get_singleton` usages, as expected. 
In many cases, it's possible to use the EditorPlugin methods instead (which use EditorNode, but that's an implementation detail).
It will be done in a follow-up PR.

`EditorNode::get_singleton` usages in master (1894f3f16567ff7475dd65ac61d6b8939fdccad4):
```
rg "EditorNode::get_singleton()" | wc -l
745
```

`EditorNode::get_singleton` usages in this PR:
```
rg "EditorNode::get_singleton()" | wc -l
996
```


CC @KoBeWi 