### PR TITLE
Fix some Animation panel icons not updating after theme change

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1458,7 +1458,8 @@ int AnimationTimelineEdit::get_name_limit() const {
 
 void AnimationTimelineEdit::_notification(int p_what) {
 	switch (p_what) {
-		case NOTIFICATION_ENTER_TREE: {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
 			panner->setup((ViewPanner::ControlScheme)EDITOR_GET("editors/panning/animation_editors_panning_scheme").operator int(), ED_GET_SHORTCUT("canvas_item_editor/pan_view"), bool(EditorSettings::get_singleton()->get("editors/panning/simple_panning")));
 			add_track->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 			loop->set_icon(get_theme_icon(SNAME("Loop"), SNAME("EditorIcons")));
@@ -1945,6 +1946,16 @@ AnimationTimelineEdit::AnimationTimelineEdit() {
 
 void AnimationTrackEdit::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_THEME_CHANGED: {
+			if (animation.is_null()) {
+				return;
+			}
+			ERR_FAIL_INDEX(track, animation->get_track_count());
+
+			type_icon = _get_key_type_icon();
+			selected_icon = get_theme_icon(SNAME("KeySelected"), SNAME("EditorIcons"));
+		} break;
+
 		case NOTIFICATION_DRAW: {
 			if (animation.is_null()) {
 				return;
@@ -1963,17 +1974,6 @@ void AnimationTrackEdit::_notification(int p_what) {
 			Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
 			int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 			Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
-			Ref<Texture2D> type_icons[9] = {
-				get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("KeyTrackPosition"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("KeyTrackRotation"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("KeyTrackScale"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("KeyTrackBlendShape"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("KeyCall"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("KeyBezier"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("KeyAudio"), SNAME("EditorIcons")),
-				get_theme_icon(SNAME("KeyAnimation"), SNAME("EditorIcons"))
-			};
 			int hsep = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
 			Color linecolor = color;
 			linecolor.a = 0.2;
@@ -1989,7 +1989,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 				draw_texture(check, check_rect.position);
 				ofs += check->get_width() + hsep;
 
-				Ref<Texture2D> type_icon = type_icons[animation->track_get_type(track)];
+				Ref<Texture2D> type_icon = _get_key_type_icon();
 				draw_texture(type_icon, Point2(ofs, int(get_size().height - type_icon->get_height()) / 2));
 				ofs += type_icon->get_width() + hsep;
 
@@ -2425,22 +2425,10 @@ void AnimationTrackEdit::set_animation_and_track(const Ref<Animation> &p_animati
 	track = p_track;
 	update();
 
-	Ref<Texture2D> type_icons[9] = {
-		get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons")),
-		get_theme_icon(SNAME("KeyXPosition"), SNAME("EditorIcons")),
-		get_theme_icon(SNAME("KeyXRotation"), SNAME("EditorIcons")),
-		get_theme_icon(SNAME("KeyXScale"), SNAME("EditorIcons")),
-		get_theme_icon(SNAME("KeyBlendShape"), SNAME("EditorIcons")),
-		get_theme_icon(SNAME("KeyCall"), SNAME("EditorIcons")),
-		get_theme_icon(SNAME("KeyBezier"), SNAME("EditorIcons")),
-		get_theme_icon(SNAME("KeyAudio"), SNAME("EditorIcons")),
-		get_theme_icon(SNAME("KeyAnimation"), SNAME("EditorIcons"))
-	};
-
 	ERR_FAIL_INDEX(track, animation->get_track_count());
 
 	node_path = animation->track_get_path(p_track);
-	type_icon = type_icons[animation->track_get_type(track)];
+	type_icon = _get_key_type_icon();
 	selected_icon = get_theme_icon(SNAME("KeySelected"), SNAME("EditorIcons"));
 }
 
@@ -2539,6 +2527,21 @@ bool AnimationTrackEdit::_is_value_key_valid(const Variant &p_key_value, Variant
 	}
 
 	return (!prop_exists || Variant::can_convert(p_key_value.get_type(), r_valid_type));
+}
+
+Ref<Texture2D> AnimationTrackEdit::_get_key_type_icon() const {
+	Ref<Texture2D> type_icons[9] = {
+		get_theme_icon(SNAME("KeyValue"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("KeyTrackPosition"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("KeyTrackRotation"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("KeyTrackScale"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("KeyTrackBlendShape"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("KeyCall"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("KeyBezier"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("KeyAudio"), SNAME("EditorIcons")),
+		get_theme_icon(SNAME("KeyAnimation"), SNAME("EditorIcons"))
+	};
+	return type_icons[animation->track_get_type(track)];
 }
 
 String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -182,6 +182,8 @@ class AnimationTrackEdit : public Control {
 	void _play_position_draw();
 	bool _is_value_key_valid(const Variant &p_key_value, Variant::Type &r_valid_type) const;
 
+	Ref<Texture2D> _get_key_type_icon() const;
+
 	mutable int dropping_at;
 	float insert_at_pos;
 	bool moving_selection_attempt;

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -156,6 +156,8 @@ void AnimationPlayerEditor::_notification(int p_what) {
 			ITEM_ICON(TOOL_EDIT_TRANSITIONS, "Blend");
 			ITEM_ICON(TOOL_EDIT_RESOURCE, "Edit");
 			ITEM_ICON(TOOL_REMOVE_ANIM, "Remove");
+
+			_update_animation_list_icons();
 		} break;
 	}
 }
@@ -859,22 +861,13 @@ void AnimationPlayerEditor::_update_player() {
 
 	int active_idx = -1;
 	for (const StringName &E : animlist) {
-		Ref<Texture2D> icon;
-		if (E == player->get_autoplay()) {
-			if (E == SceneStringNames::get_singleton()->RESET) {
-				icon = autoplay_reset_icon;
-			} else {
-				icon = autoplay_icon;
-			}
-		} else if (E == SceneStringNames::get_singleton()->RESET) {
-			icon = reset_icon;
-		}
-		animation->add_icon_item(icon, E);
+		animation->add_item(E);
 
 		if (player->get_assigned_animation() == E) {
 			active_idx = animation->get_item_count() - 1;
 		}
 	}
+	_update_animation_list_icons();
 
 	updating = false;
 	if (active_idx != -1) {
@@ -901,6 +894,30 @@ void AnimationPlayerEditor::_update_player() {
 	}
 
 	_update_animation();
+}
+
+void AnimationPlayerEditor::_update_animation_list_icons() {
+	List<StringName> animlist;
+	if (player) {
+		player->get_animation_list(&animlist);
+	}
+
+	for (int i = 0; i < animation->get_item_count(); i++) {
+		String name = animation->get_item_text(i);
+
+		Ref<Texture2D> icon;
+		if (name == player->get_autoplay()) {
+			if (name == SceneStringNames::get_singleton()->RESET) {
+				icon = autoplay_reset_icon;
+			} else {
+				icon = autoplay_icon;
+			}
+		} else if (name == SceneStringNames::get_singleton()->RESET) {
+			icon = reset_icon;
+		}
+
+		animation->set_item_icon(i, icon);
+	}
 }
 
 void AnimationPlayerEditor::edit(AnimationPlayer *p_player) {

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -196,6 +196,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _list_changed();
 	void _update_animation();
 	void _update_player();
+	void _update_animation_list_icons();
 	void _blend_edited();
 
 	void _animation_player_changed(Object *p_pl);


### PR DESCRIPTION
* Autoplay & Reset icons in animation dropdown
* Icons in timeline header (e.g. Add Track icon, node type icon...)
* Keyframe icon on the timeline

Note when cherry-picking: The get keyframe type icon logic is extracted into `AnimationTrackEdit::_get_track_type_icon()`. In `3.x`, the array entries are different.