### PR TITLE
Restrict the condition when checking if a script is a template

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -827,10 +827,6 @@ Error GDScript::reload(bool p_keep_state) {
 	if (basedir.begins_with(EditorSettings::get_singleton()->get_project_script_templates_dir())) {
 		return OK;
 	}
-#else
-	if (source.contains("_BASE_")) {
-		return OK;
-	}
 #endif
 
 	{


### PR DESCRIPTION
fix #59059

I wondering if the condition without the editor is even required but I'm not sure.

Nevertheless this PR fix the condition way too wide explained in the issue.