### PR TITLE
Fix situations in which mouse_focus_mask is not cleared

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1467,8 +1467,8 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 		gui.last_mouse_pos = mpos;
 		if (mb->is_pressed()) {
 			Size2 pos = mpos;
-			if (gui.mouse_focus_mask != MouseButton::NONE) {
-				// Do not steal mouse focus and stuff while a focus mask exists.
+			if (gui.mouse_focus_mask != MouseButton::NONE && gui.mouse_focus_mask != mouse_button_to_mask(mb->get_button_index())) {
+				// Do not steal mouse focus and stuff while a focus mask different from the pressed button exists.
 				gui.mouse_focus_mask |= mouse_button_to_mask(mb->get_button_index());
 			} else {
 				gui.mouse_focus = gui_find_control(pos);


### PR DESCRIPTION
resolve #51032
resolve #44173

In some cases Viewports `mouse_focus_mask` does not get cleared, for example in the linked bugreport. This patch takes care of these cases.

The reason for the linked issue is that on a Mouse-pressed event, the Viewport sets a `mouse_focus_mask`. Usually this `mouse_focus_mask` gets cleared afterwards in the Mouse-release event.
In case the release does not happen (for example when `_gui_input_event` doesn't get called on the Mouse-release event), this patch ensures, that focus can also be grabbed, if the pressed button is the only one in the `mouse_focus_mask`.