### PR TITLE
Abstract out RenderingDevice from Vulkan

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -98,10 +98,10 @@ const PackedStringArray ProjectSettings::_get_supported_features() {
 	features.append(VERSION_BRANCH "." _MKSTR(VERSION_PATCH));
 	features.append(VERSION_FULL_CONFIG);
 	features.append(VERSION_FULL_BUILD);
-	// For now, assume Vulkan is always supported.
-	// This should be removed if it's possible to build the editor without Vulkan.
-	features.append("Vulkan Clustered");
-	features.append("Vulkan Mobile");
+	// For now, assume some RenderingDevice driver (like Vulkan) is always supported.
+	// This should be removed if it's possible to build the editor without any.
+	features.append("Modern Clustered");
+	features.append("Modern Mobile");
 	return features;
 }
 

--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -607,7 +607,7 @@
 			Set [code]ALBEDO[/code] to the per-vertex color specified in the mesh.
 		</constant>
 		<constant name="FLAG_SRGB_VERTEX_COLOR" value="2" enum="Flags">
-			Vertex color is in sRGB space and needs to be converted to linear. Only applies in the Vulkan renderer.
+			Vertex color is in sRGB space and needs to be converted to linear. Only applies in the Modern renderer.
 		</constant>
 		<constant name="FLAG_USE_POINT_SIZE" value="3" enum="Flags">
 			Uses point size to alter the size of primitive points. Also changes the albedo texture lookup to use [code]POINT_COORD[/code] instead of [code]UV[/code].

--- a/doc/classes/NinePatchRect.xml
+++ b/doc/classes/NinePatchRect.xml
@@ -68,11 +68,11 @@
 		</constant>
 		<constant name="AXIS_STRETCH_MODE_TILE" value="1" enum="AxisStretchMode">
 			Repeats the center texture across the NinePatchRect. This won't cause any visible distortion. The texture must be seamless for this to work without displaying artifacts between edges.
-			[b]Note:[/b] Only supported when using the Vulkan renderer. When using the OpenGL renderer, this will behave like [constant AXIS_STRETCH_MODE_STRETCH].
+			[b]Note:[/b] Only supported when using the Modern renderer. When using the OpenGL renderer, this will behave like [constant AXIS_STRETCH_MODE_STRETCH].
 		</constant>
 		<constant name="AXIS_STRETCH_MODE_TILE_FIT" value="2" enum="AxisStretchMode">
 			Repeats the center texture across the NinePatchRect, but will also stretch the texture to make sure each tile is visible in full. This may cause the texture to be distorted, but less than [constant AXIS_STRETCH_MODE_STRETCH]. The texture must be seamless for this to work without displaying artifacts between edges.
-			[b]Note:[/b] Only supported when using the Vulkan renderer. When using the OpenGL renderer, this will behave like [constant AXIS_STRETCH_MODE_STRETCH].
+			[b]Note:[/b] Only supported when using the Modern renderer. When using the OpenGL renderer, this will behave like [constant AXIS_STRETCH_MODE_STRETCH].
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1596,7 +1596,7 @@
 		</member>
 		<member name="rendering/driver/depth_prepass/enable" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], performs a previous depth pass before rendering 3D materials. This increases performance significantly in scenes with high overdraw, when complex materials and lighting are used. However, in scenes with few occluded surfaces, the depth prepass may reduce performance. If your game is viewed from a fixed angle that makes it easy to avoid overdraw (such as top-down or side-scrolling perspective), consider disabling the depth prepass to improve performance. This setting can be changed at run-time to optimize performance depending on the scene currently being viewed.
-			[b]Note:[/b] Only supported when using the Vulkan Clustered backend or the OpenGL backend. When using Vulkan Mobile there is no depth prepass performed.
+			[b]Note:[/b] Only supported when using the Modern Clustered backend. When using Modern Mobile there is no depth prepass performed.
 		</member>
 		<member name="rendering/driver/driver_name" type="String" setter="" getter="" default="&quot;vulkan&quot;">
 			The video driver to use.
