### PR TITLE
Cleanup EditorNode, EditorHistory, EditorSelection and EditorData

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -3383,7 +3383,7 @@ Node *AnimationTrackEditor::get_root() const {
 void AnimationTrackEditor::update_keying() {
 	bool keying_enabled = false;
 
-	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
+	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
 	if (is_visible_in_tree() && animation.is_valid() && editor_history->get_path_size() > 0) {
 		Object *obj = ObjectDB::get_instance(editor_history->get_path_object(0));
 		keying_enabled = Object::cast_to<Node>(obj) != nullptr;
@@ -3776,7 +3776,7 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 		return;
 	}
 
-	EditorHistory *history = EditorNode::get_singleton()->get_editor_history();
+	EditorSelectionHistory *history = EditorNode::get_singleton()->get_editor_selection_history();
 	for (int i = 1; i < history->get_path_size(); i++) {
 		String prop = history->get_path_property(i);
 		ERR_FAIL_COND(prop.is_empty());
@@ -3856,7 +3856,7 @@ void AnimationTrackEditor::insert_node_value_key(Node *p_node, const String &p_p
 }
 
 void AnimationTrackEditor::insert_value_key(const String &p_property, const Variant &p_value, bool p_advance) {
-	EditorHistory *history = EditorNode::get_singleton()->get_editor_history();
+	EditorSelectionHistory *history = EditorNode::get_singleton()->get_editor_selection_history();
 
 	ERR_FAIL_COND(!root);
 	// Let's build a node path.

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -206,7 +206,7 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 void EditorDebuggerInspector::clear_cache() {
 	for (const KeyValue<ObjectID, EditorDebuggerRemoteObject *> &E : remote_objects) {
 		EditorNode *editor = EditorNode::get_singleton();
-		if (editor->get_editor_history()->get_current() == E.value->get_instance_id()) {
+		if (editor->get_editor_selection_history()->get_current() == E.value->get_instance_id()) {
 			editor->push_item(nullptr);
 		}
 		memdelete(E.value);

--- a/editor/debugger/editor_debugger_node.cpp
+++ b/editor/debugger/editor_debugger_node.cpp
@@ -181,7 +181,7 @@ void EditorDebuggerNode::_bind_methods() {
 }
 
 EditorDebuggerRemoteObject *EditorDebuggerNode::get_inspected_remote_object() {
-	return Object::cast_to<EditorDebuggerRemoteObject>(ObjectDB::get_instance(EditorNode::get_singleton()->get_editor_history()->get_current()));
+	return Object::cast_to<EditorDebuggerRemoteObject>(ObjectDB::get_instance(EditorNode::get_singleton()->get_editor_selection_history()->get_current()));
 }
 
 ScriptEditorDebugger *EditorDebuggerNode::get_debugger(int p_id) const {

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -38,12 +38,13 @@
 #include "editor/plugins/script_editor_plugin.h"
 #include "scene/resources/packed_scene.h"
 
-void EditorHistory::cleanup_history() {
+void EditorSelectionHistory::cleanup_history() {
 	for (int i = 0; i < history.size(); i++) {
 		bool fail = false;
 
 		for (int j = 0; j < history[i].path.size(); j++) {
 			if (!history[i].path[j].ref.is_null()) {
+				// Reference is not null - object still alive.
 				continue;
 			}
 
@@ -51,21 +52,16 @@ void EditorHistory::cleanup_history() {
 			if (obj) {
 				Node *n = Object::cast_to<Node>(obj);
 				if (n && n->is_inside_tree()) {
+					// Node valid and inside tree - object still alive.
 					continue;
 				}
-				if (!n) { // Possibly still alive
+				if (!n) {
+					// Node possibly still alive.
 					continue;
 				}
-			}
+			} // Else: object not valid - not alive.
 
-			if (j <= history[i].level) {
-				//before or equal level, complete fail
-				fail = true;
-			} else {
-				//after level, clip
-				history.write[i].path.resize(j);
-			}
-
+			fail = true;
 			break;
 		}
 
@@ -75,16 +71,16 @@ void EditorHistory::cleanup_history() {
 		}
 	}
 
-	if (current >= history.size()) {
-		current = history.size() - 1;
+	if (current_elem_idx >= history.size()) {
+		current_elem_idx = history.size() - 1;
 	}
 }
 
-void EditorHistory::_add_object(ObjectID p_object, const String &p_property, int p_level_change, bool p_inspector_only) {
+void EditorSelectionHistory::add_object(ObjectID p_object, const String &p_property, bool p_inspector_only) {
 	Object *obj = ObjectDB::get_instance(p_object);
 	ERR_FAIL_COND(!obj);
 	RefCounted *r = Object::cast_to<RefCounted>(obj);
-	Obj o;
+	_Object o;
 	if (r) {
 		o.ref = REF(r);
 	}
@@ -92,86 +88,64 @@ void EditorHistory::_add_object(ObjectID p_object, const String &p_property, int
 	o.property = p_property;
 	o.inspector_only = p_inspector_only;
 
-	History h;
-
-	bool has_prev = current >= 0 && current < history.size();
+	bool has_prev = current_elem_idx >= 0 && current_elem_idx < history.size();
 
 	if (has_prev) {
-		history.resize(current + 1); //clip history to next
+		history.resize(current_elem_idx + 1); // Clip history to next.
 	}
 
+	HistoryElement h;
 	if (!p_property.is_empty() && has_prev) {
-		//add a sub property
-		History &pr = history.write[current];
-		h = pr;
+		// Add a sub property.
+		HistoryElement &prev_element = history.write[current_elem_idx];
+		h = prev_element;
 		h.path.resize(h.level + 1);
 		h.path.push_back(o);
 		h.level++;
-	} else if (p_level_change != -1 && has_prev) {
-		//add a sub property
-		History &pr = history.write[current];
-		h = pr;
-		ERR_FAIL_INDEX(p_level_change, h.path.size());
-		h.level = p_level_change;
+
 	} else {
-		//add a new node
+		// Create a new history item.
 		h.path.push_back(o);
 		h.level = 0;
 	}
 
 	history.push_back(h);
-	current++;
+	current_elem_idx++;
 }
 
-void EditorHistory::add_object_inspector_only(ObjectID p_object) {
-	_add_object(p_object, "", -1, true);
-}
-
-void EditorHistory::add_object(ObjectID p_object) {
-	_add_object(p_object, "", -1);
-}
-
-void EditorHistory::add_object(ObjectID p_object, const String &p_subprop) {
-	_add_object(p_object, p_subprop, -1);
-}
-
-void EditorHistory::add_object(ObjectID p_object, int p_relevel) {
-	_add_object(p_object, "", p_relevel);
-}
-
-int EditorHistory::get_history_len() {
+int EditorSelectionHistory::get_history_len() {
 	return history.size();
 }
 
-int EditorHistory::get_history_pos() {
-	return current;
+int EditorSelectionHistory::get_history_pos() {
+	return current_elem_idx;
 }
 
-bool EditorHistory::is_history_obj_inspector_only(int p_obj) const {
+bool EditorSelectionHistory::is_history_obj_inspector_only(int p_obj) const {
 	ERR_FAIL_INDEX_V(p_obj, history.size(), false);
 	ERR_FAIL_INDEX_V(history[p_obj].level, history[p_obj].path.size(), false);
 	return history[p_obj].path[history[p_obj].level].inspector_only;
 }
 
-ObjectID EditorHistory::get_history_obj(int p_obj) const {
+ObjectID EditorSelectionHistory::get_history_obj(int p_obj) const {
 	ERR_FAIL_INDEX_V(p_obj, history.size(), ObjectID());
 	ERR_FAIL_INDEX_V(history[p_obj].level, history[p_obj].path.size(), ObjectID());
 	return history[p_obj].path[history[p_obj].level].object;
 }
 
-bool EditorHistory::is_at_beginning() const {
-	return current <= 0;
+bool EditorSelectionHistory::is_at_beginning() const {
+	return current_elem_idx <= 0;
 }
 
-bool EditorHistory::is_at_end() const {
-	return ((current + 1) >= history.size());
+bool EditorSelectionHistory::is_at_end() const {
+	return ((current_elem_idx + 1) >= history.size());
 }
 
-bool EditorHistory::next() {
+bool EditorSelectionHistory::next() {
 	cleanup_history();
 
-	if ((current + 1) < history.size()) {
-		current++;
+	if ((current_elem_idx + 1) < history.size()) {
+		current_elem_idx++;
 	} else {
 		return false;
 	}
@@ -179,11 +153,11 @@ bool EditorHistory::next() {
 	return true;
 }
 
-bool EditorHistory::previous() {
+bool EditorSelectionHistory::previous() {
 	cleanup_history();
 
-	if (current > 0) {
-		current--;
+	if (current_elem_idx > 0) {
+		current_elem_idx--;
 	} else {
 		return false;
 	}
@@ -191,75 +165,62 @@ bool EditorHistory::previous() {
 	return true;
 }
 
-bool EditorHistory::is_current_inspector_only() const {
-	if (current < 0 || current >= history.size()) {
+bool EditorSelectionHistory::is_current_inspector_only() const {
+	if (current_elem_idx < 0 || current_elem_idx >= history.size()) {
 		return false;
 	}
 
-	const History &h = history[current];
+	const HistoryElement &h = history[current_elem_idx];
 	return h.path[h.level].inspector_only;
 }
 
-ObjectID EditorHistory::get_current() {
-	if (current < 0 || current >= history.size()) {
+ObjectID EditorSelectionHistory::get_current() {
+	if (current_elem_idx < 0 || current_elem_idx >= history.size()) {
 		return ObjectID();
 	}
 
-	History &h = history.write[current];
-	Object *obj = ObjectDB::get_instance(h.path[h.level].object);
-	if (!obj) {
-		return ObjectID();
-	}
-
-	return obj->get_instance_id();
+	Object *obj = ObjectDB::get_instance(get_history_obj(current_elem_idx));
+	return obj ? obj->get_instance_id() : ObjectID();
 }
 
-int EditorHistory::get_path_size() const {
-	if (current < 0 || current >= history.size()) {
+int EditorSelectionHistory::get_path_size() const {
+	if (current_elem_idx < 0 || current_elem_idx >= history.size()) {
 		return 0;
 	}
 
-	const History &h = history[current];
-	return h.path.size();
+	return history[current_elem_idx].path.size();
 }
 
-ObjectID EditorHistory::get_path_object(int p_index) const {
-	if (current < 0 || current >= history.size()) {
+ObjectID EditorSelectionHistory::get_path_object(int p_index) const {
+	if (current_elem_idx < 0 || current_elem_idx >= history.size()) {
 		return ObjectID();
 	}
 
-	const History &h = history[current];
+	ERR_FAIL_INDEX_V(p_index, history[current_elem_idx].path.size(), ObjectID());
 
-	ERR_FAIL_INDEX_V(p_index, h.path.size(), ObjectID());
-
-	Object *obj = ObjectDB::get_instance(h.path[p_index].object);
-	if (!obj) {
-		return ObjectID();
-	}
-
-	return obj->get_instance_id();
+	Object *obj = ObjectDB::get_instance(history[current_elem_idx].path[p_index].object);
+	return obj ? obj->get_instance_id() : ObjectID();
 }
 
-String EditorHistory::get_path_property(int p_index) const {
-	if (current < 0 || current >= history.size()) {
+String EditorSelectionHistory::get_path_property(int p_index) const {
+	if (current_elem_idx < 0 || current_elem_idx >= history.size()) {
 		return "";
 	}
 
-	const History &h = history[current];
-
-	ERR_FAIL_INDEX_V(p_index, h.path.size(), "");
-
-	return h.path[p_index].property;
+	ERR_FAIL_INDEX_V(p_index, history[current_elem_idx].path.size(), "");
+	return history[current_elem_idx].path[p_index].property;
 }
 
-void EditorHistory::clear() {
+void EditorSelectionHistory::clear() {
 	history.clear();
-	current = -1;
+	current_elem_idx = -1;
 }
 
-EditorHistory::EditorHistory() {
-	current = -1;
+EditorSelectionHistory::EditorSelectionHistory() {
+	current_elem_idx = -1;
 }
+
+////////////////////////////////////////////////////////////
 
 EditorPlugin *EditorData::get_editor(Object *p_object) {
 	// We need to iterate backwards so that we can check user-created plugins first.
@@ -636,14 +597,14 @@ bool EditorData::check_and_update_scene(int p_idx) {
 
 		EditorProgress ep("update_scene", TTR("Updating Scene"), 2);
 		ep.step(TTR("Storing local changes..."), 0);
-		//pack first, so it stores diffs to previous version of saved scene
+		// Pack first, so it stores diffs to previous version of saved scene.
 		Error err = pscene->pack(edited_scene[p_idx].root);
 		ERR_FAIL_COND_V(err != OK, false);
 		ep.step(TTR("Updating scene..."), 1);
 		Node *new_scene = pscene->instantiate(PackedScene::GEN_EDIT_STATE_MAIN);
 		ERR_FAIL_COND_V(!new_scene, false);
 
-		//transfer selection
+		// Transfer selection.
 		List<Node *> new_selection;
 		for (const Node *E : edited_scene.write[p_idx].selection) {
 			NodePath p = edited_scene[p_idx].root->get_path_to(E);
@@ -675,7 +636,6 @@ int EditorData::get_edited_scene() const {
 void EditorData::set_edited_scene(int p_idx) {
 	ERR_FAIL_INDEX(p_idx, edited_scene.size());
 	current_edited_scene = p_idx;
-	//swap
 }
 
 Node *EditorData::get_edited_scene_root(int p_idx) {
@@ -850,23 +810,23 @@ NodePath EditorData::get_edited_scene_live_edit_root() {
 	return edited_scene[current_edited_scene].live_edit_root;
 }
 
-void EditorData::save_edited_scene_state(EditorSelection *p_selection, EditorHistory *p_history, const Dictionary &p_custom) {
+void EditorData::save_edited_scene_state(EditorSelection *p_selection, EditorSelectionHistory *p_history, const Dictionary &p_custom) {
 	ERR_FAIL_INDEX(current_edited_scene, edited_scene.size());
 
 	EditedScene &es = edited_scene.write[current_edited_scene];
 	es.selection = p_selection->get_full_selected_node_list();
-	es.history_current = p_history->current;
+	es.history_current = p_history->current_elem_idx;
 	es.history_stored = p_history->history;
 	es.editor_states = get_editor_states();
 	es.custom_state = p_custom;
 }
 
-Dictionary EditorData::restore_edited_scene_state(EditorSelection *p_selection, EditorHistory *p_history) {
+Dictionary EditorData::restore_edited_scene_state(EditorSelection *p_selection, EditorSelectionHistory *p_history) {
 	ERR_FAIL_INDEX_V(current_edited_scene, edited_scene.size(), Dictionary());
 
 	EditedScene &es = edited_scene.write[current_edited_scene];
 
-	p_history->current = es.history_current;
+	p_history->current_elem_idx = es.history_current;
 	p_history->history = es.history_stored;
 
 	p_selection->clear();
@@ -1033,12 +993,11 @@ void EditorData::script_class_load_icon_paths() {
 
 EditorData::EditorData() {
 	current_edited_scene = -1;
-
-	//load_imported_scenes_from_globals();
 	script_class_load_icon_paths();
 }
 
-///////////
+///////////////////////////////////////////////////////////////////////////////
+
 void EditorSelection::_node_removed(Node *p_node) {
 	if (!selection.has(p_node)) {
 		return;
@@ -1050,7 +1009,7 @@ void EditorSelection::_node_removed(Node *p_node) {
 	}
 	selection.erase(p_node);
 	changed = true;
-	nl_changed = true;
+	node_list_changed = true;
 }
 
 void EditorSelection::add_node(Node *p_node) {
@@ -1061,7 +1020,7 @@ void EditorSelection::add_node(Node *p_node) {
 	}
 
 	changed = true;
-	nl_changed = true;
+	node_list_changed = true;
 	Object *meta = nullptr;
 	for (Object *E : editor_plugins) {
 		meta = E->call("_get_editor_data", p_node);
@@ -1072,30 +1031,90 @@ void EditorSelection::add_node(Node *p_node) {
 	selection[p_node] = meta;
 
 	p_node->connect("tree_exiting", callable_mp(this, &EditorSelection::_node_removed), varray(p_node), CONNECT_ONESHOT);
-
-	//emit_signal(SNAME("selection_changed"));
 }
 
 void EditorSelection::remove_node(Node *p_node) {
 	ERR_FAIL_NULL(p_node);
-
 	if (!selection.has(p_node)) {
 		return;
 	}
 
 	changed = true;
-	nl_changed = true;
+	node_list_changed = true;
 	Object *meta = selection[p_node];
 	if (meta) {
 		memdelete(meta);
 	}
 	selection.erase(p_node);
+
 	p_node->disconnect("tree_exiting", callable_mp(this, &EditorSelection::_node_removed));
-	//emit_signal(SNAME("selection_changed"));
 }
 
 bool EditorSelection::is_selected(Node *p_node) const {
 	return selection.has(p_node);
+}
+
+void EditorSelection::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("clear"), &EditorSelection::clear);
+	ClassDB::bind_method(D_METHOD("add_node", "node"), &EditorSelection::add_node);
+	ClassDB::bind_method(D_METHOD("remove_node", "node"), &EditorSelection::remove_node);
+	ClassDB::bind_method(D_METHOD("get_selected_nodes"), &EditorSelection::get_selected_nodes);
+	ClassDB::bind_method(D_METHOD("get_transformable_selected_nodes"), &EditorSelection::_get_transformable_selected_nodes);
+	ClassDB::bind_method(D_METHOD("_emit_change"), &EditorSelection::_emit_change);
+	ADD_SIGNAL(MethodInfo("selection_changed"));
+}
+
+void EditorSelection::add_editor_plugin(Object *p_object) {
+	editor_plugins.push_back(p_object);
+}
+
+void EditorSelection::_update_node_list() {
+	if (!node_list_changed) {
+		return;
+	}
+
+	selected_node_list.clear();
+
+	// If the selection does not have the parent of the selected node, then add the node to the node list.
+	// However, if the parent is already selected, then adding this node is redundant as
+	// it is included with the parent, so skip it.
+	for (const KeyValue<Node *, Object *> &E : selection) {
+		Node *parent = E.key;
+		parent = parent->get_parent();
+		bool skip = false;
+		while (parent) {
+			if (selection.has(parent)) {
+				skip = true;
+				break;
+			}
+			parent = parent->get_parent();
+		}
+
+		if (skip) {
+			continue;
+		}
+		selected_node_list.push_back(E.key);
+	}
+
+	node_list_changed = true;
+}
+
+void EditorSelection::update() {
+	_update_node_list();
+
+	if (!changed) {
+		return;
+	}
+	changed = false;
+	if (!emitted) {
+		emitted = true;
+		call_deferred(SNAME("_emit_change"));
+	}
+}
+
+void EditorSelection::_emit_change() {
+	emit_signal(SNAME("selection_changed"));
+	emitted = false;
 }
 
 Array EditorSelection::_get_transformable_selected_nodes() {
@@ -1118,71 +1137,11 @@ TypedArray<Node> EditorSelection::get_selected_nodes() {
 	return ret;
 }
 
-void EditorSelection::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("clear"), &EditorSelection::clear);
-	ClassDB::bind_method(D_METHOD("add_node", "node"), &EditorSelection::add_node);
-	ClassDB::bind_method(D_METHOD("remove_node", "node"), &EditorSelection::remove_node);
-	ClassDB::bind_method(D_METHOD("get_selected_nodes"), &EditorSelection::get_selected_nodes);
-	ClassDB::bind_method(D_METHOD("get_transformable_selected_nodes"), &EditorSelection::_get_transformable_selected_nodes);
-	ClassDB::bind_method(D_METHOD("_emit_change"), &EditorSelection::_emit_change);
-	ADD_SIGNAL(MethodInfo("selection_changed"));
-}
-
-void EditorSelection::add_editor_plugin(Object *p_object) {
-	editor_plugins.push_back(p_object);
-}
-
-void EditorSelection::_update_nl() {
-	if (!nl_changed) {
-		return;
-	}
-
-	selected_node_list.clear();
-
-	for (const KeyValue<Node *, Object *> &E : selection) {
-		Node *parent = E.key;
-		parent = parent->get_parent();
-		bool skip = false;
-		while (parent) {
-			if (selection.has(parent)) {
-				skip = true;
-				break;
-			}
-			parent = parent->get_parent();
-		}
-
-		if (skip) {
-			continue;
-		}
-		selected_node_list.push_back(E.key);
-	}
-
-	nl_changed = true;
-}
-
-void EditorSelection::update() {
-	_update_nl();
-
-	if (!changed) {
-		return;
-	}
-	changed = false;
-	if (!emitted) {
-		emitted = true;
-		call_deferred(SNAME("_emit_change"));
-	}
-}
-
-void EditorSelection::_emit_change() {
-	emit_signal(SNAME("selection_changed"));
-	emitted = false;
-}
-
 List<Node *> &EditorSelection::get_selected_node_list() {
 	if (changed) {
 		update();
 	} else {
-		_update_nl();
+		_update_node_list();
 	}
 	return selected_node_list;
 }
@@ -1202,7 +1161,7 @@ void EditorSelection::clear() {
 	}
 
 	changed = true;
-	nl_changed = true;
+	node_list_changed = true;
 }
 
 EditorSelection::EditorSelection() {

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -225,17 +225,17 @@ void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vecto
 		index_sets.write[scene_name_to_set_index[scene_name]].insert(i);
 	}
 
-	// For each index set with a size > 1, we need to disambiguate
+	// For each index set with a size > 1, we need to disambiguate.
 	for (int i = 0; i < index_sets.size(); i++) {
 		Set<int> iset = index_sets[i];
 		while (iset.size() > 1) {
-			// Append the parent folder to each scene name
+			// Append the parent folder to each scene name.
 			for (Set<int>::Element *E = iset.front(); E; E = E->next()) {
 				int set_idx = E->get();
 				String scene_name = r_filenames[set_idx];
 				String full_path = p_full_paths[set_idx];
 
-				// Get rid of file extensions and res:// prefixes
+				// Get rid of file extensions and res:// prefixes.
 				if (scene_name.rfind(".") >= 0) {
 					scene_name = scene_name.substr(0, scene_name.rfind("."));
 				}
@@ -263,7 +263,7 @@ void EditorNode::disambiguate_filenames(const Vector<String> p_full_paths, Vecto
 				}
 			}
 
-			// Loop back through scene names and remove non-ambiguous names
+			// Loop back through scene names and remove non-ambiguous names.
 			bool can_proceed = false;
 			Set<int>::Element *E = iset.front();
 			while (E) {
@@ -648,7 +648,7 @@ void EditorNode::_notification(int p_what) {
 		case NOTIFICATION_EXIT_TREE: {
 			editor_data.save_editor_external_data();
 			FileAccess::set_file_close_fail_notify_callback(nullptr);
-			log->deinit(); // do not get messages anymore
+			log->deinit(); // Do not get messages anymore.
 			editor_data.clear_edited_scenes();
 		} break;
 
@@ -658,7 +658,7 @@ void EditorNode::_notification(int p_what) {
 
 		case NOTIFICATION_READY: {
 			{
-				_initializing_addons = true;
+				_initializing_plugins = true;
 				Vector<String> addons;
 				if (ProjectSettings::get_singleton()->has_setting("editor_plugins/enabled")) {
 					addons = ProjectSettings::get_singleton()->get("editor_plugins/enabled");
@@ -667,7 +667,7 @@ void EditorNode::_notification(int p_what) {
 				for (int i = 0; i < addons.size(); i++) {
 					set_addon_plugin_enabled(addons[i], true);
 				}
-				_initializing_addons = false;
+				_initializing_plugins = false;
 			}
 
 			RenderingServer::get_singleton()->viewport_set_disable_2d(get_scene_root()->get_viewport_rid(), true);
@@ -745,12 +745,12 @@ void EditorNode::_notification(int p_what) {
 
 			recent_scenes->reset_size();
 
-			// debugger area
+			// Update debugger area.
 			if (EditorDebuggerNode::get_singleton()->is_visible()) {
 				bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles")));
 			}
 
-			// update_icons
+			// Update icons.
 			for (int i = 0; i < singleton->main_editor_buttons.size(); i++) {
 				Button *tb = singleton->main_editor_buttons[i];
 				EditorPlugin *p_editor = singleton->editor_table[i];
@@ -893,7 +893,7 @@ void EditorNode::_resources_changed(const Vector<String> &p_resources) {
 		}
 
 		if (!res->get_import_path().is_empty()) {
-			// this is an imported resource, will be reloaded if reimported via the _resources_reimported() callback
+			// This is an imported resource, will be reloaded if reimported via the _resources_reimported() callback.
 			continue;
 		}
 
@@ -918,23 +918,23 @@ void EditorNode::_fs_changed() {
 
 	_mark_unsaved_scenes();
 
-	// FIXME: Move this to a cleaner location, it's hacky to do this is _fs_changed.
+	// FIXME: Move this to a cleaner location, it's hacky to do this in _fs_changed.
 	String export_error;
 	if (!export_defer.preset.is_empty() && !EditorFileSystem::get_singleton()->is_scanning()) {
 		String preset_name = export_defer.preset;
 		// Ensures export_project does not loop infinitely, because notifications may
 		// come during the export.
 		export_defer.preset = "";
-		Ref<EditorExportPreset> preset;
+		Ref<EditorExportPreset> export_preset;
 		for (int i = 0; i < EditorExport::get_singleton()->get_export_preset_count(); ++i) {
-			preset = EditorExport::get_singleton()->get_export_preset(i);
-			if (preset->get_name() == preset_name) {
+			export_preset = EditorExport::get_singleton()->get_export_preset(i);
+			if (export_preset->get_name() == preset_name) {
 				break;
 			}
-			preset.unref();
+			export_preset.unref();
 		}
 
-		if (preset.is_null()) {
+		if (export_preset.is_null()) {
 			DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 			if (da->file_exists("res://export_presets.cfg")) {
 				export_error = vformat(
@@ -948,8 +948,8 @@ void EditorNode::_fs_changed() {
 				export_error = "This project doesn't have an `export_presets.cfg` file at its root.\nCreate an export preset from the \"Project > Export\" dialog and try again.";
 			}
 		} else {
-			Ref<EditorExportPlatform> platform = preset->get_platform();
-			const String export_path = export_defer.path.is_empty() ? preset->get_export_path() : export_defer.path;
+			Ref<EditorExportPlatform> platform = export_preset->get_platform();
+			const String export_path = export_defer.path.is_empty() ? export_preset->get_export_path() : export_defer.path;
 			if (export_path.is_empty()) {
 				export_error = vformat("Export preset \"%s\" doesn't have a default export path, and none was specified.", preset_name);
 			} else if (platform.is_null()) {
@@ -958,18 +958,18 @@ void EditorNode::_fs_changed() {
 				Error err = OK;
 				if (export_defer.pack_only) { // Only export .pck or .zip data pack.
 					if (export_path.ends_with(".zip")) {
-						err = platform->export_zip(preset, export_defer.debug, export_path);
+						err = platform->export_zip(export_preset, export_defer.debug, export_path);
 					} else if (export_path.ends_with(".pck")) {
-						err = platform->export_pack(preset, export_defer.debug, export_path);
+						err = platform->export_pack(export_preset, export_defer.debug, export_path);
 					}
 				} else { // Normal project export.
 					String config_error;
 					bool missing_templates;
-					if (!platform->can_export(preset, config_error, missing_templates)) {
+					if (!platform->can_export(export_preset, config_error, missing_templates)) {
 						ERR_PRINT(vformat("Cannot export project with preset \"%s\" due to configuration errors:\n%s", preset_name, config_error));
 						err = missing_templates ? ERR_FILE_NOT_FOUND : ERR_UNCONFIGURED;
 					} else {
-						err = platform->export_project(preset, export_defer.debug, export_path);
+						err = platform->export_project(export_preset, export_defer.debug, export_path);
 					}
 				}
 				switch (err) {
@@ -998,21 +998,22 @@ void EditorNode::_fs_changed() {
 }
 
 void EditorNode::_resources_reimported(const Vector<String> &p_resources) {
-	List<String> scenes; // will load later
+	List<String> scenes;
 	int current_tab = scene_tabs->get_current_tab();
 
 	for (int i = 0; i < p_resources.size(); i++) {
 		String file_type = ResourceLoader::get_resource_type(p_resources[i]);
 		if (file_type == "PackedScene") {
 			scenes.push_back(p_resources[i]);
-			// reload later if needed, first go with normal resources
+			// Reload later if needed, first go with normal resources.
 			continue;
 		}
 
 		if (!ResourceCache::has(p_resources[i])) {
-			continue; // not loaded, no need to reload
+			// Not loaded, no need to reload.
+			continue;
 		}
-		// reload normally
+		// Reload normally.
 		Resource *resource = ResourceCache::get(p_resources[i]);
 		if (resource) {
 			resource->reload_from_file();
@@ -1184,7 +1185,6 @@ Error EditorNode::load_resource(const String &p_resource, bool p_ignore_broken_d
 	ERR_FAIL_COND_V(!res.is_valid(), ERR_CANT_OPEN);
 
 	if (!p_ignore_broken_deps && dependency_errors.has(p_resource)) {
-		// current_option = -1;
 		Vector<String> errors;
 		for (Set<String>::Element *E = dependency_errors[p_resource].front(); E; E = E->next()) {
 			errors.push_back(E->get());
@@ -1251,7 +1251,7 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 	file->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
 	saving_resource = p_resource;
 
-	current_option = RESOURCE_SAVE_AS;
+	current_menu_option = RESOURCE_SAVE_AS;
 	List<String> extensions;
 	Ref<PackedScene> sd = memnew(PackedScene);
 	ResourceSaver::get_recognized_extensions(p_resource, &extensions);
@@ -1260,18 +1260,18 @@ void EditorNode::save_resource_as(const Ref<Resource> &p_resource, const String 
 	List<String> preferred;
 	for (const String &E : extensions) {
 		if (p_resource->is_class("Script") && (E == "tres" || E == "res")) {
-			// this serves no purpose and confused people
+			// This serves no purpose and confused people.
 			continue;
 		}
 		file->add_filter("*." + E + " ; " + E.to_upper());
 		preferred.push_back(E);
 	}
-	// Lowest priority extension
+	// Lowest priority extension.
 	List<String>::Element *res_element = preferred.find("res");
 	if (res_element) {
 		preferred.move_to_back(res_element);
 	}
-	// Highest priority extension
+	// Highest priority extension.
 	List<String>::Element *tres_element = preferred.find("tres");
 	if (tres_element) {
 		preferred.move_to_front(tres_element);
@@ -1314,7 +1314,7 @@ void EditorNode::_menu_option(int p_option) {
 }
 
 void EditorNode::_menu_confirm_current() {
-	_menu_option_confirm(current_option, true);
+	_menu_option_confirm(current_menu_option, true);
 }
 
 void EditorNode::_dialog_display_save_error(String p_file, Error p_error) {
@@ -1369,7 +1369,8 @@ void EditorNode::_get_scene_metadata(const String &p_file) {
 
 	Error err = cf->load(path);
 	if (err != OK || !cf->has_section("editor_states")) {
-		return; // must not exist
+		// Must not exist.
+		return;
 	}
 
 	List<String> esl;
@@ -1392,9 +1393,6 @@ void EditorNode::_set_scene_metadata(const String &p_file, int p_idx) {
 	if (!scene) {
 		return;
 	}
-
-	scene->set_meta("__editor_run_settings__", Variant()); // clear it (no point in keeping it)
-	scene->set_meta("__editor_plugin_states__", Variant());
 
 	String path = EditorSettings::get_singleton()->get_project_settings_dir().plus_file(p_file.get_file() + "-editstate-" + p_file.md5_text() + ".cfg");
 
@@ -1436,10 +1434,9 @@ bool EditorNode::_find_and_save_resource(RES p_res, Map<RES, bool> &processed, i
 
 	if (p_res->get_path().is_resource_file()) {
 		if (changed || subchanged) {
-			// save
 			ResourceSaver::save(p_res->get_path(), p_res, flags);
 		}
-		processed[p_res] = false; // because it's a file
+		processed[p_res] = false; // Because it's a file.
 		return false;
 	} else {
 		processed[p_res] = changed;
@@ -1537,7 +1534,7 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 		_find_node_types(editor_data.get_edited_scene_root(), c2d, c3d);
 
 		save.step(TTR("Creating Thumbnail"), 1);
-		// current view?
+		// Current view?
 
 		Ref<Image> img;
 		// If neither 3D or 2D nodes are present, make a 1x1 black texture.
@@ -1570,13 +1567,13 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			int preview_size = EditorSettings::get_singleton()->get("filesystem/file_dialog/thumbnail_size");
 			preview_size *= EDSCALE;
 
-			// consider a square region
+			// Consider a square region.
 			int vp_size = MIN(img->get_width(), img->get_height());
 			int x = (img->get_width() - vp_size) / 2;
 			int y = (img->get_height() - vp_size) / 2;
 
 			if (vp_size < preview_size) {
-				// just square it.
+				// Just square it.
 				img->crop_from_point(x, y, vp_size, vp_size);
 			} else {
 				int ratio = vp_size / preview_size;
@@ -1590,13 +1587,12 @@ void EditorNode::_save_scene_with_preview(String p_file, int p_idx) {
 			}
 			img->convert(Image::FORMAT_RGB8);
 
-			// save thumbnail directly, as thumbnailer may not update due to actual scene not changing md5
+			// Save thumbnail directly, as thumbnailer may not update due to actual scene not changing md5.
 			String temp_path = EditorPaths::get_singleton()->get_cache_dir();
 			String cache_base = ProjectSettings::get_singleton()->globalize_path(p_file).md5_text();
 			cache_base = temp_path.plus_file("resthumb-" + cache_base);
 
-			// does not have it, try to load a cached thumbnail
-
+			// Does not have it, try to load a cached thumbnail.
 			String file = cache_base + ".png";
 
 			post_process_preview(img);
@@ -1643,7 +1639,7 @@ static bool _find_edited_resources(const Ref<Resource> &p_resource, Set<Ref<Reso
 			if (res.is_null()) {
 				continue;
 			}
-			if (res->get_path().is_resource_file()) { // not a subresource, continue
+			if (res->get_path().is_resource_file()) { // Not a subresource, continue.
 				continue;
 			}
 			if (_find_edited_resources(res, edited_resources)) {
@@ -1656,7 +1652,7 @@ static bool _find_edited_resources(const Ref<Resource> &p_resource, Set<Ref<Reso
 }
 
 int EditorNode::_save_external_resources() {
-	// save external resources and its subresources if any was modified
+	// Save external resources and its subresources if any was modified.
 
 	int flg = 0;
 	if (EditorSettings::get_singleton()->get("filesystem/on_save/compress_binary_resources")) {
@@ -1679,8 +1675,8 @@ int EditorNode::_save_external_resources() {
 		}
 	}
 
-	// clear later, because user may have put the same subresource in two different resources,
-	// which will be shared until the next reload
+	// Clear later, because user may have put the same subresource in two different resources,
+	// which will be shared until the next reload.
 
 	for (Set<Ref<Resource>>::Element *E = edited_subresources.front(); E; E = E->next()) {
 		Ref<Resource> res = E->get();
@@ -1728,9 +1724,9 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	Ref<PackedScene> sdata;
 
 	if (ResourceCache::has(p_file)) {
-		// something may be referencing this resource and we are good with that.
-		// we must update it, but also let the previous scene state go, as
-		// old version still work for referencing changes in instantiated or inherited scenes
+		// Something may be referencing this resource and we are good with that.
+		// We must update it, but also let the previous scene state go, as
+		// old version still work for referencing changes in instantiated or inherited scenes.
 
 		sdata = Ref<PackedScene>(Object::cast_to<PackedScene>(ResourceCache::get(p_file)));
 		if (sdata.is_valid()) {
@@ -1867,7 +1863,7 @@ void EditorNode::_mark_unsaved_scenes() {
 }
 
 void EditorNode::_dialog_action(String p_file) {
-	switch (current_option) {
+	switch (current_menu_option) {
 		case FILE_NEW_INHERITED_SCENE: {
 			Node *scene = editor_data.get_edited_scene_root();
 			// If the previous scene is rootless, just close it in favor of the new one.
@@ -1883,12 +1879,12 @@ void EditorNode::_dialog_action(String p_file) {
 		case SETTINGS_PICK_MAIN_SCENE: {
 			ProjectSettings::get_singleton()->set("application/run/main_scene", p_file);
 			ProjectSettings::get_singleton()->save();
-			// would be nice to show the project manager opened with the highlighted field..
+			// TODO: Would be nice to show the project manager opened with the highlighted field.
 
 			if (pick_main_scene->has_meta("from_native") && (bool)pick_main_scene->get_meta("from_native")) {
 				run_native->resume_run_native();
 			} else {
-				_run(false, ""); // automatically run the project
+				_run(false, ""); // Automatically run the project.
 			}
 		} break;
 		case FILE_CLOSE:
@@ -1898,7 +1894,7 @@ void EditorNode::_dialog_action(String p_file) {
 		case SCENE_TAB_CLOSE:
 		case FILE_SAVE_SCENE:
 		case FILE_SAVE_AS_SCENE: {
-			int scene_idx = (current_option == FILE_SAVE_SCENE || current_option == FILE_SAVE_AS_SCENE) ? -1 : tab_closing;
+			int scene_idx = (current_menu_option == FILE_SAVE_SCENE || current_menu_option == FILE_SAVE_AS_SCENE) ? -1 : tab_closing_idx;
 
 			if (file->get_file_mode() == EditorFileDialog::FILE_MODE_SAVE_FILE) {
 				bool same_open_scene = false;
@@ -1978,7 +1974,7 @@ void EditorNode::_dialog_action(String p_file) {
 			Error err = config->load(EditorSettings::get_singleton()->get_editor_layouts_config());
 
 			if (err == ERR_FILE_CANT_OPEN || err == ERR_FILE_NOT_FOUND) {
-				config.instantiate(); // new config
+				config.instantiate();
 			} else if (err != OK) {
 				show_warning(TTR("An error occurred while trying to save the editor layout.\nMake sure the editor's user data path is writable."));
 				return;
@@ -2010,11 +2006,11 @@ void EditorNode::_dialog_action(String p_file) {
 				return;
 			}
 
-			// erase
+			// Erase key values.
 			List<String> keys;
 			config->get_section_keys(p_file, &keys);
-			for (const String &E : keys) {
-				config->set_value(p_file, E, Variant());
+			for (const String &key : keys) {
+				config->set_value(p_file, key, Variant());
 			}
 
 			config->save(EditorSettings::get_singleton()->get_editor_layouts_config());
@@ -2027,8 +2023,8 @@ void EditorNode::_dialog_action(String p_file) {
 			}
 
 		} break;
-		default: { // save scene?
-
+		default: {
+			// Save scene?
 			if (file->get_file_mode() == EditorFileDialog::FILE_MODE_SAVE_FILE) {
 				_save_scene_with_preview(p_file);
 			}
@@ -2115,7 +2111,7 @@ void EditorNode::push_item(Object *p_object, const String &p_property, bool p_in
 	ObjectID id = p_object->get_instance_id();
 	if (id != editor_history.get_current()) {
 		if (p_inspector_only) {
-			editor_history.add_object_inspector_only(id);
+			editor_history.add_object(id, String(), true);
 		} else if (p_property.is_empty()) {
 			editor_history.add_object(id);
 		} else {
@@ -2196,7 +2192,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 	bool is_resource = current_obj->is_class("Resource");
 	bool is_node = current_obj->is_class("Node");
 
-	String editable_warning; // none by default
+	String editable_warning; // None by default.
 
 	if (is_resource) {
 		Resource *current_res = Object::cast_to<Resource>(current_obj);
@@ -2264,7 +2260,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 						}
 					}
 					if (!multi_nodes.is_empty()) {
-						// Pick the top-most node
+						// Pick the top-most node.
 						multi_nodes.sort_custom<Node::Comparator>();
 						selected_node = multi_nodes.front()->get();
 					}
@@ -2289,7 +2285,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 		InspectorDock::get_inspector_singleton()->set_use_folding(!disable_folding);
 	}
 
-	/* Take care of PLUGIN EDITOR */
+	// Take care of the main editor plugin.
 
 	if (!inspector_only) {
 		EditorPlugin *main_plugin = editor_data.get_editor(current_obj);
@@ -2298,7 +2294,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 		for (; plugin_index < editor_table.size(); plugin_index++) {
 			if (editor_table[plugin_index] == main_plugin) {
 				if (!main_editor_buttons[plugin_index]->is_visible()) {
-					main_plugin = nullptr; // if button is not visible, then no plugin active
+					main_plugin = nullptr; // If button is not visible, then no plugin is active.
 				}
 
 				break;
@@ -2306,7 +2302,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 		}
 
 		if (main_plugin) {
-			// special case if use of external editor is true
+			// Special case if use of external editor is true.
 			Resource *current_res = Object::cast_to<Resource>(current_obj);
 			if (main_plugin->get_name() == "Script" && current_obj->is_class("VisualScript") && current_res && !current_res->is_built_in() && (bool(EditorSettings::get_singleton()->get("text_editor/external/use_external_editor")) || overrides_external_editor(current_obj))) {
 				if (!changing_scene) {
@@ -2315,7 +2311,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 			}
 
 			else if (main_plugin != editor_plugin_screen && (!ScriptEditor::get_singleton() || !ScriptEditor::get_singleton()->is_visible_in_tree() || ScriptEditor::get_singleton()->can_take_away_focus())) {
-				// update screen main_plugin
+				// Update screen main_plugin.
 				_editor_select(plugin_index);
 				main_plugin->edit(current_obj);
 			} else {
@@ -2368,10 +2364,10 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 		}
 
 		if (scene->get_scene_file_path().is_empty()) {
-			current_option = -1;
+			current_menu_option = -1;
 			_menu_option(FILE_SAVE_AS_SCENE);
 			// Set the option to save and run so when the dialog is accepted, the scene runs.
-			current_option = FILE_SAVE_AND_RUN;
+			current_menu_option = FILE_SAVE_AND_RUN;
 			file->set_title(TTR("Save scene before running..."));
 			return;
 		}
@@ -2382,7 +2378,7 @@ void EditorNode::_run(bool p_current, const String &p_custom) {
 	}
 
 	if (run_filename.is_empty()) {
-		// evidently, run the scene
+		// Evidently, run the scene.
 		if (!ensure_main_scene(false)) {
 			return;
 		}
@@ -2446,7 +2442,7 @@ void EditorNode::_run_native(const Ref<EditorExportPreset> &p_preset) {
 		_menu_option_confirm(RUN_STOP, true);
 
 		if (!call_build()) {
-			return; // build failed
+			return; // Build failed.
 		}
 
 		EditorDebuggerNode::get_singleton()->start(p_preset->get_platform()->get_debug_protocol());
@@ -2459,8 +2455,8 @@ void EditorNode::_android_build_source_selected(const String &p_file) {
 	export_template_manager->install_android_template_from_file(p_file);
 }
 void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
-	if (!p_confirmed) { // this may be a hack..
-		current_option = (MenuOptions)p_option;
+	if (!p_confirmed) { // FIXME: this may be a hack.
+		current_menu_option = (MenuOptions)p_option;
 	}
 
 	switch (p_option) {
@@ -2513,13 +2509,13 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case FILE_CLOSE_OTHERS:
 		case FILE_CLOSE_RIGHT:
 		case FILE_CLOSE_ALL: {
-			if (editor_data.get_edited_scene_count() > 1 && (current_option != FILE_CLOSE_RIGHT || editor_data.get_edited_scene() < editor_data.get_edited_scene_count() - 1)) {
+			if (editor_data.get_edited_scene_count() > 1 && (current_menu_option != FILE_CLOSE_RIGHT || editor_data.get_edited_scene() < editor_data.get_edited_scene_count() - 1)) {
 				int next_tab = editor_data.get_edited_scene() + 1;
 				next_tab %= editor_data.get_edited_scene_count();
-				_scene_tab_closed(next_tab, current_option);
+				_scene_tab_closed(next_tab, current_menu_option);
 			} else {
-				if (current_option != FILE_CLOSE_ALL) {
-					current_option = -1;
+				if (current_menu_option != FILE_CLOSE_ALL) {
+					current_menu_option = -1;
 				} else {
 					_scene_tab_closed(editor_data.get_edited_scene());
 				}
@@ -2537,11 +2533,11 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case FILE_CLOSE_ALL_AND_RUN_PROJECT_MANAGER:
 		case FILE_CLOSE_ALL_AND_RELOAD_CURRENT_PROJECT: {
 			if (!p_confirmed) {
-				tab_closing = _next_unsaved_scene(false);
-				_scene_tab_changed(tab_closing);
+				tab_closing_idx = _next_unsaved_scene(false);
+				_scene_tab_changed(tab_closing_idx);
 
 				if (unsaved_cache || p_option == FILE_CLOSE_ALL_AND_QUIT || p_option == FILE_CLOSE_ALL_AND_RUN_PROJECT_MANAGER || p_option == FILE_CLOSE_ALL_AND_RELOAD_CURRENT_PROJECT) {
-					Node *scene_root = editor_data.get_edited_scene_root(tab_closing);
+					Node *scene_root = editor_data.get_edited_scene_root(tab_closing_idx);
 					if (scene_root) {
 						String scene_filename = scene_root->get_scene_file_path();
 						if (p_option == FILE_CLOSE_ALL_AND_RELOAD_CURRENT_PROJECT) {
@@ -2556,9 +2552,9 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 					}
 				}
 			}
-			if (!editor_data.get_edited_scene_root(tab_closing)) {
-				// empty tab
-				_scene_tab_closed(tab_closing);
+			if (!editor_data.get_edited_scene_root(tab_closing_idx)) {
+				// Empty tab.
+				_scene_tab_closed(tab_closing_idx);
 				break;
 			}
 
@@ -2566,7 +2562,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		}
 		case SCENE_TAB_CLOSE:
 		case FILE_SAVE_SCENE: {
-			int scene_idx = (p_option == FILE_SAVE_SCENE) ? -1 : tab_closing;
+			int scene_idx = (p_option == FILE_SAVE_SCENE) ? -1 : tab_closing_idx;
 			Node *scene = editor_data.get_edited_scene_root(scene_idx);
 			if (scene && !scene->get_scene_file_path().is_empty()) {
 				if (DirAccess::exists(scene->get_scene_file_path().get_base_dir())) {
@@ -2588,7 +2584,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			[[fallthrough]];
 		}
 		case FILE_SAVE_AS_SCENE: {
-			int scene_idx = (p_option == FILE_SAVE_SCENE || p_option == FILE_SAVE_AS_SCENE) ? -1 : tab_closing;
+			int scene_idx = (p_option == FILE_SAVE_SCENE || p_option == FILE_SAVE_AS_SCENE) ? -1 : tab_closing_idx;
 
 			Node *scene = editor_data.get_edited_scene_root(scene_idx);
 
@@ -2829,7 +2825,7 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 			}
 		} break;
 		case RUN_USER_DATA_FOLDER: {
-			// ensure_user_data_dir() to prevent the edge case: "Open User Data Folder" won't work after the project was renamed in ProjectSettingsEditor unless the project is saved
+			// Ensure_user_data_dir() to prevent the edge case: "Open User Data Folder" won't work after the project was renamed in ProjectSettingsEditor unless the project is saved.
 			OS::get_singleton()->ensure_user_data_dir();
 			OS::get_singleton()->shell_open(String("file://") + OS::get_singleton()->get_user_data_dir());
 		} break;
@@ -2967,12 +2963,6 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 		case HELP_SUPPORT_GODOT_DEVELOPMENT: {
 			OS::get_singleton()->shell_open("https://godotengine.org/donate");
 		} break;
-
-			//		case SET_VIDEO_DRIVER_SAVE_AND_RESTART: {
-			//			ProjectSettings::get_singleton()->set("rendering/driver/driver_name", video_driver_request);
-			//			save_all_scenes();
-			//			restart_editor();
-			//		} break;
 		case SET_RENDERING_DRIVER_SAVE_AND_RESTART: {
 			ProjectSettings::get_singleton()->set("rendering/driver/driver_name", rendering_driver_request);
 			ProjectSettings::get_singleton()->save();
@@ -3025,7 +3015,7 @@ void EditorNode::_tool_menu_option(int p_idx) {
 					String err = Variant::get_callable_error_text(callback, nullptr, 0, ce);
 					ERR_PRINT("Error calling function from tool menu: " + err);
 				}
-			} // else it's a submenu so don't do anything.
+			} // Else it's a submenu so don't do anything.
 		} break;
 	}
 }
@@ -3050,17 +3040,17 @@ int EditorNode::_next_unsaved_scene(bool p_valid_filename, int p_start) {
 
 void EditorNode::_exit_editor(int p_exit_code) {
 	exiting = true;
-	resource_preview->stop(); // stop early to avoid crashes
+	resource_preview->stop(); // Stop early to avoid crashes.
 	_save_docks();
 
-	// Dim the editor window while it's quitting to make it clearer that it's busy
+	// Dim the editor window while it's quitting to make it clearer that it's busy.
 	dim_editor(true);
 
 	get_tree()->quit(p_exit_code);
 }
 
 void EditorNode::_discard_changes(const String &p_str) {
-	switch (current_option) {
+	switch (current_menu_option) {
 		case FILE_CLOSE_ALL_AND_QUIT:
 		case FILE_CLOSE_ALL_AND_RUN_PROJECT_MANAGER:
 		case FILE_CLOSE_ALL_AND_RELOAD_CURRENT_PROJECT:
@@ -3069,7 +3059,7 @@ void EditorNode::_discard_changes(const String &p_str) {
 		case FILE_CLOSE_RIGHT:
 		case FILE_CLOSE_ALL:
 		case SCENE_TAB_CLOSE: {
-			Node *scene = editor_data.get_edited_scene_root(tab_closing);
+			Node *scene = editor_data.get_edited_scene_root(tab_closing_idx);
 			if (scene != nullptr) {
 				String scene_filename = scene->get_scene_file_path();
 				if (!scene_filename.is_empty()) {
@@ -3077,37 +3067,37 @@ void EditorNode::_discard_changes(const String &p_str) {
 				}
 			}
 
-			_remove_scene(tab_closing);
+			_remove_scene(tab_closing_idx);
 			_update_scene_tabs();
 
-			if (current_option == FILE_CLOSE_ALL_AND_QUIT || current_option == FILE_CLOSE_ALL_AND_RUN_PROJECT_MANAGER || current_option == FILE_CLOSE_ALL_AND_RELOAD_CURRENT_PROJECT) {
+			if (current_menu_option == FILE_CLOSE_ALL_AND_QUIT || current_menu_option == FILE_CLOSE_ALL_AND_RUN_PROJECT_MANAGER || current_menu_option == FILE_CLOSE_ALL_AND_RELOAD_CURRENT_PROJECT) {
 				// If restore tabs is enabled, reopen the scene that has just been closed, so it's remembered properly.
 				if (bool(EDITOR_GET("interface/scene_tabs/restore_scenes_on_load"))) {
 					_menu_option_confirm(FILE_OPEN_PREV, true);
 				}
 				if (_next_unsaved_scene(false) == -1) {
-					if (current_option == FILE_CLOSE_ALL_AND_RELOAD_CURRENT_PROJECT) {
-						current_option = RELOAD_CURRENT_PROJECT;
-					} else if (current_option == FILE_CLOSE_ALL_AND_QUIT) {
-						current_option = FILE_QUIT;
+					if (current_menu_option == FILE_CLOSE_ALL_AND_RELOAD_CURRENT_PROJECT) {
+						current_menu_option = RELOAD_CURRENT_PROJECT;
+					} else if (current_menu_option == FILE_CLOSE_ALL_AND_QUIT) {
+						current_menu_option = FILE_QUIT;
 					} else {
-						current_option = RUN_PROJECT_MANAGER;
+						current_menu_option = RUN_PROJECT_MANAGER;
 					}
 					_discard_changes();
 				} else {
-					_menu_option_confirm(current_option, false);
+					_menu_option_confirm(current_menu_option, false);
 				}
-			} else if (current_option == FILE_CLOSE_OTHERS || current_option == FILE_CLOSE_RIGHT) {
-				if (editor_data.get_edited_scene_count() == 1 || (current_option == FILE_CLOSE_RIGHT && editor_data.get_edited_scene_count() <= editor_data.get_edited_scene() + 1)) {
-					current_option = -1;
+			} else if (current_menu_option == FILE_CLOSE_OTHERS || current_menu_option == FILE_CLOSE_RIGHT) {
+				if (editor_data.get_edited_scene_count() == 1 || (current_menu_option == FILE_CLOSE_RIGHT && editor_data.get_edited_scene_count() <= editor_data.get_edited_scene() + 1)) {
+					current_menu_option = -1;
 					save_confirmation->hide();
 				} else {
-					_menu_option_confirm(current_option, false);
+					_menu_option_confirm(current_menu_option, false);
 				}
-			} else if (current_option == FILE_CLOSE_ALL && editor_data.get_edited_scene_count() > 0) {
-				_menu_option_confirm(current_option, false);
+			} else if (current_menu_option == FILE_CLOSE_ALL && editor_data.get_edited_scene_count() > 0) {
+				_menu_option_confirm(current_menu_option, false);
 			} else {
-				current_option = -1;
+				current_menu_option = -1;
 				save_confirmation->hide();
 			}
 		} break;
@@ -3166,7 +3156,7 @@ void EditorNode::_editor_select(int p_which) {
 
 	ERR_FAIL_INDEX(p_which, editor_table.size());
 
-	if (!main_editor_buttons[p_which]->is_visible()) { // button hidden, no editor
+	if (!main_editor_buttons[p_which]->is_visible()) { // Button hidden, no editor.
 		return;
 	}
 
@@ -3200,9 +3190,9 @@ void EditorNode::_editor_select(int p_which) {
 
 	if (EditorSettings::get_singleton()->get("interface/editor/separate_distraction_mode")) {
 		if (p_which == EDITOR_SCRIPT) {
-			set_distraction_free_mode(script_distraction);
+			set_distraction_free_mode(script_distraction_free);
 		} else {
-			set_distraction_free_mode(scene_distraction);
+			set_distraction_free_mode(scene_distraction_free);
 		}
 	}
 }
@@ -3282,13 +3272,13 @@ void EditorNode::remove_editor_plugin(EditorPlugin *p_editor, bool p_config_chan
 }
 
 void EditorNode::_update_addon_config() {
-	if (_initializing_addons) {
+	if (_initializing_plugins) {
 		return;
 	}
 
 	Vector<String> enabled_addons;
 
-	for (const KeyValue<String, EditorPlugin *> &E : plugin_addons) {
+	for (const KeyValue<String, EditorPlugin *> &E : addon_name_to_plugin) {
 		enabled_addons.push_back(E.key);
 	}
 
@@ -3302,14 +3292,14 @@ void EditorNode::_update_addon_config() {
 }
 
 void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled, bool p_config_changed) {
-	ERR_FAIL_COND(p_enabled && plugin_addons.has(p_addon));
-	ERR_FAIL_COND(!p_enabled && !plugin_addons.has(p_addon));
+	ERR_FAIL_COND(p_enabled && addon_name_to_plugin.has(p_addon));
+	ERR_FAIL_COND(!p_enabled && !addon_name_to_plugin.has(p_addon));
 
 	if (!p_enabled) {
-		EditorPlugin *addon = plugin_addons[p_addon];
+		EditorPlugin *addon = addon_name_to_plugin[p_addon];
 		remove_editor_plugin(addon, p_config_changed);
-		memdelete(addon); // bye
-		plugin_addons.erase(p_addon);
+		memdelete(addon);
+		addon_name_to_plugin.erase(p_addon);
 		_update_addon_config();
 		return;
 	}
@@ -3366,14 +3356,14 @@ void EditorNode::set_addon_plugin_enabled(const String &p_addon, bool p_enabled,
 
 	EditorPlugin *ep = memnew(EditorPlugin);
 	ep->set_script(script);
-	plugin_addons[p_addon] = ep;
+	addon_name_to_plugin[p_addon] = ep;
 	add_editor_plugin(ep, p_config_changed);
 
 	_update_addon_config();
 }
 
 bool EditorNode::is_addon_plugin_enabled(const String &p_addon) const {
-	return plugin_addons.has(p_addon);
+	return addon_name_to_plugin.has(p_addon);
 }
 
 void EditorNode::_remove_edited_scene(bool p_change_tab) {
@@ -3400,10 +3390,10 @@ void EditorNode::_remove_edited_scene(bool p_change_tab) {
 
 void EditorNode::_remove_scene(int index, bool p_change_tab) {
 	if (editor_data.get_edited_scene() == index) {
-		// Scene to remove is current scene
+		// Scene to remove is current scene.
 		_remove_edited_scene(p_change_tab);
 	} else {
-		// Scene to remove is not active scene
+		// Scene to remove is not active scene.
 		editor_data.remove_scene(index);
 	}
 }
@@ -3417,7 +3407,7 @@ void EditorNode::set_edited_scene(Node *p_scene) {
 	get_editor_data().set_edited_scene_root(p_scene);
 
 	if (Object::cast_to<Popup>(p_scene)) {
-		Object::cast_to<Popup>(p_scene)->show(); // show popups
+		Object::cast_to<Popup>(p_scene)->show();
 	}
 	SceneTreeDock::get_singleton()->set_edited_scene(p_scene);
 	if (get_tree()) {
@@ -3453,7 +3443,7 @@ Dictionary EditorNode::_get_main_scene_state() {
 
 void EditorNode::_set_main_scene_state(Dictionary p_state, Node *p_for_scene) {
 	if (get_edited_scene() != p_for_scene && p_for_scene != nullptr) {
-		return; // not for this scene
+		return; // Not for this scene.
 	}
 
 	changing_scene = false;
@@ -3468,7 +3458,7 @@ void EditorNode::_set_main_scene_state(Dictionary p_state, Node *p_for_scene) {
 
 	if (p_state.has("editor_index")) {
 		int index = p_state["editor_index"];
-		if (current < 2) { // if currently in spatial/2d, only switch to spatial/2d. if currently in script, stay there
+		if (current < 2) { // If currently in spatial/2d, only switch to spatial/2d. If currently in script, stay there.
 			if (index < 2 || !get_edited_scene()) {
 				_editor_select(index);
 			}
@@ -3477,7 +3467,7 @@ void EditorNode::_set_main_scene_state(Dictionary p_state, Node *p_for_scene) {
 
 	if (get_edited_scene()) {
 		if (current < 2) {
-			// use heuristic instead
+			// Use heuristic instead.
 			int n2d = 0, n3d = 0;
 			_find_node_types(get_edited_scene(), n2d, n3d);
 			if (n2d > n3d) {
@@ -3499,7 +3489,7 @@ void EditorNode::_set_main_scene_state(Dictionary p_state, Node *p_for_scene) {
 		SceneTreeDock::get_singleton()->set_filter(p_state["node_filter"]);
 	}
 
-	// this should only happen at the very end
+	// This should only happen at the very end.
 
 	EditorDebuggerNode::get_singleton()->update_live_edit_root();
 	ScriptEditor::get_singleton()->set_scene_root_script(editor_data.get_scene_root_script(editor_data.get_edited_scene()));
@@ -3548,7 +3538,7 @@ void EditorNode::set_current_scene(int p_idx) {
 	Node *new_scene = editor_data.get_edited_scene_root();
 
 	if (Object::cast_to<Popup>(new_scene)) {
-		Object::cast_to<Popup>(new_scene)->show(); // show popups
+		Object::cast_to<Popup>(new_scene)->show();
 	}
 
 	SceneTreeDock::get_singleton()->set_edited_scene(new_scene);
@@ -3567,7 +3557,7 @@ void EditorNode::set_current_scene(int p_idx) {
 
 	_update_title();
 
-	call_deferred(SNAME("_set_main_scene_state"), state, get_edited_scene()); // do after everything else is done setting up
+	call_deferred(SNAME("_set_main_scene_state"), state, get_edited_scene()); // Do after everything else is done setting up.
 }
 
 bool EditorNode::is_scene_open(const String &p_path) {
@@ -3654,7 +3644,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 	}
 
 	if (!p_ignore_broken_deps && dependency_errors.has(lpath)) {
-		current_option = -1;
+		current_menu_option = -1;
 		Vector<String> errors;
 		for (Set<String>::Element *E = dependency_errors[lpath].front(); E; E = E->next()) {
 			errors.push_back(E->get());
@@ -3669,7 +3659,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		return ERR_FILE_MISSING_DEPENDENCIES;
 	}
 
-	dependency_errors.erase(lpath); // at least not self path
+	dependency_errors.erase(lpath); // At least not self path.
 
 	for (KeyValue<String, Set<String>> &E : dependency_errors) {
 		String txt = vformat(TTR("Scene '%s' has broken dependencies:"), E.key) + "\n";
@@ -3680,7 +3670,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 	}
 
 	if (ResourceCache::has(lpath)) {
-		// used from somewhere else? no problem! update state and replace sdata
+		// Used from somewhere else? No problem! Update state and replace sdata.
 		Ref<PackedScene> ps = Ref<PackedScene>(Object::cast_to<PackedScene>(ResourceCache::get(lpath)));
 		if (ps.is_valid()) {
 			ps->replace_state(sdata->get_state());
@@ -3689,7 +3679,7 @@ Error EditorNode::load_scene(const String &p_scene, bool p_ignore_broken_deps, b
 		}
 
 	} else {
-		sdata->set_path(lpath, true); // take over path
+		sdata->set_path(lpath, true); // Take over path.
 	}
 
 	Node *new_scene = sdata->instantiate(p_set_inherited ? PackedScene::GEN_EDIT_STATE_MAIN_INHERITED : PackedScene::GEN_EDIT_STATE_MAIN);
@@ -3752,7 +3742,7 @@ void EditorNode::open_request(const String &p_path) {
 		}
 	}
 
-	load_scene(p_path); // as it will be opened in separate tab
+	load_scene(p_path); // As it will be opened in separate tab.
 }
 
 void EditorNode::edit_foreign_resource(RES p_resource) {
@@ -3769,7 +3759,7 @@ void EditorNode::request_instantiate_scenes(const Vector<String> &p_files) {
 }
 
 void EditorNode::_inherit_request(String p_file) {
-	current_option = FILE_NEW_INHERITED_SCENE;
+	current_menu_option = FILE_NEW_INHERITED_SCENE;
 	_dialog_action(p_file);
 }
 
@@ -3931,9 +3921,7 @@ void EditorNode::register_editor_types() {
 
 	GDREGISTER_ABSTRACT_CLASS(FileSystemDock);
 
-	// FIXME: Is this stuff obsolete, or should it be ported to new APIs?
 	GDREGISTER_CLASS(EditorScenePostImport);
-	//ClassDB::register_type<EditorImportExport>();
 	GDREGISTER_CLASS(EditorCommandPalette);
 	GDREGISTER_CLASS(EditorDebuggerPlugin);
 
@@ -3971,7 +3959,7 @@ Ref<Script> EditorNode::get_object_custom_type_base(const Object *p_object) cons
 		// 	return name;
 		// }
 
-		// should probably be deprecated in 4.x
+		// TODO: Should probably be deprecated in 4.x
 		StringName base = script->get_instance_base_type();
 		if (base != StringName() && EditorNode::get_editor_data().get_custom_types().has(base)) {
 			const Vector<EditorData::CustomType> &types = EditorNode::get_editor_data().get_custom_types()[base];
@@ -4007,7 +3995,7 @@ StringName EditorNode::get_object_custom_type_name(const Object *p_object) const
 				return name;
 			}
 
-			// should probably be deprecated in 4.x
+			// TODO: Should probably be deprecated in 4.x.
 			StringName base = base_script->get_instance_base_type();
 			if (base != StringName() && EditorNode::get_editor_data().get_custom_types().has(base)) {
 				const Vector<EditorData::CustomType> &types = EditorNode::get_editor_data().get_custom_types()[base];
@@ -4048,7 +4036,7 @@ void EditorNode::_pick_main_scene_custom_action(const String &p_custom_action_na
 		}
 
 		pick_main_scene->hide();
-		current_option = SETTINGS_PICK_MAIN_SCENE;
+		current_menu_option = SETTINGS_PICK_MAIN_SCENE;
 		_dialog_action(scene->get_scene_file_path());
 	}
 }
@@ -4071,7 +4059,7 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 				return icon;
 			}
 
-			// should probably be deprecated in 4.x
+			// TODO: should probably be deprecated in 4.x
 			StringName base = base_script->get_instance_base_type();
 			if (base != StringName() && EditorNode::get_editor_data().get_custom_types().has(base)) {
 				const Vector<EditorData::CustomType> &types = EditorNode::get_editor_data().get_custom_types()[base];
@@ -4085,7 +4073,7 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 		}
 	}
 
-	// should probably be deprecated in 4.x
+	// TODO: Should probably be deprecated in 4.x.
 	if (p_object->has_meta("_editor_icon")) {
 		return p_object->get_meta("_editor_icon");
 	}
@@ -4243,14 +4231,14 @@ Error EditorNode::export_preset(const String &p_preset, const String &p_path, bo
 }
 
 void EditorNode::show_accept(const String &p_text, const String &p_title) {
-	current_option = -1;
+	current_menu_option = -1;
 	accept->get_ok_button()->set_text(p_title);
 	accept->set_text(p_text);
 	accept->popup_centered();
 }
 
 void EditorNode::show_save_accept(const String &p_text, const String &p_title) {
-	current_option = -1;
+	current_menu_option = -1;
 	save_accept->get_ok_button()->set_text(p_title);
 	save_accept->set_text(p_text);
 	save_accept->popup_centered();
@@ -4290,7 +4278,7 @@ void EditorNode::_dock_floating_close_request(Control *p_control) {
 }
 
 void EditorNode::_dock_make_float() {
-	Control *dock = dock_slot[dock_popup_selected]->get_current_tab_control();
+	Control *dock = dock_slot[dock_popup_selected_idx]->get_current_tab_control();
 	ERR_FAIL_COND(!dock);
 
 	Size2 borders = Size2(4, 4) * EDSCALE;
@@ -4299,7 +4287,7 @@ void EditorNode::_dock_make_float() {
 	Point2 dock_screen_pos = dock->get_global_position() + get_tree()->get_root()->get_position() - borders;
 
 	int dock_index = dock->get_index();
-	dock_slot[dock_popup_selected]->remove_child(dock);
+	dock_slot[dock_popup_selected_idx]->remove_child(dock);
 
 	Window *window = memnew(Window);
 	window->set_title(dock->get_name());
@@ -4321,7 +4309,7 @@ void EditorNode::_dock_make_float() {
 	window->set_position(dock_screen_pos);
 	window->set_transient(true);
 	window->connect("close_requested", callable_mp(this, &EditorNode::_dock_floating_close_request), varray(dock));
-	window->set_meta("dock_slot", dock_popup_selected);
+	window->set_meta("dock_slot", dock_popup_selected_idx);
 	window->set_meta("dock_index", dock_index);
 	gui_base->add_child(window);
 
@@ -4373,9 +4361,9 @@ void EditorNode::_dock_select_input(const Ref<InputEvent> &p_input) {
 			}
 		}
 
-		if (nrect != dock_select_rect_over) {
+		if (nrect != dock_select_rect_over_idx) {
 			dock_select->update();
-			dock_select_rect_over = nrect;
+			dock_select_rect_over_idx = nrect;
 		}
 
 		if (nrect == -1) {
@@ -4384,20 +4372,20 @@ void EditorNode::_dock_select_input(const Ref<InputEvent> &p_input) {
 
 		Ref<InputEventMouseButton> mb = me;
 
-		if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed() && dock_popup_selected != nrect) {
-			Control *dock = dock_slot[dock_popup_selected]->get_current_tab_control();
+		if (mb.is_valid() && mb->get_button_index() == MouseButton::LEFT && mb->is_pressed() && dock_popup_selected_idx != nrect) {
+			Control *dock = dock_slot[dock_popup_selected_idx]->get_current_tab_control();
 			if (dock) {
-				dock_slot[dock_popup_selected]->remove_child(dock);
+				dock_slot[dock_popup_selected_idx]->remove_child(dock);
 			}
-			if (dock_slot[dock_popup_selected]->get_tab_count() == 0) {
-				dock_slot[dock_popup_selected]->hide();
+			if (dock_slot[dock_popup_selected_idx]->get_tab_count() == 0) {
+				dock_slot[dock_popup_selected_idx]->hide();
 
 			} else {
-				dock_slot[dock_popup_selected]->set_current_tab(0);
+				dock_slot[dock_popup_selected_idx]->set_current_tab(0);
 			}
 
 			dock_slot[nrect]->add_child(dock);
-			dock_popup_selected = nrect;
+			dock_popup_selected_idx = nrect;
 			dock_slot[nrect]->set_current_tab(dock_slot[nrect]->get_tab_count() - 1);
 			dock_slot[nrect]->show();
 			dock_select->update();
@@ -4411,38 +4399,38 @@ void EditorNode::_dock_select_input(const Ref<InputEvent> &p_input) {
 }
 
 void EditorNode::_dock_popup_exit() {
-	dock_select_rect_over = -1;
+	dock_select_rect_over_idx = -1;
 	dock_select->update();
 }
 
 void EditorNode::_dock_pre_popup(int p_which) {
-	dock_popup_selected = p_which;
+	dock_popup_selected_idx = p_which;
 }
 
 void EditorNode::_dock_move_left() {
-	if (dock_popup_selected < 0 || dock_popup_selected >= DOCK_SLOT_MAX) {
+	if (dock_popup_selected_idx < 0 || dock_popup_selected_idx >= DOCK_SLOT_MAX) {
 		return;
 	}
-	Control *current = dock_slot[dock_popup_selected]->get_tab_control(dock_slot[dock_popup_selected]->get_current_tab());
-	Control *prev = dock_slot[dock_popup_selected]->get_tab_control(dock_slot[dock_popup_selected]->get_current_tab() - 1);
+	Control *current = dock_slot[dock_popup_selected_idx]->get_tab_control(dock_slot[dock_popup_selected_idx]->get_current_tab());
+	Control *prev = dock_slot[dock_popup_selected_idx]->get_tab_control(dock_slot[dock_popup_selected_idx]->get_current_tab() - 1);
 	if (!current || !prev) {
 		return;
 	}
-	dock_slot[dock_popup_selected]->move_child(current, prev->get_index());
-	dock_slot[dock_popup_selected]->set_current_tab(dock_slot[dock_popup_selected]->get_current_tab() - 1);
+	dock_slot[dock_popup_selected_idx]->move_child(current, prev->get_index());
+	dock_slot[dock_popup_selected_idx]->set_current_tab(dock_slot[dock_popup_selected_idx]->get_current_tab() - 1);
 	dock_select->update();
 	_edit_current();
 	_save_docks();
 }
 
 void EditorNode::_dock_move_right() {
-	Control *current = dock_slot[dock_popup_selected]->get_tab_control(dock_slot[dock_popup_selected]->get_current_tab());
-	Control *next = dock_slot[dock_popup_selected]->get_tab_control(dock_slot[dock_popup_selected]->get_current_tab() + 1);
+	Control *current = dock_slot[dock_popup_selected_idx]->get_tab_control(dock_slot[dock_popup_selected_idx]->get_current_tab());
+	Control *next = dock_slot[dock_popup_selected_idx]->get_tab_control(dock_slot[dock_popup_selected_idx]->get_current_tab() + 1);
 	if (!current || !next) {
 		return;
 	}
-	dock_slot[dock_popup_selected]->move_child(next, current->get_index());
-	dock_slot[dock_popup_selected]->set_current_tab(dock_slot[dock_popup_selected]->get_current_tab() + 1);
+	dock_slot[dock_popup_selected_idx]->move_child(next, current->get_index());
+	dock_slot[dock_popup_selected_idx]->set_current_tab(dock_slot[dock_popup_selected_idx]->get_current_tab() + 1);
 	dock_select->update();
 	_edit_current();
 	_save_docks();
@@ -4470,9 +4458,9 @@ void EditorNode::_dock_select_draw() {
 	dock_tab_move_left->set_disabled(true);
 	dock_tab_move_right->set_disabled(true);
 
-	if (dock_popup_selected != -1 && dock_slot[dock_popup_selected]->get_tab_count()) {
-		dock_tab_move_left->set_disabled(dock_slot[dock_popup_selected]->get_current_tab() == 0);
-		dock_tab_move_right->set_disabled(dock_slot[dock_popup_selected]->get_current_tab() >= dock_slot[dock_popup_selected]->get_tab_count() - 1);
+	if (dock_popup_selected_idx != -1 && dock_slot[dock_popup_selected_idx]->get_tab_count()) {
+		dock_tab_move_left->set_disabled(dock_slot[dock_popup_selected_idx]->get_current_tab() == 0);
+		dock_tab_move_right->set_disabled(dock_slot[dock_popup_selected_idx]->get_current_tab() >= dock_slot[dock_popup_selected_idx]->get_tab_count() - 1);
 	}
 
 	for (int i = 0; i < DOCK_SLOT_MAX; i++) {
@@ -4515,7 +4503,7 @@ void EditorNode::_dock_select_draw() {
 		r.position += Vector2(2, 5);
 		r.size -= Vector2(4, 7);
 
-		if (i == dock_select_rect_over) {
+		if (i == dock_select_rect_over_idx) {
 			dock_select->draw_rect(r, used_selected);
 		} else if (dock_slot[i]->get_tab_count() == 0) {
 			dock_select->draw_rect(r, unused);
@@ -4526,7 +4514,7 @@ void EditorNode::_dock_select_draw() {
 		for (int j = 0; j < MIN(3, dock_slot[i]->get_tab_count()); j++) {
 			int xofs = (r.size.width / 3) * j;
 			Color c = used;
-			if (i == dock_popup_selected && (dock_slot[i]->get_current_tab() > 3 || dock_slot[i]->get_current_tab() == j)) {
+			if (i == dock_popup_selected_idx && (dock_slot[i]->get_current_tab() > 3 || dock_slot[i]->get_current_tab() == j)) {
 				c = tab_selected;
 			}
 			dock_select->draw_rect(Rect2(2 + ofs.x + xofs, ofs.y, r.size.width / 3 - 1, 3), c);
@@ -4536,7 +4524,7 @@ void EditorNode::_dock_select_draw() {
 
 void EditorNode::_save_docks() {
 	if (waiting_for_first_scan) {
-		return; // scanning, do not touch docks
+		return; // Scanning, do not touch docks.
 	}
 	Ref<ConfigFile> config;
 	config.instantiate();
@@ -4607,7 +4595,7 @@ void EditorNode::_load_docks() {
 	config.instantiate();
 	Error err = config->load(EditorSettings::get_singleton()->get_project_settings_dir().plus_file("editor_layout.cfg"));
 	if (err != OK) {
-		// no config
+		// No config.
 		if (overridden_default_layout >= 0) {
 			_layout_menu_option(overridden_default_layout);
 		}
@@ -4670,7 +4658,7 @@ void EditorNode::_update_dock_slots_visibility() {
 }
 
 void EditorNode::_dock_tab_changed(int p_tab) {
-	// update visibility but don't set current tab
+	// Update visibility but don't set current tab.
 
 	if (!docks_visible) {
 		for (int i = 0; i < DOCK_SLOT_MAX; i++) {
@@ -4720,7 +4708,7 @@ void EditorNode::_load_docks_from_config(Ref<ConfigFile> p_layout, const String 
 
 		for (int j = 0; j < names.size(); j++) {
 			String name = names[j];
-			// find it, in a horribly inefficient way
+			// FIXME: Find it, in a horribly inefficient way.
 			int atidx = -1;
 			Control *node = nullptr;
 			for (int k = 0; k < DOCK_SLOT_MAX; k++) {
@@ -4734,7 +4722,7 @@ void EditorNode::_load_docks_from_config(Ref<ConfigFile> p_layout, const String 
 				atidx = k;
 				break;
 			}
-			if (atidx == -1) { // well, it's not anywhere
+			if (atidx == -1) { // Well, it's not anywhere.
 				continue;
 			}
 
@@ -4850,11 +4838,11 @@ bool EditorNode::has_scenes_in_session() {
 }
 
 bool EditorNode::ensure_main_scene(bool p_from_native) {
-	pick_main_scene->set_meta("from_native", p_from_native); // whether from play button or native run
+	pick_main_scene->set_meta("from_native", p_from_native); // Whether from play button or native run.
 	String main_scene = GLOBAL_DEF("application/run/main_scene", "");
 
 	if (main_scene.is_empty()) {
-		current_option = -1;
+		current_menu_option = -1;
 		pick_main_scene->set_text(TTR("No main scene has ever been defined, select one?\nYou can change it later in \"Project Settings\" under the 'application' category."));
 		pick_main_scene->popup_centered();
 
@@ -4869,14 +4857,14 @@ bool EditorNode::ensure_main_scene(bool p_from_native) {
 	}
 
 	if (!FileAccess::exists(main_scene)) {
-		current_option = -1;
+		current_menu_option = -1;
 		pick_main_scene->set_text(vformat(TTR("Selected scene '%s' does not exist, select a valid one?\nYou can change it later in \"Project Settings\" under the 'application' category."), main_scene));
 		pick_main_scene->popup_centered();
 		return false;
 	}
 
 	if (ResourceLoader::get_resource_type(main_scene) != "PackedScene") {
-		current_option = -1;
+		current_menu_option = -1;
 		pick_main_scene->set_text(vformat(TTR("Selected scene '%s' is not a scene file, select a valid one?\nYou can change it later in \"Project Settings\" under the 'application' category."), main_scene));
 		pick_main_scene->popup_centered();
 		return false;
@@ -4971,7 +4959,7 @@ void EditorNode::_update_layouts_menu() {
 	config.instantiate();
 	Error err = config->load(EditorSettings::get_singleton()->get_editor_layouts_config());
 	if (err != OK) {
-		return; // no config
+		return; // No config.
 	}
 
 	List<String> layouts;
@@ -4990,14 +4978,14 @@ void EditorNode::_update_layouts_menu() {
 void EditorNode::_layout_menu_option(int p_id) {
 	switch (p_id) {
 		case SETTINGS_LAYOUT_SAVE: {
-			current_option = p_id;
+			current_menu_option = p_id;
 			layout_dialog->set_title(TTR("Save Layout"));
 			layout_dialog->get_ok_button()->set_text(TTR("Save"));
 			layout_dialog->popup_centered();
 			layout_dialog->set_name_line_enabled(true);
 		} break;
 		case SETTINGS_LAYOUT_DELETE: {
-			current_option = p_id;
+			current_menu_option = p_id;
 			layout_dialog->set_title(TTR("Delete Layout"));
 			layout_dialog->get_ok_button()->set_text(TTR("Delete"));
 			layout_dialog->popup_centered();
@@ -5012,7 +5000,7 @@ void EditorNode::_layout_menu_option(int p_id) {
 			config.instantiate();
 			Error err = config->load(EditorSettings::get_singleton()->get_editor_layouts_config());
 			if (err != OK) {
-				return; // no config
+				return; // No config.
 			}
 
 			_load_docks_from_config(config, editor_layouts->get_item_text(p_id));
@@ -5029,8 +5017,8 @@ void EditorNode::_scene_tab_script_edited(int p_tab) {
 }
 
 void EditorNode::_scene_tab_closed(int p_tab, int option) {
-	current_option = option;
-	tab_closing = p_tab;
+	current_menu_option = option;
+	tab_closing_idx = p_tab;
 	Node *scene = editor_data.get_edited_scene_root(p_tab);
 	if (!scene) {
 		_discard_changes();
@@ -5086,7 +5074,7 @@ void EditorNode::_scene_tab_input(const Ref<InputEvent> &p_input) {
 			}
 		}
 		if (mb->get_button_index() == MouseButton::RIGHT && mb->is_pressed()) {
-			// context menu
+			// Context menu.
 			scene_tabs_context_menu->clear();
 			scene_tabs_context_menu->reset_size();
 
@@ -5154,7 +5142,7 @@ void EditorNode::_scene_tab_changed(int p_tab) {
 	bool unsaved = (saved_version != editor_data.get_undo_redo().get_version());
 
 	if (p_tab == editor_data.get_edited_scene()) {
-		return; // pointless
+		return; // Pointless.
 	}
 
 	uint64_t next_scene_version = editor_data.get_scene_version(p_tab);
@@ -5256,7 +5244,8 @@ void EditorNode::_bottom_panel_switch(bool p_enable, int p_idx) {
 			bottom_panel_items[i].button->set_pressed(i == p_idx);
 			bottom_panel_items[i].control->set_visible(i == p_idx);
 		}
-		if (EditorDebuggerNode::get_singleton() == bottom_panel_items[p_idx].control) { // this is the debug panel which uses tabs, so the top section should be smaller
+		if (EditorDebuggerNode::get_singleton() == bottom_panel_items[p_idx].control) {
+			// This is the debug panel which uses tabs, so the top section should be smaller.
 			bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("BottomPanelDebuggerOverride"), SNAME("EditorStyles")));
 		} else {
 			bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
@@ -5301,11 +5290,11 @@ void EditorNode::_toggle_distraction_free_mode() {
 		}
 
 		if (screen == EDITOR_SCRIPT) {
-			script_distraction = !script_distraction;
-			set_distraction_free_mode(script_distraction);
+			script_distraction_free = !script_distraction_free;
+			set_distraction_free_mode(script_distraction_free);
 		} else {
-			scene_distraction = !scene_distraction;
-			set_distraction_free_mode(scene_distraction);
+			scene_distraction_free = !scene_distraction_free;
+			set_distraction_free_mode(scene_distraction_free);
 		}
 	} else {
 		set_distraction_free_mode(distraction_free->is_pressed());
@@ -5357,7 +5346,7 @@ Variant EditorNode::drag_resource(const Ref<Resource> &p_res, Control *p_from) {
 	Ref<Texture2D> preview;
 
 	{
-		// todo make proper previews
+		// TODO: make proper previews
 		Ref<ImageTexture> texture = gui_base->get_theme_icon(SNAME("FileBigThumb"), SNAME("EditorIcons"));
 		Ref<Image> img = texture->get_image();
 		img = img->duplicate();
@@ -5379,7 +5368,7 @@ Variant EditorNode::drag_resource(const Ref<Resource> &p_res, Control *p_from) {
 
 	drag_control->add_child(label);
 
-	p_from->set_drag_preview(drag_control); // wait until it enters scene
+	p_from->set_drag_preview(drag_control); // Wait until it enters scene.
 
 	label->set_position(Point2((preview->get_width() - label->get_minimum_size().width) / 2, preview->get_height()));
 
@@ -5433,7 +5422,7 @@ Variant EditorNode::drag_files_and_dirs(const Vector<String> &p_paths, Control *
 		}
 		vbox->add_child(label);
 	}
-	p_from->set_drag_preview(vbox); // wait until it enters scene
+	p_from->set_drag_preview(vbox); // Wait until it enters scene.
 
 	Dictionary drag_data;
 	drag_data["type"] = has_folder ? "files_and_dirs" : "files";
@@ -5549,7 +5538,7 @@ void EditorNode::reload_scene(const String &p_path) {
 
 	if (scene_idx == -1) {
 		if (get_edited_scene()) {
-			// scene is not open, so at it might be instantiated. We'll refresh the whole scene later.
+			// Scene is not open, so at it might be instantiated. We'll refresh the whole scene later.
 			editor_data.get_undo_redo().clear_history();
 		}
 		return;
@@ -5560,17 +5549,15 @@ void EditorNode::reload_scene(const String &p_path) {
 		_set_scene_metadata(p_path);
 	}
 
-	// remove scene
+	// Reload scene.
 	_remove_scene(scene_idx, false);
-
-	// reload scene
 	load_scene(p_path, true, false, true, true);
 
-	// adjust index so tab is back a the previous position
+	// Adjust index so tab is back a the previous position.
 	editor_data.move_edited_scene_to_index(scene_idx);
 	get_undo_redo()->clear_history();
 
-	// recover the tab
+	// Recover the tab.
 	scene_tabs->set_current_tab(current_tab);
 }
 
@@ -5669,9 +5656,9 @@ void EditorNode::_update_rendering_driver_color() {
 void EditorNode::_rendering_driver_selected(int p_which) {
 	String driver = rendering_driver->get_item_metadata(p_which);
 
-	String current = ""; // OS::get_singleton()->get_video_driver_name(OS::get_singleton()->get_current_video_driver());
+	String current_driver = OS::get_singleton()->get_current_rendering_driver_name();
 
-	if (driver == current) {
+	if (driver == current_driver) {
 		return;
 	}
 
@@ -5857,15 +5844,19 @@ EditorNode::EditorNode() {
 
 	RenderingServer::get_singleton()->set_debug_generate_wireframes(true);
 
-	NavigationServer3D::get_singleton()->set_active(false); // no nav by default if editor
+	// No navigation server by default if in editor.
+	NavigationServer3D::get_singleton()->set_active(false);
 
-	PhysicsServer3D::get_singleton()->set_active(false); // no physics by default if editor
-	PhysicsServer2D::get_singleton()->set_active(false); // no physics by default if editor
-	ScriptServer::set_scripting_enabled(false); // no scripting by default if editor
+	// No physics by default if in editor.
+	PhysicsServer3D::get_singleton()->set_active(false);
+	PhysicsServer2D::get_singleton()->set_active(false);
 
-	EditorHelp::generate_doc(); // before any editor classes are created
+	// No scripting by default if in editor.
+	ScriptServer::set_scripting_enabled(false);
+
+	EditorHelp::generate_doc(); // Before any editor classes are created.
 	SceneState::set_disable_placeholders(true);
-	ResourceLoader::clear_translation_remaps(); // no remaps using during editor
+	ResourceLoader::clear_translation_remaps(); // Using no remaps if in editor.
 	ResourceLoader::clear_path_remaps();
 
 	Input *id = Input::get_singleton();
@@ -5879,8 +5870,8 @@ EditorNode::EditorNode() {
 		}
 
 		if (!found_touchscreen && Input::get_singleton()) {
-			// only if no touchscreen ui hint, set emulation
-			id->set_emulate_touch_from_mouse(false); // just disable just in case
+			// Only if no touchscreen ui hint, disable emulation just in case.
+			id->set_emulate_touch_from_mouse(false);
 		}
 		DisplayServer::get_singleton()->cursor_set_custom_image(RES());
 	}
@@ -5889,7 +5880,7 @@ EditorNode::EditorNode() {
 	last_checked_version = 0;
 
 	TranslationServer::get_singleton()->set_enabled(false);
-	// load settings
+	// Load settings.
 	if (!EditorSettings::get_singleton()) {
 		EditorSettings::create();
 	}
@@ -5928,7 +5919,7 @@ EditorNode::EditorNode() {
 		}
 	}
 
-	// Define a minimum window size to prevent UI elements from overlapping or being cut off
+	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
 	DisplayServer::get_singleton()->window_set_min_size(Size2(1024, 600) * EDSCALE);
 
 	ResourceLoader::set_abort_on_missing_resources(false);
@@ -5938,7 +5929,8 @@ EditorNode::EditorNode() {
 	ResourceLoader::set_error_notify_func(this, _load_error_notify);
 	ResourceLoader::set_dependency_error_notify_func(this, _dependency_error_report);
 
-	{ // register importers at the beginning, so dialogs are created with the right extensions
+	{
+		// Register importers at the beginning, so dialogs are created with the right extensions.
 		Ref<ResourceImporterTexture> import_texture;
 		import_texture.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(import_texture);
@@ -6041,7 +6033,7 @@ EditorNode::EditorNode() {
 	EditorFileSystem *efs = memnew(EditorFileSystem);
 	add_child(efs);
 
-	// used for previews
+	// Used for previews.
 	FileDialog::get_icon_func = _file_dialog_get_icon;
 	FileDialog::register_func = _file_dialog_register;
 	FileDialog::unregister_func = _file_dialog_unregister;
@@ -6053,14 +6045,13 @@ EditorNode::EditorNode() {
 	editor_export = memnew(EditorExport);
 	add_child(editor_export);
 
-	// Exporters might need the theme
+	// Exporters might need the theme.
 	theme = create_custom_theme();
 
 	register_exporters();
 
 	ClassDB::set_class_enabled("RootMotionView", true);
 
-	// defs here, use EDITOR_GET in logic
 	EDITOR_DEF("interface/editor/save_on_focus_loss", false);
 	EDITOR_DEF("interface/editor/show_update_spinner", false);
 	EDITOR_DEF("interface/editor/update_continuously", false);
@@ -6105,7 +6096,7 @@ EditorNode::EditorNode() {
 	progress_dialog = memnew(ProgressDialog);
 	gui_base->add_child(progress_dialog);
 
-	// take up all screen
+	// Take up all screen.
 	gui_base->set_anchor(SIDE_RIGHT, Control::ANCHOR_END);
 	gui_base->set_anchor(SIDE_BOTTOM, Control::ANCHOR_END);
 	gui_base->set_end(Point2(0, 0));
@@ -6167,7 +6158,7 @@ EditorNode::EditorNode() {
 	dock_slot[DOCK_SLOT_RIGHT_BR] = memnew(TabContainer);
 	right_r_vsplit->add_child(dock_slot[DOCK_SLOT_RIGHT_BR]);
 
-	// Store them for easier access
+	// Store them for easier access.
 	vsplits.push_back(left_l_vsplit);
 	vsplits.push_back(left_r_vsplit);
 	vsplits.push_back(right_l_vsplit);
@@ -6236,8 +6227,9 @@ EditorNode::EditorNode() {
 	dock_vb->add_child(dock_float);
 
 	dock_select_popup->reset_size();
-	dock_select_rect_over = -1;
-	dock_popup_selected = -1;
+	dock_select_rect_over_idx = -1;
+	dock_popup_selected_idx = -1;
+
 	for (int i = 0; i < DOCK_SLOT_MAX; i++) {
 		dock_slot[i]->set_custom_minimum_size(Size2(170, 0) * EDSCALE);
 		dock_slot[i]->set_v_size_flags(Control::SIZE_EXPAND_FILL);
@@ -6514,7 +6506,7 @@ EditorNode::EditorNode() {
 	main_editor_button_vb = memnew(HBoxContainer);
 	menu_hb->add_child(main_editor_button_vb);
 
-	// Options are added and handled by DebuggerEditorPlugin
+	// Options are added and handled by DebuggerEditorPlugin.
 	debug_menu = memnew(MenuButton);
 	debug_menu->set_flat(false);
 	debug_menu->set_switch_on_hover(true);
@@ -6559,10 +6551,10 @@ EditorNode::EditorNode() {
 	p->add_separator();
 
 	if (OS::get_singleton()->get_data_path() == OS::get_singleton()->get_config_path()) {
-		// Configuration and data folders are located in the same place (Windows/macos)
+		// Configuration and data folders are located in the same place (Windows/MacOS).
 		p->add_item(TTR("Open Editor Data/Settings Folder"), SETTINGS_EDITOR_DATA_FOLDER);
 	} else {
-		// Separate configuration and data folders (Linux)
+		// Separate configuration and data folders (Linux).
 		p->add_item(TTR("Open Editor Data Folder"), SETTINGS_EDITOR_DATA_FOLDER);
 		p->add_item(TTR("Open Editor Settings Folder"), SETTINGS_EDITOR_CONFIG_FOLDER);
 	}
@@ -6571,7 +6563,6 @@ EditorNode::EditorNode() {
 	p->add_item(TTR("Manage Editor Features..."), SETTINGS_MANAGE_FEATURE_PROFILES);
 	p->add_item(TTR("Manage Export Templates..."), SETTINGS_MANAGE_EXPORT_TEMPLATES);
 
-	// Help Menu
 	help_menu = memnew(MenuButton);
 	help_menu->set_flat(false);
 	help_menu->set_switch_on_hover(true);
@@ -6736,7 +6727,7 @@ EditorNode::EditorNode() {
 	p->add_item(TTR("Hide Update Spinner"), SETTINGS_UPDATE_SPINNER_HIDE);
 	_update_update_spinner();
 
-	// Instantiate and place editor docks
+	// Instantiate and place editor docks.
 
 	memnew(SceneTreeDock(scene_root, editor_selection, editor_data));
 	memnew(InspectorDock(editor_data));
@@ -6748,27 +6739,27 @@ EditorNode::EditorNode() {
 	filesystem_dock->connect("instance", callable_mp(this, &EditorNode::_instantiate_request));
 	filesystem_dock->connect("display_mode_changed", callable_mp(this, &EditorNode::_save_docks));
 
-	// Scene: Top left
+	// Scene: Top left.
 	dock_slot[DOCK_SLOT_LEFT_UR]->add_child(SceneTreeDock::get_singleton());
 	dock_slot[DOCK_SLOT_LEFT_UR]->set_tab_title(dock_slot[DOCK_SLOT_LEFT_UR]->get_tab_idx_from_control(SceneTreeDock::get_singleton()), TTR("Scene"));
 
-	// Import: Top left, behind Scene
+	// Import: Top left, behind Scene.
 	dock_slot[DOCK_SLOT_LEFT_UR]->add_child(ImportDock::get_singleton());
 	dock_slot[DOCK_SLOT_LEFT_UR]->set_tab_title(dock_slot[DOCK_SLOT_LEFT_UR]->get_tab_idx_from_control(ImportDock::get_singleton()), TTR("Import"));
 
-	// FileSystem: Bottom left
+	// FileSystem: Bottom left.
 	dock_slot[DOCK_SLOT_LEFT_BR]->add_child(FileSystemDock::get_singleton());
 	dock_slot[DOCK_SLOT_LEFT_BR]->set_tab_title(dock_slot[DOCK_SLOT_LEFT_BR]->get_tab_idx_from_control(FileSystemDock::get_singleton()), TTR("FileSystem"));
 
-	// Inspector: Full height right
+	// Inspector: Full height right.
 	dock_slot[DOCK_SLOT_RIGHT_UL]->add_child(InspectorDock::get_singleton());
 	dock_slot[DOCK_SLOT_RIGHT_UL]->set_tab_title(dock_slot[DOCK_SLOT_RIGHT_UL]->get_tab_idx_from_control(InspectorDock::get_singleton()), TTR("Inspector"));
 
-	// Node: Full height right, behind Inspector
+	// Node: Full height right, behind Inspector.
 	dock_slot[DOCK_SLOT_RIGHT_UL]->add_child(NodeDock::get_singleton());
 	dock_slot[DOCK_SLOT_RIGHT_UL]->set_tab_title(dock_slot[DOCK_SLOT_RIGHT_UL]->get_tab_idx_from_control(NodeDock::get_singleton()), TTR("Node"));
 
-	// Hide unused dock slots and vsplits
+	// Hide unused dock slots and vsplits.
 	dock_slot[DOCK_SLOT_LEFT_UL]->hide();
 	dock_slot[DOCK_SLOT_LEFT_BL]->hide();
 	dock_slot[DOCK_SLOT_RIGHT_BL]->hide();
@@ -6777,16 +6768,16 @@ EditorNode::EditorNode() {
 	left_l_vsplit->hide();
 	right_r_vsplit->hide();
 
-	// Add some offsets to left_r and main hsplits to make LEFT_R and RIGHT_L docks wider than minsize
+	// Add some offsets to left_r and main hsplits to make LEFT_R and RIGHT_L docks wider than minsize.
 	left_r_hsplit->set_split_offset(70 * EDSCALE);
 	main_hsplit->set_split_offset(-70 * EDSCALE);
 
-	// Define corresponding default layout
+	// Define corresponding default layout.
 
 	const String docks_section = "docks";
 	overridden_default_layout = -1;
 	default_layout.instantiate();
-	// Dock numbers are based on DockSlot enum value + 1
+	// Dock numbers are based on DockSlot enum value + 1.
 	default_layout->set_value(docks_section, "dock_3", "Scene,Import");
 	default_layout->set_value(docks_section, "dock_4", "FileSystem");
 	default_layout->set_value(docks_section, "dock_5", "Inspector,Node");
@@ -6801,7 +6792,7 @@ EditorNode::EditorNode() {
 
 	_update_layouts_menu();
 
-	// Bottom panels
+	// Bottom panels.
 
 	bottom_panel = memnew(PanelContainer);
 	bottom_panel->add_theme_style_override("panel", gui_base->get_theme_stylebox(SNAME("panel"), SNAME("TabContainer")));
@@ -6837,7 +6828,7 @@ EditorNode::EditorNode() {
 	}
 	// Set the text to copy in metadata as it slightly differs from the button's text.
 	version_btn->set_meta(META_TEXT_TO_COPY, "v" VERSION_FULL_BUILD + hash);
-	// Fade out the version label to be less prominent, but still readable
+	// Fade out the version label to be less prominent, but still readable.
 	version_btn->set_self_modulate(Color(1, 1, 1, 0.65));
 	version_btn->set_underline_mode(LinkButton::UNDERLINE_MODE_ON_HOVER);
 	version_btn->set_tooltip(TTR("Click to copy."));
@@ -6960,8 +6951,8 @@ EditorNode::EditorNode() {
 	file->connect("file_selected", callable_mp(this, &EditorNode::_dialog_action));
 	file_templates->connect("file_selected", callable_mp(this, &EditorNode::_dialog_action));
 
-	preview_gen = memnew(AudioStreamPreviewGenerator);
-	add_child(preview_gen);
+	audio_preview_gen = memnew(AudioStreamPreviewGenerator);
+	add_child(audio_preview_gen);
 
 	add_editor_plugin(memnew(DebuggerEditorPlugin(debug_menu)));
 	add_editor_plugin(memnew(DebugAdapterServer()));
@@ -6996,7 +6987,7 @@ EditorNode::EditorNode() {
 
 	EditorAudioBuses *audio_bus_editor = EditorAudioBuses::register_editor();
 
-	ScriptTextEditor::register_editor(); // register one for text scripts
+	ScriptTextEditor::register_editor(); // Register one for text scripts.
 	TextEditor::register_editor();
 
 	if (StreamPeerSSL::is_available()) {
@@ -7005,12 +6996,12 @@ EditorNode::EditorNode() {
 		WARN_PRINT("Asset Library not available, as it requires SSL to work.");
 	}
 
-	// add interface before adding plugins
+	// Add interface before adding plugins.
 
 	editor_interface = memnew(EditorInterface);
 	add_child(editor_interface);
 
-	// more visually meaningful to have this later
+	// More visually meaningful to have this later.
 	raise_bottom_panel_item(AnimationPlayerEditor::get_singleton());
 	add_editor_plugin(memnew(ReplicationEditorPlugin));
 
@@ -7245,7 +7236,8 @@ EditorNode::EditorNode() {
 	screenshot_timer->set_owner(get_owner());
 
 	String exec = OS::get_singleton()->get_executable_path();
-	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "executable_path", exec); // Save editor executable path for third-party tools
+	// Save editor executable path for third-party tools.
+	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "executable_path", exec);
 }
 
 EditorNode::~EditorNode() {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -112,6 +112,13 @@ public:
 		DOCK_SLOT_MAX
 	};
 
+	enum EditorTable {
+		EDITOR_2D = 0,
+		EDITOR_3D,
+		EDITOR_SCRIPT,
+		EDITOR_ASSETLIB
+	};
+
 	struct ExecuteThreadArgs {
 		String path;
 		List<String> args;
@@ -123,10 +130,6 @@ public:
 	};
 
 private:
-	enum {
-		HISTORY_SIZE = 64
-	};
-
 	enum MenuOptions {
 		FILE_NEW_SCENE,
 		FILE_NEW_INHERITED_SCENE,
@@ -218,13 +221,59 @@ private:
 		TOOL_MENU_BASE = 1000
 	};
 
+	enum {
+		MAX_INIT_CALLBACKS = 128,
+		MAX_BUILD_CALLBACKS = 128
+	};
+
 	enum ScriptNameCasing {
 		SCENE_NAME_CASING_AUTO,
 		SCENE_NAME_CASING_PASCAL_CASE,
 		SCENE_NAME_CASING_SNAKE_CASE
 	};
 
-	SubViewport *scene_root; // root of the scene being edited
+	struct BottomPanelItem {
+		String name;
+		Control *control = nullptr;
+		Button *button = nullptr;
+	};
+
+	struct ExportDefer {
+		String preset;
+		String path;
+		bool debug = false;
+		bool pack_only = false;
+	} export_defer;
+
+	static EditorNode *singleton;
+
+	EditorData editor_data;
+	EditorFolding editor_folding;
+	EditorRun editor_run;
+	EditorSelectionHistory editor_history;
+
+	EditorCommandPalette *command_palette = nullptr;
+	EditorExport *editor_export = nullptr;
+	EditorInterface *editor_interface = nullptr;
+	EditorLog *log = nullptr;
+	EditorNativeShaderSourceVisualizer *native_shader_source_visualizer = nullptr;
+	EditorPlugin *editor_plugin_screen = nullptr;
+	EditorPluginList *editor_plugins_force_input_forwarding = nullptr;
+	EditorPluginList *editor_plugins_force_over = nullptr;
+	EditorPluginList *editor_plugins_over = nullptr;
+	EditorQuickOpen *quick_open = nullptr;
+	EditorQuickOpen *quick_run = nullptr;
+	EditorResourcePreview *resource_preview = nullptr;
+	EditorRunNative *run_native = nullptr;
+	EditorSelection *editor_selection = nullptr;
+	EditorSettingsDialog *editor_settings_dialog = nullptr;
+
+	ProjectExportDialog *project_export = nullptr;
+	ProjectSettingsEditor *project_settings_editor = nullptr;
+
+	Vector<EditorPlugin *> editor_plugins;
+	bool _initializing_plugins = false;
+	Map<String, EditorPlugin *> addon_name_to_plugin;
 
 	PanelContainer *scene_root_parent;
 	Control *theme_base;
@@ -236,11 +285,8 @@ private:
 
 	int rendering_driver_current;
 	String rendering_driver_request;
-	void _rendering_driver_selected(int);
-	void _update_rendering_driver_color();
 
-	// Split containers
-
+	// Split containers.
 	HSplitContainer *left_l_hsplit;
 	VSplitContainer *left_l_vsplit;
 	HSplitContainer *left_r_hsplit;
@@ -249,20 +295,17 @@ private:
 	HSplitContainer *right_hsplit;
 	VSplitContainer *right_l_vsplit;
 	VSplitContainer *right_r_vsplit;
-
 	VSplitContainer *center_split;
-
-	// To access those easily by index
+	// To access those easily by index.
 	Vector<VSplitContainer *> vsplits;
 	Vector<HSplitContainer *> hsplits;
 
-	// Main tabs
-
+	// Main tabs.
 	TabBar *scene_tabs;
 	PopupMenu *scene_tabs_context_menu;
 	Panel *tab_preview_panel;
 	TextureRect *tab_preview;
-	int tab_closing;
+	int tab_closing_idx;
 
 	bool exiting = false;
 	bool dimmed = false;
@@ -304,7 +347,10 @@ private:
 	Ref<Theme> theme;
 
 	PopupMenu *recent_scenes;
-	EditorRunNative *run_native;
+	String _recent_scene;
+	List<String> previous_scenes;
+	String defer_load_scene;
+	Node *_last_instantiated_scene;
 
 	ConfirmationDialog *confirmation;
 	ConfirmationDialog *save_confirmation;
@@ -325,11 +371,6 @@ private:
 	ConfirmationDialog *install_android_build_template;
 	ConfirmationDialog *remove_android_build_template;
 
-	EditorSettingsDialog *editor_settings_dialog;
-	ProjectSettingsEditor *project_settings_editor;
-	bool settings_changed = true; // make it update settings on first frame
-	void _update_from_settings();
-
 	PopupMenu *vcs_actions_menu;
 	EditorFileDialog *file;
 	ExportTemplateManager *export_template_manager;
@@ -343,26 +384,16 @@ private:
 	String current_path;
 	MenuButton *update_spinner;
 
-	EditorNativeShaderSourceVisualizer *native_shader_source_visualizer;
-
-	String defer_load_scene;
-	Node *_last_instantiated_scene;
-
-	EditorLog *log;
-	CenterContainer *tabs_center;
-	EditorQuickOpen *quick_open;
-	EditorQuickOpen *quick_run;
-	EditorCommandPalette *command_palette;
-
 	HBoxContainer *main_editor_button_vb;
 	Vector<Button *> main_editor_buttons;
 	Vector<EditorPlugin *> editor_table;
 
-	AudioStreamPreviewGenerator *preview_gen;
+	AudioStreamPreviewGenerator *audio_preview_gen;
 	ProgressDialog *progress_dialog;
 	BackgroundProgress *progress_hb;
 
 	DependencyErrorDialog *dependency_error;
+	Map<String, Set<String>> dependency_errors;
 	DependencyEditor *dependency_fixer;
 	OrphanResourcesDialog *orphan_resources;
 	ConfirmationDialog *open_imported;
@@ -371,71 +402,24 @@ private:
 
 	Vector<Control *> floating_docks;
 
-	TabContainer *dock_slot[DOCK_SLOT_MAX];
-	Rect2 dock_select_rect[DOCK_SLOT_MAX];
-	int dock_select_rect_over;
-	PopupPanel *dock_select_popup;
-	Control *dock_select;
 	Button *dock_float;
 	Button *dock_tab_move_left;
 	Button *dock_tab_move_right;
-	int dock_popup_selected;
+	Control *dock_select;
+	PopupPanel *dock_select_popup;
+	Rect2 dock_select_rect[DOCK_SLOT_MAX];
+	TabContainer *dock_slot[DOCK_SLOT_MAX];
 	Timer *dock_drag_timer;
 	bool docks_visible = true;
+	int dock_popup_selected_idx;
+	int dock_select_rect_over_idx;
 
 	HBoxContainer *tabbar_container;
 	Button *distraction_free;
 	Button *scene_tab_add;
 	Control *scene_tab_add_ph;
 
-	bool scene_distraction = false;
-	bool script_distraction = false;
-
-	String _tmp_import_path;
-
-	EditorExport *editor_export;
-
-	Object *current;
-	Ref<Resource> saving_resource;
-
-	bool _playing_edited = false;
-	String run_custom_filename;
-	bool reference_resource_mem = true;
-	uint64_t saved_version;
-	uint64_t last_checked_version;
-	bool unsaved_cache = true;
-	String open_navigate;
-	bool changing_scene = false;
-	bool waiting_for_first_scan = true;
-
-	uint64_t update_spinner_step_msec;
-	uint64_t update_spinner_step_frame;
-	int update_spinner_step;
-
-	Vector<EditorPlugin *> editor_plugins;
-	EditorPlugin *editor_plugin_screen;
-	EditorPluginList *editor_plugins_over;
-	EditorPluginList *editor_plugins_force_over;
-	EditorPluginList *editor_plugins_force_input_forwarding;
-
-	EditorHistory editor_history;
-	EditorData editor_data;
-	EditorRun editor_run;
-	EditorSelection *editor_selection;
-	ProjectExportDialog *project_export;
-	EditorResourcePreview *resource_preview;
-	EditorFolding editor_folding;
-
-	DynamicFontImportSettings *fontdata_import_settings;
-	SceneImportSettings *scene_import_settings;
-	struct BottomPanelItem {
-		String name;
-		Control *control = nullptr;
-		Button *button = nullptr;
-	};
-
 	Vector<BottomPanelItem> bottom_panel_items;
-
 	PanelContainer *bottom_panel;
 	HBoxContainer *bottom_panel_hb;
 	HBoxContainer *bottom_panel_hb_editors;
@@ -447,15 +431,81 @@ private:
 	Tree *disk_changed_list;
 	ConfirmationDialog *disk_changed;
 
-	void _bottom_panel_raise_toggled(bool);
+	bool scene_distraction_free = false;
+	bool script_distraction_free = false;
 
-	EditorInterface *editor_interface;
-
-	void _bottom_panel_switch(bool p_enable, int p_idx);
-
-	String external_file;
-	List<String> previous_scenes;
+	bool _playing_edited = false;
+	bool changing_scene = false;
+	bool cmdline_export_mode = false;
+	bool convert_old = false;
+	bool immediate_dialog_confirmed = false;
 	bool opening_prev = false;
+	bool restoring_scenes = false;
+	bool settings_changed = true; // Make it update settings on first frame.
+	bool unsaved_cache = true;
+	bool waiting_for_first_scan = true;
+
+	int current_menu_option;
+
+	SubViewport *scene_root; // Root of the scene being edited.
+	Object *current;
+
+	Ref<Resource> saving_resource;
+
+	uint64_t update_spinner_step_msec;
+	uint64_t update_spinner_step_frame;
+	int update_spinner_step;
+
+	String _tmp_import_path;
+	String external_file;
+	String open_navigate;
+	String run_custom_filename;
+
+	uint64_t saved_version;
+	uint64_t last_checked_version;
+
+	DynamicFontImportSettings *fontdata_import_settings;
+	SceneImportSettings *scene_import_settings;
+
+	String import_reload_fn;
+
+	Set<String> textfile_extensions;
+	Set<FileDialog *> file_dialogs;
+	Set<EditorFileDialog *> editor_file_dialogs;
+
+	Vector<Ref<EditorResourceConversionPlugin>> resource_conversion_plugins;
+	PrintHandlerList print_handler;
+
+	Map<String, Ref<Texture2D>> icon_type_cache;
+
+	static EditorBuildCallback build_callbacks[MAX_BUILD_CALLBACKS];
+	static EditorPluginInitializeCallback plugin_init_callbacks[MAX_INIT_CALLBACKS];
+	static int build_callback_count;
+	static int plugin_init_callback_count;
+	static Vector<EditorNodeInitCallback> _init_callbacks;
+
+	static void _dependency_error_report(void *ud, const String &p_path, const String &p_dep, const String &p_type) {
+		EditorNode *en = (EditorNode *)ud;
+		if (!en->dependency_errors.has(p_path)) {
+			en->dependency_errors[p_path] = Set<String>();
+		}
+		en->dependency_errors[p_path].insert(p_dep + "::" + p_type);
+	}
+
+	static Ref<Texture2D> _file_dialog_get_icon(const String &p_path);
+	static void _file_dialog_register(FileDialog *p_dialog);
+	static void _file_dialog_unregister(FileDialog *p_dialog);
+	static void _editor_file_dialog_register(EditorFileDialog *p_dialog);
+	static void _editor_file_dialog_unregister(EditorFileDialog *p_dialog);
+
+	static void _load_error_notify(void *p_ud, const String &p_text);
+	static void _file_access_close_error_notify(const String &p_str);
+
+	static void _print_handler(void *p_this, const String &p_string, bool p_error);
+	static void _resource_saved(RES p_resource, const String &p_path);
+	static void _resource_loaded(RES p_resource, const String &p_path);
+
+	void _build_icon_type_cache();
 
 	void _dialog_action(String p_file);
 
@@ -463,7 +513,6 @@ private:
 	void _dialog_display_save_error(String p_file, Error p_error);
 	void _dialog_display_load_error(String p_file, Error p_error);
 
-	int current_option;
 	void _menu_option(int p_option);
 	void _menu_confirm_current();
 	void _menu_option_confirm(int p_option, bool p_confirmed);
@@ -528,35 +577,17 @@ private:
 	void _global_menu_new_window(const Variant &p_tag);
 	void _dropped_files(const Vector<String> &p_files, int p_screen);
 	void _add_dropped_files_recursive(const Vector<String> &p_files, String to_path);
-	String _recent_scene;
+
+	void _update_from_settings();
+
+	void _rendering_driver_selected(int);
+	void _update_rendering_driver_color();
 
 	void _exit_editor(int p_exit_code);
 
-	bool convert_old = false;
-
 	virtual void unhandled_input(const Ref<InputEvent> &p_event) override;
 
-	static void _load_error_notify(void *p_ud, const String &p_text);
-
 	bool has_main_screen() const { return true; }
-
-	String import_reload_fn;
-
-	Set<String> textfile_extensions;
-	Set<FileDialog *> file_dialogs;
-	Set<EditorFileDialog *> editor_file_dialogs;
-
-	Map<String, Ref<Texture2D>> icon_type_cache;
-	void _build_icon_type_cache();
-
-	bool _initializing_addons = false;
-	Map<String, EditorPlugin *> plugin_addons;
-
-	static Ref<Texture2D> _file_dialog_get_icon(const String &p_path);
-	static void _file_dialog_register(FileDialog *p_dialog);
-	static void _file_dialog_unregister(FileDialog *p_dialog);
-	static void _editor_file_dialog_register(EditorFileDialog *p_dialog);
-	static void _editor_file_dialog_unregister(EditorFileDialog *p_dialog);
 
 	void _remove_edited_scene(bool p_change_tab = true);
 	void _remove_scene(int index, bool p_change_tab = true);
@@ -567,29 +598,6 @@ private:
 
 	void _find_node_types(Node *p_node, int &count_2d, int &count_3d);
 	void _save_scene_with_preview(String p_file, int p_idx = -1);
-
-	Map<String, Set<String>> dependency_errors;
-
-	static void _dependency_error_report(void *ud, const String &p_path, const String &p_dep, const String &p_type) {
-		EditorNode *en = (EditorNode *)ud;
-		if (!en->dependency_errors.has(p_path)) {
-			en->dependency_errors[p_path] = Set<String>();
-		}
-		en->dependency_errors[p_path].insert(p_dep + "::" + p_type);
-	}
-
-	struct ExportDefer {
-		String preset;
-		String path;
-		bool debug = false;
-		bool pack_only = false;
-	} export_defer;
-
-	bool cmdline_export_mode = false;
-
-	static EditorNode *singleton;
-
-	static Vector<EditorNodeInitCallback> _init_callbacks;
 
 	bool _find_scene_in_use(Node *p_node, const String &p_path) const;
 
@@ -625,7 +633,6 @@ private:
 	void _update_dock_slots_visibility();
 	void _dock_tab_changed(int p_tab);
 
-	bool restoring_scenes = false;
 	void _save_open_scenes_to_config(Ref<ConfigFile> p_layout, const String &p_section);
 	void _load_open_scenes_from_config(Ref<ConfigFile> p_layout, const String &p_section);
 
@@ -636,34 +643,13 @@ private:
 
 	void _update_addon_config();
 
-	static void _file_access_close_error_notify(const String &p_str);
-
 	void _toggle_distraction_free_mode();
-
-	enum {
-		MAX_INIT_CALLBACKS = 128,
-		MAX_BUILD_CALLBACKS = 128
-	};
 
 	void _inherit_imported(const String &p_action);
 	void _open_imported();
 
-	static int plugin_init_callback_count;
-	static EditorPluginInitializeCallback plugin_init_callbacks[MAX_INIT_CALLBACKS];
 	void _save_default_environment();
-
-	static int build_callback_count;
-	static EditorBuildCallback build_callbacks[MAX_BUILD_CALLBACKS];
-
 	void _update_update_spinner();
-
-	Vector<Ref<EditorResourceConversionPlugin>> resource_conversion_plugins;
-
-	PrintHandlerList print_handler;
-	static void _print_handler(void *p_this, const String &p_string, bool p_error);
-
-	static void _resource_saved(RES p_resource, const String &p_path);
-	static void _resource_loaded(RES p_resource, const String &p_path);
 
 	void _resources_changed(const Vector<String> &p_resources);
 	void _scan_external_changes();
@@ -677,48 +663,70 @@ private:
 
 	void _pick_main_scene_custom_action(const String &p_custom_action_name);
 
-	bool immediate_dialog_confirmed = false;
 	void _immediate_dialog_confirmed();
 
 	void _select_default_main_screen_plugin();
 
-protected:
-	void _notification(int p_what);
-
-	static void _bind_methods();
+	void _bottom_panel_switch(bool p_enable, int p_idx);
+	void _bottom_panel_raise_toggled(bool);
 
 protected:
 	friend class FileSystemDock;
+
+	static void _bind_methods();
+
+	void _notification(int p_what);
 
 	int get_current_tab();
 	void set_current_tab(int p_tab);
 
 public:
+	void set_visible_editor(EditorTable p_table) { _editor_select(p_table); }
+
 	bool call_build();
 
-	static void add_plugin_init_callback(EditorPluginInitializeCallback p_callback);
+	static void register_editor_types();
+	static void unregister_editor_types();
 
-	enum EditorTable {
-		EDITOR_2D = 0,
-		EDITOR_3D,
-		EDITOR_SCRIPT,
-		EDITOR_ASSETLIB
-	};
-
-	void set_visible_editor(EditorTable p_table) { _editor_select(p_table); }
 	static EditorNode *get_singleton() { return singleton; }
 
-	EditorPlugin *get_editor_plugin_screen() { return editor_plugin_screen; }
-	EditorPluginList *get_editor_plugins_over() { return editor_plugins_over; }
-	EditorPluginList *get_editor_plugins_force_over() { return editor_plugins_force_over; }
-	EditorPluginList *get_editor_plugins_force_input_forwarding() { return editor_plugins_force_input_forwarding; }
+	static EditorLog *get_log() { return singleton->log; }
+	static EditorData &get_editor_data() { return singleton->editor_data; }
+	static EditorFolding &get_editor_folding() { return singleton->editor_folding; }
+	static UndoRedo *get_undo_redo() { return &singleton->editor_data.get_undo_redo(); }
 
-	ProjectSettingsEditor *get_project_settings() { return project_settings_editor; }
+	static HBoxContainer *get_menu_hb() { return singleton->menu_hb; }
+	static VSplitContainer *get_top_split() { return singleton->top_split; }
+
+	static bool has_unsaved_changes() { return singleton->unsaved_cache; }
+	static void disambiguate_filenames(const Vector<String> p_full_paths, Vector<String> &r_filenames);
+	static void add_io_error(const String &p_error);
+
+	static void progress_add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel = false);
+	static bool progress_task_step(const String &p_task, const String &p_state, int p_step = -1, bool p_force_refresh = true);
+	static void progress_end_task(const String &p_task);
+
+	static void progress_add_task_bg(const String &p_task, const String &p_label, int p_steps);
+	static void progress_task_step_bg(const String &p_task, int p_step = -1);
+	static void progress_end_task_bg(const String &p_task);
 
 	static void add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed = false);
 	static void remove_editor_plugin(EditorPlugin *p_editor, bool p_config_changed = false);
 
-	static void disambiguate_filenames(const Vector<String> p_full_paths, Vector<String> &r_filenames);
+	static void add_plugin_init_callback(EditorPluginInitializeCallback p_callback);
+	static void add_init_callback(EditorNodeInitCallback p_callback) { _init_callbacks.push_back(p_callback); }
+	static void add_build_callback(EditorBuildCallback p_callback);
+
+	static bool immediate_confirmation_dialog(const String &p_text, const String &p_ok_text = TTR("Ok"), const String &p_cancel_text = TTR("Cancel"));
+
+	EditorPlugin *get_editor_plugin_screen() { return editor_plugin_screen; }
+	EditorPluginList *get_editor_plugins_force_input_forwarding() { return editor_plugins_force_input_forwarding; }
+	EditorPluginList *get_editor_plugins_force_over() { return editor_plugins_force_over; }
+	EditorPluginList *get_editor_plugins_over() { return editor_plugins_over; }
+	EditorSelection *get_editor_selection() { return editor_selection; }
+	EditorSelectionHistory *get_editor_selection_history() { return &editor_history; }
+
+	ProjectSettingsEditor *get_project_settings() { return project_settings_editor; }
 
 	void new_inherited_scene() { _menu_option_confirm(FILE_NEW_INHERITED_SCENE, false); }
 
@@ -743,10 +751,6 @@ public:
 
 	void show_about() { _menu_option_confirm(HELP_ABOUT, false); }
 
-	static bool has_unsaved_changes() { return singleton->unsaved_cache; }
-
-	static HBoxContainer *get_menu_hb() { return singleton->menu_hb; }
-
 	void push_item(Object *p_object, const String &p_property = "", bool p_inspector_only = false);
 	void edit_item(Object *p_object);
 	void edit_item_resource(RES p_resource);
@@ -760,14 +764,11 @@ public:
 
 	bool is_changing_scene() const;
 
-	static EditorLog *get_log() { return singleton->log; }
 	Control *get_main_control();
+	SubViewport *get_scene_root() { return scene_root; } // Root of the scene being edited.
 
 	void set_edited_scene(Node *p_scene);
-
 	Node *get_edited_scene() { return editor_data.get_edited_scene_root(); }
-
-	SubViewport *get_scene_root() { return scene_root; } // root of the scene being edited
 
 	void fix_dependencies(const String &p_for_file);
 	int new_scene();
@@ -779,17 +780,8 @@ public:
 	void set_current_version(uint64_t p_version);
 	void set_current_scene(int p_idx);
 
-	static EditorData &get_editor_data() { return singleton->editor_data; }
-	static EditorFolding &get_editor_folding() { return singleton->editor_folding; }
-	EditorHistory *get_editor_history() { return &editor_history; }
-
-	static VSplitContainer *get_top_split() { return singleton->top_split; }
-
 	void request_instance_scene(const String &p_path);
 	void request_instantiate_scenes(const Vector<String> &p_files);
-	static UndoRedo *get_undo_redo() { return &singleton->editor_data.get_undo_redo(); }
-
-	EditorSelection *get_editor_selection() { return editor_selection; }
 
 	void set_convert_old_scene(bool p_old) { convert_old = p_old; }
 
@@ -812,21 +804,8 @@ public:
 
 	Error export_preset(const String &p_preset, const String &p_path, bool p_debug, bool p_pack_only);
 
-	static void register_editor_types();
-	static void unregister_editor_types();
-
 	Control *get_gui_base() { return gui_base; }
 	Control *get_theme_base() { return gui_base->get_parent_control(); }
-
-	static void add_io_error(const String &p_error);
-
-	static void progress_add_task(const String &p_task, const String &p_label, int p_steps, bool p_can_cancel = false);
-	static bool progress_task_step(const String &p_task, const String &p_state, int p_step = -1, bool p_force_refresh = true);
-	static void progress_end_task(const String &p_task);
-
-	static void progress_add_task_bg(const String &p_task, const String &p_label, int p_steps);
-	static void progress_task_step_bg(const String &p_task, int p_step = -1);
-	static void progress_end_task_bg(const String &p_task);
 
 	void save_scene_to_path(String p_file, bool p_with_preview = true) {
 		if (p_with_preview) {
@@ -883,9 +862,6 @@ public:
 	void remove_resource_conversion_plugin(const Ref<EditorResourceConversionPlugin> &p_plugin);
 	Vector<Ref<EditorResourceConversionPlugin>> find_resource_conversion_plugin(const Ref<Resource> &p_for_resource);
 
-	static void add_init_callback(EditorNodeInitCallback p_callback) { _init_callbacks.push_back(p_callback); }
-	static void add_build_callback(EditorBuildCallback p_callback);
-
 	bool ensure_main_scene(bool p_from_native);
 
 	Error run_play_native(int p_idx, int p_platform);
@@ -895,8 +871,6 @@ public:
 	void run_stop();
 	bool is_run_playing() const;
 	String get_run_playing_scene() const;
-
-	static bool immediate_confirmation_dialog(const String &p_text, const String &p_ok_text = TTR("Ok"), const String &p_cancel_text = TTR("Cancel"));
 };
 
 struct EditorProgress {

--- a/editor/editor_path.cpp
+++ b/editor/editor_path.cpp
@@ -194,7 +194,7 @@ void EditorPath::_notification(int p_what) {
 void EditorPath::_bind_methods() {
 }
 
-EditorPath::EditorPath(EditorHistory *p_history) {
+EditorPath::EditorPath(EditorSelectionHistory *p_history) {
 	history = p_history;
 
 	MarginContainer *main_mc = memnew(MarginContainer);

--- a/editor/editor_path.h
+++ b/editor/editor_path.h
@@ -37,12 +37,12 @@
 #include "scene/gui/popup_menu.h"
 #include "scene/gui/texture_rect.h"
 
-class EditorHistory;
+class EditorSelectionHistory;
 
 class EditorPath : public Button {
 	GDCLASS(EditorPath, Button);
 
-	EditorHistory *history;
+	EditorSelectionHistory *history;
 
 	TextureRect *current_object_icon;
 	Label *current_object_label;
@@ -65,7 +65,7 @@ public:
 	void clear_path();
 	void enable_path();
 
-	EditorPath(EditorHistory *p_history);
+	EditorPath(EditorSelectionHistory *p_history);
 };
 
 #endif // EDITOR_PATH_H

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2806,8 +2806,8 @@ void EditorPropertyNodePath::_node_selected(const NodePath &p_path) {
 
 		if (!base_node) {
 			//try a base node within history
-			if (EditorNode::get_singleton()->get_editor_history()->get_path_size() > 0) {
-				Object *base = ObjectDB::get_instance(EditorNode::get_singleton()->get_editor_history()->get_path_object(0));
+			if (EditorNode::get_singleton()->get_editor_selection_history()->get_path_size() > 0) {
+				Object *base = ObjectDB::get_instance(EditorNode::get_singleton()->get_editor_selection_history()->get_path_object(0));
 				if (base) {
 					base_node = Object::cast_to<Node>(base);
 				}

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -250,7 +250,7 @@ void InspectorDock::_resource_file_selected(String p_file) {
 }
 
 void InspectorDock::_save_resource(bool save_as) {
-	ObjectID current = EditorNode::get_singleton()->get_editor_history()->get_current();
+	ObjectID current = EditorNode::get_singleton()->get_editor_selection_history()->get_current();
 	Object *current_obj = current.is_valid() ? ObjectDB::get_instance(current) : nullptr;
 
 	ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj));
@@ -265,7 +265,7 @@ void InspectorDock::_save_resource(bool save_as) {
 }
 
 void InspectorDock::_unref_resource() {
-	ObjectID current = EditorNode::get_singleton()->get_editor_history()->get_current();
+	ObjectID current = EditorNode::get_singleton()->get_editor_selection_history()->get_current();
 	Object *current_obj = current.is_valid() ? ObjectDB::get_instance(current) : nullptr;
 
 	ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj));
@@ -276,7 +276,7 @@ void InspectorDock::_unref_resource() {
 }
 
 void InspectorDock::_copy_resource() {
-	ObjectID current = EditorNode::get_singleton()->get_editor_history()->get_current();
+	ObjectID current = EditorNode::get_singleton()->get_editor_selection_history()->get_current();
 	Object *current_obj = current.is_valid() ? ObjectDB::get_instance(current) : nullptr;
 
 	ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj));
@@ -300,7 +300,7 @@ void InspectorDock::_prepare_resource_extra_popup() {
 }
 
 void InspectorDock::_prepare_history() {
-	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
+	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
 
 	int history_to = MAX(0, editor_history->get_history_len() - 25);
 
@@ -352,7 +352,7 @@ void InspectorDock::_prepare_history() {
 
 void InspectorDock::_select_history(int p_idx) {
 	//push it to the top, it is not correct, but it's more useful
-	ObjectID id = EditorNode::get_singleton()->get_editor_history()->get_history_obj(p_idx);
+	ObjectID id = EditorNode::get_singleton()->get_editor_selection_history()->get_history_obj(p_idx);
 	Object *obj = ObjectDB::get_instance(id);
 	if (!obj) {
 		return;
@@ -380,13 +380,13 @@ void InspectorDock::_resource_selected(const RES &p_res, const String &p_propert
 }
 
 void InspectorDock::_edit_forward() {
-	if (EditorNode::get_singleton()->get_editor_history()->next()) {
+	if (EditorNode::get_singleton()->get_editor_selection_history()->next()) {
 		EditorNode::get_singleton()->edit_current();
 	}
 }
 
 void InspectorDock::_edit_back() {
-	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
+	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
 	if ((current && editor_history->previous()) || editor_history->get_path_size() == 1) {
 		EditorNode::get_singleton()->edit_current();
 	}
@@ -476,7 +476,7 @@ void InspectorDock::clear() {
 }
 
 void InspectorDock::update(Object *p_object) {
-	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
+	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
 	backward_button->set_disabled(editor_history->is_at_beginning());
 	forward_button->set_disabled(editor_history->is_at_end());
 
@@ -635,7 +635,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 
 	HBoxContainer *subresource_hb = memnew(HBoxContainer);
 	add_child(subresource_hb);
-	editor_path = memnew(EditorPath(EditorNode::get_singleton()->get_editor_history()));
+	editor_path = memnew(EditorPath(EditorNode::get_singleton()->get_editor_selection_history()));
 	editor_path->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	subresource_hb->add_child(editor_path);
 

--- a/editor/plugins/replication_editor_plugin.cpp
+++ b/editor/plugins/replication_editor_plugin.cpp
@@ -217,7 +217,7 @@ void ReplicationEditor::update_keying() {
 	/// TODO make keying usable.
 #if 0
 	bool keying_enabled = false;
-	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
+	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
 	if (is_visible_in_tree() && config.is_valid() && editor_history->get_path_size() > 0) {
 		Object *obj = ObjectDB::get_instance(editor_history->get_path_object(0));
 		keying_enabled = Object::cast_to<Node>(obj) != nullptr;
@@ -305,7 +305,7 @@ void ReplicationEditor::property_keyed(const String &p_property) {
 	ERR_FAIL_COND(!current || config.is_null());
 	Node *root = current->get_node(current->get_root_path());
 	ERR_FAIL_COND(!root);
-	EditorHistory *history = EditorNode::get_singleton()->get_editor_history();
+	EditorSelectionHistory *history = EditorNode::get_singleton()->get_editor_selection_history();
 	ERR_FAIL_COND(history->get_path_size() == 0);
 	Node *node = Object::cast_to<Node>(ObjectDB::get_instance(history->get_path_object(0)));
 	ERR_FAIL_COND(!node);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -6035,8 +6035,8 @@ void VisualShaderNodePortPreview::_shader_changed() {
 
 	//find if a material is also being edited and copy parameters to this one
 
-	for (int i = EditorNode::get_singleton()->get_editor_history()->get_path_size() - 1; i >= 0; i--) {
-		Object *object = ObjectDB::get_instance(EditorNode::get_singleton()->get_editor_history()->get_path_object(i));
+	for (int i = EditorNode::get_singleton()->get_editor_selection_history()->get_path_size() - 1; i >= 0; i--) {
+		Object *object = ObjectDB::get_instance(EditorNode::get_singleton()->get_editor_selection_history()->get_path_object(i));
 		ShaderMaterial *src_mat;
 		if (!object) {
 			continue;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2075,8 +2075,8 @@ void SceneTreeDock::_delete_confirm(bool p_cut) {
 
 	_push_item(nullptr);
 
-	// Fixes the EditorHistory from still offering deleted notes
-	EditorHistory *editor_history = EditorNode::get_singleton()->get_editor_history();
+	// Fixes the EditorSelectionHistory from still offering deleted notes
+	EditorSelectionHistory *editor_history = EditorNode::get_singleton()->get_editor_selection_history();
 	editor_history->cleanup_history();
 	InspectorDock::get_singleton()->call("_prepare_history");
 }


### PR DESCRIPTION
This PR aims to tidy-up the EditorNode, EditorData, EditorSelection and EditorHistory classes (partially) with the following changes:
- Remove unused enums (unused HISTORY_MAX constant)
- Remove unused class attributes
- Remove some old commented out code (reenabling it caused causes undesired behavior, so it seems fine to remove it)
- Some renames of variables to be more descriptive/explicit (e.g., the term "history" was used ambiguously)
	- Rename EditorHistory to EditorSelectionHistory to better reflect what it does (this might require some discussion, as I am not quite sure with it)
- Adjusted the comment style for consistency (// Begin with whitespace + uppercase letter and place a dot at the end.)
- Removed some uninformative comments (e.g., `//bye`, `//save` after save();)
- Restructure the EditorNode header to improve readability 
	- Clearly separate class attributes and methods
	- Move enum and struct declarations
	- Group static methods
	- Group attributes/methods in a way that makes sense (I hope)
- Reimplement rendering_driver check in EditorNode::_rendering_driver_selected (old commented out version)
- Add TODO/FIXME in front of  some comments which were (implicitly or explicitly) suggesting changes/marking hacks.
- Remove an unnecessary visibility modifier since the GDCLASS macro includes "private:" at the end
- Includes almost all changes in https://github.com/godotengine/godot/pull/44222 and https://github.com/godotengine/godot/pull/44249 except the simplifications using the ERR_FAIL_INDEX macro, therefore co-authored by @EricEzaM.