### PR TITLE
[macOS] Add empty translation files to the exported app bundle, to allow translation detection by the OS.

### DIFF
--- a/platform/osx/export/export_plugin.cpp
+++ b/platform/osx/export/export_plugin.cpp
@@ -777,6 +777,24 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 		err = tmp_app_dir->make_dir_recursive(tmp_app_path_name + "/Contents/Resources");
 	}
 
+	Vector<String> translations = ProjectSettings::get_singleton()->get("internationalization/locale/translations");
+	if (translations.size() > 0) {
+		{
+			String fname = tmp_app_path_name + "/Contents/Resources/en.lproj";
+			tmp_app_dir->make_dir_recursive(fname);
+			FileAccessRef f = FileAccess::open(fname + "/InfoPlist.strings", FileAccess::WRITE);
+		}
+
+		for (const String &E : translations) {
+			Ref<Translation> tr = ResourceLoader::load(E);
+			if (tr.is_valid()) {
+				String fname = tmp_app_path_name + "/Contents/Resources/" + tr->get_locale() + ".lproj";
+				tmp_app_dir->make_dir_recursive(fname);
+				FileAccessRef f = FileAccess::open(fname + "/InfoPlist.strings", FileAccess::WRITE);
+			}
+		}
+	}
+
 	// Now process our template.
 	bool found_binary = false;
 	Vector<String> dylibs_found;


### PR DESCRIPTION
Same as #52945, but for exported apps. Adds an empty `Info.plist` translation for each language in the project.

![Screenshot 2022-02-03 at 09 40 59](https://user-images.githubusercontent.com/7645683/152301792-939c57c8-35bc-46fb-bd09-b1c4f72c5895.png)

