### PR TITLE
LOD distance is set correctly for scaled meshes

### DIFF
--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1682,7 +1682,12 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 				}
 
 				if (generate_lods) {
-					src_mesh_node->get_mesh()->generate_lods(merge_angle, split_angle);
+					// Calculate global scale not including the root scale
+					Vector3 global_scale = src_mesh_node->get_scale();
+					for (Node3D *parent = src_mesh_node->get_parent_node_3d(); parent->get_parent_node_3d() && !parent->is_set_as_top_level(); parent = parent->get_parent_node_3d()) {
+						global_scale *= parent->get_scale();
+					}
+					src_mesh_node->get_mesh()->generate_lods(merge_angle, split_angle, global_scale[0]);
 				}
 
 				if (create_shadow_meshes) {

--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -254,7 +254,7 @@ void ImporterMesh::set_surface_material(int p_surface, const Ref<Material> &p_ma
 	mesh.unref();
 }
 
-void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_split_angle) {
+void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_split_angle, float global_scale) {
 	if (!SurfaceTool::simplify_scale_func) {
 		return;
 	}
@@ -595,7 +595,7 @@ void ImporterMesh::generate_lods(float p_normal_merge_angle, float p_normal_spli
 			}
 
 			Surface::LOD lod;
-			lod.distance = MAX(mesh_error * scale, CMP_EPSILON2);
+			lod.distance = MAX(mesh_error * scale / global_scale, CMP_EPSILON2);
 			lod.indices = new_indices;
 			surfaces.write[i].lods.push_back(lod);
 			index_target = MAX(new_index_count, index_target) * 2;

--- a/scene/resources/importer_mesh.h
+++ b/scene/resources/importer_mesh.h
@@ -112,7 +112,7 @@ public:
 
 	void set_surface_material(int p_surface, const Ref<Material> &p_material);
 
-	void generate_lods(float p_normal_merge_angle, float p_normal_split_angle);
+	void generate_lods(float p_normal_merge_angle, float p_normal_split_angle, float global_scale = 1.0);
 
 	void create_shadow_mesh();
 	Ref<ImporterMesh> get_shadow_mesh() const;


### PR DESCRIPTION
WIP fix for LOD distance being set incorrectly for scaled meshes.

https://user-images.githubusercontent.com/18116695/158236346-9a90fd6b-02f6-45e9-bcbb-36f9cfbc376c.mp4


https://user-images.githubusercontent.com/18116695/158236363-01b4f9d3-08f4-46dd-819a-675c0173d999.mp4

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/57895.*
