### PR TITLE
Remove `TTRC()` with empty string

### DIFF
--- a/core/input/input_map.cpp
+++ b/core/input/input_map.cpp
@@ -344,7 +344,7 @@ static const _BuiltinActionDisplayName _builtin_action_display_names[] = {
     { "ui_filedialog_refresh",                         TTRC("Refresh") },
     { "ui_filedialog_show_hidden",                     TTRC("Show Hidden") },
     { "ui_swap_input_direction ",                      TTRC("Swap Input Direction") },
-    { "",                                              TTRC("")}
+    { "",                                              ""}
 	/* clang-format on */
 };
 


### PR DESCRIPTION
Fixes "duplicate message definition" error when extracting messages with `make update` in `editor/translations`.

Empty string is hardcoded in `extract.py` for POT output and I think it's unnecessary to localize.