### PR TITLE
Make `VMap::find_nearest` return -1 when empty

### DIFF
--- a/core/templates/vmap.h
+++ b/core/templates/vmap.h
@@ -142,6 +142,9 @@ public:
 	}
 
 	int find_nearest(const T &p_val) const {
+		if (_cowdata.is_empty()) {
+			return -1;
+		}
 		bool exact;
 		return _find(p_val, exact);
 	}


### PR DESCRIPTION
Fixes #33455

`VMap::find_nearest()` should return -1 if no such "nearest" index can be found. The tokenizer expects `find_nearest()` to return a negative value on failure, but it returns 0 in that situation actually:

https://github.com/godotengine/godot/blob/609209ab8059cd0b53025e8a49281f4aa2ff8d32/modules/gdscript/gdscript_tokenizer.cpp#L1445-L1449

p.s. `master` won't crash as loading byte code is not implemented yet, so no code uses `find_nearest()` here.

For cherry-picking:
* `core/templates/vmap.h` → `core/vmap.h`
* `is_empty()` → `empty()`