### PR TITLE
[GDExtension] Fix registration of functions with enum or native pointer return type.

### DIFF
--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -123,9 +123,9 @@ def generate_version(argcount, const=False, returns=False):
             callargtext += ","
         callargtext += " m_ret& r_ret"
         s = s.replace("$CALLSIBEGIN", "Variant ret = ")
-        s = s.replace("$CALLSIRET", "r_ret = ret;")
+        s = s.replace("$CALLSIRET", "r_ret = VariantCaster<m_ret>::cast(ret);")
         s = s.replace("$CALLPTRRETPASS", "&ret")
-        s = s.replace("$CALLPTRRET", "r_ret = ret;")
+        s = s.replace("$CALLPTRRET", "r_ret = (m_ret)ret;")
     else:
         s = s.replace("$CALLSIBEGIN", "")
         s = s.replace("$CALLSIRET", "")

--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -53,22 +53,36 @@ struct GDNativePtr {
 	operator Variant() const { return uint64_t(data); }
 };
 
-#define GDVIRTUAL_NATIVE_PTR(m_type)                                  \
-	template <>                                                       \
-	struct GDNativeConstPtr<const m_type> {                           \
-		const m_type *data = nullptr;                                 \
-		GDNativeConstPtr(const m_type *p_assign) { data = p_assign; } \
-		static const char *get_name() { return "const " #m_type; }    \
-		operator const m_type *() const { return data; }              \
-		operator Variant() const { return uint64_t(data); }           \
-	};                                                                \
-	template <>                                                       \
-	struct GDNativePtr<m_type> {                                      \
-		m_type *data = nullptr;                                       \
-		GDNativePtr(m_type *p_assign) { data = p_assign; }            \
-		static const char *get_name() { return #m_type; }             \
-		operator m_type *() const { return data; }                    \
-		operator Variant() const { return uint64_t(data); }           \
+#define GDVIRTUAL_NATIVE_PTR(m_type)                                                              \
+	template <>                                                                                   \
+	struct GDNativeConstPtr<const m_type> {                                                       \
+		const m_type *data = nullptr;                                                             \
+		GDNativeConstPtr() {}                                                                     \
+		GDNativeConstPtr(const m_type *p_assign) { data = p_assign; }                             \
+		static const char *get_name() { return "const " #m_type; }                                \
+		operator const m_type *() const { return data; }                                          \
+		operator Variant() const { return uint64_t(data); }                                       \
+	};                                                                                            \
+	template <>                                                                                   \
+	struct VariantCaster<GDNativeConstPtr<const m_type>> {                                        \
+		static _FORCE_INLINE_ GDNativeConstPtr<const m_type> cast(const Variant &p_variant) {     \
+			return GDNativeConstPtr<const m_type>((const m_type *)p_variant.operator uint64_t()); \
+		}                                                                                         \
+	};                                                                                            \
+	template <>                                                                                   \
+	struct GDNativePtr<m_type> {                                                                  \
+		m_type *data = nullptr;                                                                   \
+		GDNativePtr() {}                                                                          \
+		GDNativePtr(m_type *p_assign) { data = p_assign; }                                        \
+		static const char *get_name() { return #m_type; }                                         \
+		operator m_type *() const { return data; }                                                \
+		operator Variant() const { return uint64_t(data); }                                       \
+	};                                                                                            \
+	template <>                                                                                   \
+	struct VariantCaster<GDNativePtr<m_type>> {                                                   \
+		static _FORCE_INLINE_ GDNativePtr<m_type> cast(const Variant &p_variant) {                \
+			return GDNativePtr<m_type>((m_type *)p_variant.operator uint64_t());                  \
+		}                                                                                         \
 	};
 
 template <class T>

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -202,7 +202,7 @@
 			</description>
 		</method>
 		<method name="_font_get_hinting" qualifiers="virtual const">
-			<return type="int" />
+			<return type="int" enum="TextServer.Hinting" />
 			<argument index="0" name="font_rid" type="RID" />
 			<description>
 				Returns the font hinting mode. Used by dynamic fonts only.
@@ -1028,7 +1028,7 @@
 			</description>
 		</method>
 		<method name="_shaped_text_get_direction" qualifiers="virtual const">
-			<return type="int" />
+			<return type="int" enum="TextServer.Direction" />
 			<argument index="0" name="shaped" type="RID" />
 			<description>
 				Returns direction of the text.
@@ -1051,9 +1051,8 @@
 			</description>
 		</method>
 		<method name="_shaped_text_get_ellipsis_glyphs" qualifiers="virtual const">
-			<return type="void" />
+			<return type="Glyph*" />
 			<argument index="0" name="shaped" type="RID" />
-			<argument index="1" name="r_glyphs" type="void*" />
 			<description>
 				Returns array of the glyphs in the ellipsis.
 			</description>
@@ -1073,9 +1072,8 @@
 			</description>
 		</method>
 		<method name="_shaped_text_get_glyphs" qualifiers="virtual const">
-			<return type="void" />
+			<return type="Glyph*" />
 			<argument index="0" name="shaped" type="RID" />
-			<argument index="1" name="r_glyphs" type="void*" />
 			<description>
 				Copies text glyphs in the visual order, into preallocated array of the size returned by [method _shaped_text_get_glyph_count].
 			</description>
@@ -1089,7 +1087,7 @@
 			</description>
 		</method>
 		<method name="_shaped_text_get_inferred_direction" qualifiers="virtual const">
-			<return type="int" />
+			<return type="int" enum="TextServer.Direction" />
 			<argument index="0" name="shaped" type="RID" />
 			<description>
 				Returns direction of the text, inferred by the BiDi algorithm.
@@ -1132,7 +1130,7 @@
 			</description>
 		</method>
 		<method name="_shaped_text_get_orientation" qualifiers="virtual const">
-			<return type="int" />
+			<return type="int" enum="TextServer.Orientation" />
 			<argument index="0" name="shaped" type="RID" />
 			<description>
 				Returns text orientation.
@@ -1337,9 +1335,8 @@
 			</description>
 		</method>
 		<method name="_shaped_text_sort_logical" qualifiers="virtual">
-			<return type="void" />
+			<return type="Glyph*" />
 			<argument index="0" name="shaped" type="RID" />
-			<argument index="1" name="r_glyphs" type="void*" />
 			<description>
 				Copies text glyphs in the logical order, into preallocated array of the size returned by [method _shaped_text_get_glyph_count].
 			</description>

--- a/servers/text/text_server_extension.cpp
+++ b/servers/text/text_server_extension.cpp
@@ -230,8 +230,8 @@ void TextServerExtension::_bind_methods() {
 
 	GDVIRTUAL_BIND(_shaped_text_is_ready, "shaped");
 
-	GDVIRTUAL_BIND(_shaped_text_get_glyphs, "shaped", "r_glyphs");
-	GDVIRTUAL_BIND(_shaped_text_sort_logical, "shaped", "r_glyphs");
+	GDVIRTUAL_BIND(_shaped_text_get_glyphs, "shaped");
+	GDVIRTUAL_BIND(_shaped_text_sort_logical, "shaped");
 	GDVIRTUAL_BIND(_shaped_text_get_glyph_count, "shaped");
 
 	GDVIRTUAL_BIND(_shaped_text_get_range, "shaped");
@@ -243,7 +243,7 @@ void TextServerExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_shaped_text_get_trim_pos, "shaped");
 	GDVIRTUAL_BIND(_shaped_text_get_ellipsis_pos, "shaped");
 	GDVIRTUAL_BIND(_shaped_text_get_ellipsis_glyph_count, "shaped");
-	GDVIRTUAL_BIND(_shaped_text_get_ellipsis_glyphs, "shaped", "r_glyphs");
+	GDVIRTUAL_BIND(_shaped_text_get_ellipsis_glyphs, "shaped");
 
 	GDVIRTUAL_BIND(_shaped_text_overrun_trim_to_width, "shaped", "width", "trim_flags");
 
@@ -505,7 +505,7 @@ void TextServerExtension::font_set_hinting(RID p_font_rid, TextServer::Hinting p
 }
 
 TextServer::Hinting TextServerExtension::font_get_hinting(RID p_font_rid) const {
-	int ret;
+	TextServer::Hinting ret;
 	if (GDVIRTUAL_CALL(_font_get_hinting, p_font_rid, ret)) {
 		return (TextServer::Hinting)ret;
 	}
@@ -955,7 +955,7 @@ void TextServerExtension::shaped_text_set_direction(RID p_shaped, TextServer::Di
 }
 
 TextServer::Direction TextServerExtension::shaped_text_get_direction(RID p_shaped) const {
-	int ret;
+	TextServer::Direction ret;
 	if (GDVIRTUAL_CALL(_shaped_text_get_direction, p_shaped, ret)) {
 		return (TextServer::Direction)ret;
 	}
@@ -963,7 +963,7 @@ TextServer::Direction TextServerExtension::shaped_text_get_direction(RID p_shape
 }
 
 TextServer::Direction TextServerExtension::shaped_text_get_inferred_direction(RID p_shaped) const {
-	int ret;
+	TextServer::Direction ret;
 	if (GDVIRTUAL_CALL(_shaped_text_get_inferred_direction, p_shaped, ret)) {
 		return (TextServer::Direction)ret;
 	}
@@ -975,7 +975,7 @@ void TextServerExtension::shaped_text_set_orientation(RID p_shaped, TextServer::
 }
 
 TextServer::Orientation TextServerExtension::shaped_text_get_orientation(RID p_shaped) const {
-	int ret;
+	TextServer::Orientation ret;
 	if (GDVIRTUAL_CALL(_shaped_text_get_orientation, p_shaped, ret)) {
 		return (TextServer::Orientation)ret;
 	}
@@ -1139,16 +1139,16 @@ bool TextServerExtension::shaped_text_is_ready(RID p_shaped) const {
 }
 
 const Glyph *TextServerExtension::shaped_text_get_glyphs(RID p_shaped) const {
-	const Glyph *ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_glyphs, p_shaped, &ret)) {
+	GDNativePtr<Glyph> ret;
+	if (GDVIRTUAL_CALL(_shaped_text_get_glyphs, p_shaped, ret)) {
 		return ret;
 	}
 	return nullptr;
 }
 
 const Glyph *TextServerExtension::shaped_text_sort_logical(RID p_shaped) {
-	const Glyph *ret;
-	if (GDVIRTUAL_CALL(_shaped_text_sort_logical, p_shaped, &ret)) {
+	GDNativePtr<Glyph> ret;
+	if (GDVIRTUAL_CALL(_shaped_text_sort_logical, p_shaped, ret)) {
 		return ret;
 	}
 	return nullptr;
@@ -1211,8 +1211,8 @@ int TextServerExtension::shaped_text_get_ellipsis_pos(RID p_shaped) const {
 }
 
 const Glyph *TextServerExtension::shaped_text_get_ellipsis_glyphs(RID p_shaped) const {
-	const Glyph *ret;
-	if (GDVIRTUAL_CALL(_shaped_text_get_ellipsis_glyphs, p_shaped, &ret)) {
+	GDNativePtr<Glyph> ret;
+	if (GDVIRTUAL_CALL(_shaped_text_get_ellipsis_glyphs, p_shaped, ret)) {
 		return ret;
 	}
 	return nullptr;

--- a/servers/text/text_server_extension.h
+++ b/servers/text/text_server_extension.h
@@ -132,7 +132,7 @@ public:
 	virtual void font_set_hinting(RID p_font_rid, Hinting p_hinting) override;
 	virtual Hinting font_get_hinting(RID p_font_rid) const override;
 	GDVIRTUAL2(_font_set_hinting, RID, Hinting);
-	GDVIRTUAL1RC(/*Hinting*/ int, _font_get_hinting, RID);
+	GDVIRTUAL1RC(Hinting, _font_get_hinting, RID);
 
 	virtual void font_set_variation_coordinates(RID p_font_rid, const Dictionary &p_variation_coordinates) override;
 	virtual Dictionary font_get_variation_coordinates(RID p_font_rid) const override;
@@ -317,8 +317,8 @@ public:
 	virtual Direction shaped_text_get_direction(RID p_shaped) const override;
 	virtual Direction shaped_text_get_inferred_direction(RID p_shaped) const override;
 	GDVIRTUAL2(_shaped_text_set_direction, RID, Direction);
-	GDVIRTUAL1RC(/*Direction*/ int, _shaped_text_get_direction, RID);
-	GDVIRTUAL1RC(/*Direction*/ int, _shaped_text_get_inferred_direction, RID);
+	GDVIRTUAL1RC(Direction, _shaped_text_get_direction, RID);
+	GDVIRTUAL1RC(Direction, _shaped_text_get_inferred_direction, RID);
 
 	virtual void shaped_text_set_bidi_override(RID p_shaped, const Array &p_override) override;
 	GDVIRTUAL2(_shaped_text_set_bidi_override, RID, const Array &);
@@ -331,7 +331,7 @@ public:
 	virtual void shaped_text_set_orientation(RID p_shaped, Orientation p_orientation = ORIENTATION_HORIZONTAL) override;
 	virtual Orientation shaped_text_get_orientation(RID p_shaped) const override;
 	GDVIRTUAL2(_shaped_text_set_orientation, RID, Orientation);
-	GDVIRTUAL1RC(/*Orientation*/ int, _shaped_text_get_orientation, RID);
+	GDVIRTUAL1RC(Orientation, _shaped_text_get_orientation, RID);
 
 	virtual void shaped_text_set_preserve_invalid(RID p_shaped, bool p_enabled) override;
 	virtual bool shaped_text_get_preserve_invalid(RID p_shaped) const override;
@@ -380,8 +380,8 @@ public:
 	virtual const Glyph *shaped_text_get_glyphs(RID p_shaped) const override;
 	virtual const Glyph *shaped_text_sort_logical(RID p_shaped) override;
 	virtual int shaped_text_get_glyph_count(RID p_shaped) const override;
-	GDVIRTUAL2C(_shaped_text_get_glyphs, RID, GDNativePtr<const Glyph *>);
-	GDVIRTUAL2(_shaped_text_sort_logical, RID, GDNativePtr<const Glyph *>);
+	GDVIRTUAL1RC(GDNativePtr<Glyph>, _shaped_text_get_glyphs, RID);
+	GDVIRTUAL1R(GDNativePtr<Glyph>, _shaped_text_sort_logical, RID);
 	GDVIRTUAL1RC(int, _shaped_text_get_glyph_count, RID);
 
 	virtual Vector2i shaped_text_get_range(RID p_shaped) const override;
@@ -400,7 +400,7 @@ public:
 	virtual int shaped_text_get_ellipsis_glyph_count(RID p_shaped) const override;
 	GDVIRTUAL1RC(int, _shaped_text_get_trim_pos, RID);
 	GDVIRTUAL1RC(int, _shaped_text_get_ellipsis_pos, RID);
-	GDVIRTUAL2C(_shaped_text_get_ellipsis_glyphs, RID, GDNativePtr<const Glyph *>);
+	GDVIRTUAL1RC(GDNativePtr<Glyph>, _shaped_text_get_ellipsis_glyphs, RID);
 	GDVIRTUAL1RC(int, _shaped_text_get_ellipsis_glyph_count, RID);
 
 	virtual void shaped_text_overrun_trim_to_width(RID p_shaped, float p_width, uint16_t p_trim_flags) override;

--- a/servers/text_server.h
+++ b/servers/text_server.h
@@ -557,7 +557,6 @@ VARIANT_ENUM_CAST(TextServer::SpacingType);
 VARIANT_ENUM_CAST(TextServer::FontStyle);
 
 GDVIRTUAL_NATIVE_PTR(Glyph);
-GDVIRTUAL_NATIVE_PTR(Glyph *);
 GDVIRTUAL_NATIVE_PTR(CaretInfo);
 
 #endif // TEXT_SERVER_H


### PR DESCRIPTION
Allows GDExtension virtual functions to have `enum` or `native pointer` return type. e.g.

```c++
	VARIANT_ENUM_CAST(TextServer::Hinting);
...
	GDVIRTUAL1RC(Hinting, font_get_hinting, RID);
```

```c++
	GDVIRTUAL_NATIVE_PTR(Glyph);
...
	GDVIRTUAL1RC(GDNativePtr<Glyph>, shaped_text_get_glyphs, RID);
```

And updates `TextServerExtension` to use it.

*Edit: Updated documentation.*