### PR TITLE
[3.x] implements sky contribution saturation on ambient light

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -343,6 +343,10 @@ godot.creator.*
 projects/
 platform/windows/godot_res.res
 
+# Sublime Text project and workspace files
+*.sublime-project
+*.sublime-workspace
+
 # Visual Studio 2017 and Visual Studio Code workspace folder
 /.vs
 /.vscode

--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -64,6 +64,9 @@
 		<member name="ambient_light_sky_contribution" type="float" setter="set_ambient_light_sky_contribution" getter="get_ambient_light_sky_contribution" default="1.0">
 			Defines the amount of light that the sky brings on the scene. A value of [code]0.0[/code] means that the sky's light emission has no effect on the scene illumination, thus all ambient illumination is provided by the ambient light. On the contrary, a value of [code]1.0[/code] means that [i]all[/i] the light that affects the scene is provided by the sky, thus the ambient light parameter has no effect on the scene.
 			[b]Note:[/b] [member ambient_light_sky_contribution] is internally clamped between [code]0.0[/code] and [code]1.0[/code] (inclusive).
+		<member name="ambient_light_sky_contribution_saturation" type="float" setter="set_ambient_light_sky_contribution_saturation" getter="get_ambient_light_sky_contribution_saturation" default="1.0">
+			Defines how much saturated should be the sky contribution. A value of [code]0.0[/code] means that the sky contribution will have no color, only brightness. A value of [code]1.0[/code] means that the sky contribution will be exactly the same color as the sky color.
+			[b]Note:[/b] [member ambient_light_sky_contribution_saturation] is internally clamped between [code]0.0[/code] and [code]1.0[/code] (inclusive).
 		</member>
 		<member name="auto_exposure_enabled" type="bool" setter="set_tonemap_auto_exposure" getter="get_tonemap_auto_exposure" default="false">
 			If [code]true[/code], enables the tonemapping auto exposure mode of the scene renderer. If [code]true[/code], the renderer will automatically determine the exposure setting to adapt to the scene's illumination and the observed light.

--- a/drivers/dummy/rasterizer_dummy.h
+++ b/drivers/dummy/rasterizer_dummy.h
@@ -60,7 +60,7 @@ public:
 	void environment_set_bg_color(RID p_env, const Color &p_color) {}
 	void environment_set_bg_energy(RID p_env, float p_energy) {}
 	void environment_set_canvas_max_layer(RID p_env, int p_max_layer) {}
-	void environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy = 1.0, float p_sky_contribution = 0.0) {}
+	void environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy = 1.0, float p_sky_contribution = 0.0, float p_sky_contribution_saturation = 0.0) {}
 	void environment_set_camera_feed_id(RID p_env, int p_camera_feed_id){};
 
 	void environment_set_dof_blur_near(RID p_env, bool p_enable, float p_distance, float p_transition, float p_far_amount, VS::EnvironmentDOFBlurQuality p_quality) {}

--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -734,13 +734,14 @@ void RasterizerSceneGLES2::environment_set_canvas_max_layer(RID p_env, int p_max
 	env->canvas_max_layer = p_max_layer;
 }
 
