### PR TITLE
Fix selecting keys in Animation Track Editor

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -4952,7 +4952,7 @@ void AnimationTrackEditor::_add_method_key(const String &p_method) {
 	EditorNode::get_singleton()->show_warning(TTR("Method not found in object: ") + p_method);
 }
 
-void AnimationTrackEditor::_key_selected(int p_track, int p_key, bool p_single) {
+void AnimationTrackEditor::_key_selected(int p_key, bool p_single, int p_track) {
 	ERR_FAIL_INDEX(p_track, animation->get_track_count());
 	ERR_FAIL_INDEX(p_key, animation->track_get_key_count(p_track));
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -406,7 +406,7 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	Map<SelectedKey, KeyInfo> selection;
 
-	void _key_selected(int p_track, int p_key, bool p_single);
+	void _key_selected(int p_key, bool p_single, int p_track);
 	void _key_deselected(int p_key, int p_track);
 
 	bool moving_selection;


### PR DESCRIPTION
The recent PR #55030 introduced a regression bug that made it impossible to select keyframes in the regular track editor (though it was working in the bezier editor.) This was because the connection array argument was put first instead of last in the key selected signal connection function.