### PR TITLE
Free surface vertex_buffers after vertex_arrays to silence warnings

### DIFF
--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -3578,14 +3578,14 @@ void RendererStorageRD::mesh_instance_set_blend_shape_weight(RID p_mesh_instance
 
 void RendererStorageRD::_mesh_instance_clear(MeshInstance *mi) {
 	for (uint32_t i = 0; i < mi->surfaces.size(); i++) {
-		if (mi->surfaces[i].vertex_buffer.is_valid()) {
-			RD::get_singleton()->free(mi->surfaces[i].vertex_buffer);
-		}
 		if (mi->surfaces[i].versions) {
 			for (uint32_t j = 0; j < mi->surfaces[i].version_count; j++) {
 				RD::get_singleton()->free(mi->surfaces[i].versions[j].vertex_array);
 			}
 			memfree(mi->surfaces[i].versions);
+		}
+		if (mi->surfaces[i].vertex_buffer.is_valid()) {
+			RD::get_singleton()->free(mi->surfaces[i].vertex_buffer);
 		}
 	}
 	mi->surfaces.clear();


### PR DESCRIPTION
Switches the order to free surface vertex_buffers after vertex_arrays due to latter having a dependency in the former, resulting in attempts to free vertex_arrays which were already freed. Thanks to [lukas-toenne](https://github.com/lukas-toenne) for discovering a fix for this.

Fixes #56460
Fixes #57314