### PR TITLE
Add missing flag when encode_variant writes math types with doubles

### DIFF
--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -1067,6 +1067,21 @@ Error encode_variant(const Variant &p_variant, uint8_t *r_buffer, int &r_len, bo
 				flags |= ENCODE_FLAG_OBJECT_AS_ID;
 			}
 		} break;
+#ifdef REAL_T_IS_DOUBLE
+		case Variant::VECTOR2:
+		case Variant::VECTOR3:
+		case Variant::PACKED_VECTOR2_ARRAY:
+		case Variant::PACKED_VECTOR3_ARRAY:
+		case Variant::TRANSFORM2D:
+		case Variant::TRANSFORM3D:
+		case Variant::QUATERNION:
+		case Variant::PLANE:
+		case Variant::BASIS:
+		case Variant::RECT2:
+		case Variant::AABB: {
+			flags |= ENCODE_FLAG_64;
+		} break;
+#endif // REAL_T_IS_DOUBLE
 		default: {
 		} // nothing to do at this stage
 	}


### PR DESCRIPTION
Fixes #57935

The remote inspector is based on `encode_variant` and `decode_variant` to send and receive data. `decode_variant` uses a flag within the type to know if math types in the data are using doubles, but `encode_variant` is always writing `real_t`, without specifying the flag. So I made it so the flag is set when the instance of Godot writing the data is compiled with doubles.

cc @aaronfranke 