### PR TITLE
Fixed functions in visual script not showing correct return value type

### DIFF
--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -3536,6 +3536,16 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 		print_error("Category not handled: " + p_category.quote());
 	}
 
+	int new_id = script->get_available_id();
+	undo_redo->create_action(TTR("Add Node"));
+	undo_redo->add_do_method(script.ptr(), "add_node", new_id, vnode, pos);
+	undo_redo->add_undo_method(script.ptr(), "remove_node", new_id);
+	undo_redo->add_do_method(this, "_update_graph", new_id);
+	undo_redo->add_undo_method(this, "_update_graph", new_id);
+	undo_redo->commit_action();
+
+	port_action_new_node = new_id;
+
 	if (Object::cast_to<VisualScriptFunctionCall>(vnode.ptr()) && p_category != "Class" && p_category != "VisualScriptNode") {
 		Vector<String> property_path = p_text.split(":");
 		String class_of_method = property_path[0];
@@ -3640,16 +3650,6 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 		print_error("Not able to create node from category: \"" + p_category + "\" and text \"" + p_text + "\" Not created");
 		return;
 	}
-
-	int new_id = script->get_available_id();
-	undo_redo->create_action(TTR("Add Node"));
-	undo_redo->add_do_method(script.ptr(), "add_node", new_id, vnode, pos);
-	undo_redo->add_undo_method(script.ptr(), "remove_node", new_id);
-	undo_redo->add_do_method(this, "_update_graph", new_id);
-	undo_redo->add_undo_method(this, "_update_graph", new_id);
-	undo_redo->commit_action();
-
-	port_action_new_node = new_id;
 
 	String base_script = "";
 	String base_type = "";


### PR DESCRIPTION
#58535 
In `VisualScriptEditor::_selected_connect_node`:
```
if (Object::cast_to<VisualScriptFunctionCall>(vnode.ptr()) && p_category != "Class" && p_category != "VisualScriptNode") {
	Vector<String> property_path = p_text.split(":");
	String class_of_method = property_path[0];
	String method_name = property_path[1];

	Ref<VisualScriptFunctionCall> vsfc = vnode;
	vsfc->set_function(method_name);
```
`vsfc->set_function(method_name)` causes `VisualScriptFunctionCall::get_output_value_port_info` to be called which sets the return value type using `ret = method_cache.return_val;`. But `method_cache.return_val` is set in `VisualScriptFunctionCall::_update_method_cache` only if 
```
MethodBind *mb = ClassDB::get_method(type, function);
if (mb) {
	use_default_args = mb->get_default_argument_count();
	method_cache = MethodInfo();
```
`mb` is valid, but it never is because `type` is always empty when `call_mode == CALL_MODE_SELF`, because: 
```
else if (call_mode == CALL_MODE_SELF) {
	if (get_visual_script().is_valid()) {
		type = get_visual_script()->get_instance_base_type();
		base_type = type; //cache, too
		script = get_visual_script();
	}
```
`get_visual_script().is_valid()` is never valid because it is set with `VisualScript::add_node` function which is called after the `vsfc->set_function(method_name)`, so `type` never gets set.
In Godot 3.4  this block of code (which calls `VisualScript::add_node`):
```
int new_id = script->get_available_id();
undo_redo->create_action(TTR("Add Node"));
undo_redo->add_do_method(script.ptr(), "add_node", new_id, vnode, pos);
undo_redo->add_undo_method(script.ptr(), "remove_node", new_id);
undo_redo->add_do_method(this, "_update_graph", new_id);
undo_redo->add_undo_method(this, "_update_graph", new_id);
undo_redo->commit_action();
```
was called before `vsfc->set_function(method_name)`, so it worked correctly. Now after moving it before `vsfc->set_function(method_name)` it appears to also work correctly:

https://user-images.githubusercontent.com/25117425/155870573-027b55ab-f545-484e-82d8-c23ce161cf4e.mp4

<i>Bugsquad edit</i>: Fix #58535

