### PR TITLE
Add array element type to `_get_polygons` and `_get_outlines`

### DIFF
--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -104,8 +104,8 @@ void NavigationPolygon::_set_polygons(const TypedArray<Vector<int32_t>> &p_array
 	}
 }
 
-Array NavigationPolygon::_get_polygons() const {
-	Array ret;
+TypedArray<Vector<int32_t>> NavigationPolygon::_get_polygons() const {
+	TypedArray<Vector<int32_t>> ret;
 	ret.resize(polygons.size());
 	for (int i = 0; i < ret.size(); i++) {
 		ret[i] = polygons[i].indices;
@@ -122,8 +122,8 @@ void NavigationPolygon::_set_outlines(const TypedArray<Vector<Vector2>> &p_array
 	rect_cache_dirty = true;
 }
 
-Array NavigationPolygon::_get_outlines() const {
-	Array ret;
+TypedArray<Vector<Vector2>> NavigationPolygon::_get_outlines() const {
+	TypedArray<Vector<Vector2>> ret;
 	ret.resize(outlines.size());
 	for (int i = 0; i < ret.size(); i++) {
 		ret[i] = outlines[i];

--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -55,10 +55,10 @@ protected:
 	static void _bind_methods();
 
 	void _set_polygons(const TypedArray<Vector<int32_t>> &p_array);
-	Array _get_polygons() const;
+	TypedArray<Vector<int32_t>> _get_polygons() const;
 
 	void _set_outlines(const TypedArray<Vector<Vector2>> &p_array);
-	Array _get_outlines() const;
+	TypedArray<Vector<Vector2>> _get_outlines() const;
 
 public:
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
It seems odd that the setters take a `TypedArray` but the getters return an untyped `Array` so I added the type information to the getters too, not sure why it wasn't like this before but maybe there was a reason for this I'm not familiar with the `NavigationPolygon` code.