### PR TITLE
Default PanoramaSkyMaterial texture to black instead of white

### DIFF
--- a/scene/resources/sky_material.cpp
+++ b/scene/resources/sky_material.cpp
@@ -371,8 +371,11 @@ void PanoramaSkyMaterial::_update_shader() {
 			// Add a comment to describe the shader origin (useful when converting to ShaderMaterial).
 			RS::get_singleton()->shader_set_code(shader_cache[i], vformat(R"(
 // NOTE: Shader automatically converted from )" VERSION_NAME " " VERSION_FULL_CONFIG R"('s PanoramaSkyMaterial.
+
 shader_type sky;
-uniform sampler2D source_panorama : %s, hint_albedo;
+
+uniform sampler2D source_panorama : %s, hint_black_albedo;
+
 void sky() {
 	COLOR = texture(source_panorama, SKY_COORDS).rgb;
 }


### PR DESCRIPTION
This prevents blinding the user while the user is still setting up the panorama sky texture. This also adjusts shader formatting to match the other built-in sky shaders.

**Note:** Not applicable to `3.x`.

**Testing project:** [test_panorama_sky_material.zip](https://github.com/godotengine/godot/files/8056653/test_panorama_sky_material.zip)

### Before

![2022-02-13_22 02 16](https://user-images.githubusercontent.com/180032/153774985-2f16992d-11bf-46ad-af50-53a691bea115.png)

### After

![2022-02-13_22 02 57](https://user-images.githubusercontent.com/180032/153774986-5a49757d-ae0e-4ab8-906c-3e8b5c1395e5.png)