### PR TITLE
Decrease the default number of SDFGI cascades to 4

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -175,7 +175,7 @@
 		</member>
 		<member name="sdfgi_cascade0_distance" type="float" setter="set_sdfgi_cascade0_distance" getter="get_sdfgi_cascade0_distance" default="12.8">
 		</member>
-		<member name="sdfgi_cascades" type="int" setter="set_sdfgi_cascades" getter="get_sdfgi_cascades" default="6">
+		<member name="sdfgi_cascades" type="int" setter="set_sdfgi_cascades" getter="get_sdfgi_cascades" default="4">
 			The number of cascades to use for SDFGI (between 1 and 8). A higher number of cascades allows displaying SDFGI further away while preserving detail up close, at the cost of performance. When using SDFGI on small-scale levels, [member sdfgi_cascades] can often be decreased between [code]1[/code] and [code]4[/code] to improve performance.
 		</member>
 		<member name="sdfgi_enabled" type="bool" setter="set_sdfgi_enabled" getter="is_sdfgi_enabled" default="false">
@@ -185,7 +185,7 @@
 		</member>
 		<member name="sdfgi_energy" type="float" setter="set_sdfgi_energy" getter="get_sdfgi_energy" default="1.0">
 		</member>
-		<member name="sdfgi_max_distance" type="float" setter="set_sdfgi_max_distance" getter="get_sdfgi_max_distance" default="819.2">
+		<member name="sdfgi_max_distance" type="float" setter="set_sdfgi_max_distance" getter="get_sdfgi_max_distance" default="204.8">
 		</member>
 		<member name="sdfgi_min_cell_size" type="float" setter="set_sdfgi_min_cell_size" getter="get_sdfgi_min_cell_size" default="0.2">
 		</member>

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -147,7 +147,7 @@ private:
 
 	// SDFGI
 	bool sdfgi_enabled = false;
-	int sdfgi_cascades = 6;
+	int sdfgi_cascades = 4;
 	float sdfgi_min_cell_size = 0.2;
 	SDFGIYScale sdfgi_y_scale = SDFGI_Y_SCALE_DISABLED;
 	bool sdfgi_use_occlusion = false;

--- a/servers/rendering/renderer_rd/renderer_scene_environment_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_environment_rd.h
@@ -135,7 +135,7 @@ public:
 
 	/// SDFGI
 	bool sdfgi_enabled = false;
-	int sdfgi_cascades = 6;
+	int sdfgi_cascades = 4;
 	float sdfgi_min_cell_size = 0.2;
 	bool sdfgi_use_occlusion = false;
 	float sdfgi_bounce_feedback = 0.0;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/49738 and https://github.com/godotengine/godot/pull/54677.

This improves rendering performance noticeably, especially when the camera moves fast. The SDFGI detail remains identical otherwise.

On a medium-sized test scene on a GTX 1080 in 2560×1440, going from 6 to cascades saves 0.5 ms of frame time while looking visually identical (as most of the scene fits within the 4 cascades).

For particularly large scenes, there are still benefits to using more cascades. However, there is no visual benefit to using lots of cascades in small/medium-sized scenes.

**Testing project:** [test_sdfgi_performance.zip](https://github.com/godotengine/godot/files/8010323/test_sdfgi_performance.zip)

## Preview

### Before

![2022-02-06_14 51 02](https://user-images.githubusercontent.com/180032/152684611-4f8ede24-1898-457a-a4fa-6788249165d4.png)

### After

*There is a small difference if you look outside the window, but it won't be noticeable in most situations.*

![2022-02-06_14 51 22](https://user-images.githubusercontent.com/180032/152684614-f39329c2-ac3c-4702-81cc-5c138523e6fb.png)
