### PR TITLE
Update audio effect icon when theme changes

### DIFF
--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -92,6 +92,12 @@ void EditorAudioBus::_notification(int p_what) {
 			audio_value_preview_label->add_theme_color_override("font_color", get_theme_color(SNAME("font_color"), SNAME("TooltipLabel")));
 			audio_value_preview_label->add_theme_color_override("font_shadow_color", get_theme_color(SNAME("font_shadow_color"), SNAME("TooltipLabel")));
 			audio_value_preview_box->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("TooltipPanel")));
+
+			for (int i = 0; i < effect_options->get_item_count(); i++) {
+				String class_name = effect_options->get_item_metadata(i);
+				Ref<Texture> icon = EditorNode::get_singleton()->get_class_icon(class_name);
+				effect_options->set_item_icon(i, icon);
+			}
 		} break;
 
 		case NOTIFICATION_READY: {
@@ -917,11 +923,9 @@ EditorAudioBus::EditorAudioBus(EditorAudioBuses *p_buses, bool p_is_master) {
 			continue;
 		}
 
-		Ref<Texture2D> icon = EditorNode::get_singleton()->get_class_icon(E);
 		String name = E.operator String().replace("AudioEffect", "");
 		effect_options->add_item(name);
 		effect_options->set_item_metadata(effect_options->get_item_count() - 1, E);
-		effect_options->set_item_icon(effect_options->get_item_count() - 1, icon);
 	}
 
 	bus_options = memnew(MenuButton);


### PR DESCRIPTION
Icons in Audio Bus editor's "Add Effect" popup were only setup in the constructor.

This PR move the setup to the notification handler of `ENTER_TREE` and `THEME_CHANGED`.