### PR TITLE
Remove generating of null comparison operators from documentation

### DIFF
--- a/doc/classes/AABB.xml
+++ b/doc/classes/AABB.xml
@@ -228,11 +228,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="AABB" />
 			<description>
 				Returns [code]true[/code] if the vectors are not equal.
@@ -244,11 +239,6 @@
 			<argument index="0" name="right" type="Transform3D" />
 			<description>
 				Inversely transforms (multiplies) the [AABB] by the given [Transform3D] transformation matrix.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -511,11 +511,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Array" />
 			<description>
 			</description>
@@ -535,11 +530,6 @@
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="Array" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/Basis.xml
+++ b/doc/classes/Basis.xml
@@ -225,11 +225,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Basis" />
 			<description>
 				Returns [code]true[/code] if the [Basis] matrices are not equal.
@@ -262,11 +257,6 @@
 			<argument index="0" name="right" type="int" />
 			<description>
 				This operator multiplies all components of the [Basis], which scales it uniformly.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -150,19 +150,9 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Callable" />
 			<description>
 				Returns [code]true[/code] if both [Callable]s invoke different targets.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -915,11 +915,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Color" />
 			<description>
 				Returns [code]true[/code] if the colors are not equal.
@@ -980,11 +975,6 @@
 			<argument index="0" name="right" type="int" />
 			<description>
 				Divides each component of the [Color] by the given [int].
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -307,17 +307,7 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Dictionary" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -173,17 +173,7 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="NodePath" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -418,11 +418,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="PackedByteArray" />
 			<description>
 			</description>
@@ -430,11 +425,6 @@
 		<operator name="operator +">
 			<return type="PackedByteArray" />
 			<argument index="0" name="right" type="PackedByteArray" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -154,11 +154,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="PackedColorArray" />
 			<description>
 			</description>
@@ -166,11 +161,6 @@
 		<operator name="operator +">
 			<return type="PackedColorArray" />
 			<argument index="0" name="right" type="PackedColorArray" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -157,11 +157,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="PackedFloat32Array" />
 			<description>
 			</description>
@@ -169,11 +164,6 @@
 		<operator name="operator +">
 			<return type="PackedFloat32Array" />
 			<argument index="0" name="right" type="PackedFloat32Array" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -157,11 +157,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="PackedFloat64Array" />
 			<description>
 			</description>
@@ -169,11 +164,6 @@
 		<operator name="operator +">
 			<return type="PackedFloat64Array" />
 			<argument index="0" name="right" type="PackedFloat64Array" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -157,11 +157,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="PackedInt32Array" />
 			<description>
 			</description>
@@ -169,11 +164,6 @@
 		<operator name="operator +">
 			<return type="PackedInt32Array" />
 			<argument index="0" name="right" type="PackedInt32Array" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -157,11 +157,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="PackedInt64Array" />
 			<description>
 			</description>
@@ -169,11 +164,6 @@
 		<operator name="operator +">
 			<return type="PackedInt64Array" />
 			<argument index="0" name="right" type="PackedInt64Array" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -155,11 +155,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="PackedStringArray" />
 			<description>
 			</description>
@@ -167,11 +162,6 @@
 		<operator name="operator +">
 			<return type="PackedStringArray" />
 			<argument index="0" name="right" type="PackedStringArray" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -155,11 +155,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="PackedVector2Array" />
 			<description>
 			</description>
@@ -173,11 +168,6 @@
 		<operator name="operator +">
 			<return type="PackedVector2Array" />
 			<argument index="0" name="right" type="PackedVector2Array" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -154,11 +154,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="PackedVector3Array" />
 			<description>
 			</description>
@@ -172,11 +167,6 @@
 		<operator name="operator +">
 			<return type="PackedVector3Array" />
 			<argument index="0" name="right" type="PackedVector3Array" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/Plane.xml
+++ b/doc/classes/Plane.xml
@@ -173,20 +173,10 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Plane" />
 			<description>
 				Returns [code]true[/code] if the planes are not equal.
 				[b]Note:[/b] Due to floating-point precision errors, consider using [method is_equal_approx] instead, which is more reliable.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/Quaternion.xml
+++ b/doc/classes/Quaternion.xml
@@ -188,11 +188,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Quaternion" />
 			<description>
 				Returns [code]true[/code] if the quaternions are not equal.
@@ -253,11 +248,6 @@
 			<argument index="0" name="right" type="int" />
 			<description>
 				Divides each component of the [Quaternion] by the given value. This operation is not meaningful on its own, but it can be used as a part of a larger expression.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/RID.xml
+++ b/doc/classes/RID.xml
@@ -40,11 +40,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="RID" />
 			<description>
 			</description>
@@ -58,11 +53,6 @@
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="RID" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/Rect2.xml
+++ b/doc/classes/Rect2.xml
@@ -189,11 +189,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Rect2" />
 			<description>
 				Returns [code]true[/code] if the rectangles are not equal.
@@ -205,11 +200,6 @@
 			<argument index="0" name="right" type="Transform2D" />
 			<description>
 				Inversely transforms (multiplies) the [Rect2] by the given [Transform2D] transformation matrix.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/Rect2i.xml
