### PR TITLE
[3.x] Make string inside `TTR()` single-line

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -2203,9 +2203,7 @@ bool EditorExportPlatformAndroid::can_export(const Ref<EditorExportPreset> &p_pr
 		bool godot_google_play_billing_enabled = p_preset->get("plugins/GodotGooglePlayBilling");
 		if (!godot_google_play_billing_enabled) {
 			valid = false;
-			err += TTR("Invalid \"GodotPaymentV3\" module included in the \"android/modules\" project setting (changed in Godot 3.2.2).\n"
-					   "Replace it with the first-party \"GodotGooglePlayBilling\" plugin.\n"
-					   "Note that the singleton was also renamed from \"GodotPayments\" to \"GodotGooglePlayBilling\".");
+			err += TTR("Invalid \"GodotPaymentV3\" module included in the \"android/modules\" project setting (changed in Godot 3.2.2).\nReplace it with the first-party \"GodotGooglePlayBilling\" plugin.\nNote that the singleton was also renamed from \"GodotPayments\" to \"GodotGooglePlayBilling\".");
 			err += "\n";
 		}
 	}


### PR DESCRIPTION
Currently `TTR()` extraction only works line by line, so only the first line is extracted:

https://github.com/godotengine/godot/blob/a76316c0f06ef63f9b818d1ee8fd8771f73e4f3f/editor/translations/editor.pot#L13308-L13312