### PR TITLE
Refactor Object metadata

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -416,12 +416,22 @@ void Object::set(const StringName &p_name, const Variant &p_value, bool *r_valid
 		}
 		return;
 
-	} else if (p_name == CoreStringNames::get_singleton()->_meta) {
-		metadata = p_value.duplicate();
-		if (r_valid) {
-			*r_valid = true;
+	} else {
+		OrderedHashMap<StringName, Variant>::Element *E = metadata_properties.getptr(p_name);
+		if (E) {
+			E->get() = p_value;
+			if (r_valid) {
+				*r_valid = true;
+			}
+			return;
+		} else if (p_name.operator String().begins_with("metadata/")) {
+			// Must exist, otherwise duplicate() will not work.
+			set_meta(p_name.operator String().replace_first("metadata/", ""), p_value);
+			if (r_valid) {
+				*r_valid = true;
+			}
+			return;
 		}
-		return;
 	}
 
 	// Something inside the object... :|
@@ -496,9 +506,12 @@ Variant Object::get(const StringName &p_name, bool *r_valid) const {
 			*r_valid = true;
 		}
 		return ret;
+	}
 
-	} else if (p_name == CoreStringNames::get_singleton()->_meta) {
-		ret = metadata;
+	const OrderedHashMap<StringName, Variant>::Element *E = metadata_properties.getptr(p_name);
+
+	if (E) {
+		ret = E->get();
 		if (r_valid) {
 			*r_valid = true;
 		}
@@ -648,12 +661,19 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 	if (!is_class("Script")) { // can still be set, but this is for user-friendliness
 		p_list->push_back(PropertyInfo(Variant::OBJECT, "script", PROPERTY_HINT_RESOURCE_TYPE, "Script", PROPERTY_USAGE_DEFAULT));
 	}
-	if (!metadata.is_empty()) {
-		p_list->push_back(PropertyInfo(Variant::DICTIONARY, "__meta__", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL));
-	}
+
 	if (script_instance && !p_reversed) {
 		p_list->push_back(PropertyInfo(Variant::NIL, "Script Variables", PROPERTY_HINT_NONE, String(), PROPERTY_USAGE_CATEGORY));
 		script_instance->get_property_list(p_list);
+	}
+
+	for (OrderedHashMap<StringName, Variant>::ConstElement K = metadata.front(); K; K = K.next()) {
+		PropertyInfo pi = PropertyInfo(K.value().get_type(), "metadata/" + K.key().operator String());
+		if (K.value().get_type() == Variant::OBJECT) {
+			pi.hint = PROPERTY_HINT_RESOURCE_TYPE;
+			pi.hint_string = "Resource";
+		}
+		p_list->push_back(pi);
 	}
 }
 
@@ -915,11 +935,23 @@ bool Object::has_meta(const StringName &p_name) const {
 
 void Object::set_meta(const StringName &p_name, const Variant &p_value) {
 	if (p_value.get_type() == Variant::NIL) {
-		metadata.erase(p_name);
+		if (metadata.has(p_name)) {
+			metadata.erase(p_name);
+			metadata_properties.erase("metadata/" + p_name.operator String());
+			notify_property_list_changed();
+		}
 		return;
 	}
 
-	metadata[p_name] = p_value;
+	OrderedHashMap<StringName, Variant>::Element E = metadata.find(p_name);
+	if (E) {
+		E.value() = p_value;
+	} else {
+		ERR_FAIL_COND(!p_name.operator String().is_valid_identifier());
+		E = metadata.insert(p_name, p_value);
+		metadata_properties["metadata/" + p_name.operator String()] = E;
+		notify_property_list_changed();
+	}
 }
 
 Variant Object::get_meta(const StringName &p_name) const {
@@ -928,7 +960,7 @@ Variant Object::get_meta(const StringName &p_name) const {
 }
 
 void Object::remove_meta(const StringName &p_name) {
-	metadata.erase(p_name);
+	set_meta(p_name, Variant());
 }
 
 Array Object::_get_property_list_bind() const {
@@ -954,20 +986,16 @@ Array Object::_get_method_list_bind() const {
 Vector<StringName> Object::_get_meta_list_bind() const {
 	Vector<StringName> _metaret;
 
-	List<Variant> keys;
-	metadata.get_key_list(&keys);
-	for (const Variant &E : keys) {
-		_metaret.push_back(E);
+	for (OrderedHashMap<StringName, Variant>::ConstElement K = metadata.front(); K; K = K.next()) {
+		_metaret.push_back(K.key());
 	}
 
 	return _metaret;
 }
 
 void Object::get_meta_list(List<StringName> *p_list) const {
-	List<Variant> keys;
-	metadata.get_key_list(&keys);
-	for (const Variant &E : keys) {
-		p_list->push_back(E);
+	for (OrderedHashMap<StringName, Variant>::ConstElement K = metadata.front(); K; K = K.next()) {
+		p_list->push_back(K.key());
 	}
 }
 

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -39,6 +39,7 @@
 #include "core/templates/hash_map.h"
 #include "core/templates/list.h"
 #include "core/templates/map.h"
+#include "core/templates/ordered_hash_map.h"
 #include "core/templates/safe_refcount.h"
 #include "core/templates/set.h"
 #include "core/templates/vmap.h"
@@ -530,7 +531,8 @@ private:
 #endif
 	ScriptInstance *script_instance = nullptr;
 	Variant script; // Reference does not exist yet, store it in a Variant.
-	Dictionary metadata;
+	OrderedHashMap<StringName, Variant> metadata;
+	HashMap<StringName, OrderedHashMap<StringName, Variant>::Element> metadata_properties;
 	mutable StringName _class_name;
 	mutable const StringName *_class_ptr = nullptr;
 

--- a/core/variant/variant_construct.h
+++ b/core/variant/variant_construct.h
@@ -543,14 +543,12 @@ public:
 class VariantConstructNoArgsObject {
 public:
 	static void construct(Variant &r_ret, const Variant **p_args, Callable::CallError &r_error) {
-		VariantInternal::clear(&r_ret);
-		VariantInternal::object_assign_null(&r_ret);
+		r_ret = (Object *)nullptr; // Must construct a TYPE_OBJECT containing nullptr.
 		r_error.error = Callable::CallError::CALL_OK;
 	}
 
 	static inline void validated_construct(Variant *r_ret, const Variant **p_args) {
-		VariantInternal::clear(r_ret);
-		VariantInternal::object_assign_null(r_ret);
+		*r_ret = (Object *)nullptr; // Must construct a TYPE_OBJECT containing nullptr.
 	}
 	static void ptr_construct(void *base, const void **p_args) {
 		PtrConstruct<Object *>::construct(nullptr, base);

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -35,6 +35,7 @@
 #include "scene/gui/button.h"
 #include "scene/gui/dialogs.h"
 #include "scene/gui/line_edit.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/scroll_container.h"
 #include "scene/gui/texture_rect.h"
@@ -445,6 +446,7 @@ class EditorInspector : public ScrollContainer {
 	LineEdit *search_box;
 	bool show_categories = false;
 	bool hide_script = true;
+	bool hide_metadata = true;
 	bool use_doc_hints = false;
 	bool capitalize_paths = true;
 	bool use_filter = false;
@@ -511,6 +513,15 @@ class EditorInspector : public ScrollContainer {
 
 	void _update_inspector_bg();
 
+	ConfirmationDialog *add_meta_dialog = nullptr;
+	LineEdit *add_meta_name = nullptr;
+	OptionButton *add_meta_type = nullptr;
+	Label *add_meta_error = nullptr;
+
+	void _add_meta_confirm();
+	void _show_add_meta_dialog();
+	void _check_meta_name(String name);
+
 protected:
 	static void _bind_methods();
 	void _notification(int p_what);
@@ -541,6 +552,7 @@ public:
 	void set_show_categories(bool p_show);
 	void set_use_doc_hints(bool p_enable);
 	void set_hide_script(bool p_hide);
+	void set_hide_metadata(bool p_hide);
 
 	void set_use_filter(bool p_use);
 	void register_text_enter(Node *p_line_edit);

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -679,6 +679,7 @@ InspectorDock::InspectorDock(EditorData &p_editor_data) {
 	inspector->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	inspector->set_use_doc_hints(true);
 	inspector->set_hide_script(false);
+	inspector->set_hide_metadata(false);
 	inspector->set_enable_capitalize_paths(bool(EDITOR_GET("interface/inspector/capitalize_properties")));
 	inspector->set_use_folding(!bool(EDITOR_GET("interface/inspector/disable_folding")));
 	inspector->register_text_enter(search);

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -93,6 +93,9 @@ void AcceptDialog::_notification(int p_what) {
 }
 
 void AcceptDialog::_text_submitted(const String &p_text) {
+	if (get_ok_button() && get_ok_button()->is_disabled()) {
+		return; // Do not allow submission if OK button is disabled.
+	}
 	_ok_pressed();
 }
 

--- a/tests/core/io/test_resource.h
+++ b/tests/core/io/test_resource.h
@@ -69,7 +69,7 @@ TEST_CASE("[Resource] Duplication") {
 TEST_CASE("[Resource] Saving and loading") {
 	Ref<Resource> resource = memnew(Resource);
 	resource->set_name("Hello world");
-	resource->set_meta("    ExampleMetadata    ", Vector2i(40, 80));
+	resource->set_meta("ExampleMetadata", Vector2i(40, 80));
 	resource->set_meta("string", "The\nstring\nwith\nunnecessary\nline\n\t\\\nbreaks");
 	Ref<Resource> child_resource = memnew(Resource);
 	child_resource->set_name("I'm a child resource");
@@ -84,7 +84,7 @@ TEST_CASE("[Resource] Saving and loading") {
 			loaded_resource_binary->get_name() == "Hello world",
 			"The loaded resource name should be equal to the expected value.");
 	CHECK_MESSAGE(
-			loaded_resource_binary->get_meta("    ExampleMetadata    ") == Vector2i(40, 80),
+			loaded_resource_binary->get_meta("ExampleMetadata") == Vector2i(40, 80),
 			"The loaded resource metadata should be equal to the expected value.");
 	CHECK_MESSAGE(
 			loaded_resource_binary->get_meta("string") == "The\nstring\nwith\nunnecessary\nline\n\t\\\nbreaks",
@@ -99,7 +99,7 @@ TEST_CASE("[Resource] Saving and loading") {
 			loaded_resource_text->get_name() == "Hello world",
 			"The loaded resource name should be equal to the expected value.");
 	CHECK_MESSAGE(
-			loaded_resource_text->get_meta("    ExampleMetadata    ") == Vector2i(40, 80),
+			loaded_resource_text->get_meta("ExampleMetadata") == Vector2i(40, 80),
 			"The loaded resource metadata should be equal to the expected value.");
 	CHECK_MESSAGE(
 			loaded_resource_text->get_meta("string") == "The\nstring\nwith\nunnecessary\nline\n\t\\\nbreaks",

--- a/tests/core/object/test_object.h
+++ b/tests/core/object/test_object.h
@@ -133,7 +133,7 @@ TEST_CASE("[Object] Core getters") {
 }
 
 TEST_CASE("[Object] Metadata") {
-	const String meta_path = "hello/world complex métadata\n\n\t\tpath";
+	const String meta_path = "complex_metadata_path";
 	Object object;
 
 	object.set_meta(meta_path, Color(0, 1, 0));


### PR DESCRIPTION
* API kept the same (Although functions could be renamed to set_metadata/get_metadata in a later PR), so not much should change.
* Metadata now exposed as individual properties.
* Properties are editable in inspector (unless metadata name begins with _) under the metadata/ namespace.
* Added the ability to Add/Remove metadata properties to the inspector.
* Because metadata is now exposed as properties, the values must now be valid identifiers (had to modify tests to pass).

This is a functionality that was requested very often, that makes metadata work a bit more similar to custom properties in Blender.

How it looks:

![image](https://user-images.githubusercontent.com/6265307/159787848-e6a3ea2e-4e42-49df-b517-fdb2b1c0661b.png)

So, as a note, as metadata is now user visible, make sure to make the ones you don't intend to be seen begin with underscore ("_"). Such as

```GDScript
obj.set_metadata("_customdata",someval)
```

This way, the editor will omit it, but it will still be saved.

Supersedes #30765
