### PR TITLE
Fix Occluders to properly share resources

### DIFF
--- a/doc/classes/OccluderShapeSphere.xml
+++ b/doc/classes/OccluderShapeSphere.xml
@@ -28,7 +28,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="spheres" type="Array" setter="set_spheres" getter="get_spheres" default="[  ]">
+		<member name="spheres" type="Array" setter="set_spheres" getter="get_spheres" default="[ Plane( 0, 0, 0, 1 ) ]">
 			The sphere data can be accessed as an array of [Plane]s. The position of each sphere is stored in the [code]normal[/code], and the radius is stored in the [code]d[/code] value of the plane.
 		</member>
 	</members>

--- a/scene/3d/occluder.h
+++ b/scene/3d/occluder.h
@@ -40,6 +40,7 @@ class Occluder : public Spatial {
 	friend class OccluderSpatialGizmo;
 	friend class OccluderEditorPlugin;
 
+	RID _occluder_instance;
 	Ref<OccluderShape> _shape;
 
 	void resource_changed(RES res);

--- a/scene/resources/occluder_shape_polygon.h
+++ b/scene/resources/occluder_shape_polygon.h
@@ -81,8 +81,7 @@ public:
 
 	void clear();
 
-	virtual void notification_enter_world(RID p_scenario);
-	virtual void update_shape_to_visual_server();
+	void update_shape_to_visual_server();
 	virtual Transform center_node(const Transform &p_global_xform, const Transform &p_parent_xform, real_t p_snap);
 
 #ifdef TOOLS_ENABLED

--- a/servers/visual/portals/portal_occlusion_culler.h
+++ b/servers/visual/portals/portal_occlusion_culler.h
@@ -161,13 +161,9 @@ private:
 		return false;
 	}
 
-	bool calculate_poly_goodness_of_fit(const VSOccluder_Mesh &p_opoly, real_t &r_fit);
+	bool calculate_poly_goodness_of_fit(const VSOccluder_Poly &p_opoly, real_t &r_fit);
 	void whittle_polys();
 	void precalc_poly_edge_planes(const Vector3 &p_pt_camera);
