### PR TITLE
[Linux/X11] Fallback to the X server root window to get screen rects, if Xinerama is not available.

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -661,17 +661,17 @@ void DisplayServerX11::_clipboard_transfer_ownership(Atom p_source, Window x11_w
 
 int DisplayServerX11::get_screen_count() const {
 	_THREAD_SAFE_METHOD_
+	int count = 0;
 
 	// Using Xinerama Extension
 	int event_base, error_base;
-	const Bool ext_okay = XineramaQueryExtension(x11_display, &event_base, &error_base);
-	if (!ext_okay) {
-		return 0;
+	if (XineramaQueryExtension(x11_display, &event_base, &error_base)) {
+		XineramaScreenInfo *xsi = XineramaQueryScreens(x11_display, &count);
+		XFree(xsi);
+	} else {
+		count = XScreenCount(x11_display);
 	}
 
-	int count;
-	XineramaScreenInfo *xsi = XineramaQueryScreens(x11_display, &count);
-	XFree(xsi);
 	return count;
 }
 
@@ -702,6 +702,19 @@ Rect2i DisplayServerX11::_screen_get_rect(int p_screen) const {
 
 		if (xsi) {
 			XFree(xsi);
+		}
+	} else {
+		int count = XScreenCount(x11_display);
+		if (p_screen < count) {
+			Window root = XRootWindow(x11_display, p_screen);
+			XWindowAttributes xwa;
+			XGetWindowAttributes(x11_display, root, &xwa);
+			rect.position.x = xwa.x;
+			rect.position.y = xwa.y;
+			rect.size.width = xwa.width;
+			rect.size.height = xwa.height;
+		} else {
+			ERR_PRINT("Invalid screen index: " + itos(p_screen) + "(count: " + itos(count) + ").");
 		}
 	}
 


### PR DESCRIPTION
Instead of returning invalid `0,0,0,0` rect, use X server root window rect.

Might fix #58178, but adding extra check for screen rect validity, probably also a good idea - see #58259 comments.