### PR TITLE
[WIP] Use `editor/scene/scene_naming` in "Save Branch as Scene"

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2612,18 +2612,17 @@ void EditorNode::_menu_option_confirm(int p_option, bool p_confirmed) {
 					case SCENE_NAME_CASING_AUTO:
 						// Use casing of the root node.
 						break;
-					case SCENE_NAME_CASING_PASCAL_CASE: {
+					case SCENE_NAME_CASING_PASCAL_CASE:
 						root_name = root_name.capitalize().replace(" ", "");
-					} break;
+						break;
 					case SCENE_NAME_CASING_SNAKE_CASE:
 						root_name = root_name.capitalize().replace(" ", "").replace("-", "_").camelcase_to_underscore();
 						break;
 				}
 				file->set_current_path(root_name + "." + extensions.front()->get().to_lower());
 			}
-			file->popup_file_dialog();
 			file->set_title(TTR("Save Scene As..."));
-
+			file->popup_file_dialog();
 		} break;
 
 		case FILE_SAVE_ALL_SCENES: {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -907,13 +907,21 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 				new_scene_from_dialog->add_filter("*." + extensions[i] + " ; " + extensions[i].to_upper());
 			}
 
-			String existing;
 			if (extensions.size()) {
-				String root_name(tocopy->get_name());
-				existing = root_name + "." + extensions.front()->get().to_lower();
+				String root_name = tocopy->get_name();
+				switch (ProjectSettings::get_singleton()->get("editor/scene/scene_naming").operator int()) {
+					case 0: //SCENE_NAME_CASING_AUTO:
+						// Use casing of the root node.
+						break;
+					case 1: //SCENE_NAME_CASING_PASCAL_CASE:
+						root_name = root_name.capitalize().replace(" ", "");
+						break;
+					case 2: //SCENE_NAME_CASING_SNAKE_CASE:
+						root_name = root_name.capitalize().replace(" ", "").replace("-", "_").camelcase_to_underscore();
+						break;
+				}
+				new_scene_from_dialog->set_current_path(root_name + "." + extensions.front()->get().to_lower());
 			}
-			new_scene_from_dialog->set_current_path(existing);
-
 			new_scene_from_dialog->set_title(TTR("Save New Scene As..."));
 			new_scene_from_dialog->popup_file_dialog();
 		} break;


### PR DESCRIPTION
I added naming logic to `Save Branch as Scene`, but faced the following problems:
* `ScriptNameCasing` is defined in `editor_node.h`, should I copy it to `scene_tree_dock.h`? Maybe it's worth moving this enum to the `project_settings.h`?
* Also, I don't like the repetitive logic in the `editor_node.cpp` and the `scene_tree_dock.cpp`. But I'm still not familiar enough with the Godot structure, and I don't know how to combine it properly.

#57768, found it after making a pr. Now I see that it already has not merged fix, so I close this draft.