### PR TITLE
Change default gravity for GPUParticles2D

### DIFF
--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -127,7 +127,7 @@ void GPUParticles2D::set_process_material(const Ref<Material> &p_material) {
 	if (pm.is_valid() && !pm->get_particle_flag(ParticlesMaterial::PARTICLE_FLAG_DISABLE_Z) && pm->get_gravity() == Vector3(0, -9.8, 0)) {
 		// Likely a new (3D) material, modify it to match 2D space
 		pm->set_particle_flag(ParticlesMaterial::PARTICLE_FLAG_DISABLE_Z, true);
-		pm->set_gravity(Vector3(0, 98, 0));
+		pm->set_gravity(Vector3(0, 980, 0));
 	}
 	RID material_rid;
 	if (process_material.is_valid()) {


### PR DESCRIPTION
Keep it consistent with CPUParticles2D and 2D physics.

![cpu_particles_2d](https://user-images.githubusercontent.com/28705694/152547241-d56b1aee-9efd-4895-83da-645cd6988453.gif)