### PR TITLE
WebRTC: Fix potential nullptr dereference in error message

### DIFF
--- a/modules/webrtc/webrtc_multiplayer_peer.cpp
+++ b/modules/webrtc/webrtc_multiplayer_peer.cpp
@@ -353,10 +353,8 @@ Error WebRTCMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer_si
 		ch += CH_RESERVED_MAX - 1;
 	}
 
-	Map<int, Ref<ConnectedPeer>>::Element *E = nullptr;
-
 	if (target_peer > 0) {
-		E = peer_map.find(target_peer);
+		Map<int, Ref<ConnectedPeer>>::Element *E = peer_map.find(target_peer);
 		ERR_FAIL_COND_V_MSG(!E, ERR_INVALID_PARAMETER, "Invalid target peer: " + itos(target_peer) + ".");
 
 		ERR_FAIL_COND_V_MSG(E->value()->channels.size() <= ch, ERR_INVALID_PARAMETER, vformat("Unable to send packet on channel %d, max channels: %d", ch, E->value()->channels.size()));
@@ -372,7 +370,7 @@ Error WebRTCMultiplayerPeer::put_packet(const uint8_t *p_buffer, int p_buffer_si
 				continue;
 			}
 
-			ERR_CONTINUE_MSG(F.value->channels.size() <= ch, vformat("Unable to send packet on channel %d, max channels: %d", ch, E->value()->channels.size()));
+			ERR_CONTINUE_MSG(F.value->channels.size() <= ch, vformat("Unable to send packet on channel %d, max channels: %d", ch, F.value->channels.size()));
 			ERR_CONTINUE(F.value->channels[ch].is_null());
 			F.value->channels[ch]->put_packet(p_buffer, p_buffer_size);
 		}


### PR DESCRIPTION
This was evidently a typo. Didn't get a crash but GCC 12 raised a
`-Warray-bounds` warning:

```
In file included from ./core/io/stream_peer.h:34,
                 from ./core/io/packet_peer.h:34,
                 from ./core/multiplayer/multiplayer_peer.h:34,
                 from modules/webrtc/webrtc_multiplayer_peer.h:34,
                 from modules/webrtc/webrtc_multiplayer_peer.cpp:31:
In member function 'T* Ref<T>::operator->() [with T = WebRTCMultiplayerPeer::ConnectedPeer]',
    inlined from 'virtual Error WebRTCMultiplayerPeer::put_packet(const uint8_t*, int)' at modules/webrtc/webrtc_multiplayer_peer.cpp:376:4:
./core/object/ref_counted.h:101:24: error: array subscript 0 is outside array bounds of 'Ref<WebRTCMultiplayerPeer::ConnectedPeer> [0]' [-Werror=array-bounds]
  101 |                 return reference;
      |                        ^~~~~~~~~
```

Strangely enough it raised the warning when compiling without LTO, but not with LTO.