### PR TITLE
Fix possible error loading resource while a thread is destroying it

### DIFF
--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -54,7 +54,9 @@ void Resource::set_path(const String &p_path, bool p_take_over) {
 
 	if (!path_cache.is_empty()) {
 		ResourceCache::lock.write_lock();
-		ResourceCache::resources.erase(path_cache);
+		// This resource may have already been removed from the cache by the resource
+		// loader in a different thread. Only remove it if the one stored is the same.
+		ResourceCache::resources.erase(path_cache, this);
 		ResourceCache::lock.write_unlock();
 	}
 
@@ -436,7 +438,9 @@ Resource::Resource() :
 Resource::~Resource() {
 	if (!path_cache.is_empty()) {
 		ResourceCache::lock.write_lock();
-		ResourceCache::resources.erase(path_cache);
+		// This resource may have already been removed from the cache by the resource
+		// loader in a different thread. Only remove it if the one stored is the same.
+		ResourceCache::resources.erase(path_cache, this);
 		ResourceCache::lock.write_unlock();
 	}
 	if (owners.size()) {


### PR DESCRIPTION
This happens because the resource loader already ignores cached resources that are being destroyed (cannot be references anymore), and loads a new one. However, if the previous one is still being destroyed while the new one is assigned the resource path, this results in the `Another resource is loaded from path` error and the new resource not being assigned any resource path.

This can happen in multi-threaded scenarios.

Example reproduction project: [res_cache_threads_test.zip](https://github.com/godotengine/godot/files/7982087/res_cache_threads_test.zip)
 This example project deliberately uses a resource that takes an infinite amount of time to be destroyed (check the script), until allowed to finish.

### Possible regression

With this fix, the previous scenario results in two resources in memory having the same path associated, because one is still being destroyed. I don't know if this can cause any issue. Can resource destructors use the path for anything problematic?
