### PR TITLE
Properly exclude lights that are marked as sky only

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -3286,7 +3286,7 @@ void RendererSceneRenderRD::_setup_lights(const PagedArray<RID> &p_lights, const
 		RS::LightType type = storage->light_get_type(base);
 		switch (type) {
 			case RS::LIGHT_DIRECTIONAL: {
-				if (r_directional_light_count >= cluster.max_directional_lights) {
+				if (r_directional_light_count >= cluster.max_directional_lights || storage->light_directional_is_sky_only(base)) {
 					continue;
 				}
 


### PR DESCRIPTION
Fixes a bug introduced by https://github.com/godotengine/godot/pull/57104 which caused the "sky_only" flag to stop working.

This just re adds part of a line of code that was deleted in #57104
