### PR TITLE
Use an enum instead of an integer for shadow atlas size values

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1846,10 +1846,10 @@
 		<member name="rendering/shadows/shadow_atlas/quadrant_3_subdiv" type="int" setter="" getter="" default="4">
 			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
 		</member>
-		<member name="rendering/shadows/shadow_atlas/size" type="int" setter="" getter="" default="4096">
+		<member name="rendering/shadows/shadow_atlas/size" type="int" setter="" getter="" default="5">
 			Size for shadow atlas (used for OmniLights and SpotLights). See documentation.
 		</member>
-		<member name="rendering/shadows/shadow_atlas/size.mobile" type="int" setter="" getter="" default="2048">
+		<member name="rendering/shadows/shadow_atlas/size.mobile" type="int" setter="" getter="" default="4">
 			Lower-end override for [member rendering/shadows/shadow_atlas/size] on mobile devices, due to performance concerns or driver support.
 		</member>
 		<member name="rendering/shadows/shadows/soft_shadow_quality" type="int" setter="" getter="" default="3">

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3256,10 +3256,10 @@
 		<method name="viewport_set_shadow_atlas_size">
 			<return type="void" />
 			<argument index="0" name="viewport" type="RID" />
-			<argument index="1" name="size" type="int" />
+			<argument index="1" name="size" type="int" enum="RenderingServer.ShadowAtlasSize" />
 			<argument index="2" name="use_16_bits" type="bool" default="false" />
 			<description>
-				Sets the size of the shadow atlas's images (used for omni and spot lights). The value will be rounded up to the nearest power of 2.
+				Sets the size of the shadow atlas's images (used for omni and spot lights).
 			</description>
 		</method>
 		<method name="viewport_set_size">
@@ -3904,6 +3904,33 @@
 		</constant>
 		<constant name="FOG_VOLUME_SHAPE_WORLD" value="2" enum="FogVolumeShape">
 			[FogVolume] will have no shape, will cover the whole world and will not be culled.
+		</constant>
+		<constant name="SHADOW_ATLAS_SIZE_DISABLED" value="0" enum="ShadowAtlasSize">
+			[OmniLight3D], [SpotLight3D] [i]and[/i] [DirectionalLight3D] shadows won't be rendered. This is the fastest option (also results in the lowest memory usage). Speeds up [Viewport] initialization as no shadow atlas needs to be created.
+		</constant>
+		<constant name="SHADOW_ATLAS_SIZE_256" value="1" enum="ShadowAtlasSize">
+			[OmniLight3D] and [SpotLight3D] shadows will be rendered at extremely low resolution. This is the fastest option that still renders shadows.
+		</constant>
+		<constant name="SHADOW_ATLAS_SIZE_512" value="2" enum="ShadowAtlasSize">
+			[OmniLight3D] and [SpotLight3D] shadows will be rendered at very low resolution.
+		</constant>
+		<constant name="SHADOW_ATLAS_SIZE_1024" value="3" enum="ShadowAtlasSize">
+			[OmniLight3D] and [SpotLight3D] shadows will be rendered at low resolution.
+		</constant>
+		<constant name="SHADOW_ATLAS_SIZE_2048" value="4" enum="ShadowAtlasSize">
+			[OmniLight3D] and [SpotLight3D] shadows will be rendered at medium resolution.
+		</constant>
+		<constant name="SHADOW_ATLAS_SIZE_4096" value="5" enum="ShadowAtlasSize">
+			[OmniLight3D] and [SpotLight3D] shadows will be rendered at high resolution.
+		</constant>
+		<constant name="SHADOW_ATLAS_SIZE_8192" value="6" enum="ShadowAtlasSize">
+			[OmniLight3D] and [SpotLight3D] shadows will be rendered at very high resolution.
+		</constant>
+		<constant name="SHADOW_ATLAS_SIZE_16384" value="7" enum="ShadowAtlasSize">
+			[OmniLight3D] and [SpotLight3D] shadows will be rendered at extremely high resolution. This is the slowest option.
+		</constant>
+		<constant name="SHADOW_ATLAS_SIZE_MAX" value="8" enum="ShadowAtlasSize">
+			Represents the size of the [enum ShadowAtlasSize] enum.
 		</constant>
 		<constant name="VIEWPORT_SCALING_3D_MODE_BILINEAR" value="0" enum="ViewportScaling3DMode">
 			Enables bilinear scaling on 3D viewports. The amount of scaling can be set using [member Viewport.scaling_3d_scale]. Values less then [code]1.0[/code] will result in undersampling while values greater than [code]1.0[/code] will result in supersampling. A value of [code]1.0[/code] disables scaling.

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -271,9 +271,9 @@
 		<member name="shadow_atlas_quad_3" type="int" setter="set_shadow_atlas_quadrant_subdiv" getter="get_shadow_atlas_quadrant_subdiv" enum="Viewport.ShadowAtlasQuadrantSubdiv" default="4">
 			The subdivision amount of the fourth quadrant on the shadow atlas.
 		</member>
