### PR TITLE
[3.x] Fix CanvasItem visibility propagation

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3756,7 +3756,7 @@ void CanvasItemEditor::_draw_invisible_nodes_positions(Node *p_node, const Trans
 	}
 
 	CanvasItem *canvas_item = Object::cast_to<CanvasItem>(p_node);
-	if (canvas_item && !canvas_item->is_visible()) {
+	if (canvas_item && !canvas_item->is_visible_in_tree()) {
 		return;
 	}
 

--- a/scene/2d/canvas_item.cpp
+++ b/scene/2d/canvas_item.cpp
@@ -353,16 +353,18 @@ bool CanvasItem::is_visible_in_tree() const {
 	return visible && parent_visible_in_tree;
 }
 
-void CanvasItem::_propagate_visibility_changed(bool p_visible, bool p_was_visible) {
+void CanvasItem::_propagate_visibility_changed(bool p_visible, bool p_is_source) {
 	if (p_visible && first_draw) { //avoid propagating it twice
 		first_draw = false;
 	}
-	parent_visible_in_tree = p_visible;
+	if (!p_is_source) {
+		parent_visible_in_tree = p_visible;
+	}
 	notification(NOTIFICATION_VISIBILITY_CHANGED);
 
 	if (visible && p_visible) {
 		update();
-	} else if (!p_visible && (visible || p_was_visible)) {
+	} else if (!p_visible && (visible || p_is_source)) {
 		emit_signal(SceneStringNames::get_singleton()->hide);
 	}
 	_block();
@@ -370,8 +372,12 @@ void CanvasItem::_propagate_visibility_changed(bool p_visible, bool p_was_visibl
 	for (int i = 0; i < get_child_count(); i++) {
 		CanvasItem *c = Object::cast_to<CanvasItem>(get_child(i));
 
-		if (c && c->visible) { //should the toplevels stop propagation? i think so but..
-			c->_propagate_visibility_changed(p_visible);
+		if (c) { // Should the top_levels stop propagation? I think so, but...
+			if (c->visible) {
+				c->_propagate_visibility_changed(p_visible);
+			} else {
+				c->parent_visible_in_tree = p_visible;
+			}
 		}
 	}
 
@@ -386,11 +392,14 @@ void CanvasItem::set_visible(bool p_visible) {
 	visible = p_visible;
 	VisualServer::get_singleton()->canvas_item_set_visible(canvas_item, p_visible);
 
-	if (!is_inside_tree()) {
+	if (!parent_visible_in_tree) {
+		if (is_inside_tree()) {
+			notification(NOTIFICATION_VISIBILITY_CHANGED);
+		}
 		return;
 	}
 
-	_propagate_visibility_changed(p_visible, !p_visible);
+	_propagate_visibility_changed(p_visible, true);
 	_change_notify("visible");
 }
 

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -210,7 +210,7 @@ private:
 
 	void _toplevel_raise_self();
 
-	void _propagate_visibility_changed(bool p_visible, bool p_was_visible = false);
+	void _propagate_visibility_changed(bool p_visible, bool p_is_source = false);
 
 	void _update_callback();
 

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -59,7 +59,7 @@ void CanvasLayer::set_visible(bool p_visible) {
 			if (c->is_visible()) {
 				c->_propagate_visibility_changed(p_visible);
 			} else {
-				c->notification(CanvasItem::NOTIFICATION_VISIBILITY_CHANGED);
+				c->parent_visible_in_tree = p_visible;
 			}
 		}
 	}


### PR DESCRIPTION
Backport of #58315
It has the same issue I mentioned in that PR, but IMO it's very minor compared to broken editor, so it could be merged for now (before next beta at least) and fixed later.