### PR TITLE
Revert "[HTML5] Fetch API now passes credentials."

### DIFF
--- a/platform/javascript/js/libs/library_godot_fetch.js
+++ b/platform/javascript/js/libs/library_godot_fetch.js
@@ -89,7 +89,6 @@ const GodotFetch = {
 				method: method,
 				headers: headers,
 				body: body,
-				credentials: 'include',
 			};
 			obj.request = fetch(url, init);
 			obj.request.then(GodotFetch.onresponse.bind(null, id)).catch(GodotFetch.onerror.bind(null, id));


### PR DESCRIPTION
Reverts godotengine/godot#57934

- Fixes #58615