### PR TITLE
[3.x] Improved region-select in the 3D editor viewport

### DIFF
--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -327,6 +327,7 @@ private:
 	Vector<_RayResult> selection_results;
 	bool clicked_includes_current;
 	bool clicked_wants_append;
+	bool selection_in_progress = false;
 
 	PopupMenu *selection_menu;
 


### PR DESCRIPTION
Enable region-select when dragging the mouse. Previously this was only possible when the mouse was not over a mesh. 

- This is a backport of https://github.com/godotengine/godot/pull/57847
- Also includes this fix: #57919

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
