### PR TITLE
[HTML5] PWA cache-first strategy, update detection and forced updates.

### DIFF
--- a/doc/classes/JavaScript.xml
+++ b/doc/classes/JavaScript.xml
@@ -53,5 +53,27 @@
 				Returns an interface to a JavaScript object that can be used by scripts. The [code]interface[/code] must be a valid property of the JavaScript [code]window[/code]. The callback must accept a single [Array] argument, which will contain the JavaScript [code]arguments[/code]. See [JavaScriptObject] for usage.
 			</description>
 		</method>
+		<method name="pwa_needs_update" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if a new version of the progressive web app is waiting to be activated.
+				[b]Note:[/b] Only relevant when exported as a Progressive Web App.
+			</description>
+		</method>
+		<method name="pwa_update">
+			<return type="int" enum="Error" />
+			<description>
+				Performs the live update of the progressive web app. Forcing the new version to be installed and the page to be reloaded.
+				[b]Note:[/b] Your application will be [b]reloaded in all browser tabs[/b].
+				[b]Note:[/b] Only relevant when exported as a Progressive Web App and [method pwa_needs_update] returns [code]true[/code].
+			</description>
+		</method>
 	</methods>
+	<signals>
+		<signal name="pwa_update_available">
+			<description>
+				Emitted when an update for this progressive web app has been detected but is waiting to be activated because a previous version is active. See [method pwa_update] to force the update to take place immediately.
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/misc/dist/html/editor.html
+++ b/misc/dist/html/editor.html
@@ -265,6 +265,7 @@
 		<button id="btn-close-editor" class="btn close-btn" disabled="disabled" onclick="closeEditor()">×</button>
 		<button id="btn-tab-game" class="btn tab-btn" disabled="disabled" onclick="showTab('game')">Game</button>
 		<button id="btn-close-game" class="btn close-btn"  disabled="disabled" onclick="closeGame()">×</button>
+		<button id="btn-tab-update" class="btn tab-btn" style="display: none;">Update</button>
 	</div>
 	<div id="tabs">
 		<div id="tab-loader">
@@ -324,10 +325,39 @@
 			<div id="status-notice" class="godot" style="display: none;"></div>
 		</div>
 	</div>
-	<script>
+	<script>//<![CDATA[
 		window.addEventListener("load", () => {
+			function notifyUpdate(sw) {
+				const btn = document.getElementById("btn-tab-update");
+				btn.onclick = function () {
+					if (!window.confirm("Are you sure you want to update?\nClicking \"OK\" will reload all active instances!")) {
+						return;
+					}
+					sw.postMessage("update");
+					btn.innerHTML = "Updating...";
+					btn.disabled = true;
+				};
+				btn.style.display = "";
+			}
 			if ("serviceWorker" in navigator) {
-				navigator.serviceWorker.register("service.worker.js");
+				navigator.serviceWorker.register("service.worker.js").then(function (reg) {
+					if (reg.waiting) {
+						notifyUpdate(reg.waiting);
+					}
+					reg.addEventListener("updatefound", function () {
+						const update = reg.installing;
+						update.addEventListener("statechange", function () {
+							if (update.state === "installed") {
+								// It's a new install, claim and perform aggressive caching.
+								if (!reg.active) {
+									update.postMessage("claim");
+								} else {
+									notifyUpdate(update);
+								}
+							}
+						});
+					});
+				});
 			}
 
 			if (localStorage.getItem("welcomeModalDismissed") !== 'true') {
@@ -342,7 +372,7 @@
 				localStorage.setItem("welcomeModalDismissed", 'true');
 			}
 		}
-	</script>
+	//]]></script>
 	<script src="godot.tools.js"></script>
 	<script>//<![CDATA[
 

--- a/platform/javascript/api/api.cpp
+++ b/platform/javascript/api/api.cpp
@@ -71,6 +71,9 @@ void JavaScript::_bind_methods() {
 		ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "create_object", &JavaScript::_create_object_bind, mi);
 	}
 	ClassDB::bind_method(D_METHOD("download_buffer", "buffer", "name", "mime"), &JavaScript::download_buffer, DEFVAL("application/octet-stream"));
