### PR TITLE
[3.x] Update scroll position when zooming TileSet editor

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.h
+++ b/editor/plugins/tile_set_editor_plugin.h
@@ -230,6 +230,7 @@ private:
 	void _zoom_in();
 	void _zoom_out();
 	void _zoom_reset();
+	void _zoom_on_position(float p_zoom, const Vector2 &p_position);
 
 	void draw_highlight_current_tile();
 	void draw_highlight_subtile(Vector2 coord, const Vector<Vector2> &other_highlighted = Vector<Vector2>());


### PR DESCRIPTION
TileSet editor in `3.x` did not update scroll position when zooming. It's easy to get lost when working with small spritesheets.

This PR makes it to zoom on mouse position when zooming with mouse wheel, and zoom on top-left visible corner when zooming with +/- buttons.

The rewritten TileSet editor on `master` does not have this problem.