### PR TITLE
Add support for 2D vector type to visual shaders

### DIFF
--- a/doc/classes/VisualShaderNode.xml
+++ b/doc/classes/VisualShaderNode.xml
@@ -47,6 +47,7 @@
 			<return type="void" />
 			<argument index="0" name="port" type="int" />
 			<argument index="1" name="value" type="Variant" />
+			<argument index="2" name="prev_value" type="Variant" default="null" />
 			<description>
 				Sets the default value for the selected input [code]port[/code].
 			</description>
@@ -71,19 +72,22 @@
 		<constant name="PORT_TYPE_SCALAR_INT" value="1" enum="PortType">
 			Integer scalar. Translated to [code]int[/code] type in shader code.
 		</constant>
-		<constant name="PORT_TYPE_VECTOR" value="2" enum="PortType">
+		<constant name="PORT_TYPE_VECTOR_2D" value="2" enum="PortType">
+			2D vector of floating-point values. Translated to [code]vec2[/code] type in shader code.
+		</constant>
+		<constant name="PORT_TYPE_VECTOR" value="3" enum="PortType">
 			3D vector of floating-point values. Translated to [code]vec3[/code] type in shader code.
 		</constant>
-		<constant name="PORT_TYPE_BOOLEAN" value="3" enum="PortType">
+		<constant name="PORT_TYPE_BOOLEAN" value="4" enum="PortType">
 			Boolean type. Translated to [code]bool[/code] type in shader code.
 		</constant>
-		<constant name="PORT_TYPE_TRANSFORM" value="4" enum="PortType">
+		<constant name="PORT_TYPE_TRANSFORM" value="5" enum="PortType">
 			Transform type. Translated to [code]mat4[/code] type in shader code.
 		</constant>
-		<constant name="PORT_TYPE_SAMPLER" value="5" enum="PortType">
+		<constant name="PORT_TYPE_SAMPLER" value="6" enum="PortType">
 			Sampler type. Translated to reference of sampler uniform in shader code. Can only be used for input ports in non-uniform nodes.
 		</constant>
-		<constant name="PORT_TYPE_MAX" value="6" enum="PortType">
+		<constant name="PORT_TYPE_MAX" value="7" enum="PortType">
 			Represents the size of the [enum PortType] enum.
 		</constant>
 	</constants>

--- a/doc/classes/VisualShaderNodeClamp.xml
+++ b/doc/classes/VisualShaderNodeClamp.xml
@@ -20,10 +20,13 @@
 		<constant name="OP_TYPE_INT" value="1" enum="OpType">
 			An integer scalar.
 		</constant>
-		<constant name="OP_TYPE_VECTOR" value="2" enum="OpType">
-			A vector type.
+		<constant name="OP_TYPE_VECTOR_2D" value="2" enum="OpType">
+			A 2D vector type.
 		</constant>
-		<constant name="OP_TYPE_MAX" value="3" enum="OpType">
+		<constant name="OP_TYPE_VECTOR_3D" value="3" enum="OpType">
+			A 3D vector type.
+		</constant>
+		<constant name="OP_TYPE_MAX" value="4" enum="OpType">
 			Represents the size of the [enum OpType] enum.
 		</constant>
 	</constants>

--- a/doc/classes/VisualShaderNodeCompare.xml
+++ b/doc/classes/VisualShaderNodeCompare.xml
@@ -10,7 +10,7 @@
 	</tutorials>
 	<members>
 		<member name="condition" type="int" setter="set_condition" getter="get_condition" enum="VisualShaderNodeCompare.Condition" default="0">
-			Extra condition which is applied if [member type] is set to [constant CTYPE_VECTOR].
+			Extra condition which is applied if [member type] is set to [constant CTYPE_VECTOR_3D].
 		</member>
 		<member name="function" type="int" setter="set_function" getter="get_function" enum="VisualShaderNodeCompare.Function" default="0">
 			A comparison function. See [enum Function] for options.
@@ -26,16 +26,19 @@
 		<constant name="CTYPE_SCALAR_INT" value="1" enum="ComparisonType">
 			An integer scalar.
 		</constant>
-		<constant name="CTYPE_VECTOR" value="2" enum="ComparisonType">
+		<constant name="CTYPE_VECTOR_2D" value="2" enum="ComparisonType">
+			A 2D vector type.
+		</constant>
+		<constant name="CTYPE_VECTOR_3D" value="3" enum="ComparisonType">
 			A 3D vector type.
 		</constant>
-		<constant name="CTYPE_BOOLEAN" value="3" enum="ComparisonType">
+		<constant name="CTYPE_BOOLEAN" value="4" enum="ComparisonType">
 			A boolean type.
 		</constant>
-		<constant name="CTYPE_TRANSFORM" value="4" enum="ComparisonType">
+		<constant name="CTYPE_TRANSFORM" value="5" enum="ComparisonType">
 			A transform ([code]mat4[/code]) type.
 		</constant>
-		<constant name="CTYPE_MAX" value="5" enum="ComparisonType">
+		<constant name="CTYPE_MAX" value="6" enum="ComparisonType">
 			Represents the size of the [enum ComparisonType] enum.
 		</constant>
 		<constant name="FUNC_EQUAL" value="0" enum="Function">

--- a/doc/classes/VisualShaderNodeDerivativeFunc.xml
+++ b/doc/classes/VisualShaderNodeDerivativeFunc.xml
@@ -20,10 +20,13 @@
 		<constant name="OP_TYPE_SCALAR" value="0" enum="OpType">
 			A floating-point scalar.
 		</constant>
-		<constant name="OP_TYPE_VECTOR" value="1" enum="OpType">
+		<constant name="OP_TYPE_VECTOR_2D" value="1" enum="OpType">
+			A 2D vector type.
+		</constant>
+		<constant name="OP_TYPE_VECTOR_3D" value="2" enum="OpType">
 			A 3D vector type.
 		</constant>
-		<constant name="OP_TYPE_MAX" value="2" enum="OpType">
+		<constant name="OP_TYPE_MAX" value="3" enum="OpType">
 			Represents the size of the [enum OpType] enum.
 		</constant>
 		<constant name="FUNC_SUM" value="0" enum="Function">

--- a/doc/classes/VisualShaderNodeFaceForward.xml
+++ b/doc/classes/VisualShaderNodeFaceForward.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VisualShaderNodeFaceForward" inherits="VisualShaderNode" version="4.0">
+<class name="VisualShaderNodeFaceForward" inherits="VisualShaderNodeVectorBase" version="4.0">
 	<brief_description>
 		Returns the vector that points in the same direction as a reference vector within the visual shader graph.
 	</brief_description>

--- a/doc/classes/VisualShaderNodeMix.xml
+++ b/doc/classes/VisualShaderNodeMix.xml
@@ -15,15 +15,21 @@
 	</members>
 	<constants>
 		<constant name="OP_TYPE_SCALAR" value="0" enum="OpType">
-			A scalar type.
+			A floating-point scalar.
 		</constant>
-		<constant name="OP_TYPE_VECTOR" value="1" enum="OpType">
-			A vector type.
+		<constant name="OP_TYPE_VECTOR_2D" value="1" enum="OpType">
+			A 2D vector type.
 		</constant>
-		<constant name="OP_TYPE_VECTOR_SCALAR" value="2" enum="OpType">
-			A vector type. [code]weight[/code] port is using a scalar type.
+		<constant name="OP_TYPE_VECTOR_2D_SCALAR" value="2" enum="OpType">
+			The [code]a[/code] and [code]b[/code] ports use a 2D vector type. The [code]weight[/code] port uses a scalar type.
 		</constant>
-		<constant name="OP_TYPE_MAX" value="3" enum="OpType">
+		<constant name="OP_TYPE_VECTOR_3D" value="3" enum="OpType">
+			A 3D vector type.
+		</constant>
+		<constant name="OP_TYPE_VECTOR_3D_SCALAR" value="4" enum="OpType">
+			The [code]a[/code] and [code]b[/code] ports use a 3D vector type. The [code]weight[/code] port uses a scalar type.
+		</constant>
+		<constant name="OP_TYPE_MAX" value="5" enum="OpType">
 			Represents the size of the [enum OpType] enum.
 		</constant>
 	</constants>

--- a/doc/classes/VisualShaderNodeMultiplyAdd.xml
+++ b/doc/classes/VisualShaderNodeMultiplyAdd.xml
@@ -15,12 +15,15 @@
 	</members>
 	<constants>
 		<constant name="OP_TYPE_SCALAR" value="0" enum="OpType">
-			A scalar type.
+			A floating-point scalar type.
 		</constant>
-		<constant name="OP_TYPE_VECTOR" value="1" enum="OpType">
-			A vector type.
+		<constant name="OP_TYPE_VECTOR_2D" value="1" enum="OpType">
+			A 2D vector type.
 		</constant>
-		<constant name="OP_TYPE_MAX" value="2" enum="OpType">
+		<constant name="OP_TYPE_VECTOR_3D" value="2" enum="OpType">
+			A 3D vector type.
+		</constant>
+		<constant name="OP_TYPE_MAX" value="3" enum="OpType">
 			Represents the size of the [enum OpType] enum.
 		</constant>
 	</constants>

--- a/doc/classes/VisualShaderNodeSmoothStep.xml
+++ b/doc/classes/VisualShaderNodeSmoothStep.xml
@@ -16,15 +16,21 @@
 	</members>
 	<constants>
 		<constant name="OP_TYPE_SCALAR" value="0" enum="OpType">
-			A scalar type.
+			A floating-point scalar type.
 		</constant>
-		<constant name="OP_TYPE_VECTOR" value="1" enum="OpType">
-			A vector type.
+		<constant name="OP_TYPE_VECTOR_2D" value="1" enum="OpType">
+			A 2D vector type.
 		</constant>
-		<constant name="OP_TYPE_VECTOR_SCALAR" value="2" enum="OpType">
-			A vector type. [code]edge0[/code] and [code]edge1[/code] are using a scalar type.
+		<constant name="OP_TYPE_VECTOR_2D_SCALAR" value="2" enum="OpType">
+			The [code]x[/code] port uses a 2D vector type. The first two ports use a floating-point scalar type.
 		</constant>
-		<constant name="OP_TYPE_MAX" value="3" enum="OpType">
+		<constant name="OP_TYPE_VECTOR_3D" value="3" enum="OpType">
+			A 3D vector type.
+		</constant>
+		<constant name="OP_TYPE_VECTOR_3D_SCALAR" value="4" enum="OpType">
+			The [code]x[/code] port uses a 3D vector type. The first two ports use a floating-point scalar type.
+		</constant>
+		<constant name="OP_TYPE_MAX" value="5" enum="OpType">
 			Represents the size of the [enum OpType] enum.
 		</constant>
 	</constants>

--- a/doc/classes/VisualShaderNodeStep.xml
+++ b/doc/classes/VisualShaderNodeStep.xml
@@ -16,15 +16,21 @@
 	</members>
 	<constants>
 		<constant name="OP_TYPE_SCALAR" value="0" enum="OpType">
-			A scalar type.
+			A floating-point scalar type.
 		</constant>
-		<constant name="OP_TYPE_VECTOR" value="1" enum="OpType">
-			A vector type.
+		<constant name="OP_TYPE_VECTOR_2D" value="1" enum="OpType">
+			A 2D vector type.
 		</constant>
-		<constant name="OP_TYPE_VECTOR_SCALAR" value="2" enum="OpType">
-			A vector type. [code]edge[/code] port is using a scalar type.
+		<constant name="OP_TYPE_VECTOR_2D_SCALAR" value="2" enum="OpType">
+			The [code]x[/code] port uses a 2D vector type, while the [code]edge[/code] port uses a floating-point scalar type.
 		</constant>
-		<constant name="OP_TYPE_MAX" value="3" enum="OpType">
+		<constant name="OP_TYPE_VECTOR_3D" value="3" enum="OpType">
+			A 3D vector type.
+		</constant>
+		<constant name="OP_TYPE_VECTOR_3D_SCALAR" value="4" enum="OpType">
+			The [code]x[/code] port uses a 3D vector type, while the [code]edge[/code] port uses a floating-point scalar type.
+		</constant>
+		<constant name="OP_TYPE_MAX" value="5" enum="OpType">
 			Represents the size of the [enum OpType] enum.
 		</constant>
 	</constants>

--- a/doc/classes/VisualShaderNodeSwitch.xml
+++ b/doc/classes/VisualShaderNodeSwitch.xml
@@ -20,16 +20,19 @@
 		<constant name="OP_TYPE_INT" value="1" enum="OpType">
 			An integer scalar.
 		</constant>
-		<constant name="OP_TYPE_VECTOR" value="2" enum="OpType">
-			A vector type.
+		<constant name="OP_TYPE_VECTOR_2D" value="2" enum="OpType">
+			A 2D vector type.
 		</constant>
-		<constant name="OP_TYPE_BOOLEAN" value="3" enum="OpType">
+		<constant name="OP_TYPE_VECTOR_3D" value="3" enum="OpType">
+			A 3D vector type.
+		</constant>
+		<constant name="OP_TYPE_BOOLEAN" value="4" enum="OpType">
 			A boolean type.
 		</constant>
-		<constant name="OP_TYPE_TRANSFORM" value="4" enum="OpType">
+		<constant name="OP_TYPE_TRANSFORM" value="5" enum="OpType">
 			A transform type.
 		</constant>
-		<constant name="OP_TYPE_MAX" value="5" enum="OpType">
+		<constant name="OP_TYPE_MAX" value="6" enum="OpType">
 			Represents the size of the [enum OpType] enum.
 		</constant>
 	</constants>

--- a/doc/classes/VisualShaderNodeVec2Constant.xml
+++ b/doc/classes/VisualShaderNodeVec2Constant.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="VisualShaderNodeVec2Constant" inherits="VisualShaderNodeConstant" version="4.0">
+	<brief_description>
+		A [Vector2] constant to be used within the visual shader graph.
+	</brief_description>
+	<description>
+		A constant [Vector2], which can be used as an input node.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="constant" type="Vector2" setter="set_constant" getter="get_constant" default="Vector2(0, 0)">
+			A [Vector2] constant which represents the state of this node.
+		</member>
+	</members>
+</class>

--- a/doc/classes/VisualShaderNodeVec2Uniform.xml
+++ b/doc/classes/VisualShaderNodeVec2Uniform.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="VisualShaderNodeVec2Uniform" inherits="VisualShaderNodeUniform" version="4.0">
+	<brief_description>
+		A [Vector2] uniform to be used within the visual shader graph.
+	</brief_description>
+	<description>
+		Translated to [code]uniform vec2[/code] in the shader language.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="default_value" type="Vector2" setter="set_default_value" getter="get_default_value" default="Vector2(0, 0)">
+			A default value to be assigned within the shader.
+		</member>
+		<member name="default_value_enabled" type="bool" setter="set_default_value_enabled" getter="is_default_value_enabled" default="false">
+			Enables usage of the [member default_value].
+		</member>
+	</members>
+</class>

--- a/doc/classes/VisualShaderNodeVectorBase.xml
+++ b/doc/classes/VisualShaderNodeVectorBase.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="VisualShaderNodeVectorBase" inherits="VisualShaderNode" version="4.0">
+	<brief_description>
+		A base type for the nodes using different vector types within the visual shader graph.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="op_type" type="int" setter="set_op_type" getter="get_op_type" enum="VisualShaderNodeVectorBase.OpType" default="1">
+			A base type.
+		</member>
+	</members>
+	<constants>
+		<constant name="OP_TYPE_VECTOR_2D" value="0" enum="OpType">
+			A 2D vector type.
+		</constant>
+		<constant name="OP_TYPE_VECTOR_3D" value="1" enum="OpType">
+			A 3D vector type.
+		</constant>
+		<constant name="OP_TYPE_MAX" value="2" enum="OpType">
+			Represents the size of the [enum OpType] enum.
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/VisualShaderNodeVectorCompose.xml
+++ b/doc/classes/VisualShaderNodeVectorCompose.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VisualShaderNodeVectorCompose" inherits="VisualShaderNode" version="4.0">
+<class name="VisualShaderNodeVectorCompose" inherits="VisualShaderNodeVectorBase" version="4.0">
 	<brief_description>
 		Composes a [Vector3] from three scalars within the visual shader graph.
 	</brief_description>

--- a/doc/classes/VisualShaderNodeVectorDecompose.xml
+++ b/doc/classes/VisualShaderNodeVectorDecompose.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VisualShaderNodeVectorDecompose" inherits="VisualShaderNode" version="4.0">
+<class name="VisualShaderNodeVectorDecompose" inherits="VisualShaderNodeVectorBase" version="4.0">
 	<brief_description>
 		Decomposes a [Vector3] into three scalars within the visual shader graph.
 	</brief_description>

--- a/doc/classes/VisualShaderNodeVectorDistance.xml
+++ b/doc/classes/VisualShaderNodeVectorDistance.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VisualShaderNodeVectorDistance" inherits="VisualShaderNode" version="4.0">
+<class name="VisualShaderNodeVectorDistance" inherits="VisualShaderNodeVectorBase" version="4.0">
 	<brief_description>
 		Returns the distance between two points. To be used within the visual shader graph.
 	</brief_description>

--- a/doc/classes/VisualShaderNodeVectorFunc.xml
+++ b/doc/classes/VisualShaderNodeVectorFunc.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VisualShaderNodeVectorFunc" inherits="VisualShaderNode" version="4.0">
+<class name="VisualShaderNodeVectorFunc" inherits="VisualShaderNodeVectorBase" version="4.0">
 	<brief_description>
 		A vector function to be used within the visual shader graph.
 	</brief_description>

