### PR TITLE
Decrease the default GradientTexture and CurveTexture size

### DIFF
--- a/doc/classes/CurveTexture.xml
+++ b/doc/classes/CurveTexture.xml
@@ -14,7 +14,7 @@
 		</member>
 		<member name="texture_mode" type="int" setter="set_texture_mode" getter="get_texture_mode" enum="CurveTexture.TextureMode" default="0">
 		</member>
-		<member name="width" type="int" setter="set_width" getter="get_width" default="2048">
+		<member name="width" type="int" setter="set_width" getter="get_width" default="256">
 			The width of the texture.
 		</member>
 	</members>

--- a/doc/classes/CurveXYZTexture.xml
+++ b/doc/classes/CurveXYZTexture.xml
@@ -13,7 +13,7 @@
 		</member>
 		<member name="curve_z" type="Curve" setter="set_curve_z" getter="get_curve_z">
 		</member>
-		<member name="width" type="int" setter="set_width" getter="get_width" default="2048">
+		<member name="width" type="int" setter="set_width" getter="get_width" default="256">
 		</member>
 	</members>
 </class>

--- a/doc/classes/GradientTexture1D.xml
+++ b/doc/classes/GradientTexture1D.xml
@@ -15,7 +15,7 @@
 		<member name="use_hdr" type="bool" setter="set_use_hdr" getter="is_using_hdr" default="false">
 			If [code]true[/code], the generated texture will support high dynamic range ([constant Image.FORMAT_RGBAF] format). This allows for glow effects to work if [member Environment.glow_enabled] is [code]true[/code]. If [code]false[/code], the generated texture will use low dynamic range; overbright colors will be clamped ([constant Image.FORMAT_RGBA8] format).
 		</member>
-		<member name="width" type="int" setter="set_width" getter="get_width" default="2048">
+		<member name="width" type="int" setter="set_width" getter="get_width" default="256">
 			The number of color samples that will be obtained from the [Gradient].
 		</member>
 	</members>

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -595,7 +595,7 @@ public:
 private:
 	mutable RID _texture;
 	Ref<Curve> _curve;
-	int _width = 2048;
+	int _width = 256;
 	int _current_width = 0;
 	TextureMode texture_mode = TEXTURE_MODE_RGB;
 	TextureMode _current_texture_mode = TEXTURE_MODE_RGB;
@@ -637,7 +637,7 @@ private:
 	Ref<Curve> _curve_x;
 	Ref<Curve> _curve_y;
 	Ref<Curve> _curve_z;
-	int _width = 2048;
+	int _width = 256;
 	int _current_width = 0;
 
 	void _update();
@@ -685,7 +685,7 @@ private:
 	Ref<Gradient> gradient;
 	bool update_pending = false;
 	RID texture;
-	int width = 2048;
+	int width = 256;
 	bool use_hdr = false;
 
 	void _queue_update();


### PR DESCRIPTION
This provides better usability when a GradientTexture or CurveTexture is added to a Control node.

Visual appearance of most GradientTextures and CurveTextures will be unaffected. This change also decreases memory usage, but only by a tiny amount (since only 1792 pixels are saved per texture).

This closes https://github.com/godotengine/godot/issues/28282.