### PR TITLE
[Net] Move RPC, Node cache out of MultiplayerAPI.

### DIFF
--- a/core/multiplayer/multiplayer_api.cpp
+++ b/core/multiplayer/multiplayer_api.cpp
@@ -32,8 +32,6 @@
 
 #include "core/debugger/engine_debugger.h"
 #include "core/io/marshalls.h"
-#include "core/multiplayer/rpc_manager.h"
-#include "scene/main/node.h"
 
 #include <stdint.h>
 
@@ -42,6 +40,8 @@
 #endif
 
 MultiplayerReplicationInterface *(*MultiplayerAPI::create_default_replication_interface)(MultiplayerAPI *p_multiplayer) = nullptr;
+MultiplayerRPCInterface *(*MultiplayerAPI::create_default_rpc_interface)(MultiplayerAPI *p_multiplayer) = nullptr;
+MultiplayerCacheInterface *(*MultiplayerAPI::create_default_cache_interface)(MultiplayerAPI *p_multiplayer) = nullptr;
 
 #ifdef DEBUG_ENABLED
 void MultiplayerAPI::profile_bandwidth(const String &p_inout, int p_size) {
@@ -91,18 +91,17 @@ void MultiplayerAPI::poll() {
 
 void MultiplayerAPI::clear() {
 	connected_peers.clear();
-	path_get_cache.clear();
-	path_send_cache.clear();
 	packet_cache.clear();
-	last_send_cache_id = 1;
+	cache->clear();
 }
 
-void MultiplayerAPI::set_root_node(Node *p_node) {
-	root_node = p_node;
+void MultiplayerAPI::set_root_path(const NodePath &p_path) {
+	ERR_FAIL_COND_MSG(!p_path.is_absolute() && !p_path.is_empty(), "MultiplayerAPI root path must be absolute.");
+	root_path = p_path;
 }
 
-Node *MultiplayerAPI::get_root_node() {
-	return root_node;
+NodePath MultiplayerAPI::get_root_path() const {
+	return root_path;
 }
 
 void MultiplayerAPI::set_multiplayer_peer(const Ref<MultiplayerPeer> &p_peer) {
@@ -139,7 +138,7 @@ Ref<MultiplayerPeer> MultiplayerAPI::get_multiplayer_peer() const {
 }
 
 void MultiplayerAPI::_process_packet(int p_from, const uint8_t *p_packet, int p_packet_len) {
-	ERR_FAIL_COND_MSG(root_node == nullptr, "Multiplayer root node was not initialized. If you are using custom multiplayer, remember to set the root node via MultiplayerAPI.set_root_node before using it.");
+	ERR_FAIL_COND_MSG(root_path.is_empty(), "Multiplayer root was not initialized. If you are using custom multiplayer, remember to set the root path via MultiplayerAPI.set_root_path before using it.");
 	ERR_FAIL_COND_MSG(p_packet_len < 1, "Invalid packet received. Size too small.");
 
 #ifdef DEBUG_ENABLED
@@ -151,15 +150,15 @@ void MultiplayerAPI::_process_packet(int p_from, const uint8_t *p_packet, int p_
 
 	switch (packet_type) {
 		case NETWORK_COMMAND_SIMPLIFY_PATH: {
-			_process_simplify_path(p_from, p_packet, p_packet_len);
+			cache->process_simplify_path(p_from, p_packet, p_packet_len);
 		} break;
 
 		case NETWORK_COMMAND_CONFIRM_PATH: {
-			_process_confirm_path(p_from, p_packet, p_packet_len);
+			cache->process_confirm_path(p_from, p_packet, p_packet_len);
 		} break;
 
 		case NETWORK_COMMAND_REMOTE_CALL: {
-			rpc_manager->process_rpc(p_from, p_packet, p_packet_len);
+			rpc->process_rpc(p_from, p_packet, p_packet_len);
 		} break;
 
 		case NETWORK_COMMAND_RAW: {
@@ -175,140 +174,6 @@ void MultiplayerAPI::_process_packet(int p_from, const uint8_t *p_packet, int p_
 			replicator->on_sync_receive(p_from, p_packet, p_packet_len);
 		} break;
 	}
-}
-
-void MultiplayerAPI::_process_simplify_path(int p_from, const uint8_t *p_packet, int p_packet_len) {
-	ERR_FAIL_COND_MSG(p_packet_len < 38, "Invalid packet received. Size too small.");
-	int ofs = 1;
-
-	String methods_md5;
-	methods_md5.parse_utf8((const char *)(p_packet + ofs), 32);
-	ofs += 33;
-
-	int id = decode_uint32(&p_packet[ofs]);
-	ofs += 4;
-
-	String paths;
-	paths.parse_utf8((const char *)(p_packet + ofs), p_packet_len - ofs);
-
-	NodePath path = paths;
-
-	if (!path_get_cache.has(p_from)) {
-		path_get_cache[p_from] = PathGetCache();
-	}
-
-	Node *node = root_node->get_node(path);
-	ERR_FAIL_COND(node == nullptr);
-	const bool valid_rpc_checksum = rpc_manager->get_rpc_md5(node) == methods_md5;
-	if (valid_rpc_checksum == false) {
-		ERR_PRINT("The rpc node checksum failed. Make sure to have the same methods on both nodes. Node path: " + path);
-	}
-
-	PathGetCache::NodeInfo ni;
-	ni.path = path;
-
-	path_get_cache[p_from].nodes[id] = ni;
-
-	// Encode path to send ack.
-	CharString pname = String(path).utf8();
-	int len = encode_cstring(pname.get_data(), nullptr);
-
-	Vector<uint8_t> packet;
-
-	packet.resize(1 + 1 + len);
-	packet.write[0] = NETWORK_COMMAND_CONFIRM_PATH;
-	packet.write[1] = valid_rpc_checksum;
-	encode_cstring(pname.get_data(), &packet.write[2]);
-
-	multiplayer_peer->set_transfer_channel(0);
-	multiplayer_peer->set_transfer_mode(Multiplayer::TRANSFER_MODE_RELIABLE);
-	multiplayer_peer->set_target_peer(p_from);
-	multiplayer_peer->put_packet(packet.ptr(), packet.size());
-}
-
-void MultiplayerAPI::_process_confirm_path(int p_from, const uint8_t *p_packet, int p_packet_len) {
-	ERR_FAIL_COND_MSG(p_packet_len < 3, "Invalid packet received. Size too small.");
-
-	const bool valid_rpc_checksum = p_packet[1];
-
-	String paths;
-	paths.parse_utf8((const char *)&p_packet[2], p_packet_len - 2);
-
-	NodePath path = paths;
-
-	if (valid_rpc_checksum == false) {
-		ERR_PRINT("The rpc node checksum failed. Make sure to have the same methods on both nodes. Node path: " + path);
-	}
-
-	PathSentCache *psc = path_send_cache.getptr(path);
-	ERR_FAIL_COND_MSG(!psc, "Invalid packet received. Tries to confirm a path which was not found in cache.");
-
-	Map<int, bool>::Element *E = psc->confirmed_peers.find(p_from);
-	ERR_FAIL_COND_MSG(!E, "Invalid packet received. Source peer was not found in cache for the given path.");
-	E->get() = true;
-}
-
-bool MultiplayerAPI::_send_confirm_path(Node *p_node, NodePath p_path, PathSentCache *psc, int p_target) {
-	bool has_all_peers = true;
-	List<int> peers_to_add; // If one is missing, take note to add it.
-
-	for (Set<int>::Element *E = connected_peers.front(); E; E = E->next()) {
-		if (p_target < 0 && E->get() == -p_target) {
-			continue; // Continue, excluded.
-		}
-
-		if (p_target > 0 && E->get() != p_target) {
-			continue; // Continue, not for this peer.
-		}
-
-		Map<int, bool>::Element *F = psc->confirmed_peers.find(E->get());
-
-		if (!F || !F->get()) {
-			// Path was not cached, or was cached but is unconfirmed.
-			if (!F) {
-				// Not cached at all, take note.
-				peers_to_add.push_back(E->get());
-			}
-
-			has_all_peers = false;
-		}
-	}
-
-	if (peers_to_add.size() > 0) {
-		// Those that need to be added, send a message for this.
-
-		// Encode function name.
-		const CharString path = String(p_path).utf8();
-		const int path_len = encode_cstring(path.get_data(), nullptr);
-
-		// Extract MD5 from rpc methods list.
-		const String methods_md5 = rpc_manager->get_rpc_md5(p_node);
-		const int methods_md5_len = 33; // 32 + 1 for the `0` that is added by the encoder.
-
-		Vector<uint8_t> packet;
-		packet.resize(1 + 4 + path_len + methods_md5_len);
-		int ofs = 0;
-
-		packet.write[ofs] = NETWORK_COMMAND_SIMPLIFY_PATH;
-		ofs += 1;
-
-		ofs += encode_cstring(methods_md5.utf8().get_data(), &packet.write[ofs]);
-
-		ofs += encode_uint32(psc->id, &packet.write[ofs]);
-
-		ofs += encode_cstring(path.get_data(), &packet.write[ofs]);
-
-		for (int &E : peers_to_add) {
-			multiplayer_peer->set_target_peer(E); // To all of you.
-			multiplayer_peer->set_transfer_channel(0);
-			multiplayer_peer->set_transfer_mode(Multiplayer::TRANSFER_MODE_RELIABLE);
-			multiplayer_peer->put_packet(packet.ptr(), packet.size());
-
-			psc->confirmed_peers.insert(E, false); // Insert into confirmed, but as false since it was not confirmed.
-		}
-	}
-
-	return has_all_peers;
 }
 
 // The variant is compressed and encoded; The first byte contains all the meta
@@ -537,23 +402,14 @@ Error MultiplayerAPI::decode_and_decompress_variants(Vector<Variant> &r_variants
 
 void MultiplayerAPI::_add_peer(int p_id) {
 	connected_peers.insert(p_id);
-	path_get_cache.insert(p_id, PathGetCache());
+	cache->on_peer_change(p_id, true);
 	replicator->on_peer_change(p_id, true);
 	emit_signal(SNAME("peer_connected"), p_id);
 }
 
 void MultiplayerAPI::_del_peer(int p_id) {
 	replicator->on_peer_change(p_id, false);
-	// Cleanup get cache.
-	path_get_cache.erase(p_id);
-	// Cleanup sent cache.
-	// Some refactoring is needed to make this faster and do paths GC.
-	List<NodePath> keys;
-	path_send_cache.get_key_list(&keys);
-	for (const NodePath &E : keys) {
-		PathSentCache *psc = path_send_cache.getptr(E);
-		psc->confirmed_peers.erase(p_id);
-	}
+	cache->on_peer_change(p_id, false);
 	connected_peers.erase(p_id);
 	emit_signal(SNAME("peer_disconnected"), p_id);
 }
@@ -605,41 +461,15 @@ void MultiplayerAPI::_process_raw(int p_from, const uint8_t *p_packet, int p_pac
 }
 
 bool MultiplayerAPI::is_cache_confirmed(NodePath p_path, int p_peer) {
-	const PathSentCache *psc = path_send_cache.getptr(p_path);
-	ERR_FAIL_COND_V(!psc, false);
-	const Map<int, bool>::Element *F = psc->confirmed_peers.find(p_peer);
-	ERR_FAIL_COND_V(!F, false); // Should never happen.
-	return F->get();
+	return cache->is_cache_confirmed(p_path, p_peer);
 }
 
-bool MultiplayerAPI::send_confirm_path(Node *p_node, NodePath p_path, int p_peer_id, int &r_id) {
-	// See if the path is cached.
-	PathSentCache *psc = path_send_cache.getptr(p_path);
-	if (!psc) {
-		// Path is not cached, create.
-		path_send_cache[p_path] = PathSentCache();
-		psc = path_send_cache.getptr(p_path);
-		psc->id = last_send_cache_id++;
-	}
-	r_id = psc->id;
-
-	// See if all peers have cached path (if so, call can be fast).
-	return _send_confirm_path(p_node, p_path, psc, p_peer_id);
+bool MultiplayerAPI::send_object_cache(Object *p_obj, NodePath p_path, int p_peer_id, int &r_id) {
+	return cache->send_object_cache(p_obj, p_path, p_peer_id, r_id);
 }
 
-Node *MultiplayerAPI::get_cached_node(int p_from, uint32_t p_node_id) {
-	Map<int, PathGetCache>::Element *E = path_get_cache.find(p_from);
-	ERR_FAIL_COND_V_MSG(!E, nullptr, vformat("No cache found for peer %d.", p_from));
-
-	Map<int, PathGetCache::NodeInfo>::Element *F = E->get().nodes.find(p_node_id);
-	ERR_FAIL_COND_V_MSG(!F, nullptr, vformat("ID %d not found in cache of peer %d.", p_node_id, p_from));
-
-	PathGetCache::NodeInfo *ni = &F->get();
-	Node *node = root_node->get_node(ni->path);
-	if (!node) {
-		ERR_PRINT("Failed to get cached path: " + String(ni->path) + ".");
-	}
-	return node;
+Object *MultiplayerAPI::get_cached_object(int p_from, uint32_t p_cache_id) {
+	return cache->get_cached_object(p_from, p_cache_id);
 }
 
 int MultiplayerAPI::get_unique_id() const {
@@ -680,8 +510,12 @@ bool MultiplayerAPI::is_object_decoding_allowed() const {
 	return allow_object_decoding;
 }
 
-void MultiplayerAPI::rpcp(Node *p_node, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount) {
-	rpc_manager->rpcp(p_node, p_peer_id, p_method, p_arg, p_argcount);
+String MultiplayerAPI::get_rpc_md5(const Object *p_obj) const {
+	return rpc->get_rpc_md5(p_obj);
+}
+
+void MultiplayerAPI::rpcp(Object *p_obj, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount) {
+	rpc->rpcp(p_obj, p_peer_id, p_method, p_arg, p_argcount);
 }
 
 Error MultiplayerAPI::spawn(Object *p_object, Variant p_config) {
@@ -701,8 +535,8 @@ Error MultiplayerAPI::replication_stop(Object *p_object, Variant p_config) {
 }
 
 void MultiplayerAPI::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_root_node", "node"), &MultiplayerAPI::set_root_node);
-	ClassDB::bind_method(D_METHOD("get_root_node"), &MultiplayerAPI::get_root_node);
+	ClassDB::bind_method(D_METHOD("set_root_path", "path"), &MultiplayerAPI::set_root_path);
+	ClassDB::bind_method(D_METHOD("get_root_path"), &MultiplayerAPI::get_root_path);
 	ClassDB::bind_method(D_METHOD("send_bytes", "bytes", "id", "mode", "channel"), &MultiplayerAPI::send_bytes, DEFVAL(MultiplayerPeer::TARGET_PEER_BROADCAST), DEFVAL(Multiplayer::TRANSFER_MODE_RELIABLE), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("has_multiplayer_peer"), &MultiplayerAPI::has_multiplayer_peer);
 	ClassDB::bind_method(D_METHOD("get_multiplayer_peer"), &MultiplayerAPI::get_multiplayer_peer);
@@ -722,7 +556,7 @@ void MultiplayerAPI::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_object_decoding"), "set_allow_object_decoding", "is_object_decoding_allowed");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "refuse_new_connections"), "set_refuse_new_connections", "is_refusing_new_connections");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "multiplayer_peer", PROPERTY_HINT_RESOURCE_TYPE, "MultiplayerPeer", PROPERTY_USAGE_NONE), "set_multiplayer_peer", "get_multiplayer_peer");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "root_node", PROPERTY_HINT_RESOURCE_TYPE, "Node", PROPERTY_USAGE_NONE), "set_root_node", "get_root_node");
+	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "root_path"), "set_root_path", "get_root_path");
 	ADD_PROPERTY_DEFAULT("refuse_new_connections", false);
 
 	ADD_SIGNAL(MethodInfo("peer_connected", PropertyInfo(Variant::INT, "id")));
@@ -739,11 +573,18 @@ MultiplayerAPI::MultiplayerAPI() {
 	} else {
 		replicator.instantiate();
 	}
-	rpc_manager = memnew(RPCManager(this));
-	clear();
+	if (create_default_rpc_interface) {
+		rpc = Ref<MultiplayerRPCInterface>(create_default_rpc_interface(this));
+	} else {
+		rpc.instantiate();
+	}
+	if (create_default_cache_interface) {
+		cache = Ref<MultiplayerCacheInterface>(create_default_cache_interface(this));
+	} else {
+		cache.instantiate();
+	}
 }
 
 MultiplayerAPI::~MultiplayerAPI() {
 	clear();
-	memdelete(rpc_manager);
 }

--- a/core/multiplayer/multiplayer_api.h
+++ b/core/multiplayer/multiplayer_api.h
@@ -55,7 +55,34 @@ public:
 	MultiplayerReplicationInterface() {}
 };
 
-class RPCManager;
+class MultiplayerRPCInterface : public RefCounted {
+	GDCLASS(MultiplayerRPCInterface, RefCounted);
+
+public:
+	// Called by Node.rpc
+	virtual void rpcp(Object *p_obj, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount) {}
+	virtual void process_rpc(int p_from, const uint8_t *p_packet, int p_packet_len) {}
+	virtual String get_rpc_md5(const Object *p_obj) const { return String(); }
+
+	MultiplayerRPCInterface() {}
+};
+
+class MultiplayerCacheInterface : public RefCounted {
+	GDCLASS(MultiplayerCacheInterface, RefCounted);
+
+public:
+	virtual void clear() {}
+	virtual void on_peer_change(int p_id, bool p_connected) {}
+	virtual void process_simplify_path(int p_from, const uint8_t *p_packet, int p_packet_len) {}
+	virtual void process_confirm_path(int p_from, const uint8_t *p_packet, int p_packet_len) {}
+
+	// Returns true if all peers have cached path.
+	virtual bool send_object_cache(Object *p_obj, NodePath p_path, int p_target, int &p_id) { return false; }
+	virtual Object *get_cached_object(int p_from, uint32_t p_cache_id) { return nullptr; }
+	virtual bool is_cache_confirmed(NodePath p_path, int p_peer) { return false; }
+
+	MultiplayerCacheInterface() {}
+};
 
 class MultiplayerAPI : public RefCounted {
 	GDCLASS(MultiplayerAPI, RefCounted);
@@ -85,49 +112,30 @@ public:
 	};
 
 private:
-	//path sent caches
-	struct PathSentCache {
-		Map<int, bool> confirmed_peers;
-		int id;
-	};
-
-	//path get caches
-	struct PathGetCache {
-		struct NodeInfo {
-			NodePath path;
-			ObjectID instance;
-		};
-
-		Map<int, NodeInfo> nodes;
-	};
-
 	Ref<MultiplayerPeer> multiplayer_peer;
 	Set<int> connected_peers;
 	int remote_sender_id = 0;
 	int remote_sender_override = 0;
 
-	HashMap<NodePath, PathSentCache> path_send_cache;
-	Map<int, PathGetCache> path_get_cache;
-	int last_send_cache_id;
 	Vector<uint8_t> packet_cache;
 
-	Node *root_node = nullptr;
+	NodePath root_path;
 	bool allow_object_decoding = false;
 
+	Ref<MultiplayerCacheInterface> cache;
 	Ref<MultiplayerReplicationInterface> replicator;
-	RPCManager *rpc_manager = nullptr;
+	Ref<MultiplayerRPCInterface> rpc;
 
 protected:
 	static void _bind_methods();
 
-	bool _send_confirm_path(Node *p_node, NodePath p_path, PathSentCache *psc, int p_target);
 	void _process_packet(int p_from, const uint8_t *p_packet, int p_packet_len);
-	void _process_simplify_path(int p_from, const uint8_t *p_packet, int p_packet_len);
-	void _process_confirm_path(int p_from, const uint8_t *p_packet, int p_packet_len);
 	void _process_raw(int p_from, const uint8_t *p_packet, int p_packet_len);
 
 public:
 	static MultiplayerReplicationInterface *(*create_default_replication_interface)(MultiplayerAPI *p_multiplayer);
+	static MultiplayerRPCInterface *(*create_default_rpc_interface)(MultiplayerAPI *p_multiplayer);
+	static MultiplayerCacheInterface *(*create_default_cache_interface)(MultiplayerAPI *p_multiplayer);
 
 	static Error encode_and_compress_variant(const Variant &p_variant, uint8_t *p_buffer, int &r_len, bool p_allow_object_decoding);
 	static Error decode_and_decompress_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int *r_len, bool p_allow_object_decoding);
@@ -136,23 +144,24 @@ public:
 
 	void poll();
 	void clear();
-	void set_root_node(Node *p_node);
-	Node *get_root_node();
+	void set_root_path(const NodePath &p_path);
+	NodePath get_root_path() const;
 	void set_multiplayer_peer(const Ref<MultiplayerPeer> &p_peer);
 	Ref<MultiplayerPeer> get_multiplayer_peer() const;
 
 	Error send_bytes(Vector<uint8_t> p_data, int p_to = MultiplayerPeer::TARGET_PEER_BROADCAST, Multiplayer::TransferMode p_mode = Multiplayer::TRANSFER_MODE_RELIABLE, int p_channel = 0);
 
-	// Called by Node.rpc
-	void rpcp(Node *p_node, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount);
+	// RPC API
+	void rpcp(Object *p_obj, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount);
+	String get_rpc_md5(const Object *p_obj) const;
 	// Replication API
 	Error spawn(Object *p_object, Variant p_config);
 	Error despawn(Object *p_object, Variant p_config);
 	Error replication_start(Object *p_object, Variant p_config);
 	Error replication_stop(Object *p_object, Variant p_config);
-	// Called by replicator
-	bool send_confirm_path(Node *p_node, NodePath p_path, int p_target, int &p_id);
-	Node *get_cached_node(int p_from, uint32_t p_node_id);
+	// Cache API
+	bool send_object_cache(Object *p_obj, NodePath p_path, int p_target, int &p_id);
+	Object *get_cached_object(int p_from, uint32_t p_cache_id);
 	bool is_cache_confirmed(NodePath p_path, int p_peer);
 
 	void _add_peer(int p_id);
@@ -173,8 +182,6 @@ public:
 
 	void set_allow_object_decoding(bool p_enable);
 	bool is_object_decoding_allowed() const;
-
-	RPCManager *get_rpc_manager() const { return rpc_manager; }
 
 #ifdef DEBUG_ENABLED
 	void profile_bandwidth(const String &p_inout, int p_size);

--- a/doc/classes/MultiplayerAPI.xml
+++ b/doc/classes/MultiplayerAPI.xml
@@ -79,8 +79,8 @@
 		<member name="refuse_new_connections" type="bool" setter="set_refuse_new_connections" getter="is_refusing_new_connections" default="false">
 			If [code]true[/code], the MultiplayerAPI's [member multiplayer_peer] refuses new incoming connections.
 		</member>
-		<member name="root_node" type="Node" setter="set_root_node" getter="get_root_node">
-			The root node to use for RPCs. Instead of an absolute path, a relative path will be used to find the node upon which the RPC should be executed.
+		<member name="root_path" type="NodePath" setter="set_root_path" getter="get_root_path" default="NodePath(&quot;&quot;)">
+			The root path to use for RPCs and replication. Instead of an absolute path, a relative path will be used to find the node upon which the RPC should be executed.
 			This effectively allows to have different branches of the scene tree to be managed by different MultiplayerAPI, allowing for example to run both client and server in the same scene.
 		</member>
 	</members>

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1165,7 +1165,7 @@ void SceneTree::set_multiplayer(Ref<MultiplayerAPI> p_multiplayer) {
 	ERR_FAIL_COND(!p_multiplayer.is_valid());
 
 	multiplayer = p_multiplayer;
-	multiplayer->set_root_node(root);
+	multiplayer->set_root_path("/" + root->get_name());
 }
 
 void SceneTree::_bind_methods() {

--- a/scene/multiplayer/scene_cache_interface.cpp
+++ b/scene/multiplayer/scene_cache_interface.cpp
@@ -1,0 +1,249 @@
+/*************************************************************************/
+/*  scene_cache_interface.cpp                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "scene_cache_interface.h"
+
+#include "core/io/marshalls.h"
+#include "scene/main/node.h"
+#include "scene/main/window.h"
+
+MultiplayerCacheInterface *SceneCacheInterface::_create(MultiplayerAPI *p_multiplayer) {
+	return memnew(SceneCacheInterface(p_multiplayer));
+}
+
+void SceneCacheInterface::make_default() {
+	MultiplayerAPI::create_default_cache_interface = _create;
+}
+
+void SceneCacheInterface::on_peer_change(int p_id, bool p_connected) {
+	if (p_connected) {
+		path_get_cache.insert(p_id, PathGetCache());
+	} else {
+		// Cleanup get cache.
+		path_get_cache.erase(p_id);
+		// Cleanup sent cache.
+		// Some refactoring is needed to make this faster and do paths GC.
+		List<NodePath> keys;
+		path_send_cache.get_key_list(&keys);
+		for (const NodePath &E : keys) {
+			PathSentCache *psc = path_send_cache.getptr(E);
+			psc->confirmed_peers.erase(p_id);
+		}
+	}
+}
+
+void SceneCacheInterface::process_simplify_path(int p_from, const uint8_t *p_packet, int p_packet_len) {
+	Node *root_node = SceneTree::get_singleton()->get_root()->get_node(multiplayer->get_root_path());
+	ERR_FAIL_COND(!root_node);
+	ERR_FAIL_COND_MSG(p_packet_len < 38, "Invalid packet received. Size too small.");
+	int ofs = 1;
+
+	String methods_md5;
+	methods_md5.parse_utf8((const char *)(p_packet + ofs), 32);
+	ofs += 33;
+
+	int id = decode_uint32(&p_packet[ofs]);
+	ofs += 4;
+
+	String paths;
+	paths.parse_utf8((const char *)(p_packet + ofs), p_packet_len - ofs);
+
+	NodePath path = paths;
+
+	if (!path_get_cache.has(p_from)) {
+		path_get_cache[p_from] = PathGetCache();
+	}
+
+	Node *node = root_node->get_node(path);
+	ERR_FAIL_COND(node == nullptr);
+	const bool valid_rpc_checksum = multiplayer->get_rpc_md5(node) == methods_md5;
+	if (valid_rpc_checksum == false) {
+		ERR_PRINT("The rpc node checksum failed. Make sure to have the same methods on both nodes. Node path: " + path);
+	}
+
+	PathGetCache::NodeInfo ni;
+	ni.path = path;
+
+	path_get_cache[p_from].nodes[id] = ni;
+
+	// Encode path to send ack.
+	CharString pname = String(path).utf8();
+	int len = encode_cstring(pname.get_data(), nullptr);
+
+	Vector<uint8_t> packet;
+
+	packet.resize(1 + 1 + len);
+	packet.write[0] = MultiplayerAPI::NETWORK_COMMAND_CONFIRM_PATH;
+	packet.write[1] = valid_rpc_checksum;
+	encode_cstring(pname.get_data(), &packet.write[2]);
+
+	Ref<MultiplayerPeer> multiplayer_peer = multiplayer->get_multiplayer_peer();
+	ERR_FAIL_COND(multiplayer_peer.is_null());
+
+	multiplayer_peer->set_transfer_channel(0);
+	multiplayer_peer->set_transfer_mode(Multiplayer::TRANSFER_MODE_RELIABLE);
+	multiplayer_peer->set_target_peer(p_from);
+	multiplayer_peer->put_packet(packet.ptr(), packet.size());
+}
+
+void SceneCacheInterface::process_confirm_path(int p_from, const uint8_t *p_packet, int p_packet_len) {
+	ERR_FAIL_COND_MSG(p_packet_len < 3, "Invalid packet received. Size too small.");
+
+	const bool valid_rpc_checksum = p_packet[1];
+
+	String paths;
+	paths.parse_utf8((const char *)&p_packet[2], p_packet_len - 2);
+
+	NodePath path = paths;
+
+	if (valid_rpc_checksum == false) {
+		ERR_PRINT("The rpc node checksum failed. Make sure to have the same methods on both nodes. Node path: " + path);
+	}
+
+	PathSentCache *psc = path_send_cache.getptr(path);
+	ERR_FAIL_COND_MSG(!psc, "Invalid packet received. Tries to confirm a path which was not found in cache.");
+
+	Map<int, bool>::Element *E = psc->confirmed_peers.find(p_from);
+	ERR_FAIL_COND_MSG(!E, "Invalid packet received. Source peer was not found in cache for the given path.");
+	E->get() = true;
+}
+
+bool SceneCacheInterface::_send_confirm_path(Node *p_node, NodePath p_path, PathSentCache *psc, int p_target) {
+	bool has_all_peers = true;
+	List<int> peers_to_add; // If one is missing, take note to add it.
+
+	for (const Set<int>::Element *E = multiplayer->get_connected_peers().front(); E; E = E->next()) {
+		if (p_target < 0 && E->get() == -p_target) {
+			continue; // Continue, excluded.
+		}
+
+		if (p_target > 0 && E->get() != p_target) {
+			continue; // Continue, not for this peer.
+		}
+
+		Map<int, bool>::Element *F = psc->confirmed_peers.find(E->get());
+
+		if (!F || !F->get()) {
+			// Path was not cached, or was cached but is unconfirmed.
+			if (!F) {
+				// Not cached at all, take note.
+				peers_to_add.push_back(E->get());
+			}
+
+			has_all_peers = false;
+		}
+	}
+
+	if (peers_to_add.size() > 0) {
+		// Those that need to be added, send a message for this.
+
+		// Encode function name.
+		const CharString path = String(p_path).utf8();
+		const int path_len = encode_cstring(path.get_data(), nullptr);
+
+		// Extract MD5 from rpc methods list.
+		const String methods_md5 = multiplayer->get_rpc_md5(p_node);
+		const int methods_md5_len = 33; // 32 + 1 for the `0` that is added by the encoder.
+
+		Vector<uint8_t> packet;
+		packet.resize(1 + 4 + path_len + methods_md5_len);
+		int ofs = 0;
+
+		packet.write[ofs] = MultiplayerAPI::NETWORK_COMMAND_SIMPLIFY_PATH;
+		ofs += 1;
+
+		ofs += encode_cstring(methods_md5.utf8().get_data(), &packet.write[ofs]);
+
+		ofs += encode_uint32(psc->id, &packet.write[ofs]);
+
+		ofs += encode_cstring(path.get_data(), &packet.write[ofs]);
+
+		Ref<MultiplayerPeer> multiplayer_peer = multiplayer->get_multiplayer_peer();
+		ERR_FAIL_COND_V(multiplayer_peer.is_null(), false);
+
+		for (int &E : peers_to_add) {
+			multiplayer_peer->set_target_peer(E); // To all of you.
+			multiplayer_peer->set_transfer_channel(0);
+			multiplayer_peer->set_transfer_mode(Multiplayer::TRANSFER_MODE_RELIABLE);
+			multiplayer_peer->put_packet(packet.ptr(), packet.size());
+
+			psc->confirmed_peers.insert(E, false); // Insert into confirmed, but as false since it was not confirmed.
+		}
+	}
+
+	return has_all_peers;
+}
+
+bool SceneCacheInterface::is_cache_confirmed(NodePath p_path, int p_peer) {
+	const PathSentCache *psc = path_send_cache.getptr(p_path);
+	ERR_FAIL_COND_V(!psc, false);
+	const Map<int, bool>::Element *F = psc->confirmed_peers.find(p_peer);
+	ERR_FAIL_COND_V(!F, false); // Should never happen.
+	return F->get();
+}
+
+bool SceneCacheInterface::send_object_cache(Object *p_obj, NodePath p_path, int p_peer_id, int &r_id) {
+	Node *node = Object::cast_to<Node>(p_obj);
+	ERR_FAIL_COND_V(!node, false);
+	// See if the path is cached.
+	PathSentCache *psc = path_send_cache.getptr(p_path);
+	if (!psc) {
+		// Path is not cached, create.
+		path_send_cache[p_path] = PathSentCache();
+		psc = path_send_cache.getptr(p_path);
+		psc->id = last_send_cache_id++;
+	}
+	r_id = psc->id;
+
+	return _send_confirm_path(node, p_path, psc, p_peer_id);
+}
+
+Object *SceneCacheInterface::get_cached_object(int p_from, uint32_t p_cache_id) {
+	Node *root_node = SceneTree::get_singleton()->get_root()->get_node(multiplayer->get_root_path());
+	ERR_FAIL_COND_V(!root_node, nullptr);
+	Map<int, PathGetCache>::Element *E = path_get_cache.find(p_from);
+	ERR_FAIL_COND_V_MSG(!E, nullptr, vformat("No cache found for peer %d.", p_from));
+
+	Map<int, PathGetCache::NodeInfo>::Element *F = E->get().nodes.find(p_cache_id);
+	ERR_FAIL_COND_V_MSG(!F, nullptr, vformat("ID %d not found in cache of peer %d.", p_cache_id, p_from));
+
+	PathGetCache::NodeInfo *ni = &F->get();
+	Node *node = root_node->get_node(ni->path);
+	if (!node) {
+		ERR_PRINT("Failed to get cached path: " + String(ni->path) + ".");
+	}
+	return node;
+}
+
+void SceneCacheInterface::clear() {
+	path_get_cache.clear();
+	path_send_cache.clear();
+	last_send_cache_id = 1;
+}

--- a/scene/multiplayer/scene_cache_interface.h
+++ b/scene/multiplayer/scene_cache_interface.h
@@ -1,0 +1,82 @@
+/*************************************************************************/
+/*  scene_cache_interface.h                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef SCENE_CACHE_INTERFACE_H
+#define SCENE_CACHE_INTERFACE_H
+
+#include "core/multiplayer/multiplayer_api.h"
+
+class SceneCacheInterface : public MultiplayerCacheInterface {
+	GDCLASS(SceneCacheInterface, MultiplayerCacheInterface);
+
+private:
+	MultiplayerAPI *multiplayer;
+
+	//path sent caches
+	struct PathSentCache {
+		Map<int, bool> confirmed_peers;
+		int id;
+	};
+
+	//path get caches
+	struct PathGetCache {
+		struct NodeInfo {
+			NodePath path;
+			ObjectID instance;
+		};
+
+		Map<int, NodeInfo> nodes;
+	};
+
+	HashMap<NodePath, PathSentCache> path_send_cache;
+	Map<int, PathGetCache> path_get_cache;
+	int last_send_cache_id = 1;
+
+protected:
+	bool _send_confirm_path(Node *p_node, NodePath p_path, PathSentCache *psc, int p_target);
+	static MultiplayerCacheInterface *_create(MultiplayerAPI *p_multiplayer);
+
+public:
+	static void make_default();
+
+	virtual void clear() override;
+	virtual void on_peer_change(int p_id, bool p_connected) override;
+	virtual void process_simplify_path(int p_from, const uint8_t *p_packet, int p_packet_len) override;
+	virtual void process_confirm_path(int p_from, const uint8_t *p_packet, int p_packet_len) override;
+
+	// Returns true if all peers have cached path.
+	virtual bool send_object_cache(Object *p_obj, NodePath p_path, int p_target, int &p_id) override;
+	virtual Object *get_cached_object(int p_from, uint32_t p_cache_id) override;
+	virtual bool is_cache_confirmed(NodePath p_path, int p_peer) override;
+
+	SceneCacheInterface(MultiplayerAPI *p_multiplayer) { multiplayer = p_multiplayer; }
+};
+
+#endif // SCENE_CACHE_INTERFACE_H

--- a/scene/multiplayer/scene_replication_interface.cpp
+++ b/scene/multiplayer/scene_replication_interface.cpp
@@ -186,12 +186,10 @@ Error SceneReplicationInterface::_send_spawn(Node *p_node, MultiplayerSpawner *p
 	}
 
 	// Prepare simplified path.
-	const Node *root_node = multiplayer->get_root_node();
-	ERR_FAIL_COND_V(!root_node, ERR_UNCONFIGURED);
-	NodePath rel_path = (root_node->get_path()).rel_path_to(p_spawner->get_path());
+	NodePath rel_path = multiplayer->get_root_path().rel_path_to(p_spawner->get_path());
 
 	int path_id = 0;
-	multiplayer->send_confirm_path(p_spawner, rel_path, p_peer, path_id);
+	multiplayer->send_object_cache(p_spawner, rel_path, p_peer, path_id);
 
 	// Encode name and parent ID.
 	CharString cname = p_node->get_name().operator String().utf8();
@@ -243,7 +241,7 @@ Error SceneReplicationInterface::on_spawn_receive(int p_from, const uint8_t *p_b
 	ofs += 1;
 	uint32_t node_target = decode_uint32(&p_buffer[ofs]);
 	ofs += 4;
-	MultiplayerSpawner *spawner = Object::cast_to<MultiplayerSpawner>(multiplayer->get_cached_node(p_from, node_target));
+	MultiplayerSpawner *spawner = Object::cast_to<MultiplayerSpawner>(multiplayer->get_cached_object(p_from, node_target));
 	ERR_FAIL_COND_V(!spawner, ERR_DOES_NOT_EXIST);
 	ERR_FAIL_COND_V(p_from != spawner->get_multiplayer_authority(), ERR_UNAUTHORIZED);
 
@@ -349,11 +347,9 @@ void SceneReplicationInterface::_send_sync(int p_peer, uint64_t p_msec) {
 			uint32_t net_id = rep_state->get_net_id(oid);
 			if (net_id == 0) {
 				// First time path based ID.
-				const Node *root_node = multiplayer->get_root_node();
-				ERR_FAIL_COND(!root_node);
-				NodePath rel_path = (root_node->get_path()).rel_path_to(sync->get_path());
+				NodePath rel_path = multiplayer->get_root_path().rel_path_to(sync->get_path());
 				int path_id = 0;
-				multiplayer->send_confirm_path(sync, rel_path, p_peer, path_id);
+				multiplayer->send_object_cache(sync, rel_path, p_peer, path_id);
 				net_id = path_id;
 				rep_state->set_net_id(oid, net_id | 0x80000000);
 			}
@@ -381,7 +377,7 @@ Error SceneReplicationInterface::on_sync_receive(int p_from, const uint8_t *p_bu
 		ofs += 4;
 		Node *node = nullptr;
 		if (net_id & 0x80000000) {
-			MultiplayerSynchronizer *sync = Object::cast_to<MultiplayerSynchronizer>(multiplayer->get_cached_node(p_from, net_id & 0x7FFFFFFF));
+			MultiplayerSynchronizer *sync = Object::cast_to<MultiplayerSynchronizer>(multiplayer->get_cached_object(p_from, net_id & 0x7FFFFFFF));
 			ERR_FAIL_COND_V(!sync || sync->get_multiplayer_authority() != p_from, ERR_UNAUTHORIZED);
 			node = sync->get_node(sync->get_root_path());
 		} else {

--- a/scene/multiplayer/scene_rpc_interface.h
+++ b/scene/multiplayer/scene_rpc_interface.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  rpc_manager.h                                                        */
+/*  scene_rpc_interface.h                                                */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,15 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef MULTIPLAYER_RPC_H
-#define MULTIPLAYER_RPC_H
+#ifndef SCENE_RPC_INTERFACE_H
+#define SCENE_RPC_INTERFACE_H
 
 #include "core/multiplayer/multiplayer.h"
 #include "core/multiplayer/multiplayer_api.h"
-#include "core/object/ref_counted.h"
 
-class RPCManager : public RefCounted {
-	GDCLASS(RPCManager, RefCounted);
+class SceneRPCInterface : public MultiplayerRPCInterface {
+	GDCLASS(SceneRPCInterface, MultiplayerRPCInterface);
 
 private:
 	enum NetworkNodeIdCompression {
@@ -71,6 +70,8 @@ private:
 	Vector<uint8_t> packet_cache;
 
 protected:
+	static MultiplayerRPCInterface *_create(MultiplayerAPI *p_multiplayer);
+
 	_FORCE_INLINE_ void _profile_node_data(const String &p_what, ObjectID p_id);
 	void _process_rpc(Node *p_node, const uint16_t p_rpc_method_id, int p_from, const uint8_t *p_packet, int p_packet_len, int p_offset);
 
@@ -78,12 +79,13 @@ protected:
 	Node *_process_get_node(int p_from, const uint8_t *p_packet, uint32_t p_node_target, int p_packet_len);
 
 public:
-	// Called by Node.rpc
-	void rpcp(Node *p_node, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount);
-	void process_rpc(int p_from, const uint8_t *p_packet, int p_packet_len);
+	static void make_default();
 
-	String get_rpc_md5(const Node *p_node);
-	RPCManager(MultiplayerAPI *p_multiplayer) { multiplayer = p_multiplayer; }
+	virtual void rpcp(Object *p_obj, int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount) override;
+	virtual void process_rpc(int p_from, const uint8_t *p_packet, int p_packet_len) override;
+	virtual String get_rpc_md5(const Object *p_obj) const override;
+
+	SceneRPCInterface(MultiplayerAPI *p_multiplayer) { multiplayer = p_multiplayer; }
 };
 
-#endif // MULTIPLAYER_RPC_H
+#endif // SCENE_RPC_INTERFACE_H

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -136,7 +136,9 @@
 #include "scene/main/window.h"
 #include "scene/multiplayer/multiplayer_spawner.h"
 #include "scene/multiplayer/multiplayer_synchronizer.h"
+#include "scene/multiplayer/scene_cache_interface.h"
 #include "scene/multiplayer/scene_replication_interface.h"
+#include "scene/multiplayer/scene_rpc_interface.h"
 #include "scene/resources/audio_stream_sample.h"
 #include "scene/resources/bit_map.h"
 #include "scene/resources/box_shape_3d.h"
@@ -1058,6 +1060,8 @@ void register_scene_types() {
 
 	SceneDebugger::initialize();
 	SceneReplicationInterface::make_default();
+	SceneRPCInterface::make_default();
+	SceneCacheInterface::make_default();
 
 	NativeExtensionManager::get_singleton()->initialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SCENE);
 }


### PR DESCRIPTION
Now uses two interfaces so it can be overridden in the future, and core no longer depends on Node.

The interfaces are implements in scene/multiplayer.
Replaces root_node with root_path.
Remove all Node references from MultiplayerAPI.

EDIT: Partially address #53295 (`core/multiplayer`)