### PR TITLE
Fix crash in Create New Node dialog with certain user-created scripts

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -235,19 +235,19 @@ void CreateDialog::_add_type(const String &p_type, const TypeCategory p_type_cat
 		}
 	} else {
 		if (ScriptServer::is_global_class(p_type)) {
-			inherits = EditorNode::get_editor_data().script_class_get_base(p_type);
-			if (inherits.is_empty()) {
-				Ref<Script> script = EditorNode::get_editor_data().script_class_load_script(p_type);
-				ERR_FAIL_COND(script.is_null());
+			Ref<Script> script = EditorNode::get_editor_data().script_class_load_script(p_type);
+			ERR_FAIL_COND(script.is_null());
 
-				Ref<Script> base = script->get_base_script();
-				if (base.is_null()) {
-					String extends;
-					script->get_language()->get_global_class_name(script->get_path(), &extends);
+			Ref<Script> base = script->get_base_script();
+			if (base.is_null()) {
+				String extends;
+				script->get_language()->get_global_class_name(script->get_path(), &extends);
 
-					inherits = extends;
-					inherited_type = TypeCategory::CPP_TYPE;
-				} else {
+				inherits = extends;
+				inherited_type = TypeCategory::CPP_TYPE;
+			} else {
+				inherits = script->get_language()->get_global_class_name(base->get_path());
+				if (inherits.is_empty()) {
 					inherits = base->get_path();
 					inherited_type = TypeCategory::PATH_TYPE;
 				}


### PR DESCRIPTION
Fixes #57573

The condition at Line 239 should be inverted.

https://github.com/godotengine/godot/blob/c944c9e572e616c2f0eba1e392fd17ca030625ec/editor/create_dialog.cpp#L238-L239

The code inside that `if` block is basically the same as what `script_class_get_base()` does at Line 238, with additional `inherited_type` assignment for different cases.