### PR TITLE
Improve detection of gamepads on Linux

### DIFF
--- a/platform/linuxbsd/joypad_linux.cpp
+++ b/platform/linuxbsd/joypad_linux.cpp
@@ -333,9 +333,8 @@ void JoypadLinux::open_joypad(const char *p_path) {
 		}
 
 		// Check if the device supports basic gamepad events
-		bool has_abs_left = (test_bit(ABS_X, absbit) && test_bit(ABS_Y, absbit));
-		bool has_abs_right = (test_bit(ABS_RX, absbit) && test_bit(ABS_RY, absbit));
-		if (!(test_bit(EV_KEY, evbit) && test_bit(EV_ABS, evbit) && (has_abs_left || has_abs_right))) {
+		if (!(test_bit(EV_KEY, evbit) && test_bit(EV_ABS, evbit) &&
+					test_bit(ABS_RX, absbit) && test_bit(ABS_RY, absbit))) {
 			close(fd);
 			return;
 		}


### PR DESCRIPTION
Requires gamepads to have a right x and y axis.

#57612 reduced the restriction on gamepads from having buttons and **both** a left and right x and y axis (joystick) to having buttons and **either** a left or right x and y axis (joystick). This was required to support gamepads that only have a right joystick.

However there are probably a lot of devices that have both buttons and a left x and y axis that are not gamepads and will be incorrectly detected as such. Therefore this PR increases the restriction on gamepads to have buttons and a right x and y axis. This will prevent devises that have buttons and only a left x and y axis from being detected as a gamepad, but allow devices that have buttons and a right x and y axis (joystick) from being detected as a gamepad.

Should fix #59250.

**Note:** I'm unable to reproduce #59250 so I cannot confirm that it fixes #59250. I also don't have a gamepad with only a right joystick e.g. Nintendo Switch Right Joy-Con; so I also cannot confirm that it doesn't revert the issue fixed by #57612. Therefore both @thomaslenzi and @maiself should test with their respective setups and confirm that this PR is good.
