### PR TITLE
Store more shadows per quadrant for 3D point lights

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1852,17 +1852,21 @@
 		</member>
 		<member name="rendering/shadows/shadow_atlas/16_bits" type="bool" setter="" getter="" default="true">
 		</member>
-		<member name="rendering/shadows/shadow_atlas/quadrant_0_subdiv" type="int" setter="" getter="" default="2">
-			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
+		<member name="rendering/shadows/shadow_atlas/quadrant_0_subdiv" type="int" setter="" getter="" default="3">
+			Subdivision quadrant size for the first (and highest quality) quadrant used for [OmniLight3D] and [SpotLight3D] shadows. Higher values result in worse shadow resolution, but allow you to have more positional lights with shadows enabled until shadow quality degrades.
+			[b]Note:[/b] This property is only read when the project starts, and it only affects the root viewport's settings. To change this value at run-time, set [member Viewport.shadow_atlas_quad_0] on the root [Viewport] instead. Custom [Viewport]s must have their shadow quadrant properties set accordingly this way if needed.
 		</member>
-		<member name="rendering/shadows/shadow_atlas/quadrant_1_subdiv" type="int" setter="" getter="" default="2">
-			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
+		<member name="rendering/shadows/shadow_atlas/quadrant_1_subdiv" type="int" setter="" getter="" default="3">
+			Subdivision quadrant size for the second quadrant used for [OmniLight3D] and [SpotLight3D] shadows. Higher values result in worse shadow resolution, but allow you to have more positional lights with shadows enabled until shadow quality degrades.
+			[b]Note:[/b] This property is only read when the project starts, and it only affects the root viewport's settings. To change this value at run-time, set [member Viewport.shadow_atlas_quad_1] on the root [Viewport] instead. Custom [Viewport]s must have their shadow quadrant properties set accordingly this way if needed.
 		</member>
-		<member name="rendering/shadows/shadow_atlas/quadrant_2_subdiv" type="int" setter="" getter="" default="3">
-			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
+		<member name="rendering/shadows/shadow_atlas/quadrant_2_subdiv" type="int" setter="" getter="" default="4">
+			Subdivision quadrant size for the third quadrant used for [OmniLight3D] and [SpotLight3D] shadows. Higher values result in worse shadow resolution, but allow you to have more positional lights with shadows enabled until shadow quality degrades.
+			[b]Note:[/b] This property is only read when the project starts, and it only affects the root viewport's settings. To change this value at run-time, set [member Viewport.shadow_atlas_quad_2] on the root [Viewport] instead. Custom [Viewport]s must have their shadow quadrant properties set accordingly this way if needed.
 		</member>
 		<member name="rendering/shadows/shadow_atlas/quadrant_3_subdiv" type="int" setter="" getter="" default="4">
-			Subdivision quadrant size for shadow mapping. See shadow mapping documentation.
+			Subdivision quadrant size for the fourth (and lowest quality) quadrant used for [OmniLight3D] and [SpotLight3D] shadows. Higher values result in worse shadow resolution, but allow you to have more positional lights with shadows enabled until shadow quality degrades.
+			[b]Note:[/b] This property is only read when the project starts, and it only affects the root viewport's settings. To change this value at run-time, set [member Viewport.shadow_atlas_quad_3] on the root [Viewport] instead. Custom [Viewport]s must have their shadow quadrant properties set accordingly this way if needed.
 		</member>
 		<member name="rendering/shadows/shadow_atlas/size" type="int" setter="" getter="" default="4096">
 			Size for shadow atlas (used for OmniLights and SpotLights). See documentation.

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -251,16 +251,16 @@
 		<member name="shadow_atlas_16_bits" type="bool" setter="set_shadow_atlas_16_bits" getter="get_shadow_atlas_16_bits" default="true">
 		</member>
 		<member name="shadow_atlas_quad_0" type="int" setter="set_shadow_atlas_quadrant_subdiv" getter="get_shadow_atlas_quadrant_subdiv" enum="Viewport.ShadowAtlasQuadrantSubdiv" default="2">
-			The subdivision amount of the first quadrant on the shadow atlas.
+			Subdivision quadrant size for the first (and highest quality) quadrant used for [OmniLight3D] and [SpotLight3D] shadows. Higher values result in worse shadow resolution, but allow you to have more positional lights with shadows enabled until shadow quality degrades. See also [member ProjectSettings.rendering/shadows/shadow_atlas/quadrant_0_subdiv].
 		</member>
 		<member name="shadow_atlas_quad_1" type="int" setter="set_shadow_atlas_quadrant_subdiv" getter="get_shadow_atlas_quadrant_subdiv" enum="Viewport.ShadowAtlasQuadrantSubdiv" default="2">
-			The subdivision amount of the second quadrant on the shadow atlas.
+			Subdivision quadrant size for the second quadrant used for [OmniLight3D] and [SpotLight3D] shadows. Higher values result in worse shadow resolution, but allow you to have more positional lights with shadows enabled until shadow quality degrades.  See also [member ProjectSettings.rendering/shadows/shadow_atlas/quadrant_1_subdiv].
 		</member>
 		<member name="shadow_atlas_quad_2" type="int" setter="set_shadow_atlas_quadrant_subdiv" getter="get_shadow_atlas_quadrant_subdiv" enum="Viewport.ShadowAtlasQuadrantSubdiv" default="3">
