### PR TITLE
[TextServer] Improve word breaking when there are multiple spaces between words.

### DIFF
--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -752,15 +752,19 @@ PackedInt32Array TextServer::shaped_text_get_word_breaks(RID p_shaped, int p_gra
 	for (int i = 0; i < l_size; i++) {
 		if (l_gl[i].count > 0) {
 			if ((l_gl[i].flags & p_grapheme_flags) != 0) {
-				words.push_back(word_start);
-				words.push_back(l_gl[i].start);
+				if (word_start != l_gl[i].start) {
+					words.push_back(word_start);
+					words.push_back(l_gl[i].start);
+				}
 				word_start = l_gl[i].end;
 			}
 		}
 	}
 	if (l_size > 0) {
-		words.push_back(word_start);
-		words.push_back(range.y);
+		if (word_start != range.y) {
+			words.push_back(word_start);
+			words.push_back(range.y);
+		}
 	}
 
 	return words;


### PR DESCRIPTION
Skips zero length "words", when there are multiple spaces between words.

e.g., for `Test _ with _ _ more _ _ _ spaces` (` _ ` indicate space), it will return `0..4`, `5..9`, `11..15`, `18..24` instead of `0..4`, `5..9`, `10..10`, `11..15`, `16..16`, `17..17`, `18..24`.