### PR TITLE
Document BakedLightmap atlas generation only being compatible with GLES3

### DIFF
--- a/doc/classes/BakedLightmap.xml
+++ b/doc/classes/BakedLightmap.xml
@@ -23,7 +23,8 @@
 	</methods>
 	<members>
 		<member name="atlas_generate" type="bool" setter="set_generate_atlas" getter="is_generate_atlas_enabled" default="true">
-			When enabled, the lightmapper will merge the textures for all meshes into a single large layered texture. Not supported in GLES2.
+			If [code]true[/code], the lightmapper will merge the textures for all meshes into one or several large layered textures. If [code]false[/code], every mesh will get its own lightmap texture, which is less efficient.
+			[b]Note:[/b] Atlas lightmap rendering is only supported in GLES3, [i]not[/i] GLES2. Non-atlas lightmap rendering is supported by both GLES3 and GLES2. If [member ProjectSettings.rendering/quality/driver/fallback_to_gles2] is [code]true[/code], consider baking lightmaps with [member atlas_generate] set to [code]false[/code] so that the resulting lightmap is visible in both GLES3 and GLES2.
 		</member>
 		<member name="atlas_max_size" type="int" setter="set_max_atlas_size" getter="get_max_atlas_size" default="4096">
 			Maximum size of each lightmap layer, only used when [member atlas_generate] is enabled.


### PR DESCRIPTION
~~This closes https://github.com/godotengine/godot/issues/51741 (as there's a proposal tracking the implementation of multiple atlases: https://github.com/godotengine/godot-proposals/issues/2147).~~

**Edit:** Support for multiple atlases was added in 3.5 by https://github.com/godotengine/godot/pull/58102. This PR now only mentions the limitation about atlases not being supported in GLES2.

This shouldn't be cherry-picked to `3.4` as the wording now implies that multiple atlases are supported.