### PR TITLE
Improve some DirAccess usage

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -542,7 +542,7 @@ void EditorExportPlatform::_edit_filter_list(Set<String> &r_list, const String &
 		filters.push_back(f);
 	}
 
-	DirAccess *da = DirAccess::open("res://");
+	DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	ERR_FAIL_NULL(da);
 	_edit_files_with_filter(da, filters, r_list, exclude);
 	memdelete(da);

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -645,7 +645,7 @@ Error ExportTemplateManager::install_android_template_from_file(const String &p_
 	// To support custom Android builds, we install the Java source code and buildsystem
 	// from android_source.zip to the project's res://android folder.
 
-	DirAccessRef da = DirAccess::open("res://");
+	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	ERR_FAIL_COND_V(!da, ERR_CANT_CREATE);
 
 	// Make res://android dir (if it does not exist).

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -512,7 +512,7 @@ void FileSystemDock::_navigate_to_path(const String &p_path, bool p_select_in_fa
 		if (target_path.ends_with("/")) {
 			target_path = target_path.substr(0, target_path.length() - 1);
 		}
-		DirAccess *dirAccess = DirAccess::open("res://");
+		DirAccess *dirAccess = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		if (dirAccess->file_exists(p_path)) {
 			path = target_path;
 		} else if (dirAccess->dir_exists(p_path)) {


### PR DESCRIPTION
I noticed that there were a few usages of DirAccess with hard-coded "res://" path. `DirAccess::ACCESS_RESOURCES` is equivalent, so I think it's better to use it when possible.