### PR TITLE
Add FLAG_NONE to SaverFlags in ResourceSaver to fix api inconsistency

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -138,7 +138,7 @@ void ResourceLoader::_bind_methods() {
 
 ////// ResourceSaver //////
 
-Error ResourceSaver::save(const String &p_path, const RES &p_resource, SaverFlags p_flags) {
+Error ResourceSaver::save(const String &p_path, const RES &p_resource, uint32_t p_flags) {
 	ERR_FAIL_COND_V_MSG(p_resource.is_null(), ERR_INVALID_PARAMETER, "Can't save empty resource to path '" + String(p_path) + "'.");
 	return ::ResourceSaver::save(p_path, p_resource, p_flags);
 }
@@ -157,9 +157,10 @@ Vector<String> ResourceSaver::get_recognized_extensions(const RES &p_resource) {
 ResourceSaver *ResourceSaver::singleton = nullptr;
 
 void ResourceSaver::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("save", "path", "resource", "flags"), &ResourceSaver::save, DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("save", "path", "resource", "flags"), &ResourceSaver::save, DEFVAL((uint32_t)FLAG_NONE));
 	ClassDB::bind_method(D_METHOD("get_recognized_extensions", "type"), &ResourceSaver::get_recognized_extensions);
 
+	BIND_ENUM_CONSTANT(FLAG_NONE);
 	BIND_ENUM_CONSTANT(FLAG_RELATIVE_PATHS);
 	BIND_ENUM_CONSTANT(FLAG_BUNDLE_RESOURCES);
 	BIND_ENUM_CONSTANT(FLAG_CHANGE_PATH);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -93,6 +93,7 @@ protected:
 
 public:
 	enum SaverFlags {
+		FLAG_NONE = 0,
 		FLAG_RELATIVE_PATHS = 1,
 		FLAG_BUNDLE_RESOURCES = 2,
 		FLAG_CHANGE_PATH = 4,
@@ -104,7 +105,7 @@ public:
 
 	static ResourceSaver *get_singleton() { return singleton; }
 
-	Error save(const String &p_path, const RES &p_resource, SaverFlags p_flags);
+	Error save(const String &p_path, const RES &p_resource, uint32_t p_flags);
 	Vector<String> get_recognized_extensions(const RES &p_resource);
 
 	ResourceSaver() { singleton = this; }

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -71,6 +71,7 @@ class ResourceSaver {
 
 public:
 	enum SaverFlags {
+		FLAG_NONE = 0,
 		FLAG_RELATIVE_PATHS = 1,
 		FLAG_BUNDLE_RESOURCES = 2,
 		FLAG_CHANGE_PATH = 4,
@@ -80,7 +81,7 @@ public:
 		FLAG_REPLACE_SUBRESOURCE_PATHS = 64,
 	};
 
-	static Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = 0);
+	static Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = (uint32_t)FLAG_NONE);
 	static void get_recognized_extensions(const RES &p_resource, List<String> *p_extensions);
 	static void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front = false);
 	static void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);

--- a/doc/classes/ResourceSaver.xml
+++ b/doc/classes/ResourceSaver.xml
@@ -21,15 +21,18 @@
 			<return type="int" enum="Error" />
 			<argument index="0" name="path" type="String" />
 			<argument index="1" name="resource" type="Resource" />
-			<argument index="2" name="flags" type="int" enum="ResourceSaver.SaverFlags" default="0" />
+			<argument index="2" name="flags" type="int" default="0" />
 			<description>
 				Saves a resource to disk to the given path, using a [ResourceFormatSaver] that recognizes the resource object.
-				The [code]flags[/code] bitmask can be specified to customize the save behavior.
+				The [code]flags[/code] bitmask can be specified to customize the save behavior using [enum SaverFlags] flags.
 				Returns [constant OK] on success.
 			</description>
 		</method>
 	</methods>
 	<constants>
+		<constant name="FLAG_NONE" value="0" enum="SaverFlags">
+			No resource saving option.
+		</constant>
 		<constant name="FLAG_RELATIVE_PATHS" value="1" enum="SaverFlags">
 			Save the resource with a path relative to the scene which uses it.
 		</constant>


### PR DESCRIPTION
This adds `FLAG_NONE` to `ResourceSaver::SaverFlags`.  
This fixes api inconsistency. `ResourceSaver::save` method has a 0 default value, for type `ResourceSaver::SaverFlags`.  
This leads to not be able to retreive enum value corresponding to default value (as there is no enum value matching 0).