### PR TITLE
Replace GeometryInstance3D transparency property with opacity

### DIFF
--- a/doc/classes/GeometryInstance3D.xml
+++ b/doc/classes/GeometryInstance3D.xml
@@ -56,8 +56,10 @@
 			The material override for the whole geometry.
 			If a material is assigned to this property, it will be used instead of any material set in any material slot of the mesh.
 		</member>
-		<member name="transparency" type="float" setter="set_transparency" getter="get_transparency" default="0.0">
-			Transparency applied to the whole geometry. In spatial shaders, transparency is set as the default value of the [code]ALPHA[/code] built-in.
+		<member name="opacity" type="float" setter="set_opacity" getter="get_opacity" default="1.0">
+			The opacity applied to the whole geometry (as a multiplier of the materials' existing opacity). [code]1.0[/code] is fully opaque, while [code]0.0[/code] is fully transparent. Values lower than [code]1.0[/code] will force the geometry's materials to go through the transparent pipeline, which is slower to render and can exhibit rendering issues due to incorrect transparency sorting. However, unlike using a transparent material, setting [member opacity] to a value lower than [code]1.0[/code] will not disable shadow rendering.
+			In spatial shaders, [member opacity] is set as the default value of the [code]ALPHA[/code] built-in.
+			[b]Note:[/b] [member opacity] is clamped between [code]0.0[/code] and [code]1.0[/code], so this property cannot be used to make transparent materials more opaque than they originally are.
 		</member>
 		<member name="visibility_range_begin" type="float" setter="set_visibility_range_begin" getter="get_visibility_range_begin" default="0.0">
 			Starting distance from which the GeometryInstance3D will be visible, taking [member visibility_range_begin_margin] into account as well. The default value of 0 is used to disable the range check.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1441,20 +1441,23 @@
 				Sets a material that will override the material for all surfaces on the mesh associated with this instance. Equivalent to [member GeometryInstance3D.material_override].
 			</description>
 		</method>
+		<method name="instance_geometry_set_opacity">
+			<return type="void" />
+			<argument index="0" name="instance" type="RID" />
+			<argument index="1" name="opacity" type="float" />
+			<description>
+				Sets the opacity for the given geometry instance (as a multiplier of the materials' existing opacity). Equivalent to [member GeometryInstance3D.opacity].
+				An [code]opacity[/code] of [code]1.0[/code] is fully opaque, while [code]0.0[/code] is fully transparent. Values lower than [code]1.0[/code] will force the geometry's materials to go through the transparent pipeline, which is slower to render and can exhibit rendering issues due to incorrect transparency sorting. However, unlike using a transparent material, setting [code]opacity[/code] to a value lower than [code]1.0[/code] will not disable shadow rendering.
+				In spatial shaders, [code]opacity[/code] is set as the default value of the [code]ALPHA[/code] built-in.
+				[b]Note:[/b] [code]opacity[/code] is clamped between [code]0.0[/code] and [code]1.0[/code], so [method instance_geometry_set_opacity] cannot be used to make transparent materials more opaque than they originally are.
+			</description>
+		</method>
 		<method name="instance_geometry_set_shader_parameter">
 			<return type="void" />
 			<argument index="0" name="instance" type="RID" />
 			<argument index="1" name="parameter" type="StringName" />
 			<argument index="2" name="value" type="Variant" />
 			<description>
-			</description>
-		</method>
-		<method name="instance_geometry_set_transparency">
-			<return type="void" />
-			<argument index="0" name="instance" type="RID" />
-			<argument index="1" name="transparency" type="float" />
-			<description>
-				Sets the transparency for the given geometry instance. Equivalent to [member GeometryInstance3D.transparency].
 			</description>
 		</method>
 		<method name="instance_geometry_set_visibility_range">

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -61,7 +61,7 @@ void RasterizerSceneGLES3::geometry_instance_set_layer_mask(GeometryInstance *p_
 void RasterizerSceneGLES3::geometry_instance_set_lod_bias(GeometryInstance *p_geometry_instance, float p_lod_bias) {
 }
 
-void RasterizerSceneGLES3::geometry_instance_set_transparency(GeometryInstance *p_geometry_instance, float p_transparency) {
+void RasterizerSceneGLES3::geometry_instance_set_opacity(GeometryInstance *p_geometry_instance, float p_opacity) {
 }
 
 void RasterizerSceneGLES3::geometry_instance_set_fade_range(GeometryInstance *p_geometry_instance, bool p_enable_near, float p_near_begin, float p_near_end, bool p_enable_far, float p_far_begin, float p_far_end) {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -56,7 +56,7 @@ public:
 	void geometry_instance_set_transform(GeometryInstance *p_geometry_instance, const Transform3D &p_transform, const AABB &p_aabb, const AABB &p_transformed_aabbb) override;
 	void geometry_instance_set_layer_mask(GeometryInstance *p_geometry_instance, uint32_t p_layer_mask) override;
 	void geometry_instance_set_lod_bias(GeometryInstance *p_geometry_instance, float p_lod_bias) override;
-	void geometry_instance_set_transparency(GeometryInstance *p_geometry_instance, float p_transparency) override;
+	void geometry_instance_set_opacity(GeometryInstance *p_geometry_instance, float p_opacity) override;
 	void geometry_instance_set_fade_range(GeometryInstance *p_geometry_instance, bool p_enable_near, float p_near_begin, float p_near_end, bool p_enable_far, float p_far_begin, float p_far_end) override;
 	void geometry_instance_set_parent_fade_alpha(GeometryInstance *p_geometry_instance, float p_alpha) override;
 	void geometry_instance_set_use_baked_light(GeometryInstance *p_geometry_instance, bool p_enable) override;

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -161,13 +161,13 @@ Ref<Material> GeometryInstance3D::get_material_overlay() const {
 	return material_overlay;
 }
 
-void GeometryInstance3D::set_transparecy(float p_transparency) {
-	transparency = CLAMP(p_transparency, 0.0f, 1.0f);
-	RS::get_singleton()->instance_geometry_set_transparency(get_instance(), transparency);
+void GeometryInstance3D::set_opacity(float p_opacity) {
+	opacity = CLAMP(p_opacity, 0.0f, 1.0f);
+	RS::get_singleton()->instance_geometry_set_opacity(get_instance(), opacity);
 }
 
-float GeometryInstance3D::get_transparency() const {
-	return transparency;
+float GeometryInstance3D::get_opacity() const {
+	return opacity;
 }
 
 void GeometryInstance3D::set_visibility_range_begin(float p_dist) {
@@ -416,8 +416,8 @@ void GeometryInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_lod_bias", "bias"), &GeometryInstance3D::set_lod_bias);
 	ClassDB::bind_method(D_METHOD("get_lod_bias"), &GeometryInstance3D::get_lod_bias);
 
-	ClassDB::bind_method(D_METHOD("set_transparency", "transparency"), &GeometryInstance3D::set_transparecy);
-	ClassDB::bind_method(D_METHOD("get_transparency"), &GeometryInstance3D::get_transparency);
+	ClassDB::bind_method(D_METHOD("set_opacity", "opacity"), &GeometryInstance3D::set_opacity);
+	ClassDB::bind_method(D_METHOD("get_opacity"), &GeometryInstance3D::get_opacity);
 
 	ClassDB::bind_method(D_METHOD("set_visibility_range_end_margin", "distance"), &GeometryInstance3D::set_visibility_range_end_margin);
 	ClassDB::bind_method(D_METHOD("get_visibility_range_end_margin"), &GeometryInstance3D::get_visibility_range_end_margin);
@@ -456,7 +456,7 @@ void GeometryInstance3D::_bind_methods() {
 	ADD_GROUP("Geometry", "");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material_override", PROPERTY_HINT_RESOURCE_TYPE, "BaseMaterial3D,ShaderMaterial", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_DEFERRED_SET_RESOURCE), "set_material_override", "get_material_override");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material_overlay", PROPERTY_HINT_RESOURCE_TYPE, "BaseMaterial3D,ShaderMaterial", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_DEFERRED_SET_RESOURCE), "set_material_overlay", "get_material_overlay");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "transparency", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_transparency", "get_transparency");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "opacity", PROPERTY_HINT_RANGE, "0.0,1.0,0.01"), "set_opacity", "get_opacity");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cast_shadow", PROPERTY_HINT_ENUM, "Off,On,Double-Sided,Shadows Only"), "set_cast_shadows_setting", "get_cast_shadows_setting");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "extra_cull_margin", PROPERTY_HINT_RANGE, "0,16384,0.01"), "set_extra_cull_margin", "get_extra_cull_margin");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "lod_bias", PROPERTY_HINT_RANGE, "0.001,128,0.001"), "set_lod_bias", "get_lod_bias");

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -118,7 +118,7 @@ private:
 	float visibility_range_end_margin = 0.0;
 	VisibilityRangeFadeMode visibility_range_fade_mode = VISIBILITY_RANGE_FADE_DISABLED;
 
-	float transparency = 0.0f;
+	float opacity = 1.0f;
 
 	float lod_bias = 1.0;
 
@@ -144,8 +144,8 @@ public:
 	void set_cast_shadows_setting(ShadowCastingSetting p_shadow_casting_setting);
 	ShadowCastingSetting get_cast_shadows_setting() const;
 
-	void set_transparecy(float p_transparency);
-	float get_transparency() const;
+	void set_opacity(float p_opacity);
+	float get_opacity() const;
 
 	void set_visibility_range_begin(float p_dist);
 	float get_visibility_range_begin() const;

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -58,7 +58,7 @@ public:
 	void geometry_instance_set_cast_double_sided_shadows(GeometryInstance *p_geometry_instance, bool p_enable) override {}
 	void geometry_instance_set_fade_range(GeometryInstance *p_geometry_instance, bool p_enable_near, float p_near_begin, float p_near_end, bool p_enable_far, float p_far_begin, float p_far_end) override {}
 	void geometry_instance_set_parent_fade_alpha(GeometryInstance *p_geometry_instance, float p_alpha) override {}
-	void geometry_instance_set_transparency(GeometryInstance *p_geometry_instance, float p_transparency) override {}
+	void geometry_instance_set_opacity(GeometryInstance *p_geometry_instance, float p_opacity) override {}
 
 	uint32_t geometry_instance_get_pair_mask() override { return 0; }
 	void geometry_instance_pair_light_instances(GeometryInstance *p_geometry_instance, const RID *p_light_instances, uint32_t p_light_instance_count) override {}

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -3006,10 +3006,10 @@ void RenderForwardClustered::geometry_instance_set_parent_fade_alpha(GeometryIns
 	ginstance->parent_fade_alpha = p_alpha;
 }
 
-void RenderForwardClustered::geometry_instance_set_transparency(GeometryInstance *p_geometry_instance, float p_transparency) {
+void RenderForwardClustered::geometry_instance_set_opacity(GeometryInstance *p_geometry_instance, float p_opacity) {
 	GeometryInstanceForwardClustered *ginstance = static_cast<GeometryInstanceForwardClustered *>(p_geometry_instance);
 	ERR_FAIL_COND(!ginstance);
-	ginstance->force_alpha = CLAMP(1.0 - p_transparency, 0, 1);
+	ginstance->force_alpha = CLAMP(p_opacity, 0, 1);
 }
 
 void RenderForwardClustered::geometry_instance_set_use_baked_light(GeometryInstance *p_geometry_instance, bool p_enable) {

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.h
@@ -622,7 +622,7 @@ public:
 	virtual void geometry_instance_set_lod_bias(GeometryInstance *p_geometry_instance, float p_lod_bias) override;
 	virtual void geometry_instance_set_fade_range(GeometryInstance *p_geometry_instance, bool p_enable_near, float p_near_begin, float p_near_end, bool p_enable_far, float p_far_begin, float p_far_end) override;
 	virtual void geometry_instance_set_parent_fade_alpha(GeometryInstance *p_geometry_instance, float p_alpha) override;
-	virtual void geometry_instance_set_transparency(GeometryInstance *p_geometry_instance, float p_transparency) override;
+	virtual void geometry_instance_set_opacity(GeometryInstance *p_geometry_instance, float p_opacity) override;
 	virtual void geometry_instance_set_use_baked_light(GeometryInstance *p_geometry_instance, bool p_enable) override;
 	virtual void geometry_instance_set_use_dynamic_gi(GeometryInstance *p_geometry_instance, bool p_enable) override;
 	virtual void geometry_instance_set_use_lightmap(GeometryInstance *p_geometry_instance, RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) override;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -2099,7 +2099,7 @@ void RenderForwardMobile::geometry_instance_set_lod_bias(GeometryInstance *p_geo
 void RenderForwardMobile::geometry_instance_set_fade_range(GeometryInstance *p_geometry_instance, bool p_enable_near, float p_near_begin, float p_near_end, bool p_enable_far, float p_far_begin, float p_far_end) {
 }
 
-void RenderForwardMobile::geometry_instance_set_transparency(GeometryInstance *p_geometry_instance, float p_transparency) {
+void RenderForwardMobile::geometry_instance_set_opacity(GeometryInstance *p_geometry_instance, float p_opacity) {
 }
 
 void RenderForwardMobile::geometry_instance_set_parent_fade_alpha(GeometryInstance *p_geometry_instance, float p_alpha) {

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.h
@@ -638,7 +638,7 @@ public:
 	virtual void geometry_instance_set_lod_bias(GeometryInstance *p_geometry_instance, float p_lod_bias) override;
 	virtual void geometry_instance_set_fade_range(GeometryInstance *p_geometry_instance, bool p_enable_near, float p_near_begin, float p_near_end, bool p_enable_far, float p_far_begin, float p_far_end) override;
 	virtual void geometry_instance_set_parent_fade_alpha(GeometryInstance *p_geometry_instance, float p_alpha) override;
-	virtual void geometry_instance_set_transparency(GeometryInstance *p_geometry_instance, float p_transparency) override;
+	virtual void geometry_instance_set_opacity(GeometryInstance *p_geometry_instance, float p_opacity) override;
 	virtual void geometry_instance_set_use_baked_light(GeometryInstance *p_geometry_instance, bool p_enable) override;
 	virtual void geometry_instance_set_use_dynamic_gi(GeometryInstance *p_geometry_instance, bool p_enable) override;
 	virtual void geometry_instance_set_use_lightmap(GeometryInstance *p_geometry_instance, RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) override;

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -76,7 +76,7 @@ public:
 	virtual void instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight) = 0;
 	virtual void instance_set_surface_override_material(RID p_instance, int p_surface, RID p_material) = 0;
 	virtual void instance_set_visible(RID p_instance, bool p_visible) = 0;
-	virtual void instance_geometry_set_transparency(RID p_instance, float p_transparency) = 0;
+	virtual void instance_geometry_set_opacity(RID p_instance, float p_opacity) = 0;
 
 	virtual void instance_set_custom_aabb(RID p_instance, AABB p_aabb) = 0;
 

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -645,7 +645,7 @@ void RendererSceneCull::instance_set_base(RID p_instance, RID p_base) {
 				scene_render->geometry_instance_set_use_dynamic_gi(geom->geometry_instance, instance->dynamic_gi);
 				scene_render->geometry_instance_set_cast_double_sided_shadows(geom->geometry_instance, instance->cast_shadows == RS::SHADOW_CASTING_SETTING_DOUBLE_SIDED);
 				scene_render->geometry_instance_set_use_lightmap(geom->geometry_instance, RID(), instance->lightmap_uv_scale, instance->lightmap_slice_index);
-				scene_render->geometry_instance_set_transparency(geom->geometry_instance, instance->transparency);
+				scene_render->geometry_instance_set_opacity(geom->geometry_instance, instance->opacity);
 				if (instance->lightmap_sh.size() == 9) {
 					scene_render->geometry_instance_set_lightmap_capture(geom->geometry_instance, instance->lightmap_sh.ptr());
 				}
@@ -837,15 +837,15 @@ void RendererSceneCull::instance_set_layer_mask(RID p_instance, uint32_t p_mask)
 	}
 }
 
-void RendererSceneCull::instance_geometry_set_transparency(RID p_instance, float p_transparency) {
+void RendererSceneCull::instance_geometry_set_opacity(RID p_instance, float p_opacity) {
 	Instance *instance = instance_owner.get_or_null(p_instance);
 	ERR_FAIL_COND(!instance);
 
-	instance->transparency = p_transparency;
+	instance->opacity = p_opacity;
 
 	if ((1 << instance->base_type) & RS::INSTANCE_GEOMETRY_MASK && instance->base_data) {
 		InstanceGeometryData *geom = static_cast<InstanceGeometryData *>(instance->base_data);
-		scene_render->geometry_instance_set_transparency(geom->geometry_instance, p_transparency);
+		scene_render->geometry_instance_set_opacity(geom->geometry_instance, p_opacity);
 	}
 }
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -450,7 +450,7 @@ public:
 		Instance *visibility_parent = nullptr;
 		Set<Instance *> visibility_dependencies;
 		uint32_t visibility_dependencies_depth = 0;
-		float transparency = 0.0f;
+		float opacity = 1.0f;
 		Scenario *scenario = nullptr;
 		SelfList<Instance> scenario_item;
 
@@ -939,7 +939,7 @@ public:
 	virtual void instance_set_blend_shape_weight(RID p_instance, int p_shape, float p_weight);
 	virtual void instance_set_surface_override_material(RID p_instance, int p_surface, RID p_material);
 	virtual void instance_set_visible(RID p_instance, bool p_visible);
-	virtual void instance_geometry_set_transparency(RID p_instance, float p_transparency);
+	virtual void instance_geometry_set_opacity(RID p_instance, float p_opacity);
 
 	virtual void instance_set_custom_aabb(RID p_instance, AABB p_aabb);
 

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -57,7 +57,7 @@ public:
 	virtual void geometry_instance_set_transform(GeometryInstance *p_geometry_instance, const Transform3D &p_transform, const AABB &p_aabb, const AABB &p_transformed_aabbb) = 0;
 	virtual void geometry_instance_set_layer_mask(GeometryInstance *p_geometry_instance, uint32_t p_layer_mask) = 0;
 	virtual void geometry_instance_set_lod_bias(GeometryInstance *p_geometry_instance, float p_lod_bias) = 0;
-	virtual void geometry_instance_set_transparency(GeometryInstance *p_geometry_instance, float p_transparency) = 0;
+	virtual void geometry_instance_set_opacity(GeometryInstance *p_geometry_instance, float p_opacity) = 0;
 	virtual void geometry_instance_set_fade_range(GeometryInstance *p_geometry_instance, bool p_enable_near, float p_near_begin, float p_near_end, bool p_enable_far, float p_far_begin, float p_far_end) = 0;
 	virtual void geometry_instance_set_parent_fade_alpha(GeometryInstance *p_geometry_instance, float p_alpha) = 0;
 	virtual void geometry_instance_set_use_baked_light(GeometryInstance *p_geometry_instance, bool p_enable) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -716,7 +716,7 @@ public:
 	FUNC6(instance_geometry_set_visibility_range, RID, float, float, float, float, VisibilityRangeFadeMode)
 	FUNC4(instance_geometry_set_lightmap, RID, RID, const Rect2 &, int)
 	FUNC2(instance_geometry_set_lod_bias, RID, float)
-	FUNC2(instance_geometry_set_transparency, RID, float)
+	FUNC2(instance_geometry_set_opacity, RID, float)
 	FUNC3(instance_geometry_set_shader_parameter, RID, const StringName &, const Variant &)
 	FUNC2RC(Variant, instance_geometry_get_shader_parameter, RID, const StringName &)
 	FUNC2RC(Variant, instance_geometry_get_shader_parameter_default_value, RID, const StringName &)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2459,7 +2459,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("instance_set_blend_shape_weight", "instance", "shape", "weight"), &RenderingServer::instance_set_blend_shape_weight);
 	ClassDB::bind_method(D_METHOD("instance_set_surface_override_material", "instance", "surface", "material"), &RenderingServer::instance_set_surface_override_material);
 	ClassDB::bind_method(D_METHOD("instance_set_visible", "instance", "visible"), &RenderingServer::instance_set_visible);
-	ClassDB::bind_method(D_METHOD("instance_geometry_set_transparency", "instance", "transparency"), &RenderingServer::instance_geometry_set_transparency);
+	ClassDB::bind_method(D_METHOD("instance_geometry_set_opacity", "instance", "opacity"), &RenderingServer::instance_geometry_set_opacity);
 
 	ClassDB::bind_method(D_METHOD("instance_set_custom_aabb", "instance", "aabb"), &RenderingServer::instance_set_custom_aabb);
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1217,7 +1217,7 @@ public:
 	virtual void instance_geometry_set_visibility_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin, VisibilityRangeFadeMode p_fade_mode) = 0;
 	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice) = 0;
 	virtual void instance_geometry_set_lod_bias(RID p_instance, float p_lod_bias) = 0;
-	virtual void instance_geometry_set_transparency(RID p_instance, float p_transparency) = 0;
+	virtual void instance_geometry_set_opacity(RID p_instance, float p_opacity) = 0;
 
 	virtual void instance_geometry_set_shader_parameter(RID p_instance, const StringName &, const Variant &p_value) = 0;
 	virtual Variant instance_geometry_get_shader_parameter(RID p_instance, const StringName &) const = 0;


### PR DESCRIPTION
This makes the property more consistent with other usages of opacity in the Godot API, where 1.0 is fully opaque and 0.0 is fully transparent.

This doesn't break compatibility with `3.x` projects as this property doesn't exist in `3.x`.

I've tested this with the MRP included in https://github.com/godotengine/godot/issues/55366 and can confirm that visibility range fade still works as expected.