### PR TITLE
Fixup: Add missing binding to AudioStream class

### DIFF
--- a/doc/classes/AudioStream.xml
+++ b/doc/classes/AudioStream.xml
@@ -39,6 +39,12 @@
 				Returns the length of the audio stream in seconds.
 			</description>
 		</method>
+		<method name="instance_playback">
+			<return type="AudioStreamPlayback" />
+			<description>
+				Returns an AudioStreamPlayback. Useful for when you want to extend `_instance_playback` but call `instance_playback` from an internally held AudioStream subresource. An example of this can be found in the source files for `AudioStreamRandomPitch::instance_playback`.
+			</description>
+		</method>
 		<method name="is_monophonic" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -200,6 +200,7 @@ bool AudioStream::is_monophonic() const {
 void AudioStream::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_length"), &AudioStream::get_length);
 	ClassDB::bind_method(D_METHOD("is_monophonic"), &AudioStream::is_monophonic);
+	ClassDB::bind_method(D_METHOD("instance_playback"), &AudioStream::instance_playback);
 	GDVIRTUAL_BIND(_instance_playback);
 	GDVIRTUAL_BIND(_get_stream_name);
 	GDVIRTUAL_BIND(_get_length);


### PR DESCRIPTION
This allows for the extension of AudioStream where you can call `instance_plackback` on child AudioStream instances, much like the implementation of some child classes in C++. 

I ran into this issue when trying to make an advanced multi-sample godot plugin where I wanted to extend `instance_playback` and call `instance_playback` on child instances. While extension was possible originally, it was not possible to call instance_playback on other instances.  
