### PR TITLE
Add `icon_normal_color` to Button in editor theme

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -435,7 +435,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Color disabled_color = mono_color.inverted().lerp(base_color, 0.7);
 	const Color disabled_bg_color = mono_color.inverted().lerp(base_color, 0.9);
 
-	Color icon_hover_color = Color(1, 1, 1) * (dark_theme ? 1.15 : 1.45);
+	const Color icon_normal_color = Color(1, 1, 1);
+	Color icon_hover_color = icon_normal_color * (dark_theme ? 1.15 : 1.45);
 	icon_hover_color.a = 1.0;
 	Color icon_focus_color = icon_hover_color;
 	// Make the pressed icon color overbright because icons are not completely white on a dark theme.
@@ -688,6 +689,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_focus_color", "Button", font_focus_color);
 	theme->set_color("font_pressed_color", "Button", accent_color);
 	theme->set_color("font_disabled_color", "Button", font_disabled_color);
+	theme->set_color("icon_normal_color", "Button", icon_normal_color);
 	theme->set_color("icon_hover_color", "Button", icon_hover_color);
 	theme->set_color("icon_focus_color", "Button", icon_focus_color);
 	theme->set_color("icon_pressed_color", "Button", icon_pressed_color);


### PR DESCRIPTION
Adds `icon_normal_color` to Button in the editor theme so icons in buttons don't use the color from the custom theme specified in project settings.

alpha 4.0.alpha2 | This PR
-|-
![icon_color_4.0.alpha2](https://user-images.githubusercontent.com/3903059/156818846-1c16600f-e2d6-4422-8e0d-de6abddf540a.png) | ![icon_color_4.x](https://user-images.githubusercontent.com/3903059/156817171-d91666e7-4be8-4440-8886-15a12fee3354.png)
![icon_color_4.0.alpha2 light](https://user-images.githubusercontent.com/3903059/156818357-1d420407-fbc2-4f78-a047-e0d5c65f143e.png) |  ![icon_color_4.x light](https://user-images.githubusercontent.com/3903059/156818369-4d10ec4c-b8b1-494b-aae1-217d498b5115.png)

Test project: [EditorThemeIconColor.zip](https://github.com/godotengine/godot/files/8187950/EditorThemeIconColor.zip)
