### PR TITLE
Add normal mapping setting to Sprite3D

### DIFF
--- a/doc/classes/Sprite3D.xml
+++ b/doc/classes/Sprite3D.xml
@@ -18,6 +18,12 @@
 		<member name="hframes" type="int" setter="set_hframes" getter="get_hframes" default="1">
 			The number of columns in the sprite sheet.
 		</member>
+		<member name="normal_map" type="Texture" setter="set_normal_map" getter="get_normal_map">
+			[Texture2D] object to be used as the normal map.
+		</member>
+		<member name="normal_scale" type="float" setter="set_normal_scale" getter="get_normal_scale" default="1.0">
+			The strength of the normal map's effect.
+		</member>
 		<member name="region_enabled" type="bool" setter="set_region_enabled" getter="is_region_enabled" default="false">
 		</member>
 		<member name="region_rect" type="Rect2" setter="set_region_rect" getter="get_region_rect" default="Rect2(0, 0, 0, 0)">
@@ -25,12 +31,6 @@
 		</member>
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			[Texture2D] object to draw.
-		</member>
-		<member name="normal_map" type="Texture" setter="set_normal_map" getter="get_normal_map">
-			[Texture2D] object to be used as the normal map.
-		</member>
-		<member name="normal_scale" type="float" setter="set_normal_scale" getter="get_normal_scale" default="1.0">
-			The strength of the normal map's effect.
 		</member>
 		<member name="vframes" type="int" setter="set_vframes" getter="get_vframes" default="1">
 			The number of rows in the sprite sheet.

--- a/doc/classes/Sprite3D.xml
+++ b/doc/classes/Sprite3D.xml
@@ -26,6 +26,9 @@
 		<member name="texture" type="Texture2D" setter="set_texture" getter="get_texture">
 			[Texture2D] object to draw.
 		</member>
+		<member name="normal_map" type="Texture" setter="set_normal_map" getter="get_normal_map">
+			[Texture2D] object to be used as the normal map.
+		</member>
 		<member name="vframes" type="int" setter="set_vframes" getter="get_vframes" default="1">
 			The number of rows in the sprite sheet.
 		</member>

--- a/doc/classes/Sprite3D.xml
+++ b/doc/classes/Sprite3D.xml
@@ -29,6 +29,9 @@
 		<member name="normal_map" type="Texture" setter="set_normal_map" getter="get_normal_map">
 			[Texture2D] object to be used as the normal map.
 		</member>
