### PR TITLE
Fix disabled tab can be enabled via rearranging inside TabContainer

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -401,7 +401,10 @@ void TabContainer::_drop_data_fw(const Point2 &p_point, const Variant &p_data, C
 			}
 
 			move_child(get_tab_control(tab_from_id), get_tab_control(hover_now)->get_index(false));
-			set_current_tab(hover_now);
+			if (!is_tab_disabled(hover_now)) {
+				set_current_tab(hover_now);
+			}
+
 		} else if (get_tabs_rearrange_group() != -1) {
 			// Drag and drop between TabContainers.
 			Node *from_node = get_node(from_path);
@@ -416,8 +419,9 @@ void TabContainer::_drop_data_fw(const Point2 &p_point, const Variant &p_data, C
 				}
 
 				move_child(moving_tabc, get_tab_control(hover_now)->get_index(false));
-
-				set_current_tab(hover_now);
+				if (!is_tab_disabled(hover_now)) {
+					set_current_tab(hover_now);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #58791

When rearranging tabs, dropped tab was activated even if it was disabled.

### Before : 

![bug](https://user-images.githubusercontent.com/3649998/156897668-1fe998a0-a067-46a9-b459-abfb7882d6a9.gif)

### After : 

![tabs](https://user-images.githubusercontent.com/3649998/156897509-c0b3f383-cf32-4a12-87df-69d5919438da.gif)



