### PR TITLE
Fix CanvasItemEditor scale editor not using the editor scale methods

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1831,7 +1831,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 			Point2 drag_to_local = simple_xform.xform(drag_to);
 			Point2 offset = drag_to_local - drag_from_local;
 
-			Size2 scale = canvas_item->call("get_scale");
+			Size2 scale = canvas_item->_edit_get_scale();
 			Size2 original_scale = scale;
 			real_t ratio = scale.y / scale.x;
 			if (drag_type == DRAG_SCALE_BOTH) {
@@ -1869,7 +1869,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 				}
 			}
 
-			canvas_item->call("set_scale", scale);
+			canvas_item->_edit_set_scale(scale);
 			return true;
 		}
 


### PR DESCRIPTION
CanvasItem has special methods just for the editor, this PR uses the scale methods in CanvasItemEditor. Aside from being the more semantically correct option and maybe slightly faster, CanvasItem derived nodes are not guaranteed to have scale, so the current code can break if implementing a custom CanvasItem node (this is how I discovered this bug). 3.x version: #57903