### PR TITLE
Add check to prevent "p_gutter = -1" error spam

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1335,6 +1335,9 @@ void ScriptTextEditor::_change_syntax_highlighter(int p_idx) {
 void ScriptTextEditor::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_THEME_CHANGED:
+			if (!editor_enabled) {
+				break;
+			}
 			if (is_visible_in_tree()) {
 				_update_warnings();
 				_update_errors();


### PR DESCRIPTION
Should fix #58075, but it's entirely possible I'm being an idiot and not going back far enough! I have tested this in a build and it didn't seem to have any negative consequences, but someone who knows their way around giving their opinion would be my preference - hence the PR! Feel free to autoclave this if it's no good, I won't take offense.