### PR TITLE
Fix get_global_transform_interpolated() with multiple ticks per frame

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2240,6 +2240,7 @@ bool Main::iteration() {
 
 		if (OS::get_singleton()->get_main_loop()->iteration(frame_slice * time_scale)) {
 			exit = true;
+			Engine::get_singleton()->_in_physics = false;
 			break;
 		}
 

--- a/scene/3d/spatial.h
+++ b/scene/3d/spatial.h
@@ -55,10 +55,11 @@ class Spatial : public Node {
 	// optionally stored if we need to do interpolation
 	// client side (i.e. not in VisualServer) so interpolated transforms
 	// can be read back with get_global_transform_interpolated()
-	struct PhysicsInterpolationData {
+	struct ClientPhysicsInterpolationData {
 		Transform global_xform_curr;
 		Transform global_xform_prev;
 		uint64_t current_physics_tick = 0;
+		uint64_t timeout_physics_tick = 0;
 	};
 
 	enum TransformDirty {
@@ -69,6 +70,7 @@ class Spatial : public Node {
 	};
 
 	mutable SelfList<Node> xform_change;
+	SelfList<Spatial> _client_physics_interpolation_spatials_list;
 
 	struct Data {
 		mutable Transform global_transform;
@@ -101,7 +103,7 @@ class Spatial : public Node {
 		List<Spatial *> children;
 		List<Spatial *>::Element *C;
 
-		PhysicsInterpolationData *physics_interpolation_data;
+		ClientPhysicsInterpolationData *client_physics_interpolation_data;
 
 #ifdef TOOLS_ENABLED
 		Ref<SpatialGizmo> gizmo;
@@ -121,10 +123,10 @@ protected:
 	_FORCE_INLINE_ void set_ignore_transform_notification(bool p_ignore) { data.ignore_notification = p_ignore; }
 	_FORCE_INLINE_ void _update_local_transform() const;
 
-	void _update_physics_interpolation_data();
 	void _set_vi_visible(bool p_visible);
 	bool _is_vi_visible() const { return data.vi_visible; }
 	Transform _get_global_transform_interpolated(real_t p_interpolation_fraction);
+	void _disable_client_physics_interpolation();
 
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -162,6 +164,7 @@ public:
 	Transform get_transform() const;
 	Transform get_global_transform() const;
 	Transform get_global_transform_interpolated();
+	bool update_client_physics_interpolation_data();
 
 #ifdef TOOLS_ENABLED
 	virtual Transform get_global_gizmo_transform() const;

--- a/scene/animation/skeleton_ik.cpp
+++ b/scene/animation/skeleton_ik.cpp
@@ -550,8 +550,8 @@ Transform SkeletonIK::_get_target_transform() {
 	}
 
 	if (target_node_override && target_node_override->is_inside_tree()) {
-		// Make sure to use the interpolated transform as target. This will pass through
-		// to get_global_transform() when physics interpolation is off, and when using interpolation,
+		// Make sure to use the interpolated transform as target.
+		// This will pass through to get_global_transform() when physics interpolation is off, and when using interpolation,
 		// ensure that the target matches the interpolated visual position of the target when updating the IK each frame.
 		return target_node_override->get_global_transform_interpolated();
 	} else {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -41,6 +41,7 @@
 
 class PackedScene;
 class Node;
+class Spatial;
 class Viewport;
 class Material;
 class Mesh;
@@ -101,6 +102,11 @@ private:
 		bool changed;
 		Group() { changed = false; };
 	};
+
+	struct ClientPhysicsInterpolation {
+		SelfList<Spatial>::List _spatials_list;
+		void physics_process();
+	} _client_physics_interpolation;
 
 	Viewport *root;
 
@@ -410,6 +416,9 @@ public:
 
 	void set_physics_interpolation_enabled(bool p_enabled);
 	bool is_physics_interpolation_enabled() const;
+
+	void client_physics_interpolation_add_spatial(SelfList<Spatial> *p_elem);
+	void client_physics_interpolation_remove_spatial(SelfList<Spatial> *p_elem);
 
 	static void add_idle_callback(IdleCallback p_callback);
 	SceneTree();


### PR DESCRIPTION
The previous and current transforms in the interpolation data were not being correctly updated in cases where two or more physics ticks occurred on a frame. This PR introduces a simple mechanism to ensure updates on interpolated spatials.

On suggestion from reduz this now uses a `SelfList` to store the list of `Spatial`s to update, and this list is stored in the `SceneTree`. Members of this update list have a `timeout` value in order to reduce processing - if `get_global_transform_interpolated()` has not been called in a certain number of physics ticks, it is removed from the update list until the next time `get_global_transform_interpolated()` is called.

Note that the update list ONLY copies the current transform to the previous transform and updates the global transform. It does not perform any interpolation, that is performed on request within the `get_global_transform_interpolated()` function.

## Explanation
Previously, if there were 2 or more physics ticks in a frame (for instance setting physics tick rate to 90tps, at a frame rate of 60fps), then the previous transform would only be set _once_, and would end up being a stale previous transform, which would result in the the interpolated value being further back in time than it should be, giving a visual effect of jitter.

## Notes
* This bug only occurred when using client interpolation using the `get_global_transform_interpolated()` function (e.g. for a Camera).
* It only occurs when the tick rate is high enough that 2 or more physics ticks occur per frame (which is why I didn't notice it earlier).
* The exact same bug also came up in the smoothing addon (!) :grin: 

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
