### PR TITLE
Improve PCK loading filename handling

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -660,6 +660,34 @@ void ProjectSettings::_handle_editor_setting_compat(const String &p_original_set
 }
 #endif
 
+bool ProjectSettings::_attempt_load_from_separate_pack(const String &p_exec_path) {
+	const String exec_dir = p_exec_path.get_base_dir();
+	String exec_filename = p_exec_path.get_file();
+	while (true) {
+#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+		// Attempt to load PCK from macOS .app bundle resources.
+		if (_load_resource_pack(OS::get_singleton()->get_bundle_resource_dir().path_join(exec_filename + ".pck"), false, 0, true)) {
+			return true;
+		}
+#endif
+		// Attempt to load data pack at the location of the executable.
+		if (_load_resource_pack(exec_dir.path_join(exec_filename + ".pck"), false, 0, true)) {
+			return true;
+		}
+		// Lastly, attempt to load the PCK from the current working directory.
+		if (_load_resource_pack(exec_filename + ".pck", false, 0, true)) {
+			return true;
+		}
+		if (exec_filename.contains_char('.')) {
+			// If we still haven't found the PCK, and there is an extension to strip, we strip and try again.
+			exec_filename = exec_filename.get_basename();
+		} else {
+			// If we still haven't found the PCK, and there are no more extensions to strip, we give up.
+			return false;
+		}
+	}
+}
+
 /*
  * This method is responsible for loading a project.godot file and/or data file
  * using the following merit order:
@@ -725,34 +753,9 @@ Error ProjectSettings::_setup(const String &p_path, const String &p_main_pack, b
 		// Attempt with PCK bundled into executable.
 		bool found = _load_resource_pack(exec_path, false, 0, true);
 
-		// Attempt with exec_name.pck.
-		// (This is the usual case when distributing a Godot game.)
-		String exec_dir = exec_path.get_base_dir();
-		String exec_filename = exec_path.get_file();
-		String exec_basename = exec_filename.get_basename();
-
-		// Based on the OS, it can be the exec path + '.pck' (Linux w/o extension, macOS in .app bundle)
-		// or the exec path's basename + '.pck' (Windows).
-		// We need to test both possibilities as extensions for Linux binaries are optional
-		// (so both 'mygame.bin' and 'mygame' should be able to find 'mygame.pck').
-
-#if defined(MACOS_ENABLED) || defined(APPLE_EMBEDDED_ENABLED)
+		// Attempt to load from a separate PCK (the more usual case).
 		if (!found) {
-			// Attempt to load PCK from macOS .app bundle resources.
-			found = _load_resource_pack(OS::get_singleton()->get_bundle_resource_dir().path_join(exec_basename + ".pck"), false, 0, true) || _load_resource_pack(OS::get_singleton()->get_bundle_resource_dir().path_join(exec_filename + ".pck"), false, 0, true);
-		}
-#endif
-
-		if (!found) {
-			// Try to load data pack at the location of the executable.
-			// As mentioned above, we have two potential names to attempt.
-			found = _load_resource_pack(exec_dir.path_join(exec_basename + ".pck"), false, 0, true) || _load_resource_pack(exec_dir.path_join(exec_filename + ".pck"), false, 0, true);
-		}
-
-		if (!found) {
-			// If we couldn't find them next to the executable, we attempt
-			// the current working directory. Same story, two tests.
-			found = _load_resource_pack(exec_basename + ".pck", false, 0, true) || _load_resource_pack(exec_filename + ".pck", false, 0, true);
+			found = _attempt_load_from_separate_pack(exec_path);
 		}
 
 		// If we opened our package, try and load our project.

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -153,6 +153,7 @@ protected:
 
 	void _add_property_info_bind(const Dictionary &p_info);
 
+	bool _attempt_load_from_separate_pack(const String &p_exec_path);
 	Error _setup(const String &p_path, const String &p_main_pack, bool p_upwards = false, bool p_ignore_override = false);
 
 	void _add_builtin_input_map();


### PR DESCRIPTION
This PR changes the code for loading a PCK file, specifically how it finds the `.pck` file. Discussed on RocketChat.

The existing behavior of having `mygame.exe` and `mygame.pck` still works fine. The code in this PR is actually simpler while still having the functionality of the current master and more, although there are more lines of code because I abstracted it into a separate method and added more comments.

The code continues stripping the file name of extensions until it finds a PCK, or until there are no more extensions to strip. For example, let's say our executable is "mygame.x86_64.exe". First we look for "mygame.x86_64.exe.pck". If that fails, we look for "mygame.x86_64.pck". If that fails, we look for "mygame.pck". This allows having multiple executables for a game that share a specific PCK file, or providing different PCK files for different architectures or other custom situations. This PR also moves this logic into its own method.

Aside from allowing stripping more extensions, this PR does change the order of how things are searched, which changes behavior, but only in a minor way, and in my opinion the new behavior is much better. It will now search for the fullest names first in all locations before trying a shorter name. For example, let's say we have an executable named `mygame.exe`, in the current master it will search for `.pck` files in this order:

```
mygame.pck (in executable directory)
mygame.exe.pck (in executable directory)
mygame.pck (in current directory)
mygame.exe.pck (in current directory)
(even if there were more extensions to strip, the current master would stop after looking at these 4)
```

In this PR, the order will instead look like this:

```
mygame.exe.pck (in executable directory)
mygame.exe.pck (in current directory)
mygame.pck (in executable directory)
mygame.pck (in current directory)
(if there were more extensions to strip, this PR would continue)
```

I have already done some testing, and it works exactly as expected.