### PR TITLE
Don't show Lock & Group buttons for nodes hidden by `CanvasLayer`

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3580,7 +3580,7 @@ void CanvasItemEditor::_draw_locks_and_groups(Node *p_node, const Transform2D &p
 		return;
 	}
 	CanvasItem *canvas_item = Object::cast_to<CanvasItem>(p_node);
-	if (canvas_item && !canvas_item->is_visible()) {
+	if (canvas_item && !canvas_item->is_visible_in_tree()) {
 		return;
 	}
 


### PR DESCRIPTION
Follow-up of #58315 which fixed the drawing of the position gizmo in this situation.

| Before | After |
| ---------- | ----- |
| ![Peek 2022-03-08 19-42](https://user-images.githubusercontent.com/372476/157232795-221e5310-c081-4b85-9e93-6d37c894343b.gif) | ![Peek 2022-03-08 19-49](https://user-images.githubusercontent.com/372476/157232799-78501df0-4476-495f-9a01-27e67ecc68ad.gif) |

