### PR TITLE
EditorProperty: Fix range hint parsing with optional step

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1310,7 +1310,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/viewport_width",
 			PropertyInfo(Variant::INT, "display/window/size/viewport_width",
 					PROPERTY_HINT_RANGE,
-					"0,7680,or_greater")); // 8K resolution
+					"0,7680,1,or_greater")); // 8K resolution
 
 	GLOBAL_DEF_BASIC("display/window/size/viewport_height", 600);
 	ProjectSettings::get_singleton()->set_custom_property_info("display/window/size/viewport_height",
@@ -1333,7 +1333,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			PropertyInfo(Variant::INT,
 					"display/window/size/window_height_override",
 					PROPERTY_HINT_RANGE,
-					"0,4320,or_greater")); // 8K resolution
+					"0,4320,1,or_greater")); // 8K resolution
 
 	if (use_custom_res) {
 		if (!force_res) {


### PR DESCRIPTION
This could lead to have a step of 0 when parsing e.g. "1,10,is_greater".

More thorough fix for #57556. CC @Geometror

Could not find other instances where the step is missing while a string-based modifier is passed, with:
```
$ rg 'PROPERTY_HINT_RANGE, "[0-9 \-]+,[0-9 \-]+,[a-z]+'
$ rg '\t"[0-9 \-]+,[0-9 \-]+,[a-z]+'
```