### PR TITLE
Fixed `cubic_slerp()`'s incorrect rotation, by using exponential map

### DIFF
--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -60,6 +60,8 @@ struct _NO_DISCARD_ Quaternion {
 	Quaternion normalized() const;
 	bool is_normalized() const;
 	Quaternion inverse() const;
+	Quaternion log() const;
+	Quaternion exp() const;
 	_FORCE_INLINE_ real_t dot(const Quaternion &p_q) const;
 	real_t angle_to(const Quaternion &p_to) const;
 


### PR DESCRIPTION
Co-authored-by: K. S. Ernest (iFire) Lee <ernest.lee@chibifire.com> 

Fixed #57951. Includes #57954. There was some discussion on #40592, but it was moved to #57951 because it was a confusing several issues.

In order to interpolate multiple quaternions at the same time with weighting, it need to use exponential map.

---
The general `slerp()` requires weighting by dot product. This is incompatible with `lerp()`. In particular, when weighting three or more quaternions at the same time, it will not work due to the non-commutativity of quaternions.

There is formula for scalars as follow:
```
x^n + x^m ＝ x^(n+m)
```

Something similar can be applied to matrices and quaternions, which are the product of matrices as follow:
```
q1 * q2 ≈ exp(ln(q1) + ln(q2))
```
https://en.wikipedia.org/wiki/Baker%E2%80%93Campbell%E2%80%93Hausdorff_formula

The exact definition is different, but to put it simply, if you take the logarithm of a quaternion, you can take its angle as an exponent. Due to the non-commutativity, this is an approximation, but if you are on a exponential map, you can add Quaternions directly.

Even though it is an approximation, it is more accurate than the spherial-(non-linear)-interpolation which calculates each element of the quaternion.

So, by doing `cubic_slerp()` with multiple Quaternions on the exponential map, the completion is much more accurate than the previous `cubic_slerp()`.