+	ClassDB::bind_method(D_METHOD("pwa_needs_update"), &JavaScript::pwa_needs_update);
+	ClassDB::bind_method(D_METHOD("pwa_update"), &JavaScript::pwa_update);
+	ADD_SIGNAL(MethodInfo("pwa_update_available"));
 }
 
 #if !defined(JAVASCRIPT_ENABLED) || !defined(JAVASCRIPT_EVAL_ENABLED)
@@ -102,6 +105,12 @@ Variant JavaScript::_create_object_bind(const Variant **p_args, int p_argcount, 
 }
 #endif
 #if !defined(JAVASCRIPT_ENABLED)
+bool JavaScript::pwa_needs_update() const {
+	return false;
+}
+Error JavaScript::pwa_update() {
+	return ERR_UNAVAILABLE;
+}
 void JavaScript::download_buffer(Vector<uint8_t> p_arr, const String &p_name, const String &p_mime) {
 }
 #endif

--- a/platform/javascript/api/javascript_singleton.h
+++ b/platform/javascript/api/javascript_singleton.h
@@ -59,6 +59,8 @@ public:
 	Ref<JavaScriptObject> create_callback(const Callable &p_callable);
 	Variant _create_object_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 	void download_buffer(Vector<uint8_t> p_arr, const String &p_name, const String &p_mime = "application/octet-stream");
+	bool pwa_needs_update() const;
+	Error pwa_update();
 
 	static JavaScript *get_singleton();
 	JavaScript();

--- a/platform/javascript/export/export_plugin.cpp
+++ b/platform/javascript/export/export_plugin.cpp
@@ -139,8 +139,7 @@ void EditorExportPlatformJavaScript::_fix_html(Vector<uint8_t> &p_html, const Re
 	}
 	if (p_preset->get("progressive_web_app/enabled")) {
 		head_include += "<link rel='manifest' href='" + p_name + ".manifest.json'>\n";
-		head_include += "<script type='application/javascript'>window.addEventListener('load', () => {if ('serviceWorker' in navigator) {navigator.serviceWorker.register('" +
-				p_name + ".service.worker.js');}});</script>\n";
+		config["serviceWorker"] = p_name + ".service.worker.js";
 	}
 
 	// Replaces HTML string
