### PR TITLE
Add optional constructor arguments to more Control nodes

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -583,8 +583,8 @@ void Button::_bind_methods() {
 Button::Button(const String &p_text) {
 	text_buf.instantiate();
 	text_buf->set_flags(TextServer::BREAK_MANDATORY);
-
 	set_mouse_filter(MOUSE_FILTER_STOP);
+
 	set_text(p_text);
 }
 

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -111,9 +111,12 @@ void CheckButton::_notification(int p_what) {
 	}
 }
 
-CheckButton::CheckButton() {
+CheckButton::CheckButton(const String &p_text) :
+		Button(p_text) {
 	set_toggle_mode(true);
+
 	set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
+
 	if (is_layout_rtl()) {
 		_set_internal_margin(SIDE_LEFT, get_icon_size().width);
 	} else {

--- a/scene/gui/check_button.h
+++ b/scene/gui/check_button.h
@@ -42,7 +42,7 @@ protected:
 	void _notification(int p_what);
 
 public:
-	CheckButton();
+	CheckButton(const String &p_text = String());
 	~CheckButton();
 };
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1429,7 +1429,8 @@ void ColorPickerButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "edit_alpha"), "set_edit_alpha", "is_editing_alpha");
 }
 
-ColorPickerButton::ColorPickerButton() {
+ColorPickerButton::ColorPickerButton(const String &p_text) :
+		Button(p_text) {
 	set_toggle_mode(true);
 }
 

--- a/scene/gui/color_picker.h
+++ b/scene/gui/color_picker.h
@@ -231,7 +231,7 @@ public:
 	ColorPicker *get_picker();
 	PopupPanel *get_popup();
 
-	ColorPickerButton();
+	ColorPickerButton(const String &p_text = String());
 };
 
 VARIANT_ENUM_CAST(ColorPicker::PickerShapeType);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2437,7 +2437,7 @@ void LineEdit::_ensure_menu() {
 	}
 }
 
-LineEdit::LineEdit() {
+LineEdit::LineEdit(const String &p_placeholder) {
 	text_rid = TS->create_shaped_text();
 	_create_undo_state();
 
@@ -2451,6 +2451,8 @@ LineEdit::LineEdit() {
 	caret_blink_timer->set_wait_time(0.65);
 	caret_blink_timer->connect("timeout", callable_mp(this, &LineEdit::_toggle_draw_caret));
 	set_caret_blink_enabled(false);
+
+	set_placeholder(p_placeholder);
 
 	set_editable(true); // Initialise to opposite first, so we get past the early-out in set_editable.
 }

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -332,7 +332,7 @@ public:
 
 	void show_virtual_keyboard();
 
-	LineEdit();
+	LineEdit(const String &p_placeholder = String());
 	~LineEdit();
 };
 

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -317,8 +317,10 @@ void LinkButton::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "structured_text_bidi_override_options"), "set_structured_text_bidi_override_options", "get_structured_text_bidi_override_options");
 }
 
-LinkButton::LinkButton() {
+LinkButton::LinkButton(const String &p_text) {
 	text_buf.instantiate();
 	set_focus_mode(FOCUS_NONE);
 	set_default_cursor_shape(CURSOR_POINTING_HAND);
+
+	set_text(p_text);
 }

--- a/scene/gui/link_button.h
+++ b/scene/gui/link_button.h
@@ -90,7 +90,7 @@ public:
 	void set_underline_mode(UnderlineMode p_underline_mode);
 	UnderlineMode get_underline_mode() const;
 
-	LinkButton();
+	LinkButton(const String &p_text = String());
 };
 
 VARIANT_ENUM_CAST(LinkButton::UnderlineMode);

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -227,7 +227,8 @@ void MenuButton::set_disable_shortcuts(bool p_disabled) {
 	disable_shortcuts = p_disabled;
 }
 
-MenuButton::MenuButton() {
+MenuButton::MenuButton(const String &p_text) :
+		Button(p_text) {
 	set_flat(true);
 	set_toggle_mode(true);
 	set_disable_shortcuts(false);

--- a/scene/gui/menu_button.h
+++ b/scene/gui/menu_button.h
@@ -67,7 +67,7 @@ public:
 	void set_item_count(int p_count);
 	int get_item_count() const;
 
-	MenuButton();
+	MenuButton(const String &p_text = String());
 	~MenuButton();
 };
 

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -412,7 +412,8 @@ void OptionButton::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("item_focused", PropertyInfo(Variant::INT, "index")));
 }
 
-OptionButton::OptionButton() {
+OptionButton::OptionButton(const String &p_text) :
+		Button(p_text) {
 	set_toggle_mode(true);
 	set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 	if (is_layout_rtl()) {

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -94,7 +94,7 @@ public:
 
 	virtual void get_translatable_strings(List<String> *p_strings) const override;
 
-	OptionButton();
+	OptionButton(const String &p_text = String());
 	~OptionButton();
 };
 

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4712,7 +4712,7 @@ Dictionary RichTextLabel::parse_expressions_for_values(Vector<String> p_expressi
 	return d;
 }
 
-RichTextLabel::RichTextLabel() {
+RichTextLabel::RichTextLabel(const String &p_text) {
 	main = memnew(ItemFrame);
 	main->index = 0;
 	current = main;
@@ -4733,6 +4733,8 @@ RichTextLabel::RichTextLabel() {
 	vscroll->connect("value_changed", callable_mp(this, &RichTextLabel::_scroll_changed));
 	vscroll->set_step(1);
 	vscroll->hide();
+
+	set_text(p_text);
 
 	set_clip_contents(true);
 }

--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -620,7 +620,7 @@ public:
 	void set_fixed_size_to_width(int p_width);
 	virtual Size2 get_minimum_size() const override;
 
-	RichTextLabel();
+	RichTextLabel(const String &p_text = String());
 	~RichTextLabel();
 };
 

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6579,7 +6579,7 @@ void TextEdit::_base_remove_text(int p_from_line, int p_from_column, int p_to_li
 	emit_signal(SNAME("lines_edited_from"), p_to_line, p_from_line);
 }
 
-TextEdit::TextEdit() {
+TextEdit::TextEdit(const String &p_placeholder) {
 	placeholder_data_buf.instantiate();
 
 	clear();
@@ -6620,6 +6620,8 @@ TextEdit::TextEdit() {
 	idle_detect->connect("timeout", callable_mp(this, &TextEdit::_push_current_op));
 
 	undo_stack_max_size = GLOBAL_GET("gui/common/text_edit_undo_stack_max_size");
+
+	set_placeholder(p_placeholder);
 
 	set_editable(true);
 }

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -940,7 +940,7 @@ public:
 	void set_draw_spaces(bool p_enabled);
 	bool is_drawing_spaces() const;
 
-	TextEdit();
+	TextEdit(const String &p_placeholder = String());
 };
 
 VARIANT_ENUM_CAST(TextEdit::CaretType);


### PR DESCRIPTION
This can be used to make editor code more compact. However, as of writing, these constructor arguments cannot be used from the scripting API.

This was already provided for Label and CheckBox, but it was missing for other Control nodes where it made sense to provide a default value.