### PR TITLE
SCons: Improve logic to generate `modules_tests.gen.h`

### DIFF
--- a/modules/SCsub
+++ b/modules/SCsub
@@ -22,12 +22,37 @@ env.CommandNoCache(
     ),
 )
 
-# Header to be included in `tests/test_main.cpp` to run module-specific tests.
+
+vs_sources = []
+test_headers = []
+# libmodule_<name>.a for each active module.
+for name, path in env.module_list.items():
+    env.modules_sources = []
+
+    # Name for built-in modules, (absolute) path for custom ones.
+    base_path = path if os.path.isabs(path) else name
+    SConscript(base_path + "/SCsub")
+
+    lib = env_modules.add_library("module_%s" % name, env.modules_sources)
+    env.Prepend(LIBS=[lib])
+    if env["vsproj"]:
+        vs_sources += env.modules_sources
+
+    if env["tests"]:
+        # Lookup potential headers in `tests` subfolder.
+        import glob
+
+        module_tests = sorted(glob.glob(os.path.join(base_path, "tests", "*.h")))
+        if module_tests != []:
+            test_headers += module_tests
+
+
+# Generate header to be included in `tests/test_main.cpp` to run module-specific tests.
 if env["tests"]:
-    env.Depends("modules_tests.gen.h", Value(env.module_list))
+    env.Depends("modules_tests.gen.h", test_headers)
     env.CommandNoCache(
         "modules_tests.gen.h",
-        Value(env.module_list),
+        test_headers,
         env.Run(
             modules_builders.generate_modules_tests,
             "Generating modules tests header.",
@@ -35,22 +60,6 @@ if env["tests"]:
             subprocess=False,
         ),
     )
-    env.AlwaysBuild("modules_tests.gen.h")
-
-vs_sources = []
-# libmodule_<name>.a for each active module.
-for name, path in env.module_list.items():
-    env.modules_sources = []
-
-    if not os.path.isabs(path):
-        SConscript(name + "/SCsub")  # Built-in.
-    else:
-        SConscript(path + "/SCsub")  # Custom.
-
-    lib = env_modules.add_library("module_%s" % name, env.modules_sources)
-    env.Prepend(LIBS=[lib])
-    if env["vsproj"]:
-        vs_sources += env.modules_sources
 
 # libmodules.a with only register_module_types.
 # Must be last so that all libmodule_<name>.a libraries are on the right side

--- a/modules/modules_builders.py
+++ b/modules/modules_builders.py
@@ -14,13 +14,10 @@ def generate_modules_enabled(target, source, env):
 
 def generate_modules_tests(target, source, env):
     import os
-    import glob
 
     with open(target[0].path, "w") as f:
-        for name, path in env.module_list.items():
-            headers = glob.glob(os.path.join(path, "tests", "*.h"))
-            for h in headers:
-                f.write('#include "%s"\n' % (os.path.normpath(h)))
+        for header in source:
+            f.write('#include "%s"\n' % (os.path.normpath(header.path)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This removes the need for `AlwaysBuild` by ensuring that the proper
files are being tracked as `Depends`.

So instead of having this on all builds even without change to the codebase:
```
generate_modules_tests(["modules/modules_tests.gen.h"], [OrderedDict([('basis_universal', 'modules/basis_universal'), ('bmp', 'modules/bmp'), ('csg', 'modules/csg'), ('cvtt', 'modules/cvtt'), ('dds', 'modules/dds'), ('denoise', 'modules/denoise'), ('enet', 'modules/enet'), ('etcpak', 'modules/etcpak'), ('fbx', 'modules/fbx'), ('freetype', 'modules/freetype'), ('gdnative', 'modules/gdnative'), ('gdscript', 'modules/gdscript'), ('glslang', 'modules/glslang'), ('gltf', 'modules/gltf'), ('gridmap', 'modules/gridmap'), ('hdr', 'modules/hdr'), ('jpg', 'modules/jpg'), ('jsonrpc', 'modules/jsonrpc'), ('lightmapper_rd', 'modules/lightmapper_rd'), ('mbedtls', 'modules/mbedtls'), ('meshoptimizer', 'modules/meshoptimizer'), ('minimp3', 'modules/minimp3'), ('mobile_vr', 'modules/mobile_vr'), ('msdfgen', 'modules/msdfgen'), ('navigation', 'modules/navigation'), ('ogg', 'modules/ogg'), ('opensimplex', 'modules/opensimplex'), ('raycast', 'modules/raycast'), ('regex', 'modules/regex'), ('squish', 'modules/squish'), ('svg', 'modules/svg'), ('text_server_adv', 'modules/text_server_adv'), ('tga', 'modules/tga'), ('theora', 'modules/theora'), ('tinyexr', 'modules/tinyexr'), ('upnp', 'modules/upnp'), ('vhacd', 'modules/vhacd'), ('visual_script', 'modules/visual_script'), ('vorbis', 'modules/vorbis'), ('webp', 'modules/webp'), ('webrtc', 'modules/webrtc'), ('websocket', 'modules/websocket'), ('webxr', 'modules/webxr'), ('xatlas_unwrap', 'modules/xatlas_unwrap')])])
```

We now have this, only when any of the tests changes or hasn't been built yet:
```
generate_modules_tests(["modules/modules_tests.gen.h"], ["modules/gdnative/tests/test_variant.h", "modules/gdscript/tests/gdscript_test_runner_suite.h", "modules/gdscript/tests/test_gdscript.h", "modules/gdscript/tests/gdscript_test_runner.h", "modules/mbedtls/tests/test_crypto_mbedtls.h", "modules/regex/tests/test_regex.h"])
```

That doesn't seem to have much impact on build time, even for null builds. But it's less noisy and cleaner.