### PR TITLE
ResourceImporter: Restore default append logic for new importers

### DIFF
--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -464,7 +464,11 @@ void ResourceImporter::_bind_methods() {
 	BIND_ENUM_CONSTANT(IMPORT_ORDER_SCENE);
 }
 
-void ResourceFormatImporter::add_importer(const Ref<ResourceImporter> &p_importer) {
+void ResourceFormatImporter::add_importer(const Ref<ResourceImporter> &p_importer, bool p_first_priority) {
 	ERR_FAIL_COND(p_importer.is_null());
-	importers.insert(0, p_importer);
+	if (p_first_priority) {
+		importers.insert(0, p_importer);
+	} else {
+		importers.push_back(p_importer);
+	}
 }

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -80,7 +80,7 @@ public:
 	String get_internal_resource_path(const String &p_path) const;
 	void get_internal_resource_path_list(const String &p_path, List<String> *r_paths);
 
-	void add_importer(const Ref<ResourceImporter> &p_importer);
+	void add_importer(const Ref<ResourceImporter> &p_importer, bool p_first_priority = false);
 
 	void remove_importer(const Ref<ResourceImporter> &p_importer) { importers.erase(p_importer); }
 	Ref<ResourceImporter> get_importer_by_name(const String &p_name) const;

--- a/doc/classes/EditorPlugin.xml
+++ b/doc/classes/EditorPlugin.xml
@@ -379,8 +379,10 @@
 		<method name="add_import_plugin">
 			<return type="void" />
 			<argument index="0" name="importer" type="EditorImportPlugin" />
+			<argument index="1" name="first_priority" type="bool" default="false" />
 			<description>
 				Registers a new [EditorImportPlugin]. Import plugins are used to import custom and unsupported assets as a custom [Resource] type.
+				If [code]first_priority[/code] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
 				[b]Note:[/b] If you want to import custom 3D asset formats use [method add_scene_format_importer_plugin] instead.
 				See [method add_inspector_plugin] for an example of how to register a plugin.
 			</description>
@@ -408,15 +410,19 @@
 		<method name="add_scene_format_importer_plugin">
 			<return type="void" />
 			<argument index="0" name="scene_format_importer" type="EditorSceneFormatImporter" />
+			<argument index="1" name="first_priority" type="bool" default="false" />
 			<description>
 				Registers a new [EditorSceneFormatImporter]. Scene importers are used to import custom 3D asset formats as scenes.
+				If [code]first_priority[/code] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
 			</description>
 		</method>
 		<method name="add_scene_post_import_plugin">
 			<return type="void" />
 			<argument index="0" name="scene_import_plugin" type="EditorScenePostImportPlugin" />
+			<argument index="1" name="first_priority" type="bool" default="false" />
 			<description>
 				Add a [EditorScenePostImportPlugin]. These plugins allow customizing the import process of 3D assets by adding new options to the import dialogs.
+				If [code]first_priority[/code] is [code]true[/code], the new import plugin is inserted first in the list and takes precedence over pre-existing plugins.
 			</description>
 		</method>
 		<method name="add_spatial_gizmo_plugin">

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -717,9 +717,9 @@ void EditorPlugin::remove_translation_parser_plugin(const Ref<EditorTranslationP
 	EditorTranslationParser::get_singleton()->remove_parser(p_parser, EditorTranslationParser::CUSTOM);
 }
 
-void EditorPlugin::add_import_plugin(const Ref<EditorImportPlugin> &p_importer) {
+void EditorPlugin::add_import_plugin(const Ref<EditorImportPlugin> &p_importer, bool p_first_priority) {
 	ERR_FAIL_COND(!p_importer.is_valid());
-	ResourceFormatImporter::get_singleton()->add_importer(p_importer);
+	ResourceFormatImporter::get_singleton()->add_importer(p_importer, p_first_priority);
 	EditorFileSystem::get_singleton()->call_deferred(SNAME("scan"));
 }
 
@@ -759,9 +759,9 @@ void EditorPlugin::remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_p
 	EditorInspector::remove_inspector_plugin(p_plugin);
 }
 
-void EditorPlugin::add_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer) {
+void EditorPlugin::add_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer, bool p_first_priority) {
 	ERR_FAIL_COND(!p_importer.is_valid());
-	ResourceImporterScene::get_singleton()->add_importer(p_importer);
+	ResourceImporterScene::get_singleton()->add_importer(p_importer, p_first_priority);
 }
 
 void EditorPlugin::remove_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer) {
@@ -769,9 +769,10 @@ void EditorPlugin::remove_scene_format_importer_plugin(const Ref<EditorSceneForm
 	ResourceImporterScene::get_singleton()->remove_importer(p_importer);
 }
 
-void EditorPlugin::add_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin) {
-	ResourceImporterScene::get_singleton()->add_post_importer_plugin(p_plugin);
+void EditorPlugin::add_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin, bool p_first_priority) {
+	ResourceImporterScene::get_singleton()->add_post_importer_plugin(p_plugin, p_first_priority);
 }
+
 void EditorPlugin::remove_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin) {
 	ResourceImporterScene::get_singleton()->remove_post_importer_plugin(p_plugin);
 }
