### PR TITLE
Replace the `Color::from_string` method with a constructor

### DIFF
--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -453,16 +453,6 @@ Color Color::get_named_color(int p_idx) {
 	return named_colors[p_idx].color;
 }
 
-// For a version that errors on invalid values instead of returning
-// a default color, use the Color(String) constructor instead.
-Color Color::from_string(const String &p_string, const Color &p_default) {
-	if (html_is_valid(p_string)) {
-		return html(p_string);
-	} else {
-		return named(p_string, p_default);
-	}
-}
-
 Color Color::from_hsv(float p_h, float p_s, float p_v, float p_alpha) {
 	Color c;
 	c.set_hsv(p_h, p_s, p_v, p_alpha);

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -198,7 +198,6 @@ struct _NO_DISCARD_ Color {
 	static int get_named_color_count();
 	static String get_named_color_name(int p_idx);
 	static Color get_named_color(int p_idx);
-	static Color from_string(const String &p_string, const Color &p_default);
 	static Color from_hsv(float p_h, float p_s, float p_v, float p_alpha = 1.0f);
 	static Color from_ok_hsl(float p_h, float p_s, float p_l, float p_alpha = 1.0f);
 	static Color from_rgbe9995(uint32_t p_rgbe);
@@ -261,6 +260,14 @@ struct _NO_DISCARD_ Color {
 			*this = html(p_code);
 		} else {
 			*this = named(p_code);
+		}
+	}
+
+	Color(const String &p_code, const Color &p_default) {
+		if (html_is_valid(p_code)) {
+			*this = html(p_code);
+		} else {
+			*this = named(p_code, p_default);
 		}
 	}
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1839,7 +1839,6 @@ static void _register_variant_builtin_methods() {
 	bind_static_method(Color, get_named_color_count, sarray(), varray());
 	bind_static_method(Color, get_named_color_name, sarray("idx"), varray());
 	bind_static_method(Color, get_named_color, sarray("idx"), varray());
-	bind_static_method(Color, from_string, sarray("str", "default"), varray());
 	bind_static_method(Color, from_hsv, sarray("h", "s", "v", "alpha"), varray(1.0));
 	bind_static_method(Color, from_ok_hsl, sarray("h", "s", "l", "alpha"), varray(1.0));
 

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -170,6 +170,7 @@ void Variant::_register_variant_constructors() {
 	add_constructor<VariantConstructor<Color, double, double, double>>(sarray("r", "g", "b"));
 	add_constructor<VariantConstructor<Color, double, double, double, double>>(sarray("r", "g", "b", "a"));
 	add_constructor<VariantConstructor<Color, String>>(sarray("code"));
+	add_constructor<VariantConstructor<Color, String, Color>>(sarray("code", "default"));
 	add_constructor<VariantConstructor<Color, String, double>>(sarray("code", "alpha"));
 
 	add_constructor<VariantConstructNoArgs<StringName>>(sarray());

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -55,6 +55,14 @@
 		<constructor name="Color">
 			<return type="Color" />
 			<param index="0" name="code" type="String" />
+			<param index="1" name="default" type="Color" />
+			<description>
+				Constructs a [Color] either from an HTML color code or from a standardized color name. Supported color names are the same as the constants. Fallbacks to [param default] if the string does not denote any valid color.
+			</description>
+		</constructor>
+		<constructor name="Color">
+			<return type="Color" />
+			<param index="0" name="code" type="String" />
 			<param index="1" name="alpha" type="float" />
 			<description>
 				Constructs a [Color] either from an HTML color code or from a standardized color name, with [param alpha] on the range of 0 to 1. Supported color names are the same as the constants.
@@ -193,14 +201,6 @@
 			<param index="0" name="rgbe" type="int" />
 			<description>
 				Encodes a [Color] from a RGBE9995 format integer. See [constant Image.FORMAT_RGBE9995].
-			</description>
-		</method>
-		<method name="from_string" qualifiers="static">
-			<return type="Color" />
-			<param index="0" name="str" type="String" />
-			<param index="1" name="default" type="Color" />
-			<description>
-				Creates a [Color] from string, which can be either a HTML color code or a named color. Fallbacks to [param default] if the string does not denote any valid color.
 			</description>
 		</method>
 		<method name="get_luminance" qualifiers="const">

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -2033,7 +2033,7 @@ static void _add_text_to_rt(const String &p_bbcode, RichTextLabel *p_rt, Control
 			tag_stack.push_front(tag);
 		} else if (tag.begins_with("color=")) {
 			String col = tag.substr(6, tag.length());
-			Color color = Color::from_string(col, Color());
+			Color color = Color(col, Color());
 			p_rt->push_color(color);
 			pos = brk_end + 1;
 			tag_stack.push_front("color");

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3852,13 +3852,13 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 				Vector<String> subtag_a = subtag[i].split("=");
 				if (subtag_a.size() == 2) {
 					if (subtag_a[0] == "border") {
-						Color color = Color::from_string(subtag_a[1], fallback_color);
+						Color color = Color(subtag_a[1], fallback_color);
 						set_cell_border_color(color);
 					} else if (subtag_a[0] == "bg") {
 						Vector<String> subtag_b = subtag_a[1].split(",");
 						if (subtag_b.size() == 2) {
-							Color color1 = Color::from_string(subtag_b[0], fallback_color);
-							Color color2 = Color::from_string(subtag_b[1], fallback_color);
+							Color color1 = Color(subtag_b[0], fallback_color);
+							Color color2 = Color(subtag_b[1], fallback_color);
 							set_cell_row_background_color(color1, color2);
 						}
 					}
@@ -4089,9 +4089,9 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 					} else if (subtag_a[0] == "outline_size") {
 						outline_size = subtag_a[1].to_int();
 					} else if (subtag_a[0] == "color") {
-						color = Color::from_string(subtag_a[1], color);
+						color = Color(subtag_a[1], color);
 					} else if (subtag_a[0] == "outline_color") {
-						outline_color = Color::from_string(subtag_a[1], outline_color);
+						outline_color = Color(subtag_a[1], outline_color);
 					}
 				}
 			}
@@ -4162,7 +4162,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 				Color color = Color(1.0, 1.0, 1.0);
 				OptionMap::Iterator color_option = bbcode_options.find("color");
 				if (color_option) {
-					color = Color::from_string(color_option->value, color);
+					color = Color(color_option->value, color);
 				}
 
 				int width = 0;
@@ -4194,14 +4194,14 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 			tag_stack.push_front(bbcode_name);
 		} else if (tag.begins_with("color=")) {
 			String color_str = tag.substr(6, tag.length());
-			Color color = Color::from_string(color_str, theme_cache.default_color);
+			Color color = Color(color_str, theme_cache.default_color);
 			push_color(color);
 			pos = brk_end + 1;
 			tag_stack.push_front("color");
 
 		} else if (tag.begins_with("outline_color=")) {
 			String color_str = tag.substr(14, tag.length());
-			Color color = Color::from_string(color_str, theme_cache.default_color);
+			Color color = Color(color_str, theme_cache.default_color);
 			push_outline_color(color);
 			pos = brk_end + 1;
 			tag_stack.push_front("outline_color");
@@ -4473,7 +4473,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 
 		} else if (tag.begins_with("bgcolor=")) {
 			String color_str = tag.substr(8, tag.length());
-			Color color = Color::from_string(color_str, theme_cache.default_color);
+			Color color = Color(color_str, theme_cache.default_color);
 
 			push_bgcolor(color);
 			pos = brk_end + 1;
@@ -4481,7 +4481,7 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 
 		} else if (tag.begins_with("fgcolor=")) {
 			String color_str = tag.substr(8, tag.length());
-			Color color = Color::from_string(color_str, theme_cache.default_color);
+			Color color = Color(color_str, theme_cache.default_color);
 
 			push_fgcolor(color);
 			pos = brk_end + 1;


### PR DESCRIPTION
Because `Color(code: String)` already supports both HTML codes and named colors, I think it makes sense to replace the static method with a constructor.

See the [comment](https://github.com/godotengine/godot/pull/45030#issuecomment-757385022).