### PR TITLE
Remove code to update the layout direction of submenus from `PopupMenu`

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -435,7 +435,7 @@
 		<constant name="CONTENT_SCALE_ASPECT_EXPAND" value="4" enum="ContentScaleAspect">
 		</constant>
 		<constant name="LAYOUT_DIRECTION_INHERITED" value="0" enum="LayoutDirection">
-			Automatic layout direction, determined from the parent control layout direction.
+			Automatic layout direction, determined from the parent window layout direction.
 		</constant>
 		<constant name="LAYOUT_DIRECTION_LOCALE" value="1" enum="LayoutDirection">
 			Automatic layout direction, determined from the current locale.

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -736,26 +736,7 @@ void PopupMenu::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_THEME_CHANGED:
-		case Control::NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
-			// Pass the layout direction to all submenus.
-			for (int i = 0; i < items.size(); i++) {
-				if (items[i].submenu.is_empty()) {
-					continue;
-				}
-
-				Node *n = get_node(items[i].submenu);
-				if (!n) {
-					continue;
-				}
-
-				PopupMenu *pm = Object::cast_to<PopupMenu>(n);
-				if (pm) {
-					pm->set_layout_direction(get_layout_direction());
-				}
-			}
-
-			[[fallthrough]];
-		}
+		case Control::NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			for (int i = 0; i < items.size(); i++) {
 				items.write[i].xl_text = atr(items[i].text);


### PR DESCRIPTION
This bit of code when updating the `PopupMenu` in previous commits was pointless.

I also updated the docs about `Window`'s `set_layout_direction()` to properly say that it inherits its layout direction from parent `Window`s, and not `Control`s.