### PR TITLE
Fix SubViewportContainer processing Events before other Control-Nodes

### DIFF
--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -39,6 +39,8 @@ class SubViewportContainer : public Container {
 	bool stretch = false;
 	int shrink = 1;
 	void _notify_viewports(int p_notification);
+	bool _is_propagated_in_gui_input(const Ref<InputEvent> &p_event);
+	void _send_event_to_viewports(const Ref<InputEvent> &p_event);
 
 protected:
 	void _notification(int p_what);
@@ -49,6 +51,7 @@ public:
 	bool is_stretch_enabled() const;
 
 	virtual void input(const Ref<InputEvent> &p_event) override;
+	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual void unhandled_input(const Ref<InputEvent> &p_event) override;
 	void set_stretch_shrink(int p_shrink);
 	int get_stretch_shrink() const;


### PR DESCRIPTION
Currently, `SubViewportContainer` propagates all its events in `_input`
1 before all other `Control`-Nodes (fix #39666)
2 and where `rect_position` and `rect_size` of a `Control`-Node do not matter (fix #28833)

fix one of the reasons for #58902
alternative to #55300

MRP for all related Bugs: [SubViewportEventBugs.zip](https://github.com/godotengine/godot/files/10106285/SubViewportEventBugs.zip)

This patch changes `SubViewportContainer`, so that it propagates positional events (events that have a position property) no longer in `_input`, but in `_gui_input` to its `SubVieworts` via `push_input`.

### Event coordinates

Since `_input` and `_gui_input` expect different event-position-coordinate-systems, they now have to be adjusted only with the shrink factor in `_gui_input`.

## Changes to Events

Here is a description of how this patch affects events.

1. Events, that contain a `position`

The `position` of the event (like a mouse-click) specifies the `Control`-Node, they are intended for. Just like in master, these events get delivered to the `Control`-Node, that is located at the `position`. They are no longer delivered automatically to `SubViewports` of other `SubViewportContainer`, that are away from the position. The following graphic shows how event propagation of positional events (green line) changes.

![image](https://user-images.githubusercontent.com/6299227/156404182-91bc2cd0-e305-4a1c-940b-ab2e3b2b6d5b.png)


2. Events, that don't contain a `position`

Those events get sent to the same nodes in the same order as in the current master.

## Additional thoughts

- This bugfix solves problems in a different part of Event handling in comparison to #57894

Update 2022-09-29: Evaluate positional Events explicitely
Update 2022-10-02: Fix coordinate transform in _gui_input