### PR TITLE
Use the Static global illumination mode for CSG nodes by default

### DIFF
--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -653,6 +653,9 @@ void CSGShape3D::_bind_methods() {
 
 CSGShape3D::CSGShape3D() {
 	set_notify_local_transform(true);
+
+	// CSG shapes are typically used for static level geometry, so use a fitting GI mode by default.
+	set_gi_mode(GeometryInstance3D::GI_MODE_STATIC);
 }
 
 CSGShape3D::~CSGShape3D() {


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/59288 (can be merged independently).

This makes VoxelGI and SDFGI work out of the box with CSG nodes, which are typically used for static geometry such as level blockouts.

Note that LightmapGI will still not work until conversion to MeshInstance is implemented (ideally with UV2 unwrapping happening automatically if a LightmapGI node is present in the scene).

Interestingly, the generated class reference does not mention the `gi_mode` override (unlike e.g. CheckBox).

**Testing project:** [test_csg_static.zip](https://github.com/godotengine/godot/files/8307029/test_csg_static.zip)
 