### PR TITLE
Fix face area calculation in SoftBody 3D

### DIFF
--- a/servers/physics_3d/godot_soft_body_3d.cpp
+++ b/servers/physics_3d/godot_soft_body_3d.cpp
@@ -245,7 +245,7 @@ void GodotSoftBody3D::update_area() {
 		const Vector3 a = x1 - x0;
 		const Vector3 b = x2 - x0;
 		const Vector3 cr = vec3_cross(a, b);
-		face.ra = cr.length();
+		face.ra = cr.length() * 0.5;
 	}
 
 	// Node area.


### PR DESCRIPTION
Fixes #47962, supersedes #47964.
The face area calculation was previously off by a factor of 0.5.
This change was approved by @pouleyKetchoupp a few months ago, pending a rebase on the original PR.