### PR TITLE
Improve display for unsupported debug draw modes in GLES2

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4104,15 +4104,21 @@ SpatialEditorViewport::SpatialEditorViewport(SpatialEditor *p_spatial_editor, Ed
 		const int wireframe_idx = view_menu->get_popup()->get_item_index(VIEW_DISPLAY_WIREFRAME);
 		const int overdraw_idx = view_menu->get_popup()->get_item_index(VIEW_DISPLAY_OVERDRAW);
 		const int shadeless_idx = view_menu->get_popup()->get_item_index(VIEW_DISPLAY_SHADELESS);
-		const String unsupported_tooltip = TTR("Not available when using the GLES2 renderer.");
+		const String unsupported_suffix = " " + TTR("(Not in GLES2)");
+		const String unsupported_tooltip = TTR("Debug draw modes are only available when using the GLES3 renderer, not GLES2.");
 
-		view_menu->get_popup()->set_item_disabled(normal_idx, true);
 		view_menu->get_popup()->set_item_tooltip(normal_idx, unsupported_tooltip);
+
 		view_menu->get_popup()->set_item_disabled(wireframe_idx, true);
+		view_menu->get_popup()->set_item_text(wireframe_idx, TTR("Display Wireframe") + unsupported_suffix);
 		view_menu->get_popup()->set_item_tooltip(wireframe_idx, unsupported_tooltip);
+
 		view_menu->get_popup()->set_item_disabled(overdraw_idx, true);
+		view_menu->get_popup()->set_item_text(overdraw_idx, TTR("Display Overdraw") + unsupported_suffix);
 		view_menu->get_popup()->set_item_tooltip(overdraw_idx, unsupported_tooltip);
+
 		view_menu->get_popup()->set_item_disabled(shadeless_idx, true);
+		view_menu->get_popup()->set_item_text(shadeless_idx, TTR("Display Unshaded") + unsupported_suffix);
 		view_menu->get_popup()->set_item_tooltip(shadeless_idx, unsupported_tooltip);
 	}
 


### PR DESCRIPTION
- Don't disable the Normal option as it technically can be chosen (it's the default).
- Use a text suffix in addition to the tooltip.
  - Suffixes were made as short as possible to avoid making the menu too wide. The menu's width is defined by the length of the longest item *and* the name of the longest shortcut.

This closes https://github.com/godotengine/godot/issues/58792.

## Preview

![image](https://user-images.githubusercontent.com/180032/156895326-ecdb5663-3671-4da3-b214-32356bf938e7.png)
