### PR TITLE
Fade screen-space reflection towards inner margin

### DIFF
--- a/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/screen_space_reflection.glsl
@@ -182,17 +182,18 @@ void main() {
 	if (found) {
 		float margin_blend = 1.0;
 
-		vec2 margin = vec2((params.screen_size.x + params.screen_size.y) * 0.5 * 0.05); // make a uniform margin
-		if (any(bvec4(lessThan(pos, -margin), greaterThan(pos, params.screen_size + margin)))) {
-			// clip outside screen + margin
+		vec2 margin = vec2((params.screen_size.x + params.screen_size.y) * 0.05); // make a uniform margin
+		if (any(bvec4(lessThan(pos, vec2(0.0, 0.0)), greaterThan(pos, params.screen_size)))) {
+			// clip at the screen edges
 			imageStore(ssr_image, ssC, vec4(0.0));
 			return;
 		}
 
 		{
-			//blend fading out towards external margin
-			vec2 margin_grad = mix(pos - params.screen_size, -pos, lessThan(pos, vec2(0.0)));
-			margin_blend = 1.0 - smoothstep(0.0, margin.x, max(margin_grad.x, margin_grad.y));
+			//blend fading out towards inner margin
+			// 0.5 = midpoint of reflection
+			vec2 margin_grad = mix(params.screen_size - pos, pos, lessThan(pos, params.screen_size * 0.5));
+			margin_blend = smoothstep(0.0, margin.x * margin.y, margin_grad.x * margin_grad.y);
 			//margin_blend = 1.0;
 		}
 


### PR DESCRIPTION
This is a forward-port of https://github.com/godotengine/godot/pull/41892 for `master`, as it's still relevant there.

- Fade reflection towards inner margin and clip it at screen edges instead of external margin.
- Round edges of the fade margin if both are being cut off to prevent sharp corners.

## Preview

*Pay attention to the 3D viewport's edges (especially the top edge on these videos).*

*The SSR artifacts appearing on the whole viewport are unrelated to this PR, and are a [general regression in `master`](https://github.com/godotengine/godot/issues/56845).*

### Before

*Sudden cutoff of screen-space reflections.*

https://user-images.githubusercontent.com/180032/155904946-fcb93962-b642-4c66-b64e-977f07ef5a16.mp4

### After

*Smooth, gradual fading of screen-space reflections as they get closer to the viewport's edges.*

https://user-images.githubusercontent.com/180032/155904952-add0b41b-82f1-4fd9-adce-768746131e74.mp4