### PR TITLE
Fix Object not considered Object class in typed Array

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -98,6 +98,7 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 		case GDScriptParser::DataType::NATIVE: {
 			result.kind = GDScriptDataType::NATIVE;
 			result.native_type = p_datatype.native_type;
+			result.builtin_type = p_datatype.builtin_type;
 		} break;
 		case GDScriptParser::DataType::SCRIPT: {
 			result.kind = GDScriptDataType::SCRIPT;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/53771.

Basically the same as https://github.com/godotengine/godot/pull/58250 but for native `Object` based types.

Also fixes not being able to modify a typed array with a setter in a tool script using the inspector, as mentioned in https://github.com/godotengine/godot/issues/53771#issuecomment-1037732038. However, does _not_ fix the issue in https://github.com/godotengine/godot/issues/58285.

