### PR TITLE
Portals - fix duplication of instanced scenes during conversion

### DIFF
--- a/scene/3d/room_manager.cpp
+++ b/scene/3d/room_manager.cpp
@@ -2073,9 +2073,10 @@ void RoomManager::_flip_portals_recursive(Spatial *p_node) {
 }
 
 void RoomManager::_set_owner_recursive(Node *p_node, Node *p_owner) {
-	if (p_node != p_owner) {
+	if (!p_node->get_owner() && (p_node != p_owner)) {
 		p_node->set_owner(p_owner);
 	}
+
 	for (int n = 0; n < p_node->get_child_count(); n++) {
 		_set_owner_recursive(p_node->get_child(n), p_owner);
 	}


### PR DESCRIPTION
During room conversion, if a prefixed Spatial is converted to a Room / RoomGroup etc, when using instanced scenes the owner was incorrectly set, resulting in the instanced scene objects being duplicated.

This PR corrects this.

Fixes #58648

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
