### PR TITLE
HTML5: Explain why export templates are missing

### DIFF
--- a/platform/javascript/export/export_plugin.cpp
+++ b/platform/javascript/export/export_plugin.cpp
@@ -360,6 +360,15 @@ Ref<Texture2D> EditorExportPlatformJavaScript::get_logo() const {
 }
 
 bool EditorExportPlatformJavaScript::can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const {
+#ifndef DEV_ENABLED
+	// We don't provide export templates for the HTML5 platform currently as there
+	// is no suitable renderer to use with them. So we forbid exporting and tell
+	// users why. This is skipped in DEV_ENABLED so that contributors can still test
+	// the pipeline once we start having WebGL or WebGPU support.
+	r_error = "The HTML5 platform is currently not supported in Godot 4.0, as there is no suitable renderer for it.\n";
+	return false;
+#endif
+
 	String err;
 	bool valid = false;
 	ExportMode mode = (ExportMode)(int)p_preset->get("variant/export_type");

--- a/platform/uwp/export/export_plugin.cpp
+++ b/platform/uwp/export/export_plugin.cpp
@@ -131,6 +131,14 @@ void EditorExportPlatformUWP::get_export_options(List<ExportOption> *r_options) 
 }
 
 bool EditorExportPlatformUWP::can_export(const Ref<EditorExportPreset> &p_preset, String &r_error, bool &r_missing_templates) const {
+#ifndef DEV_ENABLED
+	// We don't provide export templates for the UWP platform currently as it
+	// has not been ported for Godot 4.0. This is skipped in DEV_ENABLED so that
+	// contributors can still test the pipeline if/when we can build it again.
+	r_error = "The UWP platform is currently not supported in Godot 4.0.\n";
+	return false;
+#endif
+
 	String err;
 	bool valid = false;
 


### PR DESCRIPTION
Same for UWP.

This is skipped in DEV_ENABLED builds so contributors can still test
the export pipeline (and CI still compiles it on debug builds).

- Closes #59476.