### PR TITLE
Remove RID_Owner.get_rid_by_index

### DIFF
--- a/core/templates/rid_owner.h
+++ b/core/templates/rid_owner.h
@@ -292,35 +292,6 @@ public:
 	_FORCE_INLINE_ uint32_t get_rid_count() const {
 		return alloc_count;
 	}
-
-	_FORCE_INLINE_ T *get_ptr_by_index(uint32_t p_index) {
-		ERR_FAIL_UNSIGNED_INDEX_V(p_index, alloc_count, nullptr);
-		if (THREAD_SAFE) {
-			spin_lock.lock();
-		}
-		uint64_t idx = free_list_chunks[p_index / elements_in_chunk][p_index % elements_in_chunk];
-		T *ptr = &chunks[idx / elements_in_chunk][idx % elements_in_chunk];
-		if (THREAD_SAFE) {
-			spin_lock.unlock();
-		}
-		return ptr;
-	}
-
-	_FORCE_INLINE_ RID get_rid_by_index(uint32_t p_index) {
-		ERR_FAIL_INDEX_V(p_index, alloc_count, RID());
-		if (THREAD_SAFE) {
-			spin_lock.lock();
-		}
-		uint64_t idx = free_list_chunks[p_index / elements_in_chunk][p_index % elements_in_chunk];
-		uint64_t validator = validator_chunks[idx / elements_in_chunk][idx % elements_in_chunk];
-
-		RID rid = _make_from_id((validator << 32) | idx);
-		if (THREAD_SAFE) {
-			spin_lock.unlock();
-		}
-		return rid;
-	}
-
 	void get_owned_list(List<RID> *p_owned) {
 		if (THREAD_SAFE) {
 			spin_lock.lock();
@@ -329,6 +300,24 @@ public:
 			uint64_t validator = validator_chunks[i / elements_in_chunk][i % elements_in_chunk];
 			if (validator != 0xFFFFFFFF) {
 				p_owned->push_back(_make_from_id((validator << 32) | i));
+			}
+		}
+		if (THREAD_SAFE) {
+			spin_lock.unlock();
+		}
+	}
+
+	//used for fast iteration in the elements or RIDs
+	void fill_owned_buffer(RID *p_rid_buffer) {
+		if (THREAD_SAFE) {
+			spin_lock.lock();
+		}
+		uint32_t idx = 0;
+		for (size_t i = 0; i < max_alloc; i++) {
+			uint64_t validator = validator_chunks[i / elements_in_chunk][i % elements_in_chunk];
+			if (validator != 0xFFFFFFFF) {
+				p_rid_buffer[idx] = _make_from_id((validator << 32) | i);
+				idx++;
 			}
 		}
 		if (THREAD_SAFE) {
@@ -425,16 +414,12 @@ public:
 		return alloc.get_rid_count();
 	}
 
-	_FORCE_INLINE_ RID get_rid_by_index(uint32_t p_index) {
-		return alloc.get_rid_by_index(p_index);
-	}
-
-	_FORCE_INLINE_ T *get_ptr_by_index(uint32_t p_index) {
-		return *alloc.get_ptr_by_index(p_index);
-	}
-
 	_FORCE_INLINE_ void get_owned_list(List<RID> *p_owned) {
 		return alloc.get_owned_list(p_owned);
+	}
+
+	void fill_owned_buffer(RID *p_rid_buffer) {
+		alloc.fill_owned_buffer(p_rid_buffer);
 	}
 
 	void set_description(const char *p_descrption) {
@@ -485,16 +470,11 @@ public:
 		return alloc.get_rid_count();
 	}
 
-	_FORCE_INLINE_ RID get_rid_by_index(uint32_t p_index) {
-		return alloc.get_rid_by_index(p_index);
-	}
-
-	_FORCE_INLINE_ T *get_ptr_by_index(uint32_t p_index) {
-		return alloc.get_ptr_by_index(p_index);
-	}
-
 	_FORCE_INLINE_ void get_owned_list(List<RID> *p_owned) {
 		return alloc.get_owned_list(p_owned);
+	}
+	void fill_owned_buffer(RID *p_rid_buffer) {
+		alloc.fill_owned_buffer(p_rid_buffer);
 	}
 
 	void set_description(const char *p_descrption) {

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3871,8 +3871,12 @@ void RendererSceneCull::update_dirty_instances() {
 
 void RendererSceneCull::update() {
 	//optimize bvhs
-	for (uint32_t i = 0; i < scenario_owner.get_rid_count(); i++) {
-		Scenario *s = scenario_owner.get_ptr_by_index(i);
+
+	uint32_t rid_count = scenario_owner.get_rid_count();
+	RID *rids = (RID *)alloca(sizeof(RID) * rid_count);
+	scenario_owner.fill_owned_buffer(rids);
+	for (uint32_t i = 0; i < rid_count; i++) {
+		Scenario *s = scenario_owner.get_or_null(rids[i]);
 		s->indexers[Scenario::INDEXER_GEOMETRY].optimize_incremental(indexer_update_iterations);
 		s->indexers[Scenario::INDEXER_VOLUMES].optimize_incremental(indexer_update_iterations);
 	}


### PR DESCRIPTION
* Implementing this function efficiently is not really possible.
* Replaced by an option to get all RIDs into a buffer for performance.

Supersedes #49501

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/44973