### PR TITLE
[4.x] Provide safe array operator for Vector2s in Debug builds

### DIFF
--- a/core/math/vector2.h
+++ b/core/math/vector2.h
@@ -31,6 +31,7 @@
 #ifndef VECTOR2_H
 #define VECTOR2_H
 
+#include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
 
 class String;
@@ -60,9 +61,15 @@ struct _NO_DISCARD_ Vector2 {
 	};
 
 	_FORCE_INLINE_ real_t &operator[](int p_idx) {
+#ifdef DEBUG_ENABLED
+		ERR_FAIL_INDEX_V(p_idx, 2, y);
+#endif
 		return coord[p_idx];
 	}
 	_FORCE_INLINE_ const real_t &operator[](int p_idx) const {
+#ifdef DEBUG_ENABLED
+		ERR_FAIL_INDEX_V(p_idx, 2, y);
+#endif
 		return coord[p_idx];
 	}
 

--- a/core/math/vector2i.h
+++ b/core/math/vector2i.h
@@ -31,6 +31,7 @@
 #ifndef VECTOR2I_H
 #define VECTOR2I_H
 
+#include "core/error/error_macros.h"
 #include "core/math/math_funcs.h"
 
 class String;
@@ -58,9 +59,15 @@ struct _NO_DISCARD_ Vector2i {
 	};
 
 	_FORCE_INLINE_ int32_t &operator[](int p_idx) {
+#ifdef DEBUG_ENABLED
+		ERR_FAIL_INDEX_V(p_idx, 2, y);
+#endif
 		return coord[p_idx];
 	}
 	_FORCE_INLINE_ const int32_t &operator[](int p_idx) const {
+#ifdef DEBUG_ENABLED
+		ERR_FAIL_INDEX_V(p_idx, 2, y);
+#endif
 		return coord[p_idx];
 	}
 


### PR DESCRIPTION
A previous PR had changed the array operator to give unbounded access. This could cause crashes where old code depended on this previous safe behaviour.

This PR adds safe ERR_FAILs to debug builds, enabling the editor to run without crashing, and allowing us to identify bugs in calling code.

4.x version of #58427

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
