### PR TITLE
Fix enabling the profiler in the debugger UI

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -104,6 +104,10 @@ void EditorProfiler::clear() {
 	updating_frame = false;
 	hover_metric = -1;
 	seeking = false;
+
+	// Ensure button text (start, stop) is correct
+	_set_button_text();
+	emit_signal(SNAME("enable_profiling"), activate->is_pressed());
 }
 
 static String _get_percent_txt(float p_value, float p_total) {
@@ -374,15 +378,23 @@ void EditorProfiler::_update_frame() {
 	updating_frame = false;
 }
 
-void EditorProfiler::_activate_pressed() {
+void EditorProfiler::_set_button_text() {
 	if (activate->is_pressed()) {
 		activate->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Stop"));
-		_clear_pressed();
 	} else {
 		activate->set_icon(get_theme_icon(SNAME("Play"), SNAME("EditorIcons")));
 		activate->set_text(TTR("Start"));
 	}
+}
+
+void EditorProfiler::_activate_pressed() {
+	_set_button_text();
+
+	if (activate->is_pressed()) {
+		_clear_pressed();
+	}
+
 	emit_signal(SNAME("enable_profiling"), activate->is_pressed());
 }
 
@@ -500,7 +512,9 @@ void EditorProfiler::_bind_methods() {
 }
 
 void EditorProfiler::set_enabled(bool p_enable) {
+	activate->set_pressed(false);
 	activate->set_disabled(!p_enable);
+	clear();
 }
 
 bool EditorProfiler::is_profiling() {

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -122,6 +122,7 @@ private:
 	Timer *frame_delay;
 	Timer *plot_delay;
 
+	void _set_button_text();
 	void _update_frame();
 
 	void _activate_pressed();

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -968,6 +968,9 @@ void ScriptEditorDebugger::stop() {
 	res_path_cache.clear();
 	profiler_signature.clear();
 
+	// Cleanup profiler and enable start again if disabled
+	profiler->set_enabled(true);
+
 	inspector->edit(nullptr);
 	_update_buttons_state();
 }


### PR DESCRIPTION
Fixes a bug where the profiler buttons would become unresponsive after pausing and restarting a running project.

https://github.com/godotengine/godot/issues/44252

> After digging some more, it appears that when entering the pause state, the proflier buttons Start and Stop become greyed out, and do not properly reset their state when the game is restarted or resumed.

> More specifically this bug occurs when:

> 1 The game is paused with the pause button (or clicking inside profiler)
> 2 The game is then restarted

> - Pausing and unpausing the game does not cause this issue.
> - Clicking inside the profiler (pausing) and then resuming the game does not cause this problem

<i>Bugsquad edit:</i>
- Fix #44252