### PR TITLE
Fix blend animation to solve TRS track bug & blend order inconsistency

### DIFF
--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -102,6 +102,22 @@ Quaternion Quaternion::inverse() const {
 	return Quaternion(-x, -y, -z, w);
 }
 
+Quaternion Quaternion::log() const {
+	Quaternion src = *this;
+	Vector3 src_v = src.get_axis() * src.get_angle();
+	return Quaternion(src_v.x, src_v.y, src_v.z, 0);
+}
+
+Quaternion Quaternion::exp() const {
+	Quaternion src = *this;
+	Vector3 src_v = Vector3(src.x, src.y, src.z);
+	float theta = src_v.length();
+	if (theta < CMP_EPSILON) {
+		return Quaternion(0, 0, 0, 1);
+	}
+	return Quaternion(src_v.normalized(), theta);
+}
+
 Quaternion Quaternion::slerp(const Quaternion &p_to, const real_t &p_weight) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!is_normalized(), Quaternion(), "The start quaternion must be normalized.");
@@ -190,6 +206,9 @@ Quaternion::operator String() const {
 }
 
 Vector3 Quaternion::get_axis() const {
+	if (Math::abs(w) > 1 - CMP_EPSILON) {
+		return Vector3(x, y, z);
+	}
 	real_t r = ((real_t)1) / Math::sqrt(1 - w * w);
 	return Vector3(x * r, y * r, z * r);
 }

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -60,6 +60,8 @@ struct _NO_DISCARD_ Quaternion {
 	Quaternion normalized() const;
 	bool is_normalized() const;
 	Quaternion inverse() const;
+	Quaternion log() const;
+	Quaternion exp() const;
 	_FORCE_INLINE_ real_t dot(const Quaternion &p_q) const;
 	real_t angle_to(const Quaternion &p_to) const;
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1626,6 +1626,8 @@ static void _register_variant_builtin_methods() {
 	bind_method(Quaternion, is_normalized, sarray(), varray());
 	bind_method(Quaternion, is_equal_approx, sarray("to"), varray());
 	bind_method(Quaternion, inverse, sarray(), varray());
+	bind_method(Quaternion, log, sarray(), varray());
+	bind_method(Quaternion, exp, sarray(), varray());
 	bind_method(Quaternion, angle_to, sarray("to"), varray());
 	bind_method(Quaternion, dot, sarray("with"), varray());
 	bind_method(Quaternion, slerp, sarray("to", "weight"), varray());

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -91,6 +91,11 @@
 				Returns the dot product of two quaternions.
 			</description>
 		</method>
+		<method name="exp" qualifiers="const">
+			<return type="Quaternion" />
+			<description>
+			</description>
+		</method>
 		<method name="get_angle" qualifiers="const">
 			<return type="float" />
 			<description>
@@ -136,6 +141,11 @@
 			<return type="float" />
 			<description>
 				Returns the length of the quaternion, squared.
+			</description>
+		</method>
+		<method name="log" qualifiers="const">
+			<return type="Quaternion" />
+			<description>
 			</description>
 		</method>
 		<method name="normalized" qualifiers="const">

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -197,9 +197,12 @@ private:
 		bool loc_used = false;
 		bool rot_used = false;
 		bool scale_used = false;
+		Vector3 init_loc = Vector3(0, 0, 0);
+		Quaternion ref_rot = Quaternion(0, 0, 0, 1);
+		Quaternion init_rot = Quaternion(0, 0, 0, 0);
+		Vector3 init_scale = Vector3(1, 1, 1);
 		Vector3 loc;
 		Quaternion rot;
-		real_t rot_blend_accum = 0.0;
 		Vector3 scale;
 
 		TrackCacheTransform() {


### PR DESCRIPTION
Fix blending errors in TRS tracks and inconsistencies due to blending order (also fix the problem of triangle blending in Blend2D). This is a result of several discussions with @Shnazzy in #46038.

~With this change, if animation A has track X and animation B does not have track X, the internal value of track X in animation B in their blend will be the initial value that the type has. To avoid this, I have implemented the initial value to refer to the RESET track, if it exists. And for Bone3D, if there is no RESET track, it is implicitly based on bone_rest.~ RESET track is no longer used, just it use rest track as default value.

When using this initial value, blending with the initial value is required even when the blend value is 0, so I changed place the check from the blend process whether the blend value is 0 or not. Without it, the value isn't updated when the blend amount to be rapidly set to 0 or 1. This causes a temporary inconsistency in the blending results and after an unintentional abrupt change in the value occurs when the blend amount is changed.

This PR supersede #34134. Also, it solves the problem to a greater extent than #54205, but the changes are larger, so if you need to make minimal fix for TRS track, use #54205.

Fixed #46038. Fixed #54407. Fixed #55838. Fixed #34694.