### PR TITLE
Document occlusion culling classes and settings

### DIFF
--- a/doc/classes/ArrayOccluder3D.xml
+++ b/doc/classes/ArrayOccluder3D.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="ArrayOccluder3D" inherits="Occluder3D" version="4.0">
 	<brief_description>
+		3D polygon shape for use with occlusion culling in [OccluderInstance3D].
 	</brief_description>
 	<description>
+		[ArrayOccluder3D] stores an arbitrary 3D polygon shape that can be used by the engine's occlusion culling system. This is analogous to [ArrayMesh], but for occluders.
+		See [OccluderInstance3D]'s documentation for instructions on setting up occlusion culling.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/BoxOccluder3D.xml
+++ b/doc/classes/BoxOccluder3D.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="BoxOccluder3D" inherits="Occluder3D" version="4.0">
 	<brief_description>
+		Cuboid shape for use with occlusion culling in [OccluderInstance3D].
 	</brief_description>
 	<description>
+		[BoxOccluder3D] stores a cuboid shape that can be used by the engine's occlusion culling system.
+		See [OccluderInstance3D]'s documentation for instructions on setting up occlusion culling.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(1, 1, 1)">
+			The box's size in 3D units.
 		</member>
 	</members>
 </class>

--- a/doc/classes/Occluder3D.xml
+++ b/doc/classes/Occluder3D.xml
@@ -1,8 +1,11 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="Occluder3D" inherits="Resource" version="4.0">
 	<brief_description>
+		Occluder shape resource for use with occlusion culling in [OccluderInstance3D].
 	</brief_description>
 	<description>
+		[Occluder3D] stores an occluder shape that can be used by the engine's occlusion culling system.
+		See [OccluderInstance3D]'s documentation for instructions on setting up occlusion culling.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -10,11 +13,13 @@
 		<method name="get_indices" qualifiers="const">
 			<return type="PackedInt32Array" />
 			<description>
+				Returns the occluder shape's vertex indices.
 			</description>
 		</method>
 		<method name="get_vertices" qualifiers="const">
 			<return type="PackedVector3Array" />
 			<description>
+				Returns the occluder shape's vertex positions.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/OccluderInstance3D.xml
+++ b/doc/classes/OccluderInstance3D.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="OccluderInstance3D" inherits="Node3D" version="4.0">
 	<brief_description>
+		Provides occlusion culling for 3D nodes, which improves performance in closed areas.
 	</brief_description>
 	<description>
