### PR TITLE
Advanced import settings inspector is cleared when opened

### DIFF
--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -529,6 +529,8 @@ void SceneImportSettings::open_settings(const String &p_path) {
 
 	base_viewport->add_child(scene);
 
+	inspector->edit(nullptr);
+
 	if (first_aabb) {
 		contents_aabb = AABB(Vector3(-1, -1, -1), Vector3(2, 2, 2));
 		first_aabb = false;


### PR DESCRIPTION
Fixes #59326

https://user-images.githubusercontent.com/18116695/159149912-e87b9811-883b-42df-929c-739c5ba3fab6.mp4


