### PR TITLE
Improve some method bindings to use specific `Object` subtypes

### DIFF
--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -438,9 +438,9 @@
 		<method name="add_tool_submenu_item">
 			<return type="void" />
 			<argument index="0" name="name" type="String" />
-			<argument index="1" name="submenu" type="Object" />
+			<argument index="1" name="submenu" type="PopupMenu" />
 			<description>
-				Adds a custom submenu under [b]Project &gt; Tools &gt;[/b] [code]name[/code]. [code]submenu[/code] should be an object of class [PopupMenu]. Use [code]remove_tool_menu_item(name)[/code] on plugin clean up to remove the menu.
+				Adds a custom [PopupMenu] submenu under [b]Project &gt; Tools &gt;[/b] [code]name[/code]. Use [code]remove_tool_menu_item(name)[/code] on plugin clean up to remove the menu.
 			</description>
 		</method>
 		<method name="add_translation_parser_plugin">

--- a/doc/classes/RayCast2D.xml
+++ b/doc/classes/RayCast2D.xml
@@ -16,9 +16,9 @@
 	<methods>
 		<method name="add_exception">
 			<return type="void" />
-			<argument index="0" name="node" type="Object" />
+			<argument index="0" name="node" type="CollisionObject2D" />
 			<description>
-				Adds a collision exception so the ray does not report collisions with the specified node.
+				Adds a collision exception so the ray does not report collisions with the specified [CollisionObject2D] node.
 			</description>
 		</method>
 		<method name="add_exception_rid">
@@ -81,9 +81,9 @@
 		</method>
 		<method name="remove_exception">
 			<return type="void" />
-			<argument index="0" name="node" type="Object" />
+			<argument index="0" name="node" type="CollisionObject2D" />
 			<description>
-				Removes a collision exception so the ray does report collisions with the specified node.
+				Removes a collision exception so the ray does report collisions with the specified [CollisionObject2D] node.
 			</description>
 		</method>
 		<method name="remove_exception_rid">

--- a/doc/classes/RayCast3D.xml
+++ b/doc/classes/RayCast3D.xml
@@ -17,9 +17,9 @@
 	<methods>
 		<method name="add_exception">
 			<return type="void" />
-			<argument index="0" name="node" type="Object" />
+			<argument index="0" name="node" type="CollisionObject3D" />
 			<description>
-				Adds a collision exception so the ray does not report collisions with the specified node.
+				Adds a collision exception so the ray does not report collisions with the specified [CollisionObject3D] node.
 			</description>
 		</method>
 		<method name="add_exception_rid">
@@ -82,9 +82,9 @@
 		</method>
 		<method name="remove_exception">
 			<return type="void" />
-			<argument index="0" name="node" type="Object" />
+			<argument index="0" name="node" type="CollisionObject3D" />
 			<description>
-				Removes a collision exception so the ray does report collisions with the specified node.
+				Removes a collision exception so the ray does report collisions with the specified [CollisionObject3D] node.
 			</description>
 		</method>
 		<method name="remove_exception_rid">

--- a/doc/classes/ShapeCast2D.xml
+++ b/doc/classes/ShapeCast2D.xml
@@ -14,9 +14,9 @@
 	<methods>
 		<method name="add_exception">
 			<return type="void" />
-			<argument index="0" name="node" type="Object" />
+			<argument index="0" name="node" type="CollisionObject2D" />
 			<description>
-				Adds a collision exception so the shape does not report collisions with the specified node.
+				Adds a collision exception so the shape does not report collisions with the specified [CollisionObject2D] node.
 			</description>
 		</method>
 		<method name="add_exception_rid">
@@ -101,9 +101,9 @@
 		</method>
 		<method name="remove_exception">
 			<return type="void" />
-			<argument index="0" name="node" type="Object" />
+			<argument index="0" name="node" type="CollisionObject2D" />
 			<description>
-				Removes a collision exception so the shape does report collisions with the specified node.
+				Removes a collision exception so the shape does report collisions with the specified [CollisionObject2D] node.
 			</description>
 		</method>
 		<method name="remove_exception_rid">

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -371,7 +371,7 @@
 		</method>
 		<method name="move_after">
 			<return type="void" />
-			<argument index="0" name="item" type="Object" />
+			<argument index="0" name="item" type="TreeItem" />
 			<description>
 				Moves this TreeItem right after the given [code]item[/code].
 				[b]Note:[/b] You can't move to the root or move the root.
@@ -379,7 +379,7 @@
 		</method>
 		<method name="move_before">
 			<return type="void" />
-			<argument index="0" name="item" type="Object" />
+			<argument index="0" name="item" type="TreeItem" />
 			<description>
 				Moves this TreeItem right before the given [code]item[/code].
 				[b]Note:[/b] You can't move to the root or move the root.
@@ -395,7 +395,7 @@
 		</method>
 		<method name="remove_child">
 			<return type="void" />
