### PR TITLE
Fixed issue with godot's changes to polypartition third-party code

### DIFF
--- a/thirdparty/misc/patches/polypartition-godot-types.patch
+++ b/thirdparty/misc/patches/polypartition-godot-types.patch
@@ -101,7 +101,7 @@ index 3a8a6efa83..8c5409bf24 100644
          pointvisible = true;
 -        for (iter2 = polys.begin(); iter2 != polys.end(); iter2++) {
 -          if (iter2->IsHole()) {
-+        for (iter2 = polys.front(); iter2; iter2->next()) {
++        for (iter2 = polys.front(); iter2; iter2 = iter2->next()) {
 +          if (iter2->get().IsHole()) {
              continue;
            }

--- a/thirdparty/misc/polypartition.cpp
+++ b/thirdparty/misc/polypartition.cpp
@@ -262,7 +262,7 @@ int TPPLPartition::RemoveHoles(TPPLPolyList *inpolys, TPPLPolyList *outpolys) {
           }
         }
         pointvisible = true;
-        for (iter2 = polys.front(); iter2; iter2->next()) {
+        for (iter2 = polys.front(); iter2; iter2 = iter2->next()) {
           if (iter2->get().IsHole()) {
             continue;
           }


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/58365

I am unsure where or if this function gets called in the engine, but it may have caused https://github.com/godotengine/godot/issues/53808 as well

*Bugsquad edit:*
- Fixes #58365
- Fixes #53808
- Regression from #48921