### PR TITLE
Re-fix Disabling Half Floats on iOS

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -2287,6 +2287,7 @@ void RasterizerStorageGLES2::mesh_add_surface(RID p_mesh, uint32_t p_format, VS:
 				if (p_format & VS::ARRAY_COMPRESS_VERTEX) {
 					attribs[i].type = _GL_HALF_FLOAT_OES;
 					positions_stride += attribs[i].size * 2;
+					uses_half_float = true;
 				} else {
 					attribs[i].type = GL_FLOAT;
 					positions_stride += attribs[i].size * 4;


### PR DESCRIPTION
A previous change missed setting a flag that specified whether half
floats were being used on vertex positions when in the GLES2 driver

This caused errors with the vertex buffer when platforms (specifically
iOS) which do not properly support half float vertex attributes on
GLES2, try to remapt the vertex buffer to stop using half floats
(in this case that remapping never happened and caused artifacts)

Re-enable setting that flag to fix rendering issues on these platforms

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
