### PR TITLE
Fix extension registration order.

### DIFF
--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -316,9 +316,11 @@ void register_core_extensions() {
 	native_extension_manager->initialize_extensions(NativeExtension::INITIALIZATION_LEVEL_CORE);
 }
 
-void unregister_core_types() {
+void unregister_core_extensions() {
 	native_extension_manager->deinitialize_extensions(NativeExtension::INITIALIZATION_LEVEL_CORE);
+}
 
+void unregister_core_types() {
 	memdelete(native_extension_manager);
 
 	memdelete(resource_uid);

--- a/core/register_core_types.h
+++ b/core/register_core_types.h
@@ -36,5 +36,6 @@ void register_core_settings();
 void register_core_extensions();
 void register_core_singletons();
 void unregister_core_types();
+void unregister_core_extensions();
 
 #endif // REGISTER_CORE_TYPES_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -487,6 +487,7 @@ void Main::test_cleanup() {
 	}
 
 	unregister_core_driver_types();
+	unregister_core_extensions();
 	unregister_core_types();
 
 	OS::get_singleton()->finalize_core();
@@ -554,6 +555,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	globals = memnew(ProjectSettings);
 
 	register_core_settings(); //here globals are present
+	register_core_extensions(); // core extensions must be registered after core settings and before display
 
 	translation_server = memnew(TranslationServer);
 	performance = memnew(Performance);
@@ -634,7 +636,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			continue;
 		}
 #endif
-
 		List<String>::Element *N = I->next();
 
 		if (I->get() == "-h" || I->get() == "--help" || I->get() == "/?") { // display help
@@ -1271,8 +1272,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	Logger::set_flush_stdout_on_print(ProjectSettings::get_singleton()->get("application/run/flush_stdout_on_print"));
 
 	OS::get_singleton()->set_cmdline(execpath, main_args);
-
-	register_core_extensions(); //before display
 	// possibly be worth changing the default from vulkan to something lower spec,
 	// for the project manager, depending on how smooth the fallback is.
 	GLOBAL_DEF_RST("rendering/driver/driver_name", "vulkan");
@@ -1529,6 +1528,7 @@ error:
 	}
 
 	unregister_core_driver_types();
+	unregister_core_extensions();
 	unregister_core_types();
 
 	OS::get_singleton()->_cmdline.clear();
@@ -2888,6 +2888,7 @@ void Main::cleanup(bool p_force) {
 	memdelete(message_queue);
 
 	unregister_core_driver_types();
+	unregister_core_extensions();
 	unregister_core_types();
 
 	OS::get_singleton()->finalize_core();


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes https://github.com/godotengine/godot/issues/50031.

- Register core extensions right after core settings. This ensures it's properly initialized when we jump into any error branching.