### PR TITLE
Generate C# singletons as non-static classes

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -18,16 +18,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          - name: Editor w/ Mono (target=release_debug, tools=yes, tests=yes)
-#            cache-name: linux-editor-mono
-#            target: release_debug
-#            tools: true
-#            tests: false # Disabled due freeze caused by mix Mono build and CI
-#            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no
-#            doc-test: true
-#            bin: "./bin/godot.linuxbsd.opt.tools.64.mono"
-#            build-mono: true
-#            artifact: true
+          - name: Editor w/ Mono (target=release_debug, tools=yes, tests=yes)
+            cache-name: linux-editor-mono
+            target: release_debug
+            tools: true
+            tests: false # Disabled due freeze caused by mix Mono build and CI
+            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no
+            doc-test: true
+            bin: "./bin/godot.linuxbsd.opt.tools.64.mono"
+            build-mono: true
+            artifact: true
 
           - name: Editor with doubles and sanitizers (target=debug, tools=yes, float=64, tests=yes, use_asan=yes, use_ubsan=yes)
             cache-name: linux-editor-double-sanitizers
@@ -44,14 +44,14 @@ jobs:
             # Skip 2GiB artifact speeding up action.
             artifact: false
 
-#          - name: Template w/ Mono (target=release, tools=no)
-#            cache-name: linux-template-mono
-#            target: release
-#            tools: false
-#            tests: false
-#            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no debug_symbols=no
-#            build-mono: false
-#            artifact: true
+          - name: Template w/ Mono (target=release, tools=no)
+            cache-name: linux-template-mono
+            target: release
+            tools: false
+            tests: false
+            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no debug_symbols=no
+            build-mono: false
+            artifact: true
 
           - name: Minimal Template (target=release, tools=no, everything disabled)
             cache-name: linux-template-minimal

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildManager.cs
@@ -62,7 +62,7 @@ namespace GodotTools.Build
 
         private static void PrintVerbose(string text)
         {
-            if (Godot.OS.IsStdoutVerbose())
+            if (Godot.OS.Singleton.IsStdoutVerbose())
                 Godot.GD.Print(text);
         }
 
@@ -164,7 +164,7 @@ namespace GodotTools.Build
             var buildInfo = new BuildInfo(GodotSharpDirs.ProjectSlnPath, targets ?? new[] {"Build"}, config, restore: true);
 
             // If a platform was not specified, try determining the current one. If that fails, let MSBuild auto-detect it.
-            if (platform != null || OS.PlatformNameMap.TryGetValue(Godot.OS.GetName(), out platform))
+            if (platform != null || OS.PlatformNameMap.TryGetValue(Godot.OS.Singleton.GetName(), out platform))
                 buildInfo.CustomProperties.Add($"GodotTargetPlatform={platform}");
 
             if (Internal.GodotIsRealTDouble())

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildOutputView.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildOutputView.cs
@@ -140,11 +140,11 @@ namespace GodotTools.Build
             if (!File.Exists(file))
                 return;
 
-            file = ProjectSettings.LocalizePath(file);
+            file = ProjectSettings.Singleton.LocalizePath(file);
 
             if (file.StartsWith("res://"))
             {
-                var script = (Script)ResourceLoader.Load(file, typeHint: Internal.CSharpLanguageType);
+                var script = (Script)ResourceLoader.Singleton.Load(file, typeHint: Internal.CSharpLanguageType);
 
                 if (script != null && Internal.ScriptEditorEdit(script, issue.Line, issue.Column))
                     Internal.EditorNodeShowScriptScreen();
@@ -326,7 +326,7 @@ namespace GodotTools.Build
                     }
 
                     if (text != null)
-                        DisplayServer.ClipboardSet(text);
+                        DisplayServer.Singleton.ClipboardSet(text);
                     break;
                 }
                 default:

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -57,7 +57,7 @@ namespace GodotTools.Build
 
             string launchMessage = $"Running: \"{startInfo.FileName}\" {startInfo.Arguments}";
             stdOutHandler?.Invoke(launchMessage);
-            if (Godot.OS.IsStdoutVerbose())
+            if (Godot.OS.Singleton.IsStdoutVerbose())
                 Console.WriteLine(launchMessage);
 
             startInfo.RedirectStandardOutput = true;

--- a/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/MsBuildFinder.cs
@@ -186,7 +186,7 @@ namespace GodotTools.Build
             var vsWhereArgs = new[] {"-latest", "-products", "*", "-requires", "Microsoft.Component.MSBuild"};
 
             var outputArray = new Godot.Collections.Array<string>();
