### PR TITLE
Migrate project list to separate config file.

### DIFF
--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -125,7 +125,7 @@ class ProjectManager : public Control {
 	void _on_projects_updated();
 	void _scan_multiple_folders(PackedStringArray p_files);
 	void _scan_begin(const String &p_base);
-	void _scan_dir(const String &path, List<String> *r_projects);
+	void _scan_dir(const String &path);
 
 	void _install_project(const String &p_zip_path, const String &p_title);
 


### PR DESCRIPTION
Storing the project/favorites list in the EditorSettings makes it
difficult to version-control your editor configuration, as the file will
continually change as you open new projects. It also means a
configuration can't be shared across machines, as they might not have
the same projects or file layout.

Now the project list is stored in `$godot_data_dir/projects.cfg`.
Each path is a section, which has a boolean favorite value.
If the new config does not exist, the editor attempts to migrate legacy
EditorSettings-based configuration to the new file.

Fixes godotengine/godot-proposals#1637.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
