### PR TITLE
[3.x] Utilize mouse position when zooming with shortcuts in 2D editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4686,7 +4686,7 @@ void CanvasItemEditor::_button_zoom_plus() {
 }
 
 void CanvasItemEditor::_shortcut_zoom_set(float p_zoom) {
-	_zoom_on_position(p_zoom * MAX(1, EDSCALE), viewport_scrollable->get_size() / 2.0);
+	_zoom_on_position(p_zoom * MAX(1, EDSCALE), viewport->get_local_mouse_position());
 }
 
 void CanvasItemEditor::_button_toggle_smart_snap(bool p_status) {


### PR DESCRIPTION
`3.x` version of #58134