### PR TITLE
Fix wording in `AnimationNode` classref

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -46,7 +46,7 @@
 		<method name="_has_filter" qualifiers="virtual const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] whether you want the blend tree editor to display filter editing on this node.
+				Returns whether you want the blend tree editor to display filter editing on this node.
 			</description>
 		</method>
 		<method name="_process" qualifiers="virtual const">
@@ -127,7 +127,7 @@
 			<return type="bool" />
 			<argument index="0" name="path" type="NodePath" />
 			<description>
-				Returns [code]true[/code] whether a given path is filtered.
+				Returns whether the given path is filtered.
 			</description>
 		</method>
 		<method name="remove_input">
@@ -150,7 +150,7 @@
 			<argument index="0" name="name" type="StringName" />
 			<argument index="1" name="value" type="Variant" />
 			<description>
-				Sets a custom parameter. These are used as local storage, because resources can be reused across the tree or scenes.
+				Sets a custom parameter. These are used as local memory, because resources can be reused across the tree or scenes.
 			</description>
 		</method>
 	</methods>
@@ -162,7 +162,7 @@
 	<signals>
 		<signal name="removed_from_graph">
 			<description>
-				Called when the node was removed from the graph.
+				Emitted when the node was removed from the graph.
 			</description>
 		</signal>
 		<signal name="tree_changed">


### PR DESCRIPTION
* `Returns [code]true[/code] whether you ...`
* Only `set_parameter` describe the parameters as "local storage", it's referred to as "local memory" in other places.
* Use "emitted when ..." for signals instead of "called when ..."