### PR TITLE
Hide text and icon properties in OptionButton

### DIFF
--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -6,6 +6,7 @@
 	<description>
 		OptionButton is a type button that provides a selectable list of items when pressed. The item selected becomes the "current" item and is displayed as the button text.
 		See also [BaseButton] which contains common properties and methods associated with this node.
+		[b]Note:[/b] Properties [member Button.text] and [member Button.icon] are automatically set based on the selected item. They shouldn't be changed manually.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -385,6 +385,12 @@ void OptionButton::get_translatable_strings(List<String> *p_strings) const {
 	popup->get_translatable_strings(p_strings);
 }
 
+void OptionButton::_validate_property(PropertyInfo &property) const {
+	if (property.name == "text" || property.name == "icon") {
+		property.usage = PROPERTY_USAGE_NONE;
+	}
+}
+
 void OptionButton::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_item", "label", "id"), &OptionButton::add_item, DEFVAL(-1));
 	ClassDB::bind_method(D_METHOD("add_icon_item", "texture", "label", "id"), &OptionButton::add_icon_item, DEFVAL(-1));

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -53,6 +53,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	virtual void _validate_property(PropertyInfo &property) const override;
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
OptionButton after this PR:
![image](https://user-images.githubusercontent.com/2223172/159121410-b66fbc67-2f26-4bbc-9679-54b3438dabef.png)
Literally every other Button:
![image](https://user-images.githubusercontent.com/2223172/159121419-67a0310a-ec2d-470e-a6f7-485b4dcc13ab.png)
The text and icon of OptionButton is set based on the selected item and it shouldn't be changed manually, so I hidden it from inspector and they are no longer saved to scene. You can still change them from code, but I added a note in the docs.