### PR TITLE
Tweak editor visual profiler frame time label for consistency

### DIFF
--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -724,7 +724,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	hb->add_child(memnew(Label(TTR("Measure:"))));
 
 	display_mode = memnew(OptionButton);
-	display_mode->add_item(TTR("Frame Time (msec)"));
+	display_mode->add_item(TTR("Frame Time (ms)"));
 	display_mode->add_item(TTR("Frame %"));
 	display_mode->connect("item_selected", callable_mp(this, &EditorVisualProfiler::_combo_changed));
 


### PR DESCRIPTION
This is consistent with the general profiler's frame time label.

Follow-up to https://github.com/godotengine/godot/pull/58734.