### PR TITLE
[3.x] Float literals - fix math classes to allow 32 bit calculations

### DIFF
--- a/core/math/aabb.h
+++ b/core/math/aabb.h
@@ -58,7 +58,7 @@ public:
 	void set_position(const Vector3 &p_pos) { position = p_pos; }
 	const Vector3 &get_size() const { return size; }
 	void set_size(const Vector3 &p_size) { size = p_size; }
-	Vector3 get_center() const { return position + (size * 0.5); }
+	Vector3 get_center() const { return position + (size * 0.5f); }
 
 	bool operator==(const AABB &p_rval) const;
 	bool operator!=(const AABB &p_rval) const;
@@ -176,7 +176,7 @@ inline bool AABB::encloses(const AABB &p_aabb) const {
 }
 
 Vector3 AABB::get_support(const Vector3 &p_normal) const {
-	Vector3 half_extents = size * 0.5;
+	Vector3 half_extents = size * 0.5f;
 	Vector3 ofs = position + half_extents;
 
 	return Vector3(
@@ -210,7 +210,7 @@ Vector3 AABB::get_endpoint(int p_point) const {
 }
 
 bool AABB::intersects_convex_shape(const Plane *p_planes, int p_plane_count, const Vector3 *p_points, int p_point_count) const {
-	Vector3 half_extents = size * 0.5;
+	Vector3 half_extents = size * 0.5f;
 	Vector3 ofs = position + half_extents;
 
 	for (int i = 0; i < p_plane_count; i++) {
@@ -252,7 +252,7 @@ bool AABB::intersects_convex_shape(const Plane *p_planes, int p_plane_count, con
 }
 
 bool AABB::inside_convex_shape(const Plane *p_planes, int p_plane_count) const {
-	Vector3 half_extents = size * 0.5;
+	Vector3 half_extents = size * 0.5f;
 	Vector3 ofs = position + half_extents;
 
 	for (int i = 0; i < p_plane_count; i++) {
@@ -322,7 +322,7 @@ inline void AABB::expand_to(const Vector3 &p_vector) {
 }
 
 void AABB::project_range_in_plane(const Plane &p_plane, real_t &r_min, real_t &r_max) const {
-	Vector3 half_extents(size.x * 0.5, size.y * 0.5, size.z * 0.5);
+	Vector3 half_extents = size * 0.5f;
 	Vector3 center(position.x + half_extents.x, position.y + half_extents.y, position.z + half_extents.z);
 
 	real_t length = p_plane.normal.abs().dot(half_extents);
@@ -360,9 +360,9 @@ inline real_t AABB::get_shortest_axis_size() const {
 }
 
 bool AABB::smits_intersect_ray(const Vector3 &p_from, const Vector3 &p_dir, real_t t0, real_t t1) const {
-	real_t divx = 1.0 / p_dir.x;
-	real_t divy = 1.0 / p_dir.y;
-	real_t divz = 1.0 / p_dir.z;
+	real_t divx = 1 / p_dir.x;
+	real_t divy = 1 / p_dir.y;
+	real_t divz = 1 / p_dir.z;
 
 	Vector3 upbound = position + size;
 	real_t tmin, tmax, tymin, tymax, tzmin, tzmax;
@@ -412,9 +412,9 @@ void AABB::grow_by(real_t p_amount) {
 	position.x -= p_amount;
 	position.y -= p_amount;
 	position.z -= p_amount;
-	size.x += 2.0 * p_amount;
-	size.y += 2.0 * p_amount;
-	size.z += 2.0 * p_amount;
+	size.x += 2 * p_amount;
+	size.y += 2 * p_amount;
+	size.z += 2 * p_amount;
 }
 
 #endif // AABB_H

--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -37,16 +37,16 @@
 	(elements[row1][col1] * elements[row2][col2] - elements[row1][col2] * elements[row2][col1])
 
 void Basis::from_z(const Vector3 &p_z) {
-	if (Math::abs(p_z.z) > Math_SQRT12) {
+	if (Math::abs(p_z.z) > (real_t)Math_SQRT12) {
 		// choose p in y-z plane
 		real_t a = p_z[1] * p_z[1] + p_z[2] * p_z[2];
-		real_t k = 1.0 / Math::sqrt(a);
+		real_t k = 1 / Math::sqrt(a);
 		elements[0] = Vector3(0, -p_z[2] * k, p_z[1] * k);
 		elements[1] = Vector3(a * k, -p_z[0] * elements[0][2], p_z[0] * elements[0][1]);
 	} else {
 		// choose p in x-y plane
 		real_t a = p_z.x * p_z.x + p_z.y * p_z.y;
-		real_t k = 1.0 / Math::sqrt(a);
+		real_t k = 1 / Math::sqrt(a);
 		elements[0] = Vector3(-p_z.y * k, p_z.x * k, 0);
 		elements[1] = Vector3(-p_z.z * elements[0].y, p_z.z * elements[0].x, a * k);
 	}
@@ -63,7 +63,7 @@ void Basis::invert() {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND(det == 0);
 #endif
-	real_t s = 1.0 / det;
+	real_t s = 1 / det;
 
 	set(co[0] * s, cofac(0, 2, 2, 1) * s, cofac(0, 1, 1, 2) * s,
 			co[1] * s, cofac(0, 0, 2, 2) * s, cofac(0, 2, 1, 0) * s,
@@ -113,13 +113,13 @@ bool Basis::is_rotation() const {
 }
 
 bool Basis::is_symmetric() const {
-	if (!Math::is_equal_approx_ratio(elements[0][1], elements[1][0], UNIT_EPSILON)) {
+	if (!Math::is_equal_approx_ratio(elements[0][1], elements[1][0], (real_t)UNIT_EPSILON)) {
 		return false;
 	}
-	if (!Math::is_equal_approx_ratio(elements[0][2], elements[2][0], UNIT_EPSILON)) {
+	if (!Math::is_equal_approx_ratio(elements[0][2], elements[2][0], (real_t)UNIT_EPSILON)) {
 		return false;
 	}
-	if (!Math::is_equal_approx_ratio(elements[1][2], elements[2][1], UNIT_EPSILON)) {
+	if (!Math::is_equal_approx_ratio(elements[1][2], elements[2][1], (real_t)UNIT_EPSILON)) {
 		return false;
 	}
 
@@ -138,7 +138,7 @@ Basis Basis::diagonalize() {
 
 	int ite = 0;
 	Basis acc_rot;
-	while (off_matrix_norm_2 > CMP_EPSILON2 && ite++ < ite_max) {
+	while (off_matrix_norm_2 > (real_t)CMP_EPSILON2 && ite++ < ite_max) {
 		real_t el01_2 = elements[0][1] * elements[0][1];
 		real_t el02_2 = elements[0][2] * elements[0][2];
 		real_t el12_2 = elements[1][2] * elements[1][2];
@@ -167,7 +167,7 @@ Basis Basis::diagonalize() {
 		if (Math::is_equal_approx(elements[j][j], elements[i][i])) {
 			angle = Math_PI / 4;
 		} else {
-			angle = 0.5 * Math::atan(2 * elements[i][j] / (elements[j][j] - elements[i][i]));
+			angle = 0.5f * Math::atan(2 * elements[i][j] / (elements[j][j] - elements[i][i]));
 		}
 
 		// Compute the rotation matrix
@@ -412,10 +412,10 @@ Vector3 Basis::get_euler_xyz() const {
 
 	Vector3 euler;
 	real_t sy = elements[0][2];
-	if (sy < (1.0 - CMP_EPSILON)) {
-		if (sy > -(1.0 - CMP_EPSILON)) {
+	if (sy < (1 - (real_t)CMP_EPSILON)) {
+		if (sy > -(1 - (real_t)CMP_EPSILON)) {
 			// is this a pure Y rotation?
-			if (elements[1][0] == 0.0 && elements[0][1] == 0.0 && elements[1][2] == 0 && elements[2][1] == 0 && elements[1][1] == 1) {
+			if (elements[1][0] == 0 && elements[0][1] == 0 && elements[1][2] == 0 && elements[2][1] == 0 && elements[1][1] == 1) {
 				// return the simplest form (human friendlier in editor and scripts)
 				euler.x = 0;
 				euler.y = atan2(elements[0][2], elements[0][0]);
@@ -447,15 +447,15 @@ void Basis::set_euler_xyz(const Vector3 &p_euler) {
 
 	c = Math::cos(p_euler.x);
 	s = Math::sin(p_euler.x);
-	Basis xmat(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c);
+	Basis xmat(1, 0, 0, 0, c, -s, 0, s, c);
 
 	c = Math::cos(p_euler.y);
 	s = Math::sin(p_euler.y);
-	Basis ymat(c, 0.0, s, 0.0, 1.0, 0.0, -s, 0.0, c);
+	Basis ymat(c, 0, s, 0, 1, 0, -s, 0, c);
 
 	c = Math::cos(p_euler.z);
 	s = Math::sin(p_euler.z);
-	Basis zmat(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0);
+	Basis zmat(c, -s, 0, s, c, 0, 0, 0, 1);
 
 	//optimizer will optimize away all this anyway
 	*this = xmat * (ymat * zmat);
@@ -471,8 +471,8 @@ Vector3 Basis::get_euler_xzy() const {
 
 	Vector3 euler;
 	real_t sz = elements[0][1];
-	if (sz < (1.0 - CMP_EPSILON)) {
-		if (sz > -(1.0 - CMP_EPSILON)) {
+	if (sz < (1 - (real_t)CMP_EPSILON)) {
+		if (sz > -(1 - (real_t)CMP_EPSILON)) {
 			euler.x = Math::atan2(elements[2][1], elements[1][1]);
 			euler.y = Math::atan2(elements[0][2], elements[0][0]);
 			euler.z = Math::asin(-sz);
@@ -496,15 +496,15 @@ void Basis::set_euler_xzy(const Vector3 &p_euler) {
 
 	c = Math::cos(p_euler.x);
 	s = Math::sin(p_euler.x);
-	Basis xmat(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c);
+	Basis xmat(1, 0, 0, 0, c, -s, 0, s, c);
 
 	c = Math::cos(p_euler.y);
 	s = Math::sin(p_euler.y);
-	Basis ymat(c, 0.0, s, 0.0, 1.0, 0.0, -s, 0.0, c);
+	Basis ymat(c, 0, s, 0, 1, 0, -s, 0, c);
 
 	c = Math::cos(p_euler.z);
 	s = Math::sin(p_euler.z);
-	Basis zmat(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0);
+	Basis zmat(c, -s, 0, s, c, 0, 0, 0, 1);
 
 	*this = xmat * zmat * ymat;
 }
@@ -519,8 +519,8 @@ Vector3 Basis::get_euler_yzx() const {
 
 	Vector3 euler;
 	real_t sz = elements[1][0];
-	if (sz < (1.0 - CMP_EPSILON)) {
-		if (sz > -(1.0 - CMP_EPSILON)) {
+	if (sz < (1 - (real_t)CMP_EPSILON)) {
+		if (sz > -(1 - (real_t)CMP_EPSILON)) {
 			euler.x = Math::atan2(-elements[1][2], elements[1][1]);
 			euler.y = Math::atan2(-elements[2][0], elements[0][0]);
 			euler.z = Math::asin(sz);
@@ -544,15 +544,15 @@ void Basis::set_euler_yzx(const Vector3 &p_euler) {
 
 	c = Math::cos(p_euler.x);
 	s = Math::sin(p_euler.x);
-	Basis xmat(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c);
+	Basis xmat(1, 0, 0, 0, c, -s, 0, s, c);
 
 	c = Math::cos(p_euler.y);
 	s = Math::sin(p_euler.y);
-	Basis ymat(c, 0.0, s, 0.0, 1.0, 0.0, -s, 0.0, c);
+	Basis ymat(c, 0, s, 0, 1, 0, -s, 0, c);
 
 	c = Math::cos(p_euler.z);
 	s = Math::sin(p_euler.z);
-	Basis zmat(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0);
+	Basis zmat(c, -s, 0, s, c, 0, 0, 0, 1);
 
 	*this = ymat * zmat * xmat;
 }
@@ -572,8 +572,8 @@ Vector3 Basis::get_euler_yxz() const {
 
 	real_t m12 = elements[1][2];
 
-	if (m12 < (1 - CMP_EPSILON)) {
-		if (m12 > -(1 - CMP_EPSILON)) {
+	if (m12 < (1 - (real_t)CMP_EPSILON)) {
+		if (m12 > -(1 - (real_t)CMP_EPSILON)) {
 			// is this a pure X rotation?
 			if (elements[1][0] == 0 && elements[0][1] == 0 && elements[0][2] == 0 && elements[2][0] == 0 && elements[0][0] == 1) {
 				// return the simplest form (human friendlier in editor and scripts)
@@ -608,15 +608,15 @@ void Basis::set_euler_yxz(const Vector3 &p_euler) {
 
 	c = Math::cos(p_euler.x);
 	s = Math::sin(p_euler.x);
-	Basis xmat(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c);
+	Basis xmat(1, 0, 0, 0, c, -s, 0, s, c);
 
 	c = Math::cos(p_euler.y);
 	s = Math::sin(p_euler.y);
-	Basis ymat(c, 0.0, s, 0.0, 1.0, 0.0, -s, 0.0, c);
+	Basis ymat(c, 0, s, 0, 1, 0, -s, 0, c);
 
 	c = Math::cos(p_euler.z);
 	s = Math::sin(p_euler.z);
-	Basis zmat(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0);
+	Basis zmat(c, -s, 0, s, c, 0, 0, 0, 1);
 
 	//optimizer will optimize away all this anyway
 	*this = ymat * xmat * zmat;
@@ -631,8 +631,8 @@ Vector3 Basis::get_euler_zxy() const {
 	//        -cx*sy            sx                    cx*cy
 	Vector3 euler;
 	real_t sx = elements[2][1];
-	if (sx < (1.0 - CMP_EPSILON)) {
-		if (sx > -(1.0 - CMP_EPSILON)) {
+	if (sx < (1 - (real_t)CMP_EPSILON)) {
+		if (sx > -(1 - (real_t)CMP_EPSILON)) {
 			euler.x = Math::asin(sx);
 			euler.y = Math::atan2(-elements[2][0], elements[2][2]);
 			euler.z = Math::atan2(-elements[0][1], elements[1][1]);
@@ -656,15 +656,15 @@ void Basis::set_euler_zxy(const Vector3 &p_euler) {
 
 	c = Math::cos(p_euler.x);
 	s = Math::sin(p_euler.x);
-	Basis xmat(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c);
+	Basis xmat(1, 0, 0, 0, c, -s, 0, s, c);
 
 	c = Math::cos(p_euler.y);
 	s = Math::sin(p_euler.y);
-	Basis ymat(c, 0.0, s, 0.0, 1.0, 0.0, -s, 0.0, c);
+	Basis ymat(c, 0, s, 0, 1, 0, -s, 0, c);
 
 	c = Math::cos(p_euler.z);
 	s = Math::sin(p_euler.z);
-	Basis zmat(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0);
+	Basis zmat(c, -s, 0, s, c, 0, 0, 0, 1);
 
 	*this = zmat * xmat * ymat;
 }
@@ -678,8 +678,8 @@ Vector3 Basis::get_euler_zyx() const {
 	//        -sy               cy*sx                 cy*cx
 	Vector3 euler;
 	real_t sy = elements[2][0];
-	if (sy < (1.0 - CMP_EPSILON)) {
-		if (sy > -(1.0 - CMP_EPSILON)) {
+	if (sy < (1 - (real_t)CMP_EPSILON)) {
+		if (sy > -(1 - (real_t)CMP_EPSILON)) {
 			euler.x = Math::atan2(elements[2][1], elements[2][2]);
 			euler.y = Math::asin(-sy);
 			euler.z = Math::atan2(elements[1][0], elements[0][0]);
@@ -703,15 +703,15 @@ void Basis::set_euler_zyx(const Vector3 &p_euler) {
 
 	c = Math::cos(p_euler.x);
 	s = Math::sin(p_euler.x);
-	Basis xmat(1.0, 0.0, 0.0, 0.0, c, -s, 0.0, s, c);
+	Basis xmat(1, 0, 0, 0, c, -s, 0, s, c);
 
 	c = Math::cos(p_euler.y);
 	s = Math::sin(p_euler.y);
-	Basis ymat(c, 0.0, s, 0.0, 1.0, 0.0, -s, 0.0, c);
+	Basis ymat(c, 0, s, 0, 1, 0, -s, 0, c);
 
 	c = Math::cos(p_euler.z);
 	s = Math::sin(p_euler.z);
-	Basis zmat(c, -s, 0.0, s, c, 0.0, 0.0, 0.0, 1.0);
+	Basis zmat(c, -s, 0, s, c, 0, 0, 0, 1);
 
 	*this = zmat * ymat * xmat;
 }
@@ -772,10 +772,10 @@ Quat Basis::get_quat() const {
 	real_t trace = m.elements[0][0] + m.elements[1][1] + m.elements[2][2];
 	real_t temp[4];
 
-	if (trace > 0.0) {
-		real_t s = Math::sqrt(trace + 1.0);
-		temp[3] = (s * 0.5);
-		s = 0.5 / s;
+	if (trace > 0) {
+		real_t s = Math::sqrt(trace + 1);
+		temp[3] = (s * 0.5f);
+		s = 0.5f / s;
 
 		temp[0] = ((m.elements[2][1] - m.elements[1][2]) * s);
 		temp[1] = ((m.elements[0][2] - m.elements[2][0]) * s);
@@ -787,9 +787,9 @@ Quat Basis::get_quat() const {
 		int j = (i + 1) % 3;
 		int k = (i + 2) % 3;
 
-		real_t s = Math::sqrt(m.elements[i][i] - m.elements[j][j] - m.elements[k][k] + 1.0);
-		temp[i] = s * 0.5;
-		s = 0.5 / s;
+		real_t s = Math::sqrt(m.elements[i][i] - m.elements[j][j] - m.elements[k][k] + 1);
+		temp[i] = s * 0.5f;
+		s = 0.5f / s;
 
 		temp[3] = (m.elements[k][j] - m.elements[j][k]) * s;
 		temp[j] = (m.elements[j][i] + m.elements[i][j]) * s;
@@ -832,10 +832,10 @@ int Basis::get_orthogonal_index() const {
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {
 			real_t v = orth[i][j];
-			if (v > 0.5) {
-				v = 1.0;
-			} else if (v < -0.5) {
-				v = -1.0;
+			if (v > 0.5f) {
+				v = 1;
+			} else if (v < -0.5f) {
+				v = -1;
 			} else {
 				v = 0;
 			}
@@ -940,14 +940,14 @@ void Basis::get_axis_angle(Vector3 &r_axis, real_t &r_angle) const {
 
 void Basis::set_quat(const Quat &p_quat) {
 	real_t d = p_quat.length_squared();
-	real_t s = 2.0 / d;
+	real_t s = 2 / d;
 	real_t xs = p_quat.x * s, ys = p_quat.y * s, zs = p_quat.z * s;
 	real_t wx = p_quat.w * xs, wy = p_quat.w * ys, wz = p_quat.w * zs;
 	real_t xx = p_quat.x * xs, xy = p_quat.x * ys, xz = p_quat.x * zs;
 	real_t yy = p_quat.y * ys, yz = p_quat.y * zs, zz = p_quat.z * zs;
-	set(1.0 - (yy + zz), xy - wz, xz + wy,
-			xy + wz, 1.0 - (xx + zz), yz - wx,
-			xz - wy, yz + wx, 1.0 - (xx + yy));
+	set(1 - (yy + zz), xy - wz, xz + wy,
+			xy + wz, 1 - (xx + zz), yz - wx,
+			xz - wy, yz + wx, 1 - (xx + yy));
 }
 
 void Basis::set_axis_angle(const Vector3 &p_axis, real_t p_phi) {
@@ -957,9 +957,9 @@ void Basis::set_axis_angle(const Vector3 &p_axis, real_t p_phi) {
 #endif
 	Vector3 axis_sq(p_axis.x * p_axis.x, p_axis.y * p_axis.y, p_axis.z * p_axis.z);
 	real_t cosine = Math::cos(p_phi);
-	elements[0][0] = axis_sq.x + cosine * (1.0 - axis_sq.x);
-	elements[1][1] = axis_sq.y + cosine * (1.0 - axis_sq.y);
-	elements[2][2] = axis_sq.z + cosine * (1.0 - axis_sq.z);
+	elements[0][0] = axis_sq.x + cosine * (1 - axis_sq.x);
+	elements[1][1] = axis_sq.y + cosine * (1 - axis_sq.y);
+	elements[2][2] = axis_sq.z + cosine * (1 - axis_sq.z);
 
 	real_t sine = Math::sin(p_phi);
 	real_t t = 1 - cosine;

--- a/core/math/bsp_tree.cpp
+++ b/core/math/bsp_tree.cpp
@@ -83,7 +83,7 @@ int BSP_Tree::_get_points_inside(int p_node, const Vector3 *p_points, int *p_ind
 	real_t dist_min = p.distance_to(min);
 	real_t dist_max = p.distance_to(max);
 
-	if ((dist_min * dist_max) < CMP_EPSILON) { //intersection, test point by point
+	if ((dist_min * dist_max) < (real_t)CMP_EPSILON) { //intersection, test point by point
 
 		int under_count = 0;
 
@@ -213,7 +213,7 @@ int BSP_Tree::get_points_inside(const Vector3 *p_points, int p_point_count) cons
 			bounds.expand_to(p_points[i]);
 	}
 
-	Vector3 half_extents = bounds.size / 2.0;
+	Vector3 half_extents = bounds.size / 2;
 	return _get_points_inside(nodes.size() + 1, p_points, indices, bounds.pos + half_extents, half_extents, p_point_count);
 #endif
 }
@@ -530,7 +530,7 @@ BSP_Tree::BSP_Tree(const PoolVector<Face3> &p_faces, real_t p_error_radius) {
 
 	ERR_FAIL_COND(aabb.has_no_area());
 
-	int top = _bsp_create_node(faces_r.ptr(), indices, planes, nodes, aabb.get_longest_axis_size() * 0.0001);
+	int top = _bsp_create_node(faces_r.ptr(), indices, planes, nodes, aabb.get_longest_axis_size() * 0.0001f);
 
 	if (top < 0) {
 		nodes.clear();

--- a/core/math/bvh.h
+++ b/core/math/bvh.h
@@ -75,7 +75,7 @@ public:
 	// see the variable declarations for more info.
 	void params_set_node_expansion(real_t p_value) {
 		BVH_LOCKED_FUNCTION
-		if (p_value >= 0.0) {
+		if (p_value >= 0) {
 			tree._node_expansion = p_value;
 			tree._auto_node_expansion = false;
 		} else {

--- a/core/math/bvh_abb.h
+++ b/core/math/bvh_abb.h
@@ -88,12 +88,12 @@ struct BVH_ABB {
 	}
 
 	POINT calculate_centre() const {
-		return POINT((calculate_size() * 0.5) + min);
+		return POINT((calculate_size() * 0.5f) + min);
 	}
 
 	real_t get_proximity_to(const BVH_ABB &p_b) const {
 		const POINT d = (min - neg_max) - (p_b.min - p_b.neg_max);
-		real_t proximity = 0.0;
+		real_t proximity = 0;
 		for (int axis = 0; axis < POINT::AXIS_COUNT; ++axis) {
 			proximity += Math::abs(d[axis]);
 		}
@@ -119,7 +119,7 @@ struct BVH_ABB {
 
 	bool intersects_plane(const Plane &p_p) const {
 		Vector3 size = calculate_size();
-		Vector3 half_extents = size * 0.5;
+		Vector3 half_extents = size * 0.5f;
 		Vector3 ofs = min + half_extents;
 
 		// forward side of plane?
@@ -143,7 +143,7 @@ struct BVH_ABB {
 
 	bool intersects_convex_optimized(const ConvexHull &p_hull, const uint32_t *p_plane_ids, uint32_t p_num_planes) const {
 		Vector3 size = calculate_size();
-		Vector3 half_extents = size * 0.5;
+		Vector3 half_extents = size * 0.5f;
 		Vector3 ofs = min + half_extents;
 
 		for (unsigned int i = 0; i < p_num_planes; i++) {
@@ -189,7 +189,7 @@ struct BVH_ABB {
 
 	bool is_point_within_hull(const ConvexHull &p_hull, const Vector3 &p_pt) const {
 		for (int n = 0; n < p_hull.num_planes; n++) {
-			if (p_hull.planes[n].distance_to(p_pt) > 0.0f) {
+			if (p_hull.planes[n].distance_to(p_pt) > 0) {
 				return false;
 			}
 		}
@@ -258,7 +258,7 @@ struct BVH_ABB {
 	// Actually surface area metric.
 	float get_area() const {
 		POINT d = calculate_size();
-		return 2.0f * (d.x * d.y + d.y * d.z + d.z * d.x);
+		return 2 * (d.x * d.y + d.y * d.z + d.z * d.x);
 	}
 
 	void set_to_max_opposite_extents() {

--- a/core/math/bvh_pair.inc
+++ b/core/math/bvh_pair.inc
@@ -64,9 +64,9 @@ struct ItemPairs {
 	// when the number of pairs is high, the density is high and a lower collision margin is better.
 	// when there are few local pairs, a larger margin is more optimal.
 	real_t scale_expansion_margin(real_t p_margin) const {
-		real_t x = real_t(num_pairs) * (1.0 / 9.0);
+		real_t x = (real_t)num_pairs * (real_t)(1.0 / 9.0);
 		x = MIN(x, 1.0);
-		x = 1.0 - x;
+		x = 1 - x;
 		return p_margin * x;
 	}
 };

--- a/core/math/bvh_public.inc
+++ b/core/math/bvh_public.inc
@@ -452,7 +452,7 @@ void update() {
 }
 
 void params_set_pairing_expansion(real_t p_value) {
-	if (p_value < 0.0) {
+	if (p_value < 0) {
 #ifdef BVH_ALLOW_AUTO_EXPANSION
 		_auto_pairing_expansion = true;
 #endif
@@ -465,8 +465,8 @@ void params_set_pairing_expansion(real_t p_value) {
 	_pairing_expansion = p_value;
 
 	// calculate shrinking threshold
-	const real_t fudge_factor = 1.1;
-	_aabb_shrinkage_threshold = _pairing_expansion * POINT::AXIS_COUNT * 2.0 * fudge_factor;
+	const real_t fudge_factor = 1.1f;
+	_aabb_shrinkage_threshold = _pairing_expansion * POINT::AXIS_COUNT * 2 * fudge_factor;
 }
 
 // This routine is not just an enclose check, it also checks for special case of shrinkage
@@ -481,8 +481,8 @@ bool expanded_aabb_encloses_not_shrink(const BOUNDS &p_expanded_aabb, const BOUN
 	const POINT &exp_size = p_expanded_aabb.size;
 	const POINT &new_size = p_aabb.size;
 
-	real_t exp_l = 0.0;
-	real_t new_l = 0.0;
+	real_t exp_l = 0;
+	real_t new_l = 0;
 
 	for (int i = 0; i < POINT::AXIS_COUNT; ++i) {
 		exp_l += exp_size[i];

--- a/core/math/camera_matrix.cpp
+++ b/core/math/camera_matrix.cpp
@@ -154,11 +154,11 @@ void CameraMatrix::set_for_hmd(int p_eye, real_t p_aspect, real_t p_intraocular_
 void CameraMatrix::set_orthogonal(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_znear, real_t p_zfar) {
 	set_identity();
 
-	matrix[0][0] = 2.0 / (p_right - p_left);
+	matrix[0][0] = 2 / (p_right - p_left);
 	matrix[3][0] = -((p_right + p_left) / (p_right - p_left));
-	matrix[1][1] = 2.0 / (p_top - p_bottom);
+	matrix[1][1] = 2 / (p_top - p_bottom);
 	matrix[3][1] = -((p_top + p_bottom) / (p_top - p_bottom));
-	matrix[2][2] = -2.0 / (p_zfar - p_znear);
+	matrix[2][2] = -2 / (p_zfar - p_znear);
 	matrix[3][2] = -((p_zfar + p_znear) / (p_zfar - p_znear));
 	matrix[3][3] = 1.0;
 }
@@ -388,7 +388,7 @@ void CameraMatrix::invert() {
 		pvt_j[k] = k;
 		for (i = k; i < 4; i++) {
 			for (j = k; j < 4; j++) {
-				if (Math::absd(matrix[i][j]) > Math::absd(pvt_val)) {
+				if (Math::abs(matrix[i][j]) > Math::abs(pvt_val)) {
 					pvt_i[k] = i;
 					pvt_j[k] = j;
 					pvt_val = matrix[i][j];
@@ -398,7 +398,7 @@ void CameraMatrix::invert() {
 
 		/** Product of pivots, gives determinant when finished **/
 		determinat *= pvt_val;
-		if (Math::absd(determinat) < 1e-7) {
+		if (Math::abs(determinat) < (real_t)1e-7) {
 			return; //(false);  /** Matrix is singular (zero determinant). **/
 		}
 
@@ -554,7 +554,7 @@ real_t CameraMatrix::get_aspect() const {
 int CameraMatrix::get_pixels_per_meter(int p_for_pixel_width) const {
 	Vector3 result = xform(Vector3(1, 0, -1));
 
-	return int((result.x * 0.5 + 0.5) * p_for_pixel_width);
+	return int((result.x * 0.5f + 0.5f) * p_for_pixel_width);
 }
 
 bool CameraMatrix::is_orthogonal() const {
@@ -571,7 +571,7 @@ real_t CameraMatrix::get_fov() const {
 	right_plane.normalize();
 
 	if ((matrix[8] == 0) && (matrix[9] == 0)) {
-		return Math::rad2deg(Math::acos(Math::abs(right_plane.normal.x))) * 2.0;
+		return Math::rad2deg(Math::acos(Math::abs(right_plane.normal.x))) * 2;
 	} else {
 		// our frustum is asymmetrical need to calculate the left planes angle separately..
 		Plane left_plane = Plane(matrix[3] + matrix[0],

--- a/core/math/face3.cpp
+++ b/core/math/face3.cpp
@@ -42,7 +42,7 @@ int Face3::split_by_plane(const Plane &p_plane, Face3 p_res[3], bool p_is_point_
 	int below_count = 0;
 
 	for (int i = 0; i < 3; i++) {
-		if (p_plane.has_point(vertex[i], CMP_EPSILON)) { // point is in plane
+		if (p_plane.has_point(vertex[i], (real_t)CMP_EPSILON)) { // point is in plane
 
 			ERR_FAIL_COND_V(above_count >= 4, 0);
 			above[above_count++] = vertex[i];
@@ -117,7 +117,7 @@ bool Face3::intersects_segment(const Vector3 &p_from, const Vector3 &p_dir, Vect
 
 bool Face3::is_degenerate() const {
 	Vector3 normal = vec3_cross(vertex[0] - vertex[1], vertex[0] - vertex[2]);
-	return (normal.length_squared() < CMP_EPSILON2);
+	return (normal.length_squared() < (real_t)CMP_EPSILON2);
 }
 
 Face3::Side Face3::get_side_of(const Face3 &p_face, ClockDirection p_clock_dir) const {
@@ -223,7 +223,7 @@ bool Face3::intersects_aabb(const AABB &p_aabb) const {
 
 			Vector3 axis = vec3_cross(e1, e2);
 
-			if (axis.length_squared() < 0.0001) {
+			if (axis.length_squared() < 0.0001f) {
 				continue; // coplanar
 			}
 			axis.normalize();
@@ -270,7 +270,7 @@ void Face3::get_support(const Vector3 &p_normal, const Transform &p_transform, V
 	Vector3 n = p_transform.basis.xform_inv(p_normal);
 
 	/** TEST FACE AS SUPPORT **/
-	if (get_plane().normal.dot(n) > _FACE_IS_VALID_SUPPORT_THRESHOLD) {
+	if (get_plane().normal.dot(n) > (real_t)_FACE_IS_VALID_SUPPORT_THRESHOLD) {
 		*p_count = MIN(3, p_max);
 
 		for (int i = 0; i < *p_count; i++) {
@@ -304,7 +304,7 @@ void Face3::get_support(const Vector3 &p_normal, const Transform &p_transform, V
 		// check if edge is valid as a support
 		real_t dot = (vertex[i] - vertex[(i + 1) % 3]).normalized().dot(n);
 		dot = ABS(dot);
-		if (dot < _EDGE_IS_VALID_SUPPORT_THRESHOLD) {
+		if (dot < (real_t)_EDGE_IS_VALID_SUPPORT_THRESHOLD) {
 			*p_count = MIN(2, p_max);
 
 			for (int j = 0; j < *p_count; j++) {

--- a/core/math/face3.h
+++ b/core/math/face3.h
@@ -106,7 +106,7 @@ inline real_t Face3::get_twice_area_squared() const {
 bool Face3::intersects_aabb2(const AABB &p_aabb) const {
 	Vector3 perp = (vertex[0] - vertex[2]).cross(vertex[0] - vertex[1]);
 
-	Vector3 half_extents = p_aabb.size * 0.5;
+	Vector3 half_extents = p_aabb.size * 0.5f;
 	Vector3 ofs = p_aabb.position + half_extents;
 
 	Vector3 sup = Vector3(
@@ -217,7 +217,7 @@ bool Face3::intersects_aabb2(const AABB &p_aabb) const {
 
 			Vector3 axis = vec3_cross(e1, e2);
 
-			if (axis.length_squared() < 0.0001) {
+			if (axis.length_squared() < 0.0001f) {
 				continue; // coplanar
 			}
 			//axis.normalize();

--- a/core/math/geometry.cpp
+++ b/core/math/geometry.cpp
@@ -160,8 +160,8 @@ static bool _connect_faces(_FaceClassify *p_faces, int len, int p_group) {
 					Vector3 vj2 = p_faces[j].face.vertex[l];
 					Vector3 vj1 = p_faces[j].face.vertex[(l + 1) % 3];
 
-					if (vi1.distance_to(vj1) < 0.00001 &&
-							vi2.distance_to(vj2) < 0.00001) {
+					if (vi1.distance_to(vj1) < 0.00001f &&
+							vi2.distance_to(vj2) < 0.00001f) {
 						if (p_faces[i].links[k].face != -1) {
 							ERR_PRINT("already linked\n");
 							error = true;
@@ -534,7 +534,7 @@ static inline void _build_faces(uint8_t ***p_cell_status, int x, int y, int z, i
 }
 
 PoolVector<Face3> Geometry::wrap_geometry(PoolVector<Face3> p_array, real_t *p_error) {
-#define _MIN_SIZE 1.0
+#define _MIN_SIZE 1.0f
 #define _MAX_LENGTH 20
 
 	int face_count = p_array.size();
@@ -551,7 +551,7 @@ PoolVector<Face3> Geometry::wrap_geometry(PoolVector<Face3> p_array, real_t *p_e
 		}
 	}
 
-	global_aabb.grow_by(0.01); // Avoid numerical error.
+	global_aabb.grow_by(0.01f); // Avoid numerical error.
 
 	// Determine amount of cells in grid axis.
 	int div_x, div_y, div_z;
@@ -716,7 +716,7 @@ Geometry::MeshData Geometry::build_convex_mesh(const PoolVector<Plane> &p_planes
 
 		Vector3 ref = Vector3(0.0, 1.0, 0.0);
 
-		if (ABS(p.normal.dot(ref)) > 0.95) {
+		if (ABS(p.normal.dot(ref)) > 0.95f) {
 			ref = Vector3(0.0, 0.0, 1.0); // Change axis.
 		}
 
@@ -740,7 +740,7 @@ Geometry::MeshData Geometry::build_convex_mesh(const PoolVector<Plane> &p_planes
 			Vector<Vector3> new_vertices;
 			Plane clip = p_planes[j];
 
-			if (clip.normal.dot(p.normal) > 0.95) {
+			if (clip.normal.dot(p.normal) > 0.95f) {
 				continue;
 			}
 
@@ -793,7 +793,7 @@ Geometry::MeshData Geometry::build_convex_mesh(const PoolVector<Plane> &p_planes
 		for (int j = 0; j < vertices.size(); j++) {
 			int idx = -1;
 			for (int k = 0; k < mesh.vertices.size(); k++) {
-				if (mesh.vertices[k].distance_to(vertices[j]) < 0.001) {
+				if (mesh.vertices[k].distance_to(vertices[j]) < 0.001f) {
 					idx = k;
 					break;
 				}
@@ -860,8 +860,8 @@ PoolVector<Plane> Geometry::build_cylinder_planes(real_t p_radius, real_t p_heig
 
 	for (int i = 0; i < p_sides; i++) {
 		Vector3 normal;
-		normal[(p_axis + 1) % 3] = Math::cos(i * (2.0 * Math_PI) / p_sides);
-		normal[(p_axis + 2) % 3] = Math::sin(i * (2.0 * Math_PI) / p_sides);
+		normal[(p_axis + 1) % 3] = Math::cos(i * (real_t)(2.0 * Math_PI) / p_sides);
+		normal[(p_axis + 2) % 3] = Math::sin(i * (real_t)(2.0 * Math_PI) / p_sides);
 
 		planes.push_back(Plane(normal, p_radius));
 	}
@@ -869,8 +869,8 @@ PoolVector<Plane> Geometry::build_cylinder_planes(real_t p_radius, real_t p_heig
 	Vector3 axis;
 	axis[p_axis] = 1.0;
 
-	planes.push_back(Plane(axis, p_height * 0.5));
-	planes.push_back(Plane(-axis, p_height * 0.5));
+	planes.push_back(Plane(axis, p_height * 0.5f));
+	planes.push_back(Plane(-axis, p_height * 0.5f));
 
 	return planes;
 }
@@ -881,17 +881,17 @@ PoolVector<Plane> Geometry::build_sphere_planes(real_t p_radius, int p_lats, int
 	PoolVector<Plane> planes;
 
 	Vector3 axis;
-	axis[p_axis] = 1.0;
+	axis[p_axis] = 1;
 
 	Vector3 axis_neg;
-	axis_neg[(p_axis + 1) % 3] = 1.0;
-	axis_neg[(p_axis + 2) % 3] = 1.0;
-	axis_neg[p_axis] = -1.0;
+	axis_neg[(p_axis + 1) % 3] = 1;
+	axis_neg[(p_axis + 2) % 3] = 1;
+	axis_neg[p_axis] = -1;
 
 	for (int i = 0; i < p_lons; i++) {
 		Vector3 normal;
-		normal[(p_axis + 1) % 3] = Math::cos(i * (2.0 * Math_PI) / p_lons);
-		normal[(p_axis + 2) % 3] = Math::sin(i * (2.0 * Math_PI) / p_lons);
+		normal[(p_axis + 1) % 3] = Math::cos(i * (real_t)(2.0 * Math_PI) / p_lons);
+		normal[(p_axis + 2) % 3] = Math::sin(i * (real_t)(2.0 * Math_PI) / p_lons);
 
 		planes.push_back(Plane(normal, p_radius));
 
@@ -913,23 +913,23 @@ PoolVector<Plane> Geometry::build_capsule_planes(real_t p_radius, real_t p_heigh
 	PoolVector<Plane> planes;
 
 	Vector3 axis;
-	axis[p_axis] = 1.0;
+	axis[p_axis] = 1;
 
 	Vector3 axis_neg;
-	axis_neg[(p_axis + 1) % 3] = 1.0;
-	axis_neg[(p_axis + 2) % 3] = 1.0;
-	axis_neg[p_axis] = -1.0;
+	axis_neg[(p_axis + 1) % 3] = 1;
+	axis_neg[(p_axis + 2) % 3] = 1;
+	axis_neg[p_axis] = -1;
 
 	for (int i = 0; i < p_sides; i++) {
 		Vector3 normal;
-		normal[(p_axis + 1) % 3] = Math::cos(i * (2.0 * Math_PI) / p_sides);
-		normal[(p_axis + 2) % 3] = Math::sin(i * (2.0 * Math_PI) / p_sides);
+		normal[(p_axis + 1) % 3] = Math::cos(i * (real_t)(2.0 * Math_PI) / p_sides);
+		normal[(p_axis + 2) % 3] = Math::sin(i * (real_t)(2.0 * Math_PI) / p_sides);
 
 		planes.push_back(Plane(normal, p_radius));
 
 		for (int j = 1; j <= p_lats; j++) {
 			Vector3 angle = normal.linear_interpolate(axis, j / (real_t)p_lats).normalized();
-			Vector3 pos = axis * p_height * 0.5 + angle * p_radius;
+			Vector3 pos = axis * p_height * 0.5f + angle * p_radius;
 			planes.push_back(Plane(pos, angle));
 			planes.push_back(Plane(pos * axis_neg, angle * axis_neg));
 		}
@@ -942,7 +942,7 @@ struct _AtlasWorkRect {
 	Size2i s;
 	Point2i p;
 	int idx;
-	_FORCE_INLINE_ bool operator<(const _AtlasWorkRect &p_r) const { return s.width > p_r.s.width; };
+	_FORCE_INLINE_ bool operator<(const _AtlasWorkRect &p_r) const { return s.width > p_r.s.width; }
 };
 
 struct _AtlasWorkRectResult {
@@ -1085,10 +1085,10 @@ Vector<Vector<Point2>> Geometry::_polypaths_do_operation(PolyBooleanOperation p_
 
 	// Need to scale points (Clipper's requirement for robust computation).
 	for (int i = 0; i != p_polypath_a.size(); ++i) {
-		path_a << IntPoint(p_polypath_a[i].x * SCALE_FACTOR, p_polypath_a[i].y * SCALE_FACTOR);
+		path_a << IntPoint(p_polypath_a[i].x * (real_t)SCALE_FACTOR, p_polypath_a[i].y * (real_t)SCALE_FACTOR);
 	}
 	for (int i = 0; i != p_polypath_b.size(); ++i) {
-		path_b << IntPoint(p_polypath_b[i].x * SCALE_FACTOR, p_polypath_b[i].y * SCALE_FACTOR);
+		path_b << IntPoint(p_polypath_b[i].x * (real_t)SCALE_FACTOR, p_polypath_b[i].y * (real_t)SCALE_FACTOR);
 	}
 	Clipper clp;
 	clp.AddPath(path_a, ptSubject, !is_a_open); // Forward compatible with Clipper 10.0.0.
@@ -1113,8 +1113,8 @@ Vector<Vector<Point2>> Geometry::_polypaths_do_operation(PolyBooleanOperation p_
 
 		for (Paths::size_type j = 0; j < scaled_path.size(); ++j) {
 			polypath.push_back(Point2(
-					static_cast<real_t>(scaled_path[j].X) / SCALE_FACTOR,
-					static_cast<real_t>(scaled_path[j].Y) / SCALE_FACTOR));
+					static_cast<real_t>(scaled_path[j].X) / (real_t)SCALE_FACTOR,
+					static_cast<real_t>(scaled_path[j].Y) / (real_t)SCALE_FACTOR));
 		}
 		polypaths.push_back(polypath);
 	}
@@ -1157,17 +1157,17 @@ Vector<Vector<Point2>> Geometry::_polypath_offset(const Vector<Point2> &p_polypa
 			et = etOpenRound;
 			break;
 	}
-	ClipperOffset co(2.0, 0.25 * SCALE_FACTOR); // Defaults from ClipperOffset.
+	ClipperOffset co(2.0f, 0.25f * (real_t)SCALE_FACTOR); // Defaults from ClipperOffset.
 	Path path;
 
 	// Need to scale points (Clipper's requirement for robust computation).
 	for (int i = 0; i != p_polypath.size(); ++i) {
-		path << IntPoint(p_polypath[i].x * SCALE_FACTOR, p_polypath[i].y * SCALE_FACTOR);
+		path << IntPoint(p_polypath[i].x * (real_t)SCALE_FACTOR, p_polypath[i].y * (real_t)SCALE_FACTOR);
 	}
 	co.AddPath(path, jt, et);
 
 	Paths paths;
-	co.Execute(paths, p_delta * SCALE_FACTOR); // Inflate/deflate.
+	co.Execute(paths, p_delta * (real_t)SCALE_FACTOR); // Inflate/deflate.
 
 	// Have to scale points down now.
 	Vector<Vector<Point2>> polypaths;
@@ -1179,8 +1179,8 @@ Vector<Vector<Point2>> Geometry::_polypath_offset(const Vector<Point2> &p_polypa
 
 		for (Paths::size_type j = 0; j < scaled_path.size(); ++j) {
 			polypath.push_back(Point2(
-					static_cast<real_t>(scaled_path[j].X) / SCALE_FACTOR,
-					static_cast<real_t>(scaled_path[j].Y) / SCALE_FACTOR));
+					static_cast<real_t>(scaled_path[j].X) / (real_t)SCALE_FACTOR,
+					static_cast<real_t>(scaled_path[j].Y) / (real_t)SCALE_FACTOR));
 		}
 		polypaths.push_back(polypath);
 	}
@@ -1189,7 +1189,7 @@ Vector<Vector<Point2>> Geometry::_polypath_offset(const Vector<Point2> &p_polypa
 
 real_t Geometry::calculate_convex_hull_volume(const Geometry::MeshData &p_md) {
 	if (!p_md.vertices.size()) {
-		return 0.0;
+		return 0;
 	}
 
 	// find center
@@ -1226,7 +1226,7 @@ real_t Geometry::calculate_convex_hull_volume(const Geometry::MeshData &p_md) {
 		volume += face_area * height;
 	}
 
-	volume *= (1.0 / 3.0) * 0.5;
+	volume *= (real_t)((1.0 / 3.0) * 0.5);
 	return volume;
 }
 
@@ -1394,7 +1394,7 @@ real_t Geometry::find_polygon_area(const Vector3 *p_verts, int p_num_verts) {
 		area += Math::sqrt(f.get_twice_area_squared());
 	}
 
-	return area * 0.5;
+	return area * 0.5f;
 }
 
 // adapted from:
@@ -1422,10 +1422,10 @@ void Geometry::sort_polygon_winding(Vector<Vector2> &r_verts, bool p_clockwise) 
 
 			// compute the cross product of vectors (center -> a) x (center -> b)
 			real_t det = (a.x - center.x) * (b.y - center.y) - (b.x - center.x) * (a.y - center.y);
-			if (det < 0.0) {
+			if (det < 0) {
 				return true;
 			}
-			if (det > 0.0) {
+			if (det > 0) {
 				return false;
 			}
 

--- a/core/math/geometry.h
+++ b/core/math/geometry.h
@@ -52,33 +52,33 @@ public:
 		real_t f = d2.dot(r);
 		real_t s, t;
 		// Check if either or both segments degenerate into points.
-		if (a <= CMP_EPSILON && e <= CMP_EPSILON) {
+		if (a <= (real_t)CMP_EPSILON && e <= (real_t)CMP_EPSILON) {
 			// Both segments degenerate into points.
 			c1 = p1;
 			c2 = p2;
 			return Math::sqrt((c1 - c2).dot(c1 - c2));
 		}
-		if (a <= CMP_EPSILON) {
+		if (a <= (real_t)CMP_EPSILON) {
 			// First segment degenerates into a point.
-			s = 0.0;
+			s = 0;
 			t = f / e; // s = 0 => t = (b*s + f) / e = f / e
-			t = CLAMP(t, 0.0, 1.0);
+			t = CLAMP(t, 0, 1);
 		} else {
 			real_t c = d1.dot(r);
-			if (e <= CMP_EPSILON) {
+			if (e <= (real_t)CMP_EPSILON) {
 				// Second segment degenerates into a point.
-				t = 0.0;
-				s = CLAMP(-c / a, 0.0, 1.0); // t = 0 => s = (b*t - c) / a = -c / a
+				t = 0;
+				s = CLAMP(-c / a, 0, 1); // t = 0 => s = (b*t - c) / a = -c / a
 			} else {
 				// The general nondegenerate case starts here.
 				real_t b = d1.dot(d2);
 				real_t denom = a * e - b * b; // Always nonnegative.
 				// If segments not parallel, compute closest point on L1 to L2 and
 				// clamp to segment S1. Else pick arbitrary s (here 0).
-				if (denom != 0.0) {
-					s = CLAMP((b * f - c * e) / denom, 0.0, 1.0);
+				if (denom != 0) {
+					s = CLAMP((b * f - c * e) / denom, 0, 1);
 				} else {
-					s = 0.0;
+					s = 0;
 				}
 				// Compute point on L2 closest to S1(s) using
 				// t = Dot((P1 + D1*s) - P2,D2) / Dot(D2,D2) = (b*s + f) / e
@@ -87,12 +87,12 @@ public:
 				//If t in [0,1] done. Else clamp t, recompute s for the new value
 				// of t using s = Dot((P2 + D2*t) - P1,D1) / Dot(D1,D1)= (t*b - c) / a
 				// and clamp s to [0, 1].
-				if (t < 0.0) {
-					t = 0.0;
-					s = CLAMP(-c / a, 0.0, 1.0);
-				} else if (t > 1.0) {
-					t = 1.0;
-					s = CLAMP((b - c) / a, 0.0, 1.0);
+				if (t < 0) {
+					t = 0;
+					s = CLAMP(-c / a, 0, 1);
+				} else if (t > 1) {
+					t = 1;
+					s = CLAMP((b - c) / a, 0, 1);
 				}
 			}
 		}
@@ -140,16 +140,16 @@ public:
 		real_t tc, tN, tD = D; // tc = tN / tD, default tD = D >= 0
 
 		// Compute the line parameters of the two closest points.
-		if (D < CMP_EPSILON) { // The lines are almost parallel.
-			sN = 0.0; // Force using point P0 on segment S1
-			sD = 1.0; // to prevent possible division by 0.0 later.
+		if (D < (real_t)CMP_EPSILON) { // The lines are almost parallel.
+			sN = 0; // Force using point P0 on segment S1
+			sD = 1; // to prevent possible division by 0.0 later.
 			tN = e;
 			tD = c;
 		} else { // Get the closest points on the infinite lines
 			sN = (b * e - c * d);
 			tN = (a * e - b * d);
-			if (sN < 0.0) { // sc < 0 => the s=0 edge is visible.
-				sN = 0.0;
+			if (sN < 0) { // sc < 0 => the s=0 edge is visible.
+				sN = 0;
 				tN = e;
 				tD = c;
 			} else if (sN > sD) { // sc > 1 => the s=1 edge is visible.
@@ -159,11 +159,11 @@ public:
 			}
 		}
 
-		if (tN < 0.0) { // tc < 0 => the t=0 edge is visible.
-			tN = 0.0;
+		if (tN < 0) { // tc < 0 => the t=0 edge is visible.
+			tN = 0;
 			// Recompute sc for this edge.
-			if (-d < 0.0) {
-				sN = 0.0;
+			if (-d < 0) {
+				sN = 0;
 			} else if (-d > a) {
 				sN = sD;
 			} else {
@@ -173,7 +173,7 @@ public:
 		} else if (tN > tD) { // tc > 1 => the t=1 edge is visible.
 			tN = tD;
 			// Recompute sc for this edge.
-			if ((-d + b) < 0.0) {
+			if ((-d + b) < 0) {
 				sN = 0;
 			} else if ((-d + b) > a) {
 				sN = sD;
@@ -183,8 +183,8 @@ public:
 			}
 		}
 		// Finally do the division to get sc and tc.
-		sc = (Math::is_zero_approx(sN) ? 0.0 : sN / sD);
-		tc = (Math::is_zero_approx(tN) ? 0.0 : tN / tD);
+		sc = (Math::is_zero_approx(sN) ? 0 : sN / sD);
+		tc = (Math::is_zero_approx(tN) ? 0 : tN / tD);
 
 		// Get the difference of the two closest points.
 		Vector3 dP = w + (sc * u) - (tc * v); // = S1(sc) - S2(tc)
@@ -201,12 +201,12 @@ public:
 			return false;
 		}
 
-		real_t f = 1.0 / a;
+		real_t f = 1 / a;
 
 		Vector3 s = p_from - p_v0;
 		real_t u = f * s.dot(h);
 
-		if (u < 0.0 || u > 1.0) {
+		if ((u < 0) || (u > 1)) {
 			return false;
 		}
 
@@ -214,7 +214,7 @@ public:
 
 		real_t v = f * p_dir.dot(q);
 
-		if (v < 0.0 || u + v > 1.0) {
+		if ((v < 0) || (u + v > 1)) {
 			return false;
 		}
 
@@ -222,7 +222,7 @@ public:
 		// the intersection point is on the line.
 		real_t t = f * e2.dot(q);
 
-		if (t > 0.00001) { // ray intersection
+		if (t > 0.00001f) { // ray intersection
 			if (r_res) {
 				*r_res = p_from + p_dir * t;
 			}
@@ -242,12 +242,12 @@ public:
 			return false;
 		}
 
-		real_t f = 1.0 / a;
+		real_t f = 1 / a;
 
 		Vector3 s = p_from - p_v0;
 		real_t u = f * s.dot(h);
 
-		if (u < 0.0 || u > 1.0) {
+		if ((u < 0) || (u > 1)) {
 			return false;
 		}
 
@@ -255,7 +255,7 @@ public:
 
 		real_t v = f * rel.dot(q);
 
-		if (v < 0.0 || u + v > 1.0) {
+		if ((v < 0) || (u + v > 1)) {
 			return false;
 		}
 
@@ -263,7 +263,7 @@ public:
 		// the intersection point is on the line.
 		real_t t = f * e2.dot(q);
 
-		if (t > CMP_EPSILON && t <= 1.0) { // Ray intersection.
+		if (t > (real_t)CMP_EPSILON && t <= 1) { // Ray intersection.
 			if (r_res) {
 				*r_res = p_from + rel * t;
 			}
@@ -277,7 +277,7 @@ public:
 		Vector3 sphere_pos = p_sphere_pos - p_from;
 		Vector3 rel = (p_to - p_from);
 		real_t rel_l = rel.length();
-		if (rel_l < CMP_EPSILON) {
+		if (rel_l < (real_t)CMP_EPSILON) {
 			return false; // Both points are the same.
 		}
 		Vector3 normal = rel / rel_l;
@@ -293,7 +293,7 @@ public:
 		real_t inters_d2 = p_sphere_radius * p_sphere_radius - ray_distance * ray_distance;
 		real_t inters_d = sphere_d;
 
-		if (inters_d2 >= CMP_EPSILON) {
+		if (inters_d2 >= (real_t)CMP_EPSILON) {
 			inters_d -= Math::sqrt(inters_d2);
 		}
 
@@ -317,14 +317,14 @@ public:
 	static inline bool segment_intersects_cylinder(const Vector3 &p_from, const Vector3 &p_to, real_t p_height, real_t p_radius, Vector3 *r_res = nullptr, Vector3 *r_norm = nullptr, int p_cylinder_axis = 2) {
 		Vector3 rel = (p_to - p_from);
 		real_t rel_l = rel.length();
-		if (rel_l < CMP_EPSILON) {
+		if (rel_l < (real_t)CMP_EPSILON) {
 			return false; // Both points are the same.
 		}
 
 		ERR_FAIL_COND_V(p_cylinder_axis < 0, false);
 		ERR_FAIL_COND_V(p_cylinder_axis > 2, false);
 		Vector3 cylinder_axis;
-		cylinder_axis[p_cylinder_axis] = 1.0;
+		cylinder_axis[p_cylinder_axis] = 1;
 
 		// First check if they are parallel.
 		Vector3 normal = (rel / rel_l);
@@ -333,9 +333,9 @@ public:
 
 		Vector3 axis_dir;
 
-		if (crs_l < CMP_EPSILON) {
+		if (crs_l < (real_t)CMP_EPSILON) {
 			Vector3 side_axis;
-			side_axis[(p_cylinder_axis + 1) % 3] = 1.0; // Any side axis OK.
+			side_axis[(p_cylinder_axis + 1) % 3] = 1; // Any side axis OK.
 			axis_dir = side_axis;
 		} else {
 			axis_dir = crs / crs_l;
@@ -349,10 +349,10 @@ public:
 
 		// Convert to 2D.
 		real_t w2 = p_radius * p_radius - dist * dist;
-		if (w2 < CMP_EPSILON) {
+		if (w2 < (real_t)CMP_EPSILON) {
 			return false; // Avoid numerical error.
 		}
-		Size2 size(Math::sqrt(w2), p_height * 0.5);
+		Size2 size(Math::sqrt(w2), p_height * 0.5f);
 
 		Vector3 side_dir = axis_dir.cross(cylinder_axis).normalized();
 
@@ -430,7 +430,7 @@ public:
 		Vector3 rel = p_to - p_from;
 		real_t rel_l = rel.length();
 
-		if (rel_l < CMP_EPSILON) {
+		if (rel_l < (real_t)CMP_EPSILON) {
 			return false;
 		}
 
@@ -443,7 +443,7 @@ public:
 
 			real_t den = p.normal.dot(dir);
 
-			if (Math::abs(den) <= CMP_EPSILON) {
+			if (Math::abs(den) <= (real_t)CMP_EPSILON) {
 				continue; // Ignore parallel plane.
 			}
 
@@ -481,13 +481,13 @@ public:
 		Vector3 p = p_point - p_segment[0];
 		Vector3 n = p_segment[1] - p_segment[0];
 		real_t l2 = n.length_squared();
-		if (l2 < 1e-20) {
+		if (l2 < 1e-20f) {
 			return p_segment[0]; // Both points are the same, just give any.
 		}
 
 		real_t d = n.dot(p) / l2;
 
-		if (d <= 0.0) {
+		if (d <= 0) {
 			return p_segment[0]; // Before first point.
 		} else if (d >= 1.0) {
 			return p_segment[1]; // After first point.
@@ -500,7 +500,7 @@ public:
 		Vector3 p = p_point - p_segment[0];
 		Vector3 n = p_segment[1] - p_segment[0];
 		real_t l2 = n.length_squared();
-		if (l2 < 1e-20) {
+		if (l2 < 1e-20f) {
 			return p_segment[0]; // Both points are the same, just give any.
 		}
 
@@ -513,15 +513,15 @@ public:
 		Vector2 p = p_point - p_segment[0];
 		Vector2 n = p_segment[1] - p_segment[0];
 		real_t l2 = n.length_squared();
-		if (l2 < 1e-20) {
+		if (l2 < 1e-20f) {
 			return p_segment[0]; // Both points are the same, just give any.
 		}
 
 		real_t d = n.dot(p) / l2;
 
-		if (d <= 0.0) {
+		if (d <= 0) {
 			return p_segment[0]; // Before first point.
-		} else if (d >= 1.0) {
+		} else if (d >= 1) {
 			return p_segment[1]; // After first point.
 		} else {
 			return p_segment[0] + n * d; // Inside.
@@ -573,7 +573,7 @@ public:
 		Vector2 p = p_point - p_segment[0];
 		Vector2 n = p_segment[1] - p_segment[0];
 		real_t l2 = n.length_squared();
-		if (l2 < 1e-20) {
+		if (l2 < 1e-20f) {
 			return p_segment[0]; // Both points are the same, just give any.
 		}
 
@@ -616,7 +616,7 @@ public:
 		real_t ABpos = D.x + (C.x - D.x) * D.y / (D.y - C.y);
 
 		// Fail if segment C-D crosses line A-B outside of segment A-B.
-		if (ABpos < 0 || ABpos > 1.0) {
+		if ((ABpos < 0) || (ABpos > 1)) {
 			return false;
 		}
 
@@ -785,11 +785,11 @@ public:
 
 		for (int a = 0; a < polygon.size(); a++) {
 			real_t dist = p_plane.distance_to(polygon[a]);
-			if (dist < -CMP_POINT_IN_PLANE_EPSILON) {
+			if (dist < (real_t)-CMP_POINT_IN_PLANE_EPSILON) {
 				location_cache[a] = LOC_INSIDE;
 				inside_count++;
 			} else {
-				if (dist > CMP_POINT_IN_PLANE_EPSILON) {
+				if (dist > (real_t)CMP_POINT_IN_PLANE_EPSILON) {
 					location_cache[a] = LOC_OUTSIDE;
 					outside_count++;
 				} else {

--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -64,7 +64,7 @@ public:
 	static _ALWAYS_INLINE_ float sinc(float p_x) { return p_x == 0 ? 1 : ::sin(p_x) / p_x; }
 	static _ALWAYS_INLINE_ double sinc(double p_x) { return p_x == 0 ? 1 : ::sin(p_x) / p_x; }
 
-	static _ALWAYS_INLINE_ float sincn(float p_x) { return sinc(Math_PI * p_x); }
+	static _ALWAYS_INLINE_ float sincn(float p_x) { return sinc((float)Math_PI * p_x); }
 	static _ALWAYS_INLINE_ double sincn(double p_x) { return sinc(Math_PI * p_x); }
 
 	static _ALWAYS_INLINE_ double cosh(double p_x) { return ::cosh(p_x); }
@@ -185,7 +185,7 @@ public:
 
 	static _ALWAYS_INLINE_ double fposmod(double p_x, double p_y) {
 		double value = Math::fmod(p_x, p_y);
-		if ((value < 0 && p_y > 0) || (value > 0 && p_y < 0)) {
+		if (((value < 0) && (p_y > 0)) || ((value > 0) && (p_y < 0))) {
 			value += p_y;
 		}
 		value += 0.0;
@@ -193,25 +193,25 @@ public:
 	}
 	static _ALWAYS_INLINE_ float fposmod(float p_x, float p_y) {
 		float value = Math::fmod(p_x, p_y);
-		if ((value < 0 && p_y > 0) || (value > 0 && p_y < 0)) {
+		if (((value < 0) && (p_y > 0)) || ((value > 0) && (p_y < 0))) {
 			value += p_y;
 		}
-		value += 0.0;
+		value += 0.0f;
 		return value;
 	}
 	static _ALWAYS_INLINE_ int64_t posmod(int64_t p_x, int64_t p_y) {
 		int64_t value = p_x % p_y;
-		if ((value < 0 && p_y > 0) || (value > 0 && p_y < 0)) {
+		if (((value < 0) && (p_y > 0)) || ((value > 0) && (p_y < 0))) {
 			value += p_y;
 		}
 		return value;
 	}
 
 	static _ALWAYS_INLINE_ double deg2rad(double p_y) { return p_y * Math_PI / 180.0; }
-	static _ALWAYS_INLINE_ float deg2rad(float p_y) { return p_y * Math_PI / 180.0; }
+	static _ALWAYS_INLINE_ float deg2rad(float p_y) { return p_y * (float)(Math_PI / 180.0); }
 
 	static _ALWAYS_INLINE_ double rad2deg(double p_y) { return p_y * 180.0 / Math_PI; }
-	static _ALWAYS_INLINE_ float rad2deg(float p_y) { return p_y * 180.0 / Math_PI; }
+	static _ALWAYS_INLINE_ float rad2deg(float p_y) { return p_y * (float)(180.0 / Math_PI); }
 
 	static _ALWAYS_INLINE_ double lerp(double p_from, double p_to, double p_weight) { return p_from + (p_to - p_from) * p_weight; }
 	static _ALWAYS_INLINE_ float lerp(float p_from, float p_to, float p_weight) { return p_from + (p_to - p_from) * p_weight; }
@@ -251,10 +251,10 @@ public:
 	static _ALWAYS_INLINE_ float move_toward(float p_from, float p_to, float p_delta) { return abs(p_to - p_from) <= p_delta ? p_to : p_from + SGN(p_to - p_from) * p_delta; }
 
 	static _ALWAYS_INLINE_ double linear2db(double p_linear) { return Math::log(p_linear) * 8.6858896380650365530225783783321; }
-	static _ALWAYS_INLINE_ float linear2db(float p_linear) { return Math::log(p_linear) * 8.6858896380650365530225783783321; }
+	static _ALWAYS_INLINE_ float linear2db(float p_linear) { return Math::log(p_linear) * (float)8.6858896380650365530225783783321; }
 
 	static _ALWAYS_INLINE_ double db2linear(double p_db) { return Math::exp(p_db * 0.11512925464970228420089957273422); }
-	static _ALWAYS_INLINE_ float db2linear(float p_db) { return Math::exp(p_db * 0.11512925464970228420089957273422); }
+	static _ALWAYS_INLINE_ float db2linear(float p_db) { return Math::exp(p_db * (float)0.11512925464970228420089957273422); }
 
 	static _ALWAYS_INLINE_ double round(double p_val) { return ::round(p_val); }
 	static _ALWAYS_INLINE_ float round(float p_val) { return ::roundf(p_val); }
@@ -296,10 +296,10 @@ public:
 		// this is an approximate way to check that numbers are close, as a ratio of their average size
 		// helps compare approximate numbers that may be very big or very small
 		real_t diff = abs(a - b);
-		if (diff == 0.0 || diff < min_epsilon) {
+		if (diff == 0 || diff < min_epsilon) {
 			return true;
 		}
-		real_t avg_size = (abs(a) + abs(b)) / 2.0;
+		real_t avg_size = (abs(a) + abs(b)) / 2;
 		diff /= avg_size;
 		return diff < epsilon;
 	}
@@ -310,9 +310,9 @@ public:
 			return true;
 		}
 		// Then check for approximate equality.
-		float tolerance = CMP_EPSILON * abs(a);
-		if (tolerance < CMP_EPSILON) {
-			tolerance = CMP_EPSILON;
+		float tolerance = (float)CMP_EPSILON * abs(a);
+		if (tolerance < (float)CMP_EPSILON) {
+			tolerance = (float)CMP_EPSILON;
 		}
 		return abs(a - b) < tolerance;
 	}
@@ -327,7 +327,7 @@ public:
 	}
 
 	static _ALWAYS_INLINE_ bool is_zero_approx(float s) {
-		return abs(s) < CMP_EPSILON;
+		return abs(s) < (float)CMP_EPSILON;
 	}
 
 	static _ALWAYS_INLINE_ bool is_equal_approx(double a, double b) {

--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -61,7 +61,7 @@ Vector3 Plane::get_any_perpendicular_normal() const {
 	static const Vector3 p2 = Vector3(0, 1, 0);
 	Vector3 p;
 
-	if (ABS(normal.dot(p1)) > 0.99) { // if too similar to p1
+	if (ABS(normal.dot(p1)) > 0.99f) { // if too similar to p1
 		p = p2; // use p2
 	} else {
 		p = p1; // use p1
@@ -109,7 +109,7 @@ bool Plane::intersects_ray(const Vector3 &p_from, const Vector3 &p_dir, Vector3 
 	real_t dist = (normal.dot(p_from) - d) / den;
 	//printf("dist is %i\n",dist);
 
-	if (dist > CMP_EPSILON) { //this is a ray, before the emitting pos (p_from) doesn't exist
+	if (dist > (real_t)CMP_EPSILON) { //this is a ray, before the emitting pos (p_from) doesn't exist
 
 		return false;
 	}
@@ -132,7 +132,7 @@ bool Plane::intersects_segment(const Vector3 &p_begin, const Vector3 &p_end, Vec
 	real_t dist = (normal.dot(p_begin) - d) / den;
 	//printf("dist is %i\n",dist);
 
-	if (dist < -CMP_EPSILON || dist > (1.0 + CMP_EPSILON)) {
+	if (dist < (real_t)-CMP_EPSILON || dist > (1 + (real_t)CMP_EPSILON)) {
 		return false;
 	}
 

--- a/core/math/quat.cpp
+++ b/core/math/quat.cpp
@@ -43,9 +43,9 @@ real_t Quat::angle_to(const Quat &p_to) const {
 // and similar for other axes.
 // This implementation uses XYZ convention (Z is the first rotation).
 void Quat::set_euler_xyz(const Vector3 &p_euler) {
-	real_t half_a1 = p_euler.x * 0.5;
-	real_t half_a2 = p_euler.y * 0.5;
-	real_t half_a3 = p_euler.z * 0.5;
+	real_t half_a1 = p_euler.x * 0.5f;
+	real_t half_a2 = p_euler.y * 0.5f;
+	real_t half_a3 = p_euler.z * 0.5f;
 
 	// R = X(a1).Y(a2).Z(a3) convention for Euler angles.
 	// Conversion to quaternion as listed in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf (page A-2)
@@ -78,9 +78,9 @@ Vector3 Quat::get_euler_xyz() const {
 // and similar for other axes.
 // This implementation uses YXZ convention (Z is the first rotation).
 void Quat::set_euler_yxz(const Vector3 &p_euler) {
-	real_t half_a1 = p_euler.y * 0.5;
-	real_t half_a2 = p_euler.x * 0.5;
-	real_t half_a3 = p_euler.z * 0.5;
+	real_t half_a1 = p_euler.y * 0.5f;
+	real_t half_a2 = p_euler.x * 0.5f;
+	real_t half_a3 = p_euler.z * 0.5f;
 
 	// R = Y(a1).X(a2).Z(a3) convention for Euler angles.
 	// Conversion to quaternion as listed in https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19770024290.pdf (page A-6)
@@ -163,7 +163,7 @@ Quat Quat::slerp(const Quat &p_to, const real_t &p_weight) const {
 	cosom = dot(p_to);
 
 	// adjust signs (if necessary)
-	if (cosom < 0.0) {
+	if (cosom < 0) {
 		cosom = -cosom;
 		to1.x = -p_to.x;
 		to1.y = -p_to.y;
@@ -178,16 +178,16 @@ Quat Quat::slerp(const Quat &p_to, const real_t &p_weight) const {
 
 	// calculate coefficients
 
-	if ((1.0 - cosom) > CMP_EPSILON) {
+	if ((1 - cosom) > (real_t)CMP_EPSILON) {
 		// standard case (slerp)
 		omega = Math::acos(cosom);
 		sinom = Math::sin(omega);
-		scale0 = Math::sin((1.0 - p_weight) * omega) / sinom;
+		scale0 = Math::sin((1 - p_weight) * omega) / sinom;
 		scale1 = Math::sin(p_weight * omega) / sinom;
 	} else {
 		// "from" and "to" quaternions are very close
 		//  ... so we can do a linear interpolation
-		scale0 = 1.0 - p_weight;
+		scale0 = 1 - p_weight;
 		scale1 = p_weight;
 	}
 	// calculate final values
@@ -207,14 +207,14 @@ Quat Quat::slerpni(const Quat &p_to, const real_t &p_weight) const {
 
 	real_t dot = from.dot(p_to);
 
-	if (Math::absf(dot) > 0.9999) {
+	if (Math::absf(dot) > 0.9999f) {
 		return from;
 	}
 
 	real_t theta = Math::acos(dot),
-		   sinT = 1.0 / Math::sin(theta),
+		   sinT = 1 / Math::sin(theta),
 		   newFactor = Math::sin(p_weight * theta) * sinT,
-		   invFactor = Math::sin((1.0 - p_weight) * theta) * sinT;
+		   invFactor = Math::sin((1 - p_weight) * theta) * sinT;
 
 	return Quat(invFactor * from.x + newFactor * p_to.x,
 			invFactor * from.y + newFactor * p_to.y,
@@ -228,7 +228,7 @@ Quat Quat::cubic_slerp(const Quat &p_b, const Quat &p_pre_a, const Quat &p_post_
 	ERR_FAIL_COND_V_MSG(!p_b.is_normalized(), Quat(), "The end quaternion must be normalized.");
 #endif
 	//the only way to do slerp :|
-	real_t t2 = (1.0 - p_weight) * p_weight * 2;
+	real_t t2 = (1 - p_weight) * p_weight * 2;
 	Quat sp = this->slerp(p_b, p_weight);
 	Quat sq = p_pre_a.slerpni(p_post_b, p_weight);
 	return sp.slerpni(sq, t2);
@@ -246,8 +246,8 @@ void Quat::set_axis_angle(const Vector3 &axis, const real_t &angle) {
 	if (d == 0) {
 		set(0, 0, 0, 0);
 	} else {
-		real_t sin_angle = Math::sin(angle * 0.5);
-		real_t cos_angle = Math::cos(angle * 0.5);
+		real_t sin_angle = Math::sin(angle * 0.5f);
+		real_t cos_angle = Math::cos(angle * 0.5f);
 		real_t s = sin_angle / d;
 		set(axis.x * s, axis.y * s, axis.z * s,
 				cos_angle);

--- a/core/math/quat.h
+++ b/core/math/quat.h
@@ -140,19 +140,19 @@ public:
 		Vector3 c = v0.cross(v1);
 		real_t d = v0.dot(v1);
 
-		if (d < -1.0 + CMP_EPSILON) {
+		if (d < -1 + (real_t)CMP_EPSILON) {
 			x = 0;
 			y = 1;
 			z = 0;
 			w = 0;
 		} else {
-			real_t s = Math::sqrt((1.0 + d) * 2.0);
-			real_t rs = 1.0 / s;
+			real_t s = Math::sqrt((1 + d) * 2);
+			real_t rs = 1 / s;
 
 			x = c.x * rs;
 			y = c.y * rs;
 			z = c.z * rs;
-			w = s * 0.5;
+			w = s * 0.5f;
 		}
 	}
 
@@ -194,7 +194,7 @@ void Quat::operator*=(const real_t &s) {
 }
 
 void Quat::operator/=(const real_t &s) {
-	*this *= 1.0 / s;
+	*this *= 1 / s;
 }
 
 Quat Quat::operator+(const Quat &q2) const {
@@ -217,7 +217,7 @@ Quat Quat::operator*(const real_t &s) const {
 }
 
 Quat Quat::operator/(const real_t &s) const {
-	return *this * (1.0 / s);
+	return *this * (1 / s);
 }
 
 bool Quat::operator==(const Quat &p_quat) const {

--- a/core/math/rect2.h
+++ b/core/math/rect2.h
@@ -46,7 +46,7 @@ struct _NO_DISCARD_CLASS_ Rect2 {
 
 	real_t get_area() const { return size.width * size.height; }
 
-	_FORCE_INLINE_ Vector2 get_center() const { return position + (size * 0.5); }
+	_FORCE_INLINE_ Vector2 get_center() const { return position + (size * 0.5f); }
 
 	inline bool intersects(const Rect2 &p_rect, const bool p_include_borders = false) const {
 		if (p_include_borders) {

--- a/core/math/transform_2d.cpp
+++ b/core/math/transform_2d.cpp
@@ -48,7 +48,7 @@ void Transform2D::affine_invert() {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND(det == 0);
 #endif
-	real_t idet = 1.0 / det;
+	real_t idet = 1 / det;
 
 	SWAP(elements[0][0], elements[1][1]);
 	elements[0] *= Vector2(idet, -idet);
@@ -238,11 +238,11 @@ Transform2D Transform2D::interpolate_with(const Transform2D &p_transform, real_t
 
 	real_t dot = v1.dot(v2);
 
-	dot = CLAMP(dot, -1.0, 1.0);
+	dot = CLAMP(dot, -1, 1);
 
 	Vector2 v;
 
-	if (dot > 0.9995) {
+	if (dot > 0.9995f) {
 		v = Vector2::linear_interpolate(v1, v2, p_c).normalized(); //linearly interpolate to avoid numerical precision issues
 	} else {
 		real_t angle = p_c * Math::acos(dot);

--- a/core/math/transform_interpolator.cpp
+++ b/core/math/transform_interpolator.cpp
@@ -64,7 +64,7 @@ Quat TransformInterpolator::_basis_to_quat_unchecked(const Basis &p_basis) {
 	real_t trace = m.elements[0][0] + m.elements[1][1] + m.elements[2][2];
 	real_t temp[4];
 
-	if (trace > 0.0) {
+	if (trace > 0) {
 		real_t s = Math::sqrt(trace + 1.0f);
 		temp[3] = (s * 0.5f);
 		s = 0.5f / s;

--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -76,7 +76,7 @@ int TriangleMesh::_create_bvh(BVH *p_bvh, BVH **p_bb, int p_from, int p_size, in
 	int index = max_alloc++;
 	BVH *_new = &p_bvh[index];
 	_new->aabb = aabb;
-	_new->center = aabb.position + aabb.size * 0.5;
+	_new->center = aabb.position + aabb.size * 0.5f;
 	_new->face_index = -1;
 	_new->left = left;
 	_new->right = right;
@@ -152,7 +152,7 @@ void TriangleMesh::create(const PoolVector<Vector3> &p_faces) {
 			bw[i].left = -1;
 			bw[i].right = -1;
 			bw[i].face_index = i;
-			bw[i].center = bw[i].aabb.position + bw[i].aabb.size * 0.5;
+			bw[i].center = bw[i].aabb.position + bw[i].aabb.size * 0.5f;
 		}
 
 		vertices.resize(db.size());

--- a/core/math/triangulate.cpp
+++ b/core/math/triangulate.cpp
@@ -39,7 +39,7 @@ real_t Triangulate::get_area(const Vector<Vector2> &contour) {
 	for (int p = n - 1, q = 0; q < n; p = q++) {
 		A += c[p].cross(c[q]);
 	}
-	return A * 0.5;
+	return A * 0.5f;
 }
 
 /*
@@ -72,9 +72,9 @@ bool Triangulate::is_inside_triangle(real_t Ax, real_t Ay,
 	bCROSScp = bx * cpy - by * cpx;
 
 	if (include_edges) {
-		return ((aCROSSbp > 0.0) && (bCROSScp > 0.0) && (cCROSSap > 0.0));
+		return ((aCROSSbp > 0) && (bCROSScp > 0) && (cCROSSap > 0));
 	} else {
-		return ((aCROSSbp >= 0.0) && (bCROSScp >= 0.0) && (cCROSSap >= 0.0));
+		return ((aCROSSbp >= 0) && (bCROSScp >= 0) && (cCROSSap >= 0));
 	}
 }
 
@@ -130,7 +130,7 @@ bool Triangulate::triangulate(const Vector<Vector2> &contour, Vector<int> &resul
 
 	/* we want a counter-clockwise polygon in V */
 
-	if (0.0 < get_area(contour)) {
+	if (0 < get_area(contour)) {
 		for (int v = 0; v < n; v++) {
 			V.write[v] = v;
 		}

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -161,11 +161,11 @@ Vector2 Vector2::cubic_interpolate(const Vector2 &p_b, const Vector2 &p_pre_a, c
 	real_t t3 = t2 * t;
 
 	Vector2 out;
-	out = 0.5 *
-			((p1 * 2.0) +
+	out = 0.5f *
+			((p1 * 2) +
 					(-p0 + p2) * t +
-					(2.0 * p0 - 5.0 * p1 + 4 * p2 - p3) * t2 +
-					(-p0 + 3.0 * p1 - 3.0 * p2 + p3) * t3);
+					(2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 +
+					(-p0 + 3 * p1 - 3 * p2 + p3) * t3);
 	return out;
 }
 
@@ -173,7 +173,7 @@ Vector2 Vector2::move_toward(const Vector2 &p_to, const real_t p_delta) const {
 	Vector2 v = *this;
 	Vector2 vd = p_to - v;
 	real_t len = vd.length();
-	return len <= p_delta || len < CMP_EPSILON ? p_to : v + vd / len * p_delta;
+	return len <= p_delta || len < (real_t)CMP_EPSILON ? p_to : v + vd / len * p_delta;
 }
 
 // slide returns the component of the vector along the given plane, specified by its normal vector.
@@ -192,7 +192,7 @@ Vector2 Vector2::reflect(const Vector2 &p_normal) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!p_normal.is_normalized(), Vector2(), "The normal Vector2 must be normalized.");
 #endif
-	return 2.0 * p_normal * this->dot(p_normal) - *this;
+	return 2 * p_normal * this->dot(p_normal) - *this;
 }
 
 bool Vector2::is_equal_approx(const Vector2 &p_v) const {

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -99,11 +99,11 @@ Vector3 Vector3::cubic_interpolaten(const Vector3 &p_b, const Vector3 &p_pre_a, 
 	real_t t3 = t2 * t;
 
 	Vector3 out;
-	out = 0.5 *
-			((p1 * 2.0) +
+	out = 0.5f *
+			((p1 * 2) +
 					(-p0 + p2) * t +
-					(2.0 * p0 - 5.0 * p1 + 4 * p2 - p3) * t2 +
-					(-p0 + 3.0 * p1 - 3.0 * p2 + p3) * t3);
+					(2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 +
+					(-p0 + 3 * p1 - 3 * p2 + p3) * t3);
 	return out;
 }
 
@@ -118,11 +118,11 @@ Vector3 Vector3::cubic_interpolate(const Vector3 &p_b, const Vector3 &p_pre_a, c
 	real_t t3 = t2 * t;
 
 	Vector3 out;
-	out = 0.5 *
-			((p1 * 2.0) +
+	out = 0.5f *
+			((p1 * 2) +
 					(-p0 + p2) * t +
-					(2.0 * p0 - 5.0 * p1 + 4 * p2 - p3) * t2 +
-					(-p0 + 3.0 * p1 - 3.0 * p2 + p3) * t3);
+					(2 * p0 - 5 * p1 + 4 * p2 - p3) * t2 +
+					(-p0 + 3 * p1 - 3 * p2 + p3) * t3);
 	return out;
 }
 
@@ -130,7 +130,7 @@ Vector3 Vector3::move_toward(const Vector3 &p_to, const real_t p_delta) const {
 	Vector3 v = *this;
 	Vector3 vd = p_to - v;
 	real_t len = vd.length();
-	return len <= p_delta || len < CMP_EPSILON ? p_to : v + vd / len * p_delta;
+	return len <= p_delta || len < (real_t)CMP_EPSILON ? p_to : v + vd / len * p_delta;
 }
 
 Basis Vector3::outer(const Vector3 &p_b) const {

--- a/core/math/vector3.h
+++ b/core/math/vector3.h
@@ -427,7 +427,7 @@ bool Vector3::is_normalized() const {
 }
 
 Vector3 Vector3::inverse() const {
-	return Vector3(1.0 / x, 1.0 / y, 1.0 / z);
+	return Vector3(1 / x, 1 / y, 1 / z);
 }
 
 void Vector3::zero() {
@@ -450,7 +450,7 @@ Vector3 Vector3::reflect(const Vector3 &p_normal) const {
 #ifdef MATH_CHECKS
 	ERR_FAIL_COND_V_MSG(!p_normal.is_normalized(), Vector3(), "The normal Vector3 must be normalized.");
 #endif
-	return 2.0 * p_normal * this->dot(p_normal) - *this;
+	return 2 * p_normal * this->dot(p_normal) - *this;
 }
 
 bool Vector3::is_equal_approx(const Vector3 &p_v, real_t p_tolerance) const {

--- a/core/typedefs.h
+++ b/core/typedefs.h
@@ -158,7 +158,7 @@ T *_nullptr() {
 #define ABSDIFF(x, y) (((x) < (y)) ? ((y) - (x)) : ((x) - (y)))
 
 #ifndef SGN
-#define SGN(m_v) (((m_v) < 0) ? (-1.0) : (+1.0))
+#define SGN(m_v) (((m_v) < 0) ? (-1.0f) : (+1.0f))
 #endif
 
 #ifndef MIN


### PR DESCRIPTION
Converts float literals from double format (e.g. 0.0) to float format (e.g. 0.0f) or integer where appropriate for 32 bit calculations, and cast to (real_t) or (float) as appropriate.

This ensures that appropriate calculations will be done at 32 bits when real_t is compiled as float, rather than promoted to 64 bits.

Combined version of #57703 and #58488 for 3.x

## Notes
* I opted to combine these into one PR for 3.x, just saves me going through the same code twice.
* In contrast to the 4.x version this also covers the BVH.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
