### PR TITLE
Adding signals and events to OpenXR interface

### DIFF
--- a/doc/classes/XRPositionalTracker.xml
+++ b/doc/classes/XRPositionalTracker.xml
@@ -72,6 +72,9 @@
 			- [code]left_hand[/code] identifies the controller held in the players left hand
 			- [code]right_hand[/code] identifies the controller held in the players right hand
 		</member>
+		<member name="profile" type="String" setter="set_tracker_profile" getter="get_tracker_profile" default="&quot;&quot;">
+			The profile associated with this tracker, interface dependent but will indicate the type of controller being tracked.
+		</member>
 		<member name="type" type="int" setter="set_tracker_type" getter="get_tracker_type" enum="XRServer.TrackerType" default="128">
 			The type of tracker.
 		</member>
@@ -107,6 +110,12 @@
 			<argument index="0" name="pose" type="XRPose" />
 			<description>
 				Emitted when the state of a pose tracked by this tracker changes.
+			</description>
+		</signal>
+		<signal name="profile_changed">
+			<argument index="0" name="role" type="String" />
+			<description>
+				Emitted when the profile of our tracker changes.
 			</description>
 		</signal>
 	</signals>

--- a/modules/openxr/doc_classes/OpenXRInterface.xml
+++ b/modules/openxr/doc_classes/OpenXRInterface.xml
@@ -10,4 +10,31 @@
 	<tutorials>
 		<link title="OpenXR documentation">$DOCS_URL/tutorials/vr/openxr/index.html</link>
 	</tutorials>
+	<signals>
+		<signal name="pose_recentered">
+			<description>
+				Informs the user queued a recenter of the player position.
+			</description>
+		</signal>
+		<signal name="session_begun">
+			<description>
+				Informs our OpenXR session has been started.
+			</description>
+		</signal>
+		<signal name="session_focussed">
+			<description>
+				Informs our OpenXR session now has focus.
+			</description>
+		</signal>
+		<signal name="session_stopping">
+			<description>
+				Informs our OpenXR session is stopping.
+			</description>
+		</signal>
+		<signal name="session_visible">
+			<description>
+				Informs our OpenXR session is now visible (output is being sent to the HMD).
+			</description>
+		</signal>
+	</signals>
 </class>

--- a/modules/openxr/openxr_util.cpp
+++ b/modules/openxr/openxr_util.cpp
@@ -278,6 +278,20 @@ String OpenXRUtil::get_session_state_name(XrSessionState p_session_state) {
 	}
 }
 
+String OpenXRUtil::get_action_type_name(XrActionType p_action_type) {
+	switch (p_action_type) {
+		ENUM_TO_STRING_CASE(XR_ACTION_TYPE_BOOLEAN_INPUT)
+		ENUM_TO_STRING_CASE(XR_ACTION_TYPE_FLOAT_INPUT)
+		ENUM_TO_STRING_CASE(XR_ACTION_TYPE_VECTOR2F_INPUT)
+		ENUM_TO_STRING_CASE(XR_ACTION_TYPE_POSE_INPUT)
+		ENUM_TO_STRING_CASE(XR_ACTION_TYPE_VIBRATION_OUTPUT)
+		ENUM_TO_STRING_CASE(XR_ACTION_TYPE_MAX_ENUM)
+		default: {
+			return String("Action type ") + String::num_int64(int64_t(p_action_type));
+		} break;
+	}
+}
+
 String OpenXRUtil::make_xr_version_string(XrVersion p_version) {
 	String version;
 

--- a/modules/openxr/openxr_util.h
+++ b/modules/openxr/openxr_util.h
@@ -40,6 +40,7 @@ public:
 	static String get_reference_space_name(XrReferenceSpaceType p_reference_space);
 	static String get_structure_type_name(XrStructureType p_structure_type);
 	static String get_session_state_name(XrSessionState p_session_state);
+	static String get_action_type_name(XrActionType p_action_type);
 	static String make_xr_version_string(XrVersion p_version);
 };
 

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -75,9 +75,18 @@ void register_openxr_types() {
 
 void unregister_openxr_types() {
 	if (openxr_interface.is_valid()) {
+		// uninitialise just in case
+		if (openxr_interface->is_initialized()) {
+			openxr_interface->uninitialize();
+		}
+
 		// unregister our interface from the XR server
-		if (XRServer::get_singleton()) {
-			XRServer::get_singleton()->remove_interface(openxr_interface);
+		XRServer *xr_server = XRServer::get_singleton();
+		if (xr_server) {
+			if (xr_server->get_primary_interface() == openxr_interface) {
+				xr_server->set_primary_interface(Ref<XRInterface>());
+			}
+			xr_server->remove_interface(openxr_interface);
 		}
 
 		// and release

--- a/servers/xr/xr_positional_tracker.cpp
+++ b/servers/xr/xr_positional_tracker.cpp
@@ -49,6 +49,10 @@ void XRPositionalTracker::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_tracker_desc", "description"), &XRPositionalTracker::set_tracker_desc);
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "description"), "set_tracker_desc", "get_tracker_desc");
 
+	ClassDB::bind_method(D_METHOD("get_tracker_profile"), &XRPositionalTracker::get_tracker_profile);
+	ClassDB::bind_method(D_METHOD("set_tracker_profile", "profile"), &XRPositionalTracker::set_tracker_profile);
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "profile"), "set_tracker_profile", "get_tracker_profile");
+
 	ClassDB::bind_method(D_METHOD("get_tracker_hand"), &XRPositionalTracker::get_tracker_hand);
 	ClassDB::bind_method(D_METHOD("set_tracker_hand", "hand"), &XRPositionalTracker::set_tracker_hand);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "hand", PROPERTY_HINT_ENUM, "Unknown,Left,Right"), "set_tracker_hand", "get_tracker_hand");
