### PR TITLE
Make popups from `MenuButton`, `OptionButton`, and submenus obey the layout direction

### DIFF
--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -136,6 +136,9 @@ int MenuButton::get_item_count() const {
 
 void MenuButton::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
+			popup->set_layout_direction((Window::LayoutDirection)get_layout_direction());
+		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible_in_tree()) {
 				popup->hide();

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -92,7 +92,10 @@ void OptionButton::_notification(int p_what) {
 			arrow->draw(ci, ofs, clr);
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED:
-		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
+			popup->set_layout_direction((Window::LayoutDirection)get_layout_direction());
+			[[fallthrough]];
+		}
 		case NOTIFICATION_THEME_CHANGED: {
 			if (has_theme_icon(SNAME("arrow"))) {
 				if (is_layout_rtl()) {


### PR DESCRIPTION
Due to popups being `Window`s instead of `Control`s, popups ignored the layout direction that they should've been inheriting. This PR makes so the layout is set manually.