### PR TITLE
Add down-mixer audio effect

### DIFF
--- a/doc/classes/AudioEffectDownmixer.xml
+++ b/doc/classes/AudioEffectDownmixer.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AudioEffectDownmixer" inherits="AudioEffect" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Down-mix effect allowing progressive conversion of stereo audio to mono.
+	</brief_description>
+	<description>
+		Down-mix effect allowing progressive conversion of stereo audio to mono.
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="strength" type="float" setter="set_strength" getter="get_strength" default="0.0">
+			The strength of the down-mixing effect. 0 means no down-mixing, 1 means down-mix to mono.
+		</member>
+	</members>
+</class>

--- a/servers/audio/effects/audio_effect_downmixer.cpp
+++ b/servers/audio/effects/audio_effect_downmixer.cpp
@@ -1,0 +1,72 @@
+/*************************************************************************/
+/*  audio_effect_downmixer.cpp                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "audio_effect_downmixer.h"
+#include "core/math/math_funcs.h"
+#include "servers/audio_server.h"
+
+void AudioEffectDownmixerInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
+	float this_mix_strength_delta = base->strength - last_strength;
+	for (int frame = 0; frame < p_frame_count; frame++) {
+		float mix_fraction = (float)frame / p_frame_count;
+		float this_frame_strength = last_strength + mix_fraction * this_mix_strength_delta;
+		float mono_val = p_src_frames[frame].l + p_src_frames[frame].r;
+		p_dst_frames[frame] = p_src_frames[frame] * (1.0f - this_frame_strength) + AudioFrame(mono_val, mono_val) * this_frame_strength;
+	}
+	last_strength = base->strength;
+}
+
+Ref<AudioEffectInstance> AudioEffectDownmixer::instantiate() {
+	Ref<AudioEffectDownmixerInstance> ins;
+	ins.instantiate();
+	ins->last_strength = strength;
+	ins->base = Ref<AudioEffectDownmixer>(this);
+
+	return ins;
+}
+
+void AudioEffectDownmixer::set_strength(float p_strength) {
+	strength = p_strength;
+}
+
+float AudioEffectDownmixer::get_strength() const {
+	return strength;
+}
+
+void AudioEffectDownmixer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_strength", "strength"), &AudioEffectDownmixer::set_strength);
+	ClassDB::bind_method(D_METHOD("get_strength"), &AudioEffectDownmixer::get_strength);
+
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "strength", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_strength", "get_strength");
+}
+
+AudioEffectDownmixer::AudioEffectDownmixer() {
+	strength = 0;
+}

--- a/servers/audio/effects/audio_effect_downmixer.h
+++ b/servers/audio/effects/audio_effect_downmixer.h
@@ -1,0 +1,67 @@
+/*************************************************************************/
+/*  audio_effect_downmixer.h                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef AUDIOEFFECTDOWNMIXER_H
+#define AUDIOEFFECTDOWNMIXER_H
+
+#include "servers/audio/audio_effect.h"
+
+class AudioEffectDownmixer;
+
+class AudioEffectDownmixerInstance : public AudioEffectInstance {
+	GDCLASS(AudioEffectDownmixerInstance, AudioEffectInstance);
+	friend class AudioEffectDownmixer;
+	Ref<AudioEffectDownmixer> base;
+	float last_strength;
+
+public:
+	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) override;
+};
+
+class AudioEffectDownmixer : public AudioEffect {
+	GDCLASS(AudioEffectDownmixer, AudioEffect);
+
+public:
+	friend class AudioEffectDownmixerInstance;
+	float strength;
+
+protected:
+	static void _bind_methods();
+
+public:
+	Ref<AudioEffectInstance> instantiate() override;
+
+	void set_strength(float p_strength);
+	float get_strength() const;
+
+	AudioEffectDownmixer();
+};
+
+#endif // AUDIOEFFECTDOWNMIXER_H

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -41,6 +41,7 @@
 #include "audio/effects/audio_effect_compressor.h"
 #include "audio/effects/audio_effect_delay.h"
 #include "audio/effects/audio_effect_distortion.h"
+#include "audio/effects/audio_effect_downmixer.h"
 #include "audio/effects/audio_effect_eq.h"
 #include "audio/effects/audio_effect_filter.h"
 #include "audio/effects/audio_effect_limiter.h"
@@ -170,6 +171,7 @@ void register_server_types() {
 		GDREGISTER_CLASS(AudioEffectEQ21);
 
 		GDREGISTER_CLASS(AudioEffectDistortion);
+		GDREGISTER_CLASS(AudioEffectDownmixer);
 
 		GDREGISTER_CLASS(AudioEffectStereoEnhance);
 


### PR DESCRIPTION
Implements modified version of https://github.com/godotengine/godot-proposals/issues/4159

This adds a new audio effect to down-mix stereo audio to mono progressively. This could be incredibly useful even outside of this one user's use-case. We're constantly getting complaints about the stereo panning being too intense in 2d, and this would allow us to easily let users adjust it to their liking.

I implemented this effect so that it lerps the strength property over the course of the mix. I think all audio effects should be implemented this way when possible because it makes it possible to change their properties on the fly smoothly and without artifacts.