### PR TITLE
[3.x] Use 3001 instead of 1001.

### DIFF
--- a/modules/websocket/library_godot_websocket.js
+++ b/modules/websocket/library_godot_websocket.js
@@ -135,7 +135,7 @@ const GodotWebSocket = {
 			if (!ref) {
 				return;
 			}
-			GodotWebSocket.close(p_id, 1001, '');
+			GodotWebSocket.close(p_id, 3001, 'destroyed');
 			IDHandler.remove(p_id);
 			ref.onopen = null;
 			ref.onmessage = null;


### PR DESCRIPTION
3.x version of https://github.com/godotengine/godot/pull/59255

Calling connect_to_host on a websocket twice in a row on HTML5 builds produces the follow HTML exception which crashes the engine.

![image](https://user-images.githubusercontent.com/78934401/158916187-97bd99ba-0c65-40f8-b3c3-71c0c5442a2a.png)

This happens because 1001 is a reserved code for the websocket close command.

I can see how this documentation would be confusing:
https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/close

3001 does not crash.