### PR TITLE
[3.x] Add an editor handle for `RayCast2D.cast_to`

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -144,6 +144,7 @@
 #include "editor/plugins/path_editor_plugin.h"
 #include "editor/plugins/physical_bone_plugin.h"
 #include "editor/plugins/polygon_2d_editor_plugin.h"
+#include "editor/plugins/ray_cast_2d_editor_plugin.h"
 #include "editor/plugins/resource_preloader_editor_plugin.h"
 #include "editor/plugins/room_manager_editor_plugin.h"
 #include "editor/plugins/root_motion_editor_plugin.h"
@@ -6974,6 +6975,7 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(MaterialEditorPlugin(this)));
 	add_editor_plugin(memnew(ViewportPreviewEditorPlugin(this)));
 	add_editor_plugin(memnew(GradientTexture2DEditorPlugin(this)));
+	add_editor_plugin(memnew(RayCast2DEditorPlugin(this)));
 
 	for (int i = 0; i < EditorPlugins::get_plugin_count(); i++) {
 		add_editor_plugin(EditorPlugins::create(i, this));

--- a/editor/plugins/ray_cast_2d_editor_plugin.cpp
+++ b/editor/plugins/ray_cast_2d_editor_plugin.cpp
@@ -1,0 +1,155 @@
+/*************************************************************************/
+/*  ray_cast_2d_editor_plugin.cpp                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "ray_cast_2d_editor_plugin.h"
+
+#include "canvas_item_editor_plugin.h"
+#include "editor/editor_node.h"
+
+void RayCast2DEditor::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE: {
+			get_tree()->connect("node_removed", this, "_node_removed");
+		} break;
+
+		case NOTIFICATION_EXIT_TREE: {
+			get_tree()->disconnect("node_removed", this, "_node_removed");
+		} break;
+	}
+}
+
+void RayCast2DEditor::_node_removed(Node *p_node) {
+	if (p_node == node) {
+		node = nullptr;
+	}
+}
+
+bool RayCast2DEditor::forward_canvas_gui_input(const Ref<InputEvent> &p_event) {
+	if (!node || !node->is_visible_in_tree()) {
+		return false;
+	}
+
+	Transform2D xform = canvas_item_editor->get_canvas_transform() * node->get_global_transform();
+
+	Ref<InputEventMouseButton> mb = p_event;
+	if (mb.is_valid() && mb->get_button_index() == BUTTON_LEFT) {
+		if (mb->is_pressed()) {
+			if (xform.xform(node->get_cast_to()).distance_to(mb->get_position()) < 8) {
+				pressed = true;
+				original_cast_to = node->get_cast_to();
+
+				return true;
+			} else {
+				pressed = false;
+
+				return false;
+			}
+		} else if (pressed) {
+			undo_redo->create_action(TTR("Set cast_to"));
+			undo_redo->add_do_method(node, "set_cast_to", node->get_cast_to());
+			undo_redo->add_do_method(canvas_item_editor, "update_viewport");
+			undo_redo->add_undo_method(node, "set_cast_to", original_cast_to);
+			undo_redo->add_undo_method(canvas_item_editor, "update_viewport");
+			undo_redo->commit_action();
+
+			pressed = false;
+
+			return true;
+		}
+	}
+
+	Ref<InputEventMouseMotion> mm = p_event;
+	if (mm.is_valid() && pressed) {
+		Vector2 point = canvas_item_editor->snap_point(canvas_item_editor->get_canvas_transform().affine_inverse().xform(mm->get_position()));
+		point = node->get_global_transform().affine_inverse().xform(point);
+
+		node->set_cast_to(point);
+		canvas_item_editor->update_viewport();
+		node->_change_notify();
+
+		return true;
+	}
+
+	return false;
+}
+
+void RayCast2DEditor::forward_canvas_draw_over_viewport(Control *p_overlay) {
+	if (!node || !node->is_visible_in_tree()) {
+		return;
+	}
+
+	Transform2D gt = canvas_item_editor->get_canvas_transform() * node->get_global_transform();
+
+	const Ref<Texture> handle = get_icon("EditorHandle", "EditorIcons");
+	p_overlay->draw_texture(handle, gt.xform(node->get_cast_to()) - handle->get_size() / 2);
+}
+
+void RayCast2DEditor::edit(Node *p_node) {
+	if (!canvas_item_editor) {
+		canvas_item_editor = CanvasItemEditor::get_singleton();
+	}
+
+	if (p_node) {
+		node = Object::cast_to<RayCast2D>(p_node);
+	} else {
+		node = nullptr;
+	}
+
+	canvas_item_editor->update_viewport();
+}
+
+void RayCast2DEditor::_bind_methods() {
+	ClassDB::bind_method("_node_removed", &RayCast2DEditor::_node_removed);
+}
+
+RayCast2DEditor::RayCast2DEditor() {
+	undo_redo = EditorNode::get_singleton()->get_undo_redo();
+}
+
+///////////////////////
+
+void RayCast2DEditorPlugin::edit(Object *p_object) {
+	ray_cast_2d_editor->edit(Object::cast_to<RayCast2D>(p_object));
+}
+
+bool RayCast2DEditorPlugin::handles(Object *p_object) const {
+	return Object::cast_to<RayCast2D>(p_object) != nullptr;
+}
+
+void RayCast2DEditorPlugin::make_visible(bool p_visible) {
+	if (!p_visible) {
+		edit(nullptr);
+	}
+}
+
+RayCast2DEditorPlugin::RayCast2DEditorPlugin(EditorNode *p_editor) {
+	ray_cast_2d_editor = memnew(RayCast2DEditor);
+	p_editor->get_gui_base()->add_child(ray_cast_2d_editor);
+}

--- a/editor/plugins/ray_cast_2d_editor_plugin.h
+++ b/editor/plugins/ray_cast_2d_editor_plugin.h
@@ -1,0 +1,80 @@
+/*************************************************************************/
+/*  ray_cast_2d_editor_plugin.h                                          */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef RAY_CAST_2D_EDITOR_PLUGIN_H
+#define RAY_CAST_2D_EDITOR_PLUGIN_H
+
+#include "editor/editor_plugin.h"
+#include "scene/2d/ray_cast_2d.h"
+
+class CanvasItemEditor;
+
+class RayCast2DEditor : public Control {
+	GDCLASS(RayCast2DEditor, Control);
+
+	UndoRedo *undo_redo = nullptr;
+	CanvasItemEditor *canvas_item_editor = nullptr;
+	RayCast2D *node;
+
+	bool pressed = false;
+	Point2 original_cast_to;
+
+protected:
+	void _notification(int p_what);
+	void _node_removed(Node *p_node);
+	static void _bind_methods();
+
+public:
+	bool forward_canvas_gui_input(const Ref<InputEvent> &p_event);
+	void forward_canvas_draw_over_viewport(Control *p_overlay);
+	void edit(Node *p_node);
+
+	RayCast2DEditor();
+};
+
+class RayCast2DEditorPlugin : public EditorPlugin {
+	GDCLASS(RayCast2DEditorPlugin, EditorPlugin);
+
+	RayCast2DEditor *ray_cast_2d_editor = nullptr;
+
+public:
+	virtual bool forward_canvas_gui_input(const Ref<InputEvent> &p_event) { return ray_cast_2d_editor->forward_canvas_gui_input(p_event); }
+	virtual void forward_canvas_draw_over_viewport(Control *p_overlay) { ray_cast_2d_editor->forward_canvas_draw_over_viewport(p_overlay); }
+
+	virtual String get_name() const { return "RayCast2D"; }
+	bool has_main_screen() const { return false; }
+	virtual void edit(Object *p_object);
+	virtual bool handles(Object *p_object) const;
+	virtual void make_visible(bool visible);
+
+	RayCast2DEditorPlugin(EditorNode *p_editor);
+};
+
+#endif // RAY_CAST_2D_EDITOR_PLUGIN_H


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/59337

Adds a handle for editing `RayCast2D.cast_to` (renamed to `target_position` in 4.0) in the 2D editor. It has the same functionality and appearance as the CollisionShape2D shape editor.

![image](https://user-images.githubusercontent.com/67974470/159145911-196ae7c1-f080-4279-848d-bf48ae0ac56b.png)