### PR TITLE
Reload and update editor and scripts properly when edited externally

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1370,15 +1370,14 @@ void ScriptTextEditor::set_find_replace_bar(FindReplaceBar *p_bar) {
 }
 
 void ScriptTextEditor::reload(bool p_soft) {
-	CodeEdit *te = code_editor->get_text_editor();
 	Ref<Script> scr = script;
 	if (scr.is_null()) {
 		return;
 	}
-	scr->set_source_code(te->get_text());
 	bool soft = p_soft || scr->get_instance_base_type() == "EditorPlugin"; // Always soft-reload editor plugins.
 
 	scr->get_language()->reload_tool_script(scr, soft);
+	reload_text();
 }
 
 Array ScriptTextEditor::get_breakpoints() {

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1921,6 +1921,7 @@ void GDScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_so
 
 	for (KeyValue<Ref<GDScript>, Map<ObjectID, List<Pair<StringName, Variant>>>> &E : to_reload) {
 		Ref<GDScript> scr = E.key;
+		scr->load_source_code(scr->get_path());
 		scr->reload(p_soft_reload);
 
 		//restore state if saved


### PR DESCRIPTION
Fix for #59115  
Made changes so the internal source code is updated when reload is called.  
Also set text editor to update text with source code instead of the other way around.  
Dunno why that was the case, so it would nice to know what the original intention was.