### PR TITLE
Use `switch` consistently in `_notification` (`scene` folder)

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -247,7 +247,6 @@ void AnimatedSprite2D::_notification(int p_what) {
 			}
 
 			texture->draw_rect_region(ci, dst_rect, Rect2(Vector2(), texture->get_size()), Color(1, 1, 1), false);
-
 		} break;
 	}
 }

--- a/scene/2d/audio_listener_2d.cpp
+++ b/scene/2d/audio_listener_2d.cpp
@@ -67,6 +67,7 @@ void AudioListener2D::_notification(int p_what) {
 				make_current();
 			}
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			if (!get_tree()->is_node_being_edited(this)) {
 				if (is_current()) {

--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -206,15 +206,7 @@ Transform2D Camera2D::get_camera_transform() {
 	if (rotating) {
 		xform.set_rotation(angle);
 	}
-	xform.set_origin(screen_rect.position /*.floor()*/);
-
-	/*
-	if (0) {
-		xform = get_global_transform() * xform;
-	} else {
-		xform.elements[2]+=get_global_transform().get_origin();
-	}
-*/
+	xform.set_origin(screen_rect.position);
 
 	return (xform).affine_inverse();
 }
@@ -224,14 +216,14 @@ void Camera2D::_notification(int p_what) {
 		case NOTIFICATION_INTERNAL_PROCESS:
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			_update_scroll();
-
 		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (!is_processing_internal() && !is_physics_processing_internal()) {
 				_update_scroll();
 			}
-
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			ERR_FAIL_COND(!is_inside_tree());
 			if (custom_viewport && ObjectDB::get_instance(custom_viewport_id)) {
@@ -256,8 +248,8 @@ void Camera2D::_notification(int p_what) {
 			_update_process_callback();
 			_update_scroll();
 			first = true;
-
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			if (is_current()) {
 				if (viewport && !(custom_viewport && !ObjectDB::get_instance(custom_viewport_id))) {
@@ -269,8 +261,8 @@ void Camera2D::_notification(int p_what) {
 			remove_from_group(group_name);
 			remove_from_group(canvas_group_name);
 			viewport = nullptr;
-
 		} break;
+
 #ifdef TOOLS_ENABLED
 		case NOTIFICATION_DRAW: {
 			if (!is_inside_tree() || !Engine::get_singleton()->is_editor_hint()) {

--- a/scene/2d/canvas_modulate.cpp
+++ b/scene/2d/canvas_modulate.cpp
@@ -31,27 +31,32 @@
 #include "canvas_modulate.h"
 
 void CanvasModulate::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_CANVAS) {
-		if (is_visible_in_tree()) {
-			RS::get_singleton()->canvas_set_modulate(get_canvas(), color);
-			add_to_group("_canvas_modulate_" + itos(get_canvas().get_id()));
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_CANVAS: {
+			if (is_visible_in_tree()) {
+				RS::get_singleton()->canvas_set_modulate(get_canvas(), color);
+				add_to_group("_canvas_modulate_" + itos(get_canvas().get_id()));
+			}
+		} break;
 
-	} else if (p_what == NOTIFICATION_EXIT_CANVAS) {
-		if (is_visible_in_tree()) {
-			RS::get_singleton()->canvas_set_modulate(get_canvas(), Color(1, 1, 1, 1));
-			remove_from_group("_canvas_modulate_" + itos(get_canvas().get_id()));
-		}
-	} else if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		if (is_visible_in_tree()) {
-			RS::get_singleton()->canvas_set_modulate(get_canvas(), color);
-			add_to_group("_canvas_modulate_" + itos(get_canvas().get_id()));
-		} else {
-			RS::get_singleton()->canvas_set_modulate(get_canvas(), Color(1, 1, 1, 1));
-			remove_from_group("_canvas_modulate_" + itos(get_canvas().get_id()));
-		}
+		case NOTIFICATION_EXIT_CANVAS: {
+			if (is_visible_in_tree()) {
+				RS::get_singleton()->canvas_set_modulate(get_canvas(), Color(1, 1, 1, 1));
+				remove_from_group("_canvas_modulate_" + itos(get_canvas().get_id()));
+			}
+		} break;
 
-		update_configuration_warnings();
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (is_visible_in_tree()) {
+				RS::get_singleton()->canvas_set_modulate(get_canvas(), color);
+				add_to_group("_canvas_modulate_" + itos(get_canvas().get_id()));
+			} else {
+				RS::get_singleton()->canvas_set_modulate(get_canvas(), Color(1, 1, 1, 1));
+				remove_from_group("_canvas_modulate_" + itos(get_canvas().get_id()));
+			}
+
+			update_configuration_warnings();
+		} break;
 	}
 }
 

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -102,26 +102,20 @@ void CollisionPolygon2D::_notification(int p_what) {
 				_build_polygon();
 				_update_in_shape_owner();
 			}
-
-			/*if (Engine::get_singleton()->is_editor_hint()) {
-				//display above all else
-				set_z_as_relative(false);
-				set_z_index(RS::CANVAS_ITEM_Z_MAX - 1);
-			}*/
-
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			if (parent) {
 				_update_in_shape_owner();
 			}
-
 		} break;
+
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 			if (parent) {
 				_update_in_shape_owner(true);
 			}
-
 		} break;
+
 		case NOTIFICATION_UNPARENTED: {
 			if (parent) {
 				parent->remove_shape_owner(owner_id);

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -59,34 +59,28 @@ void CollisionShape2D::_notification(int p_what) {
 				}
 				_update_in_shape_owner();
 			}
-
-			/*if (Engine::get_singleton()->is_editor_hint()) {
-				//display above all else
-				set_z_as_relative(false);
-				set_z_index(RS::CANVAS_ITEM_Z_MAX - 1);
-			}*/
-
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			if (parent) {
 				_update_in_shape_owner();
 			}
-
 		} break;
+
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 			if (parent) {
 				_update_in_shape_owner(true);
 			}
-
 		} break;
+
 		case NOTIFICATION_UNPARENTED: {
 			if (parent) {
 				parent->remove_shape_owner(owner_id);
 			}
 			owner_id = 0;
 			parent = nullptr;
-
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			ERR_FAIL_COND(!is_inside_tree());
 

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -1091,9 +1091,11 @@ void CPUParticles2D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			set_process_internal(emitting);
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			_set_redraw(false);
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			// first update before rendering to avoid one frame delay after emitting starts
 			if (emitting && (time == 0)) {
@@ -1111,9 +1113,11 @@ void CPUParticles2D::_notification(int p_what) {
 
 			RS::get_singleton()->canvas_item_add_multimesh(get_canvas_item(), multimesh, texrid);
 		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			_update_internal();
 		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			inv_emission_transform = get_global_transform().affine_inverse();
 

--- a/scene/2d/joint_2d.cpp
+++ b/scene/2d/joint_2d.cpp
@@ -162,6 +162,7 @@ void Joint2D::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			_update_joint();
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			if (joint.is_valid()) {
 				_disconnect_signals();

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -192,21 +192,24 @@ Light2D::BlendMode Light2D::get_blend_mode() const {
 }
 
 void Light2D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		RS::get_singleton()->canvas_light_attach_to_canvas(canvas_light, get_canvas());
-		_update_light_visibility();
-	}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			RS::get_singleton()->canvas_light_attach_to_canvas(canvas_light, get_canvas());
+			_update_light_visibility();
+		} break;
 
-	if (p_what == NOTIFICATION_TRANSFORM_CHANGED) {
-		RS::get_singleton()->canvas_light_set_transform(canvas_light, get_global_transform());
-	}
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		_update_light_visibility();
-	}
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			RS::get_singleton()->canvas_light_set_transform(canvas_light, get_global_transform());
+		} break;
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		RS::get_singleton()->canvas_light_attach_to_canvas(canvas_light, RID());
-		_update_light_visibility();
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			_update_light_visibility();
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			RS::get_singleton()->canvas_light_attach_to_canvas(canvas_light, RID());
+			_update_light_visibility();
+		} break;
 	}
 }
 

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -29,9 +29,9 @@
 /*************************************************************************/
 
 #include "light_occluder_2d.h"
-#include "core/math/geometry_2d.h"
 
 #include "core/config/engine.h"
+#include "core/math/geometry_2d.h"
 
 #define LINE_GRAB_WIDTH 8
 
@@ -158,42 +158,46 @@ void LightOccluder2D::_poly_changed() {
 }
 
 void LightOccluder2D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_CANVAS) {
-		RS::get_singleton()->canvas_light_occluder_attach_to_canvas(occluder, get_canvas());
-		RS::get_singleton()->canvas_light_occluder_set_transform(occluder, get_global_transform());
-		RS::get_singleton()->canvas_light_occluder_set_enabled(occluder, is_visible_in_tree());
-	}
-	if (p_what == NOTIFICATION_TRANSFORM_CHANGED) {
-		RS::get_singleton()->canvas_light_occluder_set_transform(occluder, get_global_transform());
-	}
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		RS::get_singleton()->canvas_light_occluder_set_enabled(occluder, is_visible_in_tree());
-	}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_CANVAS: {
+			RS::get_singleton()->canvas_light_occluder_attach_to_canvas(occluder, get_canvas());
+			RS::get_singleton()->canvas_light_occluder_set_transform(occluder, get_global_transform());
+			RS::get_singleton()->canvas_light_occluder_set_enabled(occluder, is_visible_in_tree());
+		} break;
 
-	if (p_what == NOTIFICATION_DRAW) {
-		if (Engine::get_singleton()->is_editor_hint()) {
-			if (occluder_polygon.is_valid()) {
-				Vector<Vector2> poly = occluder_polygon->get_polygon();
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			RS::get_singleton()->canvas_light_occluder_set_transform(occluder, get_global_transform());
+		} break;
 
-				if (poly.size()) {
-					if (occluder_polygon->is_closed()) {
-						Vector<Color> color;
-						color.push_back(Color(0, 0, 0, 0.6));
-						draw_polygon(Variant(poly), color);
-					} else {
-						int ps = poly.size();
-						const Vector2 *r = poly.ptr();
-						for (int i = 0; i < ps - 1; i++) {
-							draw_line(r[i], r[i + 1], Color(0, 0, 0, 0.6), 3);
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			RS::get_singleton()->canvas_light_occluder_set_enabled(occluder, is_visible_in_tree());
+		} break;
+
+		case NOTIFICATION_DRAW: {
+			if (Engine::get_singleton()->is_editor_hint()) {
+				if (occluder_polygon.is_valid()) {
+					Vector<Vector2> poly = occluder_polygon->get_polygon();
+
+					if (poly.size()) {
+						if (occluder_polygon->is_closed()) {
+							Vector<Color> color;
+							color.push_back(Color(0, 0, 0, 0.6));
+							draw_polygon(Variant(poly), color);
+						} else {
+							int ps = poly.size();
+							const Vector2 *r = poly.ptr();
+							for (int i = 0; i < ps - 1; i++) {
+								draw_line(r[i], r[i + 1], Color(0, 0, 0, 0.6), 3);
+							}
 						}
 					}
 				}
 			}
-		}
-	}
+		} break;
 
-	if (p_what == NOTIFICATION_EXIT_CANVAS) {
-		RS::get_singleton()->canvas_light_occluder_attach_to_canvas(occluder, RID());
+		case NOTIFICATION_EXIT_CANVAS: {
+			RS::get_singleton()->canvas_light_occluder_attach_to_canvas(occluder, RID());
+		} break;
 	}
 }
 

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -228,9 +228,9 @@ Line2D::LineCapMode Line2D::get_end_cap_mode() const {
 
 void Line2D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_DRAW:
+		case NOTIFICATION_DRAW: {
 			_draw();
-			break;
+		} break;
 	}
 }
 

--- a/scene/2d/mesh_instance_2d.cpp
+++ b/scene/2d/mesh_instance_2d.cpp
@@ -29,13 +29,16 @@
 /*************************************************************************/
 
 #include "mesh_instance_2d.h"
+
 #include "scene/scene_string_names.h"
 
 void MeshInstance2D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		if (mesh.is_valid()) {
-			draw_mesh(mesh, texture);
-		}
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			if (mesh.is_valid()) {
+				draw_mesh(mesh, texture);
+			}
+		} break;
 	}
 }
 

--- a/scene/2d/multimesh_instance_2d.cpp
+++ b/scene/2d/multimesh_instance_2d.cpp
@@ -29,13 +29,16 @@
 /*************************************************************************/
 
 #include "multimesh_instance_2d.h"
+
 #include "scene/scene_string_names.h"
 
 void MultiMeshInstance2D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		if (multimesh.is_valid()) {
-			draw_multimesh(multimesh, texture);
-		}
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			if (multimesh.is_valid()) {
+				draw_multimesh(multimesh, texture);
+			}
+		} break;
 	}
 }
 

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -97,10 +97,12 @@ void NavigationAgent2D::_notification(int p_what) {
 			}
 			set_physics_process_internal(true);
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			agent_parent = nullptr;
 			set_physics_process_internal(false);
 		} break;
+
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (agent_parent) {
 				NavigationServer2D::get_singleton()->agent_set_position(agent, agent_parent->get_global_position());

--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -63,17 +63,21 @@ void NavigationObstacle2D::_notification(int p_what) {
 			}
 			set_physics_process_internal(true);
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			parent_node2d = nullptr;
 			set_physics_process_internal(false);
 		} break;
+
 		case NOTIFICATION_PARENTED: {
 			parent_node2d = Object::cast_to<Node2D>(get_parent());
 			reevaluate_agent_radius();
 		} break;
+
 		case NOTIFICATION_UNPARENTED: {
 			parent_node2d = nullptr;
 		} break;
+
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (parent_node2d) {
 				NavigationServer2D::get_singleton()->agent_set_position(agent, parent_node2d->get_global_position());

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -406,15 +406,18 @@ void NavigationRegion2D::_notification(int p_what) {
 				NavigationServer2D::get_singleton_mut()->connect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
 			}
 		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			NavigationServer2D::get_singleton()->region_set_transform(region, get_global_transform());
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			NavigationServer2D::get_singleton()->region_set_map(region, RID());
 			if (enabled) {
 				NavigationServer2D::get_singleton_mut()->disconnect("map_changed", callable_mp(this, &NavigationRegion2D::_map_changed));
 			}
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_navigation_hint()) && navpoly.is_valid()) {
 				Vector<Vector2> verts = navpoly->get_vertices();

--- a/scene/2d/parallax_background.cpp
+++ b/scene/2d/parallax_background.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "parallax_background.h"
+
 #include "parallax_layer.h"
 
 void ParallaxBackground::_notification(int p_what) {
@@ -36,8 +37,8 @@ void ParallaxBackground::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			group_name = "__cameras_" + itos(get_viewport().get_id());
 			add_to_group(group_name);
-
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			remove_from_group(group_name);
 		} break;

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -99,6 +99,7 @@ void ParallaxLayer::_notification(int p_what) {
 			orig_scale = get_scale();
 			_update_mirroring();
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			if (Engine::get_singleton()->is_editor_hint()) {
 				break;

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -86,36 +86,41 @@ bool Path2D::_edit_is_selected_on_click(const Point2 &p_point, double p_toleranc
 #endif
 
 void Path2D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW && curve.is_valid()) {
-		//draw the curve!!
+	switch (p_what) {
+		// Draw the curve if navigation debugging is enabled.
+		case NOTIFICATION_DRAW: {
+			if (!curve.is_valid()) {
+				break;
+			}
 
-		if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_navigation_hint()) {
-			return;
-		}
+			if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_navigation_hint()) {
+				return;
+			}
 
-		if (curve->get_point_count() < 2) {
-			return;
-		}
+			if (curve->get_point_count() < 2) {
+				return;
+			}
 
 #ifdef TOOLS_ENABLED
-		const real_t line_width = 2 * EDSCALE;
+			const real_t line_width = 2 * EDSCALE;
 #else
-		const real_t line_width = 2;
+			const real_t line_width = 2;
 #endif
-		const Color color = Color(0.5, 0.6, 1.0, 0.7);
+			const Color color = Color(0.5, 0.6, 1.0, 0.7);
 
-		_cached_draw_pts.resize(curve->get_point_count() * 8);
-		int count = 0;
+			_cached_draw_pts.resize(curve->get_point_count() * 8);
+			int count = 0;
 
-		for (int i = 0; i < curve->get_point_count(); i++) {
-			for (int j = 0; j < 8; j++) {
-				real_t frac = j * (1.0 / 8.0);
-				Vector2 p = curve->interpolate(i, frac);
-				_cached_draw_pts.set(count++, p);
+			for (int i = 0; i < curve->get_point_count(); i++) {
+				for (int j = 0; j < 8; j++) {
+					real_t frac = j * (1.0 / 8.0);
+					Vector2 p = curve->interpolate(i, frac);
+					_cached_draw_pts.set(count++, p);
+				}
 			}
-		}
 
-		draw_polyline(_cached_draw_pts, color, line_width, true);
+			draw_polyline(_cached_draw_pts, color, line_width, true);
+		} break;
 	}
 }
 
@@ -226,8 +231,8 @@ void PathFollow2D::_notification(int p_what) {
 			if (path) {
 				_update_transform();
 			}
-
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			path = nullptr;
 		} break;

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -906,7 +906,7 @@ void RigidDynamicBody2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			if (Engine::get_singleton()->is_editor_hint()) {
-				set_notify_local_transform(true); //used for warnings and only in editor
+				set_notify_local_transform(true); // Used for warnings and only in editor.
 			}
 		} break;
 

--- a/scene/2d/position_2d.cpp
+++ b/scene/2d/position_2d.cpp
@@ -90,6 +90,7 @@ void Position2D::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			update();
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			if (!is_inside_tree()) {
 				break;
@@ -97,7 +98,6 @@ void Position2D::_notification(int p_what) {
 			if (Engine::get_singleton()->is_editor_hint()) {
 				_draw_cross();
 			}
-
 		} break;
 	}
 }

--- a/scene/2d/ray_cast_2d.cpp
+++ b/scene/2d/ray_cast_2d.cpp
@@ -150,11 +150,11 @@ void RayCast2D::_notification(int p_what) {
 				}
 			}
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			if (enabled) {
 				set_physics_process_internal(false);
 			}
-
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -163,16 +163,13 @@ void RayCast2D::_notification(int p_what) {
 				break;
 			}
 			_draw_debug_shape();
-
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (!enabled) {
 				break;
 			}
-
 			_update_raycast_state();
-
 		} break;
 	}
 }

--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -115,8 +115,8 @@ void RemoteTransform2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			_update_cache();
-
 		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (!is_inside_tree()) {
 				break;
@@ -125,7 +125,6 @@ void RemoteTransform2D::_notification(int p_what) {
 			if (cache.is_valid()) {
 				_update_remote();
 			}
-
 		} break;
 	}
 }

--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -201,6 +201,7 @@ void ShapeCast2D::_notification(int p_what) {
 				}
 			}
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			if (enabled) {
 				set_physics_process_internal(false);
@@ -254,6 +255,7 @@ void ShapeCast2D::_notification(int p_what) {
 			}
 #endif
 		} break;
+
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (!enabled) {
 				break;

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -93,223 +93,228 @@ void Bone2D::_get_property_list(List<PropertyInfo> *p_list) const {
 }
 
 void Bone2D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		Node *parent = get_parent();
-		parent_bone = Object::cast_to<Bone2D>(parent);
-		skeleton = nullptr;
-		while (parent) {
-			skeleton = Object::cast_to<Skeleton2D>(parent);
-			if (skeleton) {
-				break;
-			}
-			if (!Object::cast_to<Bone2D>(parent)) {
-				break; //skeletons must be chained to Bone2Ds.
-			}
-
-			parent = parent->get_parent();
-		}
-
-		if (skeleton) {
-			Skeleton2D::Bone bone;
-			bone.bone = this;
-			skeleton->bones.push_back(bone);
-			skeleton->_make_bone_setup_dirty();
-		}
-
-		cache_transform = get_transform();
-		copy_transform_to_cache = true;
-
-#ifdef TOOLS_ENABLED
-		// Only draw the gizmo in the editor!
-		if (Engine::get_singleton()->is_editor_hint() == false) {
-			return;
-		}
-
-		update();
-#endif // TOOLS_ENABLED
-	}
-
-	else if (p_what == NOTIFICATION_LOCAL_TRANSFORM_CHANGED) {
-		if (skeleton) {
-			skeleton->_make_transform_dirty();
-		}
-		if (copy_transform_to_cache) {
-			cache_transform = get_transform();
-		}
-#ifdef TOOLS_ENABLED
-		// Only draw the gizmo in the editor!
-		if (Engine::get_singleton()->is_editor_hint() == false) {
-			return;
-		}
-
-		update();
-
-		if (get_parent()) {
-			Bone2D *parent_bone = Object::cast_to<Bone2D>(get_parent());
-			if (parent_bone) {
-				parent_bone->update();
-			}
-		}
-#endif // TOOLS_ENABLED
-	}
-
-	else if (p_what == NOTIFICATION_MOVED_IN_PARENT) {
-		if (skeleton) {
-			skeleton->_make_bone_setup_dirty();
-		}
-		if (copy_transform_to_cache) {
-			cache_transform = get_transform();
-		}
-	}
-
-	else if (p_what == NOTIFICATION_EXIT_TREE) {
-		if (skeleton) {
-			for (int i = 0; i < skeleton->bones.size(); i++) {
-				if (skeleton->bones[i].bone == this) {
-					skeleton->bones.remove_at(i);
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			Node *parent = get_parent();
+			parent_bone = Object::cast_to<Bone2D>(parent);
+			skeleton = nullptr;
+			while (parent) {
+				skeleton = Object::cast_to<Skeleton2D>(parent);
+				if (skeleton) {
 					break;
 				}
-			}
-			skeleton->_make_bone_setup_dirty();
-			skeleton = nullptr;
-		}
-		parent_bone = nullptr;
-		set_transform(cache_transform);
-	}
+				if (!Object::cast_to<Bone2D>(parent)) {
+					break; //skeletons must be chained to Bone2Ds.
+				}
 
-	else if (p_what == NOTIFICATION_READY) {
-		if (autocalculate_length_and_angle) {
-			calculate_length_and_rotation();
-		}
-	}
+				parent = parent->get_parent();
+			}
+
+			if (skeleton) {
+				Skeleton2D::Bone bone;
+				bone.bone = this;
+				skeleton->bones.push_back(bone);
+				skeleton->_make_bone_setup_dirty();
+			}
+
+			cache_transform = get_transform();
+			copy_transform_to_cache = true;
+
 #ifdef TOOLS_ENABLED
-	else if (p_what == NOTIFICATION_EDITOR_PRE_SAVE || p_what == NOTIFICATION_EDITOR_POST_SAVE) {
-		Transform2D tmp_trans = get_transform();
-		set_transform(cache_transform);
-		cache_transform = tmp_trans;
-	}
-	// Bone2D Editor gizmo drawing:
+			// Only draw the gizmo in the editor!
+			if (Engine::get_singleton()->is_editor_hint() == false) {
+				return;
+			}
+
+			update();
+#endif // TOOLS_ENABLED
+		} break;
+
+		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
+			if (skeleton) {
+				skeleton->_make_transform_dirty();
+			}
+			if (copy_transform_to_cache) {
+				cache_transform = get_transform();
+			}
+#ifdef TOOLS_ENABLED
+			// Only draw the gizmo in the editor!
+			if (Engine::get_singleton()->is_editor_hint() == false) {
+				return;
+			}
+
+			update();
+
+			if (get_parent()) {
+				Bone2D *parent_bone = Object::cast_to<Bone2D>(get_parent());
+				if (parent_bone) {
+					parent_bone->update();
+				}
+			}
+#endif // TOOLS_ENABLED
+		} break;
+
+		case NOTIFICATION_MOVED_IN_PARENT: {
+			if (skeleton) {
+				skeleton->_make_bone_setup_dirty();
+			}
+			if (copy_transform_to_cache) {
+				cache_transform = get_transform();
+			}
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			if (skeleton) {
+				for (int i = 0; i < skeleton->bones.size(); i++) {
+					if (skeleton->bones[i].bone == this) {
+						skeleton->bones.remove_at(i);
+						break;
+					}
+				}
+				skeleton->_make_bone_setup_dirty();
+				skeleton = nullptr;
+			}
+			parent_bone = nullptr;
+			set_transform(cache_transform);
+		} break;
+
+		case NOTIFICATION_READY: {
+			if (autocalculate_length_and_angle) {
+				calculate_length_and_rotation();
+			}
+		} break;
+
+#ifdef TOOLS_ENABLED
+		case NOTIFICATION_EDITOR_PRE_SAVE:
+		case NOTIFICATION_EDITOR_POST_SAVE: {
+			Transform2D tmp_trans = get_transform();
+			set_transform(cache_transform);
+			cache_transform = tmp_trans;
+		} break;
+
+		// Bone2D Editor gizmo drawing:
 #ifndef _MSC_VER
 #warning TODO Bone2D gizmo drawing needs to be moved to an editor plugin
 #endif
