### PR TITLE
Make `--doctool` imply `--headless` to speed up class reference generation

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -974,6 +974,11 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 		} else if (I->get() == "--doctool") {
 			// Actually handling is done in start().
 			cmdline_tool = true;
+
+			// `--doctool` implies `--headless` to avoid spawning an unnecessary window
+			// and speed up class reference generation.
+			audio_driver = "Dummy";
+			display_driver = "headless";
 			main_args.push_back(I->get());
 #endif
 		} else if (I->get() == "--path") { // set path of project to start or edit


### PR DESCRIPTION
This also prevents spawning an unnecessary splash screen window while the class reference is generated.

## Benchmark

*Godot binary is located on a SATA SSD.*

**OS:** Fedora 34
**CPU:** Intel Core i7-6700K
**SCons options:** `target=debug use_llvm=yes use_lld=yes`

I've also tried using the Dummy audio driver only (without headless mode), but it does not speed up the class reference generation.

```
❯ hyperfine -w1 "bin/godot.linuxbsd.tools.64.llvm --doctool" "bin/godot.linuxbsd.tools.64.llvm --doctool --audio-driver Dummy" "bin/godot.linuxbsd.tools.64.llvm --doctool --headless"
Benchmark #1: bin/godot.linuxbsd.tools.64.llvm --doctool
  Time (mean ± σ):      3.415 s ±  0.338 s    [User: 2.320 s, System: 0.177 s]
  Range (min … max):    2.455 s …  3.551 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Benchmark #2: bin/godot.linuxbsd.tools.64.llvm --doctool --audio-driver Dummy
  Time (mean ± σ):      3.519 s ±  0.029 s    [User: 2.303 s, System: 0.170 s]
  Range (min … max):    3.468 s …  3.562 s    10 runs

Benchmark #3: bin/godot.linuxbsd.tools.64.llvm --doctool --headless
  Time (mean ± σ):      2.117 s ±  0.030 s    [User: 2.010 s, System: 0.068 s]
  Range (min … max):    2.093 s …  2.164 s    10 runs

  Warning: Statistical outliers were detected. Consider re-running this benchmark on a quiet PC without any interferences from other programs. It might help to use the '--warmup' or '--prepare' options.

Summary
  'bin/godot.linuxbsd.tools.64.llvm --doctool --headless' ran
    1.61 ± 0.16 times faster than 'bin/godot.linuxbsd.tools.64.llvm --doctool'
    1.66 ± 0.03 times faster than 'bin/godot.linuxbsd.tools.64.llvm --doctool --audio-driver Dummy'
```