### PR TITLE
Fix determination of SVG canvas size

### DIFF
--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -78,7 +78,7 @@ void ImageLoaderSVG::create_image_from_string(Ref<Image> p_image, String p_strin
 		return;
 	}
 	float fw, fh;
-	picture->viewbox(nullptr, nullptr, &fw, &fh);
+	picture->size(&fw, &fh);
 
 	uint32_t width = MIN(fw * p_scale, 16 * 1024);
 	uint32_t height = MIN(fh * p_scale, 16 * 1024);


### PR DESCRIPTION
Fixes #58434
Supersedes #58437 but it's still usable if you want to correct that special SVG file :)

When getting the original canvas size of SVG, `Picture::size()` should be used instead of `Picture::viewbox()`. [viewBox](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/viewBox) defines the SVG viewport, not the canvas.