--- a/doc/classes/VisualShaderNodeVectorLen.xml
+++ b/doc/classes/VisualShaderNodeVectorLen.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VisualShaderNodeVectorLen" inherits="VisualShaderNode" version="4.0">
+<class name="VisualShaderNodeVectorLen" inherits="VisualShaderNodeVectorBase" version="4.0">
 	<brief_description>
 		Returns the length of a [Vector3] within the visual shader graph.
 	</brief_description>

--- a/doc/classes/VisualShaderNodeVectorOp.xml
+++ b/doc/classes/VisualShaderNodeVectorOp.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="VisualShaderNodeVectorOp" inherits="VisualShaderNode" version="4.0">
+<class name="VisualShaderNodeVectorOp" inherits="VisualShaderNodeVectorBase" version="4.0">
 	<brief_description>
 		A vector operator to be used within the visual shader graph.
 	</brief_description>

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -555,11 +555,13 @@ void register_scene_types() {
 	GDREGISTER_VIRTUAL_CLASS(VisualShaderNodeResizableBase);
 	GDREGISTER_VIRTUAL_CLASS(VisualShaderNodeGroupBase);
 	GDREGISTER_VIRTUAL_CLASS(VisualShaderNodeConstant);
+	GDREGISTER_VIRTUAL_CLASS(VisualShaderNodeVectorBase);
 	GDREGISTER_CLASS(VisualShaderNodeComment);
 	GDREGISTER_CLASS(VisualShaderNodeFloatConstant);
 	GDREGISTER_CLASS(VisualShaderNodeIntConstant);
 	GDREGISTER_CLASS(VisualShaderNodeBooleanConstant);
 	GDREGISTER_CLASS(VisualShaderNodeColorConstant);
+	GDREGISTER_CLASS(VisualShaderNodeVec2Constant);
 	GDREGISTER_CLASS(VisualShaderNodeVec3Constant);
 	GDREGISTER_CLASS(VisualShaderNodeTransformConstant);
 	GDREGISTER_CLASS(VisualShaderNodeFloatOp);
@@ -603,6 +605,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(VisualShaderNodeIntUniform);
 	GDREGISTER_CLASS(VisualShaderNodeBooleanUniform);
 	GDREGISTER_CLASS(VisualShaderNodeColorUniform);
+	GDREGISTER_CLASS(VisualShaderNodeVec2Uniform);
 	GDREGISTER_CLASS(VisualShaderNodeVec3Uniform);
 	GDREGISTER_CLASS(VisualShaderNodeTransformUniform);
 	GDREGISTER_CLASS(VisualShaderNodeTextureUniform);

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -53,8 +53,98 @@ int VisualShaderNode::get_output_port_for_preview() const {
 	return port_preview;
 }
 
-void VisualShaderNode::set_input_port_default_value(int p_port, const Variant &p_value) {
-	default_input_values[p_port] = p_value;
+void VisualShaderNode::set_input_port_default_value(int p_port, const Variant &p_value, const Variant &p_prev_value) {
+	Variant value = p_value;
+
+	if (p_prev_value.get_type() != Variant::NIL) {
+		switch (p_value.get_type()) {
+			case Variant::FLOAT: {
+				switch (p_prev_value.get_type()) {
+					case Variant::INT: {
+						value = (float)p_prev_value;
+					} break;
+					case Variant::FLOAT: {
+						value = p_prev_value;
+					} break;
+					case Variant::VECTOR2: {
+						Vector2 pv = p_prev_value;
+						value = pv.x;
+					} break;
+					case Variant::VECTOR3: {
+						Vector3 pv = p_prev_value;
+						value = pv.x;
+					} break;
+					default:
+						break;
+				}
+			} break;
+			case Variant::INT: {
+				switch (p_prev_value.get_type()) {
+					case Variant::INT: {
+						value = p_prev_value;
+					} break;
+					case Variant::FLOAT: {
+						value = (int)p_prev_value;
+					} break;
+					case Variant::VECTOR2: {
+						Vector2 pv = p_prev_value;
+						value = (int)pv.x;
+					} break;
+					case Variant::VECTOR3: {
+						Vector3 pv = p_prev_value;
+						value = (int)pv.x;
+					} break;
+					default:
+						break;
+				}
+			} break;
+			case Variant::VECTOR2: {
+				switch (p_prev_value.get_type()) {
+					case Variant::INT: {
+						float pv = (float)(int)p_prev_value;
+						value = Vector2(pv, pv);
+					} break;
+					case Variant::FLOAT: {
+						float pv = p_prev_value;
+						value = Vector2(pv, pv);
+					} break;
+					case Variant::VECTOR2: {
+						value = p_prev_value;
+					} break;
+					case Variant::VECTOR3: {
+						Vector3 pv = p_prev_value;
+						value = Vector2(pv.x, pv.y);
+					} break;
+					default:
+						break;
+				}
+			} break;
+			case Variant::VECTOR3: {
+				switch (p_prev_value.get_type()) {
+					case Variant::INT: {
+						float pv = (float)(int)p_prev_value;
+						value = Vector3(pv, pv, pv);
+					} break;
+					case Variant::FLOAT: {
+						float pv = p_prev_value;
+						value = Vector3(pv, pv, pv);
+					} break;
+					case Variant::VECTOR2: {
+						Vector2 pv = p_prev_value;
+						value = Vector3(pv.x, pv.y, 0.0);
+					} break;
+					case Variant::VECTOR3: {
+						value = p_prev_value;
+					} break;
+					default:
+						break;
+				}
+			} break;
+			default:
+				break;
+		}
+	}
+	default_input_values[p_port] = value;
 	emit_changed();
 }
 
@@ -156,8 +246,15 @@ int VisualShaderNode::get_expanded_output_port_count() const {
 	int count2 = count;
 	for (int i = 0; i < count; i++) {
 		if (is_output_port_expandable(i) && _is_output_port_expanded(i)) {
-			if (get_output_port_type(i) == PORT_TYPE_VECTOR) {
-				count2 += 3;
+			switch (get_output_port_type(i)) {
+				case PORT_TYPE_VECTOR_2D: {
+					count2 += 2;
+				} break;
+				case PORT_TYPE_VECTOR: {
+					count2 += 3;
+				} break;
+				default:
+					break;
 			}
 		}
 	}
@@ -245,7 +342,7 @@ void VisualShaderNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_set_output_ports_expanded", "values"), &VisualShaderNode::_set_output_ports_expanded);
 	ClassDB::bind_method(D_METHOD("_get_output_ports_expanded"), &VisualShaderNode::_get_output_ports_expanded);
 
-	ClassDB::bind_method(D_METHOD("set_input_port_default_value", "port", "value"), &VisualShaderNode::set_input_port_default_value);
+	ClassDB::bind_method(D_METHOD("set_input_port_default_value", "port", "value", "prev_value"), &VisualShaderNode::set_input_port_default_value, DEFVAL(Variant()));
 	ClassDB::bind_method(D_METHOD("get_input_port_default_value", "port"), &VisualShaderNode::get_input_port_default_value);
 
 	ClassDB::bind_method(D_METHOD("remove_input_port_default_value", "port"), &VisualShaderNode::remove_input_port_default_value);
@@ -261,6 +358,7 @@ void VisualShaderNode::_bind_methods() {
 
 	BIND_ENUM_CONSTANT(PORT_TYPE_SCALAR);
 	BIND_ENUM_CONSTANT(PORT_TYPE_SCALAR_INT);
+	BIND_ENUM_CONSTANT(PORT_TYPE_VECTOR_2D);
 	BIND_ENUM_CONSTANT(PORT_TYPE_VECTOR);
 	BIND_ENUM_CONSTANT(PORT_TYPE_BOOLEAN);
 	BIND_ENUM_CONSTANT(PORT_TYPE_TRANSFORM);
@@ -385,9 +483,9 @@ String VisualShaderNodeCustom::generate_global_per_node(Shader::Mode p_mode, Vis
 	return "";
 }
 
-void VisualShaderNodeCustom::set_input_port_default_value(int p_port, const Variant &p_value) {
+void VisualShaderNodeCustom::set_input_port_default_value(int p_port, const Variant &p_value, const Variant &p_prev_value) {
 	if (!is_initialized) {
-		VisualShaderNode::set_input_port_default_value(p_port, p_value);
+		VisualShaderNode::set_input_port_default_value(p_port, p_value, p_prev_value);
 	}
 }
 
@@ -484,24 +582,48 @@ void VisualShader::update_engine_version(const Dictionary &p_new_version) {
 				if (expression.is_valid()) {
 					for (int j = 0; j < expression->get_input_port_count(); j++) {
 						int type = expression->get_input_port_type(j);
-						if (type > 0) { // + PORT_TYPE_SCALAR_INT
-							type += 1;
+						if (type > 0) { // + PORT_TYPE_SCALAR_INT + PORT_TYPE_VECTOR_2D
+							type += 2;
 						}
 						expression->set_input_port_type(j, type);
 					}
 					for (int j = 0; j < expression->get_output_port_count(); j++) {
 						int type = expression->get_output_port_type(j);
-						if (type > 0) { // + PORT_TYPE_SCALAR_INT
-							type += 1;
+						if (type > 0) { // + PORT_TYPE_SCALAR_INT + PORT_TYPE_VECTOR_2D
+							type += 2;
 						}
 						expression->set_output_port_type(j, type);
 					}
 				}
+				Ref<VisualShaderNodeStep> step = Object::cast_to<VisualShaderNodeStep>(E.value.node.ptr());
+				if (step.is_valid()) {
+					int op_type = int(step->get_op_type());
+					if (int(op_type) > 0) { // + OP_TYPE_VECTOR_2D + OP_TYPE_VECTOR_2D_SCALAR
+						op_type += 2;
+					}
+					step->set_op_type(VisualShaderNodeStep::OpType(op_type));
+				}
+				Ref<VisualShaderNodeSmoothStep> sstep = Object::cast_to<VisualShaderNodeSmoothStep>(E.value.node.ptr());
+				if (sstep.is_valid()) {
+					int op_type = int(sstep->get_op_type());
+					if (int(op_type) > 0) { // + OP_TYPE_VECTOR_2D + OP_TYPE_VECTOR_2D_SCALAR
+						op_type += 2;
+					}
+					sstep->set_op_type(VisualShaderNodeSmoothStep::OpType(op_type));
+				}
+				Ref<VisualShaderNodeMix> mix = Object::cast_to<VisualShaderNodeMix>(E.value.node.ptr());
+				if (mix.is_valid()) {
+					int op_type = int(mix->get_op_type());
+					if (int(op_type) > 0) { // + OP_TYPE_VECTOR_2D + OP_TYPE_VECTOR_2D_SCALAR
+						op_type += 2;
+					}
+					mix->set_op_type(VisualShaderNodeMix::OpType(op_type));
+				}
 				Ref<VisualShaderNodeCompare> compare = Object::cast_to<VisualShaderNodeCompare>(E.value.node.ptr());
 				if (compare.is_valid()) {
 					int ctype = int(compare->get_comparison_type());
-					if (int(ctype) > 0) { // + PORT_TYPE_SCALAR_INT
-						ctype += 1;
+					if (int(ctype) > 0) { // + CTYPE_SCALAR_INT + CTYPE_VECTOR_2D
+						ctype += 2;
 					}
 					compare->set_comparison_type(VisualShaderNodeCompare::ComparisonType(ctype));
 				}
@@ -719,7 +841,7 @@ bool VisualShader::can_connect_nodes(Type p_type, int p_from_node, int p_from_po
 }
 
 bool VisualShader::is_port_types_compatible(int p_a, int p_b) const {
-	return MAX(0, p_a - 3) == (MAX(0, p_b - 3));
+	return MAX(0, p_a - 4) == (MAX(0, p_b - 4));
 }
 
 void VisualShader::connect_nodes_forced(Type p_type, int p_from_node, int p_from_port, int p_to_node, int p_to_port) {
@@ -953,15 +1075,27 @@ String VisualShader::generate_preview_shader(Type p_type, int p_node, int p_port
 	Error err = _write_node(p_type, global_code, global_code_per_node, global_code_per_func, code, default_tex_params, input_connections, output_connections, p_node, processed, true, classes);
 	ERR_FAIL_COND_V(err != OK, String());
 
-	if (node->get_output_port_type(p_port) == VisualShaderNode::PORT_TYPE_SCALAR) {
-		code += "	COLOR.rgb = vec3(n_out" + itos(p_node) + "p" + itos(p_port) + " );\n";
-	} else if (node->get_output_port_type(p_port) == VisualShaderNode::PORT_TYPE_SCALAR_INT) {
-		code += "	COLOR.rgb = vec3(float(n_out" + itos(p_node) + "p" + itos(p_port) + "));\n";
-	} else if (node->get_output_port_type(p_port) == VisualShaderNode::PORT_TYPE_BOOLEAN) {
-		code += "	COLOR.rgb = vec3(n_out" + itos(p_node) + "p" + itos(p_port) + " ? 1.0 : 0.0);\n";
-	} else {
-		code += "	COLOR.rgb = n_out" + itos(p_node) + "p" + itos(p_port) + ";\n";
+	switch (node->get_output_port_type(p_port)) {
+		case VisualShaderNode::PORT_TYPE_SCALAR: {
+			code += "	COLOR.rgb = vec3(n_out" + itos(p_node) + "p" + itos(p_port) + ");\n";
+		} break;
+		case VisualShaderNode::PORT_TYPE_SCALAR_INT: {
+			code += "	COLOR.rgb = vec3(float(n_out" + itos(p_node) + "p" + itos(p_port) + "));\n";
+		} break;
+		case VisualShaderNode::PORT_TYPE_BOOLEAN: {
+			code += "	COLOR.rgb = vec3(n_out" + itos(p_node) + "p" + itos(p_port) + " ? 1.0 : 0.0);\n";
+		} break;
+		case VisualShaderNode::PORT_TYPE_VECTOR_2D: {
+			code += "	COLOR.rgb = vec3(n_out" + itos(p_node) + "p" + itos(p_port) + ", 0.0);\n";
+		} break;
+		case VisualShaderNode::PORT_TYPE_VECTOR: {
+			code += "	COLOR.rgb = n_out" + itos(p_node) + "p" + itos(p_port) + ";\n";
+		} break;
+		default: {
+			code += "	COLOR.rgb = vec3(0.0);\n";
+		} break;
 	}
+
 	code += "}\n";
 
 	//set code secretly
@@ -1406,30 +1540,102 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 				}
 			} else if (in_type == out_type) {
 				inputs[i] = src_var;
-			} else if (in_type == VisualShaderNode::PORT_TYPE_SCALAR && out_type == VisualShaderNode::PORT_TYPE_VECTOR) {
-				inputs[i] = "dot(" + src_var + ", vec3(0.333333, 0.333333, 0.333333))";
-			} else if (in_type == VisualShaderNode::PORT_TYPE_SCALAR_INT && out_type == VisualShaderNode::PORT_TYPE_VECTOR) {
-				inputs[i] = "dot(float(" + src_var + "), vec3(0.333333, 0.333333, 0.333333))";
-			} else if (in_type == VisualShaderNode::PORT_TYPE_VECTOR && out_type == VisualShaderNode::PORT_TYPE_SCALAR) {
-				inputs[i] = "vec3(" + src_var + ")";
-			} else if (in_type == VisualShaderNode::PORT_TYPE_VECTOR && out_type == VisualShaderNode::PORT_TYPE_SCALAR_INT) {
-				inputs[i] = "vec3(float(" + src_var + "))";
-			} else if (in_type == VisualShaderNode::PORT_TYPE_BOOLEAN && out_type == VisualShaderNode::PORT_TYPE_VECTOR) {
-				inputs[i] = "all(bvec3(" + src_var + "))";
-			} else if (in_type == VisualShaderNode::PORT_TYPE_BOOLEAN && out_type == VisualShaderNode::PORT_TYPE_SCALAR) {
-				inputs[i] = src_var + " > 0.0 ? true : false";
-			} else if (in_type == VisualShaderNode::PORT_TYPE_BOOLEAN && out_type == VisualShaderNode::PORT_TYPE_SCALAR_INT) {
-				inputs[i] = src_var + " > 0 ? true : false";
-			} else if (in_type == VisualShaderNode::PORT_TYPE_SCALAR && out_type == VisualShaderNode::PORT_TYPE_BOOLEAN) {
-				inputs[i] = "(" + src_var + " ? 1.0 : 0.0)";
-			} else if (in_type == VisualShaderNode::PORT_TYPE_SCALAR_INT && out_type == VisualShaderNode::PORT_TYPE_BOOLEAN) {
-				inputs[i] = "(" + src_var + " ? 1 : 0)";
-			} else if (in_type == VisualShaderNode::PORT_TYPE_VECTOR && out_type == VisualShaderNode::PORT_TYPE_BOOLEAN) {
-				inputs[i] = "vec3(" + src_var + " ? 1.0 : 0.0)";
-			} else if (in_type == VisualShaderNode::PORT_TYPE_SCALAR && out_type == VisualShaderNode::PORT_TYPE_SCALAR_INT) {
-				inputs[i] = "float(" + src_var + ")";
-			} else if (in_type == VisualShaderNode::PORT_TYPE_SCALAR_INT && out_type == VisualShaderNode::PORT_TYPE_SCALAR) {
-				inputs[i] = "int(" + src_var + ")";
+			} else {
+				switch (in_type) {
+					case VisualShaderNode::PORT_TYPE_SCALAR: {
+						switch (out_type) {
+							case VisualShaderNode::PORT_TYPE_SCALAR_INT: {
+								inputs[i] = "float(" + src_var + ")";
+							} break;
+							case VisualShaderNode::PORT_TYPE_BOOLEAN: {
+								inputs[i] = "(" + src_var + " ? 1.0 : 0.0)";
+							} break;
+							case VisualShaderNode::PORT_TYPE_VECTOR_2D: {
+								inputs[i] = "dot(" + src_var + ", vec2(0.333333, 0.333333))";
+							} break;
+							case VisualShaderNode::PORT_TYPE_VECTOR: {
+								inputs[i] = "dot(" + src_var + ", vec3(0.333333, 0.333333, 0.333333))";
+							} break;
+							default:
+								break;
+						}
+					} break;
+					case VisualShaderNode::PORT_TYPE_SCALAR_INT: {
+						switch (out_type) {
+							case VisualShaderNode::PORT_TYPE_SCALAR: {
+								inputs[i] = "int(" + src_var + ")";
+							} break;
+							case VisualShaderNode::PORT_TYPE_BOOLEAN: {
+								inputs[i] = "(" + src_var + " ? 1 : 0)";
+							} break;
+							case VisualShaderNode::PORT_TYPE_VECTOR_2D: {
+								inputs[i] = "dot(float(" + src_var + "), vec2(0.333333, 0.333333))";
+							} break;
+							case VisualShaderNode::PORT_TYPE_VECTOR: {
+								inputs[i] = "dot(float(" + src_var + "), vec3(0.333333, 0.333333, 0.333333))";
+							} break;
+							default:
+								break;
+						}
+					} break;
+					case VisualShaderNode::PORT_TYPE_BOOLEAN: {
+						switch (out_type) {
+							case VisualShaderNode::PORT_TYPE_SCALAR: {
+								inputs[i] = src_var + " > 0.0 ? true : false";
+							} break;
+							case VisualShaderNode::PORT_TYPE_SCALAR_INT: {
+								inputs[i] = src_var + " > 0 ? true : false";
+							} break;
+							case VisualShaderNode::PORT_TYPE_VECTOR_2D: {
+								inputs[i] = "all(bvec2(" + src_var + "))";
+							} break;
+							case VisualShaderNode::PORT_TYPE_VECTOR: {
+								inputs[i] = "all(bvec3(" + src_var + "))";
+							} break;
+							default:
+								break;
+						}
+					} break;
+					case VisualShaderNode::PORT_TYPE_VECTOR_2D: {
+						switch (out_type) {
+							case VisualShaderNode::PORT_TYPE_SCALAR: {
+								inputs[i] = "vec2(" + src_var + ")";
+							} break;
+							case VisualShaderNode::PORT_TYPE_SCALAR_INT: {
+								inputs[i] = "vec2(float(" + src_var + "))";
+							} break;
+							case VisualShaderNode::PORT_TYPE_BOOLEAN: {
+								inputs[i] = "vec2(" + src_var + " ? 1.0 : 0.0)";
+							} break;
+							case VisualShaderNode::PORT_TYPE_VECTOR: {
+								inputs[i] = "vec2(" + src_var + ".xy)";
+							} break;
+							default:
+								break;
+						}
+					} break;
+
+					case VisualShaderNode::PORT_TYPE_VECTOR: {
+						switch (out_type) {
+							case VisualShaderNode::PORT_TYPE_SCALAR: {
+								inputs[i] = "vec3(" + src_var + ")";
+							} break;
+							case VisualShaderNode::PORT_TYPE_SCALAR_INT: {
+								inputs[i] = "vec3(float(" + src_var + "))";
+							} break;
+							case VisualShaderNode::PORT_TYPE_BOOLEAN: {
+								inputs[i] = "vec3(" + src_var + " ? 1.0 : 0.0)";
+							} break;
+							case VisualShaderNode::PORT_TYPE_VECTOR_2D: {
+								inputs[i] = "vec3(" + src_var + ", 0.0)";
+							} break;
+							default:
+								break;
+						}
+					} break;
+					default:
+						break;
+				}
 			}
 		} else {
 			if (!vsnode->is_generate_input_var(i)) {
@@ -1449,6 +1655,10 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 				bool val = defval;
 				inputs[i] = "n_in" + itos(node) + "p" + itos(i);
 				node_code += "	bool " + inputs[i] + " = " + (val ? "true" : "false") + ";\n";
+			} else if (defval.get_type() == Variant::VECTOR2) {
+				Vector2 val = defval;
+				inputs[i] = "n_in" + itos(node) + "p" + itos(i);
+				node_code += "	vec2 " + inputs[i] + " = " + vformat("vec2(%.5f, %.5f);\n", val.x, val.y);
 			} else if (defval.get_type() == Variant::VECTOR3) {
 				Vector3 val = defval;
 				inputs[i] = "n_in" + itos(node) + "p" + itos(i);
@@ -1485,8 +1695,15 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 		if (vsnode->is_output_port_expandable(i) && vsnode->_is_output_port_expanded(i)) {
 			expanded = true;
 
-			if (vsnode->get_output_port_type(i) == VisualShaderNode::PORT_TYPE_VECTOR) {
-				output_count += 3;
+			switch (vsnode->get_output_port_type(i)) {
+				case VisualShaderNode::PORT_TYPE_VECTOR_2D: {
+					output_count += 2;
+				} break;
+				case VisualShaderNode::PORT_TYPE_VECTOR: {
+					output_count += 3;
+				} break;
+				default:
+					break;
 			}
 		}
 		expanded_output_ports.insert(i, expanded);
@@ -1506,6 +1723,9 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 				case VisualShaderNode::PORT_TYPE_SCALAR_INT:
 					outputs[i] = "int " + var_name;
 					break;
+				case VisualShaderNode::PORT_TYPE_VECTOR_2D:
+					outputs[i] = "vec2 " + var_name;
+					break;
 				case VisualShaderNode::PORT_TYPE_VECTOR:
 					outputs[i] = "vec3 " + var_name;
 					break;
@@ -1515,12 +1735,19 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 				case VisualShaderNode::PORT_TYPE_TRANSFORM:
 					outputs[i] = "mat4 " + var_name;
 					break;
-				default: {
-				}
+				default:
+					break;
 			}
 			if (expanded_output_ports[i]) {
-				if (vsnode->get_output_port_type(i) == VisualShaderNode::PORT_TYPE_VECTOR) {
-					j += 3;
+				switch (vsnode->get_output_port_type(i)) {
+					case VisualShaderNode::PORT_TYPE_VECTOR_2D: {
+						j += 2;
+					} break;
+					case VisualShaderNode::PORT_TYPE_VECTOR: {
+						j += 3;
+					} break;
+					default:
+						break;
 				}
 			}
 		}
@@ -1535,6 +1762,9 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 				case VisualShaderNode::PORT_TYPE_SCALAR_INT:
 					code += "	int " + outputs[i] + ";\n";
 					break;
+				case VisualShaderNode::PORT_TYPE_VECTOR_2D:
+					code += "	vec2 " + outputs[i] + ";\n";
+					break;
 				case VisualShaderNode::PORT_TYPE_VECTOR:
 					code += "	vec3 " + outputs[i] + ";\n";
 					break;
@@ -1544,12 +1774,19 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 				case VisualShaderNode::PORT_TYPE_TRANSFORM:
 					code += "	mat4 " + outputs[i] + ";\n";
 					break;
-				default: {
-				}
+				default:
+					break;
 			}
 			if (expanded_output_ports[i]) {
-				if (vsnode->get_output_port_type(i) == VisualShaderNode::PORT_TYPE_VECTOR) {
-					j += 3;
+				switch (vsnode->get_output_port_type(i)) {
+					case VisualShaderNode::PORT_TYPE_VECTOR_2D: {
+						j += 2;
+					} break;
+					case VisualShaderNode::PORT_TYPE_VECTOR: {
+						j += 3;
+					} break;
+					default:
+						break;
 				}
 			}
 		}
@@ -1565,38 +1802,65 @@ Error VisualShader::_write_node(Type type, StringBuilder &global_code, StringBui
 	for (int i = 0; i < output_count; i++) {
 		bool new_line_inserted = false;
 		if (expanded_output_ports[i]) {
-			if (vsnode->get_output_port_type(i) == VisualShaderNode::PORT_TYPE_VECTOR) {
-				if (vsnode->is_output_port_connected(i + 1) || (for_preview && vsnode->get_output_port_for_preview() == (i + 1))) { // red-component
-					if (!new_line_inserted) {
-						code += "\n";
-						new_line_inserted = true;
+			switch (vsnode->get_output_port_type(i)) {
+				case VisualShaderNode::PORT_TYPE_VECTOR_2D: {
+					if (vsnode->is_output_port_connected(i + 1) || (for_preview && vsnode->get_output_port_for_preview() == (i + 1))) { // red-component
+						if (!new_line_inserted) {
+							code += "\n";
+							new_line_inserted = true;
+						}
+						String r = "n_out" + itos(node) + "p" + itos(i + 1);
+						code += "	float " + r + " = n_out" + itos(node) + "p" + itos(i) + ".r;\n";
+						outputs[i + 1] = r;
 					}
-					String r = "n_out" + itos(node) + "p" + itos(i + 1);
-					code += "	float " + r + " = n_out" + itos(node) + "p" + itos(i) + ".r;\n";
-					outputs[i + 1] = r;
-				}
 
-				if (vsnode->is_output_port_connected(i + 2) || (for_preview && vsnode->get_output_port_for_preview() == (i + 2))) { // green-component
-					if (!new_line_inserted) {
-						code += "\n";
-						new_line_inserted = true;
+					if (vsnode->is_output_port_connected(i + 2) || (for_preview && vsnode->get_output_port_for_preview() == (i + 2))) { // green-component
+						if (!new_line_inserted) {
+							code += "\n";
+							new_line_inserted = true;
+						}
+						String g = "n_out" + itos(node) + "p" + itos(i + 2);
+						code += "	float " + g + " = n_out" + itos(node) + "p" + itos(i) + ".g;\n";
+						outputs[i + 2] = g;
 					}
-					String g = "n_out" + itos(node) + "p" + itos(i + 2);
-					code += "	float " + g + " = n_out" + itos(node) + "p" + itos(i) + ".g;\n";
-					outputs[i + 2] = g;
-				}
 
-				if (vsnode->is_output_port_connected(i + 3) || (for_preview && vsnode->get_output_port_for_preview() == (i + 3))) { // blue-component
-					if (!new_line_inserted) {
-						code += "\n";
-						new_line_inserted = true;
+					i += 2;
+				} break;
+				case VisualShaderNode::PORT_TYPE_VECTOR: {
+					if (vsnode->is_output_port_connected(i + 1) || (for_preview && vsnode->get_output_port_for_preview() == (i + 1))) { // red-component
+						if (!new_line_inserted) {
+							code += "\n";
+							new_line_inserted = true;
+						}
+						String r = "n_out" + itos(node) + "p" + itos(i + 1);
+						code += "	float " + r + " = n_out" + itos(node) + "p" + itos(i) + ".r;\n";
+						outputs[i + 1] = r;
 					}
-					String b = "n_out" + itos(node) + "p" + itos(i + 3);
-					code += "	float " + b + " = n_out" + itos(node) + "p" + itos(i) + ".b;\n";
-					outputs[i + 3] = b;
-				}
 
-				i += 3;
+					if (vsnode->is_output_port_connected(i + 2) || (for_preview && vsnode->get_output_port_for_preview() == (i + 2))) { // green-component
+						if (!new_line_inserted) {
+							code += "\n";
+							new_line_inserted = true;
+						}
+						String g = "n_out" + itos(node) + "p" + itos(i + 2);
+						code += "	float " + g + " = n_out" + itos(node) + "p" + itos(i) + ".g;\n";
+						outputs[i + 2] = g;
+					}
+
+					if (vsnode->is_output_port_connected(i + 3) || (for_preview && vsnode->get_output_port_for_preview() == (i + 3))) { // blue-component
+						if (!new_line_inserted) {
+							code += "\n";
+							new_line_inserted = true;
+						}
+						String b = "n_out" + itos(node) + "p" + itos(i + 3);
+						code += "	float " + b + " = n_out" + itos(node) + "p" + itos(i) + ".b;\n";
+						outputs[i + 3] = b;
+					}
+
+					i += 3;
+				} break;
+				default:
+					break;
 			}
 		}
 	}
@@ -2066,8 +2330,8 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::ports[] = {
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "normal", "NORMAL" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "tangent", "TANGENT" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "binormal", "BINORMAL" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "vec3(UV, 0.0)" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "uv2", "vec3(UV2, 0.0)" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv2", "UV2" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "color", "COLOR.rgb" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "COLOR.a" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_SCALAR, "point_size", "POINT_SIZE" },
@@ -2082,7 +2346,7 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::ports[] = {
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_TRANSFORM, "projection", "PROJECTION_MATRIX" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_TRANSFORM, "inv_projection", "INV_PROJECTION_MATRIX" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "viewport_size", "vec3(VIEWPORT_SIZE, 0)" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "viewport_size", "VIEWPORT_SIZE" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_BOOLEAN, "output_is_srgb", "OUTPUT_IS_SRGB" },
 
 	// Node3D, Fragment
@@ -2092,19 +2356,19 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::ports[] = {
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "tangent", "TANGENT" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "binormal", "BINORMAL" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "view", "VIEW" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "vec3(UV, 0.0)" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "uv2", "vec3(UV2, 0.0)" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv2", "UV2" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "color", "COLOR.rgb" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "COLOR.a" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "point_coord", "vec3(POINT_COORD, 0.0)" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "screen_uv", "vec3(SCREEN_UV, 0.0)" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "point_coord", "POINT_COORD" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "screen_uv", "SCREEN_UV" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_TRANSFORM, "world", "WORLD_MATRIX" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_TRANSFORM, "inv_camera", "INV_CAMERA_MATRIX" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_TRANSFORM, "camera", "CAMERA_MATRIX" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_TRANSFORM, "projection", "PROJECTION_MATRIX" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_TRANSFORM, "inv_projection", "INV_PROJECTION_MATRIX" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "viewport_size", "vec3(VIEWPORT_SIZE, 0.0)" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "viewport_size", "VIEWPORT_SIZE" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_BOOLEAN, "output_is_srgb", "OUTPUT_IS_SRGB" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_BOOLEAN, "front_facing", "FRONT_FACING" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SAMPLER, "screen_texture", "SCREEN_TEXTURE" },
@@ -2114,8 +2378,8 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::ports[] = {
 	// Node3D, Light
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "fragcoord", "FRAGCOORD.xyz" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "normal", "NORMAL" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "vec3(UV, 0.0)" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "uv2", "vec3(UV2, 0.0)" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv2", "UV2" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "view", "VIEW" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "light", "LIGHT" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "light_color", "LIGHT_COLOR" },
@@ -2132,18 +2396,18 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::ports[] = {
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_TRANSFORM, "projection", "PROJECTION_MATRIX" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_TRANSFORM, "inv_projection", "INV_PROJECTION_MATRIX" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "viewport_size", "vec3(VIEWPORT_SIZE, 0.0)" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "viewport_size", "VIEWPORT_SIZE" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_BOOLEAN, "output_is_srgb", "OUTPUT_IS_SRGB" },
 
 	// Canvas Item
 
 	// Canvas Item, Vertex
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "vertex", "vec3(VERTEX, 0.0)" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "vec3(UV, 0.0)" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "vertex", "VERTEX" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "color", "COLOR.rgb" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "COLOR.a" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_SCALAR, "point_size", "POINT_SIZE" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "texture_pixel_size", "vec3(TEXTURE_PIXEL_SIZE, 1.0)" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "texture_pixel_size", "TEXTURE_PIXEL_SIZE" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_TRANSFORM, "world", "WORLD_MATRIX" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_TRANSFORM, "canvas", "CANVAS_MATRIX" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_TRANSFORM, "screen", "SCREEN_MATRIX" },
@@ -2154,13 +2418,13 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::ports[] = {
 
 	// Canvas Item, Fragment
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "fragcoord", "FRAGCOORD.xyz" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "vec3(UV, 0.0)" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "color", "COLOR.rgb" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "COLOR.a" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "screen_uv", "vec3(SCREEN_UV, 0.0)" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "texture_pixel_size", "vec3(TEXTURE_PIXEL_SIZE, 1.0)" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "screen_pixel_size", "vec3(SCREEN_PIXEL_SIZE, 1.0)" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "point_coord", "vec3(POINT_COORD, 0.0)" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "screen_uv", "SCREEN_UV" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "texture_pixel_size", "TEXTURE_PIXEL_SIZE" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "screen_pixel_size", "SCREEN_PIXEL_SIZE" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "point_coord", "POINT_COORD" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_BOOLEAN, "at_light_pass", "AT_LIGHT_PASS" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SAMPLER, "texture", "TEXTURE" },
@@ -2169,11 +2433,11 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::ports[] = {
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "specular_shininess", "SPECULAR_SHININESS.rgb" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "specular_shininess_alpha", "SPECULAR_SHININESS.a" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SAMPLER, "specular_shininess_texture", "SPECULAR_SHININESS_TEXTURE" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "vertex", "vec3(VERTEX, 0.0)" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "vertex", "VERTEX" },
 
 	// Canvas Item, Light
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "fragcoord", "FRAGCOORD.xyz" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "vec3(UV, 0.0)" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "normal", "NORMAL" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "color", "COLOR.rgb" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "COLOR.a" },
@@ -2185,9 +2449,9 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::ports[] = {
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "light_vertex", "LIGHT_VERTEX" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "shadow", "SHADOW_MODULATE.rgb" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_SCALAR, "shadow_alpha", "SHADOW_MODULATE.a" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "screen_uv", "vec3(SCREEN_UV, 0.0)" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "texture_pixel_size", "vec3(TEXTURE_PIXEL_SIZE, 1.0)" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "point_coord", "vec3(POINT_COORD, 0.0)" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "screen_uv", "SCREEN_UV" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "texture_pixel_size", "TEXTURE_PIXEL_SIZE" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "point_coord", "POINT_COORD" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_SAMPLER, "texture", "TEXTURE" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "specular_shininess", "SPECULAR_SHININESS.rgb" },
@@ -2302,8 +2566,8 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::ports[] = {
 	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_VECTOR, "quarter_res_color", "QUARTER_RES_COLOR.rgb" },
 	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_SCALAR, "quarter_res_alpha", "QUARTER_RES_COLOR.a" },
 	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_SAMPLER, "radiance", "RADIANCE" },
-	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_VECTOR, "screen_uv", "vec3(SCREEN_UV, 0.0)" },
-	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_VECTOR, "sky_coords", "vec3(SKY_COORDS, 0.0)" },
+	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_VECTOR_2D, "screen_uv", "SCREEN_UV" },
+	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_VECTOR_2D, "sky_coords", "SKY_COORDS" },
 	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
 
 	// Fog, Fog
@@ -2324,11 +2588,11 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::preview_ports[] = {
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "normal", "vec3(0.0, 0.0, 1.0)" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "tangent", "vec3(0.0, 1.0, 0.0)" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "binormal", "vec3(1.0, 0.0, 0.0)" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "vec3(UV, 0.0)" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "uv2", "vec3(UV, 0.0)" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv2", "UV" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "color", "vec3(1.0)" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "1.0" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "viewport_size", "vec3(1.0, 1.0, 0.0)" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "viewport_size", "vec2(1.0)" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
 
 	// Spatial, Fragment
@@ -2337,27 +2601,27 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::preview_ports[] = {
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "normal", "vec3(0.0, 0.0, 1.0)" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "tangent", "vec3(0.0, 1.0, 0.0)" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "binormal", "vec3(1.0, 0.0, 0.0)" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "vec3(UV, 0.0)" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "uv2", "vec3(UV, 0.0)" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv2", "UV" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "color", "vec3(1.0)" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "1.0" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "screen_uv", "vec3(SCREEN_UV, 0.0)" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "viewport_size", "vec3(1.0, 1.0, 0.0)" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "screen_uv", "SCREEN_UV" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "viewport_size", "vec2(1.0)" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
 
 	// Spatial, Light
 
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "fragcoord", "FRAGCOORD.rgb" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "normal", "vec3(0.0, 0.0, 1.0)" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "vec3(UV, 0.0)" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "uv2", "vec3(UV, 0.0)" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "viewport_size", "vec3(1.0, 1.0, 0.0)" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv2", "UV" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "viewport_size", "vec2(1.0)" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
 
 	// Canvas Item, Vertex
 
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "vertex", "vec3(VERTEX, 0.0)" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "vec3(UV, 0.0)" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "vertex", "VERTEX" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "color", "vec3(1.0)" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "1.0" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
@@ -2365,20 +2629,20 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::preview_ports[] = {
 	// Canvas Item, Fragment
 
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "fragcoord", "FRAGCOORD.rgb" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "vec3(UV, 0.0)" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "color", "vec3(1.0)" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "1.0" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "screen_uv", "vec3(SCREEN_UV, 0.0)" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "screen_uv", "SCREEN_UV" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
 
 	// Canvas Item, Light
 
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "fragcoord", "FRAGCOORD.rgb" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "vec3(UV, 0.0)" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "normal", "vec3(0.0, 0.0, 1.0)" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "color", "vec3(1.0)" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "1.0" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR, "screen_uv", "vec3(SCREEN_UV, 0.0)" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "screen_uv", "SCREEN_UV" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_LIGHT, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
 
 	// Particles
@@ -2391,7 +2655,7 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::preview_ports[] = {
 
 	// Sky
 
-	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_VECTOR, "screen_uv", "vec3(SCREEN_UV, 0.0)" },
+	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_VECTOR_2D, "screen_uv", "SCREEN_UV" },
 	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
 
 	// Fog
@@ -2454,6 +2718,9 @@ String VisualShaderNodeInput::generate_code(Shader::Mode p_mode, VisualShader::T
 				} break;
 				case PORT_TYPE_SCALAR_INT: {
 					code = "	" + p_output_vars[0] + " = 0;\n";
+				} break;
+				case PORT_TYPE_VECTOR_2D: {
+					code = "	" + p_output_vars[0] + " = vec2(0.0);\n";
 				} break;
 				case PORT_TYPE_VECTOR: {
 					code = "	" + p_output_vars[0] + " = vec3(0.0);\n";
@@ -2670,7 +2937,9 @@ int VisualShaderNodeUniformRef::get_output_port_count() const {
 			return 1;
 		case UniformType::UNIFORM_TYPE_BOOLEAN:
 			return 1;
-		case UniformType::UNIFORM_TYPE_VECTOR:
+		case UniformType::UNIFORM_TYPE_VECTOR2:
+			return 1;
+		case UniformType::UNIFORM_TYPE_VECTOR3:
 			return 1;
 		case UniformType::UNIFORM_TYPE_TRANSFORM:
 			return 1;
@@ -2692,7 +2961,9 @@ VisualShaderNodeUniformRef::PortType VisualShaderNodeUniformRef::get_output_port
 			return PortType::PORT_TYPE_SCALAR_INT;
 		case UniformType::UNIFORM_TYPE_BOOLEAN:
 			return PortType::PORT_TYPE_BOOLEAN;
-		case UniformType::UNIFORM_TYPE_VECTOR:
+		case UniformType::UNIFORM_TYPE_VECTOR2:
+			return PortType::PORT_TYPE_VECTOR_2D;
+		case UniformType::UNIFORM_TYPE_VECTOR3:
 			return PortType::PORT_TYPE_VECTOR;
 		case UniformType::UNIFORM_TYPE_TRANSFORM:
 			return PortType::PORT_TYPE_TRANSFORM;
@@ -2719,7 +2990,9 @@ String VisualShaderNodeUniformRef::get_output_port_name(int p_port) const {
 			return "";
 		case UniformType::UNIFORM_TYPE_BOOLEAN:
 			return "";
-		case UniformType::UNIFORM_TYPE_VECTOR:
+		case UniformType::UNIFORM_TYPE_VECTOR2:
+			return "";
+		case UniformType::UNIFORM_TYPE_VECTOR3:
 			return "";
 		case UniformType::UNIFORM_TYPE_TRANSFORM:
 			return "";
@@ -2789,7 +3062,9 @@ VisualShaderNodeUniformRef::PortType VisualShaderNodeUniformRef::get_port_type_b
 				return PORT_TYPE_SCALAR_INT;
 			case UniformType::UNIFORM_TYPE_SAMPLER:
 				return PORT_TYPE_SAMPLER;
-			case UniformType::UNIFORM_TYPE_VECTOR:
+			case UniformType::UNIFORM_TYPE_VECTOR2:
+				return PORT_TYPE_VECTOR_2D;
+			case UniformType::UNIFORM_TYPE_VECTOR3:
 				return PORT_TYPE_VECTOR;
 			case UniformType::UNIFORM_TYPE_TRANSFORM:
 				return PORT_TYPE_TRANSFORM;
@@ -2808,26 +3083,19 @@ String VisualShaderNodeUniformRef::generate_code(Shader::Mode p_mode, VisualShad
 			if (uniform_name == "[None]") {
 				return "	" + p_output_vars[0] + " = 0.0;\n";
 			}
-			return "	" + p_output_vars[0] + " = " + get_uniform_name() + ";\n";
-		case UniformType::UNIFORM_TYPE_INT:
-			return "	" + p_output_vars[0] + " = " + get_uniform_name() + ";\n";
-		case UniformType::UNIFORM_TYPE_BOOLEAN:
-			return "	" + p_output_vars[0] + " = " + get_uniform_name() + ";\n";
-		case UniformType::UNIFORM_TYPE_VECTOR:
-			return "	" + p_output_vars[0] + " = " + get_uniform_name() + ";\n";
-		case UniformType::UNIFORM_TYPE_TRANSFORM:
-			return "	" + p_output_vars[0] + " = " + get_uniform_name() + ";\n";
+			break;
 		case UniformType::UNIFORM_TYPE_COLOR: {
 			String code = "	" + p_output_vars[0] + " = " + get_uniform_name() + ".rgb;\n";
 			code += "	" + p_output_vars[1] + " = " + get_uniform_name() + ".a;\n";
 			return code;
 		} break;
 		case UniformType::UNIFORM_TYPE_SAMPLER:
-			break;
+			return String();
 		default:
 			break;
 	}
-	return "";
+
+	return "	" + p_output_vars[0] + " = " + get_uniform_name() + ";\n";
 }
 
 void VisualShaderNodeUniformRef::_set_uniform_type(int p_uniform_type) {
@@ -2871,8 +3139,8 @@ const VisualShaderNodeOutput::Port VisualShaderNodeOutput::ports[] = {
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "normal", "NORMAL" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "tangent", "TANGENT" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "binormal", "BINORMAL" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "UV:xy" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "uv2", "UV2:xy" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv2", "UV2" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "color", "COLOR.rgb" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "COLOR.a" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_SCALAR, "roughness", "ROUGHNESS" },
@@ -2897,7 +3165,7 @@ const VisualShaderNodeOutput::Port VisualShaderNodeOutput::ports[] = {
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "clearcoat", "CLEARCOAT" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "clearcoat_gloss", "CLEARCOAT_GLOSS" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "anisotropy", "ANISOTROPY" },
-	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "anisotropy_flow", "ANISOTROPY_FLOW:xy" },
+	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "anisotropy_flow", "ANISOTROPY_FLOW" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "subsurf_scatter", "SSS_STRENGTH" },
 	{ Shader::MODE_SPATIAL, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "backlight", "BACKLIGHT" },
 
@@ -2915,8 +3183,8 @@ const VisualShaderNodeOutput::Port VisualShaderNodeOutput::ports[] = {
 	////////////////////////////////////////////////////////////////////////
 	// Canvas Item, Vertex.
 	////////////////////////////////////////////////////////////////////////
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "vertex", "VERTEX:xy" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "uv", "UV:xy" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "vertex", "VERTEX" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR_2D, "uv", "UV" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_VECTOR, "color", "COLOR.rgb" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_SCALAR, "alpha", "COLOR.a" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_VERTEX, VisualShaderNode::PORT_TYPE_SCALAR, "point_size", "POINT_SIZE" },
@@ -2929,7 +3197,7 @@ const VisualShaderNodeOutput::Port VisualShaderNodeOutput::ports[] = {
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "normal_map", "NORMAL_MAP" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_SCALAR, "normal_map_depth", "NORMAL_MAP_DEPTH" },
 	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "light_vertex", "LIGHT_VERTEX" },
-	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR, "shadow_vertex", "SHADOW_VERTEX:xy" },
+	{ Shader::MODE_CANVAS_ITEM, VisualShader::TYPE_FRAGMENT, VisualShaderNode::PORT_TYPE_VECTOR_2D, "shadow_vertex", "SHADOW_VERTEX" },
 	////////////////////////////////////////////////////////////////////////
 	// Canvas Item, Light.
 	////////////////////////////////////////////////////////////////////////
@@ -3879,6 +4147,9 @@ String VisualShaderNodeExpression::generate_code(Shader::Mode p_mode, VisualShad
 				break;
 			case PORT_TYPE_SCALAR_INT:
 				tk = "0";
+				break;
+			case PORT_TYPE_VECTOR_2D:
+				tk = "vec2(0.0, 0.0)";
 				break;
 			case PORT_TYPE_VECTOR:
 				tk = "vec3(0.0, 0.0, 0.0)";

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -214,6 +214,7 @@ public:
 	enum PortType {
 		PORT_TYPE_SCALAR,
 		PORT_TYPE_SCALAR_INT,
+		PORT_TYPE_VECTOR_2D,
 		PORT_TYPE_VECTOR,
 		PORT_TYPE_BOOLEAN,
 		PORT_TYPE_TRANSFORM,
@@ -229,7 +230,7 @@ public:
 	virtual PortType get_input_port_type(int p_port) const = 0;
 	virtual String get_input_port_name(int p_port) const = 0;
 
-	virtual void set_input_port_default_value(int p_port, const Variant &p_value);
+	virtual void set_input_port_default_value(int p_port, const Variant &p_value, const Variant &p_prev_value = Variant());
 	Variant get_input_port_default_value(int p_port) const; // if NIL (default if node does not set anything) is returned, it means no default value is wanted if disconnected, thus no input var must be supplied (empty string will be supplied)
 	Array get_default_input_values() const;
 	virtual void set_default_input_values(const Array &p_values);
@@ -311,7 +312,7 @@ protected:
 	virtual PortType get_output_port_type(int p_port) const override;
 	virtual String get_output_port_name(int p_port) const override;
 
-	virtual void set_input_port_default_value(int p_port, const Variant &p_value) override;
+	virtual void set_input_port_default_value(int p_port, const Variant &p_value, const Variant &p_prev_value = Variant()) override;
 	virtual void set_default_input_values(const Array &p_values) override;
 	virtual void remove_input_port_default_value(int p_port) override;
 	virtual void clear_default_input_values() override;
@@ -492,7 +493,8 @@ public:
 		UNIFORM_TYPE_FLOAT,
 		UNIFORM_TYPE_INT,
 		UNIFORM_TYPE_BOOLEAN,
-		UNIFORM_TYPE_VECTOR,
+		UNIFORM_TYPE_VECTOR2,
+		UNIFORM_TYPE_VECTOR3,
 		UNIFORM_TYPE_TRANSFORM,
 		UNIFORM_TYPE_COLOR,
 		UNIFORM_TYPE_SAMPLER,

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -30,6 +30,65 @@
 
 #include "visual_shader_nodes.h"
 
+////////////// Vector Base
+
+VisualShaderNodeVectorBase::PortType VisualShaderNodeVectorBase::get_input_port_type(int p_port) const {
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
+			return PORT_TYPE_VECTOR;
+		default:
+			break;
+	}
+	return PORT_TYPE_SCALAR;
+}
+
+VisualShaderNodeVectorBase::PortType VisualShaderNodeVectorBase::get_output_port_type(int p_port) const {
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
+			return PORT_TYPE_VECTOR;
+		default:
+			break;
+	}
+	return PORT_TYPE_SCALAR;
+}
+
+void VisualShaderNodeVectorBase::set_op_type(OpType p_op_type) {
+	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	if (op_type == p_op_type) {
+		return;
+	}
+	op_type = p_op_type;
+	emit_changed();
+}
+
+VisualShaderNodeVectorBase::OpType VisualShaderNodeVectorBase::get_op_type() const {
+	return op_type;
+}
+
+void VisualShaderNodeVectorBase::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_op_type", "type"), &VisualShaderNodeVectorBase::set_op_type);
+	ClassDB::bind_method(D_METHOD("get_op_type"), &VisualShaderNodeVectorBase::get_op_type);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Vector2,Vector3"), "set_op_type", "get_op_type");
+
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_2D);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_3D);
+	BIND_ENUM_CONSTANT(OP_TYPE_MAX);
+}
+
+Vector<StringName> VisualShaderNodeVectorBase::get_editable_properties() const {
+	Vector<StringName> props;
+	props.push_back("op_type");
+	return props;
+}
+
+VisualShaderNodeVectorBase::VisualShaderNodeVectorBase() {
+}
+
 ////////////// Constants Base
 
 VisualShaderNodeConstant::VisualShaderNodeConstant() {
@@ -294,10 +353,72 @@ void VisualShaderNodeColorConstant::_bind_methods() {
 VisualShaderNodeColorConstant::VisualShaderNodeColorConstant() {
 }
 
-////////////// Vector
+////////////// Vector2
+
+String VisualShaderNodeVec2Constant::get_caption() const {
+	return "Vector2Constant";
+}
+
+int VisualShaderNodeVec2Constant::get_input_port_count() const {
+	return 0;
+}
+
+VisualShaderNodeVec2Constant::PortType VisualShaderNodeVec2Constant::get_input_port_type(int p_port) const {
+	return PORT_TYPE_VECTOR_2D;
+}
+
+String VisualShaderNodeVec2Constant::get_input_port_name(int p_port) const {
+	return String();
+}
+
+int VisualShaderNodeVec2Constant::get_output_port_count() const {
+	return 1;
+}
+
+VisualShaderNodeVec2Constant::PortType VisualShaderNodeVec2Constant::get_output_port_type(int p_port) const {
+	return PORT_TYPE_VECTOR_2D;
+}
+
+String VisualShaderNodeVec2Constant::get_output_port_name(int p_port) const {
+	return ""; //no output port means the editor will be used as port
+}
+
+String VisualShaderNodeVec2Constant::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
+	return "	" + p_output_vars[0] + " = " + vformat("vec2(%.6f, %.6f)", constant.x, constant.y) + ";\n";
+}
+
+void VisualShaderNodeVec2Constant::set_constant(const Vector2 &p_constant) {
+	if (constant.is_equal_approx(p_constant)) {
+		return;
+	}
+	constant = p_constant;
+	emit_changed();
+}
+
+Vector2 VisualShaderNodeVec2Constant::get_constant() const {
+	return constant;
+}
+
+Vector<StringName> VisualShaderNodeVec2Constant::get_editable_properties() const {
+	Vector<StringName> props;
+	props.push_back("constant");
+	return props;
+}
+
+void VisualShaderNodeVec2Constant::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_constant", "constant"), &VisualShaderNodeVec2Constant::set_constant);
+	ClassDB::bind_method(D_METHOD("get_constant"), &VisualShaderNodeVec2Constant::get_constant);
+
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "constant"), "set_constant", "get_constant");
+}
+
+VisualShaderNodeVec2Constant::VisualShaderNodeVec2Constant() {
+}
+
+////////////// Vector3
 
 String VisualShaderNodeVec3Constant::get_caption() const {
-	return "VectorConstant";
+	return "Vector3Constant";
 }
 
 int VisualShaderNodeVec3Constant::get_input_port_count() const {
@@ -439,7 +560,7 @@ int VisualShaderNodeTexture::get_input_port_count() const {
 VisualShaderNodeTexture::PortType VisualShaderNodeTexture::get_input_port_type(int p_port) const {
 	switch (p_port) {
 		case 0:
-			return PORT_TYPE_VECTOR;
+			return PORT_TYPE_VECTOR_2D;
 		case 1:
 			return PORT_TYPE_SCALAR;
 		case 2:
@@ -529,7 +650,7 @@ String VisualShaderNodeTexture::generate_global(Shader::Mode p_mode, VisualShade
 String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String default_uv;
 	if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
-		default_uv = "UV.xy";
+		default_uv = "UV";
 	} else {
 		default_uv = "vec2(0.0)";
 	}
@@ -547,9 +668,9 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 
 		} else if (p_input_vars[1].is_empty()) {
 			//no lod
-			code += "	vec4 " + id + "_read = texture(" + id + ", " + p_input_vars[0] + ".xy);\n";
+			code += "	vec4 " + id + "_read = texture(" + id + ", " + p_input_vars[0] + ");\n";
 		} else {
-			code += "	vec4 " + id + "_read = textureLod(" + id + ", " + p_input_vars[0] + ".xy, " + p_input_vars[1] + ");\n";
+			code += "	vec4 " + id + "_read = textureLod(" + id + ", " + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
 		}
 
 		code += "	" + p_output_vars[0] + " = " + id + "_read.rgb;\n";
@@ -575,9 +696,9 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 
 			} else if (p_input_vars[1].is_empty()) {
 				//no lod
-				code += "		vec4 " + id + "_tex_read = texture(" + id + ", " + p_input_vars[0] + ".xy);\n";
+				code += "		vec4 " + id + "_tex_read = texture(" + id + ", " + p_input_vars[0] + ");\n";
 			} else {
-				code += "		vec4 " + id + "_tex_read = textureLod(" + id + ", " + p_input_vars[0] + ".xy, " + p_input_vars[1] + ");\n";
+				code += "		vec4 " + id + "_tex_read = textureLod(" + id + ", " + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
 			}
 
 			code += "		" + p_output_vars[0] + " = " + id + "_tex_read.rgb;\n";
@@ -599,9 +720,9 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 
 		} else if (p_input_vars[1].is_empty()) {
 			//no lod
-			code += "		vec4 _tex_read = textureLod(SCREEN_TEXTURE, " + p_input_vars[0] + ".xy, 0.0);\n";
+			code += "		vec4 _tex_read = textureLod(SCREEN_TEXTURE, " + p_input_vars[0] + ", 0.0);\n";
 		} else {
-			code += "		vec4 _tex_read = textureLod(SCREEN_TEXTURE, " + p_input_vars[0] + ".xy, " + p_input_vars[1] + ");\n";
+			code += "		vec4 _tex_read = textureLod(SCREEN_TEXTURE, " + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
 		}
 
 		code += "		" + p_output_vars[0] + " = _tex_read.rgb;\n";
@@ -622,9 +743,9 @@ String VisualShaderNodeTexture::generate_code(Shader::Mode p_mode, VisualShader:
 
 		} else if (p_input_vars[1].is_empty()) {
 			//no lod
-			code += "		vec4 _tex_read = texture(TEXTURE, " + p_input_vars[0] + ".xy);\n";
+			code += "		vec4 _tex_read = texture(TEXTURE, " + p_input_vars[0] + ");\n";
 		} else {
-			code += "		vec4 _tex_read = textureLod(TEXTURE, " + p_input_vars[0] + ".xy, " + p_input_vars[1] + ");\n";
+			code += "		vec4 _tex_read = textureLod(TEXTURE, " + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
 		}
 
 		code += "		" + p_output_vars[0] + " = _tex_read.rgb;\n";
@@ -1730,10 +1851,6 @@ int VisualShaderNodeVectorOp::get_input_port_count() const {
 	return 2;
 }
 
-VisualShaderNodeVectorOp::PortType VisualShaderNodeVectorOp::get_input_port_type(int p_port) const {
-	return PORT_TYPE_VECTOR;
-}
-
 String VisualShaderNodeVectorOp::get_input_port_name(int p_port) const {
 	return p_port == 0 ? "a" : "b";
 }
@@ -1742,12 +1859,8 @@ int VisualShaderNodeVectorOp::get_output_port_count() const {
 	return 1;
 }
 
-VisualShaderNodeVectorOp::PortType VisualShaderNodeVectorOp::get_output_port_type(int p_port) const {
-	return PORT_TYPE_VECTOR;
-}
-
 String VisualShaderNodeVectorOp::get_output_port_name(int p_port) const {
-	return "op"; //no output port means the editor will be used as port
+	return "op";
 }
 
 String VisualShaderNodeVectorOp::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
@@ -1778,13 +1891,21 @@ String VisualShaderNodeVectorOp::generate_code(Shader::Mode p_mode, VisualShader
 			code += "min(" + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
 			break;
 		case OP_CROSS:
-			code += "cross(" + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
+			if (op_type == OP_TYPE_VECTOR_2D) { // not supported
+				code += "vec2(0.0);\n";
+			} else {
+				code += "cross(" + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
+			}
 			break;
 		case OP_ATAN2:
 			code += "atan(" + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
 			break;
 		case OP_REFLECT:
-			code += "reflect(" + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
+			if (op_type == OP_TYPE_VECTOR_2D) { // not supported
+				code += "vec2(0.0);\n";
+			} else {
+				code += "reflect(" + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
+			}
 			break;
 		case OP_STEP:
 			code += "step(" + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
@@ -1794,6 +1915,27 @@ String VisualShaderNodeVectorOp::generate_code(Shader::Mode p_mode, VisualShader
 	}
 
 	return code;
+}
+
+void VisualShaderNodeVectorOp::set_op_type(OpType p_op_type) {
+	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	if (op_type == p_op_type) {
+		return;
+	}
+	switch (p_op_type) {
+		case OP_TYPE_VECTOR_2D: {
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector2(), get_input_port_default_value(1));
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector3(), get_input_port_default_value(1));
+		} break;
+		default:
+			break;
+	}
+	op_type = p_op_type;
+	emit_changed();
 }
 
 void VisualShaderNodeVectorOp::set_operator(Operator p_op) {
@@ -1810,9 +1952,25 @@ VisualShaderNodeVectorOp::Operator VisualShaderNodeVectorOp::get_operator() cons
 }
 
 Vector<StringName> VisualShaderNodeVectorOp::get_editable_properties() const {
-	Vector<StringName> props;
+	Vector<StringName> props = VisualShaderNodeVectorBase::get_editable_properties();
 	props.push_back("operator");
 	return props;
+}
+
+String VisualShaderNodeVectorOp::get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const {
+	bool invalid_type = false;
+
+	if (op_type == OP_TYPE_VECTOR_2D) {
+		if (op == OP_CROSS || op == OP_REFLECT) {
+			invalid_type = true;
+		}
+	}
+
+	if (invalid_type) {
+		return TTR("Invalid operator for that type.");
+	}
+
+	return String();
 }
 
 void VisualShaderNodeVectorOp::_bind_methods() {
@@ -1837,8 +1995,18 @@ void VisualShaderNodeVectorOp::_bind_methods() {
 }
 
 VisualShaderNodeVectorOp::VisualShaderNodeVectorOp() {
-	set_input_port_default_value(0, Vector3());
-	set_input_port_default_value(1, Vector3());
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D: {
+			set_input_port_default_value(0, Vector2());
+			set_input_port_default_value(1, Vector2());
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			set_input_port_default_value(0, Vector3());
+			set_input_port_default_value(1, Vector3());
+		} break;
+		default:
+			break;
+	}
 }
 
 ////////////// Color Op
@@ -2412,10 +2580,6 @@ int VisualShaderNodeVectorFunc::get_input_port_count() const {
 	return 1;
 }
 
-VisualShaderNodeVectorFunc::PortType VisualShaderNodeVectorFunc::get_input_port_type(int p_port) const {
-	return PORT_TYPE_VECTOR;
-}
-
 String VisualShaderNodeVectorFunc::get_input_port_name(int p_port) const {
 	return "";
 }
@@ -2424,22 +2588,18 @@ int VisualShaderNodeVectorFunc::get_output_port_count() const {
 	return 1;
 }
 
-VisualShaderNodeVectorFunc::PortType VisualShaderNodeVectorFunc::get_output_port_type(int p_port) const {
-	return PORT_TYPE_VECTOR;
-}
-
 String VisualShaderNodeVectorFunc::get_output_port_name(int p_port) const {
-	return ""; //no output port means the editor will be used as port
+	return "result";
 }
 
 String VisualShaderNodeVectorFunc::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	static const char *vec_func_id[FUNC_MAX] = {
+	static const char *funcs[FUNC_MAX] = {
 		"normalize($)",
-		"max(min($, vec3(1.0)), vec3(0.0))",
+		"", // FUNC_SATURATE
 		"-($)",
 		"1.0 / ($)",
-		"",
-		"",
+		"", // FUNC_RGB2HSV
+		"", // FUNC_HSV2RGB
 		"abs($)",
 		"acos($)",
 		"acosh($)",
@@ -2468,12 +2628,37 @@ String VisualShaderNodeVectorFunc::generate_code(Shader::Mode p_mode, VisualShad
 		"tan($)",
 		"tanh($)",
 		"trunc($)",
-		"vec3(1.0, 1.0, 1.0) - $"
+		"" // FUNC_ONEMINUS
 	};
+
+	if (func == FUNC_SATURATE) {
+		String code;
+
+		if (op_type == OP_TYPE_VECTOR_2D) {
+			code = "max(min($, vec2(1.0)), vec2(0.0))";
+		} else {
+			code = "max(min($, vec3(1.0)), vec3(0.0))";
+		}
+		return "	" + p_output_vars[0] + " = " + code.replace("$", p_input_vars[0]) + ";\n";
+	}
+
+	if (func == FUNC_ONEMINUS) {
+		String code;
+
+		if (op_type == OP_TYPE_VECTOR_2D) {
+			code = "vec2(1.0, 1.0) - $";
+		} else {
+			code = "vec3(1.0, 1.0, 1.0) - $";
+		}
+		return "	" + p_output_vars[0] + " = " + code.replace("$", p_input_vars[0]) + ";\n";
+	}
 
 	String code;
 
 	if (func == FUNC_RGB2HSV) {
+		if (op_type == OP_TYPE_VECTOR_2D) { // not supported
+			return "	" + p_output_vars[0] + " = vec2(0.0);\n";
+		}
 		code += "	{\n";
 		code += "		vec3 c = " + p_input_vars[0] + ";\n";
 		code += "		vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);\n";
@@ -2484,6 +2669,9 @@ String VisualShaderNodeVectorFunc::generate_code(Shader::Mode p_mode, VisualShad
 		code += "		" + p_output_vars[0] + " = vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);\n";
 		code += "	}\n";
 	} else if (func == FUNC_HSV2RGB) {
+		if (op_type == OP_TYPE_VECTOR_2D) { // not supported
+			return "	" + p_output_vars[0] + " = vec2(0.0);\n";
+		}
 		code += "	{\n";
 		code += "		vec3 c = " + p_input_vars[0] + ";\n";
 		code += "		vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);\n";
@@ -2492,10 +2680,29 @@ String VisualShaderNodeVectorFunc::generate_code(Shader::Mode p_mode, VisualShad
 		code += "	}\n";
 
 	} else {
-		code += "	" + p_output_vars[0] + " = " + String(vec_func_id[func]).replace("$", p_input_vars[0]) + ";\n";
+		code += "	" + p_output_vars[0] + " = " + String(funcs[func]).replace("$", p_input_vars[0]) + ";\n";
 	}
 
 	return code;
+}
+
+void VisualShaderNodeVectorFunc::set_op_type(OpType p_op_type) {
+	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	if (op_type == p_op_type) {
+		return;
+	}
+	switch (p_op_type) {
+		case OP_TYPE_VECTOR_2D: {
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0));
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0));
+		} break;
+		default:
+			break;
+	}
+	op_type = p_op_type;
+	emit_changed();
 }
 
 void VisualShaderNodeVectorFunc::set_function(Function p_func) {
@@ -2519,9 +2726,25 @@ VisualShaderNodeVectorFunc::Function VisualShaderNodeVectorFunc::get_function() 
 }
 
 Vector<StringName> VisualShaderNodeVectorFunc::get_editable_properties() const {
-	Vector<StringName> props;
+	Vector<StringName> props = VisualShaderNodeVectorBase::get_editable_properties();
 	props.push_back("function");
 	return props;
+}
+
+String VisualShaderNodeVectorFunc::get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const {
+	bool invalid_type = false;
+
+	if (op_type == OP_TYPE_VECTOR_2D) {
+		if (func == FUNC_RGB2HSV || func == FUNC_HSV2RGB) {
+			invalid_type = true;
+		}
+	}
+
+	if (invalid_type) {
+		return TTR("Invalid function for that type.");
+	}
+
+	return String();
 }
 
 void VisualShaderNodeVectorFunc::_bind_methods() {
@@ -2569,7 +2792,16 @@ void VisualShaderNodeVectorFunc::_bind_methods() {
 }
 
 VisualShaderNodeVectorFunc::VisualShaderNodeVectorFunc() {
-	set_input_port_default_value(0, Vector3());
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D: {
+			set_input_port_default_value(0, Vector2());
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			set_input_port_default_value(0, Vector3());
+		} break;
+		default:
+			break;
+	}
 }
 
 ////////////// ColorFunc
@@ -2754,11 +2986,11 @@ int VisualShaderNodeUVFunc::get_input_port_count() const {
 VisualShaderNodeUVFunc::PortType VisualShaderNodeUVFunc::get_input_port_type(int p_port) const {
 	switch (p_port) {
 		case 0:
-			[[fallthrough]]; // uv
+			return PORT_TYPE_VECTOR_2D; // uv
 		case 1:
-			return PORT_TYPE_VECTOR; // scale
+			return PORT_TYPE_VECTOR_2D; // scale
 		case 2:
-			return PORT_TYPE_VECTOR; // offset & pivot
+			return PORT_TYPE_VECTOR_2D; // offset & pivot
 		default:
 			break;
 	}
@@ -2801,7 +3033,7 @@ int VisualShaderNodeUVFunc::get_output_port_count() const {
 }
 
 VisualShaderNodeUVFunc::PortType VisualShaderNodeUVFunc::get_output_port_type(int p_port) const {
-	return PORT_TYPE_VECTOR;
+	return PORT_TYPE_VECTOR_2D;
 }
 
 String VisualShaderNodeUVFunc::get_output_port_name(int p_port) const {
@@ -2818,9 +3050,9 @@ String VisualShaderNodeUVFunc::generate_code(Shader::Mode p_mode, VisualShader::
 	String uv;
 	if (p_input_vars[0].is_empty()) {
 		if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
-			uv = "vec3(UV.xy, 0.0)";
+			uv = "UV";
 		} else {
-			uv = "vec3(0.0)";
+			uv = "vec2(0.0)";
 		}
 	} else {
 		uv = vformat("%s", p_input_vars[0]);
@@ -2847,9 +3079,9 @@ void VisualShaderNodeUVFunc::set_function(VisualShaderNodeUVFunc::Function p_fun
 		return;
 	}
 	if (p_func == FUNC_PANNING) {
-		set_input_port_default_value(2, Vector3()); // offset
+		set_input_port_default_value(2, Vector2()); // offset
 	} else { // FUNC_SCALING
-		set_input_port_default_value(2, Vector3(0.5, 0.5, 0.0)); // pivot
+		set_input_port_default_value(2, Vector2(0.5, 0.5)); // pivot
 	}
 	func = p_func;
 	emit_changed();
@@ -2877,8 +3109,8 @@ void VisualShaderNodeUVFunc::_bind_methods() {
 }
 
 VisualShaderNodeUVFunc::VisualShaderNodeUVFunc() {
-	set_input_port_default_value(1, Vector3(1.0, 1.0, 0.0)); // scale
-	set_input_port_default_value(2, Vector3()); // offset
+	set_input_port_default_value(1, Vector2(1.0, 1.0)); // scale
+	set_input_port_default_value(2, Vector2()); // offset
 }
 
 ////////////// Dot Product
@@ -2930,10 +3162,6 @@ int VisualShaderNodeVectorLen::get_input_port_count() const {
 	return 1;
 }
 
-VisualShaderNodeVectorLen::PortType VisualShaderNodeVectorLen::get_input_port_type(int p_port) const {
-	return PORT_TYPE_VECTOR;
-}
-
 String VisualShaderNodeVectorLen::get_input_port_name(int p_port) const {
 	return "";
 }
@@ -2950,12 +3178,31 @@ String VisualShaderNodeVectorLen::get_output_port_name(int p_port) const {
 	return "length";
 }
 
+void VisualShaderNodeVectorLen::set_op_type(OpType p_op_type) {
+	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	if (op_type == p_op_type) {
+		return;
+	}
+	switch (p_op_type) {
+		case OP_TYPE_VECTOR_2D: {
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0));
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0));
+		} break;
+		default:
+			break;
+	}
+	op_type = p_op_type;
+	emit_changed();
+}
+
 String VisualShaderNodeVectorLen::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	return "	" + p_output_vars[0] + " = length(" + p_input_vars[0] + ");\n";
 }
 
 VisualShaderNodeVectorLen::VisualShaderNodeVectorLen() {
-	set_input_port_default_value(0, Vector3());
+	set_input_port_default_value(0, Vector3(0.0, 0.0, 0.0));
 }
 
 ////////////// Determinant
@@ -3007,8 +3254,13 @@ int VisualShaderNodeDerivativeFunc::get_input_port_count() const {
 }
 
 VisualShaderNodeDerivativeFunc::PortType VisualShaderNodeDerivativeFunc::get_input_port_type(int p_port) const {
-	if (op_type == OP_TYPE_VECTOR) {
-		return PORT_TYPE_VECTOR;
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
+			return PORT_TYPE_VECTOR;
+		default:
+			break;
 	}
 	return PORT_TYPE_SCALAR;
 }
@@ -3022,8 +3274,13 @@ int VisualShaderNodeDerivativeFunc::get_output_port_count() const {
 }
 
 VisualShaderNodeDerivativeFunc::PortType VisualShaderNodeDerivativeFunc::get_output_port_type(int p_port) const {
-	if (op_type == OP_TYPE_VECTOR) {
-		return PORT_TYPE_VECTOR;
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
+			return PORT_TYPE_VECTOR;
+		default:
+			break;
 	}
 	return PORT_TYPE_SCALAR;
 }
@@ -3050,12 +3307,15 @@ void VisualShaderNodeDerivativeFunc::set_op_type(OpType p_op_type) {
 		return;
 	}
 	switch (p_op_type) {
-		case OP_TYPE_SCALAR:
-			set_input_port_default_value(0, 0.0);
-			break;
-		case OP_TYPE_VECTOR:
-			set_input_port_default_value(0, Vector3(0.0, 0.0, 0.0));
-			break;
+		case OP_TYPE_SCALAR: {
+			set_input_port_default_value(0, 0.0, get_input_port_default_value(0));
+		} break;
+		case OP_TYPE_VECTOR_2D: {
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0));
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0));
+		} break;
 		default:
 			break;
 	}
@@ -3094,11 +3354,12 @@ void VisualShaderNodeDerivativeFunc::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_function", "func"), &VisualShaderNodeDerivativeFunc::set_function);
 	ClassDB::bind_method(D_METHOD("get_function"), &VisualShaderNodeDerivativeFunc::get_function);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Scalar,Vector"), "set_op_type", "get_op_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Scalar,Vector2,Vector3"), "set_op_type", "get_op_type");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "function", PROPERTY_HINT_ENUM, "Sum,X,Y"), "set_function", "get_function");
 
 	BIND_ENUM_CONSTANT(OP_TYPE_SCALAR);
-	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_2D);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_3D);
 	BIND_ENUM_CONSTANT(OP_TYPE_MAX);
 
 	BIND_ENUM_CONSTANT(FUNC_SUM);
