### PR TITLE
Increase the default texel size for lightmap baking

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1542,7 +1542,7 @@ void ResourceImporterScene::get_import_options(const String &p_path, List<Import
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/generate_lods"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "meshes/create_shadow_meshes"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "meshes/light_baking", PROPERTY_HINT_ENUM, "Disabled,Static (VoxelGI/SDFGI),Static Lightmaps (VoxelGI/SDFGI/LightmapGI),Dynamic (VoxelGI only)", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), 1));
-	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "meshes/lightmap_texel_size", PROPERTY_HINT_RANGE, "0.001,100,0.001"), 0.1));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "meshes/lightmap_texel_size", PROPERTY_HINT_RANGE, "0.001,100,0.001"), 0.2));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "skins/use_named_skins"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "animation/import"), true));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::FLOAT, "animation/fps", PROPERTY_HINT_RANGE, "1,120,1"), 30));


### PR DESCRIPTION
This has several benefits:

- Baking is now significantly faster out of the box (often twice as fast).
- Lightmap texture file sizes are often divided by 2 or 3.
- Baking requires less memory and is less likely to [crash on large scenes](https://github.com/godotengine/godot/issues/54679).

Visual quality may be degraded, but it's usually not very noticeable in the default configuration where only indirect lighting is baked.

**Testing project:** https://0x0.st/o8oM.zip <sub>(link expires in October 2022)</sub>

## Preview

*Due to [bicubic sampling not being reimplemented in `master` yet](https://github.com/godotengine/godot/issues/49935), the difference between the two texel sizes is more noticeable than it would be with bicubic sampling enabled. Once bicubic sampling is reimplemented, the quality loss will be less visible.*

### Indirect lighting baked only

#### Textured

*This represents a typical usage scenario with a textured scene.*

| Before | After |
|-|-|
| ![2022-02-14_00 08 59](https://user-images.githubusercontent.com/180032/153779694-3aa06ab6-36a1-4d70-a5e9-ea72148adf89.png) | ![2022-02-14_00 10 04](https://user-images.githubusercontent.com/180032/153779697-615151a9-066d-41c3-9c8b-8a5cc5c26559.png) |

#### Untextured

*This represents a worst-case scenario for lightmaps where the texel size difference is the most noticeable.*

| Before | After |
|-|-|
| ![2022-02-14_00 08 53](https://user-images.githubusercontent.com/180032/153779693-d3327782-48bf-47eb-a5b8-4679c902a309.png) | ![2022-02-14_00 09 57](https://user-images.githubusercontent.com/180032/153779696-fa1b7028-44fd-45a4-905b-f18d5bae9f02.png) |

### Fully baked lighting

#### Textured

*This represents a typical usage scenario with a textured scene.*

| Before | After |
|-|-|
| ![2022-02-14_00 07 06](https://user-images.githubusercontent.com/180032/153779691-d7c71707-7106-41e3-abd5-001bfa270f5a.png) | ![2022-02-14_00 10 59](https://user-images.githubusercontent.com/180032/153779700-7c07ac11-8121-41f9-84d2-3924be9dfa74.png) |

#### Untextured

*This represents a worst-case scenario for lightmaps where the texel size difference is the most noticeable.*

| Before | After |
|-|-|
| ![2022-02-14_00 06 59](https://user-images.githubusercontent.com/180032/153779690-04b2abf9-5ed4-4870-81e8-8815f35effaf.png) | ![2022-02-14_00 10 53](https://user-images.githubusercontent.com/180032/153779699-7c0e37f7-2541-4d1a-bc17-a4e61b7d6636.png) |