### PR TITLE
Convert uses of `FileAccess *` to `FileAccessRef` to prevent memleaks

### DIFF
--- a/core/io/dir_access.cpp
+++ b/core/io/dir_access.cpp
@@ -276,22 +276,12 @@ String DirAccess::get_full_path(const String &p_path, AccessType p_access) {
 }
 
 Error DirAccess::copy(String p_from, String p_to, int p_chmod_flags) {
-	//printf("copy %s -> %s\n",p_from.ascii().get_data(),p_to.ascii().get_data());
 	Error err;
-	FileAccess *fsrc = FileAccess::open(p_from, FileAccess::READ, &err);
+	FileAccessRef fsrc = FileAccess::open(p_from, FileAccess::READ, &err);
+	ERR_FAIL_COND_V_MSG(err != OK, err, "Failed to open " + p_from);
 
-	if (err) {
-		ERR_PRINT("Failed to open " + p_from);
-		return err;
-	}
-
-	FileAccess *fdst = FileAccess::open(p_to, FileAccess::WRITE, &err);
-	if (err) {
-		fsrc->close();
-		memdelete(fsrc);
-		ERR_PRINT("Failed to open " + p_to);
-		return err;
-	}
+	FileAccessRef fdst = FileAccess::open(p_to, FileAccess::WRITE, &err);
+	ERR_FAIL_COND_V_MSG(err != OK, err, "Failed to open " + p_to);
 
 	fsrc->seek_end(0);
 	int size = fsrc->get_position();
@@ -318,9 +308,6 @@ Error DirAccess::copy(String p_from, String p_to, int p_chmod_flags) {
 			err = OK;
 		}
 	}
-
-	memdelete(fsrc);
-	memdelete(fdst);
 
 	return err;
 }

--- a/core/io/file_access.cpp
+++ b/core/io/file_access.cpp
@@ -55,11 +55,10 @@ bool FileAccess::exists(const String &p_name) {
 		return true;
 	}
 
-	FileAccess *f = open(p_name, READ);
+	FileAccessRef f = open(p_name, READ);
 	if (!f) {
 		return false;
 	}
-	memdelete(f);
 	return true;
 }
 
@@ -463,11 +462,10 @@ uint64_t FileAccess::get_modified_time(const String &p_file) {
 		return 0;
 	}
 
-	FileAccess *fa = create_for_path(p_file);
+	FileAccessRef fa = create_for_path(p_file);
 	ERR_FAIL_COND_V_MSG(!fa, 0, "Cannot create FileAccess for path '" + p_file + "'.");
 
 	uint64_t mt = fa->_get_modified_time(p_file);
-	memdelete(fa);
 	return mt;
 }
 
@@ -476,11 +474,10 @@ uint32_t FileAccess::get_unix_permissions(const String &p_file) {
 		return 0;
 	}
 
-	FileAccess *fa = create_for_path(p_file);
+	FileAccessRef fa = create_for_path(p_file);
 	ERR_FAIL_COND_V_MSG(!fa, 0, "Cannot create FileAccess for path '" + p_file + "'.");
 
 	uint32_t mt = fa->_get_unix_permissions(p_file);
-	memdelete(fa);
 	return mt;
 }
 
@@ -489,11 +486,10 @@ Error FileAccess::set_unix_permissions(const String &p_file, uint32_t p_permissi
 		return ERR_UNAVAILABLE;
 	}
 
-	FileAccess *fa = create_for_path(p_file);
+	FileAccessRef fa = create_for_path(p_file);
 	ERR_FAIL_COND_V_MSG(!fa, ERR_CANT_CREATE, "Cannot create FileAccess for path '" + p_file + "'.");
 
 	Error err = fa->_set_unix_permissions(p_file, p_permissions);
-	memdelete(fa);
 	return err;
 }
 
