### PR TITLE
Fix for FileSystem dock going blank on certain actions

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4288,6 +4288,7 @@ void EditorNode::_dock_make_float() {
 	_update_dock_containers();
 
 	floating_docks.push_back(dock);
+	dock->show();
 
 	_edit_current();
 }

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -301,11 +301,7 @@ void FileSystemDock::_update_display_mode(bool p_force) {
 			case DISPLAY_MODE_TREE_ONLY:
 				tree->show();
 				tree->set_v_size_flags(SIZE_EXPAND_FILL);
-				if (display_mode == DISPLAY_MODE_TREE_ONLY) {
-					toolbar2_hbc->show();
-				} else {
-					toolbar2_hbc->hide();
-				}
+				toolbar2_hbc->show();
 
 				_update_tree(_compute_uncollapsed_paths());
 				file_list_vb->hide();
@@ -457,6 +453,7 @@ void FileSystemDock::_notification(int p_what) {
 
 			// Change full tree mode.
 			_update_display_mode();
+			show();
 		} break;
 	}
 }


### PR DESCRIPTION
Fixes for #59236 and #58911.  
Sometimes the dock is cleared and updated but never drawn so added some calls to `show()`.  
Similar problem in the floating dock.

*Bugsquad edit:* 
- Fixes #59236
- Fixes #58911