### PR TITLE
CSG primitives use corresponding primitive meshes

### DIFF
--- a/modules/csg/config.py
+++ b/modules/csg/config.py
@@ -9,6 +9,7 @@ def configure(env):
 def get_doc_classes():
     return [
         "CSGBox3D",
+        "CSGCapsule3D",
         "CSGCombiner3D",
         "CSGCylinder3D",
         "CSGMesh3D",

--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -170,25 +170,31 @@ public:
 class CSGPrimitive3D : public CSGShape3D {
 	GDCLASS(CSGPrimitive3D, CSGShape3D);
 
+	Ref<Material> material;
+
 protected:
+	Ref<Mesh> mesh;
 	bool flip_faces;
+	bool smooth_faces;
+	virtual CSGBrush *_build_brush() override;
 	CSGBrush *_create_brush_from_arrays(const Vector<Vector3> &p_vertices, const Vector<Vector2> &p_uv, const Vector<bool> &p_smooth, const Vector<Ref<Material>> &p_materials);
 	static void _bind_methods();
 
 public:
-	void set_flip_faces(bool p_invert);
-	bool get_flip_faces();
+	void set_flip_faces(bool p_flip_faces);
+	bool get_flip_faces() const;
+
+	void set_smooth_faces(bool p_smooth_faces);
+	bool get_smooth_faces() const;
+
+	void set_material(const Ref<Material> &p_material);
+	Ref<Material> get_material() const;
 
 	CSGPrimitive3D();
 };
 
 class CSGMesh3D : public CSGPrimitive3D {
 	GDCLASS(CSGMesh3D, CSGPrimitive3D);
-
-	virtual CSGBrush *_build_brush() override;
-
-	Ref<Mesh> mesh;
-	Ref<Material> material;
 
 	void _mesh_changed();
 
@@ -198,73 +204,16 @@ protected:
 public:
 	void set_mesh(const Ref<Mesh> &p_mesh);
 	Ref<Mesh> get_mesh();
-
-	void set_material(const Ref<Material> &p_material);
-	Ref<Material> get_material() const;
 };
 
 class CSGSphere3D : public CSGPrimitive3D {
 	GDCLASS(CSGSphere3D, CSGPrimitive3D);
 	virtual CSGBrush *_build_brush() override;
 
-	Ref<Material> material;
-	bool smooth_faces;
-	float radius;
-	int radial_segments;
-	int rings;
-
-protected:
-	static void _bind_methods();
-
-public:
-	void set_radius(const float p_radius);
-	float get_radius() const;
-
-	void set_radial_segments(const int p_radial_segments);
-	int get_radial_segments() const;
-
-	void set_rings(const int p_rings);
-	int get_rings() const;
-
-	void set_material(const Ref<Material> &p_material);
-	Ref<Material> get_material() const;
-
-	void set_smooth_faces(bool p_smooth_faces);
-	bool get_smooth_faces() const;
-
-	CSGSphere3D();
-};
-
-class CSGBox3D : public CSGPrimitive3D {
-	GDCLASS(CSGBox3D, CSGPrimitive3D);
-	virtual CSGBrush *_build_brush() override;
-
-	Ref<Material> material;
-	Vector3 size = Vector3(1, 1, 1);
-
-protected:
-	static void _bind_methods();
-
-public:
-	void set_size(const Vector3 &p_size);
-	Vector3 get_size() const;
-
-	void set_material(const Ref<Material> &p_material);
-	Ref<Material> get_material() const;
-
-	CSGBox3D() {}
-};
-
-class CSGCylinder3D : public CSGPrimitive3D {
-	GDCLASS(CSGCylinder3D, CSGPrimitive3D);
-	virtual CSGBrush *_build_brush() override;
-
-	Ref<Material> material;
 	float radius;
 	float height;
-	int sides;
-	bool cone;
-	bool smooth_faces;
+	int radial_segments;
+	int rings;
 
 protected:
 	static void _bind_methods();
@@ -276,31 +225,99 @@ public:
 	void set_height(const float p_height);
 	float get_height() const;
 
-	void set_sides(const int p_sides);
-	int get_sides() const;
+	void set_radial_segments(const int p_radial_segments);
+	int get_radial_segments() const;
 
-	void set_cone(const bool p_cone);
-	bool is_cone() const;
+	void set_rings(const int p_rings);
+	int get_rings() const;
 
-	void set_smooth_faces(bool p_smooth_faces);
-	bool get_smooth_faces() const;
+	CSGSphere3D();
+};
 
-	void set_material(const Ref<Material> &p_material);
-	Ref<Material> get_material() const;
+class CSGBox3D : public CSGPrimitive3D {
+	GDCLASS(CSGBox3D, CSGPrimitive3D);
+	virtual CSGBrush *_build_brush() override;
+
+	Vector3 size = Vector3(1, 1, 1);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_size(const Vector3 &p_size);
+	Vector3 get_size() const;
+
+	CSGBox3D() {}
+};
+
+class CSGCylinder3D : public CSGPrimitive3D {
+	GDCLASS(CSGCylinder3D, CSGPrimitive3D);
+	virtual CSGBrush *_build_brush() override;
+
+	float top_radius;
+	float bottom_radius;
+	float height;
+	int radial_segments;
+	int rings;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_top_radius(const float p_radius);
+	float get_top_radius() const;
+
+	void set_bottom_radius(const float p_radius);
+	float get_bottom_radius() const;
+
+	void set_height(const float p_height);
+	float get_height() const;
+
+	void set_radial_segments(const int p_segments);
+	int get_radial_segments() const;
+
+	void set_rings(const int p_rings);
+	int get_rings() const;
 
 	CSGCylinder3D();
+};
+
+class CSGCapsule3D : public CSGPrimitive3D {
+	GDCLASS(CSGCapsule3D, CSGPrimitive3D);
+	virtual CSGBrush *_build_brush() override;
+
+	float radius;
+	float height;
+	int radial_segments;
+	int rings;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_radius(const float p_radius);
+	float get_radius() const;
+
+	void set_height(const float p_height);
+	float get_height() const;
+
+	void set_radial_segments(const int p_segments);
+	int get_radial_segments() const;
+
+	void set_rings(const int p_rings);
+	int get_rings() const;
+
+	CSGCapsule3D();
 };
 
 class CSGTorus3D : public CSGPrimitive3D {
 	GDCLASS(CSGTorus3D, CSGPrimitive3D);
 	virtual CSGBrush *_build_brush() override;
 
-	Ref<Material> material;
 	float inner_radius;
 	float outer_radius;
-	int sides;
-	int ring_sides;
-	bool smooth_faces;
+	int rings;
+	int ring_segments;
 
 protected:
 	static void _bind_methods();
@@ -312,17 +329,11 @@ public:
 	void set_outer_radius(const float p_outer_radius);
 	float get_outer_radius() const;
 
-	void set_sides(const int p_sides);
-	int get_sides() const;
+	void set_rings(const int p_rings);
+	int get_rings() const;
 
-	void set_ring_sides(const int p_ring_sides);
-	int get_ring_sides() const;
-
-	void set_smooth_faces(bool p_smooth_faces);
-	bool get_smooth_faces() const;
-
-	void set_material(const Ref<Material> &p_material);
-	Ref<Material> get_material() const;
+	void set_ring_segments(const int p_ring_segments);
+	int get_ring_segments() const;
 
 	CSGTorus3D();
 };
@@ -352,7 +363,6 @@ private:
 	virtual CSGBrush *_build_brush() override;
 
 	Vector<Vector2> polygon;
-	Ref<Material> material;
 
 	Mode mode;
 
@@ -370,7 +380,6 @@ private:
 
 	Path3D *path = nullptr;
 
-	bool smooth_faces;
 	bool path_continuous_u;
 	real_t path_u_distance;
 	bool path_joined;
@@ -428,12 +437,6 @@ public:
 
 	void set_path_joined(bool p_enable);
 	bool is_path_joined() const;
-
-	void set_smooth_faces(bool p_smooth_faces);
-	bool get_smooth_faces() const;
-
-	void set_material(const Ref<Material> &p_material);
-	Ref<Material> get_material() const;
 
 	CSGPolygon3D();
 };

