### PR TITLE
Add `root_subfolder` to FileDialog

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -75,6 +75,9 @@
 		<member name="mode_overrides_title" type="bool" setter="set_mode_overrides_title" getter="is_mode_overriding_title" default="true">
 			If [code]true[/code], changing the [code]Mode[/code] property will set the window title accordingly (e.g. setting mode to [constant FILE_MODE_OPEN_FILE] will change the window title to "Open a File").
 		</member>
+		<member name="root_subfolder" type="String" setter="set_root_subfolder" getter="get_root_subfolder" default="&quot;&quot;">
+			If non-empty, the given sub-folder will be "root" of this [FileDialog], i.e. user won't be able to go to its parent directory.
+		</member>
 		<member name="show_hidden_files" type="bool" setter="set_show_hidden_files" getter="is_showing_hidden_files" default="false">
 			If [code]true[/code], the dialog will show hidden files.
 		</member>

--- a/scene/gui/file_dialog.h
+++ b/scene/gui/file_dialog.h
@@ -101,6 +101,8 @@ private:
 	void _push_history();
 
 	bool mode_overrides_title = true;
+	String root_subfolder;
+	String root_prefix;
 
 	static bool default_show_hidden_files;
 	bool show_hidden_files = false;
@@ -131,6 +133,7 @@ private:
 	void _go_back();
 	void _go_forward();
 
+	void _change_dir(const String &p_new_dir);
 	void _update_drives(bool p_select = true);
 
 	virtual void shortcut_input(const Ref<InputEvent> &p_event) override;
@@ -161,6 +164,9 @@ public:
 	void set_current_dir(const String &p_dir);
 	void set_current_file(const String &p_file);
 	void set_current_path(const String &p_path);
+
+	void set_root_subfolder(const String &p_root);
+	String get_root_subfolder() const;
 
 	void set_mode_overrides_title(bool p_override);
 	bool is_mode_overriding_title() const;


### PR DESCRIPTION
Closes https://github.com/godotengine/godot-proposals/issues/3929
`root_subfolder` will make the specified sub-folder into a "fake root" of the FileDialog. You won't be able to go to parent directory and the path display changes.

Without `root_subfolder`:
![godot windows tools 64_vIhPXogvZm](https://user-images.githubusercontent.com/2223172/158039871-30f53ea4-bb20-4430-82fd-787ee0e0481a.gif)

`root_subfolder` set to `Test`:
![godot windows tools 64_iwfuPgRhJF](https://user-images.githubusercontent.com/2223172/158039899-88637f14-5d44-4938-8605-764d064daab7.gif)