@@ -3125,7 +3386,9 @@ VisualShaderNodeClamp::PortType VisualShaderNodeClamp::get_input_port_type(int p
 	switch (op_type) {
 		case OP_TYPE_INT:
 			return PORT_TYPE_SCALAR_INT;
-		case OP_TYPE_VECTOR:
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
 			return PORT_TYPE_VECTOR;
 		default:
 			break;
@@ -3152,7 +3415,9 @@ VisualShaderNodeClamp::PortType VisualShaderNodeClamp::get_output_port_type(int 
 	switch (op_type) {
 		case OP_TYPE_INT:
 			return PORT_TYPE_SCALAR_INT;
-		case OP_TYPE_VECTOR:
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
 			return PORT_TYPE_VECTOR;
 		default:
 			break;
@@ -3175,19 +3440,24 @@ void VisualShaderNodeClamp::set_op_type(OpType p_op_type) {
 	}
 	switch (p_op_type) {
 		case OP_TYPE_FLOAT:
-			set_input_port_default_value(0, 0.0);
-			set_input_port_default_value(1, 0.0);
-			set_input_port_default_value(2, 0.0);
+			set_input_port_default_value(0, 0.0, get_input_port_default_value(0));
+			set_input_port_default_value(1, 0.0, get_input_port_default_value(1));
+			set_input_port_default_value(2, 0.0, get_input_port_default_value(2));
 			break;
 		case OP_TYPE_INT:
-			set_input_port_default_value(0, 0);
-			set_input_port_default_value(1, 0);
-			set_input_port_default_value(2, 0);
+			set_input_port_default_value(0, 0, get_input_port_default_value(0));
+			set_input_port_default_value(1, 0, get_input_port_default_value(1));
+			set_input_port_default_value(2, 0, get_input_port_default_value(2));
 			break;
-		case OP_TYPE_VECTOR:
-			set_input_port_default_value(0, Vector3(0.0, 0.0, 0.0));
-			set_input_port_default_value(1, Vector3(0.0, 0.0, 0.0));
-			set_input_port_default_value(2, Vector3(0.0, 0.0, 0.0));
+		case OP_TYPE_VECTOR_2D:
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector2(), get_input_port_default_value(1));
+			set_input_port_default_value(2, Vector2(), get_input_port_default_value(2));
+			break;
+		case OP_TYPE_VECTOR_3D:
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector3(), get_input_port_default_value(1));
+			set_input_port_default_value(2, Vector3(), get_input_port_default_value(2));
 			break;
 		default:
 			break;
@@ -3210,11 +3480,12 @@ void VisualShaderNodeClamp::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_op_type", "op_type"), &VisualShaderNodeClamp::set_op_type);
 	ClassDB::bind_method(D_METHOD("get_op_type"), &VisualShaderNodeClamp::get_op_type);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Float,Int,Vector"), "set_op_type", "get_op_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Float,Int,Vector2,Vector3"), "set_op_type", "get_op_type");
 
 	BIND_ENUM_CONSTANT(OP_TYPE_FLOAT);
 	BIND_ENUM_CONSTANT(OP_TYPE_INT);
-	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_2D);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_3D);
 	BIND_ENUM_CONSTANT(OP_TYPE_MAX);
 }
 
