### PR TITLE
Add `Tree.column_title_rmb_pressed` signal

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3249,7 +3249,7 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		bool rtl = is_layout_rtl();
 
 		if (!b->is_pressed()) {
-			if (b->get_button_index() == MouseButton::LEFT) {
+			if (b->get_button_index() == MouseButton::LEFT || b->get_button_index() == MouseButton::RIGHT){
 				Point2 pos = b->get_position();
 				if (rtl) {
 					pos.x = get_size().width - pos.x;
@@ -3264,7 +3264,12 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 						for (int i = 0; i < columns.size(); i++) {
 							len += get_column_width(i);
 							if (pos.x < len) {
-								emit_signal(SNAME("column_title_pressed"), i);
+								if (b->get_button_index() == MouseButton::LEFT){
+									emit_signal(SNAME("column_title_pressed"), i);
+								} else {
+									emit_signal(SNAME("column_title_rmb_pressed"), i);
+								}
+								
 								break;
 							}
 						}
@@ -4944,6 +4949,7 @@ void Tree::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("custom_popup_edited", PropertyInfo(Variant::BOOL, "arrow_clicked")));
 	ADD_SIGNAL(MethodInfo("item_activated"));
 	ADD_SIGNAL(MethodInfo("column_title_pressed", PropertyInfo(Variant::INT, "column")));
+	ADD_SIGNAL(MethodInfo("column_title_rmb_pressed", PropertyInfo(Variant::INT, "column")));
 	ADD_SIGNAL(MethodInfo("nothing_selected"));
 
 	BIND_ENUM_CONSTANT(SELECT_SINGLE);


### PR DESCRIPTION
Adds a signal to the right click on the title Tree.