### PR TITLE
Add an `OS.get_processor_name()` method (3.x)

### DIFF
--- a/core/bind/core_bind.cpp
+++ b/core/bind/core_bind.cpp
@@ -960,6 +960,10 @@ int _OS::get_processor_count() const {
 	return OS::get_singleton()->get_processor_count();
 }
 
+String _OS::get_processor_name() const {
+	return OS::get_singleton()->get_processor_name();
+}
+
 bool _OS::is_stdout_verbose() const {
 	return OS::get_singleton()->is_stdout_verbose();
 }
@@ -1319,6 +1323,7 @@ void _OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_low_processor_usage_mode_sleep_usec"), &_OS::get_low_processor_usage_mode_sleep_usec);
 
 	ClassDB::bind_method(D_METHOD("get_processor_count"), &_OS::get_processor_count);
+	ClassDB::bind_method(D_METHOD("get_processor_name"), &_OS::get_processor_name);
 
 	ClassDB::bind_method(D_METHOD("get_executable_path"), &_OS::get_executable_path);
 	ClassDB::bind_method(D_METHOD("execute", "path", "arguments", "blocking", "output", "read_stderr", "open_console"), &_OS::execute, DEFVAL(true), DEFVAL(Array()), DEFVAL(false), DEFVAL(false));

--- a/core/bind/core_bind.h
+++ b/core/bind/core_bind.h
@@ -327,6 +327,7 @@ public:
 	bool is_stdout_verbose() const;
 
 	int get_processor_count() const;
