### PR TITLE
Update mouse cursor shape after changes

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2663,6 +2663,11 @@ void Control::set_default_cursor_shape(CursorShape p_shape) {
 	ERR_FAIL_INDEX(int(p_shape), CURSOR_MAX);
 
 	data.default_cursor = p_shape;
+
+	if (!is_inside_tree()) {
+		return;
+	}
+	get_viewport()->get_base_window()->update_mouse_cursor_shape();
 }
 
 Control::CursorShape Control::get_default_cursor_shape() const {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1087,6 +1087,7 @@ void SceneTree::_change_scene(Node *p_to) {
 	if (p_to) {
 		current_scene = p_to;
 		root->add_child(p_to);
+		root->update_mouse_cursor_shape();
 	}
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1551,7 +1551,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					gui.drag_preview_id = ObjectID();
 				}
 				_propagate_viewport_notification(this, NOTIFICATION_DRAG_END);
-				// Change mouse accordingly.
+				get_base_window()->update_mouse_cursor_shape();
 			}
 
 			_gui_cancel_tooltip();
@@ -1572,7 +1572,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				gui.dragging = false;
 				gui.drag_mouse_over = nullptr;
 				_propagate_viewport_notification(this, NOTIFICATION_DRAG_END);
-				// Change mouse accordingly.
+				get_base_window()->update_mouse_cursor_shape();
 			}
 
 			gui.mouse_focus_mask &= ~mouse_button_to_mask(mb->get_button_index()); // Remove from mask.

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -378,6 +378,18 @@ void Window::_event_callback(DisplayServer::WindowEvent p_event) {
 	}
 }
 
+void Window::update_mouse_cursor_shape() {
+	// The default shape is set in Viewport::_gui_input_event. To instantly
+	// see the shape in the viewport we need to trigger a mouse motion event.
+	Ref<InputEventMouseMotion> mm;
+	Vector2 pos = get_mouse_position();
+	Transform2D xform = get_global_canvas_transform().affine_inverse();
+	mm.instantiate();
+	mm->set_position(pos);
+	mm->set_global_position(xform.xform(pos));
+	push_input(mm);
+}
+
 void Window::show() {
 	set_visible(true);
 }

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -205,6 +205,8 @@ public:
 	void set_visible(bool p_visible);
 	bool is_visible() const;
 
+	void update_mouse_cursor_shape();
+
 	void show();
 	void hide();
 


### PR DESCRIPTION
Fix some cases where the mouse cursor shape did not change automatically, but instead required a Mouse-Move to update.

resolve #45936
resolve #30582

This uses the same technique as [Input::set_default_cursor_shape](https://github.com/godotengine/godot/blob/f73ef03a86912dfe5c6eb73a99c3f50c144c5030/core/input/input.cpp#L830-L843).