### PR TITLE
Convert _notification methods to switch - Chunk C

### DIFF
--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -200,10 +200,12 @@ void ShaderFileEditor::_update_options() {
 }
 
 void ShaderFileEditor::_notification(int p_what) {
-	if (p_what == NOTIFICATION_WM_WINDOW_FOCUS_IN) {
-		if (is_visible_in_tree() && shader_file.is_valid()) {
-			_update_options();
-		}
+	switch (p_what) {
+		case NOTIFICATION_WM_WINDOW_FOCUS_IN: {
+			if (is_visible_in_tree() && shader_file.is_valid()) {
+				_update_options();
+			}
+		} break;
 	}
 }
 

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -103,8 +103,7 @@ void BoneTransformEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			create_editors();
-			break;
-		}
+		} break;
 	}
 }
 

--- a/editor/plugins/text_control_editor_plugin.cpp
+++ b/editor/plugins/text_control_editor_plugin.cpp
@@ -34,8 +34,8 @@
 #include "editor/editor_scale.h"
 #include "editor/multi_node_edit.h"
 
-void TextControlEditor::_notification(int p_notification) {
-	switch (p_notification) {
+void TextControlEditor::_notification(int p_what) {
+	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			if (!EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &TextControlEditor::_reload_fonts))) {
 				EditorFileSystem::get_singleton()->connect("filesystem_changed", callable_mp(this, &TextControlEditor::_reload_fonts), make_binds(""));
@@ -45,13 +45,12 @@ void TextControlEditor::_notification(int p_notification) {
 		case NOTIFICATION_THEME_CHANGED: {
 			clear_formatting->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			if (EditorFileSystem::get_singleton()->is_connected("filesystem_changed", callable_mp(this, &TextControlEditor::_reload_fonts))) {
 				EditorFileSystem::get_singleton()->disconnect("filesystem_changed", callable_mp(this, &TextControlEditor::_reload_fonts));
 			}
 		} break;
-		default:
-			break;
 	}
 }
 

--- a/editor/plugins/text_control_editor_plugin.h
+++ b/editor/plugins/text_control_editor_plugin.h
@@ -66,7 +66,7 @@ class TextControlEditor : public HBoxContainer {
 	Ref<Font> custom_font;
 
 protected:
-	void _notification(int p_notification);
+	void _notification(int p_what);
 	static void _bind_methods();
 
 	void _find_resources(EditorFileSystemDirectory *p_dir);

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -35,18 +35,17 @@ void Texture3DEditor::_texture_rect_draw() {
 }
 
 void Texture3DEditor::_notification(int p_what) {
-	if (p_what == NOTIFICATION_READY) {
-		//get_scene()->connect("node_removed",this,"_node_removed");
-	}
-	if (p_what == NOTIFICATION_RESIZED) {
-		_texture_rect_update_area();
-	}
+	switch (p_what) {
+		case NOTIFICATION_RESIZED: {
+			_texture_rect_update_area();
+		} break;
 
-	if (p_what == NOTIFICATION_DRAW) {
-		Ref<Texture2D> checkerboard = get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons"));
-		Size2 size = get_size();
+		case NOTIFICATION_DRAW: {
+			Ref<Texture2D> checkerboard = get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons"));
+			Size2 size = get_size();
 
-		draw_texture_rect(checkerboard, Rect2(Point2(), size), true);
+			draw_texture_rect(checkerboard, Rect2(Point2(), size), true);
+		} break;
 	}
 }
 

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -46,18 +46,17 @@ void TextureLayeredEditor::_texture_rect_draw() {
 }
 
 void TextureLayeredEditor::_notification(int p_what) {
-	if (p_what == NOTIFICATION_READY) {
-		//get_scene()->connect("node_removed",this,"_node_removed");
-	}
-	if (p_what == NOTIFICATION_RESIZED) {
-		_texture_rect_update_area();
-	}
+	switch (p_what) {
+		case NOTIFICATION_RESIZED: {
+			_texture_rect_update_area();
+		} break;
 
-	if (p_what == NOTIFICATION_DRAW) {
-		Ref<Texture2D> checkerboard = get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons"));
-		Size2 size = get_size();
+		case NOTIFICATION_DRAW: {
+			Ref<Texture2D> checkerboard = get_theme_icon(SNAME("Checkerboard"), SNAME("EditorIcons"));
+			Size2 size = get_size();
 
-		draw_texture_rect(checkerboard, Rect2(Point2(), size), true);
+			draw_texture_rect(checkerboard, Rect2(Point2(), size), true);
+		} break;
 	}
 }
 

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -203,6 +203,7 @@ void ThemeEditorPreview::_notification(int p_what) {
 			theme_cache.preview_picker_font = get_theme_font(SNAME("status_source"), SNAME("EditorFonts"));
 			theme_cache.font_size = get_theme_font_size(SNAME("font_size"), SNAME("EditorFonts"));
 		} break;
+
 		case NOTIFICATION_PROCESS: {
 			time_left -= get_process_delta_time();
 			if (time_left < 0) {

--- a/editor/plugins/tiles/tile_atlas_view.cpp
+++ b/editor/plugins/tiles/tile_atlas_view.cpp
@@ -524,13 +524,13 @@ void TileAtlasView::update() {
 void TileAtlasView::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED:
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
-			break;
+		} break;
 
-		case NOTIFICATION_READY:
+		case NOTIFICATION_READY: {
 			button_center_view->set_icon(get_theme_icon(SNAME("CenterView"), SNAME("EditorIcons")));
-			break;
+		} break;
 	}
 }
 

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -1160,13 +1160,11 @@ void TileDataDefaultEditor::setup_property_editor(Variant::Type p_type, String p
 void TileDataDefaultEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
-		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
 			picker_button->set_icon(get_theme_icon(SNAME("ColorPick"), SNAME("EditorIcons")));
 			tile_bool_checked = get_theme_icon(SNAME("TileChecked"), SNAME("EditorIcons"));
 			tile_bool_unchecked = get_theme_icon(SNAME("TileUnchecked"), SNAME("EditorIcons"));
-			break;
-		default:
-			break;
+		} break;
 	}
 }
 
@@ -1315,11 +1313,9 @@ void TileDataOcclusionShapeEditor::_tile_set_changed() {
 
 void TileDataOcclusionShapeEditor::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_ENTER_TREE: {
 			polygon_editor->set_polygons_color(get_tree()->get_debug_collisions_color());
-			break;
-		default:
-			break;
+		} break;
 	}
 }
 
@@ -1514,11 +1510,9 @@ void TileDataCollisionEditor::_tile_set_changed() {
 
 void TileDataCollisionEditor::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_ENTER_TREE: {
 			polygon_editor->set_polygons_color(get_tree()->get_debug_collisions_color());
-			break;
-		default:
-			break;
+		} break;
 	}
 }
 
