### PR TITLE
Only uninitialise OpenXR on destruct if it was initialized

### DIFF
--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -760,8 +760,9 @@ OpenXRInterface::OpenXRInterface() {
 }
 
 OpenXRInterface::~OpenXRInterface() {
-	// should already have been called but just in case...
-	uninitialize();
+	if (is_initialized()) {
+		uninitialize();
+	}
 
 	if (openxr_api) {
 		openxr_api->set_xr_interface(nullptr);


### PR DESCRIPTION
The OpenXRInterface is constructed and added to the XRServer to make it available, when destructing it was calling it's uninitialise function to ensure all is cleaned up however if OpenXR was never even enabled that function gave some error spam.

Now only calling it if the OpenXRInterface was previously initialized to ensure it is only run when applicable.
