### PR TITLE
[3.x] [HTML5] PWA cache-first strategy, update detection and forced updates.

### DIFF
--- a/doc/classes/JavaScript.xml
+++ b/doc/classes/JavaScript.xml
@@ -54,7 +54,29 @@
 				Returns an interface to a JavaScript object that can be used by scripts. The [code]interface[/code] must be a valid property of the JavaScript [code]window[/code]. The callback must accept a single [Array] argument, which will contain the JavaScript [code]arguments[/code]. See [JavaScriptObject] for usage.
 			</description>
 		</method>
+		<method name="pwa_needs_update" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if a new version of the progressive web app is waiting to be activated.
+				[b]Note:[/b] Only relevant when exported as a Progressive Web App.
+			</description>
+		</method>
+		<method name="pwa_update">
+			<return type="int" enum="Error" />
+			<description>
+				Performs the live update of the progressive web app. Forcing the new version to be installed and the page to be reloaded.
+				[b]Note:[/b] Your application will be [b]reloaded in all browser tabs[/b].
+				[b]Note:[/b] Only relevant when exported as a Progressive Web App and [method pwa_needs_update] returns [code]true[/code].
+			</description>
+		</method>
 	</methods>
+	<signals>
+		<signal name="pwa_update_available">
+			<description>
+				Emitted when an update for this progressive web app has been detected but is waiting to be activated because a previous version is active. See [method pwa_update] to force the update to take place immediately.
+			</description>
+		</signal>
+	</signals>
 	<constants>
 	</constants>
 </class>

--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -265,6 +265,7 @@
 		<button id="btn-close-editor" class="btn close-btn" disabled="disabled" onclick="closeEditor()">×</button>
 		<button id="btn-tab-game" class="btn tab-btn" disabled="disabled" onclick="showTab('game')">Game</button>
 		<button id="btn-close-game" class="btn close-btn"  disabled="disabled" onclick="closeGame()">×</button>
+		<button id="btn-tab-update" class="btn tab-btn" style="display: none;">Update</button>
 	</div>
 	<div id="tabs">
 		<div id="tab-loader">
@@ -325,10 +326,39 @@
 			<div id="status-notice" class="godot" style="display: none;"></div>
 		</div>
 	</div>
-	<script>
+	<script>//<![CDATA[
 		window.addEventListener("load", () => {
+			function notifyUpdate(sw) {
+				const btn = document.getElementById("btn-tab-update");
+				btn.onclick = function () {
+					if (!window.confirm("Are you sure you want to update?\nClicking \"OK\" will reload all active instances!")) {
+						return;
+					}
+					sw.postMessage("update");
+					btn.innerHTML = "Updating...";
+					btn.disabled = true;
+				};
+				btn.style.display = "";
+			}
 			if ("serviceWorker" in navigator) {
-				navigator.serviceWorker.register("service.worker.js");
+				navigator.serviceWorker.register("service.worker.js").then(function (reg) {
+					if (reg.waiting) {
+						notifyUpdate(reg.waiting);
+					}
+					reg.addEventListener("updatefound", function () {
+						const update = reg.installing;
+						update.addEventListener("statechange", function () {
+							if (update.state === "installed") {
+								// It's a new install, claim and perform aggressive caching.
+								if (!reg.active) {
+									update.postMessage("claim");
+								} else {
+									notifyUpdate(update);
+								}
+							}
+						});
+					});
+				});
 			}
 
 			if (localStorage.getItem("welcomeModalDismissed") !== 'true') {
@@ -343,7 +373,7 @@
 				localStorage.setItem("welcomeModalDismissed", 'true');
 			}
 		}
-	</script>
+	//]]></script>
 	<script src="godot.tools.js"></script>
 	<script>//<![CDATA[
 

--- a/platform/javascript/api/api.cpp
+++ b/platform/javascript/api/api.cpp
@@ -71,6 +71,9 @@ void JavaScript::_bind_methods() {
 		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "create_object", &JavaScript::_create_object_bind, mi);
 	}
 	ClassDB::bind_method(D_METHOD("download_buffer", "buffer", "name", "mime"), &JavaScript::download_buffer, DEFVAL("application/octet-stream"));
