### PR TITLE
Avoid recursive errors in EditorToaster

### DIFF
--- a/editor/editor_toaster.cpp
+++ b/editor/editor_toaster.cpp
@@ -385,12 +385,19 @@ Control *EditorToaster::popup(Control *p_control, Severity p_severity, double p_
 }
 
 void EditorToaster::popup_str(String p_message, Severity p_severity, String p_tooltip) {
+	if (is_processing_error) {
+		return;
+	}
+
 	// Since "_popup_str" adds nodes to the tree, and since the "add_child" method is not
 	// thread-safe, it's better to defer the call to the next cycle to be thread-safe.
+	is_processing_error = true;
 	call_deferred(SNAME("_popup_str"), p_message, p_severity, p_tooltip);
+	is_processing_error = false;
 }
 
 void EditorToaster::_popup_str(String p_message, Severity p_severity, String p_tooltip) {
+	is_processing_error = true;
 	// Check if we already have a popup with the given message.
 	Control *control = nullptr;
 	for (KeyValue<Control *, Toast> element : toasts) {
@@ -432,6 +439,7 @@ void EditorToaster::_popup_str(String p_message, Severity p_severity, String p_t
 	} else {
 		label->set_text(vformat("%s (%d)", p_message, toasts[control].count));
 	}
+	is_processing_error = false;
 }
 
 void EditorToaster::close(Control *p_control) {

--- a/editor/editor_toaster.h
+++ b/editor/editor_toaster.h
@@ -82,6 +82,8 @@ private:
 	};
 	Map<Control *, Toast> toasts;
 
+	bool is_processing_error = false; // Makes sure that we don't handle errors that are triggered within the EditorToaster error processing.
+
 	const double default_message_duration = 5.0;
 
 	static void _error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, bool p_editor_notify, ErrorHandlerType p_type);


### PR DESCRIPTION
Make sure any error triggered during the handling of an error in EditorToaster is not handled there.
This should avoid recursive calls, and thus stackoverflows, there.