### PR TITLE
Update root order on layer change

### DIFF
--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -38,6 +38,7 @@ void CanvasLayer::set_layer(int p_xform) {
 	layer = p_xform;
 	if (viewport.is_valid()) {
 		RenderingServer::get_singleton()->viewport_set_canvas_stacking(viewport, canvas, layer, get_index());
+		vp->_gui_set_root_order_dirty();
 	}
 }
 


### PR DESCRIPTION
When the layer of a CanvasLayer changes, the order of viewport root controls needs to be recalculated.

fix #59448