@@ -2487,11 +2481,9 @@ void TileDataTerrainsEditor::draw_over_tile(CanvasItem *p_canvas_item, Transform
 void TileDataTerrainsEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
-		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
 			picker_button->set_icon(get_theme_icon(SNAME("ColorPick"), SNAME("EditorIcons")));
-			break;
-		default:
-			break;
+		} break;
 	}
 }
 
@@ -2593,11 +2585,9 @@ void TileDataNavigationEditor::_tile_set_changed() {
 
 void TileDataNavigationEditor::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_ENTER_TREE: {
 			polygon_editor->set_polygons_color(get_tree()->get_debug_navigation_color());
-			break;
-		default:
-			break;
+		} break;
 	}
 }
 

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -3359,15 +3359,16 @@ TileMapEditorTerrainsPlugin::~TileMapEditorTerrainsPlugin() {
 void TileMapEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
-		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
 			missing_tile_texture = get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons"));
 			warning_pattern_texture = get_theme_icon(SNAME("WarningPattern"), SNAME("EditorIcons"));
 			advanced_menu_button->set_icon(get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
 			toggle_grid_button->set_icon(get_theme_icon(SNAME("Grid"), SNAME("EditorIcons")));
 			toggle_grid_button->set_pressed(EditorSettings::get_singleton()->get("editors/tiles_editor/display_grid"));
 			toogle_highlight_selected_layer_button->set_icon(get_theme_icon(SNAME("TileMapHighlightSelected"), SNAME("EditorIcons")));
-			break;
-		case NOTIFICATION_INTERNAL_PROCESS:
+		} break;
+
+		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (is_visible_in_tree() && tileset_changed_needs_update) {
 				_update_bottom_panel();
 				_update_layers_selection();
@@ -3375,11 +3376,13 @@ void TileMapEditor::_notification(int p_what) {
 				CanvasItemEditor::get_singleton()->update_viewport();
 				tileset_changed_needs_update = false;
 			}
-			break;
-		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED:
+		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			toggle_grid_button->set_pressed(EditorSettings::get_singleton()->get("editors/tiles_editor/display_grid"));
-			break;
-		case NOTIFICATION_VISIBILITY_CHANGED:
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
 			TileMap *tile_map = Object::cast_to<TileMap>(ObjectDB::get_instance(tile_map_id));
 			if (tile_map) {
 				if (is_visible_in_tree()) {
@@ -3388,7 +3391,7 @@ void TileMapEditor::_notification(int p_what) {
 					tile_map->set_selected_layer(-1);
 				}
 			}
-			break;
+		} break;
 	}
 }
 

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -2270,7 +2270,7 @@ void TileSetAtlasSourceEditor::_auto_remove_tiles() {
 void TileSetAtlasSourceEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
-		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
 			tool_setup_atlas_source_button->set_icon(get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
 			tool_select_button->set_icon(get_theme_icon(SNAME("ToolSelect"), SNAME("EditorIcons")));
 			tool_paint_button->set_icon(get_theme_icon(SNAME("CanvasItem"), SNAME("EditorIcons")));
@@ -2281,8 +2281,9 @@ void TileSetAtlasSourceEditor::_notification(int p_what) {
 
 			resize_handle = get_theme_icon(SNAME("EditorHandle"), SNAME("EditorIcons"));
 			resize_handle_disabled = get_theme_icon(SNAME("EditorHandleDisabled"), SNAME("EditorIcons"));
-			break;
-		case NOTIFICATION_INTERNAL_PROCESS:
+		} break;
+
+		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (tile_set_changed_needs_update) {
 				// Update everything.
 				_update_source_inspector();
@@ -2298,9 +2299,7 @@ void TileSetAtlasSourceEditor::_notification(int p_what) {
 
 				tile_set_changed_needs_update = false;
 			}
-			break;
-		default:
-			break;
+		} break;
 	}
 }
 

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -333,14 +333,15 @@ void TileSetEditor::_set_source_sort(int p_sort) {
 void TileSetEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
-		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
 			sources_delete_button->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 			sources_add_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 			source_sort_button->set_icon(get_theme_icon(SNAME("Sort"), SNAME("EditorIcons")));
 			sources_advanced_menu_button->set_icon(get_theme_icon(SNAME("GuiTabMenuHl"), SNAME("EditorIcons")));
 			missing_texture_texture = get_theme_icon(SNAME("TileSet"), SNAME("EditorIcons"));
-			break;
-		case NOTIFICATION_INTERNAL_PROCESS:
+		} break;
+
+		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (tile_set_changed_needs_update) {
 				if (tile_set.is_valid()) {
 					tile_set->set_edited(true);
@@ -349,9 +350,7 @@ void TileSetEditor::_notification(int p_what) {
 				_update_patterns_list();
 				tile_set_changed_needs_update = false;
 			}
-			break;
-		default:
-			break;
+		} break;
 	}
 }
 

