### PR TITLE
Cleanup OpenXR on initialisation failure

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -99,17 +99,7 @@ bool OpenXRAPI::openxr_is_enabled() {
 }
 
 OpenXRAPI *OpenXRAPI::get_singleton() {
-	if (singleton != nullptr) {
-		// already constructed, return our singleton
-		return singleton;
-	} else if (openxr_is_enabled()) {
-		// construct our singleton and return it
-		singleton = memnew(OpenXRAPI);
-		return singleton;
-	} else {
-		// not enabled, don't instantiate, return nullptr
-		return nullptr;
-	}
+	return singleton;
 }
 
 String OpenXRAPI::get_default_action_map_resource_name() {
@@ -145,7 +135,7 @@ String OpenXRAPI::get_swapchain_format_name(int64_t p_swapchain_format) const {
 }
 
 bool OpenXRAPI::load_layer_properties() {
-	// This queries additional layers that are available and can be initialised when we create our OpenXR instance
+	// This queries additional layers that are available and can be initialized when we create our OpenXR instance
 	if (layer_properties != nullptr) {
 		// already retrieved this
 		return true;
@@ -175,7 +165,7 @@ bool OpenXRAPI::load_layer_properties() {
 }
 
 bool OpenXRAPI::load_supported_extensions() {
-	// This queries supported extensions that are available and can be initialised when we create our OpenXR instance
+	// This queries supported extensions that are available and can be initialized when we create our OpenXR instance
 
 	if (supported_extensions != nullptr) {
 		// already retrieved this
@@ -1010,7 +1000,7 @@ bool OpenXRAPI::is_running() {
 	return running;
 }
 
-bool OpenXRAPI::initialise(const String &p_rendering_driver) {
+bool OpenXRAPI::initialize(const String &p_rendering_driver) {
 	ERR_FAIL_COND_V_MSG(instance != XR_NULL_HANDLE, false, "OpenXR instance was already created");
 
 	if (p_rendering_driver == "vulkan") {
@@ -1034,7 +1024,7 @@ bool OpenXRAPI::initialise(const String &p_rendering_driver) {
 		ERR_FAIL_V_MSG(false, "OpenXR: Unsupported rendering device.");
 	}
 
-	// initialise
+	// initialize
 	if (!load_layer_properties()) {
 		destroy_instance();
 		return false;
@@ -1068,7 +1058,7 @@ bool OpenXRAPI::initialise(const String &p_rendering_driver) {
 	return true;
 }
 
-bool OpenXRAPI::initialise_session() {
+bool OpenXRAPI::initialize_session() {
 	if (!create_session()) {
 		destroy_session();
 		return false;
@@ -1599,7 +1589,7 @@ void OpenXRAPI::end_frame() {
 
 OpenXRAPI::OpenXRAPI() {
 	// OpenXRAPI is only constructed if OpenXR is enabled.
-	// It will be constructed when the rendering device first accesses OpenXR (be it the Vulkan or OpenGL rendering system)
+	singleton = this;
 
 	if (Engine::get_singleton()->is_editor_hint()) {
 		// Enabled OpenXR in the editor? Adjust our settings for the editor
@@ -1656,7 +1646,7 @@ OpenXRAPI::OpenXRAPI() {
 	frame_state.predictedDisplayPeriod = 0;
 
 #ifdef ANDROID_ENABLED
-	// our android wrapper will initialise our android loader at this point
+	// our android wrapper will initialize our android loader at this point
 	register_extension_wrapper(memnew(OpenXRAndroidExtension(this)));
 #endif
 }
@@ -1683,6 +1673,8 @@ OpenXRAPI::~OpenXRAPI() {
 		memfree(layer_properties);
 		layer_properties = nullptr;
 	}
+
+	singleton = nullptr;
 }
 
 Transform3D OpenXRAPI::transform_from_pose(const XrPosef &p_pose) {

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -234,8 +234,8 @@ public:
 
 	bool is_initialized();
 	bool is_running();
-	bool initialise(const String &p_rendering_driver);
-	bool initialise_session();
+	bool initialize(const String &p_rendering_driver);
+	bool initialize_session();
 	void finish();
 
 	XrTime get_next_frame_time() { return frame_state.predictedDisplayTime + frame_state.predictedDisplayPeriod; };

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -466,7 +466,7 @@ void OpenXRInterface::free_interaction_profiles() {
 	interaction_profiles.clear();
 }
 
-bool OpenXRInterface::initialise_on_startup() const {
+bool OpenXRInterface::initialize_on_startup() const {
 	if (openxr_api == nullptr) {
 		return false;
 	} else if (!openxr_api->is_initialized()) {
@@ -495,7 +495,7 @@ bool OpenXRInterface::initialize() {
 	// load up our action sets before setting up our session, note that our profiles are suggestions, OpenXR takes ownership of (re)binding
 	_load_action_map();
 
-	if (!openxr_api->initialise_session()) {
+	if (!openxr_api->initialize_session()) {
 		return false;
 	}
 

--- a/modules/openxr/openxr_interface.h
+++ b/modules/openxr/openxr_interface.h
@@ -106,7 +106,7 @@ public:
 	virtual PackedStringArray get_suggested_tracker_names() const override;
 	virtual TrackingStatus get_tracking_status() const override;
 
-	bool initialise_on_startup() const;
+	bool initialize_on_startup() const;
 	virtual bool is_initialized() const override;
 	virtual bool initialize() override;
 	virtual void uninitialize() override;

--- a/modules/openxr/register_types.cpp
+++ b/modules/openxr/register_types.cpp
@@ -45,9 +45,13 @@ void preregister_openxr_types() {
 	// For now we create our openxr device here. If we merge it with openxr_interface we'll create that here soon.
 
 	OpenXRAPI::setup_global_defs();
-	openxr_api = OpenXRAPI::get_singleton();
-	if (openxr_api) {
-		if (!openxr_api->initialise(Main::get_rendering_driver_name())) {
+	if (OpenXRAPI::openxr_is_enabled()) {
+		openxr_api = memnew(OpenXRAPI);
+		ERR_FAIL_NULL(openxr_api);
+
+		if (!openxr_api->initialize(Main::get_rendering_driver_name())) {
+			memdelete(openxr_api);
+			openxr_api = nullptr;
 			return;
 		}
 	}
@@ -67,7 +71,7 @@ void register_openxr_types() {
 		openxr_interface.instantiate();
 		xr_server->add_interface(openxr_interface);
 
-		if (openxr_interface->initialise_on_startup()) {
+		if (openxr_interface->initialize_on_startup()) {
 			openxr_interface->initialize();
 		}
 	}
@@ -75,7 +79,7 @@ void register_openxr_types() {
 
 void unregister_openxr_types() {
 	if (openxr_interface.is_valid()) {
-		// uninitialise just in case
+		// uninitialize just in case
 		if (openxr_interface->is_initialized()) {
 			openxr_interface->uninitialize();
 		}
@@ -96,5 +100,6 @@ void unregister_openxr_types() {
 	if (openxr_api) {
 		openxr_api->finish();
 		memdelete(openxr_api);
+		openxr_api = nullptr;
 	}
 }


### PR DESCRIPTION
On initialisation of OpenXR, which now happens way at the beginning of starting up Godot, if there was a failure it wouldn't clean things up and still try to set the rest of Godot up as if OpenXR was successfully setup.

This change ensure we clean up right away and Godot will start as normal. It would be nice if we just exist Godot all together at this point but there doesn't seem to be a clean way to do so. That said, the user can react on the initialise call on the interface failing and react accordingly.

OpenXR is a little strange when it comes to this.
With SteamVR if no headset is attached (because the user forgot to plug it in), instead of waiting and alerting the user, it just doesn't create the OpenXR instance and fails right off the bat.
The Oculus runtime gets a little further but will fail as we interrogate OpenXR and ask it to configure the session at this point saying that the requested mode is not available.

In both situations we now halt initialization and properly clean up resulting in Godot starting with OpenXR disabled.