### PR TITLE
Fix mixed smoothed and non-smoothed face normals computation for CSG shapes

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -303,17 +303,19 @@ void CSGShape3D::_update_shape() {
 		ERR_CONTINUE(mat < -1 || mat >= face_count.size());
 		int idx = mat == -1 ? face_count.size() - 1 : mat;
 
-		Plane p(n->faces[i].vertices[0], n->faces[i].vertices[1], n->faces[i].vertices[2]);
+		if (n->faces[i].smooth) {
+			Plane p(n->faces[i].vertices[0], n->faces[i].vertices[1], n->faces[i].vertices[2]);
 
-		for (int j = 0; j < 3; j++) {
-			Vector3 v = n->faces[i].vertices[j];
-			Vector3 add;
-			if (vec_map.lookup(v, add)) {
-				add += p.normal;
-			} else {
-				add = p.normal;
+			for (int j = 0; j < 3; j++) {
+				Vector3 v = n->faces[i].vertices[j];
+				Vector3 add;
+				if (vec_map.lookup(v, add)) {
+					add += p.normal;
+				} else {
+					add = p.normal;
+				}
+				vec_map.set(v, add);
 			}
-			vec_map.set(v, add);
 		}
 
 		face_count.write[idx]++;


### PR DESCRIPTION
When computing smoothed normals on CSG shapes, the normals from all the faces sharing a vertex are averaged together to compute the smoothed "shared" normal between the faces.

I don't think the behavior is correct, because it means that even faces that are not smoothed participate to the computation of their smooth neighbor's faces.

The problem is particularly visible when substracting a sphere or a torus from a box, at the edge between them :

**Before**
![smooth_normals_before](https://user-images.githubusercontent.com/1554884/157924889-e81c11e3-10fd-4300-8082-90a7e0e628ae.png)

**After**
![smooth_normals_after](https://user-images.githubusercontent.com/1554884/157924901-bd7d14e9-b2e5-4415-acf6-29979e8854c5.png)

and also on the cylinder which has a strange shading (and a small glitch is visible at the bottom left) :

**Before**
![cylinder_bottom_before](https://user-images.githubusercontent.com/1554884/157924935-c4bfe446-6f19-4e98-bc8c-2cfd07141d9f.png)

**After**
![cylinder_bottom_after](https://user-images.githubusercontent.com/1554884/157924955-9a9f3ed4-ab49-4a06-b865-ad38f1a691d0.png)

This is related to some comments in #49800.

Bugsquad edit:
- Fixes #49800