### PR TITLE
Fixed enum comparison causing Invalid Operand error when using type annotation

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -520,6 +520,8 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 						break;
 					case GDScriptParser::ClassNode::Member::ENUM:
 						result = member.m_enum->get_datatype();
+						result.is_constant = true;
+						result.builtin_type = Variant::INT;
 						found = true;
 						break;
 					case GDScriptParser::ClassNode::Member::CONSTANT:

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_typed_variable_compare.gd
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_typed_variable_compare.gd
@@ -1,0 +1,7 @@
+enum Named { VALUE_A, VALUE_B }
+
+func test():
+    var typed_variable_A : Named = Named.VALUE_A
+    prints(typed_variable_A == Named.VALUE_A)
+    prints(typed_variable_A == Named.VALUE_B)
+    

--- a/modules/gdscript/tests/scripts/analyzer/errors/enum_typed_variable_compare.out
+++ b/modules/gdscript/tests/scripts/analyzer/errors/enum_typed_variable_compare.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+true
+false

--- a/modules/gdscript/tests/scripts/analyzer/features/enum_compare_with_int.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/enum_compare_with_int.gd
@@ -1,0 +1,5 @@
+enum Named { VALUE_A, VALUE_B }
+
+func test():
+    prints(Named.VALUE_A == 0)
+    prints(Named.VALUE_B == 0)

--- a/modules/gdscript/tests/scripts/analyzer/features/enum_compare_with_int.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/enum_compare_with_int.out
@@ -1,0 +1,3 @@
+GDTEST_OK
+true
+false


### PR DESCRIPTION
Fixes #56878

I'm not entirely sure this is the best way to fix this so please check it before merging.

Also included two test cases.