### PR TITLE
Only store `_edit_use_anchors_` metadata if value is not the default (3.x)

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4529,9 +4529,13 @@ void CanvasItemEditor::_set_anchors_and_margins_to_keep_ratio() {
 			undo_redo->add_do_method(control, "set_anchor", MARGIN_BOTTOM, bottom_right_anchor.y, false, true);
 			undo_redo->add_do_method(control, "set_meta", "_edit_use_anchors_", true);
 
-			bool use_anchors = control->has_meta("_edit_use_anchors_") && control->get_meta("_edit_use_anchors_");
+			const bool use_anchors = control->has_meta("_edit_use_anchors_") && control->get_meta("_edit_use_anchors_");
 			undo_redo->add_undo_method(control, "_edit_set_state", control->_edit_get_state());
-			undo_redo->add_undo_method(control, "set_meta", "_edit_use_anchors_", use_anchors);
+			if (use_anchors) {
+				undo_redo->add_undo_method(control, "set_meta", "_edit_use_anchors_", true);
+			} else {
+				undo_redo->add_undo_method(control, "remove_meta", "_edit_use_anchors_");
+			}
 
 			anchors_mode = true;
 			anchor_mode_button->set_pressed(anchors_mode);
@@ -4803,7 +4807,11 @@ void CanvasItemEditor::_button_toggle_anchor_mode(bool p_status) {
 			continue;
 		}
 
-		control->set_meta("_edit_use_anchors_", p_status);
+		if (p_status) {
+			control->set_meta("_edit_use_anchors_", true);
+		} else {
+			control->remove_meta("_edit_use_anchors_");
+		}
 	}
 
 	anchors_mode = p_status;


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/57863.

The default value is assumed to be `false`, so this metadata only needs to be stored if the value is `true`.

*Bugsquad edit (keywords for easier searching): edit_use_anchors*