### PR TITLE
Document String's humanize_size static method

### DIFF
--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -265,6 +265,8 @@
 			<return type="String" />
 			<argument index="0" name="size" type="int" />
 			<description>
+				Converts an integer representing a number of bytes into a human-readable form.
+				Note that this output is in [url=https://en.wikipedia.org/wiki/Binary_prefix#IEC_prefixes]IEC prefix format[/url], and includes [code]B[/code], [code]KiB[/code], [code]MiB[/code], [code]GiB[/code], [code]TiB[/code], [code]PiB[/code], and [code]EiB[/code].
 			</description>
 		</method>
 		<method name="indent" qualifiers="const">


### PR DESCRIPTION
As it says on the tin.

Considering opening an issue about the name though - I wasn't sure what kind of size it actually represented, and I feel like a name like "humanize_bytes" or "humanize_byte_size" could be better.