### PR TITLE
PopupMenu: Fix `get_node` error on shutdown

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -743,7 +743,7 @@ void PopupMenu::_notification(int p_what) {
 					continue;
 				}
 
-				Node *n = get_node(items[i].submenu);
+				Node *n = get_node_or_null(items[i].submenu);
 				if (!n) {
 					continue;
 				}


### PR DESCRIPTION
Closing the editor would raise this error:
```
ERROR: Cannot get path of node as it is not in a scene tree.
   at: get_path (scene/main/node.cpp:1592)
ERROR: Node not found: "Version Control" (relative to "").
   at: get_node (scene/main/node.cpp:1328)
```

This was a regression from #57735. This might not be the best fix, it just silences the errors, but good enough for 4.0 alpha 2.