### PR TITLE
Add the ability to open resource paths found in output log

### DIFF
--- a/editor/editor_log.h
+++ b/editor/editor_log.h
@@ -32,6 +32,7 @@
 #define EDITOR_LOG_H
 
 #include "core/os/thread.h"
+#include "modules/regex/regex.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/label.h"
@@ -114,6 +115,7 @@ private:
 	};
 
 	Vector<LogMessage> messages;
+	RegEx resource_path_regex;
 	// Maps MessageTypes to LogFilters for convenient access and storage (don't need 1 member per filter).
 	Map<MessageType, LogFilter *> type_filter_map;
 
@@ -148,6 +150,7 @@ private:
 
 	void _rebuild_log();
 	void _add_log_line(LogMessage &p_message, bool p_replace_previous = false);
+	void _resource_path_clicked(Variant path);
 
 	void _set_filter_active(bool p_active, MessageType p_message_type);
 	void _set_search_visible(bool p_visible);

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -2340,6 +2340,22 @@ bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_gra
 					se->ensure_focus();
 				}
 
+				if (p_col > 0) {
+					CodeEdit *code_editor = Object::cast_to<CodeEdit>(se->get_base_editor());
+					
+
+					int column_offset = 0;
+					String line = code_editor->get_line(p_line-1);
+					code_editor->set_caret_column(0);
+					for (int i = 0; i <= p_col; i++) {
+						if (line[i] != '\t') {
+							column_offset += 1;
+						}
+					}
+					code_editor->set_caret_column(column_offset);
+					code_editor->update();
+				}
+
 				if (p_line > 0) {
 					se->goto_line(p_line - 1);
 				}


### PR DESCRIPTION
Allows you to open resource paths in the output log. Scripts will open in the Script Editor (has support for line:column as well), and paths to scenes will open the scene when clicked. Other files (such as images or .tres files) will select the file in the FileSystem dock when clicked.

<img width="820" alt="image" src="https://user-images.githubusercontent.com/12436824/153296273-a9204eb8-0249-48d3-8aa0-74cdbba95169.png">

Minimal Testing Project:
[FilePathOutputLog.zip](https://github.com/godotengine/godot/files/8037891/FilePathOutputLog.zip)

Closes godotengine/godot-proposals#3880