### PR TITLE
Allow using CanvasItemMaterial in the TileSet editor

### DIFF
--- a/doc/classes/TileData.xml
+++ b/doc/classes/TileData.xml
@@ -199,7 +199,8 @@
 		</member>
 		<member name="flip_v" type="bool" setter="set_flip_v" getter="get_flip_v" default="false">
 		</member>
-		<member name="material" type="ShaderMaterial" setter="set_material" getter="get_material">
+		<member name="material" type="Material" setter="set_material" getter="get_material">
+			The [Material] to use for this [TileData]. This can be a [CanvasItemMaterial] to use the default shader, or a [ShaderMaterial] to use a custom shader.
 		</member>
 		<member name="modulate" type="Color" setter="set_modulate" getter="get_modulate" default="Color(1, 1, 1, 1)">
 		</member>

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -1090,7 +1090,7 @@ void TileMap::_rendering_update_dirty_quadrants(SelfList<TileMapQuadrant>::List 
 		q.occluders.clear();
 
 		// Those allow to group cell per material or z-index.
-		Ref<ShaderMaterial> prev_material;
+		Ref<Material> prev_material;
 		int prev_z_index = 0;
 		RID prev_canvas_item;
 
@@ -1129,7 +1129,7 @@ void TileMap::_rendering_update_dirty_quadrants(SelfList<TileMapQuadrant>::List 
 						tile_data = atlas_source->get_tile_data(c.get_atlas_coords(), c.alternative_tile);
 					}
 
-					Ref<ShaderMaterial> mat = tile_data->get_material();
+					Ref<Material> mat = tile_data->get_material();
 					int z_index = tile_data->get_z_index();
 
 					// Quandrant pos.

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -5058,11 +5058,11 @@ Vector2i TileData::get_texture_offset() const {
 	return tex_offset;
 }
 
-void TileData::set_material(Ref<ShaderMaterial> p_material) {
+void TileData::set_material(Ref<Material> p_material) {
 	material = p_material;
 	emit_signal(SNAME("changed"));
 }
-Ref<ShaderMaterial> TileData::get_material() const {
+Ref<Material> TileData::get_material() const {
 	return material;
 }
 
@@ -5700,7 +5700,7 @@ void TileData::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "transpose"), "set_transpose", "get_transpose");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2I, "texture_offset", PROPERTY_HINT_NONE, "suffix:px"), "set_texture_offset", "get_texture_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "modulate"), "set_modulate", "get_modulate");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "ShaderMaterial"), "set_material", "get_material");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "material", PROPERTY_HINT_RESOURCE_TYPE, "CanvasItemMaterial,ShaderMaterial"), "set_material", "get_material");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "z_index"), "set_z_index", "get_z_index");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "y_sort_origin"), "set_y_sort_origin", "get_y_sort_origin");
 

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -164,7 +164,7 @@ private:
 		String name;
 		Ref<Texture2D> texture;
 		Vector2 tex_offset;
-		Ref<ShaderMaterial> material;
+		Ref<Material> material;
 		Rect2 region;
 		int tile_mode = 0;
 		Color modulate = Color(1, 1, 1);
@@ -783,7 +783,7 @@ private:
 	bool flip_v = false;
 	bool transpose = false;
 	Vector2i tex_offset = Vector2i();
-	Ref<ShaderMaterial> material = Ref<ShaderMaterial>();
+	Ref<Material> material = Ref<Material>();
 	Color modulate = Color(1.0, 1.0, 1.0, 1.0);
 	int z_index = 0;
 	int y_sort_origin = 0;
@@ -864,8 +864,8 @@ public:
 
 	void set_texture_offset(Vector2i p_texture_offset);
 	Vector2i get_texture_offset() const;
-	void set_material(Ref<ShaderMaterial> p_material);
-	Ref<ShaderMaterial> get_material() const;
+	void set_material(Ref<Material> p_material);
+	Ref<Material> get_material() const;
 	void set_modulate(Color p_modulate);
 	Color get_modulate() const;
 	void set_z_index(int p_z_index);


### PR DESCRIPTION
Previously, only ShaderMaterial overrides could be added.

**Note:** Not tested yet, I'll make a quick setup to make sure it works as expected.

This closes https://github.com/godotengine/godot/issues/58541.