--- a/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_scenes_collection_source_editor.cpp
@@ -330,12 +330,13 @@ void TileSetScenesCollectionSourceEditor::_update_scenes_list() {
 void TileSetScenesCollectionSourceEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
-		case NOTIFICATION_THEME_CHANGED:
+		case NOTIFICATION_THEME_CHANGED: {
 			scene_tile_add_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 			scene_tile_delete_button->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 			_update_scenes_list();
-			break;
-		case NOTIFICATION_INTERNAL_PROCESS:
+		} break;
+
+		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (tile_set_scenes_collection_source_changed_needs_update) {
 				// Update everything.
 				_update_source_inspector();
@@ -344,14 +345,13 @@ void TileSetScenesCollectionSourceEditor::_notification(int p_what) {
 				_update_tile_inspector();
 				tile_set_scenes_collection_source_changed_needs_update = false;
 			}
-			break;
-		case NOTIFICATION_VISIBILITY_CHANGED:
+		} break;
+
+		case NOTIFICATION_VISIBILITY_CHANGED: {
 			// Update things just in case.
 			_update_scenes_list();
 			_update_action_buttons();
-			break;
-		default:
-			break;
+		} break;
 	}
 }
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -3373,91 +3373,98 @@ void VisualShaderEditor::_sbox_input(const Ref<InputEvent> &p_ie) {
 }
 
 void VisualShaderEditor::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		node_filter->set_clear_button_enabled(true);
+	switch (p_what) {
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			graph->get_panner()->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
+			graph->set_warped_panning(bool(EditorSettings::get_singleton()->get("editors/panning/warped_mouse_panning")));
+		} break;
 
-		// collapse tree by default
+		case NOTIFICATION_ENTER_TREE: {
+			node_filter->set_clear_button_enabled(true);
 
-		TreeItem *category = members->get_root()->get_first_child();
-		while (category) {
-			category->set_collapsed(true);
-			TreeItem *sub_category = category->get_first_child();
-			while (sub_category) {
-				sub_category->set_collapsed(true);
-				sub_category = sub_category->get_next();
-			}
-			category = category->get_next();
-		}
-	}
+			// collapse tree by default
 
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		graph->get_panner()->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
-		graph->set_warped_panning(bool(EditorSettings::get_singleton()->get("editors/panning/warped_mouse_panning")));
-	}
-
-	if (p_what == NOTIFICATION_DRAG_BEGIN) {
-		Dictionary dd = get_viewport()->gui_get_drag_data();
-		if (members->is_visible_in_tree() && dd.has("id")) {
-			members->set_drop_mode_flags(Tree::DROP_MODE_ON_ITEM);
-		}
-	} else if (p_what == NOTIFICATION_DRAG_END) {
-		members->set_drop_mode_flags(0);
-	}
-
-	if (p_what == NOTIFICATION_ENTER_TREE || p_what == NOTIFICATION_THEME_CHANGED) {
-		highend_label->set_modulate(get_theme_color(SNAME("vulkan_color"), SNAME("Editor")));
-
-		node_filter->set_right_icon(Control::get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
-
-		preview_shader->set_icon(Control::get_theme_icon(SNAME("Shader"), SNAME("EditorIcons")));
-
-		{
-			Color background_color = EDITOR_GET("text_editor/theme/highlighting/background_color");
-			Color text_color = EDITOR_GET("text_editor/theme/highlighting/text_color");
-			Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
-			Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
-			Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
-			Color symbol_color = EDITOR_GET("text_editor/theme/highlighting/symbol_color");
-			Color function_color = EDITOR_GET("text_editor/theme/highlighting/function_color");
-			Color number_color = EDITOR_GET("text_editor/theme/highlighting/number_color");
-			Color members_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
-
-			preview_text->add_theme_color_override("background_color", background_color);
-
-			for (const String &E : keyword_list) {
-				if (ShaderLanguage::is_control_flow_keyword(E)) {
-					syntax_highlighter->add_keyword_color(E, control_flow_keyword_color);
-				} else {
-					syntax_highlighter->add_keyword_color(E, keyword_color);
+			TreeItem *category = members->get_root()->get_first_child();
+			while (category) {
+				category->set_collapsed(true);
+				TreeItem *sub_category = category->get_first_child();
+				while (sub_category) {
+					sub_category->set_collapsed(true);
+					sub_category = sub_category->get_next();
 				}
+				category = category->get_next();
 			}
 
-			preview_text->add_theme_font_override("font", get_theme_font(SNAME("expression"), SNAME("EditorFonts")));
-			preview_text->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("expression_size"), SNAME("EditorFonts")));
-			preview_text->add_theme_color_override("font_color", text_color);
-			syntax_highlighter->set_number_color(number_color);
-			syntax_highlighter->set_symbol_color(symbol_color);
-			syntax_highlighter->set_function_color(function_color);
-			syntax_highlighter->set_member_variable_color(members_color);
-			syntax_highlighter->clear_color_regions();
-			syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
-			syntax_highlighter->add_color_region("//", "", comment_color, true);
-
-			preview_text->clear_comment_delimiters();
-			preview_text->add_comment_delimiter("/*", "*/", false);
-			preview_text->add_comment_delimiter("//", "", true);
-
-			error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
-			error_label->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
-			error_label->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
-			error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			graph->get_panner()->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/sub_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
+			graph->set_warped_panning(bool(EditorSettings::get_singleton()->get("editors/panning/warped_mouse_panning")));
+			[[fallthrough]];
 		}
+		case NOTIFICATION_THEME_CHANGED: {
+			highend_label->set_modulate(get_theme_color(SNAME("vulkan_color"), SNAME("Editor")));
 
-		tools->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
+			node_filter->set_right_icon(Control::get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 
-		if (p_what == NOTIFICATION_THEME_CHANGED && is_visible_in_tree()) {
-			_update_graph();
-		}
+			preview_shader->set_icon(Control::get_theme_icon(SNAME("Shader"), SNAME("EditorIcons")));
+
+			{
+				Color background_color = EDITOR_GET("text_editor/theme/highlighting/background_color");
+				Color text_color = EDITOR_GET("text_editor/theme/highlighting/text_color");
+				Color keyword_color = EDITOR_GET("text_editor/theme/highlighting/keyword_color");
+				Color control_flow_keyword_color = EDITOR_GET("text_editor/theme/highlighting/control_flow_keyword_color");
+				Color comment_color = EDITOR_GET("text_editor/theme/highlighting/comment_color");
+				Color symbol_color = EDITOR_GET("text_editor/theme/highlighting/symbol_color");
+				Color function_color = EDITOR_GET("text_editor/theme/highlighting/function_color");
+				Color number_color = EDITOR_GET("text_editor/theme/highlighting/number_color");
+				Color members_color = EDITOR_GET("text_editor/theme/highlighting/member_variable_color");
+
+				preview_text->add_theme_color_override("background_color", background_color);
+
+				for (const String &E : keyword_list) {
+					if (ShaderLanguage::is_control_flow_keyword(E)) {
+						syntax_highlighter->add_keyword_color(E, control_flow_keyword_color);
+					} else {
+						syntax_highlighter->add_keyword_color(E, keyword_color);
+					}
+				}
+
+				preview_text->add_theme_font_override("font", get_theme_font(SNAME("expression"), SNAME("EditorFonts")));
+				preview_text->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("expression_size"), SNAME("EditorFonts")));
+				preview_text->add_theme_color_override("font_color", text_color);
+				syntax_highlighter->set_number_color(number_color);
+				syntax_highlighter->set_symbol_color(symbol_color);
+				syntax_highlighter->set_function_color(function_color);
+				syntax_highlighter->set_member_variable_color(members_color);
+				syntax_highlighter->clear_color_regions();
+				syntax_highlighter->add_color_region("/*", "*/", comment_color, false);
+				syntax_highlighter->add_color_region("//", "", comment_color, true);
+
+				preview_text->clear_comment_delimiters();
+				preview_text->add_comment_delimiter("/*", "*/", false);
+				preview_text->add_comment_delimiter("//", "", true);
+
+				error_panel->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
+				error_label->add_theme_font_override("font", get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+				error_label->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+				error_label->add_theme_color_override("font_color", get_theme_color(SNAME("error_color"), SNAME("Editor")));
+			}
+
+			tools->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
+
+			if (p_what == NOTIFICATION_THEME_CHANGED && is_visible_in_tree()) {
+				_update_graph();
+			}
+		} break;
+
+		case NOTIFICATION_DRAG_BEGIN: {
+			Dictionary dd = get_viewport()->gui_get_drag_data();
+			if (members->is_visible_in_tree() && dd.has("id")) {
+				members->set_drop_mode_flags(Tree::DROP_MODE_ON_ITEM);
+			}
+		} break;
+
+		case NOTIFICATION_DRAG_END: {
+			members->set_drop_mode_flags(0);
+		} break;
 	}
 }
 
