### PR TITLE
[3.x] Update default editor proxy port to 8080

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -652,6 +652,11 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("network/ssl/editor_ssl_certificates", _SYSTEM_CERTS_PATH);
 	hints["network/ssl/editor_ssl_certificates"] = PropertyInfo(Variant::STRING, "network/ssl/editor_ssl_certificates", PROPERTY_HINT_GLOBAL_FILE, "*.crt,*.pem");
 
+	// HTTP Proxy
+	_initial_set("network/http_proxy/host", "");
+	_initial_set("network/http_proxy/port", 8080);
+	hints["network/http_proxy/port"] = PropertyInfo(Variant::INT, "network/http_proxy/port", PROPERTY_HINT_RANGE, "1,65535,1");
+
 	/* Extra config */
 
 	_initial_set("project_manager/sorting_order", 0);

--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -150,8 +150,8 @@ void ExportTemplateManager::_download_template(const String &p_url, bool p_skip_
 	download_templates->set_download_file(EditorSettings::get_singleton()->get_cache_dir().plus_file("tmp_templates.tpz"));
 	download_templates->set_use_threads(true);
 
-	const String proxy_host = EDITOR_DEF("network/http_proxy/host", "");
-	const int proxy_port = EDITOR_DEF("network/http_proxy/port", -1);
+	const String proxy_host = EDITOR_GET("network/http_proxy/host");
+	const int proxy_port = EDITOR_GET("network/http_proxy/port");
 	download_templates->set_http_proxy(proxy_host, proxy_port);
 	download_templates->set_https_proxy(proxy_host, proxy_port);
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -40,8 +40,8 @@
 static inline void setup_http_request(HTTPRequest *request) {
 	request->set_use_threads(EDITOR_DEF("asset_library/use_threads", true));
 
-	const String proxy_host = EDITOR_DEF("network/http_proxy/host", "");
-	const int proxy_port = EDITOR_DEF("network/http_proxy/port", -1);
+	const String proxy_host = EDITOR_GET("network/http_proxy/host");
+	const int proxy_port = EDITOR_GET("network/http_proxy/port");
 	request->set_http_proxy(proxy_host, proxy_port);
 	request->set_https_proxy(proxy_host, proxy_port);
 }


### PR DESCRIPTION
It's changed on `master` in #59351.

* Updates the default port from meaningless -1 to 8080.
    * It's safe to change because it's introduced in 3.5 beta, not released yet.
    * Proxy is still inactive by default because the default host is an empty string.
* Like on `master`, changes scattered `EDITOR_DEF` into `EDITOR_GET`, and set the default value & hint in `EditorSettings`.