### PR TITLE
Fix incorrect Rect2i calculations: intersects and encloses

### DIFF
--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -382,16 +382,16 @@ struct _NO_DISCARD_ Rect2i {
 			ERR_PRINT("Rect2i size is negative, this is not supported. Use Rect2i.abs() to get a Rect2i with a positive size.");
 		}
 #endif
-		if (position.x > (p_rect.position.x + p_rect.size.width)) {
+		if (position.x >= (p_rect.position.x + p_rect.size.width)) {
 			return false;
 		}
-		if ((position.x + size.width) < p_rect.position.x) {
+		if ((position.x + size.width) <= p_rect.position.x) {
 			return false;
 		}
-		if (position.y > (p_rect.position.y + p_rect.size.height)) {
+		if (position.y >= (p_rect.position.y + p_rect.size.height)) {
 			return false;
 		}
-		if ((position.y + size.height) < p_rect.position.y) {
+		if ((position.y + size.height) <= p_rect.position.y) {
 			return false;
 		}
 
@@ -405,8 +405,8 @@ struct _NO_DISCARD_ Rect2i {
 		}
 #endif
 		return (p_rect.position.x >= position.x) && (p_rect.position.y >= position.y) &&
-				((p_rect.position.x + p_rect.size.x) < (position.x + size.x)) &&
-				((p_rect.position.y + p_rect.size.y) < (position.y + size.y));
+				((p_rect.position.x + p_rect.size.x) <= (position.x + size.x)) &&
+				((p_rect.position.y + p_rect.size.y) <= (position.y + size.y));
 	}
 
 	_FORCE_INLINE_ bool has_no_area() const {

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -70,7 +70,7 @@
 			<return type="Rect2i" />
 			<argument index="0" name="to" type="Vector2i" />
 			<description>
-				Returns a copy of this [Rect2i] expanded to include a given point.
+				Returns a copy of this [Rect2i] expanded so that the borders align with the given point.
 				[codeblocks]
 				[gdscript]
 				# position (-3, 2), size (1, 1)

--- a/tests/core/math/test_rect2.h
+++ b/tests/core/math/test_rect2.h
@@ -439,6 +439,9 @@ TEST_CASE("[Rect2i] Enclosing") {
 	CHECK_MESSAGE(
 			!Rect2i(0, 100, 1280, 720).encloses(Rect2i(-4000, -4000, 100, 100)),
 			"encloses() with non-contained Rect2i should return the expected result.");
+	CHECK_MESSAGE(
+			Rect2i(0, 100, 1280, 720).encloses(Rect2i(0, 100, 1280, 720)),
+			"encloses() with identical Rect2i should return the expected result.");
 }
 
 TEST_CASE("[Rect2i] Expanding") {
@@ -557,6 +560,9 @@ TEST_CASE("[Rect2i] Intersection") {
 	CHECK_MESSAGE(
 			!Rect2i(0, 100, 1280, 720).intersects(Rect2i(-4000, -4000, 100, 100)),
 			"intersects() with non-enclosed Rect2i should return the expected result.");
+	CHECK_MESSAGE(
+			!Rect2i(0, 0, 2, 2).intersects(Rect2i(2, 2, 2, 2)),
+			"intersects() with adjacent Rect2i should return the expected result.");
 }
 
 TEST_CASE("[Rect2i] Merging") {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Correction of some border cases for Rect2i calculations.
Clarify expand documentation.
Added Unit tests for these cases.

resolves #57468