### PR TITLE
Remove support for ARMv7 (32-bit) on iOS

### DIFF
--- a/.github/workflows/ios_builds.yml
+++ b/.github/workflows/ios_builds.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup python and scons
         uses: ./.github/actions/godot-deps
 
-      - name: Compilation (armv7)
+      - name: Compilation (arm64v8)
         uses: ./.github/actions/godot-build
         with:
           sconsflags: ${{ env.SCONSFLAGS }}

--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -325,7 +325,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "$provisioning_profile_uuid_debug";
 				TARGETED_DEVICE_FAMILY = "$targeted_device_family";
-				VALID_ARCHS = "armv7 armv7s arm64 i386 x86_64";
+				VALID_ARCHS = "arm64 x86_64";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -356,7 +356,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "$provisioning_profile_uuid_release";
 				TARGETED_DEVICE_FAMILY = "$targeted_device_family";
-				VALID_ARCHS = "armv7 armv7s arm64 i386 x86_64";
+				VALID_ARCHS = "arm64 x86_64";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;

--- a/modules/gdnative/gdnative_library_editor_plugin.cpp
+++ b/modules/gdnative/gdnative_library_editor_plugin.cpp
@@ -315,7 +315,6 @@ GDNativeLibraryEditor::GDNativeLibraryEditor() {
 
 		NativePlatformConfig platform_ios;
 		platform_ios.name = "iOS";
-		platform_ios.entries.push_back("armv7");
 		platform_ios.entries.push_back("arm64");
 		platform_ios.entries.push_back("x86_64");
 		// iOS can use both Static and Dynamic libraries.

--- a/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/AotBuilder.cs
@@ -537,7 +537,6 @@ MONO_AOT_MODE_LAST = 1000,
         {
             var iosArchs = new[]
             {
-                "armv7",
                 "arm64"
             };
 

--- a/platform/iphone/export/export_plugin.cpp
+++ b/platform/iphone/export/export_plugin.cpp
@@ -43,7 +43,6 @@ void EditorExportPlatformIOS::get_preset_features(const Ref<EditorExportPreset> 
 
 Vector<EditorExportPlatformIOS::ExportArchitecture> EditorExportPlatformIOS::_get_supported_architectures() {
 	Vector<ExportArchitecture> archs;
-	archs.push_back(ExportArchitecture("armv7", false)); // Disabled by default, not included in official templates.
 	archs.push_back(ExportArchitecture("arm64", true));
 	return archs;
 }


### PR DESCRIPTION
All iOS devices since the iPhone 5S support ARMv8 (64-bit).

The last iOS version supported on ARMv7 devices is 10.x, which is too old to run Godot 4.0 projects since [the minimum supported iOS version is 11.0](https://github.com/godotengine/godot/blob/76ce5c16f351632d40fea9e6ea2bb015cb827aca/platform/iphone/detect.py#L102).

There's the question of whether we should do this for Android too, but I think there will still be a few 32-bit Android devices still used for gaming by the time Godot 4.0 is released. Supported Android versions such as Android 7 still run on 32-bit ARM devices too.

See https://github.com/godotengine/godot/issues/34135.