### PR TITLE
Hide Polygon2D lines and handles when node is not visible in tree.

### DIFF
--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -245,6 +245,10 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 		return false;
 	}
 
+	if (!_get_node()->is_visible_in_tree()) {
+		return false;
+	}
+
 	Ref<InputEventMouseButton> mb = p_event;
 
 	if (!_has_resource()) {
@@ -475,6 +479,10 @@ bool AbstractPolygon2DEditor::forward_gui_input(const Ref<InputEvent> &p_event) 
 
 void AbstractPolygon2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 	if (!_get_node()) {
+		return;
+	}
+
+	if (!_get_node()->is_visible_in_tree()) {
 		return;
 	}
 


### PR DESCRIPTION
Fixes #57992

### Issue fixed

Polygon2D handles were still drawn if the node or one of its parents was hidden.

### Fix proposal

Do not draw handles if node is not visible in tree and prevent interaction with invisible handles.

# Before
![bug](https://user-images.githubusercontent.com/3649998/153681234-5100af88-1ad2-40ea-87a6-a53926d59e06.gif)

# After
![fixed](https://user-images.githubusercontent.com/3649998/153681243-97b7432b-4fb7-480d-9d10-8e831d1e2eea.gif)

