### PR TITLE
Fixed issue where tabs couldn't be reordered after dropping them to another dock

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -891,7 +891,7 @@ void TabContainer::drop_data(const Point2 &p_point, const Variant &p_data) {
 			if (from_tabc && from_tabc->get_tabs_rearrange_group() == get_tabs_rearrange_group()) {
 				Control *moving_tabc = from_tabc->get_tab_control(tab_from_id);
 				from_tabc->remove_child(moving_tabc);
-				add_child(moving_tabc, false, INTERNAL_MODE_FRONT);
+				add_child(moving_tabc);
 				if (hover_now < 0) {
 					hover_now = get_tab_count() - 1;
 				}


### PR DESCRIPTION
Fixes #56140

![ezgif-7-8cce18c7d7](https://user-images.githubusercontent.com/25117425/154068977-e33f7f2b-aa09-4e98-9b2c-9bc3033c3217.gif)

