### PR TITLE
Make blend shape format check less strict

### DIFF
--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -933,7 +933,7 @@ Error RenderingServer::mesh_create_surface_data_from_arrays(SurfaceData *r_surfa
 				}
 			}
 
-			ERR_FAIL_COND_V_MSG(bsformat != (format & RS::ARRAY_FORMAT_BLEND_SHAPE_MASK), ERR_INVALID_PARAMETER, "Blend shape format must match the main array format for Vertex, Normal and Tangent arrays.");
+			ERR_FAIL_COND_V_MSG((bsformat & RS::ARRAY_FORMAT_BLEND_SHAPE_MASK) != (format & RS::ARRAY_FORMAT_BLEND_SHAPE_MASK), ERR_INVALID_PARAMETER, "Blend shape format must match the main array format for Vertex, Normal and Tangent arrays.");
 		}
 	}
 


### PR DESCRIPTION
After PR #57801, we ran into a problem that all existing importers fail to import any mesh with blend shapes, because they pass the blend shapes through SurfaceTool, and SurfaceTool requires UVs in order to calculate tangents. Since UVs are not in RS::ARRAY_FORMAT_BLEND_SHAPE_MASK, this was causing an error on import of any gltf, fbx (or possibly dae) file with blend shapes.

(See modules/gltf/gltf_document.cpp line 2872; modules/fbx/data/fbx_mesh_data.cpp; editor/import/editor_import_collada.cpp line 1001)

This loosens the check to make it more similar to how it was before, though fixing the importers may also be an option.
CC @reduz 