@@ -3234,10 +3505,6 @@ int VisualShaderNodeFaceForward::get_input_port_count() const {
 	return 3;
 }
 
-VisualShaderNodeFaceForward::PortType VisualShaderNodeFaceForward::get_input_port_type(int p_port) const {
-	return PORT_TYPE_VECTOR;
-}
-
 String VisualShaderNodeFaceForward::get_input_port_name(int p_port) const {
 	switch (p_port) {
 		case 0:
@@ -3255,12 +3522,31 @@ int VisualShaderNodeFaceForward::get_output_port_count() const {
 	return 1;
 }
 
-VisualShaderNodeFaceForward::PortType VisualShaderNodeFaceForward::get_output_port_type(int p_port) const {
-	return PORT_TYPE_VECTOR;
-}
-
 String VisualShaderNodeFaceForward::get_output_port_name(int p_port) const {
 	return "";
+}
+
+void VisualShaderNodeFaceForward::set_op_type(OpType p_op_type) {
+	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	if (op_type == p_op_type) {
+		return;
+	}
+	switch (p_op_type) {
+		case OP_TYPE_VECTOR_2D: {
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector2(), get_input_port_default_value(1));
+			set_input_port_default_value(2, Vector2(), get_input_port_default_value(2));
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector3(), get_input_port_default_value(1));
+			set_input_port_default_value(2, Vector3(), get_input_port_default_value(2));
+		} break;
+		default:
+			break;
+	}
+	op_type = p_op_type;
+	emit_changed();
 }
 
 String VisualShaderNodeFaceForward::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
