### PR TITLE
[3.x] BVH - Separate into dynamic, area and static trees

### DIFF
--- a/servers/physics/broad_phase_basic.cpp
+++ b/servers/physics/broad_phase_basic.cpp
@@ -32,7 +32,7 @@
 #include "core/list.h"
 #include "core/print_string.h"
 
-BroadPhaseSW::ID BroadPhaseBasic::create(CollisionObjectSW *p_object, int p_subindex, const AABB &p_aabb, bool p_static) {
+BroadPhaseSW::ID BroadPhaseBasic::create(CollisionObjectSW *p_object, int p_subindex, const AABB &p_aabb, bool p_static, int p_collision_object_type) {
 	ERR_FAIL_COND_V(p_object == nullptr, 0);
 
 	current++;
@@ -56,7 +56,7 @@ void BroadPhaseBasic::recheck_pairs(ID p_id) {
 	// Not supported.
 }
 
-void BroadPhaseBasic::set_static(ID p_id, bool p_static) {
+void BroadPhaseBasic::set_static(ID p_id, bool p_static, int p_collision_object_type) {
 	Map<ID, Element>::Element *E = element_map.find(p_id);
 	ERR_FAIL_COND(!E);
 	E->get()._static = p_static;

--- a/servers/physics/broad_phase_basic.h
+++ b/servers/physics/broad_phase_basic.h
@@ -80,10 +80,10 @@ class BroadPhaseBasic : public BroadPhaseSW {
 
 public:
 	// 0 is an invalid ID
-	virtual ID create(CollisionObjectSW *p_object, int p_subindex = 0, const AABB &p_aabb = AABB(), bool p_static = false);
+	virtual ID create(CollisionObjectSW *p_object, int p_subindex, const AABB &p_aabb, bool p_static, int p_collision_object_type);
 	virtual void move(ID p_id, const AABB &p_aabb);
 	virtual void recheck_pairs(ID p_id);
-	virtual void set_static(ID p_id, bool p_static);
+	virtual void set_static(ID p_id, bool p_static, int p_collision_object_type);
 	virtual void remove(ID p_id);
 
 	virtual CollisionObjectSW *get_object(ID p_id) const;

--- a/servers/physics/broad_phase_bvh.h
+++ b/servers/physics/broad_phase_bvh.h
@@ -53,16 +53,18 @@ class BroadPhaseBVH : public BroadPhaseSW {
 	};
 
 	enum Tree {
-		TREE_STATIC = 0,
-		TREE_DYNAMIC = 1,
+		TREE_DYNAMIC = 0,
+		TREE_AREA = 1,
+		TREE_STATIC = 2,
 	};
 
 	enum TreeFlag {
-		TREE_FLAG_STATIC = 1 << TREE_STATIC,
 		TREE_FLAG_DYNAMIC = 1 << TREE_DYNAMIC,
+		TREE_FLAG_AREA = 1 << TREE_AREA,
+		TREE_FLAG_STATIC = 1 << TREE_STATIC,
 	};
 
-	BVH_Manager<CollisionObjectSW, 2, true, 128, UserPairTestFunction<CollisionObjectSW>, UserCullTestFunction<CollisionObjectSW>> bvh;
+	BVH_Manager<CollisionObjectSW, 3, true, 128, UserPairTestFunction<CollisionObjectSW>, UserCullTestFunction<CollisionObjectSW>> bvh;
 
 	static void *_pair_callback(void *p_self, uint32_t p_id_A, CollisionObjectSW *p_object_A, int p_subindex_A, uint32_t p_id_B, CollisionObjectSW *p_object_B, int p_subindex_B);
 	static void _unpair_callback(void *p_self, uint32_t p_id_A, CollisionObjectSW *p_object_A, int p_subindex_A, uint32_t p_id_B, CollisionObjectSW *p_object_B, int p_subindex_B, void *p_pair_data);
@@ -73,12 +75,14 @@ class BroadPhaseBVH : public BroadPhaseSW {
 	UnpairCallback unpair_callback;
 	void *unpair_userdata;
 
+	uint32_t _find_tree(bool p_static, int p_collision_object_type, uint32_t &r_tree_collision_mask) const;
+
 public:
 	// 0 is an invalid ID
-	virtual ID create(CollisionObjectSW *p_object, int p_subindex = 0, const AABB &p_aabb = AABB(), bool p_static = false);
+	virtual ID create(CollisionObjectSW *p_object, int p_subindex, const AABB &p_aabb, bool p_static, int p_collision_object_type);
 	virtual void move(ID p_id, const AABB &p_aabb);
 	virtual void recheck_pairs(ID p_id);
-	virtual void set_static(ID p_id, bool p_static);
+	virtual void set_static(ID p_id, bool p_static, int p_collision_object_type);
 	virtual void remove(ID p_id);
 
 	virtual CollisionObjectSW *get_object(ID p_id) const;

--- a/servers/physics/broad_phase_octree.cpp
+++ b/servers/physics/broad_phase_octree.cpp
@@ -31,7 +31,7 @@
 #include "broad_phase_octree.h"
 #include "collision_object_sw.h"
 
-BroadPhaseSW::ID BroadPhaseOctree::create(CollisionObjectSW *p_object, int p_subindex, const AABB &p_aabb, bool p_static) {
+BroadPhaseSW::ID BroadPhaseOctree::create(CollisionObjectSW *p_object, int p_subindex, const AABB &p_aabb, bool p_static, int p_collision_object_type) {
 	ID oid = octree.create(p_object, AABB(), p_subindex, false, 1 << p_object->get_type(), 0);
 	return oid;
 }
@@ -45,7 +45,7 @@ void BroadPhaseOctree::recheck_pairs(ID p_id) {
 	octree.move(p_id, aabb);
 }
 
-void BroadPhaseOctree::set_static(ID p_id, bool p_static) {
+void BroadPhaseOctree::set_static(ID p_id, bool p_static, int p_collision_object_type) {
 	CollisionObjectSW *it = octree.get(p_id);
 	octree.set_pairable(p_id, !p_static, 1 << it->get_type(), p_static ? 0 : 0xFFFFF); //pair everything, don't care 1?
 }

--- a/servers/physics/broad_phase_octree.h
+++ b/servers/physics/broad_phase_octree.h
@@ -47,10 +47,10 @@ class BroadPhaseOctree : public BroadPhaseSW {
 
 public:
 	// 0 is an invalid ID
-	virtual ID create(CollisionObjectSW *p_object, int p_subindex = 0, const AABB &p_aabb = AABB(), bool p_static = false);
+	virtual ID create(CollisionObjectSW *p_object, int p_subindex, const AABB &p_aabb, bool p_static, int p_collision_object_type);
 	virtual void move(ID p_id, const AABB &p_aabb);
 	virtual void recheck_pairs(ID p_id);
-	virtual void set_static(ID p_id, bool p_static);
+	virtual void set_static(ID p_id, bool p_static, int p_collision_object_type);
 	virtual void remove(ID p_id);
 
 	virtual CollisionObjectSW *get_object(ID p_id) const;

--- a/servers/physics/broad_phase_sw.h
+++ b/servers/physics/broad_phase_sw.h
@@ -48,10 +48,10 @@ public:
 	typedef void (*UnpairCallback)(CollisionObjectSW *p_object_A, int p_subindex_A, CollisionObjectSW *p_object_B, int p_subindex_B, void *p_pair_data, void *p_user_data);
 
 	// 0 is an invalid ID
-	virtual ID create(CollisionObjectSW *p_object_, int p_subindex = 0, const AABB &p_aabb = AABB(), bool p_static = false) = 0;
+	virtual ID create(CollisionObjectSW *p_object_, int p_subindex, const AABB &p_aabb, bool p_static, int p_collision_object_type) = 0;
 	virtual void move(ID p_id, const AABB &p_aabb) = 0;
 	virtual void recheck_pairs(ID p_id) = 0;
-	virtual void set_static(ID p_id, bool p_static) = 0;
+	virtual void set_static(ID p_id, bool p_static, int p_collision_object_type) = 0;
 	virtual void remove(ID p_id) = 0;
 
 	virtual CollisionObjectSW *get_object(ID p_id) const = 0;

--- a/servers/physics/collision_object_sw.cpp
+++ b/servers/physics/collision_object_sw.cpp
@@ -135,7 +135,7 @@ void CollisionObjectSW::_set_static(bool p_static) {
 	for (int i = 0; i < get_shape_count(); i++) {
 		const Shape &s = shapes[i];
 		if (s.bpid > 0) {
-			space->get_broadphase()->set_static(s.bpid, _static);
+			space->get_broadphase()->set_static(s.bpid, _static, get_type());
 		}
 	}
 }
@@ -172,8 +172,8 @@ void CollisionObjectSW::_update_shapes() {
 		s.area_cache = s.shape->get_area() * scale.x * scale.y * scale.z;
 
 		if (s.bpid == 0) {
-			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static);
-			space->get_broadphase()->set_static(s.bpid, _static);
+			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static, get_type());
+			space->get_broadphase()->set_static(s.bpid, _static, get_type());
 		}
 
 		space->get_broadphase()->move(s.bpid, shape_aabb);
@@ -216,8 +216,8 @@ void CollisionObjectSW::_update_shapes_with_motion(const Vector3 &p_motion) {
 		s.aabb_cache = shape_aabb;
 
 		if (s.bpid == 0) {
-			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static);
-			space->get_broadphase()->set_static(s.bpid, _static);
+			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static, get_type());
+			space->get_broadphase()->set_static(s.bpid, _static, get_type());
 		}
 
 		space->get_broadphase()->move(s.bpid, shape_aabb);

--- a/servers/physics_2d/broad_phase_2d_basic.cpp
+++ b/servers/physics_2d/broad_phase_2d_basic.cpp
@@ -30,7 +30,7 @@
 
 #include "broad_phase_2d_basic.h"
 
-BroadPhase2DBasic::ID BroadPhase2DBasic::create(CollisionObject2DSW *p_object_, int p_subindex, const Rect2 &p_aabb, bool p_static) {
+BroadPhase2DBasic::ID BroadPhase2DBasic::create(CollisionObject2DSW *p_object_, int p_subindex, const Rect2 &p_aabb, bool p_static, int p_collision_object_type) {
 	current++;
 
 	Element e;
@@ -52,7 +52,7 @@ void BroadPhase2DBasic::recheck_pairs(ID p_id) {
 	// Not supported.
 }
 
-void BroadPhase2DBasic::set_static(ID p_id, bool p_static) {
+void BroadPhase2DBasic::set_static(ID p_id, bool p_static, int p_collision_object_type) {
 	Map<ID, Element>::Element *E = element_map.find(p_id);
 	ERR_FAIL_COND(!E);
 	E->get()._static = p_static;

--- a/servers/physics_2d/broad_phase_2d_basic.h
+++ b/servers/physics_2d/broad_phase_2d_basic.h
@@ -79,10 +79,10 @@ class BroadPhase2DBasic : public BroadPhase2DSW {
 
 public:
 	// 0 is an invalid ID
-	virtual ID create(CollisionObject2DSW *p_object_, int p_subindex = 0, const Rect2 &p_aabb = Rect2(), bool p_static = false);
+	virtual ID create(CollisionObject2DSW *p_object_, int p_subindex, const Rect2 &p_aabb, bool p_static, int p_collision_object_type);
 	virtual void move(ID p_id, const Rect2 &p_aabb);
 	virtual void recheck_pairs(ID p_id);
-	virtual void set_static(ID p_id, bool p_static);
+	virtual void set_static(ID p_id, bool p_static, int p_collision_object_type);
 	virtual void remove(ID p_id);
 
 	virtual CollisionObject2DSW *get_object(ID p_id) const;

--- a/servers/physics_2d/broad_phase_2d_bvh.cpp
+++ b/servers/physics_2d/broad_phase_2d_bvh.cpp
@@ -32,11 +32,31 @@
 #include "collision_object_2d_sw.h"
 #include "core/project_settings.h"
 
-BroadPhase2DSW::ID BroadPhase2DBVH::create(CollisionObject2DSW *p_object, int p_subindex, const Rect2 &p_aabb, bool p_static) {
-	uint32_t tree_id = p_static ? TREE_STATIC : TREE_DYNAMIC;
-	uint32_t tree_collision_mask = p_static ? TREE_FLAG_DYNAMIC : (TREE_FLAG_STATIC | TREE_FLAG_DYNAMIC);
+BroadPhase2DSW::ID BroadPhase2DBVH::create(CollisionObject2DSW *p_object, int p_subindex, const Rect2 &p_aabb, bool p_static, int p_collision_object_type) {
+	uint32_t tree_collision_mask = 0;
+	uint32_t tree_id = _find_tree(p_static, p_collision_object_type, tree_collision_mask);
 	ID oid = bvh.create(p_object, true, tree_id, tree_collision_mask, p_aabb, p_subindex); // Pair everything, don't care?
 	return oid + 1;
+}
+
+uint32_t BroadPhase2DBVH::_find_tree(bool p_static, int p_collision_object_type, uint32_t &r_tree_collision_mask) const {
+	uint32_t tree_id = p_static ? TREE_STATIC : TREE_DYNAMIC;
+	if ((p_collision_object_type == CollisionObject2DSW::Type::TYPE_AREA) && (tree_id == TREE_STATIC)) {
+		tree_id = TREE_AREA;
+	}
+	switch (tree_id) {
+		default: {
+			r_tree_collision_mask = TREE_FLAG_DYNAMIC | TREE_FLAG_AREA | TREE_FLAG_STATIC;
+		} break;
+		case TREE_AREA: {
+			r_tree_collision_mask = TREE_FLAG_DYNAMIC | TREE_FLAG_STATIC;
+		} break;
+		case TREE_STATIC: {
+			r_tree_collision_mask = TREE_FLAG_DYNAMIC | TREE_FLAG_AREA;
+		} break;
+	}
+
+	return tree_id;
 }
 
 void BroadPhase2DBVH::move(ID p_id, const Rect2 &p_aabb) {
@@ -47,9 +67,9 @@ void BroadPhase2DBVH::recheck_pairs(ID p_id) {
 	bvh.recheck_pairs(p_id - 1);
 }
 
-void BroadPhase2DBVH::set_static(ID p_id, bool p_static) {
-	uint32_t tree_id = p_static ? TREE_STATIC : TREE_DYNAMIC;
-	uint32_t tree_collision_mask = p_static ? TREE_FLAG_DYNAMIC : (TREE_FLAG_STATIC | TREE_FLAG_DYNAMIC);
+void BroadPhase2DBVH::set_static(ID p_id, bool p_static, int p_collision_object_type) {
+	uint32_t tree_collision_mask = 0;
+	uint32_t tree_id = _find_tree(p_static, p_collision_object_type, tree_collision_mask);
 	bvh.set_tree(p_id - 1, tree_id, tree_collision_mask, false);
 }
 
@@ -65,7 +85,7 @@ CollisionObject2DSW *BroadPhase2DBVH::get_object(ID p_id) const {
 
 bool BroadPhase2DBVH::is_static(ID p_id) const {
 	uint32_t tree_id = bvh.get_tree_id(p_id - 1);
-	return tree_id == 0;
+	return tree_id != 0;
 }
 
 int BroadPhase2DBVH::get_subindex(ID p_id) const {

--- a/servers/physics_2d/broad_phase_2d_bvh.h
+++ b/servers/physics_2d/broad_phase_2d_bvh.h
@@ -55,16 +55,18 @@ class BroadPhase2DBVH : public BroadPhase2DSW {
 	};
 
 	enum Tree {
-		TREE_STATIC = 0,
-		TREE_DYNAMIC = 1,
+		TREE_DYNAMIC = 0,
+		TREE_AREA = 1,
+		TREE_STATIC = 2,
 	};
 
 	enum TreeFlag {
-		TREE_FLAG_STATIC = 1 << TREE_STATIC,
 		TREE_FLAG_DYNAMIC = 1 << TREE_DYNAMIC,
+		TREE_FLAG_AREA = 1 << TREE_AREA,
+		TREE_FLAG_STATIC = 1 << TREE_STATIC,
 	};
 
-	BVH_Manager<CollisionObject2DSW, 2, true, 128, UserPairTestFunction<CollisionObject2DSW>, UserCullTestFunction<CollisionObject2DSW>, Rect2, Vector2> bvh;
+	BVH_Manager<CollisionObject2DSW, 3, true, 128, UserPairTestFunction<CollisionObject2DSW>, UserCullTestFunction<CollisionObject2DSW>, Rect2, Vector2> bvh;
 
 	static void *_pair_callback(void *p_self, uint32_t p_id_A, CollisionObject2DSW *p_object_A, int p_subindex_A, uint32_t p_id_B, CollisionObject2DSW *p_object_B, int p_subindex_B);
 	static void _unpair_callback(void *p_self, uint32_t p_id_A, CollisionObject2DSW *p_object_A, int p_subindex_A, uint32_t p_id_B, CollisionObject2DSW *p_object_B, int p_subindex_B, void *p_pair_data);
@@ -75,12 +77,14 @@ class BroadPhase2DBVH : public BroadPhase2DSW {
 	UnpairCallback unpair_callback;
 	void *unpair_userdata;
 
+	uint32_t _find_tree(bool p_static, int p_collision_object_type, uint32_t &r_tree_collision_mask) const;
+
 public:
 	// 0 is an invalid ID
-	virtual ID create(CollisionObject2DSW *p_object, int p_subindex = 0, const Rect2 &p_aabb = Rect2(), bool p_static = false);
+	virtual ID create(CollisionObject2DSW *p_object, int p_subindex, const Rect2 &p_aabb, bool p_static, int p_collision_object_type);
 	virtual void move(ID p_id, const Rect2 &p_aabb);
 	virtual void recheck_pairs(ID p_id);
-	virtual void set_static(ID p_id, bool p_static);
+	virtual void set_static(ID p_id, bool p_static, int p_collision_object_type);
 	virtual void remove(ID p_id);
 
 	virtual CollisionObject2DSW *get_object(ID p_id) const;

--- a/servers/physics_2d/broad_phase_2d_hash_grid.cpp
+++ b/servers/physics_2d/broad_phase_2d_hash_grid.cpp
@@ -286,7 +286,7 @@ void BroadPhase2DHashGrid::_exit_grid(Element *p_elem, const Rect2 &p_rect, bool
 	}
 }
 
-BroadPhase2DHashGrid::ID BroadPhase2DHashGrid::create(CollisionObject2DSW *p_object, int p_subindex, const Rect2 &p_aabb, bool p_static) {
+BroadPhase2DHashGrid::ID BroadPhase2DHashGrid::create(CollisionObject2DSW *p_object, int p_subindex, const Rect2 &p_aabb, bool p_static, int p_collision_object_type) {
 	current++;
 
 	Element e;
@@ -344,7 +344,7 @@ void BroadPhase2DHashGrid::recheck_pairs(ID p_id) {
 	move(p_id, e.aabb);
 }
 
-void BroadPhase2DHashGrid::set_static(ID p_id, bool p_static) {
+void BroadPhase2DHashGrid::set_static(ID p_id, bool p_static, int p_collision_object_type) {
 	Map<ID, Element>::Element *E = element_map.find(p_id);
 	ERR_FAIL_COND(!E);
 

--- a/servers/physics_2d/broad_phase_2d_hash_grid.h
+++ b/servers/physics_2d/broad_phase_2d_hash_grid.h
@@ -169,10 +169,10 @@ class BroadPhase2DHashGrid : public BroadPhase2DSW {
 	void _check_motion(Element *p_elem);
 
 public:
-	virtual ID create(CollisionObject2DSW *p_object, int p_subindex = 0, const Rect2 &p_aabb = Rect2(), bool p_static = false);
+	virtual ID create(CollisionObject2DSW *p_object, int p_subindex, const Rect2 &p_aabb, bool p_static, int p_collision_object_type);
 	virtual void move(ID p_id, const Rect2 &p_aabb);
 	virtual void recheck_pairs(ID p_id);
-	virtual void set_static(ID p_id, bool p_static);
+	virtual void set_static(ID p_id, bool p_static, int p_collision_object_type);
 	virtual void remove(ID p_id);
 
 	virtual CollisionObject2DSW *get_object(ID p_id) const;

--- a/servers/physics_2d/broad_phase_2d_sw.h
+++ b/servers/physics_2d/broad_phase_2d_sw.h
@@ -48,10 +48,10 @@ public:
 	typedef void (*UnpairCallback)(CollisionObject2DSW *p_object_A, int p_subindex_A, CollisionObject2DSW *p_object_B, int p_subindex_B, void *p_pair_data, void *p_user_data);
 
 	// 0 is an invalid ID
-	virtual ID create(CollisionObject2DSW *p_object_, int p_subindex = 0, const Rect2 &p_aabb = Rect2(), bool p_static = false) = 0;
+	virtual ID create(CollisionObject2DSW *p_object_, int p_subindex, const Rect2 &p_aabb, bool p_static, int p_collision_object_type) = 0;
 	virtual void move(ID p_id, const Rect2 &p_aabb) = 0;
 	virtual void recheck_pairs(ID p_id) = 0;
-	virtual void set_static(ID p_id, bool p_static) = 0;
+	virtual void set_static(ID p_id, bool p_static, int p_collision_object_type) = 0;
 	virtual void remove(ID p_id) = 0;
 
 	virtual CollisionObject2DSW *get_object(ID p_id) const = 0;

--- a/servers/physics_2d/collision_object_2d_sw.cpp
+++ b/servers/physics_2d/collision_object_2d_sw.cpp
@@ -145,7 +145,7 @@ void CollisionObject2DSW::_set_static(bool p_static) {
 	for (int i = 0; i < get_shape_count(); i++) {
 		const Shape &s = shapes[i];
 		if (s.bpid > 0) {
-			space->get_broadphase()->set_static(s.bpid, _static);
+			space->get_broadphase()->set_static(s.bpid, _static, get_type());
 		}
 	}
 }
@@ -179,8 +179,8 @@ void CollisionObject2DSW::_update_shapes() {
 		s.aabb_cache = shape_aabb;
 
 		if (s.bpid == 0) {
-			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static);
-			space->get_broadphase()->set_static(s.bpid, _static);
+			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static, get_type());
+			space->get_broadphase()->set_static(s.bpid, _static, get_type());
 		}
 
 		space->get_broadphase()->move(s.bpid, shape_aabb);
@@ -223,8 +223,8 @@ void CollisionObject2DSW::_update_shapes_with_motion(const Vector2 &p_motion) {
 		s.aabb_cache = shape_aabb;
 
 		if (s.bpid == 0) {
-			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static);
-			space->get_broadphase()->set_static(s.bpid, _static);
+			s.bpid = space->get_broadphase()->create(this, i, shape_aabb, _static, get_type());
+			space->get_broadphase()->set_static(s.bpid, _static, get_type());
 		}
 
 		space->get_broadphase()->move(s.bpid, shape_aabb);


### PR DESCRIPTION
Separating into three trees gives finer control of collisions. 2D and 3D.

The main change this PR allows is areas to detect collisions with statics, at least as far as the BVH is concerned (it will report the changes to the physics, whether it acts on these depends on the physics).

Several users have expressed an interest that areas should be able to detect static bodies. There are a number of ways of doing this, we could alternatively add an extra flag to areas to allow them to detect static bodies, which would eliminate the cost in situations where this was not wanted.

This PR is partly intended to generate discussion of how we _want_ this to work. It is now incredibly easy for us to vary the collision matrix in the BVH, so to some extent we need to decide on a **specification**, how we want the collision options to work going forward. This has been under-specified in the past.

## Details
One of the advantages and reasons for the recent change to templated trees in the BVH is it gives us a more more customizable approach to collision, which opens up a lot more options.

Here there are 3 trees:
* Dynamic (includes monitorable areas)
* Areas (all non-monitorable)
* Statics

The changes make:
* Dynamic collides with everything
* Areas collide with dynamic and static
* Statics collide with dynamic and areas

Thus the main change in the matrix here is that areas and statics now become collidable.

The trade off here is efficiency. By making the areas collide with statics, they are potentially colliding with them when they may not be interested in this. I believe this can be solved already to some extent with the "monitoring" feature (which probably makes these areas dynamic) but this is reported to tank the performance where users have tried this.

Fixes #17238
Fixes #58555
Fixes #55965 (although could do with independently checking this)
Fixes @KoBeWi area / area collision bug (_pers. comm._)

## Alternative logic
An alternative which does not fix the long standing area - static collisions bug is #58557. That most closely matches previous behaviour.

## Current situation
Just for reference, the current situation (written as though there are 3 trees, but there are actually 2 currently):
* Dynamics collide with everything
* Areas collide with dynamics
* Statics collide with dynamics

## Notes
* This probably requires a bit of performance testing.
* Having more trees is a trade off as it allows finer control, but may introduce more housekeeping costs.
* Once we are happy with an approach this can also be used in master, as the BVH code is shared.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
