### PR TITLE
Fix GDScript error when using an inherited const as annotation

### DIFF
--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -51,6 +51,7 @@ class GDScriptAnalyzer {
 	Error check_class_member_name_conflict(const GDScriptParser::ClassNode *p_class_node, const StringName &p_member_name, const GDScriptParser::Node *p_member_node);
 
 	Error resolve_inheritance(GDScriptParser::ClassNode *p_class, bool p_recursive = true);
+	GDScriptParser::DataType resolve_user_class(GDScriptParser::ClassNode *p_user_class, const StringName &p_name, String r_error);
 	GDScriptParser::DataType resolve_datatype(GDScriptParser::TypeNode *p_type);
 
 	void decide_suite_type(GDScriptParser::Node *p_suite, GDScriptParser::Node *p_statement);

--- a/modules/gdscript/tests/scripts/analyzer/features/base_class.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/base_class.gd
@@ -1,0 +1,8 @@
+const external_script = preload("gdscript_to_preload.notest.gd")
+
+func virtual_method(_ext: external_script) -> String:
+	return "Base"
+
+func test():
+	var external_instance = external_script.new()
+	print("virtual_method call: " + virtual_method(external_instance))

--- a/modules/gdscript/tests/scripts/analyzer/features/base_class.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/base_class.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+virtual_method call: Base

--- a/modules/gdscript/tests/scripts/analyzer/features/sub_class_with_method_override.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/sub_class_with_method_override.gd
@@ -1,0 +1,9 @@
+# https://github.com/godotengine/godot/pull/57510
+extends "base_class.gd"
+
+func virtual_method(_ext: external_script) -> String:
+	return "Subclass"
+
+func test():
+	var external_instance = external_script.new()
+	print("virtual_method call: " + virtual_method(external_instance))

--- a/modules/gdscript/tests/scripts/analyzer/features/sub_class_with_method_override.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/sub_class_with_method_override.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+virtual_method call: Subclass


### PR DESCRIPTION
Fix a GDScript analyzer error when using as an annotation a class declared as `const` which is declared in the parent script (or in a relative one). Regardless the fact is not ideal, declaring again the const class in the child script raises an error because the const is already declared, preventing to workaround the issue.

Example:
```gdscript
# base_class.gd
const external_script = preload("external_script.gd")

func virtual_method(_ext: external_script) -> String:
	return "Base"
```

```gdscript
extends "base_class.gd"

# Error: "external_script" was not found in the current scope
func virtual_method(_ext: external_script) -> String:
	return "Subclass"
```

This PR includes an integration test for this issue.