### PR TITLE
Portals - Improve mesh merging

### DIFF
--- a/doc/classes/CullInstance.xml
+++ b/doc/classes/CullInstance.xml
@@ -15,6 +15,10 @@
 	<methods>
 	</methods>
 	<members>
+		<member name="allow_merging" type="bool" setter="set_allow_merging" getter="get_allow_merging" default="true">
+			This allows fine control over the mesh merging feature in the [RoomManager].
+			Setting this option to [code]false[/code] can be used to prevent an instance being merged.
+		</member>
 		<member name="autoplace_priority" type="int" setter="set_portal_autoplace_priority" getter="get_portal_autoplace_priority" default="0">
 			When set to [code]0[/code], [CullInstance]s will be autoplaced in the [Room] with the highest priority.
 			When set to a value other than [code]0[/code], the system will attempt to autoplace in a [Room] with the [code]autoplace_priority[/code], if it is present.

--- a/scene/3d/cull_instance.cpp
+++ b/scene/3d/cull_instance.cpp
@@ -45,8 +45,11 @@ void CullInstance::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_portal_mode", "mode"), &CullInstance::set_portal_mode);
 	ClassDB::bind_method(D_METHOD("get_portal_mode"), &CullInstance::get_portal_mode);
 
-	ClassDB::bind_method(D_METHOD("set_include_in_bound"), &CullInstance::set_include_in_bound);
+	ClassDB::bind_method(D_METHOD("set_include_in_bound", "enabled"), &CullInstance::set_include_in_bound);
 	ClassDB::bind_method(D_METHOD("get_include_in_bound"), &CullInstance::get_include_in_bound);
+
+	ClassDB::bind_method(D_METHOD("set_allow_merging", "enabled"), &CullInstance::set_allow_merging);
+	ClassDB::bind_method(D_METHOD("get_allow_merging"), &CullInstance::get_allow_merging);
 
 	ClassDB::bind_method(D_METHOD("set_portal_autoplace_priority", "priority"), &CullInstance::set_portal_autoplace_priority);
 	ClassDB::bind_method(D_METHOD("get_portal_autoplace_priority"), &CullInstance::get_portal_autoplace_priority);
@@ -61,11 +64,13 @@ void CullInstance::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "portal_mode", PROPERTY_HINT_ENUM, "Static,Dynamic,Roaming,Global,Ignore"), "set_portal_mode", "get_portal_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "include_in_bound"), "set_include_in_bound", "get_include_in_bound");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_merging"), "set_allow_merging", "get_allow_merging");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "autoplace_priority", PROPERTY_HINT_RANGE, "-16,16,1", PROPERTY_USAGE_DEFAULT), "set_portal_autoplace_priority", "get_portal_autoplace_priority");
 }
 
 CullInstance::CullInstance() {
 	_portal_mode = PORTAL_MODE_STATIC;
 	_include_in_bound = true;
+	_allow_merging = true;
 	_portal_autoplace_priority = 0;
 }

--- a/scene/3d/cull_instance.h
+++ b/scene/3d/cull_instance.h
@@ -48,8 +48,11 @@ public:
 	void set_portal_mode(CullInstance::PortalMode p_mode);
 	CullInstance::PortalMode get_portal_mode() const;
 
-	void set_include_in_bound(bool p_enable) { _include_in_bound = p_enable; }
+	void set_include_in_bound(bool p_enabled) { _include_in_bound = p_enabled; }
 	bool get_include_in_bound() const { return _include_in_bound; }
+
+	void set_allow_merging(bool p_enabled) { _allow_merging = p_enabled; }
+	bool get_allow_merging() const { return _allow_merging; }
 
 	void set_portal_autoplace_priority(int p_priority) { _portal_autoplace_priority = p_priority; }
 	int get_portal_autoplace_priority() const { return _portal_autoplace_priority; }
@@ -63,7 +66,8 @@ protected:
 
 private:
 	PortalMode _portal_mode;
