### PR TITLE
Enhancements and fixes for `OptionButton` and `PopupMenu`

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -331,6 +331,13 @@
 				[b]Note:[/b] The indices of items after the removed item will be shifted by one.
 			</description>
 		</method>
+		<method name="scroll_to_item">
+			<return type="void" />
+			<argument index="0" name="index" type="int" />
+			<description>
+				Moves the scroll view to make the item at the given [code]index[/code] visible.
+			</description>
+		</method>
 		<method name="set_current_index">
 			<return type="void" />
 			<argument index="0" name="index" type="int" />

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -115,6 +115,11 @@ void OptionButton::_notification(int p_what) {
 bool OptionButton::_set(const StringName &p_name, const Variant &p_value) {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0] == "popup") {
+		String property = components[2];
+		if (property != "text" && property != "icon" && property != "id" && property != "disabled" && property != "separator") {
+			return false;
+		}
+
 		bool valid;
 		popup->set(String(p_name).trim_prefix("popup/"), p_value, &valid);
 
@@ -133,6 +138,11 @@ bool OptionButton::_set(const StringName &p_name, const Variant &p_value) {
 bool OptionButton::_get(const StringName &p_name, Variant &r_ret) const {
 	Vector<String> components = String(p_name).split("/", true, 2);
 	if (components.size() >= 2 && components[0] == "popup") {
+		String property = components[2];
+		if (property != "text" && property != "icon" && property != "id" && property != "disabled" && property != "separator") {
+			return false;
+		}
+
 		bool valid;
 		r_ret = popup->get(String(p_name).trim_prefix("popup/"), &valid);
 		return valid;
@@ -146,14 +156,6 @@ void OptionButton::_get_property_list(List<PropertyInfo> *p_list) const {
 
 		PropertyInfo pi = PropertyInfo(Variant::OBJECT, vformat("popup/item_%d/icon", i), PROPERTY_HINT_RESOURCE_TYPE, "Texture2D");
 		pi.usage &= ~(popup->get_item_icon(i).is_null() ? PROPERTY_USAGE_STORAGE : 0);
-		p_list->push_back(pi);
-
-		pi = PropertyInfo(Variant::INT, vformat("popup/item_%d/checkable", i), PROPERTY_HINT_ENUM, "No,As checkbox,As radio button");
-		pi.usage &= ~(!popup->is_item_checkable(i) ? PROPERTY_USAGE_STORAGE : 0);
-		p_list->push_back(pi);
-
-		pi = PropertyInfo(Variant::BOOL, vformat("popup/item_%d/checked", i));
-		pi.usage &= ~(!popup->is_item_checked(i) ? PROPERTY_USAGE_STORAGE : 0);
 		p_list->push_back(pi);
 
 		pi = PropertyInfo(Variant::INT, vformat("popup/item_%d/id", i), PROPERTY_HINT_RANGE, "0,10,1,or_greater");
@@ -183,10 +185,13 @@ void OptionButton::pressed() {
 	popup->set_size(Size2(size.width, 0));
 
 	// If not triggered by the mouse, start the popup with the checked item selected.
-	if (popup->get_item_count() > 0 &&
-			((get_action_mode() == ActionMode::ACTION_MODE_BUTTON_PRESS && Input::get_singleton()->is_action_just_pressed("ui_accept")) ||
-					(get_action_mode() == ActionMode::ACTION_MODE_BUTTON_RELEASE && Input::get_singleton()->is_action_just_released("ui_accept")))) {
-		popup->set_current_index(current > -1 ? current : 0);
+	if (popup->get_item_count() > 0) {
+		if ((get_action_mode() == ActionMode::ACTION_MODE_BUTTON_PRESS && Input::get_singleton()->is_action_just_pressed("ui_accept")) ||
+				(get_action_mode() == ActionMode::ACTION_MODE_BUTTON_RELEASE && Input::get_singleton()->is_action_just_released("ui_accept"))) {
+			popup->set_current_index(current > -1 ? current : 0);
+		} else {
+			popup->scroll_to_item(current > -1 ? current : 0);
+		}
 	}
 
 	popup->popup();
@@ -264,7 +269,20 @@ bool OptionButton::is_item_disabled(int p_idx) const {
 
 void OptionButton::set_item_count(int p_count) {
 	ERR_FAIL_COND(p_count < 0);
+
+	int count_old = get_item_count();
+	if (p_count == count_old) {
+		return;
+	}
+
 	popup->set_item_count(p_count);
+
+	if (p_count > count_old) {
+		for (int i = count_old; i < p_count; i++) {
+			popup->set_item_as_radio_checkable(i, true);
+		}
+	}
+
 	notify_property_list_changed();
 }
 
@@ -294,7 +312,7 @@ void OptionButton::_select(int p_which, bool p_emit) {
 
 		current = NONE_SELECTED;
 		set_text("");
-		set_icon(NULL);
+		set_icon(nullptr);
 	} else {
 		ERR_FAIL_INDEX(p_which, popup->get_item_count());
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -103,7 +103,6 @@ class PopupMenu : public Popup {
 
 	int _get_item_height(int p_item) const;
 	int _get_items_total_height() const;
-	void _scroll_to_item(int p_item);
 
 	void _shape_item(int p_item);
 
@@ -217,6 +216,8 @@ public:
 
 	void set_item_count(int p_count);
 	int get_item_count() const;
+
+	void scroll_to_item(int p_item);
 
 	bool activate_item_by_event(const Ref<InputEvent> &p_event, bool p_for_global_only = false);
 	void activate_item(int p_item);


### PR DESCRIPTION
This PR improves some aspects of `OptionButton`, firstly making that the items that appear in the item list expose only the properties that make sense for it:

|Before:|After:|
|---|---|
|![Screenshot_20220206_004951](https://user-images.githubusercontent.com/30739239/152667076-a673aab0-f703-4bf9-96fc-8e2b9f5518c7.png)|![Screenshot_20220205_235532](https://user-images.githubusercontent.com/30739239/152667079-c09a4ea1-bb0f-471e-a798-b4b99394727c.png)|

It also makes all items be radio items by default.

This PR also makes that so that opening the menu always scrolls to the selected item (when before in my previous PR, it only did that when opening it without using the mouse). To accomplish that, I needed to make `PopupMenu`'s `_scroll_to_item()` public, so I took the opportunity to expose it as well.

By doing that, I discovered that item scrolling was broken when it need to scroll up. This PR fixes that too.