### PR TITLE
Add all/individual setters for StyleBox default margins and StyleBoxTexture margin size and unbind `StyleBox*.set_*_individual()` methods

### DIFF
--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -104,16 +104,6 @@
 				Sets the default margin to [param offset] pixels for all sides.
 			</description>
 		</method>
-		<method name="set_default_margin_individual">
-			<return type="void" />
-			<param index="0" name="offset_left" type="float" />
-			<param index="1" name="offset_top" type="float" />
-			<param index="2" name="offset_right" type="float" />
-			<param index="3" name="offset_bottom" type="float" />
-			<description>
-				Sets the default margin for each side to [param offset_left], [param offset_top], [param offset_right], and [param offset_bottom] pixels.
-			</description>
-		</method>
 		<method name="test_mask" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="point" type="Vector2" />

--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -97,6 +97,23 @@
 				Sets the default value of the specified [enum Side] to [param offset] pixels.
 			</description>
 		</method>
+		<method name="set_default_margin_all">
+			<return type="void" />
+			<param index="0" name="offset" type="float" />
+			<description>
+				Sets the default margin to [param offset] pixels for all sides.
+			</description>
+		</method>
+		<method name="set_default_margin_individual">
+			<return type="void" />
+			<param index="0" name="offset_left" type="float" />
+			<param index="1" name="offset_top" type="float" />
+			<param index="2" name="offset_right" type="float" />
+			<param index="3" name="offset_bottom" type="float" />
+			<description>
+				Sets the default margin for each side to [param offset_left], [param offset_top], [param offset_right], and [param offset_bottom] pixels.
+			</description>
+		</method>
 		<method name="test_mask" qualifiers="const">
 			<return type="bool" />
 			<param index="0" name="point" type="Vector2" />

--- a/doc/classes/StyleBoxFlat.xml
+++ b/doc/classes/StyleBoxFlat.xml
@@ -81,16 +81,6 @@
 				Sets the corner radius to [param radius] pixels for all corners.
 			</description>
 		</method>
-		<method name="set_corner_radius_individual">
-			<return type="void" />
-			<param index="0" name="radius_top_left" type="int" />
-			<param index="1" name="radius_top_right" type="int" />
-			<param index="2" name="radius_bottom_right" type="int" />
-			<param index="3" name="radius_bottom_left" type="int" />
-			<description>
-				Sets the corner radius for each corner to [param radius_top_left], [param radius_top_right], [param radius_bottom_right], and [param radius_bottom_left] pixels.
-			</description>
-		</method>
 		<method name="set_expand_margin">
 			<return type="void" />
 			<param index="0" name="margin" type="int" enum="Side" />
@@ -104,16 +94,6 @@
 			<param index="0" name="size" type="float" />
 			<description>
 				Sets the expand margin to [param size] pixels for all margins.
-			</description>
-		</method>
-		<method name="set_expand_margin_individual">
-			<return type="void" />
-			<param index="0" name="size_left" type="float" />
-			<param index="1" name="size_top" type="float" />
-			<param index="2" name="size_right" type="float" />
-			<param index="3" name="size_bottom" type="float" />
-			<description>
-				Sets the expand margin for each margin to [param size_left], [param size_top], [param size_right], and [param size_bottom] pixels.
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/StyleBoxTexture.xml
+++ b/doc/classes/StyleBoxTexture.xml
@@ -56,6 +56,23 @@
 				Sets the margin to [param size] pixels for the specified [enum Side].
 			</description>
 		</method>
+		<method name="set_margin_size_all">
+			<return type="void" />
+			<param index="0" name="size" type="float" />
+			<description>
+				Sets the margin to [param size] pixels for all sides.
+			</description>
+		</method>
+		<method name="set_margin_size_individual">
+			<return type="void" />
+			<param index="0" name="size_left" type="float" />
+			<param index="1" name="size_top" type="float" />
+			<param index="2" name="size_right" type="float" />
+			<param index="3" name="size_bottom" type="float" />
+			<description>
+				Sets the margin for each side to [param size_left], [param size_top], [param size_right], and [param size_bottom] pixels.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="axis_stretch_horizontal" type="int" setter="set_h_axis_stretch_mode" getter="get_h_axis_stretch_mode" enum="StyleBoxTexture.AxisStretchMode" default="0">

