### PR TITLE
Add an optional warning to type inferred variables and parameters

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -334,6 +334,12 @@
 		<member name="debug/file_logging/max_log_files" type="int" setter="" getter="" default="5">
 			Specifies the maximum amount of log files allowed (used for rotation).
 		</member>
+		<member name="debug/gdscript/type_inferencing/enforce_static_parameter_types" type="int" setter="" getter="" default="0">
+			If [code]enabled[/code] prints a warning or an error when a function parameter is not statically typed.
+		</member>
+		<member name="debug/gdscript/type_inferencing/enforce_static_variable_types" type="int" setter="" getter="" default="0">
+			If [code]enabled[/code] prints a warning or an error when a variable or constant is not statically typed.
+		</member>
 		<member name="debug/gdscript/warnings/assert_always_false" type="int" setter="" getter="" default="1">
 			If [code]enabled[/code], prints a warning or an error when an [code]assert[/code] call always returns false.
 		</member>
@@ -341,13 +347,13 @@
 			If [code]enabled[/code], prints a warning or an error when an [code]assert[/code] call always returns true.
 		</member>
 		<member name="debug/gdscript/warnings/constant_used_as_function" type="int" setter="" getter="" default="1">
-			If [code]enabled[/code], prints a warning or an error when a constant is used as a function.
+			If not set to [code]Ignore[/code], enables warnings when a constant is used as a function.
 		</member>
 		<member name="debug/gdscript/warnings/deprecated_keyword" type="int" setter="" getter="" default="1">
-			If [code]enabled[/code], prints a warning or an error when deprecated keywords are used.
+			If [code]true[/code], enables warnings when deprecated keywords are used.
 		</member>
 		<member name="debug/gdscript/warnings/empty_file" type="int" setter="" getter="" default="1">
