### PR TITLE
Fix OptionButton in create script dialog doesn't select the correct template

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -763,10 +763,10 @@ void ScriptCreateDialog::_update_dialog() {
 }
 
 ScriptLanguage::ScriptTemplate ScriptCreateDialog::_get_current_template() const {
-	int selected_id = template_menu->get_selected_id();
+	int selected_index = template_menu->get_selected();
 	for (const ScriptLanguage::ScriptTemplate &t : template_list) {
 		if (is_using_templates) {
-			if (t.id == selected_id) {
+			if (t.id == selected_index) {
 				return t;
 			}
 		} else {


### PR DESCRIPTION
Fixes #57634

### Issue description

Since 3b146c5eaa06d9f6827c651802b9fb2a9a1e013d has been merged, option button in script create dialog didn't select the correct template.

### Identified origin : 

Changes in OptionButton code has revealed a confusion between item index and ID in Create Script Dialog OptionButton management.

### Fix proposal

Use index instead of ID (as it was meant to be)

### Before

![bug](https://user-images.githubusercontent.com/3649998/152581433-07106d0c-88c4-4110-93b6-04df195a4682.jpg)

### After

![fixed](https://user-images.githubusercontent.com/3649998/152581449-b0238fc1-fc9f-44bc-b9a2-3d45c3bda21c.jpg)



