### PR TITLE
Added Method to position_caret_at_end on LineEdit

### DIFF
--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -166,7 +166,9 @@ Vector<String> FileDialog::get_selected_files() const {
 };
 
 void FileDialog::update_dir() {
-	dir->set_text(dir_access->get_current_dir(false));
+	String _current_dir = dir_access->get_current_dir(false);
+	dir->set_text(_current_dir);
+	dir->set_caret_column(_current_dir.size());
 
 	if (drives->is_visible()) {
 		if (dir_access->get_current_dir().is_network_share_path()) {


### PR DESCRIPTION
In the File Dialog (e.g. in Project Manager -> Import -> Browse), when entering a directory path and hitting enter, the caret resets back to position 0. This can be annoying for the user.

This PR adds a new method `position_caret_at_end()` on `LineEdit`.

The method is used on the `FileDialog ` to prevent the above mentioned behavior.

The `set_text` method is resetting the caret and scroll position to 0 every time this setter is called. My first attempt was to add a control flat to the setter, whether the caret should reset or not. The doctool then highlighted my mistake of  adding another parameter to a setter method.
I'm feeling that this setter method might be doing too much (i.e. resetting the caret), but this probably has a very good reason. That's why I decided to add a new method to explicitly set the caret to the end.
