### PR TITLE
Fix crash when exporting projects with shared libraries

### DIFF
--- a/core/io/dir_access.h
+++ b/core/io/dir_access.h
@@ -137,6 +137,10 @@ struct DirAccessRef {
 	DirAccess *f = nullptr;
 
 	DirAccessRef(DirAccess *fa) { f = fa; }
+	DirAccessRef(DirAccessRef &&other) {
+		f = other.f;
+		other.f = nullptr;
+	}
 	~DirAccessRef() {
 		if (f) {
 			memdelete(f);

--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -188,6 +188,10 @@ struct FileAccessRef {
 	operator FileAccess *() { return f; }
 
 	FileAccessRef(FileAccess *fa) { f = fa; }
+	FileAccessRef(FileAccessRef &&other) {
+		f = other.f;
+		other.f = nullptr;
+	}
 	~FileAccessRef() {
 		if (f) {
 			memdelete(f);

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -1878,7 +1878,6 @@ Error EditorExportPlatformPC::export_project(const Ref<EditorExportPreset> &p_pr
 
 		if (err == OK && !so_files.is_empty()) {
 			// If shared object files, copy them.
-			da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 			for (int i = 0; i < so_files.size() && err == OK; i++) {
 				String src_path = ProjectSettings::get_singleton()->globalize_path(so_files[i].path);
 				String target_path;


### PR DESCRIPTION
Fixes #59307.

The direct cause is the `DirAccessRef` object in `EditorExportPlatformPC::export_project()` assigned again unnecessarily. The temporary `DirAccessRef` object shares the same pointer as `da`, and frees the pointer upon destruction.

I added a move constructor to `FileAccessRef` and `DirAccessRef`. So such copy assignment is forbidden, but still allows a `*AccessRef` object to be constructed from a function that returns such object (existing usage).