### PR TITLE
Replace some copies and refs with constant refs

### DIFF
--- a/cpp.hint
+++ b/cpp.hint
@@ -1,0 +1,1 @@
+#define GDCLASS(m_class, m_inherits)

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -964,7 +964,7 @@ Node3D *EditorSceneFormatImporterFBX::_generate_scene(
 						// extra const required by C++11 colon/Range operator
 						// note: do not use C++17 syntax here for dicts.
 						// this is banned in Godot.
-						for (std::pair<const std::string, const FBXDocParser::AnimationCurve *> &kvp : curves) {
+						for (const std::pair<const std::string, const FBXDocParser::AnimationCurve *> &kvp : curves) {
 							const String curve_element = ImportUtils::FBXNodeToName(kvp.first);
 							const FBXDocParser::AnimationCurve *curve = kvp.second;
 							String curve_name = ImportUtils::FBXNodeToName(curve->Name());
@@ -980,7 +980,7 @@ Node3D *EditorSceneFormatImporterFBX::_generate_scene(
 							const std::map<int64_t, float> &track_time = curve->GetValueTimeTrack();
 
 							if (track_time.size() > 0) {
-								for (std::pair<int64_t, float> keyframe : track_time) {
+								for (const std::pair<const int64_t, float> &keyframe : track_time) {
 									if (curve_element == "d|X") {
 										keyframe_map.keyframes[keyframe.first].x = keyframe.second;
 									} else if (curve_element == "d|Y") {
@@ -1089,7 +1089,7 @@ Node3D *EditorSceneFormatImporterFBX::_generate_scene(
 						double max_duration = 0;
 						double anim_length = animation->get_length();
 
-						for (std::pair<int64_t, Vector3> position_key : translation_keys.keyframes) {
+						for (const std::pair<const int64_t, Vector3> &position_key : translation_keys.keyframes) {
 							pos_values.push_back(position_key.second * state.scale);
 							double animation_track_time = CONVERT_FBX_TIME(position_key.first);
 
@@ -1101,7 +1101,7 @@ Node3D *EditorSceneFormatImporterFBX::_generate_scene(
 							pos_times.push_back(animation_track_time);
 						}
 
-						for (std::pair<int64_t, Vector3> scale_key : scale_keys.keyframes) {
+						for (const std::pair<const int64_t, Vector3> &scale_key : scale_keys.keyframes) {
 							scale_values.push_back(scale_key.second);
 							double animation_track_time = CONVERT_FBX_TIME(scale_key.first);
 
@@ -1136,7 +1136,7 @@ Node3D *EditorSceneFormatImporterFBX::_generate_scene(
 
 						Quaternion lastQuaternion = Quaternion();
 
-						for (std::pair<int64_t, Vector3> rotation_key : rotation_keys.keyframes) {
+						for (const std::pair<const int64_t, Vector3> &rotation_key : rotation_keys.keyframes) {
 							double animation_track_time = CONVERT_FBX_TIME(rotation_key.first);
 
 							//print_verbose("euler rotation key: " + rotation_key.second);

--- a/thirdparty/openxr/src/loader/api_layer_interface.cpp
+++ b/thirdparty/openxr/src/loader/api_layer_interface.cpp
@@ -160,7 +160,7 @@ XrResult ApiLayerInterface::GetInstanceExtensionProperties(const std::string& op
                 result = ApiLayerManifestFile::FindManifestFiles(MANIFEST_TYPE_EXPLICIT_API_LAYER, exp_layer_man_files);
                 if (XR_SUCCEEDED(result)) {
                     for (auto& exp_layer_man_file : exp_layer_man_files) {
-                        for (std::string& enabled_layer : env_enabled_layers) {
+                        for (const std::string& enabled_layer : env_enabled_layers) {
                             // If this is an enabled layer, transfer it over to the manifest list.
                             if (enabled_layer == exp_layer_man_file->LayerName()) {
                                 manifest_files.push_back(std::move(exp_layer_man_file));

--- a/thirdparty/openxr/src/loader/loader_instance.cpp
+++ b/thirdparty/openxr/src/loader/loader_instance.cpp
@@ -294,7 +294,7 @@ LoaderInstance::~LoaderInstance() {
 }
 
 bool LoaderInstance::ExtensionIsEnabled(const std::string& extension) {
-    for (std::string& cur_enabled : _enabled_extensions) {
+    for (const std::string& cur_enabled : _enabled_extensions) {
         if (cur_enabled == extension) {
             return true;
         }

--- a/thirdparty/openxr/src/loader/manifest_file.cpp
+++ b/thirdparty/openxr/src/loader/manifest_file.cpp
@@ -92,7 +92,7 @@ static void CheckAllFilesInThePath(const std::string &search_path, bool is_direc
         } else {
             std::vector<std::string> files;
             if (FileSysUtilsFindFilesInPath(search_path, files)) {
-                for (std::string &cur_file : files) {
+                for (const std::string &cur_file : files) {
                     std::string relative_path;
                     FileSysUtilsCombinePaths(search_path, cur_file, relative_path);
                     if (!FileSysUtilsGetAbsolutePath(relative_path, absolute_path)) {
@@ -449,7 +449,7 @@ static void GetExtensionProperties(const std::vector<ExtensionListing> &extensio
 
 // Return any instance extensions found in the manifest files in the proper form for
 // OpenXR (XrExtensionProperties).
-void ManifestFile::GetInstanceExtensionProperties(std::vector<XrExtensionProperties> &props) {
+void ManifestFile::GetInstanceExtensionProperties(std::vector<XrExtensionProperties> &props) const {
     GetExtensionProperties(_instance_extensions, props);
 }
 
@@ -837,7 +837,7 @@ XrResult ApiLayerManifestFile::FindManifestFiles(ManifestFileType type,
     }
 #endif
 
-    for (std::string &cur_file : filenames) {
+    for (const std::string &cur_file : filenames) {
         ApiLayerManifestFile::CreateIfValid(type, cur_file, manifest_files);
     }
 

--- a/thirdparty/openxr/src/loader/manifest_file.hpp
+++ b/thirdparty/openxr/src/loader/manifest_file.hpp
@@ -49,7 +49,7 @@ class ManifestFile {
     ManifestFileType Type() const { return _type; }
     const std::string &Filename() const { return _filename; }
     const std::string &LibraryPath() const { return _library_path; }
-    void GetInstanceExtensionProperties(std::vector<XrExtensionProperties> &props);
+    void GetInstanceExtensionProperties(std::vector<XrExtensionProperties> &props) const;
     const std::string &GetFunctionName(const std::string &func_name) const;
 
    protected:


### PR DESCRIPTION
To:
* avoid unnecessary copying;
* avoid unintentional change of value by reference;
* give compiler more context for optimizations.