### PR TITLE
Make the OpenType "Add Feature..." button use the full width of the inspector

### DIFF
--- a/editor/plugins/ot_features_plugin.h
+++ b/editor/plugins/ot_features_plugin.h
@@ -56,10 +56,10 @@ public:
 
 /*************************************************************************/
 
-class OpenTypeFeaturesAdd : public EditorProperty {
-	GDCLASS(OpenTypeFeaturesAdd, EditorProperty);
+class OpenTypeFeaturesAdd : public Button {
+	GDCLASS(OpenTypeFeaturesAdd, Button);
 
-	Button *button = nullptr;
+	Object *edited_object = nullptr;
 	PopupMenu *menu = nullptr;
 	PopupMenu *menu_ss = nullptr;
 	PopupMenu *menu_cv = nullptr;
@@ -73,7 +73,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	virtual void update_property() override;
+	void setup(Object *p_object);
 
 	OpenTypeFeaturesAdd();
 };


### PR DESCRIPTION
This changes the OpenType "Add Feature..." button to use the full width of the inspector. This makes it consistent with the array, dictionary, and property array editors.

The reason it only used half of the inspector's width before is that it was an EditorProperty node, which also caused the left half to be selectable and have a tooltip and context menu, despite not being an actual property.

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/160041203-f47044f7-0d5d-4359-aac3-71cd31db768f.png) | ![image](https://user-images.githubusercontent.com/67974470/160041106-dc28a2e7-04f5-46d8-8a22-a1e1fbdedf00.png) |
