### PR TITLE
add_set_load_pack_enabled

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -378,6 +378,10 @@ void ProjectSettings::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 }
 
+void ProjectSettings::_set_load_pack_enabled(bool p_enabled) {
+	PackedData::get_singleton()->set_disabled(!p_enabled);
+}
+
 bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset) {
 	if (PackedData::get_singleton()->is_disabled()) {
 		return false;
@@ -1156,6 +1160,7 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("localize_path", "path"), &ProjectSettings::localize_path);
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
+	ClassDB::bind_method(D_METHOD("set_load_pack_enabled", "enabled"), &ProjectSettings::_set_load_pack_enabled);
 	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"), &ProjectSettings::_load_resource_pack, DEFVAL(true), DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("property_can_revert", "name"), &ProjectSettings::property_can_revert);
 	ClassDB::bind_method(D_METHOD("property_get_revert", "name"), &ProjectSettings::property_get_revert);

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -118,6 +118,7 @@ protected:
 
 	void _convert_to_last_version(int p_from_version);
 
+	void _set_load_pack_enabled(bool p_enabled);
 	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0);
 
 	void _add_property_info_bind(const Dictionary &p_info);

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -165,6 +165,12 @@
 				Sets the specified property's initial value. This is the value the property reverts to.
 			</description>
 		</method>
+		<method name="set_load_pack_enabled">
+			<return type="void" />
+			<argument index="0" name="enabled" type="bool" />
+			<description>
+			</description>
+		</method>
 		<method name="set_order">
 			<return type="void" />
 			<argument index="0" name="name" type="String" />


### PR DESCRIPTION
I'm developing a plugin, I want to be able to load the pck file in the editor, but there is a line in main.cpp that disables the pck loading function(line:976)
#ifdef TOOLS_ENABLED
if (editor) {
packed_data->set_disabled(true);
globals->set_disable_feature_overrides(true);
}
I would like to be able to turn this functionality on again within the editor. considering that the pck file is loaded through ProjectSettings.load_resource_pack, so I put this method in ProjectSettings.

*Bugsquad edit: `master` version of https://github.com/godotengine/godot/pull/59278.*
