### PR TITLE
Improve editor log message filter button styles.

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -80,6 +80,11 @@ void EditorLog::_update_theme() {
 	type_filter_map[MSG_TYPE_WARNING]->toggle_button->set_icon(get_theme_icon(SNAME("StatusWarning"), SNAME("EditorIcons")));
 	type_filter_map[MSG_TYPE_EDITOR]->toggle_button->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
 
+	type_filter_map[MSG_TYPE_STD]->toggle_button->set_theme_type_variation("EditorLogFilterButton");
+	type_filter_map[MSG_TYPE_ERROR]->toggle_button->set_theme_type_variation("EditorLogFilterButton");
+	type_filter_map[MSG_TYPE_WARNING]->toggle_button->set_theme_type_variation("EditorLogFilterButton");
+	type_filter_map[MSG_TYPE_EDITOR]->toggle_button->set_theme_type_variation("EditorLogFilterButton");
+
 	clear_button->set_icon(get_theme_icon(SNAME("Clear"), SNAME("EditorIcons")));
 	copy_button->set_icon(get_theme_icon(SNAME("ActionCopy"), SNAME("EditorIcons")));
 	collapse_button->set_icon(get_theme_icon(SNAME("CombineLines"), SNAME("EditorIcons")));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -702,6 +702,19 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("icon_focus_color", "Button", icon_focus_color);
 	theme->set_color("icon_pressed_color", "Button", icon_pressed_color);
 
+	// Variation for Editor Log filter buttons
+	theme->set_type_variation("EditorLogFilterButton", "Button");
+	// When pressed, don't tint the icons with the accent color, just leave them normal.
+	theme->set_color("icon_pressed_color", "EditorLogFilterButton", icon_normal_color);
+	// When unpressed, dim the icons.
+	theme->set_color("icon_normal_color", "EditorLogFilterButton", font_disabled_color);
+	// When pressed, add a small bottom border to the buttons to better show their active state,
+	// similar to active tabs.
+	Ref<StyleBoxFlat> editor_log_button_pressed = style_widget_pressed->duplicate();
+	editor_log_button_pressed->set_border_width(SIDE_BOTTOM, 2 * EDSCALE);
+	editor_log_button_pressed->set_border_color(accent_color);
+	theme->set_stylebox("pressed", "EditorLogFilterButton", editor_log_button_pressed);
+
 	// OptionButton
 	theme->set_stylebox("focus", "OptionButton", style_widget_focus);
 


### PR DESCRIPTION
Overall this should be more inline with the godot editor style, and is clearer about which filters are active or inactive.
* Removed tinting of icons (my biggest gripe).
* Added slight dimming to icons on inactive filters.
* Added border bottom border highlight to active filters.

![image](https://user-images.githubusercontent.com/41730826/158167255-3c31f351-f4a0-44c4-bdab-fe16ae268a79.png)