### PR TITLE
[Net] Socket polling for blocking input in HTTPClient.

### DIFF
--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -742,6 +742,7 @@ Error HTTPClientTCP::_get_http_data(uint8_t *p_buffer, int p_bytes, int &r_recei
 				return err;
 			}
 			left -= read;
+			tcp_connection->poll(NetSocket::POLL_TYPE_IN, 1000);
 		}
 		return err;
 	} else {

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -176,7 +176,11 @@ void HTTPRequest::_thread_func(void *p_userdata) {
 			if (exit) {
 				break;
 			}
-			OS::get_singleton()->delay_usec(1);
+			// Reduce CPU usage when not dowloading.
+			// While downloading, poll is used by HTTPClient to retrieve data in blocking mode.
+			if (hr->client->get_status() != HTTPClient::STATUS_BODY) {
+				OS::get_singleton()->delay_usec(1000);
+			}
 		}
 	}
 


### PR DESCRIPTION
This commit changes the HTTPClient to rely on socket polling instead of busy waiting when reading incoming data in blocking mode.

It also increases HTTPRequest delay usec time when not downloading (which reduces CPU usage during connecting/connected phase).

Potential fix for #35868 which should not impact download speed.