### PR TITLE
Document how to fix thin FogVolumes flickering when the camera moves

### DIFF
--- a/doc/classes/FogVolume.xml
+++ b/doc/classes/FogVolume.xml
@@ -12,6 +12,7 @@
 	<members>
 		<member name="extents" type="Vector3" setter="set_extents" getter="get_extents" default="Vector3(1, 1, 1)">
 			Sets the size of the [FogVolume] when [member shape] is [constant RenderingServer.FOG_VOLUME_SHAPE_ELLIPSOID] or [constant RenderingServer.FOG_VOLUME_SHAPE_BOX].
+			[b]Note:[/b] Thin fog volumes may appear to flicker when the camera moves or rotates. This can be alleviated by increasing [member ProjectSettings.rendering/environment/volumetric_fog/volume_depth] (at a performance cost) or by decreasing [member Environment.volumetric_fog_length] (at no performance cost, but at the cost of lower fog range). Alternatively, the [FogVolume] can be made thicker and use a lower density in the [member material].
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
 			Sets the [Material] to be used by the [FogVolume]. Can be either a [FogMaterial] or a custom [ShaderMaterial].


### PR DESCRIPTION
This is a common issue when setting up fog volumes for small details, so it makes sense to document it in the class reference.

**Note:** Not cherry-pickable to `3.x` as FogVolumes aren't implemented there.