### PR TITLE
Call NavigationAgent update_navigation in set_target_location

### DIFF
--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -199,7 +199,8 @@ real_t NavigationAgent2D::distance_to_target() const {
 	return agent_parent->get_global_position().distance_to(target_location);
 }
 
-bool NavigationAgent2D::is_target_reached() const {
+bool NavigationAgent2D::is_target_reached() {
+	update_navigation();
 	return target_reached;
 }
 
@@ -225,6 +226,16 @@ void NavigationAgent2D::set_velocity(Vector2 p_velocity) {
 	NavigationServer2D::get_singleton()->agent_set_target_velocity(agent, target_velocity);
 	NavigationServer2D::get_singleton()->agent_set_velocity(agent, prev_safe_velocity);
 	velocity_submitted = true;
+}
+
+Vector<Vector2> NavigationAgent2D::get_nav_path() {
+	update_navigation();
+	return navigation_path;
+}
+
+int NavigationAgent2D::get_nav_path_index() {
+	update_navigation();
+	return nav_path_index;
 }
 
 void NavigationAgent2D::_avoidance_done(Vector3 p_new_velocity) {

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -118,16 +118,12 @@ public:
 
 	Vector2 get_next_location();
 
-	Vector<Vector2> get_nav_path() const {
-		return navigation_path;
-	}
+	Vector<Vector2> get_nav_path();
 
-	int get_nav_path_index() const {
-		return nav_path_index;
-	}
+	int get_nav_path_index();
 
 	real_t distance_to_target() const;
-	bool is_target_reached() const;
+	bool is_target_reached();
 	bool is_target_reachable();
 	bool is_navigation_finished();
 	Vector2 get_final_location();

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -206,7 +206,8 @@ real_t NavigationAgent3D::distance_to_target() const {
 	return agent_parent->get_global_transform().origin.distance_to(target_location);
 }
 
-bool NavigationAgent3D::is_target_reached() const {
+bool NavigationAgent3D::is_target_reached() {
+	update_navigation();
 	return target_reached;
 }
 
@@ -232,6 +233,16 @@ void NavigationAgent3D::set_velocity(Vector3 p_velocity) {
 	NavigationServer3D::get_singleton()->agent_set_target_velocity(agent, target_velocity);
 	NavigationServer3D::get_singleton()->agent_set_velocity(agent, prev_safe_velocity);
 	velocity_submitted = true;
+}
+
+Vector<Vector3> NavigationAgent3D::get_nav_path() {
+	update_navigation();
+	return navigation_path;
+}
+
+int NavigationAgent3D::get_nav_path_index() {
+	update_navigation();
+	return nav_path_index;
 }
 
 void NavigationAgent3D::_avoidance_done(Vector3 p_new_velocity) {

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -125,16 +125,12 @@ public:
 
 	Vector3 get_next_location();
 
-	Vector<Vector3> get_nav_path() const {
-		return navigation_path;
-	}
+	Vector<Vector3> get_nav_path();
 
-	int get_nav_path_index() const {
-		return nav_path_index;
-	}
+	int get_nav_path_index();
 
 	real_t distance_to_target() const;
-	bool is_target_reached() const;
+	bool is_target_reached();
 	bool is_target_reachable();
 	bool is_navigation_finished();
 	Vector3 get_final_location();


### PR DESCRIPTION
We move the NavigationAgent3D and NavigationAgent2D calls to
`update_navigation()` from the getter functions, to
`set_target_location()` such that it is always updated when a new target
location is set.

Test project: [Shou/godot-demo-projects/tree/45962a9be3ae5f2d2a29b285d0d45d206a55340d/2d/navigation_agent](https://github.com/Shou/godot-demo-projects/tree/45962a9be3ae5f2d2a29b285d0d45d206a55340d/2d/navigation_agent)

Toggle the comment for `nav_agent.get_next_location()` in `navigation.gd`. It's derived from the original navigation example hence the stale comments.

Fixes https://github.com/godotengine/godot/issues/59104