-	else if (p_what == NOTIFICATION_DRAW) {
-		// Only draw the gizmo in the editor!
-		if (Engine::get_singleton()->is_editor_hint() == false) {
-			return;
-		}
-
-		if (editor_gizmo_rid.is_null()) {
-			editor_gizmo_rid = RenderingServer::get_singleton()->canvas_item_create();
-			RenderingServer::get_singleton()->canvas_item_set_parent(editor_gizmo_rid, get_canvas_item());
-			RenderingServer::get_singleton()->canvas_item_set_z_as_relative_to_parent(editor_gizmo_rid, true);
-			RenderingServer::get_singleton()->canvas_item_set_z_index(editor_gizmo_rid, 10);
-		}
-		RenderingServer::get_singleton()->canvas_item_clear(editor_gizmo_rid);
-
-		if (!_editor_show_bone_gizmo) {
-			return;
-		}
-
-		// Undo scaling
-		Transform2D editor_gizmo_trans = Transform2D();
-		editor_gizmo_trans.set_scale(Vector2(1, 1) / get_global_scale());
-		RenderingServer::get_singleton()->canvas_item_set_transform(editor_gizmo_rid, editor_gizmo_trans);
-
-		Color bone_color1 = EditorSettings::get_singleton()->get("editors/2d/bone_color1");
-		Color bone_color2 = EditorSettings::get_singleton()->get("editors/2d/bone_color2");
-		Color bone_ik_color = EditorSettings::get_singleton()->get("editors/2d/bone_ik_color");
-		Color bone_outline_color = EditorSettings::get_singleton()->get("editors/2d/bone_outline_color");
-		Color bone_selected_color = EditorSettings::get_singleton()->get("editors/2d/bone_selected_color");
-
-		bool Bone2D_found = false;
-		for (int i = 0; i < get_child_count(); i++) {
-			Bone2D *child_node = nullptr;
-			child_node = Object::cast_to<Bone2D>(get_child(i));
-			if (!child_node) {
-				continue;
-			}
-			Bone2D_found = true;
-
-			Vector<Vector2> bone_shape;
-			Vector<Vector2> bone_shape_outline;
-
-			_editor_get_bone_shape(&bone_shape, &bone_shape_outline, child_node);
-
-			Vector<Color> colors;
-			if (has_meta("_local_pose_override_enabled_")) {
-				colors.push_back(bone_ik_color);
-				colors.push_back(bone_ik_color);
-				colors.push_back(bone_ik_color);
-				colors.push_back(bone_ik_color);
-			} else {
-				colors.push_back(bone_color1);
-				colors.push_back(bone_color2);
-				colors.push_back(bone_color1);
-				colors.push_back(bone_color2);
+		case NOTIFICATION_DRAW: {
+			// Only draw the gizmo in the editor!
+			if (Engine::get_singleton()->is_editor_hint() == false) {
+				return;
 			}
 
-			Vector<Color> outline_colors;
-			if (CanvasItemEditor::get_singleton()->editor_selection->is_selected(this)) {
-				outline_colors.push_back(bone_selected_color);
-				outline_colors.push_back(bone_selected_color);
-				outline_colors.push_back(bone_selected_color);
-				outline_colors.push_back(bone_selected_color);
-				outline_colors.push_back(bone_selected_color);
-				outline_colors.push_back(bone_selected_color);
-			} else {
-				outline_colors.push_back(bone_outline_color);
-				outline_colors.push_back(bone_outline_color);
-				outline_colors.push_back(bone_outline_color);
-				outline_colors.push_back(bone_outline_color);
-				outline_colors.push_back(bone_outline_color);
-				outline_colors.push_back(bone_outline_color);
+			if (editor_gizmo_rid.is_null()) {
+				editor_gizmo_rid = RenderingServer::get_singleton()->canvas_item_create();
+				RenderingServer::get_singleton()->canvas_item_set_parent(editor_gizmo_rid, get_canvas_item());
+				RenderingServer::get_singleton()->canvas_item_set_z_as_relative_to_parent(editor_gizmo_rid, true);
+				RenderingServer::get_singleton()->canvas_item_set_z_index(editor_gizmo_rid, 10);
+			}
+			RenderingServer::get_singleton()->canvas_item_clear(editor_gizmo_rid);
+
+			if (!_editor_show_bone_gizmo) {
+				return;
 			}
 
-			RenderingServer::get_singleton()->canvas_item_add_polygon(editor_gizmo_rid, bone_shape_outline, outline_colors);
-			RenderingServer::get_singleton()->canvas_item_add_polygon(editor_gizmo_rid, bone_shape, colors);
-		}
+			// Undo scaling
+			Transform2D editor_gizmo_trans = Transform2D();
+			editor_gizmo_trans.set_scale(Vector2(1, 1) / get_global_scale());
+			RenderingServer::get_singleton()->canvas_item_set_transform(editor_gizmo_rid, editor_gizmo_trans);
 
-		if (!Bone2D_found) {
-			Vector<Vector2> bone_shape;
-			Vector<Vector2> bone_shape_outline;
+			Color bone_color1 = EditorSettings::get_singleton()->get("editors/2d/bone_color1");
+			Color bone_color2 = EditorSettings::get_singleton()->get("editors/2d/bone_color2");
+			Color bone_ik_color = EditorSettings::get_singleton()->get("editors/2d/bone_ik_color");
+			Color bone_outline_color = EditorSettings::get_singleton()->get("editors/2d/bone_outline_color");
+			Color bone_selected_color = EditorSettings::get_singleton()->get("editors/2d/bone_selected_color");
 
-			_editor_get_bone_shape(&bone_shape, &bone_shape_outline, nullptr);
+			bool Bone2D_found = false;
+			for (int i = 0; i < get_child_count(); i++) {
+				Bone2D *child_node = nullptr;
+				child_node = Object::cast_to<Bone2D>(get_child(i));
+				if (!child_node) {
+					continue;
+				}
+				Bone2D_found = true;
 
-			Vector<Color> colors;
-			if (has_meta("_local_pose_override_enabled_")) {
-				colors.push_back(bone_ik_color);
-				colors.push_back(bone_ik_color);
-				colors.push_back(bone_ik_color);
-				colors.push_back(bone_ik_color);
-			} else {
-				colors.push_back(bone_color1);
-				colors.push_back(bone_color2);
-				colors.push_back(bone_color1);
-				colors.push_back(bone_color2);
+				Vector<Vector2> bone_shape;
+				Vector<Vector2> bone_shape_outline;
+
+				_editor_get_bone_shape(&bone_shape, &bone_shape_outline, child_node);
+
+				Vector<Color> colors;
+				if (has_meta("_local_pose_override_enabled_")) {
+					colors.push_back(bone_ik_color);
+					colors.push_back(bone_ik_color);
+					colors.push_back(bone_ik_color);
+					colors.push_back(bone_ik_color);
+				} else {
+					colors.push_back(bone_color1);
+					colors.push_back(bone_color2);
+					colors.push_back(bone_color1);
+					colors.push_back(bone_color2);
+				}
+
+				Vector<Color> outline_colors;
+				if (CanvasItemEditor::get_singleton()->editor_selection->is_selected(this)) {
+					outline_colors.push_back(bone_selected_color);
+					outline_colors.push_back(bone_selected_color);
+					outline_colors.push_back(bone_selected_color);
+					outline_colors.push_back(bone_selected_color);
+					outline_colors.push_back(bone_selected_color);
+					outline_colors.push_back(bone_selected_color);
+				} else {
+					outline_colors.push_back(bone_outline_color);
+					outline_colors.push_back(bone_outline_color);
+					outline_colors.push_back(bone_outline_color);
+					outline_colors.push_back(bone_outline_color);
+					outline_colors.push_back(bone_outline_color);
+					outline_colors.push_back(bone_outline_color);
+				}
+
+				RenderingServer::get_singleton()->canvas_item_add_polygon(editor_gizmo_rid, bone_shape_outline, outline_colors);
+				RenderingServer::get_singleton()->canvas_item_add_polygon(editor_gizmo_rid, bone_shape, colors);
 			}
 
-			Vector<Color> outline_colors;
-			if (CanvasItemEditor::get_singleton()->editor_selection->is_selected(this)) {
-				outline_colors.push_back(bone_selected_color);
-				outline_colors.push_back(bone_selected_color);
-				outline_colors.push_back(bone_selected_color);
-				outline_colors.push_back(bone_selected_color);
-				outline_colors.push_back(bone_selected_color);
-				outline_colors.push_back(bone_selected_color);
-			} else {
-				outline_colors.push_back(bone_outline_color);
-				outline_colors.push_back(bone_outline_color);
-				outline_colors.push_back(bone_outline_color);
-				outline_colors.push_back(bone_outline_color);
-				outline_colors.push_back(bone_outline_color);
-				outline_colors.push_back(bone_outline_color);
-			}
+			if (!Bone2D_found) {
+				Vector<Vector2> bone_shape;
+				Vector<Vector2> bone_shape_outline;
 
-			RenderingServer::get_singleton()->canvas_item_add_polygon(editor_gizmo_rid, bone_shape_outline, outline_colors);
-			RenderingServer::get_singleton()->canvas_item_add_polygon(editor_gizmo_rid, bone_shape, colors);
-		}
+				_editor_get_bone_shape(&bone_shape, &bone_shape_outline, nullptr);
+
+				Vector<Color> colors;
+				if (has_meta("_local_pose_override_enabled_")) {
+					colors.push_back(bone_ik_color);
+					colors.push_back(bone_ik_color);
+					colors.push_back(bone_ik_color);
+					colors.push_back(bone_ik_color);
+				} else {
+					colors.push_back(bone_color1);
+					colors.push_back(bone_color2);
+					colors.push_back(bone_color1);
+					colors.push_back(bone_color2);
+				}
+
+				Vector<Color> outline_colors;
+				if (CanvasItemEditor::get_singleton()->editor_selection->is_selected(this)) {
+					outline_colors.push_back(bone_selected_color);
+					outline_colors.push_back(bone_selected_color);
+					outline_colors.push_back(bone_selected_color);
+					outline_colors.push_back(bone_selected_color);
+					outline_colors.push_back(bone_selected_color);
+					outline_colors.push_back(bone_selected_color);
+				} else {
+					outline_colors.push_back(bone_outline_color);
+					outline_colors.push_back(bone_outline_color);
+					outline_colors.push_back(bone_outline_color);
+					outline_colors.push_back(bone_outline_color);
+					outline_colors.push_back(bone_outline_color);
+					outline_colors.push_back(bone_outline_color);
+				}
+
+				RenderingServer::get_singleton()->canvas_item_add_polygon(editor_gizmo_rid, bone_shape_outline, outline_colors);
+				RenderingServer::get_singleton()->canvas_item_add_polygon(editor_gizmo_rid, bone_shape, colors);
+			}
+		} break;
+#endif // TOOLS_ENABLED
 	}
-#endif // TOOLS_ENALBED
 }
 
 #ifdef TOOLS_ENABLED

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -122,11 +122,6 @@ void Sprite2D::_notification(int p_what) {
 
 			RID ci = get_canvas_item();
 
-			/*
-			texture->draw(ci,Point2());
-			break;
-			*/
-
 			Rect2 src_rect, dst_rect;
 			bool filter_clip_enabled;
 			_get_rects(src_rect, dst_rect, filter_clip_enabled);

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -489,6 +489,7 @@ void TileMap::_notification(int p_what) {
 			_clear_internals();
 			_recreate_internals();
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			_clear_internals();
 		} break;
@@ -980,7 +981,7 @@ void TileMap::_recompute_rect_cache() {
 
 void TileMap::_rendering_notification(int p_what) {
 	switch (p_what) {
-		case CanvasItem::NOTIFICATION_VISIBILITY_CHANGED: {
+		case NOTIFICATION_VISIBILITY_CHANGED: {
 			bool visible = is_visible_in_tree();
 			for (int layer = 0; layer < (int)layers.size(); layer++) {
 				for (KeyValue<Vector2i, TileMapQuadrant> &E_quadrant : layers[layer].quadrant_map) {
@@ -997,7 +998,8 @@ void TileMap::_rendering_notification(int p_what) {
 				}
 			}
 		} break;
-		case CanvasItem::NOTIFICATION_TRANSFORM_CHANGED: {
+
+		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (!is_inside_tree()) {
 				return;
 			}
@@ -1016,7 +1018,8 @@ void TileMap::_rendering_notification(int p_what) {
 				}
 			}
 		} break;
-		case CanvasItem::NOTIFICATION_DRAW: {
+
+		case NOTIFICATION_DRAW: {
 			if (tile_set.is_valid()) {
 				RenderingServer::get_singleton()->canvas_item_set_sort_children_by_y(get_canvas_item(), is_y_sort_enabled());
 			}
@@ -1369,7 +1372,7 @@ void TileMap::draw_tile(RID p_canvas_item, Vector2i p_position, const Ref<TileSe
 
 void TileMap::_physics_notification(int p_what) {
 	switch (p_what) {
-		case CanvasItem::NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			bool in_editor = false;
 #ifdef TOOLS_ENABLED
 			in_editor = Engine::get_singleton()->is_editor_hint();
@@ -1382,7 +1385,8 @@ void TileMap::_physics_notification(int p_what) {
 				set_notify_local_transform(true);
 			}
 		} break;
-		case CanvasItem::NOTIFICATION_TRANSFORM_CHANGED: {
+
+		case NOTIFICATION_TRANSFORM_CHANGED: {
 			bool in_editor = false;
 #ifdef TOOLS_ENABLED
 			in_editor = Engine::get_singleton()->is_editor_hint();
@@ -1404,6 +1408,7 @@ void TileMap::_physics_notification(int p_what) {
 				}
 			}
 		} break;
+
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 			bool in_editor = false;
 #ifdef TOOLS_ENABLED
@@ -1600,7 +1605,7 @@ void TileMap::_physics_draw_quadrant_debug(TileMapQuadrant *p_quadrant) {
 
 void TileMap::_navigation_notification(int p_what) {
 	switch (p_what) {
-		case CanvasItem::NOTIFICATION_TRANSFORM_CHANGED: {
+		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (is_inside_tree()) {
 				for (int layer = 0; layer < (int)layers.size(); layer++) {
 					Transform2D tilemap_xform = get_global_transform();

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -134,8 +134,8 @@ void TouchScreenButton::_notification(int p_what) {
 				draw_set_transform_matrix(get_canvas_transform().translated(pos));
 				shape->draw(get_canvas_item(), draw_col);
 			}
-
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			if (!Engine::get_singleton()->is_editor_hint() && !!DisplayServer::get_singleton()->screen_is_touchscreen(DisplayServer::get_singleton()->window_get_current_screen(get_viewport()->get_window_id())) && visibility == VISIBILITY_TOUCHSCREEN_ONLY) {
 				return;
@@ -145,13 +145,14 @@ void TouchScreenButton::_notification(int p_what) {
 			if (!Engine::get_singleton()->is_editor_hint()) {
 				set_process_input(is_visible_in_tree());
 			}
-
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			if (is_pressed()) {
 				_release(true);
 			}
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (Engine::get_singleton()->is_editor_hint()) {
 				break;
@@ -165,6 +166,7 @@ void TouchScreenButton::_notification(int p_what) {
 				}
 			}
 		} break;
+
 		case NOTIFICATION_PAUSED: {
 			if (is_pressed()) {
 				_release();

--- a/scene/2d/visible_on_screen_notifier_2d.cpp
+++ b/scene/2d/visible_on_screen_notifier_2d.cpp
@@ -75,15 +75,16 @@ Rect2 VisibleOnScreenNotifier2D::get_rect() const {
 void VisibleOnScreenNotifier2D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
-			//get_world_2d()->
 			on_screen = false;
 			RS::get_singleton()->canvas_item_set_visibility_notifier(get_canvas_item(), true, rect, callable_mp(this, &VisibleOnScreenNotifier2D::_visibility_enter), callable_mp(this, &VisibleOnScreenNotifier2D::_visibility_exit));
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			if (Engine::get_singleton()->is_editor_hint()) {
 				draw_rect(rect, Color(1, 0.5, 1, 0.2));
 			}
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			on_screen = false;
 			RS::get_singleton()->canvas_item_set_visibility_notifier(get_canvas_item(), false, Rect2(), Callable(), Callable());
@@ -169,21 +170,23 @@ void VisibleOnScreenEnabler2D::_update_enable_mode(bool p_enable) {
 	}
 }
 void VisibleOnScreenEnabler2D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		if (Engine::get_singleton()->is_editor_hint()) {
-			return;
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			if (Engine::get_singleton()->is_editor_hint()) {
+				return;
+			}
 
-		node_id = ObjectID();
-		Node *node = get_node(enable_node_path);
-		if (node) {
-			node_id = node->get_instance_id();
-			node->set_process_mode(PROCESS_MODE_DISABLED);
-		}
-	}
+			node_id = ObjectID();
+			Node *node = get_node(enable_node_path);
+			if (node) {
+				node_id = node->get_instance_id();
+				node->set_process_mode(PROCESS_MODE_DISABLED);
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		node_id = ObjectID();
+		case NOTIFICATION_EXIT_TREE: {
+			node_id = ObjectID();
+		} break;
 	}
 }
 

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -344,10 +344,14 @@ void Area3D::_clear_monitoring() {
 }
 
 void Area3D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		_clear_monitoring();
-	} else if (p_what == NOTIFICATION_ENTER_TREE) {
-		_initialize_wind();
+	switch (p_what) {
+		case NOTIFICATION_EXIT_TREE: {
+			_clear_monitoring();
+		} break;
+
+		case NOTIFICATION_ENTER_TREE: {
+			_initialize_wind();
+		} break;
 	}
 }
 

--- a/scene/3d/audio_listener_3d.cpp
+++ b/scene/3d/audio_listener_3d.cpp
@@ -85,9 +85,11 @@ void AudioListener3D::_notification(int p_what) {
 				make_current();
 			}
 		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			_request_listener_update();
 		} break;
+
 		case NOTIFICATION_EXIT_WORLD: {
 			if (!get_tree()->is_node_being_edited(this)) {
 				if (is_current()) {
@@ -100,7 +102,6 @@ void AudioListener3D::_notification(int p_what) {
 			}
 
 			get_viewport()->_audio_listener_3d_remove(this);
-
 		} break;
 	}
 }

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -239,80 +239,82 @@ float AudioStreamPlayer3D::_get_attenuation_db(float p_distance) const {
 }
 
 void AudioStreamPlayer3D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		velocity_tracker->reset(get_global_transform().origin);
-		AudioServer::get_singleton()->add_listener_changed_callback(_listener_changed_cb, this);
-		if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
-			play();
-		}
-	}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			velocity_tracker->reset(get_global_transform().origin);
+			AudioServer::get_singleton()->add_listener_changed_callback(_listener_changed_cb, this);
+			if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
+				play();
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		stop();
-		AudioServer::get_singleton()->remove_listener_changed_callback(_listener_changed_cb, this);
-	}
+		case NOTIFICATION_EXIT_TREE: {
+			stop();
+			AudioServer::get_singleton()->remove_listener_changed_callback(_listener_changed_cb, this);
+		} break;
 
-	if (p_what == NOTIFICATION_PAUSED) {
-		if (!can_process()) {
-			// Node can't process so we start fading out to silence
-			set_stream_paused(true);
-		}
-	}
+		case NOTIFICATION_PAUSED: {
+			if (!can_process()) {
+				// Node can't process so we start fading out to silence.
+				set_stream_paused(true);
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_UNPAUSED) {
-		set_stream_paused(false);
-	}
+		case NOTIFICATION_UNPAUSED: {
+			set_stream_paused(false);
+		} break;
 
-	if (p_what == NOTIFICATION_TRANSFORM_CHANGED) {
-		if (doppler_tracking != DOPPLER_TRACKING_DISABLED) {
-			velocity_tracker->update_position(get_global_transform().origin);
-		}
-	}
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			if (doppler_tracking != DOPPLER_TRACKING_DISABLED) {
+				velocity_tracker->update_position(get_global_transform().origin);
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_INTERNAL_PHYSICS_PROCESS) {
-		//update anything related to position first, if possible of course
-		Vector<AudioFrame> volume_vector;
-		if (setplay.get() > 0 || (active.is_set() && last_mix_count != AudioServer::get_singleton()->get_mix_count())) {
-			volume_vector = _update_panning();
-		}
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			// Update anything related to position first, if possible of course.
+			Vector<AudioFrame> volume_vector;
+			if (setplay.get() > 0 || (active.is_set() && last_mix_count != AudioServer::get_singleton()->get_mix_count())) {
+				volume_vector = _update_panning();
+			}
 
-		if (setplay.get() >= 0 && stream.is_valid()) {
-			active.set();
-			Ref<AudioStreamPlayback> new_playback = stream->instance_playback();
-			ERR_FAIL_COND_MSG(new_playback.is_null(), "Failed to instantiate playback.");
-			Map<StringName, Vector<AudioFrame>> bus_map;
-			bus_map[_get_actual_bus()] = volume_vector;
-			AudioServer::get_singleton()->start_playback_stream(new_playback, bus_map, setplay.get(), actual_pitch_scale, linear_attenuation, attenuation_filter_cutoff_hz);
-			stream_playbacks.push_back(new_playback);
-			setplay.set(-1);
-		}
+			if (setplay.get() >= 0 && stream.is_valid()) {
+				active.set();
+				Ref<AudioStreamPlayback> new_playback = stream->instance_playback();
+				ERR_FAIL_COND_MSG(new_playback.is_null(), "Failed to instantiate playback.");
+				Map<StringName, Vector<AudioFrame>> bus_map;
+				bus_map[_get_actual_bus()] = volume_vector;
+				AudioServer::get_singleton()->start_playback_stream(new_playback, bus_map, setplay.get(), actual_pitch_scale, linear_attenuation, attenuation_filter_cutoff_hz);
+				stream_playbacks.push_back(new_playback);
+				setplay.set(-1);
+			}
 
-		if (!stream_playbacks.is_empty() && active.is_set()) {
-			// Stop playing if no longer active.
-			Vector<Ref<AudioStreamPlayback>> playbacks_to_remove;
-			for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
-				if (playback.is_valid() && !AudioServer::get_singleton()->is_playback_active(playback) && !AudioServer::get_singleton()->is_playback_paused(playback)) {
-					playbacks_to_remove.push_back(playback);
+			if (!stream_playbacks.is_empty() && active.is_set()) {
+				// Stop playing if no longer active.
+				Vector<Ref<AudioStreamPlayback>> playbacks_to_remove;
+				for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
+					if (playback.is_valid() && !AudioServer::get_singleton()->is_playback_active(playback) && !AudioServer::get_singleton()->is_playback_paused(playback)) {
+						playbacks_to_remove.push_back(playback);
+					}
+				}
+				// Now go through and remove playbacks that have finished. Removing elements from a Vector in a range based for is asking for trouble.
+				for (Ref<AudioStreamPlayback> &playback : playbacks_to_remove) {
+					stream_playbacks.erase(playback);
+				}
+				if (!playbacks_to_remove.is_empty() && stream_playbacks.is_empty()) {
+					// This node is no longer actively playing audio.
+					active.clear();
+					set_physics_process_internal(false);
+				}
+				if (!playbacks_to_remove.is_empty()) {
+					emit_signal(SNAME("finished"));
 				}
 			}
-			// Now go through and remove playbacks that have finished. Removing elements from a Vector in a range based for is asking for trouble.
-			for (Ref<AudioStreamPlayback> &playback : playbacks_to_remove) {
-				stream_playbacks.erase(playback);
-			}
-			if (!playbacks_to_remove.is_empty() && stream_playbacks.is_empty()) {
-				// This node is no longer actively playing audio.
-				active.clear();
-				set_physics_process_internal(false);
-			}
-			if (!playbacks_to_remove.is_empty()) {
-				emit_signal(SNAME("finished"));
-			}
-		}
 
-		while (stream_playbacks.size() > max_polyphony) {
-			AudioServer::get_singleton()->stop_playback_stream(stream_playbacks[0]);
-			stream_playbacks.remove_at(0);
-		}
+			while (stream_playbacks.size() > max_polyphony) {
+				AudioServer::get_singleton()->stop_playback_stream(stream_playbacks[0]);
+				stream_playbacks.remove_at(0);
+			}
+		} break;
 	}
 }
 

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -340,17 +340,20 @@ void BoneAttachment3D::_notification(int p_what) {
 			}
 			_check_bind();
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			_check_unbind();
 		} break;
+
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 			_transform_changed();
 		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (_override_dirty) {
 				_override_dirty = false;
 			}
-		}
+		} break;
 	}
 }
 

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -108,14 +108,15 @@ void Camera3D::_notification(int p_what) {
 			if (current || first_camera) {
 				viewport->_camera_3d_set(this);
 			}
-
 		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			_request_camera_update();
 			if (doppler_tracking != DOPPLER_TRACKING_DISABLED) {
 				velocity_tracker->update_position(get_global_transform().origin);
 			}
 		} break;
+
 		case NOTIFICATION_EXIT_WORLD: {
 			if (!get_tree()->is_node_being_edited(this)) {
 				if (is_current()) {
@@ -131,13 +132,14 @@ void Camera3D::_notification(int p_what) {
 				viewport->_camera_3d_remove(this);
 				viewport = nullptr;
 			}
-
 		} break;
+
 		case NOTIFICATION_BECAME_CURRENT: {
 			if (viewport) {
 				viewport->find_world_3d()->_register_camera(this);
 			}
 		} break;
+
 		case NOTIFICATION_LOST_CURRENT: {
 			if (viewport) {
 				viewport->find_world_3d()->_remove_camera(this);

--- a/scene/3d/collision_polygon_3d.cpp
+++ b/scene/3d/collision_polygon_3d.cpp
@@ -93,18 +93,19 @@ void CollisionPolygon3D::_notification(int p_what) {
 				_update_in_shape_owner();
 			}
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			if (parent) {
 				_update_in_shape_owner();
 			}
-
 		} break;
+
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 			if (parent) {
 				_update_in_shape_owner(true);
 			}
-
 		} break;
+
 		case NOTIFICATION_UNPARENTED: {
 			if (parent) {
 				parent->remove_shape_owner(owner_id);

--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -87,16 +87,19 @@ void CollisionShape3D::_notification(int p_what) {
 				_update_in_shape_owner();
 			}
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			if (parent) {
 				_update_in_shape_owner();
 			}
 		} break;
+
 		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
 			if (parent) {
 				_update_in_shape_owner(true);
 			}
 		} break;
+
 		case NOTIFICATION_UNPARENTED: {
 			if (parent) {
 				parent->remove_shape_owner(owner_id);

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -423,38 +423,41 @@ NodePath GPUParticles3D::get_sub_emitter() const {
 }
 
 void GPUParticles3D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_PAUSED || p_what == NOTIFICATION_UNPAUSED) {
-		if (can_process()) {
-			RS::get_singleton()->particles_set_speed_scale(particles, speed_scale);
-		} else {
-			RS::get_singleton()->particles_set_speed_scale(particles, 0);
-		}
-	}
+	switch (p_what) {
+		case NOTIFICATION_PAUSED:
+		case NOTIFICATION_UNPAUSED: {
+			if (can_process()) {
+				RS::get_singleton()->particles_set_speed_scale(particles, speed_scale);
+			} else {
+				RS::get_singleton()->particles_set_speed_scale(particles, 0);
+			}
+		} break;
 
-	// Use internal process when emitting and one_shot is on so that when
-	// the shot ends the editor can properly update
-	if (p_what == NOTIFICATION_INTERNAL_PROCESS) {
-		if (one_shot && !is_emitting()) {
-			notify_property_list_changed();
-			set_process_internal(false);
-		}
-	}
+		// Use internal process when emitting and one_shot is on so that when
+		// the shot ends the editor can properly update.
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			if (one_shot && !is_emitting()) {
+				notify_property_list_changed();
+				set_process_internal(false);
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		if (sub_emitter != NodePath()) {
-			_attach_sub_emitter();
-		}
-	}
+		case NOTIFICATION_ENTER_TREE: {
+			if (sub_emitter != NodePath()) {
+				_attach_sub_emitter();
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		RS::get_singleton()->particles_set_subemitter(particles, RID());
-	}
+		case NOTIFICATION_EXIT_TREE: {
+			RS::get_singleton()->particles_set_subemitter(particles, RID());
+		} break;
 
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		// make sure particles are updated before rendering occurs if they were active before
-		if (is_visible_in_tree() && !RS::get_singleton()->particles_is_inactive(particles)) {
-			RS::get_singleton()->particles_request_process(particles);
-		}
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			// Make sure particles are updated before rendering occurs if they were active before.
+			if (is_visible_in_tree() && !RS::get_singleton()->particles_is_inactive(particles)) {
+				RS::get_singleton()->particles_request_process(particles);
+			}
+		} break;
 	}
 }
 

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -584,47 +584,49 @@ GPUParticlesCollisionSDF3D::~GPUParticlesCollisionSDF3D() {
 ////////////////////////////
 
 void GPUParticlesCollisionHeightField3D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_INTERNAL_PROCESS) {
-		if (update_mode == UPDATE_MODE_ALWAYS) {
-			RS::get_singleton()->particles_collision_height_field_update(_get_collision());
-		}
+	switch (p_what) {
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			if (update_mode == UPDATE_MODE_ALWAYS) {
+				RS::get_singleton()->particles_collision_height_field_update(_get_collision());
+			}
 
-		if (follow_camera_mode && get_viewport()) {
-			Camera3D *cam = get_viewport()->get_camera_3d();
-			if (cam) {
-				Transform3D xform = get_global_transform();
-				Vector3 x_axis = xform.basis.get_axis(Vector3::AXIS_X).normalized();
-				Vector3 z_axis = xform.basis.get_axis(Vector3::AXIS_Z).normalized();
-				float x_len = xform.basis.get_scale().x;
-				float z_len = xform.basis.get_scale().z;
+			if (follow_camera_mode && get_viewport()) {
+				Camera3D *cam = get_viewport()->get_camera_3d();
+				if (cam) {
+					Transform3D xform = get_global_transform();
+					Vector3 x_axis = xform.basis.get_axis(Vector3::AXIS_X).normalized();
+					Vector3 z_axis = xform.basis.get_axis(Vector3::AXIS_Z).normalized();
+					float x_len = xform.basis.get_scale().x;
+					float z_len = xform.basis.get_scale().z;
 
-				Vector3 cam_pos = cam->get_global_transform().origin;
-				Transform3D new_xform = xform;
+					Vector3 cam_pos = cam->get_global_transform().origin;
+					Transform3D new_xform = xform;
 
-				while (x_axis.dot(cam_pos - new_xform.origin) > x_len) {
-					new_xform.origin += x_axis * x_len;
-				}
-				while (x_axis.dot(cam_pos - new_xform.origin) < -x_len) {
-					new_xform.origin -= x_axis * x_len;
-				}
+					while (x_axis.dot(cam_pos - new_xform.origin) > x_len) {
+						new_xform.origin += x_axis * x_len;
+					}
+					while (x_axis.dot(cam_pos - new_xform.origin) < -x_len) {
+						new_xform.origin -= x_axis * x_len;
+					}
 
-				while (z_axis.dot(cam_pos - new_xform.origin) > z_len) {
-					new_xform.origin += z_axis * z_len;
-				}
-				while (z_axis.dot(cam_pos - new_xform.origin) < -z_len) {
-					new_xform.origin -= z_axis * z_len;
-				}
+					while (z_axis.dot(cam_pos - new_xform.origin) > z_len) {
+						new_xform.origin += z_axis * z_len;
+					}
+					while (z_axis.dot(cam_pos - new_xform.origin) < -z_len) {
+						new_xform.origin -= z_axis * z_len;
+					}
 
-				if (new_xform != xform) {
-					set_global_transform(new_xform);
-					RS::get_singleton()->particles_collision_height_field_update(_get_collision());
+					if (new_xform != xform) {
+						set_global_transform(new_xform);
+						RS::get_singleton()->particles_collision_height_field_update(_get_collision());
+					}
 				}
 			}
-		}
-	}
+		} break;
 
-	if (p_what == NOTIFICATION_TRANSFORM_CHANGED) {
-		RS::get_singleton()->particles_collision_height_field_update(_get_collision());
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			RS::get_singleton()->particles_collision_height_field_update(_get_collision());
+		} break;
 	}
 }
 

--- a/scene/3d/joint_3d.cpp
+++ b/scene/3d/joint_3d.cpp
@@ -169,6 +169,7 @@ void Joint3D::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			_update_joint();
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			if (joint.is_valid()) {
 				_disconnect_signals();

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -177,12 +177,11 @@ void Light3D::_update_visibility() {
 }
 
 void Light3D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		_update_visibility();
-	}
-
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		_update_visibility();
+	switch (p_what) {
+		case NOTIFICATION_VISIBILITY_CHANGED:
+		case NOTIFICATION_ENTER_TREE: {
+			_update_visibility();
+		} break;
 	}
 }
 

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1176,16 +1176,18 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 }
 
 void LightmapGI::_notification(int p_what) {
-	if (p_what == NOTIFICATION_POST_ENTER_TREE) {
-		if (light_data.is_valid()) {
-			_assign_lightmaps();
-		}
-	}
+	switch (p_what) {
+		case NOTIFICATION_POST_ENTER_TREE: {
+			if (light_data.is_valid()) {
+				_assign_lightmaps();
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		if (light_data.is_valid()) {
-			_clear_lightmaps();
-		}
+		case NOTIFICATION_EXIT_TREE: {
+			if (light_data.is_valid()) {
+				_clear_lightmaps();
+			}
+		} break;
 	}
 }
 

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -328,8 +328,10 @@ void MeshInstance3D::create_multiple_convex_collisions() {
 }
 
 void MeshInstance3D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		_resolve_skeleton_path();
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			_resolve_skeleton_path();
+		} break;
 	}
 }
 

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -103,10 +103,12 @@ void NavigationAgent3D::_notification(int p_what) {
 			}
 			set_physics_process_internal(true);
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			agent_parent = nullptr;
 			set_physics_process_internal(false);
 		} break;
+
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (agent_parent) {
 				NavigationServer3D::get_singleton()->agent_set_position(agent, agent_parent->get_global_transform().origin);

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -63,17 +63,21 @@ void NavigationObstacle3D::_notification(int p_what) {
 			}
 			set_physics_process_internal(true);
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			parent_node3d = nullptr;
 			set_physics_process_internal(false);
 		} break;
+
 		case NOTIFICATION_PARENTED: {
 			parent_node3d = Object::cast_to<Node3D>(get_parent());
 			reevaluate_agent_radius();
 		} break;
+
 		case NOTIFICATION_UNPARENTED: {
 			parent_node3d = nullptr;
 		} break;
+
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (parent_node3d) {
 				NavigationServer3D::get_singleton()->agent_set_position(agent, parent_node3d->get_global_transform().origin);

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -93,12 +93,12 @@ void NavigationRegion3D::_notification(int p_what) {
 				add_child(dm);
 				debug_view = dm;
 			}
-
 		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform());
-
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			NavigationServer3D::get_singleton()->region_set_map(region, RID());
 

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -147,8 +147,8 @@ void Node3D::_notification(int p_what) {
 
 			notification(NOTIFICATION_ENTER_WORLD);
 			_update_visibility_parent(true);
-
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			notification(NOTIFICATION_EXIT_WORLD, true);
 			if (xform_change.in_list()) {
@@ -162,6 +162,7 @@ void Node3D::_notification(int p_what) {
 			data.top_level_active = false;
 			_update_visibility_parent(true);
 		} break;
+
 		case NOTIFICATION_ENTER_WORLD: {
 			data.inside_world = true;
 			data.viewport = nullptr;
@@ -192,6 +193,7 @@ void Node3D::_notification(int p_what) {
 			}
 #endif
 		} break;
+
 		case NOTIFICATION_EXIT_WORLD: {
 #ifdef TOOLS_ENABLED
 			clear_gizmos();
@@ -203,7 +205,6 @@ void Node3D::_notification(int p_what) {
 
 			data.viewport = nullptr;
 			data.inside_world = false;
-
 		} break;
 
 		case NOTIFICATION_TRANSFORM_CHANGED: {
@@ -213,9 +214,6 @@ void Node3D::_notification(int p_what) {
 			}
 #endif
 		} break;
-
-		default: {
-		}
 	}
 }
 

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -122,8 +122,10 @@ AABB Occluder3D::get_aabb() const {
 }
 
 void Occluder3D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_POSTINITIALIZE) {
-		_update();
+	switch (p_what) {
+		case NOTIFICATION_POSTINITIALIZE: {
+			_update();
+		} break;
 	}
 }
 

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -30,9 +30,6 @@
 
 #include "path_3d.h"
 
-void Path3D::_notification(int p_what) {
-}
-
 void Path3D::_curve_changed() {
 	if (is_inside_tree() && Engine::get_singleton()->is_editor_hint()) {
 		update_gizmos();
@@ -223,8 +220,8 @@ void PathFollow3D::_notification(int p_what) {
 					_update_transform(false);
 				}
 			}
-
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			path = nullptr;
 		} break;

--- a/scene/3d/path_3d.h
+++ b/scene/3d/path_3d.h
@@ -42,7 +42,6 @@ class Path3D : public Node3D {
 	void _curve_changed();
 
 protected:
-	void _notification(int p_what);
 	static void _bind_methods();
 
 public:

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -601,7 +601,7 @@ void RigidDynamicBody3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			if (Engine::get_singleton()->is_editor_hint()) {
-				set_notify_local_transform(true); //used for warnings and only in editor
+				set_notify_local_transform(true); // Used for warnings and only in editor.
 			}
 		} break;
 

--- a/scene/3d/ray_cast_3d.cpp
+++ b/scene/3d/ray_cast_3d.cpp
@@ -171,8 +171,8 @@ void RayCast3D::_notification(int p_what) {
 					exclude.erase(Object::cast_to<CollisionObject3D>(get_parent())->get_rid());
 				}
 			}
-
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			if (enabled) {
 				set_physics_process_internal(false);
@@ -181,8 +181,8 @@ void RayCast3D::_notification(int p_what) {
 			if (debug_shape) {
 				_clear_debug_shape();
 			}
-
 		} break;
+
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (!enabled) {
 				break;
@@ -193,7 +193,6 @@ void RayCast3D::_notification(int p_what) {
 			if (prev_collision_state != collided && get_tree()->is_debugging_collisions_hint()) {
 				_update_debug_shape_material(true);
 			}
-
 		} break;
 	}
 }

--- a/scene/3d/remote_transform_3d.cpp
+++ b/scene/3d/remote_transform_3d.cpp
@@ -111,8 +111,8 @@ void RemoteTransform3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			_update_cache();
-
 		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			if (!is_inside_tree()) {
 				break;
@@ -121,7 +121,6 @@ void RemoteTransform3D::_notification(int p_what) {
 			if (cache.is_valid()) {
 				_update_remote();
 			}
-
 		} break;
 	}
 }

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -318,11 +318,9 @@ void Skeleton3D::_notification(int p_what) {
 					rs->skeleton_bone_set_transform(skeleton, i, bonesptr[bone_index].pose_global * skin->get_bind_pose(i));
 				}
 			}
-
 #ifdef TOOLS_ENABLED
 			emit_signal(SceneStringNames::get_singleton()->pose_updated);
 #endif // TOOLS_ENABLED
-
 		} break;
 
 #ifndef _3D_DISABLED
@@ -344,19 +342,14 @@ void Skeleton3D::_notification(int p_what) {
 			if (modification_stack.is_valid()) {
 				execute_modifications(get_physics_process_delta_time(), SkeletonModificationStack3D::EXECUTION_MODE::execution_mode_physics_process);
 			}
-
 		} break;
-#endif // _3D_DISABLED
 
-#ifndef _3D_DISABLED
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (modification_stack.is_valid()) {
 				execute_modifications(get_process_delta_time(), SkeletonModificationStack3D::EXECUTION_MODE::execution_mode_process);
 			}
 		} break;
-#endif // _3D_DISABLED
 
-#ifndef _3D_DISABLED
 		case NOTIFICATION_READY: {
 			set_physics_process_internal(true);
 			set_process_internal(true);

--- a/scene/3d/skeleton_ik_3d.cpp
+++ b/scene/3d/skeleton_ik_3d.cpp
@@ -407,14 +407,14 @@ void SkeletonIK3D::_notification(int p_what) {
 			set_process_priority(1);
 			reload_chain();
 		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (target_node_override) {
 				reload_goal();
 			}
-
 			_solve_chain();
-
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			reload_chain();
 		} break;

--- a/scene/3d/spring_arm_3d.cpp
+++ b/scene/3d/spring_arm_3d.cpp
@@ -29,23 +29,26 @@
 /*************************************************************************/
 
 #include "spring_arm_3d.h"
+
 #include "scene/3d/camera_3d.h"
 
 void SpringArm3D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_ENTER_TREE: {
 			if (!Engine::get_singleton()->is_editor_hint()) {
 				set_physics_process_internal(true);
 			}
-			break;
-		case NOTIFICATION_EXIT_TREE:
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
 			if (!Engine::get_singleton()->is_editor_hint()) {
 				set_physics_process_internal(false);
 			}
-			break;
-		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS:
+		} break;
+
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			process_spring();
-			break;
+		} break;
 	}
 }
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -66,23 +66,25 @@ void SpriteBase3D::_propagate_color_changed() {
 }
 
 void SpriteBase3D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		if (!pending_update) {
-			_im_update();
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			if (!pending_update) {
+				_im_update();
+			}
 
-		parent_sprite = Object::cast_to<SpriteBase3D>(get_parent());
-		if (parent_sprite) {
-			pI = parent_sprite->children.push_back(this);
-		}
-	}
+			parent_sprite = Object::cast_to<SpriteBase3D>(get_parent());
+			if (parent_sprite) {
+				pI = parent_sprite->children.push_back(this);
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		if (parent_sprite) {
-			parent_sprite->children.erase(pI);
-			pI = nullptr;
-			parent_sprite = nullptr;
-		}
+		case NOTIFICATION_EXIT_TREE: {
+			if (parent_sprite) {
+				parent_sprite->children.erase(pI);
+				pI = nullptr;
+				parent_sprite = nullptr;
+			}
+		} break;
 	}
 }
 