@@ -3331,9 +3617,16 @@ int VisualShaderNodeStep::get_input_port_count() const {
 
 VisualShaderNodeStep::PortType VisualShaderNodeStep::get_input_port_type(int p_port) const {
 	switch (op_type) {
-		case OP_TYPE_VECTOR:
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_2D_SCALAR:
+			if (p_port == 1) {
+				return PORT_TYPE_VECTOR_2D;
+			}
+			break;
+		case OP_TYPE_VECTOR_3D:
 			return PORT_TYPE_VECTOR;
-		case OP_TYPE_VECTOR_SCALAR:
+		case OP_TYPE_VECTOR_3D_SCALAR:
 			if (p_port == 1) {
 				return PORT_TYPE_VECTOR;
 			}
@@ -3345,12 +3638,13 @@ VisualShaderNodeStep::PortType VisualShaderNodeStep::get_input_port_type(int p_p
 }
 
 String VisualShaderNodeStep::get_input_port_name(int p_port) const {
-	if (p_port == 0) {
-		return "edge";
-	} else if (p_port == 1) {
-		return "x";
+	switch (p_port) {
+		case 0:
+			return "edge";
+		case 1:
+			return "x";
 	}
-	return "";
+	return String();
 }
 
 int VisualShaderNodeStep::get_output_port_count() const {
@@ -3359,9 +3653,13 @@ int VisualShaderNodeStep::get_output_port_count() const {
 
 VisualShaderNodeStep::PortType VisualShaderNodeStep::get_output_port_type(int p_port) const {
 	switch (op_type) {
-		case OP_TYPE_VECTOR:
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_2D_SCALAR:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
 			return PORT_TYPE_VECTOR;
-		case OP_TYPE_VECTOR_SCALAR:
+		case OP_TYPE_VECTOR_3D_SCALAR:
 			return PORT_TYPE_VECTOR;
 		default:
 			break;
@@ -3379,30 +3677,26 @@ void VisualShaderNodeStep::set_op_type(OpType p_op_type) {
 		return;
 	}
 	switch (p_op_type) {
-		case OP_TYPE_SCALAR:
-			if (op_type == OP_TYPE_VECTOR) {
-				set_input_port_default_value(0, 0.0); // edge
-			}
-			if (op_type == OP_TYPE_VECTOR || op_type == OP_TYPE_VECTOR_SCALAR) {
-				set_input_port_default_value(1, 0.0); // x
-			}
-			break;
-		case OP_TYPE_VECTOR:
-			if (op_type == OP_TYPE_SCALAR || op_type == OP_TYPE_VECTOR_SCALAR) {
-				set_input_port_default_value(0, Vector3(0.0, 0.0, 0.0)); // edge
-			}
-			if (op_type == OP_TYPE_SCALAR) {
-				set_input_port_default_value(1, Vector3(0.0, 0.0, 0.0)); // x
-			}
-			break;
-		case OP_TYPE_VECTOR_SCALAR:
-			if (op_type == OP_TYPE_VECTOR) {
-				set_input_port_default_value(0, 0.0); // edge
-			}
-			if (op_type == OP_TYPE_SCALAR) {
-				set_input_port_default_value(1, Vector3(0.0, 0.0, 0.0)); // x
-			}
-			break;
+		case OP_TYPE_SCALAR: {
+			set_input_port_default_value(0, 0.0, get_input_port_default_value(0));
+			set_input_port_default_value(1, 0.0, get_input_port_default_value(1));
+		} break;
+		case OP_TYPE_VECTOR_2D: {
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector2(), get_input_port_default_value(1));
+		} break;
+		case OP_TYPE_VECTOR_2D_SCALAR: {
+			set_input_port_default_value(0, 0.0, get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector2(), get_input_port_default_value(1));
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector3(), get_input_port_default_value(1));
+		} break;
+		case OP_TYPE_VECTOR_3D_SCALAR: {
+			set_input_port_default_value(0, 0.0, get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector3(), get_input_port_default_value(1));
+		} break;
 		default:
 			break;
 	}
@@ -3428,11 +3722,13 @@ void VisualShaderNodeStep::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_op_type", "op_type"), &VisualShaderNodeStep::set_op_type);
 	ClassDB::bind_method(D_METHOD("get_op_type"), &VisualShaderNodeStep::get_op_type);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Scalar,Vector,VectorScalar"), "set_op_type", "get_op_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Scalar,Vector2,Vector2Scalar,Vector3,Vector3Scalar"), "set_op_type", "get_op_type");
 
 	BIND_ENUM_CONSTANT(OP_TYPE_SCALAR);
-	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR);
-	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_SCALAR);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_2D);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_2D_SCALAR);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_3D);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_3D_SCALAR);
 	BIND_ENUM_CONSTANT(OP_TYPE_MAX);
 }
 