-void RasterizerSceneGLES2::environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy, float p_sky_contribution) {
+void RasterizerSceneGLES2::environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy, float p_sky_contribution, float p_sky_contribution_saturation) {
 	Environment *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
 
 	env->ambient_color = p_color;
 	env->ambient_energy = p_energy;
 	env->ambient_sky_contribution = p_sky_contribution;
+	env->ambient_sky_contribution_saturation = p_sky_contribution_saturation;
 }
 
 void RasterizerSceneGLES2::environment_set_camera_feed_id(RID p_env, int p_camera_feed_id) {
@@ -2486,7 +2487,7 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 					state.scene_shader.set_uniform(SceneShaderGLES2::BG_ENERGY, p_env->bg_energy);
 					state.scene_shader.set_uniform(SceneShaderGLES2::BG_COLOR, p_env->bg_color);
 					state.scene_shader.set_uniform(SceneShaderGLES2::AMBIENT_SKY_CONTRIBUTION, p_env->ambient_sky_contribution);
-
+					state.scene_shader.set_uniform(SceneShaderGLES2::AMBIENT_SKY_CONTRIBUTION_SATURATION, p_env->ambient_sky_contribution_saturation);
 					state.scene_shader.set_uniform(SceneShaderGLES2::AMBIENT_COLOR, p_env->ambient_color);
 					state.scene_shader.set_uniform(SceneShaderGLES2::AMBIENT_ENERGY, p_env->ambient_energy);
 
@@ -2494,6 +2495,7 @@ void RasterizerSceneGLES2::_render_render_list(RenderList::Element **p_elements,
 					state.scene_shader.set_uniform(SceneShaderGLES2::BG_ENERGY, 1.0);
 					state.scene_shader.set_uniform(SceneShaderGLES2::BG_COLOR, state.default_bg);
 					state.scene_shader.set_uniform(SceneShaderGLES2::AMBIENT_SKY_CONTRIBUTION, 1.0);
+					state.scene_shader.set_uniform(SceneShaderGLES2::AMBIENT_SKY_CONTRIBUTION_SATURATION, 1.0);
 					state.scene_shader.set_uniform(SceneShaderGLES2::AMBIENT_COLOR, state.default_ambient);
 					state.scene_shader.set_uniform(SceneShaderGLES2::AMBIENT_ENERGY, 1.0);
 				}

--- a/drivers/gles2/rasterizer_scene_gles2.h
+++ b/drivers/gles2/rasterizer_scene_gles2.h
@@ -363,6 +363,7 @@ public:
 		Color ambient_color;
 		float ambient_energy;
 		float ambient_sky_contribution;
+		float ambient_sky_contribution_saturation;
 
 		int canvas_max_layer;
 
@@ -474,7 +475,7 @@ public:
 	virtual void environment_set_bg_color(RID p_env, const Color &p_color);
 	virtual void environment_set_bg_energy(RID p_env, float p_energy);
 	virtual void environment_set_canvas_max_layer(RID p_env, int p_max_layer);
-	virtual void environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy = 1.0, float p_sky_contribution = 0.0);
+	virtual void environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy = 1.0, float p_sky_contribution = 0.0, float p_sky_contribution_saturation = 0.0);
 	virtual void environment_set_camera_feed_id(RID p_env, int p_camera_feed_id);
 
 	virtual void environment_set_dof_blur_near(RID p_env, bool p_enable, float p_distance, float p_transition, float p_amount, VS::EnvironmentDOFBlurQuality p_quality);

--- a/drivers/gles2/shaders/scene.glsl
+++ b/drivers/gles2/shaders/scene.glsl
@@ -1025,6 +1025,7 @@ uniform vec4 bg_color;
 uniform float bg_energy;
 
 uniform float ambient_sky_contribution;
+uniform float ambient_sky_contribution_saturation;
 uniform vec4 ambient_color;
 uniform float ambient_energy;
 
@@ -1729,7 +1730,11 @@ FRAGMENT_SHADER_CODE
 		vec3 env_ambient = textureCubeLod(radiance_map, ambient_dir, 4.0).xyz * bg_energy;
 		env_ambient *= 1.0 - F;
 
-		ambient_light = mix(ambient_color.rgb, env_ambient, ambient_sky_contribution);
+		float env_ambient_luminosity = env_ambient.r * 0.2126 + env_ambient.g * 0.7152 + env_ambient.b * 0.0722;
+		vec3 env_ambient_gray = vec3(env_ambient_luminosity, env_ambient_luminosity, env_ambient_luminosity);
+		vec3 env_ambient_mix = mix(env_ambient_gray, env_ambient, ambient_sky_contribution_saturation);
+
+		ambient_light = mix(ambient_color.rgb, env_ambient_mix, ambient_sky_contribution);
 	}
 #endif
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -801,13 +801,14 @@ void RasterizerSceneGLES3::environment_set_canvas_max_layer(RID p_env, int p_max
 
 	env->canvas_max_layer = p_max_layer;
 }