--- a/scene/3d/visible_on_screen_notifier_3d.cpp
+++ b/scene/3d/visible_on_screen_notifier_3d.cpp
@@ -71,8 +71,11 @@ bool VisibleOnScreenNotifier3D::is_on_screen() const {
 }
 
 void VisibleOnScreenNotifier3D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_EXIT_TREE) {
-		on_screen = false;
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_EXIT_TREE: {
+			on_screen = false;
+		} break;
 	}
 }
 
@@ -161,21 +164,23 @@ void VisibleOnScreenEnabler3D::_update_enable_mode(bool p_enable) {
 	}
 }
 void VisibleOnScreenEnabler3D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		if (Engine::get_singleton()->is_editor_hint()) {
-			return;
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			if (Engine::get_singleton()->is_editor_hint()) {
+				return;
+			}
 
-		node_id = ObjectID();
-		Node *node = get_node(enable_node_path);
-		if (node) {
-			node_id = node->get_instance_id();
-			node->set_process_mode(PROCESS_MODE_DISABLED);
-		}
-	}
+			node_id = ObjectID();
+			Node *node = get_node(enable_node_path);
+			if (node) {
+				node_id = node->get_instance_id();
+				node->set_process_mode(PROCESS_MODE_DISABLED);
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		node_id = ObjectID();
+		case NOTIFICATION_EXIT_TREE: {
+			node_id = ObjectID();
+		} break;
 	}
 }
 

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -47,27 +47,21 @@ void VisualInstance3D::_update_visibility() {
 void VisualInstance3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_WORLD: {
-			// CHECK SKELETON => moving skeleton attaching logic to MeshInstance
-			/*
-			Skeleton *skeleton=Object::cast_to<Skeleton>(get_parent());
-			if (skeleton)
-				RenderingServer::get_singleton()->instance_attach_skeleton( instance, skeleton->get_skeleton() );
-			*/
 			ERR_FAIL_COND(get_world_3d().is_null());
 			RenderingServer::get_singleton()->instance_set_scenario(instance, get_world_3d()->get_scenario());
 			_update_visibility();
-
 		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			Transform3D gt = get_global_transform();
 			RenderingServer::get_singleton()->instance_set_transform(instance, gt);
 		} break;
+
 		case NOTIFICATION_EXIT_WORLD: {
 			RenderingServer::get_singleton()->instance_set_scenario(instance, RID());
 			RenderingServer::get_singleton()->instance_attach_skeleton(instance, RID());
-			//RS::get_singleton()->instance_geometry_set_baked_light_sampler(instance, RID() );
-
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			_update_visibility();
 		} break;
@@ -218,9 +212,6 @@ void GeometryInstance3D::set_visibility_range_fade_mode(VisibilityRangeFadeMode 
 
 GeometryInstance3D::VisibilityRangeFadeMode GeometryInstance3D::get_visibility_range_fade_mode() const {
 	return visibility_range_fade_mode;
-}
-
-void GeometryInstance3D::_notification(int p_what) {
 }
 
 const StringName *GeometryInstance3D::_instance_uniform_get_remap(const StringName p_name) const {

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -137,7 +137,6 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 
-	void _notification(int p_what);
 	static void _bind_methods();
 
 public:

--- a/scene/3d/world_environment.cpp
+++ b/scene/3d/world_environment.cpp
@@ -34,27 +34,32 @@
 #include "scene/main/window.h"
 
 void WorldEnvironment::_notification(int p_what) {
-	if (p_what == Node3D::NOTIFICATION_ENTER_WORLD || p_what == Node3D::NOTIFICATION_ENTER_TREE) {
-		if (environment.is_valid()) {
-			add_to_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
-			_update_current_environment();
-		}
+	switch (p_what) {
+		case Node3D::NOTIFICATION_ENTER_WORLD:
+		case Node3D::NOTIFICATION_ENTER_TREE: {
+			if (environment.is_valid()) {
+				add_to_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+				_update_current_environment();
+			}
 
-		if (camera_effects.is_valid()) {
-			add_to_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
-			_update_current_camera_effects();
-		}
+			if (camera_effects.is_valid()) {
+				add_to_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+				_update_current_camera_effects();
+			}
+		} break;
 
-	} else if (p_what == Node3D::NOTIFICATION_EXIT_WORLD || p_what == Node3D::NOTIFICATION_EXIT_TREE) {
-		if (environment.is_valid()) {
-			remove_from_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
-			_update_current_environment();
-		}
+		case Node3D::NOTIFICATION_EXIT_WORLD:
+		case Node3D::NOTIFICATION_EXIT_TREE: {
+			if (environment.is_valid()) {
+				remove_from_group("_world_environment_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+				_update_current_environment();
+			}
 
-		if (camera_effects.is_valid()) {
-			remove_from_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
-			_update_current_camera_effects();
-		}
+			if (camera_effects.is_valid()) {
+				remove_from_group("_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()));
+				_update_current_camera_effects();
+			}
+		} break;
 	}
 }
 

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -44,16 +44,17 @@ void XRCamera3D::_notification(int p_what) {
 			if (origin != nullptr) {
 				origin->set_tracked_camera(this);
 			}
-		}; break;
+		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			// need to find our XROrigin3D parent and let it know we're no longer its camera!
 			XROrigin3D *origin = Object::cast_to<XROrigin3D>(get_parent());
 			if (origin != nullptr && origin->get_tracked_camera() == this) {
 				origin->set_tracked_camera(nullptr);
 			}
-		}; break;
-	};
-};
+		} break;
+	}
+}
 
 void XRCamera3D::_changed_tracker(const StringName p_tracker_name, int p_tracker_type) {
 	if (p_tracker_name == tracker_name) {
@@ -657,10 +658,12 @@ void XROrigin3D::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			set_process_internal(true);
-		}; break;
+		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			set_process_internal(false);
-		}; break;
+		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			// set our world origin to our node transform
 			xr_server->set_world_origin(get_global_transform());
@@ -673,11 +676,9 @@ void XROrigin3D::_notification(int p_what) {
 
 				// now apply this to our camera
 				tracked_camera->set_transform(t);
-			};
-		}; break;
-		default:
-			break;
-	};
+			}
+		} break;
+	}
 
 	// send our notification to all active XE interfaces, they may need to react to it also
 	for (int i = 0; i < xr_server->get_interface_count(); i++) {

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -807,9 +807,6 @@ String AnimationNodeStateMachine::get_caption() const {
 	return "StateMachine";
 }
 
-void AnimationNodeStateMachine::_notification(int p_what) {
-}
-
 Ref<AnimationNode> AnimationNodeStateMachine::get_child_by_name(const StringName &p_name) {
 	return get_node(p_name);
 }

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -164,7 +164,6 @@ private:
 	void _tree_changed();
 
 protected:
-	void _notification(int p_what);
 	static void _bind_methods();
 
 	bool _set(const StringName &p_name, const Variant &p_value);

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -202,15 +202,16 @@ void AnimationPlayer::_notification(int p_what) {
 				set_physics_process_internal(false);
 				set_process_internal(false);
 			}
-			//_set_process(false);
 			clear_caches();
 		} break;
+
 		case NOTIFICATION_READY: {
 			if (!Engine::get_singleton()->is_editor_hint() && animation_set.has(autoplay)) {
 				play(autoplay);
 				_animation_process(0);
 			}
 		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (process_callback == ANIMATION_PROCESS_PHYSICS) {
 				break;
@@ -220,6 +221,7 @@ void AnimationPlayer::_notification(int p_what) {
 				_animation_process(get_process_delta_time());
 			}
 		} break;
+
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (process_callback == ANIMATION_PROCESS_IDLE) {
 				break;
@@ -229,6 +231,7 @@ void AnimationPlayer::_notification(int p_what) {
 				_animation_process(get_physics_process_delta_time());
 			}
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			clear_caches();
 		} break;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1586,29 +1586,37 @@ void AnimationTree::advance(real_t p_time) {
 }
 
 void AnimationTree::_notification(int p_what) {
-	if (active && p_what == NOTIFICATION_INTERNAL_PHYSICS_PROCESS && process_callback == ANIMATION_PROCESS_PHYSICS) {
-		_process_graph(get_physics_process_delta_time());
-	}
-
-	if (active && p_what == NOTIFICATION_INTERNAL_PROCESS && process_callback == ANIMATION_PROCESS_IDLE) {
-		_process_graph(get_process_delta_time());
-	}
-
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		_clear_caches();
-		if (last_animation_player.is_valid()) {
-			Object *player = ObjectDB::get_instance(last_animation_player);
-			if (player) {
-				player->disconnect("caches_cleared", callable_mp(this, &AnimationTree::_clear_caches));
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			if (last_animation_player.is_valid()) {
+				Object *player = ObjectDB::get_instance(last_animation_player);
+				if (player) {
+					player->connect("caches_cleared", callable_mp(this, &AnimationTree::_clear_caches));
+				}
 			}
-		}
-	} else if (p_what == NOTIFICATION_ENTER_TREE) {
-		if (last_animation_player.is_valid()) {
-			Object *player = ObjectDB::get_instance(last_animation_player);
-			if (player) {
-				player->connect("caches_cleared", callable_mp(this, &AnimationTree::_clear_caches));
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			_clear_caches();
+			if (last_animation_player.is_valid()) {
+				Object *player = ObjectDB::get_instance(last_animation_player);
+				if (player) {
+					player->disconnect("caches_cleared", callable_mp(this, &AnimationTree::_clear_caches));
+				}
 			}
-		}
+		} break;
+
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			if (active && process_callback == ANIMATION_PROCESS_IDLE) {
+				_process_graph(get_process_delta_time());
+			}
+		} break;
+
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			if (active && process_callback == ANIMATION_PROCESS_PHYSICS) {
+				_process_graph(get_physics_process_delta_time());
+			}
+		} break;
 	}
 }
 

--- a/scene/animation/root_motion_view.cpp
+++ b/scene/animation/root_motion_view.cpp
@@ -29,8 +29,10 @@
 /*************************************************************************/
 
 #include "root_motion_view.h"
+
 #include "scene/animation/animation_tree.h"
 #include "scene/resources/material.h"
+
 void RootMotionView::set_animation_path(const NodePath &p_path) {
 	path = p_path;
 	first = true;
@@ -76,84 +78,87 @@ bool RootMotionView::get_zero_y() const {
 }
 
 void RootMotionView::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		immediate_material = StandardMaterial3D::get_material_for_2d(false, true, false, false, false);
-		first = true;
-	}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			immediate_material = StandardMaterial3D::get_material_for_2d(false, true, false, false, false);
+			first = true;
+		} break;
 
-	if (p_what == NOTIFICATION_INTERNAL_PROCESS || p_what == NOTIFICATION_INTERNAL_PHYSICS_PROCESS) {
-		Transform3D transform;
+		case NOTIFICATION_INTERNAL_PROCESS:
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			Transform3D transform;
 
-		if (has_node(path)) {
-			Node *node = get_node(path);
+			if (has_node(path)) {
+				Node *node = get_node(path);
 
-			AnimationTree *tree = Object::cast_to<AnimationTree>(node);
-			if (tree && tree->is_active() && tree->get_root_motion_track() != NodePath()) {
-				if (is_processing_internal() && tree->get_process_callback() == AnimationTree::ANIMATION_PROCESS_PHYSICS) {
-					set_process_internal(false);
-					set_physics_process_internal(true);
+				AnimationTree *tree = Object::cast_to<AnimationTree>(node);
+				if (tree && tree->is_active() && tree->get_root_motion_track() != NodePath()) {
+					if (is_processing_internal() && tree->get_process_callback() == AnimationTree::ANIMATION_PROCESS_PHYSICS) {
+						set_process_internal(false);
+						set_physics_process_internal(true);
+					}
+
+					if (is_physics_processing_internal() && tree->get_process_callback() == AnimationTree::ANIMATION_PROCESS_IDLE) {
+						set_process_internal(true);
+						set_physics_process_internal(false);
+					}
+
+					transform = tree->get_root_motion_transform();
 				}
+			}
 
-				if (is_physics_processing_internal() && tree->get_process_callback() == AnimationTree::ANIMATION_PROCESS_IDLE) {
-					set_process_internal(true);
-					set_physics_process_internal(false);
+			if (!first && transform == Transform3D()) {
+				return;
+			}
+
+			first = false;
+
+			transform.orthonormalize(); //don't want scale, too imprecise
+			transform.affine_invert();
+
+			accumulated = transform * accumulated;
+			accumulated.origin.x = Math::fposmod(accumulated.origin.x, cell_size);
+			if (zero_y) {
+				accumulated.origin.y = 0;
+			}
+			accumulated.origin.z = Math::fposmod(accumulated.origin.z, cell_size);
+
+			immediate->clear_surfaces();
+
+			int cells_in_radius = int((radius / cell_size) + 1.0);
+
+			immediate->surface_begin(Mesh::PRIMITIVE_LINES, immediate_material);
+
+			for (int i = -cells_in_radius; i < cells_in_radius; i++) {
+				for (int j = -cells_in_radius; j < cells_in_radius; j++) {
+					Vector3 from(i * cell_size, 0, j * cell_size);
+					Vector3 from_i((i + 1) * cell_size, 0, j * cell_size);
+					Vector3 from_j(i * cell_size, 0, (j + 1) * cell_size);
+					from = accumulated.xform(from);
+					from_i = accumulated.xform(from_i);
+					from_j = accumulated.xform(from_j);
+
+					Color c = color, c_i = color, c_j = color;
+					c.a *= MAX(0, 1.0 - from.length() / radius);
+					c_i.a *= MAX(0, 1.0 - from_i.length() / radius);
+					c_j.a *= MAX(0, 1.0 - from_j.length() / radius);
+
+					immediate->surface_set_color(c);
+					immediate->surface_add_vertex(from);
+
+					immediate->surface_set_color(c_i);
+					immediate->surface_add_vertex(from_i);
+
+					immediate->surface_set_color(c);
+					immediate->surface_add_vertex(from);
+
+					immediate->surface_set_color(c_j);
+					immediate->surface_add_vertex(from_j);
 				}
-
-				transform = tree->get_root_motion_transform();
 			}
-		}
 
-		if (!first && transform == Transform3D()) {
-			return;
-		}
-
-		first = false;
-
-		transform.orthonormalize(); //don't want scale, too imprecise
-		transform.affine_invert();
-
-		accumulated = transform * accumulated;
-		accumulated.origin.x = Math::fposmod(accumulated.origin.x, cell_size);
-		if (zero_y) {
-			accumulated.origin.y = 0;
-		}
-		accumulated.origin.z = Math::fposmod(accumulated.origin.z, cell_size);
-
-		immediate->clear_surfaces();
-
-		int cells_in_radius = int((radius / cell_size) + 1.0);
-
-		immediate->surface_begin(Mesh::PRIMITIVE_LINES, immediate_material);
-
-		for (int i = -cells_in_radius; i < cells_in_radius; i++) {
-			for (int j = -cells_in_radius; j < cells_in_radius; j++) {
-				Vector3 from(i * cell_size, 0, j * cell_size);
-				Vector3 from_i((i + 1) * cell_size, 0, j * cell_size);
-				Vector3 from_j(i * cell_size, 0, (j + 1) * cell_size);
-				from = accumulated.xform(from);
-				from_i = accumulated.xform(from_i);
-				from_j = accumulated.xform(from_j);
-
-				Color c = color, c_i = color, c_j = color;
-				c.a *= MAX(0, 1.0 - from.length() / radius);
-				c_i.a *= MAX(0, 1.0 - from_i.length() / radius);
-				c_j.a *= MAX(0, 1.0 - from_j.length() / radius);
-
-				immediate->surface_set_color(c);
-				immediate->surface_add_vertex(from);
-
-				immediate->surface_set_color(c_i);
-				immediate->surface_add_vertex(from_i);
-
-				immediate->surface_set_color(c);
-				immediate->surface_add_vertex(from);
-
-				immediate->surface_set_color(c_j);
-				immediate->surface_add_vertex(from_j);
-			}
-		}
-
-		immediate->surface_end();
+			immediate->surface_end();
+		} break;
 	}
 }
 

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -35,49 +35,51 @@
 #include "servers/audio_server.h"
 
 void AudioStreamPlayer::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
-			play();
-		}
-	}
-
-	if (p_what == NOTIFICATION_INTERNAL_PROCESS) {
-		Vector<Ref<AudioStreamPlayback>> playbacks_to_remove;
-		for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
-			if (playback.is_valid() && !AudioServer::get_singleton()->is_playback_active(playback) && !AudioServer::get_singleton()->is_playback_paused(playback)) {
-				playbacks_to_remove.push_back(playback);
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			if (autoplay && !Engine::get_singleton()->is_editor_hint()) {
+				play();
 			}
-		}
-		// Now go through and remove playbacks that have finished. Removing elements from a Vector in a range based for is asking for trouble.
-		for (Ref<AudioStreamPlayback> &playback : playbacks_to_remove) {
-			stream_playbacks.erase(playback);
-		}
-		if (!playbacks_to_remove.is_empty() && stream_playbacks.is_empty()) {
-			// This node is no longer actively playing audio.
-			active.clear();
-			set_process_internal(false);
-		}
-		if (!playbacks_to_remove.is_empty()) {
-			emit_signal(SNAME("finished"));
-		}
-	}
+		} break;
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
-			AudioServer::get_singleton()->stop_playback_stream(playback);
-		}
-		stream_playbacks.clear();
-	}
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			Vector<Ref<AudioStreamPlayback>> playbacks_to_remove;
+			for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
+				if (playback.is_valid() && !AudioServer::get_singleton()->is_playback_active(playback) && !AudioServer::get_singleton()->is_playback_paused(playback)) {
+					playbacks_to_remove.push_back(playback);
+				}
+			}
+			// Now go through and remove playbacks that have finished. Removing elements from a Vector in a range based for is asking for trouble.
+			for (Ref<AudioStreamPlayback> &playback : playbacks_to_remove) {
+				stream_playbacks.erase(playback);
+			}
+			if (!playbacks_to_remove.is_empty() && stream_playbacks.is_empty()) {
+				// This node is no longer actively playing audio.
+				active.clear();
+				set_process_internal(false);
+			}
+			if (!playbacks_to_remove.is_empty()) {
+				emit_signal(SNAME("finished"));
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_PAUSED) {
-		if (!can_process()) {
-			// Node can't process so we start fading out to silence
-			set_stream_paused(true);
-		}
-	}
+		case NOTIFICATION_EXIT_TREE: {
+			for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
+				AudioServer::get_singleton()->stop_playback_stream(playback);
+			}
+			stream_playbacks.clear();
+		} break;
 
