### PR TITLE
Fix documentation about `TreeItem` button ID

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -18,7 +18,7 @@
 			<argument index="3" name="disabled" type="bool" default="false" />
 			<argument index="4" name="tooltip" type="String" default="&quot;&quot;" />
 			<description>
-				Adds a button with [Texture2D] [code]button[/code] at column [code]column[/code]. The [code]id[/code] is used to identify the button. If not specified, the next available index is used, which may be retrieved by calling [method get_button_count] immediately after this method. Optionally, the button can be [code]disabled[/code] and have a [code]tooltip[/code].
+				Adds a button with [Texture2D] [code]button[/code] at column [code]column[/code]. The [code]id[/code] is used to identify the button. If not specified, the next available index is used, which may be retrieved by calling [method get_button_count] immediately before this method. Optionally, the button can be [code]disabled[/code] and have a [code]tooltip[/code].
 			</description>
 		</method>
 		<method name="call_recursive" qualifiers="vararg">
@@ -92,7 +92,7 @@
 			<return type="int" />
 			<argument index="0" name="column" type="int" />
 			<description>
-				Returns the number of buttons in column [code]column[/code]. May be used to get the most recently added button's index, if no index was specified.
+				Returns the number of buttons in column [code]column[/code].
 			</description>
 		</method>
 		<method name="get_button_id" qualifiers="const">


### PR DESCRIPTION
The description about using `TreeItem.get_button_count()` to get recent button index, which is actually ID, is never true.

`TreeItem.add_button()` uses `get_button_count()` for button ID when no ID is specified. So one have to call `get_button_count()` before adding the button in order to get that ID.
