### PR TITLE
Add _group_selected to callable methods

### DIFF
--- a/editor/groups_editor.cpp
+++ b/editor/groups_editor.cpp
@@ -416,6 +416,8 @@ void GroupDialog::_bind_methods() {
 
 	ClassDB::bind_method("_rename_group_item", &GroupDialog::_rename_group_item);
 
+	ClassDB::bind_method("_group_selected", &GroupDialog::_group_selected);
+
 	ADD_SIGNAL(MethodInfo("group_edited"));
 }
 


### PR DESCRIPTION
I was able to fix this [issue](https://github.com/godotengine/godot/issues/59492), the `_group_selected` method was not added to the callable methods, so it was not being returned in `undo_redo.cpp` on line 324.

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/59492