### PR TITLE
Allow overriding face materials & UVs for CSGBox, CSGCylinder, and CSGPolygon

### DIFF
--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -33,6 +33,7 @@
 
 #define CSGJS_HEADER_ONLY
 
+#include "core/math/transform_2d.h"
 #include "csg.h"
 #include "scene/3d/path_3d.h"
 #include "scene/3d/visual_instance_3d.h"
@@ -242,17 +243,47 @@ class CSGBox3D : public CSGPrimitive3D {
 	Ref<Material> material;
 	Vector3 size = Vector3(1, 1, 1);
 
+	Vector<Ref<Material>> face_material_overrides;
+	Vector<Transform2D> face_uv_transforms;
+
 protected:
 	static void _bind_methods();
 
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
 public:
+	int get_face_count() const;
+
 	void set_size(const Vector3 &p_size);
 	Vector3 get_size() const;
 
 	void set_material(const Ref<Material> &p_material);
 	Ref<Material> get_material() const;
 
-	CSGBox3D() {}
+	void set_face_uv_scale(int p_face, const Vector2 &p_scale);
+	Vector2 get_face_uv_scale(int p_face) const;
+
+	void set_face_uv_offset(int p_face, const Vector2 &p_offset);
+	Vector2 get_face_uv_offset(int p_face) const;
+
+	void set_face_uv_rotation(int p_face, float p_rotation);
+	float get_face_uv_rotation(int p_face) const;
+
+	void set_face_uv_skew(int p_face, float p_skew);
+	float get_face_uv_skew(int p_face) const;
+
+	void set_face_uv_transform(int p_face, const Transform2D &p_uv_transform);
+	Transform2D get_face_uv_transform(int p_face) const;
+
+	void set_face_override_material(int p_face, const Ref<Material> &p_material);
+	Ref<Material> get_face_override_material(int p_face) const;
+
+	CSGBox3D() {
+		face_material_overrides.resize(6);
+		face_uv_transforms.resize(6);
+	}
 };
 
 class CSGCylinder3D : public CSGPrimitive3D {
@@ -265,11 +296,19 @@ class CSGCylinder3D : public CSGPrimitive3D {
 	int sides;
 	bool cone;
 	bool smooth_faces;
+	Vector<Ref<Material>> face_material_overrides;
+	Vector<Transform2D> face_uv_transforms;
 
 protected:
 	static void _bind_methods();
 
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
 public:
+	int get_face_count() const;
+
 	void set_radius(const float p_radius);
 	float get_radius() const;
 
@@ -287,6 +326,24 @@ public:
 
 	void set_material(const Ref<Material> &p_material);
 	Ref<Material> get_material() const;
+
+	void set_face_uv_scale(int p_face, const Vector2 &p_scale);
+	Vector2 get_face_uv_scale(int p_face) const;
+
+	void set_face_uv_offset(int p_face, const Vector2 &p_offset);
+	Vector2 get_face_uv_offset(int p_face) const;
+
+	void set_face_uv_rotation(int p_face, float p_rotation);
+	float get_face_uv_rotation(int p_face) const;
+
+	void set_face_uv_skew(int p_face, float p_skew);
+	float get_face_uv_skew(int p_face) const;
+
+	void set_face_uv_transform(int p_face, const Transform2D &p_uv_transform);
+	Transform2D get_face_uv_transform(int p_face) const;
+
+	void set_face_override_material(int p_face, Ref<Material> p_material);
+	Ref<Material> get_face_override_material(int p_face) const;
 
 	CSGCylinder3D();
 };
@@ -375,6 +432,9 @@ private:
 	real_t path_u_distance;
 	bool path_joined;
 
+	Vector<Ref<Material>> face_material_overrides;
+	Vector<Transform2D> face_uv_transforms;
+
 	bool _is_editable_3d_polygon() const;
 	bool _has_editable_3d_polygon_no_depth() const;
 
@@ -386,7 +446,13 @@ protected:
 	virtual void _validate_property(PropertyInfo &property) const override;
 	void _notification(int p_what);
 
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
 public:
+	int get_face_count() const;
+
 	void set_polygon(const Vector<Vector2> &p_polygon);
 	Vector<Vector2> get_polygon() const;
 
@@ -434,6 +500,24 @@ public:
 
 	void set_material(const Ref<Material> &p_material);
 	Ref<Material> get_material() const;
+
+	void set_face_uv_scale(int p_face, const Vector2 &p_scale);
+	Vector2 get_face_uv_scale(int p_face) const;
+
+	void set_face_uv_offset(int p_face, const Vector2 &p_offset);
+	Vector2 get_face_uv_offset(int p_face) const;
+
+	void set_face_uv_rotation(int p_face, float p_rotation);
+	float get_face_uv_rotation(int p_face) const;
+
+	void set_face_uv_skew(int p_face, float p_skew);
+	float get_face_uv_skew(int p_face) const;
+
+	void set_face_uv_transform(int p_face, const Transform2D &p_uv_transform);
+	Transform2D get_face_uv_transform(int p_face) const;
+
+	void set_face_override_material(int p_face, Ref<Material> p_material);
+	Ref<Material> get_face_override_material(int p_face) const;
 
 	CSGPolygon3D();
 };

