### PR TITLE
Rename motion_velocity to velocity

### DIFF
--- a/doc/classes/CharacterBody2D.xml
+++ b/doc/classes/CharacterBody2D.xml
@@ -55,7 +55,7 @@
 		<method name="get_real_velocity" qualifiers="const">
 			<return type="Vector2" />
 			<description>
-				Returns the current real velocity since the last call to [method move_and_slide]. For example, when you climb a slope, you will move diagonally even though the velocity is horizontal. This method returns the diagonal movement, as opposed to [member motion_velocity] which returns the requested velocity.
+				Returns the current real velocity since the last call to [method move_and_slide]. For example, when you climb a slope, you will move diagonally even though the velocity is horizontal. This method returns the diagonal movement, as opposed to [member velocity] which returns the requested velocity.
 			</description>
 		</method>
 		<method name="get_slide_collision">
@@ -131,8 +131,8 @@
 		<method name="move_and_slide">
 			<return type="bool" />
 			<description>
-				Moves the body based on [member motion_velocity]. If the body collides with another, it will slide along the other body (by default only on floor) rather than stop immediately. If the other body is a [CharacterBody2D] or [RigidDynamicBody2D], it will also be affected by the motion of the other body. You can use this to make moving and rotating platforms, or to make nodes push other nodes.
-				Modifies [member motion_velocity] if a slide collision occurred. To get the latest collision call [method get_last_slide_collision], for detailed information about collisions that occurred, use [method get_slide_collision].
+				Moves the body based on [member velocity]. If the body collides with another, it will slide along the other body (by default only on floor) rather than stop immediately. If the other body is a [CharacterBody2D] or [RigidDynamicBody2D], it will also be affected by the motion of the other body. You can use this to make moving and rotating platforms, or to make nodes push other nodes.
+				Modifies [member velocity] if a slide collision occurred. To get the latest collision call [method get_last_slide_collision], for detailed information about collisions that occurred, use [method get_slide_collision].
 				When the body touches a moving platform, the platform's velocity is automatically added to the body motion. If a collision occurs due to the platform's motion, it will always be first in the slide collisions.
 				The general behavior and available properties change according to the [member motion_mode].
 				Returns [code]true[/code] if the body collided, otherwise, returns [code]false[/code].
@@ -162,16 +162,13 @@
 		</member>
 		<member name="floor_stop_on_slope" type="bool" setter="set_floor_stop_on_slope_enabled" getter="is_floor_stop_on_slope_enabled" default="true">
 			If [code]true[/code], the body will not slide on slopes when calling [method move_and_slide] when the body is standing still.
-			If [code]false[/code], the body will slide on floor's slopes when [member motion_velocity] applies a downward force.
+			If [code]false[/code], the body will slide on floor's slopes when [member velocity] applies a downward force.
 		</member>
 		<member name="max_slides" type="int" setter="set_max_slides" getter="get_max_slides" default="4">
 			Maximum number of times the body can change direction before it stops when calling [method move_and_slide].
 		</member>
 		<member name="motion_mode" type="int" setter="set_motion_mode" getter="get_motion_mode" enum="CharacterBody2D.MotionMode" default="0">
 			Sets the motion mode which defines the behavior of [method move_and_slide]. See [enum MotionMode] constants for available modes.
-		</member>
-		<member name="motion_velocity" type="Vector2" setter="set_motion_velocity" getter="get_motion_velocity" default="Vector2(0, 0)">
-			Current velocity vector in pixels per second, used and modified during calls to [method move_and_slide].
 		</member>
 		<member name="moving_platform_apply_velocity_on_leave" type="int" setter="set_moving_platform_apply_velocity_on_leave" getter="get_moving_platform_apply_velocity_on_leave" enum="CharacterBody2D.MovingPlatformApplyVelocityOnLeave" default="0">
 			Sets the behavior to apply when you leave a moving platform. By default, to be physically accurate, when you leave the last platform velocity is applied. See [enum MovingPlatformApplyVelocityOnLeave] constants for available behavior.
