### PR TITLE
[3.x] Fix typo in CanvasItem visibility propagation backport

### DIFF
--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -371,7 +371,7 @@ void CanvasItem::_propagate_visibility_changed(bool p_visible, bool p_was_visibl
 		CanvasItem *c = Object::cast_to<CanvasItem>(get_child(i));
 
 		if (c && c->visible) { //should the toplevels stop propagation? i think so but..
-			c->_propagate_visibility_changed(p_visible, !p_visible);
+			c->_propagate_visibility_changed(p_visible);
 		}
 	}
 


### PR DESCRIPTION
Copy-paste error found when inspecting #58251 (but this is not the cause of that issue).