### PR TITLE
Implement context-based separate undo/redo stacks

### DIFF
--- a/core/object/undo_redo.h
+++ b/core/object/undo_redo.h
@@ -77,13 +77,25 @@ private:
 		uint64_t last_tick;
 	};
 
-	Vector<Action> actions;
-	int current_action = -1;
+	struct Context {
+		Vector<Action> actions;
+		int current_action;
+	};
+
+	static ObjectID get_context_id_default() { return ObjectID(uint64_t()); };
+
+	Map<ObjectID, Context> context_actions;
+	Vector<Action> *p_actions;
+	Action action;
+	int *p_current_action;
+
 	bool force_keep_in_merge_ends = false;
 	int action_level = 0;
 	MergeMode merge_mode = MERGE_DISABLE;
 	bool merging = false;
+	bool discarding_redo = false;
 	uint64_t version = 1;
+	ObjectID object_context_id;
 
 	void _pop_history_tail();
 	void _process_operation_list(List<Operation>::Element *E);
@@ -105,6 +117,8 @@ protected:
 
 public:
 	void create_action(const String &p_name = "", MergeMode p_mode = MERGE_DISABLE);
+	void set_action_context(Object *p_object);
+	void set_editor_context(ObjectID object_id = get_context_id_default());
 
 	void add_do_methodp(Object *p_object, const StringName &p_method, const Variant **p_args, int p_argcount);
 	void add_undo_methodp(Object *p_object, const StringName &p_method, const Variant **p_args, int p_argcount);
@@ -143,15 +157,15 @@ public:
 
 	bool redo();
 	bool undo();
-	String get_current_action_name() const;
+	String get_current_action_name(ObjectID object_id = get_context_id_default()) const;
 
 	int get_history_count();
 	int get_current_action();
 	String get_action_name(int p_id);
 	void clear_history(bool p_increase_version = true);
 
-	bool has_undo() const;
-	bool has_redo() const;
+	bool has_undo(ObjectID object_id = get_context_id_default()) const;
+	bool has_redo(ObjectID object_id = get_context_id_default()) const;
 
 	uint64_t get_version() const;
 
@@ -160,7 +174,7 @@ public:
 	void set_method_notify_callback(MethodNotifyCallback p_method_callback, void *p_ud);
 	void set_property_notify_callback(PropertyNotifyCallback p_property_callback, void *p_ud);
 
