### PR TITLE
Fixed issues with 3D region-select in the editor

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -269,6 +269,7 @@ private:
 	ObjectID clicked;
 	Vector<_RayResult> selection_results;
 	bool clicked_wants_append;
+	bool selection_in_progress = false;
 
 	PopupMenu *selection_menu;
 


### PR DESCRIPTION
This fixes 2 issues introduced in #57847:
- When you had selected a node with region-select, then added a new Node that is not a 2D or 3D node (something like an AnimationPlayer) the region select would activate. This only happend when double clicking on the Node type in the selection dialog. I added a `selection_in_progress` guard to prevent this
- When you region-selected a couple of nodes and then did a CTRL+Z without having them moved before, the selected nodes would get reset to the world origin (actually the whole Transform). This happend because the Blender-style transformation tools and region-select were both activated at the same time when dragging the mouse. To fix it i first check if region-select needs to be enabled.

I tested it a couple of hours while working on a project. Works fine now :)
