### PR TITLE
Don't use rounded corners for PopupMenus in the editor theme

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -912,6 +912,9 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Always display a border for PopupMenus so they can be distinguished from their background.
 	style_popup_menu->set_border_width_all(EDSCALE);
 	style_popup_menu->set_border_color(dark_color_2);
+	// Popups are separate windows by default in the editor. Windows currently don't support per-pixel transparency
+	// in 4.0, and even if it was, it may not always work in practice (e.g. running with compositing disabled).
+	style_popup_menu->set_corner_radius_all(0);
 	theme->set_stylebox("panel", "PopupMenu", style_popup_menu);
 
 	Ref<StyleBoxFlat> style_menu_hover = style_widget_hover->duplicate();


### PR DESCRIPTION
PopupMenus use separate windows by default in the editor, and windows no longer support per-pixel transparency for now in 4.0. Even if per-pixel transparency was reimplemented, we can't assume that it'll always work in practice (e.g. when compositing is disabled).

This closes https://github.com/godotengine/godot/issues/56009.

## Preview

*Scaled to 400% with nearest-neighbor filtering.*

### Before

![2022-03-11_21 53 03](https://user-images.githubusercontent.com/180032/157966885-0f8c6b3d-c192-4249-8a39-7235640059f1.png)

### After

![2022-03-11_21 54 06](https://user-images.githubusercontent.com/180032/157966887-e9bd91be-a5b2-4a46-9120-f3190f5f6bc0.png)