### PR TITLE
Tweak default BaseMaterial3D deep parallax quality to improve performance

### DIFF
--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2770,8 +2770,8 @@ BaseMaterial3D::BaseMaterial3D(bool p_orm) :
 
 	set_grow(0.0);
 
-	set_heightmap_deep_parallax_min_layers(8);
-	set_heightmap_deep_parallax_max_layers(32);
+	set_heightmap_deep_parallax_min_layers(6);
+	set_heightmap_deep_parallax_max_layers(16);
 	set_heightmap_deep_parallax_flip_tangent(false); //also sets binormal
 
 	flags[FLAG_USE_TEXTURE_REPEAT] = true;


### PR DESCRIPTION
On a GTX 1080 in 2560×1440, this reduces frame times by 0.25 ms on a test scene with 4 different materials that have Deep Parallax enabled.

There is a subtle visual difference, but it's not too noticeable on most materials.

**Note:** This should be re-assessed if https://github.com/godotengine/godot/pull/50377 is merged, as we may not be able to reduce the number of steps as much without losing too much quality.

**Testing project:** https://github.com/Calinou/godot-parallax-test-4.0/tree/performance-test-master

## Preview

*Click to view at full size.*

### Before

![2022-02-07_21 53 42](https://user-images.githubusercontent.com/180032/152871777-57fc0494-4043-4505-9b26-dd5d69dc7bab.png)

### After

![2022-02-07_22 00 29](https://user-images.githubusercontent.com/180032/152871792-b8d5f9f1-fb1b-4c6f-86e5-160fb4fbe319.png)

