### PR TITLE
Expose methods for screen-space transforms

### DIFF
--- a/doc/classes/CanvasItem.xml
+++ b/doc/classes/CanvasItem.xml
@@ -355,6 +355,13 @@
 				Returns the mouse's position in this [CanvasItem] using the local coordinate system of this [CanvasItem].
 			</description>
 		</method>
+		<method name="get_screen_transform" qualifiers="const">
+			<return type="Transform2D" />
+			<description>
+				Returns the transform of this [CanvasItem] in global screen coordinates (i.e. taking window position into account). Mostly useful for editor plugins.
+				Equals to [method get_global_transform] if the window is embedded (see [member Viewport.gui_embed_subwindows]).
+			</description>
+		</method>
 		<method name="get_transform" qualifiers="const">
 			<return type="Transform2D" />
 			<description>

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -417,6 +417,19 @@
 				Returns the position and size of the control relative to the top-left corner of the parent Control. See [member position] and [member size].
 			</description>
 		</method>
+		<method name="get_screen_position" qualifiers="const">
+			<return type="Vector2" />
+			<description>
+				Returns the position of this [Control] in global screen coordinates (i.e. taking window position into account). Mostly useful for editor plugins.
+				Equals to [member global_position] if the window is embedded (see [member Viewport.gui_embed_subwindows]).
+				Example usage for showing a popup:
+				[codeblock]
+				popup_menu.position = get_screen_position() + get_local_mouse_position()
+				popup_menu.reset_size()
+				popup_menu.popup()
+				[/codeblock]
+			</description>
+		</method>
 		<method name="get_theme_color" qualifiers="const">
 			<return type="Color" />
 			<argument index="0" name="name" type="StringName" />

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -220,6 +220,7 @@
 			If [code]true[/code], the viewport will not receive input events.
 		</member>
 		<member name="gui_embed_subwindows" type="bool" setter="set_embed_subwindows_hint" getter="get_embed_subwindows_hint" default="false">
+			If [code]true[/code], sub-windows (popups and dialogs) will be embedded inside application window as control-like nodes. If [code]false[/code], they will appear as separate windows handled by the operating system.
 		</member>
 		<member name="gui_snap_controls_to_pixels" type="bool" setter="set_snap_controls_to_pixels" getter="is_snap_controls_to_pixels_enabled" default="true">
 			If [code]true[/code], the GUI controls on the viewport will lay pixel perfectly.

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3224,6 +3224,7 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_custom_minimum_size"), &Control::get_custom_minimum_size);
 	ClassDB::bind_method(D_METHOD("get_parent_area_size"), &Control::get_parent_area_size);
 	ClassDB::bind_method(D_METHOD("get_global_position"), &Control::get_global_position);
+	ClassDB::bind_method(D_METHOD("get_screen_position"), &Control::get_screen_position);
 	ClassDB::bind_method(D_METHOD("get_rect"), &Control::get_rect);
 	ClassDB::bind_method(D_METHOD("get_global_rect"), &Control::get_global_rect);
 	ClassDB::bind_method(D_METHOD("set_focus_mode", "mode"), &Control::set_focus_mode);

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -866,7 +866,6 @@ void CanvasItem::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("_set_on_top", "on_top"), &CanvasItem::_set_on_top);
 	ClassDB::bind_method(D_METHOD("_is_on_top"), &CanvasItem::_is_on_top);
-	//ClassDB::bind_method(D_METHOD("get_transform"),&CanvasItem::get_transform);
 
 	ClassDB::bind_method(D_METHOD("draw_line", "from", "to", "color", "width"), &CanvasItem::draw_line, DEFVAL(1.0));
 	ClassDB::bind_method(D_METHOD("draw_polyline", "points", "color", "width", "antialiased"), &CanvasItem::draw_polyline, DEFVAL(1.0), DEFVAL(false));
@@ -899,6 +898,7 @@ void CanvasItem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_viewport_transform"), &CanvasItem::get_viewport_transform);
 	ClassDB::bind_method(D_METHOD("get_viewport_rect"), &CanvasItem::get_viewport_rect);
 	ClassDB::bind_method(D_METHOD("get_canvas_transform"), &CanvasItem::get_canvas_transform);
+	ClassDB::bind_method(D_METHOD("get_screen_transform"), &CanvasItem::get_screen_transform);
 	ClassDB::bind_method(D_METHOD("get_local_mouse_position"), &CanvasItem::get_local_mouse_position);
 	ClassDB::bind_method(D_METHOD("get_global_mouse_position"), &CanvasItem::get_global_mouse_position);
 	ClassDB::bind_method(D_METHOD("get_canvas"), &CanvasItem::get_canvas);


### PR DESCRIPTION
I remember someone once asked on the chat how to properly display a popup in editor plugin in 4.0. This is not obvious, because popups appear in screen-space coordinates. The methods this PR exposes make it easier to handle (they are used by the editor itself).