### PR TITLE
Allow setting the PropertyInfo class_name from GDScript custom properties

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1453,6 +1453,9 @@ void GDScriptInstance::get_property_list(List<PropertyInfo> *p_properties) const
 					if (d.has("usage")) {
 						pinfo.usage = d["usage"];
 					}
+					if (d.has("class_name")) {
+						pinfo.class_name = d["class_name"];
+					}
 
 					props.push_back(pinfo);
 				}


### PR DESCRIPTION
Collect the `class_name` key from property dictionaries returned by `_get_property_list`.

I don't know if there was a reason to exclude class_name, but this is required to use the #52277 array view from GDScript.