### PR TITLE
LSP: Fix wrong parentheses for function call autocompletion

### DIFF
--- a/modules/gdscript/language_server/gdscript_text_document.cpp
+++ b/modules/gdscript/language_server/gdscript_text_document.cpp
@@ -177,6 +177,7 @@ Array GDScriptTextDocument::completion(const Dictionary &p_params) {
 			lsp::CompletionItem item;
 			item.label = option.display;
 			item.data = request_data;
+			item.insertText = option.insert_text;
 
 			switch (option.kind) {
 				case ScriptCodeCompletionOption::KIND_ENUM:
@@ -284,12 +285,7 @@ Dictionary GDScriptTextDocument::resolve(const Dictionary &p_params) {
 		item.documentation = symbol->render();
 	}
 
-	if ((item.kind == lsp::CompletionItemKind::Method || item.kind == lsp::CompletionItemKind::Function) && !item.label.ends_with("):")) {
-		item.insertText = item.label + "(";
-		if (symbol && symbol->children.is_empty()) {
-			item.insertText += ")";
-		}
-	} else if (item.kind == lsp::CompletionItemKind::Event) {
+	if (item.kind == lsp::CompletionItemKind::Event) {
 		if (params.context.triggerKind == lsp::CompletionTriggerKind::TriggerCharacter && (params.context.triggerCharacter == "(")) {
 			const String quote_style = EDITOR_GET("text_editor/completion/use_single_quotes") ? "'" : "\"";
 			item.insertText = item.label.quote(quote_style);

--- a/modules/gdscript/language_server/lsp.hpp
+++ b/modules/gdscript/language_server/lsp.hpp
@@ -1004,8 +1004,8 @@ struct CompletionItem {
 		dict["label"] = label;
 		dict["kind"] = kind;
 		dict["data"] = data;
+		dict["insertText"] = insertText;
 		if (resolved) {
-			dict["insertText"] = insertText;
 			dict["detail"] = detail;
 			dict["documentation"] = documentation.to_json();
 			dict["deprecated"] = deprecated;


### PR DESCRIPTION
`GDScriptLanguage::complete_code()` already defines its own `insert_text` field. Instead of coming up with our own (naive) logic we should reuse that. It also adds the parentheses to function calls but its algorithm is smarter and already considers edge cases like e.g. type hints.

For this to have any effect we also have to send the `insertText` field already during the completionRequest and not only during resolve. But this is actually the recommended behavior according to the LSP specification so it's a step in the right direction anyway.

* Fixes godotengine/godot-vscode-plugin#184
* Fixes godotengine/godot-vscode-plugin#323
