### PR TITLE
Allow multiple declarations in for loop in a shader

### DIFF
--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -813,6 +813,9 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 
 				if (bnode->statements[i]->type == SL::Node::TYPE_CONTROL_FLOW || bnode->single_statement) {
 					code += scode; //use directly
+					if (bnode->use_comma_between_statements && i + 1 < bnode->statements.size()) {
+						code += ",";
+					}
 				} else {
 					code += _mktab(p_level) + scode + ";\n";
 				}
@@ -1287,10 +1290,10 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 				code += _dump_node_code(cfnode->blocks[0], p_level + 1, r_gen_code, p_actions, p_default_actions, p_assigning);
 			} else if (cfnode->flow_op == SL::FLOW_OP_FOR) {
 				String left = _dump_node_code(cfnode->blocks[0], p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
-				String middle = _dump_node_code(cfnode->expressions[0], p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
-				String right = _dump_node_code(cfnode->expressions[1], p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
+				String middle = _dump_node_code(cfnode->blocks[1], p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
+				String right = _dump_node_code(cfnode->blocks[2], p_level, r_gen_code, p_actions, p_default_actions, p_assigning);
 				code += _mktab(p_level) + "for (" + left + ";" + middle + ";" + right + ")\n";
-				code += _dump_node_code(cfnode->blocks[1], p_level + 1, r_gen_code, p_actions, p_default_actions, p_assigning);
+				code += _dump_node_code(cfnode->blocks[3], p_level + 1, r_gen_code, p_actions, p_default_actions, p_assigning);
 
 			} else if (cfnode->flow_op == SL::FLOW_OP_RETURN) {
 				if (cfnode->expressions.size()) {

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -504,7 +504,9 @@ public:
 
 		enum BlockType {
 			BLOCK_TYPE_STANDART,
-			BLOCK_TYPE_FOR,
+			BLOCK_TYPE_FOR_INIT,
+			BLOCK_TYPE_FOR_CONDITION,
+			BLOCK_TYPE_FOR_EXPRESSION,
 			BLOCK_TYPE_SWITCH,
 			BLOCK_TYPE_CASE,
 			BLOCK_TYPE_DEFAULT,
@@ -526,6 +528,7 @@ public:
 		Map<StringName, Variable> variables;
 		List<Node *> statements;
 		bool single_statement = false;
+		bool use_comma_between_statements = false;
 
 		BlockNode() :
 				Node(TYPE_BLOCK) {}


### PR DESCRIPTION
This will allow the creation of more complex loop declarations like:
```
for(int i = 0, j = 0, k[] = {0, 1}; i < 10, j > -10; i++, j--) {
}
```
translated to 
```
for (int m_i=0,m_j=0,m_k[2]=int[2](0,1);(m_i<10),(m_j>-10);m_i++,m_j--) {
}
```
by the shader compiler.

GLSL also allows empty statements in the for loop, so the following statement will be valid after merging this PR:

```
for(;;;) {
}
```
The only restriction I've added is for the initialization block to accept only a variable declaration, eg not allowing to write:
```
int i = 0;
for(i /= 10;;){
}
```