### PR TITLE
[HTML5] Fetch API now passes credentials.

### DIFF
--- a/platform/javascript/js/libs/library_godot_fetch.js
+++ b/platform/javascript/js/libs/library_godot_fetch.js
@@ -89,6 +89,7 @@ const GodotFetch = {
 				method: method,
 				headers: headers,
 				body: body,
+				credentials: 'include',
 			};
 			obj.request = fetch(url, init);
 			obj.request.then(GodotFetch.onresponse.bind(null, id)).catch(GodotFetch.onerror.bind(null, id));


### PR DESCRIPTION
Used default value before, i.e. "same-origin", now uses "include" (i.e. include for cross-origin if cross-origin is allowed).

Fixes #54447