### PR TITLE
GDExtension: change to_string signature to accept `GDNativeStringPtr` instead of returning `const char*`

### DIFF
--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -208,7 +208,7 @@ typedef struct {
 typedef const GDNativePropertyInfo *(*GDNativeExtensionClassGetPropertyList)(GDExtensionClassInstancePtr p_instance, uint32_t *r_count);
 typedef void (*GDNativeExtensionClassFreePropertyList)(GDExtensionClassInstancePtr p_instance, const GDNativePropertyInfo *p_list);
 typedef void (*GDNativeExtensionClassNotification)(GDExtensionClassInstancePtr p_instance, int32_t p_what);
-typedef const char *(*GDNativeExtensionClassToString)(GDExtensionClassInstancePtr p_instance);
+typedef void (*GDNativeExtensionClassToString)(GDExtensionClassInstancePtr p_instance, GDNativeStringPtr p_out);
 typedef void (*GDNativeExtensionClassReference)(GDExtensionClassInstancePtr p_instance);
 typedef void (*GDNativeExtensionClassUnreference)(GDExtensionClassInstancePtr p_instance);
 typedef void (*GDNativeExtensionClassCallVirtual)(GDExtensionClassInstancePtr p_instance, const GDNativeTypePtr *p_args, GDNativeTypePtr r_ret);

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -865,7 +865,9 @@ String Object::to_string() {
 		}
 	}
 	if (_extension && _extension->to_string) {
-		return _extension->to_string(_extension_instance);
+		String ret;
+		_extension->to_string(_extension_instance, &ret);
+		return ret;
 	}
 	return "[" + get_class() + ":" + itos(get_instance_id()) + "]";
 }


### PR DESCRIPTION
The current approach, returning `const char*`, forces the GDExtension binding to hold a string backing the char array. Additionally, the signature doesn't make it clear which string encoding is used.

This PR changes the signature to accept a `GDNativeStringPtr` parameter instead, which should be filled by the binding.