### PR TITLE
Use 16-bit depth texture for screen-space reflections

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1967,7 +1967,8 @@ void RendererSceneRenderRD::_process_ssr(RID p_render_buffers, RID p_dest_frameb
 
 	if (rb->ssr.depth_scaled.is_null()) {
 		RD::TextureFormat tf;
-		tf.format = RD::DATA_FORMAT_R32_SFLOAT;
+		// Use 16-bit texture to improve performance.
+		tf.format = RD::DATA_FORMAT_R16_SFLOAT;
 		tf.width = rb->internal_width / 2;
 		tf.height = rb->internal_height / 2;
 		tf.texture_type = RD::TEXTURE_TYPE_2D;

--- a/servers/rendering/renderer_rd/shaders/screen_space_reflection.glsl
+++ b/servers/rendering/renderer_rd/shaders/screen_space_reflection.glsl
@@ -7,7 +7,7 @@
 layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
 layout(rgba16f, set = 0, binding = 0) uniform restrict readonly image2D source_diffuse;
-layout(r32f, set = 0, binding = 1) uniform restrict readonly image2D source_depth;
+layout(r16f, set = 0, binding = 1) uniform restrict readonly image2D source_depth;
 layout(rgba16f, set = 1, binding = 0) uniform restrict writeonly image2D ssr_image;
 #ifdef MODE_ROUGH
 layout(r8, set = 1, binding = 1) uniform restrict writeonly image2D blur_radius_image;

--- a/servers/rendering/renderer_rd/shaders/screen_space_reflection_filter.glsl
+++ b/servers/rendering/renderer_rd/shaders/screen_space_reflection_filter.glsl
@@ -14,7 +14,7 @@ layout(rgba16f, set = 2, binding = 0) uniform restrict writeonly image2D dest_ss
 #ifndef VERTICAL_PASS
 layout(r8, set = 2, binding = 1) uniform restrict writeonly image2D dest_radius;
 #endif
-layout(r32f, set = 3, binding = 0) uniform restrict readonly image2D source_depth;
+layout(r16f, set = 3, binding = 0) uniform restrict readonly image2D source_depth;
 
 layout(push_constant, std430) uniform Params {
 	vec4 proj_info;

--- a/servers/rendering/renderer_rd/shaders/screen_space_reflection_scale.glsl
+++ b/servers/rendering/renderer_rd/shaders/screen_space_reflection_scale.glsl
@@ -10,7 +10,7 @@ layout(set = 0, binding = 0) uniform sampler2D source_ssr;
 layout(set = 1, binding = 0) uniform sampler2D source_depth;
 layout(set = 1, binding = 1) uniform sampler2D source_normal;
 layout(rgba16f, set = 2, binding = 0) uniform restrict writeonly image2D dest_ssr;
-layout(r32f, set = 3, binding = 0) uniform restrict writeonly image2D dest_depth;
+layout(r16f, set = 3, binding = 0) uniform restrict writeonly image2D dest_depth;
 layout(rgba8, set = 3, binding = 1) uniform restrict writeonly image2D dest_normal;
 
 layout(push_constant, std430) uniform Params {


### PR DESCRIPTION
This improves performance by using a lower precision texture, similar to what is being done in SSAO and SSIL already.

On a GTX 1080 in 2560×1440, this saves 0.1 ms of frametime for a nearly identical appearance.

## Performance

Average over 10 seconds (two runs each):

| Before | After |
|-|-|
| 312 FPS (3.20 mspf) | 322 FPS (3.10 mspf) |

## Preview

### Before

![image](https://user-images.githubusercontent.com/180032/155906659-ee32c8db-0ba0-4a4e-a2c2-e1e1d9ded569.png)

### After

![image](https://user-images.githubusercontent.com/180032/155906622-ff03c5cc-a984-4ecb-870e-43d0dcec486d.png)
