### PR TITLE
Fix "p_from_line > p_to_line" errors in text edit

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -4469,7 +4469,11 @@ int TextEdit::get_visible_line_count() const {
 int TextEdit::get_visible_line_count_in_range(int p_from_line, int p_to_line) const {
 	ERR_FAIL_INDEX_V(p_from_line, text.size(), 0);
 	ERR_FAIL_INDEX_V(p_to_line, text.size(), 0);
-	ERR_FAIL_COND_V(p_from_line > p_to_line, 0);
+
+	// So we can handle inputs in whatever order
+	if (p_from_line > p_to_line) {
+		SWAP(p_from_line, p_to_line);
+	}
 
 	/* Returns the total number of (lines + wrapped - hidden). */
 	if (!_is_hiding_enabled() && get_line_wrapping_mode() == LineWrappingMode::LINE_WRAPPING_NONE) {


### PR DESCRIPTION
The function in question (TextEdit::get_visible_line_count_in_range) expects "to" to be larger than "from" but a number of places that call it don't really do any check. In the issue page I made (#58906), @Paulb23 recommended that the function be modified to be tolerant of different input orderings, so that's what I've done here.

(updated with some style fixes so the checks don't fail and stuff!)
(I also thought I might have to update the docs, but this change doesn't really contradict anything so)

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/58906