### PR TITLE
Use `RTR()` for `VisualScriptNode` captions and texts

### DIFF
--- a/modules/visual_script/visual_script_expression.cpp
+++ b/modules/visual_script/visual_script_expression.cpp
@@ -176,7 +176,7 @@ PropertyInfo VisualScriptExpression::get_output_value_port_info(int p_idx) const
 }
 
 String VisualScriptExpression::get_caption() const {
-	return TTR("Expression");
+	return RTR("Expression");
 }
 
 String VisualScriptExpression::get_text() const {

--- a/modules/visual_script/visual_script_flow_control.cpp
+++ b/modules/visual_script/visual_script_flow_control.cpp
@@ -70,7 +70,7 @@ PropertyInfo VisualScriptReturn::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptReturn::get_caption() const {
-	return TTR("Return");
+	return RTR("Return");
 }
 
 String VisualScriptReturn::get_text() const {
@@ -201,11 +201,11 @@ PropertyInfo VisualScriptCondition::get_output_value_port_info(int p_idx) const 
 }
 
 String VisualScriptCondition::get_caption() const {
-	return TTR("Condition");
+	return RTR("Condition");
 }
 
 String VisualScriptCondition::get_text() const {
-	return TTR("if (cond) is:");
+	return RTR("if (cond) is:");
 }
 
 void VisualScriptCondition::_bind_methods() {
@@ -281,11 +281,11 @@ PropertyInfo VisualScriptWhile::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptWhile::get_caption() const {
-	return TTR("While");
+	return RTR("While");
 }
 
 String VisualScriptWhile::get_text() const {
-	return TTR("while (cond):");
+	return RTR("while (cond):");
 }
 
 void VisualScriptWhile::_bind_methods() {
@@ -364,11 +364,11 @@ PropertyInfo VisualScriptIterator::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptIterator::get_caption() const {
-	return TTR("Iterator");
+	return RTR("Iterator");
 }
 
 String VisualScriptIterator::get_text() const {
-	return TTR("for (elem) in (input):");
+	return RTR("for (elem) in (input):");
 }
 
 void VisualScriptIterator::_bind_methods() {
@@ -478,11 +478,11 @@ PropertyInfo VisualScriptSequence::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptSequence::get_caption() const {
-	return TTR("Sequence");
+	return RTR("Sequence");
 }
 
 String VisualScriptSequence::get_text() const {
-	return TTR("in order:");
+	return RTR("in order:");
 }
 
 void VisualScriptSequence::set_steps(int p_steps) {
@@ -587,11 +587,11 @@ PropertyInfo VisualScriptSwitch::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptSwitch::get_caption() const {
-	return TTR("Switch");
+	return RTR("Switch");
 }
 
 String VisualScriptSwitch::get_text() const {
-	return TTR("'input' is:");
+	return RTR("'input' is:");
 }
 
 class VisualScriptNodeInstanceSwitch : public VisualScriptNodeInstance {
@@ -720,14 +720,14 @@ PropertyInfo VisualScriptTypeCast::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptTypeCast::get_caption() const {
-	return TTR("Type Cast");
+	return RTR("Type Cast");
 }
 
 String VisualScriptTypeCast::get_text() const {
 	if (!script.is_empty()) {
-		return vformat(TTR("Is %s?"), script.get_file());
+		return vformat(RTR("Is %s?"), script.get_file());
 	} else {
-		return vformat(TTR("Is %s?"), base_type);
+		return vformat(RTR("Is %s?"), base_type);
 	}
 }
 

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -33,6 +33,7 @@
 #include "core/config/engine.h"
 #include "core/io/resource_loader.h"
 #include "core/os/os.h"
+#include "core/templates/local_vector.h"
 #include "scene/main/node.h"
 #include "scene/main/scene_tree.h"
 #include "visual_script_nodes.h"
@@ -261,13 +262,13 @@ String VisualScriptFunctionCall::get_text() const {
 	String text;
 
 	if (call_mode == CALL_MODE_BASIC_TYPE) {
-		text = vformat(TTR("On %s"), Variant::get_type_name(basic_type));
+		text = vformat(RTR("On %s"), Variant::get_type_name(basic_type));
 	} else if (call_mode == CALL_MODE_INSTANCE) {
-		text = vformat(TTR("On %s"), base_type);
+		text = vformat(RTR("On %s"), base_type);
 	} else if (call_mode == CALL_MODE_NODE_PATH) {
 		text = "[" + String(base_path.simplified()) + "]";
 	} else if (call_mode == CALL_MODE_SELF) {
-		text = TTR("On Self");
+		text = RTR("On Self");
 	} else if (call_mode == CALL_MODE_SINGLETON) {
 		text = String(singleton) + ":" + String(function) + "()";
 	}
@@ -1032,18 +1033,18 @@ PropertyInfo VisualScriptPropertySet::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptPropertySet::get_caption() const {
-	static const char *opname[ASSIGN_OP_MAX] = {
-		TTRC("Set %s"),
-		TTRC("Add %s"),
-		TTRC("Subtract %s"),
-		TTRC("Multiply %s"),
-		TTRC("Divide %s"),
-		TTRC("Mod %s"),
-		TTRC("ShiftLeft %s"),
-		TTRC("ShiftRight %s"),
-		TTRC("BitAnd %s"),
-		TTRC("BitOr %s"),
-		TTRC("BitXor %s")
+	static const LocalVector<String> opname = {
+		RTR("Set %s"),
+		RTR("Add %s"),
+		RTR("Subtract %s"),
+		RTR("Multiply %s"),
+		RTR("Divide %s"),
+		RTR("Mod %s"),
+		RTR("ShiftLeft %s"),
+		RTR("ShiftRight %s"),
+		RTR("BitAnd %s"),
+		RTR("BitOr %s"),
+		RTR("BitXor %s"),
 	};
 
 	String prop = property;
@@ -1051,7 +1052,7 @@ String VisualScriptPropertySet::get_caption() const {
 		prop += "." + String(index);
 	}
 
-	return vformat(TTRGET(opname[assign_op]), prop);
+	return vformat(opname[assign_op], prop);
 }
 
 String VisualScriptPropertySet::get_text() const {
@@ -1059,13 +1060,13 @@ String VisualScriptPropertySet::get_text() const {
 		return "";
 	}
 	if (call_mode == CALL_MODE_BASIC_TYPE) {
-		return vformat(TTR("On %s"), Variant::get_type_name(basic_type));
+		return vformat(RTR("On %s"), Variant::get_type_name(basic_type));
 	} else if (call_mode == CALL_MODE_INSTANCE) {
-		return vformat(TTR("On %s"), base_type);
+		return vformat(RTR("On %s"), base_type);
 	} else if (call_mode == CALL_MODE_NODE_PATH) {
 		return " [" + String(base_path.simplified()) + "]";
 	} else {
-		return TTR("On Self");
+		return RTR("On Self");
 	}
 }
 
@@ -1776,18 +1777,18 @@ String VisualScriptPropertyGet::get_caption() const {
 		prop += "." + String(index);
 	}
 
-	return vformat(TTR("Get %s"), prop);
+	return vformat(RTR("Get %s"), prop);
 }
 
 String VisualScriptPropertyGet::get_text() const {
 	if (call_mode == CALL_MODE_BASIC_TYPE) {
-		return vformat(TTR("On %s"), Variant::get_type_name(basic_type));
+		return vformat(RTR("On %s"), Variant::get_type_name(basic_type));
 	} else if (call_mode == CALL_MODE_INSTANCE) {
-		return vformat(TTR("On %s"), base_type);
+		return vformat(RTR("On %s"), base_type);
 	} else if (call_mode == CALL_MODE_NODE_PATH) {
 		return " [" + String(base_path.simplified()) + "]";
 	} else {
-		return TTR("On Self");
+		return RTR("On Self");
 	}
 }
 
@@ -2303,7 +2304,7 @@ PropertyInfo VisualScriptEmitSignal::get_output_value_port_info(int p_idx) const
 }
 
 String VisualScriptEmitSignal::get_caption() const {
-	return vformat(TTR("Emit %s"), name);
+	return vformat(RTR("Emit %s"), name);
 }
 
 void VisualScriptEmitSignal::set_signal(const StringName &p_type) {

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -204,7 +204,7 @@ PropertyInfo VisualScriptFunction::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptFunction::get_caption() const {
-	return TTR("Function");
+	return RTR("Function");
 }
 
 String VisualScriptFunction::get_text() const {
@@ -767,7 +767,7 @@ PropertyInfo VisualScriptComposeArray::get_output_value_port_info(int p_idx) con
 }
 
 String VisualScriptComposeArray::get_caption() const {
-	return TTR("Compose Array");
+	return RTR("Compose Array");
 }
 
 String VisualScriptComposeArray::get_text() const {
@@ -1186,11 +1186,11 @@ PropertyInfo VisualScriptSelect::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptSelect::get_caption() const {
-	return TTR("Select");
+	return RTR("Select");
 }
 
 String VisualScriptSelect::get_text() const {
-	return TTR("a if cond, else b");
+	return RTR("a if cond, else b");
 }
 
 void VisualScriptSelect::set_typed(Variant::Type p_op) {
@@ -1284,7 +1284,7 @@ PropertyInfo VisualScriptVariableGet::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptVariableGet::get_caption() const {
-	return vformat(TTR("Get %s"), variable);
+	return vformat(RTR("Get %s"), variable);
 }
 
 void VisualScriptVariableGet::set_variable(StringName p_variable) {
@@ -1394,7 +1394,7 @@ PropertyInfo VisualScriptVariableSet::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptVariableSet::get_caption() const {
-	return vformat(TTR("Set %s"), variable);
+	return vformat(RTR("Set %s"), variable);
 }
 
 void VisualScriptVariableSet::set_variable(StringName p_variable) {
@@ -1501,7 +1501,7 @@ PropertyInfo VisualScriptConstant::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptConstant::get_caption() const {
-	return TTR("Constant");
+	return RTR("Constant");
 }
 
 void VisualScriptConstant::set_constant_type(Variant::Type p_type) {
@@ -1628,7 +1628,7 @@ PropertyInfo VisualScriptPreload::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptPreload::get_caption() const {
-	return TTR("Preload");
+	return RTR("Preload");
 }
 
 void VisualScriptPreload::set_preload(const Ref<Resource> &p_preload) {
@@ -1708,7 +1708,7 @@ PropertyInfo VisualScriptIndexGet::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptIndexGet::get_caption() const {
-	return TTR("Get Index");
+	return RTR("Get Index");
 }
 
 class VisualScriptNodeInstanceIndexGet : public VisualScriptNodeInstance {
@@ -1775,7 +1775,7 @@ PropertyInfo VisualScriptIndexSet::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptIndexSet::get_caption() const {
-	return TTR("Set Index");
+	return RTR("Set Index");
 }
 
 class VisualScriptNodeInstanceIndexSet : public VisualScriptNodeInstance {
@@ -1836,7 +1836,7 @@ PropertyInfo VisualScriptGlobalConstant::get_output_value_port_info(int p_idx) c
 }
 
 String VisualScriptGlobalConstant::get_caption() const {
-	return TTR("Global Constant");
+	return RTR("Global Constant");
 }
 
 void VisualScriptGlobalConstant::set_global_constant(int p_which) {
@@ -1922,7 +1922,7 @@ PropertyInfo VisualScriptClassConstant::get_output_value_port_info(int p_idx) co
 }
 
 String VisualScriptClassConstant::get_caption() const {
-	return TTR("Class Constant");
+	return RTR("Class Constant");
 }
 
 void VisualScriptClassConstant::set_class_constant(const StringName &p_which) {
@@ -2047,7 +2047,7 @@ PropertyInfo VisualScriptBasicTypeConstant::get_output_value_port_info(int p_idx
 }
 
 String VisualScriptBasicTypeConstant::get_caption() const {
-	return TTR("Basic Constant");
+	return RTR("Basic Constant");
 }
 
 String VisualScriptBasicTypeConstant::get_text() const {
@@ -2212,7 +2212,7 @@ PropertyInfo VisualScriptMathConstant::get_output_value_port_info(int p_idx) con
 }
 
 String VisualScriptMathConstant::get_caption() const {
-	return TTR("Math Constant");
+	return RTR("Math Constant");
 }
 
 void VisualScriptMathConstant::set_math_constant(MathConstant p_which) {
@@ -2304,7 +2304,7 @@ PropertyInfo VisualScriptEngineSingleton::get_output_value_port_info(int p_idx) 
 }
 
 String VisualScriptEngineSingleton::get_caption() const {
-	return TTR("Get Engine Singleton");
+	return RTR("Get Engine Singleton");
 }
 
 void VisualScriptEngineSingleton::set_singleton(const String &p_string) {
@@ -2414,7 +2414,7 @@ PropertyInfo VisualScriptSceneNode::get_output_value_port_info(int p_idx) const 
 }
 
 String VisualScriptSceneNode::get_caption() const {
-	return TTR("Get Scene Node");
+	return RTR("Get Scene Node");
 }
 
 void VisualScriptSceneNode::set_node_path(const NodePath &p_path) {
@@ -2605,7 +2605,7 @@ PropertyInfo VisualScriptSceneTree::get_output_value_port_info(int p_idx) const 
 }
 
 String VisualScriptSceneTree::get_caption() const {
-	return TTR("Get Scene Tree");
+	return RTR("Get Scene Tree");
 }
 
 class VisualScriptNodeInstanceSceneTree : public VisualScriptNodeInstance {
@@ -2692,7 +2692,7 @@ PropertyInfo VisualScriptResourcePath::get_output_value_port_info(int p_idx) con
 }
 
 String VisualScriptResourcePath::get_caption() const {
-	return TTR("Resource Path");
+	return RTR("Resource Path");
 }
 
 void VisualScriptResourcePath::set_resource_path(const String &p_path) {
@@ -2774,7 +2774,7 @@ PropertyInfo VisualScriptSelf::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptSelf::get_caption() const {
-	return TTR("Get Self");
+	return RTR("Get Self");
 }
 
 class VisualScriptNodeInstanceSelf : public VisualScriptNodeInstance {
@@ -2944,7 +2944,7 @@ String VisualScriptCustomNode::get_caption() const {
 	if (GDVIRTUAL_CALL(_get_caption, ret)) {
 		return ret;
 	}
-	return TTR("CustomNode");
+	return RTR("CustomNode");
 }
 
 String VisualScriptCustomNode::get_text() const {
@@ -3138,7 +3138,7 @@ PropertyInfo VisualScriptSubCall::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptSubCall::get_caption() const {
-	return TTR("SubCall");
+	return RTR("SubCall");
 }
 
 String VisualScriptSubCall::get_text() const {
@@ -3349,7 +3349,7 @@ PropertyInfo VisualScriptConstructor::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptConstructor::get_caption() const {
-	return vformat(TTR("Construct %s"), Variant::get_type_name(type));
+	return vformat(RTR("Construct %s"), Variant::get_type_name(type));
 }
 
 String VisualScriptConstructor::get_category() const {
@@ -3466,7 +3466,7 @@ PropertyInfo VisualScriptLocalVar::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptLocalVar::get_caption() const {
-	return TTR("Get Local Var");
+	return RTR("Get Local Var");
 }
 
 String VisualScriptLocalVar::get_category() const {
@@ -3569,7 +3569,7 @@ PropertyInfo VisualScriptLocalVarSet::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptLocalVarSet::get_caption() const {
-	return TTR("Set Local Var");
+	return RTR("Set Local Var");
 }
 
 String VisualScriptLocalVarSet::get_text() const {
@@ -3693,7 +3693,7 @@ PropertyInfo VisualScriptInputAction::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptInputAction::get_caption() const {
-	return vformat(TTR("Action %s"), name);
+	return vformat(RTR("Action %s"), name);
 }
 
 String VisualScriptInputAction::get_category() const {
@@ -3847,7 +3847,7 @@ PropertyInfo VisualScriptDeconstruct::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptDeconstruct::get_caption() const {
-	return vformat(TTR("Deconstruct %s"), Variant::get_type_name(type));
+	return vformat(RTR("Deconstruct %s"), Variant::get_type_name(type));
 }
 
 String VisualScriptDeconstruct::get_category() const {

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -68,7 +68,7 @@ PropertyInfo VisualScriptYield::get_output_value_port_info(int p_idx) const {
 }
 
 String VisualScriptYield::get_caption() const {
-	return yield_mode == YIELD_RETURN ? TTR("Yield") : TTR("Wait");
+	return yield_mode == YIELD_RETURN ? RTR("Yield") : RTR("Wait");
 }
 
 String VisualScriptYield::get_text() const {
@@ -77,13 +77,13 @@ String VisualScriptYield::get_text() const {
 			return "";
 			break;
 		case YIELD_FRAME:
-			return TTR("Next Frame");
+			return RTR("Next Frame");
 			break;
 		case YIELD_PHYSICS_FRAME:
-			return TTR("Next Physics Frame");
+			return RTR("Next Physics Frame");
 			break;
 		case YIELD_WAIT:
-			return vformat(TTR("%s sec(s)"), rtos(wait_time));
+			return vformat(RTR("%s sec(s)"), rtos(wait_time));
 			break;
 	}
 
@@ -335,13 +335,18 @@ PropertyInfo VisualScriptYieldSignal::get_output_value_port_info(int p_idx) cons
 }
 
 String VisualScriptYieldSignal::get_caption() const {
-	static const char *cname[3] = {
-		TTRC("WaitSignal"),
-		TTRC("WaitNodeSignal"),
-		TTRC("WaitInstanceSignal"),
-	};
-
-	return TTRGET(cname[call_mode]);
+	switch (call_mode) {
+		case CALL_MODE_SELF: {
+			return RTR("WaitSignal");
+		} break;
+		case CALL_MODE_NODE_PATH: {
+			return RTR("WaitNodeSignal");
+		} break;
+		case CALL_MODE_INSTANCE: {
+			return RTR("WaitInstanceSignal");
+		} break;
+	}
+	return String();
 }
 
 String VisualScriptYieldSignal::get_text() const {


### PR DESCRIPTION
Although caption and text functions are only used by the editor, they are still available at runtime, so `TTR()` should not be used here.

https://github.com/godotengine/godot/blob/77f80aa4ee1a93beeb0eacaf35646fc97ddf2abb/modules/visual_script/visual_script_func_nodes.cpp#L1035-L1048

This is safe because the static local variable is initialized when first accessed, and `TranslationServer` is ready at that point. Cherry-picking might need to change this into a if empty block as list initialization is not available for `LocalVector` on `3.x`.