### PR TITLE
Fix project manager window size not applying display scale correctly

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2873,10 +2873,16 @@ ProjectManager::ProjectManager() {
 		Vector2i window_size = DisplayServer::get_singleton()->window_get_size();
 		Vector2i screen_size = DisplayServer::get_singleton()->screen_get_size();
 		Vector2i screen_position = DisplayServer::get_singleton()->screen_get_position();
-		window_size *= scale_factor;
+
+		// Consider the editor display scale.
+		window_size.x = round((float)window_size.x * scale_factor);
+		window_size.y = round((float)window_size.y * scale_factor);
+
+		// Make the window centered on the screen.
 		Vector2i window_position;
 		window_position.x = screen_position.x + (screen_size.x - window_size.x) / 2;
 		window_position.y = screen_position.y + (screen_size.y - window_size.y) / 2;
+
 		DisplayServer::get_singleton()->window_set_size(window_size);
 		DisplayServer::get_singleton()->window_set_position(window_position);
 	}


### PR DESCRIPTION
When deciding the window size for the project manager, the display scale factor is taken into account but is converted to integer when calculating the scaled window size. As a result, the window fails to center itself properly on the screen.