### PR TITLE
Support WebM seeking operation

### DIFF
--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -205,10 +205,10 @@ float VideoStreamPlaybackWebm::get_playback_position() const {
 	return video_pos;
 }
 void VideoStreamPlaybackWebm::seek(float p_time) {
-	//WARN_PRINT_ONCE("Seeking in Theora and WebM videos is not implemented yet (it's only supported for GDNative-provided video streams).");
-
-	time = webm->seek(p_time);
-	video_pos = time;
+	if (webm) {
+		time = webm->seek(p_time);
+		video_pos = time;
+	}
 }
 
 void VideoStreamPlaybackWebm::set_audio_track(int p_idx) {

--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -205,7 +205,10 @@ float VideoStreamPlaybackWebm::get_playback_position() const {
 	return video_pos;
 }
 void VideoStreamPlaybackWebm::seek(float p_time) {
-	WARN_PRINT_ONCE("Seeking in Theora and WebM videos is not implemented yet (it's only supported for GDNative-provided video streams).");
+	//WARN_PRINT_ONCE("Seeking in Theora and WebM videos is not implemented yet (it's only supported for GDNative-provided video streams).");
+	
+	time = webm->seek(p_time);
+	video_pos = time;
 }
 
 void VideoStreamPlaybackWebm::set_audio_track(int p_idx) {

--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -206,7 +206,7 @@ float VideoStreamPlaybackWebm::get_playback_position() const {
 }
 void VideoStreamPlaybackWebm::seek(float p_time) {
 	//WARN_PRINT_ONCE("Seeking in Theora and WebM videos is not implemented yet (it's only supported for GDNative-provided video streams).");
-	
+
 	time = webm->seek(p_time);
 	video_pos = time;
 }

--- a/thirdparty/libsimplewebm/WebMDemuxer.cpp
+++ b/thirdparty/libsimplewebm/WebMDemuxer.cpp
@@ -50,6 +50,8 @@ WebMDemuxer::WebMDemuxer(mkvparser::IMkvReader *reader, int videoTrack, int audi
 	m_blockFrameIndex(0),
 	m_videoTrack(NULL), m_vCodec(NO_VIDEO),
 	m_audioTrack(NULL), m_aCodec(NO_AUDIO),
+	m_seekTime(0.0f),
+	m_isSeek(false),
 	m_isOpen(false),
 	m_eos(false)
 {
@@ -143,6 +145,23 @@ int WebMDemuxer::getAudioDepth() const
 	return m_audioTrack->GetBitDepth();
 }
 
+float WebMDemuxer::seek(float p_time){
+	
+	if(p_time < 0)
+		return 0.0f;
+
+	m_seekTime = p_time;
+	m_isSeek = true;
+
+ 	const mkvparser::BlockEntry *blockEntry;
+	m_videoTrack->Seek(m_seekTime * 1e9, blockEntry);
+	if(!blockEntry)
+		return 0.0f;
+
+	const mkvparser::Block *block= blockEntry->GetBlock();
+	return  block ? (block->GetTime(blockEntry->GetCluster()) / 1e9) : 0.0f;
+}
+
 bool WebMDemuxer::readFrame(WebMFrame *videoFrame, WebMFrame *audioFrame)
 {
 	const long videoTrackNumber = (videoFrame && m_videoTrack) ? m_videoTrack->GetNumber() : 0;
@@ -186,7 +205,14 @@ bool WebMDemuxer::readFrame(WebMFrame *videoFrame, WebMFrame *audioFrame)
 		}
 		else if (!m_block || m_blockFrameIndex == m_block->GetFrameCount() || notSupportedTrackNumber(videoTrackNumber, audioTrackNumber))
 		{
-			status = m_cluster->GetNext(m_blockEntry, m_blockEntry);
+			if(m_isSeek){
+				m_videoTrack->Seek(m_seekTime * 1e9, m_blockEntry);
+				m_cluster = m_blockEntry->GetCluster();
+				m_isSeek = false;
+			}
+			else{
+				status = m_cluster->GetNext(m_blockEntry, m_blockEntry);
+			}
 			if (!m_blockEntry  || m_blockEntry->EOS())
 			{
 				blockEntryEOS = true;

--- a/thirdparty/libsimplewebm/WebMDemuxer.hpp
+++ b/thirdparty/libsimplewebm/WebMDemuxer.hpp
@@ -98,6 +98,7 @@ public:
 	int getChannels() const;
 	int getAudioDepth() const;
 
+	float seek(float p_time);
 	bool readFrame(WebMFrame *videoFrame, WebMFrame *audioFrame);
 
 private:
@@ -120,6 +121,8 @@ private:
 
 	bool m_isOpen;
 	bool m_eos;
+	bool m_isSeek;
+	float m_seekTime;
 };
 
 #endif // WEBMDEMUXER_HPP


### PR DESCRIPTION
Support webm video seeking operation with minimal modification. Currently, it only support 3.x version since master 4.0 version has abandoned webm format support.
```
Modified files:
1.modules/webm/video_stream_webm.cpp
2.thirdparty/libsimplewebm/WebMDemuxer.cpp
3.thirdparty/libsimplewebm/WebMDemuxer.hpp
```

https://user-images.githubusercontent.com/99071212/152667074-e226a8f6-b3d7-4ef0-b5af-31bec11eeb61.mp4

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
