### PR TITLE
Improve completion scroll bar visibility in the script editor

### DIFF
--- a/doc/classes/CodeEdit.xml
+++ b/doc/classes/CodeEdit.xml
@@ -589,7 +589,7 @@
 		<theme_item name="completion_font_color" data_type="color" type="Color" default="Color(0.67, 0.67, 0.67, 1)">
 			Font [Color] for the code completion popup.
 		</theme_item>
-		<theme_item name="completion_scroll_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+		<theme_item name="completion_scroll_color" data_type="color" type="Color" default="Color(1, 1, 1, 0.29)">
 			[Color] of the scrollbar in the code completion popup.
 		</theme_item>
 		<theme_item name="completion_selected_color" data_type="color" type="Color" default="Color(0.26, 0.26, 0.27, 1)">
@@ -640,7 +640,7 @@
 		<theme_item name="completion_max_width" data_type="constant" type="int" default="50">
 			Max width of options in the code completion popup. Options longer then this will be cut off.
 		</theme_item>
-		<theme_item name="completion_scroll_width" data_type="constant" type="int" default="3">
+		<theme_item name="completion_scroll_width" data_type="constant" type="int" default="6">
 			Width of the scrollbar in the code completion popup.
 		</theme_item>
 		<theme_item name="line_spacing" data_type="constant" type="int" default="4">

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -741,7 +741,7 @@ void EditorSettings::_load_godot2_text_editor_theme() {
 	_initial_set("text_editor/theme/highlighting/completion_background_color", Color(0.17, 0.16, 0.2));
 	_initial_set("text_editor/theme/highlighting/completion_selected_color", Color(0.26, 0.26, 0.27));
 	_initial_set("text_editor/theme/highlighting/completion_existing_color", Color(0.87, 0.87, 0.87, 0.13));
-	_initial_set("text_editor/theme/highlighting/completion_scroll_color", Color(1, 1, 1));
+	_initial_set("text_editor/theme/highlighting/completion_scroll_color", Color(1, 1, 1, 0.29));
 	_initial_set("text_editor/theme/highlighting/completion_font_color", Color(0.67, 0.67, 0.67));
 	_initial_set("text_editor/theme/highlighting/text_color", Color(0.67, 0.67, 0.67));
 	_initial_set("text_editor/theme/highlighting/line_number_color", Color(0.67, 0.67, 0.67, 0.4));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1544,7 +1544,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color completion_background_color = dark_theme ? base_color : background_color;
 	const Color completion_selected_color = alpha1;
 	const Color completion_existing_color = alpha2;
-	const Color completion_scroll_color = alpha1;
+	// Same opacity as the scroll grabber editor icon.
+	const Color completion_scroll_color = Color(mono_value, mono_value, mono_value, 0.29);
 	const Color completion_font_color = font_color;
 	const Color text_color = font_color;
 	const Color line_number_color = dim_color;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -466,7 +466,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 	theme->set_color("completion_background_color", "CodeEdit", Color(0.17, 0.16, 0.2));
 	theme->set_color("completion_selected_color", "CodeEdit", Color(0.26, 0.26, 0.27));
 	theme->set_color("completion_existing_color", "CodeEdit", Color(0.87, 0.87, 0.87, 0.13));
-	theme->set_color("completion_scroll_color", "CodeEdit", control_font_pressed_color);
+	theme->set_color("completion_scroll_color", "CodeEdit", control_font_pressed_color * Color(1, 1, 1, 0.29));
 	theme->set_color("completion_font_color", "CodeEdit", Color(0.67, 0.67, 0.67));
 	theme->set_color("font_color", "CodeEdit", control_font_color);
 	theme->set_color("font_selected_color", "CodeEdit", Color(0, 0, 0));
@@ -490,7 +490,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, Ref<Te
 
 	theme->set_constant("completion_lines", "CodeEdit", 7);
 	theme->set_constant("completion_max_width", "CodeEdit", 50);
-	theme->set_constant("completion_scroll_width", "CodeEdit", 3);
+	theme->set_constant("completion_scroll_width", "CodeEdit", 6);
 	theme->set_constant("line_spacing", "CodeEdit", 4 * scale);
 	theme->set_constant("outline_size", "CodeEdit", 0);
 


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/58092.

This makes the scroll bar bar thicker and more opaque (roughly matching the editor theme's scroll bar by default).

## Preview

### Before

![2022-02-14_14 34 46](https://user-images.githubusercontent.com/180032/153875264-ffb72ef3-4b8e-4d06-8d7a-e5d2c1f61f7d.png)

### After

![2022-02-14_14 41 00](https://user-images.githubusercontent.com/180032/153875271-8509a07f-d4d8-4992-b223-50743d503616.png)