### PR TITLE
Reduce busy wait frequency in threaded HTTPRequest.

### DIFF
--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -176,7 +176,7 @@ void HTTPRequest::_thread_func(void *p_userdata) {
 			if (exit) {
 				break;
 			}
-			OS::get_singleton()->delay_usec(1);
+			OS::get_singleton()->delay_usec(6900);
 		}
 	}
 


### PR DESCRIPTION
Using a threaded HTTPRequest will currently eat ~100% CPU on Linux (and
possibly other OS). The thread is just checking whether the request is
done. It generally doesn't make sense to do this any faster than the
framerate.

Fixes #35868.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
