### PR TITLE
Fix wrong collision reported on move_and_collide

### DIFF
--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -58,7 +58,11 @@ Ref<KinematicCollision2D> PhysicsBody2D::_move(const Vector2 &p_distance, bool p
 	PhysicsServer2D::MotionParameters parameters(get_global_transform(), p_distance, p_margin);
 
 	PhysicsServer2D::MotionResult result;
-	if (move_and_collide(parameters, result, p_test_only)) {
+
+	bool collided = move_and_collide(parameters, result, p_test_only);
+
+	// Don't report collision when the whole motion is done.
+	if (collided && result.collision_safe_fraction < 1) {
 		// Create a new instance when the cached reference is invalid or still in use in script.
 		if (motion_cache.is_null() || motion_cache->reference_get_count() > 1) {
 			motion_cache.instantiate();

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -96,7 +96,11 @@ Ref<KinematicCollision3D> PhysicsBody3D::_move(const Vector3 &p_distance, bool p
 	parameters.max_collisions = p_max_collisions;
 
 	PhysicsServer3D::MotionResult result;
-	if (move_and_collide(parameters, result, p_test_only)) {
+
+	bool collided = move_and_collide(parameters, result, p_test_only);
+
+	// Don't report collision when the whole motion is done.
+	if (collided && result.collision_safe_fraction < 1) {
 		// Create a new instance when the cached reference is invalid or still in use in script.
 		if (motion_cache.is_null() || motion_cache->reference_get_count() > 1) {
 			motion_cache.instantiate();


### PR DESCRIPTION
fix #59422
fix #59139

When a recover occurs, collisions are reported `to move_and_collide`, this is a useful change introduced to stabilise the movement in `move_and_slide`, but it's not something desired for `move_and_collide`.

As discussed with @reduz, there are 2 ways to solve this problem, the first is to remove the condition that report a collision when recovery occurs but this required to modify `test_body_motion` which is very sensitive and will remove the improvement mentioned above.

This PR is the safest approach, it checks if `collision_safe_fraction < 1` (which means there were no collisions in motion) and only modifies `move_and_collide`.

Before:

![mv-before](https://user-images.githubusercontent.com/6397893/159670990-d261ff8e-c1fb-4580-96ae-0f453f071832.gif)

After:

![mc-after](https://user-images.githubusercontent.com/6397893/159670973-f30afb4b-052b-469f-a0c8-585a2689ad48.gif)

I tried the examples provided by @KoBeWi , the ones provided in the documentation, and custom ones.