-            int exitCode = Godot.OS.Execute(vsWherePath, vsWhereArgs,
+            int exitCode = Godot.OS.Singleton.Execute(vsWherePath, vsWhereArgs,
                 output: (Godot.Collections.Array)outputArray);
 
             if (exitCode != 0)

--- a/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/ExportPlugin.cs
@@ -35,7 +35,7 @@ namespace GodotTools.Export
 
         private void AddI18NAssemblies(Godot.Collections.Dictionary<string, string> assemblies, string bclDir)
         {
-            var codesets = (I18NCodesets)ProjectSettings.GetSetting("mono/export/i18n_codesets");
+            var codesets = (I18NCodesets)ProjectSettings.Singleton.GetSetting("mono/export/i18n_codesets");
 
             if (codesets == I18NCodesets.None)
                 return;
@@ -65,7 +65,7 @@ namespace GodotTools.Export
 
             GlobalDef("mono/export/i18n_codesets", I18NCodesets.All);
 
-            ProjectSettings.AddPropertyInfo(new Godot.Collections.Dictionary
+            ProjectSettings.Singleton.AddPropertyInfo(new Godot.Collections.Dictionary
             {
                 ["type"] = Variant.Type.Int,
                 ["name"] = "mono/export/i18n_codesets",
@@ -104,7 +104,7 @@ namespace GodotTools.Export
 
             // TODO What if the source file is not part of the game's C# project
 
-            bool includeScriptsContent = (bool)ProjectSettings.GetSetting("mono/export/include_scripts_content");
+            bool includeScriptsContent = (bool)ProjectSettings.Singleton.GetSetting("mono/export/include_scripts_content");
 
             if (!includeScriptsContent)
             {
@@ -239,7 +239,7 @@ namespace GodotTools.Export
             string apiConfig = isDebug ? "Debug" : "Release";
             string resAssembliesDir = Path.Combine(GodotSharpDirs.ResAssembliesBaseDir, apiConfig);
 
-            bool assembliesInsidePck = (bool)ProjectSettings.GetSetting("mono/export/export_assemblies_inside_pck") || outputDataDir == null;
+            bool assembliesInsidePck = (bool)ProjectSettings.Singleton.GetSetting("mono/export/export_assemblies_inside_pck") || outputDataDir == null;
 
             if (!assembliesInsidePck)
             {
@@ -277,14 +277,14 @@ namespace GodotTools.Export
             }
 
             // AOT compilation
-            bool aotEnabled = platform == OS.Platforms.iOS || (bool)ProjectSettings.GetSetting("mono/export/aot/enabled");
+            bool aotEnabled = platform == OS.Platforms.iOS || (bool)ProjectSettings.Singleton.GetSetting("mono/export/aot/enabled");
 
             if (aotEnabled)
             {
                 string aotToolchainPath = null;
 
                 if (platform == OS.Platforms.Android)
-                    aotToolchainPath = (string)ProjectSettings.GetSetting("mono/export/aot/android_toolchain_path");
+                    aotToolchainPath = (string)ProjectSettings.Singleton.GetSetting("mono/export/aot/android_toolchain_path");
 
                 if (aotToolchainPath == string.Empty)
                     aotToolchainPath = null; // Don't risk it being used as current working dir
@@ -296,10 +296,10 @@ namespace GodotTools.Export
                     LLVMOnly = false,
                     LLVMPath = "",
                     LLVMOutputPath = "",
-                    FullAot = platform == OS.Platforms.iOS || (bool)(ProjectSettings.GetSetting("mono/export/aot/full_aot") ?? false),
-                    UseInterpreter = (bool)ProjectSettings.GetSetting("mono/export/aot/use_interpreter"),
-                    ExtraAotOptions = (string[])ProjectSettings.GetSetting("mono/export/aot/extra_aot_options") ?? Array.Empty<string>(),
-                    ExtraOptimizerOptions = (string[])ProjectSettings.GetSetting("mono/export/aot/extra_optimizer_options") ?? Array.Empty<string>(),
+                    FullAot = platform == OS.Platforms.iOS || (bool)(ProjectSettings.Singleton.GetSetting("mono/export/aot/full_aot") ?? false),
+                    UseInterpreter = (bool)ProjectSettings.Singleton.GetSetting("mono/export/aot/use_interpreter"),
+                    ExtraAotOptions = (string[])ProjectSettings.Singleton.GetSetting("mono/export/aot/extra_aot_options") ?? Array.Empty<string>(),
+                    ExtraOptimizerOptions = (string[])ProjectSettings.Singleton.GetSetting("mono/export/aot/extra_optimizer_options") ?? Array.Empty<string>(),
                     ToolchainPath = aotToolchainPath
                 };
 
@@ -470,7 +470,7 @@ namespace GodotTools.Export
 
         private static string DetermineDataDirNameForProject()
         {
-            string appName = (string)ProjectSettings.GetSetting("application/config/name");
+            string appName = (string)ProjectSettings.Singleton.GetSetting("application/config/name");
             string appNameSafe = appName.ToSafeDirName();
             return $"data_{appNameSafe}";
         }

--- a/modules/mono/editor/GodotTools/GodotTools/Export/XcodeHelper.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Export/XcodeHelper.cs
@@ -27,7 +27,7 @@ namespace GodotTools.Export
         {
             var outputWrapper = new Godot.Collections.Array();
 
-            int exitCode = Godot.OS.Execute("xcode-select", new string[] { "--print-path" }, output: outputWrapper);
+            int exitCode = Godot.OS.Singleton.Execute("xcode-select", new string[] { "--print-path" }, output: outputWrapper);
 
             if (exitCode == 0)
             {

--- a/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/GodotSharpEditor.cs
@@ -43,7 +43,7 @@ namespace GodotTools
         {
             get
             {
-                string projectAssemblyName = (string)ProjectSettings.GetSetting("application/config/name");
+                string projectAssemblyName = (string)ProjectSettings.Singleton.GetSetting("application/config/name");
                 projectAssemblyName = projectAssemblyName.ToSafeDirName();
                 if (string.IsNullOrEmpty(projectAssemblyName))
                     projectAssemblyName = "UnnamedProject";
@@ -57,7 +57,7 @@ namespace GodotTools
             {
                 pr.Step("Generating C# project...".TTR());
 
-                string resourceDir = ProjectSettings.GlobalizePath("res://");
+                string resourceDir = ProjectSettings.Singleton.GlobalizePath("res://");
 
                 string path = resourceDir;
                 string name = ProjectAssemblyName;
@@ -206,7 +206,7 @@ namespace GodotTools
                     return Error.Unavailable;
                 case ExternalEditorId.VisualStudio:
                 {
-                    string scriptPath = ProjectSettings.GlobalizePath(script.ResourcePath);
+                    string scriptPath = ProjectSettings.Singleton.GlobalizePath(script.ResourcePath);
 
                     var args = new List<string>
                     {
@@ -218,7 +218,7 @@ namespace GodotTools
 
                     try
                     {
-                        if (Godot.OS.IsStdoutVerbose())
+                        if (Godot.OS.Singleton.IsStdoutVerbose())
                             Console.WriteLine($"Running: \"{command}\" {string.Join(" ", args.Select(a => $"\"{a}\""))}");
 
                         OS.RunProcess(command, args);
@@ -234,13 +234,13 @@ namespace GodotTools
                     goto case ExternalEditorId.MonoDevelop;
                 case ExternalEditorId.Rider:
                 {
-                    string scriptPath = ProjectSettings.GlobalizePath(script.ResourcePath);
+                    string scriptPath = ProjectSettings.Singleton.GlobalizePath(script.ResourcePath);
                     RiderPathManager.OpenFile(GodotSharpDirs.ProjectSlnPath, scriptPath, line);
                     return Error.Ok;
                 }
                 case ExternalEditorId.MonoDevelop:
                 {
-                    string scriptPath = ProjectSettings.GlobalizePath(script.ResourcePath);
+                    string scriptPath = ProjectSettings.Singleton.GlobalizePath(script.ResourcePath);
 
                     GodotIdeManager.LaunchIdeAsync().ContinueWith(launchTask =>
                     {
@@ -288,10 +288,10 @@ namespace GodotTools
                         }
                     }
 
-                    string resourcePath = ProjectSettings.GlobalizePath("res://");
+                    string resourcePath = ProjectSettings.Singleton.GlobalizePath("res://");
                     args.Add(resourcePath);
 
-                    string scriptPath = ProjectSettings.GlobalizePath(script.ResourcePath);
+                    string scriptPath = ProjectSettings.Singleton.GlobalizePath(script.ResourcePath);
 
                     if (line >= 0)
                     {

--- a/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Ides/GodotIdeManager.cs
@@ -21,7 +21,7 @@ namespace GodotTools.Ides
                 return _messagingServer;
 
             _messagingServer?.Dispose();
-            _messagingServer = new MessagingServer(OS.GetExecutablePath(), ProjectSettings.GlobalizePath(GodotSharpDirs.ResMetadataDir), new GodotLogger());
+            _messagingServer = new MessagingServer(OS.Singleton.GetExecutablePath(), ProjectSettings.Singleton.GlobalizePath(GodotSharpDirs.ResMetadataDir), new GodotLogger());
 
             _ = _messagingServer.Listen();
 
@@ -200,13 +200,13 @@ namespace GodotTools.Ides
         {
             public void LogDebug(string message)
             {
-                if (OS.IsStdoutVerbose())
+                if (OS.Singleton.IsStdoutVerbose())
                     Console.WriteLine(message);
             }
 
             public void LogInfo(string message)
             {
-                if (OS.IsStdoutVerbose())
+                if (OS.Singleton.IsStdoutVerbose())
                     Console.WriteLine(message);
             }
 

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/Directory.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/Directory.cs
@@ -7,7 +7,7 @@ namespace GodotTools.Utils
     {
         private static string GlobalizePath(this string path)
         {
-            return ProjectSettings.GlobalizePath(path);
+            return ProjectSettings.Singleton.GlobalizePath(path);
         }
 
         public static bool Exists(string path)

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/File.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/File.cs
@@ -7,7 +7,7 @@ namespace GodotTools.Utils
     {
         private static string GlobalizePath(this string path)
         {
-            return ProjectSettings.GlobalizePath(path);
+            return ProjectSettings.Singleton.GlobalizePath(path);
         }
 
         public static void WriteAllText(string path, string contents)

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/FsPathUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/FsPathUtils.cs
@@ -8,7 +8,7 @@ namespace GodotTools.Utils
 {
     public static class FsPathUtils
     {
-        private static readonly string _resourcePath = ProjectSettings.GlobalizePath("res://");
+        private static readonly string _resourcePath = ProjectSettings.Singleton.GlobalizePath("res://");
 
         private static bool PathStartsWithAlreadyNorm(this string childPath, string parentPath)
         {

--- a/modules/mono/editor_templates/CharacterBody2D/basic_movement.cs
+++ b/modules/mono/editor_templates/CharacterBody2D/basic_movement.cs
@@ -9,7 +9,7 @@ public partial class _CLASS_ : _BASE_
     public const float JumpVelocity = -400.0f;
 
     // Get the gravity from the project settings to be synced with RigidDynamicBody nodes.
-    public float gravity = (float)ProjectSettings.GetSetting("physics/2d/default_gravity");
+    public float gravity = (float)ProjectSettings.Singleton.GetSetting("physics/2d/default_gravity");
 
     public override void _PhysicsProcess(float delta)
     {

--- a/modules/mono/editor_templates/CharacterBody3D/basic_movement.cs
+++ b/modules/mono/editor_templates/CharacterBody3D/basic_movement.cs
@@ -9,7 +9,7 @@ public partial class _CLASS_ : _BASE_
     public const float JumpVelocity = 4.5f;
 
     // Get the gravity from the project settings to be synced with RigidDynamicBody nodes.
-    public float gravity = (float)ProjectSettings.GetSetting("physics/3d/default_gravity");
+    public float gravity = (float)ProjectSettings.Singleton.GetSetting("physics/3d/default_gravity");
 
     public override void _PhysicsProcess(float delta)
     {

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ResourceLoaderExtensions.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Extensions/ResourceLoaderExtensions.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace Godot
 {
-    public static partial class ResourceLoader
+    public partial class ResourceLoader
     {
         /// <summary>
         /// Loads a resource at the given <paramref name="path"/>, caching the result
@@ -22,7 +22,7 @@ namespace Godot
         /// Thrown when the given the loaded resource can't be casted to the given type <typeparamref name="T"/>.
         /// </exception>
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Resource"/>.</typeparam>
-        public static T Load<T>(string path, string typeHint = null, CacheMode cacheMode = CacheMode.Reuse) where T : class
+        public T Load<T>(string path, string typeHint = null, CacheMode cacheMode = CacheMode.Reuse) where T : class
         {
             return (T)(object)Load(path, typeHint, cacheMode);
         }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GD.cs
@@ -157,7 +157,7 @@ namespace Godot
         /// <returns>The loaded <see cref="Resource"/>.</returns>
         public static Resource Load(string path)
         {
-            return ResourceLoader.Load(path);
+            return ResourceLoader.Singleton.Load(path);
         }
 
         /// <summary>
@@ -184,7 +184,7 @@ namespace Godot
         /// <typeparam name="T">The type to cast to. Should be a descendant of <see cref="Resource"/>.</typeparam>
         public static T Load<T>(string path) where T : class
         {
-            return ResourceLoader.Load<T>(path);
+            return ResourceLoader.Singleton.Load<T>(path);
         }
 
         /// <summary>


### PR DESCRIPTION
Singleton classes are no longer generated as static classes so they can be inherited.

This fixes mono after #59140 (introduces a class `PhysicsServer3DExtension` that inherits from `PhysicsServer3D` which is a singleton class) and re-enables mono CI.

The disadvantage of this is we now have to access the singleton class using the `Singleton` property everytime, which is cumbersome, but it's consistent with how it works in the engine and godot-cpp (using the `get_singleton` method).
