### PR TITLE
Sort variables in VisualScriptEditor

### DIFF
--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -1102,6 +1102,7 @@ void VisualScriptEditor::_update_members() {
 
 	List<StringName> var_names;
 	script->get_variable_list(&var_names);
+	var_names.sort_custom<StringName::AlphCompare>();
 	for (const StringName &E : var_names) {
 		TreeItem *ti = members->create_item(variables);
 


### PR DESCRIPTION
Sorts the script variables in alphabetical order to display them in `VisualScriptEditor`.

The variables are sorted in 3.x because `get_variable_list` returned the list already sorted but this was changed in #39649.
This PR sorts the variables after retrieving them in `VisualScriptEditor` instead of directly in `get_variable_list` so this works like the functions (also retrieved unsorted with `get_function_list` and then sorted by `VisualScriptEditor`).

Closes #58509