### PR TITLE
Fix 3D editor axis drag lines precision issue

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -6307,14 +6307,15 @@ void fragment() {
 			// Lines to visualize transforms locked to an axis/plane
 			{
 				Ref<SurfaceTool> surftool = memnew(SurfaceTool);
-				surftool->begin(Mesh::PRIMITIVE_LINES);
+				surftool->begin(Mesh::PRIMITIVE_LINE_STRIP);
 
 				Vector3 vec;
 				vec[i] = 1;
 
 				// line extending through infinity(ish)
-				surftool->add_vertex(vec * -99999);
-				surftool->add_vertex(vec * 99999);
+				surftool->add_vertex(vec * -1048576);
+				surftool->add_vertex(Vector3());
+				surftool->add_vertex(vec * 1048576);
 				surftool->set_material(mat_hl);
 				surftool->commit(axis_gizmo[i]);
 			}


### PR DESCRIPTION

Fixes #57893

### Issue description:

Axis drag lines in the 3D editor vibrates when dragging an object.

### Fix proposal:

Adding a central point to the axis prevent drawn line to be too long and precision issue.

### Before:
![bug](https://user-images.githubusercontent.com/3649998/153677027-4ca4b36d-ea5d-4729-9df7-562e502c6470.gif)

### After:
![fixed](https://user-images.githubusercontent.com/3649998/153677043-46d1af09-e320-4882-9bd7-d3e500abb993.gif)

