### PR TITLE
Rename graphics settings levels to use Medium as a baseline

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1841,8 +1841,8 @@
 		</member>
 		<member name="rendering/shadows/directional_shadow/soft_shadow_quality" type="int" setter="" getter="" default="2">
 			Quality setting for shadows cast by [DirectionalLight3D]s. Higher quality settings use more samples when reading from shadow maps and are thus slower. Low quality settings may result in shadows looking grainy.
-			[b]Note:[/b] The Soft Very Low setting will automatically multiply [i]constant[/i] shadow blur by 0.75x to reduce the amount of noise visible. This automatic blur change only affects the constant blur factor defined in [member Light3D.shadow_blur], not the variable blur performed by [DirectionalLight3D]s' [member Light3D.light_angular_distance].
-			[b]Note:[/b] The Soft High and Soft Ultra settings will automatically multiply [i]constant[/i] shadow blur by 1.5× and 2× respectively to make better use of the increased sample count. This increased blur also improves stability of dynamic object shadows.
+			[b]Note:[/b] The Soft Low setting will automatically multiply [i]constant[/i] shadow blur by 0.75x to reduce the amount of noise visible. This automatic blur change only affects the constant blur factor defined in [member Light3D.shadow_blur], not the variable blur performed by [DirectionalLight3D]s' [member Light3D.light_angular_distance].
+			[b]Note:[/b] The Soft Very High and Soft Ultra settings will automatically multiply [i]constant[/i] shadow blur by 1.5× and 2× respectively to make better use of the increased sample count. This increased blur also improves stability of dynamic object shadows.
 		</member>
 		<member name="rendering/shadows/directional_shadow/soft_shadow_quality.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/shadows/directional_shadow/soft_shadow_quality] on mobile devices, due to performance concerns or driver support.
@@ -1869,8 +1869,8 @@
 		</member>
 		<member name="rendering/shadows/shadows/soft_shadow_quality" type="int" setter="" getter="" default="2">
 			Quality setting for shadows cast by [OmniLight3D]s and [SpotLight3D]s. Higher quality settings use more samples when reading from shadow maps and are thus slower. Low quality settings may result in shadows looking grainy.
-			[b]Note:[/b] The Soft Very Low setting will automatically multiply [i]constant[/i] shadow blur by 0.75x to reduce the amount of noise visible. This automatic blur change only affects the constant blur factor defined in [member Light3D.shadow_blur], not the variable blur performed by [DirectionalLight3D]s' [member Light3D.light_angular_distance].
-			[b]Note:[/b] The Soft High and Soft Ultra settings will automatically multiply shadow blur by 1.5× and 2× respectively to make better use of the increased sample count. This increased blur also improves stability of dynamic object shadows.
+			[b]Note:[/b] The Soft Low setting will automatically multiply [i]constant[/i] shadow blur by 0.75x to reduce the amount of noise visible. This automatic blur change only affects the constant blur factor defined in [member Light3D.shadow_blur], not the variable blur performed by [DirectionalLight3D]s' [member Light3D.light_angular_distance].
+			[b]Note:[/b] The Soft Very High and Soft Ultra settings will automatically multiply shadow blur by 1.5× and 2× respectively to make better use of the increased sample count. This increased blur also improves stability of dynamic object shadows.
 		</member>
 		<member name="rendering/shadows/shadows/soft_shadow_quality.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/shadows/shadows/soft_shadow_quality] on mobile devices, due to performance concerns or driver support.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3785,22 +3785,23 @@
 			Lowest shadow filtering quality (fastest). Soft shadows are not available with this quality setting, which means the [member Light3D.shadow_blur] property is ignored if [member Light3D.light_size] and [member Light3D.light_angular_distance] is [code]0.0[/code].
 			[b]Note:[/b] The variable shadow blur performed by [member Light3D.light_size] and [member Light3D.light_angular_distance] is still effective when using hard shadow filtering. In this case, [member Light3D.shadow_blur] [i]is[/i] taken into account. However, the results will not be blurred, instead the blur amount is treated as a maximum radius for the penumbra.
 		</constant>