@@ -1742,6 +1742,16 @@
 			[b]Note:[/b] [member rendering/mesh_lod/lod_change/threshold_pixels] does not affect [GeometryInstance3D] visibility ranges (also known as "manual" LOD or hierarchical LOD).
 			[b]Note:[/b] This property is only read when the project starts. To adjust the automatic LOD threshold at runtime, set [member Viewport.mesh_lod_threshold] on the root [Viewport].
 		</member>
+		<member name="rendering/modern/back_end" type="int" setter="" getter="" default="0">
+		</member>
+		<member name="rendering/modern/back_end.mobile" type="int" setter="" getter="" default="1">
+		</member>
+		<member name="rendering/modern/staging_buffer/block_size_kb" type="int" setter="" getter="" default="256">
+		</member>
+		<member name="rendering/modern/staging_buffer/max_size_mb" type="int" setter="" getter="" default="128">
+		</member>
+		<member name="rendering/modern/staging_buffer/texture_upload_region_size_px" type="int" setter="" getter="" default="64">
+		</member>
 		<member name="rendering/occlusion_culling/bvh_build_quality" type="int" setter="" getter="" default="2">
 			The [url=https://en.wikipedia.org/wiki/Bounding_volume_hierarchy]BVH[/url] quality to use when rendering the occlusion culling buffer. Higher values will result in more accurate occlusion culling, at the cost of higher CPU usage.
 		</member>
@@ -1876,7 +1886,7 @@
 			The default compression level for lossless WebP. Higher levels result in smaller files at the cost of compression speed. Decompression speed is mostly unaffected by the compression level. Supported values are 0 to 9. Note that compression levels above 6 are very slow and offer very little savings.
 		</member>
 		<member name="rendering/textures/vram_compression/import_bptc" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], the texture importer will import VRAM-compressed textures using the BPTC algorithm. This texture compression algorithm is only supported on desktop platforms, and only when using the Vulkan renderer.
+			If [code]true[/code], the texture importer will import VRAM-compressed textures using the BPTC algorithm. This texture compression algorithm is only supported on desktop platforms, and only when using the Modern renderer.
 			[b]Note:[/b] Changing this setting does [i]not[/i] impact textures that were already imported before. To make this setting apply to textures that were already imported, exit the editor, remove the [code].godot/imported/[/code] folder located inside the project folder then restart the editor (see [member application/config/use_hidden_project_data_directory]).
 		</member>
 		<member name="rendering/textures/vram_compression/import_etc" type="bool" setter="" getter="" default="false">
@@ -1884,7 +1894,7 @@
 			[b]Note:[/b] Changing this setting does [i]not[/i] impact textures that were already imported before. To make this setting apply to textures that were already imported, exit the editor, remove the [code].godot/imported/[/code] folder located inside the project folder then restart the editor (see [member application/config/use_hidden_project_data_directory]).
 		</member>
 		<member name="rendering/textures/vram_compression/import_etc2" type="bool" setter="" getter="" default="true">
-			If [code]true[/code], the texture importer will import VRAM-compressed textures using the Ericsson Texture Compression 2 algorithm. This texture compression algorithm is only supported when using the Vulkan renderer.
+			If [code]true[/code], the texture importer will import VRAM-compressed textures using the Ericsson Texture Compression 2 algorithm. This texture compression algorithm is only supported when using the Modern renderer.
 			[b]Note:[/b] Changing this setting does [i]not[/i] impact textures that were already imported before. To make this setting apply to textures that were already imported, exit the editor, remove the [code].godot/imported/[/code] folder located inside the project folder then restart the editor (see [member application/config/use_hidden_project_data_directory]).
 		</member>
 		<member name="rendering/textures/vram_compression/import_s3tc" type="bool" setter="" getter="" default="true">
