### PR TITLE
Add --run-instance=<num> when run from editor

### DIFF
--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -229,16 +229,23 @@ Error EditorRun::run(const String &p_scene) {
 		}
 	}
 
-	printf("Running: %s", exec.utf8().get_data());
-	for (const String &E : args) {
-		printf(" %s", E.utf8().get_data());
-	};
-	printf("\n");
-
 	int instances = EditorSettings::get_singleton()->get_project_metadata("debug_options", "run_debug_instances", 1);
 	for (int i = 0; i < instances; i++) {
+		List<String> instance_args;
+		for (int a = 0; a < args.size(); a++) {
+			instance_args.push_back(args[a]);
+		}
+		instance_args.push_back("--run-instance=" + itos(i + 1));
+
 		OS::ProcessID pid = 0;
-		Error err = OS::get_singleton()->create_instance(args, &pid);
+
+		printf("Running: %s", exec.utf8().get_data());
+		for (const String &E : instance_args) {
+			printf(" %s", E.utf8().get_data());
+		};
+		printf("\n");
+
+		Error err = OS::get_singleton()->create_instance(instance_args, &pid);
 		ERR_FAIL_COND_V(err, err);
 		pids.push_back(pid);
 	}


### PR DESCRIPTION
This adds the instance number as `--run-instance=<num>` when the game is run from the editor.
I.e. the first instance gets `--run-instance=1`, the second one `--run-instance=2` and so on.

This is useful for multiplayer testing, for example to automatically use different user profiles for different instances, speeding up testing by not having to manually select or login as different users.

Being able to launch multiple instances from the editor was implemented in https://github.com/godotengine/godot/pull/36920, this is a small improvement upon that.

_Edit: From talking with Fales, it may make more sense to instead have custom args per instance. Will convert to draft for now._

Superseded by https://github.com/godotengine/godot/pull/57975