### PR TITLE
Fix to prevent AcceptDialog and children class taking over main window

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -436,10 +436,10 @@ void Window::set_visible(bool p_visible) {
 		if (exclusive && visible) {
 #ifdef TOOLS_ENABLED
 			if (!(Engine::get_singleton()->is_editor_hint() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->is_ancestor_of(this))) {
-#endif
 				ERR_FAIL_COND_MSG(transient_parent->exclusive_child && transient_parent->exclusive_child != this, "Transient parent has another exclusive child.");
 				transient_parent->exclusive_child = this;
 			}
+#endif
 		} else {
 			if (transient_parent->exclusive_child == this) {
 				transient_parent->exclusive_child = nullptr;

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -434,8 +434,12 @@ void Window::set_visible(bool p_visible) {
 	//update transient exclusive
 	if (transient_parent) {
 		if (exclusive && visible) {
-			ERR_FAIL_COND_MSG(transient_parent->exclusive_child && transient_parent->exclusive_child != this, "Transient parent has another exclusive child.");
-			transient_parent->exclusive_child = this;
+#ifdef TOOLS_ENABLED
+			if (!(Engine::get_singleton()->is_editor_hint() && get_tree()->get_edited_scene_root() && get_tree()->get_edited_scene_root()->is_ancestor_of(this))) {
+#endif
+				ERR_FAIL_COND_MSG(transient_parent->exclusive_child && transient_parent->exclusive_child != this, "Transient parent has another exclusive child.");
+				transient_parent->exclusive_child = this;
+			}
 		} else {
 			if (transient_parent->exclusive_child == this) {
 				transient_parent->exclusive_child = nullptr;


### PR DESCRIPTION
Potential fix for #58229.  
`AcceptDialog` and other windows with `set_exclusive(true)` take over main window when set visible in editor and makes it uninteractable.
Made behavior follow that of `Popup` (without `set_exclusive`) when in editor.  
Not sure if this is the desired behavior when editing but should remain the same outside of it.

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/51362.*