### PR TITLE
Edit font properties on multiple objects at once

### DIFF
--- a/editor/plugins/text_control_editor_plugin.h
+++ b/editor/plugins/text_control_editor_plugin.h
@@ -62,10 +62,7 @@ class TextControlEditor : public HBoxContainer {
 	ColorPickerButton *outline_color_picker = nullptr;
 	Button *clear_formatting = nullptr;
 
-	Control *edited_control = nullptr;
-	String edited_color;
-	String edited_font;
-	String edited_font_size;
+	Vector<Control *> edited_controls;
 	Ref<Font> custom_font;
 
 protected:


### PR DESCRIPTION
Allow editing font properties on multiple objects at once, including font sizes, colors and so on.
related issue: #57398 

Here are some final results on my PC:

![](https://s2.loli.net/2022/02/06/wC3eJLBsSXdWgQO.gif)

![](https://s2.loli.net/2022/02/06/5khzD1mTn2FSL9U.gif)

*Bugsquad edit:* Fixes #57398.