### PR TITLE
[3.x] Fix icons for tile bitmask copy & paste buttons

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -310,8 +310,8 @@ void TileSetEditor::_notification(int p_what) {
 			tool_workspacemode[WORKSPACE_CREATE_ATLAS]->set_icon(get_icon("AddAtlasTile", "EditorIcons"));
 
 			tools[TOOL_SELECT]->set_icon(get_icon("ToolSelect", "EditorIcons"));
-			tools[BITMASK_COPY]->set_icon(get_icon("Duplicate", "EditorIcons"));
-			tools[BITMASK_PASTE]->set_icon(get_icon("Override", "EditorIcons"));
+			tools[BITMASK_COPY]->set_icon(get_icon("ActionCopy", "EditorIcons"));
+			tools[BITMASK_PASTE]->set_icon(get_icon("ActionPaste", "EditorIcons"));
 			tools[BITMASK_CLEAR]->set_icon(get_icon("Clear", "EditorIcons"));
 			tools[SHAPE_NEW_POLYGON]->set_icon(get_icon("CollisionPolygon2D", "EditorIcons"));
 			tools[SHAPE_NEW_RECTANGLE]->set_icon(get_icon("CollisionShape2D", "EditorIcons"));


### PR DESCRIPTION
The old TileSet editor uses non-standard icons for copy and paste actions. It uses Duplicate for copy, and Override for paste. This PR changes the icons to use the normal ActionCopy and ActionPaste.

| | Screenshot |
|-|-|
| Before | ![before](https://user-images.githubusercontent.com/372476/160047398-914ec4ea-da21-4e5f-9012-a0b6d1cd421d.png) |
| After | ![after](https://user-images.githubusercontent.com/372476/160047419-c59756a2-b23d-4b0e-9445-a3cc69dbbd9a.png) |