### PR TITLE
Exposes AudioServer playback start stop methods.

### DIFF
--- a/doc/classes/AudioServer.xml
+++ b/doc/classes/AudioServer.xml
@@ -275,6 +275,22 @@
 				Sets the volume of the bus at index [code]bus_idx[/code] to [code]volume_db[/code].
 			</description>
 		</method>
+		<method name="start_playback_stream">
+			<return type="void" />
+			<argument index="0" name="arg0" type="AudioStreamPlayback" />
+			<argument index="1" name="arg1" type="StringName" />
+			<argument index="2" name="arg2" type="PackedVector2Array" />
+			<argument index="3" name="arg3" type="float" default="0" />
+			<argument index="4" name="arg4" type="float" default="1" />
+			<description>
+			</description>
+		</method>
+		<method name="stop_playback_stream">
+			<return type="void" />
+			<argument index="0" name="arg0" type="AudioStreamPlayback" />
+			<description>
+			</description>
+		</method>
 		<method name="swap_bus_effects">
 			<return type="void" />
 			<argument index="0" name="bus_idx" type="int" />

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1114,6 +1114,20 @@ float AudioServer::get_playback_speed_scale() const {
 	return playback_speed_scale;
 }
 
+void AudioServer::_start_playback_stream_binding(Ref<AudioStreamPlayback> p_playback, StringName p_bus, PackedVector2Array p_volume_db_vector, float p_start_time, float p_pitch_scale) {
+	ERR_FAIL_COND(p_playback.is_null());
+	ERR_FAIL_COND(p_volume_db_vector.size() % sizeof(AudioFrame) != 0);
+
+	const int length = p_volume_db_vector.size();
+	Vector<AudioFrame> volumes;
+	volumes.resize(length);
+	for (int i = 0; i < length; ++i) {
+		volumes.write[i] = AudioFrame(p_volume_db_vector[i]);
+	}
+
+	start_playback_stream(p_playback, p_bus, volumes, p_start_time, p_pitch_scale);
+}
+
 void AudioServer::start_playback_stream(Ref<AudioStreamPlayback> p_playback, StringName p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time, float p_pitch_scale) {
 	ERR_FAIL_COND(p_playback.is_null());
 
@@ -1728,6 +1742,9 @@ void AudioServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_bus_layout", "bus_layout"), &AudioServer::set_bus_layout);
 	ClassDB::bind_method(D_METHOD("generate_bus_layout"), &AudioServer::generate_bus_layout);
+
+	ClassDB::bind_method(D_METHOD("start_playback_stream", "playback", "bus", "volume_db_vector", "start_time", "pitch_scale"), &AudioServer::_start_playback_stream_binding, DEFVAL(0), DEFVAL(1));
+	ClassDB::bind_method(D_METHOD("stop_playback_stream", "playback"), &AudioServer::stop_playback_stream);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "bus_count"), "set_bus_count", "get_bus_count");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "device"), "set_device", "get_device");

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -368,6 +368,7 @@ public:
 	float get_playback_speed_scale() const;
 
 	// Convenience method.
+	void _start_playback_stream_binding(Ref<AudioStreamPlayback> p_playback, StringName p_bus, PackedVector2Array p_volume_db_vector, float p_start_time = 0, float p_pitch_scale = 1);
 	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, StringName p_bus, Vector<AudioFrame> p_volume_db_vector, float p_start_time = 0, float p_pitch_scale = 1);
 	// Expose all parameters.
 	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, Map<StringName, Vector<AudioFrame>> p_bus_volumes, float p_start_time = 0, float p_pitch_scale = 1, float p_highshelf_gain = 0, float p_attenuation_cutoff_hz = 0);


### PR DESCRIPTION
Added a utility *binding* method for using PackedVector2Array and
converting to Vector<AudioFrame> for exposing.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
