### PR TITLE
Clarify identical `hash()` return values due to collisions

### DIFF
--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -299,8 +299,8 @@
 		<method name="hash" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns a hashed integer value representing the array and its contents.
-				[b]Note:[/b] Arrays with equal contents can still produce different hashes. Only the exact same arrays will produce the same hashed integer value.
+				Returns a hashed 32-bit integer value representing the array and its contents.
+				[b]Note:[/b] [Array]s with equal content will always produce identical hash values. However, the reverse is not true. Returning identical hash values does [i]not[/i] imply the arrays are equal, because different arrays can have identical hash values due to hash collisions.
 			</description>
 		</method>
 		<method name="insert">

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -98,7 +98,8 @@
 		<method name="hash" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the hash value of this [Callable]'s object.
+				Returns the 32-bit hash value of this [Callable]'s object.
+				[b]Note:[/b] [Callable]s with equal content will always produce identical hash values. However, the reverse is not true. Returning identical hash values does [i]not[/i] imply the callables are equal, because different callables can have identical hash values due to hash collisions. The engine uses a 32-bit hash algorithm for [method hash].
 			</description>
 		</method>
 		<method name="is_custom" qualifiers="const">

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -259,7 +259,7 @@
 		<method name="hash" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns a hashed integer value representing the dictionary contents. This can be used to compare dictionaries by value:
+				Returns a hashed 32-bit integer value representing the dictionary contents. This can be used to compare dictionaries by value:
 				[codeblocks]
 				[gdscript]
 				var dict1 = {0: 10}
@@ -276,6 +276,7 @@
 				[/csharp]
 				[/codeblocks]
 				[b]Note:[/b] Dictionaries with the same keys/values but in a different order will have a different hash.
+				[b]Note:[/b] Dictionaries with equal content will always produce identical hash values. However, the reverse is not true. Returning identical hash values does [i]not[/i] imply the dictionaries are equal, because different dictionaries can have identical hash values due to hash collisions.
 			</description>
 		</method>
 		<method name="is_empty" qualifiers="const">

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -241,7 +241,8 @@
 		<method name="hash" qualifiers="const">
 			<return type="int" />
 			<description>
-				Hashes the string and returns a 32-bit integer.
+				Returns the 32-bit hash value representing the string's contents.
+				[b]Note:[/b] [String]s with equal content will always produce identical hash values. However, the reverse is not true. Returning identical hash values does [i]not[/i] imply the strings are equal, because different strings can have identical hash values due to hash collisions.
 			</description>
 		</method>
 		<method name="hex_to_int" qualifiers="const">


### PR DESCRIPTION
This closes https://github.com/godotengine/godot/issues/58027.