### PR TITLE
Add better alert dialogs if directory already exists

### DIFF
--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -156,10 +156,15 @@ void EditorDirDialog::_make_dir_confirm() {
 
 	String dir = ti->get_metadata(0);
 
+	if (EditorFileSystem::get_singleton()->get_filesystem_path(dir + makedirname->get_text())) {
+		mkdirerr->set_text(TTR("Could not create folder. File with that name already exists."));
+		mkdirerr->popup_centered();
+		return;
+	}
+
 	DirAccessRef d = DirAccess::open(dir);
 	ERR_FAIL_COND_MSG(!d, "Cannot open directory '" + dir + "'.");
 	Error err = d->make_dir(makedirname->get_text());
-
 	if (err != OK) {
 		mkdirerr->popup_centered(Size2(250, 80) * EDSCALE);
 	} else {

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1092,6 +1092,13 @@ EditorFileDialog::Access EditorFileDialog::get_access() const {
 }
 
 void EditorFileDialog::_make_dir_confirm() {
+	if (EditorFileSystem::get_singleton()->get_filesystem_path(makedirname->get_text().strip_edges())) {
+		error_dialog->set_text(TTR("Could not create folder. File with that name already exists."));
+		error_dialog->popup_centered(Size2(250, 50) * EDSCALE);
+		makedirname->set_text(""); // Reset label.
+		return;
+	}
+
 	Error err = dir_access->make_dir(makedirname->get_text().strip_edges());
 	if (err == OK) {
 		dir_access->change_dir(makedirname->get_text().strip_edges());

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1413,6 +1413,12 @@ void FileSystemDock::_make_dir_confirm() {
 	if (!directory.ends_with("/")) {
 		directory = directory.get_base_dir();
 	}
+
+	if (EditorFileSystem::get_singleton()->get_filesystem_path(directory + dir_name)) {
+		EditorNode::get_singleton()->show_warning(TTR("Could not create folder. File with that name already exists."));
+		return;
+	}
+
 	print_verbose("Making folder " + dir_name + " in " + directory);
 	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	Error err = da->change_dir(directory);


### PR DESCRIPTION
Checks if directory already exists and depending on that prints better Alert/Warning messages.

Implements: godotengine/godot-proposals#3809

I found out that are commented out code lines in [editor/editor_dir_dialog.cpp ](https://github.com/godotengine/godot/blob/391633760b0ea292af079287faf79c1aee6d9254/editor/editor_dir_dialog.cpp) (on lines [60](https://github.com/godotengine/godot/blob/391633760b0ea292af079287faf79c1aee6d9254/editor/editor_dir_dialog.cpp#L60), [167](https://github.com/godotengine/godot/blob/391633760b0ea292af079287faf79c1aee6d9254/editor/editor_dir_dialog.cpp#L167) and [195](https://github.com/godotengine/godot/blob/391633760b0ea292af079287faf79c1aee6d9254/editor/editor_dir_dialog.cpp#L195)) Most of them are several **years** old and I think that they might be deleted, but that should be matter of another PR.

Also, the process of adding a new directory is functionally almost the same across all files that this PR changes, but the naming and error popup handling is inconsistent, perhaps that happens on other places in the code base and it should be changed to one more consistent approach?