### PR TITLE
Document Range's `value_changed` signal is also emitted with code changes

### DIFF
--- a/doc/classes/Range.xml
+++ b/doc/classes/Range.xml
@@ -13,19 +13,20 @@
 			<return type="void" />
 			<argument index="0" name="" type="float" />
 			<description>
+				Called when the [Range]'s value is changed (following the same conditions as [signal value_changed]).
 			</description>
 		</method>
 		<method name="share">
 			<return type="void" />
 			<argument index="0" name="with" type="Node" />
 			<description>
-				Binds two ranges together along with any ranges previously grouped with either of them. When any of range's member variables change, it will share the new value with all other ranges in its group.
+				Binds two [Range]s together along with any ranges previously grouped with either of them. When any of range's member variables change, it will share the new value with all other ranges in its group.
 			</description>
 		</method>
 		<method name="unshare">
 			<return type="void" />
 			<description>
-				Stops range from sharing its member variables with any other.
+				Stops the [Range] from sharing its member variables with any other.
 			</description>
 		</method>
 	</methods>
@@ -70,7 +71,8 @@
 		<signal name="value_changed">
 			<argument index="0" name="value" type="float" />
 			<description>
-				Emitted when [member value] changes.
+				Emitted when [member value] changes. When used on a [Slider], this is called continuously while dragging (potentially every frame). If you are performing an expensive operation in a function connected to [signal value_changed], consider using a [i]debouncing[/i] [Timer] to call the function less often.
+				[b]Note:[/b] Unlike signals such as [signal LineEdit.text_changed], [signal value_changed] is also emitted when [code]value[/code] is set directly via code.
 			</description>
 		</signal>
 	</signals>


### PR DESCRIPTION
This also mentions that the signal is potentially emitted every frame, which can have performance implications.

See https://github.com/godotengine/godot/issues/37876.