### PR TITLE
Fixes camera preview toggle in additional editor viewports not disappearing corectly causing a crash

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -378,7 +378,7 @@ private:
 	Node3DEditor *spatial_editor;
 
 	Camera3D *previewing;
-	Camera3D *preview;
+	Camera3D *preview = nullptr;
 
 	bool previewing_cinema;
 	bool _is_node_locked(const Node *p_node);


### PR DESCRIPTION
Fixes #57357


https://user-images.githubusercontent.com/25117425/156004073-226fa4a6-dcb5-4329-af45-9c9bfab4a9d6.mp4



Because `preview` was not initialized to `nullptr` it contained garbage value and failed the  `ERR_FAIL_COND(p_activate && !preview)` check which caused the crash.
```cpp
void Node3DEditorViewport::_toggle_camera_preview(bool p_activate) {
	ERR_FAIL_COND(p_activate && !preview);
	ERR_FAIL_COND(!p_activate && !previewing);

	rotation_control->set_visible(!p_activate);

	if (!p_activate) {
		previewing->disconnect("tree_exiting", callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
		previewing = nullptr;
		RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), camera->get_camera()); //restore
		if (!preview) {
			preview_camera->hide();
		}
		surface->update();

	} else {
		previewing = preview;
		previewing->connect("tree_exiting", callable_mp(this, &Node3DEditorViewport::_preview_exited_scene));
		RS::get_singleton()->viewport_attach_camera(viewport->get_viewport_rid(), preview->get_camera()); //replace
		surface->update();
	}
}
```

