### PR TITLE
Add a caret width editor setting

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -466,6 +466,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/theme/icon_saturation", 1.0, "0,2,0.01")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/theme/relationship_line_opacity", 0.1, "0.00,1,0.01")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/border_size", 0, "0,2,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/caret_width", 1, "1,6,1")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/theme/corner_radius", 3, "0,6,1")
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "interface/theme/additional_spacing", 0.0, "0,5,0.1")
 	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "interface/theme/custom_theme", "", "*.res,*.tres,*.theme", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -432,8 +432,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	String preset = EDITOR_GET("interface/theme/preset");
 
-	int border_size = EDITOR_GET("interface/theme/border_size");
-	int corner_radius = EDITOR_GET("interface/theme/corner_radius");
+	const int border_size = EDITOR_GET("interface/theme/border_size");
+	const int caret_width = EDITOR_GET("interface/theme/caret_width");
+	const int corner_radius = EDITOR_GET("interface/theme/corner_radius");
 
 	Color preset_accent_color;
 	Color preset_base_color;
@@ -1535,7 +1536,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	theme->set_constant("minimum_character_width", "LineEdit", 4);
 	theme->set_constant("outline_size", "LineEdit", 0);
-	theme->set_constant("caret_width", "LineEdit", 1);
+	theme->set_constant("caret_width", "LineEdit", Math::round(caret_width * EDSCALE));
 
 	// TextEdit
 	theme->set_stylebox("normal", "TextEdit", style_line_edit);
@@ -1552,8 +1553,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("background_color", "TextEdit", Color(0, 0, 0, 0));
 
 	theme->set_constant("line_spacing", "TextEdit", 4 * EDSCALE);
-	theme->set_constant("outline_size", "TextEdit", 0);
-	theme->set_constant("caret_width", "TextEdit", 1);
+	theme->set_constant("caret_width", "TextEdit", Math::round(caret_width * EDSCALE));
 
 	theme->set_icon("h_grabber", "SplitContainer", theme->get_icon(SNAME("GuiHsplitter"), SNAME("EditorIcons")));
 	theme->set_icon("v_grabber", "SplitContainer", theme->get_icon(SNAME("GuiVsplitter"), SNAME("EditorIcons")));

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -1002,7 +1002,8 @@ void LineEdit::_notification(int p_what) {
 					} else {
 						if (caret.l_caret != Rect2() && caret.l_dir == TextServer::DIRECTION_AUTO) {
 							// Draw extra marker on top of mid caret.
-							Rect2 trect = Rect2(caret.l_caret.position.x - 2.5 * caret_width, caret.l_caret.position.y, 6 * caret_width, caret_width);
+							Size2 gr_bounds = TS->shaped_text_get_grapheme_bounds(text_rid, caret_column);
+							Rect2 trect = Rect2(gr_bounds.x, caret.l_caret.position.y, gr_bounds.y - gr_bounds.x, get_theme_default_base_scale());
 							trect.position += ofs;
 							RenderingServer::get_singleton()->canvas_item_add_rect(ci, trect, caret_color);
 						} else if (caret.l_caret != Rect2() && caret.t_caret != Rect2() && caret.l_dir != caret.t_dir) {
@@ -1043,7 +1044,7 @@ void LineEdit::_notification(int p_what) {
 							} else if (rect.position.x + rect.size.x > ofs_max) {
 								rect.size.x = ofs_max - rect.position.x;
 							}
-							rect.size.y = caret_width;
+							rect.size.y = get_theme_default_base_scale();
 							RenderingServer::get_singleton()->canvas_item_add_rect(ci, rect, caret_color);
 						}
 					}
@@ -1062,7 +1063,7 @@ void LineEdit::_notification(int p_what) {
 								} else if (rect.position.x + rect.size.x > ofs_max) {
 									rect.size.x = ofs_max - rect.position.x;
 								}
-								rect.size.y = caret_width * 3;
+								rect.size.y = 3 * get_theme_default_base_scale();
 								RenderingServer::get_singleton()->canvas_item_add_rect(ci, rect, caret_color);
 							}
 						}

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -1341,10 +1341,10 @@ void TextEdit::_notification(int p_what) {
 									int h = theme_cache.font->get_height(theme_cache.font_size);
 									if (rtl) {
 										ts_caret.l_dir = TextServer::DIRECTION_RTL;
-										ts_caret.l_caret = Rect2(Vector2(xmargin_end - char_margin + ofs_x, -h / 2), Size2(caret_width * 4, h));
+										ts_caret.l_caret = Rect2(Vector2(xmargin_end - char_margin + ofs_x, -h / 2), Size2(4 * get_theme_default_base_scale(), h));
 									} else {
 										ts_caret.l_dir = TextServer::DIRECTION_LTR;
-										ts_caret.l_caret = Rect2(Vector2(char_ofs, -h / 2), Size2(caret_width * 4, h));
+										ts_caret.l_caret = Rect2(Vector2(char_ofs, -h / 2), Size2(4 * get_theme_default_base_scale(), h));
 									}
 								}
 
