### PR TITLE
[3.x] Add property name style toggle to Inspector

### DIFF
--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -608,18 +608,24 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 		TreeItem *properties = property_list->create_item(root);
 		properties->set_text(0, TTR("Class Properties:"));
 
+		const EditorPropertyNameProcessor::Style text_style = EditorPropertyNameProcessor::get_settings_style();
+		const EditorPropertyNameProcessor::Style tooltip_style = EditorPropertyNameProcessor::get_tooltip_style(text_style);
+
 		for (List<PropertyInfo>::Element *E = props.front(); E; E = E->next()) {
 			String name = E->get().name;
 			if (!(E->get().usage & PROPERTY_USAGE_EDITOR)) {
 				continue;
 			}
+			const String text = EditorPropertyNameProcessor::get_singleton()->process_name(name, text_style);
+			const String tooltip = EditorPropertyNameProcessor::get_singleton()->process_name(name, tooltip_style);
+
 			TreeItem *property = property_list->create_item(properties);
 			property->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
 			property->set_editable(0, true);
 			property->set_selectable(0, true);
 			property->set_checked(0, !edited->is_class_property_disabled(class_name, name));
-			property->set_text(0, EditorPropertyNameProcessor::get_singleton()->process_name(name));
-			property->set_tooltip(0, EditorPropertyNameProcessor::get_singleton()->make_tooltip_for_name(name));
+			property->set_text(0, text);
+			property->set_tooltip(0, tooltip);
 			property->set_metadata(0, name);
 			String icon_type = Variant::get_type_name(E->get().type);
 			property->set_icon(0, EditorNode::get_singleton()->get_class_icon(icon_type));

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -31,6 +31,7 @@
 #ifndef EDITOR_INSPECTOR_H
 #define EDITOR_INSPECTOR_H
 
+#include "editor_property_name_processor.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/line_edit.h"
 #include "scene/gui/scroll_container.h"
@@ -288,7 +289,7 @@ class EditorInspector : public ScrollContainer {
 	bool show_categories;
 	bool hide_script;
 	bool use_doc_hints;
-	bool capitalize_paths;
+	EditorPropertyNameProcessor::Style property_name_style;
 	bool use_filter;
 	bool autoclear;
 	bool use_folding;
@@ -371,8 +372,9 @@ public:
 	void set_keying(bool p_active);
 	void set_read_only(bool p_read_only);
 
-	bool is_capitalize_paths_enabled() const;
-	void set_enable_capitalize_paths(bool p_capitalize);
+	EditorPropertyNameProcessor::Style get_property_name_style() const;
+	void set_property_name_style(EditorPropertyNameProcessor::Style p_style);
+
 	void set_autoclear(bool p_enable);
 
 	void set_show_categories(bool p_show);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5984,10 +5984,11 @@ EditorNode::EditorNode() {
 	EDITOR_DEF("interface/editor/show_update_spinner", false);
 	EDITOR_DEF("interface/editor/update_continuously", false);
 	EDITOR_DEF("interface/editor/update_vital_only", false);
-	EDITOR_DEF("interface/editor/translate_properties", true);
+	EDITOR_DEF("interface/editor/localize_settings", true);
 	EDITOR_DEF_RST("interface/scene_tabs/restore_scenes_on_load", false);
 	EDITOR_DEF_RST("interface/scene_tabs/show_thumbnail_on_hover", true);
-	EDITOR_DEF_RST("interface/inspector/capitalize_properties", true);
+	EDITOR_DEF_RST("interface/inspector/default_property_name_style", EditorPropertyNameProcessor::STYLE_CAPITALIZED);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/inspector/default_property_name_style", PROPERTY_HINT_ENUM, "Raw,Capitalized,Localized"));
 	EDITOR_DEF_RST("interface/inspector/default_float_step", 0.001);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::REAL, "interface/inspector/default_float_step", PROPERTY_HINT_RANGE, "0,1,0"));
 	EDITOR_DEF_RST("interface/inspector/disable_folding", false);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2606,7 +2606,7 @@ void EditorPropertyResource::update_property() {
 				sub_inspector->set_use_doc_hints(true);
 
 				sub_inspector->set_sub_inspector(true);
-				sub_inspector->set_enable_capitalize_paths(bool(EDITOR_GET("interface/inspector/capitalize_properties")));
+				sub_inspector->set_property_name_style(EditorNode::get_singleton()->get_inspector_dock()->get_property_name_style());
 
 				sub_inspector->connect("property_keyed", this, "_sub_inspector_property_keyed");
 				sub_inspector->connect("resource_selected", this, "_sub_inspector_resource_selected");

--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -34,6 +34,28 @@
 
 EditorPropertyNameProcessor *EditorPropertyNameProcessor::singleton = nullptr;
 
+EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_default_inspector_style() {
+	const Style style = (Style)EDITOR_GET("interface/inspector/default_property_name_style").operator int();
+	if (style == STYLE_LOCALIZED && !is_localization_available()) {
+		return STYLE_CAPITALIZED;
+	}
+	return style;
+}
+
+EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_settings_style() {
+	const bool translate = EDITOR_GET("interface/editor/localize_settings");
+	return translate ? STYLE_LOCALIZED : STYLE_CAPITALIZED;
+}
+
+EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_tooltip_style(Style p_style) {
+	return p_style == STYLE_LOCALIZED ? STYLE_CAPITALIZED : STYLE_LOCALIZED;
+}
+
+bool EditorPropertyNameProcessor::is_localization_available() {
+	const Vector<String> forbidden = String("en").split(",");
+	return forbidden.find(EDITOR_GET("interface/editor/editor_language")) == -1;
+}
+
 String EditorPropertyNameProcessor::_capitalize_name(const String &p_name) const {
 	const Map<String, String>::Element *cached = capitalize_string_cache.find(p_name);
 	if (cached) {
@@ -55,20 +77,21 @@ String EditorPropertyNameProcessor::_capitalize_name(const String &p_name) const
 	return capitalized;
 }
 
-String EditorPropertyNameProcessor::process_name(const String &p_name) const {
-	const String capitalized_string = _capitalize_name(p_name);
-	if (EDITOR_GET("interface/editor/translate_properties")) {
-		return TTRGET(capitalized_string);
-	}
-	return capitalized_string;
-}
+String EditorPropertyNameProcessor::process_name(const String &p_name, Style p_style) const {
+	switch (p_style) {
+		case STYLE_RAW: {
+			return p_name;
+		} break;
 
-String EditorPropertyNameProcessor::make_tooltip_for_name(const String &p_name) const {
-	const String capitalized_string = _capitalize_name(p_name);
-	if (EDITOR_GET("interface/editor/translate_properties")) {
-		return capitalized_string;
+		case STYLE_CAPITALIZED: {
+			return _capitalize_name(p_name);
+		} break;
+
+		case STYLE_LOCALIZED: {
+			return TTRGET(_capitalize_name(p_name));
+		} break;
 	}
-	return TTRGET(capitalized_string);
+	ERR_FAIL_V_MSG(p_name, "Unexpected property name style.");
 }
 
 EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
@@ -84,6 +107,8 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["adb"] = "ADB";
 	capitalize_string_remaps["ao"] = "AO";
 	capitalize_string_remaps["apk"] = "APK";
+	capitalize_string_remaps["arm64-v8a"] = "arm64-v8a";
+	capitalize_string_remaps["armeabi-v7a"] = "armeabi-v7a";
 	capitalize_string_remaps["arvr"] = "ARVR";
 	capitalize_string_remaps["bg"] = "BG";
 	capitalize_string_remaps["bp"] = "BP";
@@ -130,6 +155,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["ipad"] = "iPad";
 	capitalize_string_remaps["iphone"] = "iPhone";
 	capitalize_string_remaps["ipv6"] = "IPv6";
+	capitalize_string_remaps["ir"] = "IR";
 	capitalize_string_remaps["jit"] = "JIT";
 	capitalize_string_remaps["k1"] = "K1";
 	capitalize_string_remaps["k2"] = "K2";
@@ -139,10 +165,12 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["lowpass"] = "Low-pass";
 	capitalize_string_remaps["macos"] = "macOS";
 	capitalize_string_remaps["mb"] = "(MB)"; // Unit.
+	capitalize_string_remaps["mms"] = "MMS";
 	capitalize_string_remaps["ms"] = "(ms)"; // Unit
 	// Not used for now as AudioEffectReverb has a `msec` property.
 	//capitalize_string_remaps["msec"] = "(msec)"; // Unit.
 	capitalize_string_remaps["msaa"] = "MSAA";
+	capitalize_string_remaps["nfc"] = "NFC";
 	capitalize_string_remaps["normalmap"] = "Normal Map";
 	capitalize_string_remaps["ok"] = "OK";
 	capitalize_string_remaps["opengl"] = "OpenGL";
@@ -162,6 +190,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["sdfgi"] = "SDFGI";
 	capitalize_string_remaps["sdk"] = "SDK";
 	capitalize_string_remaps["sec"] = "(sec)"; // Unit.
+	capitalize_string_remaps["sms"] = "SMS";
 	capitalize_string_remaps["srgb"] = "sRGB";
 	capitalize_string_remaps["ssao"] = "SSAO";
 	capitalize_string_remaps["ssh"] = "SSH";
@@ -182,12 +211,15 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["uv2"] = "UV2";
 	capitalize_string_remaps["uwp"] = "UWP";
 	capitalize_string_remaps["vector2"] = "Vector2";
+	capitalize_string_remaps["vpn"] = "VPN";
 	capitalize_string_remaps["vram"] = "VRAM";
 	capitalize_string_remaps["vsync"] = "V-Sync";
+	capitalize_string_remaps["wap"] = "WAP";
 	capitalize_string_remaps["webp"] = "WebP";
 	capitalize_string_remaps["webrtc"] = "WebRTC";
 	capitalize_string_remaps["websocket"] = "WebSocket";
 	capitalize_string_remaps["wifi"] = "Wi-Fi";
+	capitalize_string_remaps["x86"] = "x86";
 	capitalize_string_remaps["xr"] = "XR";
 	capitalize_string_remaps["xy"] = "XY";
 	capitalize_string_remaps["xz"] = "XZ";

--- a/editor/editor_property_name_processor.h
+++ b/editor/editor_property_name_processor.h
@@ -41,16 +41,27 @@ class EditorPropertyNameProcessor : public Node {
 	mutable Map<String, String> capitalize_string_cache;
 	Map<String, String> capitalize_string_remaps;
 
+	// Capitalizes property path segments.
 	String _capitalize_name(const String &p_name) const;
 
 public:
+	// Matches `interface/inspector/capitalize_properties` editor setting.
+	enum Style {
+		STYLE_RAW,
+		STYLE_CAPITALIZED,
+		STYLE_LOCALIZED,
+	};
+
 	static EditorPropertyNameProcessor *get_singleton() { return singleton; }
 
-	// Capitalize & localize property path segments.
-	String process_name(const String &p_name) const;
+	static Style get_default_inspector_style();
+	static Style get_settings_style();
+	static Style get_tooltip_style(Style p_style);
 
-	// Make tooltip string for names processed by process_name().
-	String make_tooltip_for_name(const String &p_name) const;
+	static bool is_localization_available();
+
+	// Turns property path segment into the given style.
+	String process_name(const String &p_name, Style p_style) const;
 
 	EditorPropertyNameProcessor();
 	~EditorPropertyNameProcessor();

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -32,15 +32,16 @@
 
 #include "editor_property_name_processor.h"
 #include "editor_scale.h"
+#include "editor_settings.h"
 
-static bool _property_path_matches(const String &p_property_path, const String &p_filter) {
+static bool _property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style) {
 	if (p_property_path.findn(p_filter) != -1) {
 		return true;
 	}
 
 	const Vector<String> sections = p_property_path.split("/");
 	for (int i = 0; i < sections.size(); i++) {
-		if (p_filter.is_subsequence_ofi(EditorPropertyNameProcessor::get_singleton()->process_name(sections[i]))) {
+		if (p_filter.is_subsequence_ofi(EditorPropertyNameProcessor::get_singleton()->process_name(sections[i], p_style))) {
 			return true;
 		}
 	}
@@ -243,6 +244,9 @@ void SectionedInspector::update_category_list() {
 		filter = search_box->get_text();
 	}
 
+	const EditorPropertyNameProcessor::Style name_style = EditorPropertyNameProcessor::get_settings_style();
+	const EditorPropertyNameProcessor::Style tooltip_style = EditorPropertyNameProcessor::get_tooltip_style(name_style);
+
 	for (List<PropertyInfo>::Element *E = pinfo.front(); E; E = E->next()) {
 		PropertyInfo pi = E->get();
 
@@ -256,7 +260,7 @@ void SectionedInspector::update_category_list() {
 			continue;
 		}
 
-		if (!filter.empty() && !_property_path_matches(pi.name, filter)) {
+		if (!filter.empty() && !_property_path_matches(pi.name, filter, name_style)) {
 			continue;
 		}
 
@@ -283,8 +287,12 @@ void SectionedInspector::update_category_list() {
 			if (!section_map.has(metasection)) {
 				TreeItem *ms = sections->create_item(parent);
 				section_map[metasection] = ms;
-				ms->set_text(0, EditorPropertyNameProcessor::get_singleton()->process_name(sectionarr[i]));
-				ms->set_tooltip(0, EditorPropertyNameProcessor::get_singleton()->make_tooltip_for_name(sectionarr[i]));
+
+				const String text = EditorPropertyNameProcessor::get_singleton()->process_name(sectionarr[i], name_style);
+				const String tooltip = EditorPropertyNameProcessor::get_singleton()->process_name(sectionarr[i], tooltip_style);
+
+				ms->set_text(0, text);
+				ms->set_tooltip(0, tooltip);
 				ms->set_metadata(0, metasection);
 				ms->set_selectable(0, false);
 			}
@@ -311,6 +319,14 @@ void SectionedInspector::register_search_box(LineEdit *p_box) {
 
 void SectionedInspector::_search_changed(const String &p_what) {
 	update_category_list();
+}
+
+void SectionedInspector::_notification(int p_what) {
+	switch (p_what) {
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
+		} break;
+	}
 }
 
 EditorInspector *SectionedInspector::get_inspector() {
@@ -342,6 +358,7 @@ SectionedInspector::SectionedInspector() :
 	inspector->set_v_size_flags(SIZE_EXPAND_FILL);
 	right_vb->add_child(inspector, true);
 	inspector->set_use_doc_hints(true);
+	inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 
 	sections->connect("cell_selected", this, "_section_selected");
 }

--- a/editor/editor_sectioned_inspector.h
+++ b/editor/editor_sectioned_inspector.h
@@ -56,6 +56,9 @@ class SectionedInspector : public HSplitContainer {
 
 	void _search_changed(const String &p_what);
 
+protected:
+	void _notification(int p_what);
+
 public:
 	void register_search_box(LineEdit *p_box);
 	EditorInspector *get_inspector();

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -528,6 +528,7 @@ void ImportDock::_notification(int p_what) {
 	switch (p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			imported->add_style_override("normal", get_stylebox("normal", "LineEdit"));
+			import_opts->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
@@ -606,6 +607,7 @@ ImportDock::ImportDock() {
 	import_opts = memnew(EditorInspector);
 	content->add_child(import_opts);
 	import_opts->set_v_size_flags(SIZE_EXPAND_FILL);
+	import_opts->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 	import_opts->connect("property_edited", this, "_property_edited");
 	import_opts->connect("property_toggled", this, "_property_toggled");
 

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -37,6 +37,7 @@
 #include "editor/editor_data.h"
 #include "editor/editor_inspector.h"
 #include "editor/editor_path.h"
+#include "editor/editor_property_name_processor.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/control.h"
@@ -63,6 +64,11 @@ class InspectorDock : public VBoxContainer {
 
 		COLLAPSE_ALL,
 		EXPAND_ALL,
+
+		// Matches `EditorPropertyNameProcessor::Style`.
+		PROPERTY_NAME_STYLE_RAW,
+		PROPERTY_NAME_STYLE_CAPITALIZED,
+		PROPERTY_NAME_STYLE_LOCALIZED,
 
 		OBJECT_METHOD_BASE = 500
 	};
@@ -93,6 +99,9 @@ class InspectorDock : public VBoxContainer {
 	Button *warning;
 	AcceptDialog *warning_dialog;
 
+	EditorPropertyNameProcessor::Style property_name_style;
+
+	void _prepare_menu();
 	void _menu_option(int p_option);
 
 	void _new_resource();
@@ -132,6 +141,8 @@ public:
 	void update(Object *p_object);
 	Container *get_addon_area();
 	EditorInspector *get_inspector() { return inspector; }
+
+	EditorPropertyNameProcessor::Style get_property_name_style() const;
 
 	InspectorDock(EditorNode *p_editor, EditorData &p_editor_data);
 	~InspectorDock();

--- a/editor/plugins/item_list_editor_plugin.cpp
+++ b/editor/plugins/item_list_editor_plugin.cpp
@@ -241,11 +241,20 @@ void ItemListEditor::_node_removed(Node *p_node) {
 }
 
 void ItemListEditor::_notification(int p_notification) {
-	if (p_notification == NOTIFICATION_ENTER_TREE || p_notification == NOTIFICATION_THEME_CHANGED) {
-		add_button->set_icon(get_icon("Add", "EditorIcons"));
-		del_button->set_icon(get_icon("Remove", "EditorIcons"));
-	} else if (p_notification == NOTIFICATION_READY) {
-		get_tree()->connect("node_removed", this, "_node_removed");
+	switch (p_notification) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			add_button->set_icon(get_icon("Add", "EditorIcons"));
+			del_button->set_icon(get_icon("Remove", "EditorIcons"));
+		} break;
+
+		case NOTIFICATION_READY: {
+			get_tree()->connect("node_removed", this, "_node_removed");
+		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			property_editor->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
+		} break;
 	}
 }
 
@@ -360,6 +369,7 @@ ItemListEditor::ItemListEditor() {
 	property_editor = memnew(EditorInspector);
 	vbc->add_child(property_editor);
 	property_editor->set_v_size_flags(SIZE_EXPAND_FILL);
+	property_editor->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 }
 
 ItemListEditor::~ItemListEditor() {

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -56,12 +56,18 @@ void ProjectExportDialog::_notification(int p_what) {
 			connect("confirmed", this, "_export_pck_zip");
 			custom_feature_display->get_parent_control()->add_style_override("panel", get_stylebox("bg", "Tree"));
 		} break;
+
 		case NOTIFICATION_POPUP_HIDE: {
 			EditorSettings::get_singleton()->set_project_metadata("dialog_bounds", "export", get_rect());
 		} break;
+
 		case NOTIFICATION_THEME_CHANGED: {
 			duplicate_preset->set_icon(get_icon("Duplicate", "EditorIcons"));
 			delete_preset->set_icon(get_icon("Remove", "EditorIcons"));
+		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			parameters->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 		} break;
 	}
 }
@@ -1035,6 +1041,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	sections->add_child(parameters);
 	parameters->set_name(TTR("Options"));
 	parameters->set_v_size_flags(SIZE_EXPAND_FILL);
+	parameters->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 	parameters->connect("property_edited", this, "_update_parameters");
 	EditorExport::get_singleton()->connect("export_presets_updated", this, "_force_update_current_preset_parameters");
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -36,6 +36,7 @@
 #include "core/project_settings.h"
 #include "editor/editor_feature_profile.h"
 #include "editor/editor_node.h"
+#include "editor/editor_property_name_processor.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/multi_node_edit.h"
@@ -2591,11 +2592,11 @@ void SceneTreeDock::_files_dropped(Vector<String> p_files, NodePath p_to, int p_
 			property_drop_node = node;
 			resource_drop_path = res_path;
 
-			bool capitalize = bool(EDITOR_GET("interface/inspector/capitalize_properties"));
+			const EditorPropertyNameProcessor::Style style = EditorNode::get_singleton()->get_inspector_dock()->get_property_name_style();
 			menu_properties->clear();
 			for (List<String>::Element *E = valid_properties.front(); E; E = E->next()) {
 				String &p = E->get();
-				menu_properties->add_item(capitalize ? p.capitalize() : p);
+				menu_properties->add_item(EditorPropertyNameProcessor::get_singleton()->process_name(p, style));
 				menu_properties->set_item_metadata(menu_properties->get_item_count() - 1, p);
 			}
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -2481,7 +2481,7 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		inspector = memnew(EditorInspector);
 		inspector->set_h_size_flags(SIZE_EXPAND_FILL);
 		inspector->set_v_size_flags(SIZE_EXPAND_FILL);
-		inspector->set_enable_capitalize_paths(false);
+		inspector->set_property_name_style(EditorPropertyNameProcessor::STYLE_RAW);
 		inspector->set_read_only(true);
 		inspector->connect("object_id_selected", this, "_scene_tree_property_select_object");
 		inspector->register_text_enter(search);

--- a/editor/settings_config_dialog.cpp
+++ b/editor/settings_config_dialog.cpp
@@ -201,6 +201,9 @@ void EditorSettingsDialog::_update_shortcuts() {
 
 	Map<String, TreeItem *> sections;
 
+	const EditorPropertyNameProcessor::Style name_style = EditorPropertyNameProcessor::get_settings_style();
+	const EditorPropertyNameProcessor::Style tooltip_style = EditorPropertyNameProcessor::get_tooltip_style(name_style);
+
 	for (List<String>::Element *E = slist.front(); E; E = E->next()) {
 		Ref<ShortCut> sc = EditorSettings::get_singleton()->get_shortcut(E->get());
 		if (!sc->has_meta("original")) {
@@ -218,9 +221,11 @@ void EditorSettingsDialog::_update_shortcuts() {
 		} else {
 			section = shortcuts->create_item(root);
 
-			String item_name = EditorPropertyNameProcessor::get_singleton()->process_name(section_name);
+			const String item_name = EditorPropertyNameProcessor::get_singleton()->process_name(section_name, name_style);
+			const String tooltip = EditorPropertyNameProcessor::get_singleton()->process_name(section_name, tooltip_style);
+
 			section->set_text(0, item_name);
-			section->set_tooltip(0, EditorPropertyNameProcessor::get_singleton()->make_tooltip_for_name(section_name));
+			section->set_tooltip(0, tooltip);
 
 			if (collapsed.has(item_name)) {
 				section->set_collapsed(collapsed[item_name]);


### PR DESCRIPTION
This PR adds a button to the Inspector. It switches among three different property name styles:

| Style | Preview |
| --- | --- |
| Raw | `http_proxy` |
| Capitalized | `HTTP Proxy` |
| Localized | `HTTP 代理` | 

The Inspector defaults to the `interface/inspector/default_property_name_style` editor setting at startup. This setting defaults to "Capitalized" and it replaces the old `interface/inspector/capitalize_properties`.

| Three Menu Items | In Action |
| --- | --- |
| ![ksnip_20220323-104401](https://user-images.githubusercontent.com/372476/159613657-404cb192-b90d-40fe-ad75-eb9c556511ac.png) | ![Peek 2022-03-23 10-41](https://user-images.githubusercontent.com/372476/159613682-293d030b-5333-4526-9576-c97d463eb096.gif) |

Localization is currently disabled for "en":

![ksnip_20220323-104429](https://user-images.githubusercontent.com/372476/159614100-45796462-c577-48ce-b3b2-87604bc2c755.png)

The previous PR added a `interface/editor/translate_properties` setting for all properties. This is now replaced by `interface/editor/localize_settings` to focus on settings. It defaults to `true` because settings are usually accessed via GUI instead of code. You can still access the path via right click menu or tooltip.

Editor settings take a few seconds to make effect:

![Peek 2022-03-19 19-03](https://user-images.githubusercontent.com/372476/159119248-687034ec-3fe0-4723-a64c-21c002e577cf.gif)

The `EditorInspector` defaults to Capitalized. Common usages such as the import dock and the export dialog are set to honor `localize_settings` too. The local stack variables inspector in Debugger is kept Raw.

---

I'll make a PR for `master` after this is discussed.