### PR TITLE
[3.x][iOS] Fix touch handling for overlay views

### DIFF
--- a/platform/iphone/godot_view.h
+++ b/platform/iphone/godot_view.h
@@ -65,4 +65,9 @@ class String;
 
 @property(nonatomic, assign) BOOL useCADisplayLink;
 
+- (void)godotTouchesBegan:(NSSet *)touches withEvent:(UIEvent *)event;
+- (void)godotTouchesMoved:(NSSet *)touches withEvent:(UIEvent *)event;
+- (void)godotTouchesEnded:(NSSet *)touches withEvent:(UIEvent *)event;
+- (void)godotTouchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event;
+
 @end

--- a/platform/iphone/godot_view.mm
+++ b/platform/iphone/godot_view.mm
@@ -331,7 +331,7 @@ static const int max_touches = 8;
 	}
 }
 
-- (void)touchesBegan:(NSSet *)touchesSet withEvent:(UIEvent *)event {
+- (void)godotTouchesBegan:(NSSet *)touchesSet withEvent:(UIEvent *)event {
 	NSArray *tlist = [event.allTouches allObjects];
 	for (unsigned int i = 0; i < [tlist count]; i++) {
 		if ([touchesSet containsObject:[tlist objectAtIndex:i]]) {
@@ -349,7 +349,7 @@ static const int max_touches = 8;
 	}
 }
 
-- (void)touchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
+- (void)godotTouchesMoved:(NSSet *)touches withEvent:(UIEvent *)event {
 	NSArray *tlist = [event.allTouches allObjects];
 	for (unsigned int i = 0; i < [tlist count]; i++) {
 		if ([touches containsObject:[tlist objectAtIndex:i]]) {
@@ -370,7 +370,7 @@ static const int max_touches = 8;
 	}
 }
 
-- (void)touchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
+- (void)godotTouchesEnded:(NSSet *)touches withEvent:(UIEvent *)event {
 	NSArray *tlist = [event.allTouches allObjects];
 	for (unsigned int i = 0; i < [tlist count]; i++) {
 		if ([touches containsObject:[tlist objectAtIndex:i]]) {
@@ -388,7 +388,7 @@ static const int max_touches = 8;
 	}
 }
 
-- (void)touchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
+- (void)godotTouchesCancelled:(NSSet *)touches withEvent:(UIEvent *)event {
 	NSArray *tlist = [event.allTouches allObjects];
 	for (unsigned int i = 0; i < [tlist count]; i++) {
 		if ([touches containsObject:[tlist objectAtIndex:i]]) {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/56417

`GodotView` class now uses custom method names so iOS doesn't trigger `UIView` touch input directly via `UIWindow` on creating or showing overlay `UIView`s.
`GodotViewGestureRecognizer` now also filters out any input that's not coming from `GodotView` class which also helps when there is an overlay `UIView` on game view.