### PR TITLE
Recalculate normals for singular `CSGShapes`

### DIFF
--- a/modules/csg/csg.h
+++ b/modules/csg/csg.h
@@ -70,6 +70,7 @@ struct CSGBrushOperation {
 		OPERATION_SUBTRACTION,
 	};
 
+	void clean_brush(CSGBrush &p_brush, float p_vertex_snap);
 	void merge_brushes(Operation p_operation, const CSGBrush &p_brush_a, const CSGBrush &p_brush_b, CSGBrush &r_merged_brush, float p_vertex_snap);
 
 	struct MeshMerge {

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -158,6 +158,7 @@ CSGBrush *CSGShape3D::_get_brush() {
 		brush = nullptr;
 
 		CSGBrush *n = _build_brush();
+		int child_shape_count = 0;
 
 		for (int i = 0; i < get_child_count(); i++) {
 			CSGShape3D *child = Object::cast_to<CSGShape3D>(get_child(i));
@@ -199,6 +200,14 @@ CSGBrush *CSGShape3D::_get_brush() {
 				memdelete(nn2);
 				n = nn;
 			}
+
+			child_shape_count++;
+		}
+
+		if (is_root_shape() && child_shape_count == 0) {
+			// Recalculate normals
+			CSGBrushOperation bop;
+			bop.clean_brush(*n, get_snap());
 		}
 
 		if (n) {


### PR DESCRIPTION
Singular `CSGShapes` will now appear as they would when combined with other shapes.
- Fixes #58207.
- Does not fix issue #49800. That would require a new method of normal calculation.