### PR TITLE
Fix new performance regressions (short delay_usec)

### DIFF
--- a/platform/javascript/export/export_plugin.cpp
+++ b/platform/javascript/export/export_plugin.cpp
@@ -645,7 +645,7 @@ Ref<Texture2D> EditorExportPlatformJavaScript::get_run_icon() const {
 void EditorExportPlatformJavaScript::_server_thread_poll(void *data) {
 	EditorExportPlatformJavaScript *ej = (EditorExportPlatformJavaScript *)data;
 	while (!ej->server_quit) {
-		OS::get_singleton()->delay_usec(1000);
+		OS::get_singleton()->delay_usec(6900);
 		{
 			MutexLock lock(ej->server_lock);
 			ej->server->poll();


### PR DESCRIPTION
My Mac was using 20% cpu again, which was related to the Javascript
Export plugin.

I had however no export templates setup in the project so this is more
of a stopgap fix.

See here for a more complete description of this issue: https://github.com/godotengine/godot/issues/58082

For now I'd just like my performance back :)

## Before:
<img width="1440" alt="Screenshot 2022-02-14 at 11 04 11" src="https://user-images.githubusercontent.com/100964/153824035-e9a7b7be-b288-49bb-8198-02109ecc2f7e.png">

<img width="1552" alt="Screenshot 2022-02-14 at 11 00 35" src="https://user-images.githubusercontent.com/100964/153823620-cdf69be4-f45e-4f33-9918-3065247e0232.png">

## After

<img width="1552" alt="Screenshot 2022-02-14 at 11 15 21" src="https://user-images.githubusercontent.com/100964/153825596-e4d704b2-957f-4ec8-b9cc-3e92c0ffcab0.png">

So a reduction of around `400ms` wasted CPU time. Now most CPU usage seems now to be coming from `CoreAudio`