### PR TITLE
Fix unrestricted mouse-event propagation to SubViewports for Physics-Picking

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -158,7 +158,11 @@
 				Calling this method will propagate calls to child nodes for following methods in the given order:
 				- [method Node._input]
 				- [method Control._gui_input] for [Control] nodes
+				- [method Node._shortcut_input]
+				- [method Node._unhandled_input]
+				- [method Node._unhandled_key_input]
 				If an earlier method marks the input as handled via [method set_input_as_handled], any later method in this list will not be called.
+				If none of the methods handle the event and [member physics_object_picking] is [code]true[/code], the event is used for physics object picking.
 			</description>
 		</method>
 		<method name="push_text_input">

--- a/editor/editor_command_palette.cpp
+++ b/editor/editor_command_palette.cpp
@@ -256,7 +256,7 @@ void EditorCommandPalette::register_shortcuts_as_command() {
 		ev.instantiate();
 		ev->set_shortcut(shortcut);
 		String shortcut_text = String(shortcut->get_as_text());
-		add_command(command_name, E.key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_unhandled_input), varray(ev, false), shortcut_text);
+		add_command(command_name, E.key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_input), varray(ev, false), shortcut_text);
 	}
 	unregistered_shortcuts.clear();
 
@@ -277,7 +277,7 @@ Ref<Shortcut> EditorCommandPalette::add_shortcut_command(const String &p_command
 		ev.instantiate();
 		ev->set_shortcut(p_shortcut);
 		String shortcut_text = String(p_shortcut->get_as_text());
-		add_command(p_command, p_key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_unhandled_input), varray(ev, false), shortcut_text);
+		add_command(p_command, p_key, callable_mp(EditorNode::get_singleton()->get_viewport(), &Viewport::push_input), varray(ev, false), shortcut_text);
 	} else {
 		const String key_name = String(p_key);
 		const String command_name = String(p_command);

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -221,33 +221,6 @@ bool SubViewportContainer::_is_propagated_in_gui_input(const Ref<InputEvent> &p_
 	return false;
 }
 
-void SubViewportContainer::unhandled_input(const Ref<InputEvent> &p_event) {
-	ERR_FAIL_COND(p_event.is_null());
-
-	if (Engine::get_singleton()->is_editor_hint()) {
-		return;
-	}
-
-	Transform2D xform = get_global_transform_with_canvas();
-
-	if (stretch) {
-		Transform2D scale_xf;
-		scale_xf.scale(Vector2(shrink, shrink));
-		xform *= scale_xf;
-	}
-
-	Ref<InputEvent> ev = p_event->xformed_by(xform.affine_inverse());
-
-	for (int i = 0; i < get_child_count(); i++) {
-		SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
-		if (!c || c->is_input_disabled()) {
-			continue;
-		}
-
-		c->push_unhandled_input(ev);
-	}
-}
-
 void SubViewportContainer::add_child_notify(Node *p_child) {
 	if (Object::cast_to<SubViewport>(p_child)) {
 		queue_redraw();
@@ -290,5 +263,4 @@ void SubViewportContainer::_bind_methods() {
 
 SubViewportContainer::SubViewportContainer() {
 	set_process_input(true);
-	set_process_unhandled_input(true);
 }

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -55,7 +55,6 @@ public:
 
 	virtual void input(const Ref<InputEvent> &p_event) override;
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
-	virtual void unhandled_input(const Ref<InputEvent> &p_event) override;
 	void set_stretch_shrink(int p_shrink);
 	int get_stretch_shrink() const;
 	void recalc_force_viewport_sizes();

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2837,6 +2837,10 @@ void Viewport::push_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
 		_gui_cleanup_internal_state(ev);
 	}
 
+	if (!is_input_handled()) {
+		push_unhandled_input(ev, true);
+	}
+
 	event_count++;
 }
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1368,10 +1368,6 @@ void Window::_window_input(const Ref<InputEvent> &p_ev) {
 	if (is_inside_tree()) {
 		push_input(p_ev);
 	}
-
-	if (!is_input_handled() && is_inside_tree()) {
-		push_unhandled_input(p_ev);
-	}
 }
 
 void Window::_window_input_text(const String &p_text) {


### PR DESCRIPTION
resolve #17326
resolve #58902
resolve #75015
resolve #75019

<details>
<summary>previous description</summary>

Currently, Events get processed by Nodes in order of the green arrow in the following graphic, when a`SubViewportContainer` is within the Root Viewport:

![CurrentSubViewportHandlingOld](https://user-images.githubusercontent.com/6299227/194675345-32a2423f-e7bd-4082-adde-0078fa9cf41b.png)

The red "X" denotes the place where `set_input_as_handled()` is called within `Viewport::_gui_input_event`, when an `InputEventMouseMotion` happens over the `SubViewportContainer`. Here is the according location in the source code:
https://github.com/godotengine/godot/blob/84f2c68c84bde10026454292578e5fdcc9ab69a3/scene/main/viewport.cpp#L1789-L1796
If the `SubViewportContainer` marks the event as stopped, `_unhandled_input` is never called.
If the `SubViewportContainer` ignores the event, it is processed in `_unhandled_input`, even though ignoring should be a synonym for not sending the event to the SubViewport of SubViewportContainer.

This pull request makes sure, that the event reaches _unhandled_input inside the SubViewport before the "X":

![CurrentSubViewportHandlingNew](https://user-images.githubusercontent.com/6299227/194675411-1aaadd6b-0a25-4cc2-a121-3e312fadcd64.png)

This is done by moving the `push_unhandled_input` call from  `Window::_window_input` to  `Viewport::push_input`.

This change makes `SubViewportContainer::unhandled_input` redundant, since it would distribute the event to _unhandled_input inside the SubViewport a second time.

Shortcut Events now need to be distributed via `push_input`, in order for them to be able to reach `SubViewports`.

</details>

MRP for all linked issues: [SubViewportEventBugs.zip](https://github.com/godotengine/godot/files/11423555/SubViewportEventBugs.zip)

![BugsSVC](https://user-images.githubusercontent.com/6299227/236886495-978db522-293b-413d-b2ee-77cf67949113.png)

Currently InputEvents get sent unconditionally to `SubViewports` via `SubViewportContainer::unhandled_input`, even if the event-position is outside of the area of the `SubViewportContainer`. This leads to problems like #58902, where the mouse enters `CollisionObjects2D`, even if they are not visible. (in the MRP, clicking in the red area causes a mouse-click on the non-visible Logo within the `SubViewport`).

Also hovering `CollisionObjects2D` within `SubViewports` currently is reversed:
- If the `SubViewportContainer` is set to `MOUSE_FILTER_IGNORE`, the `CollisionObject2D` does receive mouse events.
- If the `SubViewportContainer` is set to `MOUSE_FILTER_STOP`, the `CollisionObject2D` doesn't receive mouse events.

A third bug is that a Panel with `MOUSE_FILTER_STOP`, parent of a SubViewportContainer, prohibits Physics-picking in the SubViewport.

The fourth bug, that gets fixed is that TouchScreenButtons don't receive some mouse events within `_unhandled_input`. (TouchScreenButton doesnt send event via _unhandled_input)

This PR solves all problems by moving the call of `push_unhandled_input` from `Window::_window_input` to `Viewport::push_input`.
This makes sure, that only events with a position within the area of the `SubViewportContainer` are considered for physics picking.
This change makes `SubViewportContainer::unhandled_input` redundant, since it would distribute the event to _unhandled_input inside the SubViewport a second time.

Updated 2022-09-26: fix merge conflict, made sure that this PR is still relevant after #61088 and adjusted description.
Updated 2022-10-14: adjust shortcut event handling
Updated 2022-11-06: update documentation of `push_input`.
Updated 2022-11-23: fix merge conflict
Updated 2023-01-27: fix merge conflict, update description based on the recently merged #58334
Updated 2023-03-17: fix merge conflict, updated MRP, linked a third bug, that this PR fixes.
Updated 2023-05-08: linked a fourth bug, that this PR fixes and updated description and MRP.
