### PR TITLE
Remove the error code return from `Object.connect`.

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1301,11 +1301,11 @@ void Object::get_signals_connected_to_this(List<Connection> *p_connections) cons
 	}
 }
 
-Error Object::connect(const StringName &p_signal, const Callable &p_callable, const Vector<Variant> &p_binds, uint32_t p_flags) {
-	ERR_FAIL_COND_V_MSG(p_callable.is_null(), ERR_INVALID_PARAMETER, "Cannot connect to '" + p_signal + "': the provided callable is null.");
+void Object::connect(const StringName &p_signal, const Callable &p_callable, const Vector<Variant> &p_binds, uint32_t p_flags) {
+	ERR_FAIL_COND_MSG(p_callable.is_null(), "Cannot connect to '" + p_signal + "': the provided callable is null.");
 
 	Object *target_object = p_callable.get_object();
-	ERR_FAIL_COND_V_MSG(!target_object, ERR_INVALID_PARAMETER, "Cannot connect to '" + p_signal + "' to callable '" + p_callable + "': the callable object is null.");
+	ERR_FAIL_COND_MSG(!target_object, "Cannot connect to '" + p_signal + "' to callable '" + p_callable + "': the callable object is null.");
 
 	SignalData *s = signal_map.getptr(p_signal);
 	if (!s) {
@@ -1325,7 +1325,7 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, co
 #endif
 		}
 
-		ERR_FAIL_COND_V_MSG(!signal_is_valid, ERR_INVALID_PARAMETER, "In Object of type '" + String(get_class()) + "': Attempt to connect nonexistent signal '" + p_signal + "' to callable '" + p_callable + "'.");
+		ERR_FAIL_COND_MSG(!signal_is_valid, "In Object of type '" + String(get_class()) + "': Attempt to connect nonexistent signal '" + p_signal + "' to callable '" + p_callable + "'.");
 
 		signal_map[p_signal] = SignalData();
 		s = &signal_map[p_signal];
@@ -1337,9 +1337,9 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, co
 	if (s->slot_map.has(*target.get_base_comparator())) {
 		if (p_flags & CONNECT_REFERENCE_COUNTED) {
 			s->slot_map[*target.get_base_comparator()].reference_count++;
-			return OK;
+			return;
 		} else {
-			ERR_FAIL_V_MSG(ERR_INVALID_PARAMETER, "Signal '" + p_signal + "' is already connected to given callable '" + p_callable + "' in that object.");
+			ERR_FAIL_MSG("Signal '" + p_signal + "' is already connected to given callable '" + p_callable + "' in that object.");
 		}
 	}
 
@@ -1359,7 +1359,7 @@ Error Object::connect(const StringName &p_signal, const Callable &p_callable, co
 	//use callable version as key, so binds can be ignored
 	s->slot_map[*target.get_base_comparator()] = slot;
 
-	return OK;
+	return;
 }
 
 bool Object::is_connected(const StringName &p_signal, const Callable &p_callable) const {

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -778,7 +778,7 @@ public:
 	int get_persistent_signal_connection_count() const;
 	void get_signals_connected_to_this(List<Connection> *p_connections) const;
 
-	Error connect(const StringName &p_signal, const Callable &p_callable, const Vector<Variant> &p_binds = Vector<Variant>(), uint32_t p_flags = 0);
+	void connect(const StringName &p_signal, const Callable &p_callable, const Vector<Variant> &p_binds = Vector<Variant>(), uint32_t p_flags = 0);
 	void disconnect(const StringName &p_signal, const Callable &p_callable);
 	bool is_connected(const StringName &p_signal, const Callable &p_callable) const;
 

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -382,11 +382,11 @@ Error Signal::emit(const Variant **p_arguments, int p_argcount) const {
 	return obj->emit_signal(name, p_arguments, p_argcount);
 }
 
-Error Signal::connect(const Callable &p_callable, uint32_t p_flags) {
+void Signal::connect(const Callable &p_callable, uint32_t p_flags) {
 	Object *object = get_object();
-	ERR_FAIL_COND_V(!object, ERR_UNCONFIGURED);
+	ERR_FAIL_COND(!object);
 
-	return object->connect(name, p_callable, varray(), p_flags);
+	object->connect(name, p_callable, varray(), p_flags);
 }
 
 void Signal::disconnect(const Callable &p_callable) {

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -160,7 +160,7 @@ public:
 	operator String() const;
 
 	Error emit(const Variant **p_arguments, int p_argcount) const;
-	Error connect(const Callable &p_callable, uint32_t p_flags = 0);
+	void connect(const Callable &p_callable, uint32_t p_flags = 0);
 	void disconnect(const Callable &p_callable);
 	bool is_connected(const Callable &p_callable) const;
 

--- a/doc/classes/Object.xml
+++ b/doc/classes/Object.xml
@@ -148,7 +148,7 @@
 			</description>
 		</method>
 		<method name="connect">
-			<return type="int" enum="Error" />
+			<return type="void" />
 			<argument index="0" name="signal" type="StringName" />
 			<argument index="1" name="callable" type="Callable" />
 			<argument index="2" name="binds" type="Array" default="[]" />

--- a/doc/classes/Signal.xml
+++ b/doc/classes/Signal.xml
@@ -32,7 +32,7 @@
 	</constructors>
 	<methods>
 		<method name="connect">
-			<return type="int" />
+			<return type="void" />
 			<argument index="0" name="callable" type="Callable" />
 			<argument index="1" name="flags" type="int" default="0" />
 			<description>

--- a/modules/gdscript/gdscript_vm.cpp
+++ b/modules/gdscript/gdscript_vm.cpp
@@ -2146,12 +2146,7 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 
 					retvalue = gdfs;
 
-					Error err = sig.connect(callable_bind(Callable(gdfs.ptr(), "_signal_callback"), retvalue), Object::CONNECT_ONESHOT);
-					if (err != OK) {
-						err_text = "Error connecting to signal: " + sig.get_name() + " during await.";
-						OPCODE_BREAK;
-					}
-
+					sig.connect(callable_bind(Callable(gdfs.ptr(), "_signal_callback"), retvalue), Object::CONNECT_ONESHOT);
 #ifdef DEBUG_ENABLED
 					exit_ok = true;
 					awaited = true;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/SignalAwaiter.cs
@@ -15,7 +15,7 @@ namespace Godot
         }
 
         [MethodImpl(MethodImplOptions.InternalCall)]
-        internal static extern Error godot_icall_SignalAwaiter_connect(IntPtr source, IntPtr signal, IntPtr target, SignalAwaiter awaiter);
+        internal static extern void godot_icall_SignalAwaiter_connect(IntPtr source, IntPtr signal, IntPtr target, SignalAwaiter awaiter);
 
         public bool IsCompleted
         {

--- a/modules/mono/glue/base_object_glue.cpp
+++ b/modules/mono/glue/base_object_glue.cpp
@@ -163,9 +163,9 @@ MonoObject *godot_icall_Object_weakref(Object *p_ptr) {
 	return GDMonoUtils::unmanaged_get_managed(wref.ptr());
 }
 
-int32_t godot_icall_SignalAwaiter_connect(Object *p_source, StringName *p_signal, Object *p_target, MonoObject *p_awaiter) {
+void godot_icall_SignalAwaiter_connect(Object *p_source, StringName *p_signal, Object *p_target, MonoObject *p_awaiter) {
 	StringName signal = p_signal ? *p_signal : StringName();
-	return (int32_t)gd_mono_connect_signal_awaiter(p_source, signal, p_target, p_awaiter);
+	gd_mono_connect_signal_awaiter(p_source, signal, p_target, p_awaiter);
 }
 
 MonoArray *godot_icall_DynamicGodotObject_SetMemberList(Object *p_ptr) {

--- a/modules/mono/signal_awaiter_utils.cpp
+++ b/modules/mono/signal_awaiter_utils.cpp
@@ -36,15 +36,15 @@
 #include "mono_gd/gd_mono_marshal.h"
 #include "mono_gd/gd_mono_utils.h"
 
-Error gd_mono_connect_signal_awaiter(Object *p_source, const StringName &p_signal, Object *p_target, MonoObject *p_awaiter) {
-	ERR_FAIL_NULL_V(p_source, ERR_INVALID_DATA);
-	ERR_FAIL_NULL_V(p_target, ERR_INVALID_DATA);
+void gd_mono_connect_signal_awaiter(Object *p_source, const StringName &p_signal, Object *p_target, MonoObject *p_awaiter) {
+	ERR_FAIL_NULL(p_source);
+	ERR_FAIL_NULL(p_target);
 
 	// TODO: Use pooling for ManagedCallable instances.
 	SignalAwaiterCallable *awaiter_callable = memnew(SignalAwaiterCallable(p_target, p_awaiter, p_signal));
 	Callable callable = Callable(awaiter_callable);
 
-	return p_source->connect(p_signal, callable, Vector<Variant>(), Object::CONNECT_ONESHOT);
+	p_source->connect(p_signal, callable, Vector<Variant>(), Object::CONNECT_ONESHOT);
 }
 
 bool SignalAwaiterCallable::compare_equal(const CallableCustom *p_a, const CallableCustom *p_b) {

--- a/modules/mono/signal_awaiter_utils.h
+++ b/modules/mono/signal_awaiter_utils.h
@@ -36,7 +36,7 @@
 #include "csharp_script.h"
 #include "mono_gc_handle.h"
 
-Error gd_mono_connect_signal_awaiter(Object *p_source, const StringName &p_signal, Object *p_target, MonoObject *p_awaiter);
+void gd_mono_connect_signal_awaiter(Object *p_source, const StringName &p_signal, Object *p_target, MonoObject *p_awaiter);
 
 class SignalAwaiterCallable : public CallableCustom {
 	ObjectID target_id;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/613

The only place using the returned error code was `modules/gdscript/gdscript_vm.cpp`.
I deemed it safe to remove the check entirely due to the following:
* The code already checks that the signal exists and is valid.
* It passes a new callable, which guarantees that it wont collide with
  any existing connections.
* Any error involving the signal is still logged by the connect call.

The mono version is only affected because it's in the glue. Nothing
actually checks the return code.

There was no need to update the documentation as the error code was not mentioned at all.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
