### PR TITLE
Use the `canvas_items` stretch mode by default

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2823,7 +2823,7 @@ bool Main::start() {
 			startup_benchmark_file = String();
 		}
 #endif
-		GLOBAL_DEF_BASIC("display/window/stretch/mode", "disabled");
+		GLOBAL_DEF_BASIC("display/window/stretch/mode", "canvas_items");
 		ProjectSettings::get_singleton()->set_custom_property_info("display/window/stretch/mode",
 				PropertyInfo(Variant::STRING,
 						"display/window/stretch/mode",


### PR DESCRIPTION
**Marked as draft** for the following reason:

> Since 4.0 is in feature freeze, we are now avoiding compatibility-breaking changes. As a result, if this proposal is accepted, this change should be applied to new projects only by modifying the generated project.godot file when creating a project using the project manager (similar to https://github.com/godotengine/godot-proposals/issues/4834).

___

Follow-up to https://github.com/godotengine/godot/pull/55032.

This is the stretch mode that works best for non-pixel art 2D and 3D games in general (and even many pixel art games, provided texture filtering is disabled).

The `canvas_items` stretch mode also ensures that 2D elements are always scaled to a readable size, even at high resolutions. This is especially important when targeting mobile platforms. The difference is immediately noticeable when running a new project in the [experimental editor Android port](https://github.com/godotengine/godot/pull/57747) :slightly_smiling_face: 

Since most people are using Godot to develop games (rather than applications), it makes sense to use a stretch mode that works best for games by default.

This closes https://github.com/godotengine/godot-proposals/issues/3939.

## Preview

<details>

*The previews below were made with a project base resolution of 1152×648, as proposed in https://github.com/godotengine/godot/pull/55032.*

### 2D scene

#### Default window size

*At the default size, there is no visual difference between stretch modes.*

![2022-02-13_02 02 42](https://user-images.githubusercontent.com/180032/153734096-9a11d158-51c9-4293-a2e1-0394f02478cf.png)

#### Fullscreen (2560×1440), `disabled` stretch mode (current default)

*2D elements appear very small and off-center (unless a Camera2D is added and made current).*

![2022-02-13_02 02 49](https://user-images.githubusercontent.com/180032/153734097-146ade0b-0c8c-4719-8957-20012d235fcd.png)

#### Fullscreen (2560×1440), `canvas_items` stretch mode (new)

*2D elements appear at a larger, more readable size.*

![2022-02-13_02 03 01](https://user-images.githubusercontent.com/180032/153734098-4cdee5e7-b674-4581-96cf-b57285a36d98.png)

### 3D scene

#### Default window size

*At the default size, there is no visual difference between stretch modes.*

![2022-02-13_02 01 23](https://user-images.githubusercontent.com/180032/153734093-155dfece-59ed-4399-92af-1e37a1b25bcb.png)

#### Fullscreen (2560×1440), `disabled` stretch mode (current default)

*2D elements appear very small.*

![2022-02-13_02 01 42](https://user-images.githubusercontent.com/180032/153734095-7e161a2b-a7c9-4954-aba3-38a8e5cc0b14.png)

#### Fullscreen (2560×1440), `canvas_items` stretch mode (new)

*2D elements appear at a larger, more readable size.*

![2022-02-13_02 01 27](https://user-images.githubusercontent.com/180032/153734094-0b281a90-163b-4219-92f1-34e1ef43d02c.png)
</details>