### PR TITLE
Fix text buf does not clear when calling the method set_item_text in …

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -1003,8 +1003,12 @@ void PopupMenu::set_item_text(int p_idx, const String &p_text) {
 		p_idx += get_item_count();
 	}
 	ERR_FAIL_INDEX(p_idx, items.size());
+	if (items[p_idx].text == p_text) {
+		return;
+	}
 	items.write[p_idx].text = p_text;
 	items.write[p_idx].xl_text = atr(p_text);
+	items.write[p_idx].dirty = true;
 	_shape_item(p_idx);
 
 	control->update();


### PR DESCRIPTION
Previously PopupMenu::set_item_text did not change the flag to update the text buffer, so it only changed the text in memory, but didn't use the setted text in screen.