### PR TITLE
Fix issues with native extension initialization skipped steps

### DIFF
--- a/core/extension/native_extension.h
+++ b/core/extension/native_extension.h
@@ -68,12 +68,14 @@ public:
 	void close_library();
 
 	enum InitializationLevel {
-		INITIALIZATION_LEVEL_CORE,
+		INITIALIZATION_LEVEL_CORE = 0,
 		INITIALIZATION_LEVEL_SERVERS,
 		INITIALIZATION_LEVEL_SCENE,
 		INITIALIZATION_LEVEL_EDITOR,
 		INITIALIZATION_LEVEL_DRIVER,
+		INITIALIZATION_LEVEL_MAX,
 	};
+	static constexpr bool skippable[INITIALIZATION_LEVEL_MAX] = { 0, 0, 0, 1, 0 };
 
 	bool is_library_open() const;
 

--- a/core/extension/native_extension_manager.h
+++ b/core/extension/native_extension_manager.h
@@ -36,7 +36,8 @@
 class NativeExtensionManager : public Object {
 	GDCLASS(NativeExtensionManager, Object);
 
-	int32_t level = -1;
+	NativeExtension::InitializationLevel initialized_levels[NativeExtension::INITIALIZATION_LEVEL_MAX];
+	int32_t initialized_level_index = -1;
 	Map<String, Ref<NativeExtension>> native_extension_map;
 
 	static void _bind_methods();


### PR DESCRIPTION
This fix solves native extension initialization by allowing some steps (from InitializationLevel) to be skipped. This happens in builds where there are no editor for example, I which case the `INITIALIZATION_LEVEL_EDITOR` is skipped.
I our case, it prevented us to load native extensions when compiling in release mode.

This solves the issues the following way:
- Adds a static constant `skippable` array to the NativeExtension class to define which initialization steps are skippable, and check that no non-skippable step is skipped when calling `initialize_extensions`.
- Replace the current level of initialization tracker (the `level` variable) by the `initialized_levels` array. This array contains the list of all initialized steps, and uses the `initialized_level_index` to keep track of the last initialized level index.