### PR TITLE
Streamline InputEvent class hierarchy to define position property only once

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -484,21 +484,26 @@ void InputEventKey::_bind_methods() {
 
 ///////////////////////////////////
 
-void InputEventMouse::set_button_mask(MouseButton p_mask) {
-	button_mask = p_mask;
-	emit_changed();
-}
-
-MouseButton InputEventMouse::get_button_mask() const {
-	return button_mask;
-}
-
-void InputEventMouse::set_position(const Vector2 &p_pos) {
+void InputEventWithPosition::set_position(const Vector2 &p_pos) {
 	pos = p_pos;
 }
 
-Vector2 InputEventMouse::get_position() const {
+Vector2 InputEventWithPosition::get_position() const {
 	return pos;
+}
+
+void InputEventWithPosition::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("set_position", "position"), &InputEventMouse::set_position);
+	ClassDB::bind_method(D_METHOD("get_position"), &InputEventMouse::get_position);
+
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "set_position", "get_position");
+}
+
+///////////////////////////////////
+
+void InputEventMouse::set_button_mask(MouseButton p_mask) {
+	button_mask = p_mask;
+	emit_changed();
 }
 
 void InputEventMouse::set_global_position(const Vector2 &p_global_pos) {
@@ -509,18 +514,18 @@ Vector2 InputEventMouse::get_global_position() const {
 	return global_pos;
 }
 
+MouseButton InputEventMouse::get_button_mask() const {
+	return button_mask;
+}
+
 void InputEventMouse::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_button_mask", "button_mask"), &InputEventMouse::set_button_mask);
 	ClassDB::bind_method(D_METHOD("get_button_mask"), &InputEventMouse::get_button_mask);
-
-	ClassDB::bind_method(D_METHOD("set_position", "position"), &InputEventMouse::set_position);
-	ClassDB::bind_method(D_METHOD("get_position"), &InputEventMouse::get_position);
 
 	ClassDB::bind_method(D_METHOD("set_global_position", "global_position"), &InputEventMouse::set_global_position);
 	ClassDB::bind_method(D_METHOD("get_global_position"), &InputEventMouse::get_global_position);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "button_mask"), "set_button_mask", "get_button_mask");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "global_position"), "set_global_position", "get_global_position");
 }
 
@@ -1107,14 +1112,6 @@ int InputEventScreenTouch::get_index() const {
 	return index;
 }
 
-void InputEventScreenTouch::set_position(const Vector2 &p_pos) {
-	pos = p_pos;
-}
-
-Vector2 InputEventScreenTouch::get_position() const {
-	return pos;
-}
-
 void InputEventScreenTouch::set_pressed(bool p_pressed) {
 	pressed = p_pressed;
 }