@@ -1364,7 +1364,7 @@ void TextEdit::_notification(int p_what) {
 											if (ts_caret.t_caret != Rect2()) {
 												if (overtype_mode) {
 													ts_caret.t_caret.position.y = TS->shaped_text_get_descent(rid);
-													ts_caret.t_caret.size.y = caret_width;
+													ts_caret.l_caret.size.y = get_theme_default_base_scale();
 												} else {
 													ts_caret.t_caret.position.y = -TS->shaped_text_get_ascent(rid);
 													ts_caret.t_caret.size.y = h;
@@ -1394,12 +1394,12 @@ void TextEdit::_notification(int p_what) {
 													}
 												} else if (overtype_mode) {
 													ts_caret.l_caret.position.y += ts_caret.l_caret.size.y;
-													ts_caret.l_caret.size.y = caret_width;
+													ts_caret.l_caret.size.y = get_theme_default_base_scale();
 												}
 												if (Math::ceil(ts_caret.l_caret.position.x) >= TS->shaped_text_get_size(rid).x) {
 													ts_caret.l_caret.size.x = theme_cache.font->get_char_size('m', theme_cache.font_size).x;
 												} else {
-													ts_caret.l_caret.size.x = 3 * caret_width;
+													ts_caret.l_caret.size.x = 3 * get_theme_default_base_scale();
 												}
 												ts_caret.l_caret.position += Vector2(char_margin + ofs_x, ofs_y);
 												if (ts_caret.l_dir == TextServer::DIRECTION_RTL) {
@@ -1411,7 +1411,8 @@ void TextEdit::_notification(int p_what) {
 											// Normal caret.
 											if (ts_caret.l_caret != Rect2() && ts_caret.l_dir == TextServer::DIRECTION_AUTO) {
 												// Draw extra marker on top of mid caret.
-												Rect2 trect = Rect2(ts_caret.l_caret.position.x - 2.5 * caret_width, ts_caret.l_caret.position.y, 6 * caret_width, caret_width);
+												Size2 gr_bounds = TS->shaped_text_get_grapheme_bounds(rid, caret.column);
+												Rect2 trect = Rect2(gr_bounds.x, caret.l_caret.position.y, gr_bounds.y - gr_bounds.x, get_theme_default_base_scale());
 												trect.position += Vector2(char_margin + ofs_x, ofs_y);
 												RenderingServer::get_singleton()->canvas_item_add_rect(ci, trect, theme_cache.caret_color);
 											} else if (ts_caret.l_caret != Rect2() && ts_caret.t_caret != Rect2() && ts_caret.l_dir != ts_caret.t_dir) {
@@ -1454,7 +1455,7 @@ void TextEdit::_notification(int p_what) {
 										} else if (rect.position.x + rect.size.x > xmargin_end) {
 											rect.size.x = xmargin_end - rect.position.x;
 										}
-										rect.size.y = caret_width;
+										rect.size.y = get_theme_default_base_scale();
 										draw_rect(rect, theme_cache.caret_color);
 										carets.write[c].draw_pos.x = rect.position.x;
 									}
@@ -1473,7 +1474,7 @@ void TextEdit::_notification(int p_what) {
 										} else if (rect.position.x + rect.size.x > xmargin_end) {
 											rect.size.x = xmargin_end - rect.position.x;
 										}
-										rect.size.y = caret_width * 3;
+										rect.size.y = 3 * get_theme_default_base_scale();
 										draw_rect(rect, theme_cache.caret_color);
 										carets.write[c].draw_pos.x = rect.position.x;
 									}


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/54956.

This can be used to improve caret visibility in LineEdits and TextEdits used by the editor (including the script editor).

For reference, Windows 10 allows increasing the caret width up to 20:

![image](https://user-images.githubusercontent.com/180032/156466937-371ed417-c0b3-4bb3-842a-fc64e8490e20.png)

However, I limited the setting to 6 as Godot does not draw an inverted version of the character behind the caret. This makes large caret sizes not very useful to have.

**Note:** For this to be backported to `3.x`, https://github.com/godotengine/godot/pull/54956 needs to be backported first.
WIP `3.x` backport: https://github.com/Calinou/godot/tree/editor-add-caret-width-setting-3.x

- See https://github.com/godotengine/godot-proposals/issues/8473.