### PR TITLE
Revert "[HTML5] Better engine config parsing."

### DIFF
--- a/platform/javascript/js/engine/config.js
+++ b/platform/javascript/js/engine/config.js
@@ -225,34 +225,35 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 	 */
 	Config.prototype.update = function (opts) {
 		const config = opts || {};
-		const me = this;
-		function parse(key) {
+		// NOTE: We must explicitly pass the default, accessing it via
+		// the key will fail due to closure compiler renames.
+		function parse(key, def) {
 			if (typeof (config[key]) === 'undefined') {
-				return me[key];
+				return def;
 			}
 			return config[key];
 		}
 		// Module config
-		this.unloadAfterInit = parse('unloadAfterInit');
-		this.onPrintError = parse('onPrintError');
-		this.onPrint = parse('onPrint');
-		this.onProgress = parse('onProgress');
+		this.unloadAfterInit = parse('unloadAfterInit', this.unloadAfterInit);
+		this.onPrintError = parse('onPrintError', this.onPrintError);
+		this.onPrint = parse('onPrint', this.onPrint);
+		this.onProgress = parse('onProgress', this.onProgress);
 
 		// Godot config
-		this.canvas = parse('canvas');
-		this.executable = parse('executable');
-		this.mainPack = parse('mainPack');
-		this.locale = parse('locale');
-		this.canvasResizePolicy = parse('canvasResizePolicy');
-		this.persistentPaths = parse('persistentPaths');
-		this.persistentDrops = parse('persistentDrops');
-		this.experimentalVK = parse('experimentalVK');
-		this.focusCanvas = parse('focusCanvas');
-		this.gdnativeLibs = parse('gdnativeLibs');
-		this.fileSizes = parse('fileSizes');
-		this.args = parse('args');
-		this.onExecute = parse('onExecute');
-		this.onExit = parse('onExit');
+		this.canvas = parse('canvas', this.canvas);
+		this.executable = parse('executable', this.executable);
+		this.mainPack = parse('mainPack', this.mainPack);
+		this.locale = parse('locale', this.locale);
+		this.canvasResizePolicy = parse('canvasResizePolicy', this.canvasResizePolicy);
+		this.persistentPaths = parse('persistentPaths', this.persistentPaths);
+		this.persistentDrops = parse('persistentDrops', this.persistentDrops);
+		this.experimentalVK = parse('experimentalVK', this.experimentalVK);
+		this.focusCanvas = parse('focusCanvas', this.focusCanvas);
+		this.gdnativeLibs = parse('gdnativeLibs', this.gdnativeLibs);
+		this.fileSizes = parse('fileSizes', this.fileSizes);
+		this.args = parse('args', this.args);
+		this.onExecute = parse('onExecute', this.onExecute);
+		this.onExit = parse('onExit', this.onExit);
 	};
 
 	/**


### PR DESCRIPTION
This reverts commit 2f509f1b12c33234a0d8f0e254c727fd92e57720.

Breaks closure compiler builds.
And adds a warning for future readers.

Fixes #57592 . Pretty sure it affects the exported version too (classical) too.