### PR TITLE
Move Replication tab to a fixed position

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6969,6 +6969,7 @@ EditorNode::EditorNode() {
 
 	// more visually meaningful to have this later
 	raise_bottom_panel_item(AnimationPlayerEditor::get_singleton());
+	add_editor_plugin(memnew(ReplicationEditorPlugin(this)));
 
 	add_editor_plugin(VersionControlEditorPlugin::get_singleton());
 	add_editor_plugin(memnew(ShaderEditorPlugin(this)));
@@ -7022,7 +7023,6 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(InputEventEditorPlugin(this)));
 	add_editor_plugin(memnew(SubViewportPreviewEditorPlugin(this)));
 	add_editor_plugin(memnew(TextControlEditorPlugin(this)));
-	add_editor_plugin(memnew(ReplicationEditorPlugin(this)));
 
 	for (int i = 0; i < EditorPlugins::get_plugin_count(); i++) {
 		add_editor_plugin(EditorPlugins::create(i, this));


### PR DESCRIPTION
Now the tab is always next to Animation.

Before:
![](https://chat.godotengine.org/file-upload/v9JeYX96oivwyjRjd/godot.windows.tools.64_0s2Op8dgj8.gif)

After:
![godot windows tools 64_e6DR9MJWOL](https://user-images.githubusercontent.com/2223172/152707518-017389d0-f02c-4117-b211-ef22dfe22c97.gif)
