### PR TITLE
Action Map Editor fixes and improvements

### DIFF
--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -97,7 +97,7 @@ private:
 
 	CheckBox *physical_key_checkbox;
 
-	void _set_event(const Ref<InputEvent> &p_event);
+	void _set_event(const Ref<InputEvent> &p_event, bool p_update_input_list_selection = true);
 
 	void _tab_selected(int p_tab);
 	void _listen_window_input(const Ref<InputEvent> &p_event);
@@ -110,9 +110,10 @@ private:
 	void _store_command_toggled(bool p_checked);
 	void _physical_keycode_toggled(bool p_checked);
 
-	void _set_current_device(int i_device);
+	void _device_selection_changed(int p_option_button_index);
+	void _set_current_device(int p_device);
 	int _get_current_device() const;
-	String _get_device_string(int i_device) const;
+	String _get_device_string(int p_device) const;
 
 protected:
 	void _notification(int p_what);
@@ -121,7 +122,7 @@ public:
 	// Pass an existing event to configure it. Alternatively, pass no event to start with a blank configuration.
 	void popup_and_configure(const Ref<InputEvent> &p_event = Ref<InputEvent>());
 	Ref<InputEvent> get_event() const;
-	String get_event_text(const Ref<InputEvent> &p_event);
+	String get_event_text(const Ref<InputEvent> &p_event, bool p_include_device) const;
 
 	void set_allowed_input_types(int p_type_masks);
 


### PR DESCRIPTION
Multiple fixes:
* Fixed device not being updated correctly (changing the device dropdown did not actually change the underlying event's device)
* Device selection now defaults to `All Devices`
* Device is now displayed in the text shown in the input event editor, and in the action list.
* There was code running twice previously because of the following interaction: 1) input via "Listen for Input" tab. 2) `_set_event` gets called. 3) input list tree selection gets updated to match the listened event. 4) tree "item_selection" signal is emitted. 5) eventually `_set_event` is called again.
* The only reason this was not an infinite loop is because reselection is disabled on the tree. So, the code runs twice - not a big deal, but it is unnecessary processing and it could cause an issue in the future. If someone turns on reselection on the tree, the whole thing comes crashing down. This should prevent that scenario and make the code a bit safer and more robust.

Closes #53708 (what was left after #53734 was merged)
Closes #26880 as per @Calinou's suggestion https://github.com/godotengine/godot/issues/26880#issuecomment-953366510
Closes #60065

![image](https://user-images.githubusercontent.com/41730826/160134806-3ce87ffe-701d-4438-9634-ac807c27c459.png)
![image](https://user-images.githubusercontent.com/41730826/160134955-3cda1b8a-f3ed-4d02-b8ca-4da51673ac09.png)
