### PR TITLE
Make various improvements to OptionButton

### DIFF
--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -84,7 +84,7 @@
 		<method name="get_selected_id" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the ID of the selected item, or [code]0[/code] if no item is selected.
+				Returns the ID of the selected item, or [code]-1[/code] if no item is selected.
 			</description>
 		</method>
 		<method name="get_selected_metadata" qualifiers="const">
@@ -112,6 +112,7 @@
 			<argument index="0" name="idx" type="int" />
 			<description>
 				Selects an item by index and makes it the current item. This will work even if the item is disabled.
+				Passing [code]-1[/code] as the index deselects any currently selected item.
 			</description>
 		</method>
 		<method name="set_item_disabled">

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -810,7 +810,7 @@ void PopupMenu::_notification(int p_what) {
 #define ITEM_SETUP_WITH_ACCEL(p_label, p_id, p_accel) \
 	item.text = p_label;                              \
 	item.xl_text = atr(p_label);                      \
-	item.id = p_id == -1 ? items.size() : p_id;       \
+	item.id = p_id == -1 ? items.size() - 1 : p_id;   \
 	item.accel = p_accel;
 
 void PopupMenu::add_item(const String &p_label, int p_id, Key p_accel) {
@@ -892,7 +892,7 @@ void PopupMenu::add_multistate_item(const String &p_label, int p_max_states, int
 	_ref_shortcut(p_shortcut);                                                         \
 	item.text = p_shortcut->get_name();                                                \
 	item.xl_text = atr(item.text);                                                     \
-	item.id = p_id == -1 ? items.size() : p_id;                                        \
+	item.id = p_id == -1 ? items.size() - 1 : p_id;                                    \
 	item.shortcut = p_shortcut;                                                        \
 	item.shortcut_is_global = p_global;
 
@@ -961,7 +961,7 @@ void PopupMenu::add_submenu_item(const String &p_label, const String &p_submenu,
 	Item item;
 	item.text = p_label;
 	item.xl_text = atr(p_label);
-	item.id = p_id == -1 ? items.size() : p_id;
+	item.id = p_id == -1 ? items.size() - 1 : p_id;
 	item.submenu = p_submenu;
 	items.push_back(item);
 	_shape_item(items.size() - 1);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixed several bugs from https://github.com/godotengine/godot/issues/6558

- OptionButton can now be set to no selection by calling `optionButton.select(-1)`
- The `Selected` property in the editor can now be set to `-1` for no selection
  - The `Selected` property can now be restored to default (which is -1)
- When a selected item is deleted, the selection is set to no selection (-1)
  - This also fixes the scenarios where all items are deleted and where items are added after being deleted
  
 I also found an undocumented bug introduced here: https://github.com/godotengine/godot/pull/54647
 
 The PopupMenu had been edited to use IDs starting at 0 in some places, but in other places (and in OptionButton) it was expected to use IDs starting at 1. This caused a bug where when adding OptionButton items from the inspector, both of the first two items would have ID = 1
 
 Rather than reverting, I fully converted PopupMenu and OptionButton to use 0-based IDs. This matches the documentation, which claims that IDs are set by index (which starts with 0). It also improves some dissonance where "0" could be passed in as a valid object ID but was also being used to represent "no selection" when calling `get_selected_id()`. Now, -1 represent no selection in both the index and the ID flows.