### PR TITLE
Add editor setting for 2D collision outline visibility

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -643,6 +643,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("editors/2d/bone_outline_size", 2);
 	_initial_set("editors/2d/viewport_border_color", Color(0.4, 0.4, 1.0, 0.4));
 	_initial_set("editors/2d/constrain_editor_view", true);
+	_initial_set("editors/2d/draw_collision_outlines", true);
 
 	// Panning
 	// Enum should be in sync with ControlScheme in ViewPanner.

--- a/scene/resources/shape_2d.cpp
+++ b/scene/resources/shape_2d.cpp
@@ -34,6 +34,10 @@
 #include "core/config/project_settings.h"
 #include "servers/physics_server_2d.h"
 
+#ifdef TOOLS_ENABLED
+#include "editor/editor_settings.h"
+#endif // TOOLS_ENABLED
+
 RID Shape2D::get_rid() const {
 	return shape;
 }
@@ -112,7 +116,7 @@ void Shape2D::_bind_methods() {
 bool Shape2D::is_collision_outline_enabled() {
 #ifdef TOOLS_ENABLED
 	if (Engine::get_singleton()->is_editor_hint()) {
-		return true;
+		return EditorSettings::get_singleton()->get("editors/2d/draw_2d_outlines");
 	}
 #endif
 	return GLOBAL_DEF("debug/shapes/collision/draw_2d_outlines", true);


### PR DESCRIPTION
Adds a separate `editors/2d/draw_collision_outlines` editor setting to mirror behavior of the `debug/shapes/collision/draw_2d_outlines` but in editor.

Temporary work around for #56320
Closes #56986