### PR TITLE
[3.x] Fix description of `OccluderShapePolygon.two_way`

### DIFF
--- a/doc/classes/OccluderShapePolygon.xml
+++ b/doc/classes/OccluderShapePolygon.xml
@@ -37,7 +37,7 @@
 			Allows changing the polygon geometry from code.
 		</member>
 		<member name="two_way" type="bool" setter="set_two_way" getter="is_two_way" default="true">
-			Specifies whether the occluder should operate one way only, or from both sides.
+			Specifies whether the occluder should operate from both sides. If [code]false[/code], the occluder will operate one way only.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Despite the property name, the current description sounds like the opposite way, with `true` being one way only:

https://github.com/godotengine/godot/blob/2dd545b512a19e1c1c6a8dfddff62083e96bcb49/doc/classes/OccluderShapePolygon.xml#L39-L41