### PR TITLE
Call the correct texture free method on texture storage cleanup

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.cpp
@@ -300,12 +300,14 @@ TextureStorage::TextureStorage() {
 }
 
 TextureStorage::~TextureStorage() {
-	singleton = nullptr;
-
 	//def textures
 	for (int i = 0; i < DEFAULT_RD_TEXTURE_MAX; i++) {
-		texture_free(default_rd_textures[i]);
+		if (default_rd_textures[i].is_valid()) {
+			RD::get_singleton()->free(default_rd_textures[i]);
+		}
 	}
+
+	singleton = nullptr;
 }
 
 bool TextureStorage::can_create_resources_async() const {


### PR DESCRIPTION
The new texture storage logic was calling the incorrect free method on cleanup.