### PR TITLE
Add `_get_func_code/_is_available` virtual functions to custom nodes

### DIFF
--- a/doc/classes/VisualShaderNodeCustom.xml
+++ b/doc/classes/VisualShaderNodeCustom.xml
@@ -44,6 +44,17 @@
 				Defining this method is [b]optional[/b].
 			</description>
 		</method>
+		<method name="_get_func_code" qualifiers="virtual const">
+			<return type="String" />
+			<argument index="0" name="mode" type="int" enum="Shader.Mode" />
+			<argument index="1" name="type" type="int" enum="VisualShader.Type" />
+			<description>
+				Override this method to add a shader code to the beginning of each shader function (once). The shader code should be returned as a string, which can have multiple lines (the [code]"""[/code] multiline string construct can be used for convenience).
+				If there are multiple custom nodes of different types which use this feature the order of each insertion is undefined.
+				You can customize the generated code based on the shader [code]mode[/code] (see [enum Shader.Mode]) and/or [code]type[/code] (see [enum VisualShader.Type]).
+				Defining this method is [b]optional[/b].
+			</description>
+		</method>
 		<method name="_get_global_code" qualifiers="virtual const">
 			<return type="String" />
 			<argument index="0" name="mode" type="int" enum="Shader.Mode" />
@@ -114,11 +125,20 @@
 				Defining this method is [b]optional[/b]. If not overridden, no return icon is shown.
 			</description>
 		</method>
+		<method name="_is_available" qualifiers="virtual const">
+			<return type="bool" />
+			<argument index="0" name="mode" type="int" enum="Shader.Mode" />
+			<argument index="1" name="type" type="int" enum="VisualShader.Type" />
+			<description>
+				Override this method to prevent the node to be visible in the member dialog for the certain [code]mode[/code] (see [enum Shader.Mode]) and/or [code]type[/code] (see [enum VisualShader.Type]).
+				Defining this method is [b]optional[/b]. If not overridden, it's [code]true[/code].
+			</description>
+		</method>
 		<method name="_is_highend" qualifiers="virtual const">
 			<return type="bool" />
 			<description>
 				Override this method to enable high-end mark in the Visual Shader Editor's members dialog.
-				Defining this method is [b]optional[/b]. If not overridden, it's false.
+				Defining this method is [b]optional[/b]. If not overridden, it's [code]false[/code].
 			</description>
 		</method>
 	</methods>

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -262,6 +262,7 @@ class VisualShaderEditor : public VBoxContainer {
 	void _show_add_varying_dialog();
 	void _show_remove_varying_dialog();
 
+	void _update_nodes();
 	void _update_graph();
 
 	struct AddOption {
@@ -394,6 +395,7 @@ class VisualShaderEditor : public VBoxContainer {
 		String group_inputs;
 		String group_outputs;
 		String expression;
+		bool disabled = false;
 	};
 
 	void _dup_copy_nodes(int p_type, List<CopyItem> &r_nodes, List<VisualShader::Connection> &r_connections);
@@ -476,7 +478,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void update_custom_nodes();
+	void update_nodes();
 	void add_plugin(const Ref<VisualShaderNodePlugin> &p_plugin);
 	void remove_plugin(const Ref<VisualShaderNodePlugin> &p_plugin);
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -383,14 +383,20 @@ protected:
 	GDVIRTUAL1RC(int, _get_output_port_type, int)
 	GDVIRTUAL1RC(String, _get_output_port_name, int)
 	GDVIRTUAL4RC(String, _get_code, TypedArray<String>, TypedArray<String>, Shader::Mode, VisualShader::Type)
+	GDVIRTUAL2RC(String, _get_func_code, Shader::Mode, VisualShader::Type)
 	GDVIRTUAL1RC(String, _get_global_code, Shader::Mode)
 	GDVIRTUAL0RC(bool, _is_highend)
+	GDVIRTUAL2RC(bool, _is_available, Shader::Mode, VisualShader::Type)
+
+	bool _is_valid_code(const String &p_code) const;
 
 protected:
 	void _set_input_port_default_value(int p_port, const Variant &p_value);
 
+	bool is_available(Shader::Mode p_mode, VisualShader::Type p_type) const;
 	virtual String generate_code(Shader::Mode p_mode, VisualShader::Type p_type, int p_id, const String *p_input_vars, const String *p_output_vars, bool p_for_preview = false) const override;
 	virtual String generate_global_per_node(Shader::Mode p_mode, int p_id) const override;
+	virtual String generate_global_per_func(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const override;
 
 	static void _bind_methods();
 

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -5696,7 +5696,7 @@ String VisualShaderNodeTextureUniformTriplanar::get_input_port_name(int p_port) 
 String VisualShaderNodeTextureUniformTriplanar::generate_global_per_node(Shader::Mode p_mode, int p_id) const {
 	String code;
 
-	code += "// TRIPLANAR FUNCTION GLOBAL CODE\n";
+	code += "// " + get_caption() + "\n";
 	code += "	vec4 triplanar_texture(sampler2D p_sampler, vec3 p_weights, vec3 p_triplanar_pos) {\n";
 	code += "		vec4 samp = vec4(0.0);\n";
 	code += "		samp += texture(p_sampler, p_triplanar_pos.xy) * p_weights.z;\n";
@@ -5719,11 +5719,13 @@ String VisualShaderNodeTextureUniformTriplanar::generate_global_per_func(Shader:
 	String code;
 
 	if (p_type == VisualShader::TYPE_VERTEX) {
-		code += "	// TRIPLANAR FUNCTION VERTEX CODE\n";
+		code += "// " + get_caption() + "\n";
+		code += "	{\n";
 		code += "		triplanar_power_normal = pow(abs(NORMAL), vec3(triplanar_sharpness));\n";
 		code += "		triplanar_power_normal /= dot(triplanar_power_normal, vec3(1.0));\n";
 		code += "		triplanar_pos = VERTEX * triplanar_scale + triplanar_offset;\n";
 		code += "		triplanar_pos *= vec3(1.0, -1.0, 1.0);\n";
+		code += "	}\n";
 	}
 
 	return code;


### PR DESCRIPTION
This targets to fix https://github.com/godotengine/godot-proposals/issues/3916 by adding `_get_func_code` and `_is_available` virtual functions to `VisualShaderNodeCustom` to allow generate a code at the top of each visual shader function. Also, reorganize a code for copy/pasting to disallow showing an option to paste where there are no nodes available to paste. 

cc @QbieShay - if you check this functionality that would be great!