@@ -3453,9 +3749,16 @@ int VisualShaderNodeSmoothStep::get_input_port_count() const {
 
 VisualShaderNodeSmoothStep::PortType VisualShaderNodeSmoothStep::get_input_port_type(int p_port) const {
 	switch (op_type) {
-		case OP_TYPE_VECTOR:
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_2D_SCALAR:
+			if (p_port == 2) {
+				return PORT_TYPE_VECTOR_2D; // x
+			}
+			break;
+		case OP_TYPE_VECTOR_3D:
 			return PORT_TYPE_VECTOR;
-		case OP_TYPE_VECTOR_SCALAR:
+		case OP_TYPE_VECTOR_3D_SCALAR:
 			if (p_port == 2) {
 				return PORT_TYPE_VECTOR; // x
 			}
@@ -3467,14 +3770,15 @@ VisualShaderNodeSmoothStep::PortType VisualShaderNodeSmoothStep::get_input_port_
 }
 
 String VisualShaderNodeSmoothStep::get_input_port_name(int p_port) const {
-	if (p_port == 0) {
-		return "edge0";
-	} else if (p_port == 1) {
-		return "edge1";
-	} else if (p_port == 2) {
-		return "x";
+	switch (p_port) {
+		case 0:
+			return "edge0";
+		case 1:
+			return "edge1";
+		case 2:
+			return "x";
 	}
-	return "";
+	return String();
 }
 
 int VisualShaderNodeSmoothStep::get_output_port_count() const {
@@ -3483,9 +3787,13 @@ int VisualShaderNodeSmoothStep::get_output_port_count() const {
 
 VisualShaderNodeSmoothStep::PortType VisualShaderNodeSmoothStep::get_output_port_type(int p_port) const {
 	switch (op_type) {
-		case OP_TYPE_VECTOR:
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_2D_SCALAR:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
 			return PORT_TYPE_VECTOR;
-		case OP_TYPE_VECTOR_SCALAR:
+		case OP_TYPE_VECTOR_3D_SCALAR:
 			return PORT_TYPE_VECTOR;
 		default:
 			break;
@@ -3504,31 +3812,29 @@ void VisualShaderNodeSmoothStep::set_op_type(OpType p_op_type) {
 	}
 	switch (p_op_type) {
 		case OP_TYPE_SCALAR:
-			if (op_type == OP_TYPE_VECTOR) {
-				set_input_port_default_value(0, 0.0); // edge0
-				set_input_port_default_value(1, 0.0); // edge1
-			}
-			if (op_type == OP_TYPE_VECTOR || op_type == OP_TYPE_VECTOR_SCALAR) {
-				set_input_port_default_value(2, 0.0); // x
-			}
+			set_input_port_default_value(0, 0.0, get_input_port_default_value(0)); // edge0
+			set_input_port_default_value(1, 0.0, get_input_port_default_value(1)); // edge1
+			set_input_port_default_value(2, 0.0, get_input_port_default_value(2)); // x
 			break;
-		case OP_TYPE_VECTOR:
-			if (op_type == OP_TYPE_SCALAR || op_type == OP_TYPE_VECTOR_SCALAR) {
-				set_input_port_default_value(0, Vector3(0.0, 0.0, 0.0)); // edge0
-				set_input_port_default_value(1, Vector3(0.0, 0.0, 0.0)); // edge1
-			}
-			if (op_type == OP_TYPE_SCALAR) {
-				set_input_port_default_value(2, Vector3(0.0, 0.0, 0.0)); // x
-			}
+		case OP_TYPE_VECTOR_2D:
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0)); // edge0
+			set_input_port_default_value(1, Vector2(), get_input_port_default_value(1)); // edge1
+			set_input_port_default_value(2, Vector2(), get_input_port_default_value(2)); // x
 			break;
-		case OP_TYPE_VECTOR_SCALAR:
-			if (op_type == OP_TYPE_VECTOR) {
-				set_input_port_default_value(0, 0.0); // edge0
-				set_input_port_default_value(1, 0.0); // edge1
-			}
-			if (op_type == OP_TYPE_SCALAR) {
-				set_input_port_default_value(2, Vector3(0.0, 0.0, 0.0)); // x
-			}
+		case OP_TYPE_VECTOR_2D_SCALAR:
+			set_input_port_default_value(0, 0.0, get_input_port_default_value(0)); // edge0
+			set_input_port_default_value(1, 0.0, get_input_port_default_value(1)); // edge1
+			set_input_port_default_value(2, Vector2(), get_input_port_default_value(2)); // x
+			break;
+		case OP_TYPE_VECTOR_3D:
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0)); // edge0
+			set_input_port_default_value(1, Vector3(), get_input_port_default_value(1)); // edge1
+			set_input_port_default_value(2, Vector3(), get_input_port_default_value(2)); // x
+			break;
+		case OP_TYPE_VECTOR_3D_SCALAR:
+			set_input_port_default_value(0, 0.0, get_input_port_default_value(0)); // edge0
+			set_input_port_default_value(1, 0.0, get_input_port_default_value(1)); // edge1
+			set_input_port_default_value(2, Vector3(), get_input_port_default_value(2)); // x
 			break;
 		default:
 			break;
@@ -3555,18 +3861,20 @@ void VisualShaderNodeSmoothStep::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_op_type", "op_type"), &VisualShaderNodeSmoothStep::set_op_type);
 	ClassDB::bind_method(D_METHOD("get_op_type"), &VisualShaderNodeSmoothStep::get_op_type);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Scalar,Vector,VectorScalar"), "set_op_type", "get_op_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Scalar,Vector2,Vector2Scalar,Vector3,Vector3Scalar"), "set_op_type", "get_op_type");
 
 	BIND_ENUM_CONSTANT(OP_TYPE_SCALAR);
-	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR);
-	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_SCALAR);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_2D);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_2D_SCALAR);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_3D);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_3D_SCALAR);
 	BIND_ENUM_CONSTANT(OP_TYPE_MAX);
 }
 
 VisualShaderNodeSmoothStep::VisualShaderNodeSmoothStep() {
-	set_input_port_default_value(0, 0.0);
-	set_input_port_default_value(1, 0.0);
-	set_input_port_default_value(2, 0.0);
+	set_input_port_default_value(0, 0.0); // edge0
+	set_input_port_default_value(1, 1.0); // edge1
+	set_input_port_default_value(2, 0.5); // x
 }
 
 ////////////// Distance
