### PR TITLE
Implement `get_bone_final_pose()` to `Skeleton3D`

### DIFF
--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -93,6 +93,13 @@
 				Returns the amount of bones in the skeleton.
 			</description>
 		</method>
+		<method name="get_bone_final_pose" qualifiers="const">
+			<return type="Transform3D" />
+			<argument index="0" name="bone_idx" type="int" />
+			<description>
+				Returns the final transform of the specified bone, if pose is overridden, it take that into account.
+			</description>
+		</method>
 		<method name="get_bone_global_pose" qualifiers="const">
 			<return type="Transform3D" />
 			<argument index="0" name="bone_idx" type="int" />

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -743,6 +743,17 @@ Transform3D Skeleton3D::get_bone_pose(int p_bone) const {
 	return bones[p_bone].pose_cache;
 }
 
+Transform3D Skeleton3D::get_bone_final_pose(int p_bone) const {
+	const int bone_size = bones.size();
+	ERR_FAIL_INDEX_V(p_bone, bone_size, Transform3D());
+	((Skeleton3D *)this)->bones.write[p_bone].update_pose_cache();
+	if (bones[p_bone].local_pose_override_amount >= CMP_EPSILON || bones[p_bone].global_pose_override_amount >= CMP_EPSILON) {
+		return ((Skeleton3D *)this)->global_pose_to_local_pose(p_bone, get_bone_global_pose(p_bone));
+	} else {
+		return bones[p_bone].pose_cache;
+	}
+}
+
 void Skeleton3D::_make_dirty() {
 	if (dirty) {
 		return;
@@ -1216,6 +1227,7 @@ void Skeleton3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_bones"), &Skeleton3D::clear_bones);
 
 	ClassDB::bind_method(D_METHOD("get_bone_pose", "bone_idx"), &Skeleton3D::get_bone_pose);
+	ClassDB::bind_method(D_METHOD("get_bone_final_pose", "bone_idx"), &Skeleton3D::get_bone_final_pose);
 	ClassDB::bind_method(D_METHOD("set_bone_pose_position", "bone_idx", "position"), &Skeleton3D::set_bone_pose_position);
 	ClassDB::bind_method(D_METHOD("set_bone_pose_rotation", "bone_idx", "rotation"), &Skeleton3D::set_bone_pose_rotation);
 	ClassDB::bind_method(D_METHOD("set_bone_pose_scale", "bone_idx", "scale"), &Skeleton3D::set_bone_pose_scale);

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -215,6 +215,7 @@ public:
 	void set_bone_pose_scale(int p_bone, const Vector3 &p_scale);
 
 	Transform3D get_bone_pose(int p_bone) const;
+	Transform3D get_bone_final_pose(int p_bone) const;
 
 	Vector3 get_bone_pose_position(int p_bone) const;
 	Quaternion get_bone_pose_rotation(int p_bone) const;


### PR DESCRIPTION
The refactoring done in #55840 requires a more in-depth discussion because of it affects to large area.

For now, the current problem in my case is that we can't get the final displayed pose because of the mix of `local_pose_override` and `global_pose_override` and the difficulty in knowing from outside Skeleton whether they override the original pose.

As a minimum implementation, I implemented `get_bone_final_pose()` as a function that returns the original pose if there are no overrides, and returns the local pose that takes into account the overrides if there are.