### PR TITLE
Fix using Viewport::warp_mouse within Viewports

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1125,7 +1125,8 @@ Vector2 Viewport::get_mouse_position() const {
 }
 
 void Viewport::warp_mouse(const Vector2 &p_position) {
-	Vector2 gpos = (get_final_transform().affine_inverse() * _get_input_pre_xform()).affine_inverse().xform(p_position);
+	Transform2D xform = get_screen_transform();
+	Vector2 gpos = xform.xform(p_position).round();
 	Input::get_singleton()->warp_mouse(gpos);
 }
 
@@ -3134,6 +3135,10 @@ Viewport::SDFScale Viewport::get_sdf_scale() const {
 	return sdf_scale;
 }
 
+Transform2D Viewport::get_screen_transform() const {
+	return _get_input_pre_xform().affine_inverse() * get_final_transform();
+}
+
 #ifndef _3D_DISABLED
 AudioListener3D *Viewport::get_audio_listener_3d() const {
 	return audio_listener_3d;
@@ -3990,6 +3995,20 @@ Transform2D SubViewport::_stretch_transform() {
 	}
 
 	return transform;
+}
+
+Transform2D SubViewport::get_screen_transform() const {
+	Transform2D container_transform = Transform2D();
+	SubViewportContainer *c = Object::cast_to<SubViewportContainer>(get_parent());
+	if (c) {
+		if (c->is_stretch_enabled()) {
+			container_transform.scale(Vector2(c->get_stretch_shrink(), c->get_stretch_shrink()));
+		}
+		container_transform = c->get_viewport()->get_screen_transform() * c->get_global_transform_with_canvas() * container_transform;
+	} else {
+		WARN_PRINT_ONCE("SubViewport is not a child of a SubViewportContainer. get_screen_transform doesn't return the actual screen position.");
+	}
+	return container_transform * Viewport::get_screen_transform();
 }
 
 void SubViewport::_notification(int p_what) {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -609,6 +609,8 @@ public:
 
 	void pass_mouse_focus_to(Viewport *p_viewport, Control *p_control);
 
+	virtual Transform2D get_screen_transform() const;
+
 #ifndef _3D_DISABLED
 	bool use_xr = false;
 	friend class AudioListener3D;
@@ -731,6 +733,8 @@ public:
 
 	void set_clear_mode(ClearMode p_mode);
 	ClearMode get_clear_mode() const;
+
+	virtual Transform2D get_screen_transform() const override;
 
 	SubViewport();
 	~SubViewport();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1452,6 +1452,15 @@ void Window::_validate_property(PropertyInfo &property) const {
 	}
 }
 
+Transform2D Window::get_screen_transform() const {
+	Transform2D embedder_transform = Transform2D();
+	if (_get_embedder()) {
+		embedder_transform.translate(get_position());
+		embedder_transform = _get_embedder()->get_screen_transform() * embedder_transform;
+	}
+	return embedder_transform * Viewport::get_screen_transform();
+}
+
 void Window::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_title", "title"), &Window::set_title);
 	ClassDB::bind_method(D_METHOD("get_title"), &Window::get_title);

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -291,6 +291,8 @@ public:
 	Ref<Font> get_theme_default_font() const;
 	int get_theme_default_font_size() const;
 
+	virtual Transform2D get_screen_transform() const override;
+
 	Rect2i get_parent_rect() const;
 	virtual DisplayServer::WindowID get_window_id() const override;
 


### PR DESCRIPTION
At the moment `Viewport::warp_mouse` doesn't work, when used within SubViewports or embedded Windows.
This patch addresses this issue and fixes these cases.

This is done by introducing `Viewport::get_screen_transform` as a method for constructing a `Transform2D` from the window manager screen to  the Viewport itself.

MRP: [BugWarpMouse.zip](https://github.com/godotengine/godot/files/8308597/BugWarpMouse.zip)
It contains nested Viewports (`SubViewport` & `Window`) and executes `warp_mouse` to the identical position, when a button is clicked from any Viewport within the scene tree..
1. Load and run MRP
2. Click anywhere to issue a warp to the same location

The following video shows, how the mouse cursor jumps on mouse clicks in current master, which gets solved by this patch.

https://user-images.githubusercontent.com/6299227/159107364-eeed4c4c-b222-49ce-9364-352645f70db3.mp4