+		<member name="normal_scale" type="float" setter="set_normal_scale" getter="get_normal_scale" default="1.0">
+			The strength of the normal map's effect.
+		</member>
 		<member name="vframes" type="int" setter="set_vframes" getter="get_vframes" default="1">
 			The number of rows in the sprite sheet.
 		</member>

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -588,7 +588,7 @@ void Sprite3D::_draw() {
 	set_aabb(aabb);
 
 	RID shader_rid;
-	StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), get_draw_flag(FLAG_DOUBLE_SIDED), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS, get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, &shader_rid);
+	StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), normal_map.is_valid(), get_draw_flag(FLAG_DOUBLE_SIDED), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS, get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, &shader_rid);
 	if (last_shader != shader_rid) {
 		RS::get_singleton()->material_set_shader(get_material(), shader_rid);
 		last_shader = shader_rid;
@@ -596,6 +596,15 @@ void Sprite3D::_draw() {
 	if (last_texture != texture->get_rid()) {
 		RS::get_singleton()->material_set_param(get_material(), "texture_albedo", texture->get_rid());
 		last_texture = texture->get_rid();
+	}
+	if (!normal_map.is_valid() && last_normal_map != RID()) {
+		last_normal_map = RID();
+		RS::get_singleton()->material_set_param(get_material(), "texture_normal", Variant());
+	}
+	if (normal_map.is_valid() && last_normal_map != normal_map->get_rid()) {
+		RS::get_singleton()->material_set_param(get_material(), "normal_scale", 1);
+		RS::get_singleton()->material_set_param(get_material(), "texture_normal", normal_map->get_rid());
+		last_normal_map = normal_map->get_rid();
 	}
 }
 
@@ -616,6 +625,25 @@ void Sprite3D::set_texture(const Ref<Texture2D> &p_texture) {
 
 Ref<Texture2D> Sprite3D::get_texture() const {
 	return texture;
+}
+
+void Sprite3D::set_normal_map(const Ref<Texture2D> &p_texture) {
+	if (p_texture == normal_map) {
+		return;
+	}
+	if (normal_map.is_valid()) {
+		normal_map->disconnect(CoreStringNames::get_singleton()->changed, Callable(this, "_queue_update"));
+	}
+	normal_map = p_texture;
+	if (normal_map.is_valid()) {
+		normal_map->connect(CoreStringNames::get_singleton()->changed, Callable(this, "_queue_update"));
+	}
+	_queue_update();
+	emit_signal(SceneStringNames::get_singleton()->texture_changed);
+}
+
+Ref<Texture2D> Sprite3D::get_normal_map() const {
+	return normal_map;
 }
 
 void Sprite3D::set_region_enabled(bool p_region) {
@@ -738,6 +766,9 @@ void Sprite3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_texture", "texture"), &Sprite3D::set_texture);
 	ClassDB::bind_method(D_METHOD("get_texture"), &Sprite3D::get_texture);
 
+	ClassDB::bind_method(D_METHOD("set_normal_map", "texture"), &Sprite3D::set_normal_map);
+	ClassDB::bind_method(D_METHOD("get_normal_map"), &Sprite3D::get_normal_map);
+
 	ClassDB::bind_method(D_METHOD("set_region_enabled", "enabled"), &Sprite3D::set_region_enabled);
 	ClassDB::bind_method(D_METHOD("is_region_enabled"), &Sprite3D::is_region_enabled);
 
@@ -757,6 +788,7 @@ void Sprite3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_hframes"), &Sprite3D::get_hframes);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_texture", "get_texture");
+ 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "normal_map", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_normal_map", "get_normal_map");
 	ADD_GROUP("Animation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hframes", PROPERTY_HINT_RANGE, "1,16384,1"), "set_hframes", "get_hframes");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "vframes", PROPERTY_HINT_RANGE, "1,16384,1"), "set_vframes", "get_vframes");
@@ -954,7 +986,7 @@ void AnimatedSprite3D::_draw() {
 	set_aabb(aabb);
 
 	RID shader_rid;
-	StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), get_draw_flag(FLAG_DOUBLE_SIDED), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS, get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, &shader_rid);
+	StandardMaterial3D::get_material_for_2d(get_draw_flag(FLAG_SHADED), get_draw_flag(FLAG_TRANSPARENT), false, get_draw_flag(FLAG_DOUBLE_SIDED), get_alpha_cut_mode() == ALPHA_CUT_DISCARD, get_alpha_cut_mode() == ALPHA_CUT_OPAQUE_PREPASS, get_billboard_mode() == StandardMaterial3D::BILLBOARD_ENABLED, get_billboard_mode() == StandardMaterial3D::BILLBOARD_FIXED_Y, &shader_rid);
 	if (last_shader != shader_rid) {
 		RS::get_singleton()->material_set_shader(get_material(), shader_rid);
 		last_shader = shader_rid;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -602,9 +602,12 @@ void Sprite3D::_draw() {
 		RS::get_singleton()->material_set_param(get_material(), "texture_normal", Variant());
 	}
 	if (normal_map.is_valid() && last_normal_map != normal_map->get_rid()) {
-		RS::get_singleton()->material_set_param(get_material(), "normal_scale", 1);
 		RS::get_singleton()->material_set_param(get_material(), "texture_normal", normal_map->get_rid());
 		last_normal_map = normal_map->get_rid();
+	}
+	if (normal_map.is_valid() && last_normal_scale != normal_scale) {
+		RS::get_singleton()->material_set_param(get_material(), "normal_scale", normal_scale);
+		last_normal_scale = normal_scale;
 	}
 }
 
