### PR TITLE
[3.x] Add note about encryption key to export dialog

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -38,6 +38,7 @@
 #include "core/os/file_access.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
+#include "core/version_generated.gen.h"
 #include "editor_data.h"
 #include "editor_node.h"
 #include "editor_scale.h"
@@ -426,6 +427,10 @@ void ProjectExportDialog::_export_path_changed(const StringName &p_property, con
 
 	current->set_export_path(p_value);
 	_update_presets();
+}
+
+void ProjectExportDialog::_open_key_help_link() {
+	OS::get_singleton()->shell_open(vformat("%s/development/compiling/compiling_with_script_encryption_key.html", VERSION_DOCS_URL));
 }
 
 void ProjectExportDialog::_script_export_mode_changed(int p_mode) {
@@ -937,6 +942,7 @@ void ProjectExportDialog::_bind_methods() {
 	ClassDB::bind_method("_open_export_template_manager", &ProjectExportDialog::_open_export_template_manager);
 	ClassDB::bind_method("_validate_export_path", &ProjectExportDialog::_validate_export_path);
 	ClassDB::bind_method("_export_path_changed", &ProjectExportDialog::_export_path_changed);
+	ClassDB::bind_method("_open_key_help_link", &ProjectExportDialog::_open_key_help_link);
 	ClassDB::bind_method("_script_export_mode_changed", &ProjectExportDialog::_script_export_mode_changed);
 	ClassDB::bind_method("_script_encryption_key_changed", &ProjectExportDialog::_script_encryption_key_changed);
 	ClassDB::bind_method("_export_project", &ProjectExportDialog::_export_project);
@@ -1100,6 +1106,15 @@ ProjectExportDialog::ProjectExportDialog() {
 	script_vb->add_margin_child(TTR("GDScript Encryption Key (256-bits as hexadecimal):"), script_key);
 	script_vb->add_child(script_key_error);
 	sections->add_child(script_vb);
+
+	Label *sec_info = memnew(Label);
+	sec_info->set_text(TTR("Note: Encryption key needs to be stored in the binary,\nyou need to build the export templates from source."));
+	script_vb->add_child(sec_info);
+
+	LinkButton *sec_more_info = memnew(LinkButton);
+	sec_more_info->set_text(TTR("More Info..."));
+	sec_more_info->connect("pressed", this, "_open_key_help_link");
+	script_vb->add_child(sec_more_info);
 
 	sections->connect("tab_changed", this, "_tab_changed");
 

--- a/editor/project_export.h
+++ b/editor/project_export.h
@@ -156,6 +156,8 @@ private:
 	void _script_encryption_key_changed(const String &p_key);
 	bool _validate_script_encryption_key(const String &p_key);
 
+	void _open_key_help_link();
+
 	void _tab_changed(int);
 
 protected:


### PR DESCRIPTION
Like on `master`, provide a note about encryption key and a link to the documentation.

![ksnip_20220316-195420](https://user-images.githubusercontent.com/372476/158584795-4380a982-04c8-4a11-97bc-d28e854b5f52.png)
