### PR TITLE
Remove the EditorNode parameter from EditorPlugins create methods

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7033,7 +7033,7 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(ControlEditorPlugin));
 
 	for (int i = 0; i < EditorPlugins::get_plugin_count(); i++) {
-		add_editor_plugin(EditorPlugins::create(i, this));
+		add_editor_plugin(EditorPlugins::create(i));
 	}
 
 	for (int i = 0; i < plugin_init_callback_count; i++) {

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -43,7 +43,6 @@
 #include "scene/main/node.h"
 #include "scene/resources/texture.h"
 
-class EditorNode;
 class Node3D;
 class Camera3D;
 class EditorCommandPalette;
@@ -312,7 +311,7 @@ public:
 VARIANT_ENUM_CAST(EditorPlugin::CustomControlContainer);
 VARIANT_ENUM_CAST(EditorPlugin::DockSlot);
 
-typedef EditorPlugin *(*EditorPluginCreateFunc)(EditorNode *);
+typedef EditorPlugin *(*EditorPluginCreateFunc)();
 
 class EditorPlugins {
 	enum {
@@ -323,15 +322,15 @@ class EditorPlugins {
 	static int creation_func_count;
 
 	template <class T>
-	static EditorPlugin *creator(EditorNode *p_node) {
-		return memnew(T(p_node));
+	static EditorPlugin *creator() {
+		return memnew(T);
 	}
 
 public:
 	static int get_plugin_count() { return creation_func_count; }
-	static EditorPlugin *create(int p_idx, EditorNode *p_editor) {
+	static EditorPlugin *create(int p_idx) {
 		ERR_FAIL_INDEX_V(p_idx, creation_func_count, nullptr);
-		return creation_funcs[p_idx](p_editor);
+		return creation_funcs[p_idx]();
 	}
 
 	template <class T>

--- a/modules/csg/csg_gizmos.cpp
+++ b/modules/csg/csg_gizmos.cpp
@@ -421,7 +421,7 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	}
 }
 
-EditorPluginCSG::EditorPluginCSG(EditorNode *_p_editor) {
+EditorPluginCSG::EditorPluginCSG() {
 	Ref<CSGShape3DGizmoPlugin> gizmo_plugin = Ref<CSGShape3DGizmoPlugin>(memnew(CSGShape3DGizmoPlugin));
 	Node3DEditor::get_singleton()->add_gizmo_plugin(gizmo_plugin);
 }

--- a/modules/csg/csg_gizmos.h
+++ b/modules/csg/csg_gizmos.h
@@ -57,7 +57,7 @@ class EditorPluginCSG : public EditorPlugin {
 	GDCLASS(EditorPluginCSG, EditorPlugin);
 
 public:
-	EditorPluginCSG(EditorNode *_p_editor);
+	EditorPluginCSG();
 };
 
 #endif // CSG_GIZMOS_H

--- a/modules/gltf/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor_scene_exporter_gltf_plugin.cpp
@@ -53,7 +53,7 @@ bool SceneExporterGLTFPlugin::has_main_screen() const {
 	return false;
 }
 
-SceneExporterGLTFPlugin::SceneExporterGLTFPlugin(EditorNode *_p_node) {
+SceneExporterGLTFPlugin::SceneExporterGLTFPlugin() {
 	file_export_lib = memnew(EditorFileDialog);
 	EditorNode::get_singleton()->get_gui_base()->add_child(file_export_lib);
 	file_export_lib->connect("file_selected", callable_mp(this, &SceneExporterGLTFPlugin::_gltf2_dialog_action));

--- a/modules/gltf/editor_scene_exporter_gltf_plugin.h
+++ b/modules/gltf/editor_scene_exporter_gltf_plugin.h
@@ -45,7 +45,7 @@ class SceneExporterGLTFPlugin : public EditorPlugin {
 public:
 	virtual String get_name() const override;
 	bool has_main_screen() const override;
-	SceneExporterGLTFPlugin(EditorNode *_p_node);
+	SceneExporterGLTFPlugin();
 };
 #endif // TOOLS_ENABLED
 #endif // EDITOR_SCENE_EXPORTER_GLTF_PLUGIN_H

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -1489,7 +1489,7 @@ void GridMapEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-GridMapEditorPlugin::GridMapEditorPlugin(EditorNode *_p_node) {
+GridMapEditorPlugin::GridMapEditorPlugin() {
 	EDITOR_DEF("editors/grid_map/editor_side", 1);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "editors/grid_map/editor_side", PROPERTY_HINT_ENUM, "Left,Right"));
 

--- a/modules/gridmap/grid_map_editor_plugin.h
+++ b/modules/gridmap/grid_map_editor_plugin.h
@@ -257,7 +257,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	GridMapEditorPlugin(EditorNode *_p_node);
+	GridMapEditorPlugin();
 	~GridMapEditorPlugin();
 };
 

--- a/modules/navigation/navigation_mesh_editor_plugin.cpp
+++ b/modules/navigation/navigation_mesh_editor_plugin.cpp
@@ -140,10 +140,9 @@ void NavigationMeshEditorPlugin::make_visible(bool p_visible) {
 	}
 }
 
-NavigationMeshEditorPlugin::NavigationMeshEditorPlugin(EditorNode *p_node) {
-	editor = p_node;
+NavigationMeshEditorPlugin::NavigationMeshEditorPlugin() {
 	navigation_mesh_editor = memnew(NavigationMeshEditor);
-	editor->get_main_control()->add_child(navigation_mesh_editor);
+	EditorNode::get_singleton()->get_main_control()->add_child(navigation_mesh_editor);
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, navigation_mesh_editor->bake_hbox);
 	navigation_mesh_editor->hide();
 	navigation_mesh_editor->bake_hbox->hide();

--- a/modules/navigation/navigation_mesh_editor_plugin.h
+++ b/modules/navigation/navigation_mesh_editor_plugin.h
@@ -35,7 +35,6 @@
 
 #include "editor/editor_plugin.h"
 
-class EditorNode;
 class NavigationRegion3D;
 
 class NavigationMeshEditor : public Control {
@@ -70,7 +69,6 @@ class NavigationMeshEditorPlugin : public EditorPlugin {
 	GDCLASS(NavigationMeshEditorPlugin, EditorPlugin);
 
 	NavigationMeshEditor *navigation_mesh_editor;
-	EditorNode *editor;
 
 public:
 	virtual String get_name() const override { return "NavigationMesh"; }
@@ -79,7 +77,7 @@ public:
 	virtual bool handles(Object *p_object) const override;
 	virtual void make_visible(bool p_visible) override;
 
-	NavigationMeshEditorPlugin(EditorNode *p_node);
+	NavigationMeshEditorPlugin();
 	~NavigationMeshEditorPlugin();
 };
 


### PR DESCRIPTION
Follow-up of #57306

Warning: This is going to break all external modules that use `EditorPlugins::add_by_type`. To fix it, remove the EditorNode parameter from the constructor.

After this PR, the only missing EditorNode fields are in EditorNode and in EditorScript.

Also remove the EditorNode usage in the Navigation plugin that I missed in #57306.
