### PR TITLE
Add get_character_line method for RichTextLabel

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -49,6 +49,20 @@
 				Clears the tag stack and sets [member text] to an empty string.
 			</description>
 		</method>
+		<method name="get_character_line">
+			<return type="int" />
+			<argument index="0" name="character" type="int" />
+			<description>
+				Returns the line number of the character position provided.
+			</description>
+		</method>
+		<method name="get_character_paragraph">
+			<return type="int" />
+			<argument index="0" name="character" type="int" />
+			<description>
+				Returns the paragraph number of the character position provided.
+			</description>
+		</method>
 		<method name="get_content_height" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4327,6 +4327,8 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_percent_visible", "percent_visible"), &RichTextLabel::set_percent_visible);
 	ClassDB::bind_method(D_METHOD("get_percent_visible"), &RichTextLabel::get_percent_visible);
 
+	ClassDB::bind_method(D_METHOD("get_character_line", "character"), &RichTextLabel::get_character_line);
+	ClassDB::bind_method(D_METHOD("get_character_paragraph", "character"), &RichTextLabel::get_character_paragraph);
 	ClassDB::bind_method(D_METHOD("get_total_character_count"), &RichTextLabel::get_total_character_count);
 
 	ClassDB::bind_method(D_METHOD("set_use_bbcode", "enable"), &RichTextLabel::set_use_bbcode);
@@ -4457,6 +4459,36 @@ void RichTextLabel::set_visible_characters(int p_visible) {
 
 int RichTextLabel::get_visible_characters() const {
 	return visible_characters;
+}
+
+int RichTextLabel::get_character_line(int p_char) {
+	int line_count = 0;
+	for (int i = 0; i < main->lines.size(); i++) {
+		if (main->lines[i].char_offset < p_char && p_char <= main->lines[i].char_offset + main->lines[i].char_count) {
+			for (int j = 0; j < main->lines[i].text_buf->get_line_count(); j++) {
+				Vector2i range = main->lines[i].text_buf->get_line_range(j);
+				if (main->lines[i].char_offset + range.x < p_char && p_char <= main->lines[i].char_offset + range.y) {
+					return line_count;
+				}
+				line_count++;
+			}
+		} else {
+			line_count += main->lines[i].text_buf->get_line_count();
+		}
+	}
+	return -1;
+}
+
+int RichTextLabel::get_character_paragraph(int p_char) {
+	int para_count = 0;
+	for (int i = 0; i < main->lines.size(); i++) {
+		if (main->lines[i].char_offset < p_char && p_char <= main->lines[i].char_offset + main->lines[i].char_count) {
+			return para_count;
+		} else {
+			para_count++;
+		}
+	}
+	return -1;
 }
 
 int RichTextLabel::get_total_character_count() const {

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -598,6 +598,8 @@ public:
 
 	void set_visible_characters(int p_visible);
 	int get_visible_characters() const;
+	int get_character_line(int p_char);
+	int get_character_paragraph(int p_char);
 	int get_total_character_count() const;
 	int get_total_glyph_count() const;
 


### PR DESCRIPTION
Adds the ability to get the line number of a provided character position.
This was originally going to only provide the the line number of the last visible character, as a way to know when text has gone off screen, but I felt this is a bit more versatile, since you can still provide it `VisibleCharacters`.