### PR TITLE
Include platform_config.h in thread.cpp and thread.h

### DIFF
--- a/core/os/thread.cpp
+++ b/core/os/thread.cpp
@@ -28,6 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#include "platform_config.h"
 #ifndef PLATFORM_THREAD_OVERRIDE // See details in thread.h
 
 #include "thread.h"

--- a/core/os/thread.h
+++ b/core/os/thread.h
@@ -28,6 +28,7 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#include "platform_config.h"
 // Define PLATFORM_THREAD_OVERRIDE in your platform's `platform_config.h`
 // to use a custom Thread implementation defined in `platform/[your_platform]/platform_thread.h`
 // Overriding the platform implementation is required in some proprietary platforms


### PR DESCRIPTION
Defining `PLATFORM_THREAD_OVERRIDE` in `platform_config.h` won't affect `thread.cpp` and `thread.h` if `platform_config.h` is not included at the top of each of them.

Related to: https://github.com/godotengine/godot/pull/52734, https://github.com/godotengine/godot/pull/53044