### PR TITLE
Refactor some object type checking code with `cast_to`

### DIFF
--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -683,7 +683,7 @@ EditorDebuggerNode::CameraOverride EditorDebuggerNode::get_camera_override() {
 void EditorDebuggerNode::add_debugger_plugin(const Ref<Script> &p_script) {
 	ERR_FAIL_COND_MSG(debugger_plugins.has(p_script), "Debugger plugin already exists.");
 	ERR_FAIL_COND_MSG(p_script.is_null(), "Debugger plugin script is null");
-	ERR_FAIL_COND_MSG(String(p_script->get_instance_base_type()) == "", "Debugger plugin script has error.");
+	ERR_FAIL_COND_MSG(p_script->get_instance_base_type() == StringName(), "Debugger plugin script has error.");
 	ERR_FAIL_COND_MSG(String(p_script->get_instance_base_type()) != "EditorDebuggerPlugin", "Base type of debugger plugin is not 'EditorDebuggerPlugin'.");
 	ERR_FAIL_COND_MSG(!p_script->is_tool(), "Debugger plugin script is not in tool mode.");
 	debugger_plugins.insert(p_script);

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -362,21 +362,21 @@ Node *EditorAutoloadSettings::_create_autoload(const String &p_path) {
 	RES res = ResourceLoader::load(p_path);
 	ERR_FAIL_COND_V_MSG(res.is_null(), nullptr, "Can't autoload: " + p_path + ".");
 	Node *n = nullptr;
-	if (res->is_class("PackedScene")) {
-		Ref<PackedScene> ps = res;
-		n = ps->instantiate();
-	} else if (res->is_class("Script")) {
-		Ref<Script> s = res;
-		StringName ibt = s->get_instance_base_type();
+	Ref<PackedScene> scn = res;
+	Ref<Script> script = res;
+	if (scn.is_valid()) {
+		n = scn->instantiate();
+	} else if (script.is_valid()) {
+		StringName ibt = script->get_instance_base_type();
 		bool valid_type = ClassDB::is_parent_class(ibt, "Node");
 		ERR_FAIL_COND_V_MSG(!valid_type, nullptr, "Script does not inherit a Node: " + p_path + ".");
 
 		Object *obj = ClassDB::instantiate(ibt);
 
-		ERR_FAIL_COND_V_MSG(obj == nullptr, nullptr, "Cannot instance script for AutoLoad, expected 'Node' inheritance, got: " + String(ibt) + ".");
+		ERR_FAIL_COND_V_MSG(!obj, nullptr, "Cannot instance script for AutoLoad, expected 'Node' inheritance, got: " + String(ibt) + ".");
 
 		n = Object::cast_to<Node>(obj);
-		n->set_script(s);
+		n->set_script(script);
 	}
 
 	ERR_FAIL_COND_V_MSG(!n, nullptr, "Path in AutoLoad not a node or script: " + p_path + ".");

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -610,11 +610,6 @@ TreeItem *EditorHelpSearch::Runner::_create_member_item(TreeItem *p_parent, cons
 		text = p_text;
 	} else {
 		icon = ui_service->get_theme_icon(p_icon, SNAME("EditorIcons"));
-		/*// In flat mode, show the class icon.
-if (ui_service->has_icon(p_class_name, "EditorIcons"))
-icon = ui_service->get_icon(p_class_name, "EditorIcons");
-else if (ClassDB::is_parent_class(p_class_name, "Object"))
-icon = ui_service->get_icon("Object", "EditorIcons");*/
 		text = p_class_name + "." + p_text;
 	}
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2425,7 +2425,7 @@ void EditorInspector::update_tree() {
 			if (!ClassDB::class_exists(type) && !ScriptServer::is_global_class(type) && p.hint_string.length() && FileAccess::exists(p.hint_string)) {
 				// If we have a category inside a script, search for the first script with a valid icon.
 				Ref<Script> script = ResourceLoader::load(p.hint_string, "Script");
-				String base_type;
+				StringName base_type;
 				if (script.is_valid()) {
 					base_type = script->get_instance_base_type();
 				}

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -745,7 +745,6 @@ void EditorNode::_notification(int p_what) {
 
 			bottom_panel_raise->set_icon(gui_base->get_theme_icon(SNAME("ExpandBottomDock"), SNAME("EditorIcons")));
 
-			// clear_button->set_icon(gui_base->get_icon("Close", "EditorIcons")); don't have access to that node. needs to become a class property
 			if (gui_base->is_layout_rtl()) {
 				dock_tab_move_left->set_icon(theme->get_icon(SNAME("Forward"), SNAME("EditorIcons")));
 				dock_tab_move_right->set_icon(theme->get_icon(SNAME("Back"), SNAME("EditorIcons")));
@@ -2280,7 +2279,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 		if (main_plugin) {
 			// special case if use of external editor is true
 			Resource *current_res = Object::cast_to<Resource>(current_obj);
-			if (main_plugin->get_name() == "Script" && current_obj->get_class_name() != StringName("VisualScript") && current_res && !current_res->is_built_in() && (bool(EditorSettings::get_singleton()->get("text_editor/external/use_external_editor")) || overrides_external_editor(current_obj))) {
+			if (main_plugin->get_name() == "Script" && current_obj->is_class("VisualScript") && current_res && !current_res->is_built_in() && (bool(EditorSettings::get_singleton()->get("text_editor/external/use_external_editor")) || overrides_external_editor(current_obj))) {
 				if (!changing_scene) {
 					main_plugin->edit(current_obj);
 				}
@@ -3293,8 +3292,8 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled,
 			return;
 		}
 
-		// Errors in the script cause the base_type to be an empty string.
-		if (String(script->get_instance_base_type()) == "") {
+		// Errors in the script cause the base_type to be an empty StringName.
+		if (script->get_instance_base_type() == StringName()) {
 			show_warning(vformat(TTR("Unable to load addon script from path: '%s'. This might be due to a code error in that script.\nDisabling the addon at '%s' to prevent further errors."), script_path, p_addon));
 			_remove_plugin_from_enabled(p_addon);
 			return;
@@ -3937,7 +3936,7 @@ StringName EditorNode::get_object_custom_type_name(const Object *p_object) const
 	ERR_FAIL_COND_V(!p_object, StringName());
 
 	Ref<Script> script = p_object->get_script();
-	if (script.is_null() && p_object->is_class("Script")) {
+	if (script.is_null() && Object::cast_to<Script>(p_object)) {
 		script = p_object;
 	}
 
@@ -4148,13 +4147,12 @@ Ref<Texture2D> EditorNode::_file_dialog_get_icon(const String &p_path) {
 
 void EditorNode::_build_icon_type_cache() {
 	List<StringName> tl;
-	StringName ei = "EditorIcons";
-	theme_base->get_theme()->get_icon_list(ei, &tl);
+	theme_base->get_theme()->get_icon_list(SNAME("EditorIcons"), &tl);
 	for (const StringName &E : tl) {
 		if (!ClassDB::class_exists(E)) {
 			continue;
 		}
-		icon_type_cache[E] = theme_base->get_theme()->get_icon(E, ei);
+		icon_type_cache[E] = theme_base->get_theme()->get_icon(E, SNAME("EditorIcons"));
 	}
 }
 

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -77,16 +77,16 @@ void EditorResourcePicker::_update_resource_preview(const String &p_path, const 
 		return;
 	}
 
-	String type = edited_resource->get_class_name();
-	if (ClassDB::is_parent_class(type, "Script")) {
-		assign_button->set_text(edited_resource->get_path().get_file());
+	Ref<Script> script = edited_resource;
+	if (script.is_valid()) {
+		assign_button->set_text(script->get_path().get_file());
 		return;
 	}
 
 	if (p_preview.is_valid()) {
 		preview_rect->set_offset(SIDE_LEFT, assign_button->get_icon()->get_width() + assign_button->get_theme_stylebox(SNAME("normal"))->get_default_margin(SIDE_LEFT) + get_theme_constant(SNAME("hseparation"), SNAME("Button")));
 
-		if (type == "GradientTexture1D") {
+		if (Ref<GradientTexture1D>(edited_resource).is_valid()) {
 			preview_rect->set_stretch_mode(TextureRect::STRETCH_SCALE);
 			assign_button->set_custom_minimum_size(Size2(1, 1));
 		} else {
@@ -642,7 +642,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 			for (Set<String>::Element *E = allowed_types.front(); E; E = E->next()) {
 				String at = E->get().strip_edges();
 
-				if (at == "BaseMaterial3D" && ClassDB::is_parent_class(dropped_resource->get_class(), "Texture2D")) {
+				if (at == "BaseMaterial3D" && Ref<Texture2D>(dropped_resource).is_valid()) {
 					// Use existing resource if possible and only replace its data.
 					Ref<StandardMaterial3D> mat = edited_resource;
 					if (!mat.is_valid()) {
@@ -653,7 +653,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 					break;
 				}
 
-				if (at == "ShaderMaterial" && ClassDB::is_parent_class(dropped_resource->get_class(), "Shader")) {
+				if (at == "ShaderMaterial" && Ref<Shader>(dropped_resource).is_valid()) {
 					Ref<ShaderMaterial> mat = edited_resource;
 					if (!mat.is_valid()) {
 						mat.instantiate();
@@ -663,7 +663,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 					break;
 				}
 
-				if (at == "Font" && ClassDB::is_parent_class(dropped_resource->get_class(), "FontData")) {
+				if (at == "Font" && Ref<FontData>(dropped_resource).is_valid()) {
 					Ref<Font> font = edited_resource;
 					if (!font.is_valid()) {
 						font.instantiate();
@@ -673,7 +673,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 					break;
 				}
 
-				if (at == "Texture2D" && ClassDB::is_parent_class(dropped_resource->get_class(), "Image")) {
+				if (at == "Texture2D" && Ref<Image>(dropped_resource).is_valid()) {
 					Ref<ImageTexture> texture = edited_resource;
 					if (!texture.is_valid()) {
 						texture.instantiate();

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -338,30 +338,28 @@ void FileSystemDock::_notification(int p_what) {
 			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &FileSystemDock::_fs_changed));
 			EditorResourcePreview::get_singleton()->connect("preview_invalidated", callable_mp(this, &FileSystemDock::_preview_invalidated));
 
-			String ei = "EditorIcons";
-
-			button_reload->set_icon(get_theme_icon(SNAME("Reload"), ei));
-			button_toggle_display_mode->set_icon(get_theme_icon(SNAME("Panels2"), ei));
+			button_reload->set_icon(get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
+			button_toggle_display_mode->set_icon(get_theme_icon(SNAME("Panels2"), SNAME("EditorIcons")));
 			button_file_list_display_mode->connect("pressed", callable_mp(this, &FileSystemDock::_toggle_file_display));
 
 			files->connect("item_activated", callable_mp(this, &FileSystemDock::_file_list_activate_file));
 			button_hist_next->connect("pressed", callable_mp(this, &FileSystemDock::_fw_history));
 			button_hist_prev->connect("pressed", callable_mp(this, &FileSystemDock::_bw_history));
 
-			tree_search_box->set_right_icon(get_theme_icon(SNAME("Search"), ei));
+			tree_search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			tree_search_box->set_clear_button_enabled(true);
-			tree_button_sort->set_icon(get_theme_icon(SNAME("Sort"), ei));
+			tree_button_sort->set_icon(get_theme_icon(SNAME("Sort"), SNAME("EditorIcons")));
 
-			file_list_search_box->set_right_icon(get_theme_icon(SNAME("Search"), ei));
+			file_list_search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			file_list_search_box->set_clear_button_enabled(true);
-			file_list_button_sort->set_icon(get_theme_icon(SNAME("Sort"), ei));
+			file_list_button_sort->set_icon(get_theme_icon(SNAME("Sort"), SNAME("EditorIcons")));
 
 			if (is_layout_rtl()) {
-				button_hist_next->set_icon(get_theme_icon(SNAME("Back"), ei));
-				button_hist_prev->set_icon(get_theme_icon(SNAME("Forward"), ei));
+				button_hist_next->set_icon(get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
+				button_hist_prev->set_icon(get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
 			} else {
-				button_hist_next->set_icon(get_theme_icon(SNAME("Forward"), ei));
-				button_hist_prev->set_icon(get_theme_icon(SNAME("Back"), ei));
+				button_hist_next->set_icon(get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
+				button_hist_prev->set_icon(get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
 			}
 			file_list_popup->connect("id_pressed", callable_mp(this, &FileSystemDock::_file_list_rmb_option));
 			tree_popup->connect("id_pressed", callable_mp(this, &FileSystemDock::_tree_rmb_option));
@@ -412,15 +410,14 @@ void FileSystemDock::_notification(int p_what) {
 
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			// Update icons.
-			String ei = "EditorIcons";
-			button_reload->set_icon(get_theme_icon(SNAME("Reload"), ei));
-			button_toggle_display_mode->set_icon(get_theme_icon(SNAME("Panels2"), ei));
+			button_reload->set_icon(get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
+			button_toggle_display_mode->set_icon(get_theme_icon(SNAME("Panels2"), SNAME("EditorIcons")));
 			if (is_layout_rtl()) {
-				button_hist_next->set_icon(get_theme_icon(SNAME("Back"), ei));
-				button_hist_prev->set_icon(get_theme_icon(SNAME("Forward"), ei));
+				button_hist_next->set_icon(get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
+				button_hist_prev->set_icon(get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
 			} else {
-				button_hist_next->set_icon(get_theme_icon(SNAME("Forward"), ei));
-				button_hist_prev->set_icon(get_theme_icon(SNAME("Back"), ei));
+				button_hist_next->set_icon(get_theme_icon(SNAME("Forward"), SNAME("EditorIcons")));
+				button_hist_prev->set_icon(get_theme_icon(SNAME("Back"), SNAME("EditorIcons")));
 			}
 			if (file_list_display_mode == FILE_LIST_DISPLAY_LIST) {
 				button_file_list_display_mode->set_icon(get_theme_icon(SNAME("FileThumbnail"), SNAME("EditorIcons")));
@@ -428,13 +425,13 @@ void FileSystemDock::_notification(int p_what) {
 				button_file_list_display_mode->set_icon(get_theme_icon(SNAME("FileList"), SNAME("EditorIcons")));
 			}
 
-			tree_search_box->set_right_icon(get_theme_icon(SNAME("Search"), ei));
+			tree_search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			tree_search_box->set_clear_button_enabled(true);
-			tree_button_sort->set_icon(get_theme_icon(SNAME("Sort"), ei));
+			tree_button_sort->set_icon(get_theme_icon(SNAME("Sort"), SNAME("EditorIcons")));
 
-			file_list_search_box->set_right_icon(get_theme_icon(SNAME("Search"), ei));
+			file_list_search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			file_list_search_box->set_clear_button_enabled(true);
-			file_list_button_sort->set_icon(get_theme_icon(SNAME("Sort"), ei));
+			file_list_button_sort->set_icon(get_theme_icon(SNAME("Sort"), SNAME("EditorIcons")));
 
 			// Update always show folders.
 			bool new_always_show_folders = bool(EditorSettings::get_singleton()->get("docks/filesystem/always_show_folders"));
@@ -718,7 +715,6 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 	String directory = path;
 	String file = "";
 
-	String ei = "EditorIcons";
 	int thumbnail_size = EditorSettings::get_singleton()->get("docks/filesystem/thumbnail_size");
 	thumbnail_size *= EDSCALE;
 	Ref<Texture2D> folder_thumbnail;
@@ -736,13 +732,13 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 		files->set_fixed_icon_size(Size2(thumbnail_size, thumbnail_size));
 
 		if (thumbnail_size < 64) {
-			folder_thumbnail = get_theme_icon(SNAME("FolderMediumThumb"), ei);
-			file_thumbnail = get_theme_icon(SNAME("FileMediumThumb"), ei);
-			file_thumbnail_broken = get_theme_icon(SNAME("FileDeadMediumThumb"), ei);
+			folder_thumbnail = get_theme_icon(SNAME("FolderMediumThumb"), SNAME("EditorIcons"));
+			file_thumbnail = get_theme_icon(SNAME("FileMediumThumb"), SNAME("EditorIcons"));
+			file_thumbnail_broken = get_theme_icon(SNAME("FileDeadMediumThumb"), SNAME("EditorIcons"));
 		} else {
-			folder_thumbnail = get_theme_icon(SNAME("FolderBigThumb"), ei);
-			file_thumbnail = get_theme_icon(SNAME("FileBigThumb"), ei);
-			file_thumbnail_broken = get_theme_icon(SNAME("FileDeadBigThumb"), ei);
+			folder_thumbnail = get_theme_icon(SNAME("FolderBigThumb"), SNAME("EditorIcons"));
+			file_thumbnail = get_theme_icon(SNAME("FileBigThumb"), SNAME("EditorIcons"));
+			file_thumbnail_broken = get_theme_icon(SNAME("FileDeadBigThumb"), SNAME("EditorIcons"));
 		}
 	} else {
 		// No thumbnails.
@@ -871,7 +867,6 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 
 	// Fills the ItemList control node from the FileInfos.
 	String main_scene = ProjectSettings::get_singleton()->get("application/run/main_scene");
-	String oi = "Object";
 	for (FileInfo &E : file_list) {
 		FileInfo *finfo = &(E);
 		String fname = finfo->name;
@@ -885,10 +880,10 @@ void FileSystemDock::_update_file_list(bool p_keep_selection) {
 
 		// Select the icons.
 		if (!finfo->import_broken) {
-			type_icon = (has_theme_icon(ftype, ei)) ? get_theme_icon(ftype, ei) : get_theme_icon(oi, ei);
+			type_icon = (has_theme_icon(ftype, SNAME("EditorIcons"))) ? get_theme_icon(ftype, SNAME("EditorIcons")) : get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
 			big_icon = file_thumbnail;
 		} else {
-			type_icon = get_theme_icon(SNAME("ImportFail"), ei);
+			type_icon = get_theme_icon(SNAME("ImportFail"), SNAME("EditorIcons"));
 			big_icon = file_thumbnail_broken;
 			tooltip += "\n" + TTR("Status: Import of file failed. Please fix file and reimport manually.");
 		}

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -300,7 +300,7 @@ void AnimationNodeBlendTreeEditor::_add_node(int p_idx) {
 		base_name = add_options[p_idx].name;
 	} else {
 		ERR_FAIL_COND(add_options[p_idx].script.is_null());
-		String base_type = add_options[p_idx].script->get_instance_base_type();
+		StringName base_type = add_options[p_idx].script->get_instance_base_type();
 		AnimationNode *an = Object::cast_to<AnimationNode>(ClassDB::instantiate(base_type));
 		ERR_FAIL_COND(!an);
 		anode = Ref<AnimationNode>(an);

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -188,7 +188,7 @@ bool EditorImagePreviewPlugin::generate_small_preview_automatically() const {
 }
 
 ////////////////////////////////////////////////////////////////////////////
-/////////////////////////////////////////////////
+
 bool EditorBitmapPreviewPlugin::handles(const String &p_type) const {
 	return ClassDB::is_parent_class(p_type, "BitMap");
 }
@@ -308,7 +308,7 @@ void EditorMaterialPreviewPlugin::_preview_done() {
 }
 
 bool EditorMaterialPreviewPlugin::handles(const String &p_type) const {
-	return ClassDB::is_parent_class(p_type, "Material"); //any material
+	return ClassDB::is_parent_class(p_type, "Material"); // Any material.
 }
 
 bool EditorMaterialPreviewPlugin::generate_small_preview_automatically() const {
@@ -699,7 +699,7 @@ void EditorMeshPreviewPlugin::_preview_done() {
 }
 
 bool EditorMeshPreviewPlugin::handles(const String &p_type) const {
-	return ClassDB::is_parent_class(p_type, "Mesh"); //any Mesh
+	return ClassDB::is_parent_class(p_type, "Mesh"); // Any mesh.
 }
 
 Ref<Texture2D> EditorMeshPreviewPlugin::generate(const RES &p_from, const Size2 &p_size) const {

--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -132,10 +132,7 @@ PackedSceneEditorTranslationParserPlugin::PackedSceneEditorTranslationParserPlug
 	lookup_properties.insert("script");
 
 	// Exception list (to prevent false positives).
-	exception_list.insert("LineEdit", Vector<StringName>());
-	exception_list["LineEdit"].append("text");
-	exception_list.insert("TextEdit", Vector<StringName>());
-	exception_list["TextEdit"].append("text");
-	exception_list.insert("CodeEdit", Vector<StringName>());
-	exception_list["CodeEdit"].append("text");
+	exception_list.insert("LineEdit", { "text" });
+	exception_list.insert("TextEdit", { "text" });
+	exception_list.insert("CodeEdit", { "text" });
 }

--- a/editor/plugins/packed_scene_translation_parser_plugin.h
+++ b/editor/plugins/packed_scene_translation_parser_plugin.h
@@ -37,9 +37,9 @@ class PackedSceneEditorTranslationParserPlugin : public EditorTranslationParserP
 	GDCLASS(PackedSceneEditorTranslationParserPlugin, EditorTranslationParserPlugin);
 
 	// Scene Node's properties that contain translation strings.
-	Set<StringName> lookup_properties;
+	Set<String> lookup_properties;
 	// Properties from specific Nodes that should be ignored.
-	Map<StringName, Vector<StringName>> exception_list;
+	Map<String, Vector<String>> exception_list;
 
 public:
 	virtual Error parse_file(const String &p_path, Vector<String> *r_ids, Vector<Vector<String>> *r_ids_ctx_plural) override;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2265,7 +2265,7 @@ bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_gra
 	if (use_external_editor &&
 			(EditorDebuggerNode::get_singleton()->get_dump_stack_script() != p_resource || EditorDebuggerNode::get_singleton()->get_debug_with_external_editor()) &&
 			p_resource->get_path().is_resource_file() &&
-			p_resource->get_class_name() != StringName("VisualScript")) {
+			!Ref<VisualScript>(p_resource).is_valid()) {
 		String path = EditorSettings::get_singleton()->get("text_editor/external/exec_path");
 		String flags = EditorSettings::get_singleton()->get("text_editor/external/exec_flags");
 
@@ -2364,7 +2364,7 @@ bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_gra
 
 	se->set_edited_resource(p_resource);
 
-	if (p_resource->get_class_name() != StringName("VisualScript")) {
+	if (!Ref<VisualScript>(p_resource).is_valid()) {
 		bool highlighter_set = false;
 		for (int i = 0; i < syntax_highlighters.size(); i++) {
 			Ref<EditorSyntaxHighlighter> highlighter = syntax_highlighters[i]->_create();

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1373,7 +1373,7 @@ void ScriptTextEditor::reload(bool p_soft) {
 		return;
 	}
 	scr->set_source_code(te->get_text());
-	bool soft = p_soft || scr->get_instance_base_type() == "EditorPlugin"; //always soft-reload editor plugins
+	bool soft = p_soft || scr->get_instance_base_type() == "EditorPlugin"; // Always soft-reload editor plugins.
 
 	scr->get_language()->reload_tool_script(scr, soft);
 }

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -2584,7 +2584,7 @@ void VisualShaderEditor::_add_node(int p_idx, const Vector<Variant> &p_ops, Stri
 		vsnode = Ref<VisualShaderNode>(vsn);
 	} else {
 		ERR_FAIL_COND(add_options[p_idx].script.is_null());
-		String base_type = add_options[p_idx].script->get_instance_base_type();
+		StringName base_type = add_options[p_idx].script->get_instance_base_type();
 		VisualShaderNode *vsn = Object::cast_to<VisualShaderNode>(ClassDB::instantiate(base_type));
 		ERR_FAIL_COND(!vsn);
 		vsnode = Ref<VisualShaderNode>(vsn);

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1275,8 +1275,6 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	set_hide_on_ok(false);
 
-	editor_icons = "EditorIcons";
-
 	default_filename = EditorSettings::get_singleton()->get_project_metadata("export_options", "default_filename", "");
 	// If no default set, use project name
 	if (default_filename.is_empty()) {

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -85,8 +85,6 @@ private:
 	Label *include_label;
 	MarginContainer *include_margin;
 
-	StringName editor_icons;
-
 	Button *export_button;
 	Button *export_all_button;
 	AcceptDialog *export_all_dialog;

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -766,7 +766,7 @@ Variant NativeScriptInstance::call(const StringName &p_method, const Variant **p
 void NativeScriptInstance::notification(int p_notification) {
 #ifdef DEBUG_ENABLED
 	if (p_notification == MainLoop::NOTIFICATION_CRASH) {
-		if (current_method_call != StringName("")) {
+		if (current_method_call != StringName()) {
 			ERR_PRINT("NativeScriptInstance detected crash on method: " + current_method_call);
 			current_method_call = "";
 		}

--- a/modules/gdnative/pluginscript/pluginscript_script.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_script.cpp
@@ -93,7 +93,7 @@ Variant PluginScript::_new(const Variant **p_args, int p_argcount, Callable::Cal
 	REF ref;
 	Object *owner = nullptr;
 
-	if (get_instance_base_type() == "") {
+	if (get_instance_base_type() == StringName()) {
 		owner = memnew(RefCounted);
 	} else {
 		owner = ClassDB::instantiate(get_instance_base_type());

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -196,7 +196,7 @@ Error GDScriptAnalyzer::check_class_member_name_conflict(const GDScriptParser::C
 	}
 
 	if (current_data_type && current_data_type->kind == GDScriptParser::DataType::Kind::NATIVE) {
-		if (current_data_type->native_type != StringName("")) {
+		if (current_data_type->native_type != StringName()) {
 			return check_native_member_name_conflict(
 					p_member_name,
 					p_member_node,
@@ -250,7 +250,7 @@ Error GDScriptAnalyzer::resolve_inheritance(GDScriptParser::ClassNode *p_class, 
 	if (!p_class->extends_used) {
 		result.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
 		result.kind = GDScriptParser::DataType::NATIVE;
-		result.native_type = "RefCounted";
+		result.native_type = SNAME("RefCounted");
 	} else {
 		result.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
 
@@ -438,7 +438,7 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 
 	StringName first = p_type->type_chain[0]->name;
 
-	if (first == "Variant") {
+	if (first == SNAME("Variant")) {
 		result.kind = GDScriptParser::DataType::VARIANT;
 		if (p_type->type_chain.size() > 1) {
 			push_error(R"("Variant" type don't contain nested types.)", p_type->type_chain[1]);
@@ -447,9 +447,9 @@ GDScriptParser::DataType GDScriptAnalyzer::resolve_datatype(GDScriptParser::Type
 		return result;
 	}
 
-	if (first == "Object") {
+	if (first == SNAME("Object")) {
 		result.kind = GDScriptParser::DataType::NATIVE;
-		result.native_type = "Object";
+		result.native_type = SNAME("Object");
 		if (p_type->type_chain.size() > 1) {
 			push_error(R"("Object" type don't contain nested types.)", p_type->type_chain[1]);
 			return GDScriptParser::DataType();
@@ -2552,7 +2552,7 @@ void GDScriptAnalyzer::reduce_get_node(GDScriptParser::GetNodeNode *p_get_node) 
 	GDScriptParser::DataType result;
 	result.type_source = GDScriptParser::DataType::ANNOTATED_EXPLICIT;
 	result.kind = GDScriptParser::DataType::NATIVE;
-	result.native_type = "Node";
+	result.native_type = SNAME("Node");
 	result.builtin_type = Variant::OBJECT;
 
 	if (!ClassDB::is_parent_class(parser->current_class->base_type.native_type, result.native_type)) {
@@ -3524,7 +3524,7 @@ GDScriptParser::DataType GDScriptAnalyzer::type_from_property(const PropertyInfo
 	result.builtin_type = p_property.type;
 	if (p_property.type == Variant::OBJECT) {
 		result.kind = GDScriptParser::DataType::NATIVE;
-		result.native_type = p_property.class_name == StringName() ? "Object" : p_property.class_name;
+		result.native_type = p_property.class_name == StringName() ? SNAME("Object") : p_property.class_name;
 	} else {
 		result.kind = GDScriptParser::DataType::BUILTIN;
 		result.builtin_type = p_property.type;

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -652,7 +652,7 @@ static void _get_directory_contents(EditorFileSystemDirectory *p_dir, Map<String
 }
 
 static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_annotation, int p_argument, const String p_quote_style, Map<String, ScriptCodeCompletionOption> &r_result) {
-	if (p_annotation->name == "@export_range") {
+	if (p_annotation->name == SNAME("@export_range")) {
 		if (p_argument == 3 || p_argument == 4) {
 			// Slider hint.
 			ScriptCodeCompletionOption slider1("or_greater", ScriptCodeCompletionOption::KIND_PLAIN_TEXT);
@@ -662,7 +662,7 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 			slider2.insert_text = slider2.display.quote(p_quote_style);
 			r_result.insert(slider2.display, slider2);
 		}
-	} else if (p_annotation->name == "@export_exp_easing") {
+	} else if (p_annotation->name == SNAME("@export_exp_easing")) {
 		if (p_argument == 0 || p_argument == 1) {
 			// Easing hint.
 			ScriptCodeCompletionOption hint1("attenuation", ScriptCodeCompletionOption::KIND_PLAIN_TEXT);
@@ -672,7 +672,7 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 			hint2.insert_text = hint2.display.quote(p_quote_style);
 			r_result.insert(hint2.display, hint2);
 		}
-	} else if (p_annotation->name == "@export_node_path") {
+	} else if (p_annotation->name == SNAME("@export_node_path")) {
 		ScriptCodeCompletionOption node("Node", ScriptCodeCompletionOption::KIND_CLASS);
 		r_result.insert(node.display, node);
 		List<StringName> node_types;
@@ -684,7 +684,7 @@ static void _find_annotation_arguments(const GDScriptParser::AnnotationNode *p_a
 			ScriptCodeCompletionOption option(E, ScriptCodeCompletionOption::KIND_CLASS);
 			r_result.insert(option.display, option);
 		}
-	} else if (p_annotation->name == "@warning_ignore") {
+	} else if (p_annotation->name == SNAME("@warning_ignore")) {
 		for (int warning_code = 0; warning_code < GDScriptWarning::WARNING_MAX; warning_code++) {
 			ScriptCodeCompletionOption warning(GDScriptWarning::get_name_from_code((GDScriptWarning::Code)warning_code).to_lower(), ScriptCodeCompletionOption::KIND_PLAIN_TEXT);
 			r_result.insert(warning.display, warning);
@@ -1384,7 +1384,7 @@ static bool _guess_expression_type(GDScriptParser::CompletionContext &p_context,
 
 								Object *baseptr = base.value;
 
-								if (all_is_const && String(call->function_name) == "get_node" && ClassDB::is_parent_class(native_type.native_type, "Node") && args.size()) {
+								if (all_is_const && call->function_name == SNAME("get_node") && ClassDB::is_parent_class(native_type.native_type, SNAME("Node")) && args.size()) {
 									String arg1 = args[0];
 									if (arg1.begins_with("/root/")) {
 										String which = arg1.get_slice("/", 2);
@@ -2085,7 +2085,7 @@ static bool _guess_method_return_type_from_base(GDScriptParser::CompletionContex
 	GDScriptParser::DataType base_type = p_base.type;
 	bool is_static = base_type.is_meta_type;
 
-	if (is_static && p_method == "new") {
+	if (is_static && p_method == SNAME("new")) {
 		r_type.type = base_type;
 		r_type.type.is_meta_type = false;
 		r_type.type.is_constant = false;
@@ -2274,7 +2274,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					r_arghint = _make_arguments_hint(info, p_argidx);
 				}
 
-				if (p_argidx == 0 && ClassDB::is_parent_class(class_name, "Node") && (p_method == "get_node" || p_method == "has_node")) {
+				if (p_argidx == 0 && ClassDB::is_parent_class(class_name, SNAME("Node")) && (p_method == SNAME("get_node") || p_method == SNAME("has_node"))) {
 					// Get autoloads
 					List<PropertyInfo> props;
 					ProjectSettings::get_singleton()->get_property_list(&props);
@@ -2291,7 +2291,7 @@ static void _find_call_arguments(GDScriptParser::CompletionContext &p_context, c
 					}
 				}
 
-				if (p_argidx == 0 && method_args > 0 && ClassDB::is_parent_class(class_name, "InputEvent") && p_method.operator String().contains("action")) {
+				if (p_argidx == 0 && method_args > 0 && ClassDB::is_parent_class(class_name, SNAME("InputEvent")) && p_method.operator String().contains("action")) {
 					// Get input actions
 					List<PropertyInfo> props;
 					ProjectSettings::get_singleton()->get_property_list(&props);

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -519,7 +519,7 @@ void GDScriptParser::parse_program() {
 		// Check for @tool annotation.
 		AnnotationNode *annotation = parse_annotation(AnnotationInfo::SCRIPT | AnnotationInfo::CLASS_LEVEL);
 		if (annotation != nullptr) {
-			if (annotation->name == "@tool") {
+			if (annotation->name == SNAME("@tool")) {
 				// TODO: don't allow @tool anywhere else. (Should all script annotations be the first thing?).
 				_is_tool = true;
 				if (previous.type != GDScriptTokenizer::Token::NEWLINE) {
@@ -573,7 +573,7 @@ void GDScriptParser::parse_program() {
 		// Check for @icon annotation.
 		AnnotationNode *annotation = parse_annotation(AnnotationInfo::SCRIPT | AnnotationInfo::CLASS_LEVEL);
 		if (annotation != nullptr) {
-			if (annotation->name == "@icon") {
+			if (annotation->name == SNAME("@icon")) {
 				if (previous.type != GDScriptTokenizer::Token::NEWLINE) {
 					push_error(R"(Expected newline after "@icon" annotation.)");
 				}
@@ -3503,7 +3503,7 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 	// This is called after the analyzer is done finding the type, so this should be set here.
 	DataType export_type = variable->get_datatype();
 
-	if (p_annotation->name == "@export") {
+	if (p_annotation->name == SNAME("@export")) {
 		if (variable->datatype_specifier == nullptr && variable->initializer == nullptr) {
 			push_error(R"(Cannot use simple "@export" annotation with variable without type or initializer, since type can't be inferred.)", p_annotation);
 			return false;
@@ -3528,7 +3528,7 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 				variable->export_info.hint_string = Variant::get_type_name(export_type.builtin_type);
 				break;
 			case GDScriptParser::DataType::NATIVE:
-				if (ClassDB::is_parent_class(export_type.native_type, "Resource")) {
+				if (ClassDB::is_parent_class(export_type.native_type, SNAME("Resource"))) {
 					variable->export_info.type = Variant::OBJECT;
 					variable->export_info.hint = PROPERTY_HINT_RESOURCE_TYPE;
 					variable->export_info.hint_string = export_type.native_type;

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -73,23 +73,21 @@ void init_autoloads() {
 		RES res = ResourceLoader::load(info.path);
 		ERR_CONTINUE_MSG(res.is_null(), "Can't autoload: " + info.path);
 		Node *n = nullptr;
-		if (res->is_class("PackedScene")) {
-			Ref<PackedScene> ps = res;
-			n = ps->instantiate();
-		} else if (res->is_class("Script")) {
-			Ref<Script> script_res = res;
-			StringName ibt = script_res->get_instance_base_type();
+		Ref<PackedScene> scn = res;
+		Ref<Script> script = res;
+		if (scn.is_valid()) {
+			n = scn->instantiate();
+		} else if (script.is_valid()) {
+			StringName ibt = script->get_instance_base_type();
 			bool valid_type = ClassDB::is_parent_class(ibt, "Node");
 			ERR_CONTINUE_MSG(!valid_type, "Script does not inherit a Node: " + info.path);
 
 			Object *obj = ClassDB::instantiate(ibt);
 
-			ERR_CONTINUE_MSG(obj == nullptr,
-					"Cannot instance script for autoload, expected 'Node' inheritance, got: " +
-							String(ibt));
+			ERR_CONTINUE_MSG(!obj, "Cannot instance script for autoload, expected 'Node' inheritance, got: " + String(ibt) + ".");
 
 			n = Object::cast_to<Node>(obj);
-			n->set_script(script_res);
+			n->set_script(script);
 		}
 
 		ERR_CONTINUE_MSG(!n, "Path in autoload not a node or script: " + info.path);

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -653,7 +653,6 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 
 	List<int> ids;
 	script->get_node_list(&ids);
-	StringName editor_icons = "EditorIcons";
 
 	for (int &E : ids) {
 		if (p_only_id >= 0 && p_only_id != E) {

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -1164,9 +1164,6 @@ void VisualScript::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("remove_custom_signal", "name"), &VisualScript::remove_custom_signal);
 	ClassDB::bind_method(D_METHOD("rename_custom_signal", "name", "new_name"), &VisualScript::rename_custom_signal);
 
-	//ClassDB::bind_method(D_METHOD("set_variable_info","name","info"),&VScript::set_variable_info);
-	//ClassDB::bind_method(D_METHOD("get_variable_info","name"),&VScript::set_variable_info);
-
 	ClassDB::bind_method(D_METHOD("set_instance_base_type", "type"), &VisualScript::set_instance_base_type);
 
 	ClassDB::bind_method(D_METHOD("_set_data", "data"), &VisualScript::_set_data);

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -2495,7 +2495,7 @@ static Node *_find_script_node(Node *p_edited_scene, Node *p_current_node, const
 VisualScriptSceneNode::TypeGuess VisualScriptSceneNode::guess_output_type(TypeGuess *p_inputs, int p_output) const {
 	VisualScriptSceneNode::TypeGuess tg;
 	tg.type = Variant::OBJECT;
-	tg.gdclass = "Node";
+	tg.gdclass = SNAME("Node");
 
 #ifdef TOOLS_ENABLED
 	Ref<Script> script = get_visual_script();
@@ -2649,7 +2649,7 @@ VisualScriptNodeInstance *VisualScriptSceneTree::instantiate(VisualScriptInstanc
 VisualScriptSceneTree::TypeGuess VisualScriptSceneTree::guess_output_type(TypeGuess *p_inputs, int p_output) const {
 	TypeGuess tg;
 	tg.type = Variant::OBJECT;
-	tg.gdclass = "SceneTree";
+	tg.gdclass = SNAME("SceneTree");
 	return tg;
 }
 
@@ -2766,11 +2766,11 @@ PropertyInfo VisualScriptSelf::get_input_value_port_info(int p_idx) const {
 }
 
 PropertyInfo VisualScriptSelf::get_output_value_port_info(int p_idx) const {
-	String type_name;
+	StringName type_name;
 	if (get_visual_script().is_valid()) {
 		type_name = get_visual_script()->get_instance_base_type();
 	} else {
-		type_name = "instance";
+		type_name = SNAME("instance");
 	}
 
 	return PropertyInfo(Variant::OBJECT, type_name);
@@ -2801,7 +2801,7 @@ VisualScriptNodeInstance *VisualScriptSelf::instantiate(VisualScriptInstance *p_
 VisualScriptSelf::TypeGuess VisualScriptSelf::guess_output_type(TypeGuess *p_inputs, int p_output) const {
 	VisualScriptSceneNode::TypeGuess tg;
 	tg.type = Variant::OBJECT;
-	tg.gdclass = "Object";
+	tg.gdclass = SNAME("Object");
 
 	Ref<Script> script = get_visual_script();
 	if (!script.is_valid()) {

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1951,7 +1951,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const RES &p_r
 }
 
 Error ResourceFormatSaverText::save(const String &p_path, const RES &p_resource, uint32_t p_flags) {
-	if (p_path.ends_with(".sct") && p_resource->get_class() != "PackedScene") {
+	if (p_path.ends_with(".tscn") && !Ref<PackedScene>(p_resource).is_valid()) {
 		return ERR_FILE_UNRECOGNIZED;
 	}
 
@@ -1960,14 +1960,14 @@ Error ResourceFormatSaverText::save(const String &p_path, const RES &p_resource,
 }
 
 bool ResourceFormatSaverText::recognize(const RES &p_resource) const {
-	return true; // all recognized!
+	return true; // All resources recognized!
 }
 
 void ResourceFormatSaverText::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {
-	if (p_resource->get_class() == "PackedScene") {
-		p_extensions->push_back("tscn"); //text scene
+	if (Ref<PackedScene>(p_resource).is_valid()) {
+		p_extensions->push_back("tscn"); // Text scene.
 	} else {
-		p_extensions->push_back("tres"); //text resource
+		p_extensions->push_back("tres"); // Text resource.
 	}
 }
 


### PR DESCRIPTION
**Update:** Following discussion on #core and #57788, I removed the `SNAME` additions which did not follow the new guidelines. So this PR now mostly boils down to use `cast_to` where possible.

The list of actionables below is now outdated, some of it might still be relevant to do but most of the "use `SNAME` everywhere" points are moot.

----

Less stringly typed logic, and less String allocations and comparisons.

Found by reviewing cases where `ClassDB::is_parent_class` and `Object::get_class` were unnecessarily used to do `String` comparisons instead of casting with `Object::cast_to`... and then went down a rabbit hole while seeing plenty other places nearby where `String`s or string literals were passed to functions using `StringName` parameters...

Draft as it's not well tested, and I want to go through the diff and extract some actionable items for future PRs (I only fixed stuff that I saw, there's plenty more similar cases).

----

### Overview of changes in this PR

- `StringName("some_literal")` should basically never be used, as `SNAME("some_literal")` is better to statically allocate it.
  - [x] Fixed all occurrences of `StringName("` in this PR (minus one in a GDScript test since it's GDScript code).
- `StringName` being empty should be done by comparing with `StringName()`, not `""` or `StringName("")`.
  - [ ] All fixed in this PR, but we should add `StringName::is_empty()` and use this throughout.
- `bool ClassDB::is_parent_class(const StringName &p_class, const StringName &p_inherits)` should use `SNAME` when passing a string literal. More often that not, it's actually not needed and casting with `Object::cast_to<T>` should be preferred.
  - [x] This PR reviewed all instances where `ClassDB::is_parent_class` was needlessly used.
- `bool Object:is_class(const String &p_class)` is a similar case, it should only be used when you need to evaluate a class at runtime. Otherwise if you already know which class you want to check, and you have an object pointer, use `Object::cast_to<T>` (or `Ref<T>` when you have a `Ref<T>` already).
  - [ ] This PR only changes a handful of situations where `Object::is_class()` is used. I'll review other locations in a follow-up PR.
- Comparisons between `StringName PropertyInfo.name` and string literals should use `SNAME`.
  - [ ] Fixed some in this PR, lots remaining in `_validate_property`, `_set`, `_get` implementations.
- `StringName` variables being assigned string literals should use `SNAME`.
  - [ ] More to fix in the codebase. Could add debug code in the relevant `StringName` constructor to catch and fix such cases.
- `StringName` returning methods being stored in a `String` or compared to `String`s without it being needed for further modification.
  - [ ] Some fixed here, plenty more to go through.
- `Script::get_instance_base_type()` should be compared with `StringName`s
  - [x] Reviewed and fixed all/most instances in this PR. Some related changes done in scripting language implementations, more could likely be done to avoid constant String/StringName conversions.
- GDScript annotation names use `StringName` but this wasn't respected in equality checks.
  - [ ] Fixed some, there might be more low hanging fruits for better using `StringName` / `SNAME` in GDScript.
- Theme methods now take `StringName`s and thus stuff like `"EditorIcons"` and theme types should use `SNAME` too.
  - [x] All (?) fixed in #57709 and #57725.

### Methods using `String` that could maybe use `StringName`

- [ ] `bool Object::is_class(const String &p_class)`
- [ ] `String ScriptServer::get_global_class_name(const String &p_path, String *r_base_type = nullptr, String *r_icon_path = nullptr)`
- [ ] All `ResourceLoader` and related methods that take a `const String &p_type_hint` hint could likely use `StringName` (and related `SNAME` on call sites).
- [ ] `String ResourceLoader::get_resource_type(const String &p_path)` could likely return `StringName`
- [ ] `Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p_fallback)` could use `StringName` for `p_fallback`
- [ ] `editor/property_selector.h` `base_type` could be `StringName`, together with all the related methods
- [ ] Various `handles()` and `handles_type()` callbacks used in our plugin interfaces could maybe use `StringName`s

### Details on Object casting instead of relying on string checks

This PR fixes all cases where this was not done, and reviewed all locations where `is_parent_class` was used. Some were needlessly doing stuff like:
```cpp
ClassDB::is_parent_class(p_obj->get_class(), "Node");
```
when it's much better to rely on casting when you do have an `Object *`:
```cpp
Object::cast_to<Node>(p_obj);
```

Similarly, when you have a `Ref<Resource>` (aka `RES`) instead of an `Object *`), instead of using:
```cpp
if (res->is_class("PackedScene")) {
```
you can use:
```cpp
if (Ref<PackedScene>(res).is_valid()) {
```
or if you need to keep a reference for later use in the block:
```cpp
Ref<PackedScene> scn = res;
if (scn.is_valid()) {
```