### PR TITLE
Object: Remove unused category boilerplate

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -2093,10 +2093,6 @@ int ClassDB::get_integer_constant(const StringName &p_class, const StringName &p
 	return c;
 }
 
-StringName ClassDB::get_category(const StringName &p_node) const {
-	return ::ClassDB::get_category(p_node);
-}
-
 bool ClassDB::has_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance) const {
 	return ::ClassDB::has_enum(p_class, p_name, p_no_inheritance);
 }
@@ -2168,7 +2164,6 @@ void ClassDB::_bind_methods() {
 	::ClassDB::bind_method(D_METHOD("class_get_enum_constants", "class", "enum", "no_inheritance"), &ClassDB::get_enum_constants, DEFVAL(false));
 	::ClassDB::bind_method(D_METHOD("class_get_integer_constant_enum", "class", "name", "no_inheritance"), &ClassDB::get_integer_constant_enum, DEFVAL(false));
 
-	::ClassDB::bind_method(D_METHOD("class_get_category", "class"), &ClassDB::get_category);
 	::ClassDB::bind_method(D_METHOD("is_class_enabled", "class"), &ClassDB::is_class_enabled);
 }
 

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -604,7 +604,6 @@ public:
 	PackedStringArray get_integer_constant_list(const StringName &p_class, bool p_no_inheritance = false) const;
 	bool has_integer_constant(const StringName &p_class, const StringName &p_name) const;
 	int get_integer_constant(const StringName &p_class, const StringName &p_name) const;
-	StringName get_category(const StringName &p_node) const;
 
 	bool has_enum(const StringName &p_class, const StringName &p_name, bool p_no_inheritance = false) const;
 	PackedStringArray get_enum_list(const StringName &p_class, bool p_no_inheritance = false) const;

