### PR TITLE
Revert default to update mode realtime

### DIFF
--- a/doc/classes/Sky.xml
+++ b/doc/classes/Sky.xml
@@ -9,7 +9,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="process_mode" type="int" setter="set_process_mode" getter="get_process_mode" enum="Sky.ProcessMode" default="3">
+		<member name="process_mode" type="int" setter="set_process_mode" getter="get_process_mode" enum="Sky.ProcessMode" default="0">
 			Sets the method for generating the radiance map from the sky. The radiance map is a cubemap with increasingly blurry versions of the sky corresponding to different levels of roughness. Radiance maps can be expensive to calculate. See [enum ProcessMode] for options.
 		</member>
 		<member name="radiance_size" type="int" setter="set_radiance_size" getter="get_radiance_size" enum="Sky.RadianceSize" default="3">

--- a/scene/resources/sky.cpp
+++ b/scene/resources/sky.cpp
@@ -83,7 +83,7 @@ void Sky::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_material"), &Sky::get_material);
 
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "sky_material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial,PanoramaSkyMaterial,ProceduralSkyMaterial,PhysicalSkyMaterial"), "set_material", "get_material");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_mode", PROPERTY_HINT_ENUM, "Automatic,High Quality (Slow),High Quality Incremental (Average),Real-Time (Fast)"), "set_process_mode", "get_process_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_mode", PROPERTY_HINT_ENUM, "Automatic,HighQuality,HighQualityIncremental,RealTime"), "set_process_mode", "get_process_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "radiance_size", PROPERTY_HINT_ENUM, "32,64,128,256,512,1024,2048"), "set_radiance_size", "get_radiance_size");
 
 	BIND_ENUM_CONSTANT(RADIANCE_SIZE_32);

--- a/scene/resources/sky.h
+++ b/scene/resources/sky.h
@@ -59,7 +59,7 @@ public:
 
 private:
 	RID sky;
-	ProcessMode mode = PROCESS_MODE_REALTIME;
+	ProcessMode mode = PROCESS_MODE_AUTOMATIC;
 	RadianceSize radiance_size = RADIANCE_SIZE_256;
 	Ref<Material> sky_material;
 

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.h
@@ -254,7 +254,7 @@ public:
 
 		int radiance_size = 256;
 
-		RS::SkyMode mode = RS::SKY_MODE_REALTIME;
+		RS::SkyMode mode = RS::SKY_MODE_AUTOMATIC;
 
 		ReflectionData reflection;
 		bool dirty = false;


### PR DESCRIPTION
Reverts: https://github.com/godotengine/godot/pull/57931 and https://github.com/godotengine/godot/pull/58165
Fixes: https://github.com/godotengine/godot/issues/53969

Now that https://github.com/godotengine/godot/pull/58177 is merged, the High Quality Incremental mode is by far the fastest of the three options, so the Automatic mode makes sense again. 

On my hardware high quality takes 1.5 ms, real time takes 1 ms, and high quality incremental takes 0.2 ms. 