### PR TITLE
Fix event coordinate system in Viewport::_sub_windows_forward_input

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2691,7 +2691,7 @@ void Viewport::push_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
 		ev = p_event;
 	}
 
-	if (is_embedding_subwindows() && _sub_windows_forward_input(p_event)) {
+	if (is_embedding_subwindows() && _sub_windows_forward_input(ev)) {
 		set_input_as_handled();
 		return;
 	}


### PR DESCRIPTION
Previously `Viewport::_sub_windows_forward_input` did not take into account, that the parent window-viewport could possibly be stretched. This patch changes this so that event coordinates are converted accordingly.

The position of `p_event` is in the coordinate system of the window/viewport.
The position of `ev` is in the coordinate system of the window/viewport with applied the `final_transform`, which is the coordinate system, in which the `PopupMenu` expects its `InputEvents`.

This solves problems like this for stretched Window-Viewports and PopupMenu:

https://user-images.githubusercontent.com/6299227/158078647-2c107e35-f99e-4f1e-9407-6d16edbbd875.mp4

fix #59573
Part of https://github.com/godotengine/godot-proposals/issues/3866