-		<member name="shadow_atlas_size" type="int" setter="set_shadow_atlas_size" getter="get_shadow_atlas_size" default="2048">
-			The shadow atlas' resolution (used for omni and spot lights). The value will be rounded up to the nearest power of 2.
-			[b]Note:[/b] If this is set to 0, shadows won't be visible.
+		<member name="shadow_atlas_size" type="int" setter="set_shadow_atlas_size" getter="get_shadow_atlas_size" enum="RenderingServer.ShadowAtlasSize" default="4">
+			The shadow atlas' resolution (used for omni and spot lights). When not using shadows within the [Viewport], set this to [constant RenderingServer.SHADOW_ATLAS_SIZE_DISABLED] to reduce memory usage and speed up initialization time.
+			[b]Note:[/b] If this is set to [constant RenderingServer.SHADOW_ATLAS_SIZE_DISABLED], shadows won't be visible within the [Viewport].
 		</member>
 		<member name="snap_2d_transforms_to_pixel" type="bool" setter="set_snap_2d_transforms_to_pixel" getter="is_snap_2d_transforms_to_pixel_enabled" default="false">
 		</member>

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -116,7 +116,7 @@ RID RasterizerSceneGLES3::shadow_atlas_create() {
 	return RID();
 }
 
-void RasterizerSceneGLES3::shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits) {
+void RasterizerSceneGLES3::shadow_atlas_set_size(RID p_atlas, RS::ShadowAtlasSize p_size, bool p_16_bits) {
 }
 
 void RasterizerSceneGLES3::shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -78,7 +78,7 @@ public:
 	/* SHADOW ATLAS API */
 
 	RID shadow_atlas_create() override;
-	void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = false) override;
+	void shadow_atlas_set_size(RID p_atlas, RS::ShadowAtlasSize p_size, bool p_16_bits = false) override;
 	void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) override;
 	bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version) override;
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2659,12 +2659,12 @@ void Node3DEditorPlugin::edited_scene_changed() {
 
 void Node3DEditorViewport::_project_settings_changed() {
 	//update shadow atlas if changed
-	int shadowmap_size = ProjectSettings::get_singleton()->get("rendering/shadows/shadow_atlas/size");
-	bool shadowmap_16_bits = ProjectSettings::get_singleton()->get("rendering/shadows/shadow_atlas/16_bits");
-	int atlas_q0 = ProjectSettings::get_singleton()->get("rendering/shadows/shadow_atlas/quadrant_0_subdiv");
-	int atlas_q1 = ProjectSettings::get_singleton()->get("rendering/shadows/shadow_atlas/quadrant_1_subdiv");
-	int atlas_q2 = ProjectSettings::get_singleton()->get("rendering/shadows/shadow_atlas/quadrant_2_subdiv");
-	int atlas_q3 = ProjectSettings::get_singleton()->get("rendering/shadows/shadow_atlas/quadrant_3_subdiv");
+	const RS::ShadowAtlasSize shadowmap_size = RS::ShadowAtlasSize(int(ProjectSettings::get_singleton()->get("rendering/shadows/shadow_atlas/size")));
+	const bool shadowmap_16_bits = ProjectSettings::get_singleton()->get("rendering/shadows/shadow_atlas/16_bits");
+	const int atlas_q0 = ProjectSettings::get_singleton()->get("rendering/shadows/shadow_atlas/quadrant_0_subdiv");
+	const int atlas_q1 = ProjectSettings::get_singleton()->get("rendering/shadows/shadow_atlas/quadrant_1_subdiv");
+	const int atlas_q2 = ProjectSettings::get_singleton()->get("rendering/shadows/shadow_atlas/quadrant_2_subdiv");
+	const int atlas_q3 = ProjectSettings::get_singleton()->get("rendering/shadows/shadow_atlas/quadrant_3_subdiv");
 
 	viewport->set_shadow_atlas_size(shadowmap_size);
 	viewport->set_shadow_atlas_16_bits(shadowmap_16_bits);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1367,9 +1367,9 @@ SceneTree::SceneTree() {
 	bool snap_2d_vertices = GLOBAL_DEF("rendering/2d/snap/snap_2d_vertices_to_pixel", false);
 	root->set_snap_2d_vertices_to_pixel(snap_2d_vertices);
 
-	int shadowmap_size = GLOBAL_DEF("rendering/shadows/shadow_atlas/size", 4096);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadow_atlas/size", PropertyInfo(Variant::INT, "rendering/shadows/shadow_atlas/size", PROPERTY_HINT_RANGE, "256,16384"));
-	GLOBAL_DEF("rendering/shadows/shadow_atlas/size.mobile", 2048);
+	RS::ShadowAtlasSize shadowmap_size = RS::ShadowAtlasSize(int(GLOBAL_DEF("rendering/shadows/shadow_atlas/size", RS::SHADOW_ATLAS_SIZE_4096)));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadow_atlas/size", PropertyInfo(Variant::INT, "rendering/shadows/shadow_atlas/size", PROPERTY_HINT_ENUM, String::utf8("Disabled (Fastest),256×256 (Faster), 512×512 (Faster), 1024×1024 (Faster), 2048×2048 (Fast), 4096×4096 (Average), 8192×8192 (Slow), 16384×16384 (Slowest)")));
+	GLOBAL_DEF("rendering/shadows/shadow_atlas/size.mobile", RS::SHADOW_ATLAS_SIZE_2048);
 	bool shadowmap_16_bits = GLOBAL_DEF("rendering/shadows/shadow_atlas/16_bits", true);
 	int atlas_q0 = GLOBAL_DEF("rendering/shadows/shadow_atlas/quadrant_0_subdiv", 2);
 	int atlas_q1 = GLOBAL_DEF("rendering/shadows/shadow_atlas/quadrant_1_subdiv", 2);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1054,12 +1054,12 @@ Ref<ViewportTexture> Viewport::get_texture() const {
 	return default_texture;
 }
 
-void Viewport::set_shadow_atlas_size(int p_size) {
+void Viewport::set_shadow_atlas_size(RS::ShadowAtlasSize p_size) {
 	shadow_atlas_size = p_size;
 	RS::get_singleton()->viewport_set_shadow_atlas_size(viewport, p_size, shadow_atlas_16_bits);
 }
 
-int Viewport::get_shadow_atlas_size() const {
+RS::ShadowAtlasSize Viewport::get_shadow_atlas_size() const {
 	return shadow_atlas_size;
 }
 
@@ -3716,7 +3716,7 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sdf_oversize", PROPERTY_HINT_ENUM, "100%,120%,150%,200%"), "set_sdf_oversize", "get_sdf_oversize");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "sdf_scale", PROPERTY_HINT_ENUM, "100%,50%,25%"), "set_sdf_scale", "get_sdf_scale");
 	ADD_GROUP("Shadow Atlas", "shadow_atlas_");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "shadow_atlas_size"), "set_shadow_atlas_size", "get_shadow_atlas_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "shadow_atlas_size", PROPERTY_HINT_ENUM, String::utf8("Disabled (Fastest),256×256 (Faster), 512×512 (Faster), 1024×1024 (Faster), 2048×2048 (Fast), 4096×4096 (Average), 8192×8192 (Slow), 16384×16384 (Slowest)")), "set_shadow_atlas_size", "get_shadow_atlas_size");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "shadow_atlas_16_bits"), "set_shadow_atlas_16_bits", "get_shadow_atlas_16_bits");
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "shadow_atlas_quad_0", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"), "set_shadow_atlas_quadrant_subdiv", "get_shadow_atlas_quadrant_subdiv", 0);
 	ADD_PROPERTYI(PropertyInfo(Variant::INT, "shadow_atlas_quad_1", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"), "set_shadow_atlas_quadrant_subdiv", "get_shadow_atlas_quadrant_subdiv", 1);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -285,7 +285,7 @@ private:
 
 	DebugDraw debug_draw = DEBUG_DRAW_DISABLED;
 
-	int shadow_atlas_size = 2048;
+	RS::ShadowAtlasSize shadow_atlas_size = RS::SHADOW_ATLAS_SIZE_2048;
 	bool shadow_atlas_16_bits = true;
 	ShadowAtlasQuadrantSubdiv shadow_atlas_quadrant_subdiv[4];
 
@@ -499,8 +499,8 @@ public:
 
 	Ref<ViewportTexture> get_texture() const;
 
-	void set_shadow_atlas_size(int p_size);
-	int get_shadow_atlas_size() const;
+	void set_shadow_atlas_size(RS::ShadowAtlasSize p_size);
+	RS::ShadowAtlasSize get_shadow_atlas_size() const;
 
 	void set_shadow_atlas_16_bits(bool p_16_bits);
 	bool get_shadow_atlas_16_bits() const;

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -72,7 +72,7 @@ public:
 	/* SHADOW ATLAS API */
 
 	RID shadow_atlas_create() override { return RID(); }
-	void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = false) override {}
+	void shadow_atlas_set_size(RID p_atlas, RS::ShadowAtlasSize p_size, bool p_16_bits = false) override {}
 	void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) override {}
 	bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version) override { return false; }
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -908,11 +908,10 @@ void RendererSceneRenderRD::_update_shadow_atlas(ShadowAtlas *shadow_atlas) {
 	}
 }
 
-void RendererSceneRenderRD::shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits) {
+void RendererSceneRenderRD::shadow_atlas_set_size(RID p_atlas, RS::ShadowAtlasSize p_size, bool p_16_bits) {
 	ShadowAtlas *shadow_atlas = shadow_atlas_owner.get_or_null(p_atlas);
 	ERR_FAIL_COND(!shadow_atlas);
-	ERR_FAIL_COND(p_size < 0);
-	p_size = next_power_of_2(p_size);
+	ERR_FAIL_INDEX(p_size, RS::SHADOW_ATLAS_SIZE_MAX);
 
 	if (p_size == shadow_atlas->size && p_16_bits == shadow_atlas->use_16_bits) {
 		return;
@@ -939,7 +938,36 @@ void RendererSceneRenderRD::shadow_atlas_set_size(RID p_atlas, int p_size, bool 
 	//clear owners
 	shadow_atlas->shadow_owners.clear();
 
-	shadow_atlas->size = p_size;
+	switch (p_size) {
+		case RS::SHADOW_ATLAS_SIZE_DISABLED:
+			shadow_atlas->size = 0;
+			break;
+		case RS::SHADOW_ATLAS_SIZE_256:
+			shadow_atlas->size = 256;
+			break;
+		case RS::SHADOW_ATLAS_SIZE_512:
+			shadow_atlas->size = 512;
+			break;
+		case RS::SHADOW_ATLAS_SIZE_1024:
+			shadow_atlas->size = 1024;
+			break;
+		case RS::SHADOW_ATLAS_SIZE_2048:
+			shadow_atlas->size = 2048;
+			break;
+		case RS::SHADOW_ATLAS_SIZE_4096:
+			shadow_atlas->size = 4096;
+			break;
+		case RS::SHADOW_ATLAS_SIZE_8192:
+			shadow_atlas->size = 8192;
+			break;
+		case RS::SHADOW_ATLAS_SIZE_16384:
+			shadow_atlas->size = 16384;
+			break;
+		case RS::SHADOW_ATLAS_SIZE_MAX:
+			ERR_PRINT("Invalid shadow atlas size (please report).");
+			break;
+	}
+
 	shadow_atlas->use_16_bits = p_16_bits;
 }
 
@@ -5418,7 +5446,7 @@ bool RendererSceneRenderRD::free(RID p_rid) {
 		light_instance_owner.free(p_rid);
 
 	} else if (shadow_atlas_owner.owns(p_rid)) {
-		shadow_atlas_set_size(p_rid, 0);
+		shadow_atlas_set_size(p_rid, RS::SHADOW_ATLAS_SIZE_DISABLED);
 		shadow_atlas_owner.free(p_rid);
 	} else if (fog_volume_instance_owner.owns(p_rid)) {
 		fog_volume_instance_owner.free(p_rid);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -981,7 +981,7 @@ public:
 	/* SHADOW ATLAS API */
 
 	virtual RID shadow_atlas_create() override;
-	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = false) override;
+	virtual void shadow_atlas_set_size(RID p_atlas, RS::ShadowAtlasSize p_size, bool p_16_bits = false) override;
 	virtual void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) override;
 	virtual bool shadow_atlas_update_light(RID p_atlas, RID p_light_instance, float p_coverage, uint64_t p_light_version) override;
 	_FORCE_INLINE_ bool shadow_atlas_owns_light_instance(RID p_atlas, RID p_light_intance) {

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -187,7 +187,7 @@ public:
 	virtual void directional_shadow_quality_set(RS::ShadowQuality p_quality) = 0;
 
 	virtual RID shadow_atlas_create() = 0;
-	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_use_16_bits = false) = 0;
+	virtual void shadow_atlas_set_size(RID p_atlas, RS::ShadowAtlasSize p_size, bool p_use_16_bits = false) = 0;
 	virtual void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) = 0;
 
 	/* Render Buffers */

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -358,7 +358,7 @@ void RendererSceneCull::scenario_initialize(RID p_rid) {
 	scenario->self = p_rid;
 
 	scenario->reflection_probe_shadow_atlas = scene_render->shadow_atlas_create();
-	scene_render->shadow_atlas_set_size(scenario->reflection_probe_shadow_atlas, 1024); //make enough shadows for close distance, don't bother with rest
+	scene_render->shadow_atlas_set_size(scenario->reflection_probe_shadow_atlas, RS::SHADOW_ATLAS_SIZE_1024); //make enough shadows for close distance, don't bother with rest
 	scene_render->shadow_atlas_set_quadrant_subdivision(scenario->reflection_probe_shadow_atlas, 0, 4);
 	scene_render->shadow_atlas_set_quadrant_subdivision(scenario->reflection_probe_shadow_atlas, 1, 4);
 	scene_render->shadow_atlas_set_quadrant_subdivision(scenario->reflection_probe_shadow_atlas, 2, 4);

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1165,7 +1165,7 @@ public:
 
 	/* Shadow Atlas */
 	PASS0R(RID, shadow_atlas_create)
-	PASS3(shadow_atlas_set_size, RID, int, bool)
+	PASS3(shadow_atlas_set_size, RID, RS::ShadowAtlasSize, bool)
 	PASS3(shadow_atlas_set_quadrant_subdivision, RID, int, int)
 
 	PASS1(set_debug_draw_mode, RS::ViewportDebugDraw)

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -80,7 +80,7 @@ public:
 	/* SHADOW ATLAS API */
 
 	virtual RID shadow_atlas_create() = 0;
-	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = false) = 0;
+	virtual void shadow_atlas_set_size(RID p_atlas, RS::ShadowAtlasSize p_size, bool p_16_bits = false) = 0;
 	virtual void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) = 0;
 	virtual bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version) = 0;
 

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -1018,7 +1018,7 @@ void RendererViewport::viewport_set_canvas_stacking(RID p_viewport, RID p_canvas
 	viewport->canvas_map[p_canvas].sublayer = p_sublayer;
 }
 