+++ b/doc/classes/Rect2i.xml
@@ -178,19 +178,9 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Rect2i" />
 			<description>
 				Returns [code]true[/code] if the rectangles are not equal.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/Signal.xml
+++ b/doc/classes/Signal.xml
@@ -99,17 +99,7 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Signal" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/String.xml
+++ b/doc/classes/String.xml
@@ -865,11 +865,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="String" />
 			<description>
 			</description>
@@ -901,11 +896,6 @@
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="String" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -35,11 +35,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="String" />
 			<description>
 			</description>
@@ -59,11 +54,6 @@
 		<operator name="operator &lt;=">
 			<return type="bool" />
 			<argument index="0" name="right" type="StringName" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
 			<description>
 			</description>
 		</operator>

--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -206,11 +206,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Transform2D" />
 			<description>
 				Returns [code]true[/code] if the transforms are not equal.
@@ -257,11 +252,6 @@
 			<argument index="0" name="right" type="int" />
 			<description>
 				This operator multiplies all components of the [Transform2D], including the origin vector, which scales it uniformly.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -148,11 +148,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Transform3D" />
 			<description>
 				Returns [code]true[/code] if the transforms are not equal.
@@ -199,11 +194,6 @@
 			<argument index="0" name="right" type="int" />
 			<description>
 				This operator multiplies all components of the [Transform3D], including the origin vector, which scales it uniformly.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -359,11 +359,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Vector2" />
 			<description>
 				Returns [code]true[/code] if the vectors are not equal.
@@ -457,11 +452,6 @@
 			<argument index="0" name="right" type="Vector2" />
 			<description>
 				Compares two [Vector2] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/Vector2i.xml
+++ b/doc/classes/Vector2i.xml
@@ -133,11 +133,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
 				Returns [code]true[/code] if the vectors are not equal.
@@ -249,11 +244,6 @@
 			<argument index="0" name="right" type="Vector2i" />
 			<description>
 				Compares two [Vector2i] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors. This operator is useful for sorting vectors.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -360,11 +360,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Vector3" />
 			<description>
 				Returns [code]true[/code] if the vectors are not equal.
@@ -472,11 +467,6 @@
 			<argument index="0" name="right" type="Vector3" />
 			<description>
 				Compares two [Vector3] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -140,11 +140,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
 				Returns [code]true[/code] if the vectors are not equal.
@@ -256,11 +251,6 @@
 			<argument index="0" name="right" type="Vector3i" />
 			<description>
 				Compares two [Vector3i] vectors by first checking if the X value of the left vector is less than or equal to the X value of the [code]right[/code] vector. If the X values are exactly equal, then it repeats this check with the Y values of the two vectors, and then with the Z values. This operator is useful for sorting vectors.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/bool.xml
+++ b/doc/classes/bool.xml
@@ -123,11 +123,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="bool" />
 			<description>
 				Returns [code]true[/code] if two bools are different, i.e. one is [code]true[/code] and the other is [code]false[/code].
@@ -138,12 +133,6 @@
 			<argument index="0" name="right" type="bool" />
 			<description>
 				Returns [code]true[/code] if the left operand is [code]false[/code] and the right operand is [code]true[/code].
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if two bools are equal, i.e. both are [code]true[/code] or both are [code]false[/code].
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/float.xml
+++ b/doc/classes/float.xml
@@ -44,11 +44,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] if two floats are different from each other.
@@ -197,11 +192,6 @@
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] if this [float] is less than or equal to the given [int].
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/doc/classes/int.xml
+++ b/doc/classes/int.xml
@@ -70,11 +70,6 @@
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />
-			<description>
-			</description>
-		</operator>
-		<operator name="operator !=">
-			<return type="bool" />
 			<argument index="0" name="right" type="float" />
 			<description>
 				Returns [code]true[/code] if operands are different from each other.
@@ -269,11 +264,6 @@
 			<argument index="0" name="right" type="int" />
 			<description>
 				Returns [code]true[/code] the left integer is less than or equal to the right one.
-			</description>
-		</operator>
-		<operator name="operator ==">
-			<return type="bool" />
-			<description>
 			</description>
 		</operator>
 		<operator name="operator ==">

--- a/editor/doc_tools.cpp
+++ b/editor/doc_tools.cpp
@@ -685,6 +685,11 @@ void DocTools::generate(bool p_basic_types) {
 
 		for (int j = 0; j < Variant::OP_AND; j++) { // Showing above 'and' is pretty confusing and there are a lot of variations.
 			for (int k = 0; k < Variant::VARIANT_MAX; k++) {
+				// Prevent generating for comparison with null.
+				if (Variant::Type(k) == Variant::NIL && (Variant::Operator(j) == Variant::OP_EQUAL || Variant::Operator(j) == Variant::OP_NOT_EQUAL)) {
+					continue;
+				}
+
 				Variant::Type rt = Variant::get_operator_return_type(Variant::Operator(j), Variant::Type(i), Variant::Type(k));
 				if (rt != Variant::NIL) { // Has operator.
 					// Skip String % operator as it's registered separately for each Variant arg type,


### PR DESCRIPTION
It's obvious that you can compare any type in Godot with null, so no need to make a documentation for this functionality for each basic type.
