### PR TITLE
Fix navmesh baking

### DIFF
--- a/modules/navigation/navigation_mesh_generator.h
+++ b/modules/navigation/navigation_mesh_generator.h
@@ -51,6 +51,7 @@ protected:
 
 	static void _add_vertex(const Vector3 &p_vec3, Vector<float> &p_vertices);
 	static void _add_mesh(const Ref<Mesh> &p_mesh, const Transform &p_xform, Vector<float> &p_vertices, Vector<int> &p_indices);
+	static void _add_mesh_array(const Array &p_array, const Transform &p_xform, Vector<float> &p_vertices, Vector<int> &p_indices);
 	static void _add_faces(const PoolVector3Array &p_faces, const Transform &p_xform, Vector<float> &p_vertices, Vector<int> &p_indices);
 	static void _parse_geometry(const Transform &p_navmesh_xform, Node *p_node, Vector<float> &p_vertices, Vector<int> &p_indices, int p_generate_from, uint32_t p_collision_mask, bool p_recurse_children);
 

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -270,6 +270,10 @@ PrimitiveMesh::~PrimitiveMesh() {
 */
 
 void CapsuleMesh::_create_mesh_array(Array &p_arr) const {
+	create_mesh_array(p_arr, radius, mid_height, radial_segments, rings);
+}
+
+void CapsuleMesh::create_mesh_array(Array &p_arr, const float radius, const float mid_height, const int radial_segments, const int rings) {
 	int i, j, prevrow, thisrow, point;
 	float x, y, z, u, v, w;
 	float onethird = 1.0 / 3.0;
@@ -472,8 +476,8 @@ CapsuleMesh::CapsuleMesh() {
 	// defaults
 	radius = 1.0;
 	mid_height = 1.0;
-	radial_segments = 64;
-	rings = 8;
+	radial_segments = default_radial_segments;
+	rings = default_rings;
 }
 
 /**
@@ -481,6 +485,10 @@ CapsuleMesh::CapsuleMesh() {
 */
 
 void CubeMesh::_create_mesh_array(Array &p_arr) const {
+	create_mesh_array(p_arr, size, subdivide_w, subdivide_h, subdivide_d);
+}
+
+void CubeMesh::create_mesh_array(Array &p_arr, const Vector3 size, const int subdivide_w, const int subdivide_h, const int subdivide_d) {
 	int i, j, prevrow, thisrow, point;
 	float x, y, z;
 	float onethird = 1.0 / 3.0;
@@ -728,9 +736,9 @@ int CubeMesh::get_subdivide_depth() const {
 CubeMesh::CubeMesh() {
 	// defaults
 	size = Vector3(2.0, 2.0, 2.0);
-	subdivide_w = 0;
-	subdivide_h = 0;
-	subdivide_d = 0;
+	subdivide_w = default_subdivide_w;
+	subdivide_h = default_subdivide_h;
+	subdivide_d = default_subdivide_d;
 }
 
 /**
@@ -738,6 +746,10 @@ CubeMesh::CubeMesh() {
 */
 
 void CylinderMesh::_create_mesh_array(Array &p_arr) const {
+	create_mesh_array(p_arr, top_radius, bottom_radius, height, radial_segments, rings);
+}
+
+void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float bottom_radius, float height, int radial_segments, int rings) {
 	int i, j, prevrow, thisrow, point;
 	float x, y, z, u, v, radius;
 
@@ -943,8 +955,8 @@ CylinderMesh::CylinderMesh() {
 	top_radius = 1.0;
 	bottom_radius = 1.0;
 	height = 2.0;
-	radial_segments = 64;
-	rings = 4;
+	radial_segments = default_radial_segments;
+	rings = default_rings;
 }
 
 /**
@@ -1453,6 +1465,10 @@ Vector3 QuadMesh::get_center_offset() const {
 */
 
 void SphereMesh::_create_mesh_array(Array &p_arr) const {
+	create_mesh_array(p_arr, radius, height, radial_segments, rings, is_hemisphere);
+}
+
+void SphereMesh::create_mesh_array(Array &p_arr, float radius, float height, int radial_segments, int rings, bool is_hemisphere) {
 	int i, j, prevrow, thisrow, point;
 	float x, y, z;
 
@@ -1595,9 +1611,9 @@ SphereMesh::SphereMesh() {
 	// defaults
 	radius = 1.0;
 	height = 2.0;
-	radial_segments = 64;
-	rings = 32;
-	is_hemisphere = false;
+	radial_segments = default_radial_segments;
+	rings = default_rings;
+	is_hemisphere = default_is_hemisphere;
 }
 
 /**

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -101,6 +101,10 @@ class CapsuleMesh : public PrimitiveMesh {
 	GDCLASS(CapsuleMesh, PrimitiveMesh);
 
 private:
+	static constexpr int default_radial_segments = 64;
+	static constexpr int default_rings = 8;
+
+private:
 	float radius;
 	float mid_height;
 	int radial_segments;
@@ -111,6 +115,8 @@ protected:
 	virtual void _create_mesh_array(Array &p_arr) const;
 
 public:
+	static void create_mesh_array(Array &p_arr, float radius, float mid_height, int radial_segments = default_radial_segments, int rings = default_rings);
+
 	void set_radius(const float p_radius);
 	float get_radius() const;
 
@@ -133,6 +139,11 @@ class CubeMesh : public PrimitiveMesh {
 	GDCLASS(CubeMesh, PrimitiveMesh);
 
 private:
+	static constexpr int default_subdivide_w = 0;
+	static constexpr int default_subdivide_h = 0;
+	static constexpr int default_subdivide_d = 0;
+
+private:
 	Vector3 size;
 	int subdivide_w;
 	int subdivide_h;
@@ -143,6 +154,8 @@ protected:
 	virtual void _create_mesh_array(Array &p_arr) const;
 
 public:
+	static void create_mesh_array(Array &p_arr, Vector3 size, int subdivide_w = default_subdivide_w, int subdivide_h = default_subdivide_h, int subdivide_d = default_subdivide_d);
+
 	void set_size(const Vector3 &p_size);
 	Vector3 get_size() const;
 
@@ -166,6 +179,10 @@ class CylinderMesh : public PrimitiveMesh {
 	GDCLASS(CylinderMesh, PrimitiveMesh);
 
 private:
+	static constexpr int default_radial_segments = 64;
+	static constexpr int default_rings = 4;
+
+private:
 	float top_radius;
 	float bottom_radius;
 	float height;
@@ -177,6 +194,8 @@ protected:
 	virtual void _create_mesh_array(Array &p_arr) const;
 
 public:
+	static void create_mesh_array(Array &p_arr, float top_radius, float bottom_radius, float height, int radial_segments = default_radial_segments, int rings = default_rings);
+
 	void set_top_radius(const float p_radius);
 	float get_top_radius() const;
 
@@ -295,6 +314,11 @@ class SphereMesh : public PrimitiveMesh {
 	GDCLASS(SphereMesh, PrimitiveMesh);
 
 private:
+	static constexpr int default_radial_segments = 64;
+	static constexpr int default_rings = 32;
+	static constexpr bool default_is_hemisphere = false;
+
+private:
 	float radius;
 	float height;
 	int radial_segments;
@@ -306,6 +330,8 @@ protected:
 	virtual void _create_mesh_array(Array &p_arr) const;
 
 public:
+	static void create_mesh_array(Array &p_arr, float radius, float height, int radial_segments = default_radial_segments, int rings = default_rings, bool is_hemisphere = default_is_hemisphere);
+
 	void set_radius(const float p_radius);
 	float get_radius() const;
 


### PR DESCRIPTION
fixes #57148

- improved mesh data calculation from static colliders so that no
  VisualServer calls are performed - and thus no VS mutexes need to
  be locked in case of on-thread baking
- improved the same for GridMap's static colliders
