### PR TITLE
Prevent LTCG (MSVC LTO) from removing "pck" section

### DIFF
--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -140,6 +140,11 @@ int widechar_main(int argc, wchar_t **argv) {
 
 	setlocale(LC_CTYPE, "");
 
+#ifndef TOOLS_ENABLED
+	// Workaround to prevent LTCG (MSVC LTO) from removing "pck" section
+	char *dummy_guard = dummy;
+#endif
+
 	char **argv_utf8 = new char *[argc];
 
 	for (int i = 0; i < argc; ++i) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/35590

[MSVC](https://docs.microsoft.com/en-us/cpp/preprocessor/section?view=msvc-170) doesn't have equivalent of GCC `__attribute__((used))` so this is the easiest workaround I could think of to prevent removing unused section.