### PR TITLE
Use source image format when creating padded texture

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -4434,7 +4434,7 @@ void TileSetAtlasSource::_update_padded_texture() {
 
 	Ref<Image> image;
 	image.instantiate();
-	image->create(size.x, size.y, false, Image::FORMAT_RGBA8);
+	image->create(size.x, size.y, false, src->get_format());
 
 	for (KeyValue<Vector2i, TileAlternativesData> kv : tiles) {
 		for (int frame = 0; frame < (int)kv.value.animation_frames_durations.size(); frame++) {


### PR DESCRIPTION
Format  `Image::FORMAT_RGBA8` was enforce when creating tile rect, this create glitches in related tiles when source format is different. Using the source format instead fixes it.

*Bugsquad edit:*
- Fixes #55141