### PR TITLE
Rename translate(d) to translate(d)_local in Transform 2D/3D

### DIFF
--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -136,11 +136,11 @@ void Transform2D::scale_basis(const Size2 &p_scale) {
 	columns[1][1] *= p_scale.y;
 }
 
-void Transform2D::translate(const real_t p_tx, const real_t p_ty) {
-	translate(Vector2(p_tx, p_ty));
+void Transform2D::translate_local(const real_t p_tx, const real_t p_ty) {
+	translate_local(Vector2(p_tx, p_ty));
 }
 
-void Transform2D::translate(const Vector2 &p_translation) {
+void Transform2D::translate_local(const Vector2 &p_translation) {
 	columns[2] += basis_xform(p_translation);
 }
 
@@ -235,9 +235,9 @@ Transform2D Transform2D::untranslated() const {
 	return copy;
 }
 
-Transform2D Transform2D::translated(const Vector2 &p_offset) const {
+Transform2D Transform2D::translated_local(const Vector2 &p_offset) const {
 	Transform2D copy = *this;
-	copy.translate(p_offset);
+	copy.translate_local(p_offset);
 	return copy;
 }
 

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -74,8 +74,8 @@ struct _NO_DISCARD_ Transform2D {
 
 	void scale(const Size2 &p_scale);
 	void scale_basis(const Size2 &p_scale);
-	void translate(const real_t p_tx, const real_t p_ty);
-	void translate(const Vector2 &p_translation);
+	void translate_local(const real_t p_tx, const real_t p_ty);
+	void translate_local(const Vector2 &p_translation);
 
 	real_t basis_determinant() const;
 
@@ -87,7 +87,7 @@ struct _NO_DISCARD_ Transform2D {
 
 	Transform2D scaled(const Size2 &p_scale) const;
 	Transform2D basis_scaled(const Size2 &p_scale) const;
-	Transform2D translated(const Vector2 &p_offset) const;
+	Transform2D translated_local(const Vector2 &p_offset) const;
 	Transform2D rotated(const real_t p_angle) const;
 
 	Transform2D untranslated() const;

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -123,19 +123,19 @@ void Transform3D::scale_basis(const Vector3 &p_scale) {
 	basis.scale(p_scale);
 }
 
-void Transform3D::translate(real_t p_tx, real_t p_ty, real_t p_tz) {
-	translate(Vector3(p_tx, p_ty, p_tz));
+void Transform3D::translate_local(real_t p_tx, real_t p_ty, real_t p_tz) {
+	translate_local(Vector3(p_tx, p_ty, p_tz));
 }
 
-void Transform3D::translate(const Vector3 &p_translation) {
+void Transform3D::translate_local(const Vector3 &p_translation) {
 	for (int i = 0; i < 3; i++) {
 		origin[i] += basis[i].dot(p_translation);
 	}
 }
 
-Transform3D Transform3D::translated(const Vector3 &p_translation) const {
+Transform3D Transform3D::translated_local(const Vector3 &p_translation) const {
 	Transform3D t = *this;
-	t.translate(p_translation);
+	t.translate_local(p_translation);
 	return t;
 }
 

--- a/core/math/transform_3d.h
+++ b/core/math/transform_3d.h
@@ -56,9 +56,9 @@ struct _NO_DISCARD_ Transform3D {
 	void scale(const Vector3 &p_scale);
 	Transform3D scaled(const Vector3 &p_scale) const;
 	void scale_basis(const Vector3 &p_scale);
-	void translate(real_t p_tx, real_t p_ty, real_t p_tz);
-	void translate(const Vector3 &p_translation);
-	Transform3D translated(const Vector3 &p_translation) const;
+	void translate_local(real_t p_tx, real_t p_ty, real_t p_tz);
+	void translate_local(const Vector3 &p_translation);
+	Transform3D translated_local(const Vector3 &p_translation) const;
 
 	const Basis &get_basis() const { return basis; }
 	void set_basis(const Basis &p_basis) { basis = p_basis; }

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1854,7 +1854,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform2D, orthonormalized, sarray(), varray());
 	bind_method(Transform2D, rotated, sarray("angle"), varray());
 	bind_method(Transform2D, scaled, sarray("scale"), varray());
-	bind_method(Transform2D, translated, sarray("offset"), varray());
+	bind_method(Transform2D, translated_local, sarray("offset"), varray());
 	bind_method(Transform2D, basis_xform, sarray("v"), varray());
 	bind_method(Transform2D, basis_xform_inv, sarray("v"), varray());
 	bind_method(Transform2D, interpolate_with, sarray("xform", "weight"), varray());
@@ -1919,7 +1919,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Transform3D, orthonormalized, sarray(), varray());
 	bind_method(Transform3D, rotated, sarray("axis", "angle"), varray());
 	bind_method(Transform3D, scaled, sarray("scale"), varray());
-	bind_method(Transform3D, translated, sarray("offset"), varray());
+	bind_method(Transform3D, translated_local, sarray("offset"), varray());
 	bind_method(Transform3D, looking_at, sarray("target", "up"), varray(Vector3(0, 1, 0)));
 	bind_method(Transform3D, sphere_interpolate_with, sarray("xform", "weight"), varray());
 	bind_method(Transform3D, interpolate_with, sarray("xform", "weight"), varray());

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -173,7 +173,7 @@
 				Sets the transform's skew (in radians).
 			</description>
 		</method>
-		<method name="translated" qualifiers="const">
+		<method name="translated_local" qualifiers="const">
 			<return type="Transform2D" />
 			<argument index="0" name="offset" type="Vector2" />
 			<description>

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -114,7 +114,7 @@
 				Returns a transform spherically interpolated between this transform and another by a given [code]weight[/code] (on the range of 0.0 to 1.0).
 			</description>
 		</method>
-		<method name="translated" qualifiers="const">
+		<method name="translated_local" qualifiers="const">
 			<return type="Transform3D" />
 			<argument index="0" name="offset" type="Vector3" />
 			<description>

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -135,7 +135,7 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 		Size2i ssize = texture_storage->render_target_get_size(p_to_render_target);
 
 		Transform3D screen_transform;
-		screen_transform.translate(-(ssize.width / 2.0f), -(ssize.height / 2.0f), 0.0f);
+		screen_transform.translate_local(-(ssize.width / 2.0f), -(ssize.height / 2.0f), 0.0f);
 		screen_transform.scale(Vector3(2.0f / ssize.width, 2.0f / ssize.height, 1.0f));
 		_update_transform_to_mat4(screen_transform, state_buffer.screen_transform);
 		_update_transform_2d_to_mat4(p_canvas_transform, state_buffer.canvas_transform);

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -502,7 +502,7 @@ void SceneImportSettings::_update_camera() {
 	Transform3D xf;
 	xf.basis = Basis(Vector3(1, 0, 0), rot_x) * Basis(Vector3(0, 1, 0), rot_y);
 	xf.origin = center;
-	xf.translate(0, 0, camera_size);
+	xf.translate_local(0, 0, camera_size);
 
 	camera->set_transform(xf);
 }

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2792,10 +2792,10 @@ void CanvasItemEditor::_draw_rulers() {
 	if (grid_snap_active || _is_grid_visible()) {
 		List<CanvasItem *> selection = _get_edited_canvas_items();
 		if (snap_relative && selection.size() > 0) {
-			ruler_transform.translate(_get_encompassing_rect_from_list(selection).position);
+			ruler_transform.translate_local(_get_encompassing_rect_from_list(selection).position);
 			ruler_transform.scale_basis(grid_step * Math::pow(2.0, grid_step_multiplier));
 		} else {
-			ruler_transform.translate(grid_offset);
+			ruler_transform.translate_local(grid_offset);
 			ruler_transform.scale_basis(grid_step * Math::pow(2.0, grid_step_multiplier));
 		}
 		while ((transform * ruler_transform).get_scale().x < 50 || (transform * ruler_transform).get_scale().y < 50) {

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -542,11 +542,11 @@ void CurveEditor::update_view_transform() {
 	const Vector2 scale = view_size / world_rect.size;
 
 	Transform2D world_trans;
-	world_trans.translate(-world_rect.position - Vector2(0, world_rect.size.y));
+	world_trans.translate_local(-world_rect.position - Vector2(0, world_rect.size.y));
 	world_trans.scale(Vector2(scale.x, -scale.y));
 
 	Transform2D view_trans;
-	view_trans.translate(view_margin);
+	view_trans.translate_local(view_margin);
 
 	_world_to_view = view_trans * world_trans;
 }

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -5044,8 +5044,8 @@ Basis JointGizmosDrawer::look_body_toward_z(const Transform3D &p_joint_transform
 
 void JointGizmosDrawer::draw_circle(Vector3::Axis p_axis, real_t p_radius, const Transform3D &p_offset, const Basis &p_base, real_t p_limit_lower, real_t p_limit_upper, Vector<Vector3> &r_points, bool p_inverse) {
 	if (p_limit_lower == p_limit_upper) {
-		r_points.push_back(p_offset.translated(Vector3()).origin);
-		r_points.push_back(p_offset.translated(p_base.xform(Vector3(0.5, 0, 0))).origin);
+		r_points.push_back(p_offset.translated_local(Vector3()).origin);
+		r_points.push_back(p_offset.translated_local(p_base.xform(Vector3(0.5, 0, 0))).origin);
 
 	} else {
 		if (p_limit_lower > p_limit_upper) {
@@ -5087,20 +5087,20 @@ void JointGizmosDrawer::draw_circle(Vector3::Axis p_axis, real_t p_radius, const
 			}
 
 			if (i == points - 1) {
-				r_points.push_back(p_offset.translated(to).origin);
-				r_points.push_back(p_offset.translated(Vector3()).origin);
+				r_points.push_back(p_offset.translated_local(to).origin);
+				r_points.push_back(p_offset.translated_local(Vector3()).origin);
 			}
 			if (i == 0) {
-				r_points.push_back(p_offset.translated(from).origin);
-				r_points.push_back(p_offset.translated(Vector3()).origin);
+				r_points.push_back(p_offset.translated_local(from).origin);
+				r_points.push_back(p_offset.translated_local(Vector3()).origin);
 			}
 
-			r_points.push_back(p_offset.translated(from).origin);
-			r_points.push_back(p_offset.translated(to).origin);
+			r_points.push_back(p_offset.translated_local(from).origin);
+			r_points.push_back(p_offset.translated_local(to).origin);
 		}
 
-		r_points.push_back(p_offset.translated(Vector3(0, p_radius * 1.5, 0)).origin);
-		r_points.push_back(p_offset.translated(Vector3()).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(0, p_radius * 1.5, 0)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3()).origin);
 	}
 }
 
@@ -5116,17 +5116,17 @@ void JointGizmosDrawer::draw_cone(const Transform3D &p_offset, const Basis &p_ba
 		Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * w;
 		Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * w;
 
-		r_points.push_back(p_offset.translated(p_base.xform(Vector3(d, a.x, a.y))).origin);
-		r_points.push_back(p_offset.translated(p_base.xform(Vector3(d, b.x, b.y))).origin);
+		r_points.push_back(p_offset.translated_local(p_base.xform(Vector3(d, a.x, a.y))).origin);
+		r_points.push_back(p_offset.translated_local(p_base.xform(Vector3(d, b.x, b.y))).origin);
 
 		if (i % 90 == 0) {
-			r_points.push_back(p_offset.translated(p_base.xform(Vector3(d, a.x, a.y))).origin);
-			r_points.push_back(p_offset.translated(p_base.xform(Vector3())).origin);
+			r_points.push_back(p_offset.translated_local(p_base.xform(Vector3(d, a.x, a.y))).origin);
+			r_points.push_back(p_offset.translated_local(p_base.xform(Vector3())).origin);
 		}
 	}
 
-	r_points.push_back(p_offset.translated(p_base.xform(Vector3())).origin);
-	r_points.push_back(p_offset.translated(p_base.xform(Vector3(1, 0, 0))).origin);
+	r_points.push_back(p_offset.translated_local(p_base.xform(Vector3())).origin);
+	r_points.push_back(p_offset.translated_local(p_base.xform(Vector3(1, 0, 0))).origin);
 
 	/// Twist
 	float ts = Math::rad2deg(p_twist);
@@ -5140,8 +5140,8 @@ void JointGizmosDrawer::draw_cone(const Transform3D &p_offset, const Basis &p_ba
 		Point2 a = Vector2(Math::sin(ra), Math::cos(ra)) * w * c;
 		Point2 b = Vector2(Math::sin(rb), Math::cos(rb)) * w * cn;
 
-		r_points.push_back(p_offset.translated(p_base.xform(Vector3(c, a.x, a.y))).origin);
-		r_points.push_back(p_offset.translated(p_base.xform(Vector3(cn, b.x, b.y))).origin);
+		r_points.push_back(p_offset.translated_local(p_base.xform(Vector3(c, a.x, a.y))).origin);
+		r_points.push_back(p_offset.translated_local(p_base.xform(Vector3(cn, b.x, b.y))).origin);
 	}
 }
 
@@ -5325,17 +5325,17 @@ void Joint3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 void Joint3DGizmoPlugin::CreatePinJointGizmo(const Transform3D &p_offset, Vector<Vector3> &r_cursor_points) {
 	float cs = 0.25;
 
-	r_cursor_points.push_back(p_offset.translated(Vector3(+cs, 0, 0)).origin);
-	r_cursor_points.push_back(p_offset.translated(Vector3(-cs, 0, 0)).origin);
-	r_cursor_points.push_back(p_offset.translated(Vector3(0, +cs, 0)).origin);
-	r_cursor_points.push_back(p_offset.translated(Vector3(0, -cs, 0)).origin);
-	r_cursor_points.push_back(p_offset.translated(Vector3(0, 0, +cs)).origin);
-	r_cursor_points.push_back(p_offset.translated(Vector3(0, 0, -cs)).origin);
+	r_cursor_points.push_back(p_offset.translated_local(Vector3(+cs, 0, 0)).origin);
+	r_cursor_points.push_back(p_offset.translated_local(Vector3(-cs, 0, 0)).origin);
+	r_cursor_points.push_back(p_offset.translated_local(Vector3(0, +cs, 0)).origin);
+	r_cursor_points.push_back(p_offset.translated_local(Vector3(0, -cs, 0)).origin);
+	r_cursor_points.push_back(p_offset.translated_local(Vector3(0, 0, +cs)).origin);
+	r_cursor_points.push_back(p_offset.translated_local(Vector3(0, 0, -cs)).origin);
 }
 
 void Joint3DGizmoPlugin::CreateHingeJointGizmo(const Transform3D &p_offset, const Transform3D &p_trs_joint, const Transform3D &p_trs_body_a, const Transform3D &p_trs_body_b, real_t p_limit_lower, real_t p_limit_upper, bool p_use_limit, Vector<Vector3> &r_common_points, Vector<Vector3> *r_body_a_points, Vector<Vector3> *r_body_b_points) {
-	r_common_points.push_back(p_offset.translated(Vector3(0, 0, 0.5)).origin);
-	r_common_points.push_back(p_offset.translated(Vector3(0, 0, -0.5)).origin);
+	r_common_points.push_back(p_offset.translated_local(Vector3(0, 0, 0.5)).origin);
+	r_common_points.push_back(p_offset.translated_local(Vector3(0, 0, -0.5)).origin);
 
 	if (!p_use_limit) {
 		p_limit_upper = -1;
@@ -5368,34 +5368,34 @@ void Joint3DGizmoPlugin::CreateSliderJointGizmo(const Transform3D &p_offset, con
 	p_linear_limit_upper = -p_linear_limit_upper;
 
 	float cs = 0.25;
-	r_points.push_back(p_offset.translated(Vector3(0, 0, 0.5)).origin);
-	r_points.push_back(p_offset.translated(Vector3(0, 0, -0.5)).origin);
+	r_points.push_back(p_offset.translated_local(Vector3(0, 0, 0.5)).origin);
+	r_points.push_back(p_offset.translated_local(Vector3(0, 0, -0.5)).origin);
 
 	if (p_linear_limit_lower >= p_linear_limit_upper) {
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_upper, 0, 0)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_lower, 0, 0)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_upper, 0, 0)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_lower, 0, 0)).origin);
 
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_upper, -cs, -cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_upper, -cs, cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_upper, -cs, cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_upper, cs, cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_upper, cs, cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_upper, cs, -cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_upper, cs, -cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_upper, -cs, -cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_upper, -cs, -cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_upper, -cs, cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_upper, -cs, cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_upper, cs, cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_upper, cs, cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_upper, cs, -cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_upper, cs, -cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_upper, -cs, -cs)).origin);
 
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_lower, -cs, -cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_lower, -cs, cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_lower, -cs, cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_lower, cs, cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_lower, cs, cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_lower, cs, -cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_lower, cs, -cs)).origin);
-		r_points.push_back(p_offset.translated(Vector3(p_linear_limit_lower, -cs, -cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_lower, -cs, -cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_lower, -cs, cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_lower, -cs, cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_lower, cs, cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_lower, cs, cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_lower, cs, -cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_lower, cs, -cs)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(p_linear_limit_lower, -cs, -cs)).origin);
 
 	} else {
-		r_points.push_back(p_offset.translated(Vector3(+cs * 2, 0, 0)).origin);
-		r_points.push_back(p_offset.translated(Vector3(-cs * 2, 0, 0)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(+cs * 2, 0, 0)).origin);
+		r_points.push_back(p_offset.translated_local(Vector3(-cs * 2, 0, 0)).origin);
 	}
 
 	if (r_body_a_points) {
@@ -5518,13 +5518,13 @@ void Joint3DGizmoPlugin::CreateGeneric6DOFJointGizmo(
 				break;
 		}
 
-#define ADD_VTX(x, y, z)                                   \
-	{                                                      \
-		Vector3 v;                                         \
-		v[a1] = (x);                                       \
-		v[a2] = (y);                                       \
-		v[a3] = (z);                                       \
-		r_points.push_back(p_offset.translated(v).origin); \
+#define ADD_VTX(x, y, z)                                         \
+	{                                                            \
+		Vector3 v;                                               \
+		v[a1] = (x);                                             \
+		v[a2] = (y);                                             \
+		v[a3] = (z);                                             \
+		r_points.push_back(p_offset.translated_local(v).origin); \
 	}
 
 		if (enable_lin && lll >= lul) {

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -355,14 +355,14 @@ void Node3DEditorViewport::_update_camera(real_t p_interp_delta) {
 
 Transform3D Node3DEditorViewport::to_camera_transform(const Cursor &p_cursor) const {
 	Transform3D camera_transform;
-	camera_transform.translate(p_cursor.pos);
+	camera_transform.translate_local(p_cursor.pos);
 	camera_transform.basis.rotate(Vector3(1, 0, 0), -p_cursor.x_rot);
 	camera_transform.basis.rotate(Vector3(0, 1, 0), -p_cursor.y_rot);
 
 	if (orthogonal) {
-		camera_transform.translate(0, 0, (get_zfar() - get_znear()) / 2.0);
+		camera_transform.translate_local(0, 0, (get_zfar() - get_znear()) / 2.0);
 	} else {
-		camera_transform.translate(0, 0, p_cursor.distance);
+		camera_transform.translate_local(0, 0, p_cursor.distance);
 	}
 
 	return camera_transform;
@@ -650,10 +650,10 @@ Vector3 Node3DEditorViewport::_get_screen_to_space(const Vector3 &p_vector3) {
 	Vector2 screen_he = cm.get_viewport_half_extents();
 
 	Transform3D camera_transform;
-	camera_transform.translate(cursor.pos);
+	camera_transform.translate_local(cursor.pos);
 	camera_transform.basis.rotate(Vector3(1, 0, 0), -cursor.x_rot);
 	camera_transform.basis.rotate(Vector3(0, 1, 0), -cursor.y_rot);
-	camera_transform.translate(0, 0, cursor.distance);
+	camera_transform.translate_local(0, 0, cursor.distance);
 
 	return camera_transform.xform(Vector3(((p_vector3.x / get_size().width) * 2.0 - 1.0) * screen_he.x, ((1.0 - (p_vector3.y / get_size().height)) * 2.0 - 1.0) * screen_he.y, -(get_znear() + p_vector3.z)));
 }
@@ -2099,7 +2099,7 @@ void Node3DEditorViewport::_nav_pan(Ref<InputEventWithModifiers> p_event, const 
 
 	Transform3D camera_transform;
 
-	camera_transform.translate(cursor.pos);
+	camera_transform.translate_local(cursor.pos);
 	camera_transform.basis.rotate(Vector3(1, 0, 0), -cursor.x_rot);
 	camera_transform.basis.rotate(Vector3(0, 1, 0), -cursor.y_rot);
 	const bool invert_x_axis = EditorSettings::get_singleton()->get("editors/3d/navigation/invert_x_axis");
@@ -2109,7 +2109,7 @@ void Node3DEditorViewport::_nav_pan(Ref<InputEventWithModifiers> p_event, const 
 			(invert_y_axis ? -1 : 1) * p_relative.y * pan_speed,
 			0);
 	translation *= cursor.distance / DISTANCE_DEFAULT;
-	camera_transform.translate(translation);
+	camera_transform.translate_local(translation);
 	cursor.pos = camera_transform.origin;
 }
 
@@ -2519,14 +2519,14 @@ void Node3DEditorViewport::_notification(int p_what) {
 					const Vector3 offset(0.005, 0.005, 0.005);
 					Basis aabb_s;
 					aabb_s.scale(se->aabb.size + offset);
-					t.translate(se->aabb.position - offset / 2);
+					t.translate_local(se->aabb.position - offset / 2);
 					t.basis = t.basis * aabb_s;
 				}
 				{
 					const Vector3 offset(0.01, 0.01, 0.01);
 					Basis aabb_s;
 					aabb_s.scale(se->aabb.size + offset);
-					t_offset.translate(se->aabb.position - offset / 2);
+					t_offset.translate_local(se->aabb.position - offset / 2);
 					t_offset.basis = t_offset.basis * aabb_s;
 				}
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -1822,7 +1822,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_unscaled_draw() {
 			Vector2i position = texture_region.get_center() + tile_set_atlas_source->get_tile_effective_texture_offset(coords, 0);
 
 			Transform2D xform = tile_atlas_control->get_parent_control()->get_transform();
-			xform.translate(position);
+			xform.translate_local(position);
 
 			if (tools_button_group->get_pressed_button() == tool_select_button && selection.has({ coords, 0 })) {
 				continue;
@@ -1845,7 +1845,7 @@ void TileSetAtlasSourceEditor::_tile_atlas_control_unscaled_draw() {
 				Vector2i position = texture_region.get_center() + tile_set_atlas_source->get_tile_effective_texture_offset(E.tile, 0);
 
 				Transform2D xform = tile_atlas_control->get_parent_control()->get_transform();
-				xform.translate(position);
+				xform.translate_local(position);
 
 				TileMapCell cell;
 				cell.source_id = tile_set_atlas_source_id;
@@ -1989,7 +1989,7 @@ void TileSetAtlasSourceEditor::_tile_alternatives_control_unscaled_draw() {
 				Vector2 position = rect.get_center();
 
 				Transform2D xform = alternative_tiles_control->get_parent_control()->get_transform();
-				xform.translate(position);
+				xform.translate_local(position);
 
 				if (tools_button_group->get_pressed_button() == tool_select_button && selection.has({ coords, alternative_tile })) {
 					continue;
@@ -2013,7 +2013,7 @@ void TileSetAtlasSourceEditor::_tile_alternatives_control_unscaled_draw() {
 				Vector2 position = rect.get_center();
 
 				Transform2D xform = alternative_tiles_control->get_parent_control()->get_transform();
-				xform.translate(position);
+				xform.translate_local(position);
 
 				TileMapCell cell;
 				cell.source_id = tile_set_atlas_source_id;

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1858,7 +1858,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 			}
 
 			Transform3D facing = Transform3D().looking_at(direction, current_up);
-			current_xform = base_xform.translated(current_point) * facing;
+			current_xform = base_xform.translated_local(current_point) * facing;
 		}
 
 		// Create the mesh.
@@ -1897,7 +1897,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 
 			switch (mode) {
 				case MODE_DEPTH: {
-					current_xform.translate(Vector3(0, 0, -depth));
+					current_xform.translate_local(Vector3(0, 0, -depth));
 				} break;
 				case MODE_SPIN: {
 					current_xform.rotate(Vector3(0, 1, 0), spin_step);
@@ -1945,7 +1945,7 @@ CSGBrush *CSGPolygon3D::_build_brush() {
 					}
 
 					Transform3D facing = Transform3D().looking_at(direction, current_up);
-					current_xform = base_xform.translated(current_point) * facing;
+					current_xform = base_xform.translated_local(current_point) * facing;
 				} break;
 			}
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -545,7 +545,7 @@ void GridMapEditor::_update_paste_indicator() {
 	Basis rot;
 	rot.set_orthogonal_index(paste_indicator.orientation);
 	xf.basis = rot * xf.basis;
-	xf.translate((-center * node->get_cell_size()) / scale);
+	xf.translate_local((-center * node->get_cell_size()) / scale);
 
 	RenderingServer::get_singleton()->instance_set_transform(paste_instance, node->get_global_transform() * xf);
 
@@ -553,7 +553,7 @@ void GridMapEditor::_update_paste_indicator() {
 		xf = Transform3D();
 		xf.origin = (paste_indicator.begin + (paste_indicator.current - paste_indicator.click) + center) * node->get_cell_size();
 		xf.basis = rot * xf.basis;
-		xf.translate(item.grid_offset * node->get_cell_size());
+		xf.translate_local(item.grid_offset * node->get_cell_size());
 
 		Basis item_rot;
 		item_rot.set_orthogonal_index(item.orientation);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform2D.cs
@@ -347,7 +347,7 @@ namespace Godot
         /// </summary>
         /// <param name="offset">The offset to translate by.</param>
         /// <returns>The translated matrix.</returns>
-        public Transform2D Translated(Vector2 offset)
+        public Transform2D TranslatedLocal(Vector2 offset)
         {
             Transform2D copy = this;
             copy.origin += copy.BasisXform(offset);

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Transform3D.cs
@@ -239,7 +239,7 @@ namespace Godot
         /// </summary>
         /// <param name="offset">The offset to translate by.</param>
         /// <returns>The translated matrix.</returns>
-        public Transform3D Translated(Vector3 offset)
+        public Transform3D TranslatedLocal(Vector3 offset)
         {
             return new Transform3D(basis, new Vector3
             (

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -240,7 +240,7 @@ void RayCast2D::_draw_debug_shape() {
 
 	Transform2D xf;
 	xf.rotate(target_position.angle());
-	xf.translate(Vector2(no_line ? 0 : target_position.length() - arrow_size, 0));
+	xf.translate_local(Vector2(no_line ? 0 : target_position.length() - arrow_size, 0));
 
 	Vector<Vector2> pts = {
 		xf.xform(Vector2(arrow_size, 0)),

--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -237,7 +237,7 @@ void ShapeCast2D::_notification(int p_what) {
 			if (target_position != Vector2()) {
 				Transform2D xf;
 				xf.rotate(target_position.angle());
-				xf.translate(Vector2(target_position.length(), 0));
+				xf.translate_local(Vector2(target_position.length(), 0));
 
 				draw_line(Vector2(), target_position, draw_col, 2);
 

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -131,7 +131,7 @@ void TouchScreenButton::_notification(int p_what) {
 					pos = texture_normal->get_size() * 0.5;
 				}
 
-				draw_set_transform_matrix(get_canvas_transform().translated(pos));
+				draw_set_transform_matrix(get_canvas_transform().translated_local(pos));
 				shape->draw(get_canvas_item(), draw_col);
 			}
 		} break;
@@ -258,7 +258,7 @@ bool TouchScreenButton::_is_point_inside(const Point2 &p_point) {
 			pos = texture_normal->get_size() * 0.5;
 		}
 
-		touched = shape->collide(Transform2D().translated(pos), unit_rect, Transform2D(0, coord + Vector2(0.5, 0.5)));
+		touched = shape->collide(Transform2D().translated_local(pos), unit_rect, Transform2D(0, coord + Vector2(0.5, 0.5)));
 	}
 
 	if (bitmask.is_valid()) {

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -733,7 +733,7 @@ void Node3D::rotate_z(real_t p_angle) {
 
 void Node3D::translate(const Vector3 &p_offset) {
 	Transform3D t = get_transform();
-	t.translate(p_offset);
+	t.translate_local(p_offset);
 	set_transform(t);
 }
 
@@ -741,7 +741,7 @@ void Node3D::translate_object_local(const Vector3 &p_offset) {
 	Transform3D t = get_transform();
 
 	Transform3D s;
-	s.translate(p_offset);
+	s.translate_local(p_offset);
 	set_transform(t * s);
 }
 

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -296,7 +296,7 @@ void PathFollow3D::_update_transform(bool p_update_xyz_rot) {
 			}
 		}
 
-		t.translate(Vector3(h_offset, v_offset, 0));
+		t.translate_local(Vector3(h_offset, v_offset, 0));
 	} else {
 		t.origin = pos + Vector3(h_offset, v_offset, 0);
 	}

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1516,7 +1516,7 @@ void Window::_validate_property(PropertyInfo &property) const {
 Transform2D Window::get_screen_transform() const {
 	Transform2D embedder_transform = Transform2D();
 	if (_get_embedder()) {
-		embedder_transform.translate(get_position());
+		embedder_transform.translate_local(get_position());
 		embedder_transform = _get_embedder()->get_screen_transform() * embedder_transform;
 	}
 	return embedder_transform * Viewport::get_screen_transform();

--- a/scene/resources/separation_ray_shape_2d.cpp
+++ b/scene/resources/separation_ray_shape_2d.cpp
@@ -57,7 +57,7 @@ void SeparationRayShape2D::draw(const RID &p_to_rid, const Color &p_color) {
 
 	Transform2D xf;
 	xf.rotate(target_position.angle());
-	xf.translate(Vector2(no_line ? 0 : target_position.length() - arrow_size, 0));
+	xf.translate_local(Vector2(no_line ? 0 : target_position.length() - arrow_size, 0));
 
 	Vector<Vector2> pts = {
 		xf.xform(Vector2(arrow_size, 0)),

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1304,7 +1304,7 @@ void RendererCanvasRenderRD::canvas_render_items(RID p_to_render_target, Item *p
 		Size2i ssize = texture_storage->render_target_get_size(p_to_render_target);
 
 		Transform3D screen_transform;
-		screen_transform.translate(-(ssize.width / 2.0f), -(ssize.height / 2.0f), 0.0f);
+		screen_transform.translate_local(-(ssize.width / 2.0f), -(ssize.height / 2.0f), 0.0f);
 		screen_transform.scale(Vector3(2.0f / ssize.width, 2.0f / ssize.height, 1.0f));
 		_update_transform_to_mat4(screen_transform, state_buffer.screen_transform);
 		_update_transform_2d_to_mat4(p_canvas_transform, state_buffer.canvas_transform);


### PR DESCRIPTION
This is an accompanying PR for #55923 / https://github.com/godotengine/godot-proposals/issues/1336.

It isolates the renaming for `translated` to `translated_local` (and in-place versions) without re-adding the same function with the new global semantics in the same PR to ensure that we have refactored 100% of occurrences if CI passes. This PR does nothing else.

If we want to move forwards with #55923 the idea would be to merge this PR first, and then I'll rebase the other PR, which adds all remaining variants of translated/scaled/rotated. This will simplify the other diff and should make its review more convenient.