### PR TITLE
[3.x] Avoid modifying csproj globbing includes on remove

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectUtils.cs
+++ b/modules/mono/editor/GodotTools/GodotTools.ProjectEditor/ProjectUtils.cs
@@ -108,8 +108,22 @@ namespace GodotTools.ProjectEditor
 
             var normalizedInclude = include.NormalizePath();
 
-            if (root.RemoveItemChecked(itemType, normalizedInclude))
-                root.Save();
+            var item = root.FindItemOrNullAbs(itemType, normalizedInclude);
+
+            // Couldn't find an existing item that matches to remove
+            if (item == null)
+                return;
+
+            var glob = MSBuildGlob.Parse(item.Include);
+
+            // If the item include uses globbing don't remove it
+            if (!string.IsNullOrEmpty(glob.WildcardDirectoryPart) || glob.FilenamePart.Contains("*"))
+            {
+                return;
+            }
+
+            item.Parent.RemoveChild(item);
+            root.Save();
         }
 
         public static void RenameItemsToNewFolderInProjectChecked(string projectPath, string itemType, string oldFolder, string newFolder)


### PR DESCRIPTION
_Does not apply to `master`_.

Follow-up to #54262.

Check if the found globbing include already matches the given path on removing scripts to avoid modifying users' csproj files.
