### PR TITLE
Unbind `_update_hover()` from `TabBar`

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1436,7 +1436,6 @@ void TabBar::_get_property_list(List<PropertyInfo> *p_list) const {
 }
 
 void TabBar::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("_update_hover"), &TabBar::_update_hover);
 	ClassDB::bind_method(D_METHOD("set_tab_count", "count"), &TabBar::set_tab_count);
 	ClassDB::bind_method(D_METHOD("get_tab_count"), &TabBar::get_tab_count);
 	ClassDB::bind_method(D_METHOD("set_current_tab", "tab_idx"), &TabBar::set_current_tab);


### PR DESCRIPTION
Closes #57710.