### PR TITLE
Fix tooltip flickering in some cases

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1714,7 +1714,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				if (gui.tooltip_popup) {
 					if (gui.tooltip_control) {
 						String tooltip = _gui_get_tooltip(over, gui.tooltip_control->get_global_transform().xform_inv(mpos));
-
+						tooltip = tooltip.strip_edges();
 						if (tooltip.length() == 0) {
 							_gui_cancel_tooltip();
 						} else if (gui.tooltip_label) {


### PR DESCRIPTION
This was caused due to a string comparison of two strings of which one was modified with strip_edges and the other wasn't, causing is_tooltip_shown set to false in some cases (e.g., when custom tooltips have leading or trailing whitespaces).
Fixes #58109

![tooltip flicker fix](https://user-images.githubusercontent.com/50084500/154094569-21f18828-4c09-408f-9e30-342dd9f1d8fe.gif)

