### PR TITLE
GraphEdit's popup_request signal emits mouse click position without offset

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -1170,7 +1170,7 @@ void GraphEdit::gui_input(const Ref<InputEvent> &p_ev) {
 				if (connecting) {
 					force_connection_drag_end();
 				} else {
-					emit_signal(SNAME("popup_request"), get_screen_position() + b->get_position());
+					emit_signal(SNAME("popup_request"), b->get_position());
 				}
 			}
 		}


### PR DESCRIPTION
This fixes #57410 by emitting just the mouse click position for the `popup_request` signal.

https://user-images.githubusercontent.com/18116695/158011813-935a5b1a-9dc8-4305-ac78-a4606a8e2c3f.mp4


