### PR TITLE
Use changed signals when editing material properties and shader params

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3250,6 +3250,8 @@ void EditorInspector::_edit_set(const String &p_name, const Variant &p_value, bo
 					undo_redo->add_undo_method(r, "setup_local_to_scene");
 				}
 			}
+			undo_redo->add_do_method(r, "emit_changed");
+			undo_redo->add_undo_method(r, "emit_changed");
 		}
 		undo_redo->add_do_method(this, "emit_signal", _prop_edited, p_name);
 		undo_redo->add_undo_method(this, "emit_signal", _prop_edited, p_name);

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -276,6 +276,7 @@ void ShaderMaterial::set_shader_param(const StringName &p_param, const Variant &
 			RS::get_singleton()->material_set_param(_get_material(), p_param, p_value);
 		}
 	}
+	emit_changed();
 }
 
 Variant ShaderMaterial::get_shader_param(const StringName &p_param) const {


### PR DESCRIPTION
Implements proposed changes from [#59196](https://github.com/godotengine/godot/issues/59156)

Material properties edited through the editor (or through code) will emit the Resource's `changed` signal. Shader params are also affected similarly.

Note: If the material is replaced entirely, the tool script has to be reloaded in order to re-connect the signal. That is an un-intuitive user experience use case that can be problematic if you aren't paying attention. Instead, I believe it would be better handled if the Mesh produced a signal that its material has been replaced to cover that use case.

*Bugsquad edit:*
- Fixes #59156