### PR TITLE
Make AnimatedSprite2D update animation property when SpriteFrames changes

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -271,6 +271,10 @@ void AnimatedSprite2D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 	frames = p_frames;
 	if (frames.is_valid()) {
 		frames->connect(SceneStringNames::get_singleton()->changed, callable_mp(this, &AnimatedSprite2D::_res_changed));
+		Vector<String> animation_names = frames->get_animation_names();
+		if (!animation_names.has(animation) && animation_names.size() != 0) {
+			set_animation(animation_names[0]);
+		}
 	}
 
 	if (frames.is_null()) {
@@ -378,7 +382,13 @@ bool AnimatedSprite2D::is_flipped_v() const {
 }
 
 void AnimatedSprite2D::_res_changed() {
-	set_frame(frame);
+	Vector<String> animation_names = frames->get_animation_names();
+	if (!animation_names.has(animation) && animation_names.size() != 0) {
+		set_animation(animation_names[0]);
+	}
+	else {
+		set_frame(frame);
+	}
 
 	queue_redraw();
 }
@@ -436,8 +446,9 @@ void AnimatedSprite2D::_reset_timeout() {
 }
 
 void AnimatedSprite2D::set_animation(const StringName &p_animation) {
-	ERR_FAIL_COND_MSG(frames == nullptr, vformat("There is no animation with name '%s'.", p_animation));
-	ERR_FAIL_COND_MSG(!frames->get_animation_names().has(p_animation), vformat("There is no animation with name '%s'.", p_animation));
+	if (frames.is_valid()) {
+		ERR_FAIL_COND_MSG(!frames->get_animation_names().has(p_animation), vformat("There is no animation with name '%s'.", p_animation));
+	}
 
 	if (animation == p_animation) {
 		return;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1112,6 +1112,10 @@ void AnimatedSprite3D::set_sprite_frames(const Ref<SpriteFrames> &p_frames) {
 	frames = p_frames;
 	if (frames.is_valid()) {
 		frames->connect(SceneStringNames::get_singleton()->changed, callable_mp(this, &AnimatedSprite3D::_res_changed));
+		Vector<String> animation_names = frames->get_animation_names();
+		if (!animation_names.has(animation) && animation_names.size() != 0) {
+			set_animation(animation_names[0]);
+		}
 	}
 
 	if (frames.is_null()) {
@@ -1210,7 +1214,12 @@ Rect2 AnimatedSprite3D::get_item_rect() const {
 }
 
 void AnimatedSprite3D::_res_changed() {
-	set_frame(frame);
+	Vector<String> animation_names = frames->get_animation_names();
+	if (!animation_names.has(animation) && animation_names.size() != 0) {
+		set_animation(animation_names[0]);
+	} else {
+		set_frame(frame);
+	}
 
 	_queue_redraw();
 }
@@ -1268,8 +1277,10 @@ void AnimatedSprite3D::_reset_timeout() {
 }
 
 void AnimatedSprite3D::set_animation(const StringName &p_animation) {
-	ERR_FAIL_COND_MSG(frames == nullptr, vformat("There is no animation with name '%s'.", p_animation));
-	ERR_FAIL_COND_MSG(!frames->get_animation_names().has(p_animation), vformat("There is no animation with name '%s'.", p_animation));
+	if (frames.is_valid()) {
+		ERR_FAIL_COND_MSG(!frames->get_animation_names().has(p_animation), vformat("There is no animation with name '%s'.", p_animation));
+	}
+
 	if (animation == p_animation) {
 		return;
 	}

--- a/scene/resources/sprite_frames.cpp
+++ b/scene/resources/sprite_frames.cpp
@@ -77,6 +77,7 @@ void SpriteFrames::add_animation(const StringName &p_anim) {
 	ERR_FAIL_COND_MSG(animations.has(p_anim), "SpriteFrames already has animation '" + p_anim + "'.");
 
 	animations[p_anim] = Anim();
+	emit_changed();
 }
 
 bool SpriteFrames::has_animation(const StringName &p_anim) const {
@@ -84,7 +85,9 @@ bool SpriteFrames::has_animation(const StringName &p_anim) const {
 }
 
 void SpriteFrames::remove_animation(const StringName &p_anim) {
-	animations.erase(p_anim);
+	if (animations.erase(p_anim)) {
+		emit_changed();
+	}
 }
 
 void SpriteFrames::rename_animation(const StringName &p_prev, const StringName &p_next) {


### PR DESCRIPTION
AnimatedSprite2D will ensure it has a valid animation when the SpriteFrames is set, and on its "changed" signal.
To that end, makes SpriteFrames emit the "changed" signal when one or all of its animations are deleted.
Note that the animation property will remain as-is if the SpriteFrames has no animations at all.

Removes error message on set_animation when SpriteFrames is null, which caused "no animation with name X" errors even with the "default" value of freshly created instances.
So, this allows the animation property to be set even without a valid SpriteFrames. And once one is added, the animation will be changed if necessary to make it valid, making the error pointless.

Fixes #45459 and #28658.
Related to #49495 on the 3.x branch.