### PR TITLE
[3.x] Add context support for editor translation

### DIFF
--- a/core/io/translation_loader_po.h
+++ b/core/io/translation_loader_po.h
@@ -37,7 +37,7 @@
 
 class TranslationLoaderPO : public ResourceFormatLoader {
 public:
-	static RES load_translation(FileAccess *f, Error *r_error = nullptr);
+	static RES load_translation(FileAccess *f, bool p_use_context, Error *r_error = nullptr);
 	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;

--- a/core/translation.cpp
+++ b/core/translation.cpp
@@ -870,9 +870,24 @@ void Translation::set_locale(const String &p_locale) {
 	}
 }
 
+void Translation::add_context_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context) {
+	if (p_context != StringName()) {
+		WARN_PRINT("Translation class doesn't handle context.");
+	}
+	add_message(p_src_text, p_xlated_text);
+}
+
+StringName Translation::get_context_message(const StringName &p_src_text, const StringName &p_context) const {
+	if (p_context != StringName()) {
+		WARN_PRINT("Translation class doesn't handle context.");
+	}
+	return get_message(p_src_text);
+}
+
 void Translation::add_message(const StringName &p_src_text, const StringName &p_xlated_text) {
 	translation_map[p_src_text] = p_xlated_text;
 }
+
 StringName Translation::get_message(const StringName &p_src_text) const {
 	if (get_script_instance()) {
 		return get_script_instance()->call("_get_message", p_src_text);
@@ -919,6 +934,32 @@ void Translation::_bind_methods() {
 
 Translation::Translation() :
 		locale("en") {
+}
+
+///////////////////////////////////////////////
+
+void ContextTranslation::add_context_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context) {
+	if (p_context == StringName()) {
+		add_message(p_src_text, p_xlated_text);
+	} else {
+		context_translation_map[p_context][p_src_text] = p_xlated_text;
+	}
+}
+
+StringName ContextTranslation::get_context_message(const StringName &p_src_text, const StringName &p_context) const {
+	if (p_context == StringName()) {
+		return get_message(p_src_text);
+	}
+
+	const Map<StringName, Map<StringName, StringName>>::Element *context = context_translation_map.find(p_context);
+	if (!context) {
+		return StringName();
+	}
+	const Map<StringName, StringName>::Element *message = context->get().find(p_src_text);
+	if (!message) {
+		return StringName();
+	}
+	return message->get();
 }
 
 ///////////////////////////////////////////////
@@ -1202,9 +1243,9 @@ void TranslationServer::set_tool_translation(const Ref<Translation> &p_translati
 	tool_translation = p_translation;
 }
 
-StringName TranslationServer::tool_translate(const StringName &p_message) const {
+StringName TranslationServer::tool_translate(const StringName &p_message, const StringName &p_context) const {
 	if (tool_translation.is_valid()) {
-		StringName r = tool_translation->get_message(p_message);
+		StringName r = tool_translation->get_context_message(p_message, p_context);
 		if (r) {
 			return r;
 		}

--- a/core/translation.h
+++ b/core/translation.h
@@ -60,7 +60,21 @@ public:
 	void get_message_list(List<StringName> *r_messages) const;
 	int get_message_count() const;
 
+	// Not exposed to scripting. For easy usage of `ContextTranslation`.
+	virtual void add_context_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context);
+	virtual StringName get_context_message(const StringName &p_src_text, const StringName &p_context) const;
+
 	Translation();
+};
+
+class ContextTranslation : public Translation {
+	GDCLASS(ContextTranslation, Translation);
+
+	Map<StringName, Map<StringName, StringName>> context_translation_map;
+
+public:
+	virtual void add_context_message(const StringName &p_src_text, const StringName &p_xlated_text, const StringName &p_context);
+	virtual StringName get_context_message(const StringName &p_src_text, const StringName &p_context) const;
 };
 
 class TranslationServer : public Object {
@@ -107,7 +121,7 @@ public:
 	static String get_language_code(const String &p_locale);
 
 	void set_tool_translation(const Ref<Translation> &p_translation);
-	StringName tool_translate(const StringName &p_message) const;
+	StringName tool_translate(const StringName &p_message, const StringName &p_context) const;
 	void set_doc_translation(const Ref<Translation> &p_translation);
 	StringName doc_translate(const StringName &p_message) const;
 

--- a/core/ustring.cpp
+++ b/core/ustring.cpp
@@ -4493,9 +4493,9 @@ String String::unquote() const {
 }
 
 #ifdef TOOLS_ENABLED
-String TTR(const String &p_text) {
+String TTR(const String &p_text, const String &p_context) {
 	if (TranslationServer::get_singleton()) {
-		return TranslationServer::get_singleton()->tool_translate(p_text);
+		return TranslationServer::get_singleton()->tool_translate(p_text, p_context);
 	}
 
 	return p_text;
@@ -4519,7 +4519,7 @@ String DTR(const String &p_text) {
 
 String RTR(const String &p_text) {
 	if (TranslationServer::get_singleton()) {
-		String rtr = TranslationServer::get_singleton()->tool_translate(p_text);
+		String rtr = TranslationServer::get_singleton()->tool_translate(p_text, StringName());
 		if (rtr == String() || rtr == p_text) {
 			return TranslationServer::get_singleton()->translate(p_text);
 		} else {

--- a/core/ustring.h
+++ b/core/ustring.h
@@ -423,7 +423,7 @@ _FORCE_INLINE_ bool is_str_less(const L *l_ptr, const R *r_ptr) {
 // and doc translate for the class reference (DTR).
 #ifdef TOOLS_ENABLED
 // Gets parsed.
-String TTR(const String &);
+String TTR(const String &p_text, const String &p_context = "");
 String DTR(const String &);
 // Use for C strings.
 #define TTRC(m_value) (m_value)

--- a/editor/editor_translation.cpp
+++ b/editor/editor_translation.cpp
@@ -62,7 +62,7 @@ void load_editor_translations(const String &p_locale) {
 			FileAccessMemory *fa = memnew(FileAccessMemory);
 			fa->open_custom(data.ptr(), data.size());
 
-			Ref<Translation> tr = TranslationLoaderPO::load_translation(fa);
+			Ref<Translation> tr = TranslationLoaderPO::load_translation(fa, true);
 
 			if (tr.is_valid()) {
 				tr->set_locale(etl->lang);
@@ -87,7 +87,7 @@ void load_doc_translations(const String &p_locale) {
 			FileAccessMemory *fa = memnew(FileAccessMemory);
 			fa->open_custom(data.ptr(), data.size());
 
-			Ref<Translation> tr = TranslationLoaderPO::load_translation(fa);
+			Ref<Translation> tr = TranslationLoaderPO::load_translation(fa, false);
 
 			if (tr.is_valid()) {
 				tr->set_locale(dtl->lang);


### PR DESCRIPTION
We're now able to translate property paths and later probably also enum & flags hints. It's more and more likely to encounter situations where the same word/message is used to mean different things. So I think it's necessary to backport the context feature from #40443.

Context is only added to `TTR()`-related functions and not exposed to scripting for backward compatibility.

In addition to the `extract.py` and PO parsing changes from the original PR. A `Translation` subclass `ContextTranslation` is created to support i18n with context. `TranslationLoaderPO::load_translation()` will return `ContextTranslation` instead of the vanilla version when requested. This only happens when loading editor translations.