### PR TITLE
Clarify documentation for Rect2/Rect2i's `has_no_area()`

### DIFF
--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -93,7 +93,7 @@
 		<method name="get_area" qualifiers="const">
 			<return type="float" />
 			<description>
-				Returns the area of the [Rect2].
+				Returns the area of the [Rect2]. See also [method has_no_area].
 			</description>
 		</method>
 		<method name="get_center" qualifiers="const">
@@ -130,7 +130,8 @@
 		<method name="has_no_area" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the [Rect2] is flat or empty.
+				Returns [code]true[/code] if the [Rect2] is flat or empty, [code]false[/code] otherwise. See also [method get_area].
+				[b]Note:[/b] If the [Rect2] has a negative size and is not flat or empty, [method has_no_area] will return [code]true[/code].
 			</description>
 		</method>
 		<method name="has_point" qualifiers="const">

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -90,7 +90,7 @@
 		<method name="get_area" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the area of the [Rect2i].
+				Returns the area of the [Rect2i]. See also [method has_no_area].
 			</description>
 		</method>
 		<method name="get_center" qualifiers="const">
@@ -128,7 +128,8 @@
 		<method name="has_no_area" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the [Rect2i] is flat or empty.
+				Returns [code]true[/code] if the [Rect2i] is flat or empty, [code]false[/code] otherwise. See also [method get_area].
+				[b]Note:[/b] If the [Rect2i] has a negative size and is not flat or empty, [method has_no_area] will return [code]true[/code].
 			</description>
 		</method>
 		<method name="has_point" qualifiers="const">


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/57532.

See https://github.com/godotengine/godot/issues/56736.