### PR TITLE
use exact match when checking focus next / previous

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2464,11 +2464,11 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					next = from->_get_focus_neighbour(MARGIN_BOTTOM);
 				}
 			} else {
-				if (p_event->is_action_pressed("ui_focus_next", true)) {
+				if (p_event->is_action_pressed("ui_focus_next", true, true)) {
 					next = from->find_next_valid_focus();
 				}
 
-				if (p_event->is_action_pressed("ui_focus_prev", true)) {
+				if (p_event->is_action_pressed("ui_focus_prev", true, true)) {
 					next = from->find_prev_valid_focus();
 				}
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/57854