### PR TITLE
Ignore `PhysicsServer3DExtension` class in C#

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -18,16 +18,16 @@ jobs:
       fail-fast: false
       matrix:
         include:
-#          - name: Editor w/ Mono (target=release_debug, tools=yes, tests=yes)
-#            cache-name: linux-editor-mono
-#            target: release_debug
-#            tools: true
-#            tests: false # Disabled due freeze caused by mix Mono build and CI
-#            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no
-#            doc-test: true
-#            bin: "./bin/godot.linuxbsd.opt.tools.64.mono"
-#            build-mono: true
-#            artifact: true
+          - name: Editor w/ Mono (target=release_debug, tools=yes, tests=yes)
+            cache-name: linux-editor-mono
+            target: release_debug
+            tools: true
+            tests: false # Disabled due freeze caused by mix Mono build and CI
+            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no
+            doc-test: true
+            bin: "./bin/godot.linuxbsd.opt.tools.64.mono"
+            build-mono: true
+            artifact: true
 
           - name: Editor with doubles and sanitizers (target=debug, tools=yes, float=64, tests=yes, use_asan=yes, use_ubsan=yes)
             cache-name: linux-editor-double-sanitizers
@@ -42,14 +42,14 @@ jobs:
             # Skip 2GiB artifact speeding up action.
             artifact: false
 
-#          - name: Template w/ Mono (target=release, tools=no)
-#            cache-name: linux-template-mono
-#            target: release
-#            tools: false
-#            tests: false
-#            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no debug_symbols=no
-#            build-mono: false
-#            artifact: true
+          - name: Template w/ Mono (target=release, tools=no)
+            cache-name: linux-template-mono
+            target: release
+            tools: false
+            tests: false
+            sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no debug_symbols=no
+            build-mono: false
+            artifact: true
 
           - name: Minimal Template (target=release, tools=no, everything disabled)
             cache-name: linux-template-minimal

--- a/modules/mono/editor/bindings_generator.cpp
+++ b/modules/mono/editor/bindings_generator.cpp
@@ -100,6 +100,9 @@
 
 #define BINDINGS_GENERATOR_VERSION UINT32_C(13)
 
+// Types that will be ignored by the generator and won't be available in C#.
+const Vector<String> ignored_types = { "PhysicsServer3DExtension" };
+
 const char *BindingsGenerator::TypeInterface::DEFAULT_VARARG_C_IN("\t%0 %1_in = %1;\n");
 
 static String fix_doc_description(const String &p_bbcode) {
@@ -2641,6 +2644,12 @@ bool BindingsGenerator::_populate_object_type_interfaces() {
 		ClassDB::APIType api_type = ClassDB::get_api_type(type_cname);
 
 		if (api_type == ClassDB::API_NONE) {
+			class_list.pop_front();
+			continue;
+		}
+
+		if (ignored_types.has(type_cname)) {
+			_log("Ignoring type '%s' because it's in the list of ignored types\n", String(type_cname).utf8().get_data());
 			class_list.pop_front();
 			continue;
 		}


### PR DESCRIPTION
`PhysicsServer3DExtension` inherits from `PhysicsServer3D` which is a singleton class, since singleton classes are generated as static in C# it would generate invalid C# so for now we'll be ignoring `PhysicsServer3DExtension`.

This fixes mono after https://github.com/godotengine/godot/pull/59140 (introduces the `PhysicsServer3DExtension` class) and re-enables mono CI.

Superseeds https://github.com/godotengine/godot/pull/59208
