### PR TITLE
Extract 2D debug collision drawing from `CollisionShape2D` to `CollisionObject2D`

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -121,6 +121,49 @@ void CollisionObject2D::_notification(int p_what) {
 		case NOTIFICATION_ENABLED: {
 			_apply_enabled();
 		} break;
+
+		case NOTIFICATION_DRAW: {
+			ERR_FAIL_COND(!is_inside_tree());
+
+			if (Engine::get_singleton()->is_editor_hint() || !get_tree()->is_debugging_collisions_hint()) {
+				break;
+			}
+
+			for (const KeyValue<uint32_t, ShapeData> &E : shapes) {
+				const ShapeData &shapedata = E.value;
+
+				draw_set_transform_matrix(get_canvas_transform() * shapedata.xform);
+
+				const ShapeData::Shape *shapes = shapedata.shapes.ptr();
+				for (int i = 0; i < shapedata.shapes.size(); i++) {
+					Ref<Shape2D> shape = shapes[i].shape;
+					if (!shape.is_valid() || shapedata.disabled) {
+						continue;
+					}
+
+					Color draw_col = get_tree()->get_debug_collisions_color();
+					shape->draw(get_canvas_item(), draw_col);
+
+					if (shapedata.one_way_collision) {
+						// Draw an arrow indicating the one-way collision direction
+						draw_col = draw_col.inverted();
+						Vector2 line_to(0, 20);
+						draw_line(Vector2(), line_to, draw_col, 2);
+						real_t tsize = 8;
+
+						Vector<Vector2> pts{
+							line_to + Vector2(0, tsize),
+							line_to + Vector2(Math_SQRT12 * tsize, 0),
+							line_to + Vector2(-Math_SQRT12 * tsize, 0)
+						};
+
+						Vector<Color> cols{ draw_col, draw_col, draw_col };
+
+						draw_primitive(pts, cols, Vector<Vector2>());
+					}
+				}
+			}
+		} break;
 	}
 }
 
@@ -296,6 +339,8 @@ void CollisionObject2D::shape_owner_set_disabled(uint32_t p_owner, bool p_disabl
 			PhysicsServer2D::get_singleton()->body_set_shape_disabled(rid, sd.shapes[i].index, p_disabled);
 		}
 	}
