### PR TITLE
[3.x] Revert "Fix ViewportPreview upside-down in 3.x."

### DIFF
--- a/editor/plugins/viewport_preview_editor_plugin.cpp
+++ b/editor/plugins/viewport_preview_editor_plugin.cpp
@@ -38,8 +38,6 @@ void EditorInspectorPluginViewportPreview::parse_begin(Object *p_object) {
 	Viewport *viewport = Object::cast_to<Viewport>(p_object);
 
 	TexturePreview *viewport_preview = memnew(TexturePreview(viewport->get_texture(), false));
-	viewport_preview->get_texture_display()->set_flip_v(true); // flip as ViewportTexture in 3.x is upside-down.
-
 	// Otherwise `viewport_preview`'s `texture_display` doesn't update properly when `viewport`'s size changes.
 	viewport->connect("size_changed", viewport_preview->get_texture_display(), "update");
 	add_custom_control(viewport_preview);


### PR DESCRIPTION
This reverts commit 1426df66a8397f3f03aaa541399054f0487fc8a1.

ViewportPreview should show what the ViewportTexture renders and it _is_ upside-down by default. An extra V-flip makes the __Render Target > V Flip__ property confusing.

Fixes #57246