### PR TITLE
[3.x] Backport `CanvasLayer` visibility

### DIFF
--- a/doc/classes/CanvasLayer.xml
+++ b/doc/classes/CanvasLayer.xml
@@ -47,7 +47,18 @@
 		<member name="transform" type="Transform2D" setter="set_transform" getter="get_transform" default="Transform2D( 1, 0, 0, 1, 0, 0 )">
 			The layer's transform.
 		</member>
+		<member name="visible" type="bool" setter="set_visible" getter="is_visible" default="true">
+			If [code]false[/code], any [CanvasItem] under this [CanvasLayer] will be hidden.
+			Unlike [member CanvasItem.visible], visibility of a [CanvasLayer] isn't propagated to underlying layers.
+		</member>
 	</members>
+	<signals>
+		<signal name="visibility_changed">
+			<description>
+				Emitted when visibility of the layer is changed. See [member visible].
+			</description>
+		</signal>
+	</signals>
 	<constants>
 	</constants>
 </class>

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -361,6 +361,17 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 			}
 
 			_update_visibility_color(p_node, item);
+		} else if (p_node->is_class("CanvasLayer")) {
+			bool v = p_node->call("is_visible");
+			if (v) {
+				item->add_button(0, get_icon("GuiVisibilityVisible", "EditorIcons"), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
+			} else {
+				item->add_button(0, get_icon("GuiVisibilityHidden", "EditorIcons"), BUTTON_VISIBILITY, false, TTR("Toggle Visibility"));
+			}
+
+			if (!p_node->is_connected("visibility_changed", this, "_node_visibility_changed")) {
+				p_node->connect("visibility_changed", this, "_node_visibility_changed", varray(p_node));
+			}
 		} else if (p_node->is_class("Spatial")) {
 			bool is_locked = p_node->has_meta("_edit_lock_");
 			if (is_locked) {
@@ -470,6 +481,9 @@ void SceneTreeEditor::_node_visibility_changed(Node *p_node) {
 	if (p_node->is_class("CanvasItem")) {
 		visible = p_node->call("is_visible");
 		CanvasItemEditor::get_singleton()->get_viewport_control()->update();
+	} else if (p_node->is_class("CanvasLayer")) {
+		visible = p_node->call("is_visible");
+		CanvasItemEditor::get_singleton()->get_viewport_control()->update();
 	} else if (p_node->is_class("Spatial")) {
 		visible = p_node->call("is_visible");
 	}
@@ -528,7 +542,7 @@ void SceneTreeEditor::_node_removed(Node *p_node) {
 		p_node->disconnect("script_changed", this, "_node_script_changed");
 	}
 
-	if (p_node->is_class("Spatial") || p_node->is_class("CanvasItem")) {
+	if (p_node->is_class("Spatial") || p_node->is_class("CanvasItem") || p_node->is_class("CanvasLayer")) {
 		if (p_node->is_connected("visibility_changed", this, "_node_visibility_changed")) {
 			p_node->disconnect("visibility_changed", this, "_node_visibility_changed");
 		}

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -162,6 +162,8 @@ VARIANT_ENUM_CAST(CanvasItemMaterial::LightMode)
 class CanvasItem : public Node {
 	GDCLASS(CanvasItem, Node);
 
+	friend class CanvasLayer;
+
 public:
 	enum BlendMode {
 
@@ -191,6 +193,7 @@ private:
 
 	bool first_draw;
 	bool visible;
+	bool parent_visible_in_tree;
 	bool pending_update;
 	bool toplevel;
 	bool drawing;
@@ -207,7 +210,7 @@ private:
 
 	void _toplevel_raise_self();
 
-	void _propagate_visibility_changed(bool p_visible);
+	void _propagate_visibility_changed(bool p_visible, bool p_was_visible = false);
 
 	void _update_callback();
 

--- a/scene/main/canvas_layer.h
+++ b/scene/main/canvas_layer.h
@@ -53,6 +53,7 @@ class CanvasLayer : public Node {
 	Viewport *vp;
 
 	int sort_index;
+	bool visible;
 
 	bool follow_viewport;
 	float follow_viewport_scale;
@@ -68,6 +69,9 @@ protected:
 public:
 	void set_layer(int p_xform);
 	int get_layer() const;
+
+	void set_visible(bool p_visible);
+	bool is_visible() const;
 
 	void set_transform(const Transform2D &p_xform);
 	Transform2D get_transform() const;


### PR DESCRIPTION
* Backports #56734.
    * It moves `show()` and `hide()` logic into `set_visible()`, so later changes are easier.
* Backports #48006.
    * The original PR that adds `visible` property and `visibility_changed` signal to `CanvasLayer`.
* Backports #57684.
    * It fixes a bug in `CanvasLayer` visiblity propagation of the original PR.
    * It fixes `hidden` signal so that it won't be emitted again when the `CanvasItem` was already invisible.
    * `is_visible_in_tree()` is now as cheap as `is_visible()`