### PR TITLE
[3.x] Added alignment options to icons on buttons. They can now be centered and right-aligned.

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -43,6 +43,9 @@
 			Button's icon, if text is present the icon will be placed before the text.
 			To edit margin and spacing of the icon, use [code]hseparation[/code] theme property of [Button] and [code]content_margin_*[/code] properties of the used [StyleBox]es.
 		</member>
+		<member name="icon_align" type="int" setter="set_icon_align" getter="get_icon_align" enum="Button.TextAlign" default="0">
+			Specifies if the icon should be aligned to the left, right, or center of a button. Uses the same [enum TextAlign] constants as the text alignment. If centered, text will draw on top of the icon.
+		</member>
 		<member name="text" type="String" setter="set_text" getter="get_text" default="&quot;&quot;">
 			The button's text that will be displayed inside the button's area.
 		</member>

--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -51,6 +51,7 @@ private:
 	bool expand_icon;
 	bool clip_text;
 	TextAlign align;
+	TextAlign icon_align;
 	float _internal_margin[4];
 
 protected:
@@ -78,6 +79,9 @@ public:
 
 	void set_text_align(TextAlign p_align);
 	TextAlign get_text_align() const;
+
+	void set_icon_align(TextAlign p_align);
+	TextAlign get_icon_align() const;
 
 	Button(const String &p_text = String());
 	~Button();


### PR DESCRIPTION
Backport of #37181 to `3.x`.

I recreated the image from https://github.com/godotengine/godot/issues/11380#issuecomment-546186548 to test it:

![image](https://user-images.githubusercontent.com/3903059/152867804-ff970816-bab2-453c-8441-5332f88de556.png)