@@ -1892,16 +1902,6 @@
 			[b]Note:[/b] Changing this setting does [i]not[/i] impact textures that were already imported before. To make this setting apply to textures that were already imported, exit the editor, remove the [code].godot/imported/[/code] folder located inside the project folder then restart the editor (see [member application/config/use_hidden_project_data_directory]).
 		</member>
 		<member name="rendering/vulkan/descriptor_pools/max_descriptors_per_pool" type="int" setter="" getter="" default="64">
-		</member>
-		<member name="rendering/vulkan/rendering/back_end" type="int" setter="" getter="" default="0">
-		</member>
-		<member name="rendering/vulkan/rendering/back_end.mobile" type="int" setter="" getter="" default="1">
-		</member>
-		<member name="rendering/vulkan/staging_buffer/block_size_kb" type="int" setter="" getter="" default="256">
-		</member>
-		<member name="rendering/vulkan/staging_buffer/max_size_mb" type="int" setter="" getter="" default="128">
-		</member>
-		<member name="rendering/vulkan/staging_buffer/texture_upload_region_size_px" type="int" setter="" getter="" default="64">
 		</member>
 		<member name="xr/openxr/default_action_map" type="String" setter="" getter="" default="&quot;res://openxr_action_map.tres&quot;">
 			Action map configuration to load by default.

--- a/drivers/SCsub
+++ b/drivers/SCsub
@@ -24,6 +24,7 @@ SConscript("winmidi/SCsub")
 
 # Graphics drivers
 if env["vulkan"]:
+    SConscript("spirv-reflect/SCsub")
     SConscript("vulkan/SCsub")
 if env["opengl3"]:
     SConscript("gl_context/SCsub")
@@ -31,7 +32,6 @@ if env["opengl3"]:
 
 # Core dependencies
 SConscript("png/SCsub")
-SConscript("spirv-reflect/SCsub")
 
 env.add_source_files(env.drivers_sources, "*.cpp")
 

