### PR TITLE
Remove obsolete define in the iOS buildsystem code

### DIFF
--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -120,7 +120,6 @@ def configure(env):
             )
         )
         env.Append(CPPDEFINES=["NEED_LONG_INT"])
-        env.Append(CPPDEFINES=["LIBYUV_DISABLE_NEON"])
 
     # Disable exceptions on non-tools (template) builds
     if not env["tools"]:


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/57822.

This define was used by the WebM/libvpx code, but it's now removed in `master`. There is no reference to `LIBYUV_DISABLE_NEON` anywhere in the codebase (including third-party files).

**Note:** Not cherry-pickable to `3.x` as WebM code is still present there.