### PR TITLE
Fix gridmap cursor showing the wrong mesh

### DIFF
--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -930,6 +930,7 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 	}
 
 	update_palette();
+	_update_cursor_instance();
 
 	set_process(true);
 


### PR DESCRIPTION
Fixes #59742

When there are two gridmaps in a scene with their own meshlibraries, switching between them will not update the cursor (mesh preview) when moving the mouse over the grid without placing the tile. Actually placing the tile will place the correct mesh, so it's only the cursor with the incorrect rendering.

This PR fixes this issue by updating the cursor every time a gridmap node is selected.

Here is a screencap demonstrating this problem with the sample project:

https://user-images.githubusercontent.com/5725958/155947155-80fe16a4-9452-49b9-a0b6-38f4e7172a8b.mp4

When the red gridmap is selected, the cursor becomes the red mesh. Switching to the blue gridmap incorrectly keeps the red mesh as the cursor.

Sample project: [godot-gridmap-test.zip](https://github.com/godotengine/godot/files/8151612/godot-gridmap-test.zip)

The sample project is for v3.4.3 but this same behavior is in v4.0-alpha3.
