### PR TITLE
BVH - fix leaking leaves

### DIFF
--- a/core/math/bvh_tree.h
+++ b/core/math/bvh_tree.h
@@ -262,7 +262,7 @@ private:
 				change_root_node(sibling_id, p_tree_id);
 
 				// delete the old root node as no longer needed
-				_nodes.free(p_parent_id);
+				node_free_node_and_leaf(p_parent_id);
 			}
 
 			return;
@@ -275,7 +275,19 @@ private:
 		}
 
 		// put the node on the free list to recycle
-		_nodes.free(p_parent_id);
+		node_free_node_and_leaf(p_parent_id);
+	}
+
+	// A node can either be a node, or a node AND a leaf combo.
+	// Both must be deleted to prevent a leak.
+	void node_free_node_and_leaf(uint32_t p_node_id) {
+		TNode &node = _nodes[p_node_id];
+		if (node.is_leaf()) {
+			int leaf_id = node.get_leaf_id();
+			_leaves.free(leaf_id);
+		}
+
+		_nodes.free(p_node_id);
 	}
 
 	void change_root_node(uint32_t p_new_root_id, uint32_t p_tree_id) {
@@ -367,7 +379,7 @@ private:
 				refit_upward(parent_id);
 
 				// put the node on the free list to recycle
-				_nodes.free(owner_node_id);
+				node_free_node_and_leaf(owner_node_id);
 			}
 
 			// else if no parent, it is the root node. Do not delete


### PR DESCRIPTION
In the BVH leaf nodes are a combination of two objects - a node object, and a leaf object. Testing revealed that in some situations node objects could be freed without also freeing the paired leaf object. This closes this bug.

Fixes #57555

## Notes
* This probably didn't happen all that often in real world cases, and the leak of each leaf is relatively small, hence it didn't get picked up earlier, but good to fix
* The `node_free_node_and_leaf()` function strictly speaking only has to be called in one of the three cases, as the other two are non-leaf nodes by definition, but I don't think it will hurt as it is rarely called and it guards against bugs due to future changes.
 
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
