### PR TITLE
Calculate window input event transform only on window change

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -1108,14 +1108,11 @@ Viewport::PositionalShadowAtlasQuadrantSubdiv Viewport::get_positional_shadow_at
 }
 
 Transform2D Viewport::_get_input_pre_xform() const {
-	Transform2D pre_xf;
-
-	if (to_screen_rect.size.x != 0 && to_screen_rect.size.y != 0) {
-		pre_xf.columns[2] = -to_screen_rect.position;
-		pre_xf.scale(Vector2(size) / to_screen_rect.size);
+	const Window *this_window = Object::cast_to<Window>(this);
+	if (this_window) {
+		return this_window->window_transform.affine_inverse();
 	}
-
-	return pre_xf;
+	return Transform2D();
 }
 
 Ref<InputEvent> Viewport::_make_input_local(const Ref<InputEvent> &ev) {

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -668,6 +668,7 @@ void Window::_update_viewport_size() {
 	Rect2i attach_to_screen_rect(Point2i(), size);
 	Transform2D stretch_transform;
 	float font_oversampling = 1.0;
+	window_transform = Transform2D();
 
 	if (content_scale_mode == CONTENT_SCALE_MODE_DISABLED || content_scale_size.x == 0 || content_scale_size.y == 0) {
 		font_oversampling = content_scale_factor;
@@ -754,11 +755,18 @@ void Window::_update_viewport_size() {
 				Size2 scale = Vector2(screen_size) / Vector2(final_size_override);
 				stretch_transform.scale(scale);
 
+				window_transform.translate_local(margin);
 			} break;
 			case CONTENT_SCALE_MODE_VIEWPORT: {
 				final_size = (viewport_size / content_scale_factor).floor();
 				attach_to_screen_rect = Rect2(margin, screen_size);
 
+				window_transform.translate_local(margin);
+				if (final_size.x != 0 && final_size.y != 0) {
+					Transform2D scale_transform;
+					scale_transform.scale(Vector2(attach_to_screen_rect.size) / Vector2(final_size));
+					window_transform *= scale_transform;
+				}
 			} break;
 		}
 	}

--- a/scene/main/window.h
+++ b/scene/main/window.h
@@ -152,6 +152,8 @@ private:
 
 	Viewport *embedder = nullptr;
 
+	Transform2D window_transform;
+
 	friend class Viewport; //friend back, can call the methods below
 
 	void _window_input(const Ref<InputEvent> &p_ev);


### PR DESCRIPTION
Currently during every event processing, `Viewport::_get_input_pre_xform()` calculates the `Transform2D`, that is based on a few attributes of Windows like `CONTENT_SCALE_ASPECT`, `CONTENT_SCALE_MODE` and others.
However this Transform2D only changes, when the window changes.

With this patch, the `Transform2D` gets only recalculated after a window change.
This change also makes several transform-calculations in `Viewport` simpler.

![Transforms drawio](https://user-images.githubusercontent.com/6299227/159137652-d430d46a-df85-4b07-967b-f4a76228e478.png)

My MRP for testing these changes consists of multiple subwindows, that can be configured with all available options:
[WindowsTestbed.zip](https://github.com/godotengine/godot/files/9594197/WindowsTestbed.zip) (updated 2022-05-07 since Input-API changed, updated 2022-09-18 since Transform2D-API changed)

![image](https://user-images.githubusercontent.com/6299227/159117101-f79c7682-5113-4b24-86f2-29a5f99a30a6.png)

Update 2022-10-01: split nonessential parts into other PRs