### PR TITLE
Remove extra borders from the AssetLib plugin

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1519,6 +1519,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("Information3dViewport", "EditorStyles", style_info_3d_viewport);
 
 	// Asset Library.
+	theme->set_stylebox("bg", "AssetLib", style_empty);
 	theme->set_stylebox("panel", "AssetLib", style_content_panel);
 	theme->set_color("status_color", "AssetLib", Color(0.5, 0.5, 0.5));
 	theme->set_icon("dismiss", "AssetLib", theme->get_icon(SNAME("Close"), SNAME("EditorIcons")));

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -577,6 +577,7 @@ EditorAssetLibraryItemDownload::EditorAssetLibraryItemDownload() {
 void EditorAssetLibrary::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_READY: {
+			add_theme_style_override("panel", get_theme_stylebox(SNAME("bg"), SNAME("AssetLib")));
 			error_label->raise();
 		} break;
 
@@ -1377,7 +1378,6 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	initial_loading = true;
 
 	VBoxContainer *library_main = memnew(VBoxContainer);
-
 	add_child(library_main);
 
 	HBoxContainer *search_hb = memnew(HBoxContainer);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1895,6 +1895,11 @@ void ProjectManager::_notification(int p_what) {
 				// to search without having to reach for their mouse
 				search_box->grab_focus();
 			}
+
+			if (asset_library) {
+				// Removes extra border margins.
+				asset_library->add_theme_style_override("panel", memnew(StyleBoxEmpty));
+			}
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {


### PR DESCRIPTION
This PR removes the extra border size from the AssetLib in both the Project Manager and the editor itself. Making it consistent with other borders.

|Before:|After:|
|---|---|
|![Screenshot_20220315_205035](https://user-images.githubusercontent.com/30739239/158493093-be5f854b-8aca-4fb8-a624-0f408595e24a.png)|![Screenshot_20220315_154146](https://user-images.githubusercontent.com/30739239/158493091-f6f803fc-0b42-46f9-9d2a-c30fd98b5d27.png)|