### PR TITLE
Fixing viewport texture with external textures

### DIFF
--- a/drivers/gles2/rasterizer_storage_gles2.cpp
+++ b/drivers/gles2/rasterizer_storage_gles2.cpp
@@ -5266,20 +5266,19 @@ void RasterizerStorageGLES2::_render_target_clear(RenderTarget *rt) {
 		rt->fbo = 0;
 	}
 
+	Texture *tex = texture_owner.get(rt->texture);
+	tex->alloc_height = 0;
+	tex->alloc_width = 0;
+	tex->width = 0;
+	tex->height = 0;
+	tex->active = false;
+
 	if (rt->external.fbo != 0) {
 		// free this
 		glDeleteFramebuffers(1, &rt->external.fbo);
 
-		// clean up our texture
-		Texture *t = texture_owner.get(rt->external.texture);
-		t->tex_id = 0;
-		t->alloc_height = 0;
-		t->alloc_width = 0;
-		t->width = 0;
-		t->height = 0;
-		t->active = false;
-		texture_owner.free(rt->external.texture);
-		memdelete(t);
+		// reset our texture back to the original
+		tex->tex_id = rt->color;
 
 		if (rt->external.depth != 0 && rt->external.depth_owned) {
 			glDeleteRenderbuffers(1, &rt->external.depth);
@@ -5300,13 +5299,6 @@ void RasterizerStorageGLES2::_render_target_clear(RenderTarget *rt) {
 
 		rt->depth = 0;
 	}
-
-	Texture *tex = texture_owner.get(rt->texture);
-	tex->alloc_height = 0;
-	tex->alloc_width = 0;
-	tex->width = 0;
-	tex->height = 0;
-	tex->active = false;
 
 	if (rt->copy_screen_effect.color) {
 		glDeleteFramebuffers(1, &rt->copy_screen_effect.fbo);
@@ -5403,11 +5395,7 @@ RID RasterizerStorageGLES2::render_target_get_texture(RID p_render_target) const
 	RenderTarget *rt = render_target_owner.getornull(p_render_target);
 	ERR_FAIL_COND_V(!rt, RID());
 
-	if (rt->external.fbo == 0) {
-		return rt->texture;
-	} else {
-		return rt->external.texture;
-	}
+	return rt->texture;
 }
 
 uint32_t RasterizerStorageGLES2::render_target_get_depth_texture_id(RID p_render_target) const {
@@ -5435,68 +5423,32 @@ void RasterizerStorageGLES2::render_target_set_external_texture(RID p_render_tar
 				glDeleteRenderbuffers(1, &rt->external.depth);
 			}
 
-			// clean up our texture
-			Texture *t = texture_owner.get(rt->external.texture);
-			t->tex_id = 0;
-			t->alloc_height = 0;
-			t->alloc_width = 0;
-			t->width = 0;
-			t->height = 0;
-			t->active = false;
-			texture_owner.free(rt->external.texture);
-			memdelete(t);
+			// reset our texture back to the original
+			Texture *t = texture_owner.get(rt->texture);
+			t->tex_id = rt->color;
+			t->width = rt->width;
+			t->alloc_width = rt->width;
+			t->height = rt->height;
+			t->alloc_height = rt->height;
 
 			rt->external.fbo = 0;
 			rt->external.color = 0;
 			rt->external.depth = 0;
 		}
 	} else {
-		Texture *t;
-
 		if (rt->external.fbo == 0) {
 			// create our fbo
 			glGenFramebuffers(1, &rt->external.fbo);
-			glBindFramebuffer(GL_FRAMEBUFFER, rt->external.fbo);
-
-			// allocate a texture
-			t = memnew(Texture);
-
-			t->type = VS::TEXTURE_TYPE_2D;
-			t->flags = 0;
-			t->width = 0;
-			t->height = 0;
-			t->alloc_height = 0;
-			t->alloc_width = 0;
-			t->format = Image::FORMAT_RGBA8;
-			t->target = GL_TEXTURE_2D;
-			t->gl_format_cache = 0;
-			t->gl_internal_format_cache = 0;
-			t->gl_type_cache = 0;
-			t->data_size = 0;
-			t->compressed = false;
-			t->srgb = false;
-			t->total_data_size = 0;
-			t->ignore_mipmaps = false;
-			t->mipmaps = 1;
-			t->active = true;
-			t->tex_id = 0;
-			t->render_target = rt;
-
-			rt->external.texture = texture_owner.make_rid(t);
-
-		} else {
-			// bind our frame buffer
-			glBindFramebuffer(GL_FRAMEBUFFER, rt->external.fbo);
-
-			// find our texture
-			t = texture_owner.get(rt->external.texture);
 		}
 
-		// set our texture
-		t->tex_id = p_texture_id;
+		// bind our frame buffer
+		glBindFramebuffer(GL_FRAMEBUFFER, rt->external.fbo);
+
 		rt->external.color = p_texture_id;
 
-		// size shouldn't be different
+		// Set our texture to the new image, note that we expect formats to be the same (or compatible) so we don't change those
+		Texture *t = texture_owner.get(rt->texture);
+		t->tex_id = p_texture_id;
 		t->width = rt->width;
 		t->height = rt->height;
 		t->alloc_height = rt->width;

--- a/drivers/gles2/rasterizer_storage_gles2.h
+++ b/drivers/gles2/rasterizer_storage_gles2.h
@@ -1225,7 +1225,6 @@ public:
 			GLuint color;
 			GLuint depth;
 			bool depth_owned;
-			RID texture;
 
 			External() :
 					fbo(0),

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -1381,7 +1381,6 @@ public:
 			GLuint fbo;
 			GLuint color;
 			GLuint depth;
-			RID texture;
 
 			External() :
 					fbo(0),


### PR DESCRIPTION
Couldn't get the timing right with this originally so fixed it in a very different way. Instead of using a different texture RID for external textures, we now simply overrule the main one. This means that the current way viewports are caching this RID keeps working. 

Fixes: #58353