### PR TITLE
Fix GLTF texture filename decoding

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -818,6 +818,7 @@ Error GLTFDocument::_parse_buffers(Ref<GLTFState> state, const String &p_base_pa
 					}
 					buffer_data = _parse_base64_uri(uri);
 				} else { // Relative path to an external image file.
+					uri = uri.http_unescape();
 					uri = p_base_path.plus_file(uri).replace("\\", "/"); // Fix for Windows.
 					buffer_data = FileAccess::get_file_as_array(uri);
 					ERR_FAIL_COND_V_MSG(buffer.size() == 0, ERR_PARSE_ERROR, "glTF: Couldn't load binary file as an array: " + uri);
@@ -3028,9 +3029,9 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> state, const String &p_base_pat
 
 		// We'll assume that we use either URI or bufferView, so let's warn the user
 		// if their image somehow uses both. And fail if it has neither.
-		ERR_CONTINUE_MSG(!d.has("uri") && !d.has("bufferView"), "Invalid image definition in glTF file, it should specific an 'uri' or 'bufferView'.");
+		ERR_CONTINUE_MSG(!d.has("uri") && !d.has("bufferView"), "Invalid image definition in glTF file, it should specify an 'uri' or 'bufferView'.");
 		if (d.has("uri") && d.has("bufferView")) {
-			WARN_PRINT("Invalid image definition in glTF file using both 'uri' and 'bufferView'. 'bufferView' will take precedence.");
+			WARN_PRINT("Invalid image definition in glTF file using both 'uri' and 'bufferView'. 'uri' will take precedence.");
 		}
 
 		String mimetype;
@@ -3068,6 +3069,7 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> state, const String &p_base_pat
 					}
 				}
 			} else { // Relative path to an external image file.
+				uri = uri.http_unescape();
 				uri = p_base_path.plus_file(uri).replace("\\", "/"); // Fix for Windows.
 				// ResourceLoader will rely on the file extension to use the relevant loader.
 				// The spec says that if mimeType is defined, it should take precedence (e.g.


### PR DESCRIPTION
This PR backports a specific fix to gltf filename decoding. GLTF files uri-encode references to external filenames. When importing into Godot, if the filename or a directory have any special characters, Godot fails to find the file. The solution is to decode the uri before looking for the file. On the master branch this is done using `String::uri_decode` but this is not available on 3.x. For these versions, and in this PR, I used `String::percent_decode` which covers most of the cases of uri encoding for GLFT files.

A more complete solution would be to backport the `String::uri_(en|de)code` methods and use those.

# Test Project

[gltf-tests.zip](https://github.com/godotengine/godot/files/8009102/gltf-tests.zip)

Output without this PR:

```
Resource file not found: res://cube%2Btexture.png.
Can't open file from path 'res://cube%2Btexture.png'.
modules/gltf/gltf_document.cpp:3070 - glTF: Image index '0' couldn't be loaded as a buffer of MIME type 'image/png' from URI: res://cube%2Btexture.png. Skipping it.
```

