### PR TITLE
Add a compatibility handler for StreamTexture2D -> CompressedTexture2D

### DIFF
--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -1014,7 +1014,8 @@ void register_scene_types() {
 	ClassDB::add_compatibility_class("SpringArm", "SpringArm3D");
 	ClassDB::add_compatibility_class("Sprite", "Sprite2D");
 	ClassDB::add_compatibility_class("StaticBody", "StaticBody3D");
-	ClassDB::add_compatibility_class("StreamTexture", "CompressedTexture2D");
+	ClassDB::add_compatibility_class("StreamTexture", "CompressedTexture2D"); // Godot 3.x
+	ClassDB::add_compatibility_class("StreamTexture2D", "CompressedTexture2D"); // Godot `master` branch until February 2022 (~4.0alpha3)
 	ClassDB::add_compatibility_class("TextureProgress", "TextureProgressBar");
 	ClassDB::add_compatibility_class("VehicleBody", "VehicleBody3D");
 	ClassDB::add_compatibility_class("VehicleWheel", "VehicleWheel3D");


### PR DESCRIPTION
While we don't have a compatibility guarantee across alpha releases, it makes sense to add a compatibility handler given how many people are using the 4.0 alphas already.

This closes https://github.com/godotengine/godot/issues/59206. See https://github.com/godotengine/godot/pull/58788.