### PR TITLE
Set thorvg threads to be one to avoid SVG import crash.

### DIFF
--- a/modules/svg/register_types.cpp
+++ b/modules/svg/register_types.cpp
@@ -38,7 +38,7 @@ static ImageLoaderSVG *image_loader_svg = nullptr;
 
 void register_svg_types() {
 	tvg::CanvasEngine tvgEngine = tvg::CanvasEngine::Sw;
-	if (tvg::Initializer::init(tvgEngine, 0) != tvg::Result::Success) {
+	if (tvg::Initializer::init(tvgEngine, 1) != tvg::Result::Success) {
 		return;
 	}
 	image_loader_svg = memnew(ImageLoaderSVG);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/48243.

Test cases:
[icons.zip](https://github.com/godotengine/godot/files/8358086/icons.zip)

