### PR TITLE
Fix PopupMenu behavior on MacOS when multiple monitors are used

### DIFF
--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -1682,7 +1682,11 @@ Point2i DisplayServerOSX::mouse_get_position() const {
 	for (NSScreen *screen in [NSScreen screens]) {
 		NSRect frame = [screen frame];
 		if (NSMouseInRect(mouse_pos, frame, NO)) {
-			return Vector2i((int)mouse_pos.x, (int)-mouse_pos.y) * scale + _get_screens_origin();
+			Vector2i pos = Vector2i((int)mouse_pos.x, (int)mouse_pos.y);
+			pos *= scale;
+			pos -= _get_screens_origin();
+			pos.y *= -1;
+			return pos;
 		}
 	}
 	return Vector2i();


### PR DESCRIPTION
This pull request fixes an issue that on MacOS, when multiple monitors are used, the PopupMenu in editor does not behave correctly, for example, right click a node and click "Add Child Node", the menu will disappear on mouse button down, without poping up the "Create New Node" panel.

After some digging, I found that this issue is related to **WINDOW_EVENT_CLOSE_REQUEST** sent in **DisplayServerOSX::mouse_process_popups**. **mouse_process_popups** tests whether **mouse pos** is in **win_rect**. And mouse pos seems to be incorrect in multilple monitor case.

LLDB output that shows the win_rect and mouse pos:
```
(lldb) p win_rect
(Rect2i) $3 = {
  position = {
     = {
       = {
         = (x = 2464, width = 2464)
         = (y = 2654, height = 2654)
      }
      coord = ([0] = 2464, [1] = 2654)
    }
  }
  size = {
     = {
       = {
         = (x = 748, width = 748)
         = (y = 676, height = 676)
      }
      coord = ([0] = 748, [1] = 676)
    }
  }
}
(lldb) p pos
(Point2i) $4 = {
   = {
     = {
       = (x = -1726, width = -1726)
       = (y = 2680, height = 2680)
    }
    coord = ([0] = -1726, [1] = 2680)
  }
}
```

So I changed **DisplayServerOSX::mouse_get_position**, use **DisplayServerOSX::window_get_position** as a reference, I'm not 100 percent sure this change is correct, but this change fixed the problem.

**Godot version**

4.0 dev (https://github.com/godotengine/godot/commit/bab2ad4d3283a9b4e6050a2345a4ea408001484e)
**System information**

MacOS Monterey, Vulkan, Mac Mini M1
with two monitors, one 4k as main, another 1080p 90 degrees rotated on the left
**Issue description**

Unable to add child node, because there is no response when clicking popup menu item
Issue disappears when only one monitor is used




<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
