### PR TITLE
Add a Modulate property to PanoramaSkyMaterial

### DIFF
--- a/doc/classes/PanoramaSkyMaterial.xml
+++ b/doc/classes/PanoramaSkyMaterial.xml
@@ -14,6 +14,9 @@
 		<member name="filter" type="bool" setter="set_filtering_enabled" getter="is_filtering_enabled" default="true">
 			A boolean value to determine if the background texture should be filtered or not.
 		</member>
+		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)">
+			The tint to apply to the [member panorama] texture. This can be used to change the sky's color or brightness, which is useful to adjust the scene's mood without affecting indoor lighting (unlike [member Environment.adjustment_color_correction]).
+		</member>
 		<member name="panorama" type="Texture2D" setter="set_panorama" getter="get_panorama">
 			[Texture2D] to be applied to the [PanoramaSkyMaterial].
 		</member>

--- a/scene/resources/sky_material.cpp
+++ b/scene/resources/sky_material.cpp
@@ -321,6 +321,15 @@ bool PanoramaSkyMaterial::is_filtering_enabled() const {
 	return filter;
 }
 
+void PanoramaSkyMaterial::set_modulate(const Color &p_modulate) {
+	modulate = p_modulate;
+	RS::get_singleton()->material_set_param(_get_material(), "modulate", modulate);
+}
+
+Color PanoramaSkyMaterial::get_modulate() const {
+	return modulate;
+}
+
 Shader::Mode PanoramaSkyMaterial::get_shader_mode() const {
 	return Shader::MODE_SKY;
 }
@@ -348,8 +357,12 @@ void PanoramaSkyMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_filtering_enabled", "enabled"), &PanoramaSkyMaterial::set_filtering_enabled);
 	ClassDB::bind_method(D_METHOD("is_filtering_enabled"), &PanoramaSkyMaterial::is_filtering_enabled);
 
+	ClassDB::bind_method(D_METHOD("set_modulate", "modulate"), &PanoramaSkyMaterial::set_modulate);
+	ClassDB::bind_method(D_METHOD("get_modulate"), &PanoramaSkyMaterial::get_modulate);
+
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "panorama", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_panorama", "get_panorama");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter"), "set_filtering_enabled", "is_filtering_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "modulate"), "set_modulate", "get_modulate");
 }
 
 Mutex PanoramaSkyMaterial::shader_mutex;
@@ -371,10 +384,14 @@ void PanoramaSkyMaterial::_update_shader() {
 			// Add a comment to describe the shader origin (useful when converting to ShaderMaterial).
 			RS::get_singleton()->shader_set_code(shader_cache[i], vformat(R"(
 // NOTE: Shader automatically converted from )" VERSION_NAME " " VERSION_FULL_CONFIG R"('s PanoramaSkyMaterial.
+
 shader_type sky;
+
 uniform sampler2D source_panorama : %s, hint_albedo;
+uniform vec4 modulate : hint_color = vec4(1.0, 1.0, 1.0, 1.0);
+
 void sky() {
-	COLOR = texture(source_panorama, SKY_COORDS).rgb;
+	COLOR = texture(source_panorama, SKY_COORDS).rgb * modulate.rgb * modulate.a;
 }
 )",
 																		  i ? "filter_linear" : "filter_nearest"));

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -115,6 +115,7 @@ private:
 	mutable bool shader_set = false;
 
 	bool filter = true;
+	Color modulate = Color(1, 1, 1);
 
 protected:
 	static void _bind_methods();
@@ -125,6 +126,9 @@ public:
 
 	void set_filtering_enabled(bool p_enabled);
 	bool is_filtering_enabled() const;
+
+	void set_modulate(const Color &p_modulate);
+	Color get_modulate() const;
 
 	virtual Shader::Mode get_shader_mode() const override;
 	virtual RID get_shader_rid() const override;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/58018.

This can be used for quick real-time adjustments of the panorama sky color. This can help create a different mood for the scene when using screen-space color correction is not desired (e.g. when you don't want to affect indoor lighting).

**Testing project:** [test_panorama_sky_modulate.zip](https://github.com/godotengine/godot/files/8056681/test_panorama_sky_modulate.zip)

## Preview

*HDRI panorama from Poly Haven: https://polyhaven.com/a/je_gray_park*

### Default modulate

![2022-02-13_22 14 02](https://user-images.githubusercontent.com/180032/153775568-4064fb9e-e2d3-4aad-b782-35ecebc934bb.png)

### Orange-ish modulate

![2022-02-13_22 14 29](https://user-images.githubusercontent.com/180032/153775570-f87a1331-91e5-4828-a77f-0639f042c1a7.png)

### Dark blue modulate

*Not recommended for this particular HDRI since it has an obvious sun, but it can look good for HDRIs with more cloud coverage.*

![2022-02-13_22 15 45](https://user-images.githubusercontent.com/180032/153775571-6d8ffd27-3b0a-437d-8dbb-f84a8075f8bc.png)