### PR TITLE
Create GDExtension clases for PhysicsServer3D

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -18,16 +18,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: Editor w/ Mono (target=release_debug, tools=yes, tests=yes)
-            cache-name: linux-editor-mono
-            target: release_debug
-            tools: true
-            tests: false # Disabled due freeze caused by mix Mono build and CI
-            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no
-            doc-test: true
-            bin: "./bin/godot.linuxbsd.opt.tools.64.mono"
-            build-mono: true
-            artifact: true
+#          - name: Editor w/ Mono (target=release_debug, tools=yes, tests=yes)
+#            cache-name: linux-editor-mono
+#            target: release_debug
+#            tools: true
+#            tests: false # Disabled due freeze caused by mix Mono build and CI
+#            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no
+#            doc-test: true
+#            bin: "./bin/godot.linuxbsd.opt.tools.64.mono"
+#            build-mono: true
+#            artifact: true
 
           - name: Editor with doubles and sanitizers (target=debug, tools=yes, float=64, tests=yes, use_asan=yes, use_ubsan=yes)
             cache-name: linux-editor-double-sanitizers
@@ -44,14 +44,14 @@ jobs:
             # Skip 2GiB artifact speeding up action.
             artifact: false
 
-          - name: Template w/ Mono (target=release, tools=no)
-            cache-name: linux-template-mono
-            target: release
-            tools: false
-            tests: false
-            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no debug_symbols=no
-            build-mono: false
-            artifact: true
+#          - name: Template w/ Mono (target=release, tools=no)
+#            cache-name: linux-template-mono
+#            target: release
+#            tools: false
+#            tests: false
+#            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no debug_symbols=no
+#            build-mono: false
+#            artifact: true
 
           - name: Minimal Template (target=release, tools=no, everything disabled)
             cache-name: linux-template-minimal

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -841,27 +841,16 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 	{
 		Array native_structures;
 
-		// AudioStream structures
-		{
-			Dictionary d;
-			d["name"] = "AudioFrame";
-			d["format"] = "float left,float right";
+		List<StringName> native_structs;
+		ClassDB::get_native_struct_list(&native_structs);
+		native_structs.sort_custom<StringName::AlphCompare>();
 
-			native_structures.push_back(d);
-		}
+		for (const StringName &E : native_structs) {
+			String code = ClassDB::get_native_struct_code(E);
 
-		// TextServer structures
-		{
 			Dictionary d;
-			d["name"] = "Glyph";
-			d["format"] = "int start,int end,uint8_t count,uint8_t repeat,uint16_t flags,float x_off,float y_off,float advance,RID font_rid,int font_size,int32_t index";
-
-			native_structures.push_back(d);
-		}
-		{
-			Dictionary d;
-			d["name"] = "CaretInfo";
-			d["format"] = "Rect2 leading_caret,Rect2 trailing_caret,TextServer::Direction leading_direction,TextServer::Direction trailing_direction";
+			d["name"] = String(E);
+			d["format"] = code;
 
 			native_structures.push_back(d);
 		}

--- a/core/extension/gdnative_interface.cpp
+++ b/core/extension/gdnative_interface.cpp
@@ -60,6 +60,10 @@ static void gdnative_print_script_error(const char *p_description, const char *p
 	_err_print_error(p_function, p_file, p_line, p_description, false, ERR_HANDLER_SCRIPT);
 }
 
+uint64_t gdnative_get_native_struct_size(const char *p_name) {
+	return ClassDB::get_native_struct_size(p_name);
+}
+
 // Variant functions
 
 static void gdnative_variant_new_copy(GDNativeVariantPtr r_dest, const GDNativeVariantPtr p_src) {
@@ -901,6 +905,8 @@ void gdnative_setup_interface(GDNativeInterface *p_interface) {
 	gdni.print_error = gdnative_print_error;
 	gdni.print_warning = gdnative_print_warning;
 	gdni.print_script_error = gdnative_print_script_error;
+
+	gdni.get_native_struct_size = gdnative_get_native_struct_size;
 
 	/* GODOT VARIANT */
 

--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -306,6 +306,8 @@ typedef struct {
 	void (*print_warning)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line);
 	void (*print_script_error)(const char *p_description, const char *p_function, const char *p_file, int32_t p_line);
 
+	uint64_t (*get_native_struct_size)(const char *p_name);
+
 	/* GODOT VARIANT */
 
 	/* variant general */

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1606,7 +1606,7 @@ Variant ClassDB::class_get_default_property_value(const StringName &p_class, con
 		if (Engine::get_singleton()->has_singleton(p_class)) {
 			c = Engine::get_singleton()->get_singleton_object(p_class);
 			cleanup_c = false;
-		} else if (ClassDB::can_instantiate(p_class)) {
+		} else if (ClassDB::can_instantiate(p_class) && !ClassDB::is_virtual(p_class)) {
 			c = ClassDB::instantiate(p_class);
 			cleanup_c = true;
 		}
@@ -1694,6 +1694,30 @@ void ClassDB::unregister_extension_class(const StringName &p_class) {
 	classes.erase(p_class);
 }
 
+Map<StringName, ClassDB::NativeStruct> ClassDB::native_structs;
+void ClassDB::register_native_struct(const StringName &p_name, const String &p_code, uint64_t p_current_size) {
+	NativeStruct ns;
+	ns.ccode = p_code;
+	ns.struct_size = p_current_size;
+	native_structs[p_name] = ns;
+}
+
+void ClassDB::get_native_struct_list(List<StringName> *r_names) {
+	for (const KeyValue<StringName, NativeStruct> &E : native_structs) {
+		r_names->push_back(E.key);
+	}
+}
+
+String ClassDB::get_native_struct_code(const StringName &p_name) {
+	ERR_FAIL_COND_V(!native_structs.has(p_name), String());
+	return native_structs[p_name].ccode;
+}
+
+uint64_t ClassDB::get_native_struct_size(const StringName &p_name) {
+	ERR_FAIL_COND_V(!native_structs.has(p_name), 0);
+	return native_structs[p_name].struct_size;
+}
+
 RWLock ClassDB::lock;
 
 void ClassDB::cleanup_defaults() {
@@ -1717,6 +1741,7 @@ void ClassDB::cleanup() {
 	classes.clear();
 	resource_base_extensions.clear();
 	compat_classes.clear();
+	native_structs.clear();
 }
 
 //

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -144,6 +144,13 @@ public:
 	static HashMap<StringName, HashMap<StringName, Variant>> default_values;
 	static Set<StringName> default_values_cached;
 
+	// Native structs, used by binder
+	struct NativeStruct {
+		String ccode; // C code to create the native struct, fields separated by ; Arrays accepted (even containing other structs), also function pointers. All types must be Godot types.
+		uint64_t struct_size; // local size of struct, for comparison
+	};
+	static Map<StringName, NativeStruct> native_structs;
+
 private:
 	// Non-locking variants of get_parent_class and is_parent_class.
 	static StringName _get_parent_class(const StringName &p_class);
@@ -390,6 +397,11 @@ public:
 	static APIType get_current_api();
 	static void cleanup_defaults();
 	static void cleanup();
+
+	static void register_native_struct(const StringName &p_name, const String &p_code, uint64_t p_current_size);
+	static void get_native_struct_list(List<StringName> *r_names);
+	static String get_native_struct_code(const StringName &p_name);
+	static uint64_t get_native_struct_size(const StringName &p_name); // Used for asserting
 };
 
 #ifdef DEBUG_METHODS_ENABLED
@@ -447,6 +459,8 @@ _FORCE_INLINE_ Vector<Error> errarray(P... p_args) {
 	if (!GD_IS_DEFINED(ClassDB_Disable_##m_class)) {   \
 		::ClassDB::register_abstract_class<m_class>(); \
 	}
+
+#define GDREGISTER_NATIVE_STRUCT(m_class, m_code) ClassDB::register_native_struct(#m_class, m_code, sizeof(m_class))
 
 #include "core/disabled_classes.gen.h"
 

--- a/core/object/make_virtuals.py
+++ b/core/object/make_virtuals.py
@@ -28,7 +28,8 @@ _FORCE_INLINE_ bool _gdvirtual_##m_name##_call($CALLARGS) $CONST { \\
 	}\\
 	\\
 	if (required) {\\
-	        WARN_PRINT_ONCE("Required virtual method: "+get_class()+"::" + #m_name + " must be overriden before calling.");\\
+	        ERR_PRINT_ONCE("Required virtual method: "+get_class()+"::" + #m_name + " must be overriden before calling.");\\
+	        $RVOID\\
     }\\
 \\
     return false;\\
@@ -66,10 +67,12 @@ def generate_version(argcount, const=False, returns=False):
     if returns:
         sproto += "R"
         s = s.replace("$RET", "m_ret, ")
+        s = s.replace("$RVOID", "(void)r_ret;")  # If required, may lead to uninitialized errors
         s = s.replace("$CALLPTRRETDEF", "PtrToArg<m_ret>::EncodeT ret;")
         method_info += "\tmethod_info.return_val = GetTypeInfo<m_ret>::get_class_info();\\\n"
     else:
         s = s.replace("$RET", "")
+        s = s.replace("$RVOID", "")
         s = s.replace("$CALLPTRRETDEF", "")
 
     if const:

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -261,6 +261,8 @@ void register_core_types() {
 	_classdb = memnew(core_bind::special::ClassDB);
 	_marshalls = memnew(core_bind::Marshalls);
 	_engine_debugger = memnew(core_bind::EngineDebugger);
+
+	GDREGISTER_NATIVE_STRUCT(AudioFrame, "float left;float right");
 }
 
 void register_core_settings() {

--- a/core/variant/binder_common.h
+++ b/core/variant/binder_common.h
@@ -100,6 +100,10 @@ struct VariantCaster<const T &> {
 		_FORCE_INLINE_ static void encode(m_enum p_val, const void *p_ptr) { \
 			*(int64_t *)p_ptr = (int64_t)p_val;                              \
 		}                                                                    \
+	};                                                                       \
+	template <>                                                              \
+	struct ZeroInitializer<m_enum> {                                         \
+		static void initialize(m_enum &value) { value = (m_enum)0; }         \
 	};
 
 // Object enum casts must go here

--- a/core/variant/native_ptr.h
+++ b/core/variant/native_ptr.h
@@ -124,6 +124,7 @@ struct PtrToArg<GDNativePtr<T>> {
 	}
 };
 
+GDVIRTUAL_NATIVE_PTR(void)
 GDVIRTUAL_NATIVE_PTR(AudioFrame)
 GDVIRTUAL_NATIVE_PTR(bool)
 GDVIRTUAL_NATIVE_PTR(char)

--- a/core/variant/type_info.h
+++ b/core/variant/type_info.h
@@ -281,4 +281,38 @@ inline StringName __constant_get_enum_name(T param, const String &p_constant) {
 
 #define CLASS_INFO(m_type) (GetTypeInfo<m_type *>::get_class_info())
 
+template <typename T>
+struct ZeroInitializer {
+	static void initialize(T &value) {} //no initialization by default
+};
+
+template <>
+struct ZeroInitializer<bool> {
+	static void initialize(bool &value) { value = false; }
+};
+
+template <typename T>
+struct ZeroInitializer<T *> {
+	static void initialize(T *&value) { value = nullptr; }
+};
+
+#define ZERO_INITIALIZER_NUMBER(m_type)                      \
+	template <>                                              \
+	struct ZeroInitializer<m_type> {                         \
+		static void initialize(m_type &value) { value = 0; } \
+	};
+
+ZERO_INITIALIZER_NUMBER(uint8_t)
+ZERO_INITIALIZER_NUMBER(int8_t)
+ZERO_INITIALIZER_NUMBER(uint16_t)
+ZERO_INITIALIZER_NUMBER(int16_t)
+ZERO_INITIALIZER_NUMBER(uint32_t)
+ZERO_INITIALIZER_NUMBER(int32_t)
+ZERO_INITIALIZER_NUMBER(uint64_t)
+ZERO_INITIALIZER_NUMBER(int64_t)
+ZERO_INITIALIZER_NUMBER(char16_t)
+ZERO_INITIALIZER_NUMBER(char32_t)
+ZERO_INITIALIZER_NUMBER(float)
+ZERO_INITIALIZER_NUMBER(double)
+
 #endif // TYPE_INFO_H

--- a/doc/classes/BaseButton.xml
+++ b/doc/classes/BaseButton.xml
@@ -44,25 +44,24 @@
 		</method>
 	</methods>
 	<members>
-		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" enum="BaseButton.ActionMode" default="1">
+		<member name="action_mode" type="int" setter="set_action_mode" getter="get_action_mode" enum="BaseButton.ActionMode">
 			Determines when the button is considered clicked, one of the [enum ActionMode] constants.
 		</member>
 		<member name="button_group" type="ButtonGroup" setter="set_button_group" getter="get_button_group">
 			The [ButtonGroup] associated with the button. Not to be confused with node groups.
 		</member>
-		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask" enum="MouseButton" default="1">
+		<member name="button_mask" type="int" setter="set_button_mask" getter="get_button_mask" enum="MouseButton">
 			Binary mask to choose which mouse buttons this button will respond to.
 			To allow both left-click and right-click, use [code]MOUSE_BUTTON_MASK_LEFT | MOUSE_BUTTON_MASK_RIGHT[/code].
 		</member>
-		<member name="button_pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
+		<member name="button_pressed" type="bool" setter="set_pressed" getter="is_pressed">
 			If [code]true[/code], the button's state is pressed. Means the button is pressed down or toggled (if [member toggle_mode] is active). Only works if [member toggle_mode] is [code]true[/code].
 			[b]Note:[/b] Setting [member button_pressed] will result in [signal toggled] to be emitted. If you want to change the pressed state without emitting that signal, use [method set_pressed_no_signal].
 		</member>
-		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled" default="false">
+		<member name="disabled" type="bool" setter="set_disabled" getter="is_disabled">
 			If [code]true[/code], the button is in disabled state and can't be clicked or toggled.
 		</member>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
-		<member name="keep_pressed_outside" type="bool" setter="set_keep_pressed_outside" getter="is_keep_pressed_outside" default="false">
+		<member name="keep_pressed_outside" type="bool" setter="set_keep_pressed_outside" getter="is_keep_pressed_outside">
 			If [code]true[/code], the button stays pressed when moving the cursor outside the button while pressing it.
 			[b]Note:[/b] This property only affects the button's visual appearance. Signals will be emitted at the same moment regardless of this property's value.
 		</member>
@@ -72,10 +71,10 @@
 		<member name="shortcut_context" type="Node" setter="set_shortcut_context" getter="get_shortcut_context">
 			The [Node] which must be a parent of the focused GUI [Control] for the shortcut to be activated. If [code]null[/code], the shortcut can be activated when any control is focused (a global shortcut). This allows shortcuts to be accepted only when the user has a certain area of the GUI focused.
 		</member>
-		<member name="shortcut_in_tooltip" type="bool" setter="set_shortcut_in_tooltip" getter="is_shortcut_in_tooltip_enabled" default="true">
+		<member name="shortcut_in_tooltip" type="bool" setter="set_shortcut_in_tooltip" getter="is_shortcut_in_tooltip_enabled">
 			If [code]true[/code], the button will add information about its shortcut in the tooltip.
 		</member>
-		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode" default="false">
+		<member name="toggle_mode" type="bool" setter="set_toggle_mode" getter="is_toggle_mode">
 			If [code]true[/code], the button is in toggle mode. Makes the button flip state between pressed and unpressed each time its area is clicked.
 		</member>
 	</members>

--- a/doc/classes/EditorSpinSlider.xml
+++ b/doc/classes/EditorSpinSlider.xml
@@ -11,7 +11,6 @@
 	<members>
 		<member name="flat" type="bool" setter="set_flat" getter="is_flat" default="false">
 		</member>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
 		<member name="label" type="String" setter="set_label" getter="get_label" default="&quot;&quot;">
 		</member>
 		<member name="read_only" type="bool" setter="set_read_only" getter="is_read_only" default="false">

--- a/doc/classes/GeometryInstance3D.xml
+++ b/doc/classes/GeometryInstance3D.xml
@@ -31,22 +31,22 @@
 		</method>
 	</methods>
 	<members>
-		<member name="cast_shadow" type="int" setter="set_cast_shadows_setting" getter="get_cast_shadows_setting" enum="GeometryInstance3D.ShadowCastingSetting" default="1">
+		<member name="cast_shadow" type="int" setter="set_cast_shadows_setting" getter="get_cast_shadows_setting" enum="GeometryInstance3D.ShadowCastingSetting">
 			The selected shadow casting flag. See [enum ShadowCastingSetting] for possible values.
 		</member>
-		<member name="extra_cull_margin" type="float" setter="set_extra_cull_margin" getter="get_extra_cull_margin" default="0.0">
+		<member name="extra_cull_margin" type="float" setter="set_extra_cull_margin" getter="get_extra_cull_margin">
 			The extra distance added to the GeometryInstance3D's bounding box ([AABB]) to increase its cull box.
 		</member>
-		<member name="gi_lightmap_scale" type="int" setter="set_lightmap_scale" getter="get_lightmap_scale" enum="GeometryInstance3D.LightmapScale" default="0">
+		<member name="gi_lightmap_scale" type="int" setter="set_lightmap_scale" getter="get_lightmap_scale" enum="GeometryInstance3D.LightmapScale">
 			The texel density to use for lightmapping in [LightmapGI]. Greater scale values provide higher resolution in the lightmap, which can result in sharper shadows for lights that have both direct and indirect light baked. However, greater scale values will also increase the space taken by the mesh in the lightmap texture, which increases the memory, storage, and bake time requirements. When using a single mesh at different scales, consider adjusting this value to keep the lightmap texel density consistent across meshes.
 		</member>
-		<member name="gi_mode" type="int" setter="set_gi_mode" getter="get_gi_mode" enum="GeometryInstance3D.GIMode" default="0">
+		<member name="gi_mode" type="int" setter="set_gi_mode" getter="get_gi_mode" enum="GeometryInstance3D.GIMode">
 			The global illumination mode to use for the whole geometry. To avoid inconsistent results, use a mode that matches the purpose of the mesh during gameplay (static/dynamic).
 			[b]Note:[/b] Lights' bake mode will also affect the global illumination rendering. See [member Light3D.light_bake_mode].
 		</member>
-		<member name="ignore_occlusion_culling" type="bool" setter="set_ignore_occlusion_culling" getter="is_ignoring_occlusion_culling" default="false">
+		<member name="ignore_occlusion_culling" type="bool" setter="set_ignore_occlusion_culling" getter="is_ignoring_occlusion_culling">
 		</member>
-		<member name="lod_bias" type="float" setter="set_lod_bias" getter="get_lod_bias" default="1.0">
+		<member name="lod_bias" type="float" setter="set_lod_bias" getter="get_lod_bias">
 		</member>
 		<member name="material_overlay" type="Material" setter="set_material_overlay" getter="get_material_overlay">
 			The material overlay for the whole geometry.
@@ -56,26 +56,26 @@
 			The material override for the whole geometry.
 			If a material is assigned to this property, it will be used instead of any material set in any material slot of the mesh.
 		</member>
-		<member name="transparency" type="float" setter="set_transparency" getter="get_transparency" default="0.0">
+		<member name="transparency" type="float" setter="set_transparency" getter="get_transparency">
 			The transparency applied to the whole geometry (as a multiplier of the materials' existing transparency). [code]0.0[/code] is fully opaque, while [code]1.0[/code] is fully transparent. Values greater than [code]0.0[/code] (exclusive) will force the geometry's materials to go through the transparent pipeline, which is slower to render and can exhibit rendering issues due to incorrect transparency sorting. However, unlike using a transparent material, setting [member transparency] to a value greater than [code]0.0[/code] (exclusive) will [i]not[/i] disable shadow rendering.
 			In spatial shaders, [code]1.0 - transparency[/code] is set as the default value of the [code]ALPHA[/code] built-in.
 			[b]Note:[/b] [member transparency] is clamped between [code]0.0[/code] and [code]1.0[/code], so this property cannot be used to make transparent materials more opaque than they originally are.
 		</member>
-		<member name="visibility_range_begin" type="float" setter="set_visibility_range_begin" getter="get_visibility_range_begin" default="0.0">
+		<member name="visibility_range_begin" type="float" setter="set_visibility_range_begin" getter="get_visibility_range_begin">
 			Starting distance from which the GeometryInstance3D will be visible, taking [member visibility_range_begin_margin] into account as well. The default value of 0 is used to disable the range check.
 		</member>
-		<member name="visibility_range_begin_margin" type="float" setter="set_visibility_range_begin_margin" getter="get_visibility_range_begin_margin" default="0.0">
+		<member name="visibility_range_begin_margin" type="float" setter="set_visibility_range_begin_margin" getter="get_visibility_range_begin_margin">
 			Margin for the [member visibility_range_begin] threshold. The GeometryInstance3D will only change its visibility state when it goes over or under the [member visibility_range_begin] threshold by this amount.
 			If [member visibility_range_fade_mode] is [constant VISIBILITY_RANGE_FADE_DISABLED], this acts as an hysteresis distance. If [member visibility_range_fade_mode] is [constant VISIBILITY_RANGE_FADE_SELF] or [constant VISIBILITY_RANGE_FADE_DEPENDENCIES], this acts as a fade transition distance and must be set to a value greater than [code]0.0[/code] for the effect to be noticeable.
 		</member>
-		<member name="visibility_range_end" type="float" setter="set_visibility_range_end" getter="get_visibility_range_end" default="0.0">
+		<member name="visibility_range_end" type="float" setter="set_visibility_range_end" getter="get_visibility_range_end">
 			Distance from which the GeometryInstance3D will be hidden, taking [member visibility_range_end_margin] into account as well. The default value of 0 is used to disable the range check.
 		</member>
-		<member name="visibility_range_end_margin" type="float" setter="set_visibility_range_end_margin" getter="get_visibility_range_end_margin" default="0.0">
+		<member name="visibility_range_end_margin" type="float" setter="set_visibility_range_end_margin" getter="get_visibility_range_end_margin">
 			Margin for the [member visibility_range_end] threshold. The GeometryInstance3D will only change its visibility state when it goes over or under the [member visibility_range_end] threshold by this amount.
 			If [member visibility_range_fade_mode] is [constant VISIBILITY_RANGE_FADE_DISABLED], this acts as an hysteresis distance. If [member visibility_range_fade_mode] is [constant VISIBILITY_RANGE_FADE_SELF] or [constant VISIBILITY_RANGE_FADE_DEPENDENCIES], this acts as a fade transition distance and must be set to a value greater than [code]0.0[/code] for the effect to be noticeable.
 		</member>
-		<member name="visibility_range_fade_mode" type="int" setter="set_visibility_range_fade_mode" getter="get_visibility_range_fade_mode" enum="GeometryInstance3D.VisibilityRangeFadeMode" default="0">
+		<member name="visibility_range_fade_mode" type="int" setter="set_visibility_range_fade_mode" getter="get_visibility_range_fade_mode" enum="GeometryInstance3D.VisibilityRangeFadeMode">
 			Controls which instances will be faded when approaching the limits of the visibility range. See [enum VisibilityRangeFadeMode] for possible values.
 		</member>
 	</members>

--- a/doc/classes/LinkButton.xml
+++ b/doc/classes/LinkButton.xml
@@ -33,11 +33,9 @@
 		</method>
 	</methods>
 	<members>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="0" />
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 		</member>
-		<member name="mouse_default_cursor_shape" type="int" setter="set_default_cursor_shape" getter="get_default_cursor_shape" overrides="Control" enum="Control.CursorShape" default="2" />
 		<member name="structured_text_bidi_override" type="int" setter="set_structured_text_bidi_override" getter="get_structured_text_bidi_override" enum="Control.StructuredTextParser" default="0">
 			Set BiDi algorithm override for the structured text.
 		</member>

--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -176,7 +176,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="lightmap_size_hint" type="Vector2i" setter="set_lightmap_size_hint" getter="get_lightmap_size_hint" default="Vector2i(0, 0)">
+		<member name="lightmap_size_hint" type="Vector2i" setter="set_lightmap_size_hint" getter="get_lightmap_size_hint">
 			Sets a hint to be used for lightmap resolution.
 		</member>
 	</members>

--- a/doc/classes/PhysicsDirectBodyState3DExtension.xml
+++ b/doc/classes/PhysicsDirectBodyState3DExtension.xml
@@ -1,0 +1,260 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PhysicsDirectBodyState3DExtension" inherits="PhysicsDirectBodyState3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_add_constant_central_force" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="force" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_add_constant_force" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="force" type="Vector3" />
+			<argument index="1" name="position" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_add_constant_torque" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="torque" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_apply_central_force" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="force" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_apply_central_impulse" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="impulse" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_apply_force" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="force" type="Vector3" />
+			<argument index="1" name="position" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_apply_impulse" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="impulse" type="Vector3" />
+			<argument index="1" name="position" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_apply_torque" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="torque" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_apply_torque_impulse" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="impulse" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_angular_velocity" qualifiers="virtual const">
+			<return type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_center_of_mass" qualifiers="virtual const">
+			<return type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_center_of_mass_local" qualifiers="virtual const">
+			<return type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_constant_force" qualifiers="virtual const">
+			<return type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_constant_torque" qualifiers="virtual const">
+			<return type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_contact_collider" qualifiers="virtual const">
+			<return type="RID" />
+			<argument index="0" name="contact_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_contact_collider_id" qualifiers="virtual const">
+			<return type="int" />
+			<argument index="0" name="contact_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_contact_collider_object" qualifiers="virtual const">
+			<return type="Object" />
+			<argument index="0" name="contact_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_contact_collider_position" qualifiers="virtual const">
+			<return type="Vector3" />
+			<argument index="0" name="contact_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_contact_collider_shape" qualifiers="virtual const">
+			<return type="int" />
+			<argument index="0" name="contact_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_contact_collider_velocity_at_position" qualifiers="virtual const">
+			<return type="Vector3" />
+			<argument index="0" name="contact_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_contact_count" qualifiers="virtual const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_contact_impulse" qualifiers="virtual const">
+			<return type="float" />
+			<argument index="0" name="contact_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_contact_local_normal" qualifiers="virtual const">
+			<return type="Vector3" />
+			<argument index="0" name="contact_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_contact_local_position" qualifiers="virtual const">
+			<return type="Vector3" />
+			<argument index="0" name="contact_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_contact_local_shape" qualifiers="virtual const">
+			<return type="int" />
+			<argument index="0" name="contact_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_inverse_inertia" qualifiers="virtual const">
+			<return type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_inverse_mass" qualifiers="virtual const">
+			<return type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_linear_velocity" qualifiers="virtual const">
+			<return type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_principal_inertia_axes" qualifiers="virtual const">
+			<return type="Basis" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_space_state" qualifiers="virtual">
+			<return type="PhysicsDirectSpaceState3D" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_step" qualifiers="virtual const">
+			<return type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_total_angular_damp" qualifiers="virtual const">
+			<return type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_total_gravity" qualifiers="virtual const">
+			<return type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_total_linear_damp" qualifiers="virtual const">
+			<return type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_transform" qualifiers="virtual const">
+			<return type="Transform3D" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_velocity_at_local_position" qualifiers="virtual const">
+			<return type="Vector3" />
+			<argument index="0" name="local_position" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_integrate_forces" qualifiers="virtual">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="_is_sleeping" qualifiers="virtual const">
+			<return type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_set_angular_velocity" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="velocity" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_set_constant_force" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="force" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_set_constant_torque" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="torque" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_set_linear_velocity" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="velocity" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_set_sleep_state" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="enabled" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_set_transform" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="transform" type="Transform3D" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/PhysicsDirectSpaceState3DExtension.xml
+++ b/doc/classes/PhysicsDirectSpaceState3DExtension.xml
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PhysicsDirectSpaceState3DExtension" inherits="PhysicsDirectSpaceState3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_cast_motion" qualifiers="virtual">
+			<return type="bool" />
+			<argument index="0" name="shape_rid" type="RID" />
+			<argument index="1" name="transform" type="Transform3D" />
+			<argument index="2" name="motion" type="Vector3" />
+			<argument index="3" name="margin" type="float" />
+			<argument index="4" name="collision_mask" type="int" />
+			<argument index="5" name="collide_with_bodies" type="bool" />
+			<argument index="6" name="collide_with_areas" type="bool" />
+			<argument index="7" name="closest_safe" type="float*" />
+			<argument index="8" name="closest_unsafe" type="float*" />
+			<argument index="9" name="info" type="PhysicsServer3DExtensionShapeRestInfo*" />
+			<description>
+			</description>
+		</method>
+		<method name="_collide_shape" qualifiers="virtual">
+			<return type="bool" />
+			<argument index="0" name="shape_rid" type="RID" />
+			<argument index="1" name="transform" type="Transform3D" />
+			<argument index="2" name="motion" type="Vector3" />
+			<argument index="3" name="margin" type="float" />
+			<argument index="4" name="collision_mask" type="int" />
+			<argument index="5" name="collide_with_bodies" type="bool" />
+			<argument index="6" name="collide_with_areas" type="bool" />
+			<argument index="7" name="results" type="void*" />
+			<argument index="8" name="max_results" type="int" />
+			<argument index="9" name="result_count" type="int32_t*" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_closest_point_to_object_volume" qualifiers="virtual const">
+			<return type="Vector3" />
+			<argument index="0" name="object" type="RID" />
+			<argument index="1" name="point" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_intersect_point" qualifiers="virtual">
+			<return type="int" />
+			<argument index="0" name="position" type="Vector3" />
+			<argument index="1" name="collision_mask" type="int" />
+			<argument index="2" name="collide_with_bodies" type="bool" />
+			<argument index="3" name="collide_with_areas" type="bool" />
+			<argument index="4" name="results" type="PhysicsServer3DExtensionShapeResult*" />
+			<argument index="5" name="max_results" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_intersect_ray" qualifiers="virtual">
+			<return type="bool" />
+			<argument index="0" name="from" type="Vector3" />
+			<argument index="1" name="to" type="Vector3" />
+			<argument index="2" name="collision_mask" type="int" />
+			<argument index="3" name="collide_with_bodies" type="bool" />
+			<argument index="4" name="collide_with_areas" type="bool" />
+			<argument index="5" name="hit_from_inside" type="bool" />
+			<argument index="6" name="hit_back_faces" type="bool" />
+			<argument index="7" name="result" type="PhysicsServer3DExtensionRayResult*" />
+			<description>
+			</description>
+		</method>
+		<method name="_intersect_shape" qualifiers="virtual">
+			<return type="int" />
+			<argument index="0" name="shape_rid" type="RID" />
+			<argument index="1" name="transform" type="Transform3D" />
+			<argument index="2" name="motion" type="Vector3" />
+			<argument index="3" name="margin" type="float" />
+			<argument index="4" name="collision_mask" type="int" />
+			<argument index="5" name="collide_with_bodies" type="bool" />
+			<argument index="6" name="collide_with_areas" type="bool" />
+			<argument index="7" name="result_count" type="PhysicsServer3DExtensionShapeResult*" />
+			<argument index="8" name="max_results" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_rest_info" qualifiers="virtual">
+			<return type="bool" />
+			<argument index="0" name="shape_rid" type="RID" />
+			<argument index="1" name="transform" type="Transform3D" />
+			<argument index="2" name="motion" type="Vector3" />
+			<argument index="3" name="margin" type="float" />
+			<argument index="4" name="collision_mask" type="int" />
+			<argument index="5" name="collide_with_bodies" type="bool" />
+			<argument index="6" name="collide_with_areas" type="bool" />
+			<argument index="7" name="rest_info" type="PhysicsServer3DExtensionShapeRestInfo*" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/PhysicsServer3DExtension.xml
+++ b/doc/classes/PhysicsServer3DExtension.xml
@@ -1,0 +1,897 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PhysicsServer3DExtension" inherits="PhysicsServer3D" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_area_add_shape" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="shape" type="RID" />
+			<argument index="2" name="transform" type="Transform3D" />
+			<argument index="3" name="disabled" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_attach_object_instance_id" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="id" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_clear_shapes" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_get_object_instance_id" qualifiers="virtual const">
+			<return type="int" />
+			<argument index="0" name="area" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_get_param" qualifiers="virtual const">
+			<return type="Variant" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.AreaParameter" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_get_shape" qualifiers="virtual const">
+			<return type="RID" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="shape_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_get_shape_count" qualifiers="virtual const">
+			<return type="int" />
+			<argument index="0" name="area" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_get_shape_transform" qualifiers="virtual const">
+			<return type="Transform3D" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="shape_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_get_space" qualifiers="virtual const">
+			<return type="RID" />
+			<argument index="0" name="area" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_get_transform" qualifiers="virtual const">
+			<return type="Transform3D" />
+			<argument index="0" name="area" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_remove_shape" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="shape_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_set_area_monitor_callback" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="callback" type="Callable" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_set_collision_layer" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="layer" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_set_collision_mask" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="mask" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_set_monitor_callback" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="callback" type="Callable" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_set_monitorable" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="monitorable" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_set_param" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.AreaParameter" />
+			<argument index="2" name="value" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_set_ray_pickable" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="enable" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_set_shape" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="shape_idx" type="int" />
+			<argument index="2" name="shape" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_set_shape_disabled" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="shape_idx" type="int" />
+			<argument index="2" name="disabled" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_set_shape_transform" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="shape_idx" type="int" />
+			<argument index="2" name="transform" type="Transform3D" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_set_space" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="space" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_area_set_transform" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="area" type="RID" />
+			<argument index="1" name="transform" type="Transform3D" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_add_collision_exception" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="excepted_body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_add_constant_central_force" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="force" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_add_constant_force" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="force" type="Vector3" />
+			<argument index="2" name="position" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_add_constant_torque" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="torque" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_add_shape" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="shape" type="RID" />
+			<argument index="2" name="transform" type="Transform3D" />
+			<argument index="3" name="disabled" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_apply_central_force" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="force" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_apply_central_impulse" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="impulse" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_apply_force" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="force" type="Vector3" />
+			<argument index="2" name="position" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_apply_impulse" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="impulse" type="Vector3" />
+			<argument index="2" name="position" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_apply_torque" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="torque" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_apply_torque_impulse" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="impulse" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_attach_object_instance_id" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="id" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_clear_shapes" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_collision_layer" qualifiers="virtual const">
+			<return type="int" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_collision_mask" qualifiers="virtual const">
+			<return type="int" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_constant_force" qualifiers="virtual const">
+			<return type="Vector3" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_constant_torque" qualifiers="virtual const">
+			<return type="Vector3" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_direct_state" qualifiers="virtual">
+			<return type="PhysicsDirectBodyState3D" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_max_contacts_reported" qualifiers="virtual const">
+			<return type="int" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_mode" qualifiers="virtual const">
+			<return type="int" enum="PhysicsServer3D.BodyMode" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_object_instance_id" qualifiers="virtual const">
+			<return type="int" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_param" qualifiers="virtual const">
+			<return type="Variant" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.BodyParameter" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_shape" qualifiers="virtual const">
+			<return type="RID" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="shape_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_shape_count" qualifiers="virtual const">
+			<return type="int" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_shape_transform" qualifiers="virtual const">
+			<return type="Transform3D" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="shape_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_space" qualifiers="virtual const">
+			<return type="RID" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_get_state" qualifiers="virtual const">
+			<return type="Variant" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_is_axis_locked" qualifiers="virtual const">
+			<return type="bool" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="axis" type="int" enum="PhysicsServer3D.BodyAxis" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_is_continuous_collision_detection_enabled" qualifiers="virtual const">
+			<return type="bool" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_is_omitting_force_integration" qualifiers="virtual const">
+			<return type="bool" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_remove_collision_exception" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="excepted_body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_remove_shape" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="shape_idx" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_reset_mass_properties" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_axis_lock" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="axis" type="int" enum="PhysicsServer3D.BodyAxis" />
+			<argument index="2" name="lock" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_axis_velocity" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="axis_velocity" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_collision_layer" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="layer" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_collision_mask" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="mask" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_constant_force" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="force" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_constant_torque" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="torque" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_enable_continuous_collision_detection" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="enable" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_force_integration_callback" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="callable" type="Callable" />
+			<argument index="2" name="userdata" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_max_contacts_reported" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="amount" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_mode" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="mode" type="int" enum="PhysicsServer3D.BodyMode" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_omit_force_integration" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="enable" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_param" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.BodyParameter" />
+			<argument index="2" name="value" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_ray_pickable" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="enable" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_shape" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="shape_idx" type="int" />
+			<argument index="2" name="shape" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_shape_disabled" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="shape_idx" type="int" />
+			<argument index="2" name="disabled" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_shape_transform" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="shape_idx" type="int" />
+			<argument index="2" name="transform" type="Transform3D" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_space" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="space" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_set_state" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="state" type="int" enum="PhysicsServer3D.BodyState" />
+			<argument index="2" name="value" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="_body_test_motion" qualifiers="virtual const">
+			<return type="bool" />
+			<argument index="0" name="body" type="RID" />
+			<argument index="1" name="from" type="Transform3D" />
+			<argument index="2" name="motion" type="Vector3" />
+			<argument index="3" name="margin" type="float" />
+			<argument index="4" name="max_collisions" type="int" />
+			<argument index="5" name="collide_separation_ray" type="bool" />
+			<argument index="6" name="result" type="PhysicsServer3DExtensionMotionResult*" />
+			<description>
+			</description>
+		</method>
+		<method name="_box_shape_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_capsule_shape_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_concave_polygon_shape_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_cone_twist_joint_get_param" qualifiers="virtual const">
+			<return type="float" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.ConeTwistJointParam" />
+			<description>
+			</description>
+		</method>
+		<method name="_cone_twist_joint_set_param" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.ConeTwistJointParam" />
+			<argument index="2" name="value" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_convex_polygon_shape_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_custom_shape_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_cylinder_shape_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_free_rid" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="rid" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_generic_6dof_joint_get_flag" qualifiers="virtual const">
+			<return type="bool" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="axis" type="int" enum="Vector3.Axis" />
+			<argument index="2" name="flag" type="int" enum="PhysicsServer3D.G6DOFJointAxisFlag" />
+			<description>
+			</description>
+		</method>
+		<method name="_generic_6dof_joint_get_param" qualifiers="virtual const">
+			<return type="float" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="axis" type="int" enum="Vector3.Axis" />
+			<argument index="2" name="param" type="int" enum="PhysicsServer3D.G6DOFJointAxisParam" />
+			<description>
+			</description>
+		</method>
+		<method name="_generic_6dof_joint_set_flag" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="axis" type="int" enum="Vector3.Axis" />
+			<argument index="2" name="flag" type="int" enum="PhysicsServer3D.G6DOFJointAxisFlag" />
+			<argument index="3" name="enable" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_generic_6dof_joint_set_param" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="axis" type="int" enum="Vector3.Axis" />
+			<argument index="2" name="param" type="int" enum="PhysicsServer3D.G6DOFJointAxisParam" />
+			<argument index="3" name="value" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_get_process_info" qualifiers="virtual">
+			<return type="int" />
+			<argument index="0" name="process_info" type="int" enum="PhysicsServer3D.ProcessInfo" />
+			<description>
+			</description>
+		</method>
+		<method name="_heightmap_shape_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_hinge_joint_get_flag" qualifiers="virtual const">
+			<return type="bool" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="flag" type="int" enum="PhysicsServer3D.HingeJointFlag" />
+			<description>
+			</description>
+		</method>
+		<method name="_hinge_joint_get_param" qualifiers="virtual const">
+			<return type="float" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.HingeJointParam" />
+			<description>
+			</description>
+		</method>
+		<method name="_hinge_joint_set_flag" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="flag" type="int" enum="PhysicsServer3D.HingeJointFlag" />
+			<argument index="2" name="enabled" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_hinge_joint_set_param" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.HingeJointParam" />
+			<argument index="2" name="value" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_joint_clear" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_joint_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_joint_get_solver_priority" qualifiers="virtual const">
+			<return type="int" />
+			<argument index="0" name="joint" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_joint_get_type" qualifiers="virtual const">
+			<return type="int" enum="PhysicsServer3D.JointType" />
+			<argument index="0" name="joint" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_joint_make_cone_twist" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="body_A" type="RID" />
+			<argument index="2" name="local_ref_A" type="Transform3D" />
+			<argument index="3" name="body_B" type="RID" />
+			<argument index="4" name="local_ref_B" type="Transform3D" />
+			<description>
+			</description>
+		</method>
+		<method name="_joint_make_generic_6dof" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="body_A" type="RID" />
+			<argument index="2" name="local_ref_A" type="Transform3D" />
+			<argument index="3" name="body_B" type="RID" />
+			<argument index="4" name="local_ref_B" type="Transform3D" />
+			<description>
+			</description>
+		</method>
+		<method name="_joint_make_hinge" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="body_A" type="RID" />
+			<argument index="2" name="hinge_A" type="Transform3D" />
+			<argument index="3" name="body_B" type="RID" />
+			<argument index="4" name="hinge_B" type="Transform3D" />
+			<description>
+			</description>
+		</method>
+		<method name="_joint_make_pin" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="body_A" type="RID" />
+			<argument index="2" name="local_A" type="Vector3" />
+			<argument index="3" name="body_B" type="RID" />
+			<argument index="4" name="local_B" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_joint_make_slider" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="body_A" type="RID" />
+			<argument index="2" name="local_ref_A" type="Transform3D" />
+			<argument index="3" name="body_B" type="RID" />
+			<argument index="4" name="local_ref_B" type="Transform3D" />
+			<description>
+			</description>
+		</method>
+		<method name="_joint_set_solver_priority" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="priority" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="_pin_joint_get_local_a" qualifiers="virtual const">
+			<return type="Vector3" />
+			<argument index="0" name="joint" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_pin_joint_get_local_b" qualifiers="virtual const">
+			<return type="Vector3" />
+			<argument index="0" name="joint" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_pin_joint_get_param" qualifiers="virtual const">
+			<return type="float" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.PinJointParam" />
+			<description>
+			</description>
+		</method>
+		<method name="_pin_joint_set_local_a" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="local_A" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_pin_joint_set_local_b" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="local_B" type="Vector3" />
+			<description>
+			</description>
+		</method>
+		<method name="_pin_joint_set_param" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.PinJointParam" />
+			<argument index="2" name="value" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_separation_ray_shape_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_set_active" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="active" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_shape_get_data" qualifiers="virtual const">
+			<return type="Variant" />
+			<argument index="0" name="shape" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_shape_get_type" qualifiers="virtual const">
+			<return type="int" enum="PhysicsServer3D.ShapeType" />
+			<argument index="0" name="shape" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_shape_set_data" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="shape" type="RID" />
+			<argument index="1" name="data" type="Variant" />
+			<description>
+			</description>
+		</method>
+		<method name="_slider_joint_get_param" qualifiers="virtual const">
+			<return type="float" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.SliderJointParam" />
+			<description>
+			</description>
+		</method>
+		<method name="_slider_joint_set_param" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="joint" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.SliderJointParam" />
+			<argument index="2" name="value" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_soft_body_get_bounds" qualifiers="virtual const">
+			<return type="AABB" />
+			<argument index="0" name="body" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_get_direct_state" qualifiers="virtual">
+			<return type="PhysicsDirectSpaceState3D" />
+			<argument index="0" name="space" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_get_param" qualifiers="virtual const">
+			<return type="float" />
+			<argument index="0" name="space" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.SpaceParameter" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_is_active" qualifiers="virtual const">
+			<return type="bool" />
+			<argument index="0" name="space" type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_set_active" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="space" type="RID" />
+			<argument index="1" name="active" type="bool" />
+			<description>
+			</description>
+		</method>
+		<method name="_space_set_param" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="space" type="RID" />
+			<argument index="1" name="param" type="int" enum="PhysicsServer3D.SpaceParameter" />
+			<argument index="2" name="value" type="float" />
+			<description>
+			</description>
+		</method>
+		<method name="_sphere_shape_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+		<method name="_world_boundary_shape_create" qualifiers="virtual">
+			<return type="RID" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/PhysicsServer3DRenderingServerHandler.xml
+++ b/doc/classes/PhysicsServer3DRenderingServerHandler.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="PhysicsServer3DRenderingServerHandler" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<methods>
+		<method name="_set_aabb" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="aabb" type="AABB" />
+			<description>
+			</description>
+		</method>
+		<method name="_set_normal" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="vertex_id" type="int" />
+			<argument index="1" name="normals" type="const void*" />
+			<description>
+			</description>
+		</method>
+		<method name="_set_vertex" qualifiers="virtual">
+			<return type="void" />
+			<argument index="0" name="vertex_id" type="int" />
+			<argument index="1" name="vertices" type="const void*" />
+			<description>
+			</description>
+		</method>
+	</methods>
+</class>

--- a/doc/classes/PrimitiveMesh.xml
+++ b/doc/classes/PrimitiveMesh.xml
@@ -34,10 +34,10 @@
 		</method>
 	</methods>
 	<members>
-		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb" default="AABB(0, 0, 0, 0, 0, 0)">
+		<member name="custom_aabb" type="AABB" setter="set_custom_aabb" getter="get_custom_aabb">
 			Overrides the [AABB] with one defined by user for use with frustum culling. Especially useful to avoid unexpected culling when using a shader to offset vertices.
 		</member>
-		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces" default="false">
+		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces">
 			If set, the order of the vertices in each triangle are reversed resulting in the backside of the mesh being drawn.
 			This gives the same result as using [constant BaseMaterial3D.CULL_FRONT] in [member BaseMaterial3D.cull_mode].
 		</member>

--- a/doc/classes/ProgressBar.xml
+++ b/doc/classes/ProgressBar.xml
@@ -12,8 +12,6 @@
 		<member name="percent_visible" type="bool" setter="set_percent_visible" getter="is_percent_visible" default="true">
 			If [code]true[/code], the fill percentage is displayed on the bar.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="0" />
-		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="0.01" />
 	</members>
 	<theme_items>
 		<theme_item name="font_color" data_type="color" type="Color" default="Color(0.95, 0.95, 0.95, 1)">

--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -31,34 +31,34 @@
 		</method>
 	</methods>
 	<members>
-		<member name="allow_greater" type="bool" setter="set_allow_greater" getter="is_greater_allowed" default="false">
+		<member name="allow_greater" type="bool" setter="set_allow_greater" getter="is_greater_allowed">
 			If [code]true[/code], [member value] may be greater than [member max_value].
 		</member>
-		<member name="allow_lesser" type="bool" setter="set_allow_lesser" getter="is_lesser_allowed" default="false">
+		<member name="allow_lesser" type="bool" setter="set_allow_lesser" getter="is_lesser_allowed">
 			If [code]true[/code], [member value] may be less than [member min_value].
 		</member>
-		<member name="exp_edit" type="bool" setter="set_exp_ratio" getter="is_ratio_exp" default="false">
+		<member name="exp_edit" type="bool" setter="set_exp_ratio" getter="is_ratio_exp">
 			If [code]true[/code], and [code]min_value[/code] is greater than 0, [code]value[/code] will be represented exponentially rather than linearly.
 		</member>
-		<member name="max_value" type="float" setter="set_max" getter="get_max" default="100.0">
+		<member name="max_value" type="float" setter="set_max" getter="get_max">
 			Maximum value. Range is clamped if [code]value[/code] is greater than [code]max_value[/code].
 		</member>
-		<member name="min_value" type="float" setter="set_min" getter="get_min" default="0.0">
+		<member name="min_value" type="float" setter="set_min" getter="get_min">
 			Minimum value. Range is clamped if [code]value[/code] is less than [code]min_value[/code].
 		</member>
-		<member name="page" type="float" setter="set_page" getter="get_page" default="0.0">
+		<member name="page" type="float" setter="set_page" getter="get_page">
 			Page size. Used mainly for [ScrollBar]. ScrollBar's length is its size multiplied by [code]page[/code] over the difference between [code]min_value[/code] and [code]max_value[/code].
 		</member>
 		<member name="ratio" type="float" setter="set_as_ratio" getter="get_as_ratio">
 			The value mapped between 0 and 1.
 		</member>
-		<member name="rounded" type="bool" setter="set_use_rounded_values" getter="is_using_rounded_values" default="false">
+		<member name="rounded" type="bool" setter="set_use_rounded_values" getter="is_using_rounded_values">
 			If [code]true[/code], [code]value[/code] will always be rounded to the nearest integer.
 		</member>
-		<member name="step" type="float" setter="set_step" getter="get_step" default="1.0">
+		<member name="step" type="float" setter="set_step" getter="get_step">
 			If greater than 0, [code]value[/code] will always be rounded to a multiple of [code]step[/code]. If [code]rounded[/code] is also [code]true[/code], [code]value[/code] will first be rounded to a multiple of [code]step[/code] then rounded to the nearest integer.
 		</member>
-		<member name="value" type="float" setter="set_value" getter="get_value" default="0.0">
+		<member name="value" type="float" setter="set_value" getter="get_value">
 			Range's current value.
 		</member>
 	</members>

--- a/doc/classes/ScrollBar.xml
+++ b/doc/classes/ScrollBar.xml
@@ -12,8 +12,6 @@
 		<member name="custom_step" type="float" setter="set_custom_step" getter="get_custom_step" default="-1.0">
 			Overrides the step used when clicking increment and decrement buttons or when using arrow keys when the [ScrollBar] is focused.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="0" />
-		<member name="step" type="float" setter="set_step" getter="get_step" overrides="Range" default="0.0" />
 	</members>
 	<signals>
 		<signal name="scrolling">

--- a/doc/classes/Slider.xml
+++ b/doc/classes/Slider.xml
@@ -13,11 +13,9 @@
 		<member name="editable" type="bool" setter="set_editable" getter="is_editable" default="true">
 			If [code]true[/code], the slider can be interacted with. If [code]false[/code], the value can be changed only by code.
 		</member>
-		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
 		<member name="scrollable" type="bool" setter="set_scrollable" getter="is_scrollable" default="true">
 			If [code]true[/code], the value can be changed using the mouse wheel.
 		</member>
-		<member name="size_flags_vertical" type="int" setter="set_v_size_flags" getter="get_v_size_flags" overrides="Control" default="0" />
 		<member name="tick_count" type="int" setter="set_ticks" getter="get_ticks" default="0">
 			Number of ticks displayed on the slider, including border ticks. Ticks are uniformly-distributed value markers.
 		</member>

--- a/doc/classes/StyleBox.xml
+++ b/doc/classes/StyleBox.xml
@@ -107,21 +107,21 @@
 		</method>
 	</methods>
 	<members>
-		<member name="content_margin_bottom" type="float" setter="set_default_margin" getter="get_default_margin" default="-1.0">
+		<member name="content_margin_bottom" type="float" setter="set_default_margin" getter="get_default_margin">
 			The bottom margin for the contents of this style box. Increasing this value reduces the space available to the contents from the bottom.
 			If this value is negative, it is ignored and a child-specific margin is used instead. For example for [StyleBoxFlat] the border thickness (if any) is used instead.
 			It is up to the code using this style box to decide what these contents are: for example, a [Button] respects this content margin for the textual contents of the button.
 			[method get_margin] should be used to fetch this value as consumer instead of reading these properties directly. This is because it correctly respects negative values and the fallback mentioned above.
 		</member>
-		<member name="content_margin_left" type="float" setter="set_default_margin" getter="get_default_margin" default="-1.0">
+		<member name="content_margin_left" type="float" setter="set_default_margin" getter="get_default_margin">
 			The left margin for the contents of this style box.	Increasing this value reduces the space available to the contents from the left.
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>
-		<member name="content_margin_right" type="float" setter="set_default_margin" getter="get_default_margin" default="-1.0">
+		<member name="content_margin_right" type="float" setter="set_default_margin" getter="get_default_margin">
 			The right margin for the contents of this style box. Increasing this value reduces the space available to the contents from the right.
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>
-		<member name="content_margin_top" type="float" setter="set_default_margin" getter="get_default_margin" default="-1.0">
+		<member name="content_margin_top" type="float" setter="set_default_margin" getter="get_default_margin">
 			The top margin for the contents of this style box. Increasing this value reduces the space available to the contents from the top.
 			Refer to [member content_margin_bottom] for extra considerations.
 		</member>

--- a/doc/classes/TextureProgressBar.xml
+++ b/doc/classes/TextureProgressBar.xml
@@ -27,7 +27,6 @@
 		<member name="fill_mode" type="int" setter="set_fill_mode" getter="get_fill_mode" default="0">
 			The fill direction. See [enum FillMode] for possible values.
 		</member>
-		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" overrides="Control" enum="Control.MouseFilter" default="1" />
 		<member name="nine_patch_stretch" type="bool" setter="set_nine_patch_stretch" getter="get_nine_patch_stretch" default="false">
 			If [code]true[/code], Godot treats the bar's textures like in [NinePatchRect]. Use the [code]stretch_margin_*[/code] properties like [member stretch_margin_bottom] to set up the nine patch's 3×3 grid. When using a radial [member fill_mode], this setting will enable stretching.
 		</member>

--- a/doc/classes/ViewportTexture.xml
+++ b/doc/classes/ViewportTexture.xml
@@ -14,7 +14,6 @@
 		<link title="3D Viewport Scaling Demo">https://godotengine.org/asset-library/asset/586</link>
 	</tutorials>
 	<members>
-		<member name="resource_local_to_scene" type="bool" setter="set_local_to_scene" getter="is_local_to_scene" overrides="Resource" default="true" />
 		<member name="viewport_path" type="NodePath" setter="set_viewport_path_in_scene" getter="get_viewport_path_in_scene" default="NodePath(&quot;&quot;)">
 			The path to the [Viewport] node to display. This is relative to the scene root, not to the node which uses the texture.
 		</member>

--- a/doc/classes/VisualInstance3D.xml
+++ b/doc/classes/VisualInstance3D.xml
@@ -63,7 +63,7 @@
 		</method>
 	</methods>
 	<members>
-		<member name="layers" type="int" setter="set_layer_mask" getter="get_layer_mask" default="1">
+		<member name="layers" type="int" setter="set_layer_mask" getter="get_layer_mask">
 			The render layer(s) this [VisualInstance3D] is drawn on.
 			This object will only be visible for [Camera3D]s whose cull mask includes the render object this [VisualInstance3D] is set to.
 		</member>

--- a/scene/3d/soft_dynamic_body_3d.cpp
+++ b/scene/3d/soft_dynamic_body_3d.cpp
@@ -417,8 +417,8 @@ void SoftDynamicBody3D::_draw_soft_mesh() {
 		PhysicsServer3D::get_singleton()->soft_body_set_mesh(physics_rid, mesh_rid);
 	}
 
-	if (!rendering_server_handler.is_ready(mesh_rid)) {
-		rendering_server_handler.prepare(mesh_rid, 0);
+	if (!rendering_server_handler->is_ready(mesh_rid)) {
+		rendering_server_handler->prepare(mesh_rid, 0);
 
 		/// Necessary in order to render the mesh correctly (Soft body nodes are in global space)
 		simulation_started = true;
@@ -428,11 +428,11 @@ void SoftDynamicBody3D::_draw_soft_mesh() {
 
 	_update_physics_server();
 
-	rendering_server_handler.open();
-	PhysicsServer3D::get_singleton()->soft_body_update_rendering_server(physics_rid, &rendering_server_handler);
-	rendering_server_handler.close();
+	rendering_server_handler->open();
+	PhysicsServer3D::get_singleton()->soft_body_update_rendering_server(physics_rid, rendering_server_handler);
+	rendering_server_handler->close();
 
-	rendering_server_handler.commit_changes();
+	rendering_server_handler->commit_changes();
 }
 
 void SoftDynamicBody3D::_prepare_physics_server() {
@@ -688,10 +688,12 @@ bool SoftDynamicBody3D::is_ray_pickable() const {
 
 SoftDynamicBody3D::SoftDynamicBody3D() :
 		physics_rid(PhysicsServer3D::get_singleton()->soft_body_create()) {
+	rendering_server_handler = memnew(SoftDynamicBodyRenderingServerHandler);
 	PhysicsServer3D::get_singleton()->body_attach_object_instance_id(physics_rid, get_instance_id());
 }
 
 SoftDynamicBody3D::~SoftDynamicBody3D() {
+	memdelete(rendering_server_handler);
 	PhysicsServer3D::get_singleton()->free(physics_rid);
 }
 

--- a/scene/3d/soft_dynamic_body_3d.h
+++ b/scene/3d/soft_dynamic_body_3d.h
@@ -36,7 +36,7 @@
 
 class SoftDynamicBody3D;
 
-class SoftDynamicBodyRenderingServerHandler : public RenderingServerHandler {
+class SoftDynamicBodyRenderingServerHandler : public PhysicsServer3DRenderingServerHandler {
 	friend class SoftDynamicBody3D;
 
 	RID mesh;
@@ -84,7 +84,7 @@ public:
 	};
 
 private:
-	SoftDynamicBodyRenderingServerHandler rendering_server_handler;
+	SoftDynamicBodyRenderingServerHandler *rendering_server_handler = nullptr;
 
 	RID physics_rid;
 

--- a/servers/SCsub
+++ b/servers/SCsub
@@ -13,6 +13,7 @@ SConscript("rendering/SCsub")
 SConscript("audio/SCsub")
 SConscript("text/SCsub")
 SConscript("debugger/SCsub")
+SConscript("extensions/SCsub")
 
 lib = env.add_library("servers", env.servers_sources)
 

--- a/servers/extensions/SCsub
+++ b/servers/extensions/SCsub
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+
+Import("env")
+
+import make_wrappers
+from platform_methods import run_in_subprocess
+
+env.CommandNoCache(["ext_wrappers.gen.inc"], "make_wrappers.py", run_in_subprocess(make_wrappers.run))
+
+env_object = env.Clone()
+
+env_object.add_source_files(env.servers_sources, "*.cpp")

--- a/servers/extensions/make_wrappers.py
+++ b/servers/extensions/make_wrappers.py
@@ -1,0 +1,93 @@
+proto = """
+#define EXBIND$VER($RETTYPE m_name$ARG) \\
+GDVIRTUAL$VER($RETTYPE_##m_name$ARG)\\
+virtual $RETVAL m_name($FUNCARGS) $CONST override { \\
+    $RETPRE\\
+    GDVIRTUAL_REQUIRED_CALL(_##m_name$CALLARGS$RETREF);\\
+    $RETPOST\\
+}
+"""
+
+
+def generate_version(argcount, const=False, returns=False):
+    s = proto
+    sproto = str(argcount)
+    method_info = ""
+    if returns:
+        sproto += "R"
+        s = s.replace("$RETTYPE", "m_ret, ")
+        s = s.replace("$RETVAL", "m_ret")
+        s = s.replace("$RETPRE", "m_ret ret; ZeroInitializer<m_ret>::initialize(ret);\\\n")
+        s = s.replace("$RETPOST", "return ret;\\\n")
+
+    else:
+        s = s.replace("$RETTYPE", "")
+        s = s.replace("$RETVAL", "void")
+        s = s.replace("$RETPRE", "")
+        s = s.replace("$RETPOST", "return;")
+
+    if const:
+        sproto += "C"
+        s = s.replace("$CONST", "const")
+    else:
+        s = s.replace("$CONST", "")
+
+    s = s.replace("$VER", sproto)
+    argtext = ""
+    funcargs = ""
+    callargs = ""
+
+    for i in range(argcount):
+        if i > 0:
+            funcargs += ", "
+
+        argtext += ", m_type" + str(i + 1)
+        funcargs += "m_type" + str(i + 1) + " arg" + str(i + 1)
+        callargs += ", arg" + str(i + 1)
+
+    if argcount:
+        s = s.replace("$ARG", argtext)
+        s = s.replace("$FUNCARGS", funcargs)
+        s = s.replace("$CALLARGS", callargs)
+    else:
+        s = s.replace("$ARG", "")
+        s = s.replace("$FUNCARGS", funcargs)
+        s = s.replace("$CALLARGS", callargs)
+
+    if returns:
+        s = s.replace("$RETREF", ", ret")
+    else:
+        s = s.replace("$RETREF", "")
+
+    return s
+
+
+def run(target, source, env):
+
+    max_versions = 12
+
+    txt = """
+#ifndef GDEXTENSION_WRAPPERS_GEN_H
+#define GDEXTENSION_WRAPPERS_GEN_H
+
+
+"""
+
+    for i in range(max_versions + 1):
+
+        txt += "/* " + str(i) + " Arguments */\n\n"
+        txt += generate_version(i, False, False)
+        txt += generate_version(i, False, True)
+        txt += generate_version(i, True, False)
+        txt += generate_version(i, True, True)
+
+    txt += "#endif"
+
+    with open(target[0], "w") as f:
+        f.write(txt)
+
+
+if __name__ == "__main__":
+    from platform_methods import subprocess_main
+
+    subprocess_main(globals())

--- a/servers/extensions/physics_server_3d_extension.cpp
+++ b/servers/extensions/physics_server_3d_extension.cpp
@@ -1,0 +1,322 @@
+/*************************************************************************/
+/*  physics_server_3d_extension.cpp                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "physics_server_3d_extension.h"
+
+bool PhysicsDirectSpaceState3DExtension::is_body_excluded_from_query(const RID &p_body) const {
+	return exclude && exclude->has(p_body);
+}
+
+thread_local const Set<RID> *PhysicsDirectSpaceState3DExtension::exclude = nullptr;
+
+void PhysicsDirectSpaceState3DExtension::_bind_methods() {
+	GDVIRTUAL_BIND(_intersect_ray, "from", "to", "collision_mask", "collide_with_bodies", "collide_with_areas", "hit_from_inside", "hit_back_faces", "result");
+	GDVIRTUAL_BIND(_intersect_point, "position", "collision_mask", "collide_with_bodies", "collide_with_areas", "results", "max_results");
+	GDVIRTUAL_BIND(_intersect_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "result_count", "max_results");
+	GDVIRTUAL_BIND(_cast_motion, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "closest_safe", "closest_unsafe", "info");
+	GDVIRTUAL_BIND(_collide_shape, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "results", "max_results", "result_count");
+	GDVIRTUAL_BIND(_rest_info, "shape_rid", "transform", "motion", "margin", "collision_mask", "collide_with_bodies", "collide_with_areas", "rest_info");
+	GDVIRTUAL_BIND(_get_closest_point_to_object_volume, "object", "point");
+}
+
+PhysicsDirectSpaceState3DExtension::PhysicsDirectSpaceState3DExtension() {
+}
+
+void PhysicsDirectBodyState3DExtension::_bind_methods() {
+	GDVIRTUAL_BIND(_get_total_gravity);
+	GDVIRTUAL_BIND(_get_total_linear_damp);
+	GDVIRTUAL_BIND(_get_total_angular_damp);
+
+	GDVIRTUAL_BIND(_get_center_of_mass);
+	GDVIRTUAL_BIND(_get_center_of_mass_local);
+	GDVIRTUAL_BIND(_get_principal_inertia_axes);
+
+	GDVIRTUAL_BIND(_get_inverse_mass);
+	GDVIRTUAL_BIND(_get_inverse_inertia);
+
+	GDVIRTUAL_BIND(_set_linear_velocity, "velocity");
+	GDVIRTUAL_BIND(_get_linear_velocity);
+
+	GDVIRTUAL_BIND(_set_angular_velocity, "velocity");
+	GDVIRTUAL_BIND(_get_angular_velocity);
+
+	GDVIRTUAL_BIND(_set_transform, "transform");
+	GDVIRTUAL_BIND(_get_transform);
+
+	GDVIRTUAL_BIND(_get_velocity_at_local_position, "local_position");
+
+	GDVIRTUAL_BIND(_apply_central_impulse, "impulse");
+	GDVIRTUAL_BIND(_apply_impulse, "impulse", "position");
+	GDVIRTUAL_BIND(_apply_torque_impulse, "impulse");
+
+	GDVIRTUAL_BIND(_apply_central_force, "force");
+	GDVIRTUAL_BIND(_apply_force, "force", "position");
+	GDVIRTUAL_BIND(_apply_torque, "torque");
+
+	GDVIRTUAL_BIND(_add_constant_central_force, "force");
+	GDVIRTUAL_BIND(_add_constant_force, "force", "position");
+	GDVIRTUAL_BIND(_add_constant_torque, "torque");
+
+	GDVIRTUAL_BIND(_set_constant_force, "force");
+	GDVIRTUAL_BIND(_get_constant_force);
+
+	GDVIRTUAL_BIND(_set_constant_torque, "torque");
+	GDVIRTUAL_BIND(_get_constant_torque);
+
+	GDVIRTUAL_BIND(_set_sleep_state, "enabled");
+	GDVIRTUAL_BIND(_is_sleeping);
+
+	GDVIRTUAL_BIND(_get_contact_count);
+
+	GDVIRTUAL_BIND(_get_contact_local_position, "contact_idx");
+	GDVIRTUAL_BIND(_get_contact_local_normal, "contact_idx");
+	GDVIRTUAL_BIND(_get_contact_impulse, "contact_idx");
+	GDVIRTUAL_BIND(_get_contact_local_shape, "contact_idx");
+	GDVIRTUAL_BIND(_get_contact_collider, "contact_idx");
+	GDVIRTUAL_BIND(_get_contact_collider_position, "contact_idx");
+	GDVIRTUAL_BIND(_get_contact_collider_id, "contact_idx");
+	GDVIRTUAL_BIND(_get_contact_collider_object, "contact_idx");
+	GDVIRTUAL_BIND(_get_contact_collider_shape, "contact_idx");
+	GDVIRTUAL_BIND(_get_contact_collider_velocity_at_position, "contact_idx");
+	GDVIRTUAL_BIND(_get_step);
+	GDVIRTUAL_BIND(_integrate_forces);
+	GDVIRTUAL_BIND(_get_space_state);
+}
+
+PhysicsDirectBodyState3DExtension::PhysicsDirectBodyState3DExtension() {
+}
+
+thread_local const Set<RID> *PhysicsServer3DExtension::exclude_bodies = nullptr;
+thread_local const Set<ObjectID> *PhysicsServer3DExtension::exclude_objects = nullptr;
+
+bool PhysicsServer3DExtension::body_test_motion_is_excluding_body(RID p_body) const {
+	return exclude_bodies && exclude_bodies->has(p_body);
+}
+
+bool PhysicsServer3DExtension::body_test_motion_is_excluding_object(ObjectID p_object) const {
+	return exclude_objects && exclude_objects->has(p_object);
+}
+
+void PhysicsServer3DExtension::_bind_methods() {
+	GDVIRTUAL_BIND(_world_boundary_shape_create);
+	GDVIRTUAL_BIND(_separation_ray_shape_create);
+	GDVIRTUAL_BIND(_sphere_shape_create);
+	GDVIRTUAL_BIND(_box_shape_create);
+	GDVIRTUAL_BIND(_capsule_shape_create);
+	GDVIRTUAL_BIND(_cylinder_shape_create);
+	GDVIRTUAL_BIND(_convex_polygon_shape_create);
+	GDVIRTUAL_BIND(_concave_polygon_shape_create);
+	GDVIRTUAL_BIND(_heightmap_shape_create);
+	GDVIRTUAL_BIND(_custom_shape_create);
+
+	GDVIRTUAL_BIND(_shape_set_data, "shape", "data");
+
+	GDVIRTUAL_BIND(_shape_get_type, "shape");
+	GDVIRTUAL_BIND(_shape_get_data, "shape");
+
+	GDVIRTUAL_BIND(_space_create);
+	GDVIRTUAL_BIND(_space_set_active, "space", "active");
+	GDVIRTUAL_BIND(_space_is_active, "space");
+	GDVIRTUAL_BIND(_space_set_param, "space", "param", "value");
+	GDVIRTUAL_BIND(_space_get_param, "space", "param");
+	GDVIRTUAL_BIND(_space_get_direct_state, "space");
+
+	GDVIRTUAL_BIND(_area_create);
+	GDVIRTUAL_BIND(_area_set_space, "area", "space");
+	GDVIRTUAL_BIND(_area_get_space, "area");
+
+	GDVIRTUAL_BIND(_area_add_shape, "area", "shape", "transform", "disabled");
+	GDVIRTUAL_BIND(_area_set_shape, "area", "shape_idx", "shape");
+	GDVIRTUAL_BIND(_area_set_shape_transform, "area", "shape_idx", "transform");
+	GDVIRTUAL_BIND(_area_set_shape_disabled, "area", "shape_idx", "disabled");
+
+	GDVIRTUAL_BIND(_area_get_shape_count, "area");
+	GDVIRTUAL_BIND(_area_get_shape, "area", "shape_idx");
+	GDVIRTUAL_BIND(_area_get_shape_transform, "area", "shape_idx");
+
+	GDVIRTUAL_BIND(_area_remove_shape, "area", "shape_idx");
+	GDVIRTUAL_BIND(_area_clear_shapes, "area");
+
+	GDVIRTUAL_BIND(_area_set_collision_layer, "area", "layer");
+	GDVIRTUAL_BIND(_area_set_collision_mask, "area", "mask");
+
+	GDVIRTUAL_BIND(_area_set_param, "area", "param", "value");
+	GDVIRTUAL_BIND(_area_set_transform, "area", "transform");
+
+	GDVIRTUAL_BIND(_area_get_param, "area", "param");
+	GDVIRTUAL_BIND(_area_get_transform, "area");
+
+	GDVIRTUAL_BIND(_area_attach_object_instance_id, "area", "id");
+	GDVIRTUAL_BIND(_area_get_object_instance_id, "area");
+
+	GDVIRTUAL_BIND(_area_set_monitor_callback, "area", "callback");
+	GDVIRTUAL_BIND(_area_set_area_monitor_callback, "area", "callback");
+	GDVIRTUAL_BIND(_area_set_monitorable, "area", "monitorable");
+
+	GDVIRTUAL_BIND(_area_set_ray_pickable, "area", "enable");
+
+	GDVIRTUAL_BIND(_body_create);
+
+	GDVIRTUAL_BIND(_body_set_space, "body", "space");
+	GDVIRTUAL_BIND(_body_get_space, "body");
+
+	GDVIRTUAL_BIND(_body_set_mode, "body", "mode");
+	GDVIRTUAL_BIND(_body_get_mode, "body");
+
+	GDVIRTUAL_BIND(_body_set_collision_layer, "body", "layer");
+	GDVIRTUAL_BIND(_body_get_collision_layer, "body");
+
+	GDVIRTUAL_BIND(_body_set_collision_mask, "body", "mask");
+	GDVIRTUAL_BIND(_body_get_collision_mask, "body");
+
+	GDVIRTUAL_BIND(_body_add_shape, "body", "shape", "transform", "disabled");
+	GDVIRTUAL_BIND(_body_set_shape, "body", "shape_idx", "shape");
+	GDVIRTUAL_BIND(_body_set_shape_transform, "body", "shape_idx", "transform");
+	GDVIRTUAL_BIND(_body_set_shape_disabled, "body", "shape_idx", "disabled");
+
+	GDVIRTUAL_BIND(_body_get_shape_count, "body");
+	GDVIRTUAL_BIND(_body_get_shape, "body", "shape_idx");
+	GDVIRTUAL_BIND(_body_get_shape_transform, "body", "shape_idx");
+
+	GDVIRTUAL_BIND(_body_remove_shape, "body", "shape_idx");
+	GDVIRTUAL_BIND(_body_clear_shapes, "body");
+
+	GDVIRTUAL_BIND(_body_attach_object_instance_id, "body", "id");
+	GDVIRTUAL_BIND(_body_get_object_instance_id, "body");
+
+	GDVIRTUAL_BIND(_body_set_enable_continuous_collision_detection, "body", "enable");
+	GDVIRTUAL_BIND(_body_is_continuous_collision_detection_enabled, "body");
+
+	GDVIRTUAL_BIND(_body_set_param, "body", "param", "value");
+	GDVIRTUAL_BIND(_body_get_param, "body", "param");
+
+	GDVIRTUAL_BIND(_body_reset_mass_properties, "body");
+
+	GDVIRTUAL_BIND(_body_set_state, "body", "state", "value");
+	GDVIRTUAL_BIND(_body_get_state, "body", "state");
+
+	GDVIRTUAL_BIND(_body_apply_central_impulse, "body", "impulse");
+	GDVIRTUAL_BIND(_body_apply_impulse, "body", "impulse", "position");
+	GDVIRTUAL_BIND(_body_apply_torque_impulse, "body", "impulse");
+
+	GDVIRTUAL_BIND(_body_apply_central_force, "body", "force");
+	GDVIRTUAL_BIND(_body_apply_force, "body", "force", "position");
+	GDVIRTUAL_BIND(_body_apply_torque, "body", "torque");
+
+	GDVIRTUAL_BIND(_body_add_constant_central_force, "body", "force");
+	GDVIRTUAL_BIND(_body_add_constant_force, "body", "force", "position");
+	GDVIRTUAL_BIND(_body_add_constant_torque, "body", "torque");
+
+	GDVIRTUAL_BIND(_body_set_constant_force, "body", "force");
+	GDVIRTUAL_BIND(_body_get_constant_force, "body");
+
+	GDVIRTUAL_BIND(_body_set_constant_torque, "body", "torque");
+	GDVIRTUAL_BIND(_body_get_constant_torque, "body");
+
+	GDVIRTUAL_BIND(_body_set_axis_velocity, "body", "axis_velocity");
+
+	GDVIRTUAL_BIND(_body_set_axis_lock, "body", "axis", "lock");
+	GDVIRTUAL_BIND(_body_is_axis_locked, "body", "axis");
+
+	GDVIRTUAL_BIND(_body_add_collision_exception, "body", "excepted_body");
+	GDVIRTUAL_BIND(_body_remove_collision_exception, "body", "excepted_body");
+
+	GDVIRTUAL_BIND(_body_set_max_contacts_reported, "body", "amount");
+	GDVIRTUAL_BIND(_body_get_max_contacts_reported, "body");
+
+	GDVIRTUAL_BIND(_body_set_omit_force_integration, "body", "enable");
+	GDVIRTUAL_BIND(_body_is_omitting_force_integration, "body");
+
+	GDVIRTUAL_BIND(_body_set_force_integration_callback, "body", "callable", "userdata");
+
+	GDVIRTUAL_BIND(_body_set_ray_pickable, "body", "enable");
+
+	GDVIRTUAL_BIND(_body_test_motion, "body", "from", "motion", "margin", "max_collisions", "collide_separation_ray", "result");
+
+	GDVIRTUAL_BIND(_body_get_direct_state, "body");
+
+	GDVIRTUAL_BIND(_soft_body_get_bounds, "body");
+
+	GDVIRTUAL_BIND(_joint_create);
+	GDVIRTUAL_BIND(_joint_clear, "joint");
+
+	GDVIRTUAL_BIND(_joint_make_pin, "joint", "body_A", "local_A", "body_B", "local_B");
+	GDVIRTUAL_BIND(_pin_joint_set_param, "joint", "param", "value");
+	GDVIRTUAL_BIND(_pin_joint_get_param, "joint", "param");
+
+	GDVIRTUAL_BIND(_pin_joint_set_local_a, "joint", "local_A");
+	GDVIRTUAL_BIND(_pin_joint_get_local_a, "joint");
+
+	GDVIRTUAL_BIND(_pin_joint_set_local_b, "joint", "local_B");
+	GDVIRTUAL_BIND(_pin_joint_get_local_b, "joint");
+
+	GDVIRTUAL_BIND(_joint_make_hinge, "joint", "body_A", "hinge_A", "body_B", "hinge_B");
+
+	GDVIRTUAL_BIND(_hinge_joint_set_param, "joint", "param", "value");
+	GDVIRTUAL_BIND(_hinge_joint_get_param, "joint", "param");
+
+	GDVIRTUAL_BIND(_hinge_joint_set_flag, "joint", "flag", "enabled");
+	GDVIRTUAL_BIND(_hinge_joint_get_flag, "joint", "flag");
+
+	GDVIRTUAL_BIND(_joint_make_slider, "joint", "body_A", "local_ref_A", "body_B", "local_ref_B");
+
+	GDVIRTUAL_BIND(_slider_joint_set_param, "joint", "param", "value");
+	GDVIRTUAL_BIND(_slider_joint_get_param, "joint", "param");
+
+	GDVIRTUAL_BIND(_joint_make_cone_twist, "joint", "body_A", "local_ref_A", "body_B", "local_ref_B");
+
+	GDVIRTUAL_BIND(_cone_twist_joint_set_param, "joint", "param", "value");
+	GDVIRTUAL_BIND(_cone_twist_joint_get_param, "joint", "param");
+
+	GDVIRTUAL_BIND(_joint_get_type, "joint");
+
+	GDVIRTUAL_BIND(_joint_set_solver_priority, "joint", "priority");
+	GDVIRTUAL_BIND(_joint_get_solver_priority, "joint");
+
+	GDVIRTUAL_BIND(_joint_make_generic_6dof, "joint", "body_A", "local_ref_A", "body_B", "local_ref_B");
+
+	GDVIRTUAL_BIND(_generic_6dof_joint_set_param, "joint", "axis", "param", "value");
+	GDVIRTUAL_BIND(_generic_6dof_joint_get_param, "joint", "axis", "param");
+
+	GDVIRTUAL_BIND(_generic_6dof_joint_set_flag, "joint", "axis", "flag", "enable");
+	GDVIRTUAL_BIND(_generic_6dof_joint_get_flag, "joint", "axis", "flag");
+
+	GDVIRTUAL_BIND(_free_rid, "rid");
+
+	GDVIRTUAL_BIND(_set_active, "active");
+
+	GDVIRTUAL_BIND(_get_process_info, "process_info");
+}
+
+PhysicsServer3DExtension::PhysicsServer3DExtension() {
+}
+
+PhysicsServer3DExtension::~PhysicsServer3DExtension() {
+}

--- a/servers/extensions/physics_server_3d_extension.h
+++ b/servers/extensions/physics_server_3d_extension.h
@@ -1,0 +1,548 @@
+/*************************************************************************/
+/*  physics_server_3d_extension.h                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef PHYSICS_SERVER_3D_EXTENSION_H
+#define PHYSICS_SERVER_3D_EXTENSION_H
+
+#include "core/object/script_language.h"
+#include "core/variant/native_ptr.h"
+#include "core/variant/type_info.h"
+#include "core/variant/typed_array.h"
+#include "servers/extensions/ext_wrappers.gen.inc"
+#include "servers/physics_server_3d.h"
+
+class PhysicsDirectBodyState3DExtension : public PhysicsDirectBodyState3D {
+	GDCLASS(PhysicsDirectBodyState3DExtension, PhysicsDirectBodyState3D);
+
+protected:
+	static void _bind_methods();
+
+public:
+	// The warning is valid, but unavoidable. If the function is not overriden it will error anyway.
+
+	EXBIND0RC(Vector3, get_total_gravity)
+	EXBIND0RC(real_t, get_total_angular_damp)
+	EXBIND0RC(real_t, get_total_linear_damp)
+
+	EXBIND0RC(Vector3, get_center_of_mass)
+	EXBIND0RC(Vector3, get_center_of_mass_local)
+	EXBIND0RC(Basis, get_principal_inertia_axes)
+	EXBIND0RC(real_t, get_inverse_mass)
+	EXBIND0RC(Vector3, get_inverse_inertia)
+	EXBIND0RC(Basis, get_inverse_inertia_tensor)
+
+	EXBIND1(set_linear_velocity, const Vector3 &)
+	EXBIND0RC(Vector3, get_linear_velocity)
+
+	EXBIND1(set_angular_velocity, const Vector3 &)
+	EXBIND0RC(Vector3, get_angular_velocity)
+
+	EXBIND1(set_transform, const Transform3D &)
+	EXBIND0RC(Transform3D, get_transform)
+
+	EXBIND1RC(Vector3, get_velocity_at_local_position, const Vector3 &)
+
+	EXBIND1(apply_central_impulse, const Vector3 &)
+	EXBIND2(apply_impulse, const Vector3 &, const Vector3 &)
+	EXBIND1(apply_torque_impulse, const Vector3 &)
+
+	EXBIND1(apply_central_force, const Vector3 &)
+	EXBIND2(apply_force, const Vector3 &, const Vector3 &)
+	EXBIND1(apply_torque, const Vector3 &)
+
+	EXBIND1(add_constant_central_force, const Vector3 &)
+	EXBIND2(add_constant_force, const Vector3 &, const Vector3 &)
+	EXBIND1(add_constant_torque, const Vector3 &)
+
+	EXBIND1(set_constant_force, const Vector3 &)
+	EXBIND0RC(Vector3, get_constant_force)
+
+	EXBIND1(set_constant_torque, const Vector3 &)
+	EXBIND0RC(Vector3, get_constant_torque)
+
+	EXBIND1(set_sleep_state, bool)
+	EXBIND0RC(bool, is_sleeping)
+
+	EXBIND0RC(int, get_contact_count)
+
+	EXBIND1RC(Vector3, get_contact_local_position, int)
+	EXBIND1RC(Vector3, get_contact_local_normal, int)
+	EXBIND1RC(real_t, get_contact_impulse, int)
+	EXBIND1RC(int, get_contact_local_shape, int)
+	EXBIND1RC(RID, get_contact_collider, int)
+	EXBIND1RC(Vector3, get_contact_collider_position, int)
+	EXBIND1RC(ObjectID, get_contact_collider_id, int)
+	EXBIND1RC(Object *, get_contact_collider_object, int)
+	EXBIND1RC(int, get_contact_collider_shape, int)
+	EXBIND1RC(Vector3, get_contact_collider_velocity_at_position, int)
+
+	EXBIND0RC(real_t, get_step)
+
+	EXBIND0(integrate_forces)
+	EXBIND0R(PhysicsDirectSpaceState3D *, get_space_state)
+
+	PhysicsDirectBodyState3DExtension();
+};
+
+typedef PhysicsDirectSpaceState3D::RayResult PhysicsServer3DExtensionRayResult;
+typedef PhysicsDirectSpaceState3D::ShapeResult PhysicsServer3DExtensionShapeResult;
+typedef PhysicsDirectSpaceState3D::ShapeRestInfo PhysicsServer3DExtensionShapeRestInfo;
+
+GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionRayResult)
+GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionShapeResult)
+GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionShapeRestInfo)
+
+class PhysicsDirectSpaceState3DExtension : public PhysicsDirectSpaceState3D {
+	GDCLASS(PhysicsDirectSpaceState3DExtension, PhysicsDirectSpaceState3D);
+
+	thread_local static const Set<RID> *exclude;
+
+protected:
+	static void _bind_methods();
+	bool is_body_excluded_from_query(const RID &p_body) const;
+
+	GDVIRTUAL8R(bool, _intersect_ray, const Vector3 &, const Vector3 &, uint32_t, bool, bool, bool, bool, GDNativePtr<PhysicsServer3DExtensionRayResult>)
+	GDVIRTUAL6R(int, _intersect_point, const Vector3 &, uint32_t, bool, bool, GDNativePtr<PhysicsServer3DExtensionShapeResult>, int)
+	GDVIRTUAL9R(int, _intersect_shape, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDNativePtr<PhysicsServer3DExtensionShapeResult>, int)
+	GDVIRTUAL10R(bool, _cast_motion, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDNativePtr<real_t>, GDNativePtr<real_t>, GDNativePtr<PhysicsServer3DExtensionShapeRestInfo>)
+	GDVIRTUAL10R(bool, _collide_shape, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDNativePtr<Vector3>, int, GDNativePtr<int>)
+	GDVIRTUAL8R(bool, _rest_info, RID, const Transform3D &, const Vector3 &, real_t, uint32_t, bool, bool, GDNativePtr<PhysicsServer3DExtensionShapeRestInfo>)
+	GDVIRTUAL2RC(Vector3, _get_closest_point_to_object_volume, RID, const Vector3 &)
+
+public:
+	virtual bool intersect_ray(const RayParameters &p_parameters, RayResult &r_result) override {
+		exclude = &p_parameters.exclude;
+		bool ret = false;
+		GDVIRTUAL_REQUIRED_CALL(_intersect_ray, p_parameters.from, p_parameters.to, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, p_parameters.hit_from_inside, p_parameters.hit_back_faces, &r_result, ret);
+		exclude = nullptr;
+		return ret;
+	}
+	virtual int intersect_point(const PointParameters &p_parameters, ShapeResult *r_results, int p_result_max) override {
+		exclude = &p_parameters.exclude;
+		int ret = false;
+		GDVIRTUAL_REQUIRED_CALL(_intersect_point, p_parameters.position, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, ret);
+		exclude = nullptr;
+		return ret;
+	}
+	virtual int intersect_shape(const ShapeParameters &p_parameters, ShapeResult *r_results, int p_result_max) override {
+		exclude = &p_parameters.exclude;
+		int ret = 0;
+		GDVIRTUAL_REQUIRED_CALL(_intersect_shape, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, ret);
+		exclude = nullptr;
+		return ret;
+	}
+	virtual bool cast_motion(const ShapeParameters &p_parameters, real_t &p_closest_safe, real_t &p_closest_unsafe, ShapeRestInfo *r_info = nullptr) override {
+		exclude = &p_parameters.exclude;
+		bool ret = false;
+		GDVIRTUAL_REQUIRED_CALL(_cast_motion, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, &p_closest_safe, &p_closest_unsafe, r_info, ret);
+		exclude = nullptr;
+		return ret;
+	}
+	virtual bool collide_shape(const ShapeParameters &p_parameters, Vector3 *r_results, int p_result_max, int &r_result_count) override {
+		exclude = &p_parameters.exclude;
+		bool ret = false;
+		GDVIRTUAL_REQUIRED_CALL(_collide_shape, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_results, p_result_max, &r_result_count, ret);
+		exclude = nullptr;
+		return ret;
+	}
+	virtual bool rest_info(const ShapeParameters &p_parameters, ShapeRestInfo *r_info) override {
+		exclude = &p_parameters.exclude;
+		bool ret = false;
+		GDVIRTUAL_REQUIRED_CALL(_rest_info, p_parameters.shape_rid, p_parameters.transform, p_parameters.motion, p_parameters.margin, p_parameters.collision_mask, p_parameters.collide_with_bodies, p_parameters.collide_with_areas, r_info, ret);
+		exclude = nullptr;
+		return ret;
+	}
+
+	virtual Vector3 get_closest_point_to_object_volume(RID p_object, const Vector3 p_point) const override {
+		Vector3 ret;
+		GDVIRTUAL_REQUIRED_CALL(_get_closest_point_to_object_volume, p_object, p_point, ret);
+		return ret;
+	}
+
+	PhysicsDirectSpaceState3DExtension();
+};
+
+typedef PhysicsServer3D::MotionCollision PhysicsServer3DExtensionMotionCollision;
+typedef PhysicsServer3D::MotionResult PhysicsServer3DExtensionMotionResult;
+
+struct PhysicsServer3DExtensionStateCallback {
+	void *instance;
+	void (*callback)(void *p_instance, PhysicsDirectBodyState3D *p_state);
+};
+
+GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionMotionCollision)
+GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionMotionResult)
+GDVIRTUAL_NATIVE_PTR(PhysicsServer3DExtensionStateCallback)
+
+class PhysicsServer3DExtension : public PhysicsServer3D {
+	GDCLASS(PhysicsServer3DExtension, PhysicsServer3D);
+
+protected:
+	static void _bind_methods();
+
+public:
+	// The warning is valid, but unavoidable. If the function is not overriden it will error anyway.
+
+	EXBIND0R(RID, world_boundary_shape_create)
+	EXBIND0R(RID, separation_ray_shape_create)
+	EXBIND0R(RID, sphere_shape_create)
+	EXBIND0R(RID, box_shape_create)
+	EXBIND0R(RID, capsule_shape_create)
+	EXBIND0R(RID, cylinder_shape_create)
+	EXBIND0R(RID, convex_polygon_shape_create)
+	EXBIND0R(RID, concave_polygon_shape_create)
+	EXBIND0R(RID, heightmap_shape_create)
+	EXBIND0R(RID, custom_shape_create)
+
+	EXBIND2(shape_set_data, RID, const Variant &)
+	EXBIND2(shape_set_custom_solver_bias, RID, real_t)
+
+	EXBIND2(shape_set_margin, RID, real_t)
+	EXBIND1RC(real_t, shape_get_margin, RID)
+
+	EXBIND1RC(ShapeType, shape_get_type, RID)
+	EXBIND1RC(Variant, shape_get_data, RID)
+	EXBIND1RC(real_t, shape_get_custom_solver_bias, RID)
+
+	/* SPACE API */
+
+	EXBIND0R(RID, space_create)
+	EXBIND2(space_set_active, RID, bool)
+	EXBIND1RC(bool, space_is_active, RID)
+
+	EXBIND3(space_set_param, RID, SpaceParameter, real_t)
+	EXBIND2RC(real_t, space_get_param, RID, SpaceParameter)
+
+	EXBIND1R(PhysicsDirectSpaceState3D *, space_get_direct_state, RID)
+
+	EXBIND2(space_set_debug_contacts, RID, int)
+	EXBIND1RC(Vector<Vector3>, space_get_contacts, RID)
+	EXBIND1RC(int, space_get_contact_count, RID)
+
+	/* AREA API */
+
+	//EXBIND0RID(area);
+	EXBIND0R(RID, area_create)
+
+	EXBIND2(area_set_space, RID, RID)
+	EXBIND1RC(RID, area_get_space, RID)
+
+	EXBIND4(area_add_shape, RID, RID, const Transform3D &, bool)
+	EXBIND3(area_set_shape, RID, int, RID)
+	EXBIND3(area_set_shape_transform, RID, int, const Transform3D &)
+	EXBIND3(area_set_shape_disabled, RID, int, bool)
+
+	EXBIND1RC(int, area_get_shape_count, RID)
+	EXBIND2RC(RID, area_get_shape, RID, int)
+	EXBIND2RC(Transform3D, area_get_shape_transform, RID, int)
+	EXBIND2(area_remove_shape, RID, int)
+	EXBIND1(area_clear_shapes, RID)
+
+	EXBIND2(area_attach_object_instance_id, RID, ObjectID)
+	EXBIND1RC(ObjectID, area_get_object_instance_id, RID)
+
+	EXBIND3(area_set_param, RID, AreaParameter, const Variant &)
+	EXBIND2(area_set_transform, RID, const Transform3D &)
+
+	EXBIND2RC(Variant, area_get_param, RID, AreaParameter)
+	EXBIND1RC(Transform3D, area_get_transform, RID)
+
+	EXBIND2(area_set_collision_mask, RID, uint32_t)
+	EXBIND2(area_set_collision_layer, RID, uint32_t)
+
+	EXBIND2(area_set_monitorable, RID, bool)
+	EXBIND2(area_set_ray_pickable, RID, bool)
+
+	EXBIND2(area_set_monitor_callback, RID, const Callable &)
+	EXBIND2(area_set_area_monitor_callback, RID, const Callable &)
+
+	/* BODY API */
+
+	//EXBIND2RID(body,BodyMode,bool);
+	EXBIND0R(RID, body_create)
+
+	EXBIND2(body_set_space, RID, RID)
+	EXBIND1RC(RID, body_get_space, RID)
+
+	EXBIND2(body_set_mode, RID, BodyMode)
+	EXBIND1RC(BodyMode, body_get_mode, RID)
+
+	EXBIND4(body_add_shape, RID, RID, const Transform3D &, bool)
+	EXBIND3(body_set_shape, RID, int, RID)
+	EXBIND3(body_set_shape_transform, RID, int, const Transform3D &)
+
+	EXBIND1RC(int, body_get_shape_count, RID)
+	EXBIND2RC(Transform3D, body_get_shape_transform, RID, int)
+	EXBIND2RC(RID, body_get_shape, RID, int)
+
+	EXBIND3(body_set_shape_disabled, RID, int, bool)
+
+	EXBIND2(body_remove_shape, RID, int)
+	EXBIND1(body_clear_shapes, RID)
+
+	EXBIND2(body_attach_object_instance_id, RID, ObjectID)
+	EXBIND1RC(ObjectID, body_get_object_instance_id, RID)
+
+	EXBIND2(body_set_enable_continuous_collision_detection, RID, bool)
+	EXBIND1RC(bool, body_is_continuous_collision_detection_enabled, RID)
+
+	EXBIND2(body_set_collision_layer, RID, uint32_t)
+	EXBIND1RC(uint32_t, body_get_collision_layer, RID)
+
+	EXBIND2(body_set_collision_mask, RID, uint32_t)
+	EXBIND1RC(uint32_t, body_get_collision_mask, RID)
+
+	EXBIND2(body_set_user_flags, RID, uint32_t)
+	EXBIND1RC(uint32_t, body_get_user_flags, RID)
+
+	EXBIND3(body_set_param, RID, BodyParameter, const Variant &)
+	EXBIND2RC(Variant, body_get_param, RID, BodyParameter)
+
+	EXBIND1(body_reset_mass_properties, RID)
+
+	EXBIND3(body_set_state, RID, BodyState, const Variant &)
+	EXBIND2RC(Variant, body_get_state, RID, BodyState)
+
+	EXBIND2(body_apply_torque_impulse, RID, const Vector3 &)
+	EXBIND2(body_apply_central_impulse, RID, const Vector3 &)
+	EXBIND3(body_apply_impulse, RID, const Vector3 &, const Vector3 &)
+
+	EXBIND2(body_apply_central_force, RID, const Vector3 &)
+	EXBIND3(body_apply_force, RID, const Vector3 &, const Vector3 &)
+	EXBIND2(body_apply_torque, RID, const Vector3 &)
+
+	EXBIND2(body_add_constant_central_force, RID, const Vector3 &)
+	EXBIND3(body_add_constant_force, RID, const Vector3 &, const Vector3 &)
+	EXBIND2(body_add_constant_torque, RID, const Vector3 &)
+
+	EXBIND2(body_set_constant_force, RID, const Vector3 &)
+	EXBIND1RC(Vector3, body_get_constant_force, RID)
+
+	EXBIND2(body_set_constant_torque, RID, const Vector3 &)
+	EXBIND1RC(Vector3, body_get_constant_torque, RID)
+
+	EXBIND2(body_set_axis_velocity, RID, const Vector3 &)
+
+	EXBIND3(body_set_axis_lock, RID, BodyAxis, bool)
+	EXBIND2RC(bool, body_is_axis_locked, RID, BodyAxis)
+
+	EXBIND2(body_add_collision_exception, RID, RID)
+	EXBIND2(body_remove_collision_exception, RID, RID)
+
+	GDVIRTUAL1RC(TypedArray<RID>, _body_get_collision_exceptions, RID)
+
+	void body_get_collision_exceptions(RID p_body, List<RID> *p_exceptions) override {
+		TypedArray<RID> ret;
+		GDVIRTUAL_REQUIRED_CALL(_body_get_collision_exceptions, p_body, ret);
+		for (int i = 0; i < ret.size(); i++) {
+			p_exceptions->push_back(ret[i]);
+		}
+	}
+
+	EXBIND2(body_set_max_contacts_reported, RID, int)
+	EXBIND1RC(int, body_get_max_contacts_reported, RID)
+
+	EXBIND2(body_set_contacts_reported_depth_threshold, RID, real_t)
+	EXBIND1RC(real_t, body_get_contacts_reported_depth_threshold, RID)
+
+	EXBIND2(body_set_omit_force_integration, RID, bool)
+	EXBIND1RC(bool, body_is_omitting_force_integration, RID)
+
+	GDVIRTUAL2(_body_set_state_sync_callback, RID, GDNativePtr<PhysicsServer3DExtensionStateCallback>)
+	void body_set_state_sync_callback(RID p_body, void *p_instance, BodyStateCallback p_callback) override {
+		PhysicsServer3DExtensionStateCallback callback;
+		callback.callback = p_callback;
+		callback.instance = p_instance;
+		GDVIRTUAL_REQUIRED_CALL(_body_set_state_sync_callback, p_body, &callback);
+	}
+	EXBIND3(body_set_force_integration_callback, RID, const Callable &, const Variant &)
+
+	EXBIND2(body_set_ray_pickable, RID, bool)
+
+	GDVIRTUAL7RC(bool, _body_test_motion, RID, const Transform3D &, const Vector3 &, real_t, int, bool, GDNativePtr<PhysicsServer3DExtensionMotionResult>)
+
+	thread_local static const Set<RID> *exclude_bodies;
+	thread_local static const Set<ObjectID> *exclude_objects;
+
+	bool body_test_motion_is_excluding_body(RID p_body) const;
+	bool body_test_motion_is_excluding_object(ObjectID p_object) const;
+
+	bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) override {
+		bool ret = false;
+		exclude_bodies = &p_parameters.exclude_bodies;
+		exclude_objects = &p_parameters.exclude_objects;
+		GDVIRTUAL_REQUIRED_CALL(_body_test_motion, p_body, p_parameters.from, p_parameters.motion, p_parameters.margin, p_parameters.max_collisions, p_parameters.collide_separation_ray, r_result, ret);
+		exclude_bodies = nullptr;
+		exclude_objects = nullptr;
+		return ret;
+	}
+
+	EXBIND1R(PhysicsDirectBodyState3D *, body_get_direct_state, RID)
+
+	/* SOFT BODY API */
+
+	EXBIND0R(RID, soft_body_create)
+
+	EXBIND2(soft_body_update_rendering_server, RID, PhysicsServer3DRenderingServerHandler *)
+
+	EXBIND2(soft_body_set_space, RID, RID)
+	EXBIND1RC(RID, soft_body_get_space, RID)
+
+	EXBIND2(soft_body_set_ray_pickable, RID, bool)
+
+	EXBIND2(soft_body_set_collision_layer, RID, uint32_t)
+	EXBIND1RC(uint32_t, soft_body_get_collision_layer, RID)
+
+	EXBIND2(soft_body_set_collision_mask, RID, uint32_t)
+	EXBIND1RC(uint32_t, soft_body_get_collision_mask, RID)
+
+	EXBIND2(soft_body_add_collision_exception, RID, RID)
+	EXBIND2(soft_body_remove_collision_exception, RID, RID)
+
+	GDVIRTUAL1RC(TypedArray<RID>, _soft_body_get_collision_exceptions, RID)
+
+	void soft_body_get_collision_exceptions(RID p_soft_body, List<RID> *p_exceptions) override {
+		TypedArray<RID> ret;
+		GDVIRTUAL_REQUIRED_CALL(_soft_body_get_collision_exceptions, p_soft_body, ret);
+		for (int i = 0; i < ret.size(); i++) {
+			p_exceptions->push_back(ret[i]);
+		}
+	}
+
+	EXBIND3(soft_body_set_state, RID, BodyState, const Variant &)
+	EXBIND2RC(Variant, soft_body_get_state, RID, BodyState)
+
+	EXBIND2(soft_body_set_transform, RID, const Transform3D &)
+
+	EXBIND2(soft_body_set_simulation_precision, RID, int)
+	EXBIND1RC(int, soft_body_get_simulation_precision, RID)
+
+	EXBIND2(soft_body_set_total_mass, RID, real_t)
+	EXBIND1RC(real_t, soft_body_get_total_mass, RID)
+
+	EXBIND2(soft_body_set_linear_stiffness, RID, real_t)
+	EXBIND1RC(real_t, soft_body_get_linear_stiffness, RID)
+
+	EXBIND2(soft_body_set_pressure_coefficient, RID, real_t)
+	EXBIND1RC(real_t, soft_body_get_pressure_coefficient, RID)
+
+	EXBIND2(soft_body_set_damping_coefficient, RID, real_t)
+	EXBIND1RC(real_t, soft_body_get_damping_coefficient, RID)
+
+	EXBIND2(soft_body_set_drag_coefficient, RID, real_t)
+	EXBIND1RC(real_t, soft_body_get_drag_coefficient, RID)
+
+	EXBIND2(soft_body_set_mesh, RID, RID)
+
+	EXBIND1RC(AABB, soft_body_get_bounds, RID)
+
+	EXBIND3(soft_body_move_point, RID, int, const Vector3 &)
+	EXBIND2RC(Vector3, soft_body_get_point_global_position, RID, int)
+
+	EXBIND1(soft_body_remove_all_pinned_points, RID)
+	EXBIND3(soft_body_pin_point, RID, int, bool)
+	EXBIND2RC(bool, soft_body_is_point_pinned, RID, int)
+
+	/* JOINT API */
+
+	EXBIND0R(RID, joint_create)
+
+	EXBIND1(joint_clear, RID)
+
+	EXBIND5(joint_make_pin, RID, RID, const Vector3 &, RID, const Vector3 &)
+
+	EXBIND3(pin_joint_set_param, RID, PinJointParam, real_t)
+	EXBIND2RC(real_t, pin_joint_get_param, RID, PinJointParam)
+
+	EXBIND2(pin_joint_set_local_a, RID, const Vector3 &)
+	EXBIND1RC(Vector3, pin_joint_get_local_a, RID)
+
+	EXBIND2(pin_joint_set_local_b, RID, const Vector3 &)
+	EXBIND1RC(Vector3, pin_joint_get_local_b, RID)
+
+	EXBIND5(joint_make_hinge, RID, RID, const Transform3D &, RID, const Transform3D &)
+	EXBIND7(joint_make_hinge_simple, RID, RID, const Vector3 &, const Vector3 &, RID, const Vector3 &, const Vector3 &)
+
+	EXBIND3(hinge_joint_set_param, RID, HingeJointParam, real_t)
+	EXBIND2RC(real_t, hinge_joint_get_param, RID, HingeJointParam)
+
+	EXBIND3(hinge_joint_set_flag, RID, HingeJointFlag, bool)
+	EXBIND2RC(bool, hinge_joint_get_flag, RID, HingeJointFlag)
+
+	EXBIND5(joint_make_slider, RID, RID, const Transform3D &, RID, const Transform3D &)
+
+	EXBIND3(slider_joint_set_param, RID, SliderJointParam, real_t)
+	EXBIND2RC(real_t, slider_joint_get_param, RID, SliderJointParam)
+
+	EXBIND5(joint_make_cone_twist, RID, RID, const Transform3D &, RID, const Transform3D &)
+
+	EXBIND3(cone_twist_joint_set_param, RID, ConeTwistJointParam, real_t)
+	EXBIND2RC(real_t, cone_twist_joint_get_param, RID, ConeTwistJointParam)
+
+	EXBIND5(joint_make_generic_6dof, RID, RID, const Transform3D &, RID, const Transform3D &)
+
+	EXBIND4(generic_6dof_joint_set_param, RID, Vector3::Axis, G6DOFJointAxisParam, real_t)
+	EXBIND3RC(real_t, generic_6dof_joint_get_param, RID, Vector3::Axis, G6DOFJointAxisParam)
+
+	EXBIND4(generic_6dof_joint_set_flag, RID, Vector3::Axis, G6DOFJointAxisFlag, bool)
+	EXBIND3RC(bool, generic_6dof_joint_get_flag, RID, Vector3::Axis, G6DOFJointAxisFlag)
+
+	EXBIND1RC(JointType, joint_get_type, RID)
+
+	EXBIND2(joint_set_solver_priority, RID, int)
+	EXBIND1RC(int, joint_get_solver_priority, RID)
+
+	EXBIND2(joint_disable_collisions_between_bodies, RID, bool)
+	EXBIND1RC(bool, joint_is_disabled_collisions_between_bodies, RID)
+
+	/* MISC */
+
+	GDVIRTUAL1(_free_rid, RID)
+	virtual void free(RID p_rid) override {
+		GDVIRTUAL_REQUIRED_CALL(_free_rid, p_rid);
+	}
+
+	EXBIND1(set_active, bool)
+
+	EXBIND0(init)
+	EXBIND1(step, real_t)
+	EXBIND0(sync)
+	EXBIND0(end_sync)
+	EXBIND0(flush_queries)
+	EXBIND0(finish)
+
+	EXBIND0RC(bool, is_flushing_queries)
+	EXBIND1R(int, get_process_info, ProcessInfo)
+
+	PhysicsServer3DExtension();
+	~PhysicsServer3DExtension();
+};
+
+#endif // PHYSICSSERVER3DEXTENSION_H

--- a/servers/physics_3d/godot_physics_server_3d.cpp
+++ b/servers/physics_3d/godot_physics_server_3d.cpp
@@ -920,7 +920,7 @@ RID GodotPhysicsServer3D::soft_body_create() {
 	return rid;
 }
 
-void GodotPhysicsServer3D::soft_body_update_rendering_server(RID p_body, RenderingServerHandler *p_rendering_server_handler) {
+void GodotPhysicsServer3D::soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) {
 	GodotSoftBody3D *soft_body = soft_body_owner.get_or_null(p_body);
 	ERR_FAIL_COND(!soft_body);
 
@@ -1355,7 +1355,7 @@ int GodotPhysicsServer3D::joint_get_solver_priority(RID p_joint) const {
 	return joint->get_priority();
 }
 
-void GodotPhysicsServer3D::joint_disable_collisions_between_bodies(RID p_joint, const bool p_disable) {
+void GodotPhysicsServer3D::joint_disable_collisions_between_bodies(RID p_joint, bool p_disable) {
 	GodotJoint3D *joint = joint_owner.get_or_null(p_joint);
 	ERR_FAIL_COND(!joint);
 

--- a/servers/physics_3d/godot_physics_server_3d.h
+++ b/servers/physics_3d/godot_physics_server_3d.h
@@ -253,7 +253,7 @@ public:
 
 	virtual RID soft_body_create() override;
 
-	virtual void soft_body_update_rendering_server(RID p_body, RenderingServerHandler *p_rendering_server_handler) override;
+	virtual void soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) override;
 
 	virtual void soft_body_set_space(RID p_body, RID p_space) override;
 	virtual RID soft_body_get_space(RID p_body) const override;
@@ -353,7 +353,7 @@ public:
 	virtual void joint_set_solver_priority(RID p_joint, int p_priority) override;
 	virtual int joint_get_solver_priority(RID p_joint) const override;
 
-	virtual void joint_disable_collisions_between_bodies(RID p_joint, const bool p_disable) override;
+	virtual void joint_disable_collisions_between_bodies(RID p_joint, bool p_disable) override;
 	virtual bool joint_is_disabled_collisions_between_bodies(RID p_joint) const override;
 
 	/* MISC */

--- a/servers/physics_3d/godot_soft_body_3d.cpp
+++ b/servers/physics_3d/godot_soft_body_3d.cpp
@@ -147,7 +147,7 @@ void GodotSoftBody3D::set_mesh(RID p_mesh) {
 	}
 }
 
-void GodotSoftBody3D::update_rendering_server(RenderingServerHandler *p_rendering_server_handler) {
+void GodotSoftBody3D::update_rendering_server(PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) {
 	if (soft_mesh.is_null()) {
 		return;
 	}

--- a/servers/physics_3d/godot_soft_body_3d.h
+++ b/servers/physics_3d/godot_soft_body_3d.h
@@ -157,7 +157,7 @@ public:
 
 	void set_mesh(RID p_mesh);
 
-	void update_rendering_server(RenderingServerHandler *p_rendering_server_handler);
+	void update_rendering_server(PhysicsServer3DRenderingServerHandler *p_rendering_server_handler);
 
 	Vector3 get_vertex_position(int p_index) const;
 	void set_vertex_position(int p_index, const Vector3 &p_position);

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -33,6 +33,22 @@
 #include "core/config/project_settings.h"
 #include "core/string/print_string.h"
 
+void PhysicsServer3DRenderingServerHandler::set_vertex(int p_vertex_id, const void *p_vector3) {
+	GDVIRTUAL_REQUIRED_CALL(_set_vertex, p_vertex_id, p_vector3);
+}
+void PhysicsServer3DRenderingServerHandler::set_normal(int p_vertex_id, const void *p_vector3) {
+	GDVIRTUAL_REQUIRED_CALL(_set_normal, p_vertex_id, p_vector3);
+}
+void PhysicsServer3DRenderingServerHandler::set_aabb(const AABB &p_aabb) {
+	GDVIRTUAL_REQUIRED_CALL(_set_aabb, p_aabb);
+}
+
+void PhysicsServer3DRenderingServerHandler::_bind_methods() {
+	GDVIRTUAL_BIND(_set_vertex, "vertex_id", "vertices");
+	GDVIRTUAL_BIND(_set_normal, "vertex_id", "normals");
+	GDVIRTUAL_BIND(_set_aabb, "aabb");
+}
+
 PhysicsServer3D *PhysicsServer3D::singleton = nullptr;
 
 void PhysicsDirectBodyState3D::integrate_forces() {

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -33,6 +33,9 @@
 
 #include "core/io/resource.h"
 #include "core/object/class_db.h"
+#include "core/object/gdvirtual.gen.inc"
+#include "core/object/script_language.h"
+#include "core/variant/native_ptr.h"
 
 class PhysicsDirectSpaceState3D;
 
@@ -202,13 +205,21 @@ public:
 	PhysicsDirectSpaceState3D();
 };
 
-class RenderingServerHandler {
-public:
-	virtual void set_vertex(int p_vertex_id, const void *p_vector3) = 0;
-	virtual void set_normal(int p_vertex_id, const void *p_vector3) = 0;
-	virtual void set_aabb(const AABB &p_aabb) = 0;
+class PhysicsServer3DRenderingServerHandler : public Object {
+	GDCLASS(PhysicsServer3DRenderingServerHandler, Object)
+protected:
+	GDVIRTUAL2(_set_vertex, int, GDNativeConstPtr<void>)
+	GDVIRTUAL2(_set_normal, int, GDNativeConstPtr<void>)
+	GDVIRTUAL1(_set_aabb, const AABB &)
 
-	virtual ~RenderingServerHandler() {}
+	static void _bind_methods();
+
+public:
+	virtual void set_vertex(int p_vertex_id, const void *p_vector3);
+	virtual void set_normal(int p_vertex_id, const void *p_vector3);
+	virtual void set_aabb(const AABB &p_aabb);
+
+	virtual ~PhysicsServer3DRenderingServerHandler() {}
 };
 
 class PhysicsTestMotionParameters3D;
@@ -552,7 +563,7 @@ public:
 
 	virtual RID soft_body_create() = 0;
 
-	virtual void soft_body_update_rendering_server(RID p_body, RenderingServerHandler *p_rendering_server_handler) = 0;
+	virtual void soft_body_update_rendering_server(RID p_body, PhysicsServer3DRenderingServerHandler *p_rendering_server_handler) = 0;
 
 	virtual void soft_body_set_space(RID p_body, RID p_space) = 0;
 	virtual RID soft_body_get_space(RID p_body) const = 0;
@@ -624,7 +635,7 @@ public:
 	virtual void joint_set_solver_priority(RID p_joint, int p_priority) = 0;
 	virtual int joint_get_solver_priority(RID p_joint) const = 0;
 
-	virtual void joint_disable_collisions_between_bodies(RID p_joint, const bool p_disable) = 0;
+	virtual void joint_disable_collisions_between_bodies(RID p_joint, bool p_disable) = 0;
 	virtual bool joint_is_disabled_collisions_between_bodies(RID p_joint) const = 0;
 
 	virtual void joint_make_pin(RID p_joint, RID p_body_A, const Vector3 &p_local_A, RID p_body_B, const Vector3 &p_local_B) = 0;

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -269,7 +269,7 @@ public:
 
 	FUNCRID(soft_body)
 
-	FUNC2(soft_body_update_rendering_server, RID, class RenderingServerHandler *)
+	FUNC2(soft_body_update_rendering_server, RID, PhysicsServer3DRenderingServerHandler *)
 
 	FUNC2(soft_body_set_space, RID, RID)
 	FUNC1RC(RID, soft_body_get_space, RID)
@@ -369,7 +369,7 @@ public:
 	FUNC2(joint_set_solver_priority, RID, int);
 	FUNC1RC(int, joint_get_solver_priority, RID);
 
-	FUNC2(joint_disable_collisions_between_bodies, RID, const bool);
+	FUNC2(joint_disable_collisions_between_bodies, RID, bool);
 	FUNC1RC(bool, joint_is_disabled_collisions_between_bodies, RID);
 
 	/* MISC */

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -70,6 +70,7 @@
 #include "rendering/rendering_device.h"
 #include "rendering/rendering_device_binds.h"
 #include "rendering_server.h"
+#include "servers/extensions/physics_server_3d_extension.h"
 #include "servers/rendering/shader_types.h"
 #include "text/text_server_extension.h"
 #include "text_server.h"
@@ -113,6 +114,9 @@ void preregister_server_types() {
 	GDREGISTER_ABSTRACT_CLASS(TextServer);
 	GDREGISTER_CLASS(TextServerExtension);
 
+	GDREGISTER_NATIVE_STRUCT(Glyph, "int start;int end;uint8_t count;uint8_t repeat;uint16_t flags;float x_off;float y_off;float advance;RID font_rid;int font_size;int32_t index");
+	GDREGISTER_NATIVE_STRUCT(CaretInfo, "int start;int end;uint8_t count;uint8_t repeat;uint16_t flags;float x_off;float y_off;float advance;RID font_rid;int font_size;int32_t index");
+
 	Engine::get_singleton()->add_singleton(Engine::Singleton("TextServerManager", TextServerManager::get_singleton(), "TextServerManager"));
 }
 
@@ -125,6 +129,18 @@ void register_server_types() {
 
 	GDREGISTER_ABSTRACT_CLASS(PhysicsServer2D);
 	GDREGISTER_ABSTRACT_CLASS(PhysicsServer3D);
+	GDREGISTER_VIRTUAL_CLASS(PhysicsServer3DExtension);
+	GDREGISTER_VIRTUAL_CLASS(PhysicsDirectBodyState3DExtension);
+	GDREGISTER_VIRTUAL_CLASS(PhysicsDirectSpaceState3DExtension)
+	GDREGISTER_VIRTUAL_CLASS(PhysicsServer3DRenderingServerHandler)
+
+	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionRayResult, "Vector3 position;Vector3 normal;RID rid;ObjectID collider_id;Object*collider;int shape");
+	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionShapeResult, "RID rid;ObjectID collider_id;Object*collider;int shape");
+	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionShapeRestInfo, "Vector3 point;Vector3 normal;RID rid;ObjectID collider_id;int shape;Vector3 linear_velocity;");
+	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionMotionCollision, "Vector3 position;Vector3 normal;Vector3 collider_velocity;real_t depth;int local_shape;ObjectID collider_id;RID collider;int collider_shape;");
+	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionMotionResult, "Vector3 travel;Vector3 remainder;real_t collision_safe_fraction;real_t collision_unsafe_fraction;MotionCollision collisions[32];int collision_count");
+	GDREGISTER_NATIVE_STRUCT(PhysicsServer3DExtensionStateCallback, "void *instance;void (*callback)(void *p_instance, PhysicsDirectBodyState3D *p_state)");
+
 	GDREGISTER_ABSTRACT_CLASS(NavigationServer2D);
 	GDREGISTER_ABSTRACT_CLASS(NavigationServer3D);
 	GDREGISTER_CLASS(XRServer);


### PR DESCRIPTION
* Allows creating a GDExtension based 3D Physics Server (for Bullet, PhysX, etc. support)
* Some changes on native struct binding for PhysicsServer

This allows a 3D Physics server created entirely from GDExtension. Once it works, the idea is to port the 2D one to it.
