### PR TITLE
Fix that invisible CanvasItems are visible on entering the SceneTree

### DIFF
--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -248,6 +248,8 @@ void CanvasItem::_enter_canvas() {
 		RenderingServer::get_singleton()->canvas_item_set_draw_index(canvas_item, get_index());
 	}
 
+	RenderingServer::get_singleton()->canvas_item_set_visible(canvas_item, is_visible_in_tree());
+
 	pending_update = false;
 	update();
 


### PR DESCRIPTION
resolve #58695

`CanvasItem` uses `RenderingServer::get_singleton()->canvas_item_set_visible()` for handling visibility status of CanvasItems, but does not initialize it at the moment.
This patch ensures, that hidden items are set to invisible during initialization in `CanvasItem::_enter_canvas()`.

~~I did not yet find out, why exactly the referenced issue only affects `TileMap`, but no other CanvasItems.~~