### PR TITLE
Don't block input after cancelling transform.

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -385,8 +385,6 @@ int Node3DEditorViewport::get_selected_count() const {
 }
 
 void Node3DEditorViewport::cancel_transform() {
-	_edit.mode = TRANSFORM_NONE;
-
 	List<Node *> &selection = editor_selection->get_selected_node_list();
 
 	for (List<Node *>::Element *E = selection.front(); E; E = E->next()) {
@@ -402,7 +400,8 @@ void Node3DEditorViewport::cancel_transform() {
 
 		sp->set_global_transform(se->original);
 	}
-	surface->update();
+
+	finish_transform();
 	set_message(TTR("Transform Aborted."), 3);
 }
 
@@ -4063,12 +4062,9 @@ void Node3DEditorViewport::commit_transform() {
 		undo_redo->add_undo_method(sp, "set_global_transform", se->original);
 	}
 	undo_redo->commit_action();
-	_edit.mode = TRANSFORM_NONE;
-	_edit.instant = false;
-	spatial_editor->set_local_coords_enabled(_edit.original_local);
+
+	finish_transform();
 	set_message("");
-	spatial_editor->update_transform_gizmo();
-	surface->update();
 }
 
 void Node3DEditorViewport::update_transform(Point2 p_mousepos, bool p_shift) {
@@ -4405,6 +4401,14 @@ void Node3DEditorViewport::update_transform(Point2 p_mousepos, bool p_shift) {
 		default: {
 		}
 	}
+}
+
+void Node3DEditorViewport::finish_transform() {
+	spatial_editor->set_local_coords_enabled(_edit.original_local);
+	spatial_editor->update_transform_gizmo();
+	_edit.mode = TRANSFORM_NONE;
+	_edit.instant = false;
+	surface->update();
 }
 
 Node3DEditorViewport::Node3DEditorViewport(Node3DEditor *p_spatial_editor, EditorNode *p_editor, int p_index) {

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -409,6 +409,7 @@ private:
 	void begin_transform(TransformMode p_mode, bool instant);
 	void commit_transform();
 	void update_transform(Point2 p_mousepos, bool p_shift);
+	void finish_transform();
 
 protected:
 	void _notification(int p_what);


### PR DESCRIPTION
After starting an instant transform and cancelling it, the mouse was
blocked because cancel_transform did not set _edit.instant back to
false.

This refactors all the cleanup into a separate function that both
cancel_transform and commit_transform can call.

Fixes #57868.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
