### PR TITLE
Use is_zero_approx and fix spelling in CameraMatrix invert

### DIFF
--- a/core/math/camera_matrix.cpp
+++ b/core/math/camera_matrix.cpp
@@ -436,9 +436,7 @@ void CameraMatrix::invert() {
 	int pvt_i[4], pvt_j[4]; /* Locations of pivot matrix */
 	real_t pvt_val; /* Value of current pivot element */
 	real_t hold; /* Temporary storage */
-	real_t determinat; /* Determinant */
-
-	determinat = 1.0;
+	real_t determinant = 1.0f;
 	for (k = 0; k < 4; k++) {
 		/** Locate k'th pivot element **/
 		pvt_val = matrix[k][k]; /** Initialize for search **/
@@ -446,7 +444,7 @@ void CameraMatrix::invert() {
 		pvt_j[k] = k;
 		for (i = k; i < 4; i++) {
 			for (j = k; j < 4; j++) {
-				if (Math::absd(matrix[i][j]) > Math::absd(pvt_val)) {
+				if (Math::abs(matrix[i][j]) > Math::abs(pvt_val)) {
 					pvt_i[k] = i;
 					pvt_j[k] = j;
 					pvt_val = matrix[i][j];
@@ -455,9 +453,9 @@ void CameraMatrix::invert() {
 		}
 
 		/** Product of pivots, gives determinant when finished **/
-		determinat *= pvt_val;
-		if (Math::absd(determinat) < 1e-7) {
-			return; //(false);  /** Matrix is singular (zero determinant). **/
+		determinant *= pvt_val;
+		if (Math::is_zero_approx(determinant)) {
+			return; /** Matrix is singular (zero determinant). **/
 		}
 
 		/** "Interchange" rows (with sign change stuff) **/


### PR DESCRIPTION
This PR fixes some problems noticed in https://github.com/godotengine/godot/pull/58492#discussion_r814006526

* Fix spelling of determinant (was "determinat").
* Fix `Math::absd` being used on `real_t` when it should be `Math::abs`.
* Use `is_zero_approx()` instead of `absd() < 1e-7` since `1e-7` is so small of an epsilon to the point of not being very useful (`float` precision around 1 is 2^-23 or about `1.192e-7`). It's possible that `1e-7` works for this case, but if that is true, then why it's so small needs to be explained in a comment. This part needs review from @reduz.