### PR TITLE
Fix TextEdit v_scroll_speed invalid values breaks wheel scrolling

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -542,7 +542,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/behavior/navigation/move_caret_on_right_click", true);
 	_initial_set("text_editor/behavior/navigation/scroll_past_end_of_file", false);
 	_initial_set("text_editor/behavior/navigation/smooth_scrolling", true);
-	_initial_set("text_editor/behavior/navigation/v_scroll_speed", 80);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/behavior/navigation/v_scroll_speed", 80, "1,10000,1")
 
 	// Behavior: Indent
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "text_editor/behavior/indent/type", 0, "Tabs,Spaces")

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -471,6 +471,11 @@ void TextEdit::_notification(int p_what) {
 				// To ensure minimap is responsive override the speed setting.
 				double vel = ((target_y / dist) * ((minimap_clicked) ? 3000 : v_scroll_speed)) * get_physics_process_delta_time();
 
+				// Prevent too small velocity to block scrolling
+				if (Math::abs(vel) < v_scroll->get_step()) {
+					vel = v_scroll->get_step() * SIGN(vel);
+				}
+
 				if (Math::abs(vel) >= dist) {
 					set_v_scroll(target_v_scroll);
 					scrolling = false;
@@ -4390,6 +4395,8 @@ int TextEdit::get_h_scroll() const {
 }
 
 void TextEdit::set_v_scroll_speed(float p_speed) {
+	// Prevent setting a vertical scroll speed value under 1.0
+	ERR_FAIL_COND(p_speed < 1.0);
 	v_scroll_speed = p_speed;
 }
 


### PR DESCRIPTION
Fixes #58009

### Issue description

Some values of text_editor/behavior/navigation/v_scroll_speed Editor settings breaks mouse wheel scrolling of TextEdit.

### Identified causes

- Missing hint_range in property declaration to prevent null or negative values
- If the value is under 8, the increment in vscroll position is under its range step, so the value keeps unchanged and wheel scroll is blocked.

### Fix proposal

- Add hint_range "1, 10000,1" in property declaration 
10000 leads to immediately scroll to destination. As comparison, clicking on minimap leads to a 3000 scrolling speed and is already nearly instantaneous.

- Ensure that scrolling speed is equal or greater than the scrollbar step to prevent blocking mouse wheel scroll.

### After (I roll the mouse wheel a LOT to see the scrolling speed)
![fixed](https://user-images.githubusercontent.com/3649998/153714559-4cba487b-1741-4058-a21e-d4afcab1e0b3.gif)

