### PR TITLE
Tweak the Bullet RigidBody kinematic trimesh warning message

### DIFF
--- a/modules/bullet/rigid_body_bullet.cpp
+++ b/modules/bullet/rigid_body_bullet.cpp
@@ -252,7 +252,7 @@ void RigidBodyBullet::KinematicUtilities::copyAllOwnerShapes() {
 				shapes.write[i].shape = static_cast<btConvexShape *>(shape_wrapper->shape->create_bt_shape(owner_scale * shape_wrapper->scale, safe_margin));
 			} break;
 			default:
-				WARN_PRINT("This shape is not supported to be kinematic!");
+				WARN_PRINT("RigidBody in 3D only supports primitive shapes or convex polygon shapes. Concave (trimesh) polygon shapes are not supported.");
 				shapes.write[i].shape = nullptr;
 		}
 	}


### PR DESCRIPTION
This makes it clearer that primitive or convex shapes must be used instead.

Note that this message won't be printed when using a RigidBody with a trimesh in Rigid or Character mode. This is something that could be added in a future PR (in debug builds only, if checking has a performance cost).