### PR TITLE
Add property name style toggle to Inspector

### DIFF
--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -1763,7 +1763,7 @@ ScriptEditorDebugger::ScriptEditorDebugger() {
 		inspector = memnew(EditorDebuggerInspector);
 		inspector->set_h_size_flags(SIZE_EXPAND_FILL);
 		inspector->set_v_size_flags(SIZE_EXPAND_FILL);
-		inspector->set_enable_capitalize_paths(false);
+		inspector->set_property_name_style(EditorPropertyNameProcessor::STYLE_RAW);
 		inspector->set_read_only(true);
 		inspector->connect("object_selected", callable_mp(this, &ScriptEditorDebugger::_remote_object_selected));
 		inspector->connect("object_edited", callable_mp(this, &ScriptEditorDebugger::_remote_object_edited));

--- a/editor/editor_feature_profile.cpp
+++ b/editor/editor_feature_profile.cpp
@@ -608,18 +608,24 @@ void EditorFeatureProfileManager::_class_list_item_selected() {
 		TreeItem *properties = property_list->create_item(root);
 		properties->set_text(0, TTR("Class Properties:"));
 
+		const EditorPropertyNameProcessor::Style text_style = EditorPropertyNameProcessor::get_settings_style();
+		const EditorPropertyNameProcessor::Style tooltip_style = EditorPropertyNameProcessor::get_tooltip_style(text_style);
+
 		for (const PropertyInfo &E : props) {
 			String name = E.name;
 			if (!(E.usage & PROPERTY_USAGE_EDITOR)) {
 				continue;
 			}
+			const String text = EditorPropertyNameProcessor::get_singleton()->process_name(name, text_style);
+			const String tooltip = EditorPropertyNameProcessor::get_singleton()->process_name(name, tooltip_style);
+
 			TreeItem *property = property_list->create_item(properties);
 			property->set_cell_mode(0, TreeItem::CELL_MODE_CHECK);
 			property->set_editable(0, true);
 			property->set_selectable(0, true);
 			property->set_checked(0, !edited->is_class_property_disabled(class_name, name));
-			property->set_text(0, EditorPropertyNameProcessor::get_singleton()->process_name(name));
-			property->set_tooltip(0, EditorPropertyNameProcessor::get_singleton()->make_tooltip_for_name(name));
+			property->set_text(0, text);
+			property->set_tooltip(0, tooltip);
 			property->set_metadata(0, name);
 			String icon_type = Variant::get_type_name(E.type);
 			property->set_icon(0, EditorNode::get_singleton()->get_class_icon(icon_type));

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -44,14 +44,14 @@
 #include "scene/property_utils.h"
 #include "scene/resources/packed_scene.h"
 
-static bool _property_path_matches(const String &p_property_path, const String &p_filter) {
+static bool _property_path_matches(const String &p_property_path, const String &p_filter, EditorPropertyNameProcessor::Style p_style) {
 	if (p_property_path.findn(p_filter) != -1) {
 		return true;
 	}
 
 	const Vector<String> sections = p_property_path.split("/");
 	for (int i = 0; i < sections.size(); i++) {
-		if (p_filter.is_subsequence_ofn(EditorPropertyNameProcessor::get_singleton()->process_name(sections[i]))) {
+		if (p_filter.is_subsequence_ofn(EditorPropertyNameProcessor::get_singleton()->process_name(sections[i], p_style))) {
 			return true;
 		}
 	}
@@ -2456,6 +2456,8 @@ void EditorInspector::update_tree() {
 		_parse_added_editors(main_vbox, ped);
 	}
 
+	bool in_script_variables = false;
+
 	// Get the lists of editors for properties.
 	for (List<PropertyInfo>::Element *E_property = plist.front(); E_property; E_property = E_property->next()) {
 		PropertyInfo &p = E_property->get();
@@ -2547,6 +2549,9 @@ void EditorInspector::update_tree() {
 				if (category->icon.is_null() && has_theme_icon(base_type, SNAME("EditorIcons"))) {
 					category->icon = get_theme_icon(base_type, SNAME("EditorIcons"));
 				}
+				in_script_variables = true;
+			} else {
+				in_script_variables = false;
 			}
 			if (category->icon.is_null()) {
 				if (!type.is_empty()) { // Can happen for built-in scripts.
@@ -2673,17 +2678,21 @@ void EditorInspector::update_tree() {
 
 		// Get the property label's string.
 		String name_override = (path.contains("/")) ? path.substr(path.rfind("/") + 1) : path;
-		String property_label_string = name_override;
-		if (capitalize_paths) {
-			// Capitalize paths.
-			int dot = property_label_string.find(".");
+		String feature_tag;
+		{
+			const int dot = name_override.find(".");
 			if (dot != -1) {
+				feature_tag = name_override.right(dot);
 				name_override = name_override.substr(0, dot);
-				property_label_string = EditorPropertyNameProcessor::get_singleton()->process_name(name_override) + property_label_string.substr(dot);
-			} else {
-				property_label_string = EditorPropertyNameProcessor::get_singleton()->process_name(property_label_string);
 			}
 		}
+
+		// Don't localize properties in Script Variables category.
+		EditorPropertyNameProcessor::Style name_style = property_name_style;
+		if (in_script_variables && name_style == EditorPropertyNameProcessor::STYLE_LOCALIZED) {
+			name_style = EditorPropertyNameProcessor::STYLE_CAPITALIZED;
+		}
+		const String property_label_string = EditorPropertyNameProcessor::get_singleton()->process_name(name_override, name_style) + feature_tag;
 
 		// Remove the property from the path.
 		int idx = path.rfind("/");
@@ -2696,7 +2705,7 @@ void EditorInspector::update_tree() {
 		// Ignore properties that do not fit the filter.
 		if (use_filter && !filter.is_empty()) {
 			const String property_path = property_prefix + (path.is_empty() ? "" : path + "/") + name_override;
-			if (!_property_path_matches(property_path, filter)) {
+			if (!_property_path_matches(property_path, filter, property_name_style)) {
 				continue;
 			}
 		}
@@ -2733,15 +2742,13 @@ void EditorInspector::update_tree() {
 				current_vbox->add_child(section);
 				sections.push_back(section);
 
-				String label = component;
-				if (capitalize_paths) {
-					label = EditorPropertyNameProcessor::get_singleton()->process_name(label);
-				}
+				const String label = EditorPropertyNameProcessor::get_singleton()->process_name(component, property_name_style);
+				const String tooltip = EditorPropertyNameProcessor::get_singleton()->process_name(component, EditorPropertyNameProcessor::get_tooltip_style(property_name_style));
 
 				Color c = sscolor;
 				c.a /= level;
 				section->setup(acc_path, label, object, c, use_folding, section_depth);
-				section->set_tooltip(EditorPropertyNameProcessor::get_singleton()->make_tooltip_for_name(component));
+				section->set_tooltip(tooltip);
 
 				// Add editors at the start of a group.
 				for (Ref<EditorInspectorPlugin> &ped : valid_plugins) {
@@ -2773,7 +2780,7 @@ void EditorInspector::update_tree() {
 				editor_inspector_array = memnew(EditorInspectorArray);
 
 				String array_label = path.contains("/") ? path.substr(path.rfind("/") + 1) : path;
-				array_label = EditorPropertyNameProcessor::get_singleton()->process_name(property_label_string);
+				array_label = EditorPropertyNameProcessor::get_singleton()->process_name(property_label_string, property_name_style);
 				int page = per_array_page.has(array_element_prefix) ? per_array_page[array_element_prefix] : 0;
 				editor_inspector_array->setup_with_move_element_function(object, array_label, array_element_prefix, page, c, use_folding);
 				editor_inspector_array->connect("page_change_request", callable_mp(this, &EditorInspector::_page_change_request), varray(array_element_prefix));
@@ -3037,12 +3044,15 @@ void EditorInspector::set_read_only(bool p_read_only) {
 	update_tree();
 }
 
-bool EditorInspector::is_capitalize_paths_enabled() const {
-	return capitalize_paths;
+EditorPropertyNameProcessor::Style EditorInspector::get_property_name_style() const {
+	return property_name_style;
 }
 
-void EditorInspector::set_enable_capitalize_paths(bool p_capitalize) {
-	capitalize_paths = p_capitalize;
+void EditorInspector::set_property_name_style(EditorPropertyNameProcessor::Style p_style) {
+	if (property_name_style == p_style) {
+		return;
+	}
+	property_name_style = p_style;
 	update_tree();
 }
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -31,6 +31,7 @@
 #ifndef EDITOR_INSPECTOR_H
 #define EDITOR_INSPECTOR_H
 
+#include "editor_property_name_processor.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
@@ -448,7 +449,7 @@ class EditorInspector : public ScrollContainer {
 	bool hide_script = true;
 	bool hide_metadata = true;
 	bool use_doc_hints = false;
-	bool capitalize_paths = true;
+	EditorPropertyNameProcessor::Style property_name_style = EditorPropertyNameProcessor::STYLE_CAPITALIZED;
 	bool use_filter = false;
 	bool autoclear = false;
 	bool use_folding = false;
@@ -545,8 +546,9 @@ public:
 	void set_keying(bool p_active);
 	void set_read_only(bool p_read_only);
 
-	bool is_capitalize_paths_enabled() const;
-	void set_enable_capitalize_paths(bool p_capitalize);
+	EditorPropertyNameProcessor::Style get_property_name_style() const;
+	void set_property_name_style(EditorPropertyNameProcessor::Style p_style);
+
 	void set_autoclear(bool p_enable);
 
 	void set_show_categories(bool p_show);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6055,9 +6055,10 @@ EditorNode::EditorNode() {
 	EDITOR_DEF("interface/editor/save_on_focus_loss", false);
 	EDITOR_DEF("interface/editor/show_update_spinner", false);
 	EDITOR_DEF("interface/editor/update_continuously", false);
-	EDITOR_DEF("interface/editor/translate_properties", true);
+	EDITOR_DEF("interface/editor/localize_settings", true);
 	EDITOR_DEF_RST("interface/scene_tabs/restore_scenes_on_load", true);
-	EDITOR_DEF_RST("interface/inspector/capitalize_properties", true);
+	EDITOR_DEF_RST("interface/inspector/default_property_name_style", EditorPropertyNameProcessor::STYLE_CAPITALIZED);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/inspector/default_property_name_style", PROPERTY_HINT_ENUM, "Raw,Capitalized,Localized"));
 	EDITOR_DEF_RST("interface/inspector/default_float_step", 0.001);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::FLOAT, "interface/inspector/default_float_step", PROPERTY_HINT_RANGE, "0,1,0"));
 	EDITOR_DEF_RST("interface/inspector/disable_folding", false);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3221,7 +3221,7 @@ void EditorPropertyResource::update_property() {
 				sub_inspector->set_use_doc_hints(true);
 
 				sub_inspector->set_sub_inspector(true);
-				sub_inspector->set_enable_capitalize_paths(bool(EDITOR_GET("interface/inspector/capitalize_properties")));
+				sub_inspector->set_property_name_style(InspectorDock::get_singleton()->get_property_name_style());
 
 				sub_inspector->connect("property_keyed", callable_mp(this, &EditorPropertyResource::_sub_inspector_property_keyed));
 				sub_inspector->connect("resource_selected", callable_mp(this, &EditorPropertyResource::_sub_inspector_resource_selected));

--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -34,6 +34,28 @@
 
 EditorPropertyNameProcessor *EditorPropertyNameProcessor::singleton = nullptr;
 
+EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_default_inspector_style() {
+	const Style style = (Style)EDITOR_GET("interface/inspector/default_property_name_style").operator int();
+	if (style == STYLE_LOCALIZED && !is_localization_available()) {
+		return STYLE_CAPITALIZED;
+	}
+	return style;
+}
+
+EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_settings_style() {
+	const bool translate = EDITOR_GET("interface/editor/localize_settings");
+	return translate ? STYLE_LOCALIZED : STYLE_CAPITALIZED;
+}
+
+EditorPropertyNameProcessor::Style EditorPropertyNameProcessor::get_tooltip_style(Style p_style) {
+	return p_style == STYLE_LOCALIZED ? STYLE_CAPITALIZED : STYLE_LOCALIZED;
+}
+
+bool EditorPropertyNameProcessor::is_localization_available() {
+	const Vector<String> forbidden = String("en").split(",");
+	return forbidden.find(EDITOR_GET("interface/editor/editor_language")) == -1;
+}
+
 String EditorPropertyNameProcessor::_capitalize_name(const String &p_name) const {
 	const Map<String, String>::Element *cached = capitalize_string_cache.find(p_name);
 	if (cached) {
@@ -55,20 +77,21 @@ String EditorPropertyNameProcessor::_capitalize_name(const String &p_name) const
 	return capitalized;
 }
 
-String EditorPropertyNameProcessor::process_name(const String &p_name) const {
-	const String capitalized_string = _capitalize_name(p_name);
-	if (EDITOR_GET("interface/editor/translate_properties")) {
-		return TTRGET(capitalized_string);
-	}
-	return capitalized_string;
-}
+String EditorPropertyNameProcessor::process_name(const String &p_name, Style p_style) const {
+	switch (p_style) {
+		case STYLE_RAW: {
+			return p_name;
+		} break;
 
-String EditorPropertyNameProcessor::make_tooltip_for_name(const String &p_name) const {
-	const String capitalized_string = _capitalize_name(p_name);
-	if (EDITOR_GET("interface/editor/translate_properties")) {
-		return capitalized_string;
+		case STYLE_CAPITALIZED: {
+			return _capitalize_name(p_name);
+		} break;
+
+		case STYLE_LOCALIZED: {
+			return TTRGET(_capitalize_name(p_name));
+		} break;
 	}
-	return TTRGET(capitalized_string);
+	ERR_FAIL_V_MSG(p_name, "Unexpected property name style.");
 }
 
 EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
@@ -84,6 +107,8 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["adb"] = "ADB";
 	capitalize_string_remaps["ao"] = "AO";
 	capitalize_string_remaps["apk"] = "APK";
+	capitalize_string_remaps["arm64-v8a"] = "arm64-v8a";
+	capitalize_string_remaps["armeabi-v7a"] = "armeabi-v7a";
 	capitalize_string_remaps["arvr"] = "ARVR";
 	capitalize_string_remaps["bg"] = "BG";
 	capitalize_string_remaps["bp"] = "BP";
@@ -130,6 +155,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["ipad"] = "iPad";
 	capitalize_string_remaps["iphone"] = "iPhone";
 	capitalize_string_remaps["ipv6"] = "IPv6";
+	capitalize_string_remaps["ir"] = "IR";
 	capitalize_string_remaps["jit"] = "JIT";
 	capitalize_string_remaps["k1"] = "K1";
 	capitalize_string_remaps["k2"] = "K2";
@@ -139,10 +165,12 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["lowpass"] = "Low-pass";
 	capitalize_string_remaps["macos"] = "macOS";
 	capitalize_string_remaps["mb"] = "(MB)"; // Unit.
+	capitalize_string_remaps["mms"] = "MMS";
 	capitalize_string_remaps["ms"] = "(ms)"; // Unit
 	// Not used for now as AudioEffectReverb has a `msec` property.
 	//capitalize_string_remaps["msec"] = "(msec)"; // Unit.
 	capitalize_string_remaps["msaa"] = "MSAA";
+	capitalize_string_remaps["nfc"] = "NFC";
 	capitalize_string_remaps["normalmap"] = "Normal Map";
 	capitalize_string_remaps["ok"] = "OK";
 	capitalize_string_remaps["opengl"] = "OpenGL";
@@ -162,6 +190,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["sdfgi"] = "SDFGI";
 	capitalize_string_remaps["sdk"] = "SDK";
 	capitalize_string_remaps["sec"] = "(sec)"; // Unit.
+	capitalize_string_remaps["sms"] = "SMS";
 	capitalize_string_remaps["srgb"] = "sRGB";
 	capitalize_string_remaps["ssao"] = "SSAO";
 	capitalize_string_remaps["ssh"] = "SSH";
@@ -182,12 +211,15 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["uv2"] = "UV2";
 	capitalize_string_remaps["uwp"] = "UWP";
 	capitalize_string_remaps["vector2"] = "Vector2";
+	capitalize_string_remaps["vpn"] = "VPN";
 	capitalize_string_remaps["vram"] = "VRAM";
 	capitalize_string_remaps["vsync"] = "V-Sync";
+	capitalize_string_remaps["wap"] = "WAP";
 	capitalize_string_remaps["webp"] = "WebP";
 	capitalize_string_remaps["webrtc"] = "WebRTC";
 	capitalize_string_remaps["websocket"] = "WebSocket";
 	capitalize_string_remaps["wifi"] = "Wi-Fi";
+	capitalize_string_remaps["x86"] = "x86";
 	capitalize_string_remaps["xr"] = "XR";
 	capitalize_string_remaps["xy"] = "XY";
 	capitalize_string_remaps["xz"] = "XZ";

--- a/editor/editor_property_name_processor.h
+++ b/editor/editor_property_name_processor.h
@@ -41,16 +41,27 @@ class EditorPropertyNameProcessor : public Node {
 	mutable Map<String, String> capitalize_string_cache;
 	Map<String, String> capitalize_string_remaps;
 
+	// Capitalizes property path segments.
 	String _capitalize_name(const String &p_name) const;
 
 public:
+	// Matches `interface/inspector/capitalize_properties` editor setting.
+	enum Style {
+		STYLE_RAW,
+		STYLE_CAPITALIZED,
+		STYLE_LOCALIZED,
+	};
+
 	static EditorPropertyNameProcessor *get_singleton() { return singleton; }
 
-	// Capitalize & localize property path segments.
-	String process_name(const String &p_name) const;
+	static Style get_default_inspector_style();
+	static Style get_settings_style();
+	static Style get_tooltip_style(Style p_style);
 
-	// Make tooltip string for names processed by process_name().
-	String make_tooltip_for_name(const String &p_name) const;
+	static bool is_localization_available();
+
+	// Turns property path segment into the given style.
+	String process_name(const String &p_name, Style p_style) const;
 
 	EditorPropertyNameProcessor();
 	~EditorPropertyNameProcessor();

--- a/editor/editor_sectioned_inspector.h
+++ b/editor/editor_sectioned_inspector.h
@@ -58,6 +58,9 @@ class SectionedInspector : public HSplitContainer {
 
 	void _search_changed(const String &p_what);
 
+protected:
+	void _notification(int p_what);
+
 public:
 	void register_search_box(LineEdit *p_box);
 	EditorInspector *get_inspector();

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -142,6 +142,8 @@ void EditorSettingsDialog::_notification(int p_what) {
 			if (update_shortcuts_tab) {
 				_update_shortcuts();
 			}
+
+			inspector->update_category_list();
 		} break;
 	}
 }
@@ -415,6 +417,9 @@ void EditorSettingsDialog::_update_shortcuts() {
 	List<String> slist;
 	EditorSettings::get_singleton()->get_shortcut_list(&slist);
 
+	const EditorPropertyNameProcessor::Style name_style = EditorPropertyNameProcessor::get_settings_style();
+	const EditorPropertyNameProcessor::Style tooltip_style = EditorPropertyNameProcessor::get_tooltip_style(name_style);
+
 	for (const String &E : slist) {
 		Ref<Shortcut> sc = EditorSettings::get_singleton()->get_shortcut(E);
 		if (!sc->has_meta("original")) {
@@ -431,9 +436,11 @@ void EditorSettingsDialog::_update_shortcuts() {
 		} else {
 			section = shortcuts->create_item(root);
 
-			String item_name = EditorPropertyNameProcessor::get_singleton()->process_name(section_name);
+			const String item_name = EditorPropertyNameProcessor::get_singleton()->process_name(section_name, name_style);
+			const String tooltip = EditorPropertyNameProcessor::get_singleton()->process_name(section_name, tooltip_style);
+
 			section->set_text(0, item_name);
-			section->set_tooltip(0, EditorPropertyNameProcessor::get_singleton()->make_tooltip_for_name(section_name));
+			section->set_tooltip(0, tooltip);
 			section->set_selectable(0, false);
 			section->set_selectable(1, false);
 			section->set_custom_bg_color(0, shortcuts->get_theme_color(SNAME("prop_subsection"), SNAME("Editor")));

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -844,6 +844,10 @@ void SceneImportSettings::_notification(int p_what) {
 		case NOTIFICATION_READY: {
 			connect("confirmed", callable_mp(this, &SceneImportSettings::_re_import));
 		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
+		} break;
 	}
 }
 
@@ -1231,6 +1235,7 @@ SceneImportSettings::SceneImportSettings() {
 
 	inspector = memnew(EditorInspector);
 	inspector->set_custom_minimum_size(Size2(300 * EDSCALE, 0));
+	inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 
 	property_split->add_child(inspector);
 

--- a/editor/import_dock.cpp
+++ b/editor/import_dock.cpp
@@ -564,6 +564,7 @@ void ImportDock::_notification(int p_what) {
 	switch (p_what) {
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			imported->add_theme_style_override("normal", get_theme_stylebox(SNAME("normal"), SNAME("LineEdit")));
+			import_opts->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 		} break;
 
 		case NOTIFICATION_ENTER_TREE: {
@@ -638,6 +639,7 @@ ImportDock::ImportDock() {
 	import_opts = memnew(EditorInspector);
 	content->add_child(import_opts);
 	import_opts->set_v_size_flags(SIZE_EXPAND_FILL);
+	import_opts->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 	import_opts->connect("property_edited", callable_mp(this, &ImportDock::_property_edited));
 	import_opts->connect("property_toggled", callable_mp(this, &ImportDock::_property_toggled));
 

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -37,6 +37,13 @@
 
 InspectorDock *InspectorDock::singleton = nullptr;
 
+void InspectorDock::_prepare_menu() {
+	PopupMenu *menu = object_menu->get_popup();
+	for (int i = EditorPropertyNameProcessor::STYLE_RAW; i <= EditorPropertyNameProcessor::STYLE_LOCALIZED; i++) {
+		menu->set_item_checked(menu->get_item_index(PROPERTY_NAME_STYLE_RAW + i), i == property_name_style);
+	}
+}
+
 void InspectorDock::_menu_option(int p_option) {
 	_menu_option_confirm(p_option, false);
 }
@@ -173,6 +180,13 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 				EditorNode::get_singleton()->get_editor_plugins_over()->edit(current);
 			}
 
+		} break;
+
+		case PROPERTY_NAME_STYLE_RAW:
+		case PROPERTY_NAME_STYLE_CAPITALIZED:
+		case PROPERTY_NAME_STYLE_LOCALIZED: {
+			property_name_style = (EditorPropertyNameProcessor::Style)(p_option - PROPERTY_NAME_STYLE_RAW);
+			inspector->set_property_name_style(property_name_style);
 		} break;
 
 		default: {
@@ -499,8 +513,19 @@ void InspectorDock::update(Object *p_object) {
 	p->clear();
 	p->add_icon_shortcut(get_theme_icon(SNAME("GuiTreeArrowDown"), SNAME("EditorIcons")), ED_SHORTCUT("property_editor/expand_all", TTR("Expand All")), EXPAND_ALL);
 	p->add_icon_shortcut(get_theme_icon(SNAME("GuiTreeArrowRight"), SNAME("EditorIcons")), ED_SHORTCUT("property_editor/collapse_all", TTR("Collapse All")), COLLAPSE_ALL);
-	p->add_separator();
 
+	p->add_separator(TTR("Property Name Style"));
+	p->add_radio_check_item(TTR("Raw"), PROPERTY_NAME_STYLE_RAW);
+	p->add_radio_check_item(TTR("Capitalized"), PROPERTY_NAME_STYLE_CAPITALIZED);
+	p->add_radio_check_item(TTR("Localized"), PROPERTY_NAME_STYLE_LOCALIZED);
+
+	if (!EditorPropertyNameProcessor::is_localization_available()) {
+		const int index = p->get_item_index(PROPERTY_NAME_STYLE_LOCALIZED);
+		p->set_item_disabled(index, true);
+		p->set_item_tooltip(index, TTR("Localization not available for current language."));
+	}
+
+	p->add_separator();
 	p->add_shortcut(ED_SHORTCUT("property_editor/copy_params", TTR("Copy Properties")), OBJECT_COPY_PARAMS);
 	p->add_shortcut(ED_SHORTCUT("property_editor/paste_params", TTR("Paste Properties")), OBJECT_PASTE_PARAMS);
 
@@ -534,11 +559,17 @@ void InspectorDock::go_back() {
 	_edit_back();
 }
 
+EditorPropertyNameProcessor::Style InspectorDock::get_property_name_style() const {
+	return property_name_style;
+}
+
 InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	singleton = this;
 	set_name("Inspector");
 
 	editor_data = &p_editor_data;
+
+	property_name_style = EditorPropertyNameProcessor::get_default_inspector_style();
 
 	HBoxContainer *general_options_hb = memnew(HBoxContainer);
 	add_child(general_options_hb);
@@ -632,6 +663,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	object_menu->set_shortcut_context(this);
 	property_tools_hb->add_child(object_menu);
 	object_menu->set_tooltip(TTR("Manage object properties."));
+	object_menu->get_popup()->connect("about_to_popup", callable_mp(this, &InspectorDock::_prepare_menu));
 	object_menu->get_popup()->connect("id_pressed", callable_mp(this, &InspectorDock::_menu_option));
 
 	warning = memnew(Button);
@@ -680,7 +712,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	inspector->set_use_doc_hints(true);
 	inspector->set_hide_script(false);
 	inspector->set_hide_metadata(false);
-	inspector->set_enable_capitalize_paths(bool(EDITOR_GET("interface/inspector/capitalize_properties")));
+	inspector->set_property_name_style(EditorPropertyNameProcessor::get_default_inspector_style());
 	inspector->set_use_folding(!bool(EDITOR_GET("interface/inspector/disable_folding")));
 	inspector->register_text_enter(search);
 	inspector->set_undo_redo(&editor_data->get_undo_redo());

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -62,6 +62,11 @@ class InspectorDock : public VBoxContainer {
 		COLLAPSE_ALL,
 		EXPAND_ALL,
 
+		// Matches `EditorPropertyNameProcessor::Style`.
+		PROPERTY_NAME_STYLE_RAW,
+		PROPERTY_NAME_STYLE_CAPITALIZED,
+		PROPERTY_NAME_STYLE_LOCALIZED,
+
 		OBJECT_METHOD_BASE = 500
 	};
 
@@ -94,6 +99,9 @@ class InspectorDock : public VBoxContainer {
 	ConfirmationDialog *unique_resources_confirmation;
 	Tree *unique_resources_list_tree;
 
+	EditorPropertyNameProcessor::Style property_name_style;
+
+	void _prepare_menu();
 	void _menu_option(int p_option);
 	void _menu_confirm_current();
 	void _menu_option_confirm(int p_option, bool p_confirmed);
@@ -138,6 +146,8 @@ public:
 	void update(Object *p_object);
 	Container *get_addon_area();
 	EditorInspector *get_inspector() { return inspector; }
+
+	EditorPropertyNameProcessor::Style get_property_name_style() const;
 
 	InspectorDock(EditorData &p_editor_data);
 	~InspectorDock();

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -68,6 +68,10 @@ void ProjectExportDialog::_notification(int p_what) {
 			connect("confirmed", callable_mp(this, &ProjectExportDialog::_export_pck_zip));
 			_update_export_all();
 		} break;
+
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			parameters->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
+		} break;
 	}
 }
 
@@ -1066,6 +1070,7 @@ ProjectExportDialog::ProjectExportDialog() {
 	sections->add_child(parameters);
 	parameters->set_name(TTR("Options"));
 	parameters->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	parameters->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
 	parameters->connect("property_edited", callable_mp(this, &ProjectExportDialog::_update_parameters));
 	EditorExport::get_singleton()->connect("export_presets_updated", callable_mp(this, &ProjectExportDialog::_force_update_current_preset_parameters));
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2547,10 +2547,10 @@ void SceneTreeDock::_files_dropped(Vector<String> p_files, NodePath p_to, int p_
 			property_drop_node = node;
 			resource_drop_path = res_path;
 
-			bool capitalize = bool(EDITOR_GET("interface/inspector/capitalize_properties"));
+			const EditorPropertyNameProcessor::Style style = InspectorDock::get_singleton()->get_property_name_style();
 			menu_properties->clear();
 			for (const String &p : valid_properties) {
-				menu_properties->add_item(capitalize ? p.capitalize() : p);
+				menu_properties->add_item(EditorPropertyNameProcessor::get_singleton()->process_name(p, style));
 				menu_properties->set_item_metadata(-1, p);
 			}
 

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -477,7 +477,7 @@ ShaderGlobalsEditor::ShaderGlobalsEditor() {
 	inspector->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(inspector);
 	inspector->set_use_wide_editors(true);
-	inspector->set_enable_capitalize_paths(false);
+	inspector->set_property_name_style(EditorPropertyNameProcessor::STYLE_RAW);
 	inspector->set_use_deletable_properties(true);
 	inspector->connect("property_deleted", callable_mp(this, &ShaderGlobalsEditor::_variable_deleted), varray(), CONNECT_DEFERRED);
 


### PR DESCRIPTION
`master` version of #59313

* Raw / Capitalized / Localization radio options in the Inspector object properties menu.
    * Localization disabled for selected languages (currently "en").
    * Defaults to Capitalized.
* Localize Settings editor setting to toggle localization for Editor Settings, Project Settings, Import Options, Export Options, etc.
    * Defaults to On.