### PR TITLE
Rename the Vulkan `back_end` project setting to `backend`

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1896,9 +1896,9 @@
 		</member>
 		<member name="rendering/vulkan/descriptor_pools/max_descriptors_per_pool" type="int" setter="" getter="" default="64">
 		</member>
-		<member name="rendering/vulkan/rendering/back_end" type="int" setter="" getter="" default="0">
+		<member name="rendering/vulkan/rendering/backend" type="int" setter="" getter="" default="0">
 		</member>
-		<member name="rendering/vulkan/rendering/back_end.mobile" type="int" setter="" getter="" default="1">
+		<member name="rendering/vulkan/rendering/backend.mobile" type="int" setter="" getter="" default="1">
 		</member>
 		<member name="rendering/vulkan/staging_buffer/block_size_kb" type="int" setter="" getter="" default="256">
 		</member>

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -481,7 +481,7 @@ private:
 					ProjectSettings::CustomMap initial_settings;
 					// Be sure to change this code if/when renderers are changed.
 					int renderer_type = rasterizer_button_group->get_pressed_button()->get_meta(SNAME("driver_name"));
-					initial_settings["rendering/vulkan/rendering/back_end"] = renderer_type;
+					initial_settings["rendering/vulkan/rendering/backend"] = renderer_type;
 					if (renderer_type == 0) {
 						project_features.push_back("Vulkan Clustered");
 					} else if (renderer_type == 1) {

--- a/servers/rendering/renderer_compositor.h
+++ b/servers/rendering/renderer_compositor.h
@@ -67,7 +67,7 @@ private:
 
 protected:
 	static RendererCompositor *(*_create_func)();
-	bool back_end = false;
+	bool backend = false;
 
 public:
 	static RendererCompositor *create();
@@ -89,7 +89,7 @@ public:
 	virtual uint64_t get_frame_number() const = 0;
 	virtual double get_frame_delta_time() const = 0;
 
-	_FORCE_INLINE_ virtual bool is_low_end() const { return back_end; };
+	_FORCE_INLINE_ virtual bool is_low_end() const { return backend; };
 	virtual bool is_xr_enabled() const;
 
 	RendererCompositor();

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -281,12 +281,12 @@ RendererCompositorRD::RendererCompositorRD() {
 	storage = memnew(RendererStorageRD);
 	canvas = memnew(RendererCanvasRenderRD(storage));
 
-	back_end = (bool)(int)GLOBAL_GET("rendering/vulkan/rendering/back_end");
+	backend = (bool)(int)GLOBAL_GET("rendering/vulkan/rendering/backend");
 	uint32_t textures_per_stage = RD::get_singleton()->limit_get(RD::LIMIT_MAX_TEXTURES_PER_SHADER_STAGE);
 
-	if (back_end || textures_per_stage < 48) {
+	if (backend || textures_per_stage < 48) {
 		scene = memnew(RendererSceneRenderImplementation::RenderForwardMobile(storage));
-	} else { // back_end == false
+	} else { // backend == false
 		// default to our high end renderer
 		scene = memnew(RendererSceneRenderImplementation::RenderForwardClustered(storage));
 	}

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2841,11 +2841,11 @@ RenderingServer::RenderingServer() {
 
 	GLOBAL_DEF("rendering/2d/shadow_atlas/size", 2048);
 
-	GLOBAL_DEF_RST_BASIC("rendering/vulkan/rendering/back_end", 0);
-	GLOBAL_DEF_RST_BASIC("rendering/vulkan/rendering/back_end.mobile", 1);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/vulkan/rendering/back_end",
+	GLOBAL_DEF_RST_BASIC("rendering/vulkan/rendering/backend", 0);
+	GLOBAL_DEF_RST_BASIC("rendering/vulkan/rendering/backend.mobile", 1);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/vulkan/rendering/backend",
 			PropertyInfo(Variant::INT,
-					"rendering/vulkan/rendering/back_end",
+					"rendering/vulkan/rendering/backend",
 					PROPERTY_HINT_ENUM, "Forward Clustered (Supports Desktop Only),Forward Mobile (Supports Desktop and Mobile)"));
 	// Already defined in RenderingDeviceVulkan::initialize which runs before this code.
 	// We re-define them here just for doctool's sake. Make sure to keep default values in sync.


### PR DESCRIPTION
"Backend" is more commonly used compared to "Back-end" or "back end".

This doesn't break compatibility with `3.x` projects as `3.x` uses a different setting to control whether GLES3 or GLES2 is used.