### PR TITLE
Keep 'is_attribute' false during parse error to prevent crash

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2692,12 +2692,13 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_attribute(ExpressionNode *
 		}
 	}
 
-	attribute->is_attribute = true;
 	attribute->base = p_previous_operand;
 
 	if (!consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected identifier after "." for attribute access.)")) {
 		return attribute;
 	}
+
+	attribute->is_attribute = true;
 	attribute->attribute = parse_identifier();
 
 	return attribute;


### PR DESCRIPTION
By only marking is_attribute as true if the consume function succeeded, it prevents a nullptr crash on the attribute field in _guess_expression_type when typing code like:

```self.[a```

Closes #57414