### PR TITLE
Port existing _notification code to use switch statements  (part 1/3)

### DIFF
--- a/core/object/script_language.cpp
+++ b/core/object/script_language.cpp
@@ -46,10 +46,12 @@ bool ScriptServer::languages_finished = false;
 ScriptEditRequestFunction ScriptServer::edit_request_func = nullptr;
 
 void Script::_notification(int p_what) {
-	if (p_what == NOTIFICATION_POSTINITIALIZE) {
-		if (EngineDebugger::is_active()) {
-			EngineDebugger::get_script_debugger()->set_break_language(get_language());
-		}
+	switch (p_what) {
+		case NOTIFICATION_POSTINITIALIZE: {
+			if (EngineDebugger::is_active()) {
+				EngineDebugger::get_script_debugger()->set_break_language(get_language());
+			}
+		} break;
 	}
 }
 

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -562,8 +562,6 @@ void InputEventConfigurationDialog::_notification(int p_what) {
 
 			_update_input_list();
 		} break;
-		default:
-			break;
 	}
 }
 
@@ -1014,8 +1012,6 @@ void ActionMapEditor::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			action_list_search->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 		} break;
-		default:
-			break;
 	}
 }
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1458,198 +1458,201 @@ int AnimationTimelineEdit::get_name_limit() const {
 }
 
 void AnimationTimelineEdit::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
-	}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
+			add_track->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+			loop->set_icon(get_theme_icon(SNAME("Loop"), SNAME("EditorIcons")));
+			time_icon->set_texture(get_theme_icon(SNAME("Time"), SNAME("EditorIcons")));
 
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		add_track->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
-		loop->set_icon(get_theme_icon(SNAME("Loop"), SNAME("EditorIcons")));
-		time_icon->set_texture(get_theme_icon(SNAME("Time"), SNAME("EditorIcons")));
+			add_track->get_popup()->clear();
+			add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons")), TTR("Property Track"));
+			add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyXPosition"), SNAME("EditorIcons")), TTR("3D Position Track"));
+			add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyXRotation"), SNAME("EditorIcons")), TTR("3D Rotation Track"));
+			add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyXScale"), SNAME("EditorIcons")), TTR("3D Scale Track"));
+			add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyBlendShape"), SNAME("EditorIcons")), TTR("Blend Shape Track"));
+			add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyCall"), SNAME("EditorIcons")), TTR("Call Method Track"));
+			add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyBezier"), SNAME("EditorIcons")), TTR("Bezier Curve Track"));
+			add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyAudio"), SNAME("EditorIcons")), TTR("Audio Playback Track"));
+			add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyAnimation"), SNAME("EditorIcons")), TTR("Animation Playback Track"));
+		} break;
 
-		add_track->get_popup()->clear();
-		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons")), TTR("Property Track"));
-		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyXPosition"), SNAME("EditorIcons")), TTR("3D Position Track"));
-		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyXRotation"), SNAME("EditorIcons")), TTR("3D Rotation Track"));
-		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyXScale"), SNAME("EditorIcons")), TTR("3D Scale Track"));
-		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyBlendShape"), SNAME("EditorIcons")), TTR("Blend Shape Track"));
-		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyCall"), SNAME("EditorIcons")), TTR("Call Method Track"));
-		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyBezier"), SNAME("EditorIcons")), TTR("Bezier Curve Track"));
-		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyAudio"), SNAME("EditorIcons")), TTR("Audio Playback Track"));
-		add_track->get_popup()->add_icon_item(get_theme_icon(SNAME("KeyAnimation"), SNAME("EditorIcons")), TTR("Animation Playback Track"));
-	}
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
+		} break;
 
-	if (p_what == NOTIFICATION_RESIZED) {
-		len_hb->set_position(Vector2(get_size().width - get_buttons_width(), 0));
-		len_hb->set_size(Size2(get_buttons_width(), get_size().height));
-	}
+		case NOTIFICATION_RESIZED: {
+			len_hb->set_position(Vector2(get_size().width - get_buttons_width(), 0));
+			len_hb->set_size(Size2(get_buttons_width(), get_size().height));
+		} break;
 
