### PR TITLE
Restore RMB panning to 2D editor

### DIFF
--- a/editor/scene/canvas_item_editor_plugin.cpp
+++ b/editor/scene/canvas_item_editor_plugin.cpp
@@ -83,6 +83,7 @@
 #include "servers/rendering/rendering_server.h"
 
 #define DRAG_THRESHOLD (8 * EDSCALE)
+#define PAN_THRESHOLD (8 * EDSCALE)
 constexpr real_t SCALE_HANDLE_DISTANCE = 25;
 constexpr real_t MOVE_HANDLE_DISTANCE = 25;
 
@@ -2537,43 +2538,48 @@ bool CanvasItemEditor::_gui_input_select(const Ref<InputEvent> &p_event) {
 			}
 		}
 
-		if (b.is_valid() && b->is_pressed() && b->get_button_index() == MouseButton::RIGHT && tool != TOOL_SCENE_PAINT) {
-			add_node_menu->clear();
-			add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("Add")), TTRC("Add 2D Node Here..."), ADD_NODE);
-			add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("Instance")), TTRC("Instantiate Scene Here..."), ADD_INSTANCE);
-			for (Node *node : SceneTreeDock::get_singleton()->get_node_clipboard()) {
-				if (Object::cast_to<CanvasItem>(node)) {
-					add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("ActionPaste")), TTRC("Paste Node(s) Here"), ADD_PASTE);
-					break;
+		if (b.is_valid() && b->get_button_index() == MouseButton::RIGHT && tool != TOOL_SCENE_PAINT) {
+			if (b->is_pressed()) {
+				right_click_origin = b->get_position();
+				return true;
+			} else if (b->get_position().distance_to(right_click_origin) <= PAN_THRESHOLD) {
+				add_node_menu->clear();
+				add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("Add")), TTRC("Add 2D Node Here..."), ADD_NODE);
+				add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("Instance")), TTRC("Instantiate Scene Here..."), ADD_INSTANCE);
+				for (Node *node : SceneTreeDock::get_singleton()->get_node_clipboard()) {
+					if (Object::cast_to<CanvasItem>(node)) {
+						add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("ActionPaste")), TTRC("Paste Node(s) Here"), ADD_PASTE);
+						break;
+					}
 				}
-			}
-			for (Node *node : EditorNode::get_singleton()->get_editor_selection()->get_top_selected_node_list()) {
-				if (Object::cast_to<CanvasItem>(node) && _is_node_movable(node, false)) {
-					add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("ToolMove")), TTRC("Move Node(s) Here"), ADD_MOVE);
-					break;
+				for (Node *node : EditorNode::get_singleton()->get_editor_selection()->get_top_selected_node_list()) {
+					if (Object::cast_to<CanvasItem>(node) && _is_node_movable(node, false)) {
+						add_node_menu->add_icon_item(get_editor_theme_icon(SNAME("ToolMove")), TTRC("Move Node(s) Here"), ADD_MOVE);
+						break;
+					}
 				}
-			}
 
