### PR TITLE
[3.x] Fix top level `CanvasItem` visibility

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3756,7 +3756,7 @@ void CanvasItemEditor::_draw_invisible_nodes_positions(Node *p_node, const Trans
 	}
 
 	CanvasItem *canvas_item = Object::cast_to<CanvasItem>(p_node);
-	if (canvas_item && !canvas_item->is_visible_in_tree()) {
+	if (canvas_item && !canvas_item->is_visible()) {
 		return;
 	}
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3756,7 +3756,7 @@ void CanvasItemEditor::_draw_invisible_nodes_positions(Node *p_node, const Trans
 	}
 
 	CanvasItem *canvas_item = Object::cast_to<CanvasItem>(p_node);
-	if (canvas_item && !canvas_item->is_visible()) {
+	if (canvas_item && !canvas_item->is_visible_in_tree()) {
 		return;
 	}
 

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -208,6 +208,7 @@ private:
 	mutable bool global_invalid;
 
 	void _toplevel_raise_self();
+	void _toplevel_visibility_changed(bool p_visible);
 
 	void _propagate_visibility_changed(bool p_visible);
 

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -193,7 +193,6 @@ private:
 
 	bool first_draw;
 	bool visible;
-	bool parent_visible_in_tree;
 	bool pending_update;
 	bool toplevel;
 	bool drawing;
@@ -210,7 +209,7 @@ private:
 
 	void _toplevel_raise_self();
 
-	void _propagate_visibility_changed(bool p_visible, bool p_was_visible = false);
+	void _propagate_visibility_changed(bool p_visible);
 
 	void _update_callback();
 

--- a/scene/2d/canvas_item.h
+++ b/scene/2d/canvas_item.h
@@ -210,7 +210,7 @@ private:
 
 	void _toplevel_raise_self();
 
-	void _propagate_visibility_changed(bool p_visible, bool p_is_source = false);
+	void _propagate_visibility_changed(bool p_visible, bool p_was_visible = false);
 
 	void _update_callback();
 

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -59,7 +59,7 @@ void CanvasLayer::set_visible(bool p_visible) {
 			if (c->is_visible()) {
 				c->_propagate_visibility_changed(p_visible);
 			} else {
-				c->parent_visible_in_tree = p_visible;
+				c->notification(CanvasItem::NOTIFICATION_VISIBILITY_CHANGED);
 			}
 		}
 	}

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -51,17 +51,10 @@ void CanvasLayer::set_visible(bool p_visible) {
 	visible = p_visible;
 	emit_signal("visibility_changed");
 
-	for (int i = 0; i < get_child_count(); i++) {
-		CanvasItem *c = Object::cast_to<CanvasItem>(get_child(i));
-		if (c) {
-			VisualServer::get_singleton()->canvas_item_set_visible(c->get_canvas_item(), p_visible && c->is_visible());
-
-			if (c->is_visible()) {
-				c->_propagate_visibility_changed(p_visible);
-			} else {
-				c->notification(CanvasItem::NOTIFICATION_VISIBILITY_CHANGED);
-			}
-		}
+	// For CanvasItems that is explicitly top level or has non-CanvasItem parents.
+	if (is_inside_tree()) {
+		const String group = "root_canvas" + itos(canvas.get_id());
+		get_tree()->call_group_flags(SceneTree::GROUP_CALL_UNIQUE, group, "_toplevel_visibility_changed", p_visible);
 	}
 }
 


### PR DESCRIPTION
This PR first reverts the backported #57684 (part of #57900) and #58386.

#57684 was backported mainly because it solves a bug where

> CanvasLayer could propagate its visibility to CanvasItems that were separated by plain Nodes.

But after inspection these days, I think that is the expected behavior. `CanvasItem`s that are explicitly marked as top level or have a non-`CanvasItem` parent were handled together as "top level", and they are logically parented to the nearest ancestor `CanvasLayer` or `Viewport` world canvas. See [`CanvasItem::_enter_canvas()`](https://github.com/godotengine/godot/blob/6b4d7d20a48ddcc5bf457df38053086ab6041c9f/scene/2d/canvas_item.cpp#L498-L534).

After the revert, the only problem is that `CanvasLayer` visibility propagation was only propagated to direct child `CanvasItem`s. Fortunately, all these "top level" nodes are in a group called `root_canvas{canvas_rid}`, so moving the propagation logic into a `call_group()` is all that have to be done I think.

The editor gizmo fix from the reverted 642591b6a96285d70cd1fefc6b7f997a1395c07f is kept.

---

I also stopped propagation onto explicitly top level `CanvasItem`s because:

* Their logical parent is a `CanvasLayer`.
* For `CanvasLayer`, we propagate to these `CanvasItem`s with `call_group()`.
* There was previously a comment:
    https://github.com/godotengine/godot/blob/6b4d7d20a48ddcc5bf457df38053086ab6041c9f/scene/2d/canvas_item.cpp#L385-L387
* Previously, the visibility of `CanvasItem`s are only controlled by their logical parent inside `VisualServer`. So propagating onto top level nodes won't actually change anything.

---

Tested recent regressions like #58251, #58315, and #58782. They are not reproducible.

Fixes #58782

