### PR TITLE
Fix unable to change directory in user access mode

### DIFF
--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -250,6 +250,14 @@ DirAccess *DirAccess::create(AccessType p_access) {
 	DirAccess *da = create_func[p_access] ? create_func[p_access]() : nullptr;
 	if (da) {
 		da->_access_type = p_access;
+
+		// for ACCESS_RESOURCES and ACCESS_FILESYSTEM, current_dir already defaults to where game was started
+		// in case current directory is force changed elsewhere for ACCESS_RESOURCES
+		if (p_access == ACCESS_RESOURCES) {
+			da->change_dir("res://");
+		} else if (p_access == ACCESS_USERDATA) {
+			da->change_dir("user://");
+		}
 	}
 
 	return da;


### PR DESCRIPTION
Fix #58605  
Set it to use the user directory specified  
~~Noticed that it currently ignores custom user data directory set in project settings, needs testing, might be a separate issue that affects more than Windows builds~~