### PR TITLE
Fix execution of physics picking events at unexpected times

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -519,6 +519,11 @@ void Viewport::_process_picking() {
 	if (to_screen_rect != Rect2i() && Input::get_singleton()->get_mouse_mode() == Input::MOUSE_MODE_CAPTURED) {
 		return;
 	}
+	if (!gui.mouse_in_viewport) {
+		// Clear picking events if mouse has left viewport.
+		physics_picking_events.clear();
+		return;
+	}
 
 	_drop_physics_mouseover(true);
 


### PR DESCRIPTION
resolves no longer #57588 because that was fixed elsewhere
resolve #57723

Since physics picking happens after event processing, it can happen, that after moving the mouse out of the viewport, physics picking events gets interpreted.

This patch resolves this problem by ensuring that the mouse is in a position, where physics picking makes sense before executing them.
When physics picking doesn't make sense, the physics picking events should be dropped, because otherwise they will get executed at a later time, when nobody would expect them anymore.

Update 2022-10-06: Simplify patch to address only the remaining issue