### PR TITLE
Add a way to filter nodes by type in scene tree dock.

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -602,7 +602,9 @@ bool SceneTreeEditor::_update_filter(TreeItem *p_parent, bool p_scroll_to_select
 	}
 
 	if (!keep) {
-		keep = filter.is_subsequence_ofn(p_parent->get_text(0));
+		StringName node_type = get_node(p_parent->get_metadata(0))->get_class();
+		bool is_kept_by_type = (filter.begins_with("type:") && filter.trim_prefix("type:").is_subsequence_ofn(node_type)) || (filter.begins_with("t:") && filter.trim_prefix("t:").is_subsequence_ofn(node_type));
+		keep = (filter.is_subsequence_ofn(p_parent->get_text(0)) || is_kept_by_type);
 	}
 
 	p_parent->set_visible(keep);


### PR DESCRIPTION
**This PR addresses: godotengine/godot-proposals#4040**

Now you can filter Nodes by types by typing a "type:" prefix when searching.

**Example:**

![image](https://user-images.githubusercontent.com/17956756/154855724-3da3ea91-613d-494f-9bd5-2e1d9d94d194.png)


~~I think changing the placeholder of the search bar (as Calinou mentioned in Original proposal) should be in a separate PR.~~
~~EDIT: This is a new PR instead of #58362 which git broke it. 😥~~

~~The new placeholder hasn't implemented yet.I'm new to Godot's source code, so it may take some time to finish it.~~

**Please feel free to enlight me with your instructions.**