### PR TITLE
Add an option to clamp HDR exposure to reduce environment fireflies

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -217,6 +217,7 @@ void ResourceImporterTexture::get_import_options(const String &p_path, List<Impo
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "process/premult_alpha"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "process/normal_map_invert_y"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "process/hdr_as_srgb"), false));
+	r_options->push_back(ImportOption(PropertyInfo(Variant::BOOL, "process/hdr_clamp_exposure"), false));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "process/size_limit", PROPERTY_HINT_RANGE, "0,4096,1"), 0));
 	r_options->push_back(ImportOption(PropertyInfo(Variant::INT, "detect_3d/compress_to", PROPERTY_HINT_ENUM, "Disabled,VRAM Compressed,Basis Universal"), (p_preset == PRESET_DETECT) ? 1 : 0));
 
@@ -411,6 +412,7 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 	const bool stream = p_options["compress/streamed"];
 	const int size_limit = p_options["process/size_limit"];
 	const bool hdr_as_srgb = p_options["process/hdr_as_srgb"];
+	const bool hdr_clamp_exposure = p_options["process/hdr_clamp_exposure"];
 	const int normal = p_options["compress/normal_map"];
 	const int hdr_compression = p_options["compress/hdr_compression"];
 	const int bptc_ldr = p_options["compress/bptc_ldr"];
@@ -478,6 +480,34 @@ Error ResourceImporterTexture::import(const String &p_source_file, const String 
 			for (int j = 0; j < height; j++) {
 				const Color color = image->get_pixel(i, j);
 				image->set_pixel(i, j, Color(color.r, 1 - color.g, color.b));
+			}
+		}
+	}
+
+	if (hdr_clamp_exposure) {
+		// Clamp HDR exposure following Filament's tonemapping formula.
+		// This can be used to reduce fireflies in environment maps or reduce the influence
+		// of the sun from an HDRI panorama on environment lighting (when a DirectionalLight3D is used instead).
+		const int height = image->get_height();
+		const int width = image->get_width();
+
+		// These values are chosen arbitrarily and seem to produce good results with 4,096 samples.
+		const float linear = 4096.0;
+		const float compressed = 16384.0;
+
+		for (int i = 0; i < width; i++) {
+			for (int j = 0; j < height; j++) {
+				const Color color = image->get_pixel(i, j);
+				const float luma = color.get_luminance();
+
+				Color clamped_color;
+				if (luma <= linear) {
+					clamped_color = color;
+				} else {
+					clamped_color = (color / luma) * ((linear * linear - compressed * luma) / (2 * linear - compressed - luma));
+				}
+
+				image->set_pixel(i, j, clamped_color);
 			}
 		}
 	}


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/60588.

HDRI panoramas designed for realistic lighting can have extremely bright suns, causing fireflies to appear in the environment reflection (in addition to making environment lighting too bright when a DirectionalLight3D is used).

This uses the Filament tonemapping formula.

This closes https://github.com/godotengine/godot-proposals/issues/886.

**Testing project:** [test_radiance_map_high_quality_1.zip](https://github.com/godotengine/godot/files/8075791/test_radiance_map_high_quality_1.zip)

## Preview

*I recommend comparing non-clamped versions without a DirectionalLight3D against clamped versions that use a DirectionalLight3D.*

### No DirectionalLight3D

#### High Quality filter mode

| Without clamping | With clamping |
|-|-|
| ![2022-02-18_18 50 28_720p](https://user-images.githubusercontent.com/180032/154736506-4317782c-2bdc-407e-852a-33e61871468f.png) | ![2022-02-18_18 50 55_720p](https://user-images.githubusercontent.com/180032/154736535-c7fbf8b5-0173-49f7-8b17-5b9dffce2f00.png) |

#### Real-Time filter mode

| Without clamping | With clamping |
|-|-|
| ![2022-02-18_18 50 41_720p](https://user-images.githubusercontent.com/180032/154736526-d1d0c9b7-393c-4838-a95d-3ef18168117e.png) | ![2022-02-18_18 51 07_720p](https://user-images.githubusercontent.com/180032/154736549-59138f07-83e6-4081-b038-07a7d22f0f2f.png) |

### With DirectionalLight3D

#### High Quality filter mode

*Looks too bright without clamping, but brightness is good with clamping.*

| Without clamping | With clamping |
|-|-|
| ![2022-02-18_18 51 28_720p](https://user-images.githubusercontent.com/180032/154736565-4461555a-20ce-4fb9-a950-02cba83760ad.png) | ![2022-02-18_18 51 49_720p](https://user-images.githubusercontent.com/180032/154736585-09b9f31c-b5e6-488b-9d8b-8fbd42fe6343.png) |

#### Real-Time filter mode

*Looks too bright without clamping, but brightness is good with clamping.*

| Without clamping | With clamping |
|-|-|
| ![2022-02-18_18 51 37_720p](https://user-images.githubusercontent.com/180032/154736576-0ae1e578-9629-4920-9f4d-833fb78362c0.png) | ![2022-02-18_18 51 58_720p](https://user-images.githubusercontent.com/180032/154736602-8f5a9d9d-260d-426d-9e91-fcdec24db350.png) |