### PR TITLE
Fix typo in BaseButton shortcut context methods

### DIFF
--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -349,7 +349,7 @@ Ref<Shortcut> BaseButton::get_shortcut() const {
 void BaseButton::unhandled_key_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (!_is_focus_owner_in_shorcut_context()) {
+	if (!_is_focus_owner_in_shortcut_context()) {
 		return;
 	}
 
@@ -404,7 +404,7 @@ Node *BaseButton::get_shortcut_context() const {
 	return ctx_node;
 }
 
-bool BaseButton::_is_focus_owner_in_shorcut_context() const {
+bool BaseButton::_is_focus_owner_in_shortcut_context() const {
 	if (shortcut_context == ObjectID()) {
 		// No context, therefore global - always "in" context.
 		return true;

--- a/scene/gui/base_button.h
+++ b/scene/gui/base_button.h
@@ -80,7 +80,7 @@ protected:
 	virtual void unhandled_key_input(const Ref<InputEvent> &p_event) override;
 	void _notification(int p_what);
 
-	bool _is_focus_owner_in_shorcut_context() const;
+	bool _is_focus_owner_in_shortcut_context() const;
 
 	GDVIRTUAL0(_pressed)
 	GDVIRTUAL1(_toggled, bool)

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -36,7 +36,7 @@
 void MenuButton::unhandled_key_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (!_is_focus_owner_in_shorcut_context()) {
+	if (!_is_focus_owner_in_shortcut_context()) {
 		return;
 	}
 


### PR DESCRIPTION
**Note:** Not cherry-pickable to `3.x` as the shortcut context feature doesn't exist there.