-	if (p_what == NOTIFICATION_DRAW) {
-		int key_range = get_size().width - get_buttons_width() - get_name_limit();
+		case NOTIFICATION_DRAW: {
+			int key_range = get_size().width - get_buttons_width() - get_name_limit();
 
-		if (!animation.is_valid()) {
-			return;
-		}
+			if (!animation.is_valid()) {
+				return;
+			}
 
-		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
-		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
-		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
+			Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+			int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+			Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 
-		int zoomw = key_range;
-		float scale = get_zoom_scale();
-		int h = get_size().height;
+			int zoomw = key_range;
+			float scale = get_zoom_scale();
+			int h = get_size().height;
 
-		float l = animation->get_length();
-		if (l <= 0) {
-			l = 0.001; // Avoid crashor.
-		}
+			float l = animation->get_length();
+			if (l <= 0) {
+				l = 0.001; // Avoid crashor.
+			}
 
-		Ref<Texture2D> hsize_icon = get_theme_icon(SNAME("Hsize"), SNAME("EditorIcons"));
-		hsize_rect = Rect2(get_name_limit() - hsize_icon->get_width() - 2 * EDSCALE, (get_size().height - hsize_icon->get_height()) / 2, hsize_icon->get_width(), hsize_icon->get_height());
-		draw_texture(hsize_icon, hsize_rect.position);
+			Ref<Texture2D> hsize_icon = get_theme_icon(SNAME("Hsize"), SNAME("EditorIcons"));
+			hsize_rect = Rect2(get_name_limit() - hsize_icon->get_width() - 2 * EDSCALE, (get_size().height - hsize_icon->get_height()) / 2, hsize_icon->get_width(), hsize_icon->get_height());
+			draw_texture(hsize_icon, hsize_rect.position);
 
-		{
-			float time_min = 0;
-			float time_max = animation->get_length();
-			for (int i = 0; i < animation->get_track_count(); i++) {
-				if (animation->track_get_key_count(i) > 0) {
-					float beg = animation->track_get_key_time(i, 0);
+			{
+				float time_min = 0;
+				float time_max = animation->get_length();
+				for (int i = 0; i < animation->get_track_count(); i++) {
+					if (animation->track_get_key_count(i) > 0) {
+						float beg = animation->track_get_key_time(i, 0);
 
-					if (beg < time_min) {
-						time_min = beg;
+						if (beg < time_min) {
+							time_min = beg;
+						}
+
+						float end = animation->track_get_key_time(i, animation->track_get_key_count(i) - 1);
+
+						if (end > time_max) {
+							time_max = end;
+						}
+					}
+				}
+
+				float extra = (zoomw / scale) * 0.5;
+
+				time_max += extra;
+				set_min(time_min);
+				set_max(time_max);
+
+				if (zoomw / scale < (time_max - time_min)) {
+					hscroll->show();
+
+				} else {
+					hscroll->hide();
+				}
+			}
+
+			set_page(zoomw / scale);
+
+			int end_px = (l - get_value()) * scale;
+			int begin_px = -get_value() * scale;
+			Color notimecol = get_theme_color(SNAME("dark_color_2"), SNAME("Editor"));
+			Color timecolor = color;
+			timecolor.a = 0.2;
+			Color linecolor = color;
+			linecolor.a = 0.2;
+
+			{
+				draw_rect(Rect2(Point2(get_name_limit(), 0), Point2(zoomw - 1, h)), notimecol);
+
+				if (begin_px < zoomw && end_px > 0) {
+					if (begin_px < 0) {
+						begin_px = 0;
+					}
+					if (end_px > zoomw) {
+						end_px = zoomw;
 					}
 
-					float end = animation->track_get_key_time(i, animation->track_get_key_count(i) - 1);
-
-					if (end > time_max) {
-						time_max = end;
-					}
+					draw_rect(Rect2(Point2(get_name_limit() + begin_px, 0), Point2(end_px - begin_px - 1, h)), timecolor);
 				}
 			}
 
-			float extra = (zoomw / scale) * 0.5;
-
-			time_max += extra;
-			set_min(time_min);
-			set_max(time_max);
-
-			if (zoomw / scale < (time_max - time_min)) {
-				hscroll->show();
-
-			} else {
-				hscroll->hide();
-			}
-		}
-
-		set_page(zoomw / scale);
-
-		int end_px = (l - get_value()) * scale;
-		int begin_px = -get_value() * scale;
-		Color notimecol = get_theme_color(SNAME("dark_color_2"), SNAME("Editor"));
-		Color timecolor = color;
-		timecolor.a = 0.2;
-		Color linecolor = color;
-		linecolor.a = 0.2;
-
-		{
-			draw_rect(Rect2(Point2(get_name_limit(), 0), Point2(zoomw - 1, h)), notimecol);
-
-			if (begin_px < zoomw && end_px > 0) {
-				if (begin_px < 0) {
-					begin_px = 0;
-				}
-				if (end_px > zoomw) {
-					end_px = zoomw;
-				}
-
-				draw_rect(Rect2(Point2(get_name_limit() + begin_px, 0), Point2(end_px - begin_px - 1, h)), timecolor);
-			}
-		}
-
-		Color color_time_sec = color;
-		Color color_time_dec = color;
-		color_time_dec.a *= 0.5;
+			Color color_time_sec = color;
+			Color color_time_dec = color;
+			color_time_dec.a *= 0.5;
 #define SC_ADJ 100
-		int min = 30;
-		int dec = 1;
-		int step = 1;
-		int decimals = 2;
-		bool step_found = false;
+			int min = 30;
+			int dec = 1;
+			int step = 1;
+			int decimals = 2;
+			bool step_found = false;
 
-		const float period_width = font->get_char_size('.', 0, font_size).width;
-		float max_digit_width = font->get_char_size('0', 0, font_size).width;
-		for (int i = 1; i <= 9; i++) {
-			const float digit_width = font->get_char_size('0' + i, 0, font_size).width;
-			max_digit_width = MAX(digit_width, max_digit_width);
-		}
-		const int max_sc = int(Math::ceil(zoomw / scale));
-		const int max_sc_width = String::num(max_sc).length() * max_digit_width;
-
-		while (!step_found) {
-			min = max_sc_width;
-			if (decimals > 0) {
-				min += period_width + max_digit_width * decimals;
+			const float period_width = font->get_char_size('.', 0, font_size).width;
+			float max_digit_width = font->get_char_size('0', 0, font_size).width;
+			for (int i = 1; i <= 9; i++) {
+				const float digit_width = font->get_char_size('0' + i, 0, font_size).width;
+				max_digit_width = MAX(digit_width, max_digit_width);
 			}
+			const int max_sc = int(Math::ceil(zoomw / scale));
+			const int max_sc_width = String::num(max_sc).length() * max_digit_width;
 
-			static const int _multp[3] = { 1, 2, 5 };
-			for (int i = 0; i < 3; i++) {
-				step = (_multp[i] * dec);
-				if (step * scale / SC_ADJ > min) {
-					step_found = true;
+			while (!step_found) {
+				min = max_sc_width;
+				if (decimals > 0) {
+					min += period_width + max_digit_width * decimals;
+				}
+
+				static const int _multp[3] = { 1, 2, 5 };
+				for (int i = 0; i < 3; i++) {
+					step = (_multp[i] * dec);
+					if (step * scale / SC_ADJ > min) {
+						step_found = true;
+						break;
+					}
+				}
+				if (step_found) {
 					break;
 				}
+				dec *= 10;
+				decimals--;
+				if (decimals < 0) {
+					decimals = 0;
+				}
 			}
-			if (step_found) {
-				break;
-			}
-			dec *= 10;
-			decimals--;
-			if (decimals < 0) {
-				decimals = 0;
-			}
-		}
 
-		if (use_fps) {
-			float step_size = animation->get_step();
-			if (step_size > 0) {
-				int prev_frame_ofs = -10000000;
+			if (use_fps) {
+				float step_size = animation->get_step();
+				if (step_size > 0) {
+					int prev_frame_ofs = -10000000;
 
+					for (int i = 0; i < zoomw; i++) {
+						float pos = get_value() + double(i) / scale;
+						float prev = get_value() + (double(i) - 1.0) / scale;
+
+						int frame = pos / step_size;
+						int prev_frame = prev / step_size;
+
+						bool sub = Math::floor(prev) == Math::floor(pos);
+
+						if (frame != prev_frame && i >= prev_frame_ofs) {
+							draw_line(Point2(get_name_limit() + i, 0), Point2(get_name_limit() + i, h), linecolor, Math::round(EDSCALE));
+
+							draw_string(font, Point2(get_name_limit() + i + 3 * EDSCALE, (h - font->get_height(font_size)) / 2 + font->get_ascent(font_size)).floor(), itos(frame), HORIZONTAL_ALIGNMENT_LEFT, zoomw - i, font_size, sub ? color_time_dec : color_time_sec);
+							prev_frame_ofs = i + font->get_string_size(itos(frame), font_size).x + 5 * EDSCALE;
+						}
+					}
+				}
+
+			} else {
 				for (int i = 0; i < zoomw; i++) {
 					float pos = get_value() + double(i) / scale;
 					float prev = get_value() + (double(i) - 1.0) / scale;
 
-					int frame = pos / step_size;
-					int prev_frame = prev / step_size;
+					int sc = int(Math::floor(pos * SC_ADJ));
+					int prev_sc = int(Math::floor(prev * SC_ADJ));
+					bool sub = (sc % SC_ADJ);
 
-					bool sub = Math::floor(prev) == Math::floor(pos);
-
-					if (frame != prev_frame && i >= prev_frame_ofs) {
+					if ((sc / step) != (prev_sc / step) || (prev_sc < 0 && sc >= 0)) {
+						int scd = sc < 0 ? prev_sc : sc;
 						draw_line(Point2(get_name_limit() + i, 0), Point2(get_name_limit() + i, h), linecolor, Math::round(EDSCALE));
-
-						draw_string(font, Point2(get_name_limit() + i + 3 * EDSCALE, (h - font->get_height(font_size)) / 2 + font->get_ascent(font_size)).floor(), itos(frame), HORIZONTAL_ALIGNMENT_LEFT, zoomw - i, font_size, sub ? color_time_dec : color_time_sec);
-						prev_frame_ofs = i + font->get_string_size(itos(frame), font_size).x + 5 * EDSCALE;
+						draw_string(font, Point2(get_name_limit() + i + 3, (h - font->get_height(font_size)) / 2 + font->get_ascent(font_size)).floor(), String::num((scd - (scd % step)) / double(SC_ADJ), decimals), HORIZONTAL_ALIGNMENT_LEFT, zoomw - i, font_size, sub ? color_time_dec : color_time_sec);
 					}
 				}
 			}
 
-		} else {
-			for (int i = 0; i < zoomw; i++) {
-				float pos = get_value() + double(i) / scale;
-				float prev = get_value() + (double(i) - 1.0) / scale;
-
-				int sc = int(Math::floor(pos * SC_ADJ));
-				int prev_sc = int(Math::floor(prev * SC_ADJ));
-				bool sub = (sc % SC_ADJ);
-
-				if ((sc / step) != (prev_sc / step) || (prev_sc < 0 && sc >= 0)) {
-					int scd = sc < 0 ? prev_sc : sc;
-					draw_line(Point2(get_name_limit() + i, 0), Point2(get_name_limit() + i, h), linecolor, Math::round(EDSCALE));
-					draw_string(font, Point2(get_name_limit() + i + 3, (h - font->get_height(font_size)) / 2 + font->get_ascent(font_size)).floor(), String::num((scd - (scd % step)) / double(SC_ADJ), decimals), HORIZONTAL_ALIGNMENT_LEFT, zoomw - i, font_size, sub ? color_time_dec : color_time_sec);
-				}
-			}
-		}
-
-		draw_line(Vector2(0, get_size().height), get_size(), linecolor, Math::round(EDSCALE));
+			draw_line(Vector2(0, get_size().height), get_size(), linecolor, Math::round(EDSCALE));
+		} break;
 	}
 }
 
@@ -1942,302 +1945,305 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 ////////////////////////////////////
 
 void AnimationTrackEdit::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		if (animation.is_null()) {
-			return;
-		}
-		ERR_FAIL_INDEX(track, animation->get_track_count());
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			if (animation.is_null()) {
+				return;
+			}
+			ERR_FAIL_INDEX(track, animation->get_track_count());
 
-		int limit = timeline->get_name_limit();
+			int limit = timeline->get_name_limit();
 
-		if (has_focus()) {
-			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
-			accent.a *= 0.7;
-			// Offside so the horizontal sides aren't cutoff.
-			draw_rect(Rect2(Point2(1 * EDSCALE, 0), get_size() - Size2(1 * EDSCALE, 0)), accent, false);
-		}
-
-		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
-		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
-		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
-		Ref<Texture2D> type_icons[9] = {
-			get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons")),
-			get_theme_icon(SNAME("KeyTrackPosition"), SNAME("EditorIcons")),
-			get_theme_icon(SNAME("KeyTrackRotation"), SNAME("EditorIcons")),
-			get_theme_icon(SNAME("KeyTrackScale"), SNAME("EditorIcons")),
-			get_theme_icon(SNAME("KeyTrackBlendShape"), SNAME("EditorIcons")),
-			get_theme_icon(SNAME("KeyCall"), SNAME("EditorIcons")),
-			get_theme_icon(SNAME("KeyBezier"), SNAME("EditorIcons")),
-			get_theme_icon(SNAME("KeyAudio"), SNAME("EditorIcons")),
-			get_theme_icon(SNAME("KeyAnimation"), SNAME("EditorIcons"))
-		};
-		int hsep = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
-		Color linecolor = color;
-		linecolor.a = 0.2;
-
-		// NAMES AND ICONS //
-
-		{
-			Ref<Texture2D> check = animation->track_is_enabled(track) ? get_theme_icon(SNAME("checked"), SNAME("CheckBox")) : get_theme_icon(SNAME("unchecked"), SNAME("CheckBox"));
-
-			int ofs = in_group ? check->get_width() : 0; // Not the best reference for margin but..
-
-			check_rect = Rect2(Point2(ofs, int(get_size().height - check->get_height()) / 2), check->get_size());
-			draw_texture(check, check_rect.position);
-			ofs += check->get_width() + hsep;
-
-			Ref<Texture2D> type_icon = type_icons[animation->track_get_type(track)];
-			draw_texture(type_icon, Point2(ofs, int(get_size().height - type_icon->get_height()) / 2));
-			ofs += type_icon->get_width() + hsep;
-
-			NodePath path = animation->track_get_path(track);
-			Node *node = nullptr;
-			if (root && root->has_node(path)) {
-				node = root->get_node(path);
+			if (has_focus()) {
+				Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
+				accent.a *= 0.7;
+				// Offside so the horizontal sides aren't cutoff.
+				draw_rect(Rect2(Point2(1 * EDSCALE, 0), get_size() - Size2(1 * EDSCALE, 0)), accent, false);
 			}
 
-			String text;
-			Color text_color = color;
-			if (node && EditorNode::get_singleton()->get_editor_selection()->is_selected(node)) {
-				text_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
+			Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+			int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+			Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
+			Ref<Texture2D> type_icons[9] = {
+				get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("KeyTrackPosition"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("KeyTrackRotation"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("KeyTrackScale"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("KeyTrackBlendShape"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("KeyCall"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("KeyBezier"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("KeyAudio"), SNAME("EditorIcons")),
+				get_theme_icon(SNAME("KeyAnimation"), SNAME("EditorIcons"))
+			};
+			int hsep = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
+			Color linecolor = color;
+			linecolor.a = 0.2;
+
+			// NAMES AND ICONS //
+
+			{
+				Ref<Texture2D> check = animation->track_is_enabled(track) ? get_theme_icon(SNAME("checked"), SNAME("CheckBox")) : get_theme_icon(SNAME("unchecked"), SNAME("CheckBox"));
+
+				int ofs = in_group ? check->get_width() : 0; // Not the best reference for margin but..
+
+				check_rect = Rect2(Point2(ofs, int(get_size().height - check->get_height()) / 2), check->get_size());
+				draw_texture(check, check_rect.position);
+				ofs += check->get_width() + hsep;
+
+				Ref<Texture2D> type_icon = type_icons[animation->track_get_type(track)];
+				draw_texture(type_icon, Point2(ofs, int(get_size().height - type_icon->get_height()) / 2));
+				ofs += type_icon->get_width() + hsep;
+
+				NodePath path = animation->track_get_path(track);
+				Node *node = nullptr;
+				if (root && root->has_node(path)) {
+					node = root->get_node(path);
+				}
+
+				String text;
+				Color text_color = color;
+				if (node && EditorNode::get_singleton()->get_editor_selection()->is_selected(node)) {
+					text_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
+				}
+
+				if (in_group) {
+					if (animation->track_get_type(track) == Animation::TYPE_METHOD) {
+						text = TTR("Functions:");
+					} else if (animation->track_get_type(track) == Animation::TYPE_AUDIO) {
+						text = TTR("Audio Clips:");
+					} else if (animation->track_get_type(track) == Animation::TYPE_ANIMATION) {
+						text = TTR("Anim Clips:");
+					} else {
+						text += path.get_concatenated_subnames();
+					}
+					text_color.a *= 0.7;
+				} else if (node) {
+					Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(node, "Node");
+
+					draw_texture(icon, Point2(ofs, int(get_size().height - icon->get_height()) / 2));
+					icon_cache = icon;
+
+					text = String() + node->get_name() + ":" + path.get_concatenated_subnames();
+					ofs += hsep;
+					ofs += icon->get_width();
+
+				} else {
+					icon_cache = type_icon;
+
+					text = path;
+				}
+
+				path_cache = text;
+
+				path_rect = Rect2(ofs, 0, limit - ofs - hsep, get_size().height);
+
+				Vector2 string_pos = Point2(ofs, (get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size));
+				string_pos = string_pos.floor();
+				draw_string(font, string_pos, text, HORIZONTAL_ALIGNMENT_LEFT, limit - ofs - hsep, font_size, text_color);
+
+				draw_line(Point2(limit, 0), Point2(limit, get_size().height), linecolor, Math::round(EDSCALE));
+			}
+
+			// KEYFRAMES //
+
+			draw_bg(limit, get_size().width - timeline->get_buttons_width());
+
+			{
+				float scale = timeline->get_zoom_scale();
+				int limit_end = get_size().width - timeline->get_buttons_width();
+
+				for (int i = 0; i < animation->track_get_key_count(track); i++) {
+					float offset = animation->track_get_key_time(track, i) - timeline->get_value();
+					if (editor->is_key_selected(track, i) && editor->is_moving_selection()) {
+						offset = editor->snap_time(offset + editor->get_moving_selection_offset(), true);
+					}
+					offset = offset * scale + limit;
+					if (i < animation->track_get_key_count(track) - 1) {
+						float offset_n = animation->track_get_key_time(track, i + 1) - timeline->get_value();
+						if (editor->is_key_selected(track, i + 1) && editor->is_moving_selection()) {
+							offset_n = editor->snap_time(offset_n + editor->get_moving_selection_offset());
+						}
+						offset_n = offset_n * scale + limit;
+
+						draw_key_link(i, scale, int(offset), int(offset_n), limit, limit_end);
+					}
+
+					draw_key(i, scale, int(offset), editor->is_key_selected(track, i), limit, limit_end);
+				}
+			}
+
+			draw_fg(limit, get_size().width - timeline->get_buttons_width());
+
+			// BUTTONS //
+
+			{
+				Ref<Texture2D> wrap_icon[2] = {
+					get_theme_icon(SNAME("InterpWrapClamp"), SNAME("EditorIcons")),
+					get_theme_icon(SNAME("InterpWrapLoop"), SNAME("EditorIcons")),
+				};
+
+				Ref<Texture2D> interp_icon[3] = {
+					get_theme_icon(SNAME("InterpRaw"), SNAME("EditorIcons")),
+					get_theme_icon(SNAME("InterpLinear"), SNAME("EditorIcons")),
+					get_theme_icon(SNAME("InterpCubic"), SNAME("EditorIcons"))
+				};
+				Ref<Texture2D> cont_icon[4] = {
+					get_theme_icon(SNAME("TrackContinuous"), SNAME("EditorIcons")),
+					get_theme_icon(SNAME("TrackDiscrete"), SNAME("EditorIcons")),
+					get_theme_icon(SNAME("TrackTrigger"), SNAME("EditorIcons")),
+					get_theme_icon(SNAME("TrackCapture"), SNAME("EditorIcons"))
+				};
+
+				int ofs = get_size().width - timeline->get_buttons_width();
+
+				Ref<Texture2D> down_icon = get_theme_icon(SNAME("select_arrow"), SNAME("Tree"));
+
+				draw_line(Point2(ofs, 0), Point2(ofs, get_size().height), linecolor, Math::round(EDSCALE));
+
+				ofs += hsep;
+				{
+					// Callmode.
+
+					Animation::UpdateMode update_mode;
+
+					if (animation->track_get_type(track) == Animation::TYPE_VALUE) {
+						update_mode = animation->value_track_get_update_mode(track);
+					} else {
+						update_mode = Animation::UPDATE_CONTINUOUS;
+					}
+
+					Ref<Texture2D> update_icon = cont_icon[update_mode];
+
+					update_mode_rect.position.x = ofs;
+					update_mode_rect.position.y = int(get_size().height - update_icon->get_height()) / 2;
+					update_mode_rect.size = update_icon->get_size();
+
+					if (!animation->track_is_compressed(track) && animation->track_get_type(track) == Animation::TYPE_VALUE) {
+						draw_texture(update_icon, update_mode_rect.position);
+					}
+					// Make it easier to click.
+					update_mode_rect.position.y = 0;
+					update_mode_rect.size.y = get_size().height;
+
+					ofs += update_icon->get_width() + hsep / 2;
+					update_mode_rect.size.x += hsep / 2;
+
+					if (animation->track_get_type(track) == Animation::TYPE_VALUE) {
+						draw_texture(down_icon, Vector2(ofs, int(get_size().height - down_icon->get_height()) / 2));
+						update_mode_rect.size.x += down_icon->get_width();
+					} else if (animation->track_get_type(track) == Animation::TYPE_BEZIER) {
+						Ref<Texture2D> bezier_icon = get_theme_icon(SNAME("EditBezier"), SNAME("EditorIcons"));
+						update_mode_rect.size.x += down_icon->get_width();
+
+						update_mode_rect = Rect2();
+					} else {
+						update_mode_rect = Rect2();
+					}
+
+					ofs += down_icon->get_width();
+					draw_line(Point2(ofs + hsep * 0.5, 0), Point2(ofs + hsep * 0.5, get_size().height), linecolor, Math::round(EDSCALE));
+					ofs += hsep;
+				}
+
+				{
+					// Interp.
+
+					Animation::InterpolationType interp_mode = animation->track_get_interpolation_type(track);
+
+					Ref<Texture2D> icon = interp_icon[interp_mode];
+
+					interp_mode_rect.position.x = ofs;
+					interp_mode_rect.position.y = int(get_size().height - icon->get_height()) / 2;
+					interp_mode_rect.size = icon->get_size();
+
+					if (!animation->track_is_compressed(track) && (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_BLEND_SHAPE || animation->track_get_type(track) == Animation::TYPE_POSITION_3D || animation->track_get_type(track) == Animation::TYPE_SCALE_3D || animation->track_get_type(track) == Animation::TYPE_ROTATION_3D)) {
+						draw_texture(icon, interp_mode_rect.position);
+					}
+					// Make it easier to click.
+					interp_mode_rect.position.y = 0;
+					interp_mode_rect.size.y = get_size().height;
+
+					ofs += icon->get_width() + hsep / 2;
+					interp_mode_rect.size.x += hsep / 2;
+
+					if (!animation->track_is_compressed(track) && (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_BLEND_SHAPE || animation->track_get_type(track) == Animation::TYPE_POSITION_3D || animation->track_get_type(track) == Animation::TYPE_SCALE_3D || animation->track_get_type(track) == Animation::TYPE_ROTATION_3D)) {
+						draw_texture(down_icon, Vector2(ofs, int(get_size().height - down_icon->get_height()) / 2));
+						interp_mode_rect.size.x += down_icon->get_width();
+					} else {
+						interp_mode_rect = Rect2();
+					}
+
+					ofs += down_icon->get_width();
+					draw_line(Point2(ofs + hsep * 0.5, 0), Point2(ofs + hsep * 0.5, get_size().height), linecolor, Math::round(EDSCALE));
+					ofs += hsep;
+				}
+
+				{
+					// Loop.
+
+					bool loop_wrap = animation->track_get_interpolation_loop_wrap(track);
+
+					Ref<Texture2D> icon = wrap_icon[loop_wrap ? 1 : 0];
+
+					loop_wrap_rect.position.x = ofs;
+					loop_wrap_rect.position.y = int(get_size().height - icon->get_height()) / 2;
+					loop_wrap_rect.size = icon->get_size();
+
+					if (!animation->track_is_compressed(track) && (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_BLEND_SHAPE || animation->track_get_type(track) == Animation::TYPE_POSITION_3D || animation->track_get_type(track) == Animation::TYPE_SCALE_3D || animation->track_get_type(track) == Animation::TYPE_ROTATION_3D)) {
+						draw_texture(icon, loop_wrap_rect.position);
+					}
+
+					loop_wrap_rect.position.y = 0;
+					loop_wrap_rect.size.y = get_size().height;
+
+					ofs += icon->get_width() + hsep / 2;
+					loop_wrap_rect.size.x += hsep / 2;
+
+					if (!animation->track_is_compressed(track) && (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_BLEND_SHAPE || animation->track_get_type(track) == Animation::TYPE_POSITION_3D || animation->track_get_type(track) == Animation::TYPE_SCALE_3D || animation->track_get_type(track) == Animation::TYPE_ROTATION_3D)) {
+						draw_texture(down_icon, Vector2(ofs, int(get_size().height - down_icon->get_height()) / 2));
+						loop_wrap_rect.size.x += down_icon->get_width();
+					} else {
+						loop_wrap_rect = Rect2();
+					}
+
+					ofs += down_icon->get_width();
+					draw_line(Point2(ofs + hsep * 0.5, 0), Point2(ofs + hsep * 0.5, get_size().height), linecolor, Math::round(EDSCALE));
+					ofs += hsep;
+				}
+
+				{
+					// Erase.
+
+					Ref<Texture2D> icon = get_theme_icon(animation->track_is_compressed(track) ? SNAME("Lock") : SNAME("Remove"), SNAME("EditorIcons"));
+
+					remove_rect.position.x = ofs + ((get_size().width - ofs) - icon->get_width());
+					remove_rect.position.y = int(get_size().height - icon->get_height()) / 2;
+					remove_rect.size = icon->get_size();
+
+					draw_texture(icon, remove_rect.position);
+				}
 			}
 
 			if (in_group) {
-				if (animation->track_get_type(track) == Animation::TYPE_METHOD) {
-					text = TTR("Functions:");
-				} else if (animation->track_get_type(track) == Animation::TYPE_AUDIO) {
-					text = TTR("Audio Clips:");
-				} else if (animation->track_get_type(track) == Animation::TYPE_ANIMATION) {
-					text = TTR("Anim Clips:");
-				} else {
-					text += path.get_concatenated_subnames();
-				}
-				text_color.a *= 0.7;
-			} else if (node) {
-				Ref<Texture2D> icon = EditorNode::get_singleton()->get_object_icon(node, "Node");
-
-				draw_texture(icon, Point2(ofs, int(get_size().height - icon->get_height()) / 2));
-				icon_cache = icon;
-
-				text = String() + node->get_name() + ":" + path.get_concatenated_subnames();
-				ofs += hsep;
-				ofs += icon->get_width();
-
+				draw_line(Vector2(timeline->get_name_limit(), get_size().height), get_size(), linecolor, Math::round(EDSCALE));
 			} else {
-				icon_cache = type_icon;
-
-				text = path;
+				draw_line(Vector2(0, get_size().height), get_size(), linecolor, Math::round(EDSCALE));
 			}
 
-			path_cache = text;
-
-			path_rect = Rect2(ofs, 0, limit - ofs - hsep, get_size().height);
-
-			Vector2 string_pos = Point2(ofs, (get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size));
-			string_pos = string_pos.floor();
-			draw_string(font, string_pos, text, HORIZONTAL_ALIGNMENT_LEFT, limit - ofs - hsep, font_size, text_color);
-
-			draw_line(Point2(limit, 0), Point2(limit, get_size().height), linecolor, Math::round(EDSCALE));
-		}
-
-		// KEYFRAMES //
-
-		draw_bg(limit, get_size().width - timeline->get_buttons_width());
-
-		{
-			float scale = timeline->get_zoom_scale();
-			int limit_end = get_size().width - timeline->get_buttons_width();
-
-			for (int i = 0; i < animation->track_get_key_count(track); i++) {
-				float offset = animation->track_get_key_time(track, i) - timeline->get_value();
-				if (editor->is_key_selected(track, i) && editor->is_moving_selection()) {
-					offset = editor->snap_time(offset + editor->get_moving_selection_offset(), true);
-				}
-				offset = offset * scale + limit;
-				if (i < animation->track_get_key_count(track) - 1) {
-					float offset_n = animation->track_get_key_time(track, i + 1) - timeline->get_value();
-					if (editor->is_key_selected(track, i + 1) && editor->is_moving_selection()) {
-						offset_n = editor->snap_time(offset_n + editor->get_moving_selection_offset());
-					}
-					offset_n = offset_n * scale + limit;
-
-					draw_key_link(i, scale, int(offset), int(offset_n), limit, limit_end);
-				}
-
-				draw_key(i, scale, int(offset), editor->is_key_selected(track, i), limit, limit_end);
-			}
-		}
-
-		draw_fg(limit, get_size().width - timeline->get_buttons_width());
-
-		// BUTTONS //
-
-		{
-			Ref<Texture2D> wrap_icon[2] = {
-				get_theme_icon(SNAME("InterpWrapClamp"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("InterpWrapLoop"), SNAME("EditorIcons")),
-			};
-
-			Ref<Texture2D> interp_icon[3] = {
-				get_theme_icon(SNAME("InterpRaw"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("InterpLinear"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("InterpCubic"), SNAME("EditorIcons"))
-			};
-			Ref<Texture2D> cont_icon[4] = {
-				get_theme_icon(SNAME("TrackContinuous"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("TrackDiscrete"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("TrackTrigger"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("TrackCapture"), SNAME("EditorIcons"))
-			};
-
-			int ofs = get_size().width - timeline->get_buttons_width();
-
-			Ref<Texture2D> down_icon = get_theme_icon(SNAME("select_arrow"), SNAME("Tree"));
-
-			draw_line(Point2(ofs, 0), Point2(ofs, get_size().height), linecolor, Math::round(EDSCALE));
-
-			ofs += hsep;
-			{
-				// Callmode.
-
-				Animation::UpdateMode update_mode;
-
-				if (animation->track_get_type(track) == Animation::TYPE_VALUE) {
-					update_mode = animation->value_track_get_update_mode(track);
+			if (dropping_at != 0) {
+				Color drop_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
+				if (dropping_at < 0) {
+					draw_line(Vector2(0, 0), Vector2(get_size().width, 0), drop_color, Math::round(EDSCALE));
 				} else {
-					update_mode = Animation::UPDATE_CONTINUOUS;
+					draw_line(Vector2(0, get_size().height), get_size(), drop_color, Math::round(EDSCALE));
 				}
-
-				Ref<Texture2D> update_icon = cont_icon[update_mode];
-
-				update_mode_rect.position.x = ofs;
-				update_mode_rect.position.y = int(get_size().height - update_icon->get_height()) / 2;
-				update_mode_rect.size = update_icon->get_size();
-
-				if (!animation->track_is_compressed(track) && animation->track_get_type(track) == Animation::TYPE_VALUE) {
-					draw_texture(update_icon, update_mode_rect.position);
-				}
-				// Make it easier to click.
-				update_mode_rect.position.y = 0;
-				update_mode_rect.size.y = get_size().height;
-
-				ofs += update_icon->get_width() + hsep / 2;
-				update_mode_rect.size.x += hsep / 2;
-
-				if (animation->track_get_type(track) == Animation::TYPE_VALUE) {
-					draw_texture(down_icon, Vector2(ofs, int(get_size().height - down_icon->get_height()) / 2));
-					update_mode_rect.size.x += down_icon->get_width();
-				} else if (animation->track_get_type(track) == Animation::TYPE_BEZIER) {
-					Ref<Texture2D> bezier_icon = get_theme_icon(SNAME("EditBezier"), SNAME("EditorIcons"));
-					update_mode_rect.size.x += down_icon->get_width();
-
-					update_mode_rect = Rect2();
-				} else {
-					update_mode_rect = Rect2();
-				}
-
-				ofs += down_icon->get_width();
-				draw_line(Point2(ofs + hsep * 0.5, 0), Point2(ofs + hsep * 0.5, get_size().height), linecolor, Math::round(EDSCALE));
-				ofs += hsep;
 			}
+		} break;
 
-			{
-				// Interp.
-
-				Animation::InterpolationType interp_mode = animation->track_get_interpolation_type(track);
-
-				Ref<Texture2D> icon = interp_icon[interp_mode];
-
-				interp_mode_rect.position.x = ofs;
-				interp_mode_rect.position.y = int(get_size().height - icon->get_height()) / 2;
-				interp_mode_rect.size = icon->get_size();
-
-				if (!animation->track_is_compressed(track) && (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_BLEND_SHAPE || animation->track_get_type(track) == Animation::TYPE_POSITION_3D || animation->track_get_type(track) == Animation::TYPE_SCALE_3D || animation->track_get_type(track) == Animation::TYPE_ROTATION_3D)) {
-					draw_texture(icon, interp_mode_rect.position);
-				}
-				// Make it easier to click.
-				interp_mode_rect.position.y = 0;
-				interp_mode_rect.size.y = get_size().height;
-
-				ofs += icon->get_width() + hsep / 2;
-				interp_mode_rect.size.x += hsep / 2;
-
-				if (!animation->track_is_compressed(track) && (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_BLEND_SHAPE || animation->track_get_type(track) == Animation::TYPE_POSITION_3D || animation->track_get_type(track) == Animation::TYPE_SCALE_3D || animation->track_get_type(track) == Animation::TYPE_ROTATION_3D)) {
-					draw_texture(down_icon, Vector2(ofs, int(get_size().height - down_icon->get_height()) / 2));
-					interp_mode_rect.size.x += down_icon->get_width();
-				} else {
-					interp_mode_rect = Rect2();
-				}
-
-				ofs += down_icon->get_width();
-				draw_line(Point2(ofs + hsep * 0.5, 0), Point2(ofs + hsep * 0.5, get_size().height), linecolor, Math::round(EDSCALE));
-				ofs += hsep;
-			}
-
-			{
-				// Loop.
-
-				bool loop_wrap = animation->track_get_interpolation_loop_wrap(track);
-
-				Ref<Texture2D> icon = wrap_icon[loop_wrap ? 1 : 0];
-
-				loop_wrap_rect.position.x = ofs;
-				loop_wrap_rect.position.y = int(get_size().height - icon->get_height()) / 2;
-				loop_wrap_rect.size = icon->get_size();
-
-				if (!animation->track_is_compressed(track) && (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_BLEND_SHAPE || animation->track_get_type(track) == Animation::TYPE_POSITION_3D || animation->track_get_type(track) == Animation::TYPE_SCALE_3D || animation->track_get_type(track) == Animation::TYPE_ROTATION_3D)) {
-					draw_texture(icon, loop_wrap_rect.position);
-				}
-
-				loop_wrap_rect.position.y = 0;
-				loop_wrap_rect.size.y = get_size().height;
-
-				ofs += icon->get_width() + hsep / 2;
-				loop_wrap_rect.size.x += hsep / 2;
-
-				if (!animation->track_is_compressed(track) && (animation->track_get_type(track) == Animation::TYPE_VALUE || animation->track_get_type(track) == Animation::TYPE_BLEND_SHAPE || animation->track_get_type(track) == Animation::TYPE_POSITION_3D || animation->track_get_type(track) == Animation::TYPE_SCALE_3D || animation->track_get_type(track) == Animation::TYPE_ROTATION_3D)) {
-					draw_texture(down_icon, Vector2(ofs, int(get_size().height - down_icon->get_height()) / 2));
-					loop_wrap_rect.size.x += down_icon->get_width();
-				} else {
-					loop_wrap_rect = Rect2();
-				}
-
-				ofs += down_icon->get_width();
-				draw_line(Point2(ofs + hsep * 0.5, 0), Point2(ofs + hsep * 0.5, get_size().height), linecolor, Math::round(EDSCALE));
-				ofs += hsep;
-			}
-
-			{
-				// Erase.
-
-				Ref<Texture2D> icon = get_theme_icon(animation->track_is_compressed(track) ? SNAME("Lock") : SNAME("Remove"), SNAME("EditorIcons"));
-
-				remove_rect.position.x = ofs + ((get_size().width - ofs) - icon->get_width());
-				remove_rect.position.y = int(get_size().height - icon->get_height()) / 2;
-				remove_rect.size = icon->get_size();
-
-				draw_texture(icon, remove_rect.position);
-			}
-		}
-
-		if (in_group) {
-			draw_line(Vector2(timeline->get_name_limit(), get_size().height), get_size(), linecolor, Math::round(EDSCALE));
-		} else {
-			draw_line(Vector2(0, get_size().height), get_size(), linecolor, Math::round(EDSCALE));
-		}
-
-		if (dropping_at != 0) {
-			Color drop_color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
-			if (dropping_at < 0) {
-				draw_line(Vector2(0, 0), Vector2(get_size().width, 0), drop_color, Math::round(EDSCALE));
-			} else {
-				draw_line(Vector2(0, get_size().height), get_size(), drop_color, Math::round(EDSCALE));
-			}
-		}
-	}
-
-	if (p_what == NOTIFICATION_MOUSE_EXIT || p_what == NOTIFICATION_DRAG_END) {
-		cancel_drop();
+		case NOTIFICATION_MOUSE_EXIT:
+		case NOTIFICATION_DRAG_END: {
+			cancel_drop();
+		} break;
 	}
 }
 
@@ -3205,40 +3211,42 @@ AnimationTrackEdit *AnimationTrackEditPlugin::create_animation_track_edit(Object
 ///////////////////////////////////////
 
 void AnimationTrackEditGroup::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
-		int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
-		int separation = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
-		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
+			int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
+			int separation = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
+			Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 
-		if (root && root->has_node(node)) {
-			Node *n = root->get_node(node);
-			if (n && EditorNode::get_singleton()->get_editor_selection()->is_selected(n)) {
-				color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
+			if (root && root->has_node(node)) {
+				Node *n = root->get_node(node);
+				if (n && EditorNode::get_singleton()->get_editor_selection()->is_selected(n)) {
+					color = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
+				}
 			}
-		}
 
-		Color bgcol = get_theme_color(SNAME("dark_color_2"), SNAME("Editor"));
-		bgcol.a *= 0.6;
-		draw_rect(Rect2(Point2(), get_size()), bgcol);
-		Color linecolor = color;
-		linecolor.a = 0.2;
+			Color bgcol = get_theme_color(SNAME("dark_color_2"), SNAME("Editor"));
+			bgcol.a *= 0.6;
+			draw_rect(Rect2(Point2(), get_size()), bgcol);
+			Color linecolor = color;
+			linecolor.a = 0.2;
 
-		draw_line(Point2(), Point2(get_size().width, 0), linecolor, Math::round(EDSCALE));
-		draw_line(Point2(timeline->get_name_limit(), 0), Point2(timeline->get_name_limit(), get_size().height), linecolor, Math::round(EDSCALE));
-		draw_line(Point2(get_size().width - timeline->get_buttons_width(), 0), Point2(get_size().width - timeline->get_buttons_width(), get_size().height), linecolor, Math::round(EDSCALE));
+			draw_line(Point2(), Point2(get_size().width, 0), linecolor, Math::round(EDSCALE));
+			draw_line(Point2(timeline->get_name_limit(), 0), Point2(timeline->get_name_limit(), get_size().height), linecolor, Math::round(EDSCALE));
+			draw_line(Point2(get_size().width - timeline->get_buttons_width(), 0), Point2(get_size().width - timeline->get_buttons_width(), get_size().height), linecolor, Math::round(EDSCALE));
 
-		int ofs = 0;
-		draw_texture(icon, Point2(ofs, int(get_size().height - icon->get_height()) / 2));
-		ofs += separation + icon->get_width();
-		draw_string(font, Point2(ofs, int(get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size)), node_name, HORIZONTAL_ALIGNMENT_LEFT, timeline->get_name_limit() - ofs, font_size, color);
+			int ofs = 0;
+			draw_texture(icon, Point2(ofs, int(get_size().height - icon->get_height()) / 2));
+			ofs += separation + icon->get_width();
+			draw_string(font, Point2(ofs, int(get_size().height - font->get_height(font_size)) / 2 + font->get_ascent(font_size)), node_name, HORIZONTAL_ALIGNMENT_LEFT, timeline->get_name_limit() - ofs, font_size, color);
 
-		int px = (-timeline->get_value() + timeline->get_play_position()) * timeline->get_zoom_scale() + timeline->get_name_limit();
+			int px = (-timeline->get_value() + timeline->get_play_position()) * timeline->get_zoom_scale() + timeline->get_name_limit();
 
-		if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
-			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
-			draw_line(Point2(px, 0), Point2(px, get_size().height), accent, Math::round(2 * EDSCALE));
-		}
+			if (px >= timeline->get_name_limit() && px < (get_size().width - timeline->get_buttons_width())) {
+				Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
+				draw_line(Point2(px, 0), Point2(px, get_size().height), accent, Math::round(2 * EDSCALE));
+			}
+		} break;
 	}
 }
 
@@ -4516,27 +4524,33 @@ MenuButton *AnimationTrackEditor::get_edit_menu() {
 }
 
 void AnimationTrackEditor::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
-	}
+	switch (p_what) {
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
+		} break;
 
-	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
-		zoom_icon->set_texture(get_theme_icon(SNAME("Zoom"), SNAME("EditorIcons")));
-		bezier_edit_icon->set_icon(get_theme_icon(SNAME("EditBezier"), SNAME("EditorIcons")));
-		snap->set_icon(get_theme_icon(SNAME("Snap"), SNAME("EditorIcons")));
-		view_group->set_icon(get_theme_icon(view_group->is_pressed() ? SNAME("AnimationTrackList") : SNAME("AnimationTrackGroup"), SNAME("EditorIcons")));
-		selected_filter->set_icon(get_theme_icon(SNAME("AnimationFilter"), SNAME("EditorIcons")));
-		imported_anim_warning->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
-		main_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
-		edit->get_popup()->set_item_icon(edit->get_popup()->get_item_index(EDIT_APPLY_RESET), get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
-	}
+		case NOTIFICATION_ENTER_TREE: {
+			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
+			[[fallthrough]];
+		}
+		case NOTIFICATION_THEME_CHANGED: {
+			zoom_icon->set_texture(get_theme_icon(SNAME("Zoom"), SNAME("EditorIcons")));
+			bezier_edit_icon->set_icon(get_theme_icon(SNAME("EditBezier"), SNAME("EditorIcons")));
+			snap->set_icon(get_theme_icon(SNAME("Snap"), SNAME("EditorIcons")));
+			view_group->set_icon(get_theme_icon(view_group->is_pressed() ? SNAME("AnimationTrackList") : SNAME("AnimationTrackGroup"), SNAME("EditorIcons")));
+			selected_filter->set_icon(get_theme_icon(SNAME("AnimationFilter"), SNAME("EditorIcons")));
+			imported_anim_warning->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
+			main_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
+			edit->get_popup()->set_item_icon(edit->get_popup()->get_item_index(EDIT_APPLY_RESET), get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
+		} break;
 
-	if (p_what == NOTIFICATION_READY) {
-		EditorNode::get_singleton()->get_editor_selection()->connect("selection_changed", callable_mp(this, &AnimationTrackEditor::_selection_changed));
-	}
+		case NOTIFICATION_READY: {
+			EditorNode::get_singleton()->get_editor_selection()->connect("selection_changed", callable_mp(this, &AnimationTrackEditor::_selection_changed));
+		} break;
 
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		update_keying();
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			update_keying();
+		} break;
 	}
 }
 

--- a/editor/audio_stream_preview.cpp
+++ b/editor/audio_stream_preview.cpp
@@ -214,25 +214,27 @@ void AudioStreamPreviewGenerator::_bind_methods() {
 AudioStreamPreviewGenerator *AudioStreamPreviewGenerator::singleton = nullptr;
 
 void AudioStreamPreviewGenerator::_notification(int p_what) {
-	if (p_what == NOTIFICATION_PROCESS) {
-		List<ObjectID> to_erase;
-		for (KeyValue<ObjectID, Preview> &E : previews) {
-			if (!E.value.generating.is_set()) {
-				if (E.value.thread) {
-					E.value.thread->wait_to_finish();
-					memdelete(E.value.thread);
-					E.value.thread = nullptr;
-				}
-				if (!ObjectDB::get_instance(E.key)) { //no longer in use, get rid of preview
-					to_erase.push_back(E.key);
+	switch (p_what) {
+		case NOTIFICATION_PROCESS: {
+			List<ObjectID> to_erase;
+			for (KeyValue<ObjectID, Preview> &E : previews) {
+				if (!E.value.generating.is_set()) {
+					if (E.value.thread) {
+						E.value.thread->wait_to_finish();
+						memdelete(E.value.thread);
+						E.value.thread = nullptr;
+					}
+					if (!ObjectDB::get_instance(E.key)) { //no longer in use, get rid of preview
+						to_erase.push_back(E.key);
+					}
 				}
 			}
-		}
 
-		while (to_erase.front()) {
-			previews.erase(to_erase.front()->get());
-			to_erase.pop_front();
-		}
+			while (to_erase.front()) {
+				previews.erase(to_erase.front()->get());
+				to_erase.pop_front();
+			}
+		} break;
 	}
 }
 

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -85,29 +85,31 @@ GotoLineDialog::GotoLineDialog() {
 }
 
 void FindReplaceBar::_notification(int p_what) {
-	if (p_what == NOTIFICATION_READY) {
-		find_prev->set_icon(get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")));
-		find_next->set_icon(get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")));
-		hide_button->set_normal_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
-		hide_button->set_hover_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
-		hide_button->set_pressed_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
-		hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
-	} else if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		set_process_unhandled_input(is_visible_in_tree());
-	} else if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		find_prev->set_icon(get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")));
-		find_next->set_icon(get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")));
-		hide_button->set_normal_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
-		hide_button->set_hover_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
-		hide_button->set_pressed_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
-		hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
-	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
-		matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
-	} else if (p_what == NOTIFICATION_PREDELETE) {
-		if (base_text_editor) {
-			base_text_editor->remove_find_replace_bar();
-			base_text_editor = nullptr;
-		}
+	switch (p_what) {
+		case NOTIFICATION_READY:
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			find_prev->set_icon(get_theme_icon(SNAME("MoveUp"), SNAME("EditorIcons")));
+			find_next->set_icon(get_theme_icon(SNAME("MoveDown"), SNAME("EditorIcons")));
+			hide_button->set_normal_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+			hide_button->set_hover_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+			hide_button->set_pressed_texture(get_theme_icon(SNAME("Close"), SNAME("EditorIcons")));
+			hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			set_process_unhandled_input(is_visible_in_tree());
+		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
+		} break;
+
+		case NOTIFICATION_PREDELETE: {
+			if (base_text_editor) {
+				base_text_editor->remove_find_replace_bar();
+				base_text_editor = nullptr;
+			}
+		} break;
 	}
 }
 
@@ -1658,44 +1660,47 @@ void CodeTextEditor::_error_pressed(const Ref<InputEvent> &p_event) {
 	}
 }
 
+void CodeTextEditor::_update_status_bar_theme() {
+	error_button->set_icon(get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons")));
+	error_button->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+	error_button->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	error_button->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+
+	warning_button->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
+	warning_button->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+	warning_button->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	warning_button->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+
+	line_and_col_txt->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	line_and_col_txt->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+}
+
 void CodeTextEditor::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_ENTER_TREE: {
+			_update_status_bar_theme();
+		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
-			error_button->set_icon(get_theme_icon(SNAME("StatusError"), SNAME("EditorIcons")));
-			error_button->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
-			error_button->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
-			error_button->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
-
-			warning_button->set_icon(get_theme_icon(SNAME("NodeWarning"), SNAME("EditorIcons")));
-			warning_button->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
-			warning_button->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
-			warning_button->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
-
-			line_and_col_txt->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
-			line_and_col_txt->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
-
-			if (p_what == NOTIFICATION_ENTER_TREE) {
-				break;
-			}
+			_update_status_bar_theme();
 			if (toggle_scripts_button->is_visible()) {
 				update_toggle_scripts_button();
 			}
 			_update_text_editor_theme();
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (toggle_scripts_button->is_visible()) {
 				update_toggle_scripts_button();
 			}
 			set_process_input(is_visible_in_tree());
 		} break;
+
 		case NOTIFICATION_PREDELETE: {
 			if (find_replace_bar) {
 				find_replace_bar->set_text_edit(nullptr);
 			}
 		} break;
-		default:
-			break;
 	}
 }
 

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -189,6 +189,8 @@ class CodeTextEditor : public VBoxContainer {
 	void _set_show_warnings_panel(bool p_show);
 	void _error_pressed(const Ref<InputEvent> &p_event);
 
+	void _update_status_bar_theme();
+
 	void _delete_line(int p_line);
 	void _toggle_scripts_pressed();
 

--- a/editor/connections_dialog.cpp
+++ b/editor/connections_dialog.cpp
@@ -277,8 +277,10 @@ void ConnectDialog::_update_ok_enabled() {
 }
 
 void ConnectDialog::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		bind_editor->edit(cdbinds);
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			bind_editor->edit(cdbinds);
+		} break;
 	}
 }
 
@@ -938,6 +940,7 @@ void ConnectionsDock::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 		} break;
+
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			update_tree();
 		} break;

--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -429,9 +429,11 @@ void CreateDialog::_notification(int p_what) {
 			connect("confirmed", callable_mp(this, &CreateDialog::_confirmed));
 			_update_theme();
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			disconnect("confirmed", callable_mp(this, &CreateDialog::_confirmed));
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			if (is_visible()) {
 				search_box->call_deferred(SNAME("grab_focus")); // still not visible
@@ -440,6 +442,7 @@ void CreateDialog::_notification(int p_what) {
 				EditorSettings::get_singleton()->get_project_metadata("dialog_bounds", "create_new_node", Rect2(get_position(), get_size()));
 			}
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_theme();
 		} break;

--- a/editor/debugger/debug_adapter/debug_adapter_server.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_server.cpp
@@ -42,12 +42,14 @@ DebugAdapterServer::DebugAdapterServer() {
 
 void DebugAdapterServer::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_ENTER_TREE: {
 			start();
-			break;
-		case NOTIFICATION_EXIT_TREE:
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
 			stop();
-			break;
+		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			// The main loop can be run again during request processing, which modifies internal state of the protocol.
 			// Thus, "polling" is needed to prevent it from parsing other requests while the current one isn't finished.
@@ -57,6 +59,7 @@ void DebugAdapterServer::_notification(int p_what) {
 				polling = false;
 			}
 		} break;
+
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			protocol._request_timeout = EditorSettings::get_singleton()->get("network/debug_adapter/request_timeout");
 			protocol._sync_breakpoints = EditorSettings::get_singleton()->get("network/debug_adapter/sync_breakpoints");

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -107,14 +107,13 @@ void EditorDebuggerInspector::_bind_methods() {
 
 void EditorDebuggerInspector::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_POSTINITIALIZE:
+		case NOTIFICATION_POSTINITIALIZE: {
 			connect("object_id_selected", callable_mp(this, &EditorDebuggerInspector::_object_selected));
-			break;
-		case NOTIFICATION_ENTER_TREE:
+		} break;
+
+		case NOTIFICATION_ENTER_TREE: {
 			edit(variables);
-			break;
-		default:
-			break;
+		} break;
 	}
 }
 

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -240,112 +240,113 @@ void EditorDebuggerNode::_notification(int p_what) {
 				tabs->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));
 			}
 		} break;
+
 		case NOTIFICATION_READY: {
 			_update_debug_options();
 		} break;
-		default:
-			break;
-	}
 
-	if (p_what != NOTIFICATION_PROCESS || !server.is_valid()) {
-		return;
-	}
-
-	if (!server.is_valid() || !server->is_active()) {
-		stop();
-		return;
-	}
-	server->poll();
-
-	// Errors and warnings
-	int error_count = 0;
-	int warning_count = 0;
-	_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
-		error_count += dbg->get_error_count();
-		warning_count += dbg->get_warning_count();
-	});
-
-	if (error_count != last_error_count || warning_count != last_warning_count) {
-		_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
-			dbg->update_tabs();
-		});
-
-		if (error_count == 0 && warning_count == 0) {
-			debugger_button->set_text(TTR("Debugger"));
-			debugger_button->remove_theme_color_override("font_color");
-			debugger_button->set_icon(Ref<Texture2D>());
-		} else {
-			debugger_button->set_text(TTR("Debugger") + " (" + itos(error_count + warning_count) + ")");
-			if (error_count >= 1 && warning_count >= 1) {
-				debugger_button->set_icon(get_theme_icon(SNAME("ErrorWarning"), SNAME("EditorIcons")));
-				// Use error color to represent the highest level of severity reported.
-				debugger_button->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
-			} else if (error_count >= 1) {
-				debugger_button->set_icon(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
-				debugger_button->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
-			} else {
-				debugger_button->set_icon(get_theme_icon(SNAME("Warning"), SNAME("EditorIcons")));
-				debugger_button->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
-			}
-		}
-		last_error_count = error_count;
-		last_warning_count = warning_count;
-	}
-
-	// Remote scene tree update
-	remote_scene_tree_timeout -= get_process_delta_time();
-	if (remote_scene_tree_timeout < 0) {
-		remote_scene_tree_timeout = EditorSettings::get_singleton()->get("debugger/remote_scene_tree_refresh_interval");
-		if (remote_scene_tree->is_visible_in_tree()) {
-			get_current_debugger()->request_remote_tree();
-		}
-	}
-
-	// Remote inspector update
-	inspect_edited_object_timeout -= get_process_delta_time();
-	if (inspect_edited_object_timeout < 0) {
-		inspect_edited_object_timeout = EditorSettings::get_singleton()->get("debugger/remote_inspect_refresh_interval");
-		if (EditorDebuggerRemoteObject *obj = get_inspected_remote_object()) {
-			get_current_debugger()->request_remote_object(obj->remote_object_id);
-		}
-	}
-
-	// Take connections.
-	if (server->is_connection_available()) {
-		ScriptEditorDebugger *debugger = nullptr;
-		_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
-			if (debugger || dbg->is_session_active()) {
+		case NOTIFICATION_PROCESS: {
+			if (!server.is_valid()) {
 				return;
 			}
-			debugger = dbg;
-		});
-		if (debugger == nullptr) {
-			if (tabs->get_tab_count() <= 4) { // Max 4 debugging sessions active.
-				debugger = _add_debugger();
-			} else {
-				// We already have too many sessions, disconnecting new clients to prevent them from hanging.
-				server->take_connection()->close();
-				return; // Can't add, stop here.
+
+			if (!server->is_active()) {
+				stop();
+				return;
 			}
-		}
+			server->poll();
 
-		EditorNode::get_singleton()->get_pause_button()->set_disabled(false);
-		// Switch to remote tree view if so desired.
-		auto_switch_remote_scene_tree = (bool)EditorSettings::get_singleton()->get("debugger/auto_switch_to_remote_scene_tree");
-		if (auto_switch_remote_scene_tree) {
-			SceneTreeDock::get_singleton()->show_remote_tree();
-		}
-		// Good to go.
-		SceneTreeDock::get_singleton()->show_tab_buttons();
-		debugger->set_editor_remote_tree(remote_scene_tree);
-		debugger->start(server->take_connection());
-		// Send breakpoints.
-		for (const KeyValue<Breakpoint, bool> &E : breakpoints) {
-			const Breakpoint &bp = E.key;
-			debugger->set_breakpoint(bp.source, bp.line, E.value);
-		} // Will arrive too late, how does the regular run work?
+			// Errors and warnings
+			int error_count = 0;
+			int warning_count = 0;
+			_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
+				error_count += dbg->get_error_count();
+				warning_count += dbg->get_warning_count();
+			});
 
-		debugger->update_live_edit_root();
+			if (error_count != last_error_count || warning_count != last_warning_count) {
+				_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
+					dbg->update_tabs();
+				});
+
+				if (error_count == 0 && warning_count == 0) {
+					debugger_button->set_text(TTR("Debugger"));
+					debugger_button->remove_theme_color_override("font_color");
+					debugger_button->set_icon(Ref<Texture2D>());
+				} else {
+					debugger_button->set_text(TTR("Debugger") + " (" + itos(error_count + warning_count) + ")");
+					if (error_count >= 1 && warning_count >= 1) {
+						debugger_button->set_icon(get_theme_icon(SNAME("ErrorWarning"), SNAME("EditorIcons")));
+						// Use error color to represent the highest level of severity reported.
+						debugger_button->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+					} else if (error_count >= 1) {
+						debugger_button->set_icon(get_theme_icon(SNAME("Error"), SNAME("EditorIcons")));
+						debugger_button->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+					} else {
+						debugger_button->set_icon(get_theme_icon(SNAME("Warning"), SNAME("EditorIcons")));
+						debugger_button->add_theme_color_override("font_color", get_theme_color(SNAME("warning_color"), SNAME("Editor")));
+					}
+				}
+				last_error_count = error_count;
+				last_warning_count = warning_count;
+			}
+
+			// Remote scene tree update
+			remote_scene_tree_timeout -= get_process_delta_time();
+			if (remote_scene_tree_timeout < 0) {
+				remote_scene_tree_timeout = EditorSettings::get_singleton()->get("debugger/remote_scene_tree_refresh_interval");
+				if (remote_scene_tree->is_visible_in_tree()) {
+					get_current_debugger()->request_remote_tree();
+				}
+			}
+
+			// Remote inspector update
+			inspect_edited_object_timeout -= get_process_delta_time();
+			if (inspect_edited_object_timeout < 0) {
+				inspect_edited_object_timeout = EditorSettings::get_singleton()->get("debugger/remote_inspect_refresh_interval");
+				if (EditorDebuggerRemoteObject *obj = get_inspected_remote_object()) {
+					get_current_debugger()->request_remote_object(obj->remote_object_id);
+				}
+			}
+
+			// Take connections.
+			if (server->is_connection_available()) {
+				ScriptEditorDebugger *debugger = nullptr;
+				_for_all(tabs, [&](ScriptEditorDebugger *dbg) {
+					if (debugger || dbg->is_session_active()) {
+						return;
+					}
+					debugger = dbg;
+				});
+				if (debugger == nullptr) {
+					if (tabs->get_tab_count() <= 4) { // Max 4 debugging sessions active.
+						debugger = _add_debugger();
+					} else {
+						// We already have too many sessions, disconnecting new clients to prevent them from hanging.
+						server->take_connection()->close();
+						return; // Can't add, stop here.
+					}
+				}
+
+				EditorNode::get_singleton()->get_pause_button()->set_disabled(false);
+				// Switch to remote tree view if so desired.
+				auto_switch_remote_scene_tree = (bool)EditorSettings::get_singleton()->get("debugger/auto_switch_to_remote_scene_tree");
+				if (auto_switch_remote_scene_tree) {
+					SceneTreeDock::get_singleton()->show_remote_tree();
+				}
+				// Good to go.
+				SceneTreeDock::get_singleton()->show_tab_buttons();
+				debugger->set_editor_remote_tree(remote_scene_tree);
+				debugger->start(server->take_connection());
+				// Send breakpoints.
+				for (const KeyValue<Breakpoint, bool> &E : breakpoints) {
+					const Breakpoint &bp = E.key;
+					debugger->set_breakpoint(bp.source, bp.line, E.value);
+				} // Will arrive too late, how does the regular run work?
+
+				debugger->update_live_edit_root();
+			}
+		} break;
 	}
 }
 

--- a/editor/debugger/editor_debugger_tree.cpp
+++ b/editor/debugger/editor_debugger_tree.cpp
@@ -53,10 +53,12 @@ EditorDebuggerTree::EditorDebuggerTree() {
 }
 
 void EditorDebuggerTree::_notification(int p_what) {
-	if (p_what == NOTIFICATION_POSTINITIALIZE) {
-		connect("cell_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_selected));
-		connect("item_collapsed", callable_mp(this, &EditorDebuggerTree::_scene_tree_folded));
-		connect("item_rmb_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_rmb_selected));
+	switch (p_what) {
+		case NOTIFICATION_POSTINITIALIZE: {
+			connect("cell_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_selected));
+			connect("item_collapsed", callable_mp(this, &EditorDebuggerTree::_scene_tree_folded));
+			connect("item_rmb_selected", callable_mp(this, &EditorDebuggerTree::_scene_tree_rmb_selected));
+		} break;
 	}
 }
 

--- a/editor/debugger/editor_network_profiler.cpp
+++ b/editor/debugger/editor_network_profiler.cpp
@@ -39,15 +39,18 @@ void EditorNetworkProfiler::_bind_methods() {
 }
 
 void EditorNetworkProfiler::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
-		clear_button->set_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
-		incoming_bandwidth_text->set_right_icon(get_theme_icon(SNAME("ArrowDown"), SNAME("EditorIcons")));
-		outgoing_bandwidth_text->set_right_icon(get_theme_icon(SNAME("ArrowUp"), SNAME("EditorIcons")));
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
+			clear_button->set_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
+			incoming_bandwidth_text->set_right_icon(get_theme_icon(SNAME("ArrowDown"), SNAME("EditorIcons")));
+			outgoing_bandwidth_text->set_right_icon(get_theme_icon(SNAME("ArrowUp"), SNAME("EditorIcons")));
 
-		// This needs to be done here to set the faded color when the profiler is first opened
-		incoming_bandwidth_text->add_theme_color_override("font_uneditable_color", get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, 0.5));
-		outgoing_bandwidth_text->add_theme_color_override("font_uneditable_color", get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, 0.5));
+			// This needs to be done here to set the faded color when the profiler is first opened
+			incoming_bandwidth_text->add_theme_color_override("font_uneditable_color", get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, 0.5));
+			outgoing_bandwidth_text->add_theme_color_override("font_uneditable_color", get_theme_color(SNAME("font_color"), SNAME("Editor")) * Color(1, 1, 1, 0.5));
+		} break;
 	}
 }
 

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -393,9 +393,13 @@ void EditorProfiler::_clear_pressed() {
 }
 
 void EditorProfiler::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED || p_what == NOTIFICATION_TRANSLATION_CHANGED) {
-		activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
-		clear_button->set_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
+			clear_button->set_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
+		} break;
 	}
 }
 

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -423,13 +423,17 @@ void EditorVisualProfiler::_clear_pressed() {
 }
 
 void EditorVisualProfiler::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_LAYOUT_DIRECTION_CHANGED || p_what == NOTIFICATION_TRANSLATION_CHANGED) {
-		if (is_layout_rtl()) {
-			activate->set_icon(get_theme_icon(SNAME("PlayBackwards"), SNAME("EditorIcons")));
-		} else {
-			activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
-		}
-		clear_button->set_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_LAYOUT_DIRECTION_CHANGED:
+		case NOTIFICATION_TRANSLATION_CHANGED: {
+			if (is_layout_rtl()) {
+				activate->set_icon(get_theme_icon(SNAME("PlayBackwards"), SNAME("EditorIcons")));
+			} else {
+				activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
+			}
+			clear_button->set_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
+		} break;
 	}
 }
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -796,8 +796,8 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			search->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 
 			reason->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
