### PR TITLE
glTF export for new TYPE_BLEND_SHAPE tracks

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -6470,8 +6470,8 @@ void GLTFDocument::_convert_animation(Ref<GLTFState> state, AnimationPlayer *ap,
 					gltf_animation->get_tracks().insert(transform_track_i.key, track);
 				}
 			}
-		} else if (String(orig_track_path).contains(":blend_shapes/")) {
-			const Vector<String> node_suffix = String(orig_track_path).split(":blend_shapes/");
+		} else if (String(orig_track_path).contains(":") && animation->track_get_type(track_i) == Animation::TYPE_BLEND_SHAPE) {
+			const Vector<String> node_suffix = String(orig_track_path).split(":");
 			const NodePath path = node_suffix[0];
 			const String suffix = node_suffix[1];
 			Node *node = ap->get_parent()->get_node_or_null(path);


### PR DESCRIPTION
Most of the code was updated to use TYPE_BLEND_SHAPE , but the initial condition for deciding to treat a track as a blend shape track was still using the old ":blend_shapes/" prefix.

The rest of the logic in this function already assumes the new track types, so it seems logical to change this if statement to match.

Reading the rest of the code, I don't think the old TYPE_VALUE :blend_shapes/ tracks are supported for export anymore. @fire do you know?