### PR TITLE
[macOS] Fix NO_FOCUS macOS flag.

### DIFF
--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -125,6 +125,7 @@ DisplayServerOSX::WindowID DisplayServerOSX::_create_window(WindowMode p_mode, V
 							backing:NSBackingStoreBuffered
 							  defer:NO];
 		ERR_FAIL_COND_V_MSG(wd.window_object == nil, INVALID_WINDOW_ID, "Can't create a window");
+		[wd.window_object setWindowID:window_id_counter];
 
 		wd.window_view = [[GodotContentView alloc] init];
 		ERR_FAIL_COND_V_MSG(wd.window_view == nil, INVALID_WINDOW_ID, "Can't create a window view");

--- a/platform/osx/godot_window.mm
+++ b/platform/osx/godot_window.mm
@@ -45,7 +45,7 @@
 }
 
 - (BOOL)canBecomeKeyWindow {
-	// Required for NSBorderlessWindowMask windows.
+	// Required for NSWindowStyleMaskBorderless windows.
 	DisplayServerOSX *ds = (DisplayServerOSX *)DisplayServer::get_singleton();
 	if (!ds || !ds->has_window(window_id)) {
 		return YES;
@@ -56,7 +56,7 @@
 }
 
 - (BOOL)canBecomeMainWindow {
-	// Required for NSBorderlessWindowMask windows.
+	// Required for NSWindowStyleMaskBorderless windows.
 	DisplayServerOSX *ds = (DisplayServerOSX *)DisplayServer::get_singleton();
 	if (!ds || !ds->has_window(window_id)) {
 		return YES;


### PR DESCRIPTION
I have missed one `setWindowID` call in #57305. Removes possibility to focus tooltip windows by click on them. Also, updated a comment that had deprecated constant, which is no longer used.
