### PR TITLE
Updated alpha value for disabled icons in default theme.

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -115,7 +115,7 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [Button] is being pressed.
 		</theme_item>
-		<theme_item name="icon_disabled_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="icon_disabled_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.4)">
 			Icon modulate [Color] used when the [Button] is disabled.
 		</theme_item>
 		<theme_item name="icon_focus_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -175,7 +175,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 	theme->set_color("icon_hover_color", "Button", Color(1, 1, 1, 1));
 	theme->set_color("icon_hover_pressed_color", "Button", Color(1, 1, 1, 1));
 	theme->set_color("icon_focus_color", "Button", Color(1, 1, 1, 1));
-	theme->set_color("icon_disabled_color", "Button", Color(1, 1, 1, 1));
+	theme->set_color("icon_disabled_color", "Button", Color(1, 1, 1, 0.4));
 
 	theme->set_constant("hseparation", "Button", 2 * scale);
 


### PR DESCRIPTION
Fixes #57761 

The alpha value is set to 1 for disabled icons in the default theme. Even though the issue only mentions about the pause and stop buttons, this issue is applicable to any disabled button (e.g. Lock selected nodes) in the editor. 

Fixed the issue by updating alpha for the disabled icon color to 0.4 (based on the default value in button.cpp).