### PR TITLE
Fix crash when using Set Index node in VisualScript

### DIFF
--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -1784,10 +1784,7 @@ public:
 
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) {
 		bool valid;
-		// *p_output[0] points to the same place as *p_inputs[2] so we need a temp to store the value before the change in the next line
-		Variant temp = *p_inputs[2];
-		*p_outputs[0] = *p_inputs[0];
-		p_outputs[0]->set(*p_inputs[1], temp, &valid);
+		((Variant *)p_inputs[0])->set(*p_inputs[1], *p_inputs[2], &valid);
 
 		if (!valid) {
 			r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;


### PR DESCRIPTION
Fixes #28280

https://github.com/godotengine/godot/blob/7989149b917c096af67a0566398bee4de83993ac/modules/visual_script/visual_script_nodes.cpp#L1787-L1790

The comment is not true: Output variants follow input variants on the variant stack. A `VisualScriptIndexSet` node has 3 inputs and 0 outputs, so `p_outputs[0]` is one past the end of input variants, i.e. `p_inputs[3]`.

In order to set index on `p_inputs[0]`, I cast away its constness. Another option is to access the variant via `p_outputs[-3]` which seems hacky.

p.s. It only crashes on `3.x`. On `master`, a "Max recursion reached" error is printed instead.