### PR TITLE
Fix crash when removing tabs from `TabBar`

### DIFF
--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -524,13 +524,14 @@ void TabBar::set_tab_count(int p_count) {
 		offset = MIN(offset, p_count - 1);
 		max_drawn_tab = MIN(max_drawn_tab, p_count - 1);
 		current = MIN(current, p_count - 1);
+
+		_update_cache();
+		_ensure_no_over_offset();
+		if (scroll_to_selected) {
+			ensure_tab_visible(current);
+		}
 	}
 
-	_update_cache();
-	_ensure_no_over_offset();
-	if (scroll_to_selected) {
-		ensure_tab_visible(current);
-	}
 	update();
 	update_minimum_size();
 	notify_property_list_changed();
@@ -961,7 +962,6 @@ void TabBar::clear_tabs() {
 	current = 0;
 	previous = 0;
 
-	_update_cache();
 	update();
 	update_minimum_size();
 	notify_property_list_changed();
@@ -975,18 +975,21 @@ void TabBar::remove_tab(int p_idx) {
 	}
 
 	if (current < 0) {
+		offset = 0;
+		max_drawn_tab = 0;
 		current = 0;
 		previous = 0;
-	}
-	if (current >= tabs.size()) {
-		current = tabs.size() - 1;
+	} else {
+		offset = MIN(offset, tabs.size() - 1);
+		max_drawn_tab = MIN(max_drawn_tab, tabs.size() - 1);
+
+		_update_cache();
+		_ensure_no_over_offset();
+		if (scroll_to_selected && !tabs.is_empty()) {
+			ensure_tab_visible(current);
+		}
 	}
 
-	_update_cache();
-	_ensure_no_over_offset();
-	if (scroll_to_selected && !tabs.is_empty()) {
-		ensure_tab_visible(current);
-	}
 	update();
 	update_minimum_size();
 	notify_property_list_changed();


### PR DESCRIPTION
Fixes #58047 and fixes #58048.