### PR TITLE
Make duplicate animation prompt for new name

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -125,7 +125,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 
 	ConfirmationDialog *name_dialog;
 	ConfirmationDialog *error_dialog;
-	bool renaming;
+	int name_dialog_op = TOOL_NEW_ANIM;
 
 	bool updating;
 	bool updating_blends;


### PR DESCRIPTION
Previously, choosing "Duplicate" option in Animation editor:

* `3.x`: it creates a copy with ` (copy)` appended to the name.
* `master`: it creates a copy with ` (copy)` appended to the name, and immediately invokes "Rename".

This PR makes "Duplicate" prompt for the new name. This is the same behavior as "Duplicate" in the FileSystem panel.

![Peek 2022-02-14 14-55](https://user-images.githubusercontent.com/372476/153815729-8e1b8f5f-4014-4fa3-ad2f-611f285cddaa.gif)