--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -9086,10 +9086,10 @@ void RenderingDeviceVulkan::initialize(VulkanContext *p_context, bool p_local_de
 
 	// Note: If adding new project settings here, also duplicate their definition in
 	// rendering_server.cpp for headless doctool.
-	staging_buffer_block_size = GLOBAL_DEF("rendering/vulkan/staging_buffer/block_size_kb", 256);
+	staging_buffer_block_size = GLOBAL_DEF("rendering/modern/staging_buffer/block_size_kb", 256);
 	staging_buffer_block_size = MAX(4u, staging_buffer_block_size);
 	staging_buffer_block_size *= 1024; //kb -> bytes
-	staging_buffer_max_size = GLOBAL_DEF("rendering/vulkan/staging_buffer/max_size_mb", 128);
+	staging_buffer_max_size = GLOBAL_DEF("rendering/modern/staging_buffer/max_size_mb", 128);
 	staging_buffer_max_size = MAX(1u, staging_buffer_max_size);
 	staging_buffer_max_size *= 1024 * 1024;
 
@@ -9097,7 +9097,7 @@ void RenderingDeviceVulkan::initialize(VulkanContext *p_context, bool p_local_de
 		//validate enough blocks
 		staging_buffer_max_size = staging_buffer_block_size * 4;
 	}
-	texture_upload_region_size_px = GLOBAL_DEF("rendering/vulkan/staging_buffer/texture_upload_region_size_px", 64);
+	texture_upload_region_size_px = GLOBAL_DEF("rendering/modern/staging_buffer/texture_upload_region_size_px", 64);
 	texture_upload_region_size_px = nearest_power_of_2_templated(texture_upload_region_size_px);
 
 	frames_drawn = frame_count; //start from frame count, so everything else is immediately old

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -90,6 +90,9 @@ Error EditorRun::run(const String &p_scene) {
 		screen -= 3;
 	}
 
+	args.push_back("--rendering-driver");
+	args.push_back(OS::get_singleton()->get_current_rendering_driver_name());
+
 	if (OS::get_singleton()->is_disable_crash_handler()) {
 		args.push_back("--disable-crash-handler");
 	}

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4892,7 +4892,7 @@ VisualShaderEditor::VisualShaderEditor() {
 	highend_label = memnew(Label);
 	desc_hbox->add_child(highend_label);
 	highend_label->set_visible(false);
-	highend_label->set_text("Vulkan");
+	highend_label->set_text("Modern");
 	highend_label->set_mouse_filter(Control::MOUSE_FILTER_STOP);
 	highend_label->set_tooltip(TTR("High-end node"));
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -475,11 +475,11 @@ private:
 					ProjectSettings::CustomMap initial_settings;
 					// Be sure to change this code if/when renderers are changed.
 					int renderer_type = rasterizer_button_group->get_pressed_button()->get_meta(SNAME("driver_name"));
-					initial_settings["rendering/vulkan/rendering/back_end"] = renderer_type;
+					initial_settings["rendering/modern/back_end"] = renderer_type;
 					if (renderer_type == 0) {
-						project_features.push_back("Vulkan Clustered");
+						project_features.push_back("Modern Clustered");
 					} else if (renderer_type == 1) {
-						project_features.push_back("Vulkan Mobile");
+						project_features.push_back("Modern Mobile");
 					} else {
 						WARN_PRINT("Unknown renderer type. Please report this as a bug on GitHub.");
 					}
@@ -861,8 +861,8 @@ public:
 		rshb->add_child(rvb);
 		Button *rs_button = memnew(CheckBox);
 		rs_button->set_button_group(rasterizer_button_group);
-		rs_button->set_text(TTR("Vulkan Clustered"));
-		rs_button->set_meta(SNAME("driver_name"), 0); // Vulkan backend "Forward Clustered"
+		rs_button->set_text(TTR("Modern Clustered (Vulkan)"));
+		rs_button->set_meta(SNAME("driver_name"), 0); // RenderingDevice backend "Forward Clustered"
 		rs_button->set_pressed(true);
 		rvb->add_child(rs_button);
 		l = memnew(Label);
@@ -881,8 +881,8 @@ public:
 		rshb->add_child(rvb);
 		rs_button = memnew(CheckBox);
 		rs_button->set_button_group(rasterizer_button_group);
-		rs_button->set_text(TTR("Vulkan Mobile"));
-		rs_button->set_meta(SNAME("driver_name"), 1); // Vulkan backend "Forward Mobile"
+		rs_button->set_text(TTR("Modern Mobile (Vulkan)"));
+		rs_button->set_meta(SNAME("driver_name"), 1); // RenderingDevice backend "Forward Mobile"
 		rvb->add_child(rs_button);
 		l = memnew(Label);
 		l->set_text(

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -342,8 +342,8 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  -b, --breakpoints                            Breakpoint list as source::line comma-separated pairs, no spaces (use %%20 instead).\n");
 	OS::get_singleton()->print("  --profiling                                  Enable profiling in the script debugger.\n");
 	OS::get_singleton()->print("  --gpu-profile                                Show a GPU profile of the tasks that took the most time during frame rendering.\n");
-	OS::get_singleton()->print("  --vk-layers                                  Enable Vulkan validation layers for debugging.\n");
-#if DEBUG_ENABLED
+	OS::get_singleton()->print("  --gpu-validation                             Enable modern render driver debug layers (e.g. Validation Layers in Vulkan).\n");
+#ifdef DEBUG_ENABLED
 	OS::get_singleton()->print("  --gpu-abort                                  Abort on GPU errors (usually validation layer errors), may help see the problem if your system freezes.\n");
 #endif
 	OS::get_singleton()->print("  --remote-debug <uri>                         Remote debug (<protocol>://<host/IP>[:<port>], e.g. tcp://127.0.0.1:6007).\n");
@@ -831,7 +831,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				OS::get_singleton()->print("Missing GPU index argument, aborting.\n");
 				goto error;
 			}
-		} else if (I->get() == "--vk-layers") {
+		} else if (I->get() == "--gpu-validation") {
 			Engine::singleton->use_validation_layers = true;
 #ifdef DEBUG_ENABLED
 		} else if (I->get() == "--gpu-abort") {

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -295,8 +295,8 @@ RendererCompositorRD::RendererCompositorRD() {
 	storage = memnew(RendererStorageRD);
 	canvas = memnew(RendererCanvasRenderRD(storage));
 
-	back_end = (bool)(int)GLOBAL_GET("rendering/vulkan/rendering/back_end");
-	uint64_t textures_per_stage = RD::get_singleton()->limit_get(RD::LIMIT_MAX_TEXTURES_PER_SHADER_STAGE);
+	back_end = (bool)(int)GLOBAL_GET("rendering/modern/back_end");
+	uint32_t textures_per_stage = RD::get_singleton()->limit_get(RD::LIMIT_MAX_TEXTURES_PER_SHADER_STAGE);
 
 	if (back_end || textures_per_stage < 48) {
 		scene = memnew(RendererSceneRenderImplementation::RenderForwardMobile(storage));

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2845,17 +2845,18 @@ RenderingServer::RenderingServer() {
 
 	GLOBAL_DEF("rendering/2d/shadow_atlas/size", 2048);
 
-	GLOBAL_DEF_RST_BASIC("rendering/vulkan/rendering/back_end", 0);
-	GLOBAL_DEF_RST_BASIC("rendering/vulkan/rendering/back_end.mobile", 1);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/vulkan/rendering/back_end",
+	GLOBAL_DEF_RST_BASIC("rendering/modern/back_end", 0);
+	GLOBAL_DEF_RST_BASIC("rendering/modern/back_end.mobile", 1);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/modern/back_end",
 			PropertyInfo(Variant::INT,
-					"rendering/vulkan/rendering/back_end",
+					"rendering/modern/back_end",
 					PROPERTY_HINT_ENUM, "Forward Clustered (Supports Desktop Only),Forward Mobile (Supports Desktop and Mobile)"));
-	// Already defined in RenderingDeviceVulkan::initialize which runs before this code.
+	// Already defined in RenderingDevice derivates' initialize(), which runs before this code.
 	// We re-define them here just for doctool's sake. Make sure to keep default values in sync.
-	GLOBAL_DEF("rendering/vulkan/staging_buffer/block_size_kb", 256);
-	GLOBAL_DEF("rendering/vulkan/staging_buffer/max_size_mb", 128);
-	GLOBAL_DEF("rendering/vulkan/staging_buffer/texture_upload_region_size_px", 64);
+	GLOBAL_DEF("rendering/modern/staging_buffer/block_size_kb", 256);
+	GLOBAL_DEF("rendering/modern/staging_buffer/max_size_mb", 128);
+	GLOBAL_DEF("rendering/modern/staging_buffer/texture_upload_region_size_px", 64);
+	// Same for RenderingDeviceVulkan::initialize().
 	GLOBAL_DEF("rendering/vulkan/descriptor_pools/max_descriptors_per_pool", 64);
 
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/enabled", true);


### PR DESCRIPTION
The new modern `RenderingDevice` architecture is coupled with Vulkan at the conceptual level.

Imagine a new renderer, say D3D12, is added in the future. There is a number of user-facing and internal elements that would apply to it but currently contain 'vulkan' in their names.

This PR adds 'modern' as the generic keyword for the modern rendering architecture, future-proofing it against nonsense that may happen if/when additional rendering drivers are added.

Implements, more or less, https://github.com/godotengine/godot-proposals/issues/4261.