### PR TITLE
Correct C# code example in Color class reference

### DIFF
--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -221,14 +221,15 @@
 				Returns a new color from [code]rgba[/code], an HTML hexadecimal color string. [code]rgba[/code] is not case sensitive, and may be prefixed with a '#' character.
 				[code]rgba[/code] must be a valid three-digit or six-digit hexadecimal color string, and may contain an alpha channel value. If [code]rgba[/code] does not contain an alpha channel value, an alpha channel value of 1.0 is applied.
 				If [code]rgba[/code] is invalid a Color(0.0, 0.0, 0.0, 1.0) is returned.
+				[b]Note:[/b] This method is not implemented in C#, but the same functionality is provided in the class constructor.
 				[codeblocks]
 				[gdscript]
 				var green = Color.html("#00FF00FF") # set green to Color(0.0, 1.0, 0.0, 1.0)
 				var blue = Color.html("#0000FF") # set blue to Color(0.0, 0.0, 1.0, 1.0)
 				[/gdscript]
 				[csharp]
-				var green = Color.Html("#00FF00FF"); // set green to Color(0.0, 1.0, 0.0, 1.0)
-				var blue = Color.Html("#0000FF"); // set blue to Color(0.0, 0.0, 1.0, 1.0)
+				var green = new Color("#00FF00FF"); // set green to Color(0.0, 1.0, 0.0, 1.0)
+				var blue = new Color("#0000FF"); // set blue to Color(0.0, 0.0, 1.0, 1.0)
 				[/csharp]
 				[/codeblocks]
 			</description>


### PR DESCRIPTION
Correct C# example code for `html` method in the Color class reference. The code was recently added in #57785 but changes are required to show the proper usage and C# implementation.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
