### PR TITLE
Fix Expression's parsing of positive exponent literals

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -373,6 +373,7 @@ Error Expression::_get_token(Token &r_token) {
 									is_float = true;
 								} else if (c == 'e') {
 									reading = READING_EXP;
+									is_float = true;
 								} else {
 									reading = READING_DONE;
 								}
@@ -409,9 +410,6 @@ Error Expression::_get_token(Token &r_token) {
 									exp_beg = true;
 
 								} else if ((c == '-' || c == '+') && !exp_sign && !exp_beg) {
-									if (c == '-') {
-										is_float = true;
-									}
 									exp_sign = true;
 
 								} else {

--- a/tests/core/math/test_expression.h
+++ b/tests/core/math/test_expression.h
@@ -137,7 +137,7 @@ TEST_CASE("[Expression] Scientific notation") {
 			expression.parse("2e5") == OK,
 			"The expression should parse successfully.");
 	CHECK_MESSAGE(
-			Math::is_equal_approx(double(expression.execute()), 25),
+			Math::is_equal_approx(double(expression.execute()), 2e5),
 			"The expression should return the expected result.");
 
 	CHECK_MESSAGE(


### PR DESCRIPTION
Currently `Expression` parses only negative exponent literals (eg. `3e-2`) as floats, and positive exponent literals (eg. `3e2` and `3e+2`) as integers. 
This results in negative exponent literals being parsed by `String` as expected (`3e-2` -> `0.03`), but positive exponent literals parsed by `String`'s `to_int()` method which simply disacards non numerical characters (`3e+2` -> `32`) giving an unexpected result

This PR makes `Expression` parse all exponent literals as floats so they are correctly parsed by `String`