-	bool _include_in_bound;
+	bool _include_in_bound : 1;
+	bool _allow_merging : 1;
 
 	// Allows instances to prefer to be autoplaced
 	// in specific RoomGroups. This allows building exteriors

--- a/scene/3d/mesh_instance.h
+++ b/scene/3d/mesh_instance.h
@@ -96,11 +96,12 @@ protected:
 
 private:
 	// merging
-	void _merge_into_mesh_data(const MeshInstance &p_mi, int p_surface_id, PoolVector<Vector3> &r_verts, PoolVector<Vector3> &r_norms, PoolVector<real_t> &r_tangents, PoolVector<Color> &r_colors, PoolVector<Vector2> &r_uvs, PoolVector<Vector2> &r_uv2s, PoolVector<int> &r_inds);
-	bool _ensure_indices_valid(PoolVector<int> &r_indices, const PoolVector<Vector3> &p_verts);
-	bool _check_for_valid_indices(const PoolVector<int> &p_inds, const PoolVector<Vector3> &p_verts, LocalVector<int, int32_t> *r_inds);
-	bool _triangle_is_degenerate(const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_c, real_t p_epsilon);
-	void _merge_log(String p_string);
+	bool _is_mergeable_with(const MeshInstance &p_other) const;
+	void _merge_into_mesh_data(const MeshInstance &p_mi, const Transform &p_dest_tr_inv, int p_surface_id, PoolVector<Vector3> &r_verts, PoolVector<Vector3> &r_norms, PoolVector<real_t> &r_tangents, PoolVector<Color> &r_colors, PoolVector<Vector2> &r_uvs, PoolVector<Vector2> &r_uv2s, PoolVector<int> &r_inds);
+	bool _ensure_indices_valid(PoolVector<int> &r_indices, const PoolVector<Vector3> &p_verts) const;
+	bool _check_for_valid_indices(const PoolVector<int> &p_inds, const PoolVector<Vector3> &p_verts, LocalVector<int, int32_t> *r_inds) const;
+	bool _triangle_is_degenerate(const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_c, real_t p_epsilon) const;
+	void _merge_log(String p_string) const;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
@@ -144,8 +145,8 @@ public:
 	void create_debug_tangents();
 
 	// merging
-	bool is_mergeable_with(const MeshInstance &p_other);
-	bool create_by_merging(Vector<MeshInstance *> p_list);
+	bool is_mergeable_with(Node *p_other) const;
+	bool merge_meshes(Vector<MeshInstance *> p_list, bool p_use_global_space, bool p_check_compatibility);
 
 	virtual AABB get_aabb() const;
 	virtual PoolVector<Face3> get_faces(uint32_t p_usage_flags) const;

--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -2139,8 +2139,7 @@ void RoomManager::_merge_meshes_in_room(Room *p_room) {
 			if (!bf.get_bit(c)) {
 				MeshInstance *b = source_meshes[c];
 
-				//				if (_are_meshes_mergeable(a, b)) {
-				if (a->is_mergeable_with(*b)) {
+				if (a->is_mergeable_with(b)) {
 					merge_list.push_back(b);
 					bf.set_bit(c, true);
 				}
@@ -2157,7 +2156,7 @@ void RoomManager::_merge_meshes_in_room(Room *p_room) {
 
 			_merge_log("\t\t" + merged->get_name());
 
-			if (merged->create_by_merging(merge_list)) {
+			if (merged->merge_meshes(merge_list, true, false)) {
 				// set all the source meshes to portal mode ignore so not shown
 				for (int i = 0; i < merge_list.size(); i++) {
 					merge_list[i]->set_portal_mode(CullInstance::PORTAL_MODE_IGNORE);


### PR DESCRIPTION
Some improvements to robustness to account for more properties.
Fixes correctly dealing with:
* cast shadows
* material override
* baked light flag

Also added an "allow merging" flag in the cull instance, to allow fine control over merging, defaults to true.

Fixes #57527

## Notes
* This supersedes #56513, but does not include binding the merge functions to gdscript etc, as I realise that adding APIs involves more discussion, so I will put the binding in a separate later PR.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
