### PR TITLE
Remove ParallaxLayer's invalid dependence on screen_offset

### DIFF
--- a/scene/2d/parallax_background.cpp
+++ b/scene/2d/parallax_background.cpp
@@ -102,9 +102,9 @@ void ParallaxBackground::_update_scroll() {
 		}
 
 		if (ignore_camera_zoom) {
-			l->set_base_offset_and_scale((ofs + screen_offset * (scale - 1)) / scale, 1.0, screen_offset);
+			l->set_base_offset_and_scale((ofs + screen_offset * (scale - 1)) / scale, 1.0);
 		} else {
-			l->set_base_offset_and_scale(ofs, scale, screen_offset);
+			l->set_base_offset_and_scale(ofs, scale);
 		}
 	}
 }

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -39,7 +39,7 @@ void ParallaxLayer::set_motion_scale(const Size2 &p_scale) {
 	if (pb && is_inside_tree()) {
 		Vector2 ofs = pb->get_final_offset();
 		real_t scale = pb->get_scroll_scale();
-		set_base_offset_and_scale(ofs, scale, screen_offset);
+		set_base_offset_and_scale(ofs, scale);
 	}
 }
 
@@ -54,7 +54,7 @@ void ParallaxLayer::set_motion_offset(const Size2 &p_offset) {
 	if (pb && is_inside_tree()) {
 		Vector2 ofs = pb->get_final_offset();
 		real_t scale = pb->get_scroll_scale();
-		set_base_offset_and_scale(ofs, scale, screen_offset);
+		set_base_offset_and_scale(ofs, scale);
 	}
 }
 
@@ -111,9 +111,7 @@ void ParallaxLayer::_notification(int p_what) {
 	}
 }
 
-void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, real_t p_scale, const Point2 &p_screen_offset) {
-	screen_offset = p_screen_offset;
-
+void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, real_t p_scale) {
 	if (!is_inside_tree()) {
 		return;
 	}
@@ -121,7 +119,7 @@ void ParallaxLayer::set_base_offset_and_scale(const Point2 &p_offset, real_t p_s
 		return;
 	}
 
-	Point2 new_ofs = (screen_offset + (p_offset - screen_offset) * motion_scale) + motion_offset * p_scale + orig_offset * p_scale;
+	Point2 new_ofs = p_offset * motion_scale + motion_offset * p_scale + orig_offset * p_scale;
 
 	if (mirroring.x) {
 		real_t den = mirroring.x * p_scale;

--- a/scene/2d/parallax_layer.h
+++ b/scene/2d/parallax_layer.h
@@ -43,8 +43,6 @@ class ParallaxLayer : public Node2D {
 	Vector2 mirroring;
 	void _update_mirroring();
 
-	Point2 screen_offset;
-
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -59,7 +57,7 @@ public:
 	void set_mirroring(const Size2 &p_mirroring);
 	Size2 get_mirroring() const;
 
-	void set_base_offset_and_scale(const Point2 &p_offset, real_t p_scale, const Point2 &p_screen_offset);
+	void set_base_offset_and_scale(const Point2 &p_offset, real_t p_scale);
 
 	TypedArray<String> get_configuration_warnings() const override;
 	ParallaxLayer();


### PR DESCRIPTION
Currently, `ParallaxLayer` is incorrectly incorporating the camera's offset when calculating the layer's offset. This only affects the calculation of the layer's offset when `motion_scale` is not the default `(1, 1)`. This PR correctly calculates the offset and removes the now unused `screen_offset` variable.

Fixes #26470.