### PR TITLE
VariantUtility: Unexpose `Math::range_step_decimals`

### DIFF
--- a/core/math/math_funcs.h
+++ b/core/math/math_funcs.h
@@ -322,7 +322,7 @@ public:
 	// double only, as these functions are mainly used by the editor and not performance-critical,
 	static double ease(double p_x, double p_c);
 	static int step_decimals(double p_step);
-	static int range_step_decimals(double p_step);
+	static int range_step_decimals(double p_step); // For editor use only.
 	static double snapped(double p_value, double p_step);
 
 	static uint32_t larger_prime(uint32_t p_val);

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -219,10 +219,6 @@ struct VariantUtilityFunctions {
 		return Math::step_decimals(step);
 	}
 
-	static inline int range_step_decimals(float step) {
-		return Math::range_step_decimals(step);
-	}
-
 	static inline double snapped(double value, double step) {
 		return Math::snapped(value, step);
 	}
@@ -1204,7 +1200,6 @@ void Variant::_register_variant_utility_functions() {
 
 	FUNCBINDR(ease, sarray("x", "curve"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(step_decimals, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
-	FUNCBINDR(range_step_decimals, sarray("x"), Variant::UTILITY_FUNC_TYPE_MATH);
 	FUNCBINDR(snapped, sarray("x", "step"), Variant::UTILITY_FUNC_TYPE_MATH);
 
 	FUNCBINDR(lerp, sarray("from", "to", "weight"), Variant::UTILITY_FUNC_TYPE_MATH);

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -791,12 +791,6 @@
 				[/codeblock]
 			</description>
 		</method>
-		<method name="range_step_decimals">
-			<return type="int" />
-			<argument index="0" name="x" type="float" />
-			<description>
-			</description>
-		</method>
 		<method name="rid_allocate_id">
 			<return type="int" />
 			<description>


### PR DESCRIPTION
This method was meant only as a convenience for editor code
to allow using a step of 0 to disable snapping.

It was exposed by mistake when refactoring GlobalScope.

See #30776 for context on this method.