### PR TITLE
Add support to align to left to bbcode

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -3250,6 +3250,10 @@ void RichTextLabel::append_text(const String &p_bbcode) {
 			push_paragraph(HORIZONTAL_ALIGNMENT_FILL);
 			pos = brk_end + 1;
 			tag_stack.push_front(tag);
+		} else if (tag == "left") {
+			push_paragraph(HORIZONTAL_ALIGNMENT_LEFT);
+			pos = brk_end + 1;
+			tag_stack.push_front(tag);
 		} else if (tag == "right") {
 			push_paragraph(HORIZONTAL_ALIGNMENT_RIGHT);
 			pos = brk_end + 1;


### PR DESCRIPTION
This adds support for using `[left]` on bbcode. It is necessary to align cells to the left on center aligned tables for example.

