### PR TITLE
Default to real-time radiance map filter for environment sky reflections

### DIFF
--- a/doc/classes/Sky.xml
+++ b/doc/classes/Sky.xml
@@ -9,7 +9,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="process_mode" type="int" setter="set_process_mode" getter="get_process_mode" enum="Sky.ProcessMode" default="0">
+		<member name="process_mode" type="int" setter="set_process_mode" getter="get_process_mode" enum="Sky.ProcessMode" default="3">
 			Sets the method for generating the radiance map from the sky. The radiance map is a cubemap with increasingly blurry versions of the sky corresponding to different levels of roughness. Radiance maps can be expensive to calculate. See [enum ProcessMode] for options.
 		</member>
 		<member name="radiance_size" type="int" setter="set_radiance_size" getter="get_radiance_size" enum="Sky.RadianceSize" default="3">

--- a/scene/resources/sky.cpp
+++ b/scene/resources/sky.cpp
@@ -83,7 +83,7 @@ void Sky::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_material"), &Sky::get_material);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sky_material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial"), "set_material", "get_material");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_mode", PROPERTY_HINT_ENUM, "Automatic,HighQuality,HighQualityIncremental,RealTime"), "set_process_mode", "get_process_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_mode", PROPERTY_HINT_ENUM, "Automatic,High Quality (Slow),High Quality Incremental (Average),Real-Time (Fast)"), "set_process_mode", "get_process_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "radiance_size", PROPERTY_HINT_ENUM, "32,64,128,256,512,1024,2048"), "set_radiance_size", "get_radiance_size");
 
 	BIND_ENUM_CONSTANT(RADIANCE_SIZE_32);

--- a/scene/resources/sky.h
+++ b/scene/resources/sky.h
@@ -59,7 +59,7 @@ public:
 
 private:
 	RID sky;
-	ProcessMode mode = PROCESS_MODE_AUTOMATIC;
+	ProcessMode mode = PROCESS_MODE_REALTIME;
 	RadianceSize radiance_size = RADIANCE_SIZE_256;
 	Ref<Material> sky_material;
 


### PR DESCRIPTION
Can be merged independently of https://github.com/godotengine/godot/pull/55933.

This makes radiance map updates much faster, which improves performance when rotating the sun in the editor or at run-time.

This real-time filter is also much less prone to "fireflies" that can appear when using a sky with a bright sun.

This was discussed in a PR meeting and we agreed upon having this setting as the default :slightly_smiling_face: 

Example with [this HDRI](https://polyhaven.com/a/narrow_moonlit_road):

### Before

![2022-02-10_20 16 32](https://user-images.githubusercontent.com/180032/153480652-767b6e8a-0a34-41f3-903f-07fc6fc7c085.png)

### After

![2022-02-10_20 16 41](https://user-images.githubusercontent.com/180032/153480660-fc663eb0-e54d-4143-9cd3-885589f8d99f.png)