@@ -644,6 +647,20 @@ void Sprite3D::set_normal_map(const Ref<Texture2D> &p_texture) {
 
 Ref<Texture2D> Sprite3D::get_normal_map() const {
 	return normal_map;
+}
+
+void Sprite3D::set_normal_scale(float p_normal_scale) {
+	if (p_normal_scale == normal_scale) {
+		return;
+	}
+
+	normal_scale = p_normal_scale;
+	_queue_update();
+	emit_signal(SceneStringNames::get_singleton()->texture_changed);
+}
+
+float Sprite3D::get_normal_scale() const {
+	return normal_scale;
 }
 
 void Sprite3D::set_region_enabled(bool p_region) {
@@ -769,6 +786,9 @@ void Sprite3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_normal_map", "texture"), &Sprite3D::set_normal_map);
 	ClassDB::bind_method(D_METHOD("get_normal_map"), &Sprite3D::get_normal_map);
 
+	ClassDB::bind_method(D_METHOD("set_normal_scale", "normal_scale"), &Sprite3D::set_normal_scale);
+	ClassDB::bind_method(D_METHOD("get_normal_scale"), &Sprite3D::get_normal_scale);
+
 	ClassDB::bind_method(D_METHOD("set_region_enabled", "enabled"), &Sprite3D::set_region_enabled);
 	ClassDB::bind_method(D_METHOD("is_region_enabled"), &Sprite3D::is_region_enabled);
 
@@ -788,7 +808,8 @@ void Sprite3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_hframes"), &Sprite3D::get_hframes);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_texture", "get_texture");
- 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "normal_map", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_normal_map", "get_normal_map");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "normal_map", PROPERTY_HINT_RESOURCE_TYPE, "Texture"), "set_normal_map", "get_normal_map");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "normal_scale", PROPERTY_HINT_RANGE, "-16,16,0.01"), "set_normal_scale", "get_normal_scale");
 	ADD_GROUP("Animation", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hframes", PROPERTY_HINT_RANGE, "1,16384,1"), "set_hframes", "get_hframes");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "vframes", PROPERTY_HINT_RANGE, "1,16384,1"), "set_vframes", "get_vframes");

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -148,6 +148,7 @@ class Sprite3D : public SpriteBase3D {
 	GDCLASS(Sprite3D, SpriteBase3D);
 	Ref<Texture2D> texture;
 	Ref<Texture2D> normal_map;
+	float normal_scale = 1;
 
 	bool region = false;
 	Rect2 region_rect;
@@ -160,6 +161,7 @@ class Sprite3D : public SpriteBase3D {
 	RID last_shader;
 	RID last_texture;
 	RID last_normal_map;
+	float last_normal_scale;
 
 protected:
 	virtual void _draw() override;
@@ -173,6 +175,9 @@ public:
 
 	void set_normal_map(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_normal_map() const;
+
+	void set_normal_scale(float p_normal_scale);
+	float get_normal_scale() const;
 
 	void set_region_enabled(bool p_region);
 	bool is_region_enabled() const;

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -147,6 +147,7 @@ public:
 class Sprite3D : public SpriteBase3D {
 	GDCLASS(Sprite3D, SpriteBase3D);
 	Ref<Texture2D> texture;
+	Ref<Texture2D> normal_map;
 
 	bool region = false;
 	Rect2 region_rect;
@@ -158,6 +159,7 @@ class Sprite3D : public SpriteBase3D {
 
 	RID last_shader;
 	RID last_texture;
+	RID last_normal_map;
 
 protected:
 	virtual void _draw() override;
@@ -168,6 +170,9 @@ protected:
 public:
 	void set_texture(const Ref<Texture2D> &p_texture);
 	Ref<Texture2D> get_texture() const;
+
+	void set_normal_map(const Ref<Texture2D> &p_texture);
+	Ref<Texture2D> get_normal_map() const;
 
 	void set_region_enabled(bool p_region);
 	bool is_region_enabled() const;

--- a/scene/animation/root_motion_view.cpp
+++ b/scene/animation/root_motion_view.cpp
@@ -77,7 +77,7 @@ bool RootMotionView::get_zero_y() const {
 
 void RootMotionView::_notification(int p_what) {
 	if (p_what == NOTIFICATION_ENTER_TREE) {
-		immediate_material = StandardMaterial3D::get_material_for_2d(false, true, false, false, false);
+		immediate_material = StandardMaterial3D::get_material_for_2d(false, true, false, false, false, false);
 		first = true;
 	}
 

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2095,7 +2095,7 @@ BaseMaterial3D::TextureChannel BaseMaterial3D::get_refraction_texture_channel() 
 	return refraction_texture_channel;
 }
 
-Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, bool p_transparent, bool p_double_sided, bool p_cut_alpha, bool p_opaque_prepass, bool p_billboard, bool p_billboard_y, RID *r_shader_rid) {
+Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, bool p_transparent, bool p_normal_mapping, bool p_double_sided, bool p_cut_alpha, bool p_opaque_prepass, bool p_billboard, bool p_billboard_y, RID *r_shader_rid) {
 	int version = 0;
 	if (p_shaded) {
 		version = 1;
@@ -2131,6 +2131,7 @@ Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, bool p_transpar
 
 	material->set_shading_mode(p_shaded ? SHADING_MODE_PER_PIXEL : SHADING_MODE_UNSHADED);
 	material->set_transparency(p_transparent ? (p_opaque_prepass ? TRANSPARENCY_ALPHA_DEPTH_PRE_PASS : (p_cut_alpha ? TRANSPARENCY_ALPHA_SCISSOR : TRANSPARENCY_ALPHA)) : TRANSPARENCY_DISABLED);
+ 	material->set_feature(FEATURE_NORMAL_MAPPING, p_normal_mapping);
 	material->set_cull_mode(p_double_sided ? CULL_DISABLED : CULL_BACK);
 	material->set_flag(FLAG_SRGB_VERTEX_COLOR, true);
 	material->set_flag(FLAG_ALBEDO_FROM_VERTEX_COLOR, true);

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -2131,7 +2131,7 @@ Ref<Material> BaseMaterial3D::get_material_for_2d(bool p_shaded, bool p_transpar
 
 	material->set_shading_mode(p_shaded ? SHADING_MODE_PER_PIXEL : SHADING_MODE_UNSHADED);
 	material->set_transparency(p_transparent ? (p_opaque_prepass ? TRANSPARENCY_ALPHA_DEPTH_PRE_PASS : (p_cut_alpha ? TRANSPARENCY_ALPHA_SCISSOR : TRANSPARENCY_ALPHA)) : TRANSPARENCY_DISABLED);
- 	material->set_feature(FEATURE_NORMAL_MAPPING, p_normal_mapping);
+	material->set_feature(FEATURE_NORMAL_MAPPING, p_normal_mapping);
 	material->set_cull_mode(p_double_sided ? CULL_DISABLED : CULL_BACK);
 	material->set_flag(FLAG_SRGB_VERTEX_COLOR, true);
 	material->set_flag(FLAG_ALBEDO_FROM_VERTEX_COLOR, true);

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -738,7 +738,7 @@ public:
 	static void finish_shaders();
 	static void flush_changes();
 
-	static Ref<Material> get_material_for_2d(bool p_shaded, bool p_transparent, bool p_double_sided, bool p_cut_alpha, bool p_opaque_prepass, bool p_billboard = false, bool p_billboard_y = false, RID *r_shader_rid = nullptr);
+	static Ref<Material> get_material_for_2d(bool p_shaded, bool p_transparent, bool p_normal_mapping, bool p_double_sided, bool p_cut_alpha, bool p_opaque_prepass, bool p_billboard = false, bool p_billboard_y = false, RID *r_shader_rid = nullptr);
 
 	virtual RID get_shader_rid() const override;
 


### PR DESCRIPTION
Hello, first time attempting a contribution here :)

This PR enables Sprite3D to have a configurable normal map texture.

It would come handy in a project of mine using 3D to render pixel art with day/night cycle, and I saw many people asking about this feature. Current workaround is using a quad mesh, but it can get cumbersome as it requires creating many materials and fine tune the mesh dimensions to get it right.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/3979.*