### PR TITLE
[3.x] CI: Use `mono_static=yes` for Mono builds

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -22,7 +22,7 @@ jobs:
             cache-name: linux-editor-mono
             target: release_debug
             tools: true
-            sconsflags: module_mono_enabled=yes mono_glue=no
+            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no
             bin: "./bin/godot.x11.opt.tools.64.mono"
             build-mono: true
             artifact: true
@@ -42,7 +42,7 @@ jobs:
             cache-name: linux-template-mono
             target: release
             tools: false
-            sconsflags: module_mono_enabled=yes mono_glue=no debug_symbols=no
+            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no debug_symbols=no
             build-mono: false
             artifact: true
 

--- a/.github/workflows/server_builds.yml
+++ b/.github/workflows/server_builds.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 # Global Settings
 env:
   GODOT_BASE_BRANCH: 3.x
-  SCONSFLAGS: verbose=yes warnings=all werror=yes debug_symbols=no module_mono_enabled=yes mono_glue=no
+  SCONSFLAGS: verbose=yes warnings=all werror=yes debug_symbols=no module_mono_enabled=yes mono_static=yes mono_glue=no
 
 concurrency:
   group: ci-${{github.actor}}-${{github.head_ref || github.run_number}}-${{github.ref}}-server


### PR DESCRIPTION
This removes the dependency on shared libmonosgen installed locally
and makes the artifacts usable as standalone for testing without
needing a full Mono install.