### PR TITLE
[Editor build] Use smaller .mo files instead of .po, if gettext is available.

### DIFF
--- a/editor/editor_builders.py
+++ b/editor/editor_builders.py
@@ -5,6 +5,10 @@ All such functions are invoked in a subprocess on Windows to prevent build flaki
 """
 import os
 import os.path
+import shutil
+import subprocess
+import tempfile
+import uuid
 from platform_methods import subprocess_main
 
 
@@ -89,10 +93,40 @@ def make_translations_header(target, source, env, category):
 
     sorted_paths = sorted(source, key=lambda path: os.path.splitext(os.path.basename(path))[0])
 
+    msgfmt_available = shutil.which("msgfmt") is not None
+
+    if not msgfmt_available:
+        print("WARNING: msgfmt is not found, using .po files instead of .mo")
+
     xl_names = []
     for i in range(len(sorted_paths)):
-        with open(sorted_paths[i], "rb") as f:
-            buf = f.read()
+        if msgfmt_available:
+            mo_path = os.path.join(tempfile.gettempdir(), uuid.uuid4().hex + ".mo")
+            cmd = "msgfmt " + sorted_paths[i] + " --no-hash -o " + mo_path
+            try:
+                subprocess.Popen(cmd, shell=True, stderr=subprocess.PIPE).communicate()
+                with open(mo_path, "rb") as f:
+                    buf = f.read()
+            except OSError as e:
+                print(
+                    "WARNING: msgfmt execution failed, using .po file instead of .mo: path=%r; [%s] %s"
+                    % (sorted_paths[i], e.__class__.__name__, e)
+                )
+                with open(sorted_paths[i], "rb") as f:
+                    buf = f.read()
+            finally:
+                try:
+                    os.remove(mo_path)
+                except OSError as e:
+                    # Do not fail the entire build if it cannot delete a temporary file
+                    print(
+                        "WARNING: Could not delete temporary .mo file: path=%r; [%s] %s"
+                        % (mo_path, e.__class__.__name__, e)
+                    )
+        else:
+            with open(sorted_paths[i], "rb") as f:
+                buf = f.read()
+
         decomp_size = len(buf)
         # Use maximum zlib compression level to further reduce file size
         # (at the cost of initial build times).


### PR DESCRIPTION
Makes an editor executable a bit smaller (by about 3 MB).

Note: Delete `*translations.gen.h` files before rebuilding, or it won't update until `.po` files are changed.