-
 		} break;
+
 		case NOTIFICATION_PROCESS: {
 			if (is_session_active()) {
 				peer->poll();
@@ -857,6 +857,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 				break;
 			};
 		} break;
+
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			if (tabs->has_theme_stylebox_override("panel")) {
 				tabs->add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("DebuggerPanel"), SNAME("EditorStyles")));

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -98,6 +98,7 @@ void EditorAudioBus::_notification(int p_what) {
 			update_bus();
 			set_process(true);
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			if (is_master) {
 				draw_style_box(get_theme_stylebox(SNAME("disabled"), SNAME("Button")), Rect2(Vector2(), get_size()));
@@ -113,6 +114,7 @@ void EditorAudioBus::_notification(int p_what) {
 				draw_rect(Rect2(Point2(), get_size()), accent, false);
 			}
 		} break;
+
 		case NOTIFICATION_PROCESS: {
 			if (cc != AudioServer::get_singleton()->get_bus_channels(get_index())) {
 				cc = AudioServer::get_singleton()->get_bus_channels(get_index());
@@ -157,6 +159,7 @@ void EditorAudioBus::_notification(int p_what) {
 				}
 			}
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			for (int i = 0; i < CHANNELS_MAX; i++) {
 				channel[i].peak_l = -100;
@@ -952,12 +955,14 @@ void EditorAudioBusDrop::_notification(int p_what) {
 				draw_rect(Rect2(Point2(), get_size()), accent, false);
 			}
 		} break;
+
 		case NOTIFICATION_MOUSE_ENTER: {
 			if (!hovering_drop) {
 				hovering_drop = true;
 				update();
 			}
 		} break;
+
 		case NOTIFICATION_MOUSE_EXIT:
 		case NOTIFICATION_DRAG_END: {
 			if (hovering_drop) {
@@ -1017,15 +1022,18 @@ void EditorAudioBuses::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			bus_scroll->add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("Tree")));
 		} break;
+
 		case NOTIFICATION_READY: {
 			_update_buses();
 		} break;
+
 		case NOTIFICATION_DRAG_END: {
 			if (drop_end) {
 				drop_end->queue_delete();
 				drop_end = nullptr;
 			}
 		} break;
+
 		case NOTIFICATION_PROCESS: {
 			// Check if anything was edited.
 			bool edited = AudioServer::get_singleton()->is_edited();
@@ -1401,6 +1409,7 @@ void EditorAudioMeterNotches::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			notch_color = get_theme_color(SNAME("font_color"), SNAME("Editor"));
 		} break;
+
 		case NOTIFICATION_DRAW: {
 			_draw_audio_notches();
 		} break;

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -42,23 +42,27 @@
 #define PREVIEW_LIST_MAX_SIZE 10
 
 void EditorAutoloadSettings::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		List<String> afn;
-		ResourceLoader::get_recognized_extensions_for_type("Script", &afn);
-		ResourceLoader::get_recognized_extensions_for_type("PackedScene", &afn);
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			List<String> afn;
+			ResourceLoader::get_recognized_extensions_for_type("Script", &afn);
+			ResourceLoader::get_recognized_extensions_for_type("PackedScene", &afn);
 
-		for (const String &E : afn) {
-			file_dialog->add_filter("*." + E);
-		}
-
-		for (const AutoLoadInfo &info : autoload_cache) {
-			if (info.node && info.in_editor) {
-				get_tree()->get_root()->call_deferred(SNAME("add_child"), info.node);
+			for (const String &E : afn) {
+				file_dialog->add_filter("*." + E);
 			}
-		}
-		browse_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
-	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
-		browse_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
+
+			for (const AutoLoadInfo &info : autoload_cache) {
+				if (info.node && info.in_editor) {
+					get_tree()->get_root()->call_deferred(SNAME("add_child"), info.node);
+				}
+			}
+			browse_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
+		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			browse_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
+		} break;
 	}
 }
 

