### PR TITLE
Be more verbose about why msbuild tools could not be found

### DIFF
--- a/modules/mono/build_scripts/mono_reg_utils.py
+++ b/modules/mono/build_scripts/mono_reg_utils.py
@@ -96,10 +96,10 @@ def find_msbuild_tools_path_reg():
         raise ValueError("Cannot find `installationPath` entry")
     except ValueError as e:
         print("Error reading output from vswhere: " + e.message)
-    except OSError:
-        pass  # Fine, vswhere not found
-    except (subprocess.CalledProcessError, OSError):
-        pass
+    except subprocess.CalledProcessError as e:
+        print(e.output)
+    except OSError as e:
+        print(e)
 
     # Try to find 14.0 in the Registry
 


### PR DESCRIPTION
Currently, on Windows, when building for mono and MSBuild tools cannot be found, there is no explantation. This PR simply prints the error messages.