@@ -3579,17 +3887,14 @@ int VisualShaderNodeVectorDistance::get_input_port_count() const {
 	return 2;
 }
 
-VisualShaderNodeVectorDistance::PortType VisualShaderNodeVectorDistance::get_input_port_type(int p_port) const {
-	return PORT_TYPE_VECTOR;
-}
-
 String VisualShaderNodeVectorDistance::get_input_port_name(int p_port) const {
-	if (p_port == 0) {
-		return "p0";
-	} else if (p_port == 1) {
-		return "p1";
+	switch (p_port) {
+		case 0:
+			return "a";
+		case 1:
+			return "b";
 	}
-	return "";
+	return String();
 }
 
 int VisualShaderNodeVectorDistance::get_output_port_count() const {
@@ -3604,13 +3909,34 @@ String VisualShaderNodeVectorDistance::get_output_port_name(int p_port) const {
 	return "";
 }
 
+void VisualShaderNodeVectorDistance::set_op_type(OpType p_op_type) {
+	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	if (op_type == p_op_type) {
+		return;
+	}
+	switch (p_op_type) {
+		case OP_TYPE_VECTOR_2D: {
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0)); // a
+			set_input_port_default_value(1, Vector2(), get_input_port_default_value(1)); // b
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0)); // a
+			set_input_port_default_value(1, Vector3(), get_input_port_default_value(1)); // b
+		} break;
+		default:
+			break;
+	}
+	op_type = p_op_type;
+	emit_changed();
+}
+
 String VisualShaderNodeVectorDistance::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	return "	" + p_output_vars[0] + " = distance(" + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
 }
 
 VisualShaderNodeVectorDistance::VisualShaderNodeVectorDistance() {
-	set_input_port_default_value(0, Vector3(0.0, 0.0, 0.0));
-	set_input_port_default_value(1, Vector3(0.0, 0.0, 0.0));
+	set_input_port_default_value(0, Vector3(0.0, 0.0, 0.0)); // a
+	set_input_port_default_value(1, Vector3(0.0, 0.0, 0.0)); // b
 }
 
 ////////////// Refract Vector
@@ -3632,14 +3958,15 @@ VisualShaderNodeVectorRefract::PortType VisualShaderNodeVectorRefract::get_input
 }
 
 String VisualShaderNodeVectorRefract::get_input_port_name(int p_port) const {
-	if (p_port == 0) {
-		return "I";
-	} else if (p_port == 1) {
-		return "N";
-	} else if (p_port == 2) {
-		return "eta";
+	switch (p_port) {
+		case 0:
+			return "I";
+		case 1:
+			return "N";
+		case 2:
+			return "eta";
 	}
-	return "";
+	return String();
 }
 
 int VisualShaderNodeVectorRefract::get_output_port_count() const {
@@ -3676,9 +4003,16 @@ int VisualShaderNodeMix::get_input_port_count() const {
 
 VisualShaderNodeMix::PortType VisualShaderNodeMix::get_input_port_type(int p_port) const {
 	switch (op_type) {
-		case OP_TYPE_VECTOR:
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_2D_SCALAR:
+			if (p_port == 2) {
+				break;
+			}
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
 			return PORT_TYPE_VECTOR;
-		case OP_TYPE_VECTOR_SCALAR:
+		case OP_TYPE_VECTOR_3D_SCALAR:
 			if (p_port == 2) {
 				break;
 			}
@@ -3705,9 +4039,13 @@ int VisualShaderNodeMix::get_output_port_count() const {
 
 VisualShaderNodeMix::PortType VisualShaderNodeMix::get_output_port_type(int p_port) const {
 	switch (op_type) {
-		case OP_TYPE_VECTOR:
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_2D_SCALAR:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
 			return PORT_TYPE_VECTOR;
-		case OP_TYPE_VECTOR_SCALAR:
+		case OP_TYPE_VECTOR_3D_SCALAR:
 			return PORT_TYPE_VECTOR;
 		default:
 			break;
@@ -3725,27 +4063,31 @@ void VisualShaderNodeMix::set_op_type(OpType p_op_type) {
 		return;
 	}
 	switch (p_op_type) {
-		case OP_TYPE_SCALAR:
-			set_input_port_default_value(0, 0.0); // a
-			set_input_port_default_value(1, 1.0); // b
-			if (op_type == OP_TYPE_VECTOR) {
-				set_input_port_default_value(2, 0.5); // weight
-			}
-			break;
-		case OP_TYPE_VECTOR:
-			set_input_port_default_value(0, Vector3(0.0, 0.0, 0.0)); // a
-			set_input_port_default_value(1, Vector3(1.0, 1.0, 1.0)); // b
-			if (op_type == OP_TYPE_SCALAR || op_type == OP_TYPE_VECTOR_SCALAR) {
-				set_input_port_default_value(2, Vector3(0.5, 0.5, 0.5)); // weight
-			}
-			break;
-		case OP_TYPE_VECTOR_SCALAR:
-			set_input_port_default_value(0, Vector3(0.0, 0.0, 0.0)); // a
-			set_input_port_default_value(1, Vector3(1.0, 1.0, 1.0)); // b
-			if (op_type == OP_TYPE_VECTOR) {
-				set_input_port_default_value(2, 0.5); // weight
-			}
-			break;
+		case OP_TYPE_SCALAR: {
+			set_input_port_default_value(0, 0.0, get_input_port_default_value(0)); // a
+			set_input_port_default_value(1, 0.0, get_input_port_default_value(1)); // b
+			set_input_port_default_value(2, 0.0, get_input_port_default_value(2)); // weight
+		} break;
+		case OP_TYPE_VECTOR_2D: {
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0)); // a
+			set_input_port_default_value(1, Vector2(), get_input_port_default_value(1)); // b
+			set_input_port_default_value(2, Vector2(), get_input_port_default_value(2)); // weight
+		} break;
+		case OP_TYPE_VECTOR_2D_SCALAR: {
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0)); // a
+			set_input_port_default_value(1, Vector2(), get_input_port_default_value(1)); // b
+			set_input_port_default_value(2, 0.0, get_input_port_default_value(2)); // weight
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0)); // a
+			set_input_port_default_value(1, Vector3(), get_input_port_default_value(1)); // b
+			set_input_port_default_value(2, Vector3(), get_input_port_default_value(2)); // weight
+		} break;
+		case OP_TYPE_VECTOR_3D_SCALAR: {
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0)); // a
+			set_input_port_default_value(1, Vector3(), get_input_port_default_value(1)); // b
+			set_input_port_default_value(2, 0.0, get_input_port_default_value(2)); // weight
+		} break;
 		default:
 			break;
 	}
@@ -3771,11 +4113,13 @@ void VisualShaderNodeMix::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_op_type", "op_type"), &VisualShaderNodeMix::set_op_type);
 	ClassDB::bind_method(D_METHOD("get_op_type"), &VisualShaderNodeMix::get_op_type);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Scalar,Vector,VectorScalar"), "set_op_type", "get_op_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Scalar,Vector2,Vector2Scalar,Vector3,Vector3Scalar"), "set_op_type", "get_op_type");
 
 	BIND_ENUM_CONSTANT(OP_TYPE_SCALAR);
-	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR);
-	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_SCALAR);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_2D);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_2D_SCALAR);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_3D);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_3D_SCALAR);
 	BIND_ENUM_CONSTANT(OP_TYPE_MAX);
 }
 
@@ -3792,7 +4136,15 @@ String VisualShaderNodeVectorCompose::get_caption() const {
 }
 
 int VisualShaderNodeVectorCompose::get_input_port_count() const {
-	return 3;
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D:
+			return 2;
+		case OP_TYPE_VECTOR_3D:
+			return 3;
+		default:
+			break;
+	}
+	return 0;
 }
 
 VisualShaderNodeVectorCompose::PortType VisualShaderNodeVectorCompose::get_input_port_type(int p_port) const {
@@ -3800,29 +4152,80 @@ VisualShaderNodeVectorCompose::PortType VisualShaderNodeVectorCompose::get_input
 }
 
 String VisualShaderNodeVectorCompose::get_input_port_name(int p_port) const {
-	if (p_port == 0) {
-		return "x";
-	} else if (p_port == 1) {
-		return "y";
-	} else {
-		return "z";
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D: {
+			switch (p_port) {
+				case 0:
+					return "x";
+				case 1:
+					return "y";
+			}
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			switch (p_port) {
+				case 0:
+					return "x";
+				case 1:
+					return "y";
+				case 2:
+					return "z";
+			}
+		} break;
+		default:
+			break;
 	}
+	return String();
 }
 
 int VisualShaderNodeVectorCompose::get_output_port_count() const {
 	return 1;
 }
 
-VisualShaderNodeVectorCompose::PortType VisualShaderNodeVectorCompose::get_output_port_type(int p_port) const {
-	return PORT_TYPE_VECTOR;
-}
-
 String VisualShaderNodeVectorCompose::get_output_port_name(int p_port) const {
 	return "vec";
 }
 
+void VisualShaderNodeVectorCompose::set_op_type(OpType p_op_type) {
+	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	if (op_type == p_op_type) {
+		return;
+	}
+	switch (p_op_type) {
+		case OP_TYPE_VECTOR_2D: {
+			float p1 = get_input_port_default_value(0);
+			float p2 = get_input_port_default_value(1);
+
+			set_input_port_default_value(0, p1);
+			set_input_port_default_value(1, p2);
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			float p1 = get_input_port_default_value(0);
+			float p2 = get_input_port_default_value(1);
+
+			set_input_port_default_value(0, p1);
+			set_input_port_default_value(1, p2);
+			set_input_port_default_value(2, 0.0);
+		} break;
+		default:
+			break;
+	}
+	op_type = p_op_type;
+	emit_changed();
+}
+
 String VisualShaderNodeVectorCompose::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
-	return "	" + p_output_vars[0] + " = vec3(" + p_input_vars[0] + ", " + p_input_vars[1] + ", " + p_input_vars[2] + ");\n";
+	String code;
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D: {
+			code += "	" + p_output_vars[0] + " = vec2(" + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			code += "	" + p_output_vars[0] + " = vec3(" + p_input_vars[0] + ", " + p_input_vars[1] + ", " + p_input_vars[2] + ");\n";
+		} break;
+		default:
+			break;
+	}
+	return code;
 }
 
 VisualShaderNodeVectorCompose::VisualShaderNodeVectorCompose() {
@@ -3889,16 +4292,20 @@ int VisualShaderNodeVectorDecompose::get_input_port_count() const {
 	return 1;
 }
 
-VisualShaderNodeVectorDecompose::PortType VisualShaderNodeVectorDecompose::get_input_port_type(int p_port) const {
-	return PORT_TYPE_VECTOR;
-}
-
 String VisualShaderNodeVectorDecompose::get_input_port_name(int p_port) const {
 	return "vec";
 }
 
 int VisualShaderNodeVectorDecompose::get_output_port_count() const {
-	return 3;
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D:
+			return 2;
+		case OP_TYPE_VECTOR_3D:
+			return 3;
+		default:
+			break;
+	}
+	return 0;
 }
 
 VisualShaderNodeVectorDecompose::PortType VisualShaderNodeVectorDecompose::get_output_port_type(int p_port) const {
@@ -3906,25 +4313,70 @@ VisualShaderNodeVectorDecompose::PortType VisualShaderNodeVectorDecompose::get_o
 }
 
 String VisualShaderNodeVectorDecompose::get_output_port_name(int p_port) const {
-	if (p_port == 0) {
-		return "x";
-	} else if (p_port == 1) {
-		return "y";
-	} else {
-		return "z";
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D: {
+			switch (p_port) {
+				case 0:
+					return "x";
+				case 1:
+					return "y";
+			}
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			switch (p_port) {
+				case 0:
+					return "x";
+				case 1:
+					return "y";
+				case 2:
+					return "z";
+			}
+		} break;
+		default:
+			break;
 	}
+	return String();
+}
+
+void VisualShaderNodeVectorDecompose::set_op_type(OpType p_op_type) {
+	ERR_FAIL_INDEX(int(p_op_type), int(OP_TYPE_MAX));
+	if (op_type == p_op_type) {
+		return;
+	}
+	switch (p_op_type) {
+		case OP_TYPE_VECTOR_2D: {
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0));
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0));
+		} break;
+		default:
+			break;
+	}
+	op_type = p_op_type;
+	emit_changed();
 }
 
 String VisualShaderNodeVectorDecompose::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String code;
-	code += "	" + p_output_vars[0] + " = " + p_input_vars[0] + ".x;\n";
-	code += "	" + p_output_vars[1] + " = " + p_input_vars[0] + ".y;\n";
-	code += "	" + p_output_vars[2] + " = " + p_input_vars[0] + ".z;\n";
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D: {
+			code += "	" + p_output_vars[0] + " = " + p_input_vars[0] + ".x;\n";
+			code += "	" + p_output_vars[1] + " = " + p_input_vars[0] + ".y;\n";
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			code += "	" + p_output_vars[0] + " = " + p_input_vars[0] + ".x;\n";
+			code += "	" + p_output_vars[1] + " = " + p_input_vars[0] + ".y;\n";
+			code += "	" + p_output_vars[2] + " = " + p_input_vars[0] + ".z;\n";
+		} break;
+		default:
+			break;
+	}
 	return code;
 }
 
 VisualShaderNodeVectorDecompose::VisualShaderNodeVectorDecompose() {
-	set_input_port_default_value(0, Vector3());
+	set_input_port_default_value(0, Vector3(0.0, 0.0, 0.0));
 }
 
 ////////////// Transform Decompose
@@ -4574,10 +5026,110 @@ Vector<StringName> VisualShaderNodeColorUniform::get_editable_properties() const
 VisualShaderNodeColorUniform::VisualShaderNodeColorUniform() {
 }
 
