### PR TITLE
Improves SpriteFrames editor

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -143,6 +143,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _sheet_preview_input(const Ref<InputEvent> &p_event);
 	void _sheet_scroll_input(const Ref<InputEvent> &p_event);
 	void _sheet_add_frames();
+	void _sheet_zoom_on_position(float p_zoom, const Vector2 &p_position);
 	void _sheet_zoom_in();
 	void _sheet_zoom_out();
 	void _sheet_zoom_reset();


### PR DESCRIPTION
* Fixes button icons not updating when theme changes.
* In Select Frames (split spritesheet) dialog:
    * Fixes CTRL+Wheel zooming unexpected scrolling.
    * Makes CTRL+Wheel zooming consider mouse position.
    * Adds middle mouse drag panning.