@@ -188,6 +185,9 @@
 		<member name="up_direction" type="Vector2" setter="set_up_direction" getter="get_up_direction" default="Vector2(0, -1)">
 			Direction vector used to determine what is a wall and what is a floor (or a ceiling), rather than a wall, when calling [method move_and_slide]. Defaults to [code]Vector2.UP[/code]. If set to [code]Vector2(0, 0)[/code], everything is considered a wall. This is useful for topdown games.
 		</member>
+		<member name="velocity" type="Vector2" setter="set_velocity" getter="get_velocity" default="Vector2(0, 0)">
+			Current velocity vector in pixels per second, used and modified during calls to [method move_and_slide].
+		</member>
 		<member name="wall_min_slide_angle" type="float" setter="set_wall_min_slide_angle" getter="get_wall_min_slide_angle" default="0.261799">
 			Minimum angle (in radians) where the body is allowed to slide when it encounters a slope. The default value equals 15 degrees. This property only affects movement when [member motion_mode] is [constant MOTION_MODE_FLOATING].
 		</member>
@@ -200,10 +200,10 @@
 			Apply when there is no notion of floor or ceiling. All collisions will be reported as [code]on_wall[/code]. In this mode, when you slide, the speed will always be constant. This mode is suitable for top-down games.
 		</constant>
 		<constant name="PLATFORM_VEL_ON_LEAVE_ALWAYS" value="0" enum="MovingPlatformApplyVelocityOnLeave">
-			Add the last platform velocity to the [member motion_velocity] when you leave a moving platform.
+			Add the last platform velocity to the [member velocity] when you leave a moving platform.
 		</constant>
 		<constant name="PLATFORM_VEL_ON_LEAVE_UPWARD_ONLY" value="1" enum="MovingPlatformApplyVelocityOnLeave">
-			Add the last platform velocity to the [member motion_velocity] when you leave a moving platform, but any downward motion is ignored. It's useful to keep full jump height even when the platform is moving down.
+			Add the last platform velocity to the [member velocity] when you leave a moving platform, but any downward motion is ignored. It's useful to keep full jump height even when the platform is moving down.
 		</constant>
 		<constant name="PLATFORM_VEL_ON_LEAVE_NEVER" value="2" enum="MovingPlatformApplyVelocityOnLeave">
 			Do nothing when leaving a platform.

--- a/doc/classes/CharacterBody3D.xml
+++ b/doc/classes/CharacterBody3D.xml
@@ -56,7 +56,7 @@
 		<method name="get_real_velocity" qualifiers="const">
 			<return type="Vector3" />
 			<description>
-				Returns the current real velocity since the last call to [method move_and_slide]. For example, when you climb a slope, you will move diagonally even though the velocity is horizontal. This method returns the diagonal movement, as opposed to [member motion_velocity] which returns the requested velocity.
+				Returns the current real velocity since the last call to [method move_and_slide]. For example, when you climb a slope, you will move diagonally even though the velocity is horizontal. This method returns the diagonal movement, as opposed to [member velocity] which returns the requested velocity.
 			</description>
 		</method>
 		<method name="get_slide_collision">
@@ -117,8 +117,8 @@
 		<method name="move_and_slide">
 			<return type="bool" />
 			<description>
-				Moves the body based on [member motion_velocity]. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [CharacterBody3D] or [RigidDynamicBody3D], it will also be affected by the motion of the other body. You can use this to make moving and rotating platforms, or to make nodes push other nodes.
-				Modifies [member motion_velocity] if a slide collision occurred. To get the latest collision call [method get_last_slide_collision], for more detailed information about collisions that occurred, use [method get_slide_collision].
+				Moves the body based on [member velocity]. If the body collides with another, it will slide along the other body rather than stop immediately. If the other body is a [CharacterBody3D] or [RigidDynamicBody3D], it will also be affected by the motion of the other body. You can use this to make moving and rotating platforms, or to make nodes push other nodes.
+				Modifies [member velocity] if a slide collision occurred. To get the latest collision call [method get_last_slide_collision], for more detailed information about collisions that occurred, use [method get_slide_collision].
 				When the body touches a moving platform, the platform's velocity is automatically added to the body motion. If a collision occurs due to the platform's motion, it will always be first in the slide collisions.
 				Returns [code]true[/code] if the body collided, otherwise, returns [code]false[/code].
 			</description>
