### PR TITLE
[3.x] Use `ToolSelect` icon for `TileMap` editor select button

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -66,7 +66,7 @@ void TileMapEditor::_notification(int p_what) {
 			paint_button->set_icon(get_icon("Edit", "EditorIcons"));
 			bucket_fill_button->set_icon(get_icon("Bucket", "EditorIcons"));
 			picker_button->set_icon(get_icon("ColorPick", "EditorIcons"));
-			select_button->set_icon(get_icon("ActionCopy", "EditorIcons"));
+			select_button->set_icon(get_icon("ToolSelect", "EditorIcons"));
 
 			rotate_left_button->set_icon(get_icon("RotateLeft", "EditorIcons"));
 			rotate_right_button->set_icon(get_icon("RotateRight", "EditorIcons"));


### PR DESCRIPTION
The button currently uses a "Copy" icon for "Selection", this is so confusing. Although I understand that it looks like a regular selection box.

The new tilemap editor on `master` uses the arrow icon for selection too.

| | Screenshot |
| --- | --- |
| Before | ![ksnip_20220309-144139](https://user-images.githubusercontent.com/372476/157386715-9a35f601-7299-42db-87a5-646b4ca00418.png) |
| After | ![ksnip_20220309-144225](https://user-images.githubusercontent.com/372476/157386738-75f8e131-f973-4f4a-82ad-fa40c5672ade.png) |
 