### PR TITLE
Don't show frame time panel across restarts

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -3541,14 +3541,6 @@ void Node3DEditorViewport::set_state(const Dictionary &p_state) {
 			_menu_option(VIEW_INFORMATION);
 		}
 	}
-	if (p_state.has("frame_time")) {
-		bool fps = p_state["frame_time"];
-
-		int idx = view_menu->get_popup()->get_item_index(VIEW_FRAME_TIME);
-		if (view_menu->get_popup()->is_item_checked(idx) != fps) {
-			_menu_option(VIEW_FRAME_TIME);
-		}
-	}
 	if (p_state.has("half_res")) {
 		bool half_res = p_state["half_res"];
 
@@ -3603,7 +3595,6 @@ Dictionary Node3DEditorViewport::get_state() const {
 	d["doppler"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_AUDIO_DOPPLER));
 	d["gizmos"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_GIZMOS));
 	d["information"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_INFORMATION));
-	d["frame_time"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_FRAME_TIME));
 	d["half_res"] = subviewport_container->get_stretch_shrink() > 1;
 	d["cinematic_preview"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_CINEMATIC_PREVIEW));
 	if (previewing) {


### PR DESCRIPTION
Enhancement following #59017  
Removed restoring View Frame Time option on restarts and added line to make sure it was unchecked (might be unnecessary).  
Interestingly, on Windows 11 with the frame time panel active, FPS was never pushed over 1200 and used only ~0.6% CPU and GPU. It might've been a MacOS thing.

_Production edit: Closes https://github.com/godotengine/godot/issues/59017_