### PR TITLE
Fix internal resource reuse in binary loader

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -678,11 +678,13 @@ Error ResourceLoaderBinary::load() {
 				internal_resources.write[i].path = path; // Update path.
 			}
 
-			if (cache_mode == ResourceFormatLoader::CACHE_MODE_REUSE) {
-				if (ResourceCache::has(path)) {
+			if (cache_mode == ResourceFormatLoader::CACHE_MODE_REUSE && ResourceCache::has(path)) {
+				RES cached = ResourceCache::get(path);
+				if (cached.is_valid()) {
 					//already loaded, don't do anything
 					stage++;
 					error = OK;
+					internal_index_cache[path] = cached;
 					continue;
 				}
 			}


### PR DESCRIPTION
* Fixes #48290
* Fixes #56216
* Reuse was not setting the internal index.
* Supersedes #52599, without re-reading all properties.
* Supersedes #56506, using a more thread-safe approach.
