### PR TITLE
Have look_at fallback to local transform if node not in tree

### DIFF
--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -728,7 +728,7 @@ void Node3D::set_identity() {
 }
 
 void Node3D::look_at(const Vector3 &p_target, const Vector3 &p_up) {
-	Vector3 origin = get_global_transform().origin;
+	Vector3 origin = is_inside_tree() ? get_global_transform().origin : get_transform().origin;
 	look_at_from_position(origin, p_target, p_up);
 }
 


### PR DESCRIPTION
For consideration: 

This pull request makes 
```
set_position(start_position)
look_at(end_position, Vector3.UP)
```
equivalent to `look_at_from_position(start_position, end_position, Vector3.UP)` for nodes not inside the tree. 

Currently, using `look_at` for a node not yet in the tree causes the node's position to be reset to the origin. This can be confusing to the user, as `look_at` is not supposed to move the node. This use case primarily applies to setting the position of a physics node prior to adding it to the tree, which is a best practice according to #45638. 

See https://github.com/godotengine/godot/issues/58132#issuecomment-1040451458 

Alternatively, better documentation and updated tutorials would also help. 

Note: This would also have to be back-ported to 3.x