### PR TITLE
Invert `Camera2D` zoom to make it intuitive

### DIFF
--- a/doc/classes/Camera2D.xml
+++ b/doc/classes/Camera2D.xml
@@ -157,7 +157,7 @@
 			Speed in pixels per second of the camera's smoothing effect when [member smoothing_enabled] is [code]true[/code].
 		</member>
 		<member name="zoom" type="Vector2" setter="set_zoom" getter="get_zoom" default="Vector2(1, 1)">
-			The camera's zoom relative to the viewport. Values larger than [code]Vector2(1, 1)[/code] zoom out and smaller values zoom in. For an example, use [code]Vector2(0.5, 0.5)[/code] for a 2× zoom-in, and [code]Vector2(4, 4)[/code] for a 4× zoom-out.
+			The camera's zoom. A zoom of [code]Vector(2, 2)[/code] doubles the size seen in the viewport. A zoom of [code]Vector(0.5, 0.5)[/code] halves the size seen in the viewport.
 		</member>
 	</members>
 	<constants>

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -78,6 +78,7 @@ void Camera2D::set_zoom(const Vector2 &p_zoom) {
 	ERR_FAIL_COND_MSG(Math::is_zero_approx(p_zoom.x) || Math::is_zero_approx(p_zoom.y), "Zoom level must be different from 0 (can be negative).");
 
 	zoom = p_zoom;
+	zoom_scale = Vector2(1, 1) / zoom;
 	Point2 old_smoothed_camera_pos = smoothed_camera_pos;
 	_update_scroll();
 	smoothed_camera_pos = old_smoothed_camera_pos;
@@ -102,8 +103,8 @@ Transform2D Camera2D::get_camera_transform() {
 	if (!first) {
 		if (anchor_mode == ANCHOR_MODE_DRAG_CENTER) {
 			if (drag_horizontal_enabled && !Engine::get_singleton()->is_editor_hint() && !drag_horizontal_offset_changed) {
-				camera_pos.x = MIN(camera_pos.x, (new_camera_pos.x + screen_size.x * 0.5 * zoom.x * drag_margin[SIDE_LEFT]));
-				camera_pos.x = MAX(camera_pos.x, (new_camera_pos.x - screen_size.x * 0.5 * zoom.x * drag_margin[SIDE_RIGHT]));
+				camera_pos.x = MIN(camera_pos.x, (new_camera_pos.x + screen_size.x * 0.5 * zoom_scale.x * drag_margin[SIDE_LEFT]));
+				camera_pos.x = MAX(camera_pos.x, (new_camera_pos.x - screen_size.x * 0.5 * zoom_scale.x * drag_margin[SIDE_RIGHT]));
 			} else {
 				if (drag_horizontal_offset < 0) {
 					camera_pos.x = new_camera_pos.x + screen_size.x * 0.5 * drag_margin[SIDE_RIGHT] * drag_horizontal_offset;
@@ -115,8 +116,8 @@ Transform2D Camera2D::get_camera_transform() {
 			}
 
 			if (drag_vertical_enabled && !Engine::get_singleton()->is_editor_hint() && !drag_vertical_offset_changed) {
-				camera_pos.y = MIN(camera_pos.y, (new_camera_pos.y + screen_size.y * 0.5 * zoom.y * drag_margin[SIDE_TOP]));
-				camera_pos.y = MAX(camera_pos.y, (new_camera_pos.y - screen_size.y * 0.5 * zoom.y * drag_margin[SIDE_BOTTOM]));
+				camera_pos.y = MIN(camera_pos.y, (new_camera_pos.y + screen_size.y * 0.5 * zoom_scale.y * drag_margin[SIDE_TOP]));
+				camera_pos.y = MAX(camera_pos.y, (new_camera_pos.y - screen_size.y * 0.5 * zoom_scale.y * drag_margin[SIDE_BOTTOM]));
 
 			} else {
 				if (drag_vertical_offset < 0) {
@@ -132,8 +133,8 @@ Transform2D Camera2D::get_camera_transform() {
 			camera_pos = new_camera_pos;
 		}
 
-		Point2 screen_offset = (anchor_mode == ANCHOR_MODE_DRAG_CENTER ? (screen_size * 0.5 * zoom) : Point2());
-		Rect2 screen_rect(-screen_offset + camera_pos, screen_size * zoom);
+		Point2 screen_offset = (anchor_mode == ANCHOR_MODE_DRAG_CENTER ? (screen_size * 0.5 * zoom_scale) : Point2());
+		Rect2 screen_rect(-screen_offset + camera_pos, screen_size * zoom_scale);
 
 		if (limit_smoothing_enabled) {
 			if (screen_rect.position.x < limit[SIDE_LEFT]) {
@@ -167,14 +168,14 @@ Transform2D Camera2D::get_camera_transform() {
 		first = false;
 	}
 
-	Point2 screen_offset = (anchor_mode == ANCHOR_MODE_DRAG_CENTER ? (screen_size * 0.5 * zoom) : Point2());
+	Point2 screen_offset = (anchor_mode == ANCHOR_MODE_DRAG_CENTER ? (screen_size * 0.5 * zoom_scale) : Point2());
 
 	real_t angle = get_global_rotation();
 	if (rotating) {
 		screen_offset = screen_offset.rotated(angle);
 	}
 
-	Rect2 screen_rect(-screen_offset + ret_camera_pos, screen_size * zoom);
+	Rect2 screen_rect(-screen_offset + ret_camera_pos, screen_size * zoom_scale);
 
 	if (!smoothing_enabled || !limit_smoothing_enabled) {
 		if (screen_rect.position.x < limit[SIDE_LEFT]) {
@@ -201,7 +202,7 @@ Transform2D Camera2D::get_camera_transform() {
 	camera_screen_center = screen_rect.get_center();
 
 	Transform2D xform;
-	xform.scale_basis(zoom);
+	xform.scale_basis(zoom_scale);
 	if (rotating) {
 		xform.set_rotation(angle);
 	}

--- a/scene/2d/camera_2d.h
+++ b/scene/2d/camera_2d.h
@@ -61,6 +61,7 @@ protected:
 	RID canvas;
 	Vector2 offset;
 	Vector2 zoom = Vector2(1, 1);
+	Vector2 zoom_scale = Vector2(1, 1);
 	AnchorMode anchor_mode = ANCHOR_MODE_DRAG_CENTER;
 	bool rotating = false;
 	bool current = false;


### PR DESCRIPTION
As explained in godotengine/godot-proposals#3888, currently, [`Camera2D`'s `zoom`](https://docs.godotengine.org/en/stable/classes/class_camera2d.html#class-camera2d-property-zoom) property values are inverted:
No Zoom | Zoom: (2, 2) | Zoom: (0.5, 0.5)
-- | -- | --
![Zoom x1 - Current](https://user-images.githubusercontent.com/9253928/151652691-bff072bb-d3c4-48da-91c7-ac839c4c2ea9.png) | ![Zoom x2 - Current](https://user-images.githubusercontent.com/9253928/151652696-f65b8346-cec9-497f-a6f8-50cdb104266d.png) | ![Zoom x0 5 - Current](https://user-images.githubusercontent.com/9253928/151652700-be2c26a8-ef96-4377-961f-59a8f6904e86.png)

This PR uses the inverted zoom values to scale objects in the viewport as expected i.e. a zoom of `Vector(2, 2)` doubles the size seen in the viewport, and a zoom of `Vector(0.5, 0.5)` halves the size seen in the viewport:
No Zoom | Zoom: (2, 2) | Zoom: (0.5, 0.5)
-- | -- | --
![Zoom x1 - Current](https://user-images.githubusercontent.com/9253928/151652691-bff072bb-d3c4-48da-91c7-ac839c4c2ea9.png) | ![Zoom x0 5 - Current](https://user-images.githubusercontent.com/9253928/151652700-be2c26a8-ef96-4377-961f-59a8f6904e86.png) | ![Zoom x2 - Current](https://user-images.githubusercontent.com/9253928/151652696-f65b8346-cec9-497f-a6f8-50cdb104266d.png)

Closes godotengine/godot-proposals#3888.
Supersedes #55731
