### PR TITLE
Add INTERNAL_IMPORT_CATEGORY_PREFLIGHT to post_importer_plugins to preimport

### DIFF
--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -101,6 +101,7 @@ class EditorScenePostImportPlugin : public RefCounted {
 
 public:
 	enum InternalImportCategory {
+		INTERNAL_IMPORT_CATEGORY_PREFLIGHT,
 		INTERNAL_IMPORT_CATEGORY_NODE,
 		INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE,
 		INTERNAL_IMPORT_CATEGORY_MESH,
@@ -243,6 +244,7 @@ public:
 	virtual String get_preset_name(int p_idx) const override;
 
 	enum InternalImportCategory {
+		INTERNAL_IMPORT_CATEGORY_PREFLIGHT = EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_PREFLIGHT,
 		INTERNAL_IMPORT_CATEGORY_NODE = EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_NODE,
 		INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE = EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE,
 		INTERNAL_IMPORT_CATEGORY_MESH = EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_MESH,


### PR DESCRIPTION
WORK IN PROGRESS.

Provide a way to use EditorScenePostImportPlugin to add a preflight internal process that allows one to insert gltf extensions. Then, plumbing the list of gltf extensions to be used in the gltf extension sandbox test cases in both export and import.

Work on https://github.com/godotengine/godot-proposals/issues/3305. Will be writing a new proposal superseding 3305 that shows the new design.

Use https://github.com/V-Sekai/godot-gltf-sandbox as a sandbox for testing.
