### PR TITLE
Fix visible seam on smoothed sphere and cylinder shapes

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -955,6 +955,10 @@ CSGBrush *CSGSphere3D::_build_brush() {
 				double u0 = double(j) / radial_segments;
 
 				double longitude1 = longitude_step * (j + 1);
+				if (j == radial_segments - 1) {
+					longitude1 = 0;
+				}
+
 				double x1 = Math::sin(longitude1);
 				double z1 = Math::cos(longitude1);
 				double u1 = double(j + 1) / radial_segments;
@@ -1271,6 +1275,9 @@ CSGBrush *CSGCylinder3D::_build_brush() {
 			for (int i = 0; i < sides; i++) {
 				float inc = float(i) / sides;
 				float inc_n = float((i + 1)) / sides;
+				if (i == sides - 1) {
+					inc_n = 0;
+				}
 
 				float ang = inc * Math_TAU;
 				float ang_n = inc_n * Math_TAU;


### PR DESCRIPTION
Fix visible seam on smoothed sphere and cylinder shapes, cause by a bad normal computation at the junction between the first and last radial segment of the shapes (#58207).

The problem is due to the fact that smoothed normals are computed by accumulating the normals of all the faces shared by a single vertex, found from a lookup hash table, and then normalized (see `vec_map` in `CSGShape3D::_update_shape()`). But probably due to floating point errors and the way the hash of a Vector3D is computed, the vertices on the first and the last radial segment are not detected as sharing the same faces so the computed normal is wrong.

The fix here is to detect if we are on the last radial segment, and if it is the case compute the points exactly as it was done for the first radial segment, so the results are the same and they are matched together by the hash table.

**Before**

![sphere_small_before](https://user-images.githubusercontent.com/1554884/154364441-2c37a078-b64f-454a-8b95-cf04d7118cdd.png)
![cylinder_small_before](https://user-images.githubusercontent.com/1554884/154364477-c046e4a0-e921-4cc3-ae05-5b36c10e0853.png)

**After**

![sphere_small_after](https://user-images.githubusercontent.com/1554884/154364552-5cd9467b-ebc0-4207-870f-e78b327ebb88.png)
![cylinder_small_after](https://user-images.githubusercontent.com/1554884/154364565-4b22331a-7421-4c50-b99b-1c5e9dbdbe51.png)

<!--

Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
