### PR TITLE
Use Time singleton in VersionControlEditorPlugin

### DIFF
--- a/doc/classes/EditorVCSInterface.xml
+++ b/doc/classes/EditorVCSInterface.xml
@@ -193,9 +193,10 @@
 			<argument index="0" name="msg" type="String" />
 			<argument index="1" name="author" type="String" />
 			<argument index="2" name="id" type="String" />
-			<argument index="3" name="date" type="String" />
+			<argument index="3" name="unix_timestamp" type="int" />
+			<argument index="4" name="offset_minutes" type="int" />
 			<description>
-				Helper function to create a commit [Dictionary] item. [code]msg[/code] is the commit message of the commit. [code]author[/code] is a human-readable string containing the author's details, e.g. the email and name configured in the VCS. [code]id[/code] is the identifier of the commit, in whichever format your VCS may provide an identifier to commits. [code]date[/code] is directly added to the commit item and displayed in the editor, and hence, it shall be a well-formatted, human-readable date string.
+				Helper function to create a commit [Dictionary] item. [code]msg[/code] is the commit message of the commit. [code]author[/code] is a single human-readable string containing all the author's details, e.g. the email and name configured in the VCS. [code]id[/code] is the identifier of the commit, in whichever format your VCS may provide an identifier to commits. [code]unix_timestamp[/code] is the UTC Unix timestamp of when the commit was created. [code]offset_minutes[/code] is the timezone offset in minutes, recorded from the system timezone where the commit was created.
 			</description>
 		</method>
 		<method name="create_diff_file">

--- a/editor/editor_vcs_interface.cpp
+++ b/editor/editor_vcs_interface.cpp
@@ -206,11 +206,12 @@ Dictionary EditorVCSInterface::create_diff_file(String p_new_file, String p_old_
 	return file_diff;
 }
 
-Dictionary EditorVCSInterface::create_commit(String p_msg, String p_author, String p_id, String p_date) {
+Dictionary EditorVCSInterface::create_commit(String p_msg, String p_author, String p_id, int64_t p_unix_timestamp, int64_t p_offset_minutes) {
 	Dictionary commit_info;
 	commit_info["message"] = p_msg;
 	commit_info["author"] = p_author;
-	commit_info["date"] = p_date;
+	commit_info["unix_timestamp"] = p_unix_timestamp;
+	commit_info["offset_minutes"] = p_offset_minutes;
 	commit_info["id"] = p_id;
 	return commit_info;
 }
@@ -267,7 +268,8 @@ EditorVCSInterface::Commit EditorVCSInterface::_convert_commit(Dictionary p_comm
 	EditorVCSInterface::Commit c;
 	c.msg = p_commit["message"];
 	c.author = p_commit["author"];
-	c.date = p_commit["date"];
+	c.unix_timestamp = p_commit["unix_timestamp"];
+	c.offset_minutes = p_commit["offset_minutes"];
 	c.id = p_commit["id"];
 	return c;
 }
@@ -309,7 +311,7 @@ void EditorVCSInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("create_diff_line", "new_line_no", "old_line_no", "content", "status"), &EditorVCSInterface::create_diff_line);
 	ClassDB::bind_method(D_METHOD("create_diff_hunk", "old_start", "new_start", "old_lines", "new_lines"), &EditorVCSInterface::create_diff_hunk);
 	ClassDB::bind_method(D_METHOD("create_diff_file", "new_file", "old_file"), &EditorVCSInterface::create_diff_file);
-	ClassDB::bind_method(D_METHOD("create_commit", "msg", "author", "id", "date"), &EditorVCSInterface::create_commit);
+	ClassDB::bind_method(D_METHOD("create_commit", "msg", "author", "id", "unix_timestamp", "offset_minutes"), &EditorVCSInterface::create_commit);
 	ClassDB::bind_method(D_METHOD("create_status_file", "file_path", "change_type", "area"), &EditorVCSInterface::create_status_file);
 	ClassDB::bind_method(D_METHOD("add_diff_hunks_into_diff_file", "diff_file", "diff_hunks"), &EditorVCSInterface::add_diff_hunks_into_diff_file);
 	ClassDB::bind_method(D_METHOD("add_line_diffs_into_diff_hunk", "diff_hunk", "line_diffs"), &EditorVCSInterface::add_line_diffs_into_diff_hunk);

--- a/editor/editor_vcs_interface.h
+++ b/editor/editor_vcs_interface.h
@@ -82,7 +82,8 @@ public:
 		String author;
 		String msg;
 		String id;
-		String date;
+		int64_t unix_timestamp;
+		int64_t offset_minutes;
 	};
 
 	struct StatusFile {
@@ -135,7 +136,7 @@ public:
 	Dictionary create_diff_line(int p_new_line_no, int p_old_line_no, String p_content, String p_status);
 	Dictionary create_diff_hunk(int p_old_start, int p_new_start, int p_old_lines, int p_new_lines);
 	Dictionary create_diff_file(String p_new_file, String p_old_file);
-	Dictionary create_commit(String p_msg, String p_author, String p_id, String p_date);
+	Dictionary create_commit(String p_msg, String p_author, String p_id, int64_t p_unix_timestamp, int64_t p_offset_minutes);
 	Dictionary create_status_file(String p_file_path, ChangeType p_change, TreeArea p_area);
 	Dictionary add_line_diffs_into_diff_hunk(Dictionary p_diff_hunk, Array p_line_diffs);
 	Dictionary add_diff_hunks_into_diff_file(Dictionary p_diff_file, Array p_diff_hunks);

--- a/editor/plugins/version_control_editor_plugin.h
+++ b/editor/plugins/version_control_editor_plugin.h
@@ -186,6 +186,7 @@ private:
 	void _commit_message_gui_input(const Ref<InputEvent> &p_event);
 	void _extra_option_selected(int p_index);
 	bool _is_staging_area_empty();
+	String _get_date_string_from(int64_t p_unix_timestamp, int64_t p_offset_minutes) const;
 
 	friend class EditorVCSInterface;
 


### PR DESCRIPTION
Instead of displaying the exact string, now Godot uses the Time
singleton to calculate the date string from the UTC Unix timestamp and
also handles the timezone offset conversion to string.

This PR was made in parallel to https://github.com/godotengine/godot-git-plugin/pull/107

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