--- a/core/doc_data.h
+++ b/core/doc_data.h
@@ -152,7 +152,7 @@ public:
 	struct ClassDoc {
 		String name;
 		String inherits;
-		String category;
+		String category; // FIXME: Wrongly used by VisualScriptPropertySelector, should be removed.
 		String brief_description;
 		String description;
 		Vector<TutorialDoc> tutorials;

--- a/core/io/ip.h
+++ b/core/io/ip.h
@@ -38,7 +38,6 @@ struct _IP_ResolverPrivate;
 
 class IP : public Object {
 	GDCLASS(IP, Object);
-	OBJ_CATEGORY("Networking");
 
 public:
 	enum ResolverStatus {

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -48,7 +48,6 @@ private:
 
 class Resource : public RefCounted {
 	GDCLASS(Resource, RefCounted);
-	OBJ_CATEGORY("Resources");
 
 public:
 	static void register_custom_data_to_otdb() { ClassDB::add_resource_base_extension("res", get_class_static()); }

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -39,7 +39,6 @@
 
 class StreamPeer : public RefCounted {
 	GDCLASS(StreamPeer, RefCounted);
-	OBJ_CATEGORY("Networking");
 
 protected:
 	static void _bind_methods();

--- a/core/io/stream_peer_tcp.h
+++ b/core/io/stream_peer_tcp.h
@@ -38,7 +38,6 @@
 
 class StreamPeerTCP : public StreamPeer {
 	GDCLASS(StreamPeerTCP, StreamPeer);
-	OBJ_CATEGORY("Networking");
 
 public:
 	enum Status {

--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -1551,15 +1551,6 @@ bool ClassDB::is_class_exposed(const StringName &p_class) {
 	return ti->exposed;
 }
 
-StringName ClassDB::get_category(const StringName &p_node) {
-	ERR_FAIL_COND_V(!classes.has(p_node), StringName());
-#ifdef DEBUG_ENABLED
-	return classes[p_node].category;
-#else
-	return StringName();
-#endif
-}
-
 void ClassDB::add_resource_base_extension(const StringName &p_extension, const StringName &p_class) {
 	if (resource_base_extensions.has(p_extension)) {
 		return;

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -109,7 +109,6 @@ public:
 		Set<StringName> methods_in_properties;
 		List<MethodInfo> virtual_methods;
 		Map<StringName, MethodInfo> virtual_methods_map;
-		StringName category;
 		Map<StringName, Vector<Error>> method_error_values;
 #endif
 		HashMap<StringName, PropertySetGet> property_setget;
@@ -330,8 +329,6 @@ public:
 	static void set_method_error_return_values(const StringName &p_class, const StringName &p_method, const Vector<Error> &p_values);
 	static Vector<Error> get_method_error_return_values(const StringName &p_class, const StringName &p_method);
 	static Variant class_get_default_property_value(const StringName &p_class, const StringName &p_property, bool *r_valid = nullptr);
-
-	static StringName get_category(const StringName &p_node);
 
 	static void set_class_enabled(const StringName &p_class, bool p_enable);
 	static bool is_class_enabled(const StringName &p_class);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -344,16 +344,6 @@ public:                                                                         
 		m_inherits::get_inheritance_list_static(p_inheritance_list);                                                                             \
 		p_inheritance_list->push_back(String(#m_class));                                                                                         \
 	}                                                                                                                                            \
-	static String get_category_static() {                                                                                                        \
-		String category = m_inherits::get_category_static();                                                                                     \
-		if (_get_category != m_inherits::_get_category) {                                                                                        \
-			if (!category.is_empty()) {                                                                                                          \
-				category += "/";                                                                                                                 \
-			}                                                                                                                                    \
-			category += _get_category();                                                                                                         \
-		}                                                                                                                                        \
-		return category;                                                                                                                         \
-	}                                                                                                                                            \
 	virtual bool is_class(const String &p_class) const override {                                                                                \
 		if (_get_extension() && _get_extension()->is_class(p_class)) {                                                                           \
 			return true;                                                                                                                         \
@@ -452,12 +442,6 @@ protected:                                                                      
 		}                                                                                                                                        \
 	}                                                                                                                                            \
                                                                                                                                                  \
-private:
-
-#define OBJ_CATEGORY(m_category)                                        \
-protected:                                                              \
-	_FORCE_INLINE_ static String _get_category() { return m_category; } \
-                                                                        \
 private:
 
 #define OBJ_SAVE_TYPE(m_class)                                          \
@@ -590,7 +574,6 @@ protected:
 	virtual void _get_property_listv(List<PropertyInfo> *p_list, bool p_reversed) const {};
 	virtual void _notificationv(int p_notification, bool p_reversed) {}
 
-	static String _get_category() { return ""; }
 	static void _bind_methods();
 	bool _set(const StringName &p_name, const Variant &p_property) { return false; };
 	bool _get(const StringName &p_name, Variant &r_property) const { return false; };
@@ -694,7 +677,6 @@ public:
 
 	static String get_class_static() { return "Object"; }
 	static String get_parent_class_static() { return String(); }
-	static String get_category_static() { return String(); }
 
 	virtual String get_class() const {
 		if (_extension) {

--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -38,7 +38,6 @@
 
 class MainLoop : public Object {
 	GDCLASS(MainLoop, Object);
-	OBJ_CATEGORY("Main Loop");
 
 	Ref<Script> initialize_script;
 

--- a/doc/classes/ClassDB.xml
+++ b/doc/classes/ClassDB.xml
@@ -23,13 +23,6 @@
 				Returns whether the specified [code]class[/code] is available or not.
 			</description>
 		</method>
-		<method name="class_get_category" qualifiers="const">
-			<return type="StringName" />
-			<argument index="0" name="class" type="StringName" />
-			<description>
-				Returns a category associated with the class for use in documentation and the Asset Library. Debug mode required.
-			</description>
-		</method>
 		<method name="class_get_enum_constants" qualifiers="const">
 			<return type="PackedStringArray" />
 			<argument index="0" name="class" type="StringName" />

--- a/scene/3d/collision_shape_3d.h
+++ b/scene/3d/collision_shape_3d.h
@@ -37,7 +37,6 @@
 class CollisionObject3D;
 class CollisionShape3D : public Node3D {
 	GDCLASS(CollisionShape3D, Node3D);
-	OBJ_CATEGORY("3D Physics Nodes");
 
 	Ref<Shape3D> shape;
 

--- a/scene/3d/light_3d.h
+++ b/scene/3d/light_3d.h
@@ -35,7 +35,6 @@
 
 class Light3D : public VisualInstance3D {
 	GDCLASS(Light3D, VisualInstance3D);
-	OBJ_CATEGORY("3D Light Nodes");
 
 public:
 	enum Param {

--- a/scene/3d/node_3d.h
+++ b/scene/3d/node_3d.h
@@ -50,7 +50,6 @@ public:
 
 class Node3D : public Node {
 	GDCLASS(Node3D, Node);
-	OBJ_CATEGORY("3D");
 
 public:
 	enum RotationEditMode {

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -35,7 +35,6 @@
 
 class VisualInstance3D : public Node3D {
 	GDCLASS(VisualInstance3D, Node3D);
-	OBJ_CATEGORY("3D Visual Nodes");
 
 	RID base;
 	RID instance;

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -62,7 +62,6 @@ public:
 
 class AnimationPlayer : public Node {
 	GDCLASS(AnimationPlayer, Node);
-	OBJ_CATEGORY("Animation Nodes");
 
 public:
 	enum AnimationProcessCallback {

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -44,7 +44,6 @@ class Panel;
 
 class Control : public CanvasItem {
 	GDCLASS(Control, CanvasItem);
-	OBJ_CATEGORY("GUI Nodes");
 
 public:
 	enum Anchor {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -43,7 +43,6 @@ class PropertyTweener;
 
 class Node : public Object {
 	GDCLASS(Node, Object);
-	OBJ_CATEGORY("Nodes");
 
 public:
 	enum ProcessMode {


### PR DESCRIPTION
We might want to re-add something like this if/when we find a good use case
for it and do the effort to categorize all objects in the API properly.

Until then, it's better to remove that boilerplate since it's not needed.

Closes #18711.

@godotengine/visualscript The `VisualScriptPropertySelector` kind of abuses `ClassDoc::category` to pass its own metadata around, which was not the intended use for this field. This should likely be refactored so that `category` can be removed from `ClassDoc`.