### PR TITLE
Enable `use_collision` on CSGShape3D by default

### DIFF
--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -62,7 +62,7 @@ private:
 	bool last_visible = false;
 	float snap = 0.001;
 
-	bool use_collision = false;
+	bool use_collision = true;
 	uint32_t collision_layer = 1;
 	uint32_t collision_mask = 1;
 	Ref<ConcavePolygonShape3D> root_collision_shape;

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -72,8 +72,9 @@
 		<member name="snap" type="float" setter="set_snap" getter="get_snap" default="0.001">
 			Snap makes the mesh snap to a given distance so that the faces of two meshes can be perfectly aligned. A lower value results in greater precision but may be harder to adjust.
 		</member>
-		<member name="use_collision" type="bool" setter="set_use_collision" getter="is_using_collision" default="false">
-			Adds a collision shape to the physics engine for our CSG shape. This will always act like a static body. Note that the collision shape is still active even if the CSG shape itself is hidden.
+		<member name="use_collision" type="bool" setter="set_use_collision" getter="is_using_collision" default="true">
+			If [code]true[/code], adds a [ConcavePolygonShape3D] matching the CSG shape for use by the physics engine. This will always act like a [StaticBody3D].
+			[b]Note:[/b] The collision shape is still active even if the CSG shape itself is hidden. This can be used to create invisible barriers to smooth out collisions in a level and preventing players from getting stuck in certain spots.
 		</member>
 	</members>
 	<constants>


### PR DESCRIPTION
Related to https://github.com/godotengine/godot/pull/59266 (can be merged independently).

Since collision is often desired for level prototyping (and most CSG nodes are intended to be solid), it makes sense to enable collision by default.

See discussion in https://github.com/godotengine/godot-proposals/issues/2879 for further rationale.