### PR TITLE
Add editor setting for AcceptDialog OK/Cancel buttons positioning

### DIFF
--- a/doc/classes/EditorSettings.xml
+++ b/doc/classes/EditorSettings.xml
@@ -457,6 +457,12 @@
 			If [code]true[/code], when saving a file, the editor will rename the old file to a different name, save a new file, then only remove the old file once the new file has been saved. This makes loss of data less likely to happen if the editor or operating system exits unexpectedly while saving (e.g. due to a crash or power outage).
 			[b]Note:[/b] On Windows, this feature can interact negatively with certain antivirus programs. In this case, you may have to set this to [code]false[/code] to prevent file locking issues.
 		</member>
+		<member name="interface/editor/accept_dialog_cancel_ok_buttons" type="int" setter="" getter="">
+			How to position the Cancel and OK buttons in the editor's [AcceptDialog]s. Different platforms have different standard behaviors for this, which can be overridden using this setting. This is useful if you use Godot both on Windows and macOS/Linux and your Godot muscle memory is stronger than your OS specific one.
+			- [b]Auto[/b] follows the platform convention: Cancel first on macOS and Linux, OK first on Windows.
+			- [b]Cancel First[/b] forces the ordering Cancel/OK.
+			- [b]OK First[/b] forces the ordering OK/Cancel.
+		</member>
 		<member name="interface/editor/automatically_open_screenshots" type="bool" setter="" getter="">
 			If [code]true[/code], automatically opens screenshots with the default program associated to [code].png[/code] files after a screenshot is taken using the [b]Editor &gt; Take Screenshot[/b] action.
 		</member>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6181,10 +6181,17 @@ EditorNode::EditorNode() {
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
 	DisplayServer::get_singleton()->window_set_min_size(Size2(1024, 600) * EDSCALE);
 
-	ResourceLoader::set_abort_on_missing_resources(false);
 	FileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesystem/file_dialog/show_hidden_files"));
 	EditorFileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesystem/file_dialog/show_hidden_files"));
 	EditorFileDialog::set_default_display_mode((EditorFileDialog::DisplayMode)EditorSettings::get_singleton()->get("filesystem/file_dialog/display_mode").operator int());
+
+	int swap_cancel_ok = EDITOR_GET("interface/editor/accept_dialog_cancel_ok_buttons");
+	if (swap_cancel_ok != 0) { // 0 is auto, set in register_scene based on DisplayServer.
+		// Swap on means OK first.
+		AcceptDialog::set_swap_cancel_ok(swap_cancel_ok == 2);
+	}
+
+	ResourceLoader::set_abort_on_missing_resources(false);
 	ResourceLoader::set_error_notify_func(this, _load_error_notify);
 	ResourceLoader::set_dependency_error_notify_func(this, _dependency_error_report);
 

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -438,6 +438,9 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::BOOL, PROPERTY_HINT_NONE, "interface/editor/single_window_mode", false, "", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED)
 	_initial_set("interface/editor/mouse_extra_buttons_navigate_history", true);
 	_initial_set("interface/editor/save_each_scene_on_quit", true); // Regression
+	EDITOR_SETTING_USAGE(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/accept_dialog_cancel_ok_buttons", 0,
+			vformat("Auto (%s),Cancel First,OK First", DisplayServer::get_singleton()->get_swap_cancel_ok() ? "OK First" : "Cancel First"),
+			PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 #ifdef DEV_ENABLED
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/editor/show_internal_errors_in_toast_notifications", 0, "Auto (Enabled),Enabled,Disabled")
 #else

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2594,6 +2594,12 @@ ProjectManager::ProjectManager() {
 
 	EditorFileDialog::set_default_show_hidden_files(EditorSettings::get_singleton()->get("filesystem/file_dialog/show_hidden_files"));
 
+	int swap_cancel_ok = EDITOR_GET("interface/editor/accept_dialog_cancel_ok_buttons");
+	if (swap_cancel_ok != 0) { // 0 is auto, set in register_scene based on DisplayServer.
+		// Swap on means OK first.
+		AcceptDialog::set_swap_cancel_ok(swap_cancel_ok == 2);
+	}
+
 	set_anchors_and_offsets_preset(Control::PRESET_FULL_RECT);
 	set_theme(create_custom_theme());
 


### PR DESCRIPTION
The position (left/right) of the Cancel and OK buttons in AcceptDialog
are DisplayServer specific, as Windows uses OK/Cancel and macOS uses Cancel/OK.

Linux/X11 currently uses the macOS convention which is also the GTK+/GNOME one,
though it's not consistent with Qt/KDE applications which follow the Windows
convention.

Since that can't satisfy everyone, it's best if it's configurable also for the
editor (it's already configurable for the project).

Fixes #59379.

![image](https://user-images.githubusercontent.com/4701338/159238881-144207ef-5906-4b17-ac04-27d2cc30f49b.png)

@bruvzg I used "OK First" instead of "OK Left" assuming that this would be handled with UI mirroring too for RTL, but it doesn't seem to be (at least from a quick look at `scene/gui/dialogs.cpp`). I don't know if it should be, we'd have to check e.g. Arabic on Windows and macOS.

Also, I find this whole `swap_cancel_ok` API in AcceptDialog a bit hacky (and badly named as it doesn't tell users swapping from what to what, i.e. that the "reference" unswapped positions are the GNOME/macOS ones). And on Linux one could make a case to have the behavior DE-dependent so that on predominantly Qt-based KDE it would follow the Windows convention... but that's a mess (and as a KDE user I wouldn't like the behavior to change now that I'm used to OK on the right).