### PR TITLE
Make visibility range alpha fade smoother

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -969,10 +969,11 @@ void RenderForwardClustered::_fill_render_list(RenderListType p_render_list, con
 
 		if (inst->fade_near || inst->fade_far) {
 			float fade_dist = inst->transform.origin.distance_to(p_render_data->cam_transform.origin);
+			// Use `smoothstep()` to make opacity changes more gradual and less noticeable to the player.
 			if (inst->fade_far && fade_dist > inst->fade_far_begin) {
-				fade_alpha = MAX(0.0, 1.0 - (fade_dist - inst->fade_far_begin) / (inst->fade_far_end - inst->fade_far_begin));
+				fade_alpha = Math::smoothstep(0.0f, 1.0f, 1.0f - (fade_dist - inst->fade_far_begin) / (inst->fade_far_end - inst->fade_far_begin));
 			} else if (inst->fade_near && fade_dist < inst->fade_near_end) {
-				fade_alpha = MAX(0.0, (fade_dist - inst->fade_near_begin) / (inst->fade_near_end - inst->fade_near_begin));
+				fade_alpha = Math::smoothstep(0.0f, 1.0f, (fade_dist - inst->fade_near_begin) / (inst->fade_near_end - inst->fade_near_begin));
 			}
 		}
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/57534 (can be merged independently).

`smoothstep()` avoids the sudden transparency jump when entering or leaving an object's alpha fade margin distance. This in turn helps make opacity transitions less noticeable to the player, as it's less likely to catch the player's eye.

## Preview

This demonstrates a worst case scenario where the *visibility range begin margin* ends right before the *visibility range end margin*. In real world scenarios, the difference will be more subtle, but it's still noticeable.

- *Left: before (linear fade)*
- *Right: after (with `smoothstep()`)*

https://user-images.githubusercontent.com/180032/152066913-6e892f33-df9b-46ff-b21e-f5d9487acb2c.mp4

Slow motion of the above video:

https://user-images.githubusercontent.com/180032/152066928-1ca12e0c-5d24-4bf2-9c4d-c5082cfb594b.mp4