### PR TITLE
`PinJoint2D`: fix inertia tensor, taking center of mass into account

### DIFF
--- a/servers/physics_2d/godot_joints_2d.cpp
+++ b/servers/physics_2d/godot_joints_2d.cpp
@@ -118,22 +118,26 @@ bool GodotPinJoint2D::setup(real_t p_step) {
 	K1[0].y = 0.0f;
 	K1[1].y = A->get_inv_mass() + B_inv_mass;
 
+	Vector2 r1 = rA - A->get_center_of_mass();
+
 	Transform2D K2;
-	K2[0].x = A->get_inv_inertia() * rA.y * rA.y;
-	K2[1].x = -A->get_inv_inertia() * rA.x * rA.y;
-	K2[0].y = -A->get_inv_inertia() * rA.x * rA.y;
-	K2[1].y = A->get_inv_inertia() * rA.x * rA.x;
+	K2[0].x = A->get_inv_inertia() * r1.y * r1.y;
+	K2[1].x = -A->get_inv_inertia() * r1.x * r1.y;
+	K2[0].y = -A->get_inv_inertia() * r1.x * r1.y;
+	K2[1].y = A->get_inv_inertia() * r1.x * r1.x;
 
 	Transform2D K;
 	K[0] = K1[0] + K2[0];
 	K[1] = K1[1] + K2[1];
 
 	if (B) {
+		Vector2 r2 = rB - B->get_center_of_mass();
+
 		Transform2D K3;
-		K3[0].x = B->get_inv_inertia() * rB.y * rB.y;
-		K3[1].x = -B->get_inv_inertia() * rB.x * rB.y;
-		K3[0].y = -B->get_inv_inertia() * rB.x * rB.y;
-		K3[1].y = B->get_inv_inertia() * rB.x * rB.x;
+		K3[0].x = B->get_inv_inertia() * r2.y * r2.y;
+		K3[1].x = -B->get_inv_inertia() * r2.x * r2.y;
+		K3[0].y = -B->get_inv_inertia() * r2.x * r2.y;
+		K3[1].y = B->get_inv_inertia() * r2.x * r2.x;
 
 		K[0] += K3[0];
 		K[1] += K3[1];


### PR DESCRIPTION
The same inertia tensor calculation is actually repeated in the `k_tensor` function in the same file, used by the `GrooveJoint2D`. In that function, the center of mass of each body was already taken into account:

https://github.com/godotengine/godot/blob/d3f983262fbc272c66c20d03f82b6dc658e37f4b/servers/physics_2d/godot_joints_2d.cpp#L239-L240

This PR takes the center of mass into account in the inertia tensor calculation for `PinJoint2D` in exactly the same way.

Fixes https://github.com/godotengine/godot/issues/58802.

The two calculations of the inertia tensor could be refactored into one function in the future.