### PR TITLE
[Net] Fix multi-peer path-only replication, optimize single peer object cache.

### DIFF
--- a/scene/multiplayer/scene_cache_interface.h
+++ b/scene/multiplayer/scene_cache_interface.h
@@ -60,7 +60,7 @@ private:
 	int last_send_cache_id = 1;
 
 protected:
-	bool _send_confirm_path(Node *p_node, NodePath p_path, PathSentCache *psc, int p_target);
+	Error _send_confirm_path(Node *p_node, NodePath p_path, PathSentCache *psc, const List<int> &p_peers);
 	static MultiplayerCacheInterface *_create(MultiplayerAPI *p_multiplayer);
 
 public:

--- a/scene/multiplayer/scene_replication_interface.cpp
+++ b/scene/multiplayer/scene_replication_interface.cpp
@@ -350,11 +350,12 @@ void SceneReplicationInterface::_send_sync(int p_peer, uint64_t p_msec) {
 		}
 		if (size) {
 			uint32_t net_id = rep_state->get_net_id(oid);
-			if (net_id == 0) {
+			if (net_id == 0 || (net_id & 0x80000000)) {
 				// First time path based ID.
 				NodePath rel_path = multiplayer->get_root_path().rel_path_to(sync->get_path());
 				int path_id = 0;
 				multiplayer->send_object_cache(sync, rel_path, p_peer, path_id);
+				ERR_CONTINUE_MSG(net_id && net_id != (uint32_t(path_id) | 0x80000000), "This should never happen!");
 				net_id = path_id;
 				rep_state->set_net_id(oid, net_id | 0x80000000);
 			}


### PR DESCRIPTION
It used to check if a net_id was ever assigned to that node to detect when to send the path confirm to the remote peer.
This is wrong, because the same net_id is shared for all the remote peers, but sent one by one.

Instead we now check if it's either not assigned or if the assigned net_id is a cache ID, and in that case ensure that the remote peer has been notified.

This can be further improved by unifying the cache interface, but for now it's a fast fix to get path-only sync to work.

This PR still at least optimize the check to verify if a given (single) peer has been notified or not.

Fixes #58193