### PR TITLE
`Joint2D` and `Joint3D`: update joint on `NOTIFICATION_POST_ENTER_TREE`

### DIFF
--- a/scene/2d/joint_2d.cpp
+++ b/scene/2d/joint_2d.cpp
@@ -190,6 +190,9 @@ void Joint2D::set_exclude_nodes_from_collision(bool p_enable) {
 	if (exclude_from_collision == p_enable) {
 		return;
 	}
+	if (is_configured()) {
+		_disconnect_signals();
+	}
 	_update_joint(true);
 	exclude_from_collision = p_enable;
 	_update_joint();

--- a/scene/2d/joint_2d.cpp
+++ b/scene/2d/joint_2d.cpp
@@ -159,15 +159,18 @@ NodePath Joint2D::get_node_b() const {
 
 void Joint2D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_READY: {
+		case NOTIFICATION_POST_ENTER_TREE: {
+			if (is_configured()) {
+				_disconnect_signals();
+			}
 			_update_joint();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
 			if (is_configured()) {
 				_disconnect_signals();
-				_update_joint(true);
 			}
+			_update_joint(true);
 		} break;
 	}
 }
@@ -187,7 +190,6 @@ void Joint2D::set_exclude_nodes_from_collision(bool p_enable) {
 	if (exclude_from_collision == p_enable) {
 		return;
 	}
-
 	_update_joint(true);
 	exclude_from_collision = p_enable;
 	_update_joint();

--- a/scene/3d/joint_3d.cpp
+++ b/scene/3d/joint_3d.cpp
@@ -186,6 +186,10 @@ void Joint3D::set_exclude_nodes_from_collision(bool p_enable) {
 	if (exclude_from_collision == p_enable) {
 		return;
 	}
+	if (is_configured()) {
+		_disconnect_signals();
+	}
+	_update_joint(true);
 	exclude_from_collision = p_enable;
 	_update_joint();
 }

--- a/scene/3d/joint_3d.cpp
+++ b/scene/3d/joint_3d.cpp
@@ -166,15 +166,18 @@ int Joint3D::get_solver_priority() const {
 
 void Joint3D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_READY: {
+		case NOTIFICATION_POST_ENTER_TREE: {
+			if (is_configured()) {
+				_disconnect_signals();
+			}
 			_update_joint();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
 			if (is_configured()) {
 				_disconnect_signals();
-				_update_joint(true);
 			}
+			_update_joint(true);
 		} break;
 	}
 }


### PR DESCRIPTION
In contrast with updating only on `NOTIFICATION_READY`, this allows reparenting, etc.

Fixes https://github.com/godotengine/godot/issues/31711 and fixes https://github.com/godotengine/godot/issues/41398 in `master`.

Also fixes a related issue (in a separate commit): makes `set_exclude_nodes_from_collision` respect signal connections.