### PR TITLE
Expose navigable layers for NavigationAgent2D/3D

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -90,6 +90,9 @@
 		<member name="max_speed" type="float" setter="set_max_speed" getter="get_max_speed" default="200.0">
 			The maximum speed that an agent can move.
 		</member>
+		<member name="navigable_layers" type="int" setter="set_navigable_layers" getter="get_navigable_layers" default="1">
+			A bitfield determining what layers of navigation regions this agent will use to calculate path. Changing it runtime will clear current navigation path and generate new one, according to new layers.
+		</member>
 		<member name="neighbor_dist" type="float" setter="set_neighbor_dist" getter="get_neighbor_dist" default="500.0">
 			The distance to search for other agents.
 		</member>

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -96,6 +96,9 @@
 		<member name="max_speed" type="float" setter="set_max_speed" getter="get_max_speed" default="10.0">
 			The maximum speed that an agent can move.
 		</member>
+		<member name="navigable_layers" type="int" setter="set_navigable_layers" getter="get_navigable_layers" default="1">
+			A bitfield determining what layers of navigation regions this agent will use to calculate path. Changing it runtime will clear current navigation path and generate new one, according to new layers.
+		</member>
 		<member name="neighbor_dist" type="float" setter="set_neighbor_dist" getter="get_neighbor_dist" default="50.0">
 			The distance to search for other agents.
 		</member>

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -58,6 +58,9 @@ void NavigationAgent2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_path_max_distance", "max_speed"), &NavigationAgent2D::set_path_max_distance);
 	ClassDB::bind_method(D_METHOD("get_path_max_distance"), &NavigationAgent2D::get_path_max_distance);
 
+	ClassDB::bind_method(D_METHOD("set_navigable_layers", "navigable_layers"), &NavigationAgent2D::set_navigable_layers);
+	ClassDB::bind_method(D_METHOD("get_navigable_layers"), &NavigationAgent2D::get_navigable_layers);
+
 	ClassDB::bind_method(D_METHOD("set_target_location", "location"), &NavigationAgent2D::set_target_location);
 	ClassDB::bind_method(D_METHOD("get_target_location"), &NavigationAgent2D::get_target_location);
 	ClassDB::bind_method(D_METHOD("get_next_location"), &NavigationAgent2D::get_next_location);
@@ -79,6 +82,7 @@ void NavigationAgent2D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "time_horizon", PROPERTY_HINT_RANGE, "0.1,10000,0.01"), "set_time_horizon", "get_time_horizon");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_speed", PROPERTY_HINT_RANGE, "0.1,100000,0.01"), "set_max_speed", "get_max_speed");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "path_max_distance", PROPERTY_HINT_RANGE, "10,100,1"), "set_path_max_distance", "get_path_max_distance");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigable_layers", PROPERTY_HINT_LAYERS_2D_NAVIGATION), "set_navigable_layers", "get_navigable_layers");
 
 	ADD_SIGNAL(MethodInfo("path_changed"));
 	ADD_SIGNAL(MethodInfo("target_reached"));
@@ -127,8 +131,11 @@ NavigationAgent2D::~NavigationAgent2D() {
 }
 
 void NavigationAgent2D::set_navigable_layers(uint32_t p_layers) {
+	bool layers_changed = navigable_layers != p_layers;
 	navigable_layers = p_layers;
-	update_navigation();
+	if (layers_changed) {
+		_request_repath();
+	}
 }
 
 uint32_t NavigationAgent2D::get_navigable_layers() const {
@@ -174,10 +181,7 @@ real_t NavigationAgent2D::get_path_max_distance() {
 
 void NavigationAgent2D::set_target_location(Vector2 p_location) {
 	target_location = p_location;
-	navigation_path.clear();
-	target_reached = false;
-	navigation_finished = false;
-	update_frame_id = 0;
+	_request_repath();
 }
 
 Vector2 NavigationAgent2D::get_target_location() const {
@@ -310,6 +314,13 @@ void NavigationAgent2D::update_navigation() {
 			}
 		}
 	}
+}
+
+void NavigationAgent2D::_request_repath() {
+	navigation_path.clear();
+	target_reached = false;
+	navigation_finished = false;
+	update_frame_id = 0;
 }
 
 void NavigationAgent2D::_check_distance_to_target() {

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -139,6 +139,7 @@ public:
 
 private:
 	void update_navigation();
+	void _request_repath();
 	void _check_distance_to_target();
 };
 

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -62,6 +62,9 @@ void NavigationAgent3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_path_max_distance", "max_speed"), &NavigationAgent3D::set_path_max_distance);
 	ClassDB::bind_method(D_METHOD("get_path_max_distance"), &NavigationAgent3D::get_path_max_distance);
 
