### PR TITLE
Fix build for macOS / iOS with the statically linked MoltenVK after VMA update.

### DIFF
--- a/drivers/vulkan/SCsub
+++ b/drivers/vulkan/SCsub
@@ -40,6 +40,9 @@ elif env["platform"] == "android":
     # Our current NDK version only provides old Vulkan headers,
     # so we have to limit VMA.
     env_thirdparty_vma.AppendUnique(CPPDEFINES=["VMA_VULKAN_VERSION=1000000"])
+elif env["platform"] == "osx" or env["platform"] == "iphone":
+    # MoltenVK supports only Vulkan 1.1 API, limit VMA to the same version.
+    env_thirdparty_vma.AppendUnique(CPPDEFINES=["VMA_VULKAN_VERSION=1001000"])
 
 env_thirdparty_vma.add_source_files(thirdparty_obj, thirdparty_sources_vma)
 


### PR DESCRIPTION
Current version of MoltenVK (from SDK 1.3.204.0) do not have some Vulkan 1.3 functions exposed, and building with statically linked MoltenVK fails with:

```
Undefined symbols for architecture arm64:
  "_vkGetDeviceBufferMemoryRequirements", referenced from:
      VmaAllocator_T::ImportVulkanFunctions(VmaVulkanFunctions const*) in libdrivers.osx.opt.tools.arm64.a(vk_mem_alloc.osx.opt.tools.arm64.o)
      VmaAllocator_T::ImportVulkanFunctions_Static() in libdrivers.osx.opt.tools.arm64.a(vk_mem_alloc.osx.opt.tools.arm64.o)
  "_vkGetDeviceImageMemoryRequirements", referenced from:
      VmaAllocator_T::ImportVulkanFunctions(VmaVulkanFunctions const*) in libdrivers.osx.opt.tools.arm64.a(vk_mem_alloc.osx.opt.tools.arm64.o)
      VmaAllocator_T::ImportVulkanFunctions_Static() in libdrivers.osx.opt.tools.arm64.a(vk_mem_alloc.osx.opt.tools.arm64.o)
```