### PR TITLE
Rename `Camera3D.project_position()` to `Camera3D.viewport_to_world()`

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -71,29 +71,21 @@
 		</method>
 		<method name="project_local_ray_normal" qualifiers="const">
 			<return type="Vector3" />
-			<argument index="0" name="screen_point" type="Vector2" />
+			<argument index="0" name="viewport_point" type="Vector2" />
 			<description>
 				Returns a normal vector from the screen point location directed along the camera. Orthogonal cameras are normalized. Perspective cameras account for perspective, screen width/height, etc.
 			</description>
 		</method>
-		<method name="project_position" qualifiers="const">
-			<return type="Vector3" />
-			<argument index="0" name="screen_point" type="Vector2" />
-			<argument index="1" name="z_depth" type="float" />
-			<description>
-				Returns the 3D point in world space that maps to the given 2D coordinate in the [Viewport] rectangle on a plane that is the given [code]z_depth[/code] distance into the scene away from the camera.
-			</description>
-		</method>
 		<method name="project_ray_normal" qualifiers="const">
 			<return type="Vector3" />
-			<argument index="0" name="screen_point" type="Vector2" />
+			<argument index="0" name="viewport_point" type="Vector2" />
 			<description>
 				Returns a normal vector in world space, that is the result of projecting a point on the [Viewport] rectangle by the camera projection. This is useful for casting rays in the form of (origin, normal) for object intersection or picking.
 			</description>
 		</method>
 		<method name="project_ray_origin" qualifiers="const">
 			<return type="Vector3" />
-			<argument index="0" name="screen_point" type="Vector2" />
+			<argument index="0" name="viewport_point" type="Vector2" />
 			<description>
 				Returns a 3D position in world space, that is the result of projecting a point on the [Viewport] rectangle by the camera projection. This is useful for casting rays in the form of (origin, normal) for object intersection or picking.
 			</description>
@@ -134,7 +126,15 @@
 				Sets the camera projection to perspective mode (see [constant PROJECTION_PERSPECTIVE]), by specifying a [code]fov[/code] (field of view) angle in degrees, and the [code]z_near[/code] and [code]z_far[/code] clip planes in world space units.
 			</description>
 		</method>
-		<method name="unproject_position" qualifiers="const">
+		<method name="viewport_to_world" qualifiers="const">
+			<return type="Vector3" />
+			<argument index="0" name="viewport_point" type="Vector2" />
+			<argument index="1" name="z_depth" type="float" />
+			<description>
+				Returns the 3D point in world space that maps to the given 2D coordinate in the [Viewport] rectangle on a plane that is the given [code]z_depth[/code] distance into the scene away from the camera.
+			</description>
+		</method>
+		<method name="world_to_viewport" qualifiers="const">
 			<return type="Vector2" />
 			<argument index="0" name="world_point" type="Vector3" />
 			<description>
@@ -144,7 +144,7 @@
 				# This code block is part of a script that inherits from Node3D.
 				# `control` is a reference to a node inheriting from Control.
 				control.visible = not get_viewport().get_camera_3d().is_position_behind(global_transform.origin)