--- a/doc/classes/StyleBoxTexture.xml
+++ b/doc/classes/StyleBoxTexture.xml
@@ -30,16 +30,6 @@
 				Sets the expand margin to [param size] pixels for all margins.
 			</description>
 		</method>
-		<method name="set_expand_margin_individual">
-			<return type="void" />
-			<param index="0" name="size_left" type="float" />
-			<param index="1" name="size_top" type="float" />
-			<param index="2" name="size_right" type="float" />
-			<param index="3" name="size_bottom" type="float" />
-			<description>
-				Sets the expand margin for each margin to [param size_left], [param size_top], [param size_right], and [param size_bottom] pixels.
-			</description>
-		</method>
 		<method name="set_expand_margin_size">
 			<return type="void" />
 			<param index="0" name="margin" type="int" enum="Side" />
@@ -61,16 +51,6 @@
 			<param index="0" name="size" type="float" />
 			<description>
 				Sets the margin to [param size] pixels for all sides.
-			</description>
-		</method>
-		<method name="set_margin_size_individual">
-			<return type="void" />
-			<param index="0" name="size_left" type="float" />
-			<param index="1" name="size_top" type="float" />
-			<param index="2" name="size_right" type="float" />
-			<param index="3" name="size_bottom" type="float" />
-			<description>
-				Sets the margin for each side to [param size_left], [param size_top], [param size_right], and [param size_bottom] pixels.
 			</description>
 		</method>
 	</methods>

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -157,24 +157,15 @@ void EditorColorMap::create() {
 static Ref<StyleBoxTexture> make_stylebox(Ref<Texture2D> p_texture, float p_left, float p_top, float p_right, float p_bottom, float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1, bool p_draw_center = true) {
 	Ref<StyleBoxTexture> style(memnew(StyleBoxTexture));
 	style->set_texture(p_texture);
-	style->set_margin_size(SIDE_LEFT, p_left * EDSCALE);
-	style->set_margin_size(SIDE_RIGHT, p_right * EDSCALE);
-	style->set_margin_size(SIDE_BOTTOM, p_bottom * EDSCALE);
-	style->set_margin_size(SIDE_TOP, p_top * EDSCALE);
-	style->set_default_margin(SIDE_LEFT, p_margin_left * EDSCALE);
-	style->set_default_margin(SIDE_RIGHT, p_margin_right * EDSCALE);
-	style->set_default_margin(SIDE_BOTTOM, p_margin_bottom * EDSCALE);
-	style->set_default_margin(SIDE_TOP, p_margin_top * EDSCALE);
+	style->set_margin_size_individual(p_left * EDSCALE, p_top * EDSCALE, p_right * EDSCALE, p_bottom * EDSCALE);
+	style->set_default_margin_individual(p_margin_left * EDSCALE, p_margin_top * EDSCALE, p_margin_right * EDSCALE, p_margin_bottom * EDSCALE);
 	style->set_draw_center(p_draw_center);
 	return style;
 }
 
 static Ref<StyleBoxEmpty> make_empty_stylebox(float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1) {
 	Ref<StyleBoxEmpty> style(memnew(StyleBoxEmpty));
-	style->set_default_margin(SIDE_LEFT, p_margin_left * EDSCALE);
-	style->set_default_margin(SIDE_RIGHT, p_margin_right * EDSCALE);
-	style->set_default_margin(SIDE_BOTTOM, p_margin_bottom * EDSCALE);
-	style->set_default_margin(SIDE_TOP, p_margin_top * EDSCALE);
+	style->set_default_margin_individual(p_margin_left * EDSCALE, p_margin_top * EDSCALE, p_margin_right * EDSCALE, p_margin_bottom * EDSCALE);
 	return style;
 }
 
@@ -184,10 +175,7 @@ static Ref<StyleBoxFlat> make_flat_stylebox(Color p_color, float p_margin_left =
 	// Adjust level of detail based on the corners' effective sizes.
 	style->set_corner_detail(Math::ceil(0.8 * p_corner_width * EDSCALE));
 	style->set_corner_radius_all(p_corner_width * EDSCALE);
-	style->set_default_margin(SIDE_LEFT, p_margin_left * EDSCALE);
-	style->set_default_margin(SIDE_RIGHT, p_margin_right * EDSCALE);
-	style->set_default_margin(SIDE_BOTTOM, p_margin_bottom * EDSCALE);
-	style->set_default_margin(SIDE_TOP, p_margin_top * EDSCALE);
+	style->set_default_margin_individual(p_margin_left * EDSCALE, p_margin_top * EDSCALE, p_margin_right * EDSCALE, p_margin_bottom * EDSCALE);
 	// Work around issue about antialiased edges being blurrier (GH-35279).
 	style->set_anti_aliased(false);
 	return style;
@@ -600,10 +588,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	const Vector2 widget_default_margin = Vector2(extra_spacing + 6, extra_spacing + default_margin_size + 1) * EDSCALE;
 
 	Ref<StyleBoxFlat> style_widget = style_default->duplicate();
-	style_widget->set_default_margin(SIDE_LEFT, widget_default_margin.x);
-	style_widget->set_default_margin(SIDE_TOP, widget_default_margin.y);
-	style_widget->set_default_margin(SIDE_RIGHT, widget_default_margin.x);
-	style_widget->set_default_margin(SIDE_BOTTOM, widget_default_margin.y);
+	style_widget->set_default_margin_individual(widget_default_margin.x, widget_default_margin.y, widget_default_margin.x, widget_default_margin.y);
 	style_widget->set_bg_color(dark_color_1);
 	style_widget->set_border_color(dark_color_2);
 
@@ -626,10 +611,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Style for windows, popups, etc..
 	Ref<StyleBoxFlat> style_popup = style_default->duplicate();
 	const int popup_margin_size = default_margin_size * EDSCALE * 3;
-	style_popup->set_default_margin(SIDE_LEFT, popup_margin_size);
-	style_popup->set_default_margin(SIDE_TOP, popup_margin_size);
-	style_popup->set_default_margin(SIDE_RIGHT, popup_margin_size);
-	style_popup->set_default_margin(SIDE_BOTTOM, popup_margin_size);
+	style_popup->set_default_margin_all(popup_margin_size);
 	style_popup->set_border_color(contrast_color_1);
 	const Color shadow_color = Color(0, 0, 0, dark_theme ? 0.3 : 0.1);
 	style_popup->set_shadow_color(shadow_color);
@@ -922,10 +904,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// Checkbox
 	Ref<StyleBoxFlat> sb_checkbox = style_menu->duplicate();
-	sb_checkbox->set_default_margin(SIDE_LEFT, default_margin_size * EDSCALE);
-	sb_checkbox->set_default_margin(SIDE_RIGHT, default_margin_size * EDSCALE);
-	sb_checkbox->set_default_margin(SIDE_TOP, default_margin_size * EDSCALE);
-	sb_checkbox->set_default_margin(SIDE_BOTTOM, default_margin_size * EDSCALE);
+	sb_checkbox->set_default_margin_all(default_margin_size * EDSCALE);
 
 	theme->set_stylebox("normal", "CheckBox", sb_checkbox);
 	theme->set_stylebox("pressed", "CheckBox", sb_checkbox);
@@ -965,10 +944,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// Use 1 pixel for the sides, since if 0 is used, the highlight of hovered items is drawn
 	// on top of the popup border. This causes a 'gap' in the panel border when an item is highlighted,
 	// and it looks weird. 1px solves this.
-	style_popup_menu->set_default_margin(SIDE_LEFT, EDSCALE);
-	style_popup_menu->set_default_margin(SIDE_TOP, 2 * EDSCALE);
-	style_popup_menu->set_default_margin(SIDE_RIGHT, EDSCALE);
-	style_popup_menu->set_default_margin(SIDE_BOTTOM, 2 * EDSCALE);
+	style_popup_menu->set_default_margin_individual(EDSCALE, 2 * EDSCALE, EDSCALE, 2 * EDSCALE);
 	// Always display a border for PopupMenus so they can be distinguished from their background.
 	style_popup_menu->set_border_width_all(EDSCALE);
 	style_popup_menu->set_border_color(dark_color_2);
@@ -1024,10 +1000,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		sub_inspector_bg->set_bg_color(dark_color_1.lerp(si_base_color, 0.08));
 		sub_inspector_bg->set_border_width_all(2 * EDSCALE);
 		sub_inspector_bg->set_border_color(si_base_color * Color(0.7, 0.7, 0.7, 0.8));
-		sub_inspector_bg->set_default_margin(SIDE_LEFT, 4 * EDSCALE);
-		sub_inspector_bg->set_default_margin(SIDE_RIGHT, 4 * EDSCALE);
-		sub_inspector_bg->set_default_margin(SIDE_BOTTOM, 4 * EDSCALE);
-		sub_inspector_bg->set_default_margin(SIDE_TOP, 4 * EDSCALE);
+		sub_inspector_bg->set_default_margin_all(4 * EDSCALE);
 		sub_inspector_bg->set_corner_radius(CORNER_TOP_LEFT, 0);
 		sub_inspector_bg->set_corner_radius(CORNER_TOP_RIGHT, 0);
 
@@ -1255,10 +1228,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_content_panel->set_corner_radius(CORNER_TOP_LEFT, 0);
 	style_content_panel->set_corner_radius(CORNER_TOP_RIGHT, 0);
 	// Compensate for the border.
-	style_content_panel->set_default_margin(SIDE_TOP, (2 + margin_size_extra) * EDSCALE);
-	style_content_panel->set_default_margin(SIDE_RIGHT, margin_size_extra * EDSCALE);
-	style_content_panel->set_default_margin(SIDE_BOTTOM, margin_size_extra * EDSCALE);
-	style_content_panel->set_default_margin(SIDE_LEFT, margin_size_extra * EDSCALE);
+	style_content_panel->set_default_margin_individual(margin_size_extra * EDSCALE, (2 + margin_size_extra) * EDSCALE, margin_size_extra * EDSCALE, margin_size_extra * EDSCALE);
 	theme->set_stylebox("panel", "TabContainer", style_content_panel);
 
 	// Bottom panel.
@@ -1279,10 +1249,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// This stylebox is used in 3d and 2d viewports (no borders).
 	Ref<StyleBoxFlat> style_content_panel_vp = style_content_panel->duplicate();
-	style_content_panel_vp->set_default_margin(SIDE_LEFT, border_width * 2);
-	style_content_panel_vp->set_default_margin(SIDE_TOP, default_margin_size * EDSCALE);
-	style_content_panel_vp->set_default_margin(SIDE_RIGHT, border_width * 2);
-	style_content_panel_vp->set_default_margin(SIDE_BOTTOM, border_width * 2);
+	style_content_panel_vp->set_default_margin_individual(border_width * 2, default_margin_size * EDSCALE, border_width * 2, border_width * 2);
 	theme->set_stylebox("Content", "EditorStyles", style_content_panel_vp);
 
 	// This stylebox is used by preview tabs in the Theme Editor.
@@ -1519,10 +1486,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	// is only relevant for default tooltips.
 	Ref<StyleBoxFlat> style_tooltip = style_popup->duplicate();
 	style_tooltip->set_shadow_size(0);
-	style_tooltip->set_default_margin(SIDE_LEFT, default_margin_size * EDSCALE * 0.5);
-	style_tooltip->set_default_margin(SIDE_TOP, default_margin_size * EDSCALE * 0.5);
-	style_tooltip->set_default_margin(SIDE_RIGHT, default_margin_size * EDSCALE * 0.5);
-	style_tooltip->set_default_margin(SIDE_BOTTOM, default_margin_size * EDSCALE * 0.5);
+	style_tooltip->set_default_margin_all(default_margin_size * EDSCALE * 0.5);
 	style_tooltip->set_bg_color(dark_color_3 * Color(0.8, 0.8, 0.8, 0.9));
 	style_tooltip->set_border_width_all(0);
 	theme->set_color("font_color", "TooltipLabel", font_hover_color);

--- a/editor/editor_toaster.cpp
+++ b/editor/editor_toaster.cpp
@@ -498,10 +498,7 @@ EditorToaster::EditorToaster() {
 
 	Ref<StyleBoxFlat> boxes[] = { info_panel_style_background, warning_panel_style_background, error_panel_style_background };
 	for (int i = 0; i < 3; i++) {
-		boxes[i]->set_default_margin(SIDE_LEFT, int(stylebox_radius * 2.5));
-		boxes[i]->set_default_margin(SIDE_RIGHT, int(stylebox_radius * 2.5));
-		boxes[i]->set_default_margin(SIDE_TOP, 3);
-		boxes[i]->set_default_margin(SIDE_BOTTOM, 3);
+		boxes[i]->set_default_margin_individual(int(stylebox_radius * 2.5), 3, int(stylebox_radius * 2.5), 3);
 	}
 
 	// Theming (progress).

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -101,10 +101,7 @@ void EditorAssetLibraryItem::_bind_methods() {
 EditorAssetLibraryItem::EditorAssetLibraryItem() {
 	Ref<StyleBoxEmpty> border;
 	border.instantiate();
-	border->set_default_margin(SIDE_LEFT, 5 * EDSCALE);
-	border->set_default_margin(SIDE_RIGHT, 5 * EDSCALE);
-	border->set_default_margin(SIDE_BOTTOM, 5 * EDSCALE);
-	border->set_default_margin(SIDE_TOP, 5 * EDSCALE);
+	border->set_default_margin_all(5 * EDSCALE);
 	add_theme_style_override("panel", border);
 
 	HBoxContainer *hb = memnew(HBoxContainer);
@@ -1510,10 +1507,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	Ref<StyleBoxEmpty> border2;
 	border2.instantiate();
-	border2->set_default_margin(SIDE_LEFT, 15 * EDSCALE);
-	border2->set_default_margin(SIDE_RIGHT, 35 * EDSCALE);
-	border2->set_default_margin(SIDE_BOTTOM, 15 * EDSCALE);
-	border2->set_default_margin(SIDE_TOP, 15 * EDSCALE);
+	border2->set_default_margin_individual(15 * EDSCALE, 15 * EDSCALE, 35 * EDSCALE, 15 * EDSCALE);
 
 	PanelContainer *library_vb_border = memnew(PanelContainer);
 	library_scroll->add_child(library_vb_border);

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -3959,10 +3959,8 @@ void CanvasItemEditor::_notification(int p_what) {
 
 		case NOTIFICATION_ENTER_TREE: {
 			select_sb->set_texture(get_theme_icon(SNAME("EditorRect2D"), SNAME("EditorIcons")));
-			for (int i = 0; i < 4; i++) {
-				select_sb->set_margin_size(Side(i), 4);
-				select_sb->set_default_margin(Side(i), 4);
-			}
+			select_sb->set_margin_size_all(4);
+			select_sb->set_default_margin_all(4);
 
 			AnimationPlayerEditor::get_singleton()->get_track_editor()->connect("visibility_changed", callable_mp(this, &CanvasItemEditor::_keying_changed));
 			_keying_changed();

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -51,10 +51,7 @@ static const int default_corner_radius = 3;
 static Ref<StyleBoxFlat> make_flat_stylebox(Color p_color, float p_margin_left = default_margin, float p_margin_top = default_margin, float p_margin_right = default_margin, float p_margin_bottom = default_margin, int p_corner_radius = default_corner_radius, bool p_draw_center = true, int p_border_width = 0) {
 	Ref<StyleBoxFlat> style(memnew(StyleBoxFlat));
 	style->set_bg_color(p_color);
-	style->set_default_margin(SIDE_LEFT, p_margin_left * scale);
-	style->set_default_margin(SIDE_RIGHT, p_margin_right * scale);
-	style->set_default_margin(SIDE_BOTTOM, p_margin_bottom * scale);
-	style->set_default_margin(SIDE_TOP, p_margin_top * scale);
+	style->set_default_margin_individual(p_margin_left * scale, p_margin_top * scale, p_margin_right * scale, p_margin_bottom * scale);
 
 	style->set_corner_radius_all(p_corner_radius);
 	style->set_anti_aliased(true);
@@ -93,12 +90,7 @@ static Ref<ImageTexture> generate_icon(int p_index) {
 
 static Ref<StyleBox> make_empty_stylebox(float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1) {
 	Ref<StyleBox> style(memnew(StyleBoxEmpty));
-
-	style->set_default_margin(SIDE_LEFT, p_margin_left * scale);
-	style->set_default_margin(SIDE_RIGHT, p_margin_right * scale);
-	style->set_default_margin(SIDE_BOTTOM, p_margin_bottom * scale);
-	style->set_default_margin(SIDE_TOP, p_margin_top * scale);
-
+	style->set_default_margin_individual(p_margin_left * scale, p_margin_top * scale, p_margin_right * scale, p_margin_bottom * scale);
 	return style;
 }
 
@@ -279,15 +271,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// CheckBox
 
 	Ref<StyleBox> cbx_empty = memnew(StyleBoxEmpty);
-	cbx_empty->set_default_margin(SIDE_LEFT, 4 * scale);
-	cbx_empty->set_default_margin(SIDE_RIGHT, 4 * scale);
-	cbx_empty->set_default_margin(SIDE_TOP, 4 * scale);
-	cbx_empty->set_default_margin(SIDE_BOTTOM, 4 * scale);
+	cbx_empty->set_default_margin_all(4 * scale);
 	Ref<StyleBox> cbx_focus = focus;
-	cbx_focus->set_default_margin(SIDE_LEFT, 4 * scale);
-	cbx_focus->set_default_margin(SIDE_RIGHT, 4 * scale);
-	cbx_focus->set_default_margin(SIDE_TOP, 4 * scale);
-	cbx_focus->set_default_margin(SIDE_BOTTOM, 4 * scale);
+	cbx_focus->set_default_margin_all(4 * scale);
 
 	theme->set_stylebox("normal", "CheckBox", cbx_empty);
 	theme->set_stylebox("pressed", "CheckBox", cbx_empty);
@@ -323,10 +309,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	// CheckButton
 
 	Ref<StyleBox> cb_empty = memnew(StyleBoxEmpty);
-	cb_empty->set_default_margin(SIDE_LEFT, 6 * scale);
-	cb_empty->set_default_margin(SIDE_RIGHT, 6 * scale);
-	cb_empty->set_default_margin(SIDE_TOP, 4 * scale);
-	cb_empty->set_default_margin(SIDE_BOTTOM, 4 * scale);
+	cb_empty->set_default_margin_individual(6 * scale, 4 * scale, 6 * scale, 4 * scale);
 
 	theme->set_stylebox("normal", "CheckButton", cb_empty);
 	theme->set_stylebox("pressed", "CheckButton", cb_empty);
@@ -638,16 +621,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	Ref<StyleBoxLine> separator_horizontal = memnew(StyleBoxLine);
 	separator_horizontal->set_thickness(Math::round(scale));
 	separator_horizontal->set_color(style_separator_color);
-	separator_horizontal->set_default_margin(SIDE_LEFT, default_margin);
-	separator_horizontal->set_default_margin(SIDE_TOP, 0);
-	separator_horizontal->set_default_margin(SIDE_RIGHT, default_margin);
-	separator_horizontal->set_default_margin(SIDE_BOTTOM, 0);
+	separator_horizontal->set_default_margin_individual(default_margin, 0, default_margin, 0);
 	Ref<StyleBoxLine> separator_vertical = separator_horizontal->duplicate();
 	separator_vertical->set_vertical(true);
-	separator_vertical->set_default_margin(SIDE_LEFT, 0);
-	separator_vertical->set_default_margin(SIDE_TOP, default_margin);
-	separator_vertical->set_default_margin(SIDE_RIGHT, 0);
-	separator_vertical->set_default_margin(SIDE_BOTTOM, default_margin);
+	separator_vertical->set_default_margin_individual(0, default_margin, 0, default_margin);
 
 	// Always display a border for PopupMenus so they can be distinguished from their background.
 	Ref<StyleBoxFlat> style_popup_panel = make_flat_stylebox(style_popup_color);

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -41,6 +41,7 @@ float StyleBox::get_style_margin(Side p_side) const {
 	}
 	return 0;
 }
+
 bool StyleBox::test_mask(const Point2 &p_point, const Rect2 &p_rect) const {
 	bool ret;
 	if (GDVIRTUAL_CALL(_test_mask, p_point, p_rect, ret)) {
@@ -60,6 +61,21 @@ void StyleBox::set_default_margin(Side p_side, float p_value) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 
 	margin[p_side] = p_value;
+	emit_changed();
+}
+
+void StyleBox::set_default_margin_all(float p_value) {
+	for (int i = 0; i < 4; i++) {
+		margin[i] = p_value;
+	}
+	emit_changed();
+}
+
+void StyleBox::set_default_margin_individual(float p_left, float p_top, float p_right, float p_bottom) {
+	margin[SIDE_LEFT] = p_left;
+	margin[SIDE_TOP] = p_top;
+	margin[SIDE_RIGHT] = p_right;
+	margin[SIDE_BOTTOM] = p_bottom;
 	emit_changed();
 }
 
@@ -112,6 +128,8 @@ void StyleBox::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("test_mask", "point", "rect"), &StyleBox::test_mask);
 
 	ClassDB::bind_method(D_METHOD("set_default_margin", "margin", "offset"), &StyleBox::set_default_margin);
+	ClassDB::bind_method(D_METHOD("set_default_margin_all", "offset"), &StyleBox::set_default_margin_all);
+	ClassDB::bind_method(D_METHOD("set_default_margin_individual", "offset_left", "offset_top", "offset_right", "offset_bottom"), &StyleBox::set_default_margin_individual);
 	ClassDB::bind_method(D_METHOD("get_default_margin", "margin"), &StyleBox::get_default_margin);
 
 	ClassDB::bind_method(D_METHOD("get_margin", "margin"), &StyleBox::get_margin);
@@ -162,6 +180,21 @@ void StyleBoxTexture::set_margin_size(Side p_side, float p_size) {
 	ERR_FAIL_INDEX((int)p_side, 4);
 
 	margin[p_side] = p_size;
+	emit_changed();
+}
+
+void StyleBoxTexture::set_margin_size_all(float p_size) {
+	for (int i = 0; i < 4; i++) {
+		margin[i] = p_size;
+	}
+	emit_changed();
+}
+
+void StyleBoxTexture::set_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom) {
+	margin[SIDE_LEFT] = p_left;
+	margin[SIDE_TOP] = p_top;
+	margin[SIDE_RIGHT] = p_right;
+	margin[SIDE_BOTTOM] = p_bottom;
 	emit_changed();
 }
 
@@ -292,6 +325,8 @@ void StyleBoxTexture::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_texture"), &StyleBoxTexture::get_texture);
 
 	ClassDB::bind_method(D_METHOD("set_margin_size", "margin", "size"), &StyleBoxTexture::set_margin_size);
+	ClassDB::bind_method(D_METHOD("set_margin_size_all", "size"), &StyleBoxTexture::set_margin_size_all);
+	ClassDB::bind_method(D_METHOD("set_margin_size_individual", "size_left", "size_top", "size_right", "size_bottom"), &StyleBoxTexture::set_margin_size_individual);
 	ClassDB::bind_method(D_METHOD("get_margin_size", "margin"), &StyleBoxTexture::get_margin_size);
 
 	ClassDB::bind_method(D_METHOD("set_expand_margin_size", "margin", "size"), &StyleBoxTexture::set_expand_margin_size);

--- a/scene/resources/style_box.cpp
+++ b/scene/resources/style_box.cpp
@@ -129,7 +129,6 @@ void StyleBox::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_default_margin", "margin", "offset"), &StyleBox::set_default_margin);
 	ClassDB::bind_method(D_METHOD("set_default_margin_all", "offset"), &StyleBox::set_default_margin_all);
-	ClassDB::bind_method(D_METHOD("set_default_margin_individual", "offset_left", "offset_top", "offset_right", "offset_bottom"), &StyleBox::set_default_margin_individual);
 	ClassDB::bind_method(D_METHOD("get_default_margin", "margin"), &StyleBox::get_default_margin);
 
 	ClassDB::bind_method(D_METHOD("get_margin", "margin"), &StyleBox::get_margin);
@@ -326,12 +325,10 @@ void StyleBoxTexture::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_margin_size", "margin", "size"), &StyleBoxTexture::set_margin_size);
 	ClassDB::bind_method(D_METHOD("set_margin_size_all", "size"), &StyleBoxTexture::set_margin_size_all);
-	ClassDB::bind_method(D_METHOD("set_margin_size_individual", "size_left", "size_top", "size_right", "size_bottom"), &StyleBoxTexture::set_margin_size_individual);
 	ClassDB::bind_method(D_METHOD("get_margin_size", "margin"), &StyleBoxTexture::get_margin_size);
 
 	ClassDB::bind_method(D_METHOD("set_expand_margin_size", "margin", "size"), &StyleBoxTexture::set_expand_margin_size);
 	ClassDB::bind_method(D_METHOD("set_expand_margin_all", "size"), &StyleBoxTexture::set_expand_margin_size_all);
-	ClassDB::bind_method(D_METHOD("set_expand_margin_individual", "size_left", "size_top", "size_right", "size_bottom"), &StyleBoxTexture::set_expand_margin_size_individual);
 	ClassDB::bind_method(D_METHOD("get_expand_margin_size", "margin"), &StyleBoxTexture::get_expand_margin_size);
 
 	ClassDB::bind_method(D_METHOD("set_region_rect", "region"), &StyleBoxTexture::set_region_rect);
@@ -899,7 +896,6 @@ void StyleBoxFlat::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_border_blend", "blend"), &StyleBoxFlat::set_border_blend);
 	ClassDB::bind_method(D_METHOD("get_border_blend"), &StyleBoxFlat::get_border_blend);
 
-	ClassDB::bind_method(D_METHOD("set_corner_radius_individual", "radius_top_left", "radius_top_right", "radius_bottom_right", "radius_bottom_left"), &StyleBoxFlat::set_corner_radius_individual);
 	ClassDB::bind_method(D_METHOD("set_corner_radius_all", "radius"), &StyleBoxFlat::set_corner_radius_all);
 
 	ClassDB::bind_method(D_METHOD("set_corner_radius", "corner", "radius"), &StyleBoxFlat::set_corner_radius);
@@ -907,7 +903,6 @@ void StyleBoxFlat::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_expand_margin", "margin", "size"), &StyleBoxFlat::set_expand_margin_size);
 	ClassDB::bind_method(D_METHOD("set_expand_margin_all", "size"), &StyleBoxFlat::set_expand_margin_size_all);
-	ClassDB::bind_method(D_METHOD("set_expand_margin_individual", "size_left", "size_top", "size_right", "size_bottom"), &StyleBoxFlat::set_expand_margin_size_individual);
 	ClassDB::bind_method(D_METHOD("get_expand_margin", "margin"), &StyleBoxFlat::get_expand_margin_size);
 
 	ClassDB::bind_method(D_METHOD("set_draw_center", "draw_center"), &StyleBoxFlat::set_draw_center);

--- a/scene/resources/style_box.h
+++ b/scene/resources/style_box.h
@@ -57,7 +57,10 @@ public:
 	virtual bool test_mask(const Point2 &p_point, const Rect2 &p_rect) const;
 
 	void set_default_margin(Side p_side, float p_value);
+	void set_default_margin_all(float p_value);
+	void set_default_margin_individual(float p_left, float p_top, float p_right, float p_bottom);
 	float get_default_margin(Side p_side) const;
+
 	float get_margin(Side p_side) const;
 	virtual Size2 get_center_size() const;
 
@@ -112,6 +115,8 @@ public:
 	float get_expand_margin_size(Side p_expand_side) const;
 
 	void set_margin_size(Side p_side, float p_size);
+	void set_margin_size_all(float p_size);
+	void set_margin_size_individual(float p_left, float p_top, float p_right, float p_bottom);
 	float get_margin_size(Side p_side) const;
 
 	void set_region_rect(const Rect2 &p_region_rect);


### PR DESCRIPTION
StyleBoxFlat has methods for setting border width, corner radius, and expand margin for all sides or for each individual side. This PR adds similar methods for StyleBox default margins and StyleBoxTexture margin sizes.

This also unbinds the `StyleBox*.set_*_individual()` methods to simplify the API. These methods can still be used internally, and are used frequently for editor theme and default theme generation.

#### Additions:
* StyleBox:
    * `set_default_margin_all(float offset)`
    * `set_default_margin_individual(float offset_left, float offset_top, float offset_right, float offset_bottom)`
* StyleBoxTexture:
    * `set_margin_size_all(float size)`
    * `set_margin_size_individual(float size_left, float size_top, float size_right, float size_bottom)`

#### Unbinds:
- `StyleBox.set_default_margin_individual()`
- `StyleBoxFlat.set_corner_radius_individual()`
- `StyleBoxFlat.set_expand_margin_individual()`
- `StyleBoxTexture.set_expand_margin_individual()`
- `StyleBoxTexture.set_margin_size_individual()`