### PR TITLE
VK_VERSION_* have been deprecated, replaced by VK_API_VERSION_*

### DIFF
--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -273,9 +273,9 @@ Error VulkanContext::_obtain_vulkan_version() {
 		uint32_t api_version;
 		VkResult res = func(&api_version);
 		if (res == VK_SUCCESS) {
-			vulkan_major = VK_VERSION_MAJOR(api_version);
-			vulkan_minor = VK_VERSION_MINOR(api_version);
-			vulkan_patch = VK_VERSION_PATCH(api_version);
+			vulkan_major = VK_API_VERSION_MAJOR(api_version);
+			vulkan_minor = VK_API_VERSION_MINOR(api_version);
+			vulkan_patch = VK_API_VERSION_PATCH(api_version);
 		} else {
 			// according to the documentation this shouldn't fail with anything except a memory allocation error
 			// in which case we're in deep trouble anyway


### PR DESCRIPTION
Nitpicking, `VK_VERSION_*` have been deprecated, replaced by `VK_API_VERSION_*`. Was pointed out to me and just putting it in as a quick fix. 

Note that there is also a new macro here: `VK_API_VERSION_VARIANT`
Currently we ignore this value, we may need to look into that further.

