### PR TITLE
[3.x] Simplify usage of OS::get_window_size() in SceneTree methods

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -536,7 +536,7 @@ bool SceneTree::idle(float p_time) {
 	_notify_group_pause("idle_process_internal", Node::NOTIFICATION_INTERNAL_PROCESS);
 	_notify_group_pause("idle_process", Node::NOTIFICATION_PROCESS);
 
-	Size2 win_size = Size2(OS::get_singleton()->get_window_size().width, OS::get_singleton()->get_window_size().height);
+	Size2 win_size = OS::get_singleton()->get_window_size();
 
 	if (win_size != last_screen_size) {
 		last_screen_size = win_size;
@@ -1135,7 +1135,7 @@ void SceneTree::_update_root_rect() {
 	}
 
 	//actual screen video mode
-	Size2 video_mode = Size2(OS::get_singleton()->get_window_size().width, OS::get_singleton()->get_window_size().height);
+	Size2 video_mode = OS::get_singleton()->get_window_size();
 	Size2 desired_res = stretch_min;
 
 	Size2 viewport_size;
@@ -2128,7 +2128,7 @@ SceneTree::SceneTree() {
 	stretch_aspect = STRETCH_ASPECT_IGNORE;
 	stretch_scale = 1.0;
 
-	last_screen_size = Size2(OS::get_singleton()->get_window_size().width, OS::get_singleton()->get_window_size().height);
+	last_screen_size = OS::get_singleton()->get_window_size();
 	_update_root_rect();
 
 	if (ScriptDebugger::get_singleton()) {


### PR DESCRIPTION
There's no need to create new structure from the structure returned by `get_window_size()`.