### PR TITLE
Fix button icon_disabled_color alpha channel

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -197,6 +197,8 @@ void Button::_notification(int p_what) {
 					color = get_theme_color(SNAME("font_disabled_color"));
 					if (has_theme_color(SNAME("icon_disabled_color"))) {
 						color_icon = get_theme_color(SNAME("icon_disabled_color"));
+					} else {
+						color_icon.a = 0.4;
 					}
 
 				} break;
@@ -232,9 +234,6 @@ void Button::_notification(int p_what) {
 			}
 			if (!_icon.is_null()) {
 				int valign = size.height - style->get_minimum_size().y;
-				if (is_disabled()) {
-					color_icon.a = 0.4;
-				}
 
 				float icon_ofs_region = 0.0;
 				Point2 style_offset;


### PR DESCRIPTION
Alpha is hard-coded to 0.4 for icons when a button is disabled. This change will respect the theme's icon color instead.

See https://github.com/godotengine/godot/pull/57459 for the 3.x PR