### PR TITLE
Separate 2D grid visibility and grid snap

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -116,7 +116,6 @@ private:
 		SNAP_RELATIVE,
 		SNAP_CONFIGURE,
 		SNAP_USE_PIXEL,
-		SHOW_GRID,
 		SHOW_HELPERS,
 		SHOW_RULERS,
 		SHOW_GUIDES,
@@ -175,6 +174,12 @@ private:
 		DRAG_KEY_MOVE
 	};
 
+	enum GridVisibility {
+		GRID_VISIBILITY_SHOW,
+		GRID_VISIBILITY_SHOW_WHEN_SNAPPING,
+		GRID_VISIBILITY_HIDE,
+	};
+
 	bool selection_menu_additive_selection;
 
 	Tool tool = TOOL_SELECT;
@@ -190,7 +195,7 @@ private:
 	HBoxContainer *hbc_context_menu;
 
 	Transform2D transform;
-	bool show_grid = false;
+	GridVisibility grid_visibility = GRID_VISIBILITY_SHOW_WHEN_SNAPPING;
 	bool show_rulers = true;
 	bool show_guides = true;
 	bool show_origin = true;
@@ -314,6 +319,7 @@ private:
 	MenuButton *skeleton_menu;
 	Button *override_camera_button;
 	MenuButton *view_menu;
+	PopupMenu *grid_menu;
 	HBoxContainer *animation_hb;
 	MenuButton *animation_menu;
 
@@ -390,6 +396,9 @@ private:
 	void _node_created(Node *p_node);
 	void _reset_create_position();
 	void _update_editor_settings();
+	bool _is_grid_visible() const;
+	void _prepare_grid_menu();
+	void _on_grid_menu_id_pressed(int p_id);
 
 	UndoRedo *undo_redo;
 


### PR DESCRIPTION
Splits "Always Show Grid" option into a submenu:

* Show
    * Always show grid.
* Show when snapping:
    * Show when grid snapping is on.
    * Name taken from https://github.com/godotengine/godot/issues/34386#issuecomment-578439879
* Hide
    * Always hide grid.
* Toggle Grid
    * Go to the least restrictive option possible.
    * Follows logic from https://github.com/godotengine/godot/issues/34386#issuecomment-578437218
    * The default shortcut (NumberSign `#`) may not work because it conflicts with the "zoom 12.5%" shortcut. This is an existing issue. Please change the shortcut if you want to test it.

![ksnip_20220209-180301](https://user-images.githubusercontent.com/372476/153175301-2c0b2fd1-bcd7-4572-9b14-005620fcbdd8.png)

Closes #34386
Supersedes #35565