### PR TITLE
Remove references to Control class from Popup and PopupMenu description

### DIFF
--- a/doc/classes/Popup.xml
+++ b/doc/classes/Popup.xml
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Popup" inherits="Window" version="4.0">
 	<brief_description>
-		Base container control for popups and dialogs.
+		Popup is a base window container for popup-like subwindows.
 	</brief_description>
 	<description>
-		Popup is a base [Control] used to show dialogs and popups. It's a subwindow and modal by default (see [Control]) and has helpers for custom popup behavior.
+		Popup is a base window container for popup-like subwindows. It's a modal by default (see [member close_on_parent_focus]) and has helpers for custom popup behavior.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="borderless" type="bool" setter="set_flag" getter="get_flag" overrides="Window" default="true" />
 		<member name="close_on_parent_focus" type="bool" setter="set_close_on_parent_focus" getter="get_close_on_parent_focus" default="true">
-			If [code]true[/code], the [Popup] will close when its parent is focused.
+			If true, the [Popup] will close when its parent [Window] is focused.
 		</member>
 		<member name="transient" type="bool" setter="set_transient" getter="is_transient" overrides="Window" default="true" />
 		<member name="unresizable" type="bool" setter="set_flag" getter="get_flag" overrides="Window" default="true" />
@@ -21,7 +21,7 @@
 	<signals>
 		<signal name="popup_hide">
 			<description>
-				Emitted when a popup is hidden.
+				Emitted when the popup is hidden.
 			</description>
 		</signal>
 	</signals>

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -4,7 +4,7 @@
 		PopupMenu displays a list of options.
 	</brief_description>
 	<description>
-		[PopupMenu] is a [Control] that displays a list of options. They are popular in toolbars or context menus.
+		[PopupMenu] is a modal window used to display a list of options. They are popular in toolbars or context menus.
 		The size of a [PopupMenu] can be limited by using [member Window.max_size]. If the height of the list of items is larger than the maximum height of the [PopupMenu], a [ScrollContainer] within the popup will allow the user to scroll the contents.
 		If no maximum size is set, or if it is set to 0, the [PopupMenu] height will be limited by its parent rect.
 	</description>


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Both classes do not inherit from Control, but the description gives the impression, that they do.
