### PR TITLE
Double clicking scene tree icon focuses that node

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3286,8 +3286,21 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 					} else {
 						Rect2 rect = get_selected()->get_meta("__focus_rect");
 						Point2 mpos = b->get_position();
+						int icon_size_x = 0;
+						Ref<Texture2D> icon = get_selected()->get_icon(selected_col);
+						if (icon.is_valid()) {
+							Rect2i icon_region = get_selected()->get_icon_region(selected_col);
+							if (icon_region == Rect2i()) {
+								icon_size_x = icon->get_width();
+							} else {
+								icon_size_x = icon_region.size.width;
+							}
+						}
+						// Icon is treated as if it is outside of the rect so that double clicking on it will emit the item_double_clicked signal.
 						if (rtl) {
-							mpos.x = get_size().width - mpos.x;
+							mpos.x = get_size().width - (mpos.x + icon_size_x);
+						} else {
+							mpos.x -= icon_size_x;
 						}
 						if (rect.has_point(mpos)) {
 							if (!edit_selected()) {


### PR DESCRIPTION
Fixes #58441

Left-to-Right

https://user-images.githubusercontent.com/18116695/155843758-63449b7d-8b9a-48cc-8555-935f5f730404.mp4

Right-to-Left

https://user-images.githubusercontent.com/18116695/155843762-0be36774-ab89-4afa-a207-3f3ad05052ac.mp4


