### PR TITLE
OSX: Pass `-mmacosx-version-min=11.0` instead of `11.00`

### DIFF
--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -78,9 +78,9 @@ def configure(env):
         env["osxcross"] = True
 
     if env["arch"] == "arm64":
-        print("Building for macOS 11.00+, platform arm64.")
-        env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.00"])
-        env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.00"])
+        print("Building for macOS 11.0+, platform arm64.")
+        env.Append(CCFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
+        env.Append(LINKFLAGS=["-arch", "arm64", "-mmacosx-version-min=11.0"])
     else:
         print("Building for macOS 10.12+, platform x86_64.")
         env.Append(CCFLAGS=["-arch", "x86_64", "-mmacosx-version-min=10.12"])


### PR DESCRIPTION
Both are recognized by Xcode and equivalent, but osxcross issues a
warning for the latter:
```
osxcross: warning: '-mmacosx-version-min=' (11.0.0 != 11.00)
```