### PR TITLE
Mention default output node name for `AnimationNodeBlendTree`

### DIFF
--- a/doc/classes/AnimationNodeBlendTree.xml
+++ b/doc/classes/AnimationNodeBlendTree.xml
@@ -4,7 +4,8 @@
 		[AnimationTree] node resource that contains many blend type nodes.
 	</brief_description>
 	<description>
-		This node may contain a sub-tree of any other blend type nodes, such as mix, blend2, blend3, one shot, etc. This is one of the most commonly used roots.
+		This node may contain a sub-tree of any other blend type nodes, such as [AnimationNodeTransition], [AnimationNodeBlend2], [AnimationNodeBlend3], [AnimationNodeOneShot], etc. This is one of the most commonly used roots.
+		An [AnimationNodeOutput] node named [code]output[/code] is created by default.
 	</description>
 	<tutorials>
 		<link title="AnimationTree">$DOCS_URL/tutorials/animation/animation_tree.html</link>


### PR DESCRIPTION
Fixes #59378

Also turned node types mentioned in the description into links.