@@ -147,16 +147,13 @@
 		</member>
 		<member name="floor_stop_on_slope" type="bool" setter="set_floor_stop_on_slope_enabled" getter="is_floor_stop_on_slope_enabled" default="true">
 			If [code]true[/code], the body will not slide on slopes when calling [method move_and_slide] when the body is standing still.
-			If [code]false[/code], the body will slide on floor's slopes when [member motion_velocity] applies a downward force.
+			If [code]false[/code], the body will slide on floor's slopes when [member velocity] applies a downward force.
 		</member>
 		<member name="max_slides" type="int" setter="set_max_slides" getter="get_max_slides" default="6">
 			Maximum number of times the body can change direction before it stops when calling [method move_and_slide].
 		</member>
 		<member name="motion_mode" type="int" setter="set_motion_mode" getter="get_motion_mode" enum="CharacterBody3D.MotionMode" default="0">
 			Sets the motion mode which defines the behavior of [method move_and_slide]. See [enum MotionMode] constants for available modes.
-		</member>
-		<member name="motion_velocity" type="Vector3" setter="set_motion_velocity" getter="get_motion_velocity" default="Vector3(0, 0, 0)">
-			Current velocity vector (typically meters per second), used and modified during calls to [method move_and_slide].
 		</member>
 		<member name="moving_platform_apply_velocity_on_leave" type="int" setter="set_moving_platform_apply_velocity_on_leave" getter="get_moving_platform_apply_velocity_on_leave" enum="CharacterBody3D.MovingPlatformApplyVelocityOnLeave" default="0">
 			Sets the behavior to apply when you leave a moving platform. By default, to be physically accurate, when you leave the last platform velocity is applied. See [enum MovingPlatformApplyVelocityOnLeave] constants for available behavior.
@@ -173,6 +170,9 @@
 		<member name="up_direction" type="Vector3" setter="set_up_direction" getter="get_up_direction" default="Vector3(0, 1, 0)">
 			Direction vector used to determine what is a wall and what is a floor (or a ceiling), rather than a wall, when calling [method move_and_slide]. Defaults to [code]Vector3.UP[/code]. If set to [code]Vector3(0, 0, 0)[/code], everything is considered a wall. This is useful for topdown games.
 		</member>
+		<member name="velocity" type="Vector3" setter="set_velocity" getter="get_velocity" default="Vector3(0, 0, 0)">
+			Current velocity vector (typically meters per second), used and modified during calls to [method move_and_slide].
+		</member>
 		<member name="wall_min_slide_angle" type="float" setter="set_wall_min_slide_angle" getter="get_wall_min_slide_angle" default="0.261799">
 			Minimum angle (in radians) where the body is allowed to slide when it encounters a slope. The default value equals 15 degrees. When [member motion_mode] is [constant MOTION_MODE_GROUNDED], it only affects movement if [member floor_block_on_wall] is [code]true[/code].
 		</member>
@@ -185,10 +185,10 @@
 			Apply when there is no notion of floor or ceiling. All collisions will be reported as [code]on_wall[/code]. In this mode, when you slide, the speed will always be constant. This mode is suitable for games without ground like space games.
 		</constant>
 		<constant name="PLATFORM_VEL_ON_LEAVE_ALWAYS" value="0" enum="MovingPlatformApplyVelocityOnLeave">
-			Add the last platform velocity to the [member motion_velocity] when you leave a moving platform.
+			Add the last platform velocity to the [member velocity] when you leave a moving platform.
 		</constant>
 		<constant name="PLATFORM_VEL_ON_LEAVE_UPWARD_ONLY" value="1" enum="MovingPlatformApplyVelocityOnLeave">
-			Add the last platform velocity to the [member motion_velocity] when you leave a moving platform, but any downward motion is ignored. It's useful to keep full jump height even when the platform is moving down.
+			Add the last platform velocity to the [member velocity] when you leave a moving platform, but any downward motion is ignored. It's useful to keep full jump height even when the platform is moving down.
 		</constant>
 		<constant name="PLATFORM_VEL_ON_LEAVE_NEVER" value="2" enum="MovingPlatformApplyVelocityOnLeave">
 			Do nothing when leaving a platform.

