### PR TITLE
Added more .sconsign5.dblite related files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,7 +88,7 @@ logs/
 
 # for projects that use SCons for building: https://www.scons.org/
 .sconf_temp
-.sconsign*.dblite
+.sconsign*.dblite*
 *.pyc
 
 # https://github.com/github/gitignore/blob/master/VisualStudio.gitignore


### PR DESCRIPTION
Reason: vscode c++ plugin can generate a compile_commands.json to autoconfigure IntelliSense.
For some reasons the .sconsign5.dblite-shm and .sconsign5.dblite-wal files were not included in .gitignore

![Screenshot from 2022-03-08 14-02-11](https://user-images.githubusercontent.com/2354060/157289298-da6fd0bc-01b6-4cb4-ba23-5ef2b61d86e7.png)
