### PR TITLE
Fix cannot get VisualScriptPropertySet in visual property selector

### DIFF
--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -3396,7 +3396,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 		vnode = n;
 	} else if (p_category == String("class_property")) {
 		Vector<String> property_path = p_text.split(":");
-		if (held_ctrl) {
+		if (held_ctrl || property_path[0] == "VisualScriptPropertySet") {
 			Ref<VisualScriptPropertySet> n;
 			n.instantiate();
 			n->set_property(property_path[1]);


### PR DESCRIPTION
Fixes #58128

### Issue fixed :

Selecting ``VisualScriptPropertySet`` in visual property selector add a ``VisualScriptPropertyGet`` box instead.

### Identified cause : 

Whatever setter or getter is selected, it only checks <kbd>Ctrl</kbd> key to determine if we want a setter or getter.

### Fix proposal : 

Use information about the expected method contained in ``property_path`` variable.

### After

![fixed](https://user-images.githubusercontent.com/3649998/154246458-55fa1aaf-6f83-429d-9518-a4f04823d97b.gif)

