### PR TITLE
Use the editor theme accent color for checkbox, radio, and toggle icons

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -288,17 +288,40 @@ void editor_register_and_generate_icons(Ref<Theme> p_theme, bool p_dark_theme = 
 	dark_icon_color_dictionary[Color::html("#5fff97")] = success_color;
 	dark_icon_color_dictionary[Color::html("#ffdd65")] = warning_color;
 
+	// Use the accent color for some icons (checkbox, radio, toggle, etc.).
+	Dictionary accent_color_icon_color_dictionary;
+	Set<StringName> accent_color_icons;
+
+	const Color accent_color = p_theme->get_color(SNAME("accent_color"), SNAME("Editor"));
+	accent_color_icon_color_dictionary[Color::html("699ce8")] = accent_color;
+	if (accent_color.get_luminance() > 0.75) {
+		accent_color_icon_color_dictionary[Color::html("ffffff")] = Color(0.2, 0.2, 0.2);
+	}
+
+	accent_color_icons.insert("GuiChecked");
+	accent_color_icons.insert("GuiRadioChecked");
+	accent_color_icons.insert("GuiIndeterminate");
+	accent_color_icons.insert("GuiToggleOn");
+	accent_color_icons.insert("GuiToggleOnMirrored");
+	accent_color_icons.insert("PlayOverlay");
+
 	// Generate icons.
 	if (!p_only_thumbs) {
 		for (int i = 0; i < editor_icons_count; i++) {
-			float saturation = p_icon_saturation;
+			Ref<ImageTexture> icon;
 
-			if (strcmp(editor_icons_names[i], "DefaultProjectIcon") == 0 || strcmp(editor_icons_names[i], "Godot") == 0 || strcmp(editor_icons_names[i], "Logo") == 0) {
-				saturation = 1.0;
+			if (accent_color_icons.has(editor_icons_names[i])) {
+				icon = editor_generate_icon(i, true, EDSCALE, 1.0, accent_color_icon_color_dictionary);
+			} else {
+				float saturation = p_icon_saturation;
+
+				if (strcmp(editor_icons_names[i], "DefaultProjectIcon") == 0 || strcmp(editor_icons_names[i], "Godot") == 0 || strcmp(editor_icons_names[i], "Logo") == 0) {
+					saturation = 1.0;
+				}
+
+				const int is_exception = exceptions.has(editor_icons_names[i]);
+				icon = editor_generate_icon(i, !is_exception, EDSCALE, saturation, dark_icon_color_dictionary);
 			}
-
-			const int is_exception = exceptions.has(editor_icons_names[i]);
-			const Ref<ImageTexture> icon = editor_generate_icon(i, !is_exception, EDSCALE, saturation, dark_icon_color_dictionary);
 
 			p_theme->set_icon(editor_icons_names[i], SNAME("EditorIcons"), icon);
 		}
@@ -514,8 +537,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 	// Register icons + font
 
-	// The resolution and the icon color (dark_theme bool) has not changed, so we do not regenerate the icons.
-	if (p_theme != nullptr && fabs(p_theme->get_constant(SNAME("scale"), SNAME("Editor")) - EDSCALE) < 0.00001 && (bool)p_theme->get_constant(SNAME("dark_theme"), SNAME("Editor")) == dark_theme && prev_icon_saturation == icon_saturation) {
+	// The editor scale, icon color (dark_theme bool), icon saturation, and accent color has not changed, so we do not regenerate the icons.
+	if (p_theme != nullptr && fabs(p_theme->get_constant(SNAME("scale"), SNAME("Editor")) - EDSCALE) < 0.00001 && (bool)p_theme->get_constant(SNAME("dark_theme"), SNAME("Editor")) == dark_theme && prev_icon_saturation == icon_saturation && p_theme->get_color(SNAME("accent_color"), SNAME("Editor")) == accent_color) {
 		// Register already generated icons.
 		for (int i = 0; i < editor_icons_count; i++) {
 			theme->set_icon(editor_icons_names[i], SNAME("EditorIcons"), p_theme->get_icon(editor_icons_names[i], SNAME("EditorIcons")));


### PR DESCRIPTION
The checkbox, radio, and toggle icons currently always use the default accent color. This PR makes them use the user's selected accent color instead. For very light colors, the inner color is changed to dark gray instead of white.

![image](https://user-images.githubusercontent.com/67974470/159590773-46069555-9e9e-46d9-bb04-0731ed46d6c6.png) ![image](https://user-images.githubusercontent.com/67974470/159591092-28b66209-8fda-43be-b471-b91dcf04c781.png) ![image](https://user-images.githubusercontent.com/67974470/159590890-844b59b9-6ece-4d1d-824b-44a8befe5be8.png) ![image](https://user-images.githubusercontent.com/67974470/159590958-73c29e99-553b-4978-aa82-d1f2c13e6b3b.png)

| Before | After |
--- | ---
| ![image](https://user-images.githubusercontent.com/67974470/159592770-60f6a414-e3f5-4b76-a142-8ebc434b38b1.png) | ![image](https://user-images.githubusercontent.com/67974470/159591419-13357c09-6e24-4974-853e-577e3c0c928a.png) |
