### PR TITLE
i18n: Exclude `$DOCS_URL` links from classref translations

### DIFF
--- a/doc/translations/extract.py
+++ b/doc/translations/extract.py
@@ -224,6 +224,8 @@ def _make_translation_catalog(classes):
             if elem.tag in EXTRACT_TAGS:
                 if not elem.text or len(elem.text) == 0:
                     continue
+                if elem.tag == "link" and "$DOCS_URL" in elem.text:  # No need to localize.
+                    continue
                 line_no = elem._start_line_number if elem.text[0] != "\n" else elem._start_line_number + 1
                 desc_str = elem.text.strip()
                 code_block_regions = _make_codeblock_regions(desc_str, desc_list.path)


### PR DESCRIPTION
This was suggested on https://hosted.weblate.org/translate/godot-engine/godot-class-reference/en/?&offset=5488#comments

Note that links can have an optional `title` field that we would likely want to be able to localize. But that is not extracted at this time so this doesn't change that.

This also doesn't exclude inline `[url]` links using `$DOCS_URL` as those are part of paragraphs that need to be translated.