### PR TITLE
Fix llvm compilation by adding missing override

### DIFF
--- a/modules/openxr/extensions/openxr_vulkan_extension.h
+++ b/modules/openxr/extensions/openxr_vulkan_extension.h
@@ -55,9 +55,9 @@ public:
 	virtual void on_instance_created(const XrInstance p_instance) override;
 	virtual void *set_session_create_and_get_next_pointer(void *p_next_pointer) override;
 
-	virtual bool create_vulkan_instance(const VkInstanceCreateInfo *p_vulkan_create_info, VkInstance *r_instance);
-	virtual bool get_physical_device(VkPhysicalDevice *r_device);
-	virtual bool create_vulkan_device(const VkDeviceCreateInfo *p_device_create_info, VkDevice *r_device);
+	virtual bool create_vulkan_instance(const VkInstanceCreateInfo *p_vulkan_create_info, VkInstance *r_instance) override;
+	virtual bool get_physical_device(VkPhysicalDevice *r_device) override;
+	virtual bool create_vulkan_device(const VkDeviceCreateInfo *p_device_create_info, VkDevice *r_device) override;
 
 	virtual void get_usable_swapchain_formats(Vector<int64_t> &p_usable_swap_chains) override;
 	virtual String get_swapchain_format_name(int64_t p_swapchain_format) const override;


### PR DESCRIPTION
Adds explicit override to functions needing it. This was preventing compilation with llvm and `werror=yes`:
```
scons: *** [modules/openxr/openxr_api.linuxbsd.tools.64.llvm.o] Error 1
In file included from modules/openxr/extensions/openxr_vulkan_extension.cpp:33:
./modules/openxr/extensions/openxr_vulkan_extension.h:58:15: error: 'create_vulkan_instance' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        virtual bool create_vulkan_instance(const VkInstanceCreateInfo *p_vulkan_create_info, VkInstance *r_instance);
                     ^
./drivers/vulkan/vulkan_hooks.h:42:15: note: overridden virtual function is here
        virtual bool create_vulkan_instance(const VkInstanceCreateInfo *p_vulkan_create_info, VkInstance *r_instance) { return false; };
                     ^
In file included from modules/openxr/extensions/openxr_vulkan_extension.cpp:33:
./modules/openxr/extensions/openxr_vulkan_extension.h:59:15: error: 'get_physical_device' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        virtual bool get_physical_device(VkPhysicalDevice *r_device);
                     ^
./drivers/vulkan/vulkan_hooks.h:43:15: note: overridden virtual function is here
        virtual bool get_physical_device(VkPhysicalDevice *r_device) { return false; };
                     ^
In file included from modules/openxr/extensions/openxr_vulkan_extension.cpp:33:
./modules/openxr/extensions/openxr_vulkan_extension.h:60:15: error: 'create_vulkan_device' overrides a member function but is not marked 'override' [-Werror,-Winconsistent-missing-override]
        virtual bool create_vulkan_device(const VkDeviceCreateInfo *p_device_create_info, VkDevice *r_device);
                     ^
./drivers/vulkan/vulkan_hooks.h:44:15: note: overridden virtual function is here
        virtual bool create_vulkan_device(const VkDeviceCreateInfo *p_device_create_info, VkDevice *r_device) { return false; };
                     ^
3 errors generated.
```
