### PR TITLE
Avoid directional correction when the motion is downward

### DIFF
--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -1425,7 +1425,7 @@ void CharacterBody3D::_move_and_slide_grounded(double p_delta, bool p_was_on_flo
 					const PhysicsServer3D::MotionCollision &collision = result.collisions[0];
 
 					Vector3 slide_motion = result.remainder.slide(collision.normal);
-					if (collision_state.floor && !collision_state.wall) {
+					if (collision_state.floor && !collision_state.wall && !motion_slide_up.is_equal_approx(Vector3())) {
 						// Slide using the intersection between the motion plane and the floor plane,
 						// in order to keep the direction intact.
 						real_t motion_length = slide_motion.length();


### PR DESCRIPTION
Fix: #58786

We make a slide on the intersection between the plane of the motion and the plane of the ground to keep the correct direction. However, as we use `up_direction` to determine the motion plane, when the motion is downward it will be stopped.

After:

https://user-images.githubusercontent.com/6397893/157445504-3406328d-e86b-4351-bf5d-b26045c38358.mp4



