### PR TITLE
Use get_cursor_shape for identifying the cursor shape in AnimationTimelineEdit

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1814,13 +1814,6 @@ void AnimationTimelineEdit::gui_input(const Ref<InputEvent> &p_event) {
 	Ref<InputEventMouseMotion> mm = p_event;
 
 	if (mm.is_valid()) {
-		if (hsize_rect.has_point(mm->get_position())) {
-			// Change the cursor to indicate that the track name column's width can be adjusted
-			set_default_cursor_shape(Control::CURSOR_HSIZE);
-		} else {
-			set_default_cursor_shape(Control::CURSOR_ARROW);
-		}
-
 		if (dragging_hsize) {
 			int ofs = mm->get_position().x - dragging_hsize_from;
 			name_limit = dragging_hsize_at + ofs;
@@ -1833,6 +1826,15 @@ void AnimationTimelineEdit::gui_input(const Ref<InputEvent> &p_event) {
 			float ofs = x / get_zoom_scale() + get_value();
 			emit_signal(SNAME("timeline_changed"), ofs, false, mm->is_alt_pressed());
 		}
+	}
+}
+
+Control::CursorShape AnimationTimelineEdit::get_cursor_shape(const Point2 &p_pos) const {
+	if (dragging_hsize || hsize_rect.has_point(p_pos)) {
+		// Indicate that the track name column's width can be adjusted
+		return Control::CURSOR_HSIZE;
+	} else {
+		return get_default_cursor_shape();
 	}
 }
 

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -121,6 +121,8 @@ public:
 
 	void set_hscroll(HScrollBar *p_hscroll);
 
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
+
 	AnimationTimelineEdit();
 };
 


### PR DESCRIPTION
`get_cursor_shape()` is used in cases where a Control displays different cursors in different areas.
There is no need to change the default cursor shape on every mouse move event.

This patch changes, that the `CURSOR_HSIZE` is displayed during dragging.

Was part of the reason for #58960.