### PR TITLE
Use the computed value ambient_accum for ambient_light in scene_forward_mobile.glsl

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
@@ -1054,6 +1054,12 @@ void main() {
 		if (reflection_accum.a > 0.0) {
 			specular_light = reflection_accum.rgb / reflection_accum.a;
 		}
+
+#if !defined(USE_LIGHTMAP)
+		if (ambient_accum.a > 0.0) {
+			ambient_light = ambient_accum.rgb / ambient_accum.a;
+		}
+#endif
 	} //Reflection probes
 
 	// finalize ambient light here


### PR DESCRIPTION
Currently in [scene_forward_mobile.glsl](https://github.com/godotengine/godot/blob/master/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl#L1051-L1057), `ambient_accum` is computed as a result of the `reflection_process` but is never used. When asked on the IRC, it was suggested that this is probably an oversight. 

This PR aims to fix that by making use of the computed value `ambient_accum` similar to what has been done in [scene_forward_clustered.glsl](https://github.com/godotengine/godot/blob/master/servers/rendering/renderer_rd/shaders/scene_forward_clustered.glsl#L1254-L1267).

*Bugsquad edit:*
- Fixes #56555