### PR TITLE
Add GLTF, DAE and FBX importers enforcement for blend shape mask array

### DIFF
--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -994,13 +994,12 @@ Error ColladaImport::_create_mesh_surfaces(bool p_optimize, Ref<ImporterMesh> &p
 				Array a = p_morph_meshes[mi]->get_surface_arrays(surface);
 				//add valid weight and bone arrays if they exist, TODO check if they are unique to shape (generally not)
 
-				if (has_weights) {
-					a[Mesh::ARRAY_WEIGHTS] = d[Mesh::ARRAY_WEIGHTS];
-					a[Mesh::ARRAY_BONES] = d[Mesh::ARRAY_BONES];
+				// Enforce blend shape mask array format
+				for (int mj = 0; mj < Mesh::ARRAY_MAX; mj++) {
+					if (!(Mesh::ARRAY_FORMAT_BLEND_SHAPE_MASK & (1 << mj))) {
+						a[mj] = Variant();
+					}
 				}
-
-				a[Mesh::ARRAY_INDEX] = Variant();
-				//a.resize(Mesh::ARRAY_MAX); //no need for index
 				mr.push_back(a);
 			}
 

--- a/modules/fbx/data/fbx_mesh_data.cpp
+++ b/modules/fbx/data/fbx_mesh_data.cpp
@@ -371,6 +371,17 @@ ImporterMeshInstance3D *FBXMeshData::create_fbx_mesh(const ImportState &state, c
 		Array mesh_array = surface->surface_tool->commit_to_arrays();
 		Array blend_shapes = surface->morphs;
 
+		// Enforce blend shape mask array format
+		for (int i = 0; i < blend_shapes.size(); i++) {
+			Array bsdata = blend_shapes[i];
+
+			for (int j = 0; j < Mesh::ARRAY_MAX; j++) {
+				if (!(Mesh::ARRAY_FORMAT_BLEND_SHAPE_MASK & (1 << j))) {
+					bsdata[j] = Variant();
+				}
+			}
+		}
+
 		if (surface->material.is_valid()) {
 			mesh->add_surface(Mesh::PRIMITIVE_TRIANGLES, mesh_array, blend_shapes, Dictionary(), surface->material, surface->material->get_name());
 		} else {

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -2907,6 +2907,13 @@ Error GLTFDocument::_parse_meshes(Ref<GLTFState> state) {
 					}
 					array_copy = blend_surface_tool->commit_to_arrays();
 
+					// Enforce blend shape mask array format
+					for (int l = 0; l < Mesh::ARRAY_MAX; l++) {
+						if (!(Mesh::ARRAY_FORMAT_BLEND_SHAPE_MASK & (1 << l))) {
+							array_copy[l] = Variant();
+						}
+					}
+
 					morphs.push_back(array_copy);
 				}
 			}


### PR DESCRIPTION
As suggested by @reduz and @fire in #57945, this PR add blend shape filtering in the importers before adding surface, rather than making blend shape format check less strict. (cc. @lyuma)

Blend shapes are otherwise broken since #57801.

Unfortunately, DAE does not seem to support blend shapes for now. My code just cleans up data set that cannot be. And for FBX, existing import issues prevent me to test thoroughly.