### PR TITLE
Update variable name to reflect usage

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -497,16 +497,16 @@ void Viewport::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_VP_MOUSE_ENTER: {
-			gui.mouse_in_window = true;
+			gui.mouse_in_viewport = true;
 		} break;
 
 		case NOTIFICATION_VP_MOUSE_EXIT: {
-			gui.mouse_in_window = false;
+			gui.mouse_in_viewport = false;
 			_drop_physics_mouseover();
 			_drop_mouse_over();
-			// When the mouse exits the window, we want to end mouse_over, but
+			// When the mouse exits the viewport, we want to end mouse_over, but
 			// not mouse_focus, because, for example, we want to continue
-			// dragging a scrollbar even if the mouse has left the window.
+			// dragging a scrollbar even if the mouse has left the viewport.
 		} break;
 
 		case NOTIFICATION_WM_WINDOW_FOCUS_OUT: {
@@ -1683,7 +1683,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		Control *over = nullptr;
 		if (gui.mouse_focus) {
 			over = gui.mouse_focus;
-		} else if (gui.mouse_in_window) {
+		} else if (gui.mouse_in_viewport) {
 			over = gui_find_control(mpos);
 		}
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -335,7 +335,7 @@ private:
 		// info used when this is a window
 
 		bool forced_mouse_focus = false; //used for menu buttons
-		bool mouse_in_window = true;
+		bool mouse_in_viewport = true;
 		bool key_event_accepted = false;
 		Control *mouse_focus = nullptr;
 		Control *last_mouse_focus = nullptr;


### PR DESCRIPTION
Followup to #58042

Update variable name from `gui.mouse_in_window` to `gui.mouse_in_viewport`, to reflect it's usage.
This variable no longer indicates, if the mouse is over the window, but if the mouse is over the current viewport.