### PR TITLE
Improve simulated bold fonts advance.

### DIFF
--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -242,6 +242,8 @@ class TextServerAdvanced : public TextServer {
 		}
 	}
 
+	_FORCE_INLINE_ float _get_extra_advance(RID p_font_rid, int p_font_size) const;
+
 	// Shaped text cache data.
 
 	struct ShapedTextDataAdvanced : public ShapedTextData {

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -1513,12 +1513,17 @@ Vector2 TextServerFallback::font_get_glyph_advance(RID p_font_rid, int p_size, i
 
 	const HashMap<int32_t, FontGlyph> &gl = fd->cache[size]->glyph_map;
 
+	Vector2 ea;
+	if (fd->embolden != 0.0) {
+		ea.x = fd->embolden * float(size.x) / 64.0;
+	}
+
 	if (fd->msdf) {
-		return gl[p_glyph].advance * (float)p_size / (float)fd->msdf_source_size;
+		return (gl[p_glyph].advance + ea) * (float)p_size / (float)fd->msdf_source_size;
 	} else if ((fd->subpixel_positioning == SUBPIXEL_POSITIONING_DISABLED) || (fd->subpixel_positioning == SUBPIXEL_POSITIONING_AUTO && size.x > SUBPIXEL_POSITIONING_ONE_HALF_MAX_SIZE)) {
-		return gl[p_glyph].advance.round();
+		return (gl[p_glyph].advance + ea).round();
 	} else {
-		return gl[p_glyph].advance;
+		return gl[p_glyph].advance + ea;
 	}
 }
 


### PR DESCRIPTION
An addition, for #59013, increases glyph advance for emboldened fonts.