### PR TITLE
Convert uses of `DirAccess *` to `DirAccessRef` to prevent memleaks

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -145,15 +145,13 @@ String ProjectSettings::localize_path(const String &p_path) const {
 		return p_path.simplify_path();
 	}
 
-	DirAccess *dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	DirAccessRef dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 
 	String path = p_path.replace("\\", "/").simplify_path();
 
 	if (dir->change_dir(path) == OK) {
 		String cwd = dir->get_current_dir();
 		cwd = cwd.replace("\\", "/");
-
-		memdelete(dir);
 
 		// Ensure that we end with a '/'.
 		// This is important to ensure that we do not wrongly localize the resource path
@@ -173,8 +171,6 @@ String ProjectSettings::localize_path(const String &p_path) const {
 
 		return cwd.replace_first(res_path, "res://");
 	} else {
-		memdelete(dir);
-
 		int sep = path.rfind("/");
 		if (sep == -1) {
 			return "res://" + path;
@@ -541,7 +537,7 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 	// Nothing was found, try to find a project file in provided path (`p_path`)
 	// or, if requested (`p_upwards`) in parent directories.
 
-	DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	DirAccessRef d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	ERR_FAIL_COND_V_MSG(!d, ERR_CANT_CREATE, "Cannot create DirAccess for path '" + p_path + "'.");
 	d->change_dir(p_path);
 
@@ -572,8 +568,6 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 			break;
 		}
 	}
-
-	memdelete(d);
 
 	if (!found) {
 		return err;

--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1569,10 +1569,8 @@ String Directory::get_current_dir() {
 Error Directory::make_dir(String p_dir) {
 	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory is not configured properly.");
 	if (!p_dir.is_relative_path()) {
-		DirAccess *d = DirAccess::create_for_path(p_dir);
-		Error err = d->make_dir(p_dir);
-		memdelete(d);
-		return err;
+		DirAccessRef da = DirAccess::create_for_path(p_dir);
+		return da->make_dir(p_dir);
 	}
 	return d->make_dir(p_dir);
 }
@@ -1580,10 +1578,8 @@ Error Directory::make_dir(String p_dir) {
 Error Directory::make_dir_recursive(String p_dir) {
 	ERR_FAIL_COND_V_MSG(!d, ERR_UNCONFIGURED, "Directory is not configured properly.");
 	if (!p_dir.is_relative_path()) {
-		DirAccess *d = DirAccess::create_for_path(p_dir);
-		Error err = d->make_dir_recursive(p_dir);
-		memdelete(d);
-		return err;
+		DirAccessRef da = DirAccess::create_for_path(p_dir);
+		return da->make_dir_recursive(p_dir);
 	}
 	return d->make_dir_recursive(p_dir);
 }
@@ -1593,19 +1589,14 @@ bool Directory::file_exists(String p_file) {
 	if (!p_file.is_relative_path()) {
 		return FileAccess::exists(p_file);
 	}
-
 	return d->file_exists(p_file);
 }
 
 bool Directory::dir_exists(String p_dir) {
 	ERR_FAIL_COND_V_MSG(!d, false, "Directory is not configured properly.");
 	if (!p_dir.is_relative_path()) {
-		DirAccess *d = DirAccess::create_for_path(p_dir);
-		bool exists = d->dir_exists(p_dir);
-		memdelete(d);
-		return exists;
+		return DirAccess::exists(p_dir);
 	}
-
 	return d->dir_exists(p_dir);
 }
 
@@ -1624,11 +1615,9 @@ Error Directory::rename(String p_from, String p_to) {
 	ERR_FAIL_COND_V_MSG(p_from.is_empty() || p_from == "." || p_from == "..", ERR_INVALID_PARAMETER, "Invalid path to rename.");
 
 	if (!p_from.is_relative_path()) {
-		DirAccess *d = DirAccess::create_for_path(p_from);
-		ERR_FAIL_COND_V_MSG(!d->file_exists(p_from) && !d->dir_exists(p_from), ERR_DOES_NOT_EXIST, "File or directory does not exist.");
-		Error err = d->rename(p_from, p_to);
-		memdelete(d);
-		return err;
+		DirAccessRef da = DirAccess::create_for_path(p_from);
+		ERR_FAIL_COND_V_MSG(!da->file_exists(p_from) && !da->dir_exists(p_from), ERR_DOES_NOT_EXIST, "File or directory does not exist.");
+		return da->rename(p_from, p_to);
 	}
 
 	ERR_FAIL_COND_V_MSG(!d->file_exists(p_from) && !d->dir_exists(p_from), ERR_DOES_NOT_EXIST, "File or directory does not exist.");
@@ -1638,10 +1627,8 @@ Error Directory::rename(String p_from, String p_to) {
 Error Directory::remove(String p_name) {
 	ERR_FAIL_COND_V_MSG(!is_open(), ERR_UNCONFIGURED, "Directory must be opened before use.");
 	if (!p_name.is_relative_path()) {
-		DirAccess *d = DirAccess::create_for_path(p_name);
-		Error err = d->remove(p_name);
-		memdelete(d);
-		return err;
+		DirAccessRef da = DirAccess::create_for_path(p_name);
+		return da->remove(p_name);
 	}
 
 	return d->remove(p_name);
@@ -1664,7 +1651,6 @@ void Directory::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("make_dir_recursive", "path"), &Directory::make_dir_recursive);
 	ClassDB::bind_method(D_METHOD("file_exists", "path"), &Directory::file_exists);
 	ClassDB::bind_method(D_METHOD("dir_exists", "path"), &Directory::dir_exists);
-	//ClassDB::bind_method(D_METHOD("get_modified_time","file"),&Directory::get_modified_time);
 	ClassDB::bind_method(D_METHOD("get_space_left"), &Directory::get_space_left);
 	ClassDB::bind_method(D_METHOD("copy", "from", "to"), &Directory::copy);
 	ClassDB::bind_method(D_METHOD("rename", "from", "to"), &Directory::rename);

--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -414,8 +414,6 @@ Error DirAccess::copy_dir(String p_from, String p_to, int p_chmod_flags, bool p_
 }
 
 bool DirAccess::exists(String p_dir) {
-	DirAccess *da = DirAccess::create_for_path(p_dir);
-	bool valid = da->change_dir(p_dir) == OK;
-	memdelete(da);
-	return valid;
+	DirAccessRef da = DirAccess::create_for_path(p_dir);
+	return da->change_dir(p_dir) == OK;
 }

--- a/core/io/dir_access.h
+++ b/core/io/dir_access.h
@@ -134,7 +134,7 @@ struct DirAccessRef {
 
 	operator bool() const { return f != nullptr; }
 
-	DirAccess *f;
+	DirAccess *f = nullptr;
 
 	DirAccessRef(DirAccess *fa) { f = fa; }
 	~DirAccessRef() {

--- a/core/io/logger.cpp
+++ b/core/io/logger.cpp
@@ -128,7 +128,7 @@ void RotatedFileLogger::clear_old_backups() {
 	String basename = base_path.get_file().get_basename();
 	String extension = base_path.get_extension();
 
-	DirAccess *da = DirAccess::open(base_path.get_base_dir());
+	DirAccessRef da = DirAccess::open(base_path.get_base_dir());
 	if (!da) {
 		return;
 	}
@@ -152,8 +152,6 @@ void RotatedFileLogger::clear_old_backups() {
 			da->remove(E->get());
 		}
 	}
-
-	memdelete(da);
 }
 
 void RotatedFileLogger::rotate_file() {
@@ -167,18 +165,16 @@ void RotatedFileLogger::rotate_file() {
 				backup_name += "." + base_path.get_extension();
 			}
 
-			DirAccess *da = DirAccess::open(base_path.get_base_dir());
+			DirAccessRef da = DirAccess::open(base_path.get_base_dir());
 			if (da) {
 				da->copy(base_path, backup_name);
-				memdelete(da);
 			}
 			clear_old_backups();
 		}
 	} else {
-		DirAccess *da = DirAccess::create(DirAccess::ACCESS_USERDATA);
+		DirAccessRef da = DirAccess::create(DirAccess::ACCESS_USERDATA);
 		if (da) {
 			da->make_dir_recursive(base_path.get_base_dir());
-			memdelete(da);
 		}
 	}
 

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1032,7 +1032,6 @@ RES ResourceFormatLoaderBinary::load(const String &p_path, const String &p_origi
 	String path = !p_original_path.is_empty() ? p_original_path : p_path;
 	loader.local_path = ProjectSettings::get_singleton()->localize_path(path);
 	loader.res_path = loader.local_path;
-	//loader.set_local_path( Globals::get_singleton()->localize_path(p_path) );
 	loader.open(f);
 
 	err = loader.load();
@@ -1086,17 +1085,14 @@ void ResourceFormatLoaderBinary::get_dependencies(const String &p_path, List<Str
 	ResourceLoaderBinary loader;
 	loader.local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	loader.res_path = loader.local_path;
-	//loader.set_local_path( Globals::get_singleton()->localize_path(p_path) );
 	loader.get_dependencies(f, p_dependencies, p_add_types);
 }
 
 Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, const Map<String, String> &p_map) {
-	//Error error=OK;
-
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
 	ERR_FAIL_COND_V_MSG(!f, ERR_CANT_OPEN, "Cannot open file '" + p_path + "'.");
 
-	FileAccess *fw = nullptr; //=FileAccess::open(p_path+".depren");
+	FileAccess *fw = nullptr;
 
 	String local_path = p_path.get_base_dir();
 
@@ -1158,10 +1154,12 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 	if (ver_format < FORMAT_VERSION_CAN_RENAME_DEPS) {
 		memdelete(f);
 		memdelete(fw);
-		DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-		da->remove(p_path + ".depren");
-		memdelete(da);
-		//use the old approach
+		{
+			DirAccessRef da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+			da->remove(p_path + ".depren");
+		}
+
+		// Use the old approach.
 
 		WARN_PRINT("This file is old, so it can't refactor dependencies, opening and resaving '" + p_path + "'.");
 
@@ -1174,7 +1172,6 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		loader.local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 		loader.res_path = loader.local_path;
 		loader.remaps = p_map;
-		//loader.set_local_path( Globals::get_singleton()->localize_path(p_path) );
 		loader.open(f);
 
 		err = loader.load();
@@ -1304,10 +1301,9 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		return ERR_CANT_CREATE;
 	}
 
-	DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	da->remove(p_path);
 	da->rename(p_path + ".depren", p_path);
-	memdelete(da);
 	return OK;
 }
 
@@ -1320,7 +1316,6 @@ String ResourceFormatLoaderBinary::get_resource_type(const String &p_path) const
 	ResourceLoaderBinary loader;
 	loader.local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	loader.res_path = loader.local_path;
-	//loader.set_local_path( Globals::get_singleton()->localize_path(p_path) );
 	String r = loader.recognize(f);
 	return ClassDB::get_compatibility_remapped_class(r);
 }
@@ -1339,7 +1334,6 @@ ResourceUID::ID ResourceFormatLoaderBinary::get_resource_uid(const String &p_pat
 	ResourceLoaderBinary loader;
 	loader.local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	loader.res_path = loader.local_path;
-	//loader.set_local_path( Globals::get_singleton()->localize_path(p_path) );
 	loader.open(f, true);
 	if (loader.error != OK) {
 		return ResourceUID::INVALID_ID; //could not read

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -328,17 +328,13 @@ void OS::yield() {
 
 void OS::ensure_user_data_dir() {
 	String dd = get_user_data_dir();
-	DirAccess *da = DirAccess::open(dd);
-	if (da) {
-		memdelete(da);
+	if (DirAccess::exists(dd)) {
 		return;
 	}
 
-	da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	Error err = da->make_dir_recursive(dd);
 	ERR_FAIL_COND_MSG(err != OK, "Error attempting to create data dir: " + dd + ".");
-
-	memdelete(da);
 }
 
 String OS::get_model_name() const {

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -749,12 +749,11 @@ void OrphanResourcesDialog::_find_to_delete(TreeItem *p_item, List<String> &path
 }
 
 void OrphanResourcesDialog::_delete_confirm() {
-	DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	for (const String &E : paths) {
 		da->remove(E);
 		EditorFileSystem::get_singleton()->update_file(E);
 	}
-	memdelete(da);
 	refresh();
 }
 

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -277,10 +277,8 @@ void EditorAssetInstaller::ok_pressed() {
 					dirpath = dirpath.substr(0, dirpath.length() - 1);
 				}
 
-				DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+				DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 				da->make_dir(dirpath);
-				memdelete(da);
-
 			} else {
 				Vector<uint8_t> data;
 				data.resize(info.uncompressed_size);

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -1094,12 +1094,11 @@ void EditorFileSystem::_delete_internal_files(String p_file) {
 	if (FileAccess::exists(p_file + ".import")) {
 		List<String> paths;
 		ResourceFormatImporter::get_singleton()->get_internal_resource_path_list(p_file, &paths);
-		DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		for (const String &E : paths) {
 			da->remove(E);
 		}
 		da->remove(p_file + ".import");
-		memdelete(da);
 	}
 }
 

--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -174,7 +174,7 @@ Ref<FontData> load_cached_internal_font(const uint8_t *p_data, size_t p_size, Te
 }
 
 void editor_register_fonts(Ref<Theme> p_theme) {
-	DirAccess *dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	DirAccessRef dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 
 	/* Custom font */
 
@@ -235,8 +235,6 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 	} else {
 		EditorSettings::get_singleton()->set_manually("interface/editor/code_font", "");
 	}
-
-	memdelete(dir);
 
 	/* Noto Sans */
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1222,7 +1222,7 @@ bool EditorSettings::is_dark_theme() {
 void EditorSettings::list_text_editor_themes() {
 	String themes = "Default,Godot 2,Custom";
 
-	DirAccess *d = DirAccess::open(get_text_editor_themes_dir());
+	DirAccessRef d = DirAccess::open(get_text_editor_themes_dir());
 	if (d) {
 		List<String> custom_themes;
 		d->list_dir_begin();
@@ -1234,7 +1234,6 @@ void EditorSettings::list_text_editor_themes() {
 			file = d->get_next();
 		}
 		d->list_dir_end();
-		memdelete(d);
 
 		custom_themes.sort();
 		for (const String &E : custom_themes) {
@@ -1289,10 +1288,9 @@ bool EditorSettings::import_text_editor_theme(String p_file) {
 			return false;
 		}
 
-		DirAccess *d = DirAccess::open(get_text_editor_themes_dir());
+		DirAccessRef d = DirAccess::open(get_text_editor_themes_dir());
 		if (d) {
 			d->copy(p_file, get_text_editor_themes_dir().plus_file(p_file.get_file()));
-			memdelete(d);
 			return true;
 		}
 	}
@@ -1342,7 +1340,7 @@ Vector<String> EditorSettings::get_script_templates(const String &p_extension, c
 	if (!p_custom_path.is_empty()) {
 		template_dir = p_custom_path;
 	}
-	DirAccess *d = DirAccess::open(template_dir);
+	DirAccessRef d = DirAccess::open(template_dir);
 	if (d) {
 		d->list_dir_begin();
 		String file = d->get_next();
@@ -1353,7 +1351,6 @@ Vector<String> EditorSettings::get_script_templates(const String &p_extension, c
 			file = d->get_next();
 		}
 		d->list_dir_end();
-		memdelete(d);
 	}
 	return templates;
 }

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -44,7 +44,7 @@
 
 void ExportTemplateManager::_update_template_status() {
 	// Fetch installed templates from the file system.
-	DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	const String &templates_dir = EditorSettings::get_singleton()->get_templates_dir();
 
 	Error err = da->change_dir(templates_dir);
@@ -62,7 +62,6 @@ void ExportTemplateManager::_update_template_status() {
 		}
 	}
 	da->list_dir_end();
-	memdelete(da);
 
 	// Update the state of the current version.
 	String current_version = VERSION_FULL_CONFIG;

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -50,7 +50,7 @@ void PluginConfigDialog::_on_confirmed() {
 	String path = "res://addons/" + subfolder_edit->get_text();
 
 	if (!_edit_mode) {
-		DirAccess *d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		DirAccessRef d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		if (!d || d->make_dir_recursive(path) != OK) {
 			return;
 		}

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -147,7 +147,7 @@ private:
 	}
 
 	String _test_path() {
-		DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		DirAccessRef d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 		String valid_path, valid_install_path;
 		if (d->change_dir(project_path->get_text()) == OK) {
 			valid_path = project_path->get_text();
@@ -165,7 +165,6 @@ private:
 
 		if (valid_path.is_empty()) {
 			set_message(TTR("The path specified doesn't exist."), MESSAGE_ERROR);
-			memdelete(d);
 			get_ok_button()->set_disabled(true);
 			return "";
 		}
@@ -179,7 +178,6 @@ private:
 
 			if (valid_install_path.is_empty()) {
 				set_message(TTR("The path specified doesn't exist."), MESSAGE_ERROR, INSTALL_PATH);
-				memdelete(d);
 				get_ok_button()->set_disabled(true);
 				return "";
 			}
@@ -194,7 +192,6 @@ private:
 					unzFile pkg = unzOpen2(valid_path.utf8().get_data(), &io);
 					if (!pkg) {
 						set_message(TTR("Error opening package file (it's not in ZIP format)."), MESSAGE_ERROR);
-						memdelete(d);
 						get_ok_button()->set_disabled(true);
 						unzClose(pkg);
 						return "";
@@ -215,7 +212,6 @@ private:
 
 					if (ret == UNZ_END_OF_LIST_OF_FILE) {
 						set_message(TTR("Invalid \".zip\" project file; it doesn't contain a \"project.godot\" file."), MESSAGE_ERROR);
-						memdelete(d);
 						get_ok_button()->set_disabled(true);
 						unzClose(pkg);
 						return "";
@@ -242,14 +238,12 @@ private:
 
 					if (!is_folder_empty) {
 						set_message(TTR("Please choose an empty folder."), MESSAGE_WARNING, INSTALL_PATH);
-						memdelete(d);
 						get_ok_button()->set_disabled(true);
 						return "";
 					}
 
 				} else {
 					set_message(TTR("Please choose a \"project.godot\" or \".zip\" file."), MESSAGE_ERROR);
-					memdelete(d);
 					install_path_container->hide();
 					get_ok_button()->set_disabled(true);
 					return "";
@@ -257,7 +251,6 @@ private:
 
 			} else if (valid_path.ends_with("zip")) {
 				set_message(TTR("This directory already contains a Godot project."), MESSAGE_ERROR, INSTALL_PATH);
-				memdelete(d);
 				get_ok_button()->set_disabled(true);
 				return "";
 			}
@@ -282,7 +275,6 @@ private:
 
 			if (!is_folder_empty) {
 				set_message(TTR("The selected path is not empty. Choosing an empty folder is highly recommended."), MESSAGE_WARNING);
-				memdelete(d);
 				get_ok_button()->set_disabled(false);
 				return valid_path;
 			}
@@ -290,7 +282,6 @@ private:
 
 		set_message("");
 		set_message("", MESSAGE_SUCCESS, INSTALL_PATH);
-		memdelete(d);
 		get_ok_button()->set_disabled(false);
 		return valid_path;
 	}
@@ -389,7 +380,7 @@ private:
 			return;
 		}
 
-		DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		DirAccessRef d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 		if (d->change_dir(project_path->get_text()) == OK) {
 			if (!d->dir_exists(project_name_no_edges)) {
 				if (d->make_dir(project_name_no_edges) == OK) {
@@ -408,8 +399,6 @@ private:
 				dialog_error->popup_centered();
 			}
 		}
-
-		memdelete(d);
 	}
 
 	void _text_changed(const String &p_text) {
@@ -551,14 +540,11 @@ private:
 						if (path.is_empty() || path == zip_root || !zip_root.is_subsequence_of(path)) {
 							//
 						} else if (path.ends_with("/")) { // a dir
-
 							path = path.substr(0, path.length() - 1);
 							String rel_path = path.substr(zip_root.length());
 
-							DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+							DirAccessRef da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 							da->make_dir(dir.plus_file(rel_path));
-							memdelete(da);
-
 						} else {
 							Vector<uint8_t> data;
 							data.resize(info.uncompressed_size);
@@ -620,9 +606,8 @@ private:
 
 	void _remove_created_folder() {
 		if (!created_folder_path.is_empty()) {
-			DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+			DirAccessRef d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 			d->remove(created_folder_path);
-			memdelete(d);
 
 			create_dir->set_disabled(false);
 			created_folder_path = "";
@@ -725,10 +710,9 @@ public:
 				project_path->set_text(fav_dir);
 				fdialog->set_current_dir(fav_dir);
 			} else {
-				DirAccess *d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+				DirAccessRef d = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 				project_path->set_text(d->get_current_dir());
 				fdialog->set_current_dir(d->get_current_dir());
-				memdelete(d);
 			}
 			String proj = TTR("New Game Project");
 			project_name->set_text(proj);
@@ -2411,12 +2395,11 @@ void ProjectManager::_files_dropped(PackedStringArray p_files, int p_screen) {
 		return;
 	}
 	Set<String> folders_set;
-	DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	for (int i = 0; i < p_files.size(); i++) {
 		String file = p_files[i];
 		folders_set.insert(da->dir_exists(file) ? file : file.get_base_dir());
 	}
-	memdelete(da);
 	if (folders_set.size() > 0) {
 		PackedStringArray folders;
 		for (Set<String>::Element *E = folders_set.front(); E; E = E->next()) {
@@ -2425,7 +2408,7 @@ void ProjectManager::_files_dropped(PackedStringArray p_files, int p_screen) {
 
 		bool confirm = true;
 		if (folders.size() == 1) {
-			DirAccess *dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+			DirAccessRef dir = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 			if (dir->change_dir(folders[0]) == OK) {
 				dir->list_dir_begin();
 				String file = dir->get_next();
@@ -2437,7 +2420,6 @@ void ProjectManager::_files_dropped(PackedStringArray p_files, int p_screen) {
 				}
 				dir->list_dir_end();
 			}
-			memdelete(dir);
 		}
 		if (confirm) {
 			multi_scan_ask->get_ok_button()->disconnect("pressed", callable_mp(this, &ProjectManager::_scan_multiple_folders));

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -247,23 +247,22 @@ String ScriptCreateDialog::_validate_path(const String &p_path, bool p_file_must
 		return TTR("Path is not local.");
 	}
 
-	DirAccess *d = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	if (d->change_dir(p.get_base_dir()) != OK) {
-		memdelete(d);
-		return TTR("Base path is invalid.");
+	{
+		DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		if (da->change_dir(p.get_base_dir()) != OK) {
+			return TTR("Base path is invalid.");
+		}
 	}
-	memdelete(d);
 
-	// Check if file exists.
-	DirAccess *f = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	if (f->dir_exists(p)) {
-		memdelete(f);
-		return TTR("A directory with the same name exists.");
-	} else if (p_file_must_exist && !f->file_exists(p)) {
-		memdelete(f);
-		return TTR("File does not exist.");
+	{
+		// Check if file exists.
+		DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		if (da->dir_exists(p)) {
+			return TTR("A directory with the same name exists.");
+		} else if (p_file_must_exist && !da->file_exists(p)) {
+			return TTR("File does not exist.");
+		}
 	}
-	memdelete(f);
 
 	// Check file extension.
 	String extension = p.get_extension();
@@ -556,13 +555,12 @@ void ScriptCreateDialog::_path_changed(const String &p_path) {
 	}
 
 	// Check if file exists.
-	DirAccess *f = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	String p = ProjectSettings::get_singleton()->localize_path(p_path.strip_edges());
-	if (f->file_exists(p)) {
+	if (da->file_exists(p)) {
 		is_new_script_created = false;
 		_msg_path_valid(true, TTR("File exists, it will be reused."));
 	}
-	memdelete(f);
 
 	is_path_valid = true;
 	_update_dialog();
@@ -838,7 +836,7 @@ Vector<ScriptLanguage::ScriptTemplate> ScriptCreateDialog::_get_user_templates(c
 
 	String dir_path = p_dir.plus_file(p_object);
 
-	DirAccess *d = DirAccess::open(dir_path);
+	DirAccessRef d = DirAccess::open(dir_path);
 	if (d) {
 		d->list_dir_begin();
 		String file = d->get_next();
@@ -849,7 +847,6 @@ Vector<ScriptLanguage::ScriptTemplate> ScriptCreateDialog::_get_user_templates(c
 			file = d->get_next();
 		}
 		d->list_dir_end();
-		memdelete(d);
 	}
 	return user_templates;
 }

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2099,9 +2099,8 @@ bool Main::start() {
 				checked_paths.insert(path);
 
 				// Create the module documentation directory if it doesn't exist
-				DirAccess *da = DirAccess::create_for_path(path);
+				DirAccessRef da = DirAccess::create_for_path(path);
 				err = da->make_dir_recursive(path);
-				memdelete(da);
 				ERR_FAIL_COND_V_MSG(err != OK, false, "Error: Can't create directory: " + path + ": " + itos(err));
 
 				print_line("Loading docs from: " + path);
@@ -2112,9 +2111,8 @@ bool Main::start() {
 
 		String index_path = doc_tool_path.plus_file("doc/classes");
 		// Create the main documentation directory if it doesn't exist
-		DirAccess *da = DirAccess::create_for_path(index_path);
+		DirAccessRef da = DirAccess::create_for_path(index_path);
 		err = da->make_dir_recursive(index_path);
-		memdelete(da);
 		ERR_FAIL_COND_V_MSG(err != OK, false, "Error: Can't create index directory: " + index_path + ": " + itos(err));
 
 		print_line("Loading classes from: " + index_path);
@@ -2452,15 +2450,13 @@ bool Main::start() {
 						int sep = local_game_path.rfind("/");
 
 						if (sep == -1) {
-							DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+							DirAccessRef da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 							local_game_path = da->get_current_dir().plus_file(local_game_path);
-							memdelete(da);
 						} else {
-							DirAccess *da = DirAccess::open(local_game_path.substr(0, sep));
+							DirAccessRef da = DirAccess::open(local_game_path.substr(0, sep));
 							if (da) {
 								local_game_path = da->get_current_dir().plus_file(
 										local_game_path.substr(sep + 1, local_game_path.length()));
-								memdelete(da);
 							}
 						}
 					}

--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -643,9 +643,8 @@ bool GDMono::copy_prebuilt_api_assembly(ApiAssemblyInfo::Type p_api_type, const 
 
 	// Create destination directory if needed
 	if (!DirAccess::exists(dst_dir)) {
-		DirAccess *da = DirAccess::create_for_path(dst_dir);
+		DirAccessRef da = DirAccess::create_for_path(dst_dir);
 		Error err = da->make_dir_recursive(dst_dir);
-		memdelete(da);
 
 		if (err != OK) {
 			ERR_PRINT("Failed to create destination directory for the API assemblies. Error: " + itos(err) + ".");

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -75,11 +75,10 @@ String _get_android_orientation_label(DisplayServer::ScreenOrientation screen_or
 // Utility method used to create a directory.
 Error create_directory(const String &p_dir) {
 	if (!DirAccess::exists(p_dir)) {
-		DirAccess *filesystem_da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+		DirAccessRef filesystem_da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 		ERR_FAIL_COND_V_MSG(!filesystem_da, ERR_CANT_CREATE, "Cannot create directory '" + p_dir + "'.");
 		Error err = filesystem_da->make_dir_recursive(p_dir);
 		ERR_FAIL_COND_V_MSG(err, ERR_CANT_CREATE, "Cannot create directory '" + p_dir + "'.");
-		memdelete(filesystem_da);
 	}
 	return OK;
 }

--- a/platform/iphone/export/export_plugin.cpp
+++ b/platform/iphone/export/export_plugin.cpp
@@ -534,7 +534,7 @@ Error EditorExportPlatformIOS::_export_icons(const Ref<EditorExportPreset> &p_pr
 	String json_description = "{\"images\":[";
 	String sizes;
 
-	DirAccess *da = DirAccess::open(p_iconset_dir);
+	DirAccessRef da = DirAccess::open(p_iconset_dir);
 	ERR_FAIL_COND_V_MSG(!da, ERR_CANT_OPEN, "Cannot open directory '" + p_iconset_dir + "'.");
 
 	for (uint64_t i = 0; i < (sizeof(icon_infos) / sizeof(icon_infos[0])); ++i) {
@@ -574,7 +574,6 @@ Error EditorExportPlatformIOS::_export_icons(const Ref<EditorExportPreset> &p_pr
 			}
 
 			if (err) {
-				memdelete(da);
 				String err_str = String("Failed to export icon(" + String(info.preset_key) + "): '" + icon_path + "'.");
 				ERR_PRINT(err_str.utf8().get_data());
 				return err;
@@ -592,7 +591,6 @@ Error EditorExportPlatformIOS::_export_icons(const Ref<EditorExportPreset> &p_pr
 		json_description += String("}");
 	}
 	json_description += "]}";
-	memdelete(da);
 
 	FileAccess *json_file = FileAccess::open(p_iconset_dir + "Contents.json", FileAccess::WRITE);
 	ERR_FAIL_COND_V(!json_file, ERR_CANT_CREATE);
@@ -678,7 +676,7 @@ Error EditorExportPlatformIOS::_export_loading_screen_file(const Ref<EditorExpor
 }
 
 Error EditorExportPlatformIOS::_export_loading_screen_images(const Ref<EditorExportPreset> &p_preset, const String &p_dest_dir) {
-	DirAccess *da = DirAccess::open(p_dest_dir);
+	DirAccessRef da = DirAccess::open(p_dest_dir);
 	ERR_FAIL_COND_V_MSG(!da, ERR_CANT_OPEN, "Cannot open directory '" + p_dest_dir + "'.");
 
 	for (uint64_t i = 0; i < sizeof(loading_screen_infos) / sizeof(loading_screen_infos[0]); ++i) {
@@ -716,7 +714,6 @@ Error EditorExportPlatformIOS::_export_loading_screen_images(const Ref<EditorExp
 				err = da->copy(loading_screen_file, p_dest_dir + info.export_name);
 			}
 			if (err) {
-				memdelete(da);
 				String err_str = String("Failed to export loading screen (") + info.preset_key + ") from path '" + loading_screen_file + "'.";
 				ERR_PRINT(err_str.utf8().get_data());
 				return err;
@@ -764,7 +761,6 @@ Error EditorExportPlatformIOS::_export_loading_screen_images(const Ref<EditorExp
 			}
 		}
 	}
-	memdelete(da);
 
 	return OK;
 }
@@ -970,21 +966,15 @@ void EditorExportPlatformIOS::_add_assets_to_project(const Ref<EditorExportPrese
 }
 
 Error EditorExportPlatformIOS::_copy_asset(const String &p_out_dir, const String &p_asset, const String *p_custom_file_name, bool p_is_framework, bool p_should_embed, Vector<IOSExportAsset> &r_exported_assets) {
-	DirAccess *filesystem_da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	ERR_FAIL_COND_V_MSG(!filesystem_da, ERR_CANT_CREATE, "Cannot create DirAccess for path '" + p_out_dir + "'.");
-
 	String binary_name = p_out_dir.get_file().get_basename();
 
-	DirAccess *da = DirAccess::create_for_path(p_asset);
+	DirAccessRef da = DirAccess::create_for_path(p_asset);
 	if (!da) {
-		memdelete(filesystem_da);
 		ERR_FAIL_V_MSG(ERR_CANT_CREATE, "Can't create directory: " + p_asset + ".");
 	}
 	bool file_exists = da->file_exists(p_asset);
 	bool dir_exists = da->dir_exists(p_asset);
 	if (!file_exists && !dir_exists) {
-		memdelete(da);
-		memdelete(filesystem_da);
 		return ERR_FILE_NOT_FOUND;
 	}
 
@@ -1044,19 +1034,18 @@ Error EditorExportPlatformIOS::_copy_asset(const String &p_out_dir, const String
 		destination = p_out_dir.plus_file(asset_path);
 	}
 
+	DirAccessRef filesystem_da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	ERR_FAIL_COND_V_MSG(!filesystem_da, ERR_CANT_CREATE, "Cannot create DirAccess for path '" + p_out_dir + "'.");
+
 	if (!filesystem_da->dir_exists(destination_dir)) {
 		Error make_dir_err = filesystem_da->make_dir_recursive(destination_dir);
 		if (make_dir_err) {
-			memdelete(da);
-			memdelete(filesystem_da);
 			return make_dir_err;
 		}
 	}
 
 	Error err = dir_exists ? da->copy_dir(p_asset, destination) : da->copy(p_asset, destination);
-	memdelete(da);
 	if (err) {
-		memdelete(filesystem_da);
 		return err;
 	}
 	IOSExportAsset exported_asset = { binary_name.plus_file(asset_path), p_is_framework, p_should_embed };
@@ -1120,8 +1109,6 @@ Error EditorExportPlatformIOS::_copy_asset(const String &p_out_dir, const String
 			}
 		}
 	}
-
-	memdelete(filesystem_da);
 
 	return OK;
 }
@@ -1427,29 +1414,29 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 		return ERR_FILE_BAD_PATH;
 	}
 
-	DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	if (da) {
-		String current_dir = da->get_current_dir();
+	{
+		DirAccessRef da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		if (da) {
+			String current_dir = da->get_current_dir();
 
-		// remove leftovers from last export so they don't interfere
-		// in case some files are no longer needed
-		if (da->change_dir(dest_dir + binary_name + ".xcodeproj") == OK) {
-			da->erase_contents_recursive();
-		}
-		if (da->change_dir(dest_dir + binary_name) == OK) {
-			da->erase_contents_recursive();
-		}
+			// remove leftovers from last export so they don't interfere
+			// in case some files are no longer needed
+			if (da->change_dir(dest_dir + binary_name + ".xcodeproj") == OK) {
+				da->erase_contents_recursive();
+			}
+			if (da->change_dir(dest_dir + binary_name) == OK) {
+				da->erase_contents_recursive();
+			}
 
-		da->change_dir(current_dir);
+			da->change_dir(current_dir);
 
-		if (!da->dir_exists(dest_dir + binary_name)) {
-			Error err = da->make_dir(dest_dir + binary_name);
-			if (err) {
-				memdelete(da);
-				return err;
+			if (!da->dir_exists(dest_dir + binary_name)) {
+				Error err = da->make_dir(dest_dir + binary_name);
+				if (err) {
+					return err;
+				}
 			}
 		}
-		memdelete(da);
 	}
 
 	if (ep.step("Making .pck", 0)) {
@@ -1507,7 +1494,7 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 
 	Vector<IOSExportAsset> assets;
 
-	DirAccess *tmp_app_path = DirAccess::create_for_path(dest_dir);
+	DirAccessRef tmp_app_path = DirAccess::create_for_path(dest_dir);
 	ERR_FAIL_COND_V(!tmp_app_path, ERR_CANT_CREATE);
 
 	print_line("Unzipping...");
@@ -1586,7 +1573,6 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 				if (dir_err) {
 					ERR_PRINT("Can't create '" + dir_name + "'.");
 					unzClose(src_pkg_zip);
-					memdelete(tmp_app_path);
 					return ERR_CANT_CREATE;
 				}
 			}
@@ -1596,7 +1582,6 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 			if (!f) {
 				ERR_PRINT("Can't write '" + file + "'.");
 				unzClose(src_pkg_zip);
-				memdelete(tmp_app_path);
 				return ERR_CANT_CREATE;
 			};
 			f->store_buffer(data.ptr(), data.size());
@@ -1619,7 +1604,6 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 
 	if (!found_library) {
 		ERR_PRINT("Requested template library '" + library_to_use + "' not found. It might be missing from your template archive.");
-		memdelete(tmp_app_path);
 		return ERR_FILE_NOT_FOUND;
 	}
 
@@ -1656,7 +1640,6 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 			Error lib_copy_err = tmp_app_path->copy(static_lib_path, dest_lib_file_path);
 			if (lib_copy_err != OK) {
 				ERR_PRINT("Can't copy '" + static_lib_path + "'.");
-				memdelete(tmp_app_path);
 				return lib_copy_err;
 			}
 		}
@@ -1667,7 +1650,6 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 	if (!tmp_app_path->dir_exists(iconset_dir)) {
 		err = tmp_app_path->make_dir_recursive(iconset_dir);
 	}
-	memdelete(tmp_app_path);
 	if (err) {
 		return err;
 	}
@@ -1677,42 +1659,42 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 		return err;
 	}
 
-	bool use_storyboard = p_preset->get("storyboard/use_launch_screen_storyboard");
+	{
+		bool use_storyboard = p_preset->get("storyboard/use_launch_screen_storyboard");
 
-	String launch_image_path = dest_dir + binary_name + "/Images.xcassets/LaunchImage.launchimage/";
-	String splash_image_path = dest_dir + binary_name + "/Images.xcassets/SplashImage.imageset/";
+		String launch_image_path = dest_dir + binary_name + "/Images.xcassets/LaunchImage.launchimage/";
+		String splash_image_path = dest_dir + binary_name + "/Images.xcassets/SplashImage.imageset/";
 
-	DirAccess *launch_screen_da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		DirAccessRef launch_screen_da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 
-	if (!launch_screen_da) {
-		return ERR_CANT_CREATE;
-	}
-
-	if (use_storyboard) {
-		print_line("Using Launch Storyboard");
-
-		if (launch_screen_da->change_dir(launch_image_path) == OK) {
-			launch_screen_da->erase_contents_recursive();
-			launch_screen_da->remove(launch_image_path);
+		if (!launch_screen_da) {
+			return ERR_CANT_CREATE;
 		}
 
-		err = _export_loading_screen_file(p_preset, splash_image_path);
-	} else {
-		print_line("Using Launch Images");
+		if (use_storyboard) {
+			print_line("Using Launch Storyboard");
 
-		const String launch_screen_path = dest_dir + binary_name + "/Launch Screen.storyboard";
+			if (launch_screen_da->change_dir(launch_image_path) == OK) {
+				launch_screen_da->erase_contents_recursive();
+				launch_screen_da->remove(launch_image_path);
+			}
 
-		launch_screen_da->remove(launch_screen_path);
+			err = _export_loading_screen_file(p_preset, splash_image_path);
+		} else {
+			print_line("Using Launch Images");
 
-		if (launch_screen_da->change_dir(splash_image_path) == OK) {
-			launch_screen_da->erase_contents_recursive();
-			launch_screen_da->remove(splash_image_path);
+			const String launch_screen_path = dest_dir + binary_name + "/Launch Screen.storyboard";
+
+			launch_screen_da->remove(launch_screen_path);
+
+			if (launch_screen_da->change_dir(splash_image_path) == OK) {
+				launch_screen_da->erase_contents_recursive();
+				launch_screen_da->remove(splash_image_path);
+			}
+
+			err = _export_loading_screen_images(p_preset, launch_image_path);
 		}
-
-		err = _export_loading_screen_images(p_preset, launch_image_path);
 	}
-
-	memdelete(launch_screen_da);
 
 	if (err) {
 		return err;
@@ -1732,15 +1714,17 @@ Error EditorExportPlatformIOS::export_project(const Ref<EditorExportPreset> &p_p
 	memdelete(f);
 
 #ifdef OSX_ENABLED
-	if (ep.step("Code-signing dylibs", 2)) {
-		return ERR_SKIP;
+	{
+		if (ep.step("Code-signing dylibs", 2)) {
+			return ERR_SKIP;
+		}
+		DirAccess *dylibs_dir = DirAccess::open(dest_dir + binary_name + "/dylibs");
+		ERR_FAIL_COND_V(!dylibs_dir, ERR_CANT_OPEN);
+		CodesignData codesign_data(p_preset, p_debug);
+		err = _walk_dir_recursive(dylibs_dir, _codesign, &codesign_data);
+		memdelete(dylibs_dir);
+		ERR_FAIL_COND_V(err, err);
 	}
-	DirAccess *dylibs_dir = DirAccess::open(dest_dir + binary_name + "/dylibs");
-	ERR_FAIL_COND_V(!dylibs_dir, ERR_CANT_OPEN);
-	CodesignData codesign_data(p_preset, p_debug);
-	err = _walk_dir_recursive(dylibs_dir, _codesign, &codesign_data);
-	memdelete(dylibs_dir);
-	ERR_FAIL_COND_V(err, err);
 
 	if (ep.step("Making .xcarchive", 3)) {
 		return ERR_SKIP;

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -259,11 +259,9 @@ Error OSIPhone::shell_open(String p_uri) {
 }
 
 void OSIPhone::set_user_data_dir(String p_dir) {
-	DirAccess *da = DirAccess::open(p_dir);
-
+	DirAccessRef da = DirAccess::open(p_dir);
 	user_data_dir = da->get_current_dir();
 	printf("setting data dir to %s from %s\n", user_data_dir.utf8().get_data(), p_dir.utf8().get_data());
-	memdelete(da);
 }
 
 String OSIPhone::get_user_data_dir() const {

--- a/platform/javascript/api/javascript_tools_editor_plugin.cpp
+++ b/platform/javascript/api/javascript_tools_editor_plugin.cpp
@@ -124,7 +124,7 @@ void JavaScriptToolsEditorPlugin::_zip_file(String p_path, String p_base_path, z
 }
 
 void JavaScriptToolsEditorPlugin::_zip_recursive(String p_path, String p_base_path, zipFile p_zip) {
-	DirAccess *dir = DirAccess::open(p_path);
+	DirAccessRef dir = DirAccess::open(p_path);
 	if (!dir) {
 		WARN_PRINT("Unable to open directory for zipping: " + p_path);
 		return;

--- a/platform/javascript/export/export_plugin.cpp
+++ b/platform/javascript/export/export_plugin.cpp
@@ -252,7 +252,7 @@ Error EditorExportPlatformJavaScript::_build_pwa(const Ref<EditorExportPreset> &
 	// Custom offline page
 	const String offline_page = p_preset->get("progressive_web_app/offline_page");
 	if (!offline_page.is_empty()) {
-		DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		DirAccessRef da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 		const String offline_dest = dir.plus_file(name + ".offline.html");
 		err = da->copy(ProjectSettings::get_singleton()->globalize_path(offline_page), offline_dest);
 		if (err != OK) {
@@ -445,18 +445,18 @@ Error EditorExportPlatformJavaScript::export_project(const Ref<EditorExportPrese
 		EditorNode::get_singleton()->show_warning(TTR("Could not write file:") + "\n" + pck_path);
 		return error;
 	}
-	DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
-	for (int i = 0; i < shared_objects.size(); i++) {
-		String dst = base_dir.plus_file(shared_objects[i].path.get_file());
-		error = da->copy(shared_objects[i].path, dst);
-		if (error != OK) {
-			EditorNode::get_singleton()->show_warning(TTR("Could not write file:") + "\n" + shared_objects[i].path.get_file());
-			memdelete(da);
-			return error;
+
+	{
+		DirAccessRef da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+		for (int i = 0; i < shared_objects.size(); i++) {
+			String dst = base_dir.plus_file(shared_objects[i].path.get_file());
+			error = da->copy(shared_objects[i].path, dst);
+			if (error != OK) {
+				EditorNode::get_singleton()->show_warning(TTR("Could not write file:") + "\n" + shared_objects[i].path.get_file());
+				return error;
+			}
 		}
 	}
-	memdelete(da);
-	da = nullptr;
 
 	// Extract templates.
 	error = _extract_template(template_path, base_dir, base_name, pwa);

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -535,9 +535,8 @@ Error OS_LinuxBSD::move_to_trash(const String &p_path) {
 		// Issue an error if "mv" failed to move the given resource to the trash can.
 		if (err != OK || retval != 0) {
 			ERR_PRINT("move_to_trash: Could not move the resource \"" + path + "\" to the trash can \"" + trash_path + "/files\"");
-			DirAccess *dir_access = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+			DirAccessRef dir_access = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 			err = dir_access->rename(renamed_path, path);
-			memdelete(dir_access);
 			ERR_FAIL_COND_V_MSG(err != OK, err, "Could not rename \"" + renamed_path + "\" back to its original name: \"" + path + "\"");
 			return FAILED;
 		}

--- a/platform/osx/export/codesign.cpp
+++ b/platform/osx/export/codesign.cpp
@@ -1208,7 +1208,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 	String id;
 	String main_exe = p_exe_path;
 
-	DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	if (!da) {
 		r_error_msg = TTR("Can't get filesystem access.");
 		ERR_FAIL_V_MSG(ERR_CANT_CREATE, "CodeSign: Can't get filesystem access.");
@@ -1522,7 +1522,7 @@ Error CodeSign::_codesign_file(bool p_use_hardened_runtime, bool p_force, const 
 }
 
 Error CodeSign::codesign(bool p_use_hardened_runtime, bool p_force, const String &p_path, const String &p_ent_path, String &r_error_msg) {
-	DirAccess *da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
+	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 	if (!da) {
 		r_error_msg = TTR("Can't get filesystem access.");
 		ERR_FAIL_V_MSG(ERR_CANT_CREATE, "CodeSign: Can't get filesystem access.");

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -70,7 +70,6 @@ private:
 
 	Button *makedir;
 	Access access = ACCESS_RESOURCES;
-	//Button *action;
 	VBoxContainer *vbox;
 	FileMode mode;
 	LineEdit *dir;

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -908,10 +908,9 @@ Error ResourceLoaderText::rename_dependencies(FileAccess *p_f, const String &p_p
 		return ERR_CANT_CREATE;
 	}
 
-	DirAccess *da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	da->remove(p_path);
 	da->rename(p_path + ".depren", p_path);
-	memdelete(da);
 
 	return OK;
 }


### PR DESCRIPTION
`DirAccess *` needs to be deleted manually, and this is often forgotten
especially when doing early returns with `ERR_FAIL_COND`.
`DirAccessRef` is deleted automatically when it goes out of scope.

~Adds move constructor and `operator=` to `DirAccessRef` to guarantee
that move operations will not incur double free.~

I'll do the same for `FileAccess *` in a follow-up.