### PR TITLE
Fix AnimationTrack mouse wheel zooming at low zoom level

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1844,11 +1844,14 @@ void AnimationTimelineEdit::_pan_callback(Vector2 p_scroll_vec) {
 }
 
 void AnimationTimelineEdit::_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt) {
-	if (p_scroll_vec.y < 0) {
-		get_zoom()->set_value(get_zoom()->get_value() * 1.05);
+	double new_zoom_value;
+	double current_zoom_value = get_zoom()->get_value();
+	if (current_zoom_value <= 0.1) {
+		new_zoom_value = MAX(0.01, current_zoom_value - 0.01 * SIGN(p_scroll_vec.y));
 	} else {
-		get_zoom()->set_value(get_zoom()->get_value() / 1.05);
+		new_zoom_value = p_scroll_vec.y > 0 ? MAX(0.01, current_zoom_value / 1.05) : current_zoom_value * 1.05;
 	}
+	get_zoom()->set_value(new_zoom_value);
 }
 
 void AnimationTimelineEdit::set_use_fps(bool p_use_fps) {
@@ -5332,11 +5335,14 @@ void AnimationTrackEditor::_pan_callback(Vector2 p_scroll_vec) {
 }
 
 void AnimationTrackEditor::_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt) {
-	if (p_scroll_vec.y < 0) {
-		timeline->get_zoom()->set_value(timeline->get_zoom()->get_value() * 1.05);
+	double new_zoom_value;
+	double current_zoom_value = timeline->get_zoom()->get_value();
+	if (current_zoom_value <= 0.1) {
+		new_zoom_value = MAX(0.01, current_zoom_value - 0.01 * SIGN(p_scroll_vec.y));
 	} else {
-		timeline->get_zoom()->set_value(timeline->get_zoom()->get_value() / 1.05);
+		new_zoom_value = p_scroll_vec.y > 0 ? MAX(0.01, current_zoom_value / 1.05) : current_zoom_value * 1.05;
 	}
+	timeline->get_zoom()->set_value(new_zoom_value);
 }
 
 void AnimationTrackEditor::_cancel_bezier_edit() {


### PR DESCRIPTION
Fixes #56415

### Issue description

In Animation Track, wheel mouse zooming has two problems : 

- when slider is grabbed manually and zoom level is low (under 0.1), changing zoom with wheel becomes impossible.
- when zooming out with wheel, we can't zoom under 0.1 and we see that the zoom slider is not at its minimal value. The only way to zoom under 0.1 is to grab the slider and not to use the wheel (but then we are facing the first problem).

### Identified cause

Zooming in / out was based on a factor ( previous zoom * 1.05 or previous_zoom / 1.05)
That leads to precision issue when zoom factor is very low.

### Fix proposal

Allow to zoom out with mouse wheel to very low zoom level.
For that, calculate zoom level differently  : 
- between 0.01 and 0.1, do not use a percentage modifier but add  +0.01 or -0.01 per wheel action
- above 0.1, use old factor

### Before
![bug](https://user-images.githubusercontent.com/3649998/153731306-9797725a-417b-4238-b9e3-10f7cc7e9b01.gif)
You can see that zoom can not be minimal only with mouse wheel.
Then, setting minimal zoom by grabbing the slider prevent mouse wheel to work anymore

### After
![fixed](https://user-images.githubusercontent.com/3649998/153731338-54b0d99a-3a66-4ca5-9b1b-fb995cb4ab14.gif)