--- a/modules/csg/doc_classes/CSGBox3D.xml
+++ b/modules/csg/doc_classes/CSGBox3D.xml
@@ -10,9 +10,101 @@
 	<tutorials>
 		<link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
 	</tutorials>
+	<methods>
+		<method name="get_face_override_material" qualifiers="const">
+			<return type="Material" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the override material for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="get_face_uv_offset" qualifiers="const">
+			<return type="Vector2" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV offset for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="get_face_uv_rotation" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV rotation for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="get_face_uv_scale" qualifiers="const">
+			<return type="Vector2" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV scale for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="get_face_uv_skew" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV skew for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="get_face_uv_transform" qualifiers="const">
+			<return type="Transform2D" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV transform for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_override_material">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="Material" />
+			<description>
+				Sets override material for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_uv_offset">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="Vector2" />
+			<description>
+				Sets UV offset for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_uv_rotation">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="float" />
+			<description>
+				Sets UV rotation for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_uv_scale">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="Vector2" />
+			<description>
+				Sets UV scale for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_uv_skew">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="float" />
+			<description>
+				Sets UV skew for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_uv_transform">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="Transform2D" />
+			<description>
+				Sets UV transform for the given [code]face[/code].
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
-			The material used to render the box.
+			The default material used to render the box.
 		</member>
 		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(1, 1, 1)">
 			The box's width, height and depth.

--- a/modules/csg/doc_classes/CSGCylinder3D.xml
+++ b/modules/csg/doc_classes/CSGCylinder3D.xml
@@ -10,6 +10,96 @@
 	<tutorials>
 		<link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
 	</tutorials>
+	<methods>
+		<method name="get_face_material_override" qualifiers="const">
+			<return type="Material" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_face_uv_offset" qualifiers="const">
+			<return type="Vector2" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV offset for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="get_face_uv_rotation" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV rotation for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="get_face_uv_scale" qualifiers="const">
+			<return type="Vector2" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV scale for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="get_face_uv_skew" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV skew for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="get_face_uv_transform" qualifiers="const">
+			<return type="Transform2D" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV transform for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_material_override">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="Material" />
+			<description>
+			</description>
+		</method>
+		<method name="set_face_uv_offset">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="Vector2" />
+			<description>
+				Sets UV offset for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_uv_rotation">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="float" />
+			<description>
+				Sets UV rotation for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_uv_scale">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="Vector2" />
+			<description>
+				Sets UV scale for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_uv_skew">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="float" />
+			<description>
+				Sets UV skew for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_uv_transform">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="Transform2D" />
+			<description>
+				Sets UV transform for the given [code]face[/code].
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="cone" type="bool" setter="set_cone" getter="is_cone" default="false">
 			If [code]true[/code] a cone is created, the [member radius] will only apply to one side.
