### PR TITLE
Decrease default sizes of some primitive and CSG meshes for consistency

### DIFF
--- a/doc/classes/PrismMesh.xml
+++ b/doc/classes/PrismMesh.xml
@@ -12,7 +12,7 @@
 		<member name="left_to_right" type="float" setter="set_left_to_right" getter="get_left_to_right" default="0.5">
 			Displacement of the upper edge along the X axis. 0.0 positions edge straight above the bottom-left edge.
 		</member>
-		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(2, 2, 2)">
+		<member name="size" type="Vector3" setter="set_size" getter="get_size" default="Vector3(1, 1, 1)">
 			Size of the prism.
 		</member>
 		<member name="subdivide_depth" type="int" setter="set_subdivide_depth" getter="get_subdivide_depth" default="0">

--- a/doc/classes/SphereMesh.xml
+++ b/doc/classes/SphereMesh.xml
@@ -9,7 +9,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
+		<member name="height" type="float" setter="set_height" getter="get_height" default="1.0">
 			Full height of the sphere.
 		</member>
 		<member name="is_hemisphere" type="bool" setter="set_is_hemisphere" getter="get_is_hemisphere" default="false">
@@ -19,7 +19,7 @@
 		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments" default="64">
 			Number of radial segments on the sphere.
 		</member>
-		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
 			Radius of sphere.
 		</member>
 		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="32">

--- a/doc/classes/TubeTrailMesh.xml
+++ b/doc/classes/TubeTrailMesh.xml
@@ -11,7 +11,7 @@
 		</member>
 		<member name="radial_steps" type="int" setter="set_radial_steps" getter="get_radial_steps" default="8">
 		</member>
-		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
 		</member>
 		<member name="section_length" type="float" setter="set_section_length" getter="get_section_length" default="0.2">
 		</member>

--- a/modules/csg/csg_shape.cpp
+++ b/modules/csg/csg_shape.cpp
@@ -1110,7 +1110,7 @@ Ref<Material> CSGSphere3D::get_material() const {
 
 CSGSphere3D::CSGSphere3D() {
 	// defaults
-	radius = 1.0;
+	radius = 0.5;
 	radial_segments = 12;
 	rings = 6;
 	smooth_faces = true;

--- a/modules/csg/doc_classes/CSGSphere3D.xml
+++ b/modules/csg/doc_classes/CSGSphere3D.xml
@@ -17,7 +17,7 @@
 		<member name="radial_segments" type="int" setter="set_radial_segments" getter="get_radial_segments" default="12">
 			Number of vertical slices for the sphere.
 		</member>
-		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
 			Radius of the sphere.
 		</member>
 		<member name="rings" type="int" setter="set_rings" getter="get_rings" default="6">

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -247,7 +247,7 @@ class PrismMesh : public PrimitiveMesh {
 
 private:
 	float left_to_right = 0.5;
-	Vector3 size = Vector3(2.0, 2.0, 2.0);
+	Vector3 size = Vector3(1.0, 1.0, 1.0);
 	int subdivide_w = 0;
 	int subdivide_h = 0;
 	int subdivide_d = 0;
@@ -309,8 +309,8 @@ class SphereMesh : public PrimitiveMesh {
 	GDCLASS(SphereMesh, PrimitiveMesh);
 
 private:
-	float radius = 1.0;
-	float height = 2.0;
+	float radius = 0.5;
+	float height = 1.0;
 	int radial_segments = 64;
 	int rings = 32;
 	bool is_hemisphere = false;
@@ -358,7 +358,7 @@ class TubeTrailMesh : public PrimitiveMesh {
 	GDCLASS(TubeTrailMesh, PrimitiveMesh);
 
 private:
-	float radius = 1.0;
+	float radius = 0.5;
 	int radial_steps = 8;
 	int sections = 5;
 	float section_length = 0.2;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/56365.

- SphereMesh and CSGSphere now have the same size as a box.
- PrismMesh now has the same size as a box. This makes it faster to set up in MeshLibrary for use in GridMaps.
- TubeTrailMesh now has the same size as a RibbonTrailMesh.

**Testing project:** [test_primitive_csg_meshes.zip](https://github.com/godotengine/godot/files/8309579/test_primitive_csg_meshes.zip)

## Preview

| Before | After |
|-|-|
| ![2022-03-19_16 59 43](https://user-images.githubusercontent.com/180032/159128567-9b4da5f8-04d9-4c57-b6ba-f5662822fd89.png) | ![2022-03-19_16 57 54](https://user-images.githubusercontent.com/180032/159128565-3d106197-1789-40e1-8b62-1e803b6dac60.png) |