### PR TITLE
Add `label_transparent` property to EditorProperty

### DIFF
--- a/doc/classes/EditorProperty.xml
+++ b/doc/classes/EditorProperty.xml
@@ -82,6 +82,9 @@
 		<member name="label" type="String" setter="set_label" getter="get_label" default="&quot;&quot;">
 			Set this property to change the label (if you want to show one).
 		</member>
+		<member name="label_transparent" type="bool" setter="set_label_transparent" getter="is_label_transparent" default="false">
+			If [code]true[/code], the label text will show at 0.5 transparency. This is used for feature tag overrides in the Project Settings menu.
+		</member>
 		<member name="read_only" type="bool" setter="set_read_only" getter="is_read_only" default="false">
 			Used by the inspector, set to [code]true[/code] when the property is read-only.
 		</member>

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -75,6 +75,7 @@ private:
 	int property_usage;
 
 	bool read_only = false;
+	bool label_transparent = false;
 	bool checkable = false;
 	bool checked = false;
 	bool draw_warning = false;
@@ -141,6 +142,9 @@ public:
 
 	void set_read_only(bool p_read_only);
 	bool is_read_only() const;
+
+	void set_label_transparent(bool p_label_transparent);
+	bool is_label_transparent() const;
 
 	Object *get_edited_object();
 	StringName get_edited_property();
@@ -460,6 +464,7 @@ class EditorInspector : public ScrollContainer {
 	bool sub_inspector = false;
 	bool wide_editors = false;
 	bool deletable_properties = false;
+	bool has_feature_tag_overrides = false;
 
 	float refresh_countdown;
 	bool update_tree_pending = false;
@@ -581,6 +586,7 @@ public:
 	void set_use_deletable_properties(bool p_enabled);
 
 	void set_restrict_to_basic_settings(bool p_restrict);
+	void set_has_feature_tag_overrides(bool p_enabled);
 	void set_property_clipboard(const Variant &p_value);
 	Variant get_property_clipboard() const;
 

--- a/editor/editor_sectioned_inspector.h
+++ b/editor/editor_sectioned_inspector.h
@@ -52,6 +52,7 @@ class SectionedInspector : public HSplitContainer {
 	String selected_category;
 
 	bool restrict_to_basic = false;
+	bool has_feature_tag_overrides = false;
 
 	static void _bind_methods();
 	void _section_selected();

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -617,6 +617,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	general_settings_inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	general_settings_inspector->register_search_box(search_box);
 	general_settings_inspector->get_inspector()->set_use_filter(true);
+	general_settings_inspector->get_inspector()->set_has_feature_tag_overrides(true);
 	general_settings_inspector->get_inspector()->connect("property_selected", callable_mp(this, &ProjectSettingsEditor::_setting_selected));
 	general_settings_inspector->get_inspector()->connect("property_edited", callable_mp(this, &ProjectSettingsEditor::_setting_edited));
 	general_settings_inspector->get_inspector()->connect("restart_requested", callable_mp(this, &ProjectSettingsEditor::_editor_restart_request));


### PR DESCRIPTION
This PR adds a new property to EditorProperty, `label_transparent`, which makes the label text display at 0.5 transparency. I added this property because it previously checked for a period in `label` to make text partially transparent (used for project settings feature tag overrides), but there was a comment in the code saying that this functionality should be moved to project settings instead. As an added bonus, it's exposed to GDScript so plugins can make use of it.

This comment here is the main reason for adding this:
```cpp
if (label.contains(".")) {
	// FIXME: Move this to the project settings editor, as this is only used
	// for project settings feature tag overrides.
	color.a = 0.5;
}
```

Alternatively, this could be done as a `label_transparency` property or a `label_modulate` theme property, but I'm not sure how much more useful that would really be.