### PR TITLE
Improve search filtering in scene tree editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6055,6 +6055,7 @@ EditorNode::EditorNode() {
 	ClassDB::set_class_enabled("RootMotionView", true);
 
 	EDITOR_DEF("interface/editor/save_on_focus_loss", false);
+	EDITOR_DEF("interface/editor/show_tree_in_scene_tree_search", true);
 	EDITOR_DEF("interface/editor/show_update_spinner", false);
 	EDITOR_DEF("interface/editor/update_continuously", false);
 	EDITOR_DEF("interface/editor/localize_settings", true);

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -159,7 +159,7 @@ void SceneTreeEditor::_toggle_visible(Node *p_node) {
 	}
 }
 
-bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll_to_selected) {
+bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, TreeItem *p_root, bool p_show_tree_in_scene_tree_search, bool p_scroll_to_selected) {
 	if (!p_node) {
 		return false;
 	}
@@ -428,38 +428,52 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 
 	bool keep = (filter.is_subsequence_ofn(String(p_node->get_name())));
 
+	bool node_list_is_flat = !filter.is_empty() && !p_show_tree_in_scene_tree_search;
+
+	bool children_keep = false;
 	for (int i = 0; i < p_node->get_child_count(); i++) {
-		bool child_keep = _add_nodes(p_node->get_child(i), item, p_scroll_to_selected);
-
-		keep = keep || child_keep;
+		bool current_child_keep = _add_nodes(p_node->get_child(i), node_list_is_flat ? p_root : item, p_root, p_show_tree_in_scene_tree_search, p_scroll_to_selected);
+		children_keep = node_list_is_flat ? false : (children_keep ? true : current_child_keep);
 	}
 
-	if (valid_types.size()) {
-		bool valid = false;
-		for (int i = 0; i < valid_types.size(); i++) {
-			if (p_node->is_class(valid_types[i])) {
-				valid = true;
-				break;
+	bool is_enabled = false;
+	if (keep) {
+		if (valid_types.size()) {
+			for (int i = 0; i < valid_types.size(); i++) {
+				if (p_node->is_class(valid_types[i])) {
+					is_enabled = true;
+					break;
+				}
 			}
-		}
-
-		if (!valid) {
-			//item->set_selectable(0,marked_selectable);
-			item->set_custom_color(0, get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
-			item->set_selectable(0, false);
+			// If we a filtering, we can discard invalid types
+			if (!is_enabled && !filter.is_empty()) {
+				keep = false;
+			}
+		} else {
+			is_enabled = true;
 		}
 	}
 
-	if (!keep) {
+	if (!is_enabled) {
 		if (editor_selection) {
 			Node *n = get_node(item->get_metadata(0));
 			if (n) {
 				editor_selection->remove_node(n);
 			}
 		}
+	}
+
+	if (!keep && !children_keep) {
 		memdelete(item);
 		return false;
 	} else {
+		// If we're only keeping the children or the type is invalid, grey this item out
+		if (!is_enabled) {
+			item->set_custom_color(0, get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
+			item->set_selectable(0, false);
+			item->deselect(0);
+		}
+
 		if (scroll) {
 			tree->scroll_to_item(item);
 		}
@@ -570,7 +584,12 @@ void SceneTreeEditor::_update_tree(bool p_scroll_to_selected) {
 	updating_tree = true;
 	tree->clear();
 	if (get_scene_node()) {
-		_add_nodes(get_scene_node(), nullptr, p_scroll_to_selected);
+		tree->set_hide_root(true);
+		TreeItem *root_item = tree->create_item(nullptr);
+
+		bool show_tree_in_scene_tree_search = EDITOR_GET("interface/editor/show_tree_in_scene_tree_search");
+
+		_add_nodes(get_scene_node(), root_item, root_item, show_tree_in_scene_tree_search, p_scroll_to_selected);
 		last_hash = hash_djb2_one_64(0);
 		_compute_hash(get_scene_node(), last_hash);
 	}

--- a/editor/scene_tree_editor.h
+++ b/editor/scene_tree_editor.h
@@ -72,7 +72,7 @@ class SceneTreeEditor : public Control {
 
 	void _compute_hash(Node *p_node, uint64_t &hash);
 
-	bool _add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll_to_selected = false);
+	bool _add_nodes(Node *p_node, TreeItem *p_parent, TreeItem *p_root, bool p_show_tree_in_scene_tree_search, bool p_scroll_to_selected);
 	void _test_update_tree();
 	void _update_tree(bool p_scroll_to_selected = false);
 	void _tree_changed();


### PR DESCRIPTION
Kind of a sibling PR to this #58377

Changes the functionality of scene tree search and comes in two flavours:

The first I'm advocating as default is so that the parents of any nodes which sucessfully pass the filter but which are not filtered themselves will appear as grey as and unselectable. This allows users to maintain an understanding of the context while still being able to make useful searches.
![godot windows tools 64_WlrfsuL7ef](https://user-images.githubusercontent.com/12756047/155431889-23d142f6-8d49-49e8-b9f6-26c211487cb6.png)

The second is a much simpler flat list of nodes which pass the filter, not much explanation required, but some people might have a preference for this:
![godot windows tools 64_7Vprd8eMho](https://user-images.githubusercontent.com/12756047/155431911-3bef27f2-be70-4521-83b6-1e678ef814fa.png)

These can be toggled between via an editor setting. Invalidly typed nodes such as may be present when making a NodePath selection will also be fully excluded when searching, since they are redundant to the search.

Keeping this a draft for now for a few reasons. I've encountered some strange behaviour with the scene tree editor such as it seemingly randomly not updating itself. I don't think this is caused by this PR, but just to be sure, let me investigate further. Secondly, there's still UX questions which need addressing. One such contradiction is other node states which use the greyed colour, such as editable children of an instanced subscene, and either a new colour will need to be chosen for editable children or this colouring conventional will have to be discarded entirely during searches. It would likely also be worth extending the greying out of nodes during search in the remote scene view too.