--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -79,29 +79,31 @@ void EditorDirDialog::reload(const String &p_path) {
 }
 
 void EditorDirDialog::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload), make_binds(""));
-		reload();
-
-		if (!tree->is_connected("item_collapsed", callable_mp(this, &EditorDirDialog::_item_collapsed))) {
-			tree->connect("item_collapsed", callable_mp(this, &EditorDirDialog::_item_collapsed), varray(), CONNECT_DEFERRED);
-		}
-
-		if (!EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &EditorDirDialog::reload))) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
 			EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload), make_binds(""));
-		}
-	}
-
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		if (EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &EditorDirDialog::reload))) {
-			EditorFileSystem::get_singleton()->disconnect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload));
-		}
-	}
-
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		if (must_reload && is_visible()) {
 			reload();
-		}
+
+			if (!tree->is_connected("item_collapsed", callable_mp(this, &EditorDirDialog::_item_collapsed))) {
+				tree->connect("item_collapsed", callable_mp(this, &EditorDirDialog::_item_collapsed), varray(), CONNECT_DEFERRED);
+			}
+
+			if (!EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &EditorDirDialog::reload))) {
+				EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload), make_binds(""));
+			}
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			if (EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &EditorDirDialog::reload))) {
+				EditorFileSystem::get_singleton()->disconnect("filesystem_changed", callable_mp(this, &EditorDirDialog::reload));
+			}
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (must_reload && is_visible()) {
+				reload();
+			}
+		} break;
 	}
 }
 

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1544,6 +1544,7 @@ void EditorExport::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			load_config();
 		} break;