--- a/modules/gdscript/editor_templates/CharacterBody2D/basic_movement.gd
+++ b/modules/gdscript/editor_templates/CharacterBody2D/basic_movement.gd
@@ -12,18 +12,18 @@ var gravity: int = ProjectSettings.get_setting("physics/2d/default_gravity")
 func _physics_process(delta: float) -> void:
 	# Add the gravity.
 	if not is_on_floor():
-		motion_velocity.y += gravity * delta
+		velocity.y += gravity * delta
 
 	# Handle Jump.
 	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
-		motion_velocity.y = JUMP_VELOCITY
+		velocity.y = JUMP_VELOCITY
 
 	# Get the input direction and handle the movement/deceleration.
 	# As good practice, you should replace UI actions with custom gameplay actions.
 	var direction := Input.get_axis("ui_left", "ui_right")
 	if direction:
-		motion_velocity.x = direction * SPEED
+		velocity.x = direction * SPEED
 	else:
-		motion_velocity.x = move_toward(motion_velocity.x, 0, SPEED)
+		velocity.x = move_toward(velocity.x, 0, SPEED)
 
 	move_and_slide()

--- a/modules/gdscript/editor_templates/CharacterBody3D/basic_movement.gd
+++ b/modules/gdscript/editor_templates/CharacterBody3D/basic_movement.gd
@@ -12,21 +12,21 @@ var gravity: float = ProjectSettings.get_setting("physics/3d/default_gravity")
 func _physics_process(delta: float) -> void:
 	# Add the gravity.
 	if not is_on_floor():
-		motion_velocity.y -= gravity * delta
+		velocity.y -= gravity * delta
 
 	# Handle Jump.
 	if Input.is_action_just_pressed("ui_accept") and is_on_floor():
-		motion_velocity.y = JUMP_VELOCITY
+		velocity.y = JUMP_VELOCITY
 
 	# Get the input direction and handle the movement/deceleration.
 	# As good practice, you should replace UI actions with custom gameplay actions.
 	var input_dir := Input.get_vector("ui_left", "ui_right", "ui_up", "ui_down")
 	var direction := (transform.basis * Vector3(input_dir.x, 0, input_dir.y)).normalized()
 	if direction:
-		motion_velocity.x = direction.x * SPEED
-		motion_velocity.z = direction.z * SPEED
+		velocity.x = direction.x * SPEED
+		velocity.z = direction.z * SPEED
 	else:
-		motion_velocity.x = move_toward(motion_velocity.x, 0, SPEED)
-		motion_velocity.z = move_toward(motion_velocity.z, 0, SPEED)
+		velocity.x = move_toward(velocity.x, 0, SPEED)
+		velocity.z = move_toward(velocity.z, 0, SPEED)
 
 	move_and_slide()

--- a/modules/mono/editor_templates/CharacterBody2D/basic_movement.cs
+++ b/modules/mono/editor_templates/CharacterBody2D/basic_movement.cs
@@ -13,29 +13,29 @@ public partial class _CLASS_ : _BASE_
 
     public override void _PhysicsProcess(float delta)
     {
-        Vector2 motionVelocity = MotionVelocity;
+        Vector2 velocity = Velocity;
 
         // Add the gravity.
         if (!IsOnFloor())
-            motionVelocity.y += gravity * delta;
+            velocity.y += gravity * delta;
 
         // Handle Jump.
         if (Input.IsActionJustPressed("ui_accept") && IsOnFloor())
-            motionVelocity.y = JumpVelocity;
+            velocity.y = JumpVelocity;
 
         // Get the input direction and handle the movement/deceleration.
         // As good practice, you should replace UI actions with custom gameplay actions.
         Vector2 direction = Input.GetVector("ui_left", "ui_right", "ui_up", "ui_down");
         if (direction != Vector2.Zero)
         {
-            motionVelocity.x = direction.x * Speed;
+            velocity.x = direction.x * Speed;
         }
         else
         {
-            motionVelocity.x = Mathf.MoveToward(MotionVelocity.x, 0, Speed);
+            velocity.x = Mathf.MoveToward(Velocity.x, 0, Speed);
         }
 
-        MotionVelocity = motionVelocity;
+        Velocity = velocity;
         MoveAndSlide();
     }
 }

