### PR TITLE
Improved region-select in the 3D editor viewport

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1468,6 +1468,8 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			} break;
 			case MouseButton::LEFT: {
 				if (b->is_pressed()) {
+					clicked_wants_append = b->is_shift_pressed();
+
 					if (_edit.mode != TRANSFORM_NONE && _edit.instant) {
 						commit_transform();
 						break; // just commit the edit, stop processing the event so we don't deselect the object
@@ -1597,8 +1599,6 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 
 						//clicking is always deferred to either move or release
 
-						clicked_wants_append = b->is_shift_pressed();
-
 						if (clicked.is_null()) {
 							//default to regionselect
 							cursor.region_select = true;
@@ -1725,6 +1725,12 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 					clicked = ObjectID();
 
 					_edit.mode = TRANSFORM_TRANSLATE;
+				}
+
+				// enable region-select if nothing has been selected yet or multi-select (shift key) is active
+				if (movement_threshold_passed && (get_selected_count() == 0 || clicked_wants_append)) {
+					cursor.region_select = true;
+					cursor.region_begin = _edit.original_mouse_pos;
 				}
 
 				if (cursor.region_select) {


### PR DESCRIPTION
It was impossible to batch select something (region selection) in the 3D editor when the scene covered the whole screen (i.e. when you start your selection by clicking on a mesh and then start dragging). This is really important when working on big 3D scenes (it's also how it works in Unity). This bugged me for a long time, so i decided to fix it. It's a small enough change that i don't think this requires a formal proposal.

The behaviour is now as follows:
- User clicks on nothing and starts dragging -> region selection starts (old behaviour)
- User clicks on a mesh and releases immediately -> selects the one mesh only (old behaviour)
- User clicks on a mesh and then starts dragging WITHOUT releasing the mouse -> region selection starts. Previously in this case nothing would have been selected at all.
- Multi select while holding shift works with both single click or rectangular selection (or both in combination)

### Before

https://user-images.githubusercontent.com/8750135/153169710-4cead197-2b0f-4523-a4a4-d6b049219ee5.mp4

### After

https://user-images.githubusercontent.com/8750135/153168750-b62386af-11ad-4f8e-8866-011202fd99f6.mp4

### Test Project
[SelectionTest.zip](https://github.com/godotengine/godot/files/8031409/SelectionTest.zip)
