### PR TITLE
Update to CanvasLayer sorting (issue #25384)

### DIFF
--- a/servers/visual/visual_server_viewport.h
+++ b/servers/visual/visual_server_viewport.h
@@ -81,7 +81,7 @@ public:
 			RID canvas;
 			bool operator<(const CanvasKey &p_canvas) const {
 				if (stacking == p_canvas.stacking) {
-					return canvas < p_canvas.canvas;
+					return canvas.get_id() < p_canvas.canvas.get_id();
 				}
 				return stacking < p_canvas.stacking;
 			}


### PR DESCRIPTION
This change implements explicit RID comparison for VisualServerViewport::Viewport::CanvasKey to ensure proper and consistent sorting when one CanvasLayer is nested. Changes were tested on Windows 10 and appear to exhibit identical behaviour to 4.0.alpha build.

This change is not simple to cherrypick from master since broad changes to folder structure have since been made.

*Bugsquad edit:*
- Helps with #25384