-		<constant name="SHADOW_QUALITY_SOFT_VERY_LOW" value="1" enum="ShadowQuality">
-			Very low shadow filtering quality (faster). When using this quality setting, [member Light3D.shadow_blur] is automatically multiplied by 0.75× to avoid introducing too much noise. This division only applies to lights whose [member Light3D.light_size] or [member Light3D.light_angular_distance] is [code]0.0[/code]).
+		<constant name="SHADOW_QUALITY_SOFT_LOW" value="1" enum="ShadowQuality">
+			Low shadow filtering quality (faster). When using this quality setting, [member Light3D.shadow_blur] is automatically multiplied by 0.75× to avoid introducing too much noise. This division only applies to lights whose [member Light3D.light_size] or [member Light3D.light_angular_distance] is [code]0.0[/code]).
 		</constant>
-		<constant name="SHADOW_QUALITY_SOFT_LOW" value="2" enum="ShadowQuality">
-			Low shadow filtering quality (fast).
+		<constant name="SHADOW_QUALITY_SOFT_MEDIUM" value="2" enum="ShadowQuality">
+			Medium shadow filtering quality (fast).
 		</constant>
-		<constant name="SHADOW_QUALITY_SOFT_MEDIUM" value="3" enum="ShadowQuality">
-			Medium low shadow filtering quality (average).
+		<constant name="SHADOW_QUALITY_SOFT_HIGH" value="3" enum="ShadowQuality">
+			High shadow filtering quality (average).
 		</constant>
-		<constant name="SHADOW_QUALITY_SOFT_HIGH" value="4" enum="ShadowQuality">
-			High low shadow filtering quality (slow). When using this quality setting, [member Light3D.shadow_blur] is automatically multiplied by 1.5× to better make use of the high sample count. This increased blur also improves the stability of dynamic object shadows. This multiplier only applies to lights whose [member Light3D.light_size] or [member Light3D.light_angular_distance] is [code]0.0[/code]).
+		<constant name="SHADOW_QUALITY_SOFT_VERY_HIGH" value="4" enum="ShadowQuality">
+			Very high shadow filtering quality (slow). When using this quality setting, [member Light3D.shadow_blur] is automatically multiplied by 1.5× to better make use of the high sample count. This increased blur also improves the stability of dynamic object shadows. This multiplier only applies to lights whose [member Light3D.light_size] or [member Light3D.light_angular_distance] is [code]0.0[/code]).
 		</constant>
 		<constant name="SHADOW_QUALITY_SOFT_ULTRA" value="5" enum="ShadowQuality">
-			Highest low shadow filtering quality (slowest). When using this quality setting, [member Light3D.shadow_blur] is automatically multiplied by 2× to better make use of the high sample count. This increased blur also improves the stability of dynamic object shadows. This multiplier only applies to lights whose [member Light3D.light_size] or [member Light3D.light_angular_distance] is [code]0.0[/code]).
+			Highest shadow filtering quality (slowest). When using this quality setting, [member Light3D.shadow_blur] is automatically multiplied by 2× to better make use of the high sample count. This increased blur also improves the stability of dynamic object shadows. This multiplier only applies to lights whose [member Light3D.light_size] or [member Light3D.light_angular_distance] is [code]0.0[/code]).
 		</constant>
 		<constant name="SHADOW_QUALITY_MAX" value="6" enum="ShadowQuality">
+			Represents the size of the [enum ShadowQuality] enum.
 		</constant>
 		<constant name="REFLECTION_PROBE_UPDATE_ONCE" value="0" enum="ReflectionProbeUpdateMode">
 			Reflection probe will update reflections once and then stop.
@@ -4148,11 +4149,11 @@
 		</constant>
 		<constant name="ENV_SSR_ROUGNESS_QUALITY_DISABLED" value="0" enum="EnvironmentSSRRoughnessQuality">
 		</constant>
-		<constant name="ENV_SSR_ROUGNESS_QUALITY_LOW" value="1" enum="EnvironmentSSRRoughnessQuality">
+		<constant name="ENV_SSR_ROUGNESS_QUALITY_MEDIUM" value="1" enum="EnvironmentSSRRoughnessQuality">
 		</constant>
-		<constant name="ENV_SSR_ROUGNESS_QUALITY_MEDIUM" value="2" enum="EnvironmentSSRRoughnessQuality">
+		<constant name="ENV_SSR_ROUGNESS_QUALITY_HIGH" value="2" enum="EnvironmentSSRRoughnessQuality">
 		</constant>