@@ -881,11 +882,11 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("queue_save_layout"), &EditorPlugin::queue_save_layout);
 	ClassDB::bind_method(D_METHOD("add_translation_parser_plugin", "parser"), &EditorPlugin::add_translation_parser_plugin);
 	ClassDB::bind_method(D_METHOD("remove_translation_parser_plugin", "parser"), &EditorPlugin::remove_translation_parser_plugin);
-	ClassDB::bind_method(D_METHOD("add_import_plugin", "importer"), &EditorPlugin::add_import_plugin);
+	ClassDB::bind_method(D_METHOD("add_import_plugin", "importer", "first_priority"), &EditorPlugin::add_import_plugin, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_import_plugin", "importer"), &EditorPlugin::remove_import_plugin);
-	ClassDB::bind_method(D_METHOD("add_scene_format_importer_plugin", "scene_format_importer"), &EditorPlugin::add_scene_format_importer_plugin);
+	ClassDB::bind_method(D_METHOD("add_scene_format_importer_plugin", "scene_format_importer", "first_priority"), &EditorPlugin::add_scene_format_importer_plugin, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_scene_format_importer_plugin", "scene_format_importer"), &EditorPlugin::remove_scene_format_importer_plugin);
-	ClassDB::bind_method(D_METHOD("add_scene_post_import_plugin", "scene_import_plugin"), &EditorPlugin::add_scene_post_import_plugin);
+	ClassDB::bind_method(D_METHOD("add_scene_post_import_plugin", "scene_import_plugin", "first_priority"), &EditorPlugin::add_scene_post_import_plugin, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_scene_post_import_plugin", "scene_import_plugin"), &EditorPlugin::remove_scene_post_import_plugin);
 	ClassDB::bind_method(D_METHOD("add_export_plugin", "plugin"), &EditorPlugin::add_export_plugin);
 	ClassDB::bind_method(D_METHOD("remove_export_plugin", "plugin"), &EditorPlugin::remove_export_plugin);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -278,7 +278,7 @@ public:
 	void add_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser);
 	void remove_translation_parser_plugin(const Ref<EditorTranslationParserPlugin> &p_parser);
 
-	void add_import_plugin(const Ref<EditorImportPlugin> &p_importer);
+	void add_import_plugin(const Ref<EditorImportPlugin> &p_importer, bool p_first_priority = false);
 	void remove_import_plugin(const Ref<EditorImportPlugin> &p_importer);
 
 	void add_export_plugin(const Ref<EditorExportPlugin> &p_exporter);
@@ -290,10 +290,10 @@ public:
 	void add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
 	void remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
 
-	void add_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer);
+	void add_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer, bool p_first_priority = false);
 	void remove_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer);
 
-	void add_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_importer);
+	void add_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_importer, bool p_first_priority = false);
 	void remove_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_importer);
 
 	void add_autoload_singleton(const String &p_name, const String &p_path);

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -2088,18 +2088,26 @@ ResourceImporterScene::ResourceImporterScene() {
 	singleton = this;
 }
 
-void ResourceImporterScene::add_importer(Ref<EditorSceneFormatImporter> p_importer) {
+void ResourceImporterScene::add_importer(Ref<EditorSceneFormatImporter> p_importer, bool p_first_priority) {
 	ERR_FAIL_COND(p_importer.is_null());
-	importers.insert(0, p_importer);
+	if (p_first_priority) {
+		importers.insert(0, p_importer);
+	} else {
+		importers.push_back(p_importer);
+	}
 }
 
 void ResourceImporterScene::remove_post_importer_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin) {
 	post_importer_plugins.erase(p_plugin);
 }
 
-void ResourceImporterScene::add_post_importer_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin) {
+void ResourceImporterScene::add_post_importer_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin, bool p_first_priority) {
 	ERR_FAIL_COND(p_plugin.is_null());
-	post_importer_plugins.insert(0, p_plugin);
+	if (p_first_priority) {
+		post_importer_plugins.insert(0, p_plugin);
+	} else {
+		post_importer_plugins.push_back(p_plugin);
+	}
 }
 
 void ResourceImporterScene::remove_importer(Ref<EditorSceneFormatImporter> p_importer) {

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -224,12 +224,12 @@ class ResourceImporterScene : public ResourceImporter {
 public:
 	static ResourceImporterScene *get_singleton() { return singleton; }
 
-	void add_post_importer_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin);
+	void add_post_importer_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin, bool p_first_priority = false);
 	void remove_post_importer_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin);
 
 	const Vector<Ref<EditorSceneFormatImporter>> &get_importers() const { return importers; }
 
-	void add_importer(Ref<EditorSceneFormatImporter> p_importer);
+	void add_importer(Ref<EditorSceneFormatImporter> p_importer, bool p_first_priority = false);
 	void remove_importer(Ref<EditorSceneFormatImporter> p_importer);
 
 	virtual String get_importer_name() const override;


### PR DESCRIPTION
This was changed in #56943 to allow adding new importers from plugins that
take precedence over built-in ones, but this should be opt-in, not the default
behavior.

Fixes #57730.