### PR TITLE
[macOS and iOS export] Add localized application name to the translation .plist files.

### DIFF
--- a/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
+++ b/misc/dist/ios_xcode/godot_ios.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		D0BCFE3418AEBDA2004A7AAE /* $binary.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "$binary.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		D0BCFE4318AEBDA2004A7AAE /* $binary-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "$binary-Info.plist"; sourceTree = "<group>"; };
 		D0BCFE4518AEBDA2004A7AAE /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		$pbx_locale_file_reference
 		D0BCFE7718AEBFEB004A7AAE /* $binary.pck */ = {isa = PBXFileReference; lastKnownFileType = file; path = "$binary.pck"; sourceTree = "<group>"; };
 		$pbx_launch_screen_file_reference
 /* End PBXFileReference section */
@@ -207,6 +208,7 @@
 			isa = PBXVariantGroup;
 			children = (
 				D0BCFE4518AEBDA2004A7AAE /* en */,
+				$pbx_locale_build_reference
 			);
 			name = InfoPlist.strings;
 			sourceTree = "<group>";

--- a/misc/dist/osx_template.app/Contents/Info.plist
+++ b/misc/dist/osx_template.app/Contents/Info.plist
@@ -8,6 +8,8 @@
 	<string>$binary</string>
 	<key>CFBundleName</key>
 	<string>$name</string>
+	<key>CFBundleDisplayName</key>
+	<string>$name</string>
 	<key>CFBundleGetInfoString</key>
 	<string>$info</string>
 	<key>CFBundleIconFile</key>

--- a/platform/osx/export/export_plugin.cpp
+++ b/platform/osx/export/export_plugin.cpp
@@ -787,6 +787,7 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 			String fname = tmp_app_path_name + "/Contents/Resources/en.lproj";
 			tmp_app_dir->make_dir_recursive(fname);
 			FileAccessRef f = FileAccess::open(fname + "/InfoPlist.strings", FileAccess::WRITE);
+			f->store_line("CFBundleDisplayName = \"" + ProjectSettings::get_singleton()->get("application/config/name").operator String() + "\";");
 		}
 
 		for (const String &E : translations) {
@@ -795,6 +796,10 @@ Error EditorExportPlatformOSX::export_project(const Ref<EditorExportPreset> &p_p
 				String fname = tmp_app_path_name + "/Contents/Resources/" + tr->get_locale() + ".lproj";
 				tmp_app_dir->make_dir_recursive(fname);
 				FileAccessRef f = FileAccess::open(fname + "/InfoPlist.strings", FileAccess::WRITE);
+				String prop = "application/config/name_" + tr->get_locale();
+				if (ProjectSettings::get_singleton()->has_setting(prop)) {
+					f->store_line("CFBundleDisplayName = \"" + ProjectSettings::get_singleton()->get(prop).operator String() + "\";");
+				}
 			}
 		}
 	}


### PR DESCRIPTION
- Adds an `Info.plist` translation for each language in the project for the iOS export (similar to #57577).
- Adds localized display names from `application/config/name_{locale}` into generated `.plist` s for the iOS and macOS exports (was used for this purpose for Android exports).

Note: in case of macOS, `.app` bundle file name should match non-localized name (which is true by default), if it's renamed, Finder will use file name.

Fixes #58709