-void RendererViewport::viewport_set_shadow_atlas_size(RID p_viewport, int p_size, bool p_16_bits) {
+void RendererViewport::viewport_set_shadow_atlas_size(RID p_viewport, RS::ShadowAtlasSize p_size, bool p_16_bits) {
 	Viewport *viewport = viewport_owner.get_or_null(p_viewport);
 	ERR_FAIL_COND(!viewport);
 

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -90,7 +90,7 @@ public:
 		uint64_t time_gpu_end;
 
 		RID shadow_atlas;
-		int shadow_atlas_size;
+		RS::ShadowAtlasSize shadow_atlas_size;
 		bool shadow_atlas_16_bits = false;
 
 		bool sdf_active;
@@ -147,7 +147,7 @@ public:
 			transparent_bg = false;
 
 			viewport_to_screen = DisplayServer::INVALID_WINDOW_ID;
-			shadow_atlas_size = 0;
+			shadow_atlas_size = RS::SHADOW_ATLAS_SIZE_DISABLED;
 			measure_render_time = false;
 
 			debug_draw = RS::VIEWPORT_DEBUG_DRAW_DISABLED;
@@ -247,7 +247,7 @@ public:
 	void viewport_set_global_canvas_transform(RID p_viewport, const Transform2D &p_transform);
 	void viewport_set_canvas_stacking(RID p_viewport, RID p_canvas, int p_layer, int p_sublayer);
 
-	void viewport_set_shadow_atlas_size(RID p_viewport, int p_size, bool p_16_bits = false);
+	void viewport_set_shadow_atlas_size(RID p_viewport, RS::ShadowAtlasSize p_size, bool p_16_bits = false);
 	void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv);
 
 	void viewport_set_msaa(RID p_viewport, RS::ViewportMSAA p_msaa);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -565,7 +565,7 @@ public:
 
 	FUNC2(viewport_set_global_canvas_transform, RID, const Transform2D &)
 	FUNC4(viewport_set_canvas_stacking, RID, RID, int, int)
-	FUNC3(viewport_set_shadow_atlas_size, RID, int, bool)
+	FUNC3(viewport_set_shadow_atlas_size, RID, ShadowAtlasSize, bool)
 	FUNC3(viewport_set_sdf_oversize_and_scale, RID, ViewportSDFOversize, ViewportSDFScale)
 	FUNC3(viewport_set_shadow_atlas_quadrant_subdivision, RID, int, int)
 	FUNC2(viewport_set_msaa, RID, ViewportMSAA)

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2202,6 +2202,16 @@ void RenderingServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("viewport_set_sdf_oversize_and_scale", "viewport", "oversize", "scale"), &RenderingServer::viewport_set_sdf_oversize_and_scale);
 
