### PR TITLE
Remove space in MeshLibrary toolbar button

### DIFF
--- a/editor/plugins/mesh_library_editor_plugin.cpp
+++ b/editor/plugins/mesh_library_editor_plugin.cpp
@@ -271,7 +271,7 @@ MeshLibraryEditor::MeshLibraryEditor() {
 	menu = memnew(MenuButton);
 	Node3DEditor::get_singleton()->add_control_to_menu_panel(menu);
 	menu->set_position(Point2(1, 1));
-	menu->set_text(TTR("Mesh Library"));
+	menu->set_text(TTR("MeshLibrary"));
 	menu->set_icon(EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("MeshLibrary"), SNAME("EditorIcons")));
 	menu->get_popup()->add_item(TTR("Add Item"), MENU_OPTION_ADD_ITEM);
 	menu->get_popup()->add_item(TTR("Remove Selected Item"), MENU_OPTION_REMOVE_ITEM);


### PR DESCRIPTION
Changes the MeshLibrary toolbar button text from "Mesh Library" to "MeshLibrary". This makes it consistent with other nodes that have toolbar buttons.