### PR TITLE
Minor fixes/refactoring of project and editor settings dialogs

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -93,6 +93,7 @@
 #include "editor/editor_run_script.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
+#include "editor/editor_settings_dialog.h"
 #include "editor/editor_spin_slider.h"
 #include "editor/editor_themes.h"
 #include "editor/editor_toaster.h"
@@ -190,7 +191,6 @@
 #include "editor/project_settings_editor.h"
 #include "editor/quick_open.h"
 #include "editor/register_exporters.h"
-#include "editor/settings_config_dialog.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -822,8 +822,8 @@ void EditorNode::_on_plugin_ready(Object *p_script, const String &p_activate_nam
 	if (p_activate_name.length()) {
 		set_addon_plugin_enabled(p_activate_name, true);
 	}
-	project_settings->update_plugins();
-	project_settings->hide();
+	project_settings_editor->update_plugins();
+	project_settings_editor->hide();
 	push_item(script.operator->());
 }
 
@@ -2773,7 +2773,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 		} break;
 		case RUN_SETTINGS: {
-			project_settings->popup_project_settings();
+			project_settings_editor->popup_project_settings();
 		} break;
 		case FILE_INSTALL_ANDROID_SOURCE: {
 			if (p_confirmed) {
@@ -2846,7 +2846,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			_update_update_spinner();
 		} break;
 		case SETTINGS_PREFERENCES: {
-			settings_config_dialog->popup_edit_settings();
+			editor_settings_dialog->popup_edit_settings();
 		} break;
 		case SETTINGS_EDITOR_DATA_FOLDER: {
 			OS::get_singleton()->shell_open(String("file://") + EditorPaths::get_singleton()->get_data_dir());
@@ -3240,7 +3240,7 @@ void EditorNode::_update_addon_config() {
 		ProjectSettings::get_singleton()->set("editor_plugins/enabled", enabled_addons);
 	}
 
-	project_settings->queue_save();
+	project_settings_editor->queue_save();
 }
 
 void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled, bool p_config_changed) {
@@ -6325,11 +6325,11 @@ EditorNode::EditorNode() {
 	dependency_fixer = memnew(DependencyEditor);
 	gui_base->add_child(dependency_fixer);
 
-	settings_config_dialog = memnew(EditorSettingsDialog);
-	gui_base->add_child(settings_config_dialog);
+	editor_settings_dialog = memnew(EditorSettingsDialog);
+	gui_base->add_child(editor_settings_dialog);
 
-	project_settings = memnew(ProjectSettingsEditor(&editor_data));
-	gui_base->add_child(project_settings);
+	project_settings_editor = memnew(ProjectSettingsEditor(&editor_data));
+	gui_base->add_child(project_settings_editor);
 
 	scene_import_settings = memnew(SceneImportSettings);
 	gui_base->add_child(scene_import_settings);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -323,8 +323,8 @@ private:
 	ConfirmationDialog *install_android_build_template;
 	ConfirmationDialog *remove_android_build_template;
 
-	EditorSettingsDialog *settings_config_dialog;
-	ProjectSettingsEditor *project_settings;
+	EditorSettingsDialog *editor_settings_dialog;
+	ProjectSettingsEditor *project_settings_editor;
 	bool settings_changed = true; // make it update settings on first frame
 	void _update_from_settings();
 
@@ -713,7 +713,7 @@ public:
 	EditorPluginList *get_editor_plugins_force_over() { return editor_plugins_force_over; }
 	EditorPluginList *get_editor_plugins_force_input_forwarding() { return editor_plugins_force_input_forwarding; }
 
-	ProjectSettingsEditor *get_project_settings() { return project_settings; }
+	ProjectSettingsEditor *get_project_settings() { return project_settings_editor; }
 
 	static void add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed = false);
 	static void remove_editor_plugin(EditorPlugin *p_editor, bool p_config_changed = false);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1263,7 +1263,7 @@ void EditorPropertyInteger::_bind_methods() {
 void EditorPropertyInteger::setup(int64_t p_min, int64_t p_max, int64_t p_step, bool p_allow_greater, bool p_allow_lesser) {
 	spin->set_min(p_min);
 	spin->set_max(p_max);
-	spin->set_step(p_step);
+	spin->set_step((p_step == 0) ? 1 : p_step);
 	spin->set_allow_greater(p_allow_greater);
 	spin->set_allow_lesser(p_allow_lesser);
 }
@@ -1353,7 +1353,7 @@ void EditorPropertyFloat::setup(double p_min, double p_max, double p_step, bool 
 	angle_in_radians = p_angle_in_radians;
 	spin->set_min(p_min);
 	spin->set_max(p_max);
-	spin->set_step(p_step);
+	spin->set_step((p_step == 0) ? 0.1 : p_step);
 	spin->set_hide_slider(p_no_slider);
 	spin->set_exp_ratio(p_exp_range);
 	spin->set_allow_greater(p_greater);
@@ -3435,7 +3435,9 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				EditorPropertyInteger *editor = memnew(EditorPropertyInteger);
 
 				EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, 1);
-
+				if (hint.step == 0) {
+					WARN_PRINT(p_path + ": Range step size is 0.");
+				}
 				editor->setup(hint.min, hint.max, hint.step, hint.greater, hint.lesser);
 
 				return editor;
@@ -3464,6 +3466,9 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 				EditorPropertyFloat *editor = memnew(EditorPropertyFloat);
 
 				EditorPropertyRangeHint hint = _parse_range_hint(p_hint, p_hint_text, default_float_step);
+				if (hint.step == 0) {
+					WARN_PRINT(p_path + ": Range step size is 0.");
+				}
 				editor->setup(hint.min, hint.max, hint.step, hint.hide_slider, hint.exp_range, hint.greater, hint.lesser, hint.suffix, hint.radians);
 
 				return editor;

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  settings_config_dialog.cpp                                           */
+/*  editor_settings_dialog.cpp                                           */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,7 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "settings_config_dialog.h"
+#include "editor_settings_dialog.h"
 
 #include "core/config/project_settings.h"
 #include "core/input/input_map.h"

--- a/editor/editor_settings_dialog.h
+++ b/editor/editor_settings_dialog.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  settings_config_dialog.h                                             */
+/*  editor_settings_dialog.h                                             */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SETTINGS_CONFIG_DIALOG_H
-#define SETTINGS_CONFIG_DIALOG_H
+#ifndef EDITOR_SETTINGS_DIALOG_H
+#define EDITOR_SETTINGS_DIALOG_H
 
 #include "editor/action_map_editor.h"
 #include "editor/editor_sectioned_inspector.h"
@@ -128,4 +128,4 @@ public:
 	~EditorSettingsDialog();
 };
 
-#endif // SETTINGS_CONFIG_DIALOG_H
+#endif // EDITOR_SETTINGS_DIALOG_H

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -50,8 +50,8 @@ class ProjectSettingsEditor : public AcceptDialog {
 	Timer *timer;
 
 	TabContainer *tab_container;
-	SectionedInspector *inspector;
-	ActionMapEditor *action_map;
+	SectionedInspector *general_settings_inspector;
+	ActionMapEditor *action_map_editor;
 	LocalizationEditor *localization_editor;
 	EditorAutoloadSettings *autoload_settings;
 	ShaderGlobalsEditor *shaders_global_variables_editor;
@@ -80,6 +80,8 @@ class ProjectSettingsEditor : public AcceptDialog {
 	void _update_property_box();
 	void _feature_selected(int p_index);
 	void _select_type(Variant::Type p_type);
+
+	virtual void unhandled_input(const Ref<InputEvent> &p_event) override;
 
 	String _get_setting_name() const;
 	void _setting_edited(const String &p_name);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1311,11 +1311,13 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			PropertyInfo(Variant::INT, "display/window/size/viewport_width",
 					PROPERTY_HINT_RANGE,
 					"0,7680,or_greater")); // 8K resolution
+
 	GLOBAL_DEF_BASIC("display/window/size/viewport_height", 600);
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/viewport_height",
 			PropertyInfo(Variant::INT, "display/window/size/viewport_height",
 					PROPERTY_HINT_RANGE,
-					"0,4320,or_greater")); // 8K resolution
+					"0,4320,1,or_greater")); // 8K resolution
+
 	GLOBAL_DEF_BASIC("display/window/size/resizable", true);
 	GLOBAL_DEF_BASIC("display/window/size/borderless", false);
 	GLOBAL_DEF_BASIC("display/window/size/fullscreen", false);
@@ -1325,7 +1327,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			PropertyInfo(Variant::INT,
 					"display/window/size/window_width_override",
 					PROPERTY_HINT_RANGE,
-					"0,7680,or_greater")); // 8K resolution
+					"0,7680,1,or_greater")); // 8K resolution
 	GLOBAL_DEF("display/window/size/window_height_override", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/window_height_override",
 			PropertyInfo(Variant::INT,


### PR DESCRIPTION
This PR aims to fix some problems with the project/editor settings dialogs:

- Fixes non-working/stuck sliders in project settings (fixes #57556)
    - Add a warning when a range's step size is zero and correct it
- Reimplements undo/redo in project settings
- Add shortcut to search project settings (to be consistent with the editor settings dialog)
- Rename header and source file `settings_config_dialog` -> `editor_settings_dialog` to match with class name