### PR TITLE
In final phase of test_body_motion, move and cull AABB for body once instead of for every shape

### DIFF
--- a/servers/physics_2d/godot_space_2d.cpp
+++ b/servers/physics_2d/godot_space_2d.cpp
@@ -888,6 +888,9 @@ bool GodotSpace2D::test_body_motion(GodotBody2D *p_body, const PhysicsServer2D::
 		// Allowed depth can't be lower than motion length, in order to handle contacts at low speed.
 		rcd.min_allowed_depth = MIN(motion_length, min_contact_depth);
 
+		body_aabb.position += p_parameters.motion * unsafe;
+		int amount = _cull_aabb_for_body(p_body, body_aabb);
+
 		int from_shape = best_shape != -1 ? best_shape : 0;
 		int to_shape = best_shape != -1 ? best_shape + 1 : p_body->get_shape_count();
 
@@ -898,10 +901,6 @@ bool GodotSpace2D::test_body_motion(GodotBody2D *p_body, const PhysicsServer2D::
 
 			Transform2D body_shape_xform = ugt * p_body->get_shape_transform(j);
 			GodotShape2D *body_shape = p_body->get_shape(j);
-
-			body_aabb.position += p_parameters.motion * unsafe;
-
-			int amount = _cull_aabb_for_body(p_body, body_aabb);
 
 			for (int i = 0; i < amount; i++) {
 				const GodotCollisionObject2D *col_obj = intersection_query_results[i];

--- a/servers/physics_3d/godot_space_3d.cpp
+++ b/servers/physics_3d/godot_space_3d.cpp
@@ -926,6 +926,9 @@ bool GodotSpace3D::test_body_motion(GodotBody3D *p_body, const PhysicsServer3D::
 		// Allowed depth can't be lower than motion length, in order to handle contacts at low speed.
 		rcd.min_allowed_depth = MIN(motion_length, min_contact_depth);
 
+		body_aabb.position += p_parameters.motion * unsafe;
+		int amount = _cull_aabb_for_body(p_body, body_aabb);
+
 		int from_shape = best_shape != -1 ? best_shape : 0;
 		int to_shape = best_shape != -1 ? best_shape + 1 : p_body->get_shape_count();
 
@@ -936,10 +939,6 @@ bool GodotSpace3D::test_body_motion(GodotBody3D *p_body, const PhysicsServer3D::
 
 			Transform3D body_shape_xform = ugt * p_body->get_shape_transform(j);
 			GodotShape3D *body_shape = p_body->get_shape(j);
-
-			body_aabb.position += p_parameters.motion * unsafe;
-
-			int amount = _cull_aabb_for_body(p_body, body_aabb);
 
 			for (int i = 0; i < amount; i++) {
 				const GodotCollisionObject3D *col_obj = intersection_query_results[i];


### PR DESCRIPTION
As briefly discussed on RocketChat, two lines (moving `body_aabb` and calling `_cull_aabb_for_body`) were moved into a loop over shapes in https://github.com/godotengine/godot/commit/66c6dfb3fd89d34ca9e35276113d3f105717e03d for 2D and (for consistency?) in https://github.com/godotengine/godot/pull/46148 for 3D. This PR moves those lines back to their original position, where they likely belong, as "repeatedly moving the AABB, once for each shape" does not seem to be logical.

There are no regressions when running the test projects from https://github.com/godotengine/godot/issues/16250, https://github.com/godotengine/godot/pull/35945#issuecomment-660652478, https://github.com/godotengine/godot/issues/45971, https://github.com/godotengine/godot/issues/45971#issuecomment-780217011, https://github.com/godotengine/godot/issues/46134 (after updating them to run under `master`). With more effort, more of the test projects linked in https://github.com/godotengine/godot/pull/46148 could be tested.