### PR TITLE
Fix invisible CanvasItem visibility issue

### DIFF
--- a/scene/main/canvas_item.h
+++ b/scene/main/canvas_item.h
@@ -108,7 +108,8 @@ private:
 
 	void _top_level_raise_self();
 
-	void _propagate_visibility_changed(bool p_visible, bool p_is_source = false);
+	void _propagate_visibility_changed(bool p_parent_visible_in_tree);
+	void _handle_visibility_change(bool p_visible);
 
 	void _update_callback();
 

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -58,11 +58,7 @@ void CanvasLayer::set_visible(bool p_visible) {
 		if (c) {
 			RenderingServer::get_singleton()->canvas_item_set_visible(c->get_canvas_item(), p_visible && c->is_visible());
 
-			if (c->is_visible()) {
-				c->_propagate_visibility_changed(p_visible);
-			} else {
-				c->parent_visible_in_tree = p_visible;
-			}
+			c->_propagate_visibility_changed(p_visible);
 		}
 	}
 }


### PR DESCRIPTION
Attempt to fix #58388

Make sure that parent is visible in tree before updating Rendering server.
~~I believe, that `NOTIFICATION_VISIBILITY_CHANGED` should be sent independent on the visibility status of the parent.~~
