### PR TITLE
[3.x] Enable numpad delete in TextEdit & LineEdit

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -490,6 +490,13 @@ void LineEdit::_gui_input(Ref<InputEvent> p_event) {
 					set_cursor_position(text.length());
 					shift_selection_check_post(k->get_shift());
 				} break;
+				case KEY_KP_PERIOD: {
+					if (k->get_unicode() != 0) {
+						handled = false;
+						break;
+					}
+					FALLTHROUGH;
+				}
 				case KEY_DELETE: {
 					if (!editable) {
 						break;

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2907,6 +2907,12 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 					// Special keys often used with control, wait.
 					clear = (!k->get_command() || k->get_shift() || k->get_alt());
 					break;
+				case KEY_KP_PERIOD:
+					if (!k->get_shift()) {
+						accept_event();
+						clear = true;
+					}
+					break;
 				case KEY_DELETE:
 					if (!k->get_shift()) {
 						accept_event();
@@ -3478,6 +3484,13 @@ void TextEdit::_gui_input(const Ref<InputEvent> &p_gui_input) {
 				_cancel_code_hint();
 
 			} break;
+			case KEY_KP_PERIOD: {
+				if (k->get_unicode() != 0) {
+					scancode_handled = false;
+					break;
+				}
+				FALLTHROUGH;
+			}
 			case KEY_DELETE: {
 				if (readonly) {
 					break;


### PR DESCRIPTION
Numeric keypad delete should behave the same as delete when num lock is off.
PR to 3.x as it will be completely different from master.
