### PR TITLE
Fix return type of limit_get()

### DIFF
--- a/drivers/vulkan/rendering_device_vulkan.cpp
+++ b/drivers/vulkan/rendering_device_vulkan.cpp
@@ -9295,7 +9295,7 @@ String RenderingDeviceVulkan::get_captured_timestamp_name(uint32_t p_index) cons
 	return frames[frame].timestamp_result_names[p_index];
 }
 
-int RenderingDeviceVulkan::limit_get(Limit p_limit) {
+uint64_t RenderingDeviceVulkan::limit_get(Limit p_limit) {
 	switch (p_limit) {
 		case LIMIT_MAX_BOUND_UNIFORM_SETS:
 			return limits.maxBoundDescriptorSets;

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -1203,7 +1203,7 @@ public:
 	/**** Limits ****/
 	/****************/
 
-	virtual int limit_get(Limit p_limit);
+	virtual uint64_t limit_get(Limit p_limit);
 
 	virtual void prepare_screen_for_drawing();
 	void initialize(VulkanContext *p_context, bool p_local_device = false);

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2257,7 +2257,7 @@ RendererCanvasRenderRD::RendererCanvasRenderRD(RendererStorageRD *p_storage) {
 
 		String global_defines;
 
-		uint32_t uniform_max_size = RD::get_singleton()->limit_get(RD::LIMIT_MAX_UNIFORM_BUFFER_SIZE);
+		uint64_t uniform_max_size = RD::get_singleton()->limit_get(RD::LIMIT_MAX_UNIFORM_BUFFER_SIZE);
 		if (uniform_max_size < 65536) {
 			//Yes, you guessed right, ARM again
 			state.max_lights_per_render = 64;

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -287,7 +287,7 @@ RendererCompositorRD::RendererCompositorRD() {
 	canvas = memnew(RendererCanvasRenderRD(storage));
 
 	back_end = (bool)(int)GLOBAL_GET("rendering/vulkan/rendering/back_end");
-	uint32_t textures_per_stage = RD::get_singleton()->limit_get(RD::LIMIT_MAX_TEXTURES_PER_SHADER_STAGE);
+	uint64_t textures_per_stage = RD::get_singleton()->limit_get(RD::LIMIT_MAX_TEXTURES_PER_SHADER_STAGE);
 
 	if (back_end || textures_per_stage < 48) {
 		scene = memnew(RendererSceneRenderImplementation::RenderForwardMobile(storage));

--- a/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
@@ -2453,7 +2453,7 @@ void RendererSceneGIRD::VoxelGIInstance::update(bool p_update_light_instances, c
 				passes = 1; //only re-blitting is necessary
 			}
 			int wg_size = 64;
-			int wg_limit_x = RD::get_singleton()->limit_get(RD::LIMIT_MAX_COMPUTE_WORKGROUP_COUNT_X);
+			uint64_t wg_limit_x = RD::get_singleton()->limit_get(RD::LIMIT_MAX_COMPUTE_WORKGROUP_COUNT_X);
 
 			for (int pass = 0; pass < passes; pass++) {
 				if (p_update_light_instances) {
@@ -2476,9 +2476,9 @@ void RendererSceneGIRD::VoxelGIInstance::update(bool p_update_light_instances, c
 						push_constant.cell_offset = mipmaps[i].cell_offset;
 						push_constant.cell_count = mipmaps[i].cell_count;
 
-						int wg_todo = (mipmaps[i].cell_count - 1) / wg_size + 1;
+						int64_t wg_todo = (mipmaps[i].cell_count - 1) / wg_size + 1;
 						while (wg_todo) {
-							int wg_count = MIN(wg_todo, wg_limit_x);
+							int64_t wg_count = MIN(wg_todo, wg_limit_x);
 							RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(VoxelGIPushConstant));
 							RD::get_singleton()->compute_list_dispatch(compute_list, wg_count, 1, 1);
 							wg_todo -= wg_count;
@@ -2497,9 +2497,9 @@ void RendererSceneGIRD::VoxelGIInstance::update(bool p_update_light_instances, c
 					push_constant.cell_offset = mipmaps[i].cell_offset;
 					push_constant.cell_count = mipmaps[i].cell_count;
 
-					int wg_todo = (mipmaps[i].cell_count - 1) / wg_size + 1;
+					int64_t wg_todo = (mipmaps[i].cell_count - 1) / wg_size + 1;
 					while (wg_todo) {
-						int wg_count = MIN(wg_todo, wg_limit_x);
+						int64_t wg_count = MIN(wg_todo, wg_limit_x);
 						RD::get_singleton()->compute_list_set_push_constant(compute_list, &push_constant, sizeof(VoxelGIPushConstant));
 						RD::get_singleton()->compute_list_dispatch(compute_list, wg_count, 1, 1);
 						wg_todo -= wg_count;

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -9962,7 +9962,7 @@ RendererStorageRD::RendererStorageRD() {
 
 	using_lightmap_array = true; // high end
 	if (using_lightmap_array) {
-		uint32_t textures_per_stage = RD::get_singleton()->limit_get(RD::LIMIT_MAX_TEXTURES_PER_SHADER_STAGE);
+		uint64_t textures_per_stage = RD::get_singleton()->limit_get(RD::LIMIT_MAX_TEXTURES_PER_SHADER_STAGE);
 
 		if (textures_per_stage <= 256) {
 			lightmap_textures.resize(32);

--- a/servers/rendering/rendering_device.h
+++ b/servers/rendering/rendering_device.h
@@ -1222,7 +1222,7 @@ public:
 		LIMIT_MAX_COMPUTE_WORKGROUP_SIZE_Z,
 	};
 
-	virtual int limit_get(Limit p_limit) = 0;
+	virtual uint64_t limit_get(Limit p_limit) = 0;
 
 	//methods below not exposed, used by RenderingDeviceRD
 	virtual void prepare_screen_for_drawing() = 0;

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -7483,8 +7483,8 @@ Error ShaderLanguage::_parse_shader(const Map<StringName, FunctionInfo> &p_funct
 	int uniforms = 0;
 	int instance_index = 0;
 #ifdef DEBUG_ENABLED
-	int uniform_buffer_size = 0;
-	int max_uniform_buffer_size = 0;
+	uint64_t uniform_buffer_size = 0;
+	uint64_t max_uniform_buffer_size = 0;
 	int uniform_buffer_exceeded_line = -1;
 
 	bool check_device_limit_warnings = false;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fix #58840 
The return type for `limit_get` in Vulkan renderer and base renderer class was set to int, whereas all return values are unsigned ints. This caused weird bugs like the one described in the linked bug report. This patch takes care of that.

The return types have been fixed to `uint64_t` and should not overflow/cause any weird issues.