-void RasterizerSceneGLES3::environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy, float p_sky_contribution) {
+void RasterizerSceneGLES3::environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy, float p_sky_contribution, float p_sky_contribution_saturation) {
 	Environment *env = environment_owner.getornull(p_env);
 	ERR_FAIL_COND(!env);
 
 	env->ambient_color = p_color;
 	env->ambient_energy = p_energy;
 	env->ambient_sky_contribution = p_sky_contribution;
+	env->ambient_sky_contribution_saturation = p_sky_contribution_saturation;
 }
 void RasterizerSceneGLES3::environment_set_camera_feed_id(RID p_env, int p_camera_feed_id) {
 	Environment *env = environment_owner.getornull(p_env);
@@ -2519,6 +2520,7 @@ void RasterizerSceneGLES3::_setup_environment(Environment *env, const CameraMatr
 		sky_orientation = Transform(env->sky_orientation, Vector3(0.0, 0.0, 0.0)).affine_inverse();
 
 		state.env_radiance_data.ambient_contribution = env->ambient_sky_contribution;
+		state.env_radiance_data.ambient_contribution_saturation = env->ambient_sky_contribution_saturation;
 		state.ubo_data.ambient_occlusion_affect_light = env->ssao_light_affect;
 		state.ubo_data.ambient_occlusion_affect_ssao = env->ssao_ao_channel_affect;
 
@@ -2563,6 +2565,7 @@ void RasterizerSceneGLES3::_setup_environment(Environment *env, const CameraMatr
 		state.ubo_data.bg_color[3] = linear_ambient_color.a;
 
 		state.env_radiance_data.ambient_contribution = 0;
+		state.env_radiance_data.ambient_contribution_saturation = 0;
 		state.ubo_data.ambient_occlusion_affect_light = 0;
 
 		state.ubo_data.fog_color_enabled[3] = 0.0;

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -167,7 +167,8 @@ public:
 		struct EnvironmentRadianceUBO {
 			float transform[16];
 			float ambient_contribution;
-			uint8_t padding[12];
+			float ambient_contribution_saturation;
+			uint8_t padding[8];
 
 		} env_radiance_data;
 
@@ -375,6 +376,7 @@ public:
 		Color ambient_color;
 		float ambient_energy;
 		float ambient_sky_contribution;
+		float ambient_sky_contribution_saturation;
 
 		int canvas_max_layer;
 
@@ -540,7 +542,7 @@ public:
 	virtual void environment_set_bg_color(RID p_env, const Color &p_color);
 	virtual void environment_set_bg_energy(RID p_env, float p_energy);
 	virtual void environment_set_canvas_max_layer(RID p_env, int p_max_layer);
-	virtual void environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy = 1.0, float p_sky_contribution = 0.0);
+	virtual void environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy = 1.0, float p_sky_contribution = 0.0, float p_sky_contribution_saturation = 0.0);
 	virtual void environment_set_camera_feed_id(RID p_env, int p_camera_feed_id);
 
 	virtual void environment_set_dof_blur_near(RID p_env, bool p_enable, float p_distance, float p_transition, float p_amount, VS::EnvironmentDOFBlurQuality p_quality);

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -674,6 +674,7 @@ layout(std140) uniform Radiance { // ubo:2
 
 	mat4 radiance_inverse_xform;
 	float radiance_ambient_contribution;
+	float radiance_ambient_contribution_saturation;
 };
 
 #define RADIANCE_MAX_LOD 5.0
@@ -1945,7 +1946,11 @@ FRAGMENT_SHADER_CODE
 		vec3 env_ambient = texture(irradiance_map, norm.xy).rgb * bg_energy;
 		env_ambient *= 1.0 - F;
 
-		ambient_light = mix(ambient_light_color.rgb, env_ambient, radiance_ambient_contribution);
+		float env_ambient_luminosity = env_ambient.r * 0.2126 + env_ambient.g * 0.7152 + env_ambient.b * 0.0722;
+		vec3 env_ambient_gray = vec3(env_ambient_luminosity, env_ambient_luminosity, env_ambient_luminosity);
+		vec3 env_ambient_mix = mix(env_ambient_gray, env_ambient, radiance_ambient_contribution_saturation);
+
+		ambient_light = mix(ambient_light_color.rgb, env_ambient_mix, radiance_ambient_contribution);
 	}
 #endif
 #endif //AMBIENT_LIGHT_DISABLED

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -89,17 +89,21 @@ void Environment::set_canvas_max_layer(int p_max_layer) {
 }
 void Environment::set_ambient_light_color(const Color &p_color) {
 	ambient_color = p_color;
-	VS::get_singleton()->environment_set_ambient_light(environment, ambient_color, ambient_energy, ambient_sky_contribution);
+	VS::get_singleton()->environment_set_ambient_light(environment, ambient_color, ambient_energy, ambient_sky_contribution, ambient_sky_contribution_saturation);
 }
 void Environment::set_ambient_light_energy(float p_energy) {
 	ambient_energy = p_energy;
-	VS::get_singleton()->environment_set_ambient_light(environment, ambient_color, ambient_energy, ambient_sky_contribution);
+	VS::get_singleton()->environment_set_ambient_light(environment, ambient_color, ambient_energy, ambient_sky_contribution, ambient_sky_contribution_saturation);
 }
 void Environment::set_ambient_light_sky_contribution(float p_energy) {
 	// Sky contribution values outside the [0.0; 1.0] range don't make sense and
 	// can result in negative colors.
 	ambient_sky_contribution = CLAMP(p_energy, 0.0, 1.0);
-	VS::get_singleton()->environment_set_ambient_light(environment, ambient_color, ambient_energy, ambient_sky_contribution);
+	VS::get_singleton()->environment_set_ambient_light(environment, ambient_color, ambient_energy, ambient_sky_contribution, ambient_sky_contribution_saturation);
+}
+void Environment::set_ambient_light_sky_contribution_saturation(float p_saturation) {
+	ambient_sky_contribution_saturation = p_saturation;
+	VS::get_singleton()->environment_set_ambient_light(environment, ambient_color, ambient_energy, ambient_sky_contribution, ambient_sky_contribution_saturation);
 }
 
 void Environment::set_camera_feed_id(int p_camera_feed_id) {
@@ -148,6 +152,9 @@ float Environment::get_ambient_light_energy() const {
 }
 float Environment::get_ambient_light_sky_contribution() const {
 	return ambient_sky_contribution;
+}
+float Environment::get_ambient_light_sky_contribution_saturation() const {
+	return ambient_sky_contribution_saturation;
 }
 int Environment::get_camera_feed_id() const {
 	return camera_feed_id;
@@ -813,6 +820,7 @@ void Environment::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_ambient_light_color", "color"), &Environment::set_ambient_light_color);
 	ClassDB::bind_method(D_METHOD("set_ambient_light_energy", "energy"), &Environment::set_ambient_light_energy);
 	ClassDB::bind_method(D_METHOD("set_ambient_light_sky_contribution", "energy"), &Environment::set_ambient_light_sky_contribution);
+	ClassDB::bind_method(D_METHOD("set_ambient_light_sky_contribution_saturation", "energy"), &Environment::set_ambient_light_sky_contribution_saturation);
 	ClassDB::bind_method(D_METHOD("set_camera_feed_id", "camera_feed_id"), &Environment::set_camera_feed_id);
 
 	ClassDB::bind_method(D_METHOD("get_background"), &Environment::get_background);
@@ -827,6 +835,7 @@ void Environment::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_ambient_light_color"), &Environment::get_ambient_light_color);
 	ClassDB::bind_method(D_METHOD("get_ambient_light_energy"), &Environment::get_ambient_light_energy);
 	ClassDB::bind_method(D_METHOD("get_ambient_light_sky_contribution"), &Environment::get_ambient_light_sky_contribution);
+	ClassDB::bind_method(D_METHOD("get_ambient_light_sky_contribution_saturation"), &Environment::get_ambient_light_sky_contribution_saturation);
 	ClassDB::bind_method(D_METHOD("get_camera_feed_id"), &Environment::get_camera_feed_id);
 
 	ADD_GROUP("Background", "background_");
@@ -846,6 +855,7 @@ void Environment::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "ambient_light_color"), "set_ambient_light_color", "get_ambient_light_color");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "ambient_light_energy", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_ambient_light_energy", "get_ambient_light_energy");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "ambient_light_sky_contribution", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_ambient_light_sky_contribution", "get_ambient_light_sky_contribution");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "ambient_light_sky_contribution_saturation", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_ambient_light_sky_contribution_saturation", "get_ambient_light_sky_contribution_saturation");
 
 	ClassDB::bind_method(D_METHOD("set_fog_enabled", "enabled"), &Environment::set_fog_enabled);
 	ClassDB::bind_method(D_METHOD("is_fog_enabled"), &Environment::is_fog_enabled);
