### PR TITLE
Update SceneTree debug colors when settings changed

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -546,6 +546,12 @@ void EditorNode::_update_from_settings() {
 
 	RS::get_singleton()->decals_set_filter(RS::DecalFilter(int(GLOBAL_GET("rendering/textures/decals/filter"))));
 	RS::get_singleton()->light_projectors_set_filter(RS::LightProjectorFilter(int(GLOBAL_GET("rendering/textures/light_projectors/filter"))));
+
+	SceneTree *tree = get_tree();
+	tree->set_debug_collisions_color(GLOBAL_GET("debug/shapes/collision/shape_color"));
+	tree->set_debug_collision_contact_color(GLOBAL_GET("debug/shapes/collision/contact_color"));
+	tree->set_debug_navigation_color(GLOBAL_GET("debug/shapes/navigation/geometry_color"));
+	tree->set_debug_navigation_disabled_color(GLOBAL_GET("debug/shapes/navigation/disabled_geometry_color"));
 }
 
 void EditorNode::_select_default_main_screen_plugin() {


### PR DESCRIPTION
These debug colors are only set in `SceneTree`'s constructor. Setters are provided but never called. So debug shape colors will be updated immediately if you run the game, but needs restart to take effect in the editor.

This PR calls the corresponding setters when project settings changed.

__Note:__ Nodes providing collision mostly draw the debug shapes in their `NOTIFICATION_DRAW` callback in editor. Existing visible shapes need a update to be redrawn, e.g. changing shape parameters, toggling visibility, or switching the scene tab. It would be better to trigger their update on settings change, but I don't know any clean way to do it :( I think this is acceptable as you normally only set these settings once, at least better than restarting the editor.