### PR TITLE
Remove unimplemented GridMap set_clip() method

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -117,15 +117,6 @@
 				Optionally, the item's orientation can be passed. For valid orientation values, see [method Basis.get_orthogonal_index].
 			</description>
 		</method>
-		<method name="set_clip">
-			<return type="void" />
-			<argument index="0" name="enabled" type="bool" />
-			<argument index="1" name="clipabove" type="bool" default="true" />
-			<argument index="2" name="floor" type="int" default="0" />
-			<argument index="3" name="axis" type="int" enum="Vector3.Axis" default="0" />
-			<description>
-			</description>
-		</method>
 		<method name="set_collision_layer_value">
 			<return type="void" />
 			<argument index="0" name="layer_number" type="int" />

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -874,8 +874,6 @@ void GridMap::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_center_z", "enable"), &GridMap::set_center_z);
 	ClassDB::bind_method(D_METHOD("get_center_z"), &GridMap::get_center_z);
 
-	ClassDB::bind_method(D_METHOD("set_clip", "enabled", "clipabove", "floor", "axis"), &GridMap::set_clip, DEFVAL(true), DEFVAL(0), DEFVAL(Vector3::AXIS_X));
-
 	ClassDB::bind_method(D_METHOD("clear"), &GridMap::clear);
 
 	ClassDB::bind_method(D_METHOD("get_used_cells"), &GridMap::get_used_cells);
