### PR TITLE
Use prefiltered radiance for Sky high quality  update mode

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1776,10 +1776,10 @@
 		<member name="rendering/reflections/sky_reflections/fast_filter_high_quality" type="bool" setter="" getter="" default="false">
 			Use a higher quality variant of the fast filtering algorithm. Significantly slower than using default quality, but results in smoother reflections. Should only be used when the scene is especially detailed.
 		</member>
-		<member name="rendering/reflections/sky_reflections/ggx_samples" type="int" setter="" getter="" default="1024">
+		<member name="rendering/reflections/sky_reflections/ggx_samples" type="int" setter="" getter="" default="32">
 			Sets the number of samples to take when using importance sampling for [Sky]s and [ReflectionProbe]s. A higher value will result in smoother, higher quality reflections, but increases time to calculate radiance maps. In general, fewer samples are needed for simpler, low dynamic range environments while more samples are needed for HDR environments and environments with a high level of detail.
 		</member>
-		<member name="rendering/reflections/sky_reflections/ggx_samples.mobile" type="int" setter="" getter="" default="128">
+		<member name="rendering/reflections/sky_reflections/ggx_samples.mobile" type="int" setter="" getter="" default="16">
 			Lower-end override for [member rendering/reflections/sky_reflections/ggx_samples] on mobile devices, due to performance concerns or driver support.
 		</member>
 		<member name="rendering/reflections/sky_reflections/roughness_layers" type="int" setter="" getter="" default="8">

--- a/servers/rendering/renderer_rd/effects_rd.cpp
+++ b/servers/rendering/renderer_rd/effects_rd.cpp
@@ -2040,7 +2040,7 @@ void EffectsRD::cubemap_roughness(RID p_source_rd_texture, RID p_dest_texture, u
 	RD::ComputeListID compute_list = RD::get_singleton()->compute_list_begin();
 	RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, roughness.compute_pipeline);
 
-	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, _get_compute_uniform_set_from_texture(p_source_rd_texture), 0);
+	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, _get_compute_uniform_set_from_texture(p_source_rd_texture, true), 0);
 	RD::get_singleton()->compute_list_bind_uniform_set(compute_list, _get_uniform_set_from_image(p_dest_texture), 1);
 
 	RD::get_singleton()->compute_list_set_push_constant(compute_list, &roughness.push_constant, sizeof(CubemapRoughnessPushConstant));

--- a/servers/rendering/renderer_rd/shaders/cubemap_roughness_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/cubemap_roughness_inc.glsl
@@ -47,12 +47,10 @@ vec3 texelCoordToVec(vec2 uv, uint faceID) {
 	return normalize(result);
 }
 
