### PR TITLE
[3.x] Support WebM seeking operation

### DIFF
--- a/modules/webm/video_stream_webm.cpp
+++ b/modules/webm/video_stream_webm.cpp
@@ -205,7 +205,10 @@ float VideoStreamPlaybackWebm::get_playback_position() const {
 	return video_pos;
 }
 void VideoStreamPlaybackWebm::seek(float p_time) {
-	WARN_PRINT_ONCE("Seeking in Theora and WebM videos is not implemented yet (it's only supported for GDNative-provided video streams).");
+	if (webm) {
+		time = webm->seek(p_time);
+		video_pos = time;
+	}
 }
 
 void VideoStreamPlaybackWebm::set_audio_track(int p_idx) {

--- a/thirdparty/libsimplewebm/VPXDecoder.cpp
+++ b/thirdparty/libsimplewebm/VPXDecoder.cpp
@@ -62,7 +62,11 @@ VPXDecoder::VPXDecoder(const WebMDemuxer &demuxer, unsigned threads) :
 	}
 
 	m_ctx = new vpx_codec_ctx_t;
-	if (vpx_codec_dec_init(m_ctx, codecIface, &codecCfg, m_delay > 0 ? VPX_CODEC_USE_FRAME_THREADING : 0))
+	
+	// disable multi thread for decoder to make some vp8 and vp9 video files work properly
+	// refertence url https://github.com/dimiaa/WebM-Video-Player/blob/main/src/WebMVideoDecoder.cpp
+	int codecFlags = 0;
+	if (vpx_codec_dec_init(m_ctx, codecIface, &codecCfg, codecFlags))
 	{
 		delete m_ctx;
 		m_ctx = NULL;

--- a/thirdparty/libsimplewebm/WebMDemuxer.hpp
+++ b/thirdparty/libsimplewebm/WebMDemuxer.hpp
@@ -98,6 +98,7 @@ public:
 	int getChannels() const;
 	int getAudioDepth() const;
 
+	float seek(float p_time);
 	bool readFrame(WebMFrame *videoFrame, WebMFrame *audioFrame);
 
 private:
@@ -120,6 +121,8 @@ private:
 
 	bool m_isOpen;
 	bool m_eos;
+	bool m_isSeek;
+	float m_seekTime;
 };
 
 #endif // WEBMDEMUXER_HPP

--- a/thirdparty/libvpx/vp8/decoder/decodeframe.c
+++ b/thirdparty/libvpx/vp8/decoder/decodeframe.c
@@ -548,6 +548,7 @@ static void decode_mb_rows(VP8D_COMP *pbi)
     if(pc->filter_level)
         vp8_loop_filter_frame_init(pc, xd, pc->filter_level);
 
+    pc->filter_level = 0;
     vp8_setup_intra_recon_top_line(yv12_fb_new);
 
     /* Decode the individual macro block */


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Support webm video seeking operation with minimal modification. Currently, it only support 3.x version since master 4.0 version has abandoned webm format support.
```
Modified files:
1.modules/webm/video_stream_webm.cpp
2.thirdparty/libsimplewebm/WebMDemuxer.cpp
3.thirdparty/libsimplewebm/WebMDemuxer.hpp
```
https://user-images.githubusercontent.com/99071212/152667074-e226a8f6-b3d7-4ef0-b5af-31bec11eeb61.mp4