### PR TITLE
Expose `RenderingServer::canvas_item_add_animation_slice` in GDScript

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -149,6 +149,17 @@
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] static method.
 			</description>
 		</method>
+		<method name="canvas_item_add_animation_slice">
+			<return type="void" />
+			<argument index="0" name="item" type="RID" />
+			<argument index="1" name="animation_length" type="float" />
+			<argument index="2" name="slice_begin" type="float" />
+			<argument index="3" name="slice_end" type="float" />
+			<argument index="4" name="offset" type="float" default="0.0" />
+			<description>
+				Subsequent drawing commands will be ignored unless they fall within the specified animation slice. This is a faster way to implement animations that loop on background rather than redrawing constantly.
+			</description>
+		</method>
 		<method name="canvas_item_add_circle">
 			<return type="void" />
 			<argument index="0" name="item" type="RID" />

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2580,6 +2580,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("canvas_item_add_particles", "item", "particles", "texture"), &RenderingServer::canvas_item_add_particles);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_set_transform", "item", "transform"), &RenderingServer::canvas_item_add_set_transform);
 	ClassDB::bind_method(D_METHOD("canvas_item_add_clip_ignore", "item", "ignore"), &RenderingServer::canvas_item_add_clip_ignore);
+	ClassDB::bind_method(D_METHOD("canvas_item_add_animation_slice", "item", "animation_length", "slice_begin", "slice_end", "offset"), &RenderingServer::canvas_item_add_animation_slice, DEFVAL(0.0));
 	ClassDB::bind_method(D_METHOD("canvas_item_set_sort_children_by_y", "item", "enabled"), &RenderingServer::canvas_item_set_sort_children_by_y);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_index", "item", "z_index"), &RenderingServer::canvas_item_set_z_index);
 	ClassDB::bind_method(D_METHOD("canvas_item_set_z_as_relative_to_parent", "item", "enabled"), &RenderingServer::canvas_item_set_z_as_relative_to_parent);


### PR DESCRIPTION
Currently this method is only exposed in GDScript via the `draw_animation_slice` method of `CanvasItem`s. As `RenderingServer.canvas_item_create` returns RIDs, exposing this method is necessary for adding animation slices to canvas items created via GDScript. 