--- a/modules/csg/doc_classes/CSGBox3D.xml
+++ b/modules/csg/doc_classes/CSGBox3D.xml
@@ -11,9 +11,6 @@
 		<link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
 	</tutorials>
 	<members>
-		<member name="material" type="Material" setter="set_material" getter="get_material">
-			The material used to render the box.
-		</member>
 		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(1, 1, 1)">
 			The box's width, height and depth.
 		</member>

--- a/modules/csg/doc_classes/CSGCapsule3D.xml
+++ b/modules/csg/doc_classes/CSGCapsule3D.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="CSGSphere3D" inherits="CSGPrimitive3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+<class name="CSGCapsule3D" inherits="CSGPrimitive3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
 	<brief_description>
-		A CSG Sphere shape.
+		A CSG Capsule shape.
 	</brief_description>
 	<description>
-		This node allows you to create a sphere for use with the CSG system.
+		This node allows you to create a capsule for use with the CSG system.
 		[b]Note:[/b] CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a [MeshInstance3D] with a [PrimitiveMesh]. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
 	</description>
 	<tutorials>
 		<link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
 	</tutorials>
 	<members>
-		<member name="height" type="float" setter="set_height" getter="get_height" default="1.0">
-			The height of the sphere.
+		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
+			The height of the capsule.
 		</member>
 		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments" default="12">