@@ -1186,6 +1196,7 @@ Environment::Environment() :
 	bg_canvas_max_layer = 0;
 	ambient_energy = 1.0;
 	//ambient_sky_contribution = 1.0;
+	ambient_sky_contribution_saturation = 1.0;
 	set_ambient_light_sky_contribution(1.0);
 	set_camera_feed_id(1);
 

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -99,6 +99,7 @@ private:
 	Color ambient_color;
 	float ambient_energy;
 	float ambient_sky_contribution;
+	float ambient_sky_contribution_saturation;
 	int camera_feed_id;
 
 	ToneMapper tone_mapper;
@@ -195,6 +196,7 @@ public:
 	void set_ambient_light_color(const Color &p_color);
 	void set_ambient_light_energy(float p_energy);
 	void set_ambient_light_sky_contribution(float p_energy);
+	void set_ambient_light_sky_contribution_saturation(float p_occlusion);
 	void set_camera_feed_id(int p_camera_feed_id);
 
 	BGMode get_background() const;
@@ -209,6 +211,7 @@ public:
 	Color get_ambient_light_color() const;
 	float get_ambient_light_energy() const;
 	float get_ambient_light_sky_contribution() const;
+	float get_ambient_light_sky_contribution_saturation() const;
 	int get_camera_feed_id() const;
 
 	void set_tonemapper(ToneMapper p_tone_mapper);

