### PR TITLE
BVH - Fix area-area collision regression

### DIFF
--- a/servers/physics/broad_phase_bvh.cpp
+++ b/servers/physics/broad_phase_bvh.cpp
@@ -34,7 +34,7 @@
 
 BroadPhaseSW::ID BroadPhaseBVH::create(CollisionObjectSW *p_object, int p_subindex, const AABB &p_aabb, bool p_static) {
 	uint32_t tree_id = p_static ? TREE_STATIC : TREE_DYNAMIC;
-	uint32_t tree_collision_mask = p_static ? 0 : (TREE_FLAG_STATIC | TREE_FLAG_DYNAMIC);
+	uint32_t tree_collision_mask = p_static ? TREE_FLAG_DYNAMIC : (TREE_FLAG_STATIC | TREE_FLAG_DYNAMIC);
 	ID oid = bvh.create(p_object, true, tree_id, tree_collision_mask, p_aabb, p_subindex); // Pair everything, don't care?
 	return oid + 1;
 }
@@ -49,7 +49,7 @@ void BroadPhaseBVH::recheck_pairs(ID p_id) {
 
 void BroadPhaseBVH::set_static(ID p_id, bool p_static) {
 	uint32_t tree_id = p_static ? TREE_STATIC : TREE_DYNAMIC;
-	uint32_t tree_collision_mask = p_static ? 0 : (TREE_FLAG_STATIC | TREE_FLAG_DYNAMIC);
+	uint32_t tree_collision_mask = p_static ? TREE_FLAG_DYNAMIC : (TREE_FLAG_STATIC | TREE_FLAG_DYNAMIC);
 	bvh.set_tree(p_id - 1, tree_id, tree_collision_mask, false);
 }
 

--- a/servers/physics_2d/broad_phase_2d_bvh.cpp
+++ b/servers/physics_2d/broad_phase_2d_bvh.cpp
@@ -34,7 +34,7 @@
 
 BroadPhase2DSW::ID BroadPhase2DBVH::create(CollisionObject2DSW *p_object, int p_subindex, const Rect2 &p_aabb, bool p_static) {
 	uint32_t tree_id = p_static ? TREE_STATIC : TREE_DYNAMIC;
-	uint32_t tree_collision_mask = p_static ? 0 : (TREE_FLAG_STATIC | TREE_FLAG_DYNAMIC);
+	uint32_t tree_collision_mask = p_static ? TREE_FLAG_DYNAMIC : (TREE_FLAG_STATIC | TREE_FLAG_DYNAMIC);
 	ID oid = bvh.create(p_object, true, tree_id, tree_collision_mask, p_aabb, p_subindex); // Pair everything, don't care?
 	return oid + 1;
 }
@@ -49,7 +49,7 @@ void BroadPhase2DBVH::recheck_pairs(ID p_id) {
 
 void BroadPhase2DBVH::set_static(ID p_id, bool p_static) {
 	uint32_t tree_id = p_static ? TREE_STATIC : TREE_DYNAMIC;
-	uint32_t tree_collision_mask = p_static ? 0 : (TREE_FLAG_STATIC | TREE_FLAG_DYNAMIC);
+	uint32_t tree_collision_mask = p_static ? TREE_FLAG_DYNAMIC : (TREE_FLAG_STATIC | TREE_FLAG_DYNAMIC);
 	bvh.set_tree(p_id - 1, tree_id, tree_collision_mask, false);
 }
 


### PR DESCRIPTION
Minimal approach to fixing regression whereby static areas where not detect dynamic areas.

Fixes #58555
Alternative to #58505

## Explanation
In the current version there are only two trees, DYNAMIC and STATIC.
Monitorable areas are created as DYNAMIC areas.
Monitoring (but non-monitorable) are created as STATIC areas (strangely enough, given that they can move.. :grinning: ).

In order for monitoring areas to actually detect anything, their tree must be set to collide check against DYNAMICs.

## Notes
* This is the minimum required to fix the regression, and probably most closely matched the previous behaviour
* This should be safe for 3.5 beta 2 if we are unsure about using three trees (the three trees PR enables new functionality for areas to detect STATICS, this does not, as is the status quo). 

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
