### PR TITLE
`TextureButton` Fix logic for drawing only the `focused` texture

### DIFF
--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -173,7 +173,8 @@ void TextureButton::_notification(int p_what) {
 			bool draw_focus = (has_focus() && focused.is_valid());
 
 			// If no other texture is valid, try using focused texture.
-			if (!texdraw.is_valid() && draw_focus) {
+			bool draw_focus_only = draw_focus && !texdraw.is_valid();
+			if (draw_focus_only) {
 				texdraw = focused;
 			}
 
@@ -232,7 +233,7 @@ void TextureButton::_notification(int p_what) {
 				size.width *= hflip ? -1.0f : 1.0f;
 				size.height *= vflip ? -1.0f : 1.0f;
 
-				if (texdraw == focused) {
+				if (draw_focus_only) {
 					// Do nothing, we only needed to calculate the rectangle.
 				} else if (_tile) {
 					draw_texture_rect(texdraw, Rect2(ofs, size), _tile);


### PR DESCRIPTION
If `focused` texture was the same as some other texture (`pressed`, `hover`, etc.) that should be drawn and the button wasn't focused then no texture would be drawn because of incorrect check silently assuming that `focused` is different than the other assigned textures. Should be fixed now.

Fixes #57388.
To clarify: the issue was that no texture was drawn at all; nothing was hidden and there was no issue with parent being top-level.