### PR TITLE
Modules: Don't build editor-specific classes in templates

### DIFF
--- a/modules/csg/SCsub
+++ b/modules/csg/SCsub
@@ -3,7 +3,10 @@
 Import("env")
 Import("env_modules")
 
+# Godot's own source files
 env_csg = env_modules.Clone()
 
 # Godot's own source files
 env_csg.add_source_files(env.modules_sources, "*.cpp")
+if env["tools"]:
+    env_csg.add_source_files(env.modules_sources, "editor/*.cpp")

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -30,6 +30,8 @@
 
 #include "csg_gizmos.h"
 
+#ifdef TOOLS_ENABLED
+
 #include "editor/editor_settings.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "scene/3d/camera_3d.h"
@@ -425,3 +427,5 @@ EditorPluginCSG::EditorPluginCSG() {
 	Ref<CSGShape3DGizmoPlugin> gizmo_plugin = Ref<CSGShape3DGizmoPlugin>(memnew(CSGShape3DGizmoPlugin));
 	Node3DEditor::get_singleton()->add_gizmo_plugin(gizmo_plugin);
 }
+
+#endif // TOOLS_ENABLED

--- a/modules/csg/editor/csg_gizmos.h
+++ b/modules/csg/editor/csg_gizmos.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  editor_scene_importer_gltf.cpp                                       */
+/*  csg_gizmos.h                                                         */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,46 +28,40 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#if TOOLS_ENABLED
-#include "editor_scene_importer_gltf.h"
+#ifndef CSG_GIZMOS_H
+#define CSG_GIZMOS_H
 
-#include "gltf_document.h"
-#include "gltf_state.h"
+#ifdef TOOLS_ENABLED
 
-#include "scene/3d/node_3d.h"
-#include "scene/animation/animation_player.h"
-#include "scene/resources/animation.h"
+#include "../csg_shape.h"
+#include "editor/editor_plugin.h"
+#include "editor/plugins/node_3d_editor_gizmos.h"
 
-uint32_t EditorSceneFormatImporterGLTF::get_import_flags() const {
-	return ImportFlags::IMPORT_SCENE | ImportFlags::IMPORT_ANIMATION;
-}
+class CSGShape3DGizmoPlugin : public EditorNode3DGizmoPlugin {
+	GDCLASS(CSGShape3DGizmoPlugin, EditorNode3DGizmoPlugin);
 
-void EditorSceneFormatImporterGLTF::get_extensions(List<String> *r_extensions) const {
-	r_extensions->push_back("gltf");
-	r_extensions->push_back("glb");
-}
+public:
+	virtual bool has_gizmo(Node3D *p_spatial) override;
+	virtual String get_gizmo_name() const override;
+	virtual int get_priority() const override;
+	virtual bool is_selectable_when_hidden() const override;
+	virtual void redraw(EditorNode3DGizmo *p_gizmo) override;
 
-Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path,
-		uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps,
-		List<String> *r_missing_deps,
-		Error *r_err) {
-	Ref<GLTFDocument> doc;
-	doc.instantiate();
-	Ref<GLTFState> state;
-	state.instantiate();
-	Error err = doc->append_from_file(p_path, state, p_flags, p_bake_fps);
-	if (err != OK) {
-		*r_err = err;
-		return nullptr;
-	}
-	Node *root = doc->generate_scene(state, p_bake_fps);
-	return root;
-}
+	virtual String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const override;
+	virtual Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const override;
+	virtual void set_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, Camera3D *p_camera, const Point2 &p_point) override;
+	virtual void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel) override;
 
-Ref<Animation> EditorSceneFormatImporterGLTF::import_animation(const String &p_path,
-		uint32_t p_flags, const Map<StringName, Variant> &p_options,
-		int p_bake_fps) {
-	return Ref<Animation>();
-}
+	CSGShape3DGizmoPlugin();
+};
+
+class EditorPluginCSG : public EditorPlugin {
+	GDCLASS(EditorPluginCSG, EditorPlugin);
+
+public:
+	EditorPluginCSG();
+};
 
 #endif // TOOLS_ENABLED
+
+#endif // CSG_GIZMOS_H

--- a/modules/csg/register_types.cpp
+++ b/modules/csg/register_types.cpp
@@ -30,12 +30,15 @@
 
 #include "register_types.h"
 
