### PR TITLE
[Editor] Fix font style matching issues.

### DIFF
--- a/editor/plugins/text_control_editor_plugin.cpp
+++ b/editor/plugins/text_control_editor_plugin.cpp
@@ -110,7 +110,7 @@ void TextControlEditor::_update_styles_menu() {
 		for (Map<String, String>::Element *E = fonts[name].front(); E; E = E->next()) {
 			font_style_list->add_item(E->key());
 		}
-	} else {
+	} else if (font_list->get_selected() >= 0) {
 		font_style_list->add_item("Default");
 	}
 
@@ -123,9 +123,9 @@ void TextControlEditor::_update_styles_menu() {
 
 void TextControlEditor::_update_control() {
 	if (!edited_controls.is_empty()) {
-		int font_selected = 0;
+		String font_selected;
 		bool same_font = true;
-		int style_selected = 0;
+		String style_selected;
 		bool same_style = true;
 		int font_size = 0;
 		bool same_font_size = true;
@@ -136,26 +136,23 @@ void TextControlEditor::_update_control() {
 		Color outline_color = Color{ 1.0f, 1.0f, 1.0f };
 		bool same_outline_color = true;
 
-		_update_fonts_menu();
-		_update_styles_menu();
-
 		int count = edited_controls.size();
 		for (int i = 0; i < count; ++i) {
 			Control *edited_control = edited_controls[i];
 
-			String edited_color;
-			String edited_font;
-			String edited_font_size;
+			StringName edited_color;
+			StringName edited_font;
+			StringName edited_font_size;
 
 			// Get override names.
-			if (edited_control->is_class("RichTextLabel")) {
-				edited_color = "default_color";
-				edited_font = "normal_font";
-				edited_font_size = "normal_font_size";
+			if (Object::cast_to<RichTextLabel>(edited_control)) {
+				edited_color = SNAME("default_color");
+				edited_font = SNAME("normal_font");
+				edited_font_size = SNAME("normal_font_size");
 			} else {
-				edited_color = "font_color";
-				edited_font = "font";
-				edited_font_size = "font_size";
+				edited_color = SNAME("font_color");
+				edited_font = SNAME("font");
+				edited_font_size = SNAME("font_size");
 			}
 
 			// Get font override.
@@ -166,57 +163,40 @@ void TextControlEditor::_update_control() {
 
 			if (font.is_valid()) {
 				if (font->get_data_count() != 1) {
-					custom_font = font;
 					if (i > 0) {
-						same_font = same_font && (font_selected == FONT_INFO_USER_CUSTOM);
-						same_style = same_style && (style_selected == 0);
+						same_font = same_font && (custom_font == font);
 					}
+					custom_font = font;
 
-					font_selected = FONT_INFO_USER_CUSTOM;
-					style_selected = 0;
+					font_selected = TTR("[Custom Font]");
+					same_style = false;
 				} else {
 					String name = font->get_data(0)->get_font_name();
 					String style = font->get_data(0)->get_font_style_name();
 					if (fonts.has(name) && fonts[name].has(style)) {
-						for (int j = 0; j < font_list->get_item_count(); j++) {
-							if (font_list->get_item_text(j) == name) {
-								if (i > 0) {
-									same_font = same_font && (j == font_selected);
-								}
-
-								font_selected = j;
-								break;
-							}
-						}
-						for (int j = 0; j < font_style_list->get_item_count(); j++) {
-							if (font_style_list->get_item_text(j) == style) {
-								if (i > 0) {
-									same_style = same_style && (j == style_selected);
-								}
-
-								style_selected = j;
-								break;
-							}
-						}
-					} else {
-						custom_font = font;
 						if (i > 0) {
-							same_font = same_font && (font_selected == FONT_INFO_USER_CUSTOM);
-							same_style = same_style && (style_selected == 0);
+							same_font = same_font && (name == font_selected);
+							same_style = same_style && (style == style_selected);
 						}
+						font_selected = name;
+						style_selected = style;
+					} else {
+						if (i > 0) {
+							same_font = same_font && (custom_font == font);
+						}
+						custom_font = font;
 
-						font_selected = FONT_INFO_USER_CUSTOM;
-						style_selected = 0;
+						font_selected = TTR("[Custom Font]");
+						same_style = false;
 					}
 				}
 			} else {
 				if (i > 0) {
-					same_font = same_font && (font_selected == FONT_INFO_THEME_DEFAULT);
-					same_style = same_style && (style_selected == 0);
+					same_font = same_font && (font_selected == TTR("[Theme Default]"));
 				}
 
-				font_selected = FONT_INFO_THEME_DEFAULT;
-				style_selected = 0;
+				font_selected = TTR("[Theme Default]");
+				same_style = false;
 			}
 
 			int current_font_size = edited_control->get_theme_font_size(edited_font_size);
@@ -235,19 +215,29 @@ void TextControlEditor::_update_control() {
 			font_color = current_font_color;
 			outline_color = current_outline_color;
 		}
-
 		_update_fonts_menu();
 		if (same_font) {
-			font_list->select(font_selected);
+			for (int j = 0; j < font_list->get_item_count(); j++) {
+				if (font_list->get_item_text(j) == font_selected) {
+					font_list->select(j);
+					break;
+				}
+			}
 		} else {
+			custom_font = Ref<Font>();
 			font_list->select(-1);
 		}
 
 		_update_styles_menu();
 		if (same_style) {
-			font_style_list->select(style_selected);
+			for (int j = 0; j < font_style_list->get_item_count(); j++) {
+				if (font_style_list->get_item_text(j) == style_selected) {
+					font_style_list->select(j);
+					break;
+				}
+			}
 		} else {
-			font_list->select(-1);
+			font_style_list->select(-1);
 		}
 
 		// Get other theme overrides.
@@ -282,6 +272,7 @@ void TextControlEditor::_update_control() {
 }
 
 void TextControlEditor::_font_selected(int p_id) {
+	_update_styles_menu();
 	_set_font();
 }
 
@@ -301,11 +292,11 @@ void TextControlEditor::_set_font() {
 	for (int i = 0; i < count; ++i) {
 		Control *edited_control = edited_controls[i];
 
-		String edited_font;
-		if (edited_control->is_class("RichTextLabel")) {
-			edited_font = "normal_font";
+		StringName edited_font;
+		if (Object::cast_to<RichTextLabel>(edited_control)) {
+			edited_font = SNAME("normal_font");
 		} else {
-			edited_font = "font";
+			edited_font = SNAME("font");
 		}
 
 		if (font_list->get_selected_id() == FONT_INFO_THEME_DEFAULT) {
@@ -314,14 +305,13 @@ void TextControlEditor::_set_font() {
 		} else if (font_list->get_selected_id() == FONT_INFO_USER_CUSTOM) {
 			// Restore "custom_font".
 			ur->add_do_method(edited_control, "add_theme_font_override", edited_font, custom_font);
-		} else {
+		} else if (font_list->get_selected() >= 0) {
 			// Load new font resource using selected name and style.
 			String name = font_list->get_item_text(font_list->get_selected());
 			String style = font_style_list->get_item_text(font_style_list->get_selected());
 			if (style.is_empty()) {
 				style = "Default";
 			}
-
 			if (fonts.has(name)) {
 				Ref<FontData> fd = ResourceLoader::load(fonts[name][style]);
 				if (fd.is_valid()) {
@@ -358,11 +348,11 @@ void TextControlEditor::_font_size_selected(double p_size) {
 	for (int i = 0; i < count; ++i) {
 		Control *edited_control = edited_controls[i];
 
-		String edited_font_size;
-		if (edited_control->is_class("RichTextLabel")) {
-			edited_font_size = "normal_font_size";
+		StringName edited_font_size;
+		if (Object::cast_to<RichTextLabel>(edited_control)) {
+			edited_font_size = SNAME("normal_font_size");
 		} else {
-			edited_font_size = "font_size";
+			edited_font_size = SNAME("font_size");
 		}
 
 		ur->add_do_method(edited_control, "add_theme_font_size_override", edited_font_size, p_size);
@@ -417,11 +407,11 @@ void TextControlEditor::_font_color_changed(const Color &p_color) {
 	for (int i = 0; i < count; ++i) {
 		Control *edited_control = edited_controls[i];
 
-		String edited_color;
-		if (edited_control->is_class("RichTextLabel")) {
-			edited_color = "default_color";
+		StringName edited_color;
+		if (Object::cast_to<RichTextLabel>(edited_control)) {
+			edited_color = SNAME("default_color");
 		} else {
-			edited_color = "font_color";
+			edited_color = SNAME("font_color");
 		}
 
 		ur->add_do_method(edited_control, "add_theme_color_override", edited_color, p_color);
@@ -476,19 +466,19 @@ void TextControlEditor::_clear_formatting() {
 	for (int i = 0; i < count; ++i) {
 		Control *edited_control = edited_controls[i];
 
-		String edited_color;
-		String edited_font;
-		String edited_font_size;
+		StringName edited_color;
+		StringName edited_font;
+		StringName edited_font_size;
 
 		// Get override names.
-		if (edited_control->is_class("RichTextLabel")) {
-			edited_color = "default_color";
-			edited_font = "normal_font";
-			edited_font_size = "normal_font_size";
+		if (Object::cast_to<RichTextLabel>(edited_control)) {
+			edited_color = SNAME("default_color");
+			edited_font = SNAME("normal_font");
+			edited_font_size = SNAME("normal_font_size");
 		} else {
-			edited_color = "font_color";
-			edited_font = "font";
-			edited_font_size = "font_size";
+			edited_color = SNAME("font_color");
+			edited_font = SNAME("font");
+			edited_font_size = SNAME("font_size");
 		}
 
 		ur->add_do_method(edited_control, "begin_bulk_theme_override");


### PR DESCRIPTION
- Fix font selection when no style selected.

After #57330 it's possible to have no item selected, which was not taken into account in some places.

- Fix style matching when fonts have different style sets.

Change font name and style matching to use names, instead of indices, to correctly match styles for the fonts with different style sets. Also remove some unnecessary code, since "[Theme Default]" and "[Custom]" can't have any style.

- Adds `SNAME` for undo/redo methods and theme overrides.
