### PR TITLE
Extract link titles for translation if available

### DIFF
--- a/doc/translations/extract.py
+++ b/doc/translations/extract.py
@@ -222,12 +222,14 @@ def _make_translation_catalog(classes):
         desc_list = classes[class_name]
         for elem in desc_list.doc.iter():
             if elem.tag in EXTRACT_TAGS:
-                if not elem.text or len(elem.text) == 0:
+                elem_text = elem.text
+                if elem.tag == "link":
+                    elem_text = elem.attrib["title"] if "title" in elem.attrib else ""
+                if not elem_text or len(elem_text) == 0:
                     continue
-                if elem.tag == "link" and "$DOCS_URL" in elem.text:  # No need to localize.
-                    continue
-                line_no = elem._start_line_number if elem.text[0] != "\n" else elem._start_line_number + 1
-                desc_str = elem.text.strip()
+
+                line_no = elem._start_line_number if elem_text[0] != "\n" else elem._start_line_number + 1
+                desc_str = elem_text.strip()
                 code_block_regions = _make_codeblock_regions(desc_str, desc_list.path)
                 desc_msg = _strip_and_split_desc(desc_str, code_block_regions)
                 desc_obj = Desc(line_no, desc_msg, desc_list)


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/57916. We actually never need the content of the links, not just when they start with `$DOCS_URL`. Entries like `https://godotengine.org/asset-library/asset/515` ([from here](https://hosted.weblate.org/translate/godot-engine/godot-class-reference/en/?checksum=680bb53e56bcb146&sort_by=-priority,position)) are just as untranslatable.

This also adds all the link titles to the mix, so they can now be translated. Not sure how to add a translator comment to reference the link here.