### PR TITLE
Tweak default ProceduralSkyMaterial and PhysicalSkyMaterial appearance

### DIFF
--- a/doc/classes/PhysicalSkyMaterial.xml
+++ b/doc/classes/PhysicalSkyMaterial.xml
@@ -17,14 +17,14 @@
 		<member name="exposure" type="float" setter="set_exposure" getter="get_exposure" default="0.1">
 			Sets the exposure of the sky. Higher exposure values make the entire sky brighter.
 		</member>
-		<member name="ground_color" type="Color" setter="set_ground_color" getter="get_ground_color" default="Color(1, 1, 1, 1)">
+		<member name="ground_color" type="Color" setter="set_ground_color" getter="get_ground_color" default="Color(0.1, 0.07, 0.034, 1)">
 			Modulates the [Color] on the bottom half of the sky to represent the ground.
 		</member>
 		<member name="mie_coefficient" type="float" setter="set_mie_coefficient" getter="get_mie_coefficient" default="0.005">
 			Controls the strength of mie scattering for the sky. Mie scattering results from light colliding with larger particles (like water). On earth, mie scattering results in a whitish color around the sun and horizon.
 		</member>
-		<member name="mie_color" type="Color" setter="set_mie_color" getter="get_mie_color" default="Color(0.63, 0.77, 0.92, 1)">
-			Controls the [Color] of the mie scattering effect. While not physically accurate, this allows for the creation of alien looking planets.
+		<member name="mie_color" type="Color" setter="set_mie_color" getter="get_mie_color" default="Color(0.69, 0.729, 0.812, 1)">
+			Controls the [Color] of the mie scattering effect. While not physically accurate, this allows for the creation of alien-looking planets.
 		</member>
 		<member name="mie_eccentricity" type="float" setter="set_mie_eccentricity" getter="get_mie_eccentricity" default="0.8">
 			Controls the direction of the mie scattering. A value of [code]1[/code] means that when light hits a particle it's passing through straight forward. A value of [code]-1[/code] means that all light is scatter backwards.
@@ -35,14 +35,14 @@
 		<member name="rayleigh_coefficient" type="float" setter="set_rayleigh_coefficient" getter="get_rayleigh_coefficient" default="2.0">
 			Controls the strength of the Rayleigh scattering. Rayleigh scattering results from light colliding with small particles. It is responsible for the blue color of the sky.
 		</member>
-		<member name="rayleigh_color" type="Color" setter="set_rayleigh_color" getter="get_rayleigh_color" default="Color(0.26, 0.41, 0.58, 1)">
-			Controls the [Color] of the Rayleigh scattering. While not physically accurate, this allows for the creation of alien looking planets. For example, setting this to a red [Color] results in a Mars looking atmosphere with a corresponding blue sunset.
+		<member name="rayleigh_color" type="Color" setter="set_rayleigh_color" getter="get_rayleigh_color" default="Color(0.3, 0.405, 0.6, 1)">
+			Controls the [Color] of the Rayleigh scattering. While not physically accurate, this allows for the creation of alien-looking planets. For example, setting this to a red [Color] results in a Mars-looking atmosphere with a corresponding blue sunset.
 		</member>
 		<member name="sun_disk_scale" type="float" setter="set_sun_disk_scale" getter="get_sun_disk_scale" default="1.0">
 			Sets the size of the sun disk. Default value is based on Sol's perceived size from Earth.
 		</member>
 		<member name="turbidity" type="float" setter="set_turbidity" getter="get_turbidity" default="10.0">
-			Sets the thickness of the atmosphere. High turbidity creates a foggy looking atmosphere, while a low turbidity results in a clearer atmosphere.
+			Sets the thickness of the atmosphere. High turbidity creates a foggy-looking atmosphere, while a low turbidity results in a clearer atmosphere.
 		</member>
 	</members>
 </class>

