### PR TITLE
Increase the maximum number of concurrent DNS queries from 32 to 256

### DIFF
--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -186,7 +186,7 @@ IP::ResolverID IP::resolve_hostname_queue_item(const String &p_hostname, IP::Typ
 }
 
 IP::ResolverStatus IP::get_resolve_item_status(ResolverID p_id) const {
-	ERR_FAIL_INDEX_V(p_id, IP::RESOLVER_MAX_QUERIES, IP::RESOLVER_STATUS_NONE);
+	ERR_FAIL_INDEX_V_MSG(p_id, IP::RESOLVER_MAX_QUERIES, IP::RESOLVER_STATUS_NONE, vformat("Too many concurrent DNS resolver queries (%d, but should be %d at most). Try performing less network requests at once.", p_id, IP::RESOLVER_MAX_QUERIES));
 
 	IP::ResolverStatus res = resolver->queue[p_id].status.get();
 	if (res == IP::RESOLVER_STATUS_NONE) {
@@ -197,7 +197,7 @@ IP::ResolverStatus IP::get_resolve_item_status(ResolverID p_id) const {
 }
 
 IPAddress IP::get_resolve_item_address(ResolverID p_id) const {
-	ERR_FAIL_INDEX_V(p_id, IP::RESOLVER_MAX_QUERIES, IPAddress());
+	ERR_FAIL_INDEX_V_MSG(p_id, IP::RESOLVER_MAX_QUERIES, IPAddress(), vformat("Too many concurrent DNS resolver queries (%d, but should be %d at most). Try performing less network requests at once.", p_id, IP::RESOLVER_MAX_QUERIES));
 
 	MutexLock lock(resolver->mutex);
 
@@ -217,7 +217,7 @@ IPAddress IP::get_resolve_item_address(ResolverID p_id) const {
 }
 
 Array IP::get_resolve_item_addresses(ResolverID p_id) const {
-	ERR_FAIL_INDEX_V(p_id, IP::RESOLVER_MAX_QUERIES, Array());
+	ERR_FAIL_INDEX_V_MSG(p_id, IP::RESOLVER_MAX_QUERIES, Array(), vformat("Too many concurrent DNS resolver queries (%d, but should be %d at most). Try performing less network requests at once.", p_id, IP::RESOLVER_MAX_QUERIES));
 	MutexLock lock(resolver->mutex);
 
 	if (resolver->queue[p_id].status.get() != IP::RESOLVER_STATUS_DONE) {
@@ -237,7 +237,7 @@ Array IP::get_resolve_item_addresses(ResolverID p_id) const {
 }
 
 void IP::erase_resolve_item(ResolverID p_id) {
-	ERR_FAIL_INDEX(p_id, IP::RESOLVER_MAX_QUERIES);
+	ERR_FAIL_INDEX_MSG(p_id, IP::RESOLVER_MAX_QUERIES, vformat("Too many concurrent DNS resolver queries (%d, but should be %d at most). Try performing less network requests at once.", p_id, IP::RESOLVER_MAX_QUERIES));
 
 	resolver->queue[p_id].status.set(IP::RESOLVER_STATUS_NONE);
 }

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -56,7 +56,7 @@ public:
 	};
 
 	enum {
-		RESOLVER_MAX_QUERIES = 32,
+		RESOLVER_MAX_QUERIES = 256,
 		RESOLVER_INVALID_ID = -1
 	};
 

--- a/doc/classes/IP.xml
+++ b/doc/classes/IP.xml
@@ -103,7 +103,7 @@
 		<constant name="RESOLVER_STATUS_ERROR" value="3" enum="ResolverStatus">
 			DNS hostname resolver status: Error.
 		</constant>
-		<constant name="RESOLVER_MAX_QUERIES" value="32">
+		<constant name="RESOLVER_MAX_QUERIES" value="256">
 			Maximum number of concurrent DNS resolver queries allowed, [constant RESOLVER_INVALID_ID] is returned if exceeded.
 		</constant>
 		<constant name="RESOLVER_INVALID_ID" value="-1">


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/59520.

This makes the following error message less likely to be printed when performing many concurrent HTTP requests:

    Condition ' resolving == IP::RESOLVER_INVALID_ID ' is true. returned: ERR_BUG

This closes https://github.com/godotengine/godot/issues/25052. Please [test](https://docs.godotengine.org/en/latest/community/contributing/testing_pull_requests.html) in your own projects :slightly_smiling_face: