### PR TITLE
Improve the `AudioStreamPlayer2D/3D.area_mask` documentation

### DIFF
--- a/doc/classes/AudioStreamPlayer2D.xml
+++ b/doc/classes/AudioStreamPlayer2D.xml
@@ -47,7 +47,7 @@
 	</methods>
 	<members>
 		<member name="area_mask" type="int" setter="set_area_mask" getter="get_area_mask" default="1">
-			Areas in which this sound plays.
+			Determines which [Area2D] layers affect the sound for reverb and audio bus effects. Areas can be used to redirect [AudioStream]s so that they play in a certain audio bus. An example of how you might use this is making a "water" area so that sounds played in the water are redirected through an audio bus to make them sound like they are being played underwater.
 		</member>
 		<member name="attenuation" type="float" setter="set_attenuation" getter="get_attenuation" default="1.0">
 			Dampens audio over distance with this as an exponent.

--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -48,7 +48,7 @@
 	</methods>
 	<members>
 		<member name="area_mask" type="int" setter="set_area_mask" getter="get_area_mask" default="1">
-			Areas in which this sound plays.
+			Determines which [Area3D] layers affect the sound for reverb and audio bus effects. Areas can be used to redirect [AudioStream]s so that they play in a certain audio bus. An example of how you might use this is making a "water" area so that sounds played in the water are redirected through an audio bus to make them sound like they are being played underwater.
 		</member>
 		<member name="attenuation_filter_cutoff_hz" type="float" setter="set_attenuation_filter_cutoff_hz" getter="get_attenuation_filter_cutoff_hz" default="5000.0">
 			Dampens audio using a low-pass filter above this frequency, in Hz. To disable the dampening effect entirely, set this to [code]20500[/code] as this frequency is above the human hearing limit.


### PR DESCRIPTION
The documentation was stating that the area mask affects where sounds can be heard, which is not true. Instead, the area mask affects audio bus redirection.

[Thanks to Azedaxen on the Godot forums for providing this description](https://godotforums.org/discussion/comment/62885/#Comment_62885) :slightly_smiling_face: 