-			If [code]enabled[/code], prints a warning or an error when an empty file is parsed.
+			If [code]true[/code], enables warnings when an empty file is parsed.
 		</member>
 		<member name="debug/gdscript/warnings/enable" type="bool" setter="" getter="" default="true">
 			If [code]true[/code], enables specific GDScript warnings (see [code]debug/gdscript/warnings/*[/code] settings). If [code]false[/code], disables all GDScript warnings.

--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -693,6 +693,13 @@ void GDScriptAnalyzer::resolve_class_interface(GDScriptParser::ClassNode *p_clas
 						datatype.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
 					}
 				}
+#ifdef DEBUG_ENABLED
+				if (GLOBAL_GET("debug/gdscript/type_inferencing/enforce_static_variable_types") && datatype.type_source != GDScriptParser::DataType::ANNOTATED_INFERRED) {
+					if (!member.variable->datatype_specifier && !(datatype.kind == GDScriptParser::DataType::BUILTIN && datatype.builtin_type == Variant::NIL)) {
+						enforce_static_type((GDScriptParser::Node *)member.variable, member.variable->identifier->name);
+					}
+				}
+#endif
 
 				datatype.is_constant = false;
 				member.variable->set_datatype(datatype);
@@ -745,6 +752,7 @@ void GDScriptAnalyzer::resolve_class_interface(GDScriptParser::ClassNode *p_clas
 						}
 					}
 				}
+
 				datatype.is_constant = true;
 
 				member.constant->set_datatype(datatype);
@@ -1571,6 +1579,13 @@ void GDScriptAnalyzer::resolve_constant(GDScriptParser::ConstantNode *p_constant
 		type.type_source = GDScriptParser::DataType::ANNOTATED_INFERRED;
 	}
 
+#ifdef DEBUG_ENABLED
+	if (GLOBAL_GET("debug/gdscript/type_inferencing/enforce_static_variable_types") && p_constant->datatype.type_source != GDScriptParser::DataType::ANNOTATED_INFERRED) {
+		if (!p_constant->datatype_specifier && !(p_constant->datatype.kind == GDScriptParser::DataType::BUILTIN && p_constant->datatype.builtin_type == Variant::NIL)) {
+			enforce_static_type((GDScriptParser::Node *)p_constant, p_constant->identifier->name);
+		}
+	}
+#endif
 	type.is_constant = true;
 	p_constant->set_datatype(type);
 
@@ -1725,6 +1740,14 @@ void GDScriptAnalyzer::resolve_parameter(GDScriptParser::ParameterNode *p_parame
 	if (result.builtin_type == Variant::Type::NIL && result.type_source == GDScriptParser::DataType::ANNOTATED_INFERRED && p_parameter->datatype_specifier == nullptr) {
 		push_error(vformat(R"(Could not infer the type of the variable "%s" because the initial value is "null".)", p_parameter->identifier->name), p_parameter->default_value);
 	}
+
+#ifdef DEBUG_ENABLED
+	if (GLOBAL_GET("debug/gdscript/type_inferencing/enforce_static_parameter_types") && result.type_source != GDScriptParser::DataType::ANNOTATED_INFERRED) {
+		if (!p_parameter->datatype_specifier && !(result.kind == GDScriptParser::DataType::BUILTIN && result.builtin_type == Variant::NIL)) {
+			enforce_static_type((GDScriptParser::Node *)p_parameter, p_parameter->identifier->name);
+		}
+	}
+#endif
 
 	p_parameter->set_datatype(result);
 }
@@ -4185,6 +4208,28 @@ void GDScriptAnalyzer::push_error(const String &p_message, const GDScriptParser:
 	mark_node_unsafe(p_origin);
 	parser->push_error(p_message, p_origin);
 }
+
+#ifdef DEBUG_ENABLED
+void GDScriptAnalyzer::enforce_static_type(GDScriptParser::Node *p_node, String p_identifier) {
+	String identifier_type = "";
+	GDScriptWarning::Code warning_code = GDScriptWarning::Code::ENFORCE_STATIC_VARIABLE_TYPES;
+	switch (p_node->type) {
+		case GDScriptParser::Node::Type::CONSTANT:
+			identifier_type = "Constant";
+			break;
+		case GDScriptParser::Node::Type::VARIABLE:
+			identifier_type = "Variable";
+			break;
+		case GDScriptParser::Node::Type::PARAMETER:
+			identifier_type = "Parameter";
+			warning_code = GDScriptWarning::Code::ENFORCE_STATIC_PARAMETER_TYPES;
+			break;
+		default: // Only enforce static types on Variables and parameters
+			return;
+	}
+	parser->push_warning(p_node, warning_code, identifier_type, p_identifier);
+}
+#endif
 
 void GDScriptAnalyzer::mark_node_unsafe(const GDScriptParser::Node *p_node) {
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/gdscript_analyzer.h
+++ b/modules/gdscript/gdscript_analyzer.h
@@ -119,6 +119,7 @@ class GDScriptAnalyzer {
 	bool class_exists(const StringName &p_class) const;
 	Ref<GDScriptParserRef> get_parser_for(const String &p_path);
 #ifdef DEBUG_ENABLED
+	void enforce_static_type(GDScriptParser::Node *p_node, String p_identifier);
 	bool is_shadowing(GDScriptParser::IdentifierNode *p_local, const String &p_context);
 #endif
 

--- a/modules/gdscript/gdscript_warning.cpp
+++ b/modules/gdscript/gdscript_warning.cpp
@@ -155,6 +155,14 @@ String GDScriptWarning::get_message() const {
 		case INT_ASSIGNED_TO_ENUM: {
 			return "Integer used when an enum value is expected. If this is intended cast the integer to the enum type.";
 		}
+		case ENFORCE_STATIC_VARIABLE_TYPES: {
+			CHECK_SYMBOLS(2);
+			return vformat(R"(%s '%s' does not have a static type defined.)", symbols[0], symbols[1]);
+		}
+		case ENFORCE_STATIC_PARAMETER_TYPES: {
+			CHECK_SYMBOLS(2);
+			return vformat(R"(%s '%s' does not have a static type defined.)", symbols[0], symbols[1]);
+		}
 		case WARNING_MAX:
 			break; // Can't happen, but silences warning
 	}
@@ -164,15 +172,28 @@ String GDScriptWarning::get_message() const {
 }
 
 int GDScriptWarning::get_default_value(Code p_code) {
-	if (get_name_from_code(p_code).to_lower().begins_with("unsafe_")) {
-		return WarnLevel::IGNORE;
+	switch (p_code) {
+		case ENFORCE_STATIC_VARIABLE_TYPES:
+		case ENFORCE_STATIC_PARAMETER_TYPES:
+			return WarnLevel::IGNORE;
+
+		default:
+			if (get_name_from_code(p_code).to_lower().begins_with("unsafe_")) {
+				return WarnLevel::IGNORE;
+			}
+			return WarnLevel::WARN;
 	}
-	return WarnLevel::WARN;
 }
 
 PropertyInfo GDScriptWarning::get_property_info(Code p_code) {
-	// Making this a separate function in case a warning needs different PropertyInfo in the future.
-	return PropertyInfo(Variant::INT, get_settings_path_from_code(p_code), PROPERTY_HINT_ENUM, "Ignore,Warn,Error");
+	switch (p_code) {
+		case ENFORCE_STATIC_VARIABLE_TYPES:
+		case ENFORCE_STATIC_PARAMETER_TYPES:
+			return PropertyInfo(Variant::INT, get_settings_path_from_code(p_code), PROPERTY_HINT_ENUM, "Disabled,Warn,Error");
+
+		default:
+			return PropertyInfo(Variant::INT, get_settings_path_from_code(p_code), PROPERTY_HINT_ENUM, "Ignore,Warn,Error");
+	}
 }
 
 String GDScriptWarning::get_name() const {
@@ -215,6 +236,8 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 		"EMPTY_FILE",
 		"SHADOWED_GLOBAL_IDENTIFIER",
 		"INT_ASSIGNED_TO_ENUM",
+		"ENFORCE_STATIC_VARIABLE_TYPES",
+		"ENFORCE_STATIC_PARAMETER_TYPES"
 	};
 
 	static_assert((sizeof(names) / sizeof(*names)) == WARNING_MAX, "Amount of warning types don't match the amount of warning names.");
@@ -223,7 +246,14 @@ String GDScriptWarning::get_name_from_code(Code p_code) {
 }
 
 String GDScriptWarning::get_settings_path_from_code(Code p_code) {
-	return "debug/gdscript/warnings/" + get_name_from_code(p_code).to_lower();
+	switch (p_code) {
+		case ENFORCE_STATIC_VARIABLE_TYPES:
+		case ENFORCE_STATIC_PARAMETER_TYPES:
+			return "debug/gdscript/type_inferencing/" + get_name_from_code(p_code).to_lower();
+
+		default:
+			return "debug/gdscript/warnings/" + get_name_from_code(p_code).to_lower();
+	}
 }
 
 GDScriptWarning::Code GDScriptWarning::get_code_from_name(const String &p_name) {

--- a/modules/gdscript/gdscript_warning.h
+++ b/modules/gdscript/gdscript_warning.h
@@ -78,6 +78,8 @@ public:
 		EMPTY_FILE, // A script file is empty.
 		SHADOWED_GLOBAL_IDENTIFIER, // A global class or function has the same name as variable.
 		INT_ASSIGNED_TO_ENUM, // An integer value was assigned to an enum-typed variable without casting.
+		ENFORCE_STATIC_VARIABLE_TYPES, // Disabled by default, some users would like to enforce static variable typing.
+		ENFORCE_STATIC_PARAMETER_TYPES,
 		WARNING_MAX,
 	};
 

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -136,6 +136,9 @@ GDScriptTestRunner::GDScriptTestRunner(const String &p_source_dir, bool p_init_l
 	// Enable all warnings for GDScript, so we can test them.
 	ProjectSettings::get_singleton()->set_setting("debug/gdscript/warnings/enable", true);
 	for (int i = 0; i < (int)GDScriptWarning::WARNING_MAX; i++) {
+		if (i == GDScriptWarning::ENFORCE_STATIC_VARIABLE_TYPES || i == GDScriptWarning::ENFORCE_STATIC_PARAMETER_TYPES) {
+			continue;
+		}
 		String warning = GDScriptWarning::get_name_from_code((GDScriptWarning::Code)i).to_lower();
 		ProjectSettings::get_singleton()->set_setting("debug/gdscript/warnings/" + warning, true);
 	}


### PR DESCRIPTION
Relies on #59943 

Closes godotengine/godot-proposals#173 and godotengine/godot-proposals#3531


![](https://user-images.githubusercontent.com/12436824/159627843-75b92c99-3a29-4c1f-bad2-12425c5a6c0d.png)

Warnings are now enum values (Ignore, Warn, Error) to allow setting whether you want a warning to be treated as either an error, a warning, or ignored.

The way warnings are initialized in gdscript.cpp has been improved to offer more flexibility. (Support for property info per warning and different default values.)

# Type Inferencing
Added new warnings that will let the user know if a variable or parameter they defined is not statically typed (Set to 'Ignore' by default)

<img src="https://user-images.githubusercontent.com/12436824/159628062-e6eef11d-a7ea-44b4-ba77-c8441f62ba56.png" width="75%"/>
<img src="https://user-images.githubusercontent.com/12436824/159628155-accea18f-390d-4d39-b494-c5ca63fec68b.png" width="75%"/>
<img src="https://user-images.githubusercontent.com/12436824/159628670-d53395fe-67f6-4fc3-a8d1-542804e27eb0.png" width="75%"/>


Variables that are assigned to null when declared are ignored so that if you absolutely need to, you can still have a dynamically typed variable.
<img src="https://user-images.githubusercontent.com/12436824/159628337-b811fce0-78c7-4566-856c-036afe9c290a.png"/>
