### PR TITLE
[3.x] Add option to filter the stack variables of GDScript debugger

### DIFF
--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1304,6 +1304,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			error_tree->connect("item_activated", this, "_error_activated");
 			vmem_refresh->set_icon(get_icon("Reload", "EditorIcons"));
 			vmem_export->set_icon(get_icon("Save", "EditorIcons"));
+			search->set_right_icon(get_icon("Search", "EditorIcons"));
 
 			reason->add_color_override("font_color", get_color("error_color", "Editor"));
 
@@ -1545,6 +1546,7 @@ void ScriptEditorDebugger::_notification(int p_what) {
 			docontinue->set_icon(get_icon("DebugContinue", "EditorIcons"));
 			vmem_refresh->set_icon(get_icon("Reload", "EditorIcons"));
 			vmem_export->set_icon(get_icon("Save", "EditorIcons"));
+			search->set_right_icon(get_icon("Search", "EditorIcons"));
 		} break;
 	}
 }
@@ -2464,11 +2466,27 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		stack_dump->connect("cell_selected", this, "_stack_dump_frame_selected");
 		sc->add_child(stack_dump);
 
+		VBoxContainer *inspector_vbox = memnew(VBoxContainer);
+		sc->add_child(inspector_vbox);
+
+		HBoxContainer *tools_hb = memnew(HBoxContainer);
+		inspector_vbox->add_child(tools_hb);
+
+		search = memnew(LineEdit);
+		search->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		search->set_placeholder(TTR("Filter stack variables"));
+		search->set_clear_button_enabled(true);
+		tools_hb->add_child(search);
+
 		inspector = memnew(EditorInspector);
 		inspector->set_h_size_flags(SIZE_EXPAND_FILL);
+		inspector->set_v_size_flags(SIZE_EXPAND_FILL);
 		inspector->set_enable_capitalize_paths(false);
 		inspector->set_read_only(true);
 		inspector->connect("object_id_selected", this, "_scene_tree_property_select_object");
+		inspector->register_text_enter(search);
+		inspector->set_use_filter(true);
+		inspector_vbox->add_child(inspector);
 		sc->add_child(inspector);
 
 		server.instance();

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -159,6 +159,7 @@ private:
 	LineEdit *vmem_total;
 
 	Tree *stack_dump;
+	LineEdit *search;
 	EditorInspector *inspector;
 
 	Ref<TCP_Server> server;


### PR DESCRIPTION
Backport https://github.com/godotengine/godot/pull/56719 (without resizing code since I'm not sure whether it is useful or not)
