### PR TITLE
Fix decompression functions not returning errcodes

### DIFF
--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -88,11 +88,11 @@ Error FileAccessCompressed::open_after_magic(FileAccess *p_base) {
 	read_block_count = bc;
 	read_block_size = read_blocks.size() == 1 ? read_total : block_size;
 
-	Compression::decompress(buffer.ptrw(), read_block_size, comp_buffer.ptr(), read_blocks[0].csize, cmode);
+	int ret = Compression::decompress(buffer.ptrw(), read_block_size, comp_buffer.ptr(), read_blocks[0].csize, cmode);
 	read_block = 0;
 	read_pos = 0;
 
-	return OK;
+	return ret == -1 ? ERR_FILE_CORRUPT : OK;
 }
 
 Error FileAccessCompressed::_open(const String &p_path, int p_mode_flags) {
@@ -125,10 +125,11 @@ Error FileAccessCompressed::_open(const String &p_path, int p_mode_flags) {
 		char rmagic[5];
 		f->get_buffer((uint8_t *)rmagic, 4);
 		rmagic[4] = 0;
-		if (magic != rmagic || open_after_magic(f) != OK) {
+		err = ERR_FILE_UNRECOGNIZED;
+		if (magic != rmagic || (err = open_after_magic(f)) != OK) {
 			memdelete(f);
 			f = nullptr;
-			return ERR_FILE_UNRECOGNIZED;
+			return err;
 		}
 	}
 
@@ -210,7 +211,8 @@ void FileAccessCompressed::seek(uint64_t p_position) {
 				read_block = block_idx;
 				f->seek(read_blocks[read_block].offset);
 				f->get_buffer(comp_buffer.ptrw(), read_blocks[read_block].csize);
-				Compression::decompress(buffer.ptrw(), read_blocks.size() == 1 ? read_total : block_size, comp_buffer.ptr(), read_blocks[read_block].csize, cmode);
+				int ret = Compression::decompress(buffer.ptrw(), read_blocks.size() == 1 ? read_total : block_size, comp_buffer.ptr(), read_blocks[read_block].csize, cmode);
+				ERR_FAIL_COND_MSG(ret == -1, "Compressed file is corrupt.");
 				read_block_size = read_block == read_block_count - 1 ? read_total % block_size : block_size;
 			}
 
@@ -273,7 +275,8 @@ uint8_t FileAccessCompressed::get_8() const {
 		if (read_block < read_block_count) {
 			//read another block of compressed data
 			f->get_buffer(comp_buffer.ptrw(), read_blocks[read_block].csize);
-			Compression::decompress(buffer.ptrw(), read_blocks.size() == 1 ? read_total : block_size, comp_buffer.ptr(), read_blocks[read_block].csize, cmode);
+			int total = Compression::decompress(buffer.ptrw(), read_blocks.size() == 1 ? read_total : block_size, comp_buffer.ptr(), read_blocks[read_block].csize, cmode);
+			ERR_FAIL_COND_V_MSG(total == -1, 0, "Compressed file is corrupt.");
 			read_block_size = read_block == read_block_count - 1 ? read_total % block_size : block_size;
 			read_pos = 0;
 
@@ -305,7 +308,8 @@ uint64_t FileAccessCompressed::get_buffer(uint8_t *p_dst, uint64_t p_length) con
 			if (read_block < read_block_count) {
 				//read another block of compressed data
 				f->get_buffer(comp_buffer.ptrw(), read_blocks[read_block].csize);
-				Compression::decompress(buffer.ptrw(), read_blocks.size() == 1 ? read_total : block_size, comp_buffer.ptr(), read_blocks[read_block].csize, cmode);
+				int ret = Compression::decompress(buffer.ptrw(), read_blocks.size() == 1 ? read_total : block_size, comp_buffer.ptr(), read_blocks[read_block].csize, cmode);
+				ERR_FAIL_COND_V_MSG(ret == -1, -1, "Compressed file is corrupt.");
 				read_block_size = read_block == read_block_count - 1 ? read_total % block_size : block_size;
 				read_pos = 0;
 

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -1468,7 +1468,8 @@ Error DocTools::save_classes(const String &p_default_path, const Map<String, Str
 Error DocTools::load_compressed(const uint8_t *p_data, int p_compressed_size, int p_uncompressed_size) {
 	Vector<uint8_t> data;
 	data.resize(p_uncompressed_size);
-	Compression::decompress(data.ptrw(), p_uncompressed_size, p_data, p_compressed_size, Compression::MODE_DEFLATE);
+	int ret = Compression::decompress(data.ptrw(), p_uncompressed_size, p_data, p_compressed_size, Compression::MODE_DEFLATE);
+	ERR_FAIL_COND_V_MSG(ret == -1, ERR_FILE_CORRUPT, "Compressed file is corrupt.");
 	class_list.clear();
 
 	Ref<XMLParser> parser = memnew(XMLParser);

--- a/editor/editor_translation.cpp
+++ b/editor/editor_translation.cpp
@@ -56,7 +56,8 @@ void load_editor_translations(const String &p_locale) {
 		if (etl->lang == p_locale) {
 			Vector<uint8_t> data;
 			data.resize(etl->uncomp_size);
-			Compression::decompress(data.ptrw(), etl->uncomp_size, etl->data, etl->comp_size, Compression::MODE_DEFLATE);
+			int ret = Compression::decompress(data.ptrw(), etl->uncomp_size, etl->data, etl->comp_size, Compression::MODE_DEFLATE);
+			ERR_FAIL_COND_MSG(ret == -1, "Compressed file is corrupt.");
 
 			FileAccessMemory *fa = memnew(FileAccessMemory);
 			fa->open_custom(data.ptr(), data.size());
@@ -80,7 +81,8 @@ void load_doc_translations(const String &p_locale) {
 		if (dtl->lang == p_locale) {
 			Vector<uint8_t> data;
 			data.resize(dtl->uncomp_size);
-			Compression::decompress(data.ptrw(), dtl->uncomp_size, dtl->data, dtl->comp_size, Compression::MODE_DEFLATE);
+			int ret = Compression::decompress(data.ptrw(), dtl->uncomp_size, dtl->data, dtl->comp_size, Compression::MODE_DEFLATE);
+			ERR_FAIL_COND_MSG(ret == -1, "Compressed file is corrupt.");
 
 			FileAccessMemory *fa = memnew(FileAccessMemory);
 			fa->open_custom(data.ptr(), data.size());


### PR DESCRIPTION
`Compression::decompress` returns -1 on error scenarios. This was not being propagated to let the user know there was an error while reading compressed files.

Fixes https://github.com/godotengine/godot/issues/57049
