### PR TITLE
Fix get_base_dir returning same path, if slash is in the end

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -4596,6 +4596,9 @@ String String::get_base_dir() const {
 	}
 
 	int sep = MAX(rs.rfind("/"), rs.rfind("\\"));
+	if (sep == rs.length() - 1) {
+		sep = MAX(rs.rfind("/", sep - 1), rs.rfind("\\", sep - 1));
+	}
 	if (sep == -1) {
 		return base;
 	}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/58504