-			Number of vertical slices for the sphere.
+			The number of sides of the capsule, the higher this number the more detail there will be in the capsule.
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
-			Radius of the sphere.
+			The radius of the capsule.
 		</member>
-		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="6">
-			Number of horizontal slices for the sphere.
+		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="2">
+			Number of horizontal slices for the capsule.
 		</member>
 	</members>
 </class>

--- a/modules/csg/doc_classes/CSGCylinder3D.xml
+++ b/modules/csg/doc_classes/CSGCylinder3D.xml
@@ -4,30 +4,27 @@
 		A CSG Cylinder shape.
 	</brief_description>
 	<description>
-		This node allows you to create a cylinder (or cone) for use with the CSG system.
+		This node allows you to create a cylinder for use with the CSG system.
 		[b]Note:[/b] CSG nodes are intended to be used for level prototyping. Creating CSG nodes has a significant CPU cost compared to creating a [MeshInstance3D] with a [PrimitiveMesh]. Moving a CSG node within another CSG node also has a significant CPU cost, so it should be avoided during gameplay.
 	</description>
 	<tutorials>
 		<link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
 	</tutorials>
 	<members>
-		<member name="cone" type="bool" setter="set_cone" getter="is_cone" default="false">
-			If [code]true[/code] a cone is created, the [member radius] will only apply to one side.
+		<member name="bottom_radius" type="float" setter="set_bottom_radius" getter="get_bottom_radius" default="0.5">
+			The bottom radius of the cylinder.
 		</member>
 		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
 			The height of the cylinder.
 		</member>
-		<member name="material" type="Material" setter="set_material" getter="get_material">
-			The material used to render the cylinder.
-		</member>
-		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
-			The radius of the cylinder.
-		</member>
-		<member name="sides" type="int" setter="set_sides" getter="get_sides" default="8">
+		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments" default="12">
 			The number of sides of the cylinder, the higher this number the more detail there will be in the cylinder.
 		</member>
