### PR TITLE
Add get_content_width method to RichTextLabel

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -55,6 +55,12 @@
 				Returns the height of the content.
 			</description>
 		</method>
+		<method name="get_content_width" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the width of the content.
+			</description>
+		</method>
 		<method name="get_line_count" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4157,6 +4157,14 @@ int RichTextLabel::get_content_height() const {
 	return total_height;
 }
 
+int RichTextLabel::get_content_width() const {
+	int total_width = 0;
+	for (int i = 0; i < main->lines.size(); i++) {
+		total_width = MAX(total_width, main->lines[i].offset.x + main->lines[i].text_buf->get_size().x);
+	}
+	return total_width;
+}
+
 #ifndef DISABLE_DEPRECATED
 // People will be very angry, if their texts get erased, because of #39148. (3.x -> 4.0)
 // Although some people may not used bbcode_text, so we only overwrite, if bbcode_text is not empty.
@@ -4279,6 +4287,7 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_visible_paragraph_count"), &RichTextLabel::get_visible_paragraph_count);
 
 	ClassDB::bind_method(D_METHOD("get_content_height"), &RichTextLabel::get_content_height);
+	ClassDB::bind_method(D_METHOD("get_content_width"), &RichTextLabel::get_content_width);
 
 	ClassDB::bind_method(D_METHOD("parse_expressions_for_values", "expressions"), &RichTextLabel::parse_expressions_for_values);
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -554,6 +554,7 @@ public:
 	int get_visible_line_count() const;
 
 	int get_content_height() const;
+	int get_content_width() const;
 
 	VScrollBar *get_v_scroll_bar() { return vscroll; }
 


### PR DESCRIPTION
Adds a corresponding `get_content_width()` method to `RichTextLabel`.

Closes godotengine/godot-proposals#3938