### PR TITLE
Don't translate numbers in `VersionControlEditorPlugin`

### DIFF
--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -1263,11 +1263,11 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 
 	commit_list_size_button = memnew(OptionButton);
 	commit_list_size_button->set_tooltip(TTR("Commit list size"));
-	commit_list_size_button->add_item(TTR("10"));
+	commit_list_size_button->add_item("10");
 	commit_list_size_button->set_item_metadata(0, 10);
-	commit_list_size_button->add_item(TTR("20"));
+	commit_list_size_button->add_item("20");
 	commit_list_size_button->set_item_metadata(0, 20);
-	commit_list_size_button->add_item(TTR("30"));
+	commit_list_size_button->add_item("30");
 	commit_list_size_button->set_item_metadata(0, 30);
 	commit_list_size_button->connect("pressed", this, "_refresh_commit_list");
 	commit_list_hbc->add_child(commit_list_size_button);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/58194. 
As discussed on RC, this is likely an oversight, even though there may be a reason to translate numbers for languages such as Arabic. But we don't do that anywhere else in the editor, at least not on purpose. So for the time being, this will clean up translations.

Doesn't seem to be synced with master yet, so only applicable to 3.x.