### PR TITLE
[3.x] Always register the Smooth Trimesh Collision project setting

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -1258,6 +1258,10 @@ ProjectSettings::ProjectSettings() {
 	custom_prop_info["physics/2d/thread_model"] = PropertyInfo(Variant::INT, "physics/2d/thread_model", PROPERTY_HINT_ENUM, "Single-Unsafe,Single-Safe,Multi-Threaded");
 	custom_prop_info["rendering/quality/intended_usage/framebuffer_allocation"] = PropertyInfo(Variant::INT, "rendering/quality/intended_usage/framebuffer_allocation", PROPERTY_HINT_ENUM, "2D,2D Without Sampling,3D,3D Without Effects");
 
+	// Required to make the project setting appear even if the physics engine is GodotPhysics,
+	// while also making it appear in the ProjectSettings class documentation.
+	GLOBAL_DEF("physics/3d/smooth_trimesh_collision", false);
+
 	GLOBAL_DEF("rendering/quality/filters/sharpen_intensity", 0.0);
 	custom_prop_info["rendering/quality/filters/sharpen_intensity"] = PropertyInfo(Variant::REAL, "rendering/quality/filters/sharpen_intensity", PROPERTY_HINT_RANGE, "0,1");
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1138,6 +1138,10 @@
 			Sets which physics engine to use for 3D physics.
 			"DEFAULT" is currently the [url=https://bulletphysics.org]Bullet[/url] physics engine. The "GodotPhysics" engine is still supported as an alternative.
 		</member>
+		<member name="physics/3d/smooth_trimesh_collision" type="bool" setter="" getter="" default="false">
+			If [code]true[/code], smooths out collision with trimesh shapes ([ConcavePolygonShape]) by telling the Bullet physics engine to generate internal edge information for every trimesh shape created.
+			[b]Note:[/b] Only effective if [member physics/3d/physics_engine] is set to [code]DEFAULT[/code] or [code]Bullet[/code], [i]not[/i] [code]GodotPhysics[/code].
+		</member>
 		<member name="physics/common/enable_object_picking" type="bool" setter="" getter="" default="true">
 			Enables [member Viewport.physics_object_picking] on the root viewport.
 		</member>

--- a/modules/bullet/shape_bullet.cpp
+++ b/modules/bullet/shape_bullet.cpp
@@ -422,7 +422,7 @@ void ConcavePolygonShapeBullet::setup(PoolVector<Vector3> p_faces) {
 
 		meshShape = bulletnew(btBvhTriangleMeshShape(shapeInterface, useQuantizedAabbCompression));
 
-		if (GLOBAL_DEF("physics/3d/smooth_trimesh_collision", false)) {
+		if (GLOBAL_GET("physics/3d/smooth_trimesh_collision")) {
 			btTriangleInfoMap *triangleInfoMap = new btTriangleInfoMap();
 			btGenerateInternalEdgeInfo(meshShape, triangleInfoMap);
 		}


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/58673.

This ensures the project setting never disappears from the editor, even if the current physics engine is GodotPhysics.

This also adds documentation for the Smooth Trimesh Collision project setting.

This closes https://github.com/godotengine/godot/issues/58667 and closes https://github.com/godotengine/godot/pull/42193 by superseding it.