### PR TITLE
Add item tooltip access to `OptionButton`

### DIFF
--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -74,6 +74,13 @@
 				Returns the text of the item at index [code]idx[/code].
 			</description>
 		</method>
+		<method name="get_item_tooltip" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="idx" type="int" />
+			<description>
+				Returns the tooltip of the item at index [code]idx[/code].
+			</description>
+		</method>
 		<method name="get_popup" qualifiers="const">
 			<return type="PopupMenu" />
 			<description>
@@ -154,6 +161,14 @@
 			<argument index="1" name="text" type="String" />
 			<description>
 				Sets the text of the item at index [code]idx[/code].
+			</description>
+		</method>
+		<method name="set_item_tooltip">
+			<return type="void" />
+			<argument index="0" name="idx" type="int" />
+			<argument index="1" name="tooltip" type="String" />
+			<description>
+				Sets the tooltip of the item at index [code]idx[/code].
 			</description>
 		</method>
 	</methods>

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -240,6 +240,10 @@ void OptionButton::set_item_metadata(int p_idx, const Variant &p_metadata) {
 	popup->set_item_metadata(p_idx, p_metadata);
 }
 
+void OptionButton::set_item_tooltip(int p_idx, const String &p_tooltip) {
+	popup->set_item_tooltip(p_idx, p_tooltip);
+}
+
 void OptionButton::set_item_disabled(int p_idx, bool p_disabled) {
 	popup->set_item_disabled(p_idx, p_disabled);
 }
@@ -266,6 +270,10 @@ int OptionButton::get_item_index(int p_id) const {
 
 Variant OptionButton::get_item_metadata(int p_idx) const {
 	return popup->get_item_metadata(p_idx);
+}
+
+String OptionButton::get_item_tooltip(int p_idx) const {
+	return popup->get_item_tooltip(p_idx);
 }
 
 bool OptionButton::is_item_disabled(int p_idx) const {
@@ -385,11 +393,13 @@ void OptionButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_item_disabled", "idx", "disabled"), &OptionButton::set_item_disabled);
 	ClassDB::bind_method(D_METHOD("set_item_id", "idx", "id"), &OptionButton::set_item_id);
 	ClassDB::bind_method(D_METHOD("set_item_metadata", "idx", "metadata"), &OptionButton::set_item_metadata);
+	ClassDB::bind_method(D_METHOD("set_item_tooltip", "idx", "tooltip"), &OptionButton::set_item_tooltip);
 	ClassDB::bind_method(D_METHOD("get_item_text", "idx"), &OptionButton::get_item_text);
 	ClassDB::bind_method(D_METHOD("get_item_icon", "idx"), &OptionButton::get_item_icon);
 	ClassDB::bind_method(D_METHOD("get_item_id", "idx"), &OptionButton::get_item_id);
 	ClassDB::bind_method(D_METHOD("get_item_index", "id"), &OptionButton::get_item_index);
 	ClassDB::bind_method(D_METHOD("get_item_metadata", "idx"), &OptionButton::get_item_metadata);
+	ClassDB::bind_method(D_METHOD("get_item_tooltip", "idx"), &OptionButton::get_item_tooltip);
 	ClassDB::bind_method(D_METHOD("is_item_disabled", "idx"), &OptionButton::is_item_disabled);
 	ClassDB::bind_method(D_METHOD("add_separator"), &OptionButton::add_separator);
 	ClassDB::bind_method(D_METHOD("clear"), &OptionButton::clear);

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -68,6 +68,7 @@ public:
 	void set_item_id(int p_idx, int p_id);
 	void set_item_metadata(int p_idx, const Variant &p_metadata);
 	void set_item_disabled(int p_idx, bool p_disabled);
+	void set_item_tooltip(int p_idx, const String &p_tooltip);
 
 	String get_item_text(int p_idx) const;
 	Ref<Texture2D> get_item_icon(int p_idx) const;
@@ -75,6 +76,7 @@ public:
 	int get_item_index(int p_id) const;
 	Variant get_item_metadata(int p_idx) const;
 	bool is_item_disabled(int p_idx) const;
+	String get_item_tooltip(int p_idx) const;
 
 	void set_item_count(int p_count);
 	int get_item_count() const;


### PR DESCRIPTION
We already have access to the menu items' text and icon directly in `OptionButton`. It's awkward having to get the popup only for tooltip access.