### PR TITLE
Improve detection of gamepads on Linux

### DIFF
--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -333,8 +333,9 @@ void JoypadLinux::open_joypad(const char *p_path) {
 		}
 
 		// Check if the device supports basic gamepad events
-		if (!(test_bit(EV_KEY, evbit) && test_bit(EV_ABS, evbit) &&
-					test_bit(ABS_X, absbit) && test_bit(ABS_Y, absbit))) {
+		bool has_abs_left = (test_bit(ABS_X, absbit) && test_bit(ABS_Y, absbit));
+		bool has_abs_right = (test_bit(ABS_RX, absbit) && test_bit(ABS_RY, absbit));
+		if (!(test_bit(EV_KEY, evbit) && test_bit(EV_ABS, evbit) && (has_abs_left || has_abs_right))) {
 			close(fd);
 			return;
 		}


### PR DESCRIPTION
Some devices (Nintendo Switch Right Joy-Con) report only a right stick.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
