### PR TITLE
Decrease the default line spacing in the script editor

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -43,10 +43,10 @@ void EditorAbout::_theme_changed() {
 	const int font_size = get_theme_font_size(SNAME("source_size"), SNAME("EditorFonts"));
 	_tpl_text->add_theme_font_override("normal_font", font);
 	_tpl_text->add_theme_font_size_override("normal_font_size", font_size);
-	_tpl_text->add_theme_constant_override("line_separation", 6 * EDSCALE);
+	_tpl_text->add_theme_constant_override("line_separation", 4 * EDSCALE);
 	_license_text->add_theme_font_override("normal_font", font);
 	_license_text->add_theme_font_size_override("normal_font_size", font_size);
-	_license_text->add_theme_constant_override("line_separation", 6 * EDSCALE);
+	_license_text->add_theme_constant_override("line_separation", 4 * EDSCALE);
 	_logo->set_texture(get_theme_icon(SNAME("Logo"), SNAME("EditorIcons")));
 }
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -535,7 +535,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	// Appearance: Whitespace
 	_initial_set("text_editor/appearance/whitespace/draw_tabs", true);
 	_initial_set("text_editor/appearance/whitespace/draw_spaces", false);
-	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/appearance/whitespace/line_spacing", 6, "0,50,1")
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "text_editor/appearance/whitespace/line_spacing", 4, "0,50,1")
 
 	// Behavior
 	// Behavior: Navigation


### PR DESCRIPTION
This brings the level of line spacing closer to what it was like in Godot 3.x, which improves usability on small displays.

This also decreases the default line spacing for fixed-width texts in the About dialog (license text).

This closes https://github.com/godotengine/godot/issues/58831.

## Preview

| Before | After |
|-|-|
| ![2022-03-21_02 00 32](https://user-images.githubusercontent.com/180032/159193975-f1d11c95-2dbd-4d31-94a4-d482bef7c54c.png) | ![2022-03-21_02 00 04](https://user-images.githubusercontent.com/180032/159193974-ff48defd-db79-4169-99b9-aed74a4569d3.png) |

___

I've also tried line spacing 2, but I feel the lines get too snug at this point:

![image](https://user-images.githubusercontent.com/180032/159194038-b3e4a623-61db-4de4-8ade-18322671b4ec.png)

It'd probably look good if the default font size was decreased, but as I said in https://github.com/godotengine/godot/issues/58831#issuecomment-1073387276, it might not be a good idea to do so right now.