### PR TITLE
Add simulated bold variant to the editor CJK fonts.

### DIFF
--- a/editor/editor_fonts.cpp
+++ b/editor/editor_fonts.cpp
@@ -64,8 +64,8 @@
 	m_name->add_data(FontTamilBold);      \
 	m_name->add_data(FontTeluguBold);     \
 	m_name->add_data(FontThaiBold);       \
-	m_name->add_data(FontJapanese);       \
-	m_name->add_data(FontFallback);
+	m_name->add_data(FontJapaneseBold);   \
+	m_name->add_data(FontFallbackBold);
 
 #define MAKE_DEFAULT_FONT(m_name, m_variations)                       \
 	Ref<Font> m_name;                                                 \
@@ -267,6 +267,13 @@ void editor_register_fonts(Ref<Theme> p_theme) {
 
 	Ref<FontData> FontFallback = load_cached_internal_font(_font_DroidSansFallback, _font_DroidSansFallback_size, font_hinting, font_antialiased, true, font_subpixel_positioning);
 	Ref<FontData> FontJapanese = load_cached_internal_font(_font_DroidSansJapanese, _font_DroidSansJapanese_size, font_hinting, font_antialiased, true, font_subpixel_positioning);
+
+	const float embolden_strength = 0.6;
+
+	Ref<FontData> FontFallbackBold = FontFallback->duplicate();
+	FontFallbackBold->set_embolden(embolden_strength);
+	Ref<FontData> FontJapaneseBold = FontJapanese->duplicate();
+	FontJapaneseBold->set_embolden(embolden_strength);
 
 	/* Hack */
 


### PR DESCRIPTION
Currently, there's no bold CJK font in the editor, this PR adds simulated bold variant. Probably as a temporary improvement, until https://github.com/godotengine/godot/pull/56558 or language packs are implemented.

| Before | After |
| - | - |
| <img width="196" alt="Screenshot 2022-03-13 at 17 40 52" src="https://user-images.githubusercontent.com/7645683/158067701-2feb4b21-0481-43f0-8bcc-51e8caba00be.png"> | <img width="196" alt="Screenshot 2022-03-13 at 17 40 37" src="https://user-images.githubusercontent.com/7645683/158067628-bf1e9ac2-7eed-4462-8d5d-cebd5808b047.png"> |
| <img width="197" alt="Screenshot 2022-03-13 at 17 41 31" src="https://user-images.githubusercontent.com/7645683/158067705-7eaa88fc-9ee1-4b19-8f03-c46c1abba91b.png"> | <img width="197" alt="Screenshot 2022-03-13 at 17 41 19" src="https://user-images.githubusercontent.com/7645683/158067632-c3aef04e-e709-4f07-b501-eaa494991674.png"> |


