### PR TITLE
Clear owners when pruning even out of the tree

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -252,7 +252,7 @@ void Node::_propagate_enter_tree() {
 	// enter groups
 }
 
-void Node::_propagate_after_exit_tree() {
+void Node::_propagate_after_exit_branch(bool p_exiting_tree) {
 	// Clear owner if it was not part of the pruned branch
 	if (data.owner) {
 		bool found = false;
@@ -275,11 +275,13 @@ void Node::_propagate_after_exit_tree() {
 
 	data.blocked++;
 	for (int i = 0; i < data.children.size(); i++) {
-		data.children[i]->_propagate_after_exit_tree();
+		data.children[i]->_propagate_after_exit_branch(p_exiting_tree);
 	}
 	data.blocked--;
 
-	emit_signal(SceneStringNames::get_singleton()->tree_exited);
+	if (p_exiting_tree) {
+		emit_signal(SceneStringNames::get_singleton()->tree_exited);
+	}
 }
 
 void Node::_propagate_exit_tree() {
@@ -1265,9 +1267,7 @@ void Node::remove_child(Node *p_child) {
 	p_child->data.parent = nullptr;
 	p_child->data.pos = -1;
 
-	if (data.inside_tree) {
-		p_child->_propagate_after_exit_tree();
-	}
+	p_child->_propagate_after_exit_branch(data.inside_tree);
 }
 
 int Node::get_child_count() const {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -180,7 +180,7 @@ private:
 	void _propagate_enter_tree();
 	void _propagate_ready();
 	void _propagate_exit_tree();
-	void _propagate_after_exit_tree();
+	void _propagate_after_exit_branch(bool p_exiting_tree);
 	void _propagate_physics_interpolated(bool p_interpolated);
 	void _print_stray_nodes();
 	void _propagate_pause_owner(Node *p_owner);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -707,7 +707,7 @@ void SceneTree::finish() {
 
 	if (root) {
 		root->_set_tree(nullptr);
-		root->_propagate_after_exit_tree();
+		root->_propagate_after_exit_branch(true);
 		memdelete(root); //delete root
 		root = nullptr;
 	}
@@ -2246,7 +2246,7 @@ SceneTree::SceneTree() {
 SceneTree::~SceneTree() {
 	if (root) {
 		root->_set_tree(nullptr);
-		root->_propagate_after_exit_tree();
+		root->_propagate_after_exit_branch(true);
 		memdelete(root);
 	}
 


### PR DESCRIPTION
Fixes #57097.

**NOTE:** Godot 4.0 already handles this properly.