+	BIND_ENUM_CONSTANT(SHADOW_ATLAS_SIZE_DISABLED);
+	BIND_ENUM_CONSTANT(SHADOW_ATLAS_SIZE_256);
+	BIND_ENUM_CONSTANT(SHADOW_ATLAS_SIZE_512);
+	BIND_ENUM_CONSTANT(SHADOW_ATLAS_SIZE_1024);
+	BIND_ENUM_CONSTANT(SHADOW_ATLAS_SIZE_2048);
+	BIND_ENUM_CONSTANT(SHADOW_ATLAS_SIZE_4096);
+	BIND_ENUM_CONSTANT(SHADOW_ATLAS_SIZE_8192);
+	BIND_ENUM_CONSTANT(SHADOW_ATLAS_SIZE_16384);
+	BIND_ENUM_CONSTANT(SHADOW_ATLAS_SIZE_MAX);
+
 	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_size", "viewport", "size", "use_16_bits"), &RenderingServer::viewport_set_shadow_atlas_size, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("viewport_set_shadow_atlas_quadrant_subdivision", "viewport", "quadrant", "subdivision"), &RenderingServer::viewport_set_shadow_atlas_quadrant_subdivision);
 	ClassDB::bind_method(D_METHOD("viewport_set_msaa", "viewport", "msaa"), &RenderingServer::viewport_set_msaa);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -847,7 +847,19 @@ public:
 
 	virtual void viewport_set_sdf_oversize_and_scale(RID p_viewport, ViewportSDFOversize p_oversize, ViewportSDFScale p_scale) = 0;
 
