### PR TITLE
Provide safe array operator for Vector2 / 3 in DEV builds

### DIFF
--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -208,6 +208,7 @@ void _err_flush_stdout();
 #define CRASH_BAD_INDEX(m_index, m_size)                                                                                  \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                               \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
+		_err_flush_stdout();                                                                                              \
 		GENERATE_TRAP                                                                                                     \
 	} else                                                                                                                \
 		((void)0)
@@ -221,6 +222,7 @@ void _err_flush_stdout();
 #define CRASH_BAD_INDEX_MSG(m_index, m_size, m_msg)                                                                          \
 	if (unlikely((m_index) < 0 || (m_index) >= (m_size))) {                                                                  \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), m_msg, true); \
+		_err_flush_stdout();                                                                                                 \
 		GENERATE_TRAP                                                                                                        \
 	} else                                                                                                                   \
 		((void)0)
@@ -234,6 +236,7 @@ void _err_flush_stdout();
 #define CRASH_BAD_UNSIGNED_INDEX(m_index, m_size)                                                                         \
 	if (unlikely((m_index) >= (m_size))) {                                                                                \
 		_err_print_index_error(FUNCTION_STR, __FILE__, __LINE__, m_index, m_size, _STR(m_index), _STR(m_size), "", true); \
+		_err_flush_stdout();                                                                                              \
 		GENERATE_TRAP                                                                                                     \
 	} else                                                                                                                \
 		((void)0)
@@ -305,6 +308,7 @@ void _err_flush_stdout();
 #define CRASH_COND(m_cond)                                                                                    \
 	if (unlikely(m_cond)) {                                                                                   \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true."); \
+		_err_flush_stdout();                                                                                  \
 		GENERATE_TRAP                                                                                         \
 	} else                                                                                                    \
 		((void)0)
@@ -316,6 +320,7 @@ void _err_flush_stdout();
 #define CRASH_COND_MSG(m_cond, m_msg)                                                                                \
 	if (unlikely(m_cond)) {                                                                                          \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Condition \"" _STR(m_cond) "\" is true.", m_msg); \
+		_err_flush_stdout();                                                                                         \
 		GENERATE_TRAP                                                                                                \
 	} else                                                                                                           \
 		((void)0)
@@ -427,7 +432,7 @@ void _err_flush_stdout();
 #define CRASH_NOW()                                                                  \
 	if (true) {                                                                      \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method failed."); \
-		void _err_flush_stdout();                                                    \
+		_err_flush_stdout();                                                         \
 		GENERATE_TRAP                                                                \
 	} else                                                                           \
 		((void)0)
@@ -439,7 +444,7 @@ void _err_flush_stdout();
 #define CRASH_NOW_MSG(m_msg)                                                                \
 	if (true) {                                                                             \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: Method failed.", m_msg); \
-		void _err_flush_stdout();                                                           \
+		_err_flush_stdout();                                                                \
 		GENERATE_TRAP                                                                       \
 	} else                                                                                  \
 		((void)0)
@@ -523,7 +528,7 @@ void _err_flush_stdout();
 #define DEV_ASSERT(m_cond)                                                                                              \
 	if (unlikely(!(m_cond))) {                                                                                          \
 		_err_print_error(FUNCTION_STR, __FILE__, __LINE__, "FATAL: DEV_ASSERT failed  \"" _STR(m_cond) "\" is false."); \
-		void _err_flush_stdout();                                                                                       \
+		_err_flush_stdout();                                                                                            \
 		GENERATE_TRAP                                                                                                   \
 	} else                                                                                                              \
 		((void)0)

--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -60,9 +60,11 @@ struct _NO_DISCARD_CLASS_ Vector2 {
 	};
 
 	_FORCE_INLINE_ real_t &operator[](int p_idx) {
+		DEV_ASSERT((unsigned int)p_idx < 2);
 		return coord[p_idx];
 	}
 	_FORCE_INLINE_ const real_t &operator[](int p_idx) const {
+		DEV_ASSERT((unsigned int)p_idx < 2);
 		return coord[p_idx];
 	}
 
@@ -291,9 +293,11 @@ struct _NO_DISCARD_CLASS_ Vector2i {
 	};
 
 	_FORCE_INLINE_ int &operator[](int p_idx) {
+		DEV_ASSERT((unsigned int)p_idx < 2);
 		return coord[p_idx];
 	}
 	_FORCE_INLINE_ const int &operator[](int p_idx) const {
+		DEV_ASSERT((unsigned int)p_idx < 2);
 		return coord[p_idx];
 	}
 

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -56,10 +56,12 @@ struct _NO_DISCARD_CLASS_ Vector3 {
 	};
 
 	_FORCE_INLINE_ const real_t &operator[](int p_axis) const {
+		DEV_ASSERT((unsigned int)p_axis < 3);
 		return coord[p_axis];
 	}
 
 	_FORCE_INLINE_ real_t &operator[](int p_axis) {
+		DEV_ASSERT((unsigned int)p_axis < 3);
 		return coord[p_axis];
 	}
 


### PR DESCRIPTION
A previous PR had changed the array operator to give unbounded access. This could cause crashes where old code depended on this previous safe behaviour.

This PR adds DEV_ASSERT macros for out of bound access to debug builds, allowing us to quickly identify bugs in calling code.

The current situation of having no checks is fast, and will still likely crash (without an error message), but may not crash in _all circumstances_ hence forcing a halt may be a good idea (or handling it).

Highlights crash in #58423

## Notes
* Alternatives considered include ERR_FAIL_INDEX and compiling in release
* We also originally looked at having a DEBUG_ONLY CRASH_BAD_INDEX, however on balance a DEV_ONLY macro should catch 99% of such bugs, at no cost in the `release_debug` editor, so maybe better (at least we can evaluate how we get on with this)
* I'm using the old trick here of casting the `int` to `unsigned int` therefore combining the checks for < 0 and > count in the same comparison. After a little check on godbolt, the compiler knows this trick in release with optimization but not in debug, so it is worth doing. We should probably actually do this in the `CRASH_BAD_INDEX` macro actually but I'll leave that for another PR.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
