### PR TITLE
Disable jitter fix when physics interpolation is enabled.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1159,7 +1159,8 @@
 		<member name="physics/common/physics_jitter_fix" type="float" setter="" getter="" default="0.5">
 			Controls how much physics ticks are synchronized with real time. For 0 or less, the ticks are synchronized. Such values are recommended for network games, where clock synchronization matters. Higher values cause higher deviation of in-game clock and real clock, but allows smoothing out framerate jitters. The default value of 0.5 should be fine for most; values above 2 could cause the game to react to dropped frames with a noticeable delay and are not recommended.
 			[b]Note:[/b] For best results, when using a custom physics interpolation solution, the physics jitter fix should be disabled by setting [member physics/common/physics_jitter_fix] to [code]0[/code].
-			[b]Note:[/b] This property is only read when the project starts. To change the physics FPS at runtime, set [member Engine.physics_jitter_fix] instead.
+			[b]Note:[/b] Jitter fix is automatically disabled at runtime when [member physics/common/physics_interpolation] is enabled.
+			[b]Note:[/b] This property is only read when the project starts. To change the value at runtime, set [member Engine.physics_jitter_fix] instead.
 		</member>
 		<member name="rendering/2d/opengl/batching_send_null" type="int" setter="" getter="" default="0">
 			[b]Experimental.[/b] Calls [code]glBufferData[/code] with NULL data prior to uploading batching data. This may not be necessary but can be used for safety.

--- a/main/main_timer_sync.cpp
+++ b/main/main_timer_sync.cpp
@@ -291,17 +291,6 @@ int64_t MainTimerSync::DeltaSmoother::smooth_delta(int64_t p_delta) {
 // before advance_core considers changing the physics_steps return from
 // the typical values as defined by typical_physics_steps
 float MainTimerSync::get_physics_jitter_fix() {
-	// Turn off jitter fix when using fixed timestep interpolation
-	// Note this shouldn't be on UNTIL 2d interpolation is implemented,
-	// otherwise we will get people making 2d games with the physics_interpolation
-	// set to on getting jitter fix disabled unexpectedly.
-#if 0
-	if (Engine::get_singleton()->is_physics_interpolation_enabled()) {
-		// would be better to write a simple bypass for jitter fix but this will do to get started
-		return 0.0;
-	}
-#endif
-
 	return Engine::get_singleton()->get_physics_jitter_fix();
 }
 

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -2097,7 +2097,14 @@ SceneTree::SceneTree() {
 	if (!root->get_world().is_valid()) {
 		root->set_world(Ref<World>(memnew(World)));
 	}
+
 	set_physics_interpolation_enabled(GLOBAL_DEF("physics/common/physics_interpolation", false));
+	// Always disable jitter fix if physics interpolation is enabled -
+	// Jitter fix will interfere with interpolation, and is not necessary
+	// when interpolation is active.
+	if (is_physics_interpolation_enabled()) {
+		Engine::get_singleton()->set_physics_jitter_fix(0);
+	}
 
 	// Initialize network state
 	multiplayer_poll = true;


### PR DESCRIPTION
Also adds a note to the docs.

## Notes
* I had a rethink on this and decided it probably is worth activating, given that `physics_interpolation` is off by default so this should not affect 2D games, and we will likely be able to add 2D interpolation shortly (perhaps after feedback from the beta).
* Without this it is pretty likely people would end up using interpolation with jitter fix set to non zero, and getting sub-optimal results, especially as the default for jitter fix is 0.5 and most people leave things at default values.
* This isn't completely foolproof, it works on the basis of the `project setting`. In the unlikely event a game is manually turning on interpolation at runtime, it would be responsible for setting jitter fix to 0.0.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
