### PR TITLE
Switch scene when editing foreign resource

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3721,6 +3721,11 @@ void EditorNode::open_request(const String &p_path) {
 	load_scene(p_path); // as it will be opened in separate tab
 }
 
+void EditorNode::edit_foreign_resource(RES p_resource) {
+	load_scene(p_resource->get_path().get_slice("::", 0));
+	InspectorDock::get_singleton()->call_deferred("edit_resource", p_resource);
+}
+
 void EditorNode::request_instance_scene(const String &p_path) {
 	SceneTreeDock::get_singleton()->instantiate(p_path);
 }
@@ -5706,6 +5711,7 @@ void EditorNode::_bind_methods() {
 	ClassDB::bind_method("_get_scene_metadata", &EditorNode::_get_scene_metadata);
 	ClassDB::bind_method("set_edited_scene", &EditorNode::set_edited_scene);
 	ClassDB::bind_method("open_request", &EditorNode::open_request);
+	ClassDB::bind_method("edit_foreign_resource", &EditorNode::edit_foreign_resource);
 	ClassDB::bind_method("_close_messages", &EditorNode::_close_messages);
 	ClassDB::bind_method("_show_messages", &EditorNode::_show_messages);
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -755,6 +755,7 @@ public:
 	void select_editor_by_name(const String &p_name);
 
 	void open_request(const String &p_path);
+	void edit_foreign_resource(RES p_resource);
 
 	bool is_changing_scene() const;
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2975,6 +2975,12 @@ void EditorPropertyResource::_set_read_only(bool p_read_only) {
 };
 
 void EditorPropertyResource::_resource_selected(const RES &p_resource, bool p_edit) {
+	if (p_resource->is_built_in() && !p_resource->get_path().is_empty() && p_resource->get_path().get_slice("::", 0) != EditorNode::get_singleton()->get_edited_scene()->get_scene_file_path()) {
+		// If the resource belongs to another scene, edit it in that scene instead.
+		EditorNode::get_singleton()->call_deferred("edit_foreign_resource", p_resource);
+		return;
+	}
+
 	if (!p_edit && use_sub_inspector) {
 		bool unfold = !get_edited_object()->editor_is_section_unfolded(get_edited_property());
 		get_edited_object()->editor_set_section_unfold(get_edited_property(), unfold);
@@ -3172,9 +3178,8 @@ void EditorPropertyResource::_viewport_selected(const NodePath &p_path) {
 
 void EditorPropertyResource::setup(Object *p_object, const String &p_path, const String &p_base_type) {
 	if (resource_picker) {
-		resource_picker->disconnect("resource_selected", callable_mp(this, &EditorPropertyResource::_resource_selected));
-		resource_picker->disconnect("resource_changed", callable_mp(this, &EditorPropertyResource::_resource_changed));
 		memdelete(resource_picker);
+		resource_picker = nullptr;
 	}
 
 	if (p_path == "script" && p_base_type == "Script" && Object::cast_to<Node>(p_object)) {

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -437,6 +437,8 @@ void InspectorDock::_bind_methods() {
 	ClassDB::bind_method("_menu_collapseall", &InspectorDock::_menu_collapseall);
 	ClassDB::bind_method("_menu_expandall", &InspectorDock::_menu_expandall);
 
+	ClassDB::bind_method("edit_resource", &InspectorDock::edit_resource);
+
 	ADD_SIGNAL(MethodInfo("request_help"));
 }
 


### PR DESCRIPTION
When editing a resource that belongs to another scene (usually from an instance), that scene is opened first and then the resource is edited.
![godot windows tools 64_FWJ0ToBqBO](https://user-images.githubusercontent.com/2223172/160030678-469cce52-9792-450b-b31b-7948d5739b36.gif)
Together with #59472 it should now be impossible to edit resources in a wrong scene.