### PR TITLE
Fix default sky process mode not being Real-Time

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.h
@@ -254,7 +254,7 @@ public:
 
 		int radiance_size = 256;
 
-		RS::SkyMode mode = RS::SKY_MODE_AUTOMATIC;
+		RS::SkyMode mode = RS::SKY_MODE_REALTIME;
 
 		ReflectionData reflection;
 		bool dirty = false;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/57931.

The change in 09563e4bd8fa4dda8802b3b48f111f3c1de499d8 wasn't consistently carried out everywhere needed. This led to the sky mode still being Automatic by default, even if the default option in the inspector was Real-Time.