### PR TITLE
Fill implementation for empty methods `is_animated` and `casts_shadows`

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -51,7 +51,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 
 	ShaderCompiler::GeneratedCode gen_code;
 
-	int blend_mode = BLEND_MODE_MIX;
+	blend_mode = BLEND_MODE_MIX;
 	int depth_testi = DEPTH_TEST_ENABLED;
 	int alpha_antialiasing_mode = ALPHA_ANTIALIASING_OFF;
 	int cull = CULL_BACK;
@@ -97,6 +97,7 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	actions.render_mode_values["depth_draw_never"] = Pair<int *, int>(&depth_drawi, DEPTH_DRAW_DISABLED);
 	actions.render_mode_values["depth_draw_opaque"] = Pair<int *, int>(&depth_drawi, DEPTH_DRAW_OPAQUE);
 	actions.render_mode_values["depth_draw_always"] = Pair<int *, int>(&depth_drawi, DEPTH_DRAW_ALWAYS);
+	actions.render_mode_values["depth_draw_alpha_prepass"] = Pair<int *, int>(&depth_drawi, DEPTH_DRAW_ALPHA_PREPASS);
 
 	actions.render_mode_values["depth_test_disabled"] = Pair<int *, int>(&depth_testi, DEPTH_TEST_DISABLED);
 
@@ -170,6 +171,8 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 	ubo_offsets = gen_code.uniform_offsets;
 	texture_uniforms = gen_code.texture_uniforms;
 
+	uses_fragment_time = gen_code.uses_fragment_time;
+	uses_vertex_time = gen_code.uses_vertex_time;
 	//blend modes
 
 	// if any form of Alpha Antialiasing is enabled, set the blend mode to alpha to coverage
@@ -408,11 +411,11 @@ bool SceneShaderForwardClustered::ShaderData::is_param_texture(const StringName 
 }
 
 bool SceneShaderForwardClustered::ShaderData::is_animated() const {
-	return false;
+	return (uses_discard && uses_fragment_time) || (uses_vertex && uses_vertex_time);
 }
 
 bool SceneShaderForwardClustered::ShaderData::casts_shadows() const {
-	return false;
+	return (blend_mode == BLEND_MODE_MIX) && (!(uses_alpha && uses_alpha_clip) || (depth_draw == DEPTH_DRAW_ALPHA_PREPASS));
 }
 
 Variant SceneShaderForwardClustered::ShaderData::get_default_parameter(const StringName &p_parameter) const {

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -105,7 +105,8 @@ public:
 		enum DepthDraw {
 			DEPTH_DRAW_DISABLED,
 			DEPTH_DRAW_OPAQUE,
-			DEPTH_DRAW_ALWAYS
+			DEPTH_DRAW_ALWAYS,
+			DEPTH_DRAW_ALPHA_PREPASS
 		};
 
 		enum DepthTest {
@@ -152,6 +153,8 @@ public:
 		DepthDraw depth_draw;
 		DepthTest depth_test;
 
+		int blend_mode;
+
 		bool uses_point_size;
 		bool uses_alpha;
 		bool uses_blend_alpha;
@@ -173,6 +176,9 @@ public:
 		bool uses_time;
 		bool writes_modelview_or_projection;
 		bool uses_world_coordinates;
+
+		bool uses_fragment_time;
+		bool uses_vertex_time;
 
 		uint64_t last_pass = 0;
 		uint32_t index = 0;


### PR DESCRIPTION
This revision implemented below empty methods
* `SceneShaderForwardClustered::ShaderData::is_animated`
* `SceneShaderForwardClustered::ShaderData::casts_shadows`

Implementation referenced on below codes https://github.com/godotengine/godot/blob/6071d78ba103d346599f1f9748337fcc8915adcb/drivers/gles3/rasterizer_storage_gles3.cpp#L3179-L3196

I added three more member variables in `SceneShaderForwardClustered::ShaderData` for calculating.

* Fixes https://github.com/godotengine/godot/issues/58380