### PR TITLE
fix resetting of multiple animtrees on single state_machine

### DIFF
--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -111,10 +111,12 @@ class AnimationNodeStateMachinePlayback : public Resource {
 	StringName start_request;
 	bool start_request_travel = false;
 	bool stop_request = false;
+	bool transitioning = false;
 
 	bool _travel(AnimationNodeStateMachine *p_state_machine, const StringName &p_travel);
 
 	double process(AnimationNodeStateMachine *p_state_machine, double p_time, bool p_seek);
+	void _update_current(const StringName next);
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
Tentative fix to #57223. 

I couldn't produce complex animation trees to make sure that behaviour remains the same, so I'd like to ask some help in determining whether this fix maintains old behaviour.