### PR TITLE
Fix navigation in 3D viewport

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4377,7 +4377,7 @@ Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, Edito
 	_edit.mode = TRANSFORM_NONE;
 	_edit.plane = TRANSFORM_VIEW;
 	_edit.snap = true;
-	_edit.instant = true;
+	_edit.instant = false;
 	_edit.gizmo_handle = -1;
 	_edit.gizmo_handle_secondary = false;
 


### PR DESCRIPTION
The incorrect initialization of `EditData::instant` to `true` was preventing the navigation code to run until the transform gizmo was used.

*Bugsquad edit:* Fixes https://github.com/godotengine/godot/pull/56543#issuecomment-1032766015
