### PR TITLE
Fix adding `(` to autocompleted method signatures with type hints enabled

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -284,7 +284,7 @@ Dictionary GDScriptTextDocument::resolve(const Dictionary &p_params) {
 		item.documentation = symbol->render();
 	}
 
-	if ((item.kind == lsp::CompletionItemKind::Method || item.kind == lsp::CompletionItemKind::Function) && !item.label.ends_with("):")) {
+	if ((item.kind == lsp::CompletionItemKind::Method || item.kind == lsp::CompletionItemKind::Function) && !item.label.ends_with(":")) {
 		item.insertText = item.label + "(";
 		if (symbol && symbol->children.is_empty()) {
 			item.insertText += ")";


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-vscode-plugin/issues/323

Autocomplete adds `(` when completing method calls but should not do it when completing method signatures.
To see if it was a method signature it was checking that it ended with `):` which is true when type hints are disabled, but fails when type hints are enabled.

It seems checking only that it ends with `:` is enough. See https://github.com/godotengine/godot-vscode-plugin/issues/323#issuecomment-1050073504.

I tested this only in `3.x`.