### PR TITLE
Fix the texture draw size may exceed the control size.

### DIFF
--- a/scene/gui/texture_button.cpp
+++ b/scene/gui/texture_button.cpp
@@ -184,7 +184,8 @@ void TextureButton::_notification(int p_what) {
 				_tile = false;
 				switch (stretch_mode) {
 					case STRETCH_KEEP:
-						size = texdraw->get_size();
+						size = size.min(get_size());
+						_texture_region = Rect2(Point2(), size);
 						break;
 					case STRETCH_SCALE:
 						size = get_size();

--- a/scene/gui/texture_rect.cpp
+++ b/scene/gui/texture_rect.cpp
@@ -55,6 +55,8 @@ void TextureRect::_notification(int p_what) {
 				} break;
 				case STRETCH_KEEP: {
 					size = texture->get_size();
+					size = size.min(get_size());
+					region = Rect2(Point2(), size);
 				} break;
 				case STRETCH_KEEP_CENTERED: {
 					offset = (get_size() - texture->get_size()) / 2;


### PR DESCRIPTION
In `TextureRect` and `TextureButton`.
That will happen when `ignore_texture_size` = `true`, `stretch_mode` = keep, and texture size is larger than the control size.

| Before | After |
| :----: | :----: |
| ![1](https://user-images.githubusercontent.com/30386067/159633118-17297542-0bef-4c21-9faf-0fabf4708a97.jpg) | ![2](https://user-images.githubusercontent.com/30386067/159633127-4fc44a76-3074-410c-9159-f0782b6af163.jpg) |
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