@@ -18,7 +108,7 @@
 			The height of the cylinder.
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
-			The material used to render the cylinder.
+			The default material used to render the cylinder. This material is used by the top and bottom faces if their materials are not set.
 		</member>
 		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
 			The radius of the cylinder.

--- a/modules/csg/doc_classes/CSGPolygon3D.xml
+++ b/modules/csg/doc_classes/CSGPolygon3D.xml
@@ -10,12 +10,103 @@
 	<tutorials>
 		<link title="Prototyping levels with CSG">$DOCS_URL/tutorials/3d/csg_tools.html</link>
 	</tutorials>
+	<methods>
+		<method name="get_face_material_override" qualifiers="const">
+			<return type="Material" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_face_uv_offset" qualifiers="const">
+			<return type="Vector2" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV offset for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="get_face_uv_rotation" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV rotation for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="get_face_uv_scale" qualifiers="const">
+			<return type="Vector2" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV scale for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="get_face_uv_skew" qualifiers="const">
+			<return type="float" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV skew for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="get_face_uv_transform" qualifiers="const">
+			<return type="Transform2D" />
+			<argument index="0" name="arg0" type="int" />
+			<description>
+				Returns the UV transform for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_material_override">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="Material" />
+			<description>
+			</description>
+		</method>
+		<method name="set_face_uv_offset">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="Vector2" />
+			<description>
+				Sets UV offset for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_uv_rotation">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="float" />
+			<description>
+				Sets UV rotation for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_uv_scale">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="Vector2" />
+			<description>
+				Sets UV scale for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_uv_skew">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="float" />
+			<description>
+				Sets UV skew for the given [code]face[/code].
+			</description>
+		</method>
+		<method name="set_face_uv_transform">
+			<return type="void" />
+			<argument index="0" name="arg0" type="int" />
+			<argument index="1" name="arg1" type="Transform2D" />
+			<description>
+				Sets UV transform for the given [code]face[/code].
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="depth" type="float" setter="set_depth" getter="get_depth" default="1.0">
 			When [member mode] is [constant MODE_DEPTH], the depth of the extrusion.
 		</member>
 		<member name="material" type="Material" setter="set_material" getter="get_material">
-			Material to use for the resulting mesh. The UV maps the top half of the material to the extruded shape (U along the length of the extrusions and V around the outline of the [member polygon]), the bottom-left quarter to the front end face, and the bottom-right quarter to the back end face.
+			The default material to use for the resulting mesh. The UV maps the top half of the material to the extruded shape (U along the length of the extrusions and V around the outline of the [member polygon]), the bottom-left quarter to the front end face, and the bottom-right quarter to the back end face.
+			This material is used by the front and back faces if their materials are not set.
 		</member>
 		<member name="mode" type="int" setter="set_mode" getter="get_mode" enum="CSGPolygon3D.Mode" default="0">
 			The [member mode] used to extrude the [member polygon].


### PR DESCRIPTION
Add unique face materials and UV transforms for select CSG nodes.

This is in response to godotengine/godot-proposals#937 and godotengine/godot-proposals#2879

This is backwards compatible, since the old `material` property is used as a fallback when any of the new materials are `null`.

![Screenshot from 2022-04-10 14-31-50](https://user-images.githubusercontent.com/872609/162616000-11b086ff-9f38-4e90-8b6e-372e9df81c19.png)

![Screenshot from 2022-04-10 14-34-16](https://user-images.githubusercontent.com/872609/162616086-c7873ce5-8916-4884-aac8-57abfa13b2f6.png)


#### Simple demo project:
[csg-faces-demo-3.zip](https://github.com/godotengine/godot/files/8458858/csg-faces-demo-3.zip)


