### PR TITLE
Fix a parse error in the @export_enum editor

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3414,7 +3414,19 @@ EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_
 		case Variant::INT: {
 			if (p_hint == PROPERTY_HINT_ENUM) {
 				EditorPropertyEnum *editor = memnew(EditorPropertyEnum);
-				Vector<String> options = p_hint_text.split(",");
+				Vector<String> options;
+				Variant script = p_object->get_script();
+				bool use_hint_text = true;
+
+				if (script.get_type() != Variant::NIL && script.has_method("get_export_enum_hints")) {
+					options = script.call("get_export_enum_hints", p_path);
+					use_hint_text = options.is_empty();
+				}
+
+				if (use_hint_text) {
+					options = p_hint_text.split(",");
+				}
+
 				editor->setup(options);
 				return editor;
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -88,7 +88,7 @@ class GDScript : public Script {
 	Vector<Multiplayer::RPCConfig> rpc_functions;
 
 #ifdef TOOLS_ENABLED
-
+	Map<StringName, Vector<String>> export_enum_hints;
 	Map<StringName, int> member_lines;
 	Map<StringName, Variant> member_default_values;
 	List<PropertyInfo> members_cache;
@@ -215,6 +215,8 @@ public:
 	virtual const Vector<DocData::ClassDoc> &get_documentation() const override {
 		return docs;
 	}
+
+	Vector<String> get_export_enum_hints(const StringName &p_name) const;
 #endif // TOOLS_ENABLED
 
 	virtual Error reload(bool p_keep_state = false) override;


### PR DESCRIPTION
related issue: #58846 
Now `@export_enum("A, B", "C") var pick: int` will not cause a parse error, and the dropdown editor can show enum usually.
![image.png](https://s2.loli.net/2022/03/17/NE2GlizDYO43vjq.png)

But it is noticed that `@export_enum("A, B", "C", v) var pick: int`, where `var v = "D"`, has a hint string like this:
![image.png](https://s2.loli.net/2022/03/17/dHzNEAtVSjLZyc6.png)

Even though I process my code the same way, I think it may be weird, and it may need further discussion.