+
+	_update_debug_shapes(false);
 }
 
 bool CollisionObject2D::is_shape_owner_disabled(uint32_t p_owner) const {
@@ -316,6 +361,8 @@ void CollisionObject2D::shape_owner_set_one_way_collision(uint32_t p_owner, bool
 	for (int i = 0; i < sd.shapes.size(); i++) {
 		PhysicsServer2D::get_singleton()->body_set_shape_as_one_way_collision(rid, sd.shapes[i].index, sd.one_way_collision, sd.one_way_collision_margin);
 	}
+
+	_update_debug_shapes(false);
 }
 
 bool CollisionObject2D::is_shape_owner_one_way_collision_enabled(uint32_t p_owner) const {
@@ -372,6 +419,8 @@ void CollisionObject2D::shape_owner_set_transform(uint32_t p_owner, const Transf
 			PhysicsServer2D::get_singleton()->body_set_shape_transform(rid, sd.shapes[i].index, sd.xform);
 		}
 	}
+
+	_update_debug_shapes(false);
 }
 
 Transform2D CollisionObject2D::shape_owner_get_transform(uint32_t p_owner) const {
@@ -402,6 +451,11 @@ void CollisionObject2D::shape_owner_add_shape(uint32_t p_owner, const Ref<Shape2
 	sd.shapes.push_back(s);
 
 	total_subshapes++;
+
+	if (s.shape.is_valid() && !s.shape->is_connected("changed", callable_mp(this, &CollisionObject2D::_shape_changed))) {
+		s.shape->connect("changed", callable_mp(this, &CollisionObject2D::_shape_changed));
+	}
+	_update_debug_shapes(false);
 }
 
 int CollisionObject2D::shape_owner_get_shape_count(uint32_t p_owner) const {
@@ -435,6 +489,11 @@ void CollisionObject2D::shape_owner_remove_shape(uint32_t p_owner, int p_shape) 
 		PhysicsServer2D::get_singleton()->body_remove_shape(rid, index_to_remove);
 	}
 
+	Ref<Shape2D> shape = shapes[p_owner].shapes[p_shape].shape;
+	if (shape.is_valid() && shape->is_connected("changed", callable_mp(this, &CollisionObject2D::_shape_changed))) {
+		shape->disconnect("changed", callable_mp(this, &CollisionObject2D::_shape_changed));
+	}
+
 	shapes[p_owner].shapes.remove_at(p_shape);
 
 	for (KeyValue<uint32_t, ShapeData> &E : shapes) {
@@ -446,6 +505,8 @@ void CollisionObject2D::shape_owner_remove_shape(uint32_t p_owner, int p_shape) 
 	}
 
 	total_subshapes--;
+
+	_update_debug_shapes(true);
 }
 
 void CollisionObject2D::shape_owner_clear_shapes(uint32_t p_owner) {
@@ -469,6 +530,32 @@ uint32_t CollisionObject2D::shape_find_owner(int p_shape_index) const {
 
 	//in theory it should be unreachable
 	ERR_FAIL_V_MSG(UINT32_MAX, "Can't find owner for shape index " + itos(p_shape_index) + ".");
+}
+
+bool CollisionObject2D::_are_debug_shapes_visible() const {
+	return !Engine::get_singleton()->is_editor_hint() && is_inside_tree() && get_tree()->is_debugging_collisions_hint();
+}
+
+void CollisionObject2D::_update_debug_shapes(bool p_reconnect_signals) {
+	if (_are_debug_shapes_visible()) {
+		update();
+	}
+	if (p_reconnect_signals) {
+		for (const KeyValue<uint32_t, ShapeData> &E : shapes) {
+			const ShapeData &shapedata = E.value;
+			const ShapeData::Shape *shapes = shapedata.shapes.ptr();
+			for (int i = 0; i < shapedata.shapes.size(); i++) {
+				Ref<Shape2D> shape = shapes[i].shape;
+				if (shape.is_valid() && !shape->is_connected("changed", callable_mp(this, &CollisionObject2D::_shape_changed))) {
+					shape->connect("changed", callable_mp(this, &CollisionObject2D::_shape_changed));
+				}
+			}
+		}
+	}
+}
+
+void CollisionObject2D::_shape_changed() {
+	_update_debug_shapes(false);
 }
 
 void CollisionObject2D::set_pickable(bool p_enabled) {

--- a/scene/2d/collision_object_2d.h
+++ b/scene/2d/collision_object_2d.h
@@ -146,6 +146,10 @@ public:
 
 	uint32_t shape_find_owner(int p_shape_index) const;
 
+	bool _are_debug_shapes_visible() const;
+	void _update_debug_shapes(bool p_reconnect_signals);
+	void _shape_changed();
+
 	void set_pickable(bool p_enabled);
 	bool is_pickable() const;
 

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -84,15 +84,13 @@ void CollisionShape2D::_notification(int p_what) {
 		case NOTIFICATION_DRAW: {
 			ERR_FAIL_COND(!is_inside_tree());
 
-			if (!Engine::get_singleton()->is_editor_hint() && !get_tree()->is_debugging_collisions_hint()) {
+			if (!Engine::get_singleton()->is_editor_hint()) {
 				break;
 			}
 
 			if (!shape.is_valid()) {
 				break;
 			}
-
-			rect = Rect2();
 
 			Color draw_col = get_tree()->get_debug_collisions_color();
 			if (disabled) {
@@ -103,9 +101,6 @@ void CollisionShape2D::_notification(int p_what) {
 				draw_col.a *= 0.5;
 			}
 			shape->draw(get_canvas_item(), draw_col);
-
-			rect = shape->get_rect();
-			rect = rect.grow(3);
 
 			if (one_way_collision) {
 				// Draw an arrow indicating the one-way collision direction

--- a/scene/2d/collision_shape_2d.h
+++ b/scene/2d/collision_shape_2d.h
@@ -39,7 +39,6 @@ class CollisionObject2D;
 class CollisionShape2D : public Node2D {
 	GDCLASS(CollisionShape2D, Node2D);
 	Ref<Shape2D> shape;
-	Rect2 rect = Rect2(-Point2(10, 10), Point2(20, 20));
 	uint32_t owner_id = 0;
 	CollisionObject2D *parent = nullptr;
 	void _shape_changed();


### PR DESCRIPTION
This is more flexible, as it allows displaying collision shapes which were created directly in the physics server without a `CollisionShape2D` node. In 3D the `CollisionObject3D` also handles the debug drawing.

Fixes https://github.com/godotengine/godot/issues/36499.

Would appreciate testing to confirm that the shapes are still drawn in the right position in all cases.

*Note:* This change implies that the debug shape of a "lone" `CollisionShape2D` node (not a child of any node derived from `CollisionObject2D`) is no longer drawn. I consider this an improvement, as it is less confusing (there is already an in-editor configuration warning saying a `CollisionShape2D` should only be used as a child of a node derived from `CollisionObject2D`). Moreover, this is the same behavior as it is currently in 3D.

*Note 2:* This change also allows to hide disabled collision shapes completely, which was not possible before due to the coupling with the editor code. I've hidden the disabled collision shapes in this PR, but this decision is up for debate (whether they should always be hidden, always be shown greyed out as in the editor, or whether an option to toggle the behavior should be added). In 3D, disabled collision shapes are always hidden.