### PR TITLE
Use get_cursor_shape for identifying the cursor shape in AnimationNodeStateMachineEditor

### DIFF
--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -138,7 +138,6 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	StringName selected_transition_from;
 	StringName selected_transition_to;
 
-	bool over_text;
 	StringName over_node;
 	int over_node_what;
 
@@ -185,6 +184,7 @@ public:
 	static AnimationNodeStateMachineEditor *get_singleton() { return singleton; }
 	virtual bool can_edit(const Ref<AnimationNode> &p_node) override;
 	virtual void edit(const Ref<AnimationNode> &p_node) override;
+	virtual CursorShape get_cursor_shape(const Point2 &p_pos) const override;
 	AnimationNodeStateMachineEditor();
 };
 


### PR DESCRIPTION
get_cursor_shape() is used in cases where a Control displays different cursors in different areas.
There is no need to set the default cursor shape on every mouse move event.

Was part of the reason for #58960.

Also fix that the cursor was `CURSOR_IBEAM` in some cases where no text input field was selectable.