### PR TITLE
Fix loading of binary resources with 64-bit floats

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -901,6 +901,7 @@ void ResourceLoaderBinary::open(FileAccess *p_f, bool p_no_resources, bool p_kee
 	if (flags & ResourceFormatSaverBinaryInstance::FORMAT_FLAG_UIDS) {
 		using_uids = true;
 	}
+	f->real_is_double = (flags & ResourceFormatSaverBinaryInstance::FORMAT_FLAG_REAL_T_IS_DOUBLE) != 0;
 
 	if (using_uids) {
 		uid = f->get_64();
@@ -1902,7 +1903,13 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const RES &p
 
 	save_unicode_string(f, p_resource->get_class());
 	f->store_64(0); //offset to import metadata
-	f->store_32(FORMAT_FLAG_NAMED_SCENE_IDS | FORMAT_FLAG_UIDS);
+	{
+		uint32_t format_flags = FORMAT_FLAG_NAMED_SCENE_IDS | FORMAT_FLAG_UIDS;
+#ifdef REAL_T_IS_DOUBLE
+		format_flags |= FORMAT_FLAG_REAL_T_IS_DOUBLE;
+#endif
+		f->store_32(format_flags);
+	}
 	ResourceUID::ID uid = ResourceSaver::get_resource_id_for_path(p_path, true);
 	f->store_64(uid);
 	for (int i = 0; i < ResourceFormatSaverBinaryInstance::RESERVED_FIELDS; i++) {

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -164,6 +164,8 @@ public:
 	enum {
 		FORMAT_FLAG_NAMED_SCENE_IDS = 1,
 		FORMAT_FLAG_UIDS = 2,
+		FORMAT_FLAG_REAL_T_IS_DOUBLE = 4,
+
 		// Amount of reserved 32-bit fields in resource header
 		RESERVED_FIELDS = 11
 	};


### PR DESCRIPTION
Fixes #57554

Binary resources did not account for files saved with 64-bit floats (when Godot is compiled with `float=64`). There was a flag in `FileAccess` already made for that, but it was never set, so it defaulted to `false`, so Godot attempted to read 32-bit floats all the time. There was also no information in the header to tell if the file contained doubles or not.

I added a flag to the header to recognize files with doubles in them. Files should still load fine if opened with a version of Godot without 64-bit floats, it will just loose the extra precision. The opposite should also work.
This shouldn't break old files: the flag will be 0, so it only breaks if you try to load them with a version of Godot compiled with 64-bit floats prior to this fix.

cc @aaronfranke 