### PR TITLE
use physical keys for numpad emulation in the editor

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1883,7 +1883,7 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		}
 
 		if (EditorSettings::get_singleton()->get("editors/3d/navigation/emulate_numpad")) {
-			const Key code = k->get_keycode();
+			const Key code = k->get_physical_keycode();
 			if (code >= Key::KEY_0 && code <= Key::KEY_9) {
 				k->set_keycode(code - Key::KEY_0 + Key::KP_0);
 			}


### PR DESCRIPTION
This allows non-qwerty keyboard to benefit from this feature

*Bugsquad edit:* Ref. https://github.com/godotengine/godot/pull/56543#issuecomment-1036964666. `master` version of https://github.com/godotengine/godot/pull/60768.