### PR TITLE
Fix that subwindows receive events outside of their viewport

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2665,6 +2665,12 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 	window_ofs.set_origin(-gui.subwindow_focused->get_position());
 
 	Ref<InputEvent> ev = p_event->xformed_by(window_ofs);
+	if (ev->has_method("get_position")) {
+		Point2 pos = ev->call("get_position");
+		if (!gui.subwindow_focused->get_visible_rect().has_point(pos)) {
+			return false;
+		}
+	}
 
 	gui.subwindow_focused->_window_input(ev);
 


### PR DESCRIPTION
SubWindows do receive events, that are outside of their borders. This patch restricts that events with a position outside of the SubWindows viewport are not sent to the SubWindow.

Fixes that buttons receive events, even if the mouse is outside of their SubWindow:

https://user-images.githubusercontent.com/6299227/158175641-0ec98896-58fa-44a9-a7c7-fd72969d48e0.mp4
