### PR TITLE
Fix project manager window centering in multi-monitor situation

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2872,10 +2872,11 @@ ProjectManager::ProjectManager() {
 	if (scale_factor > 1.0) {
 		Vector2i window_size = DisplayServer::get_singleton()->window_get_size();
 		Vector2i screen_size = DisplayServer::get_singleton()->screen_get_size();
+		Vector2i screen_position = DisplayServer::get_singleton()->screen_get_position();
 		window_size *= scale_factor;
 		Vector2i window_position;
-		window_position.x = (screen_size.x - window_size.x) / 2;
-		window_position.y = (screen_size.y - window_size.y) / 2;
+		window_position.x = screen_position.x + (screen_size.x - window_size.x) / 2;
+		window_position.y = screen_position.y + (screen_size.y - window_size.y) / 2;
 		DisplayServer::get_singleton()->window_set_size(window_size);
 		DisplayServer::get_singleton()->window_set_position(window_position);
 	}


### PR DESCRIPTION
This pull request fixed an issue that when main screen's position in not (0,0) and editor scale is larger than 1, the project manager window was not centered in main screen.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