@@ -188,35 +187,46 @@ Error EditorExportPlatformJavaScript::_add_manifest_icon(const String &p_path, c
 }
 
 Error EditorExportPlatformJavaScript::_build_pwa(const Ref<EditorExportPreset> &p_preset, const String p_path, const Vector<SharedObject> &p_shared_objects) {
+	String proj_name = ProjectSettings::get_singleton()->get_setting("application/config/name");
+	if (proj_name.is_empty()) {
+		proj_name = "Godot Game";
+	}
+
 	// Service worker
 	const String dir = p_path.get_base_dir();
 	const String name = p_path.get_file().get_basename();
 	const ExportMode mode = (ExportMode)(int)p_preset->get("variant/export_type");
 	Map<String, String> replaces;
-	replaces["@GODOT_VERSION@"] = "1";
-	replaces["@GODOT_NAME@"] = name;
+	replaces["@GODOT_VERSION@"] = String::num_int64(OS::get_singleton()->get_unix_time()) + "|" + String::num_int64(OS::get_singleton()->get_ticks_usec());
+	replaces["@GODOT_NAME@"] = proj_name.substr(0, 16);
 	replaces["@GODOT_OFFLINE_PAGE@"] = name + ".offline.html";
-	Array files;
-	replaces["@GODOT_OPT_CACHE@"] = Variant(files).to_json_string();
-	files.push_back(name + ".html");
-	files.push_back(name + ".js");
-	files.push_back(name + ".wasm");
-	files.push_back(name + ".pck");
-	files.push_back(name + ".offline.html");
+
+	// Files cached during worker install.
+	Array cache_files;
+	cache_files.push_back(name + ".html");
+	cache_files.push_back(name + ".js");
+	cache_files.push_back(name + ".offline.html");
 	if (p_preset->get("html/export_icon")) {
-		files.push_back(name + ".icon.png");
-		files.push_back(name + ".apple-touch-icon.png");
+		cache_files.push_back(name + ".icon.png");
+		cache_files.push_back(name + ".apple-touch-icon.png");
 	}
 	if (mode == EXPORT_MODE_THREADS) {
-		files.push_back(name + ".worker.js");
-		files.push_back(name + ".audio.worklet.js");
-	} else if (mode == EXPORT_MODE_GDNATIVE) {
-		files.push_back(name + ".side.wasm");
+		cache_files.push_back(name + ".worker.js");
+		cache_files.push_back(name + ".audio.worklet.js");
+	}
+	replaces["@GODOT_CACHE@"] = Variant(cache_files).to_json_string();
+
+	// Heavy files that are cached on demand.
+	Array opt_cache_files;
+	opt_cache_files.push_back(name + ".wasm");
+	opt_cache_files.push_back(name + ".pck");
+	if (mode == EXPORT_MODE_GDNATIVE) {
+		opt_cache_files.push_back(name + ".side.wasm");
 		for (int i = 0; i < p_shared_objects.size(); i++) {
-			files.push_back(p_shared_objects[i].path.get_file());
+			opt_cache_files.push_back(p_shared_objects[i].path.get_file());
 		}
 	}
-	replaces["@GODOT_CACHE@"] = Variant(files).to_json_string();
+	replaces["@GODOT_OPT_CACHE@"] = Variant(opt_cache_files).to_json_string();
 
 	const String sw_path = dir.plus_file(name + ".service.worker.js");
 	Vector<uint8_t> sw;
@@ -256,10 +266,6 @@ Error EditorExportPlatformJavaScript::_build_pwa(const Ref<EditorExportPreset> &
 	const int orientation = CLAMP(int(p_preset->get("progressive_web_app/orientation")), 0, 3);
 
 	Dictionary manifest;
-	String proj_name = ProjectSettings::get_singleton()->get_setting("application/config/name");
-	if (proj_name.is_empty()) {
-		proj_name = "Godot Game";
-	}
 	manifest["name"] = proj_name;
 	manifest["start_url"] = "./" + name + ".html";
 	manifest["display"] = String::utf8(modes[display]);

--- a/platform/javascript/godot_js.h
+++ b/platform/javascript/godot_js.h
@@ -49,6 +49,8 @@ extern void godot_js_os_fs_sync(void (*p_callback)());
 extern int godot_js_os_execute(const char *p_json);
 extern void godot_js_os_shell_open(const char *p_uri);
 extern int godot_js_os_hw_concurrency_get();
+extern int godot_js_pwa_cb(void (*p_callback)());
+extern int godot_js_pwa_update();
 
 // Input
 extern void godot_js_input_mouse_button_cb(int (*p_callback)(int p_pressed, int p_button, double p_x, double p_y, int p_modifiers));

--- a/platform/javascript/javascript_singleton.cpp
+++ b/platform/javascript/javascript_singleton.cpp
@@ -30,6 +30,7 @@
 
 #include "api/javascript_singleton.h"
 #include "emscripten.h"
+#include "os_javascript.h"
 
 extern "C" {
 extern void godot_js_os_download_buffer(const uint8_t *p_buf, int p_buf_size, const char *p_name, const char *p_mime);
@@ -354,4 +355,11 @@ Variant JavaScript::eval(const String &p_code, bool p_use_global_exec_context) {
 
 void JavaScript::download_buffer(Vector<uint8_t> p_arr, const String &p_name, const String &p_mime) {
 	godot_js_os_download_buffer(p_arr.ptr(), p_arr.size(), p_name.utf8().get_data(), p_mime.utf8().get_data());
+}
+
+bool JavaScript::pwa_needs_update() const {
+	return OS_JavaScript::get_singleton()->pwa_needs_update();
+}
+Error JavaScript::pwa_update() {
+	return OS_JavaScript::get_singleton()->pwa_update();
 }

--- a/platform/javascript/js/engine/config.js
+++ b/platform/javascript/js/engine/config.js
@@ -107,6 +107,13 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		 */
 		experimentalVK: false,
 		/**
+		 * The progressive web app service worker to install.
+		 * @memberof EngineConfig
+		 * @default
+		 * @type {string}
+		 */
+		serviceWorker: '',
+		/**
 		 * @ignore
 		 * @type {Array.<string>}
 		 */
@@ -249,6 +256,7 @@ const InternalConfig = function (initConfig) { // eslint-disable-line no-unused-
 		this.persistentDrops = parse('persistentDrops', this.persistentDrops);
 		this.experimentalVK = parse('experimentalVK', this.experimentalVK);
 		this.focusCanvas = parse('focusCanvas', this.focusCanvas);
+		this.serviceWorker = parse('serviceWorker', this.serviceWorker);
 		this.gdnativeLibs = parse('gdnativeLibs', this.gdnativeLibs);
 		this.fileSizes = parse('fileSizes', this.fileSizes);
 		this.args = parse('args', this.args);

--- a/platform/javascript/js/engine/engine.js
+++ b/platform/javascript/js/engine/engine.js
@@ -189,6 +189,9 @@ const Engine = (function () {
 							preloader.preloadedFiles.length = 0; // Clear memory
 							me.rtenv['callMain'](me.config.args);
 							initPromise = null;
+							if (me.config.serviceWorker && 'serviceWorker' in navigator) {
+								navigator.serviceWorker.register(me.config.serviceWorker);
+							}
 							resolve();
 						});
 					});

--- a/platform/javascript/os_javascript.h
+++ b/platform/javascript/os_javascript.h
@@ -45,11 +45,13 @@ class OS_JavaScript : public OS_Unix {
 	bool idb_is_syncing = false;
 	bool idb_available = false;
 	bool idb_needs_sync = false;
+	bool pwa_is_waiting = false;
 
 	static void main_loop_callback();
 
 	static void file_access_close_callback(const String &p_file, int p_flags);
 	static void fs_sync_callback();
+	static void update_pwa_state_callback();
 
 protected:
 	void initialize() override;
@@ -64,6 +66,9 @@ protected:
 public:
 	// Override return type to make writing static callbacks less tedious.
 	static OS_JavaScript *get_singleton();
+
+	bool pwa_needs_update() const { return pwa_is_waiting; }
+	Error pwa_update();
 
 	void initialize_joypads() override;
 


### PR DESCRIPTION
`master` version of #57485 (use that to test, master HTML5 builds are broken).

In this PR:
- PWA service worker is now registered by the Engine if the `serviceWorker` config option is set (done by the exporter).
- PWA service worker first registration is delayed to after Godot has started, trying to improve time to first interaction.
- Godot will now try to detect service workers waiting to update, allowing to force it (by reloading all blocking pages).
- PWA service worker now uses a cache-first strategy for fetched resources, cache consistency is ensured by timestamping each build cache version during export.

Example auto update code:
```gdscript
extends Node

func _ready():
	# Check if the PWA needs updating
	if JavaScript.pwa_needs_update():
		_update()
	# The state might change after startup, due to installation asynchronicity
	JavaScript.connect("pwa_update_available", self, "_update")

func _update():
        # Better ask the user if they want to reload ;)
	OS.alert("Updating PWA")
	JavaScript.pwa_update()
```

This PR also adds a (not super nice) `update` button to the Web Editor when an update is available (mostly relevant on `/latest/` endpoint), hidden when no update is detected.

![update1](https://user-images.githubusercontent.com/1687918/151831807-92f8a16f-80ab-40f2-a403-0a8de8fc2d3e.png)

![update2](https://user-images.githubusercontent.com/1687918/151831803-1df1d6ff-019c-4e5d-8c68-2e537a2cec10.png)

Hopefully fixes #56103 .