-
-	bool is_vso_poly_culled(const VSOccluder_Mesh &p_opoly, const LocalVector<Plane> &p_planes) const {
-		return is_poly_culled(p_opoly.poly_world, p_planes);
-	}
 
 	// If all the points of the poly are beyond one of the planes (e.g. frustum), it is completely culled.
 	bool is_poly_culled(const Occlusion::PolyPlane &p_opoly, const LocalVector<Plane> &p_planes) const {

--- a/servers/visual/portals/portal_resources.cpp
+++ b/servers/visual/portals/portal_resources.cpp
@@ -1,0 +1,216 @@
+/*************************************************************************/
+/*  portal_resources.cpp                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "portal_resources.h"
+
+OccluderResourceHandle PortalResources::occluder_resource_create() {
+	uint32_t pool_id = 0;
+	VSOccluder_Resource *occ = _occluder_resource_pool.request(pool_id);
+	occ->create();
+
+	OccluderResourceHandle handle = pool_id + 1;
+	return handle;
+}
+
+void PortalResources::occluder_resource_destroy(OccluderResourceHandle p_handle) {
+	p_handle--;
+
+	// Depending on the occluder resource type, remove the spheres, polys, holes etc
+	// We can reuse the update methods for this.
+	VSOccluder_Resource &occ = _occluder_resource_pool[p_handle];
+	switch (occ.type) {
+		case VSOccluder_Instance::OT_SPHERE: {
+			occluder_resource_update_spheres(p_handle + 1, Vector<Plane>());
+		} break;
+		case VSOccluder_Instance::OT_MESH: {
+			occluder_resource_update_mesh(p_handle + 1, Geometry::OccluderMeshData());
+		} break;
+		default: {
+		} break;
+	}
+
+	// This also clears the occluder
+	occ.create();
+
+	_occluder_resource_pool.free(p_handle);
+}
+
+void PortalResources::occluder_resource_prepare(OccluderResourceHandle p_handle, VSOccluder_Instance::Type p_type) {
+	p_handle--;
+
+	// depending on the occluder type, remove the spheres etc
+	VSOccluder_Resource &occ = _occluder_resource_pool[p_handle];
+
+	if (occ.type != VSOccluder_Instance::OT_UNDEFINED) {
+		ERR_PRINT_ONCE("occluder_resource_prepare should be called only once.");
+	}
+
+	occ.type = p_type;
+	ERR_FAIL_COND(p_type == VSOccluder_Instance::OT_UNDEFINED);
+}
+
+void PortalResources::occluder_resource_update_spheres(OccluderResourceHandle p_handle, const Vector<Plane> &p_spheres) {
+	p_handle--;
+	VSOccluder_Resource &occ = _occluder_resource_pool[p_handle];
+	ERR_FAIL_COND(occ.type != VSOccluder_Resource::OT_SPHERE);
+
+	// first deal with the situation where the number of spheres has changed (rare)
+	if (occ.list_ids.size() != p_spheres.size()) {
+		// not the most efficient, but works...
+		// remove existing
+		for (int n = 0; n < occ.list_ids.size(); n++) {
+			uint32_t id = occ.list_ids[n];
+			_occluder_local_sphere_pool.free(id);
+		}
+
+		occ.list_ids.clear();
+		// create new
+		for (int n = 0; n < p_spheres.size(); n++) {
+			uint32_t id;
+			VSOccluder_Sphere *sphere = _occluder_local_sphere_pool.request(id);
+			sphere->create();
+			occ.list_ids.push_back(id);
+		}
+	}
+
+	// new positions
+	for (int n = 0; n < occ.list_ids.size(); n++) {
+		uint32_t id = occ.list_ids[n];
+		VSOccluder_Sphere &sphere = _occluder_local_sphere_pool[id];
+		sphere.from_plane(p_spheres[n]);
+	}
+
+	// mark as dirty as the world space spheres will be out of date next time this resource is used
+	occ.revision += 1;
+}
+
+void PortalResources::occluder_resource_update_mesh(OccluderResourceHandle p_handle, const Geometry::OccluderMeshData &p_mesh_data) {
+	p_handle--;
+	VSOccluder_Resource &occ = _occluder_resource_pool[p_handle];
+	ERR_FAIL_COND(occ.type != VSOccluder_Resource::OT_MESH);
+
+	// mark as dirty, needs world points updating next time this resource is used
+	occ.revision += 1;
+
+	const LocalVectori<Geometry::OccluderMeshData::Face> &faces = p_mesh_data.faces;
+	const LocalVectori<Vector3> &vertices = p_mesh_data.vertices;
+
+	// first deal with the situation where the number of polys has changed (rare)
+	if (occ.list_ids.size() != faces.size()) {
+		// not the most efficient, but works...
+		// remove existing
+		for (int n = 0; n < occ.list_ids.size(); n++) {
+			uint32_t id = occ.list_ids[n];
+
+			// must also free the holes
+			VSOccluder_Poly &opoly = _occluder_local_poly_pool[id];
+			for (int h = 0; h < opoly.num_holes; h++) {
+				_occluder_local_hole_pool.free(opoly.hole_pool_ids[h]);
+
+				// perhaps debug only
+				opoly.hole_pool_ids[h] = UINT32_MAX;
+			}
+
+			_occluder_local_poly_pool.free(id);
+		}
+
+		occ.list_ids.clear();
+		// create new
+		for (int n = 0; n < faces.size(); n++) {
+			uint32_t id;
+			VSOccluder_Poly *poly = _occluder_local_poly_pool.request(id);
+			poly->create();
+			occ.list_ids.push_back(id);
+		}
+	}
+
+	// new data
+	for (int n = 0; n < occ.list_ids.size(); n++) {
+		uint32_t id = occ.list_ids[n];
+
+		VSOccluder_Poly &opoly = _occluder_local_poly_pool[id];
+		Occlusion::PolyPlane &poly = opoly.poly;
+
+		// source face
+		const Geometry::OccluderMeshData::Face &face = faces[n];
+		opoly.two_way = face.two_way;
+
+		// make sure the number of holes is correct
+		if (face.holes.size() != opoly.num_holes) {
+			// slow but hey ho
+			// delete existing holes
+			for (int i = 0; i < opoly.num_holes; i++) {
+				_occluder_local_hole_pool.free(opoly.hole_pool_ids[i]);
+				opoly.hole_pool_ids[i] = UINT32_MAX;
+			}
+			// create any new holes
+			opoly.num_holes = face.holes.size();
+			for (int i = 0; i < opoly.num_holes; i++) {
+				uint32_t hole_id;
+				VSOccluder_Hole *hole = _occluder_local_hole_pool.request(hole_id);
+				opoly.hole_pool_ids[i] = hole_id;
+				hole->create();
+			}
+		}
+
+		// set up the poly basics, plane and verts
+		poly.plane = face.plane;
+		poly.num_verts = MIN(face.indices.size(), Occlusion::PolyPlane::MAX_POLY_VERTS);
+
+		for (int c = 0; c < poly.num_verts; c++) {
+			int vert_index = face.indices[c];
+
+			if (vert_index < vertices.size()) {
+				poly.verts[c] = vertices[vert_index];
+			} else {
+				WARN_PRINT_ONCE("occluder_update_mesh : poly index out of range");
+			}
+		}
+
+		// set up any holes that are present
+		for (int h = 0; h < opoly.num_holes; h++) {
+			VSOccluder_Hole &dhole = get_pool_occluder_local_hole(opoly.hole_pool_ids[h]);
+			const Geometry::OccluderMeshData::Hole &shole = face.holes[h];
+
+			dhole.num_verts = shole.indices.size();
+			dhole.num_verts = MIN(dhole.num_verts, Occlusion::Poly::MAX_POLY_VERTS);
+
+			for (int c = 0; c < dhole.num_verts; c++) {
+				int vert_index = shole.indices[c];
+				if (vert_index < vertices.size()) {
+					dhole.verts[c] = vertices[vert_index];
+				} else {
+					WARN_PRINT_ONCE("occluder_update_mesh : hole index out of range");
+				}
+			} // for c through hole verts
+		} // for h through holes
+
+	} // for n through occluders
+}

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -592,12 +592,16 @@ public:
 	BIND2(roomgroup_add_room, RID, RID)
 
 	// Occluders
-	BIND0R(RID, occluder_create)
-	BIND3(occluder_set_scenario, RID, RID, OccluderType)
-	BIND2(occluder_spheres_update, RID, const Vector<Plane> &)
-	BIND2(occluder_mesh_update, RID, const Geometry::OccluderMeshData &)
-	BIND2(occluder_set_transform, RID, const Transform &)
-	BIND2(occluder_set_active, RID, bool)
+	BIND0R(RID, occluder_instance_create)
+	BIND2(occluder_instance_set_scenario, RID, RID)
+	BIND2(occluder_instance_link_resource, RID, RID)
+	BIND2(occluder_instance_set_transform, RID, const Transform &)
+	BIND2(occluder_instance_set_active, RID, bool)
+
+	BIND0R(RID, occluder_resource_create)
+	BIND2(occluder_resource_prepare, RID, OccluderType)
+	BIND2(occluder_resource_spheres_update, RID, const Vector<Plane> &)
+	BIND2(occluder_resource_mesh_update, RID, const Geometry::OccluderMeshData &)
 	BIND1(set_use_occlusion_culling, bool)
 	BIND1RC(Geometry::MeshData, occlusion_debug_get_current_polys, RID)
 

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -1192,65 +1192,88 @@ void VisualServerScene::roomgroup_add_room(RID p_roomgroup, RID p_room) {
 }
 
 // Occluders
-RID VisualServerScene::occluder_create() {
-	Occluder *ro = memnew(Occluder);
+RID VisualServerScene::occluder_instance_create() {
+	OccluderInstance *ro = memnew(OccluderInstance);
 	ERR_FAIL_COND_V(!ro, RID());
-	RID occluder_rid = occluder_owner.make_rid(ro);
+	RID occluder_rid = occluder_instance_owner.make_rid(ro);
 	return occluder_rid;
 }
 
-void VisualServerScene::occluder_set_scenario(RID p_occluder, RID p_scenario, VisualServer::OccluderType p_type) {
-	Occluder *ro = occluder_owner.getornull(p_occluder);
-	ERR_FAIL_COND(!ro);
+void VisualServerScene::occluder_instance_link_resource(RID p_occluder_instance, RID p_occluder_resource) {
+	OccluderInstance *oi = occluder_instance_owner.getornull(p_occluder_instance);
+	ERR_FAIL_COND(!oi);
+	ERR_FAIL_COND(!oi->scenario);
+
+	OccluderResource *res = occluder_resource_owner.getornull(p_occluder_resource);
+	ERR_FAIL_COND(!res);
+
+	oi->scenario->_portal_renderer.occluder_instance_link(oi->scenario_occluder_id, res->occluder_resource_id);
+}
+
+void VisualServerScene::occluder_instance_set_scenario(RID p_occluder_instance, RID p_scenario) {
+	OccluderInstance *oi = occluder_instance_owner.getornull(p_occluder_instance);
+	ERR_FAIL_COND(!oi);
 	Scenario *scenario = scenario_owner.getornull(p_scenario);
 
 	// noop?
-	if (ro->scenario == scenario) {
+	if (oi->scenario == scenario) {
 		return;
 	}
 
 	// if the portal is in a scenario already, remove it
-	if (ro->scenario) {
-		ro->scenario->_portal_renderer.occluder_destroy(ro->scenario_occluder_id);
-		ro->scenario = nullptr;
-		ro->scenario_occluder_id = 0;
+	if (oi->scenario) {
+		oi->scenario->_portal_renderer.occluder_instance_destroy(oi->scenario_occluder_id);
+		oi->scenario = nullptr;
+		oi->scenario_occluder_id = 0;
 	}
 
 	// create when entering the world
 	if (scenario) {
-		ro->scenario = scenario;
-
-		// defer the actual creation to here
-		ro->scenario_occluder_id = scenario->_portal_renderer.occluder_create((VSOccluder::Type)p_type);
+		oi->scenario = scenario;
+		oi->scenario_occluder_id = scenario->_portal_renderer.occluder_instance_create();
 	}
 }
 
-void VisualServerScene::occluder_set_active(RID p_occluder, bool p_active) {
-	Occluder *ro = occluder_owner.getornull(p_occluder);
-	ERR_FAIL_COND(!ro);
-	ERR_FAIL_COND(!ro->scenario);
-	ro->scenario->_portal_renderer.occluder_set_active(ro->scenario_occluder_id, p_active);
+void VisualServerScene::occluder_instance_set_active(RID p_occluder_instance, bool p_active) {
+	OccluderInstance *oi = occluder_instance_owner.getornull(p_occluder_instance);
+	ERR_FAIL_COND(!oi);
+	ERR_FAIL_COND(!oi->scenario);
+	oi->scenario->_portal_renderer.occluder_instance_set_active(oi->scenario_occluder_id, p_active);
 }
 
-void VisualServerScene::occluder_set_transform(RID p_occluder, const Transform &p_xform) {
-	Occluder *ro = occluder_owner.getornull(p_occluder);
-	ERR_FAIL_COND(!ro);
-	ERR_FAIL_COND(!ro->scenario);
-	ro->scenario->_portal_renderer.occluder_set_transform(ro->scenario_occluder_id, p_xform);
+void VisualServerScene::occluder_instance_set_transform(RID p_occluder_instance, const Transform &p_xform) {
+	OccluderInstance *oi = occluder_instance_owner.getornull(p_occluder_instance);
+	ERR_FAIL_COND(!oi);
+	ERR_FAIL_COND(!oi->scenario);
+	oi->scenario->_portal_renderer.occluder_instance_set_transform(oi->scenario_occluder_id, p_xform);
 }
 
-void VisualServerScene::occluder_spheres_update(RID p_occluder, const Vector<Plane> &p_spheres) {
-	Occluder *ro = occluder_owner.getornull(p_occluder);
-	ERR_FAIL_COND(!ro);
-	ERR_FAIL_COND(!ro->scenario);
-	ro->scenario->_portal_renderer.occluder_update_spheres(ro->scenario_occluder_id, p_spheres);
+RID VisualServerScene::occluder_resource_create() {
+	OccluderResource *res = memnew(OccluderResource);
+	ERR_FAIL_COND_V(!res, RID());
+
+	res->occluder_resource_id = _portal_resources.occluder_resource_create();
+
+	RID occluder_resource_rid = occluder_resource_owner.make_rid(res);
+	return occluder_resource_rid;
 }
 
-void VisualServerScene::occluder_mesh_update(RID p_occluder, const Geometry::OccluderMeshData &p_mesh_data) {
-	Occluder *ro = occluder_owner.getornull(p_occluder);
-	ERR_FAIL_COND(!ro);
-	ERR_FAIL_COND(!ro->scenario);
-	ro->scenario->_portal_renderer.occluder_update_mesh(ro->scenario_occluder_id, p_mesh_data);
+void VisualServerScene::occluder_resource_prepare(RID p_occluder_resource, VisualServer::OccluderType p_type) {
+	OccluderResource *res = occluder_resource_owner.getornull(p_occluder_resource);
+	ERR_FAIL_COND(!res);
+	_portal_resources.occluder_resource_prepare(res->occluder_resource_id, (VSOccluder_Instance::Type)p_type);
+}
+
+void VisualServerScene::occluder_resource_spheres_update(RID p_occluder_resource, const Vector<Plane> &p_spheres) {
+	OccluderResource *res = occluder_resource_owner.getornull(p_occluder_resource);
+	ERR_FAIL_COND(!res);
+	_portal_resources.occluder_resource_update_spheres(res->occluder_resource_id, p_spheres);
+}
+
+void VisualServerScene::occluder_resource_mesh_update(RID p_occluder_resource, const Geometry::OccluderMeshData &p_mesh_data) {
+	OccluderResource *res = occluder_resource_owner.getornull(p_occluder_resource);
+	ERR_FAIL_COND(!res);
+	_portal_resources.occluder_resource_update_mesh(res->occluder_resource_id, p_mesh_data);
 }
 
 void VisualServerScene::set_use_occlusion_culling(bool p_enable) {
@@ -4153,10 +4176,15 @@ bool VisualServerScene::free(RID p_rid) {
 		RoomGroup *roomgroup = roomgroup_owner.get(p_rid);
 		roomgroup_owner.free(p_rid);
 		memdelete(roomgroup);
-	} else if (occluder_owner.owns(p_rid)) {
-		Occluder *ro = occluder_owner.get(p_rid);
-		occluder_owner.free(p_rid);
-		memdelete(ro);
+	} else if (occluder_instance_owner.owns(p_rid)) {
+		OccluderInstance *occ_inst = occluder_instance_owner.get(p_rid);
+		occluder_instance_owner.free(p_rid);
+		memdelete(occ_inst);
+	} else if (occluder_resource_owner.owns(p_rid)) {
+		OccluderResource *occ_res = occluder_resource_owner.get(p_rid);
+		occ_res->destroy(_portal_resources);
+		occluder_resource_owner.free(p_rid);
+		memdelete(occ_res);
 	} else {
 		return false;
 	}

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -678,29 +678,47 @@ public:
 	virtual void roomgroup_add_room(RID p_roomgroup, RID p_room);
 
 	// Occluders
-	struct Occluder : RID_Data {
+	struct OccluderInstance : RID_Data {
 		uint32_t scenario_occluder_id = 0;
 		Scenario *scenario = nullptr;
-		virtual ~Occluder() {
+		virtual ~OccluderInstance() {
 			if (scenario) {
-				scenario->_portal_renderer.occluder_destroy(scenario_occluder_id);
+				scenario->_portal_renderer.occluder_instance_destroy(scenario_occluder_id);
 				scenario = nullptr;
 				scenario_occluder_id = 0;
 			}
 		}
 	};
-	RID_Owner<Occluder> occluder_owner;
+	RID_Owner<OccluderInstance> occluder_instance_owner;
 
-	virtual RID occluder_create();
-	virtual void occluder_set_scenario(RID p_occluder, RID p_scenario, VisualServer::OccluderType p_type);
-	virtual void occluder_spheres_update(RID p_occluder, const Vector<Plane> &p_spheres);
-	virtual void occluder_mesh_update(RID p_occluder, const Geometry::OccluderMeshData &p_mesh_data);
-	virtual void occluder_set_transform(RID p_occluder, const Transform &p_xform);
-	virtual void occluder_set_active(RID p_occluder, bool p_active);
+	struct OccluderResource : RID_Data {
+		uint32_t occluder_resource_id = 0;
+		void destroy(PortalResources &r_portal_resources) {
+			r_portal_resources.occluder_resource_destroy(occluder_resource_id);
+			occluder_resource_id = 0;
+		}
+		virtual ~OccluderResource() {
+			DEV_ASSERT(occluder_resource_id == 0);
+		}
+	};
+	RID_Owner<OccluderResource> occluder_resource_owner;
+
+	virtual RID occluder_instance_create();
+	virtual void occluder_instance_set_scenario(RID p_occluder_instance, RID p_scenario);
+	virtual void occluder_instance_link_resource(RID p_occluder_instance, RID p_occluder_resource);
+	virtual void occluder_instance_set_transform(RID p_occluder_instance, const Transform &p_xform);
+	virtual void occluder_instance_set_active(RID p_occluder_instance, bool p_active);
+
+	virtual RID occluder_resource_create();
+	virtual void occluder_resource_prepare(RID p_occluder_resource, VisualServer::OccluderType p_type);
+	virtual void occluder_resource_spheres_update(RID p_occluder_resource, const Vector<Plane> &p_spheres);
+	virtual void occluder_resource_mesh_update(RID p_occluder_resource, const Geometry::OccluderMeshData &p_mesh_data);
 	virtual void set_use_occlusion_culling(bool p_enable);
 
 	// editor only .. slow
 	virtual Geometry::MeshData occlusion_debug_get_current_polys(RID p_scenario) const;
+	const PortalResources &get_portal_resources() const { return _portal_resources; }
+	PortalResources &get_portal_resources() { return _portal_resources; }
 
 	// Rooms
 	struct Room : RID_Data {
@@ -821,6 +839,7 @@ public:
 private:
 	bool _use_bvh;
 	VisualServerCallbacks *_visual_server_callbacks;
+	PortalResources _portal_resources;
 
 public:
 	VisualServerScene();

--- a/servers/visual/visual_server_wrap_mt.cpp
+++ b/servers/visual/visual_server_wrap_mt.cpp
@@ -144,7 +144,8 @@ void VisualServerWrapMT::finish() {
 	roomgroup_free_cached_ids();
 	portal_free_cached_ids();
 	ghost_free_cached_ids();
-	occluder_free_cached_ids();
+	occluder_instance_free_cached_ids();
+	occluder_resource_free_cached_ids();
 }
 
 void VisualServerWrapMT::set_use_vsync_callback(bool p_enable) {

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -505,12 +505,16 @@ public:
 	FUNC2(roomgroup_add_room, RID, RID)
 
 	// Occluders
-	FUNCRID(occluder)
-	FUNC3(occluder_set_scenario, RID, RID, OccluderType)
-	FUNC2(occluder_spheres_update, RID, const Vector<Plane> &)
-	FUNC2(occluder_mesh_update, RID, const Geometry::OccluderMeshData &)
-	FUNC2(occluder_set_transform, RID, const Transform &)
-	FUNC2(occluder_set_active, RID, bool)
+	FUNCRID(occluder_instance)
+	FUNC2(occluder_instance_set_scenario, RID, RID)
+	FUNC2(occluder_instance_link_resource, RID, RID)
+	FUNC2(occluder_instance_set_transform, RID, const Transform &)
+	FUNC2(occluder_instance_set_active, RID, bool)
+
+	FUNCRID(occluder_resource)
+	FUNC2(occluder_resource_prepare, RID, OccluderType)
+	FUNC2(occluder_resource_spheres_update, RID, const Vector<Plane> &)
+	FUNC2(occluder_resource_mesh_update, RID, const Geometry::OccluderMeshData &)
 	FUNC1(set_use_occlusion_culling, bool)
 	FUNC1RC(Geometry::MeshData, occlusion_debug_get_current_polys, RID)
 

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -905,12 +905,17 @@ public:
 		OCCLUDER_TYPE_NUM_TYPES,
 	};
 
-	virtual RID occluder_create() = 0;
-	virtual void occluder_set_scenario(RID p_occluder, RID p_scenario, VisualServer::OccluderType p_type) = 0;
-	virtual void occluder_spheres_update(RID p_occluder, const Vector<Plane> &p_spheres) = 0;
-	virtual void occluder_mesh_update(RID p_occluder, const Geometry::OccluderMeshData &p_mesh_data) = 0;
-	virtual void occluder_set_transform(RID p_occluder, const Transform &p_xform) = 0;
-	virtual void occluder_set_active(RID p_occluder, bool p_active) = 0;
+	virtual RID occluder_instance_create() = 0;
+	virtual void occluder_instance_set_scenario(RID p_occluder_instance, RID p_scenario) = 0;
+	virtual void occluder_instance_link_resource(RID p_occluder_instance, RID p_occluder_resource) = 0;
+	virtual void occluder_instance_set_transform(RID p_occluder_instance, const Transform &p_xform) = 0;
+	virtual void occluder_instance_set_active(RID p_occluder_instance, bool p_active) = 0;
+
+	virtual RID occluder_resource_create() = 0;
+	virtual void occluder_resource_prepare(RID p_occluder_resource, VisualServer::OccluderType p_type) = 0;
+	virtual void occluder_resource_spheres_update(RID p_occluder_resource, const Vector<Plane> &p_spheres) = 0;
+	virtual void occluder_resource_mesh_update(RID p_occluder_resource, const Geometry::OccluderMeshData &p_mesh_data) = 0;
+
 	virtual void set_use_occlusion_culling(bool p_enable) = 0;
 	virtual Geometry::MeshData occlusion_debug_get_current_polys(RID p_scenario) const = 0;
 


### PR DESCRIPTION
In order to properly support the resource sharing paradigm, Occluders are split into Instances and Resources in the VisualServer. Instances are owned by a Scenario, and Resources are global. OccluderShape resources can now correctly be shared by multiple OccluderInstances.

Fixes #58003

## Notes
* I realised when we were discussing resources for another PR that I previously wasn't handling these correctly as they needed to be able to be able to handle being shared between more than one Occluder instance.
* A fair amount of housework to get this working to split the local space data (resources) from the world space instance data, but the actual implementation etc is unchanged.
* The resources are held as a member variable of `VisualServerScene`. This seemed like the most logical place to put them, as they are not held within a scenario, and other resources are held within `VisualServerScene`.
  
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