@@ -5052,8 +5059,10 @@ class VisualShaderNodePluginInputEditor : public OptionButton {
 
 public:
 	void _notification(int p_what) {
-		if (p_what == NOTIFICATION_READY) {
-			connect("item_selected", callable_mp(this, &VisualShaderNodePluginInputEditor::_item_selected));
+		switch (p_what) {
+			case NOTIFICATION_READY: {
+				connect("item_selected", callable_mp(this, &VisualShaderNodePluginInputEditor::_item_selected));
+			} break;
 		}
 	}
 
@@ -5100,8 +5109,10 @@ class VisualShaderNodePluginUniformRefEditor : public OptionButton {
 
 public:
 	void _notification(int p_what) {
-		if (p_what == NOTIFICATION_READY) {
-			connect("item_selected", callable_mp(this, &VisualShaderNodePluginUniformRefEditor::_item_selected));
+		switch (p_what) {
+			case NOTIFICATION_READY: {
+				connect("item_selected", callable_mp(this, &VisualShaderNodePluginUniformRefEditor::_item_selected));
+			} break;
 		}
 	}
 
@@ -5514,29 +5525,31 @@ Size2 VisualShaderNodePortPreview::get_minimum_size() const {
 }
 
 void VisualShaderNodePortPreview::_notification(int p_what) {
-	if (p_what == NOTIFICATION_DRAW) {
-		Vector<Vector2> points = {
-			Vector2(),
-			Vector2(get_size().width, 0),
-			get_size(),
-			Vector2(0, get_size().height)
-		};
+	switch (p_what) {
+		case NOTIFICATION_DRAW: {
+			Vector<Vector2> points = {
+				Vector2(),
+				Vector2(get_size().width, 0),
+				get_size(),
+				Vector2(0, get_size().height)
+			};
 
-		Vector<Vector2> uvs = {
-			Vector2(0, 0),
-			Vector2(1, 0),
-			Vector2(1, 1),
-			Vector2(0, 1)
-		};
+			Vector<Vector2> uvs = {
+				Vector2(0, 0),
+				Vector2(1, 0),
+				Vector2(1, 1),
+				Vector2(0, 1)
+			};
 
-		Vector<Color> colors = {
-			Color(1, 1, 1, 1),
-			Color(1, 1, 1, 1),
-			Color(1, 1, 1, 1),
-			Color(1, 1, 1, 1)
-		};
+			Vector<Color> colors = {
+				Color(1, 1, 1, 1),
+				Color(1, 1, 1, 1),
+				Color(1, 1, 1, 1),
+				Color(1, 1, 1, 1)
+			};
 
-		draw_primitive(points, colors, uvs);
+			draw_primitive(points, colors, uvs);
+		} break;
 	}
 }
 

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -65,41 +65,43 @@ bool VoxelGIEditorPlugin::handles(Object *p_object) const {
 }
 
 void VoxelGIEditorPlugin::_notification(int p_what) {
-	if (p_what == NOTIFICATION_PROCESS) {
-		if (!voxel_gi) {
-			return;
-		}
+	switch (p_what) {
+		case NOTIFICATION_PROCESS: {
+			if (!voxel_gi) {
+				return;
+			}
 
-		// Set information tooltip on the Bake button. This information is useful
-		// to optimize performance (video RAM size) and reduce light leaking (individual cell size).
+			// Set information tooltip on the Bake button. This information is useful
+			// to optimize performance (video RAM size) and reduce light leaking (individual cell size).
 
-		const Vector3i size = voxel_gi->get_estimated_cell_size();
+			const Vector3i size = voxel_gi->get_estimated_cell_size();
 
-		const Vector3 extents = voxel_gi->get_extents();
+			const Vector3 extents = voxel_gi->get_extents();
 
-		const int data_size = 4;
-		const double size_mb = size.x * size.y * size.z * data_size / (1024.0 * 1024.0);
-		// Add a qualitative measurement to help the user assess whether a VoxelGI node is using a lot of VRAM.
-		String size_quality;
-		if (size_mb < 16.0) {
-			size_quality = TTR("Low");
-		} else if (size_mb < 64.0) {
-			size_quality = TTR("Moderate");
-		} else {
-			size_quality = TTR("High");
-		}
+			const int data_size = 4;
+			const double size_mb = size.x * size.y * size.z * data_size / (1024.0 * 1024.0);
+			// Add a qualitative measurement to help the user assess whether a VoxelGI node is using a lot of VRAM.
+			String size_quality;
+			if (size_mb < 16.0) {
+				size_quality = TTR("Low");
+			} else if (size_mb < 64.0) {
+				size_quality = TTR("Moderate");
+			} else {
+				size_quality = TTR("High");
+			}
 
-		String text;
-		text += vformat(TTR("Subdivisions: %s"), vformat(String::utf8("%d × %d × %d"), size.x, size.y, size.z)) + "\n";
-		text += vformat(TTR("Cell size: %s"), vformat(String::utf8("%.3f × %.3f × %.3f"), extents.x / size.x, extents.y / size.y, extents.z / size.z)) + "\n";
-		text += vformat(TTR("Video RAM size: %s MB (%s)"), String::num(size_mb, 2), size_quality);
+			String text;
+			text += vformat(TTR("Subdivisions: %s"), vformat(String::utf8("%d × %d × %d"), size.x, size.y, size.z)) + "\n";
+			text += vformat(TTR("Cell size: %s"), vformat(String::utf8("%.3f × %.3f × %.3f"), extents.x / size.x, extents.y / size.y, extents.z / size.z)) + "\n";
+			text += vformat(TTR("Video RAM size: %s MB (%s)"), String::num(size_mb, 2), size_quality);
 
-		// Only update the tooltip when needed to avoid constant redrawing.
-		if (bake->get_tooltip(Point2()) == text) {
-			return;
-		}
+			// Only update the tooltip when needed to avoid constant redrawing.
+			if (bake->get_tooltip(Point2()) == text) {
+				return;
+			}
 
-		bake->set_tooltip(text);
+			bake->set_tooltip(text);
+		} break;
 	}
 }
 

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -61,6 +61,7 @@ void ProjectExportDialog::_notification(int p_what) {
 				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "export", Rect2(get_position(), get_size()));
 			}
 		} break;
+
 		case NOTIFICATION_READY: {
 			duplicate_preset->set_icon(presets->get_theme_icon(SNAME("Duplicate"), SNAME("EditorIcons")));
 			delete_preset->set_icon(presets->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -647,8 +647,10 @@ private:
 	}
 
 	void _notification(int p_what) {
-		if (p_what == NOTIFICATION_WM_CLOSE_REQUEST) {
-			_remove_created_folder();
+		switch (p_what) {
+			case NOTIFICATION_WM_CLOSE_REQUEST: {
+				_remove_created_folder();
+			} break;
 		}
 	}
 
@@ -978,10 +980,12 @@ public:
 				hover = true;
 				update();
 			} break;
+
 			case NOTIFICATION_MOUSE_EXIT: {
 				hover = false;
 				update();
 			} break;
+
 			case NOTIFICATION_DRAW: {
 				if (hover) {
 					draw_style_box(get_theme_stylebox(SNAME("hover"), SNAME("Tree")), Rect2(Point2(), get_size()));
@@ -1143,18 +1147,20 @@ void ProjectList::update_icons_async() {
 }
 
 void ProjectList::_notification(int p_what) {
-	if (p_what == NOTIFICATION_PROCESS) {
-		// Load icons as a coroutine to speed up launch when you have hundreds of projects
-		if (_icon_load_index < _projects.size()) {
-			Item &item = _projects.write[_icon_load_index];
-			if (item.control->icon_needs_reload) {
-				load_project_icon(_icon_load_index);
-			}
-			_icon_load_index++;
+	switch (p_what) {
+		case NOTIFICATION_PROCESS: {
+			// Load icons as a coroutine to speed up launch when you have hundreds of projects
+			if (_icon_load_index < _projects.size()) {
+				Item &item = _projects.write[_icon_load_index];
+				if (item.control->icon_needs_reload) {
+					load_project_icon(_icon_load_index);
+				}
+				_icon_load_index++;
 
-		} else {
-			set_process(false);
-		}
+			} else {
+				set_process(false);
+			}
+		} break;
 	}
 }
 
@@ -1872,17 +1878,20 @@ void ProjectManager::_notification(int p_what) {
 			settings_hb->set_anchors_and_offsets_preset(Control::PRESET_TOP_RIGHT);
 			update();
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			search_box->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			search_box->set_clear_button_enabled(true);
 
 			Engine::get_singleton()->set_editor_hint(false);
 		} break;
+
 		case NOTIFICATION_RESIZED: {
 			if (open_templates->is_visible()) {
 				open_templates->popup_centered();
 			}
 		} break;
+
 		case NOTIFICATION_READY: {
 			int default_sorting = (int)EditorSettings::get_singleton()->get("project_manager/sorting_order");
 			filter_option->select(default_sorting);
@@ -1898,12 +1907,15 @@ void ProjectManager::_notification(int p_what) {
 				search_box->grab_focus();
 			}
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			set_process_unhandled_key_input(is_visible_in_tree());
 		} break;
+
 		case NOTIFICATION_WM_CLOSE_REQUEST: {
 			_dim_window();
 		} break;
+
 		case NOTIFICATION_WM_ABOUT: {
 			_show_about();
 		} break;

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -531,11 +531,13 @@ void ProjectSettingsEditor::_notification(int p_what) {
 				EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "project_settings", Rect2(get_position(), get_size()));
 			}
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			general_settings_inspector->edit(ps);
 			_update_action_map_editor();
 			_update_theme();
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_theme();
 		} break;

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -94,8 +94,10 @@ Ref<Resource> EditorResourceConversionPlugin::convert(const Ref<Resource> &p_res
 }
 
 void CustomPropertyEditor::_notification(int p_what) {
-	if (p_what == NOTIFICATION_WM_CLOSE_REQUEST) {
-		hide();
+	switch (p_what) {
+		case NOTIFICATION_WM_CLOSE_REQUEST: {
+			hide();
+		} break;
 	}
 }
 

--- a/editor/property_selector.cpp
+++ b/editor/property_selector.cpp
@@ -421,10 +421,14 @@ void PropertySelector::_hide_requested() {
 }
 
 void PropertySelector::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		connect("confirmed", callable_mp(this, &PropertySelector::_confirmed));
-	} else if (p_what == NOTIFICATION_EXIT_TREE) {
-		disconnect("confirmed", callable_mp(this, &PropertySelector::_confirmed));
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			connect("confirmed", callable_mp(this, &PropertySelector::_confirmed));
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			disconnect("confirmed", callable_mp(this, &PropertySelector::_confirmed));
+		} break;
 	}
 }
 

--- a/editor/quick_open.cpp
+++ b/editor/quick_open.cpp
@@ -229,6 +229,7 @@ void EditorQuickOpen::_notification(int p_what) {
 
 			search_box->set_clear_button_enabled(true);
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			disconnect("confirmed", callable_mp(this, &EditorQuickOpen::_confirmed));
 		} break;

--- a/editor/reparent_dialog.cpp
+++ b/editor/reparent_dialog.cpp
@@ -35,12 +35,14 @@
 #include "scene/gui/label.h"
 
 void ReparentDialog::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		connect("confirmed", callable_mp(this, &ReparentDialog::_reparent));
-	}
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			connect("confirmed", callable_mp(this, &ReparentDialog::_reparent));
+		} break;
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		disconnect("confirmed", callable_mp(this, &ReparentDialog::_reparent));
+		case NOTIFICATION_EXIT_TREE: {
+			disconnect("confirmed", callable_mp(this, &ReparentDialog::_reparent));
+		} break;
 	}
 }
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1270,6 +1270,7 @@ void SceneTreeDock::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			clear_inherit_confirm->disconnect("confirmed", callable_mp(this, &SceneTreeDock::_tool_selected));
 		} break;
