### PR TITLE
Fix regressions with nameless and icon-only tabs

### DIFF
--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -121,7 +121,7 @@
 			<argument index="0" name="tab_idx" type="int" />
 			<argument index="1" name="title" type="String" />
 			<description>
-				Sets a custom title for the tab at index [code]tab_idx[/code] (tab titles default to the name of the indexed child node). Set it to blank to make it the child's name again.
+				Sets a custom title for the tab at index [code]tab_idx[/code] (tab titles default to the name of the indexed child node). Set it back to the child's name to make the tab default to it again.
 			</description>
 		</method>
 	</methods>

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -71,7 +71,7 @@ Size2 TabBar::get_minimum_size() const {
 
 		Ref<Texture2D> tex = tabs[i].icon;
 		if (tex.is_valid()) {
-			ms.height = MAX(ms.height, tex->get_size().height);
+			ms.height = MAX(ms.height, tex->get_size().height + y_margin);
 			ms.width += tex->get_size().width + hseparation;
 		}
 
@@ -91,13 +91,13 @@ Size2 TabBar::get_minimum_size() const {
 				ms.width += button_highlight->get_margin(SIDE_LEFT) + rb->get_width() + hseparation;
 			}
 
-			ms.height = MAX(rb->get_height() + style->get_minimum_size().height, ms.height);
+			ms.height = MAX(ms.height, rb->get_height() + y_margin);
 		}
 
 		if (close_visible) {
 			ms.width += button_highlight->get_margin(SIDE_LEFT) + close->get_width() + hseparation;
 
-			ms.height = MAX(close->get_height() + style->get_minimum_size().height, ms.height);
+			ms.height = MAX(ms.height, close->get_height() + y_margin);
 		}
 
 		if (ms.width - ofs > style->get_minimum_size().width) {

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -635,14 +635,13 @@ void TabContainer::set_tab_title(int p_tab, const String &p_title) {
 	Control *child = get_tab_control(p_tab);
 	ERR_FAIL_COND(!child);
 
-	if (p_title.is_empty()) {
-		tab_bar->set_tab_title(p_tab, String(child->get_name()));
+	tab_bar->set_tab_title(p_tab, p_title);
 
+	if (p_title == child->get_name()) {
 		if (child->has_meta("_tab_name")) {
 			child->remove_meta("_tab_name");
 		}
 	} else {
-		tab_bar->set_tab_title(p_tab, p_title);
 		child->set_meta("_tab_name", p_title);
 	}
 


### PR DESCRIPTION
The issues can be seen in the theme editor.

- Fix icon-only tabs not taking the `y` margin size into account.
- Make possible to once again make tabs nameless. Now setting a tab's name to the name of the child will make it follow the name instead.