### PR TITLE
Drop mouse focus and over when gui input is globally disabled

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2768,6 +2768,14 @@ Vector2 Viewport::get_camera_rect_size() const {
 }
 
 void Viewport::set_disable_input(bool p_disable) {
+	if (p_disable == disable_input) {
+		return;
+	}
+	if (p_disable) {
+		_drop_mouse_focus();
+		_drop_mouse_over();
+		_gui_cancel_tooltip();
+	}
 	disable_input = p_disable;
 }
 


### PR DESCRIPTION
This is an effort to have the same phylosophy in pause-aware physics picking; that is, you enable a mechanism to stop input from reaching targets, so the engine ensures current hovers, etc. get released to avoid keeping them in a transient state for too long, making it difficult both to itself and user code to recover when normal functionality is resumed later.

Fixes #44173.
Partially supersedes #58944.

**NOTE:** PR for 3.x submitted as #59100.