### PR TITLE
Handle NOTIFICATION_WM_CLOSE_REQUEST in EditorSpinSlider

### DIFF
--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -443,6 +443,7 @@ void EditorSpinSlider::_notification(int p_what) {
 
 		case NOTIFICATION_WM_WINDOW_FOCUS_IN:
 		case NOTIFICATION_WM_WINDOW_FOCUS_OUT:
+		case NOTIFICATION_WM_CLOSE_REQUEST:
 		case NOTIFICATION_EXIT_TREE: {
 			if (grabbing_spinner) {
 				grabber->hide();


### PR DESCRIPTION
resolve #59174

The bug in the referenced issue is caused by the fact that the `EditorSpinSlider` receives a `NOTIFICATION_WM_CLOSE_REQUEST`, that is initiated in
https://github.com/godotengine/godot/blob/cfd21adf64087c750dde89191bcfcf4d166adc85/platform/linuxbsd/display_server_x11.cpp#L3261-L3270
because the mouse leaves the area of the popup window.

This patch makes sure, that `NOTIFICATION_WM_CLOSE_REQUEST` is handled correctly in `EditorSpinSlider::_notification`, so that the GUI does not get into an unstable internal state.

It feels like unintended behavior, that dragging the mouse too far causes the `sun_environ_popup` to close itself.
Therefore this patch also sets the `safe_rect` of the `sun_environ_popup` to the screen size, so that the close request is never sent.