### PR TITLE
[Net] StreamPeer::get_data now always returns the number of bytes read.

### DIFF
--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -66,13 +66,15 @@ void FileAccessNetworkClient::put_64(int64_t p_64) {
 
 int FileAccessNetworkClient::get_32() {
 	uint8_t buf[4];
-	client->get_data(buf, 4);
+	int read;
+	client->get_data(buf, 4, read);
 	return decode_uint32(buf);
 }
 
 int64_t FileAccessNetworkClient::get_64() {
 	uint8_t buf[8];
-	client->get_data(buf, 8);
+	int read;
+	client->get_data(buf, 8, read);
 	return decode_uint64(buf);
 }
 
@@ -136,10 +138,11 @@ void FileAccessNetworkClient::_thread_func() {
 			case FileAccessNetwork::RESPONSE_DATA: {
 				int64_t offset = get_64();
 				int32_t len = get_32();
+				int read = 0;
 
 				Vector<uint8_t> block;
 				block.resize(len);
-				client->get_data(block.ptrw(), len);
+				client->get_data(block.ptrw(), len, read);
 
 				if (fa) { //may have been queued
 					fa->_set_block(offset, block);

--- a/core/io/http_client_tcp.cpp
+++ b/core/io/http_client_tcp.cpp
@@ -725,25 +725,7 @@ bool HTTPClientTCP::is_blocking_mode_enabled() const {
 
 Error HTTPClientTCP::_get_http_data(uint8_t *p_buffer, int p_bytes, int &r_received) {
 	if (blocking) {
-		// We can't use StreamPeer.get_data, since when reaching EOF we will get an
-		// error without knowing how many bytes we received.
-		Error err = ERR_FILE_EOF;
-		int read = 0;
-		int left = p_bytes;
-		r_received = 0;
-		while (left > 0) {
-			err = connection->get_partial_data(p_buffer + r_received, left, read);
-			if (err == OK) {
-				r_received += read;
-			} else if (err == ERR_FILE_EOF) {
-				r_received += read;
-				return err;
-			} else {
-				return err;
-			}
-			left -= read;
-		}
-		return err;
+		return connection->get_data(p_buffer + r_received, p_bytes, r_received);
 	} else {
 		return connection->get_partial_data(p_buffer, p_bytes, r_received);
 	}

--- a/core/io/stream_peer.h
+++ b/core/io/stream_peer.h
@@ -57,7 +57,7 @@ public:
 	virtual Error put_data(const uint8_t *p_data, int p_bytes) = 0; ///< put a whole chunk of data, blocking until it sent
 	virtual Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) = 0; ///< put as much data as possible, without blocking.
 
-	virtual Error get_data(uint8_t *p_buffer, int p_bytes) = 0; ///< read p_bytes of data, if p_bytes > available, it will block
+	virtual Error get_data(uint8_t *p_buffer, int p_bytes, int &r_received) = 0; ///< read p_bytes of data, if p_bytes > available, it will block
 	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) = 0; ///< read as much data as p_bytes into buffer, if less was read, return in r_received
 
 	virtual int get_available_bytes() const = 0;
@@ -106,7 +106,7 @@ protected:
 public:
 	virtual Error put_data(const uint8_t *p_data, int p_bytes) override;
 	virtual Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) override;
-	virtual Error get_data(uint8_t *p_buffer, int p_bytes) override;
+	virtual Error get_data(uint8_t *p_buffer, int p_bytes, int &r_received) override;
 	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) override;
 	virtual int get_available_bytes() const override;
 
@@ -130,7 +130,7 @@ public:
 	Error put_data(const uint8_t *p_data, int p_bytes) override;
 	Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) override;
 
-	Error get_data(uint8_t *p_buffer, int p_bytes) override;
+	Error get_data(uint8_t *p_buffer, int p_bytes, int &r_received) override;
 	Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) override;
 
 	virtual int get_available_bytes() const override;