@@ -559,7 +555,7 @@ void FileAccess::store_buffer(const uint8_t *p_src, uint64_t p_length) {
 }
 
 Vector<uint8_t> FileAccess::get_file_as_array(const String &p_path, Error *r_error) {
-	FileAccess *f = FileAccess::open(p_path, READ, r_error);
+	FileAccessRef f = FileAccess::open(p_path, READ, r_error);
 	if (!f) {
 		if (r_error) { // if error requested, do not throw error
 			return Vector<uint8_t>();
@@ -569,7 +565,6 @@ Vector<uint8_t> FileAccess::get_file_as_array(const String &p_path, Error *r_err
 	Vector<uint8_t> data;
 	data.resize(f->get_length());
 	f->get_buffer(data.ptrw(), data.size());
-	memdelete(f);
 	return data;
 }
 
@@ -592,7 +587,7 @@ String FileAccess::get_file_as_string(const String &p_path, Error *r_error) {
 }
 
 String FileAccess::get_md5(const String &p_file) {
-	FileAccess *f = FileAccess::open(p_file, READ);
+	FileAccessRef f = FileAccess::open(p_file, READ);
 	if (!f) {
 		return String();
 	}
@@ -615,8 +610,6 @@ String FileAccess::get_md5(const String &p_file) {
 	unsigned char hash[16];
 	ctx.finish(hash);
 
-	memdelete(f);
-
 	return String::md5(hash);
 }
 
@@ -625,7 +618,7 @@ String FileAccess::get_multiple_md5(const Vector<String> &p_file) {
 	ctx.start();
 
 	for (int i = 0; i < p_file.size(); i++) {
-		FileAccess *f = FileAccess::open(p_file[i], READ);
+		FileAccessRef f = FileAccess::open(p_file[i], READ);
 		ERR_CONTINUE(!f);
 
 		unsigned char step[32768];
@@ -639,7 +632,6 @@ String FileAccess::get_multiple_md5(const Vector<String> &p_file) {
 				break;
 			}
 		}
-		memdelete(f);
 	}
 
 	unsigned char hash[16];
@@ -649,7 +641,7 @@ String FileAccess::get_multiple_md5(const Vector<String> &p_file) {
 }
 
 String FileAccess::get_sha256(const String &p_file) {
-	FileAccess *f = FileAccess::open(p_file, READ);
+	FileAccessRef f = FileAccess::open(p_file, READ);
 	if (!f) {
 		return String();
 	}
@@ -672,6 +664,5 @@ String FileAccess::get_sha256(const String &p_file) {
 	unsigned char hash[32];
 	ctx.finish(hash);
 
-	memdelete(f);
 	return String::hex_encode_buffer(hash, 32);
 }

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -347,11 +347,10 @@ void FileAccessCompressed::store_8(uint8_t p_dest) {
 }
 
 bool FileAccessCompressed::file_exists(const String &p_name) {
-	FileAccess *fa = FileAccess::open(p_name, FileAccess::READ);
+	FileAccessRef fa = FileAccess::open(p_name, FileAccess::READ);
 	if (!fa) {
 		return false;
 	}
-	memdelete(fa);
 	return true;
 }
 

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -291,11 +291,10 @@ void FileAccessEncrypted::store_8(uint8_t p_dest) {
 }
 
 bool FileAccessEncrypted::file_exists(const String &p_name) {
-	FileAccess *fa = FileAccess::open(p_name, FileAccess::READ);
+	FileAccessRef fa = FileAccess::open(p_name, FileAccess::READ);
 	if (!fa) {
 		return false;
 	}
-	memdelete(fa);
 	return true;
 }
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -126,7 +126,7 @@ PackedData::~PackedData() {
 //////////////////////////////////////////////////////////////////
 
 bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, uint64_t p_offset) {
-	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
+	FileAccessRef f = FileAccess::open(p_path, FileAccess::READ);
 	if (!f) {
 		return false;
 	}
@@ -138,8 +138,6 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 	if (magic != PACK_HEADER_MAGIC) {
 		// loading with offset feature not supported for self contained exe files
 		if (p_offset != 0) {
-			f->close();
-			memdelete(f);
 			ERR_FAIL_V_MSG(false, "Loading self-contained executable with offset not supported.");
 		}
 
@@ -148,8 +146,6 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 		f->seek(f->get_position() - 4);
 		magic = f->get_32();
 		if (magic != PACK_HEADER_MAGIC) {
-			f->close();
-			memdelete(f);
 			return false;
 		}
 		f->seek(f->get_position() - 12);
@@ -159,8 +155,6 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 
 		magic = f->get_32();
 		if (magic != PACK_HEADER_MAGIC) {
-			f->close();
-			memdelete(f);
 			return false;
 		}
 	}
@@ -171,13 +165,9 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 	f->get_32(); // patch number, not used for validation.
 
 	if (version != PACK_FORMAT_VERSION) {
-		f->close();
-		memdelete(f);
 		ERR_FAIL_V_MSG(false, "Pack version unsupported: " + itos(version) + ".");
 	}
 	if (ver_major > VERSION_MAJOR || (ver_major == VERSION_MAJOR && ver_minor > VERSION_MINOR)) {
-		f->close();
-		memdelete(f);
 		ERR_FAIL_V_MSG(false, "Pack created with a newer version of the engine: " + itos(ver_major) + "." + itos(ver_minor) + ".");
 	}
 
@@ -196,8 +186,6 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 	if (enc_directory) {
 		FileAccessEncrypted *fae = memnew(FileAccessEncrypted);
 		if (!fae) {
-			f->close();
-			memdelete(f);
 			ERR_FAIL_V_MSG(false, "Can't open encrypted pack directory.");
 		}
 
@@ -209,8 +197,6 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 
 		Error err = fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
 		if (err) {
-			f->close();
-			memdelete(f);
 			memdelete(fae);
 			ERR_FAIL_V_MSG(false, "Can't open encrypted pack directory.");
 		}
@@ -236,8 +222,6 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 		PackedData::get_singleton()->add_path(p_path, path, ofs + p_offset, size, md5, this, p_replace_files, (flags & PACK_FILE_ENCRYPTED));
 	}
 
-	f->close();
-	memdelete(f);
 	return true;
 }
 

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -86,9 +86,7 @@ static long godot_seek(voidpf opaque, voidpf stream, uLong offset, int origin) {
 static int godot_close(voidpf opaque, voidpf stream) {
 	FileAccess *f = (FileAccess *)stream;
 	if (f) {
-		f->close();
 		memdelete(f);
-		f = nullptr;
 	}
 	return 0;
 }

--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -123,7 +123,7 @@ void ImageLoader::cleanup() {
 /////////////////
 
 RES ResourceFormatLoaderImage::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
-	FileAccess *f = FileAccess::open(p_path, FileAccess::READ);
+	FileAccessRef f = FileAccess::open(p_path, FileAccess::READ);
 	if (!f) {
 		if (r_error) {
 			*r_error = ERR_CANT_OPEN;
@@ -136,7 +136,6 @@ RES ResourceFormatLoaderImage::load(const String &p_path, const String &p_origin
 
 	bool unrecognized = header[0] != 'G' || header[1] != 'D' || header[2] != 'I' || header[3] != 'M';
 	if (unrecognized) {
-		memdelete(f);
 		if (r_error) {
 			*r_error = ERR_FILE_UNRECOGNIZED;
 		}
@@ -155,7 +154,6 @@ RES ResourceFormatLoaderImage::load(const String &p_path, const String &p_origin
 	}
 
 	if (idx == -1) {
-		memdelete(f);
 		if (r_error) {
 			*r_error = ERR_FILE_UNRECOGNIZED;
 		}
@@ -166,8 +164,6 @@ RES ResourceFormatLoaderImage::load(const String &p_path, const String &p_origin
 	image.instantiate();
 
 	Error err = ImageLoader::loader[idx]->load_image(image, f, false, 1.0);
-
-	memdelete(f);
 
 	if (err != OK) {
 		if (r_error) {

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -112,7 +112,7 @@ Error PCKPacker::pck_start(const String &p_file, int p_alignment, const String &
 }
 
 Error PCKPacker::add_file(const String &p_file, const String &p_src, bool p_encrypt) {
-	FileAccess *f = FileAccess::open(p_src, FileAccess::READ);
+	FileAccessRef f = FileAccess::open(p_src, FileAccess::READ);
 	if (!f) {
 		return ERR_FILE_CANT_OPEN;
 	}
@@ -148,9 +148,6 @@ Error PCKPacker::add_file(const String &p_file, const String &p_src, bool p_encr
 	ofs = ofs + _size + pad;
 
 	files.push_back(pf);
-
-	f->close();
-	memdelete(f);
 
 	return OK;
 }
@@ -272,7 +269,7 @@ Error PCKPacker::flush(bool p_verbose) {
 }
 
 PCKPacker::~PCKPacker() {
-	if (file != nullptr) {
+	if (file) {
 		memdelete(file);
 	}
 	file = nullptr;

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -538,11 +538,8 @@ void ResourceCache::dump(const char *p_file, bool p_short) {
 
 	Map<String, int> type_count;
 
-	FileAccess *f = nullptr;
-	if (p_file) {
-		f = FileAccess::open(String::utf8(p_file), FileAccess::WRITE);
-		ERR_FAIL_COND_MSG(!f, "Cannot create file at path '" + String::utf8(p_file) + "'.");
-	}
+	FileAccessRef f = FileAccess::open(String::utf8(p_file), FileAccess::WRITE);
+	ERR_FAIL_COND_MSG(!f, "Cannot create file at path '" + String::utf8(p_file) + "'.");
 
 	const String *K = nullptr;
 	while ((K = resources.next(K))) {
@@ -555,20 +552,12 @@ void ResourceCache::dump(const char *p_file, bool p_short) {
 		type_count[r->get_class()]++;
 
 		if (!p_short) {
-			if (f) {
-				f->store_line(r->get_class() + ": " + r->get_path());
-			}
+			f->store_line(r->get_class() + ": " + r->get_path());
 		}
 	}
 
 	for (const KeyValue<String, int> &E : type_count) {
-		if (f) {
-			f->store_line(E.key + " count: " + itos(E.value));
-		}
-	}
-	if (f) {
-		f->close();
-		memdelete(f);
+		f->store_line(E.key + " count: " + itos(E.value));
 	}
 
 	lock.read_unlock();

--- a/core/io/resource_uid.cpp
+++ b/core/io/resource_uid.cpp
@@ -204,7 +204,7 @@ Error ResourceUID::update_cache() {
 	FileAccess *f = nullptr;
 	for (OrderedHashMap<ID, Cache>::Element E = unique_ids.front(); E; E = E.next()) {
 		if (!E.get().saved_to_cache) {
-			if (f == nullptr) {
+			if (!f) {
 				f = FileAccess::open(get_cache_file(), FileAccess::READ_WRITE); //append
 				if (!f) {
 					return ERR_CANT_OPEN;
@@ -220,10 +220,9 @@ Error ResourceUID::update_cache() {
 		}
 	}
 
-	if (f != nullptr) {
+	if (f) {
 		f->seek(0);
 		f->store_32(cache_entries); //update amount of entries
-		f->close();
 		memdelete(f);
 	}
 

--- a/core/io/xml_parser.cpp
+++ b/core/io/xml_parser.cpp
@@ -472,7 +472,7 @@ Error XMLParser::open_buffer(const Vector<uint8_t> &p_buffer) {
 
 Error XMLParser::open(const String &p_path) {
 	Error err;
-	FileAccess *file = FileAccess::open(p_path, FileAccess::READ, &err);
+	FileAccessRef file = FileAccess::open(p_path, FileAccess::READ, &err);
 
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot open file '" + p_path + "'.");
 
@@ -487,8 +487,6 @@ Error XMLParser::open(const String &p_path) {
 	file->get_buffer((uint8_t *)data, length);
 	data[length] = 0;
 	P = data;
-
-	memdelete(file);
 
 	return OK;
 }

--- a/core/io/zip_io.cpp
+++ b/core/io/zip_io.cpp
@@ -87,9 +87,7 @@ long zipio_seek(voidpf opaque, voidpf stream, uLong offset, int origin) {
 int zipio_close(voidpf opaque, voidpf stream) {
 	FileAccess *&f = *(FileAccess **)opaque;
 	if (f) {
-		f->close();
 		memdelete(f);
-		f = nullptr;
 	}
 	return 0;
 }

--- a/core/string/translation_po.cpp
+++ b/core/string/translation_po.cpp
@@ -35,7 +35,7 @@
 #ifdef DEBUG_TRANSLATION_PO
 void TranslationPO::print_translation_map() {
 	Error err;
-	FileAccess *file = FileAccess::open("translation_map_print_test.txt", FileAccess::WRITE, &err);
+	FileAccessRef file = FileAccess::open("translation_map_print_test.txt", FileAccess::WRITE, &err);
 	if (err != OK) {
 		ERR_PRINT("Failed to open translation_map_print_test.txt");
 		return;
@@ -62,7 +62,6 @@ void TranslationPO::print_translation_map() {
 			file->store_line("");
 		}
 	}
-	file->close();
 }
 #endif
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -217,17 +217,14 @@ Error ResourceFormatSaverShader::save(const String &p_path, const RES &p_resourc
 	String source = shader->get_code();
 
 	Error err;
-	FileAccess *file = FileAccess::open(p_path, FileAccess::WRITE, &err);
+	FileAccessRef file = FileAccess::open(p_path, FileAccess::WRITE, &err);
 
 	ERR_FAIL_COND_V_MSG(err, err, "Cannot save shader '" + p_path + "'.");
 
 	file->store_string(source);
 	if (file->get_error() != OK && file->get_error() != ERR_FILE_EOF) {
-		memdelete(file);
 		return ERR_CANT_CREATE;
 	}
-	file->close();
-	memdelete(file);
 
 	return OK;
 }

--- a/scene/resources/text_file.cpp
+++ b/scene/resources/text_file.cpp
@@ -51,7 +51,7 @@ void TextFile::reload_from_file() {
 Error TextFile::load_text(const String &p_path) {
 	Vector<uint8_t> sourcef;
 	Error err;
-	FileAccess *f = FileAccess::open(p_path, FileAccess::READ, &err);
+	FileAccessRef f = FileAccess::open(p_path, FileAccess::READ, &err);
 
 	ERR_FAIL_COND_V_MSG(err, err, "Cannot open TextFile '" + p_path + "'.");
 
@@ -59,8 +59,6 @@ Error TextFile::load_text(const String &p_path) {
 	sourcef.resize(len + 1);
 	uint8_t *w = sourcef.ptrw();
 	uint64_t r = f->get_buffer(w, len);
-	f->close();
-	memdelete(f);
 	ERR_FAIL_COND_V(r != len, ERR_CANT_OPEN);
 	w[len] = 0;
 

--- a/tests/core/math/test_math.cpp
+++ b/tests/core/math/test_math.cpp
@@ -513,14 +513,16 @@ MainLoop *test() {
 		return nullptr;
 	}
 
-	FileAccess *fa = FileAccess::open(test, FileAccess::READ);
-	ERR_FAIL_COND_V_MSG(!fa, nullptr, "Could not open file: " + test);
-
 	Vector<uint8_t> buf;
-	uint64_t flen = fa->get_length();
-	buf.resize(fa->get_length() + 1);
-	fa->get_buffer(buf.ptrw(), flen);
-	buf.write[flen] = 0;
+	{
+		FileAccessRef fa = FileAccess::open(test, FileAccess::READ);
+		ERR_FAIL_COND_V_MSG(!fa, nullptr, "Could not open file: " + test);
+
+		uint64_t flen = fa->get_length();
+		buf.resize(fa->get_length() + 1);
+		fa->get_buffer(buf.ptrw(), flen);
+		buf.write[flen] = 0;
+	}
 
 	String code;
 	code.parse_utf8((const char *)&buf[0]);

--- a/tests/servers/test_shader_lang.cpp
+++ b/tests/servers/test_shader_lang.cpp
@@ -313,22 +313,19 @@ MainLoop *test() {
 		return nullptr;
 	}
 
-	String test = cmdlargs.back()->get();
-
-	FileAccess *fa = FileAccess::open(test, FileAccess::READ);
-
-	if (!fa) {
-		ERR_FAIL_V(nullptr);
-	}
-
 	String code;
+	{
+		String test = cmdlargs.back()->get();
+		FileAccessRef fa = FileAccess::open(test, FileAccess::READ);
+		ERR_FAIL_COND_V(!fa, nullptr);
 
-	while (true) {
-		char32_t c = fa->get_8();
-		if (fa->eof_reached()) {
-			break;
+		while (true) {
+			char32_t c = fa->get_8();
+			if (fa->eof_reached()) {
+				break;
+			}
+			code += c;
 		}
-		code += c;
 	}
 
 	SL sl;


### PR DESCRIPTION
Also removes explicit calls to `FileAccess::close()` before `memdelete()`
since it's done by the destructor.

There's a number of `FileAccess *` which I left alone because they're either class members or passed as method parameters, especially in `core/io`.

---

Only checked `core/` for now, I'll port the rest of the codebase but wanted to make sure the approach is good.