--- a/modules/mono/editor_templates/CharacterBody3D/basic_movement.cs
+++ b/modules/mono/editor_templates/CharacterBody3D/basic_movement.cs
@@ -13,15 +13,15 @@ public partial class _CLASS_ : _BASE_
 
     public override void _PhysicsProcess(float delta)
     {
-        Vector3 motionVelocity = MotionVelocity;
+        Vector3 velocity = Velocity;
 
         // Add the gravity.
         if (!IsOnFloor())
-            motionVelocity.y -= gravity * delta;
+            velocity.y -= gravity * delta;
 
         // Handle Jump.
         if (Input.IsActionJustPressed("ui_accept") && IsOnFloor())
-             motionVelocity.y = JumpVelocity;
+             velocity.y = JumpVelocity;
 
         // Get the input direction and handle the movement/deceleration.
         // As good practice, you should replace UI actions with custom gameplay actions.
@@ -29,16 +29,16 @@ public partial class _CLASS_ : _BASE_
         Vector3 direction = Transform.basis.Xform(new Vector3(inputDir.x, 0, inputDir.y)).Normalized();
         if (direction != Vector3.Zero)
         {
-            motionVelocity.x = direction.x * Speed;
-            motionVelocity.z = direction.z * Speed;
+            velocity.x = direction.x * Speed;
+            velocity.z = direction.z * Speed;
         }
         else
         {
-            motionVelocity.x = Mathf.MoveToward(MotionVelocity.x, 0, Speed);
-            motionVelocity.z = Mathf.MoveToward(MotionVelocity.z, 0, Speed);
+            velocity.x = Mathf.MoveToward(Velocity.x, 0, Speed);
+            velocity.z = Mathf.MoveToward(Velocity.z, 0, Speed);
         }
 
-        MotionVelocity = motionVelocity;
+        Velocity = velocity;
         MoveAndSlide();
     }
 }

--- a/scene/2d/physics_body_2d.h
+++ b/scene/2d/physics_body_2d.h
@@ -337,8 +337,8 @@ public:
 	};
 	bool move_and_slide();
 
-	const Vector2 &get_motion_velocity() const;
-	void set_motion_velocity(const Vector2 &p_velocity);
+	const Vector2 &get_velocity() const;
+	void set_velocity(const Vector2 &p_velocity);
 
 	bool is_on_floor() const;
 	bool is_on_floor_only() const;
@@ -378,7 +378,7 @@ private:
 	Vector2 up_direction = Vector2(0.0, -1.0);
 	uint32_t moving_platform_floor_layers = UINT32_MAX;
 	uint32_t moving_platform_wall_layers = 0;
-	Vector2 motion_velocity;
+	Vector2 velocity;
 
 	Vector2 floor_normal;
 	Vector2 platform_velocity;

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -354,8 +354,8 @@ public:
 	};
 	bool move_and_slide();
 
-	const Vector3 &get_motion_velocity() const;
-	void set_motion_velocity(const Vector3 &p_velocity);
+	const Vector3 &get_velocity() const;
+	void set_velocity(const Vector3 &p_velocity);
 
 	bool is_on_floor() const;
 	bool is_on_floor_only() const;
@@ -416,7 +416,7 @@ private:
 	real_t floor_max_angle = Math::deg2rad((real_t)45.0);
 	real_t wall_min_slide_angle = Math::deg2rad((real_t)15.0);
 	Vector3 up_direction = Vector3(0.0, 1.0, 0.0);
-	Vector3 motion_velocity;
+	Vector3 velocity;
 	Vector3 floor_normal;
 	Vector3 wall_normal;
 	Vector3 ceiling_normal;


### PR DESCRIPTION
This is purely a name change. `motion_velocity` is redundant and awkward, akin to `location_position` instead of `position`. 

I've seen the arguments that people have been using `velocity` as a user-defined variable in Godot 3.x, but I don't see how that prevents using the name now. We're already breaking all those old scripts with the rest of the new functionality. The reason that we all named it `velocity` in our scripts in 3.x is because that's what the value *is*. We have a `position` property, and now we have a `velocity` property.

We're going to be looking at this a lot in the next `n` years, so let's fix it now. I could also live with `motion` or `linear_velocity` (to be consistent with the rigid body property), if necessary.
