### PR TITLE
Fix LineEdit and TextEdit carets disappearing at theme scales below 1.0

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -847,7 +847,8 @@ void LineEdit::_notification(int p_what) {
 			// Draw carets.
 			ofs.x = x_ofs + scroll_offset;
 			if (draw_caret || drag_caret_force_displayed) {
-				const int caret_width = get_theme_constant(SNAME("caret_width")) * get_theme_default_base_scale();
+				// Prevent carets from disappearing at theme scales below 1.0 (if the caret width is 1).
+				const int caret_width = get_theme_constant(SNAME("caret_width")) * MAX(1, get_theme_default_base_scale());
 
 				if (ime_text.length() == 0) {
 					// Normal caret.

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1283,7 +1283,8 @@ void TextEdit::_notification(int p_what) {
 					}
 
 					// Carets.
-					const int caret_width = get_theme_constant(SNAME("caret_width")) * get_theme_default_base_scale();
+					// Prevent carets from disappearing at theme scales below 1.0 (if the caret width is 1).
+					const int caret_width = get_theme_constant(SNAME("caret_width")) * MAX(1, get_theme_default_base_scale());
 
 					if (!clipped && caret.line == line && line_wrap_index == caret_wrap_index) {
 						caret.draw_pos.y = ofs_y + ldata->get_line_descent(line_wrap_index);


### PR DESCRIPTION
This fixes carets disappearing in the editor when the Editor Scale setting is set below 100%.

This closes https://github.com/godotengine/godot/issues/57251.

## Preview

![2022-03-03_00 17 09](https://user-images.githubusercontent.com/180032/156466060-10edb69a-c77a-4656-ba3a-094147419e92.png)

![2022-03-03_00 17 16](https://user-images.githubusercontent.com/180032/156466062-f01f969d-a5a2-41dd-984f-f73cd9947511.png)

