### PR TITLE
Hide "Normal Map" import option when using lossless compression

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -171,6 +171,11 @@ bool ResourceImporterTexture::get_option_visibility(const String &p_path, const 
 		if (compress_mode < COMPRESS_VRAM_COMPRESSED) {
 			return false;
 		}
+	} else if (p_option == "compress/normal_map") {
+		int compress_mode = int(p_options["compress/mode"]);
+		if (compress_mode == COMPRESS_LOSSLESS) {
+			return false;
+		}
 	} else if (p_option == "mipmaps/limit") {
 		return p_options["mipmaps/generate"];
 


### PR DESCRIPTION
This pull request resolves an issue where images being imported with lossless compression allowed you to select a normal map, but the normal map only applies if you're using VRAM compression. Thereby making it redundant to appear when using lossless compression. This pull request hides the normal map option when lossless compression is selected.

https://user-images.githubusercontent.com/62965063/160260442-0b38ee46-fe11-4cfb-8400-1da354717d06.mp4

Resolves: #59435
