### PR TITLE
Fix not being able to stop() empty Tweens

### DIFF
--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -249,8 +249,6 @@ bool Tween::custom_step(float p_delta) {
 }
 
 bool Tween::step(float p_delta) {
-	ERR_FAIL_COND_V_MSG(tweeners.is_empty(), false, "Tween started, but has no Tweeners.");
-
 	if (dead) {
 		return false;
 	}
@@ -271,6 +269,7 @@ bool Tween::step(float p_delta) {
 	}
 
 	if (!started) {
+		ERR_FAIL_COND_V_MSG(tweeners.is_empty(), false, "Tween started, but has no Tweeners.");
 		current_step = 0;
 		loops_done = 0;
 		start_tweeners();


### PR DESCRIPTION
You should be able to `stop()` empty Tween and add Tweeners later. It's rather useless use-case, but it's documented and there's no reason to prevent it.

Closes #57333