### PR TITLE
Clamp BaseMaterial3D triplanar sharpness to values that never look broken

### DIFF
--- a/doc/classes/BaseMaterial3D.xml
+++ b/doc/classes/BaseMaterial3D.xml
@@ -369,6 +369,7 @@
 		</member>
 		<member name="uv1_triplanar_sharpness" type="float" setter="set_uv1_triplanar_blend_sharpness" getter="get_uv1_triplanar_blend_sharpness" default="1.0">
 			A lower number blends the texture more softly while a higher number blends the texture more sharply.
+			[b]Note:[/b] [member uv1_triplanar_sharpness] is clamped between [code]0.0[/code] and [code]150.0[/code] (inclusive) as values outside that range can look broken depending on the mesh.
 		</member>
 		<member name="uv1_world_triplanar" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], triplanar mapping for [code]UV[/code] is calculated in world space rather than object local space. See also [member uv1_triplanar].
@@ -384,6 +385,7 @@
 		</member>
 		<member name="uv2_triplanar_sharpness" type="float" setter="set_uv2_triplanar_blend_sharpness" getter="get_uv2_triplanar_blend_sharpness" default="1.0">
 			A lower number blends the texture more softly while a higher number blends the texture more sharply.
+			[b]Note:[/b] [member uv2_triplanar_sharpness] is clamped between [code]0.0[/code] and [code]150.0[/code] (inclusive) as values outside that range can look broken depending on the mesh.
 		</member>
 		<member name="uv2_world_triplanar" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], triplanar mapping for [code]UV2[/code] is calculated in world space rather than object local space. See also [member uv2_triplanar].

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1873,8 +1873,9 @@ Vector3 BaseMaterial3D::get_uv1_offset() const {
 }
 
 void BaseMaterial3D::set_uv1_triplanar_blend_sharpness(float p_sharpness) {
-	uv1_triplanar_sharpness = p_sharpness;
-	RS::get_singleton()->material_set_param(_get_material(), shader_names->uv1_blend_sharpness, p_sharpness);
+	// Negative values or values higher than 150 can result in NaNs, leading to broken rendering.
+	uv1_triplanar_sharpness = CLAMP(p_sharpness, 0.0, 150.0);
+	RS::get_singleton()->material_set_param(_get_material(), shader_names->uv1_blend_sharpness, uv1_triplanar_sharpness);
 }
 
 float BaseMaterial3D::get_uv1_triplanar_blend_sharpness() const {
@@ -1900,8 +1901,9 @@ Vector3 BaseMaterial3D::get_uv2_offset() const {
 }
 
 void BaseMaterial3D::set_uv2_triplanar_blend_sharpness(float p_sharpness) {
-	uv2_triplanar_sharpness = p_sharpness;
-	RS::get_singleton()->material_set_param(_get_material(), shader_names->uv2_blend_sharpness, p_sharpness);
+	// Negative values or values higher than 150 can result in NaNs, leading to broken rendering.
+	uv2_triplanar_sharpness = CLAMP(p_sharpness, 0.0, 150.0);
+	RS::get_singleton()->material_set_param(_get_material(), shader_names->uv2_blend_sharpness, uv2_triplanar_sharpness);
 }
 
 float BaseMaterial3D::get_uv2_triplanar_blend_sharpness() const {


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/58601.

An alternative solution I was thinking about was to switch to a "hard" cutoff that only performs one sample per pixel when the sharpness is greater than 150. This would also improve performance in situations where you don't need triplanar mapping to smoothly blend between textures (e.g. in hard surface level design with CSG nodes).
That said, this may be better suited to a dedicated boolean property.

This closes https://github.com/godotengine/godot/issues/58587.

**Testing project:** [test_triplanar2.zip](https://github.com/godotengine/godot/files/8149211/test_triplanar2.zip)
 