### PR TITLE
Expose `AudioServer.capture_device` as a property

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -29,23 +29,10 @@
 				Adds an [AudioEffect] effect to the bus [code]bus_idx[/code] at [code]at_position[/code].
 			</description>
 		</method>
-		<method name="capture_get_device">
-			<return type="String" />
-			<description>
-				Name of the current device for audio input (see [method capture_get_device_list]). The value [code]"Default"[/code] means that the system-wide default audio input is currently used.
-			</description>
-		</method>
 		<method name="capture_get_device_list">
 			<return type="Array" />
 			<description>
 				Returns the names of all audio input devices detected on the system.
-			</description>
-		</method>
-		<method name="capture_set_device">
-			<return type="void" />
-			<argument index="0" name="name" type="String" />
-			<description>
-				Sets which audio input device is used for audio capture. On systems with multiple audio inputs (such as analog and USB), this can be used to select the audio input device. Setting the value [code]"Default"[/code] will record audio from the system-wide default audio input. If an invalid device name is set, the value will be reverted back to [code]"Default"[/code].
 			</description>
 		</method>
 		<method name="generate_bus_layout" qualifiers="const">
@@ -307,6 +294,9 @@
 	<members>
 		<member name="bus_count" type="int" setter="set_bus_count" getter="get_bus_count" default="1">
 			Number of available audio buses.
+		</member>
+		<member name="capture_device" type="String" setter="capture_set_device" getter="capture_get_device" default="&quot;Default&quot;">
+			Name of the current device for audio input (see [method get_device_list]). On systems with multiple audio inputs (such as analog, USB and HDMI audio), this can be used to select the audio input device. The value [code]"Default"[/code] will record audio on the system-wide default audio input. If an invalid device name is set, the value will be reverted back to [code]"Default"[/code].
 		</member>
 		<member name="device" type="String" setter="set_device" getter="get_device" default="&quot;Default&quot;">
 			Name of the current device for audio output (see [method get_device_list]). On systems with multiple audio outputs (such as analog, USB and HDMI audio), this can be used to select the audio output device. The value [code]"Default"[/code] will play audio on the system-wide default audio output. If an invalid device name is set, the value will be reverted back to [code]"Default"[/code].

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1731,6 +1731,10 @@ void AudioServer::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bus_count"), "set_bus_count", "get_bus_count");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "device"), "set_device", "get_device");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "capture_device"), "capture_set_device", "capture_get_device");
+	// The default value may be set to an empty string by the platform-specific audio driver.
+	// Override for class reference generation purposes.
+	ADD_PROPERTY_DEFAULT("capture_device", "Default");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "playback_speed_scale"), "set_playback_speed_scale", "get_playback_speed_scale");
 
 	ADD_SIGNAL(MethodInfo("bus_layout_changed"));


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/58104.

This is more consistent with `AudioServer.device` (for output), which is already exposed as a property.


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->