### PR TITLE
Rename the "BackSpace" and "BackTab" key strings to "Backspace"/"Backtab"

### DIFF
--- a/core/os/keyboard.cpp
+++ b/core/os/keyboard.cpp
@@ -41,8 +41,8 @@ static const _KeyCodeText _keycodes[] = {
 	/* clang-format off */
 	{Key::ESCAPE                ,"Escape"},
 	{Key::TAB                   ,"Tab"},
-	{Key::BACKTAB               ,"BackTab"},
-	{Key::BACKSPACE             ,"BackSpace"},
+	{Key::BACKTAB               ,"Backtab"},
+	{Key::BACKSPACE             ,"Backspace"},
 	{Key::ENTER                 ,"Enter"},
 	{Key::KP_ENTER              ,"Kp Enter"},
 	{Key::INSERT                ,"Insert"},


### PR DESCRIPTION
Minor aesthetic change that should be visible in the Editor Settings' Shortcuts tab :slightly_smiling_face:

See https://github.com/godotengine/godot-proposals/discussions/4098#discussioncomment-2259883.

PS: How is Delete-as-Backspace handled on macOS in `master` right now? Is there any automatic conversion happening? I can't find it.