+
 		case NOTIFICATION_PROCESS: {
 			update_export_presets();
 		} break;

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -309,18 +309,20 @@ EditorFeatureProfile::EditorFeatureProfile() {}
 //////////////////////////
 
 void EditorFeatureProfileManager::_notification(int p_what) {
-	if (p_what == NOTIFICATION_READY) {
-		current_profile = EDITOR_GET("_default_feature_profile");
-		if (!current_profile.is_empty()) {
-			current.instantiate();
-			Error err = current->load_from_file(EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(current_profile + ".profile"));
-			if (err != OK) {
-				ERR_PRINT("Error loading default feature profile: " + current_profile);
-				current_profile = String();
-				current.unref();
+	switch (p_what) {
+		case NOTIFICATION_READY: {
+			current_profile = EDITOR_GET("_default_feature_profile");
+			if (!current_profile.is_empty()) {
+				current.instantiate();
+				Error err = current->load_from_file(EditorSettings::get_singleton()->get_feature_profiles_dir().plus_file(current_profile + ".profile"));
+				if (err != OK) {
+					ERR_PRINT("Error loading default feature profile: " + current_profile);
+					current_profile = String();
+					current.unref();
+				}
 			}
-		}
-		_update_profile_list(current_profile);
+			_update_profile_list(current_profile);
+		} break;
 	}
 }
 

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1163,6 +1163,7 @@ void EditorFileSystem::_notification(int p_what) {
 			call_deferred(SNAME("scan")); //this should happen after every editor node entered the tree
 
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			Thread &active_thread = thread.is_started() ? thread : thread_sources;
 			if (use_threads && active_thread.is_started()) {
@@ -1184,8 +1185,8 @@ void EditorFileSystem::_notification(int p_what) {
 			}
 			filesystem = nullptr;
 			new_filesystem = nullptr;
-
 		} break;
+
 		case NOTIFICATION_PROCESS: {
 			if (use_threads) {
 				if (scanning_changes) {

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -1770,17 +1770,17 @@ void EditorHelp::_notification(int p_what) {
 			_wait_for_thread();
 			_update_doc();
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			if (is_inside_tree()) {
 				_class_desc_resized(true);
 			}
 			update_toggle_scripts_button();
 		} break;
-		case NOTIFICATION_VISIBILITY_CHANGED:
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
 			update_toggle_scripts_button();
-			break;
-		default:
-			break;
+		} break;
 	}
 }
 
@@ -2041,6 +2041,7 @@ void FindBar::_notification(int p_what) {
 			hide_button->set_custom_minimum_size(hide_button->get_normal_texture()->get_size());
 			matches_label->add_theme_color_override("font_color", results_count > 0 ? get_theme_color(SNAME("font_color"), SNAME("Label")) : get_theme_color(SNAME("error_color"), SNAME("Editor")));
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			set_process_unhandled_input(is_visible_in_tree());
 		} break;

--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -111,9 +111,11 @@ void EditorHelpSearch::_notification(int p_what) {
 				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "search_help", Rect2(get_position(), get_size()));
 			}
 		} break;
+
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			_update_icons();
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			connect("confirmed", callable_mp(this, &EditorHelpSearch::_confirmed));
 			_update_icons();

--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -93,12 +93,11 @@ void EditorLog::_notification(int p_what) {
 			_update_theme();
 			_load_state();
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_theme();
 			_rebuild_log();
 		} break;
-		default:
-			break;
 	}
 }
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -849,11 +849,14 @@ void EditorPlugin::_editor_project_settings_changed() {
 	emit_signal(SNAME("project_settings_changed"));
 }
 void EditorPlugin::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		EditorNode::get_singleton()->connect("project_settings_changed", callable_mp(this, &EditorPlugin::_editor_project_settings_changed));
