### PR TITLE
Display emission on unshaded materials

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2054,6 +2054,7 @@ void BaseMaterial3D::_validate_property(PropertyInfo &p_property) const {
 			// Vertex not supported in ORM mode, since no individual roughness.
 			p_property.hint_string = "Unshaded,Per-Pixel";
 		}
+
 		if (p_property.name.begins_with("roughness") || p_property.name.begins_with("metallic") || p_property.name.begins_with("ao_texture")) {
 			p_property.usage = PROPERTY_USAGE_NONE;
 		}
@@ -2070,13 +2071,11 @@ void BaseMaterial3D::_validate_property(PropertyInfo &p_property) const {
 			if (p_property.name.begins_with("ao")) {
 				p_property.usage = PROPERTY_USAGE_NONE;
 			}
-			if (p_property.name.begins_with("emission")) {
-				p_property.usage = PROPERTY_USAGE_NONE;
-			}
 
 			if (p_property.name.begins_with("metallic")) {
 				p_property.usage = PROPERTY_USAGE_NONE;
 			}
+
 			if (p_property.name.begins_with("rim")) {
 				p_property.usage = PROPERTY_USAGE_NONE;
 			}

--- a/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_clustered/scene_forward_clustered.glsl
@@ -2274,7 +2274,7 @@ void fragment_shader(in SceneData scene_data) {
 #else //MODE_SEPARATE_SPECULAR
 
 #ifdef MODE_UNSHADED
-	frag_color = vec4(albedo, alpha);
+	frag_color = vec4(emission + albedo, alpha);
 #else
 	frag_color = vec4(emission + ambient_light + diffuse_light + specular_light, alpha);
 //frag_color = vec4(1.0);

--- a/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/forward_mobile/scene_forward_mobile.glsl
@@ -1764,7 +1764,7 @@ void main() {
 #else //MODE_MULTIPLE_RENDER_TARGETS
 
 #ifdef MODE_UNSHADED
-	frag_color = vec4(albedo, alpha);
+	frag_color = vec4(emission + albedo, alpha);
 #else // MODE_UNSHADED
 	frag_color = vec4(emission + ambient_light + diffuse_light + specular_light, alpha);
 #endif // MODE_UNSHADED


### PR DESCRIPTION
Emission is added to albedo and is displayed on unshaded materials.

This is more intuitive overall, especially when writing custom shaders or when using the Unshaded debug draw mode. Many engines seem to do this already ([Cube 2: Sauerbraten](https://imgsli.com/OTMzNTk) for instance).

This may be worth considering for a `3.x` backport, since it's not possible to set emission in a SpatialMaterial (it will be hidden once you enable the unshaded flag). In a custom ShaderMaterial, it was possible to write to emission in an unshaded surface but it was never visible. Therefore, the likelihood that this change breaks an existing project is low.

This change was requested by Zylann on the Godot Contributors Chat.

**Testing project:** [test_emission_unshaded.zip](https://github.com/godotengine/godot/files/7964814/test_emission_unshaded.zip)
Make sure to open the project *after* building this PR, or the emission value set within the material may be lost when saving the scene (since the category is hidden in `master`).

## Preview

*From left to right: albedo, emission, albedo + emission, unshaded albedo, unshaded emission, unshaded albedo + emission*
*Albedo color: `Color(1, 0.75, 0)`*
*Emission color: `Color(0, 1, 2)` (overbright)*

### Before

![2022-01-29_22 43 22](https://user-images.githubusercontent.com/180032/151678721-22b1e0d1-126c-4dee-9632-b9ba83c2105d.png)

### After

*The unshaded emission sphere now emits subtle glow.*

![2022-01-29_22 49 38](https://user-images.githubusercontent.com/180032/151678722-71c0d172-7e65-41f1-ac81-4f7e1cdb0a46.png)