### PR TITLE
Fix `RayCast{2,3}D.clear_exceptions` clears parent

### DIFF
--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -279,6 +279,13 @@ void RayCast2D::remove_exception(const CollisionObject2D *p_node) {
 
 void RayCast2D::clear_exceptions() {
 	exclude.clear();
+
+	if (exclude_parent_body && is_inside_tree()) {
+		CollisionObject2D *parent = Object::cast_to<CollisionObject2D>(get_parent());
+		if (parent) {
+			exclude.insert(parent->get_rid());
+		}
+	}
 }
 
 void RayCast2D::set_collide_with_areas(bool p_enabled) {

--- a/scene/3d/ray_cast_3d.cpp
+++ b/scene/3d/ray_cast_3d.cpp
@@ -259,6 +259,13 @@ void RayCast3D::remove_exception(const CollisionObject3D *p_node) {
 
 void RayCast3D::clear_exceptions() {
 	exclude.clear();
+
+	if (exclude_parent_body && is_inside_tree()) {
+		CollisionObject3D *parent = Object::cast_to<CollisionObject3D>(get_parent());
+		if (parent) {
+			exclude.insert(parent->get_rid());
+		}
+	}
 }
 
 void RayCast3D::set_collide_with_areas(bool p_enabled) {


### PR DESCRIPTION
Fixes #57772

This PR re-adds parent to the exclude set when necessary.

If the node is not currently inside tree, its parent will be excluded when handling `NOTIFICATION_ENTER_TREE`. (existing logic)