### PR TITLE
Rework CanvasItem visibility propagation

### DIFF
--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -87,6 +87,7 @@ private:
 	Window *window = nullptr;
 	bool first_draw = false;
 	bool visible = true;
+	bool visible_in_tree = false;
 	bool clip_children = false;
 	bool pending_update = false;
 	bool top_level = false;
@@ -109,7 +110,7 @@ private:
 
 	void _top_level_raise_self();
 
-	void _propagate_visibility_changed(bool p_visible);
+	void _propagate_visibility_changed(bool p_visible, bool p_was_visible = false);
 
 	void _update_callback();
 


### PR DESCRIPTION
This PR optimizes the way CanvasItems determine their visibility in tree. I added `visible_in_tree` property, which depends on parent CanvasItem, CanvasLayer or Viewport. `is_visible_in_tree()` was changed from complex parent search to one-liner: `return visible && visible_in_tree`.

`visible_in_tree` is false by default. When CanvasItem enters tree, it's checking its parents for visibility to set initial value of `visible_in_tree` (I added it to a code that already existed). It's set to `false` when node exists tree. Also it's modified in `_propagate_visibility_changed()`.

I also slightly changed behavior of `hidden` signal. Previously it was emitted when node was already invisible, but the parent was made invisible too, which was incorrect. Also, as a result of aforementioned changes, this PR fixes a bug from #48006 where CanvasLayer could propagate its visibility to CanvasItems that were separated by plain Nodes.

Finally, I removed some "todo optimize" comments. I assume this is what they wanted to optimize. `is_visible_in_tree()` is now as cheap to use as `is_visible()`.