### PR TITLE
Improved as_text() for InputEventAction

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -1327,7 +1327,12 @@ bool InputEventAction::action_match(const Ref<InputEvent> &p_event, bool p_exact
 }
 
 String InputEventAction::as_text() const {
-	return vformat(RTR("Input Action %s was %s"), action, pressed ? "pressed" : "released");
+	const List<Ref<InputEvent>> *events = InputMap::get_singleton()->action_get_events(action);
+	if (!events->is_empty()) {
+		return events->front()->get()->as_text();
+	}
+
+	return TTR("No Events");
 }
 
 String InputEventAction::to_string() {


### PR DESCRIPTION
Closes #52117

Previously `InputEventAction` did not return the text of the underlying action in the `as_text()` method. Now it should return the text of the input event for the first configured action. This is more useful for scenarios such as that shown in the above linked issue.

cc @LunaticInAHat, is this what you were thinking?