### PR TITLE
CI: Fix exclude patterns with `git ls-files`

### DIFF
--- a/misc/scripts/black_format.sh
+++ b/misc/scripts/black_format.sh
@@ -6,7 +6,7 @@ set -uo pipefail
 
 # Apply black.
 echo -e "Formatting Python files..."
-PY_FILES=$(git ls-files '*SConstruct' '*SCsub' '*.py' --exclude='.git/*' --exclude='thirdparty/*')
+PY_FILES=$(git ls-files -- '*SConstruct' '*SCsub' '*.py' ':!:.git/*' ':!:thirdparty/*')
 black -l 120 $PY_FILES
 
 diff=$(git diff --color)

--- a/misc/scripts/clang_format.sh
+++ b/misc/scripts/clang_format.sh
@@ -6,17 +6,9 @@
 set -uo pipefail
 
 # Loops through all code files tracked by Git.
-git ls-files '*.c' '*.h' '*.cpp' '*.hpp' '*.cc' '*.hh' '*.cxx' '*.m' '*.mm' '*.inc' '*.java' '*.glsl' |
+git ls-files -- '*.c' '*.h' '*.cpp' '*.hpp' '*.cc' '*.hh' '*.cxx' '*.m' '*.mm' '*.inc' '*.java' '*.glsl' \
+                ':!:.git/*' ':!:thirdparty/*' ':!:platform/android/java/lib/src/com/google/*' ':!:*-so_wrap.*' |
 while read -r f; do
-    # Exclude some files.
-    if [[ "$f" == "thirdparty"* ]]; then
-        continue
-    elif [[ "$f" == "platform/android/java/lib/src/com/google"* ]]; then
-        continue
-    elif [[ "$f" == *"-so_wrap."* ]]; then
-        continue
-    fi
-
     # Run clang-format.
     clang-format --Wno-error=unknown -i "$f"
 

--- a/misc/scripts/clang_tidy.sh
+++ b/misc/scripts/clang_tidy.sh
@@ -6,17 +6,9 @@
 set -uo pipefail
 
 # Loops through all code files tracked by Git.
-git ls-files '*.c' '*.h' '*.cpp' '*.hpp' '*.cc' '*.hh' '*.cxx' '*.m' '*.mm' '*.inc' '*.java' '*.glsl' |
+git ls-files -- '*.c' '*.h' '*.cpp' '*.hpp' '*.cc' '*.hh' '*.cxx' '*.m' '*.mm' '*.inc' '*.java' '*.glsl' \
+                ':!:.git/*' ':!:thirdparty/*' ':!:platform/android/java/lib/src/com/google/*' ':!:*-so_wrap.*' |
 while read -r f; do
-    # Exclude some files.
-    if [[ "$f" == "thirdparty"* ]]; then
-        continue
-    elif [[ "$f" == "platform/android/java/lib/src/com/google"* ]]; then
-        continue
-    elif [[ "$f" == *"-so_wrap."* ]]; then
-        continue
-    fi
-
     # Run clang-tidy.
     clang-tidy --quiet --fix "$f" &> /dev/null
 


### PR DESCRIPTION
Follow-up to #55785.

In `black_format.sh`, the `--exclude` switch was wrongly used. [It's a misnomer
that only excludes _untracked_ files](https://stackoverflow.com/questions/36753573/how-do-i-exclude-files-from-git-ls-files), arcane pathspec patterns should instead
be used to exclude _tracked_ files.

Using this newfound knowledge, we can also simplify the other scripts.

CC @nathanfranke 