### PR TITLE
Only store `_edit_use_anchors_` metadata if value is not the default

### DIFF
--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -504,9 +504,13 @@ void ControlEditorToolbar::_set_anchors_and_offsets_to_keep_ratio() {
 			undo_redo->add_do_method(control, "set_anchor", SIDE_BOTTOM, bottom_right_anchor.y, false, true);
 			undo_redo->add_do_method(control, "set_meta", "_edit_use_anchors_", true);
 
-			bool use_anchors = control->has_meta("_edit_use_anchors_") && control->get_meta("_edit_use_anchors_");
+			const bool use_anchors = control->has_meta("_edit_use_anchors_") && control->get_meta("_edit_use_anchors_");
 			undo_redo->add_undo_method(control, "_edit_set_state", control->_edit_get_state());
-			undo_redo->add_undo_method(control, "set_meta", "_edit_use_anchors_", use_anchors);
+			if (use_anchors) {
+				undo_redo->add_undo_method(control, "set_meta", "_edit_use_anchors_", true);
+			} else {
+				undo_redo->add_undo_method(control, "remove_meta", "_edit_use_anchors_");
+			}
 
 			anchors_mode = true;
 			anchor_mode_button->set_pressed(anchors_mode);
@@ -596,7 +600,11 @@ void ControlEditorToolbar::_button_toggle_anchor_mode(bool p_status) {
 			continue;
 		}
 
-		E->set_meta("_edit_use_anchors_", p_status);
+		if (p_status) {
+			E->set_meta("_edit_use_anchors_", true);
+		} else {
+			E->remove_meta("_edit_use_anchors_");
+		}
 	}
 
 	anchors_mode = p_status;


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/58254.

The default value is assumed to be `false`, so this metadata only needs to be stored if the value is `true`.

This closes https://github.com/godotengine/godot/issues/57862.

*Bugsquad edit (keywords for easier searching): edit_use_anchors*