### PR TITLE
Fix local variables not showing in debugger when break-pointing on final line

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -95,7 +95,7 @@ void GDScriptFunction::debug_get_stack_member_state(int p_line, List<Pair<String
 	int oc = 0;
 	Map<StringName, _GDFKC> sdmap;
 	for (const StackDebug &sd : stack_debug) {
-		if (sd.line > p_line) {
+		if (sd.line >= p_line) {
 			break;
 		}
 


### PR DESCRIPTION
Changes the scoping check in `debug_get_stack_member_state` line from `>` to `>=`, which should prevent relevant local variables being excluded from the debug message when debugging from the final line of a scoped code block.

Close #58200