### PR TITLE
Add a signal to notify when children nodes enter or exit tree

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -726,6 +726,18 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="child_entered_tree">
+			<argument index="0" name="node" type="Node" />
+			<description>
+				Emitted when a child node enters the scene tree, either because it entered on its own or because this node entered with it.
+			</description>
+		</signal>
+		<signal name="child_exited_tree">
+			<argument index="0" name="node" type="Node" />
+			<description>
+				Emitted when a child node exits the scene tree, either because it exited on its own or because this node exited.
+			</description>
+		</signal>
 		<signal name="ready">
 			<description>
 				Emitted when the node is ready. Comes after [method _ready] callback and follows the same rules.

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -211,6 +211,12 @@ void Node::_propagate_enter_tree() {
 
 	data.tree->node_added(this);
 
+	if (data.parent) {
+		Variant c = this;
+		const Variant *cptr = &c;
+		data.parent->emit_signal(SNAME("child_entered_tree"), &cptr, 1);
+	}
+
 	data.blocked++;
 	//block while adding children
 
@@ -279,6 +285,12 @@ void Node::_propagate_exit_tree() {
 	notification(NOTIFICATION_EXIT_TREE, true);
 	if (data.tree) {
 		data.tree->node_removed(this);
+	}
+
+	if (data.parent) {
+		Variant c = this;
+		const Variant *cptr = &c;
+		data.parent->emit_signal(SNAME("child_exited_tree"), &cptr, 1);
 	}
 
 	// exit groups
@@ -2865,6 +2877,8 @@ void Node::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("tree_entered"));
 	ADD_SIGNAL(MethodInfo("tree_exiting"));
 	ADD_SIGNAL(MethodInfo("tree_exited"));
+	ADD_SIGNAL(MethodInfo("child_entered_tree", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "Node")));
+	ADD_SIGNAL(MethodInfo("child_exited_tree", PropertyInfo(Variant::OBJECT, "node", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_DEFAULT, "Node")));
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "name", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_name", "get_name");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "scene_file_path", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "set_scene_file_path", "get_scene_file_path");


### PR DESCRIPTION
* Allows more fine grained notifications (hence better performance) than using the global scene tree signals (node added and removed).
* Required for #55950

*Bugsquad edit:*
- Resolves https://github.com/godotengine/godot-proposals/issues/724
- Resolves https://github.com/godotengine/godot-proposals/issues/2544