### PR TITLE
[iOS] Fix multitouch not working correctly

### DIFF
--- a/platform/iphone/godot_view.mm
+++ b/platform/iphone/godot_view.mm
@@ -154,6 +154,8 @@ static const float earth_gravity = 9.80665;
 
 	[self initTouches];
 
+	self.multipleTouchEnabled = YES;
+
 	// Configure and start accelerometer
 	if (!self.motionManager) {
 		self.motionManager = [[CMMotionManager alloc] init];


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/58550.
Enabled `GodotViewGestureRecognizer` to connect multiple touches to the view it's connected to.

Can be cherry-picked to the `3.x` and `3.4` branches.