+	ClassDB::bind_method(D_METHOD("pwa_needs_update"), &JavaScript::pwa_needs_update);
+	ClassDB::bind_method(D_METHOD("pwa_update"), &JavaScript::pwa_update);
+	ADD_SIGNAL(MethodInfo("pwa_update_available"));
 }
 
 #if !defined(JAVASCRIPT_ENABLED) || !defined(JAVASCRIPT_EVAL_ENABLED)
@@ -102,6 +105,12 @@ Variant JavaScript::_create_object_bind(const Variant **p_args, int p_argcount, 
 }
 #endif
 #if !defined(JAVASCRIPT_ENABLED)
+bool JavaScript::pwa_needs_update() const {
+	return false;
+}
+Error JavaScript::pwa_update() {
+	return ERR_UNAVAILABLE;
+}
 void JavaScript::download_buffer(Vector<uint8_t> p_arr, const String &p_name, const String &p_mime) {
 }
 #endif

--- a/platform/javascript/api/javascript_singleton.h
+++ b/platform/javascript/api/javascript_singleton.h
@@ -59,6 +59,8 @@ public:
 	Ref<JavaScriptObject> create_callback(Object *p_ref, const StringName &p_method);
 	Variant _create_object_bind(const Variant **p_args, int p_argcount, Variant::CallError &r_error);
 	void download_buffer(Vector<uint8_t> p_arr, const String &p_name, const String &p_mime = "application/octet-stream");
+	bool pwa_needs_update() const;
+	Error pwa_update();
 
 	static JavaScript *get_singleton();
 	JavaScript();

--- a/platform/javascript/godot_js.h
+++ b/platform/javascript/godot_js.h
@@ -49,6 +49,8 @@ extern void godot_js_os_fs_sync(void (*p_callback)());
 extern int godot_js_os_execute(const char *p_json);
 extern void godot_js_os_shell_open(const char *p_uri);
 extern int godot_js_os_hw_concurrency_get();
+extern int godot_js_pwa_cb(void (*p_callback)());
+extern int godot_js_pwa_update();
 
 // Input
 extern void godot_js_input_mouse_button_cb(int (*p_callback)(int p_pressed, int p_button, double p_x, double p_y, int p_modifiers));

--- a/platform/javascript/javascript_singleton.cpp
+++ b/platform/javascript/javascript_singleton.cpp
@@ -30,6 +30,7 @@
 
 #include "api/javascript_singleton.h"
 #include "emscripten.h"
+#include "os_javascript.h"
 
 extern "C" {
 extern void godot_js_os_download_buffer(const uint8_t *p_buf, int p_buf_size, const char *p_name, const char *p_mime);
@@ -345,4 +346,11 @@ Variant JavaScript::eval(const String &p_code, bool p_use_global_exec_context) {
 
 void JavaScript::download_buffer(Vector<uint8_t> p_arr, const String &p_name, const String &p_mime) {
 	godot_js_os_download_buffer(p_arr.ptr(), p_arr.size(), p_name.utf8().get_data(), p_mime.utf8().get_data());
+}
+
+bool JavaScript::pwa_needs_update() const {
+	return OS_JavaScript::get_singleton()->pwa_needs_update();
+}
+Error JavaScript::pwa_update() {
+	return OS_JavaScript::get_singleton()->pwa_update();
 }

--- a/platform/javascript/js/engine/config.js
+++ b/platform/javascript/js/engine/config.js
@@ -107,6 +107,13 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		 */
 		experimentalVK: false,
 		/**
+		 * The progressive web app service worker to install.
+		 * @memberof EngineConfig
+		 * @default
+		 * @type {string}
+		 */
+		serviceWorker: '',
+		/**
 		 * @ignore
 		 * @type {Array.<string>}
 		 */
@@ -249,6 +256,7 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		this.persistentDrops = parse('persistentDrops', this.persistentDrops);
 		this.experimentalVK = parse('experimentalVK', this.experimentalVK);
 		this.focusCanvas = parse('focusCanvas', this.focusCanvas);
+		this.serviceWorker = parse('serviceWorker', this.serviceWorker);
 		this.gdnativeLibs = parse('gdnativeLibs', this.gdnativeLibs);
 		this.fileSizes = parse('fileSizes', this.fileSizes);
 		this.args = parse('args', this.args);

--- a/platform/javascript/js/engine/engine.js
+++ b/platform/javascript/js/engine/engine.js
@@ -189,6 +189,9 @@ const Engine = (function () {
 							preloader.preloadedFiles.length = 0; // Clear memory
 							me.rtenv['callMain'](me.config.args);
 							initPromise = null;
+							if (me.config.serviceWorker && 'serviceWorker' in navigator) {
+								navigator.serviceWorker.register(me.config.serviceWorker);
+							}
 							resolve();
 						});
 					});

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -46,6 +46,7 @@
 #include <png.h>
 #include <stdlib.h>
 