-	if (p_what == NOTIFICATION_UNPAUSED) {
-		set_stream_paused(false);
+		case NOTIFICATION_PAUSED: {
+			if (!can_process()) {
+				// Node can't process so we start fading out to silence
+				set_stream_paused(true);
+			}
+		} break;
+
+		case NOTIFICATION_UNPAUSED: {
+			set_stream_paused(false);
+		} break;
 	}
 }
 

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -81,42 +81,50 @@ void BaseButton::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void BaseButton::_notification(int p_what) {
-	if (p_what == NOTIFICATION_MOUSE_ENTER) {
-		status.hovering = true;
-		update();
-	}
+	switch (p_what) {
+		case NOTIFICATION_MOUSE_ENTER: {
+			status.hovering = true;
+			update();
+		} break;
 
-	if (p_what == NOTIFICATION_MOUSE_EXIT) {
-		status.hovering = false;
-		update();
-	}
-	if (p_what == NOTIFICATION_DRAG_BEGIN || p_what == NOTIFICATION_SCROLL_BEGIN) {
-		if (status.press_attempt) {
+		case NOTIFICATION_MOUSE_EXIT: {
+			status.hovering = false;
+			update();
+		} break;
+
+		case NOTIFICATION_DRAG_BEGIN:
+		case NOTIFICATION_SCROLL_BEGIN: {
+			if (status.press_attempt) {
+				status.press_attempt = false;
+				update();
+			}
+		} break;
+
+		case NOTIFICATION_FOCUS_ENTER: {
+			update();
+		} break;
+
+		case NOTIFICATION_FOCUS_EXIT: {
+			if (status.press_attempt) {
+				status.press_attempt = false;
+				update();
+			} else if (status.hovering) {
+				update();
+			}
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED:
+		case NOTIFICATION_EXIT_TREE: {
+			if (p_what == NOTIFICATION_VISIBILITY_CHANGED && is_visible_in_tree()) {
+				break;
+			}
+			if (!toggle_mode) {
+				status.pressed = false;
+			}
+			status.hovering = false;
 			status.press_attempt = false;
-			update();
-		}
-	}
-
-	if (p_what == NOTIFICATION_FOCUS_ENTER) {
-		update();
-	}
-
-	if (p_what == NOTIFICATION_FOCUS_EXIT) {
-		if (status.press_attempt) {
-			status.press_attempt = false;
-			update();
-		} else if (status.hovering) {
-			update();
-		}
-	}
-
-	if (p_what == NOTIFICATION_EXIT_TREE || (p_what == NOTIFICATION_VISIBILITY_CHANGED && !is_visible_in_tree())) {
-		if (!toggle_mode) {
-			status.pressed = false;
-		}
-		status.hovering = false;
-		status.press_attempt = false;
-		status.pressing_inside = false;
+			status.pressing_inside = false;
+		} break;
 	}
 }
 

--- a/scene/gui/box_container.cpp
+++ b/scene/gui/box_container.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "box_container.h"
+
 #include "label.h"
 #include "margin_container.h"
 
@@ -294,9 +295,11 @@ void BoxContainer::_notification(int p_what) {
 		case NOTIFICATION_SORT_CHILDREN: {
 			_resort();
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			update_minimum_size();
 		} break;
+
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			queue_sort();

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -78,6 +78,7 @@ void Button::_notification(int p_what) {
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			update();
 		} break;
+
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			xl_text = atr(text);
 			_shape();
@@ -85,12 +86,14 @@ void Button::_notification(int p_what) {
 			update_minimum_size();
 			update();
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			_shape();
 
 			update_minimum_size();
 			update();
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
 			Size2 size = get_size();

--- a/scene/gui/center_container.cpp
+++ b/scene/gui/center_container.cpp
@@ -78,21 +78,23 @@ Vector<int> CenterContainer::get_allowed_size_flags_vertical() const {
 }
 
 void CenterContainer::_notification(int p_what) {
-	if (p_what == NOTIFICATION_SORT_CHILDREN) {
-		Size2 size = get_size();
-		for (int i = 0; i < get_child_count(); i++) {
-			Control *c = Object::cast_to<Control>(get_child(i));
-			if (!c) {
-				continue;
-			}
-			if (c->is_set_as_top_level()) {
-				continue;
-			}
+	switch (p_what) {
+		case NOTIFICATION_SORT_CHILDREN: {
+			Size2 size = get_size();
+			for (int i = 0; i < get_child_count(); i++) {
+				Control *c = Object::cast_to<Control>(get_child(i));
+				if (!c) {
+					continue;
+				}
+				if (c->is_set_as_top_level()) {
+					continue;
+				}
 
-			Size2 minsize = c->get_combined_minimum_size();
-			Point2 ofs = use_top_left ? (-minsize * 0.5).floor() : ((size - minsize) / 2.0).floor();
-			fit_child_in_rect(c, Rect2(ofs, minsize));
-		}
+				Size2 minsize = c->get_combined_minimum_size();
+				Point2 ofs = use_top_left ? (-minsize * 0.5).floor() : ((size - minsize) / 2.0).floor();
+				fit_child_in_rect(c, Rect2(ofs, minsize));
+			}
+		} break;
 	}
 }
 

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -84,34 +84,40 @@ Size2 CheckBox::get_minimum_size() const {
 }
 
 void CheckBox::_notification(int p_what) {
-	if ((p_what == NOTIFICATION_THEME_CHANGED) || (p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED || (p_what == NOTIFICATION_TRANSLATION_CHANGED))) {
-		if (is_layout_rtl()) {
-			_set_internal_margin(SIDE_LEFT, 0.f);
-			_set_internal_margin(SIDE_RIGHT, get_icon_size().width);
-		} else {
-			_set_internal_margin(SIDE_LEFT, get_icon_size().width);
-			_set_internal_margin(SIDE_RIGHT, 0.f);
-		}
-	} else if (p_what == NOTIFICATION_DRAW) {
-		RID ci = get_canvas_item();
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			if (is_layout_rtl()) {
+				_set_internal_margin(SIDE_LEFT, 0.f);
+				_set_internal_margin(SIDE_RIGHT, get_icon_size().width);
+			} else {
+				_set_internal_margin(SIDE_LEFT, get_icon_size().width);
+				_set_internal_margin(SIDE_RIGHT, 0.f);
+			}
+		} break;
 
-		Ref<Texture2D> on = Control::get_theme_icon(vformat("%s%s", is_radio() ? "radio_checked" : "checked", is_disabled() ? "_disabled" : ""));
-		Ref<Texture2D> off = Control::get_theme_icon(vformat("%s%s", is_radio() ? "radio_unchecked" : "unchecked", is_disabled() ? "_disabled" : ""));
-		Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
+		case NOTIFICATION_DRAW: {
+			RID ci = get_canvas_item();
 
-		Vector2 ofs;
-		if (is_layout_rtl()) {
-			ofs.x = get_size().x - sb->get_margin(SIDE_RIGHT) - get_icon_size().width;
-		} else {
-			ofs.x = sb->get_margin(SIDE_LEFT);
-		}
-		ofs.y = int((get_size().height - get_icon_size().height) / 2) + get_theme_constant(SNAME("check_vadjust"));
+			Ref<Texture2D> on = Control::get_theme_icon(vformat("%s%s", is_radio() ? "radio_checked" : "checked", is_disabled() ? "_disabled" : ""));
+			Ref<Texture2D> off = Control::get_theme_icon(vformat("%s%s", is_radio() ? "radio_unchecked" : "unchecked", is_disabled() ? "_disabled" : ""));
+			Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
 
-		if (is_pressed()) {
-			on->draw(ci, ofs);
-		} else {
-			off->draw(ci, ofs);
-		}
+			Vector2 ofs;
+			if (is_layout_rtl()) {
+				ofs.x = get_size().x - sb->get_margin(SIDE_RIGHT) - get_icon_size().width;
+			} else {
+				ofs.x = sb->get_margin(SIDE_LEFT);
+			}
+			ofs.y = int((get_size().height - get_icon_size().height) / 2) + get_theme_constant(SNAME("check_vadjust"));
+
+			if (is_pressed()) {
+				on->draw(ci, ofs);
+			} else {
+				off->draw(ci, ofs);
+			}
+		} break;
 	}
 }
 

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -61,47 +61,53 @@ Size2 CheckButton::get_minimum_size() const {
 }
 
 void CheckButton::_notification(int p_what) {
-	if ((p_what == NOTIFICATION_THEME_CHANGED) || (p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED) || (p_what == NOTIFICATION_TRANSLATION_CHANGED)) {
-		if (is_layout_rtl()) {
-			_set_internal_margin(SIDE_LEFT, get_icon_size().width);
-			_set_internal_margin(SIDE_RIGHT, 0.f);
-		} else {
-			_set_internal_margin(SIDE_LEFT, 0.f);
-			_set_internal_margin(SIDE_RIGHT, get_icon_size().width);
-		}
-	} else if (p_what == NOTIFICATION_DRAW) {
-		RID ci = get_canvas_item();
-		bool rtl = is_layout_rtl();
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			if (is_layout_rtl()) {
+				_set_internal_margin(SIDE_LEFT, get_icon_size().width);
+				_set_internal_margin(SIDE_RIGHT, 0.f);
+			} else {
+				_set_internal_margin(SIDE_LEFT, 0.f);
+				_set_internal_margin(SIDE_RIGHT, get_icon_size().width);
+			}
+		} break;
 
-		Ref<Texture2D> on;
-		if (rtl) {
-			on = Control::get_theme_icon(is_disabled() ? "on_disabled_mirrored" : "on_mirrored");
-		} else {
-			on = Control::get_theme_icon(is_disabled() ? "on_disabled" : "on");
-		}
-		Ref<Texture2D> off;
-		if (rtl) {
-			off = Control::get_theme_icon(is_disabled() ? "off_disabled_mirrored" : "off_mirrored");
-		} else {
-			off = Control::get_theme_icon(is_disabled() ? "off_disabled" : "off");
-		}
+		case NOTIFICATION_DRAW: {
+			RID ci = get_canvas_item();
+			bool rtl = is_layout_rtl();
 
-		Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
-		Vector2 ofs;
-		Size2 tex_size = get_icon_size();
+			Ref<Texture2D> on;
+			if (rtl) {
+				on = Control::get_theme_icon(is_disabled() ? "on_disabled_mirrored" : "on_mirrored");
+			} else {
+				on = Control::get_theme_icon(is_disabled() ? "on_disabled" : "on");
+			}
+			Ref<Texture2D> off;
+			if (rtl) {
+				off = Control::get_theme_icon(is_disabled() ? "off_disabled_mirrored" : "off_mirrored");
+			} else {
+				off = Control::get_theme_icon(is_disabled() ? "off_disabled" : "off");
+			}
 
-		if (rtl) {
-			ofs.x = sb->get_margin(SIDE_LEFT);
-		} else {
-			ofs.x = get_size().width - (tex_size.width + sb->get_margin(SIDE_RIGHT));
-		}
-		ofs.y = (get_size().height - tex_size.height) / 2 + get_theme_constant(SNAME("check_vadjust"));
+			Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
+			Vector2 ofs;
+			Size2 tex_size = get_icon_size();
 
-		if (is_pressed()) {
-			on->draw(ci, ofs);
-		} else {
-			off->draw(ci, ofs);
-		}
+			if (rtl) {
+				ofs.x = sb->get_margin(SIDE_LEFT);
+			} else {
+				ofs.x = get_size().width - (tex_size.width + sb->get_margin(SIDE_RIGHT));
+			}
+			ofs.y = (get_size().height - tex_size.height) / 2 + get_theme_constant(SNAME("check_vadjust"));
+
+			if (is_pressed()) {
+				on->draw(ci, ofs);
+			} else {
+				off->draw(ci, ofs);
+			}
+		} break;
 	}
 }
 

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -74,6 +74,7 @@ void CodeEdit::_notification(int p_what) {
 
 			line_length_guideline_color = get_theme_color(SNAME("line_length_guideline_color"));
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
 			const Size2 size = get_size();

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -33,11 +33,11 @@
 #include "core/input/input.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
+#include "scene/main/window.h"
 
 #ifdef TOOLS_ENABLED
 #include "editor/editor_settings.h"
 #endif
-#include "scene/main/window.h"
 
 List<Color> ColorPicker::preset_cache;
 
@@ -45,7 +45,6 @@ void ColorPicker::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			_update_color();
-
 #ifdef TOOLS_ENABLED
 			if (Engine::get_singleton()->is_editor_hint()) {
 				if (preset_cache.is_empty()) {
@@ -1347,17 +1346,18 @@ void ColorPickerButton::_notification(int p_what) {
 				draw_texture(Control::get_theme_icon(SNAME("overbright_indicator"), SNAME("ColorPicker")), normal->get_offset());
 			}
 		} break;
+
 		case NOTIFICATION_WM_CLOSE_REQUEST: {
 			if (popup) {
 				popup->hide();
 			}
 		} break;
-	}
 
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		if (popup && !is_visible_in_tree()) {
-			popup->hide();
-		}
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (popup && !is_visible_in_tree()) {
+				popup->hide();
+			}
+		} break;
 	}
 }
 

--- a/scene/gui/color_rect.cpp
+++ b/scene/gui/color_rect.cpp
@@ -40,8 +40,10 @@ Color ColorRect::get_color() const {
 }
 
 void ColorRect::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		draw_rect(Rect2(Point2(), get_size()), color);
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			draw_rect(Rect2(Point2(), get_size()), color);
+		} break;
 	}
 }
 

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "container.h"
+
 #include "core/object/message_queue.h"
 #include "scene/scene_string_names.h"
 
@@ -177,12 +178,12 @@ void Container::_notification(int p_what) {
 			pending_sort = false;
 			queue_sort();
 		} break;
-		case NOTIFICATION_RESIZED: {
-			queue_sort();
-		} break;
+
+		case NOTIFICATION_RESIZED:
 		case NOTIFICATION_THEME_CHANGED: {
 			queue_sort();
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible_in_tree()) {
 				queue_sort();

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -691,17 +691,17 @@ void Control::_update_canvas_item_transform() {
 
 void Control::_notification(int p_notification) {
 	switch (p_notification) {
-		case NOTIFICATION_ENTER_TREE: {
-		} break;
 		case NOTIFICATION_POST_ENTER_TREE: {
 			data.minimum_size_valid = false;
 			data.is_rtl_dirty = true;
 			_size_changed();
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			release_focus();
 			get_viewport()->_gui_remove_control(this);
 		} break;
+
 		case NOTIFICATION_READY: {
 #ifdef DEBUG_ENABLED
 			connect("ready", callable_mp(this, &Control::_clear_size_warning), varray(), CONNECT_DEFERRED | CONNECT_ONESHOT);
@@ -764,6 +764,7 @@ void Control::_notification(int p_notification) {
 				viewport->connect("size_changed", callable_mp(this, &Control::_size_changed));
 			}
 		} break;
+
 		case NOTIFICATION_EXIT_CANVAS: {
 			if (data.parent_canvas_item) {
 				data.parent_canvas_item->disconnect("item_rect_changed", callable_mp(this, &Control::_size_changed));
@@ -784,8 +785,8 @@ void Control::_notification(int p_notification) {
 			data.parent_canvas_item = nullptr;
 			data.parent_window = nullptr;
 			data.is_rtl_dirty = true;
-
 		} break;
+
 		case NOTIFICATION_MOVED_IN_PARENT: {
 			// some parents need to know the order of the children to draw (like TabContainer)
 			// update if necessary
@@ -797,50 +798,52 @@ void Control::_notification(int p_notification) {
 			if (data.RI) {
 				get_viewport()->_gui_set_root_order_dirty();
 			}
-
 		} break;
+
 		case NOTIFICATION_RESIZED: {
 			emit_signal(SceneStringNames::get_singleton()->resized);
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			_update_canvas_item_transform();
 			RenderingServer::get_singleton()->canvas_item_set_custom_rect(get_canvas_item(), !data.disable_visibility_clip, Rect2(Point2(), get_size()));
 			RenderingServer::get_singleton()->canvas_item_set_clip(get_canvas_item(), data.clip_contents);
-			//emit_signal(SceneStringNames::get_singleton()->draw);
-
 		} break;
+
 		case NOTIFICATION_MOUSE_ENTER: {
 			emit_signal(SceneStringNames::get_singleton()->mouse_entered);
 		} break;
+
 		case NOTIFICATION_MOUSE_EXIT: {
 			emit_signal(SceneStringNames::get_singleton()->mouse_exited);
 		} break;
+
 		case NOTIFICATION_FOCUS_ENTER: {
 			emit_signal(SceneStringNames::get_singleton()->focus_entered);
 			update();
 		} break;
+
 		case NOTIFICATION_FOCUS_EXIT: {
 			emit_signal(SceneStringNames::get_singleton()->focus_exited);
 			update();
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			update_minimum_size();
 			update();
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible_in_tree()) {
 				if (get_viewport() != nullptr) {
 					get_viewport()->_gui_hide_control(this);
 				}
-
-				//remove key focus
-
 			} else {
 				data.minimum_size_valid = false;
 				_size_changed();
 			}
-
 		} break;
+
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			if (is_inside_tree()) {

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -67,21 +67,25 @@ void AcceptDialog::_notification(int p_what) {
 				}
 			}
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			bg->add_theme_style_override("panel", bg->get_theme_stylebox(SNAME("panel"), SNAME("AcceptDialog")));
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			if (parent_visible) {
 				parent_visible->disconnect("focus_entered", callable_mp(this, &AcceptDialog::_parent_focused));
 				parent_visible = nullptr;
 			}
 		} break;
+
 		case NOTIFICATION_READY:
 		case NOTIFICATION_WM_SIZE_CHANGED: {
 			if (is_visible()) {
 				_update_child_rects();
 			}
 		} break;
+
 		case NOTIFICATION_WM_CLOSE_REQUEST: {
 			_cancel_pressed();
 		} break;

--- a/scene/gui/file_dialog.cpp
+++ b/scene/gui/file_dialog.cpp
@@ -92,26 +92,30 @@ void FileDialog::_theme_changed() {
 }
 
 void FileDialog::_notification(int p_what) {
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		if (!is_visible()) {
-			set_process_unhandled_input(false);
-		}
-	}
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		dir_up->set_icon(vbox->get_theme_icon(SNAME("parent_folder"), SNAME("FileDialog")));
-		if (vbox->is_layout_rtl()) {
-			dir_prev->set_icon(vbox->get_theme_icon(SNAME("forward_folder"), SNAME("FileDialog")));
-			dir_next->set_icon(vbox->get_theme_icon(SNAME("back_folder"), SNAME("FileDialog")));
-		} else {
-			dir_prev->set_icon(vbox->get_theme_icon(SNAME("back_folder"), SNAME("FileDialog")));
-			dir_next->set_icon(vbox->get_theme_icon(SNAME("forward_folder"), SNAME("FileDialog")));
-		}
-		refresh->set_icon(vbox->get_theme_icon(SNAME("reload"), SNAME("FileDialog")));
-		show_hidden->set_icon(vbox->get_theme_icon(SNAME("toggle_hidden"), SNAME("FileDialog")));
-		_theme_changed();
-	}
-	if (p_what == NOTIFICATION_TRANSLATION_CHANGED) {
-		update_filters();
+	switch (p_what) {
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (!is_visible()) {
+				set_process_unhandled_input(false);
+			}
+		} break;
+
+		case NOTIFICATION_ENTER_TREE: {
+			dir_up->set_icon(vbox->get_theme_icon(SNAME("parent_folder"), SNAME("FileDialog")));
+			if (vbox->is_layout_rtl()) {
+				dir_prev->set_icon(vbox->get_theme_icon(SNAME("forward_folder"), SNAME("FileDialog")));
+				dir_next->set_icon(vbox->get_theme_icon(SNAME("back_folder"), SNAME("FileDialog")));
+			} else {
+				dir_prev->set_icon(vbox->get_theme_icon(SNAME("back_folder"), SNAME("FileDialog")));
+				dir_next->set_icon(vbox->get_theme_icon(SNAME("forward_folder"), SNAME("FileDialog")));
+			}
+			refresh->set_icon(vbox->get_theme_icon(SNAME("reload"), SNAME("FileDialog")));
+			show_hidden->set_icon(vbox->get_theme_icon(SNAME("toggle_hidden"), SNAME("FileDialog")));
+			_theme_changed();
+		} break;
+
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			update_filters();
+		} break;
 	}
 }
 

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -251,9 +251,11 @@ void FlowContainer::_notification(int p_what) {
 			_resort();
 			update_minimum_size();
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			update_minimum_size();
 		} break;
+
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			queue_sort();

--- a/scene/gui/gradient_edit.cpp
+++ b/scene/gui/gradient_edit.cpp
@@ -287,84 +287,85 @@ void GradientEdit::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void GradientEdit::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		if (!picker->is_connected("color_changed", callable_mp(this, &GradientEdit::_color_changed))) {
-			picker->connect("color_changed", callable_mp(this, &GradientEdit::_color_changed));
-		}
-	}
-
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		draw_spacing = BASE_SPACING * get_theme_default_base_scale();
-		draw_point_width = BASE_POINT_WIDTH * get_theme_default_base_scale();
-	}
-
-	if (p_what == NOTIFICATION_DRAW) {
-		int w = get_size().x;
-		int h = get_size().y;
-
-		if (w == 0 || h == 0) {
-			return; // Safety check. We have division by 'h'. And in any case there is nothing to draw with such size.
-		}
-
-		int total_w = get_size().width - get_size().height - draw_spacing;
-
-		// Draw checker pattern for ramp.
-		draw_texture_rect(get_theme_icon(SNAME("GuiMiniCheckerboard"), SNAME("EditorIcons")), Rect2(0, 0, total_w, h), true);
-
-		// Draw color ramp.
-
-		gradient_cache->set_points(points);
-		gradient_cache->set_interpolation_mode(interpolation_mode);
-		preview_texture->set_gradient(gradient_cache);
-		draw_texture_rect(preview_texture, Rect2(0, 0, total_w, h));
-
-		// Draw point markers.
-		for (int i = 0; i < points.size(); i++) {
-			Color col = points[i].color.inverted();
-			col.a = 0.9;
-
-			draw_line(Vector2(points[i].offset * total_w, 0), Vector2(points[i].offset * total_w, h / 2), col);
-			Rect2 rect = Rect2(points[i].offset * total_w - draw_point_width / 2, h / 2, draw_point_width, h / 2);
-			draw_rect(rect, points[i].color, true);
-			draw_rect(rect, col, false);
-			if (grabbed == i) {
-				rect = rect.grow(-1);
-				if (has_focus()) {
-					draw_rect(rect, Color(1, 0, 0, 0.9), false);
-				} else {
-					draw_rect(rect, Color(0.6, 0, 0, 0.9), false);
-				}
-
-				rect = rect.grow(-1);
-				draw_rect(rect, col, false);
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			if (!picker->is_connected("color_changed", callable_mp(this, &GradientEdit::_color_changed))) {
+				picker->connect("color_changed", callable_mp(this, &GradientEdit::_color_changed));
 			}
+			[[fallthrough]];
 		}
+		case NOTIFICATION_THEME_CHANGED: {
+			draw_spacing = BASE_SPACING * get_theme_default_base_scale();
+			draw_point_width = BASE_POINT_WIDTH * get_theme_default_base_scale();
+		} break;
 
-		//Draw "button" for color selector
-		draw_texture_rect(get_theme_icon(SNAME("GuiMiniCheckerboard"), SNAME("EditorIcons")), Rect2(total_w + draw_spacing, 0, h, h), true);
-		if (grabbed != -1) {
-			//Draw with selection color
-			draw_rect(Rect2(total_w + draw_spacing, 0, h, h), points[grabbed].color);
-		} else {
-			//if no color selected draw grey color with 'X' on top.
-			draw_rect(Rect2(total_w + draw_spacing, 0, h, h), Color(0.5, 0.5, 0.5, 1));
-			draw_line(Vector2(total_w + draw_spacing, 0), Vector2(total_w + draw_spacing + h, h), Color(1, 1, 1, 0.6));
-			draw_line(Vector2(total_w + draw_spacing, h), Vector2(total_w + draw_spacing + h, 0), Color(1, 1, 1, 0.6));
-		}
+		case NOTIFICATION_DRAW: {
+			int w = get_size().x;
+			int h = get_size().y;
 
-		// Draw borders around color ramp if in focus.
-		if (has_focus()) {
-			draw_line(Vector2(-1, -1), Vector2(total_w + 1, -1), Color(1, 1, 1, 0.6));
-			draw_line(Vector2(total_w + 1, -1), Vector2(total_w + 1, h + 1), Color(1, 1, 1, 0.6));
-			draw_line(Vector2(total_w + 1, h + 1), Vector2(-1, h + 1), Color(1, 1, 1, 0.6));
-			draw_line(Vector2(-1, -1), Vector2(-1, h + 1), Color(1, 1, 1, 0.6));
-		}
-	}
+			if (w == 0 || h == 0) {
+				return; // Safety check. We have division by 'h'. And in any case there is nothing to draw with such size.
+			}
 
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		if (!is_visible()) {
-			grabbing = false;
-		}
+			int total_w = get_size().width - get_size().height - draw_spacing;
+
+			// Draw checker pattern for ramp.
+			draw_texture_rect(get_theme_icon(SNAME("GuiMiniCheckerboard"), SNAME("EditorIcons")), Rect2(0, 0, total_w, h), true);
+
+			// Draw color ramp.
+			gradient_cache->set_points(points);
+			gradient_cache->set_interpolation_mode(interpolation_mode);
+			preview_texture->set_gradient(gradient_cache);
+			draw_texture_rect(preview_texture, Rect2(0, 0, total_w, h));
+
+			// Draw point markers.
+			for (int i = 0; i < points.size(); i++) {
+				Color col = points[i].color.inverted();
+				col.a = 0.9;
+
+				draw_line(Vector2(points[i].offset * total_w, 0), Vector2(points[i].offset * total_w, h / 2), col);
+				Rect2 rect = Rect2(points[i].offset * total_w - draw_point_width / 2, h / 2, draw_point_width, h / 2);
+				draw_rect(rect, points[i].color, true);
+				draw_rect(rect, col, false);
+				if (grabbed == i) {
+					rect = rect.grow(-1);
+					if (has_focus()) {
+						draw_rect(rect, Color(1, 0, 0, 0.9), false);
+					} else {
+						draw_rect(rect, Color(0.6, 0, 0, 0.9), false);
+					}
+
+					rect = rect.grow(-1);
+					draw_rect(rect, col, false);
+				}
+			}
+
+			// Draw "button" for color selector.
+			draw_texture_rect(get_theme_icon(SNAME("GuiMiniCheckerboard"), SNAME("EditorIcons")), Rect2(total_w + draw_spacing, 0, h, h), true);
+			if (grabbed != -1) {
+				// Draw with selection color.
+				draw_rect(Rect2(total_w + draw_spacing, 0, h, h), points[grabbed].color);
+			} else {
+				// If no color selected draw grey color with 'X' on top.
+				draw_rect(Rect2(total_w + draw_spacing, 0, h, h), Color(0.5, 0.5, 0.5, 1));
+				draw_line(Vector2(total_w + draw_spacing, 0), Vector2(total_w + draw_spacing + h, h), Color(1, 1, 1, 0.6));
+				draw_line(Vector2(total_w + draw_spacing, h), Vector2(total_w + draw_spacing + h, 0), Color(1, 1, 1, 0.6));
+			}
+
+			// Draw borders around color ramp if in focus.
+			if (has_focus()) {
+				draw_line(Vector2(-1, -1), Vector2(total_w + 1, -1), Color(1, 1, 1, 0.6));
+				draw_line(Vector2(total_w + 1, -1), Vector2(total_w + 1, h + 1), Color(1, 1, 1, 0.6));
+				draw_line(Vector2(total_w + 1, h + 1), Vector2(-1, h + 1), Color(1, 1, 1, 0.6));
+				draw_line(Vector2(-1, -1), Vector2(-1, h + 1), Color(1, 1, 1, 0.6));
+			}
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (!is_visible()) {
+				grabbing = false;
+			}
+		} break;
 	}
 }
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -423,82 +423,86 @@ void GraphEdit::remove_child_notify(Node *p_child) {
 }
 
 void GraphEdit::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		port_grab_distance_horizontal = get_theme_constant(SNAME("port_grab_distance_horizontal"));
-		port_grab_distance_vertical = get_theme_constant(SNAME("port_grab_distance_vertical"));
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			port_grab_distance_horizontal = get_theme_constant(SNAME("port_grab_distance_horizontal"));
+			port_grab_distance_vertical = get_theme_constant(SNAME("port_grab_distance_vertical"));
 
-		zoom_minus->set_icon(get_theme_icon(SNAME("minus")));
-		zoom_reset->set_icon(get_theme_icon(SNAME("reset")));
-		zoom_plus->set_icon(get_theme_icon(SNAME("more")));
-		snap_button->set_icon(get_theme_icon(SNAME("snap")));
-		minimap_button->set_icon(get_theme_icon(SNAME("minimap")));
-		layout_button->set_icon(get_theme_icon(SNAME("layout")));
+			zoom_minus->set_icon(get_theme_icon(SNAME("minus")));
+			zoom_reset->set_icon(get_theme_icon(SNAME("reset")));
+			zoom_plus->set_icon(get_theme_icon(SNAME("more")));
+			snap_button->set_icon(get_theme_icon(SNAME("snap")));
+			minimap_button->set_icon(get_theme_icon(SNAME("minimap")));
+			layout_button->set_icon(get_theme_icon(SNAME("layout")));
 
-		zoom_label->set_custom_minimum_size(Size2(48, 0) * get_theme_default_base_scale());
-	}
-	if (p_what == NOTIFICATION_READY) {
-		Size2 hmin = h_scroll->get_combined_minimum_size();
-		Size2 vmin = v_scroll->get_combined_minimum_size();
+			zoom_label->set_custom_minimum_size(Size2(48, 0) * get_theme_default_base_scale());
+		} break;
 