--- a/doc/classes/ProceduralSkyMaterial.xml
+++ b/doc/classes/ProceduralSkyMaterial.xml
@@ -11,7 +11,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="ground_bottom_color" type="Color" setter="set_ground_bottom_color" getter="get_ground_bottom_color" default="Color(0.12, 0.12, 0.13, 1)">
+		<member name="ground_bottom_color" type="Color" setter="set_ground_bottom_color" getter="get_ground_bottom_color" default="Color(0.2, 0.169, 0.133, 1)">
 			Color of the ground at the bottom. Blends with [member ground_horizon_color].
 		</member>
 		<member name="ground_curve" type="float" setter="set_ground_curve" getter="get_ground_curve" default="0.02">
@@ -20,25 +20,25 @@
 		<member name="ground_energy" type="float" setter="set_ground_energy" getter="get_ground_energy" default="1.0">
 			Amount of energy contribution from the ground.
 		</member>
-		<member name="ground_horizon_color" type="Color" setter="set_ground_horizon_color" getter="get_ground_horizon_color" default="Color(0.37, 0.33, 0.31, 1)">
+		<member name="ground_horizon_color" type="Color" setter="set_ground_horizon_color" getter="get_ground_horizon_color" default="Color(0.6463, 0.6558, 0.6708, 1)">
 			Color of the ground at the horizon. Blends with [member ground_bottom_color].
 		</member>
-		<member name="sky_curve" type="float" setter="set_sky_curve" getter="get_sky_curve" default="0.09">
+		<member name="sky_curve" type="float" setter="set_sky_curve" getter="get_sky_curve" default="0.15">
 			How quickly the [member sky_horizon_color] fades into the [member sky_top_color].
 		</member>
 		<member name="sky_energy" type="float" setter="set_sky_energy" getter="get_sky_energy" default="1.0">
 			Amount of energy contribution from the sky.
 		</member>
-		<member name="sky_horizon_color" type="Color" setter="set_sky_horizon_color" getter="get_sky_horizon_color" default="Color(0.55, 0.69, 0.81, 1)">
+		<member name="sky_horizon_color" type="Color" setter="set_sky_horizon_color" getter="get_sky_horizon_color" default="Color(0.6463, 0.6558, 0.6708, 1)">
 			Color of the sky at the horizon. Blends with [member sky_top_color].
 		</member>
-		<member name="sky_top_color" type="Color" setter="set_sky_top_color" getter="get_sky_top_color" default="Color(0.35, 0.46, 0.71, 1)">
+		<member name="sky_top_color" type="Color" setter="set_sky_top_color" getter="get_sky_top_color" default="Color(0.385, 0.454, 0.55, 1)">
 			Color of the sky at the top. Blends with [member sky_horizon_color].
 		</member>
-		<member name="sun_angle_max" type="float" setter="set_sun_angle_max" getter="get_sun_angle_max" default="100.0">
+		<member name="sun_angle_max" type="float" setter="set_sun_angle_max" getter="get_sun_angle_max" default="30.0">
 			Distance from center of sun where it fades out completely.
 		</member>
