### PR TITLE
Add linear_velocity and angular_velocity to PhysicalBone3D

### DIFF
--- a/doc/classes/PhysicalBone3D.xml
+++ b/doc/classes/PhysicalBone3D.xml
@@ -7,6 +7,13 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="_integrate_forces" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="state" type="PhysicsDirectBodyState3D" />
+			<description>
+				Called during physics processing, allowing you to read and safely modify the simulation state for the object. By default, it works in addition to the usual physics behavior, but the [member custom_integrator] property allows you to disable the default behavior and do fully custom force integration for a body.
+			</description>
+		</method>
 		<method name="apply_central_impulse">
 			<return type="void" />
 			<argument index="0" name="impulse" type="Vector3" />
@@ -44,6 +51,9 @@
 		<member name="angular_damp_mode" type="int" setter="set_angular_damp_mode" getter="get_angular_damp_mode" enum="PhysicalBone3D.DampMode" default="0">
 			Defines how [member angular_damp] is applied. See [enum DampMode] for possible values.
 		</member>
+		<member name="angular_velocity" type="Vector3" setter="set_angular_velocity" getter="get_angular_velocity" default="Vector3(0, 0, 0)">
+			The PhysicalBone3D's rotational velocity in [i]radians[/i] per second.
+		</member>
 		<member name="body_offset" type="Transform3D" setter="set_body_offset" getter="get_body_offset" default="Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0)">
 			Sets the body's transform.
 		</member>
@@ -52,6 +62,9 @@
 		</member>
 		<member name="can_sleep" type="bool" setter="set_can_sleep" getter="is_able_to_sleep" default="true">
 			If [code]true[/code], the body is deactivated when there is no movement, so it will not take part in the simulation until it is awakened by an external force.
+		</member>
+		<member name="custom_integrator" type="bool" setter="set_use_custom_integrator" getter="is_using_custom_integrator" default="false">
+			If [code]true[/code], internal force integration will be disabled (like gravity or air friction) for this body. Other than collision response, the body will only move as determined by the [method _integrate_forces] function, if defined.
 		</member>
 		<member name="friction" type="float" setter="set_friction" getter="get_friction" default="1.0">
 			The body's friction, from [code]0[/code] (frictionless) to [code]1[/code] (max friction).
@@ -74,6 +87,9 @@
 		</member>
 		<member name="linear_damp_mode" type="int" setter="set_linear_damp_mode" getter="get_linear_damp_mode" enum="PhysicalBone3D.DampMode" default="0">
 			Defines how [member linear_damp] is applied. See [enum DampMode] for possible values.
+		</member>
+		<member name="linear_velocity" type="Vector3" setter="set_linear_velocity" getter="get_linear_velocity" default="Vector3(0, 0, 0)">
+			The body's linear velocity in units per second. Can be used sporadically, but [b]don't set this every frame[/b], because physics may run in another thread and runs at a different granularity. Use [method _integrate_forces] as your process loop for precise control of the body state.
 		</member>
 		<member name="mass" type="float" setter="set_mass" getter="get_mass" default="1.0">
 			The body's mass.

--- a/scene/3d/physics_body_3d.h
+++ b/scene/3d/physics_body_3d.h
@@ -662,8 +662,12 @@ private:
 	real_t bounce = 0.0;
 	real_t mass = 1.0;
 	real_t friction = 1.0;
+	Vector3 linear_velocity;
+	Vector3 angular_velocity;
 	real_t gravity_scale = 1.0;
 	bool can_sleep = true;
+
+	bool custom_integrator = false;
 
 	DampMode linear_damp_mode = DAMP_MODE_COMBINE;
 	DampMode angular_damp_mode = DAMP_MODE_COMBINE;
@@ -676,6 +680,7 @@ protected:
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _notification(int p_what);
+	GDVIRTUAL1(_integrate_forces, PhysicsDirectBodyState3D *)
 	static void _body_state_changed_callback(void *p_instance, PhysicsDirectBodyState3D *p_state);
 	void _body_state_changed(PhysicsDirectBodyState3D *p_state);
 
@@ -690,6 +695,15 @@ private:
 
 public:
 	void _on_bone_parent_changed();
+
+	void set_linear_velocity(const Vector3 &p_velocity);
+	Vector3 get_linear_velocity() const override;
+
+	void set_angular_velocity(const Vector3 &p_velocity);
+	Vector3 get_angular_velocity() const override;
+
+	void set_use_custom_integrator(bool p_enable);
+	bool is_using_custom_integrator();
 
 #ifdef TOOLS_ENABLED
 	void _set_gizmo_move_joint(bool p_move_joint);


### PR DESCRIPTION
This is because my previous pull request was cancelled,
this was really annoying to do, finding all the little things and copying them
but i have an idea

we make another class that rigidbody3d and physicalbone3d inherit from
so physical bone and rigid body stay up to date but its still easy to make them different
this class controls stuff like physicalmaterial, damping, accessing velocity and more
but still that rigid body and physial bone can be seperated

so we have the pros of having to do less annoying copying
while not having the cons of physicalbone beeing harder to edit

does it sound good? (not in this pull request, just an idea)