### PR TITLE
CI: Use `mono_static=yes` for Mono builds

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -23,7 +23,7 @@ jobs:
             target: release_debug
             tools: true
             tests: false # Disabled due freeze caused by mix Mono build and CI
-            sconsflags: module_mono_enabled=yes mono_glue=no
+            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no
             doc-test: true
             bin: "./bin/godot.linuxbsd.opt.tools.64.mono"
             build-mono: true
@@ -47,7 +47,7 @@ jobs:
             target: release
             tools: false
             tests: false
-            sconsflags: module_mono_enabled=yes mono_glue=no debug_symbols=no
+            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no debug_symbols=no
             build-mono: false
             artifact: true
 


### PR DESCRIPTION
This removes the dependency on shared libmonosgen installed locally
and makes the artifacts usable as standalone for testing without
needing a full Mono install.

`master` version of #58425.