### PR TITLE
Improve `TreeItem` button API

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -72,6 +72,13 @@
 				[b]Note:[/b] Despite the name of this method, the focus cursor itself is only visible in [constant SELECT_MULTI] mode.
 			</description>
 		</method>
+		<method name="get_button_id_at_position" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="position" type="Vector2" />
+			<description>
+				Returns the button id at [code]position[/code], or -1 if no button is there.
+			</description>
+		</method>
 		<method name="get_column_at_position" qualifiers="const">
 			<return type="int" />
 			<argument index="0" name="position" type="Vector2" />

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -14,11 +14,11 @@
 			<return type="void" />
 			<argument index="0" name="column" type="int" />
 			<argument index="1" name="button" type="Texture2D" />
-			<argument index="2" name="button_idx" type="int" default="-1" />
+			<argument index="2" name="id" type="int" default="-1" />
 			<argument index="3" name="disabled" type="bool" default="false" />
 			<argument index="4" name="tooltip" type="String" default="&quot;&quot;" />
 			<description>
-				Adds a button with [Texture2D] [code]button[/code] at column [code]column[/code]. The [code]button_idx[/code] index is used to identify the button when calling other methods. If not specified, the next available index is used, which may be retrieved by calling [method get_button_count] immediately after this method. Optionally, the button can be [code]disabled[/code] and have a [code]tooltip[/code].
+				Adds a button with [Texture2D] [code]button[/code] at column [code]column[/code]. The [code]id[/code] is used to identify the button. If not specified, the next available index is used, which may be retrieved by calling [method get_button_count] immediately after this method. Optionally, the button can be [code]disabled[/code] and have a [code]tooltip[/code].
 			</description>
 		</method>
 		<method name="call_recursive" qualifiers="vararg">
@@ -80,11 +80,27 @@
 				Returns the [Texture2D] of the button at index [code]button_idx[/code] in column [code]column[/code].
 			</description>
 		</method>
+		<method name="get_button_by_id" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="column" type="int" />
+			<argument index="1" name="id" type="int" />
+			<description>
+				Returns the button index if there is a button with id [code]id[/code] in column [code]column[/code], otherwise returns -1.
+			</description>
+		</method>
 		<method name="get_button_count" qualifiers="const">
 			<return type="int" />
 			<argument index="0" name="column" type="int" />
 			<description>
 				Returns the number of buttons in column [code]column[/code]. May be used to get the most recently added button's index, if no index was specified.
+			</description>
+		</method>
+		<method name="get_button_id" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="column" type="int" />
+			<argument index="1" name="button_idx" type="int" />
+			<description>
+				Returns the id for the button at index [code]button_idx[/code] in column [code]column[/code].
 			</description>
 		</method>
 		<method name="get_button_tooltip" qualifiers="const">

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -905,6 +905,12 @@ String TreeItem::get_button_tooltip(int p_column, int p_idx) const {
 	return cells[p_column].buttons[p_idx].tooltip;
 }
 
+int TreeItem::get_button_id(int p_column, int p_idx) const {
+	ERR_FAIL_INDEX_V(p_column, cells.size(), -1);
+	ERR_FAIL_INDEX_V(p_idx, cells[p_column].buttons.size(), -1);
+	return cells[p_column].buttons[p_idx].id;
+}
+
 void TreeItem::erase_button(int p_column, int p_idx) {
 	ERR_FAIL_INDEX(p_column, cells.size());
 	ERR_FAIL_INDEX(p_idx, cells[p_column].buttons.size());
@@ -1283,9 +1289,11 @@ void TreeItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_custom_as_button", "column", "enable"), &TreeItem::set_custom_as_button);
 	ClassDB::bind_method(D_METHOD("is_custom_set_as_button", "column"), &TreeItem::is_custom_set_as_button);
 
-	ClassDB::bind_method(D_METHOD("add_button", "column", "button", "button_idx", "disabled", "tooltip"), &TreeItem::add_button, DEFVAL(-1), DEFVAL(false), DEFVAL(""));
+	ClassDB::bind_method(D_METHOD("add_button", "column", "button", "id", "disabled", "tooltip"), &TreeItem::add_button, DEFVAL(-1), DEFVAL(false), DEFVAL(""));
 	ClassDB::bind_method(D_METHOD("get_button_count", "column"), &TreeItem::get_button_count);
 	ClassDB::bind_method(D_METHOD("get_button_tooltip", "column", "button_idx"), &TreeItem::get_button_tooltip);
+	ClassDB::bind_method(D_METHOD("get_button_id", "column", "button_idx"), &TreeItem::get_button_id);
+	ClassDB::bind_method(D_METHOD("get_button_by_id", "column", "id"), &TreeItem::get_button_by_id);
 	ClassDB::bind_method(D_METHOD("get_button", "column", "button_idx"), &TreeItem::get_button);
 	ClassDB::bind_method(D_METHOD("set_button", "column", "button_idx", "button"), &TreeItem::set_button);
 	ClassDB::bind_method(D_METHOD("erase_button", "column", "button_idx"), &TreeItem::erase_button);
@@ -4856,6 +4864,7 @@ void Tree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_item_at_position", "position"), &Tree::get_item_at_position);
 	ClassDB::bind_method(D_METHOD("get_column_at_position", "position"), &Tree::get_column_at_position);
 	ClassDB::bind_method(D_METHOD("get_drop_section_at_position", "position"), &Tree::get_drop_section_at_position);
+	ClassDB::bind_method(D_METHOD("get_button_id_at_position", "position"), &Tree::get_button_id_at_position);
 
 	ClassDB::bind_method(D_METHOD("ensure_cursor_is_visible"), &Tree::ensure_cursor_is_visible);
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -248,6 +248,7 @@ public:
 	int get_button_count(int p_column) const;
 	String get_button_tooltip(int p_column, int p_idx) const;
 	Ref<Texture2D> get_button(int p_column, int p_idx) const;
+	int get_button_id(int p_column, int p_idx) const;
 	void erase_button(int p_column, int p_idx);
 	int get_button_by_id(int p_column, int p_id) const;
 	void set_button(int p_column, int p_idx, const Ref<Texture2D> &p_button);


### PR DESCRIPTION
The id of `TreeItem` buttons is never described in the documentation, but passed as the parameter of `Tree.button_pressed` signal.

* The third parameter of `TreeItem.add_button` is the button id, not the button index. Although it defaults to the button index.
* Exposes `TreeItem.get_button_id(index)` which returns the id and `TreeItem.get_button_by_id(id)` which returns the index.
    * `get_button_id` only exists on `3.x` so it is added on `master`. It's a simple getter method.
* Exposes `Tree.get_button_id_at_position(pos)` so that it completes `get_item_at_position` and `get_column_at_position`.
    * These can now be used as the poll version of signal `button_pressed(item, column, id)`
    * Closes https://github.com/godotengine/godot-proposals/issues/2470