### PR TITLE
Animation: Silence false positive -Wstringop-overflow warning

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -4347,7 +4347,7 @@ struct AnimationCompressionDataState {
 		if (temp_packets.size() == 0) {
 			return; //nohing to do
 		}
-#define DEBUG_PACKET_PUSH
+//#define DEBUG_PACKET_PUSH
 #ifdef DEBUG_PACKET_PUSH
 #ifndef _MSC_VER
 #warning Debugging packet push, disable this code in production to gain a bit more import performance.
@@ -4378,7 +4378,7 @@ struct AnimationCompressionDataState {
 			header_bytes += 2;
 		}
 
-		while (header_bytes % 4 != 0) {
+		while (header_bytes < 8 && header_bytes % 4 != 0) { // First cond needed to silence wrong GCC warning.
 			header[header_bytes++] = 0;
 		}
 


### PR DESCRIPTION
And disable debug code which was wrongly left enabled.

@marxin I don't know if that's an expected false positive from GCC, or a situation which is still risky enough (while being correct in this case) to warrant warning just in case. I reduced it to this:
```cpp
#include <cstdint>
#include <cstdio>

uint32_t some_func(const uint32_t components) {
	uint8_t header[8];
	uint32_t header_bytes = 0;
	for (uint32_t i = 0; i < components; i++) {
		header_bytes += 2;
	}
	header_bytes += 2;
	// This works it around, but shouldn't be needed AFAICT.
	//while (header_bytes != 8 && header_bytes % 4 != 0) {
	while (header_bytes % 4 != 0) {
		header[header_bytes++] = 0;
	}
	for (uint32_t i = 0; i < header_bytes; i++) {
		printf("%d\n", header[i]);
	}
	return header_bytes;
}

int main() {
	some_func(1);
	some_func(3);
	return 0;
}
```

```
$ g++ main.cpp -O3 -Wstringop-overflow=2
main.cpp: In function ‘uint32_t some_func(uint32_t)’:
main.cpp:14:40: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
   14 |                 header[header_bytes++] = 0;
      |                 ~~~~~~~~~~~~~~~~~~~~~~~^~~
main.cpp:5:17: note: at offset 8 into destination object ‘header’ of size 8
    5 |         uint8_t header[8];
      |                 ^~~~~~
```
It doesn't happen with lower levels of optimization (and happens with any level of `-Wstringop-overflow=`).