### PR TITLE
Fix getaddrinfo failed with undefined proxy config

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -716,6 +716,10 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Profiler
 	_initial_set("debugger/profiler_frame_history_size", 600);
 
+	// HTTP Proxy
+	_initial_set("network/http_proxy/host", "");
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "network/http_proxy/port", 8080, "1,65535,1")
+
 	/* Extra config */
 
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "project_manager/sorting_order", 0, "Name,Path,Last Edited")

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -147,8 +147,8 @@ void ExportTemplateManager::_download_template(const String &p_url, bool p_skip_
 	download_templates->set_download_file(EditorPaths::get_singleton()->get_cache_dir().plus_file("tmp_templates.tpz"));
 	download_templates->set_use_threads(true);
 
-	const String proxy_host = EDITOR_DEF("network/http_proxy/host", "");
-	const int proxy_port = EDITOR_DEF("network/http_proxy/port", -1);
+	const String proxy_host = EDITOR_GET("network/http_proxy/host");
+	const int proxy_port = EDITOR_GET("network/http_proxy/port");
 	download_templates->set_http_proxy(proxy_host, proxy_port);
 	download_templates->set_https_proxy(proxy_host, proxy_port);
 


### PR DESCRIPTION
HTTPClientTCP expects proxy host to be empty or port to be -1 to ignore
the proxy. When getting the proxy config from the settings file, the
values will default to U"null" and 0, respectively, making HTTPClientTCP
to attempt to use the values as a proxy, which causes getaddrinfo to
fail looking up a "null" hostname.

Setting the default config values seems like a good approach to prevent
this issue.

Fixes #59037
