### PR TITLE
Add temporary pivot for rotating multiple 2D nodes

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -174,6 +174,7 @@ private:
 		DRAG_SCALE_BOTH,
 		DRAG_ROTATE,
 		DRAG_PIVOT,
+		DRAG_TEMP_PIVOT,
 		DRAG_V_GUIDE,
 		DRAG_H_GUIDE,
 		DRAG_DOUBLE_GUIDE,
@@ -251,6 +252,7 @@ private:
 	bool key_scale = false;
 
 	bool pan_pressed = false;
+	Vector2 temp_pivot = Vector2(INFINITY, INFINITY);
 
 	bool ruler_tool_active = false;
 	Point2 ruler_tool_origin;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/3684
![godot windows tools 64_zJr9fwPUZV](https://user-images.githubusercontent.com/2223172/154871426-c22f6b17-05c8-4294-a8a2-f5cbf798bf2b.gif)


You can set a temporary pivot, which will be used as rotation origin for the selected nodes, in global coordinates. It's very useful when e.g. placing objects on your level (using a parent node as rotation point is very inconvenient, because usually you don't need it after rotation). The pivot disappears when selection changes.

~~Submitting as draft, as I didn't know where to put it xd Right now it uses hard-coded P shortcut. I've been thinking about 3 options:~~ Resolved.
- add a "Rotation Pivot" tool that would set the temporary pivot
- use the existing Pivot Tool and just make it so if you have multiple nodes selected, the temporary pivot would be set instead (which means you wouldn't be able to change pivot of multiple nodes)
- add a modifier for Pivot Tool, e.g. Alt. Then Alt+V would set the temporary pivot in Select mode

I like the third one the best, but it's probably up to discussion. The code uses the easiest option until this is settled.