### PR TITLE
Add ParticleShader Userdata

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -2660,6 +2660,9 @@ void RasterizerStorageGLES3::particles_set_use_local_coordinates(RID p_particles
 
 void RasterizerStorageGLES3::particles_set_process_material(RID p_particles, RID p_material) {
 }
+RID RasterizerStorageGLES3::particles_get_process_material(RID p_particles) const {
+	return RID();
+}
 
 void RasterizerStorageGLES3::particles_set_fixed_fps(RID p_particles, int p_fps) {
 }

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1050,6 +1050,7 @@ public:
 	void particles_set_speed_scale(RID p_particles, double p_scale) override;
 	void particles_set_use_local_coordinates(RID p_particles, bool p_enable) override;
 	void particles_set_process_material(RID p_particles, RID p_material) override;
+	RID particles_get_process_material(RID p_particles) const override;
 	void particles_set_fixed_fps(RID p_particles, int p_fps) override;
 	void particles_set_interpolate(RID p_particles, bool p_enable) override;
 	void particles_set_fractional_delta(RID p_particles, bool p_enable) override;

--- a/servers/rendering/rasterizer_dummy.h
+++ b/servers/rendering/rasterizer_dummy.h
@@ -560,6 +560,7 @@ public:
 	void particles_set_speed_scale(RID p_particles, double p_scale) override {}
 	void particles_set_use_local_coordinates(RID p_particles, bool p_enable) override {}
 	void particles_set_process_material(RID p_particles, RID p_material) override {}
+	RID particles_get_process_material(RID p_particles) const override { return RID(); }
 	void particles_set_fixed_fps(RID p_particles, int p_fps) override {}
 	void particles_set_interpolate(RID p_particles, bool p_enable) override {}
 	void particles_set_fractional_delta(RID p_particles, bool p_enable) override {}

--- a/servers/rendering/renderer_rd/renderer_storage_rd.h
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.h
@@ -751,6 +751,8 @@ private:
 		RID particle_instance_buffer;
 		RID frame_params_buffer;
 
+		uint32_t userdata_count = 0;
+
 		RID particles_material_uniform_set;
 		RID particles_copy_uniform_set;
 		RID particles_transforms_buffer_uniform_set;
@@ -849,12 +851,14 @@ private:
 			uint32_t order_by_lifetime;
 			uint32_t lifetime_split;
 			uint32_t lifetime_reverse;
-			uint32_t pad;
+			uint32_t copy_mode_2d;
 		};
 
 		enum {
+			MAX_USERDATAS = 6
+		};
+		enum {
 			COPY_MODE_FILL_INSTANCES,
-			COPY_MODE_FILL_INSTANCES_2D,
 			COPY_MODE_FILL_SORT_BUFFER,
 			COPY_MODE_FILL_INSTANCES_WITH_SORT_BUFFER,
 			COPY_MODE_MAX,
@@ -862,7 +866,7 @@ private:
 
 		ParticlesCopyShaderRD copy_shader;
 		RID copy_shader_version;
-		RID copy_pipelines[COPY_MODE_MAX];
+		RID copy_pipelines[COPY_MODE_MAX * (MAX_USERDATAS + 1)];
 
 		LocalVector<float> pose_update_buffer;
 
@@ -888,7 +892,10 @@ private:
 
 		RID pipeline;
 
-		bool uses_time;
+		bool uses_time = false;
+
+		bool userdatas_used[ParticlesShader::MAX_USERDATAS] = {};
+		uint32_t userdata_count = 0;
 
 		virtual void set_code(const String &p_Code);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index);
@@ -2162,6 +2169,8 @@ public:
 	void particles_set_speed_scale(RID p_particles, double p_scale);
 	void particles_set_use_local_coordinates(RID p_particles, bool p_enable);
 	void particles_set_process_material(RID p_particles, RID p_material);
+	RID particles_get_process_material(RID p_particles) const;
+
 	void particles_set_fixed_fps(RID p_particles, int p_fps);
 	void particles_set_interpolate(RID p_particles, bool p_enable);
 	void particles_set_fractional_delta(RID p_particles, bool p_enable);

