### PR TITLE
Const Ref Callable for custom sort/search

### DIFF
--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -97,24 +97,29 @@ public:
 
 	_FORCE_INLINE_ bool has(const T &p_val) const { return find(p_val) != -1; }
 
-	template <class C>
-	void sort_custom() {
+	void sort() {
+		sort_custom<_DefaultComparator<T>>();
+	}
+
+	template <class Comparator, bool Validate = SORT_ARRAY_VALIDATE_ENABLED, class... Args>
+	void sort_custom(Args &&...args) {
 		int len = _cowdata.size();
 		if (len == 0) {
 			return;
 		}
 
 		T *data = ptrw();
-		SortArray<T, C> sorter;
+		SortArray<T, Comparator, Validate> sorter{ args... };
 		sorter.sort(data, len);
 	}
 
-	void sort() {
-		sort_custom<_DefaultComparator<T>>();
+	int bsearch(const T &p_value, bool p_before) {
+		return bsearch_custom<_DefaultComparator<T>>(p_value, p_before);
 	}
 
-	int bsearch(const T &p_value, bool p_before) {
-		SearchArray<T> search;
+	template <class Comparator, class Value, class... Args>
+	int bsearch_custom(const Value &p_value, bool p_before, Args &&...args) {
+		SearchArray<T, Comparator> search{ args... };
 		return search.bisect(ptrw(), size(), p_value, p_before);
 	}
 

--- a/core/variant/array.cpp
+++ b/core/variant/array.cpp
@@ -484,24 +484,8 @@ void Array::sort() {
 	_p->array.sort_custom<_ArrayVariantSort>();
 }
 
-struct _ArrayVariantSortCustom {
-	Callable func;
-
-	_FORCE_INLINE_ bool operator()(const Variant &p_l, const Variant &p_r) const {
-		const Variant *args[2] = { &p_l, &p_r };
-		Callable::CallError err;
-		Variant res;
-		func.call(args, 2, res, err);
-		ERR_FAIL_COND_V_MSG(err.error != Callable::CallError::CALL_OK, false,
-				"Error calling sorting method: " + Variant::get_callable_error_text(func, args, 1, err));
-		return res;
-	}
-};
-
-void Array::sort_custom(Callable p_callable) {
-	SortArray<Variant, _ArrayVariantSortCustom, true> avs;
-	avs.compare.func = p_callable;
-	avs.sort(_p->array.ptrw(), _p->array.size());
+void Array::sort_custom(const Callable &p_callable) {
+	_p->array.sort_custom<CallableComparator, true>(p_callable);
 }
 
 void Array::shuffle() {
@@ -524,13 +508,10 @@ int Array::bsearch(const Variant &p_value, bool p_before) {
 	return avs.bisect(_p->array.ptrw(), _p->array.size(), p_value, p_before);
 }
 
-int Array::bsearch_custom(const Variant &p_value, Callable p_callable, bool p_before) {
+int Array::bsearch_custom(const Variant &p_value, const Callable &p_callable, bool p_before) {
 	ERR_FAIL_COND_V(!_p->typed.validate(p_value, "custom binary search"), -1);
 
-	SearchArray<Variant, _ArrayVariantSortCustom> avs;
-	avs.compare.func = p_callable;
-
-	return avs.bisect(_p->array.ptrw(), _p->array.size(), p_value, p_before);
+	return _p->array.bsearch_custom<CallableComparator>(p_value, p_before, p_callable);
 }
 
 void Array::reverse() {

--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -82,10 +82,10 @@ public:
 	Variant back() const;
 
 	void sort();
-	void sort_custom(Callable p_callable);
+	void sort_custom(const Callable &p_callable);
 	void shuffle();
 	int bsearch(const Variant &p_value, bool p_before = true);
-	int bsearch_custom(const Variant &p_value, Callable p_callable, bool p_before = true);
+	int bsearch_custom(const Variant &p_value, const Callable &p_callable, bool p_before = true);
 	void reverse();
 
 	int find(const Variant &p_value, int p_from = 0) const;

--- a/core/variant/callable.cpp
+++ b/core/variant/callable.cpp
@@ -429,3 +429,13 @@ Signal::Signal(ObjectID p_object, const StringName &p_name) {
 	object = p_object;
 	name = p_name;
 }
+
+bool CallableComparator::operator()(const Variant &p_l, const Variant &p_r) const {
+	const Variant *args[2] = { &p_l, &p_r };
+	Callable::CallError err;
+	Variant res;
+	func.call(args, 2, res, err);
+	ERR_FAIL_COND_V_MSG(err.error != Callable::CallError::CALL_OK, false,
+			"Error calling compare method: " + Variant::get_callable_error_text(func, args, 1, err));
+	return res;
+}

--- a/core/variant/callable.h
+++ b/core/variant/callable.h
@@ -170,4 +170,10 @@ public:
 	Signal() {}
 };
 
+struct CallableComparator {
+	const Callable &func;
+
+	bool operator()(const Variant &p_l, const Variant &p_r) const;
+};
+
 #endif // CALLABLE_H


### PR DESCRIPTION
The `sort_custom` and `bsearch_custom` pass `Callable` by value. This PR changes them to take `const Callable&` (by reference). This required some new utility classes to get things working and variadic templates. Not much code was affected by this change though. Besides the slight performance improvement, this makes it a bit easier to extend the `bsearch_custom` and `sort_custom` in the future.