-		h_scroll->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, 0);
-		h_scroll->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, 0);
-		h_scroll->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -hmin.height);
-		h_scroll->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, 0);
+		case NOTIFICATION_READY: {
+			Size2 hmin = h_scroll->get_combined_minimum_size();
+			Size2 vmin = v_scroll->get_combined_minimum_size();
 
-		v_scroll->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -vmin.width);
-		v_scroll->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, 0);
-		v_scroll->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, 0);
-		v_scroll->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, 0);
-	}
-	if (p_what == NOTIFICATION_DRAW) {
-		draw_style_box(get_theme_stylebox(SNAME("bg")), Rect2(Point2(), get_size()));
+			h_scroll->set_anchor_and_offset(SIDE_LEFT, ANCHOR_BEGIN, 0);
+			h_scroll->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, 0);
+			h_scroll->set_anchor_and_offset(SIDE_TOP, ANCHOR_END, -hmin.height);
+			h_scroll->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, 0);
 
-		if (is_using_snap()) {
-			//draw grid
+			v_scroll->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -vmin.width);
+			v_scroll->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, 0);
+			v_scroll->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, 0);
+			v_scroll->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, 0);
+		} break;
 
-			int snap = get_snap();
+		case NOTIFICATION_DRAW: {
+			draw_style_box(get_theme_stylebox(SNAME("bg")), Rect2(Point2(), get_size()));
 
-			Vector2 offset = get_scroll_ofs() / zoom;
-			Size2 size = get_size() / zoom;
+			if (is_using_snap()) {
+				// Draw grid.
+				int snap = get_snap();
 
-			Point2i from = (offset / float(snap)).floor();
-			Point2i len = (size / float(snap)).floor() + Vector2(1, 1);
+				Vector2 offset = get_scroll_ofs() / zoom;
+				Size2 size = get_size() / zoom;
 
-			Color grid_minor = get_theme_color(SNAME("grid_minor"));
-			Color grid_major = get_theme_color(SNAME("grid_major"));
+				Point2i from = (offset / float(snap)).floor();
+				Point2i len = (size / float(snap)).floor() + Vector2(1, 1);
 
-			for (int i = from.x; i < from.x + len.x; i++) {
-				Color color;
+				Color grid_minor = get_theme_color(SNAME("grid_minor"));
+				Color grid_major = get_theme_color(SNAME("grid_major"));
 
-				if (ABS(i) % 10 == 0) {
-					color = grid_major;
-				} else {
-					color = grid_minor;
+				for (int i = from.x; i < from.x + len.x; i++) {
+					Color color;
+
+					if (ABS(i) % 10 == 0) {
+						color = grid_major;
+					} else {
+						color = grid_minor;
+					}
+
+					float base_ofs = i * snap * zoom - offset.x * zoom;
+					draw_line(Vector2(base_ofs, 0), Vector2(base_ofs, get_size().height), color);
 				}
 
-				float base_ofs = i * snap * zoom - offset.x * zoom;
-				draw_line(Vector2(base_ofs, 0), Vector2(base_ofs, get_size().height), color);
-			}
+				for (int i = from.y; i < from.y + len.y; i++) {
+					Color color;
 
-			for (int i = from.y; i < from.y + len.y; i++) {
-				Color color;
+					if (ABS(i) % 10 == 0) {
+						color = grid_major;
+					} else {
+						color = grid_minor;
+					}
 
-				if (ABS(i) % 10 == 0) {
-					color = grid_major;
-				} else {
-					color = grid_minor;
+					float base_ofs = i * snap * zoom - offset.y * zoom;
+					draw_line(Vector2(0, base_ofs), Vector2(get_size().width, base_ofs), color);
 				}
-
-				float base_ofs = i * snap * zoom - offset.y * zoom;
-				draw_line(Vector2(0, base_ofs), Vector2(get_size().width, base_ofs), color);
 			}
-		}
-	}
+		} break;
 
-	if (p_what == NOTIFICATION_RESIZED) {
-		_update_scroll();
-		top_layer->update();
-		minimap->update();
+		case NOTIFICATION_RESIZED: {
+			_update_scroll();
+			top_layer->update();
+			minimap->update();
+		} break;
 	}
 }
 

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -31,6 +31,7 @@
 #include "graph_node.h"
 
 #include "core/string/translation.h"
+
 #ifdef TOOLS_ENABLED
 #include "graph_edit.h"
 #endif

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -179,11 +179,12 @@ void GridContainer::_notification(int p_what) {
 					col_ofs += s.width + hsep;
 				}
 			}
-
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			update_minimum_size();
 		} break;
+
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			queue_sort();

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -855,445 +855,449 @@ static Rect2 _adjust_to_max_size(Size2 p_size, Size2 p_max_size) {
 }
 
 void ItemList::_notification(int p_what) {
-	if (p_what == NOTIFICATION_RESIZED) {
-		shape_changed = true;
-		update();
-	}
+	switch (p_what) {
+		case NOTIFICATION_RESIZED: {
+			shape_changed = true;
+			update();
+		} break;
 
-	if ((p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED) || (p_what == NOTIFICATION_TRANSLATION_CHANGED) || (p_what == NOTIFICATION_THEME_CHANGED)) {
-		for (int i = 0; i < items.size(); i++) {
-			_shape(i);
-		}
-		shape_changed = true;
-		update();
-	}
-
-	if (p_what == NOTIFICATION_DRAW) {
-		Ref<StyleBox> bg = get_theme_stylebox(SNAME("bg"));
-
-		int mw = scroll_bar->get_minimum_size().x;
-		scroll_bar->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -mw);
-		scroll_bar->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, 0);
-		scroll_bar->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, bg->get_margin(SIDE_TOP));
-		scroll_bar->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -bg->get_margin(SIDE_BOTTOM));
-
-		Size2 size = get_size();
-
-		int width = size.width - bg->get_minimum_size().width;
-		if (scroll_bar->is_visible()) {
-			width -= mw;
-		}
-
-		draw_style_box(bg, Rect2(Point2(), size));
-
-		int hseparation = get_theme_constant(SNAME("hseparation"));
-		int vseparation = get_theme_constant(SNAME("vseparation"));
-		int icon_margin = get_theme_constant(SNAME("icon_margin"));
-		int line_separation = get_theme_constant(SNAME("line_separation"));
-		Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
-		int outline_size = get_theme_constant(SNAME("outline_size"));
-
-		Ref<StyleBox> sbsel = has_focus() ? get_theme_stylebox(SNAME("selected_focus")) : get_theme_stylebox(SNAME("selected"));
-		Ref<StyleBox> cursor = has_focus() ? get_theme_stylebox(SNAME("cursor")) : get_theme_stylebox(SNAME("cursor_unfocused"));
-		bool rtl = is_layout_rtl();
-
-		Color guide_color = get_theme_color(SNAME("guide_color"));
-		Color font_color = get_theme_color(SNAME("font_color"));
-		Color font_selected_color = get_theme_color(SNAME("font_selected_color"));
-
-		if (has_focus()) {
-			RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), true);
-			draw_style_box(get_theme_stylebox(SNAME("bg_focus")), Rect2(Point2(), size));
-			RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), false);
-		}
-
-		if (shape_changed) {
-			float max_column_width = 0.0;
-
-			//1- compute item minimum sizes
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
+		case NOTIFICATION_TRANSLATION_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
 			for (int i = 0; i < items.size(); i++) {
-				Size2 minsize;
-				if (items[i].icon.is_valid()) {
-					if (fixed_icon_size.x > 0 && fixed_icon_size.y > 0) {
-						minsize = fixed_icon_size * icon_scale;
-					} else {
-						minsize = items[i].get_icon_size() * icon_scale;
+				_shape(i);
+			}
+			shape_changed = true;
+			update();
+		} break;
+
+		case NOTIFICATION_DRAW: {
+			Ref<StyleBox> bg = get_theme_stylebox(SNAME("bg"));
+
+			int mw = scroll_bar->get_minimum_size().x;
+			scroll_bar->set_anchor_and_offset(SIDE_LEFT, ANCHOR_END, -mw);
+			scroll_bar->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, 0);
+			scroll_bar->set_anchor_and_offset(SIDE_TOP, ANCHOR_BEGIN, bg->get_margin(SIDE_TOP));
+			scroll_bar->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, -bg->get_margin(SIDE_BOTTOM));
+
+			Size2 size = get_size();
+
+			int width = size.width - bg->get_minimum_size().width;
+			if (scroll_bar->is_visible()) {
+				width -= mw;
+			}
+
+			draw_style_box(bg, Rect2(Point2(), size));
+
+			int hseparation = get_theme_constant(SNAME("hseparation"));
+			int vseparation = get_theme_constant(SNAME("vseparation"));
+			int icon_margin = get_theme_constant(SNAME("icon_margin"));
+			int line_separation = get_theme_constant(SNAME("line_separation"));
+			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+			int outline_size = get_theme_constant(SNAME("outline_size"));
+
+			Ref<StyleBox> sbsel = has_focus() ? get_theme_stylebox(SNAME("selected_focus")) : get_theme_stylebox(SNAME("selected"));
+			Ref<StyleBox> cursor = has_focus() ? get_theme_stylebox(SNAME("cursor")) : get_theme_stylebox(SNAME("cursor_unfocused"));
+			bool rtl = is_layout_rtl();
+
+			Color guide_color = get_theme_color(SNAME("guide_color"));
+			Color font_color = get_theme_color(SNAME("font_color"));
+			Color font_selected_color = get_theme_color(SNAME("font_selected_color"));
+
+			if (has_focus()) {
+				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), true);
+				draw_style_box(get_theme_stylebox(SNAME("bg_focus")), Rect2(Point2(), size));
+				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(get_canvas_item(), false);
+			}
+
+			if (shape_changed) {
+				float max_column_width = 0.0;
+
+				//1- compute item minimum sizes
+				for (int i = 0; i < items.size(); i++) {
+					Size2 minsize;
+					if (items[i].icon.is_valid()) {
+						if (fixed_icon_size.x > 0 && fixed_icon_size.y > 0) {
+							minsize = fixed_icon_size * icon_scale;
+						} else {
+							minsize = items[i].get_icon_size() * icon_scale;
+						}
+
+						if (!items[i].text.is_empty()) {
+							if (icon_mode == ICON_MODE_TOP) {
+								minsize.y += icon_margin;
+							} else {
+								minsize.x += icon_margin;
+							}
+						}
 					}
 
 					if (!items[i].text.is_empty()) {
+						int max_width = -1;
+						if (fixed_column_width) {
+							max_width = fixed_column_width;
+						} else if (same_column_width) {
+							max_width = items[i].rect_cache.size.x;
+						}
+						items.write[i].text_buf->set_width(max_width);
+						Size2 s = items[i].text_buf->get_size();
+
 						if (icon_mode == ICON_MODE_TOP) {
-							minsize.y += icon_margin;
+							minsize.x = MAX(minsize.x, s.width);
+							if (max_text_lines > 0) {
+								minsize.y += s.height + line_separation * max_text_lines;
+							} else {
+								minsize.y += s.height;
+							}
+
 						} else {
-							minsize.x += icon_margin;
+							minsize.y = MAX(minsize.y, s.height);
+							minsize.x += s.width;
 						}
 					}
+
+					if (fixed_column_width > 0) {
+						minsize.x = fixed_column_width;
+					}
+					max_column_width = MAX(max_column_width, minsize.x);
+
+					// elements need to adapt to the selected size
+					minsize.y += vseparation;
+					minsize.x += hseparation;
+					items.write[i].rect_cache.size = minsize;
+					items.write[i].min_rect_cache.size = minsize;
+				}
+
+				int fit_size = size.x - bg->get_minimum_size().width - mw;
+
+				//2-attempt best fit
+				current_columns = 0x7FFFFFFF;
+				if (max_columns > 0) {
+					current_columns = max_columns;
+				}
+
+				while (true) {
+					//repeat until all fits
+					bool all_fit = true;
+					Vector2 ofs;
+					int col = 0;
+					int max_h = 0;
+					separators.clear();
+					for (int i = 0; i < items.size(); i++) {
+						if (current_columns > 1 && items[i].rect_cache.size.width + ofs.x > fit_size) {
+							//went past
+							current_columns = MAX(col, 1);
+							all_fit = false;
+							break;
+						}
+
+						if (same_column_width) {
+							items.write[i].rect_cache.size.x = max_column_width;
+						}
+						items.write[i].rect_cache.position = ofs;
+						max_h = MAX(max_h, items[i].rect_cache.size.y);
+						ofs.x += items[i].rect_cache.size.x + hseparation;
+						col++;
+						if (col == current_columns) {
+							if (i < items.size() - 1) {
+								separators.push_back(ofs.y + max_h + vseparation / 2);
+							}
+
+							for (int j = i; j >= 0 && col > 0; j--, col--) {
+								items.write[j].rect_cache.size.y = max_h;
+							}
+
+							ofs.x = 0;
+							ofs.y += max_h + vseparation;
+							col = 0;
+							max_h = 0;
+						}
+					}
+
+					for (int j = items.size() - 1; j >= 0 && col > 0; j--, col--) {
+						items.write[j].rect_cache.size.y = max_h;
+					}
+
+					if (all_fit) {
+						float page = MAX(0, size.height - bg->get_minimum_size().height);
+						float max = MAX(page, ofs.y + max_h);
+						if (auto_height) {
+							auto_height_value = ofs.y + max_h + bg->get_minimum_size().height;
+						}
+						scroll_bar->set_max(max);
+						scroll_bar->set_page(page);
+						if (max <= page) {
+							scroll_bar->set_value(0);
+							scroll_bar->hide();
+						} else {
+							scroll_bar->show();
+
+							if (do_autoscroll_to_bottom) {
+								scroll_bar->set_value(max);
+							}
+						}
+						break;
+					}
+				}
+
+				update_minimum_size();
+				shape_changed = false;
+			}
+
+			//ensure_selected_visible needs to be checked before we draw the list.
+			if (ensure_selected_visible && current >= 0 && current < items.size()) {
+				Rect2 r = items[current].rect_cache;
+				int from = scroll_bar->get_value();
+				int to = from + scroll_bar->get_page();
+
+				if (r.position.y < from) {
+					scroll_bar->set_value(r.position.y);
+				} else if (r.position.y + r.size.y > to) {
+					scroll_bar->set_value(r.position.y + r.size.y - (to - from));
+				}
+			}
+
+			ensure_selected_visible = false;
+
+			Vector2 base_ofs = bg->get_offset();
+			base_ofs.y -= int(scroll_bar->get_value());
+
+			const Rect2 clip(-base_ofs, size); // visible frame, don't need to draw outside of there
+
+			int first_item_visible;
+			{
+				// do a binary search to find the first item whose rect reaches below clip.position.y
+				int lo = 0;
+				int hi = items.size();
+				while (lo < hi) {
+					const int mid = (lo + hi) / 2;
+					const Rect2 &rcache = items[mid].rect_cache;
+					if (rcache.position.y + rcache.size.y < clip.position.y) {
+						lo = mid + 1;
+					} else {
+						hi = mid;
+					}
+				}
+				// we might have ended up with column 2, or 3, ..., so let's find the first column
+				while (lo > 0 && items[lo - 1].rect_cache.position.y == items[lo].rect_cache.position.y) {
+					lo -= 1;
+				}
+				first_item_visible = lo;
+			}
+
+			for (int i = first_item_visible; i < items.size(); i++) {
+				Rect2 rcache = items[i].rect_cache;
+
+				if (rcache.position.y > clip.position.y + clip.size.y) {
+					break; // done
+				}
+
+				if (!clip.intersects(rcache)) {
+					continue;
+				}
+
+				if (current_columns == 1) {
+					rcache.size.width = width - rcache.position.x;
+				}
+
+				if (items[i].selected) {
+					Rect2 r = rcache;
+					r.position += base_ofs;
+					r.position.y -= vseparation / 2;
+					r.size.y += vseparation;
+					r.position.x -= hseparation / 2;
+					r.size.x += hseparation;
+
+					if (rtl) {
+						r.position.x = size.width - r.position.x - r.size.x;
+					}
+
+					draw_style_box(sbsel, r);
+				}
+				if (items[i].custom_bg.a > 0.001) {
+					Rect2 r = rcache;
+					r.position += base_ofs;
+
+					// Size rect to make the align the temperature colors
+					r.position.y -= vseparation / 2;
+					r.size.y += vseparation;
+					r.position.x -= hseparation / 2;
+					r.size.x += hseparation;
+
+					if (rtl) {
+						r.position.x = size.width - r.position.x - r.size.x;
+					}
+
+					draw_rect(r, items[i].custom_bg);
+				}
+
+				Vector2 text_ofs;
+				if (items[i].icon.is_valid()) {
+					Size2 icon_size;
+					//= _adjust_to_max_size(items[i].get_icon_size(),fixed_icon_size) * icon_scale;
+
+					if (fixed_icon_size.x > 0 && fixed_icon_size.y > 0) {
+						icon_size = fixed_icon_size * icon_scale;
+					} else {
+						icon_size = items[i].get_icon_size() * icon_scale;
+					}
+
+					Vector2 icon_ofs;
+
+					Point2 pos = items[i].rect_cache.position + icon_ofs + base_ofs;
+
+					if (icon_mode == ICON_MODE_TOP) {
+						pos.x += Math::floor((items[i].rect_cache.size.width - icon_size.width) / 2);
+						pos.y += icon_margin;
+						text_ofs.y = icon_size.height + icon_margin * 2;
+					} else {
+						pos.y += Math::floor((items[i].rect_cache.size.height - icon_size.height) / 2);
+						text_ofs.x = icon_size.width + icon_margin;
+					}
+
+					Rect2 draw_rect = Rect2(pos, icon_size);
+
+					if (fixed_icon_size.x > 0 && fixed_icon_size.y > 0) {
+						Rect2 adj = _adjust_to_max_size(items[i].get_icon_size() * icon_scale, icon_size);
+						draw_rect.position += adj.position;
+						draw_rect.size = adj.size;
+					}
+
+					Color modulate = items[i].icon_modulate;
+					if (items[i].disabled) {
+						modulate.a *= 0.5;
+					}
+
+					// If the icon is transposed, we have to switch the size so that it is drawn correctly
+					if (items[i].icon_transposed) {
+						Size2 size_tmp = draw_rect.size;
+						draw_rect.size.x = size_tmp.y;
+						draw_rect.size.y = size_tmp.x;
+					}
+
+					Rect2 region = (items[i].icon_region.size.x == 0 || items[i].icon_region.size.y == 0) ? Rect2(Vector2(), items[i].icon->get_size()) : Rect2(items[i].icon_region);
+
+					if (rtl) {
+						draw_rect.position.x = size.width - draw_rect.position.x - draw_rect.size.x;
+					}
+					draw_texture_rect_region(items[i].icon, draw_rect, region, modulate, items[i].icon_transposed);
+				}
+
+				if (items[i].tag_icon.is_valid()) {
+					Point2 draw_pos = items[i].rect_cache.position;
+					if (rtl) {
+						draw_pos.x = size.width - draw_pos.x - items[i].tag_icon->get_width();
+					}
+					draw_texture(items[i].tag_icon, draw_pos + base_ofs);
 				}
 
 				if (!items[i].text.is_empty()) {
-					int max_width = -1;
+					int max_len = -1;
+
+					Vector2 size2 = items[i].text_buf->get_size();
 					if (fixed_column_width) {
-						max_width = fixed_column_width;
+						max_len = fixed_column_width;
 					} else if (same_column_width) {
-						max_width = items[i].rect_cache.size.x;
+						max_len = items[i].rect_cache.size.x;
+					} else {
+						max_len = size2.x;
 					}
-					items.write[i].text_buf->set_width(max_width);
-					Size2 s = items[i].text_buf->get_size();
 
-					if (icon_mode == ICON_MODE_TOP) {
-						minsize.x = MAX(minsize.x, s.width);
-						if (max_text_lines > 0) {
-							minsize.y += s.height + line_separation * max_text_lines;
+					Color modulate = items[i].selected ? font_selected_color : (items[i].custom_fg != Color() ? items[i].custom_fg : font_color);
+					if (items[i].disabled) {
+						modulate.a *= 0.5;
+					}
+
+					if (icon_mode == ICON_MODE_TOP && max_text_lines > 0) {
+						text_ofs += base_ofs;
+						text_ofs += items[i].rect_cache.position;
+
+						if (rtl) {
+							text_ofs.x = size.width - text_ofs.x - max_len;
+						}
+
+						items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+
+						if (outline_size > 0 && font_outline_color.a > 0) {
+							items[i].text_buf->draw_outline(get_canvas_item(), text_ofs, outline_size, font_outline_color);
+						}
+
+						items[i].text_buf->draw(get_canvas_item(), text_ofs, modulate);
+					} else {
+						if (fixed_column_width > 0) {
+							size2.x = MIN(size2.x, fixed_column_width);
+						}
+
+						if (icon_mode == ICON_MODE_TOP) {
+							text_ofs.x += (items[i].rect_cache.size.width - size2.x) / 2;
 						} else {
-							minsize.y += s.height;
+							text_ofs.y += (items[i].rect_cache.size.height - size2.y) / 2;
 						}
 
-					} else {
-						minsize.y = MAX(minsize.y, s.height);
-						minsize.x += s.width;
-					}
-				}
+						text_ofs += base_ofs;
+						text_ofs += items[i].rect_cache.position;
 
-				if (fixed_column_width > 0) {
-					minsize.x = fixed_column_width;
-				}
-				max_column_width = MAX(max_column_width, minsize.x);
-
-				// elements need to adapt to the selected size
-				minsize.y += vseparation;
-				minsize.x += hseparation;
-				items.write[i].rect_cache.size = minsize;
-				items.write[i].min_rect_cache.size = minsize;
-			}
-
-			int fit_size = size.x - bg->get_minimum_size().width - mw;
-
-			//2-attempt best fit
-			current_columns = 0x7FFFFFFF;
-			if (max_columns > 0) {
-				current_columns = max_columns;
-			}
-
-			while (true) {
-				//repeat until all fits
-				bool all_fit = true;
-				Vector2 ofs;
-				int col = 0;
-				int max_h = 0;
-				separators.clear();
-				for (int i = 0; i < items.size(); i++) {
-					if (current_columns > 1 && items[i].rect_cache.size.width + ofs.x > fit_size) {
-						//went past
-						current_columns = MAX(col, 1);
-						all_fit = false;
-						break;
-					}
-
-					if (same_column_width) {
-						items.write[i].rect_cache.size.x = max_column_width;
-					}
-					items.write[i].rect_cache.position = ofs;
-					max_h = MAX(max_h, items[i].rect_cache.size.y);
-					ofs.x += items[i].rect_cache.size.x + hseparation;
-					col++;
-					if (col == current_columns) {
-						if (i < items.size() - 1) {
-							separators.push_back(ofs.y + max_h + vseparation / 2);
+						if (rtl) {
+							text_ofs.x = size.width - text_ofs.x - max_len;
 						}
 
-						for (int j = i; j >= 0 && col > 0; j--, col--) {
-							items.write[j].rect_cache.size.y = max_h;
+						items.write[i].text_buf->set_width(max_len);
+
+						if (rtl) {
+							items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
+						} else {
+							items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 						}
 
-						ofs.x = 0;
-						ofs.y += max_h + vseparation;
-						col = 0;
-						max_h = 0;
-					}
-				}
-
-				for (int j = items.size() - 1; j >= 0 && col > 0; j--, col--) {
-					items.write[j].rect_cache.size.y = max_h;
-				}
-
-				if (all_fit) {
-					float page = MAX(0, size.height - bg->get_minimum_size().height);
-					float max = MAX(page, ofs.y + max_h);
-					if (auto_height) {
-						auto_height_value = ofs.y + max_h + bg->get_minimum_size().height;
-					}
-					scroll_bar->set_max(max);
-					scroll_bar->set_page(page);
-					if (max <= page) {
-						scroll_bar->set_value(0);
-						scroll_bar->hide();
-					} else {
-						scroll_bar->show();
-
-						if (do_autoscroll_to_bottom) {
-							scroll_bar->set_value(max);
+						if (outline_size > 0 && font_outline_color.a > 0) {
+							items[i].text_buf->draw_outline(get_canvas_item(), text_ofs, outline_size, font_outline_color);
 						}
+
+						items[i].text_buf->draw(get_canvas_item(), text_ofs, modulate);
 					}
-					break;
-				}
-			}
-
-			update_minimum_size();
-			shape_changed = false;
-		}
-
-		//ensure_selected_visible needs to be checked before we draw the list.
-		if (ensure_selected_visible && current >= 0 && current < items.size()) {
-			Rect2 r = items[current].rect_cache;
-			int from = scroll_bar->get_value();
-			int to = from + scroll_bar->get_page();
-
-			if (r.position.y < from) {
-				scroll_bar->set_value(r.position.y);
-			} else if (r.position.y + r.size.y > to) {
-				scroll_bar->set_value(r.position.y + r.size.y - (to - from));
-			}
-		}
-
-		ensure_selected_visible = false;
-
-		Vector2 base_ofs = bg->get_offset();
-		base_ofs.y -= int(scroll_bar->get_value());
-
-		const Rect2 clip(-base_ofs, size); // visible frame, don't need to draw outside of there
-
-		int first_item_visible;
-		{
-			// do a binary search to find the first item whose rect reaches below clip.position.y
-			int lo = 0;
-			int hi = items.size();
-			while (lo < hi) {
-				const int mid = (lo + hi) / 2;
-				const Rect2 &rcache = items[mid].rect_cache;
-				if (rcache.position.y + rcache.size.y < clip.position.y) {
-					lo = mid + 1;
-				} else {
-					hi = mid;
-				}
-			}
-			// we might have ended up with column 2, or 3, ..., so let's find the first column
-			while (lo > 0 && items[lo - 1].rect_cache.position.y == items[lo].rect_cache.position.y) {
-				lo -= 1;
-			}
-			first_item_visible = lo;
-		}
-
-		for (int i = first_item_visible; i < items.size(); i++) {
-			Rect2 rcache = items[i].rect_cache;
-
-			if (rcache.position.y > clip.position.y + clip.size.y) {
-				break; // done
-			}
-
-			if (!clip.intersects(rcache)) {
-				continue;
-			}
-
-			if (current_columns == 1) {
-				rcache.size.width = width - rcache.position.x;
-			}
-
-			if (items[i].selected) {
-				Rect2 r = rcache;
-				r.position += base_ofs;
-				r.position.y -= vseparation / 2;
-				r.size.y += vseparation;
-				r.position.x -= hseparation / 2;
-				r.size.x += hseparation;
-
-				if (rtl) {
-					r.position.x = size.width - r.position.x - r.size.x;
 				}
 
-				draw_style_box(sbsel, r);
-			}
-			if (items[i].custom_bg.a > 0.001) {
-				Rect2 r = rcache;
-				r.position += base_ofs;
-
-				// Size rect to make the align the temperature colors
-				r.position.y -= vseparation / 2;
-				r.size.y += vseparation;
-				r.position.x -= hseparation / 2;
-				r.size.x += hseparation;
-
-				if (rtl) {
-					r.position.x = size.width - r.position.x - r.size.x;
-				}
-
-				draw_rect(r, items[i].custom_bg);
-			}
-
-			Vector2 text_ofs;
-			if (items[i].icon.is_valid()) {
-				Size2 icon_size;
-				//= _adjust_to_max_size(items[i].get_icon_size(),fixed_icon_size) * icon_scale;
-
-				if (fixed_icon_size.x > 0 && fixed_icon_size.y > 0) {
-					icon_size = fixed_icon_size * icon_scale;
-				} else {
-					icon_size = items[i].get_icon_size() * icon_scale;
-				}
-
-				Vector2 icon_ofs;
-
-				Point2 pos = items[i].rect_cache.position + icon_ofs + base_ofs;
-
-				if (icon_mode == ICON_MODE_TOP) {
-					pos.x += Math::floor((items[i].rect_cache.size.width - icon_size.width) / 2);
-					pos.y += icon_margin;
-					text_ofs.y = icon_size.height + icon_margin * 2;
-				} else {
-					pos.y += Math::floor((items[i].rect_cache.size.height - icon_size.height) / 2);
-					text_ofs.x = icon_size.width + icon_margin;
-				}
-
-				Rect2 draw_rect = Rect2(pos, icon_size);
-
-				if (fixed_icon_size.x > 0 && fixed_icon_size.y > 0) {
-					Rect2 adj = _adjust_to_max_size(items[i].get_icon_size() * icon_scale, icon_size);
-					draw_rect.position += adj.position;
-					draw_rect.size = adj.size;
-				}
-
-				Color modulate = items[i].icon_modulate;
-				if (items[i].disabled) {
-					modulate.a *= 0.5;
-				}
-
-				// If the icon is transposed, we have to switch the size so that it is drawn correctly
-				if (items[i].icon_transposed) {
-					Size2 size_tmp = draw_rect.size;
-					draw_rect.size.x = size_tmp.y;
-					draw_rect.size.y = size_tmp.x;
-				}
-
-				Rect2 region = (items[i].icon_region.size.x == 0 || items[i].icon_region.size.y == 0) ? Rect2(Vector2(), items[i].icon->get_size()) : Rect2(items[i].icon_region);
-
-				if (rtl) {
-					draw_rect.position.x = size.width - draw_rect.position.x - draw_rect.size.x;
-				}
-				draw_texture_rect_region(items[i].icon, draw_rect, region, modulate, items[i].icon_transposed);
-			}
-
-			if (items[i].tag_icon.is_valid()) {
-				Point2 draw_pos = items[i].rect_cache.position;
-				if (rtl) {
-					draw_pos.x = size.width - draw_pos.x - items[i].tag_icon->get_width();
-				}
-				draw_texture(items[i].tag_icon, draw_pos + base_ofs);
-			}
-
-			if (!items[i].text.is_empty()) {
-				int max_len = -1;
-
-				Vector2 size2 = items[i].text_buf->get_size();
-				if (fixed_column_width) {
-					max_len = fixed_column_width;
-				} else if (same_column_width) {
-					max_len = items[i].rect_cache.size.x;
-				} else {
-					max_len = size2.x;
-				}
-
-				Color modulate = items[i].selected ? font_selected_color : (items[i].custom_fg != Color() ? items[i].custom_fg : font_color);
-				if (items[i].disabled) {
-					modulate.a *= 0.5;
-				}
-
-				if (icon_mode == ICON_MODE_TOP && max_text_lines > 0) {
-					text_ofs += base_ofs;
-					text_ofs += items[i].rect_cache.position;
+				if (select_mode == SELECT_MULTI && i == current) {
+					Rect2 r = rcache;
+					r.position += base_ofs;
+					r.position.y -= vseparation / 2;
+					r.size.y += vseparation;
+					r.position.x -= hseparation / 2;
+					r.size.x += hseparation;
 
 					if (rtl) {
-						text_ofs.x = size.width - text_ofs.x - max_len;
+						r.position.x = size.width - r.position.x - r.size.x;
 					}
 
-					items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+					draw_style_box(cursor, r);
+				}
+			}
 
-					if (outline_size > 0 && font_outline_color.a > 0) {
-						items[i].text_buf->draw_outline(get_canvas_item(), text_ofs, outline_size, font_outline_color);
-					}
-
-					items[i].text_buf->draw(get_canvas_item(), text_ofs, modulate);
-				} else {
-					if (fixed_column_width > 0) {
-						size2.x = MIN(size2.x, fixed_column_width);
-					}
-
-					if (icon_mode == ICON_MODE_TOP) {
-						text_ofs.x += (items[i].rect_cache.size.width - size2.x) / 2;
+			int first_visible_separator = 0;
+			{
+				// do a binary search to find the first separator that is below clip_position.y
+				int lo = 0;
+				int hi = separators.size();
+				while (lo < hi) {
+					const int mid = (lo + hi) / 2;
+					if (separators[mid] < clip.position.y) {
+						lo = mid + 1;
 					} else {
-						text_ofs.y += (items[i].rect_cache.size.height - size2.y) / 2;
+						hi = mid;
 					}
-
-					text_ofs += base_ofs;
-					text_ofs += items[i].rect_cache.position;
-
-					if (rtl) {
-						text_ofs.x = size.width - text_ofs.x - max_len;
-					}
-
-					items.write[i].text_buf->set_width(max_len);
-
-					if (rtl) {
-						items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
-					} else {
-						items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_LEFT);
-					}
-
-					if (outline_size > 0 && font_outline_color.a > 0) {
-						items[i].text_buf->draw_outline(get_canvas_item(), text_ofs, outline_size, font_outline_color);
-					}
-
-					items[i].text_buf->draw(get_canvas_item(), text_ofs, modulate);
 				}
+				first_visible_separator = lo;
 			}
 
-			if (select_mode == SELECT_MULTI && i == current) {
-				Rect2 r = rcache;
-				r.position += base_ofs;
-				r.position.y -= vseparation / 2;
-				r.size.y += vseparation;
-				r.position.x -= hseparation / 2;
-				r.size.x += hseparation;
-
-				if (rtl) {
-					r.position.x = size.width - r.position.x - r.size.x;
+			for (int i = first_visible_separator; i < separators.size(); i++) {
+				if (separators[i] > clip.position.y + clip.size.y) {
+					break; // done
 				}
 
-				draw_style_box(cursor, r);
+				const int y = base_ofs.y + separators[i];
+				draw_line(Vector2(bg->get_margin(SIDE_LEFT), y), Vector2(width, y), guide_color);
 			}
-		}
-
-		int first_visible_separator = 0;
-		{
-			// do a binary search to find the first separator that is below clip_position.y
-			int lo = 0;
-			int hi = separators.size();
-			while (lo < hi) {
-				const int mid = (lo + hi) / 2;
-				if (separators[mid] < clip.position.y) {
-					lo = mid + 1;
-				} else {
-					hi = mid;
-				}
-			}
-			first_visible_separator = lo;
-		}
-
-		for (int i = first_visible_separator; i < separators.size(); i++) {
-			if (separators[i] > clip.position.y + clip.size.y) {
-				break; // done
-			}
-
-			const int y = base_ofs.y + separators[i];
-			draw_line(Vector2(bg->get_margin(SIDE_LEFT), y), Vector2(width, y), guide_color);
-		}
+		} break;
 	}
 }
 

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -656,31 +656,37 @@ void LineEdit::_notification(int p_what) {
 			}
 		} break;
 #endif
+
 		case NOTIFICATION_RESIZED: {
 			_fit_to_width();
 			scroll_offset = 0;
 			set_caret_column(get_caret_column());
 		} break;
+
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
 			_shape();
 			update();
 		} break;
+
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			placeholder_translated = atr(placeholder);
 			_shape();
 			update();
 		} break;
+
 		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
 			window_has_focus = true;
 			draw_caret = true;
 			update();
 		} break;
