### PR TITLE
Expose local gizmos like regular gizmos.

### DIFF
--- a/doc/classes/Node3D.xml
+++ b/doc/classes/Node3D.xml
@@ -44,6 +44,18 @@
 				Returns all the gizmos attached to this [code]Node3D[/code].
 			</description>
 		</method>
+		<method name="get_global_gizmo_transform" qualifiers="const">
+			<return type="Transform3D" />
+			<description>
+				Returns the global gizmo transform.
+			</description>
+		</method>
+		<method name="get_local_gizmo_transform" qualifiers="const">
+			<return type="Transform3D" />
+			<description>
+				Returns the local gizmo transform.
+			</description>
+		</method>
 		<method name="get_parent_node_3d" qualifiers="const">
 			<return type="Node3D" />
 			<description>
@@ -94,6 +106,12 @@
 			<return type="bool" />
 			<description>
 				Returns whether this node uses a scale of [code](1, 1, 1)[/code] or its local transformation scale.
+			</description>
+		</method>
+		<method name="is_transform_gizmo_visible" qualifiers="const">
+			<return type="bool" />
+			<description>
+				Returns whether the transform gizmo is shown.
 			</description>
 		</method>
 		<method name="is_transform_notification_enabled" qualifiers="const">
@@ -233,6 +251,13 @@
 			<argument index="2" name="transform" type="Transform3D" />
 			<description>
 				Set subgizmo selection for this node in the editor.
+			</description>
+		</method>
+		<method name="set_transform_gizmo_visible">
+			<return type="void" />
+			<argument index="0" name="visible" type="bool" />
+			<description>
+				Set the transform gizmo to be shown.
 			</description>
 		</method>
 		<method name="show">

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -934,6 +934,13 @@ void Node3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_subgizmo_selection", "gizmo", "id", "transform"), &Node3D::set_subgizmo_selection);
 	ClassDB::bind_method(D_METHOD("clear_subgizmo_selection"), &Node3D::clear_subgizmo_selection);
 
+#ifdef TOOLS_ENABLED
+	ClassDB::bind_method(D_METHOD("get_global_gizmo_transform"), &Node3D::get_global_gizmo_transform);
+	ClassDB::bind_method(D_METHOD("get_local_gizmo_transform"), &Node3D::get_local_gizmo_transform);
+	ClassDB::bind_method(D_METHOD("set_transform_gizmo_visible", "visible"), &Node3D::set_transform_gizmo_visible);
+	ClassDB::bind_method(D_METHOD("is_transform_gizmo_visible"), &Node3D::is_transform_gizmo_visible);
+#endif
+
 	ClassDB::bind_method(D_METHOD("set_visible", "visible"), &Node3D::set_visible);
 	ClassDB::bind_method(D_METHOD("is_visible"), &Node3D::is_visible);
 	ClassDB::bind_method(D_METHOD("is_visible_in_tree"), &Node3D::is_visible_in_tree);


### PR DESCRIPTION
Working on PLY for Godot Engine 4. https://github.com/jarneson/godot-ply

We're unable to change the local gizmo visiblity beause it's not exposed to gdscript.

Expose the functions to gdscript.

1. Add to bind_methods..
2. ???
3. Next.

The goal is to expose to a few lines of script.

Gizmos code is core and cannot be modified outside.