### PR TITLE
Expose Color's `to_linear()` and `to_srgb()` to scripting

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1656,6 +1656,8 @@ static void _register_variant_builtin_methods() {
 	bind_method(Color, darkened, sarray("amount"), varray());
 	bind_method(Color, blend, sarray("over"), varray());
 	bind_method(Color, get_luminance, sarray(), varray());
+	bind_method(Color, to_linear, sarray(), varray());
+	bind_method(Color, to_srgb, sarray(), varray());
 
 	bind_method(Color, is_equal_approx, sarray("to"), varray());
 

--- a/doc/classes/Color.xml
+++ b/doc/classes/Color.xml
@@ -183,6 +183,7 @@
 			<description>
 				Returns the luminance of the color in the [code][0.0, 1.0][/code] range.
 				This is useful when determining light or dark color. Colors with a luminance smaller than 0.5 can be generally considered dark.
+				[b]Note:[/b] [method get_luminance] relies on the colour being in the linear color space to return an accurate relative luminance value. If the color is in the sRGB color space, use [method to_linear] to convert it to the linear color space first.
 			</description>
 		</method>
 		<method name="get_named_color" qualifiers="static">
@@ -404,6 +405,12 @@
 				[/codeblocks]
 			</description>
 		</method>
+		<method name="to_linear" qualifiers="const">
+			<return type="Color" />
+			<description>
+				Returns the color converted to the linear color space. This assumes the original color is in the sRGB color space. See also [method to_srgb] which performs the opposite operation.
+			</description>
+		</method>
 		<method name="to_rgba32" qualifiers="const">
 			<return type="int" />
 			<description>
@@ -434,6 +441,12 @@
 				GD.Print(color.ToRgba64()); // Prints -140736629309441
 				[/csharp]
 				[/codeblocks]
+			</description>
+		</method>
+		<method name="to_srgb" qualifiers="const">
+			<return type="Color" />
+			<description>
+				Returns the color converted to the [url=https://en.wikipedia.org/wiki/SRGB]sRGB[/url] color space. This assumes the original color is in the linear color space. See also [method to_linear] which performs the opposite operation.
 			</description>
 		</method>
 	</methods>

--- a/tests/core/math/test_color.h
+++ b/tests/core/math/test_color.h
@@ -144,6 +144,24 @@ TEST_CASE("[Color] Conversion methods") {
 			"The string representation should match the expected value.");
 }
 
+TEST_CASE("[Color] Linear <-> sRGB conversion") {
+	const Color color = Color(0.35, 0.5, 0.6, 0.7);
+	const Color color_linear = color.to_linear();
+	const Color color_srgb = color.to_srgb();
+	CHECK_MESSAGE(
+			color_linear.is_equal_approx(Color(0.100481, 0.214041, 0.318547, 0.7)),
+			"The color converted to linear color space should match the expected value.");
+	CHECK_MESSAGE(
+			color_srgb.is_equal_approx(Color(0.62621, 0.735357, 0.797738, 0.7)),
+			"The color converted to sRGB color space should match the expected value.");
+	CHECK_MESSAGE(
+			color_linear.to_srgb().is_equal_approx(Color(0.35, 0.5, 0.6, 0.7)),
+			"The linear color converted back to sRGB color space should match the expected value.");
+	CHECK_MESSAGE(
+			color_srgb.to_linear().is_equal_approx(Color(0.35, 0.5, 0.6, 0.7)),
+			"The sRGB color converted back to linear color space should match the expected value.");
+}
+
 TEST_CASE("[Color] Named colors") {
 	CHECK_MESSAGE(
 			Color::named("red").is_equal_approx(Color::hex(0xFF0000FF)),


### PR DESCRIPTION
This also adds unit tests for `to_linear()` and `to_srgb()`.

See https://github.com/godotengine/godot-proposals/discussions/4246#discussioncomment-2410357.