### PR TITLE
Rename StreamTexture* to CompressedTexture*

### DIFF
--- a/doc/classes/CompressedCubemap.xml
+++ b/doc/classes/CompressedCubemap.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="CompressedCubemap" inherits="CompressedTextureLayered" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/CompressedCubemapArray.xml
+++ b/doc/classes/CompressedCubemapArray.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="CompressedCubemapArray" inherits="CompressedTextureLayered" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/CompressedTexture2D.xml
+++ b/doc/classes/CompressedTexture2D.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="StreamTexture2D" inherits="Texture2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="CompressedTexture2D" inherits="Texture2D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		A [code].stex[/code] texture.
 	</brief_description>
@@ -19,7 +19,7 @@
 	</methods>
 	<members>
 		<member name="load_path" type="String" setter="load" getter="get_load_path" default="&quot;&quot;">
-			The StreamTexture's file path to a [code].stex[/code] file.
+			The CompressedTexture's file path to a [code].stex[/code] file.
 		</member>
 	</members>
 </class>

--- a/doc/classes/CompressedTexture2DArray.xml
+++ b/doc/classes/CompressedTexture2DArray.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="CompressedTexture2DArray" inherits="CompressedTextureLayered" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/CompressedTexture3D.xml
+++ b/doc/classes/CompressedTexture3D.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="StreamTexture3D" inherits="Texture3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="CompressedTexture3D" inherits="Texture3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/CompressedTextureLayered.xml
+++ b/doc/classes/CompressedTextureLayered.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="StreamTextureLayered" inherits="TextureLayered" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="CompressedTextureLayered" inherits="TextureLayered" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 	</brief_description>
 	<description>

--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -18,7 +18,7 @@
 		var texture = load("res://icon.png")
 		$Sprite2D.texture = texture
 		[/codeblock]
-		This is because images have to be imported as a [StreamTexture2D] first to be loaded with [method @GDScript.load]. If you'd still like to load an image file just like any other [Resource], import it as an [Image] resource instead, and then load it normally using the [method @GDScript.load] method.
+		This is because images have to be imported as a [CompressedTexture2D] first to be loaded with [method @GDScript.load]. If you'd still like to load an image file just like any other [Resource], import it as an [Image] resource instead, and then load it normally using the [method @GDScript.load] method.
 		[b]Note:[/b] The image can be retrieved from an imported texture using the [method Texture2D.get_image] method, which returns a copy of the image:
 		[codeblock]
 		var texture = load("res://icon.png")

--- a/doc/classes/ResourceFormatLoader.xml
+++ b/doc/classes/ResourceFormatLoader.xml
@@ -6,7 +6,7 @@
 	<description>
 		Godot loads resources in the editor or in exported games using ResourceFormatLoaders. They are queried automatically via the [ResourceLoader] singleton, or when a resource with internal dependencies is loaded. Each file type may load as a different resource type, so multiple ResourceFormatLoaders are registered in the engine.
 		Extending this class allows you to define your own loader. Be sure to respect the documented return types and values. You should give it a global class name with [code]class_name[/code] for it to be registered. Like built-in ResourceFormatLoaders, it will be called automatically when loading resources of its handled type(s). You may also implement a [ResourceFormatSaver].
-		[b]Note:[/b] You can also extend [EditorImportPlugin] if the resource type you need exists but Godot is unable to load its format. Choosing one way over another depends on if the format is suitable or not for the final exported game. For example, it's better to import [code].png[/code] textures as [code].stex[/code] ([StreamTexture2D]) first, so they can be loaded with better efficiency on the graphics card.
+		[b]Note:[/b] You can also extend [EditorImportPlugin] if the resource type you need exists but Godot is unable to load its format. Choosing one way over another depends on if the format is suitable or not for the final exported game. For example, it's better to import [code].png[/code] textures as [code].stex[/code] ([CompressedTexture2D]) first, so they can be loaded with better efficiency on the graphics card.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/StreamCubemap.xml
+++ b/doc/classes/StreamCubemap.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<class name="StreamCubemap" inherits="StreamTextureLayered" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
-	</brief_description>
-	<description>
-	</description>
-	<tutorials>
-	</tutorials>
-</class>

--- a/doc/classes/StreamCubemapArray.xml
+++ b/doc/classes/StreamCubemapArray.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<class name="StreamCubemapArray" inherits="StreamTextureLayered" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
-	</brief_description>
-	<description>
-	</description>
-	<tutorials>
-	</tutorials>
-</class>

--- a/doc/classes/StreamTexture2DArray.xml
+++ b/doc/classes/StreamTexture2DArray.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8" ?>
-<class name="StreamTexture2DArray" inherits="StreamTextureLayered" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
-	<brief_description>
-	</brief_description>
-	<description>
-	</description>
-	<tutorials>
-	</tutorials>
-</class>

