### PR TITLE
Portals - fix DYNAMIC particle systems

### DIFF
--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -1281,13 +1281,17 @@ void RoomManager::_process_static(Room *p_room, Spatial *p_node, Vector<Vector3>
 	bool ignore = false;
 	VisualInstance *vi = Object::cast_to<VisualInstance>(p_node);
 
+	bool is_dynamic = false;
+
 	// we are only interested in VIs with static or dynamic mode
 	if (vi) {
 		switch (vi->get_portal_mode()) {
 			default: {
 				ignore = true;
 			} break;
-			case CullInstance::PORTAL_MODE_DYNAMIC:
+			case CullInstance::PORTAL_MODE_DYNAMIC: {
+				is_dynamic = true;
+			} break;
 			case CullInstance::PORTAL_MODE_STATIC:
 				break;
 		}
@@ -1335,7 +1339,7 @@ void RoomManager::_process_static(Room *p_room, Spatial *p_node, Vector<Vector3>
 					// NOTE the is_visible check MAY cause problems if conversion run on nodes that
 					// aren't properly in the tree. It can optionally be removed. Certainly calling is_visible_in_tree
 					// DID cause problems.
-					if (mi->get_include_in_bound() && mi->is_visible()) {
+					if (!is_dynamic && mi->get_include_in_bound() && mi->is_visible()) {
 						r_room_pts.append_array(object_pts);
 					}
 
@@ -1353,12 +1357,13 @@ void RoomManager::_process_static(Room *p_room, Spatial *p_node, Vector<Vector3>
 				AABB aabb;
 
 				// attempt to recognise this GeometryInstance and read back the geometry
-				if (_bound_findpoints_geom_instance(gi, object_pts, aabb)) {
+				// Note: never attempt to add dynamics to the room aabb
+				if (is_dynamic || _bound_findpoints_geom_instance(gi, object_pts, aabb)) {
 					// need to keep track of room bound
 					// NOTE the is_visible check MAY cause problems if conversion run on nodes that
 					// aren't properly in the tree. It can optionally be removed. Certainly calling is_visible_in_tree
 					// DID cause problems.
-					if (gi->get_include_in_bound() && gi->is_visible()) {
+					if (!is_dynamic && gi->get_include_in_bound() && gi->is_visible()) {
 						r_room_pts.append_array(object_pts);
 					}
 


### PR DESCRIPTION
A regression had occurred whereby particle systems in DYNAMIC mode weren't added to the room correctly.
This PR recognise the case and bypasses the function to retrieve geometry, as retrieving the geometry is not necessary for DYNAMIC objects as they should not affect the room bound. Their AABB will be retrieved during gameplay rather than once off at level conversion.

Fixes #57528

## Notes
* Not sure when the regression came in, this was working originally, probably during a bug fix I didn't consider this case.
* They will have been able to work already as GLOBAL or ROAMING, but DYNAMIC is the most efficient mode for particles that stay in the same room.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
