### PR TITLE
Remove "Percent" group in ProgressBar

### DIFF
--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -100,7 +100,7 @@ bool ProgressBar::is_percent_visible() const {
 void ProgressBar::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_percent_visible", "visible"), &ProgressBar::set_percent_visible);
 	ClassDB::bind_method(D_METHOD("is_percent_visible"), &ProgressBar::is_percent_visible);
-	ADD_GROUP("Percent", "percent_");
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "percent_visible"), "set_percent_visible", "is_percent_visible");
 }
 


### PR DESCRIPTION
ProgressBar has only one property, but it has a group. This PR removes the group because having a group for only one property is unnecessary.

| Before | After |
---|---
| ![ProgressBar before](https://user-images.githubusercontent.com/67974470/159387112-c55e3d47-b284-485f-893a-9771a8c1b795.jpg) | ![ProgressBar after](https://user-images.githubusercontent.com/67974470/159387119-ce8046b5-f3d1-4367-90b3-8d500e40ff3b.jpg) |