### PR TITLE
Increase RemoteDebuggerPeerTCP poll to 6.9ms to reduce CPU usage

### DIFF
--- a/core/debugger/remote_debugger_peer.cpp
+++ b/core/debugger/remote_debugger_peer.cpp
@@ -190,7 +190,8 @@ Error RemoteDebuggerPeerTCP::connect_to_host(const String &p_host, uint16_t p_po
 }
 
 void RemoteDebuggerPeerTCP::_thread_func(void *p_ud) {
-	const uint64_t min_tick = 100;
+	// Update in time for 144hz monitors
+	const uint64_t min_tick = 6900;
 	RemoteDebuggerPeerTCP *peer = (RemoteDebuggerPeerTCP *)p_ud;
 	while (peer->running && peer->is_peer_connected()) {
 		uint64_t ticks_usec = OS::get_singleton()->get_ticks_usec();


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/57256

<img width="743" alt="Screenshot 2022-02-01 at 22 17 32" src="https://user-images.githubusercontent.com/100964/152035808-b104b33a-fb98-45e6-a90d-140225254acf.png">

And profile report:

<img width="1440" alt="Screenshot 2022-02-01 at 22 20 23" src="https://user-images.githubusercontent.com/100964/152036252-a43d5c7d-130f-4f7d-bbd0-d7d90a505945.png">
