### PR TITLE
Don't display empty Class Properties in feature profile

### DIFF
--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -592,7 +592,15 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 	List<PropertyInfo> props;
 	ClassDB::get_property_list(class_name, &props, true);
 
-	if (props.size() > 0) {
+	bool has_editor_props = false;
+	for (const PropertyInfo &E : props) {
+		if (E.usage & PROPERTY_USAGE_EDITOR) {
+			has_editor_props = true;
+			break;
+		}
+	}
+
+	if (has_editor_props) {
 		TreeItem *properties = property_list->create_item(root);
 		properties->set_text(0, TTR("Class Properties:"));
 


### PR DESCRIPTION
Classes like `SpriteFrames`, `World2D`, and `AnimationNode` have properties but no editor properties. An empty "Class Properties:" header was displayed for such classes in the Editor Feature Profile dialog:

![ksnip_20220207-190049](https://user-images.githubusercontent.com/372476/152776001-b7d0dbb0-8ca3-47a4-bea0-5fb58a618b3b.png)

This is because properties without `PROPERTY_USAGE_EDITOR` set is skipped but the total amount of properties is checked.

https://github.com/godotengine/godot/blob/b02460266065413957eae3de34f9aef49c5a72f1/editor/editor_feature_profile.cpp#L595-L603

This PR checks if there is any property with `PROPERTY_USAGE_EDITOR` instead of using `props.size()`.

Note for cherry-picking: the ranged for loop has to be changed to a plain for loop.