-			The subdivision amount of the third quadrant on the shadow atlas.
+			Subdivision quadrant size for the third quadrant used for [OmniLight3D] and [SpotLight3D] shadows. Higher values result in worse shadow resolution, but allow you to have more positional lights with shadows enabled until shadow quality degrades.  See also [member ProjectSettings.rendering/shadows/shadow_atlas/quadrant_2_subdiv].
 		</member>
 		<member name="shadow_atlas_quad_3" type="int" setter="set_shadow_atlas_quadrant_subdiv" getter="get_shadow_atlas_quadrant_subdiv" enum="Viewport.ShadowAtlasQuadrantSubdiv" default="4">
-			The subdivision amount of the fourth quadrant on the shadow atlas.
+			Subdivision quadrant size for the fourth (and lowest quality) quadrant used for [OmniLight3D] and [SpotLight3D] shadows. Higher values result in worse shadow resolution, but allow you to have more positional lights with shadows enabled until shadow quality degrades. See also [member ProjectSettings.rendering/shadows/shadow_atlas/quadrant_3_subdiv].
 		</member>
 		<member name="shadow_atlas_size" type="int" setter="set_shadow_atlas_size" getter="get_shadow_atlas_size" default="2048">
 			The shadow atlas' resolution (used for omni and spot lights). The value will be rounded up to the nearest power of 2.

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1404,9 +1404,9 @@ SceneTree::SceneTree() {
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadow_atlas/size", PropertyInfo(Variant::INT, "rendering/shadows/shadow_atlas/size", PROPERTY_HINT_RANGE, "256,16384"));
 	GLOBAL_DEF("rendering/shadows/shadow_atlas/size.mobile", 2048);
 	bool shadowmap_16_bits = GLOBAL_DEF("rendering/shadows/shadow_atlas/16_bits", true);
-	int atlas_q0 = GLOBAL_DEF("rendering/shadows/shadow_atlas/quadrant_0_subdiv", 2);
-	int atlas_q1 = GLOBAL_DEF("rendering/shadows/shadow_atlas/quadrant_1_subdiv", 2);
-	int atlas_q2 = GLOBAL_DEF("rendering/shadows/shadow_atlas/quadrant_2_subdiv", 3);
+	int atlas_q0 = GLOBAL_DEF("rendering/shadows/shadow_atlas/quadrant_0_subdiv", 3);
+	int atlas_q1 = GLOBAL_DEF("rendering/shadows/shadow_atlas/quadrant_1_subdiv", 3);
+	int atlas_q2 = GLOBAL_DEF("rendering/shadows/shadow_atlas/quadrant_2_subdiv", 4);
 	int atlas_q3 = GLOBAL_DEF("rendering/shadows/shadow_atlas/quadrant_3_subdiv", 4);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadow_atlas/quadrant_0_subdiv", PropertyInfo(Variant::INT, "rendering/shadows/shadow_atlas/quadrant_0_subdiv", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"));
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadow_atlas/quadrant_1_subdiv", PropertyInfo(Variant::INT, "rendering/shadows/shadow_atlas/quadrant_1_subdiv", PROPERTY_HINT_ENUM, "Disabled,1 Shadow,4 Shadows,16 Shadows,64 Shadows,256 Shadows,1024 Shadows"));


### PR DESCRIPTION
This has several benefits:

- Performance increases noticeably, especially when lights with shadows are moving, or when objects move close to point lights that have shadows.
- Point light shadows look less sharp and more consistent with directional shadows' default appearance. Previously, point light shadows had a tendency to look overly sharp compared to directional shadows in most scenes.
- Up to 16 lights with shadows can be placed in a scene until shadow quality degrades, instead of just 4. It's not always obvious for people why the quality degrades in this case, so it's good to have this happen as late as possible (and ideally never in some projects).

This closes https://github.com/godotengine/godot/issues/61747.

**Testing project:** [test_omni_spot_shadow_performance.zip](https://github.com/godotengine/godot/files/8173456/test_omni_spot_shadow_performance.zip)
Press <kbd>Space</kbd> to start/pause the animation.

## Preview

**OS:** Fedora 36
**GPU:** NVIDIA GeForce GTX 1080
**Screen resolution:** 2560×1440

*The scene has 2 OmniLights with shadows and 1 SpotLight with shadows. Most complex scenes will have more lights with shadows than that, on top of having more complex meshes. This means the real world performance difference is likely greater than what demonstrated here.*

### Static scene

*Since this is a simple scene and the shadow atlas doesn't need to be updated every frame, the performance difference is small.*

| Before | After
|-|-|
| ![2022-06-11_17 00 15_static_2560_old](https://user-images.githubusercontent.com/180032/173193413-43a1ba79-5cf6-45c6-8420-2e3643c06dbd.png) | ![2022-06-11_17 03 56_static_2560_new](https://user-images.githubusercontent.com/180032/173193420-5926bbc1-8593-49e4-97b3-f4acf197bc0a.png) |

### Scene with moving object

*The shadow atlas needs to be updated every frame in this scenario, leading to a much more pronounced performance difference.*

| Before | After
|-|-|
| ![2022-06-11_17 01 33_moving_2560_old](https://user-images.githubusercontent.com/180032/173193408-99ba742b-9086-46d8-a733-3b2a3f441f89.png) | ![2022-06-11_17 04 25_moving_2560_new](https://user-images.githubusercontent.com/180032/173193410-ae36092e-181d-40d6-b672-38fe11e9f158.png) |