### PR TITLE
Reduce the size of Controls editor toolbar

### DIFF
--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -818,7 +818,7 @@ void ControlEditorToolbar::_notification(int p_what) {
 	switch (p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
-			anchor_layouts_icon->set_texture(get_theme_icon(SNAME("ControlLayout"), SNAME("EditorIcons")));
+			anchor_presets_menu->set_icon(get_theme_icon(SNAME("ControlLayout"), SNAME("EditorIcons")));
 
 			PopupMenu *p = anchor_presets_menu->get_popup();
 			p->clear();
@@ -871,7 +871,8 @@ void ControlEditorToolbar::_notification(int p_what) {
 
 			anchor_mode_button->set_icon(get_theme_icon(SNAME("Anchor"), SNAME("EditorIcons")));
 
-			container_layouts_icon->set_texture(get_theme_icon(SNAME("Container"), SNAME("EditorIcons")));
+			container_h_presets_menu->set_icon(get_theme_icon(SNAME("Container"), SNAME("EditorIcons")));
+			container_v_presets_menu->set_icon(get_theme_icon(SNAME("Container"), SNAME("EditorIcons")));
 
 			p = container_h_presets_menu->get_popup();
 			p->clear();
@@ -925,27 +926,19 @@ void ControlEditorToolbar::_notification(int p_what) {
 				}
 
 				if (enable_anchors) {
-					anchor_presets_menu->set_disabled(false);
-					anchor_presets_menu->set_tooltip(TTR("Presets for the anchor and offset values of a Control node."));
-					anchor_mode_button->set_disabled(false);
-					anchor_mode_button->set_tooltip(TTR("When active, moving Control nodes changes their anchors instead of their offsets."));
+					anchor_presets_menu->set_visible(true);
+					anchor_mode_button->set_visible(true);
 				} else {
-					anchor_presets_menu->set_disabled(true);
-					anchor_presets_menu->set_tooltip(TTR("Children of containers have their anchors and offsets values controlled by their parent."));
-					anchor_mode_button->set_disabled(true);
-					anchor_mode_button->set_tooltip(TTR("Children of containers have their anchors and offsets values controlled by their parent."));
+					anchor_presets_menu->set_visible(false);
+					anchor_mode_button->set_visible(false);
 				}
 
 				if (enable_containers) {
-					container_h_presets_menu->set_disabled(false);
-					container_h_presets_menu->set_tooltip(TTR("Horizontal sizing setting for children of a Container node."));
-					container_v_presets_menu->set_disabled(false);
-					container_v_presets_menu->set_tooltip(TTR("Vertical sizing setting for children of a Container node."));
+					container_h_presets_menu->set_visible(true);
+					container_v_presets_menu->set_visible(true);
 				} else {
-					container_h_presets_menu->set_disabled(true);
-					container_h_presets_menu->set_tooltip(TTR("Children of regular controls are controlled by their anchors and offsets."));
-					container_v_presets_menu->set_disabled(true);
-					container_v_presets_menu->set_tooltip(TTR("Children of regular controls are controlled by their anchors and offsets."));
+					container_h_presets_menu->set_visible(false);
+					container_v_presets_menu->set_visible(false);
 				}
 			} else {
 				set_visible(false);
@@ -955,18 +948,10 @@ void ControlEditorToolbar::_notification(int p_what) {
 }
 
 ControlEditorToolbar::ControlEditorToolbar() {
-	anchor_layouts_icon = memnew(TextureRect);
-	anchor_layouts_icon->set_stretch_mode(TextureRect::StretchMode::STRETCH_KEEP_CENTERED);
-	add_child(anchor_layouts_icon);
-
-	Label *l = memnew(Label);
-	l->set_text(TTR("Anchors"));
-	l->set_vertical_alignment(VerticalAlignment::VERTICAL_ALIGNMENT_CENTER);
-	add_child(l);
-
 	anchor_presets_menu = memnew(MenuButton);
 	anchor_presets_menu->set_shortcut_context(this);
-	anchor_presets_menu->set_text(TTR("Preset"));
+	anchor_presets_menu->set_text(TTR("Anchors"));
+	anchor_presets_menu->set_tooltip(TTR("Presets for the anchor and offset values of a Control node."));
 	add_child(anchor_presets_menu);
 	anchor_presets_menu->set_switch_on_hover(true);
 
@@ -981,23 +966,16 @@ ControlEditorToolbar::ControlEditorToolbar() {
 	anchor_mode_button = memnew(Button);
 	anchor_mode_button->set_flat(true);
 	anchor_mode_button->set_toggle_mode(true);
+	anchor_mode_button->set_tooltip(TTR("When active, moving Control nodes changes their anchors instead of their offsets."));
 	add_child(anchor_mode_button);
 	anchor_mode_button->connect("toggled", callable_mp(this, &ControlEditorToolbar::_button_toggle_anchor_mode));
 
 	add_child(memnew(VSeparator));
 
-	container_layouts_icon = memnew(TextureRect);
-	container_layouts_icon->set_stretch_mode(TextureRect::StretchMode::STRETCH_KEEP_CENTERED);
-	add_child(container_layouts_icon);
-
-	l = memnew(Label);
-	l->set_text(TTR("Containers"));
-	l->set_vertical_alignment(VerticalAlignment::VERTICAL_ALIGNMENT_CENTER);
-	add_child(l);
-
 	container_h_presets_menu = memnew(MenuButton);
 	container_h_presets_menu->set_shortcut_context(this);
 	container_h_presets_menu->set_text(TTR("Horizontal"));
+	container_h_presets_menu->set_tooltip(TTR("Horizontal sizing setting for children of a Container node."));
 	add_child(container_h_presets_menu);
 	container_h_presets_menu->set_switch_on_hover(true);
 
@@ -1007,6 +985,7 @@ ControlEditorToolbar::ControlEditorToolbar() {
 	container_v_presets_menu = memnew(MenuButton);
 	container_v_presets_menu->set_shortcut_context(this);
 	container_v_presets_menu->set_text(TTR("Vertical"));
+	container_v_presets_menu->set_tooltip(TTR("Vertical sizing setting for children of a Container node."));
 	add_child(container_v_presets_menu);
 	container_v_presets_menu->set_switch_on_hover(true);
 

--- a/editor/plugins/control_editor_plugin.h
+++ b/editor/plugins/control_editor_plugin.h
@@ -198,10 +198,8 @@ class ControlEditorToolbar : public HBoxContainer {
 		CONTAINERS_V_PRESET_SHRINK_END,
 	};
 
-	TextureRect *anchor_layouts_icon;
 	MenuButton *anchor_presets_menu;
 	PopupMenu *anchors_popup;
-	TextureRect *container_layouts_icon;
 	MenuButton *container_h_presets_menu;
 	MenuButton *container_v_presets_menu;
 


### PR DESCRIPTION
- remove "Anchors" and "Containers" fake buttons
  - Anchors is now a name of the button
  - Horizontal and Vertical just got Container icon
- hide Anchors/Containers when unavailable, instead of disabling them
  - this removes their disabled tooltip, but it's better than taking space

Before:
![godot windows tools 64_qo3LmXJSML](https://user-images.githubusercontent.com/2223172/159171467-93b147a9-0a21-4077-9d29-c5311e8f23c1.gif)
After:
![godot windows tools 64_qO4RMPMx2A](https://user-images.githubusercontent.com/2223172/159171474-fdc9e066-0137-4bfd-859c-5951d67eb027.gif)

Resolves #58052