### PR TITLE
Improve inspector filtering

### DIFF
--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -33,6 +33,20 @@
 #include "editor/editor_property_name_processor.h"
 #include "editor/editor_scale.h"
 
+static bool _property_path_matches(const String &p_property_path, const String &p_filter) {
+	if (p_property_path.findn(p_filter) != -1) {
+		return true;
+	}
+
+	const Vector<String> sections = p_property_path.split("/");
+	for (int i = 0; i < sections.size(); i++) {
+		if (p_filter.is_subsequence_ofn(EditorPropertyNameProcessor::get_singleton()->process_name(sections[i]))) {
+			return true;
+		}
+	}
+	return false;
+}
+
 class SectionedInspectorFilter : public Object {
 	GDCLASS(SectionedInspectorFilter, Object);
 
@@ -232,7 +246,7 @@ void SectionedInspector::update_category_list() {
 			continue;
 		}
 
-		if (!filter.is_empty() && pi.name.findn(filter) == -1 && pi.name.replace("/", " ").capitalize().findn(filter) == -1) {
+		if (!filter.is_empty() && !_property_path_matches(pi.name, filter)) {
 			continue;
 		}
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -617,6 +617,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	general_settings_inspector->get_inspector()->set_undo_redo(EditorNode::get_singleton()->get_undo_redo());
 	general_settings_inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	general_settings_inspector->register_search_box(search_box);
+	general_settings_inspector->get_inspector()->set_use_filter(true);
 	general_settings_inspector->get_inspector()->connect("property_selected", callable_mp(this, &ProjectSettingsEditor::_setting_selected));
 	general_settings_inspector->get_inspector()->connect("property_edited", callable_mp(this, &ProjectSettingsEditor::_setting_edited));
 	general_settings_inspector->get_inspector()->connect("restart_requested", callable_mp(this, &ProjectSettingsEditor::_editor_restart_request));


### PR DESCRIPTION
* Unified `SectionedInspector` and `EditorInspector` filtering rules.
    * The rules now are: 
        1. Substring match in full property path.
        2. Subsequence match in each part of the property path, capitalized & localized.
    * <details><summary>Previous rules were different, so there were some related bugs.</summary>
      
      * `EditorInspector`
          1. Subsequence match of localized group, or localized name if group does not exist.
          2. Subsequence match of the property name.
          3. Substring match of the prefix (used by sectioned inspector).
      * `SectionedInspector`
          1. Substring match of the full property path.
          2. Substring match of the simple capitalized property path (not replacement or localization).
      
      </details>
* ~~Added caching to capitialization process because filtering now tests on capitalized & localized name.~~ Moved to another PR.
* Fixes Project Settings not filtering property list. (`master` only)

Fixes #58815
Fixes #56840

p.s. I defined `_property_path_matches()` separately in the two inspector files mostly because I'm not sure where to put it. Any suggestions?