### PR TITLE
[3.x] Add support for 16-bit directional and point light shadow atlases

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1682,6 +1682,9 @@
 		<member name="rendering/quality/depth_prepass/enable" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], performs a previous depth pass before rendering materials. This increases performance in scenes with high overdraw, when complex materials and lighting are used.
 		</member>
+		<member name="rendering/quality/directional_shadow/16_bits" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], renders directional shadows on a buffer with 16-bit precision. This results in slightly better performance with usually no noticeable visual difference. If [code]false[/code], renders directional shadows on a buffer with 24-bit precision.
+		</member>
 		<member name="rendering/quality/directional_shadow/size" type="int" setter="" getter="" default="4096">
 			The directional shadow's size in pixels. Higher values will result in sharper shadows, at the cost of performance. The value will be rounded up to the nearest power of 2. This setting can be changed at run-time; the change will be applied immediately.
 		</member>
@@ -1778,6 +1781,9 @@
 		<member name="rendering/quality/shading/use_physical_light_attenuation" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], enables new physical light attenuation for [OmniLight]s and [SpotLight]s. This results in more realistic lighting appearance with a very small performance cost. When physical light attenuation is enabled, lights will appear to be darker as a result of the new attenuation formula. This can be compensated by adjusting the lights' energy or attenuation values.
 			Changes to this setting will only be applied upon restarting the application.
+		</member>
+		<member name="rendering/quality/shadow_atlas/16_bits" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], renders point light shadows on a buffer with 16-bit precision. This results in slightly better performance with usually no noticeable visual difference. If [code]false[/code], renders point light shadows on a buffer with 24-bit precision.
 		</member>
 		<member name="rendering/quality/shadow_atlas/cubemap_size" type="int" setter="" getter="" default="512">
 			Size for cubemap into which the shadow is rendered before being copied into the shadow atlas. A higher number can result in higher resolution shadows when used with a higher [member rendering/quality/shadow_atlas/size]. Setting higher than a quarter of the [member rendering/quality/shadow_atlas/size] will not result in a perceptible increase in visual quality.

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -262,6 +262,9 @@
 		<member name="render_target_v_flip" type="bool" setter="set_vflip" getter="get_vflip" default="false">
 			If [code]true[/code], the result of rendering will be flipped vertically. Since Viewports in Godot 3.x render upside-down, it's recommended to set this to [code]true[/code] in most situations.
 		</member>
+		<member name="shadow_atlas_16_bits" type="bool" setter="set_shadow_atlas_16_bits" getter="is_shadow_atlas_16_bits" default="true">
+			If [code]true[/code], renders point light shadows on a buffer with 16-bit precision. This results in slightly better performance with usually no noticeable visual difference. If [code]false[/code], renders point light shadows on a buffer with 24-bit precision.
+		</member>
 		<member name="shadow_atlas_quad_0" type="int" setter="set_shadow_atlas_quadrant_subdiv" getter="get_shadow_atlas_quadrant_subdiv" enum="Viewport.ShadowAtlasQuadrantSubdiv" default="2">
 			The subdivision amount of the first quadrant on the shadow atlas.
 		</member>

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -3182,8 +3182,9 @@
 			<return type="void" />
 			<argument index="0" name="viewport" type="RID" />
 			<argument index="1" name="size" type="int" />
+			<argument index="2" name="use_16_bits" type="bool" default="true" />
 			<description>
-				Sets the size of the shadow atlas's images (used for omni and spot lights). The value will be rounded up to the nearest power of 2.
+				Sets the size of the shadow atlas's images (used for omni and spot lights). The value will be rounded up to the nearest power of 2. If [code]use_16_bits[/code] is [code]true[/code], renders point light shadows on a buffer with 16-bit precision. This results in slightly better performance with usually no noticeable visual difference. If [code]use_16_bits[/code] is [code]false[/code], renders point light shadows on a buffer with 24-bit precision.
 			</description>
 		</method>
 		<method name="viewport_set_sharpen_intensity">

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -42,7 +42,7 @@ public:
 	/* SHADOW ATLAS API */
 
 	RID shadow_atlas_create() { return RID(); }