-	}
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		EditorNode::get_singleton()->disconnect("project_settings_changed", callable_mp(this, &EditorPlugin::_editor_project_settings_changed));
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			EditorNode::get_singleton()->connect("project_settings_changed", callable_mp(this, &EditorPlugin::_editor_project_settings_changed));
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			EditorNode::get_singleton()->disconnect("project_settings_changed", callable_mp(this, &EditorPlugin::_editor_project_settings_changed));
+		} break;
 	}
 }
 

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -39,11 +39,15 @@
 #include "scene/gui/margin_container.h"
 
 void EditorPluginSettings::_notification(int p_what) {
-	if (p_what == NOTIFICATION_WM_WINDOW_FOCUS_IN) {
-		update_plugins();
-	} else if (p_what == Node::NOTIFICATION_READY) {
-		plugin_config_dialog->connect("plugin_ready", Callable(EditorNode::get_singleton(), "_on_plugin_ready"));
-		plugin_list->connect("button_pressed", callable_mp(this, &EditorPluginSettings::_cell_button_pressed));
+	switch (p_what) {
+		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
+			update_plugins();
+		} break;
+
+		case Node::NOTIFICATION_READY: {
+			plugin_config_dialog->connect("plugin_ready", Callable(EditorNode::get_singleton(), "_on_plugin_ready"));
+			plugin_list->connect("button_pressed", callable_mp(this, &EditorPluginSettings::_cell_button_pressed));
+		} break;
 	}
 }
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -166,7 +166,6 @@ void EditorPropertyMultilineText::_notification(int p_what) {
 			Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
 			int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 			text->set_custom_minimum_size(Vector2(0, font->get_height(font_size) * 6));
-
 		} break;
 	}
 }
