### PR TITLE
Return a correctly typed variant in case of function error

### DIFF
--- a/modules/gdscript/gdscript_function.h
+++ b/modules/gdscript/gdscript_function.h
@@ -502,6 +502,8 @@ private:
 
 	List<StackDebug> stack_debug;
 
+	Variant _get_default_variant_for_data_type(const GDScriptDataType &p_data_type);
+
 	_FORCE_INLINE_ Variant *_get_variant(int p_address, GDScriptInstance *p_instance, Variant *p_stack, String &r_error) const;
 	_FORCE_INLINE_ String _get_call_error(const Callable::CallError &p_err, const String &p_where, const Variant **argptrs) const;
 


### PR DESCRIPTION
Adds a function to the GDScript VM to return a valid default Variant type based on the function definitions return_type in case of an error. This should prevent rare instances where the result of an explicitly typed array is passed into another function unchecked via something like OPCODE_CALL_BUILTIN_TYPE_VALIDATED and can subsequently causes a crash.
Closes #57585