### PR TITLE
[WIP] Implement interface for accessibility GDExtension modules.

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1741,13 +1741,16 @@ uint32_t Object::get_edited_version() const {
 
 void Object::set_instance_binding(void *p_token, void *p_binding, const GDNativeInstanceBindingCallbacks *p_callbacks) {
 	// This is only meant to be used on creation by the binder.
-	ERR_FAIL_COND(_instance_bindings != nullptr);
-	_instance_bindings = (InstanceBinding *)memalloc(sizeof(InstanceBinding));
-	_instance_bindings[0].binding = p_binding;
-	_instance_bindings[0].free_callback = p_callbacks->free_callback;
-	_instance_bindings[0].reference_callback = p_callbacks->reference_callback;
-	_instance_bindings[0].token = p_token;
-	_instance_binding_count = 1;
+	//ERR_FAIL_COND(_instance_bindings != nullptr);
+	// TODO FIX, seems to be called every time after object is wrapped by get_instance_binding
+	if (_instance_bindings == nullptr) {
+		_instance_bindings = (InstanceBinding *)memalloc(sizeof(InstanceBinding));
+		_instance_bindings[0].binding = p_binding;
+		_instance_bindings[0].free_callback = p_callbacks->free_callback;
+		_instance_bindings[0].reference_callback = p_callbacks->reference_callback;
+		_instance_bindings[0].token = p_token;
+		_instance_binding_count = 1;
+	}
 }
 
 void *Object::get_instance_binding(void *p_token, const GDNativeInstanceBindingCallbacks *p_callbacks) {

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -1083,6 +1083,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="AccessibilityServerManager" type="AccessibilityServerManager" setter="" getter="">
+			The [AccessibilityServerManager] singleton.
+		</member>
 		<member name="AudioServer" type="AudioServer" setter="" getter="">
 			The [AudioServer] singleton.
 		</member>

--- a/doc/classes/AccessibilityServer.xml
+++ b/doc/classes/AccessibilityServer.xml
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AccessibilityServer" inherits="RefCounted" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="create_window_context">
+			<return type="void" />
+			<argument index="0" name="window" type="int" />
+			<argument index="1" name="arg1" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="destroy_window_context">
+			<return type="void" />
+			<argument index="0" name="window" type="int" />
+			<argument index="1" name="arg1" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_features" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_name" qualifiers="const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="has_feature" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="feature" type="int" enum="AccessibilityServer.Feature" />
+			<description>
+			</description>
+		</method>
+		<method name="post_tree_update">
+			<return type="void" />
+			<argument index="0" name="update_data" type="PackedInt64Array" />
+			<argument index="1" name="kdb_focused" type="int" />
+			<argument index="2" name="mouse_focus" type="int" />
+			<argument index="3" name="window" type="int" />
+			<argument index="4" name="arg4" type="int" />
+			<description>
+			</description>
+		</method>
+	</methods>
+	<constants>
+		<constant name="ROLE_UNKNOWN" value="0" enum="Role">
+		</constant>
+		<constant name="ROLE_BUTTON" value="1" enum="Role">
+		</constant>
+		<constant name="ROLE_CHECK_BOX" value="2" enum="Role">
+		</constant>
+		<constant name="ROLE_CHECK_BUTTON" value="3" enum="Role">
+		</constant>
+		<constant name="ROLE_CONTAINER" value="4" enum="Role">
+		</constant>
+		<constant name="ROLE_ITEM_LIST" value="5" enum="Role">
+		</constant>
+		<constant name="ROLE_ITEM_LIST_ITEM" value="6" enum="Role">
+		</constant>
+		<constant name="ROLE_LABEL" value="7" enum="Role">
+		</constant>
+		<constant name="ROLE_LINE_EDIT" value="8" enum="Role">
+		</constant>
+		<constant name="ROLE_LINK" value="9" enum="Role">
+		</constant>
+		<constant name="ROLE_MENU_BUTTON" value="10" enum="Role">
+		</constant>
+		<constant name="ROLE_OPTION_BUTTON" value="11" enum="Role">
+		</constant>
+		<constant name="ROLE_PROGRESS_BAR" value="12" enum="Role">
+		</constant>
+		<constant name="ROLE_RICH_TEXT" value="13" enum="Role">
+		</constant>
+		<constant name="ROLE_SCROLL_BAR" value="14" enum="Role">
+		</constant>
+		<constant name="ROLE_SCROLL_CONTAINER" value="15" enum="Role">
+		</constant>
+		<constant name="ROLE_SLIDER" value="16" enum="Role">
+		</constant>
+		<constant name="ROLE_SPIN_BOX" value="17" enum="Role">
+		</constant>
+		<constant name="ROLE_TAB_BAR" value="18" enum="Role">
+		</constant>
+		<constant name="ROLE_TAB" value="19" enum="Role">
+		</constant>
+		<constant name="ROLE_TEXT_EDIT" value="20" enum="Role">
+		</constant>
+		<constant name="ROLE_TREE" value="21" enum="Role">
+		</constant>
+		<constant name="ROLE_TREE_ITEM" value="22" enum="Role">
+		</constant>
+		<constant name="ROLE_WINDOW" value="23" enum="Role">
+		</constant>
+		<constant name="NODE_RELATION_INDIRECT_CHILD" value="0" enum="NodeRelation">
+		</constant>
+		<constant name="NODE_RELATION_ERROR_MESSAGE" value="1" enum="NodeRelation">
+		</constant>
+		<constant name="NODE_RELATION_LINK_TARGET" value="2" enum="NodeRelation">
+		</constant>
+		<constant name="NODE_RELATION_GROUP_MEMBER" value="3" enum="NodeRelation">
+		</constant>
+		<constant name="NODE_RELATION_POPUP" value="4" enum="NodeRelation">
+		</constant>
+		<constant name="NODE_RELATION_CONTROLS" value="5" enum="NodeRelation">
+		</constant>
+		<constant name="NODE_RELATION_DETAILS" value="6" enum="NodeRelation">
+		</constant>
+		<constant name="NODE_RELATION_DESCRIBED" value="7" enum="NodeRelation">
+		</constant>
+		<constant name="NODE_RELATION_FLOW_TO" value="8" enum="NodeRelation">
+		</constant>
+		<constant name="NODE_RELATION_LABELLED" value="9" enum="NodeRelation">
+		</constant>
+		<constant name="NODE_RELATION_RADIO_GROUP_MEMBER" value="10" enum="NodeRelation">
+		</constant>
+		<constant name="FEATURE_SCREEN_READER_SUPPORT" value="1" enum="Feature">
+		</constant>
+		<constant name="FEATURE_USE_NATIVE_CB" value="2" enum="Feature">
+		</constant>
+		<constant name="FEATURE_USE_TREE_UPDATES" value="4" enum="Feature">
+		</constant>
+	</constants>
+</class>

--- a/doc/classes/AccessibilityServerDummy.xml
+++ b/doc/classes/AccessibilityServerDummy.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AccessibilityServerDummy" inherits="AccessibilityServerExtension" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/doc/classes/AccessibilityServerExtension.xml
+++ b/doc/classes/AccessibilityServerExtension.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AccessibilityServerExtension" inherits="AccessibilityServer" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_create_window_context" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="window" type="int" />
+			<argument index="1" name="root_node" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_destroy_window_context" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="window" type="int" />
+			<argument index="1" name="root_node" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_features" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_name" qualifiers="virtual const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="_has_feature" qualifiers="virtual const">
+			<return type="bool" />
+			<argument index="0" name="feature" type="int" enum="AccessibilityServer.Feature" />
+			<description>
+			</description>
+		</method>
+		<method name="_native_window_callback" qualifiers="virtual">
+			<return type="int" />
+			<argument index="0" name="object" type="int" />
+			<argument index="1" name="wparam" type="int" />
+			<argument index="2" name="lparam" type="int" />
+			<argument index="3" name="window" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_post_tree_update" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="update_data" type="PackedInt64Array" />
+			<argument index="1" name="root_node" type="int" />
+			<argument index="2" name="kbd_focus" type="int" />
+			<argument index="3" name="mouse_focus" type="int" />
+			<argument index="4" name="window" type="int" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/AccessibilityServerManager.xml
+++ b/doc/classes/AccessibilityServerManager.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="AccessibilityServerManager" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="add_interface">
+			<return type="void" />
+			<argument index="0" name="interface" type="AccessibilityServer" />
+			<description>
+			</description>
+		</method>
+		<method name="find_interface" qualifiers="const">
+			<return type="AccessibilityServer" />
+			<argument index="0" name="name" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="get_interface" qualifiers="const">
+			<return type="AccessibilityServer" />
+			<argument index="0" name="idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_interface_count" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_interfaces" qualifiers="const">
+			<return type="Array" />
+			<description>
+			</description>
+		</method>
+		<method name="get_primary_interface" qualifiers="const">
+			<return type="AccessibilityServer" />
+			<description>
+			</description>
+		</method>
+		<method name="remove_interface">
+			<return type="void" />
+			<argument index="0" name="interface" type="AccessibilityServer" />
+			<description>
+			</description>
+		</method>
+		<method name="set_primary_interface">
+			<return type="void" />
+			<argument index="0" name="index" type="AccessibilityServer" />
+			<description>
+			</description>
+		</method>
+	</methods>
+	<signals>
+		<signal name="interface_added">
+			<argument index="0" name="interface_name" type="StringName" />
+			<description>
+			</description>
+		</signal>
+		<signal name="interface_removed">
+			<argument index="0" name="interface_name" type="StringName" />
+			<description>
+			</description>
+		</signal>
+	</signals>
+</class>

--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -10,6 +10,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="2" />
 		<member name="alignment" type="int" setter="set_text_alignment" getter="get_text_alignment" overrides="Button" enum="HorizontalAlignment" default="0" />
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" overrides="BaseButton" default="true" />
 	</members>

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -10,6 +10,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="3" />
 		<member name="alignment" type="int" setter="set_text_alignment" getter="get_text_alignment" overrides="Button" enum="HorizontalAlignment" default="0" />
 		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" overrides="BaseButton" default="true" />
 	</members>

--- a/doc/classes/Container.xml
+++ b/doc/classes/Container.xml
@@ -40,6 +40,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="4" />
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" overrides="Control" enum="Control.MouseFilter" default="1" />
 	</members>
 	<signals>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -358,6 +358,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="5" />
 		<member name="allow_reselect" type="bool" setter="set_allow_reselect" getter="get_allow_reselect" default="false">
 			If [code]true[/code], the currently selected item can be selected again.
 		</member>

--- a/doc/classes/Label.xml
+++ b/doc/classes/Label.xml
@@ -61,6 +61,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="7" />
 		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="Label.AutowrapMode" default="0">
 			If set to something other than [constant AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. If you resize the node, it will change its height automatically to show all the text. To see how each mode behaves, see [enum AutowrapMode].
 		</member>

--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -159,6 +159,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="8" />
 		<member name="alignment" type="int" setter="set_horizontal_alignment" getter="get_horizontal_alignment" enum="HorizontalAlignment" default="0">
 			Text alignment as defined in the [enum HorizontalAlignment] enum.
 		</member>

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -27,6 +27,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="10" />
 		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" overrides="BaseButton" enum="BaseButton.ActionMode" default="0" />
 		<member name="flat" type="bool" setter="set_flat" getter="is_flat" overrides="Button" default="true" />
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="0" />

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -22,6 +22,13 @@
 		<link title="All Demos">https://github.com/godotengine/godot-demo-projects/</link>
 	</tutorials>
 	<methods>
+		<method name="_accessibility_action" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="action" type="StringName" />
+			<argument index="1" name="data" type="Variant" />
+			<description>
+			</description>
+		</method>
 		<method name="_enter_tree" qualifiers="virtual">
 			<return type="void" />
 			<description>
@@ -34,6 +41,23 @@
 			<description>
 				Called when the node is about to leave the [SceneTree] (e.g. upon freeing, scene changing, or after calling [method remove_child] in a script). If the node has children, its [method _exit_tree] callback will be called last, after all its children have left the tree.
 				Corresponds to the [constant NOTIFICATION_EXIT_TREE] notification in [method Object._notification] and signal [signal tree_exiting]. To get notified when the node has already left the active tree, connect to the [signal tree_exited].
+			</description>
+		</method>
+		<method name="_get_accessibility_action" qualifiers="virtual const">
+			<return type="StringName" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_accessibility_action_count" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_accessibility_related_nodes" qualifiers="virtual const">
+			<return type="NodePath[]" />
+			<argument index="0" name="" type="int" enum="AccessibilityServer.NodeRelation" />
+			<description>
 			</description>
 		</method>
 		<method name="_get_configuration_warnings" qualifiers="virtual const">
@@ -203,6 +227,23 @@
 				Finds the first parent of the current node whose name matches [code]mask[/code] as in [method String.match] (i.e. case-sensitive, but [code]"*"[/code] matches zero or more characters and [code]"?"[/code] matches any single character except [code]"."[/code]).
 				[b]Note:[/b] It does not match against the full path, just against individual node names.
 				[b]Note:[/b] As this method walks upwards in the scene tree, it can be slow in large, deeply nested scene trees. Whenever possible, consider using [method get_node] instead. To avoid using [method find_parent] too often, consider caching the node reference into a variable.
+			</description>
+		</method>
+		<method name="get_accessibility_action" qualifiers="const">
+			<return type="StringName" />
+			<argument index="0" name="index" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_accessibility_action_count" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_accessibility_related_nodes" qualifiers="const">
+			<return type="NodePath[]" />
+			<argument index="0" name="relation" type="int" enum="AccessibilityServer.NodeRelation" />
+			<description>
 			</description>
 		</method>
 		<method name="get_child" qualifiers="const">
@@ -702,6 +743,12 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_description" type="String" setter="set_accessibility_description" getter="get_accessibility_description" default="&quot;&quot;">
+		</member>
+		<member name="accessibility_name" type="String" setter="set_accessibility_name" getter="get_accessibility_name" default="&quot;&quot;">
+		</member>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" enum="AccessibilityServer.Role" default="0">
+		</member>
 		<member name="custom_multiplayer" type="MultiplayerAPI" setter="set_custom_multiplayer" getter="get_custom_multiplayer">
 			The override to the default [MultiplayerAPI]. Set to [code]null[/code] to use the default [SceneTree] one.
 		</member>

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -173,6 +173,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="11" />
 		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" overrides="BaseButton" enum="BaseButton.ActionMode" default="0" />
 		<member name="alignment" type="int" setter="set_text_alignment" getter="get_text_alignment" overrides="Button" enum="HorizontalAlignment" default="0" />
 		<member name="item_count" type="int" setter="set_item_count" getter="get_item_count" default="0">

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -193,6 +193,8 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility/accessibility_driver" type="String" setter="" getter="" default="&quot;&quot;">
+		</member>
 		<member name="application/boot_splash/bg_color" type="Color" setter="" getter="" default="Color(0.14, 0.14, 0.14, 1)">
 			Background color for the boot splash.
 		</member>

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -406,6 +406,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="13" />
 		<member name="autowrap_mode" type="int" setter="set_autowrap_mode" getter="get_autowrap_mode" enum="RichTextLabel.AutowrapMode" default="3">
 			If set to something other than [constant AUTOWRAP_OFF], the text gets wrapped inside the node's bounding rectangle. To see how each mode behaves, see [enum AutowrapMode].
 		</member>

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -40,6 +40,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="15" />
 		<member name="clip_contents" type="bool" setter="set_clip_contents" getter="is_clipping_contents" overrides="Control" default="true" />
 		<member name="follow_focus" type="bool" setter="set_follow_focus" getter="is_following_focus" default="false">
 			If [code]true[/code], the ScrollContainer will automatically scroll to focused children (including indirect children) to make sure they are fully visible.

--- a/doc/classes/SubViewport.xml
+++ b/doc/classes/SubViewport.xml
@@ -17,6 +17,7 @@
 		<link title="3D Viewport Scaling Demo">https://godotengine.org/asset-library/asset/586</link>
 	</tutorials>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="0" />
 		<member name="render_target_clear_mode" type="int" setter="set_clear_mode" getter="get_clear_mode" enum="SubViewport.ClearMode" default="0">
 			The clear mode when the sub-viewport is used as a render target.
 			[b]Note:[/b] This property is intended for 2D usage.

--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -202,6 +202,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="18" />
 		<member name="clip_tabs" type="bool" setter="set_clip_tabs" getter="get_clip_tabs" default="true">
 			If [code]true[/code], tabs overflowing this node's width will be hidden, displaying two navigation buttons instead. Otherwise, this node's minimum size is updated so that all tabs are visible.
 		</member>

--- a/doc/classes/TextEdit.xml
+++ b/doc/classes/TextEdit.xml
@@ -933,6 +933,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="20" />
 		<member name="caret_blink" type="bool" setter="set_caret_blink_enabled" getter="is_caret_blink_enabled" default="false">
 			Sets if the caret should blink.
 		</member>

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -317,6 +317,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="21" />
 		<member name="allow_reselect" type="bool" setter="set_allow_reselect" getter="get_allow_reselect" default="false">
 			If [code]true[/code], the currently selected cell may be selected again.
 		</member>

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -100,6 +100,11 @@
 				Returns the visible rectangle in global screen coordinates.
 			</description>
 		</method>
+		<method name="get_window_id" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="gui_get_drag_data" qualifiers="const">
 			<return type="Variant" />
 			<description>
@@ -179,6 +184,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="accessibility_role" type="int" setter="set_accessibility_role" getter="get_accessibility_role" overrides="Node" enum="AccessibilityServer.Role" default="23" />
 		<member name="audio_listener_enable_2d" type="bool" setter="set_as_audio_listener_2d" getter="is_audio_listener_2d" default="false">
 			If [code]true[/code], the viewport will process 2D audio streams.
 		</member>

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -35,6 +35,7 @@
 #include "main/main.h"
 #include "os_windows.h"
 #include "scene/resources/texture.h"
+#include "servers/accessibility_server.h"
 
 #include <avrt.h>
 
@@ -2180,6 +2181,11 @@ LRESULT DisplayServerWindows::WndProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARA
 
 	// Process window messages.
 	switch (uMsg) {
+		case WM_GETOBJECT: {
+			if (ACS.is_valid() && ACS->has_feature(AccessibilityServer::FEATURE_USE_NATIVE_CB)) {
+				return (LRESULT)ACS->native_window_callback((int64_t)hWnd, (int64_t)wParam, (int64_t)lParam, window_id);
+			}
+		} break;
 		case WM_MOUSEACTIVATE: {
 			if (windows[window_id].no_focus) {
 				return MA_NOACTIVATEANDEAT; // Do not activate, and discard mouse messages.

--- a/scene/gui/base_button.cpp
+++ b/scene/gui/base_button.cpp
@@ -475,6 +475,7 @@ void BaseButton::_bind_methods() {
 }
 
 BaseButton::BaseButton() {
+	set_accessibility_role(AccessibilityServer::ROLE_BUTTON);
 	set_focus_mode(FOCUS_ALL);
 }
 

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -128,6 +128,7 @@ bool CheckBox::is_radio() {
 CheckBox::CheckBox(const String &p_text) :
 		Button(p_text) {
 	set_toggle_mode(true);
+	set_accessibility_role(AccessibilityServer::ROLE_CHECK_BOX);
 
 	set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -117,6 +117,7 @@ CheckButton::CheckButton(const String &p_text) :
 
 	set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 
+	set_accessibility_role(AccessibilityServer::ROLE_CHECK_BUTTON);
 	if (is_layout_rtl()) {
 		_set_internal_margin(SIDE_LEFT, get_icon_size().width);
 	} else {

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -219,4 +219,5 @@ void Container::_bind_methods() {
 Container::Container() {
 	// All containers should let mouse events pass by default.
 	set_mouse_filter(MOUSE_FILTER_PASS);
+	set_accessibility_role(AccessibilityServer::ROLE_CONTAINER);
 }

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1494,6 +1494,8 @@ void Control::_size_changed() {
 		if (pos_changed && !size_changed) {
 			_update_canvas_item_transform(); //move because it won't be updated
 		}
+
+		get_viewport()->accessibility_data_updated(get_instance_id());
 	}
 }
 

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -1755,6 +1755,7 @@ void ItemList::_bind_methods() {
 }
 
 ItemList::ItemList() {
+	set_accessibility_role(AccessibilityServer::ROLE_ITEM_LIST);
 	scroll_bar = memnew(VScrollBar);
 	add_child(scroll_bar, false, INTERNAL_MODE_FRONT);
 

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -951,6 +951,7 @@ void Label::_bind_methods() {
 }
 
 Label::Label(const String &p_text) {
+	set_accessibility_role(AccessibilityServer::ROLE_LABEL);
 	text_rid = TS->create_shaped_text();
 
 	set_mouse_filter(MOUSE_FILTER_IGNORE);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2438,6 +2438,7 @@ void LineEdit::_ensure_menu() {
 }
 
 LineEdit::LineEdit(const String &p_placeholder) {
+	set_accessibility_role(AccessibilityServer::ROLE_LINE_EDIT);
 	text_rid = TS->create_shaped_text();
 	_create_undo_state();
 

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -321,6 +321,7 @@ LinkButton::LinkButton(const String &p_text) {
 	text_buf.instantiate();
 	set_focus_mode(FOCUS_NONE);
 	set_default_cursor_shape(CURSOR_POINTING_HAND);
+	set_accessibility_role(AccessibilityServer::ROLE_LINK);
 
 	set_text(p_text);
 }

--- a/scene/gui/menu_button.cpp
+++ b/scene/gui/menu_button.cpp
@@ -229,6 +229,7 @@ void MenuButton::set_disable_shortcuts(bool p_disabled) {
 
 MenuButton::MenuButton(const String &p_text) :
 		Button(p_text) {
+	set_accessibility_role(AccessibilityServer::ROLE_MENU_BUTTON);
 	set_flat(true);
 	set_toggle_mode(true);
 	set_disable_shortcuts(false);

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -425,6 +425,7 @@ void OptionButton::_bind_methods() {
 OptionButton::OptionButton(const String &p_text) :
 		Button(p_text) {
 	set_toggle_mode(true);
+	set_accessibility_role(AccessibilityServer::ROLE_OPTION_BUTTON);
 	set_text_alignment(HORIZONTAL_ALIGNMENT_LEFT);
 	if (is_layout_rtl()) {
 		if (has_theme_icon(SNAME("arrow"))) {

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -105,6 +105,7 @@ void ProgressBar::_bind_methods() {
 }
 
 ProgressBar::ProgressBar() {
+	set_accessibility_role(AccessibilityServer::ROLE_PROGRESS_BAR);
 	set_v_size_flags(0);
 	set_step(0.01);
 }

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -4720,6 +4720,8 @@ Dictionary RichTextLabel::parse_expressions_for_values(Vector<String> p_expressi
 }
 
 RichTextLabel::RichTextLabel(const String &p_text) {
+	set_accessibility_role(AccessibilityServer::ROLE_RICH_TEXT);
+
 	main = memnew(ItemFrame);
 	main->index = 0;
 	current = main;

--- a/scene/gui/scroll_bar.cpp
+++ b/scene/gui/scroll_bar.cpp
@@ -627,6 +627,7 @@ void ScrollBar::_bind_methods() {
 
 ScrollBar::ScrollBar(Orientation p_orientation) {
 	orientation = p_orientation;
+	set_accessibility_role(AccessibilityServer::ROLE_SCROLL_BAR);
 
 	if (focus_by_default) {
 		set_focus_mode(FOCUS_ALL);

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -593,6 +593,8 @@ void ScrollContainer::_bind_methods() {
 };
 
 ScrollContainer::ScrollContainer() {
+	set_accessibility_role(AccessibilityServer::ROLE_SCROLL_CONTAINER);
+
 	h_scroll = memnew(HScrollBar);
 	h_scroll->set_name("_h_scroll");
 	add_child(h_scroll, false, INTERNAL_MODE_BACK);

--- a/scene/gui/slider.cpp
+++ b/scene/gui/slider.cpp
@@ -285,4 +285,5 @@ void Slider::_bind_methods() {
 Slider::Slider(Orientation p_orientation) {
 	orientation = p_orientation;
 	set_focus_mode(FOCUS_ALL);
+	set_accessibility_role(AccessibilityServer::ROLE_SLIDER);
 }

--- a/scene/gui/spin_box.cpp
+++ b/scene/gui/spin_box.cpp
@@ -318,6 +318,7 @@ void SpinBox::_bind_methods() {
 SpinBox::SpinBox() {
 	line_edit = memnew(LineEdit);
 	add_child(line_edit, false, INTERNAL_MODE_FRONT);
+	set_accessibility_role(AccessibilityServer::ROLE_SPIN_BOX);
 
 	line_edit->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	line_edit->set_mouse_filter(MOUSE_FILTER_PASS);

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -1548,6 +1548,7 @@ void TabBar::_bind_methods() {
 }
 
 TabBar::TabBar() {
+	set_accessibility_role(AccessibilityServer::ROLE_TAB_BAR);
 	set_size(Size2(get_size().width, get_minimum_size().height));
 	connect("mouse_exited", callable_mp(this, &TabBar::_on_mouse_exited));
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6593,6 +6593,8 @@ TextEdit::TextEdit(const String &p_placeholder) {
 	_update_caches();
 	set_default_cursor_shape(CURSOR_IBEAM);
 
+	set_accessibility_role(AccessibilityServer::ROLE_TEXT_EDIT);
+
 	text.set_tab_size(text.get_tab_size());
 
 	h_scroll = memnew(HScrollBar);

--- a/scene/gui/texture_progress_bar.cpp
+++ b/scene/gui/texture_progress_bar.cpp
@@ -663,4 +663,5 @@ void TextureProgressBar::_bind_methods() {
 
 TextureProgressBar::TextureProgressBar() {
 	set_mouse_filter(MOUSE_FILTER_PASS);
+	set_accessibility_role(AccessibilityServer::ROLE_PROGRESS_BAR);
 }

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4959,6 +4959,7 @@ Tree::Tree() {
 	columns.resize(1);
 
 	set_focus_mode(FOCUS_ALL);
+	set_accessibility_role(AccessibilityServer::ROLE_TREE);
 
 	popup_menu = memnew(PopupMenu);
 	popup_menu->hide();

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -35,6 +35,7 @@
 #include "core/templates/map.h"
 #include "core/variant/typed_array.h"
 #include "scene/main/scene_tree.h"
+#include "servers/accessibility_server.h"
 
 class Viewport;
 class SceneState;
@@ -96,6 +97,10 @@ private:
 		String scene_file_path;
 		Ref<SceneState> instance_state;
 		Ref<SceneState> inherited_state;
+
+		AccessibilityServer::Role ac_role = AccessibilityServer::ROLE_UNKNOWN;
+		String ac_name;
+		String ac_description;
 
 		Node *parent = nullptr;
 		Node *owner = nullptr;
@@ -291,6 +296,27 @@ public:
 
 	StringName get_name() const;
 	void set_name(const String &p_name);
+
+	virtual AccessibilityServer::Role get_accessibility_role() const;
+	virtual void set_accessibility_role(AccessibilityServer::Role p_role);
+
+	virtual String get_accessibility_name() const;
+	virtual void set_accessibility_name(const String &p_name);
+
+	virtual String get_accessibility_description() const;
+	virtual void set_accessibility_description(const String &p_description);
+
+	virtual TypedArray<NodePath> get_accessibility_related_nodes(AccessibilityServer::NodeRelation p_rel) const;
+	GDVIRTUAL1RC(TypedArray<NodePath>, _get_accessibility_related_nodes, AccessibilityServer::NodeRelation);
+
+	virtual void accessibility_action(const StringName &p_action, const Variant &p_data);
+	GDVIRTUAL2(_accessibility_action, const StringName &, const Variant &)
+
+	virtual int64_t get_accessibility_action_count() const;
+	GDVIRTUAL0RC(int64_t, _get_accessibility_action_count)
+
+	virtual StringName get_accessibility_action(int64_t p_index) const;
+	GDVIRTUAL1RC(StringName, _get_accessibility_action, int64_t)
 
 	void add_child(Node *p_child, bool p_legible_unique_name = false, InternalMode p_internal = INTERNAL_MODE_DISABLED);
 	void add_sibling(Node *p_sibling, bool p_legible_unique_name = false);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -33,6 +33,7 @@
 
 #include "scene/main/node.h"
 #include "scene/resources/texture.h"
+#include "servers/accessibility_server.h"
 
 #ifndef _3D_DISABLED
 class Camera3D;
@@ -204,6 +205,9 @@ private:
 	AudioListener2D *audio_listener_2d = nullptr;
 	Camera2D *camera_2d = nullptr;
 	Set<CanvasLayer *> canvas_layers;
+
+	bool ac_tree_valid = false;
+	Set<ObjectID> pending_ac_tree_updates;
 
 	RID viewport;
 	RID current_canvas;
@@ -460,6 +464,8 @@ protected:
 	Size2i _get_size_2d_override() const;
 	bool _is_size_allocated() const;
 
+	void _ac_node_add_data(const Node *p_node, bool p_recursive, PackedInt64Array &r_update);
+
 	void _notification(int p_what);
 	void _process_picking();
 	static void _bind_methods();
@@ -473,6 +479,9 @@ public:
 	bool is_audio_listener_2d() const;
 
 	void update_canvas_items();
+
+	void accessibility_data_updated(const ObjectID &p_object);
+	void invalidate_accessibility_data();
 
 	Rect2 get_visible_rect() const;
 	RID get_viewport_rid() const;

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -5,6 +5,7 @@ Import("env")
 env.servers_sources = []
 env.add_source_files(env.servers_sources, "*.cpp")
 
+SConscript("accessibility/SCsub")
 SConscript("xr/SCsub")
 SConscript("camera/SCsub")
 SConscript("physics_3d/SCsub")

--- a/servers/accessibility/SCsub
+++ b/servers/accessibility/SCsub
@@ -1,0 +1,5 @@
+#!/usr/bin/env python
+
+Import("env")
+
+env.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/accessibility/accessibility_server_dummy.h
+++ b/servers/accessibility/accessibility_server_dummy.h
@@ -1,0 +1,48 @@
+/*************************************************************************/
+/*  accessibility_server_dummy.h                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef ACCESSIBILITY_SERVER_DUMMY_H
+#define ACCESSIBILITY_SERVER_DUMMY_H
+
+#include "servers/accessibility/accessibility_server_extension.h"
+
+/*************************************************************************/
+
+class AccessibilityServerDummy : public AccessibilityServerExtension {
+	GDCLASS(AccessibilityServerDummy, AccessibilityServerExtension);
+	_THREAD_SAFE_CLASS_
+
+public:
+	virtual String get_name() const override {
+		return "Dummy";
+	}
+};
+
+#endif // ACCESSIBILITY_SERVER_DUMMY_H

--- a/servers/accessibility/accessibility_server_extension.cpp
+++ b/servers/accessibility/accessibility_server_extension.cpp
@@ -1,0 +1,88 @@
+/*************************************************************************/
+/*  accessibility_server_extension.cpp                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "accessibility_server_extension.h"
+
+void AccessibilityServerExtension::_bind_methods() {
+	GDVIRTUAL_BIND(_has_feature, "feature");
+	GDVIRTUAL_BIND(_get_name);
+	GDVIRTUAL_BIND(_get_features);
+
+	GDVIRTUAL_BIND(_create_window_context, "window", "root_node");
+	GDVIRTUAL_BIND(_destroy_window_context, "window", "root_node");
+
+	GDVIRTUAL_BIND(_post_tree_update, "update_data", "root_node", "kbd_focus", "mouse_focus", "window");
+
+	GDVIRTUAL_BIND(_native_window_callback, "object", "wparam", "lparam", "window");
+}
+
+bool AccessibilityServerExtension::has_feature(Feature p_feature) const {
+	bool ret;
+	if (GDVIRTUAL_CALL(_has_feature, p_feature, ret)) {
+		return ret;
+	}
+	return false;
+}
+
+String AccessibilityServerExtension::get_name() const {
+	String ret;
+	if (GDVIRTUAL_CALL(_get_name, ret)) {
+		return ret;
+	}
+	return "Unknown";
+}
+
+int64_t AccessibilityServerExtension::get_features() const {
+	int64_t ret;
+	if (GDVIRTUAL_CALL(_get_features, ret)) {
+		return ret;
+	}
+	return 0;
+}
+
+void AccessibilityServerExtension::create_window_context(DisplayServer::WindowID p_window, ObjectID p_root_node) {
+	GDVIRTUAL_CALL(_create_window_context, p_window, p_root_node);
+}
+
+void AccessibilityServerExtension::destroy_window_context(DisplayServer::WindowID p_window, ObjectID p_root_node) {
+	GDVIRTUAL_CALL(_destroy_window_context, p_window, p_root_node);
+}
+
+void AccessibilityServerExtension::post_tree_update(const PackedInt64Array &p_update_data, ObjectID p_root_node, ObjectID p_kbd_focus, ObjectID p_mouse_focus, DisplayServer::WindowID p_window) {
+	GDVIRTUAL_CALL(_post_tree_update, p_update_data, p_root_node, p_kbd_focus, p_mouse_focus, p_window);
+}
+
+int64_t AccessibilityServerExtension::native_window_callback(int64_t p_object, int64_t p_wparam, int64_t p_lparam, DisplayServer::WindowID p_window) {
+	int64_t ret;
+	if (GDVIRTUAL_CALL(_native_window_callback, p_object, p_wparam, p_lparam, p_window, ret)) {
+		return ret;
+	}
+	return 0;
+}

--- a/servers/accessibility/accessibility_server_extension.h
+++ b/servers/accessibility/accessibility_server_extension.h
@@ -1,0 +1,68 @@
+/*************************************************************************/
+/*  accessibility_server_extension.h                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef ACCESSIBILITY_SERVER_EXTENSION_H
+#define ACCESSIBILITY_SERVER_EXTENSION_H
+
+#include "core/object/gdvirtual.gen.inc"
+#include "core/object/script_language.h"
+#include "core/os/thread_safe.h"
+#include "core/variant/native_ptr.h"
+#include "servers/accessibility_server.h"
+
+class AccessibilityServerExtension : public AccessibilityServer {
+	GDCLASS(AccessibilityServerExtension, AccessibilityServer);
+
+protected:
+	_THREAD_SAFE_CLASS_
+
+	static void _bind_methods();
+
+public:
+	virtual bool has_feature(Feature p_feature) const override;
+	virtual String get_name() const override;
+	virtual int64_t get_features() const override;
+	GDVIRTUAL1RC(bool, _has_feature, Feature);
+	GDVIRTUAL0RC(String, _get_name);
+	GDVIRTUAL0RC(int64_t, _get_features);
+
+	virtual void create_window_context(DisplayServer::WindowID p_window, ObjectID p_root_node) override;
+	virtual void destroy_window_context(DisplayServer::WindowID p_window, ObjectID p_root_node) override;
+	GDVIRTUAL2(_create_window_context, DisplayServer::WindowID, ObjectID);
+	GDVIRTUAL2(_destroy_window_context, DisplayServer::WindowID, ObjectID);
+
+	virtual void post_tree_update(const PackedInt64Array &p_update_data, ObjectID p_root_node, ObjectID p_kbd_focus, ObjectID p_mouse_focus, DisplayServer::WindowID p_window) override;
+	GDVIRTUAL5(_post_tree_update, const PackedInt64Array &, ObjectID, ObjectID, ObjectID, DisplayServer::WindowID);
+
+	virtual int64_t native_window_callback(int64_t p_object, int64_t p_wparam, int64_t p_lparam, DisplayServer::WindowID p_window) override;
+	GDVIRTUAL4R(int64_t, _native_window_callback, int64_t, int64_t, int64_t, DisplayServer::WindowID);
+};
+
+#endif // ACCESSIBILITY_SERVER_EXTENSION_H

--- a/servers/accessibility_server.cpp
+++ b/servers/accessibility_server.cpp
@@ -1,0 +1,204 @@
+/*************************************************************************/
+/*  accessibility_server.cpp                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "servers/accessibility_server.h"
+
+AccessibilityServerManager *AccessibilityServerManager::singleton = nullptr;
+
+void AccessibilityServerManager::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("add_interface", "interface"), &AccessibilityServerManager::add_interface);
+	ClassDB::bind_method(D_METHOD("get_interface_count"), &AccessibilityServerManager::get_interface_count);
+	ClassDB::bind_method(D_METHOD("remove_interface", "interface"), &AccessibilityServerManager::remove_interface);
+	ClassDB::bind_method(D_METHOD("get_interface", "idx"), &AccessibilityServerManager::get_interface);
+	ClassDB::bind_method(D_METHOD("get_interfaces"), &AccessibilityServerManager::get_interfaces);
+	ClassDB::bind_method(D_METHOD("find_interface", "name"), &AccessibilityServerManager::find_interface);
+
+	ClassDB::bind_method(D_METHOD("set_primary_interface", "index"), &AccessibilityServerManager::set_primary_interface);
+	ClassDB::bind_method(D_METHOD("get_primary_interface"), &AccessibilityServerManager::get_primary_interface);
+
+	ADD_SIGNAL(MethodInfo("interface_added", PropertyInfo(Variant::STRING_NAME, "interface_name")));
+	ADD_SIGNAL(MethodInfo("interface_removed", PropertyInfo(Variant::STRING_NAME, "interface_name")));
+}
+
+void AccessibilityServerManager::add_interface(const Ref<AccessibilityServer> &p_interface) {
+	ERR_FAIL_COND(p_interface.is_null());
+
+	for (int i = 0; i < interfaces.size(); i++) {
+		if (interfaces[i] == p_interface) {
+			ERR_PRINT("AccessibilityServer: Interface was already added.");
+			return;
+		};
+	};
+
+	interfaces.push_back(p_interface);
+	print_verbose("AccessibilityServer: Added interface \"" + p_interface->get_name() + "\"");
+	emit_signal(SNAME("interface_added"), p_interface->get_name());
+}
+
+void AccessibilityServerManager::remove_interface(const Ref<AccessibilityServer> &p_interface) {
+	ERR_FAIL_COND(p_interface.is_null());
+	ERR_FAIL_COND_MSG(p_interface == primary_interface, "AccessibilityServer: Can't remove primary interface.");
+
+	int idx = -1;
+	for (int i = 0; i < interfaces.size(); i++) {
+		if (interfaces[i] == p_interface) {
+			idx = i;
+			break;
+		};
+	};
+
+	ERR_FAIL_COND(idx == -1);
+	print_verbose("AccessibilityServer: Removed interface \"" + p_interface->get_name() + "\"");
+	emit_signal(SNAME("interface_removed"), p_interface->get_name());
+	interfaces.remove_at(idx);
+}
+
+int AccessibilityServerManager::get_interface_count() const {
+	return interfaces.size();
+}
+
+Ref<AccessibilityServer> AccessibilityServerManager::get_interface(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, interfaces.size(), nullptr);
+	return interfaces[p_index];
+}
+
+Ref<AccessibilityServer> AccessibilityServerManager::find_interface(const String &p_name) const {
+	int idx = -1;
+	for (int i = 0; i < interfaces.size(); i++) {
+		if (interfaces[i]->get_name() == p_name) {
+			idx = i;
+			break;
+		};
+	};
+
+	ERR_FAIL_COND_V(idx == -1, nullptr);
+	return interfaces[idx];
+}
+
+Array AccessibilityServerManager::get_interfaces() const {
+	Array ret;
+
+	for (int i = 0; i < interfaces.size(); i++) {
+		Dictionary iface_info;
+
+		iface_info["id"] = i;
+		iface_info["name"] = interfaces[i]->get_name();
+
+		ret.push_back(iface_info);
+	};
+
+	return ret;
+}
+
+void AccessibilityServerManager::set_primary_interface(const Ref<AccessibilityServer> &p_primary_interface) {
+	if (p_primary_interface.is_null()) {
+		print_verbose("AccessibilityServer: Clearing primary interface");
+		primary_interface.unref();
+	} else {
+		primary_interface = p_primary_interface;
+		print_verbose("AccessibilityServer: Primary interface set to: \"" + primary_interface->get_name() + "\".");
+
+		if (OS::get_singleton()->get_main_loop()) {
+			OS::get_singleton()->get_main_loop()->notification(MainLoop::NOTIFICATION_TEXT_SERVER_CHANGED);
+		}
+	}
+}
+
+AccessibilityServerManager::AccessibilityServerManager() {
+	singleton = this;
+}
+
+AccessibilityServerManager::~AccessibilityServerManager() {
+	if (primary_interface.is_valid()) {
+		primary_interface.unref();
+	}
+	while (interfaces.size() > 0) {
+		interfaces.remove_at(0);
+	}
+	singleton = nullptr;
+}
+
+/*************************************************************************/
+
+void AccessibilityServer::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("has_feature", "feature"), &AccessibilityServer::has_feature);
+	ClassDB::bind_method(D_METHOD("get_name"), &AccessibilityServer::get_name);
+	ClassDB::bind_method(D_METHOD("get_features"), &AccessibilityServer::get_features);
+
+	ClassDB::bind_method(D_METHOD("create_window_context", "window"), &AccessibilityServer::create_window_context);
+	ClassDB::bind_method(D_METHOD("destroy_window_context", "window"), &AccessibilityServer::destroy_window_context);
+
+	ClassDB::bind_method(D_METHOD("post_tree_update", "update_data", "kdb_focused", "mouse_focus", "window"), &AccessibilityServer::post_tree_update);
+
+	/* Role */
+	BIND_ENUM_CONSTANT(ROLE_UNKNOWN);
+	BIND_ENUM_CONSTANT(ROLE_BUTTON);
+	BIND_ENUM_CONSTANT(ROLE_CHECK_BOX);
+	BIND_ENUM_CONSTANT(ROLE_CHECK_BUTTON); // AccessKit ToggleButton
+	BIND_ENUM_CONSTANT(ROLE_CONTAINER); // AccessKit GenericContainer
+	BIND_ENUM_CONSTANT(ROLE_ITEM_LIST); // AccessKit ListBox ? (or List ?)
+	BIND_ENUM_CONSTANT(ROLE_ITEM_LIST_ITEM); // AccessKit ListBoxOption? (or ListItem ?)
+	BIND_ENUM_CONSTANT(ROLE_LABEL);
+	BIND_ENUM_CONSTANT(ROLE_LINE_EDIT); // AccessKit TextBox
+	BIND_ENUM_CONSTANT(ROLE_LINK);
+	BIND_ENUM_CONSTANT(ROLE_MENU_BUTTON); // AccessKit PopupButton ?
+	BIND_ENUM_CONSTANT(ROLE_OPTION_BUTTON); // AccessKit ComboBoxMenuButton ?
+	BIND_ENUM_CONSTANT(ROLE_PROGRESS_BAR); // AccessKit ProgressIndicator
+	BIND_ENUM_CONSTANT(ROLE_RICH_TEXT); // AccessKit Documnet ? (or StaticText)
+	BIND_ENUM_CONSTANT(ROLE_SCROLL_BAR);
+	BIND_ENUM_CONSTANT(ROLE_SCROLL_CONTAINER); // AccessKit ScrollView
+	BIND_ENUM_CONSTANT(ROLE_SLIDER);
+	BIND_ENUM_CONSTANT(ROLE_SPIN_BOX); // AccessKit SpinButton
+	BIND_ENUM_CONSTANT(ROLE_TAB_BAR); // AccessKit TabList
+	BIND_ENUM_CONSTANT(ROLE_TAB);
+	BIND_ENUM_CONSTANT(ROLE_TEXT_EDIT); // AccessKit TextBox + multiline flag ?
+	BIND_ENUM_CONSTANT(ROLE_TREE); // AccessKit Tree or TreeGrid
+	BIND_ENUM_CONSTANT(ROLE_TREE_ITEM);
+	BIND_ENUM_CONSTANT(ROLE_WINDOW);
+	//TODO add other roles
+
+	/* NodeRelation */
+	BIND_ENUM_CONSTANT(NODE_RELATION_INDIRECT_CHILD);
+	BIND_ENUM_CONSTANT(NODE_RELATION_ERROR_MESSAGE);
+	BIND_ENUM_CONSTANT(NODE_RELATION_LINK_TARGET);
+	BIND_ENUM_CONSTANT(NODE_RELATION_GROUP_MEMBER);
+	BIND_ENUM_CONSTANT(NODE_RELATION_POPUP);
+	BIND_ENUM_CONSTANT(NODE_RELATION_CONTROLS);
+	BIND_ENUM_CONSTANT(NODE_RELATION_DETAILS);
+	BIND_ENUM_CONSTANT(NODE_RELATION_DESCRIBED);
+	BIND_ENUM_CONSTANT(NODE_RELATION_FLOW_TO);
+	BIND_ENUM_CONSTANT(NODE_RELATION_LABELLED);
+	BIND_ENUM_CONSTANT(NODE_RELATION_RADIO_GROUP_MEMBER);
+
+	/* Feature */
+	BIND_ENUM_CONSTANT(FEATURE_SCREEN_READER_SUPPORT);
+	BIND_ENUM_CONSTANT(FEATURE_USE_NATIVE_CB);
+	BIND_ENUM_CONSTANT(FEATURE_USE_TREE_UPDATES);
+}

--- a/servers/accessibility_server.h
+++ b/servers/accessibility_server.h
@@ -1,0 +1,151 @@
+/*************************************************************************/
+/*  accessibility_server.h                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef ACCESSIBILITY_SERVER_H
+#define ACCESSIBILITY_SERVER_H
+
+#include "core/object/object_id.h"
+#include "core/object/ref_counted.h"
+#include "core/os/os.h"
+#include "core/variant/variant.h"
+#include "servers/display_server.h"
+
+class AccessibilityServer : public RefCounted {
+	GDCLASS(AccessibilityServer, RefCounted);
+
+public:
+	enum Role {
+		ROLE_UNKNOWN,
+		ROLE_BUTTON,
+		ROLE_CHECK_BOX,
+		ROLE_CHECK_BUTTON, // AccessKit ToggleButton
+		ROLE_CONTAINER, // AccessKit GenericContainer
+		ROLE_ITEM_LIST, // AccessKit ListBox ? (or List ?)
+		ROLE_ITEM_LIST_ITEM, // AccessKit ListBoxOption? (or ListItem ?)
+		ROLE_LABEL,
+		ROLE_LINE_EDIT, // AccessKit TextBox
+		ROLE_LINK,
+		ROLE_MENU_BUTTON, // AccessKit PopupButton ?
+		ROLE_OPTION_BUTTON, // AccessKit ComboBoxMenuButton ?
+		ROLE_PROGRESS_BAR, // AccessKit ProgressIndicator
+		ROLE_RICH_TEXT, // AccessKit Documnet ? (or StaticText)
+		ROLE_SCROLL_BAR,
+		ROLE_SCROLL_CONTAINER, // AccessKit ScrollView
+		ROLE_SLIDER,
+		ROLE_SPIN_BOX, // AccessKit SpinButton
+		ROLE_TAB_BAR, // AccessKit TabList
+		ROLE_TAB,
+		ROLE_TEXT_EDIT, // AccessKit TextBox + multiline flag ?
+		ROLE_TREE, // AccessKit Tree or TreeGrid
+		ROLE_TREE_ITEM,
+		ROLE_WINDOW
+		//TODO add other roles
+	};
+
+	enum NodeRelation {
+		NODE_RELATION_INDIRECT_CHILD,
+		NODE_RELATION_ERROR_MESSAGE,
+		NODE_RELATION_LINK_TARGET,
+		NODE_RELATION_GROUP_MEMBER,
+		NODE_RELATION_POPUP,
+		NODE_RELATION_CONTROLS,
+		NODE_RELATION_DETAILS,
+		NODE_RELATION_DESCRIBED,
+		NODE_RELATION_FLOW_TO,
+		NODE_RELATION_LABELLED,
+		NODE_RELATION_RADIO_GROUP_MEMBER,
+	};
+
+	enum Feature {
+		FEATURE_SCREEN_READER_SUPPORT = 1 << 0,
+		FEATURE_USE_NATIVE_CB = 1 << 1,
+		FEATURE_USE_TREE_UPDATES = 1 << 2,
+	};
+
+protected:
+	static void _bind_methods();
+
+public:
+	virtual bool has_feature(Feature p_feature) const = 0;
+	virtual String get_name() const = 0;
+	virtual int64_t get_features() const = 0;
+
+	virtual void create_window_context(DisplayServer::WindowID p_window, ObjectID p_root_node) = 0;
+	virtual void destroy_window_context(DisplayServer::WindowID p_window, ObjectID p_root_node) = 0;
+
+	virtual void post_tree_update(const PackedInt64Array &p_update_data, ObjectID p_root_node, ObjectID p_kbd_focus, ObjectID p_mouse_focus, DisplayServer::WindowID p_window) = 0;
+
+	virtual int64_t native_window_callback(int64_t p_object, int64_t p_wparam, int64_t p_lparam, DisplayServer::WindowID p_window) = 0;
+};
+
+/*************************************************************************/
+
+class AccessibilityServerManager : public Object {
+	GDCLASS(AccessibilityServerManager, Object);
+
+protected:
+	static void _bind_methods();
+
+private:
+	static AccessibilityServerManager *singleton;
+
+	Ref<AccessibilityServer> primary_interface;
+	Vector<Ref<AccessibilityServer>> interfaces;
+
+public:
+	_FORCE_INLINE_ static AccessibilityServerManager *get_singleton() {
+		return singleton;
+	}
+
+	void add_interface(const Ref<AccessibilityServer> &p_interface);
+	void remove_interface(const Ref<AccessibilityServer> &p_interface);
+	int get_interface_count() const;
+	Ref<AccessibilityServer> get_interface(int p_index) const;
+	Ref<AccessibilityServer> find_interface(const String &p_name) const;
+	Array get_interfaces() const;
+
+	_FORCE_INLINE_ Ref<AccessibilityServer> get_primary_interface() const {
+		return primary_interface;
+	}
+	void set_primary_interface(const Ref<AccessibilityServer> &p_primary_interface);
+
+	AccessibilityServerManager();
+	~AccessibilityServerManager();
+};
+
+/*************************************************************************/
+
+#define ACS AccessibilityServerManager::get_singleton()->get_primary_interface()
+
+VARIANT_ENUM_CAST(AccessibilityServer::Role);
+VARIANT_ENUM_CAST(AccessibilityServer::NodeRelation);
+VARIANT_ENUM_CAST(AccessibilityServer::Feature);
+
+#endif // ACCESSIBILITY_SERVER_H

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -33,6 +33,9 @@
 #include "core/config/engine.h"
 #include "core/config/project_settings.h"
 
+#include "accessibility/accessibility_server_dummy.h"
+#include "accessibility/accessibility_server_extension.h"
+#include "accessibility_server.h"
 #include "audio/audio_effect.h"
 #include "audio/audio_stream.h"
 #include "audio/effects/audio_effect_amplify.h"
@@ -120,6 +123,13 @@ void preregister_server_types() {
 	GDREGISTER_NATIVE_STRUCT(CaretInfo, "Rect2 leading_caret;Rect2 trailing_caret;TextServer::Direction leading_direction;TextServer::Direction trailing_direction");
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("TextServerManager", TextServerManager::get_singleton(), "TextServerManager"));
+
+	GDREGISTER_CLASS(AccessibilityServerManager);
+	GDREGISTER_ABSTRACT_CLASS(AccessibilityServer);
+	GDREGISTER_VIRTUAL_CLASS(AccessibilityServerExtension);
+	GDREGISTER_CLASS(AccessibilityServerDummy);
+
+	Engine::get_singleton()->add_singleton(Engine::Singleton("AccessibilityServerManager", AccessibilityServerManager::get_singleton(), "AccessibilityServerManager"));
 }
 
 void register_server_types() {


### PR DESCRIPTION
A very early interface draft for screen-reader support GDExtension plugins.

At this point, the engine should be able to provide minimal information about node tree changes, and native system callbacks required by AccessKit library (but it might change in the process).

TODO:
  - [ ] GDExtension module interface / core.
      - [x] Add generic accessibility role / name / description properties to the nodes (more detailed info can be gathered on the module side, using existing properties).
      - [x] Collect and send node tree updates to the module.
          - [ ] Ensure updates work correctly for embedded viewports and editor internal nodes.
      - [ ] Native system callback for the module.
          - [x] Windows: `WM_GETOBJECT` callback.
          - [x] macOS: `(id)childAccessibleElement` callback.
      - [ ] Add supported action lists and process actions received from the module.
      - [ ] Setup built-in node roles, and ensure all information required by the module is accessible.
      - [ ] Ensure all relevant property changes trigger tree updates for the module.
      - [ ] Documentation.

  - [ ] AccessKit based GDExtension module (in progress, not it this PR, I'll make a dedicated repo as soon as it's usable)
      - [x] C interface for AccessKit `Note` / `Tree` / `TreeUpdate` structs.
      - [ ] Construct AccessKit `Node`s / `TreeUpdate`s, from node properties and tree updates provided by the engine.
      - [ ] C interface and callback for AccessKit `Action`/`ActionRequest` and action processing.


~Note: Temporary includes `Revert "Discern between virtual and abstract class bindings"` commit, since it's breaking `godot-cpp` completely.~ Removed, should work with https://github.com/godotengine/godot-cpp/pull/724 and synced `godot-headers`.