### PR TITLE
Minify GLSL shaders in release export templates to reduce binary size

### DIFF
--- a/gles3_builders.py
+++ b/gles3_builders.py
@@ -3,6 +3,7 @@
 import os.path
 from typing import Optional
 
+from glsl_common import minify_glsl
 from methods import print_error, to_raw_cstring
 
 
@@ -31,7 +32,7 @@ class GLES3HeaderStruct:
         self.specialization_values = []
 
 
-def include_file_in_gles3_header(filename: str, header_data: GLES3HeaderStruct, depth: int):
+def include_file_in_gles3_header(filename: str, header_data: GLES3HeaderStruct, depth: int, env):
     with open(filename, "r", encoding="utf-8") as fs:
         line = fs.readline()
 
@@ -94,11 +95,11 @@ def include_file_in_gles3_header(filename: str, header_data: GLES3HeaderStruct, 
                 included_file = os.path.relpath(os.path.dirname(filename) + "/" + includeline)
                 if included_file not in header_data.vertex_included_files and header_data.reading == "vertex":
                     header_data.vertex_included_files += [included_file]
-                    if include_file_in_gles3_header(included_file, header_data, depth + 1) is None:
+                    if include_file_in_gles3_header(included_file, header_data, depth + 1, env) is None:
                         print_error(f'In file "{filename}": #include "{includeline}" could not be found!"')
                 elif included_file not in header_data.fragment_included_files and header_data.reading == "fragment":
                     header_data.fragment_included_files += [included_file]
-                    if include_file_in_gles3_header(included_file, header_data, depth + 1) is None:
+                    if include_file_in_gles3_header(included_file, header_data, depth + 1, env) is None:
                         print_error(f'In file "{filename}": #include "{includeline}" could not be found!"')
 
                 line = fs.readline()
@@ -178,13 +179,23 @@ def include_file_in_gles3_header(filename: str, header_data: GLES3HeaderStruct, 
             line = line.replace("\r", "")
             line = line.replace("\n", "")
 
-            if header_data.reading == "vertex":
-                header_data.vertex_lines += [line]
-            if header_data.reading == "fragment":
-                header_data.fragment_lines += [line]
+            # Strip whitespace in release export templates to reduce binary size.
+            if env["target"] == "template_release":
+                line = line.strip()
+
+            # In release export templates, don't add blank lines to reduce binary size.
+            if env["target"] != "template_release" or line != "":
+                if env["target"] == "template_release":
+                    line = minify_glsl(line)
+
+                if header_data.reading == "vertex":
+                    header_data.vertex_lines += [line]
+                if header_data.reading == "fragment":
+                    header_data.fragment_lines += [line]
+
+                header_data.line_offset += 1
 
             line = fs.readline()
-            header_data.line_offset += 1
 
     return header_data
 
@@ -195,9 +206,10 @@ def build_gles3_header(
     class_suffix: str,
     optional_output_filename: Optional[str] = None,
     header_data: Optional[GLES3HeaderStruct] = None,
+    env=None,
 ):
     header_data = header_data or GLES3HeaderStruct()
-    include_file_in_gles3_header(filename, header_data, 0)
+    include_file_in_gles3_header(filename, header_data, 0, env)
 
     if optional_output_filename is None:
         out_file = filename + ".gen.h"
@@ -586,4 +598,4 @@ def build_gles3_header(
 
 def build_gles3_headers(target, source, env):
     for x in source:
-        build_gles3_header(str(x), include="drivers/gles3/shader_gles3.h", class_suffix="GLES3")
+        build_gles3_header(str(x), include="drivers/gles3/shader_gles3.h", class_suffix="GLES3", env=env)

--- a/glsl_builders.py
+++ b/glsl_builders.py
@@ -3,6 +3,7 @@
 import os.path
 from typing import Optional
 
+from glsl_common import minify_glsl
 from methods import print_error, to_raw_cstring
 
 
@@ -23,7 +24,7 @@ class RDHeaderStruct:
         self.compute_offset = 0
 
 
-def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth: int) -> RDHeaderStruct:
+def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth: int, env) -> RDHeaderStruct:
     with open(filename, "r", encoding="utf-8") as fs:
         line = fs.readline()
 
@@ -64,39 +65,52 @@ def include_file_in_rd_header(filename: str, header_data: RDHeaderStruct, depth:
 
                 if included_file not in header_data.vertex_included_files and header_data.reading == "vertex":
                     header_data.vertex_included_files += [included_file]
-                    if include_file_in_rd_header(included_file, header_data, depth + 1) is None:
+                    if include_file_in_rd_header(included_file, header_data, depth + 1, env) is None:
                         print_error(f'In file "{filename}": #include "{includeline}" could not be found!"')
                 elif included_file not in header_data.fragment_included_files and header_data.reading == "fragment":
                     header_data.fragment_included_files += [included_file]
-                    if include_file_in_rd_header(included_file, header_data, depth + 1) is None:
+                    if include_file_in_rd_header(included_file, header_data, depth + 1, env) is None:
                         print_error(f'In file "{filename}": #include "{includeline}" could not be found!"')
                 elif included_file not in header_data.compute_included_files and header_data.reading == "compute":
                     header_data.compute_included_files += [included_file]
-                    if include_file_in_rd_header(included_file, header_data, depth + 1) is None:
+                    if include_file_in_rd_header(included_file, header_data, depth + 1, env) is None:
                         print_error(f'In file "{filename}": #include "{includeline}" could not be found!"')
 
                 line = fs.readline()
 
             line = line.replace("\r", "").replace("\n", "")
 
-            if header_data.reading == "vertex":
-                header_data.vertex_lines += [line]
-            if header_data.reading == "fragment":
-                header_data.fragment_lines += [line]
-            if header_data.reading == "compute":
-                header_data.compute_lines += [line]
+            # Strip whitespace in release export templates to reduce binary size.
+            if env["target"] == "template_release":
+                line = line.strip()
+
+            # In release export templates, don't add blank lines to reduce binary size.
+            if env["target"] != "template_release" or line != "":
+                if env["target"] == "template_release":
+                    line = minify_glsl(line)
+
+                if header_data.reading == "vertex":
+                    header_data.vertex_lines += [line]
+                if header_data.reading == "fragment":
+                    header_data.fragment_lines += [line]
+                if header_data.reading == "compute":
+                    header_data.compute_lines += [line]
+
+                header_data.line_offset += 1
 
             line = fs.readline()
-            header_data.line_offset += 1
 
     return header_data
 
 
 def build_rd_header(
-    filename: str, optional_output_filename: Optional[str] = None, header_data: Optional[RDHeaderStruct] = None
+    filename: str,
+    optional_output_filename: Optional[str] = None,
+    header_data: Optional[RDHeaderStruct] = None,
+    env=None,
 ) -> None:
     header_data = header_data or RDHeaderStruct()
-    include_file_in_rd_header(filename, header_data, 0)
+    include_file_in_rd_header(filename, header_data, 0, env)
 
     if optional_output_filename is None:
         out_file = filename + ".gen.h"
@@ -149,7 +163,7 @@ public:
 
 def build_rd_headers(target, source, env):
     for x in source:
-        build_rd_header(filename=str(x))
+        build_rd_header(filename=str(x), env=env)
 
 
 class RAWHeaderStruct:
@@ -157,7 +171,7 @@ class RAWHeaderStruct:
         self.code = ""
 
 
-def include_file_in_raw_header(filename: str, header_data: RAWHeaderStruct, depth: int) -> None:
+def include_file_in_raw_header(filename: str, header_data: RAWHeaderStruct, depth: int, env) -> None:
     with open(filename, "r", encoding="utf-8") as fs:
         line = fs.readline()
 
@@ -166,19 +180,23 @@ def include_file_in_raw_header(filename: str, header_data: RAWHeaderStruct, dept
                 includeline = line.replace("#include ", "").strip()[1:-1]
 
                 included_file = os.path.relpath(os.path.dirname(filename) + "/" + includeline)
-                include_file_in_raw_header(included_file, header_data, depth + 1)
+                include_file_in_raw_header(included_file, header_data, depth + 1, env)
 
                 line = fs.readline()
 
             header_data.code += line
+
             line = fs.readline()
 
 
 def build_raw_header(
-    filename: str, optional_output_filename: Optional[str] = None, header_data: Optional[RAWHeaderStruct] = None
+    filename: str,
+    optional_output_filename: Optional[str] = None,
+    header_data: Optional[RAWHeaderStruct] = None,
+    env=None,
 ):
     header_data = header_data or RAWHeaderStruct()
-    include_file_in_raw_header(filename, header_data, 0)
+    include_file_in_raw_header(filename, header_data, 0, env)
 
     if optional_output_filename is None:
         out_file = filename + ".gen.h"
@@ -206,4 +224,4 @@ static const char {out_file_base}[] = {{
 
 def build_raw_headers(target, source, env):
     for x in source:
-        build_raw_header(filename=str(x))
+        build_raw_header(filename=str(x), env=env)

--- a/glsl_common.py
+++ b/glsl_common.py
@@ -1,0 +1,43 @@
+def minify_glsl(line: str):
+    """
+    Perform basic line-by-line GLSL minification to reduce the compiled binary size.
+    """
+
+    # index = line.find("//")
+    # if index != -1:
+    #     # Strip comments.
+    #     line = line[:index]
+
+    line = line.replace(" = ", "=")
+    line = line.replace(" += ", "+=")
+    line = line.replace(" -= ", "-=")
+    line = line.replace(" *= ", "*=")
+    line = line.replace(" /= ", "/=")
+    line = line.replace(" %= ", "%=")
+    line = line.replace(" &= ", "&=")
+    line = line.replace(" |= ", "|=")
+    line = line.replace(" ^= ", "^=")
+
+    line = line.replace(", ", ",")
+    line = line.replace("; ", ";")
+    line = line.replace("if (", "if(")
+    line = line.replace("} else {", "}else{")
+    line = line.replace("} else", "}else")
+    line = line.replace("for (", "for(")
+    line = line.replace("while (", "while(")
+    line = line.replace(") {", "){")
+    line = line.replace(" && ", "&&")
+    line = line.replace(" || ", "||")
+
+    line = line.replace(" + ", "+")
+    line = line.replace(" - ", "-")
+    line = line.replace(" * ", "*")
+    line = line.replace(" / ", "/")
+    line = line.replace(" % ", "%")
+    line = line.replace(" & ", "&")
+    line = line.replace(" | ", "|")
+    line = line.replace(" ^ ", "^")
+    line = line.replace(" >> ", ">>")
+    line = line.replace(" << ", "<<")
+
+    return line

--- a/tests/python_build/test_gles3_builder.py
+++ b/tests/python_build/test_gles3_builder.py
@@ -14,8 +14,11 @@ from gles3_builders import GLES3HeaderStruct, build_gles3_header
 )
 def test_gles3_builder(shader_files, builder, header_struct):
     header = header_struct()
+    env = {
+        "target": "release",
+    }
 
-    builder(shader_files["path_input"], "drivers/gles3/shader_gles3.h", "GLES3", header_data=header)
+    builder(shader_files["path_input"], "drivers/gles3/shader_gles3.h", "GLES3", header_data=header, env=env)
 
     with open(shader_files["path_expected_parts"], "r", encoding="utf-8") as f:
         expected_parts = json.load(f)

--- a/tests/python_build/test_glsl_builder.py
+++ b/tests/python_build/test_glsl_builder.py
@@ -21,7 +21,11 @@ from glsl_builders import RAWHeaderStruct, RDHeaderStruct, build_raw_header, bui
 )
 def test_glsl_builder(shader_files, builder, header_struct):
     header = header_struct()
-    builder(shader_files["path_input"], header_data=header)
+    env = {
+        "target": "release",
+    }
+
+    builder(shader_files["path_input"], header_data=header, env=env)
 
     with open(shader_files["path_expected_parts"], "r", encoding="utf-8") as f:
         expected_parts = json.load(f)


### PR DESCRIPTION
This reduces release export template binary sizes by about 103 KB. To avoid interfering with debugging, only `target=template_release` builds make use of GLSL minification.

## TODO

- [x] Figure out how to avoid copy-pasting the list of minification replacements in both GLES3 and Vulkan builders.
