### PR TITLE
Fix animation resource name after duplication in editor

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -547,6 +547,7 @@ void AnimationPlayerEditor::_animation_name_edited() {
 			Ref<Animation> anim = player->get_animation(current);
 
 			Ref<Animation> new_anim = _animation_clone(anim);
+			new_anim->set_name(new_name);
 
 			undo_redo->create_action(TTR("Duplicate Animation"));
 			undo_redo->add_do_method(player, "add_animation", new_name, new_anim);


### PR DESCRIPTION
I forgot to update the resource name of the duplicated animation in #58079 :(