### PR TITLE
Setup logic to publish the Godot Android library to MavenCentral

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -4,7 +4,7 @@ ext.versions = [
     minSdk             : 19, // Also update 'platform/android/java/lib/AndroidManifest.xml#minSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
     targetSdk          : 30, // Also update 'platform/android/java/lib/AndroidManifest.xml#targetSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
     buildTools         : '30.0.3',
-    kotlinVersion      : '1.5.10',
+    kotlinVersion      : '1.6.10',
     fragmentVersion    : '1.3.6',
     javaVersion        : 11,
     ndkVersion         : '21.4.7075529' // Also update 'platform/android/detect.py#get_project_ndk_version()' when this is updated.
@@ -86,13 +86,12 @@ ext.getGodotEditorVersion = { ->
     return editorVersion
 }
 
-ext.getGodotLibraryVersion = { ->
+ext.generateGodotLibraryVersion = { List<String> requiredKeys ->
     // Attempt to read the version from the `version.py` file.
     String libraryVersion = ""
 
     File versionFile = new File("../../../version.py")
     if (versionFile.isFile()) {
-        List<String> requiredKeys = ["major", "minor", "patch", "status", "module_config"]
         def map = [:]
 
         List<String> lines = versionFile.readLines()
@@ -119,6 +118,16 @@ ext.getGodotLibraryVersion = { ->
         libraryVersion = "custom_build"
     }
     return libraryVersion
+}
+
+ext.getGodotLibraryVersion = { ->
+    List<String> requiredKeys = ["major", "minor", "patch", "status", "module_config"]
+    return generateGodotLibraryVersion(requiredKeys)
+}
+
+ext.getGodotPublishVersion = { ->
+    List<String> requiredKeys = ["major", "minor", "patch", "status"]
+    return generateGodotLibraryVersion(requiredKeys)
 }
 
 final String VALUE_SEPARATOR_REGEX = "\\|"

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -1,4 +1,6 @@
+apply plugin: 'io.github.gradle-nexus.publish-plugin'
 apply from: 'app/config.gradle'
+apply from: 'scripts/publish-root.gradle'
 
 buildscript {
     apply from: 'app/config.gradle'
@@ -6,10 +8,12 @@ buildscript {
     repositories {
         google()
         mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath libraries.androidGradlePlugin
         classpath libraries.kotlinGradlePlugin
+        classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
     }
 }
 

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -1,6 +1,13 @@
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
+ext {
+    PUBLISH_VERSION = getGodotPublishVersion()
+    PUBLISH_ARTIFACT_ID = 'godot'
+}
+
+apply from: "../scripts/publish-module.gradle"
+
 dependencies {
     implementation libraries.kotlinStdLib
     implementation libraries.androidxFragment
@@ -20,6 +27,8 @@ android {
 
         manifestPlaceholders = [godotLibraryVersion: getGodotLibraryVersion()]
     }
+
+    namespace = "org.godotengine.godot"
 
     compileOptions {
         sourceCompatibility versions.javaVersion
@@ -111,4 +120,12 @@ android {
         // Schedule the tasks so the generated libs are present before the aar file is packaged.
         tasks["merge${buildType}JniLibFolders"].dependsOn taskName
     }
+
+    // TODO: Enable when issues with AGP 7.1+ are resolved (https://github.com/GodotVR/godot_openxr/issues/187).
+//    publishing {
+//        singleVariant("release") {
+//            withSourcesJar()
+//            withJavadocJar()
+//        }
+//    }
 }

--- a/platform/android/java/scripts/publish-module.gradle
+++ b/platform/android/java/scripts/publish-module.gradle
@@ -1,0 +1,74 @@
+apply plugin: 'maven-publish'
+apply plugin: 'signing'
+
+group = ossrhGroupId
+version = PUBLISH_VERSION
+
+afterEvaluate {
+    publishing {
+        publications {
+            release(MavenPublication) {
+                // The coordinates of the library, being set from variables that
+                // we'll set up later
+                groupId ossrhGroupId
+                artifactId PUBLISH_ARTIFACT_ID
+                version PUBLISH_VERSION
+
+                // Two artifacts, the `aar` (or `jar`) and the sources
+                if (project.plugins.findPlugin("com.android.library")) {
+                    from components.release
+                } else {
+                    from components.java
+                }
+
+                // Mostly self-explanatory metadata
+                pom {
+                    name = PUBLISH_ARTIFACT_ID
+                    description = 'Godot Engine Android Library'
+                    url = 'https://godotengine.org/'
+                    licenses {
+                        license {
+                            name = 'MIT License'
+                            url = 'https://github.com/godotengine/godot/blob/master/LICENSE.txt'
+                        }
+                    }
+                    developers {
+                        developer {
+                            id = 'm4gr3d'
+                            name = 'Fredia Huya-Kouadio'
+                            email = 'fhuyakou@gmail.com'
+                        }
+                        developer {
+                            id = 'reduz'
+                            name = 'Juan Linietsky'
+                            email = 'reduzio@gmail.com'
+                        }
+                        developer {
+                            id = 'akien-mga'
+                            name = 'Rémi Verschelde'
+                            email = 'rverschelde@gmail.com'
+                        }
+                        // Add all other devs here...
+                    }
+
+                    // Version control info - if you're using GitHub, follow the
+                    // format as seen here
+                    scm {
+                        connection = 'scm:git:github.com/godotengine/godot.git'
+                        developerConnection = 'scm:git:ssh://github.com/godotengine/godot.git'
+                        url = 'https://github.com/godotengine/godot/tree/master'
+                    }
+                }
+            }
+        }
+    }
+}
+
+signing {
+    useInMemoryPgpKeys(
+        rootProject.ext["signing.keyId"],
+        rootProject.ext["signing.key"],
+        rootProject.ext["signing.password"],
+    )
+    sign publishing.publications
+}

--- a/platform/android/java/scripts/publish-root.gradle
+++ b/platform/android/java/scripts/publish-root.gradle
@@ -1,0 +1,39 @@
+// Create variables with empty default values
+ext["signing.keyId"] = ''
+ext["signing.password"] = ''
+ext["signing.key"] = ''
+ext["ossrhGroupId"] = ''
+ext["ossrhUsername"] = ''
+ext["ossrhPassword"] = ''
+ext["sonatypeStagingProfileId"] = ''
+
+File secretPropsFile = project.rootProject.file('local.properties')
+if (secretPropsFile.exists()) {
+    // Read local.properties file first if it exists
+    Properties p = new Properties()
+    new FileInputStream(secretPropsFile).withCloseable { is -> p.load(is) }
+    p.each { name, value -> ext[name] = value }
+} else {
+    // Use system environment variables
+    ext["ossrhGroupId"] = System.getenv('OSSRH_GROUP_ID')
+    ext["ossrhUsername"] = System.getenv('OSSRH_USERNAME')
+    ext["ossrhPassword"] = System.getenv('OSSRH_PASSWORD')
+    ext["sonatypeStagingProfileId"] = System.getenv('SONATYPE_STAGING_PROFILE_ID')
+    ext["signing.keyId"] = System.getenv('SIGNING_KEY_ID')
+    ext["signing.password"] = System.getenv('SIGNING_PASSWORD')
+    ext["signing.key"] = System.getenv('SIGNING_KEY')
+}
+
+// Set up Sonatype repository
+nexusPublishing {
+    repositories {
+        sonatype {
+            stagingProfileId = sonatypeStagingProfileId
+            username = ossrhUsername
+            password = ossrhPassword
+            nexusUrl.set(uri("https://s01.oss.sonatype.org/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://s01.oss.sonatype.org/content/repositories/snapshots/"))
+        }
+    }
+}
+


### PR DESCRIPTION
This PR follows the instructions from https://getstream.io/blog/publishing-libraries-to-mavencentral-2021/ to setup the logic to publish the Godot Engine Android Library to MavenCentral.

[MavenCentral](https://search.maven.org/) is a repository provided by the Maven community which contains a large number of commonly used libraries.
It's an important tool for java and Android developers as it simplifies the resolution and fetching process for a project's dependencies by build tools like Gradle.

The updated logic will enable to push (automatically) the generated [Godot Android Library](https://downloads.tuxfamily.org/godotengine/3.4.3/godot-lib.3.4.3.stable.release.aar) to MavenCentral so that users can access it by adding a single line to their gradle build file:
```
dependencies {
    ...
    implementation 'io.github.m4gr3d:godot:<versions>'
    ...
}
```

#### Publishing To MavenCentral
- This requires a [sonatype account](https://getstream.io/blog/publishing-libraries-to-mavencentral-2021/#registering-a-sonatype-account) and a [GPG key](https://getstream.io/blog/publishing-libraries-to-mavencentral-2021/#generating-a-gpg-key-pair) to sign the generated library.
- Provide values for the variables defined in [`publish-root.gradle`](https://github.com/m4gr3d/godot/blob/a6dbe0dc5720dd5fb53f239159294843adbe998b/platform/android/java/scripts/publish-root.gradle). This can either be done via environment variables, or through the `local.properties` file (that file is not and should not be added to git).
- Generate the Godot Android Library via the usual build process.
- Run the following commands to push the generated library to MavenCentral:
   -  `cd platform/android/java`
   - `./gradlew :lib:publishReleasePublicationToSonatypeRepository`
- Follow [these steps](https://getstream.io/blog/publishing-libraries-to-mavencentral-2021/#your-first-release) to review the uploaded binary and release it publicly on MavenCentral.


#### Notes & TODOs
- [ ] I'm using my own sonatype credentials at the moment to publish the library. Eventually, we would want to switch to Godot's own set of credentials.
- [ ] Automatic publishing is blocked by above todo. Once we have a set of credentials for Godot, we can automate the publishing of the Godot Android Library by leveraging github workflows as described [here](https://getstream.io/blog/publishing-libraries-to-mavencentral-2021/#automating-sonatype-actions).
- [ ] Update internal logic (e.g: Android template logic) to leverage the published library via gradle
- [ ] Update Android related documentation accordingly.


Part of https://github.com/godotengine/godot-docs/issues/4018
Implements https://github.com/godotengine/godot-proposals/issues/4230
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
