### PR TITLE
Bind mesh merging functionality in MeshInstance

### DIFF
--- a/doc/classes/MeshInstance.xml
+++ b/doc/classes/MeshInstance.xml
@@ -61,6 +61,28 @@
 				Returns the number of surface materials.
 			</description>
 		</method>
+		<method name="is_mergeable_with" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="other_mesh_instance" type="Node" />
+			<description>
+				Returns [code]true[/code] if this [MeshInstance] can be merged with the specified [code]other_mesh_instance[/code], using the [method MeshInstance.merge_meshes] function.
+				In order to be mergeable, properties of the [MeshInstance] must match, and each surface must match, in terms of material, attributes and vertex format.
+			</description>
+		</method>
+		<method name="merge_meshes">
+			<return type="bool" />
+			<argument index="0" name="mesh_instances" type="Array" default="[  ]" />
+			<argument index="1" name="use_global_space" type="bool" default="false" />
+			<argument index="2" name="check_compatibility" type="bool" default="true" />
+			<description>
+				This function can merge together the data from several source [MeshInstance]s into a single destination [MeshInstance] (the MeshInstance the function is called from). This is primarily useful for improving performance by reducing the number of drawcalls and [Node]s.
+				Merging should only be attempted for simple meshes that do not contain animation.
+				The final vertices can either be returned in global space, or in local space relative to the destination [MeshInstance] global transform (the destination Node must be inside the [SceneTree] for local space to work).
+				The function will make a final check for compatibility between the [MeshInstance]s by default, this should always be used unless you have previously checked for compatibility using [method MeshInstance.is_mergeable_with]. If the compatibility check is omitted and the meshes are merged, you may see rendering errors.
+				[b]Note:[/b] The requirements for similarity between meshes are quite stringent. They can be checked using the [method MeshInstance.is_mergeable_with] function prior to calling [method MeshInstance.merge_meshes].
+				Also note that any initial data in the destination [MeshInstance] data will be discarded.
+			</description>
+		</method>
 		<method name="set_surface_material">
 			<return type="void" />
 			<argument index="0" name="surface" type="int" />

--- a/scene/3d/mesh_instance.h
+++ b/scene/3d/mesh_instance.h
@@ -96,6 +96,7 @@ protected:
 
 private:
 	// merging
+	bool _merge_meshes(Vector<MeshInstance *> p_list, bool p_use_global_space, bool p_check_compatibility);
 	bool _is_mergeable_with(const MeshInstance &p_other) const;
 	void _merge_into_mesh_data(const MeshInstance &p_mi, const Transform &p_dest_tr_inv, int p_surface_id, PoolVector<Vector3> &r_verts, PoolVector<Vector3> &r_norms, PoolVector<real_t> &r_tangents, PoolVector<Color> &r_colors, PoolVector<Vector2> &r_uvs, PoolVector<Vector2> &r_uv2s, PoolVector<int> &r_inds);
 	bool _ensure_indices_valid(PoolVector<int> &r_indices, const PoolVector<Vector3> &p_verts) const;
@@ -146,7 +147,7 @@ public:
 
 	// merging
 	bool is_mergeable_with(Node *p_other) const;
-	bool merge_meshes(Vector<MeshInstance *> p_list, bool p_use_global_space, bool p_check_compatibility);
+	bool merge_meshes(Vector<Variant> p_list, bool p_use_global_space, bool p_check_compatibility);
 
 	virtual AABB get_aabb() const;
 	virtual PoolVector<Face3> get_faces(uint32_t p_usage_flags) const;

--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -2156,7 +2156,14 @@ void RoomManager::_merge_meshes_in_room(Room *p_room) {
 
 			_merge_log("\t\t" + merged->get_name());
 
-			if (merged->merge_meshes(merge_list, true, false)) {
+			// merge function takes a vector of variants
+			Vector<Variant> variant_merge_list;
+			variant_merge_list.resize(merge_list.size());
+			for (int i = 0; i < merge_list.size(); i++) {
+				variant_merge_list.set(i, merge_list[i]);
+			}
+
+			if (merged->merge_meshes(variant_merge_list, true, false)) {
 				// set all the source meshes to portal mode ignore so not shown
 				for (int i = 0; i < merge_list.size(); i++) {
 					merge_list[i]->set_portal_mode(CullInstance::PORTAL_MODE_IGNORE);


### PR DESCRIPTION
The portal system introduced basic mesh merging functionality, this has wide ranging uses outside of the portal system.
For this reason, this PR binds the mesh merging functionality.
It also slightly modifies the calling from RoomManager to use a Vector of Node *, in order to allow binding of the function.

## Introduction
Mesh merging is a very useful tool in the performance toolbox. Many games, especially outdoor games are bottlenecked by the number of MeshInstances, both in terms of draw calls in the renderer (especially with OpenGL), but also in terms of housekeeping scene tree side.
Merging meshes, either ahead of time (pre-baking and saving) or at runtime (usually at level startup) can offer significant performance improvements, particularly for things like vegetation and procedural modular block levels (such as minecraft type maps).
This is especially relevant when hardware instancing is not available, such as in GLES2, or where hardware instancing cannot be used, such as when a variety of different meshes must be drawn at once.

Note however that there is a trade off - merged meshes will be culled as a block, so depending on how you apply it you can lose culling accuracy. This will still be a net win in many situations though. And, unlike instancing, you also lose the ability to move the merged objects relative to each other, they can only be moved as a group.

## Local or Global space
The merged vertices can either be defined in global (world) space, or in the local space of the destination `MeshInstance` (provided it is in the SceneTree, which is necessary in order to get its global_transform).

In a static scene, global space may make sense, but when merging sub-parts of a movable object (say a spaceship), you may want the vertices specified relative to the object, so that when you move it the parts move in unison.

Local space is default. Note that local space will flag a warning if you merge _before_ adding the MeshInstance to the SceneTree (because the local space is undefined), and will revert to global space.

## Notes
* The mesh merging functionality is already available in Rooms & Portals, so it would seem logical to make it available for general use, as there are many other use cases outside the portal system.
* The system initially offers only very simplistic merging (in particularly materials must match) but it should be suitable for many use cases.
* Suggestions welcome for better names for the functions that are exposed, or improvements to the API (especially for future considerations).
* It may be desirable at some stage to add something to the UI to give this a more user-orientated experience, but this is not necessary to get the ball rolling for people who want to use this.
* Merging from source meshes that are not in the SceneTree will work (and just use an identity transform for the source mesh), but it will flag a benign error from calling `get_global_transform()`. I'm not quite sure whether it would be better to check `is_inside_tree()` and silently allow this, we can always change this based on feedback though.

## Example script:
```
	print($MeshInstance.is_mergeable_with($MeshInstance2))
	
	var arr = []
	arr.push_back($MeshInstance)
	arr.push_back($MeshInstance2)
	
	$Merged.merge_meshes(arr)
```

## Example project
20,000 boxes, either drawn separately or merged:
[MergingTest.zip](https://github.com/godotengine/godot/files/8008215/MergingTest.zip)

Separate 28 fps
Merged 664 fps (24 x faster)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

*Bugsquad edit: Related (but not closing) https://github.com/godotengine/godot-proposals/issues/901.*