### PR TITLE
[3.x] Document that `PhysicsServer`'s `get_process_info` is implemented only for Godot Physics

### DIFF
--- a/doc/classes/PhysicsServer.xml
+++ b/doc/classes/PhysicsServer.xml
@@ -673,7 +673,7 @@
 			<return type="int" />
 			<argument index="0" name="process_info" type="int" enum="PhysicsServer.ProcessInfo" />
 			<description>
-				Returns an Info defined by the [enum ProcessInfo] input given.
+				Returns information about the current state of the 3D physics engine. See [enum ProcessInfo] for a list of available states. Only implemented for Godot Physics.
 			</description>
 		</method>
 		<method name="hinge_joint_get_flag" qualifiers="const">


### PR DESCRIPTION
From a glance it seems that Bullet doesn't store these statistics by default, so it would probably require a patch to Bullet to obtain the information. In the meantime, we document the limitation (and copy the better phrasing of the documentation from the 2D docs).

Inspired by https://github.com/godotengine/godot/issues/59279.