### PR TITLE
Fix orthogonal camera auto LOD calculation

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1081,6 +1081,10 @@ void RenderForwardClustered::_fill_render_list(RenderListType p_render_list, con
 					distance = -distance_max;
 				}
 
+				if (p_render_data->cam_ortogonal) {
+					distance = 1.0;
+				}
+
 				uint32_t indices;
 				surf->sort.lod_index = storage->mesh_surface_get_lod(surf->surface, inst->lod_model_scale * inst->lod_bias, distance * p_render_data->lod_distance_multiplier, p_render_data->screen_mesh_lod_threshold, &indices);
 				if (p_render_data->render_info) {

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1429,6 +1429,10 @@ void RenderForwardMobile::_fill_render_list(RenderListType p_render_list, const 
 					distance = -distance_max;
 				}
 
+				if (p_render_data->cam_ortogonal) {
+					distance = 1.0;
+				}
+
 				uint32_t indices;
 				surf->lod_index = storage->mesh_surface_get_lod(surf->surface, inst->lod_model_scale * inst->lod_bias, distance * p_render_data->lod_distance_multiplier, p_render_data->screen_mesh_lod_threshold, &indices);
 				if (p_render_data->render_info) {


### PR DESCRIPTION
Resolves #57404

- Orthogonal camera used to take into account its distance from a mesh for auto LOD. 
- This should not be done as the distance does not affect how the mesh visually appears. 
- This was most obvious when using the "Preview Orthogonal" camera as it was placed ~2000m away and most meshes near the origin would then only show their lowest LOD. 