### PR TITLE
Improve scene playing and reloading

### DIFF
--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -470,7 +470,9 @@ private:
 	String _tmp_import_path;
 	String external_file;
 	String open_navigate;
+
 	String run_custom_filename;
+	String run_current_filename;
 
 	DynamicFontImportSettings *fontdata_import_settings = nullptr;
 	SceneImportSettings *scene_import_settings = nullptr;
@@ -580,6 +582,7 @@ private:
 
 	void _run(bool p_current = false, const String &p_custom = "");
 	void _run_native(const Ref<EditorExportPreset> &p_preset);
+	void _reset_play_buttons();
 
 	void _add_to_recent_scenes(const String &p_scene);
 	void _update_recent_scenes();


### PR DESCRIPTION
This PR improves the scene reloading behavior in the editor. When you play a scene, the play button you pressed turns into reload arrow. In case of play custom, it reloaded again the scene you picked, but for play current it always played the currently opened the scene, despite the button also changes. I also added a tooltip to better indicate this behavior and refactored code a bit to decrease duplication.
![image](https://user-images.githubusercontent.com/2223172/156258765-b5f7e42c-3d81-40b6-a434-3de92d7fd6d0.png)

Fixes #31515