### PR TITLE
[3.x] i18n: Make property paths and categories translatable

### DIFF
--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -33,6 +33,7 @@
 #include "core/os/dir_access.h"
 #include "editor/editor_settings.h"
 #include "editor_node.h"
+#include "editor_property_name_processor.h"
 #include "editor_scale.h"
 
 const char *EditorFeatureProfile::feature_names[FEATURE_MAX] = {
@@ -617,7 +618,8 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 			property->set_editable(0, true);
 			property->set_selectable(0, true);
 			property->set_checked(0, !edited->is_class_property_disabled(class_name, name));
-			property->set_text(0, name.capitalize());
+			property->set_text(0, EditorPropertyNameProcessor::get_singleton()->process_name(name));
+			property->set_tooltip(0, EditorPropertyNameProcessor::get_singleton()->make_tooltip_for_name(name));
 			property->set_metadata(0, name);
 			String icon_type = Variant::get_type_name(E->get().type);
 			property->set_icon(0, EditorNode::get_singleton()->get_class_icon(icon_type));

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -36,6 +36,7 @@
 #include "dictionary_property_edit.h"
 #include "editor_feature_profile.h"
 #include "editor_node.h"
+#include "editor_property_name_processor.h"
 #include "editor_scale.h"
 #include "editor_settings.h"
 #include "multi_node_edit.h"
@@ -1551,11 +1552,11 @@ void EditorInspector::update_tree() {
 			if (dot != -1) {
 				String ov = name.right(dot);
 				name = name.substr(0, dot);
-				name = name.capitalize();
+				name = EditorPropertyNameProcessor::get_singleton()->process_name(name);
 				name += ov;
 
 			} else {
-				name = name.capitalize();
+				name = EditorPropertyNameProcessor::get_singleton()->process_name(name);
 			}
 		}
 
@@ -1565,7 +1566,7 @@ void EditorInspector::update_tree() {
 			String cat = path;
 
 			if (capitalize_paths) {
-				cat = cat.capitalize();
+				cat = EditorPropertyNameProcessor::get_singleton()->process_name(cat);
 			}
 
 			if (!filter.is_subsequence_ofi(cat) && !filter.is_subsequence_ofi(name) && property_prefix.to_lower().find(filter.to_lower()) == -1) {
@@ -1594,13 +1595,15 @@ void EditorInspector::update_tree() {
 					current_vbox->add_child(section);
 					sections.push_back(section);
 
+					String label = path_name;
 					if (capitalize_paths) {
-						path_name = path_name.capitalize();
+						label = EditorPropertyNameProcessor::get_singleton()->process_name(label);
 					}
 
 					Color c = sscolor;
 					c.a /= level;
-					section->setup(acc_path, path_name, object, c, use_folding);
+					section->setup(acc_path, label, object, c, use_folding);
+					section->set_tooltip(EditorPropertyNameProcessor::get_singleton()->make_tooltip_for_name(path_name));
 
 					VBoxContainer *vb = section->get_vbox();
 					item_path[acc_path] = vb;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -80,6 +80,7 @@
 #include "editor/editor_log.h"
 #include "editor/editor_plugin.h"
 #include "editor/editor_properties.h"
+#include "editor/editor_property_name_processor.h"
 #include "editor/editor_resource_picker.h"
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_run_native.h"
@@ -5771,6 +5772,9 @@ int EditorNode::execute_and_show_output(const String &p_title, const String &p_p
 }
 
 EditorNode::EditorNode() {
+	EditorPropertyNameProcessor *epnp = memnew(EditorPropertyNameProcessor);
+	add_child(epnp);
+
 	Input::get_singleton()->set_use_accumulated_input(true);
 	Resource::_get_local_scene_func = _resource_get_edited_scene;
 
@@ -5970,6 +5974,7 @@ EditorNode::EditorNode() {
 	EDITOR_DEF("interface/editor/show_update_spinner", false);
 	EDITOR_DEF("interface/editor/update_continuously", false);
 	EDITOR_DEF("interface/editor/update_vital_only", false);
+	EDITOR_DEF("interface/editor/translate_properties", true);
 	EDITOR_DEF_RST("interface/scene_tabs/restore_scenes_on_load", false);
 	EDITOR_DEF_RST("interface/scene_tabs/show_thumbnail_on_hover", true);
 	EDITOR_DEF_RST("interface/inspector/capitalize_properties", true);

--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -1,0 +1,121 @@
+/*************************************************************************/
+/*  editor_property_name_processor.cpp                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "editor_property_name_processor.h"
+
+#include "editor_settings.h"
+
+EditorPropertyNameProcessor *EditorPropertyNameProcessor::singleton = nullptr;
+
+String EditorPropertyNameProcessor::_capitalize_name(const String &p_name) const {
+	String capitalized_string = p_name.capitalize();
+
+	// Fix the casing of a few strings commonly found in editor property/setting names.
+	for (Map<String, String>::Element *E = capitalize_string_remaps.front(); E; E = E->next()) {
+		capitalized_string = capitalized_string.replace(E->key(), E->value());
+	}
+
+	return capitalized_string;
+}
+
+String EditorPropertyNameProcessor::process_name(const String &p_name) const {
+	const String capitalized_string = _capitalize_name(p_name);
+	if (EDITOR_GET("interface/editor/translate_properties")) {
+		return TTRGET(capitalized_string);
+	}
+	return capitalized_string;
+}
+
+String EditorPropertyNameProcessor::make_tooltip_for_name(const String &p_name) const {
+	const String capitalized_string = _capitalize_name(p_name);
+	if (EDITOR_GET("interface/editor/translate_properties")) {
+		return capitalized_string;
+	}
+	return TTRGET(capitalized_string);
+}
+
+EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
+	ERR_FAIL_COND(singleton != nullptr);
+	singleton = this;
+
+	// The following initialization is parsed in `editor/translations/extract.py` with a regex.
+	// The map name and value definition format should be kept synced with the regex.
+	capitalize_string_remaps["2d"] = "2D";
+	capitalize_string_remaps["3d"] = "3D";
+	capitalize_string_remaps["Adb"] = "ADB";
+	capitalize_string_remaps["Bptc"] = "BPTC";
+	capitalize_string_remaps["Bvh"] = "BVH";
+	capitalize_string_remaps["Csg"] = "CSG";
+	capitalize_string_remaps["Cpu"] = "CPU";
+	capitalize_string_remaps["Db"] = "dB";
+	capitalize_string_remaps["Dof"] = "DoF";
+	capitalize_string_remaps["Dpi"] = "DPI";
+	capitalize_string_remaps["Etc"] = "ETC";
+	capitalize_string_remaps["Fbx"] = "FBX";
+	capitalize_string_remaps["Fps"] = "FPS";
+	capitalize_string_remaps["Fov"] = "FOV";
+	capitalize_string_remaps["Fs"] = "FS";
+	capitalize_string_remaps["Fxaa"] = "FXAA";
+	capitalize_string_remaps["Ggx"] = "GGX";
+	capitalize_string_remaps["Gdscript"] = "GDScript";
+	capitalize_string_remaps["Gles 2"] = "GLES2";
+	capitalize_string_remaps["Gles 3"] = "GLES3";
+	capitalize_string_remaps["Gi Probe"] = "GI Probe";
+	capitalize_string_remaps["Hdr"] = "HDR";
+	capitalize_string_remaps["Hidpi"] = "hiDPI";
+	capitalize_string_remaps["Ik"] = "IK";
+	capitalize_string_remaps["Ios"] = "iOS";
+	capitalize_string_remaps["Kb"] = "KB";
+	capitalize_string_remaps["Msaa"] = "MSAA";
+	capitalize_string_remaps["Macos"] = "macOS";
+	capitalize_string_remaps["Opentype"] = "OpenType";
+	capitalize_string_remaps["Png"] = "PNG";
+	capitalize_string_remaps["Pvs"] = "PVS";
+	capitalize_string_remaps["Pvrtc"] = "PVRTC";
+	capitalize_string_remaps["S 3 Tc"] = "S3TC";
+	capitalize_string_remaps["Sdfgi"] = "SDFGI";
+	capitalize_string_remaps["Srgb"] = "sRGB";
+	capitalize_string_remaps["Ssao"] = "SSAO";
+	capitalize_string_remaps["Ssl"] = "SSL";
+	capitalize_string_remaps["Ssh"] = "SSH";
+	capitalize_string_remaps["Sdk"] = "SDK";
+	capitalize_string_remaps["Tcp"] = "TCP";
+	capitalize_string_remaps["Uv 1"] = "UV1";
+	capitalize_string_remaps["Uv 2"] = "UV2";
+	capitalize_string_remaps["Vram"] = "VRAM";
+	capitalize_string_remaps["Vsync"] = "V-Sync";
+	capitalize_string_remaps["Vector 2"] = "Vector2";
+	capitalize_string_remaps["Webrtc"] = "WebRTC";
+	capitalize_string_remaps["Websocket"] = "WebSocket";
+}
+
+EditorPropertyNameProcessor::~EditorPropertyNameProcessor() {
+	singleton = nullptr;
+}

--- a/editor/editor_property_name_processor.h
+++ b/editor/editor_property_name_processor.h
@@ -1,0 +1,58 @@
+/*************************************************************************/
+/*  editor_property_name_processor.h                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef EDITOR_PROPERTY_NAME_PROCESSOR_H
+#define EDITOR_PROPERTY_NAME_PROCESSOR_H
+
+#include "scene/main/node.h"
+
+class EditorPropertyNameProcessor : public Node {
+	GDCLASS(EditorPropertyNameProcessor, Node);
+
+	static EditorPropertyNameProcessor *singleton;
+
+	Map<String, String> capitalize_string_remaps;
+
+	String _capitalize_name(const String &p_name) const;
+
+public:
+	static EditorPropertyNameProcessor *get_singleton() { return singleton; }
+
+	// Capitalize & localize property path segments.
+	String process_name(const String &p_name) const;
+
+	// Make tooltip string for names processed by process_name().
+	String make_tooltip_for_name(const String &p_name) const;
+
+	EditorPropertyNameProcessor();
+	~EditorPropertyNameProcessor();
+};
+
+#endif // EDITOR_PROPERTY_NAME_PROCESSOR_H

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -29,7 +29,10 @@
 /*************************************************************************/
 
 #include "editor_sectioned_inspector.h"
+
+#include "editor_property_name_processor.h"
 #include "editor_scale.h"
+
 class SectionedInspectorFilter : public Object {
 	GDCLASS(SectionedInspectorFilter, Object);
 
@@ -266,7 +269,8 @@ void SectionedInspector::update_category_list() {
 			if (!section_map.has(metasection)) {
 				TreeItem *ms = sections->create_item(parent);
 				section_map[metasection] = ms;
-				ms->set_text(0, sectionarr[i].capitalize());
+				ms->set_text(0, EditorPropertyNameProcessor::get_singleton()->process_name(sectionarr[i]));
+				ms->set_tooltip(0, EditorPropertyNameProcessor::get_singleton()->make_tooltip_for_name(sectionarr[i]));
 				ms->set_metadata(0, metasection);
 				ms->set_selectable(0, false);
 			}

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -35,6 +35,7 @@
 #include "editor_file_system.h"
 #include "editor_log.h"
 #include "editor_node.h"
+#include "editor_property_name_processor.h"
 #include "editor_scale.h"
 #include "editor_settings.h"
 #include "scene/gui/margin_container.h"
@@ -217,8 +218,9 @@ void EditorSettingsDialog::_update_shortcuts() {
 		} else {
 			section = shortcuts->create_item(root);
 
-			String item_name = section_name.capitalize();
+			String item_name = EditorPropertyNameProcessor::get_singleton()->process_name(section_name);
 			section->set_text(0, item_name);
+			section->set_tooltip(0, EditorPropertyNameProcessor::get_singleton()->make_tooltip_for_name(section_name));
 
 			if (collapsed.has(item_name)) {
 				section->set_collapsed(collapsed[item_name]);


### PR DESCRIPTION
`3.x` l10n is more complete than `master`, thus easier to test, so this PR targets `3.x`. I'll do a `master` version after this is discussed :)

I did some Ad-hoc localization for testing locally. When `interface/editor/translate_properties` is on, which is the default, the editor looks like this:

![ksnip_20220301-153147](https://user-images.githubusercontent.com/372476/156125220-96edca32-cbc0-4328-8460-52c543143539.png)

* As you can see from the screenshot, VRAM and GLES2 are correctly capitalized. This makes `msgid`s in the `POT` file easier to read. Capitalization logic is from (and thus supersedes) #32734.
    * Translation happens after capitalization.
    * Translation only happen when the new editor setting `interface/editor/translate_properties` is on.
* Tooltips are added to section headers.
    * When `translate_properties` is on, shows the original name.
    * When `translate_properties` is off, shows the translated name.
* In `extract.py`:
    * Replaced character by character line parsing with regular expression matching.
        * Extracting property paths are as easy as adding additional expressions.
        * I tested extraction without the property path patterns, the result is the same as the original approach. Except one string, which is fixed in #58627.
    * Capitalization data are also extracted from C++ code with regular expression.
