### PR TITLE
Stop GLTF importer from forced skipping animation tracks automatically

### DIFF
--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -5934,59 +5934,25 @@ void GLTFDocument::_import_animation(Ref<GLTFState> state, AnimationPlayer *ap, 
 			int scale_idx = -1;
 
 			if (track.position_track.values.size()) {
-				Vector3 base_pos = state->nodes[track_i.key]->position;
-				bool not_default = false; //discard the track if all it contains is default values
-				for (int i = 0; i < track.position_track.times.size(); i++) {
-					Vector3 value = track.position_track.values[track.position_track.interpolation == GLTFAnimation::INTERP_CUBIC_SPLINE ? (1 + i * 3) : i];
-					if (!value.is_equal_approx(base_pos)) {
-						not_default = true;
-						break;
-					}
-				}
-				if (not_default) {
-					position_idx = base_idx;
-					animation->add_track(Animation::TYPE_POSITION_3D);
-					animation->track_set_path(position_idx, transform_node_path);
-					animation->track_set_imported(position_idx, true); //helps merging later
-
-					base_idx++;
-				}
+				position_idx = base_idx;
+				animation->add_track(Animation::TYPE_POSITION_3D);
+				animation->track_set_path(position_idx, transform_node_path);
+				animation->track_set_imported(position_idx, true); //helps merging later
+				base_idx++;
 			}
 			if (track.rotation_track.values.size()) {
-				Quaternion base_rot = state->nodes[track_i.key]->rotation.normalized();
-				bool not_default = false; //discard the track if all it contains is default values
-				for (int i = 0; i < track.rotation_track.times.size(); i++) {
-					Quaternion value = track.rotation_track.values[track.rotation_track.interpolation == GLTFAnimation::INTERP_CUBIC_SPLINE ? (1 + i * 3) : i].normalized();
-					if (!value.is_equal_approx(base_rot)) {
-						not_default = true;
-						break;
-					}
-				}
-				if (not_default) {
-					rotation_idx = base_idx;
-					animation->add_track(Animation::TYPE_ROTATION_3D);
-					animation->track_set_path(rotation_idx, transform_node_path);
-					animation->track_set_imported(rotation_idx, true); //helps merging later
-					base_idx++;
-				}
+				rotation_idx = base_idx;
+				animation->add_track(Animation::TYPE_ROTATION_3D);
+				animation->track_set_path(rotation_idx, transform_node_path);
+				animation->track_set_imported(rotation_idx, true); //helps merging later
+				base_idx++;
 			}
 			if (track.scale_track.values.size()) {
-				Vector3 base_scale = state->nodes[track_i.key]->scale;
-				bool not_default = false; //discard the track if all it contains is default values
-				for (int i = 0; i < track.scale_track.times.size(); i++) {
-					Vector3 value = track.scale_track.values[track.scale_track.interpolation == GLTFAnimation::INTERP_CUBIC_SPLINE ? (1 + i * 3) : i];
-					if (!value.is_equal_approx(base_scale)) {
-						not_default = true;
-						break;
-					}
-				}
-				if (not_default) {
-					scale_idx = base_idx;
-					animation->add_track(Animation::TYPE_SCALE_3D);
-					animation->track_set_path(scale_idx, transform_node_path);
-					animation->track_set_imported(scale_idx, true); //helps merging later
-					base_idx++;
-				}
+				scale_idx = base_idx;
+				animation->add_track(Animation::TYPE_SCALE_3D);
+				animation->track_set_path(scale_idx, transform_node_path);
+				animation->track_set_imported(scale_idx, true); //helps merging later
+				base_idx++;
 			}
 
 			//first determine animation length


### PR DESCRIPTION
Fixes #59150 

TL;DR:
GLTF improter as the only importer here was hardcoded to skip animation tracks that don't differ from rest pose. If you are going to reuse that animation on different (but compatible) target whose rest pose is different, you have broken animation.
No other importer do that and if we actually want to skip some tracks or optimize them, it's more reasonable to leave it to "Optimizer" and "Import Tracks" options, cause they are common for every improter.
