### PR TITLE
[macOS] Disable window redraw during resize, when rendering in the separate thread.

### DIFF
--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -160,6 +160,7 @@ private:
 	float display_max_scale = 1.f;
 	Point2i origin;
 	bool displays_arrangement_dirty = true;
+	bool is_resizing = false;
 
 	CursorShape cursor_shape = CURSOR_ARROW;
 	NSCursor *cursors[CURSOR_MAX];
@@ -206,6 +207,8 @@ public:
 	void mouse_process_popups(bool p_close = false);
 	void popup_open(WindowID p_window);
 	void popup_close(WindowID p_window);
+	void set_is_resizing(bool p_is_resizing);
+	bool get_is_resizing() const;
 
 	void window_update(WindowID p_window);
 	void window_destroy(WindowID p_window);

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -599,6 +599,14 @@ void DisplayServerOSX::set_last_focused_window(WindowID p_window) {
 	last_focused_window = p_window;
 }
 
+void DisplayServerOSX::set_is_resizing(bool p_is_resizing) {
+	is_resizing = p_is_resizing;
+}
+
+bool DisplayServerOSX::get_is_resizing() const {
+	return is_resizing;
+}
+
 void DisplayServerOSX::window_update(WindowID p_window) {
 #if defined(GLES3_ENABLED)
 	if (gl_manager) {

--- a/platform/osx/godot_window_delegate.mm
+++ b/platform/osx/godot_window_delegate.mm
@@ -149,6 +149,20 @@
 	}
 }
 
+- (void)windowWillStartLiveResize:(NSNotification *)notification {
+	DisplayServerOSX *ds = (DisplayServerOSX *)DisplayServer::get_singleton();
+	if (ds) {
+		ds->set_is_resizing(true);
+	}
+}
+
+- (void)windowDidEndLiveResize:(NSNotification *)notification {
+	DisplayServerOSX *ds = (DisplayServerOSX *)DisplayServer::get_singleton();
+	if (ds) {
+		ds->set_is_resizing(false);
+	}
+}
+
 - (void)windowDidResize:(NSNotification *)notification {
 	DisplayServerOSX *ds = (DisplayServerOSX *)DisplayServer::get_singleton();
 	if (!ds || !ds->has_window(window_id)) {

--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -58,7 +58,8 @@ _FORCE_INLINE_ String OS_OSX::get_framework_executable(const String &p_path) {
 void OS_OSX::pre_wait_observer_cb(CFRunLoopObserverRef p_observer, CFRunLoopActivity p_activiy, void *p_context) {
 	// Prevent main loop from sleeping and redraw window during resize / modal popups.
 
-	if (get_singleton()->get_main_loop()) {
+	DisplayServerOSX *ds = (DisplayServerOSX *)DisplayServer::get_singleton();
+	if (get_singleton()->get_main_loop() && ds && (get_singleton()->get_render_thread_mode() != RENDER_SEPARATE_THREAD || !ds->get_is_resizing())) {
 		Main::force_redraw();
 		if (!Main::is_iterating()) { // Avoid cyclic loop.
 			Main::iteration();


### PR DESCRIPTION
Same as #56059 for `master`.

Fixes #58606