### PR TITLE
Fix extension registration order.

### DIFF
--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -295,9 +295,10 @@ NativeExtension::InitializationLevel NativeExtension::get_minimum_library_initia
 	ERR_FAIL_COND_V(library == nullptr, INITIALIZATION_LEVEL_CORE);
 	return InitializationLevel(initialization.minimum_initialization_level);
 }
+
 void NativeExtension::initialize_library(InitializationLevel p_level) {
 	ERR_FAIL_COND(library == nullptr);
-	ERR_FAIL_COND(p_level <= int32_t(level_initialized));
+	ERR_FAIL_COND_MSG(p_level <= int32_t(level_initialized), vformat("Level '%d' must be higher than the current level '%d'", p_level, level_initialized));
 
 	level_initialized = int32_t(p_level);
 

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -108,6 +108,8 @@ extern void unregister_global_constants();
 
 static ResourceUID *resource_uid = nullptr;
 
+static bool _is_core_extensions_registered = false;
+
 void register_core_types() {
 	//consistency check
 	static_assert(sizeof(Callable) <= 16);
@@ -314,11 +316,16 @@ void register_core_extensions() {
 	NativeExtension::initialize_native_extensions();
 	native_extension_manager->load_extensions();
 	native_extension_manager->initialize_extensions(NativeExtension::INITIALIZATION_LEVEL_CORE);
+	_is_core_extensions_registered = true;
+}
+
+void unregister_core_extensions() {
+	if (_is_core_extensions_registered) {
+		native_extension_manager->deinitialize_extensions(NativeExtension::INITIALIZATION_LEVEL_CORE);
+	}
 }
 
 void unregister_core_types() {
-	native_extension_manager->deinitialize_extensions(NativeExtension::INITIALIZATION_LEVEL_CORE);
-
 	memdelete(native_extension_manager);
 
 	memdelete(resource_uid);

--- a/core/register_core_types.h
+++ b/core/register_core_types.h
@@ -36,5 +36,6 @@ void register_core_settings();
 void register_core_extensions();
 void register_core_singletons();
 void unregister_core_types();
+void unregister_core_extensions();
 
 #endif // REGISTER_CORE_TYPES_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -487,6 +487,7 @@ void Main::test_cleanup() {
 	}
 
 	unregister_core_driver_types();
+	unregister_core_extensions();
 	unregister_core_types();
 
 	OS::get_singleton()->finalize_core();
@@ -634,7 +635,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			continue;
 		}
 #endif
-
 		List<String>::Element *N = I->next();
 
 		if (I->get() == "-h" || I->get() == "--help" || I->get() == "/?") { // display help
@@ -1157,6 +1157,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	// Initialize user data dir.
 	OS::get_singleton()->ensure_user_data_dir();
 
+	register_core_extensions(); // core extensions must be registered after globals setup and before display
+
 	ResourceUID::get_singleton()->load_from_cache(); // load UUIDs from cache.
 
 	GLOBAL_DEF("memory/limits/multithreaded_server/rid_pool_prealloc", 60);
@@ -1272,7 +1274,6 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 	OS::get_singleton()->set_cmdline(execpath, main_args);
 
-	register_core_extensions(); //before display
 	// possibly be worth changing the default from vulkan to something lower spec,
 	// for the project manager, depending on how smooth the fallback is.
 	GLOBAL_DEF_RST("rendering/driver/driver_name", "vulkan");
@@ -1529,6 +1530,7 @@ error:
 	}
 
 	unregister_core_driver_types();
+	unregister_core_extensions();
 	unregister_core_types();
 
 	OS::get_singleton()->_cmdline.clear();
@@ -2888,6 +2890,7 @@ void Main::cleanup(bool p_force) {
 	memdelete(message_queue);
 
 	unregister_core_driver_types();
+	unregister_core_extensions();
 	unregister_core_types();
 
 	OS::get_singleton()->finalize_core();


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Fixes https://github.com/godotengine/godot/issues/50031. This is the second patch, the [first one](https://github.com/godotengine/godot/pull/58196/files) broke GDExtensions and had to be reverted.

I have tested this with the demo extension we have under `godot-cpp`.
