### PR TITLE
Remove unimplemented `OS.dump_memory_to_file()` method

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -436,10 +436,6 @@ bool OS::is_stdout_verbose() const {
 	return ::OS::get_singleton()->is_stdout_verbose();
 }
 
-void OS::dump_memory_to_file(const String &p_file) {
-	::OS::get_singleton()->dump_memory_to_file(p_file.utf8().get_data());
-}
-
 struct OSCoreBindImg {
 	String path;
 	Size2 size;
@@ -666,7 +662,6 @@ void OS::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_debug_build"), &OS::is_debug_build);
 
-	ClassDB::bind_method(D_METHOD("dump_memory_to_file", "file"), &OS::dump_memory_to_file);
 	ClassDB::bind_method(D_METHOD("dump_resources_to_file", "file"), &OS::dump_resources_to_file);
 	ClassDB::bind_method(D_METHOD("print_resources_in_use", "short"), &OS::print_resources_in_use, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("print_all_resources", "tofile"), &OS::print_all_resources, DEFVAL(""));

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -199,7 +199,6 @@ public:
 
 	String get_model_name() const;
 
-	void dump_memory_to_file(const String &p_file);
 	void dump_resources_to_file(const String &p_file);
 
 	void print_resources_in_use(bool p_short = false);

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -190,10 +190,6 @@ void OS::set_stderr_enabled(bool p_enabled) {
 	_stderr_enabled = p_enabled;
 }
 
-void OS::dump_memory_to_file(const char *p_file) {
-	//Memory::dump_static_mem_to_file(p_file);
-}
-
 static Ref<FileAccess> _OSPRF;
 
 static void _OS_printres(Object *p_obj) {

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -249,7 +249,6 @@ public:
 	virtual bool is_disable_crash_handler() const { return false; }
 	virtual void initialize_debugging() {}
 
-	virtual void dump_memory_to_file(const char *p_file);
 	virtual void dump_resources_to_file(const char *p_file);
 	virtual void print_resources_in_use(bool p_short = false);
 	virtual void print_all_resources(String p_to_file = "");

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -88,14 +88,6 @@
 				[b]Note:[/b] When [method delay_usec] is called on the main thread, it will freeze the project and will prevent it from redrawing and registering input until the delay has passed. When using [method delay_usec] as part of an [EditorPlugin] or [EditorScript], it will freeze the editor but won't freeze the project if it is currently running (since the project is an independent child process).
 			</description>
 		</method>
-		<method name="dump_memory_to_file">
-			<return type="void" />
-			<param index="0" name="file" type="String" />
-			<description>
-				Dumps the memory allocation ringlist to a file (only works in debug).
-				Entry format per line: "Address - Size - Description".
-			</description>
-		</method>
 		<method name="dump_resources_to_file">
 			<return type="void" />
 			<param index="0" name="file" type="String" />


### PR DESCRIPTION
This method never did anything in Godot since 3.0, since its code was commented out. The last time the method had an implementation was in Godot 2.1.x.

It would be good to reassess whether there's a need to reimplement this method, but until then, the method can be removed in 4.0. For `3.x`, the class reference should be updated instead.