+
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			scene_tree->set_auto_expand_selected(EditorSettings::get_singleton()->get("docks/scene_tree/auto_expand_to_selected"), false);
 			button_add->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
@@ -1286,6 +1287,7 @@ void SceneTreeDock::_notification(int p_what) {
 			filter->set_right_icon(get_theme_icon(SNAME("Search"), SNAME("EditorIcons")));
 			filter->set_clear_button_enabled(true);
 		} break;
+
 		case NOTIFICATION_PROCESS: {
 			bool show_create_root = bool(EDITOR_GET("interface/editors/show_scene_tree_root_selection")) && get_tree()->get_edited_scene_root() == nullptr;
 
@@ -1298,7 +1300,6 @@ void SceneTreeDock::_notification(int p_what) {
 					scene_tree->show();
 				}
 			}
-
 		} break;
 	}
 }

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -700,6 +700,7 @@ void SceneTreeEditor::_notification(int p_what) {
 
 			_update_tree();
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			get_tree()->disconnect("tree_changed", callable_mp(this, &SceneTreeEditor::_tree_changed));
 			get_tree()->disconnect("tree_process_mode_changed", callable_mp(this, &SceneTreeEditor::_tree_process_mode_changed));
@@ -708,6 +709,7 @@ void SceneTreeEditor::_notification(int p_what) {
 			tree->disconnect("item_collapsed", callable_mp(this, &SceneTreeEditor::_cell_collapsed));
 			get_tree()->disconnect("node_configuration_warning_changed", callable_mp(this, &SceneTreeEditor::_warning_changed));
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_tree();
 		} break;
@@ -1283,13 +1285,16 @@ void SceneTreeDialog::_notification(int p_what) {
 				tree->update_tree();
 			}
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			connect("confirmed", callable_mp(this, &SceneTreeDialog::_select));
 			_update_theme();
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_theme();
 		} break;