-			<argument index="0" name="child" type="Object" />
+			<argument index="0" name="child" type="TreeItem" />
 			<description>
 				Removes the given child [TreeItem] and all its children from the [Tree]. Note that it doesn't free the item from memory, so it can be reused later. To completely remove a [TreeItem] use [method Object.free].
 			</description>

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -513,11 +513,9 @@ void EditorPlugin::add_tool_menu_item(const String &p_name, const Callable &p_ca
 	EditorNode::get_singleton()->add_tool_menu_item(p_name, p_callable);
 }
 
-void EditorPlugin::add_tool_submenu_item(const String &p_name, Object *p_submenu) {
+void EditorPlugin::add_tool_submenu_item(const String &p_name, PopupMenu *p_submenu) {
 	ERR_FAIL_NULL(p_submenu);
-	PopupMenu *submenu = Object::cast_to<PopupMenu>(p_submenu);
-	ERR_FAIL_NULL(submenu);
-	EditorNode::get_singleton()->add_tool_submenu_item(p_name, submenu);
+	EditorNode::get_singleton()->add_tool_submenu_item(p_name, p_submenu);
 }
 
 void EditorPlugin::remove_tool_menu_item(const String &p_name) {

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -42,6 +42,7 @@
 #include "scene/3d/camera_3d.h"
 #include "scene/main/node.h"
 #include "scene/resources/texture.h"
+
 class EditorNode;
 class Node3D;
 class Camera3D;
@@ -217,7 +218,7 @@ public:
 	void remove_control_from_bottom_panel(Control *p_control);
 
 	void add_tool_menu_item(const String &p_name, const Callable &p_callable);
-	void add_tool_submenu_item(const String &p_name, Object *p_submenu);
+	void add_tool_submenu_item(const String &p_name, PopupMenu *p_submenu);
 	void remove_tool_menu_item(const String &p_name);
 
 	void set_input_event_forwarding_always_enabled();

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -263,26 +263,18 @@ void RayCast2D::add_exception_rid(const RID &p_rid) {
 	exclude.insert(p_rid);
 }
 
-void RayCast2D::add_exception(const Object *p_object) {
-	ERR_FAIL_NULL(p_object);
-	const CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_object);
-	if (!co) {
-		return;
-	}
-	add_exception_rid(co->get_rid());
+void RayCast2D::add_exception(const CollisionObject2D *p_node) {
+	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject2D.");
+	add_exception_rid(p_node->get_rid());
 }
 
 void RayCast2D::remove_exception_rid(const RID &p_rid) {
 	exclude.erase(p_rid);
 }
 
-void RayCast2D::remove_exception(const Object *p_object) {
-	ERR_FAIL_NULL(p_object);
-	const CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_object);
-	if (!co) {
-		return;
-	}
-	remove_exception_rid(co->get_rid());
+void RayCast2D::remove_exception(const CollisionObject2D *p_node) {
+	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject2D.");
+	remove_exception_rid(p_node->get_rid());
 }
 
 void RayCast2D::clear_exceptions() {

--- a/scene/2d/ray_cast_2d.h
+++ b/scene/2d/ray_cast_2d.h
@@ -33,6 +33,8 @@
 
 #include "scene/2d/node_2d.h"
 
+class CollisionObject2D;
+
 class RayCast2D : public Node2D {
 	GDCLASS(RayCast2D, Node2D);
 
@@ -94,9 +96,9 @@ public:
 	Vector2 get_collision_normal() const;
 
 	void add_exception_rid(const RID &p_rid);
-	void add_exception(const Object *p_object);
+	void add_exception(const CollisionObject2D *p_node);
 	void remove_exception_rid(const RID &p_rid);
-	void remove_exception(const Object *p_object);
+	void remove_exception(const CollisionObject2D *p_node);
 	void clear_exceptions();
 
 	RayCast2D();

--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -322,26 +322,18 @@ void ShapeCast2D::add_exception_rid(const RID &p_rid) {
 	exclude.insert(p_rid);
 }
 
-void ShapeCast2D::add_exception(const Object *p_object) {
-	ERR_FAIL_NULL(p_object);
-	const CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_object);
-	if (!co) {
-		return;
-	}
-	add_exception_rid(co->get_rid());
+void ShapeCast2D::add_exception(const CollisionObject2D *p_node) {
+	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject2D.");
+	add_exception_rid(p_node->get_rid());
 }
 
 void ShapeCast2D::remove_exception_rid(const RID &p_rid) {
 	exclude.erase(p_rid);
 }
 
-void ShapeCast2D::remove_exception(const Object *p_object) {
-	ERR_FAIL_NULL(p_object);
-	const CollisionObject2D *co = Object::cast_to<CollisionObject2D>(p_object);
-	if (!co) {
-		return;
-	}
-	remove_exception_rid(co->get_rid());
+void ShapeCast2D::remove_exception(const CollisionObject2D *p_node) {
+	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject2D.");
+	remove_exception_rid(p_node->get_rid());
 }
 
 void ShapeCast2D::clear_exceptions() {

--- a/scene/2d/shape_cast_2d.h
+++ b/scene/2d/shape_cast_2d.h
@@ -34,6 +34,8 @@
 #include "scene/2d/node_2d.h"
 #include "scene/resources/shape_2d.h"
 
+class CollisionObject2D;
+
 class ShapeCast2D : public Node2D {
 	GDCLASS(ShapeCast2D, Node2D);
 
@@ -109,9 +111,9 @@ public:
 	real_t get_closest_collision_unsafe_fraction() const;
 
 	void add_exception_rid(const RID &p_rid);
-	void add_exception(const Object *p_object);
+	void add_exception(const CollisionObject2D *p_node);
 	void remove_exception_rid(const RID &p_rid);
-	void remove_exception(const Object *p_object);
+	void remove_exception(const CollisionObject2D *p_node);
 	void clear_exceptions();
 
 	TypedArray<String> get_configuration_warnings() const override;

--- a/scene/3d/ray_cast_3d.cpp
+++ b/scene/3d/ray_cast_3d.cpp
@@ -243,26 +243,18 @@ void RayCast3D::add_exception_rid(const RID &p_rid) {
 	exclude.insert(p_rid);
 }
 
-void RayCast3D::add_exception(const Object *p_object) {
-	ERR_FAIL_NULL(p_object);
-	const CollisionObject3D *co = Object::cast_to<CollisionObject3D>(p_object);
-	if (!co) {
-		return;
-	}
-	add_exception_rid(co->get_rid());
+void RayCast3D::add_exception(const CollisionObject3D *p_node) {
+	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject3D.");
+	add_exception_rid(p_node->get_rid());
 }
 
 void RayCast3D::remove_exception_rid(const RID &p_rid) {
 	exclude.erase(p_rid);
 }
 
-void RayCast3D::remove_exception(const Object *p_object) {
-	ERR_FAIL_NULL(p_object);
-	const CollisionObject3D *co = Object::cast_to<CollisionObject3D>(p_object);
-	if (!co) {
-		return;
-	}
-	remove_exception_rid(co->get_rid());
+void RayCast3D::remove_exception(const CollisionObject3D *p_node) {
+	ERR_FAIL_NULL_MSG(p_node, "The passed Node must be an instance of CollisionObject3D.");
+	remove_exception_rid(p_node->get_rid());
 }
 
 void RayCast3D::clear_exceptions() {

--- a/scene/3d/ray_cast_3d.h
+++ b/scene/3d/ray_cast_3d.h
@@ -33,6 +33,8 @@
 
 #include "scene/3d/node_3d.h"
 
+class CollisionObject3D;
+
 class RayCast3D : public Node3D {
 	GDCLASS(RayCast3D, Node3D);
 
@@ -116,9 +118,9 @@ public:
 	Vector3 get_collision_normal() const;
 
 	void add_exception_rid(const RID &p_rid);
-	void add_exception(const Object *p_object);
+	void add_exception(const CollisionObject3D *p_node);
 	void remove_exception_rid(const RID &p_rid);
-	void remove_exception(const Object *p_object);
+	void remove_exception(const CollisionObject3D *p_node);
 	void clear_exceptions();
 
 	RayCast3D();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1317,10 +1317,10 @@ void TreeItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_children"), &TreeItem::get_children);
 	ClassDB::bind_method(D_METHOD("get_index"), &TreeItem::get_index);
 
-	ClassDB::bind_method(D_METHOD("move_before", "item"), &TreeItem::_move_before);
-	ClassDB::bind_method(D_METHOD("move_after", "item"), &TreeItem::_move_after);
+	ClassDB::bind_method(D_METHOD("move_before", "item"), &TreeItem::move_before);
+	ClassDB::bind_method(D_METHOD("move_after", "item"), &TreeItem::move_after);
 
-	ClassDB::bind_method(D_METHOD("remove_child", "child"), &TreeItem::_remove_child);
+	ClassDB::bind_method(D_METHOD("remove_child", "child"), &TreeItem::remove_child);
 
 	{
 		MethodInfo mi;

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -188,16 +188,6 @@ protected:
 
 		return d;
 	}
-	void _remove_child(Object *p_child) {
-		remove_child(Object::cast_to<TreeItem>(p_child));
-	}
-
-	void _move_before(Object *p_item) {
-		move_before(Object::cast_to<TreeItem>(p_item));
-	}
-	void _move_after(Object *p_item) {
-		move_after(Object::cast_to<TreeItem>(p_item));
-	}
 
 	Variant _call_recursive_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 


### PR DESCRIPTION
This was made possible by changes to `VariantCaster` which now make
it possible to pass any `Object`-derived type as pointer (#57205).