### PR TITLE
EditorHelpBit: Fix content height fit and RTL theme propagation

### DIFF
--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -540,13 +540,27 @@ ConnectDialog::~ConnectDialog() {
 // Originally copied and adapted from EditorProperty, try to keep style in sync.
 Control *ConnectionsDockTree::make_custom_tooltip(const String &p_text) const {
 	EditorHelpBit *help_bit = memnew(EditorHelpBit);
-	help_bit->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel")));
 	help_bit->get_rich_text()->set_fixed_size_to_width(360 * EDSCALE);
 
-	String text = TTR("Signal:") + " [u][b]" + p_text.get_slice("::", 0) + "[/b][/u]";
-	text += p_text.get_slice("::", 1).strip_edges() + "\n";
-	text += p_text.get_slice("::", 2).strip_edges();
-	help_bit->call_deferred(SNAME("set_text"), text); // Hack so it uses proper theme once inside scene.
+	// p_text is expected to be something like this:
+	// "gui_input::(event: InputEvent)::<Signal description>"
+	// with the latter being possibly empty.
+	PackedStringArray slices = p_text.split("::", false);
+	if (slices.size() < 2) {
+		// Shouldn't happen here, but just in case pass the text along.
+		help_bit->set_text(p_text);
+		return help_bit;
+	}
+
+	String text = TTR("Signal:") + " [u][b]" + slices[0] + "[/b][/u]";
+	text += slices[1].strip_edges() + "\n";
+	if (slices.size() > 2) {
+		text += slices[2].strip_edges();
+	} else {
+		text += "[i]" + TTR("No description.") + "[/i]";
+	}
+	help_bit->set_text(text);
+
 	return help_bit;
 }
 

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1910,6 +1910,8 @@ DocTools *EditorHelp::get_doc_data() {
 	return doc;
 }
 
+//// EditorHelpBit ///
+
 void EditorHelpBit::_go_to_help(String p_what) {
 	EditorNode::get_singleton()->set_visible_editor(EditorNode::EDITOR_SCRIPT);
 	ScriptEditor::get_singleton()->goto_help(p_what);
@@ -1950,12 +1952,9 @@ void EditorHelpBit::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			rich_text->add_theme_color_override("selection_color", get_theme_color(SNAME("selection_color"), SNAME("EditorHelp")));
-		} break;
-
-		case NOTIFICATION_READY: {
 			rich_text->clear();
 			_add_text_to_rt(text, rich_text);
-
+			rich_text->reset_size(); // Force recalculating size after parsing bbcode.
 		} break;
 	}
 }
@@ -1971,8 +1970,11 @@ EditorHelpBit::EditorHelpBit() {
 	add_child(rich_text);
 	rich_text->connect("meta_clicked", callable_mp(this, &EditorHelpBit::_meta_clicked));
 	rich_text->set_override_selected_font_color(false);
-	set_custom_minimum_size(Size2(0, 70 * EDSCALE));
+	rich_text->set_fit_content_height(true);
+	set_custom_minimum_size(Size2(0, 50 * EDSCALE));
 }
+
+//// FindBar ///
 
 FindBar::FindBar() {
 	search_text = memnew(LineEdit);

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -833,28 +833,40 @@ void EditorProperty::_update_pin_flags() {
 	}
 }
 
-Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
-	tooltip_text = p_text;
+static Control *make_help_bit(const String &p_text, bool p_property) {
 	EditorHelpBit *help_bit = memnew(EditorHelpBit);
-	//help_bit->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel")));
 	help_bit->get_rich_text()->set_fixed_size_to_width(360 * EDSCALE);
 
-	String text;
 	PackedStringArray slices = p_text.split("::", false);
-	if (!slices.is_empty()) {
-		String property_name = slices[0].strip_edges();
-		text = TTR("Property:") + " [u][b]" + property_name + "[/b][/u]";
-
-		if (slices.size() > 1) {
-			String property_doc = slices[1].strip_edges();
-			if (property_name != property_doc) {
-				text += "\n" + property_doc;
-			}
-		}
-		help_bit->call_deferred(SNAME("set_text"), text); //hack so it uses proper theme once inside scene
+	if (slices.is_empty()) {
+		// Shouldn't happen here, but just in case pass the text along.
+		help_bit->set_text(p_text);
+		return help_bit;
 	}
 
+	String property_name = slices[0].strip_edges();
+	String text;
+	if (p_property) {
+		text = TTR("Property:") + " ";
+	}
+	text += "[u][b]" + property_name + "[/b][/u]";
+
+	if (slices.size() > 1) {
+		String property_doc = slices[1].strip_edges();
+		if (property_name != property_doc) {
+			text += "\n" + property_doc;
+		}
+	} else {
+		text += "\n[i]" + TTR("No description.") + "[/i]";
+	}
+	help_bit->set_text(text);
+
 	return help_bit;
+}
+
+Control *EditorProperty::make_custom_tooltip(const String &p_text) const {
+	tooltip_text = p_text;
+	return make_help_bit(p_text, true);
 }
 
 String EditorProperty::get_tooltip_text() const {
@@ -1094,25 +1106,7 @@ void EditorInspectorCategory::_notification(int p_what) {
 
 Control *EditorInspectorCategory::make_custom_tooltip(const String &p_text) const {
 	tooltip_text = p_text;
-	EditorHelpBit *help_bit = memnew(EditorHelpBit);
-	help_bit->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel")));
-	help_bit->get_rich_text()->set_fixed_size_to_width(360 * EDSCALE);
-
-	PackedStringArray slices = p_text.split("::", false);
-	if (!slices.is_empty()) {
-		String property_name = slices[0].strip_edges();
-		String text = "[u][b]" + property_name + "[/b][/u]";
-
-		if (slices.size() > 1) {
-			String property_doc = slices[1].strip_edges();
-			if (property_name != property_doc) {
-				text += "\n" + property_doc;
-			}
-		}
-		help_bit->call_deferred(SNAME("set_text"), text); //hack so it uses proper theme once inside scene
-	}
-
-	return help_bit;
+	return make_help_bit(p_text, false);
 }
 
 Size2 EditorInspectorCategory::get_minimum_size() const {


### PR DESCRIPTION
This reverts #51619 and fixes the issue properly, as well as enabling
`fit_content_height` which is necessary following #57304.

- Fixes #57174.

Also adds placeholder for property and signal tooltips with no description,
factoring the code while at it.

Thanks @bruvzg for the hints.

---

Before:
![image](https://user-images.githubusercontent.com/4701338/152170241-34c1a4e7-7f1c-4115-bae2-ca652e60ba71.png)

![image](https://user-images.githubusercontent.com/4701338/152169830-dcc0cc43-20ea-41bd-8173-9497e3500cfd.png)

After:
![image](https://user-images.githubusercontent.com/4701338/152170051-f484c053-66d2-45c2-abbf-c4c97a4893c5.png)

![image](https://user-images.githubusercontent.com/4701338/152170131-869a7a28-7a93-4573-a562-e1a5031685cb.png)
(Was meant to be italics but we don't set an italics font for the `EditorHelp` it seems.)