+
 		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
 			window_has_focus = false;
 			draw_caret = false;
 			update();
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			if ((!has_focus() && !(menu && menu->has_focus()) && !caret_force_displayed) || !window_has_focus) {
 				draw_caret = false;
@@ -923,6 +929,7 @@ void LineEdit::_notification(int p_what) {
 				}
 			}
 		} break;
+
 		case NOTIFICATION_FOCUS_ENTER: {
 			if (!caret_force_displayed) {
 				if (caret_blink_enabled) {
@@ -942,6 +949,7 @@ void LineEdit::_notification(int p_what) {
 
 			show_virtual_keyboard();
 		} break;
+
 		case NOTIFICATION_FOCUS_EXIT: {
 			if (caret_blink_enabled && !caret_force_displayed) {
 				caret_blink_timer->stop();
@@ -964,6 +972,7 @@ void LineEdit::_notification(int p_what) {
 				deselect();
 			}
 		} break;
+
 		case MainLoop::NOTIFICATION_OS_IME_UPDATE: {
 			if (has_focus()) {
 				ime_text = DisplayServer::get_singleton()->ime_get_text();
@@ -974,10 +983,12 @@ void LineEdit::_notification(int p_what) {
 				update();
 			}
 		} break;
-		case Control::NOTIFICATION_DRAG_BEGIN: {
+
+		case NOTIFICATION_DRAG_BEGIN: {
 			drag_action = true;
 		} break;
-		case Control::NOTIFICATION_DRAG_END: {
+
+		case NOTIFICATION_DRAG_END: {
 			if (is_drag_successful()) {
 				if (selection.drag_attempt) {
 					selection.drag_attempt = false;

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "link_button.h"
+
 #include "core/string/translation.h"
 
 void LinkButton::_shape() {
@@ -148,18 +149,20 @@ void LinkButton::_notification(int p_what) {
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			xl_text = atr(text);
 			_shape();
-
 			update_minimum_size();
 			update();
 		} break;
+
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			update();
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			_shape();
 			update_minimum_size();
 			update();
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
 			Size2 size = get_size();
@@ -230,7 +233,6 @@ void LinkButton::_notification(int p_what) {
 					draw_line(Vector2(0, y), Vector2(width, y), color, text_buf->get_line_underline_thickness());
 				}
 			}
-
 		} break;
 	}
 }

--- a/scene/gui/margin_container.cpp
+++ b/scene/gui/margin_container.cpp
@@ -107,6 +107,7 @@ void MarginContainer::_notification(int p_what) {
 				fit_child_in_rect(c, Rect2(margin_left, margin_top, w, h));
 			}
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			update_minimum_size();
 		} break;

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -139,11 +139,13 @@ void MenuButton::_notification(int p_what) {
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			popup->set_layout_direction((Window::LayoutDirection)get_layout_direction());
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible_in_tree()) {
 				popup->hide();
 			}
 		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			Vector2i mouse_pos = DisplayServer::get_singleton()->mouse_get_position() - mouse_pos_adjusted;
 			MenuButton *menu_btn_other = Object::cast_to<MenuButton>(get_viewport()->gui_find_control(mouse_pos));

--- a/scene/gui/nine_patch_rect.cpp
+++ b/scene/gui/nine_patch_rect.cpp
@@ -34,18 +34,20 @@
 #include "servers/rendering_server.h"
 
 void NinePatchRect::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		if (texture.is_null()) {
-			return;
-		}
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			if (texture.is_null()) {
+				return;
+			}
 
-		Rect2 rect = Rect2(Point2(), get_size());
-		Rect2 src_rect = region_rect;
+			Rect2 rect = Rect2(Point2(), get_size());
+			Rect2 src_rect = region_rect;
 
-		texture->get_rect_region(rect, src_rect, rect, src_rect);
+			texture->get_rect_region(rect, src_rect, rect, src_rect);
 
-		RID ci = get_canvas_item();
-		RS::get_singleton()->canvas_item_add_nine_patch(ci, rect, src_rect, texture->get_rid(), Vector2(margin[SIDE_LEFT], margin[SIDE_TOP]), Vector2(margin[SIDE_RIGHT], margin[SIDE_BOTTOM]), RS::NinePatchAxisMode(axis_h), RS::NinePatchAxisMode(axis_v), draw_center);
+			RID ci = get_canvas_item();
+			RS::get_singleton()->canvas_item_add_nine_patch(ci, rect, src_rect, texture->get_rid(), Vector2(margin[SIDE_LEFT], margin[SIDE_TOP]), Vector2(margin[SIDE_RIGHT], margin[SIDE_BOTTOM]), RS::NinePatchAxisMode(axis_h), RS::NinePatchAxisMode(axis_v), draw_center);
+		} break;
 	}
 }
 

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -91,6 +91,7 @@ void OptionButton::_notification(int p_what) {
 			}
 			arrow->draw(ci, ofs, clr);
 		} break;
+
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			popup->set_layout_direction((Window::LayoutDirection)get_layout_direction());
@@ -107,6 +108,7 @@ void OptionButton::_notification(int p_what) {
 				}
 			}
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible_in_tree()) {
 				popup->hide();

--- a/scene/gui/panel.cpp
+++ b/scene/gui/panel.cpp
@@ -31,10 +31,12 @@
 #include "panel.h"
 
 void Panel::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		RID ci = get_canvas_item();
-		Ref<StyleBox> style = get_theme_stylebox(SNAME("panel"));
-		style->draw(ci, Rect2(Point2(), get_size()));
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			RID ci = get_canvas_item();
+			Ref<StyleBox> style = get_theme_stylebox(SNAME("panel"));
+			style->draw(ci, Rect2(Point2(), get_size()));
+		} break;
 	}
 }
 

--- a/scene/gui/panel_container.cpp
+++ b/scene/gui/panel_container.cpp
@@ -79,46 +79,48 @@ Vector<int> PanelContainer::get_allowed_size_flags_vertical() const {
 }
 
 void PanelContainer::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		RID ci = get_canvas_item();
-		Ref<StyleBox> style;
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			RID ci = get_canvas_item();
+			Ref<StyleBox> style;
 
-		if (has_theme_stylebox(SNAME("panel"))) {
-			style = get_theme_stylebox(SNAME("panel"));
-		} else {
-			style = get_theme_stylebox(SNAME("panel"), SNAME("PanelContainer"));
-		}
-
-		style->draw(ci, Rect2(Point2(), get_size()));
-	}
-
-	if (p_what == NOTIFICATION_SORT_CHILDREN) {
-		Ref<StyleBox> style;
-
-		if (has_theme_stylebox(SNAME("panel"))) {
-			style = get_theme_stylebox(SNAME("panel"));
-		} else {
-			style = get_theme_stylebox(SNAME("panel"), SNAME("PanelContainer"));
-		}
-
-		Size2 size = get_size();
-		Point2 ofs;
-		if (style.is_valid()) {
-			size -= style->get_minimum_size();
-			ofs += style->get_offset();
-		}
-
-		for (int i = 0; i < get_child_count(); i++) {
-			Control *c = Object::cast_to<Control>(get_child(i));
-			if (!c || !c->is_visible_in_tree()) {
-				continue;
-			}
-			if (c->is_set_as_top_level()) {
-				continue;
+			if (has_theme_stylebox(SNAME("panel"))) {
+				style = get_theme_stylebox(SNAME("panel"));
+			} else {
+				style = get_theme_stylebox(SNAME("panel"), SNAME("PanelContainer"));
 			}
 
-			fit_child_in_rect(c, Rect2(ofs, size));
-		}
+			style->draw(ci, Rect2(Point2(), get_size()));
+		} break;
+
+		case NOTIFICATION_SORT_CHILDREN: {
+			Ref<StyleBox> style;
+
+			if (has_theme_stylebox(SNAME("panel"))) {
+				style = get_theme_stylebox(SNAME("panel"));
+			} else {
+				style = get_theme_stylebox(SNAME("panel"), SNAME("PanelContainer"));
+			}
+
+			Size2 size = get_size();
+			Point2 ofs;
+			if (style.is_valid()) {
+				size -= style->get_minimum_size();
+				ofs += style->get_offset();
+			}
+
+			for (int i = 0; i < get_child_count(); i++) {
+				Control *c = Object::cast_to<Control>(get_child(i));
+				if (!c || !c->is_visible_in_tree()) {
+					continue;
+				}
+				if (c->is_set_as_top_level()) {
+					continue;
+				}
+
+				fit_child_in_rect(c, Rect2(ofs, size));
+			}
+		} break;
 	}
 }
 

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -74,19 +74,19 @@ void Popup::_notification(int p_what) {
 				emit_signal(SNAME("popup_hide"));
 				popped_up = false;
 			}
-
 		} break;
+
 		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
 			if (has_focus()) {
 				popped_up = true;
 			}
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			_deinitialize_visible_parents();
 		} break;
-		case NOTIFICATION_WM_CLOSE_REQUEST: {
-			_close_pressed();
-		} break;
+
+		case NOTIFICATION_WM_CLOSE_REQUEST:
 		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
 			_close_pressed();
 		} break;
@@ -241,13 +241,20 @@ void PopupPanel::_update_child_rects() {
 }
 
 void PopupPanel::_notification(int p_what) {
-	if (p_what == NOTIFICATION_THEME_CHANGED) {
-		panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), get_class_name()));
-	} else if (p_what == NOTIFICATION_READY || p_what == NOTIFICATION_ENTER_TREE) {
-		panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), get_class_name()));
-		_update_child_rects();
-	} else if (p_what == NOTIFICATION_WM_SIZE_CHANGED) {
-		_update_child_rects();
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), get_class_name()));
+		} break;
+
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_READY: {
+			panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), get_class_name()));
+			_update_child_rects();
+		} break;
+
+		case NOTIFICATION_WM_SIZE_CHANGED: {
+			_update_child_rects();
+		} break;
 	}
 }
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -736,6 +736,7 @@ void PopupMenu::_notification(int p_what) {
 				set_submenu_popup_delay(pm_delay);
 			}
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED:
 		case Control::NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED: {
@@ -748,23 +749,25 @@ void PopupMenu::_notification(int p_what) {
 			child_controls_changed();
 			control->update();
 		} break;
+
 		case NOTIFICATION_WM_MOUSE_ENTER: {
 			grab_focus();
 		} break;
+
 		case NOTIFICATION_WM_MOUSE_EXIT: {
 			if (mouse_over >= 0 && (items[mouse_over].submenu.is_empty() || submenu_over != -1)) {
 				mouse_over = -1;
 				control->update();
 			}
 		} break;
+
 		case NOTIFICATION_POST_POPUP: {
 			initial_button_mask = Input::get_singleton()->get_mouse_button_mask();
 			during_grabbed_click = (bool)initial_button_mask;
 		} break;
-		case NOTIFICATION_WM_SIZE_CHANGED: {
-		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
-			//only used when using operating system windows
+			// Only used when using operating system windows.
 			if (!is_embedded() && autohide_areas.size()) {
 				Point2 mouse_pos = DisplayServer::get_singleton()->mouse_get_position();
 				mouse_pos -= get_position();
@@ -777,6 +780,7 @@ void PopupMenu::_notification(int p_what) {
 				}
 			}
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (!is_visible()) {
 				if (mouse_over >= 0) {

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "progress_bar.h"
+
 #include "scene/resources/text_line.h"
 
 Size2 ProgressBar::get_minimum_size() const {
@@ -52,36 +53,38 @@ Size2 ProgressBar::get_minimum_size() const {
 }
 
 void ProgressBar::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		Ref<StyleBox> bg = get_theme_stylebox(SNAME("bg"));
-		Ref<StyleBox> fg = get_theme_stylebox(SNAME("fg"));
-		Ref<Font> font = get_theme_font(SNAME("font"));
-		int font_size = get_theme_font_size(SNAME("font_size"));
-		Color font_color = get_theme_color(SNAME("font_color"));
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			Ref<StyleBox> bg = get_theme_stylebox(SNAME("bg"));
+			Ref<StyleBox> fg = get_theme_stylebox(SNAME("fg"));
+			Ref<Font> font = get_theme_font(SNAME("font"));
+			int font_size = get_theme_font_size(SNAME("font_size"));
+			Color font_color = get_theme_color(SNAME("font_color"));
 
-		draw_style_box(bg, Rect2(Point2(), get_size()));
-		float r = get_as_ratio();
-		int mp = fg->get_minimum_size().width;
-		int p = r * (get_size().width - mp);
-		if (p > 0) {
-			if (is_layout_rtl()) {
-				draw_style_box(fg, Rect2(Point2(p, 0), Size2(fg->get_minimum_size().width, get_size().height)));
-			} else {
-				draw_style_box(fg, Rect2(Point2(0, 0), Size2(p + fg->get_minimum_size().width, get_size().height)));
+			draw_style_box(bg, Rect2(Point2(), get_size()));
+			float r = get_as_ratio();
+			int mp = fg->get_minimum_size().width;
+			int p = r * (get_size().width - mp);
+			if (p > 0) {
+				if (is_layout_rtl()) {
+					draw_style_box(fg, Rect2(Point2(p, 0), Size2(fg->get_minimum_size().width, get_size().height)));
+				} else {
+					draw_style_box(fg, Rect2(Point2(0, 0), Size2(p + fg->get_minimum_size().width, get_size().height)));
+				}
 			}
-		}
 
-		if (percent_visible) {
-			String txt = TS->format_number(itos(int(get_as_ratio() * 100))) + TS->percent_sign();
-			TextLine tl = TextLine(txt, font, font_size);
-			Vector2 text_pos = (Point2(get_size().width - tl.get_size().x, get_size().height - tl.get_size().y) / 2).round();
-			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
-			int outline_size = get_theme_constant(SNAME("outline_size"));
-			if (outline_size > 0 && font_outline_color.a > 0) {
-				tl.draw_outline(get_canvas_item(), text_pos, outline_size, font_outline_color);
+			if (percent_visible) {
+				String txt = TS->format_number(itos(int(get_as_ratio() * 100))) + TS->percent_sign();
+				TextLine tl = TextLine(txt, font, font_size);
+				Vector2 text_pos = (Point2(get_size().width - tl.get_size().x, get_size().height - tl.get_size().y) / 2).round();
+				Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+				int outline_size = get_theme_constant(SNAME("outline_size"));
+				if (outline_size > 0 && font_outline_color.a > 0) {
+					tl.draw_outline(get_canvas_item(), text_pos, outline_size, font_outline_color);
+				}
+				tl.draw(get_canvas_item(), text_pos, font_color);
 			}
-			tl.draw(get_canvas_item(), text_pos, font_color);
-		}
+		} break;
 	}
 }
 

--- a/scene/gui/reference_rect.cpp
+++ b/scene/gui/reference_rect.cpp
@@ -33,13 +33,15 @@
 #include "core/config/engine.h"
 
 void ReferenceRect::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		if (!is_inside_tree()) {
-			return;
-		}
-		if (Engine::get_singleton()->is_editor_hint() || !editor_only) {
-			draw_rect(Rect2(Point2(), get_size()), border_color, false, border_width);
-		}
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			if (!is_inside_tree()) {
+				return;
+			}
+			if (Engine::get_singleton()->is_editor_hint() || !editor_only) {
+				draw_rect(Rect2(Point2(), get_size()), border_color, false, border_width);
+			}
+		} break;
 	}
 }
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1502,15 +1502,17 @@ void RichTextLabel::_notification(int p_what) {
 				update();
 			}
 		} break;
+
 		case NOTIFICATION_RESIZED: {
 			main->first_resized_line = 0; //invalidate ALL
 			update();
-
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			main->first_invalid_font_line = 0; //invalidate ALL
 			update();
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			if (!text.is_empty()) {
 				set_text(text);
@@ -1519,11 +1521,13 @@ void RichTextLabel::_notification(int p_what) {
 			main->first_invalid_line = 0; //invalidate ALL
 			update();
 		} break;
+
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			main->first_invalid_line = 0; //invalidate ALL
 			update();
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			_validate_line_caches(main);
 			_update_scroll();
@@ -1578,6 +1582,7 @@ void RichTextLabel::_notification(int p_what) {
 				from_line++;
 			}
 		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (is_visible_in_tree()) {
 				double dt = get_process_delta_time();
@@ -1585,12 +1590,14 @@ void RichTextLabel::_notification(int p_what) {
 				update();
 			}
 		} break;
+
 		case NOTIFICATION_FOCUS_EXIT: {
 			if (deselect_on_focus_loss_enabled) {
 				selection.active = false;
 				update();
 			}
 		} break;
+
 		case NOTIFICATION_DRAG_END: {
 			selection.drag_attempt = false;
 		} break;

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -218,195 +218,198 @@ void ScrollBar::gui_input(const Ref<InputEvent> &p_event) {
 }
 
 void ScrollBar::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		RID ci = get_canvas_item();
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			RID ci = get_canvas_item();
 
-		Ref<Texture2D> decr, incr;
+			Ref<Texture2D> decr, incr;
 
-		if (decr_active) {
-			decr = get_theme_icon(SNAME("decrement_pressed"));
-		} else if (highlight == HIGHLIGHT_DECR) {
-			decr = get_theme_icon(SNAME("decrement_highlight"));
-		} else {
-			decr = get_theme_icon(SNAME("decrement"));
-		}
+			if (decr_active) {
+				decr = get_theme_icon(SNAME("decrement_pressed"));
+			} else if (highlight == HIGHLIGHT_DECR) {
+				decr = get_theme_icon(SNAME("decrement_highlight"));
+			} else {
+				decr = get_theme_icon(SNAME("decrement"));
+			}
 
-		if (incr_active) {
-			incr = get_theme_icon(SNAME("increment_pressed"));
-		} else if (highlight == HIGHLIGHT_INCR) {
-			incr = get_theme_icon(SNAME("increment_highlight"));
-		} else {
-			incr = get_theme_icon(SNAME("increment"));
-		}
+			if (incr_active) {
+				incr = get_theme_icon(SNAME("increment_pressed"));
+			} else if (highlight == HIGHLIGHT_INCR) {
+				incr = get_theme_icon(SNAME("increment_highlight"));
+			} else {
+				incr = get_theme_icon(SNAME("increment"));
+			}
 
-		Ref<StyleBox> bg = has_focus() ? get_theme_stylebox(SNAME("scroll_focus")) : get_theme_stylebox(SNAME("scroll"));
+			Ref<StyleBox> bg = has_focus() ? get_theme_stylebox(SNAME("scroll_focus")) : get_theme_stylebox(SNAME("scroll"));
 
-		Ref<StyleBox> grabber;
-		if (drag.active) {
-			grabber = get_theme_stylebox(SNAME("grabber_pressed"));
-		} else if (highlight == HIGHLIGHT_RANGE) {
-			grabber = get_theme_stylebox(SNAME("grabber_highlight"));
-		} else {
-			grabber = get_theme_stylebox(SNAME("grabber"));
-		}
+			Ref<StyleBox> grabber;
+			if (drag.active) {
+				grabber = get_theme_stylebox(SNAME("grabber_pressed"));
+			} else if (highlight == HIGHLIGHT_RANGE) {
+				grabber = get_theme_stylebox(SNAME("grabber_highlight"));
+			} else {
+				grabber = get_theme_stylebox(SNAME("grabber"));
+			}
 
-		Point2 ofs;
+			Point2 ofs;
 
-		decr->draw(ci, Point2());
+			decr->draw(ci, Point2());
 
-		if (orientation == HORIZONTAL) {
-			ofs.x += decr->get_width();
-		} else {
-			ofs.y += decr->get_height();
-		}
+			if (orientation == HORIZONTAL) {
+				ofs.x += decr->get_width();
+			} else {
+				ofs.y += decr->get_height();
+			}
 
-		Size2 area = get_size();
+			Size2 area = get_size();
 
-		if (orientation == HORIZONTAL) {
-			area.width -= incr->get_width() + decr->get_width();
-		} else {
-			area.height -= incr->get_height() + decr->get_height();
-		}
+			if (orientation == HORIZONTAL) {
+				area.width -= incr->get_width() + decr->get_width();
+			} else {
+				area.height -= incr->get_height() + decr->get_height();
+			}
 
-		bg->draw(ci, Rect2(ofs, area));
+			bg->draw(ci, Rect2(ofs, area));
 
-		if (orientation == HORIZONTAL) {
-			ofs.width += area.width;
-		} else {
-			ofs.height += area.height;
-		}
+			if (orientation == HORIZONTAL) {
+				ofs.width += area.width;
+			} else {
+				ofs.height += area.height;
+			}
 
-		incr->draw(ci, ofs);
-		Rect2 grabber_rect;
+			incr->draw(ci, ofs);
+			Rect2 grabber_rect;
 
-		if (orientation == HORIZONTAL) {
-			grabber_rect.size.width = get_grabber_size();
-			grabber_rect.size.height = get_size().height;
-			grabber_rect.position.y = 0;
-			grabber_rect.position.x = get_grabber_offset() + decr->get_width() + bg->get_margin(SIDE_LEFT);
-		} else {
-			grabber_rect.size.width = get_size().width;
-			grabber_rect.size.height = get_grabber_size();
-			grabber_rect.position.y = get_grabber_offset() + decr->get_height() + bg->get_margin(SIDE_TOP);
-			grabber_rect.position.x = 0;
-		}
+			if (orientation == HORIZONTAL) {
+				grabber_rect.size.width = get_grabber_size();
+				grabber_rect.size.height = get_size().height;
+				grabber_rect.position.y = 0;
+				grabber_rect.position.x = get_grabber_offset() + decr->get_width() + bg->get_margin(SIDE_LEFT);
+			} else {
+				grabber_rect.size.width = get_size().width;
+				grabber_rect.size.height = get_grabber_size();
+				grabber_rect.position.y = get_grabber_offset() + decr->get_height() + bg->get_margin(SIDE_TOP);
+				grabber_rect.position.x = 0;
+			}
 
-		grabber->draw(ci, grabber_rect);
-	}
+			grabber->draw(ci, grabber_rect);
+		} break;
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		if (has_node(drag_node_path)) {
-			Node *n = get_node(drag_node_path);
-			drag_node = Object::cast_to<Control>(n);
-		}
+		case NOTIFICATION_ENTER_TREE: {
+			if (has_node(drag_node_path)) {
+				Node *n = get_node(drag_node_path);
+				drag_node = Object::cast_to<Control>(n);
+			}
 
-		if (drag_node) {
-			drag_node->connect("gui_input", callable_mp(this, &ScrollBar::_drag_node_input));
-			drag_node->connect("tree_exiting", callable_mp(this, &ScrollBar::_drag_node_exit), varray(), CONNECT_ONESHOT);
-		}
-	}
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		if (drag_node) {
-			drag_node->disconnect("gui_input", callable_mp(this, &ScrollBar::_drag_node_input));
-			drag_node->disconnect("tree_exiting", callable_mp(this, &ScrollBar::_drag_node_exit));
-		}
+			if (drag_node) {
+				drag_node->connect("gui_input", callable_mp(this, &ScrollBar::_drag_node_input));
+				drag_node->connect("tree_exiting", callable_mp(this, &ScrollBar::_drag_node_exit), varray(), CONNECT_ONESHOT);
+			}
+		} break;
 
