### PR TITLE
Replace copies with constant refs in FBX importer

### DIFF
--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -964,7 +964,7 @@ Node3D *EditorSceneFormatImporterFBX::_generate_scene(
 						// extra const required by C++11 colon/Range operator
 						// note: do not use C++17 syntax here for dicts.
 						// this is banned in Godot.
-						for (std::pair<const std::string, const FBXDocParser::AnimationCurve *> &kvp : curves) {
+						for (const std::pair<const std::string, const FBXDocParser::AnimationCurve *> &kvp : curves) {
 							const String curve_element = ImportUtils::FBXNodeToName(kvp.first);
 							const FBXDocParser::AnimationCurve *curve = kvp.second;
 							String curve_name = ImportUtils::FBXNodeToName(curve->Name());
@@ -980,7 +980,7 @@ Node3D *EditorSceneFormatImporterFBX::_generate_scene(
 							const std::map<int64_t, float> &track_time = curve->GetValueTimeTrack();
 
 							if (track_time.size() > 0) {
-								for (std::pair<int64_t, float> keyframe : track_time) {
+								for (const std::pair<const int64_t, float> &keyframe : track_time) {
 									if (curve_element == "d|X") {
 										keyframe_map.keyframes[keyframe.first].x = keyframe.second;
 									} else if (curve_element == "d|Y") {
@@ -1089,7 +1089,7 @@ Node3D *EditorSceneFormatImporterFBX::_generate_scene(
 						double max_duration = 0;
 						double anim_length = animation->get_length();
 
-						for (std::pair<int64_t, Vector3> position_key : translation_keys.keyframes) {
+						for (const std::pair<const int64_t, Vector3> &position_key : translation_keys.keyframes) {
 							pos_values.push_back(position_key.second * state.scale);
 							double animation_track_time = CONVERT_FBX_TIME(position_key.first);
 
@@ -1101,7 +1101,7 @@ Node3D *EditorSceneFormatImporterFBX::_generate_scene(
 							pos_times.push_back(animation_track_time);
 						}
 
-						for (std::pair<int64_t, Vector3> scale_key : scale_keys.keyframes) {
+						for (const std::pair<const int64_t, Vector3> &scale_key : scale_keys.keyframes) {
 							scale_values.push_back(scale_key.second);
 							double animation_track_time = CONVERT_FBX_TIME(scale_key.first);
 
@@ -1136,7 +1136,7 @@ Node3D *EditorSceneFormatImporterFBX::_generate_scene(
 
 						Quaternion lastQuaternion = Quaternion();
 
-						for (std::pair<int64_t, Vector3> rotation_key : rotation_keys.keyframes) {
+						for (const std::pair<const int64_t, Vector3> &rotation_key : rotation_keys.keyframes) {
 							double animation_track_time = CONVERT_FBX_TIME(rotation_key.first);
 
 							//print_verbose("euler rotation key: " + rotation_key.second);


### PR DESCRIPTION
To:
* avoid unnecessary copying;
* avoid unintentional change of value by reference;
* give compiler more context for optimizations.

Sorry for previous pr, I did not notice how I changed thirdparty files :)