### PR TITLE
Fix `get_simple_path` behavior in 2D & 3D

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -376,18 +376,15 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 
 			// Add mid points
 			int np_id = least_cost_id;
-			while (np_id != -1) {
-#ifdef USE_ENTRY_POINT
-				Vector3 point = navigation_polys[np_id].entry;
-#else
+			while (np_id != -1 && navigation_polys[np_id].prev_navigation_poly_id != -1) {
 				int prev = navigation_polys[np_id].back_navigation_edge;
 				int prev_n = (navigation_polys[np_id].back_navigation_edge + 1) % navigation_polys[np_id].poly->points.size();
 				Vector3 point = (navigation_polys[np_id].poly->points[prev].pos + navigation_polys[np_id].poly->points[prev_n].pos) * 0.5;
-#endif
-
 				path.push_back(point);
 				np_id = navigation_polys[np_id].prev_navigation_poly_id;
 			}
+
+			path.push_back(begin_point);
 
 			path.invert();
 		}


### PR DESCRIPTION
fixes #56852

tested both `2D` and `3D` and it looks like both cases are fixed.

Btw. optimized `get_simple_path` was not impacted.

2D before fix:
![2d-get-simple-path-before](https://user-images.githubusercontent.com/1207385/154534124-98b82c40-bd89-45a4-ba69-f23d64901bb1.png)

2D after fix:
![2d-get-simple-path-after](https://user-images.githubusercontent.com/1207385/154534162-d6527e28-c279-461c-8d53-a994cf01a40f.png)

3D before fix:
![3d-get-simple-path-before](https://user-images.githubusercontent.com/1207385/154534210-e3c506bd-0e48-453c-9f86-5254645bd24a.png)

3D after fix:
![3d-get-simple-path-after](https://user-images.githubusercontent.com/1207385/154534236-041a9e8c-0482-4bdc-906d-5cf5c38aa794.png)

If accepted, I'll prepare separate PR for master.