### PR TITLE
Editor: Allow to override CLI args on a per-instance basis

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1221,6 +1221,10 @@ ProjectSettings::ProjectSettings() {
 	extensions.push_back("gdshader");
 
 	GLOBAL_DEF("editor/run/main_run_args", "");
+	GLOBAL_DEF("editor/run/instance_1_run_args", "");
+	GLOBAL_DEF("editor/run/instance_2_run_args", "");
+	GLOBAL_DEF("editor/run/instance_3_run_args", "");
+	GLOBAL_DEF("editor/run/instance_4_run_args", "");
 
 	GLOBAL_DEF("editor/script/search_in_file_extensions", extensions);
 	custom_prop_info["editor/script/search_in_file_extensions"] = PropertyInfo(Variant::PACKED_STRING_ARRAY, "editor/script/search_in_file_extensions");

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -536,6 +536,23 @@
 		<member name="editor/node_naming/name_num_separator" type="int" setter="" getter="" default="0">
 			What to use to separate node name from number. This is mostly an editor setting.
 		</member>
+		<member name="editor/run/instance_1_run_args" type="String" setter="" getter="" default="&quot;&quot;">
+			The command-line arguments to use for instance 1 when running the project. This overrides the arguments set in [member editor/run/main_run_args].
+			For further details, see [member editor/run/main_run_args].
+			Instance 1 is the default instance. The Editor can be set to start multiple instances by using the "Run Multiple Instances" setting in the Debug menu.
+		</member>
+		<member name="editor/run/instance_2_run_args" type="String" setter="" getter="" default="&quot;&quot;">
+			The command-line arguments to use for instance 2 when running the project. This overrides the arguments set in [member editor/run/main_run_args].
+			For further details, see [member editor/run/main_run_args]. The Editor can be set to start multiple instances by using the "Run Multiple Instances" setting in the Debug menu.
+		</member>
+		<member name="editor/run/instance_3_run_args" type="String" setter="" getter="" default="&quot;&quot;">
+			The command-line arguments to use for instance 3 when running the project. This overrides the arguments set in [member editor/run/main_run_args].
+			For further details, see [member editor/run/main_run_args]. The Editor can be set to start multiple instances by using the "Run Multiple Instances" setting in the Debug menu.
+		</member>
+		<member name="editor/run/instance_4_run_args" type="String" setter="" getter="" default="&quot;&quot;">
+			The command-line arguments to use for instance 3 when running the project. This overrides the arguments set in [member editor/run/main_run_args].
+			For further details, see [member editor/run/main_run_args]. The Editor can be set to start multiple instances by using the "Run Multiple Instances" setting in the Debug menu.
+		</member>
 		<member name="editor/run/main_run_args" type="String" setter="" getter="" default="&quot;&quot;">
 			The command-line arguments to append to Godot's own command line when running the project. This doesn't affect the editor itself.
 			It is possible to make another executable run Godot by using the [code]%command%[/code] placeholder. The placeholder will be replaced with Godot's own command line. Program-specific arguments should be placed [i]before[/i] the placeholder, whereas Godot-specific arguments should be placed [i]after[/i] the placeholder.
@@ -543,6 +560,8 @@
 			[codeblock]
 			prime-run %command%
 			[/codeblock]
+			Note that the settings [member editor/run/instance_1_run_args] to [member editor/run/instance_4_run_args] allow to override these arguments on a per-instance basis.
+			Instance 1 is the default instance. Instances 2 to 4 can be enabled by using the "Run Multiple Instances" setting in the Debug menu.
 		</member>
 		<member name="editor/script/search_in_file_extensions" type="PackedStringArray" setter="" getter="" default="PackedStringArray(&quot;gd&quot;, &quot;gdshader&quot;)">
 			Text-based file extensions to include in the script editor's "Find in Files" feature. You can add e.g. [code]tscn[/code] if you wish to also parse your scene files, especially if you use built-in scripts which are serialized in the scene files.

--- a/editor/editor_run.h
+++ b/editor/editor_run.h
@@ -47,6 +47,8 @@ private:
 	Status status;
 	String running_scene;
 
+	void parse_run_args(String *exec_path, List<String> *args, const String raw_custom_args);
+
 public:
 	Status get_status() const;
 	String get_running_scene() const;


### PR DESCRIPTION
When running the Project from the Editor, this allows the user to override the CLI arguments each instance is started with per instance using the new advanced project settings `editor/run/instance_1_run_args` through `editor/run/instance_4_run_args` (overriding `editor/run/main_run_args` for each instance if set).

This is useful for multiplayer testing or when testing with different settings/profiles to reduce manual configuration on each test/run.

These new advanced settings, like the main run args one, are hidden by default.
Supersedes https://github.com/godotengine/godot/pull/57910. May also be a first step towards this proposal: https://github.com/godotengine/godot-proposals/issues/522