-			// Context menu plugin receives paths of nodes under cursor. It's a complex operation, so perform it only when necessary.
-			if (EditorContextMenuPluginManager::get_singleton()->has_plugins_for_slot(EditorContextMenuPlugin::CONTEXT_SLOT_2D_EDITOR)) {
-				selection_results.clear();
-				_get_canvas_items_at_pos(transform.affine_inverse().xform(viewport->get_local_mouse_position()), selection_results, true);
+				// Context menu plugin receives paths of nodes under cursor. It's a complex operation, so perform it only when necessary.
+				if (EditorContextMenuPluginManager::get_singleton()->has_plugins_for_slot(EditorContextMenuPlugin::CONTEXT_SLOT_2D_EDITOR)) {
+					selection_results.clear();
+					_get_canvas_items_at_pos(transform.affine_inverse().xform(viewport->get_local_mouse_position()), selection_results, true);
 
-				PackedStringArray paths;
-				paths.resize(selection_results.size());
-				String *paths_write = paths.ptrw();
+					PackedStringArray paths;
+					paths.resize(selection_results.size());
+					String *paths_write = paths.ptrw();
 
-				for (int i = 0; i < paths.size(); i++) {
-					paths_write[i] = String(selection_results[i].item->get_path());
+					for (int i = 0; i < paths.size(); i++) {
+						paths_write[i] = String(selection_results[i].item->get_path());
+					}
+					EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(add_node_menu, EditorContextMenuPlugin::CONTEXT_SLOT_2D_EDITOR, paths);
 				}
-				EditorContextMenuPluginManager::get_singleton()->add_options_from_plugins(add_node_menu, EditorContextMenuPlugin::CONTEXT_SLOT_2D_EDITOR, paths);
-			}
 
-			add_node_menu->reset_size();
-			add_node_menu->set_position(viewport->get_screen_transform().xform(b->get_position()));
-			add_node_menu->popup();
-			node_create_position = transform.affine_inverse().xform(b->get_position());
-			return true;
+				add_node_menu->reset_size();
+				add_node_menu->set_position(viewport->get_screen_transform().xform(b->get_position()));
+				add_node_menu->popup();
+				node_create_position = transform.affine_inverse().xform(b->get_position());
+				return true;
+			}
 		}
 
 		Point2 click;
@@ -2811,8 +2817,9 @@ void CanvasItemEditor::_gui_input_viewport(const Ref<InputEvent> &p_event) {
 
 	Ref<InputEventMouseButton> mb = p_event;
 	bool release_lmb = (mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT); // Required to properly release some stuff (e.g. selection box) while panning.
+	bool release_rmb = (mb.is_valid() && !mb->is_pressed() && mb->get_button_index() == MouseButton::RIGHT);
 
-	if (simple_panning || !pan_pressed || release_lmb) {
+	if (simple_panning || !pan_pressed || release_lmb || release_rmb) {
 		accepted = true;
 		if (_gui_input_rulers_and_guides(p_event)) {
 			// print_line("Rulers and guides");
@@ -5819,6 +5826,7 @@ CanvasItemEditor::CanvasItemEditor() {
 
 	panner.instantiate();
 	panner->set_callbacks(callable_mp(this, &CanvasItemEditor::_pan_callback), callable_mp(this, &CanvasItemEditor::_zoom_callback));
+	panner->set_enable_rmb(true);
 
 	viewport = memnew(CanvasItemEditorViewport(this));
 	viewport->set_mouse_filter(MOUSE_FILTER_PASS);

--- a/editor/scene/canvas_item_editor_plugin.h
+++ b/editor/scene/canvas_item_editor_plugin.h
@@ -279,6 +279,7 @@ private:
 	Point2 ruler_tool_origin;
 	real_t ruler_width_scaled = 16.0;
 	int ruler_font_size = 8;
+	Point2 right_click_origin;
 	Point2 node_create_position;
 	real_t grab_distance = 0.0;
 	bool simple_panning = false;

--- a/scene/gui/view_panner.cpp
+++ b/scene/gui/view_panner.cpp
@@ -113,7 +113,7 @@ bool ViewPanner::gui_input(const Ref<InputEvent> &p_event, Rect2 p_canvas_rect) 
 			if (mb->is_pressed()) {
 				drag_type = DragType::DRAG_TYPE_PAN;
 			}
-			return mb->get_button_index() != MouseButton::LEFT || mb->is_pressed(); // Don't consume LMB release events (it fixes some selection problems).
+			return mb->is_pressed();
 		}
 	}
 


### PR DESCRIPTION
Not super-crucial feature, but seems like some people are missing it and [Calinou suggested a way to re-implement it without getting in the way of context menu](https://github.com/godotengine/godot-proposals/issues/3881#issuecomment-1037301274), so why not.

You can again pan with RMB, but if you release the button without moving more than 8 pixels, the menu will open normally. I also fixed the menu position, as it was wrongly centered.
![godot windows tools 64_i0Bp8HeyK7](https://user-images.githubusercontent.com/2223172/154864919-559c3d5a-df18-474c-b428-1d72e357c460.gif)

This addresses https://github.com/godotengine/godot-proposals/issues/3881; not sure if closes it fully, as the proposal mentions some other stuff.

