### PR TITLE
Remap property path based on path substrings

### DIFF
--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -35,14 +35,24 @@
 EditorPropertyNameProcessor *EditorPropertyNameProcessor::singleton = nullptr;
 
 String EditorPropertyNameProcessor::_capitalize_name(const String &p_name) const {
-	String capitalized_string = p_name.capitalize();
-
-	// Fix the casing of a few strings commonly found in editor property/setting names.
-	for (Map<String, String>::Element *E = capitalize_string_remaps.front(); E; E = E->next()) {
-		capitalized_string = capitalized_string.replace(E->key(), E->value());
+	const Map<String, String>::Element *cached = capitalize_string_cache.find(p_name);
+	if (cached) {
+		return cached->value();
 	}
 
-	return capitalized_string;
+	Vector<String> parts = p_name.split("_", false);
+	for (int i = 0; i < parts.size(); i++) {
+		const Map<String, String>::Element *remap = capitalize_string_remaps.find(parts[i]);
+		if (remap) {
+			parts.write[i] = remap->get();
+		} else {
+			parts.write[i] = parts[i].capitalize();
+		}
+	}
+	const String capitalized = String(" ").join(parts);
+
+	capitalize_string_cache[p_name] = capitalized;
+	return capitalized;
 }
 
 String EditorPropertyNameProcessor::process_name(const String &p_name) const {
@@ -69,66 +79,69 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	// The map name and value definition format should be kept synced with the regex.
 	capitalize_string_remaps["2d"] = "2D";
 	capitalize_string_remaps["3d"] = "3D";
-	capitalize_string_remaps["Aa"] = "AA";
-	capitalize_string_remaps["Adb"] = "ADB";
-	capitalize_string_remaps["Ao"] = "AO";
-	capitalize_string_remaps["Bptc"] = "BPTC";
-	capitalize_string_remaps["Bvh"] = "BVH";
-	capitalize_string_remaps["Csg"] = "CSG";
-	capitalize_string_remaps["Cpu"] = "CPU";
-	capitalize_string_remaps["Db"] = "dB";
-	capitalize_string_remaps["Dof"] = "DoF";
-	capitalize_string_remaps["Dpi"] = "DPI";
-	capitalize_string_remaps["Etc"] = "ETC";
-	capitalize_string_remaps["Fbx"] = "FBX";
-	capitalize_string_remaps["Fps"] = "FPS";
-	capitalize_string_remaps["Fov"] = "FOV";
-	capitalize_string_remaps["Fsr"] = "FSR";
-	capitalize_string_remaps["Fs"] = "FS";
-	capitalize_string_remaps["Fxaa"] = "FXAA";
-	capitalize_string_remaps["Ggx"] = "GGX";
-	capitalize_string_remaps["Gi"] = "GI";
-	capitalize_string_remaps["Gdscript"] = "GDScript";
-	capitalize_string_remaps["Gles 2"] = "GLES2";
-	capitalize_string_remaps["Gles 3"] = "GLES3";
-	capitalize_string_remaps["Gpu"] = "GPU";
-	capitalize_string_remaps["Gui"] = "GUI";
-	capitalize_string_remaps["Hdr"] = "HDR";
-	capitalize_string_remaps["Hidpi"] = "hiDPI";
-	capitalize_string_remaps["Http"] = "HTTP";
-	capitalize_string_remaps["Ik"] = "IK";
-	capitalize_string_remaps["Ios"] = "iOS";
-	capitalize_string_remaps["Kb"] = "KB";
-	capitalize_string_remaps["Lod"] = "LOD";
-	capitalize_string_remaps["Msaa"] = "MSAA";
-	capitalize_string_remaps["Macos"] = "macOS";
-	capitalize_string_remaps["Opentype"] = "OpenType";
-	capitalize_string_remaps["Openxr"] = "OpenXR";
-	capitalize_string_remaps["Png"] = "PNG";
-	capitalize_string_remaps["Pvs"] = "PVS";
-	capitalize_string_remaps["Pvrtc"] = "PVRTC";
-	capitalize_string_remaps["S 3 Tc"] = "S3TC";
-	capitalize_string_remaps["Sdfgi"] = "SDFGI";
-	capitalize_string_remaps["Srgb"] = "sRGB";
-	capitalize_string_remaps["Ssao"] = "SSAO";
-	capitalize_string_remaps["Ssl"] = "SSL";
-	capitalize_string_remaps["Ssil"] = "SSIL";
-	capitalize_string_remaps["Ssh"] = "SSH";
-	capitalize_string_remaps["Sdf"] = "SDF";
-	capitalize_string_remaps["Sdk"] = "SDK";
-	capitalize_string_remaps["Tcp"] = "TCP";
-	capitalize_string_remaps["Url"] = "URL";
-	capitalize_string_remaps["Uv 1"] = "UV1";
-	capitalize_string_remaps["Uv 2"] = "UV2";
-	capitalize_string_remaps["Uv"] = "UV";
-	capitalize_string_remaps["Uwp"] = "UWP";
-	capitalize_string_remaps["Vram"] = "VRAM";
-	capitalize_string_remaps["Vsync"] = "V-Sync";
-	capitalize_string_remaps["Vector 2"] = "Vector2";
-	capitalize_string_remaps["Webp"] = "WebP";
-	capitalize_string_remaps["Webrtc"] = "WebRTC";
-	capitalize_string_remaps["Websocket"] = "WebSocket";
-	capitalize_string_remaps["Xr"] = "XR";
+	capitalize_string_remaps["aa"] = "AA";
+	capitalize_string_remaps["aabb"] = "AABB";
+	capitalize_string_remaps["adb"] = "ADB";
+	capitalize_string_remaps["ao"] = "AO";
+	capitalize_string_remaps["bptc"] = "BPTC";
+	capitalize_string_remaps["bvh"] = "BVH";
+	capitalize_string_remaps["cpu"] = "CPU";
+	capitalize_string_remaps["csg"] = "CSG";
+	capitalize_string_remaps["db"] = "dB";
+	capitalize_string_remaps["dof"] = "DoF";
+	capitalize_string_remaps["dpi"] = "DPI";
+	capitalize_string_remaps["etc"] = "ETC";
+	capitalize_string_remaps["etc2"] = "ETC2";
+	capitalize_string_remaps["fov"] = "FOV";
+	capitalize_string_remaps["fps"] = "FPS";
+	capitalize_string_remaps["fs"] = "FS";
+	capitalize_string_remaps["fsr"] = "FSR";
+	capitalize_string_remaps["fxaa"] = "FXAA";
+	capitalize_string_remaps["gdscript"] = "GDScript";
+	capitalize_string_remaps["ggx"] = "GGX";
+	capitalize_string_remaps["gi"] = "GI";
+	capitalize_string_remaps["gles2"] = "GLES2";
+	capitalize_string_remaps["gles3"] = "GLES3";
+	capitalize_string_remaps["gpu"] = "GPU";
+	capitalize_string_remaps["gui"] = "GUI";
+	capitalize_string_remaps["hdr"] = "HDR";
+	capitalize_string_remaps["hidpi"] = "hiDPI";
+	capitalize_string_remaps["http"] = "HTTP";
+	capitalize_string_remaps["ik"] = "IK";
+	capitalize_string_remaps["ios"] = "iOS";
+	capitalize_string_remaps["kb"] = "KB";
+	capitalize_string_remaps["lod"] = "LOD";
+	capitalize_string_remaps["macos"] = "macOS";
+	capitalize_string_remaps["msaa"] = "MSAA";
+	capitalize_string_remaps["opentype"] = "OpenType";
+	capitalize_string_remaps["openxr"] = "OpenXR";
+	capitalize_string_remaps["png"] = "PNG";
+	capitalize_string_remaps["po2"] = "Power of 2";
+	capitalize_string_remaps["pvs"] = "PVS";
+	capitalize_string_remaps["pvrtc"] = "PVRTC";
+	capitalize_string_remaps["s3tc"] = "S3TC";
+	capitalize_string_remaps["sdf"] = "SDF";
+	capitalize_string_remaps["sdfgi"] = "SDFGI";
+	capitalize_string_remaps["sdk"] = "SDK";
+	capitalize_string_remaps["ssao"] = "SSAO";
+	capitalize_string_remaps["ssh"] = "SSH";
+	capitalize_string_remaps["ssil"] = "SSIL";
+	capitalize_string_remaps["ssl"] = "SSL";
+	capitalize_string_remaps["tcp"] = "TCP";
+	capitalize_string_remaps["url"] = "URL";
+	capitalize_string_remaps["urls"] = "URLs";
+	capitalize_string_remaps["ui"] = "UI";
+	capitalize_string_remaps["uv"] = "UV";
+	capitalize_string_remaps["uv1"] = "UV1";
+	capitalize_string_remaps["uv2"] = "UV2";
+	capitalize_string_remaps["uwp"] = "UWP";
+	capitalize_string_remaps["vector2"] = "Vector2";
+	capitalize_string_remaps["vram"] = "VRAM";
+	capitalize_string_remaps["vsync"] = "V-Sync";
+	capitalize_string_remaps["webp"] = "WebP";
+	capitalize_string_remaps["webrtc"] = "WebRTC";
+	capitalize_string_remaps["websocket"] = "WebSocket";
+	capitalize_string_remaps["xr"] = "XR";
 }
 
 EditorPropertyNameProcessor::~EditorPropertyNameProcessor() {

--- a/editor/editor_property_name_processor.h
+++ b/editor/editor_property_name_processor.h
@@ -38,6 +38,7 @@ class EditorPropertyNameProcessor : public Node {
 
 	static EditorPropertyNameProcessor *singleton;
 
+	mutable Map<String, String> capitalize_string_cache;
 	Map<String, String> capitalize_string_remaps;
 
 	String _capitalize_name(const String &p_name) const;

--- a/editor/translations/extract.py
+++ b/editor/translations/extract.py
@@ -87,17 +87,24 @@ capitalize_re = re.compile(r"(?<=\D)(?=\d)|(?<=\d)(?=\D([a-z]|\d))")
 
 
 def _process_editor_string(name):
-    # See String::capitalize().
-    # fmt: off
-    capitalized = " ".join(
-        part.title()
-        for part in capitalize_re.sub("_", name).replace("_", " ").split()
-    )
-    # fmt: on
-    # See EditorStringProcessor::process_string().
-    for key, value in remaps.items():
-        capitalized = capitalized.replace(key, value)
-    return capitalized
+    # See EditorPropertyNameProcessor::process_string().
+    capitalized_parts = []
+    for segment in name.split("_"):
+        if not segment:
+            continue
+        remapped = remaps.get(segment)
+        if remapped:
+            capitalized_parts.append(remapped)
+        else:
+            # See String::capitalize().
+            # fmt: off
+            capitalized_parts.append(" ".join(
+                part.title()
+                for part in capitalize_re.sub("_", segment).replace("_", " ").split()
+            ))
+            # fmt: on
+
+    return " ".join(capitalized_parts)
 
 
 def _write_message(msgctx, msg, msg_plural, location):


### PR DESCRIPTION
As discussed on RocketChat, the original capitalization approach caused some problems. Remapping property paths based on path substrings works better.

Also added captialization caching.