### PR TITLE
Use memory pools for Variant extended types

### DIFF
--- a/core/error_macros.cpp
+++ b/core/error_macros.cpp
@@ -36,6 +36,12 @@
 
 static ErrorHandlerList *error_handler_list = nullptr;
 
+// This has to be accessible from low level headers,
+// and cannot be in Engine or OS to avoid circular includes.
+namespace Godot {
+bool g_leak_reporting_enabled = true;
+}
+
 void add_error_handler(ErrorHandlerList *p_handler) {
 	_global_lock();
 	p_handler->next = error_handler_list;

--- a/core/error_macros.h
+++ b/core/error_macros.h
@@ -60,6 +60,10 @@ enum ErrorHandlerType {
 class String;
 typedef void (*ErrorHandlerFunc)(void *, const char *, const char *, int p_line, const char *, const char *, ErrorHandlerType p_type);
 
+namespace Godot {
+extern bool g_leak_reporting_enabled;
+}
+
 struct ErrorHandlerList {
 	ErrorHandlerFunc errfunc;
 	void *userdata;

--- a/core/variant.h
+++ b/core/variant.h
@@ -45,6 +45,7 @@
 #include "core/math/vector3.h"
 #include "core/node_path.h"
 #include "core/object_id.h"
+#include "core/paged_allocator.h"
 #include "core/pool_vector.h"
 #include "core/ref_ptr.h"
 #include "core/rid.h"
@@ -161,6 +162,12 @@ private:
 		void *_ptr; //generic pointer
 		uint8_t _mem[sizeof(ObjData) > (sizeof(real_t) * 4) ? sizeof(ObjData) : (sizeof(real_t) * 4)];
 	} _data GCC_ALIGNED_8;
+
+	// Use memory pools for larger attached types, this is crucial as alloc / frees are done frequently
+	static PagedAllocator<Transform, true> _pool_transforms;
+	static PagedAllocator<Transform2D, true> _pool_transform2ds;
+	static PagedAllocator<::AABB, true> _pool_aabbs;
+	static PagedAllocator<Basis, true> _pool_bases;
 
 	void reference(const Variant &p_variant);
 	void clear();

--- a/platform/x11/detect_prime.cpp
+++ b/platform/x11/detect_prime.cpp
@@ -177,6 +177,11 @@ int detect_prime() {
 		} else {
 			// In child, exit() here will not quit the engine.
 
+			// Prevent false leak reports as we will not be properly
+			// cleaning up these processes, and fork() makes a copy
+			// of all globals.
+			Godot::g_leak_reporting_enabled = false;
+
 			char string[201];
 
 			close(fdset[0]);


### PR DESCRIPTION
Memory pools allow O(1) allocation / free times for the rapid allocations required by Variant. This can both increase performance, and reduce hiccups.

This is first of a series of PRs I'll do to try and convert some of our frequent small allocations to use memory pools. Variant is a good target as it should make gdscript etc run better as well as the engine.

This PR also fixes a bug in `PagedAllocator` where `allocs_available` was changed outside a lock, and changes spinlocks to mutexes (as advised by @reduz).

## detect_prime() and preventing false leak messages
This should be straight forward aside from one aspect: I discovered that during the `detect_prime` function on X11, `fork()` is called, which unlike threads, makes a copy of all the globals. These new processes are not cleanly shutdown, and thus report leaks.

It probably isn't viable to go for a clean shutdown in these cases (the whole `detect_prime` system is a bit hacky, because there is no easy way to do it), so to prevent these false error messages, I have added a simple on/off bool (`leak_reporting_enabled`).

I initially tried to put this setting in `OS`, however there was a problem of circular includes with it in OS or Engine. So instead I've put it in `error_macros`, which isn't ideal, but leak reporting is to do with errors so it makes some sense. If a better way of doing this can be suggested I will change.

Without this mechanism the false errors appear something like this at startup:
```
ERROR: Pages in use exist at exit in PagedAllocator
   at: ~PagedAllocator (./core/paged_allocator.h:129)
ERROR: Pages in use exist at exit in PagedAllocator
   at: ~PagedAllocator (./core/paged_allocator.h:129)
ERROR: Pages in use exist at exit in PagedAllocator
   at: ~PagedAllocator (./core/paged_allocator.h:129)
ERROR: Pages in use exist at exit in PagedAllocator
   at: ~PagedAllocator (./core/paged_allocator.h:129)
ERROR: Pages in use exist at exit in PagedAllocator
   at: ~PagedAllocator (./core/paged_allocator.h:129)
ERROR: Pages in use exist at exit in PagedAllocator
   at: ~PagedAllocator (./core/paged_allocator.h:129)
```

## Notes
* On discussion with @reduz I am using PagedAllocator for the pools.
* We may be able to pass the argument to `alloc()` to avoid double construction. I tried the `alloc()` version that passed arguments from Godot 4.x but it didn't pass CI for windows (perhaps uses some later c++ version feature?).
* `leak_reporting_enabled` may possibly need to be set on other platforms, if they do something similar to `detect_prime()`. I only have linux here to test, so I'll leave that to someone else to fix if necessary.
* I can make a version for 4.x once we are happy with the approach here, there is currently no pooling in Variant in 4.x.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