+	ClassDB::bind_method(D_METHOD("set_navigable_layers", "navigable_layers"), &NavigationAgent3D::set_navigable_layers);
+	ClassDB::bind_method(D_METHOD("get_navigable_layers"), &NavigationAgent3D::get_navigable_layers);
+
 	ClassDB::bind_method(D_METHOD("set_target_location", "location"), &NavigationAgent3D::set_target_location);
 	ClassDB::bind_method(D_METHOD("get_target_location"), &NavigationAgent3D::get_target_location);
 	ClassDB::bind_method(D_METHOD("get_next_location"), &NavigationAgent3D::get_next_location);
@@ -85,6 +88,7 @@ void NavigationAgent3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_speed", PROPERTY_HINT_RANGE, "0.1,10000,0.01"), "set_max_speed", "get_max_speed");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "path_max_distance", PROPERTY_HINT_RANGE, "0.01,100,0.1"), "set_path_max_distance", "get_path_max_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_y"), "set_ignore_y", "get_ignore_y");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigable_layers", PROPERTY_HINT_LAYERS_3D_NAVIGATION), "set_navigable_layers", "get_navigable_layers");
 
 	ADD_SIGNAL(MethodInfo("path_changed"));
 	ADD_SIGNAL(MethodInfo("target_reached"));
@@ -131,6 +135,18 @@ NavigationAgent3D::NavigationAgent3D() {
 NavigationAgent3D::~NavigationAgent3D() {
 	NavigationServer3D::get_singleton()->free(agent);
 	agent = RID(); // Pointless
+}
+
+void NavigationAgent3D::set_navigable_layers(uint32_t p_layers) {
+	bool layers_changed = navigable_layers != p_layers;
+	navigable_layers = p_layers;
+	if (layers_changed) {
+		_request_repath();
+	}
+}
+
+uint32_t NavigationAgent3D::get_navigable_layers() const {
+	return navigable_layers;
 }
 
 void NavigationAgent3D::set_target_desired_distance(real_t p_dd) {
@@ -181,10 +197,7 @@ real_t NavigationAgent3D::get_path_max_distance() {
 
 void NavigationAgent3D::set_target_location(Vector3 p_location) {
 	target_location = p_location;
-	navigation_path.clear();
-	target_reached = false;
-	navigation_finished = false;
-	update_frame_id = 0;
+	_request_repath();
 }
 
 Vector3 NavigationAgent3D::get_target_location() const {
@@ -294,7 +307,7 @@ void NavigationAgent3D::update_navigation() {
 	}
 
 	if (reload_path) {
-		navigation_path = NavigationServer3D::get_singleton()->map_get_path(agent_parent->get_world_3d()->get_navigation_map(), o, target_location, true);
+		navigation_path = NavigationServer3D::get_singleton()->map_get_path(agent_parent->get_world_3d()->get_navigation_map(), o, target_location, true, navigable_layers);
 		navigation_finished = false;
 		nav_path_index = 0;
 		emit_signal(SNAME("path_changed"));
@@ -318,6 +331,13 @@ void NavigationAgent3D::update_navigation() {
 			}
 		}
 	}
+}
+
+void NavigationAgent3D::_request_repath() {
+	navigation_path.clear();
+	target_reached = false;
+	navigation_finished = false;
+	update_frame_id = 0;
 }
 
 void NavigationAgent3D::_check_distance_to_target() {

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -42,6 +42,8 @@ class NavigationAgent3D : public Node {
 
 	RID agent;
 
+	uint32_t navigable_layers = 1;
+
 	real_t target_desired_distance = 1.0;
 	real_t radius;
 	real_t navigation_height_offset = 0.0;
@@ -76,6 +78,9 @@ public:
 	RID get_rid() const {
 		return agent;
 	}
+
+	void set_navigable_layers(uint32_t p_layers);
+	uint32_t get_navigable_layers() const;
 
 	void set_target_desired_distance(real_t p_dd);
 	real_t get_target_desired_distance() const {
@@ -146,6 +151,7 @@ public:
 
 private:
 	void update_navigation();
+	void _request_repath();
 	void _check_distance_to_target();
 };
 


### PR DESCRIPTION
Navigation Regions/Polygons can be set to layers, but agents not - they were forced to use first layer, at least using nodes because through navigation server you could manipulate it as you want.

I saw that agent 2D had only partially exposed layers for configuration.
Couldn't find any related issue/PR (it's something I need for my personal project), so I've decided to make it fully exposed for both - agent 2D and 3D.

Works as intended - you can now very easily create agents that can (or not) move on specified region layers e.g. make lava regions that only fire elementals will can walk on.

I attach sample projects for 2D and 3D.

![image](https://user-images.githubusercontent.com/23014550/159138427-e6768768-fcdb-425c-b580-251e08d51199.png)
![image](https://user-images.githubusercontent.com/23014550/159138438-21e74123-6be4-433c-9f69-ca56faf0146f.png)

[Agent Layers Test 2D.zip](https://github.com/godotengine/godot/files/8310131/Agent.Layers.Test.2D.zip)
[Agent Layers Test 3D.zip](https://github.com/godotengine/godot/files/8310133/Agent.Layers.Test.3D.zip)

