### PR TITLE
Exposes gui_release_focus and gui_get_focus_owner to Viewport

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -107,6 +107,12 @@
 				Returns the drag data from the GUI, that was previously returned by [method Control._get_drag_data].
 			</description>
 		</method>
+		<method name="gui_get_focus_owner">
+			<return type="Control" />
+			<description>
+				Returns the [Control] having the focus within this viewport. If no [Control] has the focus, returns null.
+			</description>
+		</method>
 		<method name="gui_is_drag_successful" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -117,6 +123,12 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the viewport is currently performing a drag operation.
+			</description>
+		</method>
+		<method name="gui_release_focus">
+			<return type="void" />
+			<description>
+				Removes the focus from the currently focussed [Control] within this viewport. If no [Control] has the focus, does nothing.
 			</description>
 		</method>
 		<method name="is_embedding_subwindows" qualifiers="const">

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2196,8 +2196,7 @@ void Control::release_focus() {
 		return;
 	}
 
-	get_viewport()->_gui_remove_focus();
-	update();
+	get_viewport()->gui_release_focus();
 }
 
 bool Control::is_top_level_control() const {
@@ -2602,7 +2601,7 @@ Control::MouseFilter Control::get_mouse_filter() const {
 
 Control *Control::get_focus_owner() const {
 	ERR_FAIL_COND_V(!is_inside_tree(), nullptr);
-	return get_viewport()->_gui_get_focus_owner();
+	return get_viewport()->gui_get_focus_owner();
 }
 
 void Control::warp_mouse(const Point2 &p_to_pos) {

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2098,7 +2098,7 @@ void Viewport::_gui_hide_control(Control *p_control) {
 	}
 
 	if (gui.key_focus == p_control) {
-		_gui_remove_focus();
+		gui_release_focus();
 	}
 	if (gui.mouse_over == p_control) {
 		gui.mouse_over = nullptr;
@@ -2148,15 +2148,7 @@ Window *Viewport::get_base_window() const {
 }
 void Viewport::_gui_remove_focus_for_window(Node *p_window) {
 	if (get_base_window() == p_window) {
-		_gui_remove_focus();
-	}
-}
-
-void Viewport::_gui_remove_focus() {
-	if (gui.key_focus) {
-		Node *f = gui.key_focus;
-		gui.key_focus = nullptr;
-		f->notification(Control::NOTIFICATION_FOCUS_EXIT, true);
+		gui_release_focus();
 	}
 }
 
@@ -2276,10 +2268,6 @@ void Viewport::_cleanup_mouseover_colliders(bool p_clean_all_frames, bool p_paus
 		physics_2d_shape_mouseover.erase(shapes_to_erase.front()->get());
 		shapes_to_erase.pop_front();
 	}
-}
-
-Control *Viewport::_gui_get_focus_owner() {
-	return gui.key_focus;
 }
 
 void Viewport::_gui_grab_click_focus(Control *p_control) {
@@ -2795,6 +2783,19 @@ void Viewport::gui_reset_canvas_sort_index() {
 
 int Viewport::gui_get_canvas_sort_index() {
 	return gui.canvas_sort_index++;
+}
+
+void Viewport::gui_release_focus() {
+	if (gui.key_focus) {
+		Control *f = gui.key_focus;
+		gui.key_focus = nullptr;
+		f->notification(Control::NOTIFICATION_FOCUS_EXIT, true);
+		f->update();
+	}
+}
+
+Control *Viewport::gui_get_focus_owner() {
+	return gui.key_focus;
 }
 
 void Viewport::set_msaa(MSAA p_msaa) {
@@ -3589,6 +3590,9 @@ void Viewport::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("gui_get_drag_data"), &Viewport::gui_get_drag_data);
 	ClassDB::bind_method(D_METHOD("gui_is_dragging"), &Viewport::gui_is_dragging);
 	ClassDB::bind_method(D_METHOD("gui_is_drag_successful"), &Viewport::gui_is_drag_successful);
+
+	ClassDB::bind_method(D_METHOD("gui_release_focus"), &Viewport::gui_release_focus);
+	ClassDB::bind_method(D_METHOD("gui_get_focus_owner"), &Viewport::gui_get_focus_owner);
 
 	ClassDB::bind_method(D_METHOD("set_disable_input", "disable"), &Viewport::set_disable_input);
 	ClassDB::bind_method(D_METHOD("is_input_disabled"), &Viewport::is_input_disabled);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -410,15 +410,12 @@ private:
 	Control *_gui_get_drag_preview();
 
 	void _gui_remove_focus_for_window(Node *p_window);
-	void _gui_remove_focus();
 	void _gui_unfocus_control(Control *p_control);
 	bool _gui_control_has_focus(const Control *p_control);
 	void _gui_control_grab_focus(Control *p_control);
 	void _gui_grab_click_focus(Control *p_control);
 	void _post_gui_grab_click_focus();
 	void _gui_accept_event();
-
-	Control *_gui_get_focus_owner();
 
 	bool _gui_drop(Control *p_at_control, Point2 p_at_pos, bool p_just_check);
 
@@ -556,6 +553,9 @@ public:
 
 	void gui_reset_canvas_sort_index();
 	int gui_get_canvas_sort_index();
+
+	void gui_release_focus();
+	Control *gui_get_focus_owner();
 
 	TypedArray<String> get_configuration_warnings() const override;
 


### PR DESCRIPTION
Right now, if you want to release the focus from all control, you have to:
- find a random Control node in the tree,
- call `get_focus_owner().release_focus()` on it.

As it makes little sense to either need a random control to access the currently focused node, or to need access the currently focused node to remove its focus, I implemented this PR.

It exposes two functions in Viewport's API: `gui_get_focus_owner ` which returns the currently focused control in the Viewport and `gui_release_focus`, which unfocus any focused node (if there is one).

I tested both, they seem to work fine. It's not a lot of changes anyway, most of those function were already present but not exposed.