### PR TITLE
Proposal for SubViewportContainer input handling

### DIFF
--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -140,7 +140,7 @@ void SubViewportContainer::_notification(int p_what) {
 	}
 }
 
-void SubViewportContainer::input(const Ref<InputEvent> &p_event) {
+void SubViewportContainer::gui_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
 	if (Engine::get_singleton()->is_editor_hint()) {
@@ -164,33 +164,6 @@ void SubViewportContainer::input(const Ref<InputEvent> &p_event) {
 		}
 
 		c->push_input(ev);
-	}
-}
-
-void SubViewportContainer::unhandled_input(const Ref<InputEvent> &p_event) {
-	ERR_FAIL_COND(p_event.is_null());
-
-	if (Engine::get_singleton()->is_editor_hint()) {
-		return;
-	}
-
-	Transform2D xform = get_global_transform();
-
-	if (stretch) {
-		Transform2D scale_xf;
-		scale_xf.scale(Vector2(shrink, shrink));
-		xform *= scale_xf;
-	}
-
-	Ref<InputEvent> ev = p_event->xformed_by(xform.affine_inverse());
-
-	for (int i = 0; i < get_child_count(); i++) {
-		SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
-		if (!c || c->is_input_disabled()) {
-			continue;
-		}
-
-		c->push_unhandled_input(ev);
 	}
 }
 

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -138,6 +138,36 @@ void SubViewportContainer::_notification(int p_what) {
 			}
 		}
 	}
