### PR TITLE
Fix typos in editor font preload dialog warning messages

### DIFF
--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -560,7 +560,7 @@ void DynamicFontImportSettings::_variation_changed(const String &p_edited_proper
 void DynamicFontImportSettings::_variations_validate() {
 	String warn;
 	if (!vars_list_root->get_first_child()) {
-		warn = TTR("Warinig: There are no configurations specified, no glyphs will be pre-rendered.");
+		warn = TTR("Warning: There are no configurations specified, no glyphs will be pre-rendered.");
 	}
 	for (TreeItem *vars_item_a = vars_list_root->get_first_child(); vars_item_a; vars_item_a = vars_item_a->get_next()) {
 		Ref<DynamicFontImportSettingsData> import_variation_data_a = vars_item_a->get_metadata(0);
@@ -575,7 +575,7 @@ void DynamicFontImportSettings::_variations_validate() {
 					match = match && (import_variation_data_b->settings[E->key()] == E->get());
 				}
 				if (match) {
-					warn = TTR("Warinig: Multiple configurations have identical settings. Duplicates will be ignored.");
+					warn = TTR("Warning: Multiple configurations have identical settings. Duplicates will be ignored.");
 					break;
 				}
 			}


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/58341#issuecomment-1046468266. Thanks @girng for spotting it :slightly_smiling_face:

**Note:** Not cherry-pickable to `3.x`.