-		<member name="smooth_faces" type="bool" setter="set_smooth_faces" getter="get_smooth_faces" default="true">
-			If [code]true[/code] the normals of the cylinder are set to give a smooth effect making the cylinder seem rounded. If [code]false[/code] the cylinder will have a flat shaded look.
+		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="3">
+			Number of horizontal slices for the cylinder.
+		</member>
+		<member name="top_radius" type="float" setter="set_top_radius" getter="get_top_radius" default="0.5">
+			The top radius of the cylinder.
 		</member>
 	</members>
 </class>

--- a/modules/csg/doc_classes/CSGMesh3D.xml
+++ b/modules/csg/doc_classes/CSGMesh3D.xml
@@ -11,9 +11,6 @@
 		<link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
 	</tutorials>
 	<members>
-		<member name="material" type="Material" setter="set_material" getter="get_material">
-			The [Material] used in drawing the CSG shape.
-		</member>
 		<member name="mesh" type="Mesh" setter="set_mesh" getter="get_mesh">
 			The [Mesh] resource to use as a CSG shape.
 			[b]Note:[/b] When using an [ArrayMesh], avoid meshes with vertex normals unless a flat shader is required. By default, CSGMesh will ignore the mesh's vertex normals and use a smooth shader calculated using the faces' normals. If a flat shader is required, ensure that all faces' vertex normals are parallel.

--- a/modules/csg/doc_classes/CSGPolygon3D.xml
+++ b/modules/csg/doc_classes/CSGPolygon3D.xml
@@ -14,14 +14,11 @@
 		<member name="depth" type="float" setter="set_depth" getter="get_depth" default="1.0">
 			When [member mode] is [constant MODE_DEPTH], the depth of the extrusion.
 		</member>
-		<member name="material" type="Material" setter="set_material" getter="get_material">
-			Material to use for the resulting mesh. The UV maps the top half of the material to the extruded shape (U along the length of the extrusions and V around the outline of the [member polygon]), the bottom-left quarter to the front end face, and the bottom-right quarter to the back end face.
-		</member>
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="CSGPolygon3D.Mode" default="0">
 			The [member mode] used to extrude the [member polygon].
 		</member>
 		<member name="path_continuous_u" type="bool" setter="set_path_continuous_u" getter="is_path_continuous_u">
-			When [member mode] is [constant MODE_PATH], by default, the top half of the [member material] is stretched along the entire length of the extruded shape. If [code]false[/code] the top half of the material is repeated every step of the extrusion.
+			When [member mode] is [constant MODE_PATH], by default, the top half of the material is stretched along the entire length of the extruded shape. If [code]false[/code] the top half of the material is repeated every step of the extrusion.
 		</member>
 		<member name="path_interval" type="float" setter="set_path_interval" getter="get_path_interval">
 			When [member mode] is [constant MODE_PATH], the path interval or ratio of path points to extrusions.
@@ -50,9 +47,6 @@
 		<member name="polygon" type="PackedVector2Array" setter="set_polygon" getter="get_polygon" default="PackedVector2Array(0, 0, 0, 1, 1, 1, 1, 0)">
 			The point array that defines the 2D polygon that is extruded. This can be a convex or concave polygon with 3 or more points. The polygon must [i]not[/i] have any intersecting edges. Otherwise, triangulation will fail and no mesh will be generated.
 			[b]Note:[/b] If only 1 or 2 points are defined in [member polygon], no mesh will be generated.
-		</member>
-		<member name="smooth_faces" type="bool" setter="set_smooth_faces" getter="get_smooth_faces" default="false">
-			If [code]true[/code], applies smooth shading to the extrusions.
 		</member>
 		<member name="spin_degrees" type="float" setter="set_spin_degrees" getter="get_spin_degrees">
 			When [member mode] is [constant MODE_SPIN], the total number of degrees the [member polygon] is rotated when extruding.

