### PR TITLE
Connect text_submitted of built-in script name

### DIFF
--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -1038,6 +1038,7 @@ ScriptCreateDialog::ScriptCreateDialog() {
 
 	internal_name = memnew(LineEdit);
 	internal_name->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	internal_name->connect("text_submitted", callable_mp(this, &ScriptCreateDialog::_path_submitted));
 	label = memnew(Label(TTR("Name:")));
 	gc->add_child(label);
 	gc->add_child(internal_name);


### PR DESCRIPTION
This PR connects the `text_submitted` signal from the LineEdit that allows changing built-in script name, so you can accept script creation using Enter (it already works like that with path).