### PR TITLE
Fix flipped EYEDIR.z in sky shaders

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
@@ -837,7 +837,7 @@ void RendererSceneSkyRD::init(RendererStorageRD *p_storage) {
 
 		actions.renames["COLOR"] = "color";
 		actions.renames["ALPHA"] = "alpha";
-		actions.renames["EYEDIR"] = "eyedir";
+		actions.renames["EYEDIR"] = "cube_normal";
 		actions.renames["POSITION"] = "params.position_multiplier.xyz";
 		actions.renames["SKY_COORDS"] = "panorama_coords";
 		actions.renames["SCREEN_UV"] = "uv";

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
@@ -837,7 +837,7 @@ void RendererSceneSkyRD::init(RendererStorageRD *p_storage) {
 
 		actions.renames["COLOR"] = "color";
 		actions.renames["ALPHA"] = "alpha";
-		actions.renames["EYEDIR"] = "cube_normal";
+		actions.renames["EYEDIR"] = "eyedir";
 		actions.renames["POSITION"] = "params.position_multiplier.xyz";
 		actions.renames["SKY_COORDS"] = "panorama_coords";
 		actions.renames["SCREEN_UV"] = "uv";

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
@@ -1169,7 +1169,7 @@ void RendererSceneSkyRD::setup(RendererSceneEnvironmentRD *p_env, RID p_render_b
 
 					sky_light_data.direction[0] = world_direction.x;
 					sky_light_data.direction[1] = world_direction.y;
-					sky_light_data.direction[2] = -world_direction.z;
+					sky_light_data.direction[2] = world_direction.z;
 
 					float sign = storage->light_is_negative(base) ? -1 : 1;
 					sky_light_data.energy = sign * storage->light_get_param(base, RS::LIGHT_PARAM_ENERGY);

--- a/servers/rendering/renderer_rd/shaders/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/sky.glsl
@@ -180,12 +180,11 @@ void main() {
 	cube_normal.x = (cube_normal.z * (-uv_interp.x - params.projections[ViewIndex].x)) / params.projections[ViewIndex].y;
 	cube_normal.y = -(cube_normal.z * (-uv_interp.y - params.projections[ViewIndex].z)) / params.projections[ViewIndex].w;
 	cube_normal = mat3(params.orientation) * cube_normal;
-	cube_normal.z = -cube_normal.z;
 	cube_normal = normalize(cube_normal);
 
 	vec2 uv = uv_interp * 0.5 + 0.5;
 
-	vec2 panorama_coords = vec2(atan(cube_normal.x, cube_normal.z), acos(cube_normal.y));
+	vec2 panorama_coords = vec2(atan(cube_normal.x, -cube_normal.z), acos(cube_normal.y));
 
 	if (panorama_coords.x < 0.0) {
 		panorama_coords.x += M_PI * 2.0;
@@ -199,15 +198,12 @@ void main() {
 	vec4 quarter_res_color = vec4(1.0);
 	vec4 custom_fog = vec4(0.0);
 
-	vec3 eyedir = cube_normal;
-	eyedir.z *= -1.0;
-
 #ifdef USE_CUBEMAP_PASS
 #ifdef USES_HALF_RES_COLOR
-	half_res_color = texture(samplerCube(half_res, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), eyedir) * params.luminance_multiplier;
+	half_res_color = texture(samplerCube(half_res, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), cube_normal) * params.luminance_multiplier;
 #endif
 #ifdef USES_QUARTER_RES_COLOR
-	quarter_res_color = texture(samplerCube(quarter_res, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), eyedir) * params.luminance_multiplier;
+	quarter_res_color = texture(samplerCube(quarter_res, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), cube_normal) * params.luminance_multiplier;
 #endif
 #else
 #ifdef USES_HALF_RES_COLOR

--- a/servers/rendering/renderer_rd/shaders/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/sky.glsl
@@ -199,14 +199,15 @@ void main() {
 	vec4 quarter_res_color = vec4(1.0);
 	vec4 custom_fog = vec4(0.0);
 
+	vec3 eyedir = cube_normal;
+	eyedir.z *= -1.0;
+
 #ifdef USE_CUBEMAP_PASS
-	vec3 inverted_cube_normal = cube_normal;
-	inverted_cube_normal.z *= -1.0;
 #ifdef USES_HALF_RES_COLOR
-	half_res_color = texture(samplerCube(half_res, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), inverted_cube_normal) * params.luminance_multiplier;
+	half_res_color = texture(samplerCube(half_res, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), eyedir) * params.luminance_multiplier;
 #endif
 #ifdef USES_QUARTER_RES_COLOR
-	quarter_res_color = texture(samplerCube(quarter_res, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), inverted_cube_normal) * params.luminance_multiplier;
+	quarter_res_color = texture(samplerCube(quarter_res, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), eyedir) * params.luminance_multiplier;
 #endif
 #else
 #ifdef USES_HALF_RES_COLOR


### PR DESCRIPTION
As reported in #47711, `EYEDIR`'s Z component had the wrong sign.

We were already accounting for this in the cubemap pass, so this commit just moves that declaration into the common part of the shader. I don't fully follow the math here; it's possible that `cube_normal` itself is incorrect and/or that `panorama_coords` is too. Any advice there?

Here's a before (left) and after (right), looking toward +X +Y +Z with FOV 120:

```glsl
shader_type sky;
void sky() { COLOR = EYEDIR; }
```

![demo](https://user-images.githubusercontent.com/52548/156905936-7dbe2c4d-3a3a-42a4-aef5-26c5c16ebdab.png)