-		<member name="sun_curve" type="float" setter="set_sun_curve" getter="get_sun_curve" default="0.05">
+		<member name="sun_curve" type="float" setter="set_sun_curve" getter="get_sun_curve" default="0.15">
 			How quickly the sun fades away between the edge of the sun disk and [member sun_angle_max].
 		</member>
 	</members>

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7353,8 +7353,8 @@ void Node3DEditor::_load_default_preview_settings() {
 	sun_angle_altitude->set_value(-Math::rad2deg(sun_rotation.x));
 	sun_angle_azimuth->set_value(180.0 - Math::rad2deg(sun_rotation.y));
 	sun_direction->update();
-	environ_sky_color->set_pick_color(Color::hex(0x91b2ceff));
-	environ_ground_color->set_pick_color(Color::hex(0x1f1f21ff));
+	environ_sky_color->set_pick_color(Color(0.385, 0.454, 0.55));
+	environ_ground_color->set_pick_color(Color(0.2, 0.169, 0.133));
 	environ_energy->set_value(1.0);
 	environ_glow_button->set_pressed(true);
 	environ_tonemap_button->set_pressed(true);

--- a/scene/resources/sky_material.cpp
+++ b/scene/resources/sky_material.cpp
@@ -208,16 +208,16 @@ void ProceduralSkyMaterial::_update_shader() {
 
 shader_type sky;
 
-uniform vec4 sky_top_color : hint_color = vec4(0.35, 0.46, 0.71, 1.0);
-uniform vec4 sky_horizon_color : hint_color = vec4(0.55, 0.69, 0.81, 1.0);
-uniform float sky_curve : hint_range(0, 1) = 0.09;
+uniform vec4 sky_top_color : hint_color = vec4(0.385, 0.454, 0.55, 1.0);
+uniform vec4 sky_horizon_color : hint_color = vec4(0.646, 0.656, 0.67, 1.0);
+uniform float sky_curve : hint_range(0, 1) = 0.15;
 uniform float sky_energy = 1.0;
-uniform vec4 ground_bottom_color : hint_color = vec4(0.12, 0.12, 0.13, 1.0);
-uniform vec4 ground_horizon_color : hint_color = vec4(0.37, 0.33, 0.31, 1.0);
+uniform vec4 ground_bottom_color : hint_color = vec4(0.2, 0.169, 0.133, 1.0);
+uniform vec4 ground_horizon_color : hint_color = vec4(0.646, 0.656, 0.67, 1.0);
 uniform float ground_curve : hint_range(0, 1) = 0.02;
 uniform float ground_energy = 1.0;
-uniform float sun_angle_max = 1.74;
-uniform float sun_curve : hint_range(0, 1) = 0.05;
+uniform float sun_angle_max = 30.0;
+uniform float sun_curve : hint_range(0, 1) = 0.15;
 
 void sky() {
 	float v_angle = acos(clamp(EYEDIR.y, -1.0, 1.0));
@@ -277,18 +277,18 @@ void sky() {
 }
 
 ProceduralSkyMaterial::ProceduralSkyMaterial() {
-	set_sky_top_color(Color(0.35, 0.46, 0.71));
-	set_sky_horizon_color(Color(0.55, 0.69, 0.81));
-	set_sky_curve(0.09);
+	set_sky_top_color(Color(0.385, 0.454, 0.55));
+	set_sky_horizon_color(Color(0.6463, 0.6558, 0.6708));
+	set_sky_curve(0.15);
 	set_sky_energy(1.0);
 
-	set_ground_bottom_color(Color(0.12, 0.12, 0.13));
-	set_ground_horizon_color(Color(0.37, 0.33, 0.31));
+	set_ground_bottom_color(Color(0.2, 0.169, 0.133));
+	set_ground_horizon_color(Color(0.6463, 0.6558, 0.6708));
 	set_ground_curve(0.02);
 	set_ground_energy(1.0);
 
-	set_sun_angle_max(100.0);
-	set_sun_curve(0.05);
+	set_sun_angle_max(30.0);
+	set_sun_curve(0.15);
 }
 
 ProceduralSkyMaterial::~ProceduralSkyMaterial() {
@@ -583,14 +583,14 @@ void PhysicalSkyMaterial::_update_shader() {
 shader_type sky;
 
 uniform float rayleigh : hint_range(0, 64) = 2.0;
-uniform vec4 rayleigh_color : hint_color = vec4(0.26, 0.41, 0.58, 1.0);
+uniform vec4 rayleigh_color : hint_color = vec4(0.3, 0.405, 0.6, 1.0);
 uniform float mie : hint_range(0, 1) = 0.005;
 uniform float mie_eccentricity : hint_range(-1, 1) = 0.8;
-uniform vec4 mie_color : hint_color = vec4(0.63, 0.77, 0.92, 1.0);
+uniform vec4 mie_color : hint_color = vec4(0.69, 0.729, 0.812, 1.0);
 
 uniform float turbidity : hint_range(0, 1000) = 10.0;
 uniform float sun_disk_scale : hint_range(0, 360) = 1.0;
-uniform vec4 ground_color : hint_color = vec4(1.0);
+uniform vec4 ground_color : hint_color = vec4(0.1, 0.07, 0.034, 1.0);
 uniform float exposure : hint_range(0, 128) = 0.1;
 uniform float dither_strength : hint_range(0, 10) = 1.0;
 
@@ -680,13 +680,13 @@ void sky() {
 
 PhysicalSkyMaterial::PhysicalSkyMaterial() {
 	set_rayleigh_coefficient(2.0);
-	set_rayleigh_color(Color(0.26, 0.41, 0.58));
+	set_rayleigh_color(Color(0.3, 0.405, 0.6));
 	set_mie_coefficient(0.005);
 	set_mie_eccentricity(0.8);
-	set_mie_color(Color(0.63, 0.77, 0.92));
+	set_mie_color(Color(0.69, 0.729, 0.812));
 	set_turbidity(10.0);
 	set_sun_disk_scale(1.0);
-	set_ground_color(Color(1.0, 1.0, 1.0));
+	set_ground_color(Color(0.1, 0.07, 0.034));
 	set_exposure(0.1);
 	set_dither_strength(1.0);
 }


### PR DESCRIPTION
:warning: *This page is screenshot-heavy (~30 MB). Consider stopping page loading if you are on a heavily data capped connection.*

- Tweak colors to be less saturated and more balanced (in terms of hue). The cool blue sky is balanced by a warm brown ground, which makes reflections look closer to how they'd look like when using an HDRI panorama texture.
- Make the ground color dark on both ProceduralSkyMaterial and PhysicalSkyMaterial to reduce indoor light leaking, especially when using GI.
- Tweak the PhysicalSkyMaterial colors to be as close as possible to ProceduralSkyMaterial (with the default sun orientation).
- Tweak editor environment defaults to be identical to the default ProceduralSkyMaterial colors. Previously, the default editor sky color was different from the colors of a newly created ProceduralSkyMaterial resource.

Both new skies were tested without GI, with SDFGI and with VoxelGI. They were tuned to look best when using ACES tonemapping with a whitepoint set to 6, but they still look good with other tonemapping operators.

This partially addresses https://github.com/godotengine/godot-proposals/issues/348.

**Testing project:** [environment_tweaks.zip](https://github.com/godotengine/godot/files/8052123/environment_tweaks.zip)

## Preview

<details>
<summary>Screenshots</summary>

*Glow is disabled, and tonemapper is set to ACES with a whitepoint of 6 (as done in https://github.com/godotengine/godot/pull/49736).*

### Simple scene (non-textured)

#### ProceduralSkyMaterial, No GI

| Before | After |
|-|-|
| ![2022-02-11_22 08 37](https://user-images.githubusercontent.com/180032/153681435-3443c4aa-147e-4085-a488-fdf0a4631680.png) | ![2022-02-11_22 53 03](https://user-images.githubusercontent.com/180032/153681729-d8381629-255f-45ca-b039-61d3a570d4bd.png) |

#### ProceduralSkyMaterial, SDFGI

| Before | After |
|-|-|
| ![2022-02-11_22 10 29](https://user-images.githubusercontent.com/180032/153681511-cb51b8dc-92d1-462f-8fad-2349a9b4d27c.png) | ![2022-02-11_22 53 15](https://user-images.githubusercontent.com/180032/153681739-96ba3bb7-7630-4866-9682-4ba95fc359a6.png) |

#### ProceduralSkyMaterial, VoxelGI

| Before | After |
|-|-|
| ![2022-02-11_22 09 25](https://user-images.githubusercontent.com/180032/153681471-128dcb57-1aca-45be-b64a-22e4d5aa6fb7.png) | ![2022-02-11_22 54 19](https://user-images.githubusercontent.com/180032/153681754-e78e5ab6-94cc-4598-b447-6e8f7365ee49.png) |

#### PhysicalSkyMaterial, No GI

| Before | After |
|-|-|
| ![2022-02-11_22 08 47](https://user-images.githubusercontent.com/180032/153681442-0fae66d7-2de3-4eb3-90f7-44e3712720dc.png) | ![2022-02-11_22 08 17](https://user-images.githubusercontent.com/180032/153681420-b01ad5ce-34b4-484b-a802-9f450d371d35.png) |


#### PhysicalSkyMaterial, SDFGI

| Before | After |
|-|-|
| ![2022-02-11_22 10 37](https://user-images.githubusercontent.com/180032/153681532-017a036b-4f5e-4f30-b53d-67dd915ff797.png) | ![2022-02-11_22 10 20](https://user-images.githubusercontent.com/180032/153681489-90495964-0e81-406f-8b10-097eacfb2927.png) |

#### PhysicalSkyMaterial, VoxelGI

| Before | After |
|-|-|
| ![2022-02-11_22 09 33](https://user-images.githubusercontent.com/180032/153681479-004d6e23-bf1c-4535-a914-56c3c98f7e65.png) | ![2022-02-11_22 09 13](https://user-images.githubusercontent.com/180032/153681460-144364da-a24b-4841-a75d-4705a47d7476.png) |

### Octavus (non-textured)

#### ProceduralSkyMaterial, No GI

| Before | After |
|-|-|
| ![2022-02-11_22 11 19](https://user-images.githubusercontent.com/180032/153681576-4c74c0f0-c5bb-4727-a6a6-315050755d58.png) | ![2022-02-11_22 52 10](https://user-images.githubusercontent.com/180032/153681668-8ce0432d-9a69-489c-be7c-45c51fdc5158.png) |

#### ProceduralSkyMaterial, SDFGI

| Before | After |
|-|-|
| ![2022-02-11_22 11 55](https://user-images.githubusercontent.com/180032/153681620-ee32029a-99c7-4940-b50a-31507ac9d748.png) | ![2022-02-11_22 52 22](https://user-images.githubusercontent.com/180032/153681706-a1f912cb-e2f7-4d1f-ad7c-87d06e5af7cd.png) |

#### PhysicalSkyMaterial, No GI

| Before | After |
|-|-|
| ![2022-02-11_22 11 27](https://user-images.githubusercontent.com/180032/153681580-27d1a7aa-7f85-492e-8d3f-541f325d9280.png) | ![2022-02-11_22 11 10](https://user-images.githubusercontent.com/180032/153681572-33d4b504-c0a8-42ae-b54a-501f1a34d832.png) |

#### PhysicalSkyMaterial, SDFGI

| Before | After |
|-|-|
| ![2022-02-11_22 13 22](https://user-images.githubusercontent.com/180032/153681632-0289b21c-0661-4820-9426-730ccbbc950e.png) | ![2022-02-11_22 11 47](https://user-images.githubusercontent.com/180032/153681615-51cd758a-29a9-47b2-a2f0-af12d9490d45.png) |

### Octavus (textured)

#### ProceduralSkyMaterial, No GI

| Before | After |
|-|-|
| ![2022-02-11_23 47 04](https://user-images.githubusercontent.com/180032/153681797-8349b1f9-9ace-42e7-baee-7fe8f86fcfd7.png) | ![2022-02-11_23 45 46](https://user-images.githubusercontent.com/180032/153681793-3c8d10ae-18ae-4374-a6a1-d525a08e364e.png) |

#### ProceduralSkyMaterial, SDFGI

| Before | After |
|-|-|
| ![2022-02-11_23 49 19](https://user-images.githubusercontent.com/180032/153681803-9197adc9-f3c5-4548-aa38-9679ea4d31e3.png) | ![2022-02-11_23 48 21](https://user-images.githubusercontent.com/180032/153681800-69c5b091-8c92-4c05-b595-60d0ede55bf9.png) |

#### PhysicalSkyMaterial, No GI

| Before | After |
|-|-|
| ![2022-02-11_23 47 17](https://user-images.githubusercontent.com/180032/153681799-1b536a2e-cf5c-4550-90f4-8a538e19e572.png) | ![2022-02-11_23 45 56](https://user-images.githubusercontent.com/180032/153681795-852dc0fb-2d4a-4670-b222-d399523415d1.png) |

#### PhysicalSkyMaterial, SDFGI

| Before | After |
|-|-|
| ![2022-02-11_23 49 29](https://user-images.githubusercontent.com/180032/153681805-281ce4e1-32e1-4d86-9b21-a3165f3207ed.png) | ![2022-02-11_23 48 30](https://user-images.githubusercontent.com/180032/153681801-ceb518b3-0885-405b-89b8-e9c3f20bdc7c.png) |
</details>