### PR TITLE
Consistent capitalization of default scene file names

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2605,9 +2605,9 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 					case SCENE_NAME_CASING_AUTO:
 						// Use casing of the root node.
 						break;
-					case SCENE_NAME_CASING_PASCAL_CASE: {
+					case SCENE_NAME_CASING_PASCAL_CASE:
 						root_name = root_name.capitalize().replace(" ", "");
-					} break;
+						break;
 					case SCENE_NAME_CASING_SNAKE_CASE:
 						root_name = root_name.capitalize().replace(" ", "").replace("-", "_").camelcase_to_underscore();
 						break;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -111,6 +111,12 @@ public:
 		DOCK_SLOT_MAX
 	};
 
+	enum ScriptNameCasing {
+		SCENE_NAME_CASING_AUTO,
+		SCENE_NAME_CASING_PASCAL_CASE,
+		SCENE_NAME_CASING_SNAKE_CASE
+	};
+
 	struct ExecuteThreadArgs {
 		String path;
 		List<String> args;
@@ -214,12 +220,6 @@ private:
 		IMPORT_PLUGIN_BASE = 100,
 
 		TOOL_MENU_BASE = 1000
-	};
-
-	enum ScriptNameCasing {
-		SCENE_NAME_CASING_AUTO,
-		SCENE_NAME_CASING_PASCAL_CASE,
-		SCENE_NAME_CASING_SNAKE_CASE
 	};
 
 	SubViewport *scene_root; // root of the scene being edited

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -906,6 +906,17 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 			String existing;
 			if (extensions.size()) {
 				String root_name(tocopy->get_name());
+				switch (ProjectSettings::get_singleton()->get("editor/scene/scene_naming").operator int()) {
+					case EditorNode::SCENE_NAME_CASING_AUTO:
+						// Use casing of the root node.
+						break;
+					case EditorNode::SCENE_NAME_CASING_PASCAL_CASE:
+						root_name = root_name.capitalize().replace(" ", "");
+						break;
+					case EditorNode::SCENE_NAME_CASING_SNAKE_CASE:
+						root_name = root_name.capitalize().replace(" ", "").replace("-", "_").camelcase_to_underscore();
+						break;
+				}
 				existing = root_name + "." + extensions.front()->get().to_lower();
 			}
 			new_scene_from_dialog->set_current_path(existing);


### PR DESCRIPTION
Fix for [#57768](https://github.com/godotengine/godot/issues/57768)

Found the "save node as scene" not using the default scene naming convention from settings, so I made the enum from `editor_node.h` public to use it in `scene_tree_dock.cpp`.

Also removed unnecessary braces.
