### PR TITLE
Revert "Add missing SNAME macro optimization to all theme methods call"

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4368,7 +4368,7 @@ void AnimationTrackEditor::_update_tracks() {
 				g->set_timeline(timeline);
 				groups.push_back(g);
 				VBoxContainer *vb = memnew(VBoxContainer);
-				vb->add_theme_constant_override(SNAME("separation"), 0);
+				vb->add_theme_constant_override("separation", 0);
 				vb->add_child(g);
 				track_vbox->add_child(vb);
 				group_sort[base_path] = vb;
@@ -4519,7 +4519,7 @@ void AnimationTrackEditor::_notification(int p_what) {
 		view_group->set_icon(get_theme_icon(view_group->is_pressed() ? SNAME("AnimationTrackList") : SNAME("AnimationTrackGroup"), SNAME("EditorIcons")));
 		selected_filter->set_icon(get_theme_icon(SNAME("AnimationFilter"), SNAME("EditorIcons")));
 		imported_anim_warning->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
-		main_panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		main_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		edit->get_popup()->set_item_icon(edit->get_popup()->get_item_index(EDIT_APPLY_RESET), get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
 	}
 
@@ -6085,7 +6085,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	timeline_scroll->add_child(timeline_vbox);
 	timeline_vbox->set_v_size_flags(SIZE_EXPAND_FILL);
 	timeline_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
-	timeline_vbox->add_theme_constant_override(SNAME("separation"), 0);
+	timeline_vbox->add_theme_constant_override("separation", 0);
 
 	info_message = memnew(Label);
 	info_message->set_text(TTR("Select an AnimationPlayer node to create and edit animations."));
@@ -6140,7 +6140,7 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	scroll->add_child(track_vbox);
 	track_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
 	scroll->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
-	track_vbox->add_theme_constant_override(SNAME("separation"), 0);
+	track_vbox->add_theme_constant_override("separation", 0);
 
 	HBoxContainer *bottom_hb = memnew(HBoxContainer);
 	add_child(bottom_hb);

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -105,7 +105,7 @@ void FindReplaceBar::_notification(int p_what) {
 		hide_button->set_pressed_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
 		hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
-		matches_label->add_theme_color_override(SNAME("font_color"), results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	} else if (p_what == NOTIFICATION_PREDELETE) {
 		if (base_text_editor) {
 			base_text_editor->remove_find_replace_bar();
@@ -301,7 +301,7 @@ void FindReplaceBar::_replace_all() {
 	}
 
 	text_editor->set_v_scroll(vsval);
-	matches_label->add_theme_color_override(SNAME("font_color"), rc > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
+	matches_label->add_theme_color_override("font_color", rc > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	matches_label->set_text(vformat(TTR("%d replaced."), rc));
 
 	text_editor->call_deferred(SNAME("connect"), "text_changed", callable_mp(this, &FindReplaceBar::_editor_text_changed));
@@ -365,7 +365,7 @@ void FindReplaceBar::_update_matches_label() {
 	} else {
 		matches_label->show();
 
-		matches_label->add_theme_color_override(SNAME("font_color"), results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		matches_label->set_text(vformat(results_count == 1 ? TTR("%d match.") : TTR("%d matches."), results_count));
 	}
 }
@@ -818,7 +818,7 @@ void CodeTextEditor::_zoom_changed() {
 
 void CodeTextEditor::_reset_zoom() {
 	EditorSettings::get_singleton()->set("interface/editor/code_font_size", 14);
-	text_editor->add_theme_font_size_override(SNAME("font_size"), 14 * EDSCALE);
+	text_editor->add_theme_font_size_override("font_size", 14 * EDSCALE);
 }
 
 void CodeTextEditor::_line_col_changed() {
@@ -936,7 +936,7 @@ bool CodeTextEditor::_add_font_size(int p_delta) {
 
 	if (new_size != old_size) {
 		EditorSettings::get_singleton()->set("interface/editor/code_font_size", new_size / EDSCALE);
-		text_editor->add_theme_font_size_override(SNAME("font_size"), new_size);
+		text_editor->add_theme_font_size_override("font_size", new_size);
 	}
 
 	return true;
@@ -1567,14 +1567,14 @@ void CodeTextEditor::_update_text_editor_theme() {
 
 	Ref<Font> status_bar_font = get_theme_font(SNAME("status_source"), SNAME("EditorFonts"));
 	int status_bar_font_size = get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts"));
-	error->add_theme_font_override(SNAME("font"), status_bar_font);
-	error->add_theme_font_size_override(SNAME("font_size"), status_bar_font_size);
+	error->add_theme_font_override("font", status_bar_font);
+	error->add_theme_font_size_override("font_size", status_bar_font_size);
 	int count = status_bar->get_child_count();
 	for (int i = 0; i < count; i++) {
 		Control *n = Object::cast_to<Control>(status_bar->get_child(i));
 		if (n) {
-			n->add_theme_font_override(SNAME("font"), status_bar_font);
-			n->add_theme_font_size_override(SNAME("font_size"), status_bar_font_size);
+			n->add_theme_font_override("font", status_bar_font);
+			n->add_theme_font_size_override("font_size", status_bar_font_size);
 		}
 	}
 	error->end_bulk_theme_override();
@@ -1666,17 +1666,17 @@ void CodeTextEditor::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			error_button->set_icon(get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons")));
-			error_button->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
-			error_button->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
-			error_button->add_theme_font_size_override(SNAME("font_size"), get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+			error_button->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			error_button->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+			error_button->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 
 			warning_button->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
-			warning_button->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("warning_color"), SNAME("Editor")));
-			warning_button->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
-			warning_button->add_theme_font_size_override(SNAME("font_size"), get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+			warning_button->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+			warning_button->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+			warning_button->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 
-			line_and_col_txt->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
-			line_and_col_txt->add_theme_font_size_override(SNAME("font_size"), get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+			line_and_col_txt->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+			line_and_col_txt->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 
 			if (p_what == NOTIFICATION_ENTER_TREE) {
 				break;
@@ -1935,5 +1935,5 @@ CodeTextEditor::CodeTextEditor() {
 	font_resize_timer->connect("timeout", callable_mp(this, &CodeTextEditor::_font_resize_timeout));
 
 	EditorSettings::get_singleton()->connect("settings_changed", callable_mp(this, &CodeTextEditor::_on_settings_change));
-	add_theme_constant_override(SNAME("separation"), 4 * EDSCALE);
+	add_theme_constant_override("separation", 4 * EDSCALE);
 }

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -381,7 +381,7 @@ void ConnectDialog::init(ConnectionData p_cd, bool p_edit) {
 
 void ConnectDialog::popup_dialog(const String &p_for_signal) {
 	from_signal->set_text(p_for_signal);
-	error_label->add_theme_color_override(SNAME("font_color"), error_label->get_theme_color(SNAME("error_color"), SNAME("Editor")));
+	error_label->add_theme_color_override("font_color", error_label->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	if (!advanced->is_pressed()) {
 		error_label->set_visible(!_find_first_script(get_tree()->get_edited_scene_root(), get_tree()->get_edited_scene_root()));
 	}
@@ -1200,7 +1200,7 @@ ConnectionsDock::ConnectionsDock(EditorNode *p_editor) {
 	tree->connect("item_activated", callable_mp(this, &ConnectionsDock::_tree_item_activated));
 	tree->connect("item_rmb_selected", callable_mp(this, &ConnectionsDock::_rmb_pressed));
 
-	add_theme_constant_override(SNAME("separation"), 3 * EDSCALE);
+	add_theme_constant_override("separation", 3 * EDSCALE);
 
 	EDITOR_DEF("interface/editors/default_signal_callback_name", "_on_{node_name}_{signal_name}");
 }

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -733,7 +733,7 @@ CreateDialog::CreateDialog() {
 	favorites->set_allow_reselect(true);
 	favorites->connect("cell_selected", callable_mp(this, &CreateDialog::_favorite_selected));
 	favorites->connect("item_activated", callable_mp(this, &CreateDialog::_favorite_activated));
-	favorites->add_theme_constant_override(SNAME("draw_guides"), 1);
+	favorites->add_theme_constant_override("draw_guides", 1);
 #ifndef _MSC_VER
 #warning cannot forward drag data to a non control, must be fixed
 #endif
@@ -750,7 +750,7 @@ CreateDialog::CreateDialog() {
 	recent->set_allow_reselect(true);
 	recent->connect("item_selected", callable_mp(this, &CreateDialog::_history_selected));
 	recent->connect("item_activated", callable_mp(this, &CreateDialog::_history_activated));
-	recent->add_theme_constant_override(SNAME("draw_guides"), 1);
+	recent->add_theme_constant_override("draw_guides", 1);
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	vbc->set_custom_minimum_size(Size2(300, 0) * EDSCALE);

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -55,8 +55,8 @@ EditorDebuggerNode::EditorDebuggerNode() {
 		singleton = this;
 	}
 
-	add_theme_constant_override(SNAME("margin_left"), -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles"))->get_margin(SIDE_LEFT));
-	add_theme_constant_override(SNAME("margin_right"), -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles"))->get_margin(SIDE_RIGHT));
+	add_theme_constant_override("margin_left", -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles"))->get_margin(SIDE_LEFT));
+	add_theme_constant_override("margin_right", -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles"))->get_margin(SIDE_RIGHT));
 
 	tabs = memnew(TabContainer);
 	tabs->set_tab_alignment(TabContainer::ALIGNMENT_LEFT);
@@ -66,7 +66,7 @@ EditorDebuggerNode::EditorDebuggerNode() {
 
 	Ref<StyleBoxEmpty> empty;
 	empty.instantiate();
-	tabs->add_theme_style_override(SNAME("panel"), empty);
+	tabs->add_theme_style_override("panel", empty);
 
 	auto_switch_remote_scene_tree = EDITOR_DEF("debugger/auto_switch_to_remote_scene_tree", false);
 	_add_debugger();
@@ -113,7 +113,7 @@ ScriptEditorDebugger *EditorDebuggerNode::_add_debugger() {
 	if (tabs->get_tab_count() > 1) {
 		node->clear_style();
 		tabs->set_tabs_visible(true);
-		tabs->add_theme_style_override(SNAME("panel"), EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
+		tabs->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
 	}
 
 	if (!debugger_plugins.is_empty()) {
@@ -233,10 +233,10 @@ void EditorDebuggerNode::_notification(int p_what) {
 	switch (p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (tabs->get_tab_count() > 1) {
-				add_theme_constant_override(SNAME("margin_left"), -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles"))->get_margin(SIDE_LEFT));
-				add_theme_constant_override(SNAME("margin_right"), -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles"))->get_margin(SIDE_RIGHT));
+				add_theme_constant_override("margin_left", -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles"))->get_margin(SIDE_LEFT));
+				add_theme_constant_override("margin_right", -EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles"))->get_margin(SIDE_RIGHT));
 
-				tabs->add_theme_style_override(SNAME("panel"), EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
+				tabs->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
 			}
 		} break;
 		case NOTIFICATION_READY: {
@@ -271,20 +271,20 @@ void EditorDebuggerNode::_notification(int p_what) {
 
 		if (error_count == 0 && warning_count == 0) {
 			debugger_button->set_text(TTR("Debugger"));
-			debugger_button->remove_theme_color_override(SNAME("font_color"));
+			debugger_button->remove_theme_color_override("font_color");
 			debugger_button->set_icon(Ref<Texture2D>());
 		} else {
 			debugger_button->set_text(TTR("Debugger") + " (" + itos(error_count + warning_count) + ")");
 			if (error_count >= 1 && warning_count >= 1) {
 				debugger_button->set_icon(get_theme_icon(SNAME("ErrorWarning"), SNAME("EditorIcons")));
 				// Use error color to represent the highest level of severity reported.
-				debugger_button->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
+				debugger_button->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 			} else if (error_count >= 1) {
 				debugger_button->set_icon(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
-				debugger_button->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
+				debugger_button->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 			} else {
 				debugger_button->set_icon(get_theme_icon(SNAME("Warning"), SNAME("EditorIcons")));
-				debugger_button->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+				debugger_button->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 			}
 		}
 		last_error_count = error_count;

--- a/editor/debugger/editor_network_profiler.cpp
+++ b/editor/debugger/editor_network_profiler.cpp
@@ -46,8 +46,8 @@ void EditorNetworkProfiler::_notification(int p_what) {
 		outgoing_bandwidth_text->set_right_icon(get_theme_icon(SNAME("ArrowUp"), SNAME("EditorIcons")));
 
 		// This needs to be done here to set the faded color when the profiler is first opened
-		incoming_bandwidth_text->add_theme_color_override(SNAME("font_uneditable_color"), get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, 0.5));
-		outgoing_bandwidth_text->add_theme_color_override(SNAME("font_uneditable_color"), get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, 0.5));
+		incoming_bandwidth_text->add_theme_color_override("font_uneditable_color", get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, 0.5));
+		outgoing_bandwidth_text->add_theme_color_override("font_uneditable_color", get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, 0.5));
 	}
 }
 
@@ -126,7 +126,7 @@ bool EditorNetworkProfiler::is_profiling() {
 
 EditorNetworkProfiler::EditorNetworkProfiler() {
 	HBoxContainer *hb = memnew(HBoxContainer);
-	hb->add_theme_constant_override(SNAME("separation"), 8 * EDSCALE);
+	hb->add_theme_constant_override("separation", 8 * EDSCALE);
 	add_child(hb);
 
 	activate = memnew(Button);

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -618,7 +618,7 @@ EditorProfiler::EditorProfiler() {
 	hb->add_child(cursor_metric_edit);
 	cursor_metric_edit->connect("value_changed", callable_mp(this, &EditorProfiler::_cursor_metric_changed));
 
-	hb->add_theme_constant_override(SNAME("separation"), 8 * EDSCALE);
+	hb->add_theme_constant_override("separation", 8 * EDSCALE);
 
 	h_split = memnew(HSplitContainer);
 	add_child(h_split);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -758,7 +758,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	hb->add_child(cursor_metric_edit);
 	cursor_metric_edit->connect("value_changed", callable_mp(this, &EditorVisualProfiler::_cursor_metric_changed));
 
-	hb->add_theme_constant_override(SNAME("separation"), 8 * EDSCALE);
+	hb->add_theme_constant_override("separation", 8 * EDSCALE);
 
 	h_split = memnew(HSplitContainer);
 	add_child(h_split);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -147,7 +147,7 @@ void ScriptEditorDebugger::update_tabs() {
 }
 
 void ScriptEditorDebugger::clear_style() {
-	tabs->remove_theme_style_override(SNAME("panel"));
+	tabs->remove_theme_style_override("panel");
 }
 
 void ScriptEditorDebugger::save_node(ObjectID p_id, const String &p_file) {
@@ -762,13 +762,13 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 void ScriptEditorDebugger::_set_reason_text(const String &p_reason, MessageType p_type) {
 	switch (p_type) {
 		case MESSAGE_ERROR:
-			reason->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			reason->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 			break;
 		case MESSAGE_WARNING:
-			reason->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+			reason->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 			break;
 		default:
-			reason->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("success_color"), SNAME("Editor")));
+			reason->add_theme_color_override("font_color", get_theme_color(SNAME("success_color"), SNAME("Editor")));
 	}
 	reason->set_text(p_reason);
 	reason->set_tooltip(p_reason.word_wrap(80));
@@ -793,7 +793,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			vmem_export->set_icon(get_theme_icon(SNAME("Save"), SNAME("EditorIcons")));
 			search->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 
-			reason->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			reason->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
 		} break;
 		case NOTIFICATION_PROCESS: {
@@ -855,8 +855,8 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			};
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			if (tabs->has_theme_stylebox_override(SNAME("panel"))) {
-				tabs->add_theme_style_override(SNAME("panel"), editor->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
+			if (tabs->has_theme_stylebox_override("panel")) {
+				tabs->add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
 			}
 
 			copy->set_icon(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")));
@@ -1665,7 +1665,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 
 	tabs = memnew(TabContainer);
 	tabs->set_tab_alignment(TabContainer::ALIGNMENT_LEFT);
-	tabs->add_theme_style_override(SNAME("panel"), editor->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
+	tabs->add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
 	tabs->connect("tab_changed", callable_mp(this, &ScriptEditorDebugger::_tab_changed));
 
 	add_child(tabs);

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -43,12 +43,12 @@ static const String META_TEXT_TO_COPY = "text_to_copy";
 void EditorAbout::_theme_changed() {
 	const Ref<Font> font = get_theme_font(SNAME("source"), SNAME("EditorFonts"));
 	const int font_size = get_theme_font_size(SNAME("source_size"), SNAME("EditorFonts"));
-	_tpl_text->add_theme_font_override(SNAME("normal_font"), font);
-	_tpl_text->add_theme_font_size_override(SNAME("normal_font_size"), font_size);
-	_tpl_text->add_theme_constant_override(SNAME("line_separation"), 6 * EDSCALE);
-	_license_text->add_theme_font_override(SNAME("normal_font"), font);
-	_license_text->add_theme_font_size_override(SNAME("normal_font_size"), font_size);
-	_license_text->add_theme_constant_override(SNAME("line_separation"), 6 * EDSCALE);
+	_tpl_text->add_theme_font_override("normal_font", font);
+	_tpl_text->add_theme_font_size_override("normal_font_size", font_size);
+	_tpl_text->add_theme_constant_override("line_separation", 6 * EDSCALE);
+	_license_text->add_theme_font_override("normal_font", font);
+	_license_text->add_theme_font_size_override("normal_font_size", font_size);
+	_license_text->add_theme_constant_override("line_separation", 6 * EDSCALE);
 	_logo->set_texture(get_theme_icon(SNAME("Logo"), SNAME("EditorIcons")));
 }
 
@@ -101,7 +101,7 @@ ScrollContainer *EditorAbout::_populate_list(const String &p_name, const List<St
 			il->set_same_column_width(true);
 			il->set_auto_height(true);
 			il->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
-			il->add_theme_constant_override(SNAME("hseparation"), 16 * EDSCALE);
+			il->add_theme_constant_override("hseparation", 16 * EDSCALE);
 			while (*names_ptr) {
 				il->add_item(String::utf8(*names_ptr++), nullptr, false);
 			}
@@ -126,7 +126,7 @@ EditorAbout::EditorAbout() {
 	HBoxContainer *hbc = memnew(HBoxContainer);
 	hbc->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	hbc->set_alignment(BoxContainer::ALIGNMENT_CENTER);
-	hbc->add_theme_constant_override(SNAME("separation"), 30 * EDSCALE);
+	hbc->add_theme_constant_override("separation", 30 * EDSCALE);
 	add_child(vbc);
 	vbc->add_child(hbc);
 

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -79,17 +79,17 @@ void EditorAudioBus::_notification(int p_what) {
 			Color bypass_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(0.13, 0.8, 1.0) : Color(0.44, 0.87, 1.0);
 
 			solo->set_icon(get_theme_icon(SNAME("AudioBusSolo"), SNAME("EditorIcons")));
-			solo->add_theme_color_override(SNAME("icon_pressed_color"), solo_color);
+			solo->add_theme_color_override("icon_pressed_color", solo_color);
 			mute->set_icon(get_theme_icon(SNAME("AudioBusMute"), SNAME("EditorIcons")));
-			mute->add_theme_color_override(SNAME("icon_pressed_color"), mute_color);
+			mute->add_theme_color_override("icon_pressed_color", mute_color);
 			bypass->set_icon(get_theme_icon(SNAME("AudioBusBypass"), SNAME("EditorIcons")));
-			bypass->add_theme_color_override(SNAME("icon_pressed_color"), bypass_color);
+			bypass->add_theme_color_override("icon_pressed_color", bypass_color);
 
 			bus_options->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 
-			audio_value_preview_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("font_color"), SNAME("TooltipLabel")));
-			audio_value_preview_label->add_theme_color_override(SNAME("font_shadow_color"), get_theme_color(SNAME("font_shadow_color"), SNAME("TooltipLabel")));
-			audio_value_preview_box->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel")));
+			audio_value_preview_label->add_theme_color_override("font_color", get_theme_color(SNAME("font_color"), SNAME("TooltipLabel")));
+			audio_value_preview_label->add_theme_color_override("font_shadow_color", get_theme_color(SNAME("font_shadow_color"), SNAME("TooltipLabel")));
+			audio_value_preview_box->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel")));
 		} break;
 
 		case NOTIFICATION_READY: {
@@ -574,7 +574,7 @@ Variant EditorAudioBus::get_drag_data(const Point2 &p_point) {
 	Panel *p = memnew(Panel);
 	c->add_child(p);
 	p->set_modulate(Color(1, 1, 1, 0.7));
-	p->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("focus"), SNAME("Button")));
+	p->add_theme_style_override("panel", get_theme_stylebox(SNAME("focus"), SNAME("Button")));
 	p->set_size(get_size());
 	p->set_position(-p_point);
 	set_drag_preview(c);
@@ -804,10 +804,10 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 	Ref<StyleBoxEmpty> sbempty = memnew(StyleBoxEmpty);
 	for (int i = 0; i < hbc->get_child_count(); i++) {
 		Control *child = Object::cast_to<Control>(hbc->get_child(i));
-		child->add_theme_style_override(SNAME("normal"), sbempty);
-		child->add_theme_style_override(SNAME("hover"), sbempty);
-		child->add_theme_style_override(SNAME("focus"), sbempty);
-		child->add_theme_style_override(SNAME("pressed"), sbempty);
+		child->add_theme_style_override("normal", sbempty);
+		child->add_theme_style_override("hover", sbempty);
+		child->add_theme_style_override("focus", sbempty);
+		child->add_theme_style_override("pressed", sbempty);
 	}
 
 	HSeparator *separator = memnew(HSeparator);
@@ -1013,7 +1013,7 @@ void EditorAudioBuses::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			bus_scroll->add_theme_style_override(SNAME("bg"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			bus_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		} break;
 		case NOTIFICATION_READY: {
 			_update_buses();

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -839,7 +839,7 @@ EditorAutoloadSettings::EditorAutoloadSettings() {
 	error_message = memnew(Label);
 	error_message->hide();
 	error_message->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
-	error_message->add_theme_color_override(SNAME("font_color"), EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
+	error_message->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	add_child(error_message);
 
 	Label *l = memnew(Label);

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -955,7 +955,7 @@ EditorFeatureProfileManager::EditorFeatureProfileManager() {
 	// Add some spacing above the help label.
 	Ref<StyleBoxEmpty> sb = memnew(StyleBoxEmpty);
 	sb->set_default_margin(SIDE_TOP, 20 * EDSCALE);
-	no_profile_selected_help->add_theme_style_override(SNAME("normal"), sb);
+	no_profile_selected_help->add_theme_style_override("normal", sb);
 	no_profile_selected_help->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	no_profile_selected_help->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	h_split->add_child(no_profile_selected_help);

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -279,67 +279,67 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	p_theme->set_default_font(df); // Default theme font
 	p_theme->set_default_font_size(default_font_size);
 
-	p_theme->set_font_size(SNAME("main_size"), SNAME("EditorFonts"), default_font_size);
-	p_theme->set_font(SNAME("main"), SNAME("EditorFonts"), df);
+	p_theme->set_font_size("main_size", "EditorFonts", default_font_size);
+	p_theme->set_font("main", "EditorFonts", df);
 
 	// Bold font
 	MAKE_BOLD_FONT(df_bold, String());
-	p_theme->set_font_size(SNAME("bold_size"), SNAME("EditorFonts"), default_font_size);
-	p_theme->set_font(SNAME("bold"), SNAME("EditorFonts"), df_bold);
+	p_theme->set_font_size("bold_size", "EditorFonts", default_font_size);
+	p_theme->set_font("bold", "EditorFonts", df_bold);
 
 	// Title font
-	p_theme->set_font_size(SNAME("title_size"), SNAME("EditorFonts"), default_font_size + 1 * EDSCALE);
-	p_theme->set_font(SNAME("title"), SNAME("EditorFonts"), df_bold);
+	p_theme->set_font_size("title_size", "EditorFonts", default_font_size + 1 * EDSCALE);
+	p_theme->set_font("title", "EditorFonts", df_bold);
 
-	p_theme->set_font_size(SNAME("main_button_font_size"), SNAME("EditorFonts"), default_font_size + 1 * EDSCALE);
-	p_theme->set_font(SNAME("main_button_font"), SNAME("EditorFonts"), df_bold);
+	p_theme->set_font_size("main_button_font_size", "EditorFonts", default_font_size + 1 * EDSCALE);
+	p_theme->set_font("main_button_font", "EditorFonts", df_bold);
 
-	p_theme->set_font(SNAME("font"), SNAME("Label"), df);
+	p_theme->set_font("font", "Label", df);
 
-	p_theme->set_type_variation(SNAME("HeaderSmall"), SNAME("Label"));
-	p_theme->set_font(SNAME("font"), SNAME("HeaderSmall"), df_bold);
-	p_theme->set_font_size(SNAME("font_size"), SNAME("HeaderSmall"), default_font_size);
+	p_theme->set_type_variation("HeaderSmall", "Label");
+	p_theme->set_font("font", "HeaderSmall", df_bold);
+	p_theme->set_font_size("font_size", "HeaderSmall", default_font_size);
 
-	p_theme->set_type_variation(SNAME("HeaderMedium"), SNAME("Label"));
-	p_theme->set_font(SNAME("font"), SNAME("HeaderMedium"), df_bold);
-	p_theme->set_font_size(SNAME("font_size"), SNAME("HeaderMedium"), default_font_size + 1 * EDSCALE);
+	p_theme->set_type_variation("HeaderMedium", "Label");
+	p_theme->set_font("font", "HeaderMedium", df_bold);
+	p_theme->set_font_size("font_size", "HeaderMedium", default_font_size + 1 * EDSCALE);
 
-	p_theme->set_type_variation(SNAME("HeaderLarge"), SNAME("Label"));
-	p_theme->set_font(SNAME("font"), SNAME("HeaderLarge"), df_bold);
-	p_theme->set_font_size(SNAME("font_size"), SNAME("HeaderLarge"), default_font_size + 3 * EDSCALE);
+	p_theme->set_type_variation("HeaderLarge", "Label");
+	p_theme->set_font("font", "HeaderLarge", df_bold);
+	p_theme->set_font_size("font_size", "HeaderLarge", default_font_size + 3 * EDSCALE);
 
 	// Documentation fonts
 	String code_font_custom_variations = EditorSettings::get_singleton()->get("interface/editor/code_font_custom_variations");
 	MAKE_SOURCE_FONT(df_code, code_font_custom_variations);
-	p_theme->set_font_size(SNAME("doc_size"), SNAME("EditorFonts"), int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
-	p_theme->set_font(SNAME("doc"), SNAME("EditorFonts"), df);
-	p_theme->set_font_size(SNAME("doc_bold_size"), SNAME("EditorFonts"), int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
-	p_theme->set_font(SNAME("doc_bold"), SNAME("EditorFonts"), df_bold);
-	p_theme->set_font_size(SNAME("doc_title_size"), SNAME("EditorFonts"), int(EDITOR_GET("text_editor/help/help_title_font_size")) * EDSCALE);
-	p_theme->set_font(SNAME("doc_title"), SNAME("EditorFonts"), df_bold);
-	p_theme->set_font_size(SNAME("doc_source_size"), SNAME("EditorFonts"), int(EDITOR_GET("text_editor/help/help_source_font_size")) * EDSCALE);
-	p_theme->set_font(SNAME("doc_source"), SNAME("EditorFonts"), df_code);
-	p_theme->set_font_size(SNAME("doc_keyboard_size"), SNAME("EditorFonts"), (int(EDITOR_GET("text_editor/help/help_source_font_size")) - 1) * EDSCALE);
-	p_theme->set_font(SNAME("doc_keyboard"), SNAME("EditorFonts"), df_code);
+	p_theme->set_font_size("doc_size", "EditorFonts", int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
+	p_theme->set_font("doc", "EditorFonts", df);
+	p_theme->set_font_size("doc_bold_size", "EditorFonts", int(EDITOR_GET("text_editor/help/help_font_size")) * EDSCALE);
+	p_theme->set_font("doc_bold", "EditorFonts", df_bold);
+	p_theme->set_font_size("doc_title_size", "EditorFonts", int(EDITOR_GET("text_editor/help/help_title_font_size")) * EDSCALE);
+	p_theme->set_font("doc_title", "EditorFonts", df_bold);
+	p_theme->set_font_size("doc_source_size", "EditorFonts", int(EDITOR_GET("text_editor/help/help_source_font_size")) * EDSCALE);
+	p_theme->set_font("doc_source", "EditorFonts", df_code);
+	p_theme->set_font_size("doc_keyboard_size", "EditorFonts", (int(EDITOR_GET("text_editor/help/help_source_font_size")) - 1) * EDSCALE);
+	p_theme->set_font("doc_keyboard", "EditorFonts", df_code);
 
 	// Ruler font
-	p_theme->set_font_size(SNAME("rulers_size"), SNAME("EditorFonts"), 8 * EDSCALE);
-	p_theme->set_font(SNAME("rulers"), SNAME("EditorFonts"), df);
+	p_theme->set_font_size("rulers_size", "EditorFonts", 8 * EDSCALE);
+	p_theme->set_font("rulers", "EditorFonts", df);
 
 	// Rotation widget font
-	p_theme->set_font_size(SNAME("rotation_control_size"), SNAME("EditorFonts"), 14 * EDSCALE);
-	p_theme->set_font(SNAME("rotation_control"), SNAME("EditorFonts"), df);
+	p_theme->set_font_size("rotation_control_size", "EditorFonts", 14 * EDSCALE);
+	p_theme->set_font("rotation_control", "EditorFonts", df);
 
 	// Code font
-	p_theme->set_font_size(SNAME("source_size"), SNAME("EditorFonts"), int(EDITOR_GET("interface/editor/code_font_size")) * EDSCALE);
-	p_theme->set_font(SNAME("source"), SNAME("EditorFonts"), df_code);
+	p_theme->set_font_size("source_size", "EditorFonts", int(EDITOR_GET("interface/editor/code_font_size")) * EDSCALE);
+	p_theme->set_font("source", "EditorFonts", df_code);
 
-	p_theme->set_font_size(SNAME("expression_size"), SNAME("EditorFonts"), (int(EDITOR_GET("interface/editor/code_font_size")) - 1) * EDSCALE);
-	p_theme->set_font(SNAME("expression"), SNAME("EditorFonts"), df_code);
+	p_theme->set_font_size("expression_size", "EditorFonts", (int(EDITOR_GET("interface/editor/code_font_size")) - 1) * EDSCALE);
+	p_theme->set_font("expression", "EditorFonts", df_code);
 
-	p_theme->set_font_size(SNAME("output_source_size"), SNAME("EditorFonts"), int(EDITOR_GET("run/output/font_size")) * EDSCALE);
-	p_theme->set_font(SNAME("output_source"), SNAME("EditorFonts"), df_code);
+	p_theme->set_font_size("output_source_size", "EditorFonts", int(EDITOR_GET("run/output/font_size")) * EDSCALE);
+	p_theme->set_font("output_source", "EditorFonts", df_code);
 
-	p_theme->set_font_size(SNAME("status_source_size"), SNAME("EditorFonts"), default_font_size);
-	p_theme->set_font(SNAME("status_source"), SNAME("EditorFonts"), df_code);
+	p_theme->set_font_size("status_source_size", "EditorFonts", default_font_size);
+	p_theme->set_font("status_source", "EditorFonts", df_code);
 }

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -54,10 +54,10 @@ void EditorHelp::_update_theme() {
 	qualifier_color = get_theme_color(SNAME("qualifier_color"), SNAME("EditorHelp"));
 	type_color = get_theme_color(SNAME("type_color"), SNAME("EditorHelp"));
 
-	class_desc->add_theme_color_override(SNAME("selection_color"), get_theme_color(SNAME("selection_color"), SNAME("EditorHelp")));
-	class_desc->add_theme_constant_override(SNAME("line_separation"), get_theme_constant(SNAME("line_separation"), SNAME("EditorHelp")));
-	class_desc->add_theme_constant_override(SNAME("table_hseparation"), get_theme_constant(SNAME("table_hseparation"), SNAME("EditorHelp")));
-	class_desc->add_theme_constant_override(SNAME("table_vseparation"), get_theme_constant(SNAME("table_vseparation"), SNAME("EditorHelp")));
+	class_desc->add_theme_color_override("selection_color", get_theme_color(SNAME("selection_color"), SNAME("EditorHelp")));
+	class_desc->add_theme_constant_override("line_separation", get_theme_constant(SNAME("line_separation"), SNAME("EditorHelp")));
+	class_desc->add_theme_constant_override("table_hseparation", get_theme_constant(SNAME("table_hseparation"), SNAME("EditorHelp")));
+	class_desc->add_theme_constant_override("table_vseparation", get_theme_constant(SNAME("table_vseparation"), SNAME("EditorHelp")));
 
 	doc_font = get_theme_font(SNAME("doc"), SNAME("EditorFonts"));
 	doc_bold_font = get_theme_font(SNAME("doc_bold"), SNAME("EditorFonts"));
@@ -176,7 +176,7 @@ void EditorHelp::_class_desc_resized(bool p_force_update_theme) {
 		Ref<StyleBox> class_desc_stylebox = EditorNode::get_singleton()->get_theme_base()->get_theme_stylebox(SNAME("normal"), SNAME("RichTextLabel"))->duplicate();
 		class_desc_stylebox->set_default_margin(SIDE_LEFT, display_margin);
 		class_desc_stylebox->set_default_margin(SIDE_RIGHT, display_margin);
-		class_desc->add_theme_style_override(SNAME("normal"), class_desc_stylebox);
+		class_desc->add_theme_style_override("normal", class_desc_stylebox);
 	}
 }
 
@@ -1872,7 +1872,7 @@ EditorHelp::EditorHelp() {
 	class_desc = memnew(RichTextLabel);
 	add_child(class_desc);
 	class_desc->set_v_size_flags(SIZE_EXPAND_FILL);
-	class_desc->add_theme_color_override(SNAME("selection_color"), get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
+	class_desc->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
 
 	class_desc->connect("meta_clicked", callable_mp(this, &EditorHelp::_class_desc_select));
 	class_desc->connect("gui_input", callable_mp(this, &EditorHelp::_class_desc_input));
@@ -1951,7 +1951,7 @@ void EditorHelpBit::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			rich_text->add_theme_color_override(SNAME("selection_color"), get_theme_color(SNAME("selection_color"), SNAME("EditorHelp")));
+			rich_text->add_theme_color_override("selection_color", get_theme_color(SNAME("selection_color"), SNAME("EditorHelp")));
 			rich_text->clear();
 			_add_text_to_rt(text, rich_text);
 			rich_text->reset_size(); // Force recalculating size after parsing bbcode.
@@ -2039,7 +2039,7 @@ void FindBar::_notification(int p_what) {
 			hide_button->set_hover_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
 			hide_button->set_pressed_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
 			hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
-			matches_label->add_theme_color_override(SNAME("font_color"), results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			set_process_unhandled_input(is_visible_in_tree());
@@ -2110,7 +2110,7 @@ void FindBar::_update_matches_label() {
 	} else {
 		matches_label->show();
 
-		matches_label->add_theme_color_override(SNAME("font_color"), results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		matches_label->set_text(vformat(results_count == 1 ? TTR("%d match.") : TTR("%d matches."), results_count));
 	}
 }

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -38,7 +38,7 @@
 void EditorHelpSearch::_update_icons() {
 	search_box->set_right_icon(results_tree->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 	search_box->set_clear_button_enabled(true);
-	search_box->add_theme_icon_override(SNAME("right_icon"), results_tree->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
+	search_box->add_theme_icon_override("right_icon", results_tree->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 	case_sensitive_button->set_icon(results_tree->get_theme_icon(SNAME("MatchCase"), SNAME("EditorIcons")));
 	hierarchy_button->set_icon(results_tree->get_theme_icon(SNAME("ClassList"), SNAME("EditorIcons")));
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1890,10 +1890,10 @@ void EditorInspectorArray::_setup() {
 		ae.margin->set_mouse_filter(MOUSE_FILTER_PASS);
 		if (is_inside_tree()) {
 			Size2 min_size = get_theme_stylebox(SNAME("Focus"), SNAME("EditorStyles"))->get_minimum_size();
-			ae.margin->add_theme_constant_override(SNAME("margin_left"), min_size.x / 2);
-			ae.margin->add_theme_constant_override(SNAME("margin_top"), min_size.y / 2);
-			ae.margin->add_theme_constant_override(SNAME("margin_right"), min_size.x / 2);
-			ae.margin->add_theme_constant_override(SNAME("margin_bottom"), min_size.y / 2);
+			ae.margin->add_theme_constant_override("margin_left", min_size.x / 2);
+			ae.margin->add_theme_constant_override("margin_top", min_size.y / 2);
+			ae.margin->add_theme_constant_override("margin_right", min_size.x / 2);
+			ae.margin->add_theme_constant_override("margin_bottom", min_size.y / 2);
 		}
 		ae.panel->add_child(ae.margin);
 
@@ -1989,10 +1989,10 @@ void EditorInspectorArray::_notification(int p_what) {
 				ae.move_texture_rect->set_texture(get_theme_icon(SNAME("TripleBar"), SNAME("EditorIcons")));
 
 				Size2 min_size = get_theme_stylebox(SNAME("Focus"), SNAME("EditorStyles"))->get_minimum_size();
-				ae.margin->add_theme_constant_override(SNAME("margin_left"), min_size.x / 2);
-				ae.margin->add_theme_constant_override(SNAME("margin_top"), min_size.y / 2);
-				ae.margin->add_theme_constant_override(SNAME("margin_right"), min_size.x / 2);
-				ae.margin->add_theme_constant_override(SNAME("margin_bottom"), min_size.y / 2);
+				ae.margin->add_theme_constant_override("margin_left", min_size.x / 2);
+				ae.margin->add_theme_constant_override("margin_top", min_size.y / 2);
+				ae.margin->add_theme_constant_override("margin_right", min_size.x / 2);
+				ae.margin->add_theme_constant_override("margin_bottom", min_size.y / 2);
 			}
 
 			add_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
@@ -2083,7 +2083,7 @@ EditorInspectorArray::EditorInspectorArray() {
 	add_child(rmb_popup);
 
 	elements_vbox = memnew(VBoxContainer);
-	elements_vbox->add_theme_constant_override(SNAME("separation"), 0);
+	elements_vbox->add_theme_constant_override("separation", 0);
 	vbox->add_child(elements_vbox);
 
 	add_button = memnew(Button);
@@ -2109,7 +2109,7 @@ EditorInspectorArray::EditorInspectorArray() {
 
 	page_line_edit = memnew(LineEdit);
 	page_line_edit->connect("text_submitted", callable_mp(this, &EditorInspectorArray::_page_line_edit_text_submitted));
-	page_line_edit->add_theme_constant_override(SNAME("minimum_character_width"), 2);
+	page_line_edit->add_theme_constant_override("minimum_character_width", 2);
 	hbox_pagination->add_child(page_line_edit);
 
 	page_count_label = memnew(Label);
@@ -3020,9 +3020,9 @@ void EditorInspector::_update_inspector_bg() {
 			n = n->get_parent();
 		}
 		count_subinspectors = MIN(15, count_subinspectors);
-		add_theme_style_override(SNAME("bg"), get_theme_stylebox("sub_inspector_bg" + itos(count_subinspectors), SNAME("Editor")));
+		add_theme_style_override("bg", get_theme_stylebox("sub_inspector_bg" + itos(count_subinspectors), "Editor"));
 	} else {
-		add_theme_style_override(SNAME("bg"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 	}
 }
 void EditorInspector::set_sub_inspector(bool p_enable) {
@@ -3551,7 +3551,7 @@ EditorInspector::EditorInspector() {
 	undo_redo = nullptr;
 	main_vbox = memnew(VBoxContainer);
 	main_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
-	main_vbox->add_theme_constant_override(SNAME("separation"), 0);
+	main_vbox->add_theme_constant_override("separation", 0);
 	add_child(main_vbox);
 	set_horizontal_scroll_mode(SCROLL_MODE_DISABLED);
 

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3020,7 +3020,7 @@ void EditorInspector::_update_inspector_bg() {
 			n = n->get_parent();
 		}
 		count_subinspectors = MIN(15, count_subinspectors);
-		add_theme_style_override("bg", get_theme_stylebox("sub_inspector_bg" + itos(count_subinspectors), "Editor"));
+		add_theme_style_override("bg", get_theme_stylebox("sub_inspector_bg" + itos(count_subinspectors), SNAME("Editor")));
 	} else {
 		add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 	}

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -64,15 +64,15 @@ void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_f
 void EditorLog::_update_theme() {
 	Ref<Font> normal_font = get_theme_font(SNAME("output_source"), SNAME("EditorFonts"));
 	if (normal_font.is_valid()) {
-		log->add_theme_font_override(SNAME("normal_font"), normal_font);
+		log->add_theme_font_override("normal_font", normal_font);
 	}
 
-	log->add_theme_font_size_override(SNAME("normal_font_size"), get_theme_font_size(SNAME("output_source_size"), SNAME("EditorFonts")));
-	log->add_theme_color_override(SNAME("selection_color"), get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
+	log->add_theme_font_size_override("normal_font_size", get_theme_font_size(SNAME("output_source_size"), SNAME("EditorFonts")));
+	log->add_theme_color_override("selection_color", get_theme_color(SNAME("accent_color"), SNAME("Editor")) * Color(1, 1, 1, 0.4));
 
 	Ref<Font> bold_font = get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
 	if (bold_font.is_valid()) {
-		log->add_theme_font_override(SNAME("bold_font"), bold_font);
+		log->add_theme_font_override("bold_font", bold_font);
 	}
 
 	type_filter_map[MSG_TYPE_STD]->toggle_button->set_icon(get_theme_icon(SNAME("Popup"), SNAME("EditorIcons")));

--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -85,7 +85,7 @@ private:
 			toggle_button->set_text(itos(message_count));
 			toggle_button->set_tooltip(TTR(p_tooltip));
 			// Don't tint the icon even when in "pressed" state.
-			toggle_button->add_theme_color_override(SNAME("icon_color_pressed"), Color(1, 1, 1, 1));
+			toggle_button->add_theme_color_override("icon_color_pressed", Color(1, 1, 1, 1));
 			toggle_button->set_focus_mode(FOCUS_NONE);
 			// When toggled call the callback and pass the MessageType this button is for.
 			toggle_button->connect("toggled", p_toggled_callback, varray(type));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -692,17 +692,17 @@ void EditorNode::_notification(int p_what) {
 			theme_base->set_theme(theme);
 			gui_base->set_theme(theme);
 
-			gui_base->add_theme_style_override(SNAME("panel"), gui_base->get_theme_stylebox(SNAME("Background"), SNAME("EditorStyles")));
-			scene_root_parent->add_theme_style_override(SNAME("panel"), gui_base->get_theme_stylebox(SNAME("Content"), SNAME("EditorStyles")));
-			bottom_panel->add_theme_style_override(SNAME("panel"), gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
-			scene_tabs->add_theme_style_override(SNAME("tab_selected"), gui_base->get_theme_stylebox(SNAME("SceneTabFG"), SNAME("EditorStyles")));
-			scene_tabs->add_theme_style_override(SNAME("tab_unselected"), gui_base->get_theme_stylebox(SNAME("SceneTabBG"), SNAME("EditorStyles")));
+			gui_base->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("Background"), SNAME("EditorStyles")));
+			scene_root_parent->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("Content"), SNAME("EditorStyles")));
+			bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
+			scene_tabs->add_theme_style_override("tab_selected", gui_base->get_theme_stylebox(SNAME("SceneTabFG"), SNAME("EditorStyles")));
+			scene_tabs->add_theme_style_override("tab_unselected", gui_base->get_theme_stylebox(SNAME("SceneTabBG"), SNAME("EditorStyles")));
 
-			file_menu->add_theme_style_override(SNAME("hover"), gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
-			project_menu->add_theme_style_override(SNAME("hover"), gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
-			debug_menu->add_theme_style_override(SNAME("hover"), gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
-			settings_menu->add_theme_style_override(SNAME("hover"), gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
-			help_menu->add_theme_style_override(SNAME("hover"), gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+			file_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+			project_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+			debug_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+			settings_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+			help_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
 
 			if (EDITOR_GET("interface/scene_tabs/resize_if_many_tabs")) {
 				scene_tabs->set_min_width(int(EDITOR_GET("interface/scene_tabs/minimum_width")) * EDSCALE);
@@ -715,7 +715,7 @@ void EditorNode::_notification(int p_what) {
 
 			// debugger area
 			if (EditorDebuggerNode::get_singleton()->is_visible()) {
-				bottom_panel->add_theme_style_override(SNAME("panel"), gui_base->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles")));
+				bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles")));
 			}
 
 			// update_icons
@@ -766,8 +766,8 @@ void EditorNode::_notification(int p_what) {
 			p->set_item_icon(p->get_item_index(HELP_SUPPORT_GODOT_DEVELOPMENT), gui_base->get_theme_icon(SNAME("Heart"), SNAME("EditorIcons")));
 
 			for (int i = 0; i < main_editor_buttons.size(); i++) {
-				main_editor_buttons.write[i]->add_theme_font_override(SNAME("font"), gui_base->get_theme_font(SNAME("main_button_font"), SNAME("EditorFonts")));
-				main_editor_buttons.write[i]->add_theme_font_size_override(SNAME("font_size"), gui_base->get_theme_font_size(SNAME("main_button_font_size"), SNAME("EditorFonts")));
+				main_editor_buttons.write[i]->add_theme_font_override("font", gui_base->get_theme_font(SNAME("main_button_font"), SNAME("EditorFonts")));
+				main_editor_buttons.write[i]->add_theme_font_size_override("font_size", gui_base->get_theme_font_size(SNAME("main_button_font_size"), SNAME("EditorFonts")));
 			}
 
 			Set<String> updated_textfile_extensions;
@@ -3184,8 +3184,8 @@ void EditorNode::add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed
 			tb->set_icon(singleton->gui_base->get_theme_icon(p_editor->get_name(), SNAME("EditorIcons")));
 		}
 
-		tb->add_theme_font_override(SNAME("font"), singleton->gui_base->get_theme_font(SNAME("main_button_font"), SNAME("EditorFonts")));
-		tb->add_theme_font_size_override(SNAME("font_size"), singleton->gui_base->get_theme_font_size(SNAME("main_button_font_size"), SNAME("EditorFonts")));
+		tb->add_theme_font_override("font", singleton->gui_base->get_theme_font(SNAME("main_button_font"), SNAME("EditorFonts")));
+		tb->add_theme_font_size_override("font_size", singleton->gui_base->get_theme_font_size(SNAME("main_button_font_size"), SNAME("EditorFonts")));
 
 		singleton->main_editor_buttons.push_back(tb);
 		singleton->main_editor_button_vb->add_child(tb);
@@ -4252,10 +4252,10 @@ void EditorNode::_dock_make_float() {
 	window->add_child(p);
 	MarginContainer *margin = memnew(MarginContainer);
 	margin->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
-	margin->add_theme_constant_override(SNAME("margin_right"), borders.width);
-	margin->add_theme_constant_override(SNAME("margin_top"), borders.height);
-	margin->add_theme_constant_override(SNAME("margin_left"), borders.width);
-	margin->add_theme_constant_override(SNAME("margin_bottom"), borders.height);
+	margin->add_theme_constant_override("margin_right", borders.width);
+	margin->add_theme_constant_override("margin_top", borders.height);
+	margin->add_theme_constant_override("margin_left", borders.width);
+	margin->add_theme_constant_override("margin_bottom", borders.height);
 	window->add_child(margin);
 	dock->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	margin->add_child(dock);
@@ -5200,9 +5200,9 @@ void EditorNode::_bottom_panel_switch(bool p_enable, int p_idx) {
 			bottom_panel_items[i].control->set_visible(i == p_idx);
 		}
 		if (EditorDebuggerNode::get_singleton() == bottom_panel_items[p_idx].control) { // this is the debug panel which uses tabs, so the top section should be smaller
-			bottom_panel->add_theme_style_override(SNAME("panel"), gui_base->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles")));
+			bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles")));
 		} else {
-			bottom_panel->add_theme_style_override(SNAME("panel"), gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
+			bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
 		}
 		center_split->set_dragger_visibility(SplitContainer::DRAGGER_VISIBLE);
 		center_split->set_collapsed(false);
@@ -5212,7 +5212,7 @@ void EditorNode::_bottom_panel_switch(bool p_enable, int p_idx) {
 		bottom_panel_raise->show();
 
 	} else {
-		bottom_panel->add_theme_style_override(SNAME("panel"), gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
+		bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
 		bottom_panel_items[p_idx].button->set_pressed(false);
 		bottom_panel_items[p_idx].control->set_visible(false);
 		center_split->set_dragger_visibility(SplitContainer::DRAGGER_HIDDEN);
@@ -5603,9 +5603,9 @@ void EditorNode::_bottom_panel_raise_toggled(bool p_pressed) {
 
 void EditorNode::_update_rendering_driver_color() {
 	if (rendering_driver->get_text() == "opengl3") {
-		rendering_driver->add_theme_color_override(SNAME("font_color"), Color::hex(0x5586a4ff));
+		rendering_driver->add_theme_color_override("font_color", Color::hex(0x5586a4ff));
 	} else if (rendering_driver->get_text() == "vulkan") {
-		rendering_driver->add_theme_color_override(SNAME("font_color"), theme_base->get_theme_color(SNAME("vulkan_color"), SNAME("Editor")));
+		rendering_driver->add_theme_color_override("font_color", theme_base->get_theme_color(SNAME("vulkan_color"), SNAME("Editor")));
 	}
 }
 
@@ -6054,7 +6054,7 @@ EditorNode::EditorNode() {
 
 	theme_base->set_theme(theme);
 	gui_base->set_theme(theme);
-	gui_base->add_theme_style_override(SNAME("panel"), gui_base->get_theme_stylebox(SNAME("Background"), SNAME("EditorStyles")));
+	gui_base->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("Background"), SNAME("EditorStyles")));
 
 	resource_preview = memnew(EditorResourcePreview);
 	add_child(resource_preview);
@@ -6069,7 +6069,7 @@ EditorNode::EditorNode() {
 	main_vbox = memnew(VBoxContainer);
 	gui_base->add_child(main_vbox);
 	main_vbox->set_anchors_and_offsets_preset(Control::PRESET_WIDE, Control::PRESET_MODE_MINSIZE, 8);
-	main_vbox->add_theme_constant_override(SNAME("separation"), 8 * EDSCALE);
+	main_vbox->add_theme_constant_override("separation", 8 * EDSCALE);
 
 	menu_hb = memnew(HBoxContainer);
 	main_vbox->add_child(menu_hb);
@@ -6220,7 +6220,7 @@ EditorNode::EditorNode() {
 	VBoxContainer *srt = memnew(VBoxContainer);
 	srt->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	top_split->add_child(srt);
-	srt->add_theme_constant_override(SNAME("separation"), 0);
+	srt->add_theme_constant_override("separation", 0);
 
 	tab_preview_panel = memnew(Panel);
 	tab_preview_panel->set_size(Size2(100, 100) * EDSCALE);
@@ -6238,8 +6238,8 @@ EditorNode::EditorNode() {
 	srt->add_child(tabbar_container);
 
 	scene_tabs = memnew(TabBar);
-	scene_tabs->add_theme_style_override(SNAME("tab_selected"), gui_base->get_theme_stylebox(SNAME("SceneTabFG"), SNAME("EditorStyles")));
-	scene_tabs->add_theme_style_override(SNAME("tab_unselected"), gui_base->get_theme_stylebox(SNAME("SceneTabBG"), SNAME("EditorStyles")));
+	scene_tabs->add_theme_style_override("tab_selected", gui_base->get_theme_stylebox(SNAME("SceneTabFG"), SNAME("EditorStyles")));
+	scene_tabs->add_theme_style_override("tab_unselected", gui_base->get_theme_stylebox(SNAME("SceneTabBG"), SNAME("EditorStyles")));
 	scene_tabs->set_select_with_rmb(true);
 	scene_tabs->add_tab("unsaved");
 	scene_tabs->set_tab_alignment(TabBar::ALIGNMENT_LEFT);
@@ -6265,7 +6265,7 @@ EditorNode::EditorNode() {
 	scene_tab_add->set_flat(true);
 	scene_tab_add->set_tooltip(TTR("Add a new scene."));
 	scene_tab_add->set_icon(gui_base->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
-	scene_tab_add->add_theme_color_override(SNAME("icon_normal_color"), Color(0.6f, 0.6f, 0.6f, 0.8f));
+	scene_tab_add->add_theme_color_override("icon_normal_color", Color(0.6f, 0.6f, 0.6f, 0.8f));
 	scene_tabs->add_child(scene_tab_add);
 	scene_tab_add->connect("pressed", callable_mp(this, &EditorNode::_menu_option), make_binds(FILE_NEW_SCENE));
 
@@ -6287,7 +6287,7 @@ EditorNode::EditorNode() {
 
 	scene_root_parent = memnew(PanelContainer);
 	scene_root_parent->set_custom_minimum_size(Size2(0, 80) * EDSCALE);
-	scene_root_parent->add_theme_style_override(SNAME("panel"), gui_base->get_theme_stylebox(SNAME("Content"), SNAME("EditorStyles")));
+	scene_root_parent->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("Content"), SNAME("EditorStyles")));
 	scene_root_parent->set_draw_behind_parent(true);
 	srt->add_child(scene_root_parent);
 	scene_root_parent->set_v_size_flags(Control::SIZE_EXPAND_FILL);
@@ -6301,7 +6301,7 @@ EditorNode::EditorNode() {
 
 	main_control = memnew(VBoxContainer);
 	main_control->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	main_control->add_theme_constant_override(SNAME("separation"), 0);
+	main_control->add_theme_constant_override("separation", 0);
 	scene_root_parent->add_child(main_control);
 
 	HBoxContainer *left_menu_hb = memnew(HBoxContainer);
@@ -6311,7 +6311,7 @@ EditorNode::EditorNode() {
 	file_menu->set_flat(false);
 	file_menu->set_switch_on_hover(true);
 	file_menu->set_text(TTR("Scene"));
-	file_menu->add_theme_style_override(SNAME("hover"), gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+	file_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
 	left_menu_hb->add_child(file_menu);
 
 	prev_scene = memnew(Button);
@@ -6427,7 +6427,7 @@ EditorNode::EditorNode() {
 	project_menu->set_switch_on_hover(true);
 	project_menu->set_tooltip(TTR("Miscellaneous project or scene-wide tools."));
 	project_menu->set_text(TTR("Project"));
-	project_menu->add_theme_style_override(SNAME("hover"), gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+	project_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
 	left_menu_hb->add_child(project_menu);
 
 	p = project_menu->get_popup();
@@ -6477,7 +6477,7 @@ EditorNode::EditorNode() {
 	debug_menu->set_flat(false);
 	debug_menu->set_switch_on_hover(true);
 	debug_menu->set_text(TTR("Debug"));
-	debug_menu->add_theme_style_override(SNAME("hover"), gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+	debug_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
 	left_menu_hb->add_child(debug_menu);
 
 	menu_hb->add_spacer();
@@ -6486,7 +6486,7 @@ EditorNode::EditorNode() {
 	settings_menu->set_flat(false);
 	settings_menu->set_switch_on_hover(true);
 	settings_menu->set_text(TTR("Editor"));
-	settings_menu->add_theme_style_override(SNAME("hover"), gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+	settings_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
 	left_menu_hb->add_child(settings_menu);
 
 	p = settings_menu->get_popup();
@@ -6534,7 +6534,7 @@ EditorNode::EditorNode() {
 	help_menu->set_flat(false);
 	help_menu->set_switch_on_hover(true);
 	help_menu->set_text(TTR("Help"));
-	help_menu->add_theme_style_override(SNAME("hover"), gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
+	help_menu->add_theme_style_override("hover", gui_base->get_theme_stylebox(SNAME("MenuHover"), SNAME("EditorStyles")));
 	left_menu_hb->add_child(help_menu);
 
 	p = help_menu->get_popup();
@@ -6638,8 +6638,8 @@ EditorNode::EditorNode() {
 	rendering_driver->set_flat(true);
 	rendering_driver->set_focus_mode(Control::FOCUS_NONE);
 	rendering_driver->connect("item_selected", callable_mp(this, &EditorNode::_rendering_driver_selected));
-	rendering_driver->add_theme_font_override(SNAME("font"), gui_base->get_theme_font(SNAME("bold"), SNAME("EditorFonts")));
-	rendering_driver->add_theme_font_size_override(SNAME("font_size"), gui_base->get_theme_font_size(SNAME("bold_size"), SNAME("EditorFonts")));
+	rendering_driver->add_theme_font_override("font", gui_base->get_theme_font(SNAME("bold"), SNAME("EditorFonts")));
+	rendering_driver->add_theme_font_size_override("font_size", gui_base->get_theme_font_size(SNAME("bold_size"), SNAME("EditorFonts")));
 
 	right_menu_hb->add_child(rendering_driver);
 
@@ -6762,7 +6762,7 @@ EditorNode::EditorNode() {
 	// Bottom panels
 
 	bottom_panel = memnew(PanelContainer);
-	bottom_panel->add_theme_style_override(SNAME("panel"), gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
+	bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
 	center_split->add_child(bottom_panel);
 	center_split->set_dragger_visibility(SplitContainer::DRAGGER_HIDDEN);
 

--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -181,7 +181,7 @@ void EditorPath::_notification(int p_what) {
 			update_path();
 
 			sub_objects_icon->set_texture(get_theme_icon(SNAME("select_arrow"), SNAME("Tree")));
-			current_object_label->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("main"), SNAME("EditorFonts")));
+			current_object_label->add_theme_font_override("font", get_theme_font(SNAME("main"), SNAME("EditorFonts")));
 		} break;
 
 		case NOTIFICATION_READY: {
@@ -198,8 +198,8 @@ EditorPath::EditorPath(EditorHistory *p_history) {
 
 	MarginContainer *main_mc = memnew(MarginContainer);
 	main_mc->set_anchors_and_offsets_preset(PRESET_WIDE);
-	main_mc->add_theme_constant_override(SNAME("margin_left"), 4 * EDSCALE);
-	main_mc->add_theme_constant_override(SNAME("margin_right"), 6 * EDSCALE);
+	main_mc->add_theme_constant_override("margin_left", 4 * EDSCALE);
+	main_mc->add_theme_constant_override("margin_right", 6 * EDSCALE);
 	add_child(main_mc);
 
 	HBoxContainer *main_hb = memnew(HBoxContainer);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3087,18 +3087,18 @@ void EditorPropertyResource::_update_property_bg() {
 		}
 		count_subinspectors = MIN(15, count_subinspectors);
 
-		add_theme_color_override(SNAME("property_color"), get_theme_color(SNAME("sub_inspector_property_color"), SNAME("Editor")));
-		add_theme_style_override(SNAME("bg_selected"), get_theme_stylebox("sub_inspector_property_bg_selected" + itos(count_subinspectors), SNAME("Editor")));
-		add_theme_style_override(SNAME("bg"), get_theme_stylebox("sub_inspector_property_bg" + itos(count_subinspectors), SNAME("Editor")));
+		add_theme_color_override("property_color", get_theme_color(SNAME("sub_inspector_property_color"), SNAME("Editor")));
+		add_theme_style_override("bg_selected", get_theme_stylebox("sub_inspector_property_bg_selected" + itos(count_subinspectors), SNAME("Editor")));
+		add_theme_style_override("bg", get_theme_stylebox("sub_inspector_property_bg" + itos(count_subinspectors), SNAME("Editor")));
 
-		add_theme_constant_override(SNAME("font_offset"), get_theme_constant(SNAME("sub_inspector_font_offset"), SNAME("Editor")));
-		add_theme_constant_override(SNAME("vseparation"), 0);
+		add_theme_constant_override("font_offset", get_theme_constant(SNAME("sub_inspector_font_offset"), SNAME("Editor")));
+		add_theme_constant_override("vseparation", 0);
 	} else {
-		add_theme_color_override(SNAME("property_color"), get_theme_color(SNAME("property_color"), SNAME("EditorProperty")));
-		add_theme_style_override(SNAME("bg_selected"), get_theme_stylebox(SNAME("bg_selected"), SNAME("EditorProperty")));
-		add_theme_style_override(SNAME("bg"), get_theme_stylebox(SNAME("bg"), SNAME("EditorProperty")));
-		add_theme_constant_override(SNAME("vseparation"), get_theme_constant(SNAME("vseparation"), SNAME("EditorProperty")));
-		add_theme_constant_override(SNAME("font_offset"), get_theme_constant(SNAME("font_offset"), SNAME("EditorProperty")));
+		add_theme_color_override("property_color", get_theme_color(SNAME("property_color"), SNAME("EditorProperty")));
+		add_theme_style_override("bg_selected", get_theme_stylebox(SNAME("bg_selected"), SNAME("EditorProperty")));
+		add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("EditorProperty")));
+		add_theme_constant_override("vseparation", get_theme_constant(SNAME("vseparation"), SNAME("EditorProperty")));
+		add_theme_constant_override("font_offset", get_theme_constant(SNAME("font_offset"), SNAME("EditorProperty")));
 	}
 
 	updating_theme = false;

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -1082,7 +1082,7 @@ void EditorPropertyDictionary::update_property() {
 				}
 				flat->set_bg_color(get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
 
-				pc->add_theme_style_override(SNAME("panel"), flat);
+				pc->add_theme_style_override("panel", flat);
 				add_vbox = memnew(VBoxContainer);
 				pc->add_child(add_vbox);
 			}

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -302,7 +302,7 @@ SectionedInspector::SectionedInspector() :
 		sections(memnew(Tree)),
 		filter(memnew(SectionedInspectorFilter)),
 		inspector(memnew(EditorInspector)) {
-	add_theme_constant_override(SNAME("autohide"), 1); // Fixes the dragger always showing up
+	add_theme_constant_override("autohide", 1); // Fixes the dragger always showing up
 
 	VBoxContainer *left_vb = memnew(VBoxContainer);
 	left_vb->set_custom_minimum_size(Size2(190, 0) * EDSCALE);

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -182,9 +182,9 @@ void EditorSettingsDialog::_update_icons() {
 	shortcut_search_box->set_clear_button_enabled(true);
 
 	restart_close_button->set_icon(shortcuts->get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
-	restart_container->add_theme_style_override(SNAME("panel"), shortcuts->get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+	restart_container->add_theme_style_override("panel", shortcuts->get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 	restart_icon->set_texture(shortcuts->get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
-	restart_label->add_theme_color_override(SNAME("font_color"), shortcuts->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+	restart_label->add_theme_color_override("font_color", shortcuts->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 }
 
 void EditorSettingsDialog::_event_config_confirmed() {
@@ -272,15 +272,15 @@ void EditorSettingsDialog::_create_shortcut_treeitem(TreeItem *p_parent, const S
 	shortcut_item->set_text(1, sc_text);
 	if (sc_text == "None") {
 		// Fade out unassigned shortcut labels for easier visual grepping.
-		shortcut_item->set_custom_color(1, shortcuts->get_theme_color(SNAME("font_color"), SNAME("Label")) * Color(1, 1, 1, 0.5));
+		shortcut_item->set_custom_color(1, shortcuts->get_theme_color("font_color", "Label") * Color(1, 1, 1, 0.5));
 	}
 
 	if (p_allow_revert) {
-		shortcut_item->add_button(1, shortcuts->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")), SHORTCUT_REVERT);
+		shortcut_item->add_button(1, shortcuts->get_theme_icon("Reload", "EditorIcons"), SHORTCUT_REVERT);
 	}
 
-	shortcut_item->add_button(1, shortcuts->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), SHORTCUT_ADD);
-	shortcut_item->add_button(1, shortcuts->get_theme_icon(SNAME("Close"), SNAME("EditorIcons")), SHORTCUT_ERASE);
+	shortcut_item->add_button(1, shortcuts->get_theme_icon("Add", "EditorIcons"), SHORTCUT_ADD);
+	shortcut_item->add_button(1, shortcuts->get_theme_icon("Close", "EditorIcons"), SHORTCUT_ERASE);
 
 	shortcut_item->set_meta("is_action", p_is_action);
 	shortcut_item->set_meta("type", "shortcut");
@@ -299,11 +299,11 @@ void EditorSettingsDialog::_create_shortcut_treeitem(TreeItem *p_parent, const S
 		event_item->set_text(0, shortcut_item->get_child_count() == 1 ? "Primary" : "");
 		event_item->set_text(1, ie->as_text());
 
-		event_item->add_button(1, shortcuts->get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), SHORTCUT_EDIT);
-		event_item->add_button(1, shortcuts->get_theme_icon(SNAME("Close"), SNAME("EditorIcons")), SHORTCUT_ERASE);
+		event_item->add_button(1, shortcuts->get_theme_icon("Edit", "EditorIcons"), SHORTCUT_EDIT);
+		event_item->add_button(1, shortcuts->get_theme_icon("Close", "EditorIcons"), SHORTCUT_ERASE);
 
-		event_item->set_custom_bg_color(0, shortcuts->get_theme_color(SNAME("dark_color_3"), SNAME("Editor")));
-		event_item->set_custom_bg_color(1, shortcuts->get_theme_color(SNAME("dark_color_3"), SNAME("Editor")));
+		event_item->set_custom_bg_color(0, shortcuts->get_theme_color("dark_color_3", "Editor"));
+		event_item->set_custom_bg_color(1, shortcuts->get_theme_color("dark_color_3", "Editor"));
 
 		event_item->set_meta("is_action", p_is_action);
 		event_item->set_meta("type", "event");

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -272,15 +272,15 @@ void EditorSettingsDialog::_create_shortcut_treeitem(TreeItem *p_parent, const S
 	shortcut_item->set_text(1, sc_text);
 	if (sc_text == "None") {
 		// Fade out unassigned shortcut labels for easier visual grepping.
-		shortcut_item->set_custom_color(1, shortcuts->get_theme_color("font_color", "Label") * Color(1, 1, 1, 0.5));
+		shortcut_item->set_custom_color(1, shortcuts->get_theme_color(SNAME("font_color"), SNAME("Label")) * Color(1, 1, 1, 0.5));
 	}
 
 	if (p_allow_revert) {
-		shortcut_item->add_button(1, shortcuts->get_theme_icon("Reload", "EditorIcons"), SHORTCUT_REVERT);
+		shortcut_item->add_button(1, shortcuts->get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")), SHORTCUT_REVERT);
 	}
 
-	shortcut_item->add_button(1, shortcuts->get_theme_icon("Add", "EditorIcons"), SHORTCUT_ADD);
-	shortcut_item->add_button(1, shortcuts->get_theme_icon("Close", "EditorIcons"), SHORTCUT_ERASE);
+	shortcut_item->add_button(1, shortcuts->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")), SHORTCUT_ADD);
+	shortcut_item->add_button(1, shortcuts->get_theme_icon(SNAME("Close"), SNAME("EditorIcons")), SHORTCUT_ERASE);
 
 	shortcut_item->set_meta("is_action", p_is_action);
 	shortcut_item->set_meta("type", "shortcut");
@@ -299,11 +299,11 @@ void EditorSettingsDialog::_create_shortcut_treeitem(TreeItem *p_parent, const S
 		event_item->set_text(0, shortcut_item->get_child_count() == 1 ? "Primary" : "");
 		event_item->set_text(1, ie->as_text());
 
-		event_item->add_button(1, shortcuts->get_theme_icon("Edit", "EditorIcons"), SHORTCUT_EDIT);
-		event_item->add_button(1, shortcuts->get_theme_icon("Close", "EditorIcons"), SHORTCUT_ERASE);
+		event_item->add_button(1, shortcuts->get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")), SHORTCUT_EDIT);
+		event_item->add_button(1, shortcuts->get_theme_icon(SNAME("Close"), SNAME("EditorIcons")), SHORTCUT_ERASE);
 
-		event_item->set_custom_bg_color(0, shortcuts->get_theme_color("dark_color_3", "Editor"));
-		event_item->set_custom_bg_color(1, shortcuts->get_theme_color("dark_color_3", "Editor"));
+		event_item->set_custom_bg_color(0, shortcuts->get_theme_color(SNAME("dark_color_3"), SNAME("Editor")));
+		event_item->set_custom_bg_color(1, shortcuts->get_theme_color(SNAME("dark_color_3"), SNAME("Editor")));
 
 		event_item->set_meta("is_action", p_is_action);
 		event_item->set_meta("type", "event");

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -268,7 +268,7 @@ void EditorSpinSlider::_update_value_input_stylebox() {
 		stylebox->set_default_margin(SIDE_RIGHT, 0);
 	}
 
-	value_input->add_theme_style_override(SNAME("normal"), stylebox);
+	value_input->add_theme_style_override("normal", stylebox);
 }
 
 void EditorSpinSlider::_draw_spin_slider() {

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -446,28 +446,28 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	float prev_icon_saturation = theme->has_color(SNAME("icon_saturation"), SNAME("Editor")) ? theme->get_color(SNAME("icon_saturation"), SNAME("Editor")).r : 1.0;
 
-	theme->set_color(SNAME("icon_saturation"), SNAME("Editor"), Color(icon_saturation, icon_saturation, icon_saturation)); // can't save single float in theme, so using color
-	theme->set_color(SNAME("accent_color"), SNAME("Editor"), accent_color);
-	theme->set_color(SNAME("highlight_color"), SNAME("Editor"), highlight_color);
-	theme->set_color(SNAME("disabled_highlight_color"), SNAME("Editor"), disabled_highlight_color);
-	theme->set_color(SNAME("base_color"), SNAME("Editor"), base_color);
-	theme->set_color(SNAME("dark_color_1"), SNAME("Editor"), dark_color_1);
-	theme->set_color(SNAME("dark_color_2"), SNAME("Editor"), dark_color_2);
-	theme->set_color(SNAME("dark_color_3"), SNAME("Editor"), dark_color_3);
-	theme->set_color(SNAME("contrast_color_1"), SNAME("Editor"), contrast_color_1);
-	theme->set_color(SNAME("contrast_color_2"), SNAME("Editor"), contrast_color_2);
-	theme->set_color(SNAME("box_selection_fill_color"), SNAME("Editor"), accent_color * Color(1, 1, 1, 0.3));
-	theme->set_color(SNAME("box_selection_stroke_color"), SNAME("Editor"), accent_color * Color(1, 1, 1, 0.8));
+	theme->set_color("icon_saturation", "Editor", Color(icon_saturation, icon_saturation, icon_saturation)); // can't save single float in theme, so using color
+	theme->set_color("accent_color", "Editor", accent_color);
+	theme->set_color("highlight_color", "Editor", highlight_color);
+	theme->set_color("disabled_highlight_color", "Editor", disabled_highlight_color);
+	theme->set_color("base_color", "Editor", base_color);
+	theme->set_color("dark_color_1", "Editor", dark_color_1);
+	theme->set_color("dark_color_2", "Editor", dark_color_2);
+	theme->set_color("dark_color_3", "Editor", dark_color_3);
+	theme->set_color("contrast_color_1", "Editor", contrast_color_1);
+	theme->set_color("contrast_color_2", "Editor", contrast_color_2);
+	theme->set_color("box_selection_fill_color", "Editor", accent_color * Color(1, 1, 1, 0.3));
+	theme->set_color("box_selection_stroke_color", "Editor", accent_color * Color(1, 1, 1, 0.8));
 
-	theme->set_color(SNAME("axis_x_color"), SNAME("Editor"), Color(0.96, 0.20, 0.32));
-	theme->set_color(SNAME("axis_y_color"), SNAME("Editor"), Color(0.53, 0.84, 0.01));
-	theme->set_color(SNAME("axis_z_color"), SNAME("Editor"), Color(0.16, 0.55, 0.96));
+	theme->set_color("axis_x_color", "Editor", Color(0.96, 0.20, 0.32));
+	theme->set_color("axis_y_color", "Editor", Color(0.53, 0.84, 0.01));
+	theme->set_color("axis_z_color", "Editor", Color(0.16, 0.55, 0.96));
 
-	theme->set_color(SNAME("font_color"), SNAME("Editor"), font_color);
-	theme->set_color(SNAME("highlighted_font_color"), SNAME("Editor"), font_hover_color);
-	theme->set_color(SNAME("disabled_font_color"), SNAME("Editor"), font_disabled_color);
+	theme->set_color("font_color", "Editor", font_color);
+	theme->set_color("highlighted_font_color", "Editor", font_hover_color);
+	theme->set_color("disabled_font_color", "Editor", font_disabled_color);
 
-	theme->set_color(SNAME("mono_color"), SNAME("Editor"), mono_color);
+	theme->set_color("mono_color", "Editor", mono_color);
 
 	Color success_color = Color(0.45, 0.95, 0.5);
 	Color warning_color = Color(1, 0.87, 0.4);
@@ -483,21 +483,21 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		error_color = error_color.lerp(mono_color, 0.25);
 	}
 
-	theme->set_color(SNAME("success_color"), SNAME("Editor"), success_color);
-	theme->set_color(SNAME("warning_color"), SNAME("Editor"), warning_color);
-	theme->set_color(SNAME("error_color"), SNAME("Editor"), error_color);
-	theme->set_color(SNAME("property_color"), SNAME("Editor"), property_color);
-	theme->set_color(SNAME("readonly_color"), SNAME("Editor"), readonly_color);
+	theme->set_color("success_color", "Editor", success_color);
+	theme->set_color("warning_color", "Editor", warning_color);
+	theme->set_color("error_color", "Editor", error_color);
+	theme->set_color("property_color", "Editor", property_color);
+	theme->set_color("readonly_color", "Editor", readonly_color);
 
 	if (!dark_theme) {
-		theme->set_color(SNAME("vulkan_color"), SNAME("Editor"), Color::hex(0xad1128ff));
+		theme->set_color("vulkan_color", "Editor", Color::hex(0xad1128ff));
 	} else {
-		theme->set_color(SNAME("vulkan_color"), SNAME("Editor"), Color(1.0, 0.0, 0.0));
+		theme->set_color("vulkan_color", "Editor", Color(1.0, 0.0, 0.0));
 	}
 	const int thumb_size = EDITOR_GET("filesystem/file_dialog/thumbnail_size");
-	theme->set_constant(SNAME("scale"), SNAME("Editor"), EDSCALE);
-	theme->set_constant(SNAME("thumb_size"), SNAME("Editor"), thumb_size);
-	theme->set_constant(SNAME("dark_theme"), SNAME("Editor"), dark_theme);
+	theme->set_constant("scale", "Editor", EDSCALE);
+	theme->set_constant("thumb_size", "Editor", thumb_size);
+	theme->set_constant("dark_theme", "Editor", dark_theme);
 
 	// Register icons + font
 
@@ -632,113 +632,113 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Editor background
 	Color background_color_opaque = background_color;
 	background_color_opaque.a = 1.0;
-	theme->set_stylebox(SNAME("Background"), SNAME("EditorStyles"), make_flat_stylebox(background_color_opaque, default_margin_size, default_margin_size, default_margin_size, default_margin_size));
+	theme->set_stylebox("Background", "EditorStyles", make_flat_stylebox(background_color_opaque, default_margin_size, default_margin_size, default_margin_size, default_margin_size));
 
 	// Focus
-	theme->set_stylebox(SNAME("Focus"), SNAME("EditorStyles"), style_widget_focus);
+	theme->set_stylebox("Focus", "EditorStyles", style_widget_focus);
 	// Use a less opaque color to be less distracting for the 2D and 3D editor viewports.
 	Ref<StyleBoxFlat> style_widget_focus_viewport = style_widget_focus->duplicate();
 	style_widget_focus_viewport->set_border_color(accent_color * Color(1, 1, 1, 0.5));
-	theme->set_stylebox(SNAME("FocusViewport"), SNAME("EditorStyles"), style_widget_focus_viewport);
+	theme->set_stylebox("FocusViewport", "EditorStyles", style_widget_focus_viewport);
 
 	// Menu
 	Ref<StyleBoxFlat> style_menu = style_widget->duplicate();
 	style_menu->set_draw_center(false);
 	style_menu->set_border_width_all(0);
-	theme->set_stylebox(SNAME("panel"), SNAME("PanelContainer"), style_menu);
-	theme->set_stylebox(SNAME("MenuPanel"), SNAME("EditorStyles"), style_menu);
+	theme->set_stylebox("panel", "PanelContainer", style_menu);
+	theme->set_stylebox("MenuPanel", "EditorStyles", style_menu);
 
 	// CanvasItem Editor
 	Ref<StyleBoxFlat> style_canvas_editor_info = make_flat_stylebox(Color(0.0, 0.0, 0.0, 0.2));
 	style_canvas_editor_info->set_expand_margin_size_all(4 * EDSCALE);
-	theme->set_stylebox(SNAME("CanvasItemInfoOverlay"), SNAME("EditorStyles"), style_canvas_editor_info);
+	theme->set_stylebox("CanvasItemInfoOverlay", "EditorStyles", style_canvas_editor_info);
 
 	// Script Editor
-	theme->set_stylebox(SNAME("ScriptEditorPanel"), SNAME("EditorStyles"), make_empty_stylebox(default_margin_size, 0, default_margin_size, default_margin_size));
-	theme->set_stylebox(SNAME("ScriptEditor"), SNAME("EditorStyles"), make_empty_stylebox(0, 0, 0, 0));
+	theme->set_stylebox("ScriptEditorPanel", "EditorStyles", make_empty_stylebox(default_margin_size, 0, default_margin_size, default_margin_size));
+	theme->set_stylebox("ScriptEditor", "EditorStyles", make_empty_stylebox(0, 0, 0, 0));
 
 	// Play button group
-	theme->set_stylebox(SNAME("PlayButtonPanel"), SNAME("EditorStyles"), style_empty);
+	theme->set_stylebox("PlayButtonPanel", "EditorStyles", style_empty);
 
-	theme->set_stylebox(SNAME("normal"), SNAME("MenuButton"), style_menu);
-	theme->set_stylebox(SNAME("hover"), SNAME("MenuButton"), style_widget_hover);
-	theme->set_stylebox(SNAME("pressed"), SNAME("MenuButton"), style_menu);
-	theme->set_stylebox(SNAME("focus"), SNAME("MenuButton"), style_menu);
-	theme->set_stylebox(SNAME("disabled"), SNAME("MenuButton"), style_menu);
+	theme->set_stylebox("normal", "MenuButton", style_menu);
+	theme->set_stylebox("hover", "MenuButton", style_widget_hover);
+	theme->set_stylebox("pressed", "MenuButton", style_menu);
+	theme->set_stylebox("focus", "MenuButton", style_menu);
+	theme->set_stylebox("disabled", "MenuButton", style_menu);
 
-	theme->set_color(SNAME("font_color"), SNAME("MenuButton"), font_color);
-	theme->set_color(SNAME("font_hover_color"), SNAME("MenuButton"), font_hover_color);
-	theme->set_color(SNAME("font_focus_color"), SNAME("MenuButton"), font_focus_color);
+	theme->set_color("font_color", "MenuButton", font_color);
+	theme->set_color("font_hover_color", "MenuButton", font_hover_color);
+	theme->set_color("font_focus_color", "MenuButton", font_focus_color);
 
-	theme->set_stylebox(SNAME("MenuHover"), SNAME("EditorStyles"), style_widget_hover);
+	theme->set_stylebox("MenuHover", "EditorStyles", style_widget_hover);
 
 	// Buttons
-	theme->set_stylebox(SNAME("normal"), SNAME("Button"), style_widget);
-	theme->set_stylebox(SNAME("hover"), SNAME("Button"), style_widget_hover);
-	theme->set_stylebox(SNAME("pressed"), SNAME("Button"), style_widget_pressed);
-	theme->set_stylebox(SNAME("focus"), SNAME("Button"), style_widget_focus);
-	theme->set_stylebox(SNAME("disabled"), SNAME("Button"), style_widget_disabled);
+	theme->set_stylebox("normal", "Button", style_widget);
+	theme->set_stylebox("hover", "Button", style_widget_hover);
+	theme->set_stylebox("pressed", "Button", style_widget_pressed);
+	theme->set_stylebox("focus", "Button", style_widget_focus);
+	theme->set_stylebox("disabled", "Button", style_widget_disabled);
 
-	theme->set_color(SNAME("font_color"), SNAME("Button"), font_color);
-	theme->set_color(SNAME("font_hover_color"), SNAME("Button"), font_hover_color);
-	theme->set_color(SNAME("font_focus_color"), SNAME("Button"), font_focus_color);
-	theme->set_color(SNAME("font_pressed_color"), SNAME("Button"), accent_color);
-	theme->set_color(SNAME("font_disabled_color"), SNAME("Button"), font_disabled_color);
-	theme->set_color(SNAME("icon_hover_color"), SNAME("Button"), icon_hover_color);
-	theme->set_color(SNAME("icon_focus_color"), SNAME("Button"), icon_focus_color);
-	theme->set_color(SNAME("icon_pressed_color"), SNAME("Button"), icon_pressed_color);
+	theme->set_color("font_color", "Button", font_color);
+	theme->set_color("font_hover_color", "Button", font_hover_color);
+	theme->set_color("font_focus_color", "Button", font_focus_color);
+	theme->set_color("font_pressed_color", "Button", accent_color);
+	theme->set_color("font_disabled_color", "Button", font_disabled_color);
+	theme->set_color("icon_hover_color", "Button", icon_hover_color);
+	theme->set_color("icon_focus_color", "Button", icon_focus_color);
+	theme->set_color("icon_pressed_color", "Button", icon_pressed_color);
 
 	// OptionButton
-	theme->set_stylebox(SNAME("focus"), SNAME("OptionButton"), style_widget_focus);
+	theme->set_stylebox("focus", "OptionButton", style_widget_focus);
 
-	theme->set_stylebox(SNAME("normal"), SNAME("OptionButton"), style_widget);
-	theme->set_stylebox(SNAME("hover"), SNAME("OptionButton"), style_widget_hover);
-	theme->set_stylebox(SNAME("pressed"), SNAME("OptionButton"), style_widget_pressed);
-	theme->set_stylebox(SNAME("disabled"), SNAME("OptionButton"), style_widget_disabled);
+	theme->set_stylebox("normal", "OptionButton", style_widget);
+	theme->set_stylebox("hover", "OptionButton", style_widget_hover);
+	theme->set_stylebox("pressed", "OptionButton", style_widget_pressed);
+	theme->set_stylebox("disabled", "OptionButton", style_widget_disabled);
 
-	theme->set_stylebox(SNAME("normal_mirrored"), SNAME("OptionButton"), style_widget);
-	theme->set_stylebox(SNAME("hover_mirrored"), SNAME("OptionButton"), style_widget_hover);
-	theme->set_stylebox(SNAME("pressed_mirrored"), SNAME("OptionButton"), style_widget_pressed);
-	theme->set_stylebox(SNAME("disabled_mirrored"), SNAME("OptionButton"), style_widget_disabled);
+	theme->set_stylebox("normal_mirrored", "OptionButton", style_widget);
+	theme->set_stylebox("hover_mirrored", "OptionButton", style_widget_hover);
+	theme->set_stylebox("pressed_mirrored", "OptionButton", style_widget_pressed);
+	theme->set_stylebox("disabled_mirrored", "OptionButton", style_widget_disabled);
 
-	theme->set_color(SNAME("font_color"), SNAME("OptionButton"), font_color);
-	theme->set_color(SNAME("font_hover_color"), SNAME("OptionButton"), font_hover_color);
-	theme->set_color(SNAME("font_focus_color"), SNAME("OptionButton"), font_focus_color);
-	theme->set_color(SNAME("font_pressed_color"), SNAME("OptionButton"), accent_color);
-	theme->set_color(SNAME("font_disabled_color"), SNAME("OptionButton"), font_disabled_color);
-	theme->set_color(SNAME("icon_hover_color"), SNAME("OptionButton"), icon_hover_color);
-	theme->set_color(SNAME("icon_focus_color"), SNAME("OptionButton"), icon_focus_color);
-	theme->set_icon(SNAME("arrow"), SNAME("OptionButton"), theme->get_icon(SNAME("GuiOptionArrow"), SNAME("EditorIcons")));
-	theme->set_constant(SNAME("arrow_margin"), SNAME("OptionButton"), widget_default_margin.x - 2 * EDSCALE);
-	theme->set_constant(SNAME("modulate_arrow"), SNAME("OptionButton"), true);
-	theme->set_constant(SNAME("hseparation"), SNAME("OptionButton"), 4 * EDSCALE);
+	theme->set_color("font_color", "OptionButton", font_color);
+	theme->set_color("font_hover_color", "OptionButton", font_hover_color);
+	theme->set_color("font_focus_color", "OptionButton", font_focus_color);
+	theme->set_color("font_pressed_color", "OptionButton", accent_color);
+	theme->set_color("font_disabled_color", "OptionButton", font_disabled_color);
+	theme->set_color("icon_hover_color", "OptionButton", icon_hover_color);
+	theme->set_color("icon_focus_color", "OptionButton", icon_focus_color);
+	theme->set_icon("arrow", "OptionButton", theme->get_icon(SNAME("GuiOptionArrow"), SNAME("EditorIcons")));
+	theme->set_constant("arrow_margin", "OptionButton", widget_default_margin.x - 2 * EDSCALE);
+	theme->set_constant("modulate_arrow", "OptionButton", true);
+	theme->set_constant("hseparation", "OptionButton", 4 * EDSCALE);
 
 	// CheckButton
-	theme->set_stylebox(SNAME("normal"), SNAME("CheckButton"), style_menu);
-	theme->set_stylebox(SNAME("pressed"), SNAME("CheckButton"), style_menu);
-	theme->set_stylebox(SNAME("disabled"), SNAME("CheckButton"), style_menu);
-	theme->set_stylebox(SNAME("hover"), SNAME("CheckButton"), style_menu);
+	theme->set_stylebox("normal", "CheckButton", style_menu);
+	theme->set_stylebox("pressed", "CheckButton", style_menu);
+	theme->set_stylebox("disabled", "CheckButton", style_menu);
+	theme->set_stylebox("hover", "CheckButton", style_menu);
 
-	theme->set_icon(SNAME("on"), SNAME("CheckButton"), theme->get_icon(SNAME("GuiToggleOn"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("on_disabled"), SNAME("CheckButton"), theme->get_icon(SNAME("GuiToggleOnDisabled"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("off"), SNAME("CheckButton"), theme->get_icon(SNAME("GuiToggleOff"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("off_disabled"), SNAME("CheckButton"), theme->get_icon(SNAME("GuiToggleOffDisabled"), SNAME("EditorIcons")));
+	theme->set_icon("on", "CheckButton", theme->get_icon(SNAME("GuiToggleOn"), SNAME("EditorIcons")));
+	theme->set_icon("on_disabled", "CheckButton", theme->get_icon(SNAME("GuiToggleOnDisabled"), SNAME("EditorIcons")));
+	theme->set_icon("off", "CheckButton", theme->get_icon(SNAME("GuiToggleOff"), SNAME("EditorIcons")));
+	theme->set_icon("off_disabled", "CheckButton", theme->get_icon(SNAME("GuiToggleOffDisabled"), SNAME("EditorIcons")));
 
-	theme->set_icon(SNAME("on_mirrored"), SNAME("CheckButton"), theme->get_icon(SNAME("GuiToggleOnMirrored"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("on_disabled_mirrored"), SNAME("CheckButton"), theme->get_icon(SNAME("GuiToggleOnDisabledMirrored"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("off_mirrored"), SNAME("CheckButton"), theme->get_icon(SNAME("GuiToggleOffMirrored"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("off_disabled_mirrored"), SNAME("CheckButton"), theme->get_icon(SNAME("GuiToggleOffDisabledMirrored"), SNAME("EditorIcons")));
+	theme->set_icon("on_mirrored", "CheckButton", theme->get_icon(SNAME("GuiToggleOnMirrored"), SNAME("EditorIcons")));
+	theme->set_icon("on_disabled_mirrored", "CheckButton", theme->get_icon(SNAME("GuiToggleOnDisabledMirrored"), SNAME("EditorIcons")));
+	theme->set_icon("off_mirrored", "CheckButton", theme->get_icon(SNAME("GuiToggleOffMirrored"), SNAME("EditorIcons")));
+	theme->set_icon("off_disabled_mirrored", "CheckButton", theme->get_icon(SNAME("GuiToggleOffDisabledMirrored"), SNAME("EditorIcons")));
 
-	theme->set_color(SNAME("font_color"), SNAME("CheckButton"), font_color);
-	theme->set_color(SNAME("font_hover_color"), SNAME("CheckButton"), font_hover_color);
-	theme->set_color(SNAME("font_focus_color"), SNAME("CheckButton"), font_focus_color);
-	theme->set_color(SNAME("font_pressed_color"), SNAME("CheckButton"), accent_color);
-	theme->set_color(SNAME("font_disabled_color"), SNAME("CheckButton"), font_disabled_color);
-	theme->set_color(SNAME("icon_hover_color"), SNAME("CheckButton"), icon_hover_color);
-	theme->set_color(SNAME("icon_focus_color"), SNAME("CheckButton"), icon_focus_color);
+	theme->set_color("font_color", "CheckButton", font_color);
+	theme->set_color("font_hover_color", "CheckButton", font_hover_color);
+	theme->set_color("font_focus_color", "CheckButton", font_focus_color);
+	theme->set_color("font_pressed_color", "CheckButton", accent_color);
+	theme->set_color("font_disabled_color", "CheckButton", font_disabled_color);
+	theme->set_color("icon_hover_color", "CheckButton", icon_hover_color);
+	theme->set_color("icon_focus_color", "CheckButton", icon_focus_color);
 
-	theme->set_constant(SNAME("hseparation"), SNAME("CheckButton"), 8 * EDSCALE);
-	theme->set_constant(SNAME("check_vadjust"), SNAME("CheckButton"), 0 * EDSCALE);
+	theme->set_constant("hseparation", "CheckButton", 8 * EDSCALE);
+	theme->set_constant("check_vadjust", "CheckButton", 0 * EDSCALE);
 
 	// Checkbox
 	Ref<StyleBoxFlat> sb_checkbox = style_menu->duplicate();
@@ -747,32 +747,32 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	sb_checkbox->set_default_margin(SIDE_TOP, default_margin_size * EDSCALE);
 	sb_checkbox->set_default_margin(SIDE_BOTTOM, default_margin_size * EDSCALE);
 
-	theme->set_stylebox(SNAME("normal"), SNAME("CheckBox"), sb_checkbox);
-	theme->set_stylebox(SNAME("pressed"), SNAME("CheckBox"), sb_checkbox);
-	theme->set_stylebox(SNAME("disabled"), SNAME("CheckBox"), sb_checkbox);
-	theme->set_stylebox(SNAME("hover"), SNAME("CheckBox"), sb_checkbox);
-	theme->set_icon(SNAME("checked"), SNAME("CheckBox"), theme->get_icon(SNAME("GuiChecked"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("unchecked"), SNAME("CheckBox"), theme->get_icon(SNAME("GuiUnchecked"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("radio_checked"), SNAME("CheckBox"), theme->get_icon(SNAME("GuiRadioChecked"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("radio_unchecked"), SNAME("CheckBox"), theme->get_icon(SNAME("GuiRadioUnchecked"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("checked_disabled"), SNAME("CheckBox"), theme->get_icon(SNAME("GuiCheckedDisabled"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("unchecked_disabled"), SNAME("CheckBox"), theme->get_icon(SNAME("GuiUncheckedDisabled"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("radio_checked_disabled"), SNAME("CheckBox"), theme->get_icon(SNAME("GuiRadioCheckedDisabled"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("radio_unchecked_disabled"), SNAME("CheckBox"), theme->get_icon(SNAME("GuiRadioUncheckedDisabled"), SNAME("EditorIcons")));
+	theme->set_stylebox("normal", "CheckBox", sb_checkbox);
+	theme->set_stylebox("pressed", "CheckBox", sb_checkbox);
+	theme->set_stylebox("disabled", "CheckBox", sb_checkbox);
+	theme->set_stylebox("hover", "CheckBox", sb_checkbox);
+	theme->set_icon("checked", "CheckBox", theme->get_icon(SNAME("GuiChecked"), SNAME("EditorIcons")));
+	theme->set_icon("unchecked", "CheckBox", theme->get_icon(SNAME("GuiUnchecked"), SNAME("EditorIcons")));
+	theme->set_icon("radio_checked", "CheckBox", theme->get_icon(SNAME("GuiRadioChecked"), SNAME("EditorIcons")));
+	theme->set_icon("radio_unchecked", "CheckBox", theme->get_icon(SNAME("GuiRadioUnchecked"), SNAME("EditorIcons")));
+	theme->set_icon("checked_disabled", "CheckBox", theme->get_icon(SNAME("GuiCheckedDisabled"), SNAME("EditorIcons")));
+	theme->set_icon("unchecked_disabled", "CheckBox", theme->get_icon(SNAME("GuiUncheckedDisabled"), SNAME("EditorIcons")));
+	theme->set_icon("radio_checked_disabled", "CheckBox", theme->get_icon(SNAME("GuiRadioCheckedDisabled"), SNAME("EditorIcons")));
+	theme->set_icon("radio_unchecked_disabled", "CheckBox", theme->get_icon(SNAME("GuiRadioUncheckedDisabled"), SNAME("EditorIcons")));
 
-	theme->set_color(SNAME("font_color"), SNAME("CheckBox"), font_color);
-	theme->set_color(SNAME("font_hover_color"), SNAME("CheckBox"), font_hover_color);
-	theme->set_color(SNAME("font_focus_color"), SNAME("CheckBox"), font_focus_color);
-	theme->set_color(SNAME("font_pressed_color"), SNAME("CheckBox"), accent_color);
-	theme->set_color(SNAME("font_disabled_color"), SNAME("CheckBox"), font_disabled_color);
-	theme->set_color(SNAME("icon_hover_color"), SNAME("CheckBox"), icon_hover_color);
-	theme->set_color(SNAME("icon_focus_color"), SNAME("CheckBox"), icon_focus_color);
+	theme->set_color("font_color", "CheckBox", font_color);
+	theme->set_color("font_hover_color", "CheckBox", font_hover_color);
+	theme->set_color("font_focus_color", "CheckBox", font_focus_color);
+	theme->set_color("font_pressed_color", "CheckBox", accent_color);
+	theme->set_color("font_disabled_color", "CheckBox", font_disabled_color);
+	theme->set_color("icon_hover_color", "CheckBox", icon_hover_color);
+	theme->set_color("icon_focus_color", "CheckBox", icon_focus_color);
 
-	theme->set_constant(SNAME("hseparation"), SNAME("CheckBox"), 8 * EDSCALE);
-	theme->set_constant(SNAME("check_vadjust"), SNAME("CheckBox"), 0 * EDSCALE);
+	theme->set_constant("hseparation", "CheckBox", 8 * EDSCALE);
+	theme->set_constant("check_vadjust", "CheckBox", 0 * EDSCALE);
 
 	// PopupDialog
-	theme->set_stylebox(SNAME("panel"), SNAME("PopupDialog"), style_popup);
+	theme->set_stylebox("panel", "PopupDialog", style_popup);
 
 	// PopupMenu
 	const int popup_menu_margin_size = default_margin_size * 1.5 * EDSCALE;
@@ -787,39 +787,39 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Always display a border for PopupMenus so they can be distinguished from their background.
 	style_popup_menu->set_border_width_all(1 * EDSCALE);
 	style_popup_menu->set_border_color(dark_color_2);
-	theme->set_stylebox(SNAME("panel"), SNAME("PopupMenu"), style_popup_menu);
+	theme->set_stylebox("panel", "PopupMenu", style_popup_menu);
 
 	Ref<StyleBoxFlat> style_menu_hover = style_widget_hover->duplicate();
 	// Don't use rounded corners for hover highlights since the StyleBox touches the PopupMenu's edges.
 	style_menu_hover->set_corner_radius_all(0);
-	theme->set_stylebox(SNAME("hover"), SNAME("PopupMenu"), style_menu_hover);
+	theme->set_stylebox("hover", "PopupMenu", style_menu_hover);
 
-	theme->set_stylebox(SNAME("separator"), SNAME("PopupMenu"), style_popup_separator);
-	theme->set_stylebox(SNAME("labeled_separator_left"), SNAME("PopupMenu"), style_popup_labeled_separator_left);
-	theme->set_stylebox(SNAME("labeled_separator_right"), SNAME("PopupMenu"), style_popup_labeled_separator_right);
+	theme->set_stylebox("separator", "PopupMenu", style_popup_separator);
+	theme->set_stylebox("labeled_separator_left", "PopupMenu", style_popup_labeled_separator_left);
+	theme->set_stylebox("labeled_separator_right", "PopupMenu", style_popup_labeled_separator_right);
 
-	theme->set_color(SNAME("font_color"), SNAME("PopupMenu"), font_color);
-	theme->set_color(SNAME("font_hover_color"), SNAME("PopupMenu"), font_hover_color);
-	theme->set_color(SNAME("font_accelerator_color"), SNAME("PopupMenu"), font_disabled_color);
-	theme->set_color(SNAME("font_disabled_color"), SNAME("PopupMenu"), font_disabled_color);
-	theme->set_color(SNAME("font_separator_color"), SNAME("PopupMenu"), font_disabled_color);
-	theme->set_icon(SNAME("checked"), SNAME("PopupMenu"), theme->get_icon(SNAME("GuiChecked"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("unchecked"), SNAME("PopupMenu"), theme->get_icon(SNAME("GuiUnchecked"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("radio_checked"), SNAME("PopupMenu"), theme->get_icon(SNAME("GuiRadioChecked"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("radio_unchecked"), SNAME("PopupMenu"), theme->get_icon(SNAME("GuiRadioUnchecked"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("checked_disabled"), SNAME("PopupMenu"), theme->get_icon(SNAME("GuiCheckedDisabled"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("unchecked_disabled"), SNAME("PopupMenu"), theme->get_icon(SNAME("GuiUncheckedDisabled"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("radio_checked_disabled"), SNAME("PopupMenu"), theme->get_icon(SNAME("GuiRadioCheckedDisabled"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("radio_unchecked_disabled"), SNAME("PopupMenu"), theme->get_icon(SNAME("GuiRadioUncheckedDisabled"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("submenu"), SNAME("PopupMenu"), theme->get_icon(SNAME("ArrowRight"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("submenu_mirrored"), SNAME("PopupMenu"), theme->get_icon(SNAME("ArrowLeft"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("visibility_hidden"), SNAME("PopupMenu"), theme->get_icon(SNAME("GuiVisibilityHidden"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("visibility_visible"), SNAME("PopupMenu"), theme->get_icon(SNAME("GuiVisibilityVisible"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("visibility_xray"), SNAME("PopupMenu"), theme->get_icon(SNAME("GuiVisibilityXray"), SNAME("EditorIcons")));
+	theme->set_color("font_color", "PopupMenu", font_color);
+	theme->set_color("font_hover_color", "PopupMenu", font_hover_color);
+	theme->set_color("font_accelerator_color", "PopupMenu", font_disabled_color);
+	theme->set_color("font_disabled_color", "PopupMenu", font_disabled_color);
+	theme->set_color("font_separator_color", "PopupMenu", font_disabled_color);
+	theme->set_icon("checked", "PopupMenu", theme->get_icon(SNAME("GuiChecked"), SNAME("EditorIcons")));
+	theme->set_icon("unchecked", "PopupMenu", theme->get_icon(SNAME("GuiUnchecked"), SNAME("EditorIcons")));
+	theme->set_icon("radio_checked", "PopupMenu", theme->get_icon(SNAME("GuiRadioChecked"), SNAME("EditorIcons")));
+	theme->set_icon("radio_unchecked", "PopupMenu", theme->get_icon(SNAME("GuiRadioUnchecked"), SNAME("EditorIcons")));
+	theme->set_icon("checked_disabled", "PopupMenu", theme->get_icon(SNAME("GuiCheckedDisabled"), SNAME("EditorIcons")));
+	theme->set_icon("unchecked_disabled", "PopupMenu", theme->get_icon(SNAME("GuiUncheckedDisabled"), SNAME("EditorIcons")));
+	theme->set_icon("radio_checked_disabled", "PopupMenu", theme->get_icon(SNAME("GuiRadioCheckedDisabled"), SNAME("EditorIcons")));
+	theme->set_icon("radio_unchecked_disabled", "PopupMenu", theme->get_icon(SNAME("GuiRadioUncheckedDisabled"), SNAME("EditorIcons")));
+	theme->set_icon("submenu", "PopupMenu", theme->get_icon(SNAME("ArrowRight"), SNAME("EditorIcons")));
+	theme->set_icon("submenu_mirrored", "PopupMenu", theme->get_icon(SNAME("ArrowLeft"), SNAME("EditorIcons")));
+	theme->set_icon("visibility_hidden", "PopupMenu", theme->get_icon(SNAME("GuiVisibilityHidden"), SNAME("EditorIcons")));
+	theme->set_icon("visibility_visible", "PopupMenu", theme->get_icon(SNAME("GuiVisibilityVisible"), SNAME("EditorIcons")));
+	theme->set_icon("visibility_xray", "PopupMenu", theme->get_icon(SNAME("GuiVisibilityXray"), SNAME("EditorIcons")));
 
-	theme->set_constant(SNAME("vseparation"), SNAME("PopupMenu"), (extra_spacing + default_margin_size + 1) * EDSCALE);
-	theme->set_constant(SNAME("item_start_padding"), SNAME("PopupMenu"), popup_menu_margin_size * EDSCALE);
-	theme->set_constant(SNAME("item_end_padding"), SNAME("PopupMenu"), popup_menu_margin_size * EDSCALE);
+	theme->set_constant("vseparation", "PopupMenu", (extra_spacing + default_margin_size + 1) * EDSCALE);
+	theme->set_constant("item_start_padding", "PopupMenu", popup_menu_margin_size * EDSCALE);
+	theme->set_constant("item_end_padding", "PopupMenu", popup_menu_margin_size * EDSCALE);
 
 	for (int i = 0; i < 16; i++) {
 		Color si_base_color = accent_color;
@@ -843,7 +843,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		sub_inspector_bg->set_border_color(si_base_color * Color(0.7, 0.7, 0.7, 0.8));
 		sub_inspector_bg->set_draw_center(true);
 
-		theme->set_stylebox("sub_inspector_bg" + itos(i), SNAME("Editor"), sub_inspector_bg);
+		theme->set_stylebox("sub_inspector_bg" + itos(i), "Editor", sub_inspector_bg);
 
 		Ref<StyleBoxFlat> bg_color;
 		bg_color.instantiate();
@@ -855,99 +855,99 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		bg_color_selected->set_border_width_all(0);
 		bg_color_selected->set_bg_color(si_base_color * Color(0.8, 0.8, 0.8, 0.8));
 
-		theme->set_stylebox("sub_inspector_property_bg" + itos(i), SNAME("Editor"), bg_color);
-		theme->set_stylebox("sub_inspector_property_bg_selected" + itos(i), SNAME("Editor"), bg_color_selected);
+		theme->set_stylebox("sub_inspector_property_bg" + itos(i), "Editor", bg_color);
+		theme->set_stylebox("sub_inspector_property_bg_selected" + itos(i), "Editor", bg_color_selected);
 	}
 
-	theme->set_color(SNAME("sub_inspector_property_color"), SNAME("Editor"), dark_theme ? Color(1, 1, 1, 1) : Color(0, 0, 0, 1));
-	theme->set_constant(SNAME("sub_inspector_font_offset"), SNAME("Editor"), 4 * EDSCALE);
+	theme->set_color("sub_inspector_property_color", "Editor", dark_theme ? Color(1, 1, 1, 1) : Color(0, 0, 0, 1));
+	theme->set_constant("sub_inspector_font_offset", "Editor", 4 * EDSCALE);
 
 	Ref<StyleBoxFlat> style_property_bg = style_default->duplicate();
 	style_property_bg->set_bg_color(highlight_color);
 	style_property_bg->set_border_width_all(0);
 
-	theme->set_constant(SNAME("font_offset"), SNAME("EditorProperty"), 8 * EDSCALE);
-	theme->set_stylebox(SNAME("bg_selected"), SNAME("EditorProperty"), style_property_bg);
-	theme->set_stylebox(SNAME("bg"), SNAME("EditorProperty"), Ref<StyleBoxEmpty>(memnew(StyleBoxEmpty)));
-	theme->set_constant(SNAME("vseparation"), SNAME("EditorProperty"), (extra_spacing + default_margin_size) * EDSCALE);
-	theme->set_color(SNAME("warning_color"), SNAME("EditorProperty"), warning_color);
-	theme->set_color(SNAME("property_color"), SNAME("EditorProperty"), property_color);
-	theme->set_color(SNAME("readonly_color"), SNAME("EditorProperty"), readonly_color);
-	theme->set_color(SNAME("readonly_warning_color"), SNAME("EditorProperty"), readonly_warning_color);
+	theme->set_constant("font_offset", "EditorProperty", 8 * EDSCALE);
+	theme->set_stylebox("bg_selected", "EditorProperty", style_property_bg);
+	theme->set_stylebox("bg", "EditorProperty", Ref<StyleBoxEmpty>(memnew(StyleBoxEmpty)));
+	theme->set_constant("vseparation", "EditorProperty", (extra_spacing + default_margin_size) * EDSCALE);
+	theme->set_color("warning_color", "EditorProperty", warning_color);
+	theme->set_color("property_color", "EditorProperty", property_color);
+	theme->set_color("readonly_color", "EditorProperty", readonly_color);
+	theme->set_color("readonly_warning_color", "EditorProperty", readonly_warning_color);
 
 	Color inspector_section_color = font_color.lerp(Color(0.5, 0.5, 0.5), 0.35);
-	theme->set_color(SNAME("font_color"), SNAME("EditorInspectorSection"), inspector_section_color);
+	theme->set_color("font_color", "EditorInspectorSection", inspector_section_color);
 
-	theme->set_constant(SNAME("inspector_margin"), SNAME("Editor"), 12 * EDSCALE);
+	theme->set_constant("inspector_margin", "Editor", 12 * EDSCALE);
 
 	// Tree & ItemList background
 	Ref<StyleBoxFlat> style_tree_bg = style_default->duplicate();
 	// Make Trees easier to distinguish from other controls by using a darker background color.
 	style_tree_bg->set_bg_color(dark_color_1.lerp(dark_color_2, 0.5));
 	style_tree_bg->set_border_color(dark_color_3);
-	theme->set_stylebox(SNAME("bg"), SNAME("Tree"), style_tree_bg);
+	theme->set_stylebox("bg", "Tree", style_tree_bg);
 
 	// Tree
-	theme->set_icon(SNAME("checked"), SNAME("Tree"), theme->get_icon(SNAME("GuiChecked"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("indeterminate"), SNAME("Tree"), theme->get_icon(SNAME("GuiIndeterminate"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("unchecked"), SNAME("Tree"), theme->get_icon(SNAME("GuiUnchecked"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("arrow"), SNAME("Tree"), theme->get_icon(SNAME("GuiTreeArrowDown"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("arrow_collapsed"), SNAME("Tree"), theme->get_icon(SNAME("GuiTreeArrowRight"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("arrow_collapsed_mirrored"), SNAME("Tree"), theme->get_icon(SNAME("GuiTreeArrowLeft"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("updown"), SNAME("Tree"), theme->get_icon(SNAME("GuiTreeUpdown"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("select_arrow"), SNAME("Tree"), theme->get_icon(SNAME("GuiDropdown"), SNAME("EditorIcons")));
-	theme->set_stylebox(SNAME("bg_focus"), SNAME("Tree"), style_widget_focus);
-	theme->set_stylebox(SNAME("custom_button"), SNAME("Tree"), make_empty_stylebox());
-	theme->set_stylebox(SNAME("custom_button_pressed"), SNAME("Tree"), make_empty_stylebox());
-	theme->set_stylebox(SNAME("custom_button_hover"), SNAME("Tree"), style_widget);
-	theme->set_color(SNAME("custom_button_font_highlight"), SNAME("Tree"), font_hover_color);
-	theme->set_color(SNAME("font_color"), SNAME("Tree"), font_color);
-	theme->set_color(SNAME("font_selected_color"), SNAME("Tree"), mono_color);
-	theme->set_color(SNAME("title_button_color"), SNAME("Tree"), font_color);
-	theme->set_color(SNAME("drop_position_color"), SNAME("Tree"), accent_color);
-	theme->set_constant(SNAME("vseparation"), SNAME("Tree"), widget_default_margin.y - EDSCALE);
-	theme->set_constant(SNAME("hseparation"), SNAME("Tree"), 6 * EDSCALE);
-	theme->set_constant(SNAME("guide_width"), SNAME("Tree"), border_width);
-	theme->set_constant(SNAME("item_margin"), SNAME("Tree"), 3 * default_margin_size * EDSCALE);
-	theme->set_constant(SNAME("button_margin"), SNAME("Tree"), default_margin_size * EDSCALE);
-	theme->set_constant(SNAME("scroll_border"), SNAME("Tree"), 40 * EDSCALE);
-	theme->set_constant(SNAME("scroll_speed"), SNAME("Tree"), 12);
+	theme->set_icon("checked", "Tree", theme->get_icon(SNAME("GuiChecked"), SNAME("EditorIcons")));
+	theme->set_icon("indeterminate", "Tree", theme->get_icon(SNAME("GuiIndeterminate"), SNAME("EditorIcons")));
+	theme->set_icon("unchecked", "Tree", theme->get_icon(SNAME("GuiUnchecked"), SNAME("EditorIcons")));
+	theme->set_icon("arrow", "Tree", theme->get_icon(SNAME("GuiTreeArrowDown"), SNAME("EditorIcons")));
+	theme->set_icon("arrow_collapsed", "Tree", theme->get_icon(SNAME("GuiTreeArrowRight"), SNAME("EditorIcons")));
+	theme->set_icon("arrow_collapsed_mirrored", "Tree", theme->get_icon(SNAME("GuiTreeArrowLeft"), SNAME("EditorIcons")));
+	theme->set_icon("updown", "Tree", theme->get_icon(SNAME("GuiTreeUpdown"), SNAME("EditorIcons")));
+	theme->set_icon("select_arrow", "Tree", theme->get_icon(SNAME("GuiDropdown"), SNAME("EditorIcons")));
+	theme->set_stylebox("bg_focus", "Tree", style_widget_focus);
+	theme->set_stylebox("custom_button", "Tree", make_empty_stylebox());
+	theme->set_stylebox("custom_button_pressed", "Tree", make_empty_stylebox());
+	theme->set_stylebox("custom_button_hover", "Tree", style_widget);
+	theme->set_color("custom_button_font_highlight", "Tree", font_hover_color);
+	theme->set_color("font_color", "Tree", font_color);
+	theme->set_color("font_selected_color", "Tree", mono_color);
+	theme->set_color("title_button_color", "Tree", font_color);
+	theme->set_color("drop_position_color", "Tree", accent_color);
+	theme->set_constant("vseparation", "Tree", widget_default_margin.y - EDSCALE);
+	theme->set_constant("hseparation", "Tree", 6 * EDSCALE);
+	theme->set_constant("guide_width", "Tree", border_width);
+	theme->set_constant("item_margin", "Tree", 3 * default_margin_size * EDSCALE);
+	theme->set_constant("button_margin", "Tree", default_margin_size * EDSCALE);
+	theme->set_constant("scroll_border", "Tree", 40 * EDSCALE);
+	theme->set_constant("scroll_speed", "Tree", 12);
 
 	const Color guide_color = mono_color * Color(1, 1, 1, 0.05);
 	Color relationship_line_color = mono_color * Color(1, 1, 1, relationship_line_opacity);
 
-	theme->set_constant(SNAME("draw_guides"), SNAME("Tree"), relationship_line_opacity < 0.01);
-	theme->set_color(SNAME("guide_color"), SNAME("Tree"), guide_color);
+	theme->set_constant("draw_guides", "Tree", relationship_line_opacity < 0.01);
+	theme->set_color("guide_color", "Tree", guide_color);
 
 	int relationship_line_width = 1;
 	Color parent_line_color = mono_color * Color(1, 1, 1, CLAMP(relationship_line_opacity + 0.45, 0.0, 1.0));
 	Color children_line_color = mono_color * Color(1, 1, 1, CLAMP(relationship_line_opacity + 0.25, 0.0, 1.0));
-	theme->set_constant(SNAME("draw_relationship_lines"), SNAME("Tree"), relationship_line_opacity >= 0.01);
-	theme->set_constant(SNAME("relationship_line_width"), SNAME("Tree"), relationship_line_width);
-	theme->set_constant(SNAME("parent_hl_line_width"), SNAME("Tree"), relationship_line_width * 2);
-	theme->set_constant(SNAME("children_hl_line_width"), SNAME("Tree"), relationship_line_width);
-	theme->set_constant(SNAME("parent_hl_line_margin"), SNAME("Tree"), relationship_line_width * 3);
-	theme->set_color(SNAME("relationship_line_color"), SNAME("Tree"), relationship_line_color);
-	theme->set_color(SNAME("parent_hl_line_color"), SNAME("Tree"), parent_line_color);
-	theme->set_color(SNAME("children_hl_line_color"), SNAME("Tree"), children_line_color);
+	theme->set_constant("draw_relationship_lines", "Tree", relationship_line_opacity >= 0.01);
+	theme->set_constant("relationship_line_width", "Tree", relationship_line_width);
+	theme->set_constant("parent_hl_line_width", "Tree", relationship_line_width * 2);
+	theme->set_constant("children_hl_line_width", "Tree", relationship_line_width);
+	theme->set_constant("parent_hl_line_margin", "Tree", relationship_line_width * 3);
+	theme->set_color("relationship_line_color", "Tree", relationship_line_color);
+	theme->set_color("parent_hl_line_color", "Tree", parent_line_color);
+	theme->set_color("children_hl_line_color", "Tree", children_line_color);
 
 	Ref<StyleBoxFlat> style_tree_btn = style_default->duplicate();
 	style_tree_btn->set_bg_color(highlight_color);
 	style_tree_btn->set_border_width_all(0);
-	theme->set_stylebox(SNAME("button_pressed"), SNAME("Tree"), style_tree_btn);
+	theme->set_stylebox("button_pressed", "Tree", style_tree_btn);
 
 	Ref<StyleBoxFlat> style_tree_hover = style_default->duplicate();
 	style_tree_hover->set_bg_color(highlight_color * Color(1, 1, 1, 0.4));
 	style_tree_hover->set_border_width_all(0);
-	theme->set_stylebox(SNAME("hover"), SNAME("Tree"), style_tree_hover);
+	theme->set_stylebox("hover", "Tree", style_tree_hover);
 
 	Ref<StyleBoxFlat> style_tree_focus = style_default->duplicate();
 	style_tree_focus->set_bg_color(highlight_color);
 	style_tree_focus->set_border_width_all(0);
-	theme->set_stylebox(SNAME("selected_focus"), SNAME("Tree"), style_tree_focus);
+	theme->set_stylebox("selected_focus", "Tree", style_tree_focus);
 
 	Ref<StyleBoxFlat> style_tree_selected = style_tree_focus->duplicate();
-	theme->set_stylebox(SNAME("selected"), SNAME("Tree"), style_tree_selected);
+	theme->set_stylebox("selected", "Tree", style_tree_selected);
 
 	Ref<StyleBoxFlat> style_tree_cursor = style_default->duplicate();
 	style_tree_cursor->set_draw_center(false);
@@ -957,25 +957,25 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<StyleBoxFlat> style_tree_title = style_default->duplicate();
 	style_tree_title->set_bg_color(dark_color_3);
 	style_tree_title->set_border_width_all(0);
-	theme->set_stylebox(SNAME("cursor"), SNAME("Tree"), style_tree_cursor);
-	theme->set_stylebox(SNAME("cursor_unfocused"), SNAME("Tree"), style_tree_cursor);
-	theme->set_stylebox(SNAME("title_button_normal"), SNAME("Tree"), style_tree_title);
-	theme->set_stylebox(SNAME("title_button_hover"), SNAME("Tree"), style_tree_title);
-	theme->set_stylebox(SNAME("title_button_pressed"), SNAME("Tree"), style_tree_title);
+	theme->set_stylebox("cursor", "Tree", style_tree_cursor);
+	theme->set_stylebox("cursor_unfocused", "Tree", style_tree_cursor);
+	theme->set_stylebox("title_button_normal", "Tree", style_tree_title);
+	theme->set_stylebox("title_button_hover", "Tree", style_tree_title);
+	theme->set_stylebox("title_button_pressed", "Tree", style_tree_title);
 
 	Color prop_category_color = dark_color_1.lerp(mono_color, 0.12);
 	Color prop_section_color = dark_color_1.lerp(mono_color, 0.09);
 	Color prop_subsection_color = dark_color_1.lerp(mono_color, 0.06);
-	theme->set_color(SNAME("prop_category"), SNAME("Editor"), prop_category_color);
-	theme->set_color(SNAME("prop_section"), SNAME("Editor"), prop_section_color);
-	theme->set_color(SNAME("prop_subsection"), SNAME("Editor"), prop_subsection_color);
-	theme->set_color(SNAME("drop_position_color"), SNAME("Tree"), accent_color);
+	theme->set_color("prop_category", "Editor", prop_category_color);
+	theme->set_color("prop_section", "Editor", prop_section_color);
+	theme->set_color("prop_subsection", "Editor", prop_subsection_color);
+	theme->set_color("drop_position_color", "Tree", accent_color);
 
 	Ref<StyleBoxFlat> category_bg = style_default->duplicate();
 	// Make Trees easier to distinguish from other controls by using a darker background color.
 	category_bg->set_bg_color(prop_category_color);
 	category_bg->set_border_color(prop_category_color);
-	theme->set_stylebox(SNAME("prop_category_style"), SNAME("Editor"), category_bg);
+	theme->set_stylebox("prop_category_style", "Editor", category_bg);
 
 	// ItemList
 	Ref<StyleBoxFlat> style_itemlist_bg = style_default->duplicate();
@@ -987,47 +987,47 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_itemlist_cursor->set_draw_center(false);
 	style_itemlist_cursor->set_border_width_all(border_width);
 	style_itemlist_cursor->set_border_color(highlight_color);
-	theme->set_stylebox(SNAME("cursor"), SNAME("ItemList"), style_itemlist_cursor);
-	theme->set_stylebox(SNAME("cursor_unfocused"), SNAME("ItemList"), style_itemlist_cursor);
-	theme->set_stylebox(SNAME("selected_focus"), SNAME("ItemList"), style_tree_focus);
-	theme->set_stylebox(SNAME("selected"), SNAME("ItemList"), style_tree_selected);
-	theme->set_stylebox(SNAME("bg_focus"), SNAME("ItemList"), style_widget_focus);
-	theme->set_stylebox(SNAME("bg"), SNAME("ItemList"), style_itemlist_bg);
-	theme->set_color(SNAME("font_color"), SNAME("ItemList"), font_color);
-	theme->set_color(SNAME("font_selected_color"), SNAME("ItemList"), mono_color);
-	theme->set_color(SNAME("guide_color"), SNAME("ItemList"), guide_color);
-	theme->set_constant(SNAME("vseparation"), SNAME("ItemList"), widget_default_margin.y - EDSCALE);
-	theme->set_constant(SNAME("hseparation"), SNAME("ItemList"), 6 * EDSCALE);
-	theme->set_constant(SNAME("icon_margin"), SNAME("ItemList"), 6 * EDSCALE);
-	theme->set_constant(SNAME("line_separation"), SNAME("ItemList"), 3 * EDSCALE);
+	theme->set_stylebox("cursor", "ItemList", style_itemlist_cursor);
+	theme->set_stylebox("cursor_unfocused", "ItemList", style_itemlist_cursor);
+	theme->set_stylebox("selected_focus", "ItemList", style_tree_focus);
+	theme->set_stylebox("selected", "ItemList", style_tree_selected);
+	theme->set_stylebox("bg_focus", "ItemList", style_widget_focus);
+	theme->set_stylebox("bg", "ItemList", style_itemlist_bg);
+	theme->set_color("font_color", "ItemList", font_color);
+	theme->set_color("font_selected_color", "ItemList", mono_color);
+	theme->set_color("guide_color", "ItemList", guide_color);
+	theme->set_constant("vseparation", "ItemList", widget_default_margin.y - EDSCALE);
+	theme->set_constant("hseparation", "ItemList", 6 * EDSCALE);
+	theme->set_constant("icon_margin", "ItemList", 6 * EDSCALE);
+	theme->set_constant("line_separation", "ItemList", 3 * EDSCALE);
 
 	// TabBar & TabContainer
-	theme->set_stylebox(SNAME("tab_selected"), SNAME("TabContainer"), style_tab_selected);
-	theme->set_stylebox(SNAME("tab_unselected"), SNAME("TabContainer"), style_tab_unselected);
-	theme->set_stylebox(SNAME("tab_disabled"), SNAME("TabContainer"), style_tab_disabled);
-	theme->set_stylebox(SNAME("tab_selected"), SNAME("TabBar"), style_tab_selected);
-	theme->set_stylebox(SNAME("tab_unselected"), SNAME("TabBar"), style_tab_unselected);
-	theme->set_stylebox(SNAME("tab_disabled"), SNAME("TabBar"), style_tab_disabled);
-	theme->set_color(SNAME("font_selected_color"), SNAME("TabContainer"), font_color);
-	theme->set_color(SNAME("font_unselected_color"), SNAME("TabContainer"), font_disabled_color);
-	theme->set_color(SNAME("font_selected_color"), SNAME("TabBar"), font_color);
-	theme->set_color(SNAME("font_unselected_color"), SNAME("TabBar"), font_disabled_color);
-	theme->set_icon(SNAME("menu"), SNAME("TabContainer"), theme->get_icon(SNAME("GuiTabMenu"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("menu_highlight"), SNAME("TabContainer"), theme->get_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
-	theme->set_stylebox(SNAME("SceneTabFG"), SNAME("EditorStyles"), style_tab_selected);
-	theme->set_stylebox(SNAME("SceneTabBG"), SNAME("EditorStyles"), style_tab_unselected);
-	theme->set_icon(SNAME("close"), SNAME("TabBar"), theme->get_icon(SNAME("GuiClose"), SNAME("EditorIcons")));
-	theme->set_stylebox(SNAME("button_pressed"), SNAME("TabBar"), style_menu);
-	theme->set_stylebox(SNAME("button_highlight"), SNAME("TabBar"), style_menu);
-	theme->set_icon(SNAME("increment"), SNAME("TabContainer"), theme->get_icon(SNAME("GuiScrollArrowRight"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("decrement"), SNAME("TabContainer"), theme->get_icon(SNAME("GuiScrollArrowLeft"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("increment"), SNAME("TabBar"), theme->get_icon(SNAME("GuiScrollArrowRight"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("decrement"), SNAME("TabBar"), theme->get_icon(SNAME("GuiScrollArrowLeft"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("increment_highlight"), SNAME("TabBar"), theme->get_icon(SNAME("GuiScrollArrowRightHl"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("decrement_highlight"), SNAME("TabBar"), theme->get_icon(SNAME("GuiScrollArrowLeftHl"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("increment_highlight"), SNAME("TabContainer"), theme->get_icon(SNAME("GuiScrollArrowRightHl"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("decrement_highlight"), SNAME("TabContainer"), theme->get_icon(SNAME("GuiScrollArrowLeftHl"), SNAME("EditorIcons")));
-	theme->set_constant(SNAME("hseparation"), SNAME("TabBar"), 4 * EDSCALE);
+	theme->set_stylebox("tab_selected", "TabContainer", style_tab_selected);
+	theme->set_stylebox("tab_unselected", "TabContainer", style_tab_unselected);
+	theme->set_stylebox("tab_disabled", "TabContainer", style_tab_disabled);
+	theme->set_stylebox("tab_selected", "TabBar", style_tab_selected);
+	theme->set_stylebox("tab_unselected", "TabBar", style_tab_unselected);
+	theme->set_stylebox("tab_disabled", "TabBar", style_tab_disabled);
+	theme->set_color("font_selected_color", "TabContainer", font_color);
+	theme->set_color("font_unselected_color", "TabContainer", font_disabled_color);
+	theme->set_color("font_selected_color", "TabBar", font_color);
+	theme->set_color("font_unselected_color", "TabBar", font_disabled_color);
+	theme->set_icon("menu", "TabContainer", theme->get_icon(SNAME("GuiTabMenu"), SNAME("EditorIcons")));
+	theme->set_icon("menu_highlight", "TabContainer", theme->get_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
+	theme->set_stylebox("SceneTabFG", "EditorStyles", style_tab_selected);
+	theme->set_stylebox("SceneTabBG", "EditorStyles", style_tab_unselected);
+	theme->set_icon("close", "TabBar", theme->get_icon(SNAME("GuiClose"), SNAME("EditorIcons")));
+	theme->set_stylebox("button_pressed", "TabBar", style_menu);
+	theme->set_stylebox("button_highlight", "TabBar", style_menu);
+	theme->set_icon("increment", "TabContainer", theme->get_icon(SNAME("GuiScrollArrowRight"), SNAME("EditorIcons")));
+	theme->set_icon("decrement", "TabContainer", theme->get_icon(SNAME("GuiScrollArrowLeft"), SNAME("EditorIcons")));
+	theme->set_icon("increment", "TabBar", theme->get_icon(SNAME("GuiScrollArrowRight"), SNAME("EditorIcons")));
+	theme->set_icon("decrement", "TabBar", theme->get_icon(SNAME("GuiScrollArrowLeft"), SNAME("EditorIcons")));
+	theme->set_icon("increment_highlight", "TabBar", theme->get_icon(SNAME("GuiScrollArrowRightHl"), SNAME("EditorIcons")));
+	theme->set_icon("decrement_highlight", "TabBar", theme->get_icon(SNAME("GuiScrollArrowLeftHl"), SNAME("EditorIcons")));
+	theme->set_icon("increment_highlight", "TabContainer", theme->get_icon(SNAME("GuiScrollArrowRightHl"), SNAME("EditorIcons")));
+	theme->set_icon("decrement_highlight", "TabContainer", theme->get_icon(SNAME("GuiScrollArrowLeftHl"), SNAME("EditorIcons")));
+	theme->set_constant("hseparation", "TabBar", 4 * EDSCALE);
 
 	// Content of each tab
 	Ref<StyleBoxFlat> style_content_panel = style_default->duplicate();
@@ -1041,16 +1041,16 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Display border to visually split the body of the container from its possible backgrounds.
 	style_content_panel->set_border_width(Side::SIDE_TOP, Math::round(2 * EDSCALE));
 	style_content_panel->set_border_color(dark_color_2);
-	theme->set_stylebox(SNAME("panel"), SNAME("TabContainer"), style_content_panel);
+	theme->set_stylebox("panel", "TabContainer", style_content_panel);
 
 	// These styleboxes can be used on tabs against the base color background (e.g. nested tabs).
 	Ref<StyleBoxFlat> style_tab_selected_odd = style_tab_selected->duplicate();
 	style_tab_selected_odd->set_bg_color(disabled_bg_color);
-	theme->set_stylebox(SNAME("tab_selected_odd"), SNAME("TabContainer"), style_tab_selected_odd);
+	theme->set_stylebox("tab_selected_odd", "TabContainer", style_tab_selected_odd);
 
 	Ref<StyleBoxFlat> style_content_panel_odd = style_content_panel->duplicate();
 	style_content_panel_odd->set_bg_color(disabled_bg_color);
-	theme->set_stylebox(SNAME("panel_odd"), SNAME("TabContainer"), style_content_panel_odd);
+	theme->set_stylebox("panel_odd", "TabContainer", style_content_panel_odd);
 
 	// This stylebox is used in 3d and 2d viewports (no borders).
 	Ref<StyleBoxFlat> style_content_panel_vp = style_content_panel->duplicate();
@@ -1058,31 +1058,31 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_content_panel_vp->set_default_margin(SIDE_TOP, default_margin_size * EDSCALE);
 	style_content_panel_vp->set_default_margin(SIDE_RIGHT, border_width * 2);
 	style_content_panel_vp->set_default_margin(SIDE_BOTTOM, border_width * 2);
-	theme->set_stylebox(SNAME("Content"), SNAME("EditorStyles"), style_content_panel_vp);
+	theme->set_stylebox("Content", "EditorStyles", style_content_panel_vp);
 
 	// This stylebox is used by preview tabs in the Theme Editor.
 	Ref<StyleBoxFlat> style_theme_preview_tab = style_tab_selected_odd->duplicate();
 	style_theme_preview_tab->set_expand_margin_size(SIDE_BOTTOM, 5 * EDSCALE);
-	theme->set_stylebox(SNAME("ThemeEditorPreviewFG"), SNAME("EditorStyles"), style_theme_preview_tab);
+	theme->set_stylebox("ThemeEditorPreviewFG", "EditorStyles", style_theme_preview_tab);
 	Ref<StyleBoxFlat> style_theme_preview_bg_tab = style_tab_unselected->duplicate();
 	style_theme_preview_bg_tab->set_expand_margin_size(SIDE_BOTTOM, 2 * EDSCALE);
-	theme->set_stylebox(SNAME("ThemeEditorPreviewBG"), SNAME("EditorStyles"), style_theme_preview_bg_tab);
+	theme->set_stylebox("ThemeEditorPreviewBG", "EditorStyles", style_theme_preview_bg_tab);
 
 	// Separators
-	theme->set_stylebox(SNAME("separator"), SNAME("HSeparator"), make_line_stylebox(separator_color, MAX(Math::round(EDSCALE), border_width)));
-	theme->set_stylebox(SNAME("separator"), SNAME("VSeparator"), make_line_stylebox(separator_color, MAX(Math::round(EDSCALE), border_width), 0, 0, true));
+	theme->set_stylebox("separator", "HSeparator", make_line_stylebox(separator_color, MAX(Math::round(EDSCALE), border_width)));
+	theme->set_stylebox("separator", "VSeparator", make_line_stylebox(separator_color, MAX(Math::round(EDSCALE), border_width), 0, 0, true));
 
 	// Debugger
 
 	Ref<StyleBoxFlat> style_panel_debugger = style_content_panel->duplicate();
 	style_panel_debugger->set_border_width(SIDE_BOTTOM, 0);
-	theme->set_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles"), style_panel_debugger);
+	theme->set_stylebox("DebuggerPanel", "EditorStyles", style_panel_debugger);
 
 	Ref<StyleBoxFlat> style_panel_invisible_top = style_content_panel->duplicate();
 	int stylebox_offset = theme->get_font(SNAME("tab_selected"), SNAME("TabContainer"))->get_height(theme->get_font_size(SNAME("tab_selected"), SNAME("TabContainer"))) + theme->get_stylebox(SNAME("tab_selected"), SNAME("TabContainer"))->get_minimum_size().height + theme->get_stylebox(SNAME("panel"), SNAME("TabContainer"))->get_default_margin(SIDE_TOP);
 	style_panel_invisible_top->set_expand_margin_size(SIDE_TOP, -stylebox_offset);
 	style_panel_invisible_top->set_default_margin(SIDE_TOP, 0);
-	theme->set_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles"), style_panel_invisible_top);
+	theme->set_stylebox("BottomPanelDebuggerOverride", "EditorStyles", style_panel_invisible_top);
 
 	// LineEdit
 
@@ -1102,74 +1102,74 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_line_edit_disabled->set_border_color(disabled_color);
 	style_line_edit_disabled->set_bg_color(disabled_bg_color);
 
-	theme->set_stylebox(SNAME("normal"), SNAME("LineEdit"), style_line_edit);
-	theme->set_stylebox(SNAME("focus"), SNAME("LineEdit"), style_widget_focus);
-	theme->set_stylebox(SNAME("read_only"), SNAME("LineEdit"), style_line_edit_disabled);
-	theme->set_icon(SNAME("clear"), SNAME("LineEdit"), theme->get_icon(SNAME("GuiClose"), SNAME("EditorIcons")));
-	theme->set_color(SNAME("read_only"), SNAME("LineEdit"), font_disabled_color);
-	theme->set_color(SNAME("font_color"), SNAME("LineEdit"), font_color);
-	theme->set_color(SNAME("font_selected_color"), SNAME("LineEdit"), mono_color);
-	theme->set_color(SNAME("font_uneditable_color"), SNAME("LineEdit"), font_readonly_color);
-	theme->set_color(SNAME("font_placeholder_color"), SNAME("LineEdit"), font_placeholder_color);
-	theme->set_color(SNAME("caret_color"), SNAME("LineEdit"), font_color);
-	theme->set_color(SNAME("selection_color"), SNAME("LineEdit"), selection_color);
-	theme->set_color(SNAME("clear_button_color"), SNAME("LineEdit"), font_color);
-	theme->set_color(SNAME("clear_button_color_pressed"), SNAME("LineEdit"), accent_color);
+	theme->set_stylebox("normal", "LineEdit", style_line_edit);
+	theme->set_stylebox("focus", "LineEdit", style_widget_focus);
+	theme->set_stylebox("read_only", "LineEdit", style_line_edit_disabled);
+	theme->set_icon("clear", "LineEdit", theme->get_icon(SNAME("GuiClose"), SNAME("EditorIcons")));
+	theme->set_color("read_only", "LineEdit", font_disabled_color);
+	theme->set_color("font_color", "LineEdit", font_color);
+	theme->set_color("font_selected_color", "LineEdit", mono_color);
+	theme->set_color("font_uneditable_color", "LineEdit", font_readonly_color);
+	theme->set_color("font_placeholder_color", "LineEdit", font_placeholder_color);
+	theme->set_color("caret_color", "LineEdit", font_color);
+	theme->set_color("selection_color", "LineEdit", selection_color);
+	theme->set_color("clear_button_color", "LineEdit", font_color);
+	theme->set_color("clear_button_color_pressed", "LineEdit", accent_color);
 
 	// TextEdit
-	theme->set_stylebox(SNAME("normal"), SNAME("TextEdit"), style_line_edit);
-	theme->set_stylebox(SNAME("focus"), SNAME("TextEdit"), style_widget_focus);
-	theme->set_stylebox(SNAME("read_only"), SNAME("TextEdit"), style_line_edit_disabled);
-	theme->set_constant(SNAME("side_margin"), SNAME("TabContainer"), 0);
-	theme->set_icon(SNAME("tab"), SNAME("TextEdit"), theme->get_icon(SNAME("GuiTab"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("space"), SNAME("TextEdit"), theme->get_icon(SNAME("GuiSpace"), SNAME("EditorIcons")));
-	theme->set_color(SNAME("font_color"), SNAME("TextEdit"), font_color);
-	theme->set_color(SNAME("font_readonly_color"), SNAME("TextEdit"), font_readonly_color);
-	theme->set_color(SNAME("font_placeholder_color"), SNAME("TextEdit"), font_placeholder_color);
-	theme->set_color(SNAME("caret_color"), SNAME("TextEdit"), font_color);
-	theme->set_color(SNAME("selection_color"), SNAME("TextEdit"), selection_color);
-	theme->set_constant(SNAME("line_spacing"), SNAME("TextEdit"), 4 * EDSCALE);
+	theme->set_stylebox("normal", "TextEdit", style_line_edit);
+	theme->set_stylebox("focus", "TextEdit", style_widget_focus);
+	theme->set_stylebox("read_only", "TextEdit", style_line_edit_disabled);
+	theme->set_constant("side_margin", "TabContainer", 0);
+	theme->set_icon("tab", "TextEdit", theme->get_icon(SNAME("GuiTab"), SNAME("EditorIcons")));
+	theme->set_icon("space", "TextEdit", theme->get_icon(SNAME("GuiSpace"), SNAME("EditorIcons")));
+	theme->set_color("font_color", "TextEdit", font_color);
+	theme->set_color("font_readonly_color", "TextEdit", font_readonly_color);
+	theme->set_color("font_placeholder_color", "TextEdit", font_placeholder_color);
+	theme->set_color("caret_color", "TextEdit", font_color);
+	theme->set_color("selection_color", "TextEdit", selection_color);
+	theme->set_constant("line_spacing", "TextEdit", 4 * EDSCALE);
 
 	// CodeEdit
-	theme->set_font(SNAME("font"), SNAME("CodeEdit"), theme->get_font(SNAME("source"), SNAME("EditorFonts")));
-	theme->set_font_size(SNAME("font_size"), SNAME("CodeEdit"), theme->get_font_size(SNAME("source_size"), SNAME("EditorFonts")));
-	theme->set_stylebox(SNAME("normal"), SNAME("CodeEdit"), style_widget);
-	theme->set_stylebox(SNAME("focus"), SNAME("CodeEdit"), style_widget_hover);
-	theme->set_stylebox(SNAME("read_only"), SNAME("CodeEdit"), style_widget_disabled);
-	theme->set_icon(SNAME("tab"), SNAME("CodeEdit"), theme->get_icon(SNAME("GuiTab"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("space"), SNAME("CodeEdit"), theme->get_icon(SNAME("GuiSpace"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("folded"), SNAME("CodeEdit"), theme->get_icon(SNAME("GuiTreeArrowRight"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("can_fold"), SNAME("CodeEdit"), theme->get_icon(SNAME("GuiTreeArrowDown"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("executing_line"), SNAME("CodeEdit"), theme->get_icon(SNAME("MainPlay"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("breakpoint"), SNAME("CodeEdit"), theme->get_icon(SNAME("Breakpoint"), SNAME("EditorIcons")));
-	theme->set_constant(SNAME("line_spacing"), SNAME("CodeEdit"), EDITOR_DEF("text_editor/appearance/whitespace/line_spacing", 6));
+	theme->set_font("font", "CodeEdit", theme->get_font(SNAME("source"), SNAME("EditorFonts")));
+	theme->set_font_size("font_size", "CodeEdit", theme->get_font_size(SNAME("source_size"), SNAME("EditorFonts")));
+	theme->set_stylebox("normal", "CodeEdit", style_widget);
+	theme->set_stylebox("focus", "CodeEdit", style_widget_hover);
+	theme->set_stylebox("read_only", "CodeEdit", style_widget_disabled);
+	theme->set_icon("tab", "CodeEdit", theme->get_icon(SNAME("GuiTab"), SNAME("EditorIcons")));
+	theme->set_icon("space", "CodeEdit", theme->get_icon(SNAME("GuiSpace"), SNAME("EditorIcons")));
+	theme->set_icon("folded", "CodeEdit", theme->get_icon(SNAME("GuiTreeArrowRight"), SNAME("EditorIcons")));
+	theme->set_icon("can_fold", "CodeEdit", theme->get_icon(SNAME("GuiTreeArrowDown"), SNAME("EditorIcons")));
+	theme->set_icon("executing_line", "CodeEdit", theme->get_icon(SNAME("MainPlay"), SNAME("EditorIcons")));
+	theme->set_icon("breakpoint", "CodeEdit", theme->get_icon(SNAME("Breakpoint"), SNAME("EditorIcons")));
+	theme->set_constant("line_spacing", "CodeEdit", EDITOR_DEF("text_editor/appearance/whitespace/line_spacing", 6));
 
 	// H/VSplitContainer
-	theme->set_stylebox(SNAME("bg"), SNAME("VSplitContainer"), make_stylebox(theme->get_icon(SNAME("GuiVsplitBg"), SNAME("EditorIcons")), 1, 1, 1, 1));
-	theme->set_stylebox(SNAME("bg"), SNAME("HSplitContainer"), make_stylebox(theme->get_icon(SNAME("GuiHsplitBg"), SNAME("EditorIcons")), 1, 1, 1, 1));
+	theme->set_stylebox("bg", "VSplitContainer", make_stylebox(theme->get_icon(SNAME("GuiVsplitBg"), SNAME("EditorIcons")), 1, 1, 1, 1));
+	theme->set_stylebox("bg", "HSplitContainer", make_stylebox(theme->get_icon(SNAME("GuiHsplitBg"), SNAME("EditorIcons")), 1, 1, 1, 1));
 
-	theme->set_icon(SNAME("grabber"), SNAME("VSplitContainer"), theme->get_icon(SNAME("GuiVsplitter"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("grabber"), SNAME("HSplitContainer"), theme->get_icon(SNAME("GuiHsplitter"), SNAME("EditorIcons")));
+	theme->set_icon("grabber", "VSplitContainer", theme->get_icon(SNAME("GuiVsplitter"), SNAME("EditorIcons")));
+	theme->set_icon("grabber", "HSplitContainer", theme->get_icon(SNAME("GuiHsplitter"), SNAME("EditorIcons")));
 
-	theme->set_constant(SNAME("separation"), SNAME("HSplitContainer"), default_margin_size * 2 * EDSCALE);
-	theme->set_constant(SNAME("separation"), SNAME("VSplitContainer"), default_margin_size * 2 * EDSCALE);
+	theme->set_constant("separation", "HSplitContainer", default_margin_size * 2 * EDSCALE);
+	theme->set_constant("separation", "VSplitContainer", default_margin_size * 2 * EDSCALE);
 
 	// Containers
-	theme->set_constant(SNAME("separation"), SNAME("BoxContainer"), default_margin_size * EDSCALE);
-	theme->set_constant(SNAME("separation"), SNAME("HBoxContainer"), default_margin_size * EDSCALE);
-	theme->set_constant(SNAME("separation"), SNAME("VBoxContainer"), default_margin_size * EDSCALE);
-	theme->set_constant(SNAME("margin_left"), SNAME("MarginContainer"), 0);
-	theme->set_constant(SNAME("margin_top"), SNAME("MarginContainer"), 0);
-	theme->set_constant(SNAME("margin_right"), SNAME("MarginContainer"), 0);
-	theme->set_constant(SNAME("margin_bottom"), SNAME("MarginContainer"), 0);
-	theme->set_constant(SNAME("hseparation"), SNAME("GridContainer"), default_margin_size * EDSCALE);
-	theme->set_constant(SNAME("vseparation"), SNAME("GridContainer"), default_margin_size * EDSCALE);
-	theme->set_constant(SNAME("hseparation"), SNAME("FlowContainer"), default_margin_size * EDSCALE);
-	theme->set_constant(SNAME("vseparation"), SNAME("FlowContainer"), default_margin_size * EDSCALE);
-	theme->set_constant(SNAME("hseparation"), SNAME("HFlowContainer"), default_margin_size * EDSCALE);
-	theme->set_constant(SNAME("vseparation"), SNAME("HFlowContainer"), default_margin_size * EDSCALE);
-	theme->set_constant(SNAME("hseparation"), SNAME("VFlowContainer"), default_margin_size * EDSCALE);
-	theme->set_constant(SNAME("vseparation"), SNAME("VFlowContainer"), default_margin_size * EDSCALE);
+	theme->set_constant("separation", "BoxContainer", default_margin_size * EDSCALE);
+	theme->set_constant("separation", "HBoxContainer", default_margin_size * EDSCALE);
+	theme->set_constant("separation", "VBoxContainer", default_margin_size * EDSCALE);
+	theme->set_constant("margin_left", "MarginContainer", 0);
+	theme->set_constant("margin_top", "MarginContainer", 0);
+	theme->set_constant("margin_right", "MarginContainer", 0);
+	theme->set_constant("margin_bottom", "MarginContainer", 0);
+	theme->set_constant("hseparation", "GridContainer", default_margin_size * EDSCALE);
+	theme->set_constant("vseparation", "GridContainer", default_margin_size * EDSCALE);
+	theme->set_constant("hseparation", "FlowContainer", default_margin_size * EDSCALE);
+	theme->set_constant("vseparation", "FlowContainer", default_margin_size * EDSCALE);
+	theme->set_constant("hseparation", "HFlowContainer", default_margin_size * EDSCALE);
+	theme->set_constant("vseparation", "HFlowContainer", default_margin_size * EDSCALE);
+	theme->set_constant("hseparation", "VFlowContainer", default_margin_size * EDSCALE);
+	theme->set_constant("vseparation", "VFlowContainer", default_margin_size * EDSCALE);
 
 	// Window
 
@@ -1184,119 +1184,119 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_window->set_border_color(base_color);
 	style_window->set_border_width(SIDE_TOP, 24 * EDSCALE);
 	style_window->set_expand_margin_size(SIDE_TOP, 24 * EDSCALE);
-	theme->set_stylebox(SNAME("embedded_border"), SNAME("Window"), style_window);
+	theme->set_stylebox("embedded_border", "Window", style_window);
 
-	theme->set_color(SNAME("title_color"), SNAME("Window"), font_color);
-	theme->set_icon(SNAME("close"), SNAME("Window"), theme->get_icon(SNAME("GuiClose"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("close_pressed"), SNAME("Window"), theme->get_icon(SNAME("GuiClose"), SNAME("EditorIcons")));
-	theme->set_constant(SNAME("close_h_ofs"), SNAME("Window"), 22 * EDSCALE);
-	theme->set_constant(SNAME("close_v_ofs"), SNAME("Window"), 20 * EDSCALE);
-	theme->set_constant(SNAME("title_height"), SNAME("Window"), 24 * EDSCALE);
-	theme->set_constant(SNAME("resize_margin"), SNAME("Window"), 4 * EDSCALE);
-	theme->set_font(SNAME("title_font"), SNAME("Window"), theme->get_font(SNAME("title"), SNAME("EditorFonts")));
-	theme->set_font_size(SNAME("title_font_size"), SNAME("Window"), theme->get_font_size(SNAME("title_size"), SNAME("EditorFonts")));
+	theme->set_color("title_color", "Window", font_color);
+	theme->set_icon("close", "Window", theme->get_icon(SNAME("GuiClose"), SNAME("EditorIcons")));
+	theme->set_icon("close_pressed", "Window", theme->get_icon(SNAME("GuiClose"), SNAME("EditorIcons")));
+	theme->set_constant("close_h_ofs", "Window", 22 * EDSCALE);
+	theme->set_constant("close_v_ofs", "Window", 20 * EDSCALE);
+	theme->set_constant("title_height", "Window", 24 * EDSCALE);
+	theme->set_constant("resize_margin", "Window", 4 * EDSCALE);
+	theme->set_font("title_font", "Window", theme->get_font(SNAME("title"), SNAME("EditorFonts")));
+	theme->set_font_size("title_font_size", "Window", theme->get_font_size(SNAME("title_size"), SNAME("EditorFonts")));
 
 	// Complex window (currently only Editor Settings and Project Settings)
 	Ref<StyleBoxFlat> style_complex_window = style_window->duplicate();
 	style_complex_window->set_bg_color(dark_color_2);
 	style_complex_window->set_border_color(dark_color_2);
-	theme->set_stylebox(SNAME("panel"), SNAME("EditorSettingsDialog"), style_complex_window);
-	theme->set_stylebox(SNAME("panel"), SNAME("ProjectSettingsEditor"), style_complex_window);
-	theme->set_stylebox(SNAME("panel"), SNAME("EditorAbout"), style_complex_window);
+	theme->set_stylebox("panel", "EditorSettingsDialog", style_complex_window);
+	theme->set_stylebox("panel", "ProjectSettingsEditor", style_complex_window);
+	theme->set_stylebox("panel", "EditorAbout", style_complex_window);
 
 	// AcceptDialog
-	theme->set_stylebox(SNAME("panel"), SNAME("AcceptDialog"), style_window_title);
+	theme->set_stylebox("panel", "AcceptDialog", style_window_title);
 
 	// HScrollBar
 	Ref<Texture2D> empty_icon = memnew(ImageTexture);
 
-	theme->set_stylebox(SNAME("scroll"), SNAME("HScrollBar"), make_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 0, 0, 0, 0));
-	theme->set_stylebox(SNAME("scroll_focus"), SNAME("HScrollBar"), make_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 0, 0, 0, 0));
-	theme->set_stylebox(SNAME("grabber"), SNAME("HScrollBar"), make_stylebox(theme->get_icon(SNAME("GuiScrollGrabber"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 2, 2, 2));
-	theme->set_stylebox(SNAME("grabber_highlight"), SNAME("HScrollBar"), make_stylebox(theme->get_icon(SNAME("GuiScrollGrabberHl"), SNAME("EditorIcons")), 5, 5, 5, 5, 2, 2, 2, 2));
-	theme->set_stylebox(SNAME("grabber_pressed"), SNAME("HScrollBar"), make_stylebox(theme->get_icon(SNAME("GuiScrollGrabberPressed"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 2, 2, 2));
+	theme->set_stylebox("scroll", "HScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 0, 0, 0, 0));
+	theme->set_stylebox("scroll_focus", "HScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 0, 0, 0, 0));
+	theme->set_stylebox("grabber", "HScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollGrabber"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 2, 2, 2));
+	theme->set_stylebox("grabber_highlight", "HScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollGrabberHl"), SNAME("EditorIcons")), 5, 5, 5, 5, 2, 2, 2, 2));
+	theme->set_stylebox("grabber_pressed", "HScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollGrabberPressed"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 2, 2, 2));
 
-	theme->set_icon(SNAME("increment"), SNAME("HScrollBar"), empty_icon);
-	theme->set_icon(SNAME("increment_highlight"), SNAME("HScrollBar"), empty_icon);
-	theme->set_icon(SNAME("increment_pressed"), SNAME("HScrollBar"), empty_icon);
-	theme->set_icon(SNAME("decrement"), SNAME("HScrollBar"), empty_icon);
-	theme->set_icon(SNAME("decrement_highlight"), SNAME("HScrollBar"), empty_icon);
-	theme->set_icon(SNAME("decrement_pressed"), SNAME("HScrollBar"), empty_icon);
+	theme->set_icon("increment", "HScrollBar", empty_icon);
+	theme->set_icon("increment_highlight", "HScrollBar", empty_icon);
+	theme->set_icon("increment_pressed", "HScrollBar", empty_icon);
+	theme->set_icon("decrement", "HScrollBar", empty_icon);
+	theme->set_icon("decrement_highlight", "HScrollBar", empty_icon);
+	theme->set_icon("decrement_pressed", "HScrollBar", empty_icon);
 
 	// VScrollBar
-	theme->set_stylebox(SNAME("scroll"), SNAME("VScrollBar"), make_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 0, 0, 0, 0));
-	theme->set_stylebox(SNAME("scroll_focus"), SNAME("VScrollBar"), make_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 0, 0, 0, 0));
-	theme->set_stylebox(SNAME("grabber"), SNAME("VScrollBar"), make_stylebox(theme->get_icon(SNAME("GuiScrollGrabber"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 2, 2, 2));
-	theme->set_stylebox(SNAME("grabber_highlight"), SNAME("VScrollBar"), make_stylebox(theme->get_icon(SNAME("GuiScrollGrabberHl"), SNAME("EditorIcons")), 5, 5, 5, 5, 2, 2, 2, 2));
-	theme->set_stylebox(SNAME("grabber_pressed"), SNAME("VScrollBar"), make_stylebox(theme->get_icon(SNAME("GuiScrollGrabberPressed"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 2, 2, 2));
+	theme->set_stylebox("scroll", "VScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 0, 0, 0, 0));
+	theme->set_stylebox("scroll_focus", "VScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollBg"), SNAME("EditorIcons")), 5, 5, 5, 5, 0, 0, 0, 0));
+	theme->set_stylebox("grabber", "VScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollGrabber"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 2, 2, 2));
+	theme->set_stylebox("grabber_highlight", "VScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollGrabberHl"), SNAME("EditorIcons")), 5, 5, 5, 5, 2, 2, 2, 2));
+	theme->set_stylebox("grabber_pressed", "VScrollBar", make_stylebox(theme->get_icon(SNAME("GuiScrollGrabberPressed"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 2, 2, 2));
 
-	theme->set_icon(SNAME("increment"), SNAME("VScrollBar"), empty_icon);
-	theme->set_icon(SNAME("increment_highlight"), SNAME("VScrollBar"), empty_icon);
-	theme->set_icon(SNAME("increment_pressed"), SNAME("VScrollBar"), empty_icon);
-	theme->set_icon(SNAME("decrement"), SNAME("VScrollBar"), empty_icon);
-	theme->set_icon(SNAME("decrement_highlight"), SNAME("VScrollBar"), empty_icon);
-	theme->set_icon(SNAME("decrement_pressed"), SNAME("VScrollBar"), empty_icon);
+	theme->set_icon("increment", "VScrollBar", empty_icon);
+	theme->set_icon("increment_highlight", "VScrollBar", empty_icon);
+	theme->set_icon("increment_pressed", "VScrollBar", empty_icon);
+	theme->set_icon("decrement", "VScrollBar", empty_icon);
+	theme->set_icon("decrement_highlight", "VScrollBar", empty_icon);
+	theme->set_icon("decrement_pressed", "VScrollBar", empty_icon);
 
 	// HSlider
-	theme->set_icon(SNAME("grabber_highlight"), SNAME("HSlider"), theme->get_icon(SNAME("GuiSliderGrabberHl"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("grabber"), SNAME("HSlider"), theme->get_icon(SNAME("GuiSliderGrabber"), SNAME("EditorIcons")));
-	theme->set_stylebox(SNAME("slider"), SNAME("HSlider"), make_flat_stylebox(dark_color_3, 0, default_margin_size / 2, 0, default_margin_size / 2, corner_width));
-	theme->set_stylebox(SNAME("grabber_area"), SNAME("HSlider"), make_flat_stylebox(contrast_color_1, 0, default_margin_size / 2, 0, default_margin_size / 2, corner_width));
-	theme->set_stylebox(SNAME("grabber_area_highlight"), SNAME("HSlider"), make_flat_stylebox(contrast_color_1, 0, default_margin_size / 2, 0, default_margin_size / 2));
+	theme->set_icon("grabber_highlight", "HSlider", theme->get_icon(SNAME("GuiSliderGrabberHl"), SNAME("EditorIcons")));
+	theme->set_icon("grabber", "HSlider", theme->get_icon(SNAME("GuiSliderGrabber"), SNAME("EditorIcons")));
+	theme->set_stylebox("slider", "HSlider", make_flat_stylebox(dark_color_3, 0, default_margin_size / 2, 0, default_margin_size / 2, corner_width));
+	theme->set_stylebox("grabber_area", "HSlider", make_flat_stylebox(contrast_color_1, 0, default_margin_size / 2, 0, default_margin_size / 2, corner_width));
+	theme->set_stylebox("grabber_area_highlight", "HSlider", make_flat_stylebox(contrast_color_1, 0, default_margin_size / 2, 0, default_margin_size / 2));
 
 	// VSlider
-	theme->set_icon(SNAME("grabber"), SNAME("VSlider"), theme->get_icon(SNAME("GuiSliderGrabber"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("grabber_highlight"), SNAME("VSlider"), theme->get_icon(SNAME("GuiSliderGrabberHl"), SNAME("EditorIcons")));
-	theme->set_stylebox(SNAME("slider"), SNAME("VSlider"), make_flat_stylebox(dark_color_3, default_margin_size / 2, 0, default_margin_size / 2, 0, corner_width));
-	theme->set_stylebox(SNAME("grabber_area"), SNAME("VSlider"), make_flat_stylebox(contrast_color_1, default_margin_size / 2, 0, default_margin_size / 2, 0, corner_width));
-	theme->set_stylebox(SNAME("grabber_area_highlight"), SNAME("VSlider"), make_flat_stylebox(contrast_color_1, default_margin_size / 2, 0, default_margin_size / 2, 0));
+	theme->set_icon("grabber", "VSlider", theme->get_icon(SNAME("GuiSliderGrabber"), SNAME("EditorIcons")));
+	theme->set_icon("grabber_highlight", "VSlider", theme->get_icon(SNAME("GuiSliderGrabberHl"), SNAME("EditorIcons")));
+	theme->set_stylebox("slider", "VSlider", make_flat_stylebox(dark_color_3, default_margin_size / 2, 0, default_margin_size / 2, 0, corner_width));
+	theme->set_stylebox("grabber_area", "VSlider", make_flat_stylebox(contrast_color_1, default_margin_size / 2, 0, default_margin_size / 2, 0, corner_width));
+	theme->set_stylebox("grabber_area_highlight", "VSlider", make_flat_stylebox(contrast_color_1, default_margin_size / 2, 0, default_margin_size / 2, 0));
 
 	// RichTextLabel
-	theme->set_color(SNAME("default_color"), SNAME("RichTextLabel"), font_color);
-	theme->set_color(SNAME("font_shadow_color"), SNAME("RichTextLabel"), Color(0, 0, 0, 0));
-	theme->set_constant(SNAME("shadow_offset_x"), SNAME("RichTextLabel"), 1 * EDSCALE);
-	theme->set_constant(SNAME("shadow_offset_y"), SNAME("RichTextLabel"), 1 * EDSCALE);
-	theme->set_constant(SNAME("shadow_outline_size"), SNAME("RichTextLabel"), 1 * EDSCALE);
-	theme->set_stylebox(SNAME("focus"), SNAME("RichTextLabel"), make_empty_stylebox());
-	theme->set_stylebox(SNAME("normal"), SNAME("RichTextLabel"), style_tree_bg);
+	theme->set_color("default_color", "RichTextLabel", font_color);
+	theme->set_color("font_shadow_color", "RichTextLabel", Color(0, 0, 0, 0));
+	theme->set_constant("shadow_offset_x", "RichTextLabel", 1 * EDSCALE);
+	theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * EDSCALE);
+	theme->set_constant("shadow_outline_size", "RichTextLabel", 1 * EDSCALE);
+	theme->set_stylebox("focus", "RichTextLabel", make_empty_stylebox());
+	theme->set_stylebox("normal", "RichTextLabel", style_tree_bg);
 
 	// Editor help.
-	theme->set_color(SNAME("title_color"), SNAME("EditorHelp"), accent_color);
-	theme->set_color(SNAME("headline_color"), SNAME("EditorHelp"), mono_color);
-	theme->set_color(SNAME("text_color"), SNAME("EditorHelp"), font_color);
-	theme->set_color(SNAME("comment_color"), SNAME("EditorHelp"), font_color * Color(1, 1, 1, 0.6));
-	theme->set_color(SNAME("symbol_color"), SNAME("EditorHelp"), font_color * Color(1, 1, 1, 0.6));
-	theme->set_color(SNAME("value_color"), SNAME("EditorHelp"), font_color * Color(1, 1, 1, 0.6));
-	theme->set_color(SNAME("qualifier_color"), SNAME("EditorHelp"), font_color * Color(1, 1, 1, 0.8));
-	theme->set_color(SNAME("type_color"), SNAME("EditorHelp"), accent_color.lerp(font_color, 0.5));
-	theme->set_color(SNAME("selection_color"), SNAME("EditorHelp"), accent_color * Color(1, 1, 1, 0.4));
-	theme->set_color(SNAME("link_color"), SNAME("EditorHelp"), accent_color.lerp(mono_color, 0.8));
-	theme->set_color(SNAME("code_color"), SNAME("EditorHelp"), accent_color.lerp(mono_color, 0.6));
-	theme->set_color(SNAME("kbd_color"), SNAME("EditorHelp"), accent_color.lerp(property_color, 0.6));
-	theme->set_constant(SNAME("line_separation"), SNAME("EditorHelp"), Math::round(6 * EDSCALE));
-	theme->set_constant(SNAME("table_hseparation"), SNAME("EditorHelp"), 16 * EDSCALE);
-	theme->set_constant(SNAME("table_vseparation"), SNAME("EditorHelp"), 6 * EDSCALE);
+	theme->set_color("title_color", "EditorHelp", accent_color);
+	theme->set_color("headline_color", "EditorHelp", mono_color);
+	theme->set_color("text_color", "EditorHelp", font_color);
+	theme->set_color("comment_color", "EditorHelp", font_color * Color(1, 1, 1, 0.6));
+	theme->set_color("symbol_color", "EditorHelp", font_color * Color(1, 1, 1, 0.6));
+	theme->set_color("value_color", "EditorHelp", font_color * Color(1, 1, 1, 0.6));
+	theme->set_color("qualifier_color", "EditorHelp", font_color * Color(1, 1, 1, 0.8));
+	theme->set_color("type_color", "EditorHelp", accent_color.lerp(font_color, 0.5));
+	theme->set_color("selection_color", "EditorHelp", accent_color * Color(1, 1, 1, 0.4));
+	theme->set_color("link_color", "EditorHelp", accent_color.lerp(mono_color, 0.8));
+	theme->set_color("code_color", "EditorHelp", accent_color.lerp(mono_color, 0.6));
+	theme->set_color("kbd_color", "EditorHelp", accent_color.lerp(property_color, 0.6));
+	theme->set_constant("line_separation", "EditorHelp", Math::round(6 * EDSCALE));
+	theme->set_constant("table_hseparation", "EditorHelp", 16 * EDSCALE);
+	theme->set_constant("table_vseparation", "EditorHelp", 6 * EDSCALE);
 
 	// Panel
-	theme->set_stylebox(SNAME("panel"), SNAME("Panel"), make_flat_stylebox(dark_color_1, 6, 4, 6, 4, corner_width));
-	theme->set_stylebox(SNAME("PanelForeground"), SNAME("EditorStyles"), style_default);
+	theme->set_stylebox("panel", "Panel", make_flat_stylebox(dark_color_1, 6, 4, 6, 4, corner_width));
+	theme->set_stylebox("PanelForeground", "EditorStyles", style_default);
 
 	// Label
-	theme->set_stylebox(SNAME("normal"), SNAME("Label"), style_empty);
-	theme->set_color(SNAME("font_color"), SNAME("Label"), font_color);
-	theme->set_color(SNAME("font_shadow_color"), SNAME("Label"), Color(0, 0, 0, 0));
-	theme->set_constant(SNAME("shadow_offset_x"), SNAME("Label"), 1 * EDSCALE);
-	theme->set_constant(SNAME("shadow_offset_y"), SNAME("Label"), 1 * EDSCALE);
-	theme->set_constant(SNAME("shadow_outline_size"), SNAME("Label"), 1 * EDSCALE);
-	theme->set_constant(SNAME("line_spacing"), SNAME("Label"), 3 * EDSCALE);
+	theme->set_stylebox("normal", "Label", style_empty);
+	theme->set_color("font_color", "Label", font_color);
+	theme->set_color("font_shadow_color", "Label", Color(0, 0, 0, 0));
+	theme->set_constant("shadow_offset_x", "Label", 1 * EDSCALE);
+	theme->set_constant("shadow_offset_y", "Label", 1 * EDSCALE);
+	theme->set_constant("shadow_outline_size", "Label", 1 * EDSCALE);
+	theme->set_constant("line_spacing", "Label", 3 * EDSCALE);
 
 	// LinkButton
-	theme->set_stylebox(SNAME("focus"), SNAME("LinkButton"), style_empty);
-	theme->set_color(SNAME("font_color"), SNAME("LinkButton"), font_color);
-	theme->set_color(SNAME("font_hover_color"), SNAME("LinkButton"), font_hover_color);
-	theme->set_color(SNAME("font_focus_color"), SNAME("LinkButton"), font_focus_color);
-	theme->set_color(SNAME("font_pressed_color"), SNAME("LinkButton"), accent_color);
-	theme->set_color(SNAME("font_disabled_color"), SNAME("LinkButton"), font_disabled_color);
+	theme->set_stylebox("focus", "LinkButton", style_empty);
+	theme->set_color("font_color", "LinkButton", font_color);
+	theme->set_color("font_hover_color", "LinkButton", font_hover_color);
+	theme->set_color("font_focus_color", "LinkButton", font_focus_color);
+	theme->set_color("font_pressed_color", "LinkButton", accent_color);
+	theme->set_color("font_disabled_color", "LinkButton", font_disabled_color);
 
 	// TooltipPanel
 	Ref<StyleBoxFlat> style_tooltip = style_popup->duplicate();
@@ -1307,48 +1307,48 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_tooltip->set_default_margin(SIDE_BOTTOM, default_margin_size * EDSCALE * 0.5);
 	style_tooltip->set_bg_color(dark_color_3 * Color(0.8, 0.8, 0.8, 0.9));
 	style_tooltip->set_border_width_all(0);
-	theme->set_color(SNAME("font_color"), SNAME("TooltipLabel"), font_hover_color);
-	theme->set_color(SNAME("font_color_shadow"), SNAME("TooltipLabel"), Color(0, 0, 0, 0));
-	theme->set_stylebox(SNAME("panel"), SNAME("TooltipPanel"), style_tooltip);
+	theme->set_color("font_color", "TooltipLabel", font_hover_color);
+	theme->set_color("font_color_shadow", "TooltipLabel", Color(0, 0, 0, 0));
+	theme->set_stylebox("panel", "TooltipPanel", style_tooltip);
 
 	// PopupPanel
-	theme->set_stylebox(SNAME("panel"), SNAME("PopupPanel"), style_popup);
+	theme->set_stylebox("panel", "PopupPanel", style_popup);
 
 	// SpinBox
-	theme->set_icon(SNAME("updown"), SNAME("SpinBox"), theme->get_icon(SNAME("GuiSpinboxUpdown"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("updown_disabled"), SNAME("SpinBox"), theme->get_icon(SNAME("GuiSpinboxUpdownDisabled"), SNAME("EditorIcons")));
+	theme->set_icon("updown", "SpinBox", theme->get_icon(SNAME("GuiSpinboxUpdown"), SNAME("EditorIcons")));
+	theme->set_icon("updown_disabled", "SpinBox", theme->get_icon(SNAME("GuiSpinboxUpdownDisabled"), SNAME("EditorIcons")));
 
 	// ProgressBar
-	theme->set_stylebox(SNAME("bg"), SNAME("ProgressBar"), make_stylebox(theme->get_icon(SNAME("GuiProgressBar"), SNAME("EditorIcons")), 4, 4, 4, 4, 0, 0, 0, 0));
-	theme->set_stylebox(SNAME("fg"), SNAME("ProgressBar"), make_stylebox(theme->get_icon(SNAME("GuiProgressFill"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 1, 2, 1));
-	theme->set_color(SNAME("font_color"), SNAME("ProgressBar"), font_color);
+	theme->set_stylebox("bg", "ProgressBar", make_stylebox(theme->get_icon(SNAME("GuiProgressBar"), SNAME("EditorIcons")), 4, 4, 4, 4, 0, 0, 0, 0));
+	theme->set_stylebox("fg", "ProgressBar", make_stylebox(theme->get_icon(SNAME("GuiProgressFill"), SNAME("EditorIcons")), 6, 6, 6, 6, 2, 1, 2, 1));
+	theme->set_color("font_color", "ProgressBar", font_color);
 
 	// GraphEdit
-	theme->set_stylebox(SNAME("bg"), "GraphEdit", style_tree_bg);
+	theme->set_stylebox("bg", "GraphEdit", style_tree_bg);
 	if (dark_theme) {
-		theme->set_color(SNAME("grid_major"), SNAME("GraphEdit"), Color(1.0, 1.0, 1.0, 0.15));
-		theme->set_color(SNAME("grid_minor"), SNAME("GraphEdit"), Color(1.0, 1.0, 1.0, 0.07));
+		theme->set_color("grid_major", "GraphEdit", Color(1.0, 1.0, 1.0, 0.15));
+		theme->set_color("grid_minor", "GraphEdit", Color(1.0, 1.0, 1.0, 0.07));
 	} else {
-		theme->set_color(SNAME("grid_major"), SNAME("GraphEdit"), Color(0.0, 0.0, 0.0, 0.15));
-		theme->set_color(SNAME("grid_minor"), SNAME("GraphEdit"), Color(0.0, 0.0, 0.0, 0.07));
+		theme->set_color("grid_major", "GraphEdit", Color(0.0, 0.0, 0.0, 0.15));
+		theme->set_color("grid_minor", "GraphEdit", Color(0.0, 0.0, 0.0, 0.07));
 	}
-	theme->set_color(SNAME("selection_fill"), SNAME("GraphEdit"), theme->get_color(SNAME("box_selection_fill_color"), SNAME("Editor")));
-	theme->set_color(SNAME("selection_stroke"), SNAME("GraphEdit"), theme->get_color(SNAME("box_selection_stroke_color"), SNAME("Editor")));
-	theme->set_color(SNAME("activity"), SNAME("GraphEdit"), accent_color);
-	theme->set_icon(SNAME("minus"), SNAME("GraphEdit"), theme->get_icon(SNAME("ZoomLess"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("more"), SNAME("GraphEdit"), theme->get_icon(SNAME("ZoomMore"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("reset"), SNAME("GraphEdit"), theme->get_icon(SNAME("ZoomReset"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("snap"), SNAME("GraphEdit"), theme->get_icon(SNAME("SnapGrid"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("minimap"), SNAME("GraphEdit"), theme->get_icon(SNAME("GridMinimap"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("layout"), SNAME("GraphEdit"), theme->get_icon(SNAME("GridLayout"), SNAME("EditorIcons")));
-	theme->set_constant(SNAME("bezier_len_pos"), SNAME("GraphEdit"), 80 * EDSCALE);
-	theme->set_constant(SNAME("bezier_len_neg"), SNAME("GraphEdit"), 160 * EDSCALE);
+	theme->set_color("selection_fill", "GraphEdit", theme->get_color(SNAME("box_selection_fill_color"), SNAME("Editor")));
+	theme->set_color("selection_stroke", "GraphEdit", theme->get_color(SNAME("box_selection_stroke_color"), SNAME("Editor")));
+	theme->set_color("activity", "GraphEdit", accent_color);
+	theme->set_icon("minus", "GraphEdit", theme->get_icon(SNAME("ZoomLess"), SNAME("EditorIcons")));
+	theme->set_icon("more", "GraphEdit", theme->get_icon(SNAME("ZoomMore"), SNAME("EditorIcons")));
+	theme->set_icon("reset", "GraphEdit", theme->get_icon(SNAME("ZoomReset"), SNAME("EditorIcons")));
+	theme->set_icon("snap", "GraphEdit", theme->get_icon(SNAME("SnapGrid"), SNAME("EditorIcons")));
+	theme->set_icon("minimap", "GraphEdit", theme->get_icon(SNAME("GridMinimap"), SNAME("EditorIcons")));
+	theme->set_icon("layout", "GraphEdit", theme->get_icon(SNAME("GridLayout"), SNAME("EditorIcons")));
+	theme->set_constant("bezier_len_pos", "GraphEdit", 80 * EDSCALE);
+	theme->set_constant("bezier_len_neg", "GraphEdit", 160 * EDSCALE);
 
 	// GraphEditMinimap
 	Ref<StyleBoxFlat> style_minimap_bg = make_flat_stylebox(dark_color_1, 0, 0, 0, 0);
 	style_minimap_bg->set_border_color(dark_color_3);
 	style_minimap_bg->set_border_width_all(1);
-	theme->set_stylebox(SNAME("bg"), SNAME("GraphEditMinimap"), style_minimap_bg);
+	theme->set_stylebox("bg", "GraphEditMinimap", style_minimap_bg);
 
 	Ref<StyleBoxFlat> style_minimap_camera;
 	Ref<StyleBoxFlat> style_minimap_node;
@@ -1363,8 +1363,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	}
 	style_minimap_camera->set_border_width_all(1);
 	style_minimap_node->set_corner_radius_all(1);
-	theme->set_stylebox(SNAME("camera"), SNAME("GraphEditMinimap"), style_minimap_camera);
-	theme->set_stylebox(SNAME("node"), SNAME("GraphEditMinimap"), style_minimap_node);
+	theme->set_stylebox("camera", "GraphEditMinimap", style_minimap_camera);
+	theme->set_stylebox("node", "GraphEditMinimap", style_minimap_node);
 
 	Ref<Texture2D> minimap_resizer_icon = theme->get_icon(SNAME("GuiResizer"), SNAME("EditorIcons"));
 	Color minimap_resizer_color;
@@ -1373,8 +1373,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	} else {
 		minimap_resizer_color = Color(0, 0, 0, 0.65);
 	}
-	theme->set_icon(SNAME("resizer"), SNAME("GraphEditMinimap"), flip_icon(minimap_resizer_icon, true, true));
-	theme->set_color(SNAME("resizer_color"), SNAME("GraphEditMinimap"), minimap_resizer_color);
+	theme->set_icon("resizer", "GraphEditMinimap", flip_icon(minimap_resizer_icon, true, true));
+	theme->set_color("resizer_color", "GraphEditMinimap", minimap_resizer_color);
 
 	// GraphNode
 	const int gn_margin_side = 28;
@@ -1413,93 +1413,93 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	graphsbcomment->set_border_width(SIDE_TOP, 24 * EDSCALE);
 	graphsbcommentselected->set_border_width(SIDE_TOP, 24 * EDSCALE);
 
-	theme->set_stylebox(SNAME("frame"), SNAME("GraphNode"), graphsb);
-	theme->set_stylebox(SNAME("selectedframe"), SNAME("GraphNode"), graphsbselected);
-	theme->set_stylebox(SNAME("comment"), SNAME("GraphNode"), graphsbcomment);
-	theme->set_stylebox(SNAME("commentfocus"), SNAME("GraphNode"), graphsbcommentselected);
-	theme->set_stylebox(SNAME("breakpoint"), SNAME("GraphNode"), graphsbbreakpoint);
-	theme->set_stylebox(SNAME("position"), SNAME("GraphNode"), graphsbposition);
-	theme->set_stylebox(SNAME("state_machine_frame"), SNAME("GraphNode"), smgraphsb);
-	theme->set_stylebox(SNAME("state_machine_selectedframe"), SNAME("GraphNode"), smgraphsbselected);
+	theme->set_stylebox("frame", "GraphNode", graphsb);
+	theme->set_stylebox("selectedframe", "GraphNode", graphsbselected);
+	theme->set_stylebox("comment", "GraphNode", graphsbcomment);
+	theme->set_stylebox("commentfocus", "GraphNode", graphsbcommentselected);
+	theme->set_stylebox("breakpoint", "GraphNode", graphsbbreakpoint);
+	theme->set_stylebox("position", "GraphNode", graphsbposition);
+	theme->set_stylebox("state_machine_frame", "GraphNode", smgraphsb);
+	theme->set_stylebox("state_machine_selectedframe", "GraphNode", smgraphsbselected);
 
 	Color default_node_color = dark_color_1.inverted();
-	theme->set_color(SNAME("title_color"), SNAME("GraphNode"), default_node_color);
+	theme->set_color("title_color", "GraphNode", default_node_color);
 	default_node_color.a = 0.7;
-	theme->set_color(SNAME("close_color"), SNAME("GraphNode"), default_node_color);
-	theme->set_color(SNAME("resizer_color"), SNAME("GraphNode"), default_node_color);
+	theme->set_color("close_color", "GraphNode", default_node_color);
+	theme->set_color("resizer_color", "GraphNode", default_node_color);
 
-	theme->set_constant(SNAME("port_offset"), SNAME("GraphNode"), 14 * EDSCALE);
-	theme->set_constant(SNAME("title_h_offset"), SNAME("GraphNode"), -16 * EDSCALE);
-	theme->set_constant(SNAME("title_offset"), SNAME("GraphNode"), 20 * EDSCALE);
-	theme->set_constant(SNAME("close_h_offset"), SNAME("GraphNode"), 20 * EDSCALE);
-	theme->set_constant(SNAME("close_offset"), SNAME("GraphNode"), 20 * EDSCALE);
-	theme->set_constant(SNAME("separation"), SNAME("GraphNode"), 1 * EDSCALE);
+	theme->set_constant("port_offset", "GraphNode", 14 * EDSCALE);
+	theme->set_constant("title_h_offset", "GraphNode", -16 * EDSCALE);
+	theme->set_constant("title_offset", "GraphNode", 20 * EDSCALE);
+	theme->set_constant("close_h_offset", "GraphNode", 20 * EDSCALE);
+	theme->set_constant("close_offset", "GraphNode", 20 * EDSCALE);
+	theme->set_constant("separation", "GraphNode", 1 * EDSCALE);
 
-	theme->set_icon(SNAME("close"), SNAME("GraphNode"), theme->get_icon(SNAME("GuiCloseCustomizable"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("resizer"), SNAME("GraphNode"), theme->get_icon(SNAME("GuiResizer"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("port"), SNAME("GraphNode"), theme->get_icon(SNAME("GuiGraphNodePort"), SNAME("EditorIcons")));
+	theme->set_icon("close", "GraphNode", theme->get_icon(SNAME("GuiCloseCustomizable"), SNAME("EditorIcons")));
+	theme->set_icon("resizer", "GraphNode", theme->get_icon(SNAME("GuiResizer"), SNAME("EditorIcons")));
+	theme->set_icon("port", "GraphNode", theme->get_icon(SNAME("GuiGraphNodePort"), SNAME("EditorIcons")));
 
 	// GridContainer
-	theme->set_constant(SNAME("vseparation"), SNAME("GridContainer"), Math::round(widget_default_margin.y - 2 * EDSCALE));
+	theme->set_constant("vseparation", "GridContainer", Math::round(widget_default_margin.y - 2 * EDSCALE));
 
 	// FileDialog
-	theme->set_icon(SNAME("folder"), SNAME("FileDialog"), theme->get_icon(SNAME("Folder"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("parent_folder"), SNAME("FileDialog"), theme->get_icon(SNAME("ArrowUp"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("back_folder"), SNAME("FileDialog"), theme->get_icon(SNAME("Back"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("forward_folder"), SNAME("FileDialog"), theme->get_icon(SNAME("Forward"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("reload"), SNAME("FileDialog"), theme->get_icon(SNAME("Reload"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("toggle_hidden"), SNAME("FileDialog"), theme->get_icon(SNAME("GuiVisibilityVisible"), SNAME("EditorIcons")));
+	theme->set_icon("folder", "FileDialog", theme->get_icon(SNAME("Folder"), SNAME("EditorIcons")));
+	theme->set_icon("parent_folder", "FileDialog", theme->get_icon(SNAME("ArrowUp"), SNAME("EditorIcons")));
+	theme->set_icon("back_folder", "FileDialog", theme->get_icon(SNAME("Back"), SNAME("EditorIcons")));
+	theme->set_icon("forward_folder", "FileDialog", theme->get_icon(SNAME("Forward"), SNAME("EditorIcons")));
+	theme->set_icon("reload", "FileDialog", theme->get_icon(SNAME("Reload"), SNAME("EditorIcons")));
+	theme->set_icon("toggle_hidden", "FileDialog", theme->get_icon(SNAME("GuiVisibilityVisible"), SNAME("EditorIcons")));
 	// Use a different color for folder icons to make them easier to distinguish from files.
 	// On a light theme, the icon will be dark, so we need to lighten it before blending it with the accent color.
-	theme->set_color(SNAME("folder_icon_modulate"), SNAME("FileDialog"), (dark_theme ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25)).lerp(accent_color, 0.7));
-	theme->set_color(SNAME("files_disabled"), SNAME("FileDialog"), font_disabled_color);
+	theme->set_color("folder_icon_modulate", "FileDialog", (dark_theme ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25)).lerp(accent_color, 0.7));
+	theme->set_color("files_disabled", "FileDialog", font_disabled_color);
 
 	// ColorPicker
-	theme->set_constant(SNAME("margin"), SNAME("ColorPicker"), popup_margin_size);
-	theme->set_constant(SNAME("sv_width"), SNAME("ColorPicker"), 256 * EDSCALE);
-	theme->set_constant(SNAME("sv_height"), SNAME("ColorPicker"), 256 * EDSCALE);
-	theme->set_constant(SNAME("h_width"), SNAME("ColorPicker"), 30 * EDSCALE);
-	theme->set_constant(SNAME("label_width"), SNAME("ColorPicker"), 10 * EDSCALE);
-	theme->set_icon(SNAME("screen_picker"), SNAME("ColorPicker"), theme->get_icon(SNAME("ColorPick"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("add_preset"), SNAME("ColorPicker"), theme->get_icon(SNAME("Add"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("sample_bg"), SNAME("ColorPicker"), theme->get_icon(SNAME("GuiMiniCheckerboard"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("overbright_indicator"), SNAME("ColorPicker"), theme->get_icon(SNAME("OverbrightIndicator"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("bar_arrow"), SNAME("ColorPicker"), theme->get_icon(SNAME("ColorPickerBarArrow"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("picker_cursor"), SNAME("ColorPicker"), theme->get_icon(SNAME("PickerCursor"), SNAME("EditorIcons")));
+	theme->set_constant("margin", "ColorPicker", popup_margin_size);
+	theme->set_constant("sv_width", "ColorPicker", 256 * EDSCALE);
+	theme->set_constant("sv_height", "ColorPicker", 256 * EDSCALE);
+	theme->set_constant("h_width", "ColorPicker", 30 * EDSCALE);
+	theme->set_constant("label_width", "ColorPicker", 10 * EDSCALE);
+	theme->set_icon("screen_picker", "ColorPicker", theme->get_icon(SNAME("ColorPick"), SNAME("EditorIcons")));
+	theme->set_icon("add_preset", "ColorPicker", theme->get_icon(SNAME("Add"), SNAME("EditorIcons")));
+	theme->set_icon("sample_bg", "ColorPicker", theme->get_icon(SNAME("GuiMiniCheckerboard"), SNAME("EditorIcons")));
+	theme->set_icon("overbright_indicator", "ColorPicker", theme->get_icon(SNAME("OverbrightIndicator"), SNAME("EditorIcons")));
+	theme->set_icon("bar_arrow", "ColorPicker", theme->get_icon(SNAME("ColorPickerBarArrow"), SNAME("EditorIcons")));
+	theme->set_icon("picker_cursor", "ColorPicker", theme->get_icon(SNAME("PickerCursor"), SNAME("EditorIcons")));
 
 	// ColorPickerButton
-	theme->set_icon(SNAME("bg"), SNAME("ColorPickerButton"), theme->get_icon(SNAME("GuiMiniCheckerboard"), SNAME("EditorIcons")));
+	theme->set_icon("bg", "ColorPickerButton", theme->get_icon(SNAME("GuiMiniCheckerboard"), SNAME("EditorIcons")));
 
 	// ColorPresetButton
 	Ref<StyleBoxFlat> preset_sb = make_flat_stylebox(Color(1, 1, 1), 2, 2, 2, 2, 2);
 	preset_sb->set_anti_aliased(false);
-	theme->set_stylebox(SNAME("preset_fg"), SNAME("ColorPresetButton"), preset_sb);
-	theme->set_icon(SNAME("preset_bg"), SNAME("ColorPresetButton"), theme->get_icon(SNAME("GuiMiniCheckerboard"), SNAME("EditorIcons")));
-	theme->set_icon(SNAME("overbright_indicator"), SNAME("ColorPresetButton"), theme->get_icon(SNAME("OverbrightIndicator"), SNAME("EditorIcons")));
+	theme->set_stylebox("preset_fg", "ColorPresetButton", preset_sb);
+	theme->set_icon("preset_bg", "ColorPresetButton", theme->get_icon(SNAME("GuiMiniCheckerboard"), SNAME("EditorIcons")));
+	theme->set_icon("overbright_indicator", "ColorPresetButton", theme->get_icon(SNAME("OverbrightIndicator"), SNAME("EditorIcons")));
 
 	// Information on 3D viewport
 	Ref<StyleBoxFlat> style_info_3d_viewport = style_default->duplicate();
 	style_info_3d_viewport->set_bg_color(style_info_3d_viewport->get_bg_color() * Color(1, 1, 1, 0.5));
 	style_info_3d_viewport->set_border_width_all(0);
-	theme->set_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles"), style_info_3d_viewport);
+	theme->set_stylebox("Information3dViewport", "EditorStyles", style_info_3d_viewport);
 
 	// Asset Library.
-	theme->set_stylebox(SNAME("panel"), SNAME("AssetLib"), style_content_panel);
-	theme->set_color(SNAME("status_color"), SNAME("AssetLib"), Color(0.5, 0.5, 0.5));
-	theme->set_icon(SNAME("dismiss"), SNAME("AssetLib"), theme->get_icon(SNAME("Close"), SNAME("EditorIcons")));
+	theme->set_stylebox("panel", "AssetLib", style_content_panel);
+	theme->set_color("status_color", "AssetLib", Color(0.5, 0.5, 0.5));
+	theme->set_icon("dismiss", "AssetLib", theme->get_icon(SNAME("Close"), SNAME("EditorIcons")));
 
 	// Theme editor.
-	theme->set_color(SNAME("preview_picker_overlay_color"), SNAME("ThemeEditor"), Color(0.1, 0.1, 0.1, 0.25));
+	theme->set_color("preview_picker_overlay_color", "ThemeEditor", Color(0.1, 0.1, 0.1, 0.25));
 	Color theme_preview_picker_bg_color = accent_color;
 	theme_preview_picker_bg_color.a = 0.2;
 	Ref<StyleBoxFlat> theme_preview_picker_sb = make_flat_stylebox(theme_preview_picker_bg_color, 0, 0, 0, 0);
 	theme_preview_picker_sb->set_border_color(accent_color);
 	theme_preview_picker_sb->set_border_width_all(1.0 * EDSCALE);
-	theme->set_stylebox(SNAME("preview_picker_overlay"), SNAME("ThemeEditor"), theme_preview_picker_sb);
+	theme->set_stylebox("preview_picker_overlay", "ThemeEditor", theme_preview_picker_sb);
 	Color theme_preview_picker_label_bg_color = accent_color;
 	theme_preview_picker_label_bg_color.set_v(0.5);
 	Ref<StyleBoxFlat> theme_preview_picker_label_sb = make_flat_stylebox(theme_preview_picker_label_bg_color, 4.0, 1.0, 4.0, 3.0);
-	theme->set_stylebox(SNAME("preview_picker_label"), SNAME("ThemeEditor"), theme_preview_picker_label_sb);
+	theme->set_stylebox("preview_picker_label", "ThemeEditor", theme_preview_picker_label_sb);
 
 	// adaptive script theme constants
 	// for comments and elements with lower relevance
@@ -1593,27 +1593,27 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	}
 
 	// Now theme is loaded, apply it to CodeEdit.
-	theme->set_color(SNAME("background_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/background_color"));
-	theme->set_color(SNAME("completion_background_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/completion_background_color"));
-	theme->set_color(SNAME("completion_selected_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/completion_selected_color"));
-	theme->set_color(SNAME("completion_existing_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/completion_existing_color"));
-	theme->set_color(SNAME("completion_scroll_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/completion_scroll_color"));
-	theme->set_color(SNAME("completion_font_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/completion_font_color"));
-	theme->set_color(SNAME("font_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/text_color"));
-	theme->set_color(SNAME("line_number_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/line_number_color"));
-	theme->set_color(SNAME("caret_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/caret_color"));
-	theme->set_color(SNAME("font_selected_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/text_selected_color"));
-	theme->set_color(SNAME("selection_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/selection_color"));
-	theme->set_color(SNAME("brace_mismatch_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/brace_mismatch_color"));
-	theme->set_color(SNAME("current_line_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/current_line_color"));
-	theme->set_color(SNAME("line_length_guideline_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/line_length_guideline_color"));
-	theme->set_color(SNAME("word_highlighted_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/word_highlighted_color"));
-	theme->set_color(SNAME("bookmark_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/bookmark_color"));
-	theme->set_color(SNAME("breakpoint_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/breakpoint_color"));
-	theme->set_color(SNAME("executing_line_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/executing_line_color"));
-	theme->set_color(SNAME("code_folding_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/code_folding_color"));
-	theme->set_color(SNAME("search_result_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/search_result_color"));
-	theme->set_color(SNAME("search_result_border_color"), SNAME("CodeEdit"), EDITOR_GET("text_editor/theme/highlighting/search_result_border_color"));
+	theme->set_color("background_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/background_color"));
+	theme->set_color("completion_background_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/completion_background_color"));
+	theme->set_color("completion_selected_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/completion_selected_color"));
+	theme->set_color("completion_existing_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/completion_existing_color"));
+	theme->set_color("completion_scroll_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/completion_scroll_color"));
+	theme->set_color("completion_font_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/completion_font_color"));
+	theme->set_color("font_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/text_color"));
+	theme->set_color("line_number_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/line_number_color"));
+	theme->set_color("caret_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/caret_color"));
+	theme->set_color("font_selected_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/text_selected_color"));
+	theme->set_color("selection_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/selection_color"));
+	theme->set_color("brace_mismatch_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/brace_mismatch_color"));
+	theme->set_color("current_line_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/current_line_color"));
+	theme->set_color("line_length_guideline_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/line_length_guideline_color"));
+	theme->set_color("word_highlighted_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/word_highlighted_color"));
+	theme->set_color("bookmark_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/bookmark_color"));
+	theme->set_color("breakpoint_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/breakpoint_color"));
+	theme->set_color("executing_line_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/executing_line_color"));
+	theme->set_color("code_folding_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/code_folding_color"));
+	theme->set_color("search_result_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/search_result_color"));
+	theme->set_color("search_result_border_color", "CodeEdit", EDITOR_GET("text_editor/theme/highlighting/search_result_border_color"));
 
 	return theme;
 }

--- a/editor/editor_toaster.cpp
+++ b/editor/editor_toaster.cpp
@@ -113,22 +113,22 @@ void EditorToaster::_notification(int p_what) {
 			disable_notifications_button->set_icon(get_theme_icon(SNAME("NotificationDisabled"), SNAME("EditorIcons")));
 
 			// Styleboxes background.
-			info_panel_style_background->set_bg_color(get_theme_color("base_color", "Editor"));
+			info_panel_style_background->set_bg_color(get_theme_color(SNAME("base_color"), SNAME("Editor")));
 
-			warning_panel_style_background->set_bg_color(get_theme_color("base_color", "Editor"));
-			warning_panel_style_background->set_border_color(get_theme_color("warning_color", "Editor"));
+			warning_panel_style_background->set_bg_color(get_theme_color(SNAME("base_color"), SNAME("Editor")));
+			warning_panel_style_background->set_border_color(get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 
-			error_panel_style_background->set_bg_color(get_theme_color("base_color", "Editor"));
-			error_panel_style_background->set_border_color(get_theme_color("error_color", "Editor"));
+			error_panel_style_background->set_bg_color(get_theme_color(SNAME("base_color"), SNAME("Editor")));
+			error_panel_style_background->set_border_color(get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
 			// Styleboxes progress.
-			info_panel_style_progress->set_bg_color(get_theme_color("base_color", "Editor").lightened(0.03));
+			info_panel_style_progress->set_bg_color(get_theme_color(SNAME("base_color"), SNAME("Editor")).lightened(0.03));
 
-			warning_panel_style_progress->set_bg_color(get_theme_color("base_color", "Editor").lightened(0.03));
-			warning_panel_style_progress->set_border_color(get_theme_color("warning_color", "Editor"));
+			warning_panel_style_progress->set_bg_color(get_theme_color(SNAME("base_color"), SNAME("Editor")).lightened(0.03));
+			warning_panel_style_progress->set_border_color(get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 
-			error_panel_style_progress->set_bg_color(get_theme_color("base_color", "Editor").lightened(0.03));
-			error_panel_style_progress->set_border_color(get_theme_color("error_color", "Editor"));
+			error_panel_style_progress->set_bg_color(get_theme_color(SNAME("base_color"), SNAME("Editor")).lightened(0.03));
+			error_panel_style_progress->set_border_color(get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
 			main_button->update();
 			disable_notifications_button->update();
@@ -256,13 +256,13 @@ void EditorToaster::_draw_button() {
 	real_t button_radius = main_button->get_size().x / 8;
 	switch (highest_severity) {
 		case SEVERITY_INFO:
-			color = get_theme_color("accent_color", "Editor");
+			color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			break;
 		case SEVERITY_WARNING:
-			color = get_theme_color("warning_color", "Editor");
+			color = get_theme_color(SNAME("warning_color"), SNAME("Editor"));
 			break;
 		case SEVERITY_ERROR:
-			color = get_theme_color("error_color", "Editor");
+			color = get_theme_color(SNAME("error_color"), SNAME("Editor"));
 			break;
 		default:
 			break;
@@ -360,7 +360,7 @@ Control *EditorToaster::popup(Control *p_control, Severity p_severity, double p_
 	if (p_time > 0.0) {
 		Button *close_button = memnew(Button);
 		close_button->set_flat(true);
-		close_button->set_icon(get_theme_icon("Close", "EditorIcons"));
+		close_button->set_icon(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
 		close_button->connect("pressed", callable_bind(callable_mp(this, &EditorToaster::close), panel));
 		close_button->connect("theme_changed", callable_bind(callable_mp(this, &EditorToaster::_close_button_theme_changed), close_button));
 		hbox_container->add_child(close_button);
@@ -442,7 +442,7 @@ void EditorToaster::close(Control *p_control) {
 void EditorToaster::_close_button_theme_changed(Control *p_close_button) {
 	Button *close_button = Object::cast_to<Button>(p_close_button);
 	if (close_button) {
-		close_button->set_icon(get_theme_icon("Close", "EditorIcons"));
+		close_button->set_icon(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
 	}
 }
 

--- a/editor/editor_toaster.cpp
+++ b/editor/editor_toaster.cpp
@@ -113,22 +113,22 @@ void EditorToaster::_notification(int p_what) {
 			disable_notifications_button->set_icon(get_theme_icon(SNAME("NotificationDisabled"), SNAME("EditorIcons")));
 
 			// Styleboxes background.
-			info_panel_style_background->set_bg_color(get_theme_color(SNAME("base_color"), SNAME("Editor")));
+			info_panel_style_background->set_bg_color(get_theme_color("base_color", "Editor"));
 
-			warning_panel_style_background->set_bg_color(get_theme_color(SNAME("base_color"), SNAME("Editor")));
-			warning_panel_style_background->set_border_color(get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+			warning_panel_style_background->set_bg_color(get_theme_color("base_color", "Editor"));
+			warning_panel_style_background->set_border_color(get_theme_color("warning_color", "Editor"));
 
-			error_panel_style_background->set_bg_color(get_theme_color(SNAME("base_color"), SNAME("Editor")));
-			error_panel_style_background->set_border_color(get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			error_panel_style_background->set_bg_color(get_theme_color("base_color", "Editor"));
+			error_panel_style_background->set_border_color(get_theme_color("error_color", "Editor"));
 
 			// Styleboxes progress.
-			info_panel_style_progress->set_bg_color(get_theme_color(SNAME("base_color"), SNAME("Editor")).lightened(0.03));
+			info_panel_style_progress->set_bg_color(get_theme_color("base_color", "Editor").lightened(0.03));
 
-			warning_panel_style_progress->set_bg_color(get_theme_color(SNAME("base_color"), SNAME("Editor")).lightened(0.03));
-			warning_panel_style_progress->set_border_color(get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+			warning_panel_style_progress->set_bg_color(get_theme_color("base_color", "Editor").lightened(0.03));
+			warning_panel_style_progress->set_border_color(get_theme_color("warning_color", "Editor"));
 
-			error_panel_style_progress->set_bg_color(get_theme_color(SNAME("base_color"), SNAME("Editor")).lightened(0.03));
-			error_panel_style_progress->set_border_color(get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			error_panel_style_progress->set_bg_color(get_theme_color("base_color", "Editor").lightened(0.03));
+			error_panel_style_progress->set_border_color(get_theme_color("error_color", "Editor"));
 
 			main_button->update();
 			disable_notifications_button->update();
@@ -256,13 +256,13 @@ void EditorToaster::_draw_button() {
 	real_t button_radius = main_button->get_size().x / 8;
 	switch (highest_severity) {
 		case SEVERITY_INFO:
-			color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
+			color = get_theme_color("accent_color", "Editor");
 			break;
 		case SEVERITY_WARNING:
-			color = get_theme_color(SNAME("warning_color"), SNAME("Editor"));
+			color = get_theme_color("warning_color", "Editor");
 			break;
 		case SEVERITY_ERROR:
-			color = get_theme_color(SNAME("error_color"), SNAME("Editor"));
+			color = get_theme_color("error_color", "Editor");
 			break;
 		default:
 			break;
@@ -333,13 +333,13 @@ Control *EditorToaster::popup(Control *p_control, Severity p_severity, double p_
 	panel->set_tooltip(p_tooltip);
 	switch (p_severity) {
 		case SEVERITY_INFO:
-			panel->add_theme_style_override(SNAME("panel"), info_panel_style_background);
+			panel->add_theme_style_override("panel", info_panel_style_background);
 			break;
 		case SEVERITY_WARNING:
-			panel->add_theme_style_override(SNAME("panel"), warning_panel_style_background);
+			panel->add_theme_style_override("panel", warning_panel_style_background);
 			break;
 		case SEVERITY_ERROR:
-			panel->add_theme_style_override(SNAME("panel"), error_panel_style_background);
+			panel->add_theme_style_override("panel", error_panel_style_background);
 			break;
 		default:
 			break;
@@ -360,7 +360,7 @@ Control *EditorToaster::popup(Control *p_control, Severity p_severity, double p_
 	if (p_time > 0.0) {
 		Button *close_button = memnew(Button);
 		close_button->set_flat(true);
-		close_button->set_icon(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+		close_button->set_icon(get_theme_icon("Close", "EditorIcons"));
 		close_button->connect("pressed", callable_bind(callable_mp(this, &EditorToaster::close), panel));
 		close_button->connect("theme_changed", callable_bind(callable_mp(this, &EditorToaster::_close_button_theme_changed), close_button));
 		hbox_container->add_child(close_button);
@@ -442,7 +442,7 @@ void EditorToaster::close(Control *p_control) {
 void EditorToaster::_close_button_theme_changed(Control *p_close_button) {
 	Button *close_button = Object::cast_to<Button>(p_close_button);
 	if (close_button) {
-		close_button->set_icon(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+		close_button->set_icon(get_theme_icon("Close", "EditorIcons"));
 	}
 }
 
@@ -508,7 +508,7 @@ EditorToaster::EditorToaster() {
 	// Disable notification button.
 	disable_notifications_panel = memnew(PanelContainer);
 	disable_notifications_panel->set_as_top_level(true);
-	disable_notifications_panel->add_theme_style_override(SNAME("panel"), info_panel_style_background);
+	disable_notifications_panel->add_theme_style_override("panel", info_panel_style_background);
 	add_child(disable_notifications_panel);
 
 	disable_notifications_button = memnew(Button);

--- a/editor/editor_zoom_widget.cpp
+++ b/editor/editor_zoom_widget.cpp
@@ -176,9 +176,9 @@ EditorZoomWidget::EditorZoomWidget() {
 	zoom_reset = memnew(Button);
 	zoom_reset->set_flat(true);
 	add_child(zoom_reset);
-	zoom_reset->add_theme_constant_override(SNAME("outline_size"), 1);
-	zoom_reset->add_theme_color_override(SNAME("font_outline_color"), Color(0, 0, 0));
-	zoom_reset->add_theme_color_override(SNAME("font_color"), Color(1, 1, 1));
+	zoom_reset->add_theme_constant_override("outline_size", 1);
+	zoom_reset->add_theme_color_override("font_outline_color", Color(0, 0, 0));
+	zoom_reset->add_theme_color_override("font_color", Color(1, 1, 1));
 	zoom_reset->connect("pressed", callable_mp(this, &EditorZoomWidget::_button_zoom_reset));
 	zoom_reset->set_shortcut(ED_SHORTCUT("canvas_item_editor/zoom_reset", TTR("Zoom Reset"), KeyModifierMask::CMD | Key::KEY_0));
 	zoom_reset->set_shortcut_context(this);
@@ -197,5 +197,5 @@ EditorZoomWidget::EditorZoomWidget() {
 
 	_update_zoom_label();
 
-	add_theme_constant_override(SNAME("separation"), Math::round(-8 * EDSCALE));
+	add_theme_constant_override("separation", Math::round(-8 * EDSCALE));
 }

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -357,9 +357,9 @@ void ExportTemplateManager::_set_current_progress_status(const String &p_status,
 	download_progress_label->set_text(p_status);
 
 	if (p_error) {
-		download_progress_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		download_progress_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	} else {
-		download_progress_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("font_color"), SNAME("Label")));
+		download_progress_label->add_theme_color_override("font_color", get_theme_color(SNAME("font_color"), SNAME("Label")));
 	}
 }
 
@@ -744,9 +744,9 @@ void ExportTemplateManager::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			current_value->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("main"), SNAME("EditorFonts")));
-			current_missing_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
-			current_installed_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
+			current_value->add_theme_font_override("font", get_theme_font(SNAME("main"), SNAME("EditorFonts")));
+			current_missing_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			current_installed_label->add_theme_color_override("font_color", get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
 
 			mirror_options_button->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 		} break;

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2834,7 +2834,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	add_child(top_vbc);
 
 	HBoxContainer *toolbar_hbc = memnew(HBoxContainer);
-	toolbar_hbc->add_theme_constant_override(SNAME("separation"), 0);
+	toolbar_hbc->add_theme_constant_override("separation", 0);
 	top_vbc->add_child(toolbar_hbc);
 
 	button_hist_prev = memnew(Button);
@@ -2873,7 +2873,7 @@ FileSystemDock::FileSystemDock(EditorNode *p_editor) {
 	toolbar_hbc->add_child(button_toggle_display_mode);
 
 	toolbar2_hbc = memnew(HBoxContainer);
-	toolbar2_hbc->add_theme_constant_override(SNAME("separation"), 0);
+	toolbar2_hbc->add_theme_constant_override("separation", 0);
 	top_vbc->add_child(toolbar2_hbc);
 
 	tree_search_box = memnew(LineEdit);

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -567,8 +567,8 @@ FindInFilesPanel::FindInFilesPanel() {
 		hbc->add_child(find_label);
 
 		_search_text_label = memnew(Label);
-		_search_text_label->add_theme_font_override(SNAME("font"), EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("source"), SNAME("EditorFonts")));
-		_search_text_label->add_theme_font_size_override(SNAME("font_size"), EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("source_size"), SNAME("EditorFonts")));
+		_search_text_label->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("source"), SNAME("EditorFonts")));
+		_search_text_label->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("source_size"), SNAME("EditorFonts")));
 		hbc->add_child(_search_text_label);
 
 		_progress_bar = memnew(ProgressBar);
@@ -596,8 +596,8 @@ FindInFilesPanel::FindInFilesPanel() {
 	}
 
 	_results_display = memnew(Tree);
-	_results_display->add_theme_font_override(SNAME("font"), EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("source"), SNAME("EditorFonts")));
-	_results_display->add_theme_font_size_override(SNAME("font_size"), EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("source_size"), SNAME("EditorFonts")));
+	_results_display->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("source"), SNAME("EditorFonts")));
+	_results_display->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("source_size"), SNAME("EditorFonts")));
 	_results_display->set_v_size_flags(SIZE_EXPAND_FILL);
 	_results_display->connect("item_selected", callable_mp(this, &FindInFilesPanel::_on_result_selected));
 	_results_display->connect("item_edited", callable_mp(this, &FindInFilesPanel::_on_item_edited));
@@ -689,8 +689,8 @@ void FindInFilesPanel::_notification(int p_what) {
 	if (p_what == NOTIFICATION_PROCESS) {
 		_progress_bar->set_as_ratio(_finder->get_progress());
 	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
-		_search_text_label->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("source"), SNAME("EditorFonts")));
-		_results_display->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("source"), SNAME("EditorFonts")));
+		_search_text_label->add_theme_font_override("font", get_theme_font(SNAME("source"), SNAME("EditorFonts")));
+		_results_display->add_theme_font_override("font", get_theme_font(SNAME("source"), SNAME("EditorFonts")));
 	}
 }
 

--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -448,7 +448,7 @@ GroupDialog::GroupDialog() {
 	groups->set_allow_reselect(true);
 	groups->set_allow_rmb_select(true);
 	groups->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	groups->add_theme_constant_override(SNAME("draw_guides"), 1);
+	groups->add_theme_constant_override("draw_guides", 1);
 	groups->connect("item_selected", callable_mp(this, &GroupDialog::_group_selected));
 	groups->connect("button_pressed", callable_mp(this, &GroupDialog::_modify_group_pressed));
 	groups->connect("item_edited", callable_mp(this, &GroupDialog::_group_renamed));
@@ -484,10 +484,10 @@ GroupDialog::GroupDialog() {
 	nodes_to_add->set_hide_folding(true);
 	nodes_to_add->set_select_mode(Tree::SELECT_MULTI);
 	nodes_to_add->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	nodes_to_add->add_theme_constant_override(SNAME("draw_guides"), 1);
+	nodes_to_add->add_theme_constant_override("draw_guides", 1);
 
 	HBoxContainer *add_filter_hbc = memnew(HBoxContainer);
-	add_filter_hbc->add_theme_constant_override(SNAME("separate"), 0);
+	add_filter_hbc->add_theme_constant_override("separate", 0);
 	vbc_add->add_child(add_filter_hbc);
 
 	add_filter = memnew(LineEdit);
@@ -534,10 +534,10 @@ GroupDialog::GroupDialog() {
 	nodes_to_remove->set_hide_root(true);
 	nodes_to_remove->set_hide_folding(true);
 	nodes_to_remove->set_select_mode(Tree::SELECT_MULTI);
-	nodes_to_remove->add_theme_constant_override(SNAME("draw_guides"), 1);
+	nodes_to_remove->add_theme_constant_override("draw_guides", 1);
 
 	HBoxContainer *remove_filter_hbc = memnew(HBoxContainer);
-	remove_filter_hbc->add_theme_constant_override(SNAME("separate"), 0);
+	remove_filter_hbc->add_theme_constant_override("separate", 0);
 	vbc_remove->add_child(remove_filter_hbc);
 
 	remove_filter = memnew(LineEdit);
@@ -733,8 +733,8 @@ GroupsEditor::GroupsEditor() {
 	tree->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	vbc->add_child(tree);
 	tree->connect("button_pressed", callable_mp(this, &GroupsEditor::_modify_group));
-	tree->add_theme_constant_override(SNAME("draw_guides"), 1);
-	add_theme_constant_override(SNAME("separation"), 3 * EDSCALE);
+	tree->add_theme_constant_override("draw_guides", 1);
+	add_theme_constant_override("separation", 3 * EDSCALE);
 
 	_group_name_changed("");
 }

--- a/editor/import/dynamicfont_import_settings.cpp
+++ b/editor/import/dynamicfont_import_settings.cpp
@@ -495,7 +495,7 @@ void DynamicFontImportSettings::_variation_add() {
 
 	vars_item->set_text(0, TTR("New configuration"));
 	vars_item->set_editable(0, true);
-	vars_item->add_button(1, vars_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove Variation"));
+	vars_item->add_button(1, vars_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove Variation"));
 	vars_item->set_button_color(1, 0, Color(1, 1, 1, 0.75));
 
 	Ref<DynamicFontImportSettingsData> import_variation_data;
@@ -643,8 +643,8 @@ void DynamicFontImportSettings::_glyph_selected() {
 	TreeItem *item = glyph_table->get_selected();
 	ERR_FAIL_NULL(item);
 
-	Color scol = glyph_table->get_theme_color("box_selection_fill_color", "Editor");
-	Color fcol = glyph_table->get_theme_color("font_selected_color", "Editor");
+	Color scol = glyph_table->get_theme_color(SNAME("box_selection_fill_color"), SNAME("Editor"));
+	Color fcol = glyph_table->get_theme_color(SNAME("font_selected_color"), SNAME("Editor"));
 	scol.a = 1.f;
 
 	int32_t c = item->get_metadata(glyph_table->get_selected_column());
@@ -705,8 +705,8 @@ void DynamicFontImportSettings::_edit_range(int32_t p_start, int32_t p_end) {
 	TreeItem *root = glyph_table->create_item();
 	ERR_FAIL_NULL(root);
 
-	Color scol = glyph_table->get_theme_color("box_selection_fill_color", "Editor");
-	Color fcol = glyph_table->get_theme_color("font_selected_color", "Editor");
+	Color scol = glyph_table->get_theme_color(SNAME("box_selection_fill_color"), SNAME("Editor"));
+	Color fcol = glyph_table->get_theme_color(SNAME("font_selected_color"), SNAME("Editor"));
 	scol.a = 1.f;
 
 	TreeItem *item = nullptr;
@@ -719,12 +719,12 @@ void DynamicFontImportSettings::_edit_range(int32_t p_start, int32_t p_end) {
 			item->set_text(0, _pad_zeros(String::num_int64(c, 16)));
 			item->set_text_alignment(0, HORIZONTAL_ALIGNMENT_LEFT);
 			item->set_selectable(0, false);
-			item->set_custom_bg_color(0, glyph_table->get_theme_color("dark_color_3", "Editor"));
+			item->set_custom_bg_color(0, glyph_table->get_theme_color(SNAME("dark_color_3"), SNAME("Editor")));
 		}
 		if (font_main->has_char(c)) {
 			item->set_text(col + 1, String::chr(c));
 			item->set_custom_color(col + 1, Color(1, 1, 1));
-			if (selected_chars.has(c) || (font_main->get_data(0).is_valid() && selected_glyphs.has(font_main->get_data(0)->get_glyph_index(get_theme_font_size("font_size") * 2, c)))) {
+			if (selected_chars.has(c) || (font_main->get_data(0).is_valid() && selected_glyphs.has(font_main->get_data(0)->get_glyph_index(get_theme_font_size(SNAME("font_size")) * 2, c)))) {
 				item->set_custom_color(col + 1, fcol);
 				item->set_custom_bg_color(col + 1, scol);
 			} else {
@@ -732,13 +732,13 @@ void DynamicFontImportSettings::_edit_range(int32_t p_start, int32_t p_end) {
 				item->clear_custom_bg_color(col + 1);
 			}
 		} else {
-			item->set_custom_bg_color(col + 1, glyph_table->get_theme_color("dark_color_2", "Editor"));
+			item->set_custom_bg_color(col + 1, glyph_table->get_theme_color(SNAME("dark_color_2"), SNAME("Editor")));
 		}
 		item->set_metadata(col + 1, c);
 		item->set_text_alignment(col + 1, HORIZONTAL_ALIGNMENT_CENTER);
 		item->set_selectable(col + 1, true);
 		item->set_custom_font(col + 1, font_main);
-		item->set_custom_font_size(col + 1, get_theme_font_size("font_size") * 2);
+		item->set_custom_font_size(col + 1, get_theme_font_size(SNAME("font_size")) * 2);
 
 		col++;
 		if (col == 16) {
@@ -752,8 +752,8 @@ bool DynamicFontImportSettings::_char_update(int32_t p_char) {
 	if (selected_chars.has(p_char)) {
 		selected_chars.erase(p_char);
 		return false;
-	} else if (font_main->get_data(0).is_valid() && selected_glyphs.has(font_main->get_data(0)->get_glyph_index(get_theme_font_size("font_size") * 2, p_char))) {
-		selected_glyphs.erase(font_main->get_data(0)->get_glyph_index(get_theme_font_size("font_size") * 2, p_char));
+	} else if (font_main->get_data(0).is_valid() && selected_glyphs.has(font_main->get_data(0)->get_glyph_index(get_theme_font_size(SNAME("font_size")) * 2, p_char))) {
+		selected_glyphs.erase(font_main->get_data(0)->get_glyph_index(get_theme_font_size(SNAME("font_size")) * 2, p_char));
 		return false;
 	} else {
 		selected_chars.insert(p_char);
@@ -767,7 +767,7 @@ void DynamicFontImportSettings::_range_update(int32_t p_start, int32_t p_end) {
 	for (int32_t i = p_start; i <= p_end; i++) {
 		if (font_main->has_char(i)) {
 			if (font_main->get_data(0).is_valid()) {
-				all_selected = all_selected && (selected_chars.has(i) || (font_main->get_data(0).is_valid() && selected_glyphs.has(font_main->get_data(0)->get_glyph_index(get_theme_font_size("font_size") * 2, i))));
+				all_selected = all_selected && (selected_chars.has(i) || (font_main->get_data(0).is_valid() && selected_glyphs.has(font_main->get_data(0)->get_glyph_index(get_theme_font_size(SNAME("font_size")) * 2, i))));
 			} else {
 				all_selected = all_selected && selected_chars.has(i);
 			}
@@ -780,7 +780,7 @@ void DynamicFontImportSettings::_range_update(int32_t p_start, int32_t p_end) {
 			} else {
 				selected_chars.erase(i);
 				if (font_main->get_data(0).is_valid()) {
-					selected_glyphs.erase(font_main->get_data(0)->get_glyph_index(get_theme_font_size("font_size") * 2, i));
+					selected_glyphs.erase(font_main->get_data(0)->get_glyph_index(get_theme_font_size(SNAME("font_size")) * 2, i));
 				}
 			}
 		}
@@ -809,7 +809,7 @@ void DynamicFontImportSettings::_lang_add_item(const String &p_locale) {
 	lang_item->set_checked(0, false);
 	lang_item->set_text(1, p_locale);
 	lang_item->set_editable(1, true);
-	lang_item->add_button(2, lang_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+	lang_item->add_button(2, lang_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 	lang_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 }
 
@@ -841,7 +841,7 @@ void DynamicFontImportSettings::_ot_add_item(int p_option) {
 	ot_item->set_editable(0, false);
 	ot_item->set_text(1, "1");
 	ot_item->set_editable(1, true);
-	ot_item->add_button(2, ot_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+	ot_item->add_button(2, ot_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 	ot_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 }
 
@@ -868,7 +868,7 @@ void DynamicFontImportSettings::_script_add_item(int p_option) {
 	script_item->set_checked(0, false);
 	script_item->set_text(1, script_codes[p_option]);
 	script_item->set_editable(1, true);
-	script_item->add_button(2, lang_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+	script_item->add_button(2, lang_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 	script_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 }
 
@@ -895,10 +895,10 @@ void DynamicFontImportSettings::_notification(int p_what) {
 	if (p_what == NOTIFICATION_READY) {
 		connect("confirmed", callable_mp(this, &DynamicFontImportSettings::_re_import));
 	} else if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		add_lang->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
-		add_script->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
-		add_var->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
-		add_ot->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
+		add_lang->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+		add_script->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+		add_var->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+		add_ot->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 	}
 }
 
@@ -1043,7 +1043,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 	inspector_vars->edit(nullptr);
 	inspector_general->edit(nullptr);
 
-	int gww = get_theme_font("font")->get_string_size("00000", get_theme_font_size("font_size")).x + 50;
+	int gww = get_theme_font(SNAME("font"))->get_string_size("00000", get_theme_font_size(SNAME("font_size"))).x + 50;
 	glyph_table->set_column_custom_minimum_width(0, gww);
 
 	glyph_table->clear();
@@ -1146,7 +1146,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 
 					vars_item->set_text(0, TTR("Configuration") + " " + itos(i));
 					vars_item->set_editable(0, true);
-					vars_item->add_button(1, vars_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove Variation"));
+					vars_item->add_button(1, vars_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove Variation"));
 					vars_item->set_button_color(1, 0, Color(1, 1, 1, 0.75));
 
 					Ref<DynamicFontImportSettingsData> import_variation_data_custom;
@@ -1184,7 +1184,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 					lang_item->set_checked(0, true);
 					lang_item->set_text(1, _langs[i]);
 					lang_item->set_editable(1, true);
-					lang_item->add_button(2, lang_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+					lang_item->add_button(2, lang_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 				}
 			} else if (key == "support_overrides/language_disabled") {
 				PackedStringArray _langs = config->get_value("params", key);
@@ -1197,7 +1197,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 					lang_item->set_checked(0, false);
 					lang_item->set_text(1, _langs[i]);
 					lang_item->set_editable(1, true);
-					lang_item->add_button(2, lang_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+					lang_item->add_button(2, lang_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 				}
 			} else if (key == "support_overrides/script_enabled") {
 				PackedStringArray _scripts = config->get_value("params", key);
@@ -1210,7 +1210,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 					script_item->set_checked(0, true);
 					script_item->set_text(1, _scripts[i]);
 					script_item->set_editable(1, true);
-					script_item->add_button(2, lang_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+					script_item->add_button(2, lang_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 				}
 			} else if (key == "support_overrides/script_disabled") {
 				PackedStringArray _scripts = config->get_value("params", key);
@@ -1223,7 +1223,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 					script_item->set_checked(0, false);
 					script_item->set_text(1, _scripts[i]);
 					script_item->set_editable(1, true);
-					script_item->add_button(2, lang_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+					script_item->add_button(2, lang_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 				}
 			} else if (key == "opentype_feature_overrides") {
 				Dictionary features = config->get_value("params", key);
@@ -1239,7 +1239,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 					ot_item->set_editable(0, false);
 					ot_item->set_text(1, itos(value));
 					ot_item->set_editable(1, true);
-					ot_item->add_button(2, ot_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+					ot_item->add_button(2, ot_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 					ot_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 				}
 			} else {
@@ -1356,7 +1356,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	menu_ot->add_child(menu_ot_cu);
 	menu_ot_cu->connect("id_pressed", callable_mp(this, &DynamicFontImportSettings::_ot_add_item));
 
-	Color warn_color = (EditorNode::get_singleton()) ? EditorNode::get_singleton()->get_gui_base()->get_theme_color("warning_color", "Editor") : Color(1, 1, 0);
+	Color warn_color = (EditorNode::get_singleton()) ? EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("warning_color"), SNAME("Editor")) : Color(1, 1, 0);
 
 	// Root layout
 
@@ -1438,7 +1438,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	add_var = memnew(Button);
 	page2_hb_vars->add_child(add_var);
 	add_var->set_tooltip(TTR("Add configuration"));
-	add_var->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
+	add_var->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 	add_var->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_variation_add));
 
 	vars_list = memnew(Tree);
@@ -1545,8 +1545,8 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	for (int i = 0; i < 16; i++) {
 		glyph_table->set_column_title(i + 1, String::num_int64(i, 16));
 	}
-	glyph_table->add_theme_style_override("selected", glyph_table->get_theme_stylebox("bg"));
-	glyph_table->add_theme_style_override("selected_focus", glyph_table->get_theme_stylebox("bg"));
+	glyph_table->add_theme_style_override("selected", glyph_table->get_theme_stylebox(SNAME("bg")));
+	glyph_table->add_theme_style_override("selected_focus", glyph_table->get_theme_stylebox(SNAME("bg")));
 	glyph_table->add_theme_constant_override("hseparation", 0);
 	glyph_table->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	glyph_table->set_v_size_flags(Control::SIZE_EXPAND_FILL);
@@ -1590,7 +1590,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	add_lang = memnew(Button);
 	hb_lang->add_child(add_lang);
 	add_lang->set_tooltip(TTR("Add language override"));
-	add_lang->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
+	add_lang->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 	add_lang->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_lang_add));
 
 	lang_list = memnew(Tree);
@@ -1618,7 +1618,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	add_script = memnew(Button);
 	hb_script->add_child(add_script);
 	add_script->set_tooltip(TTR("Add script override"));
-	add_script->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
+	add_script->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 	add_script->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_script_add));
 
 	script_list = memnew(Tree);
@@ -1646,7 +1646,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	add_ot = memnew(Button);
 	hb_ot->add_child(add_ot);
 	add_ot->set_tooltip(TTR("Add feature override"));
-	add_ot->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
+	add_ot->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 	add_ot->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_ot_add));
 
 	ot_list = memnew(Tree);

--- a/editor/import/dynamicfont_import_settings.cpp
+++ b/editor/import/dynamicfont_import_settings.cpp
@@ -481,7 +481,7 @@ void DynamicFontImportSettings::_main_prop_changed(const String &p_edited_proper
 			font_preview->get_data(0)->set_oversampling(import_settings_data->get("oversampling"));
 		}
 	}
-	font_preview_label->add_theme_font_override(SNAME("font"), font_preview);
+	font_preview_label->add_theme_font_override("font", font_preview);
 	font_preview_label->update();
 }
 
@@ -495,7 +495,7 @@ void DynamicFontImportSettings::_variation_add() {
 
 	vars_item->set_text(0, TTR("New configuration"));
 	vars_item->set_editable(0, true);
-	vars_item->add_button(1, vars_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove Variation"));
+	vars_item->add_button(1, vars_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove Variation"));
 	vars_item->set_button_color(1, 0, Color(1, 1, 1, 0.75));
 
 	Ref<DynamicFontImportSettingsData> import_variation_data;
@@ -643,8 +643,8 @@ void DynamicFontImportSettings::_glyph_selected() {
 	TreeItem *item = glyph_table->get_selected();
 	ERR_FAIL_NULL(item);
 
-	Color scol = glyph_table->get_theme_color(SNAME("box_selection_fill_color"), SNAME("Editor"));
-	Color fcol = glyph_table->get_theme_color(SNAME("font_selected_color"), SNAME("Editor"));
+	Color scol = glyph_table->get_theme_color("box_selection_fill_color", "Editor");
+	Color fcol = glyph_table->get_theme_color("font_selected_color", "Editor");
 	scol.a = 1.f;
 
 	int32_t c = item->get_metadata(glyph_table->get_selected_column());
@@ -705,8 +705,8 @@ void DynamicFontImportSettings::_edit_range(int32_t p_start, int32_t p_end) {
 	TreeItem *root = glyph_table->create_item();
 	ERR_FAIL_NULL(root);
 
-	Color scol = glyph_table->get_theme_color(SNAME("box_selection_fill_color"), SNAME("Editor"));
-	Color fcol = glyph_table->get_theme_color(SNAME("font_selected_color"), SNAME("Editor"));
+	Color scol = glyph_table->get_theme_color("box_selection_fill_color", "Editor");
+	Color fcol = glyph_table->get_theme_color("font_selected_color", "Editor");
 	scol.a = 1.f;
 
 	TreeItem *item = nullptr;
@@ -719,12 +719,12 @@ void DynamicFontImportSettings::_edit_range(int32_t p_start, int32_t p_end) {
 			item->set_text(0, _pad_zeros(String::num_int64(c, 16)));
 			item->set_text_alignment(0, HORIZONTAL_ALIGNMENT_LEFT);
 			item->set_selectable(0, false);
-			item->set_custom_bg_color(0, glyph_table->get_theme_color(SNAME("dark_color_3"), SNAME("Editor")));
+			item->set_custom_bg_color(0, glyph_table->get_theme_color("dark_color_3", "Editor"));
 		}
 		if (font_main->has_char(c)) {
 			item->set_text(col + 1, String::chr(c));
 			item->set_custom_color(col + 1, Color(1, 1, 1));
-			if (selected_chars.has(c) || (font_main->get_data(0).is_valid() && selected_glyphs.has(font_main->get_data(0)->get_glyph_index(get_theme_font_size(SNAME("font_size")) * 2, c)))) {
+			if (selected_chars.has(c) || (font_main->get_data(0).is_valid() && selected_glyphs.has(font_main->get_data(0)->get_glyph_index(get_theme_font_size("font_size") * 2, c)))) {
 				item->set_custom_color(col + 1, fcol);
 				item->set_custom_bg_color(col + 1, scol);
 			} else {
@@ -732,13 +732,13 @@ void DynamicFontImportSettings::_edit_range(int32_t p_start, int32_t p_end) {
 				item->clear_custom_bg_color(col + 1);
 			}
 		} else {
-			item->set_custom_bg_color(col + 1, glyph_table->get_theme_color(SNAME("dark_color_2"), SNAME("Editor")));
+			item->set_custom_bg_color(col + 1, glyph_table->get_theme_color("dark_color_2", "Editor"));
 		}
 		item->set_metadata(col + 1, c);
 		item->set_text_alignment(col + 1, HORIZONTAL_ALIGNMENT_CENTER);
 		item->set_selectable(col + 1, true);
 		item->set_custom_font(col + 1, font_main);
-		item->set_custom_font_size(col + 1, get_theme_font_size(SNAME("font_size")) * 2);
+		item->set_custom_font_size(col + 1, get_theme_font_size("font_size") * 2);
 
 		col++;
 		if (col == 16) {
@@ -752,8 +752,8 @@ bool DynamicFontImportSettings::_char_update(int32_t p_char) {
 	if (selected_chars.has(p_char)) {
 		selected_chars.erase(p_char);
 		return false;
-	} else if (font_main->get_data(0).is_valid() && selected_glyphs.has(font_main->get_data(0)->get_glyph_index(get_theme_font_size(SNAME("font_size")) * 2, p_char))) {
-		selected_glyphs.erase(font_main->get_data(0)->get_glyph_index(get_theme_font_size(SNAME("font_size")) * 2, p_char));
+	} else if (font_main->get_data(0).is_valid() && selected_glyphs.has(font_main->get_data(0)->get_glyph_index(get_theme_font_size("font_size") * 2, p_char))) {
+		selected_glyphs.erase(font_main->get_data(0)->get_glyph_index(get_theme_font_size("font_size") * 2, p_char));
 		return false;
 	} else {
 		selected_chars.insert(p_char);
@@ -767,7 +767,7 @@ void DynamicFontImportSettings::_range_update(int32_t p_start, int32_t p_end) {
 	for (int32_t i = p_start; i <= p_end; i++) {
 		if (font_main->has_char(i)) {
 			if (font_main->get_data(0).is_valid()) {
-				all_selected = all_selected && (selected_chars.has(i) || (font_main->get_data(0).is_valid() && selected_glyphs.has(font_main->get_data(0)->get_glyph_index(get_theme_font_size(SNAME("font_size")) * 2, i))));
+				all_selected = all_selected && (selected_chars.has(i) || (font_main->get_data(0).is_valid() && selected_glyphs.has(font_main->get_data(0)->get_glyph_index(get_theme_font_size("font_size") * 2, i))));
 			} else {
 				all_selected = all_selected && selected_chars.has(i);
 			}
@@ -780,7 +780,7 @@ void DynamicFontImportSettings::_range_update(int32_t p_start, int32_t p_end) {
 			} else {
 				selected_chars.erase(i);
 				if (font_main->get_data(0).is_valid()) {
-					selected_glyphs.erase(font_main->get_data(0)->get_glyph_index(get_theme_font_size(SNAME("font_size")) * 2, i));
+					selected_glyphs.erase(font_main->get_data(0)->get_glyph_index(get_theme_font_size("font_size") * 2, i));
 				}
 			}
 		}
@@ -809,7 +809,7 @@ void DynamicFontImportSettings::_lang_add_item(const String &p_locale) {
 	lang_item->set_checked(0, false);
 	lang_item->set_text(1, p_locale);
 	lang_item->set_editable(1, true);
-	lang_item->add_button(2, lang_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+	lang_item->add_button(2, lang_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 	lang_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 }
 
@@ -841,7 +841,7 @@ void DynamicFontImportSettings::_ot_add_item(int p_option) {
 	ot_item->set_editable(0, false);
 	ot_item->set_text(1, "1");
 	ot_item->set_editable(1, true);
-	ot_item->add_button(2, ot_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+	ot_item->add_button(2, ot_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 	ot_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 }
 
@@ -868,7 +868,7 @@ void DynamicFontImportSettings::_script_add_item(int p_option) {
 	script_item->set_checked(0, false);
 	script_item->set_text(1, script_codes[p_option]);
 	script_item->set_editable(1, true);
-	script_item->add_button(2, lang_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+	script_item->add_button(2, lang_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 	script_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 }
 
@@ -895,10 +895,10 @@ void DynamicFontImportSettings::_notification(int p_what) {
 	if (p_what == NOTIFICATION_READY) {
 		connect("confirmed", callable_mp(this, &DynamicFontImportSettings::_re_import));
 	} else if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		add_lang->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
-		add_script->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
-		add_var->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
-		add_ot->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+		add_lang->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
+		add_script->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
+		add_var->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
+		add_ot->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
 	}
 }
 
@@ -1036,14 +1036,14 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 
 	font_main.instantiate();
 	font_main->add_data(dfont_main);
-	text_edit->add_theme_font_override(SNAME("font"), font_main);
+	text_edit->add_theme_font_override("font", font_main);
 
 	base_path = p_path;
 
 	inspector_vars->edit(nullptr);
 	inspector_general->edit(nullptr);
 
-	int gww = get_theme_font(SNAME("font"))->get_string_size("00000", get_theme_font_size(SNAME("font_size"))).x + 50;
+	int gww = get_theme_font("font")->get_string_size("00000", get_theme_font_size("font_size")).x + 50;
 	glyph_table->set_column_custom_minimum_width(0, gww);
 
 	glyph_table->clear();
@@ -1146,7 +1146,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 
 					vars_item->set_text(0, TTR("Configuration") + " " + itos(i));
 					vars_item->set_editable(0, true);
-					vars_item->add_button(1, vars_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove Variation"));
+					vars_item->add_button(1, vars_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove Variation"));
 					vars_item->set_button_color(1, 0, Color(1, 1, 1, 0.75));
 
 					Ref<DynamicFontImportSettingsData> import_variation_data_custom;
@@ -1184,7 +1184,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 					lang_item->set_checked(0, true);
 					lang_item->set_text(1, _langs[i]);
 					lang_item->set_editable(1, true);
-					lang_item->add_button(2, lang_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+					lang_item->add_button(2, lang_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 				}
 			} else if (key == "support_overrides/language_disabled") {
 				PackedStringArray _langs = config->get_value("params", key);
@@ -1197,7 +1197,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 					lang_item->set_checked(0, false);
 					lang_item->set_text(1, _langs[i]);
 					lang_item->set_editable(1, true);
-					lang_item->add_button(2, lang_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+					lang_item->add_button(2, lang_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 				}
 			} else if (key == "support_overrides/script_enabled") {
 				PackedStringArray _scripts = config->get_value("params", key);
@@ -1210,7 +1210,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 					script_item->set_checked(0, true);
 					script_item->set_text(1, _scripts[i]);
 					script_item->set_editable(1, true);
-					script_item->add_button(2, lang_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+					script_item->add_button(2, lang_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 				}
 			} else if (key == "support_overrides/script_disabled") {
 				PackedStringArray _scripts = config->get_value("params", key);
@@ -1223,7 +1223,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 					script_item->set_checked(0, false);
 					script_item->set_text(1, _scripts[i]);
 					script_item->set_editable(1, true);
-					script_item->add_button(2, lang_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+					script_item->add_button(2, lang_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 				}
 			} else if (key == "opentype_feature_overrides") {
 				Dictionary features = config->get_value("params", key);
@@ -1239,7 +1239,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 					ot_item->set_editable(0, false);
 					ot_item->set_text(1, itos(value));
 					ot_item->set_editable(1, true);
-					ot_item->add_button(2, ot_list->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), BUTTON_REMOVE_VAR, false, TTR("Remove"));
+					ot_item->add_button(2, ot_list->get_theme_icon("Remove", "EditorIcons"), BUTTON_REMOVE_VAR, false, TTR("Remove"));
 					ot_item->set_button_color(2, 0, Color(1, 1, 1, 0.75));
 				}
 			} else {
@@ -1263,7 +1263,7 @@ void DynamicFontImportSettings::open_settings(const String &p_path) {
 		font_preview->get_data(0)->set_hinting((TextServer::Hinting)import_settings_data->get("hinting").operator int());
 		font_preview->get_data(0)->set_oversampling(import_settings_data->get("oversampling"));
 	}
-	font_preview_label->add_theme_font_override(SNAME("font"), font_preview);
+	font_preview_label->add_theme_font_override("font", font_preview);
 	font_preview_label->update();
 
 	menu_ot->clear();
@@ -1356,7 +1356,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	menu_ot->add_child(menu_ot_cu);
 	menu_ot_cu->connect("id_pressed", callable_mp(this, &DynamicFontImportSettings::_ot_add_item));
 
-	Color warn_color = (EditorNode::get_singleton()) ? EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("warning_color"), SNAME("Editor")) : Color(1, 1, 0);
+	Color warn_color = (EditorNode::get_singleton()) ? EditorNode::get_singleton()->get_gui_base()->get_theme_color("warning_color", "Editor") : Color(1, 1, 0);
 
 	// Root layout
 
@@ -1372,7 +1372,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	label_warn->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	label_warn->set_text("");
 	root_vb->add_child(label_warn);
-	label_warn->add_theme_color_override(SNAME("font_color"), warn_color);
+	label_warn->add_theme_color_override("font_color", warn_color);
 	label_warn->hide();
 
 	// Page 1 layout: Rendering Options
@@ -1392,7 +1392,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	page1_vb->add_child(page1_hb);
 
 	font_preview_label = memnew(Label);
-	font_preview_label->add_theme_font_size_override(SNAME("font_size"), 200 * EDSCALE);
+	font_preview_label->add_theme_font_size_override("font_size", 200 * EDSCALE);
 	font_preview_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	font_preview_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
 	font_preview_label->set_autowrap_mode(Label::AUTOWRAP_ARBITRARY);
@@ -1438,7 +1438,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	add_var = memnew(Button);
 	page2_hb_vars->add_child(add_var);
 	add_var->set_tooltip(TTR("Add configuration"));
-	add_var->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+	add_var->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
 	add_var->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_variation_add));
 
 	vars_list = memnew(Tree);
@@ -1545,9 +1545,9 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	for (int i = 0; i < 16; i++) {
 		glyph_table->set_column_title(i + 1, String::num_int64(i, 16));
 	}
-	glyph_table->add_theme_style_override(SNAME("selected"), glyph_table->get_theme_stylebox(SNAME("bg")));
-	glyph_table->add_theme_style_override(SNAME("selected_focus"), glyph_table->get_theme_stylebox(SNAME("bg")));
-	glyph_table->add_theme_constant_override(SNAME("hseparation"), 0);
+	glyph_table->add_theme_style_override("selected", glyph_table->get_theme_stylebox("bg"));
+	glyph_table->add_theme_style_override("selected_focus", glyph_table->get_theme_stylebox("bg"));
+	glyph_table->add_theme_constant_override("hseparation", 0);
 	glyph_table->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	glyph_table->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
@@ -1590,7 +1590,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	add_lang = memnew(Button);
 	hb_lang->add_child(add_lang);
 	add_lang->set_tooltip(TTR("Add language override"));
-	add_lang->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+	add_lang->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
 	add_lang->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_lang_add));
 
 	lang_list = memnew(Tree);
@@ -1618,7 +1618,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	add_script = memnew(Button);
 	hb_script->add_child(add_script);
 	add_script->set_tooltip(TTR("Add script override"));
-	add_script->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+	add_script->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
 	add_script->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_script_add));
 
 	script_list = memnew(Tree);
@@ -1646,7 +1646,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	add_ot = memnew(Button);
 	hb_ot->add_child(add_ot);
 	add_ot->set_tooltip(TTR("Add feature override"));
-	add_ot->set_icon(add_var->get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+	add_ot->set_icon(add_var->get_theme_icon("Add", "EditorIcons"));
 	add_ot->connect("pressed", callable_mp(this, &DynamicFontImportSettings::_ot_add));
 
 	ot_list = memnew(Tree);

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -561,12 +561,12 @@ void ImportDock::_reimport() {
 void ImportDock::_notification(int p_what) {
 	switch (p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			imported->add_theme_style_override(SNAME("normal"), get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
+			imported->add_theme_style_override("normal", get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
 			import_opts->edit(params);
-			label_warning->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+			label_warning->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 		} break;
 	}
 }
@@ -579,12 +579,12 @@ void ImportDock::_set_dirty(bool p_dirty) {
 	if (p_dirty) {
 		// Add a dirty marker to notify the user that they should reimport the selected resource to see changes.
 		import->set_text(TTR("Reimport") + " (*)");
-		import->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+		import->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 		import->set_tooltip(TTR("You have pending changes that haven't been applied yet. Click Reimport to apply changes made to the import options.\nSelecting another resource in the FileSystem dock without clicking Reimport first will discard changes made in the Import dock."));
 	} else {
 		// Remove the dirty marker on the Reimport button.
 		import->set_text(TTR("Reimport"));
-		import->remove_theme_color_override(SNAME("font_color"));
+		import->remove_theme_color_override("font_color");
 		import->set_tooltip("");
 	}
 }
@@ -617,7 +617,7 @@ ImportDock::ImportDock() {
 	content->hide();
 
 	imported = memnew(Label);
-	imported->add_theme_style_override(SNAME("normal"), EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
+	imported->add_theme_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
 	imported->set_clip_text(true);
 	content->add_child(imported);
 	HBoxContainer *hb = memnew(HBoxContainer);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -422,7 +422,7 @@ void InspectorDock::_notification(int p_what) {
 			object_menu->set_icon(get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
 			search->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			warning->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
-			warning->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+			warning->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 		} break;
 	}
 }

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -530,9 +530,9 @@ void AnimationNodeBlendSpace1DEditor::_open_editor() {
 
 void AnimationNodeBlendSpace1DEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		error_panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
-		error_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
-		panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		tool_blend->set_icon(get_theme_icon(SNAME("EditPivot"), SNAME("EditorIcons")));
 		tool_select->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
 		tool_create->set_icon(get_theme_icon(SNAME("EditKey"), SNAME("EditorIcons")));

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -730,9 +730,9 @@ void AnimationNodeBlendSpace2DEditor::_edit_point_pos(double) {
 
 void AnimationNodeBlendSpace2DEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		error_panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
-		error_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
-		panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		tool_blend->set_icon(get_theme_icon(SNAME("EditPivot"), SNAME("EditorIcons")));
 		tool_select->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
 		tool_create->set_icon(get_theme_icon(SNAME("EditKey"), SNAME("EditorIcons")));

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -243,10 +243,10 @@ void AnimationNodeBlendTreeEditor::_update_graph() {
 		mono_color.a = 0.85;
 		c = mono_color;
 
-		node->add_theme_color_override(SNAME("title_color"), c);
+		node->add_theme_color_override("title_color", c);
 		c.a = 0.7;
-		node->add_theme_color_override(SNAME("close_color"), c);
-		node->add_theme_color_override(SNAME("resizer_color"), c);
+		node->add_theme_color_override("close_color", c);
+		node->add_theme_color_override("resizer_color", c);
 	}
 
 	List<AnimationNodeBlendTree::NodeConnection> connections;
@@ -739,8 +739,8 @@ void AnimationNodeBlendTreeEditor::_notification(int p_what) {
 	}
 
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		error_panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
-		error_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
 		if (p_what == NOTIFICATION_THEME_CHANGED && is_visible_in_tree()) {
 			_update_graph();

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -101,10 +101,10 @@ void AnimationPlayerEditor::_notification(int p_what) {
 
 			get_tree()->connect("node_removed", callable_mp(this, &AnimationPlayerEditor::_node_removed));
 
-			add_theme_style_override(SNAME("panel"), editor->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
+			add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			add_theme_style_override(SNAME("panel"), editor->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
+			add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
 		} break;
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
@@ -137,8 +137,8 @@ void AnimationPlayerEditor::_notification(int p_what) {
 
 			pin->set_icon(get_theme_icon(SNAME("Pin"), SNAME("EditorIcons")));
 
-			tool_anim->add_theme_style_override(SNAME("normal"), get_theme_stylebox(SNAME("normal"), SNAME("Button")));
-			track_editor->get_edit_menu()->add_theme_style_override(SNAME("normal"), get_theme_stylebox(SNAME("normal"), SNAME("Button")));
+			tool_anim->add_theme_style_override("normal", get_theme_stylebox(SNAME("normal"), SNAME("Button")));
+			track_editor->get_edit_menu()->add_theme_style_override("normal", get_theme_stylebox(SNAME("normal"), SNAME("Button")));
 
 #define ITEM_ICON(m_item, m_icon) tool_anim->get_popup()->set_item_icon(tool_anim->get_popup()->get_item_index(m_item), get_theme_icon(SNAME(m_icon), SNAME("EditorIcons")))
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -883,9 +883,9 @@ void AnimationNodeStateMachineEditor::_update_graph() {
 
 void AnimationNodeStateMachineEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED || p_what == NOTIFICATION_TRANSLATION_CHANGED) {
-		error_panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
-		error_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
-		panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 
 		tool_select->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
 		tool_create->set_icon(get_theme_icon(SNAME("ToolAddNode"), SNAME("EditorIcons")));

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -68,9 +68,9 @@ void EditorAssetLibraryItem::set_image(int p_type, int p_index, const Ref<Textur
 void EditorAssetLibraryItem::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
 		icon->set_normal_texture(get_theme_icon(SNAME("ProjectIconLoading"), SNAME("EditorIcons")));
-		category->add_theme_color_override(SNAME("font_color"), Color(0.5, 0.5, 0.5));
-		author->add_theme_color_override(SNAME("font_color"), Color(0.5, 0.5, 0.5));
-		price->add_theme_color_override(SNAME("font_color"), Color(0.5, 0.5, 0.5));
+		category->add_theme_color_override("font_color", Color(0.5, 0.5, 0.5));
+		author->add_theme_color_override("font_color", Color(0.5, 0.5, 0.5));
+		price->add_theme_color_override("font_color", Color(0.5, 0.5, 0.5));
 	}
 }
 
@@ -100,11 +100,11 @@ EditorAssetLibraryItem::EditorAssetLibraryItem() {
 	border->set_default_margin(SIDE_RIGHT, 5 * EDSCALE);
 	border->set_default_margin(SIDE_BOTTOM, 5 * EDSCALE);
 	border->set_default_margin(SIDE_TOP, 5 * EDSCALE);
-	add_theme_style_override(SNAME("panel"), border);
+	add_theme_style_override("panel", border);
 
 	HBoxContainer *hb = memnew(HBoxContainer);
 	// Add some spacing to visually separate the icon from the asset details.
-	hb->add_theme_constant_override(SNAME("separation"), 15 * EDSCALE);
+	hb->add_theme_constant_override("separation", 15 * EDSCALE);
 	add_child(hb);
 
 	icon = memnew(TextureButton);
@@ -195,7 +195,7 @@ void EditorAssetLibraryItemDescription::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			previews_bg->add_theme_style_override(SNAME("panel"), previews->get_theme_stylebox(SNAME("normal"), SNAME("TextEdit")));
+			previews_bg->add_theme_style_override("panel", previews->get_theme_stylebox(SNAME("normal"), SNAME("TextEdit")));
 		} break;
 	}
 }
@@ -269,7 +269,7 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 	add_child(hbox);
 	VBoxContainer *desc_vbox = memnew(VBoxContainer);
 	hbox->add_child(desc_vbox);
-	hbox->add_theme_constant_override(SNAME("separation"), 15 * EDSCALE);
+	hbox->add_theme_constant_override("separation", 15 * EDSCALE);
 
 	item = memnew(EditorAssetLibraryItem);
 
@@ -280,11 +280,11 @@ EditorAssetLibraryItemDescription::EditorAssetLibraryItemDescription() {
 	desc_vbox->add_child(description);
 	description->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	description->connect("meta_clicked", callable_mp(this, &EditorAssetLibraryItemDescription::_link_click));
-	description->add_theme_constant_override(SNAME("line_separation"), Math::round(5 * EDSCALE));
+	description->add_theme_constant_override("line_separation", Math::round(5 * EDSCALE));
 
 	VBoxContainer *previews_vbox = memnew(VBoxContainer);
 	hbox->add_child(previews_vbox);
-	previews_vbox->add_theme_constant_override(SNAME("separation"), 15 * EDSCALE);
+	previews_vbox->add_theme_constant_override("separation", 15 * EDSCALE);
 	previews_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 
 	preview = memnew(TextureRect);
@@ -400,8 +400,8 @@ void EditorAssetLibraryItemDownload::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("panel"), SNAME("AssetLib")));
-			status->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("status_color"), SNAME("AssetLib")));
+			panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("AssetLib")));
+			status->add_theme_color_override("font_color", get_theme_color(SNAME("status_color"), SNAME("AssetLib")));
 			dismiss_button->set_normal_texture(get_theme_icon(SNAME("dismiss"), SNAME("AssetLib")));
 		} break;
 		case NOTIFICATION_PROCESS: {
@@ -578,9 +578,9 @@ void EditorAssetLibrary::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			error_tr->set_texture(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
 			filter->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
-			library_scroll_bg->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
-			downloads_scroll->add_theme_style_override(SNAME("bg"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
-			error_label->add_theme_color_override(SNAME("color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			library_scroll_bg->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			downloads_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			error_label->add_theme_color_override("color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible()) {
@@ -984,7 +984,7 @@ HBoxContainer *EditorAssetLibrary::_make_pages(int p_page, int p_page_count, int
 	}
 
 	hbc->add_spacer();
-	hbc->add_theme_constant_override(SNAME("separation"), 5 * EDSCALE);
+	hbc->add_theme_constant_override("separation", 5 * EDSCALE);
 
 	Button *first = memnew(Button);
 	first->set_text(TTR("First"));
@@ -1191,8 +1191,8 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 
 			asset_items = memnew(GridContainer);
 			asset_items->set_columns(2);
-			asset_items->add_theme_constant_override(SNAME("hseparation"), 10 * EDSCALE);
-			asset_items->add_theme_constant_override(SNAME("vseparation"), 10 * EDSCALE);
+			asset_items->add_theme_constant_override("hseparation", 10 * EDSCALE);
+			asset_items->add_theme_constant_override("vseparation", 10 * EDSCALE);
 
 			library_vb->add_child(asset_items);
 
@@ -1374,7 +1374,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	HBoxContainer *search_hb = memnew(HBoxContainer);
 
 	library_main->add_child(search_hb);
-	library_main->add_theme_constant_override(SNAME("separation"), 10 * EDSCALE);
+	library_main->add_theme_constant_override("separation", 10 * EDSCALE);
 
 	filter = memnew(LineEdit);
 	if (templates_only) {
@@ -1482,7 +1482,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	PanelContainer *library_vb_border = memnew(PanelContainer);
 	library_scroll->add_child(library_vb_border);
-	library_vb_border->add_theme_style_override(SNAME("panel"), border2);
+	library_vb_border->add_theme_style_override("panel", border2);
 	library_vb_border->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 	library_vb = memnew(VBoxContainer);
@@ -1504,8 +1504,8 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	asset_items = memnew(GridContainer);
 	asset_items->set_columns(2);
-	asset_items->add_theme_constant_override(SNAME("hseparation"), 10 * EDSCALE);
-	asset_items->add_theme_constant_override(SNAME("vseparation"), 10 * EDSCALE);
+	asset_items->add_theme_constant_override("hseparation", 10 * EDSCALE);
+	asset_items->add_theme_constant_override("vseparation", 10 * EDSCALE);
 
 	library_vb->add_child(asset_items);
 
@@ -1519,7 +1519,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	last_queue_id = 0;
 
-	library_vb->add_theme_constant_override(SNAME("separation"), 20 * EDSCALE);
+	library_vb->add_theme_constant_override("separation", 20 * EDSCALE);
 
 	error_hb = memnew(HBoxContainer);
 	library_main->add_child(error_hb);

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -224,7 +224,7 @@ AudioStreamEditor::AudioStreamEditor() {
 	_preview->add_child(_indicator);
 
 	HBoxContainer *hbox = memnew(HBoxContainer);
-	hbox->add_theme_constant_override(SNAME("separation"), 0);
+	hbox->add_theme_constant_override("separation", 0);
 	vbox->add_child(hbox);
 
 	_play_button = memnew(Button);
@@ -243,14 +243,14 @@ AudioStreamEditor::AudioStreamEditor() {
 	_current_label = memnew(Label);
 	_current_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	_current_label->set_h_size_flags(SIZE_EXPAND_FILL);
-	_current_label->add_theme_font_override(SNAME("font"), EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
-	_current_label->add_theme_font_size_override(SNAME("font_size"), EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+	_current_label->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	_current_label->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 	_current_label->set_modulate(Color(1, 1, 1, 0.5));
 	hbox->add_child(_current_label);
 
 	_duration_label = memnew(Label);
-	_duration_label->add_theme_font_override(SNAME("font"), EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
-	_duration_label->add_theme_font_size_override(SNAME("font_size"), EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+	_duration_label->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	_duration_label->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 	hbox->add_child(_duration_label);
 }
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3847,7 +3847,7 @@ void CanvasItemEditor::_notification(int p_what) {
 		// the icon will be dark, so we need to lighten it before blending it
 		// with the red color.
 		const Color key_auto_color = EditorSettings::get_singleton()->is_dark_theme() ? Color(1, 1, 1) : Color(4.25, 4.25, 4.25);
-		key_auto_insert_button->add_theme_color_override(SNAME("icon_pressed_color"), key_auto_color.lerp(Color(1, 0, 0), 0.55));
+		key_auto_insert_button->add_theme_color_override("icon_pressed_color", key_auto_color.lerp(Color(1, 0, 0), 0.55));
 		animation_menu->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 
 		_update_context_menu_stylebox();
@@ -3967,7 +3967,7 @@ void CanvasItemEditor::_update_context_menu_stylebox() {
 	context_menu_stylebox->set_border_color(accent_color);
 	context_menu_stylebox->set_border_width(SIDE_BOTTOM, Math::round(2 * EDSCALE));
 	context_menu_stylebox->set_default_margin(SIDE_BOTTOM, 0);
-	context_menu_container->add_theme_style_override(SNAME("panel"), context_menu_stylebox);
+	context_menu_container->add_theme_style_override("panel", context_menu_stylebox);
 }
 
 void CanvasItemEditor::_update_scrollbars() {
@@ -6073,7 +6073,7 @@ void CanvasItemEditorViewport::_notification(int p_what) {
 			check->set_icon(get_theme_icon(check->get_text(), SNAME("EditorIcons")));
 		}
 
-		label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+		label->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 	}
 
 	switch (p_what) {
@@ -6141,16 +6141,16 @@ CanvasItemEditorViewport::CanvasItemEditorViewport(EditorNode *p_node, CanvasIte
 	}
 
 	label = memnew(Label);
-	label->add_theme_color_override(SNAME("font_shadow_color"), Color(0, 0, 0, 1));
-	label->add_theme_constant_override(SNAME("shadow_outline_size"), 1 * EDSCALE);
+	label->add_theme_color_override("font_shadow_color", Color(0, 0, 0, 1));
+	label->add_theme_constant_override("shadow_outline_size", 1 * EDSCALE);
 	label->hide();
 	canvas_item_editor->get_controls_container()->add_child(label);
 
 	label_desc = memnew(Label);
-	label_desc->add_theme_color_override(SNAME("font_color"), Color(0.6f, 0.6f, 0.6f, 1));
-	label_desc->add_theme_color_override(SNAME("font_shadow_color"), Color(0.2f, 0.2f, 0.2f, 1));
-	label_desc->add_theme_constant_override(SNAME("shadow_outline_size"), 1 * EDSCALE);
-	label_desc->add_theme_constant_override(SNAME("line_spacing"), 0);
+	label_desc->add_theme_color_override("font_color", Color(0.6f, 0.6f, 0.6f, 1));
+	label_desc->add_theme_color_override("font_shadow_color", Color(0.2f, 0.2f, 0.2f, 1));
+	label_desc->add_theme_constant_override("shadow_outline_size", 1 * EDSCALE);
+	label_desc->add_theme_constant_override("line_spacing", 0);
 	label_desc->hide();
 	canvas_item_editor->get_controls_container()->add_child(label_desc);
 

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -54,7 +54,7 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(EditorNode *p_editor, MenuButton *p_d
 	EditorDebuggerNode *debugger = memnew(EditorDebuggerNode);
 	Button *db = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Debugger"), debugger);
 	// Add separation for the warning/error icon that is displayed later.
-	db->add_theme_constant_override(SNAME("hseparation"), 6 * EDSCALE);
+	db->add_theme_constant_override("hseparation", 6 * EDSCALE);
 	debugger->set_tool_button(db);
 
 	// Main editor debug menu.

--- a/editor/plugins/input_event_editor_plugin.cpp
+++ b/editor/plugins/input_event_editor_plugin.cpp
@@ -76,10 +76,10 @@ void InputEventConfigContainer::set_event(const Ref<InputEvent> &p_event) {
 
 InputEventConfigContainer::InputEventConfigContainer() {
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->add_theme_constant_override(SNAME("margin_left"), 10);
-	mc->add_theme_constant_override(SNAME("margin_right"), 10);
-	mc->add_theme_constant_override(SNAME("margin_top"), 10);
-	mc->add_theme_constant_override(SNAME("margin_bottom"), 10);
+	mc->add_theme_constant_override("margin_left", 10);
+	mc->add_theme_constant_override("margin_right", 10);
+	mc->add_theme_constant_override("margin_top", 10);
+	mc->add_theme_constant_override("margin_bottom", 10);
 	add_child(mc);
 
 	HBoxContainer *hb = memnew(HBoxContainer);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2946,28 +2946,28 @@ void Node3DEditorViewport::_notification(int p_what) {
 		view_menu->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 		preview_camera->set_icon(get_theme_icon(SNAME("Camera3D"), SNAME("EditorIcons")));
 
-		view_menu->add_theme_style_override(SNAME("normal"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		view_menu->add_theme_style_override(SNAME("hover"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		view_menu->add_theme_style_override(SNAME("pressed"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		view_menu->add_theme_style_override(SNAME("focus"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		view_menu->add_theme_style_override(SNAME("disabled"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("hover", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("pressed", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("focus", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		view_menu->add_theme_style_override("disabled", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
 
-		preview_camera->add_theme_style_override(SNAME("normal"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		preview_camera->add_theme_style_override(SNAME("hover"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		preview_camera->add_theme_style_override(SNAME("pressed"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		preview_camera->add_theme_style_override(SNAME("focus"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		preview_camera->add_theme_style_override(SNAME("disabled"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("hover", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("pressed", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("focus", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		preview_camera->add_theme_style_override("disabled", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
 
 		frame_time_gradient->set_color(0, get_theme_color(SNAME("success_color"), SNAME("Editor")));
 		frame_time_gradient->set_color(1, get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 		frame_time_gradient->set_color(2, get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
-		info_label->add_theme_style_override(SNAME("normal"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		cpu_time_label->add_theme_style_override(SNAME("normal"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		gpu_time_label->add_theme_style_override(SNAME("normal"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		fps_label->add_theme_style_override(SNAME("normal"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		cinema_label->add_theme_style_override(SNAME("normal"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
-		locked_label->add_theme_style_override(SNAME("normal"), editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		info_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		cpu_time_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		gpu_time_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		fps_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		cinema_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
+		locked_label->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("Information3dViewport"), SNAME("EditorStyles")));
 	}
 }
 
@@ -4512,7 +4512,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 	zoom_limit_label->set_offset(Side::SIDE_TOP, -28 * EDSCALE);
 	zoom_limit_label->set_text(TTR("To zoom further, change the camera's clipping planes (View -> Settings...)"));
 	zoom_limit_label->set_name("ZoomLimitMessageLabel");
-	zoom_limit_label->add_theme_color_override(SNAME("font_color"), Color(1, 1, 1, 1));
+	zoom_limit_label->add_theme_color_override("font_color", Color(1, 1, 1, 1));
 	zoom_limit_label->hide();
 	surface->add_child(zoom_limit_label);
 
@@ -4526,7 +4526,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 	// Make sure frame time labels don't touch the viewport's edge.
 	top_right_vbox->set_custom_minimum_size(Size2(100, 0) * EDSCALE);
 	// Prevent visible spacing between frame time labels.
-	top_right_vbox->add_theme_constant_override(SNAME("separation"), 0);
+	top_right_vbox->add_theme_constant_override("separation", 0);
 
 	rotation_control = memnew(ViewportRotationControl);
 	rotation_control->set_custom_minimum_size(Size2(80, 80) * EDSCALE);
@@ -6190,7 +6190,7 @@ void Node3DEditor::_update_context_menu_stylebox() {
 	context_menu_stylebox->set_border_color(accent_color);
 	context_menu_stylebox->set_border_width(SIDE_BOTTOM, Math::round(2 * EDSCALE));
 	context_menu_stylebox->set_default_margin(SIDE_BOTTOM, 0);
-	context_menu_container->add_theme_style_override(SNAME("panel"), context_menu_stylebox);
+	context_menu_container->add_theme_style_override("panel", context_menu_stylebox);
 }
 
 void Node3DEditor::_update_gizmos_menu() {
@@ -6777,8 +6777,8 @@ void Node3DEditor::_update_theme() {
 	environ_button->set_icon(get_theme_icon(SNAME("WorldEnvironment"), SNAME("EditorIcons")));
 	sun_environ_settings->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 
-	sun_title->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("title_font"), SNAME("Window")));
-	environ_title->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("title_font"), SNAME("Window")));
+	sun_title->add_theme_font_override("font", get_theme_font(SNAME("title_font"), SNAME("Window")));
+	environ_title->add_theme_font_override("font", get_theme_font(SNAME("title_font"), SNAME("Window")));
 }
 
 void Node3DEditor::_notification(int p_what) {
@@ -6815,8 +6815,8 @@ void Node3DEditor::_notification(int p_what) {
 			_update_theme();
 			_update_gizmos_menu_theme();
 			_update_context_menu_stylebox();
-			sun_title->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("title_font"), SNAME("Window")));
-			environ_title->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("title_font"), SNAME("Window")));
+			sun_title->add_theme_font_override("font", get_theme_font(SNAME("title_font"), SNAME("Window")));
+			environ_title->add_theme_font_override("font", get_theme_font(SNAME("title_font"), SNAME("Window")));
 		} break;
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			// Update grid color by rebuilding grid.
@@ -7806,7 +7806,7 @@ void fragment() {
 		sun_angle_azimuth->connect("value_changed", callable_mp(this, &Node3DEditor::_sun_direction_angle_set).unbind(1));
 		sun_angle_azimuth_vbox->add_child(sun_angle_azimuth);
 		sun_angle_hbox->add_child(sun_angle_azimuth_vbox);
-		sun_angle_hbox->add_theme_constant_override(SNAME("separation"), 10);
+		sun_angle_hbox->add_theme_constant_override("separation", 10);
 		sun_vb->add_child(sun_angle_hbox);
 
 		sun_color = memnew(ColorPickerButton);

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -92,8 +92,8 @@ void Polygon2DEditor::_notification(int p_what) {
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
-			uv_edit_draw->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
-			bone_scroll->add_theme_style_override(SNAME("bg"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			uv_edit_draw->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			bone_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		} break;
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible()) {

--- a/editor/plugins/replication_editor_plugin.cpp
+++ b/editor/plugins/replication_editor_plugin.cpp
@@ -258,7 +258,7 @@ void ReplicationEditor::edit(MultiplayerSynchronizer *p_sync) {
 
 Ref<Texture2D> ReplicationEditor::_get_class_icon(const Node *p_node) {
 	if (!p_node || !has_theme_icon(p_node->get_class(), "EditorIcons")) {
-		return get_theme_icon("ImportFail", "EditorIcons");
+		return get_theme_icon(SNAME("ImportFail"), SNAME("EditorIcons"));
 	}
 	return get_theme_icon(p_node->get_class(), "EditorIcons");
 }
@@ -285,7 +285,7 @@ void ReplicationEditor::_add_property(const NodePath &p_property, bool p_spawn, 
 		icon = _get_class_icon(node);
 	}
 	item->set_icon(0, icon);
-	item->add_button(3, get_theme_icon("Remove", "EditorIcons"));
+	item->add_button(3, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 	item->set_text_alignment(1, HORIZONTAL_ALIGNMENT_CENTER);
 	item->set_cell_mode(1, TreeItem::CELL_MODE_CHECK);
 	item->set_checked(1, p_spawn);

--- a/editor/plugins/replication_editor_plugin.cpp
+++ b/editor/plugins/replication_editor_plugin.cpp
@@ -95,7 +95,7 @@ void ReplicationEditor::_bind_methods() {
 
 void ReplicationEditor::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		add_theme_style_override(SNAME("panel"), editor->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
+		add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
 	} else if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
 		update_keying();
 	}
@@ -257,10 +257,10 @@ void ReplicationEditor::edit(MultiplayerSynchronizer *p_sync) {
 }
 
 Ref<Texture2D> ReplicationEditor::_get_class_icon(const Node *p_node) {
-	if (!p_node || !has_theme_icon(p_node->get_class(), SNAME("EditorIcons"))) {
-		return get_theme_icon(SNAME("ImportFail"), SNAME("EditorIcons"));
+	if (!p_node || !has_theme_icon(p_node->get_class(), "EditorIcons")) {
+		return get_theme_icon("ImportFail", "EditorIcons");
 	}
-	return get_theme_icon(p_node->get_class(), SNAME("EditorIcons"));
+	return get_theme_icon(p_node->get_class(), "EditorIcons");
 }
 
 void ReplicationEditor::_add_property(const NodePath &p_property, bool p_spawn, bool p_sync) {
@@ -285,7 +285,7 @@ void ReplicationEditor::_add_property(const NodePath &p_property, bool p_spawn, 
 		icon = _get_class_icon(node);
 	}
 	item->set_icon(0, icon);
-	item->add_button(3, get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
+	item->add_button(3, get_theme_icon("Remove", "EditorIcons"));
 	item->set_text_alignment(1, HORIZONTAL_ALIGNMENT_CENTER);
 	item->set_cell_mode(1, TreeItem::CELL_MODE_CHECK);
 	item->set_checked(1, p_spawn);

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -341,7 +341,7 @@ void ResourcePreloaderEditor::_bind_methods() {
 }
 
 ResourcePreloaderEditor::ResourcePreloaderEditor() {
-	//add_style_override(SNAME("panel"), EditorNode::get_singleton()->get_gui_base()->get_stylebox("panel","Panel"));
+	//add_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_stylebox("panel","Panel"));
 
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -381,7 +381,7 @@ ScriptEditorQuickOpen::ScriptEditorQuickOpen() {
 	search_options->connect("item_activated", callable_mp(this, &ScriptEditorQuickOpen::_confirmed));
 	search_options->set_hide_root(true);
 	search_options->set_hide_folding(true);
-	search_options->add_theme_constant_override(SNAME("draw_guides"), 1);
+	search_options->add_theme_constant_override("draw_guides", 1);
 }
 
 /////////////////////////////////
@@ -1630,7 +1630,7 @@ void ScriptEditor::_notification(int p_what) {
 			filter_scripts->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			filter_methods->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 
-			filename->add_theme_style_override(SNAME("normal"), editor->get_gui_base()->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
+			filename->add_theme_style_override("normal", editor->get_gui_base()->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
 
 			recent_scripts->set_as_minsize();
 
@@ -3693,7 +3693,7 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 	filename = memnew(Label);
 	filename->set_clip_text(true);
 	filename->set_h_size_flags(SIZE_EXPAND_FILL);
-	filename->add_theme_style_override(SNAME("normal"), EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
+	filename->add_theme_style_override("normal", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
 	buttons_hbox->add_child(filename);
 
 	members_overview_alphabeta_sort_button = memnew(Button);
@@ -3948,8 +3948,8 @@ ScriptEditor::ScriptEditor(EditorNode *p_editor) {
 
 	ScriptServer::edit_request_func = _open_script_request;
 
-	add_theme_style_override(SNAME("panel"), editor->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditorPanel"), SNAME("EditorStyles")));
-	tab_container->add_theme_style_override(SNAME("panel"), editor->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditor"), SNAME("EditorStyles")));
+	add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditorPanel"), SNAME("EditorStyles")));
+	tab_container->add_theme_style_override("panel", editor->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditor"), SNAME("EditorStyles")));
 }
 
 ScriptEditor::~ScriptEditor() {

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1848,7 +1848,7 @@ void ScriptTextEditor::_enable_code_editor() {
 
 ScriptTextEditor::ScriptTextEditor() {
 	code_editor = memnew(CodeTextEditor);
-	code_editor->add_theme_constant_override(SNAME("separation"), 2);
+	code_editor->add_theme_constant_override("separation", 2);
 	code_editor->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	code_editor->set_code_complete_func(_code_complete_scripts, this);
 	code_editor->set_v_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -189,8 +189,8 @@ void ShaderTextEditor::_load_theme_settings() {
 
 	if (warnings_panel) {
 		// Warnings panel
-		warnings_panel->add_theme_font_override(SNAME("normal_font"), EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("main"), SNAME("EditorFonts")));
-		warnings_panel->add_theme_font_size_override(SNAME("normal_font_size"), EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("main_size"), SNAME("EditorFonts")));
+		warnings_panel->add_theme_font_override("normal_font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("main"), SNAME("EditorFonts")));
+		warnings_panel->add_theme_font_size_override("normal_font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("main_size"), SNAME("EditorFonts")));
 	}
 }
 
@@ -443,7 +443,7 @@ void ShaderEditor::_notification(int p_what) {
 void ShaderEditor::_editor_settings_changed() {
 	shader_editor->update_editor_settings();
 
-	shader_editor->get_text_editor()->add_theme_constant_override(SNAME("line_spacing"), EditorSettings::get_singleton()->get("text_editor/appearance/whitespace/line_spacing"));
+	shader_editor->get_text_editor()->add_theme_constant_override("line_spacing", EditorSettings::get_singleton()->get("text_editor/appearance/whitespace/line_spacing"));
 	shader_editor->get_text_editor()->set_draw_breakpoints_gutter(false);
 	shader_editor->get_text_editor()->set_draw_executing_lines_gutter(false);
 }
@@ -701,7 +701,7 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 
 	shader_editor = memnew(ShaderTextEditor);
 	shader_editor->set_v_size_flags(SIZE_EXPAND_FILL);
-	shader_editor->add_theme_constant_override(SNAME("separation"), 0);
+	shader_editor->add_theme_constant_override("separation", 0);
 	shader_editor->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 
 	shader_editor->connect("show_warnings_panel", callable_mp(this, &ShaderEditor::_show_warnings_panel));
@@ -789,7 +789,7 @@ ShaderEditor::ShaderEditor(EditorNode *p_node) {
 	hbc->add_child(edit_menu);
 	hbc->add_child(goto_menu);
 	hbc->add_child(help_menu);
-	hbc->add_theme_style_override(SNAME("panel"), p_node->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditorPanel"), SNAME("EditorStyles")));
+	hbc->add_theme_style_override("panel", p_node->get_gui_base()->get_theme_stylebox(SNAME("ScriptEditorPanel"), SNAME("EditorStyles")));
 
 	VSplitContainer *editor_box = memnew(VSplitContainer);
 	main_container->add_child(editor_box);

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -602,7 +602,7 @@ void Skeleton3DEditor::update_editors() {
 
 void Skeleton3DEditor::create_editors() {
 	set_h_size_flags(SIZE_EXPAND_FILL);
-	add_theme_constant_override(SNAME("separation"), 0);
+	add_theme_constant_override("separation", 0);
 
 	set_focus_mode(FOCUS_ALL);
 

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -328,10 +328,10 @@ void SpriteFramesEditor::_notification(int p_what) {
 			[[fallthrough]];
 		}
 		case NOTIFICATION_THEME_CHANGED: {
-			split_sheet_scroll->add_theme_style_override(SNAME("bg"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			split_sheet_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		} break;
 		case NOTIFICATION_READY: {
-			add_theme_constant_override(SNAME("autohide"), 1); // Fixes the dragger always showing up.
+			add_theme_constant_override("autohide", 1); // Fixes the dragger always showing up.
 		} break;
 	}
 }
@@ -1247,8 +1247,8 @@ SpriteFramesEditor::SpriteFramesEditor() {
 	split_sheet_panel->add_child(split_sheet_zoom_margin);
 	split_sheet_zoom_margin->set_h_size_flags(0);
 	split_sheet_zoom_margin->set_v_size_flags(0);
-	split_sheet_zoom_margin->add_theme_constant_override(SNAME("margin_top"), 5);
-	split_sheet_zoom_margin->add_theme_constant_override(SNAME("margin_left"), 5);
+	split_sheet_zoom_margin->add_theme_constant_override("margin_top", 5);
+	split_sheet_zoom_margin->add_theme_constant_override("margin_left", 5);
 	HBoxContainer *split_sheet_zoom_hb = memnew(HBoxContainer);
 	split_sheet_zoom_margin->add_child(split_sheet_zoom_hb);
 

--- a/editor/plugins/style_box_editor_plugin.cpp
+++ b/editor/plugins/style_box_editor_plugin.cpp
@@ -50,7 +50,7 @@ void StyleBoxPreview::edit(const Ref<StyleBox> &p_stylebox) {
 	}
 	stylebox = p_stylebox;
 	if (p_stylebox.is_valid()) {
-		preview->add_theme_style_override(SNAME("panel"), stylebox);
+		preview->add_theme_style_override("panel", stylebox);
 		stylebox->connect("changed", callable_mp(this, &StyleBoxPreview::_sb_changed));
 	}
 	_sb_changed();

--- a/editor/plugins/text_control_editor_plugin.cpp
+++ b/editor/plugins/text_control_editor_plugin.cpp
@@ -220,9 +220,9 @@ void TextControlEditor::_update_control() {
 			}
 
 			int current_font_size = edited_control->get_theme_font_size(edited_font_size);
-			int current_outline_size = edited_control->get_theme_constant("outline_size");
+			int current_outline_size = edited_control->get_theme_constant(SNAME("outline_size"));
 			Color current_font_color = edited_control->get_theme_color(edited_color);
-			Color current_outline_color = edited_control->get_theme_color("font_outline_color");
+			Color current_outline_color = edited_control->get_theme_color(SNAME("font_outline_color"));
 			if (i > 0) {
 				same_font_size = same_font_size && (font_size == current_font_size);
 				same_outline_size = same_outline_size && (outline_size == current_outline_size);
@@ -393,7 +393,7 @@ void TextControlEditor::_outline_size_selected(double p_size) {
 
 		ur->add_do_method(edited_control, "add_theme_constant_override", "outline_size", p_size);
 		if (edited_control->has_theme_constant_override("outline_size")) {
-			ur->add_undo_method(edited_control, "add_theme_constant_override", "outline_size", edited_control->get_theme_constant("outline_size"));
+			ur->add_undo_method(edited_control, "add_theme_constant_override", "outline_size", edited_control->get_theme_constant(SNAME("outline_size")));
 		} else {
 			ur->add_undo_method(edited_control, "remove_theme_constant_override", "outline_size");
 		}
@@ -452,7 +452,7 @@ void TextControlEditor::_outline_color_changed(const Color &p_color) {
 
 		ur->add_do_method(edited_control, "add_theme_color_override", "font_outline_color", p_color);
 		if (edited_control->has_theme_color_override("font_outline_color")) {
-			ur->add_undo_method(edited_control, "add_theme_color_override", "font_outline_color", edited_control->get_theme_color("font_outline_color"));
+			ur->add_undo_method(edited_control, "add_theme_color_override", "font_outline_color", edited_control->get_theme_color(SNAME("font_outline_color")));
 		} else {
 			ur->add_undo_method(edited_control, "remove_theme_color_override", "font_outline_color");
 		}
@@ -511,12 +511,12 @@ void TextControlEditor::_clear_formatting() {
 
 		ur->add_do_method(edited_control, "remove_theme_color_override", "font_outline_color");
 		if (edited_control->has_theme_color_override("font_outline_color")) {
-			ur->add_undo_method(edited_control, "add_theme_color_override", "font_outline_color", edited_control->get_theme_color("font_outline_color"));
+			ur->add_undo_method(edited_control, "add_theme_color_override", "font_outline_color", edited_control->get_theme_color(SNAME("font_outline_color")));
 		}
 
 		ur->add_do_method(edited_control, "remove_theme_constant_override", "outline_size");
 		if (edited_control->has_theme_constant_override("outline_size")) {
-			ur->add_undo_method(edited_control, "add_theme_constant_override", "outline_size", edited_control->get_theme_constant("outline_size"));
+			ur->add_undo_method(edited_control, "add_theme_constant_override", "outline_size", edited_control->get_theme_constant(SNAME("outline_size")));
 		}
 
 		ur->add_do_method(edited_control, "end_bulk_theme_override");

--- a/editor/plugins/text_control_editor_plugin.cpp
+++ b/editor/plugins/text_control_editor_plugin.cpp
@@ -220,9 +220,9 @@ void TextControlEditor::_update_control() {
 			}
 
 			int current_font_size = edited_control->get_theme_font_size(edited_font_size);
-			int current_outline_size = edited_control->get_theme_constant(SNAME("outline_size"));
+			int current_outline_size = edited_control->get_theme_constant("outline_size");
 			Color current_font_color = edited_control->get_theme_color(edited_color);
-			Color current_outline_color = edited_control->get_theme_color(SNAME("font_outline_color"));
+			Color current_outline_color = edited_control->get_theme_color("font_outline_color");
 			if (i > 0) {
 				same_font_size = same_font_size && (font_size == current_font_size);
 				same_outline_size = same_outline_size && (outline_size == current_outline_size);
@@ -392,8 +392,8 @@ void TextControlEditor::_outline_size_selected(double p_size) {
 		Control *edited_control = edited_controls[i];
 
 		ur->add_do_method(edited_control, "add_theme_constant_override", "outline_size", p_size);
-		if (edited_control->has_theme_constant_override(SNAME("outline_size"))) {
-			ur->add_undo_method(edited_control, "add_theme_constant_override", "outline_size", edited_control->get_theme_constant(SNAME("outline_size")));
+		if (edited_control->has_theme_constant_override("outline_size")) {
+			ur->add_undo_method(edited_control, "add_theme_constant_override", "outline_size", edited_control->get_theme_constant("outline_size"));
 		} else {
 			ur->add_undo_method(edited_control, "remove_theme_constant_override", "outline_size");
 		}
@@ -451,8 +451,8 @@ void TextControlEditor::_outline_color_changed(const Color &p_color) {
 		Control *edited_control = edited_controls[i];
 
 		ur->add_do_method(edited_control, "add_theme_color_override", "font_outline_color", p_color);
-		if (edited_control->has_theme_color_override(SNAME("font_outline_color"))) {
-			ur->add_undo_method(edited_control, "add_theme_color_override", "font_outline_color", edited_control->get_theme_color(SNAME("font_outline_color")));
+		if (edited_control->has_theme_color_override("font_outline_color")) {
+			ur->add_undo_method(edited_control, "add_theme_color_override", "font_outline_color", edited_control->get_theme_color("font_outline_color"));
 		} else {
 			ur->add_undo_method(edited_control, "remove_theme_color_override", "font_outline_color");
 		}
@@ -510,13 +510,13 @@ void TextControlEditor::_clear_formatting() {
 		}
 
 		ur->add_do_method(edited_control, "remove_theme_color_override", "font_outline_color");
-		if (edited_control->has_theme_color_override(SNAME("font_outline_color"))) {
-			ur->add_undo_method(edited_control, "add_theme_color_override", "font_outline_color", edited_control->get_theme_color(SNAME("font_outline_color")));
+		if (edited_control->has_theme_color_override("font_outline_color")) {
+			ur->add_undo_method(edited_control, "add_theme_color_override", "font_outline_color", edited_control->get_theme_color("font_outline_color"));
 		}
 
 		ur->add_do_method(edited_control, "remove_theme_constant_override", "outline_size");
-		if (edited_control->has_theme_constant_override(SNAME("outline_size"))) {
-			ur->add_undo_method(edited_control, "add_theme_constant_override", "outline_size", edited_control->get_theme_constant(SNAME("outline_size")));
+		if (edited_control->has_theme_constant_override("outline_size")) {
+			ur->add_undo_method(edited_control, "add_theme_constant_override", "outline_size", edited_control->get_theme_constant("outline_size"));
 		}
 
 		ur->add_do_method(edited_control, "end_bulk_theme_override");
@@ -600,7 +600,7 @@ TextControlEditor::TextControlEditor() {
 
 	font_size_list = memnew(SpinBox);
 	font_size_list->set_tooltip(TTR("Font Size"));
-	font_size_list->get_line_edit()->add_theme_constant_override(SNAME("minimum_character_width"), 2);
+	font_size_list->get_line_edit()->add_theme_constant_override("minimum_character_width", 2);
 	font_size_list->set_min(6);
 	font_size_list->set_step(1);
 	font_size_list->set_max(96);
@@ -619,7 +619,7 @@ TextControlEditor::TextControlEditor() {
 
 	outline_size_list = memnew(SpinBox);
 	outline_size_list->set_tooltip(TTR("Outline Size"));
-	outline_size_list->get_line_edit()->add_theme_constant_override(SNAME("minimum_character_width"), 2);
+	outline_size_list->get_line_edit()->add_theme_constant_override("minimum_character_width", 2);
 	outline_size_list->set_min(0);
 	outline_size_list->set_step(1);
 	outline_size_list->set_max(96);

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -521,7 +521,7 @@ void TextEditor::update_toggle_scripts_button() {
 TextEditor::TextEditor() {
 	code_editor = memnew(CodeTextEditor);
 	add_child(code_editor);
-	code_editor->add_theme_constant_override(SNAME("separation"), 0);
+	code_editor->add_theme_constant_override("separation", 0);
 	code_editor->connect("load_theme_settings", callable_mp(this, &TextEditor::_load_theme_settings));
 	code_editor->connect("validate_script", callable_mp(this, &TextEditor::_validate_script));
 	code_editor->set_anchors_and_offsets_preset(Control::PRESET_WIDE);

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -171,11 +171,11 @@ Texture3DEditor::Texture3DEditor() {
 	info->set_anchor(SIDE_TOP, 1);
 	info->set_h_grow_direction(GROW_DIRECTION_BEGIN);
 	info->set_v_grow_direction(GROW_DIRECTION_BEGIN);
-	info->add_theme_color_override(SNAME("font_color"), Color(1, 1, 1, 1));
-	info->add_theme_color_override(SNAME("font_shadow_color"), Color(0, 0, 0, 0.5));
-	info->add_theme_constant_override(SNAME("shadow_outline_size"), 1);
-	info->add_theme_constant_override(SNAME("shadow_offset_x"), 2);
-	info->add_theme_constant_override(SNAME("shadow_offset_y"), 2);
+	info->add_theme_color_override("font_color", Color(1, 1, 1, 1));
+	info->add_theme_color_override("font_shadow_color", Color(0, 0, 0, 0.5));
+	info->add_theme_constant_override("shadow_outline_size", 1);
+	info->add_theme_constant_override("shadow_offset_x", 2);
+	info->add_theme_constant_override("shadow_offset_y", 2);
 
 	setting = false;
 	layer->connect("value_changed", Callable(this, "_layer_changed"));

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -50,7 +50,7 @@ void TexturePreview::_notification(int p_what) {
 
 			if (metadata_label) {
 				Ref<Font> metadata_label_font = get_theme_font(SNAME("expression"), SNAME("EditorFonts"));
-				metadata_label->add_theme_font_override(SNAME("font"), metadata_label_font);
+				metadata_label->add_theme_font_override("font", metadata_label_font);
 			}
 
 			checkerboard->set_texture(get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons")));
@@ -94,14 +94,14 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 		p_texture->connect("changed", callable_mp(this, &TexturePreview::_update_metadata_label_text));
 
 		// It's okay that these colors are static since the grid color is static too.
-		metadata_label->add_theme_color_override(SNAME("font_color"), Color::named("white"));
-		metadata_label->add_theme_color_override(SNAME("font_color_shadow"), Color::named("black"));
+		metadata_label->add_theme_color_override("font_color", Color::named("white"));
+		metadata_label->add_theme_color_override("font_color_shadow", Color::named("black"));
 
-		metadata_label->add_theme_font_size_override(SNAME("font_size"), 16 * EDSCALE);
-		metadata_label->add_theme_color_override(SNAME("font_outline_color"), Color::named("black"));
-		metadata_label->add_theme_constant_override(SNAME("outline_size"), 2 * EDSCALE);
+		metadata_label->add_theme_font_size_override("font_size", 16 * EDSCALE);
+		metadata_label->add_theme_color_override("font_outline_color", Color::named("black"));
+		metadata_label->add_theme_constant_override("outline_size", 2 * EDSCALE);
 
-		metadata_label->add_theme_constant_override(SNAME("shadow_outline_size"), 1);
+		metadata_label->add_theme_constant_override("shadow_outline_size", 1);
 		metadata_label->set_h_size_flags(Control::SIZE_SHRINK_END);
 		metadata_label->set_v_size_flags(Control::SIZE_SHRINK_END);
 

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -247,11 +247,11 @@ TextureLayeredEditor::TextureLayeredEditor() {
 	info->set_anchor(SIDE_TOP, 1);
 	info->set_h_grow_direction(GROW_DIRECTION_BEGIN);
 	info->set_v_grow_direction(GROW_DIRECTION_BEGIN);
-	info->add_theme_color_override(SNAME("font_color"), Color(1, 1, 1, 1));
-	info->add_theme_color_override(SNAME("font_shadow_color"), Color(0, 0, 0, 0.5));
-	info->add_theme_constant_override(SNAME("shadow_outline_size"), 1);
-	info->add_theme_constant_override(SNAME("shadow_offset_x"), 2);
-	info->add_theme_constant_override(SNAME("shadow_offset_y"), 2);
+	info->add_theme_color_override("font_color", Color(1, 1, 1, 1));
+	info->add_theme_color_override("font_shadow_color", Color(0, 0, 0, 0.5));
+	info->add_theme_constant_override("shadow_outline_size", 1);
+	info->add_theme_constant_override("shadow_offset_x", 2);
+	info->add_theme_constant_override("shadow_offset_y", 2);
 
 	setting = false;
 	layer->connect("value_changed", Callable(this, "_layer_changed"));

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -808,7 +808,7 @@ void TextureRegionEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			edit_draw->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			edit_draw->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		} break;
 		case NOTIFICATION_READY: {
 			zoom_out->set_icon(get_theme_icon(SNAME("ZoomLess"), SNAME("EditorIcons")));

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -830,7 +830,7 @@ void ThemeItemImportTree::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			select_icons_warning_icon->set_texture(get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
-			select_icons_warning->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
+			select_icons_warning->add_theme_color_override("font_color", get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
 
 			// Bottom panel buttons.
 			import_collapse_types_button->set_icon(get_theme_icon(SNAME("CollapseTree"), SNAME("EditorIcons")));
@@ -1824,8 +1824,8 @@ void ThemeItemEditorDialog::_notification(int p_what) {
 
 			import_another_theme_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 
-			tc->add_theme_style_override(SNAME("tab_selected"), get_theme_stylebox(SNAME("tab_selected_odd"), SNAME("TabContainer")));
-			tc->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("panel_odd"), SNAME("TabContainer")));
+			tc->add_theme_style_override("tab_selected", get_theme_stylebox(SNAME("tab_selected_odd"), SNAME("TabContainer")));
+			tc->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel_odd"), SNAME("TabContainer")));
 		} break;
 	}
 }
@@ -2389,7 +2389,7 @@ HBoxContainer *ThemeTypeEditor::_create_property_control(Theme::DataType p_data_
 		item_rename_cancel_button->connect("pressed", callable_mp(this, &ThemeTypeEditor::_item_rename_canceled), varray(p_data_type, p_item_name, item_name_container));
 		item_rename_cancel_button->hide();
 	} else {
-		item_name->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
+		item_name->add_theme_color_override("font_color", get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
 
 		Button *item_override_button = memnew(Button);
 		item_override_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
@@ -3251,8 +3251,8 @@ void ThemeTypeEditor::_notification(int p_what) {
 			data_type_tabs->set_tab_icon(5, get_theme_icon(SNAME("StyleBoxFlat"), SNAME("EditorIcons")));
 			data_type_tabs->set_tab_icon(6, get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
 
-			data_type_tabs->add_theme_style_override(SNAME("tab_selected"), get_theme_stylebox(SNAME("tab_selected_odd"), SNAME("TabContainer")));
-			data_type_tabs->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("panel_odd"), SNAME("TabContainer")));
+			data_type_tabs->add_theme_style_override("tab_selected", get_theme_stylebox(SNAME("tab_selected_odd"), SNAME("TabContainer")));
+			data_type_tabs->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel_odd"), SNAME("TabContainer")));
 
 			type_variation_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 		} break;
@@ -3532,9 +3532,9 @@ void ThemeEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
-			preview_tabs->add_theme_style_override(SNAME("tab_selected"), get_theme_stylebox(SNAME("ThemeEditorPreviewFG"), SNAME("EditorStyles")));
-			preview_tabs->add_theme_style_override(SNAME("tab_unselected"), get_theme_stylebox(SNAME("ThemeEditorPreviewBG"), SNAME("EditorStyles")));
-			preview_tabs_content->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("panel_odd"), SNAME("TabContainer")));
+			preview_tabs->add_theme_style_override("tab_selected", get_theme_stylebox(SNAME("ThemeEditorPreviewFG"), SNAME("EditorStyles")));
+			preview_tabs->add_theme_style_override("tab_unselected", get_theme_stylebox(SNAME("ThemeEditorPreviewBG"), SNAME("EditorStyles")));
+			preview_tabs_content->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel_odd"), SNAME("TabContainer")));
 
 			add_preview_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 		} break;
@@ -3586,7 +3586,7 @@ ThemeEditor::ThemeEditor() {
 	VBoxContainer *preview_tabs_vb = memnew(VBoxContainer);
 	preview_tabs_vb->set_h_size_flags(SIZE_EXPAND_FILL);
 	preview_tabs_vb->set_custom_minimum_size(Size2(520, 0) * EDSCALE);
-	preview_tabs_vb->add_theme_constant_override(SNAME("separation"), 2 * EDSCALE);
+	preview_tabs_vb->add_theme_constant_override("separation", 2 * EDSCALE);
 	main_hs->add_child(preview_tabs_vb);
 	HBoxContainer *preview_tabbar_hb = memnew(HBoxContainer);
 	preview_tabs_vb->add_child(preview_tabbar_hb);

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -247,10 +247,10 @@ ThemeEditorPreview::ThemeEditorPreview() {
 
 	preview_content = memnew(MarginContainer);
 	preview_root->add_child(preview_content);
-	preview_content->add_theme_constant_override(SNAME("margin_right"), 4 * EDSCALE);
-	preview_content->add_theme_constant_override(SNAME("margin_top"), 4 * EDSCALE);
-	preview_content->add_theme_constant_override(SNAME("margin_left"), 4 * EDSCALE);
-	preview_content->add_theme_constant_override(SNAME("margin_bottom"), 4 * EDSCALE);
+	preview_content->add_theme_constant_override("margin_right", 4 * EDSCALE);
+	preview_content->add_theme_constant_override("margin_top", 4 * EDSCALE);
+	preview_content->add_theme_constant_override("margin_left", 4 * EDSCALE);
+	preview_content->add_theme_constant_override("margin_bottom", 4 * EDSCALE);
 
 	preview_overlay = memnew(MarginContainer);
 	preview_overlay->set_mouse_filter(MOUSE_FILTER_IGNORE);
@@ -269,20 +269,20 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 	preview_content->add_child(main_panel);
 
 	MarginContainer *main_mc = memnew(MarginContainer);
-	main_mc->add_theme_constant_override(SNAME("margin_right"), 4 * EDSCALE);
-	main_mc->add_theme_constant_override(SNAME("margin_top"), 4 * EDSCALE);
-	main_mc->add_theme_constant_override(SNAME("margin_left"), 4 * EDSCALE);
-	main_mc->add_theme_constant_override(SNAME("margin_bottom"), 4 * EDSCALE);
+	main_mc->add_theme_constant_override("margin_right", 4 * EDSCALE);
+	main_mc->add_theme_constant_override("margin_top", 4 * EDSCALE);
+	main_mc->add_theme_constant_override("margin_left", 4 * EDSCALE);
+	main_mc->add_theme_constant_override("margin_bottom", 4 * EDSCALE);
 	preview_content->add_child(main_mc);
 
 	HBoxContainer *main_hb = memnew(HBoxContainer);
 	main_mc->add_child(main_hb);
-	main_hb->add_theme_constant_override(SNAME("separation"), 20 * EDSCALE);
+	main_hb->add_theme_constant_override("separation", 20 * EDSCALE);
 
 	VBoxContainer *first_vb = memnew(VBoxContainer);
 	main_hb->add_child(first_vb);
 	first_vb->set_h_size_flags(SIZE_EXPAND_FILL);
-	first_vb->add_theme_constant_override(SNAME("separation"), 10 * EDSCALE);
+	first_vb->add_theme_constant_override("separation", 10 * EDSCALE);
 
 	first_vb->add_child(memnew(Label("Label")));
 
@@ -343,7 +343,7 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 	VBoxContainer *second_vb = memnew(VBoxContainer);
 	second_vb->set_h_size_flags(SIZE_EXPAND_FILL);
 	main_hb->add_child(second_vb);
-	second_vb->add_theme_constant_override(SNAME("separation"), 10 * EDSCALE);
+	second_vb->add_theme_constant_override("separation", 10 * EDSCALE);
 	LineEdit *le = memnew(LineEdit);
 	le->set_text("LineEdit");
 	second_vb->add_child(le);
@@ -383,7 +383,7 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 
 	VBoxContainer *third_vb = memnew(VBoxContainer);
 	third_vb->set_h_size_flags(SIZE_EXPAND_FILL);
-	third_vb->add_theme_constant_override(SNAME("separation"), 10 * EDSCALE);
+	third_vb->add_theme_constant_override("separation", 10 * EDSCALE);
 	main_hb->add_child(third_vb);
 
 	TabContainer *tc = memnew(TabContainer);

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -585,7 +585,7 @@ TileAtlasView::TileAtlasView() {
 
 	hbox = memnew(HBoxContainer);
 	hbox->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
-	hbox->add_theme_constant_override(SNAME("separation"), 10);
+	hbox->add_theme_constant_override("separation", 10);
 	hbox->hide();
 	margin_container->add_child(hbox);
 

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -2095,7 +2095,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	scatter_spinbox->set_max(1000);
 	scatter_spinbox->set_step(0.001);
 	scatter_spinbox->set_tooltip(TTR("Defines the probability of painting nothing instead of a randomly selected tile."));
-	scatter_spinbox->get_line_edit()->add_theme_constant_override(SNAME("minimum_character_width"), 4);
+	scatter_spinbox->get_line_edit()->add_theme_constant_override("minimum_character_width", 4);
 	scatter_spinbox->connect("value_changed", callable_mp(this, &TileMapEditorTilesPlugin::_on_scattering_spinbox_changed));
 	tools_settings->add_child(scatter_spinbox);
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -609,8 +609,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 	}
 
 	// Theming.
-	tile_data_editors_tree->add_theme_constant_override(SNAME("vseparation"), 1);
-	tile_data_editors_tree->add_theme_constant_override(SNAME("hseparation"), 3);
+	tile_data_editors_tree->add_theme_constant_override("vseparation", 1);
+	tile_data_editors_tree->add_theme_constant_override("hseparation", 3);
 
 	Color group_color = get_theme_color(SNAME("prop_category"), SNAME("Editor"));
 
@@ -908,10 +908,10 @@ void TileSetAtlasSourceEditor::_update_atlas_view() {
 			alternative_tiles_control->add_child(button);
 			button->set_flat(true);
 			button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
-			button->add_theme_style_override(SNAME("normal"), memnew(StyleBoxEmpty));
-			button->add_theme_style_override(SNAME("hover"), memnew(StyleBoxEmpty));
-			button->add_theme_style_override(SNAME("focus"), memnew(StyleBoxEmpty));
-			button->add_theme_style_override(SNAME("pressed"), memnew(StyleBoxEmpty));
+			button->add_theme_style_override("normal", memnew(StyleBoxEmpty));
+			button->add_theme_style_override("hover", memnew(StyleBoxEmpty));
+			button->add_theme_style_override("focus", memnew(StyleBoxEmpty));
+			button->add_theme_style_override("pressed", memnew(StyleBoxEmpty));
 			button->connect("pressed", callable_mp(tile_set_atlas_source, &TileSetAtlasSource::create_alternative_tile), varray(tile_id, TileSetSource::INVALID_TILE_ALTERNATIVE));
 			button->set_rect(Rect2(Vector2(pos.x, pos.y + (y_increment - texture_region_base_size.y) / 2.0), Vector2(texture_region_base_size_min, texture_region_base_size_min)));
 			button->set_expand_icon(true);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -679,7 +679,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		} else {
 			hb = memnew(HBoxContainer);
 		}
-		hb->add_theme_constant_override(SNAME("separation"), 7 * EDSCALE);
+		hb->add_theme_constant_override("separation", 7 * EDSCALE);
 
 		Variant default_value;
 
@@ -732,14 +732,14 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 				} else {
 					Label *label = memnew(Label);
 					label->set_text(name_left);
-					label->add_theme_style_override(SNAME("normal"), label_style); //more compact
+					label->add_theme_style_override("normal", label_style); //more compact
 					hb->add_child(label);
 
 					if (vsnode->is_input_port_default(i, mode) && !port_left_used) {
 						Label *hint_label = memnew(Label);
 						hint_label->set_text(TTR("[default]"));
-						hint_label->add_theme_color_override(SNAME("font_color"), editor->get_theme_color(SNAME("font_readonly_color"), SNAME("TextEdit")));
-						hint_label->add_theme_style_override(SNAME("normal"), label_style);
+						hint_label->add_theme_color_override("font_color", editor->get_theme_color(SNAME("font_readonly_color"), SNAME("TextEdit")));
+						hint_label->add_theme_style_override("normal", label_style);
 						hb->add_child(hint_label);
 					}
 				}
@@ -779,7 +779,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 				} else {
 					Label *label = memnew(Label);
 					label->set_text(name_right);
-					label->add_theme_style_override(SNAME("normal"), label_style); //more compact
+					label->add_theme_style_override("normal", label_style); //more compact
 					hb->add_child(label);
 				}
 			}
@@ -896,7 +896,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 	String error = vsnode->get_warning(mode, p_type);
 	if (!error.is_empty()) {
 		Label *error_label = memnew(Label);
-		error_label->add_theme_color_override(SNAME("font_color"), editor->get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		error_label->add_theme_color_override("font_color", editor->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		error_label->set_text(error);
 		node->add_child(error_label);
 	}
@@ -920,7 +920,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		Color members_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
 
 		expression_box->set_syntax_highlighter(expression_syntax_highlighter);
-		expression_box->add_theme_color_override(SNAME("background_color"), background_color);
+		expression_box->add_theme_color_override("background_color", background_color);
 
 		for (const String &E : editor->keyword_list) {
 			if (ShaderLanguage::is_control_flow_keyword(E)) {
@@ -930,9 +930,9 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			}
 		}
 
-		expression_box->add_theme_font_override(SNAME("font"), editor->get_theme_font(SNAME("expression"), SNAME("EditorFonts")));
-		expression_box->add_theme_font_size_override(SNAME("font_size"), editor->get_theme_font_size(SNAME("expression_size"), SNAME("EditorFonts")));
-		expression_box->add_theme_color_override(SNAME("font_color"), text_color);
+		expression_box->add_theme_font_override("font", editor->get_theme_font(SNAME("expression"), SNAME("EditorFonts")));
+		expression_box->add_theme_font_size_override("font_size", editor->get_theme_font_size(SNAME("expression_size"), SNAME("EditorFonts")));
+		expression_box->add_theme_color_override("font_color", text_color);
 		expression_syntax_highlighter->set_number_color(number_color);
 		expression_syntax_highlighter->set_symbol_color(symbol_color);
 		expression_syntax_highlighter->set_function_color(function_color);
@@ -1512,10 +1512,10 @@ void VisualShaderEditor::_update_created_node(GraphNode *node) {
 	const Color mono_color = ((c.r + c.g + c.b) / 3) < 0.7 ? Color(1.0, 1.0, 1.0, 0.85) : Color(0.0, 0.0, 0.0, 0.85);
 	c = mono_color;
 
-	node->add_theme_color_override(SNAME("title_color"), c);
+	node->add_theme_color_override("title_color", c);
 	c.a = 0.7;
-	node->add_theme_color_override(SNAME("close_color"), c);
-	node->add_theme_color_override(SNAME("resizer_color"), c);
+	node->add_theme_color_override("close_color", c);
+	node->add_theme_color_override("resizer_color", c);
 }
 
 void VisualShaderEditor::_update_uniforms(bool p_update_refs) {
@@ -3421,7 +3421,7 @@ void VisualShaderEditor::_notification(int p_what) {
 			Color number_color = EDITOR_GET("text_editor/theme/highlighting/number_color");
 			Color members_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
 
-			preview_text->add_theme_color_override(SNAME("background_color"), background_color);
+			preview_text->add_theme_color_override("background_color", background_color);
 
 			for (const String &E : keyword_list) {
 				if (ShaderLanguage::is_control_flow_keyword(E)) {
@@ -3431,9 +3431,9 @@ void VisualShaderEditor::_notification(int p_what) {
 				}
 			}
 
-			preview_text->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("expression"), SNAME("EditorFonts")));
-			preview_text->add_theme_font_size_override(SNAME("font_size"), get_theme_font_size(SNAME("expression_size"), SNAME("EditorFonts")));
-			preview_text->add_theme_color_override(SNAME("font_color"), text_color);
+			preview_text->add_theme_font_override("font", get_theme_font(SNAME("expression"), SNAME("EditorFonts")));
+			preview_text->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("expression_size"), SNAME("EditorFonts")));
+			preview_text->add_theme_color_override("font_color", text_color);
 			syntax_highlighter->set_number_color(number_color);
 			syntax_highlighter->set_symbol_color(symbol_color);
 			syntax_highlighter->set_function_color(function_color);
@@ -3446,10 +3446,10 @@ void VisualShaderEditor::_notification(int p_what) {
 			preview_text->add_comment_delimiter("/*", "*/", false);
 			preview_text->add_comment_delimiter("//", "", true);
 
-			error_panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
-			error_label->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
-			error_label->add_theme_font_size_override(SNAME("font_size"), get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
-			error_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
+			error_label->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+			error_label->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+			error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		}
 
 		tools->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
@@ -4301,7 +4301,7 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	preview_vbox = memnew(VBoxContainer);
 	preview_window->add_child(preview_vbox);
-	preview_vbox->add_theme_constant_override(SNAME("separation"), 0);
+	preview_vbox->add_theme_constant_override("separation", 0);
 
 	preview_text = memnew(CodeEdit);
 	syntax_highlighter.instantiate();

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1158,7 +1158,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	script_key->connect("text_changed", callable_mp(this, &ProjectExportDialog::_script_encryption_key_changed));
 	script_key_error = memnew(Label);
 	script_key_error->set_text(String::utf8("•  ") + TTR("Invalid Encryption Key (must be 64 hexadecimal characters long)"));
-	script_key_error->add_theme_color_override(SNAME("font_color"), EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
+	script_key_error->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	sec_vb->add_margin_child(TTR("Encryption Key (256-bits as hexadecimal):"), script_key);
 	sec_vb->add_child(script_key_error);
 	sections->add_child(sec_vb);
@@ -1227,12 +1227,12 @@ ProjectExportDialog::ProjectExportDialog() {
 	export_error = memnew(Label);
 	main_vb->add_child(export_error);
 	export_error->hide();
-	export_error->add_theme_color_override(SNAME("font_color"), EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
+	export_error->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 
 	export_warning = memnew(Label);
 	main_vb->add_child(export_warning);
 	export_warning->hide();
-	export_warning->add_theme_color_override(SNAME("font_color"), EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+	export_warning->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 
 	export_templates_error = memnew(HBoxContainer);
 	main_vb->add_child(export_templates_error);
@@ -1240,7 +1240,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	Label *export_error2 = memnew(Label);
 	export_templates_error->add_child(export_error2);
-	export_error2->add_theme_color_override(SNAME("font_color"), EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
+	export_error2->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	export_error2->set_text(String::utf8("•  ") + TTR("Export templates for this platform are missing:") + " ");
 
 	error_dialog = memnew(AcceptDialog);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -117,13 +117,13 @@ private:
 
 		switch (p_type) {
 			case MESSAGE_ERROR: {
-				msg->add_theme_color_override(SNAME("font_color"), msg->get_theme_color(SNAME("error_color"), SNAME("Editor")));
+				msg->add_theme_color_override("font_color", msg->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 				msg->set_modulate(Color(1, 1, 1, 1));
 				new_icon = msg->get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons"));
 
 			} break;
 			case MESSAGE_WARNING: {
-				msg->add_theme_color_override(SNAME("font_color"), msg->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+				msg->add_theme_color_override("font_color", msg->get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 				msg->set_modulate(Color(1, 1, 1, 1));
 				new_icon = msg->get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons"));
 
@@ -1349,7 +1349,7 @@ void ProjectList::create_project_item_control(int p_index) {
 	ProjectListItemControl *hb = memnew(ProjectListItemControl);
 	hb->connect("draw", callable_mp(this, &ProjectList::_panel_draw), varray(hb));
 	hb->connect("gui_input", callable_mp(this, &ProjectList::_panel_input), varray(hb));
-	hb->add_theme_constant_override(SNAME("separation"), 10 * EDSCALE);
+	hb->add_theme_constant_override("separation", 10 * EDSCALE);
 	hb->set_tooltip(item.description);
 
 	VBoxContainer *favorite_box = memnew(VBoxContainer);
@@ -1394,9 +1394,9 @@ void ProjectList::create_project_item_control(int p_index) {
 
 		Label *title = memnew(Label(!item.missing ? item.project_name : TTR("Missing Project")));
 		title->set_h_size_flags(Control::SIZE_EXPAND_FILL);
-		title->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("title"), SNAME("EditorFonts")));
-		title->add_theme_font_size_override(SNAME("font_size"), get_theme_font_size(SNAME("title_size"), SNAME("EditorFonts")));
-		title->add_theme_color_override(SNAME("font_color"), font_color);
+		title->add_theme_font_override("font", get_theme_font(SNAME("title"), SNAME("EditorFonts")));
+		title->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("title_size"), SNAME("EditorFonts")));
+		title->add_theme_color_override("font_color", font_color);
 		title->set_clip_text(true);
 		title_hb->add_child(title);
 
@@ -1405,8 +1405,8 @@ void ProjectList::create_project_item_control(int p_index) {
 		if (length > 0) {
 			Label *unsupported_label = memnew(Label(unsupported_features_str));
 			unsupported_label->set_custom_minimum_size(Size2(length * 15, 10) * EDSCALE);
-			unsupported_label->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("title"), SNAME("EditorFonts")));
-			unsupported_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+			unsupported_label->add_theme_font_override("font", get_theme_font(SNAME("title"), SNAME("EditorFonts")));
+			unsupported_label->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 			unsupported_label->set_clip_text(true);
 			unsupported_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 			title_hb->add_child(unsupported_label);
@@ -1443,7 +1443,7 @@ void ProjectList::create_project_item_control(int p_index) {
 		path_hb->add_child(fpath);
 		fpath->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		fpath->set_modulate(Color(1, 1, 1, 0.5));
-		fpath->add_theme_color_override(SNAME("font_color"), font_color);
+		fpath->add_theme_color_override("font_color", font_color);
 		fpath->set_clip_text(true);
 	}
 
@@ -2524,7 +2524,7 @@ ProjectManager::ProjectManager() {
 	Panel *panel = memnew(Panel);
 	add_child(panel);
 	panel->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
-	panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("Background"), SNAME("EditorStyles")));
+	panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("Background"), SNAME("EditorStyles")));
 
 	VBoxContainer *vb = memnew(VBoxContainer);
 	panel->add_child(vb);
@@ -2562,7 +2562,7 @@ ProjectManager::ProjectManager() {
 		hb->add_child(search_box);
 
 		loading_label = memnew(Label(TTR("Loading, please wait...")));
-		loading_label->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("bold"), SNAME("EditorFonts")));
+		loading_label->add_theme_font_override("font", get_theme_font(SNAME("bold"), SNAME("EditorFonts")));
 		loading_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		hb->add_child(loading_label);
 		// Hide the label but make it still take up space. This prevents reflows when showing the label.
@@ -2588,7 +2588,7 @@ ProjectManager::ProjectManager() {
 		}
 
 		PanelContainer *pc = memnew(PanelContainer);
-		pc->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+		pc->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		pc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 		search_tree_vb->add_child(pc);
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -509,9 +509,9 @@ void ProjectSettingsEditor::_update_action_map_editor() {
 void ProjectSettingsEditor::_update_theme() {
 	search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 	restart_close_button->set_icon(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
-	restart_container->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+	restart_container->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 	restart_icon->set_texture(get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
-	restart_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+	restart_label->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 
 	type_box->clear();
 	for (int i = 0; i < Variant::VARIANT_MAX; i++) {

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -261,7 +261,7 @@ EditorQuickOpen::EditorQuickOpen() {
 	search_options->create_item();
 	search_options->set_hide_root(true);
 	search_options->set_hide_folding(true);
-	search_options->add_theme_constant_override(SNAME("draw_guides"), 1);
+	search_options->add_theme_constant_override("draw_guides", 1);
 	vbc->add_margin_child(TTR("Matches:"), search_options, true);
 
 	get_ok_button()->set_text(TTR("Open"));

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -391,9 +391,9 @@ void RenameDialog::_update_preview(String new_text) {
 			// New name is identical to the old one. Don't color it as much to avoid distracting the user.
 			const Color accent_color = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("accent_color"), SNAME("Editor"));
 			const Color text_color = EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("default_color"), SNAME("RichTextLabel"));
-			lbl_preview->add_theme_color_override(SNAME("font_color"), accent_color.lerp(text_color, 0.5));
+			lbl_preview->add_theme_color_override("font_color", accent_color.lerp(text_color, 0.5));
 		} else {
-			lbl_preview->add_theme_color_override(SNAME("font_color"), EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("success_color"), SNAME("Editor")));
+			lbl_preview->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("success_color"), SNAME("Editor")));
 		}
 	}
 
@@ -479,7 +479,7 @@ void RenameDialog::_error_handler(void *p_self, const char *p_func, const char *
 
 	self->has_errors = true;
 	self->lbl_preview_title->set_text(TTR("Regular Expression Error:"));
-	self->lbl_preview->add_theme_color_override(SNAME("font_color"), EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
+	self->lbl_preview->add_theme_color_override("font_color", EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	self->lbl_preview->set_text(vformat(TTR("At character %s"), err_str));
 }
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3301,7 +3301,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	VBoxContainer *vbc = this;
 
 	HBoxContainer *filter_hbc = memnew(HBoxContainer);
-	filter_hbc->add_theme_constant_override(SNAME("separate"), 0);
+	filter_hbc->add_theme_constant_override("separate", 0);
 
 	ED_SHORTCUT("scene_tree/rename", TTR("Rename"), Key::F2);
 	ED_SHORTCUT_OVERRIDE("scene_tree/rename", "macos", Key::ENTER);
@@ -3349,7 +3349,7 @@ SceneTreeDock::SceneTreeDock(EditorNode *p_editor, Node *p_scene_root, EditorSel
 	filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	filter->set_placeholder(TTR("Filter nodes"));
 	filter_hbc->add_child(filter);
-	filter->add_theme_constant_override(SNAME("minimum_character_width"), 0);
+	filter->add_theme_constant_override("minimum_character_width", 0);
 	filter->connect("text_changed", callable_mp(this, &SceneTreeDock::_filter_changed));
 
 	button_create_script = memnew(Button);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1219,7 +1219,7 @@ SceneTreeEditor::SceneTreeEditor(bool p_label, bool p_can_rename, bool p_can_ope
 	tree->set_begin(Point2(0, p_label ? 18 : 0));
 	tree->set_end(Point2(0, 0));
 	tree->set_allow_reselect(true);
-	tree->add_theme_constant_override(SNAME("button_margin"), 0);
+	tree->add_theme_constant_override("button_margin", 0);
 
 	add_child(tree);
 
@@ -1324,7 +1324,7 @@ SceneTreeDialog::SceneTreeDialog() {
 	filter->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	filter->set_placeholder(TTR("Filter nodes"));
 	filter->set_clear_button_enabled(true);
-	filter->add_theme_constant_override(SNAME("minimum_character_width"), 0);
+	filter->add_theme_constant_override("minimum_character_width", 0);
 	filter->connect("text_changed", callable_mp(this, &SceneTreeDialog::_filter_changed));
 	vbc->add_child(filter);
 

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -70,7 +70,7 @@ void ScriptCreateDialog::_notification(int p_what) {
 			path_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 			parent_browse_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
 			parent_search_button->set_icon(get_theme_icon(SNAME("ClassList"), SNAME("EditorIcons")));
-			status_panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			status_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		} break;
 	}
 }
@@ -291,7 +291,7 @@ void ScriptCreateDialog::_template_changed(int p_template) {
 		template_info += " - " + sinfo.description;
 	}
 	template_info_label->set_text(template_info);
-	template_info_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("success_color"), SNAME("Editor")));
+	template_info_label->add_theme_color_override("font_color", get_theme_color(SNAME("success_color"), SNAME("Editor")));
 }
 
 void ScriptCreateDialog::ok_pressed() {
@@ -522,18 +522,18 @@ void ScriptCreateDialog::_path_submitted(const String &p_path) {
 void ScriptCreateDialog::_msg_script_valid(bool valid, const String &p_msg) {
 	error_label->set_text(String::utf8("•  ") + p_msg);
 	if (valid) {
-		error_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("success_color"), SNAME("Editor")));
+		error_label->add_theme_color_override("font_color", get_theme_color(SNAME("success_color"), SNAME("Editor")));
 	} else {
-		error_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	}
 }
 
 void ScriptCreateDialog::_msg_path_valid(bool valid, const String &p_msg) {
 	path_error_label->set_text(String::utf8("•  ") + p_msg);
 	if (valid) {
-		path_error_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("success_color"), SNAME("Editor")));
+		path_error_label->add_theme_color_override("font_color", get_theme_color(SNAME("success_color"), SNAME("Editor")));
 	} else {
-		path_error_label->add_theme_color_override(SNAME("font_color"), get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		path_error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	}
 }
 
@@ -658,7 +658,7 @@ void ScriptCreateDialog::_update_dialog() {
 			class_name->set_placeholder(TTR("Allowed: a-z, A-Z, 0-9, _ and ."));
 			Color placeholder_color = class_name->get_theme_color(SNAME("font_placeholder_color"));
 			placeholder_color.a = 0.3;
-			class_name->add_theme_color_override(SNAME("font_placeholder_color"), placeholder_color);
+			class_name->add_theme_color_override("font_placeholder_color", placeholder_color);
 		} else {
 			class_name->set_editable(false);
 		}
@@ -667,7 +667,7 @@ void ScriptCreateDialog::_update_dialog() {
 		class_name->set_placeholder(TTR("N/A"));
 		Color placeholder_color = class_name->get_theme_color(SNAME("font_placeholder_color"));
 		placeholder_color.a = 1;
-		class_name->add_theme_color_override(SNAME("font_placeholder_color"), placeholder_color);
+		class_name->add_theme_color_override("font_placeholder_color", placeholder_color);
 		class_name->set_text("");
 	}
 
@@ -911,7 +911,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 	script_name_warning_label->set_text(
 			TTR("Warning: Having the script name be the same as a built-in type is usually not desired."));
 	vb->add_child(script_name_warning_label);
-	script_name_warning_label->add_theme_color_override(SNAME("font_color"), Color(1, 0.85, 0.4));
+	script_name_warning_label->add_theme_color_override("font_color", Color(1, 0.85, 0.4));
 	script_name_warning_label->set_autowrap_mode(Label::AUTOWRAP_WORD_SMART);
 	script_name_warning_label->hide();
 

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -72,7 +72,7 @@ void ShaderCreateDialog::_update_theme() {
 	}
 
 	path_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
-	status_panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+	status_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 }
 
 void ShaderCreateDialog::_update_language_info() {
@@ -419,18 +419,18 @@ String ShaderCreateDialog::_validate_path(const String &p_path) {
 void ShaderCreateDialog::_msg_script_valid(bool valid, const String &p_msg) {
 	error_label->set_text("- " + p_msg);
 	if (valid) {
-		error_label->add_theme_color_override(SNAME("font_color"), gc->get_theme_color(SNAME("success_color"), SNAME("Editor")));
+		error_label->add_theme_color_override("font_color", gc->get_theme_color(SNAME("success_color"), SNAME("Editor")));
 	} else {
-		error_label->add_theme_color_override(SNAME("font_color"), gc->get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		error_label->add_theme_color_override("font_color", gc->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	}
 }
 
 void ShaderCreateDialog::_msg_path_valid(bool valid, const String &p_msg) {
 	path_error_label->set_text("- " + p_msg);
 	if (valid) {
-		path_error_label->add_theme_color_override(SNAME("font_color"), gc->get_theme_color(SNAME("success_color"), SNAME("Editor")));
+		path_error_label->add_theme_color_override("font_color", gc->get_theme_color(SNAME("success_color"), SNAME("Editor")));
 	} else {
-		path_error_label->add_theme_color_override(SNAME("font_color"), gc->get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		path_error_label->add_theme_color_override("font_color", gc->get_theme_color(SNAME("error_color"), SNAME("Editor")));
 	}
 }
 

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -1181,7 +1181,7 @@ GridMapEditor::GridMapEditor(EditorNode *p_editor) {
 	floor->set_min(-32767);
 	floor->set_max(32767);
 	floor->set_step(1);
-	floor->get_line_edit()->add_theme_constant_override(SNAME("minimum_character_width"), 16);
+	floor->get_line_edit()->add_theme_constant_override("minimum_character_width", 16);
 
 	spatial_editor_hb->add_child(floor);
 	floor->connect("value_changed", callable_mp(this, &GridMapEditor::_floor_changed));

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -713,7 +713,7 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			LineEdit *line_edit = memnew(LineEdit);
 			line_edit->set_text(node->get_text());
 			line_edit->set_expand_to_text_length_enabled(true);
-			line_edit->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("source"), SNAME("EditorFonts")));
+			line_edit->add_theme_font_override("font", get_theme_font(SNAME("source"), SNAME("EditorFonts")));
 			gnode->add_child(line_edit);
 			line_edit->connect("text_changed", callable_mp(this, &VisualScriptEditor::_expression_text_changed), varray(E));
 		} else {
@@ -743,11 +743,11 @@ void VisualScriptEditor::_update_graph(int p_only_id) {
 			Color c = sbf->get_border_color();
 			c = ((c.r + c.g + c.b) / 3) < 0.7 ? Color(1.0, 1.0, 1.0, 0.85) : Color(0.0, 0.0, 0.0, 0.85);
 			Color ic = c;
-			gnode->add_theme_color_override(SNAME("title_color"), c);
+			gnode->add_theme_color_override("title_color", c);
 			c.a = 1;
-			gnode->add_theme_color_override(SNAME("close_color"), c);
-			gnode->add_theme_color_override(SNAME("resizer_color"), ic);
-			gnode->add_theme_style_override(SNAME("frame"), sbf);
+			gnode->add_theme_color_override("close_color", c);
+			gnode->add_theme_color_override("resizer_color", ic);
+			gnode->add_theme_style_override("frame", sbf);
 		}
 
 		const Color mono_color = get_theme_color(SNAME("mono_color"), SNAME("Editor"));
@@ -2661,7 +2661,7 @@ Ref<Texture2D> VisualScriptEditor::get_theme_icon() {
 		icon_name += "Internal";
 	}
 
-	if (Control::has_theme_icon(icon_name, SNAME("EditorIcons"))) {
+	if (Control::has_theme_icon(icon_name, "EditorIcons")) {
 		return Control::get_theme_icon(icon_name, SNAME("EditorIcons"));
 	}
 
@@ -3931,13 +3931,13 @@ void VisualScriptEditor::_notification(int p_what) {
 
 			update_toggle_scripts_button();
 
-			edit_variable_edit->add_theme_style_override(SNAME("bg"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
-			edit_signal_edit->add_theme_style_override(SNAME("bg"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
-			func_input_scroll->add_theme_style_override(SNAME("bg"), get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			edit_variable_edit->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			edit_signal_edit->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			func_input_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 
 			Ref<Theme> tm = EditorNode::get_singleton()->get_theme_base()->get_theme();
 
-			bool dark_theme = tm->get_constant(SNAME("dark_theme"), SNAME("Editor"));
+			bool dark_theme = tm->get_constant("dark_theme", "Editor");
 
 			if (dark_theme) {
 				node_colors["flow_control"] = Color(0.96, 0.96, 0.96);

--- a/modules/visual_script/editor/visual_script_property_selector.cpp
+++ b/modules/visual_script/editor/visual_script_property_selector.cpp
@@ -46,7 +46,7 @@
 void VisualScriptPropertySelector::_update_icons() {
 	search_box->set_right_icon(results_tree->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 	search_box->set_clear_button_enabled(true);
-	search_box->add_theme_icon_override(SNAME("right_icon"), results_tree->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
+	search_box->add_theme_icon_override("right_icon", results_tree->get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 
 	search_visual_script_nodes->set_icon(results_tree->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons")));
 	search_classes->set_icon(results_tree->get_theme_icon(SNAME("Object"), SNAME("EditorIcons")));
@@ -1114,14 +1114,14 @@ TreeItem *VisualScriptPropertySelector::SearchRunner::_create_class_item(TreeIte
 	String details = p_doc->name;
 	if (p_doc->category.begins_with("VisualScriptCustomNode/")) {
 		Vector<String> path = p_doc->name.split("/");
-		icon = ui_service->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons"));
+		icon = ui_service->get_theme_icon("VisualScript", "EditorIcons");
 		text_0 = path[path.size() - 1];
 		text_1 = "VisualScriptCustomNode";
 		what = "VisualScriptCustomNode";
 		details = "CustomNode";
 	} else if (p_doc->category.begins_with("VisualScriptNode/")) {
 		Vector<String> path = p_doc->name.split("/");
-		icon = ui_service->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons"));
+		icon = ui_service->get_theme_icon("VisualScript", "EditorIcons");
 		text_0 = path[path.size() - 1];
 		if (p_doc->category.begins_with("VisualScriptNode/deconstruct")) {
 			text_0 = "deconstruct " + text_0;
@@ -1142,11 +1142,11 @@ TreeItem *VisualScriptPropertySelector::SearchRunner::_create_class_item(TreeIte
 	} else {
 		if (p_doc->name.is_quoted()) {
 			text_0 = p_doc->name.unquote().get_file();
-			if (ui_service->has_theme_icon(p_doc->inherits, SNAME("EditorIcons"))) {
-				icon = ui_service->get_theme_icon(p_doc->inherits, SNAME("EditorIcons"));
+			if (ui_service->has_theme_icon(p_doc->inherits, "EditorIcons")) {
+				icon = ui_service->get_theme_icon(p_doc->inherits, "EditorIcons");
 			}
-		} else if (ui_service->has_theme_icon(p_doc->name, SNAME("EditorIcons"))) {
-			icon = ui_service->get_theme_icon(p_doc->name, SNAME("EditorIcons"));
+		} else if (ui_service->has_theme_icon(p_doc->name, "EditorIcons")) {
+			icon = ui_service->get_theme_icon(p_doc->name, "EditorIcons");
 		} else if (ClassDB::class_exists(p_doc->name) && ClassDB::is_parent_class(p_doc->name, "Object")) {
 			icon = ui_service->get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
 		}

--- a/modules/visual_script/editor/visual_script_property_selector.cpp
+++ b/modules/visual_script/editor/visual_script_property_selector.cpp
@@ -1114,14 +1114,14 @@ TreeItem *VisualScriptPropertySelector::SearchRunner::_create_class_item(TreeIte
 	String details = p_doc->name;
 	if (p_doc->category.begins_with("VisualScriptCustomNode/")) {
 		Vector<String> path = p_doc->name.split("/");
-		icon = ui_service->get_theme_icon("VisualScript", "EditorIcons");
+		icon = ui_service->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons"));
 		text_0 = path[path.size() - 1];
 		text_1 = "VisualScriptCustomNode";
 		what = "VisualScriptCustomNode";
 		details = "CustomNode";
 	} else if (p_doc->category.begins_with("VisualScriptNode/")) {
 		Vector<String> path = p_doc->name.split("/");
-		icon = ui_service->get_theme_icon("VisualScript", "EditorIcons");
+		icon = ui_service->get_theme_icon(SNAME("VisualScript"), SNAME("EditorIcons"));
 		text_0 = path[path.size() - 1];
 		if (p_doc->category.begins_with("VisualScriptNode/deconstruct")) {
 			text_0 = "deconstruct " + text_0;

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -353,7 +353,7 @@ MarginContainer *VBoxContainer::add_margin_child(const String &p_label, Control 
 	l->set_text(p_label);
 	add_child(l);
 	MarginContainer *mc = memnew(MarginContainer);
-	mc->add_theme_constant_override(SNAME("margin_left"), 0);
+	mc->add_theme_constant_override("margin_left", 0);
 	mc->add_child(p_control, true);
 	add_child(mc);
 	if (p_expand) {

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -127,7 +127,7 @@ void Button::_notification(int p_what) {
 				} break;
 				case DRAW_HOVER_PRESSED: {
 					// Edge case for CheckButton and CheckBox.
-					if (has_theme_stylebox(SNAME("hover_pressed"))) {
+					if (has_theme_stylebox("hover_pressed")) {
 						if (rtl && has_theme_stylebox(SNAME("hover_pressed_mirrored"))) {
 							style = get_theme_stylebox(SNAME("hover_pressed_mirrored"));
 						} else {

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -70,7 +70,7 @@ void ColorPicker::_notification(int p_what) {
 			w_edit->set_custom_minimum_size(Size2(get_theme_constant(SNAME("h_width")), 0));
 
 			wheel_edit->set_custom_minimum_size(Size2(get_theme_constant(SNAME("sv_width")), get_theme_constant(SNAME("sv_height"))));
-			wheel_margin->add_theme_constant_override(SNAME("margin_bottom"), 8 * get_theme_default_base_scale());
+			wheel_margin->add_theme_constant_override("margin_bottom", 8 * get_theme_default_base_scale());
 
 			for (int i = 0; i < 4; i++) {
 				labels[i]->set_custom_minimum_size(Size2(get_theme_constant(SNAME("label_width")), 0));
@@ -191,22 +191,22 @@ void ColorPicker::_update_controls() {
 
 	if (raw_mode_enabled) {
 		for (int i = 0; i < 3; i++) {
-			scroll[i]->remove_theme_icon_override(SNAME("grabber"));
-			scroll[i]->remove_theme_icon_override(SNAME("grabber_highlight"));
-			scroll[i]->remove_theme_style_override(SNAME("slider"));
-			scroll[i]->remove_theme_style_override(SNAME("grabber_area"));
-			scroll[i]->remove_theme_style_override(SNAME("grabber_area_highlight"));
+			scroll[i]->remove_theme_icon_override("grabber");
+			scroll[i]->remove_theme_icon_override("grabber_highlight");
+			scroll[i]->remove_theme_style_override("slider");
+			scroll[i]->remove_theme_style_override("grabber_area");
+			scroll[i]->remove_theme_style_override("grabber_area_highlight");
 		}
 	} else {
 		Ref<StyleBoxEmpty> style_box_empty(memnew(StyleBoxEmpty));
 		Ref<Texture2D> bar_arrow = get_theme_icon(SNAME("bar_arrow"));
 
 		for (int i = 0; i < 4; i++) {
-			scroll[i]->add_theme_icon_override(SNAME("grabber"), bar_arrow);
-			scroll[i]->add_theme_icon_override(SNAME("grabber_highlight"), bar_arrow);
-			scroll[i]->add_theme_style_override(SNAME("slider"), style_box_empty);
-			scroll[i]->add_theme_style_override(SNAME("grabber_area"), style_box_empty);
-			scroll[i]->add_theme_style_override(SNAME("grabber_area_highlight"), style_box_empty);
+			scroll[i]->add_theme_icon_override("grabber", bar_arrow);
+			scroll[i]->add_theme_icon_override("grabber_highlight", bar_arrow);
+			scroll[i]->add_theme_style_override("slider", style_box_empty);
+			scroll[i]->add_theme_style_override("grabber_area", style_box_empty);
+			scroll[i]->add_theme_style_override("grabber_area_highlight", style_box_empty);
 		}
 	}
 
@@ -1245,7 +1245,7 @@ ColorPicker::ColorPicker() :
 	circle_mat.instantiate();
 	circle_mat->set_shader(circle_shader);
 
-	wheel_margin->add_theme_constant_override(SNAME("margin_bottom"), 8);
+	wheel_margin->add_theme_constant_override("margin_bottom", 8);
 	wheel_edit->add_child(wheel_margin);
 
 	wheel_margin->add_child(wheel);

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -73,7 +73,7 @@ void AcceptDialog::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_THEME_CHANGED: {
-			bg->add_theme_style_override(SNAME("panel"), bg->get_theme_stylebox(SNAME("panel"), SNAME("AcceptDialog")));
+			bg->add_theme_style_override("panel", bg->get_theme_stylebox(SNAME("panel"), SNAME("AcceptDialog")));
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			if (parent_visible) {

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -65,30 +65,30 @@ void FileDialog::_theme_changed() {
 	Color font_focus_color = vbox->get_theme_color(SNAME("font_focus_color"), SNAME("Button"));
 	Color font_pressed_color = vbox->get_theme_color(SNAME("font_pressed_color"), SNAME("Button"));
 
-	dir_up->add_theme_color_override(SNAME("icon_normal_color"), font_color);
-	dir_up->add_theme_color_override(SNAME("icon_hover_color"), font_hover_color);
-	dir_up->add_theme_color_override(SNAME("icon_focus_color"), font_focus_color);
-	dir_up->add_theme_color_override(SNAME("icon_pressed_color"), font_pressed_color);
+	dir_up->add_theme_color_override("icon_normal_color", font_color);
+	dir_up->add_theme_color_override("icon_hover_color", font_hover_color);
+	dir_up->add_theme_color_override("icon_focus_color", font_focus_color);
+	dir_up->add_theme_color_override("icon_pressed_color", font_pressed_color);
 
-	dir_prev->add_theme_color_override(SNAME("icon_color_normal"), font_color);
-	dir_prev->add_theme_color_override(SNAME("icon_color_hover"), font_hover_color);
-	dir_prev->add_theme_color_override(SNAME("icon_focus_color"), font_focus_color);
-	dir_prev->add_theme_color_override(SNAME("icon_color_pressed"), font_pressed_color);
+	dir_prev->add_theme_color_override("icon_color_normal", font_color);
+	dir_prev->add_theme_color_override("icon_color_hover", font_hover_color);
+	dir_prev->add_theme_color_override("icon_focus_color", font_focus_color);
+	dir_prev->add_theme_color_override("icon_color_pressed", font_pressed_color);
 
-	dir_next->add_theme_color_override(SNAME("icon_color_normal"), font_color);
-	dir_next->add_theme_color_override(SNAME("icon_color_hover"), font_hover_color);
-	dir_next->add_theme_color_override(SNAME("icon_focus_color"), font_focus_color);
-	dir_next->add_theme_color_override(SNAME("icon_color_pressed"), font_pressed_color);
+	dir_next->add_theme_color_override("icon_color_normal", font_color);
+	dir_next->add_theme_color_override("icon_color_hover", font_hover_color);
+	dir_next->add_theme_color_override("icon_focus_color", font_focus_color);
+	dir_next->add_theme_color_override("icon_color_pressed", font_pressed_color);
 
-	refresh->add_theme_color_override(SNAME("icon_normal_color"), font_color);
-	refresh->add_theme_color_override(SNAME("icon_hover_color"), font_hover_color);
-	refresh->add_theme_color_override(SNAME("icon_focus_color"), font_focus_color);
-	refresh->add_theme_color_override(SNAME("icon_pressed_color"), font_pressed_color);
+	refresh->add_theme_color_override("icon_normal_color", font_color);
+	refresh->add_theme_color_override("icon_hover_color", font_hover_color);
+	refresh->add_theme_color_override("icon_focus_color", font_focus_color);
+	refresh->add_theme_color_override("icon_pressed_color", font_pressed_color);
 
-	show_hidden->add_theme_color_override(SNAME("icon_normal_color"), font_color);
-	show_hidden->add_theme_color_override(SNAME("icon_hover_color"), font_hover_color);
-	show_hidden->add_theme_color_override(SNAME("icon_focus_color"), font_focus_color);
-	show_hidden->add_theme_color_override(SNAME("icon_pressed_color"), font_pressed_color);
+	show_hidden->add_theme_color_override("icon_normal_color", font_color);
+	show_hidden->add_theme_color_override("icon_hover_color", font_hover_color);
+	show_hidden->add_theme_color_override("icon_focus_color", font_focus_color);
+	show_hidden->add_theme_color_override("icon_pressed_color", font_pressed_color);
 }
 
 void FileDialog::_notification(int p_what) {

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -242,9 +242,9 @@ void PopupPanel::_update_child_rects() {
 
 void PopupPanel::_notification(int p_what) {
 	if (p_what == NOTIFICATION_THEME_CHANGED) {
-		panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("panel"), get_class_name()));
+		panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), get_class_name()));
 	} else if (p_what == NOTIFICATION_READY || p_what == NOTIFICATION_ENTER_TREE) {
-		panel->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("panel"), get_class_name()));
+		panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), get_class_name()));
 		_update_child_rects();
 	} else if (p_what == NOTIFICATION_WM_SIZE_CHANGED) {
 		_update_child_rects();

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -846,10 +846,10 @@ void PopupMenu::_notification(int p_what) {
 
 				// Set margin on the margin container
 				Ref<StyleBox> panel_style = get_theme_stylebox(SNAME("panel"));
-				margin_container->add_theme_constant_override(SNAME("margin_top"), panel_style->get_margin(Side::SIDE_TOP));
-				margin_container->add_theme_constant_override(SNAME("margin_bottom"), panel_style->get_margin(Side::SIDE_BOTTOM));
-				margin_container->add_theme_constant_override(SNAME("margin_left"), panel_style->get_margin(Side::SIDE_LEFT));
-				margin_container->add_theme_constant_override(SNAME("margin_right"), panel_style->get_margin(Side::SIDE_RIGHT));
+				margin_container->add_theme_constant_override("margin_top", panel_style->get_margin(Side::SIDE_TOP));
+				margin_container->add_theme_constant_override("margin_bottom", panel_style->get_margin(Side::SIDE_BOTTOM));
+				margin_container->add_theme_constant_override("margin_left", panel_style->get_margin(Side::SIDE_LEFT));
+				margin_container->add_theme_constant_override("margin_right", panel_style->get_margin(Side::SIDE_RIGHT));
 			}
 		} break;
 	}

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4941,7 +4941,7 @@ Tree::Tree() {
 	add_child(popup_editor, false, INTERNAL_MODE_FRONT);
 	popup_editor_vb = memnew(VBoxContainer);
 	popup_editor->add_child(popup_editor_vb);
-	popup_editor_vb->add_theme_constant_override(SNAME("separation"), 0);
+	popup_editor_vb->add_theme_constant_override("separation", 0);
 	popup_editor_vb->set_anchors_and_offsets_preset(PRESET_WIDE);
 	text_editor = memnew(LineEdit);
 	popup_editor_vb->add_child(text_editor);

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -139,8 +139,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 	}
 
 	// Panel
-	theme->set_stylebox(SNAME("panel"), SNAME("Panel"), make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
-	theme->set_stylebox(SNAME("panel_fg"), SNAME("Panel"), make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
+	theme->set_stylebox("panel", "Panel", make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
+	theme->set_stylebox("panel_fg", "Panel", make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
 
 	// Button
 
@@ -152,108 +152,108 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 	// Make the focus outline appear to be flush with the buttons it's focusing.
 	focus->set_expand_margin_size_all(2 * scale);
 
-	theme->set_stylebox(SNAME("normal"), SNAME("Button"), button_normal);
-	theme->set_stylebox(SNAME("hover"), SNAME("Button"), button_hover);
-	theme->set_stylebox(SNAME("pressed"), SNAME("Button"), button_pressed);
-	theme->set_stylebox(SNAME("disabled"), SNAME("Button"), button_disabled);
-	theme->set_stylebox(SNAME("focus"), SNAME("Button"), focus);
+	theme->set_stylebox("normal", "Button", button_normal);
+	theme->set_stylebox("hover", "Button", button_hover);
+	theme->set_stylebox("pressed", "Button", button_pressed);
+	theme->set_stylebox("disabled", "Button", button_disabled);
+	theme->set_stylebox("focus", "Button", focus);
 
-	theme->set_font(SNAME("font"), SNAME("Button"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("Button"), -1);
-	theme->set_constant(SNAME("outline_size"), SNAME("Button"), 0 * scale);
+	theme->set_font("font", "Button", Ref<Font>());
+	theme->set_font_size("font_size", "Button", -1);
+	theme->set_constant("outline_size", "Button", 0 * scale);
 
-	theme->set_color(SNAME("font_color"), SNAME("Button"), control_font_color);
-	theme->set_color(SNAME("font_pressed_color"), SNAME("Button"), control_font_pressed_color);
-	theme->set_color(SNAME("font_hover_color"), SNAME("Button"), control_font_hover_color);
-	theme->set_color(SNAME("font_focus_color"), SNAME("Button"), control_font_focus_color);
-	theme->set_color(SNAME("font_hover_pressed_color"), SNAME("Button"), control_font_pressed_color);
-	theme->set_color(SNAME("font_disabled_color"), SNAME("Button"), control_font_disabled_color);
-	theme->set_color(SNAME("font_outline_color"), SNAME("Button"), Color(1, 1, 1));
+	theme->set_color("font_color", "Button", control_font_color);
+	theme->set_color("font_pressed_color", "Button", control_font_pressed_color);
+	theme->set_color("font_hover_color", "Button", control_font_hover_color);
+	theme->set_color("font_focus_color", "Button", control_font_focus_color);
+	theme->set_color("font_hover_pressed_color", "Button", control_font_pressed_color);
+	theme->set_color("font_disabled_color", "Button", control_font_disabled_color);
+	theme->set_color("font_outline_color", "Button", Color(1, 1, 1));
 
-	theme->set_color(SNAME("icon_normal_color"), SNAME("Button"), Color(1, 1, 1, 1));
-	theme->set_color(SNAME("icon_pressed_color"), SNAME("Button"), Color(1, 1, 1, 1));
-	theme->set_color(SNAME("icon_hover_color"), SNAME("Button"), Color(1, 1, 1, 1));
-	theme->set_color(SNAME("icon_hover_pressed_color"), SNAME("Button"), Color(1, 1, 1, 1));
-	theme->set_color(SNAME("icon_focus_color"), SNAME("Button"), Color(1, 1, 1, 1));
-	theme->set_color(SNAME("icon_disabled_color"), SNAME("Button"), Color(1, 1, 1, 1));
+	theme->set_color("icon_normal_color", "Button", Color(1, 1, 1, 1));
+	theme->set_color("icon_pressed_color", "Button", Color(1, 1, 1, 1));
+	theme->set_color("icon_hover_color", "Button", Color(1, 1, 1, 1));
+	theme->set_color("icon_hover_pressed_color", "Button", Color(1, 1, 1, 1));
+	theme->set_color("icon_focus_color", "Button", Color(1, 1, 1, 1));
+	theme->set_color("icon_disabled_color", "Button", Color(1, 1, 1, 1));
 
-	theme->set_constant(SNAME("hseparation"), SNAME("Button"), 2 * scale);
+	theme->set_constant("hseparation", "Button", 2 * scale);
 
 	// LinkButton
 
-	theme->set_stylebox(SNAME("focus"), SNAME("LinkButton"), focus);
+	theme->set_stylebox("focus", "LinkButton", focus);
 
-	theme->set_font(SNAME("font"), SNAME("LinkButton"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("LinkButton"), -1);
+	theme->set_font("font", "LinkButton", Ref<Font>());
+	theme->set_font_size("font_size", "LinkButton", -1);
 
-	theme->set_color(SNAME("font_color"), SNAME("LinkButton"), control_font_color);
-	theme->set_color(SNAME("font_pressed_color"), SNAME("LinkButton"), control_font_pressed_color);
-	theme->set_color(SNAME("font_hover_color"), SNAME("LinkButton"), control_font_hover_color);
-	theme->set_color(SNAME("font_focus_color"), SNAME("LinkButton"), control_font_focus_color);
-	theme->set_color(SNAME("font_outline_color"), SNAME("LinkButton"), Color(1, 1, 1));
+	theme->set_color("font_color", "LinkButton", control_font_color);
+	theme->set_color("font_pressed_color", "LinkButton", control_font_pressed_color);
+	theme->set_color("font_hover_color", "LinkButton", control_font_hover_color);
+	theme->set_color("font_focus_color", "LinkButton", control_font_focus_color);
+	theme->set_color("font_outline_color", "LinkButton", Color(1, 1, 1));
 
-	theme->set_constant(SNAME("outline_size"), SNAME("LinkButton"), 0);
-	theme->set_constant(SNAME("underline_spacing"), SNAME("LinkButton"), 2 * scale);
+	theme->set_constant("outline_size", "LinkButton", 0);
+	theme->set_constant("underline_spacing", "LinkButton", 2 * scale);
 
 	// OptionButton
-	theme->set_stylebox(SNAME("focus"), SNAME("OptionButton"), focus);
+	theme->set_stylebox("focus", "OptionButton", focus);
 
 	Ref<StyleBox> sb_optbutton_normal = make_flat_stylebox(style_normal_color, 2 * default_margin, default_margin, 21, default_margin);
 	Ref<StyleBox> sb_optbutton_hover = make_flat_stylebox(style_hover_color, 2 * default_margin, default_margin, 21, default_margin);
 	Ref<StyleBox> sb_optbutton_pressed = make_flat_stylebox(style_pressed_color, 2 * default_margin, default_margin, 21, default_margin);
 	Ref<StyleBox> sb_optbutton_disabled = make_flat_stylebox(style_disabled_color, 2 * default_margin, default_margin, 21, default_margin);
 
-	theme->set_stylebox(SNAME("normal"), SNAME("OptionButton"), sb_optbutton_normal);
-	theme->set_stylebox(SNAME("hover"), SNAME("OptionButton"), sb_optbutton_hover);
-	theme->set_stylebox(SNAME("pressed"), SNAME("OptionButton"), sb_optbutton_pressed);
-	theme->set_stylebox(SNAME("disabled"), SNAME("OptionButton"), sb_optbutton_disabled);
+	theme->set_stylebox("normal", "OptionButton", sb_optbutton_normal);
+	theme->set_stylebox("hover", "OptionButton", sb_optbutton_hover);
+	theme->set_stylebox("pressed", "OptionButton", sb_optbutton_pressed);
+	theme->set_stylebox("disabled", "OptionButton", sb_optbutton_disabled);
 
 	Ref<StyleBox> sb_optbutton_normal_mirrored = make_flat_stylebox(style_normal_color, 21, default_margin, 2 * default_margin, default_margin);
 	Ref<StyleBox> sb_optbutton_hover_mirrored = make_flat_stylebox(style_hover_color, 21, default_margin, 2 * default_margin, default_margin);
 	Ref<StyleBox> sb_optbutton_pressed_mirrored = make_flat_stylebox(style_pressed_color, 21, default_margin, 2 * default_margin, default_margin);
 	Ref<StyleBox> sb_optbutton_disabled_mirrored = make_flat_stylebox(style_disabled_color, 21, default_margin, 2 * default_margin, default_margin);
 
-	theme->set_stylebox(SNAME("normal_mirrored"), SNAME("OptionButton"), sb_optbutton_normal_mirrored);
-	theme->set_stylebox(SNAME("hover_mirrored"), SNAME("OptionButton"), sb_optbutton_hover_mirrored);
-	theme->set_stylebox(SNAME("pressed_mirrored"), SNAME("OptionButton"), sb_optbutton_pressed_mirrored);
-	theme->set_stylebox(SNAME("disabled_mirrored"), SNAME("OptionButton"), sb_optbutton_disabled_mirrored);
+	theme->set_stylebox("normal_mirrored", "OptionButton", sb_optbutton_normal_mirrored);
+	theme->set_stylebox("hover_mirrored", "OptionButton", sb_optbutton_hover_mirrored);
+	theme->set_stylebox("pressed_mirrored", "OptionButton", sb_optbutton_pressed_mirrored);
+	theme->set_stylebox("disabled_mirrored", "OptionButton", sb_optbutton_disabled_mirrored);
 
-	theme->set_icon(SNAME("arrow"), SNAME("OptionButton"), icons["option_button_arrow"]);
+	theme->set_icon("arrow", "OptionButton", icons["option_button_arrow"]);
 
-	theme->set_font(SNAME("font"), SNAME("OptionButton"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("OptionButton"), -1);
+	theme->set_font("font", "OptionButton", Ref<Font>());
+	theme->set_font_size("font_size", "OptionButton", -1);
 
-	theme->set_color(SNAME("font_color"), SNAME("OptionButton"), control_font_color);
-	theme->set_color(SNAME("font_pressed_color"), SNAME("OptionButton"), control_font_pressed_color);
-	theme->set_color(SNAME("font_hover_color"), SNAME("OptionButton"), control_font_hover_color);
-	theme->set_color(SNAME("font_focus_color"), SNAME("OptionButton"), control_font_focus_color);
-	theme->set_color(SNAME("font_disabled_color"), SNAME("OptionButton"), control_font_disabled_color);
-	theme->set_color(SNAME("font_outline_color"), SNAME("OptionButton"), Color(1, 1, 1));
+	theme->set_color("font_color", "OptionButton", control_font_color);
+	theme->set_color("font_pressed_color", "OptionButton", control_font_pressed_color);
+	theme->set_color("font_hover_color", "OptionButton", control_font_hover_color);
+	theme->set_color("font_focus_color", "OptionButton", control_font_focus_color);
+	theme->set_color("font_disabled_color", "OptionButton", control_font_disabled_color);
+	theme->set_color("font_outline_color", "OptionButton", Color(1, 1, 1));
 
-	theme->set_constant(SNAME("hseparation"), SNAME("OptionButton"), 2 * scale);
-	theme->set_constant(SNAME("arrow_margin"), SNAME("OptionButton"), 4 * scale);
-	theme->set_constant(SNAME("outline_size"), SNAME("OptionButton"), 0);
+	theme->set_constant("hseparation", "OptionButton", 2 * scale);
+	theme->set_constant("arrow_margin", "OptionButton", 4 * scale);
+	theme->set_constant("outline_size", "OptionButton", 0);
 
 	// MenuButton
 
-	theme->set_stylebox(SNAME("normal"), SNAME("MenuButton"), button_normal);
-	theme->set_stylebox(SNAME("pressed"), SNAME("MenuButton"), button_pressed);
-	theme->set_stylebox(SNAME("hover"), SNAME("MenuButton"), button_hover);
-	theme->set_stylebox(SNAME("disabled"), SNAME("MenuButton"), button_disabled);
-	theme->set_stylebox(SNAME("focus"), SNAME("MenuButton"), focus);
+	theme->set_stylebox("normal", "MenuButton", button_normal);
+	theme->set_stylebox("pressed", "MenuButton", button_pressed);
+	theme->set_stylebox("hover", "MenuButton", button_hover);
+	theme->set_stylebox("disabled", "MenuButton", button_disabled);
+	theme->set_stylebox("focus", "MenuButton", focus);
 
-	theme->set_font(SNAME("font"), SNAME("MenuButton"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("MenuButton"), -1);
+	theme->set_font("font", "MenuButton", Ref<Font>());
+	theme->set_font_size("font_size", "MenuButton", -1);
 
-	theme->set_color(SNAME("font_color"), SNAME("MenuButton"), control_font_color);
-	theme->set_color(SNAME("font_pressed_color"), SNAME("MenuButton"), control_font_pressed_color);
-	theme->set_color(SNAME("font_hover_color"), SNAME("MenuButton"), control_font_hover_color);
-	theme->set_color(SNAME("font_focus_color"), SNAME("MenuButton"), control_font_focus_color);
-	theme->set_color(SNAME("font_disabled_color"), SNAME("MenuButton"), Color(1, 1, 1, 0.3));
-	theme->set_color(SNAME("font_outline_color"), SNAME("MenuButton"), Color(1, 1, 1));
+	theme->set_color("font_color", "MenuButton", control_font_color);
+	theme->set_color("font_pressed_color", "MenuButton", control_font_pressed_color);
+	theme->set_color("font_hover_color", "MenuButton", control_font_hover_color);
+	theme->set_color("font_focus_color", "MenuButton", control_font_focus_color);
+	theme->set_color("font_disabled_color", "MenuButton", Color(1, 1, 1, 0.3));
+	theme->set_color("font_outline_color", "MenuButton", Color(1, 1, 1));
 
-	theme->set_constant(SNAME("hseparation"), SNAME("MenuButton"), 3 * scale);
-	theme->set_constant(SNAME("outline_size"), SNAME("MenuButton"), 0);
+	theme->set_constant("hseparation", "MenuButton", 3 * scale);
+	theme->set_constant("outline_size", "MenuButton", 0);
 
 	// CheckBox
 
@@ -268,36 +268,36 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 	cbx_focus->set_default_margin(SIDE_TOP, 4 * scale);
 	cbx_focus->set_default_margin(SIDE_BOTTOM, 4 * scale);
 
-	theme->set_stylebox(SNAME("normal"), SNAME("CheckBox"), cbx_empty);
-	theme->set_stylebox(SNAME("pressed"), SNAME("CheckBox"), cbx_empty);
-	theme->set_stylebox(SNAME("disabled"), SNAME("CheckBox"), cbx_empty);
-	theme->set_stylebox(SNAME("hover"), SNAME("CheckBox"), cbx_empty);
-	theme->set_stylebox(SNAME("hover_pressed"), SNAME("CheckBox"), cbx_empty);
-	theme->set_stylebox(SNAME("focus"), SNAME("CheckBox"), cbx_focus);
+	theme->set_stylebox("normal", "CheckBox", cbx_empty);
+	theme->set_stylebox("pressed", "CheckBox", cbx_empty);
+	theme->set_stylebox("disabled", "CheckBox", cbx_empty);
+	theme->set_stylebox("hover", "CheckBox", cbx_empty);
+	theme->set_stylebox("hover_pressed", "CheckBox", cbx_empty);
+	theme->set_stylebox("focus", "CheckBox", cbx_focus);
 
-	theme->set_icon(SNAME("checked"), SNAME("CheckBox"), icons["checked"]);
-	theme->set_icon(SNAME("checked_disabled"), SNAME("CheckBox"), icons["checked"]);
-	theme->set_icon(SNAME("unchecked"), SNAME("CheckBox"), icons["unchecked"]);
-	theme->set_icon(SNAME("unchecked_disabled"), SNAME("CheckBox"), icons["unchecked"]);
-	theme->set_icon(SNAME("radio_checked"), SNAME("CheckBox"), icons["radio_checked"]);
-	theme->set_icon(SNAME("radio_checked_disabled"), SNAME("CheckBox"), icons["radio_checked"]);
-	theme->set_icon(SNAME("radio_unchecked"), SNAME("CheckBox"), icons["radio_unchecked"]);
-	theme->set_icon(SNAME("radio_unchecked_disabled"), SNAME("CheckBox"), icons["radio_unchecked"]);
+	theme->set_icon("checked", "CheckBox", icons["checked"]);
+	theme->set_icon("checked_disabled", "CheckBox", icons["checked"]);
+	theme->set_icon("unchecked", "CheckBox", icons["unchecked"]);
+	theme->set_icon("unchecked_disabled", "CheckBox", icons["unchecked"]);
+	theme->set_icon("radio_checked", "CheckBox", icons["radio_checked"]);
+	theme->set_icon("radio_checked_disabled", "CheckBox", icons["radio_checked"]);
+	theme->set_icon("radio_unchecked", "CheckBox", icons["radio_unchecked"]);
+	theme->set_icon("radio_unchecked_disabled", "CheckBox", icons["radio_unchecked"]);
 
-	theme->set_font(SNAME("font"), SNAME("CheckBox"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("CheckBox"), -1);
+	theme->set_font("font", "CheckBox", Ref<Font>());
+	theme->set_font_size("font_size", "CheckBox", -1);
 
-	theme->set_color(SNAME("font_color"), SNAME("CheckBox"), control_font_color);
-	theme->set_color(SNAME("font_pressed_color"), SNAME("CheckBox"), control_font_pressed_color);
-	theme->set_color(SNAME("font_hover_color"), SNAME("CheckBox"), control_font_hover_color);
-	theme->set_color(SNAME("font_hover_pressed_color"), SNAME("CheckBox"), control_font_pressed_color);
-	theme->set_color(SNAME("font_focus_color"), SNAME("CheckBox"), control_font_focus_color);
-	theme->set_color(SNAME("font_disabled_color"), SNAME("CheckBox"), control_font_disabled_color);
-	theme->set_color(SNAME("font_outline_color"), SNAME("CheckBox"), Color(1, 1, 1));
+	theme->set_color("font_color", "CheckBox", control_font_color);
+	theme->set_color("font_pressed_color", "CheckBox", control_font_pressed_color);
+	theme->set_color("font_hover_color", "CheckBox", control_font_hover_color);
+	theme->set_color("font_hover_pressed_color", "CheckBox", control_font_pressed_color);
+	theme->set_color("font_focus_color", "CheckBox", control_font_focus_color);
+	theme->set_color("font_disabled_color", "CheckBox", control_font_disabled_color);
+	theme->set_color("font_outline_color", "CheckBox", Color(1, 1, 1));
 
-	theme->set_constant(SNAME("hseparation"), SNAME("CheckBox"), 4 * scale);
-	theme->set_constant(SNAME("check_vadjust"), SNAME("CheckBox"), 0 * scale);
-	theme->set_constant(SNAME("outline_size"), SNAME("CheckBox"), 0);
+	theme->set_constant("hseparation", "CheckBox", 4 * scale);
+	theme->set_constant("check_vadjust", "CheckBox", 0 * scale);
+	theme->set_constant("outline_size", "CheckBox", 0);
 
 	// CheckButton
 
@@ -307,62 +307,62 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 	cb_empty->set_default_margin(SIDE_TOP, 4 * scale);
 	cb_empty->set_default_margin(SIDE_BOTTOM, 4 * scale);
 
-	theme->set_stylebox(SNAME("normal"), SNAME("CheckButton"), cb_empty);
-	theme->set_stylebox(SNAME("pressed"), SNAME("CheckButton"), cb_empty);
-	theme->set_stylebox(SNAME("disabled"), SNAME("CheckButton"), cb_empty);
-	theme->set_stylebox(SNAME("hover"), SNAME("CheckButton"), cb_empty);
-	theme->set_stylebox(SNAME("hover_pressed"), SNAME("CheckButton"), cb_empty);
-	theme->set_stylebox(SNAME("focus"), SNAME("CheckButton"), focus);
+	theme->set_stylebox("normal", "CheckButton", cb_empty);
+	theme->set_stylebox("pressed", "CheckButton", cb_empty);
+	theme->set_stylebox("disabled", "CheckButton", cb_empty);
+	theme->set_stylebox("hover", "CheckButton", cb_empty);
+	theme->set_stylebox("hover_pressed", "CheckButton", cb_empty);
+	theme->set_stylebox("focus", "CheckButton", focus);
 
-	theme->set_icon(SNAME("on"), SNAME("CheckButton"), icons["toggle_on"]);
-	theme->set_icon(SNAME("on_disabled"), SNAME("CheckButton"), icons["toggle_on_disabled"]);
-	theme->set_icon(SNAME("off"), SNAME("CheckButton"), icons["toggle_off"]);
-	theme->set_icon(SNAME("off_disabled"), SNAME("CheckButton"), icons["toggle_off_disabled"]);
+	theme->set_icon("on", "CheckButton", icons["toggle_on"]);
+	theme->set_icon("on_disabled", "CheckButton", icons["toggle_on_disabled"]);
+	theme->set_icon("off", "CheckButton", icons["toggle_off"]);
+	theme->set_icon("off_disabled", "CheckButton", icons["toggle_off_disabled"]);
 
-	theme->set_icon(SNAME("on_mirrored"), SNAME("CheckButton"), icons["toggle_on_mirrored"]);
-	theme->set_icon(SNAME("on_disabled_mirrored"), SNAME("CheckButton"), icons["toggle_on_disabled_mirrored"]);
-	theme->set_icon(SNAME("off_mirrored"), SNAME("CheckButton"), icons["toggle_off_mirrored"]);
-	theme->set_icon(SNAME("off_disabled_mirrored"), SNAME("CheckButton"), icons["toggle_off_disabled_mirrored"]);
+	theme->set_icon("on_mirrored", "CheckButton", icons["toggle_on_mirrored"]);
+	theme->set_icon("on_disabled_mirrored", "CheckButton", icons["toggle_on_disabled_mirrored"]);
+	theme->set_icon("off_mirrored", "CheckButton", icons["toggle_off_mirrored"]);
+	theme->set_icon("off_disabled_mirrored", "CheckButton", icons["toggle_off_disabled_mirrored"]);
 
-	theme->set_font(SNAME("font"), SNAME("CheckButton"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("CheckButton"), -1);
+	theme->set_font("font", "CheckButton", Ref<Font>());
+	theme->set_font_size("font_size", "CheckButton", -1);
 
-	theme->set_color(SNAME("font_color"), SNAME("CheckButton"), control_font_color);
-	theme->set_color(SNAME("font_pressed_color"), SNAME("CheckButton"), control_font_pressed_color);
-	theme->set_color(SNAME("font_hover_color"), SNAME("CheckButton"), control_font_hover_color);
-	theme->set_color(SNAME("font_hover_pressed_color"), SNAME("CheckButton"), control_font_pressed_color);
-	theme->set_color(SNAME("font_focus_color"), SNAME("CheckButton"), control_font_focus_color);
-	theme->set_color(SNAME("font_disabled_color"), SNAME("CheckButton"), control_font_disabled_color);
-	theme->set_color(SNAME("font_outline_color"), SNAME("CheckButton"), Color(1, 1, 1));
+	theme->set_color("font_color", "CheckButton", control_font_color);
+	theme->set_color("font_pressed_color", "CheckButton", control_font_pressed_color);
+	theme->set_color("font_hover_color", "CheckButton", control_font_hover_color);
+	theme->set_color("font_hover_pressed_color", "CheckButton", control_font_pressed_color);
+	theme->set_color("font_focus_color", "CheckButton", control_font_focus_color);
+	theme->set_color("font_disabled_color", "CheckButton", control_font_disabled_color);
+	theme->set_color("font_outline_color", "CheckButton", Color(1, 1, 1));
 
-	theme->set_constant(SNAME("hseparation"), SNAME("CheckButton"), 4 * scale);
-	theme->set_constant(SNAME("check_vadjust"), SNAME("CheckButton"), 0 * scale);
-	theme->set_constant(SNAME("outline_size"), SNAME("CheckButton"), 0);
+	theme->set_constant("hseparation", "CheckButton", 4 * scale);
+	theme->set_constant("check_vadjust", "CheckButton", 0 * scale);
+	theme->set_constant("outline_size", "CheckButton", 0);
 
 	// Label
 
-	theme->set_stylebox(SNAME("normal"), SNAME("Label"), memnew(StyleBoxEmpty));
-	theme->set_font(SNAME("font"), SNAME("Label"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("Label"), -1);
+	theme->set_stylebox("normal", "Label", memnew(StyleBoxEmpty));
+	theme->set_font("font", "Label", Ref<Font>());
+	theme->set_font_size("font_size", "Label", -1);
 
-	theme->set_color(SNAME("font_color"), SNAME("Label"), Color(1, 1, 1));
-	theme->set_color(SNAME("font_shadow_color"), SNAME("Label"), Color(0, 0, 0, 0));
-	theme->set_color(SNAME("font_outline_color"), SNAME("Label"), Color(1, 1, 1));
+	theme->set_color("font_color", "Label", Color(1, 1, 1));
+	theme->set_color("font_shadow_color", "Label", Color(0, 0, 0, 0));
+	theme->set_color("font_outline_color", "Label", Color(1, 1, 1));
 
-	theme->set_constant(SNAME("shadow_offset_x"), SNAME("Label"), 1 * scale);
-	theme->set_constant(SNAME("shadow_offset_y"), SNAME("Label"), 1 * scale);
-	theme->set_constant(SNAME("outline_size"), SNAME("Label"), 0);
-	theme->set_constant(SNAME("shadow_outline_size"), SNAME("Label"), 1 * scale);
-	theme->set_constant(SNAME("line_spacing"), SNAME("Label"), 3 * scale);
+	theme->set_constant("shadow_offset_x", "Label", 1 * scale);
+	theme->set_constant("shadow_offset_y", "Label", 1 * scale);
+	theme->set_constant("outline_size", "Label", 0);
+	theme->set_constant("shadow_outline_size", "Label", 1 * scale);
+	theme->set_constant("line_spacing", "Label", 3 * scale);
 
-	theme->set_type_variation(SNAME("HeaderSmall"), SNAME("Label"));
-	theme->set_font_size(SNAME("font_size"), SNAME("HeaderSmall"), default_font_size + 4);
+	theme->set_type_variation("HeaderSmall", "Label");
+	theme->set_font_size("font_size", "HeaderSmall", default_font_size + 4);
 
-	theme->set_type_variation(SNAME("HeaderMedium"), SNAME("Label"));
-	theme->set_font_size(SNAME("font_size"), SNAME("HeaderMedium"), default_font_size + 8);
+	theme->set_type_variation("HeaderMedium", "Label");
+	theme->set_font_size("font_size", "HeaderMedium", default_font_size + 8);
 
-	theme->set_type_variation(SNAME("HeaderLarge"), SNAME("Label"));
-	theme->set_font_size(SNAME("font_size"), SNAME("HeaderLarge"), default_font_size + 12);
+	theme->set_type_variation("HeaderLarge", "Label");
+	theme->set_font_size("font_size", "HeaderLarge", default_font_size + 12);
 
 	// LineEdit
 
@@ -370,129 +370,129 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 	// Add a line at the bottom to make LineEdits distinguishable from Buttons.
 	style_line_edit->set_border_width(SIDE_BOTTOM, 2);
 	style_line_edit->set_border_color(style_pressed_color);
-	theme->set_stylebox(SNAME("normal"), SNAME("LineEdit"), style_line_edit);
+	theme->set_stylebox("normal", "LineEdit", style_line_edit);
 
-	theme->set_stylebox(SNAME("focus"), SNAME("LineEdit"), focus);
+	theme->set_stylebox("focus", "LineEdit", focus);
 
 	Ref<StyleBoxFlat> style_line_edit_read_only = make_flat_stylebox(style_disabled_color);
 	// Add a line at the bottom to make LineEdits distinguishable from Buttons.
 	style_line_edit_read_only->set_border_width(SIDE_BOTTOM, 2);
 	style_line_edit_read_only->set_border_color(style_pressed_color * Color(1, 1, 1, 0.5));
-	theme->set_stylebox(SNAME("read_only"), SNAME("LineEdit"), style_line_edit_read_only);
+	theme->set_stylebox("read_only", "LineEdit", style_line_edit_read_only);
 
-	theme->set_font(SNAME("font"), SNAME("LineEdit"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("LineEdit"), -1);
+	theme->set_font("font", "LineEdit", Ref<Font>());
+	theme->set_font_size("font_size", "LineEdit", -1);
 
-	theme->set_color(SNAME("font_color"), SNAME("LineEdit"), control_font_color);
-	theme->set_color(SNAME("font_selected_color"), SNAME("LineEdit"), control_font_pressed_color);
-	theme->set_color(SNAME("font_uneditable_color"), SNAME("LineEdit"), control_font_disabled_color);
-	theme->set_color(SNAME("font_placeholder_color"), SNAME("LineEdit"), control_font_placeholder_color);
-	theme->set_color(SNAME("font_outline_color"), SNAME("LineEdit"), Color(1, 1, 1));
-	theme->set_color(SNAME("caret_color"), SNAME("LineEdit"), control_font_hover_color);
-	theme->set_color(SNAME("selection_color"), SNAME("LineEdit"), control_selection_color);
-	theme->set_color(SNAME("clear_button_color"), SNAME("LineEdit"), control_font_color);
-	theme->set_color(SNAME("clear_button_color_pressed"), SNAME("LineEdit"), control_font_pressed_color);
+	theme->set_color("font_color", "LineEdit", control_font_color);
+	theme->set_color("font_selected_color", "LineEdit", control_font_pressed_color);
+	theme->set_color("font_uneditable_color", "LineEdit", control_font_disabled_color);
+	theme->set_color("font_placeholder_color", "LineEdit", control_font_placeholder_color);
+	theme->set_color("font_outline_color", "LineEdit", Color(1, 1, 1));
+	theme->set_color("caret_color", "LineEdit", control_font_hover_color);
+	theme->set_color("selection_color", "LineEdit", control_selection_color);
+	theme->set_color("clear_button_color", "LineEdit", control_font_color);
+	theme->set_color("clear_button_color_pressed", "LineEdit", control_font_pressed_color);
 
-	theme->set_constant(SNAME("minimum_character_width"), SNAME("LineEdit"), 4);
-	theme->set_constant(SNAME("outline_size"), SNAME("LineEdit"), 0);
-	theme->set_constant(SNAME("caret_width"), SNAME("LineEdit"), 1);
+	theme->set_constant("minimum_character_width", "LineEdit", 4);
+	theme->set_constant("outline_size", "LineEdit", 0);
+	theme->set_constant("caret_width", "LineEdit", 1);
 
-	theme->set_icon(SNAME("clear"), SNAME("LineEdit"), icons["line_edit_clear"]);
+	theme->set_icon("clear", "LineEdit", icons["line_edit_clear"]);
 
 	// ProgressBar
 
-	theme->set_stylebox(SNAME("bg"), SNAME("ProgressBar"), make_flat_stylebox(style_disabled_color, 2, 2, 2, 2, 6));
-	theme->set_stylebox(SNAME("fg"), SNAME("ProgressBar"), make_flat_stylebox(style_progress_color, 2, 2, 2, 2, 6));
+	theme->set_stylebox("bg", "ProgressBar", make_flat_stylebox(style_disabled_color, 2, 2, 2, 2, 6));
+	theme->set_stylebox("fg", "ProgressBar", make_flat_stylebox(style_progress_color, 2, 2, 2, 2, 6));
 
-	theme->set_font(SNAME("font"), SNAME("ProgressBar"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("ProgressBar"), -1);
+	theme->set_font("font", "ProgressBar", Ref<Font>());
+	theme->set_font_size("font_size", "ProgressBar", -1);
 
-	theme->set_color(SNAME("font_color"), SNAME("ProgressBar"), control_font_hover_color);
-	theme->set_color(SNAME("font_shadow_color"), SNAME("ProgressBar"), Color(0, 0, 0));
-	theme->set_color(SNAME("font_outline_color"), SNAME("ProgressBar"), Color(1, 1, 1));
+	theme->set_color("font_color", "ProgressBar", control_font_hover_color);
+	theme->set_color("font_shadow_color", "ProgressBar", Color(0, 0, 0));
+	theme->set_color("font_outline_color", "ProgressBar", Color(1, 1, 1));
 
-	theme->set_constant(SNAME("outline_size"), SNAME("ProgressBar"), 0);
+	theme->set_constant("outline_size", "ProgressBar", 0);
 
 	// TextEdit
 
-	theme->set_stylebox(SNAME("normal"), SNAME("TextEdit"), style_line_edit);
-	theme->set_stylebox(SNAME("focus"), SNAME("TextEdit"), focus);
-	theme->set_stylebox(SNAME("read_only"), SNAME("TextEdit"), style_line_edit_read_only);
+	theme->set_stylebox("normal", "TextEdit", style_line_edit);
+	theme->set_stylebox("focus", "TextEdit", focus);
+	theme->set_stylebox("read_only", "TextEdit", style_line_edit_read_only);
 
-	theme->set_icon(SNAME("tab"), SNAME("TextEdit"), icons["text_edit_tab"]);
-	theme->set_icon(SNAME("space"), SNAME("TextEdit"), icons["text_edit_space"]);
+	theme->set_icon("tab", "TextEdit", icons["text_edit_tab"]);
+	theme->set_icon("space", "TextEdit", icons["text_edit_space"]);
 
-	theme->set_font(SNAME("font"), SNAME("TextEdit"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("TextEdit"), -1);
+	theme->set_font("font", "TextEdit", Ref<Font>());
+	theme->set_font_size("font_size", "TextEdit", -1);
 
-	theme->set_color(SNAME("background_color"), SNAME("TextEdit"), Color(0, 0, 0, 0));
-	theme->set_color(SNAME("font_color"), SNAME("TextEdit"), control_font_color);
-	theme->set_color(SNAME("font_selected_color"), SNAME("TextEdit"), control_font_pressed_color);
-	theme->set_color(SNAME("font_readonly_color"), SNAME("TextEdit"), control_font_disabled_color);
-	theme->set_color(SNAME("font_placeholder_color"), SNAME("TextEdit"), control_font_placeholder_color);
-	theme->set_color(SNAME("font_outline_color"), SNAME("TextEdit"), Color(1, 1, 1));
-	theme->set_color(SNAME("selection_color"), SNAME("TextEdit"), control_selection_color);
-	theme->set_color(SNAME("current_line_color"), SNAME("TextEdit"), Color(0.25, 0.25, 0.26, 0.8));
-	theme->set_color(SNAME("caret_color"), SNAME("TextEdit"), control_font_color);
-	theme->set_color(SNAME("caret_background_color"), SNAME("TextEdit"), Color(0, 0, 0));
-	theme->set_color(SNAME("word_highlighted_color"), SNAME("TextEdit"), Color(0.5, 0.5, 0.5, 0.25));
-	theme->set_color(SNAME("search_result_color"), SNAME("TextEdit"), Color(0.3, 0.3, 0.3));
-	theme->set_color(SNAME("search_result_border_color"), SNAME("TextEdit"), Color(0.3, 0.3, 0.3, 0.4));
+	theme->set_color("background_color", "TextEdit", Color(0, 0, 0, 0));
+	theme->set_color("font_color", "TextEdit", control_font_color);
+	theme->set_color("font_selected_color", "TextEdit", control_font_pressed_color);
+	theme->set_color("font_readonly_color", "TextEdit", control_font_disabled_color);
+	theme->set_color("font_placeholder_color", "TextEdit", control_font_placeholder_color);
+	theme->set_color("font_outline_color", "TextEdit", Color(1, 1, 1));
+	theme->set_color("selection_color", "TextEdit", control_selection_color);
+	theme->set_color("current_line_color", "TextEdit", Color(0.25, 0.25, 0.26, 0.8));
+	theme->set_color("caret_color", "TextEdit", control_font_color);
+	theme->set_color("caret_background_color", "TextEdit", Color(0, 0, 0));
+	theme->set_color("word_highlighted_color", "TextEdit", Color(0.5, 0.5, 0.5, 0.25));
+	theme->set_color("search_result_color", "TextEdit", Color(0.3, 0.3, 0.3));
+	theme->set_color("search_result_border_color", "TextEdit", Color(0.3, 0.3, 0.3, 0.4));
 
-	theme->set_constant(SNAME("line_spacing"), SNAME("TextEdit"), 4 * scale);
-	theme->set_constant(SNAME("outline_size"), SNAME("TextEdit"), 0);
-	theme->set_constant(SNAME("caret_width"), SNAME("TextEdit"), 1);
+	theme->set_constant("line_spacing", "TextEdit", 4 * scale);
+	theme->set_constant("outline_size", "TextEdit", 0);
+	theme->set_constant("caret_width", "TextEdit", 1);
 
 	// CodeEdit
 
-	theme->set_stylebox(SNAME("normal"), SNAME("CodeEdit"), style_line_edit);
-	theme->set_stylebox(SNAME("focus"), SNAME("CodeEdit"), focus);
-	theme->set_stylebox(SNAME("read_only"), SNAME("CodeEdit"), style_line_edit_read_only);
-	theme->set_stylebox(SNAME("completion"), SNAME("CodeEdit"), make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
+	theme->set_stylebox("normal", "CodeEdit", style_line_edit);
+	theme->set_stylebox("focus", "CodeEdit", focus);
+	theme->set_stylebox("read_only", "CodeEdit", style_line_edit_read_only);
+	theme->set_stylebox("completion", "CodeEdit", make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
 
-	theme->set_icon(SNAME("tab"), SNAME("CodeEdit"), icons["text_edit_tab"]);
-	theme->set_icon(SNAME("space"), SNAME("CodeEdit"), icons["text_edit_space"]);
-	theme->set_icon(SNAME("breakpoint"), SNAME("CodeEdit"), icons["breakpoint"]);
-	theme->set_icon(SNAME("bookmark"), SNAME("CodeEdit"), icons["bookmark"]);
-	theme->set_icon(SNAME("executing_line"), SNAME("CodeEdit"), icons["arrow_right"]);
-	theme->set_icon(SNAME("can_fold"), SNAME("CodeEdit"), icons["arrow_down"]);
-	theme->set_icon(SNAME("folded"), SNAME("CodeEdit"), icons["arrow_right"]);
-	theme->set_icon(SNAME("folded_eol_icon"), SNAME("CodeEdit"), icons["text_edit_ellipsis"]);
+	theme->set_icon("tab", "CodeEdit", icons["text_edit_tab"]);
+	theme->set_icon("space", "CodeEdit", icons["text_edit_space"]);
+	theme->set_icon("breakpoint", "CodeEdit", icons["breakpoint"]);
+	theme->set_icon("bookmark", "CodeEdit", icons["bookmark"]);
+	theme->set_icon("executing_line", "CodeEdit", icons["arrow_right"]);
+	theme->set_icon("can_fold", "CodeEdit", icons["arrow_down"]);
+	theme->set_icon("folded", "CodeEdit", icons["arrow_right"]);
+	theme->set_icon("folded_eol_icon", "CodeEdit", icons["text_edit_ellipsis"]);
 
-	theme->set_font(SNAME("font"), SNAME("CodeEdit"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("CodeEdit"), -1);
+	theme->set_font("font", "CodeEdit", Ref<Font>());
+	theme->set_font_size("font_size", "CodeEdit", -1);
 
-	theme->set_color(SNAME("background_color"), SNAME("CodeEdit"), Color(0, 0, 0, 0));
-	theme->set_color(SNAME("completion_background_color"), SNAME("CodeEdit"), Color(0.17, 0.16, 0.2));
-	theme->set_color(SNAME("completion_selected_color"), SNAME("CodeEdit"), Color(0.26, 0.26, 0.27));
-	theme->set_color(SNAME("completion_existing_color"), SNAME("CodeEdit"), Color(0.87, 0.87, 0.87, 0.13));
-	theme->set_color(SNAME("completion_scroll_color"), SNAME("CodeEdit"), control_font_pressed_color);
-	theme->set_color(SNAME("completion_font_color"), SNAME("CodeEdit"), Color(0.67, 0.67, 0.67));
-	theme->set_color(SNAME("font_color"), SNAME("CodeEdit"), control_font_color);
-	theme->set_color(SNAME("font_selected_color"), SNAME("CodeEdit"), Color(0, 0, 0));
-	theme->set_color(SNAME("font_readonly_color"), SNAME("CodeEdit"), Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
-	theme->set_color(SNAME("font_placeholder_color"), SNAME("CodeEdit"), control_font_placeholder_color);
-	theme->set_color(SNAME("font_outline_color"), SNAME("CodeEdit"), Color(1, 1, 1));
-	theme->set_color(SNAME("selection_color"), SNAME("CodeEdit"), control_selection_color);
-	theme->set_color(SNAME("bookmark_color"), SNAME("CodeEdit"), Color(0.5, 0.64, 1, 0.8));
-	theme->set_color(SNAME("breakpoint_color"), SNAME("CodeEdit"), Color(0.9, 0.29, 0.3));
-	theme->set_color(SNAME("executing_line_color"), SNAME("CodeEdit"), Color(0.98, 0.89, 0.27));
-	theme->set_color(SNAME("current_line_color"), SNAME("CodeEdit"), Color(0.25, 0.25, 0.26, 0.8));
-	theme->set_color(SNAME("code_folding_color"), SNAME("CodeEdit"), Color(0.8, 0.8, 0.8, 0.8));
-	theme->set_color(SNAME("caret_color"), SNAME("CodeEdit"), control_font_color);
-	theme->set_color(SNAME("caret_background_color"), SNAME("CodeEdit"), Color(0, 0, 0));
-	theme->set_color(SNAME("brace_mismatch_color"), SNAME("CodeEdit"), Color(1, 0.2, 0.2));
-	theme->set_color(SNAME("line_number_color"), SNAME("CodeEdit"), Color(0.67, 0.67, 0.67, 0.4));
-	theme->set_color(SNAME("word_highlighted_color"), SNAME("CodeEdit"), Color(0.8, 0.9, 0.9, 0.15));
-	theme->set_color(SNAME("line_length_guideline_color"), SNAME("CodeEdit"), Color(0.3, 0.5, 0.8, 0.1));
-	theme->set_color(SNAME("search_result_color"), SNAME("CodeEdit"), Color(0.3, 0.3, 0.3));
-	theme->set_color(SNAME("search_result_border_color"), SNAME("CodeEdit"), Color(0.3, 0.3, 0.3, 0.4));
+	theme->set_color("background_color", "CodeEdit", Color(0, 0, 0, 0));
+	theme->set_color("completion_background_color", "CodeEdit", Color(0.17, 0.16, 0.2));
+	theme->set_color("completion_selected_color", "CodeEdit", Color(0.26, 0.26, 0.27));
+	theme->set_color("completion_existing_color", "CodeEdit", Color(0.87, 0.87, 0.87, 0.13));
+	theme->set_color("completion_scroll_color", "CodeEdit", control_font_pressed_color);
+	theme->set_color("completion_font_color", "CodeEdit", Color(0.67, 0.67, 0.67));
+	theme->set_color("font_color", "CodeEdit", control_font_color);
+	theme->set_color("font_selected_color", "CodeEdit", Color(0, 0, 0));
+	theme->set_color("font_readonly_color", "CodeEdit", Color(control_font_color.r, control_font_color.g, control_font_color.b, 0.5f));
+	theme->set_color("font_placeholder_color", "CodeEdit", control_font_placeholder_color);
+	theme->set_color("font_outline_color", "CodeEdit", Color(1, 1, 1));
+	theme->set_color("selection_color", "CodeEdit", control_selection_color);
+	theme->set_color("bookmark_color", "CodeEdit", Color(0.5, 0.64, 1, 0.8));
+	theme->set_color("breakpoint_color", "CodeEdit", Color(0.9, 0.29, 0.3));
+	theme->set_color("executing_line_color", "CodeEdit", Color(0.98, 0.89, 0.27));
+	theme->set_color("current_line_color", "CodeEdit", Color(0.25, 0.25, 0.26, 0.8));
+	theme->set_color("code_folding_color", "CodeEdit", Color(0.8, 0.8, 0.8, 0.8));
+	theme->set_color("caret_color", "CodeEdit", control_font_color);
+	theme->set_color("caret_background_color", "CodeEdit", Color(0, 0, 0));
+	theme->set_color("brace_mismatch_color", "CodeEdit", Color(1, 0.2, 0.2));
+	theme->set_color("line_number_color", "CodeEdit", Color(0.67, 0.67, 0.67, 0.4));
+	theme->set_color("word_highlighted_color", "CodeEdit", Color(0.8, 0.9, 0.9, 0.15));
+	theme->set_color("line_length_guideline_color", "CodeEdit", Color(0.3, 0.5, 0.8, 0.1));
+	theme->set_color("search_result_color", "CodeEdit", Color(0.3, 0.3, 0.3));
+	theme->set_color("search_result_border_color", "CodeEdit", Color(0.3, 0.3, 0.3, 0.4));
 
-	theme->set_constant(SNAME("completion_lines"), SNAME("CodeEdit"), 7);
-	theme->set_constant(SNAME("completion_max_width"), SNAME("CodeEdit"), 50);
-	theme->set_constant(SNAME("completion_scroll_width"), SNAME("CodeEdit"), 3);
-	theme->set_constant(SNAME("line_spacing"), SNAME("CodeEdit"), 4 * scale);
-	theme->set_constant(SNAME("outline_size"), SNAME("CodeEdit"), 0);
+	theme->set_constant("completion_lines", "CodeEdit", 7);
+	theme->set_constant("completion_max_width", "CodeEdit", 50);
+	theme->set_constant("completion_scroll_width", "CodeEdit", 3);
+	theme->set_constant("line_spacing", "CodeEdit", 4 * scale);
+	theme->set_constant("outline_size", "CodeEdit", 0);
 
 	Ref<Texture2D> empty_icon = memnew(ImageTexture);
 
@@ -503,33 +503,33 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 
 	// HScrollBar
 
-	theme->set_stylebox(SNAME("scroll"), SNAME("HScrollBar"), style_scrollbar);
-	theme->set_stylebox(SNAME("scroll_focus"), SNAME("HScrollBar"), focus);
-	theme->set_stylebox(SNAME("grabber"), SNAME("HScrollBar"), style_scrollbar_grabber);
-	theme->set_stylebox(SNAME("grabber_highlight"), SNAME("HScrollBar"), style_scrollbar_grabber_highlight);
-	theme->set_stylebox(SNAME("grabber_pressed"), SNAME("HScrollBar"), style_scrollbar_grabber_pressed);
+	theme->set_stylebox("scroll", "HScrollBar", style_scrollbar);
+	theme->set_stylebox("scroll_focus", "HScrollBar", focus);
+	theme->set_stylebox("grabber", "HScrollBar", style_scrollbar_grabber);
+	theme->set_stylebox("grabber_highlight", "HScrollBar", style_scrollbar_grabber_highlight);
+	theme->set_stylebox("grabber_pressed", "HScrollBar", style_scrollbar_grabber_pressed);
 
-	theme->set_icon(SNAME("increment"), SNAME("HScrollBar"), empty_icon);
-	theme->set_icon(SNAME("increment_highlight"), SNAME("HScrollBar"), empty_icon);
-	theme->set_icon(SNAME("increment_pressed"), SNAME("HScrollBar"), empty_icon);
-	theme->set_icon(SNAME("decrement"), SNAME("HScrollBar"), empty_icon);
-	theme->set_icon(SNAME("decrement_highlight"), SNAME("HScrollBar"), empty_icon);
-	theme->set_icon(SNAME("decrement_pressed"), SNAME("HScrollBar"), empty_icon);
+	theme->set_icon("increment", "HScrollBar", empty_icon);
+	theme->set_icon("increment_highlight", "HScrollBar", empty_icon);
+	theme->set_icon("increment_pressed", "HScrollBar", empty_icon);
+	theme->set_icon("decrement", "HScrollBar", empty_icon);
+	theme->set_icon("decrement_highlight", "HScrollBar", empty_icon);
+	theme->set_icon("decrement_pressed", "HScrollBar", empty_icon);
 
 	// VScrollBar
 
-	theme->set_stylebox(SNAME("scroll"), SNAME("VScrollBar"), style_scrollbar);
-	theme->set_stylebox(SNAME("scroll_focus"), SNAME("VScrollBar"), focus);
-	theme->set_stylebox(SNAME("grabber"), SNAME("VScrollBar"), style_scrollbar_grabber);
-	theme->set_stylebox(SNAME("grabber_highlight"), SNAME("VScrollBar"), style_scrollbar_grabber_highlight);
-	theme->set_stylebox(SNAME("grabber_pressed"), SNAME("VScrollBar"), style_scrollbar_grabber_pressed);
+	theme->set_stylebox("scroll", "VScrollBar", style_scrollbar);
+	theme->set_stylebox("scroll_focus", "VScrollBar", focus);
+	theme->set_stylebox("grabber", "VScrollBar", style_scrollbar_grabber);
+	theme->set_stylebox("grabber_highlight", "VScrollBar", style_scrollbar_grabber_highlight);
+	theme->set_stylebox("grabber_pressed", "VScrollBar", style_scrollbar_grabber_pressed);
 
-	theme->set_icon(SNAME("increment"), SNAME("VScrollBar"), empty_icon);
-	theme->set_icon(SNAME("increment_highlight"), SNAME("VScrollBar"), empty_icon);
-	theme->set_icon(SNAME("increment_pressed"), SNAME("VScrollBar"), empty_icon);
-	theme->set_icon(SNAME("decrement"), SNAME("VScrollBar"), empty_icon);
-	theme->set_icon(SNAME("decrement_highlight"), SNAME("VScrollBar"), empty_icon);
-	theme->set_icon(SNAME("decrement_pressed"), SNAME("VScrollBar"), empty_icon);
+	theme->set_icon("increment", "VScrollBar", empty_icon);
+	theme->set_icon("increment_highlight", "VScrollBar", empty_icon);
+	theme->set_icon("increment_pressed", "VScrollBar", empty_icon);
+	theme->set_icon("decrement", "VScrollBar", empty_icon);
+	theme->set_icon("decrement_highlight", "VScrollBar", empty_icon);
+	theme->set_icon("decrement_pressed", "VScrollBar", empty_icon);
 
 	const Ref<StyleBoxFlat> style_slider = make_flat_stylebox(style_normal_color, 4, 4, 4, 4, 4);
 	const Ref<StyleBoxFlat> style_slider_grabber = make_flat_stylebox(style_progress_color, 4, 4, 4, 4, 4);
@@ -537,83 +537,83 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 
 	// HSlider
 
-	theme->set_stylebox(SNAME("slider"), SNAME("HSlider"), style_slider);
-	theme->set_stylebox(SNAME("grabber_area"), SNAME("HSlider"), style_slider_grabber);
-	theme->set_stylebox(SNAME("grabber_area_highlight"), SNAME("HSlider"), style_slider_grabber_highlight);
+	theme->set_stylebox("slider", "HSlider", style_slider);
+	theme->set_stylebox("grabber_area", "HSlider", style_slider_grabber);
+	theme->set_stylebox("grabber_area_highlight", "HSlider", style_slider_grabber_highlight);
 
-	theme->set_icon(SNAME("grabber"), SNAME("HSlider"), icons["slider_grabber"]);
-	theme->set_icon(SNAME("grabber_highlight"), SNAME("HSlider"), icons["slider_grabber_hl"]);
-	theme->set_icon(SNAME("grabber_disabled"), SNAME("HSlider"), icons["slider_grabber_disabled"]);
-	theme->set_icon(SNAME("tick"), SNAME("HSlider"), icons["hslider_tick"]);
+	theme->set_icon("grabber", "HSlider", icons["slider_grabber"]);
+	theme->set_icon("grabber_highlight", "HSlider", icons["slider_grabber_hl"]);
+	theme->set_icon("grabber_disabled", "HSlider", icons["slider_grabber_disabled"]);
+	theme->set_icon("tick", "HSlider", icons["hslider_tick"]);
 
 	// VSlider
 
-	theme->set_stylebox(SNAME("slider"), SNAME("VSlider"), style_slider);
-	theme->set_stylebox(SNAME("grabber_area"), SNAME("VSlider"), style_slider_grabber);
-	theme->set_stylebox(SNAME("grabber_area_highlight"), SNAME("VSlider"), style_slider_grabber_highlight);
+	theme->set_stylebox("slider", "VSlider", style_slider);
+	theme->set_stylebox("grabber_area", "VSlider", style_slider_grabber);
+	theme->set_stylebox("grabber_area_highlight", "VSlider", style_slider_grabber_highlight);
 
-	theme->set_icon(SNAME("grabber"), SNAME("VSlider"), icons["slider_grabber"]);
-	theme->set_icon(SNAME("grabber_highlight"), SNAME("VSlider"), icons["slider_grabber_hl"]);
-	theme->set_icon(SNAME("grabber_disabled"), SNAME("VSlider"), icons["slider_grabber_disabled"]);
-	theme->set_icon(SNAME("tick"), SNAME("VSlider"), icons["vslider_tick"]);
+	theme->set_icon("grabber", "VSlider", icons["slider_grabber"]);
+	theme->set_icon("grabber_highlight", "VSlider", icons["slider_grabber_hl"]);
+	theme->set_icon("grabber_disabled", "VSlider", icons["slider_grabber_disabled"]);
+	theme->set_icon("tick", "VSlider", icons["vslider_tick"]);
 
 	// SpinBox
 
-	theme->set_icon(SNAME("updown"), SNAME("SpinBox"), icons["updown"]);
+	theme->set_icon("updown", "SpinBox", icons["updown"]);
 
 	// ScrollContainer
 
 	Ref<StyleBoxEmpty> empty;
 	empty.instantiate();
-	theme->set_stylebox(SNAME("bg"), SNAME("ScrollContainer"), empty);
+	theme->set_stylebox("bg", "ScrollContainer", empty);
 
 	// Window
 
-	theme->set_stylebox(SNAME("embedded_border"), SNAME("Window"), sb_expand(make_flat_stylebox(style_popup_color, 10, 28, 10, 8), 8, 32, 8, 6));
-	theme->set_constant(SNAME("scaleborder_size"), SNAME("Window"), 4 * scale);
+	theme->set_stylebox("embedded_border", "Window", sb_expand(make_flat_stylebox(style_popup_color, 10, 28, 10, 8), 8, 32, 8, 6));
+	theme->set_constant("scaleborder_size", "Window", 4 * scale);
 
-	theme->set_font(SNAME("title_font"), SNAME("Window"), Ref<Font>());
-	theme->set_font_size(SNAME("title_font_size"), SNAME("Window"), -1);
-	theme->set_color(SNAME("title_color"), SNAME("Window"), control_font_color);
-	theme->set_color(SNAME("title_outline_modulate"), SNAME("Window"), Color(1, 1, 1));
-	theme->set_constant(SNAME("title_outline_size"), SNAME("Window"), 0);
-	theme->set_constant(SNAME("title_height"), SNAME("Window"), 36 * scale);
-	theme->set_constant(SNAME("resize_margin"), SNAME("Window"), 4 * scale);
+	theme->set_font("title_font", "Window", Ref<Font>());
+	theme->set_font_size("title_font_size", "Window", -1);
+	theme->set_color("title_color", "Window", control_font_color);
+	theme->set_color("title_outline_modulate", "Window", Color(1, 1, 1));
+	theme->set_constant("title_outline_size", "Window", 0);
+	theme->set_constant("title_height", "Window", 36 * scale);
+	theme->set_constant("resize_margin", "Window", 4 * scale);
 
-	theme->set_icon(SNAME("close"), SNAME("Window"), icons["close"]);
-	theme->set_icon(SNAME("close_pressed"), SNAME("Window"), icons["close_hl"]);
-	theme->set_constant(SNAME("close_h_ofs"), SNAME("Window"), 18 * scale);
-	theme->set_constant(SNAME("close_v_ofs"), SNAME("Window"), 24 * scale);
+	theme->set_icon("close", "Window", icons["close"]);
+	theme->set_icon("close_pressed", "Window", icons["close_hl"]);
+	theme->set_constant("close_h_ofs", "Window", 18 * scale);
+	theme->set_constant("close_v_ofs", "Window", 24 * scale);
 
 	// Dialogs
 
-	theme->set_constant(SNAME("margin"), SNAME("Dialogs"), 8 * scale);
-	theme->set_constant(SNAME("button_margin"), SNAME("Dialogs"), 32 * scale);
+	theme->set_constant("margin", "Dialogs", 8 * scale);
+	theme->set_constant("button_margin", "Dialogs", 32 * scale);
 
 	// AcceptDialog
 
-	theme->set_stylebox(SNAME("panel"), SNAME("AcceptDialog"), make_flat_stylebox(style_popup_color, 0, 0, 0, 0));
+	theme->set_stylebox("panel", "AcceptDialog", make_flat_stylebox(style_popup_color, 0, 0, 0, 0));
 
 	// File Dialog
 
-	theme->set_icon(SNAME("parent_folder"), SNAME("FileDialog"), icons["folder_up"]);
-	theme->set_icon(SNAME("back_folder"), SNAME("FileDialog"), icons["arrow_left"]);
-	theme->set_icon(SNAME("forward_folder"), SNAME("FileDialog"), icons["arrow_right"]);
-	theme->set_icon(SNAME("reload"), SNAME("FileDialog"), icons["reload"]);
-	theme->set_icon(SNAME("toggle_hidden"), SNAME("FileDialog"), icons["visibility_visible"]);
-	theme->set_icon(SNAME("folder"), SNAME("FileDialog"), icons["folder"]);
-	theme->set_icon(SNAME("file"), SNAME("FileDialog"), icons["file"]);
-	theme->set_color(SNAME("folder_icon_modulate"), SNAME("FileDialog"), Color(1, 1, 1));
-	theme->set_color(SNAME("file_icon_modulate"), SNAME("FileDialog"), Color(1, 1, 1));
-	theme->set_color(SNAME("files_disabled"), SNAME("FileDialog"), Color(0, 0, 0, 0.7));
+	theme->set_icon("parent_folder", "FileDialog", icons["folder_up"]);
+	theme->set_icon("back_folder", "FileDialog", icons["arrow_left"]);
+	theme->set_icon("forward_folder", "FileDialog", icons["arrow_right"]);
+	theme->set_icon("reload", "FileDialog", icons["reload"]);
+	theme->set_icon("toggle_hidden", "FileDialog", icons["visibility_visible"]);
+	theme->set_icon("folder", "FileDialog", icons["folder"]);
+	theme->set_icon("file", "FileDialog", icons["file"]);
+	theme->set_color("folder_icon_modulate", "FileDialog", Color(1, 1, 1));
+	theme->set_color("file_icon_modulate", "FileDialog", Color(1, 1, 1));
+	theme->set_color("files_disabled", "FileDialog", Color(0, 0, 0, 0.7));
 
 	// Popup
 
-	theme->set_stylebox(SNAME("panel"), SNAME("PopupPanel"), make_flat_stylebox(style_normal_color));
+	theme->set_stylebox("panel", "PopupPanel", make_flat_stylebox(style_normal_color));
 
 	// PopupDialog
 
-	theme->set_stylebox(SNAME("panel"), SNAME("PopupDialog"), make_flat_stylebox(style_normal_color));
+	theme->set_stylebox("panel", "PopupDialog", make_flat_stylebox(style_normal_color));
 
 	// PopupMenu
 
@@ -638,35 +638,35 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 	Ref<StyleBoxFlat> style_popup_panel_disabled = style_popup_panel->duplicate();
 	style_popup_panel_disabled->set_bg_color(style_disabled_color);
 
-	theme->set_stylebox(SNAME("panel"), SNAME("PopupMenu"), style_popup_panel);
-	theme->set_stylebox(SNAME("panel_disabled"), SNAME("PopupMenu"), style_popup_panel_disabled);
-	theme->set_stylebox(SNAME("hover"), SNAME("PopupMenu"), make_flat_stylebox(style_popup_hover_color));
-	theme->set_stylebox(SNAME("separator"), SNAME("PopupMenu"), separator_horizontal);
-	theme->set_stylebox(SNAME("labeled_separator_left"), SNAME("PopupMenu"), separator_horizontal);
-	theme->set_stylebox(SNAME("labeled_separator_right"), SNAME("PopupMenu"), separator_horizontal);
+	theme->set_stylebox("panel", "PopupMenu", style_popup_panel);
+	theme->set_stylebox("panel_disabled", "PopupMenu", style_popup_panel_disabled);
+	theme->set_stylebox("hover", "PopupMenu", make_flat_stylebox(style_popup_hover_color));
+	theme->set_stylebox("separator", "PopupMenu", separator_horizontal);
+	theme->set_stylebox("labeled_separator_left", "PopupMenu", separator_horizontal);
+	theme->set_stylebox("labeled_separator_right", "PopupMenu", separator_horizontal);
 
-	theme->set_icon(SNAME("checked"), SNAME("PopupMenu"), icons["checked"]);
-	theme->set_icon(SNAME("unchecked"), SNAME("PopupMenu"), icons["unchecked"]);
-	theme->set_icon(SNAME("radio_checked"), SNAME("PopupMenu"), icons["radio_checked"]);
-	theme->set_icon(SNAME("radio_unchecked"), SNAME("PopupMenu"), icons["radio_unchecked"]);
-	theme->set_icon(SNAME("submenu"), SNAME("PopupMenu"), icons["arrow_right"]);
-	theme->set_icon(SNAME("submenu_mirrored"), SNAME("PopupMenu"), icons["arrow_left"]);
+	theme->set_icon("checked", "PopupMenu", icons["checked"]);
+	theme->set_icon("unchecked", "PopupMenu", icons["unchecked"]);
+	theme->set_icon("radio_checked", "PopupMenu", icons["radio_checked"]);
+	theme->set_icon("radio_unchecked", "PopupMenu", icons["radio_unchecked"]);
+	theme->set_icon("submenu", "PopupMenu", icons["arrow_right"]);
+	theme->set_icon("submenu_mirrored", "PopupMenu", icons["arrow_left"]);
 
-	theme->set_font(SNAME("font"), SNAME("PopupMenu"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("PopupMenu"), -1);
+	theme->set_font("font", "PopupMenu", Ref<Font>());
+	theme->set_font_size("font_size", "PopupMenu", -1);
 
-	theme->set_color(SNAME("font_color"), SNAME("PopupMenu"), control_font_color);
-	theme->set_color(SNAME("font_accelerator_color"), SNAME("PopupMenu"), Color(0.7, 0.7, 0.7, 0.8));
-	theme->set_color(SNAME("font_disabled_color"), SNAME("PopupMenu"), Color(0.4, 0.4, 0.4, 0.8));
-	theme->set_color(SNAME("font_hover_color"), SNAME("PopupMenu"), control_font_color);
-	theme->set_color(SNAME("font_separator_color"), SNAME("PopupMenu"), control_font_color);
-	theme->set_color(SNAME("font_outline_color"), SNAME("PopupMenu"), Color(1, 1, 1));
+	theme->set_color("font_color", "PopupMenu", control_font_color);
+	theme->set_color("font_accelerator_color", "PopupMenu", Color(0.7, 0.7, 0.7, 0.8));
+	theme->set_color("font_disabled_color", "PopupMenu", Color(0.4, 0.4, 0.4, 0.8));
+	theme->set_color("font_hover_color", "PopupMenu", control_font_color);
+	theme->set_color("font_separator_color", "PopupMenu", control_font_color);
+	theme->set_color("font_outline_color", "PopupMenu", Color(1, 1, 1));
 
-	theme->set_constant(SNAME("hseparation"), SNAME("PopupMenu"), 4 * scale);
-	theme->set_constant(SNAME("vseparation"), SNAME("PopupMenu"), 4 * scale);
-	theme->set_constant(SNAME("outline_size"), SNAME("PopupMenu"), 0);
-	theme->set_constant(SNAME("item_start_padding"), SNAME("PopupMenu"), 2 * scale);
-	theme->set_constant(SNAME("item_end_padding"), SNAME("PopupMenu"), 2 * scale);
+	theme->set_constant("hseparation", "PopupMenu", 4 * scale);
+	theme->set_constant("vseparation", "PopupMenu", 4 * scale);
+	theme->set_constant("outline_size", "PopupMenu", 0);
+	theme->set_constant("item_start_padding", "PopupMenu", 2 * scale);
+	theme->set_constant("item_end_padding", "PopupMenu", 2 * scale);
 
 	// GraphNode
 	Ref<StyleBoxFlat> graphnode_normal = make_flat_stylebox(style_normal_color, 18, 42, 18, 12);
@@ -683,101 +683,101 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 	Ref<StyleBoxFlat> graphnode_position = make_flat_stylebox(style_pressed_color, 18, 42, 18, 12, 6, true, 4);
 	graphnode_position->set_border_color(Color(0.98, 0.89, 0.27));
 
-	theme->set_stylebox(SNAME("frame"), SNAME("GraphNode"), graphnode_normal);
-	theme->set_stylebox(SNAME("selectedframe"), SNAME("GraphNode"), graphnode_selected);
-	theme->set_stylebox(SNAME("comment"), SNAME("GraphNode"), graphnode_comment_normal);
-	theme->set_stylebox(SNAME("commentfocus"), SNAME("GraphNode"), graphnode_comment_selected);
-	theme->set_stylebox(SNAME("breakpoint"), SNAME("GraphNode"), graphnode_breakpoint);
-	theme->set_stylebox(SNAME("position"), SNAME("GraphNode"), graphnode_position);
+	theme->set_stylebox("frame", "GraphNode", graphnode_normal);
+	theme->set_stylebox("selectedframe", "GraphNode", graphnode_selected);
+	theme->set_stylebox("comment", "GraphNode", graphnode_comment_normal);
+	theme->set_stylebox("commentfocus", "GraphNode", graphnode_comment_selected);
+	theme->set_stylebox("breakpoint", "GraphNode", graphnode_breakpoint);
+	theme->set_stylebox("position", "GraphNode", graphnode_position);
 
-	theme->set_icon(SNAME("port"), SNAME("GraphNode"), icons["graph_port"]);
-	theme->set_icon(SNAME("close"), SNAME("GraphNode"), icons["close"]);
-	theme->set_icon(SNAME("resizer"), SNAME("GraphNode"), icons["resizer_se"]);
-	theme->set_font(SNAME("title_font"), SNAME("GraphNode"), Ref<Font>());
-	theme->set_color(SNAME("title_color"), SNAME("GraphNode"), control_font_color);
-	theme->set_color(SNAME("close_color"), SNAME("GraphNode"), control_font_color);
-	theme->set_color(SNAME("resizer_color"), SNAME("GraphNode"), control_font_color);
-	theme->set_constant(SNAME("separation"), SNAME("GraphNode"), 2 * scale);
-	theme->set_constant(SNAME("title_offset"), SNAME("GraphNode"), 26 * scale);
-	theme->set_constant(SNAME("close_offset"), SNAME("GraphNode"), 22 * scale);
-	theme->set_constant(SNAME("port_offset"), SNAME("GraphNode"), 0);
+	theme->set_icon("port", "GraphNode", icons["graph_port"]);
+	theme->set_icon("close", "GraphNode", icons["close"]);
+	theme->set_icon("resizer", "GraphNode", icons["resizer_se"]);
+	theme->set_font("title_font", "GraphNode", Ref<Font>());
+	theme->set_color("title_color", "GraphNode", control_font_color);
+	theme->set_color("close_color", "GraphNode", control_font_color);
+	theme->set_color("resizer_color", "GraphNode", control_font_color);
+	theme->set_constant("separation", "GraphNode", 2 * scale);
+	theme->set_constant("title_offset", "GraphNode", 26 * scale);
+	theme->set_constant("close_offset", "GraphNode", 22 * scale);
+	theme->set_constant("port_offset", "GraphNode", 0);
 
 	// Tree
 
-	theme->set_stylebox(SNAME("bg"), SNAME("Tree"), make_flat_stylebox(style_normal_color, 4, 4, 4, 5));
-	theme->set_stylebox(SNAME("bg_focus"), SNAME("Tree"), focus);
-	theme->set_stylebox(SNAME("selected"), SNAME("Tree"), make_flat_stylebox(style_selected_color));
-	theme->set_stylebox(SNAME("selected_focus"), SNAME("Tree"), make_flat_stylebox(style_selected_color));
-	theme->set_stylebox(SNAME("cursor"), SNAME("Tree"), focus);
-	theme->set_stylebox(SNAME("cursor_unfocused"), SNAME("Tree"), focus);
-	theme->set_stylebox(SNAME("button_pressed"), SNAME("Tree"), button_pressed);
-	theme->set_stylebox(SNAME("title_button_normal"), SNAME("Tree"), make_flat_stylebox(style_pressed_color, 4, 4, 4, 4));
-	theme->set_stylebox(SNAME("title_button_pressed"), SNAME("Tree"), make_flat_stylebox(style_hover_color, 4, 4, 4, 4));
-	theme->set_stylebox(SNAME("title_button_hover"), SNAME("Tree"), make_flat_stylebox(style_normal_color, 4, 4, 4, 4));
-	theme->set_stylebox(SNAME("custom_button"), SNAME("Tree"), button_normal);
-	theme->set_stylebox(SNAME("custom_button_pressed"), SNAME("Tree"), button_pressed);
-	theme->set_stylebox(SNAME("custom_button_hover"), SNAME("Tree"), button_hover);
+	theme->set_stylebox("bg", "Tree", make_flat_stylebox(style_normal_color, 4, 4, 4, 5));
+	theme->set_stylebox("bg_focus", "Tree", focus);
+	theme->set_stylebox("selected", "Tree", make_flat_stylebox(style_selected_color));
+	theme->set_stylebox("selected_focus", "Tree", make_flat_stylebox(style_selected_color));
+	theme->set_stylebox("cursor", "Tree", focus);
+	theme->set_stylebox("cursor_unfocused", "Tree", focus);
+	theme->set_stylebox("button_pressed", "Tree", button_pressed);
+	theme->set_stylebox("title_button_normal", "Tree", make_flat_stylebox(style_pressed_color, 4, 4, 4, 4));
+	theme->set_stylebox("title_button_pressed", "Tree", make_flat_stylebox(style_hover_color, 4, 4, 4, 4));
+	theme->set_stylebox("title_button_hover", "Tree", make_flat_stylebox(style_normal_color, 4, 4, 4, 4));
+	theme->set_stylebox("custom_button", "Tree", button_normal);
+	theme->set_stylebox("custom_button_pressed", "Tree", button_pressed);
+	theme->set_stylebox("custom_button_hover", "Tree", button_hover);
 
-	theme->set_icon(SNAME("checked"), SNAME("Tree"), icons["checked"]);
-	theme->set_icon(SNAME("unchecked"), SNAME("Tree"), icons["unchecked"]);
-	theme->set_icon(SNAME("indeterminate"), SNAME("Tree"), icons["indeterminate"]);
-	theme->set_icon(SNAME("updown"), SNAME("Tree"), icons["updown"]);
-	theme->set_icon(SNAME("select_arrow"), SNAME("Tree"), icons["option_button_arrow"]);
-	theme->set_icon(SNAME("arrow"), SNAME("Tree"), icons["arrow_down"]);
-	theme->set_icon(SNAME("arrow_collapsed"), SNAME("Tree"), icons["arrow_right"]);
-	theme->set_icon(SNAME("arrow_collapsed_mirrored"), SNAME("Tree"), icons["arrow_left"]);
+	theme->set_icon("checked", "Tree", icons["checked"]);
+	theme->set_icon("unchecked", "Tree", icons["unchecked"]);
+	theme->set_icon("indeterminate", "Tree", icons["indeterminate"]);
+	theme->set_icon("updown", "Tree", icons["updown"]);
+	theme->set_icon("select_arrow", "Tree", icons["option_button_arrow"]);
+	theme->set_icon("arrow", "Tree", icons["arrow_down"]);
+	theme->set_icon("arrow_collapsed", "Tree", icons["arrow_right"]);
+	theme->set_icon("arrow_collapsed_mirrored", "Tree", icons["arrow_left"]);
 
-	theme->set_font(SNAME("title_button_font"), SNAME("Tree"), Ref<Font>());
-	theme->set_font(SNAME("font"), SNAME("Tree"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("Tree"), -1);
+	theme->set_font("title_button_font", "Tree", Ref<Font>());
+	theme->set_font("font", "Tree", Ref<Font>());
+	theme->set_font_size("font_size", "Tree", -1);
 
-	theme->set_color(SNAME("title_button_color"), SNAME("Tree"), control_font_color);
-	theme->set_color(SNAME("font_color"), SNAME("Tree"), control_font_low_color);
-	theme->set_color(SNAME("font_selected_color"), SNAME("Tree"), control_font_pressed_color);
-	theme->set_color(SNAME("font_outline_color"), SNAME("Tree"), Color(1, 1, 1));
-	theme->set_color(SNAME("guide_color"), SNAME("Tree"), Color(0.7, 0.7, 0.7, 0.25));
-	theme->set_color(SNAME("drop_position_color"), SNAME("Tree"), Color(1, 0.3, 0.2));
-	theme->set_color(SNAME("relationship_line_color"), SNAME("Tree"), Color(0.27, 0.27, 0.27));
-	theme->set_color(SNAME("parent_hl_line_color"), SNAME("Tree"), Color(0.27, 0.27, 0.27));
-	theme->set_color(SNAME("children_hl_line_color"), SNAME("Tree"), Color(0.27, 0.27, 0.27));
-	theme->set_color(SNAME("custom_button_font_highlight"), SNAME("Tree"), control_font_hover_color);
+	theme->set_color("title_button_color", "Tree", control_font_color);
+	theme->set_color("font_color", "Tree", control_font_low_color);
+	theme->set_color("font_selected_color", "Tree", control_font_pressed_color);
+	theme->set_color("font_outline_color", "Tree", Color(1, 1, 1));
+	theme->set_color("guide_color", "Tree", Color(0.7, 0.7, 0.7, 0.25));
+	theme->set_color("drop_position_color", "Tree", Color(1, 0.3, 0.2));
+	theme->set_color("relationship_line_color", "Tree", Color(0.27, 0.27, 0.27));
+	theme->set_color("parent_hl_line_color", "Tree", Color(0.27, 0.27, 0.27));
+	theme->set_color("children_hl_line_color", "Tree", Color(0.27, 0.27, 0.27));
+	theme->set_color("custom_button_font_highlight", "Tree", control_font_hover_color);
 
-	theme->set_constant(SNAME("hseparation"), SNAME("Tree"), 4 * scale);
-	theme->set_constant(SNAME("vseparation"), SNAME("Tree"), 4 * scale);
-	theme->set_constant(SNAME("item_margin"), SNAME("Tree"), 16 * scale);
-	theme->set_constant(SNAME("button_margin"), SNAME("Tree"), 4 * scale);
-	theme->set_constant(SNAME("draw_relationship_lines"), SNAME("Tree"), 0);
-	theme->set_constant(SNAME("relationship_line_width"), SNAME("Tree"), 1);
-	theme->set_constant(SNAME("parent_hl_line_width"), SNAME("Tree"), 1);
-	theme->set_constant(SNAME("children_hl_line_width"), SNAME("Tree"), 1);
-	theme->set_constant(SNAME("parent_hl_line_margin"), SNAME("Tree"), 0);
-	theme->set_constant(SNAME("draw_guides"), SNAME("Tree"), 1);
-	theme->set_constant(SNAME("scroll_border"), SNAME("Tree"), 4);
-	theme->set_constant(SNAME("scroll_speed"), SNAME("Tree"), 12);
-	theme->set_constant(SNAME("outline_size"), SNAME("Tree"), 0);
+	theme->set_constant("hseparation", "Tree", 4 * scale);
+	theme->set_constant("vseparation", "Tree", 4 * scale);
+	theme->set_constant("item_margin", "Tree", 16 * scale);
+	theme->set_constant("button_margin", "Tree", 4 * scale);
+	theme->set_constant("draw_relationship_lines", "Tree", 0);
+	theme->set_constant("relationship_line_width", "Tree", 1);
+	theme->set_constant("parent_hl_line_width", "Tree", 1);
+	theme->set_constant("children_hl_line_width", "Tree", 1);
+	theme->set_constant("parent_hl_line_margin", "Tree", 0);
+	theme->set_constant("draw_guides", "Tree", 1);
+	theme->set_constant("scroll_border", "Tree", 4);
+	theme->set_constant("scroll_speed", "Tree", 12);
+	theme->set_constant("outline_size", "Tree", 0);
 
 	// ItemList
 
-	theme->set_stylebox(SNAME("bg"), SNAME("ItemList"), make_flat_stylebox(style_normal_color));
-	theme->set_stylebox(SNAME("bg_focus"), SNAME("ItemList"), focus);
-	theme->set_constant(SNAME("hseparation"), SNAME("ItemList"), 4);
-	theme->set_constant(SNAME("vseparation"), SNAME("ItemList"), 2);
-	theme->set_constant(SNAME("icon_margin"), SNAME("ItemList"), 4);
-	theme->set_constant(SNAME("line_separation"), SNAME("ItemList"), 2 * scale);
+	theme->set_stylebox("bg", "ItemList", make_flat_stylebox(style_normal_color));
+	theme->set_stylebox("bg_focus", "ItemList", focus);
+	theme->set_constant("hseparation", "ItemList", 4);
+	theme->set_constant("vseparation", "ItemList", 2);
+	theme->set_constant("icon_margin", "ItemList", 4);
+	theme->set_constant("line_separation", "ItemList", 2 * scale);
 
-	theme->set_font(SNAME("font"), SNAME("ItemList"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("ItemList"), -1);
+	theme->set_font("font", "ItemList", Ref<Font>());
+	theme->set_font_size("font_size", "ItemList", -1);
 
-	theme->set_color(SNAME("font_color"), SNAME("ItemList"), control_font_lower_color);
-	theme->set_color(SNAME("font_selected_color"), SNAME("ItemList"), control_font_pressed_color);
-	theme->set_color(SNAME("font_outline_color"), SNAME("ItemList"), Color(1, 1, 1));
-	theme->set_color(SNAME("guide_color"), SNAME("ItemList"), Color(0, 0, 0, 0.1));
-	theme->set_stylebox(SNAME("selected"), SNAME("ItemList"), make_flat_stylebox(style_selected_color));
-	theme->set_stylebox(SNAME("selected_focus"), SNAME("ItemList"), make_flat_stylebox(style_selected_color));
-	theme->set_stylebox(SNAME("cursor"), SNAME("ItemList"), focus);
-	theme->set_stylebox(SNAME("cursor_unfocused"), SNAME("ItemList"), focus);
+	theme->set_color("font_color", "ItemList", control_font_lower_color);
+	theme->set_color("font_selected_color", "ItemList", control_font_pressed_color);
+	theme->set_color("font_outline_color", "ItemList", Color(1, 1, 1));
+	theme->set_color("guide_color", "ItemList", Color(0, 0, 0, 0.1));
+	theme->set_stylebox("selected", "ItemList", make_flat_stylebox(style_selected_color));
+	theme->set_stylebox("selected_focus", "ItemList", make_flat_stylebox(style_selected_color));
+	theme->set_stylebox("cursor", "ItemList", focus);
+	theme->set_stylebox("cursor_unfocused", "ItemList", focus);
 
-	theme->set_constant(SNAME("outline_size"), SNAME("ItemList"), 0);
+	theme->set_constant("outline_size", "ItemList", 0);
 
 	// TabContainer
 
@@ -792,105 +792,105 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 	Ref<StyleBoxFlat> style_tab_disabled = style_tab_unselected->duplicate();
 	style_tab_disabled->set_bg_color(style_disabled_color);
 
-	theme->set_stylebox(SNAME("tab_selected"), SNAME("TabContainer"), style_tab_selected);
-	theme->set_stylebox(SNAME("tab_unselected"), SNAME("TabContainer"), style_tab_unselected);
-	theme->set_stylebox(SNAME("tab_disabled"), SNAME("TabContainer"), style_tab_disabled);
-	theme->set_stylebox(SNAME("panel"), SNAME("TabContainer"), make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
+	theme->set_stylebox("tab_selected", "TabContainer", style_tab_selected);
+	theme->set_stylebox("tab_unselected", "TabContainer", style_tab_unselected);
+	theme->set_stylebox("tab_disabled", "TabContainer", style_tab_disabled);
+	theme->set_stylebox("panel", "TabContainer", make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
 
-	theme->set_icon(SNAME("increment"), SNAME("TabContainer"), icons["scroll_button_right"]);
-	theme->set_icon(SNAME("increment_highlight"), SNAME("TabContainer"), icons["scroll_button_right_hl"]);
-	theme->set_icon(SNAME("decrement"), SNAME("TabContainer"), icons["scroll_button_left"]);
-	theme->set_icon(SNAME("decrement_highlight"), SNAME("TabContainer"), icons["scroll_button_left_hl"]);
-	theme->set_icon(SNAME("menu"), SNAME("TabContainer"), icons["tabs_menu"]);
-	theme->set_icon(SNAME("menu_highlight"), SNAME("TabContainer"), icons["tabs_menu_hl"]);
+	theme->set_icon("increment", "TabContainer", icons["scroll_button_right"]);
+	theme->set_icon("increment_highlight", "TabContainer", icons["scroll_button_right_hl"]);
+	theme->set_icon("decrement", "TabContainer", icons["scroll_button_left"]);
+	theme->set_icon("decrement_highlight", "TabContainer", icons["scroll_button_left_hl"]);
+	theme->set_icon("menu", "TabContainer", icons["tabs_menu"]);
+	theme->set_icon("menu_highlight", "TabContainer", icons["tabs_menu_hl"]);
 
-	theme->set_font(SNAME("font"), SNAME("TabContainer"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("TabContainer"), -1);
+	theme->set_font("font", "TabContainer", Ref<Font>());
+	theme->set_font_size("font_size", "TabContainer", -1);
 
-	theme->set_color(SNAME("font_selected_color"), SNAME("TabContainer"), control_font_hover_color);
-	theme->set_color(SNAME("font_unselected_color"), SNAME("TabContainer"), control_font_low_color);
-	theme->set_color(SNAME("font_disabled_color"), SNAME("TabContainer"), control_font_disabled_color);
-	theme->set_color(SNAME("font_outline_color"), SNAME("TabContainer"), Color(1, 1, 1));
+	theme->set_color("font_selected_color", "TabContainer", control_font_hover_color);
+	theme->set_color("font_unselected_color", "TabContainer", control_font_low_color);
+	theme->set_color("font_disabled_color", "TabContainer", control_font_disabled_color);
+	theme->set_color("font_outline_color", "TabContainer", Color(1, 1, 1));
 
-	theme->set_constant(SNAME("side_margin"), SNAME("TabContainer"), 8 * scale);
-	theme->set_constant(SNAME("icon_separation"), SNAME("TabContainer"), 4 * scale);
-	theme->set_constant(SNAME("outline_size"), SNAME("TabContainer"), 0);
+	theme->set_constant("side_margin", "TabContainer", 8 * scale);
+	theme->set_constant("icon_separation", "TabContainer", 4 * scale);
+	theme->set_constant("outline_size", "TabContainer", 0);
 
 	// TabBar
 
-	theme->set_stylebox(SNAME("tab_selected"), SNAME("TabBar"), style_tab_selected);
-	theme->set_stylebox(SNAME("tab_unselected"), SNAME("TabBar"), style_tab_unselected);
-	theme->set_stylebox(SNAME("tab_disabled"), SNAME("TabBar"), style_tab_disabled);
-	theme->set_stylebox(SNAME("button_pressed"), SNAME("TabBar"), button_pressed);
-	theme->set_stylebox(SNAME("button_highlight"), SNAME("TabBar"), button_normal);
+	theme->set_stylebox("tab_selected", "TabBar", style_tab_selected);
+	theme->set_stylebox("tab_unselected", "TabBar", style_tab_unselected);
+	theme->set_stylebox("tab_disabled", "TabBar", style_tab_disabled);
+	theme->set_stylebox("button_pressed", "TabBar", button_pressed);
+	theme->set_stylebox("button_highlight", "TabBar", button_normal);
 
-	theme->set_icon(SNAME("increment"), SNAME("TabBar"), icons["scroll_button_right"]);
-	theme->set_icon(SNAME("increment_highlight"), SNAME("TabBar"), icons["scroll_button_right_hl"]);
-	theme->set_icon(SNAME("decrement"), SNAME("TabBar"), icons["scroll_button_left"]);
-	theme->set_icon(SNAME("decrement_highlight"), SNAME("TabBar"), icons["scroll_button_left_hl"]);
-	theme->set_icon(SNAME("close"), SNAME("TabBar"), icons["close"]);
+	theme->set_icon("increment", "TabBar", icons["scroll_button_right"]);
+	theme->set_icon("increment_highlight", "TabBar", icons["scroll_button_right_hl"]);
+	theme->set_icon("decrement", "TabBar", icons["scroll_button_left"]);
+	theme->set_icon("decrement_highlight", "TabBar", icons["scroll_button_left_hl"]);
+	theme->set_icon("close", "TabBar", icons["close"]);
 
-	theme->set_font(SNAME("font"), SNAME("TabBar"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("TabBar"), -1);
+	theme->set_font("font", "TabBar", Ref<Font>());
+	theme->set_font_size("font_size", "TabBar", -1);
 
-	theme->set_color(SNAME("font_selected_color"), SNAME("TabBar"), control_font_hover_color);
-	theme->set_color(SNAME("font_unselected_color"), SNAME("TabBar"), control_font_low_color);
-	theme->set_color(SNAME("font_disabled_color"), SNAME("TabBar"), control_font_disabled_color);
-	theme->set_color(SNAME("font_outline_color"), SNAME("TabBar"), Color(1, 1, 1));
+	theme->set_color("font_selected_color", "TabBar", control_font_hover_color);
+	theme->set_color("font_unselected_color", "TabBar", control_font_low_color);
+	theme->set_color("font_disabled_color", "TabBar", control_font_disabled_color);
+	theme->set_color("font_outline_color", "TabBar", Color(1, 1, 1));
 
-	theme->set_constant(SNAME("hseparation"), SNAME("TabBar"), 4 * scale);
-	theme->set_constant(SNAME("outline_size"), SNAME("TabBar"), 0);
+	theme->set_constant("hseparation", "TabBar", 4 * scale);
+	theme->set_constant("outline_size", "TabBar", 0);
 
 	// Separators
 
-	theme->set_stylebox(SNAME("separator"), SNAME("HSeparator"), separator_horizontal);
-	theme->set_stylebox(SNAME("separator"), SNAME("VSeparator"), separator_vertical);
+	theme->set_stylebox("separator", "HSeparator", separator_horizontal);
+	theme->set_stylebox("separator", "VSeparator", separator_vertical);
 
-	theme->set_icon(SNAME("close"), SNAME("Icons"), icons["close"]);
-	theme->set_font(SNAME("normal"), SNAME("Fonts"), Ref<Font>());
-	theme->set_font(SNAME("large"), SNAME("Fonts"), Ref<Font>());
+	theme->set_icon("close", "Icons", icons["close"]);
+	theme->set_font("normal", "Fonts", Ref<Font>());
+	theme->set_font("large", "Fonts", Ref<Font>());
 
-	theme->set_constant(SNAME("separation"), SNAME("HSeparator"), 4 * scale);
-	theme->set_constant(SNAME("separation"), SNAME("VSeparator"), 4 * scale);
+	theme->set_constant("separation", "HSeparator", 4 * scale);
+	theme->set_constant("separation", "VSeparator", 4 * scale);
 
 	// ColorPicker
 
-	theme->set_constant(SNAME("margin"), SNAME("ColorPicker"), 4 * scale);
-	theme->set_constant(SNAME("sv_width"), SNAME("ColorPicker"), 256 * scale);
-	theme->set_constant(SNAME("sv_height"), SNAME("ColorPicker"), 256 * scale);
-	theme->set_constant(SNAME("h_width"), SNAME("ColorPicker"), 30 * scale);
-	theme->set_constant(SNAME("label_width"), SNAME("ColorPicker"), 10 * scale);
+	theme->set_constant("margin", "ColorPicker", 4 * scale);
+	theme->set_constant("sv_width", "ColorPicker", 256 * scale);
+	theme->set_constant("sv_height", "ColorPicker", 256 * scale);
+	theme->set_constant("h_width", "ColorPicker", 30 * scale);
+	theme->set_constant("label_width", "ColorPicker", 10 * scale);
 
-	theme->set_icon(SNAME("screen_picker"), SNAME("ColorPicker"), icons["color_picker_pipette"]);
-	theme->set_icon(SNAME("add_preset"), SNAME("ColorPicker"), icons["add"]);
-	theme->set_icon(SNAME("color_hue"), SNAME("ColorPicker"), icons["color_picker_hue"]);
-	theme->set_icon(SNAME("color_sample"), SNAME("ColorPicker"), icons["color_picker_sample"]);
-	theme->set_icon(SNAME("sample_bg"), SNAME("ColorPicker"), icons["mini_checkerboard"]);
-	theme->set_icon(SNAME("overbright_indicator"), SNAME("ColorPicker"), icons["color_picker_overbright"]);
-	theme->set_icon(SNAME("bar_arrow"), SNAME("ColorPicker"), icons["color_picker_bar_arrow"]);
-	theme->set_icon(SNAME("picker_cursor"), SNAME("ColorPicker"), icons["color_picker_cursor"]);
+	theme->set_icon("screen_picker", "ColorPicker", icons["color_picker_pipette"]);
+	theme->set_icon("add_preset", "ColorPicker", icons["add"]);
+	theme->set_icon("color_hue", "ColorPicker", icons["color_picker_hue"]);
+	theme->set_icon("color_sample", "ColorPicker", icons["color_picker_sample"]);
+	theme->set_icon("sample_bg", "ColorPicker", icons["mini_checkerboard"]);
+	theme->set_icon("overbright_indicator", "ColorPicker", icons["color_picker_overbright"]);
+	theme->set_icon("bar_arrow", "ColorPicker", icons["color_picker_bar_arrow"]);
+	theme->set_icon("picker_cursor", "ColorPicker", icons["color_picker_cursor"]);
 
 	// ColorPickerButton
 
-	theme->set_icon(SNAME("bg"), SNAME("ColorPickerButton"), icons["mini_checkerboard"]);
-	theme->set_stylebox(SNAME("normal"), SNAME("ColorPickerButton"), button_normal);
-	theme->set_stylebox(SNAME("pressed"), SNAME("ColorPickerButton"), button_pressed);
-	theme->set_stylebox(SNAME("hover"), SNAME("ColorPickerButton"), button_hover);
-	theme->set_stylebox(SNAME("disabled"), SNAME("ColorPickerButton"), button_disabled);
-	theme->set_stylebox(SNAME("focus"), SNAME("ColorPickerButton"), focus);
+	theme->set_icon("bg", "ColorPickerButton", icons["mini_checkerboard"]);
+	theme->set_stylebox("normal", "ColorPickerButton", button_normal);
+	theme->set_stylebox("pressed", "ColorPickerButton", button_pressed);
+	theme->set_stylebox("hover", "ColorPickerButton", button_hover);
+	theme->set_stylebox("disabled", "ColorPickerButton", button_disabled);
+	theme->set_stylebox("focus", "ColorPickerButton", focus);
 
-	theme->set_font(SNAME("font"), SNAME("ColorPickerButton"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("ColorPickerButton"), -1);
+	theme->set_font("font", "ColorPickerButton", Ref<Font>());
+	theme->set_font_size("font_size", "ColorPickerButton", -1);
 
-	theme->set_color(SNAME("font_color"), SNAME("ColorPickerButton"), Color(1, 1, 1, 1));
-	theme->set_color(SNAME("font_pressed_color"), SNAME("ColorPickerButton"), Color(0.8, 0.8, 0.8, 1));
-	theme->set_color(SNAME("font_hover_color"), SNAME("ColorPickerButton"), Color(1, 1, 1, 1));
-	theme->set_color(SNAME("font_focus_color"), SNAME("ColorPickerButton"), Color(1, 1, 1, 1));
-	theme->set_color(SNAME("font_disabled_color"), SNAME("ColorPickerButton"), Color(0.9, 0.9, 0.9, 0.3));
-	theme->set_color(SNAME("font_outline_color"), SNAME("ColorPickerButton"), Color(1, 1, 1));
+	theme->set_color("font_color", "ColorPickerButton", Color(1, 1, 1, 1));
+	theme->set_color("font_pressed_color", "ColorPickerButton", Color(0.8, 0.8, 0.8, 1));
+	theme->set_color("font_hover_color", "ColorPickerButton", Color(1, 1, 1, 1));
+	theme->set_color("font_focus_color", "ColorPickerButton", Color(1, 1, 1, 1));
+	theme->set_color("font_disabled_color", "ColorPickerButton", Color(0.9, 0.9, 0.9, 0.3));
+	theme->set_color("font_outline_color", "ColorPickerButton", Color(1, 1, 1));
 
-	theme->set_constant(SNAME("hseparation"), SNAME("ColorPickerButton"), 2 * scale);
-	theme->set_constant(SNAME("outline_size"), SNAME("ColorPickerButton"), 0);
+	theme->set_constant("hseparation", "ColorPickerButton", 2 * scale);
+	theme->set_constant("outline_size", "ColorPickerButton", 0);
 
 	// ColorPresetButton
 
@@ -899,118 +899,118 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 	preset_sb->set_corner_detail(2);
 	preset_sb->set_anti_aliased(false);
 
-	theme->set_stylebox(SNAME("preset_fg"), SNAME("ColorPresetButton"), preset_sb);
-	theme->set_icon(SNAME("preset_bg"), SNAME("ColorPresetButton"), icons["mini_checkerboard"]);
-	theme->set_icon(SNAME("overbright_indicator"), SNAME("ColorPresetButton"), icons["color_picker_overbright"]);
+	theme->set_stylebox("preset_fg", "ColorPresetButton", preset_sb);
+	theme->set_icon("preset_bg", "ColorPresetButton", icons["mini_checkerboard"]);
+	theme->set_icon("overbright_indicator", "ColorPresetButton", icons["color_picker_overbright"]);
 
 	// TooltipPanel + TooltipLabel
 
-	theme->set_stylebox(SNAME("panel"), SNAME("TooltipPanel"),
+	theme->set_stylebox("panel", "TooltipPanel",
 			make_flat_stylebox(Color(0, 0, 0, 0.5), 2 * default_margin, 0.5 * default_margin, 2 * default_margin, 0.5 * default_margin));
 
-	theme->set_font(SNAME("font"), SNAME("TooltipLabel"), Ref<Font>());
-	theme->set_font_size(SNAME("font_size"), SNAME("TooltipLabel"), -1);
+	theme->set_font("font", "TooltipLabel", Ref<Font>());
+	theme->set_font_size("font_size", "TooltipLabel", -1);
 
-	theme->set_color(SNAME("font_color"), SNAME("TooltipLabel"), control_font_color);
-	theme->set_color(SNAME("font_shadow_color"), SNAME("TooltipLabel"), Color(0, 0, 0, 0));
-	theme->set_color(SNAME("font_outline_color"), SNAME("TooltipLabel"), Color(0, 0, 0, 0));
+	theme->set_color("font_color", "TooltipLabel", control_font_color);
+	theme->set_color("font_shadow_color", "TooltipLabel", Color(0, 0, 0, 0));
+	theme->set_color("font_outline_color", "TooltipLabel", Color(0, 0, 0, 0));
 
-	theme->set_constant(SNAME("shadow_offset_x"), SNAME("TooltipLabel"), 1);
-	theme->set_constant(SNAME("shadow_offset_y"), SNAME("TooltipLabel"), 1);
-	theme->set_constant(SNAME("outline_size"), SNAME("TooltipLabel"), 0);
+	theme->set_constant("shadow_offset_x", "TooltipLabel", 1);
+	theme->set_constant("shadow_offset_y", "TooltipLabel", 1);
+	theme->set_constant("outline_size", "TooltipLabel", 0);
 
 	// RichTextLabel
 
-	theme->set_stylebox(SNAME("focus"), SNAME("RichTextLabel"), focus);
-	theme->set_stylebox(SNAME("normal"), SNAME("RichTextLabel"), make_empty_stylebox(0, 0, 0, 0));
+	theme->set_stylebox("focus", "RichTextLabel", focus);
+	theme->set_stylebox("normal", "RichTextLabel", make_empty_stylebox(0, 0, 0, 0));
 
-	theme->set_font(SNAME("normal_font"), SNAME("RichTextLabel"), Ref<Font>());
-	theme->set_font(SNAME("bold_font"), SNAME("RichTextLabel"), Ref<Font>());
-	theme->set_font(SNAME("italics_font"), SNAME("RichTextLabel"), Ref<Font>());
-	theme->set_font(SNAME("bold_italics_font"), SNAME("RichTextLabel"), Ref<Font>());
-	theme->set_font(SNAME("mono_font"), SNAME("RichTextLabel"), Ref<Font>());
+	theme->set_font("normal_font", "RichTextLabel", Ref<Font>());
+	theme->set_font("bold_font", "RichTextLabel", Ref<Font>());
+	theme->set_font("italics_font", "RichTextLabel", Ref<Font>());
+	theme->set_font("bold_italics_font", "RichTextLabel", Ref<Font>());
+	theme->set_font("mono_font", "RichTextLabel", Ref<Font>());
 
-	theme->set_font_size(SNAME("normal_font_size"), SNAME("RichTextLabel"), -1);
-	theme->set_font_size(SNAME("bold_font_size"), SNAME("RichTextLabel"), -1);
-	theme->set_font_size(SNAME("italics_font_size"), SNAME("RichTextLabel"), -1);
-	theme->set_font_size(SNAME("bold_italics_font_size"), SNAME("RichTextLabel"), -1);
-	theme->set_font_size(SNAME("mono_font_size"), SNAME("RichTextLabel"), -1);
+	theme->set_font_size("normal_font_size", "RichTextLabel", -1);
+	theme->set_font_size("bold_font_size", "RichTextLabel", -1);
+	theme->set_font_size("italics_font_size", "RichTextLabel", -1);
+	theme->set_font_size("bold_italics_font_size", "RichTextLabel", -1);
+	theme->set_font_size("mono_font_size", "RichTextLabel", -1);
 
-	theme->set_color(SNAME("default_color"), SNAME("RichTextLabel"), Color(1, 1, 1));
-	theme->set_color(SNAME("font_selected_color"), SNAME("RichTextLabel"), Color(0, 0, 0));
-	theme->set_color(SNAME("selection_color"), SNAME("RichTextLabel"), Color(0.1, 0.1, 1, 0.8));
+	theme->set_color("default_color", "RichTextLabel", Color(1, 1, 1));
+	theme->set_color("font_selected_color", "RichTextLabel", Color(0, 0, 0));
+	theme->set_color("selection_color", "RichTextLabel", Color(0.1, 0.1, 1, 0.8));
 
-	theme->set_color(SNAME("font_shadow_color"), SNAME("RichTextLabel"), Color(0, 0, 0, 0));
+	theme->set_color("font_shadow_color", "RichTextLabel", Color(0, 0, 0, 0));
 
-	theme->set_color(SNAME("font_outline_color"), SNAME("RichTextLabel"), Color(1, 1, 1));
+	theme->set_color("font_outline_color", "RichTextLabel", Color(1, 1, 1));
 
-	theme->set_constant(SNAME("shadow_offset_x"), SNAME("RichTextLabel"), 1 * scale);
-	theme->set_constant(SNAME("shadow_offset_y"), SNAME("RichTextLabel"), 1 * scale);
-	theme->set_constant(SNAME("shadow_outline_size"), SNAME("RichTextLabel"), 1 * scale);
+	theme->set_constant("shadow_offset_x", "RichTextLabel", 1 * scale);
+	theme->set_constant("shadow_offset_y", "RichTextLabel", 1 * scale);
+	theme->set_constant("shadow_outline_size", "RichTextLabel", 1 * scale);
 
-	theme->set_constant(SNAME("line_separation"), SNAME("RichTextLabel"), 0 * scale);
-	theme->set_constant(SNAME("table_hseparation"), SNAME("RichTextLabel"), 3 * scale);
-	theme->set_constant(SNAME("table_vseparation"), SNAME("RichTextLabel"), 3 * scale);
+	theme->set_constant("line_separation", "RichTextLabel", 0 * scale);
+	theme->set_constant("table_hseparation", "RichTextLabel", 3 * scale);
+	theme->set_constant("table_vseparation", "RichTextLabel", 3 * scale);
 
-	theme->set_constant(SNAME("outline_size"), SNAME("RichTextLabel"), 0);
+	theme->set_constant("outline_size", "RichTextLabel", 0);
 
-	theme->set_color(SNAME("table_odd_row_bg"), SNAME("RichTextLabel"), Color(0, 0, 0, 0));
-	theme->set_color(SNAME("table_even_row_bg"), SNAME("RichTextLabel"), Color(0, 0, 0, 0));
-	theme->set_color(SNAME("table_border"), SNAME("RichTextLabel"), Color(0, 0, 0, 0));
+	theme->set_color("table_odd_row_bg", "RichTextLabel", Color(0, 0, 0, 0));
+	theme->set_color("table_even_row_bg", "RichTextLabel", Color(0, 0, 0, 0));
+	theme->set_color("table_border", "RichTextLabel", Color(0, 0, 0, 0));
 
 	// Containers
 
-	theme->set_icon(SNAME("grabber"), SNAME("VSplitContainer"), icons["vsplitter"]);
-	theme->set_icon(SNAME("grabber"), SNAME("HSplitContainer"), icons["hsplitter"]);
+	theme->set_icon("grabber", "VSplitContainer", icons["vsplitter"]);
+	theme->set_icon("grabber", "HSplitContainer", icons["hsplitter"]);
 
-	theme->set_constant(SNAME("separation"), SNAME("HBoxContainer"), 4 * scale);
-	theme->set_constant(SNAME("separation"), SNAME("VBoxContainer"), 4 * scale);
-	theme->set_constant(SNAME("margin_left"), SNAME("MarginContainer"), 0 * scale);
-	theme->set_constant(SNAME("margin_top"), SNAME("MarginContainer"), 0 * scale);
-	theme->set_constant(SNAME("margin_right"), SNAME("MarginContainer"), 0 * scale);
-	theme->set_constant(SNAME("margin_bottom"), SNAME("MarginContainer"), 0 * scale);
-	theme->set_constant(SNAME("hseparation"), SNAME("GridContainer"), 4 * scale);
-	theme->set_constant(SNAME("vseparation"), SNAME("GridContainer"), 4 * scale);
-	theme->set_constant(SNAME("separation"), SNAME("HSplitContainer"), 12 * scale);
-	theme->set_constant(SNAME("separation"), SNAME("VSplitContainer"), 12 * scale);
-	theme->set_constant(SNAME("autohide"), SNAME("HSplitContainer"), 1 * scale);
-	theme->set_constant(SNAME("autohide"), SNAME("VSplitContainer"), 1 * scale);
-	theme->set_constant(SNAME("hseparation"), SNAME("HFlowContainer"), 4 * scale);
-	theme->set_constant(SNAME("vseparation"), SNAME("HFlowContainer"), 4 * scale);
-	theme->set_constant(SNAME("hseparation"), SNAME("VFlowContainer"), 4 * scale);
-	theme->set_constant(SNAME("vseparation"), SNAME("VFlowContainer"), 4 * scale);
+	theme->set_constant("separation", "HBoxContainer", 4 * scale);
+	theme->set_constant("separation", "VBoxContainer", 4 * scale);
+	theme->set_constant("margin_left", "MarginContainer", 0 * scale);
+	theme->set_constant("margin_top", "MarginContainer", 0 * scale);
+	theme->set_constant("margin_right", "MarginContainer", 0 * scale);
+	theme->set_constant("margin_bottom", "MarginContainer", 0 * scale);
+	theme->set_constant("hseparation", "GridContainer", 4 * scale);
+	theme->set_constant("vseparation", "GridContainer", 4 * scale);
+	theme->set_constant("separation", "HSplitContainer", 12 * scale);
+	theme->set_constant("separation", "VSplitContainer", 12 * scale);
+	theme->set_constant("autohide", "HSplitContainer", 1 * scale);
+	theme->set_constant("autohide", "VSplitContainer", 1 * scale);
+	theme->set_constant("hseparation", "HFlowContainer", 4 * scale);
+	theme->set_constant("vseparation", "HFlowContainer", 4 * scale);
+	theme->set_constant("hseparation", "VFlowContainer", 4 * scale);
+	theme->set_constant("vseparation", "VFlowContainer", 4 * scale);
 
-	theme->set_stylebox(SNAME("panel"), SNAME("PanelContainer"), make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
+	theme->set_stylebox("panel", "PanelContainer", make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
 
-	theme->set_icon(SNAME("minus"), SNAME("GraphEdit"), icons["zoom_less"]);
-	theme->set_icon(SNAME("reset"), SNAME("GraphEdit"), icons["zoom_reset"]);
-	theme->set_icon(SNAME("more"), SNAME("GraphEdit"), icons["zoom_more"]);
-	theme->set_icon(SNAME("snap"), SNAME("GraphEdit"), icons["grid_snap"]);
-	theme->set_icon(SNAME("minimap"), SNAME("GraphEdit"), icons["grid_minimap"]);
-	theme->set_icon(SNAME("layout"), SNAME("GraphEdit"), icons["grid_layout"]);
-	theme->set_stylebox(SNAME("bg"), SNAME("GraphEdit"), make_flat_stylebox(style_normal_color, 4, 4, 4, 5));
-	theme->set_color(SNAME("grid_minor"), SNAME("GraphEdit"), Color(1, 1, 1, 0.05));
-	theme->set_color(SNAME("grid_major"), SNAME("GraphEdit"), Color(1, 1, 1, 0.2));
-	theme->set_color(SNAME("selection_fill"), SNAME("GraphEdit"), Color(1, 1, 1, 0.3));
-	theme->set_color(SNAME("selection_stroke"), SNAME("GraphEdit"), Color(1, 1, 1, 0.8));
-	theme->set_color(SNAME("activity"), SNAME("GraphEdit"), Color(1, 1, 1));
-	theme->set_constant(SNAME("bezier_len_pos"), SNAME("GraphEdit"), 80 * scale);
-	theme->set_constant(SNAME("bezier_len_neg"), SNAME("GraphEdit"), 160 * scale);
+	theme->set_icon("minus", "GraphEdit", icons["zoom_less"]);
+	theme->set_icon("reset", "GraphEdit", icons["zoom_reset"]);
+	theme->set_icon("more", "GraphEdit", icons["zoom_more"]);
+	theme->set_icon("snap", "GraphEdit", icons["grid_snap"]);
+	theme->set_icon("minimap", "GraphEdit", icons["grid_minimap"]);
+	theme->set_icon("layout", "GraphEdit", icons["grid_layout"]);
+	theme->set_stylebox("bg", "GraphEdit", make_flat_stylebox(style_normal_color, 4, 4, 4, 5));
+	theme->set_color("grid_minor", "GraphEdit", Color(1, 1, 1, 0.05));
+	theme->set_color("grid_major", "GraphEdit", Color(1, 1, 1, 0.2));
+	theme->set_color("selection_fill", "GraphEdit", Color(1, 1, 1, 0.3));
+	theme->set_color("selection_stroke", "GraphEdit", Color(1, 1, 1, 0.8));
+	theme->set_color("activity", "GraphEdit", Color(1, 1, 1));
+	theme->set_constant("bezier_len_pos", "GraphEdit", 80 * scale);
+	theme->set_constant("bezier_len_neg", "GraphEdit", 160 * scale);
 
 	// Visual Node Ports
 
-	theme->set_constant(SNAME("port_grab_distance_horizontal"), SNAME("GraphEdit"), 24 * scale);
-	theme->set_constant(SNAME("port_grab_distance_vertical"), SNAME("GraphEdit"), 26 * scale);
+	theme->set_constant("port_grab_distance_horizontal", "GraphEdit", 24 * scale);
+	theme->set_constant("port_grab_distance_vertical", "GraphEdit", 26 * scale);
 
-	theme->set_stylebox(SNAME("bg"), SNAME("GraphEditMinimap"), make_flat_stylebox(Color(0.24, 0.24, 0.24), 0, 0, 0, 0));
+	theme->set_stylebox("bg", "GraphEditMinimap", make_flat_stylebox(Color(0.24, 0.24, 0.24), 0, 0, 0, 0));
 	Ref<StyleBoxFlat> style_minimap_camera = make_flat_stylebox(Color(0.65, 0.65, 0.65, 0.2), 0, 0, 0, 0, 0);
 	style_minimap_camera->set_border_color(Color(0.65, 0.65, 0.65, 0.45));
 	style_minimap_camera->set_border_width_all(1);
-	theme->set_stylebox(SNAME("camera"), SNAME("GraphEditMinimap"), style_minimap_camera);
-	theme->set_stylebox(SNAME("node"), SNAME("GraphEditMinimap"), make_flat_stylebox(Color(1, 1, 1), 0, 0, 0, 0, 2));
+	theme->set_stylebox("camera", "GraphEditMinimap", style_minimap_camera);
+	theme->set_stylebox("node", "GraphEditMinimap", make_flat_stylebox(Color(1, 1, 1), 0, 0, 0, 0, 2));
 
-	theme->set_icon(SNAME("resizer"), SNAME("GraphEditMinimap"), icons["resizer_nw"]);
-	theme->set_color(SNAME("resizer_color"), SNAME("GraphEditMinimap"), Color(1, 1, 1, 0.85));
+	theme->set_icon("resizer", "GraphEditMinimap", icons["resizer_nw"]);
+	theme->set_color("resizer_color", "GraphEditMinimap", Color(1, 1, 1, 0.85));
 
 	// Theme
 

--- a/tests/scene/test_gui.cpp
+++ b/tests/scene/test_gui.cpp
@@ -103,7 +103,7 @@ public:
 		item->set_editable(0, true);
 		item->set_range_config(0, 0, 20, 0.1);
 		item->set_range(0, 2);
-		item->add_button(0, Theme::get_default()->get_icon(SNAME("folder"), SNAME("FileDialog")));
+		item->add_button(0, Theme::get_default()->get_icon("folder", "FileDialog"));
 		item->set_cell_mode(1, TreeItem::CELL_MODE_RANGE);
 		item->set_editable(1, true);
 		item->set_range_config(1, 0, 20, 0.1);


### PR DESCRIPTION
Reverts #57725, but the second commit re-applies parts of it (changes to `get_theme_*` calls only).

As discussed in https://github.com/godotengine/godot/pull/57725 and clarified in https://github.com/godotengine/godot/pull/57788, `SNAME` is not meant to be used everywhere but only in critical code paths. For theme methods specifically, it was by design that only getters use `SNAME` and not setters.