### PR TITLE
Vectors: Use clear() and has().

### DIFF
--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -68,8 +68,8 @@ void RemoteDebuggerPeerTCP::close() {
 	running = false;
 	thread.wait_to_finish();
 	tcp_client->disconnect_from_host();
-	out_buf.resize(0);
-	in_buf.resize(0);
+	out_buf.clear();
+	in_buf.clear();
 }
 
 RemoteDebuggerPeerTCP::RemoteDebuggerPeerTCP(Ref<StreamPeerTCP> p_tcp) {

--- a/core/debugger/script_debugger.cpp
+++ b/core/debugger/script_debugger.cpp
@@ -104,7 +104,7 @@ void ScriptDebugger::send_error(const String &p_func, const String &p_file, int 
 	// Store stack info, this is ugly, but allows us to separate EngineDebugger and ScriptDebugger. There might be a better way.
 	error_stack_info.append_array(p_stack_info);
 	EngineDebugger::get_singleton()->send_error(p_func, p_file, p_line, p_err, p_descr, p_editor_notify, p_type);
-	error_stack_info.resize(0);
+	error_stack_info.clear();
 }
 
 Vector<ScriptLanguage::StackInfo> ScriptDebugger::get_error_stack_info() const {

--- a/core/io/compression.cpp
+++ b/core/io/compression.cpp
@@ -212,7 +212,7 @@ int Compression::decompress_dynamic(Vector<uint8_t> *p_dst_vect, int p_max_dst_s
 	strm.avail_in = p_src_size;
 
 	// Ensure the destination buffer is empty
-	p_dst_vect->resize(0);
+	p_dst_vect->clear();
 
 	// decompress until deflate stream ends or end of file
 	do {
@@ -244,7 +244,7 @@ int Compression::decompress_dynamic(Vector<uint8_t> *p_dst_vect, int p_max_dst_s
 						WARN_PRINT(strm.msg);
 					}
 					(void)inflateEnd(&strm);
-					p_dst_vect->resize(0);
+					p_dst_vect->clear();
 					return ret;
 			}
 		} while (strm.avail_out > 0 && strm.avail_in > 0);
@@ -254,7 +254,7 @@ int Compression::decompress_dynamic(Vector<uint8_t> *p_dst_vect, int p_max_dst_s
 		// Enforce max output size
 		if (p_max_dst_size > -1 && strm.total_out > (uint64_t)p_max_dst_size) {
 			(void)inflateEnd(&strm);
-			p_dst_vect->resize(0);
+			p_dst_vect->clear();
 			return Z_BUF_ERROR;
 		}
 	} while (ret != Z_STREAM_END);

--- a/core/io/packet_peer.cpp
+++ b/core/io/packet_peer.cpp
@@ -39,7 +39,7 @@ void PacketPeer::set_encode_buffer_max_size(int p_max_size) {
 	ERR_FAIL_COND_MSG(p_max_size < 1024, "Max encode buffer must be at least 1024 bytes");
 	ERR_FAIL_COND_MSG(p_max_size > 256 * 1024 * 1024, "Max encode buffer cannot exceed 256 MiB");
 	encode_buffer_max_size = next_power_of_2(p_max_size);
-	encode_buffer.resize(0);
+	encode_buffer.clear();
 }
 
 int PacketPeer::get_encode_buffer_max_size() const {

--- a/core/io/stream_peer.cpp
+++ b/core/io/stream_peer.cpp
@@ -98,7 +98,7 @@ Array StreamPeer::_get_partial_data(int p_bytes) {
 	Error err = get_partial_data(&w[0], p_bytes, received);
 
 	if (err != OK) {
-		data.resize(0);
+		data.clear();
 	} else if (received != data.size()) {
 		data.resize(received);
 	}
@@ -563,7 +563,7 @@ Vector<uint8_t> StreamPeerBuffer::get_data_array() const {
 }
 
 void StreamPeerBuffer::clear() {
-	data.resize(0);
+	data.clear();
 	pointer = 0;
 }
 

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -2129,7 +2129,7 @@ bool ConvexHullInternal::shift_face(Face *p_face, real_t p_amount, LocalVector<V
 	printf("Needed %d iterations to remove part\n", n);
 #endif
 
-	p_stack.resize(0);
+	p_stack.clear();
 	p_face->origin = shifted_origin;
 
 	return true;
@@ -2167,9 +2167,9 @@ real_t ConvexHullComputer::compute(const Vector3 *p_coords, int32_t p_count, rea
 		return shift;
 	}
 
-	vertices.resize(0);
-	edges.resize(0);
-	faces.resize(0);
+	vertices.clear();
+	edges.clear();
+	faces.clear();
 
 	LocalVector<ConvexHullInternal::Vertex *> old_vertices;
 	get_vertex_copy(hull.vertex_list, old_vertices);

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -95,9 +95,7 @@ public:
 
 	void append_array(Vector<T> p_other);
 
-	bool has(const T &p_val) const {
-		return find(p_val, 0) != -1;
-	}
+	_FORCE_INLINE_ bool has(const T &p_val) const { return find(p_val) != -1; }
 
 	template <class C>
 	void sort_custom() {

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3289,7 +3289,7 @@ AnimationTrackEditGroup::AnimationTrackEditGroup() {
 //////////////////////////////////////
 
 void AnimationTrackEditor::add_track_edit_plugin(const Ref<AnimationTrackEditPlugin> &p_plugin) {
-	if (track_edit_plugins.find(p_plugin) != -1) {
+	if (track_edit_plugins.has(p_plugin)) {
 		return;
 	}
 	track_edit_plugins.push_back(p_plugin);

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -467,7 +467,7 @@ void CreateDialog::select_type(const String &p_type) {
 	}
 
 	favorite->set_disabled(false);
-	favorite->set_pressed(favorite_list.find(p_type) != -1);
+	favorite->set_pressed(favorite_list.has(p_type));
 	get_ok_button()->set_disabled(false);
 }
 
@@ -539,12 +539,12 @@ void CreateDialog::_favorite_toggled() {
 
 	String name = item->get_text(0);
 
-	if (favorite_list.find(name) == -1) {
-		favorite_list.push_back(name);
-		favorite->set_pressed(true);
-	} else {
+	if (favorite_list.has(name)) {
 		favorite_list.erase(name);
 		favorite->set_pressed(false);
+	} else {
+		favorite_list.push_back(name);
+		favorite->set_pressed(true);
 	}
 
 	_save_and_update_favorite_list();

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -534,11 +534,11 @@ void DocTools::generate(bool p_basic_types) {
 
 			Vector<Error> errs = ClassDB::get_method_error_return_values(name, E.name);
 			if (errs.size()) {
-				if (errs.find(OK) == -1) {
+				if (!errs.has(OK)) {
 					errs.insert(0, OK);
 				}
 				for (int i = 0; i < errs.size(); i++) {
-					if (method.errors_returned.find(errs[i]) == -1) {
+					if (!method.errors_returned.has(errs[i])) {
 						method.errors_returned.push_back(errs[i]);
 					}
 				}

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1525,7 +1525,7 @@ void EditorExport::remove_export_preset(int p_idx) {
 }
 
 void EditorExport::add_export_plugin(const Ref<EditorExportPlugin> &p_plugin) {
-	if (export_plugins.find(p_plugin) == -1) {
+	if (!export_plugins.has(p_plugin)) {
 		export_plugins.push_back(p_plugin);
 	}
 }

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3725,7 +3725,7 @@ void EditorNode::_show_messages() {
 
 void EditorNode::_add_to_recent_scenes(const String &p_scene) {
 	Array rc = EditorSettings::get_singleton()->get_project_metadata("recent_files", "scenes", Array());
-	if (rc.find(p_scene) != -1) {
+	if (rc.has(p_scene)) {
 		rc.erase(p_scene);
 	}
 	rc.push_front(p_scene);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -369,7 +369,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 			// Skip locales which we can't render properly (see above comment).
 			// Test against language code without regional variants (e.g. ur_PK).
 			String lang_code = locale.get_slice("_", 0);
-			if (locales_to_skip.find(lang_code) != -1) {
+			if (locales_to_skip.has(lang_code)) {
 				continue;
 			}
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1801,7 +1801,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			// Add the files from favorites.
 			Vector<String> favorites = EditorSettings::get_singleton()->get_favorites();
 			for (int i = 0; i < p_selected.size(); i++) {
-				if (favorites.find(p_selected[i]) == -1) {
+				if (!favorites.has(p_selected[i])) {
 					favorites.push_back(p_selected[i]);
 				}
 			}
@@ -2324,7 +2324,7 @@ void FileSystemDock::drop_data_fw(const Point2 &p_point, const Variant &p_data, 
 			Vector<String> fnames = drag_data["files"];
 			Vector<String> favorites = EditorSettings::get_singleton()->get_favorites();
 			for (int i = 0; i < fnames.size(); i++) {
-				if (favorites.find(fnames[i]) == -1) {
+				if (!favorites.has(fnames[i])) {
 					favorites.push_back(fnames[i]);
 				}
 			}

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -517,7 +517,7 @@ bool ResourceImporterLayeredTexture::are_import_settings_valid(const String &p_p
 		String setting_path = "rendering/textures/vram_compression/import_" + String(compression_formats[index]);
 		bool test = ProjectSettings::get_singleton()->get(setting_path);
 		if (test) {
-			if (formats_imported.find(compression_formats[index]) == -1) {
+			if (!formats_imported.has(compression_formats[index])) {
 				valid = false;
 				break;
 			}

--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -628,7 +628,7 @@ bool ResourceImporterTexture::are_import_settings_valid(const String &p_path) co
 		String setting_path = "rendering/textures/vram_compression/import_" + String(compression_formats[index]);
 		bool test = ProjectSettings::get_singleton()->get(setting_path);
 		if (test) {
-			if (formats_imported.find(compression_formats[index]) == -1) {
+			if (!formats_imported.has(compression_formats[index])) {
 				valid = false;
 				break;
 			}

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -447,7 +447,7 @@ static bool _find_owners(EditorFileSystemDirectory *efsd, const String &p_path) 
 
 	for (int i = 0; i < efsd->get_file_count(); i++) {
 		Vector<String> deps = efsd->get_file_deps(i);
-		if (deps.find(p_path) != -1) {
+		if (deps.has(p_path)) {
 			return true;
 		}
 	}

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -180,7 +180,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 		selected_point = -1;
 
 		for (int i = 0; i < points.size(); i++) {
-			if (making_triangle.find(i) != -1) {
+			if (making_triangle.has(i)) {
 				continue;
 			}
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -755,7 +755,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 		//now scroll it to draw
 		state_machine_draw->draw_style_box(sb, nr.node);
 
-		if (playing && (blend_from == name || current == name || travel_path.find(name) != -1)) {
+		if (playing && (blend_from == name || current == name || travel_path.has(name))) {
 			state_machine_draw->draw_style_box(playing_overlay, nr.node);
 		}
 

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -473,7 +473,7 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 				uv_move_current = uv_mode;
 				if (uv_move_current == UV_MODE_CREATE) {
 					if (!uv_create) {
-						points_prev.resize(0);
+						points_prev.clear();
 						Vector2 tuv = mtx.affine_inverse().xform(snap_point(mb->get_position()));
 						points_prev.push_back(tuv);
 						uv_create_to = tuv;
@@ -682,7 +682,7 @@ void Polygon2DEditor::_uv_input(const Ref<InputEvent> &p_input) {
 							}
 
 							polygon_create.clear();
-						} else if (polygon_create.find(closest) == -1) {
+						} else if (!polygon_create.has(closest)) {
 							//add temporarily if not exists
 							polygon_create.push_back(closest);
 						}

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -3486,7 +3486,7 @@ void ScriptEditor::_open_script_request(const String &p_path) {
 void ScriptEditor::register_syntax_highlighter(const Ref<EditorSyntaxHighlighter> &p_syntax_highlighter) {
 	ERR_FAIL_COND(p_syntax_highlighter.is_null());
 
-	if (syntax_highlighters.find(p_syntax_highlighter) == -1) {
+	if (!syntax_highlighters.has(p_syntax_highlighter)) {
 		syntax_highlighters.push_back(p_syntax_highlighter);
 	}
 }

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1030,7 +1030,7 @@ void VisualShaderEditor::edit(VisualShader *p_visual_shader) {
 }
 
 void VisualShaderEditor::add_plugin(const Ref<VisualShaderNodePlugin> &p_plugin) {
-	if (plugins.find(p_plugin) != -1) {
+	if (plugins.has(p_plugin)) {
 		return;
 	}
 	plugins.push_back(p_plugin);

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -185,7 +185,7 @@ void PropertySelector::_update_search() {
 				continue;
 			}
 
-			if (type_filter.size() && type_filter.find(E.type) == -1) {
+			if (type_filter.size() && !type_filter.has(E.type)) {
 				continue;
 			}
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1723,7 +1723,7 @@ void SceneTreeDock::_do_reparent(Node *p_new_parent, int p_position_in_parent, V
 
 	Node *validate = new_parent;
 	while (validate) {
-		ERR_FAIL_COND_MSG(p_nodes.find(validate) != -1, "Selection changed at some point. Can't reparent.");
+		ERR_FAIL_COND_MSG(p_nodes.has(validate), "Selection changed at some point. Can't reparent.");
 		validate = validate->get_parent();
 	}
 

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -417,7 +417,7 @@ void AnimatedSprite2D::_reset_timeout() {
 
 void AnimatedSprite2D::set_animation(const StringName &p_animation) {
 	ERR_FAIL_COND_MSG(frames == nullptr, vformat("There is no animation with name '%s'.", p_animation));
-	ERR_FAIL_COND_MSG(frames->get_animation_names().find(p_animation) == -1, vformat("There is no animation with name '%s'.", p_animation));
+	ERR_FAIL_COND_MSG(!frames->get_animation_names().has(p_animation), vformat("There is no animation with name '%s'.", p_animation));
 
 	if (animation == p_animation) {
 		return;

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -133,7 +133,7 @@ int Line2D::get_point_count() const {
 void Line2D::clear_points() {
 	int count = _points.size();
 	if (count > 0) {
-		_points.resize(0);
+		_points.clear();
 		update();
 	}
 }

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -299,7 +299,7 @@ void NavigationPolygon::make_polygons_from_outlines() {
 	}
 
 	polygons.clear();
-	vertices.resize(0);
+	vertices.clear();
 
 	Map<Vector2, int> points;
 	for (List<TPPLPoly>::Element *I = out_poly.front(); I; I = I->next()) {

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -46,7 +46,7 @@ Error HTTPRequest::_parse_url(const String &p_url) {
 	request_sent = false;
 	got_response = false;
 	body_len = -1;
-	body.resize(0);
+	body.clear();
 	downloaded.set(0);
 	redirections = 0;
 
@@ -202,7 +202,7 @@ void HTTPRequest::cancel_request() {
 		file = nullptr;
 	}
 	client->close();
-	body.resize(0);
+	body.clear();
 	got_response = false;
 	response_code = -1;
 	request_sent = false;
@@ -220,7 +220,7 @@ bool HTTPRequest::_handle_response(bool *ret_value) {
 	response_code = client->get_response_code();
 	List<String> rheaders;
 	client->get_response_headers(&rheaders);
-	response_headers.resize(0);
+	response_headers.clear();
 	downloaded.set(0);
 	for (const String &E : rheaders) {
 		response_headers.push_back(E);
@@ -260,7 +260,7 @@ bool HTTPRequest::_handle_response(bool *ret_value) {
 				request_sent = false;
 				got_response = false;
 				body_len = -1;
-				body.resize(0);
+				body.clear();
 				downloaded.set(0);
 				redirections = new_redirs;
 				*ret_value = false;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -130,7 +130,7 @@ SceneTree::Group *SceneTree::add_to_group(const StringName &p_group, Node *p_nod
 		E = group_map.insert(p_group, Group());
 	}
 
-	ERR_FAIL_COND_V_MSG(E->get().nodes.find(p_node) != -1, &E->get(), "Already in group: " + p_group + ".");
+	ERR_FAIL_COND_V_MSG(E->get().nodes.has(p_node), &E->get(), "Already in group: " + p_group + ".");
 	E->get().nodes.push_back(p_node);
 	//E->get().last_tree_version=0;
 	E->get().changed = true;

--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -661,8 +661,8 @@ void Curve2D::_bake() const {
 	baked_cache_dirty = false;
 
 	if (points.size() == 0) {
-		baked_point_cache.resize(0);
-		baked_dist_cache.resize(0);
+		baked_point_cache.clear();
+		baked_dist_cache.clear();
 		return;
 	}
 
@@ -1164,10 +1164,10 @@ void Curve3D::_bake() const {
 	baked_cache_dirty = false;
 
 	if (points.size() == 0) {
-		baked_point_cache.resize(0);
-		baked_tilt_cache.resize(0);
-		baked_up_vector_cache.resize(0);
-		baked_dist_cache.resize(0);
+		baked_point_cache.clear();
+		baked_tilt_cache.clear();
+		baked_up_vector_cache.clear();
+		baked_dist_cache.clear();
 		return;
 	}
 
@@ -1183,7 +1183,7 @@ void Curve3D::_bake() const {
 			baked_up_vector_cache.resize(1);
 			baked_up_vector_cache.set(0, Vector3(0, 1, 0));
 		} else {
-			baked_up_vector_cache.resize(0);
+			baked_up_vector_cache.clear();
 		}
 
 		return;

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1475,12 +1475,12 @@ void ArrayMesh::add_blend_shape(const StringName &p_name) {
 
 	StringName name = p_name;
 
-	if (blend_shapes.find(name) != -1) {
+	if (blend_shapes.has(name)) {
 		int count = 2;
 		do {
 			name = String(p_name) + " " + itos(count);
 			count++;
-		} while (blend_shapes.find(name) != -1);
+		} while (blend_shapes.has(name));
 	}
 
 	blend_shapes.push_back(name);

--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -112,7 +112,7 @@ void AudioEffectRecordInstance::init() {
 	ring_buffer_read_pos = 0;
 
 	//We start a new recording
-	recording_data.resize(0); //Clear data completely and reset length
+	recording_data.clear(); //Clear data completely and reset length
 	is_recording = true;
 
 #ifdef NO_THREADS

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -925,7 +925,7 @@ void RendererSceneRenderRD::shadow_atlas_set_size(RID p_atlas, int p_size, bool 
 	}
 	for (int i = 0; i < 4; i++) {
 		//clear subdivisions
-		shadow_atlas->quadrants[i].shadows.resize(0);
+		shadow_atlas->quadrants[i].shadows.clear();
 		shadow_atlas->quadrants[i].shadows.resize(1 << shadow_atlas->quadrants[i].subdivision);
 	}
 
@@ -972,7 +972,7 @@ void RendererSceneRenderRD::shadow_atlas_set_quadrant_subdivision(RID p_atlas, i
 		}
 	}
 
-	shadow_atlas->quadrants[p_quadrant].shadows.resize(0);
+	shadow_atlas->quadrants[p_quadrant].shadows.clear();
 	shadow_atlas->quadrants[p_quadrant].shadows.resize(subdiv * subdiv);
 	shadow_atlas->quadrants[p_quadrant].subdivision = subdiv;
 

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -6238,7 +6238,7 @@ void RendererStorageRD::skeleton_allocate_data(RID p_skeleton, int p_bones, bool
 	if (skeleton->buffer.is_valid()) {
 		RD::get_singleton()->free(skeleton->buffer);
 		skeleton->buffer = RID();
-		skeleton->data.resize(0);
+		skeleton->data.clear();
 		skeleton->uniform_set_mi = RID();
 	}
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -822,7 +822,7 @@ void RendererViewport::viewport_set_active(RID p_viewport, bool p_active) {
 	ERR_FAIL_COND(!viewport);
 
 	if (p_active) {
-		ERR_FAIL_COND_MSG(active_viewports.find(viewport) != -1, "Can't make active a Viewport that is already active.");
+		ERR_FAIL_COND_MSG(active_viewports.has(viewport), "Can't make active a Viewport that is already active.");
 		viewport->occlusion_buffer_dirty = true;
 		active_viewports.push_back(viewport);
 	} else {

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -7476,7 +7476,7 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 
 					const String smode = String(mode);
 
-					if (shader->render_modes.find(mode) != -1) {
+					if (shader->render_modes.has(mode)) {
 						_set_error(vformat(RTR("Duplicated render mode: '%s'."), smode));
 						return ERR_PARSE_ERROR;
 					}
@@ -7489,7 +7489,7 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 
 						if (smode.begins_with(name)) {
 							if (!info.options.is_empty()) {
-								if (info.options.find(smode.substr(name.length() + 1)) != -1) {
+								if (info.options.has(smode.substr(name.length() + 1))) {
 									found = true;
 
 									if (defined_modes.has(name)) {


### PR DESCRIPTION
Use `clear()` instead of `resize(0)` for Vectors, mostly where readability isn't affected.
https://github.com/godotengine/godot/blob/ea12094f19b028c1dcf6d402b8cbb3296b2065a8/core/templates/vector.h#L84


Use `has()` instead of "find(p_val) != -1".
https://github.com/godotengine/godot/blob/ea12094f19b028c1dcf6d402b8cbb3296b2065a8/core/templates/vector.h#L98-L100

Rewrite `has()`, as `p_from ` in `find()` is initialized to 0.
https://github.com/godotengine/godot/blob/ea12094f19b028c1dcf6d402b8cbb3296b2065a8/core/templates/vector.h#L94