### PR TITLE
Correct DST errors on Windows (3.x)

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2406,7 +2406,7 @@ OS::Date OS_Windows::get_date(bool utc) const {
 	if (GetTimeZoneInformation(&info) == TIME_ZONE_ID_DAYLIGHT) {
 		daylight = true;
 	}
-	
+
 	Date date;
 	date.day = systemtime.wDay;
 	date.month = Month(systemtime.wMonth);
@@ -2435,7 +2435,7 @@ OS::TimeZoneInfo OS_Windows::get_time_zone_info() const {
 	if (GetTimeZoneInformation(&info) == TIME_ZONE_ID_DAYLIGHT) {
 		daylight = true;
 	}
-	
+
 	// Daylight Bias needs to be added to the bias if DST is in effect, or else it will not properly update.
 	TimeZoneInfo ret;
 	if (daylight) {

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2440,7 +2440,7 @@ OS::TimeZoneInfo OS_Windows::get_time_zone_info() const {
 	TimeZoneInfo ret;
 	if (daylight) {
 		ret.name = info.DaylightName;
-		ret.bias = info.Bias+info.DaylightBias;
+		ret.bias = info.Bias + info.DaylightBias;
 	} else {
 		ret.name = info.StandardName;
 		ret.bias = info.Bias;

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2400,12 +2400,19 @@ OS::Date OS_Windows::get_date(bool utc) const {
 	else
 		GetLocalTime(&systemtime);
 
+	//Get DST information from Windows.
+	TIME_ZONE_INFORMATION info;
+	bool daylight = false;
+	if (GetTimeZoneInformation(&info) == TIME_ZONE_ID_DAYLIGHT) {
+		daylight = true;
+	}
+	
 	Date date;
 	date.day = systemtime.wDay;
 	date.month = Month(systemtime.wMonth);
 	date.weekday = Weekday(systemtime.wDayOfWeek);
 	date.year = systemtime.wYear;
-	date.dst = false;
+	date.dst = daylight;
 	return date;
 }
 OS::Time OS_Windows::get_time(bool utc) const {
@@ -2425,19 +2432,23 @@ OS::Time OS_Windows::get_time(bool utc) const {
 OS::TimeZoneInfo OS_Windows::get_time_zone_info() const {
 	TIME_ZONE_INFORMATION info;
 	bool daylight = false;
-	if (GetTimeZoneInformation(&info) == TIME_ZONE_ID_DAYLIGHT)
+	if (GetTimeZoneInformation(&info) == TIME_ZONE_ID_DAYLIGHT) {
 		daylight = true;
-
+	}
+	
+	// Daylight Bias needs to be added to the bias if DST is in effect, or else it will not properly update.
 	TimeZoneInfo ret;
 	if (daylight) {
 		ret.name = info.DaylightName;
+		ret.bias = info.Bias+info.DaylightBias;
 	} else {
 		ret.name = info.StandardName;
+		ret.bias = info.Bias;
 	}
 
 	// Bias value returned by GetTimeZoneInformation is inverted of what we expect
-	// For example on GMT-3 GetTimeZoneInformation return a Bias of 180, so invert the value to get -180
-	ret.bias = -info.Bias;
+	// For example, on GMT-3 GetTimeZoneInformation return a Bias of 180, so invert the value to get -180
+	ret.bias = -ret.bias;
 	return ret;
 }
 

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -2400,10 +2400,10 @@ OS::Date OS_Windows::get_date(bool utc) const {
 	else
 		GetLocalTime(&systemtime);
 
-	//Get DST information from Windows.
+	//Get DST information from Windows, but only if p_utc is false.
 	TIME_ZONE_INFORMATION info;
 	bool daylight = false;
-	if (GetTimeZoneInformation(&info) == TIME_ZONE_ID_DAYLIGHT) {
+	if (p_utc == false && GetTimeZoneInformation(&info) == TIME_ZONE_ID_DAYLIGHT) {
 		daylight = true;
 	}
 


### PR DESCRIPTION
The DST code on windows for both master and 3.x was set to always return false in OS.get_datetime(), and reported the incorrect DST bias. Fixes #59214 and Fixes #37571

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
