### PR TITLE
Add random rotation to cubemap roughness sampling

### DIFF
--- a/servers/rendering/renderer_rd/shaders/cubemap_roughness.glsl
+++ b/servers/rendering/renderer_rd/shaders/cubemap_roughness.glsl
@@ -28,8 +28,10 @@ void main() {
 	} else {
 		vec4 sum = vec4(0.0, 0.0, 0.0, 0.0);
 
+		float rotation = quick_hash(id.y * uint(params.face_size) + id.x); // Add some random rotation to the Hammersley sequence
 		for (uint sampleNum = 0u; sampleNum < params.sample_count; sampleNum++) {
 			vec2 xi = Hammersley(sampleNum, params.sample_count);
+			xi.x += rotation;
 
 			vec3 H = ImportanceSampleGGX(xi, params.roughness, N);
 			vec3 V = N;

--- a/servers/rendering/renderer_rd/shaders/cubemap_roughness_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/cubemap_roughness_inc.glsl
@@ -92,3 +92,11 @@ float radicalInverse_VdC(uint bits) {
 vec2 Hammersley(uint i, uint N) {
 	return vec2(float(i) / float(N), radicalInverse_VdC(i));
 }
+
+float quick_hash(uint x) {
+	const uint k = 1103515245U;
+	x = ((x >> 8U) ^ x) * k;
+	x = ((x >> 8U) ^ x) * k;
+	x = ((x >> 8U) ^ x) * k;
+	return float(x) * (1.0 / float(0xffffffffU));
+}


### PR DESCRIPTION
Adds a random rotation offset to each texel in order to break the aliasing pattern. It still doesn't get rid of fireflies, but it makes them more uniform and therefore less noticeable.

Comparison at various roughness and metallic levels:
Left is before, right is after.
![fireflies](https://user-images.githubusercontent.com/4402304/153857755-1533ac5b-f975-4d42-b42d-d052551efec6.png)

