### PR TITLE
Raycasts hitting from inside: return collision point in global coordinates

### DIFF
--- a/servers/physics_2d/godot_space_2d.cpp
+++ b/servers/physics_2d/godot_space_2d.cpp
@@ -158,7 +158,7 @@ bool GodotPhysicsDirectSpaceState2D::intersect_ray(const RayParameters &p_parame
 			if (p_parameters.hit_from_inside) {
 				// Hit shape at starting point.
 				min_d = 0;
-				res_point = local_from;
+				res_point = begin;
 				res_normal = Vector2();
 				res_shape = shape_idx;
 				res_obj = col_obj;

--- a/servers/physics_3d/godot_space_3d.cpp
+++ b/servers/physics_3d/godot_space_3d.cpp
@@ -153,7 +153,7 @@ bool GodotPhysicsDirectSpaceState3D::intersect_ray(const RayParameters &p_parame
 			if (p_parameters.hit_from_inside) {
 				// Hit shape at starting point.
 				min_d = 0;
-				res_point = local_from;
+				res_point = begin;
 				res_normal = Vector3();
 				res_shape = shape_idx;
 				res_obj = col_obj;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/59335 for both 2D and 3D.