+	String get_processor_name() const;
 
 	enum SystemDir {
 		SYSTEM_DIR_DESKTOP,

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -512,6 +512,10 @@ int OS::get_processor_count() const {
 	return 1;
 }
 
+String OS::get_processor_name() const {
+	return "";
+}
+
 Error OS::native_video_play(String p_path, float p_volume, String p_audio_track, String p_subtitle_track) {
 	return FAILED;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -519,6 +519,7 @@ public:
 	virtual bool is_custom_exit_code();
 
 	virtual int get_processor_count() const;
+	virtual String get_processor_name() const;
 
 	virtual String get_unique_id() const;
 

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -345,7 +345,14 @@
 		<method name="get_processor_count" qualifiers="const">
 			<return type="int" />
 			<description>
-				Returns the number of threads available on the host machine.
+				Returns the number of [i]logical[/i] CPU cores available on the host machine. On CPUs with HyperThreading enabled, this number will be greater than the number of [i]physical[/i] CPU cores.
+			</description>
+		</method>
+		<method name="get_processor_name" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the name of the CPU model on the host machine (e.g. "Intel(R) Core(TM) i7-6700K CPU @ 4.00GHz").
+				[b]Note:[/b] This method is only implemented on Windows, macOS, Linux and iOS. On Android, HTML5 and UWP, [method get_processor_name] returns an empty string.
 			</description>
 		</method>
 		<method name="get_real_window_size" qualifiers="const">

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -123,6 +123,7 @@ public:
 	String get_locale() const;
 
 	String get_unique_id() const;
+	virtual String get_processor_name() const;
 
 	virtual void vibrate_handheld(int p_duration_ms = 500);
 

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -54,6 +54,7 @@
 
 #import <UIKit/UIKit.h>
 #include <dlfcn.h>
+#include <sys/sysctl.h>
 #import <sys/utsname.h>
 
 extern int gl_view_base_fb; // from gl_view.mm
@@ -663,6 +664,15 @@ void OSIPhone::native_video_stop() {
 	if (native_video_is_playing()) {
 		[AppDelegate.viewController.videoView stopVideo];
 	}
+}
+
+String OSIPhone::get_processor_name() const {
+	char buffer[256];
+	size_t buffer_len = 256;
+	if (sysctlbyname("machdep.cpu.brand_string", &buffer, &buffer_len, NULL, 0) == 0) {
+		return String::utf8(buffer, buffer_len);
+	}
+	ERR_FAIL_V_MSG("", String("Couldn't get the CPU model name. Returning an empty string."));
 }
 
 void OSIPhone::vibrate_handheld(int p_duration_ms) {

--- a/platform/osx/os_osx.h
+++ b/platform/osx/os_osx.h
@@ -310,6 +310,7 @@ public:
 	virtual String get_ime_text() const;
 
 	virtual String get_unique_id() const;
+	virtual String get_processor_name() const;
 
 	virtual OS::PowerState get_power_state();
 	virtual int get_power_seconds_left();

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -41,6 +41,8 @@
 #include "servers/visual/visual_server_raster.h"
 
 #include <mach-o/dyld.h>
+#include <os/log.h>
+#include <sys/sysctl.h>
 
 #include <Carbon/Carbon.h>
 #import <Cocoa/Cocoa.h>
@@ -48,9 +50,6 @@
 #include <IOKit/IOKitLib.h>
 #include <IOKit/hid/IOHIDKeys.h>
 #include <IOKit/hid/IOHIDLib.h>
-#if MAC_OS_X_VERSION_MAX_ALLOWED >= 101200
-#include <os/log.h>
-#endif
 
 #include <dlfcn.h>
 #include <fcntl.h>
@@ -1508,6 +1507,15 @@ void OS_OSX::set_ime_active(const bool p_active) {
 
 void OS_OSX::set_ime_position(const Point2 &p_pos) {
 	im_position = p_pos;
+}
+
+String OS_OSX::get_processor_name() const {
+	char buffer[256];
+	size_t buffer_len = 256;
+	if (sysctlbyname("machdep.cpu.brand_string", &buffer, &buffer_len, NULL, 0) == 0) {
+		return String::utf8(buffer, buffer_len);
+	}
+	ERR_FAIL_V_MSG("", String("Couldn't get the CPU model name. Returning an empty string."));
 }
 
 void OS_OSX::initialize_core() {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -3130,6 +3130,26 @@ int OS_Windows::get_processor_count() const {
 	return sysinfo.dwNumberOfProcessors;
 }
 
+String OS_Windows::get_processor_name() const {
+	const String id = "Hardware\\Description\\System\\CentralProcessor\\0";
+
+	HKEY hkey;
+	if (RegOpenKeyExW(HKEY_LOCAL_MACHINE, (LPCWSTR)(id.c_str()), 0, KEY_QUERY_VALUE, &hkey) != ERROR_SUCCESS) {
+		ERR_FAIL_V_MSG("", String("Couldn't get the CPU model name. Returning an empty string."));
+	}
+
+	WCHAR buffer[256];
+	DWORD buffer_len = 256;
+	DWORD vtype = REG_SZ;
+	if (RegQueryValueExW(hkey, L"ProcessorNameString", NULL, &vtype, (LPBYTE)buffer, &buffer_len) == ERROR_SUCCESS) {
+		RegCloseKey(hkey);
+		return String((const wchar_t *)buffer, buffer_len).strip_edges();
+	} else {
+		RegCloseKey(hkey);
+		ERR_FAIL_V_MSG("", String("Couldn't get the CPU model name. Returning an empty string."));
+	}
+}
+
 OS::LatinKeyboardVariant OS_Windows::get_latin_keyboard_variant() const {
 	unsigned long azerty[] = {
 		0x00020401, // Arabic (102) AZERTY

--- a/platform/windows/os_windows.h
+++ b/platform/windows/os_windows.h
@@ -520,6 +520,7 @@ public:
 	virtual String get_locale() const;
 
 	virtual int get_processor_count() const;
+	virtual String get_processor_name() const;
 
 	virtual LatinKeyboardVariant get_latin_keyboard_variant() const;
 	virtual int keyboard_get_layout_count() const;

--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -806,6 +806,20 @@ String OS_X11::get_unique_id() const {
 	return machine_id;
 }
 
+String OS_X11::get_processor_name() const {
+	FileAccessRef f = FileAccess::open("/proc/cpuinfo", FileAccess::READ);
+	ERR_FAIL_COND_V_MSG(!f, "", String("Couldn't open `/proc/cpuinfo` to get the CPU model name. Returning an empty string."));
+
+	while (!f->eof_reached()) {
+		const String line = f->get_line();
+		if (line.find("model name") != -1) {
+			return line.split(":")[1].strip_edges();
+		}
+	}
+
+	ERR_FAIL_V_MSG("", String("Couldn't get the CPU model name from `/proc/cpuinfo`. Returning an empty string."));
+}
+
 void OS_X11::finalize() {
 	events_thread_done = true;
 	events_thread.wait_to_finish();

--- a/platform/x11/os_x11.h
+++ b/platform/x11/os_x11.h
@@ -329,6 +329,7 @@ public:
 	virtual void set_ime_position(const Point2 &p_pos);
 
 	virtual String get_unique_id() const;
+	virtual String get_processor_name() const;
 
 	virtual void move_window_to_foreground();
 	virtual void alert(const String &p_alert, const String &p_title = "ALERT!");


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/44716.

This method can be used to get the CPU model name. It can be used in conjunction with `VisualServer.get_video_adapter_name()` and `VisualServer.get_video_adapter_vendor()` for annotating benchmarks and automatic graphics quality configuration.

## Preview

![image](https://user-images.githubusercontent.com/180032/154152036-d5ed1422-fbc1-4eac-9b81-36133cf8ff8f.png)