@@ -65,6 +69,7 @@ void XRPositionalTracker::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("button_released", PropertyInfo(Variant::STRING, "name")));
 	ADD_SIGNAL(MethodInfo("input_value_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::FLOAT, "value")));
 	ADD_SIGNAL(MethodInfo("input_axis_changed", PropertyInfo(Variant::STRING, "name"), PropertyInfo(Variant::VECTOR2, "vector")));
+	ADD_SIGNAL(MethodInfo("profile_changed", PropertyInfo(Variant::STRING, "role")));
 };
 
 void XRPositionalTracker::set_tracker_type(XRServer::TrackerType p_type) {
@@ -93,6 +98,18 @@ void XRPositionalTracker::set_tracker_desc(const String &p_desc) {
 
 String XRPositionalTracker::get_tracker_desc() const {
 	return description;
+}
+
+void XRPositionalTracker::set_tracker_profile(const String &p_profile) {
+	if (profile != p_profile) {
+		profile = p_profile;
+
+		emit_signal("profile_changed", profile);
+	}
+}
+
+String XRPositionalTracker::get_tracker_profile() const {
+	return profile;
 }
 
 XRPositionalTracker::TrackerHand XRPositionalTracker::get_tracker_hand() const {

--- a/servers/xr/xr_positional_tracker.h
+++ b/servers/xr/xr_positional_tracker.h
@@ -56,7 +56,8 @@ public:
 private:
 	XRServer::TrackerType type; // type of tracker
 	StringName name; // (unique) name of the tracker
-	String description; // description of the tracker, this is interface dependent, for OpenXR this will be the interaction profile bound for to the tracker
+	String description; // description of the tracker
+	String profile; // this is interface dependent, for OpenXR this will be the interaction profile bound for to the tracker
 	TrackerHand hand; // if known, the hand this tracker is held in
 
 	Map<StringName, Ref<XRPose>> poses;
@@ -72,6 +73,8 @@ public:
 	StringName get_tracker_name() const;
 	void set_tracker_desc(const String &p_desc);
 	String get_tracker_desc() const;
+	void set_tracker_profile(const String &p_profile);
+	String get_tracker_profile() const;
 	XRPositionalTracker::TrackerHand get_tracker_hand() const;
 	void set_tracker_hand(const XRPositionalTracker::TrackerHand p_hand);
 


### PR DESCRIPTION
Completed the functionality around signals and events:
- Changing session state now sends out signals through our `OpenXRInterface` instance
- Now processing all the core OpenXR events, most just log stuff.

Also made a number of improvements to interaction profiles. We now register these with the OpenXR API class and when the interaction profile is assigned to a controller we process actions accordingly. I'm not 100% sure of this change yet, I may revert back to processing actions linked to each tracker. 