### PR TITLE
Set default box size to (2.0, 2.0, 2.0) on box collider when importing

### DIFF
--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -404,6 +404,8 @@ Vector<Ref<Shape3D>> ResourceImporterScene::get_collision_shapes(const Ref<Mesh>
 		box.instantiate();
 		if (p_options.has(SNAME("primitive/size"))) {
 			box->set_size(p_options[SNAME("primitive/size")]);
+		} else {
+			box->set_size(Vector3(2.0, 2.0, 2.0));
 		}
 
 		Vector<Ref<Shape3D>> shapes;


### PR DESCRIPTION
Makes sure to set the importer box collider size to (2.0, 2.0, 2.0) if no option is found, which fixes a bug where the box collider would actually come in at its internal default size, which is still (1.0, 1.0, 1.0)

Closes #58289