### PR TITLE
[3.x] Add fflush to error macros

### DIFF
--- a/core/error_macros.cpp
+++ b/core/error_macros.cpp
@@ -107,3 +107,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool fatal) {
 	_err_print_index_error(p_function, p_file, p_line, p_index, p_size, p_index_str, p_size_str, p_message.utf8().get_data(), fatal);
 }
+
+void _err_flush_stdout() {
+	fflush(stdout);
+}

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -84,6 +84,7 @@ void _err_print_error(const char *p_function, const char *p_file, int p_line, co
 void _err_print_error(const char *p_function, const char *p_file, int p_line, const String &p_error, const String &p_message, ErrorHandlerType p_type = ERR_HANDLER_ERROR);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const char *p_message = "", bool fatal = false);
 void _err_print_index_error(const char *p_function, const char *p_file, int p_line, int64_t p_index, int64_t p_size, const char *p_index_str, const char *p_size_str, const String &p_message, bool fatal = false);
+void _err_flush_stdout();
 
 #ifndef _STR
 #define _STR(m_x) #m_x
@@ -426,6 +427,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 #define CRASH_NOW()                                                                  \
 	if (true) {                                                                      \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method failed."); \
+		void _err_flush_stdout();                                                    \
 		GENERATE_TRAP                                                                \
 	} else                                                                           \
 		((void)0)
@@ -437,6 +439,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 #define CRASH_NOW_MSG(m_msg)                                                                \
 	if (true) {                                                                             \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method failed.", m_msg); \
+		void _err_flush_stdout();                                                           \
 		GENERATE_TRAP                                                                       \
 	} else                                                                                  \
 		((void)0)
@@ -520,6 +523,7 @@ void _err_print_index_error(const char *p_function, const char *p_file, int p_li
 #define DEV_ASSERT(m_cond)                                                                                              \
 	if (unlikely(!(m_cond))) {                                                                                          \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: DEV_ASSERT failed  \"" _STR(m_cond) "\" is false."); \
+		void _err_flush_stdout();                                                                                       \
 		GENERATE_TRAP                                                                                                   \
 	} else                                                                                                              \
 		((void)0)


### PR DESCRIPTION
CRASH_NOW and DEV_ASSERT macros would previously terminate before outputting any error messages.
This PR ensures calling fflush for stdout before terminating.

3.x version of #57657

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
