### PR TITLE
Inspector retains content when detached and when docked

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4222,6 +4222,8 @@ void EditorNode::_dock_floating_close_request(Control *p_control) {
 	_update_dock_containers();
 
 	floating_docks.erase(p_control);
+
+	_edit_current();
 }
 
 void EditorNode::_dock_make_float() {
@@ -4264,6 +4266,8 @@ void EditorNode::_dock_make_float() {
 	_update_dock_containers();
 
 	floating_docks.push_back(dock);
+
+	_edit_current();
 }
 
 void EditorNode::_update_dock_containers() {


### PR DESCRIPTION
Inspector now retains its contents when it's turned into a floating window and when it's docked again (fixed #45749).

https://user-images.githubusercontent.com/18116695/151673447-76aef34f-1d56-4ce6-ae47-873ed39c8bdc.mp4


