### PR TITLE
SCons: Add `fast_unsafe` option for faster rebuilds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -179,9 +179,10 @@ opts.Add(BoolVariable("use_volk", "Use the volk library to load the Vulkan loade
 
 # Advanced options
 opts.Add(BoolVariable("dev", "If yes, alias for verbose=yes warnings=extra werror=yes", False))
-opts.Add(BoolVariable("progress", "Show a progress indicator during compilation", True))
 opts.Add(BoolVariable("tests", "Build the unit tests", False))
+opts.Add(BoolVariable("fast_unsafe", "Enable unsafe options for faster rebuilds", False))
 opts.Add(BoolVariable("verbose", "Enable verbose output for the compilation", False))
+opts.Add(BoolVariable("progress", "Show a progress indicator during compilation", True))
 opts.Add(EnumVariable("warnings", "Level of compilation warnings", "all", ("extra", "all", "moderate", "no")))
 opts.Add(BoolVariable("werror", "Treat compiler warnings as errors", False))
 opts.Add("extra_suffix", "Custom extra suffix added to the base filename of all generated binary files", "")
@@ -359,6 +360,17 @@ if env_base["target"] == "debug":
     # DEV_ENABLED enables *engine developer* code which should only be compiled for those
     # working on the engine itself.
     env_base.Append(CPPDEFINES=["DEV_ENABLED"])
+
+# SCons speed optimization controlled by the `fast_unsafe` option, which provide
+# more than 10 s speed up for incremental rebuilds.
+# Unsafe as they reduce the certainty of rebuilding all changed files, so it's
+# enabled by default for `debug` builds, and can be overridden from command line.
+# Ref: https://github.com/SCons/scons/wiki/GoFastButton
+if methods.get_cmdline_bool("fast_unsafe", env_base["target"] == "debug"):
+    # Renamed to `content-timestamp` in SCons >= 4.2, keeping MD5 for compat.
+    env_base.Decider("MD5-timestamp")
+    env_base.SetOption("implicit_cache", 1)
+    env_base.SetOption("max_drift", 60)
 
 if env_base["use_precise_math_checks"]:
     env_base.Append(CPPDEFINES=["PRECISE_MATH_CHECKS"])


### PR DESCRIPTION
This reverts #53828 which had caused a significant drop in incremental
rebuild time for debug builds (from 10s to 23s on my laptop).

The "faster but unsafe" options are re-added, as well as adding
`max_drift=60` which we didn't use previously.

These options speed up SCons' own processing of the codebase to decide
what to build/rebuild (i.e. the first step before actually calling the
compiler). This will therefore not make much difference for scratch
builds, and is mostly useful for incremental rebuilds (including "null"
rebuilds with no change).

These options are enabled automatically for `debug` builds, unless
`fast_unsafe=no` is passed.
They are disabled by default for `release` and `release_debug` builds,
unless `fast_unsafe=yes` is passed.

See https://github.com/SCons/scons/wiki/GoFastButton and the SCons man page for details.

-----

Would be good to have this tested on different hardware and OSes, as well as with different combinations of the three options to see what gives the best results.

"Null rebuild" means issuing a rebuild with the same command after a full build (so no file needs to be rebuilt, nor linked, so it only tests SCons' parsing of our scripts and codebase).

"`main.cpp` rebuild" is a rebuild with only a cosmetic change done with `main.cpp` (leading to rebuilding `main.cpp` and relinking). Note that linker time is now included and can be quite long depending on the OS and linker used. I'm using the [`mold`](https://github.com/rui314/mold) linker which takes ~2s to link Godot in `debug` mode for me.

Here's the results on my system:

```
System:    Host: cauldron Kernel: 5.16.7-desktop-1.mga9 x86_64 bits: 64 Desktop: KDE Plasma 5.23.4 Distro: Mageia 9 mga9 
CPU:       Info: Quad Core model: Intel Core i7-8705G bits: 64 type: MT MCP cache: L2: 8 MiB 
           Speed: 900 MHz min/max: 800/3100 MHz Core speeds (MHz): 1: 900 2: 900 3: 900 4: 900 5: 900 6: 900 7: 900 8: 900 
```
Python 3.9.8 (CPython)
SCons 4.2.0
Build command:
```
scons -j7 p=linuxbsd verbose=yes warnings=extra werror=yes tests=yes LINKFLAGS=-B/usr/local/libexec/mold
```

| Combination | Null rebuild speed | `main.cpp` rebuild speed |
| --- | --- | --- |
| None (`fast_unsafe=no`) | 22.7 - 23.8 s | 25.0 - 25.4 s |
| MD5-timestamp | 15.3 - 15.5 s | 18.3 - 18.7 s |
| implicit_cache=1 | 17.2 - 17.9 s | 20.1 - 20.3 s |
| max_drift=60 | 14.8 - 15.7 s | 17.5 - 17.9 s |
| MD5-timestamp + implicit_cache=1 | 10.0 - 11.3 s | |
| MD5-timestamp + max_drift=60 | 15.3 - 15.8 s | |
| implicit_cache=1 + max_drift=60 | 9.4 - 10.2 s | |
| MD5-timestamp + implicit-cache=1 + max_drift=60 | 9.8 - 10.3 s | 12.6 - 13.2 s |