### PR TITLE
Revert #52647 (Don't update CSG Shape when not inside tree)

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -280,7 +280,7 @@ void CSGShape3D::mikktSetTSpaceDefault(const SMikkTSpaceContext *pContext, const
 }
 
 void CSGShape3D::_update_shape() {
-	if (!is_root_shape() || !is_inside_tree()) {
+	if (!is_root_shape()) {
 		return;
 	}
 


### PR DESCRIPTION
Reverts #52647.
Fixes #54445.
#52642 stays fixed, presumably due to #40814.