### PR TITLE
[3.x] Fix `CanvasItem` visibility propagation

### DIFF
--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -210,7 +210,7 @@ private:
 
 	void _toplevel_raise_self();
 
-	void _propagate_visibility_changed(bool p_visible, bool p_was_visible = false);
+	void _propagate_visibility_changed(bool p_visible, bool p_is_source = false);
 
 	void _update_callback();
 


### PR DESCRIPTION
Fixes #58251

I believe the logic is also wrong on `master`, see https://github.com/godotengine/godot/issues/58251#issuecomment-1044352456. But I'm not sure if a similar fix would cancel the optimization of #57684 on `master`. Since the issue is currently only reproducible on `3.x`, this PR only targets `3.x`.

---

The name of `p_was_visible` parameter is no accurate. It's only "was visible" if the node is the source of the propagation. It's always `false` for other nodes in the propagation chain, making the name awkward. The only place that passes the parameter is `set_visible()`:

https://github.com/godotengine/godot/blob/7384475493711d622e98691469b0c4ea801118a3/scene/2d/canvas_item.cpp#L393

When used, it only makes sense if it's `true`:

https://github.com/godotengine/godot/blob/7384475493711d622e98691469b0c4ea801118a3/scene/2d/canvas_item.cpp#L365-L367

So I changed it to `p_is_source` so it's easier to understand. The above code will emit the signal when it's propagating "hide" and if the current node is visible or the current node is the source of propagation.

---

The actual cause of the issue is line 360:

https://github.com/godotengine/godot/blob/7384475493711d622e98691469b0c4ea801118a3/scene/2d/canvas_item.cpp#L356-L361

1. When toggling visibility of a `CanvasItem`, this syncs `parent_is_visible_in_tree` with it. This should only happen for other  nodes in the propagation chain, not for the node itself.
2. For other nodes in the propagation chain, `p_visible` is the `visible` of the propagation source, it does not have to be the same as its `is_visible_in_tree()`. So a proper check like in `NOTIFICATION_ENTER_TREE` should be done.