### PR TITLE
Allow automatic lod when importing 3D scenes with Static Lightmaps

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1649,14 +1649,6 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 					}
 				}
 
-				if (generate_lods) {
-					src_mesh_node->get_mesh()->generate_lods(merge_angle, split_angle);
-				}
-
-				if (create_shadow_meshes) {
-					src_mesh_node->get_mesh()->create_shadow_mesh();
-				}
-
 				if (bake_lightmaps) {
 					Transform3D xf;
 					Node3D *n = src_mesh_node;
@@ -1687,6 +1679,14 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 							}
 						}
 					}
+				}
+
+				if (generate_lods) {
+					src_mesh_node->get_mesh()->generate_lods(merge_angle, split_angle);
+				}
+
+				if (create_shadow_meshes) {
+					src_mesh_node->get_mesh()->create_shadow_mesh();
 				}
 
 				if (!save_to_file.is_empty()) {

--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -275,6 +275,7 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 		PackedInt32Array indices = surfaces[i].arrays[RS::ARRAY_INDEX];
 		Vector<Vector3> normals = surfaces[i].arrays[RS::ARRAY_NORMAL];
 		Vector<Vector2> uvs = surfaces[i].arrays[RS::ARRAY_TEX_UV];
+		Vector<Vector2> uv2s = surfaces[i].arrays[RS::ARRAY_TEX_UV2];
 
 		unsigned int index_count = indices.size();
 		unsigned int vertex_count = vertices.size();
@@ -313,6 +314,7 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 		LocalVector<Vector3> merged_normals;
 		LocalVector<int> merged_normals_counts;
 		const Vector2 *uvs_ptr = uvs.ptr();
+		const Vector2 *uv2s_ptr = uv2s.ptr();
 
 		for (unsigned int j = 0; j < vertex_count; j++) {
 			const Vector3 &v = vertices_ptr[j];
@@ -327,8 +329,10 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 				for (unsigned int k = 0; k < close_verts.size(); k++) {
 					const Pair<int, int> &idx = close_verts[k];
 
-					// TODO check more attributes?
-					if ((!uvs_ptr || uvs_ptr[j].distance_squared_to(uvs_ptr[idx.second]) < CMP_EPSILON2) && normals[idx.second].dot(n) > normal_merge_threshold) {
+					bool is_uvs_close = (!uvs_ptr || uvs_ptr[j].distance_squared_to(uvs_ptr[idx.second]) < CMP_EPSILON2);
+					bool is_uv2s_close = (!uv2s_ptr || uv2s_ptr[j].distance_squared_to(uv2s_ptr[idx.second]) < CMP_EPSILON2);
+					bool is_normals_close = normals[idx.second].dot(n) > normal_merge_threshold;
+					if (is_uvs_close && is_uv2s_close && is_normals_close) {
 						vertex_remap.push_back(idx.first);
 						merged_normals[idx.first] += normals[idx.second];
 						merged_normals_counts[idx.first]++;


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/53818 @Calinou 

This fix works by avoiding the normal merge procedure when uv2s are different and makes generating lod happen after the lightmap generation.

To avoid UV seams, also tried modifying the simplification algorithm from meshoptimzier, but that was a dead end.

Tested using https://github.com/godotengine/godot/files/7349367/test_auto_lod.zip