### PR TITLE
Add more information on triangulate polygon

### DIFF
--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -209,7 +209,7 @@
 			<return type="PackedInt32Array" />
 			<argument index="0" name="polygon" type="PackedVector2Array" />
 			<description>
-				Triangulates the polygon specified by the points in [code]polygon[/code]. Returns a [PackedInt32Array] where each triangle consists of three consecutive point indices into [code]polygon[/code] (i.e. the returned array will have [code]n * 3[/code] elements, with [code]n[/code] being the number of found triangles). If the triangulation did not succeed, an empty [PackedInt32Array] is returned.
+				Triangulates the polygon specified by the points in [code]polygon[/code]. Returns a [PackedInt32Array] where each triangle consists of three consecutive point indices into [code]polygon[/code] (i.e. the returned array will have [code]n * 3[/code] elements, with [code]n[/code] being the number of found triangles). Output triangles will always be counter clockwise, and the contour will be flipped if it's clockwise. If the triangulation did not succeed, an empty [PackedInt32Array] is returned.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
Adds that output triangles will always be counter clockwise, and that the contour will be flipped if it's clockwise. Closes https://github.com/godotengine/godot-docs/issues/5566.