### PR TITLE
Move extension logic to EditorExportPlatformLinuxBSD

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1819,23 +1819,6 @@ bool EditorExportPlatformPC::can_export(const Ref<EditorExportPreset> &p_preset,
 	return valid;
 }
 
-List<String> EditorExportPlatformPC::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {
-	List<String> list;
-	for (const KeyValue<String, String> &E : extensions) {
-		if (p_preset->get(E.key)) {
-			list.push_back(extensions[E.key]);
-			return list;
-		}
-	}
-
-	if (extensions.has("default")) {
-		list.push_back(extensions["default"]);
-		return list;
-	}
-
-	return list;
-}
-
 Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags) {
 	ExportNotifier notifier(*this, p_preset, p_debug, p_path, p_flags);
 
@@ -1925,10 +1908,6 @@ Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_pr
 
 Error EditorExportPlatformPC::sign_shared_object(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path) {
 	return OK;
-}
-
-void EditorExportPlatformPC::set_extension(const String &p_extension, const String &p_feature_key) {
-	extensions[p_feature_key] = p_extension;
 }
 
 void EditorExportPlatformPC::set_name(const String &p_name) {

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -425,7 +425,6 @@ private:
 	Ref<ImageTexture> logo;
 	String name;
 	String os_name;
-	Map<String, String> extensions;
 
 	String release_file_32;
 	String release_file_64;
@@ -444,11 +443,9 @@ public:
 	virtual Ref<Texture2D> get_logo() const override;
 
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const override;
-	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
 	virtual Error sign_shared_object(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path);
 
-	void set_extension(const String &p_extension, const String &p_feature_key = "default");
 	void set_name(const String &p_name);
 	void set_os_name(const String &p_name);
 

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -73,6 +73,27 @@ Error EditorExportPlatformLinuxBSD::export_project(const Ref<EditorExportPreset>
 	return err;
 }
 
+void EditorExportPlatformLinuxBSD::set_extension(const String &p_extension, const String &p_feature_key) {
+	extensions[p_feature_key] = p_extension;
+}
+
+List<String> EditorExportPlatformLinuxBSD::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {
+	List<String> list;
+	for (const KeyValue<String, String> &E : extensions) {
+		if (p_preset->get(E.key)) {
+			list.push_back(extensions[E.key]);
+			return list;
+		}
+	}
+
+	if (extensions.has("default")) {
+		list.push_back(extensions["default"]);
+		return list;
+	}
+
+	return list;
+}
+
 Error EditorExportPlatformLinuxBSD::fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) const {
 	// Patch the header of the "pck" section in the ELF file so that it corresponds to the embedded data
 

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -38,9 +38,12 @@
 #include "scene/resources/texture.h"
 
 class EditorExportPlatformLinuxBSD : public EditorExportPlatformPC {
+	Map<String, String> extensions;
 	Error _export_debug_script(const Ref<EditorExportPreset> &p_preset, const String &p_app_name, const String &p_pkg_name, const String &p_path);
 
 public:
+	void set_extension(const String &p_extension, const String &p_feature_key = "default");
+	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
 	virtual Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) const override;
 };

--- a/platform/windows/export/export.cpp
+++ b/platform/windows/export/export.cpp
@@ -55,7 +55,6 @@ void register_windows_exporter() {
 	logo->create_from_image(img);
 	platform->set_logo(logo);
 	platform->set_name("Windows Desktop");
-	platform->set_extension("exe");
 	platform->set_release_32("windows_32_release.exe");
 	platform->set_debug_32("windows_32_debug.exe");
 	platform->set_release_64("windows_64_release.exe");

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -86,6 +86,12 @@ Error EditorExportPlatformWindows::export_project(const Ref<EditorExportPreset> 
 	return err;
 }
 
+List<String> EditorExportPlatformWindows::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {
+	List<String> list;
+	list.push_back("exe");
+	return list;
+}
+
 bool EditorExportPlatformWindows::get_export_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const {
 	// This option is not supported by "osslsigncode", used on non-Windows host.
 	if (!OS::get_singleton()->has_feature("windows") && p_option == "codesign/identity_type") {

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -45,6 +45,7 @@ class EditorExportPlatformWindows : public EditorExportPlatformPC {
 public:
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
 	virtual Error sign_shared_object(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path) override;
+	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
 	virtual void get_export_options(List<ExportOption> *r_options) override;
 	virtual bool get_export_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const override;
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const override;


### PR DESCRIPTION
Since we now have `EditorExportPlatformLinuxBSD` thanks to #58455, this PR moves the extension setting logic to that class. Previously this code was shared between Windows and Linux in EditorExportPlatformPC, but it was only meaningfully used by Linux, and with Windows it just was hard-coded to `exe` anyway.