### PR TITLE
[Windows] Fix Vulkan driver crash on sub-window minimization.

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -6652,6 +6652,10 @@ RenderingDevice::DrawListID RenderingDeviceVulkan::draw_list_begin_for_screen(Di
 
 	VkCommandBuffer command_buffer = frames[frame].draw_command_buffer;
 
+	if (!context->window_is_valid_swapchain(p_screen)) {
+		return INVALID_ID;
+	}
+
 	Size2i size = Size2i(context->window_get_width(p_screen), context->window_get_height(p_screen));
 
 	_draw_list_allocate(Rect2i(Vector2i(), size), 0, 0);

--- a/drivers/vulkan/vulkan_context.cpp
+++ b/drivers/vulkan/vulkan_context.cpp
@@ -1348,6 +1348,12 @@ int VulkanContext::window_get_height(DisplayServer::WindowID p_window) {
 	return windows[p_window].height;
 }
 
+bool VulkanContext::window_is_valid_swapchain(DisplayServer::WindowID p_window) {
+	ERR_FAIL_COND_V(!windows.has(p_window), false);
+	Window *w = &windows[p_window];
+	return w->swapchain_image_resources != VK_NULL_HANDLE;
+}
+
 VkRenderPass VulkanContext::window_get_render_pass(DisplayServer::WindowID p_window) {
 	ERR_FAIL_COND_V(!windows.has(p_window), VK_NULL_HANDLE);
 	Window *w = &windows[p_window];
@@ -1360,7 +1366,11 @@ VkFramebuffer VulkanContext::window_get_framebuffer(DisplayServer::WindowID p_wi
 	ERR_FAIL_COND_V(!buffers_prepared, VK_NULL_HANDLE);
 	Window *w = &windows[p_window];
 	//vulkan use of currentbuffer
-	return w->swapchain_image_resources[w->current_buffer].framebuffer;
+	if (w->swapchain_image_resources != VK_NULL_HANDLE) {
+		return w->swapchain_image_resources[w->current_buffer].framebuffer;
+	} else {
+		return VK_NULL_HANDLE;
+	}
 }
 
 void VulkanContext::window_destroy(DisplayServer::WindowID p_window_id) {

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -266,6 +266,7 @@ public:
 	void window_resize(DisplayServer::WindowID p_window_id, int p_width, int p_height);
 	int window_get_width(DisplayServer::WindowID p_window = 0);
 	int window_get_height(DisplayServer::WindowID p_window = 0);
+	bool window_is_valid_swapchain(DisplayServer::WindowID p_window = 0);
 	void window_destroy(DisplayServer::WindowID p_window_id);
 	VkFramebuffer window_get_framebuffer(DisplayServer::WindowID p_window = 0);
 	VkRenderPass window_get_render_pass(DisplayServer::WindowID p_window = 0);

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2778,13 +2778,14 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 					window.width = window_client_rect.size.width;
 					window.height = window_client_rect.size.height;
 
-#if defined(VULKAN_ENABLED)
-					if (context_vulkan && window_created) {
-						context_vulkan->window_resize(window_id, window.width, window.height);
-					}
-#endif
 					rect_changed = true;
 				}
+#if defined(VULKAN_ENABLED)
+				if (context_vulkan && window_created) {
+					// Note: Trigger resize event to update swapchains when window is minimized/restored, even if size is not changed.
+					context_vulkan->window_resize(window_id, window.width, window.height);
+				}
+#endif
 			}
 
 			if (!window.minimized && (!(window_pos_params->flags & SWP_NOMOVE) || window_pos_params->flags & SWP_FRAMECHANGED)) {

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -39,6 +39,9 @@ void RendererCompositorRD::prepare_for_blitting_render_targets() {
 
 void RendererCompositorRD::blit_render_targets_to_screen(DisplayServer::WindowID p_screen, const BlitToScreen *p_render_targets, int p_amount) {
 	RD::DrawListID draw_list = RD::get_singleton()->draw_list_begin_for_screen(p_screen);
+	if (draw_list == RD::INVALID_ID) {
+		return; // Window is minimized and does not have valid swapchain, skip drawing without printing errors.
+	}
 
 	for (int i = 0; i < p_amount; i++) {
 		RID texture = storage->render_target_get_texture(p_render_targets[i].render_target);


### PR DESCRIPTION
Seems like NVIDIA Vulkan drivers can't create swapchain for minimized sub-window and leave it in invalid state.

This PR:
- Triggers Vulkan context resize event when window is minimized / restored.
- Adds swapchain validity checks to some Vulkan device / context methods.

Fixes #51537, fixes #54308