### PR TITLE
Change extension for Linux 32-bit x86 exports to `x86_32`

### DIFF
--- a/platform/linuxbsd/export/export.cpp
+++ b/platform/linuxbsd/export/export.cpp
@@ -42,7 +42,7 @@ void register_linuxbsd_exporter() {
 	logo->create_from_image(img);
 	platform->set_logo(logo);
 	platform->set_name("Linux/X11");
-	platform->set_extension("x86");
+	platform->set_extension("x86_32");
 	platform->set_extension("x86_64", "binary_format/64_bits");
 	platform->set_release_32("linux_x11_32_release");
 	platform->set_debug_32("linux_x11_32_debug");


### PR DESCRIPTION
This is purely a cosmetic change that changes the file extension during a LinuxBSD export to `.x86_32` to indicate that this file is for 32-bit x86. This will affect minor things like SteamDB heuristics so it deserves a PR of its own.

This change is related to #59371 and #55778, but is not dependent on either one. Eventually we should add `.arm32`, `.arm64`, `.rv64`, etc, but that will wait for a future PR, and in the meantime we can do this rename for x86.