### PR TITLE
Include diagonal tiles in surrounding tiles

### DIFF
--- a/doc/classes/TileMap.xml
+++ b/doc/classes/TileMap.xml
@@ -158,8 +158,9 @@
 		<method name="get_surrounding_tiles">
 			<return type="Vector2i[]" />
 			<argument index="0" name="coords" type="Vector2i" />
+			<argument index="1" name="p_include_diagonal_tiles" type="bool" />
 			<description>
-				Returns the list of all neighbourings cells to the one at [code]coords[/code]
+				Returns the list of all neighbouring cells to the one at [code]coords[/code]
 			</description>
 		</method>
 		<method name="get_used_cells" qualifiers="const">

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -3465,7 +3465,7 @@ void TileMap::set_texture_repeat(CanvasItem::TextureRepeat p_texture_repeat) {
 	}
 }
 
-TypedArray<Vector2i> TileMap::get_surrounding_tiles(Vector2i coords) {
+TypedArray<Vector2i> TileMap::get_surrounding_tiles(Vector2i coords, bool p_include_diagonal_tiles) {
 	if (!tile_set.is_valid()) {
 		return TypedArray<Vector2i>();
 	}
@@ -3477,6 +3477,12 @@ TypedArray<Vector2i> TileMap::get_surrounding_tiles(Vector2i coords) {
 		around.push_back(get_neighbor_cell(coords, TileSet::CELL_NEIGHBOR_BOTTOM_SIDE));
 		around.push_back(get_neighbor_cell(coords, TileSet::CELL_NEIGHBOR_LEFT_SIDE));
 		around.push_back(get_neighbor_cell(coords, TileSet::CELL_NEIGHBOR_TOP_SIDE));
+        if(p_include_diagonal_tiles) {
+            around.push_back(get_neighbor_cell(coords, TileSet::CELL_NEIGHBOR_TOP_LEFT_CORNER));
+            around.push_back(get_neighbor_cell(coords, TileSet::CELL_NEIGHBOR_TOP_RIGHT_CORNER));
+            around.push_back(get_neighbor_cell(coords, TileSet::CELL_NEIGHBOR_BOTTOM_LEFT_CORNER));
+            around.push_back(get_neighbor_cell(coords, TileSet::CELL_NEIGHBOR_BOTTOM_RIGHT_CORNER));
+        }
 	} else if (shape == TileSet::TILE_SHAPE_ISOMETRIC) {
 		around.push_back(get_neighbor_cell(coords, TileSet::CELL_NEIGHBOR_BOTTOM_RIGHT_SIDE));
 		around.push_back(get_neighbor_cell(coords, TileSet::CELL_NEIGHBOR_BOTTOM_LEFT_SIDE));

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -375,7 +375,7 @@ public:
 	void force_update(int p_layer = -1);
 
 	// Helpers?
-	TypedArray<Vector2i> get_surrounding_tiles(Vector2i coords);
+	TypedArray<Vector2i> get_surrounding_tiles(Vector2i coords, bool p_include_diagonal_tiles = false);
 	void draw_cells_outline(Control *p_control, Set<Vector2i> p_cells, Color p_color, Transform2D p_transform = Transform2D());
 
 	// Virtual function to modify the TileData at runtime


### PR DESCRIPTION
On TileMaps the call get_surrounding_tiles will only return the left, top, right and bottom cells. I introduced an optional parameter that also allows the selection of the diagonal parameters.

_Production edit: Closes https://github.com/godotengine/godot-proposals/issues/3973_