### PR TITLE
Fixed bug with text going under scrollbar

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -401,7 +401,7 @@
 		<member name="select_mode" type="int" setter="set_select_mode" getter="get_select_mode" enum="ItemList.SelectMode" default="0">
 			Allows single or multiple item selection. See the [enum SelectMode] constants.
 		</member>
-		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextParagraph.OverrunBehavior" default="0">
+		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextParagraph.OverrunBehavior" default="3">
 			Sets the clipping behavior when the text exceeds an item's bounding rectangle. See [enum TextParagraph.OverrunBehavior] for a description of all modes.
 		</member>
 	</members>

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1241,7 +1241,7 @@ void ItemList::_notification(int p_what) {
 							text_ofs.x = size.width - text_ofs.x - max_len;
 						}
 
-						items.write[i].text_buf->set_width(max_len);
+						items.write[i].text_buf->set_width(width - text_ofs.x);
 
 						if (rtl) {
 							items.write[i].text_buf->set_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
@@ -1253,7 +1253,9 @@ void ItemList::_notification(int p_what) {
 							items[i].text_buf->draw_outline(get_canvas_item(), text_ofs, outline_size, font_outline_color);
 						}
 
-						items[i].text_buf->draw(get_canvas_item(), text_ofs, modulate);
+						if (width - text_ofs.x > 0) {
+							items[i].text_buf->draw(get_canvas_item(), text_ofs, modulate);
+						}
 					}
 				}
 

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -99,7 +99,7 @@ private:
 	SelectMode select_mode = SELECT_SINGLE;
 	IconMode icon_mode = ICON_MODE_LEFT;
 	VScrollBar *scroll_bar;
-	TextParagraph::OverrunBehavior text_overrun_behavior = TextParagraph::OVERRUN_NO_TRIMMING;
+	TextParagraph::OverrunBehavior text_overrun_behavior = TextParagraph::OVERRUN_TRIM_ELLIPSIS;
 
 	uint64_t search_time_msec = 0;
 	String search_string;


### PR DESCRIPTION
Fixes #57881
I fixed the issue with the text going under the scroll bar in `ItemList`. I changed the default OverrunBehavior to add ellipsis instead of doing nothing.
![working preview of itemlist 2](https://user-images.githubusercontent.com/65504787/155409126-34ba22b6-f066-481b-9914-d5326bb4542a.gif)
 