### PR TITLE
Float literals - fix main primitives to use real_t casting

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -37,7 +37,7 @@
 	(elements[row1][col1] * elements[row2][col2] - elements[row1][col2] * elements[row2][col1])
 
 void Basis::from_z(const Vector3 &p_z) {
-	if (Math::abs(p_z.z) > Math_SQRT12) {
+	if (Math::abs(p_z.z) > (real_t)Math_SQRT12) {
 		// choose p in y-z plane
 		real_t a = p_z[1] * p_z[1] + p_z[2] * p_z[2];
 		real_t k = 1.0f / Math::sqrt(a);
@@ -153,7 +153,7 @@ Basis Basis::diagonalize() {
 
 	int ite = 0;
 	Basis acc_rot;
-	while (off_matrix_norm_2 > CMP_EPSILON2 && ite++ < ite_max) {
+	while (off_matrix_norm_2 > (real_t)CMP_EPSILON2 && ite++ < ite_max) {
 		real_t el01_2 = elements[0][1] * elements[0][1];
 		real_t el02_2 = elements[0][2] * elements[0][2];
 		real_t el12_2 = elements[1][2] * elements[1][2];
@@ -463,8 +463,8 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 
 			Vector3 euler;
 			real_t sy = elements[0][2];
-			if (sy < (1.0f - CMP_EPSILON)) {
-				if (sy > -(1.0f - CMP_EPSILON)) {
+			if (sy < (1.0f - (real_t)CMP_EPSILON)) {
+				if (sy > -(1.0f - (real_t)CMP_EPSILON)) {
 					// is this a pure Y rotation?
 					if (elements[1][0] == 0 && elements[0][1] == 0 && elements[1][2] == 0 && elements[2][1] == 0 && elements[1][1] == 1) {
 						// return the simplest form (human friendlier in editor and scripts)
@@ -498,8 +498,8 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 
 			Vector3 euler;
 			real_t sz = elements[0][1];
-			if (sz < (1.0f - CMP_EPSILON)) {
-				if (sz > -(1.0f - CMP_EPSILON)) {
+			if (sz < (1.0f - (real_t)CMP_EPSILON)) {
+				if (sz > -(1.0f - (real_t)CMP_EPSILON)) {
 					euler.x = Math::atan2(elements[2][1], elements[1][1]);
 					euler.y = Math::atan2(elements[0][2], elements[0][0]);
 					euler.z = Math::asin(-sz);
@@ -529,8 +529,8 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 
 			real_t m12 = elements[1][2];
 
-			if (m12 < (1 - CMP_EPSILON)) {
-				if (m12 > -(1 - CMP_EPSILON)) {
+			if (m12 < (1 - (real_t)CMP_EPSILON)) {
+				if (m12 > -(1 - (real_t)CMP_EPSILON)) {
 					// is this a pure X rotation?
 					if (elements[1][0] == 0 && elements[0][1] == 0 && elements[0][2] == 0 && elements[2][0] == 0 && elements[0][0] == 1) {
 						// return the simplest form (human friendlier in editor and scripts)
@@ -565,8 +565,8 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 
 			Vector3 euler;
 			real_t sz = elements[1][0];
-			if (sz < (1.0f - CMP_EPSILON)) {
-				if (sz > -(1.0f - CMP_EPSILON)) {
+			if (sz < (1.0f - (real_t)CMP_EPSILON)) {
+				if (sz > -(1.0f - (real_t)CMP_EPSILON)) {
 					euler.x = Math::atan2(-elements[1][2], elements[1][1]);
 					euler.y = Math::atan2(-elements[2][0], elements[0][0]);
 					euler.z = Math::asin(sz);
@@ -593,8 +593,8 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 			//        -cx*sy            sx                    cx*cy
 			Vector3 euler;
 			real_t sx = elements[2][1];
-			if (sx < (1.0f - CMP_EPSILON)) {
-				if (sx > -(1.0f - CMP_EPSILON)) {
+			if (sx < (1.0f - (real_t)CMP_EPSILON)) {
+				if (sx > -(1.0f - (real_t)CMP_EPSILON)) {
 					euler.x = Math::asin(sx);
 					euler.y = Math::atan2(-elements[2][0], elements[2][2]);
 					euler.z = Math::atan2(-elements[0][1], elements[1][1]);
@@ -621,8 +621,8 @@ Vector3 Basis::get_euler(EulerOrder p_order) const {
 			//        -sy               cy*sx                 cy*cx
 			Vector3 euler;
 			real_t sy = elements[2][0];
-			if (sy < (1.0f - CMP_EPSILON)) {
-				if (sy > -(1.0f - CMP_EPSILON)) {
+			if (sy < (1.0f - (real_t)CMP_EPSILON)) {
+				if (sy > -(1.0f - (real_t)CMP_EPSILON)) {
 					euler.x = Math::atan2(elements[2][1], elements[2][2]);
 					euler.y = Math::asin(-sy);
 					euler.z = Math::atan2(elements[1][0], elements[0][0]);

--- a/core/math/color.h
+++ b/core/math/color.h
@@ -138,7 +138,7 @@ struct _NO_DISCARD_ Color {
 
 		float cMax = MAX(cRed, MAX(cGreen, cBlue));
 
-		float expp = MAX(-B - 1.0f, floor(Math::log(cMax) / Math_LN2)) + 1.0f + B;
+		float expp = MAX(-B - 1.0f, floor(Math::log(cMax) / (real_t)Math_LN2)) + 1.0f + B;
 
 		float sMax = (float)floor((cMax / Math::pow(2.0f, expp - B - N)) + 0.5f);
 

--- a/core/math/face3.cpp
+++ b/core/math/face3.cpp
@@ -42,7 +42,7 @@ int Face3::split_by_plane(const Plane &p_plane, Face3 p_res[3], bool p_is_point_
 	int below_count = 0;
 
 	for (int i = 0; i < 3; i++) {
-		if (p_plane.has_point(vertex[i], CMP_EPSILON)) { // point is in plane
+		if (p_plane.has_point(vertex[i], (real_t)CMP_EPSILON)) { // point is in plane
 
 			ERR_FAIL_COND_V(above_count >= 4, 0);
 			above[above_count++] = vertex[i];
@@ -117,7 +117,7 @@ bool Face3::intersects_segment(const Vector3 &p_from, const Vector3 &p_dir, Vect
 
 bool Face3::is_degenerate() const {
 	Vector3 normal = vec3_cross(vertex[0] - vertex[1], vertex[0] - vertex[2]);
-	return (normal.length_squared() < CMP_EPSILON2);
+	return (normal.length_squared() < (real_t)CMP_EPSILON2);
 }
 
 Face3::Side Face3::get_side_of(const Face3 &p_face, ClockDirection p_clock_dir) const {

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -218,10 +218,10 @@ Vector<Vector<Point2>> Geometry2D::_polypaths_do_operation(PolyBooleanOperation 
 
 	// Need to scale points (Clipper's requirement for robust computation).
 	for (int i = 0; i != p_polypath_a.size(); ++i) {
-		path_a << IntPoint(p_polypath_a[i].x * SCALE_FACTOR, p_polypath_a[i].y * SCALE_FACTOR);
+		path_a << IntPoint(p_polypath_a[i].x * (real_t)SCALE_FACTOR, p_polypath_a[i].y * (real_t)SCALE_FACTOR);
 	}
 	for (int i = 0; i != p_polypath_b.size(); ++i) {
-		path_b << IntPoint(p_polypath_b[i].x * SCALE_FACTOR, p_polypath_b[i].y * SCALE_FACTOR);
+		path_b << IntPoint(p_polypath_b[i].x * (real_t)SCALE_FACTOR, p_polypath_b[i].y * (real_t)SCALE_FACTOR);
 	}
 	Clipper clp;
 	clp.AddPath(path_a, ptSubject, !is_a_open); // Forward compatible with Clipper 10.0.0.
@@ -246,8 +246,8 @@ Vector<Vector<Point2>> Geometry2D::_polypaths_do_operation(PolyBooleanOperation 
 
 		for (Paths::size_type j = 0; j < scaled_path.size(); ++j) {
 			polypath.push_back(Point2(
-					static_cast<real_t>(scaled_path[j].X) / SCALE_FACTOR,
-					static_cast<real_t>(scaled_path[j].Y) / SCALE_FACTOR));
+					static_cast<real_t>(scaled_path[j].X) / (real_t)SCALE_FACTOR,
+					static_cast<real_t>(scaled_path[j].Y) / (real_t)SCALE_FACTOR));
 		}
 		polypaths.push_back(polypath);
 	}
@@ -290,17 +290,17 @@ Vector<Vector<Point2>> Geometry2D::_polypath_offset(const Vector<Point2> &p_poly
 			et = etOpenRound;
 			break;
 	}
-	ClipperOffset co(2.0, 0.25f * SCALE_FACTOR); // Defaults from ClipperOffset.
+	ClipperOffset co(2.0, 0.25f * (real_t)SCALE_FACTOR); // Defaults from ClipperOffset.
 	Path path;
 
 	// Need to scale points (Clipper's requirement for robust computation).
 	for (int i = 0; i != p_polypath.size(); ++i) {
-		path << IntPoint(p_polypath[i].x * SCALE_FACTOR, p_polypath[i].y * SCALE_FACTOR);
+		path << IntPoint(p_polypath[i].x * (real_t)SCALE_FACTOR, p_polypath[i].y * (real_t)SCALE_FACTOR);
 	}
 	co.AddPath(path, jt, et);
 
 	Paths paths;
-	co.Execute(paths, p_delta * SCALE_FACTOR); // Inflate/deflate.
+	co.Execute(paths, p_delta * (real_t)SCALE_FACTOR); // Inflate/deflate.
 
 	// Have to scale points down now.
 	Vector<Vector<Point2>> polypaths;
@@ -312,8 +312,8 @@ Vector<Vector<Point2>> Geometry2D::_polypath_offset(const Vector<Point2> &p_poly
 
 		for (Paths::size_type j = 0; j < scaled_path.size(); ++j) {
 			polypath.push_back(Point2(
-					static_cast<real_t>(scaled_path[j].X) / SCALE_FACTOR,
-					static_cast<real_t>(scaled_path[j].Y) / SCALE_FACTOR));
+					static_cast<real_t>(scaled_path[j].X) / (real_t)SCALE_FACTOR,
+					static_cast<real_t>(scaled_path[j].Y) / (real_t)SCALE_FACTOR));
 		}
 		polypaths.push_back(polypath);
 	}

--- a/core/math/geometry_2d.h
+++ b/core/math/geometry_2d.h
@@ -51,20 +51,20 @@ public:
 		real_t f = d2.dot(r);
 		real_t s, t;
 		// Check if either or both segments degenerate into points.
-		if (a <= CMP_EPSILON && e <= CMP_EPSILON) {
+		if (a <= (real_t)CMP_EPSILON && e <= (real_t)CMP_EPSILON) {
 			// Both segments degenerate into points.
 			c1 = p1;
 			c2 = p2;
 			return Math::sqrt((c1 - c2).dot(c1 - c2));
 		}
-		if (a <= CMP_EPSILON) {
+		if (a <= (real_t)CMP_EPSILON) {
 			// First segment degenerates into a point.
 			s = 0.0;
 			t = f / e; // s = 0 => t = (b*s + f) / e = f / e
 			t = CLAMP(t, 0.0f, 1.0f);
 		} else {
 			real_t c = d1.dot(r);
-			if (e <= CMP_EPSILON) {
+			if (e <= (real_t)CMP_EPSILON) {
 				// Second segment degenerates into a point.
 				t = 0.0;
 				s = CLAMP(-c / a, 0.0f, 1.0f); // t = 0 => s = (b*t - c) / a = -c / a
@@ -185,7 +185,7 @@ public:
 		D = Vector2(D.x * Bn.x + D.y * Bn.y, D.y * Bn.x - D.x * Bn.y);
 
 		// Fail if C x B and D x B have the same sign (segments don't intersect).
-		if ((C.y < -CMP_EPSILON && D.y < -CMP_EPSILON) || (C.y > CMP_EPSILON && D.y > CMP_EPSILON)) {
+		if ((C.y < (real_t)-CMP_EPSILON && D.y < (real_t)-CMP_EPSILON) || (C.y > (real_t)CMP_EPSILON && D.y > (real_t)CMP_EPSILON)) {
 			return false;
 		}
 
@@ -198,7 +198,7 @@ public:
 		real_t ABpos = D.x + (C.x - D.x) * D.y / (D.y - C.y);
 
 		// Fail if segment C-D crosses line A-B outside of segment A-B.
-		if (ABpos < 0 || ABpos > 1.0f) {
+		if ((ABpos < 0) || (ABpos > 1)) {
 			return false;
 		}
 

--- a/core/math/geometry_3d.cpp
+++ b/core/math/geometry_3d.cpp
@@ -879,7 +879,7 @@ Vector<Vector3> Geometry3D::compute_convex_mesh_points(const Plane *p_planes, in
 					for (int n = 0; n < p_plane_count; n++) {
 						if (n != i && n != j && n != k) {
 							real_t dp = p_planes[n].normal.dot(convex_shape_point);
-							if (dp - p_planes[n].d > CMP_EPSILON) {
+							if (dp - p_planes[n].d > (real_t)CMP_EPSILON) {
 								excluded = true;
 								break;
 							}

--- a/core/math/geometry_3d.h
+++ b/core/math/geometry_3d.h
@@ -76,7 +76,7 @@ public:
 		real_t tc, tN, tD = D; // tc = tN / tD, default tD = D >= 0
 
 		// Compute the line parameters of the two closest points.
-		if (D < CMP_EPSILON) { // The lines are almost parallel.
+		if (D < (real_t)CMP_EPSILON) { // The lines are almost parallel.
 			sN = 0.0f; // Force using point P0 on segment S1
 			sD = 1.0f; // to prevent possible division by 0.0 later.
 			tN = e;
@@ -142,7 +142,7 @@ public:
 		Vector3 s = p_from - p_v0;
 		real_t u = f * s.dot(h);
 
-		if (u < 0.0f || u > 1.0f) {
+		if ((u < 0.0f) || (u > 1.0f)) {
 			return false;
 		}
 
@@ -150,7 +150,7 @@ public:
 
 		real_t v = f * p_dir.dot(q);
 
-		if (v < 0.0f || u + v > 1.0f) {
+		if ((v < 0.0f) || (u + v > 1.0f)) {
 			return false;
 		}
 
@@ -183,7 +183,7 @@ public:
 		Vector3 s = p_from - p_v0;
 		real_t u = f * s.dot(h);
 
-		if (u < 0.0f || u > 1.0f) {
+		if ((u < 0.0f) || (u > 1.0f)) {
 			return false;
 		}
 
@@ -191,7 +191,7 @@ public:
 
 		real_t v = f * rel.dot(q);
 
-		if (v < 0.0f || u + v > 1.0f) {
+		if ((v < 0.0f) || (u + v > 1.0f)) {
 			return false;
 		}
 
@@ -199,7 +199,7 @@ public:
 		// the intersection point is on the line.
 		real_t t = f * e2.dot(q);
 
-		if (t > CMP_EPSILON && t <= 1.0f) { // Ray intersection.
+		if (t > (real_t)CMP_EPSILON && t <= 1.0f) { // Ray intersection.
 			if (r_res) {
 				*r_res = p_from + rel * t;
 			}
@@ -213,7 +213,7 @@ public:
 		Vector3 sphere_pos = p_sphere_pos - p_from;
 		Vector3 rel = (p_to - p_from);
 		real_t rel_l = rel.length();
-		if (rel_l < CMP_EPSILON) {
+		if (rel_l < (real_t)CMP_EPSILON) {
 			return false; // Both points are the same.
 		}
 		Vector3 normal = rel / rel_l;
@@ -229,7 +229,7 @@ public:
 		real_t inters_d2 = p_sphere_radius * p_sphere_radius - ray_distance * ray_distance;
 		real_t inters_d = sphere_d;
 
-		if (inters_d2 >= CMP_EPSILON) {
+		if (inters_d2 >= (real_t)CMP_EPSILON) {
 			inters_d -= Math::sqrt(inters_d2);
 		}
 
@@ -253,7 +253,7 @@ public:
 	static inline bool segment_intersects_cylinder(const Vector3 &p_from, const Vector3 &p_to, real_t p_height, real_t p_radius, Vector3 *r_res = nullptr, Vector3 *r_norm = nullptr, int p_cylinder_axis = 2) {
 		Vector3 rel = (p_to - p_from);
 		real_t rel_l = rel.length();
-		if (rel_l < CMP_EPSILON) {
+		if (rel_l < (real_t)CMP_EPSILON) {
 			return false; // Both points are the same.
 		}
 
@@ -269,7 +269,7 @@ public:
 
 		Vector3 axis_dir;
 
-		if (crs_l < CMP_EPSILON) {
+		if (crs_l < (real_t)CMP_EPSILON) {
 			Vector3 side_axis;
 			side_axis[(p_cylinder_axis + 1) % 3] = 1.0f; // Any side axis OK.
 			axis_dir = side_axis;
@@ -285,7 +285,7 @@ public:
 
 		// Convert to 2D.
 		real_t w2 = p_radius * p_radius - dist * dist;
-		if (w2 < CMP_EPSILON) {
+		if (w2 < (real_t)CMP_EPSILON) {
 			return false; // Avoid numerical error.
 		}
 		Size2 size(Math::sqrt(w2), p_height * 0.5f);
@@ -366,7 +366,7 @@ public:
 		Vector3 rel = p_to - p_from;
 		real_t rel_l = rel.length();
 
-		if (rel_l < CMP_EPSILON) {
+		if (rel_l < (real_t)CMP_EPSILON) {
 			return false;
 		}
 
@@ -379,7 +379,7 @@ public:
 
 			real_t den = p.normal.dot(dir);
 
-			if (Math::abs(den) <= CMP_EPSILON) {
+			if (Math::abs(den) <= (real_t)CMP_EPSILON) {
 				continue; // Ignore parallel plane.
 			}
 
@@ -564,11 +564,11 @@ public:
 
 		for (int a = 0; a < polygon.size(); a++) {
 			real_t dist = p_plane.distance_to(polygon[a]);
-			if (dist < -CMP_POINT_IN_PLANE_EPSILON) {
+			if (dist < (real_t)-CMP_POINT_IN_PLANE_EPSILON) {
 				location_cache[a] = LOC_INSIDE;
 				inside_count++;
 			} else {
-				if (dist > CMP_POINT_IN_PLANE_EPSILON) {
+				if (dist > (real_t)CMP_POINT_IN_PLANE_EPSILON) {
 					location_cache[a] = LOC_OUTSIDE;
 					outside_count++;
 				} else {

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -64,7 +64,7 @@ public:
 	static _ALWAYS_INLINE_ float sinc(float p_x) { return p_x == 0 ? 1 : ::sin(p_x) / p_x; }
 	static _ALWAYS_INLINE_ double sinc(double p_x) { return p_x == 0 ? 1 : ::sin(p_x) / p_x; }
 
-	static _ALWAYS_INLINE_ float sincn(float p_x) { return sinc(Math_PI * p_x); }
+	static _ALWAYS_INLINE_ float sincn(float p_x) { return sinc((float)Math_PI * p_x); }
 	static _ALWAYS_INLINE_ double sincn(double p_x) { return sinc(Math_PI * p_x); }
 
 	static _ALWAYS_INLINE_ double cosh(double p_x) { return ::cosh(p_x); }
@@ -187,7 +187,7 @@ public:
 
 	static _ALWAYS_INLINE_ double fposmod(double p_x, double p_y) {
 		double value = Math::fmod(p_x, p_y);
-		if ((value < 0 && p_y > 0) || (value > 0 && p_y < 0)) {
+		if (((value < 0) && (p_y > 0)) || ((value > 0) && (p_y < 0))) {
 			value += p_y;
 		}
 		value += 0.0;
@@ -195,7 +195,7 @@ public:
 	}
 	static _ALWAYS_INLINE_ float fposmod(float p_x, float p_y) {
 		float value = Math::fmod(p_x, p_y);
-		if ((value < 0 && p_y > 0) || (value > 0 && p_y < 0)) {
+		if (((value < 0) && (p_y > 0)) || ((value > 0) && (p_y < 0))) {
 			value += p_y;
 		}
 		value += 0.0f;
@@ -220,17 +220,17 @@ public:
 
 	static _ALWAYS_INLINE_ int64_t posmod(int64_t p_x, int64_t p_y) {
 		int64_t value = p_x % p_y;
-		if ((value < 0 && p_y > 0) || (value > 0 && p_y < 0)) {
+		if (((value < 0) && (p_y > 0)) || ((value > 0) && (p_y < 0))) {
 			value += p_y;
 		}
 		return value;
 	}
 
 	static _ALWAYS_INLINE_ double deg2rad(double p_y) { return p_y * (Math_PI / 180.0); }
-	static _ALWAYS_INLINE_ float deg2rad(float p_y) { return p_y * (Math_PI / 180.0); }
+	static _ALWAYS_INLINE_ float deg2rad(float p_y) { return p_y * (float)(Math_PI / 180.0); }
 
 	static _ALWAYS_INLINE_ double rad2deg(double p_y) { return p_y * (180.0 / Math_PI); }
-	static _ALWAYS_INLINE_ float rad2deg(float p_y) { return p_y * (180.0 / Math_PI); }
+	static _ALWAYS_INLINE_ float rad2deg(float p_y) { return p_y * (float)(180.0 / Math_PI); }
 
 	static _ALWAYS_INLINE_ double lerp(double p_from, double p_to, double p_weight) { return p_from + (p_to - p_from) * p_weight; }
 	static _ALWAYS_INLINE_ float lerp(float p_from, float p_to, float p_weight) { return p_from + (p_to - p_from) * p_weight; }
@@ -285,10 +285,10 @@ public:
 	static _ALWAYS_INLINE_ float move_toward(float p_from, float p_to, float p_delta) { return abs(p_to - p_from) <= p_delta ? p_to : p_from + SIGN(p_to - p_from) * p_delta; }
 
 	static _ALWAYS_INLINE_ double linear2db(double p_linear) { return Math::log(p_linear) * 8.6858896380650365530225783783321; }
-	static _ALWAYS_INLINE_ float linear2db(float p_linear) { return Math::log(p_linear) * 8.6858896380650365530225783783321; }
+	static _ALWAYS_INLINE_ float linear2db(float p_linear) { return Math::log(p_linear) * (float)8.6858896380650365530225783783321; }
 
 	static _ALWAYS_INLINE_ double db2linear(double p_db) { return Math::exp(p_db * 0.11512925464970228420089957273422); }
-	static _ALWAYS_INLINE_ float db2linear(float p_db) { return Math::exp(p_db * 0.11512925464970228420089957273422); }
+	static _ALWAYS_INLINE_ float db2linear(float p_db) { return Math::exp(p_db * (float)0.11512925464970228420089957273422); }
 
 	static _ALWAYS_INLINE_ double round(double p_val) { return ::round(p_val); }
 	static _ALWAYS_INLINE_ float round(float p_val) { return ::roundf(p_val); }
@@ -345,9 +345,9 @@ public:
 			return true;
 		}
 		// Then check for approximate equality.
-		float tolerance = CMP_EPSILON * abs(a);
-		if (tolerance < CMP_EPSILON) {
-			tolerance = CMP_EPSILON;
+		float tolerance = (float)CMP_EPSILON * abs(a);
+		if (tolerance < (float)CMP_EPSILON) {
+			tolerance = (float)CMP_EPSILON;
 		}
 		return abs(a - b) < tolerance;
 	}
@@ -362,7 +362,7 @@ public:
 	}
 
 	static _ALWAYS_INLINE_ bool is_zero_approx(float s) {
-		return abs(s) < CMP_EPSILON;
+		return abs(s) < (float)CMP_EPSILON;
 	}
 
 	static _ALWAYS_INLINE_ bool is_equal_approx(double a, double b) {

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -106,7 +106,7 @@ bool Plane::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 
 	real_t dist = (normal.dot(p_from) - d) / den;
 	//printf("dist is %i\n",dist);
 
-	if (dist > CMP_EPSILON) { //this is a ray, before the emitting pos (p_from) doesn't exist
+	if (dist > (real_t)CMP_EPSILON) { //this is a ray, before the emitting pos (p_from) doesn't exist
 
 		return false;
 	}
@@ -129,7 +129,7 @@ bool Plane::intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vec
 	real_t dist = (normal.dot(p_begin) - d) / den;
 	//printf("dist is %i\n",dist);
 
-	if (dist < -CMP_EPSILON || dist > (1.0f + CMP_EPSILON)) {
+	if (dist < (real_t)-CMP_EPSILON || dist > (1.0f + (real_t)CMP_EPSILON)) {
 		return false;
 	}
 

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -129,7 +129,7 @@ Quaternion Quaternion::slerp(const Quaternion &p_to, const real_t &p_weight) con
 
 	// calculate coefficients
 
-	if ((1.0f - cosom) > CMP_EPSILON) {
+	if ((1.0f - cosom) > (real_t)CMP_EPSILON) {
 		// standard case (slerp)
 		omega = Math::acos(cosom);
 		sinom = Math::sin(omega);

--- a/core/math/quaternion.h
+++ b/core/math/quaternion.h
@@ -145,7 +145,7 @@ struct _NO_DISCARD_ Quaternion {
 		Vector3 c = v0.cross(v1);
 		real_t d = v0.dot(v1);
 
-		if (d < -1.0f + CMP_EPSILON) {
+		if (d < -1.0f + (real_t)CMP_EPSILON) {
 			x = 0;
 			y = 1;
 			z = 0;

--- a/core/math/random_pcg.h
+++ b/core/math/random_pcg.h
@@ -129,7 +129,7 @@ public:
 		return p_mean + p_deviation * (cos(Math_TAU * randd()) * sqrt(-2.0 * log(randd()))); // Box-Muller transform
 	}
 	_FORCE_INLINE_ float randfn(float p_mean, float p_deviation) {
-		return p_mean + p_deviation * (cos(Math_TAU * randf()) * sqrt(-2.0 * log(randf()))); // Box-Muller transform
+		return p_mean + p_deviation * (cos((float)Math_TAU * randf()) * sqrt(-2.0 * log(randf()))); // Box-Muller transform
 	}
 
 	double random(double p_from, double p_to);

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -71,12 +71,12 @@ void Transform2D::rotate(const real_t p_phi) {
 
 real_t Transform2D::get_skew() const {
 	real_t det = basis_determinant();
-	return Math::acos(elements[0].normalized().dot(SIGN(det) * elements[1].normalized())) - Math_PI * 0.5f;
+	return Math::acos(elements[0].normalized().dot(SIGN(det) * elements[1].normalized())) - (real_t)Math_PI * 0.5f;
 }
 
 void Transform2D::set_skew(const real_t p_angle) {
 	real_t det = basis_determinant();
-	elements[1] = SIGN(det) * elements[0].rotated((Math_PI * 0.5f + p_angle)).normalized() * elements[1].length();
+	elements[1] = SIGN(det) * elements[0].rotated(((real_t)Math_PI * 0.5f + p_angle)).normalized() * elements[1].length();
 }
 
 real_t Transform2D::get_rotation() const {

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -163,7 +163,7 @@ Vector2 Vector2::move_toward(const Vector2 &p_to, const real_t p_delta) const {
 	Vector2 v = *this;
 	Vector2 vd = p_to - v;
 	real_t len = vd.length();
-	return len <= p_delta || len < CMP_EPSILON ? p_to : v + vd / len * p_delta;
+	return len <= p_delta || len < (real_t)CMP_EPSILON ? p_to : v + vd / len * p_delta;
 }
 
 // slide returns the component of the vector along the given plane, specified by its normal vector.

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -97,7 +97,7 @@ Vector3 Vector3::move_toward(const Vector3 &p_to, const real_t p_delta) const {
 	Vector3 v = *this;
 	Vector3 vd = p_to - v;
 	real_t len = vd.length();
-	return len <= p_delta || len < CMP_EPSILON ? p_to : v + vd / len * p_delta;
+	return len <= p_delta || len < (real_t)CMP_EPSILON ? p_to : v + vd / len * p_delta;
 }
 
 Vector2 Vector3::octahedron_encode() const {

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -103,7 +103,7 @@
 #endif
 
 #ifndef SIGN
-#define SIGN(m_v) (((m_v) == 0) ? (0.0) : (((m_v) < 0) ? (-1.0) : (+1.0)))
+#define SIGN(m_v) (((m_v) == 0) ? (0.0f) : (((m_v) < 0) ? (-1.0f) : (+1.0f)))
 #endif
 
 #ifndef MIN


### PR DESCRIPTION
Uses (real_t) casting to ensure appropriate calculations are done in 32 bit where real_t is compiled as 32 bit.

2nd part of #57703

## Notes
* There are also a couple of places I've added extra brackets where my compiler has indicated the order of precedence is ambiguous.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
