### PR TITLE
Enable 16-bit shadow atlas by default in the RenderingServer methods

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -78,11 +78,11 @@ public:
 	/* SHADOW ATLAS API */
 
 	RID shadow_atlas_create() override;
-	void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = false) override;
+	void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = true) override;
 	void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) override;
 	bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version) override;
 
-	void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = false) override;
+	void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = true) override;
 	int get_directional_light_shadow_size(RID p_light_intance) override;
 	void set_directional_shadow_count(int p_count) override;
 

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -72,11 +72,11 @@ public:
 	/* SHADOW ATLAS API */
 
 	RID shadow_atlas_create() override { return RID(); }
-	void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = false) override {}
+	void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = true) override {}
 	void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) override {}
 	bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version) override { return false; }
 
-	void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = false) override {}
+	void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = true) override {}
 	int get_directional_light_shadow_size(RID p_light_intance) override { return 0; }
 	void set_directional_shadow_count(int p_count) override {}
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -293,7 +293,7 @@ private:
 		uint32_t smallest_subdiv = 0;
 
 		int size = 0;
-		bool use_16_bits = false;
+		bool use_16_bits = true;
 
 		RID depth;
 		RID fb; //for copying
@@ -333,7 +333,7 @@ private:
 
 		int light_count = 0;
 		int size = 0;
-		bool use_16_bits = false;
+		bool use_16_bits = true;
 		int current_light = 0;
 
 	} directional_shadow;
@@ -981,7 +981,7 @@ public:
 	/* SHADOW ATLAS API */
 
 	virtual RID shadow_atlas_create() override;
-	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = false) override;
+	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = true) override;
 	virtual void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) override;
 	virtual bool shadow_atlas_update_light(RID p_atlas, RID p_light_instance, float p_coverage, uint64_t p_light_version) override;
 	_FORCE_INLINE_ bool shadow_atlas_owns_light_instance(RID p_atlas, RID p_light_intance) {
@@ -1002,7 +1002,7 @@ public:
 		return Size2(atlas->size, atlas->size);
 	}
 
-	virtual void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = false) override;
+	virtual void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = true) override;
 	virtual int get_directional_light_shadow_size(RID p_light_intance) override;
 	virtual void set_directional_shadow_count(int p_count) override;
 

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -105,7 +105,7 @@ public:
 	virtual Variant instance_geometry_get_shader_parameter(RID p_instance, const StringName &p_parameter) const = 0;
 	virtual Variant instance_geometry_get_shader_parameter_default_value(RID p_instance, const StringName &p_parameter) const = 0;
 
-	virtual void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = false) = 0;
+	virtual void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = true) = 0;
 
 	/* SKY API */
 
@@ -187,7 +187,7 @@ public:
 	virtual void directional_shadow_quality_set(RS::ShadowQuality p_quality) = 0;
 
 	virtual RID shadow_atlas_create() = 0;
-	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_use_16_bits = false) = 0;
+	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_use_16_bits = true) = 0;
 	virtual void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) = 0;
 
 	/* Render Buffers */

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -80,11 +80,11 @@ public:
 	/* SHADOW ATLAS API */
 
 	virtual RID shadow_atlas_create() = 0;
-	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = false) = 0;
+	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_16_bits = true) = 0;
 	virtual void shadow_atlas_set_quadrant_subdivision(RID p_atlas, int p_quadrant, int p_subdivision) = 0;
 	virtual bool shadow_atlas_update_light(RID p_atlas, RID p_light_intance, float p_coverage, uint64_t p_light_version) = 0;
 
-	virtual void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = false) = 0;
+	virtual void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = true) = 0;
 	virtual int get_directional_light_shadow_size(RID p_light_intance) = 0;
 	virtual void set_directional_shadow_count(int p_count) = 0;
 

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -91,7 +91,7 @@ public:
 
 		RID shadow_atlas;
 		int shadow_atlas_size;
-		bool shadow_atlas_16_bits = false;
+		bool shadow_atlas_16_bits = true;
 
 		bool sdf_active;
 
@@ -247,7 +247,7 @@ public:
 	void viewport_set_global_canvas_transform(RID p_viewport, const Transform2D &p_transform);
 	void viewport_set_canvas_stacking(RID p_viewport, RID p_canvas, int p_layer, int p_sublayer);
 
-	void viewport_set_shadow_atlas_size(RID p_viewport, int p_size, bool p_16_bits = false);
+	void viewport_set_shadow_atlas_size(RID p_viewport, int p_size, bool p_16_bits = true);
 	void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv);
 
 	void viewport_set_msaa(RID p_viewport, RS::ViewportMSAA p_msaa);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -473,7 +473,7 @@ public:
 	virtual void light_directional_set_blend_splits(RID p_light, bool p_enable) = 0;
 	virtual void light_directional_set_sky_only(RID p_light, bool p_sky_only) = 0;
 
-	virtual void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = false) = 0;
+	virtual void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = true) = 0;
 
 	enum ShadowQuality {
 		SHADOW_QUALITY_HARD,
@@ -847,7 +847,7 @@ public:
 
 	virtual void viewport_set_sdf_oversize_and_scale(RID p_viewport, ViewportSDFOversize p_oversize, ViewportSDFScale p_scale) = 0;
 
-	virtual void viewport_set_shadow_atlas_size(RID p_viewport, int p_size, bool p_16_bits = false) = 0;
+	virtual void viewport_set_shadow_atlas_size(RID p_viewport, int p_size, bool p_16_bits = true) = 0;
 	virtual void viewport_set_shadow_atlas_quadrant_subdivision(RID p_viewport, int p_quadrant, int p_subdiv) = 0;
 
 	enum ViewportMSAA {


### PR DESCRIPTION
16-bit shadow atlases are already the default in the project settings, but low-level methods used 24-bit shadows by default.

This makes low-level methods more consistent with the default project settings to avoid accidental performance issues when users change the shadow size at run-time.

**Note:** This PR doesn't break compatibility with `3.x` as it doesn't have 16-bit shadows (only 24-bit).