### PR TITLE
Update mouse cursor shape after changes

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2225,7 +2225,19 @@ void Control::_window_find_focus_neighbor(const Vector2 &p_dir, Node *p_at, cons
 void Control::set_default_cursor_shape(CursorShape p_shape) {
 	ERR_FAIL_INDEX(int(p_shape), CURSOR_MAX);
 
+	if (data.default_cursor == p_shape) {
+		return;
+	}
 	data.default_cursor = p_shape;
+
+	if (!is_inside_tree()) {
+		return;
+	}
+	if (!get_global_rect().has_point(get_global_mouse_position())) {
+		return;
+	}
+
+	get_viewport()->get_base_window()->update_mouse_cursor_shape();
 }
 
 Control::CursorShape Control::get_default_cursor_shape() const {

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1085,6 +1085,7 @@ void SceneTree::_change_scene(Node *p_to) {
 	if (p_to) {
 		current_scene = p_to;
 		root->add_child(p_to);
+		root->update_mouse_cursor_shape();
 	}
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1576,7 +1576,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 					gui.drag_preview_id = ObjectID();
 				}
 				_propagate_viewport_notification(this, NOTIFICATION_DRAG_END);
-				// Change mouse accordingly.
+				get_base_window()->update_mouse_cursor_shape();
 			}
 
 			_gui_cancel_tooltip();
@@ -1597,7 +1597,7 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				gui.dragging = false;
 				gui.drag_mouse_over = nullptr;
 				_propagate_viewport_notification(this, NOTIFICATION_DRAG_END);
-				// Change mouse accordingly.
+				get_base_window()->update_mouse_cursor_shape();
 			}
 
 			gui.mouse_focus_mask &= ~mouse_button_to_mask(mb->get_button_index()); // Remove from mask.

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -392,6 +392,18 @@ void Window::_event_callback(DisplayServer::WindowEvent p_event) {
 	}
 }
 
+void Window::update_mouse_cursor_shape() {
+	// The default shape is set in Viewport::_gui_input_event. To instantly
+	// see the shape in the viewport we need to trigger a mouse motion event.
+	Ref<InputEventMouseMotion> mm;
+	Vector2 pos = get_mouse_position();
+	Transform2D xform = get_global_canvas_transform().affine_inverse();
+	mm.instantiate();
+	mm->set_position(pos);
+	mm->set_global_position(xform.xform(pos));
+	push_input(mm);
+}
+
 void Window::show() {
 	set_visible(true);
 }

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -220,6 +220,8 @@ public:
 	void set_visible(bool p_visible);
 	bool is_visible() const;
 
+	void update_mouse_cursor_shape();
+
 	void show();
 	void hide();
 


### PR DESCRIPTION
resolves #45936
supersedes #58913

This fixes some cases where the mouse cursor shape did not change automatically, but instead required a MouseMove to update.

#58913 introduced a bug that caused a recursive call loop (#58960) for `AnimationTimelineEdit` and `AnimationTrackEditTypeAudio`, both of which change the default cursor shape on every mouse move event:

InputEventMouseMove -> set_default_cursor_shape() -> update_mouse_cursor_shape() -> InputEventMouseMove -> loop back

This patch makes sure that the recursion loop is broken in `Control::set_default_cursor_shape()`, which is a prudent safeguard.
I verified, that I can not reproduce #58960 with this patch.

A different alternative to resolve the recursive loop would be to not use `set_default_cursor_shape` during every mouse move in `AnimationTimelineEdit::gui_input` and `AnimationTrackEditTypeAudio::gui_input`.
It feels strange, that a MouseMove event would change the default cursor shape, since there is `Control::get_cursor_shape` for such cases, in which a Control-Node displays different cursor shapes.