### PR TITLE
Fix `D_GGX` code which can cause `divide-by-zero`

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -1,9 +1,9 @@
 // Functions related to lighting
 
 float D_GGX(float cos_theta_m, float alpha) {
-	float alpha2 = alpha * alpha;
-	float d = 1.0 + (alpha2 - 1.0) * cos_theta_m * cos_theta_m;
-	return alpha2 / (M_PI * d * d);
+	float a = cos_theta_m * alpha;
+	float k = alpha / (1.0 - cos_theta_m * cos_theta_m + a * a);
+	return k * k * (1.0 / M_PI);
 }
 
 // From Earl Hammon, Jr. "PBR Diffuse Lighting for GGX+Smith Microsurfaces" https://www.gdcvault.com/play/1024478/PBR-Diffuse-Lighting-for-GGX


### PR DESCRIPTION
This revision Fix #56373.

When given roughness is lower than 0.01, d value in the original code will
be zero because of floating-point precision. 
This can make the last return value NAN because of divide-by-zero.

Modified code is referenced on `D_GGX` function of `google/filament`
(https://github.com/google/filament/blob/main/shaders/src/brdf.fs#L54-L79)

### Before
![image](https://user-images.githubusercontent.com/24654975/158086982-6ef8d57b-7dd6-45d2-a70d-aef9e43064db.png)

### After
![image](https://user-images.githubusercontent.com/24654975/158086971-b483de78-010c-4ec9-8259-e8c47cdf5bbc.png)
