### PR TITLE
Backport improved look_at docs

### DIFF
--- a/doc/classes/Spatial.xml
+++ b/doc/classes/Spatial.xml
@@ -94,8 +94,9 @@
 			<argument index="0" name="target" type="Vector3" />
 			<argument index="1" name="up" type="Vector3" />
 			<description>
-				Rotates itself so that the local -Z axis points towards the [code]target[/code] position.
-				The transform will first be rotated around the given [code]up[/code] vector, and then fully aligned to the target by a further rotation around an axis perpendicular to both the [code]target[/code] and [code]up[/code] vectors.
+				Rotates the node so that the local forward axis (-Z) points toward the [code]target[/code] position.
+				The local up axis (+Y) points as close to the [code]up[/code] vector as possible while staying perpendicular to the local forward axis. The resulting transform is orthogonal, and the scale is preserved. Non-uniform scaling may not work correctly.
+				The [code]target[/code] position cannot be the same as the node's position, the [code]up[/code] vector cannot be zero, and the direction from the node's position to the [code]target[/code] vector cannot be parallel to the [code]up[/code] vector.
 				Operations take place in global space.
 			</description>
 		</method>

--- a/scene/3d/spatial.cpp
+++ b/scene/3d/spatial.cpp
@@ -668,6 +668,7 @@ void Spatial::look_at(const Vector3 &p_target, const Vector3 &p_up) {
 
 void Spatial::look_at_from_position(const Vector3 &p_pos, const Vector3 &p_target, const Vector3 &p_up) {
 	ERR_FAIL_COND_MSG(p_pos == p_target, "Node origin and target are in the same position, look_at() failed.");
+	ERR_FAIL_COND_MSG(p_up == Vector3(), "The up vector can't be zero, look_at() failed.");
 	ERR_FAIL_COND_MSG(p_up.cross(p_target - p_pos) == Vector3(), "Up vector and direction between node origin and target are aligned, look_at() failed.");
 
 	Transform lookat;


### PR DESCRIPTION
Take extra constraint info and function description from Node3D.look_at to improve Spatial.look_at docs.

The implementations of Spatial.look_at and Node3D.look_at are marginally different, but all the claims appear to still be valid.

Resolves #57457.