### PR TITLE
ResourceImporterWAV: Allow configuring loop mode on import

### DIFF
--- a/scene/resources/audio_stream_sample.h
+++ b/scene/resources/audio_stream_sample.h
@@ -89,6 +89,7 @@ public:
 		FORMAT_IMA_ADPCM
 	};
 
+	// Keep the ResourceImporterWAV `edit/loop_mode` enum hint in sync with these options.
 	enum LoopMode {
 		LOOP_DISABLED,
 		LOOP_FORWARD,


### PR DESCRIPTION
The new `edit/loop_mode` import options lets user choose to either:
- Detect loop points from the WAV (default, same behavior as before)
- Set the loop mode and loop points manually like in AudioStreamSample

Previously the only options were to import loop points from WAV, or to force a full-length forward loop. There was no easy way to disable looping if it's embedded in the WAV, which confuses many users.

Fixes #46164, at least the most egregious part. The UX around editing loop points on an already imported WAV resource is still awkward.

### Notes

- For a potential `3.x` backport, the compatibility should be preserved with the previous `edit/loop` boolean option. Could possibly be added in this PR too for `master` if wanted.
- "Loop Begin" and "Loop End" import options are only shown when the "Loop Mode" is neither "Detect From WAV" nor "Disabled".
- "Loop Begin" and "Loop End" import options support negative positions, so one can use `-1` to select the end frame (and that's the default value for "Loop End").
- I noticed that the generated spectrum preview in the Inspector actually reflects the loop mode when importing as "Backward" (so it's flipped), but that's not refreshed when reimporting. One needs to reopen the editor for the preview to match the import option at the time of opening.

https://user-images.githubusercontent.com/4701338/158416488-153bd2c6-8e85-4e52-b68a-e820831b1dac.mp4