### PR TITLE
Harmonize size terminology for HeightMapShape3D

### DIFF
--- a/doc/classes/HeightMapShape3D.xml
+++ b/doc/classes/HeightMapShape3D.xml
@@ -11,13 +11,13 @@
 	</tutorials>
 	<members>
 		<member name="map_data" type="PackedFloat32Array" setter="set_map_data" getter="get_map_data" default="PackedFloat32Array(0, 0, 0, 0)">
-			Height map data, pool array must be of [member map_width] * [member map_depth] size.
+			Height map data, pool array must be of ([member map_width] + 1) * ([member map_depth] + 1) size.
 		</member>
-		<member name="map_depth" type="int" setter="set_map_depth" getter="get_map_depth" default="2">
-			Depth of the height map data. Changing this will resize the [member map_data].
+		<member name="map_depth" type="int" setter="set_map_depth" getter="get_map_depth" default="1">
+			Depth of the height map data in spatial units. Changing this will resize the [member map_data].
 		</member>
-		<member name="map_width" type="int" setter="set_map_width" getter="get_map_width" default="2">
-			Width of the height map data. Changing this will resize the [member map_data].
+		<member name="map_width" type="int" setter="set_map_width" getter="get_map_width" default="1">
+			Width of the height map data in spatial units. Changing this will resize the [member map_data].
 		</member>
 	</members>
 </class>

--- a/scene/resources/height_map_shape_3d.h
+++ b/scene/resources/height_map_shape_3d.h
@@ -36,11 +36,13 @@
 class HeightMapShape3D : public Shape3D {
 	GDCLASS(HeightMapShape3D, Shape3D);
 
-	int map_width = 2;
-	int map_depth = 2;
-	Vector<real_t> map_data;
+	int map_width = 1;
+	int map_depth = 1;
+	Vector<real_t> map_data = { 0.0, 0.0, 0.0, 0.0 };
 	real_t min_height = 0.0;
 	real_t max_height = 0.0;
+
+	void _update_after_size_change(const int p_was_size);
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
resolve #58933

Previously `map_width` and `map_depth` denoted number of pixels in `HeightMapShape3D`.
This created confusion for users who interpreted them as size, because other Nodes use similar named properties for their size.

This PR changes the properties so that they denote size and not heightmap-pixels. It does not change, how heightmaps are stored and used within `PhysicsServer3D`.

Additional changes:
- Fix that `min_height` and `max_height` were not recalculated after changing width and depth.
- Make `get_enclosing_radius` calculation more precise
- Perform initialization in header

This PR breaks existing projects, that rely on the previous meaning.