### PR TITLE
Disable blender-style transforms in freelook.

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2037,14 +2037,16 @@ void Node3DEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		if (ED_IS_SHORTCUT("spatial_editor/cancel_transform", p_event) && _edit.mode != TRANSFORM_NONE) {
 			cancel_transform();
 		}
-		if (ED_IS_SHORTCUT("spatial_editor/instant_translate", p_event)) {
-			begin_transform(TRANSFORM_TRANSLATE, true);
-		}
-		if (ED_IS_SHORTCUT("spatial_editor/instant_rotate", p_event)) {
-			begin_transform(TRANSFORM_ROTATE, true);
-		}
-		if (ED_IS_SHORTCUT("spatial_editor/instant_scale", p_event)) {
-			begin_transform(TRANSFORM_SCALE, true);
+		if (!is_freelook_active()) {
+			if (ED_IS_SHORTCUT("spatial_editor/instant_translate", p_event)) {
+				begin_transform(TRANSFORM_TRANSLATE, true);
+			}
+			if (ED_IS_SHORTCUT("spatial_editor/instant_rotate", p_event)) {
+				begin_transform(TRANSFORM_ROTATE, true);
+			}
+			if (ED_IS_SHORTCUT("spatial_editor/instant_scale", p_event)) {
+				begin_transform(TRANSFORM_SCALE, true);
+			}
 		}
 
 		// Freelook doesn't work in orthogonal mode.


### PR DESCRIPTION
It's common to bind `instant_scale` to s, which conflicts with WASD
bindings in freelook mode.

Fixes #58502.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
