### PR TITLE
Avoid setting sub-window or started project window positions, if it's impossible to get screen rect.

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1365,6 +1365,12 @@ float EditorSettings::get_auto_display_scale() const {
 	return DisplayServer::get_singleton()->screen_get_max_scale();
 #else
 	const int screen = DisplayServer::get_singleton()->window_get_current_screen();
+
+	if (DisplayServer::get_singleton()->screen_get_size(screen) == Vector2i()) {
+		// Invalid screen size, skip.
+		return 1.0;
+	}
+
 	// Use the smallest dimension to use a correct display scale on portrait displays.
 	const int smallest_dimension = MIN(DisplayServer::get_singleton()->screen_get_size(screen).x, DisplayServer::get_singleton()->screen_get_size(screen).y);
 	if (DisplayServer::get_singleton()->screen_get_dpi(screen) >= 192 && smallest_dimension >= 1400) {

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2877,17 +2877,15 @@ ProjectManager::ProjectManager() {
 		Vector2i screen_size = DisplayServer::get_singleton()->screen_get_size();
 		Vector2i screen_position = DisplayServer::get_singleton()->screen_get_position();
 
-		// Consider the editor display scale.
-		window_size.x = round((float)window_size.x * scale_factor);
-		window_size.y = round((float)window_size.y * scale_factor);
-
-		// Make the window centered on the screen.
-		Vector2i window_position;
-		window_position.x = screen_position.x + (screen_size.x - window_size.x) / 2;
-		window_position.y = screen_position.y + (screen_size.y - window_size.y) / 2;
+		window_size *= scale_factor;
 
 		DisplayServer::get_singleton()->window_set_size(window_size);
-		DisplayServer::get_singleton()->window_set_position(window_position);
+		if (screen_size != Vector2i()) {
+			Vector2i window_position;
+			window_position.x = screen_position.x + (screen_size.x - window_size.x) / 2;
+			window_position.y = screen_position.y + (screen_size.y - window_size.y) / 2;
+			DisplayServer::get_singleton()->window_set_position(window_position);
+		}
 	}
 
 	OS::get_singleton()->set_low_processor_usage_mode(true);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1045,7 +1045,9 @@ void Window::popup_centered_clamped(const Size2i &p_size, float p_fallback_ratio
 
 	Rect2i popup_rect;
 	popup_rect.size = Vector2i(MIN(size_ratio.x, p_size.x), MIN(size_ratio.y, p_size.y));
-	popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
+	if (parent_rect != Rect2()) {
+		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
+	}
 
 	popup(popup_rect);
 }
@@ -1069,7 +1071,10 @@ void Window::popup_centered(const Size2i &p_minsize) {
 	Size2 contents_minsize = _get_contents_minimum_size();
 	popup_rect.size.x = MAX(p_minsize.x, contents_minsize.x);
 	popup_rect.size.y = MAX(p_minsize.y, contents_minsize.y);
-	popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
+
+	if (parent_rect != Rect2()) {
+		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
+	}
 
 	popup(popup_rect);
 }
@@ -1091,8 +1096,10 @@ void Window::popup_centered_ratio(float p_ratio) {
 	}
 
 	Rect2i popup_rect;
-	popup_rect.size = parent_rect.size * p_ratio;
-	popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
+	if (parent_rect != Rect2()) {
+		popup_rect.size = parent_rect.size * p_ratio;
+		popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
+	}
 
 	popup(popup_rect);
 }


### PR DESCRIPTION
Prevents popup windows or started project positions outside of the screen, when it's impossible to get screen rect for any reason (e.g., missing Xinerama).

Addition to #58272, Alternative for #58259