-vec3 ImportanceSampleGGX(vec2 Xi, float Roughness, vec3 N) {
-	float a = Roughness * Roughness; // DISNEY'S ROUGHNESS [see Burley'12 siggraph]
-
+vec3 ImportanceSampleGGX(vec2 xi, float roughness4) {
 	// Compute distribution direction
-	float Phi = 2.0 * M_PI * Xi.x;
-	float CosTheta = sqrt((1.0 - Xi.y) / (1.0 + (a * a - 1.0) * Xi.y));
+	float Phi = 2.0 * M_PI * xi.x;
+	float CosTheta = sqrt((1.0 - xi.y) / (1.0 + (roughness4 - 1.0) * xi.y));
 	float SinTheta = sqrt(1.0 - CosTheta * CosTheta);
 
 	// Convert to spherical direction
@@ -61,12 +59,15 @@ vec3 ImportanceSampleGGX(vec2 Xi, float Roughness, vec3 N) {
 	H.y = SinTheta * sin(Phi);
 	H.z = CosTheta;
 
-	vec3 UpVector = abs(N.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
-	vec3 TangentX = normalize(cross(UpVector, N));
-	vec3 TangentY = cross(N, TangentX);
+	return H;
+}
 
-	// Tangent to world space
-	return TangentX * H.x + TangentY * H.y + N * H.z;
+float DistributionGGX(float NdotH, float roughness4) {
+	float NdotH2 = NdotH * NdotH;
+	float denom = (NdotH2 * (roughness4 - 1.0) + 1.0);
+	denom = M_PI * denom * denom;
+
+	return roughness4 / denom;
 }
 
 // https://graphicrants.blogspot.com.au/2013/08/specular-brdf-reference.html

--- a/servers/rendering/renderer_rd/shaders/cubemap_roughness_raster.glsl
+++ b/servers/rendering/renderer_rd/shaders/cubemap_roughness_raster.glsl
@@ -42,17 +42,33 @@ void main() {
 	} else {
 		vec4 sum = vec4(0.0, 0.0, 0.0, 0.0);
 
+		float solid_angle_texel = 4.0 * M_PI / (6.0 * params.face_size * params.face_size);
+		float roughness2 = params.roughness * params.roughness;
+		float roughness4 = roughness2 * roughness2;
+		vec3 UpVector = abs(N.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+		mat3 T;
+		T[0] = normalize(cross(UpVector, N));
+		T[1] = cross(N, T[0]);
+		T[2] = N;
+
 		for (uint sampleNum = 0u; sampleNum < params.sample_count; sampleNum++) {
 			vec2 xi = Hammersley(sampleNum, params.sample_count);
 
-			vec3 H = ImportanceSampleGGX(xi, params.roughness, N);
-			vec3 V = N;
-			vec3 L = (2.0 * dot(V, H) * H - V);
+			vec3 H = T * ImportanceSampleGGX(xi, roughness4);
+			float NdotH = dot(N, H);
+			vec3 L = (2.0 * NdotH * H - N);
 
 			float ndotl = clamp(dot(N, L), 0.0, 1.0);
 
 			if (ndotl > 0.0) {
-				sum.rgb += textureLod(source_cube, L, 0.0).rgb * ndotl;
+				float D = DistributionGGX(NdotH, roughness4);
+				float pdf = D * NdotH / (4.0 * NdotH) + 0.0001;
+
+				float solid_angle_sample = 1.0 / (float(params.sample_count) * pdf + 0.0001);
+
+				float mipLevel = params.roughness == 0.0 ? 0.0 : 0.5 * log2(solid_angle_sample / solid_angle_texel);
+
+				sum.rgb += textureLod(source_cube, L, mipLevel).rgb * ndotl;
 				sum.a += ndotl;
 			}
 		}

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2860,11 +2860,11 @@ RenderingServer::RenderingServer() {
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/strip_debug", false);
 	GLOBAL_DEF("rendering/shader_compiler/shader_cache/strip_debug.release", true);
 
-	GLOBAL_DEF("rendering/reflections/sky_reflections/roughness_layers", 8);
+	GLOBAL_DEF_RST("rendering/reflections/sky_reflections/roughness_layers", 8); // Assumes a 256x256 cubemap
 	GLOBAL_DEF_RST("rendering/reflections/sky_reflections/texture_array_reflections", true);
 	GLOBAL_DEF("rendering/reflections/sky_reflections/texture_array_reflections.mobile", false);
-	GLOBAL_DEF("rendering/reflections/sky_reflections/ggx_samples", 1024);
-	GLOBAL_DEF("rendering/reflections/sky_reflections/ggx_samples.mobile", 128);
+	GLOBAL_DEF_RST("rendering/reflections/sky_reflections/ggx_samples", 32);
+	GLOBAL_DEF("rendering/reflections/sky_reflections/ggx_samples.mobile", 16);
 	GLOBAL_DEF("rendering/reflections/sky_reflections/fast_filter_high_quality", false);
 	GLOBAL_DEF("rendering/reflections/reflection_atlas/reflection_size", 256);
 	GLOBAL_DEF("rendering/reflections/reflection_atlas/reflection_size.mobile", 128);


### PR DESCRIPTION
Fixes: #43763
The first of the improvements discussed https://github.com/godotengine/godot/issues/43763#issuecomment-1039518040

This PR substantially improves the quality of the high quality update mode and improves the performance (from ~60ms per frame to ~5ms per frame on my device). High Quality mode is still not suitable for updating every frame, but the incremental mode is now faster than the real time mode making it the most suitable for updates in the editor (Once this is merged we can revert https://github.com/godotengine/godot/pull/57931 and https://github.com/godotengine/godot/pull/58165 and allow skys to default to "automatic mode").

Further, High Quality/Incremental can be made very fast by setting the radiance size to 128 (which is the default size in many other engines) or by disabling "use_arrays" in the project settings. With a radiance size of 128, high quality mode takes the same amount of time to update as Realtime at 256. So Realtime is still the preferred choice when updating every frame, but the performance quality tradeoff is more even now

<details>
  <summary>Photo comparison</summary>
  
_Using 1024 samples (~65ms):_
![Screenshot (251)](https://user-images.githubusercontent.com/16521339/154220384-d8b54b8d-c40a-4759-9aa3-f92b349bfbf3.png)

_Using 32 samples (~5ms):_
![Screenshot (252)](https://user-images.githubusercontent.com/16521339/154220408-6e0d789a-dc58-4638-9099-85a395405d47.png)

_Old version using 32 samples (~4ms):_
![Screenshot (253)](https://user-images.githubusercontent.com/16521339/154220461-fcdc953e-61b9-4579-8cac-c6759f37a3f2.png)

_Old version with 1024 samples (~60ms):_
![Screenshot (254)](https://user-images.githubusercontent.com/16521339/154220498-26ba1e55-8086-4839-b81d-74cfbf423cc6.png)

</details>