-		<constant name="ENV_SSR_ROUGNESS_QUALITY_HIGH" value="3" enum="EnvironmentSSRRoughnessQuality">
+		<constant name="ENV_SSR_ROUGNESS_QUALITY_ULTRA" value="3" enum="EnvironmentSSRRoughnessQuality">
 		</constant>
 		<constant name="ENV_SSAO_QUALITY_VERY_LOW" value="0" enum="EnvironmentSSAOQuality">
 			Lowest quality of screen-space ambient occlusion.
@@ -4234,11 +4235,11 @@
 		</constant>
 		<constant name="SUB_SURFACE_SCATTERING_QUALITY_DISABLED" value="0" enum="SubSurfaceScatteringQuality">
 		</constant>
-		<constant name="SUB_SURFACE_SCATTERING_QUALITY_LOW" value="1" enum="SubSurfaceScatteringQuality">
+		<constant name="SUB_SURFACE_SCATTERING_QUALITY_MEDIUM" value="1" enum="SubSurfaceScatteringQuality">
 		</constant>
-		<constant name="SUB_SURFACE_SCATTERING_QUALITY_MEDIUM" value="2" enum="SubSurfaceScatteringQuality">
+		<constant name="SUB_SURFACE_SCATTERING_QUALITY_HIGH" value="2" enum="SubSurfaceScatteringQuality">
 		</constant>
-		<constant name="SUB_SURFACE_SCATTERING_QUALITY_HIGH" value="3" enum="SubSurfaceScatteringQuality">
+		<constant name="SUB_SURFACE_SCATTERING_QUALITY_ULTRA" value="3" enum="SubSurfaceScatteringQuality">
 		</constant>
 		<constant name="DOF_BOKEH_BOX" value="0" enum="DOFBokehShape">
 			Calculate the DOF blur using a box filter. The fastest option, but results in obvious lines in blur pattern.
@@ -4249,16 +4250,16 @@
 		<constant name="DOF_BOKEH_CIRCLE" value="2" enum="DOFBokehShape">
 			Calculates DOF blur using a circle shaped filter. Best quality and most realistic, but slowest. Use only for areas where a lot of performance can be dedicated to post-processing (e.g. cutscenes).
 		</constant>
-		<constant name="DOF_BLUR_QUALITY_VERY_LOW" value="0" enum="DOFBlurQuality">
-			Lowest quality DOF blur. This is the fastest setting, but you may be able to see filtering artifacts.
+		<constant name="DOF_BLUR_QUALITY_LOW" value="0" enum="DOFBlurQuality">
+			Low quality DOF blur. This is the fastest setting, but you may be able to see filtering artifacts.
 		</constant>
-		<constant name="DOF_BLUR_QUALITY_LOW" value="1" enum="DOFBlurQuality">
-			Low quality DOF blur.
-		</constant>
-		<constant name="DOF_BLUR_QUALITY_MEDIUM" value="2" enum="DOFBlurQuality">
+		<constant name="DOF_BLUR_QUALITY_MEDIUM" value="1" enum="DOFBlurQuality">
 			Medium quality DOF blur.
 		</constant>
-		<constant name="DOF_BLUR_QUALITY_HIGH" value="3" enum="DOFBlurQuality">
+		<constant name="DOF_BLUR_QUALITY_HIGH" value="2" enum="DOFBlurQuality">
+			High quality DOF blur.
+		</constant>
+		<constant name="DOF_BLUR_QUALITY_ULTRA" value="3" enum="DOFBlurQuality">
 			Highest quality DOF blur. Results in the smoothest looking blur by taking the most samples, but is also significantly slower.
 		</constant>
 		<constant name="INSTANCE_NONE" value="0" enum="InstanceType">

