### PR TITLE
Fix Rect2i.intersects doc: Remove nonexistent parameter from documentation

### DIFF
--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -152,7 +152,6 @@
 			<argument index="0" name="b" type="Rect2i" />
 			<description>
 				Returns [code]true[/code] if the [Rect2i] overlaps with [code]b[/code] (i.e. they have at least one point in common).
-				If [code]include_borders[/code] is [code]true[/code], they will also be considered overlapping if their borders touch, even without intersection.
 			</description>
 		</method>
 		<method name="merge" qualifiers="const">


### PR DESCRIPTION
Since the function `Rect2i.intersects` doesn't have a parameter of the name `include_borders`, in should be removed from the documentation.
It seems like this is a copy and paste error from `Rect2`.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
