### PR TITLE
Remove broken, unused filtering code in the SSR scale shader

### DIFF
--- a/servers/rendering/renderer_rd/effects_rd.cpp
+++ b/servers/rendering/renderer_rd/effects_rd.cpp
@@ -607,7 +607,6 @@ void EffectsRD::screen_space_reflection(RID p_diffuse, RID p_normal_roughness, R
 		ssr_scale.push_constant.camera_z_far = p_camera.get_z_far();
 		ssr_scale.push_constant.camera_z_near = p_camera.get_z_near();
 		ssr_scale.push_constant.orthogonal = p_camera.is_orthogonal();
-		ssr_scale.push_constant.filter = false; //enabling causes arctifacts
 		ssr_scale.push_constant.screen_size[0] = p_screen_size.x;
 		ssr_scale.push_constant.screen_size[1] = p_screen_size.y;
 

--- a/servers/rendering/renderer_rd/effects_rd.h
+++ b/servers/rendering/renderer_rd/effects_rd.h
@@ -772,8 +772,7 @@ private:
 		float camera_z_far;
 
 		uint32_t orthogonal;
-		uint32_t filter;
-		uint32_t pad[2];
+		uint32_t pad[3];
 	};
 
 	struct ScreenSpaceReflectionScale {

--- a/servers/rendering/renderer_rd/shaders/screen_space_reflection_scale.glsl
+++ b/servers/rendering/renderer_rd/shaders/screen_space_reflection_scale.glsl
@@ -19,8 +19,7 @@ layout(push_constant, std430) uniform Params {
 	float camera_z_far;
 
 	bool orthogonal;
-	bool filtered;
-	uint pad[2];
+	uint pad[3];
 }
 params;
 
@@ -31,58 +30,23 @@ void main() {
 	if (any(greaterThanEqual(ssC, params.screen_size))) { //too large, do nothing
 		return;
 	}
-	//do not filter, SSR will generate arctifacts if this is done
 
 	float divisor = 0.0;
 	vec4 color;
 	float depth;
 	vec4 normal;
 
-	if (params.filtered) {
-		color = vec4(0.0);
-		depth = 0.0;
-		normal = vec4(0.0);
+	color = texelFetch(source_ssr, ssC << 1, 0);
+	depth = texelFetch(source_depth, ssC << 1, 0).r;
+	normal = texelFetch(source_normal, ssC << 1, 0);
 
-		for (int i = 0; i < 4; i++) {
-			ivec2 ofs = ssC << 1;
-			if (bool(i & 1)) {
-				ofs.x += 1;
-			}
-			if (bool(i & 2)) {
-				ofs.y += 1;
-			}
-			color += texelFetch(source_ssr, ofs, 0);
-			float d = texelFetch(source_depth, ofs, 0).r;
-			vec4 nr = texelFetch(source_normal, ofs, 0);
-			normal.xyz += nr.xyz * 2.0 - 1.0;
-			normal.w += nr.w;
-
-			d = d * 2.0 - 1.0;
-			if (params.orthogonal) {
-				d = ((d + (params.camera_z_far + params.camera_z_near) / (params.camera_z_far - params.camera_z_near)) * (params.camera_z_far - params.camera_z_near)) / 2.0;
-			} else {
-				d = 2.0 * params.camera_z_near * params.camera_z_far / (params.camera_z_far + params.camera_z_near - d * (params.camera_z_far - params.camera_z_near));
-			}
-			depth += -d;
-		}
-
-		color /= 4.0;
-		depth /= 4.0;
-		normal.xyz = normalize(normal.xyz / 4.0) * 0.5 + 0.5;
-		normal.w /= 4.0;
+	depth = depth * 2.0 - 1.0;
+	if (params.orthogonal) {
+		depth = ((depth + (params.camera_z_far + params.camera_z_near) / (params.camera_z_far - params.camera_z_near)) * (params.camera_z_far - params.camera_z_near)) / 2.0;
 	} else {
-		color = texelFetch(source_ssr, ssC << 1, 0);
-		depth = texelFetch(source_depth, ssC << 1, 0).r;
-		normal = texelFetch(source_normal, ssC << 1, 0);
-
-		depth = depth * 2.0 - 1.0;
-		if (params.orthogonal) {
-			depth = ((depth + (params.camera_z_far + params.camera_z_near) / (params.camera_z_far - params.camera_z_near)) * (params.camera_z_far - params.camera_z_near)) / 2.0;
-		} else {
-			depth = 2.0 * params.camera_z_near * params.camera_z_far / (params.camera_z_far + params.camera_z_near - depth * (params.camera_z_far - params.camera_z_near));
-		}
-		depth = -depth;
+		depth = 2.0 * params.camera_z_near * params.camera_z_far / (params.camera_z_far + params.camera_z_near - depth * (params.camera_z_far - params.camera_z_near));
 	}
+	depth = -depth;
 
 	imageStore(dest_ssr, ssC, color);
 	imageStore(dest_depth, ssC, vec4(depth));


### PR DESCRIPTION
This code still led to noticeable artifacting when manually enabled in the latest `master` branch.

**Testing project:** [test_ssr_roughness_master.zip](https://github.com/godotengine/godot-proposals/files/8008939/test_ssr_roughness_master.zip)

## Preview

*Screen-space reflections' Depth Tolerance property is set to 1.0, following https://github.com/godotengine/godot/pull/57719. With the default value of 0.2, artifacting is even worse when filtering is enabled.*

### Current appearance

![2022-02-28_00 46 52_filter_disabled](https://user-images.githubusercontent.com/180032/155905275-f0b05757-254e-4f01-bc05-89d0d0f0fd24.png)

### With `filtered` set to `true` and the editor recompiled

![2022-02-28_00 44 34_filter_enabled](https://user-images.githubusercontent.com/180032/155905274-6082b238-a864-482b-8441-dd4613353966.png)