### PR TITLE
Add default physics material and physics material override for root CSGShape

### DIFF
--- a/modules/csg/csg_shape.h
+++ b/modules/csg/csg_shape.h
@@ -37,6 +37,7 @@
 #include "scene/3d/path_3d.h"
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/resources/concave_polygon_shape_3d.h"
+#include "scene/resources/physics_material.h"
 #include "thirdparty/misc/mikktspace.h"
 
 class CSGShape3D : public GeometryInstance3D {
@@ -72,6 +73,8 @@ private:
 
 	Ref<ArrayMesh> root_mesh;
 
+	Ref<PhysicsMaterial> physics_material_override;
+
 	struct Vector3Hasher {
 		_ALWAYS_INLINE_ uint32_t hash(const Vector3 &p_vec3) const {
 			uint32_t h = hash_djb2_one_float(p_vec3.x);
@@ -106,6 +109,7 @@ private:
 
 	void _update_shape();
 	void _update_collision_faces();
+	void _update_physics_params();
 
 protected:
 	void _notification(int p_what);
@@ -149,6 +153,9 @@ public:
 
 	void set_calculate_tangents(bool p_calculate_tangents);
 	bool is_calculating_tangents() const;
+
+	void set_physics_material_override(const Ref<PhysicsMaterial> &p_physics_material_override);
+	Ref<PhysicsMaterial> get_physics_material_override() const;
 
 	bool is_root_shape() const;
 	CSGShape3D();

--- a/modules/csg/doc_classes/CSGShape3D.xml
+++ b/modules/csg/doc_classes/CSGShape3D.xml
@@ -69,6 +69,10 @@
 		<member name="operation" type="int" setter="set_operation" getter="get_operation" enum="CSGShape3D.Operation" default="0">
 			The operation that is performed on this shape. This is ignored for the first CSG child node as the operation is between this node and the previous child of this nodes parent.
 		</member>
+		<member name="physics_material_override" type="PhysicsMaterial" setter="set_physics_material_override" getter="get_physics_material_override">
+			The physics material override for the CSG shape.
+			If a material is assigned to this property, it will be used instead of a default physics material.
+		</member>
 		<member name="snap" type="float" setter="set_snap" getter="get_snap" default="0.001">
 			Snap makes the mesh snap to a given distance so that the faces of two meshes can be perfectly aligned. A lower value results in greater precision but may be harder to adjust.
 		</member>


### PR DESCRIPTION
Adds a default physics material, same that `StaticBody3D` has, and adds a new property to override the default physics material.

Fixes #36893

Small demo project: [csg-physics-material-demo.zip](https://github.com/godotengine/godot/files/8315491/csg-physics-material-demo.zip)

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/7568.*