-		drag_node = nullptr;
-	}
+		case NOTIFICATION_EXIT_TREE: {
+			if (drag_node) {
+				drag_node->disconnect("gui_input", callable_mp(this, &ScrollBar::_drag_node_input));
+				drag_node->disconnect("tree_exiting", callable_mp(this, &ScrollBar::_drag_node_exit));
+			}
 
-	if (p_what == NOTIFICATION_INTERNAL_PHYSICS_PROCESS) {
-		if (scrolling) {
-			if (get_value() != target_scroll) {
-				double target = target_scroll - get_value();
-				double dist = sqrt(target * target);
-				double vel = ((target / dist) * 500) * get_physics_process_delta_time();
+			drag_node = nullptr;
+		} break;
 
-				if (Math::abs(vel) >= dist) {
-					set_value(target_scroll);
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			if (scrolling) {
+				if (get_value() != target_scroll) {
+					double target = target_scroll - get_value();
+					double dist = sqrt(target * target);
+					double vel = ((target / dist) * 500) * get_physics_process_delta_time();
+
+					if (Math::abs(vel) >= dist) {
+						set_value(target_scroll);
+						scrolling = false;
+						set_physics_process_internal(false);
+					} else {
+						set_value(get_value() + vel);
+					}
+				} else {
 					scrolling = false;
 					set_physics_process_internal(false);
+				}
+
+			} else if (drag_node_touching) {
+				if (drag_node_touching_deaccel) {
+					Vector2 pos = Vector2(orientation == HORIZONTAL ? get_value() : 0, orientation == VERTICAL ? get_value() : 0);
+					pos += drag_node_speed * get_physics_process_delta_time();
+
+					bool turnoff = false;
+
+					if (orientation == HORIZONTAL) {
+						if (pos.x < 0) {
+							pos.x = 0;
+							turnoff = true;
+						}
+
+						if (pos.x > (get_max() - get_page())) {
+							pos.x = get_max() - get_page();
+							turnoff = true;
+						}
+
+						set_value(pos.x);
+
+						float sgn_x = drag_node_speed.x < 0 ? -1 : 1;
+						float val_x = Math::abs(drag_node_speed.x);
+						val_x -= 1000 * get_physics_process_delta_time();
+
+						if (val_x < 0) {
+							turnoff = true;
+						}
+
+						drag_node_speed.x = sgn_x * val_x;
+
+					} else {
+						if (pos.y < 0) {
+							pos.y = 0;
+							turnoff = true;
+						}
+
+						if (pos.y > (get_max() - get_page())) {
+							pos.y = get_max() - get_page();
+							turnoff = true;
+						}
+
+						set_value(pos.y);
+
+						float sgn_y = drag_node_speed.y < 0 ? -1 : 1;
+						float val_y = Math::abs(drag_node_speed.y);
+						val_y -= 1000 * get_physics_process_delta_time();
+
+						if (val_y < 0) {
+							turnoff = true;
+						}
+						drag_node_speed.y = sgn_y * val_y;
+					}
+
+					if (turnoff) {
+						set_physics_process_internal(false);
+						drag_node_touching = false;
+						drag_node_touching_deaccel = false;
+					}
+
 				} else {
-					set_value(get_value() + vel);
+					if (time_since_motion == 0 || time_since_motion > 0.1) {
+						Vector2 diff = drag_node_accum - last_drag_node_accum;
+						last_drag_node_accum = drag_node_accum;
+						drag_node_speed = diff / get_physics_process_delta_time();
+					}
+
+					time_since_motion += get_physics_process_delta_time();
 				}
-			} else {
-				scrolling = false;
-				set_physics_process_internal(false);
 			}
+		} break;
 
-		} else if (drag_node_touching) {
-			if (drag_node_touching_deaccel) {
-				Vector2 pos = Vector2(orientation == HORIZONTAL ? get_value() : 0, orientation == VERTICAL ? get_value() : 0);
-				pos += drag_node_speed * get_physics_process_delta_time();
-
-				bool turnoff = false;
-
-				if (orientation == HORIZONTAL) {
-					if (pos.x < 0) {
-						pos.x = 0;
-						turnoff = true;
-					}
-
-					if (pos.x > (get_max() - get_page())) {
-						pos.x = get_max() - get_page();
-						turnoff = true;
-					}
-
-					set_value(pos.x);
-
-					float sgn_x = drag_node_speed.x < 0 ? -1 : 1;
-					float val_x = Math::abs(drag_node_speed.x);
-					val_x -= 1000 * get_physics_process_delta_time();
-
-					if (val_x < 0) {
-						turnoff = true;
-					}
-
-					drag_node_speed.x = sgn_x * val_x;
-
-				} else {
-					if (pos.y < 0) {
-						pos.y = 0;
-						turnoff = true;
-					}
-
-					if (pos.y > (get_max() - get_page())) {
-						pos.y = get_max() - get_page();
-						turnoff = true;
-					}
-
-					set_value(pos.y);
-
-					float sgn_y = drag_node_speed.y < 0 ? -1 : 1;
-					float val_y = Math::abs(drag_node_speed.y);
-					val_y -= 1000 * get_physics_process_delta_time();
-
-					if (val_y < 0) {
-						turnoff = true;
-					}
-					drag_node_speed.y = sgn_y * val_y;
-				}
-
-				if (turnoff) {
-					set_physics_process_internal(false);
-					drag_node_touching = false;
-					drag_node_touching_deaccel = false;
-				}
-
-			} else {
-				if (time_since_motion == 0 || time_since_motion > 0.1) {
-					Vector2 diff = drag_node_accum - last_drag_node_accum;
-					last_drag_node_accum = drag_node_accum;
-					drag_node_speed = diff / get_physics_process_delta_time();
-				}
-
-				time_since_motion += get_physics_process_delta_time();
-			}
-		}
-	}
-
-	if (p_what == NOTIFICATION_MOUSE_EXIT) {
-		highlight = HIGHLIGHT_NONE;
-		update();
+		case NOTIFICATION_MOUSE_EXIT: {
+			highlight = HIGHLIGHT_NONE;
+			update();
+		} break;
 	}
 }
 

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -316,97 +316,102 @@ void ScrollContainer::_update_dimensions() {
 }
 
 void ScrollContainer::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED || p_what == NOTIFICATION_TRANSLATION_CHANGED) {
-		_updating_scrollbars = true;
-		call_deferred(SNAME("_update_scrollbar_position"));
-	};
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			_updating_scrollbars = true;
+			call_deferred(SNAME("_update_scrollbar_position"));
+		} break;
 
-	if (p_what == NOTIFICATION_READY) {
-		Viewport *viewport = get_viewport();
-		ERR_FAIL_COND(!viewport);
-		viewport->connect("gui_focus_changed", callable_mp(this, &ScrollContainer::_gui_focus_changed));
-		_update_dimensions();
-	}
+		case NOTIFICATION_READY: {
+			Viewport *viewport = get_viewport();
+			ERR_FAIL_COND(!viewport);
+			viewport->connect("gui_focus_changed", callable_mp(this, &ScrollContainer::_gui_focus_changed));
+			_update_dimensions();
+		} break;
 
-	if (p_what == NOTIFICATION_SORT_CHILDREN) {
-		_update_dimensions();
-	};
+		case NOTIFICATION_SORT_CHILDREN: {
+			_update_dimensions();
+		} break;
 
-	if (p_what == NOTIFICATION_DRAW) {
-		Ref<StyleBox> sb = get_theme_stylebox(SNAME("bg"));
-		draw_style_box(sb, Rect2(Vector2(), get_size()));
+		case NOTIFICATION_DRAW: {
+			Ref<StyleBox> sb = get_theme_stylebox(SNAME("bg"));
+			draw_style_box(sb, Rect2(Vector2(), get_size()));
 
-		update_scrollbars();
-	}
+			update_scrollbars();
+		} break;
 
-	if (p_what == NOTIFICATION_INTERNAL_PHYSICS_PROCESS) {
-		if (drag_touching) {
-			if (drag_touching_deaccel) {
-				Vector2 pos = Vector2(h_scroll->get_value(), v_scroll->get_value());
-				pos += drag_speed * get_physics_process_delta_time();
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			if (drag_touching) {
+				if (drag_touching_deaccel) {
+					Vector2 pos = Vector2(h_scroll->get_value(), v_scroll->get_value());
+					pos += drag_speed * get_physics_process_delta_time();
 
-				bool turnoff_h = false;
-				bool turnoff_v = false;
+					bool turnoff_h = false;
+					bool turnoff_v = false;
 
-				if (pos.x < 0) {
-					pos.x = 0;
-					turnoff_h = true;
+					if (pos.x < 0) {
+						pos.x = 0;
+						turnoff_h = true;
+					}
+					if (pos.x > (h_scroll->get_max() - h_scroll->get_page())) {
+						pos.x = h_scroll->get_max() - h_scroll->get_page();
+						turnoff_h = true;
+					}
+
+					if (pos.y < 0) {
+						pos.y = 0;
+						turnoff_v = true;
+					}
+					if (pos.y > (v_scroll->get_max() - v_scroll->get_page())) {
+						pos.y = v_scroll->get_max() - v_scroll->get_page();
+						turnoff_v = true;
+					}
+
+					if (horizontal_scroll_mode != SCROLL_MODE_DISABLED) {
+						h_scroll->set_value(pos.x);
+					}
+					if (vertical_scroll_mode != SCROLL_MODE_DISABLED) {
+						v_scroll->set_value(pos.y);
+					}
+
+					float sgn_x = drag_speed.x < 0 ? -1 : 1;
+					float val_x = Math::abs(drag_speed.x);
+					val_x -= 1000 * get_physics_process_delta_time();
+
+					if (val_x < 0) {
+						turnoff_h = true;
+					}
+
+					float sgn_y = drag_speed.y < 0 ? -1 : 1;
+					float val_y = Math::abs(drag_speed.y);
+					val_y -= 1000 * get_physics_process_delta_time();
+
+					if (val_y < 0) {
+						turnoff_v = true;
+					}
+
+					drag_speed = Vector2(sgn_x * val_x, sgn_y * val_y);
+
+					if (turnoff_h && turnoff_v) {
+						_cancel_drag();
+					}
+
+				} else {
+					if (time_since_motion == 0 || time_since_motion > 0.1) {
+						Vector2 diff = drag_accum - last_drag_accum;
+						last_drag_accum = drag_accum;
+						drag_speed = diff / get_physics_process_delta_time();
+					}
+
+					time_since_motion += get_physics_process_delta_time();
 				}
-				if (pos.x > (h_scroll->get_max() - h_scroll->get_page())) {
-					pos.x = h_scroll->get_max() - h_scroll->get_page();
-					turnoff_h = true;
-				}
-
-				if (pos.y < 0) {
-					pos.y = 0;
-					turnoff_v = true;
-				}
-				if (pos.y > (v_scroll->get_max() - v_scroll->get_page())) {
-					pos.y = v_scroll->get_max() - v_scroll->get_page();
-					turnoff_v = true;
-				}
-
-				if (horizontal_scroll_mode != SCROLL_MODE_DISABLED) {
-					h_scroll->set_value(pos.x);
-				}
-				if (vertical_scroll_mode != SCROLL_MODE_DISABLED) {
-					v_scroll->set_value(pos.y);
-				}
-
-				float sgn_x = drag_speed.x < 0 ? -1 : 1;
-				float val_x = Math::abs(drag_speed.x);
-				val_x -= 1000 * get_physics_process_delta_time();
-
-				if (val_x < 0) {
-					turnoff_h = true;
-				}
-
-				float sgn_y = drag_speed.y < 0 ? -1 : 1;
-				float val_y = Math::abs(drag_speed.y);
-				val_y -= 1000 * get_physics_process_delta_time();
-
-				if (val_y < 0) {
-					turnoff_v = true;
-				}
-
-				drag_speed = Vector2(sgn_x * val_x, sgn_y * val_y);
-
-				if (turnoff_h && turnoff_v) {
-					_cancel_drag();
-				}
-
-			} else {
-				if (time_since_motion == 0 || time_since_motion > 0.1) {
-					Vector2 diff = drag_accum - last_drag_accum;
-					last_drag_accum = drag_accum;
-					drag_speed = diff / get_physics_process_delta_time();
-				}
-
-				time_since_motion += get_physics_process_delta_time();
 			}
-		}
+		} break;
 	}
-};
+}
 
 void ScrollContainer::update_scrollbars() {
 	Size2 size = get_size();

--- a/scene/gui/separator.cpp
+++ b/scene/gui/separator.cpp
@@ -52,7 +52,6 @@ void Separator::_notification(int p_what) {
 			} else {
 				style->draw(get_canvas_item(), Rect2(0, (size.y - ssize.y) / 2, size.x, ssize.y));
 			}
-
 		} break;
 	}
 }

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "slider.h"
+
 #include "core/os/keyboard.h"
 
 Size2 Slider::get_minimum_size() const {
@@ -150,19 +151,23 @@ void Slider::_notification(int p_what) {
 			update_minimum_size();
 			update();
 		} break;
+
 		case NOTIFICATION_MOUSE_ENTER: {
 			mouse_inside = true;
 			update();
 		} break;
+
 		case NOTIFICATION_MOUSE_EXIT: {
 			mouse_inside = false;
 			update();
 		} break;
-		case NOTIFICATION_VISIBILITY_CHANGED: // fallthrough
+
+		case NOTIFICATION_VISIBILITY_CHANGED:
 		case NOTIFICATION_EXIT_TREE: {
 			mouse_inside = false;
 			grab.active = false;
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			RID ci = get_canvas_item();
 			Size2i size = get_size();
@@ -209,7 +214,6 @@ void Slider::_notification(int p_what) {
 				}
 				grabber->draw(ci, Point2i(ratio * areasize, size.height / 2 - grabber->get_size().height / 2));
 			}
-
 		} break;
 	}
 }

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -196,34 +196,44 @@ inline void SpinBox::_adjust_width_for_icon(const Ref<Texture2D> &icon) {
 }
 
 void SpinBox::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		Ref<Texture2D> updown = get_theme_icon(SNAME("updown"));
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			Ref<Texture2D> updown = get_theme_icon(SNAME("updown"));
 
-		_adjust_width_for_icon(updown);
+			_adjust_width_for_icon(updown);
 
-		RID ci = get_canvas_item();
-		Size2i size = get_size();
+			RID ci = get_canvas_item();
+			Size2i size = get_size();
 
-		if (is_layout_rtl()) {
-			updown->draw(ci, Point2i(0, (size.height - updown->get_height()) / 2));
-		} else {
-			updown->draw(ci, Point2i(size.width - updown->get_width(), (size.height - updown->get_height()) / 2));
-		}
+			if (is_layout_rtl()) {
+				updown->draw(ci, Point2i(0, (size.height - updown->get_height()) / 2));
+			} else {
+				updown->draw(ci, Point2i(size.width - updown->get_width(), (size.height - updown->get_height()) / 2));
+			}
+		} break;
 
-	} else if (p_what == NOTIFICATION_FOCUS_EXIT) {
-		//_value_changed(0);
-	} else if (p_what == NOTIFICATION_ENTER_TREE) {
-		_adjust_width_for_icon(get_theme_icon(SNAME("updown")));
-		_value_changed(0);
-	} else if (p_what == NOTIFICATION_EXIT_TREE) {
-		_release_mouse();
-	} else if (p_what == NOTIFICATION_TRANSLATION_CHANGED) {
-		_value_changed(0);
-	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
-		call_deferred(SNAME("update_minimum_size"));
-		get_line_edit()->call_deferred(SNAME("update_minimum_size"));
-	} else if (p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED || p_what == NOTIFICATION_TRANSLATION_CHANGED) {
-		update();
+		case NOTIFICATION_ENTER_TREE: {
+			_adjust_width_for_icon(get_theme_icon(SNAME("updown")));
+			_value_changed(0);
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			_release_mouse();
+		} break;
+
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			_value_changed(0);
+			update();
+		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			call_deferred(SNAME("update_minimum_size"));
+			get_line_edit()->call_deferred(SNAME("update_minimum_size"));
+		} break;
+
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
+			update();
+		} break;
 	}
 }
 

--- a/scene/gui/split_container.cpp
+++ b/scene/gui/split_container.cpp
@@ -168,15 +168,18 @@ void SplitContainer::_notification(int p_what) {
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			queue_sort();
 		} break;
+
 		case NOTIFICATION_SORT_CHILDREN: {
 			_resort();
 		} break;