--- a/servers/rendering/renderer_rd/effects_rd.cpp
+++ b/servers/rendering/renderer_rd/effects_rd.cpp
@@ -667,13 +667,13 @@ void EffectsRD::screen_space_reflection(RID p_diffuse, RID p_normal_roughness, R
 		ssr_filter.push_constant.proj_info[2] = (1.0f - p_camera.matrix[0][2]) / p_camera.matrix[0][0];
 		ssr_filter.push_constant.proj_info[3] = (1.0f + p_camera.matrix[1][2]) / p_camera.matrix[1][1];
 		ssr_filter.push_constant.vertical = 0;
-		if (p_roughness_quality == RS::ENV_SSR_ROUGNESS_QUALITY_LOW) {
+		if (p_roughness_quality == RS::ENV_SSR_ROUGNESS_QUALITY_MEDIUM) {
 			ssr_filter.push_constant.steps = p_max_steps / 3;
 			ssr_filter.push_constant.increment = 3;
-		} else if (p_roughness_quality == RS::ENV_SSR_ROUGNESS_QUALITY_MEDIUM) {
+		} else if (p_roughness_quality == RS::ENV_SSR_ROUGNESS_QUALITY_HIGH) {
 			ssr_filter.push_constant.steps = p_max_steps / 2;
 			ssr_filter.push_constant.increment = 2;
-		} else {
+		} else { // RS::ENV_SSR_ROUGNESS_QUALITY_ULTRA
 			ssr_filter.push_constant.steps = p_max_steps;
 			ssr_filter.push_constant.increment = 1;
 		}
@@ -1065,7 +1065,7 @@ void EffectsRD::bokeh_dof(const BokehBuffers &p_buffers, bool p_dof_far, float p
 
 		bokeh.push_constant.steps = quality_samples[p_quality];
 
-		if (p_quality == RS::DOF_BLUR_QUALITY_VERY_LOW || p_quality == RS::DOF_BLUR_QUALITY_LOW) {
+		if (p_quality == RS::DOF_BLUR_QUALITY_LOW || p_quality == RS::DOF_BLUR_QUALITY_MEDIUM) {
 			//box and hexagon are more or less the same, and they can work in either half (very low and low quality) or full (medium and high quality_ sizes)
 
 			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, _get_uniform_set_from_image(p_buffers.half_texture[0]), 0);
@@ -1090,7 +1090,7 @@ void EffectsRD::bokeh_dof(const BokehBuffers &p_buffers, bool p_dof_far, float p
 		//third pass
 		bokeh.push_constant.second_pass = true;
 
-		if (p_quality == RS::DOF_BLUR_QUALITY_VERY_LOW || p_quality == RS::DOF_BLUR_QUALITY_LOW) {
+		if (p_quality == RS::DOF_BLUR_QUALITY_LOW || p_quality == RS::DOF_BLUR_QUALITY_MEDIUM) {
 			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, _get_uniform_set_from_image(p_buffers.half_texture[1]), 0);
 			RD::get_singleton()->compute_list_bind_uniform_set(compute_list, _get_compute_uniform_set_from_texture(p_buffers.half_texture[0]), 1);
 		} else {
@@ -1103,8 +1103,8 @@ void EffectsRD::bokeh_dof(const BokehBuffers &p_buffers, bool p_dof_far, float p
 		RD::get_singleton()->compute_list_dispatch_threads(compute_list, bokeh.push_constant.size[0], bokeh.push_constant.size[1], 1);
 		RD::get_singleton()->compute_list_add_barrier(compute_list);
 
-		if (p_quality == RS::DOF_BLUR_QUALITY_VERY_LOW || p_quality == RS::DOF_BLUR_QUALITY_LOW) {
-			//forth pass, upscale for low quality
+		if (p_quality == RS::DOF_BLUR_QUALITY_LOW || p_quality == RS::DOF_BLUR_QUALITY_MEDIUM) {
+			//forth pass, upscale for low and medium quality
 
 			RD::get_singleton()->compute_list_bind_compute_pipeline(compute_list, bokeh.compute_pipelines[BOKEH_COMPOSITE]);
 
@@ -1213,8 +1213,8 @@ void EffectsRD::bokeh_dof_raster(const BokehBuffers &p_buffers, bool p_dof_far, 
 			// double pass approach
 			BokehMode mode = p_bokeh_shape == RS::DOF_BOKEH_BOX ? BOKEH_GEN_BOKEH_BOX : BOKEH_GEN_BOKEH_HEXAGONAL;
 
-			if (p_quality == RS::DOF_BLUR_QUALITY_VERY_LOW || p_quality == RS::DOF_BLUR_QUALITY_LOW) {
-				//box and hexagon are more or less the same, and they can work in either half (very low and low quality) or full (medium and high quality_ sizes)
+			if (p_quality == RS::DOF_BLUR_QUALITY_LOW || p_quality == RS::DOF_BLUR_QUALITY_MEDIUM) {
+				//box and hexagon are more or less the same, and they can work in either half (low and medium quality) or full (high and ultra quality_ sizes)
 				bokeh.push_constant.size[0] = p_buffers.base_texture_size.x >> 1;
 				bokeh.push_constant.size[1] = p_buffers.base_texture_size.y >> 1;
 				bokeh.push_constant.half_size = true;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -3071,22 +3071,22 @@ void RendererSceneRenderRD::shadows_quality_set(RS::ShadowQuality p_quality) {
 				soft_shadow_samples = 0;
 				shadows_quality_radius = 1.0;
 			} break;
-			case RS::SHADOW_QUALITY_SOFT_VERY_LOW: {
+			case RS::SHADOW_QUALITY_SOFT_LOW: {
 				penumbra_shadow_samples = 4;
 				soft_shadow_samples = 1;
 				shadows_quality_radius = 1.5;
 			} break;
-			case RS::SHADOW_QUALITY_SOFT_LOW: {
+			case RS::SHADOW_QUALITY_SOFT_MEDIUM: {
 				penumbra_shadow_samples = 8;
 				soft_shadow_samples = 4;
 				shadows_quality_radius = 2.0;
 			} break;
-			case RS::SHADOW_QUALITY_SOFT_MEDIUM: {
+			case RS::SHADOW_QUALITY_SOFT_HIGH: {
 				penumbra_shadow_samples = 12;
 				soft_shadow_samples = 8;
 				shadows_quality_radius = 2.0;
 			} break;
-			case RS::SHADOW_QUALITY_SOFT_HIGH: {
+			case RS::SHADOW_QUALITY_SOFT_VERY_HIGH: {
 				penumbra_shadow_samples = 24;
 				soft_shadow_samples = 16;
 				shadows_quality_radius = 3.0;
@@ -3118,22 +3118,22 @@ void RendererSceneRenderRD::directional_shadow_quality_set(RS::ShadowQuality p_q
 				directional_soft_shadow_samples = 0;
 				directional_shadow_quality_radius = 1.0;
 			} break;
-			case RS::SHADOW_QUALITY_SOFT_VERY_LOW: {
+			case RS::SHADOW_QUALITY_SOFT_LOW: {
 				directional_penumbra_shadow_samples = 4;
 				directional_soft_shadow_samples = 1;
 				directional_shadow_quality_radius = 1.5;
 			} break;
-			case RS::SHADOW_QUALITY_SOFT_LOW: {
+			case RS::SHADOW_QUALITY_SOFT_MEDIUM: {
 				directional_penumbra_shadow_samples = 8;
 				directional_soft_shadow_samples = 4;
 				directional_shadow_quality_radius = 2.0;
 			} break;
-			case RS::SHADOW_QUALITY_SOFT_MEDIUM: {
+			case RS::SHADOW_QUALITY_SOFT_HIGH: {
 				directional_penumbra_shadow_samples = 12;
 				directional_soft_shadow_samples = 8;
 				directional_shadow_quality_radius = 2.0;
 			} break;
-			case RS::SHADOW_QUALITY_SOFT_HIGH: {
+			case RS::SHADOW_QUALITY_SOFT_VERY_HIGH: {
 				directional_penumbra_shadow_samples = 24;
 				directional_soft_shadow_samples = 16;
 				directional_shadow_quality_radius = 3.0;

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -428,7 +428,7 @@ private:
 
 	bool glow_bicubic_upscale = false;
 	bool glow_high_quality = false;
-	RS::EnvironmentSSRRoughnessQuality ssr_roughness_quality = RS::ENV_SSR_ROUGNESS_QUALITY_LOW;
+	RS::EnvironmentSSRRoughnessQuality ssr_roughness_quality = RS::ENV_SSR_ROUGNESS_QUALITY_MEDIUM;
 
 	mutable RID_Owner<RendererSceneEnvironmentRD, true> environment_owner;
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1942,10 +1942,10 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("directional_shadow_atlas_set_size", "size", "is_16bits"), &RenderingServer::directional_shadow_atlas_set_size);
 
 	BIND_ENUM_CONSTANT(SHADOW_QUALITY_HARD);
-	BIND_ENUM_CONSTANT(SHADOW_QUALITY_SOFT_VERY_LOW);
 	BIND_ENUM_CONSTANT(SHADOW_QUALITY_SOFT_LOW);
 	BIND_ENUM_CONSTANT(SHADOW_QUALITY_SOFT_MEDIUM);
 	BIND_ENUM_CONSTANT(SHADOW_QUALITY_SOFT_HIGH);
+	BIND_ENUM_CONSTANT(SHADOW_QUALITY_SOFT_VERY_HIGH);
 	BIND_ENUM_CONSTANT(SHADOW_QUALITY_SOFT_ULTRA);
 	BIND_ENUM_CONSTANT(SHADOW_QUALITY_MAX);
 
@@ -2372,9 +2372,9 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(ENV_TONE_MAPPER_ACES);
 
 	BIND_ENUM_CONSTANT(ENV_SSR_ROUGNESS_QUALITY_DISABLED);
-	BIND_ENUM_CONSTANT(ENV_SSR_ROUGNESS_QUALITY_LOW);
 	BIND_ENUM_CONSTANT(ENV_SSR_ROUGNESS_QUALITY_MEDIUM);
 	BIND_ENUM_CONSTANT(ENV_SSR_ROUGNESS_QUALITY_HIGH);
+	BIND_ENUM_CONSTANT(ENV_SSR_ROUGNESS_QUALITY_ULTRA);
 
 	BIND_ENUM_CONSTANT(ENV_SSAO_QUALITY_VERY_LOW);
 	BIND_ENUM_CONSTANT(ENV_SSAO_QUALITY_LOW);
@@ -2417,9 +2417,9 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(ENV_SDFGI_UPDATE_LIGHT_MAX);
 
 	BIND_ENUM_CONSTANT(SUB_SURFACE_SCATTERING_QUALITY_DISABLED);
-	BIND_ENUM_CONSTANT(SUB_SURFACE_SCATTERING_QUALITY_LOW);
 	BIND_ENUM_CONSTANT(SUB_SURFACE_SCATTERING_QUALITY_MEDIUM);
 	BIND_ENUM_CONSTANT(SUB_SURFACE_SCATTERING_QUALITY_HIGH);
+	BIND_ENUM_CONSTANT(SUB_SURFACE_SCATTERING_QUALITY_ULTRA);
 
 	/* CAMERA EFFECTS */
 
@@ -2435,10 +2435,10 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(DOF_BOKEH_HEXAGON);
 	BIND_ENUM_CONSTANT(DOF_BOKEH_CIRCLE);
 
-	BIND_ENUM_CONSTANT(DOF_BLUR_QUALITY_VERY_LOW);
 	BIND_ENUM_CONSTANT(DOF_BLUR_QUALITY_LOW);
 	BIND_ENUM_CONSTANT(DOF_BLUR_QUALITY_MEDIUM);
 	BIND_ENUM_CONSTANT(DOF_BLUR_QUALITY_HIGH);
+	BIND_ENUM_CONSTANT(DOF_BLUR_QUALITY_ULTRA);
 
 	/* SCENARIO */
 
@@ -2832,12 +2832,12 @@ RenderingServer::RenderingServer() {
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/directional_shadow/size", PropertyInfo(Variant::INT, "rendering/shadows/directional_shadow/size", PROPERTY_HINT_RANGE, "256,16384"));
 	GLOBAL_DEF("rendering/shadows/directional_shadow/soft_shadow_quality", 2);
 	GLOBAL_DEF("rendering/shadows/directional_shadow/soft_shadow_quality.mobile", 0);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/directional_shadow/soft_shadow_quality", PropertyInfo(Variant::INT, "rendering/shadows/directional_shadow/soft_shadow_quality", PROPERTY_HINT_ENUM, "Hard (Fastest),Soft Very Low (Faster),Soft Low (Fast),Soft Medium (Average),Soft High (Slow),Soft Ultra (Slowest)"));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/directional_shadow/soft_shadow_quality", PropertyInfo(Variant::INT, "rendering/shadows/directional_shadow/soft_shadow_quality", PROPERTY_HINT_ENUM, "Hard (Fastest),Soft Low (Faster),Soft Medium (Fast),Soft High (Average),Soft Very High (Slow),Soft Ultra (Slowest)"));
 	GLOBAL_DEF("rendering/shadows/directional_shadow/16_bits", true);
 
 	GLOBAL_DEF("rendering/shadows/shadows/soft_shadow_quality", 2);
 	GLOBAL_DEF("rendering/shadows/shadows/soft_shadow_quality.mobile", 0);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadows/soft_shadow_quality", PropertyInfo(Variant::INT, "rendering/shadows/shadows/soft_shadow_quality", PROPERTY_HINT_ENUM, "Hard (Fastest),Soft Very Low (Faster),Soft Low (Fast),Soft Medium (Average),Soft High (Slow),Soft Ultra (Slowest)"));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadows/soft_shadow_quality", PropertyInfo(Variant::INT, "rendering/shadows/shadows/soft_shadow_quality", PROPERTY_HINT_ENUM, "Hard (Fastest),Soft Low (Faster),Soft Medium (Fast),Soft High (Average),Soft Very High (Slow),Soft Ultra (Slowest)"));
 
 	GLOBAL_DEF("rendering/2d/shadow_atlas/size", 2048);
 
@@ -2873,7 +2873,7 @@ RenderingServer::RenderingServer() {
 	GLOBAL_DEF("rendering/global_illumination/gi/use_half_resolution", false);
 
 	GLOBAL_DEF("rendering/global_illumination/voxel_gi/quality", 0);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/global_illumination/voxel_gi/quality", PropertyInfo(Variant::INT, "rendering/global_illumination/voxel_gi/quality", PROPERTY_HINT_ENUM, "Low (4 Cones - Fast),High (6 Cones - Slow)"));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/global_illumination/voxel_gi/quality", PropertyInfo(Variant::INT, "rendering/global_illumination/voxel_gi/quality", PROPERTY_HINT_ENUM, "Medium (4 Cones - Fast),High (6 Cones - Slow)"));
 
 	GLOBAL_DEF("rendering/shading/overrides/force_vertex_shading", false);
 	GLOBAL_DEF("rendering/shading/overrides/force_vertex_shading.mobile", true);
@@ -2891,11 +2891,11 @@ RenderingServer::RenderingServer() {
 	GLOBAL_DEF("rendering/camera/depth_of_field/depth_of_field_bokeh_shape", 1);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/camera/depth_of_field/depth_of_field_bokeh_shape", PropertyInfo(Variant::INT, "rendering/camera/depth_of_field/depth_of_field_bokeh_shape", PROPERTY_HINT_ENUM, "Box (Fast),Hexagon (Average),Circle (Slowest)"));
 	GLOBAL_DEF("rendering/camera/depth_of_field/depth_of_field_bokeh_quality", 1);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/camera/depth_of_field/depth_of_field_bokeh_quality", PropertyInfo(Variant::INT, "rendering/camera/depth_of_field/depth_of_field_bokeh_quality", PROPERTY_HINT_ENUM, "Very Low (Fastest),Low (Fast),Medium (Average),High (Slow)"));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/camera/depth_of_field/depth_of_field_bokeh_quality", PropertyInfo(Variant::INT, "rendering/camera/depth_of_field/depth_of_field_bokeh_quality", PROPERTY_HINT_ENUM, "Low (Fastest),Medium (Fast),High (Average),Ultra (Slow)"));
 	GLOBAL_DEF("rendering/camera/depth_of_field/depth_of_field_use_jitter", false);
 
 	GLOBAL_DEF("rendering/environment/ssao/quality", 2);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/ssao/quality", PropertyInfo(Variant::INT, "rendering/environment/ssao/quality", PROPERTY_HINT_ENUM, "Very Low (Fast),Low (Fast),Medium (Average),High (Slow),Ultra (Custom)"));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/ssao/quality", PropertyInfo(Variant::INT, "rendering/environment/ssao/quality", PROPERTY_HINT_ENUM, "Very Low (Fastest),Low (Fast),Medium (Average),High (Slow),Ultra (Custom)"));
 	GLOBAL_DEF("rendering/environment/ssao/half_size", false);
 	GLOBAL_DEF("rendering/environment/ssao/half_size.mobile", true);
 	GLOBAL_DEF("rendering/environment/ssao/adaptive_target", 0.5);
@@ -2963,10 +2963,10 @@ RenderingServer::RenderingServer() {
 	GLOBAL_DEF("rendering/environment/glow/use_high_quality", false);
 
 	GLOBAL_DEF("rendering/environment/screen_space_reflection/roughness_quality", 1);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/screen_space_reflection/roughness_quality", PropertyInfo(Variant::INT, "rendering/environment/screen_space_reflection/roughness_quality", PROPERTY_HINT_ENUM, "Disabled (Fastest),Low (Fast),Medium (Average),High (Slow)"));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/screen_space_reflection/roughness_quality", PropertyInfo(Variant::INT, "rendering/environment/screen_space_reflection/roughness_quality", PROPERTY_HINT_ENUM, "Disabled (Fastest),Medium (Fast),High (Average),Ultra (Slow)"));
 
 	GLOBAL_DEF("rendering/environment/subsurface_scattering/subsurface_scattering_quality", 1);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/subsurface_scattering/subsurface_scattering_quality", PropertyInfo(Variant::INT, "rendering/environment/subsurface_scattering/subsurface_scattering_quality", PROPERTY_HINT_ENUM, "Disabled (Fastest),Low (Fast),Medium (Average),High (Slow)"));
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/subsurface_scattering/subsurface_scattering_quality", PropertyInfo(Variant::INT, "rendering/environment/subsurface_scattering/subsurface_scattering_quality", PROPERTY_HINT_ENUM, "Disabled (Fastest),Medium (Fast),High (Average),Ultra (Slow)"));
 	GLOBAL_DEF("rendering/environment/subsurface_scattering/subsurface_scattering_scale", 0.05);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/environment/subsurface_scattering/subsurface_scattering_scale", PropertyInfo(Variant::FLOAT, "rendering/environment/subsurface_scattering/subsurface_scattering_scale", PROPERTY_HINT_RANGE, "0.001,1,0.001"));
 	GLOBAL_DEF("rendering/environment/subsurface_scattering/subsurface_scattering_depth_scale", 0.01);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -477,10 +477,10 @@ public:
 
 	enum ShadowQuality {
 		SHADOW_QUALITY_HARD,
-		SHADOW_QUALITY_SOFT_VERY_LOW,
 		SHADOW_QUALITY_SOFT_LOW,
 		SHADOW_QUALITY_SOFT_MEDIUM,
 		SHADOW_QUALITY_SOFT_HIGH,
+		SHADOW_QUALITY_SOFT_VERY_HIGH,
 		SHADOW_QUALITY_SOFT_ULTRA,
 		SHADOW_QUALITY_MAX
 	};
@@ -1010,9 +1010,9 @@ public:
 
 	enum EnvironmentSSRRoughnessQuality {
 		ENV_SSR_ROUGNESS_QUALITY_DISABLED,
-		ENV_SSR_ROUGNESS_QUALITY_LOW,
 		ENV_SSR_ROUGNESS_QUALITY_MEDIUM,
 		ENV_SSR_ROUGNESS_QUALITY_HIGH,
+		ENV_SSR_ROUGNESS_QUALITY_ULTRA,
 	};
 
 	virtual void environment_set_ssr_roughness_quality(EnvironmentSSRRoughnessQuality p_quality) = 0;
@@ -1097,9 +1097,9 @@ public:
 
 	enum SubSurfaceScatteringQuality {
 		SUB_SURFACE_SCATTERING_QUALITY_DISABLED,
-		SUB_SURFACE_SCATTERING_QUALITY_LOW,
 		SUB_SURFACE_SCATTERING_QUALITY_MEDIUM,
 		SUB_SURFACE_SCATTERING_QUALITY_HIGH,
+		SUB_SURFACE_SCATTERING_QUALITY_ULTRA,
 	};
 
 	virtual void sub_surface_scattering_set_quality(SubSurfaceScatteringQuality p_quality) = 0;
@@ -1110,10 +1110,10 @@ public:
 	virtual RID camera_effects_create() = 0;
 
 	enum DOFBlurQuality {
-		DOF_BLUR_QUALITY_VERY_LOW,
 		DOF_BLUR_QUALITY_LOW,
 		DOF_BLUR_QUALITY_MEDIUM,
 		DOF_BLUR_QUALITY_HIGH,
+		DOF_BLUR_QUALITY_ULTRA,
 	};
 
 	virtual void camera_effects_set_dof_blur_quality(DOFBlurQuality p_quality, bool p_use_jitter) = 0;


### PR DESCRIPTION
Graphics settings which defaulted to Low were renamed to Medium, with other settings renamed accordingly.

This ensures all default settings are set to Medium, which makes graphics adjustments more intuitive.

**Note:** Not cherry-pickable to `3.x`.