+		Occlusion culling can improve rendering performance in closed/semi-open areas by hiding geometry that is occluded by other objects.
+		The occlusion culling system is mostly static. [OccluderInstance3D]s can be moved or hidden at run-time, but doing so will trigger a background recomputation that can take several frames. It is recommended to only move [OccluderInstance3D]s sporadically (e.g. for procedural generation purposes), rather than doing so every frame.
+		The occlusion culling system works by rendering the occluders on the CPU in parallel using [url=https://www.embree.org/]Embree[/url], drawing the result to a low-resolution buffer then using this to cull 3D nodes individually. In the 3D editor, you can preview the occlusion culling buffer by choosing [b]Perspective &gt; Debug Advanced... &gt; Occlusion Culling Buffer[/b] in the top-left corner of the 3D viewport. The occlusion culling buffer quality can be adjusted in the Project Settings.
+		[b]Baking:[/b] Select an [OccluderInstance3D] node, then use the [b]Bake Occluders[/b] button at the top of the 3D editor. Only opaque materials will be taken into account; transparent materials (alpha-blended or alpha-tested) will be ignored by the occluder generation.
+		[b]Note:[/b] Occlusion culling is only effective if [member ProjectSettings.rendering/occlusion_culling/use_occlusion_culling] is [code]true[/code]. Enabling occlusion culling has a cost on the CPU. Only enable occlusion culling if you actually plan to use it. Large open scenes with few or no objects blocking the view will generally not benefit much from occlusion culling. Large open scenes generally benefit more from mesh LOD and visibility ranges ([member GeometryInstance3D.visibility_range_begin] and [member GeometryInstance3D.visibility_range_end]) compared to occlusion culling.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -11,7 +17,7 @@
 			<return type="bool" />
 			<argument index="0" name="layer_number" type="int" />
 			<description>
-				Returns whether or not the specified layer of the [member bake_mask] is enabled, given a [code]layer_number[/code] between 1 and 20.
+				Returns whether or not the specified layer of the [member bake_mask] is enabled, given a [code]layer_number[/code] between 1 and 32.
 			</description>
 		</method>
 		<method name="set_bake_mask_value">
@@ -19,16 +25,25 @@
 			<argument index="0" name="layer_number" type="int" />
 			<argument index="1" name="value" type="bool" />
 			<description>
-				Based on [code]value[/code], enables or disables the specified layer in the [member bake_mask], given a [code]layer_number[/code] between 1 and 20.
+				Based on [code]value[/code], enables or disables the specified layer in the [member bake_mask], given a [code]layer_number[/code] between 1 and 32.
 			</description>
 		</method>
 	</methods>
 	<members>
 		<member name="bake_mask" type="int" setter="set_bake_mask" getter="get_bake_mask" default="4294967295">
+			The visual layers to account for when baking for occluders. Only [MeshInstance3D]s whose [member VisualInstance3D.layers] match with this [member bake_mask] will be included in the generated occluder mesh. By default, all objects are taken into account for the occluder baking.
+			To improve performance and avoid artifacts, it is recommended to exclude dynamic objects, small objects and fixtures from the baking process by moving them to a separate visual layer and excluding this layer in [member bake_mask].
 		</member>
 		<member name="bake_simplification_distance" type="float" setter="set_bake_simplification_distance" getter="get_bake_simplification_distance" default="0.1">
+			The simplification distance to use for simplifying the generated occluder polygon (in 3D units). Higher values result in a less detailed occluder mesh, which improves performance but reduces culling accuracy.
+			The occluder geometry is rendered on the CPU, so it is important to keep its geometry as simple as possible. Since the buffer is rendered at a low resolution, less detailed occluder meshes generally still work well. The default value is fairly aggressive, so you may have to decrase it if you run into false negatives (objects being occluded even though they are visible by the camera). A value of [code]0.01[/code] will act conservatively, and will keep geometry [i]perceptually[/i] unaffected in the occlusion culling buffer. Depending on the scene, a value of [code]0.01[/code] may still simplify the mesh noticeably compared to disabling simplification entirely.
+			Setting this to [code]0.0[/code] disables simplification entirely, but vertices in the exact same position will still be merged. The mesh will also be re-indexed to reduce both the number of vertices and indices.
+			[b]Note:[/b] This uses the [url=https://meshoptimizer.org/]meshoptimizer[/url] library under the hood, similar to LOD generation.
 		</member>
 		<member name="occluder" type="Occluder3D" setter="set_occluder" getter="get_occluder">
+			The occluder resource for this [OccluderInstance3D]. You can generate an occluder resource by selecting an [OccluderInstance3D] node then using the [b]Bake Occluders[/b] button at the top of the editor.
+			You can also draw your own 2D occluder polygon by adding a new [PolygonOccluder3D] resource to the [member occluder] property in the inspector.
+			Alternatively, you can select a primitive occluder to use: [QuadOccluder3D], [BoxOccluder3D] or [SphereOccluder3D].
 		</member>
 	</members>
 </class>

--- a/doc/classes/PolygonOccluder3D.xml
+++ b/doc/classes/PolygonOccluder3D.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PolygonOccluder3D" inherits="Occluder3D" version="4.0">
 	<brief_description>
+		Flat 2D polygon shape for use with occlusion culling in [OccluderInstance3D].
 	</brief_description>
 	<description>
+		[PolygonOccluder3D] stores a polygon shape that can be used by the engine's occlusion culling system. When an [OccluderInstance3D] with a [PolygonOccluder3D] is selected in the editor, an editor will appear at the top of the 3D viewport so you can add/remove points. All points must be placed on the same 2D plane, which means it is not possible to create arbitrary 3D shapes with a single [PolygonOccluder3D]. To use arbitrary 3D shapes as occluders, use [ArrayOccluder3D] or [OccluderInstance3D]'s baking feature instead.
+		See [OccluderInstance3D]'s documentation for instructions on setting up occlusion culling.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array()">
+			The polygon to use for occlusion culling. The polygon can be convex or concave, but it should have as few points as possible to maximize performance.
+			The polygon must [i]not[/i] have intersecting lines. Otherwise, triangulation will fail (with an error message printed).
 		</member>
 	</members>
 </class>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1746,10 +1746,14 @@
 			[b]Note:[/b] This property is only read when the project starts. To adjust the automatic LOD threshold at runtime, set [member Viewport.mesh_lod_threshold] on the root [Viewport].
 		</member>
 		<member name="rendering/occlusion_culling/bvh_build_quality" type="int" setter="" getter="" default="2">
+			The [url=https://en.wikipedia.org/wiki/Bounding_volume_hierarchy]BVH[/url] quality to use when rendering the occlusion culling buffer. Higher values will result in more accurate occlusion culling, at the cost of higher CPU usage.
 		</member>
 		<member name="rendering/occlusion_culling/occlusion_rays_per_thread" type="int" setter="" getter="" default="512">
+			Higher values will result in more accurate occlusion culling, at the cost of higher CPU usage. The occlusion culling buffer's pixel count is roughly equal to [code]occlusion_rays_per_thread * number_of_logical_cpu_cores[/code], so it will depend on the system's CPU. Therefore, CPUs with fewer cores will use a lower resolution to attempt keeping performance costs even across devices.
 		</member>
 		<member name="rendering/occlusion_culling/use_occlusion_culling" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], [OccluderInstance3D] nodes will be usable for occlusion culling in 3D in the root viewport. In custom viewports, [member Viewport.use_occlusion_culling] must be set to [code]true[/code] instead.
+			[b]Note:[/b] Enabling occlusion culling has a cost on the CPU. Only enable occlusion culling if you actually plan to use it. Large open scenes with few or no objects blocking the view will generally not benefit much from occlusion culling. Large open scenes generally benefit more from mesh LOD and visibility ranges ([member GeometryInstance3D.visibility_range_begin] and [member GeometryInstance3D.visibility_range_end]) compared to occlusion culling.
 		</member>
 		<member name="rendering/reflections/reflection_atlas/reflection_count" type="int" setter="" getter="" default="64">
 			Number of cubemaps to store in the reflection atlas. The number of [ReflectionProbe]s in a scene will be limited by this amount. A higher number requires more VRAM.

--- a/doc/classes/QuadOccluder3D.xml
+++ b/doc/classes/QuadOccluder3D.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="QuadOccluder3D" inherits="Occluder3D" version="4.0">
 	<brief_description>
+		Flat plane shape for use with occlusion culling in [OccluderInstance3D].
 	</brief_description>
 	<description>
+		[QuadOccluder3D] stores a flat plane shape that can be used by the engine's occlusion culling system. See also [PolygonOccluder3D] if you need to customize the quad's shape.
+		See [OccluderInstance3D]'s documentation for instructions on setting up occlusion culling.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="size" type="Vector2" setter="set_size" getter="get_size" default="Vector2(1, 1)">
+			The quad's size in 3D units.
 		</member>
 	</members>
 </class>

--- a/doc/classes/SphereOccluder3D.xml
+++ b/doc/classes/SphereOccluder3D.xml
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="SphereOccluder3D" inherits="Occluder3D" version="4.0">
 	<brief_description>
+		Spherical shape for use with occlusion culling in [OccluderInstance3D].
 	</brief_description>
 	<description>
+		[SphereOccluder3D] stores a sphere shape that can be used by the engine's occlusion culling system.
+		See [OccluderInstance3D]'s documentation for instructions on setting up occlusion culling.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
+			The sphere's radius in 3D units.
 		</member>
 	</members>
 </class>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -285,6 +285,8 @@
 		<member name="use_debanding" type="bool" setter="set_use_debanding" getter="is_using_debanding" default="false">
 		</member>
 		<member name="use_occlusion_culling" type="bool" setter="set_use_occlusion_culling" getter="is_using_occlusion_culling" default="false">
+			If [code]true[/code], [OccluderInstance3D] nodes will be usable for occlusion culling in 3D for this viewport. For the root viewport, [member ProjectSettings.rendering/occlusion_culling/use_occlusion_culling] must be set to [code]true[/code] instead.
+			[b]Note:[/b] Enabling occlusion culling has a cost on the CPU. Only enable occlusion culling if you actually plan to use it, and think whether your scene can actually benefit from occlusion culling. Large, open scenes with few or no objects blocking the view will generally not benefit much from occlusion culling. Large open scenes generally benefit more from mesh LOD and visibility ranges ([member GeometryInstance3D.visibility_range_begin] and [member GeometryInstance3D.visibility_range_end]) compared to occlusion culling.
 		</member>
 		<member name="use_xr" type="bool" setter="set_use_xr" getter="is_using_xr" default="false">
 			If [code]true[/code], the viewport will use the primary XR interface to render XR output. When applicable this can result in a stereoscopic image and the resulting render being output to a headset.


### PR DESCRIPTION
This salvages the documentation improvements from https://github.com/godotengine/godot/pull/50408, on top of adding some new changes.