### PR TITLE
Fix GridMap memory leak

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -813,6 +813,7 @@ void GridMap::_update_octants_callback() {
 	}
 
 	while (to_delete.front()) {
+		memdelete(octant_map[to_delete.front()->get()]);
 		octant_map.erase(to_delete.front()->get());
 		to_delete.pop_front();
 	}


### PR DESCRIPTION
Fixes #57746

The `memdelete` is necessary and was deleted in #12488, thus the memory leak. Not sure why it was deleted, maybe it's a fix for an undo crash judging from the commit message. I'm unable to reproduce the crash on current `3.x` or `master` after the `memdelete` is restored.