+
 		case NOTIFICATION_MOUSE_EXIT: {
 			mouse_inside = false;
 			if (get_theme_constant(SNAME("autohide"))) {
 				update();
 			}
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			if (!_getch(0) || !_getch(1)) {
 				return;
@@ -200,6 +203,7 @@ void SplitContainer::_notification(int p_what) {
 				draw_texture(tex, Point2i(middle_sep + (sep - tex->get_width()) / 2, (size.y - tex->get_height()) / 2));
 			}
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			update_minimum_size();
 		} break;

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -100,51 +100,54 @@ Vector<int> SubViewportContainer::get_allowed_size_flags_vertical() const {
 }
 
 void SubViewportContainer::_notification(int p_what) {
-	if (p_what == NOTIFICATION_RESIZED) {
-		if (!stretch) {
-			return;
-		}
-
-		for (int i = 0; i < get_child_count(); i++) {
-			SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
-			if (!c) {
-				continue;
+	switch (p_what) {
+		case NOTIFICATION_RESIZED: {
+			if (!stretch) {
+				return;
 			}
 
-			c->set_size(get_size() / shrink);
-		}
-	}
+			for (int i = 0; i < get_child_count(); i++) {
+				SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+				if (!c) {
+					continue;
+				}
 
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		for (int i = 0; i < get_child_count(); i++) {
-			SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
-			if (!c) {
-				continue;
+				c->set_size(get_size() / shrink);
 			}
+		} break;
 
-			if (is_visible_in_tree()) {
-				c->set_update_mode(SubViewport::UPDATE_ALWAYS);
-			} else {
-				c->set_update_mode(SubViewport::UPDATE_DISABLED);
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			for (int i = 0; i < get_child_count(); i++) {
+				SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+				if (!c) {
+					continue;
+				}
+
+				if (is_visible_in_tree()) {
+					c->set_update_mode(SubViewport::UPDATE_ALWAYS);
+				} else {
+					c->set_update_mode(SubViewport::UPDATE_DISABLED);
+				}
+
+				c->set_handle_input_locally(false); //do not handle input locally here
 			}
+		} break;
 
-			c->set_handle_input_locally(false); //do not handle input locally here
-		}
-	}
+		case NOTIFICATION_DRAW: {
+			for (int i = 0; i < get_child_count(); i++) {
+				SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
+				if (!c) {
+					continue;
+				}
 
-	if (p_what == NOTIFICATION_DRAW) {
-		for (int i = 0; i < get_child_count(); i++) {
-			SubViewport *c = Object::cast_to<SubViewport>(get_child(i));
-			if (!c) {
-				continue;
+				if (stretch) {
+					draw_texture_rect(c->get_texture(), Rect2(Vector2(), get_size()));
+				} else {
+					draw_texture_rect(c->get_texture(), Rect2(Vector2(), c->get_size()));
+				}
 			}
-
-			if (stretch) {
-				draw_texture_rect(c->get_texture(), Rect2(Vector2(), get_size()));
-			} else {
-				draw_texture_rect(c->get_texture(), Rect2(Vector2(), c->get_size()));
-			}
-		}
+		} break;
 	}
 }
 

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -32,7 +32,6 @@
 
 #include "core/object/message_queue.h"
 #include "core/string/translation.h"
-
 #include "scene/gui/box_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/texture_rect.h"
@@ -313,6 +312,7 @@ void TabBar::_notification(int p_what) {
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED: {
 			update();
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			for (int i = 0; i < tabs.size(); ++i) {
@@ -332,6 +332,7 @@ void TabBar::_notification(int p_what) {
 				ensure_tab_visible(current);
 			}
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			if (tabs.is_empty()) {
 				return;

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -32,7 +32,6 @@
 
 #include "core/object/message_queue.h"
 #include "core/string/translation.h"
-
 #include "scene/gui/box_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/texture_rect.h"
@@ -326,6 +325,7 @@ void TabContainer::_notification(int p_what) {
 				first_tab_cache--;
 			}
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			RID canvas = get_canvas_item();
 			Size2 size = get_size();
@@ -522,6 +522,7 @@ void TabContainer::_notification(int p_what) {
 				}
 			}
 		} break;
+
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -432,32 +432,38 @@ void TextEdit::_notification(int p_what) {
 			}
 			_update_wrap_at_column(true);
 		} break;
+
 		case NOTIFICATION_RESIZED: {
 			_update_scrollbars();
 			_update_wrap_at_column();
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible()) {
 				call_deferred(SNAME("_update_scrollbars"));
 				call_deferred(SNAME("_update_wrap_at_column"));
 			}
 		} break;
+
 		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
 		case NOTIFICATION_TRANSLATION_CHANGED:
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_caches();
 			_update_wrap_at_column(true);
 		} break;
+
 		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
 			window_has_focus = true;
 			draw_caret = true;
 			update();
 		} break;
+
 		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
 			window_has_focus = false;
 			draw_caret = false;
 			update();
 		} break;
+
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (scrolling && get_v_scroll() != target_v_scroll) {
 				double target_y = target_v_scroll - get_v_scroll();
@@ -479,6 +485,7 @@ void TextEdit::_notification(int p_what) {
 				set_physics_process_internal(false);
 			}
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			if (first_draw) {
 				// Size may not be the final one, so attempts to ensure caret was visible may have failed.
@@ -1427,6 +1434,7 @@ void TextEdit::_notification(int p_what) {
 				}
 			}
 		} break;
+
 		case NOTIFICATION_FOCUS_ENTER: {
 			if (caret_blink_enabled) {
 				caret_blink_timer->start();
@@ -1458,6 +1466,7 @@ void TextEdit::_notification(int p_what) {
 				DisplayServer::get_singleton()->virtual_keyboard_show(get_text(), get_global_rect(), true, -1, caret_start, caret_end);
 			}
 		} break;
+
 		case NOTIFICATION_FOCUS_EXIT: {
 			if (caret_blink_enabled) {
 				caret_blink_timer->stop();
@@ -1481,6 +1490,7 @@ void TextEdit::_notification(int p_what) {
 				deselect();
 			}
 		} break;
+
 		case MainLoop::NOTIFICATION_OS_IME_UPDATE: {
 			if (has_focus()) {
 				ime_text = DisplayServer::get_singleton()->ime_get_text();
@@ -1497,7 +1507,8 @@ void TextEdit::_notification(int p_what) {
 				update();
 			}
 		} break;
-		case Control::NOTIFICATION_DRAG_BEGIN: {
+
+		case NOTIFICATION_DRAG_BEGIN: {
 			selection.selecting_mode = SelectionMode::SELECTION_MODE_NONE;
 			drag_action = true;
 			dragging_minimap = false;
@@ -1505,7 +1516,8 @@ void TextEdit::_notification(int p_what) {
 			can_drag_minimap = false;
 			click_select_held->stop();
 		} break;
-		case Control::NOTIFICATION_DRAG_END: {
+
+		case NOTIFICATION_DRAG_END: {
 			if (is_drag_successful()) {
 				if (selection.drag_attempt) {
 					selection.drag_attempt = false;

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -29,84 +29,87 @@
 /*************************************************************************/
 
 #include "texture_rect.h"
+
 #include "core/core_string_names.h"
 #include "servers/rendering_server.h"
 
 void TextureRect::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		if (texture.is_null()) {
-			return;
-		}
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			if (texture.is_null()) {
+				return;
+			}
 
-		Size2 size;
-		Point2 offset;
-		Rect2 region;
-		bool tile = false;
+			Size2 size;
+			Point2 offset;
+			Rect2 region;
+			bool tile = false;
 
-		switch (stretch_mode) {
-			case STRETCH_SCALE: {
-				size = get_size();
-			} break;
-			case STRETCH_TILE: {
-				size = get_size();
-				tile = true;
-			} break;
-			case STRETCH_KEEP: {
-				size = texture->get_size();
-			} break;
-			case STRETCH_KEEP_CENTERED: {
-				offset = (get_size() - texture->get_size()) / 2;
-				size = texture->get_size();
-			} break;
-			case STRETCH_KEEP_ASPECT_CENTERED:
-			case STRETCH_KEEP_ASPECT: {
-				size = get_size();
-				int tex_width = texture->get_width() * size.height / texture->get_height();
-				int tex_height = size.height;
+			switch (stretch_mode) {
+				case STRETCH_SCALE: {
+					size = get_size();
+				} break;
+				case STRETCH_TILE: {
+					size = get_size();
+					tile = true;
+				} break;
+				case STRETCH_KEEP: {
+					size = texture->get_size();
+				} break;
+				case STRETCH_KEEP_CENTERED: {
+					offset = (get_size() - texture->get_size()) / 2;
+					size = texture->get_size();
+				} break;
+				case STRETCH_KEEP_ASPECT_CENTERED:
+				case STRETCH_KEEP_ASPECT: {
+					size = get_size();
+					int tex_width = texture->get_width() * size.height / texture->get_height();
+					int tex_height = size.height;
 
-				if (tex_width > size.width) {
-					tex_width = size.width;
-					tex_height = texture->get_height() * tex_width / texture->get_width();
-				}
+					if (tex_width > size.width) {
+						tex_width = size.width;
+						tex_height = texture->get_height() * tex_width / texture->get_width();
+					}
 
-				if (stretch_mode == STRETCH_KEEP_ASPECT_CENTERED) {
-					offset.x += (size.width - tex_width) / 2;
-					offset.y += (size.height - tex_height) / 2;
-				}
+					if (stretch_mode == STRETCH_KEEP_ASPECT_CENTERED) {
+						offset.x += (size.width - tex_width) / 2;
+						offset.y += (size.height - tex_height) / 2;
+					}
 
-				size.width = tex_width;
-				size.height = tex_height;
-			} break;
-			case STRETCH_KEEP_ASPECT_COVERED: {
-				size = get_size();
+					size.width = tex_width;
+					size.height = tex_height;
+				} break;
+				case STRETCH_KEEP_ASPECT_COVERED: {
+					size = get_size();
 
-				Size2 tex_size = texture->get_size();
-				Size2 scale_size(size.width / tex_size.width, size.height / tex_size.height);
-				float scale = scale_size.width > scale_size.height ? scale_size.width : scale_size.height;
-				Size2 scaled_tex_size = tex_size * scale;
+					Size2 tex_size = texture->get_size();
+					Size2 scale_size(size.width / tex_size.width, size.height / tex_size.height);
+					float scale = scale_size.width > scale_size.height ? scale_size.width : scale_size.height;
+					Size2 scaled_tex_size = tex_size * scale;
 
-				region.position = ((scaled_tex_size - size) / scale).abs() / 2.0f;
-				region.size = size / scale;
-			} break;
-		}
+					region.position = ((scaled_tex_size - size) / scale).abs() / 2.0f;
+					region.size = size / scale;
+				} break;
+			}
 
-		Ref<AtlasTexture> p_atlas = texture;
+			Ref<AtlasTexture> p_atlas = texture;
 
-		if (p_atlas.is_valid() && region.has_no_area()) {
-			Size2 scale_size(size.width / texture->get_width(), size.height / texture->get_height());
+			if (p_atlas.is_valid() && region.has_no_area()) {
+				Size2 scale_size(size.width / texture->get_width(), size.height / texture->get_height());
 
-			offset.width += hflip ? p_atlas->get_margin().get_position().width * scale_size.width * 2 : 0;
-			offset.height += vflip ? p_atlas->get_margin().get_position().height * scale_size.height * 2 : 0;
-		}
+				offset.width += hflip ? p_atlas->get_margin().get_position().width * scale_size.width * 2 : 0;
+				offset.height += vflip ? p_atlas->get_margin().get_position().height * scale_size.height * 2 : 0;
+			}
 
-		size.width *= hflip ? -1.0f : 1.0f;
-		size.height *= vflip ? -1.0f : 1.0f;
+			size.width *= hflip ? -1.0f : 1.0f;
+			size.height *= vflip ? -1.0f : 1.0f;
 
-		if (region.has_no_area()) {
-			draw_texture_rect(texture, Rect2(offset, size), tile);
-		} else {
-			draw_texture_rect_region(texture, Rect2(offset, size), region);
-		}
+			if (region.has_no_area()) {
+				draw_texture_rect(texture, Rect2(offset, size), tile);
+			} else {
+				draw_texture_rect_region(texture, Rect2(offset, size), region);
+			}
+		} break;
 	}
 }
 

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -37,9 +37,8 @@
 #include "core/os/os.h"
 #include "core/string/print_string.h"
 #include "core/string/translation.h"
+#include "scene/gui/box_container.h"
 #include "scene/main/window.h"
-
-#include "box_container.h"
 
 #include <limits.h>
 
@@ -3636,178 +3635,187 @@ int Tree::_get_title_button_height() const {
 }
 
 void Tree::_notification(int p_what) {
-	if (p_what == NOTIFICATION_FOCUS_ENTER) {
-		if (get_viewport()) {
-			focus_in_id = get_viewport()->get_processed_events_count();
-		}
-	}
-	if (p_what == NOTIFICATION_MOUSE_EXIT) {
-		if (cache.hover_type != Cache::CLICK_NONE) {
-			cache.hover_type = Cache::CLICK_NONE;
+	switch (p_what) {
+		case NOTIFICATION_FOCUS_ENTER: {
+			if (get_viewport()) {
+				focus_in_id = get_viewport()->get_processed_events_count();
+			}
+		} break;
+
+		case NOTIFICATION_MOUSE_EXIT: {
+			if (cache.hover_type != Cache::CLICK_NONE) {
+				cache.hover_type = Cache::CLICK_NONE;
+				update();
+			}
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			drag_touching = false;
+		} break;
+
+		case NOTIFICATION_ENTER_TREE: {
+			update_cache();
+		} break;
+
+		case NOTIFICATION_DRAG_END: {
+			drop_mode_flags = 0;
+			scrolling = false;
+			set_physics_process_internal(false);
 			update();
-		}
-	}
+		} break;
 
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		drag_touching = false;
-	}
+		case NOTIFICATION_DRAG_BEGIN: {
+			single_select_defer = nullptr;
+			if (cache.scroll_speed > 0) {
+				scrolling = true;
+				set_physics_process_internal(true);
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		update_cache();
-	}
-	if (p_what == NOTIFICATION_DRAG_END) {
-		drop_mode_flags = 0;
-		scrolling = false;
-		set_physics_process_internal(false);
-		update();
-	}
-	if (p_what == NOTIFICATION_DRAG_BEGIN) {
-		single_select_defer = nullptr;
-		if (cache.scroll_speed > 0) {
-			scrolling = true;
-			set_physics_process_internal(true);
-		}
-	}
-	if (p_what == NOTIFICATION_INTERNAL_PHYSICS_PROCESS) {
-		if (drag_touching) {
-			if (drag_touching_deaccel) {
-				float pos = v_scroll->get_value();
-				pos += drag_speed * get_physics_process_delta_time();
+		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
+			if (drag_touching) {
+				if (drag_touching_deaccel) {
+					float pos = v_scroll->get_value();
+					pos += drag_speed * get_physics_process_delta_time();
 
-				bool turnoff = false;
-				if (pos < 0) {
-					pos = 0;
-					turnoff = true;
-					set_physics_process_internal(false);
-					drag_touching = false;
-					drag_touching_deaccel = false;
-				}
-				if (pos > (v_scroll->get_max() - v_scroll->get_page())) {
-					pos = v_scroll->get_max() - v_scroll->get_page();
-					turnoff = true;
-				}
+					bool turnoff = false;
+					if (pos < 0) {
+						pos = 0;
+						turnoff = true;
+						set_physics_process_internal(false);
+						drag_touching = false;
+						drag_touching_deaccel = false;
+					}
+					if (pos > (v_scroll->get_max() - v_scroll->get_page())) {
+						pos = v_scroll->get_max() - v_scroll->get_page();
+						turnoff = true;
+					}
 
-				v_scroll->set_value(pos);
-				float sgn = drag_speed < 0 ? -1 : 1;
-				float val = Math::abs(drag_speed);
-				val -= 1000 * get_physics_process_delta_time();
+					v_scroll->set_value(pos);
+					float sgn = drag_speed < 0 ? -1 : 1;
+					float val = Math::abs(drag_speed);
+					val -= 1000 * get_physics_process_delta_time();
 
-				if (val < 0) {
-					turnoff = true;
-				}
-				drag_speed = sgn * val;
+					if (val < 0) {
+						turnoff = true;
+					}
+					drag_speed = sgn * val;
 
-				if (turnoff) {
-					set_physics_process_internal(false);
-					drag_touching = false;
-					drag_touching_deaccel = false;
+					if (turnoff) {
+						set_physics_process_internal(false);
+						drag_touching = false;
+						drag_touching_deaccel = false;
+					}
 				}
 			}
-		}
 
-		Point2 mouse_position = get_viewport()->get_mouse_position() - get_global_position();
-		if (scrolling && get_rect().grow(cache.scroll_border).has_point(mouse_position)) {
-			Point2 point;
+			Point2 mouse_position = get_viewport()->get_mouse_position() - get_global_position();
+			if (scrolling && get_rect().grow(cache.scroll_border).has_point(mouse_position)) {
+				Point2 point;
 
-			if ((ABS(mouse_position.x) < ABS(mouse_position.x - get_size().width)) && (ABS(mouse_position.x) < cache.scroll_border)) {
-				point.x = mouse_position.x - cache.scroll_border;
-			} else if (ABS(mouse_position.x - get_size().width) < cache.scroll_border) {
-				point.x = mouse_position.x - (get_size().width - cache.scroll_border);
-			}
-
-			if ((ABS(mouse_position.y) < ABS(mouse_position.y - get_size().height)) && (ABS(mouse_position.y) < cache.scroll_border)) {
-				point.y = mouse_position.y - cache.scroll_border;
-			} else if (ABS(mouse_position.y - get_size().height) < cache.scroll_border) {
-				point.y = mouse_position.y - (get_size().height - cache.scroll_border);
-			}
-
-			point *= cache.scroll_speed * get_physics_process_delta_time();
-			point += get_scroll();
-			h_scroll->set_value(point.x);
-			v_scroll->set_value(point.y);
-		}
-	}
-
-	if (p_what == NOTIFICATION_DRAW) {
-		update_cache();
-		update_scrollbars();
-		RID ci = get_canvas_item();
-
-		Ref<StyleBox> bg = cache.bg;
-		Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
-		int outline_size = get_theme_constant(SNAME("outline_size"));
-
-		Point2 draw_ofs;
-		draw_ofs += bg->get_offset();
-		Size2 draw_size = get_size() - bg->get_minimum_size();
-		if (h_scroll->is_visible()) {
-			draw_size.width -= h_scroll->get_minimum_size().width;
-		}
-
-		bg->draw(ci, Rect2(Point2(), get_size()));
-
-		int tbh = _get_title_button_height();
-
-		draw_ofs.y += tbh;
-		draw_size.y -= tbh;
-
-		cache.rtl = is_layout_rtl();
-
-		if (root && get_size().x > 0 && get_size().y > 0) {
-			draw_item(Point2(), draw_ofs, draw_size, root);
-		}
-
-		if (show_column_titles) {
-			//title buttons
-			int ofs2 = cache.bg->get_margin(SIDE_LEFT);
-			for (int i = 0; i < columns.size(); i++) {
-				Ref<StyleBox> sb = (cache.click_type == Cache::CLICK_TITLE && cache.click_index == i) ? cache.title_button_pressed : ((cache.hover_type == Cache::CLICK_TITLE && cache.hover_index == i) ? cache.title_button_hover : cache.title_button);
-				Ref<Font> f = cache.tb_font;
-				Rect2 tbrect = Rect2(ofs2 - cache.offset.x, bg->get_margin(SIDE_TOP), get_column_width(i), tbh);
-				if (cache.rtl) {
-					tbrect.position.x = get_size().width - tbrect.size.x - tbrect.position.x;
+				if ((ABS(mouse_position.x) < ABS(mouse_position.x - get_size().width)) && (ABS(mouse_position.x) < cache.scroll_border)) {
+					point.x = mouse_position.x - cache.scroll_border;
+				} else if (ABS(mouse_position.x - get_size().width) < cache.scroll_border) {
+					point.x = mouse_position.x - (get_size().width - cache.scroll_border);
 				}
-				sb->draw(ci, tbrect);
-				ofs2 += tbrect.size.width;
-				//text
-				int clip_w = tbrect.size.width - sb->get_minimum_size().width;
-				columns.write[i].text_buf->set_width(clip_w);
 
-				Vector2 text_pos = tbrect.position + Point2i(sb->get_offset().x + (tbrect.size.width - columns[i].text_buf->get_size().x) / 2, (tbrect.size.height - columns[i].text_buf->get_size().y) / 2);
-				if (outline_size > 0 && font_outline_color.a > 0) {
-					columns[i].text_buf->draw_outline(ci, text_pos, outline_size, font_outline_color);
+				if ((ABS(mouse_position.y) < ABS(mouse_position.y - get_size().height)) && (ABS(mouse_position.y) < cache.scroll_border)) {
+					point.y = mouse_position.y - cache.scroll_border;
+				} else if (ABS(mouse_position.y - get_size().height) < cache.scroll_border) {
+					point.y = mouse_position.y - (get_size().height - cache.scroll_border);
 				}
-				columns[i].text_buf->draw(ci, text_pos, cache.title_button_color);
+
+				point *= cache.scroll_speed * get_physics_process_delta_time();
+				point += get_scroll();
+				h_scroll->set_value(point.x);
+				v_scroll->set_value(point.y);
 			}
-		}
+		} break;
 
-		// Draw the background focus outline last, so that it is drawn in front of the section headings.
-		// Otherwise, section heading backgrounds can appear to be in front of the focus outline when scrolling.
-		if (has_focus()) {
-			RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, true);
-			const Ref<StyleBox> bg_focus = get_theme_stylebox(SNAME("bg_focus"));
-			bg_focus->draw(ci, Rect2(Point2(), get_size()));
-			RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, false);
-		}
-	}
+		case NOTIFICATION_DRAW: {
+			update_cache();
+			update_scrollbars();
+			RID ci = get_canvas_item();
 
-	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED || p_what == NOTIFICATION_TRANSLATION_CHANGED) {
-		update_cache();
-		_update_all();
-	}
+			Ref<StyleBox> bg = cache.bg;
+			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
+			int outline_size = get_theme_constant(SNAME("outline_size"));
 
-	if (p_what == NOTIFICATION_RESIZED || p_what == NOTIFICATION_TRANSFORM_CHANGED) {
-		if (popup_edited_item != nullptr) {
-			Rect2 rect = popup_edited_item->get_meta("__focus_rect");
-			Vector2 ofs(0, (text_editor->get_size().height - rect.size.height) / 2);
-			Point2i textedpos = get_global_position() + rect.position - ofs;
-
-			if (cache.text_editor_position != textedpos) {
-				cache.text_editor_position = textedpos;
-				text_editor->set_position(textedpos);
-				value_editor->set_position(textedpos + Point2i(0, text_editor->get_size().height));
+			Point2 draw_ofs;
+			draw_ofs += bg->get_offset();
+			Size2 draw_size = get_size() - bg->get_minimum_size();
+			if (h_scroll->is_visible()) {
+				draw_size.width -= h_scroll->get_minimum_size().width;
 			}
-		}
+
+			bg->draw(ci, Rect2(Point2(), get_size()));
+
+			int tbh = _get_title_button_height();
+
+			draw_ofs.y += tbh;
+			draw_size.y -= tbh;
+
+			cache.rtl = is_layout_rtl();
+
+			if (root && get_size().x > 0 && get_size().y > 0) {
+				draw_item(Point2(), draw_ofs, draw_size, root);
+			}
+
+			if (show_column_titles) {
+				//title buttons
+				int ofs2 = cache.bg->get_margin(SIDE_LEFT);
+				for (int i = 0; i < columns.size(); i++) {
+					Ref<StyleBox> sb = (cache.click_type == Cache::CLICK_TITLE && cache.click_index == i) ? cache.title_button_pressed : ((cache.hover_type == Cache::CLICK_TITLE && cache.hover_index == i) ? cache.title_button_hover : cache.title_button);
+					Ref<Font> f = cache.tb_font;
+					Rect2 tbrect = Rect2(ofs2 - cache.offset.x, bg->get_margin(SIDE_TOP), get_column_width(i), tbh);
+					if (cache.rtl) {
+						tbrect.position.x = get_size().width - tbrect.size.x - tbrect.position.x;
+					}
+					sb->draw(ci, tbrect);
+					ofs2 += tbrect.size.width;
+					//text
+					int clip_w = tbrect.size.width - sb->get_minimum_size().width;
+					columns.write[i].text_buf->set_width(clip_w);
+
+					Vector2 text_pos = tbrect.position + Point2i(sb->get_offset().x + (tbrect.size.width - columns[i].text_buf->get_size().x) / 2, (tbrect.size.height - columns[i].text_buf->get_size().y) / 2);
+					if (outline_size > 0 && font_outline_color.a > 0) {
+						columns[i].text_buf->draw_outline(ci, text_pos, outline_size, font_outline_color);
+					}
+					columns[i].text_buf->draw(ci, text_pos, cache.title_button_color);
+				}
+			}
+
+			// Draw the background focus outline last, so that it is drawn in front of the section headings.
+			// Otherwise, section heading backgrounds can appear to be in front of the focus outline when scrolling.
+			if (has_focus()) {
+				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, true);
+				const Ref<StyleBox> bg_focus = get_theme_stylebox(SNAME("bg_focus"));
+				bg_focus->draw(ci, Rect2(Point2(), get_size()));
+				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(ci, false);
+			}
+		} break;
+
+		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			update_cache();
+			_update_all();
+		} break;
+
+		case NOTIFICATION_RESIZED:
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			if (popup_edited_item != nullptr) {
+				Rect2 rect = popup_edited_item->get_meta("__focus_rect");
+				Vector2 ofs(0, (text_editor->get_size().height - rect.size.height) / 2);
+				Point2i textedpos = get_global_position() + rect.position - ofs;
+
+				if (cache.text_editor_position != textedpos) {
+					cache.text_editor_position = textedpos;
+					text_editor->set_position(textedpos);
+					value_editor->set_position(textedpos + Point2i(0, text_editor->get_size().height));
+				}
+			}
+		} break;
 	}
 }
 

--- a/scene/gui/video_stream_player.cpp
+++ b/scene/gui/video_stream_player.cpp
@@ -134,7 +134,6 @@ void VideoStreamPlayer::_notification(int p_notification) {
 			if (stream.is_valid() && autoplay && !Engine::get_singleton()->is_editor_hint()) {
 				play();
 			}
-
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -162,7 +161,6 @@ void VideoStreamPlayer::_notification(int p_notification) {
 			if (!playback->is_playing()) {
 				emit_signal(SceneStringNames::get_singleton()->finished);
 			}
-
 		} break;
 
 		case NOTIFICATION_DRAW: {
@@ -175,10 +173,9 @@ void VideoStreamPlayer::_notification(int p_notification) {
 
 			Size2 s = expand ? get_size() : texture->get_size();
 			draw_texture_rect(texture, Rect2(Point2(), s), false);
-
 		} break;
-	};
-};
+	}
+}
 
 Size2 VideoStreamPlayer::get_minimum_size() const {
 	if (!expand && !texture.is_null()) {

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -305,6 +305,7 @@ void CanvasItem::_notification(int p_what) {
 				get_tree()->xform_change_list.add(&xform_change);
 			}
 		} break;
+
 		case NOTIFICATION_MOVED_IN_PARENT: {
 			if (!is_inside_tree()) {
 				break;
@@ -317,8 +318,8 @@ void CanvasItem::_notification(int p_what) {
 				ERR_FAIL_COND(!p);
 				RenderingServer::get_singleton()->canvas_item_set_draw_index(canvas_item, get_index());
 			}
-
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			if (xform_change.in_list()) {
 				get_tree()->xform_change_list.remove(&xform_change);
@@ -334,9 +335,7 @@ void CanvasItem::_notification(int p_what) {
 			global_invalid = true;
 			visible_in_tree = false;
 		} break;
-		case NOTIFICATION_DRAW:
-		case NOTIFICATION_TRANSFORM_CHANGED: {
-		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			emit_signal(SceneStringNames::get_singleton()->visibility_changed);
 		} break;

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -174,8 +174,8 @@ void CanvasLayer::_notification(int p_what) {
 			RenderingServer::get_singleton()->viewport_set_canvas_stacking(viewport, canvas, layer, get_index());
 			RenderingServer::get_singleton()->viewport_set_canvas_transform(viewport, canvas, transform);
 			_update_follow_viewport();
-
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			ERR_FAIL_NULL_MSG(vp, "Viewport is not initialized.");
 
@@ -183,13 +183,12 @@ void CanvasLayer::_notification(int p_what) {
 			RenderingServer::get_singleton()->viewport_remove_canvas(viewport, canvas);
 			viewport = RID();
 			_update_follow_viewport(false);
-
 		} break;
+
 		case NOTIFICATION_MOVED_IN_PARENT: {
 			if (is_inside_tree()) {
 				RenderingServer::get_singleton()->viewport_set_canvas_stacking(viewport, canvas, layer, get_index());
 			}
-
 		} break;
 	}
 }

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -464,20 +464,22 @@ void HTTPRequest::_request_done(int p_status, int p_code, const PackedStringArra
 }
 
 void HTTPRequest::_notification(int p_what) {
-	if (p_what == NOTIFICATION_INTERNAL_PROCESS) {
-		if (use_threads.is_set()) {
-			return;
-		}
-		bool done = _update_connection();
-		if (done) {
-			set_process_internal(false);
-		}
-	}
+	switch (p_what) {
+		case NOTIFICATION_INTERNAL_PROCESS: {
+			if (use_threads.is_set()) {
+				return;
+			}
+			bool done = _update_connection();
+			if (done) {
+				set_process_internal(false);
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		if (requesting) {
-			cancel_request();
-		}
+		case NOTIFICATION_EXIT_TREE: {
+			if (requesting) {
+				cancel_request();
+			}
+		} break;
 	}
 }
 

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -54,12 +54,12 @@ void Node::_notification(int p_notification) {
 	switch (p_notification) {
 		case NOTIFICATION_PROCESS: {
 			GDVIRTUAL_CALL(_process, get_process_delta_time());
-
 		} break;
+
 		case NOTIFICATION_PHYSICS_PROCESS: {
 			GDVIRTUAL_CALL(_physics_process, get_physics_process_delta_time());
-
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			ERR_FAIL_COND(!get_viewport());
 			ERR_FAIL_COND(!get_tree());
@@ -88,8 +88,8 @@ void Node::_notification(int p_notification) {
 
 			get_tree()->node_count++;
 			orphan_node_count--;
-
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			ERR_FAIL_COND(!get_viewport());
 			ERR_FAIL_COND(!get_tree());
@@ -113,12 +113,14 @@ void Node::_notification(int p_notification) {
 				data.path_cache = nullptr;
 			}
 		} break;
+
 		case NOTIFICATION_PATH_RENAMED: {
 			if (data.path_cache) {
 				memdelete(data.path_cache);
 				data.path_cache = nullptr;
 			}
 		} break;
+
 		case NOTIFICATION_READY: {
 			if (GDVIRTUAL_IS_OVERRIDDEN(_input)) {
 				set_process_input(true);
@@ -141,9 +143,11 @@ void Node::_notification(int p_notification) {
 
 			GDVIRTUAL_CALL(_ready);
 		} break;
+
 		case NOTIFICATION_POSTINITIALIZE: {
 			data.in_constructor = false;
 		} break;
+
 		case NOTIFICATION_PREDELETE: {
 			if (data.parent) {
 				data.parent->remove_child(this);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -616,6 +616,7 @@ void SceneTree::_notification(int p_notification) {
 				get_root()->propagate_notification(p_notification);
 			}
 		} break;
+
 		case NOTIFICATION_OS_MEMORY_WARNING:
 		case NOTIFICATION_OS_IME_UPDATE:
 		case NOTIFICATION_WM_ABOUT:
@@ -624,13 +625,11 @@ void SceneTree::_notification(int p_notification) {
 		case NOTIFICATION_APPLICATION_PAUSED:
 		case NOTIFICATION_APPLICATION_FOCUS_IN:
 		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
-			get_root()->propagate_notification(p_notification); //pass these to nodes, since they are mirrored
+			// Pass these to nodes, since they are mirrored.
+			get_root()->propagate_notification(p_notification);
 		} break;
-
-		default:
-			break;
-	};
-};
+	}
+}
 
 void SceneTree::set_auto_accept_quit(bool p_enable) {
 	accept_quit = p_enable;

--- a/scene/main/shader_globals_override.cpp
+++ b/scene/main/shader_globals_override.cpp
@@ -247,26 +247,29 @@ void ShaderGlobalsOverride::_activate() {
 }
 
 void ShaderGlobalsOverride::_notification(int p_what) {
-	if (p_what == Node3D::NOTIFICATION_ENTER_TREE) {
-		add_to_group(SceneStringNames::get_singleton()->shader_overrides_group);
-		_activate();
+	switch (p_what) {
+		case Node3D::NOTIFICATION_ENTER_TREE: {
+			add_to_group(SceneStringNames::get_singleton()->shader_overrides_group);
+			_activate();
+		} break;
 
-	} else if (p_what == Node3D::NOTIFICATION_EXIT_TREE) {
-		if (active) {
-			//remove overrides
-			const StringName *K = nullptr;
-			while ((K = overrides.next(K))) {
-				Override *o = overrides.getptr(*K);
-				if (o->in_use) {
-					RS::get_singleton()->global_variable_set_override(*K, Variant());
+		case Node3D::NOTIFICATION_EXIT_TREE: {
+			if (active) {
+				//remove overrides
+				const StringName *K = nullptr;
+				while ((K = overrides.next(K))) {
+					Override *o = overrides.getptr(*K);
+					if (o->in_use) {
+						RS::get_singleton()->global_variable_set_override(*K, Variant());
+					}
 				}
 			}
-		}
 
-		remove_from_group(SceneStringNames::get_singleton()->shader_overrides_group_active);
-		remove_from_group(SceneStringNames::get_singleton()->shader_overrides_group);
-		get_tree()->call_group(SceneStringNames::get_singleton()->shader_overrides_group, "_activate"); //another may want to activate when this is removed
-		active = false;
+			remove_from_group(SceneStringNames::get_singleton()->shader_overrides_group_active);
+			remove_from_group(SceneStringNames::get_singleton()->shader_overrides_group);
+			get_tree()->call_group(SceneStringNames::get_singleton()->shader_overrides_group, "_activate"); //another may want to activate when this is removed
+			active = false;
+		} break;
 	}
 }
 

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -43,6 +43,7 @@ void Timer::_notification(int p_what) {
 				autostart = false;
 			}
 		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (!processing || timer_process_callback == TIMER_PROCESS_PHYSICS || !is_processing_internal()) {
 				return;
@@ -58,8 +59,8 @@ void Timer::_notification(int p_what) {
 
 				emit_signal(SNAME("timeout"));
 			}
-
 		} break;
+
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (!processing || timer_process_callback == TIMER_PROCESS_IDLE || !is_physics_processing_internal()) {
 				return;
@@ -74,7 +75,6 @@ void Timer::_notification(int p_what) {
 				}
 				emit_signal(SNAME("timeout"));
 			}
-
 		} break;
 	}
 }

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -406,8 +406,8 @@ void Viewport::_notification(int p_what) {
 #endif // _3D_DISABLED
 				set_physics_process_internal(true);
 			}
-
 		} break;
+
 		case NOTIFICATION_READY: {
 #ifndef _3D_DISABLED
 			if (audio_listener_3d_set.size() && !audio_listener_3d) {
@@ -438,6 +438,7 @@ void Viewport::_notification(int p_what) {
 			}
 #endif // _3D_DISABLED
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			_gui_cancel_tooltip();
 
@@ -461,6 +462,7 @@ void Viewport::_notification(int p_what) {
 			RS::get_singleton()->viewport_set_active(viewport, false);
 			RenderingServer::get_singleton()->viewport_set_parent_viewport(viewport, RID());
 		} break;
+
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			if (!get_tree()) {
 				return;
@@ -493,9 +495,11 @@ void Viewport::_notification(int p_what) {
 			}
 #endif // _3D_DISABLED
 		} break;
+
 		case NOTIFICATION_WM_MOUSE_ENTER: {
 			gui.mouse_in_window = true;
 		} break;
+
 		case NOTIFICATION_WM_MOUSE_EXIT: {
 			gui.mouse_in_window = false;
 			_drop_physics_mouseover();
@@ -504,6 +508,7 @@ void Viewport::_notification(int p_what) {
 			// not mouse_focus, because, for example, we want to continue
 			// dragging a scrollbar even if the mouse has left the window.
 		} break;
+
 		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
 			_drop_physics_mouseover();
 			if (gui.mouse_focus && !gui.forced_mouse_focus) {
@@ -3939,11 +3944,14 @@ Transform2D SubViewport::_stretch_transform() {
 }
 
 void SubViewport::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		RS::get_singleton()->viewport_set_active(get_viewport_rid(), true);
-	}
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		RS::get_singleton()->viewport_set_active(get_viewport_rid(), false);
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			RS::get_singleton()->viewport_set_active(get_viewport_rid(), true);
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			RS::get_singleton()->viewport_set_active(get_viewport_rid(), false);
+		} break;
 	}
 }
 

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -738,18 +738,16 @@ void Window::_notification(int p_what) {
 			bool embedded = false;
 			{
 				embedder = _get_embedder();
-
 				if (embedder) {
 					embedded = true;
-
 					if (!visible) {
-						embedder = nullptr; //not yet since not visible
+						embedder = nullptr; // Not yet since not visible.
 					}
 				}
 			}
 
 			if (embedded) {
-				//create as embedded
+				// Create as embedded.
 				if (embedder) {
 					embedder->_sub_window_register(this);
 					RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RS::VIEWPORT_UPDATE_WHEN_PARENT_VISIBLE);
@@ -757,22 +755,22 @@ void Window::_notification(int p_what) {
 				}
 
 			} else {
-				if (get_parent() == nullptr) {
-					//it's the root window!
-					visible = true; //always visible
+				if (!get_parent()) {
+					// It's the root window!
+					visible = true; // Always visible.
 					window_id = DisplayServer::MAIN_WINDOW_ID;
 					DisplayServer::get_singleton()->window_attach_instance_id(get_instance_id(), window_id);
 					_update_from_window();
-					//since this window already exists (created on start), we must update pos and size from it
+					// Since this window already exists (created on start), we must update pos and size from it.
 					{
 						position = DisplayServer::get_singleton()->window_get_position(window_id);
 						size = DisplayServer::get_singleton()->window_get_size(window_id);
 					}
-					_update_viewport_size(); //then feed back to the viewport
+					_update_viewport_size(); // Then feed back to the viewport.
 					_update_window_callbacks();
 					RS::get_singleton()->viewport_set_update_mode(get_viewport_rid(), RS::VIEWPORT_UPDATE_WHEN_VISIBLE);
 				} else {
-					//create
+					// Create.
 					if (visible) {
 						_make_window();
 					}
@@ -788,11 +786,13 @@ void Window::_notification(int p_what) {
 				RS::get_singleton()->viewport_set_active(get_viewport_rid(), true);
 			}
 		} break;
+
 		case NOTIFICATION_READY: {
 			if (wrap_controls) {
 				_update_child_controls();
 			}
 		} break;
+
 		case NOTIFICATION_TRANSLATION_CHANGED: {
 			if (embedder) {
 				embedder->_sub_window_update(this);
@@ -811,6 +811,7 @@ void Window::_notification(int p_what) {
 
 			child_controls_changed();
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			if (transient) {
 				_clear_transient();

--- a/scene/multiplayer/multiplayer_synchronizer.cpp
+++ b/scene/multiplayer/multiplayer_synchronizer.cpp
@@ -108,10 +108,15 @@ void MultiplayerSynchronizer::_notification(int p_what) {
 	if (root_path.is_empty()) {
 		return;
 	}
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		_start();
-	} else if (p_what == NOTIFICATION_EXIT_TREE) {
-		_stop();
+
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			_start();
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			_stop();
+		} break;
 	}
 }
 


### PR DESCRIPTION
Unifies the code style in `_notification` methods by using `switch` statements consistently, with the following opinionated style (which mostly matches our current "best practice", at least it's what recently added code tends to use):

```cpp
void MyClass::_notification(int p_what) {
	switch (p_what) {
		case NOTIFICATION_ENTER_TREE:
		case NOTIFICATION_MOVED_IN_PARENT: {
			// Do stuff.
		} break;

		case NOTIFICATION_EXIT_TREE: {
			// Do other stuff.
		} break;

		case NOTIFICATION_FOCUS_ENTER: {
			// Do custom stuff for focus enter.
			[[fallthrough]];
		}
		case NOTIFICATION_FOCUS_EXIT: {
			// Do common stuff for any focus change.
		} break;
}
```

I.e.:
- Always use brackets for `case` blocks
- Always use `break;` after the closing bracket
- Keep a separation line between cases, unless they're a fallthrough (instead of using a weird empty line before `} break;`)
  * This is not a policy for all `switch` statements in the codebase, only for `_notification` ones which tend to be very big. (Can still be used for other `switch`es as needed when more visual separation helps readability.)

---

Reviewing the whole of `scene` was a pretty tedious 2.5 hours of work, I might solicit contributors help to port the rest of the codebase if we agree about those changes.

This is best reviewed with whitespace changes hidden (add `?w=1` to PR files view URL): https://github.com/godotengine/godot/pull/58151/files?w=1