### PR TITLE
Make PhysicalBone3D inherit RigidDynamicBody3D

### DIFF
--- a/doc/classes/PhysicalBone3D.xml
+++ b/doc/classes/PhysicalBone3D.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="PhysicalBone3D" inherits="PhysicsBody3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="PhysicalBone3D" inherits="RigidDynamicBody3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>
@@ -7,19 +7,6 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="apply_central_impulse">
-			<return type="void" />
-			<argument index="0" name="impulse" type="Vector3" />
-			<description>
-			</description>
-		</method>
-		<method name="apply_impulse">
-			<return type="void" />
-			<argument index="0" name="impulse" type="Vector3" />
-			<argument index="1" name="position" type="Vector3" default="Vector3(0, 0, 0)" />
-			<description>
-			</description>
-		</method>
 		<method name="get_bone_id" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -37,27 +24,8 @@
 		</method>
 	</methods>
 	<members>
-		<member name="angular_damp" type="float" setter="set_angular_damp" getter="get_angular_damp" default="0.0">
-			Damps the body's rotation. By default, the body will use the [b]Default Angular Damp[/b] in [b]Project &gt; Project Settings &gt; Physics &gt; 3d[/b] or any value override set by an [Area3D] the body is in. Depending on [member angular_damp_mode], you can set [member angular_damp] to be added to or to replace the body's damping value.
-			See [member ProjectSettings.physics/3d/default_angular_damp] for more details about damping.
-		</member>
-		<member name="angular_damp_mode" type="int" setter="set_angular_damp_mode" getter="get_angular_damp_mode" enum="PhysicalBone3D.DampMode" default="0">
-			Defines how [member angular_damp] is applied. See [enum DampMode] for possible values.
-		</member>
 		<member name="body_offset" type="Transform3D" setter="set_body_offset" getter="get_body_offset" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			Sets the body's transform.
-		</member>
-		<member name="bounce" type="float" setter="set_bounce" getter="get_bounce" default="0.0">
-			The body's bounciness. Values range from [code]0[/code] (no bounce) to [code]1[/code] (full bounciness).
-		</member>
-		<member name="can_sleep" type="bool" setter="set_can_sleep" getter="is_able_to_sleep" default="true">
-			If [code]true[/code], the body is deactivated when there is no movement, so it will not take part in the simulation until it is awakened by an external force.
-		</member>
-		<member name="friction" type="float" setter="set_friction" getter="get_friction" default="1.0">
-			The body's friction, from [code]0[/code] (frictionless) to [code]1[/code] (max friction).
-		</member>
-		<member name="gravity_scale" type="float" setter="set_gravity_scale" getter="get_gravity_scale" default="1.0">
-			This is multiplied by the global 3D gravity setting found in [b]Project &gt; Project Settings &gt; Physics &gt; 3d[/b] to produce the body's gravity. For example, a value of 1 will be normal gravity, 2 will apply double gravity, and 0.5 will apply half gravity to this object.
 		</member>
 		<member name="joint_offset" type="Transform3D" setter="set_joint_offset" getter="get_joint_offset" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			Sets the joint's transform.
@@ -68,24 +36,8 @@
 		<member name="joint_type" type="int" setter="set_joint_type" getter="get_joint_type" enum="PhysicalBone3D.JointType" default="0">
 			Sets the joint type. See [enum JointType] for possible values.
 		</member>
-		<member name="linear_damp" type="float" setter="set_linear_damp" getter="get_linear_damp" default="0.0">
-			Damps the body's movement. By default, the body will use the [b]Default Linear Damp[/b] in [b]Project &gt; Project Settings &gt; Physics &gt; 3d[/b] or any value override set by an [Area3D] the body is in. Depending on [member linear_damp_mode], you can set [member linear_damp] to be added to or to replace the body's damping value.
-			See [member ProjectSettings.physics/3d/default_linear_damp] for more details about damping.
-		</member>
-		<member name="linear_damp_mode" type="int" setter="set_linear_damp_mode" getter="get_linear_damp_mode" enum="PhysicalBone3D.DampMode" default="0">
-			Defines how [member linear_damp] is applied. See [enum DampMode] for possible values.
-		</member>
-		<member name="mass" type="float" setter="set_mass" getter="get_mass" default="1.0">
-			The body's mass.
-		</member>
 	</members>
 	<constants>
