### PR TITLE
Make Decal distance fade smoother

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -3735,12 +3735,13 @@ void RendererSceneRenderRD::_setup_decals(const PagedArray<RID> &p_decals, const
 		float fade = 1.0;
 
 		if (texture_storage->decal_is_distance_fade_enabled(decal)) {
-			real_t distance = -p_camera_inverse_xform.xform(xform.origin).z;
-			float fade_begin = texture_storage->decal_get_distance_fade_begin(decal);
-			float fade_length = texture_storage->decal_get_distance_fade_length(decal);
+			const real_t distance = -p_camera_inverse_xform.xform(xform.origin).z;
+			const float fade_begin = texture_storage->decal_get_distance_fade_begin(decal);
+			const float fade_length = texture_storage->decal_get_distance_fade_length(decal);
 
 			if (distance > fade_begin) {
-				fade = 1.0 - (distance - fade_begin) / fade_length;
+				// Use `smoothstep()` to make opacity changes more gradual and less noticeable to the player.
+				fade = Math::smoothstep(0.0f, 1.0f, 1.0f - float(distance - fade_begin) / fade_length);
 			}
 		}
 


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/57535 and https://github.com/godotengine/godot/pull/58296 (can be merged independently).

`smoothstep()` avoids the sudden transparency jump when entering or leaving a decal's distance fade margin distance. This in turn helps make opacity transitions less noticeable to the player, as it's less likely to catch the player's eye.

**Testing project:** [test_decal_distance_fade.zip](https://github.com/godotengine/godot/files/8100654/test_decal_distance_fade.zip)

## Preview

*Left: Before, Right: After*

https://user-images.githubusercontent.com/180032/154766380-e13929cd-a9bf-438c-adf7-159c4efd19eb.mp4
