### PR TITLE
Make EditorSpinSlider label color a theme property

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -691,15 +691,11 @@ void EditorProperty::unhandled_key_input(const Ref<InputEvent> &p_event) {
 }
 
 const Color *EditorProperty::_get_property_colors() {
-	const Color base = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
-	const float saturation = base.get_s() * 0.75;
-	const float value = base.get_v();
-
 	static Color c[4];
-	c[0].set_hsv(0.0 / 3.0 + 0.05, saturation, value);
-	c[1].set_hsv(1.0 / 3.0 + 0.05, saturation, value);
-	c[2].set_hsv(2.0 / 3.0 + 0.05, saturation, value);
-	c[3].set_hsv(1.5 / 3.0 + 0.05, saturation, value);
+	c[0] = get_theme_color(SNAME("property_color_x"), SNAME("Editor"));
+	c[1] = get_theme_color(SNAME("property_color_y"), SNAME("Editor"));
+	c[2] = get_theme_color(SNAME("property_color_z"), SNAME("Editor"));
+	c[3] = get_theme_color(SNAME("property_color_w"), SNAME("Editor"));
 	return c;
 }
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -1626,7 +1626,7 @@ void EditorPropertyVector2::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			const Color *colors = _get_property_colors();
 			for (int i = 0; i < 2; i++) {
-				spin[i]->set_custom_label_color(true, colors[i]);
+				spin[i]->add_theme_color_override("label_color", colors[i]);
 			}
 		} break;
 	}
@@ -1720,7 +1720,7 @@ void EditorPropertyRect2::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			const Color *colors = _get_property_colors();
 			for (int i = 0; i < 4; i++) {
-				spin[i]->set_custom_label_color(true, colors[i % 2]);
+				spin[i]->add_theme_color_override("label_color", colors[i % 2]);
 			}
 		} break;
 	}
@@ -1849,7 +1849,7 @@ void EditorPropertyVector3::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			const Color *colors = _get_property_colors();
 			for (int i = 0; i < 3; i++) {
-				spin[i]->set_custom_label_color(true, colors[i]);
+				spin[i]->add_theme_color_override("label_color", colors[i]);
 			}
 		} break;
 	}
@@ -1939,7 +1939,7 @@ void EditorPropertyVector2i::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			const Color *colors = _get_property_colors();
 			for (int i = 0; i < 2; i++) {
-				spin[i]->set_custom_label_color(true, colors[i]);
+				spin[i]->add_theme_color_override("label_color", colors[i]);
 			}
 		} break;
 	}
@@ -2033,7 +2033,7 @@ void EditorPropertyRect2i::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			const Color *colors = _get_property_colors();
 			for (int i = 0; i < 4; i++) {
-				spin[i]->set_custom_label_color(true, colors[i % 2]);
+				spin[i]->add_theme_color_override("label_color", colors[i % 2]);
 			}
 		} break;
 	}
@@ -2135,7 +2135,7 @@ void EditorPropertyVector3i::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			const Color *colors = _get_property_colors();
 			for (int i = 0; i < 3; i++) {
-				spin[i]->set_custom_label_color(true, colors[i]);
+				spin[i]->add_theme_color_override("label_color", colors[i]);
 			}
 		} break;
 	}
@@ -2228,7 +2228,7 @@ void EditorPropertyPlane::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			const Color *colors = _get_property_colors();
 			for (int i = 0; i < 4; i++) {
-				spin[i]->set_custom_label_color(true, colors[i]);
+				spin[i]->add_theme_color_override("label_color", colors[i]);
 			}
 		} break;
 	}
@@ -2322,7 +2322,7 @@ void EditorPropertyQuaternion::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			const Color *colors = _get_property_colors();
 			for (int i = 0; i < 4; i++) {
-				spin[i]->set_custom_label_color(true, colors[i]);
+				spin[i]->add_theme_color_override("label_color", colors[i]);
 			}
 		} break;
 	}
@@ -2419,7 +2419,7 @@ void EditorPropertyAABB::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			const Color *colors = _get_property_colors();
 			for (int i = 0; i < 6; i++) {
-				spin[i]->set_custom_label_color(true, colors[i % 3]);
+				spin[i]->add_theme_color_override("label_color", colors[i % 3]);
 			}
 		} break;
 	}
@@ -2505,9 +2505,9 @@ void EditorPropertyTransform2D::_notification(int p_what) {
 			for (int i = 0; i < 6; i++) {
 				// For Transform2D, use the 4th color (cyan) for the origin vector.
 				if (i % 3 == 2) {
-					spin[i]->set_custom_label_color(true, colors[3]);
+					spin[i]->add_theme_color_override("label_color", colors[3]);
 				} else {
-					spin[i]->set_custom_label_color(true, colors[i % 3]);
+					spin[i]->add_theme_color_override("label_color", colors[i % 3]);
 				}
 			}
 		} break;
@@ -2599,7 +2599,7 @@ void EditorPropertyBasis::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			const Color *colors = _get_property_colors();
 			for (int i = 0; i < 9; i++) {
-				spin[i]->set_custom_label_color(true, colors[i % 3]);
+				spin[i]->add_theme_color_override("label_color", colors[i % 3]);
 			}
 		} break;
 	}
