### PR TITLE
Add static method support to ClassDB

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1334,7 +1334,7 @@ void File::store_buffer(const Vector<uint8_t> &p_buffer) {
 	f->store_buffer(&r[0], len);
 }
 
-bool File::file_exists(const String &p_name) const {
+bool File::file_exists(const String &p_name) {
 	return FileAccess::exists(p_name);
 }
 
@@ -1424,7 +1424,7 @@ void File::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("store_pascal_string", "string"), &File::store_pascal_string);
 	ClassDB::bind_method(D_METHOD("get_pascal_string"), &File::get_pascal_string);
 
-	ClassDB::bind_method(D_METHOD("file_exists", "path"), &File::file_exists);
+	ClassDB::bind_static_method("File", D_METHOD("file_exists", "path"), &File::file_exists);
 	ClassDB::bind_method(D_METHOD("get_modified_time", "file"), &File::get_modified_time);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "big_endian"), "set_big_endian", "is_big_endian");

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -436,7 +436,7 @@ public:
 
 	void store_var(const Variant &p_var, bool p_full_objects = false);
 
-	bool file_exists(const String &p_name) const; // Return true if a file exists.
+	static bool file_exists(const String &p_name); // Return true if a file exists.
 
 	uint64_t get_modified_time(const String &p_file) const;
 

--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -666,6 +666,7 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 						Dictionary d2;
 						d2["name"] = String(method_name);
 						d2["is_const"] = (F.flags & METHOD_FLAG_CONST) ? true : false;
+						d2["is_static"] = (F.flags & METHOD_FLAG_STATIC) ? true : false;
 						d2["is_vararg"] = false;
 						d2["is_virtual"] = true;
 						// virtual functions have no hash since no MethodBind is involved
@@ -708,6 +709,7 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 
 						d2["is_const"] = method->is_const();
 						d2["is_vararg"] = method->is_vararg();
+						d2["is_static"] = method->is_static();
 						d2["is_virtual"] = false;
 						d2["hash"] = method->get_hash();
 

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -227,75 +227,27 @@ public:
 
 	static uint64_t get_api_hash(APIType p_api);
 
-	template <class N, class M>
-	static MethodBind *bind_method(N p_method_name, M p_method) {
+	template <class N, class M, typename... VarArgs>
+	static MethodBind *bind_method(N p_method_name, M p_method, VarArgs... p_args) {
+		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
+		const Variant *argptrs[sizeof...(p_args) + 1];
+		for (uint32_t i = 0; i < sizeof...(p_args); i++) {
+			argptrs[i] = &args[i];
+		}
 		MethodBind *bind = create_method_bind(p_method);
-
-		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, p_method_name, nullptr, 0); //use static function, much smaller binary usage
+		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, p_method_name, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
 	}
 
