### PR TITLE
Add configuration warning for SubViewportContainer

### DIFF
--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -223,6 +223,23 @@ void SubViewportContainer::unhandled_input(const Ref<InputEvent> &p_event) {
 	}
 }
 
+TypedArray<String> SubViewportContainer::get_configuration_warnings() const {
+	TypedArray<String> warnings = Node::get_configuration_warnings();
+
+	bool has_viewport = false;
+	for (int i = 0; i < get_child_count(); i++) {
+		if (Object::cast_to<SubViewport>(get_child(i))) {
+			has_viewport = true;
+			break;
+		}
+	}
+	if (!has_viewport) {
+		warnings.push_back(TTR("This node doesn't have a SubViewport as child, so it can't display its intended content.\nConsider adding a SubViewport as a child to provide something displayable."));
+	}
+
+	return warnings;
+}
+
 void SubViewportContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_stretch", "enable"), &SubViewportContainer::set_stretch);
 	ClassDB::bind_method(D_METHOD("is_stretch_enabled"), &SubViewportContainer::is_stretch_enabled);

--- a/scene/gui/subviewport_container.h
+++ b/scene/gui/subviewport_container.h
@@ -58,6 +58,8 @@ public:
 	virtual Vector<int> get_allowed_size_flags_horizontal() const override;
 	virtual Vector<int> get_allowed_size_flags_vertical() const override;
 
+	TypedArray<String> get_configuration_warnings() const override;
+
 	SubViewportContainer();
 };
 


### PR DESCRIPTION
Display a warning when a `SubViewportContainer` doesn't have a `SubViewport` as child.