### PR TITLE
Add auto-wrap mode property to the RichTextLabel.

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -372,6 +372,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="RichTextLabel.AutowrapMode" default="3">
+			If set to something other than [constant AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. To see how each mode behaves, see [enum AutowrapMode].
+		</member>
 		<member name="bbcode_enabled" type="bool" setter="set_use_bbcode" getter="is_using_bbcode" default="false">
 			If [code]true[/code], the label uses BBCode formatting.
 		</member>
@@ -454,6 +457,18 @@
 		</signal>
 	</signals>
 	<constants>
+		<constant name="AUTOWRAP_OFF" value="0" enum="AutowrapMode">
+			Autowrap is disabled.
+		</constant>
+		<constant name="AUTOWRAP_ARBITRARY" value="1" enum="AutowrapMode">
+			Wraps the text inside the node's bounding rectangle by allowing to break lines at arbitrary positions, which is useful when very limited space is available.
+		</constant>
+		<constant name="AUTOWRAP_WORD" value="2" enum="AutowrapMode">
+			Wraps the text inside the node's bounding rectangle by soft-breaking between words.
+		</constant>
+		<constant name="AUTOWRAP_WORD_SMART" value="3" enum="AutowrapMode">
+			Behaves similarly to [constant AUTOWRAP_WORD], but force-breaks a word if that single word does not fit in one line.
+		</constant>
 		<constant name="LIST_NUMBERS" value="0" enum="ListType">
 			Each list item has a number marker.
 		</constant>

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -39,6 +39,13 @@ class RichTextLabel : public Control {
 	GDCLASS(RichTextLabel, Control);
 
 public:
+	enum AutowrapMode {
+		AUTOWRAP_OFF,
+		AUTOWRAP_ARBITRARY,
+		AUTOWRAP_WORD,
+		AUTOWRAP_WORD_SMART
+	};
+
 	enum ListType {
 		LIST_NUMBERS,
 		LIST_LETTERS,
@@ -346,6 +353,8 @@ private:
 
 	VScrollBar *vscroll = nullptr;
 
+	AutowrapMode autowrap_mode = AUTOWRAP_WORD_SMART;
+
 	bool scroll_visible = false;
 	bool scroll_follow = false;
 	bool scroll_following = false;
@@ -574,6 +583,9 @@ public:
 	void set_language(const String &p_language);
 	String get_language() const;
 
+	void set_autowrap_mode(AutowrapMode p_mode);
+	AutowrapMode get_autowrap_mode() const;
+
 	void set_structured_text_bidi_override(Control::StructuredTextParser p_parser);
 	Control::StructuredTextParser get_structured_text_bidi_override() const;
 
@@ -603,6 +615,7 @@ public:
 	~RichTextLabel();
 };
 
+VARIANT_ENUM_CAST(RichTextLabel::AutowrapMode);
 VARIANT_ENUM_CAST(RichTextLabel::ListType);
 VARIANT_ENUM_CAST(RichTextLabel::ItemType);
 VARIANT_ENUM_CAST(RichTextLabel::VisibleCharactersBehavior);


### PR DESCRIPTION
Exposes the same auto-wrap modes as `Label`, but default auto-wrap mode is set to `AUTOWRAP_WORD_SMART` to match 3.x behavior.

Fixes #57536

![Screenshot 2022-02-03 at 15 50 14](https://user-images.githubusercontent.com/7645683/152357027-209c588f-7b38-40cf-ae9c-b5eb8216ffb9.png)

