### PR TITLE
Add `EditorPaginator` and unify array, dictionary, and inspector array editors

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -317,18 +317,11 @@ class EditorInspectorArray : public EditorInspectorSection {
 	LineEdit *new_size_line_edit;
 
 	// Pagination
-	int page_lenght = 5;
+	int page_length = 5;
 	int page = 0;
 	int max_page = 0;
 	int begin_array_index = 0;
 	int end_array_index = 0;
-	HBoxContainer *hbox_pagination;
-	Button *first_page_button;
-	Button *prev_page_button;
-	LineEdit *page_line_edit;
-	Label *page_count_label;
-	Button *next_page_button;
-	Button *last_page_button;
 
 	enum MenuOptions {
 		OPTION_MOVE_UP = 0,
@@ -356,12 +349,7 @@ class EditorInspectorArray : public EditorInspectorSection {
 
 	int _get_array_count();
 	void _add_button_pressed();
-
-	void _first_page_button_pressed();
-	void _prev_page_button_pressed();
-	void _page_line_edit_text_submitted(String p_text);
-	void _next_page_button_pressed();
-	void _last_page_button_pressed();
+	void _paginator_page_changed(int p_page);
 
 	void _rmb_popup_id_pressed(int p_id);
 
@@ -400,6 +388,34 @@ public:
 	VBoxContainer *get_vbox(int p_index);
 
 	EditorInspectorArray();
+};
+
+class EditorPaginator : public HBoxContainer {
+	GDCLASS(EditorPaginator, HBoxContainer);
+
+	int page = 0;
+	int max_page = 0;
+	Button *first_page_button;
+	Button *prev_page_button;
+	LineEdit *page_line_edit;
+	Label *page_count_label;
+	Button *next_page_button;
+	Button *last_page_button;
+
+	void _first_page_button_pressed();
+	void _prev_page_button_pressed();
+	void _page_line_edit_text_submitted(String p_text);
+	void _next_page_button_pressed();
+	void _last_page_button_pressed();
+
+protected:
+	void _notification(int p_what);
+	static void _bind_methods();
+
+public:
+	void update(int p_page, int p_max_page);
+
+	EditorPaginator();
 };
 
 class EditorInspector : public ScrollContainer {

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -259,8 +259,8 @@ void EditorPropertyArray::update_property() {
 	}
 
 	int size = array.call("size");
-	int pages = MAX(0, size - 1) / page_length + 1;
-	page_index = MIN(page_index, pages - 1);
+	int max_page = MAX(0, size - 1) / page_length;
+	page_index = MIN(page_index, max_page);
 	int offset = page_index * page_length;
 
 	edit->set_text(arrtype + " (size " + itos(size) + ")");
@@ -292,35 +292,37 @@ void EditorPropertyArray::update_property() {
 			size_slider->connect("value_changed", callable_mp(this, &EditorPropertyArray::_length_changed));
 			hbox->add_child(size_slider);
 
-			page_hbox = memnew(HBoxContainer);
-			vbox->add_child(page_hbox);
+			property_vbox = memnew(VBoxContainer);
+			property_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+			vbox->add_child(property_vbox);
 
-			label = memnew(Label(TTR("Page: ")));
-			label->set_h_size_flags(SIZE_EXPAND_FILL);
-			page_hbox->add_child(label);
+			button_add_item = memnew(Button);
+			button_add_item->set_text(TTR("Add Element"));
+			button_add_item->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+			button_add_item->connect(SNAME("pressed"), callable_mp(this, &EditorPropertyArray::_add_element));
+			vbox->add_child(button_add_item);
 
-			page_slider = memnew(EditorSpinSlider);
-			page_slider->set_step(1);
-			page_slider->set_h_size_flags(SIZE_EXPAND_FILL);
-			page_slider->connect("value_changed", callable_mp(this, &EditorPropertyArray::_page_changed));
-			page_hbox->add_child(page_slider);
+			paginator = memnew(EditorPaginator);
+			paginator->connect("page_changed", callable_mp(this, &EditorPropertyArray::_page_changed));
+			vbox->add_child(paginator);
 		} else {
 			// Bye bye children of the box.
-			for (int i = vbox->get_child_count() - 1; i >= 2; i--) {
-				Node *child = vbox->get_child(i);
+			for (int i = property_vbox->get_child_count() - 1; i >= 0; i--) {
+				Node *child = property_vbox->get_child(i);
 				if (child == reorder_selected_element_hbox) {
 					continue; // Don't remove the property that the user is moving.
 				}
 
 				child->queue_delete(); // Button still needed after pressed is called.
-				vbox->remove_child(child);
+				property_vbox->remove_child(child);
 			}
 		}
 
 		size_slider->set_value(size);
-		page_slider->set_max(pages);
-		page_slider->set_value(page_index);
-		page_hbox->set_visible(pages > 1);
+		property_vbox->set_visible(size > 0);
+		button_add_item->set_visible(page_index == max_page);
+		paginator->update(page_index, max_page);
+		paginator->set_visible(max_page > 0);
 
 		if (array.get_type() == Variant::ARRAY) {
 			array = array.call("duplicate");
@@ -343,7 +345,7 @@ void EditorPropertyArray::update_property() {
 			}
 
 			HBoxContainer *hbox = memnew(HBoxContainer);
-			vbox->add_child(hbox);
+			property_vbox->add_child(hbox);
 
 			Button *reorder_button = memnew(Button);
 			reorder_button->set_icon(get_theme_icon(SNAME("TripleBar"), SNAME("EditorIcons")));
@@ -397,7 +399,7 @@ void EditorPropertyArray::update_property() {
 		}
 
 		if (reorder_to_index % page_length > 0) {
-			vbox->move_child(vbox->get_child(2), reorder_to_index % page_length + 2);
+			property_vbox->move_child(property_vbox->get_child(0), reorder_to_index % page_length);
 		}
 
 		updating = false;
@@ -510,6 +512,10 @@ void EditorPropertyArray::_notification(int p_what) {
 		}
 		change_type->add_separator();
 		change_type->add_icon_item(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), TTR("Remove Item"), Variant::VARIANT_MAX);
+
+		if (Object::cast_to<Button>(button_add_item)) {
+			button_add_item->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+		}
 	}
 
 	if (p_what == NOTIFICATION_DRAG_BEGIN) {
@@ -542,7 +548,7 @@ void EditorPropertyArray::_edit_pressed() {
 	update_property();
 }
 
-void EditorPropertyArray::_page_changed(double p_page) {
+void EditorPropertyArray::_page_changed(int p_page) {
 	if (updating) {
 		return;
 	}
@@ -589,6 +595,10 @@ void EditorPropertyArray::_length_changed(double p_page) {
 	update_property();
 }
 
+void EditorPropertyArray::_add_element() {
+	_length_changed(double(object->get_array().call("size")) + 1.0);
+}
+
 void EditorPropertyArray::setup(Variant::Type p_array_type, const String &p_hint_string) {
 	array_type = p_array_type;
 
@@ -633,9 +643,9 @@ void EditorPropertyArray::_reorder_button_gui_input(const Ref<InputEvent> &p_eve
 			reorder_to_index += direction;
 			if ((direction < 0 && reorder_to_index % page_length == page_length - 1) || (direction > 0 && reorder_to_index % page_length == 0)) {
 				// Automatically move to the next/previous page.
-				page_slider->set_value(page_index + direction);
+				_page_changed(page_index + direction);
 			}
-			vbox->move_child(reorder_selected_element_hbox, reorder_to_index % page_length + 2);
+			property_vbox->move_child(reorder_selected_element_hbox, reorder_to_index % page_length);
 			// Ensure the moving element is visible.
 			InspectorDock::get_inspector_singleton()->ensure_control_visible(reorder_selected_element_hbox);
 		}
@@ -645,7 +655,7 @@ void EditorPropertyArray::_reorder_button_gui_input(const Ref<InputEvent> &p_eve
 void EditorPropertyArray::_reorder_button_down(int p_index) {
 	reorder_from_index = p_index;
 	reorder_to_index = p_index;
-	reorder_selected_element_hbox = Object::cast_to<HBoxContainer>(vbox->get_child(p_index % page_length + 2));
+	reorder_selected_element_hbox = Object::cast_to<HBoxContainer>(property_vbox->get_child(p_index % page_length));
 	reorder_selected_button = Object::cast_to<Button>(reorder_selected_element_hbox->get_child(0));
 	// Ideally it'd to be able to show the mouse but I had issues with
 	// Control's `mouse_exit()`/`mouse_entered()` signals not getting called.
@@ -685,6 +695,7 @@ void EditorPropertyArray::_bind_methods() {
 EditorPropertyArray::EditorPropertyArray() {
 	object.instantiate();
 	page_length = int(EDITOR_GET("interface/inspector/max_array_dictionary_items_per_page"));
+
 	edit = memnew(Button);
 	edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit->set_clip_text(true);
@@ -694,9 +705,12 @@ EditorPropertyArray::EditorPropertyArray() {
 	edit->connect("draw", callable_mp(this, &EditorPropertyArray::_button_draw));
 	add_child(edit);
 	add_focusable(edit);
+
 	vbox = nullptr;
-	page_slider = nullptr;
+	property_vbox = nullptr;
 	size_slider = nullptr;
+	button_add_item = nullptr;
+	paginator = nullptr;
 	updating = false;
 	change_type = memnew(PopupMenu);
 	add_child(change_type);
@@ -824,35 +838,32 @@ void EditorPropertyDictionary::update_property() {
 			add_child(vbox);
 			set_bottom_editor(vbox);
 
-			page_hbox = memnew(HBoxContainer);
-			vbox->add_child(page_hbox);
-			Label *label = memnew(Label(TTR("Page: ")));
-			label->set_h_size_flags(SIZE_EXPAND_FILL);
-			page_hbox->add_child(label);
-			page_slider = memnew(EditorSpinSlider);
-			page_slider->set_step(1);
-			page_hbox->add_child(page_slider);
-			page_slider->set_h_size_flags(SIZE_EXPAND_FILL);
-			page_slider->connect("value_changed", callable_mp(this, &EditorPropertyDictionary::_page_changed));
+			property_vbox = memnew(VBoxContainer);
+			property_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
+			vbox->add_child(property_vbox);
+
+			paginator = memnew(EditorPaginator);
+			paginator->connect("page_changed", callable_mp(this, &EditorPropertyDictionary::_page_changed));
+			vbox->add_child(paginator);
 		} else {
 			// Queue children for deletion, deleting immediately might cause errors.
-			for (int i = 1; i < vbox->get_child_count(); i++) {
-				vbox->get_child(i)->queue_delete();
+			for (int i = property_vbox->get_child_count() - 1; i >= 0; i--) {
+				property_vbox->get_child(i)->queue_delete();
 			}
 		}
 
 		int size = dict.size();
 
-		int pages = MAX(0, size - 1) / page_length + 1;
+		int max_page = MAX(0, size - 1) / page_length;
+		page_index = MIN(page_index, max_page);
 
-		page_slider->set_max(pages);
-		page_index = MIN(page_index, pages - 1);
-		page_slider->set_value(page_index);
-		page_hbox->set_visible(pages > 1);
+		paginator->update(page_index, max_page);
+		paginator->set_visible(max_page > 0);
 
 		int offset = page_index * page_length;
 
 		int amount = MIN(size - offset, page_length);
+		int total_amount = page_index == max_page ? amount + 2 : amount; // For the "Add Key/Value Pair" box on last page.
 
 		dict = dict.duplicate();
 
@@ -860,7 +871,7 @@ void EditorPropertyDictionary::update_property() {
 		VBoxContainer *add_vbox = nullptr;
 		double default_float_step = EDITOR_GET("interface/inspector/default_float_step");
 
-		for (int i = 0; i < amount + 2; i++) {
+		for (int i = 0; i < total_amount; i++) {
 			String prop_name;
 			Variant key;
 			Variant value;
@@ -1074,15 +1085,9 @@ void EditorPropertyDictionary::update_property() {
 
 			if (i == amount) {
 				PanelContainer *pc = memnew(PanelContainer);
-				vbox->add_child(pc);
-				Ref<StyleBoxFlat> flat;
-				flat.instantiate();
-				for (int j = 0; j < 4; j++) {
-					flat->set_default_margin(Side(j), 2 * EDSCALE);
-				}
-				flat->set_bg_color(get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));
+				property_vbox->add_child(pc);
+				pc->add_theme_style_override(SNAME("panel"), get_theme_stylebox(SNAME("DictionaryAddItem"), SNAME("EditorStyles")));
 
-				pc->add_theme_style_override("panel", flat);
 				add_vbox = memnew(VBoxContainer);
 				pc->add_child(add_vbox);
 			}
@@ -1110,7 +1115,7 @@ void EditorPropertyDictionary::update_property() {
 			if (add_vbox) {
 				add_vbox->add_child(hbox);
 			} else {
-				vbox->add_child(hbox);
+				property_vbox->add_child(hbox);
 			}
 			hbox->add_child(prop);
 			prop->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1173,7 +1178,7 @@ void EditorPropertyDictionary::_edit_pressed() {
 	update_property();
 }
 
-void EditorPropertyDictionary::_page_changed(double p_page) {
+void EditorPropertyDictionary::_page_changed(int p_page) {
 	if (updating) {
 		return;
 	}
@@ -1187,6 +1192,7 @@ void EditorPropertyDictionary::_bind_methods() {
 EditorPropertyDictionary::EditorPropertyDictionary() {
 	object.instantiate();
 	page_length = int(EDITOR_GET("interface/inspector/max_array_dictionary_items_per_page"));
+
 	edit = memnew(Button);
 	edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	edit->set_clip_text(true);
@@ -1194,9 +1200,10 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 	edit->set_toggle_mode(true);
 	add_child(edit);
 	add_focusable(edit);
+
 	vbox = nullptr;
-	page_slider = nullptr;
 	button_add_item = nullptr;
+	paginator = nullptr;
 	updating = false;
 	change_type = memnew(PopupMenu);
 	add_child(change_type);

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -89,9 +89,10 @@ class EditorPropertyArray : public EditorProperty {
 	int changing_type_index;
 	Button *edit;
 	VBoxContainer *vbox;
+	VBoxContainer *property_vbox;
 	EditorSpinSlider *size_slider;
-	EditorSpinSlider *page_slider;
-	HBoxContainer *page_hbox;
+	Button *button_add_item;
+	EditorPaginator *paginator;
 	Variant::Type array_type;
 	Variant::Type subtype;
 	PropertyHint subtype_hint;
@@ -103,8 +104,9 @@ class EditorPropertyArray : public EditorProperty {
 	HBoxContainer *reorder_selected_element_hbox = nullptr;
 	Button *reorder_selected_button = nullptr;
 
-	void _page_changed(double p_page);
+	void _page_changed(int p_page);
 	void _length_changed(double p_page);
+	void _add_element();
 	void _edit_pressed();
 	void _property_changed(const String &p_property, Variant p_value, const String &p_name = "", bool p_changing = false);
 	void _change_type(Object *p_button, int p_index);
@@ -144,12 +146,12 @@ class EditorPropertyDictionary : public EditorProperty {
 	int changing_type_index;
 	Button *edit;
 	VBoxContainer *vbox;
+	VBoxContainer *property_vbox;
 	EditorSpinSlider *size_slider;
-	EditorSpinSlider *page_slider;
-	HBoxContainer *page_hbox;
 	Button *button_add_item;
+	EditorPaginator *paginator;
 
-	void _page_changed(double p_page);
+	void _page_changed(int p_page);
 	void _edit_pressed();
 	void _property_changed(const String &p_property, Variant p_value, const String &p_name = "", bool p_changing = false);
 	void _change_type(Object *p_button, int p_index);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1501,6 +1501,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	Ref<StyleBoxFlat> theme_preview_picker_label_sb = make_flat_stylebox(theme_preview_picker_label_bg_color, 4.0, 1.0, 4.0, 3.0);
 	theme->set_stylebox("preview_picker_label", "ThemeEditor", theme_preview_picker_label_sb);
 
+	// Dictionary editor add item.
+	theme->set_stylebox("DictionaryAddItem", "EditorStyles", make_flat_stylebox(prop_subsection_color, 4, 4, 4, 4, corner_radius));
+
 	// adaptive script theme constants
 	// for comments and elements with lower relevance
 	const Color dim_color = Color(font_color.r, font_color.g, font_color.b, 0.5);


### PR DESCRIPTION
This PR makes a few improvements to the array and dictionary editors:
* Extracts the paginator from `EditorInspectorArray` into a new class, `EditorPaginator`. 
* Replaces the page sliders in the array and dictionary editors with `EditorPaginator`.
* Adds an "Add Element" button to the end of the array editor.
* Makes the "Add Key/Value Pair" box only appear on the last page of the dictionary editor.

![image](https://user-images.githubusercontent.com/67974470/153242443-cf3fb12a-80a0-414d-9247-0aa13b021348.png)
![image](https://user-images.githubusercontent.com/67974470/153243695-89c537bc-2adc-4801-9372-ad2edbf226b4.png)
