### PR TITLE
RID: Change comparison operators to use RID_Data id instead of address

### DIFF
--- a/core/rid.h
+++ b/core/rid.h
@@ -68,13 +68,13 @@ public:
 		return _data == p_rid._data;
 	}
 	_FORCE_INLINE_ bool operator<(const RID &p_rid) const {
-		return _data < p_rid._data;
+		return get_id() < p_rid.get_id();
 	}
 	_FORCE_INLINE_ bool operator<=(const RID &p_rid) const {
-		return _data <= p_rid._data;
+		return get_id() <= p_rid.get_id();
 	}
 	_FORCE_INLINE_ bool operator>(const RID &p_rid) const {
-		return _data > p_rid._data;
+		return get_id() > p_rid.get_id();
 	}
 	_FORCE_INLINE_ bool operator!=(const RID &p_rid) const {
 		return _data != p_rid._data;


### PR DESCRIPTION
This should helps making sorting more deterministic in physics and rendering.

The same change was done for 4.0 in 4f163972bbd9c7379b01a1f9aa5310646ca7865e.

Alternative to #59192 fixing the issue as its root.
Helps with #25384 by making sorting deterministic - but I'm not sure it will make it predictable / as users expect it.

I could use help testing and making sure that this doesn't impact performance noticeably.

---

According to Sourcetrail, these operators are used like this:

- `RID::operator<`:
![image](https://user-images.githubusercontent.com/4701338/158786865-6fea8d54-c089-4bf2-860e-5202c27df1ce.png)
Through `Comparator` this is also used in `Map` and `Set`
- `RID::operator<=`: Used in `Variant::evaluate`
- `RID::operator>`: Never used.