### PR TITLE
Clamp SpatialMaterial triplanar sharpness to values that never look broken

### DIFF
--- a/doc/classes/SpatialMaterial.xml
+++ b/doc/classes/SpatialMaterial.xml
@@ -360,6 +360,7 @@
 		</member>
 		<member name="uv1_triplanar_sharpness" type="float" setter="set_uv1_triplanar_blend_sharpness" getter="get_uv1_triplanar_blend_sharpness" default="1.0">
 			A lower number blends the texture more softly while a higher number blends the texture more sharply.
+			[b]Note:[/b] [member uv1_triplanar_sharpness] is clamped between [code]0.0[/code] and [code]150.0[/code] (inclusive) as values outside that range can look broken depending on the mesh.
 		</member>
 		<member name="uv2_offset" type="Vector3" setter="set_uv2_offset" getter="get_uv2_offset" default="Vector3( 0, 0, 0 )">
 			How much to offset the [code]UV2[/code] coordinates. This amount will be added to [code]UV2[/code] in the vertex function. This can be used to offset a texture.
@@ -372,6 +373,7 @@
 		</member>
 		<member name="uv2_triplanar_sharpness" type="float" setter="set_uv2_triplanar_blend_sharpness" getter="get_uv2_triplanar_blend_sharpness" default="1.0">
 			A lower number blends the texture more softly while a higher number blends the texture more sharply.
+			[b]Note:[/b] [member uv2_triplanar_sharpness] is clamped between [code]0.0[/code] and [code]150.0[/code] (inclusive) as values outside that range can look broken depending on the mesh.
 		</member>
 		<member name="vertex_color_is_srgb" type="bool" setter="set_flag" getter="get_flag" default="false">
 			If [code]true[/code], the model's vertex colors are processed as sRGB mode.

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1519,8 +1519,9 @@ Vector3 SpatialMaterial::get_uv1_offset() const {
 }
 
 void SpatialMaterial::set_uv1_triplanar_blend_sharpness(float p_sharpness) {
-	uv1_triplanar_sharpness = p_sharpness;
-	VS::get_singleton()->material_set_param(_get_material(), shader_names->uv1_blend_sharpness, p_sharpness);
+	// Negative values or values higher than 150 can result in NaNs, leading to broken rendering.
+	uv1_triplanar_sharpness = CLAMP(p_sharpness, 0.0, 150.0);
+	VS::get_singleton()->material_set_param(_get_material(), shader_names->uv1_blend_sharpness, uv1_triplanar_sharpness);
 }
 
 float SpatialMaterial::get_uv1_triplanar_blend_sharpness() const {
@@ -1546,8 +1547,9 @@ Vector3 SpatialMaterial::get_uv2_offset() const {
 }
 
 void SpatialMaterial::set_uv2_triplanar_blend_sharpness(float p_sharpness) {
-	uv2_triplanar_sharpness = p_sharpness;
-	VS::get_singleton()->material_set_param(_get_material(), shader_names->uv2_blend_sharpness, p_sharpness);
+	// Negative values or values higher than 150 can result in NaNs, leading to broken rendering.
+	uv2_triplanar_sharpness = CLAMP(p_sharpness, 0.0, 150.0);
+	VS::get_singleton()->material_set_param(_get_material(), shader_names->uv2_blend_sharpness, uv2_triplanar_sharpness);
 }
 
 float SpatialMaterial::get_uv2_triplanar_blend_sharpness() const {


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/58600.

This closes https://github.com/godotengine/godot/issues/58587.