### PR TITLE
Add sky cover texture for ProceduralSkyMaterial

### DIFF
--- a/doc/classes/ProceduralSkyMaterial.xml
+++ b/doc/classes/ProceduralSkyMaterial.xml
@@ -23,6 +23,12 @@
 		<member name="ground_horizon_color" type="Color" setter="set_ground_horizon_color" getter="get_ground_horizon_color" default="Color(0.6463, 0.6558, 0.6708, 1)">
 			Color of the ground at the horizon. Blends with [member ground_bottom_color].
 		</member>
+		<member name="sky_cover" type="Texture2D" setter="set_sky_cover" getter="get_sky_cover">
+			The sky cover texture to use. This texture must use an equirectangular projection (similar to [PanoramaSkyMaterial]). The texture's colors will be [i]added[/i] to the existing sky color, and will be multiplied by [member sky_energy] and [member sky_cover_modulate]. This is mainly suited to displaying stars at night, but it can also be used to display clouds at day or night (with a non-physically-accurate look).
+		</member>
+		<member name="sky_cover_modulate" type="Color" setter="set_sky_cover_modulate" getter="get_sky_cover_modulate" default="Color(1, 1, 1, 1)">
+			The tint to apply to the [member sky_cover] texture. This can be used to change the sky cover's colors or opacity independently of the sky energy, which is useful for day/night or weather transitions. Only effective if a texture is defined in [member sky_cover].
+		</member>
 		<member name="sky_curve" type="float" setter="set_sky_curve" getter="get_sky_curve" default="0.15">
 			How quickly the [member sky_horizon_color] fades into the [member sky_top_color].
 		</member>

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -42,6 +42,8 @@ private:
 	Color sky_horizon_color;
 	float sky_curve;
 	float sky_energy;
+	Ref<Texture2D> sky_cover;
+	Color sky_cover_modulate;
 
 	Color ground_bottom_color;
 	Color ground_horizon_color;
@@ -71,6 +73,12 @@ public:
 
 	void set_sky_energy(float p_energy);
 	float get_sky_energy() const;
+
+	void set_sky_cover(const Ref<Texture2D> &p_sky_cover);
+	Ref<Texture2D> get_sky_cover() const;
+
+	void set_sky_cover_modulate(const Color &p_sky_cover_modulate);
+	Color get_sky_cover_modulate() const;
 
 	void set_ground_bottom_color(const Color &p_ground_bottom);
 	Color get_ground_bottom_color() const;


### PR DESCRIPTION
This brings PhysicalSkyMaterial's Night Sky functionality to ProceduralSkyMaterial, but in a more powerful and general fashion.

This can be used to display stars at night, or clouds at day and night. For clouds, it won't be physically accurate, but it can look good still.

The Sky Cover Modulate property can be used to adjust the sky cover's colors and opacity in real-time, which is useful for day/night or weather transitions.

Compared to using a premade PanoramaSkyMaterial, using a separate texture for sky cover allows you to benefit from ProceduralSkyMaterial's various real-time tweaks (sun direction, sky color, ground color, …).

From a performance standpoint, this adds a texture fetch. I haven't measured the performance impact yet, but if it turns out to be significant, I can make it so a different shader version is generated when you don't use a sky cover texture. This way, there won't be an additional cost when not using this feature.

If the idea behind this PR is accepted, I can bring this functionality to PhysicalSkyMaterial as well (in a separate PR) :slightly_smiling_face:
**Edit:** Done in https://github.com/godotengine/godot/pull/61478.

This addresses https://github.com/godotengine/godot-proposals/issues/835 for ProceduralSkyMaterial.

**Testing project:** [test_night_sky.zip](https://github.com/godotengine/godot/files/8054179/test_night_sky.zip)

## Preview

*The sky cover texture was edited from https://ambientcg.com/view?id=SkyOnlyHDRI001 using GIMP's Color to Alpha filter.*

### Day

![2022-02-12_18 33 17](https://user-images.githubusercontent.com/180032/153722096-b3f00ae9-73db-41bd-89b8-846b46ed0af0.png)

### Night

![2022-02-12_18 34 57](https://user-images.githubusercontent.com/180032/153722097-baf16b9e-f4ec-4810-b63d-0a1a31a46184.png)
