### PR TITLE
Updated out of date CharacterBody documentation.

### DIFF
--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -132,7 +132,6 @@
 			<return type="bool" />
 			<description>
 				Moves the body based on [member motion_velocity]. If the body collides with another, it will slide along the other body (by default only on floor) rather than stop immediately. If the other body is a [CharacterBody2D] or [RigidDynamicBody2D], it will also be affected by the motion of the other body. You can use this to make moving and rotating platforms, or to make nodes push other nodes.
-				This method should be used in [method Node._physics_process] (or in a method called by [method Node._physics_process]), as it uses the physics step's [code]delta[/code] value automatically in calculations. Otherwise, the simulation will run at an incorrect speed.
 				Modifies [member motion_velocity] if a slide collision occurred. To get the latest collision call [method get_last_slide_collision], for detailed information about collisions that occurred, use [method get_slide_collision].
 				When the body touches a moving platform, the platform's velocity is automatically added to the body motion. If a collision occurs due to the platform's motion, it will always be first in the slide collisions.
 				The general behavior and available properties change according to the [member motion_mode].

--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -118,7 +118,6 @@
 			<return type="bool" />
 			<description>
 				Moves the body based on [member motion_velocity]. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [CharacterBody3D] or [RigidDynamicBody3D], it will also be affected by the motion of the other body. You can use this to make moving and rotating platforms, or to make nodes push other nodes.
-				This method should be used in [method Node._physics_process] (or in a method called by [method Node._physics_process]), as it uses the physics step's [code]delta[/code] value automatically in calculations. Otherwise, the simulation will run at an incorrect speed.
 				Modifies [member motion_velocity] if a slide collision occurred. To get the latest collision call [method get_last_slide_collision], for more detailed information about collisions that occurred, use [method get_slide_collision].
 				When the body touches a moving platform, the platform's velocity is automatically added to the body motion. If a collision occurs due to the platform's motion, it will always be first in the slide collisions.
 				Returns [code]true[/code] if the body collided, otherwise, returns [code]false[/code].


### PR DESCRIPTION
CharacterBody documentation incorrectly stated that calling `move_and_slide` from `_process` would cause the simulation to run at an incorrect speed.

As evidenced by [physics_body_3d.cpp](https://github.com/godotengine/godot/blob/master/scene/3d/physics_body_3d.cpp#L1168) and [physics_body_2d.cpp](https://github.com/godotengine/godot/blob/master/scene/2d/physics_body_2d.cpp#L1105), this is no longer the case.

It is important that this warning is removed as calling `move_and_slide` from `_physics_process` can result in visibly jerky movement when running on high refresh rate displays. A developer may wish to switch player movement to `_process` to allow for smooth control without having to pay the cost of a higher physics tick rate but would be warned away from this change by the docs.