-	UndoRedo() {}
+	UndoRedo();
 	~UndoRedo();
 };
 

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -6026,6 +6026,8 @@ void AnimationTrackEditor::_select_all_tracks_for_copy() {
 }
 
 void AnimationTrackEditor::_bind_methods() {
+	ClassDB::bind_method("get_current_animation", &AnimationTrackEditor::get_current_animation);
+
 	ClassDB::bind_method("_animation_update", &AnimationTrackEditor::_animation_update);
 	ClassDB::bind_method("_track_grab_focus", &AnimationTrackEditor::_track_grab_focus);
 	ClassDB::bind_method("_update_tracks", &AnimationTrackEditor::_update_tracks);

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3555,6 +3555,12 @@ void EditorInspector::_notification(int p_what) {
 			changing--;
 		} break;
 
+		case NOTIFICATION_DRAW: {
+			if (has_focus()) {
+				draw_style_box(get_theme_stylebox("Focus", "EditorStyles"), Rect2(Vector2(), get_size()));
+			}
+		} break;
+
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			_update_inspector_bg();
 
@@ -3773,6 +3779,8 @@ void EditorInspector::_show_add_meta_dialog() {
 }
 
 void EditorInspector::_bind_methods() {
+	ClassDB::bind_method("get_edited_object", &EditorInspector::get_edited_object);
+
 	ClassDB::bind_method("_edit_request_change", &EditorInspector::_edit_request_change);
 
 	ADD_SIGNAL(MethodInfo("property_selected", PropertyInfo(Variant::STRING, "property")));
@@ -3794,6 +3802,7 @@ EditorInspector::EditorInspector() {
 	main_vbox->add_theme_constant_override("separation", 0);
 	add_child(main_vbox);
 	set_horizontal_scroll_mode(SCROLL_MODE_DISABLED);
+	set_focus_mode(FocusMode::FOCUS_ALL);
 
 	changing = 0;
 	search_box = nullptr;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -639,6 +639,19 @@ private:
 	void _update_layouts_menu();
 	void _layout_menu_option(int p_id);
 
+	struct EditorUndoContext {
+		Object *p_editor;
+		String p_get_edited_object;
+		bool returns_ref;
+		ObjectID constant_object_id;
+		bool use_constant_id;
+	};
+
+	Map<String, EditorUndoContext> undo_contexts;
+	Map<String, EditorUndoContext *> undo_context_links;
+
+	void _register_undo_context(String dock_name, Object *p_editor, String editor_class = "", String p_get_edited_object = "", bool returns_ref = false);
+
 	void _clear_undo_history();
 
 	void _update_addon_config();
@@ -694,6 +707,8 @@ public:
 	static EditorData &get_editor_data() { return singleton->editor_data; }
 	static EditorFolding &get_editor_folding() { return singleton->editor_folding; }
 	static UndoRedo *get_undo_redo() { return &singleton->editor_data.get_undo_redo(); }
+
+	ObjectID get_edited_object_id();
 
 	static HBoxContainer *get_menu_hb() { return singleton->menu_hb; }
 	static VSplitContainer *get_top_split() { return singleton->top_split; }

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -211,7 +211,9 @@ void ProjectSettingsEditor::unhandled_input(const Ref<InputEvent> &p_event) {
 		bool handled = false;
 
 		if (ED_IS_SHORTCUT("ui_undo", p_event)) {
-			String action = undo_redo->get_current_action_name();
+			ObjectID object_id = EditorNode::get_singleton()->get_edited_object_id();
+			undo_redo->set_editor_context(object_id);
+			String action = undo_redo->get_current_action_name(object_id);
 			if (!action.is_empty()) {
 				EditorNode::get_log()->add_message("Undo: " + action, EditorLog::MSG_TYPE_EDITOR);
 			}
@@ -220,8 +222,10 @@ void ProjectSettingsEditor::unhandled_input(const Ref<InputEvent> &p_event) {
 		}
 
 		if (ED_IS_SHORTCUT("ui_redo", p_event)) {
+			ObjectID object_id = EditorNode::get_singleton()->get_edited_object_id();
+			undo_redo->set_editor_context(object_id);
 			undo_redo->redo();
-			String action = undo_redo->get_current_action_name();
+			String action = undo_redo->get_current_action_name(object_id);
 			if (!action.is_empty()) {
 				EditorNode::get_log()->add_message("Redo: " + action, EditorLog::MSG_TYPE_EDITOR);
 			}

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -4485,6 +4485,8 @@ void VisualScriptEditor::update_toggle_scripts_button() {
 }
 
 void VisualScriptEditor::_bind_methods() {
+	ClassDB::bind_method("get_edited_resource", &VisualScriptEditor::get_edited_resource);
+
 	ClassDB::bind_method("_move_node", &VisualScriptEditor::_move_node);
 	ClassDB::bind_method("_update_graph", &VisualScriptEditor::_update_graph, DEFVAL(-1));
 


### PR DESCRIPTION
See [this proposal](https://github.com/godotengine/godot-proposals/issues/4284) for a description and my argument for contextual undo.

This PR is mainly intended to continue discussions on how per-scene undo may be implemented; 'contextual undo' is just one idea I had for doing it, and other ideas would be gratefully accepted.

Note that this modifies the internals of `undo_redo.cpp` in order to let it support multiple stacks, but essentially the same approach could be used except with using one `UndoRedo` object per stack; the API would be changed in a different way and this would be a more object-oriented approach, I just happened to prefer the processing and memory benefits of not instantiating the relatively heavy `UndoRedo` class multiple times. This 'contextual undo' implementation is focused on an approach to separating stacks and handling context, so the details of how different stacks are accessed are less important.

https://user-images.githubusercontent.com/66553618/160278845-78333a5a-ccbb-4127-8f52-d369ae01cf27.mp4