### PR TITLE
Fix typos with codespell

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1030,7 +1030,7 @@ static void _encode_string(const String &p_string, uint8_t *&buf, int &r_len) {
 }
 
 Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bool p_full_objects, int p_depth) {
-	ERR_FAIL_COND_V_MSG(p_depth > Variant::MAX_RECURSION_DEPTH, ERR_OUT_OF_MEMORY, "Potential inifite recursion detected. Bailing.");
+	ERR_FAIL_COND_V_MSG(p_depth > Variant::MAX_RECURSION_DEPTH, ERR_OUT_OF_MEMORY, "Potential infinite recursion detected. Bailing.");
 	uint8_t *buf = r_buffer;
 
 	r_len = 0;

--- a/core/string/string_name.h
+++ b/core/string/string_name.h
@@ -188,7 +188,7 @@ StringName _scs_create(const char *p_chr, bool p_static = false);
  * - Control::get_theme_*(<name> and Window::get_theme_*(<name> functions.
  * - emit_signal(<name>,..) function
  * - call_deferred(<name>,..) function
- * - Comparisons to a StringName in overriden _set and _get methods.
+ * - Comparisons to a StringName in overridden _set and _get methods.
  *
  * Use in places that can be called hundreds of times per frame (or more) is recommended, but this situation is very rare. If in doubt, do not use.
  */

--- a/doc/classes/EngineDebugger.xml
+++ b/doc/classes/EngineDebugger.xml
@@ -67,7 +67,7 @@
 			<argument index="0" name="name" type="StringName" />
 			<argument index="1" name="profiler" type="EngineProfiler" />
 			<description>
-				Registers a profiler with the given [code]name[/code]. See [EngineProfiler] for more informations.
+				Registers a profiler with the given [code]name[/code]. See [EngineProfiler] for more information.
 			</description>
 		</method>
 		<method name="send_message">

--- a/doc/classes/EngineProfiler.xml
+++ b/doc/classes/EngineProfiler.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		This class can be used to implement custom profilers that are able to interact with the engine and editor debugger.
-		See [EngineDebugger] and [EditorDebuggerPlugin] for more informations.
+		See [EngineDebugger] and [EditorDebuggerPlugin] for more information.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -24,7 +24,7 @@
 			<argument index="2" name="physics_time" type="float" />
 			<argument index="3" name="physics_frame_time" type="float" />
 			<description>
-				Called once every engine iteration when the profiler is active with informations about the current frame.
+				Called once every engine iteration when the profiler is active with information about the current frame.
 			</description>
 		</method>
 		<method name="_toggle" qualifiers="virtual">

--- a/doc/classes/FontData.xml
+++ b/doc/classes/FontData.xml
@@ -577,7 +577,7 @@
 			Font style flags, see [enum TextServer.FontStyle].
 		</member>
 		<member name="force_autohinter" type="bool" setter="set_force_autohinter" getter="is_force_autohinter" default="false">
-			If set to [code]true[/code], auto-hinting is supported and preffered over font built-in hinting. Used by dynamic fonts only.
+			If set to [code]true[/code], auto-hinting is supported and preferred over font built-in hinting. Used by dynamic fonts only.
 		</member>
 		<member name="hinting" type="int" setter="set_hinting" getter="get_hinting" enum="TextServer.Hinting" default="1">
 			Font hinting mode. Used by dynamic fonts only.

--- a/doc/classes/GPUParticles2D.xml
+++ b/doc/classes/GPUParticles2D.xml
@@ -119,7 +119,7 @@
 			Particle starts with specified color.
 		</constant>
 		<constant name="EMIT_FLAG_CUSTOM" value="16" enum="EmitFlags">
-			Particle starts with specificed [code]CUSTOM[/code] data.
+			Particle starts with specified [code]CUSTOM[/code] data.
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/GPUParticles3D.xml
+++ b/doc/classes/GPUParticles3D.xml
@@ -150,7 +150,7 @@
 			Particle starts with specified color.
 		</constant>
 		<constant name="EMIT_FLAG_CUSTOM" value="16" enum="EmitFlags">
-			Particle starts with specificed [code]CUSTOM[/code] data.
+			Particle starts with specified [code]CUSTOM[/code] data.
 		</constant>
 		<constant name="MAX_DRAW_PASSES" value="4">
 			Maximum number of draw passes supported.

--- a/doc/classes/TextServerExtension.xml
+++ b/doc/classes/TextServerExtension.xml
@@ -557,7 +557,7 @@
 			<argument index="0" name="font_rid" type="RID" />
 			<argument index="1" name="force_autohinter" type="bool" />
 			<description>
-				If set to [code]true[/code] auto-hinting is preffered over font built-in hinting.
+				If set to [code]true[/code] auto-hinting is preferred over font built-in hinting.
 			</description>
 		</method>
 		<method name="_font_set_global_oversampling" qualifiers="virtual">

--- a/doc/classes/TranslationServer.xml
+++ b/doc/classes/TranslationServer.xml
@@ -138,7 +138,7 @@
 			<return type="String" />
 			<argument index="0" name="locale" type="String" />
 			<description>
-				Retunrs [code]locale[/code] string standardized to match known locales (e.g. [code]en-US[/code] would be matched to [code]en_US[/code]).
+				Returns [code]locale[/code] string standardized to match known locales (e.g. [code]en-US[/code] would be matched to [code]en_US[/code]).
 			</description>
 		</method>
 		<method name="translate" qualifiers="const">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -55,7 +55,7 @@
 		<method name="get_mouse_position" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the mouse's positon in this [Viewport] using the coordinate system of this [Viewport].
+				Returns the mouse's position in this [Viewport] using the coordinate system of this [Viewport].
 			</description>
 		</method>
 		<method name="get_render_info">
@@ -128,7 +128,7 @@
 		<method name="gui_release_focus">
 			<return type="void" />
 			<description>
-				Removes the focus from the currently focussed [Control] within this viewport. If no [Control] has the focus, does nothing.
+				Removes the focus from the currently focused [Control] within this viewport. If no [Control] has the focus, does nothing.
 			</description>
 		</method>
 		<method name="is_embedding_subwindows" qualifiers="const">

--- a/doc/tools/make_rst.py
+++ b/doc/tools/make_rst.py
@@ -536,19 +536,19 @@ def make_rst_class(class_def, state, dry_run, output_dir):  # type: (ClassDef, S
     # Inheritance tree
     # Ascendants
     if class_def.inherits:
-        inh = class_def.inherits.strip()
+        inherits = class_def.inherits.strip()
         f.write("**" + translate("Inherits:") + "** ")
         first = True
-        while inh in state.classes:
+        while inherits in state.classes:
             if not first:
                 f.write(" **<** ")
             else:
                 first = False
 
-            f.write(make_type(inh, state))
-            inode = state.classes[inh].inherits
+            f.write(make_type(inherits, state))
+            inode = state.classes[inherits].inherits
             if inode:
-                inh = inode.strip()
+                inherits = inode.strip()
             else:
                 break
         f.write("\n\n")

--- a/doc/translations/classes.pot
+++ b/doc/translations/classes.pot
@@ -34818,7 +34818,7 @@ msgstr ""
 #: doc/classes/NavigationAgent.xml doc/classes/NavigationAgent2D.xml
 msgid ""
 "The minimal amount of time for which this agent's velocities, that are "
-"computed with the collision avoidance algorithim, are safe with respect to "
+"computed with the collision avoidance algorithm, are safe with respect to "
 "other agents. The larger the number, the sooner the agent will respond to "
 "other agents, but the less freedom in choosing its velocities. Must be "
 "positive."

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -860,7 +860,7 @@ Error VulkanContext::_create_physical_device(VkSurfaceKHR p_surface) {
 		free(device_queue_props);
 		print_verbose("  #" + itos(i) + ": " + vendor + " " + name + " - " + (present_supported ? "Supported" : "Unsupported") + ", " + dev_type);
 
-		if (present_supported) { // Select first supported device of preffered type: Discrete > Integrated > Virtual > CPU > Other.
+		if (present_supported) { // Select first supported device of preferred type: Discrete > Integrated > Virtual > CPU > Other.
 			switch (props.deviceType) {
 				case VkPhysicalDeviceType::VK_PHYSICAL_DEVICE_TYPE_DISCRETE_GPU: {
 					if (type_selected < 4) {

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -159,7 +159,7 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 
 		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ffffff", "#414141"); // Pure white
 		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#000000", "#bfbfbf"); // Pure black
-		// Keep pure RGB colors as is, but list them for explicity.
+		// Keep pure RGB colors as is, but list them for explicitly.
 		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#ff0000", "#ff0000"); // Pure red
 		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#00ff00", "#00ff00"); // Pure green
 		ADD_CONVERT_COLOR(dark_icon_color_dictionary, "#0000ff", "#0000ff"); // Pure blue

--- a/misc/hooks/pre-commit-black
+++ b/misc/hooks/pre-commit-black
@@ -139,11 +139,11 @@ fi
 while true; do
     if [ $terminal = "0" ] ; then
         if [ -x "$ZENITY" ] ; then
-            ans=$($ZENITY --text-info --filename="$patch" --width=800 --height=600 --title="Do you want to apply that patch?" --ok-label="Apply" --cancel-label="Do not apply" --extra-button="Apply and stage")
+            choice=$($ZENITY --text-info --filename="$patch" --width=800 --height=600 --title="Do you want to apply that patch?" --ok-label="Apply" --cancel-label="Do not apply" --extra-button="Apply and stage")
             if [ "$?" = "0" ] ; then
                 yn="Y"
             else
-                if [ "$ans" = "Apply and stage" ] ; then
+                if [ "$choice" = "Apply and stage" ] ; then
                     yn="S"
                 else
                     yn="N"
@@ -151,10 +151,10 @@ while true; do
             fi
         elif [ -x "$XMSG" ] ; then
             $XMSG -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
-            ans=$?
-            if [ "$ans" = "100" ] ; then
+            choice=$?
+            if [ "$choice" = "100" ] ; then
                 yn="Y"
-            elif [ "$ans" = "200" ] ; then
+            elif [ "$choice" = "200" ] ; then
                 yn="S"
             else
                 yn="N"
@@ -162,10 +162,10 @@ while true; do
         elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
             winmessage="$(canonicalize_filename "./.git/hooks/winmessage.ps1")"
             $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
-            ans=$?
-            if [ "$ans" = "100" ] ; then
+            choice=$?
+            if [ "$choice" = "100" ] ; then
                 yn="Y"
-            elif [ "$ans" = "200" ] ; then
+            elif [ "$choice" = "200" ] ; then
                 yn="S"
             else
                 yn="N"

--- a/misc/hooks/pre-commit-clang-format
+++ b/misc/hooks/pre-commit-clang-format
@@ -179,11 +179,11 @@ fi
 while true; do
     if [ $terminal = "0" ] ; then
         if [ -x "$ZENITY" ] ; then
-            ans=$($ZENITY --text-info --filename="$patch" --width=800 --height=600 --title="Do you want to apply that patch?" --ok-label="Apply" --cancel-label="Do not apply" --extra-button="Apply and stage")
+            choice=$($ZENITY --text-info --filename="$patch" --width=800 --height=600 --title="Do you want to apply that patch?" --ok-label="Apply" --cancel-label="Do not apply" --extra-button="Apply and stage")
             if [ "$?" = "0" ] ; then
                 yn="Y"
             else
-                if [ "$ans" = "Apply and stage" ] ; then
+                if [ "$choice" = "Apply and stage" ] ; then
                     yn="S"
                 else
                     yn="N"
@@ -191,10 +191,10 @@ while true; do
             fi
         elif [ -x "$XMSG" ] ; then
             $XMSG -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
-            ans=$?
-            if [ "$ans" = "100" ] ; then
+            choice=$?
+            if [ "$choice" = "100" ] ; then
                 yn="Y"
-            elif [ "$ans" = "200" ] ; then
+            elif [ "$choice" = "200" ] ; then
                 yn="S"
             else
                 yn="N"
@@ -202,10 +202,10 @@ while true; do
         elif [ \( \( "$OSTYPE" = "msys" \) -o \( "$OSTYPE" = "win32" \) \) -a \( -x "$PWSH" \) ]; then
             winmessage="$(canonicalize_filename "./.git/hooks/winmessage.ps1")"
             $PWSH -noprofile -executionpolicy bypass -file "$winmessage" -file "$patch" -buttons "Apply":100,"Apply and stage":200,"Do not apply":0 -center -default "Do not apply" -geometry 800x600 -title "Do you want to apply that patch?"
-            ans=$?
-            if [ "$ans" = "100" ] ; then
+            choice=$?
+            if [ "$choice" = "100" ] ; then
                 yn="Y"
-            elif [ "$ans" = "200" ] ; then
+            elif [ "$choice" = "200" ] ; then
                 yn="S"
             else
                 yn="N"

--- a/misc/scripts/codespell.sh
+++ b/misc/scripts/codespell.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+SKIP_LIST="./thirdparty,*.gen.*,*.po,*.pot,package-lock.json,./core/string/locales.h,./DONORS.md,./misc/scripts/codespell.sh"
+IGNORE_LIST="ba,childs,curvelinear,expct,fave,findn,gird,inout,lod,nd,numer,ois,ro,statics,te,varn"
+
+codespell -w -q 3 -S "${SKIP_LIST}" -L "${IGNORE_LIST}"

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3373,9 +3373,9 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> state) {
 					orm_texture_index = _set_texture(state, orm_texture);
 				}
 				if (has_ao) {
-					Dictionary ot;
-					ot["index"] = orm_texture_index;
-					d["occlusionTexture"] = ot;
+					Dictionary occt;
+					occt["index"] = orm_texture_index;
+					d["occlusionTexture"] = occt;
 				}
 				if (has_roughness || has_metalness) {
 					mrt["index"] = orm_texture_index;

--- a/modules/text_server_adv/script_iterator.cpp
+++ b/modules/text_server_adv/script_iterator.cpp
@@ -82,7 +82,7 @@ ScriptIterator::ScriptIterator(const String &p_string, int p_start, int p_length
 					paren_stack[paren_sp].pair_index = ch;
 					paren_stack[paren_sp].script_code = script_code;
 				} else if (paren_sp >= 0) {
-					// If it's a close character, find the matching open on the stack, and use that script code. Any non-matching open characters above it on the stack will be poped.
+					// If it's a close character, find the matching open on the stack, and use that script code. Any non-matching open characters above it on the stack will be popped.
 					UChar32 paired_ch = u_getBidiPairedBracket(ch);
 					while (paren_sp >= 0 && paren_stack[paren_sp].pair_index != paired_ch) {
 						paren_sp -= 1;

--- a/modules/visual_script/editor/visual_script_property_selector.cpp
+++ b/modules/visual_script/editor/visual_script_property_selector.cpp
@@ -493,7 +493,7 @@ VisualScriptPropertySelector::VisualScriptPropertySelector() {
 	hbox->add_child(scope_combo);
 
 	search_box = memnew(LineEdit);
-	search_box->set_tooltip(TTR("Enter \" \" to show all filterd options\nEnter \".\" to show all filterd methods, operators and constructors\nUse CTRL_KEY to drop property setters"));
+	search_box->set_tooltip(TTR("Enter \" \" to show all filtered options\nEnter \".\" to show all filtered methods, operators and constructors\nUse CTRL_KEY to drop property setters"));
 	search_box->set_custom_minimum_size(Size2(200, 0) * EDSCALE);
 	search_box->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	search_box->connect("text_changed", callable_mp(this, &VisualScriptPropertySelector::_update_results_s));
@@ -694,7 +694,7 @@ bool VisualScriptPropertySelector::SearchRunner::_phase_match_classes_init() {
 			class_doc.name = selector_ui->base_script;
 
 			class_doc.inherits = script->get_instance_base_type();
-			class_doc.brief_description = ".vs files not suported by EditorHelp::get_doc_data()";
+			class_doc.brief_description = ".vs files not supported by EditorHelp::get_doc_data()";
 			class_doc.description = "";
 
 			Object *obj = ObjectDB::get_instance(script->get_instance_id());
@@ -711,9 +711,9 @@ bool VisualScriptPropertySelector::SearchRunner::_phase_match_classes_init() {
 					class_doc.signals.push_back(_get_method_doc(S->get()));
 				}
 
-				List<PropertyInfo> propertys;
-				Object::cast_to<Script>(obj)->get_script_property_list(&propertys);
-				for (List<PropertyInfo>::Element *P = propertys.front(); P; P = P->next()) {
+				List<PropertyInfo> properties;
+				Object::cast_to<Script>(obj)->get_script_property_list(&properties);
+				for (List<PropertyInfo>::Element *P = properties.front(); P; P = P->next()) {
 					DocData::PropertyDoc pd = DocData::PropertyDoc();
 					pd.name = P->get().name;
 					pd.type = Variant::get_type_name(P->get().type);

--- a/modules/websocket/wsl_client.cpp
+++ b/modules/websocket/wsl_client.cpp
@@ -177,7 +177,7 @@ Error WSLClient::connect_to_host(String p_host, String p_path, uint16_t p_port, 
 		}
 	}
 
-	// We assume OK while hostname resultion is pending.
+	// We assume OK while hostname resolution is pending.
 	Error err = _resolver_id != IP::RESOLVER_INVALID_ID ? OK : FAILED;
 	while (_ip_candidates.size()) {
 		err = _tcp->connect_to_host(_ip_candidates.pop_front(), p_port);

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -164,7 +164,7 @@ int DisplayServerAndroid::screen_get_dpi(int p_screen) const {
 float DisplayServerAndroid::screen_get_refresh_rate(int p_screen) const {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
 	if (!godot_io_java) {
-		ERR_PRINT("An error occured while trying to get the screen refresh rate.");
+		ERR_PRINT("An error occurred while trying to get the screen refresh rate.");
 		return SCREEN_REFRESH_RATE_FALLBACK;
 	}
 

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -141,12 +141,12 @@ float GodotIOJavaWrapper::get_screen_refresh_rate(float fallback) {
 	if (_get_screen_refresh_rate) {
 		JNIEnv *env = get_jni_env();
 		if (env == nullptr) {
-			ERR_PRINT("An error occured while trying to get screen refresh rate.");
+			ERR_PRINT("An error occurred while trying to get screen refresh rate.");
 			return fallback;
 		}
 		return (float)env->CallDoubleMethod(godot_io_instance, _get_screen_refresh_rate, (double)fallback);
 	}
-	ERR_PRINT("An error occured while trying to get the screen refresh rate.");
+	ERR_PRINT("An error occurred while trying to get the screen refresh rate.");
 	return fallback;
 }
 

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -1077,7 +1077,7 @@ float DisplayServerX11::screen_get_refresh_rate(int p_screen) const {
 				monitors = xrr_get_monitors(x11_display, windows[MAIN_WINDOW_ID].x11_window, true, &count);
 				ERR_FAIL_INDEX_V(p_screen, count, SCREEN_REFRESH_RATE_FALLBACK);
 			} else {
-				ERR_PRINT("An error occured while trying to get the screen refresh rate.");
+				ERR_PRINT("An error occurred while trying to get the screen refresh rate.");
 				return SCREEN_REFRESH_RATE_FALLBACK;
 			}
 
@@ -1105,14 +1105,14 @@ float DisplayServerX11::screen_get_refresh_rate(int p_screen) const {
 				}
 			}
 
-			ERR_PRINT("An error occured while trying to get the screen refresh rate."); // We should have returned the refresh rate by now. An error must have occured.
+			ERR_PRINT("An error occurred while trying to get the screen refresh rate."); // We should have returned the refresh rate by now. An error must have occurred.
 			return SCREEN_REFRESH_RATE_FALLBACK;
 		} else {
-			ERR_PRINT("An error occured while trying to get the screen refresh rate.");
+			ERR_PRINT("An error occurred while trying to get the screen refresh rate.");
 			return SCREEN_REFRESH_RATE_FALLBACK;
 		}
 	}
-	ERR_PRINT("An error occured while trying to get the screen refresh rate.");
+	ERR_PRINT("An error occurred while trying to get the screen refresh rate.");
 	return SCREEN_REFRESH_RATE_FALLBACK;
 }
 

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -1335,7 +1335,7 @@ float DisplayServerOSX::screen_get_refresh_rate(int p_screen) const {
 		const double displayRefreshRate = CGDisplayModeGetRefreshRate(displayMode);
 		return (float)displayRefreshRate;
 	}
-	ERR_PRINT("An error occured while trying to get the screen refresh rate.");
+	ERR_PRINT("An error occurred while trying to get the screen refresh rate.");
 	return SCREEN_REFRESH_RATE_FALLBACK;
 }
 

--- a/scene/3d/spring_arm_3d.cpp
+++ b/scene/3d/spring_arm_3d.cpp
@@ -185,14 +185,14 @@ void SpringArm3D::process_spring() {
 	}
 
 	current_spring_length = spring_length * motion_delta;
-	Transform3D childs_transform;
-	childs_transform.origin = get_global_transform().origin + cast_direction * (spring_length * motion_delta);
+	Transform3D child_transform;
+	child_transform.origin = get_global_transform().origin + cast_direction * (spring_length * motion_delta);
 
 	for (int i = get_child_count() - 1; 0 <= i; --i) {
 		Node3D *child = Object::cast_to<Node3D>(get_child(i));
 		if (child) {
-			childs_transform.basis = child->get_global_transform().basis;
-			child->set_global_transform(childs_transform);
+			child_transform.basis = child->get_global_transform().basis;
+			child->set_global_transform(child_transform);
 		}
 	}
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2472,7 +2472,7 @@ void TextEdit::_update_placeholder() {
 		return; // Not in tree?
 	}
 
-	// Placeholder is generally smaller then text docuemnts, and updates less so this should be fast enough for now.
+	// Placeholder is generally smaller then text documents, and updates less so this should be fast enough for now.
 	placeholder_data_buf->clear();
 	placeholder_data_buf->set_width(text.get_width());
 	placeholder_data_buf->set_direction((TextServer::Direction)text_direction);

--- a/tests/core/math/test_vector3.h
+++ b/tests/core/math/test_vector3.h
@@ -58,7 +58,7 @@ TEST_CASE("[Vector3] Angle methods") {
 
 	CHECK_MESSAGE(
 			Math::is_equal_approx(vector_x.signed_angle_to(vector_y, vector_y), (real_t)Math_TAU / 4),
-			"Vector3 signed_angle_to edge case should be postiive.");
+			"Vector3 signed_angle_to edge case should be positive.");
 	CHECK_MESSAGE(
 			Math::is_equal_approx(vector_x.signed_angle_to(vector_yz, vector_y), (real_t)Math_TAU / -4),
 			"Vector3 signed_angle_to should work as expected.");


### PR DESCRIPTION
Using codespell 2.2-dev from current git.

Added `misc/scripts/codespell.sh` to make it easier to run it once in a
while and update the skip and ignore lists.