### PR TITLE
Generate export template file names instead of having a fixed set

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1794,8 +1794,8 @@ bool EditorExportPlatformPC::can_export(const Ref<EditorExportPreset> &p_preset,
 	// Look for export templates (first official, and if defined custom templates).
 
 	bool use64 = p_preset->get("binary_format/64_bits");
-	bool dvalid = exists_export_template(use64 ? debug_file_64 : debug_file_32, &err);
-	bool rvalid = exists_export_template(use64 ? release_file_64 : release_file_32, &err);
+	bool dvalid = exists_export_template(get_template_file_name("debug", use64 ? "64" : "32"), &err);
+	bool rvalid = exists_export_template(get_template_file_name("release", use64 ? "64" : "32"), &err);
 
 	if (p_preset->get("custom_template/debug") != "") {
 		dvalid = FileAccess::exists(p_preset->get("custom_template/debug"));
@@ -1830,19 +1830,7 @@ Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_pr
 	template_path = template_path.strip_edges();
 
 	if (template_path.is_empty()) {
-		if (p_preset->get("binary_format/64_bits")) {
-			if (p_debug) {
-				template_path = find_export_template(debug_file_64);
-			} else {
-				template_path = find_export_template(release_file_64);
-			}
-		} else {
-			if (p_debug) {
-				template_path = find_export_template(debug_file_32);
-			} else {
-				template_path = find_export_template(release_file_32);
-			}
-		}
+		template_path = find_export_template(get_template_file_name(p_debug ? "debug" : "release", p_preset->get("binary_format/64_bits") ? "64" : "32"));
 	}
 
 	if (!template_path.is_empty() && !FileAccess::exists(template_path)) {
@@ -1920,22 +1908,6 @@ void EditorExportPlatformPC::set_os_name(const String &p_name) {
 
 void EditorExportPlatformPC::set_logo(const Ref<Texture2D> &p_logo) {
 	logo = p_logo;
-}
-
-void EditorExportPlatformPC::set_release_64(const String &p_file) {
-	release_file_64 = p_file;
-}
-
-void EditorExportPlatformPC::set_release_32(const String &p_file) {
-	release_file_32 = p_file;
-}
-
-void EditorExportPlatformPC::set_debug_64(const String &p_file) {
-	debug_file_64 = p_file;
-}
-
-void EditorExportPlatformPC::set_debug_32(const String &p_file) {
-	debug_file_32 = p_file;
 }
 
 void EditorExportPlatformPC::get_platform_features(List<String> *r_features) {

--- a/editor/editor_export.h
+++ b/editor/editor_export.h
@@ -426,11 +426,6 @@ private:
 	String name;
 	String os_name;
 
-	String release_file_32;
-	String release_file_64;
-	String debug_file_32;
-	String debug_file_64;
-
 	int chmod_flags = -1;
 
 public:
@@ -445,16 +440,12 @@ public:
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const override;
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
 	virtual Error sign_shared_object(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path);
+	virtual String get_template_file_name(const String &p_target, const String &p_arch) const = 0;
 
 	void set_name(const String &p_name);
 	void set_os_name(const String &p_name);
 
 	void set_logo(const Ref<Texture2D> &p_logo);
-
-	void set_release_64(const String &p_file);
-	void set_release_32(const String &p_file);
-	void set_debug_64(const String &p_file);
-	void set_debug_32(const String &p_file);
 
 	void add_platform_feature(const String &p_feature);
 	virtual void get_platform_features(List<String> *r_features) override;

--- a/platform/linuxbsd/export/export.cpp
+++ b/platform/linuxbsd/export/export.cpp
@@ -44,10 +44,6 @@ void register_linuxbsd_exporter() {
 	platform->set_name("Linux/X11");
 	platform->set_extension("x86_32");
 	platform->set_extension("x86_64", "binary_format/64_bits");
-	platform->set_release_32("linux_x11_32_release");
-	platform->set_debug_32("linux_x11_32_debug");
-	platform->set_release_64("linux_x11_64_release");
-	platform->set_debug_64("linux_x11_64_debug");
 	platform->set_os_name("LinuxBSD");
 	platform->set_chmod_flags(0755);
 

--- a/platform/linuxbsd/export/export_plugin.cpp
+++ b/platform/linuxbsd/export/export_plugin.cpp
@@ -77,6 +77,10 @@ void EditorExportPlatformLinuxBSD::set_extension(const String &p_extension, cons
 	extensions[p_feature_key] = p_extension;
 }
 
+String EditorExportPlatformLinuxBSD::get_template_file_name(const String &p_target, const String &p_arch) const {
+	return "linux_x11_" + p_arch + "_" + p_target;
+}
+
 List<String> EditorExportPlatformLinuxBSD::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {
 	List<String> list;
 	for (const KeyValue<String, String> &E : extensions) {

--- a/platform/linuxbsd/export/export_plugin.h
+++ b/platform/linuxbsd/export/export_plugin.h
@@ -45,6 +45,7 @@ public:
 	void set_extension(const String &p_extension, const String &p_feature_key = "default");
 	virtual List<String> get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const override;
 	virtual Error export_project(const Ref<EditorExportPreset> &p_preset, bool p_debug, const String &p_path, int p_flags = 0) override;
+	virtual String get_template_file_name(const String &p_target, const String &p_arch) const override;
 	virtual Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) const override;
 };
 

--- a/platform/windows/export/export.cpp
+++ b/platform/windows/export/export.cpp
@@ -55,10 +55,6 @@ void register_windows_exporter() {
 	logo->create_from_image(img);
 	platform->set_logo(logo);
 	platform->set_name("Windows Desktop");
-	platform->set_release_32("windows_32_release.exe");
-	platform->set_debug_32("windows_32_debug.exe");
-	platform->set_release_64("windows_64_release.exe");
-	platform->set_debug_64("windows_64_debug.exe");
 	platform->set_os_name("Windows");
 
 	EditorExport::get_singleton()->add_export_platform(platform);

--- a/platform/windows/export/export_plugin.cpp
+++ b/platform/windows/export/export_plugin.cpp
@@ -86,6 +86,10 @@ Error EditorExportPlatformWindows::export_project(const Ref<EditorExportPreset> 
 	return err;
 }
 
+String EditorExportPlatformWindows::get_template_file_name(const String &p_target, const String &p_arch) const {
+	return "windows_" + p_arch + "_" + p_target + ".exe";
+}
+
 List<String> EditorExportPlatformWindows::get_binary_extensions(const Ref<EditorExportPreset> &p_preset) const {
 	List<String> list;
 	list.push_back("exe");

--- a/platform/windows/export/export_plugin.h
+++ b/platform/windows/export/export_plugin.h
@@ -49,6 +49,7 @@ public:
 	virtual void get_export_options(List<ExportOption> *r_options) override;
 	virtual bool get_export_option_visibility(const String &p_option, const Map<StringName, Variant> &p_options) const override;
 	virtual bool can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const override;
+	virtual String get_template_file_name(const String &p_target, const String &p_arch) const override;
 	virtual Error fixup_embedded_pck(const String &p_path, int64_t p_embedded_start, int64_t p_embedded_size) const override;
 };
 


### PR DESCRIPTION
Since we now have `EditorExportPlatformLinuxBSD` thanks to #58455, this PR changes the logic for finding export template files to use generated names instead of hard-coding a fixed set of names in the Windows and Linux code.

This is done by adding a new method `String get_template_file_name(const String &p_target, const String &p_arch)` which is overridden by both Windows and Linux. Here is what the methods look like:

```cpp
return "windows_" + p_arch + "_" + p_target + ".exe";
return "linux_x11_" + p_arch + "_" + p_target;
```

Which is called in these places:

```cpp
bool dvalid = exists_export_template(get_template_file_name("debug", use64 ? "64" : "32"), &err);
bool rvalid = exists_export_template(get_template_file_name("release", use64 ? "64" : "32"), &err);
template_path = find_export_template(get_template_file_name(p_debug ? "debug" : "release", p_preset->get("binary_format/64_bits") ? "64" : "32"));
```

This doesn't break compatibility with the existing export template names. I tested with the alpha4 templates. However, we could decide to do a rename of 64 -> x86_64 etc in this PR if @akien-mga thinks that's better.

This was made with #55778 in mind. All that will be required with that PR is to replace `use64 ? "64" : "32"` and `p_preset->get("binary_format/64_bits") ? "64" : "32"` with the architecture value and then it will generate file names like `windows_myarchhere_debug.exe`.