### PR TITLE
[3.x] Fix CanvasItemEditor scale editor not using the editor methods

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -2083,7 +2083,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 			Point2 drag_to_local = simple_xform.xform(drag_to);
 			Point2 offset = drag_to_local - drag_from_local;
 
-			Size2 scale = canvas_item->call("get_scale");
+			Size2 scale = canvas_item->_edit_get_scale();
 			float ratio = scale.y / scale.x;
 			if (drag_type == DRAG_SCALE_BOTH) {
 				Size2 scale_factor = drag_to_local / drag_from_local;
@@ -2114,7 +2114,7 @@ bool CanvasItemEditor::_gui_input_scale(const Ref<InputEvent> &p_event) {
 				scale.y = roundf(scale.y / snap_scale_step) * snap_scale_step;
 			}
 
-			canvas_item->call("set_scale", scale);
+			canvas_item->_edit_set_scale(scale);
 			return true;
 		}
 


### PR DESCRIPTION
Same as #57902 but for the 3.x branch, manually backported since there were conflicts.