### PR TITLE
Convert usages of EditorNode to EditorPlugin

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -37,6 +37,7 @@
 #include "editor/editor_scale.h"
 #include "editor/plugins/animation_player_editor_plugin.h"
 #include "scene/animation/animation_player.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/view_panner.h"
 #include "scene/main/window.h"
 #include "scene/scene_string_names.h"

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1367,9 +1367,6 @@ bool AudioBusesEditorPlugin::handles(Object *p_node) const {
 	return (Object::cast_to<AudioBusLayout>(p_node) != nullptr);
 }
 
-void AudioBusesEditorPlugin::make_visible(bool p_visible) {
-}
-
 AudioBusesEditorPlugin::AudioBusesEditorPlugin(EditorAudioBuses *p_node) {
 	audio_bus_editor = p_node;
 }

--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -46,6 +46,8 @@
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
 
+class EditorFileDialog;
+
 class EditorAudioBuses;
 
 class EditorAudioBus : public PanelContainer {
@@ -269,7 +271,6 @@ public:
 	bool has_main_screen() const override { return false; }
 	virtual void edit(Object *p_node) override;
 	virtual bool handles(Object *p_node) const override;
-	virtual void make_visible(bool p_visible) override;
 
 	AudioBusesEditorPlugin(EditorAudioBuses *p_node);
 	~AudioBusesEditorPlugin();

--- a/editor/editor_feature_profile.h
+++ b/editor/editor_feature_profile.h
@@ -40,6 +40,8 @@
 #include "scene/gui/split_container.h"
 #include "scene/gui/tree.h"
 
+class EditorFileDialog;
+
 class EditorFeatureProfile : public RefCounted {
 	GDCLASS(EditorFeatureProfile, RefCounted);
 

--- a/editor/editor_locale_dialog.cpp
+++ b/editor/editor_locale_dialog.cpp
@@ -33,6 +33,7 @@
 #include "core/config/project_settings.h"
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
+#include "scene/gui/box_container.h"
 #include "scene/gui/check_button.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/option_button.h"

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -107,6 +107,7 @@
 #include "editor/filesystem_dock.h"
 #include "editor/import/dynamic_font_import_settings.h"
 #include "editor/import/editor_import_collada.h"
+#include "editor/import/editor_import_plugin.h"
 #include "editor/import/resource_importer_bitmask.h"
 #include "editor/import/resource_importer_bmfont.h"
 #include "editor/import/resource_importer_csv_translation.h"
@@ -3236,7 +3237,7 @@ void EditorNode::add_editor_plugin(EditorPlugin *p_editor, bool p_config_changed
 		singleton->distraction_free->raise();
 	}
 	singleton->editor_data.add_editor_plugin(p_editor);
-	singleton->add_child(p_editor);
+	singleton->editor_plugins_container->add_child(p_editor);
 	if (p_config_changed) {
 		p_editor->enable_plugin();
 	}
@@ -6956,6 +6957,9 @@ EditorNode::EditorNode() {
 	audio_preview_gen = memnew(AudioStreamPreviewGenerator);
 	add_child(audio_preview_gen);
 
+	editor_plugins_container = memnew(Node);
+	add_child(editor_plugins_container);
+
 	add_editor_plugin(memnew(DebuggerEditorPlugin(debug_menu)));
 	add_editor_plugin(memnew(DebugAdapterServer()));
 
@@ -6982,6 +6986,10 @@ EditorNode::EditorNode() {
 
 	gui_base->add_child(disk_changed);
 
+	// Add interface before adding plugins
+	editor_interface = memnew(EditorInterface);
+	add_child(editor_interface);
+
 	add_editor_plugin(memnew(AnimationPlayerEditorPlugin));
 	add_editor_plugin(memnew(CanvasItemEditorPlugin));
 	add_editor_plugin(memnew(Node3DEditorPlugin));
@@ -6997,11 +7005,6 @@ EditorNode::EditorNode() {
 	} else {
 		WARN_PRINT("Asset Library not available, as it requires SSL to work.");
 	}
-
-	// Add interface before adding plugins.
-
-	editor_interface = memnew(EditorInterface);
-	add_child(editor_interface);
 
 	// More visually meaningful to have this later.
 	raise_bottom_panel_item(AnimationPlayerEditor::get_singleton());
@@ -7240,6 +7243,10 @@ EditorNode::EditorNode() {
 	String exec = OS::get_singleton()->get_executable_path();
 	// Save editor executable path for third-party tools.
 	EditorSettings::get_singleton()->set_project_metadata("editor_metadata", "executable_path", exec);
+
+	// Move EditorInterface and the EditorPlugin container to the top, so they are the last nodes to free.
+	editor_interface->raise();
+	editor_plugins_container->raise();
 }
 
 EditorNode::~EditorNode() {

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -271,6 +271,7 @@ private:
 	ProjectExportDialog *project_export = nullptr;
 	ProjectSettingsEditor *project_settings_editor = nullptr;
 
+	Node *editor_plugins_container = nullptr;
 	Vector<EditorPlugin *> editor_plugins;
 	bool _initializing_plugins = false;
 	Map<String, EditorPlugin *> addon_name_to_plugin;

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -30,13 +30,17 @@
 
 #include "editor_plugin.h"
 
+#include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_command_palette.h"
 #include "editor/editor_export.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_settings.h"
+#include "editor/editor_translation_parser.h"
 #include "editor/filesystem_dock.h"
+#include "editor/import/editor_import_plugin.h"
+#include "editor/import/resource_importer_scene.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/plugins/script_editor_plugin.h"
@@ -371,6 +375,10 @@ void EditorInterface::_bind_methods() {
 
 EditorInterface::EditorInterface() {
 	singleton = this;
+}
+
+EditorInterface::~EditorInterface() {
+	singleton = nullptr;
 }
 
 ///////////////////////////////////////////
@@ -881,7 +889,7 @@ void EditorPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("make_bottom_panel_item_visible", "item"), &EditorPlugin::make_bottom_panel_item_visible);
 	ClassDB::bind_method(D_METHOD("hide_bottom_panel"), &EditorPlugin::hide_bottom_panel);
 
-	ClassDB::bind_method(D_METHOD("get_undo_redo"), &EditorPlugin::_get_undo_redo);
+	ClassDB::bind_method(D_METHOD("get_undo_redo"), &EditorPlugin::get_undo_redo);
 	ClassDB::bind_method(D_METHOD("add_undo_redo_inspector_hook_callback", "callable"), &EditorPlugin::add_undo_redo_inspector_hook_callback);
 	ClassDB::bind_method(D_METHOD("remove_undo_redo_inspector_hook_callback", "callable"), &EditorPlugin::remove_undo_redo_inspector_hook_callback);
 	ClassDB::bind_method(D_METHOD("queue_save_layout"), &EditorPlugin::queue_save_layout);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -32,19 +32,22 @@
 #define EDITOR_PLUGIN_H
 
 #include "core/io/config_file.h"
-#include "core/object/undo_redo.h"
-#include "editor/debugger/editor_debugger_node.h"
-#include "editor/editor_inspector.h"
-#include "editor/editor_translation_parser.h"
-#include "editor/import/editor_import_plugin.h"
-#include "editor/import/resource_importer_scene.h"
-#include "editor/script_create_dialog.h"
 #include "scene/3d/camera_3d.h"
-#include "scene/main/node.h"
-#include "scene/resources/texture.h"
+#include "scene/gui/control.h"
 
+class UndoRedo;
 class Node3D;
-class Camera3D;
+class Button;
+class PopupMenu;
+class EditorImportPlugin;
+class EditorInspectorPlugin;
+class EditorInspector;
+class EditorTranslationParserPlugin;
+class EditorImportPlugin;
+class EditorExportPlugin;
+class EditorSceneFormatImporter;
+class EditorScenePostImportPlugin;
+class ScriptCreateDialog;
 class EditorCommandPalette;
 class EditorSelection;
 class EditorExport;
@@ -124,14 +127,13 @@ public:
 	bool is_distraction_free_mode_enabled() const;
 
 	EditorInterface();
+	~EditorInterface();
 };
 
 class EditorPlugin : public Node {
 	GDCLASS(EditorPlugin, Node);
 	friend class EditorData;
 	UndoRedo *undo_redo = nullptr;
-
-	UndoRedo *_get_undo_redo() { return undo_redo; }
 
 	bool input_event_forwarding_always_enabled = false;
 	bool force_draw_over_forwarding_enabled = false;
@@ -144,7 +146,6 @@ protected:
 	void _notification(int p_what);
 
 	static void _bind_methods();
-	UndoRedo &get_undo_redo() { return *undo_redo; }
 
 	void add_custom_type(const String &p_type, const String &p_base, const Ref<Script> &p_script, const Ref<Texture2D> &p_icon);
 	void remove_custom_type(const String &p_type);
@@ -206,6 +207,8 @@ public:
 		AFTER_GUI_INPUT_STOP,
 		AFTER_GUI_INPUT_DESELECT
 	};
+
+	UndoRedo *get_undo_redo() { return undo_redo; }
 
 	//TODO: send a resource for editing to the editor node?
 

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -31,6 +31,7 @@
 #include "editor_run.h"
 
 #include "core/config/project_settings.h"
+#include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "servers/display_server.h"

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -42,6 +42,8 @@
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
+#include "editor/import/editor_import_plugin.h"
+#include "editor/import/resource_importer_scene.h"
 #include "editor/import_dock.h"
 #include "editor/scene_tree_dock.h"
 #include "editor/shader_create_dialog.h"

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -34,6 +34,7 @@
 #include "editor/editor_plugin.h"
 #include "scene/2d/polygon_2d.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/dialogs.h"
 
 class CanvasItemEditor;
 

--- a/editor/plugins/animation_blend_space_1d_editor.h
+++ b/editor/plugins/animation_blend_space_1d_editor.h
@@ -37,6 +37,7 @@
 #include "scene/animation/animation_blend_space_1d.h"
 #include "scene/gui/button.h"
 #include "scene/gui/graph_edit.h"
+#include "scene/gui/panel_container.h"
 #include "scene/gui/popup.h"
 #include "scene/gui/tree.h"
 

--- a/editor/plugins/animation_blend_space_2d_editor.h
+++ b/editor/plugins/animation_blend_space_2d_editor.h
@@ -37,6 +37,7 @@
 #include "scene/animation/animation_blend_space_2d.h"
 #include "scene/gui/button.h"
 #include "scene/gui/graph_edit.h"
+#include "scene/gui/panel_container.h"
 #include "scene/gui/popup.h"
 #include "scene/gui/tree.h"
 

--- a/editor/plugins/animation_blend_tree_editor_plugin.h
+++ b/editor/plugins/animation_blend_tree_editor_plugin.h
@@ -32,11 +32,13 @@
 #define ANIMATION_BLEND_TREE_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
+#include "editor/editor_properties.h"
 #include "editor/plugins/animation_tree_editor_plugin.h"
 #include "editor/property_editor.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/gui/button.h"
 #include "scene/gui/graph_edit.h"
+#include "scene/gui/panel_container.h"
 #include "scene/gui/popup.h"
 #include "scene/gui/tree.h"
 

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -36,6 +36,7 @@
 #include "editor/plugins/animation_library_editor.h"
 #include "scene/animation/animation_player.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/menu_button.h"
 #include "scene/gui/slider.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/texture_button.h"
@@ -100,7 +101,6 @@ class AnimationPlayerEditor : public VBoxContainer {
 	LineEdit *name = nullptr;
 	OptionButton *library = nullptr;
 	Label *name_title = nullptr;
-	UndoRedo *undo_redo = nullptr;
 
 	Ref<Texture2D> autoplay_icon;
 	Ref<Texture2D> reset_icon;
@@ -232,7 +232,6 @@ public:
 
 	void ensure_visibility();
 
-	void set_undo_redo(UndoRedo *p_undo_redo) { undo_redo = p_undo_redo; }
 	void edit(AnimationPlayer *p_player);
 	void forward_force_draw_over_viewport(Control *p_overlay);
 

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -37,6 +37,7 @@
 #include "scene/animation/animation_node_state_machine.h"
 #include "scene/gui/button.h"
 #include "scene/gui/graph_edit.h"
+#include "scene/gui/panel_container.h"
 #include "scene/gui/popup.h"
 #include "scene/gui/tree.h"
 

--- a/editor/plugins/animation_tree_editor_plugin.cpp
+++ b/editor/plugins/animation_tree_editor_plugin.cpp
@@ -40,7 +40,6 @@
 #include "core/math/delaunay_2d.h"
 #include "core/os/keyboard.h"
 #include "editor/editor_file_dialog.h"
-#include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/animation/animation_player.h"
@@ -261,11 +260,11 @@ void AnimationTreeEditorPlugin::make_visible(bool p_visible) {
 		//editor->hide_animation_player_editors();
 		//editor->animation_panel_make_visible(true);
 		button->show();
-		EditorNode::get_singleton()->make_bottom_panel_item_visible(anim_tree_editor);
+		make_bottom_panel_item_visible(anim_tree_editor);
 		anim_tree_editor->set_process(true);
 	} else {
 		if (anim_tree_editor->is_visible_in_tree()) {
-			EditorNode::get_singleton()->hide_bottom_panel();
+			hide_bottom_panel();
 		}
 		button->hide();
 		anim_tree_editor->set_process(false);
@@ -276,7 +275,7 @@ AnimationTreeEditorPlugin::AnimationTreeEditorPlugin() {
 	anim_tree_editor = memnew(AnimationTreeEditor);
 	anim_tree_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
 
-	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("AnimationTree"), anim_tree_editor);
+	button = add_control_to_bottom_panel(anim_tree_editor, TTR("AnimationTree"));
 	button->hide();
 }
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -35,7 +35,6 @@
 #include "core/os/keyboard.h"
 #include "core/version.h"
 #include "editor/editor_file_dialog.h"
-#include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
@@ -1562,7 +1561,7 @@ void AssetLibraryEditorPlugin::make_visible(bool p_visible) {
 AssetLibraryEditorPlugin::AssetLibraryEditorPlugin() {
 	addon_library = memnew(EditorAssetLibrary);
 	addon_library->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	EditorNode::get_singleton()->get_main_control()->add_child(addon_library);
+	get_editor_interface()->get_editor_main_control()->add_child(addon_library);
 	addon_library->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	addon_library->hide();
 }

--- a/editor/plugins/audio_stream_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_editor_plugin.cpp
@@ -34,9 +34,11 @@
 #include "core/io/resource_loader.h"
 #include "core/os/keyboard.h"
 #include "editor/audio_stream_preview.h"
-#include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/button.h"
+#include "scene/gui/label.h"
 
 void AudioStreamEditor::_notification(int p_what) {
 	switch (p_what) {
@@ -205,8 +207,10 @@ void AudioStreamEditor::edit(Ref<AudioStream> p_stream) {
 void AudioStreamEditor::_bind_methods() {
 }
 
-AudioStreamEditor::AudioStreamEditor() {
+AudioStreamEditor::AudioStreamEditor(EditorPlugin *p_plugin) {
 	set_custom_minimum_size(Size2(1, 100) * EDSCALE);
+
+	Control *gui_base = p_plugin->get_editor_interface()->get_base_control();
 
 	_player = memnew(AudioStreamPlayer);
 	_player->connect("finished", callable_mp(this, &AudioStreamEditor::_on_finished));
@@ -247,14 +251,14 @@ AudioStreamEditor::AudioStreamEditor() {
 	_current_label = memnew(Label);
 	_current_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_RIGHT);
 	_current_label->set_h_size_flags(SIZE_EXPAND_FILL);
-	_current_label->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
-	_current_label->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+	_current_label->add_theme_font_override("font", gui_base->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	_current_label->add_theme_font_size_override("font_size", gui_base->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 	_current_label->set_modulate(Color(1, 1, 1, 0.5));
 	hbox->add_child(_current_label);
 
 	_duration_label = memnew(Label);
-	_duration_label->add_theme_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
-	_duration_label->add_theme_font_size_override("font_size", EditorNode::get_singleton()->get_gui_base()->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
+	_duration_label->add_theme_font_override("font", gui_base->get_theme_font(SNAME("status_source"), SNAME("EditorFonts")));
+	_duration_label->add_theme_font_size_override("font_size", gui_base->get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 	hbox->add_child(_duration_label);
 }
 
@@ -276,7 +280,7 @@ void AudioStreamEditorPlugin::make_visible(bool p_visible) {
 }
 
 AudioStreamEditorPlugin::AudioStreamEditorPlugin() {
-	audio_editor = memnew(AudioStreamEditor);
+	audio_editor = memnew(AudioStreamEditor(this));
 	add_control_to_container(CONTAINER_PROPERTY_EDITOR_BOTTOM, audio_editor);
 	audio_editor->hide();
 }

--- a/editor/plugins/audio_stream_editor_plugin.h
+++ b/editor/plugins/audio_stream_editor_plugin.h
@@ -69,7 +69,7 @@ protected:
 
 public:
 	void edit(Ref<AudioStream> p_stream);
-	AudioStreamEditor();
+	AudioStreamEditor(EditorPlugin *p_plugin);
 };
 
 class AudioStreamEditorPlugin : public EditorPlugin {

--- a/editor/plugins/camera_3d_editor_plugin.cpp
+++ b/editor/plugins/camera_3d_editor_plugin.cpp
@@ -30,7 +30,6 @@
 
 #include "camera_3d_editor_plugin.h"
 
-#include "editor/editor_node.h"
 #include "node_3d_editor_plugin.h"
 
 void Camera3DEditor::_node_removed(Node *p_node) {

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -35,7 +35,9 @@
 #include "editor/editor_zoom_widget.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/check_box.h"
+#include "scene/gui/dialogs.h"
 #include "scene/gui/label.h"
+#include "scene/gui/menu_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/split_container.h"
@@ -181,6 +183,8 @@ private:
 	};
 
 	bool selection_menu_additive_selection;
+
+	EditorPlugin *plugin;
 
 	Tool tool = TOOL_SELECT;
 	Control *viewport = nullptr;
@@ -400,8 +404,6 @@ private:
 	void _prepare_grid_menu();
 	void _on_grid_menu_id_pressed(int p_id);
 
-	UndoRedo *undo_redo = nullptr;
-
 	List<CanvasItem *> _get_edited_canvas_items(bool retrieve_locked = false, bool remove_canvas_item_if_parent_in_selection = true);
 	Rect2 _get_encompassing_rect_from_list(List<CanvasItem *> p_list);
 	void _expand_encompassing_rect_using_children(Rect2 &r_rect, const Node *p_node, bool &r_first, const Transform2D &p_parent_xform = Transform2D(), const Transform2D &p_canvas_xform = Transform2D(), bool include_locked_nodes = true);
@@ -550,14 +552,13 @@ public:
 	Tool get_current_tool() { return tool; }
 	void set_current_tool(Tool p_tool);
 
-	void set_undo_redo(UndoRedo *p_undo_redo) { undo_redo = p_undo_redo; }
 	void edit(CanvasItem *p_canvas_item);
 
 	void focus_selection();
 
 	EditorSelection *editor_selection = nullptr;
 
-	CanvasItemEditor();
+	CanvasItemEditor(EditorPlugin *p_plugin);
 };
 
 class CanvasItemEditorPlugin : public EditorPlugin {
@@ -595,6 +596,7 @@ class CanvasItemEditorViewport : public Control {
 	EditorData *editor_data = nullptr;
 	CanvasItemEditor *canvas_item_editor = nullptr;
 	Control *preview_node = nullptr;
+	EditorPlugin *plugin = nullptr;
 	AcceptDialog *accept = nullptr;
 	AcceptDialog *selector = nullptr;
 	Label *selector_label = nullptr;
@@ -629,7 +631,7 @@ public:
 	virtual bool can_drop_data(const Point2 &p_point, const Variant &p_data) const override;
 	virtual void drop_data(const Point2 &p_point, const Variant &p_data) override;
 
-	CanvasItemEditorViewport(CanvasItemEditor *p_canvas_item_editor);
+	CanvasItemEditorViewport(CanvasItemEditor *p_canvas_item_editor, EditorPlugin *p_plugin);
 	~CanvasItemEditorViewport();
 };
 

--- a/editor/plugins/collision_shape_2d_editor_plugin.h
+++ b/editor/plugins/collision_shape_2d_editor_plugin.h
@@ -61,8 +61,7 @@ class CollisionShape2DEditor : public Control {
 		Point2(1, -1),
 	};
 
-	UndoRedo *undo_redo = nullptr;
-	CanvasItemEditor *canvas_item_editor = nullptr;
+	EditorPlugin *plugin = nullptr;
 	CollisionShape2D *node = nullptr;
 
 	Vector<Point2> handles;
@@ -90,7 +89,7 @@ public:
 	void forward_canvas_draw_over_viewport(Control *p_overlay);
 	void edit(Node *p_node);
 
-	CollisionShape2DEditor();
+	CollisionShape2DEditor(EditorPlugin *p_plugin);
 };
 
 class CollisionShape2DEditorPlugin : public EditorPlugin {

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -455,6 +455,7 @@ bool EditorInspectorPluginControl::parse_property(Object *p_object, const Varian
 void ControlEditorToolbar::_set_anchors_and_offsets_preset(Control::LayoutPreset p_preset) {
 	List<Node *> selection = editor_selection->get_selected_node_list();
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Change Anchors and Offsets"));
 
 	for (Node *E : selection) {
@@ -496,6 +497,7 @@ void ControlEditorToolbar::_set_anchors_and_offsets_preset(Control::LayoutPreset
 void ControlEditorToolbar::_set_anchors_and_offsets_to_keep_ratio() {
 	List<Node *> selection = editor_selection->get_selected_node_list();
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Change Anchors and Offsets"));
 
 	for (Node *E : selection) {
@@ -528,6 +530,7 @@ void ControlEditorToolbar::_set_anchors_and_offsets_to_keep_ratio() {
 void ControlEditorToolbar::_set_anchors_preset(Control::LayoutPreset p_preset) {
 	List<Node *> selection = editor_selection->get_selected_node_list();
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Change Anchors"));
 	for (Node *E : selection) {
 		Control *control = Object::cast_to<Control>(E);
@@ -543,6 +546,7 @@ void ControlEditorToolbar::_set_anchors_preset(Control::LayoutPreset p_preset) {
 void ControlEditorToolbar::_set_container_h_preset(Control::SizeFlags p_preset) {
 	List<Node *> selection = editor_selection->get_selected_node_list();
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Change Horizontal Size Flags"));
 	for (Node *E : selection) {
 		Control *control = Object::cast_to<Control>(E);
@@ -558,6 +562,7 @@ void ControlEditorToolbar::_set_container_h_preset(Control::SizeFlags p_preset) 
 void ControlEditorToolbar::_set_container_v_preset(Control::SizeFlags p_preset) {
 	List<Node *> selection = editor_selection->get_selected_node_list();
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Change Horizontal Size Flags"));
 	for (Node *E : selection) {
 		Control *control = Object::cast_to<Control>(E);
@@ -947,7 +952,8 @@ void ControlEditorToolbar::_notification(int p_what) {
 	}
 }
 
-ControlEditorToolbar::ControlEditorToolbar() {
+ControlEditorToolbar::ControlEditorToolbar(EditorPlugin *p_plugin) {
+	plugin = p_plugin;
 	anchor_presets_menu = memnew(MenuButton);
 	anchor_presets_menu->set_shortcut_context(this);
 	anchor_presets_menu->set_text(TTR("Anchors"));
@@ -992,8 +998,7 @@ ControlEditorToolbar::ControlEditorToolbar() {
 	p = container_v_presets_menu->get_popup();
 	p->connect("id_pressed", callable_mp(this, &ControlEditorToolbar::_popup_callback));
 
-	undo_redo = EditorNode::get_singleton()->get_undo_redo();
-	editor_selection = EditorNode::get_singleton()->get_editor_selection();
+	editor_selection = plugin->get_editor_interface()->get_selection();
 	editor_selection->add_editor_plugin(this);
 	editor_selection->connect("selection_changed", callable_mp(this, &ControlEditorToolbar::_selection_changed));
 
@@ -1003,7 +1008,7 @@ ControlEditorToolbar::ControlEditorToolbar() {
 ControlEditorToolbar *ControlEditorToolbar::singleton = nullptr;
 
 ControlEditorPlugin::ControlEditorPlugin() {
-	toolbar = memnew(ControlEditorToolbar);
+	toolbar = memnew(ControlEditorToolbar(this));
 	toolbar->hide();
 	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, toolbar);
 

--- a/editor/plugins/control_editor_plugin.h
+++ b/editor/plugins/control_editor_plugin.h
@@ -31,12 +31,15 @@
 #ifndef CONTROL_EDITOR_PLUGIN_H
 #define CONTROL_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/control.h"
+#include "scene/gui/grid_container.h"
 #include "scene/gui/label.h"
 #include "scene/gui/margin_container.h"
+#include "scene/gui/menu_button.h"
 #include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/texture_rect.h"
@@ -128,7 +131,7 @@ public:
 class ControlEditorToolbar : public HBoxContainer {
 	GDCLASS(ControlEditorToolbar, HBoxContainer);
 
-	UndoRedo *undo_redo = nullptr;
+	EditorPlugin *plugin = nullptr;
 	EditorSelection *editor_selection = nullptr;
 
 	enum MenuOption {
@@ -233,7 +236,7 @@ public:
 
 	static ControlEditorToolbar *get_singleton() { return singleton; }
 
-	ControlEditorToolbar();
+	ControlEditorToolbar(EditorPlugin *p_plugin);
 };
 
 class ControlEditorPlugin : public EditorPlugin {

--- a/editor/plugins/cpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.cpp
@@ -33,7 +33,6 @@
 #include "canvas_item_editor_plugin.h"
 #include "core/io/image_loader.h"
 #include "editor/editor_file_dialog.h"
-#include "editor/editor_node.h"
 #include "scene/2d/cpu_particles_2d.h"
 #include "scene/gui/separator.h"
 #include "scene/resources/particles_material.h"
@@ -238,7 +237,6 @@ void CPUParticles2DEditorPlugin::_bind_methods() {
 
 CPUParticles2DEditorPlugin::CPUParticles2DEditorPlugin() {
 	particles = nullptr;
-	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 	toolbar = memnew(HBoxContainer);
 	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, toolbar);

--- a/editor/plugins/cpu_particles_2d_editor_plugin.h
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.h
@@ -35,8 +35,11 @@
 #include "scene/2d/collision_polygon_2d.h"
 #include "scene/2d/cpu_particles_2d.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
 
-class EditorPlugin;
 class SpinBox;
 class EditorFileDialog;
 
@@ -70,7 +73,6 @@ class CPUParticles2DEditorPlugin : public EditorPlugin {
 
 	String source_emission_file;
 
-	UndoRedo *undo_redo = nullptr;
 	void _file_selected(const String &p_file);
 	void _menu_callback(int p_idx);
 	void _generate_emission_mask();

--- a/editor/plugins/cpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/cpu_particles_3d_editor_plugin.cpp
@@ -30,7 +30,6 @@
 
 #include "cpu_particles_3d_editor_plugin.h"
 
-#include "editor/editor_node.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/scene_tree_editor.h"
 #include "scene/gui/menu_button.h"
@@ -126,7 +125,7 @@ void CPUParticles3DEditorPlugin::make_visible(bool p_visible) {
 
 CPUParticles3DEditorPlugin::CPUParticles3DEditorPlugin() {
 	particles_editor = memnew(CPUParticles3DEditor);
-	EditorNode::get_singleton()->get_main_control()->add_child(particles_editor);
+	get_editor_interface()->get_editor_main_control()->add_child(particles_editor);
 
 	particles_editor->hide();
 }

--- a/editor/plugins/curve_editor_plugin.h
+++ b/editor/plugins/curve_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef CURVE_EDITOR_PLUGIN_H
 #define CURVE_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "editor/editor_resource_preview.h"
 #include "scene/resources/curve.h"
@@ -40,7 +41,7 @@ class CurveEditor : public Control {
 	GDCLASS(CurveEditor, Control);
 
 public:
-	CurveEditor();
+	CurveEditor(EditorPlugin *p_plugin);
 
 	Size2 get_minimum_size() const override;
 
@@ -96,6 +97,8 @@ private:
 	void _draw();
 
 private:
+	EditorPlugin *plugin;
+
 	Transform2D _world_to_view;
 
 	Ref<Curve> _curve_ref;
@@ -119,9 +122,13 @@ private:
 class EditorInspectorPluginCurve : public EditorInspectorPlugin {
 	GDCLASS(EditorInspectorPluginCurve, EditorInspectorPlugin);
 
+	EditorPlugin *plugin;
+
 public:
 	virtual bool can_handle(Object *p_object) override;
 	virtual void parse_begin(Object *p_object) override;
+
+	EditorInspectorPluginCurve(EditorPlugin *p_plugin);
 };
 
 class CurveEditorPlugin : public EditorPlugin {

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -33,8 +33,8 @@
 #include "core/os/keyboard.h"
 #include "editor/debugger/editor_debugger_node.h"
 #include "editor/debugger/editor_debugger_server.h"
-#include "editor/editor_node.h"
 #include "editor/editor_scale.h"
+#include "editor/editor_settings.h"
 #include "editor/fileserver/editor_file_server.h"
 #include "editor/plugins/script_editor_plugin.h"
 #include "scene/gui/menu_button.h"
@@ -53,7 +53,7 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(MenuButton *p_debug_menu) {
 	file_server = memnew(EditorFileServer);
 
 	EditorDebuggerNode *debugger = memnew(EditorDebuggerNode);
-	Button *db = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Debugger"), debugger);
+	Button *db = add_control_to_bottom_panel(debugger, TTR("Debugger"));
 	// Add separation for the warning/error icon that is displayed later.
 	db->add_theme_constant_override("hseparation", 6 * EDSCALE);
 	debugger->set_tool_button(db);

--- a/editor/plugins/font_editor_plugin.cpp
+++ b/editor/plugins/font_editor_plugin.cpp
@@ -102,5 +102,5 @@ bool EditorInspectorPluginFont::parse_property(Object *p_object, const Variant::
 FontEditorPlugin::FontEditorPlugin() {
 	Ref<EditorInspectorPluginFont> fd_plugin;
 	fd_plugin.instantiate();
-	EditorInspector::add_inspector_plugin(fd_plugin);
+	add_inspector_plugin(fd_plugin);
 }

--- a/editor/plugins/font_editor_plugin.h
+++ b/editor/plugins/font_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef FONT_EDITOR_PLUGIN_H
 #define FONT_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "scene/resources/font.h"
 #include "scene/resources/text_line.h"

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -61,7 +61,7 @@ void GPUParticles2DEditorPlugin::_file_selected(const String &p_file) {
 }
 
 void GPUParticles2DEditorPlugin::_selection_changed() {
-	List<Node *> selected_nodes = EditorNode::get_singleton()->get_editor_selection()->get_selected_node_list();
+	List<Node *> selected_nodes = get_editor_interface()->get_selection()->get_selected_node_list();
 
 	if (selected_particles.is_empty() && selected_nodes.is_empty()) {
 		return;
@@ -111,7 +111,7 @@ void GPUParticles2DEditorPlugin::_menu_callback(int p_idx) {
 			cpu_particles->set_process_mode(particles->get_process_mode());
 			cpu_particles->set_z_index(particles->get_z_index());
 
-			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+			UndoRedo *ur = get_undo_redo();
 			ur->create_action(TTR("Convert to CPUParticles2D"));
 			ur->add_do_method(SceneTreeDock::get_singleton(), "replace_node", particles, cpu_particles, true, false);
 			ur->add_do_reference(cpu_particles);
@@ -158,6 +158,8 @@ void GPUParticles2DEditorPlugin::_generate_visibility_rect() {
 	if (!was_emitting) {
 		particles->set_emitting(false);
 	}
+
+	UndoRedo *undo_redo = get_undo_redo();
 
 	undo_redo->create_action(TTR("Generate Visibility Rect"));
 	undo_redo->add_do_method(particles, "set_visibility_rect", rect);
@@ -359,7 +361,7 @@ void GPUParticles2DEditorPlugin::_notification(int p_what) {
 			menu->get_popup()->connect("id_pressed", callable_mp(this, &GPUParticles2DEditorPlugin::_menu_callback));
 			menu->set_icon(menu->get_theme_icon(SNAME("GPUParticles2D"), SNAME("EditorIcons")));
 			file->connect("file_selected", callable_mp(this, &GPUParticles2DEditorPlugin::_file_selected));
-			EditorNode::get_singleton()->get_editor_selection()->connect("selection_changed", callable_mp(this, &GPUParticles2DEditorPlugin::_selection_changed));
+			get_editor_interface()->get_selection()->connect("selection_changed", callable_mp(this, &GPUParticles2DEditorPlugin::_selection_changed));
 		} break;
 	}
 }
@@ -369,7 +371,6 @@ void GPUParticles2DEditorPlugin::_bind_methods() {
 
 GPUParticles2DEditorPlugin::GPUParticles2DEditorPlugin() {
 	particles = nullptr;
-	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 	toolbar = memnew(HBoxContainer);
 	add_control_to_container(CONTAINER_CANVAS_EDITOR_MENU, toolbar);

--- a/editor/plugins/gpu_particles_2d_editor_plugin.h
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.h
@@ -35,6 +35,10 @@
 #include "scene/2d/collision_polygon_2d.h"
 #include "scene/2d/gpu_particles_2d.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/spin_box.h"
 
 class EditorFileDialog;
@@ -75,7 +79,6 @@ class GPUParticles2DEditorPlugin : public EditorPlugin {
 
 	String source_emission_file;
 
-	UndoRedo *undo_redo = nullptr;
 	void _file_selected(const String &p_file);
 	void _menu_callback(int p_idx);
 	void _generate_visibility_rect();

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -271,7 +271,7 @@ void GPUParticles3DEditor::_menu_option(int p_option) {
 			cpu_particles->set_visible(node->is_visible());
 			cpu_particles->set_process_mode(node->get_process_mode());
 
-			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+			UndoRedo *ur = plugin->get_undo_redo();
 			ur->create_action(TTR("Convert to CPUParticles3D"));
 			ur->add_do_method(SceneTreeDock::get_singleton(), "replace_node", node, cpu_particles, true, false);
 			ur->add_do_reference(cpu_particles);
@@ -321,7 +321,7 @@ void GPUParticles3DEditor::_generate_aabb() {
 		node->set_emitting(false);
 	}
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Generate Visibility AABB"));
 	ur->add_do_method(node, "set_visibility_aabb", rect);
 	ur->add_undo_method(node, "set_visibility_aabb", node->get_visibility_aabb());
@@ -408,7 +408,8 @@ void GPUParticles3DEditor::_generate_emission_points() {
 void GPUParticles3DEditor::_bind_methods() {
 }
 
-GPUParticles3DEditor::GPUParticles3DEditor() {
+GPUParticles3DEditor::GPUParticles3DEditor(EditorPlugin *p_plugin) {
+	plugin = p_plugin;
 	node = nullptr;
 	particles_editor_hb = memnew(HBoxContainer);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(particles_editor_hb);
@@ -460,8 +461,8 @@ void GPUParticles3DEditorPlugin::make_visible(bool p_visible) {
 }
 
 GPUParticles3DEditorPlugin::GPUParticles3DEditorPlugin() {
-	particles_editor = memnew(GPUParticles3DEditor);
-	EditorNode::get_singleton()->get_main_control()->add_child(particles_editor);
+	particles_editor = memnew(GPUParticles3DEditor(this));
+	get_editor_interface()->get_editor_main_control()->add_child(particles_editor);
 
 	particles_editor->hide();
 }

--- a/editor/plugins/gpu_particles_3d_editor_plugin.h
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.h
@@ -33,6 +33,9 @@
 
 #include "editor/editor_plugin.h"
 #include "scene/3d/gpu_particles_3d.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/spin_box.h"
 
 class SceneTreeDialog;
@@ -67,6 +70,8 @@ public:
 class GPUParticles3DEditor : public GPUParticles3DEditorBase {
 	GDCLASS(GPUParticles3DEditor, GPUParticles3DEditorBase);
 
+	EditorPlugin *plugin = nullptr;
+
 	ConfirmationDialog *generate_aabb = nullptr;
 	SpinBox *generate_seconds = nullptr;
 	GPUParticles3D *node = nullptr;
@@ -95,7 +100,7 @@ protected:
 
 public:
 	void edit(GPUParticles3D *p_particles);
-	GPUParticles3DEditor();
+	GPUParticles3DEditor(EditorPlugin *p_plugin);
 };
 
 class GPUParticles3DEditorPlugin : public EditorPlugin {

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -182,7 +182,7 @@ GPUParticlesCollisionSDF3DEditorPlugin::GPUParticlesCollisionSDF3DEditorPlugin()
 	bake_hb->hide();
 	bake = memnew(Button);
 	bake->set_flat(true);
-	bake->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
+	bake->set_icon(get_editor_interface()->get_base_control()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake SDF"));
 	bake->connect("pressed", callable_mp(this, &GPUParticlesCollisionSDF3DEditorPlugin::_bake));
 	bake_hb->add_child(bake);

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
@@ -33,6 +33,7 @@
 
 #include "editor/editor_plugin.h"
 #include "scene/3d/gpu_particles_collision_3d.h"
+#include "scene/gui/box_container.h"
 #include "scene/resources/material.h"
 
 struct EditorProgress;

--- a/editor/plugins/gradient_editor_plugin.h
+++ b/editor/plugins/gradient_editor_plugin.h
@@ -31,11 +31,14 @@
 #ifndef GRADIENT_EDITOR_PLUGIN_H
 #define GRADIENT_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "scene/gui/gradient_edit.h"
 
 class GradientEditor : public GradientEdit {
 	GDCLASS(GradientEditor, GradientEdit);
+
+	EditorPlugin *plugin;
 
 	bool editing;
 	Ref<Gradient> gradient;
@@ -50,7 +53,7 @@ public:
 	virtual Size2 get_minimum_size() const override;
 	void set_gradient(const Ref<Gradient> &p_gradient);
 	void reverse_gradient();
-	GradientEditor();
+	GradientEditor(EditorPlugin *p_plugin);
 };
 
 class GradientReverseButton : public BaseButton {
@@ -65,6 +68,7 @@ class GradientReverseButton : public BaseButton {
 class EditorInspectorPluginGradient : public EditorInspectorPlugin {
 	GDCLASS(EditorInspectorPluginGradient, EditorInspectorPlugin);
 
+	EditorPlugin *plugin = nullptr;
 	GradientEditor *editor = nullptr;
 	HBoxContainer *gradient_tools_hbox = nullptr;
 	GradientReverseButton *reverse_btn = nullptr;
@@ -74,6 +78,8 @@ class EditorInspectorPluginGradient : public EditorInspectorPlugin {
 public:
 	virtual bool can_handle(Object *p_object) override;
 	virtual void parse_begin(Object *p_object) override;
+
+	EditorInspectorPluginGradient(EditorPlugin *p_plugin);
 };
 
 class GradientEditorPlugin : public EditorPlugin {

--- a/editor/plugins/gradient_texture_2d_editor_plugin.h
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.h
@@ -31,8 +31,10 @@
 #ifndef GRADIENT_TEXTURE_2D_EDITOR
 #define GRADIENT_TEXTURE_2D_EDITOR
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "editor/editor_spin_slider.h"
+#include "scene/gui/box_container.h"
 
 class GradientTexture2DEditorRect : public Control {
 	GDCLASS(GradientTexture2DEditorRect, Control);

--- a/editor/plugins/light_occluder_2d_editor_plugin.cpp
+++ b/editor/plugins/light_occluder_2d_editor_plugin.cpp
@@ -30,6 +30,8 @@
 
 #include "light_occluder_2d_editor_plugin.h"
 
+#include "core/object/undo_redo.h"
+
 Ref<OccluderPolygon2D> LightOccluder2DEditor::_ensure_occluder() const {
 	Ref<OccluderPolygon2D> occluder = node->get_occluder_polygon();
 	if (!occluder.is_valid()) {
@@ -93,7 +95,6 @@ void LightOccluder2DEditor::_create_resource() {
 	if (!node) {
 		return;
 	}
-
 	undo_redo->create_action(TTR("Create Occluder Polygon"));
 	undo_redo->add_do_method(node, "set_occluder_polygon", Ref<OccluderPolygon2D>(memnew(OccluderPolygon2D)));
 	undo_redo->add_undo_method(node, "set_occluder_polygon", Variant(REF()));

--- a/editor/plugins/lightmap_gi_editor_plugin.cpp
+++ b/editor/plugins/lightmap_gi_editor_plugin.cpp
@@ -129,7 +129,7 @@ void LightmapGIEditorPlugin::_bind_methods() {
 LightmapGIEditorPlugin::LightmapGIEditorPlugin() {
 	bake = memnew(Button);
 	bake->set_flat(true);
-	bake->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
+	bake->set_icon(get_editor_interface()->get_base_control()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake Lightmaps"));
 	bake->hide();
 	bake->connect("pressed", Callable(this, "_bake"));

--- a/editor/plugins/line_2d_editor_plugin.cpp
+++ b/editor/plugins/line_2d_editor_plugin.cpp
@@ -30,6 +30,8 @@
 
 #include "line_2d_editor_plugin.h"
 
+#include "core/object/undo_redo.h"
+
 Node2D *Line2DEditor::_get_node() const {
 	return node;
 }
@@ -52,6 +54,7 @@ void Line2DEditor::_set_polygon(int p_idx, const Variant &p_polygon) const {
 
 void Line2DEditor::_action_set_polygon(int p_idx, const Variant &p_previous, const Variant &p_polygon) {
 	Node2D *node = _get_node();
+
 	undo_redo->add_do_method(node, "set_points", p_polygon);
 	undo_redo->add_undo_method(node, "set_points", p_previous);
 }

--- a/editor/plugins/material_editor_plugin.h
+++ b/editor/plugins/material_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef MATERIAL_EDITOR_PLUGIN_H
 #define MATERIAL_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "editor/property_editor.h"
 #include "scene/3d/camera_3d.h"

--- a/editor/plugins/mesh_editor_plugin.h
+++ b/editor/plugins/mesh_editor_plugin.h
@@ -31,11 +31,14 @@
 #ifndef MESH_EDITOR_PLUGIN_H
 #define MESH_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/light_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/gui/subviewport_container.h"
+#include "scene/gui/texture_button.h"
+#include "scene/main/viewport.h"
 #include "scene/resources/material.h"
 
 class MeshEditor : public SubViewportContainer {

--- a/editor/plugins/mesh_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.cpp
@@ -30,7 +30,8 @@
 
 #include "mesh_instance_3d_editor_plugin.h"
 
-#include "editor/editor_node.h"
+#include "core/object/undo_redo.h"
+#include "editor/editor_data.h"
 #include "editor/editor_scale.h"
 #include "node_3d_editor_plugin.h"
 #include "scene/3d/collision_shape_3d.h"
@@ -59,8 +60,8 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 	switch (p_option) {
 		case MENU_OPTION_CREATE_STATIC_TRIMESH_BODY: {
-			EditorSelection *editor_selection = EditorNode::get_singleton()->get_editor_selection();
-			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+			EditorSelection *editor_selection = plugin->get_editor_interface()->get_selection();
+			UndoRedo *ur = plugin->get_undo_redo();
 
 			List<Node *> selection = editor_selection->get_selected_node_list();
 
@@ -143,7 +144,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 			Node *owner = node->get_owner();
 
-			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+			UndoRedo *ur = plugin->get_undo_redo();
 
 			ur->create_action(TTR("Create Trimesh Static Shape"));
 
@@ -172,7 +173,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 				err_dialog->popup_centered();
 				return;
 			}
-			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+			UndoRedo *ur = plugin->get_undo_redo();
 
 			if (simplify) {
 				ur->create_action(TTR("Create Simplified Convex Shape"));
@@ -211,7 +212,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 				err_dialog->popup_centered();
 				return;
 			}
-			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+			UndoRedo *ur = plugin->get_undo_redo();
 
 			ur->create_action(TTR("Create Multiple Convex Shapes"));
 
@@ -245,7 +246,7 @@ void MeshInstance3DEditor::_menu_option(int p_option) {
 
 			Node *owner = node == get_tree()->get_edited_scene_root() ? node : node->get_owner();
 
-			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+			UndoRedo *ur = plugin->get_undo_redo();
 			ur->create_action(TTR("Create Navigation Mesh"));
 
 			ur->add_do_method(node, "add_child", nmi, true);
@@ -423,7 +424,7 @@ void MeshInstance3DEditor::_create_outline_mesh() {
 		owner = node;
 	}
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 
 	ur->create_action(TTR("Create Outline"));
 
@@ -438,13 +439,15 @@ void MeshInstance3DEditor::_create_outline_mesh() {
 void MeshInstance3DEditor::_bind_methods() {
 }
 
-MeshInstance3DEditor::MeshInstance3DEditor() {
+MeshInstance3DEditor::MeshInstance3DEditor(EditorPlugin *p_plugin) {
+	plugin = p_plugin;
+
 	options = memnew(MenuButton);
 	options->set_switch_on_hover(true);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(options);
 
 	options->set_text(TTR("Mesh"));
-	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("MeshInstance3D"), SNAME("EditorIcons")));
+	options->set_icon(plugin->get_editor_interface()->get_base_control()->get_theme_icon(SNAME("MeshInstance3D"), SNAME("EditorIcons")));
 
 	options->get_popup()->add_item(TTR("Create Trimesh Static Body"), MENU_OPTION_CREATE_STATIC_TRIMESH_BODY);
 	options->get_popup()->set_item_tooltip(-1, TTR("Creates a StaticBody3D and assigns a polygon-based collision shape to it automatically.\nThis is the most accurate (but slowest) option for collision detection."));
@@ -517,8 +520,8 @@ void MeshInstance3DEditorPlugin::make_visible(bool p_visible) {
 }
 
 MeshInstance3DEditorPlugin::MeshInstance3DEditorPlugin() {
-	mesh_editor = memnew(MeshInstance3DEditor);
-	EditorNode::get_singleton()->get_main_control()->add_child(mesh_editor);
+	mesh_editor = memnew(MeshInstance3DEditor(this));
+	get_editor_interface()->get_editor_main_control()->add_child(mesh_editor);
 
 	mesh_editor->options->hide();
 }

--- a/editor/plugins/mesh_instance_3d_editor_plugin.h
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.h
@@ -33,10 +33,14 @@
 
 #include "editor/editor_plugin.h"
 #include "scene/3d/mesh_instance_3d.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/menu_button.h"
 #include "scene/gui/spin_box.h"
 
 class MeshInstance3DEditor : public Control {
 	GDCLASS(MeshInstance3DEditor, Control);
+
+	EditorPlugin *plugin;
 
 	enum Menu {
 		MENU_OPTION_CREATE_STATIC_TRIMESH_BODY,
@@ -78,7 +82,7 @@ protected:
 
 public:
 	void edit(MeshInstance3D *p_mesh);
-	MeshInstance3DEditor();
+	MeshInstance3DEditor(EditorPlugin *p_plugin);
 };
 
 class MeshInstance3DEditorPlugin : public EditorPlugin {

--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -31,8 +31,8 @@
 #include "mesh_library_editor_plugin.h"
 
 #include "editor/editor_file_dialog.h"
-#include "editor/editor_node.h"
 #include "editor/editor_settings.h"
+#include "editor/inspector_dock.h"
 #include "main/main.h"
 #include "node_3d_editor_plugin.h"
 #include "scene/3d/mesh_instance_3d.h"
@@ -254,7 +254,7 @@ void MeshLibraryEditor::_menu_cbk(int p_option) {
 void MeshLibraryEditor::_bind_methods() {
 }
 
-MeshLibraryEditor::MeshLibraryEditor() {
+MeshLibraryEditor::MeshLibraryEditor(EditorPlugin *p_plugin) {
 	file = memnew(EditorFileDialog);
 	file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	//not for now?
@@ -272,7 +272,7 @@ MeshLibraryEditor::MeshLibraryEditor() {
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(menu);
 	menu->set_position(Point2(1, 1));
 	menu->set_text(TTR("MeshLibrary"));
-	menu->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("MeshLibrary"), SNAME("EditorIcons")));
+	menu->set_icon(p_plugin->get_editor_interface()->get_base_control()->get_theme_icon(SNAME("MeshLibrary"), SNAME("EditorIcons")));
 	menu->get_popup()->add_item(TTR("Add Item"), MENU_OPTION_ADD_ITEM);
 	menu->get_popup()->add_item(TTR("Remove Selected Item"), MENU_OPTION_REMOVE_ITEM);
 	menu->get_popup()->add_separator();
@@ -317,9 +317,9 @@ void MeshLibraryEditorPlugin::make_visible(bool p_visible) {
 }
 
 MeshLibraryEditorPlugin::MeshLibraryEditorPlugin() {
-	mesh_library_editor = memnew(MeshLibraryEditor);
+	mesh_library_editor = memnew(MeshLibraryEditor(this));
 
-	EditorNode::get_singleton()->get_main_control()->add_child(mesh_library_editor);
+	get_editor_interface()->get_editor_main_control()->add_child(mesh_library_editor);
 	mesh_library_editor->set_anchors_and_offsets_preset(Control::PRESET_TOP_WIDE);
 	mesh_library_editor->set_end(Point2(0, 22));
 	mesh_library_editor->hide();

--- a/editor/plugins/mesh_library_editor_plugin.h
+++ b/editor/plugins/mesh_library_editor_plugin.h
@@ -75,7 +75,7 @@ public:
 	void edit(const Ref<MeshLibrary> &p_mesh_library);
 	static Error update_library_file(Node *p_base_scene, Ref<MeshLibrary> ml, bool p_merge = true, bool p_apply_xforms = false);
 
-	MeshLibraryEditor();
+	MeshLibraryEditor(EditorPlugin *p_plugin);
 };
 
 class MeshLibraryEditorPlugin : public EditorPlugin {

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -30,9 +30,8 @@
 
 #include "multimesh_editor_plugin.h"
 
-#include "editor/editor_node.h"
+#include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/scene_tree_editor.h"
-#include "node_3d_editor_plugin.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/gui/box_container.h"
 
@@ -264,13 +263,13 @@ void MultiMeshEditor::_browse(bool p_source) {
 void MultiMeshEditor::_bind_methods() {
 }
 
-MultiMeshEditor::MultiMeshEditor() {
+MultiMeshEditor::MultiMeshEditor(EditorPlugin *p_plugin) {
 	options = memnew(MenuButton);
 	options->set_switch_on_hover(true);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(options);
 
 	options->set_text("MultiMesh");
-	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("MultiMeshInstance3D"), SNAME("EditorIcons")));
+	options->set_icon(p_plugin->get_editor_interface()->get_base_control()->get_theme_icon(SNAME("MultiMeshInstance3D"), SNAME("EditorIcons")));
 
 	options->get_popup()->add_item(TTR("Populate Surface"));
 	options->get_popup()->connect("id_pressed", callable_mp(this, &MultiMeshEditor::_menu_option));
@@ -378,8 +377,8 @@ void MultiMeshEditorPlugin::make_visible(bool p_visible) {
 }
 
 MultiMeshEditorPlugin::MultiMeshEditorPlugin() {
-	multimesh_editor = memnew(MultiMeshEditor);
-	EditorNode::get_singleton()->get_main_control()->add_child(multimesh_editor);
+	multimesh_editor = memnew(MultiMeshEditor(this));
+	get_editor_interface()->get_editor_main_control()->add_child(multimesh_editor);
 
 	multimesh_editor->options->hide();
 }

--- a/editor/plugins/multimesh_editor_plugin.h
+++ b/editor/plugins/multimesh_editor_plugin.h
@@ -33,6 +33,9 @@
 
 #include "editor/editor_plugin.h"
 #include "scene/3d/multimesh_instance_3d.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/slider.h"
 #include "scene/gui/spin_box.h"
 
@@ -79,7 +82,7 @@ protected:
 
 public:
 	void edit(MultiMeshInstance3D *p_multimesh);
-	MultiMeshEditor();
+	MultiMeshEditor(EditorPlugin *p_plugin);
 };
 
 class MultiMeshEditorPlugin : public EditorPlugin {

--- a/editor/plugins/navigation_polygon_editor_plugin.cpp
+++ b/editor/plugins/navigation_polygon_editor_plugin.cpp
@@ -30,6 +30,8 @@
 
 #include "navigation_polygon_editor_plugin.h"
 
+#include "core/object/undo_redo.h"
+
 Ref<NavigationPolygon> NavigationPolygonEditor::_ensure_navpoly() const {
 	Ref<NavigationPolygon> navpoly = node->get_navigation_polygon();
 	if (!navpoly.is_valid()) {

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -40,6 +40,7 @@
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/3d/world_environment.h"
 #include "scene/gui/color_picker.h"
+#include "scene/gui/menu_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/split_container.h"
@@ -51,6 +52,10 @@ class EditorData;
 class Node3DEditor;
 class Node3DEditorViewport;
 class SubViewportContainer;
+class ConfirmationDialog;
+class AcceptDialog;
+class CheckBox;
+class OptionButton;
 class DirectionalLight3D;
 class WorldEnvironment;
 
@@ -181,6 +186,8 @@ public:
 	};
 
 private:
+	EditorPlugin *plugin;
+
 	double cpu_time_history[FRAME_TIME_HISTORY];
 	int cpu_time_history_index;
 	double gpu_time_history[FRAME_TIME_HISTORY];
@@ -442,7 +449,7 @@ public:
 	SubViewport *get_viewport_node() { return viewport; }
 	Camera3D *get_camera_3d() { return camera; } // return the default camera object.
 
-	Node3DEditorViewport(Node3DEditor *p_spatial_editor, int p_index);
+	Node3DEditorViewport(Node3DEditor *p_spatial_editor, EditorPlugin *p_plugin, int p_index);
 	~Node3DEditorViewport();
 };
 
@@ -537,6 +544,7 @@ public:
 	};
 
 private:
+	EditorPlugin *plugin = nullptr;
 	EditorSelection *editor_selection = nullptr;
 
 	Node3DEditorViewportContainer *viewport_base = nullptr;
@@ -861,7 +869,7 @@ public:
 	void edit(Node3D *p_spatial);
 	void clear();
 
-	Node3DEditor();
+	Node3DEditor(EditorPlugin *p_plugin);
 	~Node3DEditor();
 };
 

--- a/editor/plugins/occluder_instance_3d_editor_plugin.cpp
+++ b/editor/plugins/occluder_instance_3d_editor_plugin.cpp
@@ -104,7 +104,7 @@ void OccluderInstance3DEditorPlugin::_bind_methods() {
 OccluderInstance3DEditorPlugin::OccluderInstance3DEditorPlugin() {
 	bake = memnew(Button);
 	bake->set_flat(true);
-	bake->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
+	bake->set_icon(get_editor_interface()->get_base_control()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake Occluders"));
 	bake->hide();
 	bake->connect("pressed", Callable(this, "_bake"));

--- a/editor/plugins/path_2d_editor_plugin.cpp
+++ b/editor/plugins/path_2d_editor_plugin.cpp
@@ -30,12 +30,12 @@
 
 #include "path_2d_editor_plugin.h"
 
-#include "canvas_item_editor_plugin.h"
 #include "core/io/file_access.h"
+#include "core/object/undo_redo.h"
 #include "core/os/keyboard.h"
-#include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
+#include "editor/plugins/canvas_item_editor_plugin.h"
 
 void Path2DEditor::_notification(int p_what) {
 	switch (p_what) {
@@ -516,9 +516,9 @@ void Path2DEditor::_handle_option_pressed(int p_option) {
 	}
 }
 
-Path2DEditor::Path2DEditor() {
+Path2DEditor::Path2DEditor(EditorPlugin *p_plugin) {
 	canvas_item_editor = nullptr;
-	undo_redo = EditorNode::get_singleton()->get_undo_redo();
+	undo_redo = p_plugin->get_undo_redo();
 	mirror_handle_angle = true;
 	mirror_handle_length = true;
 	on_edge = false;
@@ -610,7 +610,7 @@ void Path2DEditorPlugin::make_visible(bool p_visible) {
 }
 
 Path2DEditorPlugin::Path2DEditorPlugin() {
-	path2d_editor = memnew(Path2DEditor);
+	path2d_editor = memnew(Path2DEditor(this));
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(path2d_editor);
 	path2d_editor->hide();
 }

--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -33,6 +33,8 @@
 
 #include "editor/editor_plugin.h"
 #include "scene/2d/path_2d.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/menu_button.h"
 #include "scene/gui/separator.h"
 
 class CanvasItemEditor;
@@ -104,7 +106,7 @@ public:
 	bool forward_gui_input(const Ref<InputEvent> &p_event);
 	void forward_canvas_draw_over_viewport(Control *p_overlay);
 	void edit(Node *p_path2d);
-	Path2DEditor();
+	Path2DEditor(EditorPlugin *p_plugin);
 };
 
 class Path2DEditorPlugin : public EditorPlugin {

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -32,9 +32,10 @@
 
 #include "core/math/geometry_2d.h"
 #include "core/math/geometry_3d.h"
+#include "core/object/undo_redo.h"
 #include "core/os/keyboard.h"
-#include "editor/editor_node.h"
-#include "node_3d_editor_plugin.h"
+#include "editor/editor_settings.h"
+#include "editor/plugins/node_3d_editor_plugin.h"
 #include "scene/resources/curve.h"
 
 String Path3DGizmo::get_handle_name(int p_id, bool p_secondary) const {
@@ -379,7 +380,7 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_spatial_gui_input(Camera
 				}
 			}
 
-			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+			UndoRedo *ur = get_undo_redo();
 			if (closest_seg != -1) {
 				//subdivide
 
@@ -420,22 +421,20 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_spatial_gui_input(Camera
 
 				// Find the offset and point index of the place to break up.
 				// Also check for the control points.
+				UndoRedo *ur = get_undo_redo();
 				if (dist_to_p < click_dist) {
-					UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 					ur->create_action(TTR("Remove Path Point"));
 					ur->add_do_method(c.ptr(), "remove_point", i);
 					ur->add_undo_method(c.ptr(), "add_point", c->get_point_position(i), c->get_point_in(i), c->get_point_out(i), i);
 					ur->commit_action();
 					return EditorPlugin::AFTER_GUI_INPUT_STOP;
 				} else if (dist_to_p_out < click_dist) {
-					UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 					ur->create_action(TTR("Remove Out-Control Point"));
 					ur->add_do_method(c.ptr(), "set_point_out", i, Vector3());
 					ur->add_undo_method(c.ptr(), "set_point_out", i, c->get_point_out(i));
 					ur->commit_action();
 					return EditorPlugin::AFTER_GUI_INPUT_STOP;
 				} else if (dist_to_p_in < click_dist) {
-					UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
 					ur->create_action(TTR("Remove In-Control Point"));
 					ur->add_do_method(c.ptr(), "set_point_in", i, Vector3());
 					ur->add_undo_method(c.ptr(), "set_point_in", i, c->get_point_in(i));
@@ -514,7 +513,7 @@ void Path3DEditorPlugin::_close_curve() {
 	if (c->get_point_position(0) == c->get_point_position(c->get_point_count() - 1)) {
 		return;
 	}
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = get_undo_redo();
 	ur->create_action(TTR("Close Curve"));
 	ur->add_do_method(c.ptr(), "add_point", c->get_point_position(0), c->get_point_in(0), c->get_point_out(0), -1);
 	ur->add_undo_method(c.ptr(), "remove_point", c->get_point_count());

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -35,6 +35,7 @@
 #include "editor/plugins/node_3d_editor_gizmos.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/path_3d.h"
+#include "scene/gui/menu_button.h"
 #include "scene/gui/separator.h"
 
 class Path3DGizmo : public EditorNode3DGizmo {

--- a/editor/plugins/polygon_2d_editor_plugin.cpp
+++ b/editor/plugins/polygon_2d_editor_plugin.cpp
@@ -32,6 +32,7 @@
 
 #include "core/input/input_event.h"
 #include "core/math/geometry_2d.h"
+#include "core/object/undo_redo.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -35,8 +35,12 @@
 
 class HSlider;
 class Panel;
+class MenuButton;
 class ScrollContainer;
 class SpinBox;
+class HScrollBar;
+class VScrollBar;
+class TextureRect;
 class ViewPanner;
 
 class Polygon2DEditor : public AbstractPolygon2DEditor {

--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -35,8 +35,8 @@
 #include "core/input/input.h"
 #include "core/io/file_access.h"
 #include "core/math/geometry_2d.h"
+#include "core/object/undo_redo.h"
 #include "core/os/keyboard.h"
-#include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "node_3d_editor_plugin.h"
 #include "scene/3d/camera_3d.h"
@@ -524,9 +524,9 @@ void Polygon3DEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_polygon_draw"), &Polygon3DEditor::_polygon_draw);
 }
 
-Polygon3DEditor::Polygon3DEditor() {
+Polygon3DEditor::Polygon3DEditor(EditorPlugin *p_plugin) {
 	node = nullptr;
-	undo_redo = EditorNode::get_undo_redo();
+	undo_redo = p_plugin->get_undo_redo();
 
 	add_child(memnew(VSeparator));
 	button_create = memnew(Button);
@@ -561,7 +561,7 @@ Polygon3DEditor::Polygon3DEditor() {
 	handle_material->set_transparency(StandardMaterial3D::TRANSPARENCY_ALPHA);
 	handle_material->set_flag(StandardMaterial3D::FLAG_ALBEDO_FROM_VERTEX_COLOR, true);
 	handle_material->set_flag(StandardMaterial3D::FLAG_SRGB_VERTEX_COLOR, true);
-	Ref<Texture2D> handle = EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Editor3DHandle"), SNAME("EditorIcons"));
+	Ref<Texture2D> handle = p_plugin->get_editor_interface()->get_base_control()->get_theme_icon(SNAME("Editor3DHandle"), SNAME("EditorIcons"));
 	handle_material->set_point_size(handle->get_width());
 	handle_material->set_texture(StandardMaterial3D::TEXTURE_ALBEDO, handle);
 
@@ -596,7 +596,7 @@ void Polygon3DEditorPlugin::make_visible(bool p_visible) {
 }
 
 Polygon3DEditorPlugin::Polygon3DEditorPlugin() {
-	polygon_editor = memnew(Polygon3DEditor);
+	polygon_editor = memnew(Polygon3DEditor(this));
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(polygon_editor);
 
 	polygon_editor->hide();

--- a/editor/plugins/polygon_3d_editor_plugin.h
+++ b/editor/plugins/polygon_3d_editor_plugin.h
@@ -34,6 +34,8 @@
 #include "editor/editor_plugin.h"
 #include "scene/3d/collision_polygon_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/menu_button.h"
 #include "scene/resources/immediate_mesh.h"
 
 class CanvasItemEditor;
@@ -91,7 +93,7 @@ protected:
 public:
 	virtual EditorPlugin::AfterGUIInput forward_spatial_gui_input(Camera3D *p_camera, const Ref<InputEvent> &p_event);
 	void edit(Node *p_node);
-	Polygon3DEditor();
+	Polygon3DEditor(EditorPlugin *p_plugin);
 	~Polygon3DEditor();
 };
 

--- a/editor/plugins/replication_editor_plugin.h
+++ b/editor/plugins/replication_editor_plugin.h
@@ -32,16 +32,21 @@
 #define REPLICATION_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
+#include "scene/gui/box_container.h"
 #include "scene/resources/scene_replication_config.h"
 
 class ConfirmationDialog;
 class MultiplayerSynchronizer;
 class Tree;
+class AcceptDialog;
+class LineEdit;
 
 class ReplicationEditor : public VBoxContainer {
 	GDCLASS(ReplicationEditor, VBoxContainer);
 
 private:
+	EditorPlugin *plugin;
+
 	MultiplayerSynchronizer *current = nullptr;
 
 	AcceptDialog *error_dialog = nullptr;
@@ -76,7 +81,7 @@ public:
 	MultiplayerSynchronizer *get_current() const { return current; }
 	void property_keyed(const String &p_property);
 
-	ReplicationEditor();
+	ReplicationEditor(EditorPlugin *p_plugin);
 	~ReplicationEditor() {}
 };
 

--- a/editor/plugins/resource_preloader_editor_plugin.h
+++ b/editor/plugins/resource_preloader_editor_plugin.h
@@ -33,6 +33,7 @@
 
 #include "editor/editor_plugin.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/panel_container.h"
 #include "scene/gui/tree.h"
 #include "scene/main/resource_preloader.h"
 
@@ -46,6 +47,8 @@ class ResourcePreloaderEditor : public PanelContainer {
 		BUTTON_EDIT_RESOURCE,
 		BUTTON_REMOVE
 	};
+
+	EditorPlugin *plugin = nullptr;
 
 	Button *load = nullptr;
 	Button *paste = nullptr;
@@ -66,8 +69,6 @@ class ResourcePreloaderEditor : public PanelContainer {
 	void _cell_button_pressed(Object *p_item, int p_column, int p_id);
 	void _item_edited();
 
-	UndoRedo *undo_redo = nullptr;
-
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
@@ -78,10 +79,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_undo_redo(UndoRedo *p_undo_redo) { undo_redo = p_undo_redo; }
-
 	void edit(ResourcePreloader *p_preloader);
-	ResourcePreloaderEditor();
+	ResourcePreloaderEditor(EditorPlugin *p_plugin);
 };
 
 class ResourcePreloaderEditorPlugin : public EditorPlugin {

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -35,7 +35,6 @@
 #include "editor/code_editor.h"
 #include "editor/editor_help.h"
 #include "editor/editor_help_search.h"
-#include "editor/editor_plugin.h"
 #include "editor/script_create_dialog.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/line_edit.h"
@@ -43,6 +42,7 @@
 #include "scene/gui/split_container.h"
 #include "scene/gui/tab_container.h"
 #include "scene/gui/text_edit.h"
+#include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
 #include "scene/main/timer.h"
 #include "scene/resources/text_file.h"
@@ -241,6 +241,7 @@ class ScriptEditor : public PanelContainer {
 		DISPLAY_DIR_AND_NAME,
 		DISPLAY_FULL_PATH,
 	};
+	EditorPlugin *plugin = nullptr;
 
 	HBoxContainer *menu_hb = nullptr;
 	MenuButton *file_menu = nullptr;
@@ -522,7 +523,7 @@ public:
 
 	static void register_create_script_editor_function(CreateScriptEditorFunc p_func);
 
-	ScriptEditor();
+	ScriptEditor(EditorPlugin *p_plugin);
 	~ScriptEditor();
 };
 

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -51,6 +51,8 @@ class ShaderTextEditor : public CodeTextEditor {
 		_ALWAYS_INLINE_ bool operator()(const ShaderWarning &p_a, const ShaderWarning &p_b) const { return (p_a.get_line() < p_b.get_line()); }
 	};
 
+	EditorPlugin *plugin;
+
 	Ref<CodeHighlighter> syntax_highlighter;
 	RichTextLabel *warnings_panel = nullptr;
 	Ref<Shader> shader;
@@ -75,7 +77,7 @@ public:
 
 	Ref<Shader> get_edited_shader() const;
 	void set_edited_shader(const Ref<Shader> &p_shader);
-	ShaderTextEditor();
+	ShaderTextEditor(EditorPlugin *p_plugin);
 };
 
 class ShaderEditor : public PanelContainer {
@@ -154,7 +156,7 @@ public:
 	virtual Size2 get_minimum_size() const override { return Size2(0, 200); }
 	void save_external_data(const String &p_str = "");
 
-	ShaderEditor();
+	ShaderEditor(EditorPlugin *p_plugin);
 };
 
 class ShaderEditorPlugin : public EditorPlugin {

--- a/editor/plugins/shader_file_editor_plugin.cpp
+++ b/editor/plugins/shader_file_editor_plugin.cpp
@@ -34,10 +34,10 @@
 #include "core/io/resource_saver.h"
 #include "core/os/keyboard.h"
 #include "core/os/os.h"
-#include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/property_editor.h"
+#include "scene/gui/item_list.h"
 #include "servers/display_server.h"
 #include "servers/rendering/shader_types.h"
 
@@ -303,12 +303,12 @@ bool ShaderFileEditorPlugin::handles(Object *p_object) const {
 void ShaderFileEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		button->show();
-		EditorNode::get_singleton()->make_bottom_panel_item_visible(shader_editor);
+		make_bottom_panel_item_visible(shader_editor);
 
 	} else {
 		button->hide();
 		if (shader_editor->is_visible_in_tree()) {
-			EditorNode::get_singleton()->hide_bottom_panel();
+			hide_bottom_panel();
 		}
 	}
 }
@@ -317,7 +317,7 @@ ShaderFileEditorPlugin::ShaderFileEditorPlugin() {
 	shader_editor = memnew(ShaderFileEditor);
 
 	shader_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
-	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("ShaderFile"), shader_editor);
+	button = add_control_to_bottom_panel(shader_editor, TTR("ShaderFile"));
 	button->hide();
 }
 

--- a/editor/plugins/skeleton_2d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_2d_editor_plugin.cpp
@@ -30,8 +30,8 @@
 
 #include "skeleton_2d_editor_plugin.h"
 
-#include "canvas_item_editor_plugin.h"
-#include "editor/editor_node.h"
+#include "core/object/undo_redo.h"
+#include "editor/plugins/canvas_item_editor_plugin.h"
 #include "scene/2d/mesh_instance_2d.h"
 #include "scene/gui/box_container.h"
 #include "thirdparty/misc/clipper.hpp"
@@ -59,7 +59,7 @@ void Skeleton2DEditor::_menu_option(int p_option) {
 				err_dialog->popup_centered();
 				return;
 			}
-			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+			UndoRedo *ur = plugin->get_undo_redo();
 			ur->create_action(TTR("Set Rest Pose to Bones"));
 			for (int i = 0; i < node->get_bone_count(); i++) {
 				Bone2D *bone = node->get_bone(i);
@@ -75,7 +75,7 @@ void Skeleton2DEditor::_menu_option(int p_option) {
 				err_dialog->popup_centered();
 				return;
 			}
-			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+			UndoRedo *ur = plugin->get_undo_redo();
 			ur->create_action(TTR("Create Rest Pose from Bones"));
 			for (int i = 0; i < node->get_bone_count(); i++) {
 				Bone2D *bone = node->get_bone(i);
@@ -91,13 +91,14 @@ void Skeleton2DEditor::_menu_option(int p_option) {
 void Skeleton2DEditor::_bind_methods() {
 }
 
-Skeleton2DEditor::Skeleton2DEditor() {
+Skeleton2DEditor::Skeleton2DEditor(EditorPlugin *p_plugin) {
+	plugin = p_plugin;
 	options = memnew(MenuButton);
 
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(options);
 
 	options->set_text(TTR("Skeleton2D"));
-	options->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Skeleton2D"), SNAME("EditorIcons")));
+	options->set_icon(plugin->get_editor_interface()->get_base_control()->get_theme_icon(SNAME("Skeleton2D"), SNAME("EditorIcons")));
 
 	options->get_popup()->add_item(TTR("Reset to Rest Pose"), MENU_OPTION_SET_REST);
 	options->get_popup()->add_separator();
@@ -129,8 +130,8 @@ void Skeleton2DEditorPlugin::make_visible(bool p_visible) {
 }
 
 Skeleton2DEditorPlugin::Skeleton2DEditorPlugin() {
-	sprite_editor = memnew(Skeleton2DEditor);
-	EditorNode::get_singleton()->get_main_control()->add_child(sprite_editor);
+	sprite_editor = memnew(Skeleton2DEditor(this));
+	get_editor_interface()->get_editor_main_control()->add_child(sprite_editor);
 	make_visible(false);
 
 	//sprite_editor->options->hide();

--- a/editor/plugins/skeleton_2d_editor_plugin.h
+++ b/editor/plugins/skeleton_2d_editor_plugin.h
@@ -33,6 +33,8 @@
 
 #include "editor/editor_plugin.h"
 #include "scene/2d/skeleton_2d.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/menu_button.h"
 #include "scene/gui/spin_box.h"
 
 class Skeleton2DEditor : public Control {
@@ -43,6 +45,7 @@ class Skeleton2DEditor : public Control {
 		MENU_OPTION_MAKE_REST,
 	};
 
+	EditorPlugin *plugin = nullptr;
 	Skeleton2D *node = nullptr;
 
 	MenuButton *options = nullptr;
@@ -59,7 +62,7 @@ protected:
 
 public:
 	void edit(Skeleton2D *p_sprite);
-	Skeleton2DEditor();
+	Skeleton2DEditor(EditorPlugin *p_plugin);
 };
 
 class Skeleton2DEditorPlugin : public EditorPlugin {

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -61,9 +61,8 @@ class BoneTransformEditor : public VBoxContainer {
 	Rect2 background_rects[5];
 
 	Skeleton3D *skeleton = nullptr;
+	EditorPlugin *plugin = nullptr;
 	// String property;
-
-	UndoRedo *undo_redo = nullptr;
 
 	bool toggle_enabled = false;
 	bool updating = false;
@@ -80,7 +79,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	BoneTransformEditor(Skeleton3D *p_skeleton);
+	BoneTransformEditor(Skeleton3D *p_skeleton, EditorPlugin *p_plugin);
 
 	// Which transform target to modify.
 	void set_target(const String &p_prop);
@@ -108,7 +107,9 @@ class Skeleton3DEditor : public VBoxContainer {
 		Transform3D relative_rest; // Relative to skeleton node.
 	};
 
-	EditorInspectorPluginSkeleton *editor_plugin = nullptr;
+	EditorPlugin *plugin = nullptr;
+
+	EditorInspectorPluginSkeleton *inspector_plugin = nullptr;
 
 	Skeleton3D *skeleton = nullptr;
 
@@ -211,7 +212,7 @@ public:
 	Quaternion get_bone_original_rotation() const { return bone_original_rotation; };
 	Vector3 get_bone_original_scale() const { return bone_original_scale; };
 
-	Skeleton3DEditor(EditorInspectorPluginSkeleton *e_plugin, Skeleton3D *skeleton);
+	Skeleton3DEditor(EditorInspectorPluginSkeleton *p_inspector_plugin, EditorPlugin *p_plugin, Skeleton3D *skeleton);
 	~Skeleton3DEditor();
 };
 
@@ -221,10 +222,13 @@ class EditorInspectorPluginSkeleton : public EditorInspectorPlugin {
 	friend class Skeleton3DEditorPlugin;
 
 	Skeleton3DEditor *skel_editor = nullptr;
+	EditorPlugin *plugin = nullptr;
 
 public:
 	virtual bool can_handle(Object *p_object) override;
 	virtual void parse_begin(Object *p_object) override;
+
+	EditorInspectorPluginSkeleton(EditorPlugin *p_plugin);
 };
 
 class Skeleton3DEditorPlugin : public EditorPlugin {

--- a/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_ik_3d_editor_plugin.cpp
@@ -30,8 +30,8 @@
 
 #include "skeleton_ik_3d_editor_plugin.h"
 
-#include "editor/editor_node.h"
 #include "scene/3d/skeleton_ik_3d.h"
+#include "scene/gui/button.h"
 
 void SkeletonIK3DEditorPlugin::_play() {
 	if (!skeleton_ik) {
@@ -83,7 +83,7 @@ void SkeletonIK3DEditorPlugin::_bind_methods() {
 
 SkeletonIK3DEditorPlugin::SkeletonIK3DEditorPlugin() {
 	play_btn = memnew(Button);
-	play_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
+	play_btn->set_icon(get_editor_interface()->get_base_control()->get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
 	play_btn->set_text(TTR("Play IK"));
 	play_btn->set_toggle_mode(true);
 	play_btn->hide();

--- a/editor/plugins/sprite_2d_editor_plugin.cpp
+++ b/editor/plugins/sprite_2d_editor_plugin.cpp
@@ -32,7 +32,6 @@
 
 #include "canvas_item_editor_plugin.h"
 #include "core/math/geometry_2d.h"
-#include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 #include "editor/scene_tree_dock.h"
 #include "scene/2d/collision_polygon_2d.h"
@@ -337,7 +336,7 @@ void Sprite2DEditor::_convert_to_mesh_2d_node() {
 	MeshInstance2D *mesh_instance = memnew(MeshInstance2D);
 	mesh_instance->set_mesh(mesh);
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Convert to MeshInstance2D"));
 	ur->add_do_method(SceneTreeDock::get_singleton(), "replace_node", node, mesh_instance, true, false);
 	ur->add_do_reference(mesh_instance);
@@ -395,7 +394,7 @@ void Sprite2DEditor::_convert_to_polygon_2d_node() {
 	polygon_2d_instance->set_polygon(polygon);
 	polygon_2d_instance->set_polygons(polys);
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Convert to Polygon2D"));
 	ur->add_do_method(SceneTreeDock::get_singleton(), "replace_node", node, polygon_2d_instance, true, false);
 	ur->add_do_reference(polygon_2d_instance);
@@ -417,7 +416,7 @@ void Sprite2DEditor::_create_collision_polygon_2d_node() {
 		CollisionPolygon2D *collision_polygon_2d_instance = memnew(CollisionPolygon2D);
 		collision_polygon_2d_instance->set_polygon(outline);
 
-		UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+		UndoRedo *ur = plugin->get_undo_redo();
 		ur->create_action(TTR("Create CollisionPolygon2D Sibling"));
 		ur->add_do_method(this, "_add_as_sibling_or_child", node, collision_polygon_2d_instance);
 		ur->add_do_reference(collision_polygon_2d_instance);
@@ -450,7 +449,7 @@ void Sprite2DEditor::_create_light_occluder_2d_node() {
 		LightOccluder2D *light_occluder_2d_instance = memnew(LightOccluder2D);
 		light_occluder_2d_instance->set_occluder_polygon(polygon);
 
-		UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+		UndoRedo *ur = plugin->get_undo_redo();
 		ur->create_action(TTR("Create LightOccluder2D Sibling"));
 		ur->add_do_method(this, "_add_as_sibling_or_child", node, light_occluder_2d_instance);
 		ur->add_do_reference(light_occluder_2d_instance);
@@ -516,7 +515,8 @@ void Sprite2DEditor::_bind_methods() {
 	ClassDB::bind_method("_add_as_sibling_or_child", &Sprite2DEditor::_add_as_sibling_or_child);
 }
 
-Sprite2DEditor::Sprite2DEditor() {
+Sprite2DEditor::Sprite2DEditor(EditorPlugin *p_plugin) {
+	plugin = p_plugin;
 	options = memnew(MenuButton);
 
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(options);
@@ -597,8 +597,8 @@ void Sprite2DEditorPlugin::make_visible(bool p_visible) {
 }
 
 Sprite2DEditorPlugin::Sprite2DEditorPlugin() {
-	sprite_editor = memnew(Sprite2DEditor);
-	EditorNode::get_singleton()->get_main_control()->add_child(sprite_editor);
+	sprite_editor = memnew(Sprite2DEditor(this));
+	get_editor_interface()->get_editor_main_control()->add_child(sprite_editor);
 	make_visible(false);
 
 	//sprite_editor->options->hide();

--- a/editor/plugins/sprite_2d_editor_plugin.h
+++ b/editor/plugins/sprite_2d_editor_plugin.h
@@ -33,6 +33,8 @@
 
 #include "editor/editor_plugin.h"
 #include "scene/2d/sprite_2d.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/menu_button.h"
 #include "scene/gui/spin_box.h"
 
 class Sprite2DEditor : public Control {
@@ -44,6 +46,8 @@ class Sprite2DEditor : public Control {
 		MENU_OPTION_CREATE_COLLISION_POLY_2D,
 		MENU_OPTION_CREATE_LIGHT_OCCLUDER_2D
 	};
+
+	EditorPlugin *plugin;
 
 	Menu selected_menu_item;
 
@@ -92,7 +96,7 @@ protected:
 
 public:
 	void edit(Sprite2D *p_sprite);
-	Sprite2DEditor();
+	Sprite2DEditor(EditorPlugin *p_plugin);
 };
 
 class Sprite2DEditorPlugin : public EditorPlugin {

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -228,6 +228,7 @@ void SpriteFramesEditor::_sheet_add_frames() {
 	int frame_count_y = split_sheet_v->get_value();
 	Size2 frame_size(texture_size.width / frame_count_x, texture_size.height / frame_count_y);
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Add Frame"));
 
 	int fc = frames->get_frame_count(edited_anim);
@@ -376,6 +377,7 @@ void SpriteFramesEditor::_file_load_request(const Vector<String> &p_path, int p_
 		return;
 	}
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Add Frame"));
 	int fc = frames->get_frame_count(edited_anim);
 
@@ -420,6 +422,7 @@ void SpriteFramesEditor::_paste_pressed() {
 		return; ///beh should show an error i guess
 	}
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Paste Frame"));
 	undo_redo->add_do_method(frames, "add_frame", edited_anim, r);
 	undo_redo->add_undo_method(frames, "remove_frame", edited_anim, frames->get_frame_count(edited_anim));
@@ -457,6 +460,7 @@ void SpriteFramesEditor::_empty_pressed() {
 
 	Ref<Texture2D> r;
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Add Empty"));
 	undo_redo->add_do_method(frames, "add_frame", edited_anim, r, from);
 	undo_redo->add_undo_method(frames, "remove_frame", edited_anim, from);
@@ -480,6 +484,7 @@ void SpriteFramesEditor::_empty2_pressed() {
 
 	Ref<Texture2D> r;
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Add Empty"));
 	undo_redo->add_do_method(frames, "add_frame", edited_anim, r, from + 1);
 	undo_redo->add_undo_method(frames, "remove_frame", edited_anim, from + 1);
@@ -503,6 +508,7 @@ void SpriteFramesEditor::_up_pressed() {
 	sel = to_move;
 	sel -= 1;
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Delete Resource"));
 	undo_redo->add_do_method(frames, "set_frame", edited_anim, to_move, frames->get_frame(edited_anim, to_move - 1));
 	undo_redo->add_do_method(frames, "set_frame", edited_anim, to_move - 1, frames->get_frame(edited_anim, to_move));
@@ -528,6 +534,7 @@ void SpriteFramesEditor::_down_pressed() {
 	sel = to_move;
 	sel += 1;
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Delete Resource"));
 	undo_redo->add_do_method(frames, "set_frame", edited_anim, to_move, frames->get_frame(edited_anim, to_move + 1));
 	undo_redo->add_do_method(frames, "set_frame", edited_anim, to_move + 1, frames->get_frame(edited_anim, to_move));
@@ -550,6 +557,7 @@ void SpriteFramesEditor::_delete_pressed() {
 		return;
 	}
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Delete Resource"));
 	undo_redo->add_do_method(frames, "remove_frame", edited_anim, to_delete);
 	undo_redo->add_undo_method(frames, "add_frame", edited_anim, frames->get_frame(edited_anim, to_delete), to_delete);
@@ -634,8 +642,9 @@ void SpriteFramesEditor::_animation_name_edited() {
 	}
 
 	List<Node *> nodes;
-	_find_anim_sprites(EditorNode::get_singleton()->get_edited_scene(), &nodes, Ref<SpriteFrames>(frames));
+	_find_anim_sprites(plugin->get_editor_interface()->get_edited_scene_root(), &nodes, Ref<SpriteFrames>(frames));
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Rename Animation"));
 	undo_redo->add_do_method(frames, "rename_animation", edited_anim, name);
 	undo_redo->add_undo_method(frames, "rename_animation", name, edited_anim);
@@ -663,8 +672,9 @@ void SpriteFramesEditor::_animation_add() {
 	}
 
 	List<Node *> nodes;
-	_find_anim_sprites(EditorNode::get_singleton()->get_edited_scene(), &nodes, Ref<SpriteFrames>(frames));
+	_find_anim_sprites(plugin->get_editor_interface()->get_edited_scene_root(), &nodes, Ref<SpriteFrames>(frames));
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Add Animation"));
 	undo_redo->add_do_method(frames, "add_animation", name);
 	undo_redo->add_undo_method(frames, "remove_animation", name);
@@ -697,6 +707,7 @@ void SpriteFramesEditor::_animation_remove() {
 }
 
 void SpriteFramesEditor::_animation_remove_confirmed() {
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Remove Animation"));
 	undo_redo->add_do_method(frames, "remove_animation", edited_anim);
 	undo_redo->add_undo_method(frames, "add_animation", edited_anim);
@@ -720,6 +731,7 @@ void SpriteFramesEditor::_animation_loop_changed() {
 		return;
 	}
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Change Animation Loop"));
 	undo_redo->add_do_method(frames, "set_animation_loop", edited_anim, anim_loop->is_pressed());
 	undo_redo->add_undo_method(frames, "set_animation_loop", edited_anim, frames->get_animation_loop(edited_anim));
@@ -733,6 +745,7 @@ void SpriteFramesEditor::_animation_fps_changed(double p_value) {
 		return;
 	}
 
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Change Animation FPS"), UndoRedo::MERGE_ENDS);
 	undo_redo->add_do_method(frames, "set_animation_speed", edited_anim, p_value);
 	undo_redo->add_undo_method(frames, "set_animation_speed", edited_anim, frames->get_animation_speed(edited_anim));
@@ -989,6 +1002,7 @@ void SpriteFramesEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 				reorder = true;
 			}
 
+			UndoRedo *undo_redo = plugin->get_undo_redo();
 			if (reorder) { //drop is from reordering frames
 				int from_frame = -1;
 				if (d.has("frame")) {
@@ -1032,7 +1046,8 @@ void SpriteFramesEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_drop_data_fw"), &SpriteFramesEditor::drop_data_fw);
 }
 
-SpriteFramesEditor::SpriteFramesEditor() {
+SpriteFramesEditor::SpriteFramesEditor(EditorPlugin *p_plugin) {
+	plugin = p_plugin;
 	VBoxContainer *vbc_animlist = memnew(VBoxContainer);
 	add_child(vbc_animlist);
 	vbc_animlist->set_custom_minimum_size(Size2(150, 0) * EDSCALE);
@@ -1307,8 +1322,6 @@ SpriteFramesEditor::SpriteFramesEditor() {
 }
 
 void SpriteFramesEditorPlugin::edit(Object *p_object) {
-	frames_editor->set_undo_redo(&get_undo_redo());
-
 	SpriteFrames *s;
 	AnimatedSprite2D *animated_sprite = Object::cast_to<AnimatedSprite2D>(p_object);
 	if (animated_sprite) {
@@ -1340,19 +1353,19 @@ bool SpriteFramesEditorPlugin::handles(Object *p_object) const {
 void SpriteFramesEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		button->show();
-		EditorNode::get_singleton()->make_bottom_panel_item_visible(frames_editor);
+		make_bottom_panel_item_visible(frames_editor);
 	} else {
 		button->hide();
 		if (frames_editor->is_visible_in_tree()) {
-			EditorNode::get_singleton()->hide_bottom_panel();
+			hide_bottom_panel();
 		}
 	}
 }
 
 SpriteFramesEditorPlugin::SpriteFramesEditorPlugin() {
-	frames_editor = memnew(SpriteFramesEditor);
+	frames_editor = memnew(SpriteFramesEditor(this));
 	frames_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
-	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("SpriteFrames"), frames_editor);
+	button = add_control_to_bottom_panel(frames_editor, TTR("SpriteFrames"));
 	button->hide();
 }
 

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -48,6 +48,8 @@ class EditorFileDialog;
 class SpriteFramesEditor : public HSplitContainer {
 	GDCLASS(SpriteFramesEditor, HSplitContainer);
 
+	EditorPlugin *plugin;
+
 	Button *load = nullptr;
 	Button *load_sheet = nullptr;
 	Button *_delete = nullptr;
@@ -129,8 +131,6 @@ class SpriteFramesEditor : public HSplitContainer {
 
 	bool updating;
 
-	UndoRedo *undo_redo = nullptr;
-
 	Variant get_drag_data_fw(const Point2 &p_point, Control *p_from);
 	bool can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
 	void drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
@@ -155,10 +155,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void set_undo_redo(UndoRedo *p_undo_redo) { undo_redo = p_undo_redo; }
-
 	void edit(SpriteFrames *p_frames);
-	SpriteFramesEditor();
+	SpriteFramesEditor(EditorPlugin *p_plugin);
 };
 
 class SpriteFramesEditorPlugin : public EditorPlugin {

--- a/editor/plugins/sub_viewport_preview_editor_plugin.h
+++ b/editor/plugins/sub_viewport_preview_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef SUB_VIEWPORT_PREVIEW_EDITOR_PLUGIN_H
 #define SUB_VIEWPORT_PREVIEW_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "editor/plugins/texture_editor_plugin.h"
 #include "scene/main/viewport.h"

--- a/editor/plugins/text_control_editor_plugin.cpp
+++ b/editor/plugins/text_control_editor_plugin.cpp
@@ -285,7 +285,7 @@ void TextControlEditor::_set_font() {
 		return;
 	}
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Set Font"));
 
 	int count = edited_controls.size();
@@ -341,7 +341,7 @@ void TextControlEditor::_font_size_selected(double p_size) {
 		return;
 	}
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Set Font Size"));
 
 	int count = edited_controls.size();
@@ -374,7 +374,7 @@ void TextControlEditor::_outline_size_selected(double p_size) {
 		return;
 	}
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Set Font Outline Size"));
 
 	int count = edited_controls.size();
@@ -400,7 +400,7 @@ void TextControlEditor::_font_color_changed(const Color &p_color) {
 		return;
 	}
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Set Font Color"), UndoRedo::MERGE_ENDS);
 
 	int count = edited_controls.size();
@@ -433,7 +433,7 @@ void TextControlEditor::_outline_color_changed(const Color &p_color) {
 		return;
 	}
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Set Font Outline Color"), UndoRedo::MERGE_ENDS);
 
 	int count = edited_controls.size();
@@ -459,7 +459,7 @@ void TextControlEditor::_clear_formatting() {
 		return;
 	}
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Clear Control Formatting"));
 
 	int count = edited_controls.size();
@@ -530,7 +530,8 @@ void TextControlEditor::edit(Object *p_object) {
 		_update_control();
 	} else if (multi_node && handles(multi_node)) {
 		int count = multi_node->get_node_count();
-		Node *scene = EditorNode::get_singleton()->get_edited_scene();
+
+		Node *scene = plugin->get_editor_interface()->get_edited_scene_root();
 
 		for (int i = 0; i < count; ++i) {
 			Control *child = Object::cast_to<Control>(scene->get_node(multi_node->get_node(i)));
@@ -572,7 +573,8 @@ bool TextControlEditor::handles(Object *p_object) const {
 	}
 }
 
-TextControlEditor::TextControlEditor() {
+TextControlEditor::TextControlEditor(EditorPlugin *p_plugin) {
+	plugin = p_plugin;
 	add_child(memnew(VSeparator));
 
 	font_list = memnew(OptionButton);
@@ -653,7 +655,7 @@ void TextControlEditorPlugin::make_visible(bool p_visible) {
 }
 
 TextControlEditorPlugin::TextControlEditorPlugin() {
-	text_ctl_editor = memnew(TextControlEditor);
+	text_ctl_editor = memnew(TextControlEditor(this));
 	CanvasItemEditor::get_singleton()->add_control_to_menu_panel(text_ctl_editor);
 
 	text_ctl_editor->hide();

--- a/editor/plugins/text_control_editor_plugin.h
+++ b/editor/plugins/text_control_editor_plugin.h
@@ -52,6 +52,8 @@ class TextControlEditor : public HBoxContainer {
 		FONT_INFO_ID = 100,
 	};
 
+	EditorPlugin *plugin;
+
 	Map<String, Map<String, String>> fonts;
 
 	OptionButton *font_list = nullptr;
@@ -92,7 +94,7 @@ public:
 	void edit(Object *p_object);
 	bool handles(Object *p_object) const;
 
-	TextControlEditor();
+	TextControlEditor(EditorPlugin *p_plugin);
 };
 
 /*************************************************************************/

--- a/editor/plugins/texture_3d_editor_plugin.h
+++ b/editor/plugins/texture_3d_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef TEXTURE_3D_EDITOR_PLUGIN_H
 #define TEXTURE_3D_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "scene/gui/spin_box.h"
 #include "scene/resources/shader.h"

--- a/editor/plugins/texture_editor_plugin.h
+++ b/editor/plugins/texture_editor_plugin.h
@@ -31,7 +31,10 @@
 #ifndef TEXTURE_EDITOR_PLUGIN_H
 #define TEXTURE_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
+#include "scene/gui/margin_container.h"
+#include "scene/gui/texture_rect.h"
 #include "scene/resources/texture.h"
 
 class TexturePreview : public MarginContainer {

--- a/editor/plugins/texture_layered_editor_plugin.h
+++ b/editor/plugins/texture_layered_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef TEXTURE_LAYERED_EDITOR_PLUGIN_H
 #define TEXTURE_LAYERED_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "scene/gui/spin_box.h"
 #include "scene/resources/shader.h"

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -35,7 +35,9 @@
 #include "editor/editor_plugin.h"
 #include "scene/2d/sprite_2d.h"
 #include "scene/3d/sprite_3d.h"
+#include "scene/gui/box_container.h"
 #include "scene/gui/nine_patch_rect.h"
+#include "scene/gui/option_button.h"
 #include "scene/resources/style_box.h"
 #include "scene/resources/texture.h"
 
@@ -52,6 +54,9 @@ class TextureRegionEditor : public VBoxContainer {
 	};
 
 	friend class TextureRegionEditorPlugin;
+
+	EditorPlugin *plugin = nullptr;
+
 	OptionButton *snap_mode_button = nullptr;
 	Button *zoom_in = nullptr;
 	Button *zoom_reset = nullptr;
@@ -67,8 +72,6 @@ class TextureRegionEditor : public VBoxContainer {
 
 	VScrollBar *vscroll = nullptr;
 	HScrollBar *hscroll = nullptr;
-
-	UndoRedo *undo_redo = nullptr;
 
 	Vector2 draw_ofs;
 	float draw_zoom;
@@ -99,6 +102,9 @@ class TextureRegionEditor : public VBoxContainer {
 	int drag_index;
 
 	Ref<ViewPanner> panner;
+
+	void _draw_margin_line(Control *edit_draw, Vector2 from, Vector2 to);
+
 	void _scroll_callback(Vector2 p_scroll_vec, bool p_alt);
 	void _pan_callback(Vector2 p_scroll_vec);
 	void _zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt);
@@ -139,7 +145,7 @@ public:
 	Sprite3D *get_sprite_3d();
 
 	void edit(Object *p_obj);
-	TextureRegionEditor();
+	TextureRegionEditor(EditorPlugin *p_plugin);
 };
 
 class TextureRegionEditorPlugin : public EditorPlugin {

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -787,7 +787,7 @@ void ThemeItemImportTree::_import_selected() {
 
 	ProgressDialog::get_singleton()->end_task("import_theme_items");
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Import Theme Items"));
 
 	ur->add_do_method(*edited_theme, "clear");
@@ -880,7 +880,9 @@ void ThemeItemImportTree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("items_imported"));
 }
 
-ThemeItemImportTree::ThemeItemImportTree() {
+ThemeItemImportTree::ThemeItemImportTree(EditorPlugin *p_plugin) {
+	plugin = p_plugin;
+
 	HBoxContainer *import_items_filter_hb = memnew(HBoxContainer);
 	add_child(import_items_filter_hb);
 	Label *import_items_filter_label = memnew(Label);
@@ -1478,7 +1480,7 @@ void ThemeItemEditorDialog::_item_tree_button_pressed(Object *p_item, int p_colu
 			String item_name = item->get_text(0);
 			int data_type = item->get_parent()->get_metadata(0);
 
-			UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+			UndoRedo *ur = plugin->get_undo_redo();
 			ur->create_action(TTR("Remove Theme Item"));
 			ur->add_do_method(*edited_theme, "clear_theme_item", (Theme::DataType)data_type, item_name, edited_item_type);
 			ur->add_undo_method(*edited_theme, "set_theme_item", (Theme::DataType)data_type, item_name, edited_item_type, edited_theme->get_theme_item((Theme::DataType)data_type, item_name, edited_item_type));
@@ -1497,7 +1499,7 @@ void ThemeItemEditorDialog::_add_theme_type(const String &p_new_text) {
 	const String new_type = edit_add_type_value->get_text().strip_edges();
 	edit_add_type_value->clear();
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Add Theme Type"));
 
 	ur->add_do_method(*edited_theme, "add_type", new_type);
@@ -1509,7 +1511,7 @@ void ThemeItemEditorDialog::_add_theme_type(const String &p_new_text) {
 }
 
 void ThemeItemEditorDialog::_add_theme_item(Theme::DataType p_data_type, String p_item_name, String p_item_type) {
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Create Theme Item"));
 
 	switch (p_data_type) {
@@ -1554,7 +1556,7 @@ void ThemeItemEditorDialog::_remove_theme_type(const String &p_theme_type) {
 	Ref<Theme> old_snapshot = edited_theme->duplicate();
 	Ref<Theme> new_snapshot = edited_theme->duplicate();
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Remove Theme Type"));
 
 	new_snapshot->remove_type(p_theme_type);
@@ -1577,7 +1579,7 @@ void ThemeItemEditorDialog::_remove_data_type_items(Theme::DataType p_data_type,
 	Ref<Theme> old_snapshot = edited_theme->duplicate();
 	Ref<Theme> new_snapshot = edited_theme->duplicate();
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Remove Data Type Items From Theme"));
 
 	new_snapshot->get_theme_item_list(p_data_type, p_item_type, &names);
@@ -1606,7 +1608,7 @@ void ThemeItemEditorDialog::_remove_class_items() {
 	Ref<Theme> old_snapshot = edited_theme->duplicate();
 	Ref<Theme> new_snapshot = edited_theme->duplicate();
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Remove Class Items From Theme"));
 
 	for (int dt = 0; dt < Theme::DATA_TYPE_MAX; dt++) {
@@ -1642,7 +1644,7 @@ void ThemeItemEditorDialog::_remove_custom_items() {
 	Ref<Theme> old_snapshot = edited_theme->duplicate();
 	Ref<Theme> new_snapshot = edited_theme->duplicate();
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Remove Custom Items From Theme"));
 
 	for (int dt = 0; dt < Theme::DATA_TYPE_MAX; dt++) {
@@ -1678,7 +1680,7 @@ void ThemeItemEditorDialog::_remove_all_items() {
 	Ref<Theme> old_snapshot = edited_theme->duplicate();
 	Ref<Theme> new_snapshot = edited_theme->duplicate();
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Remove All Items From Theme"));
 
 	for (int dt = 0; dt < Theme::DATA_TYPE_MAX; dt++) {
@@ -1782,7 +1784,7 @@ void ThemeItemEditorDialog::_confirm_edit_theme_item() {
 	if (item_popup_mode == CREATE_THEME_ITEM) {
 		_add_theme_item(edit_item_data_type, theme_item_name->get_text(), edited_item_type);
 	} else if (item_popup_mode == RENAME_THEME_ITEM) {
-		UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+		UndoRedo *ur = plugin->get_undo_redo();
 		ur->create_action(TTR("Rename Theme Item"));
 
 		ur->add_do_method(*edited_theme, "rename_theme_item", edit_item_data_type, edit_item_old_name, theme_item_name->get_text(), edited_item_type);
@@ -1879,11 +1881,12 @@ void ThemeItemEditorDialog::set_edited_theme(const Ref<Theme> &p_theme) {
 	edited_theme = p_theme;
 }
 
-ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_editor) {
+ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_editor, EditorPlugin *p_plugin) {
 	set_title(TTR("Manage Theme Items"));
 	get_ok_button()->set_text(TTR("Close"));
 	set_hide_on_ok(false); // Closing may require a confirmation in some cases.
 
+	plugin = p_plugin;
 	theme_type_editor = p_theme_type_editor;
 
 	tc = memnew(TabContainer);
@@ -2049,12 +2052,12 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 	tc->add_child(import_tc);
 	tc->set_tab_title(1, TTR("Import Items"));
 
-	import_default_theme_items = memnew(ThemeItemImportTree);
+	import_default_theme_items = memnew(ThemeItemImportTree(plugin));
 	import_tc->add_child(import_default_theme_items);
 	import_tc->set_tab_title(0, TTR("Default Theme"));
 	import_default_theme_items->connect("items_imported", callable_mp(this, &ThemeItemEditorDialog::_update_edit_types));
 
-	import_editor_theme_items = memnew(ThemeItemImportTree);
+	import_editor_theme_items = memnew(ThemeItemImportTree(plugin));
 	import_tc->add_child(import_editor_theme_items);
 	import_tc->set_tab_title(1, TTR("Editor Theme"));
 	import_editor_theme_items->connect("items_imported", callable_mp(this, &ThemeItemEditorDialog::_update_edit_types));
@@ -2082,7 +2085,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 	import_another_file_hb->add_child(import_another_theme_dialog);
 	import_another_theme_dialog->connect("file_selected", callable_mp(this, &ThemeItemEditorDialog::_select_another_theme_cbk));
 
-	import_other_theme_items = memnew(ThemeItemImportTree);
+	import_other_theme_items = memnew(ThemeItemImportTree(plugin));
 	import_other_theme_items->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	import_another_theme_vb->add_child(import_other_theme_items);
 
@@ -2804,7 +2807,7 @@ void ThemeTypeEditor::_add_default_type_items() {
 
 	updating = false;
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Override All Default Theme Items"));
 
 	ur->add_do_method(*edited_theme, "merge_with", new_snapshot);
@@ -2824,7 +2827,7 @@ void ThemeTypeEditor::_item_add_cbk(int p_data_type, Control *p_control) {
 	}
 
 	String item_name = le->get_text().strip_edges();
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Add Theme Item"));
 
 	switch (p_data_type) {
@@ -2869,7 +2872,7 @@ void ThemeTypeEditor::_item_add_lineedit_cbk(String p_value, int p_data_type, Co
 }
 
 void ThemeTypeEditor::_item_override_cbk(int p_data_type, String p_item_name) {
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Override Theme Item"));
 
 	switch (p_data_type) {
@@ -2908,7 +2911,7 @@ void ThemeTypeEditor::_item_override_cbk(int p_data_type, String p_item_name) {
 }
 
 void ThemeTypeEditor::_item_remove_cbk(int p_data_type, String p_item_name) {
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Remove Theme Item"));
 
 	switch (p_data_type) {
@@ -2986,7 +2989,7 @@ void ThemeTypeEditor::_item_rename_confirmed(int p_data_type, String p_item_name
 		return;
 	}
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Rename Theme Item"));
 
 	switch (p_data_type) {
@@ -3042,7 +3045,7 @@ void ThemeTypeEditor::_item_rename_canceled(int p_data_type, String p_item_name,
 }
 
 void ThemeTypeEditor::_color_item_changed(Color p_value, String p_item_name) {
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Set Color Item in Theme"), UndoRedo::MERGE_ENDS);
 	ur->add_do_method(*edited_theme, "set_color", p_item_name, edited_type, p_value);
 	ur->add_undo_method(*edited_theme, "set_color", p_item_name, edited_type, edited_theme->get_color(p_item_name, edited_type));
@@ -3050,7 +3053,7 @@ void ThemeTypeEditor::_color_item_changed(Color p_value, String p_item_name) {
 }
 
 void ThemeTypeEditor::_constant_item_changed(float p_value, String p_item_name) {
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Set Constant Item in Theme"));
 	ur->add_do_method(*edited_theme, "set_constant", p_item_name, edited_type, p_value);
 	ur->add_undo_method(*edited_theme, "set_constant", p_item_name, edited_type, edited_theme->get_constant(p_item_name, edited_type));
@@ -3058,7 +3061,7 @@ void ThemeTypeEditor::_constant_item_changed(float p_value, String p_item_name) 
 }
 
 void ThemeTypeEditor::_font_size_item_changed(float p_value, String p_item_name) {
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Set Font Size Item in Theme"));
 	ur->add_do_method(*edited_theme, "set_font_size", p_item_name, edited_type, p_value);
 	ur->add_undo_method(*edited_theme, "set_font_size", p_item_name, edited_type, edited_theme->get_font_size(p_item_name, edited_type));
@@ -3070,7 +3073,7 @@ void ThemeTypeEditor::_edit_resource_item(RES p_resource, bool p_edit) {
 }
 
 void ThemeTypeEditor::_font_item_changed(Ref<Font> p_value, String p_item_name) {
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Set Font Item in Theme"));
 
 	ur->add_do_method(*edited_theme, "set_font", p_item_name, edited_type, p_value.is_valid() ? p_value : Ref<Font>());
@@ -3087,7 +3090,7 @@ void ThemeTypeEditor::_font_item_changed(Ref<Font> p_value, String p_item_name) 
 }
 
 void ThemeTypeEditor::_icon_item_changed(Ref<Texture2D> p_value, String p_item_name) {
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Set Icon Item in Theme"));
 
 	ur->add_do_method(*edited_theme, "set_icon", p_item_name, edited_type, p_value.is_valid() ? p_value : Ref<Texture2D>());
@@ -3104,7 +3107,7 @@ void ThemeTypeEditor::_icon_item_changed(Ref<Texture2D> p_value, String p_item_n
 }
 
 void ThemeTypeEditor::_stylebox_item_changed(Ref<StyleBox> p_value, String p_item_name) {
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Set Stylebox Item in Theme"));
 
 	ur->add_do_method(*edited_theme, "set_stylebox", p_item_name, edited_type, p_value.is_valid() ? p_value : Ref<StyleBox>());
@@ -3147,7 +3150,7 @@ void ThemeTypeEditor::_on_pin_leader_button_pressed(Control *p_editor, String p_
 		stylebox = Object::cast_to<EditorResourcePicker>(p_editor)->get_edited_resource();
 	}
 
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Pin Stylebox"));
 	ur->add_do_method(this, "_pin_leading_stylebox", p_item_name, stylebox);
 
@@ -3180,7 +3183,7 @@ void ThemeTypeEditor::_pin_leading_stylebox(String p_item_name, Ref<StyleBox> p_
 }
 
 void ThemeTypeEditor::_on_unpin_leader_button_pressed() {
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Unpin Stylebox"));
 	ur->add_do_method(this, "_unpin_leading_stylebox");
 	ur->add_undo_method(this, "_pin_leading_stylebox", leading_stylebox.item_name, leading_stylebox.stylebox);
@@ -3247,7 +3250,7 @@ void ThemeTypeEditor::_update_stylebox_from_leading() {
 }
 
 void ThemeTypeEditor::_type_variation_changed(const String p_value) {
-	UndoRedo *ur = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *ur = plugin->get_undo_redo();
 	ur->create_action(TTR("Set Theme Type Variation"));
 
 	if (p_value.is_empty()) {
@@ -3353,7 +3356,9 @@ bool ThemeTypeEditor::is_stylebox_pinned(Ref<StyleBox> p_stylebox) {
 	return leading_stylebox.pinned && leading_stylebox.stylebox == p_stylebox;
 }
 
-ThemeTypeEditor::ThemeTypeEditor() {
+ThemeTypeEditor::ThemeTypeEditor(EditorPlugin *p_plugin) {
+	plugin = p_plugin;
+
 	VBoxContainer *main_vb = memnew(VBoxContainer);
 	add_child(main_vb);
 
@@ -3514,7 +3519,9 @@ void ThemeEditor::_add_preview_tab(ThemeEditorPreview *p_preview_tab, const Stri
 
 	preview_tabs->add_tab(p_preview_name, p_icon);
 	preview_tabs_content->add_child(p_preview_tab);
-	preview_tabs->set_tab_button_icon(preview_tabs->get_tab_count() - 1, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("close"), SNAME("TabBar")));
+	Control *base_control = plugin->get_editor_interface()->get_base_control();
+
+	preview_tabs->set_tab_button_icon(preview_tabs->get_tab_count() - 1, base_control->get_theme_icon(SNAME("close"), SNAME("TabBar")));
 	p_preview_tab->connect("control_picked", callable_mp(this, &ThemeEditor::_preview_control_picked));
 
 	preview_tabs->set_current_tab(preview_tabs->get_tab_count() - 1);
@@ -3586,7 +3593,9 @@ void ThemeEditor::_notification(int p_what) {
 	}
 }
 
-ThemeEditor::ThemeEditor() {
+ThemeEditor::ThemeEditor(EditorPlugin *p_plugin) {
+	plugin = p_plugin;
+
 	HBoxContainer *top_menu = memnew(HBoxContainer);
 	add_child(top_menu);
 
@@ -3618,9 +3627,9 @@ ThemeEditor::ThemeEditor() {
 	theme_edit_button->connect("pressed", callable_mp(this, &ThemeEditor::_theme_edit_button_cbk));
 	top_menu->add_child(theme_edit_button);
 
-	theme_type_editor = memnew(ThemeTypeEditor);
+	theme_type_editor = memnew(ThemeTypeEditor(plugin));
 
-	theme_edit_dialog = memnew(ThemeItemEditorDialog(theme_type_editor));
+	theme_edit_dialog = memnew(ThemeItemEditorDialog(theme_type_editor, plugin));
 	theme_edit_dialog->hide();
 	top_menu->add_child(theme_edit_dialog);
 
@@ -3757,10 +3766,10 @@ bool ThemeEditorPlugin::handles(Object *p_node) const {
 void ThemeEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
 		button->show();
-		EditorNode::get_singleton()->make_bottom_panel_item_visible(theme_editor);
+		make_bottom_panel_item_visible(theme_editor);
 	} else {
 		if (theme_editor->is_visible_in_tree()) {
-			EditorNode::get_singleton()->hide_bottom_panel();
+			hide_bottom_panel();
 		}
 
 		button->hide();
@@ -3768,9 +3777,9 @@ void ThemeEditorPlugin::make_visible(bool p_visible) {
 }
 
 ThemeEditorPlugin::ThemeEditorPlugin() {
-	theme_editor = memnew(ThemeEditor);
+	theme_editor = memnew(ThemeEditor(this));
 	theme_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
 
-	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Theme"), theme_editor);
+	button = add_control_to_bottom_panel(theme_editor, TTR("Theme"));
 	button->hide();
 }

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -38,8 +38,10 @@
 #include "scene/gui/item_list.h"
 #include "scene/gui/margin_container.h"
 #include "scene/gui/option_button.h"
+#include "scene/gui/panel_container.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/tab_bar.h"
+#include "scene/gui/tab_container.h"
 #include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
 #include "scene/resources/theme.h"
@@ -48,6 +50,8 @@ class EditorFileDialog;
 
 class ThemeItemImportTree : public VBoxContainer {
 	GDCLASS(ThemeItemImportTree, VBoxContainer);
+
+	EditorPlugin *plugin;
 
 	Ref<Theme> edited_theme;
 	Ref<Theme> base_theme;
@@ -178,13 +182,15 @@ public:
 
 	bool has_selected_items() const;
 
-	ThemeItemImportTree();
+	ThemeItemImportTree(EditorPlugin *p_plugin);
 };
 
 class ThemeTypeEditor;
 
 class ThemeItemEditorDialog : public AcceptDialog {
 	GDCLASS(ThemeItemEditorDialog, AcceptDialog);
+
+	EditorPlugin *plugin = nullptr;
 
 	ThemeTypeEditor *theme_type_editor = nullptr;
 
@@ -277,7 +283,7 @@ protected:
 public:
 	void set_edited_theme(const Ref<Theme> &p_theme);
 
-	ThemeItemEditorDialog(ThemeTypeEditor *p_theme_editor);
+	ThemeItemEditorDialog(ThemeTypeEditor *p_theme_editor, EditorPlugin *p_plugin);
 };
 
 class ThemeTypeDialog : public ConfirmationDialog {
@@ -319,6 +325,7 @@ public:
 class ThemeTypeEditor : public MarginContainer {
 	GDCLASS(ThemeTypeEditor, MarginContainer);
 
+	EditorPlugin *plugin;
 	Ref<Theme> edited_theme;
 	String edited_type;
 	bool updating = false;
@@ -409,11 +416,13 @@ public:
 	void select_type(String p_type_name);
 	bool is_stylebox_pinned(Ref<StyleBox> p_stylebox);
 
-	ThemeTypeEditor();
+	ThemeTypeEditor(EditorPlugin *p_plugin);
 };
 
 class ThemeEditor : public VBoxContainer {
 	GDCLASS(ThemeEditor, VBoxContainer);
+
+	EditorPlugin *plugin;
 
 	Ref<Theme> theme;
 
@@ -446,7 +455,7 @@ public:
 	void edit(const Ref<Theme> &p_theme);
 	Ref<Theme> get_edited_theme();
 
-	ThemeEditor();
+	ThemeEditor(EditorPlugin *p_plugin);
 };
 
 class ThemeEditorPlugin : public EditorPlugin {

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -36,8 +36,13 @@
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 #include "scene/gui/button.h"
+#include "scene/gui/check_box.h"
 #include "scene/gui/color_picker.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/progress_bar.h"
+#include "scene/gui/separator.h"
+#include "scene/gui/slider.h"
+#include "scene/gui/tab_container.h"
 #include "scene/resources/packed_scene.h"
 
 constexpr double REFRESH_TIMER = 1.5;

--- a/editor/plugins/tiles/tile_data_editors.cpp
+++ b/editor/plugins/tiles/tile_data_editors.cpp
@@ -35,6 +35,8 @@
 #include "core/math/geometry_2d.h"
 #include "core/os/keyboard.h"
 
+#include "scene/gui/option_button.h"
+
 #include "editor/editor_node.h"
 #include "editor/editor_properties.h"
 #include "editor/editor_scale.h"

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -161,9 +161,9 @@ void TilesEditorPlugin::_update_editors() {
 	// Update visibility of bottom panel buttons.
 	if (tileset_editor_button->is_pressed() && !tile_set.is_valid()) {
 		if (tile_map) {
-			EditorNode::get_singleton()->make_bottom_panel_item_visible(tilemap_editor);
+			make_bottom_panel_item_visible(tilemap_editor);
 		} else {
-			EditorNode::get_singleton()->hide_bottom_panel();
+			hide_bottom_panel();
 		}
 	}
 }
@@ -190,15 +190,15 @@ void TilesEditorPlugin::make_visible(bool p_visible) {
 		tileset_editor_button->set_visible(tile_set.is_valid());
 		tilemap_editor_button->set_visible(tile_map);
 		if (tile_map) {
-			EditorNode::get_singleton()->make_bottom_panel_item_visible(tilemap_editor);
+			make_bottom_panel_item_visible(tilemap_editor);
 		} else {
-			EditorNode::get_singleton()->make_bottom_panel_item_visible(tileset_editor);
+			make_bottom_panel_item_visible(tileset_editor);
 		}
 
 	} else {
 		tileset_editor_button->hide();
 		tilemap_editor_button->hide();
-		EditorNode::get_singleton()->hide_bottom_panel();
+		hide_bottom_panel();
 	}
 }
 
@@ -353,7 +353,7 @@ void TilesEditorPlugin::edit(Object *p_object) {
 			tile_map_id = p_object->get_instance_id();
 			tile_map = Object::cast_to<TileMap>(ObjectDB::get_instance(tile_map_id));
 			tile_set = tile_map->get_tileset();
-			EditorNode::get_singleton()->make_bottom_panel_item_visible(tilemap_editor);
+			make_bottom_panel_item_visible(tilemap_editor);
 		} else if (p_object->is_class("TileSet")) {
 			tile_set = Ref<TileSet>(p_object);
 			if (tile_map) {
@@ -362,7 +362,7 @@ void TilesEditorPlugin::edit(Object *p_object) {
 					tile_map_id = ObjectID();
 				}
 			}
-			EditorNode::get_singleton()->make_bottom_panel_item_visible(tileset_editor);
+			make_bottom_panel_item_visible(tileset_editor);
 		}
 	}
 
@@ -403,9 +403,9 @@ TilesEditorPlugin::TilesEditorPlugin() {
 	pattern_preview_thread.start(_thread_func, this);
 
 	// Bottom buttons.
-	tileset_editor_button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("TileSet"), tileset_editor);
+	tileset_editor_button = add_control_to_bottom_panel(tileset_editor, TTR("TileSet"));
 	tileset_editor_button->hide();
-	tilemap_editor_button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("TileMap"), tilemap_editor);
+	tilemap_editor_button = add_control_to_bottom_panel(tilemap_editor, TTR("TileMap"));
 	tilemap_editor_button->hide();
 
 	// Initialization.

--- a/editor/plugins/version_control_editor_plugin.h
+++ b/editor/plugins/version_control_editor_plugin.h
@@ -34,6 +34,8 @@
 #include "editor/editor_plugin.h"
 #include "editor/editor_vcs_interface.h"
 #include "scene/gui/box_container.h"
+#include "scene/gui/dialogs.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/rich_text_label.h"
 #include "scene/gui/split_container.h"
 #include "scene/gui/text_edit.h"

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -42,6 +42,7 @@
 #include "editor/editor_scale.h"
 #include "scene/animation/animation_player.h"
 #include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/panel.h"
 #include "scene/gui/view_panner.h"
 #include "scene/main/window.h"
@@ -97,7 +98,8 @@ static Ref<StyleBoxEmpty> make_empty_stylebox(float p_margin_left = -1, float p_
 
 ///////////////////
 
-VisualShaderGraphPlugin::VisualShaderGraphPlugin() {
+VisualShaderGraphPlugin::VisualShaderGraphPlugin(EditorPlugin *p_plugin) {
+	plugin = p_plugin;
 }
 
 void VisualShaderGraphPlugin::_bind_methods() {
@@ -508,7 +510,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			curve->get_texture()->connect("changed", ce, varray(p_id));
 		}
 
-		CurveEditor *curve_editor = memnew(CurveEditor);
+		CurveEditor *curve_editor = memnew(CurveEditor(plugin));
 		node->add_child(curve_editor);
 		register_curve_editor(p_id, 0, curve_editor);
 		curve_editor->set_custom_minimum_size(Size2(300, 0));
@@ -526,7 +528,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			curve_xyz->get_texture()->connect("changed", ce, varray(p_id));
 		}
 
-		CurveEditor *curve_editor_x = memnew(CurveEditor);
+		CurveEditor *curve_editor_x = memnew(CurveEditor(plugin));
 		node->add_child(curve_editor_x);
 		register_curve_editor(p_id, 0, curve_editor_x);
 		curve_editor_x->set_custom_minimum_size(Size2(300, 0));
@@ -535,7 +537,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			curve_editor_x->set_curve(curve_xyz->get_texture()->get_curve_x());
 		}
 
-		CurveEditor *curve_editor_y = memnew(CurveEditor);
+		CurveEditor *curve_editor_y = memnew(CurveEditor(plugin));
 		node->add_child(curve_editor_y);
 		register_curve_editor(p_id, 1, curve_editor_y);
 		curve_editor_y->set_custom_minimum_size(Size2(300, 0));
@@ -544,7 +546,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			curve_editor_y->set_curve(curve_xyz->get_texture()->get_curve_y());
 		}
 
-		CurveEditor *curve_editor_z = memnew(CurveEditor);
+		CurveEditor *curve_editor_z = memnew(CurveEditor(plugin));
 		node->add_child(curve_editor_z);
 		register_curve_editor(p_id, 2, curve_editor_z);
 		curve_editor_z->set_custom_minimum_size(Size2(300, 0));
@@ -702,6 +704,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			hb->add_child(custom_editor);
 			custom_editor->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		} else {
+			Control *base_control = plugin->get_editor_interface()->get_base_control();
 			if (valid_left) {
 				if (is_group) {
 					OptionButton *type_box = memnew(OptionButton);
@@ -726,7 +729,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 					name_box->connect("focus_exited", callable_mp(editor, &VisualShaderEditor::_port_name_focus_out), varray(name_box, p_id, i, false), CONNECT_DEFERRED);
 
 					Button *remove_btn = memnew(Button);
-					remove_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
+					remove_btn->set_icon(base_control->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 					remove_btn->set_tooltip(TTR("Remove") + " " + name_left);
 					remove_btn->connect("pressed", callable_mp(editor, &VisualShaderEditor::_remove_input_port), varray(p_id, i), CONNECT_DEFERRED);
 					hb->add_child(remove_btn);
@@ -753,7 +756,7 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 			if (valid_right) {
 				if (is_group) {
 					Button *remove_btn = memnew(Button);
-					remove_btn->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
+					remove_btn->set_icon(base_control->get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 					remove_btn->set_tooltip(TTR("Remove") + " " + name_left);
 					remove_btn->connect("pressed", callable_mp(editor, &VisualShaderEditor::_remove_output_port), varray(p_id, i), CONNECT_DEFERRED);
 					hb->add_child(remove_btn);
@@ -1454,27 +1457,30 @@ void VisualShaderEditor::_update_options_menu() {
 			node_desc->set_text(options[i].description);
 			is_first_item = false;
 		}
+
+		Control *base_control = plugin->get_editor_interface()->get_base_control();
+
 		switch (options[i].return_type) {
 			case VisualShaderNode::PORT_TYPE_SCALAR:
-				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("float"), SNAME("EditorIcons")));
+				item->set_icon(0, base_control->get_theme_icon(SNAME("float"), SNAME("EditorIcons")));
 				break;
 			case VisualShaderNode::PORT_TYPE_SCALAR_INT:
-				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("int"), SNAME("EditorIcons")));
+				item->set_icon(0, base_control->get_theme_icon(SNAME("int"), SNAME("EditorIcons")));
 				break;
 			case VisualShaderNode::PORT_TYPE_VECTOR_2D:
-				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")));
+				item->set_icon(0, base_control->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")));
 				break;
 			case VisualShaderNode::PORT_TYPE_VECTOR_3D:
-				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")));
+				item->set_icon(0, base_control->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")));
 				break;
 			case VisualShaderNode::PORT_TYPE_BOOLEAN:
-				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")));
+				item->set_icon(0, base_control->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")));
 				break;
 			case VisualShaderNode::PORT_TYPE_TRANSFORM:
-				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")));
+				item->set_icon(0, base_control->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")));
 				break;
 			case VisualShaderNode::PORT_TYPE_SAMPLER:
-				item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")));
+				item->set_icon(0, base_control->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")));
 				break;
 			default:
 				break;
@@ -3640,8 +3646,7 @@ void VisualShaderEditor::_notification(int p_what) {
 				error_label->add_theme_font_size_override("font_size", get_theme_font_size(SNAME("status_source_size"), SNAME("EditorFonts")));
 				error_label->add_theme_color_override("font_color", error_color);
 			}
-
-			tools->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
+			tools->set_icon(get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
 
 			if (p_what == NOTIFICATION_THEME_CHANGED && is_visible_in_tree()) {
 				_update_graph();
@@ -3945,7 +3950,7 @@ void VisualShaderEditor::_input_select_item(Ref<VisualShaderNodeInput> p_input, 
 
 	bool type_changed = p_input->get_input_type_by_name(p_name) != p_input->get_input_type_by_name(prev_name);
 
-	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Visual Shader Input Type Changed"));
 
 	undo_redo->add_do_method(p_input.ptr(), "set_input_name", p_name);
@@ -3991,7 +3996,7 @@ void VisualShaderEditor::_uniform_select_item(Ref<VisualShaderNodeUniformRef> p_
 
 	bool type_changed = p_uniform_ref->get_uniform_type_by_name(p_name) != p_uniform_ref->get_uniform_type_by_name(prev_name);
 
-	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("UniformRef Name Changed"));
 
 	undo_redo->add_do_method(p_uniform_ref.ptr(), "set_uniform_name", p_name);
@@ -4035,7 +4040,7 @@ void VisualShaderEditor::_varying_select_item(Ref<VisualShaderNodeVarying> p_var
 
 	bool is_getter = Ref<VisualShaderNodeVaryingGetter>(p_varying.ptr()).is_valid();
 
-	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
+	UndoRedo *undo_redo = plugin->get_undo_redo();
 	undo_redo->create_action(TTR("Varying Name Changed"));
 
 	undo_redo->add_do_method(p_varying.ptr(), "set_varying_name", p_name);
@@ -4165,22 +4170,22 @@ void VisualShaderEditor::_update_varying_tree() {
 			if (i == 0) {
 				item->select(0);
 			}
-
+			Control *base_control = plugin->get_editor_interface()->get_base_control();
 			switch (varying->type) {
 				case VisualShader::VARYING_TYPE_FLOAT:
-					item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("float"), SNAME("EditorIcons")));
+					item->set_icon(0, base_control->get_theme_icon(SNAME("float"), SNAME("EditorIcons")));
 					break;
 				case VisualShader::VARYING_TYPE_VECTOR_2D:
-					item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")));
+					item->set_icon(0, base_control->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")));
 					break;
 				case VisualShader::VARYING_TYPE_VECTOR_3D:
-					item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")));
+					item->set_icon(0, base_control->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")));
 					break;
 				case VisualShader::VARYING_TYPE_COLOR:
-					item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")));
+					item->set_icon(0, base_control->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")));
 					break;
 				case VisualShader::VARYING_TYPE_TRANSFORM:
-					item->set_icon(0, EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")));
+					item->set_icon(0, base_control->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")));
 					break;
 				default:
 					break;
@@ -4530,8 +4535,10 @@ void VisualShaderEditor::_bind_methods() {
 
 VisualShaderEditor *VisualShaderEditor::singleton = nullptr;
 
-VisualShaderEditor::VisualShaderEditor() {
+VisualShaderEditor::VisualShaderEditor(EditorPlugin *p_plugin) {
 	singleton = this;
+
+	plugin = p_plugin;
 	ShaderLanguage::get_keyword_list(&keyword_list);
 
 	graph = memnew(GraphEdit);
@@ -5446,13 +5453,13 @@ VisualShaderEditor::VisualShaderEditor() {
 
 	_update_options_menu();
 
-	undo_redo = EditorNode::get_singleton()->get_undo_redo();
+	undo_redo = plugin->get_undo_redo();
 
 	Ref<VisualShaderNodePluginDefault> default_plugin;
 	default_plugin.instantiate();
 	add_plugin(default_plugin);
 
-	graph_plugin.instantiate();
+	graph_plugin.reference_ptr(memnew(VisualShaderGraphPlugin(plugin)));
 
 	property_editor = memnew(CustomPropertyEditor);
 	add_child(property_editor);
@@ -5475,13 +5482,13 @@ void VisualShaderEditorPlugin::make_visible(bool p_visible) {
 		//editor->hide_animation_player_editors();
 		//editor->animation_panel_make_visible(true);
 		button->show();
-		EditorNode::get_singleton()->make_bottom_panel_item_visible(visual_shader_editor);
+		make_bottom_panel_item_visible(visual_shader_editor);
 		visual_shader_editor->update_nodes();
 		visual_shader_editor->set_process_input(true);
 		//visual_shader_editor->set_process(true);
 	} else {
 		if (visual_shader_editor->is_visible_in_tree()) {
-			EditorNode::get_singleton()->hide_bottom_panel();
+			hide_bottom_panel();
 		}
 		button->hide();
 		visual_shader_editor->set_process_input(false);
@@ -5490,10 +5497,10 @@ void VisualShaderEditorPlugin::make_visible(bool p_visible) {
 }
 
 VisualShaderEditorPlugin::VisualShaderEditorPlugin() {
-	visual_shader_editor = memnew(VisualShaderEditor);
+	visual_shader_editor = memnew(VisualShaderEditor(this));
 	visual_shader_editor->set_custom_minimum_size(Size2(0, 300) * EDSCALE);
 
-	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("VisualShader"), visual_shader_editor);
+	button = add_control_to_bottom_panel(visual_shader_editor, TTR("VisualShader"));
 	button->hide();
 }
 
@@ -5525,14 +5532,16 @@ public:
 
 	void setup(const Ref<VisualShaderNodeInput> &p_input) {
 		input = p_input;
+		Control *base_control = EditorNode::get_singleton()->get_gui_base();
+
 		Ref<Texture2D> type_icon[7] = {
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")),
 		};
 
 		add_item("[None]");
@@ -5573,13 +5582,13 @@ public:
 
 	void setup(const Ref<VisualShaderNodeVarying> &p_varying, VisualShader::Type p_type) {
 		varying = p_varying;
-
+		Control *base_control = EditorNode::get_singleton()->get_gui_base();
 		Ref<Texture2D> type_icon[] = {
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
 		};
 
 		bool is_getter = Ref<VisualShaderNodeVaryingGetter>(p_varying.ptr()).is_valid();
@@ -5652,15 +5661,16 @@ public:
 	void setup(const Ref<VisualShaderNodeUniformRef> &p_uniform_ref) {
 		uniform_ref = p_uniform_ref;
 
+		Control *base_control = EditorNode::get_singleton()->get_gui_base();
 		Ref<Texture2D> type_icon[8] = {
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")),
-			EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("float"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("int"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("bool"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("Vector2"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("Vector3"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("Transform3D"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("Color"), SNAME("EditorIcons")),
+			base_control->get_theme_icon(SNAME("ImageTexture"), SNAME("EditorIcons")),
 		};
 
 		add_item("[None]");
@@ -6009,7 +6019,6 @@ bool EditorInspectorShaderModePlugin::parse_property(Object *p_object, const Var
 }
 
 //////////////////////////////////
-
 void VisualShaderNodePortPreview::_shader_changed() {
 	if (shader.is_null()) {
 		return;
@@ -6032,9 +6041,9 @@ void VisualShaderNodePortPreview::_shader_changed() {
 	material->set_shader(preview_shader);
 
 	//find if a material is also being edited and copy parameters to this one
-
-	for (int i = EditorNode::get_singleton()->get_editor_selection_history()->get_path_size() - 1; i >= 0; i--) {
-		Object *object = ObjectDB::get_instance(EditorNode::get_singleton()->get_editor_selection_history()->get_path_object(i));
+	EditorSelectionHistory *selection_history = EditorNode::get_singleton()->get_editor_selection_history();
+	for (int i = selection_history->get_path_size() - 1; i >= 0; i--) {
+		Object *object = ObjectDB::get_instance(selection_history->get_path_object(i));
 		ShaderMaterial *src_mat;
 		if (!object) {
 			continue;

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -58,6 +58,8 @@ class VisualShaderGraphPlugin : public RefCounted {
 	GDCLASS(VisualShaderGraphPlugin, RefCounted);
 
 private:
+	EditorPlugin *plugin;
+
 	struct InputPort {
 		Button *default_input_button = nullptr;
 	};
@@ -124,7 +126,7 @@ public:
 	void update_theme();
 	VisualShader::Type get_shader_type() const;
 
-	VisualShaderGraphPlugin();
+	VisualShaderGraphPlugin(EditorPlugin *p_plugin);
 	~VisualShaderGraphPlugin();
 };
 
@@ -132,6 +134,7 @@ class VisualShaderEditor : public VBoxContainer {
 	GDCLASS(VisualShaderEditor, VBoxContainer);
 	friend class VisualShaderGraphPlugin;
 
+	EditorPlugin *plugin;
 	CustomPropertyEditor *property_editor = nullptr;
 	int editing_node = -1;
 	int editing_port = -1;
@@ -490,7 +493,7 @@ public:
 
 	virtual Size2 get_minimum_size() const override;
 	void edit(VisualShader *p_visual_shader);
-	VisualShaderEditor();
+	VisualShaderEditor(EditorPlugin *p_plugin);
 };
 
 class VisualShaderEditorPlugin : public EditorPlugin {

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -152,7 +152,7 @@ VoxelGIEditorPlugin::VoxelGIEditorPlugin() {
 	bake_hb->hide();
 	bake = memnew(Button);
 	bake->set_flat(true);
-	bake->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
+	bake->set_icon(get_editor_interface()->get_base_control()->get_theme_icon(SNAME("Bake"), SNAME("EditorIcons")));
 	bake->set_text(TTR("Bake VoxelGI"));
 	bake->connect("pressed", callable_mp(this, &VoxelGIEditorPlugin::_bake));
 	bake_hb->add_child(bake);

--- a/editor/plugins/voxel_gi_editor_plugin.h
+++ b/editor/plugins/voxel_gi_editor_plugin.h
@@ -33,6 +33,7 @@
 
 #include "editor/editor_plugin.h"
 #include "scene/3d/voxel_gi.h"
+#include "scene/gui/box_container.h"
 #include "scene/resources/material.h"
 
 class EditorFileDialog;

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -36,6 +36,7 @@
 #include "editor/groups_editor.h"
 #include "editor/quick_open.h"
 #include "editor/reparent_dialog.h"
+#include "editor/scene_tree_editor.h"
 #include "editor/script_create_dialog.h"
 #include "scene/animation/animation_player.h"
 #include "scene/gui/box_container.h"
@@ -43,8 +44,8 @@
 #include "scene/gui/control.h"
 #include "scene/gui/label.h"
 #include "scene/gui/popup_menu.h"
+#include "scene/gui/texture_rect.h"
 #include "scene/gui/tree.h"
-#include "scene_tree_editor.h"
 
 #include "modules/modules_enabled.gen.h" // For regex.
 #ifdef MODULE_REGEX_ENABLED

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -79,6 +79,7 @@
 #endif
 
 #ifdef TOOLS_ENABLED
+#include "editor/debugger/editor_debugger_node.h"
 #include "editor/doc_data_class_path.gen.h"
 #include "editor/doc_tools.h"
 #include "editor/editor_node.h"

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -32,6 +32,7 @@
 
 #ifdef TOOLS_ENABLED
 
+#include "core/object/undo_redo.h"
 #include "editor/editor_settings.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "scene/3d/camera_3d.h"

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
@@ -56,7 +56,7 @@ bool SceneExporterGLTFPlugin::has_main_screen() const {
 
 SceneExporterGLTFPlugin::SceneExporterGLTFPlugin() {
 	file_export_lib = memnew(EditorFileDialog);
-	EditorNode::get_singleton()->get_gui_base()->add_child(file_export_lib);
+	get_editor_interface()->get_base_control()->add_child(file_export_lib);
 	file_export_lib->connect("file_selected", callable_mp(this, &SceneExporterGLTFPlugin::_gltf2_dialog_action));
 	file_export_lib->set_title(TTR("Export Library"));
 	file_export_lib->set_file_mode(EditorFileDialog::FILE_MODE_SAVE_FILE);
@@ -70,7 +70,7 @@ SceneExporterGLTFPlugin::SceneExporterGLTFPlugin() {
 }
 
 void SceneExporterGLTFPlugin::_gltf2_dialog_action(String p_file) {
-	Node *root = EditorNode::get_singleton()->get_tree()->get_edited_scene_root();
+	Node *root = get_editor_interface()->get_edited_scene_root();
 	if (!root) {
 		EditorNode::get_singleton()->show_accept(TTR("This operation can't be done without a scene."), TTR("OK"));
 		return;
@@ -93,7 +93,7 @@ void SceneExporterGLTFPlugin::_gltf2_dialog_action(String p_file) {
 }
 
 void SceneExporterGLTFPlugin::convert_scene_to_gltf2() {
-	Node *root = EditorNode::get_singleton()->get_tree()->get_edited_scene_root();
+	Node *root = get_editor_interface()->get_edited_scene_root();
 	if (!root) {
 		EditorNode::get_singleton()->show_accept(TTR("This operation can't be done without a scene."), TTR("OK"));
 		return;

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
@@ -33,6 +33,7 @@
 
 #ifdef TOOLS_ENABLED
 
+#include "editor/editor_file_dialog.h"
 #include "editor/editor_plugin.h"
 #include "editor_scene_importer_gltf.h"
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -1137,8 +1137,8 @@ void GridMapEditor::_bind_methods() {
 	ClassDB::bind_method("_set_selection", &GridMapEditor::_set_selection);
 }
 
-GridMapEditor::GridMapEditor() {
-	undo_redo = EditorNode::get_singleton()->get_undo_redo();
+GridMapEditor::GridMapEditor(EditorPlugin *p_plugin) {
+	undo_redo = p_plugin->get_undo_redo();
 
 	int mw = EDITOR_DEF("editors/grid_map/palette_min_width", 230);
 	Control *ec = memnew(Control);
@@ -1467,7 +1467,7 @@ GridMapEditorPlugin::GridMapEditorPlugin() {
 	EDITOR_DEF("editors/grid_map/editor_side", 1);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "editors/grid_map/editor_side", PROPERTY_HINT_ENUM, "Left,Right"));
 
-	grid_map_editor = memnew(GridMapEditor);
+	grid_map_editor = memnew(GridMapEditor(this));
 	switch ((int)EditorSettings::get_singleton()->get("editors/grid_map/editor_side")) {
 		case 0: { // Left.
 			Node3DEditor::get_singleton()->add_control_to_left_panel(grid_map_editor);

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -35,7 +35,10 @@
 
 #include "../grid_map.h"
 #include "editor/editor_plugin.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/dialogs.h"
 #include "scene/gui/item_list.h"
+#include "scene/gui/menu_button.h"
 #include "scene/gui/slider.h"
 #include "scene/gui/spin_box.h"
 
@@ -227,7 +230,7 @@ public:
 	EditorPlugin::AfterGUIInput forward_spatial_input_event(Camera3D *p_camera, const Ref<InputEvent> &p_event);
 
 	void edit(GridMap *p_gridmap);
-	GridMapEditor();
+	GridMapEditor(EditorPlugin *p_plugin);
 	~GridMapEditor();
 };
 

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
@@ -35,7 +35,6 @@
 #include "../navigation_mesh_generator.h"
 #include "core/io/marshalls.h"
 #include "core/io/resource_saver.h"
-#include "editor/editor_node.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/gui/box_container.h"
 
@@ -145,7 +144,7 @@ void NavigationMeshEditorPlugin::make_visible(bool p_visible) {
 
 NavigationMeshEditorPlugin::NavigationMeshEditorPlugin() {
 	navigation_mesh_editor = memnew(NavigationMeshEditor);
-	EditorNode::get_singleton()->get_main_control()->add_child(navigation_mesh_editor);
+	get_editor_interface()->get_editor_main_control()->add_child(navigation_mesh_editor);
 	add_control_to_container(CONTAINER_SPATIAL_EDITOR_MENU, navigation_mesh_editor->bake_hbox);
 	navigation_mesh_editor->hide();
 	navigation_mesh_editor->bake_hbox->hide();

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.h
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.h
@@ -34,6 +34,7 @@
 #ifdef TOOLS_ENABLED
 
 #include "editor/editor_plugin.h"
+#include "scene/gui/dialogs.h"
 
 class NavigationRegion3D;
 


### PR DESCRIPTION
**Warning**: This can't be merged as-is because there are some heap-use-after-free caused by deleted EditorPlugins and EditorInterface. I need to figure out how to fix them.

Follow up of #57306

This PR remove direct usages of EditorNode in favor of EditorPlugin and EditorInterface methods.
Where necessary, the EditorPlugin pointer is stored in the class where necessary (pretty much how it was done for EditorNode before #57306).
In some cases, I create local variables because the new syntax is too long (and it was too long).

Also, it reduces the EditorPlugin includes to 3 by forward-declaring everything else. EDIT: Now done in #60684
<hr/>

Note for reviewers:
There are some inconsistencies, unrelated changes, missing and wrong changes in the PR. Here's a list:
- The plugin pointer should be typed EditorPlugin, not SomethingEditorPlugin. Using the real type is useless and requires a forward declaration.
- In several cases I renamed the local variables, but It's not done consistently.
- The EditorNode method names differs from EditorInterface ones, so it's possible that the picked method is wrong.
  To check that, compare the old name with the one in the EditorInterface's method body. If they differ, the used EditorInterface method is wrong.
  For example, EditorInterface::get_base_control calls EditorNode::get_gui_base

<hr/>

Many methods in EditorNode don't have their counterparts in EditorInterface, which I want to add in a follow-up PR to further reduce the (direct) dependencies to EditorNode.
Here's a list of the methods:
```
EditorNode::show_warning
EditorNode::show_accept
EditorNode::load_resource
EditorNode::save_resource
EditorNode::save_resource_as
EditorNode::set_visible_editor
EditorNode::get_editor_plugin_screen
EditorNode::push_item
EditorNode::get_scene_root
EditorNode::load_scene
EditorNode::get_object_icon
EditorNode::get_editor_plugins_over
EditorNode::get_editor_plugins_force_over
EditorNode::get_editor_history
EditorNode::drag_resource
EditorNode::is_scene_open
EditorNode::show_accept
EditorNode::is_changing_scene
EditorNode::save_scene_list
EditorNode::get_editor_data (can't be exposed as-is)
EditorNode::get_theme_base
EditorNode::get_log
```

<hr/>

This PR decreases the EditorNode::get_singleton usages.

EditorNode::get_singleton usages in master (https://github.com/godotengine/godot/commit/4dc8214831d1617e7f5f06e8294fb37ea23dae59):
```
rg "EditorNode::get_singleton()" | wc -l
1003
```

EditorNode::get_singleton usages in this PR:
```
rg "EditorNode::get_singleton()" | wc -l
713
```