### PR TITLE
Restore "snap controls to pixels" functionality.

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -576,6 +576,11 @@ void Control::_update_canvas_item_transform() {
 	Transform2D xform = _get_internal_transform();
 	xform[2] += get_position();
 
+	// We use a little workaround to avoid flickering when moving the pivot with _edit_set_pivot()
+	if (is_inside_tree() && Math::abs(Math::sin(data.rotation * 4.0f)) < 0.00001f && get_viewport()->is_snap_controls_to_pixels_enabled()) {
+		xform[2] = xform[2].round();
+	}
+
 	RenderingServer::get_singleton()->canvas_item_set_transform(get_canvas_item(), xform);
 }
 


### PR DESCRIPTION
Revert "Fix control node transform animation jitter with pivot offset"
This reverts commit dfb7d46a2aaf9bef2c7dd067e699e70291062fb6.

In the `3.x` branch, this code was removed and reverted multiple times. Maybe some other approach was planned for `master`, but it's not implemented, and without it, issues with blurry controls and fonts are still there.

Fixes #57340