### PR TITLE
Fix out of bounds crash in particle collision gizmo

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -3177,13 +3177,8 @@ void GPUParticlesCollision3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 						continue;
 					}
 
-					Vector2 dir;
-					dir[j] = 1.0;
-					Vector2 ta, tb;
 					int j_n1 = (j + 1) % 3;
 					int j_n2 = (j + 2) % 3;
-					ta[j_n1] = 1.0;
-					tb[j_n2] = 1.0;
 
 					for (int k = 0; k < 4; k++) {
 						Vector3 from = aabb.position, to = aabb.position;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/59083.

The fix is exactly the same as it was for the GIProbe gizmo in https://github.com/godotengine/godot/pull/58444.