### PR TITLE
Display built-in script names in the inspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3479,10 +3479,14 @@ void EditorInspector::_update_script_class_properties(const Object &p_object, Li
 		String path = s->get_path();
 		String name = EditorNode::get_editor_data().script_class_get_name(path);
 		if (name.is_empty()) {
-			if (!s->is_built_in()) {
-				name = path.get_file();
+			if (s->is_built_in()) {
+				if (s->get_name().is_empty()) {
+					name = TTR("Built-in script");
+				} else {
+					name = vformat("%s (%s)", s->get_name(), TTR("Built-in"));
+				}
 			} else {
-				name = TTR("Built-in script");
+				name = path.get_file();
 			}
 		}
 


### PR DESCRIPTION
Somewhat follow-up to #40145

Built-in script name will be displayed as category if available:
![image](https://user-images.githubusercontent.com/2223172/153017060-47d73033-bcc0-40bc-94c0-7b2f2f03e71e.png)
