### PR TITLE
Rename `Node.print_stray_nodes()` to `Node.print_orphan_nodes()`

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -483,10 +483,11 @@
 				[b]Note:[/b] Internal children can only be moved within their expected "internal range" (see [code]internal[/code] parameter in [method add_child]).
 			</description>
 		</method>
-		<method name="print_stray_nodes">
+		<method name="print_orphan_nodes">
 			<return type="void" />
 			<description>
-				Prints all stray nodes (nodes outside the [SceneTree]). Used for debugging. Works only in debug builds.
+				Prints all orphan nodes (nodes outside the [SceneTree]). Used for debugging.
+				[b]Note:[/b] [method print_orphan_nodes] only works in debug builds. When called in a project exported in release mode, [method print_orphan_nodes] will not print anything.
 			</description>
 		</method>
 		<method name="print_tree">

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2487,11 +2487,11 @@ static void _Node_debug_sn(Object *p_obj) {
 }
 #endif // DEBUG_ENABLED
 
-void Node::_print_stray_nodes() {
-	print_stray_nodes();
+void Node::_print_orphan_nodes() {
+	print_orphan_nodes();
 }
 
-void Node::print_stray_nodes() {
+void Node::print_orphan_nodes() {
 #ifdef DEBUG_ENABLED
 	ObjectDB::debug_objects(_Node_debug_sn);
 #endif
@@ -2703,7 +2703,7 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_process_mode", "mode"), &Node::set_process_mode);
 	ClassDB::bind_method(D_METHOD("get_process_mode"), &Node::get_process_mode);
 	ClassDB::bind_method(D_METHOD("can_process"), &Node::can_process);
-	ClassDB::bind_method(D_METHOD("print_stray_nodes"), &Node::_print_stray_nodes);
+	ClassDB::bind_method(D_METHOD("print_orphan_nodes"), &Node::_print_orphan_nodes);
 
 	ClassDB::bind_method(D_METHOD("set_display_folded", "fold"), &Node::set_display_folded);
 	ClassDB::bind_method(D_METHOD("is_displayed_folded"), &Node::is_displayed_folded);

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -169,7 +169,7 @@ private:
 	void _propagate_ready();
 	void _propagate_exit_tree();
 	void _propagate_after_exit_tree();
-	void _print_stray_nodes();
+	void _print_orphan_nodes();
 	void _propagate_process_owner(Node *p_owner, int p_pause_notification, int p_enabled_notification);
 	Array _get_node_and_resource(const NodePath &p_path);
 
@@ -436,7 +436,7 @@ public:
 
 	void request_ready();
 
-	static void print_stray_nodes();
+	static void print_orphan_nodes();
 
 #ifdef TOOLS_ENABLED
 	String validate_child_name(Node *p_child);


### PR DESCRIPTION
The "orphan" terminology is already used elsewhere.

See https://github.com/godotengine/godot/issues/54161#issuecomment-1024248415.