### PR TITLE
Fix TextureRegion editor grid color for light themes

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -85,8 +85,10 @@ void TextureRegionEditor::_region_draw() {
 	edit_draw->draw_texture(base_tex, Point2());
 	RS::get_singleton()->canvas_item_add_set_transform(edit_draw->get_canvas_item(), Transform2D());
 
+	const Color color = get_theme_color(SNAME("mono_color"), SNAME("Editor"));
+
 	if (snap_mode == SNAP_GRID) {
-		Color grid_color = Color(1.0, 1.0, 1.0, 0.15);
+		const Color grid_color = Color(color.r, color.g, color.b, color.a * 0.15);
 		Size2 s = edit_draw->get_size();
 		int last_cell = 0;
 
@@ -172,7 +174,6 @@ void TextureRegionEditor::_region_draw() {
 		mtx.basis_xform(raw_endpoints[2]),
 		mtx.basis_xform(raw_endpoints[3])
 	};
-	Color color = get_theme_color(SNAME("mono_color"), SNAME("Editor"));
 	for (int i = 0; i < 4; i++) {
 		int prev = (i + 3) % 4;
 		int next = (i + 1) % 4;


### PR DESCRIPTION
The grid lines were draw using a fixed color previously, so it's invisible on transparent areas when using light themes.

This PR makes the grid color theme-dependent.

| Before | After |
| --- | --- |
| ![grid-before](https://user-images.githubusercontent.com/372476/157580302-930bdc15-f04d-4e12-8861-47c04fa19f77.png) | ![grid-after](https://user-images.githubusercontent.com/372476/157580316-39694519-eeec-41d3-8fd5-41c7e4689289.png) |
 