--- a/servers/visual/rasterizer.h
+++ b/servers/visual/rasterizer.h
@@ -59,7 +59,7 @@ public:
 	virtual void environment_set_bg_color(RID p_env, const Color &p_color) = 0;
 	virtual void environment_set_bg_energy(RID p_env, float p_energy) = 0;
 	virtual void environment_set_canvas_max_layer(RID p_env, int p_max_layer) = 0;
-	virtual void environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy = 1.0, float p_sky_contribution = 0.0) = 0;
+	virtual void environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy = 1.0, float p_sky_contribution = 0.0, float p_sky_contribution_saturation = 0.0) = 0;
 	virtual void environment_set_camera_feed_id(RID p_env, int p_camera_feed_id) = 0;
 
 	virtual void environment_set_dof_blur_near(RID p_env, bool p_enable, float p_distance, float p_transition, float p_far_amount, VS::EnvironmentDOFBlurQuality p_quality) = 0;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -510,7 +510,7 @@ public:
 	BIND2(environment_set_bg_color, RID, const Color &)
 	BIND2(environment_set_bg_energy, RID, float)
 	BIND2(environment_set_canvas_max_layer, RID, int)
-	BIND4(environment_set_ambient_light, RID, const Color &, float, float)
+	BIND5(environment_set_ambient_light, RID, const Color &, float, float, float)
 	BIND2(environment_set_camera_feed_id, RID, int)
 	BIND7(environment_set_ssr, RID, bool, int, float, float, float, bool)
 	BIND13(environment_set_ssao, RID, bool, float, float, float, float, float, float, float, const Color &, EnvironmentSSAOQuality, EnvironmentSSAOBlur, float)

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -438,7 +438,7 @@ public:
 	FUNC2(environment_set_bg_color, RID, const Color &)
 	FUNC2(environment_set_bg_energy, RID, float)
 	FUNC2(environment_set_canvas_max_layer, RID, int)