--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -301,9 +301,8 @@ Error StreamPeerTCP::put_partial_data(const uint8_t *p_data, int p_bytes, int &r
 	return write(p_data, p_bytes, r_sent, false);
 }
 
-Error StreamPeerTCP::get_data(uint8_t *p_buffer, int p_bytes) {
-	int total;
-	return read(p_buffer, p_bytes, total, true);
+Error StreamPeerTCP::get_data(uint8_t *p_buffer, int p_bytes, int &r_received) {
+	return read(p_buffer, p_bytes, r_received, true);
 }
 
 Error StreamPeerTCP::get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) {

--- a/core/io/stream_peer_tcp.h
+++ b/core/io/stream_peer_tcp.h
@@ -84,7 +84,7 @@ public:
 	// Read/Write from StreamPeer
 	Error put_data(const uint8_t *p_data, int p_bytes) override;
 	Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent) override;
-	Error get_data(uint8_t *p_buffer, int p_bytes) override;
+	Error get_data(uint8_t *p_buffer, int p_bytes, int &r_received) override;
 	Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received) override;
 
 	StreamPeerTCP();

--- a/editor/fileserver/editor_file_server.cpp
+++ b/editor/fileserver/editor_file_server.cpp
@@ -57,7 +57,8 @@ void EditorFileServer::_subthread_start(void *s) {
 
 	cd->connection->set_no_delay(true);
 	uint8_t buf4[8];
-	Error err = cd->connection->get_data(buf4, 4);
+	int read = 0;
+	Error err = cd->connection->get_data(buf4, 4, read);
 	if (err != OK) {
 		_close_client(cd);
 		ERR_FAIL_COND(err != OK);
@@ -71,7 +72,7 @@ void EditorFileServer::_subthread_start(void *s) {
 	} else if (passlen > 0) {
 		Vector<char> passutf8;
 		passutf8.resize(passlen + 1);
-		err = cd->connection->get_data((uint8_t *)passutf8.ptr(), passlen);
+		err = cd->connection->get_data((uint8_t *)passutf8.ptr(), passlen, read);
 		if (err != OK) {
 			_close_client(cd);
 			ERR_FAIL_COND(err != OK);
@@ -103,7 +104,7 @@ void EditorFileServer::_subthread_start(void *s) {
 
 	while (!cd->quit) {
 		//wait for ID
-		err = cd->connection->get_data(buf4, 4);
+		err = cd->connection->get_data(buf4, 4, read);
 		DEBUG_TIME("get_data")
 
 		if (err != OK) {
@@ -113,7 +114,7 @@ void EditorFileServer::_subthread_start(void *s) {
 		int id = decode_uint32(buf4);
 
 		//wait for command
-		err = cd->connection->get_data(buf4, 4);
+		err = cd->connection->get_data(buf4, 4, read);
 		if (err != OK) {
 			_close_client(cd);
 			ERR_FAIL_COND(err != OK);
@@ -125,7 +126,7 @@ void EditorFileServer::_subthread_start(void *s) {
 			case FileAccessNetwork::COMMAND_GET_MODTIME:
 			case FileAccessNetwork::COMMAND_OPEN_FILE: {
 				DEBUG_TIME("open_file")
-				err = cd->connection->get_data(buf4, 4);
+				err = cd->connection->get_data(buf4, 4, read);
 				if (err != OK) {
 					_close_client(cd);
 					ERR_FAIL_COND(err != OK);
@@ -134,7 +135,7 @@ void EditorFileServer::_subthread_start(void *s) {
 				int namelen = decode_uint32(buf4);
 				Vector<char> fileutf8;
 				fileutf8.resize(namelen + 1);
-				err = cd->connection->get_data((uint8_t *)fileutf8.ptr(), namelen);
+				err = cd->connection->get_data((uint8_t *)fileutf8.ptr(), namelen, read);
 				if (err != OK) {
 					_close_client(cd);
 					ERR_FAIL_COND(err != OK);
@@ -208,7 +209,7 @@ void EditorFileServer::_subthread_start(void *s) {
 
 			} break;
 			case FileAccessNetwork::COMMAND_READ_BLOCK: {
-				err = cd->connection->get_data(buf4, 8);
+				err = cd->connection->get_data(buf4, 8, read);
 				if (err != OK) {
 					_close_client(cd);
 					ERR_FAIL_COND(err != OK);
@@ -218,7 +219,7 @@ void EditorFileServer::_subthread_start(void *s) {
 
 				uint64_t offset = decode_uint64(buf4);
 
-				err = cd->connection->get_data(buf4, 4);
+				err = cd->connection->get_data(buf4, 4, read);
 				if (err != OK) {
 					_close_client(cd);
 					ERR_FAIL_COND(err != OK);
@@ -230,7 +231,7 @@ void EditorFileServer::_subthread_start(void *s) {
 				cd->files[id]->seek(offset);
 				Vector<uint8_t> buf;
 				buf.resize(blocklen);
-				uint32_t read = cd->files[id]->get_buffer(buf.ptrw(), blocklen);
+				uint32_t size = cd->files[id]->get_buffer(buf.ptrw(), blocklen);
 
 				print_verbose("GET BLOCK - offset: " + itos(offset) + ", blocklen: " + itos(blocklen));
 
@@ -241,9 +242,9 @@ void EditorFileServer::_subthread_start(void *s) {
 				cd->connection->put_data(buf4, 4);
 				encode_uint64(offset, buf4);
 				cd->connection->put_data(buf4, 8);
-				encode_uint32(read, buf4);
+				encode_uint32(size, buf4);
 				cd->connection->put_data(buf4, 4);
-				cd->connection->put_data(buf.ptr(), read);
+				cd->connection->put_data(buf.ptr(), size);
 
 			} break;
 			case FileAccessNetwork::COMMAND_CLOSE: {

--- a/modules/mbedtls/stream_peer_mbedtls.h
+++ b/modules/mbedtls/stream_peer_mbedtls.h
@@ -47,10 +47,13 @@ private:
 	static int bio_send(void *ctx, const unsigned char *buf, size_t len);
 	void _cleanup();
 
+	bool blocking = false;
+
 protected:
 	Ref<SSLContextMbedTLS> ssl_ctx;
 
 	Error _do_handshake();
+	Error read(uint8_t *p_buffer, int p_bytes, int &r_received, bool p_block);
 
 public:
 	virtual void poll();
@@ -63,7 +66,7 @@ public:
 	virtual Error put_data(const uint8_t *p_data, int p_bytes);
 	virtual Error put_partial_data(const uint8_t *p_data, int p_bytes, int &r_sent);
 
-	virtual Error get_data(uint8_t *p_buffer, int p_bytes);
+	virtual Error get_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 	virtual Error get_partial_data(uint8_t *p_buffer, int p_bytes, int &r_received);
 
 	virtual int get_available_bytes() const;

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -176,7 +176,11 @@ void HTTPRequest::_thread_func(void *p_userdata) {
 			if (exit) {
 				break;
 			}
-			OS::get_singleton()->delay_usec(1);
+			// Reduce CPU usage when not dowloading.
+			// While downloading, poll is used by HTTPClient to retrieve data in blocking mode.
+			if (hr->client->get_status() != HTTPClient::STATUS_BODY) {
+				OS::get_singleton()->delay_usec(1000);
+			}
 		}
 	}
 


### PR DESCRIPTION
HTTPClient now uses StreamPeer::get_data in blocking mode.

Increase HTTPRequest delay usec time when not downloading (which reduces CPU usage during connecting/connected phase).

Potential fix for #35868 .

Conflicting with #59579 worth discussing which approach we want to take in a meeting.