### PR TITLE
Fix `UndoRedo::create_action()` invalid memory usage

### DIFF
--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -66,6 +66,8 @@ private:
 		ObjectID object;
 		StringName name;
 		Variant args[VARIANT_ARG_MAX];
+
+		void delete_reference();
 	};
 
 	struct Action {


### PR DESCRIPTION
Fixes #50769 (second case)

* Modified a `memdelete()` which was missed in #50782.
* Extracted the same code blocks into a separate function.