+
 		case NOTIFICATION_EXIT_TREE: {
 			disconnect("confirmed", callable_mp(this, &SceneTreeDialog::_select));
 		} break;

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -57,6 +57,7 @@ void ShaderCreateDialog::_notification(int p_what) {
 			current_mode = EditorSettings::get_singleton()->get_project_metadata("shader_setup", "last_selected_mode", 0);
 			mode_menu->select(current_mode);
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			_update_theme();
 		} break;

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -438,13 +438,16 @@ void ShaderGlobalsEditor::_bind_methods() {
 }
 
 void ShaderGlobalsEditor::_notification(int p_what) {
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		if (is_visible_in_tree()) {
-			inspector->edit(interface);
-		}
-	}
-	if (p_what == NOTIFICATION_PREDELETE) {
-		inspector->edit(nullptr);
+	switch (p_what) {
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (is_visible_in_tree()) {
+				inspector->edit(interface);
+			}
+		} break;
+
+		case NOTIFICATION_PREDELETE: {
+			inspector->edit(nullptr);
+		} break;
 	}
 }
 

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -491,61 +491,63 @@ Vector<Face3> CSGShape3D::get_faces(uint32_t p_usage_flags) const {
 }
 
 void CSGShape3D::_notification(int p_what) {
-	if (p_what == NOTIFICATION_ENTER_TREE) {
-		Node *parentn = get_parent();
-		if (parentn) {
-			parent = Object::cast_to<CSGShape3D>(parentn);
-			if (parent) {
-				set_base(RID());
-				root_mesh.unref();
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			Node *parentn = get_parent();
+			if (parentn) {
+				parent = Object::cast_to<CSGShape3D>(parentn);
+				if (parent) {
+					set_base(RID());
+					root_mesh.unref();
+				}
 			}
-		}
 
-		if (use_collision && is_root_shape()) {
-			root_collision_shape.instantiate();
-			root_collision_instance = PhysicsServer3D::get_singleton()->body_create();
-			PhysicsServer3D::get_singleton()->body_set_mode(root_collision_instance, PhysicsServer3D::BODY_MODE_STATIC);
-			PhysicsServer3D::get_singleton()->body_set_state(root_collision_instance, PhysicsServer3D::BODY_STATE_TRANSFORM, get_global_transform());
-			PhysicsServer3D::get_singleton()->body_add_shape(root_collision_instance, root_collision_shape->get_rid());
-			PhysicsServer3D::get_singleton()->body_set_space(root_collision_instance, get_world_3d()->get_space());
-			PhysicsServer3D::get_singleton()->body_attach_object_instance_id(root_collision_instance, get_instance_id());
-			set_collision_layer(collision_layer);
-			set_collision_mask(collision_mask);
-		}
+			if (use_collision && is_root_shape()) {
+				root_collision_shape.instantiate();
+				root_collision_instance = PhysicsServer3D::get_singleton()->body_create();
+				PhysicsServer3D::get_singleton()->body_set_mode(root_collision_instance, PhysicsServer3D::BODY_MODE_STATIC);
+				PhysicsServer3D::get_singleton()->body_set_state(root_collision_instance, PhysicsServer3D::BODY_STATE_TRANSFORM, get_global_transform());
+				PhysicsServer3D::get_singleton()->body_add_shape(root_collision_instance, root_collision_shape->get_rid());
+				PhysicsServer3D::get_singleton()->body_set_space(root_collision_instance, get_world_3d()->get_space());
+				PhysicsServer3D::get_singleton()->body_attach_object_instance_id(root_collision_instance, get_instance_id());
+				set_collision_layer(collision_layer);
+				set_collision_mask(collision_mask);
+			}
 
-		_make_dirty();
-	}
+			_make_dirty();
+		} break;
 
-	if (p_what == NOTIFICATION_TRANSFORM_CHANGED) {
-		if (use_collision && is_root_shape() && root_collision_instance.is_valid()) {
-			PhysicsServer3D::get_singleton()->body_set_state(root_collision_instance, PhysicsServer3D::BODY_STATE_TRANSFORM, get_global_transform());
-		}
-	}
+		case NOTIFICATION_TRANSFORM_CHANGED: {
+			if (use_collision && is_root_shape() && root_collision_instance.is_valid()) {
+				PhysicsServer3D::get_singleton()->body_set_state(root_collision_instance, PhysicsServer3D::BODY_STATE_TRANSFORM, get_global_transform());
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_LOCAL_TRANSFORM_CHANGED) {
-		if (parent) {
-			parent->_make_dirty();
-		}
-	}
+		case NOTIFICATION_LOCAL_TRANSFORM_CHANGED: {
+			if (parent) {
+				parent->_make_dirty();
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		if (parent) {
-			parent->_make_dirty();
-		}
-	}
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (parent) {
+				parent->_make_dirty();
+			}
+		} break;
 
-	if (p_what == NOTIFICATION_EXIT_TREE) {
-		if (parent) {
-			parent->_make_dirty();
-		}
-		parent = nullptr;
+		case NOTIFICATION_EXIT_TREE: {
+			if (parent) {
+				parent->_make_dirty();
+			}
+			parent = nullptr;
 
-		if (use_collision && is_root_shape() && root_collision_instance.is_valid()) {
-			PhysicsServer3D::get_singleton()->free(root_collision_instance);
-			root_collision_instance = RID();
-			root_collision_shape.unref();
-		}
-		_make_dirty();
+			if (use_collision && is_root_shape() && root_collision_instance.is_valid()) {
+				PhysicsServer3D::get_singleton()->free(root_collision_instance);
+				root_collision_instance = RID();
+				root_collision_shape.unref();
+			}
+			_make_dirty();
+		} break;
 	}
 }
 

--- a/modules/gdnative/gdnative_library_singleton_editor.cpp
+++ b/modules/gdnative/gdnative_library_singleton_editor.cpp
@@ -183,10 +183,12 @@ void GDNativeLibrarySingletonEditor::_item_edited() {
 }
 
 void GDNativeLibrarySingletonEditor::_notification(int p_what) {
-	if (p_what == NOTIFICATION_VISIBILITY_CHANGED) {
-		if (is_visible_in_tree()) {
-			_update_libraries();
-		}
+	switch (p_what) {
+		case NOTIFICATION_VISIBILITY_CHANGED: {
+			if (is_visible_in_tree()) {
+				_update_libraries();
+			}
+		} break;
 	}
 }
 

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -763,17 +763,19 @@ Variant NativeScriptInstance::call(const StringName &p_method, const Variant **p
 	return Variant();
 }
 
-void NativeScriptInstance::notification(int p_notification) {
+void NativeScriptInstance::notification(int p_what) {
 #ifdef DEBUG_ENABLED
-	if (p_notification == MainLoop::NOTIFICATION_CRASH) {
-		if (current_method_call != StringName()) {
-			ERR_PRINT("NativeScriptInstance detected crash on method: " + current_method_call);
-			current_method_call = "";
-		}
+	switch (p_what) {
+		case MainLoop::NOTIFICATION_CRASH: {
+			if (current_method_call != StringName()) {
+				ERR_PRINT("NativeScriptInstance detected crash on method: " + current_method_call);
+				current_method_call = "";
+			}
+		} break;
 	}
 #endif
 
-	Variant value = p_notification;
+	Variant value = p_what;
 	const Variant *args[1] = { &value };
 	Callable::CallError error;
 	call("_notification", args, 1, error);
@@ -1639,7 +1641,6 @@ void NativeReloadNode::_bind_methods() {
 
 void NativeReloadNode::_notification(int p_what) {
 #ifdef TOOLS_ENABLED
-
 	switch (p_what) {
 		case NOTIFICATION_APPLICATION_FOCUS_OUT: {
 			if (unloaded) {
@@ -1672,7 +1673,6 @@ void NativeReloadNode::_notification(int p_what) {
 			}
 
 			unloaded = true;
-
 		} break;
 
 		case NOTIFICATION_APPLICATION_FOCUS_IN: {
@@ -1736,10 +1736,7 @@ void NativeReloadNode::_notification(int p_what) {
 			for (Set<StringName>::Element *R = libs_to_remove.front(); R; R = R->next()) {
 				NSL->library_gdnatives.erase(R->get());
 			}
-
 		} break;
-		default: {
-		};
 	}
 #endif
 }

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -209,7 +209,7 @@ public:
 	virtual void get_method_list(List<MethodInfo> *p_list) const;
 	virtual bool has_method(const StringName &p_method) const;
 	virtual Variant call(const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error);
-	virtual void notification(int p_notification);
+	virtual void notification(int p_what);
 	String to_string(bool *r_valid);
 	virtual Ref<Script> get_script() const;
 

--- a/modules/gdscript/language_server/gdscript_language_server.cpp
+++ b/modules/gdscript/language_server/gdscript_language_server.cpp
@@ -45,17 +45,20 @@ GDScriptLanguageServer::GDScriptLanguageServer() {
 
 void GDScriptLanguageServer::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_ENTER_TREE: {
 			start();
-			break;
-		case NOTIFICATION_EXIT_TREE:
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
 			stop();
-			break;
+		} break;
+
 		case NOTIFICATION_INTERNAL_PROCESS: {
 			if (started && !use_thread) {
 				protocol.poll();
 			}
 		} break;
+
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			String host = String(_EDITOR_GET("network/language_server/remote_host"));
 			int port = (int)_EDITOR_GET("network/language_server/remote_port");

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -703,8 +703,8 @@ void GridMap::_notification(int p_what) {
 				RS::get_singleton()->instance_set_scenario(baked_meshes[i].instance, get_world_3d()->get_scenario());
 				RS::get_singleton()->instance_set_transform(baked_meshes[i].instance, get_global_transform());
 			}
-
 		} break;
+
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			Transform3D new_xform = get_global_transform();
 			if (new_xform == last_transform) {
@@ -721,6 +721,7 @@ void GridMap::_notification(int p_what) {
 				RS::get_singleton()->instance_set_transform(baked_meshes[i].instance, get_global_transform());
 			}
 		} break;
+
 		case NOTIFICATION_EXIT_WORLD: {
 			for (const KeyValue<OctantKey, Octant *> &E : octant_map) {
 				_octant_exit_world(E.key);
@@ -732,8 +733,8 @@ void GridMap::_notification(int p_what) {
 			for (int i = 0; i < baked_meshes.size(); i++) {
 				RS::get_singleton()->instance_set_scenario(baked_meshes[i].instance, RID());
 			}
-
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			_update_visibility();
 		} break;

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -1456,15 +1456,17 @@ GridMapEditor::~GridMapEditor() {
 }
 
 void GridMapEditorPlugin::_notification(int p_what) {
-	if (p_what == EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED) {
-		switch ((int)EditorSettings::get_singleton()->get("editors/grid_map/editor_side")) {
-			case 0: { // Left.
-				Node3DEditor::get_singleton()->move_control_to_left_panel(grid_map_editor);
-			} break;
-			case 1: { // Right.
-				Node3DEditor::get_singleton()->move_control_to_right_panel(grid_map_editor);
-			} break;
-		}
+	switch (p_what) {
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			switch ((int)EditorSettings::get_singleton()->get("editors/grid_map/editor_side")) {
+				case 0: { // Left.
+					Node3DEditor::get_singleton()->move_control_to_left_panel(grid_map_editor);
+				} break;
+				case 1: { // Right.
+					Node3DEditor::get_singleton()->move_control_to_right_panel(grid_map_editor);
+				} break;
+			}
+		} break;
 	}
 }
 

--- a/modules/navigation/navigation_mesh_editor_plugin.cpp
+++ b/modules/navigation/navigation_mesh_editor_plugin.cpp
@@ -46,10 +46,12 @@ void NavigationMeshEditor::_node_removed(Node *p_node) {
 	}
 }
 
-void NavigationMeshEditor::_notification(int p_option) {
-	if (p_option == NOTIFICATION_ENTER_TREE) {
-		button_bake->set_icon(get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
-		button_reset->set_icon(get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
+void NavigationMeshEditor::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			button_bake->set_icon(get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
+			button_reset->set_icon(get_theme_icon(SNAME("Reload"), SNAME("EditorIcons")));
+		} break;
 	}
 }
 

--- a/modules/navigation/navigation_mesh_editor_plugin.h
+++ b/modules/navigation/navigation_mesh_editor_plugin.h
@@ -57,7 +57,7 @@ class NavigationMeshEditor : public Control {
 protected:
 	void _node_removed(Node *p_node);
 	static void _bind_methods();
-	void _notification(int p_option);
+	void _notification(int p_what);
 
 public:
 	void edit(NavigationRegion3D *p_nav_region);

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -3978,6 +3978,7 @@ void VisualScriptEditor::_notification(int p_what) {
 				_update_graph();
 			}
 		} break;
+
 		case NOTIFICATION_VISIBILITY_CHANGED: {
 			update_toggle_scripts_button();
 			members_section->set_visible(is_visible_in_tree());

--- a/modules/visual_script/editor/visual_script_property_selector.cpp
+++ b/modules/visual_script/editor/visual_script_property_selector.cpp
@@ -118,9 +118,11 @@ void VisualScriptPropertySelector::_notification(int p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			_update_icons();
 		} break;
+
 		case NOTIFICATION_ENTER_TREE: {
 			connect("confirmed", callable_mp(this, &VisualScriptPropertySelector::_confirmed));
 		} break;
+
 		case NOTIFICATION_PROCESS: {
 			// Update background search.
 			if (search_runner.is_valid()) {


### PR DESCRIPTION
Converts `::_notification` methods to use `switch` statements instead of `if`. Chunk C of #58155.

I think I didn't miss anything!