### PR TITLE
Add functionality for enlarging Rect2i to include a given point

### DIFF
--- a/core/math/rect2i.h
+++ b/core/math/rect2i.h
@@ -216,6 +216,39 @@ struct _NO_DISCARD_ Rect2i {
 		size = end - begin;
 	}
 
+	_FORCE_INLINE_ Rect2i expand_include(const Vector2i &p_vector) const {
+		Rect2i r = *this;
+		r.expand_to_include(p_vector);
+		return r;
+	}
+
+	inline void expand_to_include(const Point2i &p_vector) {
+#ifdef MATH_CHECKS
+		if (unlikely(size.x < 0 || size.y < 0)) {
+			ERR_PRINT("Rect2i size is negative, this is not supported. Use Rect2i.abs() to get a Rect2i with a positive size.");
+		}
+#endif
+		Point2i begin = position;
+		Point2i end = position + size;
+
+		if (p_vector.x < begin.x) {
+			begin.x = p_vector.x;
+		}
+		if (p_vector.y < begin.y) {
+			begin.y = p_vector.y;
+		}
+
+		if (p_vector.x >= end.x) {
+			end.x = p_vector.x + 1;
+		}
+		if (p_vector.y >= end.y) {
+			end.y = p_vector.y + 1;
+		}
+
+		position = begin;
+		size = end - begin;
+	}
+
 	_FORCE_INLINE_ Rect2i abs() const {
 		return Rect2i(Point2i(position.x + MIN(size.x, 0), position.y + MIN(size.y, 0)), size.abs());
 	}

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1550,6 +1550,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Rect2i, intersection, sarray("b"), varray());
 	bind_method(Rect2i, merge, sarray("b"), varray());
 	bind_method(Rect2i, expand, sarray("to"), varray());
+	bind_method(Rect2i, expand_include, sarray("to"), varray());
 	bind_method(Rect2i, grow, sarray("amount"), varray());
 	bind_methodv(Rect2i, grow_side, &Rect2i::grow_side_bind, sarray("side", "amount"), varray());
 	bind_method(Rect2i, grow_individual, sarray("left", "top", "right", "bottom"), varray());

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -85,6 +85,29 @@
 				var rect2 = rect.Expand(new Vector2i(0, -1));
 				[/csharp]
 				[/codeblocks]
+				[b]Note:[/b] If you need functionality that includes the point into the [Rect2i], use [method expand_include] instead.
+			</description>
+		</method>
+		<method name="expand_include" qualifiers="const">
+			<return type="Rect2i" />
+			<argument index="0" name="to" type="Vector2i" />
+			<description>
+				Returns a copy of this [Rect2i] expanded so that it contains the given point.
+				[codeblocks]
+				[gdscript]
+				# position (2, 1), size (1, 1)
+				var rect = Rect2i(Vector2i(2, 1), Vector2i(1, 1))
+				# position (2, 1), size (2, 2), so we fit both rect and Vector2i(3, 2)
+				var rect2 = rect.expand_include(Vector2i(3, 2))
+				[/gdscript]
+				[csharp]
+				# position (2, 1), size (1, 1)
+				var rect = new Rect2i(new Vector2i(2, 1), new Vector2i(1, 1));
+				# position (2, 1), size (2, 2), so we fit both rect and Vector2i(3, 2)
+				var rect2 = rect.ExpandInclude(new Vector2i(3, 2));
+				[/csharp]
+				[/codeblocks]
+				[b]Note:[/b] If you need functionality that mimicks [method Rect2.expand], use [method expand] instead.
 			</description>
 		</method>
 		<method name="get_area" qualifiers="const">

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -829,7 +829,7 @@ void TileMapEditorTilesPlugin::forward_canvas_draw_over_viewport(Control *p_over
 			if (expand_grid && !preview.is_empty()) {
 				drawn_grid_rect = Rect2i(preview.front()->key(), Vector2i(1, 1));
 				for (const KeyValue<Vector2i, TileMapCell> &E : preview) {
-					drawn_grid_rect.expand_to(E.key);
+					drawn_grid_rect.expand_to_include(E.key);
 				}
 			}
 		}
