### PR TITLE
Expand description for warp_mouse_position method

### DIFF
--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -383,7 +383,8 @@
 			<return type="void" />
 			<argument index="0" name="to" type="Vector2" />
 			<description>
-				Sets the mouse position to the specified vector.
+				Sets the mouse position to the specified vector, provided in pixels and relative to an origin at the upper left corner of the game window.
+				Mouse position is clipped to the limits of the screen resolution, or to the limits of the game window if [enum MouseMode] is set to [code]MOUSE_MODE_CONFINED[/code] or [code]MOUSE_MODE_CONFINED_HIDDEN[/code].
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Add more detail to the description for the warp_mouse_position method, clarifying that the vector is in screen coordinates and relative to an origin at the top of the game window.

Addresses godotengine/godot-docs#5576

_Bugsquad edit: Fixes godotengine/godot-docs#5576_
