### PR TITLE
Add `GridMap.get_used_cells_by_item`

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -79,6 +79,13 @@
 				Returns an array of [Vector3] with the non-empty cell coordinates in the grid map.
 			</description>
 		</method>
+		<method name="get_used_cells_by_item" qualifiers="const">
+			<return type="Array" />
+			<argument index="0" name="item" type="int" />
+			<description>
+				Returns an array of all cells with the given item index specified in [code]item[/code].
+			</description>
+		</method>
 		<method name="make_baked_meshes">
 			<return type="void" />
 			<argument index="0" name="gen_lightmap_uv" type="bool" default="false" />

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -878,6 +878,7 @@ void GridMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear"), &GridMap::clear);
 
 	ClassDB::bind_method(D_METHOD("get_used_cells"), &GridMap::get_used_cells);
+	ClassDB::bind_method(D_METHOD("get_used_cells_by_item", "item"), &GridMap::get_used_cells_by_item);
 
 	ClassDB::bind_method(D_METHOD("get_meshes"), &GridMap::get_meshes);
 	ClassDB::bind_method(D_METHOD("get_bake_meshes"), &GridMap::get_bake_meshes);
@@ -945,6 +946,18 @@ Array GridMap::get_used_cells() const {
 	for (const KeyValue<IndexKey, Cell> &E : cell_map) {
 		Vector3 p(E.key.x, E.key.y, E.key.z);
 		a[i++] = p;
+	}
+
+	return a;
+}
+
+Array GridMap::get_used_cells_by_item(int p_item) const {
+	Array a;
+	for (const KeyValue<IndexKey, Cell> &E : cell_map) {
+		if (E.value.item == p_item) {
+			Vector3 p(E.key.x, E.key.y, E.key.z);
+			a.push_back(p);
+		}
 	}
 
 	return a;

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -266,6 +266,7 @@ public:
 	float get_cell_scale() const;
 
 	Array get_used_cells() const;
+	Array get_used_cells_by_item(int p_item) const;
 
 	Array get_meshes() const;
 


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/1375

Why the name is not the proposed `get_used_cells_by_id`: `id` was only used in `TileMap`. We have explicitly named the term "item" in method names like `get_cell_item` and `set_cell_item`.