### PR TITLE
Use lowercase names for audio driver names

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -780,7 +780,7 @@
 		<member name="internationalization/locale/include_text_server_data" type="bool" setter="" getter="" default="false">
 			If [code]true[/code], text server break iteration rule sets, dictionaries and other optional data are included in the exported project.
 			[b]Note:[/b] "ICU / HarfBuzz / Graphite" text server data includes dictionaries for Burmese, Chinese, Japanese, Khmer, Lao and Thai as well as Unicode Standard Annex #29 and Unicode Standard Annex #14 word and line breaking rules. Data is about 4 MB large.
-			[b]Note:[/b] "Fallback" text server does not use additional data.
+			[b]Note:[/b] The "Fallback" text server does not use additional data.
 		</member>
 		<member name="internationalization/locale/test" type="String" setter="" getter="" default="&quot;&quot;">
 			If non-empty, this locale will be used when running the project from the editor.

--- a/drivers/alsa/audio_driver_alsa.h
+++ b/drivers/alsa/audio_driver_alsa.h
@@ -70,7 +70,7 @@ class AudioDriverALSA : public AudioDriver {
 
 public:
 	const char *get_name() const {
-		return "ALSA";
+		return "alsa";
 	};
 
 	virtual Error init();

--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -88,7 +88,7 @@ class AudioDriverCoreAudio : public AudioDriver {
 
 public:
 	const char *get_name() const {
-		return "CoreAudio";
+		return "coreaudio";
 	};
 
 	virtual Error init();

--- a/drivers/pulseaudio/audio_driver_pulseaudio.h
+++ b/drivers/pulseaudio/audio_driver_pulseaudio.h
@@ -95,7 +95,7 @@ class AudioDriverPulseAudio : public AudioDriver {
 
 public:
 	const char *get_name() const {
-		return "PulseAudio";
+		return "pulseaudio";
 	};
 
 	virtual Error init();

--- a/drivers/wasapi/audio_driver_wasapi.h
+++ b/drivers/wasapi/audio_driver_wasapi.h
@@ -95,7 +95,7 @@ class AudioDriverWASAPI : public AudioDriver {
 
 public:
 	virtual const char *get_name() const {
-		return "WASAPI";
+		return "wasapi";
 	}
 
 	virtual Error init();

--- a/drivers/xaudio2/audio_driver_xaudio2.cpp
+++ b/drivers/xaudio2/audio_driver_xaudio2.cpp
@@ -34,7 +34,7 @@
 #include "core/os/os.h"
 
 const char *AudioDriverXAudio2::get_name() const {
-	return "XAudio2";
+	return "xaudio2";
 }
 
 Error AudioDriverXAudio2::init() {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -686,8 +686,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				}
 
 				if (!found) {
-					OS::get_singleton()->print("Unknown audio driver '%s', aborting.\nValid options are ",
-							audio_driver.utf8().get_data());
+					// Audio driver options are generally OS-specific.
+					OS::get_singleton()->print("Unknown audio driver '%s', aborting.\nValid options on %s are ",
+							audio_driver.utf8().get_data(), OS::get_singleton()->get_name().utf8().get_data());
 
 					for (int i = 0; i < AudioDriverManager::get_driver_count(); i++) {
 						if (i == AudioDriverManager::get_driver_count() - 1) {
@@ -731,8 +732,9 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 				}
 
 				if (!found) {
-					OS::get_singleton()->print("Unknown display driver '%s', aborting.\nValid options are ",
-							display_driver.utf8().get_data());
+					// Display driver options are generally OS-specific.
+					OS::get_singleton()->print("Unknown display driver '%s', aborting.\nValid options on %s are ",
+							display_driver.utf8().get_data(), OS::get_singleton()->get_name().utf8().get_data());
 
 					for (int i = 0; i < DisplayServer::get_create_function_count(); i++) {
 						if (i == DisplayServer::get_create_function_count() - 1) {
@@ -892,7 +894,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 
 		} else if (I->get() == "--headless") { // enable headless mode (no audio, no rendering).
 
-			audio_driver = "Dummy";
+			audio_driver = "dummy";
 			display_driver = "headless";
 
 		} else if (I->get() == "--profiling") { // enable profiling

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -83,7 +83,7 @@ void AudioDriverOpenSL::_buffer_callbacks(
 AudioDriverOpenSL *AudioDriverOpenSL::s_ad = nullptr;
 
 const char *AudioDriverOpenSL::get_name() const {
-	return "Android";
+	return "opensl";
 }
 
 Error AudioDriverOpenSL::init() {

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -70,7 +70,7 @@ bool DisplayServerAndroid::has_feature(Feature p_feature) const {
 }
 
 String DisplayServerAndroid::get_name() const {
-	return "Android";
+	return "android";
 }
 
 void DisplayServerAndroid::clipboard_set(const String &p_text) {

--- a/servers/audio/audio_driver_dummy.h
+++ b/servers/audio/audio_driver_dummy.h
@@ -56,7 +56,7 @@ class AudioDriverDummy : public AudioDriver {
 
 public:
 	const char *get_name() const {
-		return "Dummy";
+		return "dummy";
 	};
 
 	virtual Error init();

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -225,8 +225,8 @@ void AudioDriverManager::initialize(int p_driver) {
 		}
 	}
 
-	if (driver_count > 1 && String(AudioDriver::get_singleton()->get_name()) == "Dummy") {
-		WARN_PRINT("All audio drivers failed, falling back to the dummy driver.");
+	if (driver_count > 1 && String(AudioDriver::get_singleton()->get_name()) == "dummy") {
+		WARN_PRINT("All audio drivers failed. Falling back to the dummy driver.");
 	}
 }
 

--- a/servers/text/text_server_dummy.h
+++ b/servers/text/text_server_dummy.h
@@ -41,7 +41,7 @@ class TextServerDummy : public TextServerExtension {
 
 public:
 	virtual String get_name() const override {
-		return "Dummy";
+		return "dummy";
 	}
 };
 


### PR DESCRIPTION
This is consistent with rendering, display and tablet driver names which are now all lowercase in `master`.

This also mentions in the error message that display and audio drivers are OS-specific (which means the list of allowed values depends on the OS).

The audio driver used on Android was renamed to `opensl` to reflect the actual backend used.

Projects that use project settings or command line arguments to force a specific audio driver will need to be updated.