@@ -1128,8 +1125,9 @@ Ref<InputEvent> InputEventScreenTouch::xformed_by(const Transform2D &p_xform, co
 	st.instantiate();
 	st->set_device(get_device());
 	st->set_window_id(get_window_id());
+	st->set_modifiers_from_event(this);
 	st->set_index(index);
-	st->set_position(p_xform.xform(pos + p_local_ofs));
+	st->set_position(p_xform.xform(get_position() + p_local_ofs));
 	st->set_pressed(pressed);
 
 	return st;
@@ -1150,14 +1148,10 @@ void InputEventScreenTouch::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_index", "index"), &InputEventScreenTouch::set_index);
 	ClassDB::bind_method(D_METHOD("get_index"), &InputEventScreenTouch::get_index);
 
-	ClassDB::bind_method(D_METHOD("set_position", "position"), &InputEventScreenTouch::set_position);
-	ClassDB::bind_method(D_METHOD("get_position"), &InputEventScreenTouch::get_position);
-
 	ClassDB::bind_method(D_METHOD("set_pressed", "pressed"), &InputEventScreenTouch::set_pressed);
 	//ClassDB::bind_method(D_METHOD("is_pressed"),&InputEventScreenTouch::is_pressed);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "index"), "set_index", "get_index");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 }
 
@@ -1169,14 +1163,6 @@ void InputEventScreenDrag::set_index(int p_index) {
 
 int InputEventScreenDrag::get_index() const {
 	return index;
-}
-
-void InputEventScreenDrag::set_position(const Vector2 &p_pos) {
-	pos = p_pos;
-}
-
-Vector2 InputEventScreenDrag::get_position() const {
-	return pos;
 }
 
 void InputEventScreenDrag::set_relative(const Vector2 &p_relative) {
@@ -1202,9 +1188,10 @@ Ref<InputEvent> InputEventScreenDrag::xformed_by(const Transform2D &p_xform, con
 
 	sd->set_device(get_device());
 	sd->set_window_id(get_window_id());
+	sd->set_modifiers_from_event(this);
 
 	sd->set_index(index);
-	sd->set_position(p_xform.xform(pos + p_local_ofs));
+	sd->set_position(p_xform.xform(get_position() + p_local_ofs));
 	sd->set_relative(p_xform.basis_xform(relative));
 	sd->set_velocity(p_xform.basis_xform(velocity));
 
@@ -1240,9 +1227,6 @@ void InputEventScreenDrag::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_index", "index"), &InputEventScreenDrag::set_index);
 	ClassDB::bind_method(D_METHOD("get_index"), &InputEventScreenDrag::get_index);
 
-	ClassDB::bind_method(D_METHOD("set_position", "position"), &InputEventScreenDrag::set_position);
-	ClassDB::bind_method(D_METHOD("get_position"), &InputEventScreenDrag::get_position);
-
 	ClassDB::bind_method(D_METHOD("set_relative", "relative"), &InputEventScreenDrag::set_relative);
 	ClassDB::bind_method(D_METHOD("get_relative"), &InputEventScreenDrag::get_relative);
 
@@ -1250,7 +1234,6 @@ void InputEventScreenDrag::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_velocity"), &InputEventScreenDrag::get_velocity);
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "index"), "set_index", "get_index");
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "set_position", "get_position");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "relative"), "set_relative", "get_relative");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "velocity"), "set_velocity", "get_velocity");
 }
@@ -1340,23 +1323,6 @@ void InputEventAction::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "action"), "set_action", "get_action");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "pressed"), "set_pressed", "is_pressed");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "strength", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_strength", "get_strength");
-}
-
-///////////////////////////////////
-
-void InputEventGesture::set_position(const Vector2 &p_pos) {
-	pos = p_pos;
-}
-
-void InputEventGesture::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("set_position", "position"), &InputEventGesture::set_position);
-	ClassDB::bind_method(D_METHOD("get_position"), &InputEventGesture::get_position);
-
-	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "position"), "set_position", "get_position");
-}
-
-Vector2 InputEventGesture::get_position() const {
-	return pos;
 }
 
 ///////////////////////////////////

--- a/core/input/input_event.h
+++ b/core/input/input_event.h
@@ -205,12 +205,25 @@ public:
 	InputEventKey() {}
 };
 