-	template <class N, class M>
-	static MethodBind *bind_method(N p_method_name, M p_method, const Variant &p_def1) {
-		MethodBind *bind = create_method_bind(p_method);
-		const Variant *ptr[1] = { &p_def1 };
-
-		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, p_method_name, ptr, 1);
-	}
-
-	template <class N, class M>
-	static MethodBind *bind_method(N p_method_name, M p_method, const Variant &p_def1, const Variant &p_def2) {
-		MethodBind *bind = create_method_bind(p_method);
-		const Variant *ptr[2] = { &p_def1, &p_def2 };
-
-		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, p_method_name, ptr, 2);
-	}
-
-	template <class N, class M>
-	static MethodBind *bind_method(N p_method_name, M p_method, const Variant &p_def1, const Variant &p_def2, const Variant &p_def3) {
-		MethodBind *bind = create_method_bind(p_method);
-		const Variant *ptr[3] = { &p_def1, &p_def2, &p_def3 };
-
-		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, p_method_name, ptr, 3);
-	}
-
-	template <class N, class M>
-	static MethodBind *bind_method(N p_method_name, M p_method, const Variant &p_def1, const Variant &p_def2, const Variant &p_def3, const Variant &p_def4) {
-		MethodBind *bind = create_method_bind(p_method);
-		const Variant *ptr[4] = { &p_def1, &p_def2, &p_def3, &p_def4 };
-
-		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, p_method_name, ptr, 4);
-	}
-
-	template <class N, class M>
-	static MethodBind *bind_method(N p_method_name, M p_method, const Variant &p_def1, const Variant &p_def2, const Variant &p_def3, const Variant &p_def4, const Variant &p_def5) {
-		MethodBind *bind = create_method_bind(p_method);
-		const Variant *ptr[5] = { &p_def1, &p_def2, &p_def3, &p_def4, &p_def5 };
-
-		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, p_method_name, ptr, 5);
-	}
-
-	template <class N, class M>
-	static MethodBind *bind_method(N p_method_name, M p_method, const Variant &p_def1, const Variant &p_def2, const Variant &p_def3, const Variant &p_def4, const Variant &p_def5, const Variant &p_def6) {
-		MethodBind *bind = create_method_bind(p_method);
-		const Variant *ptr[6] = { &p_def1, &p_def2, &p_def3, &p_def4, &p_def5, &p_def6 };
-
-		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, p_method_name, ptr, 6);
-	}
-
-	template <class N, class M>
-	static MethodBind *bind_method(N p_method_name, M p_method, const Variant &p_def1, const Variant &p_def2, const Variant &p_def3, const Variant &p_def4, const Variant &p_def5, const Variant &p_def6, const Variant &p_def7) {
-		MethodBind *bind = create_method_bind(p_method);
-		const Variant *ptr[7] = { &p_def1, &p_def2, &p_def3, &p_def4, &p_def5, &p_def6, &p_def7 };
-
-		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, p_method_name, ptr, 7);
-	}
-
-	template <class N, class M>
-	static MethodBind *bind_method(N p_method_name, M p_method, const Variant &p_def1, const Variant &p_def2, const Variant &p_def3, const Variant &p_def4, const Variant &p_def5, const Variant &p_def6, const Variant &p_def7, const Variant &p_def8) {
-		MethodBind *bind = create_method_bind(p_method);
-		const Variant *ptr[8] = { &p_def1, &p_def2, &p_def3, &p_def4, &p_def5, &p_def6, &p_def7, &p_def8 };
-
-		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, p_method_name, ptr, 8);
+	template <class N, class M, typename... VarArgs>
+	static MethodBind *bind_static_method(const StringName &p_class, N p_method_name, M p_method, VarArgs... p_args) {
+		Variant args[sizeof...(p_args) + 1] = { p_args..., Variant() }; // +1 makes sure zero sized arrays are also supported.
+		const Variant *argptrs[sizeof...(p_args) + 1];
+		for (uint32_t i = 0; i < sizeof...(p_args); i++) {
+			argptrs[i] = &args[i];
+		}
+		MethodBind *bind = create_static_method_bind(p_method);
+		bind->set_instance_class(p_class);
+		return bind_methodfi(METHOD_FLAGS_DEFAULT, bind, p_method_name, sizeof...(p_args) == 0 ? nullptr : (const Variant **)argptrs, sizeof...(p_args));
 	}
 
 	template <class M>

--- a/core/object/method_bind.cpp
+++ b/core/object/method_bind.cpp
@@ -83,6 +83,10 @@ void MethodBind::_set_const(bool p_const) {
 	_const = p_const;
 }
 
+void MethodBind::_set_static(bool p_static) {
+	_static = p_static;
+}
+
 void MethodBind::_set_returns(bool p_returns) {
 	_returns = p_returns;
 }

--- a/doc/classes/File.xml
+++ b/doc/classes/File.xml
@@ -74,7 +74,7 @@
 				[/codeblocks]
 			</description>
 		</method>
-		<method name="file_exists" qualifiers="const">
+		<method name="file_exists" qualifiers="static">
 			<return type="bool" />
 			<argument index="0" name="path" type="String" />
 			<description>


### PR DESCRIPTION
* Based on the work done for Variant in the past.
* Added `ClassDB::bind_static_method`
* Cleaned up ClassDB::bind_method to use variadic templates.

This adds support for having static methods in Object derived classes.
Note that this does not make it work yet in GDScript, Visual Script or Mono and, while it works for GDExtension, GodotCPP needs to be updated.