### PR TITLE
Deselect nodes in the 3D editor when pressing ESC

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1888,7 +1888,12 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 			}
 		}
 
-		if (_edit.mode != TRANSFORM_NONE) {
+		if (_edit.mode == TRANSFORM_NONE) {
+			if (k->get_keycode() == Key::ESCAPE && !cursor.region_select) {
+				_clear_selected();
+				return;
+			}
+		} else {
 			// We're actively transforming, handle keys specially
 			TransformPlane new_plane = TRANSFORM_VIEW;
 			String new_message;


### PR DESCRIPTION
This is an improved version of #57860, which only deselects when not in the process of transforming or selecting nodes.