### PR TITLE
Update SceneTree property descriptions

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -204,7 +204,7 @@
 	</methods>
 	<members>
 		<member name="current_scene" type="Node" setter="set_current_scene" getter="get_current_scene">
-			The current scene.
+			The top node of the current scene.
 		</member>
 		<member name="debug_collisions_hint" type="bool" setter="set_debug_collisions_hint" getter="is_debugging_collisions_hint" default="false">
 			If [code]true[/code], collision shapes will be visible when running the game from the editor for debugging purposes.
@@ -213,7 +213,7 @@
 			If [code]true[/code], navigation polygons will be visible when running the game from the editor for debugging purposes.
 		</member>
 		<member name="edited_scene_root" type="Node" setter="set_edited_scene_root" getter="get_edited_scene_root">
-			The root of the edited scene.
+			The top node of the current editor scene.
 		</member>
 		<member name="multiplayer" type="MultiplayerAPI" setter="set_multiplayer" getter="get_multiplayer">
 			The default [MultiplayerAPI] instance for this [SceneTree].

--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -204,7 +204,7 @@
 	</methods>
 	<members>
 		<member name="current_scene" type="Node" setter="set_current_scene" getter="get_current_scene">
-			The top node of the current scene.
+			The topmost node of the current scene.
 		</member>
 		<member name="debug_collisions_hint" type="bool" setter="set_debug_collisions_hint" getter="is_debugging_collisions_hint" default="false">
 			If [code]true[/code], collision shapes will be visible when running the game from the editor for debugging purposes.
@@ -213,7 +213,7 @@
 			If [code]true[/code], navigation polygons will be visible when running the game from the editor for debugging purposes.
 		</member>
 		<member name="edited_scene_root" type="Node" setter="set_edited_scene_root" getter="get_edited_scene_root">
-			The top node of the current editor scene.
+			The topmost node of the current editor scene.
 		</member>
 		<member name="multiplayer" type="MultiplayerAPI" setter="set_multiplayer" getter="get_multiplayer">
 			The default [MultiplayerAPI] instance for this [SceneTree].


### PR DESCRIPTION
As discussed in https://github.com/godotengine/godot-proposals/issues/4034, the methods `current_scene` and `edited_scene_root` are related but have inconsistent naming.

I looked over renaming `edited_scene_root` to `editor_current_scene` in `SceneTree` but I noticed that there are other internal methods which also refers to an `edited_scene_root` for `EditorData` that is very far reaching. I still believe that they should be named consistently, but it would be a *lot* of changes, so for now, I think being more consistent in the API description gives a better idea that they are related.