### PR TITLE
Restore and fix post-process shadow blurring in 3D

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl
@@ -1683,7 +1683,7 @@ void fragment_shader(in SceneData scene_data) {
 			}
 #endif
 
-			blur_shadow(shadow);
+			shadow = blur_shadow(shadow);
 
 			float size_A = sc_use_light_soft_shadows ? directional_lights.data[i].size : 0.0;
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -951,21 +951,16 @@ void reflection_process(uint ref_index, vec3 view, vec3 vertex, vec3 normal, flo
 }
 
 float blur_shadow(float shadow) {
-	return shadow;
-#if 0
-	//disabling for now, will investigate later
 	float interp_shadow = shadow;
-	if (gl_HelperInvocation) {
-		interp_shadow = -4.0; // technically anything below -4 will do but just to make sure
-	}
 
 	uvec2 fc2 = uvec2(gl_FragCoord.xy);
-	interp_shadow -= dFdx(interp_shadow) * (float(fc2.x & 1) - 0.5);
-	interp_shadow -= dFdy(interp_shadow) * (float(fc2.y & 1) - 0.5);
+	interp_shadow -= dFdxFine(interp_shadow) * (float(fc2.x & 1) - 0.5);
+	interp_shadow -= dFdyFine(interp_shadow) * (float(fc2.y & 1) - 0.5);
+	interp_shadow = min(interp_shadow, 1.0);
 
 	if (interp_shadow >= 0.0) {
 		shadow = interp_shadow;
 	}
+
 	return shadow;
-#endif
 }

--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
@@ -1408,7 +1408,7 @@ void main() {
 				shadow = float(shadow1 >> ((i - 4) * 8) & 0xFF) / 255.0;
 			}
 #endif
-			blur_shadow(shadow);
+			shadow = blur_shadow(shadow);
 
 			light_compute(normal, directional_lights.data[i].direction, normalize(view), 0.0, directional_lights.data[i].color * directional_lights.data[i].energy, shadow, f0, orms, 1.0, albedo, alpha,
 #ifdef LIGHT_BACKLIGHT_USED


### PR DESCRIPTION
When uncommented, this function resulted in the dithering pattern being less noticeable. However, it also introduced jaggies in distant shadows, which are especially jarring in motion. Its performance cost was fairly low, but it wasn't worth the tradeoff.

The filter was quite effective for blurry shadows that are up close, so maybe it could be resurrected in the future based on shadow texel density relative to the camera.

In the future, temporal antialiasing will be added to optionally hide the dithering pattern by changing it every frame (letting the accumulation buffer do its job of averaging it all). On high refresh rate monitors, [the shadow filtering pattern can be jittered](https://github.com/Calinou/godot/tree/shadow-filter-jitter) to let the monitor's response time perform this averaging (without relying on TAA).

## Preview

*To see the negative impact of the filter on distant shadows, look at the top of the first screenshot, and compare it with the **Filtering uncommented** screenshot.*

### Current shadow rendering

![2022-03-04_23 20 36_without_filter](https://user-images.githubusercontent.com/180032/156850523-fecc7df1-f62b-4898-8cb0-0152af7befca.png)

![2022-03-04_23 20 36_without_filter_closeup](https://user-images.githubusercontent.com/180032/156850519-004b5855-24c2-478a-9f91-c7b21f0d54b4.png)

### Filtering uncommented

![2022-03-04_23 21 39_with_filter](https://user-images.githubusercontent.com/180032/156850539-a7d7ed47-f53a-4afc-bd49-e98a4cba1d76.png)

![2022-03-04_23 20 36_with_filter_closeup](https://user-images.githubusercontent.com/180032/156850534-68af5ad5-3dff-45e0-be13-66974d9607fc.png)