### PR TITLE
Improve completion scroll bar visibility in the script editor (3.x)

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -641,7 +641,7 @@
 		</theme_item>
 		<theme_item name="completion_font_color" data_type="color" type="Color" default="Color( 0.67, 0.67, 0.67, 1 )">
 		</theme_item>
-		<theme_item name="completion_scroll_color" data_type="color" type="Color" default="Color( 1, 1, 1, 1 )">
+		<theme_item name="completion_scroll_color" data_type="color" type="Color" default="Color( 1, 1, 1, 0.29 )">
 		</theme_item>
 		<theme_item name="completion_selected_color" data_type="color" type="Color" default="Color( 0.26, 0.26, 0.27, 1 )">
 		</theme_item>
@@ -684,7 +684,7 @@
 		</theme_item>
 		<theme_item name="completion_max_width" data_type="constant" type="int" default="50">
 		</theme_item>
-		<theme_item name="completion_scroll_width" data_type="constant" type="int" default="3">
+		<theme_item name="completion_scroll_width" data_type="constant" type="int" default="6">
 		</theme_item>
 		<theme_item name="line_spacing" data_type="constant" type="int" default="4">
 			Sets the spacing between the lines.

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -694,7 +694,7 @@ void EditorSettings::_load_default_text_editor_theme() {
 	_initial_set("text_editor/highlighting/completion_background_color", Color(0.17, 0.16, 0.2));
 	_initial_set("text_editor/highlighting/completion_selected_color", Color(0.26, 0.26, 0.27));
 	_initial_set("text_editor/highlighting/completion_existing_color", Color(0.13, 0.87, 0.87, 0.87));
-	_initial_set("text_editor/highlighting/completion_scroll_color", Color(1, 1, 1));
+	_initial_set("text_editor/highlighting/completion_scroll_color", Color(1, 1, 1, 0.29));
 	_initial_set("text_editor/highlighting/completion_font_color", Color(0.67, 0.67, 0.67));
 	_initial_set("text_editor/highlighting/text_color", Color(0.67, 0.67, 0.67));
 	_initial_set("text_editor/highlighting/line_number_color", Color(0.67, 0.67, 0.67, 0.4));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1337,7 +1337,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color completion_background_color = dark_theme ? base_color : background_color;
 	const Color completion_selected_color = alpha1;
 	const Color completion_existing_color = alpha2;
-	const Color completion_scroll_color = alpha1;
+	const Color completion_scroll_color = Color(mono_value, mono_value, mono_value, 0.29);
 	const Color completion_font_color = font_color;
 	const Color text_color = font_color;
 	const Color line_number_color = dim_color;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -453,7 +453,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("completion_background_color", "TextEdit", Color(0.17, 0.16, 0.2));
 	theme->set_color("completion_selected_color", "TextEdit", Color(0.26, 0.26, 0.27));
 	theme->set_color("completion_existing_color", "TextEdit", Color(0.87, 0.87, 0.87, 0.13));
-	theme->set_color("completion_scroll_color", "TextEdit", control_font_color_pressed);
+	theme->set_color("completion_scroll_color", "TextEdit", control_font_color_pressed * Color(1, 1, 1, 0.29));
 	theme->set_color("completion_font_color", "TextEdit", Color(0.67, 0.67, 0.67));
 	theme->set_color("font_color", "TextEdit", control_font_color);
 	theme->set_color("font_color_selected", "TextEdit", Color(0, 0, 0));
@@ -478,7 +478,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_constant("completion_lines", "TextEdit", 7);
 	theme->set_constant("completion_max_width", "TextEdit", 50);
-	theme->set_constant("completion_scroll_width", "TextEdit", 3);
+	theme->set_constant("completion_scroll_width", "TextEdit", 6 * scale);
 	theme->set_constant("line_spacing", "TextEdit", 4 * scale);
 
 	Ref<Texture> empty_icon = memnew(ImageTexture);


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/58091.

This makes the scroll bar bar thicker and more opaque (roughly matching the editor theme's scroll bar by default).

## Preview

### Before

![2022-02-14_14 46 39](https://user-images.githubusercontent.com/180032/153877233-ef94aad9-60ca-431a-9a01-a3affd8f9036.png)

### After

![2022-02-14_14 53 57](https://user-images.githubusercontent.com/180032/153877236-b5550550-4dd4-4c27-aa9d-000748c2310e.png)