--- a/editor/import/resource_importer_layered_texture.cpp
+++ b/editor/import/resource_importer_layered_texture.cpp
@@ -104,16 +104,16 @@ String ResourceImporterLayeredTexture::get_save_extension() const {
 String ResourceImporterLayeredTexture::get_resource_type() const {
 	switch (mode) {
 		case MODE_CUBEMAP: {
-			return "StreamCubemap";
+			return "CompressedCubemap";
 		} break;
 		case MODE_2D_ARRAY: {
-			return "StreamTexture2DArray";
+			return "CompressedTexture2DArray";
 		} break;
 		case MODE_CUBEMAP_ARRAY: {
-			return "StreamCubemapArray";
+			return "CompressedCubemapArray";
 		} break;
 		case MODE_3D: {
-			return "StreamTexture3D";
+			return "CompressedTexture3D";
 		} break;
 	}
 	ERR_FAIL_V(String());
@@ -263,7 +263,7 @@ void ResourceImporterLayeredTexture::_save_tex(Vector<Ref<Image>> p_images, cons
 	f->store_8('T');
 	f->store_8('L');
 
-	f->store_32(StreamTextureLayered::FORMAT_VERSION);
+	f->store_32(CompressedTextureLayered::FORMAT_VERSION);
 	f->store_32(p_images.size()); // For 2d layers or 3d depth.
 	f->store_32(mode);
 	f->store_32(0);

--- a/editor/import/resource_importer_layered_texture.h
+++ b/editor/import/resource_importer_layered_texture.h
@@ -35,7 +35,7 @@
 #include "core/io/resource_importer.h"
 #include "core/object/ref_counted.h"
 
-class StreamTexture2D;
+class CompressedTexture2D;
 
 class LayeredTextureImport : public RefCounted {
 	GDCLASS(LayeredTextureImport, RefCounted);

--- a/editor/import/resource_importer_texture.h
+++ b/editor/import/resource_importer_texture.h
@@ -37,7 +37,7 @@
 #include "scene/resources/texture.h"
 #include "servers/rendering_server.h"
 
-class StreamTexture2D;
+class CompressedTexture2D;
 
 class ResourceImporterTexture : public ResourceImporter {
 	GDCLASS(ResourceImporterTexture, ResourceImporter);
@@ -67,9 +67,9 @@ protected:
 
 	Map<StringName, MakeInfo> make_flags;
 
-	static void _texture_reimport_roughness(const Ref<StreamTexture2D> &p_tex, const String &p_normal_path, RenderingServer::TextureDetectRoughnessChannel p_channel);
-	static void _texture_reimport_3d(const Ref<StreamTexture2D> &p_tex);
-	static void _texture_reimport_normal(const Ref<StreamTexture2D> &p_tex);
+	static void _texture_reimport_roughness(const Ref<CompressedTexture2D> &p_tex, const String &p_normal_path, RenderingServer::TextureDetectRoughnessChannel p_channel);
+	static void _texture_reimport_3d(const Ref<CompressedTexture2D> &p_tex);
+	static void _texture_reimport_normal(const Ref<CompressedTexture2D> &p_tex);
 
 	static ResourceImporterTexture *singleton;
 	static const char *compression_formats[];

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.cpp
@@ -152,7 +152,7 @@ void GPUParticlesCollisionSDF3DEditorPlugin::_sdf_save_path_and_bake(const Strin
 		}
 
 		config->set_value("remap", "importer", "3d_texture");
-		config->set_value("remap", "type", "StreamTexture3D");
+		config->set_value("remap", "type", "CompressedTexture3D");
 		if (!config->has_section_key("params", "compress/mode")) {
 			config->set_value("params", "compress/mode", 3); //user may want another compression, so leave it be
 		}

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -64,8 +64,8 @@ void TexturePreview::_update_metadata_label_text() {
 	String format;
 	if (Object::cast_to<ImageTexture>(*texture)) {
 		format = Image::get_format_name(Object::cast_to<ImageTexture>(*texture)->get_format());
-	} else if (Object::cast_to<StreamTexture2D>(*texture)) {
-		format = Image::get_format_name(Object::cast_to<StreamTexture2D>(*texture)->get_format());
+	} else if (Object::cast_to<CompressedTexture2D>(*texture)) {
+		format = Image::get_format_name(Object::cast_to<CompressedTexture2D>(*texture)->get_format());
 	} else {
 		format = texture->get_class();
 	}
@@ -110,7 +110,7 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 }
 
 bool EditorInspectorPluginTexture::can_handle(Object *p_object) {
-	return Object::cast_to<ImageTexture>(p_object) != nullptr || Object::cast_to<AtlasTexture>(p_object) != nullptr || Object::cast_to<StreamTexture2D>(p_object) != nullptr || Object::cast_to<AnimatedTexture>(p_object) != nullptr;
+	return Object::cast_to<ImageTexture>(p_object) != nullptr || Object::cast_to<AtlasTexture>(p_object) != nullptr || Object::cast_to<CompressedTexture2D>(p_object) != nullptr || Object::cast_to<AnimatedTexture>(p_object) != nullptr;
 }
 
 void EditorInspectorPluginTexture::parse_begin(Object *p_object) {

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -543,7 +543,7 @@ bool EditorExportPlatformAndroid::_should_compress_asset(const String &p_path, c
 		".webp", // Same reasoning as .png
 		".cfb", // Don't let small config files slow-down startup
 		".scn", // Binary scenes are usually already compressed
-		".stex", // Streamable textures are usually already compressed
+		".ctex", // Streamable textures are usually already compressed
 		// Trailer for easier processing
 		nullptr
 	};

--- a/platform/uwp/export/export_plugin.cpp
+++ b/platform/uwp/export/export_plugin.cpp
@@ -98,13 +98,13 @@ void EditorExportPlatformUWP::get_export_options(List<ExportOption> *r_options) 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "orientation/portrait_flipped"), true));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::STRING, "images/background_color"), "transparent"));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/store_logo", PROPERTY_HINT_RESOURCE_TYPE, "StreamTexture2D"), Variant()));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/square44x44_logo", PROPERTY_HINT_RESOURCE_TYPE, "StreamTexture2D"), Variant()));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/square71x71_logo", PROPERTY_HINT_RESOURCE_TYPE, "StreamTexture2D"), Variant()));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/square150x150_logo", PROPERTY_HINT_RESOURCE_TYPE, "StreamTexture2D"), Variant()));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/square310x310_logo", PROPERTY_HINT_RESOURCE_TYPE, "StreamTexture2D"), Variant()));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/wide310x150_logo", PROPERTY_HINT_RESOURCE_TYPE, "StreamTexture2D"), Variant()));
-	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/splash_screen", PROPERTY_HINT_RESOURCE_TYPE, "StreamTexture2D"), Variant()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/store_logo", PROPERTY_HINT_RESOURCE_TYPE, "CompressedTexture2D"), Variant()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/square44x44_logo", PROPERTY_HINT_RESOURCE_TYPE, "CompressedTexture2D"), Variant()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/square71x71_logo", PROPERTY_HINT_RESOURCE_TYPE, "CompressedTexture2D"), Variant()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/square150x150_logo", PROPERTY_HINT_RESOURCE_TYPE, "CompressedTexture2D"), Variant()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/square310x310_logo", PROPERTY_HINT_RESOURCE_TYPE, "CompressedTexture2D"), Variant()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/wide310x150_logo", PROPERTY_HINT_RESOURCE_TYPE, "CompressedTexture2D"), Variant()));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::OBJECT, "images/splash_screen", PROPERTY_HINT_RESOURCE_TYPE, "CompressedTexture2D"), Variant()));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "tiles/show_name_on_square150x150"), false));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "tiles/show_name_on_wide310x150"), false));
@@ -201,37 +201,37 @@ bool EditorExportPlatformUWP::can_export(const Ref<EditorExportPreset> &p_preset
 		err += TTR("Invalid background color.") + "\n";
 	}
 