+#include "api/javascript_singleton.h"
 #include "dom_keys.inc"
 #include "godot_js.h"
 
@@ -1035,6 +1036,19 @@ void OS_JavaScript::file_access_close_callback(const String &p_file, int p_flags
 	}
 }
 
+void OS_JavaScript::update_pwa_state_callback() {
+	if (OS_JavaScript::get_singleton()) {
+		OS_JavaScript::get_singleton()->pwa_is_waiting = true;
+	}
+	if (JavaScript::get_singleton()) {
+		JavaScript::get_singleton()->emit_signal("pwa_update_available");
+	}
+}
+
+Error OS_JavaScript::pwa_update() {
+	return godot_js_pwa_update() ? FAILED : OK;
+}
+
 bool OS_JavaScript::is_userfs_persistent() const {
 	return idb_available;
 }
@@ -1072,6 +1086,8 @@ OS_JavaScript::OS_JavaScript() {
 	idb_available = godot_js_os_fs_is_persistent() != 0;
 	idb_needs_sync = false;
 	idb_is_syncing = false;
+	pwa_is_waiting = false;
+	godot_js_pwa_cb(&OS_JavaScript::update_pwa_state_callback);
 
 	if (AudioDriverJavaScript::is_available()) {
 #ifdef NO_THREADS

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -78,6 +78,7 @@ private:
 	bool idb_available;
 	bool idb_needs_sync;
 	bool idb_is_syncing;
+	bool pwa_is_waiting;
 
 	static void fullscreen_change_callback(int p_fullscreen);
 	static int mouse_button_callback(int p_pressed, int p_button, double p_x, double p_y, int p_modifiers);
@@ -98,6 +99,7 @@ private:
 	static void send_notification_callback(int p_notification);
 	static void fs_sync_callback();
 	static void update_clipboard_callback(const char *p_text);
+	static void update_pwa_state_callback();
 
 protected:
 	void resume_audio();
@@ -116,6 +118,8 @@ protected:
 
 public:
 	bool check_size_force_redraw();
+	bool pwa_needs_update() const { return pwa_is_waiting; }
+	Error pwa_update();
 
 	// Override return type to make writing static callbacks less tedious.
 	static OS_JavaScript *get_singleton();


### PR DESCRIPTION
This PR will needs a `master` version (hence the draft), but would really like some feedback first.

In this PR:
- PWA service worker is now registered by the Engine if the `serviceWorker` config option is set (done by the exporter).
- PWA service worker first registration is delayed to after Godot has started, trying to improve time to first interaction.
- Godot will now try to detect service workers waiting to update, allowing to force it (by reloading all blocking pages).
- PWA service worker now uses a cache-first strategy for fetched resources, cache consistency is ensured by timestamping each build cache version during export.

Example auto update code:
```gdscript
extends Node

func _ready():
	# Check if the PWA needs updating
	if JavaScript.pwa_needs_update():
		_update()
	# The state might change after startup, due to installation asynchronicity
	JavaScript.connect("pwa_update_available", self, "_update")

func _update():
        # Better ask the user if they want to reload ;)
	OS.alert("Updating PWA")
	JavaScript.pwa_update()
```

This PR also adds a (not super nice) `update` button to the Web Editor when an update is available (mostly relevant on `/latest/` endpoint), hidden when no update is detected.

![update1](https://user-images.githubusercontent.com/1687918/151831807-92f8a16f-80ab-40f2-a403-0a8de8fc2d3e.png)

![update2](https://user-images.githubusercontent.com/1687918/151831803-1df1d6ff-019c-4e5d-8c68-2e537a2cec10.png)

Hopefully fixes #56103 .
Ping to @charliewhitfield which has been really helpful in debugging the original issue, and @Calinou which will probably be interested in the web editor changes.