### PR TITLE
Fix Project Manager crash on exit and editor settings loading / saving.

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1863,6 +1863,8 @@ void ProjectList::_bind_methods() {
 	ADD_SIGNAL(MethodInfo(SIGNAL_PROJECT_ASK_OPEN));
 }
 
+ProjectManager *ProjectManager::singleton = nullptr;
+
 void ProjectManager::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED:
@@ -1908,10 +1910,8 @@ void ProjectManager::_notification(int p_what) {
 	}
 }
 
-Map<String, Ref<Texture2D>> ProjectManager::icon_type_cache;
-
 Ref<Texture2D> ProjectManager::_file_dialog_get_icon(const String &p_path) {
-	return icon_type_cache["ObjectHR"];
+	return singleton->icon_type_cache["ObjectHR"];
 }
 
 void ProjectManager::_build_icon_type_cache(Ref<Theme> p_theme) {
@@ -2481,6 +2481,8 @@ void ProjectManager::_version_button_pressed() {
 }
 
 ProjectManager::ProjectManager() {
+	singleton = this;
+
 	// load settings
 	if (!EditorSettings::get_singleton()) {
 		EditorSettings::create();
@@ -2870,6 +2872,7 @@ ProjectManager::ProjectManager() {
 }
 
 ProjectManager::~ProjectManager() {
+	singleton = nullptr;
 	if (EditorSettings::get_singleton()) {
 		EditorSettings::destroy();
 	}

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -50,8 +50,10 @@ enum FilterOption {
 class ProjectManager : public Control {
 	GDCLASS(ProjectManager, Control);
 
-	static Map<String, Ref<Texture2D>> icon_type_cache;
-	static void _build_icon_type_cache(Ref<Theme> p_theme);
+	Map<String, Ref<Texture2D>> icon_type_cache;
+	void _build_icon_type_cache(Ref<Theme> p_theme);
+
+	static ProjectManager *singleton;
 
 	TabContainer *tabs;
 
@@ -139,6 +141,8 @@ protected:
 	static void _bind_methods();
 
 public:
+	static ProjectManager *get_singleton() { return singleton; }
+
 	ProjectManager();
 	~ProjectManager();
 };

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1212,6 +1212,10 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		// If we didn't find a project, we fall back to the project manager.
 		project_manager = !found_project && !cmdline_tool;
 	}
+
+	if (project_manager) {
+		Engine::get_singleton()->set_project_manager_hint(true);
+	}
 #endif
 
 	GLOBAL_DEF("debug/file_logging/enable_file_logging", false);
@@ -2540,7 +2544,6 @@ bool Main::start() {
 #ifdef TOOLS_ENABLED
 		if (project_manager) {
 			Engine::get_singleton()->set_editor_hint(true);
-			Engine::get_singleton()->set_project_manager_hint(true);
 			ProjectManager *pmanager = memnew(ProjectManager);
 			ProgressDialog *progress_dialog = memnew(ProgressDialog);
 			pmanager->add_child(progress_dialog);


### PR DESCRIPTION
Fixes multiple regressions from #52742 (see comments in the PR).

## Fix Project Manager crash on exit.
Use PM singleton and, instead of `static` map, which is freed after all resources were unloaded and cause double free crash.

## Fix editor settings loading / saving by Project Manager.
A new `Engine` variable for project manager detection was set too late for the editor setting to be loaded correctly and was causing editor settings to be saved in the current folder, instead of `Application Support` (or whatever it is on other OSes).
