### PR TITLE
Float literals - fix main primitives to use .f

### DIFF
--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -119,7 +119,7 @@ struct _NO_DISCARD_ AABB {
 	}
 
 	_FORCE_INLINE_ Vector3 get_center() const {
-		return position + (size * 0.5);
+		return position + (size * 0.5f);
 	}
 
 	operator String() const;
@@ -208,7 +208,7 @@ inline bool AABB::encloses(const AABB &p_aabb) const {
 }
 
 Vector3 AABB::get_support(const Vector3 &p_normal) const {
-	Vector3 half_extents = size * 0.5;
+	Vector3 half_extents = size * 0.5f;
 	Vector3 ofs = position + half_extents;
 
 	return Vector3(
@@ -242,7 +242,7 @@ Vector3 AABB::get_endpoint(int p_point) const {
 }
 
 bool AABB::intersects_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count) const {
-	Vector3 half_extents = size * 0.5;
+	Vector3 half_extents = size * 0.5f;
 	Vector3 ofs = position + half_extents;
 
 	for (int i = 0; i < p_plane_count; i++) {
@@ -284,7 +284,7 @@ bool AABB::intersects_convex_shape(const Plane *p_planes, int p_plane_count, con
 }
 
 bool AABB::inside_convex_shape(const Plane *p_planes, int p_plane_count) const {
-	Vector3 half_extents = size * 0.5;
+	Vector3 half_extents = size * 0.5f;
 	Vector3 ofs = position + half_extents;
 
 	for (int i = 0; i < p_plane_count; i++) {
@@ -364,7 +364,7 @@ inline void AABB::expand_to(const Vector3 &p_vector) {
 }
 
 void AABB::project_range_in_plane(const Plane &p_plane, real_t &r_min, real_t &r_max) const {
-	Vector3 half_extents(size.x * 0.5, size.y * 0.5, size.z * 0.5);
+	Vector3 half_extents(size.x * 0.5f, size.y * 0.5f, size.z * 0.5f);
 	Vector3 center(position.x + half_extents.x, position.y + half_extents.y, position.z + half_extents.z);
 
 	real_t length = p_plane.normal.abs().dot(half_extents);
@@ -407,9 +407,9 @@ bool AABB::smits_intersect_ray(const Vector3 &p_from, const Vector3 &p_dir, real
 		ERR_PRINT("AABB size is negative, this is not supported. Use AABB.abs() to get an AABB with a positive size.");
 	}
 #endif
-	real_t divx = 1.0 / p_dir.x;
-	real_t divy = 1.0 / p_dir.y;
-	real_t divz = 1.0 / p_dir.z;
+	real_t divx = 1.0f / p_dir.x;
+	real_t divy = 1.0f / p_dir.y;
+	real_t divz = 1.0f / p_dir.z;
 
 	Vector3 upbound = position + size;
 	real_t tmin, tmax, tymin, tymax, tzmin, tzmax;
@@ -459,9 +459,9 @@ void AABB::grow_by(real_t p_amount) {
 	position.x -= p_amount;
 	position.y -= p_amount;
 	position.z -= p_amount;
-	size.x += 2.0 * p_amount;
-	size.y += 2.0 * p_amount;
-	size.z += 2.0 * p_amount;
+	size.x += 2.0f * p_amount;
+	size.y += 2.0f * p_amount;
+	size.z += 2.0f * p_amount;
 }
 
 void AABB::quantize(real_t p_unit) {

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -40,13 +40,13 @@ void Basis::from_z(const Vector3 &p_z) {
 	if (Math::abs(p_z.z) > Math_SQRT12) {
 		// choose p in y-z plane
 		real_t a = p_z[1] * p_z[1] + p_z[2] * p_z[2];
-		real_t k = 1.0 / Math::sqrt(a);
+		real_t k = 1.0f / Math::sqrt(a);
 		elements[0] = Vector3(0, -p_z[2] * k, p_z[1] * k);
 		elements[1] = Vector3(a * k, -p_z[0] * elements[0][2], p_z[0] * elements[0][1]);
 	} else {
 		// choose p in x-y plane
 		real_t a = p_z.x * p_z.x + p_z.y * p_z.y;
-		real_t k = 1.0 / Math::sqrt(a);
+		real_t k = 1.0f / Math::sqrt(a);
 		elements[0] = Vector3(-p_z.y * k, p_z.x * k, 0);
 		elements[1] = Vector3(-p_z.z * elements[0].y, p_z.z * elements[0].x, a * k);
 	}
@@ -63,7 +63,7 @@ void Basis::invert() {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND(det == 0);
 #endif
-	real_t s = 1.0 / det;
+	real_t s = 1.0f / det;
 
 	set(co[0] * s, cofac(0, 2, 2, 1) * s, cofac(0, 1, 1, 2) * s,
 			co[1] * s, cofac(0, 0, 2, 2) * s, cofac(0, 2, 1, 0) * s,
@@ -182,7 +182,7 @@ Basis Basis::diagonalize() {
 		if (Math::is_equal_approx(elements[j][j], elements[i][i])) {
 			angle = Math_PI / 4;
 		} else {
-			angle = 0.5 * Math::atan(2 * elements[i][j] / (elements[j][j] - elements[i][i]));
+			angle = 0.5f * Math::atan(2 * elements[i][j] / (elements[j][j] - elements[i][i]));
 		}
 
 		// Compute the rotation matrix
@@ -268,11 +268,11 @@ Basis Basis::scaled_orthogonal(const Vector3 &p_scale) const {
 }
 
 float Basis::get_uniform_scale() const {
-	return (elements[0].length() + elements[1].length() + elements[2].length()) / 3.0;
+	return (elements[0].length() + elements[1].length() + elements[2].length()) / 3.0f;
 }
 
 void Basis::make_scale_uniform() {
-	float l = (elements[0].length() + elements[1].length() + elements[2].length()) / 3.0;
+	float l = (elements[0].length() + elements[1].length() + elements[2].length()) / 3.0f;
 	for (int i = 0; i < 3; i++) {
 		elements[i].normalize();
 		elements[i] *= l;
@@ -415,7 +415,7 @@ void Basis::rotate_to_align(Vector3 p_start_direction, Vector3 p_end_direction) 
 	const Vector3 axis = p_start_direction.cross(p_end_direction).normalized();
 	if (axis.length_squared() != 0) {
 		real_t dot = p_start_direction.dot(p_end_direction);
-		dot = CLAMP(dot, -1.0, 1.0);
+		dot = CLAMP(dot, -1.0f, 1.0f);
 		const real_t angle_rads = Math::acos(dot);
 		set_axis_angle(axis, angle_rads);
 	}
@@ -463,10 +463,10 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 
 			Vector3 euler;
 			real_t sy = elements[0][2];
-			if (sy < (1.0 - CMP_EPSILON)) {
-				if (sy > -(1.0 - CMP_EPSILON)) {
+			if (sy < (1.0f - CMP_EPSILON)) {
+				if (sy > -(1.0f - CMP_EPSILON)) {
 					// is this a pure Y rotation?
-					if (elements[1][0] == 0.0 && elements[0][1] == 0.0 && elements[1][2] == 0 && elements[2][1] == 0 && elements[1][1] == 1) {
+					if (elements[1][0] == 0 && elements[0][1] == 0 && elements[1][2] == 0 && elements[2][1] == 0 && elements[1][1] == 1) {
 						// return the simplest form (human friendlier in editor and scripts)
 						euler.x = 0;
 						euler.y = atan2(elements[0][2], elements[0][0]);
@@ -478,13 +478,13 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 					}
 				} else {
 					euler.x = Math::atan2(elements[2][1], elements[1][1]);
-					euler.y = -Math_PI / 2.0;
-					euler.z = 0.0;
+					euler.y = -Math_PI / 2.0f;
+					euler.z = 0.0f;
 				}
 			} else {
 				euler.x = Math::atan2(elements[2][1], elements[1][1]);
-				euler.y = Math_PI / 2.0;
-				euler.z = 0.0;
+				euler.y = Math_PI / 2.0f;
+				euler.z = 0.0f;
 			}
 			return euler;
 		} break;
@@ -498,22 +498,22 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 
 			Vector3 euler;
 			real_t sz = elements[0][1];
-			if (sz < (1.0 - CMP_EPSILON)) {
-				if (sz > -(1.0 - CMP_EPSILON)) {
+			if (sz < (1.0f - CMP_EPSILON)) {
+				if (sz > -(1.0f - CMP_EPSILON)) {
 					euler.x = Math::atan2(elements[2][1], elements[1][1]);
 					euler.y = Math::atan2(elements[0][2], elements[0][0]);
 					euler.z = Math::asin(-sz);
 				} else {
 					// It's -1
 					euler.x = -Math::atan2(elements[1][2], elements[2][2]);
-					euler.y = 0.0;
-					euler.z = Math_PI / 2.0;
+					euler.y = 0.0f;
+					euler.z = Math_PI / 2.0f;
 				}
 			} else {
 				// It's 1
 				euler.x = -Math::atan2(elements[1][2], elements[2][2]);
-				euler.y = 0.0;
-				euler.z = -Math_PI / 2.0;
+				euler.y = 0.0f;
+				euler.z = -Math_PI / 2.0f;
 			}
 			return euler;
 		} break;
@@ -543,12 +543,12 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 						euler.z = atan2(elements[1][0], elements[1][1]);
 					}
 				} else { // m12 == -1
-					euler.x = Math_PI * 0.5;
+					euler.x = Math_PI * 0.5f;
 					euler.y = atan2(elements[0][1], elements[0][0]);
 					euler.z = 0;
 				}
 			} else { // m12 == 1
-				euler.x = -Math_PI * 0.5;
+				euler.x = -Math_PI * 0.5f;
 				euler.y = -atan2(elements[0][1], elements[0][0]);
 				euler.z = 0;
 			}
@@ -565,22 +565,22 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 
 			Vector3 euler;
 			real_t sz = elements[1][0];
-			if (sz < (1.0 - CMP_EPSILON)) {
-				if (sz > -(1.0 - CMP_EPSILON)) {
+			if (sz < (1.0f - CMP_EPSILON)) {
+				if (sz > -(1.0f - CMP_EPSILON)) {
 					euler.x = Math::atan2(-elements[1][2], elements[1][1]);
 					euler.y = Math::atan2(-elements[2][0], elements[0][0]);
 					euler.z = Math::asin(sz);
 				} else {
 					// It's -1
 					euler.x = Math::atan2(elements[2][1], elements[2][2]);
-					euler.y = 0.0;
-					euler.z = -Math_PI / 2.0;
+					euler.y = 0.0f;
+					euler.z = -Math_PI / 2.0f;
 				}
 			} else {
 				// It's 1
 				euler.x = Math::atan2(elements[2][1], elements[2][2]);
-				euler.y = 0.0;
-				euler.z = Math_PI / 2.0;
+				euler.y = 0.0f;
+				euler.z = Math_PI / 2.0f;
 			}
 			return euler;
 		} break;
@@ -593,20 +593,20 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 			//        -cx*sy            sx                    cx*cy
 			Vector3 euler;
 			real_t sx = elements[2][1];
-			if (sx < (1.0 - CMP_EPSILON)) {
-				if (sx > -(1.0 - CMP_EPSILON)) {
+			if (sx < (1.0f - CMP_EPSILON)) {
+				if (sx > -(1.0f - CMP_EPSILON)) {
 					euler.x = Math::asin(sx);
 					euler.y = Math::atan2(-elements[2][0], elements[2][2]);
 					euler.z = Math::atan2(-elements[0][1], elements[1][1]);
 				} else {
 					// It's -1
-					euler.x = -Math_PI / 2.0;
+					euler.x = -Math_PI / 2.0f;
 					euler.y = Math::atan2(elements[0][2], elements[0][0]);
 					euler.z = 0;
 				}
 			} else {
 				// It's 1
-				euler.x = Math_PI / 2.0;
+				euler.x = Math_PI / 2.0f;
 				euler.y = Math::atan2(elements[0][2], elements[0][0]);
 				euler.z = 0;
 			}
@@ -621,21 +621,21 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 			//        -sy               cy*sx                 cy*cx
 			Vector3 euler;
 			real_t sy = elements[2][0];
-			if (sy < (1.0 - CMP_EPSILON)) {
-				if (sy > -(1.0 - CMP_EPSILON)) {
+			if (sy < (1.0f - CMP_EPSILON)) {
+				if (sy > -(1.0f - CMP_EPSILON)) {
 					euler.x = Math::atan2(elements[2][1], elements[2][2]);
 					euler.y = Math::asin(-sy);
 					euler.z = Math::atan2(elements[1][0], elements[0][0]);
 				} else {
 					// It's -1
 					euler.x = 0;
-					euler.y = Math_PI / 2.0;
+					euler.y = Math_PI / 2.0f;
 					euler.z = -Math::atan2(elements[0][1], elements[1][1]);
 				}
 			} else {
 				// It's 1
 				euler.x = 0;
-				euler.y = -Math_PI / 2.0;
+				euler.y = -Math_PI / 2.0f;
 				euler.z = -Math::atan2(elements[0][1], elements[1][1]);
 			}
 			return euler;
@@ -652,15 +652,15 @@ void Basis::set_euler(const Vector3 &p_euler, EulerOrder p_order) {
 
 	c = Math::cos(p_euler.x);
 	s = Math::sin(p_euler.x);
-	Basis xmat(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c);
+	Basis xmat(1, 0, 0, 0, c, -s, 0, s, c);
 
 	c = Math::cos(p_euler.y);
 	s = Math::sin(p_euler.y);
-	Basis ymat(c, 0.0, s, 0.0, 1.0, 0.0, -s, 0.0, c);
+	Basis ymat(c, 0, s, 0, 1, 0, -s, 0, c);
 
 	c = Math::cos(p_euler.z);
 	s = Math::sin(p_euler.z);
-	Basis zmat(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0);
+	Basis zmat(c, -s, 0, s, c, 0, 0, 0, 1);
 
 	switch (p_order) {
 		case EULER_ORDER_XYZ: {
@@ -722,10 +722,10 @@ Quaternion Basis::get_quaternion() const {
 	real_t trace = m.elements[0][0] + m.elements[1][1] + m.elements[2][2];
 	real_t temp[4];
 
-	if (trace > 0.0) {
-		real_t s = Math::sqrt(trace + 1.0);
-		temp[3] = (s * 0.5);
-		s = 0.5 / s;
+	if (trace > 0.0f) {
+		real_t s = Math::sqrt(trace + 1.0f);
+		temp[3] = (s * 0.5f);
+		s = 0.5f / s;
 
 		temp[0] = ((m.elements[2][1] - m.elements[1][2]) * s);
 		temp[1] = ((m.elements[0][2] - m.elements[2][0]) * s);
@@ -737,9 +737,9 @@ Quaternion Basis::get_quaternion() const {
 		int j = (i + 1) % 3;
 		int k = (i + 2) % 3;
 
-		real_t s = Math::sqrt(m.elements[i][i] - m.elements[j][j] - m.elements[k][k] + 1.0);
-		temp[i] = s * 0.5;
-		s = 0.5 / s;
+		real_t s = Math::sqrt(m.elements[i][i] - m.elements[j][j] - m.elements[k][k] + 1.0f);
+		temp[i] = s * 0.5f;
+		s = 0.5f / s;
 
 		temp[3] = (m.elements[k][j] - m.elements[j][k]) * s;
 		temp[j] = (m.elements[j][i] + m.elements[i][j]) * s;
@@ -782,10 +782,10 @@ int Basis::get_orthogonal_index() const {
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {
 			real_t v = orth[i][j];
-			if (v > 0.5) {
-				v = 1.0;
-			} else if (v < -0.5) {
-				v = -1.0;
+			if (v > 0.5f) {
+				v = 1.0f;
+			} else if (v < -0.5f) {
+				v = -1.0f;
 			} else {
 				v = 0;
 			}
@@ -890,14 +890,14 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 
 void Basis::set_quaternion(const Quaternion &p_quaternion) {
 	real_t d = p_quaternion.length_squared();
-	real_t s = 2.0 / d;
+	real_t s = 2.0f / d;
 	real_t xs = p_quaternion.x * s, ys = p_quaternion.y * s, zs = p_quaternion.z * s;
 	real_t wx = p_quaternion.w * xs, wy = p_quaternion.w * ys, wz = p_quaternion.w * zs;
 	real_t xx = p_quaternion.x * xs, xy = p_quaternion.x * ys, xz = p_quaternion.x * zs;
 	real_t yy = p_quaternion.y * ys, yz = p_quaternion.y * zs, zz = p_quaternion.z * zs;
-	set(1.0 - (yy + zz), xy - wz, xz + wy,
-			xy + wz, 1.0 - (xx + zz), yz - wx,
-			xz - wy, yz + wx, 1.0 - (xx + yy));
+	set(1.0f - (yy + zz), xy - wz, xz + wy,
+			xy + wz, 1.0f - (xx + zz), yz - wx,
+			xz - wy, yz + wx, 1.0f - (xx + yy));
 }
 
 void Basis::set_axis_angle(const Vector3 &p_axis, real_t p_phi) {
@@ -907,9 +907,9 @@ void Basis::set_axis_angle(const Vector3 &p_axis, real_t p_phi) {
 #endif
 	Vector3 axis_sq(p_axis.x * p_axis.x, p_axis.y * p_axis.y, p_axis.z * p_axis.z);
 	real_t cosine = Math::cos(p_phi);
-	elements[0][0] = axis_sq.x + cosine * (1.0 - axis_sq.x);
-	elements[1][1] = axis_sq.y + cosine * (1.0 - axis_sq.y);
-	elements[2][2] = axis_sq.z + cosine * (1.0 - axis_sq.z);
+	elements[0][0] = axis_sq.x + cosine * (1.0f - axis_sq.x);
+	elements[1][1] = axis_sq.y + cosine * (1.0f - axis_sq.y);
+	elements[2][2] = axis_sq.z + cosine * (1.0f - axis_sq.z);
 
 	real_t sine = Math::sin(p_phi);
 	real_t t = 1 - cosine;

--- a/core/math/color.cpp
+++ b/core/math/color.cpp
@@ -161,9 +161,9 @@ float Color::get_h() const {
 		h = 4 + (r - g) / delta; // between magenta & cyan
 	}
 
-	h /= 6.0;
+	h /= 6.0f;
 	if (h < 0) {
-		h += 1.0;
+		h += 1.0f;
 	}
 
 	return h;
@@ -197,7 +197,7 @@ void Color::set_hsv(float p_h, float p_s, float p_v, float p_alpha) {
 		return;
 	}
 
-	p_h *= 6.0;
+	p_h *= 6.0f;
 	p_h = Math::fmod(p_h, 6);
 	i = Math::floor(p_h);
 
@@ -253,31 +253,31 @@ Color Color::clamp(const Color &p_min, const Color &p_max) const {
 }
 
 void Color::invert() {
-	r = 1.0 - r;
-	g = 1.0 - g;
-	b = 1.0 - b;
+	r = 1.0f - r;
+	g = 1.0f - g;
+	b = 1.0f - b;
 }
 
 Color Color::hex(uint32_t p_hex) {
-	float a = (p_hex & 0xFF) / 255.0;
+	float a = (p_hex & 0xFF) / 255.0f;
 	p_hex >>= 8;
-	float b = (p_hex & 0xFF) / 255.0;
+	float b = (p_hex & 0xFF) / 255.0f;
 	p_hex >>= 8;
-	float g = (p_hex & 0xFF) / 255.0;
+	float g = (p_hex & 0xFF) / 255.0f;
 	p_hex >>= 8;
-	float r = (p_hex & 0xFF) / 255.0;
+	float r = (p_hex & 0xFF) / 255.0f;
 
 	return Color(r, g, b, a);
 }
 
 Color Color::hex64(uint64_t p_hex) {
-	float a = (p_hex & 0xFFFF) / 65535.0;
+	float a = (p_hex & 0xFFFF) / 65535.0f;
 	p_hex >>= 16;
-	float b = (p_hex & 0xFFFF) / 65535.0;
+	float b = (p_hex & 0xFFFF) / 65535.0f;
 	p_hex >>= 16;
-	float g = (p_hex & 0xFFFF) / 65535.0;
+	float g = (p_hex & 0xFFFF) / 65535.0f;
 	p_hex >>= 16;
-	float r = (p_hex & 0xFFFF) / 65535.0;
+	float r = (p_hex & 0xFFFF) / 65535.0f;
 
 	return Color(r, g, b, a);
 }
@@ -333,18 +333,18 @@ Color Color::html(const String &p_rgba) {
 
 	float r, g, b, a = 1.0;
 	if (is_shorthand) {
-		r = _parse_col4(color, 0) / 15.0;
-		g = _parse_col4(color, 1) / 15.0;
-		b = _parse_col4(color, 2) / 15.0;
+		r = _parse_col4(color, 0) / 15.0f;
+		g = _parse_col4(color, 1) / 15.0f;
+		b = _parse_col4(color, 2) / 15.0f;
 		if (alpha) {
-			a = _parse_col4(color, 3) / 15.0;
+			a = _parse_col4(color, 3) / 15.0f;
 		}
 	} else {
-		r = _parse_col8(color, 0) / 255.0;
-		g = _parse_col8(color, 2) / 255.0;
-		b = _parse_col8(color, 4) / 255.0;
+		r = _parse_col8(color, 0) / 255.0f;
+		g = _parse_col8(color, 2) / 255.0f;
+		b = _parse_col8(color, 4) / 255.0f;
 		if (alpha) {
-			a = _parse_col8(color, 6) / 255.0;
+			a = _parse_col8(color, 6) / 255.0f;
 		}
 	}
 	ERR_FAIL_COND_V_MSG(r < 0, Color(), "Invalid color code: " + p_rgba + ".");
@@ -458,7 +458,7 @@ Color Color::from_rgbe9995(uint32_t p_rgbe) {
 	float g = (p_rgbe >> 9) & 0x1ff;
 	float b = (p_rgbe >> 18) & 0x1ff;
 	float e = (p_rgbe >> 27);
-	float m = Math::pow(2, e - 15.0 - 9.0);
+	float m = Math::pow(2, e - 15.0f - 9.0f);
 
 	float rd = r * m;
 	float gd = g * m;
@@ -563,8 +563,8 @@ void Color::operator/=(float p_scalar) {
 
 Color Color::operator-() const {
 	return Color(
-			1.0 - r,
-			1.0 - g,
-			1.0 - b,
-			1.0 - a);
+			1.0f - r,
+			1.0f - g,
+			1.0f - b,
+			1.0f - a);
 }

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -95,7 +95,7 @@ struct _NO_DISCARD_ Color {
 	Color inverted() const;
 
 	_FORCE_INLINE_ float get_luminance() const {
-		return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+		return 0.2126f * r + 0.7152f * g + 0.0722f * b;
 	}
 
 	_FORCE_INLINE_ Color lerp(const Color &p_to, float p_weight) const {
@@ -144,7 +144,7 @@ struct _NO_DISCARD_ Color {
 
 		float exps = expp + 1.0f;
 
-		if (0.0 <= sMax && sMax < pow2to9) {
+		if (0.0f <= sMax && sMax < pow2to9) {
 			exps = expp;
 		}
 
@@ -157,7 +157,7 @@ struct _NO_DISCARD_ Color {
 
 	_FORCE_INLINE_ Color blend(const Color &p_over) const {
 		Color res;
-		float sa = 1.0 - p_over.a;
+		float sa = 1.0f - p_over.a;
 		res.a = a * sa + p_over.a;
 		if (res.a == 0) {
 			return Color(0, 0, 0, 0);
@@ -171,16 +171,16 @@ struct _NO_DISCARD_ Color {
 
 	_FORCE_INLINE_ Color to_linear() const {
 		return Color(
-				r < 0.04045 ? r * (1.0 / 12.92) : Math::pow((r + 0.055) * (1.0 / (1 + 0.055)), 2.4),
-				g < 0.04045 ? g * (1.0 / 12.92) : Math::pow((g + 0.055) * (1.0 / (1 + 0.055)), 2.4),
-				b < 0.04045 ? b * (1.0 / 12.92) : Math::pow((b + 0.055) * (1.0 / (1 + 0.055)), 2.4),
+				r < 0.04045f ? r * (1.0 / 12.92) : Math::pow((r + 0.055f) * (float)(1.0 / (1 + 0.055)), 2.4f),
+				g < 0.04045f ? g * (1.0 / 12.92) : Math::pow((g + 0.055f) * (float)(1.0 / (1 + 0.055)), 2.4f),
+				b < 0.04045f ? b * (1.0 / 12.92) : Math::pow((b + 0.055f) * (float)(1.0 / (1 + 0.055)), 2.4f),
 				a);
 	}
 	_FORCE_INLINE_ Color to_srgb() const {
 		return Color(
-				r < 0.0031308 ? 12.92 * r : (1.0 + 0.055) * Math::pow(r, 1.0f / 2.4f) - 0.055,
-				g < 0.0031308 ? 12.92 * g : (1.0 + 0.055) * Math::pow(g, 1.0f / 2.4f) - 0.055,
-				b < 0.0031308 ? 12.92 * b : (1.0 + 0.055) * Math::pow(b, 1.0f / 2.4f) - 0.055, a);
+				r < 0.0031308f ? 12.92f * r : (1.0f + 0.055f) * Math::pow(r, 1.0f / 2.4f) - 0.055f,
+				g < 0.0031308f ? 12.92f * g : (1.0f + 0.055f) * Math::pow(g, 1.0f / 2.4f) - 0.055f,
+				b < 0.0031308f ? 12.92f * b : (1.0f + 0.055f) * Math::pow(b, 1.0f / 2.4f) - 0.055f, a);
 	}
 
 	static Color hex(uint32_t p_hex);
@@ -201,13 +201,13 @@ struct _NO_DISCARD_ Color {
 	operator String() const;
 
 	// For the binder.
-	_FORCE_INLINE_ void set_r8(int32_t r8) { r = (CLAMP(r8, 0, 255) / 255.0); }
+	_FORCE_INLINE_ void set_r8(int32_t r8) { r = (CLAMP(r8, 0, 255) / 255.0f); }
 	_FORCE_INLINE_ int32_t get_r8() const { return int32_t(CLAMP(Math::round(r * 255.0f), 0.0f, 255.0f)); }
-	_FORCE_INLINE_ void set_g8(int32_t g8) { g = (CLAMP(g8, 0, 255) / 255.0); }
+	_FORCE_INLINE_ void set_g8(int32_t g8) { g = (CLAMP(g8, 0, 255) / 255.0f); }
 	_FORCE_INLINE_ int32_t get_g8() const { return int32_t(CLAMP(Math::round(g * 255.0f), 0.0f, 255.0f)); }
-	_FORCE_INLINE_ void set_b8(int32_t b8) { b = (CLAMP(b8, 0, 255) / 255.0); }
+	_FORCE_INLINE_ void set_b8(int32_t b8) { b = (CLAMP(b8, 0, 255) / 255.0f); }
 	_FORCE_INLINE_ int32_t get_b8() const { return int32_t(CLAMP(Math::round(b * 255.0f), 0.0f, 255.0f)); }
-	_FORCE_INLINE_ void set_a8(int32_t a8) { a = (CLAMP(a8, 0, 255) / 255.0); }
+	_FORCE_INLINE_ void set_a8(int32_t a8) { a = (CLAMP(a8, 0, 255) / 255.0f); }
 	_FORCE_INLINE_ int32_t get_a8() const { return int32_t(CLAMP(Math::round(a * 255.0f), 0.0f, 255.0f)); }
 
 	_FORCE_INLINE_ void set_h(float p_h) { set_hsv(p_h, get_s(), get_v()); }
@@ -234,7 +234,7 @@ struct _NO_DISCARD_ Color {
 		r = p_r;
 		g = p_g;
 		b = p_b;
-		a = 1.0;
+		a = 1.0f;
 	}
 
 	/**

--- a/core/math/face3.cpp
+++ b/core/math/face3.cpp
@@ -157,7 +157,7 @@ Vector3 Face3::get_random_point_inside() const {
 		SWAP(a, b);
 	}
 
-	return vertex[0] * a + vertex[1] * (b - a) + vertex[2] * (1.0 - b);
+	return vertex[0] * a + vertex[1] * (b - a) + vertex[2] * (1.0f - b);
 }
 
 Plane Face3::get_plane(ClockDirection p_dir) const {
@@ -165,11 +165,11 @@ Plane Face3::get_plane(ClockDirection p_dir) const {
 }
 
 Vector3 Face3::get_median_point() const {
-	return (vertex[0] + vertex[1] + vertex[2]) / 3.0;
+	return (vertex[0] + vertex[1] + vertex[2]) / 3.0f;
 }
 
 real_t Face3::get_area() const {
-	return vec3_cross(vertex[0] - vertex[1], vertex[0] - vertex[2]).length() * 0.5;
+	return vec3_cross(vertex[0] - vertex[1], vertex[0] - vertex[2]).length() * 0.5f;
 }
 
 ClockDirection Face3::get_clock_dir() const {
@@ -223,7 +223,7 @@ bool Face3::intersects_aabb(const AABB &p_aabb) const {
 
 			Vector3 axis = vec3_cross(e1, e2);
 
-			if (axis.length_squared() < 0.0001) {
+			if (axis.length_squared() < 0.0001f) {
 				continue; // coplanar
 			}
 			axis.normalize();

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -95,7 +95,7 @@ struct _NO_DISCARD_ Face3 {
 bool Face3::intersects_aabb2(const AABB &p_aabb) const {
 	Vector3 perp = (vertex[0] - vertex[2]).cross(vertex[0] - vertex[1]);
 
-	Vector3 half_extents = p_aabb.size * 0.5;
+	Vector3 half_extents = p_aabb.size * 0.5f;
 	Vector3 ofs = p_aabb.position + half_extents;
 
 	Vector3 sup = Vector3(
@@ -206,7 +206,7 @@ bool Face3::intersects_aabb2(const AABB &p_aabb) const {
 
 			Vector3 axis = vec3_cross(e1, e2);
 
-			if (axis.length_squared() < 0.0001) {
+			if (axis.length_squared() < 0.0001f) {
 				continue; // coplanar
 			}
 			//axis.normalize();

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -290,7 +290,7 @@ Vector<Vector<Point2>> Geometry2D::_polypath_offset(const Vector<Point2> &p_poly
 			et = etOpenRound;
 			break;
 	}
-	ClipperOffset co(2.0, 0.25 * SCALE_FACTOR); // Defaults from ClipperOffset.
+	ClipperOffset co(2.0, 0.25f * SCALE_FACTOR); // Defaults from ClipperOffset.
 	Path path;
 
 	// Need to scale points (Clipper's requirement for robust computation).

--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -61,21 +61,21 @@ public:
 			// First segment degenerates into a point.
 			s = 0.0;
 			t = f / e; // s = 0 => t = (b*s + f) / e = f / e
-			t = CLAMP(t, 0.0, 1.0);
+			t = CLAMP(t, 0.0f, 1.0f);
 		} else {
 			real_t c = d1.dot(r);
 			if (e <= CMP_EPSILON) {
 				// Second segment degenerates into a point.
 				t = 0.0;
-				s = CLAMP(-c / a, 0.0, 1.0); // t = 0 => s = (b*t - c) / a = -c / a
+				s = CLAMP(-c / a, 0.0f, 1.0f); // t = 0 => s = (b*t - c) / a = -c / a
 			} else {
 				// The general nondegenerate case starts here.
 				real_t b = d1.dot(d2);
 				real_t denom = a * e - b * b; // Always nonnegative.
 				// If segments not parallel, compute closest point on L1 to L2 and
 				// clamp to segment S1. Else pick arbitrary s (here 0).
-				if (denom != 0.0) {
-					s = CLAMP((b * f - c * e) / denom, 0.0, 1.0);
+				if (denom != 0.0f) {
+					s = CLAMP((b * f - c * e) / denom, 0.0f, 1.0f);
 				} else {
 					s = 0.0;
 				}
@@ -86,12 +86,12 @@ public:
 				//If t in [0,1] done. Else clamp t, recompute s for the new value
 				// of t using s = Dot((P2 + D2*t) - P1,D1) / Dot(D1,D1)= (t*b - c) / a
 				// and clamp s to [0, 1].
-				if (t < 0.0) {
+				if (t < 0.0f) {
 					t = 0.0;
-					s = CLAMP(-c / a, 0.0, 1.0);
-				} else if (t > 1.0) {
+					s = CLAMP(-c / a, 0.0f, 1.0f);
+				} else if (t > 1.0f) {
 					t = 1.0;
-					s = CLAMP((b - c) / a, 0.0, 1.0);
+					s = CLAMP((b - c) / a, 0.0f, 1.0f);
 				}
 			}
 		}
@@ -104,15 +104,15 @@ public:
 		Vector2 p = p_point - p_segment[0];
 		Vector2 n = p_segment[1] - p_segment[0];
 		real_t l2 = n.length_squared();
-		if (l2 < 1e-20) {
+		if (l2 < 1e-20f) {
 			return p_segment[0]; // Both points are the same, just give any.
 		}
 
 		real_t d = n.dot(p) / l2;
 
-		if (d <= 0.0) {
+		if (d <= 0.0f) {
 			return p_segment[0]; // Before first point.
-		} else if (d >= 1.0) {
+		} else if (d >= 1.0f) {
 			return p_segment[1]; // After first point.
 		} else {
 			return p_segment[0] + n * d; // Inside.
@@ -137,7 +137,7 @@ public:
 		Vector2 p = p_point - p_segment[0];
 		Vector2 n = p_segment[1] - p_segment[0];
 		real_t l2 = n.length_squared();
-		if (l2 < 1e-20) {
+		if (l2 < 1e-20f) {
 			return p_segment[0]; // Both points are the same, just give any.
 		}
 
@@ -198,7 +198,7 @@ public:
 		real_t ABpos = D.x + (C.x - D.x) * D.y / (D.y - C.y);
 
 		// Fail if segment C-D crosses line A-B outside of segment A-B.
-		if (ABpos < 0 || ABpos > 1.0) {
+		if (ABpos < 0 || ABpos > 1.0f) {
 			return false;
 		}
 

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -124,8 +124,8 @@ static bool _connect_faces(_FaceClassify *p_faces, int len, int p_group) {
 					Vector3 vj2 = p_faces[j].face.vertex[l];
 					Vector3 vj1 = p_faces[j].face.vertex[(l + 1) % 3];
 
-					if (vi1.distance_to(vj1) < 0.00001 &&
-							vi2.distance_to(vj2) < 0.00001) {
+					if (vi1.distance_to(vj1) < 0.00001f &&
+							vi2.distance_to(vj2) < 0.00001f) {
 						if (p_faces[i].links[k].face != -1) {
 							ERR_PRINT("already linked\n");
 							error = true;
@@ -508,7 +508,7 @@ Vector<Face3> Geometry3D::wrap_geometry(Vector<Face3> p_array, real_t *p_error) 
 		}
 	}
 
-	global_aabb.grow_by(0.01); // Avoid numerical error.
+	global_aabb.grow_by(0.01f); // Avoid numerical error.
 
 	// Determine amount of cells in grid axis.
 	int div_x, div_y, div_z;
@@ -638,7 +638,7 @@ Geometry3D::MeshData Geometry3D::build_convex_mesh(const Vector<Plane> &p_planes
 
 		Vector3 ref = Vector3(0.0, 1.0, 0.0);
 
-		if (ABS(p.normal.dot(ref)) > 0.95) {
+		if (ABS(p.normal.dot(ref)) > 0.95f) {
 			ref = Vector3(0.0, 0.0, 1.0); // Change axis.
 		}
 
@@ -663,7 +663,7 @@ Geometry3D::MeshData Geometry3D::build_convex_mesh(const Vector<Plane> &p_planes
 			Vector<Vector3> new_vertices;
 			Plane clip = p_planes[j];
 
-			if (clip.normal.dot(p.normal) > 0.95) {
+			if (clip.normal.dot(p.normal) > 0.95f) {
 				continue;
 			}
 
@@ -716,7 +716,7 @@ Geometry3D::MeshData Geometry3D::build_convex_mesh(const Vector<Plane> &p_planes
 		for (int j = 0; j < vertices.size(); j++) {
 			int idx = -1;
 			for (int k = 0; k < mesh.vertices.size(); k++) {
-				if (mesh.vertices[k].distance_to(vertices[j]) < 0.001) {
+				if (mesh.vertices[k].distance_to(vertices[j]) < 0.001f) {
 					idx = k;
 					break;
 				}
@@ -793,8 +793,8 @@ Vector<Plane> Geometry3D::build_cylinder_planes(real_t p_radius, real_t p_height
 	Vector3 axis;
 	axis[p_axis] = 1.0;
 
-	planes.push_back(Plane(axis, p_height * 0.5));
-	planes.push_back(Plane(-axis, p_height * 0.5));
+	planes.push_back(Plane(axis, p_height * 0.5f));
+	planes.push_back(Plane(-axis, p_height * 0.5f));
 
 	return planes;
 }
@@ -853,7 +853,7 @@ Vector<Plane> Geometry3D::build_capsule_planes(real_t p_radius, real_t p_height,
 
 		for (int j = 1; j <= p_lats; j++) {
 			Vector3 plane_normal = normal.lerp(axis, j / (real_t)p_lats).normalized();
-			Vector3 position = axis * p_height * 0.5 + plane_normal * p_radius;
+			Vector3 position = axis * p_height * 0.5f + plane_normal * p_radius;
 			planes.push_back(Plane(plane_normal, position));
 			planes.push_back(Plane(plane_normal * axis_neg, position * axis_neg));
 		}

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -77,15 +77,15 @@ public:
 
 		// Compute the line parameters of the two closest points.
 		if (D < CMP_EPSILON) { // The lines are almost parallel.
-			sN = 0.0; // Force using point P0 on segment S1
-			sD = 1.0; // to prevent possible division by 0.0 later.
+			sN = 0.0f; // Force using point P0 on segment S1
+			sD = 1.0f; // to prevent possible division by 0.0 later.
 			tN = e;
 			tD = c;
 		} else { // Get the closest points on the infinite lines
 			sN = (b * e - c * d);
 			tN = (a * e - b * d);
-			if (sN < 0.0) { // sc < 0 => the s=0 edge is visible.
-				sN = 0.0;
+			if (sN < 0.0f) { // sc < 0 => the s=0 edge is visible.
+				sN = 0.0f;
 				tN = e;
 				tD = c;
 			} else if (sN > sD) { // sc > 1 => the s=1 edge is visible.
@@ -95,11 +95,11 @@ public:
 			}
 		}
 
-		if (tN < 0.0) { // tc < 0 => the t=0 edge is visible.
-			tN = 0.0;
+		if (tN < 0.0f) { // tc < 0 => the t=0 edge is visible.
+			tN = 0.0f;
 			// Recompute sc for this edge.
-			if (-d < 0.0) {
-				sN = 0.0;
+			if (-d < 0.0f) {
+				sN = 0.0f;
 			} else if (-d > a) {
 				sN = sD;
 			} else {
@@ -109,7 +109,7 @@ public:
 		} else if (tN > tD) { // tc > 1 => the t=1 edge is visible.
 			tN = tD;
 			// Recompute sc for this edge.
-			if ((-d + b) < 0.0) {
+			if ((-d + b) < 0.0f) {
 				sN = 0;
 			} else if ((-d + b) > a) {
 				sN = sD;
@@ -119,8 +119,8 @@ public:
 			}
 		}
 		// Finally do the division to get sc and tc.
-		sc = (Math::is_zero_approx(sN) ? 0.0 : sN / sD);
-		tc = (Math::is_zero_approx(tN) ? 0.0 : tN / tD);
+		sc = (Math::is_zero_approx(sN) ? 0.0f : sN / sD);
+		tc = (Math::is_zero_approx(tN) ? 0.0f : tN / tD);
 
 		// Get the difference of the two closest points.
 		Vector3 dP = w + (sc * u) - (tc * v); // = S1(sc) - S2(tc)
@@ -137,12 +137,12 @@ public:
 			return false;
 		}
 
-		real_t f = 1.0 / a;
+		real_t f = 1.0f / a;
 
 		Vector3 s = p_from - p_v0;
 		real_t u = f * s.dot(h);
 
-		if (u < 0.0 || u > 1.0) {
+		if (u < 0.0f || u > 1.0f) {
 			return false;
 		}
 
@@ -150,7 +150,7 @@ public:
 
 		real_t v = f * p_dir.dot(q);
 
-		if (v < 0.0 || u + v > 1.0) {
+		if (v < 0.0f || u + v > 1.0f) {
 			return false;
 		}
 
@@ -158,7 +158,7 @@ public:
 		// the intersection point is on the line.
 		real_t t = f * e2.dot(q);
 
-		if (t > 0.00001) { // ray intersection
+		if (t > 0.00001f) { // ray intersection
 			if (r_res) {
 				*r_res = p_from + p_dir * t;
 			}
@@ -178,12 +178,12 @@ public:
 			return false;
 		}
 
-		real_t f = 1.0 / a;
+		real_t f = 1.0f / a;
 
 		Vector3 s = p_from - p_v0;
 		real_t u = f * s.dot(h);
 
-		if (u < 0.0 || u > 1.0) {
+		if (u < 0.0f || u > 1.0f) {
 			return false;
 		}
 
@@ -191,7 +191,7 @@ public:
 
 		real_t v = f * rel.dot(q);
 
-		if (v < 0.0 || u + v > 1.0) {
+		if (v < 0.0f || u + v > 1.0f) {
 			return false;
 		}
 
@@ -199,7 +199,7 @@ public:
 		// the intersection point is on the line.
 		real_t t = f * e2.dot(q);
 
-		if (t > CMP_EPSILON && t <= 1.0) { // Ray intersection.
+		if (t > CMP_EPSILON && t <= 1.0f) { // Ray intersection.
 			if (r_res) {
 				*r_res = p_from + rel * t;
 			}
@@ -260,7 +260,7 @@ public:
 		ERR_FAIL_COND_V(p_cylinder_axis < 0, false);
 		ERR_FAIL_COND_V(p_cylinder_axis > 2, false);
 		Vector3 cylinder_axis;
-		cylinder_axis[p_cylinder_axis] = 1.0;
+		cylinder_axis[p_cylinder_axis] = 1.0f;
 
 		// First check if they are parallel.
 		Vector3 normal = (rel / rel_l);
@@ -271,7 +271,7 @@ public:
 
 		if (crs_l < CMP_EPSILON) {
 			Vector3 side_axis;
-			side_axis[(p_cylinder_axis + 1) % 3] = 1.0; // Any side axis OK.
+			side_axis[(p_cylinder_axis + 1) % 3] = 1.0f; // Any side axis OK.
 			axis_dir = side_axis;
 		} else {
 			axis_dir = crs / crs_l;
@@ -288,7 +288,7 @@ public:
 		if (w2 < CMP_EPSILON) {
 			return false; // Avoid numerical error.
 		}
-		Size2 size(Math::sqrt(w2), p_height * 0.5);
+		Size2 size(Math::sqrt(w2), p_height * 0.5f);
 
 		Vector3 side_dir = axis_dir.cross(cylinder_axis).normalized();
 
@@ -417,15 +417,15 @@ public:
 		Vector3 p = p_point - p_segment[0];
 		Vector3 n = p_segment[1] - p_segment[0];
 		real_t l2 = n.length_squared();
-		if (l2 < 1e-20) {
+		if (l2 < 1e-20f) {
 			return p_segment[0]; // Both points are the same, just give any.
 		}
 
 		real_t d = n.dot(p) / l2;
 
-		if (d <= 0.0) {
+		if (d <= 0.0f) {
 			return p_segment[0]; // Before first point.
-		} else if (d >= 1.0) {
+		} else if (d >= 1.0f) {
 			return p_segment[1]; // After first point.
 		} else {
 			return p_segment[0] + n * d; // Inside.
@@ -436,7 +436,7 @@ public:
 		Vector3 p = p_point - p_segment[0];
 		Vector3 n = p_segment[1] - p_segment[0];
 		real_t l2 = n.length_squared();
-		if (l2 < 1e-20) {
+		if (l2 < 1e-20f) {
 			return p_segment[0]; // Both points are the same, just give any.
 		}
 
@@ -907,9 +907,9 @@ public:
 
 	_FORCE_INLINE_ static Vector3 octahedron_map_decode(const Vector2 &p_uv) {
 		// https://twitter.com/Stubbesaurus/status/937994790553227264
-		Vector2 f = p_uv * 2.0 - Vector2(1.0, 1.0);
+		Vector2 f = p_uv * 2.0f - Vector2(1.0f, 1.0f);
 		Vector3 n = Vector3(f.x, f.y, 1.0f - Math::abs(f.x) - Math::abs(f.y));
-		float t = CLAMP(-n.z, 0.0, 1.0);
+		float t = CLAMP(-n.z, 0.0f, 1.0f);
 		n.x += n.x >= 0 ? -t : t;
 		n.y += n.y >= 0 ? -t : t;
 		return n.normalized();

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -198,7 +198,7 @@ public:
 		if ((value < 0 && p_y > 0) || (value > 0 && p_y < 0)) {
 			value += p_y;
 		}
-		value += 0.0;
+		value += 0.0f;
 		return value;
 	}
 	static _ALWAYS_INLINE_ float fposmodp(float p_x, float p_y) {
@@ -206,7 +206,7 @@ public:
 		if (value < 0) {
 			value += p_y;
 		}
-		value += 0.0;
+		value += 0.0f;
 		return value;
 	}
 	static _ALWAYS_INLINE_ double fposmodp(double p_x, double p_y) {

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -58,7 +58,7 @@ Vector3 Plane::get_any_perpendicular_normal() const {
 	static const Vector3 p2 = Vector3(0, 1, 0);
 	Vector3 p;
 
-	if (ABS(normal.dot(p1)) > 0.99) { // if too similar to p1
+	if (ABS(normal.dot(p1)) > 0.99f) { // if too similar to p1
 		p = p2; // use p2
 	} else {
 		p = p1; // use p1
@@ -129,7 +129,7 @@ bool Plane::intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vec
 	real_t dist = (normal.dot(p_begin) - d) / den;
 	//printf("dist is %i\n",dist);
 
-	if (dist < -CMP_EPSILON || dist > (1.0 + CMP_EPSILON)) {
+	if (dist < -CMP_EPSILON || dist > (1.0f + CMP_EPSILON)) {
 		return false;
 	}
 

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -114,7 +114,7 @@ Quaternion Quaternion::slerp(const Quaternion &p_to, const real_t &p_weight) con
 	cosom = dot(p_to);
 
 	// adjust signs (if necessary)
-	if (cosom < 0.0) {
+	if (cosom < 0.0f) {
 		cosom = -cosom;
 		to1.x = -p_to.x;
 		to1.y = -p_to.y;
@@ -129,7 +129,7 @@ Quaternion Quaternion::slerp(const Quaternion &p_to, const real_t &p_weight) con
 
 	// calculate coefficients
 
-	if ((1.0 - cosom) > CMP_EPSILON) {
+	if ((1.0f - cosom) > CMP_EPSILON) {
 		// standard case (slerp)
 		omega = Math::acos(cosom);
 		sinom = Math::sin(omega);
@@ -138,7 +138,7 @@ Quaternion Quaternion::slerp(const Quaternion &p_to, const real_t &p_weight) con
 	} else {
 		// "from" and "to" quaternions are very close
 		//  ... so we can do a linear interpolation
-		scale0 = 1.0 - p_weight;
+		scale0 = 1.0f - p_weight;
 		scale1 = p_weight;
 	}
 	// calculate final values
@@ -158,14 +158,14 @@ Quaternion Quaternion::slerpni(const Quaternion &p_to, const real_t &p_weight) c
 
 	real_t dot = from.dot(p_to);
 
-	if (Math::absf(dot) > 0.9999) {
+	if (Math::absf(dot) > 0.9999f) {
 		return from;
 	}
 
 	real_t theta = Math::acos(dot),
-		   sinT = 1.0 / Math::sin(theta),
+		   sinT = 1.0f / Math::sin(theta),
 		   newFactor = Math::sin(p_weight * theta) * sinT,
-		   invFactor = Math::sin((1.0 - p_weight) * theta) * sinT;
+		   invFactor = Math::sin((1.0f - p_weight) * theta) * sinT;
 
 	return Quaternion(invFactor * from.x + newFactor * p_to.x,
 			invFactor * from.y + newFactor * p_to.y,
@@ -179,7 +179,7 @@ Quaternion Quaternion::cubic_slerp(const Quaternion &p_b, const Quaternion &p_pr
 	ERR_FAIL_COND_V_MSG(!p_b.is_normalized(), Quaternion(), "The end quaternion must be normalized.");
 #endif
 	//the only way to do slerp :|
-	real_t t2 = (1.0 - p_weight) * p_weight * 2;
+	real_t t2 = (1.0f - p_weight) * p_weight * 2;
 	Quaternion sp = this->slerp(p_b, p_weight);
 	Quaternion sq = p_pre_a.slerpni(p_post_b, p_weight);
 	return sp.slerpni(sq, t2);
@@ -209,8 +209,8 @@ Quaternion::Quaternion(const Vector3 &p_axis, real_t p_angle) {
 		z = 0;
 		w = 0;
 	} else {
-		real_t sin_angle = Math::sin(p_angle * 0.5);
-		real_t cos_angle = Math::cos(p_angle * 0.5);
+		real_t sin_angle = Math::sin(p_angle * 0.5f);
+		real_t cos_angle = Math::cos(p_angle * 0.5f);
 		real_t s = sin_angle / d;
 		x = p_axis.x * s;
 		y = p_axis.y * s;
@@ -224,9 +224,9 @@ Quaternion::Quaternion(const Vector3 &p_axis, real_t p_angle) {
 // and similar for other axes.
 // This implementation uses YXZ convention (Z is the first rotation).
 Quaternion::Quaternion(const Vector3 &p_euler) {
-	real_t half_a1 = p_euler.y * 0.5;
-	real_t half_a2 = p_euler.x * 0.5;
-	real_t half_a3 = p_euler.z * 0.5;
+	real_t half_a1 = p_euler.y * 0.5f;
+	real_t half_a2 = p_euler.x * 0.5f;
+	real_t half_a3 = p_euler.z * 0.5f;
 
 	// R = Y(a1).X(a2).Z(a3) convention for Euler angles.
 	// Conversion to quaternion as listed in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf (page A-6)

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -145,19 +145,19 @@ struct _NO_DISCARD_ Quaternion {
 		Vector3 c = v0.cross(v1);
 		real_t d = v0.dot(v1);
 
-		if (d < -1.0 + CMP_EPSILON) {
+		if (d < -1.0f + CMP_EPSILON) {
 			x = 0;
 			y = 1;
 			z = 0;
 			w = 0;
 		} else {
-			real_t s = Math::sqrt((1.0 + d) * 2.0);
-			real_t rs = 1.0 / s;
+			real_t s = Math::sqrt((1.0f + d) * 2.0f);
+			real_t rs = 1.0f / s;
 
 			x = c.x * rs;
 			y = c.y * rs;
 			z = c.z * rs;
-			w = s * 0.5;
+			w = s * 0.5f;
 		}
 	}
 };
@@ -192,7 +192,7 @@ void Quaternion::operator*=(const real_t &s) {
 }
 
 void Quaternion::operator/=(const real_t &s) {
-	*this *= 1.0 / s;
+	*this *= 1.0f / s;
 }
 
 Quaternion Quaternion::operator+(const Quaternion &q2) const {
@@ -215,7 +215,7 @@ Quaternion Quaternion::operator*(const real_t &s) const {
 }
 
 Quaternion Quaternion::operator/(const real_t &s) const {
-	return *this * (1.0 / s);
+	return *this * (1.0f / s);
 }
 
 bool Quaternion::operator==(const Quaternion &p_quaternion) const {

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -49,7 +49,7 @@ struct _NO_DISCARD_ Rect2 {
 
 	real_t get_area() const { return size.width * size.height; }
 
-	_FORCE_INLINE_ Vector2 get_center() const { return position + (size * 0.5); }
+	_FORCE_INLINE_ Vector2 get_center() const { return position + (size * 0.5f); }
 
 	inline bool intersects(const Rect2 &p_rect, const bool p_include_borders = false) const {
 #ifdef MATH_CHECKS
@@ -285,7 +285,7 @@ struct _NO_DISCARD_ Rect2 {
 	}
 
 	Vector2 get_support(const Vector2 &p_normal) const {
-		Vector2 half_extents = size * 0.5;
+		Vector2 half_extents = size * 0.5f;
 		Vector2 ofs = position + half_extents;
 		return Vector2(
 					   (p_normal.x > 0) ? -half_extents.x : half_extents.x,
@@ -307,14 +307,14 @@ struct _NO_DISCARD_ Rect2 {
 
 			Vector2 r = (b - a);
 			float l = r.length();
-			if (l == 0.0) {
+			if (l == 0.0f) {
 				continue;
 			}
 
 			//check inside
 			Vector2 tg = r.orthogonal();
 			float s = tg.dot(center) - tg.dot(a);
-			if (s < 0.0) {
+			if (s < 0.0f) {
 				side_plus++;
 			} else {
 				side_minus++;
@@ -322,7 +322,7 @@ struct _NO_DISCARD_ Rect2 {
 
 			//check ray box
 			r /= l;
-			Vector2 ir(1.0 / r.x, 1.0 / r.y);
+			Vector2 ir(1.0f / r.x, 1.0f / r.y);
 
 			// lb is the corner of AABB with minimal coordinates - left bottom, rt is maximal corner
 			// r.org is origin of ray

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -50,7 +50,7 @@ void Transform2D::affine_invert() {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND(det == 0);
 #endif
-	real_t idet = 1.0 / det;
+	real_t idet = 1.0f / det;
 
 	SWAP(elements[0][0], elements[1][1]);
 	elements[0] *= Vector2(idet, -idet);
@@ -71,12 +71,12 @@ void Transform2D::rotate(const real_t p_phi) {
 
 real_t Transform2D::get_skew() const {
 	real_t det = basis_determinant();
-	return Math::acos(elements[0].normalized().dot(SIGN(det) * elements[1].normalized())) - Math_PI * 0.5;
+	return Math::acos(elements[0].normalized().dot(SIGN(det) * elements[1].normalized())) - Math_PI * 0.5f;
 }
 
 void Transform2D::set_skew(const real_t p_angle) {
 	real_t det = basis_determinant();
-	elements[1] = SIGN(det) * elements[0].rotated((Math_PI * 0.5 + p_angle)).normalized() * elements[1].length();
+	elements[1] = SIGN(det) * elements[0].rotated((Math_PI * 0.5f + p_angle)).normalized() * elements[1].length();
 }
 
 real_t Transform2D::get_rotation() const {
@@ -268,11 +268,11 @@ Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, const 
 
 	real_t dot = v1.dot(v2);
 
-	dot = CLAMP(dot, -1.0, 1.0);
+	dot = CLAMP(dot, -1.0f, 1.0f);
 
 	Vector2 v;
 
-	if (dot > 0.9995) {
+	if (dot > 0.9995f) {
 		v = v1.lerp(v2, p_c).normalized(); //linearly interpolate to avoid numerical precision issues
 	} else {
 		real_t angle = p_c * Math::acos(dot);

--- a/core/math/triangulate.cpp
+++ b/core/math/triangulate.cpp
@@ -39,7 +39,7 @@ real_t Triangulate::get_area(const Vector<Vector2> &contour) {
 	for (int p = n - 1, q = 0; q < n; p = q++) {
 		A += c[p].cross(c[q]);
 	}
-	return A * 0.5;
+	return A * 0.5f;
 }
 
 /* `is_inside_triangle` decides if a point P is inside the triangle
@@ -70,9 +70,9 @@ bool Triangulate::is_inside_triangle(real_t Ax, real_t Ay,
 	bCROSScp = bx * cpy - by * cpx;
 
 	if (include_edges) {
-		return ((aCROSSbp > 0.0) && (bCROSScp > 0.0) && (cCROSSap > 0.0));
+		return ((aCROSSbp > 0.0f) && (bCROSScp > 0.0f) && (cCROSSap > 0.0f));
 	} else {
-		return ((aCROSSbp >= 0.0) && (bCROSScp >= 0.0) && (cCROSSap >= 0.0));
+		return ((aCROSSbp >= 0.0f) && (bCROSScp >= 0.0f) && (cCROSSap >= 0.0f));
 	}
 }
 
@@ -128,7 +128,7 @@ bool Triangulate::triangulate(const Vector<Vector2> &contour, Vector<int> &resul
 
 	/* we want a counter-clockwise polygon in V */
 
-	if (0.0 < get_area(contour)) {
+	if (0.0f < get_area(contour)) {
 		for (int v = 0; v < n; v++) {
 			V.write[v] = v;
 		}

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -163,11 +163,11 @@ Vector2 Vector2::cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, c
 	real_t t3 = t2 * t;
 
 	Vector2 out;
-	out = 0.5 *
-			((p1 * 2.0) +
+	out = 0.5f *
+			((p1 * 2.0f) +
 					(-p0 + p2) * t +
-					(2.0 * p0 - 5.0 * p1 + 4 * p2 - p3) * t2 +
-					(-p0 + 3.0 * p1 - 3.0 * p2 + p3) * t3);
+					(2.0f * p0 - 5.0f * p1 + 4 * p2 - p3) * t2 +
+					(-p0 + 3.0f * p1 - 3.0f * p2 + p3) * t3);
 	return out;
 }
 
@@ -194,7 +194,7 @@ Vector2 Vector2::reflect(const Vector2 &p_normal) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!p_normal.is_normalized(), Vector2(), "The normal Vector2 must be normalized.");
 #endif
-	return 2.0 * p_normal * this->dot(p_normal) - *this;
+	return 2.0f * p_normal * this->dot(p_normal) - *this;
 }
 
 bool Vector2::is_equal_approx(const Vector2 &p_v) const {

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -248,7 +248,7 @@ Vector2 Vector2::lerp(const Vector2 &p_to, const real_t p_weight) const {
 Vector2 Vector2::slerp(const Vector2 &p_to, const real_t p_weight) const {
 	real_t start_length_sq = length_squared();
 	real_t end_length_sq = p_to.length_squared();
-	if (unlikely(start_length_sq == 0.0 || end_length_sq == 0.0)) {
+	if (unlikely(start_length_sq == 0.0f || end_length_sq == 0.0f)) {
 		// Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
 		return lerp(p_to, p_weight);
 	}

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -93,11 +93,11 @@ Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, c
 	real_t t3 = t2 * t;
 
 	Vector3 out;
-	out = 0.5 *
-			((p1 * 2.0) +
+	out = 0.5f *
+			((p1 * 2.0f) +
 					(-p0 + p2) * t +
-					(2.0 * p0 - 5.0 * p1 + 4.0 * p2 - p3) * t2 +
-					(-p0 + 3.0 * p1 - 3.0 * p2 + p3) * t3);
+					(2.0f * p0 - 5.0f * p1 + 4.0f * p2 - p3) * t2 +
+					(-p0 + 3.0f * p1 - 3.0f * p2 + p3) * t3);
 	return out;
 }
 

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -108,22 +108,22 @@ struct _NO_DISCARD_ Vector3 {
 		Vector3 n = *this;
 		n /= Math::abs(n.x) + Math::abs(n.y) + Math::abs(n.z);
 		Vector2 o;
-		if (n.z >= 0.0) {
+		if (n.z >= 0.0f) {
 			o.x = n.x;
 			o.y = n.y;
 		} else {
-			o.x = (1.0 - Math::abs(n.y)) * (n.x >= 0.0 ? 1.0 : -1.0);
-			o.y = (1.0 - Math::abs(n.x)) * (n.y >= 0.0 ? 1.0 : -1.0);
+			o.x = (1.0f - Math::abs(n.y)) * (n.x >= 0.0f ? 1.0f : -1.0f);
+			o.y = (1.0f - Math::abs(n.x)) * (n.y >= 0.0f ? 1.0f : -1.0f);
 		}
-		o.x = o.x * 0.5 + 0.5;
-		o.y = o.y * 0.5 + 0.5;
+		o.x = o.x * 0.5f + 0.5f;
+		o.y = o.y * 0.5f + 0.5f;
 		return o;
 	}
 
 	static _FORCE_INLINE_ Vector3 octahedron_decode(const Vector2 &p_oct) {
-		Vector2 f(p_oct.x * 2.0 - 1.0, p_oct.y * 2.0 - 1.0);
+		Vector2 f(p_oct.x * 2.0f - 1.0f, p_oct.y * 2.0f - 1.0f);
 		Vector3 n(f.x, f.y, 1.0f - Math::abs(f.x) - Math::abs(f.y));
-		float t = CLAMP(-n.z, 0.0, 1.0);
+		float t = CLAMP(-n.z, 0.0f, 1.0f);
 		n.x += n.x >= 0 ? -t : t;
 		n.y += n.y >= 0 ? -t : t;
 		return n.normalized();
@@ -243,7 +243,7 @@ Vector3 Vector3::lerp(const Vector3 &p_to, const real_t p_weight) const {
 Vector3 Vector3::slerp(const Vector3 &p_to, const real_t p_weight) const {
 	real_t start_length_sq = length_squared();
 	real_t end_length_sq = p_to.length_squared();
-	if (unlikely(start_length_sq == 0.0 || end_length_sq == 0.0)) {
+	if (unlikely(start_length_sq == 0.0f || end_length_sq == 0.0f)) {
 		// Zero length vectors have no angle, so the best we can do is either lerp or throw an error.
 		return lerp(p_to, p_weight);
 	}
@@ -477,7 +477,7 @@ bool Vector3::is_normalized() const {
 }
 
 Vector3 Vector3::inverse() const {
-	return Vector3(1.0 / x, 1.0 / y, 1.0 / z);
+	return Vector3(1.0f / x, 1.0f / y, 1.0f / z);
 }
 
 void Vector3::zero() {
@@ -500,7 +500,7 @@ Vector3 Vector3::reflect(const Vector3 &p_normal) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!p_normal.is_normalized(), Vector3(), "The normal Vector3 must be normalized.");
 #endif
-	return 2.0 * p_normal * this->dot(p_normal) - *this;
+	return 2.0f * p_normal * this->dot(p_normal) - *this;
 }
 
 #endif // VECTOR3_H


### PR DESCRIPTION
Converts float literals from double format (e.g. `0.0`) to float format (e.g. `0.0f`) where appropriate for 32 bit calculations.

As discussed in the PR meeting, there was a desire for 2 PRs, this one, including changes to use `0.0f` float format literals, and another one for casts to `real_t` etc.

As discussed, this covers the main classes in `core/math` which are most likely to be bottlenecks, rather than the whole codebase. The exception is BVH which makes more sense to do in the next sync with 3.x.

See #56396 for details.

## Introduction
After some investigation using godbolt using clang, gcc, msvc, ARM and all major compilers, it turns out that our technique of using double literals in float calculations `0.0` is problematic because it causes promotion of the calculation to occur in 64 bit.

This involves:
* Converting arguments from 32 to 64 bit
* Calculation in 64 bit (potentially slower because the SIMD instruction is wider, less can be done at once)
* Converting result back to 32 bit 

This is considerably less efficient than simply doing the calculation in 32 bit in a single instruction, which is normally the intention. The difference this makes in terms of speed / power use etc will depend on the platform - some mobiles may be particularly sensitive. The binary may also be slightly smaller too, but probably not by a huge margin.

There appear to be 3 obvious ways of resolving this problem:
* Specify the literal as a float e.g. `0.0f`
* Cast the value to `float` (or `real_t` depending on usage)
* Use a macro to cast to e.g. `real_t`

## Caveats
Although these calculations will be be faster, the result may in some cases be very slight smidgen different. Although the arguments and results are to all extents and purposes 32 bit in the before and after case, the calculation was done at a higher precision when 64 bit was (erroneously) used.

This is equivalent to the difference between the result of 80 bit floating point calculations converted to 64 bit on the old x86 instructions. Something to be aware of when attempting e.g. deterministic repeatability, but hopefully not hugely important in terms of result accuracy (although we might watch for any possible difference in e.g. physics). This would have been nice to have avoided by doing all the calculations at 32 bit from the get go, but it seems worth investigating this change.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
