### PR TITLE
Add AutoLoad option to the script creation dialog

### DIFF
--- a/doc/classes/ScriptCreateDialog.xml
+++ b/doc/classes/ScriptCreateDialog.xml
@@ -32,7 +32,8 @@
 			<argument index="0" name="inherits" type="String" />
 			<argument index="1" name="path" type="String" />
 			<argument index="2" name="built_in_enabled" type="bool" default="true" />
-			<argument index="3" name="load_enabled" type="bool" default="true" />
+			<argument index="3" name="autoload_enabled" type="bool" default="false" />
+			<argument index="4" name="load_enabled" type="bool" default="true" />
 			<description>
 				Prefills required fields to configure the ScriptCreateDialog for use.
 			</description>

--- a/editor/editor_autoload_settings.h
+++ b/editor/editor_autoload_settings.h
@@ -103,8 +103,9 @@ protected:
 
 public:
 	void update_autoload();
-	bool autoload_add(const String &p_name, const String &p_path);
+	bool autoload_add(const String &p_name, const String &p_path, bool p_use_undoredo = true);
 	void autoload_remove(const String &p_name);
+	bool autoload_name_is_valid(const String &p_name, String *r_error = nullptr);
 
 	EditorAutoloadSettings();
 	~EditorAutoloadSettings();

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1972,7 +1972,7 @@ void FileSystemDock::_file_option(int p_option, const Vector<String> &p_selected
 			if (!fpath.ends_with("/")) {
 				fpath = fpath.get_base_dir();
 			}
-			make_script_dialog->config("Node", fpath.plus_file("new_script.gd"), false, false);
+			make_script_dialog->config("Node", fpath.plus_file("new_script.gd"), false, true, false);
 			make_script_dialog->popup_centered();
 		} break;
 

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -36,7 +36,6 @@
 #include "editor/editor_dir_dialog.h"
 #include "editor/editor_file_system.h"
 #include "editor/plugins/script_editor_plugin.h"
-#include "editor/script_create_dialog.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/control.h"
 #include "scene/gui/dialogs.h"
@@ -47,6 +46,7 @@
 #include "scene/gui/split_container.h"
 #include "scene/gui/tree.h"
 
+class ScriptCreateDialog;
 class ShaderCreateDialog;
 
 class FileSystemDock : public VBoxContainer {

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -36,7 +36,6 @@
 #include "editor/editor_help.h"
 #include "editor/editor_help_search.h"
 #include "editor/editor_plugin.h"
-#include "editor/script_create_dialog.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/menu_button.h"
@@ -184,6 +183,7 @@ typedef ScriptEditorBase *(*CreateScriptEditorFunc)(const RES &p_resource);
 class EditorScriptCodeCompletionCache;
 class FindInFilesDialog;
 class FindInFilesPanel;
+class ScriptCreateDialog;
 
 class ScriptEditor : public PanelContainer {
 	GDCLASS(ScriptEditor, PanelContainer);

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -3301,6 +3301,10 @@ void SceneTreeDock::_update_configuration_warning() {
 	}
 }
 
+ScriptCreateDialog *SceneTreeDock::get_script_create_dialog() {
+	return script_create_dialog;
+}
+
 SceneTreeDock::SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selection, EditorData &p_editor_data) {
 	singleton = this;
 	set_name("Scene");

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -36,7 +36,6 @@
 #include "editor/groups_editor.h"
 #include "editor/quick_open.h"
 #include "editor/reparent_dialog.h"
-#include "editor/script_create_dialog.h"
 #include "scene/animation/animation_player.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
@@ -52,6 +51,7 @@ class RenameDialog;
 #endif // MODULE_REGEX_ENABLED
 
 class ShaderCreateDialog;
+class ScriptCreateDialog;
 
 class SceneTreeDock : public VBoxContainer {
 	GDCLASS(SceneTreeDock, VBoxContainer);
@@ -317,7 +317,7 @@ public:
 	List<Node *> paste_nodes();
 	List<Node *> get_node_clipboard() const;
 
-	ScriptCreateDialog *get_script_create_dialog() { return script_create_dialog; }
+	ScriptCreateDialog *get_script_create_dialog();
 
 	SceneTreeDock(Node *p_scene_root, EditorSelection *p_editor_selection, EditorData &p_editor_data);
 	~SceneTreeDock();

--- a/editor/script_create_dialog.h
+++ b/editor/script_create_dialog.h
@@ -62,6 +62,7 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	Button *path_button;
 	EditorFileDialog *file_browse;
 	CheckBox *internal;
+	CheckBox *autoload;
 	CheckBox *use_templates;
 	VBoxContainer *path_vb;
 	AcceptDialog *alert;
@@ -79,8 +80,10 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool is_parent_name_valid;
 	bool is_class_name_valid;
 	bool is_built_in;
+	bool is_autoload = false;
 	bool is_using_templates;
 	bool built_in_enabled;
+	bool autoload_enabled = false;
 	bool load_enabled;
 	int current_language;
 	int default_language;
@@ -98,8 +101,10 @@ class ScriptCreateDialog : public ConfirmationDialog {
 	bool _can_be_built_in();
 	void _path_changed(const String &p_path = String());
 	void _path_submitted(const String &p_path = String());
+	void _name_changed(const String &p_name = String());
 	void _language_changed(int l = 0);
 	void _built_in_pressed();
+	void _autoload_pressed();
 	void _use_template_pressed();
 	bool _validate_parent(const String &p_string);
 	bool _validate_class(const String &p_string);
@@ -130,7 +135,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void config(const String &p_base_name, const String &p_base_path, bool p_built_in_enabled = true, bool p_load_enabled = true);
+	void config(const String &p_base_name, const String &p_base_path, bool p_built_in_enabled = true, bool p_autoload_enabled = false, bool p_load_enabled = true);
 	void set_inheritance_base_type(const String &p_base);
 	ScriptCreateDialog();
 };


### PR DESCRIPTION
Editor QoL enhancement which adds an option to auto-add the new script to the autoload list:
![autoload_script2](https://user-images.githubusercontent.com/3036176/153890616-8264e6b8-cbed-4be1-b802-7bea8149d207.gif)

Note: this option would be available only for scripts created in FileSystem.