### PR TITLE
[Fix #58248] Add custom type check before hiding type

### DIFF
--- a/editor/create_dialog.cpp
+++ b/editor/create_dialog.cpp
@@ -125,7 +125,7 @@ bool CreateDialog::_should_hide_type(const String &p_type) const {
 		return true; // Do not show editor nodes.
 	}
 
-	if (p_type == base_type) {
+	if (p_type == base_type && !EditorNode::get_editor_data().get_custom_types().has(p_type)) {
 		return true; // Root is already added.
 	}
 


### PR DESCRIPTION
**This PR replaces #59399** (due to a bad git move)

Before looping through custom types, Godot runs the _should_hide_type function to skip EditorNodes and other non-usable nodes. Unfortunately, Godot would flag Node and Resources (and other root nodes) as "should hide", even if custom types would extend these root nodes.

That explains why adding a custom type extending Node2D, that type would display in the Create Node dialog, but not a custom type extending Node or Resource.

With my fix, if the node is a base type, _should_hide_type checks before returning true, if the base type has custom types attached to it. If so, it does not return true right away.

Fixes #58248