### PR TITLE
[3.x] instance audio streams before AudioServer::lock call

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -271,6 +271,9 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 }
 
 void AudioStreamPlayer2D::set_stream(Ref<AudioStream> p_stream) {
+	// Instancing audio streams can cause large memory allocations, do it prior to AudioServer::lock.
+	Ref<AudioStreamPlayback> pre_instanced_playback = p_stream->instance_playback();
+
 	AudioServer::get_singleton()->lock();
 
 	mix_buffer.resize(AudioServer::get_singleton()->thread_get_mix_buffer_size());
@@ -284,7 +287,7 @@ void AudioStreamPlayer2D::set_stream(Ref<AudioStream> p_stream) {
 
 	if (p_stream.is_valid()) {
 		stream = p_stream;
-		stream_playback = p_stream->instance_playback();
+		stream_playback = pre_instanced_playback;
 	}
 
 	AudioServer::get_singleton()->unlock();

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -622,6 +622,9 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 }
 
 void AudioStreamPlayer3D::set_stream(Ref<AudioStream> p_stream) {
+	// Instancing audio streams can cause large memory allocations, do it prior to AudioServer::lock.
+	Ref<AudioStreamPlayback> pre_instanced_playback = p_stream->instance_playback();
+
 	AudioServer::get_singleton()->lock();
 
 	mix_buffer.resize(AudioServer::get_singleton()->thread_get_mix_buffer_size());
@@ -635,7 +638,7 @@ void AudioStreamPlayer3D::set_stream(Ref<AudioStream> p_stream) {
 
 	if (p_stream.is_valid()) {
 		stream = p_stream;
-		stream_playback = p_stream->instance_playback();
+		stream_playback = pre_instanced_playback;
 	}
 
 	AudioServer::get_singleton()->unlock();

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -167,6 +167,9 @@ void AudioStreamPlayer::_notification(int p_what) {
 }
 
 void AudioStreamPlayer::set_stream(Ref<AudioStream> p_stream) {
+	// Instancing audio streams can cause large memory allocations, do it prior to AudioServer::lock.
+	Ref<AudioStreamPlayback> pre_instanced_playback = p_stream->instance_playback();
+
 	AudioServer::get_singleton()->lock();
 
 	if (active.is_set() && stream_playback.is_valid() && !stream_paused) {
@@ -203,7 +206,7 @@ void AudioStreamPlayer::set_stream(Ref<AudioStream> p_stream) {
 
 	if (p_stream.is_valid()) {
 		stream = p_stream;
-		stream_playback = p_stream->instance_playback();
+		stream_playback = pre_instanced_playback;
 	}
 
 	AudioServer::get_singleton()->unlock();


### PR DESCRIPTION
Fixes #22016 in 3.x

This was fixed in `master` by #51296

The bug seems to be caused by an underrun due to the `set_stream` calls holding the global audio server lock during instancing of an ogg stream. It does seem like several different bugs may have been tracked by that issue at some point or another, but the only repro I have is caused by an underrun and this seems to fix it.