### PR TITLE
[3.x] `Joint2D` and `Joint`: update joint on `NOTIFICATION_POST_ENTER_TREE`

### DIFF
--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -198,7 +198,9 @@ void Joint2D::set_exclude_nodes_from_collision(bool p_enable) {
 	if (exclude_from_collision == p_enable) {
 		return;
 	}
-
+	if (joint.is_valid()) {
+		_disconnect_signals();
+	}
 	_update_joint(true);
 	exclude_from_collision = p_enable;
 	_update_joint();

--- a/scene/2d/joints_2d.cpp
+++ b/scene/2d/joints_2d.cpp
@@ -168,14 +168,17 @@ NodePath Joint2D::get_node_b() const {
 
 void Joint2D::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_READY: {
+		case NOTIFICATION_POST_ENTER_TREE: {
+			if (joint.is_valid()) {
+				_disconnect_signals();
+			}
 			_update_joint();
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			if (joint.is_valid()) {
 				_disconnect_signals();
-				_update_joint(true);
 			}
+			_update_joint(true);
 		} break;
 	}
 }

--- a/scene/3d/physics_joint.cpp
+++ b/scene/3d/physics_joint.cpp
@@ -178,14 +178,17 @@ int Joint::get_solver_priority() const {
 
 void Joint::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_READY: {
+		case NOTIFICATION_POST_ENTER_TREE: {
+			if (joint.is_valid()) {
+				_disconnect_signals();
+			}
 			_update_joint();
 		} break;
 		case NOTIFICATION_EXIT_TREE: {
 			if (joint.is_valid()) {
 				_disconnect_signals();
-				_update_joint(true);
 			}
+			_update_joint(true);
 		} break;
 	}
 }

--- a/scene/3d/physics_joint.cpp
+++ b/scene/3d/physics_joint.cpp
@@ -197,6 +197,10 @@ void Joint::set_exclude_nodes_from_collision(bool p_enable) {
 	if (exclude_from_collision == p_enable) {
 		return;
 	}
+	if (joint.is_valid()) {
+		_disconnect_signals();
+	}
+	_update_joint(true);
 	exclude_from_collision = p_enable;
 	_update_joint();
 }


### PR DESCRIPTION
In contrast with updating only on `NOTIFICATION_READY`, this allows reparenting, etc.

Fixes https://github.com/godotengine/godot/issues/31711 and fixes https://github.com/godotengine/godot/issues/41398 in `3.x`.

Also fixes a related issue (in a separate commit): makes `set_exclude_nodes_from_collision` respect signal connections.

This is the `3.x` version of https://github.com/godotengine/godot/pull/58641.