### PR TITLE
Use get_cursor_shape for identifying the cursor shape in AnimationTrackEditTypeAudio

### DIFF
--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -1080,12 +1080,7 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 				len_resizing_index = i;
 			}
 		}
-
-		if (use_hsize_cursor) {
-			set_default_cursor_shape(CURSOR_HSIZE);
-		} else {
-			set_default_cursor_shape(CURSOR_ARROW);
-		}
+		over_drag_position = use_hsize_cursor;
 	}
 
 	if (len_resizing && mm.is_valid()) {
@@ -1097,7 +1092,7 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	Ref<InputEventMouseButton> mb = p_event;
-	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT && get_default_cursor_shape() == CURSOR_HSIZE) {
+	if (mb.is_valid() && mb->is_pressed() && mb->get_button_index() == MouseButton::LEFT && over_drag_position) {
 		len_resizing = true;
 		len_resizing_start = mb->is_shift_pressed();
 		len_resizing_from_px = mb->get_position().x;
@@ -1132,6 +1127,14 @@ void AnimationTrackEditTypeAudio::gui_input(const Ref<InputEvent> &p_event) {
 	}
 
 	AnimationTrackEdit::gui_input(p_event);
+}
+
+Control::CursorShape AnimationTrackEditTypeAudio::get_cursor_shape(const Point2 &p_pos) const {
+	if (over_drag_position || len_resizing) {
+		return Control::CURSOR_HSIZE;
+	} else {
+		return get_default_cursor_shape();
+	}
 }
 
 ////////////////////

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -119,6 +119,7 @@ class AnimationTrackEditTypeAudio : public AnimationTrackEdit {
 	int len_resizing_index;
 	float len_resizing_from_px;
 	float len_resizing_rel;
+	bool over_drag_position = false;
 
 protected:
 	static void _bind_methods();
@@ -133,6 +134,8 @@ public:
 	virtual Rect2 get_key_rect(int p_index, float p_pixels_sec) override;
 	virtual bool is_key_selectable_by_distance() const override;
 	virtual void draw_key(int p_index, float p_pixels_sec, int p_x, bool p_selected, int p_clip_left, int p_clip_right) override;
+
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 
 	AnimationTrackEditTypeAudio();
 };


### PR DESCRIPTION
get_cursor_shape() is used in cases where a Control displays different cursors in different areas.
There is no need to set the default cursor shape on every mouse move event.

Was part of the reason for https://github.com/godotengine/godot/issues/58960.