### PR TITLE
Validate `PhysicsDirectSpaceState{2,3}D::_intersect_point` input

### DIFF
--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -336,6 +336,8 @@ Dictionary PhysicsDirectSpaceState2D::_intersect_ray(const Ref<PhysicsRayQueryPa
 }
 
 Array PhysicsDirectSpaceState2D::_intersect_point(const Ref<PhysicsPointQueryParameters2D> &p_point_query, int p_max_results) {
+	ERR_FAIL_COND_V(p_point_query.is_null(), Array());
+
 	Vector<ShapeResult> ret;
 	ret.resize(p_max_results);
 

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -339,6 +339,8 @@ Dictionary PhysicsDirectSpaceState3D::_intersect_ray(const Ref<PhysicsRayQueryPa
 }
 
 Array PhysicsDirectSpaceState3D::_intersect_point(const Ref<PhysicsPointQueryParameters3D> &p_point_query, int p_max_results) {
+	ERR_FAIL_COND_V(p_point_query.is_null(), Array());
+
 	Vector<ShapeResult> ret;
 	ret.resize(p_max_results);
 


### PR DESCRIPTION
Fixes #57502

Similar validations already exist in `_intersect_ray()` and `_intersect_shape()`.