### PR TITLE
[Net] Non-blocking request in HTTPClientTCP.

### DIFF
--- a/core/io/http_client_tcp.h
+++ b/core/io/http_client_tcp.h
@@ -62,6 +62,7 @@ private:
 	int64_t body_left = 0;
 	bool read_until_eof = false;
 
+	Ref<StreamPeerBuffer> request_buffer;
 	Ref<StreamPeerTCP> tcp_connection;
 	Ref<StreamPeer> connection;
 	Ref<HTTPClientTCP> proxy_client; // Negotiate with proxy server.


### PR DESCRIPTION
HTTPClientJavaScript already supports non-blocking requests.

This is also potentially cherry-pickable to `3.x` since it does not break the exposed API (though I would warrant some more testing).