### PR TITLE
[RTL] Fix "img" tag not setting image size.

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -514,7 +514,7 @@ void RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> 
 			} break;
 			case ITEM_IMAGE: {
 				ItemImage *img = (ItemImage *)it;
-				l.text_buf->add_object((uint64_t)it, img->image->get_size(), img->inline_align, 1);
+				l.text_buf->add_object((uint64_t)it, img->size, img->inline_align, 1);
 				text += String::chr(0xfffc);
 				l.char_count++;
 				remaining_characters--;


### PR DESCRIPTION
<img width="366" alt="Screenshot 2022-02-12 at 11 50 44" src="https://user-images.githubusercontent.com/7645683/153706383-0ba80068-876d-468e-a34b-b12c8b22dd8b.png">

Fixes #57976