### PR TITLE
`Joint2D` and `Joint3D`: disconnect only connected signals

### DIFF
--- a/scene/2d/joint_2d.cpp
+++ b/scene/2d/joint_2d.cpp
@@ -128,7 +128,7 @@ void Joint2D::set_node_a(const NodePath &p_node_a) {
 		return;
 	}
 
-	if (joint.is_valid()) {
+	if (is_configured()) {
 		_disconnect_signals();
 	}
 
@@ -145,7 +145,7 @@ void Joint2D::set_node_b(const NodePath &p_node_b) {
 		return;
 	}
 
-	if (joint.is_valid()) {
+	if (is_configured()) {
 		_disconnect_signals();
 	}
 
@@ -164,7 +164,7 @@ void Joint2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			if (joint.is_valid()) {
+			if (is_configured()) {
 				_disconnect_signals();
 				_update_joint(true);
 			}

--- a/scene/3d/joint_3d.cpp
+++ b/scene/3d/joint_3d.cpp
@@ -124,7 +124,7 @@ void Joint3D::set_node_a(const NodePath &p_node_a) {
 		return;
 	}
 
-	if (joint.is_valid()) {
+	if (is_configured()) {
 		_disconnect_signals();
 	}
 
@@ -141,7 +141,7 @@ void Joint3D::set_node_b(const NodePath &p_node_b) {
 		return;
 	}
 
-	if (joint.is_valid()) {
+	if (is_configured()) {
 		_disconnect_signals();
 	}
 
@@ -171,7 +171,7 @@ void Joint3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
-			if (joint.is_valid()) {
+			if (is_configured()) {
 				_disconnect_signals();
 				_update_joint(true);
 			}


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/55473 and fixes https://github.com/godotengine/godot/issues/58312.

In the `NOTIFICATION_EXIT_TREE` there is additionally a call to `_update_joint(true)`. My impression was that this call could stay within the same conditional (as it is in this PR), but let me know if it should be moved outside instead.