### PR TITLE
Simplify signature of Viewport::push_input

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -138,7 +138,6 @@
 		<method name="push_input">
 			<return type="void" />
 			<argument index="0" name="event" type="InputEvent" />
-			<argument index="1" name="in_local_coords" type="bool" default="false" />
 			<description>
 			</description>
 		</method>

--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -290,7 +290,7 @@ void TouchScreenButton::_press(int p_finger_pressed) {
 		iea.instantiate();
 		iea->set_action(action);
 		iea->set_pressed(true);
-		get_viewport()->push_input(iea, true);
+		get_viewport()->push_input(iea);
 	}
 
 	emit_signal(SNAME("pressed"));
@@ -307,7 +307,7 @@ void TouchScreenButton::_release(bool p_exiting_tree) {
 			iea.instantiate();
 			iea->set_action(action);
 			iea->set_pressed(false);
-			get_viewport()->push_input(iea, true);
+			get_viewport()->push_input(iea);
 		}
 	}
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2671,7 +2671,7 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 	return true;
 }
 
-void Viewport::push_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
+void Viewport::push_input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(!is_inside_tree());
 
 	if (disable_input) {
@@ -2684,12 +2684,7 @@ void Viewport::push_input(const Ref<InputEvent> &p_event, bool p_local_coords) {
 
 	local_input_handled = false;
 
-	Ref<InputEvent> ev;
-	if (!p_local_coords) {
-		ev = _make_input_local(p_event);
-	} else {
-		ev = p_event;
-	}
+	Ref<InputEvent> ev = _make_input_local(p_event);
 
 	if (is_embedding_subwindows() && _sub_windows_forward_input(p_event)) {
 		set_input_as_handled();
@@ -3606,7 +3601,7 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_viewport_rid"), &Viewport::get_viewport_rid);
 	ClassDB::bind_method(D_METHOD("push_text_input", "text"), &Viewport::push_text_input);
-	ClassDB::bind_method(D_METHOD("push_input", "event", "in_local_coords"), &Viewport::push_input, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("push_input", "event"), &Viewport::push_input);
 	ClassDB::bind_method(D_METHOD("push_unhandled_input", "event", "in_local_coords"), &Viewport::push_unhandled_input, DEFVAL(false));
 
 	ClassDB::bind_method(D_METHOD("get_camera_2d"), &Viewport::get_camera_2d);

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -540,7 +540,7 @@ public:
 	Vector2 get_camera_rect_size() const;
 
 	void push_text_input(const String &p_text);
-	void push_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
+	void push_input(const Ref<InputEvent> &p_event);
 	void push_unhandled_input(const Ref<InputEvent> &p_event, bool p_local_coords = false);
 
 	void set_disable_input(bool p_disable);


### PR DESCRIPTION
This patch simplifies the signature of `Viewport::push_input` and the function itself.

This got introduced in 8e6960a69e0202cb1e6f3b3dc9f9bb34e1c1d889 to allow sending `InputEventAction` events with local coords in scene/2d/touch_screen_button.cpp
However these events don't have positions. This means, that handling local coordinates was not a required use case in the first place.