### PR TITLE
[Export] Add "export console script" option for Linux, macOS, and Windows exports.

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1755,6 +1755,8 @@ void EditorExportPlatformPC::get_export_options(List<ExportOption> *r_options) {
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/debug", PROPERTY_HINT_GLOBAL_FILE), ""));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "custom_template/release", PROPERTY_HINT_GLOBAL_FILE), ""));
 
+	r_options->push_back(ExportOption(PropertyInfo(Variant::INT, "debug/export_console_script", PROPERTY_HINT_ENUM, "No,Debug Only,Debug and Release"), 1));
+
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "binary_format/64_bits"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "binary_format/embed_pck"), false));
 

--- a/platform/linuxbsd/export/export.cpp
+++ b/platform/linuxbsd/export/export.cpp
@@ -30,15 +30,12 @@
 
 #include "export.h"
 
-#include "core/io/file_access.h"
-#include "editor/editor_export.h"
-#include "platform/linuxbsd/logo.gen.h"
-#include "scene/resources/texture.h"
+#include "export_plugin.h"
 
 static Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size);
 
 void register_linuxbsd_exporter() {
-	Ref<EditorExportPlatformPC> platform;
+	Ref<EditorExportPlatformLinuxBSD> platform;
 	platform.instantiate();
 
 	Ref<Image> img = memnew(Image(_linuxbsd_logo));

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -28,26 +28,20 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef WINDOWS_EXPORT_PLUGIN_H
-#define WINDOWS_EXPORT_PLUGIN_H
+#ifndef LINUXBSD_EXPORT_PLUGIN_H
+#define LINUXBSD_EXPORT_PLUGIN_H
 
 #include "core/io/file_access.h"
-#include "core/os/os.h"
 #include "editor/editor_export.h"
 #include "editor/editor_settings.h"
-#include "platform/windows/logo.gen.h"
+#include "platform/linuxbsd/logo.gen.h"
+#include "scene/resources/texture.h"
 
-class EditorExportPlatformWindows : public EditorExportPlatformPC {
-	void _rcedit_add_data(const Ref<EditorExportPreset> &p_preset, const String &p_path);
-	Error _code_sign(const Ref<EditorExportPreset> &p_preset, const String &p_path);
+class EditorExportPlatformLinuxBSD : public EditorExportPlatformPC {
 	Error _export_debug_script(const Ref<EditorExportPreset> &p_preset, const String &p_app_name, const String &p_pkg_name, const String &p_path);
 
 public:
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
-	virtual Error sign_shared_object(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path) override;
-	virtual void get_export_options(List<ExportOption> *r_options) override;
-	virtual bool get_export_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const override;
-	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const override;
 };
 
 #endif

--- a/platform/osx/export/export_plugin.h
+++ b/platform/osx/export/export_plugin.h
@@ -66,6 +66,7 @@ class EditorExportPlatformOSX : public EditorExportPlatform {
 			const String &p_ent_path);
 	Error _create_dmg(const String &p_dmg_path, const String &p_pkg_name, const String &p_app_path_name);
 	void _zip_folder_recursive(zipFile &p_zip, const String &p_root_path, const String &p_folder, const String &p_pkg_name);
+	Error _export_debug_script(const Ref<EditorExportPreset> &p_preset, const String &p_app_name, const String &p_pkg_name, const String &p_path);
 
 	bool use_codesign() const { return true; }
 #ifdef OSX_ENABLED


### PR DESCRIPTION
Add "export console script" option (default value "Debug Only"):

<img width="604" alt="option" src="https://user-images.githubusercontent.com/7645683/155276401-7bbab197-6b6f-4583-9269-5301bf066032.png">

Which generates a script to run the exported project with the open console:

<img width="314" alt="macos" src="https://user-images.githubusercontent.com/7645683/155276517-7830e0c0-0308-463c-b9c0-e9e9a7a44769.png">
<img width="219" alt="windows" src="https://user-images.githubusercontent.com/7645683/155276571-37bb84cc-9575-4bd7-83a8-7189d99da91a.png">

*Note:* Probably it's distro dependent, but at least some Linux file managers do not run `.sh` scripts on double-click (and require right-click ⇾ "Run as application", or something similar). On macOS, this is solved by using `.command` extension, but I have no idea if there's a portable equivalent on Linux.

Fixes #58241