### PR TITLE
Clamp environment light sky contribution to the [0.0; 1.0] range

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -57,7 +57,8 @@
 			The ambient light's energy. The higher the value, the stronger the light.
 		</member>
 		<member name="ambient_light_sky_contribution" type="float" setter="set_ambient_light_sky_contribution" getter="get_ambient_light_sky_contribution" default="1.0">
-			Defines the amount of light that the sky brings on the scene. A value of 0 means that the sky's light emission has no effect on the scene illumination, thus all ambient illumination is provided by the ambient light. On the contrary, a value of 1 means that all the light that affects the scene is provided by the sky, thus the ambient light parameter has no effect on the scene.
+			Defines the amount of light that the sky brings on the scene. A value of [code]0.0[/code] means that the sky's light emission has no effect on the scene illumination, thus all ambient illumination is provided by the ambient light. On the contrary, a value of [code]1.0[/code] means that [i]all[/i] the light that affects the scene is provided by the sky, thus the ambient light parameter has no effect on the scene.
+			[b]Note:[/b] [member ambient_light_sky_contribution] is internally clamped between [code]0.0[/code] and [code]1.0[/code] (inclusive).
 		</member>
 		<member name="ambient_light_source" type="int" setter="set_ambient_source" getter="get_ambient_source" enum="Environment.AmbientSource" default="0">
 		</member>

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -155,7 +155,9 @@ float Environment::get_ambient_light_energy() const {
 }
 
 void Environment::set_ambient_light_sky_contribution(float p_ratio) {
-	ambient_sky_contribution = p_ratio;
+	// Sky contribution values outside the [0.0; 1.0] range don't make sense and
+	// can result in negative colors.
+	ambient_sky_contribution = CLAMP(p_ratio, 0.0, 1.0);
 	_update_ambient_light();
 }
 


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/58101.

The value is already clamped in the editor, but it wasn't being clamped when the value was set via code. Values outside the [0.0; 1.0] range can result in broken rendering.

This was reported by @jitspoe during a stream.