### PR TITLE
Print every file exported with `PCKPacker.flush()`'s verbose parameter

### DIFF
--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -257,10 +257,7 @@ Error PCKPacker::flush(bool p_verbose) {
 		count += 1;
 		const int file_num = files.size();
 		if (p_verbose && (file_num > 0)) {
-			if (count % 100 == 0) {
-				printf("%i/%i (%.2f)\r", count, file_num, float(count) / file_num * 100);
-				fflush(stdout);
-			}
+			print_line(vformat("[%d/%d - %d%%] PCKPacker flush: %s -> %s", count, file_num, float(count) / file_num * 100, files[i].src_path, files[i].path));
 		}
 	}
 


### PR DESCRIPTION
Previously, only one line per 100 files was printed.

This also refactors the print statement to use Godot methods and make it more informative overall.

This closes https://github.com/godotengine/godot/issues/58392.

**Testing project:** [test_pck_export.zip](https://github.com/godotengine/godot/files/8140949/test_pck_export.zip)

## Preview

```gdscript
extends Node


func _ready() -> void:
	var small_packer = PCKPacker.new()
	assert(OK == small_packer.pck_start("small.pck"))
	assert(OK == small_packer.add_file("res://test.png", "icon.png"))
	assert(OK == small_packer.flush(true))
```

Results in:

```
[1/1 - 100%] PCKPacker flush: icon.png -> res://test.png
```