### PR TITLE
Copy full project setting path from dialog.

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -881,7 +881,7 @@ void EditorProperty::menu_option(int p_option) {
 			emit_changed(property, InspectorDock::get_inspector_singleton()->get_property_clipboard());
 		} break;
 		case MENU_COPY_PROPERTY_PATH: {
-			DisplayServer::get_singleton()->clipboard_set(property);
+			DisplayServer::get_singleton()->clipboard_set(property_path);
 		} break;
 		case MENU_PIN_VALUE: {
 			emit_signal(SNAME("property_pinned"), property, !pinned);
@@ -2331,6 +2331,7 @@ void EditorInspector::_parse_added_editors(VBoxContainer *current_vbox, Ref<Edit
 				if (F.properties.size() == 1) {
 					//since it's one, associate:
 					ep->property = F.properties[0];
+					ep->property_path = property_prefix + F.properties[0];
 					ep->property_usage = 0;
 				}
 
@@ -2889,6 +2890,7 @@ void EditorInspector::update_tree() {
 						if (F.properties.size() == 1) {
 							//since it's one, associate:
 							ep->property = F.properties[0];
+							ep->property_path = property_prefix + F.properties[0];
 							ep->property_usage = p.usage;
 							//and set label?
 						}

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -68,6 +68,7 @@ private:
 	friend class EditorInspector;
 	Object *object;
 	StringName property;
+	String property_path;
 
 	int property_usage;
 


### PR DESCRIPTION
The EditorProperty UI elements for project settings are created from
SectionedInspector, which has a prefix added to each property path. Each
EditorProperty needs to be made aware of this path so copy_property_path
copies the full path, and not just the suffix.

Fixes #59020.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
