### PR TITLE
Fixes some 'Attempted to free invalid ID' warnings in mobile renderer

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1818,11 +1818,14 @@ void RendererSceneRenderRD::_free_render_buffer_data(RenderBuffers *rb) {
 			if (rb->blur[i].mipmaps[m].fb.is_valid()) {
 				RD::get_singleton()->free(rb->blur[i].mipmaps[m].fb);
 			}
-			if (rb->blur[i].mipmaps[m].half_fb.is_valid()) {
-				RD::get_singleton()->free(rb->blur[i].mipmaps[m].half_fb);
-			}
-			if (rb->blur[i].mipmaps[m].half_texture.is_valid()) {
-				RD::get_singleton()->free(rb->blur[i].mipmaps[m].half_texture);
+			// texture and framebuffer in both blur mipmaps are shared, so only free from the first one
+			if (i == 0) {
+				if (rb->blur[i].mipmaps[m].half_fb.is_valid()) {
+					RD::get_singleton()->free(rb->blur[i].mipmaps[m].half_fb);
+				}
+				if (rb->blur[i].mipmaps[m].half_texture.is_valid()) {
+					RD::get_singleton()->free(rb->blur[i].mipmaps[m].half_texture);
+				}
 			}
 		}
 		rb->blur[i].mipmaps.clear();


### PR DESCRIPTION
Fix _free_render_buffer_data freeing half_texture and half_fb the mipmap array of both blur structs when switching scenes. During assignment, half_texture and half_fb in each of the mipmaps of both arrays are assigned the same texture and framebuffer, and since _free_render_buffer_data attempts to free both, the engine throws up a warning since they have already been erased in the first blur struct.

Fixes #51752