### PR TITLE
Feature/typed vararg method bind

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -39,7 +39,7 @@ jobs:
             proj-test: true
             # Can be turned off for PRs that intentionally break compat with godot-cpp,
             # until both the upstream PR and the matching godot-cpp changes are merged.
-            godot-cpp-test: true
+            godot-cpp-test: false
             bin: "./bin/godot.linuxbsd.double.tools.64.san"
             build-mono: false
             # Skip 2GiB artifact speeding up action.

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -143,21 +143,20 @@ public:
 	virtual ~MethodBind();
 };
 
-template <class T>
-class MethodBindVarArg : public MethodBind {
-public:
-	typedef Variant (T::*NativeCall)(const Variant **, int, Callable::CallError &);
-
+// MethodBindVarArg base CRTP
+template <class Derived, class T, class R, bool should_returns>
+class MethodBindVarArgBase : public MethodBind {
 protected:
-	NativeCall call_method = nullptr;
-	MethodInfo arguments;
+	R(T::*method)
+	(const Variant **, int, Callable::CallError &);
+	MethodInfo method_info;
 
 public:
 	virtual PropertyInfo _gen_argument_type_info(int p_arg) const {
 		if (p_arg < 0) {
-			return arguments.return_val;
-		} else if (p_arg < arguments.arguments.size()) {
-			return arguments.arguments[p_arg];
+			return _gen_return_type_info();
+		} else if (p_arg < method_info.arguments.size()) {
+			return method_info.arguments[p_arg];
 		} else {
 			return PropertyInfo(Variant::NIL, "arg_" + itos(p_arg), PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_NIL_IS_VARIANT);
 		}
@@ -173,24 +172,31 @@ public:
 	}
 #endif
 
-	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
-		T *instance = static_cast<T *>(p_object);
-		return (instance->*call_method)(p_args, p_arg_count, r_error);
+	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) {
+		ERR_FAIL(); // Can't call.
 	}
 
-	void set_method_info(const MethodInfo &p_info, bool p_return_nil_is_variant) {
-		set_argument_count(p_info.arguments.size());
-		Variant::Type *at = memnew_arr(Variant::Type, p_info.arguments.size() + 1);
-		at[0] = p_info.return_val.type;
-		if (p_info.arguments.size()) {
+	virtual bool is_const() const { return false; }
+
+	virtual bool is_vararg() const { return true; }
+
+	MethodBindVarArgBase(
+			R (T::*p_method)(const Variant **, int, Callable::CallError &),
+			const MethodInfo &p_method_info,
+			bool p_return_nil_is_variant) :
+			method(p_method), method_info(p_method_info) {
+		set_argument_count(method_info.arguments.size());
+		Variant::Type *at = memnew_arr(Variant::Type, method_info.arguments.size() + 1);
+		at[0] = _gen_return_type_info().type;
+		if (method_info.arguments.size()) {
 #ifdef DEBUG_METHODS_ENABLED
 			Vector<StringName> names;
-			names.resize(p_info.arguments.size());
+			names.resize(method_info.arguments.size());
 #endif
-			for (int i = 0; i < p_info.arguments.size(); i++) {
-				at[i + 1] = p_info.arguments[i].type;
+			for (int i = 0; i < method_info.arguments.size(); i++) {
+				at[i + 1] = method_info.arguments[i].type;
 #ifdef DEBUG_METHODS_ENABLED
-				names.write[i] = p_info.arguments[i].name;
+				names.write[i] = method_info.arguments[i].name;
 #endif
 			}
 
@@ -199,31 +205,76 @@ public:
 #endif
 		}
 		argument_types = at;
-		arguments = p_info;
 		if (p_return_nil_is_variant) {
-			arguments.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
+			method_info.return_val.usage |= PROPERTY_USAGE_NIL_IS_VARIANT;
 		}
+
+		_set_returns(should_returns);
 	}
 
-	virtual void ptrcall(Object *p_object, const void **p_args, void *r_ret) {
-		ERR_FAIL(); // Can't call.
+private:
+	PropertyInfo _gen_return_type_info() const {
+		return reinterpret_cast<const Derived *>(this)->_gen_return_type_info_impl();
+	}
+};
+
+// variadic, no return
+template <class T>
+class MethodBindVarArgT : public MethodBindVarArgBase<MethodBindVarArgT<T>, T, void, false> {
+	friend class MethodBindVarArgBase<MethodBindVarArgT<T>, T, void, false>;
+
+public:
+	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+		(static_cast<T *>(p_object)->*MethodBindVarArgBase<MethodBindVarArgT<T>, T, void, false>::method)(p_args, p_arg_count, r_error);
+		return {};
 	}
 
-	void set_method(NativeCall p_method) { call_method = p_method; }
-	virtual bool is_const() const { return false; }
+	MethodBindVarArgT(
+			void (T::*p_method)(const Variant **, int, Callable::CallError &),
+			const MethodInfo &p_method_info,
+			bool p_return_nil_is_variant) :
+			MethodBindVarArgBase<MethodBindVarArgT<T>, T, void, false>(p_method, p_method_info, p_return_nil_is_variant) {
+	}
 
-	virtual bool is_vararg() const { return true; }
-
-	MethodBindVarArg() {
-		_set_returns(true);
+private:
+	PropertyInfo _gen_return_type_info_impl() const {
+		return {};
 	}
 };
 
 template <class T>
-MethodBind *create_vararg_method_bind(Variant (T::*p_method)(const Variant **, int, Callable::CallError &), const MethodInfo &p_info, bool p_return_nil_is_variant) {
-	MethodBindVarArg<T> *a = memnew((MethodBindVarArg<T>));
-	a->set_method(p_method);
-	a->set_method_info(p_info, p_return_nil_is_variant);
+MethodBind *create_vararg_method_bind(void (T::*p_method)(const Variant **, int, Callable::CallError &), const MethodInfo &p_info, bool p_return_nil_is_variant) {
+	MethodBind *a = memnew((MethodBindVarArgT<T>)(p_method, p_info, p_return_nil_is_variant));
+	a->set_instance_class(T::get_class_static());
+	return a;
+}
+
+// variadic, return
+template <class T, class R>
+class MethodBindVarArgTR : public MethodBindVarArgBase<MethodBindVarArgTR<T, R>, T, R, true> {
+	friend class MethodBindVarArgBase<MethodBindVarArgTR<T, R>, T, R, true>;
+
+public:
+	virtual Variant call(Object *p_object, const Variant **p_args, int p_arg_count, Callable::CallError &r_error) {
+		return (static_cast<T *>(p_object)->*MethodBindVarArgBase<MethodBindVarArgTR<T, R>, T, R, true>::method)(p_args, p_arg_count, r_error);
+	}
+
+	MethodBindVarArgTR(
+			R (T::*p_method)(const Variant **, int, Callable::CallError &),
+			const MethodInfo &p_info,
+			bool p_return_nil_is_variant) :
+			MethodBindVarArgBase<MethodBindVarArgTR<T, R>, T, R, true>(p_method, p_info, p_return_nil_is_variant) {
+	}
+
+private:
+	PropertyInfo _gen_return_type_info_impl() const {
+		return GetTypeInfo<R>::get_class_info();
+	}
+};
+
+template <class T, class R>
+MethodBind *create_vararg_method_bind(R (T::*p_method)(const Variant **, int, Callable::CallError &), const MethodInfo &p_info, bool p_return_nil_is_variant) {
+	MethodBind *a = memnew((MethodBindVarArgTR<T, R>)(p_method, p_info, p_return_nil_is_variant));
 	a->set_instance_class(T::get_class_static());
 	return a;
 }

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1028,15 +1028,15 @@ struct _ObjectSignalDisconnectData {
 	Callable callable;
 };
 
-Variant Object::_emit_signal(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+Error Object::_emit_signal(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 
-	ERR_FAIL_COND_V(p_argcount < 1, Variant());
+	ERR_FAIL_COND_V(p_argcount < 1, Error::ERR_INVALID_PARAMETER);
 	if (p_args[0]->get_type() != Variant::STRING_NAME && p_args[0]->get_type() != Variant::STRING) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::STRING_NAME;
-		ERR_FAIL_COND_V(p_args[0]->get_type() != Variant::STRING_NAME && p_args[0]->get_type() != Variant::STRING, Variant());
+		ERR_FAIL_COND_V(p_args[0]->get_type() != Variant::STRING_NAME && p_args[0]->get_type() != Variant::STRING, Error::ERR_INVALID_PARAMETER);
 	}
 
 	r_error.error = Callable::CallError::CALL_OK;
@@ -1050,9 +1050,7 @@ Variant Object::_emit_signal(const Variant **p_args, int p_argcount, Callable::C
 		args = &p_args[1];
 	}
 
-	emit_signalp(signal, args, argc);
-
-	return Variant();
+	return emit_signalp(signal, args, argc);
 }
 
 Error Object::emit_signalp(const StringName &p_name, const Variant **p_args, int p_argcount) {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -522,7 +522,7 @@ private:
 
 	void _add_user_signal(const String &p_name, const Array &p_args = Array());
 	bool _has_user_signal(const StringName &p_name) const;
-	Variant _emit_signal(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
+	Error _emit_signal(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 	Array _get_signal_list() const;
 	Array _get_signal_connection_list(const String &p_signal) const;
 	Array _get_incoming_connections() const;

--- a/core/object/undo_redo.cpp
+++ b/core/object/undo_redo.cpp
@@ -444,25 +444,25 @@ UndoRedo::~UndoRedo() {
 	clear_history();
 }
 
-Variant UndoRedo::_add_do_method(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+void UndoRedo::_add_do_method(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	if (p_argcount < 2) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 		r_error.argument = 0;
-		return Variant();
+		return;
 	}
 
 	if (p_args[0]->get_type() != Variant::OBJECT) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::OBJECT;
-		return Variant();
+		return;
 	}
 
 	if (p_args[1]->get_type() != Variant::STRING_NAME && p_args[1]->get_type() != Variant::STRING) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 1;
 		r_error.expected = Variant::STRING_NAME;
-		return Variant();
+		return;
 	}
 
 	r_error.error = Callable::CallError::CALL_OK;
@@ -471,28 +471,27 @@ Variant UndoRedo::_add_do_method(const Variant **p_args, int p_argcount, Callabl
 	StringName method = *p_args[1];
 
 	add_do_methodp(object, method, p_args + 2, p_argcount - 2);
-	return Variant();
 }
 
-Variant UndoRedo::_add_undo_method(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+void UndoRedo::_add_undo_method(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	if (p_argcount < 2) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 		r_error.argument = 0;
-		return Variant();
+		return;
 	}
 
 	if (p_args[0]->get_type() != Variant::OBJECT) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::OBJECT;
-		return Variant();
+		return;
 	}
 
 	if (p_args[1]->get_type() != Variant::STRING_NAME && p_args[1]->get_type() != Variant::STRING) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 1;
 		r_error.expected = Variant::STRING_NAME;
-		return Variant();
+		return;
 	}
 
 	r_error.error = Callable::CallError::CALL_OK;
@@ -501,7 +500,6 @@ Variant UndoRedo::_add_undo_method(const Variant **p_args, int p_argcount, Calla
 	StringName method = *p_args[1];
 
 	add_undo_methodp(object, method, p_args + 2, p_argcount - 2);
-	return Variant();
 }
 
 void UndoRedo::_bind_methods() {

--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -46,8 +46,8 @@ public:
 	};
 
 	typedef void (*CommitNotifyCallback)(void *p_ud, const String &p_name);
-	Variant _add_do_method(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
-	Variant _add_undo_method(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
+	void _add_do_method(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
+	void _add_undo_method(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
 	typedef void (*MethodNotifyCallback)(void *p_ud, Object *p_base, const StringName &p_name, const Variant **p_args, int p_argcount);
 	typedef void (*PropertyNotifyCallback)(void *p_ud, Object *p_base, const StringName &p_property, const Variant &p_value);

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -586,7 +586,7 @@
 			</description>
 		</method>
 		<method name="rpc" qualifiers="vararg">
-			<return type="Variant" />
+			<return type="void" />
 			<argument index="0" name="method" type="StringName" />
 			<description>
 				Sends a remote procedure call request for the given [code]method[/code] to peers on the network (and locally), optionally sending all additional arguments as arguments to the method called by the RPC. The call request will only be received by nodes with the same [NodePath], including the exact same node name. Behaviour depends on the RPC configuration for the given method, see [method rpc_config]. Methods are not exposed to RPCs by default. Returns an empty [Variant].
@@ -605,7 +605,7 @@
 			</description>
 		</method>
 		<method name="rpc_id" qualifiers="vararg">
-			<return type="Variant" />
+			<return type="void" />
 			<argument index="0" name="peer_id" type="int" />
 			<argument index="1" name="method" type="StringName" />
 			<description>

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -107,7 +107,7 @@
 			</description>
 		</method>
 		<method name="call_deferred" qualifiers="vararg">
-			<return type="void" />
+			<return type="Variant" />
 			<argument index="0" name="method" type="StringName" />
 			<description>
 				Calls the [code]method[/code] on the object during idle time. This method supports a variable number of arguments, so parameters are passed as a comma separated list. Example:
@@ -301,7 +301,7 @@
 			</description>
 		</method>
 		<method name="emit_signal" qualifiers="vararg">
-			<return type="void" />
+			<return type="int" enum="Error" />
 			<argument index="0" name="signal" type="StringName" />
 			<description>
 				Emits the given [code]signal[/code]. The signal must exist, so it should be a built-in signal of this class or one of its parent classes, or a user-defined signal. This method supports a variable number of arguments, so parameters are passed as a comma separated list. Example:

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -14,7 +14,7 @@
 	</tutorials>
 	<methods>
 		<method name="call_group" qualifiers="vararg">
-			<return type="Variant" />
+			<return type="void" />
 			<argument index="0" name="group" type="StringName" />
 			<argument index="1" name="method" type="StringName" />
 			<description>
@@ -24,7 +24,7 @@
 			</description>
 		</method>
 		<method name="call_group_flags" qualifiers="vararg">
-			<return type="Variant" />
+			<return type="void" />
 			<argument index="0" name="flags" type="int" />
 			<argument index="1" name="group" type="StringName" />
 			<argument index="2" name="method" type="StringName" />

--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -22,7 +22,7 @@
 			</description>
 		</method>
 		<method name="call_recursive" qualifiers="vararg">
-			<return type="Variant" />
+			<return type="void" />
 			<argument index="0" name="method" type="StringName" />
 			<description>
 				Calls the [code]method[/code] on the actual TreeItem and its children recursively. Pass parameters as a comma separated list.

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1162,24 +1162,23 @@ Size2 TreeItem::get_minimum_size(int p_column) {
 	return cell.cached_minimum_size;
 }
 
-Variant TreeItem::_call_recursive_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+void TreeItem::_call_recursive_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	if (p_argcount < 1) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 		r_error.argument = 0;
-		return Variant();
+		return;
 	}
 
 	if (p_args[0]->get_type() != Variant::STRING && p_args[0]->get_type() != Variant::STRING_NAME) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::STRING_NAME;
-		return Variant();
+		return;
 	}
 
 	StringName method = *p_args[0];
 
 	call_recursive(method, &p_args[1], p_argcount - 1, r_error);
-	return Variant();
 }
 
 void recursive_call_aux(TreeItem *p_item, const StringName &p_method, const Variant **p_args, int p_argcount, Callable::CallError &r_error) {

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -189,7 +189,7 @@ protected:
 		return d;
 	}
 
-	Variant _call_recursive_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
+	void _call_recursive_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
 public:
 	/* cell mode */

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -582,11 +582,11 @@ uint16_t Node::rpc_config(const StringName &p_method, Multiplayer::RPCMode p_rpc
 
 /***** RPC FUNCTIONS ********/
 
-Variant Node::_rpc_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+void Node::_rpc_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	if (p_argcount < 1) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 		r_error.argument = 1;
-		return Variant();
+		return;
 	}
 
 	Variant::Type type = p_args[0]->get_type();
@@ -594,7 +594,7 @@ Variant Node::_rpc_bind(const Variant **p_args, int p_argcount, Callable::CallEr
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::STRING_NAME;
-		return Variant();
+		return;
 	}
 
 	StringName method = (*p_args[0]).operator StringName();
@@ -602,21 +602,20 @@ Variant Node::_rpc_bind(const Variant **p_args, int p_argcount, Callable::CallEr
 	rpcp(0, method, &p_args[1], p_argcount - 1);
 
 	r_error.error = Callable::CallError::CALL_OK;
-	return Variant();
 }
 
-Variant Node::_rpc_id_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+void Node::_rpc_id_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	if (p_argcount < 2) {
 		r_error.error = Callable::CallError::CALL_ERROR_TOO_FEW_ARGUMENTS;
 		r_error.argument = 2;
-		return Variant();
+		return;
 	}
 
 	if (p_args[0]->get_type() != Variant::INT) {
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 0;
 		r_error.expected = Variant::INT;
-		return Variant();
+		return;
 	}
 
 	Variant::Type type = p_args[1]->get_type();
@@ -624,7 +623,7 @@ Variant Node::_rpc_id_bind(const Variant **p_args, int p_argcount, Callable::Cal
 		r_error.error = Callable::CallError::CALL_ERROR_INVALID_ARGUMENT;
 		r_error.argument = 1;
 		r_error.expected = Variant::STRING_NAME;
-		return Variant();
+		return;
 	}
 
 	int peer_id = *p_args[0];
@@ -633,7 +632,6 @@ Variant Node::_rpc_id_bind(const Variant **p_args, int p_argcount, Callable::Cal
 	rpcp(peer_id, method, &p_args[2], p_argcount - 2);
 
 	r_error.error = Callable::CallError::CALL_OK;
-	return Variant();
 }
 
 void Node::rpcp(int p_peer_id, const StringName &p_method, const Variant **p_arg, int p_argcount) {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -178,8 +178,8 @@ private:
 	TypedArray<Node> _get_children(bool p_include_internal = true) const;
 	Array _get_groups() const;
 
-	Variant _rpc_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
-	Variant _rpc_id_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
+	void _rpc_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
+	void _rpc_id_bind(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
 	_FORCE_INLINE_ bool _is_internal_front() const { return data.parent && data.pos < data.parent->data.internal_children_front; }
 	_FORCE_INLINE_ bool _is_internal_back() const { return data.parent && data.pos >= data.parent->data.children.size() - data.parent->data.internal_children_back; }

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -912,34 +912,32 @@ void SceneTree::_call_input_pause(const StringName &p_group, CallInputType p_cal
 	}
 }
 
-Variant SceneTree::_call_group_flags(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+void SceneTree::_call_group_flags(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	r_error.error = Callable::CallError::CALL_OK;
 
-	ERR_FAIL_COND_V(p_argcount < 3, Variant());
-	ERR_FAIL_COND_V(!p_args[0]->is_num(), Variant());
-	ERR_FAIL_COND_V(p_args[1]->get_type() != Variant::STRING_NAME && p_args[1]->get_type() != Variant::STRING, Variant());
-	ERR_FAIL_COND_V(p_args[2]->get_type() != Variant::STRING_NAME && p_args[2]->get_type() != Variant::STRING, Variant());
+	ERR_FAIL_COND(p_argcount < 3);
+	ERR_FAIL_COND(!p_args[0]->is_num());
+	ERR_FAIL_COND(p_args[1]->get_type() != Variant::STRING_NAME && p_args[1]->get_type() != Variant::STRING);
+	ERR_FAIL_COND(p_args[2]->get_type() != Variant::STRING_NAME && p_args[2]->get_type() != Variant::STRING);
 
 	int flags = *p_args[0];
 	StringName group = *p_args[1];
 	StringName method = *p_args[2];
 
 	call_group_flagsp(flags, group, method, p_args + 3, p_argcount - 3);
-	return Variant();
 }
 
-Variant SceneTree::_call_group(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
+void SceneTree::_call_group(const Variant **p_args, int p_argcount, Callable::CallError &r_error) {
 	r_error.error = Callable::CallError::CALL_OK;
 
-	ERR_FAIL_COND_V(p_argcount < 2, Variant());
-	ERR_FAIL_COND_V(p_args[0]->get_type() != Variant::STRING_NAME && p_args[0]->get_type() != Variant::STRING, Variant());
-	ERR_FAIL_COND_V(p_args[1]->get_type() != Variant::STRING_NAME && p_args[1]->get_type() != Variant::STRING, Variant());
+	ERR_FAIL_COND(p_argcount < 2);
+	ERR_FAIL_COND(p_args[0]->get_type() != Variant::STRING_NAME && p_args[0]->get_type() != Variant::STRING);
+	ERR_FAIL_COND(p_args[1]->get_type() != Variant::STRING_NAME && p_args[1]->get_type() != Variant::STRING);
 
 	StringName group = *p_args[0];
 	StringName method = *p_args[1];
 
 	call_group_flagsp(0, group, method, p_args + 2, p_argcount - 2);
-	return Variant();
 }
 
 int64_t SceneTree::get_frame() const {

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -175,8 +175,8 @@ private:
 	void make_group_changed(const StringName &p_group);
 
 	void _notify_group_pause(const StringName &p_group, int p_notification);
-	Variant _call_group_flags(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
-	Variant _call_group(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
+	void _call_group_flags(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
+	void _call_group(const Variant **p_args, int p_argcount, Callable::CallError &r_error);
 
 	void _flush_delete_queue();
 	// Optimization.


### PR DESCRIPTION
This enables to register variadic method with typed return (not only `Variant`) and `void`.  
This make api more precise when dealing with variadic methods.