### PR TITLE
Fix nullptr error in _update_padded_texture on texture with no image

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -4432,6 +4432,10 @@ void TileSetAtlasSource::_update_padded_texture() {
 
 	Ref<Image> src = texture->get_image();
 
+	if (!src.is_valid()) {
+		return;
+	}
+
 	Ref<Image> image;
 	image.instantiate();
 	image->create(size.x, size.y, false, src->get_format());


### PR DESCRIPTION
Adds an additional check to prevent a nullptr crash when assigning a texture without an associated image to a tileset atlas

Closes #57192

There's a possibility that this *might* fix this too #52439, but further investigation will be required.