### PR TITLE
Increase the default depth tolerance for screen-space reflections

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -206,8 +206,8 @@
 		</member>
 		<member name="sky_rotation" type="Vector3" setter="set_sky_rotation" getter="get_sky_rotation" default="Vector3(0, 0, 0)">
 		</member>
-		<member name="ss_reflections_depth_tolerance" type="float" setter="set_ssr_depth_tolerance" getter="get_ssr_depth_tolerance" default="0.2">
-			The depth tolerance for screen-space reflections.
+		<member name="ss_reflections_depth_tolerance" type="float" setter="set_ssr_depth_tolerance" getter="get_ssr_depth_tolerance" default="1.0">
+			The depth tolerance for screen-space reflections. Higher values will reduce visible artifacting in screen-space reflections, at the cost of some "hallucinated" reflections appearing due to depth buffer discontinuities. Higher values work best with mostly static camera angles, while lower values are preferred in scenes with a more dynamic camera angle (such as a first-person game).
 		</member>
 		<member name="ss_reflections_enabled" type="bool" setter="set_ssr_enabled" getter="is_ssr_enabled" default="false">
 			If [code]true[/code], screen-space reflections are enabled. Screen-space reflections are more accurate than reflections from [VoxelGI]s or [ReflectionProbe]s, but are slower and can't reflect surfaces occluded by others.

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -1244,7 +1244,7 @@ void Environment::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "ss_reflections_max_steps", PROPERTY_HINT_RANGE, "1,512,1"), "set_ssr_max_steps", "get_ssr_max_steps");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ss_reflections_fade_in", PROPERTY_HINT_EXP_EASING), "set_ssr_fade_in", "get_ssr_fade_in");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ss_reflections_fade_out", PROPERTY_HINT_EXP_EASING), "set_ssr_fade_out", "get_ssr_fade_out");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ss_reflections_depth_tolerance", PROPERTY_HINT_RANGE, "0.01,128,0.1"), "set_ssr_depth_tolerance", "get_ssr_depth_tolerance");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "ss_reflections_depth_tolerance", PROPERTY_HINT_RANGE, "0.01,128,0.01"), "set_ssr_depth_tolerance", "get_ssr_depth_tolerance");
 
 	// SSAO
 	ClassDB::bind_method(D_METHOD("set_ssao_enabled", "enabled"), &Environment::set_ssao_enabled);

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -121,7 +121,7 @@ private:
 	int ssr_max_steps = 64;
 	float ssr_fade_in = 0.15;
 	float ssr_fade_out = 2.0;
-	float ssr_depth_tolerance = 0.2;
+	float ssr_depth_tolerance = 1.0;
 	void _update_ssr();
 
 	// SSAO

--- a/servers/rendering/renderer_rd/renderer_scene_environment_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_environment_rd.h
@@ -123,7 +123,7 @@ public:
 	int ssr_max_steps = 64;
 	float ssr_fade_in = 0.15;
 	float ssr_fade_out = 2.0;
-	float ssr_depth_tolerance = 0.2;
+	float ssr_depth_tolerance = 1.0;
 
 	/// SSIL
 	///


### PR DESCRIPTION
This reduces visible artifacting in screen-space reflections. While this makes reflections less physically accurate, the reduced artifacting makes them less distracting, which I feel is generally more important for screen-space reflections.

This closes https://github.com/godotengine/godot-proposals/issues/3919.

**Testing project:** [test_ssr_roughness_master.zip](https://github.com/godotengine/godot-proposals/files/8008939/test_ssr_roughness_master.zip)

## Preview

### Before

![2022-02-05_22 11 38_depth_tolerance_0_2](https://user-images.githubusercontent.com/180032/152659316-45c11a3e-a765-448c-9441-abdf4d58f502.png)

### After

![2022-02-05_22 12 02_depth_tolerance_1_0](https://user-images.githubusercontent.com/180032/152659319-f49ae1c0-af39-41a8-b702-f4fcab5f8961.png)