### PR TITLE
Remove extra separator when `TextEdit` is read only and unselectable

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -5664,8 +5664,10 @@ void TextEdit::_generate_context_menu() {
 	if (editable) {
 		menu->add_item(RTR("Paste"), MENU_PASTE, is_shortcut_keys_enabled() ? _get_menu_action_accelerator("ui_paste") : Key::NONE);
 	}
-	menu->add_separator();
-	if (is_selecting_enabled()) {
+	if (selecting_enabled || editable) {
+		menu->add_separator();
+	}
+	if (selecting_enabled) {
 		menu->add_item(RTR("Select All"), MENU_SELECT_ALL, is_shortcut_keys_enabled() ? _get_menu_action_accelerator("ui_text_select_all") : Key::NONE);
 	}
 	if (editable) {


### PR DESCRIPTION
This PR makes the separator only appear when the following two blocks of items will be added.

Also changed calling `is_selecting_enabled()` to using `selecting_enabled` directly. This is the only place that uses the getter inside the cpp.

| Before | After |
| --- | --- |
| ![ksnip_20220304-161723](https://user-images.githubusercontent.com/372476/156726617-b03f69c1-ea60-49f7-b89c-a01680c7ed90.png) | ![ksnip_20220304-162223](https://user-images.githubusercontent.com/372476/156726627-ccdd0d16-db0f-4049-a33c-748ca95e6150.png) |

It's basically the same on `3.x` and the fix is the same.

![ksnip_20220304-161759](https://user-images.githubusercontent.com/372476/156726621-727ee518-2fb1-4af4-a5ff-53e40eb44957.png)