--- a/modules/csg/doc_classes/CSGPrimitive3D.xml
+++ b/modules/csg/doc_classes/CSGPrimitive3D.xml
@@ -14,5 +14,11 @@
 		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces" default="false">
 			If set, the order of the vertices in each triangle are reversed resulting in the backside of the mesh being drawn.
 		</member>
+		<member name="material" type="Material" setter="set_material" getter="get_material">
+			The material used to render the primitive.
+		</member>
+		<member name="smooth_faces" type="bool" setter="set_smooth_faces" getter="get_smooth_faces" default="true">
+			If [code]true[/code] the normals of the mesh are set to give a smooth effect making the mesh seem rounded. If [code]false[/code] the mesh will have a flat shaded look.
+		</member>
 	</members>
 </class>

--- a/modules/csg/doc_classes/CSGTorus3D.xml
+++ b/modules/csg/doc_classes/CSGTorus3D.xml
@@ -14,20 +14,14 @@
 		<member name="inner_radius" type="float" setter="set_inner_radius" getter="get_inner_radius" default="0.5">
 			The inner radius of the torus.
 		</member>
-		<member name="material" type="Material" setter="set_material" getter="get_material">
-			The material used to render the torus.
-		</member>
 		<member name="outer_radius" type="float" setter="set_outer_radius" getter="get_outer_radius" default="1.0">
 			The outer radius of the torus.
 		</member>
-		<member name="ring_sides" type="int" setter="set_ring_sides" getter="get_ring_sides" default="6">
+		<member name="ring_segments" type="int" setter="set_ring_segments" getter="get_ring_segments" default="6">
 			The number of edges each ring of the torus is constructed of.
 		</member>
-		<member name="sides" type="int" setter="set_sides" getter="get_sides" default="8">
+		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="12">
 			The number of slices the torus is constructed of.
-		</member>
-		<member name="smooth_faces" type="bool" setter="set_smooth_faces" getter="get_smooth_faces" default="true">
-			If [code]true[/code] the normals of the torus are set to give a smooth effect making the torus seem rounded. If [code]false[/code] the torus will have a flat shaded look.
 		</member>
 	</members>
 </class>

--- a/modules/csg/register_types.cpp
+++ b/modules/csg/register_types.cpp
@@ -45,6 +45,7 @@ void initialize_csg_module(ModuleInitializationLevel p_level) {
 		GDREGISTER_CLASS(CSGMesh3D);
 		GDREGISTER_CLASS(CSGSphere3D);
 		GDREGISTER_CLASS(CSGBox3D);
+		GDREGISTER_CLASS(CSGCapsule3D);
 		GDREGISTER_CLASS(CSGCylinder3D);
 		GDREGISTER_CLASS(CSGTorus3D);
 		GDREGISTER_CLASS(CSGPolygon3D);

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -52,7 +52,6 @@ private:
 	mutable int index_array_len = 0;
 
 	Ref<Material> material;
-	bool flip_faces = false;
 
 	// make sure we do an update after we've finished constructing our object
 	mutable bool pending_request = true;
@@ -61,6 +60,9 @@ private:
 protected:
 	// assume primitive triangles as the type, correct for all but one and it will change this :)
 	Mesh::PrimitiveType primitive_type = Mesh::PRIMITIVE_TRIANGLES;
+
+	bool flip_faces = false;
+	bool smooth_faces = true;
 
 	static void _bind_methods();
 


### PR DESCRIPTION
# Requires #60843

Instead of generating meshes themselves, CSG primitives will now behave kind of like `CSGMesh3D` and pull the mesh from their corresponding primitive meshes.
- Added `CSGCapsule3D`.
- Added missing properties for `CSGCylinder3D` and `CSGSphere3D`.
- Modified gizmos to support the new properties and the new Capsule shape.
- Updated docs.
- Fixes #19143.
- Closes #52516.

Test project: [59077.zip](https://github.com/godotengine/godot/files/8238463/59077.zip)