@@ -1577,8 +1577,7 @@ void TileMapEditorTilesPlugin::_update_selection_pattern_from_tileset_tiles_sele
 			if (E_cell) {
 				encompassing_rect_coords = Rect2i(E_cell->key(), Vector2i(1, 1));
 				for (; E_cell; E_cell = E_cell->next()) {
-					encompassing_rect_coords.expand_to(E_cell->key() + Vector2i(1, 1));
-					encompassing_rect_coords.expand_to(E_cell->key());
+					encompassing_rect_coords.expand_to_include(E_cell->key());
 				}
 			}
 		} else {
@@ -3001,7 +3000,7 @@ void TileMapEditorTerrainsPlugin::forward_canvas_draw_over_viewport(Control *p_o
 			if (expand_grid && !preview.is_empty()) {
 				drawn_grid_rect = Rect2i(preview.front()->get(), Vector2i(1, 1));
 				for (const Vector2i &E : preview) {
-					drawn_grid_rect.expand_to(E);
+					drawn_grid_rect.expand_to_include(E);
 				}
 			}
 		}
@@ -3880,13 +3879,10 @@ void TileMapEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
 
 	// Determine the drawn area.
 	Size2 screen_size = p_overlay->get_size();
-	Rect2i screen_rect;
-	screen_rect.position = tile_map->world_to_map(xform_inv.xform(Vector2()));
-	screen_rect.expand_to(tile_map->world_to_map(xform_inv.xform(Vector2(0, screen_size.height))));
-	screen_rect.expand_to(tile_map->world_to_map(xform_inv.xform(Vector2(screen_size.width, 0))));
-	screen_rect.expand_to(tile_map->world_to_map(xform_inv.xform(screen_size)));
-	screen_rect = screen_rect.grow(1);
-
+	Rect2i screen_rect = Rect2i(tile_map->world_to_map(xform_inv.xform(Vector2())), Size2i(1, 1));
+	screen_rect.expand_to_include(tile_map->world_to_map(xform_inv.xform(Vector2(0, screen_size.height))));
+	screen_rect.expand_to_include(tile_map->world_to_map(xform_inv.xform(Vector2(screen_size.width, 0))));
+	screen_rect.expand_to_include(tile_map->world_to_map(xform_inv.xform(screen_size)));
 	Rect2i tilemap_used_rect = tile_map->get_used_rect();
 
 	Rect2i displayed_rect = tilemap_used_rect.intersection(screen_rect);

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -3374,19 +3374,16 @@ Rect2 TileMap::get_used_rect() { // Not const because of cache
 			const Map<Vector2i, TileMapCell> &tile_map = layers[i].tile_map;
 			if (tile_map.size() > 0) {
 				if (first) {
-					used_rect_cache = Rect2i(tile_map.front()->key().x, tile_map.front()->key().y, 0, 0);
+					used_rect_cache = Rect2i(tile_map.front()->key().x, tile_map.front()->key().y, 1, 1);
 					first = false;
 				}
 
 				for (const KeyValue<Vector2i, TileMapCell> &E : tile_map) {
-					used_rect_cache.expand_to(Vector2i(E.key.x, E.key.y));
+					used_rect_cache.expand_to_include(Vector2i(E.key.x, E.key.y));
 				}
 			}
 		}
 
-		if (!first) { // first is true if every layer is empty.
-			used_rect_cache.size += Vector2i(1, 1); // The cache expands to top-left coordinate, so we add one full tile.
-		}
 		used_rect_cache_dirty = false;
 	}
 


### PR DESCRIPTION
resolve #58431

~~This patch fixes the incompatibility between `Rect2i.expand` and `Rect2i.has_point` by adjusting the behavior of `expand` to comply with `has_point`. It also makes sure, that all locations within the source code, that use `Rect2i.expand`, are adjusted accordingly, which means code-simplifications or bug-fixes.~~
This patch adds new functionality `Rect2i::expand_to_include` that allows a `Rect2i` to grow, so that it includes a given `Vector2i`. It also implements the new function in places of the source code, where it results in code-simplifications or bug fixes.

As @lawnjelly already pointed out the [problems, that this incompatibility brings with it](https://github.com/godotengine/godot/pull/57469#issuecomment-1026525782), I would like to add one thought:

The `Rect2i` code is based on the `Rect2` code. For float numbers there is a distinction between 'inside', 'outside' and 'on the border'. For integers there is no such thing as 'on the border', because it can clearly be distinguished between 'inside' and 'outside'. So the concepts, that are valid for floats, need to be adjusted for integers. This patch does this adjustment for `expand`.

The mentioned problems are also apparent within the Godot source code itself and here are a few examples, that get resolved by this patch.

### Simplifications
The expansion is done on `encompassing_rect_coords` a second time with the point+(1,1), in order to make sure that the point is within the Rect2i:
https://github.com/godotengine/godot/blob/f880414b6a49e869ef6713f77d927fab0a250760/editor/plugins/tiles/tile_map_editor.cpp#L1573-L1577

The Rect2i `screen_rect` is manually enlarged afterwards:
https://github.com/godotengine/godot/blob/872e8a43ca08920c8d3d82a20265742ac7186a66/editor/plugins/tiles/tile_map_editor.cpp#L3878-L3883

### Bug fixes

The current implementation resulted in unnoticed bugs in some areas. One example is that the fade-out grid is under certain conditions too short on the right and on the bottom side:
![TileMapOffset](https://user-images.githubusercontent.com/6299227/155152110-225f3445-8807-4d29-9fa8-4e396949c020.png)

