### PR TITLE
[3.x] Massive Performance increase of opening the editor

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -870,21 +870,12 @@ bool EditorData::script_class_is_parent(const String &p_class, const String &p_i
 		return false;
 	}
 
-	Ref<Script> script = script_class_load_script(p_class);
-	if (script.is_null()) {
-		return false;
-	}
-
-	String base = script_class_get_base(p_class);
-	Ref<Script> base_script = script->get_base_script();
-
-	while (p_inherits != base) {
+	String base = p_class;
+	while (base != p_inherits) {
 		if (ClassDB::class_exists(base)) {
 			return ClassDB::is_parent_class(base, p_inherits);
 		} else if (ScriptServer::is_global_class(base)) {
-			base = script_class_get_base(base);
-		} else if (base_script.is_valid()) {
-			return ClassDB::is_parent_class(base_script->get_instance_base_type(), p_inherits);
+			base = ScriptServer::get_global_class_base(base);
 		} else {
 			return false;
 		}


### PR DESCRIPTION
Master branch version: https://github.com/godotengine/godot/pull/57766

In 3.4 there is a performance regression for me where Godot takes >15 seconds to open our project. I found that it Loads some of our 300+ GDScript files many many times in order to compute the EditorResourcePicker::get_allowed_types for Theme, Script, Material and some other simple base types. Then when I open a scene with a new Resource type in it, I get a very noticable lag spike.

Ultimately this lag spike was caused by the change in how EditorResourcePicker was caching it's get_allowed types. Specifically slow is EditorData::script_class_get_base, which would load every single class_name in our GDScript many times. In my testing, I found that even switching the order of 2 of the initialization lines in that previous code would allow the GDScript resources to be cached. I discovered that the old code was even _parsing_ GDScript to find the base class, which seems strange considering that ScriptServer has a very fast answer to what the baseclass of a GDScript file is.

This code change rewrites EditorData::script_class_is_parent to be over 1000x faster by using ScriptServer to find the base class of a Script instead of loading and parsing GDScript.

I have confirmed that the new code produces the exact same result as the old code in our project of over 300 gdscript files, 100 .tres, including Scripted Resources, and many layers of class hierarchy.