### PR TITLE
Fix the expand icon calculation logic to the function Button::get_minimum_size

### DIFF
--- a/scene/gui/button.h
+++ b/scene/gui/button.h
@@ -64,6 +64,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	virtual int _get_extra_width() const;
 
 public:
 	virtual Size2 get_minimum_size() const override;

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -40,15 +40,27 @@ Size2 OptionButton::get_minimum_size() const {
 	if (has_theme_icon(SNAME("arrow"))) {
 		const Size2 padding = get_theme_stylebox(SNAME("normal"))->get_minimum_size();
 		const Size2 arrow_size = Control::get_theme_icon(SNAME("arrow"))->get_size();
+		const int arrow_margin = get_theme_constant(SNAME("arrow_margin"));
 
 		Size2 content_size = minsize - padding;
-		content_size.width += arrow_size.width + get_theme_constant(SNAME("h_separation"));
+
+		content_size.width += arrow_size.width + get_theme_constant(SNAME("h_separation")) + arrow_margin;
+
 		content_size.height = MAX(content_size.height, arrow_size.height);
 
 		minsize = content_size + padding;
 	}
 
 	return minsize;
+}
+
+int OptionButton::_get_extra_width() const {
+	int _extra_width = Button::_get_extra_width();
+	_extra_width += get_theme_constant(SNAME("arrow_margin"));
+	if (has_theme_icon(SNAME("arrow"))) {
+		_extra_width += Control::get_theme_icon(SNAME("arrow"))->get_size().width;
+	}
+	return _extra_width;
 }
 
 void OptionButton::_notification(int p_what) {

--- a/scene/gui/option_button.h
+++ b/scene/gui/option_button.h
@@ -53,6 +53,7 @@ protected:
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;
 	void _get_property_list(List<PropertyInfo> *p_list) const;
+	int _get_extra_width() const override;
 	virtual void _validate_property(PropertyInfo &property) const override;
 	static void _bind_methods();
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fix the expand icon calculation logic which belongs to the function `Button::get_minimum_size`
| Type | Before | After |
| :----: | :----: | :----: |
|  Button | ![1](https://user-images.githubusercontent.com/30386067/159189679-bf29eaec-f8b2-415d-8c8d-ae5aad5b181a.gif) | ![3](https://user-images.githubusercontent.com/30386067/159189716-96938e93-29f1-476e-9903-735404a2ba6b.gif) |
| OptionButton | ![2](https://user-images.githubusercontent.com/30386067/159189680-0e6fbc25-0eb9-41af-bff6-a368030f8384.gif) | ![4](https://user-images.githubusercontent.com/30386067/159189718-cef43d94-6148-4ac9-9e6a-758f5459edd8.gif) |

If enable the `expand_icon`, the icon may be hidden when the width of the button is not wide enough. This is where I mainly want to fix in this patch.



**Note:**
The last thing worth noting is that the minimum achievable scale size is highly correlated with the font size, even if the text is empty. So, if you want a small texture size, you need to make the font size small enough. I'm not sure the specific design requirements, just adjusted some logic. 

Should we make the texture keep aspect, or follow other rules?

**Other matters**

~~I'm glad it partially resolves #59202, but if the height of the button is too large, it will still appear.~~

![5](https://user-images.githubusercontent.com/30386067/159190034-d5aa8447-4df7-4728-8229-4178c7ed3a6f.gif)![6](https://user-images.githubusercontent.com/30386067/159192600-548b37a1-cc3f-47ed-9899-351372e835cf.gif)
I checked the source code of `OptionButton`, it overrides this method, maybe this problem needs to be fixed there. It is very likely that this property `theme_override_constants/arrow_margin` was not considered.