-	void shadow_atlas_set_size(RID p_atlas, int p_size) {}
+	void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = true) {}
 	void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) {}
 	bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version) { return false; }
 

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -76,6 +76,7 @@ void RasterizerSceneGLES2::directional_shadow_create() {
 
 	directional_shadow.light_count = 0;
 	directional_shadow.size = next_power_of_2(directional_shadow_size);
+	directional_shadow.use_16_bits = directional_shadow_16_bits;
 
 	if (directional_shadow.size > storage->config.max_viewport_dimensions[0] || directional_shadow.size > storage->config.max_viewport_dimensions[1]) {
 		WARN_PRINT("Cannot set directional shadow size larger than maximum hardware supported size of (" + itos(storage->config.max_viewport_dimensions[0]) + ", " + itos(storage->config.max_viewport_dimensions[1]) + "). Setting size to maximum.");
@@ -90,7 +91,7 @@ void RasterizerSceneGLES2::directional_shadow_create() {
 		//maximum compatibility, renderbuffer and RGBA shadow
 		glGenRenderbuffers(1, &directional_shadow.depth);
 		glBindRenderbuffer(GL_RENDERBUFFER, directional_shadow.depth);
-		glRenderbufferStorage(GL_RENDERBUFFER, storage->config.depth_buffer_internalformat, directional_shadow.size, directional_shadow.size);
+		glRenderbufferStorage(GL_RENDERBUFFER, directional_shadow.use_16_bits ? GL_DEPTH_COMPONENT16 : storage->config.depth_buffer_internalformat, directional_shadow.size, directional_shadow.size);
 		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, directional_shadow.depth);
 
 		glGenTextures(1, &directional_shadow.color);
@@ -106,7 +107,7 @@ void RasterizerSceneGLES2::directional_shadow_create() {
 		glGenTextures(1, &directional_shadow.depth);
 		glBindTexture(GL_TEXTURE_2D, directional_shadow.depth);
 
-		glTexImage2D(GL_TEXTURE_2D, 0, storage->config.depth_internalformat, directional_shadow.size, directional_shadow.size, 0, GL_DEPTH_COMPONENT, storage->config.depth_type, nullptr);
+		glTexImage2D(GL_TEXTURE_2D, 0, directional_shadow.use_16_bits ? GL_DEPTH_COMPONENT16 : storage->config.depth_internalformat, directional_shadow.size, directional_shadow.size, 0, GL_DEPTH_COMPONENT, storage->config.depth_type, nullptr);
 
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -130,6 +131,7 @@ RID RasterizerSceneGLES2::shadow_atlas_create() {
 	shadow_atlas->depth = 0;
 	shadow_atlas->color = 0;
 	shadow_atlas->size = 0;
+	shadow_atlas->use_16_bits = true;
 	shadow_atlas->smallest_subdiv = 0;
 
 	for (int i = 0; i < 4; i++) {
@@ -139,14 +141,14 @@ RID RasterizerSceneGLES2::shadow_atlas_create() {
 	return shadow_atlas_owner.make_rid(shadow_atlas);
 }
 
-void RasterizerSceneGLES2::shadow_atlas_set_size(RID p_atlas, int p_size) {
+void RasterizerSceneGLES2::shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits) {
 	ShadowAtlas *shadow_atlas = shadow_atlas_owner.getornull(p_atlas);
 	ERR_FAIL_COND(!shadow_atlas);
 	ERR_FAIL_COND(p_size < 0);
 
 	p_size = next_power_of_2(p_size);
 
-	if (p_size == shadow_atlas->size) {
+	if (p_size == shadow_atlas->size && p_16_bits == shadow_atlas->use_16_bits) {
 		return;
 	}
 
@@ -177,6 +179,7 @@ void RasterizerSceneGLES2::shadow_atlas_set_size(RID p_atlas, int p_size) {
 	shadow_atlas->shadow_owners.clear();
 
 	shadow_atlas->size = p_size;
+	shadow_atlas->use_16_bits = p_16_bits;
 
 	if (shadow_atlas->size) {
 		glGenFramebuffers(1, &shadow_atlas->fbo);
@@ -195,7 +198,7 @@ void RasterizerSceneGLES2::shadow_atlas_set_size(RID p_atlas, int p_size) {
 			//maximum compatibility, renderbuffer and RGBA shadow
 			glGenRenderbuffers(1, &shadow_atlas->depth);
 			glBindRenderbuffer(GL_RENDERBUFFER, shadow_atlas->depth);
-			glRenderbufferStorage(GL_RENDERBUFFER, storage->config.depth_buffer_internalformat, shadow_atlas->size, shadow_atlas->size);
+			glRenderbufferStorage(GL_RENDERBUFFER, shadow_atlas->use_16_bits ? GL_DEPTH_COMPONENT16 : storage->config.depth_buffer_internalformat, shadow_atlas->size, shadow_atlas->size);
 			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, shadow_atlas->depth);
 
 			glGenTextures(1, &shadow_atlas->color);
@@ -210,7 +213,7 @@ void RasterizerSceneGLES2::shadow_atlas_set_size(RID p_atlas, int p_size) {
 			//just depth texture
 			glGenTextures(1, &shadow_atlas->depth);
 			glBindTexture(GL_TEXTURE_2D, shadow_atlas->depth);
-			glTexImage2D(GL_TEXTURE_2D, 0, storage->config.depth_internalformat, shadow_atlas->size, shadow_atlas->size, 0, GL_DEPTH_COMPONENT, storage->config.depth_type, nullptr);
+			glTexImage2D(GL_TEXTURE_2D, 0, shadow_atlas->use_16_bits ? GL_DEPTH_COMPONENT16 : storage->config.depth_internalformat, shadow_atlas->size, shadow_atlas->size, 0, GL_DEPTH_COMPONENT, storage->config.depth_type, nullptr);
 
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -4111,8 +4114,10 @@ void RasterizerSceneGLES2::iteration() {
 	shadow_filter_mode = ShadowFilterMode(int(GLOBAL_GET("rendering/quality/shadows/filter_mode")));
 
 	const int directional_shadow_size_new = next_power_of_2(int(GLOBAL_GET("rendering/quality/directional_shadow/size")));
-	if (directional_shadow_size != directional_shadow_size_new) {
+	const bool directional_shadow_16_bits_new = bool(GLOBAL_GET("rendering/quality/directional_shadow/16_bits"));
+	if (directional_shadow_size != directional_shadow_size_new || directional_shadow_16_bits_new != directional_shadow_16_bits) {
 		directional_shadow_size = directional_shadow_size_new;
+		directional_shadow_16_bits = directional_shadow_16_bits_new;
 		directional_shadow_create();
 	}
 }
@@ -4123,6 +4128,7 @@ void RasterizerSceneGLES2::finalize() {
 RasterizerSceneGLES2::RasterizerSceneGLES2() {
 	_light_counter = 0;
 	directional_shadow_size = next_power_of_2(int(GLOBAL_GET("rendering/quality/directional_shadow/size")));
+	directional_shadow_16_bits = bool(GLOBAL_GET("rendering/quality/directional_shadow/16_bits"));
 }
 
 RasterizerSceneGLES2::~RasterizerSceneGLES2() {

--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -259,6 +259,7 @@ public:
 		uint32_t smallest_subdiv;
 
 		int size;
+		bool use_16_bits;
 
 		GLuint fbo;
 		GLuint depth;
@@ -278,11 +279,12 @@ public:
 	RID_Owner<ShadowAtlas> shadow_atlas_owner;
 
 	int directional_shadow_size;
+	bool directional_shadow_16_bits;
 
 	void directional_shadow_create();
 
 	RID shadow_atlas_create();
-	void shadow_atlas_set_size(RID p_atlas, int p_size);
+	void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = true);
 	void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision);
 	bool _shadow_atlas_find_shadow(ShadowAtlas *shadow_atlas, int *p_in_quadrants, int p_quadrant_count, int p_current_subdiv, uint64_t p_tick, int &r_quadrant, int &r_shadow);
 	bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version);
@@ -294,6 +296,7 @@ public:
 
 		int light_count = 0;
 		int size = 0;
+		bool use_16_bits = true;
 		int current_light = 0;
 	} directional_shadow;
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -91,11 +91,12 @@ void RasterizerSceneGLES3::directional_shadow_create() {
 
 	directional_shadow.light_count = 0;
 	directional_shadow.size = next_power_of_2(directional_shadow_size);
+	directional_shadow.use_16_bits = directional_shadow_16_bits;
 	glGenFramebuffers(1, &directional_shadow.fbo);
 	glBindFramebuffer(GL_FRAMEBUFFER, directional_shadow.fbo);
 	glGenTextures(1, &directional_shadow.depth);
 	glBindTexture(GL_TEXTURE_2D, directional_shadow.depth);
-	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, directional_shadow.size, directional_shadow.size, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
+	glTexImage2D(GL_TEXTURE_2D, 0, directional_shadow.use_16_bits ? GL_DEPTH_COMPONENT16 : GL_DEPTH_COMPONENT24, directional_shadow.size, directional_shadow.size, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
@@ -115,6 +116,7 @@ RID RasterizerSceneGLES3::shadow_atlas_create() {
 	shadow_atlas->fbo = 0;
 	shadow_atlas->depth = 0;
 	shadow_atlas->size = 0;
+	shadow_atlas->use_16_bits = true;
 	shadow_atlas->smallest_subdiv = 0;
 
 	for (int i = 0; i < 4; i++) {
@@ -124,14 +126,14 @@ RID RasterizerSceneGLES3::shadow_atlas_create() {
 	return shadow_atlas_owner.make_rid(shadow_atlas);
 }
 
-void RasterizerSceneGLES3::shadow_atlas_set_size(RID p_atlas, int p_size) {
+void RasterizerSceneGLES3::shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits) {
 	ShadowAtlas *shadow_atlas = shadow_atlas_owner.getornull(p_atlas);
 	ERR_FAIL_COND(!shadow_atlas);
 	ERR_FAIL_COND(p_size < 0);
 
 	p_size = next_power_of_2(p_size);
 
-	if (p_size == shadow_atlas->size) {
+	if (p_size == shadow_atlas->size && p_16_bits == shadow_atlas->use_16_bits) {
 		return;
 	}
 
@@ -160,6 +162,7 @@ void RasterizerSceneGLES3::shadow_atlas_set_size(RID p_atlas, int p_size) {
 	shadow_atlas->shadow_owners.clear();
 
 	shadow_atlas->size = p_size;
+	shadow_atlas->use_16_bits = p_16_bits;
 
 	if (shadow_atlas->size) {
 		glGenFramebuffers(1, &shadow_atlas->fbo);
@@ -169,7 +172,7 @@ void RasterizerSceneGLES3::shadow_atlas_set_size(RID p_atlas, int p_size) {
 		glActiveTexture(GL_TEXTURE0);
 		glGenTextures(1, &shadow_atlas->depth);
 		glBindTexture(GL_TEXTURE_2D, shadow_atlas->depth);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT24, shadow_atlas->size, shadow_atlas->size, 0,
+		glTexImage2D(GL_TEXTURE_2D, 0, shadow_atlas->use_16_bits ? GL_DEPTH_COMPONENT16 : GL_DEPTH_COMPONENT24, shadow_atlas->size, shadow_atlas->size, 0,
 				GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
 
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
@@ -5329,8 +5332,10 @@ void RasterizerSceneGLES3::iteration() {
 	shadow_filter_mode = ShadowFilterMode(int(GLOBAL_GET("rendering/quality/shadows/filter_mode")));
 
 	const int directional_shadow_size_new = next_power_of_2(int(GLOBAL_GET("rendering/quality/directional_shadow/size")));
-	if (directional_shadow_size != directional_shadow_size_new) {
+	const bool directional_shadow_16_bits_new = bool(GLOBAL_GET("rendering/quality/directional_shadow/16_bits"));
+	if (directional_shadow_size != directional_shadow_size_new || directional_shadow_16_bits_new != directional_shadow_16_bits) {
 		directional_shadow_size = directional_shadow_size_new;
+		directional_shadow_16_bits = directional_shadow_16_bits_new;
 		directional_shadow_create();
 	}
 
@@ -5349,6 +5354,7 @@ void RasterizerSceneGLES3::finalize() {
 
 RasterizerSceneGLES3::RasterizerSceneGLES3() {
 	directional_shadow_size = next_power_of_2(int(GLOBAL_GET("rendering/quality/directional_shadow/size")));
+	directional_shadow_16_bits = bool(GLOBAL_GET("rendering/quality/directional_shadow/16_bits"));
 }
 
 RasterizerSceneGLES3::~RasterizerSceneGLES3() {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -251,6 +251,7 @@ public:
 		uint32_t smallest_subdiv;
 
 		int size;
+		bool use_16_bits;
 
 		GLuint fbo;
 		GLuint depth;
@@ -269,10 +270,11 @@ public:
 	RID_Owner<ShadowAtlas> shadow_atlas_owner;
 
 	int directional_shadow_size;
+	bool directional_shadow_16_bits;
 
 	void directional_shadow_create();
 	RID shadow_atlas_create();
-	void shadow_atlas_set_size(RID p_atlas, int p_size);
+	void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = true);
 	void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision);
 	bool _shadow_atlas_find_shadow(ShadowAtlas *shadow_atlas, int *p_in_quadrants, int p_quadrant_count, int p_current_subdiv, uint64_t p_tick, int &r_quadrant, int &r_shadow);
 	bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version);
@@ -282,6 +284,7 @@ public:
 		GLuint depth = 0;
 		int light_count = 0;
 		int size = 0;
+		bool use_16_bits = true;
 		int current_light = 0;
 	} directional_shadow;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1354,11 +1354,24 @@ void Viewport::set_shadow_atlas_size(int p_size) {
 	}
 
 	shadow_atlas_size = p_size;
-	VS::get_singleton()->viewport_set_shadow_atlas_size(viewport, p_size);
+	VS::get_singleton()->viewport_set_shadow_atlas_size(viewport, p_size, shadow_atlas_16_bits);
 }
 
 int Viewport::get_shadow_atlas_size() const {
 	return shadow_atlas_size;
+}
+
+void Viewport::set_shadow_atlas_16_bits(bool p_16_bits) {
+	if (shadow_atlas_16_bits == p_16_bits) {
+		return;
+	}
+
+	shadow_atlas_16_bits = p_16_bits;
+	VS::get_singleton()->viewport_set_shadow_atlas_size(viewport, shadow_atlas_size, p_16_bits);
+}
+
+bool Viewport::is_shadow_atlas_16_bits() const {
+	return shadow_atlas_16_bits;
 }
 
 void Viewport::set_shadow_atlas_quadrant_subdiv(int p_quadrant, ShadowAtlasQuadrantSubdiv p_subdiv) {
@@ -3346,6 +3359,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shadow_atlas_size", "size"), &Viewport::set_shadow_atlas_size);
 	ClassDB::bind_method(D_METHOD("get_shadow_atlas_size"), &Viewport::get_shadow_atlas_size);
 
+	ClassDB::bind_method(D_METHOD("set_shadow_atlas_16_bits", "16_bits"), &Viewport::set_shadow_atlas_16_bits);
+	ClassDB::bind_method(D_METHOD("is_shadow_atlas_16_bits"), &Viewport::is_shadow_atlas_16_bits);
+
 	ClassDB::bind_method(D_METHOD("set_snap_controls_to_pixels", "enabled"), &Viewport::set_snap_controls_to_pixels);
 	ClassDB::bind_method(D_METHOD("is_snap_controls_to_pixels_enabled"), &Viewport::is_snap_controls_to_pixels_enabled);
 
@@ -3399,6 +3415,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "gui_snap_controls_to_pixels"), "set_snap_controls_to_pixels", "is_snap_controls_to_pixels_enabled");
 	ADD_GROUP("Shadow Atlas", "shadow_atlas_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "shadow_atlas_size", PROPERTY_HINT_RANGE, "0,16384,256"), "set_shadow_atlas_size", "get_shadow_atlas_size");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shadow_atlas_16_bits"), "set_shadow_atlas_16_bits", "is_shadow_atlas_16_bits");
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "shadow_atlas_quad_0", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"), "set_shadow_atlas_quadrant_subdiv", "get_shadow_atlas_quadrant_subdiv", 0);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "shadow_atlas_quad_1", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"), "set_shadow_atlas_quadrant_subdiv", "get_shadow_atlas_quadrant_subdiv", 1);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "shadow_atlas_quad_2", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"), "set_shadow_atlas_quadrant_subdiv", "get_shadow_atlas_quadrant_subdiv", 2);
@@ -3502,6 +3519,7 @@ Viewport::Viewport() {
 	physics_last_mousepos = Vector2(Math_INF, Math_INF);
 
 	shadow_atlas_size = 0;
+	shadow_atlas_16_bits = true;
 	for (int i = 0; i < 4; i++) {
 		shadow_atlas_quadrant_subdiv[i] = SHADOW_ATLAS_QUADRANT_SUBDIV_MAX;
 	}

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -279,6 +279,7 @@ private:
 	Usage usage;
 
 	int shadow_atlas_size;
+	bool shadow_atlas_16_bits;
 	ShadowAtlasQuadrantSubdiv shadow_atlas_quadrant_subdiv[4];
 
 	MSAA msaa;
@@ -504,6 +505,9 @@ public:
 
 	void set_shadow_atlas_size(int p_size);
 	int get_shadow_atlas_size() const;
+
+	void set_shadow_atlas_16_bits(bool p_16_bits);
+	bool is_shadow_atlas_16_bits() const;
 
 	void set_shadow_atlas_quadrant_subdiv(int p_quadrant, ShadowAtlasQuadrantSubdiv p_subdiv);
 	ShadowAtlasQuadrantSubdiv get_shadow_atlas_quadrant_subdiv(int p_quadrant) const;

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -42,7 +42,7 @@ public:
 	/* SHADOW ATLAS API */
 
 	virtual RID shadow_atlas_create() = 0;
-	virtual void shadow_atlas_set_size(RID p_atlas, int p_size) = 0;
+	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = true) = 0;
 	virtual void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) = 0;
 	virtual bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version) = 0;
 

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -511,7 +511,7 @@ public:
 
 	BIND2(viewport_set_global_canvas_transform, RID, const Transform2D &)
 	BIND4(viewport_set_canvas_stacking, RID, RID, int, int)
-	BIND2(viewport_set_shadow_atlas_size, RID, int)
+	BIND3(viewport_set_shadow_atlas_size, RID, int, bool)
 	BIND3(viewport_set_shadow_atlas_quadrant_subdivision, RID, int, int)
 	BIND2(viewport_set_msaa, RID, ViewportMSAA)
 	BIND2(viewport_set_use_fxaa, RID, bool)

--- a/servers/visual/visual_server_viewport.cpp
+++ b/servers/visual/visual_server_viewport.cpp
@@ -610,13 +610,14 @@ void VisualServerViewport::viewport_set_canvas_stacking(RID p_viewport, RID p_ca
 	viewport->canvas_map[p_canvas].sublayer = p_sublayer;
 }
 
-void VisualServerViewport::viewport_set_shadow_atlas_size(RID p_viewport, int p_size) {
+void VisualServerViewport::viewport_set_shadow_atlas_size(RID p_viewport, int p_size, bool p_16_bits) {
 	Viewport *viewport = viewport_owner.getornull(p_viewport);
 	ERR_FAIL_COND(!viewport);
 
 	viewport->shadow_atlas_size = p_size;
+	viewport->shadow_atlas_16_bits = p_16_bits;
 
-	VSG::scene_render->shadow_atlas_set_size(viewport->shadow_atlas, viewport->shadow_atlas_size);
+	VSG::scene_render->shadow_atlas_set_size(viewport->shadow_atlas, viewport->shadow_atlas_size, viewport->shadow_atlas_16_bits);
 }
 
 void VisualServerViewport::viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv) {

--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -68,6 +68,7 @@ public:
 
 		RID shadow_atlas;
 		int shadow_atlas_size;
+		bool shadow_atlas_16_bits;
 
 		int render_info[VS::VIEWPORT_RENDER_INFO_MAX];
 		VS::ViewportDebugDraw debug_draw;
@@ -114,6 +115,7 @@ public:
 			disable_environment = false;
 			viewport_to_screen = 0;
 			shadow_atlas_size = 0;
+			shadow_atlas_16_bits = true;
 			disable_3d = false;
 			disable_3d_by_usage = false;
 			keep_3d_linear = false;
@@ -182,7 +184,7 @@ public:
 	void viewport_set_global_canvas_transform(RID p_viewport, const Transform2D &p_transform);
 	void viewport_set_canvas_stacking(RID p_viewport, RID p_canvas, int p_layer, int p_sublayer);
 
-	void viewport_set_shadow_atlas_size(RID p_viewport, int p_size);
+	void viewport_set_shadow_atlas_size(RID p_viewport, int p_size, bool p_16_bits = true);
 	void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv);
 
 	void viewport_set_msaa(RID p_viewport, VS::ViewportMSAA p_msaa);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -419,7 +419,7 @@ public:
 
 	FUNC2(viewport_set_global_canvas_transform, RID, const Transform2D &)
 	FUNC4(viewport_set_canvas_stacking, RID, RID, int, int)
-	FUNC2(viewport_set_shadow_atlas_size, RID, int)
+	FUNC3(viewport_set_shadow_atlas_size, RID, int, bool)
 	FUNC3(viewport_set_shadow_atlas_quadrant_subdivision, RID, int, int)
 	FUNC2(viewport_set_msaa, RID, ViewportMSAA)
 	FUNC2(viewport_set_use_fxaa, RID, bool)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2094,7 +2094,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_transparent_background", "viewport", "enabled"), &VisualServer::viewport_set_transparent_background);
 	ClassDB::bind_method(D_METHOD("viewport_set_global_canvas_transform", "viewport", "transform"), &VisualServer::viewport_set_global_canvas_transform);
 	ClassDB::bind_method(D_METHOD("viewport_set_canvas_stacking", "viewport", "canvas", "layer", "sublayer"), &VisualServer::viewport_set_canvas_stacking);
-	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_size", "viewport", "size"), &VisualServer::viewport_set_shadow_atlas_size);
+	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_size", "viewport", "size", "use_16_bits"), &VisualServer::viewport_set_shadow_atlas_size, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_quadrant_subdivision", "viewport", "quadrant", "subdivision"), &VisualServer::viewport_set_shadow_atlas_quadrant_subdivision);
 	ClassDB::bind_method(D_METHOD("viewport_set_msaa", "viewport", "msaa"), &VisualServer::viewport_set_msaa);
 	ClassDB::bind_method(D_METHOD("viewport_set_use_fxaa", "viewport", "fxaa"), &VisualServer::viewport_set_use_fxaa);
@@ -2639,11 +2639,13 @@ VisualServer::VisualServer() {
 	GLOBAL_DEF("rendering/quality/directional_shadow/size", 4096);
 	GLOBAL_DEF("rendering/quality/directional_shadow/size.mobile", 2048);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/directional_shadow/size", PropertyInfo(Variant::INT, "rendering/quality/directional_shadow/size", PROPERTY_HINT_RANGE, "256,16384,256"));
+	GLOBAL_DEF("rendering/quality/directional_shadow/16_bits", true);
 	GLOBAL_DEF_RST("rendering/quality/shadow_atlas/size", 4096);
 	GLOBAL_DEF("rendering/quality/shadow_atlas/size.mobile", 2048);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/size", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/size", PROPERTY_HINT_RANGE, "256,16384,256"));
 	GLOBAL_DEF_RST("rendering/quality/shadow_atlas/cubemap_size", 512);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/quality/shadow_atlas/cubemap_size", PropertyInfo(Variant::INT, "rendering/quality/shadow_atlas/cubemap_size", PROPERTY_HINT_RANGE, "64,16384,64"));
+	GLOBAL_DEF_RST("rendering/quality/shadow_atlas/16_bits", true);
 	GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_0_subdiv", 1);
 	GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_1_subdiv", 2);
 	GLOBAL_DEF("rendering/quality/shadow_atlas/quadrant_2_subdiv", 3);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -693,7 +693,7 @@ public:
 	virtual void viewport_set_global_canvas_transform(RID p_viewport, const Transform2D &p_transform) = 0;
 	virtual void viewport_set_canvas_stacking(RID p_viewport, RID p_canvas, int p_layer, int p_sublayer) = 0;
 
-	virtual void viewport_set_shadow_atlas_size(RID p_viewport, int p_size) = 0;
+	virtual void viewport_set_shadow_atlas_size(RID p_viewport, int p_size, bool p_16_bits = true) = 0;
 	virtual void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv) = 0;
 
 	enum ViewportMSAA {


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/54165.

This results in slightly faster rendering with no discernible visual difference in most scenes. Both GLES3 and GLES2 support this option, which is also enabled by default.

Please test on various platforms, especially Android, iOS and HTML5 :slightly_smiling_face: 

**Testing project:** [test_shadow_16_bits_3.x.zip](https://github.com/godotengine/godot/files/7965083/test_shadow_16_bits_3.x.zip)

## Preview

Tested on a GeForce GTX 1080 in 2560×1440.

*The performance difference is very slight here, but in a more complex scene with more lights, it would be more significant.*

### GLES3

| 24-bit | 16-bit | Difference ([dssim](https://github.com/kornelski/dssim)) |
|-|-|-|
| ![2022-01-30_01 33 56](https://user-images.githubusercontent.com/180032/151682793-c6917c54-9f08-4dea-920d-d299608b21b4.png) | ![2022-01-30_01 35 03](https://user-images.githubusercontent.com/180032/151682794-57b114b3-3da8-4e67-8d25-11917caa91a1.png) | ![d-0](https://user-images.githubusercontent.com/180032/151682807-2a92975c-a572-4100-a50a-0dc0a7499d15.png) |

### GLES2

| 24-bit | 16-bit | Difference ([dssim](https://github.com/kornelski/dssim)) |
|-|-|-|
| ![2022-01-30_01 35 55](https://user-images.githubusercontent.com/180032/151682795-ef42e55c-ac6e-45e1-8ed5-89eb5a182e69.png) | ![2022-01-30_01 37 12](https://user-images.githubusercontent.com/180032/151682796-3334b177-c922-4318-8ea7-d9b7b4400b9d.png) | ![d_gles2-0](https://user-images.githubusercontent.com/180032/151682803-1beed019-e914-4016-8da5-c8e1014d05a0.png) |