### PR TITLE
Change tabs_rearrange_group to property

### DIFF
--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -106,12 +106,6 @@
 				Returns the title of the tab at index [code]tab_idx[/code].
 			</description>
 		</method>
-		<method name="get_tabs_rearrange_group" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns the [TabBar]'s rearrange group ID.
-			</description>
-		</method>
 		<method name="is_tab_disabled" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="tab_idx" type="int" />
@@ -206,13 +200,6 @@
 				Sets a [code]title[/code] for the tab at index [code]tab_idx[/code].
 			</description>
 		</method>
-		<method name="set_tabs_rearrange_group">
-			<return type="void" />
-			<argument index="0" name="group_id" type="int" />
-			<description>
-				Defines the rearrange group ID. Choose for each [TabBar] the same value to dragging tabs between [TabBar]. Enable drag with [member drag_to_rearrange_enabled].
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="clip_tabs" type="bool" setter="set_clip_tabs" getter="get_clip_tabs" default="true">
@@ -241,6 +228,10 @@
 		</member>
 		<member name="tab_count" type="int" setter="set_tab_count" getter="get_tab_count" default="0">
 			The number of tabs currently in the bar.
+		</member>
+		<member name="tabs_rearrange_group" type="int" setter="set_tabs_rearrange_group" getter="get_tabs_rearrange_group" default="-1">
+			[TabBar]s with the same rearrange group ID will allow dragging the tabs between them. Enable drag with [member drag_to_rearrange_enabled].
+			Setting this to [code]-1[/code] will disable rearranging between [TabBar]s.
 		</member>
 	</members>
 	<signals>

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -71,12 +71,6 @@
 				Returns the title of the tab at index [code]tab_idx[/code]. Tab titles default to the name of the indexed child node, but this can be overridden with [method set_tab_title].
 			</description>
 		</method>
-		<method name="get_tabs_rearrange_group" qualifiers="const">
-			<return type="int" />
-			<description>
-				Returns the [TabContainer] rearrange group id.
-			</description>
-		</method>
 		<method name="is_tab_disabled" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="tab_idx" type="int" />
@@ -130,13 +124,6 @@
 				Sets a custom title for the tab at index [code]tab_idx[/code] (tab titles default to the name of the indexed child node). Set it to blank to make it the child's name again.
 			</description>
 		</method>
-		<method name="set_tabs_rearrange_group">
-			<return type="void" />
-			<argument index="0" name="group_id" type="int" />
-			<description>
-				Defines rearrange group id, choose for each [TabContainer] the same value to enable tab drag between [TabContainer]. Enable drag with [member drag_to_rearrange_enabled].
-			</description>
-		</method>
 	</methods>
 	<members>
 		<member name="all_tabs_in_front" type="bool" setter="set_all_tabs_in_front" getter="is_all_tabs_in_front" default="false">
@@ -153,6 +140,10 @@
 		</member>
 		<member name="tab_alignment" type="int" setter="set_tab_alignment" getter="get_tab_alignment" enum="TabBar.AlignmentMode" default="1">
 			Sets the position at which tabs will be placed. See [enum TabBar.AlignmentMode] for details.
+		</member>
+		<member name="tabs_rearrange_group" type="int" setter="set_tabs_rearrange_group" getter="get_tabs_rearrange_group" default="-1">
+			[TabContainer]s with the same rearrange group ID will allow dragging the tabs between them. Enable drag with [member drag_to_rearrange_enabled].
+			Setting this to [code]-1[/code] will disable rearranging between [TabContainer]s.
 		</member>
 		<member name="tabs_visible" type="bool" setter="set_tabs_visible" getter="are_tabs_visible" default="true">
 			If [code]true[/code], tabs are visible. If [code]false[/code], tabs' content and titles are hidden.

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1541,6 +1541,7 @@ void TabBar::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "tab_close_display_policy", PROPERTY_HINT_ENUM, "Show Never,Show Active Only,Show Always"), "set_tab_close_display_policy", "get_tab_close_display_policy");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scrolling_enabled"), "set_scrolling_enabled", "get_scrolling_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_to_rearrange_enabled"), "set_drag_to_rearrange_enabled", "get_drag_to_rearrange_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tabs_rearrange_group"), "set_tabs_rearrange_group", "get_tabs_rearrange_group");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "scroll_to_selected"), "set_scroll_to_selected", "get_scroll_to_selected");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "select_with_rmb"), "set_select_with_rmb", "get_select_with_rmb");
 

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -401,7 +401,10 @@ void TabContainer::_drop_data_fw(const Point2 &p_point, const Variant &p_data, C
 			}
 
 			move_child(get_tab_control(tab_from_id), get_tab_control(hover_now)->get_index(false));
-			set_current_tab(hover_now);
+			if (!is_tab_disabled(hover_now)) {
+				set_current_tab(hover_now);
+			}
+
 		} else if (get_tabs_rearrange_group() != -1) {
 			// Drag and drop between TabContainers.
 			Node *from_node = get_node(from_path);
@@ -416,8 +419,9 @@ void TabContainer::_drop_data_fw(const Point2 &p_point, const Variant &p_data, C
 				}
 
 				move_child(moving_tabc, get_tab_control(hover_now)->get_index(false));
-
-				set_current_tab(hover_now);
+				if (!is_tab_disabled(hover_now)) {
+					set_current_tab(hover_now);
+				}
 			}
 		}
 	}
@@ -864,6 +868,7 @@ void TabContainer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "tabs_visible"), "set_tabs_visible", "are_tabs_visible");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "all_tabs_in_front"), "set_all_tabs_in_front", "is_all_tabs_in_front");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "drag_to_rearrange_enabled"), "set_drag_to_rearrange_enabled", "get_drag_to_rearrange_enabled");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "tabs_rearrange_group"), "set_tabs_rearrange_group", "get_tabs_rearrange_group");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_hidden_tabs_for_min_size"), "set_use_hidden_tabs_for_min_size", "get_use_hidden_tabs_for_min_size");
 }
 


### PR DESCRIPTION
It has both setter and getter, so there is no reason it's not a property. Also this allows setting the group in the editor.
Also clarified the description a bit (mentioned that -1 disables this).