### PR TITLE
Add a way to filter nodes by "type:" in the Scene tree dock.

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -423,7 +423,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		}
 		item->set_as_cursor(0);
 	}
-	
+
 	bool is_kept_by_type = filter.begins_with(String("type:")) && filter.replace_first(String("type:"), "").is_subsequence_ofn(String(p_node->get_class()));
 
 	bool keep = (filter.is_subsequence_ofn(String(p_node->get_name())) || is_kept_by_type);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -423,8 +423,10 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		}
 		item->set_as_cursor(0);
 	}
+	
+	bool is_kept_by_type = filter.begins_with(String("type:")) && filter.replace_first(String("type:"), "").is_subsequence_ofn(String(p_node->get_class()));
 
-	bool keep = (filter.is_subsequence_ofn(String(p_node->get_name())));
+	bool keep = (filter.is_subsequence_ofn(String(p_node->get_name())) || is_kept_by_type);
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {
 		bool child_keep = _add_nodes(p_node->get_child(i), item, p_scroll_to_selected);


### PR DESCRIPTION
**This PR addresses: godotengine/godot-proposals#4040**

Now you can filter Nodes by types by typing a "type:" prefix when searching.

**Example:**

![image](https://user-images.githubusercontent.com/17956756/154855724-3da3ea91-613d-494f-9bd5-2e1d9d94d194.png)


I think changing the placeholder of the search bar (as @Calinou mentioned in Original proposal) should be in a separate PR. But I'm new to Godot's source code, so it may be done in the future.

Please feel free to enlight me with your instructions.
