### PR TITLE
Add `get_offset` methods for lines and paragraphs in `RichTextLabel`

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -67,10 +67,24 @@
 				Returns the total number of lines in the text. Wrapped text is counted as multiple lines.
 			</description>
 		</method>
+		<method name="get_line_offset">
+			<return type="float" />
+			<argument index="0" name="line" type="int" />
+			<description>
+				Returns the vertical offset of the line found at the provided index.
+			</description>
+		</method>
 		<method name="get_paragraph_count" qualifiers="const">
 			<return type="int" />
 			<description>
 				Returns the total number of paragraphs (newlines or [code]p[/code] tags in the tag stack's text tags). Considers wrapped text as one paragraph.
+			</description>
+		</method>
+		<method name="get_paragraph_offset">
+			<return type="float" />
+			<argument index="0" name="paragraph" type="int" />
+			<description>
+				Returns the vertical offset of the paragraph found at the provided index.
 			</description>
 		</method>
 		<method name="get_parsed_text" qualifiers="const">

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3727,6 +3727,28 @@ void RichTextLabel::scroll_to_line(int p_line) {
 	}
 }
 
+float RichTextLabel::get_line_offset(int p_line) {
+	int line_count = 0;
+	for (int i = 0; i < main->lines.size(); i++) {
+		if ((line_count <= p_line) && (p_line <= line_count + main->lines[i].text_buf->get_line_count())) {
+			float line_offset = 0.f;
+			for (int j = 0; j < p_line - line_count; j++) {
+				line_offset += main->lines[i].text_buf->get_line_size(j).y + get_theme_constant(SNAME("line_separation"));
+			}
+			return main->lines[i].offset.y + line_offset;
+		}
+		line_count += main->lines[i].text_buf->get_line_count();
+	}
+	return 0;
+}
+
+float RichTextLabel::get_paragraph_offset(int p_paragraph) {
+	if (0 <= p_paragraph && p_paragraph < main->lines.size()) {
+		return main->lines[p_paragraph].offset.y;
+	}
+	return 0;
+}
+
 int RichTextLabel::get_line_count() const {
 	int line_count = 0;
 	for (int i = 0; i < main->lines.size(); i++) {
@@ -4340,6 +4362,9 @@ void RichTextLabel::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_content_height"), &RichTextLabel::get_content_height);
 	ClassDB::bind_method(D_METHOD("get_content_width"), &RichTextLabel::get_content_width);
+
+	ClassDB::bind_method(D_METHOD("get_line_offset", "line"), &RichTextLabel::get_line_offset);
+	ClassDB::bind_method(D_METHOD("get_paragraph_offset", "paragraph"), &RichTextLabel::get_paragraph_offset);
 
 	ClassDB::bind_method(D_METHOD("parse_expressions_for_values", "expressions"), &RichTextLabel::parse_expressions_for_values);
 

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -551,6 +551,9 @@ public:
 	int get_paragraph_count() const;
 	int get_visible_paragraph_count() const;
 
+	float get_line_offset(int p_line);
+	float get_paragraph_offset(int p_paragraph);
+
 	void scroll_to_line(int p_line);
 	int get_line_count() const;
 	int get_visible_line_count() const;


### PR DESCRIPTION
Adds `get_line_offset` and `get_paragraph_offset` methods to `RichTextLabel`.

Takes `line_separation` into account.

*Bugsquad edit: Related to https://github.com/godotengine/godot/pull/57988.*