-	if (!p_preset->get("images/store_logo").is_zero() && !_valid_image((Object::cast_to<StreamTexture2D>((Object *)p_preset->get("images/store_logo"))), 50, 50)) {
+	if (!p_preset->get("images/store_logo").is_zero() && !_valid_image((Object::cast_to<CompressedTexture2D>((Object *)p_preset->get("images/store_logo"))), 50, 50)) {
 		valid = false;
 		err += TTR("Invalid Store Logo image dimensions (should be 50x50).") + "\n";
 	}
 
-	if (!p_preset->get("images/square44x44_logo").is_zero() && !_valid_image((Object::cast_to<StreamTexture2D>((Object *)p_preset->get("images/square44x44_logo"))), 44, 44)) {
+	if (!p_preset->get("images/square44x44_logo").is_zero() && !_valid_image((Object::cast_to<CompressedTexture2D>((Object *)p_preset->get("images/square44x44_logo"))), 44, 44)) {
 		valid = false;
 		err += TTR("Invalid square 44x44 logo image dimensions (should be 44x44).") + "\n";
 	}
 
-	if (!p_preset->get("images/square71x71_logo").is_zero() && !_valid_image((Object::cast_to<StreamTexture2D>((Object *)p_preset->get("images/square71x71_logo"))), 71, 71)) {
+	if (!p_preset->get("images/square71x71_logo").is_zero() && !_valid_image((Object::cast_to<CompressedTexture2D>((Object *)p_preset->get("images/square71x71_logo"))), 71, 71)) {
 		valid = false;
 		err += TTR("Invalid square 71x71 logo image dimensions (should be 71x71).") + "\n";
 	}
 
-	if (!p_preset->get("images/square150x150_logo").is_zero() && !_valid_image((Object::cast_to<StreamTexture2D>((Object *)p_preset->get("images/square150x150_logo"))), 150, 150)) {
+	if (!p_preset->get("images/square150x150_logo").is_zero() && !_valid_image((Object::cast_to<CompressedTexture2D>((Object *)p_preset->get("images/square150x150_logo"))), 150, 150)) {
 		valid = false;
 		err += TTR("Invalid square 150x150 logo image dimensions (should be 150x150).") + "\n";
 	}
 
-	if (!p_preset->get("images/square310x310_logo").is_zero() && !_valid_image((Object::cast_to<StreamTexture2D>((Object *)p_preset->get("images/square310x310_logo"))), 310, 310)) {
+	if (!p_preset->get("images/square310x310_logo").is_zero() && !_valid_image((Object::cast_to<CompressedTexture2D>((Object *)p_preset->get("images/square310x310_logo"))), 310, 310)) {
 		valid = false;
 		err += TTR("Invalid square 310x310 logo image dimensions (should be 310x310).") + "\n";
 	}
 
-	if (!p_preset->get("images/wide310x150_logo").is_zero() && !_valid_image((Object::cast_to<StreamTexture2D>((Object *)p_preset->get("images/wide310x150_logo"))), 310, 150)) {
+	if (!p_preset->get("images/wide310x150_logo").is_zero() && !_valid_image((Object::cast_to<CompressedTexture2D>((Object *)p_preset->get("images/wide310x150_logo"))), 310, 150)) {
 		valid = false;
 		err += TTR("Invalid wide 310x150 logo image dimensions (should be 310x150).") + "\n";
 	}
 
-	if (!p_preset->get("images/splash_screen").is_zero() && !_valid_image((Object::cast_to<StreamTexture2D>((Object *)p_preset->get("images/splash_screen"))), 620, 300)) {
+	if (!p_preset->get("images/splash_screen").is_zero() && !_valid_image((Object::cast_to<CompressedTexture2D>((Object *)p_preset->get("images/splash_screen"))), 620, 300)) {
 		valid = false;
 		err += TTR("Invalid splash screen image dimensions (should be 620x300).") + "\n";
 	}

--- a/platform/uwp/export/export_plugin.h
+++ b/platform/uwp/export/export_plugin.h
@@ -191,7 +191,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 		return false;
 	}
 
-	bool _valid_image(const StreamTexture2D *p_image, int p_width, int p_height) const {
+	bool _valid_image(const CompressedTexture2D *p_image, int p_width, int p_height) const {
 		if (!p_image) {
 			return false;
 		}
@@ -311,22 +311,22 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 
 	Vector<uint8_t> _get_image_data(const Ref<EditorExportPreset> &p_preset, const String &p_path) {
 		Vector<uint8_t> data;
-		StreamTexture2D *texture = nullptr;
+		CompressedTexture2D *texture = nullptr;
 
 		if (p_path.find("StoreLogo") != -1) {
-			texture = p_preset->get("images/store_logo").is_zero() ? nullptr : Object::cast_to<StreamTexture2D>(((Object *)p_preset->get("images/store_logo")));
+			texture = p_preset->get("images/store_logo").is_zero() ? nullptr : Object::cast_to<CompressedTexture2D>(((Object *)p_preset->get("images/store_logo")));
 		} else if (p_path.find("Square44x44Logo") != -1) {
-			texture = p_preset->get("images/square44x44_logo").is_zero() ? nullptr : Object::cast_to<StreamTexture2D>(((Object *)p_preset->get("images/square44x44_logo")));
+			texture = p_preset->get("images/square44x44_logo").is_zero() ? nullptr : Object::cast_to<CompressedTexture2D>(((Object *)p_preset->get("images/square44x44_logo")));
 		} else if (p_path.find("Square71x71Logo") != -1) {
-			texture = p_preset->get("images/square71x71_logo").is_zero() ? nullptr : Object::cast_to<StreamTexture2D>(((Object *)p_preset->get("images/square71x71_logo")));
+			texture = p_preset->get("images/square71x71_logo").is_zero() ? nullptr : Object::cast_to<CompressedTexture2D>(((Object *)p_preset->get("images/square71x71_logo")));
 		} else if (p_path.find("Square150x150Logo") != -1) {
-			texture = p_preset->get("images/square150x150_logo").is_zero() ? nullptr : Object::cast_to<StreamTexture2D>(((Object *)p_preset->get("images/square150x150_logo")));
+			texture = p_preset->get("images/square150x150_logo").is_zero() ? nullptr : Object::cast_to<CompressedTexture2D>(((Object *)p_preset->get("images/square150x150_logo")));
 		} else if (p_path.find("Square310x310Logo") != -1) {
-			texture = p_preset->get("images/square310x310_logo").is_zero() ? nullptr : Object::cast_to<StreamTexture2D>(((Object *)p_preset->get("images/square310x310_logo")));
+			texture = p_preset->get("images/square310x310_logo").is_zero() ? nullptr : Object::cast_to<CompressedTexture2D>(((Object *)p_preset->get("images/square310x310_logo")));
 		} else if (p_path.find("Wide310x150Logo") != -1) {
-			texture = p_preset->get("images/wide310x150_logo").is_zero() ? nullptr : Object::cast_to<StreamTexture2D>(((Object *)p_preset->get("images/wide310x150_logo")));
+			texture = p_preset->get("images/wide310x150_logo").is_zero() ? nullptr : Object::cast_to<CompressedTexture2D>(((Object *)p_preset->get("images/wide310x150_logo")));
 		} else if (p_path.find("SplashScreen") != -1) {
-			texture = p_preset->get("images/splash_screen").is_zero() ? nullptr : Object::cast_to<StreamTexture2D>(((Object *)p_preset->get("images/splash_screen")));
+			texture = p_preset->get("images/splash_screen").is_zero() ? nullptr : Object::cast_to<CompressedTexture2D>(((Object *)p_preset->get("images/splash_screen")));
 		} else {
 			ERR_PRINT("Unable to load logo");
 		}
@@ -393,7 +393,7 @@ class EditorExportPlatformUWP : public EditorExportPlatform {
 			".webp", // Same reasoning as .png
 			".cfb", // Don't let small config files slow-down startup
 			".scn", // Binary scenes are usually already compressed
-			".stex", // Streamable textures are usually already compressed
+			".ctex", // Streamable textures are usually already compressed
 			// Trailer for easier processing
 			nullptr
 		};

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -982,7 +982,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 		}
 
 		config->set_value("remap", "importer", "2d_array_texture");
-		config->set_value("remap", "type", "StreamTexture2DArray");
+		config->set_value("remap", "type", "CompressedTexture2DArray");
 		if (!config->has_section_key("params", "compress/mode")) {
 			config->set_value("params", "compress/mode", 2); //user may want another compression, so leave it be
 		}

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -260,9 +260,9 @@
 static Ref<ResourceFormatSaverText> resource_saver_text;
 static Ref<ResourceFormatLoaderText> resource_loader_text;
 
-static Ref<ResourceFormatLoaderStreamTexture2D> resource_loader_stream_texture;
-static Ref<ResourceFormatLoaderStreamTextureLayered> resource_loader_texture_layered;
-static Ref<ResourceFormatLoaderStreamTexture3D> resource_loader_texture_3d;
+static Ref<ResourceFormatLoaderCompressedTexture2D> resource_loader_stream_texture;
+static Ref<ResourceFormatLoaderCompressedTextureLayered> resource_loader_texture_layered;
+static Ref<ResourceFormatLoaderCompressedTexture3D> resource_loader_texture_3d;
 
 static Ref<ResourceFormatSaverShader> resource_saver_shader;
 static Ref<ResourceFormatLoaderShader> resource_loader_shader;
@@ -805,7 +805,7 @@ void register_scene_types() {
 	GDREGISTER_VIRTUAL_CLASS(Texture);
 	GDREGISTER_VIRTUAL_CLASS(Texture2D);
 	GDREGISTER_CLASS(Sky);
-	GDREGISTER_CLASS(StreamTexture2D);
+	GDREGISTER_CLASS(CompressedTexture2D);
 	GDREGISTER_CLASS(ImageTexture);
 	GDREGISTER_CLASS(AtlasTexture);
 	GDREGISTER_CLASS(MeshTexture);
@@ -820,14 +820,14 @@ void register_scene_types() {
 	GDREGISTER_VIRTUAL_CLASS(ImageTextureLayered);
 	GDREGISTER_VIRTUAL_CLASS(Texture3D);
 	GDREGISTER_CLASS(ImageTexture3D);
-	GDREGISTER_CLASS(StreamTexture3D);
+	GDREGISTER_CLASS(CompressedTexture3D);
 	GDREGISTER_CLASS(Cubemap);
 	GDREGISTER_CLASS(CubemapArray);
 	GDREGISTER_CLASS(Texture2DArray);
-	GDREGISTER_VIRTUAL_CLASS(StreamTextureLayered);
-	GDREGISTER_CLASS(StreamCubemap);
-	GDREGISTER_CLASS(StreamCubemapArray);
-	GDREGISTER_CLASS(StreamTexture2DArray);
+	GDREGISTER_VIRTUAL_CLASS(CompressedTextureLayered);
+	GDREGISTER_CLASS(CompressedCubemap);
+	GDREGISTER_CLASS(CompressedCubemapArray);
+	GDREGISTER_CLASS(CompressedTexture2DArray);
 
 	GDREGISTER_CLASS(Animation);
 	GDREGISTER_CLASS(FontData);
@@ -1013,7 +1013,7 @@ void register_scene_types() {
 	ClassDB::add_compatibility_class("SpringArm", "SpringArm3D");
 	ClassDB::add_compatibility_class("Sprite", "Sprite2D");
 	ClassDB::add_compatibility_class("StaticBody", "StaticBody3D");
-	ClassDB::add_compatibility_class("StreamTexture", "StreamTexture2D");
+	ClassDB::add_compatibility_class("CompressedTexture", "CompressedTexture2D");
 	ClassDB::add_compatibility_class("TextureProgress", "TextureProgressBar");
 	ClassDB::add_compatibility_class("VehicleBody", "VehicleBody3D");
 	ClassDB::add_compatibility_class("VehicleWheel", "VehicleWheel3D");

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -293,7 +293,7 @@ ImageTexture::~ImageTexture() {
 
 //////////////////////////////////////////
 
-Ref<Image> StreamTexture2D::load_image_from_file(FileAccess *f, int p_size_limit) {
+Ref<Image> CompressedTexture2D::load_image_from_file(FileAccess *f, int p_size_limit) {
 	uint32_t data_format = f->get_32();
 	uint32_t w = f->get_16();
 	uint32_t h = f->get_16();
@@ -426,7 +426,7 @@ Ref<Image> StreamTexture2D::load_image_from_file(FileAccess *f, int p_size_limit
 	return Ref<Image>();
 }
 
-void StreamTexture2D::set_path(const String &p_path, bool p_take_over) {
+void CompressedTexture2D::set_path(const String &p_path, bool p_take_over) {
 	if (texture.is_valid()) {
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
@@ -434,36 +434,36 @@ void StreamTexture2D::set_path(const String &p_path, bool p_take_over) {
 	Resource::set_path(p_path, p_take_over);
 }
 
-void StreamTexture2D::_requested_3d(void *p_ud) {
-	StreamTexture2D *st = (StreamTexture2D *)p_ud;
-	Ref<StreamTexture2D> stex(st);
+void CompressedTexture2D::_requested_3d(void *p_ud) {
+	CompressedTexture2D *st = (CompressedTexture2D *)p_ud;
+	Ref<CompressedTexture2D> stex(st);
 	ERR_FAIL_COND(!request_3d_callback);
 	request_3d_callback(stex);
 }
 
-void StreamTexture2D::_requested_roughness(void *p_ud, const String &p_normal_path, RS::TextureDetectRoughnessChannel p_roughness_channel) {
-	StreamTexture2D *st = (StreamTexture2D *)p_ud;
-	Ref<StreamTexture2D> stex(st);
+void CompressedTexture2D::_requested_roughness(void *p_ud, const String &p_normal_path, RS::TextureDetectRoughnessChannel p_roughness_channel) {
+	CompressedTexture2D *st = (CompressedTexture2D *)p_ud;
+	Ref<CompressedTexture2D> stex(st);
 	ERR_FAIL_COND(!request_roughness_callback);
 	request_roughness_callback(stex, p_normal_path, p_roughness_channel);
 }
 
-void StreamTexture2D::_requested_normal(void *p_ud) {
-	StreamTexture2D *st = (StreamTexture2D *)p_ud;
-	Ref<StreamTexture2D> stex(st);
+void CompressedTexture2D::_requested_normal(void *p_ud) {
+	CompressedTexture2D *st = (CompressedTexture2D *)p_ud;
+	Ref<CompressedTexture2D> stex(st);
 	ERR_FAIL_COND(!request_normal_callback);
 	request_normal_callback(stex);
 }
 
-StreamTexture2D::TextureFormatRequestCallback StreamTexture2D::request_3d_callback = nullptr;
-StreamTexture2D::TextureFormatRoughnessRequestCallback StreamTexture2D::request_roughness_callback = nullptr;
-StreamTexture2D::TextureFormatRequestCallback StreamTexture2D::request_normal_callback = nullptr;
+CompressedTexture2D::TextureFormatRequestCallback CompressedTexture2D::request_3d_callback = nullptr;
+CompressedTexture2D::TextureFormatRoughnessRequestCallback CompressedTexture2D::request_roughness_callback = nullptr;
+CompressedTexture2D::TextureFormatRequestCallback CompressedTexture2D::request_normal_callback = nullptr;
 
-Image::Format StreamTexture2D::get_format() const {
+Image::Format CompressedTexture2D::get_format() const {
 	return format;
 }
 
-Error StreamTexture2D::_load_data(const String &p_path, int &r_width, int &r_height, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &mipmap_limit, int p_size_limit) {
+Error CompressedTexture2D::_load_data(const String &p_path, int &r_width, int &r_height, Ref<Image> &image, bool &r_request_3d, bool &r_request_normal, bool &r_request_roughness, int &mipmap_limit, int p_size_limit) {
 	alpha_cache.unref();
 
 	ERR_FAIL_COND_V(image.is_null(), ERR_INVALID_PARAMETER);
@@ -523,7 +523,7 @@ Error StreamTexture2D::_load_data(const String &p_path, int &r_width, int &r_hei
 	return OK;
 }
 
-Error StreamTexture2D::load(const String &p_path) {
+Error CompressedTexture2D::load(const String &p_path) {
 	int lw, lh;
 	Ref<Image> image;
 	image.instantiate();
@@ -590,51 +590,51 @@ Error StreamTexture2D::load(const String &p_path) {
 	return OK;
 }
 
-String StreamTexture2D::get_load_path() const {
+String CompressedTexture2D::get_load_path() const {
 	return path_to_file;
 }
 
-int StreamTexture2D::get_width() const {
+int CompressedTexture2D::get_width() const {
 	return w;
 }
 
-int StreamTexture2D::get_height() const {
+int CompressedTexture2D::get_height() const {
 	return h;
 }
 
-RID StreamTexture2D::get_rid() const {
+RID CompressedTexture2D::get_rid() const {
 	if (!texture.is_valid()) {
 		texture = RS::get_singleton()->texture_2d_placeholder_create();
 	}
 	return texture;
 }
 
-void StreamTexture2D::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate, bool p_transpose) const {
+void CompressedTexture2D::draw(RID p_canvas_item, const Point2 &p_pos, const Color &p_modulate, bool p_transpose) const {
 	if ((w | h) == 0) {
 		return;
 	}
 	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, Rect2(p_pos, Size2(w, h)), texture, false, p_modulate, p_transpose);
 }
 
-void StreamTexture2D::draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose) const {
+void CompressedTexture2D::draw_rect(RID p_canvas_item, const Rect2 &p_rect, bool p_tile, const Color &p_modulate, bool p_transpose) const {
 	if ((w | h) == 0) {
 		return;
 	}
 	RenderingServer::get_singleton()->canvas_item_add_texture_rect(p_canvas_item, p_rect, texture, p_tile, p_modulate, p_transpose);
 }
 
-void StreamTexture2D::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) const {
+void CompressedTexture2D::draw_rect_region(RID p_canvas_item, const Rect2 &p_rect, const Rect2 &p_src_rect, const Color &p_modulate, bool p_transpose, bool p_clip_uv) const {
 	if ((w | h) == 0) {
 		return;
 	}
 	RenderingServer::get_singleton()->canvas_item_add_texture_rect_region(p_canvas_item, p_rect, texture, p_src_rect, p_modulate, p_transpose, p_clip_uv);
 }
 
-bool StreamTexture2D::has_alpha() const {
+bool CompressedTexture2D::has_alpha() const {
 	return false;
 }
 
-Ref<Image> StreamTexture2D::get_image() const {
+Ref<Image> CompressedTexture2D::get_image() const {
 	if (texture.is_valid()) {
 		return RS::get_singleton()->texture_2d_get(texture);
 	} else {
@@ -642,7 +642,7 @@ Ref<Image> StreamTexture2D::get_image() const {
 	}
 }
 
-bool StreamTexture2D::is_pixel_opaque(int p_x, int p_y) const {
+bool CompressedTexture2D::is_pixel_opaque(int p_x, int p_y) const {
 	if (!alpha_cache.is_valid()) {
 		Ref<Image> img = get_image();
 		if (img.is_valid()) {
@@ -676,7 +676,7 @@ bool StreamTexture2D::is_pixel_opaque(int p_x, int p_y) const {
 	return true;
 }
 
-void StreamTexture2D::reload_from_file() {
+void CompressedTexture2D::reload_from_file() {
 	String path = get_path();
 	if (!path.is_resource_file()) {
 		return;
@@ -691,26 +691,26 @@ void StreamTexture2D::reload_from_file() {
 	load(path);
 }
 
-void StreamTexture2D::_validate_property(PropertyInfo &property) const {
+void CompressedTexture2D::_validate_property(PropertyInfo &property) const {
 }
 
-void StreamTexture2D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("load", "path"), &StreamTexture2D::load);
-	ClassDB::bind_method(D_METHOD("get_load_path"), &StreamTexture2D::get_load_path);
+void CompressedTexture2D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("load", "path"), &CompressedTexture2D::load);
+	ClassDB::bind_method(D_METHOD("get_load_path"), &CompressedTexture2D::get_load_path);
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "load_path", PROPERTY_HINT_FILE, "*.stex"), "load", "get_load_path");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "load_path", PROPERTY_HINT_FILE, "*.ctex"), "load", "get_load_path");
 }
 
-StreamTexture2D::StreamTexture2D() {}
+CompressedTexture2D::CompressedTexture2D() {}
 
-StreamTexture2D::~StreamTexture2D() {
+CompressedTexture2D::~CompressedTexture2D() {
 	if (texture.is_valid()) {
 		RS::get_singleton()->free(texture);
 	}
 }
 
-RES ResourceFormatLoaderStreamTexture2D::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
-	Ref<StreamTexture2D> st;
+RES ResourceFormatLoaderCompressedTexture2D::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+	Ref<CompressedTexture2D> st;
 	st.instantiate();
 	Error err = st->load(p_path);
 	if (r_error) {
@@ -723,17 +723,17 @@ RES ResourceFormatLoaderStreamTexture2D::load(const String &p_path, const String
 	return st;
 }
 
-void ResourceFormatLoaderStreamTexture2D::get_recognized_extensions(List<String> *p_extensions) const {
-	p_extensions->push_back("stex");
+void ResourceFormatLoaderCompressedTexture2D::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("ctex");
 }
 
-bool ResourceFormatLoaderStreamTexture2D::handles_type(const String &p_type) const {
-	return p_type == "StreamTexture2D";
+bool ResourceFormatLoaderCompressedTexture2D::handles_type(const String &p_type) const {
+	return p_type == "CompressedTexture2D";
 }
 
-String ResourceFormatLoaderStreamTexture2D::get_resource_type(const String &p_path) const {
-	if (p_path.get_extension().to_lower() == "stex") {
-		return "StreamTexture2D";
+String ResourceFormatLoaderCompressedTexture2D::get_resource_type(const String &p_path) const {
+	if (p_path.get_extension().to_lower() == "ctex") {
+		return "CompressedTexture2D";
 	}
 	return "";
 }
@@ -846,7 +846,7 @@ ImageTexture3D::~ImageTexture3D() {
 
 ////////////////////////////////////////////
 
-void StreamTexture3D::set_path(const String &p_path, bool p_take_over) {
+void CompressedTexture3D::set_path(const String &p_path, bool p_take_over) {
 	if (texture.is_valid()) {
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
@@ -854,11 +854,11 @@ void StreamTexture3D::set_path(const String &p_path, bool p_take_over) {
 	Resource::set_path(p_path, p_take_over);
 }
 
-Image::Format StreamTexture3D::get_format() const {
+Image::Format CompressedTexture3D::get_format() const {
 	return format;
 }
 
-Error StreamTexture3D::_load_data(const String &p_path, Vector<Ref<Image>> &r_data, Image::Format &r_format, int &r_width, int &r_height, int &r_depth, bool &r_mipmaps) {
+Error CompressedTexture3D::_load_data(const String &p_path, Vector<Ref<Image>> &r_data, Image::Format &r_format, int &r_width, int &r_height, int &r_depth, bool &r_mipmaps) {
 	FileAccessRef f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(!f, ERR_CANT_OPEN, vformat("Unable to open file: %s.", p_path));
 
@@ -887,7 +887,7 @@ Error StreamTexture3D::_load_data(const String &p_path, Vector<Ref<Image>> &r_da
 	r_data.clear();
 
 	for (int i = 0; i < (r_depth + mipmaps); i++) {
-		Ref<Image> image = StreamTexture2D::load_image_from_file(f, 0);
+		Ref<Image> image = CompressedTexture2D::load_image_from_file(f, 0);
 		ERR_FAIL_COND_V(image.is_null() || image->is_empty(), ERR_CANT_OPEN);
 		if (i == 0) {
 			r_format = image->get_format();
@@ -900,7 +900,7 @@ Error StreamTexture3D::_load_data(const String &p_path, Vector<Ref<Image>> &r_da
 	return OK;
 }
 
-Error StreamTexture3D::load(const String &p_path) {
+Error CompressedTexture3D::load(const String &p_path) {
 	Vector<Ref<Image>> data;
 
 	int tw, th, td;
@@ -937,34 +937,34 @@ Error StreamTexture3D::load(const String &p_path) {
 	return OK;
 }
 
-String StreamTexture3D::get_load_path() const {
+String CompressedTexture3D::get_load_path() const {
 	return path_to_file;
 }
 
-int StreamTexture3D::get_width() const {
+int CompressedTexture3D::get_width() const {
 	return w;
 }
 
-int StreamTexture3D::get_height() const {
+int CompressedTexture3D::get_height() const {
 	return h;
 }
 
-int StreamTexture3D::get_depth() const {
+int CompressedTexture3D::get_depth() const {
 	return d;
 }
 
-bool StreamTexture3D::has_mipmaps() const {
+bool CompressedTexture3D::has_mipmaps() const {
 	return mipmaps;
 }
 
-RID StreamTexture3D::get_rid() const {
+RID CompressedTexture3D::get_rid() const {
 	if (!texture.is_valid()) {
 		texture = RS::get_singleton()->texture_3d_placeholder_create();
 	}
 	return texture;
 }
 
-Vector<Ref<Image>> StreamTexture3D::get_data() const {
+Vector<Ref<Image>> CompressedTexture3D::get_data() const {
 	if (texture.is_valid()) {
 		return RS::get_singleton()->texture_3d_get(texture);
 	} else {
@@ -972,7 +972,7 @@ Vector<Ref<Image>> StreamTexture3D::get_data() const {
 	}
 }
 
-void StreamTexture3D::reload_from_file() {
+void CompressedTexture3D::reload_from_file() {
 	String path = get_path();
 	if (!path.is_resource_file()) {
 		return;
@@ -987,19 +987,19 @@ void StreamTexture3D::reload_from_file() {
 	load(path);
 }
 
-void StreamTexture3D::_validate_property(PropertyInfo &property) const {
+void CompressedTexture3D::_validate_property(PropertyInfo &property) const {
 }
 
-void StreamTexture3D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("load", "path"), &StreamTexture3D::load);
-	ClassDB::bind_method(D_METHOD("get_load_path"), &StreamTexture3D::get_load_path);
+void CompressedTexture3D::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("load", "path"), &CompressedTexture3D::load);
+	ClassDB::bind_method(D_METHOD("get_load_path"), &CompressedTexture3D::get_load_path);
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "load_path", PROPERTY_HINT_FILE, "*.stex"), "load", "get_load_path");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "load_path", PROPERTY_HINT_FILE, "*.ctex"), "load", "get_load_path");
 }
 
-StreamTexture3D::StreamTexture3D() {}
+CompressedTexture3D::CompressedTexture3D() {}
 
-StreamTexture3D::~StreamTexture3D() {
+CompressedTexture3D::~CompressedTexture3D() {
 	if (texture.is_valid()) {
 		RS::get_singleton()->free(texture);
 	}
@@ -1007,8 +1007,8 @@ StreamTexture3D::~StreamTexture3D() {
 
 /////////////////////////////
 
-RES ResourceFormatLoaderStreamTexture3D::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
-	Ref<StreamTexture3D> st;
+RES ResourceFormatLoaderCompressedTexture3D::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+	Ref<CompressedTexture3D> st;
 	st.instantiate();
 	Error err = st->load(p_path);
 	if (r_error) {
@@ -1021,17 +1021,17 @@ RES ResourceFormatLoaderStreamTexture3D::load(const String &p_path, const String
 	return st;
 }
 
-void ResourceFormatLoaderStreamTexture3D::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceFormatLoaderCompressedTexture3D::get_recognized_extensions(List<String> *p_extensions) const {
 	p_extensions->push_back("stex3d");
 }
 
-bool ResourceFormatLoaderStreamTexture3D::handles_type(const String &p_type) const {
-	return p_type == "StreamTexture3D";
+bool ResourceFormatLoaderCompressedTexture3D::handles_type(const String &p_type) const {
+	return p_type == "CompressedTexture3D";
 }
 
-String ResourceFormatLoaderStreamTexture3D::get_resource_type(const String &p_path) const {
+String ResourceFormatLoaderCompressedTexture3D::get_resource_type(const String &p_path) const {
 	if (p_path.get_extension().to_lower() == "stex3d") {
-		return "StreamTexture3D";
+		return "CompressedTexture3D";
 	}
 	return "";
 }
@@ -2599,7 +2599,7 @@ ImageTextureLayered::~ImageTextureLayered() {
 
 ///////////////////////////////////////////
 
-void StreamTextureLayered::set_path(const String &p_path, bool p_take_over) {
+void CompressedTextureLayered::set_path(const String &p_path, bool p_take_over) {
 	if (texture.is_valid()) {
 		RenderingServer::get_singleton()->texture_set_path(texture, p_path);
 	}
@@ -2607,11 +2607,11 @@ void StreamTextureLayered::set_path(const String &p_path, bool p_take_over) {
 	Resource::set_path(p_path, p_take_over);
 }
 
-Image::Format StreamTextureLayered::get_format() const {
+Image::Format CompressedTextureLayered::get_format() const {
 	return format;
 }
 
-Error StreamTextureLayered::_load_data(const String &p_path, Vector<Ref<Image>> &images, int &mipmap_limit, int p_size_limit) {
+Error CompressedTextureLayered::_load_data(const String &p_path, Vector<Ref<Image>> &images, int &mipmap_limit, int p_size_limit) {
 	ERR_FAIL_COND_V(images.size() != 0, ERR_INVALID_PARAMETER);
 
 	FileAccessRef f = FileAccess::open(p_path, FileAccess::READ);
@@ -2647,7 +2647,7 @@ Error StreamTextureLayered::_load_data(const String &p_path, Vector<Ref<Image>> 
 	images.resize(layer_count);
 
 	for (uint32_t i = 0; i < layer_count; i++) {
-		Ref<Image> image = StreamTexture2D::load_image_from_file(f, p_size_limit);
+		Ref<Image> image = CompressedTexture2D::load_image_from_file(f, p_size_limit);
 		ERR_FAIL_COND_V(image.is_null() || image->is_empty(), ERR_CANT_OPEN);
 		images.write[i] = image;
 	}
@@ -2655,7 +2655,7 @@ Error StreamTextureLayered::_load_data(const String &p_path, Vector<Ref<Image>> 
 	return OK;
 }
 
-Error StreamTextureLayered::load(const String &p_path) {
+Error CompressedTextureLayered::load(const String &p_path) {
 	Vector<Ref<Image>> images;
 
 	int mipmap_limit;
@@ -2690,38 +2690,38 @@ Error StreamTextureLayered::load(const String &p_path) {
 	return OK;
 }
 
-String StreamTextureLayered::get_load_path() const {
+String CompressedTextureLayered::get_load_path() const {
 	return path_to_file;
 }
 
-int StreamTextureLayered::get_width() const {
+int CompressedTextureLayered::get_width() const {
 	return w;
 }
 
-int StreamTextureLayered::get_height() const {
+int CompressedTextureLayered::get_height() const {
 	return h;
 }
 
-int StreamTextureLayered::get_layers() const {
+int CompressedTextureLayered::get_layers() const {
 	return layers;
 }
 
-bool StreamTextureLayered::has_mipmaps() const {
+bool CompressedTextureLayered::has_mipmaps() const {
 	return mipmaps;
 }
 
-TextureLayered::LayeredType StreamTextureLayered::get_layered_type() const {
+TextureLayered::LayeredType CompressedTextureLayered::get_layered_type() const {
 	return layered_type;
 }
 
-RID StreamTextureLayered::get_rid() const {
+RID CompressedTextureLayered::get_rid() const {
 	if (!texture.is_valid()) {
 		texture = RS::get_singleton()->texture_2d_layered_placeholder_create(RS::TextureLayeredType(layered_type));
 	}
 	return texture;
 }
 
-Ref<Image> StreamTextureLayered::get_layer_data(int p_layer) const {
+Ref<Image> CompressedTextureLayered::get_layer_data(int p_layer) const {
 	if (texture.is_valid()) {
 		return RS::get_singleton()->texture_2d_layer_get(texture, p_layer);
 	} else {
@@ -2729,7 +2729,7 @@ Ref<Image> StreamTextureLayered::get_layer_data(int p_layer) const {
 	}
 }
 
-void StreamTextureLayered::reload_from_file() {
+void CompressedTextureLayered::reload_from_file() {
 	String path = get_path();
 	if (!path.is_resource_file()) {
 		return;
@@ -2744,21 +2744,21 @@ void StreamTextureLayered::reload_from_file() {
 	load(path);
 }
 
-void StreamTextureLayered::_validate_property(PropertyInfo &property) const {
+void CompressedTextureLayered::_validate_property(PropertyInfo &property) const {
 }
 
-void StreamTextureLayered::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("load", "path"), &StreamTextureLayered::load);
-	ClassDB::bind_method(D_METHOD("get_load_path"), &StreamTextureLayered::get_load_path);
+void CompressedTextureLayered::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("load", "path"), &CompressedTextureLayered::load);
+	ClassDB::bind_method(D_METHOD("get_load_path"), &CompressedTextureLayered::get_load_path);
 
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "load_path", PROPERTY_HINT_FILE, "*.stex"), "load", "get_load_path");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "load_path", PROPERTY_HINT_FILE, "*.ctex"), "load", "get_load_path");
 }
 
-StreamTextureLayered::StreamTextureLayered(LayeredType p_type) {
+CompressedTextureLayered::CompressedTextureLayered(LayeredType p_type) {
 	layered_type = p_type;
 }
 
-StreamTextureLayered::~StreamTextureLayered() {
+CompressedTextureLayered::~CompressedTextureLayered() {
 	if (texture.is_valid()) {
 		RS::get_singleton()->free(texture);
 	}
@@ -2766,18 +2766,18 @@ StreamTextureLayered::~StreamTextureLayered() {
 
 /////////////////////////////////////////////////
 
-RES ResourceFormatLoaderStreamTextureLayered::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
-	Ref<StreamTextureLayered> st;
+RES ResourceFormatLoaderCompressedTextureLayered::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+	Ref<CompressedTextureLayered> st;
 	if (p_path.get_extension().to_lower() == "stexarray") {
-		Ref<StreamTexture2DArray> s;
+		Ref<CompressedTexture2DArray> s;
 		s.instantiate();
 		st = s;
 	} else if (p_path.get_extension().to_lower() == "scube") {
-		Ref<StreamCubemap> s;
+		Ref<CompressedCubemap> s;
 		s.instantiate();
 		st = s;
 	} else if (p_path.get_extension().to_lower() == "scubearray") {
-		Ref<StreamCubemapArray> s;
+		Ref<CompressedCubemapArray> s;
 		s.instantiate();
 		st = s;
 	} else {
@@ -2797,25 +2797,25 @@ RES ResourceFormatLoaderStreamTextureLayered::load(const String &p_path, const S
 	return st;
 }
 
-void ResourceFormatLoaderStreamTextureLayered::get_recognized_extensions(List<String> *p_extensions) const {
+void ResourceFormatLoaderCompressedTextureLayered::get_recognized_extensions(List<String> *p_extensions) const {
 	p_extensions->push_back("stexarray");
 	p_extensions->push_back("scube");
 	p_extensions->push_back("scubearray");
 }
 
-bool ResourceFormatLoaderStreamTextureLayered::handles_type(const String &p_type) const {
-	return p_type == "StreamTexture2DArray" || p_type == "StreamCubemap" || p_type == "StreamCubemapArray";
+bool ResourceFormatLoaderCompressedTextureLayered::handles_type(const String &p_type) const {
+	return p_type == "CompressedTexture2DArray" || p_type == "CompressedCubemap" || p_type == "CompressedCubemapArray";
 }
 
-String ResourceFormatLoaderStreamTextureLayered::get_resource_type(const String &p_path) const {
+String ResourceFormatLoaderCompressedTextureLayered::get_resource_type(const String &p_path) const {
 	if (p_path.get_extension().to_lower() == "stexarray") {
-		return "StreamTexture2DArray";
+		return "CompressedTexture2DArray";
 	}
 	if (p_path.get_extension().to_lower() == "scube") {
-		return "StreamCubemap";
+		return "CompressedCubemap";
 	}
 	if (p_path.get_extension().to_lower() == "scubearray") {
-		return "StreamCubemapArray";
+		return "CompressedCubemapArray";
 	}
 	return "";
 }

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -128,8 +128,8 @@ public:
 	~ImageTexture();
 };
 
-class StreamTexture2D : public Texture2D {
-	GDCLASS(StreamTexture2D, Texture2D);
+class CompressedTexture2D : public Texture2D {
+	GDCLASS(CompressedTexture2D, Texture2D);
 
 public:
 	enum DataFormat {
@@ -174,8 +174,8 @@ protected:
 public:
 	static Ref<Image> load_image_from_file(FileAccess *p_file, int p_size_limit);
 
-	typedef void (*TextureFormatRequestCallback)(const Ref<StreamTexture2D> &);
-	typedef void (*TextureFormatRoughnessRequestCallback)(const Ref<StreamTexture2D> &, const String &p_normal_path, RS::TextureDetectRoughnessChannel p_roughness_channel);
+	typedef void (*TextureFormatRequestCallback)(const Ref<CompressedTexture2D> &);
+	typedef void (*TextureFormatRoughnessRequestCallback)(const Ref<CompressedTexture2D> &, const String &p_normal_path, RS::TextureDetectRoughnessChannel p_roughness_channel);
 
 	static TextureFormatRequestCallback request_3d_callback;
 	static TextureFormatRoughnessRequestCallback request_roughness_callback;
@@ -200,11 +200,11 @@ public:
 
 	virtual Ref<Image> get_image() const override;
 
-	StreamTexture2D();
-	~StreamTexture2D();
+	CompressedTexture2D();
+	~CompressedTexture2D();
 };
 
-class ResourceFormatLoaderStreamTexture2D : public ResourceFormatLoader {
+class ResourceFormatLoaderCompressedTexture2D : public ResourceFormatLoader {
 public:
 	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
@@ -380,8 +380,8 @@ public:
 			ImageTextureLayered(LAYERED_TYPE_CUBEMAP_ARRAY) {}
 };
 
-class StreamTextureLayered : public TextureLayered {
-	GDCLASS(StreamTextureLayered, TextureLayered);
+class CompressedTextureLayered : public TextureLayered {
+	GDCLASS(CompressedTextureLayered, TextureLayered);
 
 public:
 	enum DataFormat {
@@ -433,34 +433,34 @@ public:
 
 	virtual Ref<Image> get_layer_data(int p_layer) const override;
 
-	StreamTextureLayered(LayeredType p_layered_type);
-	~StreamTextureLayered();
+	CompressedTextureLayered(LayeredType p_layered_type);
+	~CompressedTextureLayered();
 };
 
-class StreamTexture2DArray : public StreamTextureLayered {
-	GDCLASS(StreamTexture2DArray, StreamTextureLayered)
+class CompressedTexture2DArray : public CompressedTextureLayered {
+	GDCLASS(CompressedTexture2DArray, CompressedTextureLayered)
 public:
-	StreamTexture2DArray() :
-			StreamTextureLayered(LAYERED_TYPE_2D_ARRAY) {}
+	CompressedTexture2DArray() :
+			CompressedTextureLayered(LAYERED_TYPE_2D_ARRAY) {}
 };
 
-class StreamCubemap : public StreamTextureLayered {
-	GDCLASS(StreamCubemap, StreamTextureLayered);
-
-public:
-	StreamCubemap() :
-			StreamTextureLayered(LAYERED_TYPE_CUBEMAP) {}
-};
-
-class StreamCubemapArray : public StreamTextureLayered {
-	GDCLASS(StreamCubemapArray, StreamTextureLayered);
+class CompressedCubemap : public CompressedTextureLayered {
+	GDCLASS(CompressedCubemap, CompressedTextureLayered);
 
 public:
-	StreamCubemapArray() :
-			StreamTextureLayered(LAYERED_TYPE_CUBEMAP_ARRAY) {}
+	CompressedCubemap() :
+			CompressedTextureLayered(LAYERED_TYPE_CUBEMAP) {}
 };
 
-class ResourceFormatLoaderStreamTextureLayered : public ResourceFormatLoader {
+class CompressedCubemapArray : public CompressedTextureLayered {
+	GDCLASS(CompressedCubemapArray, CompressedTextureLayered);
+
+public:
+	CompressedCubemapArray() :
+			CompressedTextureLayered(LAYERED_TYPE_CUBEMAP_ARRAY) {}
+};
+
+class ResourceFormatLoaderCompressedTextureLayered : public ResourceFormatLoader {
 public:
 	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
@@ -520,8 +520,8 @@ public:
 	~ImageTexture3D();
 };
 
-class StreamTexture3D : public Texture3D {
-	GDCLASS(StreamTexture3D, Texture3D);
+class CompressedTexture3D : public Texture3D {
+	GDCLASS(CompressedTexture3D, Texture3D);
 
 public:
 	enum DataFormat {
@@ -571,11 +571,11 @@ public:
 
 	virtual Vector<Ref<Image>> get_data() const override;
 
-	StreamTexture3D();
-	~StreamTexture3D();
+	CompressedTexture3D();
+	~CompressedTexture3D();
 };
 
-class ResourceFormatLoaderStreamTexture3D : public ResourceFormatLoader {
+class ResourceFormatLoaderCompressedTexture3D : public ResourceFormatLoader {
 public:
 	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;


### PR DESCRIPTION
* It is not and will not be used for streaming.
* Streaming will be implemented in 4.1 and it will work different.
* It makes more sense to be called CompressedTexture since it imports and compresses texture files.