-	FUNC4(environment_set_ambient_light, RID, const Color &, float, float)
+	FUNC5(environment_set_ambient_light, RID, const Color &, float, float, float)
 	FUNC2(environment_set_camera_feed_id, RID, int)
 	FUNC7(environment_set_ssr, RID, bool, int, float, float, float, bool)
 	FUNC13(environment_set_ssao, RID, bool, float, float, float, float, float, float, float, const Color &, EnvironmentSSAOQuality, EnvironmentSSAOBlur, float)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2098,7 +2098,7 @@ void VisualServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("environment_set_bg_color", "env", "color"), &VisualServer::environment_set_bg_color);
 	ClassDB::bind_method(D_METHOD("environment_set_bg_energy", "env", "energy"), &VisualServer::environment_set_bg_energy);
 	ClassDB::bind_method(D_METHOD("environment_set_canvas_max_layer", "env", "max_layer"), &VisualServer::environment_set_canvas_max_layer);
-	ClassDB::bind_method(D_METHOD("environment_set_ambient_light", "env", "color", "energy", "sky_contibution"), &VisualServer::environment_set_ambient_light, DEFVAL(1.0), DEFVAL(0.0));
+	ClassDB::bind_method(D_METHOD("environment_set_ambient_light", "env", "color", "energy", "sky_contibution", "sky_contibution_saturation"), &VisualServer::environment_set_ambient_light, DEFVAL(1.0), DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("environment_set_dof_blur_near", "env", "enable", "distance", "transition", "far_amount", "quality"), &VisualServer::environment_set_dof_blur_near);
 	ClassDB::bind_method(D_METHOD("environment_set_dof_blur_far", "env", "enable", "distance", "transition", "far_amount", "quality"), &VisualServer::environment_set_dof_blur_far);
 	ClassDB::bind_method(D_METHOD("environment_set_glow", "env", "enable", "level_flags", "intensity", "strength", "bloom_threshold", "blend_mode", "hdr_bleed_threshold", "hdr_bleed_scale", "hdr_luminance_cap", "bicubic_upscale", "high_quality"), &VisualServer::environment_set_glow);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -750,7 +750,7 @@ public:
 	virtual void environment_set_bg_color(RID p_env, const Color &p_color) = 0;
 	virtual void environment_set_bg_energy(RID p_env, float p_energy) = 0;
 	virtual void environment_set_canvas_max_layer(RID p_env, int p_max_layer) = 0;
-	virtual void environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy = 1.0, float p_sky_contribution = 0.0) = 0;
+	virtual void environment_set_ambient_light(RID p_env, const Color &p_color, float p_energy = 1.0, float p_sky_contribution = 0.0, float p_sky_contribution_saturation = 0.0) = 0;
 	virtual void environment_set_camera_feed_id(RID p_env, int p_camera_feed_id) = 0;
 
 	//set default SSAO options


### PR DESCRIPTION
This PR implements a sky ambient light contribution saturation control via an environment resource parameter as shown in the attached video. Since this is specific to 3.x, I'm doing the PR over 3.4 instead of master.

https://user-images.githubusercontent.com/5783414/157842795-19844815-35b5-4e82-8930-a2683b687c07.mp4
