### PR TITLE
Core: Move generated `VERSION_HASH` to a `.cpp` file

### DIFF
--- a/core/SCsub
+++ b/core/SCsub
@@ -147,6 +147,7 @@ env.core_sources += thirdparty_obj
 
 env.add_source_files(env.core_sources, "*.cpp")
 env.add_source_files(env.core_sources, "script_encryption_key.gen.cpp")
+env.add_source_files(env.core_sources, "version_hash.gen.cpp")
 
 # Certificates
 env.Depends(

--- a/core/config/engine.cpp
+++ b/core/config/engine.cpp
@@ -35,7 +35,6 @@
 #include "core/donors.gen.h"
 #include "core/license.gen.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 
 void Engine::set_physics_ticks_per_second(int p_ips) {
 	ERR_FAIL_COND_MSG(p_ips <= 0, "Engine iterations per second must be greater than 0.");
@@ -95,8 +94,8 @@ Dictionary Engine::get_version_info() const {
 	dict["build"] = VERSION_BUILD;
 	dict["year"] = VERSION_YEAR;
 
-	String hash = VERSION_HASH;
-	dict["hash"] = hash.length() == 0 ? String("unknown") : hash;
+	String hash = String(VERSION_HASH);
+	dict["hash"] = hash.is_empty() ? String("unknown") : hash;
 
 	String stringver = String(dict["major"]) + "." + String(dict["minor"]);
 	if ((int)dict["patch"] != 0) {

--- a/core/version.h
+++ b/core/version.h
@@ -68,4 +68,7 @@
 // Example: "Godot v3.1.4.stable.official.mono"
 #define VERSION_FULL_NAME "" VERSION_NAME " v" VERSION_FULL_BUILD
 
+// Git commit hash, generated at build time in `core/version_hash.gen.cpp`.
+extern const char *const VERSION_HASH;
+
 #endif // VERSION_H

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -36,7 +36,6 @@
 #include "core/io/marshalls.h"
 #include "core/string/ustring.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "editor/debugger/debug_adapter/debug_adapter_protocol.h"
 #include "editor/debugger/editor_network_profiler.h"
 #include "editor/debugger/editor_performance_profiler.h"
@@ -1543,19 +1542,10 @@ void ScriptEditorDebugger::_item_menu_id_pressed(int p_option) {
 			const int line_number = file_line_number[1].to_int();
 
 			// Construct a GitHub repository URL and open it in the user's default web browser.
-			if (String(VERSION_HASH).length() >= 1) {
-				// Git commit hash information available; use it for greater accuracy, including for development versions.
-				OS::get_singleton()->shell_open(vformat("https://github.com/godotengine/godot/blob/%s/%s#L%d",
-						VERSION_HASH,
-						file,
-						line_number));
-			} else {
-				// Git commit hash information unavailable; fall back to tagged releases.
-				OS::get_singleton()->shell_open(vformat("https://github.com/godotengine/godot/blob/%s-stable/%s#L%d",
-						VERSION_NUMBER,
-						file,
-						line_number));
-			}
+			// If the commit hash is available, use it for greater accuracy. Otherwise fall back to tagged release.
+			String git_ref = String(VERSION_HASH).is_empty() ? String(VERSION_NUMBER) + "-stable" : String(VERSION_HASH);
+			OS::get_singleton()->shell_open(vformat("https://github.com/godotengine/godot/blob/%s/%s#L%d",
+					git_ref, file, line_number));
 		} break;
 		case ACTION_DELETE_BREAKPOINT: {
 			const TreeItem *selected = breakpoints_tree->get_selected();

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -29,13 +29,12 @@
 /*************************************************************************/
 
 #include "editor_about.h"
-#include "editor_node.h"
 
 #include "core/authors.gen.h"
 #include "core/donors.gen.h"
 #include "core/license.gen.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
+#include "editor_node.h"
 
 // The metadata key used to store and retrieve the version text to copy to the clipboard.
 static const String META_TEXT_TO_COPY = "text_to_copy";

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -47,7 +47,6 @@
 #include "core/string/print_string.h"
 #include "core/string/translation.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "main/main.h"
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/gui/center_container.h"

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -40,7 +40,6 @@
 #include "core/os/os.h"
 #include "core/string/translation.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "editor/editor_vcs_interface.h"
 #include "editor_scale.h"
 #include "editor_settings.h"

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -50,7 +50,6 @@
 #include "core/register_core_types.h"
 #include "core/string/translation.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "drivers/register_driver_types.h"
 #include "main/app_icon.gen.h"
 #include "main/main_timer_sync.h"
@@ -200,7 +199,7 @@ static String unescape_cmdline(const String &p_str) {
 
 static String get_full_version_string() {
 	String hash = String(VERSION_HASH);
-	if (hash.length() != 0) {
+	if (!hash.is_empty()) {
 		hash = "." + hash.left(9);
 	}
 	return String(VERSION_FULL_BUILD) + hash;

--- a/methods.py
+++ b/methods.py
@@ -111,10 +111,9 @@ def update_version(module_version_string=""):
     f.close()
 
     # NOTE: It is safe to generate this file here, since this is still executed serially
-    fhash = open("core/version_hash.gen.h", "w")
+    fhash = open("core/version_hash.gen.cpp", "w")
     fhash.write("/* THIS FILE IS GENERATED DO NOT EDIT */\n")
-    fhash.write("#ifndef VERSION_HASH_GEN_H\n")
-    fhash.write("#define VERSION_HASH_GEN_H\n")
+    fhash.write('#include "core/version.h"\n')
     githash = ""
     gitfolder = ".git"
 
@@ -132,8 +131,7 @@ def update_version(module_version_string=""):
         else:
             githash = head
 
-    fhash.write('#define VERSION_HASH "' + githash + '"\n')
-    fhash.write("#endif // VERSION_HASH_GEN_H\n")
+    fhash.write('const char *const VERSION_HASH = "' + githash + '";\n')
     fhash.close()
 
 

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -57,7 +57,6 @@
 #include "core/variant/typed_array.h"
 #include "core/variant/variant.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "drivers/png/png_driver_common.h"
 #include "editor/import/resource_importer_scene.h"
 #include "scene/2d/node_2d.h"
@@ -6655,8 +6654,8 @@ Error GLTFDocument::_serialize_version(Ref<GLTFState> state) {
 	Dictionary asset;
 	asset["version"] = version;
 
-	String hash = VERSION_HASH;
-	asset["generator"] = String(VERSION_FULL_NAME) + String("@") + (hash.length() == 0 ? String("unknown") : hash);
+	String hash = String(VERSION_HASH);
+	asset["generator"] = String(VERSION_FULL_NAME) + String("@") + (hash.is_empty() ? String("unknown") : hash);
 	state->json["asset"] = asset;
 	ERR_FAIL_COND_V(!asset.has("version"), Error::FAILED);
 	ERR_FAIL_COND_V(!state->json.has("asset"), Error::FAILED);

--- a/platform/linuxbsd/crash_handler_linuxbsd.cpp
+++ b/platform/linuxbsd/crash_handler_linuxbsd.cpp
@@ -33,7 +33,6 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "main/main.h"
 
 #ifdef DEBUG_ENABLED
@@ -71,10 +70,10 @@ static void handle_crash(int sig) {
 	}
 
 	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
-	if (String(VERSION_HASH).length() != 0) {
-		fprintf(stderr, "Engine version: " VERSION_FULL_NAME " (" VERSION_HASH ")\n");
+	if (String(VERSION_HASH).is_empty()) {
+		fprintf(stderr, "Engine version: %s\n", VERSION_FULL_NAME);
 	} else {
-		fprintf(stderr, "Engine version: " VERSION_FULL_NAME "\n");
+		fprintf(stderr, "Engine version: %s (%s)\n", VERSION_FULL_NAME, VERSION_HASH);
 	}
 	fprintf(stderr, "Dumping the backtrace. %s\n", msg.utf8().get_data());
 	char **strings = backtrace_symbols(bt_buffer, size);

--- a/platform/osx/crash_handler_osx.mm
+++ b/platform/osx/crash_handler_osx.mm
@@ -33,7 +33,6 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "main/main.h"
 
 #include <string.h>
@@ -94,10 +93,10 @@ static void handle_crash(int sig) {
 		OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_CRASH);
 
 	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
-	if (String(VERSION_HASH).length() != 0) {
-		fprintf(stderr, "Engine version: " VERSION_FULL_NAME " (" VERSION_HASH ")\n");
+	if (String(VERSION_HASH).is_empty()) {
+		fprintf(stderr, "Engine version: %s\n", VERSION_FULL_NAME);
 	} else {
-		fprintf(stderr, "Engine version: " VERSION_FULL_NAME "\n");
+		fprintf(stderr, "Engine version: %s (%s)\n", VERSION_FULL_NAME, VERSION_HASH);
 	}
 	fprintf(stderr, "Dumping the backtrace. %s\n", msg.utf8().get_data());
 	char **strings = backtrace_symbols(bt_buffer, size);

--- a/platform/windows/crash_handler_windows.cpp
+++ b/platform/windows/crash_handler_windows.cpp
@@ -33,7 +33,6 @@
 #include "core/config/project_settings.h"
 #include "core/os/os.h"
 #include "core/version.h"
-#include "core/version_hash.gen.h"
 #include "main/main.h"
 
 #ifdef CRASH_HANDLER_EXCEPTION
@@ -179,10 +178,10 @@ DWORD CrashHandlerException(EXCEPTION_POINTERS *ep) {
 	}
 
 	// Print the engine version just before, so that people are reminded to include the version in backtrace reports.
-	if (String(VERSION_HASH).length() != 0) {
-		fprintf(stderr, "Engine version: " VERSION_FULL_NAME " (" VERSION_HASH ")\n");
+	if (String(VERSION_HASH).is_empty()) {
+		fprintf(stderr, "Engine version: %s\n", VERSION_FULL_NAME);
 	} else {
-		fprintf(stderr, "Engine version: " VERSION_FULL_NAME "\n");
+		fprintf(stderr, "Engine version: %s (%s)\n", VERSION_FULL_NAME, VERSION_HASH);
 	}
 	fprintf(stderr, "Dumping the backtrace. %s\n", msg.utf8().get_data());
 


### PR DESCRIPTION
This lets us have its definition in `core/version.h` and avoid
rebuilding a handful of files every time the commit hash changes.

Makes a null rebuild after `git commit --amend` go from 27.4 s to 13.1 s for me (with #57806 merged locally).

### Before

```
$ gobuild_linux 
/usr/bin/scons -j7 p=linuxbsd verbose=yes warnings=extra werror=yes tests=yes LINKFLAGS=-B/usr/local/libexec/mold 2>&1 | tee -a build.log
scons: Reading SConscript files ...
Note: Building a debug binary (which will run slowly). Use `target=release_debug` to build an optimized release binary.
Checking for C header file mntent.h... (cached) yes
scons: done reading SConscript files.
scons: Building targets ...
g++ -o platform/linuxbsd/crash_handler_linuxbsd.linuxbsd.tools.64.o -c -std=gnu++17 -Wctor-dtor-privacy -Wnon-virtual-dtor -Wplacement-new=1 -Wno-error=cpp -g3 -pipe -Wall -Wextra -Wwrite-strings -Wno-unused-parameter -Wshadow-local -Wno-misleading-indentation -Walloc-zero -Wduplicated-branches -Wduplicated-cond -Wstringop-overflow=4 -Wlogical-op -Wattribute-alias=2 -Werror -DDEBUG_ENABLED -DDEV_ENABLED -DNO_EDITOR_SPLASH -DTOUCH_ENABLED -DALSA_ENABLED -DALSAMIDI_ENABLED -DPULSEAUDIO_ENABLED -D_REENTRANT -DDBUS_ENABLED -DJOYDEV_ENABLED -DUDEV_ENABLED -DX11_ENABLED -DUNIX_ENABLED -D_FILE_OFFSET_BITS=64 -DVULKAN_ENABLED -DGLES3_ENABLED -DTOOLS_ENABLED -DMINIZIP_ENABLED -DZSTD_STATIC_LINKING_ONLY -DUSE_VOLK -DVK_USE_PLATFORM_XLIB_KHR -DGLAD_ENABLED -DGLES_OVER_GL -DHAVE_MNTENT -Ithirdparty/freetype/include -Ithirdparty/libpng -Ithirdparty/glad -Ithirdparty/volk -Ithirdparty/vulkan -Ithirdparty/vulkan/include -Ithirdparty/zstd -Ithirdparty/zlib -Iplatform/linuxbsd -I. -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include platform/linuxbsd/crash_handler_linuxbsd.cpp
g++ -o main/main.linuxbsd.tools.64.o -c -std=gnu++17 -Wctor-dtor-privacy -Wnon-virtual-dtor -Wplacement-new=1 -Wno-error=cpp -g3 -pipe -Wall -Wextra -Wwrite-strings -Wno-unused-parameter -Wshadow-local -Wno-misleading-indentation -Walloc-zero -Wduplicated-branches -Wduplicated-cond -Wstringop-overflow=4 -Wlogical-op -Wattribute-alias=2 -Werror -DDEBUG_ENABLED -DDEV_ENABLED -DNO_EDITOR_SPLASH -DTOUCH_ENABLED -DALSA_ENABLED -DALSAMIDI_ENABLED -DPULSEAUDIO_ENABLED -D_REENTRANT -DDBUS_ENABLED -DJOYDEV_ENABLED -DUDEV_ENABLED -DX11_ENABLED -DUNIX_ENABLED -D_FILE_OFFSET_BITS=64 -DVULKAN_ENABLED -DGLES3_ENABLED -DTOOLS_ENABLED -DMINIZIP_ENABLED -DZSTD_STATIC_LINKING_ONLY -DUSE_VOLK -DVK_USE_PLATFORM_XLIB_KHR -DGLAD_ENABLED -DGLES_OVER_GL -DTESTS_ENABLED -Ithirdparty/freetype/include -Ithirdparty/libpng -Ithirdparty/glad -Ithirdparty/volk -Ithirdparty/vulkan -Ithirdparty/vulkan/include -Ithirdparty/zstd -Ithirdparty/zlib -Iplatform/linuxbsd -I. -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include main/main.cpp
g++ -o modules/gltf/gltf_document.linuxbsd.tools.64.o -c -std=gnu++17 -Wctor-dtor-privacy -Wnon-virtual-dtor -Wplacement-new=1 -Wno-error=cpp -g3 -pipe -Wall -Wextra -Wwrite-strings -Wno-unused-parameter -Wshadow-local -Wno-misleading-indentation -Walloc-zero -Wduplicated-branches -Wduplicated-cond -Wstringop-overflow=4 -Wlogical-op -Wattribute-alias=2 -Werror -DDEBUG_ENABLED -DDEV_ENABLED -DNO_EDITOR_SPLASH -DTOUCH_ENABLED -DALSA_ENABLED -DALSAMIDI_ENABLED -DPULSEAUDIO_ENABLED -D_REENTRANT -DDBUS_ENABLED -DJOYDEV_ENABLED -DUDEV_ENABLED -DX11_ENABLED -DUNIX_ENABLED -D_FILE_OFFSET_BITS=64 -DVULKAN_ENABLED -DGLES3_ENABLED -DTOOLS_ENABLED -DMINIZIP_ENABLED -DZSTD_STATIC_LINKING_ONLY -DUSE_VOLK -DVK_USE_PLATFORM_XLIB_KHR -DGLAD_ENABLED -DGLES_OVER_GL -Imodules/gltf -Ithirdparty/libpng -Ithirdparty/glad -Ithirdparty/volk -Ithirdparty/vulkan -Ithirdparty/vulkan/include -Ithirdparty/zstd -Ithirdparty/zlib -Iplatform/linuxbsd -I. -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include modules/gltf/gltf_document.cpp
modules/gltf/gltf_document.cpp:2538:2: warning: #warning line loop and triangle fan are not supported and need to be converted to lines and triangles [-Wcpp]
 2538 | #warning line loop and triangle fan are not supported and need to be converted to lines and triangles
      |  ^~~~~~~
g++ -o editor/editor_about.linuxbsd.tools.64.o -c -std=gnu++17 -Wctor-dtor-privacy -Wnon-virtual-dtor -Wplacement-new=1 -Wno-error=cpp -g3 -pipe -Wall -Wextra -Wwrite-strings -Wno-unused-parameter -Wshadow-local -Wno-misleading-indentation -Walloc-zero -Wduplicated-branches -Wduplicated-cond -Wstringop-overflow=4 -Wlogical-op -Wattribute-alias=2 -Werror -DDEBUG_ENABLED -DDEV_ENABLED -DNO_EDITOR_SPLASH -DTOUCH_ENABLED -DALSA_ENABLED -DALSAMIDI_ENABLED -DPULSEAUDIO_ENABLED -D_REENTRANT -DDBUS_ENABLED -DJOYDEV_ENABLED -DUDEV_ENABLED -DX11_ENABLED -DUNIX_ENABLED -D_FILE_OFFSET_BITS=64 -DVULKAN_ENABLED -DGLES3_ENABLED -DTOOLS_ENABLED -DMINIZIP_ENABLED -DZSTD_STATIC_LINKING_ONLY -DUSE_VOLK -DVK_USE_PLATFORM_XLIB_KHR -DGLAD_ENABLED -DGLES_OVER_GL -DHAVE_MNTENT -Ithirdparty/freetype/include -Ithirdparty/libpng -Ithirdparty/glad -Ithirdparty/volk -Ithirdparty/vulkan -Ithirdparty/vulkan/include -Ithirdparty/zstd -Ithirdparty/zlib -Iplatform/linuxbsd -I. -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include editor/editor_about.cpp
g++ -o editor/editor_node.linuxbsd.tools.64.o -c -std=gnu++17 -Wctor-dtor-privacy -Wnon-virtual-dtor -Wplacement-new=1 -Wno-error=cpp -g3 -pipe -Wall -Wextra -Wwrite-strings -Wno-unused-parameter -Wshadow-local -Wno-misleading-indentation -Walloc-zero -Wduplicated-branches -Wduplicated-cond -Wstringop-overflow=4 -Wlogical-op -Wattribute-alias=2 -Werror -DDEBUG_ENABLED -DDEV_ENABLED -DNO_EDITOR_SPLASH -DTOUCH_ENABLED -DALSA_ENABLED -DALSAMIDI_ENABLED -DPULSEAUDIO_ENABLED -D_REENTRANT -DDBUS_ENABLED -DJOYDEV_ENABLED -DUDEV_ENABLED -DX11_ENABLED -DUNIX_ENABLED -D_FILE_OFFSET_BITS=64 -DVULKAN_ENABLED -DGLES3_ENABLED -DTOOLS_ENABLED -DMINIZIP_ENABLED -DZSTD_STATIC_LINKING_ONLY -DUSE_VOLK -DVK_USE_PLATFORM_XLIB_KHR -DGLAD_ENABLED -DGLES_OVER_GL -DHAVE_MNTENT -Ithirdparty/freetype/include -Ithirdparty/libpng -Ithirdparty/glad -Ithirdparty/volk -Ithirdparty/vulkan -Ithirdparty/vulkan/include -Ithirdparty/zstd -Ithirdparty/zlib -Iplatform/linuxbsd -I. -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include editor/editor_node.cpp
g++ -o editor/project_manager.linuxbsd.tools.64.o -c -std=gnu++17 -Wctor-dtor-privacy -Wnon-virtual-dtor -Wplacement-new=1 -Wno-error=cpp -g3 -pipe -Wall -Wextra -Wwrite-strings -Wno-unused-parameter -Wshadow-local -Wno-misleading-indentation -Walloc-zero -Wduplicated-branches -Wduplicated-cond -Wstringop-overflow=4 -Wlogical-op -Wattribute-alias=2 -Werror -DDEBUG_ENABLED -DDEV_ENABLED -DNO_EDITOR_SPLASH -DTOUCH_ENABLED -DALSA_ENABLED -DALSAMIDI_ENABLED -DPULSEAUDIO_ENABLED -D_REENTRANT -DDBUS_ENABLED -DJOYDEV_ENABLED -DUDEV_ENABLED -DX11_ENABLED -DUNIX_ENABLED -D_FILE_OFFSET_BITS=64 -DVULKAN_ENABLED -DGLES3_ENABLED -DTOOLS_ENABLED -DMINIZIP_ENABLED -DZSTD_STATIC_LINKING_ONLY -DUSE_VOLK -DVK_USE_PLATFORM_XLIB_KHR -DGLAD_ENABLED -DGLES_OVER_GL -DHAVE_MNTENT -Ithirdparty/freetype/include -Ithirdparty/libpng -Ithirdparty/glad -Ithirdparty/volk -Ithirdparty/vulkan -Ithirdparty/vulkan/include -Ithirdparty/zstd -Ithirdparty/zlib -Iplatform/linuxbsd -I. -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include editor/project_manager.cpp
g++ -o editor/debugger/script_editor_debugger.linuxbsd.tools.64.o -c -std=gnu++17 -Wctor-dtor-privacy -Wnon-virtual-dtor -Wplacement-new=1 -Wno-error=cpp -g3 -pipe -Wall -Wextra -Wwrite-strings -Wno-unused-parameter -Wshadow-local -Wno-misleading-indentation -Walloc-zero -Wduplicated-branches -Wduplicated-cond -Wstringop-overflow=4 -Wlogical-op -Wattribute-alias=2 -Werror -DDEBUG_ENABLED -DDEV_ENABLED -DNO_EDITOR_SPLASH -DTOUCH_ENABLED -DALSA_ENABLED -DALSAMIDI_ENABLED -DPULSEAUDIO_ENABLED -D_REENTRANT -DDBUS_ENABLED -DJOYDEV_ENABLED -DUDEV_ENABLED -DX11_ENABLED -DUNIX_ENABLED -D_FILE_OFFSET_BITS=64 -DVULKAN_ENABLED -DGLES3_ENABLED -DTOOLS_ENABLED -DMINIZIP_ENABLED -DZSTD_STATIC_LINKING_ONLY -DUSE_VOLK -DVK_USE_PLATFORM_XLIB_KHR -DGLAD_ENABLED -DGLES_OVER_GL -DHAVE_MNTENT -Ithirdparty/freetype/include -Ithirdparty/libpng -Ithirdparty/glad -Ithirdparty/volk -Ithirdparty/vulkan -Ithirdparty/vulkan/include -Ithirdparty/zstd -Ithirdparty/zlib -Iplatform/linuxbsd -I. -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include editor/debugger/script_editor_debugger.cpp
g++ -o core/config/engine.linuxbsd.tools.64.o -c -std=gnu++17 -Wctor-dtor-privacy -Wnon-virtual-dtor -Wplacement-new=1 -Wno-error=cpp -g3 -pipe -Wall -Wextra -Wwrite-strings -Wno-unused-parameter -Wshadow-local -Wno-misleading-indentation -Walloc-zero -Wduplicated-branches -Wduplicated-cond -Wstringop-overflow=4 -Wlogical-op -Wattribute-alias=2 -Werror -DDEBUG_ENABLED -DDEV_ENABLED -DNO_EDITOR_SPLASH -DTOUCH_ENABLED -DALSA_ENABLED -DALSAMIDI_ENABLED -DPULSEAUDIO_ENABLED -D_REENTRANT -DDBUS_ENABLED -DJOYDEV_ENABLED -DUDEV_ENABLED -DX11_ENABLED -DUNIX_ENABLED -D_FILE_OFFSET_BITS=64 -DVULKAN_ENABLED -DGLES3_ENABLED -DTOOLS_ENABLED -DMINIZIP_ENABLED -DZSTD_STATIC_LINKING_ONLY -Ithirdparty/zstd -Ithirdparty/zlib -Iplatform/linuxbsd -I. -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include core/config/engine.cpp
ar rc main/libmain.linuxbsd.tools.64.a main/main.linuxbsd.tools.64.o main/main_timer_sync.linuxbsd.tools.64.o main/performance.linuxbsd.tools.64.o
ranlib main/libmain.linuxbsd.tools.64.a
ar rc core/libcore.linuxbsd.tools.64.a thirdparty/misc/fastlz.linuxbsd.tools.64.o thirdparty/misc/r128.linuxbsd.tools.64.o thirdparty/misc/smaz.linuxbsd.tools.64.o thirdparty/misc/pcg.linuxbsd.tools.64.o thirdparty/misc/polypartition.linuxbsd.tools.64.o thirdparty/misc/clipper.linuxbsd.tools.64.o thirdparty/misc/smolv.linuxbsd.tools.64.o thirdparty/zlib/adler32.linuxbsd.tools.64.o thirdparty/zlib/compress.linuxbsd.tools.64.o thirdparty/zlib/crc32.linuxbsd.tools.64.o thirdparty/zlib/deflate.linuxbsd.tools.64.o thirdparty/zlib/infback.linuxbsd.tools.64.o thirdparty/zlib/inffast.linuxbsd.tools.64.o thirdparty/zlib/inflate.linuxbsd.tools.64.o thirdparty/zlib/inftrees.linuxbsd.tools.64.o thirdparty/zlib/trees.linuxbsd.tools.64.o thirdparty/zlib/uncompr.linuxbsd.tools.64.o thirdparty/zlib/zutil.linuxbsd.tools.64.o thirdparty/minizip/ioapi.linuxbsd.tools.64.o thirdparty/minizip/unzip.linuxbsd.tools.64.o thirdparty/minizip/zip.linuxbsd.tools.64.o thirdparty/zstd/common/debug.linuxbsd.tools.64.o thirdparty/zstd/common/entropy_common.linuxbsd.tools.64.o thirdparty/zstd/common/error_private.linuxbsd.tools.64.o thirdparty/zstd/common/fse_decompress.linuxbsd.tools.64.o thirdparty/zstd/common/pool.linuxbsd.tools.64.o thirdparty/zstd/common/threading.linuxbsd.tools.64.o thirdparty/zstd/common/xxhash.linuxbsd.tools.64.o thirdparty/zstd/common/zstd_common.linuxbsd.tools.64.o thirdparty/zstd/compress/fse_compress.linuxbsd.tools.64.o thirdparty/zstd/compress/hist.linuxbsd.tools.64.o thirdparty/zstd/compress/huf_compress.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_compress.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_double_fast.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_fast.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_lazy.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_ldm.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_opt.linuxbsd.tools.64.o thirdparty/zstd/compress/zstdmt_compress.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_compress_literals.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_compress_sequences.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_compress_superblock.linuxbsd.tools.64.o thirdparty/zstd/decompress/huf_decompress.linuxbsd.tools.64.o thirdparty/zstd/decompress/zstd_ddict.linuxbsd.tools.64.o thirdparty/zstd/decompress/zstd_decompress_block.linuxbsd.tools.64.o thirdparty/zstd/decompress/zstd_decompress.linuxbsd.tools.64.o core/core_bind.linuxbsd.tools.64.o core/core_constants.linuxbsd.tools.64.o core/core_string_names.linuxbsd.tools.64.o core/doc_data.linuxbsd.tools.64.o core/register_core_types.linuxbsd.tools.64.o core/script_encryption_key.gen.linuxbsd.tools.64.o core/os/keyboard.linuxbsd.tools.64.o core/os/main_loop.linuxbsd.tools.64.o core/os/memory.linuxbsd.tools.64.o core/os/midi_driver.linuxbsd.tools.64.o core/os/mutex.linuxbsd.tools.64.o core/os/os.linuxbsd.tools.64.o core/os/pool_allocator.linuxbsd.tools.64.o core/os/thread.linuxbsd.tools.64.o core/os/time.linuxbsd.tools.64.o core/math/a_star.linuxbsd.tools.64.o core/math/aabb.linuxbsd.tools.64.o core/math/basis.linuxbsd.tools.64.o core/math/camera_matrix.linuxbsd.tools.64.o core/math/color.linuxbsd.tools.64.o core/math/convex_hull.linuxbsd.tools.64.o core/math/dynamic_bvh.linuxbsd.tools.64.o core/math/expression.linuxbsd.tools.64.o core/math/face3.linuxbsd.tools.64.o core/math/geometry_2d.linuxbsd.tools.64.o core/math/geometry_3d.linuxbsd.tools.64.o core/math/math_fieldwise.linuxbsd.tools.64.o core/math/math_funcs.linuxbsd.tools.64.o core/math/plane.linuxbsd.tools.64.o core/math/quaternion.linuxbsd.tools.64.o core/math/quick_hull.linuxbsd.tools.64.o core/math/random_number_generator.linuxbsd.tools.64.o core/math/random_pcg.linuxbsd.tools.64.o core/math/rect2.linuxbsd.tools.64.o core/math/rect2i.linuxbsd.tools.64.o core/math/static_raycaster.linuxbsd.tools.64.o core/math/transform_2d.linuxbsd.tools.64.o core/math/transform_3d.linuxbsd.tools.64.o core/math/triangle_mesh.linuxbsd.tools.64.o core/math/triangulate.linuxbsd.tools.64.o core/math/vector2.linuxbsd.tools.64.o core/math/vector2i.linuxbsd.tools.64.o core/math/vector3.linuxbsd.tools.64.o core/math/vector3i.linuxbsd.tools.64.o core/crypto/aes_context.linuxbsd.tools.64.o core/crypto/crypto.linuxbsd.tools.64.o core/crypto/crypto_core.linuxbsd.tools.64.o core/crypto/hashing_context.linuxbsd.tools.64.o core/io/compression.linuxbsd.tools.64.o core/io/config_file.linuxbsd.tools.64.o core/io/dir_access.linuxbsd.tools.64.o core/io/dtls_server.linuxbsd.tools.64.o core/io/file_access.linuxbsd.tools.64.o core/io/file_access_compressed.linuxbsd.tools.64.o core/io/file_access_encrypted.linuxbsd.tools.64.o core/io/file_access_memory.linuxbsd.tools.64.o core/io/file_access_network.linuxbsd.tools.64.o core/io/file_access_pack.linuxbsd.tools.64.o core/io/file_access_zip.linuxbsd.tools.64.o core/io/http_client.linuxbsd.tools.64.o core/io/http_client_tcp.linuxbsd.tools.64.o core/io/image.linuxbsd.tools.64.o core/io/image_loader.linuxbsd.tools.64.o core/io/ip.linuxbsd.tools.64.o core/io/ip_address.linuxbsd.tools.64.o core/io/json.linuxbsd.tools.64.o core/io/logger.linuxbsd.tools.64.o core/io/marshalls.linuxbsd.tools.64.o core/io/net_socket.linuxbsd.tools.64.o core/io/packed_data_container.linuxbsd.tools.64.o core/io/packet_peer.linuxbsd.tools.64.o core/io/packet_peer_dtls.linuxbsd.tools.64.o core/io/packet_peer_udp.linuxbsd.tools.64.o core/io/pck_packer.linuxbsd.tools.64.o core/io/resource.linuxbsd.tools.64.o core/io/resource_format_binary.linuxbsd.tools.64.o core/io/resource_importer.linuxbsd.tools.64.o core/io/resource_loader.linuxbsd.tools.64.o core/io/resource_saver.linuxbsd.tools.64.o core/io/resource_uid.linuxbsd.tools.64.o core/io/stream_peer.linuxbsd.tools.64.o core/io/stream_peer_ssl.linuxbsd.tools.64.o core/io/stream_peer_tcp.linuxbsd.tools.64.o core/io/tcp_server.linuxbsd.tools.64.o core/io/translation_loader_po.linuxbsd.tools.64.o core/io/udp_server.linuxbsd.tools.64.o core/io/xml_parser.linuxbsd.tools.64.o core/io/zip_io.linuxbsd.tools.64.o core/multiplayer/multiplayer_api.linuxbsd.tools.64.o core/multiplayer/multiplayer_peer.linuxbsd.tools.64.o core/debugger/debugger_marshalls.linuxbsd.tools.64.o core/debugger/engine_debugger.linuxbsd.tools.64.o core/debugger/local_debugger.linuxbsd.tools.64.o core/debugger/remote_debugger.linuxbsd.tools.64.o core/debugger/remote_debugger_peer.linuxbsd.tools.64.o core/debugger/script_debugger.linuxbsd.tools.64.o core/input/input.linuxbsd.tools.64.o core/input/input_event.linuxbsd.tools.64.o core/input/input_map.linuxbsd.tools.64.o core/input/shortcut.linuxbsd.tools.64.o core/input/default_controller_mappings.gen.linuxbsd.tools.64.o core/variant/array.linuxbsd.tools.64.o core/variant/callable.linuxbsd.tools.64.o core/variant/callable_bind.linuxbsd.tools.64.o core/variant/dictionary.linuxbsd.tools.64.o core/variant/variant.linuxbsd.tools.64.o core/variant/variant_call.linuxbsd.tools.64.o core/variant/variant_construct.linuxbsd.tools.64.o core/variant/variant_destruct.linuxbsd.tools.64.o core/variant/variant_op.linuxbsd.tools.64.o core/variant/variant_parser.linuxbsd.tools.64.o core/variant/variant_setget.linuxbsd.tools.64.o core/variant/variant_utility.linuxbsd.tools.64.o core/extension/extension_api_dump.linuxbsd.tools.64.o core/extension/gdnative_interface.linuxbsd.tools.64.o core/extension/native_extension.linuxbsd.tools.64.o core/extension/native_extension_manager.linuxbsd.tools.64.o core/object/callable_method_pointer.linuxbsd.tools.64.o core/object/class_db.linuxbsd.tools.64.o core/object/message_queue.linuxbsd.tools.64.o core/object/method_bind.linuxbsd.tools.64.o core/object/object.linuxbsd.tools.64.o core/object/ref_counted.linuxbsd.tools.64.o core/object/script_language.linuxbsd.tools.64.o core/object/undo_redo.linuxbsd.tools.64.o core/templates/command_queue_mt.linuxbsd.tools.64.o core/templates/rid_owner.linuxbsd.tools.64.o core/templates/thread_work_pool.linuxbsd.tools.64.o core/string/node_path.linuxbsd.tools.64.o core/string/optimized_translation.linuxbsd.tools.64.o core/string/print_string.linuxbsd.tools.64.o core/string/string_builder.linuxbsd.tools.64.o core/string/string_name.linuxbsd.tools.64.o core/string/translation.linuxbsd.tools.64.o core/string/translation_po.linuxbsd.tools.64.o core/string/ustring.linuxbsd.tools.64.o core/config/engine.linuxbsd.tools.64.o core/config/project_settings.linuxbsd.tools.64.o core/error/error_list.linuxbsd.tools.64.o core/error/error_macros.linuxbsd.tools.64.o
ranlib core/libcore.linuxbsd.tools.64.a
ar rc modules/libmodule_gltf.linuxbsd.tools.64.a modules/gltf/editor_scene_exporter_gltf_plugin.linuxbsd.tools.64.o modules/gltf/editor_scene_importer_gltf.linuxbsd.tools.64.o modules/gltf/gltf_accessor.linuxbsd.tools.64.o modules/gltf/gltf_animation.linuxbsd.tools.64.o modules/gltf/gltf_buffer_view.linuxbsd.tools.64.o modules/gltf/gltf_camera.linuxbsd.tools.64.o modules/gltf/gltf_document.linuxbsd.tools.64.o modules/gltf/gltf_document_extension.linuxbsd.tools.64.o modules/gltf/gltf_document_extension_convert_importer_mesh.linuxbsd.tools.64.o modules/gltf/gltf_light.linuxbsd.tools.64.o modules/gltf/gltf_mesh.linuxbsd.tools.64.o modules/gltf/gltf_node.linuxbsd.tools.64.o modules/gltf/gltf_skeleton.linuxbsd.tools.64.o modules/gltf/gltf_skin.linuxbsd.tools.64.o modules/gltf/gltf_spec_gloss.linuxbsd.tools.64.o modules/gltf/gltf_state.linuxbsd.tools.64.o modules/gltf/gltf_texture.linuxbsd.tools.64.o modules/gltf/register_types.linuxbsd.tools.64.o
ranlib modules/libmodule_gltf.linuxbsd.tools.64.a
Building compilation database compile_commands.json
progress_finish(["progress_finish"], [])
ar rc editor/libeditor.linuxbsd.tools.64.a platform/android/export/export.linuxbsd.tools.64.o platform/android/export/export_plugin.linuxbsd.tools.64.o platform/android/export/godot_plugin_config.linuxbsd.tools.64.o platform/android/export/gradle_export_util.linuxbsd.tools.64.o platform/iphone/export/export.linuxbsd.tools.64.o platform/iphone/export/export_plugin.linuxbsd.tools.64.o platform/iphone/export/godot_plugin_config.linuxbsd.tools.64.o platform/javascript/export/export.linuxbsd.tools.64.o platform/javascript/export/export_plugin.linuxbsd.tools.64.o platform/linuxbsd/export/export.linuxbsd.tools.64.o platform/osx/export/codesign.linuxbsd.tools.64.o platform/osx/export/export.linuxbsd.tools.64.o platform/osx/export/export_plugin.linuxbsd.tools.64.o platform/osx/export/lipo.linuxbsd.tools.64.o platform/osx/export/macho.linuxbsd.tools.64.o platform/osx/export/plist.linuxbsd.tools.64.o platform/uwp/export/app_packager.linuxbsd.tools.64.o platform/uwp/export/export.linuxbsd.tools.64.o platform/uwp/export/export_plugin.linuxbsd.tools.64.o platform/windows/export/export.linuxbsd.tools.64.o platform/windows/export/export_plugin.linuxbsd.tools.64.o editor/action_map_editor.linuxbsd.tools.64.o editor/animation_bezier_editor.linuxbsd.tools.64.o editor/animation_track_editor.linuxbsd.tools.64.o editor/animation_track_editor_plugins.linuxbsd.tools.64.o editor/array_property_edit.linuxbsd.tools.64.o editor/audio_stream_preview.linuxbsd.tools.64.o editor/code_editor.linuxbsd.tools.64.o editor/connections_dialog.linuxbsd.tools.64.o editor/create_dialog.linuxbsd.tools.64.o editor/dependency_editor.linuxbsd.tools.64.o editor/dictionary_property_edit.linuxbsd.tools.64.o editor/doc_tools.linuxbsd.tools.64.o editor/editor_about.linuxbsd.tools.64.o editor/editor_asset_installer.linuxbsd.tools.64.o editor/editor_atlas_packer.linuxbsd.tools.64.o editor/editor_audio_buses.linuxbsd.tools.64.o editor/editor_autoload_settings.linuxbsd.tools.64.o editor/editor_command_palette.linuxbsd.tools.64.o editor/editor_data.linuxbsd.tools.64.o editor/editor_dir_dialog.linuxbsd.tools.64.o editor/editor_export.linuxbsd.tools.64.o editor/editor_feature_profile.linuxbsd.tools.64.o editor/editor_file_dialog.linuxbsd.tools.64.o editor/editor_file_system.linuxbsd.tools.64.o editor/editor_folding.linuxbsd.tools.64.o editor/editor_fonts.linuxbsd.tools.64.o editor/editor_help.linuxbsd.tools.64.o editor/editor_help_search.linuxbsd.tools.64.o editor/editor_inspector.linuxbsd.tools.64.o editor/editor_layouts_dialog.linuxbsd.tools.64.o editor/editor_locale_dialog.linuxbsd.tools.64.o editor/editor_log.linuxbsd.tools.64.o editor/editor_native_shader_source_visualizer.linuxbsd.tools.64.o editor/editor_node.linuxbsd.tools.64.o editor/editor_path.linuxbsd.tools.64.o editor/editor_paths.linuxbsd.tools.64.o editor/editor_plugin.linuxbsd.tools.64.o editor/editor_plugin_settings.linuxbsd.tools.64.o editor/editor_properties.linuxbsd.tools.64.o editor/editor_properties_array_dict.linuxbsd.tools.64.o editor/editor_resource_picker.linuxbsd.tools.64.o editor/editor_resource_preview.linuxbsd.tools.64.o editor/editor_run.linuxbsd.tools.64.o editor/editor_run_native.linuxbsd.tools.64.o editor/editor_run_script.linuxbsd.tools.64.o editor/editor_scale.linuxbsd.tools.64.o editor/editor_sectioned_inspector.linuxbsd.tools.64.o editor/editor_settings.linuxbsd.tools.64.o editor/editor_settings_dialog.linuxbsd.tools.64.o editor/editor_spin_slider.linuxbsd.tools.64.o editor/editor_themes.linuxbsd.tools.64.o editor/editor_toaster.linuxbsd.tools.64.o editor/editor_translation.linuxbsd.tools.64.o editor/editor_translation_parser.linuxbsd.tools.64.o editor/editor_vcs_interface.linuxbsd.tools.64.o editor/editor_zoom_widget.linuxbsd.tools.64.o editor/export_template_manager.linuxbsd.tools.64.o editor/filesystem_dock.linuxbsd.tools.64.o editor/find_in_files.linuxbsd.tools.64.o editor/groups_editor.linuxbsd.tools.64.o editor/import_defaults_editor.linuxbsd.tools.64.o editor/import_dock.linuxbsd.tools.64.o editor/inspector_dock.linuxbsd.tools.64.o editor/localization_editor.linuxbsd.tools.64.o editor/multi_node_edit.linuxbsd.tools.64.o editor/node_dock.linuxbsd.tools.64.o editor/plugin_config_dialog.linuxbsd.tools.64.o editor/pot_generator.linuxbsd.tools.64.o editor/progress_dialog.linuxbsd.tools.64.o editor/project_export.linuxbsd.tools.64.o editor/project_manager.linuxbsd.tools.64.o editor/project_settings_editor.linuxbsd.tools.64.o editor/property_editor.linuxbsd.tools.64.o editor/property_selector.linuxbsd.tools.64.o editor/quick_open.linuxbsd.tools.64.o editor/rename_dialog.linuxbsd.tools.64.o editor/reparent_dialog.linuxbsd.tools.64.o editor/scene_tree_dock.linuxbsd.tools.64.o editor/scene_tree_editor.linuxbsd.tools.64.o editor/script_create_dialog.linuxbsd.tools.64.o editor/shader_create_dialog.linuxbsd.tools.64.o editor/shader_globals_editor.linuxbsd.tools.64.o editor/register_exporters.gen.linuxbsd.tools.64.o editor/debugger/editor_debugger_inspector.linuxbsd.tools.64.o editor/debugger/editor_debugger_node.linuxbsd.tools.64.o editor/debugger/editor_debugger_server.linuxbsd.tools.64.o editor/debugger/editor_debugger_tree.linuxbsd.tools.64.o editor/debugger/editor_network_profiler.linuxbsd.tools.64.o editor/debugger/editor_performance_profiler.linuxbsd.tools.64.o editor/debugger/editor_profiler.linuxbsd.tools.64.o editor/debugger/editor_visual_profiler.linuxbsd.tools.64.o editor/debugger/script_editor_debugger.linuxbsd.tools.64.o editor/debugger/debug_adapter/debug_adapter_parser.linuxbsd.tools.64.o editor/debugger/debug_adapter/debug_adapter_protocol.linuxbsd.tools.64.o editor/debugger/debug_adapter/debug_adapter_server.linuxbsd.tools.64.o editor/fileserver/editor_file_server.linuxbsd.tools.64.o editor/import/collada.linuxbsd.tools.64.o editor/import/dynamicfont_import_settings.linuxbsd.tools.64.o editor/import/editor_import_collada.linuxbsd.tools.64.o editor/import/editor_import_plugin.linuxbsd.tools.64.o editor/import/resource_importer_bitmask.linuxbsd.tools.64.o editor/import/resource_importer_bmfont.linuxbsd.tools.64.o editor/import/resource_importer_csv_translation.linuxbsd.tools.64.o editor/import/resource_importer_dynamicfont.linuxbsd.tools.64.o editor/import/resource_importer_image.linuxbsd.tools.64.o editor/import/resource_importer_imagefont.linuxbsd.tools.64.o editor/import/resource_importer_layered_texture.linuxbsd.tools.64.o editor/import/resource_importer_obj.linuxbsd.tools.64.o editor/import/resource_importer_scene.linuxbsd.tools.64.o editor/import/resource_importer_shader_file.linuxbsd.tools.64.o editor/import/resource_importer_texture.linuxbsd.tools.64.o editor/import/resource_importer_texture_atlas.linuxbsd.tools.64.o editor/import/resource_importer_wav.linuxbsd.tools.64.o editor/import/scene_import_settings.linuxbsd.tools.64.o editor/plugins/abstract_polygon_2d_editor.linuxbsd.tools.64.o editor/plugins/animation_blend_space_1d_editor.linuxbsd.tools.64.o editor/plugins/animation_blend_space_2d_editor.linuxbsd.tools.64.o editor/plugins/animation_blend_tree_editor_plugin.linuxbsd.tools.64.o editor/plugins/animation_player_editor_plugin.linuxbsd.tools.64.o editor/plugins/animation_state_machine_editor.linuxbsd.tools.64.o editor/plugins/animation_tree_editor_plugin.linuxbsd.tools.64.o editor/plugins/asset_library_editor_plugin.linuxbsd.tools.64.o editor/plugins/audio_stream_editor_plugin.linuxbsd.tools.64.o editor/plugins/camera_3d_editor_plugin.linuxbsd.tools.64.o editor/plugins/canvas_item_editor_plugin.linuxbsd.tools.64.o editor/plugins/collision_polygon_2d_editor_plugin.linuxbsd.tools.64.o editor/plugins/collision_polygon_3d_editor_plugin.linuxbsd.tools.64.o editor/plugins/collision_shape_2d_editor_plugin.linuxbsd.tools.64.o editor/plugins/cpu_particles_2d_editor_plugin.linuxbsd.tools.64.o editor/plugins/cpu_particles_3d_editor_plugin.linuxbsd.tools.64.o editor/plugins/curve_editor_plugin.linuxbsd.tools.64.o editor/plugins/debugger_editor_plugin.linuxbsd.tools.64.o editor/plugins/editor_debugger_plugin.linuxbsd.tools.64.o editor/plugins/editor_preview_plugins.linuxbsd.tools.64.o editor/plugins/font_editor_plugin.linuxbsd.tools.64.o editor/plugins/gpu_particles_2d_editor_plugin.linuxbsd.tools.64.o editor/plugins/gpu_particles_3d_editor_plugin.linuxbsd.tools.64.o editor/plugins/gpu_particles_collision_sdf_editor_plugin.linuxbsd.tools.64.o editor/plugins/gradient_editor_plugin.linuxbsd.tools.64.o editor/plugins/input_event_editor_plugin.linuxbsd.tools.64.o editor/plugins/light_occluder_2d_editor_plugin.linuxbsd.tools.64.o editor/plugins/lightmap_gi_editor_plugin.linuxbsd.tools.64.o editor/plugins/line_2d_editor_plugin.linuxbsd.tools.64.o editor/plugins/material_editor_plugin.linuxbsd.tools.64.o editor/plugins/mesh_editor_plugin.linuxbsd.tools.64.o editor/plugins/mesh_instance_3d_editor_plugin.linuxbsd.tools.64.o editor/plugins/mesh_library_editor_plugin.linuxbsd.tools.64.o editor/plugins/multimesh_editor_plugin.linuxbsd.tools.64.o editor/plugins/navigation_polygon_editor_plugin.linuxbsd.tools.64.o editor/plugins/node_3d_editor_gizmos.linuxbsd.tools.64.o editor/plugins/node_3d_editor_plugin.linuxbsd.tools.64.o editor/plugins/occluder_instance_3d_editor_plugin.linuxbsd.tools.64.o editor/plugins/ot_features_plugin.linuxbsd.tools.64.o editor/plugins/packed_scene_translation_parser_plugin.linuxbsd.tools.64.o editor/plugins/path_2d_editor_plugin.linuxbsd.tools.64.o editor/plugins/path_3d_editor_plugin.linuxbsd.tools.64.o editor/plugins/physical_bone_3d_editor_plugin.linuxbsd.tools.64.o editor/plugins/polygon_2d_editor_plugin.linuxbsd.tools.64.o editor/plugins/replication_editor_plugin.linuxbsd.tools.64.o editor/plugins/resource_preloader_editor_plugin.linuxbsd.tools.64.o editor/plugins/root_motion_editor_plugin.linuxbsd.tools.64.o editor/plugins/script_editor_plugin.linuxbsd.tools.64.o editor/plugins/script_text_editor.linuxbsd.tools.64.o editor/plugins/shader_editor_plugin.linuxbsd.tools.64.o editor/plugins/shader_file_editor_plugin.linuxbsd.tools.64.o editor/plugins/skeleton_2d_editor_plugin.linuxbsd.tools.64.o editor/plugins/skeleton_3d_editor_plugin.linuxbsd.tools.64.o editor/plugins/skeleton_ik_3d_editor_plugin.linuxbsd.tools.64.o editor/plugins/sprite_2d_editor_plugin.linuxbsd.tools.64.o editor/plugins/sprite_frames_editor_plugin.linuxbsd.tools.64.o editor/plugins/style_box_editor_plugin.linuxbsd.tools.64.o editor/plugins/sub_viewport_preview_editor_plugin.linuxbsd.tools.64.o editor/plugins/text_control_editor_plugin.linuxbsd.tools.64.o editor/plugins/text_editor.linuxbsd.tools.64.o editor/plugins/texture_3d_editor_plugin.linuxbsd.tools.64.o editor/plugins/texture_editor_plugin.linuxbsd.tools.64.o editor/plugins/texture_layered_editor_plugin.linuxbsd.tools.64.o editor/plugins/texture_region_editor_plugin.linuxbsd.tools.64.o editor/plugins/theme_editor_plugin.linuxbsd.tools.64.o editor/plugins/theme_editor_preview.linuxbsd.tools.64.o editor/plugins/version_control_editor_plugin.linuxbsd.tools.64.o editor/plugins/visual_shader_editor_plugin.linuxbsd.tools.64.o editor/plugins/voxel_gi_editor_plugin.linuxbsd.tools.64.o editor/plugins/tiles/atlas_merging_dialog.linuxbsd.tools.64.o editor/plugins/tiles/tile_atlas_view.linuxbsd.tools.64.o editor/plugins/tiles/tile_data_editors.linuxbsd.tools.64.o editor/plugins/tiles/tile_map_editor.linuxbsd.tools.64.o editor/plugins/tiles/tile_proxies_manager_dialog.linuxbsd.tools.64.o editor/plugins/tiles/tile_set_atlas_source_editor.linuxbsd.tools.64.o editor/plugins/tiles/tile_set_editor.linuxbsd.tools.64.o editor/plugins/tiles/tile_set_scenes_collection_source_editor.linuxbsd.tools.64.o editor/plugins/tiles/tiles_editor_plugin.linuxbsd.tools.64.o
ranlib editor/libeditor.linuxbsd.tools.64.a
g++ -o bin/godot.linuxbsd.tools.64 -B/usr/local/libexec/mold -rdynamic -pipe -static-libgcc -static-libstdc++ platform/linuxbsd/godot_linuxbsd.linuxbsd.tools.64.o platform/linuxbsd/crash_handler_linuxbsd.linuxbsd.tools.64.o platform/linuxbsd/os_linuxbsd.linuxbsd.tools.64.o platform/linuxbsd/joypad_linux.linuxbsd.tools.64.o platform/linuxbsd/freedesktop_screensaver.linuxbsd.tools.64.o platform/linuxbsd/gl_manager_x11.linuxbsd.tools.64.o platform/linuxbsd/detect_prime_x11.linuxbsd.tools.64.o platform/linuxbsd/display_server_x11.linuxbsd.tools.64.o platform/linuxbsd/key_mapping_x11.linuxbsd.tools.64.o platform/linuxbsd/vulkan_context_x11.linuxbsd.tools.64.o platform/linuxbsd/libudev-so_wrap.linuxbsd.tools.64.o main/libmain.linuxbsd.tools.64.a tests/libtests.linuxbsd.tools.64.a modules/libmodules.linuxbsd.tools.64.a modules/libmodule_xatlas_unwrap.linuxbsd.tools.64.a modules/libmodule_webxr.linuxbsd.tools.64.a modules/libmodule_websocket.linuxbsd.tools.64.a modules/libmodule_webrtc.linuxbsd.tools.64.a modules/libmodule_webp.linuxbsd.tools.64.a modules/libmodule_vorbis.linuxbsd.tools.64.a modules/libmodule_visual_script.linuxbsd.tools.64.a modules/libmodule_vhacd.linuxbsd.tools.64.a modules/libmodule_upnp.linuxbsd.tools.64.a modules/libmodule_tinyexr.linuxbsd.tools.64.a modules/libmodule_theora.linuxbsd.tools.64.a modules/libmodule_tga.linuxbsd.tools.64.a modules/libmodule_text_server_adv.linuxbsd.tools.64.a modules/libmodule_svg.linuxbsd.tools.64.a modules/libmodule_squish.linuxbsd.tools.64.a modules/libmodule_regex.linuxbsd.tools.64.a modules/libmodule_raycast.linuxbsd.tools.64.a modules/libmodule_opensimplex.linuxbsd.tools.64.a modules/libmodule_ogg.linuxbsd.tools.64.a modules/libmodule_navigation.linuxbsd.tools.64.a modules/libmodule_msdfgen.linuxbsd.tools.64.a modules/libmodule_mobile_vr.linuxbsd.tools.64.a modules/libmodule_minimp3.linuxbsd.tools.64.a modules/libmodule_meshoptimizer.linuxbsd.tools.64.a modules/libmodule_mbedtls.linuxbsd.tools.64.a modules/libmodule_lightmapper_rd.linuxbsd.tools.64.a modules/libmodule_jsonrpc.linuxbsd.tools.64.a modules/libmodule_jpg.linuxbsd.tools.64.a modules/libmodule_hdr.linuxbsd.tools.64.a modules/libmodule_gridmap.linuxbsd.tools.64.a modules/libmodule_gltf.linuxbsd.tools.64.a modules/libmodule_glslang.linuxbsd.tools.64.a modules/libmodule_gdscript.linuxbsd.tools.64.a modules/libmodule_gdnative.linuxbsd.tools.64.a modules/libmodule_freetype.linuxbsd.tools.64.a modules/libmodule_fbx.linuxbsd.tools.64.a modules/libmodule_etcpak.linuxbsd.tools.64.a modules/libmodule_enet.linuxbsd.tools.64.a modules/libmodule_denoise.linuxbsd.tools.64.a modules/libmodule_dds.linuxbsd.tools.64.a modules/libmodule_cvtt.linuxbsd.tools.64.a modules/libmodule_csg.linuxbsd.tools.64.a modules/libmodule_bmp.linuxbsd.tools.64.a modules/libmodule_basis_universal.linuxbsd.tools.64.a platform/libplatform.linuxbsd.tools.64.a drivers/libdrivers.linuxbsd.tools.64.a editor/libeditor.linuxbsd.tools.64.a scene/libscene.linuxbsd.tools.64.a servers/libservers.linuxbsd.tools.64.a core/libcore.linuxbsd.tools.64.a modules/freetype/libfreetype_builtin.linuxbsd.tools.64.a modules/msdfgen/libmsdfgen_builtin.linuxbsd.tools.64.a modules/text_server_adv/libharfbuzz_builtin.linuxbsd.tools.64.a modules/text_server_adv/libgraphite_builtin.linuxbsd.tools.64.a modules/text_server_adv/libicu_builtin.linuxbsd.tools.64.a -lXcursor -lXinerama -lXext -lXrandr -lXrender -lX11 -lXi -ldbus-1 -lGL -lpthread -ldl
scons: done building targets.
[Time elapsed: 00:00:27.452]
```

### After

```
$ gobuild_linux 
/usr/bin/scons -j7 p=linuxbsd verbose=yes warnings=extra werror=yes tests=yes LINKFLAGS=-B/usr/local/libexec/mold 2>&1 | tee -a build.log
scons: Reading SConscript files ...
Note: Building a debug binary (which will run slowly). Use `target=release_debug` to build an optimized release binary.
Checking for C header file mntent.h... (cached) yes
scons: done reading SConscript files.
scons: Building targets ...
g++ -o core/version_hash.gen.linuxbsd.tools.64.o -c -std=gnu++17 -Wctor-dtor-privacy -Wnon-virtual-dtor -Wplacement-new=1 -Wno-error=cpp -g3 -pipe -Wall -Wextra -Wwrite-strings -Wno-unused-parameter -Wshadow-local -Wno-misleading-indentation -Walloc-zero -Wduplicated-branches -Wduplicated-cond -Wstringop-overflow=4 -Wlogical-op -Wattribute-alias=2 -Werror -DDEBUG_ENABLED -DDEV_ENABLED -DNO_EDITOR_SPLASH -DTOUCH_ENABLED -DALSA_ENABLED -DALSAMIDI_ENABLED -DPULSEAUDIO_ENABLED -D_REENTRANT -DDBUS_ENABLED -DJOYDEV_ENABLED -DUDEV_ENABLED -DX11_ENABLED -DUNIX_ENABLED -D_FILE_OFFSET_BITS=64 -DVULKAN_ENABLED -DGLES3_ENABLED -DTOOLS_ENABLED -DMINIZIP_ENABLED -DZSTD_STATIC_LINKING_ONLY -DUSE_VOLK -DVK_USE_PLATFORM_XLIB_KHR -DGLAD_ENABLED -DGLES_OVER_GL -DHAVE_MNTENT -Ithirdparty/freetype/include -Ithirdparty/libpng -Ithirdparty/glad -Ithirdparty/volk -Ithirdparty/vulkan -Ithirdparty/vulkan/include -Ithirdparty/zstd -Ithirdparty/zlib -Iplatform/linuxbsd -I. -I/usr/include/dbus-1.0 -I/usr/lib64/dbus-1.0/include core/version_hash.gen.cpp
ar rc core/libcore.linuxbsd.tools.64.a thirdparty/misc/fastlz.linuxbsd.tools.64.o thirdparty/misc/r128.linuxbsd.tools.64.o thirdparty/misc/smaz.linuxbsd.tools.64.o thirdparty/misc/pcg.linuxbsd.tools.64.o thirdparty/misc/polypartition.linuxbsd.tools.64.o thirdparty/misc/clipper.linuxbsd.tools.64.o thirdparty/misc/smolv.linuxbsd.tools.64.o thirdparty/zlib/adler32.linuxbsd.tools.64.o thirdparty/zlib/compress.linuxbsd.tools.64.o thirdparty/zlib/crc32.linuxbsd.tools.64.o thirdparty/zlib/deflate.linuxbsd.tools.64.o thirdparty/zlib/infback.linuxbsd.tools.64.o thirdparty/zlib/inffast.linuxbsd.tools.64.o thirdparty/zlib/inflate.linuxbsd.tools.64.o thirdparty/zlib/inftrees.linuxbsd.tools.64.o thirdparty/zlib/trees.linuxbsd.tools.64.o thirdparty/zlib/uncompr.linuxbsd.tools.64.o thirdparty/zlib/zutil.linuxbsd.tools.64.o thirdparty/minizip/ioapi.linuxbsd.tools.64.o thirdparty/minizip/unzip.linuxbsd.tools.64.o thirdparty/minizip/zip.linuxbsd.tools.64.o thirdparty/zstd/common/debug.linuxbsd.tools.64.o thirdparty/zstd/common/entropy_common.linuxbsd.tools.64.o thirdparty/zstd/common/error_private.linuxbsd.tools.64.o thirdparty/zstd/common/fse_decompress.linuxbsd.tools.64.o thirdparty/zstd/common/pool.linuxbsd.tools.64.o thirdparty/zstd/common/threading.linuxbsd.tools.64.o thirdparty/zstd/common/xxhash.linuxbsd.tools.64.o thirdparty/zstd/common/zstd_common.linuxbsd.tools.64.o thirdparty/zstd/compress/fse_compress.linuxbsd.tools.64.o thirdparty/zstd/compress/hist.linuxbsd.tools.64.o thirdparty/zstd/compress/huf_compress.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_compress.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_double_fast.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_fast.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_lazy.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_ldm.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_opt.linuxbsd.tools.64.o thirdparty/zstd/compress/zstdmt_compress.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_compress_literals.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_compress_sequences.linuxbsd.tools.64.o thirdparty/zstd/compress/zstd_compress_superblock.linuxbsd.tools.64.o thirdparty/zstd/decompress/huf_decompress.linuxbsd.tools.64.o thirdparty/zstd/decompress/zstd_ddict.linuxbsd.tools.64.o thirdparty/zstd/decompress/zstd_decompress_block.linuxbsd.tools.64.o thirdparty/zstd/decompress/zstd_decompress.linuxbsd.tools.64.o core/core_bind.linuxbsd.tools.64.o core/core_constants.linuxbsd.tools.64.o core/core_string_names.linuxbsd.tools.64.o core/doc_data.linuxbsd.tools.64.o core/register_core_types.linuxbsd.tools.64.o core/script_encryption_key.gen.linuxbsd.tools.64.o core/version_hash.gen.linuxbsd.tools.64.o core/os/keyboard.linuxbsd.tools.64.o core/os/main_loop.linuxbsd.tools.64.o core/os/memory.linuxbsd.tools.64.o core/os/midi_driver.linuxbsd.tools.64.o core/os/mutex.linuxbsd.tools.64.o core/os/os.linuxbsd.tools.64.o core/os/pool_allocator.linuxbsd.tools.64.o core/os/thread.linuxbsd.tools.64.o core/os/time.linuxbsd.tools.64.o core/math/a_star.linuxbsd.tools.64.o core/math/aabb.linuxbsd.tools.64.o core/math/basis.linuxbsd.tools.64.o core/math/camera_matrix.linuxbsd.tools.64.o core/math/color.linuxbsd.tools.64.o core/math/convex_hull.linuxbsd.tools.64.o core/math/dynamic_bvh.linuxbsd.tools.64.o core/math/expression.linuxbsd.tools.64.o core/math/face3.linuxbsd.tools.64.o core/math/geometry_2d.linuxbsd.tools.64.o core/math/geometry_3d.linuxbsd.tools.64.o core/math/math_fieldwise.linuxbsd.tools.64.o core/math/math_funcs.linuxbsd.tools.64.o core/math/plane.linuxbsd.tools.64.o core/math/quaternion.linuxbsd.tools.64.o core/math/quick_hull.linuxbsd.tools.64.o core/math/random_number_generator.linuxbsd.tools.64.o core/math/random_pcg.linuxbsd.tools.64.o core/math/rect2.linuxbsd.tools.64.o core/math/rect2i.linuxbsd.tools.64.o core/math/static_raycaster.linuxbsd.tools.64.o core/math/transform_2d.linuxbsd.tools.64.o core/math/transform_3d.linuxbsd.tools.64.o core/math/triangle_mesh.linuxbsd.tools.64.o core/math/triangulate.linuxbsd.tools.64.o core/math/vector2.linuxbsd.tools.64.o core/math/vector2i.linuxbsd.tools.64.o core/math/vector3.linuxbsd.tools.64.o core/math/vector3i.linuxbsd.tools.64.o core/crypto/aes_context.linuxbsd.tools.64.o core/crypto/crypto.linuxbsd.tools.64.o core/crypto/crypto_core.linuxbsd.tools.64.o core/crypto/hashing_context.linuxbsd.tools.64.o core/io/compression.linuxbsd.tools.64.o core/io/config_file.linuxbsd.tools.64.o core/io/dir_access.linuxbsd.tools.64.o core/io/dtls_server.linuxbsd.tools.64.o core/io/file_access.linuxbsd.tools.64.o core/io/file_access_compressed.linuxbsd.tools.64.o core/io/file_access_encrypted.linuxbsd.tools.64.o core/io/file_access_memory.linuxbsd.tools.64.o core/io/file_access_network.linuxbsd.tools.64.o core/io/file_access_pack.linuxbsd.tools.64.o core/io/file_access_zip.linuxbsd.tools.64.o core/io/http_client.linuxbsd.tools.64.o core/io/http_client_tcp.linuxbsd.tools.64.o core/io/image.linuxbsd.tools.64.o core/io/image_loader.linuxbsd.tools.64.o core/io/ip.linuxbsd.tools.64.o core/io/ip_address.linuxbsd.tools.64.o core/io/json.linuxbsd.tools.64.o core/io/logger.linuxbsd.tools.64.o core/io/marshalls.linuxbsd.tools.64.o core/io/net_socket.linuxbsd.tools.64.o core/io/packed_data_container.linuxbsd.tools.64.o core/io/packet_peer.linuxbsd.tools.64.o core/io/packet_peer_dtls.linuxbsd.tools.64.o core/io/packet_peer_udp.linuxbsd.tools.64.o core/io/pck_packer.linuxbsd.tools.64.o core/io/resource.linuxbsd.tools.64.o core/io/resource_format_binary.linuxbsd.tools.64.o core/io/resource_importer.linuxbsd.tools.64.o core/io/resource_loader.linuxbsd.tools.64.o core/io/resource_saver.linuxbsd.tools.64.o core/io/resource_uid.linuxbsd.tools.64.o core/io/stream_peer.linuxbsd.tools.64.o core/io/stream_peer_ssl.linuxbsd.tools.64.o core/io/stream_peer_tcp.linuxbsd.tools.64.o core/io/tcp_server.linuxbsd.tools.64.o core/io/translation_loader_po.linuxbsd.tools.64.o core/io/udp_server.linuxbsd.tools.64.o core/io/xml_parser.linuxbsd.tools.64.o core/io/zip_io.linuxbsd.tools.64.o core/multiplayer/multiplayer_api.linuxbsd.tools.64.o core/multiplayer/multiplayer_peer.linuxbsd.tools.64.o core/debugger/debugger_marshalls.linuxbsd.tools.64.o core/debugger/engine_debugger.linuxbsd.tools.64.o core/debugger/local_debugger.linuxbsd.tools.64.o core/debugger/remote_debugger.linuxbsd.tools.64.o core/debugger/remote_debugger_peer.linuxbsd.tools.64.o core/debugger/script_debugger.linuxbsd.tools.64.o core/input/input.linuxbsd.tools.64.o core/input/input_event.linuxbsd.tools.64.o core/input/input_map.linuxbsd.tools.64.o core/input/shortcut.linuxbsd.tools.64.o core/input/default_controller_mappings.gen.linuxbsd.tools.64.o core/variant/array.linuxbsd.tools.64.o core/variant/callable.linuxbsd.tools.64.o core/variant/callable_bind.linuxbsd.tools.64.o core/variant/dictionary.linuxbsd.tools.64.o core/variant/variant.linuxbsd.tools.64.o core/variant/variant_call.linuxbsd.tools.64.o core/variant/variant_construct.linuxbsd.tools.64.o core/variant/variant_destruct.linuxbsd.tools.64.o core/variant/variant_op.linuxbsd.tools.64.o core/variant/variant_parser.linuxbsd.tools.64.o core/variant/variant_setget.linuxbsd.tools.64.o core/variant/variant_utility.linuxbsd.tools.64.o core/extension/extension_api_dump.linuxbsd.tools.64.o core/extension/gdnative_interface.linuxbsd.tools.64.o core/extension/native_extension.linuxbsd.tools.64.o core/extension/native_extension_manager.linuxbsd.tools.64.o core/object/callable_method_pointer.linuxbsd.tools.64.o core/object/class_db.linuxbsd.tools.64.o core/object/message_queue.linuxbsd.tools.64.o core/object/method_bind.linuxbsd.tools.64.o core/object/object.linuxbsd.tools.64.o core/object/ref_counted.linuxbsd.tools.64.o core/object/script_language.linuxbsd.tools.64.o core/object/undo_redo.linuxbsd.tools.64.o core/templates/command_queue_mt.linuxbsd.tools.64.o core/templates/rid_owner.linuxbsd.tools.64.o core/templates/thread_work_pool.linuxbsd.tools.64.o core/string/node_path.linuxbsd.tools.64.o core/string/optimized_translation.linuxbsd.tools.64.o core/string/print_string.linuxbsd.tools.64.o core/string/string_builder.linuxbsd.tools.64.o core/string/string_name.linuxbsd.tools.64.o core/string/translation.linuxbsd.tools.64.o core/string/translation_po.linuxbsd.tools.64.o core/string/ustring.linuxbsd.tools.64.o core/config/engine.linuxbsd.tools.64.o core/config/project_settings.linuxbsd.tools.64.o core/error/error_list.linuxbsd.tools.64.o core/error/error_macros.linuxbsd.tools.64.o
ranlib core/libcore.linuxbsd.tools.64.a
g++ -o bin/godot.linuxbsd.tools.64 -B/usr/local/libexec/mold -rdynamic -pipe -static-libgcc -static-libstdc++ platform/linuxbsd/godot_linuxbsd.linuxbsd.tools.64.o platform/linuxbsd/crash_handler_linuxbsd.linuxbsd.tools.64.o platform/linuxbsd/os_linuxbsd.linuxbsd.tools.64.o platform/linuxbsd/joypad_linux.linuxbsd.tools.64.o platform/linuxbsd/freedesktop_screensaver.linuxbsd.tools.64.o platform/linuxbsd/gl_manager_x11.linuxbsd.tools.64.o platform/linuxbsd/detect_prime_x11.linuxbsd.tools.64.o platform/linuxbsd/display_server_x11.linuxbsd.tools.64.o platform/linuxbsd/key_mapping_x11.linuxbsd.tools.64.o platform/linuxbsd/vulkan_context_x11.linuxbsd.tools.64.o platform/linuxbsd/libudev-so_wrap.linuxbsd.tools.64.o main/libmain.linuxbsd.tools.64.a tests/libtests.linuxbsd.tools.64.a modules/libmodules.linuxbsd.tools.64.a modules/libmodule_xatlas_unwrap.linuxbsd.tools.64.a modules/libmodule_webxr.linuxbsd.tools.64.a modules/libmodule_websocket.linuxbsd.tools.64.a modules/libmodule_webrtc.linuxbsd.tools.64.a modules/libmodule_webp.linuxbsd.tools.64.a modules/libmodule_vorbis.linuxbsd.tools.64.a modules/libmodule_visual_script.linuxbsd.tools.64.a modules/libmodule_vhacd.linuxbsd.tools.64.a modules/libmodule_upnp.linuxbsd.tools.64.a modules/libmodule_tinyexr.linuxbsd.tools.64.a modules/libmodule_theora.linuxbsd.tools.64.a modules/libmodule_tga.linuxbsd.tools.64.a modules/libmodule_text_server_adv.linuxbsd.tools.64.a modules/libmodule_svg.linuxbsd.tools.64.a modules/libmodule_squish.linuxbsd.tools.64.a modules/libmodule_regex.linuxbsd.tools.64.a modules/libmodule_raycast.linuxbsd.tools.64.a modules/libmodule_opensimplex.linuxbsd.tools.64.a modules/libmodule_ogg.linuxbsd.tools.64.a modules/libmodule_navigation.linuxbsd.tools.64.a modules/libmodule_msdfgen.linuxbsd.tools.64.a modules/libmodule_mobile_vr.linuxbsd.tools.64.a modules/libmodule_minimp3.linuxbsd.tools.64.a modules/libmodule_meshoptimizer.linuxbsd.tools.64.a modules/libmodule_mbedtls.linuxbsd.tools.64.a modules/libmodule_lightmapper_rd.linuxbsd.tools.64.a modules/libmodule_jsonrpc.linuxbsd.tools.64.a modules/libmodule_jpg.linuxbsd.tools.64.a modules/libmodule_hdr.linuxbsd.tools.64.a modules/libmodule_gridmap.linuxbsd.tools.64.a modules/libmodule_gltf.linuxbsd.tools.64.a modules/libmodule_glslang.linuxbsd.tools.64.a modules/libmodule_gdscript.linuxbsd.tools.64.a modules/libmodule_gdnative.linuxbsd.tools.64.a modules/libmodule_freetype.linuxbsd.tools.64.a modules/libmodule_fbx.linuxbsd.tools.64.a modules/libmodule_etcpak.linuxbsd.tools.64.a modules/libmodule_enet.linuxbsd.tools.64.a modules/libmodule_denoise.linuxbsd.tools.64.a modules/libmodule_dds.linuxbsd.tools.64.a modules/libmodule_cvtt.linuxbsd.tools.64.a modules/libmodule_csg.linuxbsd.tools.64.a modules/libmodule_bmp.linuxbsd.tools.64.a modules/libmodule_basis_universal.linuxbsd.tools.64.a platform/libplatform.linuxbsd.tools.64.a drivers/libdrivers.linuxbsd.tools.64.a editor/libeditor.linuxbsd.tools.64.a scene/libscene.linuxbsd.tools.64.a servers/libservers.linuxbsd.tools.64.a core/libcore.linuxbsd.tools.64.a modules/freetype/libfreetype_builtin.linuxbsd.tools.64.a modules/msdfgen/libmsdfgen_builtin.linuxbsd.tools.64.a modules/text_server_adv/libharfbuzz_builtin.linuxbsd.tools.64.a modules/text_server_adv/libgraphite_builtin.linuxbsd.tools.64.a modules/text_server_adv/libicu_builtin.linuxbsd.tools.64.a -lXcursor -lXinerama -lXext -lXrandr -lXrender -lX11 -lXi -ldbus-1 -lGL -lpthread -ldl
progress_finish(["progress_finish"], [])
Building compilation database compile_commands.json
scons: done building targets.
[Time elapsed: 00:00:13.070]
```