### PR TITLE
AnimationTree: New "Phase" Node

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -109,7 +109,7 @@
 				Amount of inputs in this node, only useful for nodes that go into [AnimationNodeBlendTree].
 			</description>
 		</method>
-		<method name="get_input_name">
+		<method name="get_input_name" qualifiers="const">
 			<return type="String" />
 			<argument index="0" name="input" type="int" />
 			<description>

--- a/doc/classes/AnimationNodePhase.xml
+++ b/doc/classes/AnimationNodePhase.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AnimationNodePhase" inherits="AnimationNode" version="4.0">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/editor/plugins/animation_blend_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_blend_tree_editor_plugin.cpp
@@ -964,6 +964,7 @@ AnimationNodeBlendTreeEditor::AnimationNodeBlendTreeEditor() {
 	add_options.push_back(AddOption("Blend2", "AnimationNodeBlend2", 2));
 	add_options.push_back(AddOption("Blend3", "AnimationNodeBlend3", 3));
 	add_options.push_back(AddOption("Seek", "AnimationNodeTimeSeek", 1));
+	add_options.push_back(AddOption("Phase", "AnimationNodePhase", 1));
 	add_options.push_back(AddOption("TimeScale", "AnimationNodeTimeScale", 1));
 	add_options.push_back(AddOption("Transition", "AnimationNodeTransition"));
 	add_options.push_back(AddOption("BlendTree", "AnimationNodeBlendTree"));

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -276,6 +276,29 @@ public:
 	AnimationNodeTimeSeek();
 };
 
+class AnimationNodePhase : public AnimationNode {
+	GDCLASS(AnimationNodePhase, AnimationNode);
+
+	StringName phase = "phase";
+
+private:
+	static void _recurse_inputs_impl(List<Ref<AnimationNode>> *r_input_names, const AnimationNode *node, const AnimationNodeBlendTree *p_parent);
+	void _recurse_inputs(List<Ref<AnimationNode>> *r_input_nodes) const;
+	void _all_input_animation_nodes(List<Ref<AnimationNodeAnimation>> *r_anim_nodes) const;
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
+
+	virtual String get_caption() const override;
+
+	double process(double p_time, bool p_seek) override;
+	AnimationNodePhase();
+};
+
 class AnimationNodeTransition : public AnimationNode {
 	GDCLASS(AnimationNodeTransition, AnimationNode);
 

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -296,7 +296,7 @@ int AnimationNode::get_input_count() const {
 	return inputs.size();
 }
 
-String AnimationNode::get_input_name(int p_input) {
+String AnimationNode::get_input_name(int p_input) const {
 	ERR_FAIL_INDEX_V(p_input, inputs.size(), String());
 	return inputs[p_input].name;
 }

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -135,7 +135,7 @@ public:
 	virtual String get_caption() const;
 
 	int get_input_count() const;
-	String get_input_name(int p_input);
+	String get_input_name(int p_input) const;
 
 	void add_input(const String &p_name);
 	void set_input_name(int p_input, const String &p_name);

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -443,6 +443,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(AnimationNodeBlend3);
 	GDREGISTER_CLASS(AnimationNodeTimeScale);
 	GDREGISTER_CLASS(AnimationNodeTimeSeek);
+	GDREGISTER_CLASS(AnimationNodePhase);
 	GDREGISTER_CLASS(AnimationNodeTransition);
 
 	GDREGISTER_CLASS(ShaderGlobalsOverride); // can be used in any shader


### PR DESCRIPTION
Phase node allows for the use of connected animation player nodes as a normalized seek (0.0->1.0) where you describe where in the animation you want to be. It will use the longest time of all connected animations to determine the phase scale.

This can be useful in circumstances where the user wants to treat an animation as it's own blend space, where the beginning and end of the animation represent a blend between states.

In the below video, I'm using hand tailored animation to represent a blend space between "full turn left" and "full turn right" of a snowboarder. When combined with other layers of animation, you could see that this would be quite powerful when programmatically animating a character. (The below image links to a youtube video.)

[![godot-animation-phase-node](https://user-images.githubusercontent.com/3040352/153544080-f6efecd2-e7be-4ade-95cc-a8a87a20c377.gif)](https://www.youtube.com/watch?v=bUHfMXsvVt4)

