### PR TITLE
Add warning for Windows export when rcedit is not configured

### DIFF
--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -47,6 +47,7 @@ public:
 	virtual Error sign_shared_object(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path) override;
 	virtual void get_export_options(List<ExportOption> *r_options) override;
 	virtual bool get_export_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const override;
+	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const override;
 };
 
 #endif


### PR DESCRIPTION
Add warning for Windows export when rcedit is not configured mentioned in #57320.
I think there is no need for checking whether application details are filled or not since the default value(like file version `1.0.0`) will be ignored too if rcedit is not configured. 

*Bugsquad edit:* Fixes #57320.