### PR TITLE
[3.x] Fix `RayCast{,2D}.clear_exceptions` clears parent

### DIFF
--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -258,6 +258,13 @@ void RayCast2D::remove_exception(const Object *p_object) {
 
 void RayCast2D::clear_exceptions() {
 	exclude.clear();
+
+	if (exclude_parent_body && is_inside_tree()) {
+		CollisionObject2D *parent = Object::cast_to<CollisionObject2D>(get_parent());
+		if (parent) {
+			exclude.insert(parent->get_rid());
+		}
+	}
 }
 
 void RayCast2D::set_collide_with_areas(bool p_clip) {

--- a/scene/3d/ray_cast.cpp
+++ b/scene/3d/ray_cast.cpp
@@ -256,6 +256,13 @@ void RayCast::remove_exception(const Object *p_object) {
 
 void RayCast::clear_exceptions() {
 	exclude.clear();
+
+	if (exclude_parent_body && is_inside_tree()) {
+		CollisionObject *parent = Object::cast_to<CollisionObject>(get_parent());
+		if (parent) {
+			exclude.insert(parent->get_rid());
+		}
+	}
 }
 
 void RayCast::set_collide_with_areas(bool p_clip) {


### PR DESCRIPTION
`3.x` version of #57791