### PR TITLE
GLES2: Fix VersionKey comparison in `ShaderGLES2::bind()`

### DIFF
--- a/drivers/gles2/shader_gles2.cpp
+++ b/drivers/gles2/shader_gles2.cpp
@@ -77,7 +77,7 @@ GLint ShaderGLES2::get_uniform_location(int p_index) const {
 }
 
 bool ShaderGLES2::bind() {
-	if (active != this || !version || new_conditional_version.key != conditional_version.key) {
+	if (active != this || !version || !(new_conditional_version == conditional_version)) {
 		conditional_version = new_conditional_version;
 		version = get_current_version();
 	} else {


### PR DESCRIPTION
This was comparing arrays, GCC 12 raises a warning for it:

```
drivers/gles2/shader_gles2.cpp: In member function 'bool ShaderGLES2::bind()':
drivers/gles2/shader_gles2.cpp:80:71: error: comparison between two arrays [-Werror=array-compare]
   80 |         if (active != this || !version || new_conditional_version.key != conditional_version.key) {
      |                                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~
drivers/gles2/shader_gles2.cpp:80:71: note: use unary '+' which decays operands to pointers or '&'component_ref' not supported by dump_decl<declaration error>[0] != &'component_ref' not supported by dump_decl<declaration error>[0]' to compare the addresses
```

For context:
https://github.com/godotengine/godot/blob/b28eea610ccd461a7bd67cc6f0c2dd17384ca0de/drivers/gles2/shader_gles2.h#L126-L134

GLES3 is somewhat different and spells things out more in detail:
https://github.com/godotengine/godot/blob/b28eea610ccd461a7bd67cc6f0c2dd17384ca0de/drivers/gles3/shader_gles3.cpp#L96-L109
Ubershader logic aside, it should amount to the same as what my GLES2 fix does.

Tested on Jetpaca, didn't spot any obvious issue.

Would need review from rendering team, I just fixed the C++ bug, and that might fix some actual GLES2 shader issues or introduce some.