### PR TITLE
Revert "Fix ProjectSettings has_setting() when used on a overriden setting with feature tags"

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -614,11 +614,7 @@ Error ProjectSettings::setup(const String &p_path, const String &p_main_pack, bo
 bool ProjectSettings::has_setting(String p_var) const {
 	_THREAD_SAFE_METHOD_
 
-	StringName name = p_var;
-	if (!disable_feature_overrides && feature_overrides.has(name)) {
-		name = feature_overrides[name];
-	}
-	return props.has(name);
+	return props.has(p_var);
 }
 
 Error ProjectSettings::_load_settings_binary(const String &p_path) {


### PR DESCRIPTION
Reverts godotengine/godot#57972. See discussion there for details.

Fixes #58294.