### PR TITLE
Fixed wrong inverse for basis_xform_inv

### DIFF
--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -160,9 +160,15 @@ Vector2 Transform2D::basis_xform(const Vector2 &p_vec) const {
 }
 
 Vector2 Transform2D::basis_xform_inv(const Vector2 &p_vec) const {
+	real_t det = basis_determinant();
+#ifdef MATH_CHECKS
+	ERR_FAIL_COND_V(det == 0, Vector2());
+#endif
+	real_t idet = 1.0f / det;
+
 	return Vector2(
-			elements[0].dot(p_vec),
-			elements[1].dot(p_vec));
+			elements[1][1] * idet * p_vec.x + elements[1][0] * -idet * p_vec.y,
+			elements[0][1] * -idet * p_vec.x + elements[0][0] * idet * p_vec.y);
 }
 
 Vector2 Transform2D::xform(const Vector2 &p_vec) const {


### PR DESCRIPTION
Fix for #58556  
Might have to check how it affects other classes using it
Also might need a check for determinant==0 like in `affine_invert()`  
Also noticed that `xform_inv()` a few lines below is using same wrong formula but not sure enough to change it