### PR TITLE
[3.x] Fix crash on `get_joy_button_index_from_string` and `get_joy_axis_index_from_string` for non-existing key

### DIFF
--- a/main/input_default.cpp
+++ b/main/input_default.cpp
@@ -1338,11 +1338,14 @@ String InputDefault::get_joy_button_string(int p_button) {
 
 int InputDefault::get_joy_button_index_from_string(String p_button) {
 	for (int i = 0; i < JOY_BUTTON_MAX; i++) {
-		if (p_button == _buttons[i]) {
+		if (_buttons[i] == nullptr) {
+			break;
+		}
+		if (p_button == String(_buttons[i])) {
 			return i;
 		}
 	}
-	ERR_FAIL_V(-1);
+	ERR_FAIL_V_MSG(-1, vformat("Could not find a button index matching the string \"%s\".", p_button));
 }
 
 int InputDefault::get_unused_joy_id() {
@@ -1361,9 +1364,12 @@ String InputDefault::get_joy_axis_string(int p_axis) {
 
 int InputDefault::get_joy_axis_index_from_string(String p_axis) {
 	for (int i = 0; i < JOY_AXIS_MAX; i++) {
-		if (p_axis == _axes[i]) {
+		if (_axes[i] == nullptr) {
+			break;
+		}
+		if (p_axis == String(_axes[i])) {
 			return i;
 		}
 	}
-	ERR_FAIL_V(-1);
+	ERR_FAIL_V_MSG(-1, vformat("Could not find an axis index matching the string \"%s\".", p_axis));
 }


### PR DESCRIPTION
This revision fixes issue #59175.

```c++
int InputDefault::get_joy_button_index_from_string(String p_button) {
	for (int i = 0; i < JOY_BUTTON_MAX; i++) {
		if (p_button == _buttons[i]) {
			return i;
		}
	}
	ERR_FAIL_V(-1);
}

int InputDefault::get_joy_axis_index_from_string(String p_axis) {
	for (int i = 0; i < JOY_AXIS_MAX; i++) {
		if (p_axis == _axes[i]) {
			return i;
		}
	}
	ERR_FAIL_V(-1);
}
```
As _buttons and _axes have both valid string and nullptr.
When iterating over them, if a given key exists it will work correctly.

But if given key does not exist, it will end up with `String::operator=(nullptr)`. 
As String constructor from nullptr exists, I use it.

`JOY_BUTTON_MAX` have value **128** and only used parts of array have max length only **23**.
When iterating over them, adding check for nullptr and early-quit is also considerable. 

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/59175