### PR TITLE
Improve `--debug-stringnames` to be more useful

### DIFF
--- a/core/string/string_name.cpp
+++ b/core/string/string_name.cpp
@@ -73,11 +73,23 @@ void StringName::cleanup() {
 				d = d->next;
 			}
 		}
-		print_line("\nStringName Reference Ranking:\n");
+
+		print_line("\nStringName reference ranking (from most to least referenced):\n");
+
 		data.sort_custom<DebugSortReferences>();
-		for (int i = 0; i < MIN(100, data.size()); i++) {
+		int unreferenced_stringnames = 0;
+		int rarely_referenced_stringnames = 0;
+		for (int i = 0; i < data.size(); i++) {
 			print_line(itos(i + 1) + ": " + data[i]->get_name() + " - " + itos(data[i]->debug_references));
+			if (data[i]->debug_references == 0) {
+				unreferenced_stringnames += 1;
+			} else if (data[i]->debug_references < 5) {
+				rarely_referenced_stringnames += 1;
+			}
 		}
+
+		print_line(vformat("\nOut of %d StringNames, %d StringNames were never referenced during this run (0 times) (%.2f%%).", data.size(), unreferenced_stringnames, unreferenced_stringnames / float(data.size()) * 100));
+		print_line(vformat("Out of %d StringNames, %d StringNames were rarely referenced during this run (1-4 times) (%.2f%%).", data.size(), rarely_referenced_stringnames, rarely_referenced_stringnames / float(data.size()) * 100));
 	}
 #endif
 	int lost_strings = 0;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -348,6 +348,7 @@ void Main::print_help(const char *p_binary) {
 #if defined(DEBUG_ENABLED)
 	OS::get_singleton()->print("  --debug-collisions                           Show collision shapes when running the scene.\n");
 	OS::get_singleton()->print("  --debug-navigation                           Show navigation polygons when running the scene.\n");
+	OS::get_singleton()->print("  --debug-stringnames                          Print all StringName allocations to stdout when the engine quits.\n");
 #endif
 	OS::get_singleton()->print("  --frame-delay <ms>                           Simulate high CPU load (delay each frame by <ms> milliseconds).\n");
 	OS::get_singleton()->print("  --time-scale <scale>                         Force time scale (higher values are faster, 1.0 is normal speed).\n");

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -66,6 +66,7 @@ _arguments \
   '--remote-debug[enable remote debugging]:remote debugger address' \
   '--debug-collisions[show collision shapes when running the scene]' \
   '--debug-navigation[show navigation polygons when running the scene]' \
+  '--debug-stringnames[print all StringName allocations to stdout when the engine quits]' \
   '--frame-delay[simulate high CPU load (delay each frame by the given number of milliseconds)]:number of milliseconds' \
   '--time-scale[force time scale (higher values are faster, 1.0 is normal speed)]:time scale' \
   '--disable-render-loop[disable render loop so rendering only occurs when called explicitly from script]' \

--- a/misc/dist/shell/godot.bash-completion
+++ b/misc/dist/shell/godot.bash-completion
@@ -68,6 +68,7 @@ _complete_godot_options() {
 --remote-debug
 --debug-collisions
 --debug-navigation
+--debug-stringnames
 --frame-delay
 --time-scale
 --disable-render-loop

--- a/misc/dist/shell/godot.fish
+++ b/misc/dist/shell/godot.fish
@@ -78,6 +78,7 @@ complete -c godot -l gpu-abort -d "Abort on GPU errors (usually validation layer
 complete -c godot -l remote-debug -d "Enable remote debugging"
 complete -c godot -l debug-collisions -d "Show collision shapes when running the scene"
 complete -c godot -l debug-navigation -d "Show navigation polygons when running the scene"
+complete -c godot -l debug-stringnames -d "Print all StringName allocations to stdout when the engine quits"
 complete -c godot -l frame-delay -d "Simulate high CPU load (delay each frame by the given number of milliseconds)" -x
 complete -c godot -l time-scale -d "Force time scale (higher values are faster, 1.0 is normal speed)" -x
 complete -c godot -l disable-render-loop -d "Disable render loop so rendering only occurs when called explicitly from script"


### PR DESCRIPTION
- Print all StringNames, not just the top 100.
- Print statistics at the end of the list of StringNames, with unreferenced and rarely referenced StringNames.
- List the CLI argument in `--help` and shell completion.

This will be helpful for @lawnjelly's optimization work :slightly_smiling_face:

**Note:** Not cherry-pickable to `3.x` as the StringName implementation is entirely different.

## Preview (`godot --quit`)

```
Godot Engine v4.0.alpha.custom_build.7a454842d - https://godotengine.org
Vulkan API 1.2.189 - Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 1080
 

StringName reference ranking (from most to least referenced):

1: TextParagraph - 8012
2: _draw - 1956
3: RenderingServer - 1750
4: changed - 1511
5: item_rect_changed - 1333
6: physics/2d/solver/contact_max_separation - 1021
7: physics/2d/time_before_sleep - 1021
8: physics/2d/solver/contact_max_allowed_penetration - 1021
9: physics/2d/default_angular_damp - 1021
10: physics/2d/solver/solver_iterations - 1021
11: physics/2d/solver/contact_recycle_radius - 1021
12: physics/2d/solver/default_contact_bias - 1021
13: physics/2d/solver/default_constraint_bias - 1021
14: physics/2d/default_linear_damp - 1021
15: gui/timers/tooltip_delay_sec - 1021
16: _input - 971
17: _unhandled_input - 971
18: _exit_tree - 971
19: _enter_tree - 971
20: _unhandled_key_input - 971
21: _ready - 971
22: _get_configuration_warnings - 970
23: _get_height - 921
24: _get_width - 921
25: _draw_rect - 919
26: _draw_rect_region - 919
27: _is_pixel_opaque - 919
28: _has_alpha - 919
29: ImageTexture - 867
30: _has_point - 825
31: _gui_input - 825
32: _structured_text_parser - 825
33: _can_drop_data - 825
34: _get_drag_data - 825
35: _get_minimum_size - 825
36: _drop_data - 825
37: ready - 825
38: _make_custom_tooltip - 824
39: physics/2d/default_gravity - 817
40: physics/2d/default_gravity_vector - 817
41: navigation/2d/default_edge_connection_margin - 817
42: navigation/2d/default_cell_size - 817
43: physics/2d/sleep_threshold_angular - 817
44: physics/2d/sleep_threshold_linear - 817
45: GDScriptNativeClass - 815
46: RenderingDevice - 730
47: Control - 715
48: EditorSettings - 712
49: TextEdit - 705
50: Environment - 694
51: BaseMaterial3D - 641
52: visibility_changed - 634
53: minimum_size_changed - 631
54: size_flags_changed - 631
55: TextServer - 581
56: AnimatedTexture - 563
57: TextLine - 539
58: PhysicsServer3D - 529
59: Texture2D - 454
60: Node - 444
61: DisplayServer - 411
62: CodeEdit - 410
63: PhysicsServer2D - 404
64: Viewport - 401
65: StyleBoxFlat - 397
66: TreeItem - 388
67: RichTextLabel - 381
68: CPUParticles3D - 362
69: FontData - 360
70: LineEdit - 337
71: Window - 331
72: size_changed - 317
73: CPUParticles2D - 315
74: CanvasItem - 313
75: ParticlesMaterial - 310
76: Tree - 304
77: PopupMenu - 301
78: ItemList - 301
79: TileSet - 288
80: Label - 280
81: get_frame_delay - 257
82: get_frame_texture - 256
83: set_frame_texture - 256
84: set_frame_delay - 256
85: Node3D - 254
86: Animation - 246
87: Button - 242
88: AnimationNodeBlendSpace2D - 228
89: RenderingDevice.DataFormat - 226
90: Theme - 225
91: _get_allowed_size_flags_vertical - 220
92: _get_allowed_size_flags_horizontal - 220
93: DataFormat - 219
94: GraphEdit - 219
95: RigidDynamicBody3D - 218
96: RigidDynamicBody2D - 218
97: _get_draw_rect - 210
98: _get_center_size - 210
99: _get_style_margin - 210
100: _test_mask - 210
101: TabBar - 207
102: original - 206
103: NavigationMesh - 204
104: GPUParticles3D - 198
105: Area3D - 193
106: GraphNode - 190
107: Generic6DOFJoint3D - 190
108: AnimationNodeBlendSpace1D - 181
109: GLTFState - 177
110: TextServerExtension - 175
111: GPUParticles2D - 175
112: Camera2D - 174
113: Camera3D - 173
114: Skeleton3D - 173
115: EditorPlugin - 172
116: CharacterBody2D - 167
117: CharacterBody3D - 167
118: AudioStreamPlayer3D - 165
119: TabContainer - 165
120: Input - 161
121: texture - 161
122: TileMap - 160
123: AnimationPlayer - 157
124: Node2D - 155
125: AudioServer - 152
126: PhysicsDirectBodyState3D - 149
127: GridMap - 149
128: RDPipelineDepthStencilState - 149
129: TileData - 148
130: pressed - 147
131: _toggled - 146
132: _pressed - 146
133: Polygon2D - 144
134: Area2D - 141
135: PhysicalBone3D - 141
136: PhysicsDirectBodyState2D - 141
137: Mesh - 141
138: Curve - 140
139: AnimationRootNode - 139
140: VisualScript - 138
141: _viewports - 136
142: OptionButton - 134
143: SceneTree - 134
144: Light3D - 133
145: GeometryInstance3D - 132
146: Timer - 131
147: CSGPolygon3D - 130
148: get_blend_point_position - 129
149: get_blend_point_node - 129
150: set_blend_point_position - 129
151: _add_blend_point - 129
152: EditorIcons - 126
153: Line2D - 124
154: NavigationServer3D - 123
155: Light2D - 123
156: TileSetAtlasSource - 120
157: VehicleWheel3D - 119
158: ShapeCast2D - 119
159: LightmapGI - 119
160: panel - 119
161: CollisionObject2D - 118
162: SkeletonModification3DJiggle - 118
163: FileDialog - 118
164: SoftDynamicBody3D - 117
165: MeshDataTool - 115
166: MultiMesh - 115
167: EditorInterface - 113
168: SkeletonModification2DJiggle - 112
169: TextureProgressBar - 111
170: NavigationAgent3D - 110
171: CollisionObject3D - 110
172: fragment - 110
173: RayCast3D - 108
174: SurfaceTool - 108
175: RDSamplerState - 107
176: EditorFileDialog - 106
177: draw_center - 105
178: Function - 105
179: ArrayMesh - 104
180: Font - 104
181: NavigationServer2D - 102
182: border_color - 102
183: column - 101
184: VisualShaderNode - 101
185: shadow_color - 100
186: ReflectionProbe - 100
187: Decal - 100
188: expand_margin_right - 99
189: GLTFAccessor - 99
190: expand_margin_left - 99
191: expand_margin_bottom - 99
192: Sprite2D - 99
193: light - 99
194: expand_margin_top - 99
195: AudioStreamPlayer2D - 99
196: _value_changed - 98
197: content_margin_right - 98
198: value_changed - 98
199: content_margin_left - 98
200: content_margin_bottom - 98
201: HTTPRequest - 98
202: StyleBox - 98
203: content_margin_top - 98
204: BaseButton - 97
205: ColorPicker - 97
206: VisualShader - 97
207: corner_radius_bottom_left - 96
208: border_blend - 96
209: corner_radius_top_left - 96
210: border_width_right - 96
211: corner_radius_top_right - 96
212: corner_radius_bottom_right - 96
213: anti_aliasing - 96
214: Curve3D - 96
215: shadow_offset - 96
216: shadow_size - 96
217: anti_aliasing_size - 96
218: border_width_bottom - 96
219: corner_detail - 96
220: border_width_left - 96
221: bg_color - 96
222: border_width_top - 96
223: SpriteBase3D - 95
224: ScrollContainer - 95
225: NavigationAgent2D - 95
226: EditorProperty - 94
227: Editor - 94
228: p_member - 94
229: CodeHighlighter - 92
230: RayCast2D - 92
231: window_input - 92
232: GLTFNode - 92
233: AudioEffectDelay - 92
234: Tween - 92
235: StyleBoxTexture - 92
236: font_rid - 91
237: Range - 91
238: AnimationNodeTransition - 91
239: ProceduralSkyMaterial - 90
240: World2D - 89
241: Param - 89
242: VideoStreamPlayer - 88
243: AcceptDialog - 88
244: joint_idx - 88
245: VisualScriptFunctionCall - 88
246: AudioStreamPlayer - 88
247: SkeletonModification3DTwoBoneIK - 87
248: XRInterface - 87
249: timeout - 86
250: SkeletonIK3D - 86
251: rendering/scaling_3d/fsr_sharpness - 84
252: UPNP - 84
253: rendering/scaling_3d/scale - 84
254: rendering/scaling_3d/mode - 84
255: VScrollBar - 84
256: rendering/scaling_3d/fsr_mipmap_bias - 84
257: HBoxContainer - 83
258: VoxelGIData - 83
259: AudioEffectChorus - 82
260: PhysicalSkyMaterial - 82
261: transform - 81
262: RDPipelineColorBlendStateAttachment - 81
263: TextureButton - 81
264: CanvasLayer - 81
265: amount - 81
266: SkeletonModification3DFABRIK - 80
267: VisualScriptPropertySet - 79
268: RDPipelineRasterizationState - 79
269: material - 79
270: CharFXTransform - 79
271: AnimationNode - 78
272: ViewportTexture - 78
273: ImporterMesh - 77
274: AnimatedSprite2D - 77
275: VisualScriptBuiltinFunc - 77
276: LinkButton - 76
277: shape - 75
278: vertex - 74
279: CameraEffects - 74
280: theme_type - 73
281: Curve2D - 73
282: TouchScreenButton - 73
283: XRServer - 73
284: Material - 72
285: GLTFSkin - 71
286: RDTextureFormat - 71
287: mesh - 71
288: SkeletonModification3DCCDIK - 71
289: margin - 71
290: CSGShape3D - 71
291: AnimationNodeStateMachine - 70
292: ENetPacketPeer - 69
293: PhysicsShapeQueryParameters2D - 69
294: PhysicsShapeQueryParameters3D - 69
295: Gradient - 69
296: VisualScriptBuiltinFunc.BuiltinFunc - 69
297: param - 69
298: SpriteFrames - 69
299: BuiltinFunc - 69
300: GodotPhysicsDirectSpaceState2D - 68
301: SceneState - 68
302: ENetConnection - 68
303: MeshInstance3D - 68
304: ScriptEditor - 67
305: SliderJoint3D - 67
306: UPNPDevice - 67
307: Operator - 67
308: MeshLibrary - 66
309: XRPositionalTracker - 66
310: VisualShaderNodeGroupBase - 65
311: EditorNode3DGizmo - 65
312: VBoxContainer - 65
313: VisualScriptNode - 64
314: EditorVCSInterface - 64
315: SkeletonModification2DCCDIK - 64
316: NavigationPolygon - 64
317: GradientTexture2D - 63
318: AudioStreamSample - 63
319: get_texture - 62
320: OpenSimplexNoise - 62
321: WebSocketServer - 61
322: VisualScriptPropertyGet - 61
323: set_texture - 61
324: PathFollow2D - 59
325: HScrollBar - 59
326: MenuItems - 59
327: WebXRInterface - 59
328: track_idx - 59
329: AudioEffectReverb - 59
330: PathFollow3D - 58
331: scale - 58
332: PhysicsRayQueryParameters3D - 58
333: get_param - 58
334: set_param - 58
335: disabled - 58
336: global - 57
337: Sprite3D - 56
338: draw - 56
339: AnimationTree - 55
340: NoiseTexture - 55
341: VisualShaderNodeTextureUniform - 55
342: font - 55
343: CanvasTexture - 54
344: AnimationNodeOneShot - 54
345: AudioStreamRandomizer - 54
346: CursorShape - 54
347: SkeletonModification2DTwoBoneIK - 54
348: NinePatchRect - 54
349: CanvasItemMaterial - 53
350: CheckBox - 53
351: TextureRect - 53
352: shaped - 53
353: OpType - 53
354: collision_mask - 52
355: SkeletonModification2DLookAt - 52
356: constants - 52
357: SkeletonModificationStack2D - 52
358: SkeletonModificationStack3D - 52
359: EditorResourcePicker - 52
360: WebRTCDataChannel - 52
361: PhysicsTestMotionParameters3D - 51
362: layer - 51
363: ArrayFormat - 51
364: MobileVRInterface - 51
365: Feature - 51
366: PhysicsRayQueryParameters2D - 51
367: VisualShaderNodeFloatUniform - 50
368: XRPose - 50
369: HingeJoint3D - 50
370: AudioEffectCompressor - 50
371: CheckButton - 50
372: VisualShaderNodeIntUniform - 49
373: area - 49
374: ParallaxBackground - 49
375: CameraFeed - 49
376: AnimationNodeStateMachineTransition - 48
377: GPUParticlesCollisionHeightField3D - 48
378: SubViewport - 48
379: MenuButton - 48
380: RibbonTrailMesh - 47
381: LightmapGIData - 47
382: StyleBoxLine - 47
383: MarginContainer - 47
384: BitMap - 47
385: SpinBox - 47
386: node - 46
387: VisualShaderNodeVectorFunc - 46
388: CSGCylinder3D - 46
389: item - 46
390: ColorPickerButton - 46
391: CSGTorus3D - 46
392: TubeTrailMesh - 45
393: AnimatedSprite3D - 45
394: SkeletonModification2D - 45
395: BoneAttachment3D - 45
396: cache_index - 45
397: normal - 45
398: FogMaterial - 45
399: bone_idx - 45
400: Panel - 45
401: PhysicsTestMotionParameters2D - 44
402: SpringArm3D - 44
403: World3D - 44
404: constant - 44
405: VisualInstance3D - 44
406: PhysicsPointQueryParameters2D - 44
407: VisualShaderNodeFloatFunc - 44
408: PhysicsTestMotionResult3D - 44
409: RDPipelineMultisampleState - 44
410: GLTFLight - 43
411: Shape2D - 43
412: HeaderSmall - 43
413: Shape3D - 43
414: Bone2D - 43
415: font_size - 43
416: RemoteTransform3D - 43
417: hseparation - 43
418: EditorFileSystemDirectory - 43
419: gui/common/default_scroll_deadzone - 42
420: Skin - 42
421: RemoteTransform2D - 42
422: Sky - 42
423: EditorFeatureProfile - 42
424: PhysicalBone2D - 42
425: KinematicCollision3D - 42
426: PhysicsTestMotionResult2D - 42
427: PhysicsMaterial - 41
428: AnimationNodeBlendTree - 41
429: ConfirmationDialog - 41
430: viewport - 41
431: outline_size - 41
432: AudioEffectDistortion - 41
433: Parameter - 41
434: CollisionPolygon2D - 40
435: AudioEffectFilter - 40
436: SkeletonModification3DLookAt - 40
437: PrimitiveMesh - 39
438: VisualShaderNodeCompare - 39
439: target_nodepath - 39
440: RDTextureView - 39
441: AspectRatioContainer - 39
442: SkeletonModification2DFABRIK - 39
443: CurveTexture - 39
444: WebRTCPeerConnection - 39
445: joint - 39
446: CSGSphere3D - 39
447: direction - 39
448: EditorExportPlugin - 39
449: RootMotionView - 39
450: font_color - 38
451: set_param_min - 38
452: CylinderMesh - 38
453: SphereMesh - 38
454: GPUParticlesCollisionSDF3D - 38
455: GLTFSkeleton - 38
456: PrismMesh - 38
457: set_param_max - 38
458: get_param_min - 38
459: get_param_max - 38
460: KinematicCollision2D - 38
461: RDFramebufferPass - 37
462: PhysicsPointQueryParameters3D - 37
463: Texture3D - 37
464: VoxelGI - 37
465: OK - 37
466: process - 37
467: get_radius - 37
468: set_radius - 37
469: rendering/textures/default_filters/use_nearest_mipmap_filter - 37
470: SkeletonModification3D - 37
471: modulate - 37
472: OccluderInstance3D - 37
473: GLTFSpecGloss - 36
474: EditorNode3DGizmoPlugin - 36
475: EditorFonts - 36
476: AudioEffectPhaser - 36
477: VisualShaderNodeVectorFunc.Function - 36
478: Popup - 36
479: TextureLayered - 36
480: RDVertexAttribute - 36
481: GLTFBufferView - 36
482: Joint3D - 35
483: DirectionalLight3D - 35
484: FileSystemDock - 35
485: Limit - 35
486: MultiplayerSpawner - 35
487: RenderingDevice.Limit - 35
488: CollisionPolygon3D - 35
489: NavigationRegion3D - 34
490: XRInterfaceExtension - 34
491: PhysicsBody3D - 34
492: TileSetScenesCollectionSource - 34
493: TileMapPattern - 34
494: Skeleton2D - 34
495: distance - 34
496: PolygonPathFinder - 34
497: particles - 33
498: ImmediateMesh - 33
499: VisualShaderNodeTexture - 33
500: ConeTwistJoint3D - 33
501: layer_number - 33
502: ENetMultiplayerPeer - 33
503: Shader - 33
504: VisualShaderNodeFloatFunc.Function - 33
505: function - 33
506: Slider - 33
507: get_collision_mask - 33
508: All Files (*) - 33
509: set_collision_mask - 33
510: get_input_caption - 32
511: COLOR - 32
512: CurveXYZTexture - 32
513: float - 32
514: set_input_caption - 32
515: VisualScriptYieldSignal - 32
516: Joint2D - 32
517: BoxMesh - 32
518: WebSocketClient - 32
519: set_input_as_auto_advance - 32
520: GLTFDocumentExtension - 32
521: AtlasTexture - 32
522: GPUParticlesAttractor3D - 32
523: is_input_set_as_auto_advance - 32
524: EditorFileSystem - 32
525: force - 32
526: separation - 32
527: SplitContainer - 31
528: VisualShaderNodeCubemap - 31
529: set_size - 31
530: PackedScene - 31
531: DampedSpringJoint2D - 31
532: OpenXRActionSet - 31
533: CapsuleMesh - 31
534: PlaneMesh - 31
535: CollisionShape2D - 31
536: OpenXRAction - 31
537: EditorSpinSlider - 31
538: Cancel - 30
539: set_flag - 30
540: WebSocketPeer - 30
541: TextServerManager - 30
542: OccluderPolygon2D - 30
543: get_flag - 30
544: GLTFDocument - 30
545: gui_focus_changed - 30
546: curve - 30
547: OpenXRActionMap - 30
548: op_type - 30
549: RDPipelineColorBlendState - 30
550: atlas_coords - 29
551: XRNode3D - 29
552: AudioEffectLimiter - 29
553: tab_idx - 29
554: Flags - 29
555: GlobalVariableType - 29
556: item_selected - 29
557: RenderingServer.GlobalVariableType - 29
558: UPNPResult - 29
559: AudioEffectCapture - 29
560: pos - 29
561: GLTFCamera - 29
562: ArrayType - 29
563: SceneReplicationConfig - 28
564: TextEdit.MenuItems - 28
565: LineEdit.MenuItems - 28
566: rendering/textures/default_filters/anisotropic_filtering_level - 28
567: editor/node_naming/name_casing - 28
568: _h_scroll - 28
569: ratio - 28
570: bg - 28
571: NavigationRegion2D - 28
572: RDUniform - 28
573: Container - 28
574: _v_scroll - 28
575: AudioEffectPitchShift - 28
576: ResourcePreloader - 28
577: RDShaderSPIRV - 28
578: RegEx - 28
579: UPNP.UPNPResult - 28
580: base_type - 28
581: AudioEffectSpectrumAnalyzer - 28
582: Generic6DOFJoint3D.Param - 28
583: EditorScenePostImportPlugin - 27
584: AreaParameter - 27
585: GradientTexture1D - 27
586: ProjectDialog - 27
587: VisualShaderNodeUniform - 27
588: AudioStream - 27
589: JSONRPC - 27
590: owner_id - 27
591: VisualScriptCustomNode - 27
592: gravity - 27
593: VisualShader.Type - 27
594: EditorDebuggerPlugin - 26
595: _update_minimum_size - 26
596: AudioStreamOGGVorbis - 26
597: VehicleBody3D - 26
598: collide_with_areas - 26
599: sky - 26
600: VisualShaderNodeCustom - 26
601: VisualScriptLists - 26
602: PointLight2D - 26
603: docks/property_editor/subresource_hue_tint - 26
604: vec3 - 26
605: OGGPacketSequence - 26
606: get_offset - 26
607: StaticBody3D - 26
608: antialiased - 26
609: set_color - 26
610: title - 26
611: collide_with_bodies - 26
612: font_outline_color - 26
613: multimesh - 26
614: frame - 26
615: ItemType - 26
616: AudioStreamMP3 - 26
617: RenderingServer.ViewportDebugDraw - 25
618: MultiMeshInstance2D - 25
619: Viewport.DebugDraw - 25
620: VisualShaderNodeDerivativeFunc - 25
621: rendering/vulkan/staging_buffer/texture_upload_region_size_px - 25
622: rendering/environment/defaults/default_clear_color - 25
623: StaticBody2D - 25
624: MeshInstance2D - 25
625: CameraServer - 25
626: HeightMapShape3D - 25
627: CollisionShape3D - 25
628: visible - 25
629: ParallaxLayer - 25
630: DebugDraw - 25
631: RegExMatch - 25
632: rendering/vulkan/staging_buffer/max_size_mb - 25
633: step - 25
634: env - 25
635: set_offset - 25
636: CanvasGroup - 25
637: MeshTexture - 25
638: TextureFilter - 25
639: get_color - 25
640: tag - 25
641: AnimationNodeStateMachinePlayback - 25
642: ViewportDebugDraw - 25
643: rendering/vulkan/staging_buffer/block_size_kb - 25
644: display/window/energy_saving/keep_screen_on - 25
645: RichTextLabel.ItemType - 25
646: rendering/vulkan/descriptor_pools/max_descriptors_per_pool - 25
647: JavaScript - 24
648: set_height - 24
649: ReferenceRect - 24
650: SliderJoint3D.Param - 24
651: region - 24
652: LightOccluder2D - 24
653: CameraTexture - 24
654: RenderingServer.ArrayFormat - 24
655: TextureType - 24
656: shape_idx - 24
657: PhysicsServer3D.SliderJointParam - 24
658: VisualScriptComment - 24
659: RDShaderFile - 24
660: FogVolume - 24
661: ShaderMaterial - 24
662: Mesh.ArrayFormat - 24
663: get_param_curve - 23
664: key_idx - 23
665: space - 23
666: set_material - 23
667: skeleton - 23
668: VisualShaderNodeIntOp - 23
669: SliderJointParam - 23
670: BodyParameter - 23
671: set_param_curve - 23
672: canvas - 23
673: default_value - 23
674: get_material - 23
675: SkeletonModification2DPhysicalBones - 23
676: RenderingDevice.BlendFactor - 23
677: time - 23
678: exclude - 23
679: MultiplayerSynchronizer - 22
680: gutter - 22
681: VisualShaderNodeFloatOp - 22
682: GLTFMesh - 22
683: bus_idx - 22
684: PhysicsDirectSpaceState3D - 22
685: EmissionShape - 22
686: VisualShaderNodeParticleMeshEmitter - 22
687: WebRTCMultiplayerPeer - 22
688: AudioEffectStereoEnhance - 22
689: ProgressBar - 22
690: TileSetSource - 22
691: mass - 22
692: bias - 22
693: label - 22
694: RDShaderSource - 22
695: RDAttachmentFormat - 22
696: TIME - 22
697: PhysicsDirectSpaceState2D - 22
698: BaseMaterial3D.Flags - 22
699: VisibleOnScreenEnabler3D - 22
700: ImporterMeshInstance3D - 22
701: energy - 22
702: operator - 21
703: glyph - 21
704: linear_velocity - 21
705: VisibleOnScreenEnabler2D - 21
706: Occluder3D - 21
707: agent - 21
708: ShapeType - 21
709: layers - 21
710: set_target_node - 21
711: flip_v - 21
712: flip_h - 21
713: angular_velocity - 21
714: Light3D.Param - 21
715: frames - 21
716: VisualShaderNodeVectorOp - 21
717: get_target_node - 21
718: BaseMaterial3D.TextureParam - 20
719: Third-party Licenses - 20
720: loop - 20
721: SyntaxHighlighter - 20
722: EditorSelection - 20
723: BlendFactor - 20
724: get_mesh - 20
725: VisualShaderNodeColorOp - 20
726: XRController3D - 20
727: Donors - 20
728: rotation - 20
729: default_value_enabled - 20
730: physics/3d/physics_engine - 20
731: RenderingServer.LightParam - 20
732: BackBufferCopy - 20
733: StretchMode - 20
734: text_direction - 20
735: active - 20
736: HSlider - 20
737: WebRTCDataChannelExtension - 20
738: physics/2d/physics_engine - 20
739: EditorResourcePreview - 20
740: set_param_x - 20
741: get_param_x - 20
742: get_param_y - 20
743: flag - 20
744: LightParam - 20
745: set_param_y - 20
746: set_param_z - 20
747: License - 20
748: popup_hide - 20
749: VisualShaderNodeBillboard - 20
750: get_param_z - 20
751: _vp_unhandled_key_input20870857097 - 20
752: Authors - 20
753: CapsuleShape3D - 20
754: set_transform - 19
755: AudioStreamGeneratorPlayback - 19
756: Local Projects - 19
757: ArrayCustomFormat - 19
758: get_function - 19
759: CallMode - 19
760: DisplayServer.CursorShape - 19
761: EditorStyles - 19
762: AudioEffect - 19
763: layer_id - 19
764: get_transform - 19
765: VisualShaderNodeTransformOp - 19
766: angular_damp - 19
767: rendering/global_illumination/sdfgi/frames_to_update_lights - 19
768: TextureParam - 19
769: linear_damp - 19
770: rendering/global_illumination/sdfgi/frames_to_converge - 19
771: focus - 19
772: CapsuleShape2D - 19
773: Asset Library Projects - 19
774: rendering/global_illumination/voxel_gi/quality - 19
775: set_function - 19
776: layer_index - 19
777: PropertyTweener - 19
778: rendering/global_illumination/sdfgi/probe_ray_count - 19
779: set_mesh - 19
780: PhysicsBody2D - 19
781: set_enabled - 19
782: VisualScriptInputAction - 19
783: OpenXRInteractionProfile - 18
784: torque - 18
785: CSGBox3D - 18
786: VelocityTracker3D - 18
787: CenterContainer - 18
788: emitting - 18
789: VisualScriptYield - 18
790: tab_selected - 18
791: anim - 18
792: EditorInspectorPlugin - 18
793: WorldBoundaryShape2D - 18
794: SpaceParameter - 18
795: CPUParticles2D.Parameter - 18
796: get_margin - 18
797: NavigationObstacle3D - 18
798: HSeparator - 18
799: impulse - 18
800: TAU - 18
801: Input.CursorShape - 18
802: TileSet.CellNeighbor - 18
803: CPUParticles3D.Parameter - 18
804: JointType - 18
805: CSGMesh3D - 18
806: ConcavePolygonShape3D - 18
807: SubViewportContainer - 18
808: oversampling - 18
809: contact_idx - 18
810: margin_left - 18
811: VisualShaderNodeVectorBase - 18
812: Control.LayoutPreset - 18
813: font_selected_color - 18
814: SeparationRayShape2D - 18
815: SeparationRayShape3D - 18
816: memory/limits/multithreaded_server/rid_pool_prealloc - 18
817: coords - 18
818: collision_index - 18
819: CylinderShape3D - 18
820: depth - 18
821: vseparation - 18
822: DisplayServer.Feature - 18
823: font_disabled_color - 18
824: ParticlesMaterial.Parameter - 18
825: BlendMode - 18
826: BoxContainer - 18
827: rendering/environment/volumetric_fog/volume_size - 17
828: VisualShaderNodeColorUniform - 17
829: EditorPaths - 17
830: PhysicsServer3D.G6DOFJointAxisParam - 17
831: Create Folder - 17
832: rendering/camera/depth_of_field/depth_of_field_bokeh_quality - 17
833: rendering/environment/subsurface_scattering/subsurface_scattering_quality - 17
834: rendering/environment/ssao/adaptive_target - 17
835: rendering/environment/volumetric_fog/use_filter - 17
836: source - 17
837: LogicOperation - 17
838: rendering/shadows/directional_shadow/size - 17
839: rendering/environment/glow/upscale_mode - 17
840: is_collide_with_bodies_enabled - 17
841: PanoramaSkyMaterial - 17
842: set_collide_with_areas - 17
843: rendering/shadows/shadows/soft_shadow_quality - 17
844: rendering/occlusion_culling/bvh_build_quality - 17
845: rendering/vulkan/rendering/back_end - 17
846: WorldEnvironment - 17
847: VisualShaderNodeSmoothStep - 17
848: rendering/textures/light_projectors/filter - 17
849: rendering/limits/forward_renderer/threaded_render_minimum_instances - 17
850: rendering/environment/ssao/fadeout_from - 17
851: rendering/limits/spatial_indexer/update_iterations_per_frame - 17
852: VisualShaderNodeBooleanUniform - 17
853: display/mouse_cursor/custom_image - 17
854: internationalization/rendering/text_driver - 17
855: callback - 17
856: rendering/driver/driver_name - 17
857: VisualShaderNodeComment - 17
858: VisualShaderNodeVec3Uniform - 17
859: OverrunBehavior - 17
860: rendering/environment/ssil/fadeout_to - 17
861: rendering/environment/ssil/quality - 17
862: ButtonGroup - 17
863: NavigationObstacle2D - 17
864: is_collide_with_areas_enabled - 17
865: set_margin - 17
866: GPUParticlesAttractorVectorField3D - 17
867: VisualScriptMathConstant - 17
868: rendering/environment/ssao/fadeout_to - 17
869: rendering/anti_aliasing/screen_space_roughness_limiter/amount - 17
870: VisualShaderNodeMix - 17
871: set_width - 17
872: get_shape - 17
873: rendering/shadows/directional_shadow/soft_shadow_quality - 17
874: rendering/environment/volumetric_fog/volume_depth - 17
875: set_shape - 17
876: set_collide_with_bodies - 17
877: rendering/environment/subsurface_scattering/subsurface_scattering_depth_scale - 17
878: rendering/textures/decals/filter - 17
879: Control.CursorShape - 17
880: rendering/limits/cluster_builder/max_clustered_elements - 17
881: rendering/anti_aliasing/screen_space_roughness_limiter/limit - 17
882: rendering/lightmapping/probe_capture/update_speed - 17
883: RenderingDevice.LogicOperation - 17
884: rendering/camera/depth_of_field/depth_of_field_bokeh_shape - 17
885: rendering/environment/ssil/fadeout_from - 17
886: SegmentShape2D - 17
887: rendering/environment/ssao/quality - 17
888: confirmed - 17
889: fixed_size - 17
890: get_op_type - 17
891: GrooveJoint2D - 17
892: rendering/limits/spatial_indexer/threaded_cull_minimum_instances - 17
893: rendering/environment/ssao/blur_passes - 17
894: VisualShaderNodeTransformUniform - 17
895: text_submitted - 17
896: set_op_type - 17
897: RDPipelineSpecializationConstant - 17
898: rendering/environment/ssil/blur_passes - 17
899: EmitFlags - 17
900: rendering/environment/screen_space_reflection/roughness_quality - 17
901: set_extents - 17
902: rendering/environment/subsurface_scattering/subsurface_scattering_scale - 17
903: QuadMesh - 17
904: get_extents - 17
905: VisualShaderNodeVarying - 17
906: rendering/environment/ssil/adaptive_target - 17
907: mix - 17
908: VisibleOnScreenNotifier2D - 17
909: AudioEffectRecord - 17
910: rendering/limits/time/time_rollover_secs - 17
911: menu_root - 17
912: AnimationNodeAnimation - 17
913: OpenXRIPBinding - 16
914: StyleBoxEmpty - 16
915: rendering/batching/precision/uv_contract_amount - 16
916: xr/openxr/form_factor - 16
917: OmniLight3D - 16
918: debug/shapes/collision/max_contacts_displayed - 16
919: playing - 16
920: display/window/stretch/aspect - 16
921: display/window/size/viewport_height - 16
922: rendering/textures/canvas_textures/default_texture_repeat - 16
923: debug/settings/visual_script/max_call_stack - 16
924: UpdateMode - 16
925: gui/theme/default_font_hinting - 16
926: rendering/batching/parameters/colored_vertex_format_threshold - 16
927: network/limits/debugger/max_warnings_per_second - 16
928: network/limits/webrtc/max_channel_in_buffer_kb - 16
929: xr/openxr/view_configuration - 16
930: debug/file_logging/max_log_files - 16
931: rendering/environment/defaults/default_environment - 16
932: set_language - 16
933: application/run/low_processor_mode_sleep_usec - 16
934: PhysicsServer3D.AreaParameter - 16
935: rendering/2d/opengl/batching_send_null - 16
936: gui/theme/default_font_antialiased - 16
937: rendering/2d/sdf/scale - 16
938: gui/theme/default_theme_scale - 16
939: rendering/textures/lossless_compression/webp_compression_level - 16
940: physics/common/physics_ticks_per_second - 16
941: rendering/2d/opengl/legacy_orphan_buffers - 16
942: debug/settings/fps/force_fps - 16
943: display/window/stretch/shrink - 16
944: network/limits/debugger/max_chars_per_second - 16
945: rendering/batching/parameters/batch_buffer_size - 16
946: icon - 16
947: display/window/size/window_width_override - 16
948: surface - 16
949: CellNeighbor - 16
950: PinJoint3D - 16
951: network/remote_fs/page_size - 16
952: rendering/batching/lights/max_join_items - 16
953: RenderingDevice.ShaderStage - 16
954: application/config/icon - 16
955: rendering/batching/lights/scissor_area_threshold - 16
956: rendering/2d/sdf/oversize - 16
957: network/limits/debugger/max_queued_messages - 16
958: gui/theme/default_font_subpixel_positioning - 16
959: rendering/shadows/shadow_atlas/quadrant_1_subdiv - 16
960: LayoutPreset - 16
961: rendering/batching/parameters/max_join_item_commands - 16
962: physics/3d/solver/solver_iterations - 16
963: rendering/2d/opengl/legacy_stream - 16
964: rendering/shadows/shadow_atlas/quadrant_2_subdiv - 16
965: get_language - 16
966: physics/3d/default_linear_damp - 16
967: physics/3d/time_before_sleep - 16
968: rendering/textures/canvas_textures/default_texture_filter - 16
969: SCREEN_TEXTURE - 16
970: EditorSceneFormatImporter - 16
971: physics/3d/solver/contact_recycle_radius - 16
972: physics/3d/default_angular_damp - 16
973: network/limits/debugger/max_errors_per_second - 16
974: gui/theme/custom_font - 16
975: rendering/batching/parameters/item_reordering_lookahead - 16
976: physics/3d/solver/contact_max_separation - 16
977: internationalization/locale/fallback - 16
978: application/config/macos_native_icon - 16
979: VisualShaderNodeSwitch - 16
980: memory/limits/message_queue/max_size_kb - 16
981: G6DOFJointAxisParam - 16
982: physics/3d/solver/contact_max_allowed_penetration - 16
983: rendering/anti_aliasing/quality/screen_space_aa - 16
984: rendering/2d/options/ninepatch_mode - 16
985: gui/timers/text_edit_idle_detect_sec - 16
986: terrain_set - 16
987: application/config/windows_native_icon - 16
988: xr/openxr/reference_space - 16
989: gui/timers/incremental_search_max_interval_msec - 16
990: input_devices/pen_tablet/driver.windows - 16
991: rendering/shadows/shadow_atlas/quadrant_3_subdiv - 16
992: rendering/mesh_lod/lod_change/threshold_pixels - 16
993: rendering/anti_aliasing/quality/msaa - 16
994: rendering/shadows/shadow_atlas/quadrant_0_subdiv - 16
995: rendering/shadows/shadow_atlas/size - 16
996: audio/buses/channel_disable_time - 16
997: application/boot_splash/image - 16
998: AudioListener3D - 16
999: editor/node_naming/name_num_separator - 16
1000: UV - 16
1001: debug/settings/gdscript/max_call_stack - 16
1002: display/window/stretch/mode - 16
1003: Control.TextDirection - 16
1004: display/window/size/window_height_override - 16
1005: network/remote_fs/page_read_ahead - 16
1006: GridContainer - 16
1007: rendering/2d/opengl/batching_stream - 16
1008: damping - 16
1009: display/window/size/viewport_width - 16
1010: gui/common/text_edit_undo_stack_max_size - 16
1011: physics/3d/solver/default_contact_bias - 16
1012: xr/openxr/default_action_map - 16
1013: application/run/frame_delay_msec - 16
1014: gui/theme/custom - 16
1015: VisualScriptDeconstruct - 15
1016: VisualScriptConstructor - 15
1017: VisualShaderNodeTransformVecMult - 15
1018: Source - 15
1019: VisualShaderNodeClamp - 15
1020: interface/theme/base_color - 15
1021: bus - 15
1022: autoplay - 15
1023: /home/hugo - 15
1024: rings - 15
1025: physics_material_override - 15
1026: ScriptEditorBase - 15
1027: VisualScriptConstant - 15
1028: VisualScriptLocalVarSet - 15
1029: speed_scale - 15
1030: grabber - 15
1031: cull_mask - 15
1032: VSlider - 15
1033: collision_layer - 15
1034: CSGPrimitive3D - 15
1035: EditorImportPlugin - 15
1036: VisualShaderNodeStep - 15
1037: motion - 15
1038: VisualScriptReturn - 15
1039: VisualShaderNodeVec2Uniform - 15
1040: volume_db - 15
1041: internationalization/rendering/force_right_to_left_layout_direction - 15
1042: item_count - 15
1043: VisualScriptLocalVar - 15
1044: transpose - 15
1045: center_of_mass - 15
1046: VisualScriptBasicTypeConstant - 15
1047: one_shot - 15
1048: VisualShaderNodeIntFunc - 15
1049: InstanceType - 15
1050: VisualScriptTypeCast - 15
1051: set_text - 15
1052: VisualShaderNodeUniformRef - 15
1053: DrawOrder - 15
1054: VisualScriptClassConstant - 15
1055: / - 15
1056: Resolution - 15
1057: sync - 15
1058: VisibleOnScreenNotifier3D - 15
1059: VisualScriptOperator - 15
1060: editable - 15
1061: smooth_faces - 15
1062: animation - 15
1063: AudioStreamGenerator - 15
1064: msdf_size - 14
1065: VSeparator - 14
1066: read_only - 14
1067: rendering/shadows/directional_shadow/16_bits - 14
1068: degrees - 14
1069: get_text_direction - 14
1070: debug/file_logging/enable_file_logging - 14
1071: rendering/environment/glow/use_high_quality - 14
1072: rendering/shader_compiler/shader_cache/strip_debug - 14
1073: get_gravity - 14
1074: rendering/reflections/sky_reflections/texture_array_reflections - 14
1075: base_script - 14
1076: VisualShaderNodeInput - 14
1077: fract - 14
1078: checked - 14
1079: rendering/anti_aliasing/screen_space_roughness_limiter/enabled - 14
1080: rendering/reflections/sky_reflections/roughness_layers - 14
1081: subpixel_positioning - 14
1082: rendering/camera/depth_of_field/depth_of_field_use_jitter - 14
1083: radians - 14
1084: debug/settings/stdout/print_fps - 14
1085: interface/theme/accent_color - 14
1086: id_focused - 14
1087: _data - 14
1088: get_constant - 14
1089: index_pressed - 14
1090: ALBEDO - 14
1091: interface/theme/contrast - 14
1092: node_path - 14
1093: vertices - 14
1094: msdf_pixel_range - 14
1095: pitch_scale - 14
1096: RenderingDevice.StencilOperation - 14
1097: rendering/global_illumination/gi/use_half_resolution - 14
1098: HSplitContainer - 14
1099: rendering/reflections/sky_reflections/ggx_samples - 14
1100: rendering/reflections/reflection_atlas/reflection_count - 14
1101: rendering/occlusion_culling/occlusion_rays_per_thread - 14
1102: blend_mode - 14
1103: font_hover_color - 14
1104: rendering/shader_compiler/shader_cache/use_zstd_compression - 14
1105: camera - 14
1106: set_constant - 14
1107: rendering/shading/overrides/force_lambert_over_burley - 14
1108: rendering/reflections/reflection_atlas/reflection_size - 14
1109: audio/driver/output_latency - 14
1110: shader - 14
1111: rendering/shader_compiler/shader_cache/compress - 14
1112: debug/settings/stdout/verbose_stdout - 14
1113: rendering/environment/ssil/half_size - 14
1114: rendering/reflections/sky_reflections/fast_filter_high_quality - 14
1115: intensity - 14
1116: rendering/environment/ssao/half_size - 14
1117: set_gravity - 14
1118: input_devices/pen_tablet/driver - 14
1119: PeerStatistic - 14
1120: hinting - 14
1121: xr/shaders/enabled - 14
1122: force_autohinter - 14
1123: structured_text_bidi_override_options - 14
1124: audio/driver/mix_rate - 14
1125: ParticleFlags - 14
1126: set_text_direction - 14
1127: rendering/shader_compiler/shader_cache/enabled - 14
1128: EditorHelp - 14
1129: RenderingServer.InstanceType - 14
1130: audio/driver/driver - 14
1131: Tween.TransitionType - 14
1132: structured_text_bidi_override - 14
1133: basic_type - 14
1134: rendering/2d/shadow_atlas/size - 14
1135: BaseMaterial3D.Feature - 14
1136: debug/settings/stdout/print_gpu_profile - 14
1137: Result - 14
1138: ImageTextureLayered - 14
1139: set_mode - 14
1140: ENetPacketPeer.PeerStatistic - 14
1141: rendering/limits/global_shader_variables/buffer_size - 14
1142: get_text - 14
1143: debug/gdscript/warnings/function_used_as_property - 13
1144: rendering/batching/debug/flash_batching - 13
1145: RenderingDevice.DriverResource - 13
1146: physics/3d/default_gravity_vector - 13
1147: layer_names/3d_render/layer_12 - 13
1148: debug/file_logging/enable_file_logging.pc - 13
1149: get_default_value - 13
1150: internationalization/pseudolocalization/skip_placeholders - 13
1151: debug/gdscript/warnings/constant_used_as_function - 13
1152: display/window/ios/hide_home_indicator - 13
1153: layer_names/3d_render/layer_13 - 13
1154: rendering/shading/overrides/force_vertex_shading.mobile - 13
1155: navigation/3d/default_cell_size - 13
1156: debug/gdscript/warnings/narrowing_conversion - 13
1157: debug/shapes/navigation/geometry_color - 13
1158: aabb - 13
1159: Mesh.ArrayType - 13
1160: internationalization/pseudolocalization/prefix - 13
1161: text_editor/theme/highlighting/selection_color - 13
1162: layer_names/3d_render/layer_14 - 13
1163: Remove - 13
1164: application/boot_splash/bg_color - 13
1165: rendering/lightmapping/bake_quality/high_quality_ray_count - 13
1166: debug/gdscript/warnings/unreachable_pattern - 13
1167: internationalization/pseudolocalization/replace_with_accents - 13
1168: rendering/batching/options/use_batching_in_editor - 13
1169: layer_names/2d_render/layer_9 - 13
1170: rendering/batching/precision/uv_contract - 13
1171: debug/gdscript/warnings/unused_variable - 13
1172: rendering/textures/vram_compression/import_s3tc - 13
1173: display/window/dpi/allow_hidpi - 13
1174: VSplitContainer - 13
1175: set_base_type - 13
1176: debug/gdscript/warnings/standalone_expression - 13
1177: debug/gdscript/warnings/unreachable_code - 13
1178: text_editor/theme/highlighting/brace_mismatch_color - 13
1179: VisualShaderNodeSample3D - 13
1180: debug/gdscript/warnings/standalone_ternary - 13
1181: application/boot_splash/fullsize - 13
1182: display/window/size/fullscreen - 13
1183: rendering/shadows/directional_shadow/size.mobile - 13
1184: debug/gdscript/warnings/redundant_await - 13
1185: get_operator - 13
1186: debug/gdscript/warnings/void_assignment - 13
1187: internationalization/locale/include_text_server_data - 13
1188: text_editor/theme/highlighting/completion_selected_color - 13
1189: layer_names/3d_render/layer_11 - 13
1190: layer_names/2d_render/layer_1 - 13
1191: layer_names/2d_render/layer_2 - 13
1192: layer_names/2d_render/layer_3 - 13
1193: layer_names/3d_render/layer_10 - 13
1194: rendering/lightmapping/bake_performance/region_size - 13
1195: text_editor/theme/highlighting/search_result_color - 13
1196: text_editor/theme/highlighting/text_selected_color - 13
1197: layer_names/2d_render/layer_4 - 13
1198: layer_names/2d_render/layer_5 - 13
1199: layer_names/2d_render/layer_6 - 13
1200: layer_names/2d_render/layer_7 - 13
1201: AudioEffectEQ - 13
1202: HTTPRequest.Result - 13
1203: layer_names/2d_render/layer_8 - 13
1204: gui/fonts/dynamic_fonts/use_oversampling - 13
1205: layer_names/2d_physics/layer_22 - 13
1206: layer_names/2d_physics/layer_21 - 13
1207: layer_names/2d_physics/layer_20 - 13
1208: layer_names/2d_physics/layer_19 - 13
1209: rendering/shader_compiler/shader_cache/strip_debug.release - 13
1210: physics/3d/default_gravity - 13
1211: text_editor/theme/highlighting/completion_existing_color - 13
1212: layer_names/2d_physics/layer_18 - 13
1213: text_editor/theme/highlighting/line_number_color - 13
1214: rendering/shadows/shadow_atlas/size.mobile - 13
1215: rendering/reflections/sky_reflections/ggx_samples.mobile - 13
1216: layer_names/2d_physics/layer_17 - 13
1217: layer_names/2d_physics/layer_16 - 13
1218: EditorInspector - 13
1219: rendering/gles2/compatibility/enable_high_float.Android - 13
1220: EditorPlugin.CustomControlContainer - 13
1221: layer_names/2d_physics/layer_15 - 13
1222: layer_names/2d_physics/layer_14 - 13
1223: layer_names/2d_physics/layer_13 - 13
1224: debug/gdscript/warnings/integer_division - 13
1225: text_editor/theme/highlighting/breakpoint_color - 13
1226: rendering/lightmapping/bake_performance/max_rays_per_pass - 13
1227: physics/3d/sleep_threshold_linear - 13
1228: radial_segments - 13
1229: text_editor/theme/highlighting/text_color - 13
1230: physics/common/enable_object_picking - 13
1231: FFTSize - 13
1232: layer_names/2d_physics/layer_32 - 13
1233: layer_names/2d_physics/layer_31 - 13
1234: layer_names/2d_physics/layer_30 - 13
1235: layer_names/2d_physics/layer_29 - 13
1236: layer_names/2d_physics/layer_28 - 13
1237: layer_names/2d_physics/layer_27 - 13
1238: layer_names/2d_physics/layer_26 - 13
1239: layer_names/2d_physics/layer_25 - 13
1240: debug/shapes/collision/draw_2d_outlines - 13
1241: layer_names/2d_physics/layer_24 - 13
1242: layer_names/2d_physics/layer_23 - 13
1243: layer_names/3d_render/layer_19 - 13
1244: layer_names/3d_render/layer_18 - 13
1245: layer_names/3d_render/layer_17 - 13
1246: rendering/shadows/shadows/soft_shadow_quality.mobile - 13
1247: DriverResource - 13
1248: debug/gdscript/warnings/assert_always_true - 13
1249: audio/driver/enable_input - 13
1250: rendering/lightmapping/bake_quality/low_quality_probe_ray_count - 13
1251: Theme.DataType - 13
1252: rendering/batching/options/single_rect_fallback - 13
1253: debug/gdscript/warnings/unused_private_class_variable - 13
1254: layer_names/3d_render/layer_16 - 13
1255: Control.StructuredTextParser - 13
1256: decrement - 13
1257: layer_names/3d_render/layer_15 - 13
1258: text_editor/theme/highlighting/line_length_guideline_color - 13
1259: rendering/lightmapping/bake_quality/ultra_quality_probe_ray_count - 13
1260: internationalization/locale/test - 13
1261: text_editor/theme/highlighting/completion_font_color - 13
1262: layer_names/2d_physics/layer_12 - 13
1263: VisualShaderNodeVectorOp.Operator - 13
1264: layer_names/2d_physics/layer_11 - 13
1265: layer_names/2d_physics/layer_10 - 13
1266: internationalization/pseudolocalization/use_pseudolocalization - 13
1267: stiffness - 13
1268: sleeping - 13
1269: debug/gdscript/warnings/unused_parameter - 13
1270: internationalization/pseudolocalization/double_vowels - 13
1271: application/config/quit_on_go_back - 13
1272: display/window/size/borderless - 13
1273: rendering/shading/overrides/force_vertex_shading - 13
1274: rendering/2d/snap/snap_2d_vertices_to_pixel - 13
1275: display/window/size/resizable - 13
1276: layer_names/3d_render/layer_20 - 13
1277: text_editor/theme/highlighting/background_color - 13
1278: rendering/batching/options/use_batching - 13
1279: debug/gdscript/warnings/unsafe_call_argument - 13
1280: debug/gdscript/warnings/property_used_as_function - 13
1281: rendering/textures/vram_compression/import_etc2 - 13
1282: rendering/lightmapping/bake_performance/max_rays_per_probe_pass - 13
1283: layer_names/2d_physics/layer_3 - 13
1284: layer_names/2d_physics/layer_2 - 13
1285: layer_names/2d_physics/layer_1 - 13
1286: rendering/textures/vram_compression/import_bptc - 13
1287: debug/gdscript/warnings/shadowed_variable_base_class - 13
1288: layer_names/2d_navigation/layer_9 - 13
1289: layer_names/2d_navigation/layer_8 - 13
1290: layer_names/2d_navigation/layer_7 - 13
1291: layer_names/2d_navigation/layer_6 - 13
1292: layer_names/2d_navigation/layer_5 - 13
1293: layer_names/2d_navigation/layer_4 - 13
1294: layer_names/2d_navigation/layer_3 - 13
1295: layer_names/2d_navigation/layer_2 - 13
1296: layer_names/2d_navigation/layer_1 - 13
1297: rendering/vulkan/rendering/back_end.mobile - 13
1298: display/mouse_cursor/custom_image_hotspot - 13
1299: layer_names/3d_navigation/layer_10 - 13
1300: debug/gdscript/warnings/assert_always_false - 13
1301: layer_names/3d_navigation/layer_11 - 13
1302: layer_names/3d_navigation/layer_12 - 13
1303: layer_names/3d_navigation/layer_13 - 13
1304: layer_names/3d_physics/layer_16 - 13
1305: layer_names/3d_physics/layer_15 - 13
1306: layer_names/3d_physics/layer_14 - 13
1307: rendering/environment/ssao/half_size.mobile - 13
1308: layer_names/3d_physics/layer_13 - 13
1309: layer_names/3d_physics/layer_12 - 13
1310: layer_names/3d_physics/layer_11 - 13
1311: layer_names/3d_physics/layer_10 - 13
1312: font_focus_color - 13
1313: physics/3d/sleep_threshold_angular - 13
1314: internationalization/pseudolocalization/override - 13
1315: rendering/shadows/directional_shadow/soft_shadow_quality.mobile - 13
1316: display/window/subwindows/embed_subwindows - 13
1317: input_devices/buffering/agile_event_flushing - 13
1318: layer_names/2d_physics/layer_9 - 13
1319: layer_names/2d_physics/layer_8 - 13
1320: layer_names/2d_physics/layer_7 - 13
1321: layer_names/2d_physics/layer_6 - 13
1322: layer_names/2d_physics/layer_5 - 13
1323: rendering/shadows/shadow_atlas/16_bits - 13
1324: application/run/main_loop_type - 13
1325: layer_names/2d_physics/layer_4 - 13
1326: layer_names/3d_navigation/layer_32 - 13
1327: text_editor/theme/highlighting/word_highlighted_color - 13
1328: rendering/lightmapping/bake_quality/ultra_quality_ray_count - 13
1329: rendering/gles2/compatibility/disable_half_float - 13
1330: debug/file_logging/log_path - 13
1331: layer_names/3d_navigation/layer_9 - 13
1332: debug/gdscript/warnings/unused_local_constant - 13
1333: layer_names/3d_navigation/layer_8 - 13
1334: layer_names/3d_navigation/layer_7 - 13
1335: text_editor/theme/highlighting/caret_color - 13
1336: layer_names/3d_navigation/layer_6 - 13
1337: layer_names/3d_navigation/layer_5 - 13
1338: debug/gdscript/warnings/empty_file - 13
1339: layer_names/3d_navigation/layer_4 - 13
1340: gui/common/swap_cancel_ok - 13
1341: application/boot_splash/show_image - 13
1342: layer_names/3d_navigation/layer_3 - 13
1343: layer_names/3d_navigation/layer_2 - 13
1344: debug/gdscript/warnings/shadowed_variable - 13
1345: layer_names/3d_navigation/layer_1 - 13
1346: debug/gdscript/warnings/int_assigned_to_enum - 13
1347: rid - 13
1348: layer_names/3d_navigation/layer_14 - 13
1349: layer_names/3d_navigation/layer_15 - 13
1350: layer_names/3d_navigation/layer_16 - 13
1351: layer_names/3d_navigation/layer_17 - 13
1352: layer_names/3d_navigation/layer_18 - 13
1353: layer_names/3d_navigation/layer_19 - 13
1354: layer_names/3d_navigation/layer_20 - 13
1355: layer_names/3d_navigation/layer_21 - 13
1356: rendering/environment/glow/upscale_mode.mobile - 13
1357: layer_names/3d_navigation/layer_22 - 13
1358: layer_names/3d_navigation/layer_23 - 13
1359: layer_names/3d_navigation/layer_24 - 13
1360: description - 13
1361: layer_names/3d_navigation/layer_25 - 13
1362: rendering/batching/debug/diagnose_frame - 13
1363: layer_names/3d_navigation/layer_26 - 13
1364: text_editor/theme/highlighting/completion_background_color - 13
1365: layer_names/3d_navigation/layer_27 - 13
1366: layer_names/3d_navigation/layer_28 - 13
1367: layer_names/3d_navigation/layer_29 - 13
1368: application/boot_splash/use_filter - 13
1369: layer_names/3d_navigation/layer_30 - 13
1370: layer_names/3d_navigation/layer_31 - 13
1371: input_devices/pointing/ios/touch_delay - 13
1372: layer_names/2d_navigation/layer_32 - 13
1373: layer_names/2d_navigation/layer_31 - 13
1374: layer_names/2d_navigation/layer_30 - 13
1375: layer_names/2d_navigation/layer_29 - 13
1376: layer_names/2d_navigation/layer_28 - 13
1377: layer_names/2d_navigation/layer_27 - 13
1378: debug/gdscript/warnings/shadowed_global_identifier - 13
1379: layer_names/2d_navigation/layer_26 - 13
1380: layer_names/2d_navigation/layer_25 - 13
1381: is_default_value_enabled - 13
1382: layer_names/2d_navigation/layer_24 - 13
1383: layer_names/2d_navigation/layer_23 - 13
1384: internationalization/pseudolocalization/suffix - 13
1385: increment - 13
1386: layer_names/2d_navigation/layer_22 - 13
1387: layer_names/2d_navigation/layer_21 - 13
1388: layer_names/2d_navigation/layer_20 - 13
1389: set_default_value - 13
1390: debug/gdscript/warnings/treat_warnings_as_errors - 13
1391: layer_names/2d_navigation/layer_19 - 13
1392: layer_names/2d_navigation/layer_18 - 13
1393: rendering/textures/lossless_compression/force_png - 13
1394: rendering/occlusion_culling/use_occlusion_culling - 13
1395: internationalization/pseudolocalization/expansion_ratio - 13
1396: ConvexPolygonShape2D - 13
1397: rendering/lightmapping/bake_quality/low_quality_ray_count - 13
1398: rendering/lightmapping/bake_quality/medium_quality_ray_count - 13
1399: layer_names/2d_render/layer_10 - 13
1400: layer_names/2d_render/layer_11 - 13
1401: rendering/textures/vram_compression/import_etc - 13
1402: layer_names/2d_render/layer_12 - 13
1403: layer_names/2d_render/layer_13 - 13
1404: layer_names/2d_render/layer_14 - 13
1405: layer_names/2d_render/layer_15 - 13
1406: layer_names/2d_render/layer_16 - 13
1407: layer_names/2d_render/layer_17 - 13
1408: layer_names/2d_render/layer_18 - 13
1409: layer_names/2d_render/layer_19 - 13
1410: hover - 13
1411: display/mouse_cursor/tooltip_position_offset - 13
1412: layer_names/2d_render/layer_20 - 13
1413: internationalization/pseudolocalization/fake_bidi - 13
1414: text_editor/theme/highlighting/current_line_color - 13
1415: debug/shapes/navigation/disabled_geometry_color - 13
1416: rendering/shading/overrides/force_lambert_over_burley.mobile - 13
1417: WebRTCPeerConnectionExtension - 13
1418: layer_names/3d_physics/layer_32 - 13
1419: layer_names/3d_physics/layer_31 - 13
1420: layer_names/3d_physics/layer_30 - 13
1421: debug/gdscript/warnings/unsafe_property_access - 13
1422: layer_names/3d_physics/layer_29 - 13
1423: layer_names/3d_physics/layer_28 - 13
1424: layer_names/3d_physics/layer_27 - 13
1425: layer_names/3d_physics/layer_26 - 13
1426: display/window/size/always_on_top - 13
1427: layer_names/3d_physics/layer_25 - 13
1428: layer_names/3d_physics/layer_24 - 13
1429: layer_names/3d_physics/layer_23 - 13
1430: interface/editor/enable_debugging_pseudolocalization - 13
1431: rendering/reflections/sky_reflections/texture_array_reflections.mobile - 13
1432: layer_names/3d_physics/layer_22 - 13
1433: layer_names/3d_physics/layer_21 - 13
1434: layer_names/3d_physics/layer_20 - 13
1435: layer_names/3d_physics/layer_19 - 13
1436: layer_names/3d_physics/layer_18 - 13
1437: layer_names/3d_physics/layer_17 - 13
1438: layer_names/2d_navigation/layer_17 - 13
1439: layer_names/2d_navigation/layer_16 - 13
1440: layer_names/2d_navigation/layer_15 - 13
1441: layer_names/2d_navigation/layer_14 - 13
1442: rendering/anti_aliasing/quality/use_debanding - 13
1443: layer_names/2d_navigation/layer_13 - 13
1444: layer_names/2d_navigation/layer_12 - 13
1445: layer_names/2d_navigation/layer_11 - 13
1446: layer_names/2d_navigation/layer_10 - 13
1447: probe - 13
1448: get_polygon - 13
1449: debug/gdscript/warnings/exclude_addons - 13
1450: application/run/low_processor_mode - 13
1451: set_default_value_enabled - 13
1452: debug/gdscript/warnings/return_value_discarded - 13
1453: audio/buses/channel_disable_threshold_db - 13
1454: audio/driver/output_latency.web - 13
1455: voxel_gi - 13
1456: rendering/lightmapping/bake_quality/high_quality_probe_ray_count - 13
1457: rendering/lightmapping/bake_quality/medium_quality_probe_ray_count - 13
1458: parameters - 13
1459: rendering/2d/options/use_software_skinning - 13
1460: gui/common/snap_controls_to_pixels - 13
1461: layer_names/3d_render/layer_4 - 13
1462: layer_names/3d_render/layer_5 - 13
1463: layer_names/3d_render/layer_6 - 13
1464: layer_names/3d_render/layer_7 - 13
1465: layer_names/3d_render/layer_8 - 13
1466: layer_names/3d_render/layer_9 - 13
1467: skin - 13
1468: Expression - 13
1469: RenderingServer.ArrayType - 13
1470: text_editor/theme/highlighting/code_folding_color - 13
1471: application/config/auto_accept_quit - 13
1472: occluder - 13
1473: VisualShaderNodeIntOp.Operator - 13
1474: debug/gdscript/warnings/unused_signal - 13
1475: physics/common/physics_jitter_fix - 13
1476: input_devices/pointing/emulate_mouse_from_touch - 13
1477: get_base_type - 13
1478: debug/gdscript/warnings/incompatible_ternary - 13
1479: layer_names/3d_physics/layer_9 - 13
1480: layer_names/3d_physics/layer_8 - 13
1481: rendering/driver/depth_prepass/enable - 13
1482: debug/gdscript/warnings/enable - 13
1483: debug/shapes/collision/shape_color - 13
1484: set_operator - 13
1485: debug/gdscript/warnings/deprecated_keyword - 13
1486: navigation/3d/default_edge_connection_margin - 13
1487: audio/driver/mix_rate.web - 13
1488: debug/gdscript/warnings/unassigned_variable - 13
1489: audio/video/video_delay_compensation_ms - 13
1490: rendering/reflections/reflection_atlas/reflection_size.mobile - 13
1491: rendering/2d/snap/snap_2d_transforms_to_pixel - 13
1492: debug/gdscript/warnings/unsafe_cast - 13
1493: debug/gdscript/warnings/unassigned_variable_op_assign - 13
1494: screen - 13
1495: VisualShaderNodeParticleEmit - 13
1496: debug/shapes/collision/contact_color - 13
1497: debug/gdscript/warnings/unsafe_method_access - 13
1498: layer_names/3d_render/layer_1 - 13
1499: layer_names/3d_render/layer_2 - 13
1500: layer_names/3d_render/layer_3 - 13
1501: layer_names/3d_physics/layer_7 - 13
1502: layer_names/3d_physics/layer_6 - 13
1503: layer_names/3d_physics/layer_1 - 13
1504: layer_names/3d_physics/layer_2 - 13
1505: layer_names/3d_physics/layer_3 - 13
1506: layer_names/3d_physics/layer_5 - 13
1507: snap - 13
1508: input_devices/pointing/emulate_touch_from_mouse - 13
1509: xr/openxr/enabled - 13
1510: layer_names/3d_physics/layer_4 - 13
1511: style_name - 12
1512: text_editor/theme/highlighting/function_color - 12
1513: interface/editor/main_font_bold - 12
1514: colors - 12
1515: GPUParticlesCollision3D - 12
1516: selected - 12
1517: text_editor/theme/highlighting/member_variable_color - 12
1518: Path3D - 12
1519: embolden - 12
1520: VisualShaderNodeMultiplyAdd - 12
1521: ArrayOccluder3D - 12
1522: fog - 12
1523: randomness - 12
1524: arrow - 12
1525: RenderingDevice.TextureSamples - 12
1526: RenderingDevice.RenderPrimitive - 12
1527: PrimitiveType - 12
1528: CompressedTexture2D - 12
1529: text_editor/theme/highlighting/symbol_color - 12
1530: RenderingDevice.CompareOperator - 12
1531: renamed - 12
1532: VisualShaderNodeParticleAccelerator - 12
1533: text_editor/theme/highlighting/user_type_color - 12
1534: environment - 12
1535: lifetime - 12
1536: interface/editor/main_font - 12
1537: project_manager/sorting_order - 12
1538: Texture - 12
1539: text_editor/theme/highlighting/engine_type_color - 12
1540: PhysicsServer2D.AreaParameter - 12
1541: spread - 12
1542: CompressedTextureLayered - 12
1543: text_editor/theme/highlighting/completion_scroll_color - 12
1544: text_editor/theme/highlighting/bookmark_color - 12
1545: text_editor/theme/highlighting/string_color - 12
1546: network/debug/remote_host - 12
1547: max_distance - 12
1548: text_editor/help/help_font_size - 12
1549: PhysicsServer2D.BodyParameter - 12
1550: textureLod - 12
1551: AlignmentMode - 12
1552: text_editor/theme/highlighting/executing_line_color - 12
1553: PhysicsServer3D.BodyParameter - 12
1554: VisualScriptFunctionState - 12
1555: interface/editor/code_font - 12
1556: text_editor/theme/highlighting/control_flow_keyword_color - 12
1557: multichannel_signed_distance_field - 12
1558: image - 12
1559: text_editor/theme/highlighting/keyword_color - 12
1560: CustomControlContainer - 12
1561: RenderPrimitive - 12
1562: VisualShaderNodeParticleRandomness - 12
1563: surf_idx - 12
1564: text_editor/theme/highlighting/base_type_color - 12
1565: text_editor/theme/highlighting/search_result_border_color - 12
1566: font_name - 12
1567: close - 12
1568: interface/editor/editor_language - 12
1569: set_feature - 12
1570: text_editor/help/help_source_font_size - 12
1571: get_feature - 12
1572: AudioListener2D - 12
1573: set_length - 12
1574: Generic6DOFJoint3D.Flag - 12
1575: text_editor/theme/highlighting/number_color - 12
1576: interface/theme/preset - 12
1577: VisualShaderNodeResizableBase - 12
1578: text_editor/theme/highlighting/safe_line_number_color - 12
1579: opentype_feature_overrides - 12
1580: text_editor/theme/highlighting/comment_color - 12
1581: filesystem/directories/default_project_path - 12
1582: set_speed_scale - 12
1583: orientation - 12
1584: _repaint - 12
1585: text_editor/theme/highlighting/mark_color - 12
1586: font_style - 12
1587: interface/editor/code_font_size - 12
1588: VisualShaderNodeParticleEmitter - 12
1589: VisualScriptPropertySet.AssignOp - 11
1590: interface/editor/font_subpixel_positioning - 11
1591: get_speed_scale - 11
1592: font_pressed_color - 11
1593: voice_idx - 11
1594: set_param_texture - 11
1595: is_disabled - 11
1596: _tab_name - 11
1597: get_angular_velocity - 11
1598: region_rect - 11
1599: quality - 11
1600: VisualShaderNodeExpression - 11
1601: texture_repeat - 11
1602: from_node - 11
1603: set_flip_h - 11
1604: set_flip_v - 11
1605: v_offset - 11
1606: ConvexPolygonShape3D - 11
1607: max_speed - 11
1608: filesystem/file_dialog/thumbnail_size - 11
1609: up_direction - 11
1610: BoxShape3D - 11
1611: is_playing - 11
1612: set_polygon - 11
1613: execution_mode - 11
1614: TransitionType - 11
1615: get_param_texture - 11
1616: line_separation - 11
1617: text_editor/theme/highlighting/caret_background_color - 11
1618: interface/theme/relationship_line_opacity - 11
1619: var_name - 11
1620: VisualShaderNodeUVFunc - 11
1621: get_exclude - 11
1622: interface/editor/code_font_custom_variations - 11
1623: VisualShaderNodeTransformFunc - 11
1624: Flag - 11
1625: ScrollBar - 11
1626: set_disabled - 11
1627: DirectionalLight2D - 11
1628: DecalTexture - 11
1629: gravity_scale - 11
1630: VisualShaderNodeColorFunc - 11
1631: set_angular_velocity - 11
1632: is_editable - 11
1633: get_cull_mask - 11
1634: AssignOp - 11
1635: network/ssl/editor_ssl_certificates - 11
1636: explosiveness - 11
1637: h_offset - 11
1638: get_linear_velocity - 11
1639: texture_type - 11
1640: SCREEN_UV - 11
1641: set_exclude - 11
1642: polygons - 11
1643: RenderingDevice.UniformType - 11
1644: interface/editor/main_font_size - 11
1645: XROrigin3D - 11
1646: SpaceOverride - 11
1647: to_node - 11
1648: MouseMode - 11
1649: disable - 11
1650: TextServer.SpacingType - 11
1651: texture_filter - 11
1652: AreaSpaceOverrideMode - 11
1653: FileMode - 11
1654: interface/theme/additional_spacing - 11
1655: secs - 11
1656: interface/theme/corner_radius - 11
1657: VisualShaderNodeIs - 11
1658: filesystem/file_dialog/show_hidden_files - 11
1659: filesystem/directories/autoscan_project_path - 11
1660: scenario - 11
1661: from_port - 11
1662: ShaderStage - 11
1663: SphereShape3D - 11
1664: linear_damp_mode - 11
1665: centered - 11
1666: get_step - 11
1667: to_port - 11
1668: SkinReference - 11
1669: interface/theme/icon_and_font_color - 11
1670: set_cull_mask - 11
1671: set_curve - 11
1672: UniformType - 11
1673: fract_delta - 11
1674: ROUGHNESS - 11
1675: /home/hugo/Sync/Blender/hudguns/rocket - 11
1676: get_curve - 11
1677: preprocess - 11
1678: is_enabled - 11
1679: interface/editor/display_scale - 11
1680: GraphemeFlag - 11
1681: text_editor/appearance/whitespace/line_spacing - 11
1682: run/output/font_size - 11
1683: max_polyphony - 11
1684: hit_from_inside - 11
1685: fixed_fps - 11
1686: VisualShaderNodeFloatOp.Operator - 11
1687: VisibleCharactersBehavior - 11
1688: source_from - 11
1689: BodyState - 11
1690: text_editor/theme/color_theme - 11
1691: text_editor/behavior/files/auto_reload_scripts_on_external_change - 11
1692: EditorScript - 11
1693: interface/editor/font_antialiased - 11
1694: RenderingDevice.TextureSwizzle - 11
1695: MultiMeshInstance3D - 11
1696: interface/theme/custom_theme - 11
1697: WorldBoundaryShape3D - 11
1698: set_linear_velocity - 11
1699: interface/theme/icon_saturation - 11
1700: text_overrun_behavior - 11
1701: PolygonOccluder3D - 11
1702: angular_damp_mode - 11
1703: local_coords - 11
1704: interface/theme/border_size - 11
1705: bool - 11
1706: text_editor/help/help_title_font_size - 11
1707: min_value - 11
1708: /mnt/data - 11
1709: interface/editor/font_hinting - 11
1710: draw_order - 11
1711: percent_visible - 10
1712: CircleShape2D - 10
1713: InstancePlaceholder - 10
1714: run/window_placement/screen - 10
1715: resolution - 10
1716: DisableMode - 10
1717: editors/3d/navigation/navigation_scheme - 10
1718: editors/3d/navigation_feel/zoom_inertia - 10
1719: editors/2d/bone_selected_color - 10
1720: editors/animation/confirm_insert_track - 10
1721: VisualShaderNodeTransformOp.Operator - 10
1722: text_editor/appearance/guidelines/line_length_guideline_hard_column - 10
1723: docks/filesystem/always_show_folders - 10
1724: interface/editor/show_internal_errors_in_toast_notifications - 10
1725: max_value - 10
1726: editors/3d/primary_grid_steps - 10
1727: editors/3d/navigation/zoom_modifier - 10
1728: run/output/always_open_output_on_play - 10
1729: editors/animation/onion_layers_past_color - 10
1730: UPNPDevice.IGDStatus - 10
1731: text_editor/behavior/navigation/scroll_past_end_of_file - 10
1732: editors/panning/simple_panning - 10
1733: run/output/always_clear_output_on_play - 10
1734: interior - 10
1735: VisualShaderNodeColorOp.Operator - 10
1736: text_editor/behavior/files/restore_scripts_on_load - 10
1737: text_editor/behavior/indent/auto_indent - 10
1738: text_editor/appearance/gutters/show_bookmark_gutter - 10
1739: text_editor/behavior/indent/size - 10
1740: editors/3d/navigation/emulate_numpad - 10
1741: Position2D - 10
1742: run/window_placement/rect - 10
1743: PanelContainer - 10
1744: text_editor/appearance/guidelines/show_line_length_guidelines - 10
1745: run/auto_save/save_before_running - 10
1746: editors/3d/navigation/invert_y_axis - 10
1747: control - 10
1748: PeerState - 10
1749: text_editor/appearance/caret/caret_blink - 10
1750: bone_name - 10
1751: HingeJoint3D.Param - 10
1752: text_editor/completion/complete_file_paths - 10
1753: decrement_highlight - 10
1754: GPUParticlesAttractorSphere3D - 10
1755: text_editor/completion/auto_brace_complete - 10
1756: text_editor/appearance/caret/type - 10
1757: editors/polygon_editor/point_grab_radius - 10
1758: interface/editor/automatically_open_screenshots - 10
1759: editors/animation/onion_layers_future_color - 10
1760: text_editor/behavior/files/convert_indent_on_save - 10
1761: text_editor/completion/put_callhint_tooltip_below_current_line - 10
1762: XRAnchor3D - 10
1763: text_editor/appearance/minimap/show_minimap - 10
1764: text_editor/behavior/indent/type - 10
1765: editors/2d/bone_width - 10
1766: interface/editor/code_font_contextual_ligatures - 10
1767: VisualShaderNodeCurveTexture - 10
1768: docks/filesystem/textfile_extensions - 10
1769: filesystem/on_save/safe_save_on_backup_then_rename - 10
1770: interface/editor/custom_display_scale - 10
1771: interface/scene_tabs/maximum_width - 10
1772: editors/3d/navigation/pan_modifier - 10
1773: MethodTweener - 10
1774: indices - 10
1775: filesystem/on_save/compress_binary_resources - 10
1776: TextServer.Feature - 10
1777: editors/animation/default_create_bezier_tracks - 10
1778: PhysicsServer3D.ShapeType - 10
1779: network/debug/remote_port - 10
1780: editors/3d/default_fov - 10
1781: editors/3d/grid_yz_plane - 10
1782: editors/3d_gizmos/gizmo_colors/shape - 10
1783: editors/3d/navigation/invert_x_axis - 10
1784: interface/editor/save_each_scene_on_quit - 10
1785: TextServer.GraphemeFlag - 10
1786: text_editor/appearance/whitespace/draw_tabs - 10
1787: CodeEdit.CodeCompletionKind - 10
1788: set_structured_text_bidi_override_options - 10
1789: interface/editor/low_processor_mode_sleep_usec - 10
1790: TextureRepeat - 10
1791: text_editor/help/class_reference_examples - 10
1792: editors/3d/secondary_grid_color - 10
1793: cull_mode - 10
1794: set_structured_text_bidi_override - 10
1795: GPUParticlesAttractorBox3D - 10
1796: text_editor/script_list/show_members_overview - 10
1797: GPUParticlesCollisionBox3D - 10
1798: editors/3d_gizmos/gizmo_colors/joint - 10
1799: GPUParticlesCollisionSphere3D - 10
1800: text_editor/appearance/gutters/line_numbers_zero_padded - 10
1801: Shader.Mode - 10
1802: ProcessMode - 10
1803: text_editor/appearance/gutters/show_line_numbers - 10
1804: text_editor/behavior/navigation/move_caret_on_right_click - 10
1805: text_editor/completion/use_single_quotes - 10
1806: editors/2d/smart_snapping_line_color - 10
1807: text_editor/completion/code_complete_delay - 10
1808: editors/2d/bone_ik_color - 10
1809: WebSocketMultiplayerPeer - 10
1810: ProxyTexture - 10
1811: angle_min - 10
1812: VisualShaderNodeCurveXYZTexture - 10
1813: editors/panning/warped_mouse_panning - 10
1814: editors/2d/bone_outline_size - 10
1815: NORMAL - 10
1816: editors/2d/guides_color - 10
1817: text_editor/appearance/minimap/minimap_width - 10
1818: docks/property_editor/auto_refresh_interval - 10
1819: editors/panning/2d_editor_panning_scheme - 10
1820: editors/3d/navigation_feel/orbit_inertia - 10
1821: interface/editor/mouse_extra_buttons_navigate_history - 10
1822: editors/3d/grid_division_level_max - 10
1823: editors/3d/navigation/orbit_modifier - 10
1824: group - 10
1825: interface/scene_tabs/display_close_button - 10
1826: stretch_mode - 10
1827: editors/3d/grid_division_level_min - 10
1828: editors/animation/autorename_animation_tracks - 10
1829: interface/editor/unfocused_low_processor_mode_sleep_usec - 10
1830: set_editable - 10
1831: docks/scene_tree/auto_expand_to_selected - 10
1832: editors/3d/freelook/freelook_inertia - 10
1833: interface/inspector/max_array_dictionary_items_per_page - 10
1834: editors/3d/grid_xy_plane - 10
1835: paused - 10
1836: RenderingServer.CanvasItemTextureFilter - 10
1837: increment_highlight - 10
1838: text_editor/completion/idle_parse_delay - 10
1839: editors/3d_gizmos/gizmo_colors/instantiated - 10
1840: interface/scene_tabs/show_thumbnail_on_hover - 10
1841: editors/3d/navigation/warped_mouse_panning - 10
1842: editors/3d/grid_size - 10
1843: text_editor/behavior/files/autosave_interval_secs - 10
1844: editors/3d/freelook/freelook_sensitivity - 10
1845: text_editor/appearance/lines/code_folding - 10
1846: angle_max - 10
1847: VisualScriptCustomNodes - 10
1848: surface_idx - 10
1849: button_pressed - 10
1850: CodeCompletionKind - 10
1851: bones - 10
1852: editors/2d/viewport_border_color - 10
1853: editors/2d/bone_color2 - 10
1854: editors/2d/bone_color1 - 10
1855: gradient - 10
1856: editors/panning/2d_editor_pan_speed - 10
1857: ColorRect - 10
1858: editors/panning/animation_editors_panning_scheme - 10
1859: get_structured_text_bidi_override_options - 10
1860: VERTEX - 10
1861: editors/tiles_editor/grid_color - 10
1862: editor_only - 10
1863: VisualShaderNodeColorConstant - 10
1864: editors/3d/default_z_far - 10
1865: editors/3d/navigation/zoom_style - 10
1866: RenderingDevice.InitialAction - 10
1867: docks/filesystem/thumbnail_size - 10
1868: EditorFeatureProfile.Feature - 10
1869: run/window_placement/rect_custom_position - 10
1870: get_structured_text_bidi_override - 10
1871: PI - 10
1872: text_editor/appearance/caret/highlight_current_line - 10
1873: TextServer.Direction - 10
1874: canvas_item - 10
1875: interface/editor/code_font_custom_opentype_features - 10
1876: interface/editor/separate_distraction_mode - 10
1877: editors/3d/primary_grid_color - 10
1878: text_editor/appearance/gutters/highlight_type_safe_lines - 10
1879: CanvasModulate - 10
1880: editors/panning/sub_editors_panning_scheme - 10
1881: text_editor/behavior/navigation/smooth_scrolling - 10
1882: IGDStatus - 10
1883: interface/editor/single_window_mode - 10
1884: TextureUsageBits - 10
1885: filesystem/file_dialog/display_mode - 10
1886: editors/2d/grid_color - 10
1887: id_pressed - 10
1888: text_editor/completion/add_type_hints - 10
1889: editors/3d/freelook/freelook_base_speed - 10
1890: editors/2d/bone_outline_color - 10
1891: Animation.TrackType - 10
1892: editors/3d/grid_xz_plane - 10
1893: AudioStreamPlayback - 10
1894: editors/3d/navigation_feel/orbit_sensitivity - 10
1895: text_editor/appearance/gutters/show_info_gutter - 10
1896: editors/3d/navigation_feel/translation_inertia - 10
1897: text_editor/appearance/caret/caret_blink_speed - 10
1898: PinJoint2D - 10
1899: PhysicsServer2D.SpaceParameter - 10
1900: run/output/always_close_output_on_stop - 10
1901: text_editor/help/show_help_index - 10
1902: editors/3d/freelook/freelook_activation_modifier - 10
1903: editors/3d/grid_division_level_bias - 10
1904: editors/3d/navigation/emulate_3_button_mouse - 10
1905: AnimatableBody3D - 10
1906: editors/grid_map/pick_distance - 10
1907: debugger/profiler_frame_history_size - 10
1908: vec4 - 10
1909: editors/polygon_editor/show_previous_outline - 10
1910: editors/3d/default_z_near - 10
1911: text_editor/behavior/navigation/v_scroll_speed - 10
1912: interface/scene_tabs/show_script_button - 10
1913: text_editor/appearance/whitespace/draw_spaces - 10
1914: editors/visual_editors/minimap_opacity - 10
1915: AnimatableBody2D - 10
1916: RectangleShape2D - 10
1917: editors/3d/selection_box_color - 10
1918: Path2D - 10
1919: text_editor/appearance/caret/highlight_all_occurrences - 10
1920: text_editor/script_list/sort_members_outline_alphabetically - 10
1921: text_editor/appearance/guidelines/line_length_guideline_soft_column - 10
1922: ConcavePolygonShape2D - 10
1923: editors/2d/constrain_editor_view - 10
1924: docks/scene_tree/start_create_dialog_fully_expanded - 10
1925: text_editor/behavior/files/trim_trailing_whitespace_on_save - 10
1926: editors/animation/default_create_reset_tracks - 10
1927: editors/3d/freelook/freelook_navigation_scheme - 10
1928: text_editor/appearance/lines/word_wrap - 10
1929: editors/tiles_editor/display_grid - 10
1930: editors/3d/freelook/freelook_speed_zoom_link - 10
1931: use_gravity - 9
1932: cache/0/variation_coordinates - 9
1933: is_visible - 9
1934: set_particle_flag - 9
1935: orbit_velocity_min - 9
1936: ALPHA - 9
1937: z_index - 9
1938: FUNC_MAX - 9
1939: VisualShaderNodeFloatConstant - 9
1940: base - 9
1941: textureGrad - 9
1942: set_use_sync - 9
1943: damping_min - 9
1944: lifetime_randomness - 9
1945: damping_max - 9
1946: color_initial_ramp - 9
1947: is_using_sync - 9
1948: max_results - 9
1949: get_direction - 9
1950: angular_velocity_max - 9
1951: freeze_mode - 9
1952: CompressedTexture3D - 9
1953: StencilOperation - 9
1954: set_direction - 9
1955: range - 9
1956: textureProjLod - 9
1957: ENetPacketPeer.PeerState - 9
1958: anim_offset_min - 9
1959: anim_speed_max - 9
1960: decal - 9
1961: set_autoplay - 9
1962: center_of_mass_mode - 9
1963: set_angular_damp - 9
1964: emission_sphere_radius - 9
1965: anim_speed_min - 9
1966: texelFetch - 9
1967: TooltipLabel - 9
1968: PhysicsServer3D.BodyAxis - 9
1969: get_frame - 9
1970: get_mass - 9
1971: tab_unselected - 9
1972: get_collision_layer - 9
1973: TrackType - 9
1974: CanvasItem.TextureFilter - 9
1975: linear_accel_min - 9
1976: set_collision_layer - 9
1977: texture_index - 9
1978: FillMode - 9
1979: RenderingDevice.TextureUsageBits - 9
1980: SpotLight3D - 9
1981: textureProj - 9
1982: thickness - 9
1983: anim_offset_max - 9
1984: angular_velocity_min - 9
1985: pixels - 9
1986: GenEditState - 9
1987: SurfaceTool.CustomFormat - 9
1988: set_modulate - 9
1989: set_mass - 9
1990: emission - 9
1991: get_modulate - 9
1992: EditorPlugin.DockSlot - 9
1993: hue_variation_min - 9
1994: LayoutDirection - 9
1995: start_key - 9
1996: PhysicsServer3D.HingeJointParam - 9
1997: particles_collision - 9
1998: bone_index - 9
1999: E - 9
2000: radial_accel_min - 9
2001: get_particle_flag - 9
2002: PhysicsServer3D.SpaceParameter - 9
2003: MathConstant - 9
2004: textureGather - 9
2005: AutowrapMode - 9
2006: RotationMode - 9
2007: EditorSyntaxHighlighter - 9
2008: fps - 9
2009: BodyMode - 9
2010: linear_accel_max - 9
2011: is_flipped_v - 9
2012: textureSize - 9
2013: set_format - 9
2014: is_flipped_h - 9
2015: GraphEditMinimap - 9
2016: Hint - 9
2017: tab_disabled - 9
2018: get_linear_damp - 9
2019: VisualScriptMathConstant.MathConstant - 9
2020: set_one_shot - 9
2021: hue_variation_max - 9
2022: CompareOperator - 9
2023: ShadowCastingSetting - 9
2024: texture_normal - 9
2025: set_loop - 9
2026: radial_accel_max - 9
2027: get_skeleton - 9
2028: NavigationMeshGenerator - 9
2029: get_angular_damp - 9
2030: DockSlot - 9
2031: set_linear_damp - 9
2032: CustomFormat - 9
2033: SceneTreeTimer - 9
2034: orbit_velocity_max - 9
2035: segments - 9
2036: color_ramp - 9
2037: flat - 9
2038: AnimationNodeBlend2 - 8
2039: can_sleep - 8
2040: get_depth - 8
2041: AnimationNodeBlend3 - 8
2042: VisualShaderNodeTexture2DArray - 8
2043: cell_size - 8
2044: RenderingServer.ShadowQuality - 8
2045: radial_accel_curve - 8
2046: get_mode - 8
2047: Sky.RadianceSize - 8
2048: BaseMaterial3D,ShaderMaterial - 8
2049: VisualShaderNodeParticleMultiplyByAxisAngle - 8
2050: AudioEffectPanner - 8
2051: RadianceSize - 8
2052: emission_shape - 8
2053: texture_offset - 8
2054: VisualScriptSequence - 8
2055: feature - 8
2056: asset_library/available_urls - 8
2057: args - 8
2058: EditorScriptPicker - 8
2059: set_stream - 8
2060: filters - 8
2061: show - 8
2062: func - 8
2063: Mesh.PrimitiveType - 8
2064: linear_accel_curve - 8
2065: stream_paused - 8
2066: AudioEffectAmplify - 8
2067: anim_speed_curve - 8
2068: OP_TYPE_VECTOR_2D - 8
2069: RenderingServer.EnvironmentSDFGIRayCount - 8
2070: disable_mode - 8
2071: get_collision_mask_value - 8
2072: pose - 8
2073: VisualScriptEmitSignal - 8
2074: angle_curve - 8
2075: FlowContainer - 8
2076: deselect_on_focus_loss_enabled - 8
2077: GLTFTexture - 8
2078: sections - 8
2079: angular_velocity_curve - 8
2080: VisualShaderNodeConstant - 8
2081: buffer_length - 8
2082: VisualScriptSceneNode - 8
2083: orbit_velocity_curve - 8
2084: friction - 8
2085: VisualShaderNodeIntConstant - 8
2086: threshold - 8
2087: DisplayServer.WindowFlags - 8
2088: process_callback - 8
2089: RenderingDevice.TextureType - 8
2090: DampMode - 8
2091: OP_TYPE_MAX - 8
2092: VisualScriptVariableSet - 8
2093: PortType - 8
2094: VisualScriptResourcePath - 8
2095: TextServer.Orientation - 8
2096: hue_variation_curve - 8
2097: theme - 8
2098: AudioStreamPlaybackResampled - 8
2099: VisualShaderNodeVec3Constant - 8
2100: emission_energy - 8
2101: OP_TYPE_VECTOR_3D - 8
2102: GLTFAnimation - 8
2103: EditorResourcePreviewGenerator - 8
2104: HingeJointParam - 8
2105: AnimationNodeAdd2 - 8
2106: VisualScriptPreload - 8
2107: VisualScriptSelect - 8
2108: CanvasItemTextureFilter - 8
2109: get_stream - 8
2110: VideoStreamTheora - 8
2111: tangential_accel_curve - 8
2112: char - 8
2113: VisualScriptEngineSingleton - 8
2114: VisualShaderNodeTexture3D - 8
2115: shortcuts - 8
2116: VisualScriptGlobalConstant - 8
2117: GDScript - 8
2118: subdivide_width - 8
2119: set_collision_mask_value - 8
2120: subdivide_depth - 8
2121: lightmap - 8
2122: load_path - 8
2123: EnvironmentSDFGIRayCount - 8
2124: tangential_accel_max - 8
2125: VisualShaderNodeVec2Constant - 8
2126: unit_offset - 8
2127: custom_integrator - 8
2128: coords_from - 8
2129: LoopMode - 8
2130: VisualShaderNodeTextureUniform.TextureFilter - 8
2131: to_point - 8
2132: Mesh.ArrayCustomFormat - 8
2133: selection_color - 8
2134: VisualShaderNodeBooleanConstant - 8
2135: tip_nodepath - 8
2136: tangential_accel_min - 8
2137: TextureSwizzle - 8
2138: Window.Flags - 8
2139: builtin_action_overrides - 8
2140: RenderingDevice.SamplerRepeatMode - 8
2141: initial_velocity_max - 8
2142: TextureProgressBar.FillMode - 8
2143: asset_library/use_threads - 8
2144: VisualScriptVariableGet - 8
2145: transparency - 8
2146: SphereOccluder3D - 8
2147: get_skin - 8
2148: PhysicsServer2D.ShapeType - 8
2149: POSITION - 8
2150: TextureSamples - 8
2151: VisualShaderNodeTransformConstant - 8
2152: override - 8
2153: BaseMaterial3D.TextureChannel - 8
2154: RenderingServer.ArrayCustomFormat - 8
2155: exclude_parent - 8
2156: Viewport.ShadowAtlasQuadrantSubdiv - 8
2157: line_spacing - 8
2158: mouse_exited - 8
2159: AnimationNodeAdd3 - 8
2160: set_active - 8
2161: set_frame - 8
2162: dry - 8
2163: initial_velocity_min - 8
2164: particle_flag_align_y - 8
2165: QuadOccluder3D - 8
2166: target_position - 8
2167: BoxOccluder3D - 8
2168: ShadowAtlasQuadrantSubdiv - 8
2169: damping_curve - 8
2170: anim_offset_curve - 8
2171: set_horizontal_alignment - 7
2172: network/http_proxy/host - 7
2173: particles_anim_v_frames - 7
2174: ComparisonType - 7
2175: grabber_highlight - 7
2176: AxisStretchMode - 7
2177: set_step - 7
2178: get_motion - 7
2179: samples - 7
2180: InitialAction - 7
2181: unchecked - 7
2182: set_damping - 7
2183: Access - 7
2184: Capabilities - 7
2185: joints - 7
2186: get_blend_mode - 7
2187: loop_mode - 7
2188: OpenXRInterface - 7
2189: set_min - 7
2190: set_motion - 7
2191: get_item_count - 7
2192: Path: - 7
2193: File: - 7
2194: get_pitch_scale - 7
2195: network/http_proxy/port - 7
2196: BakeError - 7
2197: VisibilityRangeFadeMode - 7
2198: InternalImportCategory - 7
2199: particles_anim_loop - 7
2200: SkeletonModification3DStackHolder - 7
2201: zoom - 7
2202: set_item_count - 7
2203: hframes - 7
2204: get_glow_level - 7
2205: AnimationProcessCallback - 7
2206: get_spread - 7
2207: set_bus - 7
2208: set_priority - 7
2209: WindowFlags - 7
2210: old_name - 7
2211: XRInterface.PlayAreaMode - 7
2212: vframes - 7
2213: ShadowQuality - 7
2214: set_depth - 7
2215: GPUParticlesCollisionHeightField3D.Resolution - 7
2216: set_volume_db - 7
2217: ScriptCreateDialog - 7
2218: byte_offset - 7
2219: use_global_coordinates - 7
2220: set_base_path - 7
2221: set_texture_filter - 7
2222: BGMode - 7
2223: post_barrier - 7
2224: set_explosiveness_ratio - 7
2225: VisualShaderNode.PortType - 7
2226: CCDMode - 7
2227: uv - 7
2228: get_damping - 7
2229: clip_tabs - 7
2230: set_max - 7
2231: get_pre_process_time - 7
2232: get_physics_material_override - 7
2233: is_hit_from_inside_enabled - 7
2234: MovingPlatformApplyVelocityOnLeave - 7
2235: VisualShaderNodeSwitch.OpType - 7
2236: RenderingServer.CanvasItemTextureRepeat - 7
2237: lock_rotation - 7
2238: Tween.EaseType - 7
2239: plugin - 7
2240: set_base_script - 7
2241: EnvironmentSDFGIFramesToConverge - 7
2242: particles_anim_h_frames - 7
2243: density - 7
2244: get_enabled - 7
2245: localized_name - 7
2246: set_radial_segments - 7
2247: get_region_rect - 7
2248: set_blend_mode - 7
2249: Directories & Files: - 7
2250: access - 7
2251: _set_playing - 7
2252: TrackerType - 7
2253: is_sleeping - 7
2254: PARAM_MAX - 7
2255: get_randomness_ratio - 7
2256: set_lifetime - 7
2257: TextureRect.StretchMode - 7
2258: VisualShaderNodeTexture.Source - 7
2259: steering - 7
2260: pause - 7
2261: RenderingServer.EnvironmentSDFGIFramesToConverge - 7
2262: estimate_radius - 7
2263: inertia - 7
2264: get_center_of_mass - 7
2265: Environment.BGMode - 7
2266: set_fractional_delta - 7
2267: get_min - 7
2268: Recent: - 7
2269: get_base_path - 7
2270: suffix - 7
2271: RenderingServer.EnvironmentBG - 7
2272: NORMAL_MAP - 7
2273: Area2D.SpaceOverride - 7
2274: SamplerBorderColor - 7
2275: get_max - 7
2276: get_radial_segments - 7
2277: VisualShaderNodeCompare.ComparisonType - 7
2278: DopplerTracking - 7
2279: scale_curve - 7
2280: get_basic_type - 7
2281: RenderingServer.ParticlesCollisionType - 7
2282: ParticlesMaterial.EmissionShape - 7
2283: split_scale - 7
2284: RenderingDevice.SamplerBorderColor - 7
2285: max_neighbors - 7
2286: HFlowContainer - 7
2287: normal_font - 7
2288: get_rings - 7
2289: has_loop - 7
2290: get_priority - 7
2291: type_cache - 7
2292: set_basic_type - 7
2293: TextServer.SubpixelPositioning - 7
2294: get_smooth_faces - 7
2295: VisualShaderNodeCompare.Function - 7
2296: set_text_overrun_behavior - 7
2297: Name: - 7
2298: get_volume_db - 7
2299: set_smooth_faces - 7
2300: floor_snap_length - 7
2301: set_texture_type - 7
2302: texture_scale - 7
2303: XRServer.TrackerType - 7
2304: normal_map - 7
2305: set_title - 7
2306: unique_names - 7
2307: max_space - 7
2308: EnvironmentBG - 7
2309: brake - 7
2310: camera_effects - 7
2311: outline - 7
2312: CullMode - 7
2313: get_use_local_coordinates - 7
2314: neighbor_dist - 7
2315: get_fixed_fps - 7
2316: section_length - 7
2317: set_amount - 7
2318: get_explosiveness_ratio - 7
2319: set_draw_order - 7
2320: get_one_shot - 7

[... omitted to fit within paste limit ...]

20237: erase_preset - 0
20238: session_focussed - 0
20239: _get_input_port_name - 0
20240: particles_collision_set_sphere_radius - 0
20241: ROTATION_NONE - 0
20242: OP_NOT - 0
20243: DATA_FORMAT_ASTC_10x6_UNORM_BLOCK - 0

Out of 20243 StringNames, 8977 StringNames were never referenced during this run (0 times) (44.35%).
Out of 20243 StringNames, 8068 StringNames were rarely referenced during this run (1-4 times) (39.86%).
```