### PR TITLE
Fix crash when dragging array members in inspector

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -638,6 +638,10 @@ void EditorPropertyArray::_reorder_button_gui_input(const Ref<InputEvent> &p_eve
 			vbox->move_child(reorder_selected_element_hbox, reorder_to_index % page_length + 2);
 			// Ensure the moving element is visible.
 			InspectorDock::get_inspector_singleton()->ensure_control_visible(reorder_selected_element_hbox);
+
+			if ((reorder_to_index == 0 && reorder_mouse_y_delta < 0.0f) || (reorder_to_index == size - 1 && reorder_mouse_y_delta > 0.0f)) {
+				reorder_mouse_y_delta = 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
To fix #57745 - it actually happens with any types, not just Vector2, reproduced on Windows 10 x64 on master branch.

When clicking and dragging, if you move the mouse rapidly enough you can accumulate enough mouse delta to move multiple indexes in one frame, then when the mouse stops moving or moves the other way, the check on line 623 does not return and the child can be inserted out of bounds. Zeroing out the mouse delta if we hit the first or last indexes prevents this.

Submitting as a draft PR because there is probably a smarter way to refactor this whole section.

