### PR TITLE
Increase the Profiler Frame Max Functions value to 16384

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1241,9 +1241,6 @@ ProjectSettings::ProjectSettings() {
 	GLOBAL_DEF("physics/2d/run_on_separate_thread", false);
 	GLOBAL_DEF("physics/3d/run_on_separate_thread", false);
 
-	GLOBAL_DEF("debug/settings/profiler/max_functions", 16384);
-	custom_prop_info["debug/settings/profiler/max_functions"] = PropertyInfo(Variant::INT, "debug/settings/profiler/max_functions", PROPERTY_HINT_RANGE, "128,65535,1");
-
 	GLOBAL_DEF("compression/formats/zstd/long_distance_matching", Compression::zstd_long_distance_matching);
 	custom_prop_info["compression/formats/zstd/long_distance_matching"] = PropertyInfo(Variant::BOOL, "compression/formats/zstd/long_distance_matching");
 	GLOBAL_DEF("compression/formats/zstd/compression_level", Compression::zstd_level);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -439,9 +439,6 @@
 		<member name="debug/settings/gdscript/max_call_stack" type="int" setter="" getter="" default="1024">
 			Maximum call stack allowed for debugging GDScript.
 		</member>
-		<member name="debug/settings/profiler/max_functions" type="int" setter="" getter="" default="16384">
-			Maximum amount of functions per frame allowed when profiling.
-		</member>
 		<member name="debug/settings/stdout/print_fps" type="bool" setter="" getter="" default="false">
 			Print frames per second to standard output every second.
 		</member>

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -665,8 +665,6 @@ EditorProfiler::EditorProfiler() {
 	last_metric = -1;
 	hover_metric = -1;
 
-	EDITOR_DEF("debugger/profiler_frame_max_functions", 64);
-
 	frame_delay = memnew(Timer);
 	frame_delay->set_wait_time(0.1);
 	frame_delay->set_one_shot(true);

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -986,9 +986,9 @@ void ScriptEditorDebugger::_profiler_activate(bool p_enable, int p_type) {
 				// Clear old script signatures. (should we move all this into the profiler?)
 				profiler_signature.clear();
 				// Add max funcs options to request.
+				// The hardcoded value below matches the size in the ScriptsProfiler constructor.
 				Array opts;
-				int max_funcs = EditorSettings::get_singleton()->get("debugger/profiler_frame_max_functions");
-				opts.push_back(CLAMP(max_funcs, 16, 512));
+				opts.push_back(16384);
 				data.push_back(opts);
 			}
 			_put_msg("profiler:servers", data);

--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -267,7 +267,8 @@ public:
 	}
 
 	ScriptsProfiler() {
-		info.resize(GLOBAL_GET("debug/settings/profiler/max_functions"));
+		// The hardcoded value below matches the size in ScriptEditorDebugger.
+		info.resize(16384);
 		ptrs.resize(info.size());
 	}
 };


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/43697.

Since the default value is now very high, the settings to adjust it were removed as they're probably not needed anymore.