@@ -294,11 +293,11 @@ void EditorPropertyTextEnum::_bind_methods() {
 void EditorPropertyTextEnum::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
-		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
 			edit_button->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
 			accept_button->set_icon(get_theme_icon(SNAME("ImportCheck"), SNAME("EditorIcons")));
 			cancel_button->set_icon(get_theme_icon(SNAME("ImportFail"), SNAME("EditorIcons")));
-			break;
+		} break;
 	}
 }
 
@@ -374,8 +373,11 @@ void EditorPropertyLocale::setup(const String &p_hint_text) {
 }
 
 void EditorPropertyLocale::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		locale_edit->set_icon(get_theme_icon(SNAME("Translation"), SNAME("EditorIcons")));
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			locale_edit->set_icon(get_theme_icon(SNAME("Translation"), SNAME("EditorIcons")));
+		} break;
 	}
 }
 
@@ -467,8 +469,11 @@ void EditorPropertyPath::set_save_mode() {
 }
 
 void EditorPropertyPath::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		path_edit->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			path_edit->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
+		} break;
 	}
 }
 
@@ -1065,9 +1070,6 @@ void EditorPropertyLayersGrid::_notification(int p_what) {
 				update();
 			}
 		} break;
-
-		default:
-			break;
 	}
 }
 
@@ -1619,11 +1621,14 @@ void EditorPropertyVector2::update_property() {
 }
 
 void EditorPropertyVector2::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		const Color *colors = _get_property_colors();
-		for (int i = 0; i < 2; i++) {
-			spin[i]->set_custom_label_color(true, colors[i]);
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color *colors = _get_property_colors();
+			for (int i = 0; i < 2; i++) {
+				spin[i]->set_custom_label_color(true, colors[i]);
+			}
+		} break;
 	}
 }
 
@@ -1710,11 +1715,14 @@ void EditorPropertyRect2::update_property() {
 }
 
 void EditorPropertyRect2::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		const Color *colors = _get_property_colors();
-		for (int i = 0; i < 4; i++) {
-			spin[i]->set_custom_label_color(true, colors[i % 2]);
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color *colors = _get_property_colors();
+			for (int i = 0; i < 4; i++) {
+				spin[i]->set_custom_label_color(true, colors[i % 2]);
+			}
+		} break;
 	}
 }
 
@@ -1836,11 +1844,14 @@ Vector3 EditorPropertyVector3::get_vector() {
 }
 
 void EditorPropertyVector3::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		const Color *colors = _get_property_colors();
-		for (int i = 0; i < 3; i++) {
-			spin[i]->set_custom_label_color(true, colors[i]);
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color *colors = _get_property_colors();
+			for (int i = 0; i < 3; i++) {
+				spin[i]->set_custom_label_color(true, colors[i]);
+			}
+		} break;
 	}
 }
 
@@ -1923,11 +1934,14 @@ void EditorPropertyVector2i::update_property() {
 }
 
 void EditorPropertyVector2i::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		const Color *colors = _get_property_colors();
-		for (int i = 0; i < 2; i++) {
-			spin[i]->set_custom_label_color(true, colors[i]);
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color *colors = _get_property_colors();
+			for (int i = 0; i < 2; i++) {
+				spin[i]->set_custom_label_color(true, colors[i]);
+			}
+		} break;
 	}
 }
 
@@ -2014,11 +2028,14 @@ void EditorPropertyRect2i::update_property() {
 }
 
 void EditorPropertyRect2i::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		const Color *colors = _get_property_colors();
-		for (int i = 0; i < 4; i++) {
-			spin[i]->set_custom_label_color(true, colors[i % 2]);
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color *colors = _get_property_colors();
+			for (int i = 0; i < 4; i++) {
+				spin[i]->set_custom_label_color(true, colors[i % 2]);
+			}
+		} break;
 	}
 }
 
@@ -2113,11 +2130,14 @@ void EditorPropertyVector3i::update_property() {
 }
 
 void EditorPropertyVector3i::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		const Color *colors = _get_property_colors();
-		for (int i = 0; i < 3; i++) {
-			spin[i]->set_custom_label_color(true, colors[i]);
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color *colors = _get_property_colors();
+			for (int i = 0; i < 3; i++) {
+				spin[i]->set_custom_label_color(true, colors[i]);
+			}
+		} break;
 	}
 }
 
@@ -2203,11 +2223,14 @@ void EditorPropertyPlane::update_property() {
 }
 
 void EditorPropertyPlane::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		const Color *colors = _get_property_colors();
-		for (int i = 0; i < 4; i++) {
-			spin[i]->set_custom_label_color(true, colors[i]);
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color *colors = _get_property_colors();
+			for (int i = 0; i < 4; i++) {
+				spin[i]->set_custom_label_color(true, colors[i]);
+			}
+		} break;
 	}
 }
 
@@ -2294,11 +2317,14 @@ void EditorPropertyQuaternion::update_property() {
 }
 
 void EditorPropertyQuaternion::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		const Color *colors = _get_property_colors();
-		for (int i = 0; i < 4; i++) {
-			spin[i]->set_custom_label_color(true, colors[i]);
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color *colors = _get_property_colors();
+			for (int i = 0; i < 4; i++) {
+				spin[i]->set_custom_label_color(true, colors[i]);
+			}
+		} break;
 	}
 }
 
@@ -2388,11 +2414,14 @@ void EditorPropertyAABB::update_property() {
 }
 
 void EditorPropertyAABB::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		const Color *colors = _get_property_colors();
-		for (int i = 0; i < 6; i++) {
-			spin[i]->set_custom_label_color(true, colors[i % 3]);
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color *colors = _get_property_colors();
+			for (int i = 0; i < 6; i++) {
+				spin[i]->set_custom_label_color(true, colors[i % 3]);
+			}
+		} break;
 	}
 }
 
@@ -2469,16 +2498,19 @@ void EditorPropertyTransform2D::update_property() {
 }
 
 void EditorPropertyTransform2D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		const Color *colors = _get_property_colors();
-		for (int i = 0; i < 6; i++) {
-			// For Transform2D, use the 4th color (cyan) for the origin vector.
-			if (i % 3 == 2) {
-				spin[i]->set_custom_label_color(true, colors[3]);
-			} else {
-				spin[i]->set_custom_label_color(true, colors[i % 3]);
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color *colors = _get_property_colors();
+			for (int i = 0; i < 6; i++) {
+				// For Transform2D, use the 4th color (cyan) for the origin vector.
+				if (i % 3 == 2) {
+					spin[i]->set_custom_label_color(true, colors[3]);
+				} else {
+					spin[i]->set_custom_label_color(true, colors[i % 3]);
+				}
 			}
-		}
+		} break;
 	}
 }
 
@@ -2562,11 +2594,14 @@ void EditorPropertyBasis::update_property() {
 }
 
 void EditorPropertyBasis::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		const Color *colors = _get_property_colors();
-		for (int i = 0; i < 9; i++) {
-			spin[i]->set_custom_label_color(true, colors[i % 3]);
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color *colors = _get_property_colors();
+			for (int i = 0; i < 9; i++) {
+				spin[i]->set_custom_label_color(true, colors[i % 3]);
+			}
+		} break;
 	}
 }
 
@@ -2656,11 +2691,14 @@ void EditorPropertyTransform3D::update_using_transform(Transform3D p_transform) 
 }
 
 void EditorPropertyTransform3D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		const Color *colors = _get_property_colors();
-		for (int i = 0; i < 12; i++) {
-			spin[i]->set_custom_label_color(true, colors[i % 4]);
-		}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			const Color *colors = _get_property_colors();
+			for (int i = 0; i < 12; i++) {
+				spin[i]->set_custom_label_color(true, colors[i % 4]);
+			}
+		} break;
 	}
 }
 
@@ -2902,9 +2940,12 @@ void EditorPropertyNodePath::setup(const NodePath &p_base_hint, Vector<StringNam
 }
 
 void EditorPropertyNodePath::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		Ref<Texture2D> t = get_theme_icon(SNAME("Clear"), SNAME("EditorIcons"));
-		clear->set_icon(t);
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			Ref<Texture2D> t = get_theme_icon(SNAME("Clear"), SNAME("EditorIcons"));
+			clear->set_icon(t);
+		} break;
 	}
 }
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -504,34 +504,37 @@ void EditorPropertyArray::drop_data_fw(const Point2 &p_point, const Variant &p_d
 }
 
 void EditorPropertyArray::_notification(int p_what) {
-	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
-		change_type->clear();
-		for (int i = 0; i < Variant::VARIANT_MAX; i++) {
-			String type = Variant::get_type_name(Variant::Type(i));
-			change_type->add_icon_item(get_theme_icon(type, SNAME("EditorIcons")), type, i);
-		}
-		change_type->add_separator();
-		change_type->add_icon_item(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), TTR("Remove Item"), Variant::VARIANT_MAX);
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_ENTER_TREE: {
+			change_type->clear();
+			for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+				String type = Variant::get_type_name(Variant::Type(i));
+				change_type->add_icon_item(get_theme_icon(type, SNAME("EditorIcons")), type, i);
+			}
+			change_type->add_separator();
+			change_type->add_icon_item(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), TTR("Remove Item"), Variant::VARIANT_MAX);
 
-		if (Object::cast_to<Button>(button_add_item)) {
-			button_add_item->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
-		}
-	}
+			if (Object::cast_to<Button>(button_add_item)) {
+				button_add_item->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_DRAG_BEGIN) {
-		if (is_visible_in_tree()) {
-			if (_is_drop_valid(get_viewport()->gui_get_drag_data())) {
-				dropping = true;
+		case NOTIFICATION_DRAG_BEGIN: {
+			if (is_visible_in_tree()) {
+				if (_is_drop_valid(get_viewport()->gui_get_drag_data())) {
+					dropping = true;
+					edit->update();
+				}
+			}
+		} break;
+
+		case NOTIFICATION_DRAG_END: {
+			if (dropping) {
+				dropping = false;
 				edit->update();
 			}
-		}
-	}
-
-	if (p_what == NOTIFICATION_DRAG_END) {
-		if (dropping) {
-			dropping = false;
-			edit->update();
-		}
+		} break;
 	}
 }
 
