### PR TITLE
[3.x] Fix text color of TileMap editor info overlay

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.cpp
+++ b/editor/plugins/tile_map_editor_plugin.cpp
@@ -2062,6 +2062,7 @@ TileMapEditor::TileMapEditor(EditorNode *p_editor) {
 	tile_info->set_modulate(Color(1, 1, 1, 0.8));
 	tile_info->set_mouse_filter(MOUSE_FILTER_IGNORE);
 	tile_info->add_font_override("font", EditorNode::get_singleton()->get_gui_base()->get_font("main", "EditorFonts"));
+	tile_info->add_color_override("font_color", Color(1, 1, 1, 0.8)); // Overlay has a fixed dark background.
 	// The tile info is only displayed after a tile has been hovered.
 	tile_info->hide();
 	CanvasItemEditor::get_singleton()->add_control_to_info_overlay(tile_info);


### PR DESCRIPTION
Text color of TileMap editor info overlay was using the theme default `Label` color. But the CanvasItem editor's overlay always have a dark background. So the text was invisible when using Light theme:

![ksnip_20220310-190332](https://user-images.githubusercontent.com/372476/157653416-9aff60dc-ee9f-408b-a9f9-4894f729a8e1.png)
