### PR TITLE
Fixing iteration for extension level loading.

### DIFF
--- a/core/extension/native_extension_manager.cpp
+++ b/core/extension/native_extension_manager.cpp
@@ -40,12 +40,12 @@ NativeExtensionManager::LoadStatus NativeExtensionManager::load_extension(const 
 		return LOAD_STATUS_FAILED;
 	}
 
-	if (level >= 0) { //already initialized up to some level
+	if (level >= 0) { // Already initialized up to some level.
 		int32_t minimum_level = extension->get_minimum_library_initialization_level();
 		if (minimum_level < MIN(level, NativeExtension::INITIALIZATION_LEVEL_SCENE)) {
 			return LOAD_STATUS_NEEDS_RESTART;
 		}
-		//initialize up to current level
+		// Initialize up to current level.
 		for (int32_t i = minimum_level; i <= level; i++) {
 			extension->initialize_library(NativeExtension::InitializationLevel(i));
 		}
@@ -64,12 +64,12 @@ NativeExtensionManager::LoadStatus NativeExtensionManager::unload_extension(cons
 
 	Ref<NativeExtension> extension = native_extension_map[p_path];
 
-	if (level >= 0) { //already initialized up to some level
+	if (level >= 0) { // Already initialized up to some level.
 		int32_t minimum_level = extension->get_minimum_library_initialization_level();
 		if (minimum_level < MIN(level, NativeExtension::INITIALIZATION_LEVEL_SCENE)) {
 			return LOAD_STATUS_NEEDS_RESTART;
 		}
-		// deinitialize down to current level
+		// Deinitialize down to current level.
 		for (int32_t i = level; i >= minimum_level; i--) {
 			extension->deinitialize_library(NativeExtension::InitializationLevel(i));
 		}

--- a/core/extension/native_extension_manager.cpp
+++ b/core/extension/native_extension_manager.cpp
@@ -46,8 +46,8 @@ NativeExtensionManager::LoadStatus NativeExtensionManager::load_extension(const 
 			return LOAD_STATUS_NEEDS_RESTART;
 		}
 		//initialize up to current level
-		for (int32_t i = minimum_level; i < level; i++) {
-			extension->initialize_library(NativeExtension::InitializationLevel(level));
+		for (int32_t i = minimum_level; i <= level; i++) {
+			extension->initialize_library(NativeExtension::InitializationLevel(i));
 		}
 	}
 	native_extension_map[p_path] = extension;
@@ -69,9 +69,9 @@ NativeExtensionManager::LoadStatus NativeExtensionManager::unload_extension(cons
 		if (minimum_level < MIN(level, NativeExtension::INITIALIZATION_LEVEL_SCENE)) {
 			return LOAD_STATUS_NEEDS_RESTART;
 		}
-		//initialize up to current level
+		// deinitialize down to current level
 		for (int32_t i = level; i >= minimum_level; i--) {
-			extension->deinitialize_library(NativeExtension::InitializationLevel(level));
+			extension->deinitialize_library(NativeExtension::InitializationLevel(i));
 		}
 	}
 	native_extension_map.erase(p_path);


### PR DESCRIPTION
Extensions are not getting instantiating properly due to iteration calling the wrong levels for loading.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
