### PR TITLE
Make script templates follow the GDScript style guide

### DIFF
--- a/modules/gdscript/editor_templates/CharacterBody2D/basic_movement.gd
+++ b/modules/gdscript/editor_templates/CharacterBody2D/basic_movement.gd
@@ -2,8 +2,9 @@
 
 extends _BASE_
 
-const SPEED: float = 300.0
-const JUMP_VELOCITY: float = -400.0
+
+const SPEED = 300.0
+const JUMP_VELOCITY = -400.0
 
 # Get the gravity from the project settings to be synced with RigidDynamicBody nodes.
 var gravity: int = ProjectSettings.get_setting("physics/2d/default_gravity")

--- a/modules/gdscript/editor_templates/CharacterBody3D/basic_movement.gd
+++ b/modules/gdscript/editor_templates/CharacterBody3D/basic_movement.gd
@@ -2,8 +2,9 @@
 
 extends _BASE_
 
-const SPEED: float = 5.0
-const JUMP_VELOCITY: float = 4.5
+
+const SPEED = 5.0
+const JUMP_VELOCITY = 4.5
 
 # Get the gravity from the project settings to be synced with RigidDynamicBody nodes.
 var gravity: float = ProjectSettings.get_setting("physics/3d/default_gravity")

--- a/modules/gdscript/editor_templates/EditorPlugin/plugin.gd
+++ b/modules/gdscript/editor_templates/EditorPlugin/plugin.gd
@@ -2,10 +2,12 @@
 @tool
 extends EditorPlugin
 
+
 func _enter_tree() -> void:
-    # Initialization of the plugin goes here.
-    pass
+	# Initialization of the plugin goes here.
+	pass
+
 
 func _exit_tree() -> void:
-    # Clean-up of the plugin goes here.
-    pass
+	# Clean-up of the plugin goes here.
+	pass

--- a/modules/gdscript/editor_templates/EditorScript/basic_editor_script.gd
+++ b/modules/gdscript/editor_templates/EditorScript/basic_editor_script.gd
@@ -2,6 +2,7 @@
 @tool
 extends EditorScript
 
+
+# Called when the script is executed (using File -> Run in Script Editor).
 func _run() -> void:
-    # Called when the script is executed (using File -> Run in Script Editor).
-    pass
+	pass

--- a/modules/gdscript/editor_templates/Node/default.gd
+++ b/modules/gdscript/editor_templates/Node/default.gd
@@ -2,9 +2,11 @@
 
 extends _BASE_
 
+
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
 	pass # Replace with function body.
+
 
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta: float) -> void:

--- a/modules/gdscript/editor_templates/VisualShaderNodeCustom/basic.gd
+++ b/modules/gdscript/editor_templates/VisualShaderNodeCustom/basic.gd
@@ -1,38 +1,50 @@
 # meta-description: Visual shader's node plugin template
 
 @tool
-extends _BASE_
 class_name VisualShaderNode_CLASS_
+extends _BASE_
+
 
 func _get_name() -> String:
 	return "_CLASS_"
 
+
 func _get_category() -> String:
 	return ""
+
 
 func _get_description() -> String:
 	return ""
 
+
 func _get_return_icon_type() -> int:
 	return PORT_TYPE_SCALAR
+
 
 func _get_input_port_count() -> int:
 	return 0
 
+
 func _get_input_port_name(port: int) -> String:
 	return ""
+
 
 func _get_input_port_type(port: int) -> int:
 	return PORT_TYPE_SCALAR
 
+
 func _get_output_port_count() -> int:
 	return 1
+
 
 func _get_output_port_name(port: int) -> String:
 	return "result"
 
+
 func _get_output_port_type(port: int) -> int:
 	return PORT_TYPE_SCALAR
 
-func _get_code(input_vars: Array[String], output_vars: Array[String], mode: int, type: int) -> String:
+
+func _get_code(input_vars: Array[String], output_vars: Array[String],
+		mode: int, type: int) -> String:
 	return output_vars[0] + " = 0.0;"

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -68,14 +68,21 @@ Ref<Script> GDScriptLanguage::make_template(const String &p_template, const Stri
 	if (!EDITOR_GET("text_editor/completion/add_type_hints")) {
 		processed_template = processed_template.replace(": int", "")
 									 .replace(": String", "")
+									 .replace(": Array[String]", "")
 									 .replace(": float", "")
 									 .replace(":=", "=")
+									 .replace(" -> String", "")
+									 .replace(" -> int", "")
 									 .replace(" -> void", "");
 	}
 #else
 	processed_template = processed_template.replace(": int", "")
 								 .replace(": String", "")
+								 .replace(": Array[String]", "")
 								 .replace(": float", "")
+								 .replace(":=", "=")
+								 .replace(" -> String", "")
+								 .replace(" -> int", "")
 								 .replace(" -> void", "");
 #endif
 

--- a/modules/mono/editor_templates/EditorPlugin/plugin.cs
+++ b/modules/mono/editor_templates/EditorPlugin/plugin.cs
@@ -1,4 +1,5 @@
 // meta-description: Basic plugin template
+
 #if TOOLS
 using _BINDINGS_NAMESPACE_;
 using System;

--- a/modules/mono/editor_templates/EditorScript/basic_editor_script.cs
+++ b/modules/mono/editor_templates/EditorScript/basic_editor_script.cs
@@ -1,4 +1,5 @@
 // meta-description: Basic editor script template
+
 #if TOOLS
 using _BINDINGS_NAMESPACE_;
 using System;
@@ -6,9 +7,9 @@ using System;
 [Tool]
 public partial class _CLASS_ : _BASE_
 {
+    // Called when the script is executed (using File -> Run in Script Editor).
     public override void _Run()
     {
-        // Called when the script is executed (using File -> Run in Script Editor).
     }
 }
 #endif

--- a/modules/mono/editor_templates/Node/default.cs
+++ b/modules/mono/editor_templates/Node/default.cs
@@ -8,12 +8,10 @@ public partial class _CLASS_ : _BASE_
     // Called when the node enters the scene tree for the first time.
     public override void _Ready()
     {
-
     }
 
     // Called every frame. 'delta' is the elapsed time since the previous frame.
     public override void _Process(float delta)
     {
-
     }
 }

--- a/modules/mono/editor_templates/Object/empty.cs
+++ b/modules/mono/editor_templates/Object/empty.cs
@@ -5,5 +5,4 @@ using System;
 
 public partial class _CLASS_ : _BASE_
 {
-
 }


### PR DESCRIPTION
Makes the script templates obey the [GDScript style guide](https://docs.godotengine.org/en/latest/tutorials/scripting/gdscript/gdscript_styleguide.html), with the following changes:

- Use the correct number of line breaks.
- Remove unnecessary typing.
- Add more types to be removed when type hints are disabled.
- Rearrange some elements.