### PR TITLE
Remove unused code in `AnimationPlayerEditor::_update_animation_list_icons()`

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -897,11 +897,6 @@ void AnimationPlayerEditor::_update_player() {
 }
 
 void AnimationPlayerEditor::_update_animation_list_icons() {
-	List<StringName> animlist;
-	if (player) {
-		player->get_animation_list(&animlist);
-	}
-
 	for (int i = 0; i < animation->get_item_count(); i++) {
 		String name = animation->get_item_text(i);
 


### PR DESCRIPTION
Left-over of #58969.

It was part of the original extracted code, but became unused after I rewrote the update logic.