@@ -907,28 +905,6 @@ void GridMap::_bind_methods() {
 	BIND_CONSTANT(INVALID_CELL_ITEM);
 
 	ADD_SIGNAL(MethodInfo("cell_size_changed", PropertyInfo(Variant::VECTOR3, "cell_size")));
-}
-
-void GridMap::set_clip(bool p_enabled, bool p_clip_above, int p_floor, Vector3::Axis p_axis) {
-	if (!p_enabled && !clip) {
-		return;
-	}
-	if (clip && p_enabled && clip_floor == p_floor && p_clip_above == clip_above && p_axis == clip_axis) {
-		return;
-	}
-
-	clip = p_enabled;
-	clip_floor = p_floor;
-	clip_axis = p_axis;
-	clip_above = p_clip_above;
-
-	//make it all update
-	for (KeyValue<OctantKey, Octant *> &E : octant_map) {
-		Octant *g = E.value;
-		g->dirty = true;
-	}
-	awaiting_update = true;
-	_update_octants_callback();
 }
 
 void GridMap::set_cell_scale(float p_scale) {

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -150,13 +150,7 @@ class GridMap : public Node3D {
 	bool center_z = true;
 	float cell_scale = 1.0;
 
-	bool clip = false;
-	bool clip_above = true;
-	int clip_floor = 0;
-
 	bool recreating_octants = false;
-
-	Vector3::Axis clip_axis = Vector3::AXIS_Z;
 
 	Ref<MeshLibrary> mesh_library;
 
@@ -259,8 +253,6 @@ public:
 
 	Vector3i world_to_map(const Vector3 &p_world_position) const;
 	Vector3 map_to_world(const Vector3i &p_map_position) const;
-
-	void set_clip(bool p_enabled, bool p_clip_above = true, int p_floor = 0, Vector3::Axis p_axis = Vector3::AXIS_X);
 
 	void set_cell_scale(float p_scale);
 	float get_cell_scale() const;

--- a/modules/gridmap/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/grid_map_editor_plugin.cpp
@@ -63,17 +63,6 @@ void GridMapEditor::_menu_option(int p_option) {
 			floor->set_value(floor->get_value() + 1);
 		} break;
 
-		case MENU_OPTION_CLIP_DISABLED:
-		case MENU_OPTION_CLIP_ABOVE:
-		case MENU_OPTION_CLIP_BELOW: {
-			clip_mode = ClipMode(p_option - MENU_OPTION_CLIP_DISABLED);
-			for (int i = 0; i < 3; i++) {
-				int index = options->get_popup()->get_item_index(MENU_OPTION_CLIP_DISABLED + i);
-				options->get_popup()->set_item_checked(index, i == clip_mode);
-			}
-
-			_update_clip();
-		} break;
 		case MENU_OPTION_X_AXIS:
 		case MENU_OPTION_Y_AXIS:
 		case MENU_OPTION_Z_AXIS: {
@@ -98,7 +87,6 @@ void GridMapEditor::_menu_option(int p_option) {
 			}
 			edit_axis = Vector3::Axis(new_axis);
 			update_grid();
-			_update_clip();
 
 		} break;
 		case MENU_OPTION_CURSOR_ROTATE_Y: {
@@ -943,22 +931,10 @@ void GridMapEditor::edit(GridMap *p_gridmap) {
 
 	set_process(true);
 
-	clip_mode = p_gridmap->has_meta("_editor_clip_") ? ClipMode(p_gridmap->get_meta("_editor_clip_").operator int()) : CLIP_DISABLED;
-
 	_draw_grids(node->get_cell_size());
 	update_grid();
-	_update_clip();
 
 	node->connect("cell_size_changed", callable_mp(this, &GridMapEditor::_draw_grids));
-}
-
-void GridMapEditor::_update_clip() {
-	node->set_meta("_editor_clip_", clip_mode);
-	if (clip_mode == CLIP_DISABLED) {
-		node->set_clip(false);
-	} else {
-		node->set_clip(true, clip_mode == CLIP_ABOVE, edit_floor[edit_axis], edit_axis);
-	}
 }
 
 void GridMapEditor::update_grid() {
@@ -1147,7 +1123,6 @@ void GridMapEditor::_floor_changed(float p_value) {
 	edit_floor[edit_axis] = p_value;
 	node->set_meta("_editor_floor_", Vector3(edit_floor[0], edit_floor[1], edit_floor[2]));
 	update_grid();
-	_update_clip();
 	_update_selection_transform();
 }
 
@@ -1197,11 +1172,6 @@ GridMapEditor::GridMapEditor() {
 	options->set_text(TTR("Grid Map"));
 	options->get_popup()->add_item(TTR("Previous Floor"), MENU_OPTION_PREV_LEVEL, Key::Q);
 	options->get_popup()->add_item(TTR("Next Floor"), MENU_OPTION_NEXT_LEVEL, Key::E);
-	options->get_popup()->add_separator();
-	options->get_popup()->add_radio_check_item(TTR("Clip Disabled"), MENU_OPTION_CLIP_DISABLED);
-	options->get_popup()->set_item_checked(options->get_popup()->get_item_index(MENU_OPTION_CLIP_DISABLED), true);
-	options->get_popup()->add_radio_check_item(TTR("Clip Above"), MENU_OPTION_CLIP_ABOVE);
-	options->get_popup()->add_radio_check_item(TTR("Clip Below"), MENU_OPTION_CLIP_BELOW);
 	options->get_popup()->add_separator();
 	options->get_popup()->add_radio_check_item(TTR("Edit X Axis"), MENU_OPTION_X_AXIS, Key::Z);
 	options->get_popup()->add_radio_check_item(TTR("Edit Y Axis"), MENU_OPTION_Y_AXIS, Key::X);

--- a/modules/gridmap/grid_map_editor_plugin.h
+++ b/modules/gridmap/grid_map_editor_plugin.h
@@ -55,12 +55,6 @@ class GridMapEditor : public VBoxContainer {
 		INPUT_PASTE,
 	};
 
-	enum ClipMode {
-		CLIP_DISABLED,
-		CLIP_ABOVE,
-		CLIP_BELOW
-	};
-
 	enum DisplayMode {
 		DISPLAY_THUMBNAIL,
 		DISPLAY_LIST
@@ -94,7 +88,6 @@ class GridMapEditor : public VBoxContainer {
 
 	GridMap *node = nullptr;
 	MeshLibrary *last_mesh_library;
-	ClipMode clip_mode = CLIP_DISABLED;
 
 	Transform3D grid_xform;
 	Transform3D edit_grid_xform;
@@ -159,9 +152,6 @@ class GridMapEditor : public VBoxContainer {
 		MENU_OPTION_NEXT_LEVEL,
 		MENU_OPTION_PREV_LEVEL,
 		MENU_OPTION_LOCK_VIEW,
-		MENU_OPTION_CLIP_DISABLED,
-		MENU_OPTION_CLIP_ABOVE,
-		MENU_OPTION_CLIP_BELOW,
 		MENU_OPTION_X_AXIS,
 		MENU_OPTION_Y_AXIS,
 		MENU_OPTION_Z_AXIS,
@@ -200,7 +190,6 @@ class GridMapEditor : public VBoxContainer {
 	void _item_selected_cbk(int idx);
 	void _update_cursor_transform();
 	void _update_cursor_instance();
-	void _update_clip();
 	void _update_theme();
 
 	void _text_changed(const String &p_text);


### PR DESCRIPTION
Resolves #11936
The method was never changed (implementation-wise) since Godot was open-sourced, the issue is 5 years old and keeps being bumped between milestones. While [miracles sometimes happen](https://github.com/godotengine/godot/issues/3383), there is clearly no interest in this functionality being implemented properly. Removing it should be fine.