### PR TITLE
Hide CollisionShape2D handles when node is not visible in tree.

### DIFF
--- a/editor/plugins/collision_shape_2d_editor_plugin.cpp
+++ b/editor/plugins/collision_shape_2d_editor_plugin.cpp
@@ -323,6 +323,10 @@ bool CollisionShape2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_e
 		return false;
 	}
 
+	if (!node->is_visible_in_tree()) {
+		return false;
+	}
+
 	if (shape_type == -1) {
 		return false;
 	}
@@ -442,6 +446,10 @@ void CollisionShape2DEditor::forward_canvas_draw_over_viewport(Control *p_overla
 	}
 
 	if (!node->get_shape().is_valid()) {
+		return;
+	}
+
+	if (!node->is_visible_in_tree()) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #57924

### Issue fixed

CollisionShape2D handles were still drawn if the node or one of its parents was hidden.
This behavior was different from 3D beheviour.

### Fix proposal

Do not draw handles if node is not visible in tree and prevent interaction with invisible handles.

# Before
![bug](https://user-images.githubusercontent.com/3649998/153643173-fae35f88-74dd-49ae-b521-8bc77cc115b0.gif)

# After
![fixed](https://user-images.githubusercontent.com/3649998/153643189-d006394e-b80d-4acb-ae5e-2c6dbc57c4ee.gif)