-class InputEventMouse : public InputEventWithModifiers {
-	GDCLASS(InputEventMouse, InputEventWithModifiers);
-
-	MouseButton button_mask = MouseButton::NONE;
+class InputEventWithPosition : public InputEventWithModifiers {
+	GDCLASS(InputEventWithPosition, InputEventWithModifiers);
 
 	Vector2 pos;
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_position(const Vector2 &p_pos);
+	Vector2 get_position() const;
+
+	InputEventWithPosition() {}
+};
+
+class InputEventMouse : public InputEventWithPosition {
+	GDCLASS(InputEventMouse, InputEventWithPosition);
+
+	MouseButton button_mask = MouseButton::NONE;
 	Vector2 global_pos;
 
 protected:
@@ -219,9 +232,6 @@ protected:
 public:
 	void set_button_mask(MouseButton p_mask);
 	MouseButton get_button_mask() const;
-
-	void set_position(const Vector2 &p_pos);
-	Vector2 get_position() const;
 
 	void set_global_position(const Vector2 &p_global_pos);
 	Vector2 get_global_position() const;
@@ -357,10 +367,9 @@ public:
 	InputEventJoypadButton() {}
 };
 
-class InputEventScreenTouch : public InputEventFromWindow {
-	GDCLASS(InputEventScreenTouch, InputEventFromWindow);
+class InputEventScreenTouch : public InputEventWithPosition {
+	GDCLASS(InputEventScreenTouch, InputEventWithPosition);
 	int index = 0;
-	Vector2 pos;
 	bool pressed = false;
 
 protected:
@@ -369,9 +378,6 @@ protected:
 public:
 	void set_index(int p_index);
 	int get_index() const;
-
-	void set_position(const Vector2 &p_pos);
-	Vector2 get_position() const;
 
 	void set_pressed(bool p_pressed);
 	virtual bool is_pressed() const override;
@@ -383,10 +389,9 @@ public:
 	InputEventScreenTouch() {}
 };
 
-class InputEventScreenDrag : public InputEventFromWindow {
-	GDCLASS(InputEventScreenDrag, InputEventFromWindow);
+class InputEventScreenDrag : public InputEventWithPosition {
+	GDCLASS(InputEventScreenDrag, InputEventWithPosition);
 	int index = 0;
-	Vector2 pos;
 	Vector2 relative;
 	Vector2 velocity;
 
@@ -396,9 +401,6 @@ protected:
 public:
 	void set_index(int p_index);
 	int get_index() const;
-
-	void set_position(const Vector2 &p_pos);
-	Vector2 get_position() const;
 
 	void set_relative(const Vector2 &p_relative);
 	Vector2 get_relative() const;
@@ -448,17 +450,8 @@ public:
 	InputEventAction() {}
 };
 
-class InputEventGesture : public InputEventWithModifiers {
-	GDCLASS(InputEventGesture, InputEventWithModifiers);
-
-	Vector2 pos;
-
-protected:
-	static void _bind_methods();
-
-public:
-	void set_position(const Vector2 &p_pos);
-	Vector2 get_position() const;
+class InputEventGesture : public InputEventWithPosition {
+	GDCLASS(InputEventGesture, InputEventWithPosition);
 };
 
 class InputEventMagnifyGesture : public InputEventGesture {

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -152,6 +152,7 @@ void register_core_types() {
 	GDREGISTER_ABSTRACT_CLASS(InputEvent);
 	GDREGISTER_ABSTRACT_CLASS(InputEventWithModifiers);
 	GDREGISTER_ABSTRACT_CLASS(InputEventFromWindow);
+	GDREGISTER_ABSTRACT_CLASS(InputEventWithPosition);
 	GDREGISTER_CLASS(InputEventKey);
 	GDREGISTER_CLASS(InputEventShortcut);
 	GDREGISTER_ABSTRACT_CLASS(InputEventMouse);

--- a/doc/classes/InputEventFromWindow.xml
+++ b/doc/classes/InputEventFromWindow.xml
@@ -7,7 +7,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="window_id" type="int" setter="set_window_id" getter="get_window_id" default="0">
+		<member name="window_id" type="int" setter="set_window_id" getter="get_window_id">
 		</member>
 	</members>
 </class>

--- a/doc/classes/InputEventGesture.xml
+++ b/doc/classes/InputEventGesture.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="InputEventGesture" inherits="InputEventWithModifiers" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="InputEventGesture" inherits="InputEventWithPosition" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Base class for touch control gestures.
 	</brief_description>
@@ -7,9 +7,4 @@
 	</description>
 	<tutorials>
 	</tutorials>
-	<members>
-		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
-			The local gesture position relative to the [Viewport]. If used in [method Control._gui_input], the position is relative to the current [Control] that received this gesture.
-		</member>
-	</members>
 </class>

--- a/doc/classes/InputEventMouse.xml
+++ b/doc/classes/InputEventMouse.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="InputEventMouse" inherits="InputEventWithModifiers" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="InputEventMouse" inherits="InputEventWithPosition" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Base input event type for mouse events.
 	</brief_description>
@@ -16,10 +16,6 @@
 		<member name="global_position" type="Vector2" setter="set_global_position" getter="get_global_position" default="Vector2(0, 0)">
 			When received in [method Node._input] or [method Node._unhandled_input], returns the mouse's position in the root [Viewport] using the coordinate system of the root [Viewport].
 			When received in [method Control._gui_input], returns the mouse's position in the [CanvasLayer] that the [Control] is in using the coordinate system of the [CanvasLayer].
-		</member>
-		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
-			When received in [method Node._input] or [method Node._unhandled_input], returns the mouse's position in the [Viewport] this [Node] is in using the coordinate system of this [Viewport].
-			When received in [method Control._gui_input], returns the mouse's position in the [Control] using the local coordinate system of the [Control].
 		</member>
 	</members>
 </class>

--- a/doc/classes/InputEventScreenDrag.xml
+++ b/doc/classes/InputEventScreenDrag.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="InputEventScreenDrag" inherits="InputEventFromWindow" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="InputEventScreenDrag" inherits="InputEventWithPosition" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Input event type for screen drag events. Only available on mobile devices.
 	</brief_description>
@@ -12,9 +12,6 @@
 	<members>
 		<member name="index" type="int" setter="set_index" getter="get_index" default="0">
 			The drag event index in the case of a multi-drag event.
-		</member>
-		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
-			The drag position.
 		</member>
 		<member name="relative" type="Vector2" setter="set_relative" getter="get_relative" default="Vector2(0, 0)">
 			The drag position relative to the previous position (position at the last frame).

--- a/doc/classes/InputEventScreenTouch.xml
+++ b/doc/classes/InputEventScreenTouch.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="InputEventScreenTouch" inherits="InputEventFromWindow" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="InputEventScreenTouch" inherits="InputEventWithPosition" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Input event type for screen touch events.
 		(only available on mobile devices)
@@ -13,9 +13,6 @@
 	<members>
 		<member name="index" type="int" setter="set_index" getter="get_index" default="0">
 			The touch index in the case of a multi-touch event. One index = one finger.
-		</member>
-		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
-			The touch position, in screen (global) coordinates.
 		</member>
 		<member name="pressed" type="bool" setter="set_pressed" getter="is_pressed" default="false">
 			If [code]true[/code], the touch's state is pressed. If [code]false[/code], the touch's state is released.

--- a/doc/classes/InputEventWithPosition.xml
+++ b/doc/classes/InputEventWithPosition.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="InputEventWithPosition" inherits="InputEventWithModifiers" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Base class for events that contain a position.
+	</brief_description>
+	<description>
+	</description>
+	<tutorials>
+	</tutorials>
+	<members>
+		<member name="position" type="Vector2" setter="set_position" getter="get_position" default="Vector2(0, 0)">
+			The local event position relative to the [Viewport]. If used in [method Control._gui_input], the position is relative to the current [Control] that received this event.
+		</member>
+	</members>
+</class>


### PR DESCRIPTION
This PR changes the `InputEvent` class hierarchy, so that the position property is defined only in a single new class named `InputEventWithPosition`. Current status is, that position gets defined in four different classes with their own getters and setters, which would be simplified by this patch. Another benefit is, that this change makes it easy to distinguish between events with and without position.

In order to make this possible, this patch changes `InputEventScreenDrag` and `InputEventScreenTouch`, so that they now also inherit from `InputEventWithModifiers`.

The changed class hierarchy would look like this:
- InputEventFromWindow
  - InputEventWithModifiers
    - InputEventKey
    - InputEventWithPosition (new)
      - InputEventScreenDrag
      - InputEventScreenTouch
      - InputEventGesture
      - InputEventMouse

Implements https://github.com/godotengine/godot-proposals/discussions/4158

*Bugsquad edit*: Related to #55300 and #58334
