### PR TITLE
Fix incorrect surfacetool example in class docs

### DIFF
--- a/doc/classes/SurfaceTool.xml
+++ b/doc/classes/SurfaceTool.xml
@@ -11,14 +11,14 @@
 		st.begin(Mesh.PRIMITIVE_TRIANGLES)
 		st.set_color(Color(1, 0, 0))
 		st.set_uv(Vector2(0, 0))
-		st.set_vertex(Vector3(0, 0, 0))
+		st.add_vertex(Vector3(0, 0, 0))
 		[/gdscript]
 		[csharp]
 		var st = new SurfaceTool();
 		st.Begin(Mesh.PrimitiveType.Triangles);
 		st.SetColor(new Color(1, 0, 0));
 		st.SetUv(new Vector2(0, 0));
-		st.SetVertex(new Vector3(0, 0, 0));
+		st.AddVertex(new Vector3(0, 0, 0));
 		[/csharp]
 		[/codeblocks]
 		The above [SurfaceTool] now contains one vertex of a triangle which has a UV coordinate and a specified [Color]. If another vertex were added without calling [method set_uv] or [method set_color], then the last values would be used.


### PR DESCRIPTION
Should be add_vertex not set_vertex, I guess this was accidentally done when converting from the old syntax where all methods were prefixed with add_*