--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -112,6 +112,24 @@ struct ParticleData {
 	uint flags;
 	vec4 color;
 	vec4 custom;
+#ifdef USERDATA1_USED
+	vec4 userdata1;
+#endif
+#ifdef USERDATA2_USED
+	vec4 userdata2;
+#endif
+#ifdef USERDATA3_USED
+	vec4 userdata3;
+#endif
+#ifdef USERDATA4_USED
+	vec4 userdata4;
+#endif
+#ifdef USERDATA5_USED
+	vec4 userdata5;
+#endif
+#ifdef USERDATA6_USED
+	vec4 userdata6;
+#endif
 };
 
 layout(set = 1, binding = 1, std430) restrict buffer Particles {

--- a/servers/rendering/renderer_rd/shaders/particles_copy.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles_copy.glsl
@@ -16,6 +16,9 @@ struct ParticleData {
 	uint flags;
 	vec4 color;
 	vec4 custom;
+#ifdef USERDATA_COUNT
+	vec4 userdata[USERDATA_COUNT];
+#endif
 };
 
 layout(set = 0, binding = 1, std430) restrict readonly buffer Particles {
@@ -57,7 +60,7 @@ layout(push_constant, std430) uniform Params {
 	bool order_by_lifetime;
 	uint lifetime_split;
 	bool lifetime_reverse;
-	uint pad;
+	bool copy_mode_2d;
 }
 params;
 
@@ -201,25 +204,22 @@ void main() {
 		txform = mat4(vec4(0.0), vec4(0.0), vec4(0.0), vec4(0.0)); //zero scale, becomes invisible
 	}
 
-#ifdef MODE_2D
+	if (params.copy_mode_2d) {
+		uint write_offset = gl_GlobalInvocationID.x * (2 + 1 + 1); //xform + color + custom
 
-	uint write_offset = gl_GlobalInvocationID.x * (2 + 1 + 1); //xform + color + custom
+		instances.data[write_offset + 0] = txform[0];
+		instances.data[write_offset + 1] = txform[1];
+		instances.data[write_offset + 2] = particles.data[particle].color;
+		instances.data[write_offset + 3] = particles.data[particle].custom;
+	} else {
+		uint write_offset = gl_GlobalInvocationID.x * (3 + 1 + 1); //xform + color + custom
 
-	instances.data[write_offset + 0] = txform[0];
-	instances.data[write_offset + 1] = txform[1];
-	instances.data[write_offset + 2] = particles.data[particle].color;
-	instances.data[write_offset + 3] = particles.data[particle].custom;
-
-#else
-
-	uint write_offset = gl_GlobalInvocationID.x * (3 + 1 + 1); //xform + color + custom
-
-	instances.data[write_offset + 0] = txform[0];
-	instances.data[write_offset + 1] = txform[1];
-	instances.data[write_offset + 2] = txform[2];
-	instances.data[write_offset + 3] = particles.data[particle].color;
-	instances.data[write_offset + 4] = particles.data[particle].custom;
-#endif //MODE_2D
+		instances.data[write_offset + 0] = txform[0];
+		instances.data[write_offset + 1] = txform[1];
+		instances.data[write_offset + 2] = txform[2];
+		instances.data[write_offset + 3] = particles.data[particle].color;
+		instances.data[write_offset + 4] = particles.data[particle].custom;
+	}
 
 #endif
 }

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -3683,6 +3683,15 @@ void RendererSceneCull::_update_dirty_instance(Instance *p_instance) {
 			_instance_update_mesh_instance(p_instance);
 		}
 
+		if (p_instance->base_type == RS::INSTANCE_PARTICLES) {
+			// update the process material dependency
+
+			RID particle_material = RSG::storage->particles_get_process_material(p_instance->base);
+			if (particle_material.is_valid()) {
+				RSG::storage->material_update_dependency(particle_material, &p_instance->dependency_tracker);
+			}
+		}
+
 		if ((1 << p_instance->base_type) & RS::INSTANCE_GEOMETRY_MASK) {
 			InstanceGeometryData *geom = static_cast<InstanceGeometryData *>(p_instance->base_data);
 

--- a/servers/rendering/renderer_storage.h
+++ b/servers/rendering/renderer_storage.h
@@ -477,6 +477,7 @@ public:
 	virtual void particles_set_speed_scale(RID p_particles, double p_scale) = 0;
 	virtual void particles_set_use_local_coordinates(RID p_particles, bool p_enable) = 0;
 	virtual void particles_set_process_material(RID p_particles, RID p_material) = 0;
+	virtual RID particles_get_process_material(RID p_particles) const = 0;
 	virtual void particles_set_fixed_fps(RID p_particles, int p_fps) = 0;
 	virtual void particles_set_interpolate(RID p_particles, bool p_enable) = 0;
 	virtual void particles_set_fractional_delta(RID p_particles, bool p_enable) = 0;

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -318,6 +318,12 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["MASS"] = ShaderLanguage::TYPE_FLOAT;
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["ACTIVE"] = ShaderLanguage::TYPE_BOOL;
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["CUSTOM"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["USERDATA1"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["USERDATA2"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["USERDATA3"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["USERDATA4"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["USERDATA5"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["USERDATA6"] = ShaderLanguage::TYPE_VEC4;
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["TRANSFORM"] = ShaderLanguage::TYPE_MAT4;
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["LIFETIME"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[RS::SHADER_PARTICLES].functions["start"].built_ins["DELTA"] = constt(ShaderLanguage::TYPE_FLOAT);
@@ -338,6 +344,12 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["ACTIVE"] = ShaderLanguage::TYPE_BOOL;
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["RESTART"] = constt(ShaderLanguage::TYPE_BOOL);
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["CUSTOM"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["USERDATA1"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["USERDATA2"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["USERDATA3"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["USERDATA4"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["USERDATA5"] = ShaderLanguage::TYPE_VEC4;
+	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["USERDATA6"] = ShaderLanguage::TYPE_VEC4;
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["TRANSFORM"] = ShaderLanguage::TYPE_MAT4;
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["LIFETIME"] = constt(ShaderLanguage::TYPE_FLOAT);
 	shader_modes[RS::SHADER_PARTICLES].functions["process"].built_ins["DELTA"] = constt(ShaderLanguage::TYPE_FLOAT);


### PR DESCRIPTION
* Adds optional vec4 USERDATA1 .. USERDATA6 to particles, allowing to store custom data.
* This data is allocated on demand, so shaders that do not use it do not cost more.

Why 6 and not 4 or 8? Too many would add too many shader versions, too few is not enough for something @QbieShay and @Chaosus wants to do with visual particle shaders. If more are needed, more can be added.

~~This is **UNTESTED** (I will test later when I have a bit more time).~~ It' s now ready for review!