-				control.rect_position = get_viewport().get_camera_3d().unproject_position(global_transform.origin)
+				control.rect_position = get_viewport().get_camera_3d().world_to_viewport(global_transform.origin)
 				[/codeblock]
 			</description>
 		</method>

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -595,7 +595,7 @@ void EditorNode3DGizmo::handles_intersect_ray(Camera3D *p_camera, const Vector2 
 
 	for (int i = 0; i < secondary_handles.size(); i++) {
 		Vector3 hpos = t.xform(secondary_handles[i]);
-		Vector2 p = p_camera->unproject_position(hpos);
+		Vector2 p = p_camera->world_to_viewport(hpos);
 
 		if (p.distance_to(p_point) < HANDLE_HALF_SIZE) {
 			real_t dp = p_camera->get_transform().origin.distance_to(hpos);
@@ -619,7 +619,7 @@ void EditorNode3DGizmo::handles_intersect_ray(Camera3D *p_camera, const Vector2 
 
 	for (int i = 0; i < handles.size(); i++) {
 		Vector3 hpos = t.xform(handles[i]);
-		Vector2 p = p_camera->unproject_position(hpos);
+		Vector2 p = p_camera->world_to_viewport(hpos);
 
 		if (p.distance_to(p_point) < HANDLE_HALF_SIZE) {
 			real_t dp = p_camera->get_transform().origin.distance_to(hpos);
@@ -659,7 +659,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 			scale = size / aspect;
 		}
 
-		Point2 center = p_camera->unproject_position(t.origin);
+		Point2 center = p_camera->world_to_viewport(t.origin);
 
 		Transform3D orig_camera_transform = p_camera->get_camera_transform();
 
@@ -671,8 +671,8 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 		Vector3 c0 = t.xform(Vector3(selectable_icon_size, selectable_icon_size, 0) * scale);
 		Vector3 c1 = t.xform(Vector3(-selectable_icon_size, -selectable_icon_size, 0) * scale);
 
-		Point2 p0 = p_camera->unproject_position(c0);
-		Point2 p1 = p_camera->unproject_position(c1);
+		Point2 p0 = p_camera->world_to_viewport(c0);
+		Point2 p1 = p_camera->world_to_viewport(c1);
 
 		p_camera->set_global_transform(orig_camera_transform);
 
@@ -704,8 +704,8 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 			Vector3 a = t.xform(vptr[i * 2 + 0]);
 			Vector3 b = t.xform(vptr[i * 2 + 1]);
 			Vector2 s[2];
-			s[0] = p_camera->unproject_position(a);
-			s[1] = p_camera->unproject_position(b);
+			s[0] = p_camera->world_to_viewport(a);
+			s[1] = p_camera->world_to_viewport(b);
 
 			Vector2 p = Geometry2D::get_closest_point_to_segment(p_point, s);
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -432,7 +432,7 @@ Vector3 Node3DEditorViewport::_get_camera_position() const {
 }
 
 Point2 Node3DEditorViewport::_point_to_screen(const Vector3 &p_point) {
-	return camera->unproject_position(p_point) * subviewport_container->get_stretch_shrink();
+	return camera->world_to_viewport(p_point) * subviewport_container->get_stretch_shrink();
 }
 
 Vector3 Node3DEditorViewport::_get_ray_pos(const Vector2 &p_pos) const {
@@ -3395,8 +3395,8 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 	const Vector3 camy = -camera_xform.get_basis().get_axis(1).normalized();
 	const Plane p = Plane(camz, camera_xform.origin);
 	const real_t gizmo_d = MAX(Math::abs(p.distance_to(xform.origin)), CMP_EPSILON);
-	const real_t d0 = camera->unproject_position(camera_xform.origin + camz * gizmo_d).y;
-	const real_t d1 = camera->unproject_position(camera_xform.origin + camz * gizmo_d + camy).y;
+	const real_t d0 = camera->world_to_viewport(camera_xform.origin + camz * gizmo_d).y;
+	const real_t d1 = camera->world_to_viewport(camera_xform.origin + camz * gizmo_d + camy).y;
 	const real_t dd = MAX(Math::abs(d0 - d1), CMP_EPSILON);
 
 	const real_t gizmo_size = EditorSettings::get_singleton()->get("editors/3d/manipulator_gizmo_size");

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -329,14 +329,14 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_spatial_gui_input(Camera
 			if (rc >= 2) {
 				const Vector3 *r = v3a.ptr();
 
-				if (p_camera->unproject_position(gt.xform(c->get_point_position(0))).distance_to(mbpos) < click_dist) {
+				if (p_camera->world_to_viewport(gt.xform(c->get_point_position(0))).distance_to(mbpos) < click_dist) {
 					return EditorPlugin::AFTER_GUI_INPUT_PASS; //nope, existing
 				}
 
 				for (int i = 0; i < c->get_point_count() - 1; i++) {
 					//find the offset and point index of the place to break up
 					int j = idx;
-					if (p_camera->unproject_position(gt.xform(c->get_point_position(i + 1))).distance_to(mbpos) < click_dist) {
+					if (p_camera->world_to_viewport(gt.xform(c->get_point_position(i + 1))).distance_to(mbpos) < click_dist) {
 						return EditorPlugin::AFTER_GUI_INPUT_PASS; //nope, existing
 					}
 
@@ -348,8 +348,8 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_spatial_gui_input(Camera
 						to = gt.xform(to);
 						if (cdist > 0) {
 							Vector2 s[2];
-							s[0] = p_camera->unproject_position(from);
-							s[1] = p_camera->unproject_position(to);
+							s[0] = p_camera->world_to_viewport(from);
+							s[1] = p_camera->world_to_viewport(to);
 							Vector2 inters = Geometry2D::get_closest_point_to_segment(mbpos, s);
 							float d = inters.distance_to(mbpos);
 
@@ -414,9 +414,9 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_spatial_gui_input(Camera
 
 		} else if (mb->is_pressed() && ((mb->get_button_index() == MouseButton::LEFT && curve_del->is_pressed()) || (mb->get_button_index() == MouseButton::RIGHT && curve_edit->is_pressed()))) {
 			for (int i = 0; i < c->get_point_count(); i++) {
-				real_t dist_to_p = p_camera->unproject_position(gt.xform(c->get_point_position(i))).distance_to(mbpos);
-				real_t dist_to_p_out = p_camera->unproject_position(gt.xform(c->get_point_position(i) + c->get_point_out(i))).distance_to(mbpos);
-				real_t dist_to_p_in = p_camera->unproject_position(gt.xform(c->get_point_position(i) + c->get_point_in(i))).distance_to(mbpos);
+				real_t dist_to_p = p_camera->world_to_viewport(gt.xform(c->get_point_position(i))).distance_to(mbpos);
+				real_t dist_to_p_out = p_camera->world_to_viewport(gt.xform(c->get_point_position(i) + c->get_point_out(i))).distance_to(mbpos);
+				real_t dist_to_p_in = p_camera->world_to_viewport(gt.xform(c->get_point_position(i) + c->get_point_in(i))).distance_to(mbpos);
 
 				// Find the offset and point index of the place to break up.
 				// Also check for the control points.

--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -159,7 +159,7 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_spatial_gui_input(Camera3D 
 						edited_point = 1;
 						return EditorPlugin::AFTER_GUI_INPUT_STOP;
 					} else {
-						if (wip.size() > 1 && p_camera->unproject_position(gt.xform(Vector3(wip[0].x, wip[0].y, depth))).distance_to(gpoint) < grab_threshold) {
+						if (wip.size() > 1 && p_camera->world_to_viewport(gt.xform(Vector3(wip[0].x, wip[0].y, depth))).distance_to(gpoint) < grab_threshold) {
 							//wip closed
 							_wip_close();
 
@@ -199,8 +199,8 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_spatial_gui_input(Camera3D 
 							real_t closest_dist = 1e10;
 							for (int i = 0; i < poly.size(); i++) {
 								Vector2 points[2] = {
-									p_camera->unproject_position(gt.xform(Vector3(poly[i].x, poly[i].y, depth))),
-									p_camera->unproject_position(gt.xform(Vector3(poly[(i + 1) % poly.size()].x, poly[(i + 1) % poly.size()].y, depth)))
+									p_camera->world_to_viewport(gt.xform(Vector3(poly[i].x, poly[i].y, depth))),
+									p_camera->world_to_viewport(gt.xform(Vector3(poly[(i + 1) % poly.size()].x, poly[(i + 1) % poly.size()].y, depth)))
 								};
 
 								Vector2 cp = Geometry2D::get_closest_point_to_segment(gpoint, points);
@@ -234,7 +234,7 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_spatial_gui_input(Camera3D 
 							Vector2 closest_pos;
 							real_t closest_dist = 1e10;
 							for (int i = 0; i < poly.size(); i++) {
-								Vector2 cp = p_camera->unproject_position(gt.xform(Vector3(poly[i].x, poly[i].y, depth)));
+								Vector2 cp = p_camera->world_to_viewport(gt.xform(Vector3(poly[i].x, poly[i].y, depth)));
 
 								real_t d = cp.distance_to(gpoint);
 								if (d < closest_dist && d < grab_threshold) {
@@ -278,7 +278,7 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_spatial_gui_input(Camera3D 
 					Vector2 closest_pos;
 					real_t closest_dist = 1e10;
 					for (int i = 0; i < poly.size(); i++) {
-						Vector2 cp = p_camera->unproject_position(gt.xform(Vector3(poly[i].x, poly[i].y, depth)));
+						Vector2 cp = p_camera->world_to_viewport(gt.xform(Vector3(poly[i].x, poly[i].y, depth)));
 
 						real_t d = cp.distance_to(gpoint);
 						if (d < closest_dist && d < grab_threshold) {

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -1163,7 +1163,7 @@ int Skeleton3DGizmoPlugin::subgizmos_intersect_ray(const EditorNode3DGizmo *p_gi
 	const int bone_len = skeleton->get_bone_count();
 	for (int i = 0; i < bone_len; i++) {
 		Vector3 joint_pos_3d = gt.xform(skeleton->get_bone_global_pose(i).origin);
-		Vector2 joint_pos_2d = p_camera->unproject_position(joint_pos_3d);
+		Vector2 joint_pos_2d = p_camera->world_to_viewport(joint_pos_3d);
 		real_t dist_3d = ray_from.distance_to(joint_pos_3d);
 		real_t dist_2d = p_point.distance_to(joint_pos_2d);
 		if (dist_2d < grab_threshold && dist_3d < closest_dist) {

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -337,7 +337,7 @@ Vector<Vector3> Camera3D::get_near_plane_points() const {
 	return points;
 }
 
-Point2 Camera3D::unproject_position(const Vector3 &p_pos) const {
+Point2 Camera3D::world_to_viewport(const Vector3 &p_pos) const {
 	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector2(), "Camera is not inside scene.");
 
 	Size2 viewport_size = get_viewport()->get_visible_rect().size;
@@ -362,7 +362,7 @@ Point2 Camera3D::unproject_position(const Vector3 &p_pos) const {
 	return res;
 }
 
-Vector3 Camera3D::project_position(const Point2 &p_point, real_t p_z_depth) const {
+Vector3 Camera3D::viewport_to_world(const Point2 &p_point, real_t p_z_depth) const {
 	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector3(), "Camera is not inside scene.");
 
 	if (p_z_depth == 0 && mode != PROJECTION_ORTHOGONAL) {
@@ -449,12 +449,12 @@ Camera3D::DopplerTracking Camera3D::get_doppler_tracking() const {
 }
 
 void Camera3D::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("project_ray_normal", "screen_point"), &Camera3D::project_ray_normal);
-	ClassDB::bind_method(D_METHOD("project_local_ray_normal", "screen_point"), &Camera3D::project_local_ray_normal);
-	ClassDB::bind_method(D_METHOD("project_ray_origin", "screen_point"), &Camera3D::project_ray_origin);
-	ClassDB::bind_method(D_METHOD("unproject_position", "world_point"), &Camera3D::unproject_position);
+	ClassDB::bind_method(D_METHOD("project_ray_normal", "viewport_point"), &Camera3D::project_ray_normal);
+	ClassDB::bind_method(D_METHOD("project_local_ray_normal", "viewport_point"), &Camera3D::project_local_ray_normal);
+	ClassDB::bind_method(D_METHOD("project_ray_origin", "viewport_point"), &Camera3D::project_ray_origin);
+	ClassDB::bind_method(D_METHOD("world_to_viewport", "world_point"), &Camera3D::world_to_viewport);
 	ClassDB::bind_method(D_METHOD("is_position_behind", "world_point"), &Camera3D::is_position_behind);
-	ClassDB::bind_method(D_METHOD("project_position", "screen_point", "z_depth"), &Camera3D::project_position);
+	ClassDB::bind_method(D_METHOD("viewport_to_world", "viewport_point", "z_depth"), &Camera3D::viewport_to_world);
 	ClassDB::bind_method(D_METHOD("set_perspective", "fov", "z_near", "z_far"), &Camera3D::set_perspective);
 	ClassDB::bind_method(D_METHOD("set_orthogonal", "size", "z_near", "z_far"), &Camera3D::set_orthogonal);
 	ClassDB::bind_method(D_METHOD("set_frustum", "size", "offset", "z_near", "z_far"), &Camera3D::set_frustum);

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -140,9 +140,9 @@ public:
 	virtual Vector3 project_ray_normal(const Point2 &p_pos) const;
 	virtual Vector3 project_ray_origin(const Point2 &p_pos) const;
 	virtual Vector3 project_local_ray_normal(const Point2 &p_pos) const;
-	virtual Point2 unproject_position(const Vector3 &p_pos) const;
+	virtual Point2 world_to_viewport(const Vector3 &p_pos) const;
 	bool is_position_behind(const Vector3 &p_pos) const;
-	virtual Vector3 project_position(const Point2 &p_point, real_t p_z_depth) const;
+	virtual Vector3 viewport_to_world(const Point2 &p_point, real_t p_z_depth) const;
 
 	Vector<Vector3> get_near_plane_points() const;
 

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -127,7 +127,7 @@ Vector3 XRCamera3D::project_local_ray_normal(const Point2 &p_pos) const {
 	return ray;
 };
 
-Point2 XRCamera3D::unproject_position(const Vector3 &p_pos) const {
+Point2 XRCamera3D::world_to_viewport(const Vector3 &p_pos) const {
 	// get our XRServer
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, Vector2());
@@ -135,7 +135,7 @@ Point2 XRCamera3D::unproject_position(const Vector3 &p_pos) const {
 	Ref<XRInterface> xr_interface = xr_server->get_primary_interface();
 	if (xr_interface.is_null()) {
 		// we might be in the editor or have VR turned off, just call superclass
-		return Camera3D::unproject_position(p_pos);
+		return Camera3D::world_to_viewport(p_pos);
 	}
 
 	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector2(), "Camera is not inside scene.");
@@ -157,7 +157,7 @@ Point2 XRCamera3D::unproject_position(const Vector3 &p_pos) const {
 	return res;
 };
 
-Vector3 XRCamera3D::project_position(const Point2 &p_point, real_t p_z_depth) const {
+Vector3 XRCamera3D::viewport_to_world(const Point2 &p_point, real_t p_z_depth) const {
 	// get our XRServer
 	XRServer *xr_server = XRServer::get_singleton();
 	ERR_FAIL_NULL_V(xr_server, Vector3());
@@ -165,7 +165,7 @@ Vector3 XRCamera3D::project_position(const Point2 &p_point, real_t p_z_depth) co
 	Ref<XRInterface> xr_interface = xr_server->get_primary_interface();
 	if (xr_interface.is_null()) {
 		// we might be in the editor or have VR turned off, just call superclass
-		return Camera3D::project_position(p_point, p_z_depth);
+		return Camera3D::viewport_to_world(p_point, p_z_depth);
 	}
 
 	ERR_FAIL_COND_V_MSG(!is_inside_tree(), Vector3(), "Camera is not inside scene.");

--- a/scene/3d/xr_nodes.h
+++ b/scene/3d/xr_nodes.h
@@ -58,8 +58,8 @@ public:
 	TypedArray<String> get_configuration_warnings() const override;
 
 	virtual Vector3 project_local_ray_normal(const Point2 &p_pos) const override;
-	virtual Point2 unproject_position(const Vector3 &p_pos) const override;
-	virtual Vector3 project_position(const Point2 &p_point, real_t p_z_depth) const override;
+	virtual Point2 world_to_viewport(const Vector3 &p_pos) const override;
+	virtual Vector3 viewport_to_world(const Point2 &p_point, real_t p_z_depth) const override;
 	virtual Vector<Plane> get_frustum() const override;
 
 	XRCamera3D();


### PR DESCRIPTION
`Camera3D.unproject_position()` was also renamed to `Camera3D.world_to_viewport()`. The `screen_point` parameters to various Camera3D methods were also renamed to `viewport_point` to be more explicit.

This wording is less technically accurate, but it is much more obvious, especially for those less familiar with 3D rendering.

See https://github.com/godotengine/godot/issues/54161#issuecomment-970764753.