### PR TITLE
[3.x] Expose `TextEdit` `get_visible_rows()` and `get_total_visible_rows()` to GDScript

### DIFF
--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -239,6 +239,18 @@
 				Returns the total width of all gutters and internal padding.
 			</description>
 		</method>
+		<method name="get_total_visible_rows" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the total amount of lines that could be drawn.
+			</description>
+		</method>
+		<method name="get_visible_rows" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the number of visible lines, including wrapped text.
+			</description>
+		</method>
 		<method name="get_word_under_cursor" qualifiers="const">
 			<return type="String" />
 			<description>

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -7298,6 +7298,8 @@ void TextEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_draw_fold_gutter"), &TextEdit::set_draw_fold_gutter);
 	ClassDB::bind_method(D_METHOD("is_drawing_fold_gutter"), &TextEdit::is_drawing_fold_gutter);
 	ClassDB::bind_method(D_METHOD("get_total_gutter_width"), &TextEdit::get_total_gutter_width);
+	ClassDB::bind_method(D_METHOD("get_visible_rows"), &TextEdit::get_visible_rows);
+	ClassDB::bind_method(D_METHOD("get_total_visible_rows"), &TextEdit::get_total_visible_rows);
 
 	ClassDB::bind_method(D_METHOD("set_hiding_enabled", "enable"), &TextEdit::set_hiding_enabled);
 	ClassDB::bind_method(D_METHOD("is_hiding_enabled"), &TextEdit::is_hiding_enabled);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

These are useful for making the TextEdit bounding box automatically increase in size while typing.

The equivalent of these functions are already exposed in `master`.