### PR TITLE
Allow ScrollContainer to be clicked for focus and border

### DIFF
--- a/doc/classes/EditorInspector.xml
+++ b/doc/classes/EditorInspector.xml
@@ -22,6 +22,7 @@
 		</method>
 	</methods>
 	<members>
+		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
 		<member name="horizontal_scroll_mode" type="int" setter="set_horizontal_scroll_mode" getter="get_horizontal_scroll_mode" overrides="ScrollContainer" enum="ScrollContainer.ScrollMode" default="0" />
 	</members>
 	<signals>

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -87,8 +87,11 @@
 		</constant>
 	</constants>
 	<theme_items>
+		<theme_item name="focus" data_type="style" type="StyleBox">
+			[StyleBox] used when the [ScrollContainer] is focused.
+		</theme_item>
 		<theme_item name="panel" data_type="style" type="StyleBox">
-			The background [StyleBox] of the [ScrollContainer].
+			Default [StyleBox] for the [ScrollContainer], i.e. used when the control is not focused.
 		</theme_item>
 	</theme_items>
 </class>

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -4089,6 +4089,7 @@ EditorInspector::EditorInspector() {
 	search_box = nullptr;
 	_prop_edited = "property_edited";
 	set_process(false);
+	set_focus_mode(FocusMode::FOCUS_ALL);
 	property_focusable = -1;
 	property_clipboard = Variant();
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -643,6 +643,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_widget_focus->set_draw_center(false);
 	style_widget_focus->set_border_width_all(Math::round(2 * MAX(1, EDSCALE)));
 	style_widget_focus->set_border_color(accent_color);
+	// Make the focus outline appear to be flush with the buttons it's focusing, so not draw on top of the content.
+	style_widget_focus->set_expand_margin_size_all(2);
 
 	Ref<StyleBoxFlat> style_widget_pressed = style_widget->duplicate();
 	style_widget_pressed->set_bg_color(dark_color_1.darkened(0.125));
@@ -1375,6 +1377,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("minimum_grab_thickness", "VSplitContainer", 6 * EDSCALE);
 
 	// Containers
+	theme->set_stylebox("focus", "ScrollContainer", style_widget_focus);
 	theme->set_constant("separation", "BoxContainer", default_margin_size * EDSCALE);
 	theme->set_constant("separation", "HBoxContainer", default_margin_size * EDSCALE);
 	theme->set_constant("separation", "VBoxContainer", default_margin_size * EDSCALE);

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -84,6 +84,7 @@ void ScrollContainer::_update_theme_item_cache() {
 	Container::_update_theme_item_cache();
 
 	theme_cache.panel_style = get_theme_stylebox(SNAME("panel"));
+	theme_cache.focus_style = get_theme_stylebox(SNAME("focus"));
 }
 
 void ScrollContainer::_cancel_drag() {
@@ -342,6 +343,12 @@ void ScrollContainer::_notification(int p_what) {
 
 		case NOTIFICATION_DRAW: {
 			draw_style_box(theme_cache.panel_style, Rect2(Vector2(), get_size()));
+			if (has_focus()) {
+				RID canvas_item = get_canvas_item();
+				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(canvas_item, true);
+				draw_style_box(theme_cache.focus_style, Rect2(Point2(), get_size()));
+				RenderingServer::get_singleton()->canvas_item_add_clip_ignore(canvas_item, false);
+			}
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {

--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -33,6 +33,7 @@
 
 #include "container.h"
 
+#include "scene/resources/style_box.h"
 #include "scroll_bar.h"
 
 class ScrollContainer : public Container {
@@ -71,6 +72,7 @@ private:
 
 	struct ThemeCache {
 		Ref<StyleBox> panel_style;
+		Ref<StyleBox> focus_style;
 	} theme_cache;
 
 	void _cancel_drag();

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -141,7 +141,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	const Ref<StyleBoxFlat> button_pressed = make_flat_stylebox(style_pressed_color);
 	const Ref<StyleBoxFlat> button_disabled = make_flat_stylebox(style_disabled_color);
 	Ref<StyleBoxFlat> focus = make_flat_stylebox(style_focus_color, default_margin, default_margin, default_margin, default_margin, default_corner_radius, false, 2);
-	// Make the focus outline appear to be flush with the buttons it's focusing.
+	// Make the focus outline appear to be flush with the buttons it's focusing, so not draw on top of the content.
 	focus->set_expand_margin_size_all(2 * scale);
 
 	theme->set_stylebox("normal", "Button", button_normal);
@@ -573,6 +573,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	Ref<StyleBoxEmpty> empty;
 	empty.instantiate();
 	theme->set_stylebox("panel", "ScrollContainer", empty);
+	theme->set_stylebox("focus", "ScrollContainer", empty);
 
 	// Window
 


### PR DESCRIPTION
The SceneTree and FileSystem docks have focus borders automatically since TreeDialog is one of the few classes which provides this, and also offer focus-on-click. In my opinion the style of this works well with Godot and is potentially useful for checking what the user is currently doing - for example, if they are editing the SceneTree then that dock has focus.

In order to make the Inspector dock more consistent with this style, since it has a similar feel and context anyway, I have made it (a) clickable and (b) draw the same border when focused. This is a really useful feature for another PR I'm making soon which needs to recognise what dock the user is working in, but it certainly has other use cases (e.g. for plugins) as well and just looks nice.

Problems:
1. ~~The border-focus stylebox is drawn underneath elements such as text boxes. I don't know if this matters, but it's something that could be fixed if necessary.~~ _This has now been fixed by using a more general and standard method for drawing the focus stylebox._
![image](https://user-images.githubusercontent.com/66553618/159190970-518b5d6d-9e3e-4306-98f4-bab5d0aecfd5.png)
2. ~~When doing something like dragging a slider immediately after something else was focused, focus returns to that area and not the Inspector. This probably doesn't matter though and, again, could be fixed.~~ _This still occurs but is no longer a problem, since recent updates have made focus changes more stable._

Update 2022-09-01: additionally, the focus border has been made available in ScrollContainer as a whole.