### PR TITLE
[3.x] Make WebXR touch events proportional to render target size, not viewport

### DIFF
--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -554,16 +554,9 @@ Vector2 WebXRInterfaceJS::_get_joy_vector_from_axes(int *p_axes) {
 }
 
 Vector2 WebXRInterfaceJS::_get_screen_position_from_joy_vector(const Vector2 &p_joy_vector) {
-	SceneTree *scene_tree = Object::cast_to<SceneTree>(OS::get_singleton()->get_main_loop());
-	if (!scene_tree) {
-		return Vector2();
-	}
-
-	Viewport *viewport = scene_tree->get_root();
-
 	// Invert the y-axis.
 	Vector2 position_percentage((p_joy_vector.x + 1.0f) / 2.0f, ((-p_joy_vector.y) + 1.0f) / 2.0f);
-	Vector2 position = viewport->get_size() * position_percentage;
+	Vector2 position = get_render_targetsize() * position_percentage;
 
 	return position;
 }


### PR DESCRIPTION
This is a fix to #56819 which is only in 3.x.

The position of touch events was previously proportional to the viewport. This is problematic when the render target from WebXR is a different size than the viewport - the touches will be in the wrong place.

_(Note: This isn't the ideal fix - it would be better if the viewport resized to match the render target, but for some reason that isn't "sticking". I suspect this may require some deeper changes in the HTML5 platform. But that's for a future PR!)_