### PR TITLE
Fix CSG gizmos only working on root shapes

### DIFF
--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -347,14 +347,12 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 	p_gizmo->add_lines(lines, material);
 	p_gizmo->add_collision_segments(lines);
 
-	Array csg_meshes = cs->get_meshes();
-	if (csg_meshes.size() != 2) {
-		return;
-	}
-
-	Ref<Mesh> csg_mesh = csg_meshes[1];
-	if (csg_mesh.is_valid()) {
-		p_gizmo->add_collision_triangles(csg_mesh->generate_triangle_mesh());
+	if (cs->is_root_shape()) {
+		Array csg_meshes = cs->get_meshes();
+		Ref<Mesh> csg_mesh = csg_meshes[1];
+		if (csg_mesh.is_valid()) {
+			p_gizmo->add_collision_triangles(csg_mesh->generate_triangle_mesh());
+		}
 	}
 
 	if (p_gizmo->is_selected()) {


### PR DESCRIPTION
#56602 added an early return to `CSGShape3DGizmoPlugin::redraw` that broke gizmos for all child CSG shapes. This PR fixes the issue by adding the collision triangles only for root shapes and not returning too soon.

Fixes #57853