### PR TITLE
Fix Godot crash when adding VisualScript Call node

### DIFF
--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -3535,7 +3535,7 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 		print_error("Category not handled: " + p_category.quote());
 	}
 
-	if (Object::cast_to<VisualScriptFunctionCall>(vnode.ptr()) && p_category != "Class") {
+	if (Object::cast_to<VisualScriptFunctionCall>(vnode.ptr()) && p_category != "Class" && p_category != "VisualScriptNode") {
 		Vector<String> property_path = p_text.split(":");
 		String class_of_method = property_path[0];
 		String method_name = property_path[1];


### PR DESCRIPTION
Fixes  #58036

Issue appears to be caused by the property text for the `Call` node. The property text for `Call` is `functions/call`, but this code expects something like `Node3d:call` https://github.com/godotengine/godot/blob/6a51999b7f4d9f7b1f950d7a655a464f28542318/modules/visual_script/editor/visual_script_editor.cpp#L3538-L3541. 

I'm pretty sure this code is irrelevant to VisualScriptNodes, as the legacy 3.x code used to return much earlier. 