### PR TITLE
Fix using typed arrays based on script classes

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -132,11 +132,13 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 					result.kind = GDScriptDataType::GDSCRIPT;
 					result.script_type = script.ptr();
 					result.native_type = script->get_instance_base_type();
+					result.builtin_type = p_datatype.builtin_type;
 				} else {
 					result.kind = GDScriptDataType::GDSCRIPT;
 					result.script_type_ref = GDScriptCache::get_shallow_script(p_datatype.script_path, main_script->path);
 					result.script_type = result.script_type_ref.ptr();
 					result.native_type = p_datatype.native_type;
+					result.builtin_type = p_datatype.builtin_type;
 				}
 			}
 		} break;


### PR DESCRIPTION
Assigning the builtin type should fix issues when creating typed arrays for custom script classes.

Closes #58203