### PR TITLE
Fix: Decal 'Normal Fade' feature appears incorrect on scaled meshes

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
@@ -829,7 +829,7 @@ void main() {
 				float fade = pow(1.0 - (uv_local.y > 0.0 ? uv_local.y : -uv_local.y), uv_local.y > 0.0 ? decals.data[decal_index].upper_fade : decals.data[decal_index].lower_fade);
 
 				if (decals.data[decal_index].normal_fade > 0.0) {
-					fade *= smoothstep(decals.data[decal_index].normal_fade, 1.0, dot(normal_interp, decals.data[decal_index].normal) * 0.5 + 0.5);
+					fade *= smoothstep(decals.data[decal_index].normal_fade, 1.0, dot(normal, decals.data[decal_index].normal) * 0.5 + 0.5);
 				}
 
 				//we need ddx/ddy for mipmaps, so simulate them

--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
@@ -793,7 +793,7 @@ void main() {
 			float fade = pow(1.0 - (uv_local.y > 0.0 ? uv_local.y : -uv_local.y), uv_local.y > 0.0 ? decals.data[decal_index].upper_fade : decals.data[decal_index].lower_fade);
 
 			if (decals.data[decal_index].normal_fade > 0.0) {
-				fade *= smoothstep(decals.data[decal_index].normal_fade, 1.0, dot(normal_interp, decals.data[decal_index].normal) * 0.5 + 0.5);
+				fade *= smoothstep(decals.data[decal_index].normal_fade, 1.0, dot(normal, decals.data[decal_index].normal) * 0.5 + 0.5);
 			}
 
 			//we need ddx/ddy for mipmaps, so simulate them


### PR DESCRIPTION
Fixes #56590.

Before: 
![image](https://user-images.githubusercontent.com/26199781/154119269-e589b7b9-8a7c-4a83-ada9-b2761e89acf6.png)

After:
![image](https://user-images.githubusercontent.com/26199781/154119691-7f302caf-bd65-4c47-abe1-d997e2dd4709.png)


