### PR TITLE
[Net] Change HTTPRequest timeout type to double.

### DIFF
--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -247,7 +247,7 @@
 		<member name="max_redirects" type="int" setter="set_max_redirects" getter="get_max_redirects" default="8">
 			Maximum number of allowed redirects.
 		</member>
-		<member name="timeout" type="int" setter="set_timeout" getter="get_timeout" default="0">
+		<member name="timeout" type="float" setter="set_timeout" getter="get_timeout" default="0.0">
 		</member>
 		<member name="use_threads" type="bool" setter="set_use_threads" getter="is_using_threads" default="false">
 			If [code]true[/code], multithreading is used to improve performance.

--- a/scene/main/http_request.cpp
+++ b/scene/main/http_request.cpp
@@ -558,12 +558,12 @@ void HTTPRequest::set_https_proxy(const String &p_host, int p_port) {
 	client->set_https_proxy(p_host, p_port);
 }
 
-void HTTPRequest::set_timeout(int p_timeout) {
+void HTTPRequest::set_timeout(double p_timeout) {
 	ERR_FAIL_COND(p_timeout < 0);
 	timeout = p_timeout;
 }
 
-int HTTPRequest::get_timeout() {
+double HTTPRequest::get_timeout() {
 	return timeout;
 }
 
@@ -615,7 +615,7 @@ void HTTPRequest::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "accept_gzip"), "set_accept_gzip", "is_accepting_gzip");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "body_size_limit", PROPERTY_HINT_RANGE, "-1,2000000000"), "set_body_size_limit", "get_body_size_limit");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_redirects", PROPERTY_HINT_RANGE, "-1,64"), "set_max_redirects", "get_max_redirects");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "timeout", PROPERTY_HINT_RANGE, "0,86400"), "set_timeout", "get_timeout");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "timeout", PROPERTY_HINT_RANGE, "0,3600,0.1,or_greater"), "set_timeout", "get_timeout");
 
 	ADD_SIGNAL(MethodInfo("request_completed", PropertyInfo(Variant::INT, "result"), PropertyInfo(Variant::INT, "response_code"), PropertyInfo(Variant::PACKED_STRING_ARRAY, "headers"), PropertyInfo(Variant::PACKED_BYTE_ARRAY, "body")));
 

--- a/scene/main/http_request.h
+++ b/scene/main/http_request.h
@@ -96,7 +96,7 @@ private:
 
 	int max_redirects = 8;
 
-	int timeout = 0;
+	double timeout = 0;
 
 	void _redirect_request(const String &p_new_url);
 
@@ -146,8 +146,8 @@ public:
 
 	Timer *timer;
 
-	void set_timeout(int p_timeout);
-	int get_timeout();
+	void set_timeout(double p_timeout);
+	double get_timeout();
 
 	void _timeout();
 


### PR DESCRIPTION
For consistency with the Timer class and general time representation inside the engine.

The step is left to `0.1` since I think that's fine-grained enough.
The "high" value is set to `3600` but allows for greater values.

Fixes #44258 .