### PR TITLE
Remove files_dropped signal from SceneTree

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -232,13 +232,6 @@
 		</member>
 	</members>
 	<signals>
-		<signal name="files_dropped">
-			<argument index="0" name="files" type="PackedStringArray" />
-			<argument index="1" name="screen" type="int" />
-			<description>
-				Emitted when files are dragged from the OS file manager and dropped in the game window. The arguments are a list of file paths and the identifier of the screen where the drag originated.
-			</description>
-		</signal>
 		<signal name="node_added">
 			<argument index="0" name="node" type="Node" />
 			<description>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -348,6 +348,7 @@
 		<signal name="files_dropped">
 			<argument index="0" name="files" type="PackedStringArray" />
 			<description>
+				Emitted when files are dragged from the OS file manager and dropped in the game window. The argument is a list of file paths.
 			</description>
 		</signal>
 		<signal name="focus_entered">

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1256,8 +1256,6 @@ void SceneTree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("process_frame"));
 	ADD_SIGNAL(MethodInfo("physics_frame"));
 
-	ADD_SIGNAL(MethodInfo("files_dropped", PropertyInfo(Variant::PACKED_STRING_ARRAY, "files"), PropertyInfo(Variant::INT, "screen")));
-
 	BIND_ENUM_CONSTANT(GROUP_CALL_DEFAULT);
 	BIND_ENUM_CONSTANT(GROUP_CALL_REVERSE);
 	BIND_ENUM_CONSTANT(GROUP_CALL_REALTIME);


### PR DESCRIPTION
Fixes #57442
In Godot 4 the `files_dropped` signal was moved to `Window`, but in `SceneTree` the signal was still declared, but never emitted.
