### PR TITLE
Add a property hint for the Line2D Round Precision property

### DIFF
--- a/doc/classes/Line2D.xml
+++ b/doc/classes/Line2D.xml
@@ -79,7 +79,8 @@
 			The points that form the lines. The line is drawn between every point set in this array. Points are interpreted as local vectors.
 		</member>
 		<member name="round_precision" type="int" setter="set_round_precision" getter="get_round_precision" default="8">
-			The smoothness of the rounded joints and caps. This is only used if a cap or joint is set as round.
+			The smoothness of the rounded joints and caps. Higher values result in smoother corners, but are more demanding to render and update. This is only used if a cap or joint is set as round.
+			[b]Note:[/b] The default value is tuned for lines with the default [member width]. For thin lines, this value should be reduced to a number between [code]2[/code] and [code]4[/code] to improve performance.
 		</member>
 		<member name="sharp_limit" type="float" setter="set_sharp_limit" getter="get_sharp_limit" default="2.0">
 			The direction difference in radians between vector points. This value is only used if [member joint_mode] is set to [constant LINE_JOINT_SHARP].

--- a/scene/2d/line_2d.cpp
+++ b/scene/2d/line_2d.cpp
@@ -247,10 +247,7 @@ float Line2D::get_sharp_limit() const {
 }
 
 void Line2D::set_round_precision(int p_precision) {
-	if (p_precision < 1) {
-		p_precision = 1;
-	}
-	_round_precision = p_precision;
+	_round_precision = MAX(1, p_precision);
 	update();
 }
 
@@ -409,7 +406,7 @@ void Line2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "end_cap_mode", PROPERTY_HINT_ENUM, "None,Box,Round"), "set_end_cap_mode", "get_end_cap_mode");
 	ADD_GROUP("Border", "");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "sharp_limit"), "set_sharp_limit", "get_sharp_limit");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "round_precision"), "set_round_precision", "get_round_precision");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "round_precision", PROPERTY_HINT_RANGE, "1,32,1"), "set_round_precision", "get_round_precision");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "antialiased"), "set_antialiased", "get_antialiased");
 
 	BIND_ENUM_CONSTANT(LINE_JOINT_SHARP);


### PR DESCRIPTION
This prevents choosing extremely high values which cause performance issues for no visual benefit.

We could also consider using a lower value by default in 4.0 (such as 4 or 6).

See https://godotforums.org/discussion/29080/rendering-thin-300-600-polyline-line2d-quality-speed-memory.