### PR TITLE
[3.x] Improve TileMap editor grid

### DIFF
--- a/editor/plugins/tile_map_editor_plugin.h
+++ b/editor/plugins/tile_map_editor_plugin.h
@@ -172,6 +172,7 @@ class TileMapEditor : public VBoxContainer {
 	void _select(const Point2i &p_from, const Point2i &p_to);
 	void _erase_selection();
 
+	void _draw_grid(Control *p_viewport, const Rect2 &p_rect) const;
 	void _draw_cell(Control *p_viewport, int p_cell, const Point2i &p_point, bool p_flip_h, bool p_flip_v, bool p_transpose, const Point2i &p_autotile_coord, const Transform2D &p_xform);
 	void _draw_fill_preview(Control *p_viewport, int p_cell, const Point2i &p_point, bool p_flip_h, bool p_flip_v, bool p_transpose, const Point2i &p_autotile_coord, const Transform2D &p_xform);
 	void _clear_bucket_cache();


### PR DESCRIPTION
This PR implements `4.0`-style TileMap grid.

* Grid is now only drawn for certain areas and fades in from cells around.
    * The used rect of TileMap.
    * The preview rect of Paint tool (cell / line / rect).
* The grid now fades out when the drawn cell size is relatively small. Both for performance and visual pleasing.
* Grid for TileMaps with half-offset now has a slightly performance improvement.
    * A grid line with half-offset is drawn in a single `draw_multiline_colors()` instead of several `draw_line()` calls.
* Adds editor settings to toggle the grid and to change the grid color.

Also fixed some `EDITOR_DEF()` that should be `EDITOR_GET()` in tilemap code.


https://user-images.githubusercontent.com/372476/157790026-b81cf427-38ea-447c-80af-2c598a69ec5d.mp4

p.s. The bright yellow lines in the video are part of the TileMap editor. I turned off "Show Origin" and "Show Viewport" when recording.