### PR TITLE
Add get_remapped_files() method to Directory

### DIFF
--- a/core/io/dir_access.h
+++ b/core/io/dir_access.h
@@ -150,6 +150,8 @@ public:
 
 	PackedStringArray get_files();
 	static PackedStringArray get_files_at(const String &p_path);
+	PackedStringArray get_remapped_files();
+	static PackedStringArray get_remapped_files_at(const String &p_path);
 	PackedStringArray get_directories();
 	static PackedStringArray get_directories_at(const String &p_path);
 	String _get_next();

--- a/doc/classes/DirAccess.xml
+++ b/doc/classes/DirAccess.xml
@@ -173,6 +173,7 @@
 			<description>
 				Returns a [PackedStringArray] containing filenames of the directory contents, excluding directories. The array is sorted alphabetically.
 				Affected by [member include_hidden].
+				[b]Note:[/code] This method returns the factual list of files and the results may be different when used in exported project (e.g. for importable files, like images or sounds, only the [code].import[/code] files will be in the directory). To get the list of original files based on their remaps, use [method get_remapped_files].
 			</description>
 		</method>
 		<method name="get_files_at" qualifiers="static">
@@ -194,6 +195,13 @@
 			<return type="int" enum="Error" />
 			<description>
 				Returns the result of the last [method open] call in the current thread.
+			</description>
+		</method>
+		<method name="get_remapped_files">
+			<return type="PackedStringArray" />
+			<description>
+				Returns the list of files in a directory, with imported or remapped files listed as their original files. The list is consistent between editor and exported project (excluding files that weren't exported).
+				For example, for this file list: [code]icon.png.import, icon.wav.import, player.tscn.remap, player.gdc, player.gd.remap[/code], the returned list by this method will be [code]icon.png, icon.wav, player.tscn, player.gd[/code].
 			</description>
 		</method>
 		<method name="get_space_left">


### PR DESCRIPTION
Resolves #25672

I clarified the description of `get_files()` to mention what happens on export and added `get_remapped_files()` method. The method returns the list of original files based on remaps. The list is consistent between editor and exported project.

For example, the original list of files returned by `get_files()` when running from editor:
```
[Chicken.png, Chicken.png.import, Chicken.tscn, Chicken.wav, Chicken.wav.import, Egg.png, Egg.png.import, Rooster.tscn]
```
List from `get_remapped_files()`:
```
[Chicken.png, Chicken.wav, Egg.png]
```
`get_files()` in exported project:
```
[Chicken.png.import, Chicken.tscn.remap, Chicken.wav.import, Egg.png.import, Rooster.tscn.remap]
```
^ this is different than in editor (hence infinite confusion for some users)
List from `get_remapped_files()`:
```
[Chicken.png, Chicken.tscn, Chicken.wav, Egg.png, Rooster.tscn]
```
^ same as in editor.

`get_remapped_files()` handles `.import`, `.remap` and `.gdc` files (the latter is probably not needed anymore, see #59241), but maybe there are more files that differ in export?