-#include "csg_gizmos.h"
-#include "csg_shape.h"
-
-void register_csg_types() {
 #ifndef _3D_DISABLED
 
+#include "csg_shape.h"
+
+#ifdef TOOLS_ENABLED
+#include "editor/csg_gizmos.h"
+#endif
+
+void register_csg_types() {
 	GDREGISTER_ABSTRACT_CLASS(CSGShape3D);
 	GDREGISTER_ABSTRACT_CLASS(CSGPrimitive3D);
 	GDREGISTER_CLASS(CSGMesh3D);
@@ -49,8 +52,9 @@ void register_csg_types() {
 #ifdef TOOLS_ENABLED
 	EditorPlugins::add_by_type<EditorPluginCSG>();
 #endif
-#endif
 }
 
 void unregister_csg_types() {
 }
+
+#endif // _3D_DISABLED

--- a/modules/gltf/SCsub
+++ b/modules/gltf/SCsub
@@ -4,7 +4,8 @@ Import("env")
 Import("env_modules")
 
 env_gltf = env_modules.Clone()
-env_gltf.Prepend(CPPPATH=["."])
 
 # Godot's own source files
 env_gltf.add_source_files(env.modules_sources, "*.cpp")
+if env["tools"]:
+    env_gltf.add_source_files(env.modules_sources, "editor/*.cpp")

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.cpp
@@ -28,8 +28,12 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#if TOOLS_ENABLED
+#ifdef TOOLS_ENABLED
+
 #include "editor_scene_exporter_gltf_plugin.h"
+
+#include "../gltf_document.h"
+#include "../gltf_state.h"
 
 #include "core/config/project_settings.h"
 #include "core/error/error_list.h"
@@ -37,13 +41,10 @@
 #include "core/templates/vector.h"
 #include "editor/editor_file_dialog.h"
 #include "editor/editor_file_system.h"
-#include "gltf_document.h"
-#include "gltf_state.h"
+#include "editor/editor_node.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/gui/check_box.h"
 #include "scene/main/node.h"
-
-#include "editor/editor_node.h"
 
 String SceneExporterGLTFPlugin::get_name() const {
 	return "ConvertGLTF2";

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
@@ -31,7 +31,8 @@
 #ifndef EDITOR_SCENE_EXPORTER_GLTF_PLUGIN_H
 #define EDITOR_SCENE_EXPORTER_GLTF_PLUGIN_H
 
-#if TOOLS_ENABLED
+#ifdef TOOLS_ENABLED
+
 #include "editor/editor_plugin.h"
 #include "editor_scene_importer_gltf.h"
 
@@ -47,5 +48,7 @@ public:
 	bool has_main_screen() const override;
 	SceneExporterGLTFPlugin();
 };
+
 #endif // TOOLS_ENABLED
+
 #endif // EDITOR_SCENE_EXPORTER_GLTF_PLUGIN_H

--- a/modules/gltf/editor/editor_scene_importer_gltf.h
+++ b/modules/gltf/editor/editor_scene_importer_gltf.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  csg_gizmos.h                                                         */
+/*  editor_scene_importer_gltf.h                                         */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,36 +28,31 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef CSG_GIZMOS_H
-#define CSG_GIZMOS_H
+#ifndef EDITOR_SCENE_IMPORTER_GLTF_H
+#define EDITOR_SCENE_IMPORTER_GLTF_H
 
-#include "csg_shape.h"
-#include "editor/editor_plugin.h"
-#include "editor/plugins/node_3d_editor_gizmos.h"
+#ifdef TOOLS_ENABLED
 
-class CSGShape3DGizmoPlugin : public EditorNode3DGizmoPlugin {
-	GDCLASS(CSGShape3DGizmoPlugin, EditorNode3DGizmoPlugin);
+#include "../gltf_document_extension.h"
+#include "../gltf_state.h"
 
-public:
-	virtual bool has_gizmo(Node3D *p_spatial) override;
-	virtual String get_gizmo_name() const override;
-	virtual int get_priority() const override;
-	virtual bool is_selectable_when_hidden() const override;
-	virtual void redraw(EditorNode3DGizmo *p_gizmo) override;
+#include "editor/import/resource_importer_scene.h"
+#include "scene/main/node.h"
+#include "scene/resources/packed_scene.h"
 
-	virtual String get_handle_name(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const override;
-	virtual Variant get_handle_value(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary) const override;
-	virtual void set_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, Camera3D *p_camera, const Point2 &p_point) override;
-	virtual void commit_handle(const EditorNode3DGizmo *p_gizmo, int p_id, bool p_secondary, const Variant &p_restore, bool p_cancel) override;
+class Animation;
 
-	CSGShape3DGizmoPlugin();
-};
-
-class EditorPluginCSG : public EditorPlugin {
-	GDCLASS(EditorPluginCSG, EditorPlugin);
+class EditorSceneFormatImporterGLTF : public EditorSceneFormatImporter {
+	GDCLASS(EditorSceneFormatImporterGLTF, EditorSceneFormatImporter);
 
 public:
-	EditorPluginCSG();
+	virtual uint32_t get_import_flags() const override;
+	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps, List<String> *r_missing_deps, Error *r_err = nullptr) override;
+	virtual Ref<Animation> import_animation(const String &p_path,
+			uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps) override;
 };
 
-#endif // CSG_GIZMOS_H
+#endif // TOOLS_ENABLED
+
+#endif // EDITOR_SCENE_IMPORTER_GLTF_H

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -30,9 +30,8 @@
 
 #include "register_types.h"
 
-#include "editor/editor_node.h"
-#include "editor_scene_exporter_gltf_plugin.h"
-#include "editor_scene_importer_gltf.h"
+#ifndef _3D_DISABLED
+
 #include "gltf_accessor.h"
 #include "gltf_animation.h"
 #include "gltf_buffer_view.h"
@@ -49,18 +48,19 @@
 #include "gltf_state.h"
 #include "gltf_texture.h"
 
-#ifndef _3D_DISABLED
 #ifdef TOOLS_ENABLED
+#include "editor/editor_node.h"
+#include "editor/editor_scene_exporter_gltf_plugin.h"
+#include "editor/editor_scene_importer_gltf.h"
+
 static void _editor_init() {
 	Ref<EditorSceneFormatImporterGLTF> import_gltf;
 	import_gltf.instantiate();
 	ResourceImporterScene::get_singleton()->add_importer(import_gltf);
 }
 #endif
-#endif
 
 void register_gltf_types() {
-#ifndef _3D_DISABLED
 #ifdef TOOLS_ENABLED
 	ClassDB::APIType prev_api = ClassDB::get_current_api();
 	ClassDB::set_current_api(ClassDB::API_EDITOR);
@@ -84,8 +84,9 @@ void register_gltf_types() {
 	GDREGISTER_CLASS(GLTFDocumentExtensionConvertImporterMesh);
 	GDREGISTER_CLASS(GLTFDocumentExtension);
 	GDREGISTER_CLASS(GLTFDocument);
-#endif
 }
 
 void unregister_gltf_types() {
 }
+
+#endif // _3D_DISABLED

--- a/modules/gridmap/SCsub
+++ b/modules/gridmap/SCsub
@@ -5,4 +5,7 @@ Import("env_modules")
 
 env_gridmap = env_modules.Clone()
 
+# Godot's own source files
 env_gridmap.add_source_files(env.modules_sources, "*.cpp")
+if env["tools"]:
+    env_gridmap.add_source_files(env.modules_sources, "editor/*.cpp")

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -29,14 +29,16 @@
 /*************************************************************************/
 
 #include "grid_map_editor_plugin.h"
+
+#ifdef TOOLS_ENABLED
+
 #include "core/input/input.h"
+#include "core/os/keyboard.h"
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "scene/3d/camera_3d.h"
-
-#include "core/os/keyboard.h"
 #include "scene/main/window.h"
 
 void GridMapEditor::_node_removed(Node *p_node) {
@@ -1479,3 +1481,5 @@ GridMapEditorPlugin::GridMapEditorPlugin() {
 
 GridMapEditorPlugin::~GridMapEditorPlugin() {
 }
+
+#endif // TOOLS_ENABLED

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -31,8 +31,10 @@
 #ifndef GRID_MAP_EDITOR_PLUGIN_H
 #define GRID_MAP_EDITOR_PLUGIN_H
 
+#ifdef TOOLS_ENABLED
+
+#include "../grid_map.h"
 #include "editor/editor_plugin.h"
-#include "grid_map.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/slider.h"
 #include "scene/gui/spin_box.h"
@@ -249,4 +251,6 @@ public:
 	~GridMapEditorPlugin();
 };
 
-#endif // CUBE_GRID_MAP_EDITOR_PLUGIN_H
+#endif // TOOLS_ENABLED
+
+#endif // GRID_MAP_EDITOR_PLUGIN_H

--- a/modules/gridmap/register_types.cpp
+++ b/modules/gridmap/register_types.cpp
@@ -28,21 +28,25 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "register_types.h"
 #ifndef _3D_DISABLED
+
+#include "register_types.h"
+
 #include "core/object/class_db.h"
 #include "grid_map.h"
-#include "grid_map_editor_plugin.h"
+
+#ifdef TOOLS_ENABLED
+#include "editor/grid_map_editor_plugin.h"
 #endif
 
 void register_gridmap_types() {
-#ifndef _3D_DISABLED
 	GDREGISTER_CLASS(GridMap);
 #ifdef TOOLS_ENABLED
 	EditorPlugins::add_by_type<GridMapEditorPlugin>();
-#endif
 #endif
 }
 
 void unregister_gridmap_types() {
 }
+
+#endif // _3D_DISABLED

--- a/modules/navigation/SCsub
+++ b/modules/navigation/SCsub
@@ -57,6 +57,8 @@ env.modules_sources += thirdparty_obj
 module_obj = []
 
 env_navigation.add_source_files(module_obj, "*.cpp")
+if env["tools"]:
+    env_navigation.add_source_files(module_obj, "editor/*.cpp")
 env.modules_sources += module_obj
 
 # Needed to force rebuilding the module files when the thirdparty library is updated.

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.cpp
@@ -28,13 +28,14 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifdef TOOLS_ENABLED
 #include "navigation_mesh_editor_plugin.h"
 
+#ifdef TOOLS_ENABLED
+
+#include "../navigation_mesh_generator.h"
 #include "core/io/marshalls.h"
 #include "core/io/resource_saver.h"
 #include "editor/editor_node.h"
-#include "navigation_mesh_generator.h"
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/gui/box_container.h"
 
@@ -153,4 +154,4 @@ NavigationMeshEditorPlugin::NavigationMeshEditorPlugin() {
 NavigationMeshEditorPlugin::~NavigationMeshEditorPlugin() {
 }
 
-#endif
+#endif // TOOLS_ENABLED

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.h
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  editor_scene_importer_gltf.h                                         */
+/*  navigation_mesh_editor_plugin.h                                      */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,28 +28,59 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITOR_SCENE_IMPORTER_GLTF_H
-#define EDITOR_SCENE_IMPORTER_GLTF_H
+#ifndef NAVIGATION_MESH_EDITOR_PLUGIN_H
+#define NAVIGATION_MESH_EDITOR_PLUGIN_H
+
 #ifdef TOOLS_ENABLED
-#include "gltf_state.h"
 
-#include "gltf_document_extension.h"
+#include "editor/editor_plugin.h"
 
-#include "editor/import/resource_importer_scene.h"
-#include "scene/main/node.h"
-#include "scene/resources/packed_scene.h"
+class NavigationRegion3D;
 
-class Animation;
+class NavigationMeshEditor : public Control {
+	friend class NavigationMeshEditorPlugin;
 
-class EditorSceneFormatImporterGLTF : public EditorSceneFormatImporter {
-	GDCLASS(EditorSceneFormatImporterGLTF, EditorSceneFormatImporter);
+	GDCLASS(NavigationMeshEditor, Control);
+
+	AcceptDialog *err_dialog;
+
+	HBoxContainer *bake_hbox;
+	Button *button_bake;
+	Button *button_reset;
+	Label *bake_info;
+
+	NavigationRegion3D *node;
+
+	void _bake_pressed();
+	void _clear_pressed();
+
+protected:
+	void _node_removed(Node *p_node);
+	static void _bind_methods();
+	void _notification(int p_what);
 
 public:
-	virtual uint32_t get_import_flags() const override;
-	virtual void get_extensions(List<String> *r_extensions) const override;
-	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps, List<String> *r_missing_deps, Error *r_err = nullptr) override;
-	virtual Ref<Animation> import_animation(const String &p_path,
-			uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps) override;
+	void edit(NavigationRegion3D *p_nav_region);
+	NavigationMeshEditor();
+	~NavigationMeshEditor();
 };
+
+class NavigationMeshEditorPlugin : public EditorPlugin {
+	GDCLASS(NavigationMeshEditorPlugin, EditorPlugin);
+
+	NavigationMeshEditor *navigation_mesh_editor;
+
+public:
+	virtual String get_name() const override { return "NavigationMesh"; }
+	bool has_main_screen() const override { return false; }
+	virtual void edit(Object *p_object) override;
+	virtual bool handles(Object *p_object) const override;
+	virtual void make_visible(bool p_visible) override;
+
+	NavigationMeshEditorPlugin();
+	~NavigationMeshEditorPlugin();
+};
+
 #endif // TOOLS_ENABLED
-#endif // EDITOR_SCENE_IMPORTER_GLTF_H
+
+#endif // NAVIGATION_MESH_EDITOR_PLUGIN_H

--- a/modules/navigation/register_types.cpp
+++ b/modules/navigation/register_types.cpp
@@ -40,7 +40,7 @@
 #endif
 
 #ifdef TOOLS_ENABLED
-#include "navigation_mesh_editor_plugin.h"
+#include "editor/navigation_mesh_editor_plugin.h"
 #endif
 
 #ifndef _3D_DISABLED

--- a/modules/websocket/SCsub
+++ b/modules/websocket/SCsub
@@ -41,6 +41,8 @@ elif env["builtin_wslay"]:
 module_obj = []
 
 env_ws.add_source_files(module_obj, "*.cpp")
+if env["tools"]:
+    env_ws.add_source_files(module_obj, "editor/*.cpp")
 env.modules_sources += module_obj
 
 # Needed to force rebuilding the module files when the thirdparty library is updated.

--- a/modules/websocket/editor/editor_debugger_server_websocket.cpp
+++ b/modules/websocket/editor/editor_debugger_server_websocket.cpp
@@ -30,11 +30,13 @@
 
 #include "editor_debugger_server_websocket.h"
 
+#ifdef TOOLS_ENABLED
+
+#include "../remote_debugger_peer_websocket.h"
 #include "core/config/project_settings.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
-#include "modules/websocket/remote_debugger_peer_websocket.h"
 
 void EditorDebuggerServerWebSocket::_peer_connected(int p_id, String _protocol) {
 	pending_peers.push_back(p_id);
@@ -129,3 +131,5 @@ EditorDebuggerServer *EditorDebuggerServerWebSocket::create(const String &p_prot
 	ERR_FAIL_COND_V(p_protocol != "ws://", nullptr);
 	return memnew(EditorDebuggerServerWebSocket);
 }
+
+#endif // TOOLS_ENABLED

--- a/modules/websocket/editor/editor_debugger_server_websocket.h
+++ b/modules/websocket/editor/editor_debugger_server_websocket.h
@@ -31,8 +31,10 @@
 #ifndef EDITOR_DEBUGGER_SERVER_WEBSOCKET_H
 #define EDITOR_DEBUGGER_SERVER_WEBSOCKET_H
 
+#ifdef TOOLS_ENABLED
+
+#include "../websocket_server.h"
 #include "editor/debugger/editor_debugger_server.h"
-#include "modules/websocket/websocket_server.h"
 
 class EditorDebuggerServerWebSocket : public EditorDebuggerServer {
 	GDCLASS(EditorDebuggerServerWebSocket, EditorDebuggerServer);
@@ -59,5 +61,7 @@ public:
 	EditorDebuggerServerWebSocket();
 	~EditorDebuggerServerWebSocket();
 };
+
+#endif // TOOLS_ENABLED
 
 #endif // EDITOR_DEBUGGER_SERVER_WEBSOCKET_H

--- a/modules/websocket/register_types.cpp
+++ b/modules/websocket/register_types.cpp
@@ -29,8 +29,10 @@
 /*************************************************************************/
 
 #include "register_types.h"
+
 #include "core/config/project_settings.h"
 #include "core/error/error_macros.h"
+
 #ifdef JAVASCRIPT_ENABLED
 #include "emscripten.h"
 #include "emws_client.h"
@@ -40,10 +42,11 @@
 #include "wsl_client.h"
 #include "wsl_server.h"
 #endif
+
 #ifdef TOOLS_ENABLED
 #include "editor/debugger/editor_debugger_server.h"
+#include "editor/editor_debugger_server_websocket.h"
 #include "editor/editor_node.h"
-#include "editor_debugger_server_websocket.h"
 #endif
 
 #ifdef TOOLS_ENABLED

--- a/modules/websocket/remote_debugger_peer_websocket.h
+++ b/modules/websocket/remote_debugger_peer_websocket.h
@@ -31,12 +31,13 @@
 #ifndef REMOTE_DEBUGGER_PEER_WEBSOCKET_H
 #define REMOTE_DEBUGGER_PEER_WEBSOCKET_H
 
-#ifdef JAVASCRIPT_ENABLED
-#include "modules/websocket/emws_client.h"
-#else
-#include "modules/websocket/wsl_client.h"
-#endif
 #include "core/debugger/remote_debugger_peer.h"
+
+#ifdef JAVASCRIPT_ENABLED
+#include "emws_client.h"
+#else
+#include "wsl_client.h"
+#endif
 
 class RemoteDebuggerPeerWebSocket : public RemoteDebuggerPeer {
 	Ref<WebSocketClient> ws_client;


### PR DESCRIPTION
They're moved to an `editor` subfolder so that we can easily handle them separately.