### PR TITLE
Fix `AnimatedSprite` infinite loop

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -158,14 +158,14 @@ void AnimatedSprite2D::_notification(int p_what) {
 				return;
 			}
 
-			double speed = frames->get_animation_speed(animation) * speed_scale;
-			if (speed == 0) {
-				return; //do nothing
-			}
-
 			double remaining = get_process_delta_time();
 
 			while (remaining) {
+				double speed = frames->get_animation_speed(animation) * speed_scale;
+				if (speed == 0) {
+					return; // Do nothing.
+				}
+
 				if (timeout <= 0) {
 					timeout = _get_frame_duration();
 

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1019,14 +1019,14 @@ void AnimatedSprite3D::_notification(int p_what) {
 				return;
 			}
 
-			float speed = frames->get_animation_speed(animation);
-			if (speed == 0) {
-				return; //do nothing
-			}
-
 			double remaining = get_process_delta_time();
 
 			while (remaining) {
+				double speed = frames->get_animation_speed(animation);
+				if (speed == 0) {
+					return; // Do nothing.
+				}
+
 				if (timeout <= 0) {
 					timeout = 1.0 / speed;
 


### PR DESCRIPTION
Fixes #38052

I moved the speed check into the `while` loop, so that speed changes after handling signals can be caught.

In addition to playing an freeze frame animation, speed change can also happen if `speed_scale` is set to 0 when handling the signal.