### PR TITLE
Fix text clipping on the right side.

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -293,7 +293,7 @@ void Button::_notification(int p_what) {
 			int text_clip = size.width - style->get_minimum_size().width - icon_ofs.width;
 			text_buf->set_width(clip_text ? text_clip : -1);
 
-			int text_width = clip_text ? MIN(text_clip, text_buf->get_size().x) : text_buf->get_size().x;
+			int text_width = MAX(1, clip_text ? MIN(text_clip, text_buf->get_size().x) : text_buf->get_size().x);
 
 			if (_internal_margin[SIDE_LEFT] > 0) {
 				text_clip -= _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("hseparation"));

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -1267,11 +1267,11 @@ void TextServer::shaped_text_draw(RID p_shaped, RID p_canvas, const Vector2 &p_p
 			if (p_clip_r > 0) {
 				// Clip right / bottom.
 				if (orientation == ORIENTATION_HORIZONTAL) {
-					if (ofs.x - p_pos.x > p_clip_r) {
+					if (ofs.x - p_pos.x + glyphs[i].advance > p_clip_r) {
 						return;
 					}
 				} else {
-					if (ofs.y - p_pos.y > p_clip_r) {
+					if (ofs.y - p_pos.y + glyphs[i].advance > p_clip_r) {
 						return;
 					}
 				}
@@ -1362,11 +1362,11 @@ void TextServer::shaped_text_draw_outline(RID p_shaped, RID p_canvas, const Vect
 			if (p_clip_r > 0) {
 				// Clip right / bottom.
 				if (orientation == ORIENTATION_HORIZONTAL) {
-					if (ofs.x - p_pos.x > p_clip_r) {
+					if (ofs.x - p_pos.x + glyphs[i].advance > p_clip_r) {
 						return;
 					}
 				} else {
-					if (ofs.y - p_pos.y > p_clip_r) {
+					if (ofs.y - p_pos.y + glyphs[i].advance > p_clip_r) {
 						return;
 					}
 				}


### PR DESCRIPTION
Fixes #59073

Fixes clipping on the right side of text for `Button` (and probably other control).

Note: `Label` use different type of clipping (`canvas_item_set_clip`) instead of skipping some chars, I'm not sure which one is better. But since `canvas_item_set_clip` won't take style box margins into account, it can't be used for controls like button.

https://user-images.githubusercontent.com/7645683/158067153-b86a2d50-23b8-40da-8dc6-05d00c747cf1.mov
