### PR TITLE
Input: Make `get_action_raw_strength` print error when the action doesn't exist

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -325,6 +325,7 @@ float Input::get_action_strength(const StringName &p_action, bool p_exact) const
 }
 
 float Input::get_action_raw_strength(const StringName &p_action, bool p_exact) const {
+	ERR_FAIL_COND_V_MSG(!InputMap::get_singleton()->has_action(p_action), 0.0, InputMap::get_singleton()->suggest_actions(p_action));
 	HashMap<StringName, Action>::ConstIterator E = action_state.find(p_action);
 	if (!E) {
 		return 0.0f;


### PR DESCRIPTION
Input.get_vector doesn't work with simulated events made with Input.action_press, Input.action_release or Input.parse_input_event (while get_axis works fine), adding that line of code should resolve the issue.

[Issue](https://github.com/MarcoFazioRandom/Virtual-Joystick-Godot/issues/31) on my Godot repository that made me found this bug.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