-////////////// Vector Uniform
+////////////// Vector2 Uniform
+
+String VisualShaderNodeVec2Uniform::get_caption() const {
+	return "Vector2Uniform";
+}
+
+int VisualShaderNodeVec2Uniform::get_input_port_count() const {
+	return 0;
+}
+
+VisualShaderNodeVec2Uniform::PortType VisualShaderNodeVec2Uniform::get_input_port_type(int p_port) const {
+	return PORT_TYPE_VECTOR_2D;
+}
+
+String VisualShaderNodeVec2Uniform::get_input_port_name(int p_port) const {
+	return String();
+}
+
+int VisualShaderNodeVec2Uniform::get_output_port_count() const {
+	return 1;
+}
+
+VisualShaderNodeVec2Uniform::PortType VisualShaderNodeVec2Uniform::get_output_port_type(int p_port) const {
+	return PORT_TYPE_VECTOR_2D;
+}
+
+String VisualShaderNodeVec2Uniform::get_output_port_name(int p_port) const {
+	return String();
+}
+
+void VisualShaderNodeVec2Uniform::set_default_value_enabled(bool p_enabled) {
+	default_value_enabled = p_enabled;
+	emit_changed();
+}
+
+bool VisualShaderNodeVec2Uniform::is_default_value_enabled() const {
+	return default_value_enabled;
+}
+
+void VisualShaderNodeVec2Uniform::set_default_value(const Vector2 &p_value) {
+	default_value = p_value;
+	emit_changed();
+}
+
+Vector2 VisualShaderNodeVec2Uniform::get_default_value() const {
+	return default_value;
+}
+
+String VisualShaderNodeVec2Uniform::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
+	String code = _get_qual_str() + "uniform vec2 " + get_uniform_name();
+	if (default_value_enabled) {
+		code += vformat(" = vec2(%.6f, %.6f)", default_value.x, default_value.y);
+	}
+	code += ";\n";
+	return code;
+}
+
+String VisualShaderNodeVec2Uniform::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
+	return "	" + p_output_vars[0] + " = " + get_uniform_name() + ";\n";
+}
+
+void VisualShaderNodeVec2Uniform::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_default_value_enabled", "enabled"), &VisualShaderNodeVec2Uniform::set_default_value_enabled);
+	ClassDB::bind_method(D_METHOD("is_default_value_enabled"), &VisualShaderNodeVec2Uniform::is_default_value_enabled);
+
+	ClassDB::bind_method(D_METHOD("set_default_value", "value"), &VisualShaderNodeVec2Uniform::set_default_value);
+	ClassDB::bind_method(D_METHOD("get_default_value"), &VisualShaderNodeVec2Uniform::get_default_value);
+
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "default_value_enabled"), "set_default_value_enabled", "is_default_value_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "default_value"), "set_default_value", "get_default_value");
+}
+
+bool VisualShaderNodeVec2Uniform::is_show_prop_names() const {
+	return true;
+}
+
+bool VisualShaderNodeVec2Uniform::is_use_prop_slots() const {
+	return true;
+}
+
+bool VisualShaderNodeVec2Uniform::is_qualifier_supported(Qualifier p_qual) const {
+	return true; // all qualifiers are supported
+}
+
+bool VisualShaderNodeVec2Uniform::is_convertible_to_constant() const {
+	return true; // conversion is allowed
+}
+
+Vector<StringName> VisualShaderNodeVec2Uniform::get_editable_properties() const {
+	Vector<StringName> props = VisualShaderNodeUniform::get_editable_properties();
+	props.push_back("default_value_enabled");
+	if (default_value_enabled) {
+		props.push_back("default_value");
+	}
+	return props;
+}
+
+VisualShaderNodeVec2Uniform::VisualShaderNodeVec2Uniform() {
+}
+
+////////////// Vector3 Uniform
 
 String VisualShaderNodeVec3Uniform::get_caption() const {
-	return "VectorUniform";
+	return "Vector3Uniform";
 }
 
 int VisualShaderNodeVec3Uniform::get_input_port_count() const {
@@ -4792,7 +5344,7 @@ int VisualShaderNodeTextureUniform::get_input_port_count() const {
 }
 
 VisualShaderNodeTextureUniform::PortType VisualShaderNodeTextureUniform::get_input_port_type(int p_port) const {
-	return p_port == 0 ? PORT_TYPE_VECTOR : PORT_TYPE_SCALAR;
+	return p_port == 0 ? PORT_TYPE_VECTOR_2D : PORT_TYPE_SCALAR;
 }
 
 String VisualShaderNodeTextureUniform::get_input_port_name(int p_port) const {
@@ -4940,7 +5492,7 @@ bool VisualShaderNodeTextureUniform::is_code_generated() const {
 String VisualShaderNodeTextureUniform::generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview) const {
 	String default_uv;
 	if (p_mode == Shader::MODE_CANVAS_ITEM || p_mode == Shader::MODE_SPATIAL) {
-		default_uv = "UV.xy";
+		default_uv = "UV";
 	} else {
 		default_uv = "vec2(0.0)";
 	}
@@ -4955,9 +5507,9 @@ String VisualShaderNodeTextureUniform::generate_code(Shader::Mode p_mode, Visual
 		}
 	} else if (p_input_vars[1].is_empty()) {
 		//no lod
-		code += "		vec4 n_tex_read = texture(" + id + ", " + p_input_vars[0] + ".xy);\n";
+		code += "		vec4 n_tex_read = texture(" + id + ", " + p_input_vars[0] + ");\n";
 	} else {
-		code += "		vec4 n_tex_read = textureLod(" + id + ", " + p_input_vars[0] + ".xy, " + p_input_vars[1] + ");\n";
+		code += "		vec4 n_tex_read = textureLod(" + id + ", " + p_input_vars[0] + ", " + p_input_vars[1] + ");\n";
 	}
 
 	code += "		" + p_output_vars[0] + " = n_tex_read.rgb;\n";
@@ -5523,7 +6075,9 @@ VisualShaderNodeSwitch::PortType VisualShaderNodeSwitch::get_input_port_type(int
 		switch (op_type) {
 			case OP_TYPE_INT:
 				return PORT_TYPE_SCALAR_INT;
-			case OP_TYPE_VECTOR:
+			case OP_TYPE_VECTOR_2D:
+				return PORT_TYPE_VECTOR_2D;
+			case OP_TYPE_VECTOR_3D:
 				return PORT_TYPE_VECTOR;
 			case OP_TYPE_BOOLEAN:
 				return PORT_TYPE_BOOLEAN;
@@ -5557,7 +6111,9 @@ VisualShaderNodeSwitch::PortType VisualShaderNodeSwitch::get_output_port_type(in
 	switch (op_type) {
 		case OP_TYPE_INT:
 			return PORT_TYPE_SCALAR_INT;
-		case OP_TYPE_VECTOR:
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
 			return PORT_TYPE_VECTOR;
 		case OP_TYPE_BOOLEAN:
 			return PORT_TYPE_BOOLEAN;
@@ -5580,16 +6136,20 @@ void VisualShaderNodeSwitch::set_op_type(OpType p_op_type) {
 	}
 	switch (p_op_type) {
 		case OP_TYPE_FLOAT:
-			set_input_port_default_value(1, 1.0);
-			set_input_port_default_value(2, 0.0);
+			set_input_port_default_value(1, 1.0, get_input_port_default_value(1));
+			set_input_port_default_value(2, 0.0, get_input_port_default_value(2));
 			break;
 		case OP_TYPE_INT:
-			set_input_port_default_value(1, 1);
-			set_input_port_default_value(2, 0);
+			set_input_port_default_value(1, 1, get_input_port_default_value(1));
+			set_input_port_default_value(2, 0, get_input_port_default_value(2));
 			break;
-		case OP_TYPE_VECTOR:
-			set_input_port_default_value(1, Vector3(1.0, 1.0, 1.0));
-			set_input_port_default_value(2, Vector3(0.0, 0.0, 0.0));
+		case OP_TYPE_VECTOR_2D:
+			set_input_port_default_value(1, Vector2(1.0, 1.0), get_input_port_default_value(1));
+			set_input_port_default_value(2, Vector2(0.0, 0.0), get_input_port_default_value(2));
+			break;
+		case OP_TYPE_VECTOR_3D:
+			set_input_port_default_value(1, Vector3(1.0, 1.0, 1.0), get_input_port_default_value(1));
+			set_input_port_default_value(2, Vector3(0.0, 0.0, 0.0), get_input_port_default_value(2));
 			break;
 		case OP_TYPE_BOOLEAN:
 			set_input_port_default_value(1, true);
@@ -5620,11 +6180,12 @@ void VisualShaderNodeSwitch::_bind_methods() { // static
 	ClassDB::bind_method(D_METHOD("set_op_type", "type"), &VisualShaderNodeSwitch::set_op_type);
 	ClassDB::bind_method(D_METHOD("get_op_type"), &VisualShaderNodeSwitch::get_op_type);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Float,Int,Vector,Boolean,Transform"), "set_op_type", "get_op_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Float,Int,Vector2,Vector3,Boolean,Transform"), "set_op_type", "get_op_type");
 
 	BIND_ENUM_CONSTANT(OP_TYPE_FLOAT);
 	BIND_ENUM_CONSTANT(OP_TYPE_INT);
-	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_2D);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_3D);
 	BIND_ENUM_CONSTANT(OP_TYPE_BOOLEAN);
 	BIND_ENUM_CONSTANT(OP_TYPE_TRANSFORM);
 	BIND_ENUM_CONSTANT(OP_TYPE_MAX);
@@ -5854,7 +6415,9 @@ VisualShaderNodeCompare::PortType VisualShaderNodeCompare::get_input_port_type(i
 			return PORT_TYPE_SCALAR;
 		case CTYPE_SCALAR_INT:
 			return PORT_TYPE_SCALAR_INT;
-		case CTYPE_VECTOR:
+		case CTYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case CTYPE_VECTOR_3D:
 			return PORT_TYPE_VECTOR;
 		case CTYPE_BOOLEAN:
 			return PORT_TYPE_BOOLEAN;
@@ -5926,7 +6489,7 @@ String VisualShaderNodeCompare::generate_code(Shader::Mode p_mode, VisualShader:
 
 	String code;
 	switch (comparison_type) {
-		case CTYPE_SCALAR:
+		case CTYPE_SCALAR: {
 			if (func == FUNC_EQUAL) {
 				code += "	" + p_output_vars[0] + " = (abs(" + p_input_vars[0] + " - " + p_input_vars[1] + ") < " + p_input_vars[2] + ");";
 			} else if (func == FUNC_NOT_EQUAL) {
@@ -5934,33 +6497,34 @@ String VisualShaderNodeCompare::generate_code(Shader::Mode p_mode, VisualShader:
 			} else {
 				code += "	" + p_output_vars[0] + " = " + (p_input_vars[0] + " $ " + p_input_vars[1]).replace("$", operators[func]) + ";\n";
 			}
-			break;
-
-		case CTYPE_SCALAR_INT:
+		} break;
+		case CTYPE_SCALAR_INT: {
 			code += "	" + p_output_vars[0] + " = " + (p_input_vars[0] + " $ " + p_input_vars[1]).replace("$", operators[func]) + ";\n";
-			break;
-
-		case CTYPE_VECTOR:
+		} break;
+		case CTYPE_VECTOR_2D: {
+			code += "	{\n";
+			code += "		bvec2 _bv = " + String(functions[func]).replace("$", p_input_vars[0] + ", " + p_input_vars[1]) + ";\n";
+			code += "		" + p_output_vars[0] + " = " + String(conditions[condition]).replace("$", "_bv") + ";\n";
+			code += "	}\n";
+		} break;
+		case CTYPE_VECTOR_3D: {
 			code += "	{\n";
 			code += "		bvec3 _bv = " + String(functions[func]).replace("$", p_input_vars[0] + ", " + p_input_vars[1]) + ";\n";
 			code += "		" + p_output_vars[0] + " = " + String(conditions[condition]).replace("$", "_bv") + ";\n";
 			code += "	}\n";
-			break;
-
-		case CTYPE_BOOLEAN:
+		} break;
+		case CTYPE_BOOLEAN: {
 			if (func > FUNC_NOT_EQUAL) {
 				return "	" + p_output_vars[0] + " = false;\n";
 			}
 			code += "	" + p_output_vars[0] + " = " + (p_input_vars[0] + " $ " + p_input_vars[1]).replace("$", operators[func]) + ";\n";
-			break;
-
-		case CTYPE_TRANSFORM:
+		} break;
+		case CTYPE_TRANSFORM: {
 			if (func > FUNC_NOT_EQUAL) {
 				return "	" + p_output_vars[0] + " = false;\n";
 			}
 			code += "	" + p_output_vars[0] + " = " + (p_input_vars[0] + " $ " + p_input_vars[1]).replace("$", operators[func]) + ";\n";
-			break;
-
+		} break;
 		default:
 			break;
 	}
@@ -5974,18 +6538,23 @@ void VisualShaderNodeCompare::set_comparison_type(ComparisonType p_comparison_ty
 	}
 	switch (p_comparison_type) {
 		case CTYPE_SCALAR:
-			set_input_port_default_value(0, 0.0);
-			set_input_port_default_value(1, 0.0);
+			set_input_port_default_value(0, 0.0, get_input_port_default_value(0));
+			set_input_port_default_value(1, 0.0, get_input_port_default_value(1));
 			simple_decl = true;
 			break;
 		case CTYPE_SCALAR_INT:
-			set_input_port_default_value(0, 0);
-			set_input_port_default_value(1, 0);
+			set_input_port_default_value(0, 0, get_input_port_default_value(0));
+			set_input_port_default_value(1, 0, get_input_port_default_value(1));
 			simple_decl = true;
 			break;
-		case CTYPE_VECTOR:
-			set_input_port_default_value(0, Vector3(0.0, 0.0, 0.0));
-			set_input_port_default_value(1, Vector3(0.0, 0.0, 0.0));
+		case CTYPE_VECTOR_2D:
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector2(), get_input_port_default_value(1));
+			simple_decl = false;
+			break;
+		case CTYPE_VECTOR_3D:
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector3(), get_input_port_default_value(1));
 			simple_decl = false;
 			break;
 		case CTYPE_BOOLEAN:
@@ -6039,7 +6608,7 @@ Vector<StringName> VisualShaderNodeCompare::get_editable_properties() const {
 	Vector<StringName> props;
 	props.push_back("type");
 	props.push_back("function");
-	if (comparison_type == CTYPE_VECTOR) {
+	if (comparison_type == CTYPE_VECTOR_2D || comparison_type == CTYPE_VECTOR_3D) {
 		props.push_back("condition");
 	}
 	return props;
@@ -6055,13 +6624,14 @@ void VisualShaderNodeCompare::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_condition", "condition"), &VisualShaderNodeCompare::set_condition);
 	ClassDB::bind_method(D_METHOD("get_condition"), &VisualShaderNodeCompare::get_condition);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "type", PROPERTY_HINT_ENUM, "Float,Int,Vector,Boolean,Transform"), "set_comparison_type", "get_comparison_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "type", PROPERTY_HINT_ENUM, "Float,Int,Vector2,Vector3,Boolean,Transform"), "set_comparison_type", "get_comparison_type");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "function", PROPERTY_HINT_ENUM, "a == b,a != b,a > b,a >= b,a < b,a <= b"), "set_function", "get_function");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "condition", PROPERTY_HINT_ENUM, "All,Any"), "set_condition", "get_condition");
 
 	BIND_ENUM_CONSTANT(CTYPE_SCALAR);
 	BIND_ENUM_CONSTANT(CTYPE_SCALAR_INT);
-	BIND_ENUM_CONSTANT(CTYPE_VECTOR);
+	BIND_ENUM_CONSTANT(CTYPE_VECTOR_2D);
+	BIND_ENUM_CONSTANT(CTYPE_VECTOR_3D);
 	BIND_ENUM_CONSTANT(CTYPE_BOOLEAN);
 	BIND_ENUM_CONSTANT(CTYPE_TRANSFORM);
 	BIND_ENUM_CONSTANT(CTYPE_MAX);
@@ -6096,8 +6666,13 @@ int VisualShaderNodeMultiplyAdd::get_input_port_count() const {
 }
 
 VisualShaderNodeMultiplyAdd::PortType VisualShaderNodeMultiplyAdd::get_input_port_type(int p_port) const {
-	if (op_type == OP_TYPE_VECTOR) {
-		return PORT_TYPE_VECTOR;
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
+			return PORT_TYPE_VECTOR;
+		default:
+			break;
 	}
 	return PORT_TYPE_SCALAR;
 }
@@ -6118,11 +6693,15 @@ int VisualShaderNodeMultiplyAdd::get_output_port_count() const {
 }
 
 VisualShaderNodeMultiplyAdd::PortType VisualShaderNodeMultiplyAdd::get_output_port_type(int p_port) const {
-	if (op_type == OP_TYPE_SCALAR) {
-		return PORT_TYPE_SCALAR;
-	} else {
-		return PORT_TYPE_VECTOR;
+	switch (op_type) {
+		case OP_TYPE_VECTOR_2D:
+			return PORT_TYPE_VECTOR_2D;
+		case OP_TYPE_VECTOR_3D:
+			return PORT_TYPE_VECTOR;
+		default:
+			break;
 	}
+	return PORT_TYPE_SCALAR;
 }
 
 String VisualShaderNodeMultiplyAdd::get_output_port_name(int p_port) const {
@@ -6139,16 +6718,21 @@ void VisualShaderNodeMultiplyAdd::set_op_type(OpType p_op_type) {
 		return;
 	}
 	switch (p_op_type) {
-		case OP_TYPE_SCALAR:
-			set_input_port_default_value(0, 0.0);
-			set_input_port_default_value(1, 0.0);
-			set_input_port_default_value(2, 0.0);
-			break;
-		case OP_TYPE_VECTOR:
-			set_input_port_default_value(0, Vector3(0.0, 0.0, 0.0));
-			set_input_port_default_value(1, Vector3(0.0, 0.0, 0.0));
-			set_input_port_default_value(2, Vector3(0.0, 0.0, 0.0));
-			break;
+		case OP_TYPE_SCALAR: {
+			set_input_port_default_value(0, 0.0, get_input_port_default_value(0));
+			set_input_port_default_value(1, 0.0, get_input_port_default_value(1));
+			set_input_port_default_value(2, 0.0, get_input_port_default_value(2));
+		} break;
+		case OP_TYPE_VECTOR_2D: {
+			set_input_port_default_value(0, Vector2(), get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector2(), get_input_port_default_value(1));
+			set_input_port_default_value(2, Vector2(), get_input_port_default_value(2));
+		} break;
+		case OP_TYPE_VECTOR_3D: {
+			set_input_port_default_value(0, Vector3(), get_input_port_default_value(0));
+			set_input_port_default_value(1, Vector3(), get_input_port_default_value(1));
+			set_input_port_default_value(2, Vector3(), get_input_port_default_value(2));
+		} break;
 		default:
 			break;
 	}
@@ -6170,10 +6754,11 @@ void VisualShaderNodeMultiplyAdd::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_op_type", "type"), &VisualShaderNodeMultiplyAdd::set_op_type);
 	ClassDB::bind_method(D_METHOD("get_op_type"), &VisualShaderNodeMultiplyAdd::get_op_type);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Scalar,Vector"), "set_op_type", "get_op_type");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "op_type", PROPERTY_HINT_ENUM, "Scalar,Vector2,Vector3"), "set_op_type", "get_op_type");
 
 	BIND_ENUM_CONSTANT(OP_TYPE_SCALAR);
-	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_2D);
+	BIND_ENUM_CONSTANT(OP_TYPE_VECTOR_3D);
 	BIND_ENUM_CONSTANT(OP_TYPE_MAX);
 }
 


### PR DESCRIPTION
This PR adds Vector2 support to visual shaders:

- Added `VisualShaderNodeVec2Uniform` and `VisualShaderNodeVec2Constant`.
- Added operand type property to `VisualShaderNodeVectorFunc`, `VisualShaderNodeVectorOp`, `VisualShaderNodeVectorCompose` and `VisualShaderNodeVectorDecompose` to re-use them with a new Vector type.
- Added Vector2 type for several other nodes.
- Fixed several built-in to use Vector2 instead of Vector3 type (for example UV).

![image](https://user-images.githubusercontent.com/3036176/151936508-30d32f23-c6d8-45bb-9dac-beeadcd999cd.png)