@@ -1151,18 +1154,21 @@ void EditorPropertyDictionary::_object_id_selected(const StringName &p_property,
 }
 
 void EditorPropertyDictionary::_notification(int p_what) {
-	if (p_what == NOTIFICATION_THEME_CHANGED || p_what == NOTIFICATION_ENTER_TREE) {
-		change_type->clear();
-		for (int i = 0; i < Variant::VARIANT_MAX; i++) {
-			String type = Variant::get_type_name(Variant::Type(i));
-			change_type->add_icon_item(get_theme_icon(type, SNAME("EditorIcons")), type, i);
-		}
-		change_type->add_separator();
-		change_type->add_icon_item(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), TTR("Remove Item"), Variant::VARIANT_MAX);
+	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_ENTER_TREE: {
+			change_type->clear();
+			for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+				String type = Variant::get_type_name(Variant::Type(i));
+				change_type->add_icon_item(get_theme_icon(type, SNAME("EditorIcons")), type, i);
+			}
+			change_type->add_separator();
+			change_type->add_icon_item(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")), TTR("Remove Item"), Variant::VARIANT_MAX);
 
-		if (Object::cast_to<Button>(button_add_item)) {
-			button_add_item->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
-		}
+			if (Object::cast_to<Button>(button_add_item)) {
+				button_add_item->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+			}
+		} break;
 	}
 }
 

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -35,61 +35,63 @@
 #include "editor/editor_scale.h"
 
 void EditorRunNative::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		for (int i = 0; i < EditorExport::get_singleton()->get_export_platform_count(); i++) {
-			Ref<EditorExportPlatform> eep = EditorExport::get_singleton()->get_export_platform(i);
-			if (eep.is_null()) {
-				continue;
-			}
-			Ref<ImageTexture> icon = eep->get_run_icon();
-			if (!icon.is_null()) {
-				Ref<Image> im = icon->get_image();
-				im = im->duplicate();
-				im->clear_mipmaps();
-				if (!im->is_empty()) {
-					im->resize(16 * EDSCALE, 16 * EDSCALE);
-					Ref<ImageTexture> small_icon;
-					small_icon.instantiate();
-					small_icon->create_from_image(im);
-					MenuButton *mb = memnew(MenuButton);
-					mb->get_popup()->connect("id_pressed", callable_mp(this, &EditorRunNative::run_native), varray(i));
-					mb->connect("pressed", callable_mp(this, &EditorRunNative::run_native), varray(-1, i));
-					mb->set_icon(small_icon);
-					add_child(mb);
-					menus[i] = mb;
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			for (int i = 0; i < EditorExport::get_singleton()->get_export_platform_count(); i++) {
+				Ref<EditorExportPlatform> eep = EditorExport::get_singleton()->get_export_platform(i);
+				if (eep.is_null()) {
+					continue;
 				}
-			}
-		}
-	}
-
-	if (p_what == NOTIFICATION_PROCESS) {
-		bool changed = EditorExport::get_singleton()->poll_export_platforms() || first;
-
-		if (changed) {
-			for (KeyValue<int, MenuButton *> &E : menus) {
-				Ref<EditorExportPlatform> eep = EditorExport::get_singleton()->get_export_platform(E.key);
-				MenuButton *mb = E.value;
-				int dc = eep->get_options_count();
-
-				if (dc == 0) {
-					mb->hide();
-				} else {
-					mb->get_popup()->clear();
-					mb->show();
-					if (dc == 1) {
-						mb->set_tooltip(eep->get_option_tooltip(0));
-					} else {
-						mb->set_tooltip(eep->get_options_tooltip());
-						for (int i = 0; i < dc; i++) {
-							mb->get_popup()->add_icon_item(eep->get_option_icon(i), eep->get_option_label(i));
-							mb->get_popup()->set_item_tooltip(mb->get_popup()->get_item_count() - 1, eep->get_option_tooltip(i));
-						}
+				Ref<ImageTexture> icon = eep->get_run_icon();
+				if (!icon.is_null()) {
+					Ref<Image> im = icon->get_image();
+					im = im->duplicate();
+					im->clear_mipmaps();
+					if (!im->is_empty()) {
+						im->resize(16 * EDSCALE, 16 * EDSCALE);
+						Ref<ImageTexture> small_icon;
+						small_icon.instantiate();
+						small_icon->create_from_image(im);
+						MenuButton *mb = memnew(MenuButton);
+						mb->get_popup()->connect("id_pressed", callable_mp(this, &EditorRunNative::run_native), varray(i));
+						mb->connect("pressed", callable_mp(this, &EditorRunNative::run_native), varray(-1, i));
+						mb->set_icon(small_icon);
+						add_child(mb);
+						menus[i] = mb;
 					}
 				}
 			}
+		} break;
 
-			first = false;
-		}
+		case NOTIFICATION_PROCESS: {
+			bool changed = EditorExport::get_singleton()->poll_export_platforms() || first;
+
+			if (changed) {
+				for (KeyValue<int, MenuButton *> &E : menus) {
+					Ref<EditorExportPlatform> eep = EditorExport::get_singleton()->get_export_platform(E.key);
+					MenuButton *mb = E.value;
+					int dc = eep->get_options_count();
+
+					if (dc == 0) {
+						mb->hide();
+					} else {
+						mb->get_popup()->clear();
+						mb->show();
+						if (dc == 1) {
+							mb->set_tooltip(eep->get_option_tooltip(0));
+						} else {
+							mb->set_tooltip(eep->get_options_tooltip());
+							for (int i = 0; i < dc; i++) {
+								mb->get_popup()->add_icon_item(eep->get_option_icon(i), eep->get_option_label(i));
+								mb->get_popup()->set_item_tooltip(mb->get_popup()->get_item_count() - 1, eep->get_option_tooltip(i));
+							}
+						}
+					}
+				}
+
+				first = false;
+			}
+		} break;
 	}
 }
 

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -121,14 +121,17 @@ void EditorSettingsDialog::_notification(int p_what) {
 				set_process_unhandled_input(false);
 			}
 		} break;
+
 		case NOTIFICATION_READY: {
 			undo_redo->set_method_notify_callback(EditorDebuggerNode::_method_changeds, nullptr);
 			undo_redo->set_property_notify_callback(EditorDebuggerNode::_property_changeds, nullptr);
 			undo_redo->set_commit_notify_callback(_undo_redo_callback, this);
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			_update_icons();
 		} break;
+
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			_update_icons();
 			// Update theme colors.

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -430,47 +430,49 @@ void EditorSpinSlider::_draw_spin_slider() {
 void EditorSpinSlider::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
-		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
 			_update_value_input_stylebox();
-			break;
+		} break;
 
-		case NOTIFICATION_INTERNAL_PROCESS:
+		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (value_input_dirty) {
 				value_input_dirty = false;
 				value_input->set_text(get_text_value());
 			}
 			set_process_internal(false);
-			break;
+		} break;
 
-		case NOTIFICATION_DRAW:
+		case NOTIFICATION_DRAW: {
 			_draw_spin_slider();
-			break;
+		} break;
 
 		case NOTIFICATION_WM_WINDOW_FOCUS_IN:
 		case NOTIFICATION_WM_WINDOW_FOCUS_OUT:
-		case NOTIFICATION_EXIT_TREE:
+		case NOTIFICATION_EXIT_TREE: {
 			if (grabbing_spinner) {
 				grabber->hide();
 				Input::get_singleton()->set_mouse_mode(Input::MOUSE_MODE_VISIBLE);
 				grabbing_spinner = false;
 				grabbing_spinner_attempt = false;
 			}
-			break;
+		} break;
 
-		case NOTIFICATION_MOUSE_ENTER:
+		case NOTIFICATION_MOUSE_ENTER: {
 			mouse_over_spin = true;
 			update();
-			break;
-		case NOTIFICATION_MOUSE_EXIT:
+		} break;
+
+		case NOTIFICATION_MOUSE_EXIT: {
 			mouse_over_spin = false;
 			update();
-			break;
-		case NOTIFICATION_FOCUS_ENTER:
+		} break;
+
+		case NOTIFICATION_FOCUS_ENTER: {
 			if ((Input::get_singleton()->is_action_pressed("ui_focus_next") || Input::get_singleton()->is_action_pressed("ui_focus_prev")) && !value_input_just_closed) {
 				_focus_entered();
 			}
 			value_input_just_closed = false;
-			break;
+		} break;
 	}
 }
 

--- a/editor/editor_toaster.cpp
+++ b/editor/editor_toaster.cpp
@@ -104,6 +104,7 @@ void EditorToaster::_notification(int p_what) {
 				main_button->update();
 			}
 		} break;
+
 		case NOTIFICATION_ENTER_TREE:
 		case NOTIFICATION_THEME_CHANGED: {
 			if (vbox_container->is_visible()) {
@@ -134,12 +135,11 @@ void EditorToaster::_notification(int p_what) {
 			main_button->update();
 			disable_notifications_button->update();
 		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			_update_vbox_position();
 			_update_disable_notifications_button();
 		} break;
-		default:
-			break;
 	}
 }
 

--- a/editor/editor_zoom_widget.cpp
+++ b/editor/editor_zoom_widget.cpp
@@ -144,12 +144,10 @@ void EditorZoomWidget::set_zoom_by_increments(int p_increment_count, bool p_inte
 void EditorZoomWidget::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
-		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
 			zoom_minus->set_icon(get_theme_icon(SNAME("ZoomLess"), SNAME("EditorIcons")));
 			zoom_plus->set_icon(get_theme_icon(SNAME("ZoomMore"), SNAME("EditorIcons")));
-			break;
-		default:
-			break;
+		} break;
 	}
 }
 

--- a/editor/find_in_files.cpp
+++ b/editor/find_in_files.cpp
@@ -103,9 +103,11 @@ void FindInFiles::set_filter(const Set<String> &exts) {
 	_extension_filter = exts;
 }
 
-void FindInFiles::_notification(int p_notification) {
-	if (p_notification == NOTIFICATION_PROCESS) {
-		_process();
+void FindInFiles::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_PROCESS: {
+			_process();
+		} break;
 	}
 }
 
@@ -456,26 +458,28 @@ Set<String> FindInFilesDialog::get_filter() const {
 }
 
 void FindInFilesDialog::_notification(int p_what) {
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		if (is_visible()) {
-			// Doesn't work more than once if not deferred...
-			_search_text_line_edit->call_deferred(SNAME("grab_focus"));
-			_search_text_line_edit->select_all();
-			// Extensions might have changed in the meantime, we clean them and instance them again.
-			for (int i = 0; i < _filters_container->get_child_count(); i++) {
-				_filters_container->get_child(i)->queue_delete();
-			}
-			Array exts = ProjectSettings::get_singleton()->get("editor/script/search_in_file_extensions");
-			for (int i = 0; i < exts.size(); ++i) {
-				CheckBox *cb = memnew(CheckBox);
-				cb->set_text(exts[i]);
-				if (!_filters_preferences.has(exts[i])) {
-					_filters_preferences[exts[i]] = true;
+	switch (p_what) {
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (is_visible()) {
+				// Doesn't work more than once if not deferred...
+				_search_text_line_edit->call_deferred(SNAME("grab_focus"));
+				_search_text_line_edit->select_all();
+				// Extensions might have changed in the meantime, we clean them and instance them again.
+				for (int i = 0; i < _filters_container->get_child_count(); i++) {
+					_filters_container->get_child(i)->queue_delete();
 				}
-				cb->set_pressed(_filters_preferences[exts[i]]);
-				_filters_container->add_child(cb);
+				Array exts = ProjectSettings::get_singleton()->get("editor/script/search_in_file_extensions");
+				for (int i = 0; i < exts.size(); ++i) {
+					CheckBox *cb = memnew(CheckBox);
+					cb->set_text(exts[i]);
+					if (!_filters_preferences.has(exts[i])) {
+						_filters_preferences[exts[i]] = true;
+					}
+					cb->set_pressed(_filters_preferences[exts[i]]);
+					_filters_container->add_child(cb);
+				}
 			}
-		}
+		} break;
 	}
 }
 
@@ -687,11 +691,15 @@ void FindInFilesPanel::stop_search() {
 }
 
 void FindInFilesPanel::_notification(int p_what) {
-	if (p_what == NOTIFICATION_PROCESS) {
-		_progress_bar->set_as_ratio(_finder->get_progress());
-	} else if (p_what == NOTIFICATION_THEME_CHANGED) {
-		_search_text_label->add_theme_font_override("font", get_theme_font(SNAME("source"), SNAME("EditorFonts")));
-		_results_display->add_theme_font_override("font", get_theme_font(SNAME("source"), SNAME("EditorFonts")));
+	switch (p_what) {
+		case NOTIFICATION_PROCESS: {
+			_progress_bar->set_as_ratio(_finder->get_progress());
+		} break;
+
+		case NOTIFICATION_THEME_CHANGED: {
+			_search_text_label->add_theme_font_override("font", get_theme_font(SNAME("source"), SNAME("EditorFonts")));
+			_results_display->add_theme_font_override("font", get_theme_font(SNAME("source"), SNAME("EditorFonts")));
+		} break;
 	}
 }
 

--- a/editor/find_in_files.h
+++ b/editor/find_in_files.h
@@ -60,7 +60,7 @@ public:
 	float get_progress() const;
 
 protected:
-	void _notification(int p_notification);
+	void _notification(int p_what);
 
 	static void _bind_methods();
 


### PR DESCRIPTION
> Following https://github.com/godotengine/godot/pull/58151, the rest of the codebase should be given the same treatment to review all \_notification methods and ensure that they use switch statements instead of a list of if (p_what == NOTIFICATION_*).

First chunk of #58155

```core/object/script_language.cpp
editor/action_map_editor.cpp
editor/animation_bezier_editor.cpp
editor/animation_track_editor.cpp
editor/audio_stream_preview.cpp
editor/code_editor.cpp
editor/connections_dialog.cpp
editor/create_dialog.cpp
editor/debugger/debug_adapter/debug_adapter_server.cpp
editor/debugger/editor_debugger_inspector.cpp
editor/debugger/editor_debugger_node.cpp
editor/debugger/editor_debugger_tree.cpp
editor/debugger/editor_network_profiler.cpp
editor/debugger/editor_profiler.cpp
editor/debugger/editor_visual_profiler.cpp
editor/debugger/script_editor_debugger.cpp
editor/editor_about.cpp
editor/editor_audio_buses.cpp
editor/editor_autoload_settings.cpp
editor/editor_dir_dialog.cpp
editor/editor_export.cpp
editor/editor_feature_profile.cpp
editor/editor_file_dialog.cpp
editor/editor_file_system.cpp
editor/editor_help.cpp
editor/editor_help_search.cpp
editor/editor_inspector.cpp
editor/editor_log.cpp
editor/editor_node.cpp
editor/editor_path.cpp
editor/editor_plugin.cpp
editor/editor_plugin_settings.cpp
editor/editor_properties_array_dict.cpp
editor/editor_properties.cpp
editor/editor_resource_picker.cpp
editor/editor_run_native.cpp
editor/editor_settings_dialog.cpp
editor/editor_spin_slider.cpp
editor/editor_toaster.cpp
editor/editor_zoom_widget.cpp
editor/export_template_manager.cpp
editor/filesystem_dock.cpp
editor/find_in_files.cpp```