-		<constant name="DAMP_MODE_COMBINE" value="0" enum="DampMode">
-			In this mode, the body's damping value is added to any value set in areas or the default value.
-		</constant>
-		<constant name="DAMP_MODE_REPLACE" value="1" enum="DampMode">
-			In this mode, the body's damping value replaces any value set in areas or the default value.
-		</constant>
 		<constant name="JOINT_TYPE_NONE" value="0" enum="JointType">
 		</constant>
 		<constant name="JOINT_TYPE_PIN" value="1" enum="JointType">

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -516,8 +516,8 @@ public:
 	Vector3 get_collider_velocity(int p_collision_index = 0) const;
 };
 
-class PhysicalBone3D : public PhysicsBody3D {
-	GDCLASS(PhysicalBone3D, PhysicsBody3D);
+class PhysicalBone3D : public RigidDynamicBody3D {
+	GDCLASS(PhysicalBone3D, RigidDynamicBody3D);
 
 public:
 	enum DampMode {
@@ -659,25 +659,14 @@ private:
 	int bone_id = -1;
 
 	String bone_name;
-	real_t bounce = 0.0;
-	real_t mass = 1.0;
-	real_t friction = 1.0;
-	real_t gravity_scale = 1.0;
-	bool can_sleep = true;
-
-	DampMode linear_damp_mode = DAMP_MODE_COMBINE;
-	DampMode angular_damp_mode = DAMP_MODE_COMBINE;
-
-	real_t linear_damp = 0.0;
-	real_t angular_damp = 0.0;
 
 protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
-	static void _body_state_changed_callback(void *p_instance, PhysicsDirectBodyState3D *p_state);
-	void _body_state_changed(PhysicsDirectBodyState3D *p_state);
+	static void _bone_state_changed_callback(void *p_instance, PhysicsDirectBodyState3D *p_state);
+	void _bone_state_changed(PhysicsDirectBodyState3D *p_state);
 
 	static void _bind_methods();
 
@@ -721,33 +710,6 @@ public:
 	void set_bone_name(const String &p_name);
 	const String &get_bone_name() const;
 
-	void set_mass(real_t p_mass);
-	real_t get_mass() const;
-
-	void set_friction(real_t p_friction);
-	real_t get_friction() const;
-
-	void set_bounce(real_t p_bounce);
-	real_t get_bounce() const;
-
-	void set_gravity_scale(real_t p_gravity_scale);
-	real_t get_gravity_scale() const;
-
-	void set_linear_damp_mode(DampMode p_mode);
-	DampMode get_linear_damp_mode() const;
-
-	void set_angular_damp_mode(DampMode p_mode);
-	DampMode get_angular_damp_mode() const;
-
-	void set_linear_damp(real_t p_linear_damp);
-	real_t get_linear_damp() const;
-
-	void set_angular_damp(real_t p_angular_damp);
-	real_t get_angular_damp() const;
-
-	void set_can_sleep(bool p_active);
-	bool is_able_to_sleep() const;
-
 	void apply_central_impulse(const Vector3 &p_impulse);
 	void apply_impulse(const Vector3 &p_impulse, const Vector3 &p_position = Vector3());
 
@@ -766,6 +728,5 @@ private:
 };
 
 VARIANT_ENUM_CAST(PhysicalBone3D::JointType);
-VARIANT_ENUM_CAST(PhysicalBone3D::DampMode);
 
 #endif // PHYSICS_BODY__H


### PR DESCRIPTION
this fix is ported from https://github.com/godotengine/godot/pull/44150 tested, and works

![image](https://user-images.githubusercontent.com/84625713/156207816-e9b6e9cb-e7c4-4a31-b0d5-9a7c6f9c81b9.png)

to get the features from RigidDynamicBody3D into PhysicalBone3D to make PhysicalBone3D behave like a rigid body yea

i hope you like it

(closes https://github.com/godotengine/godot-proposals/issues/1951)