-	virtual void viewport_set_shadow_atlas_size(RID p_viewport, int p_size, bool p_16_bits = false) = 0;
+	enum ShadowAtlasSize {
+		SHADOW_ATLAS_SIZE_DISABLED,
+		SHADOW_ATLAS_SIZE_256,
+		SHADOW_ATLAS_SIZE_512,
+		SHADOW_ATLAS_SIZE_1024,
+		SHADOW_ATLAS_SIZE_2048,
+		SHADOW_ATLAS_SIZE_4096,
+		SHADOW_ATLAS_SIZE_8192,
+		SHADOW_ATLAS_SIZE_16384,
+		SHADOW_ATLAS_SIZE_MAX,
+	};
+
+	virtual void viewport_set_shadow_atlas_size(RID p_viewport, ShadowAtlasSize p_size, bool p_16_bits = false) = 0;
 	virtual void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv) = 0;
 
 	enum ViewportMSAA {
@@ -1610,6 +1622,7 @@ VARIANT_ENUM_CAST(RenderingServer::SubSurfaceScatteringQuality);
 VARIANT_ENUM_CAST(RenderingServer::DOFBlurQuality);
 VARIANT_ENUM_CAST(RenderingServer::DOFBokehShape);
 VARIANT_ENUM_CAST(RenderingServer::ShadowQuality);
+VARIANT_ENUM_CAST(RenderingServer::ShadowAtlasSize);
 VARIANT_ENUM_CAST(RenderingServer::InstanceType);
 VARIANT_ENUM_CAST(RenderingServer::InstanceFlags);
 VARIANT_ENUM_CAST(RenderingServer::ShadowCastingSetting);


### PR DESCRIPTION
By design, shadow atlases must use power-of-two sizes. Therefore, using an enum instead of an integer makes more sense and allows for providing better documentation.

This does not affect directional shadow size as there are plans to [allow non-power-of-two values as directional shadow sizes](https://github.com/godotengine/godot/pull/54041).

## Preview

https://user-images.githubusercontent.com/180032/152450116-d38ec041-cb65-46e2-9a43-e16d03852a3a.mp4