+
+	if (p_what == NOTIFICATION_MOUSE_ENTER) {
+		for (int i = 0; i < get_child_count(); i++) {
+			SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+			if (!c) {
+				continue;
+			}
+			c->notification(NOTIFICATION_WM_MOUSE_ENTER);
+		}
+	}
+
+	if (p_what == NOTIFICATION_MOUSE_EXIT) {
+		for (int i = 0; i < get_child_count(); i++) {
+			SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+			if (!c) {
+				continue;
+			}
+			c->notification(NOTIFICATION_WM_MOUSE_EXIT);
+		}
+	}
+
+	if (p_what == NOTIFICATION_FOCUS_EXIT) {
+		for (int i = 0; i < get_child_count(); i++) {
+			SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+			if (!c) {
+				continue;
+			}
+			c->notification(NOTIFICATION_WM_WINDOW_FOCUS_OUT);
+		}
+	}
 }
 
 void SubViewportContainer::gui_input(const Ref<InputEvent> &p_event) {

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -147,7 +147,7 @@ void SubViewportContainer::gui_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	Transform2D xform = get_global_transform();
+	Transform2D xform = get_viewport()->get_global_canvas_transform();
 
 	if (stretch) {
 		Transform2D scale_xf;

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -42,13 +42,12 @@ class SubViewportContainer : public Container {
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 
 public:
 	void set_stretch(bool p_enable);
 	bool is_stretch_enabled() const;
 
-	virtual void input(const Ref<InputEvent> &p_event) override;
-	virtual void unhandled_input(const Ref<InputEvent> &p_event) override;
 	void set_stretch_shrink(int p_shrink);
 	int get_stretch_shrink() const;
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1340,7 +1340,7 @@ void Viewport::_gui_call_notification(Control *p_control, int p_what) {
 }
 
 Control *Viewport::gui_find_control(const Point2 &p_global) {
-	// Handle subwindows.
+	// Handle child Control nodes.
 	_gui_sort_roots();
 
 	for (List<Control *>::Element *E = gui.roots.back(); E; E = E->prev()) {
@@ -2155,7 +2155,7 @@ void Viewport::_gui_control_grab_focus(Control *p_control) {
 		// No need for change.
 		return;
 	}
-	get_tree()->call_group_flags(SceneTree::GROUP_CALL_REALTIME, "_viewports", "_gui_remove_focus_for_window", (Node *)get_base_window());
+	gui_release_focus();
 	gui.key_focus = p_control;
 	emit_signal(SNAME("gui_focus_changed"), p_control);
 	p_control->notification(Control::NOTIFICATION_FOCUS_ENTER);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2732,6 +2732,7 @@ void Viewport::push_unhandled_input(const Ref<InputEvent> &p_event, bool p_local
 
 						)) {
 			physics_picking_events.push_back(ev);
+			_set_input_as_handled_keep_physics();
 		}
 	}
 }
@@ -2914,7 +2915,10 @@ bool Viewport::gui_is_drag_successful() const {
 
 void Viewport::set_input_as_handled() {
 	_drop_physics_mouseover();
+	_set_input_as_handled_keep_physics();
+}
 
+void Viewport::_set_input_as_handled_keep_physics() {
 	if (!handle_input_locally) {
 		ERR_FAIL_COND(!is_inside_tree());
 		Viewport *vp = this;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2687,6 +2687,10 @@ void Viewport::push_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
 		_gui_input_event(ev);
 	}
 
+	if (!is_input_handled()) {
+		push_unhandled_input(p_event, p_local_coords);
+	}
+
 	event_count++;
 }
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -452,6 +452,8 @@ private:
 	virtual bool _can_consume_input_events() const { return true; }
 	uint64_t event_count = 0;
 
+	void _set_input_as_handled_keep_physics();
+
 protected:
 	void _set_size(const Size2i &p_size, const Size2i &p_size_2d_override, const Rect2i &p_to_screen_rect, const Transform2D &p_stretch_transform, bool p_allocated);
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -966,9 +966,6 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 	emit_signal(SceneStringNames::get_singleton()->window_input, p_ev);
 
 	push_input(p_ev);
-	if (!is_input_handled()) {
-		push_unhandled_input(p_ev);
-	}
 }
 
 void Window::_window_input_text(const String &p_text) {


### PR DESCRIPTION
This pull request intends to solve the problem, that SubViewportContainer does not send unhandled input events to the Viewport, which is tracked in #17326. The current situation makes it necessary to include code like this for each SubViewportContainer, that needs to send events to it's viewport:
``` gdscript
extends SubViewportContainer

func _input(event):
	$Viewport.unhandled_input(event)
```

The reason for this problem is in my opinion, that events get sent to SubViewports during _input and also during _unhandled_input. This conflicts with Control Nodes (in this case the SubViewportContainer) setting the event to handled during _gui_input, so that _unhandled_input is not triggered at all.

My suggested solution to this problem is to switch from the current event-layer-first approach to a viewport-first approach: Handle events primarily within a Viewport and only in special cases jump to other viewports.
For SubViewportContainer, this special case should be within _gui_input, because this is where all other Control nodes handle their functionality.
This solution makes SubViewport event propagation work out of the box.

This change happens to resolve several other bugs as well. Including the one, that the pull request #55300 also tries to solve. Unfortunately the two pull requests are not compatible, because the other one extends on the event-layer-first approach. I have found no way to resolve the intended bug with that approach.

Here is a list of all resolved issues:
1. Unhandled events do not get sent to SubViewports
fix #17326

2. SubViewportContainer catches mouse events despite being under Control Nodes
fix #48401
fix #45400
fix #39666

3. Clip Content does not work for SubViewportContainer
fix #57653
fix #28833

4. Misaligned Event coordinates inside SubViewports for MouseEvents
fix #48368

5. Some Event notifications get dropped at SubViewportContainer border
fix #57762

It is related to
- #31802
- #26181

I did not yet squash the commits together for a better understandability of the changes.

## Concept

This chart shows the high level concept of Event handling in my proposed changes:

![InputEventsFlowchart](https://user-images.githubusercontent.com/6299227/152703608-d708d2e4-1406-4ddc-afc1-33e6ec6ced3c.png)

The basic idea of this patch is to replace `input()` with `gui_input()` in `SubViewportContainer` and to step through all event layers inside of Viewport.

# Reasoning

The reasons for this approach are:

1. While `_input()` is used to filter out events of interest for user-convenience, `_gui_input()` usually handles the behavior of `Control` elements. Since `SubViewportContainer` is a `Control` element, `_gui_input()` should be the place, where it performs it's actions, in this case handling the interaction between parent Viewport and SubViewport. This includes handling of event-propagation.
2. Keeping the handling of the layers at one location within the viewport simplifies the whole procedure and makes it less error-prone. This pull request separates viewports as much as possible from each other. This is more similar to the viewport-separation idea described in the [Using InputEvent Tutorial](https://docs.godotengine.org/en/latest/tutorials/inputs/inputevent.html#how-does-it-work), than the current status of the implementation is.
3. Since these changes simplify the behavior of input propagation and reduce the deviation between the behavior of `SubViewportContainer` and `Control` nodes, event handling is simpler to document and I believe that it is easier for users to understand in comparison to the current implementation.

# Introduced Changes

This approach changes the current behavior in the following ways:

1. `SubViewportContainer` sends received gui-events as input-events to the child `SubViewport`.
2. The order in which Nodes recieve an event is changed as shown in the flowchart above.
3. Key-Events are only delivered from a `SubViewportContainer` to the corresponding `SubViewport`, if the `SubViewportContainer` has active `key_focus`. This makes it consistent with the way other `Control` nodes treat Key-Events.
4. Propagation from Gui Event Layer to Unhandled Key Event Layer now happens in Viewport. `SubViewportContainers` no longer need to propagate `unhandled_key_events` and `Window` does not need to address `unhandled_key_events` separately. This also fixes the problem, that `TouchScreenButton` events do not get propagated correctly to unhandled_events.
5. Event propagation (e.g. Physics Collider with Mouse) now also work out of the box in SubViewports without the need for [workarounds](https://github.com/godotengine/godot/issues/17326#issuecomment-431186323).
6. When setting `key_focus`, now only the `key_focus` of the current `SubViewport` is erased, instead of all viewports of the current window. This allows gui_events to travel through a sequence of viewport-transitions.
7. Input Events no longer get propagated by all `SubViewportContainers` to their `SubViewports`, but only by those that are active in regard to Gui Input Events. For example MouseClick Events no longer get delivered to SubViewports, which are away from the MousePointer, reducing unnecessary events. This also makes the behavior of SubViewportContainers consistent with the regular behavior of Control Nodes.
8. `SubViewportContainer` now sends relevant notifications to `SubViewport` so that focus is handled correctly.

# Testing

Here is my project file, that I used for testing the implementation: [SubViewportClick.zip](https://github.com/godotengine/godot/files/8010736/SubViewportClick.zip)

I performed the following steps during testing:
- Ensured that the MRP's of all mentioned issues work
- Mouse Event propagation with two levels of subviewports
- Keyboard Event propagation with two levels of subviewports
- Physics picking with two levels of subviewports
- Correctness of Viewport-Transformations with two levels of subviewports (moved & rotated)
- SubViewportContainer siblings
- 3D SubViewport at root level
- RootWindow -> Window -> SubViewportContainer

# Known issues

- If a SubViewport with 2D/3D content contains a SubViewport with 3D/2D content, then the inner content is not visible - this is the same behavior as in master. This pull request doesn't try to fix this issue
- #57723 happens also at the border of `SubViewportContainer`
- An active Camera2D inside a viewport with a non default `Transorm2D` does not work correctly, just like in master.

# Related

The suggested changes will interfere with #48800, because `set_input_as_handled()` is called immediately after `physics_picking_events.push_back(ev);`.
My reasoning is that if a viewport has `physics_object_picking`enabled, the event should be considered as handled, no matter if the event actually finds a CollisionObject. Also the physics processing happen later and possibly within a different thread, so feedback is non reliable and for this implementation it is necessary to be reliable. If `set_input_as_handled()` is used within Physics-processing, it should be independent from the `set_input_as_handled()` of Event-processing.

If this pull request is accepted, `Viewport::_gui_remove_focus_for_window` is no longer used anywhere in the code. Should that function be accordingly removed in this pull request?

Should this pull request be accepted, I am willing to contribute to the InputEvent Tutorial.