@@ -2696,7 +2696,7 @@ void EditorPropertyTransform3D::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			const Color *colors = _get_property_colors();
 			for (int i = 0; i < 12; i++) {
-				spin[i]->set_custom_label_color(true, colors[i % 4]);
+				spin[i]->add_theme_color_override("label_color", colors[i % 4]);
 			}
 		} break;
 	}

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -300,12 +300,7 @@ void EditorSpinSlider::_draw_spin_slider() {
 	int vofs = (size.height - font->get_height(font_size)) / 2 + font->get_ascent(font_size);
 
 	Color fc = get_theme_color(is_read_only() ? SNAME("font_uneditable_color") : SNAME("font_color"), SNAME("LineEdit"));
-	Color lc;
-	if (use_custom_label_color) {
-		lc = custom_label_color;
-	} else {
-		lc = fc;
-	}
+	Color lc = get_theme_color(is_read_only() ? SNAME("read_only_label_color") : SNAME("label_color"));
 
 	if (flat && !label.is_empty()) {
 		Color label_bg_color = get_theme_color(SNAME("dark_color_3"), SNAME("Editor"));
@@ -605,11 +600,6 @@ bool EditorSpinSlider::is_flat() const {
 	return flat;
 }
 
-void EditorSpinSlider::set_custom_label_color(bool p_use_custom_label_color, Color p_custom_label_color) {
-	use_custom_label_color = p_use_custom_label_color;
-	custom_label_color = p_custom_label_color;
-}
-
 void EditorSpinSlider::_focus_entered() {
 	_ensure_input_popup();
 	Rect2 gr = get_screen_rect();
@@ -689,5 +679,4 @@ EditorSpinSlider::EditorSpinSlider() {
 	value_input_just_closed = false;
 	hide_slider = false;
 	read_only = false;
-	use_custom_label_color = false;
 }

--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -76,9 +76,6 @@ class EditorSpinSlider : public Range {
 	bool hide_slider;
 	bool flat;
 
-	bool use_custom_label_color;
-	Color custom_label_color;
-
 	void _evaluate_input_text();
 
 	void _update_value_input_stylebox();
@@ -111,8 +108,6 @@ public:
 
 	void set_flat(bool p_enable);
 	bool is_flat() const;
-
-	void set_custom_label_color(bool p_use_custom_label_color, Color p_custom_label_color);
 
 	void setup_and_show() { _focus_entered(); }
 	LineEdit *get_line_edit();

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -464,6 +464,14 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("axis_y_color", "Editor", Color(0.53, 0.84, 0.01));
 	theme->set_color("axis_z_color", "Editor", Color(0.16, 0.55, 0.96));
 
+	const float prop_color_saturation = accent_color.get_s() * 0.75;
+	const float prop_color_value = accent_color.get_v();
+
+	theme->set_color("property_color_x", "Editor", Color().from_hsv(0.0 / 3.0 + 0.05, prop_color_saturation, prop_color_value));
+	theme->set_color("property_color_y", "Editor", Color().from_hsv(1.0 / 3.0 + 0.05, prop_color_saturation, prop_color_value));
+	theme->set_color("property_color_z", "Editor", Color().from_hsv(2.0 / 3.0 + 0.05, prop_color_saturation, prop_color_value));
+	theme->set_color("property_color_w", "Editor", Color().from_hsv(1.5 / 3.0 + 0.05, prop_color_saturation, prop_color_value));
+
 	theme->set_color("font_color", "Editor", font_color);
 	theme->set_color("highlighted_font_color", "Editor", font_hover_color);
 	theme->set_color("disabled_font_color", "Editor", font_disabled_color);
@@ -863,6 +871,10 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	theme->set_color("sub_inspector_property_color", "Editor", dark_theme ? Color(1, 1, 1, 1) : Color(0, 0, 0, 1));
 	theme->set_constant("sub_inspector_font_offset", "Editor", 4 * EDSCALE);
+
+	// EditorSpinSlider.
+	theme->set_color("label_color", "EditorSpinSlider", font_color);
+	theme->set_color("read_only_label_color", "EditorSpinSlider", font_readonly_color);
 
 	Ref<StyleBoxFlat> style_property_bg = style_default->duplicate();
 	style_property_bg->set_bg_color(highlight_color);

--- a/editor/plugins/ot_features_plugin.cpp
+++ b/editor/plugins/ot_features_plugin.cpp
@@ -53,7 +53,7 @@ void OpenTypeFeaturesEditor::_notification(int p_what) {
 
 			button->set_icon(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons")));
 			button->set_size(get_theme_icon(SNAME("Remove"), SNAME("EditorIcons"))->get_size());
-			spin->set_custom_label_color(true, base);
+			spin->add_theme_color_override("label_color", base);
 		} break;
 	}
 }


### PR DESCRIPTION
* Replaces `EditorSpinSlider.set_custom_label_color()` with two theme properties: `label_color` and `read_only_label_color` so that plugins can use custom label colors.
* Moves property colors from `EditorProperty._get_property_colors()` to editor theme so they can be accessed by plugins.

*Bugsquad edit: This closes https://github.com/godotengine/godot-proposals/issues/4154.*