### PR TITLE
String: Remove TTR and DTR defines in non-tools build

### DIFF
--- a/core/input/input_event.cpp
+++ b/core/input/input_event.cpp
@@ -382,7 +382,7 @@ String InputEventKey::to_string() {
 	}
 
 	String mods = InputEventWithModifiers::as_text();
-	mods = mods.is_empty() ? TTR("none") : mods;
+	mods = mods.is_empty() ? "none" : mods;
 
 	return vformat("InputEventKey: keycode=%s, mods=%s, physical=%s, pressed=%s, echo=%s", kc, mods, physical, p, e);
 }
@@ -690,14 +690,14 @@ String InputEventMouseButton::to_string() {
 		case MouseButton::WHEEL_RIGHT:
 		case MouseButton::MB_XBUTTON1:
 		case MouseButton::MB_XBUTTON2:
-			button_string += " (" + RTR(_mouse_button_descriptions[(size_t)idx - 1]) + ")"; // button index starts from 1, array index starts from 0, so subtract 1
+			button_string += vformat(" (%s)", TTRGET(_mouse_button_descriptions[(size_t)idx - 1])); // button index starts from 1, array index starts from 0, so subtract 1
 			break;
 		default:
 			break;
 	}
 
 	String mods = InputEventWithModifiers::as_text();
-	mods = mods.is_empty() ? TTR("none") : mods;
+	mods = mods.is_empty() ? "none" : mods;
 
 	// Work around the fact vformat can only take 5 substitutions but 6 need to be passed.
 	String index_and_mods = vformat("button_index=%s, mods=%s", button_index, mods);
@@ -787,19 +787,19 @@ String InputEventMouseMotion::to_string() {
 	String button_mask_string = itos((int64_t)button_mask);
 	switch (button_mask) {
 		case MouseButton::MASK_LEFT:
-			button_mask_string += " (" + RTR(_mouse_button_descriptions[(size_t)MouseButton::LEFT - 1]) + ")";
+			button_mask_string += vformat(" (%s)", TTRGET(_mouse_button_descriptions[(size_t)MouseButton::LEFT - 1]));
 			break;
 		case MouseButton::MASK_MIDDLE:
-			button_mask_string += " (" + RTR(_mouse_button_descriptions[(size_t)MouseButton::MIDDLE - 1]) + ")";
+			button_mask_string += vformat(" (%s)", TTRGET(_mouse_button_descriptions[(size_t)MouseButton::MIDDLE - 1]));
 			break;
 		case MouseButton::MASK_RIGHT:
-			button_mask_string += " (" + RTR(_mouse_button_descriptions[(size_t)MouseButton::RIGHT - 1]) + ")";
+			button_mask_string += vformat(" (%s)", TTRGET(_mouse_button_descriptions[(size_t)MouseButton::RIGHT - 1]));
 			break;
 		case MouseButton::MASK_XBUTTON1:
-			button_mask_string += " (" + RTR(_mouse_button_descriptions[(size_t)MouseButton::MB_XBUTTON1 - 1]) + ")";
+			button_mask_string += vformat(" (%s)", TTRGET(_mouse_button_descriptions[(size_t)MouseButton::MB_XBUTTON1 - 1]));
 			break;
 		case MouseButton::MASK_XBUTTON2:
-			button_mask_string += " (" + RTR(_mouse_button_descriptions[(size_t)MouseButton::MB_XBUTTON2 - 1]) + ")";
+			button_mask_string += vformat(" (%s)", TTRGET(_mouse_button_descriptions[(size_t)MouseButton::MB_XBUTTON2 - 1]));
 			break;
 		default:
 			break;
@@ -961,9 +961,9 @@ static const char *_joy_axis_descriptions[(size_t)JoyAxis::MAX] = {
 };
 
 String InputEventJoypadMotion::as_text() const {
-	String desc = axis < JoyAxis::MAX ? RTR(_joy_axis_descriptions[(size_t)axis]) : TTR("Unknown Joypad Axis");
+	String desc = axis < JoyAxis::MAX ? TTRGET(_joy_axis_descriptions[(size_t)axis]) : RTR("Unknown Joypad Axis");
 
-	return vformat(TTR("Joypad Motion on Axis %d (%s) with Value %.2f"), axis, desc, axis_value);
+	return vformat(RTR("Joypad Motion on Axis %d (%s) with Value %.2f"), axis, desc, axis_value);
 }
 
 String InputEventJoypadMotion::to_string() {

--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -378,25 +378,25 @@ Image::Image3DValidateError Image::validate_3d_image(Image::Format p_format, int
 String Image::get_3d_image_validation_error_text(Image3DValidateError p_error) {
 	switch (p_error) {
 		case VALIDATE_3D_OK: {
-			return TTR("Ok");
+			return "Ok";
 		} break;
 		case VALIDATE_3D_ERR_IMAGE_EMPTY: {
-			return TTR("Empty Image found");
+			return "Empty Image found";
 		} break;
 		case VALIDATE_3D_ERR_MISSING_IMAGES: {
-			return TTR("Missing Images");
+			return "Missing Images";
 		} break;
 		case VALIDATE_3D_ERR_EXTRA_IMAGES: {
-			return TTR("Too many Images");
+			return "Too many Images";
 		} break;
 		case VALIDATE_3D_ERR_IMAGE_SIZE_MISMATCH: {
-			return TTR("Image size mismatch");
+			return "Image size mismatch";
 		} break;
 		case VALIDATE_3D_ERR_IMAGE_FORMAT_MISMATCH: {
-			return TTR("Image format mismatch");
+			return "Image format mismatch";
 		} break;
 		case VALIDATE_3D_ERR_IMAGE_HAS_MIPMAPS: {
-			return TTR("Image has included mipmaps");
+			return "Image has included mipmaps";
 		} break;
 	}
 	return String();

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -523,10 +523,6 @@ String DTRN(const String &p_text, const String &p_text_plural, int p_n, const St
 #define TTRGET(m_value) TTR(m_value)
 
 #else
-#define TTR(m_value) String()
-#define TTRN(m_value) String()
-#define DTR(m_value) String()
-#define DTRN(m_value) String()
 #define TTRC(m_value) (m_value)
 #define TTRGET(m_value) (m_value)
 #endif

--- a/modules/lightmapper_rd/lightmapper_rd.cpp
+++ b/modules/lightmapper_rd/lightmapper_rd.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "lightmapper_rd.h"
+
 #include "core/config/project_settings.h"
 #include "core/math/geometry_2d.h"
 #include "lm_blendseams.glsl.gen.h"
@@ -174,7 +175,7 @@ Lightmapper::BakeError LightmapperRD::_blit_meshes_into_atlas(int p_max_texture_
 	}
 
 	if (p_step_function) {
-		p_step_function(0.1, TTR("Determining optimal atlas size"), p_bake_userdata, true);
+		p_step_function(0.1, RTR("Determining optimal atlas size"), p_bake_userdata, true);
 	}
 
 	atlas_size = Size2i(max, max);
@@ -243,7 +244,7 @@ Lightmapper::BakeError LightmapperRD::_blit_meshes_into_atlas(int p_max_texture_
 	emission_images.resize(atlas_slices);
 
 	if (p_step_function) {
-		p_step_function(0.2, TTR("Blitting albedo and emission"), p_bake_userdata, true);
+		p_step_function(0.2, RTR("Blitting albedo and emission"), p_bake_userdata, true);
 	}
 
 	for (int i = 0; i < atlas_slices; i++) {
@@ -295,7 +296,7 @@ void LightmapperRD::_create_acceleration_structures(RenderingDevice *rd, Size2i 
 	for (int m_i = 0; m_i < mesh_instances.size(); m_i++) {
 		if (p_step_function) {
 			float p = float(m_i + 1) / mesh_instances.size() * 0.1;
-			p_step_function(0.3 + p, vformat(TTR("Plotting mesh into acceleration structure %d/%d"), m_i + 1, mesh_instances.size()), p_bake_userdata, false);
+			p_step_function(0.3 + p, vformat(RTR("Plotting mesh into acceleration structure %d/%d"), m_i + 1, mesh_instances.size()), p_bake_userdata, false);
 		}
 
 		HashMap<Edge, EdgeUV2, EdgeHash> edges;
@@ -409,7 +410,7 @@ void LightmapperRD::_create_acceleration_structures(RenderingDevice *rd, Size2i 
 	seams.sort();
 
 	if (p_step_function) {
-		p_step_function(0.4, TTR("Optimizing acceleration structure"), p_bake_userdata, true);
+		p_step_function(0.4, RTR("Optimizing acceleration structure"), p_bake_userdata, true);
 	}
 
 	//fill list of triangles in grid
@@ -668,7 +669,7 @@ LightmapperRD::BakeError LightmapperRD::_dilate(RenderingDevice *rd, Ref<RDShade
 
 LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_denoiser, int p_bounces, float p_bias, int p_max_texture_size, bool p_bake_sh, GenerateProbes p_generate_probes, const Ref<Image> &p_environment_panorama, const Basis &p_environment_transform, BakeStepFunc p_step_function, void *p_bake_userdata) {
 	if (p_step_function) {
-		p_step_function(0.0, TTR("Begin Bake"), p_bake_userdata, true);
+		p_step_function(0.0, RTR("Begin Bake"), p_bake_userdata, true);
 	}
 	bake_textures.clear();
 	int grid_size = 128;
@@ -819,7 +820,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	_create_acceleration_structures(rd, atlas_size, atlas_slices, bounds, grid_size, probe_positions, p_generate_probes, slice_triangle_count, slice_seam_count, vertex_buffer, triangle_buffer, lights_buffer, triangle_cell_indices_buffer, probe_positions_buffer, grid_texture, seams_buffer, p_step_function, p_bake_userdata);
 
 	if (p_step_function) {
-		p_step_function(0.47, TTR("Preparing shaders"), p_bake_userdata, true);
+		p_step_function(0.47, RTR("Preparing shaders"), p_bake_userdata, true);
 	}
 
 	//shaders
@@ -1046,7 +1047,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	rd->sync();
 
 	if (p_step_function) {
-		p_step_function(0.49, TTR("Un-occluding geometry"), p_bake_userdata, true);
+		p_step_function(0.49, RTR("Un-occluding geometry"), p_bake_userdata, true);
 	}
 
 	/* UNOCCLUDE */
@@ -1086,7 +1087,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	}
 
 	if (p_step_function) {
-		p_step_function(0.5, TTR("Plot direct lighting"), p_bake_userdata, true);
+		p_step_function(0.5, RTR("Plot direct lighting"), p_bake_userdata, true);
 	}
 
 	/* PRIMARY (direct) LIGHT PASS */
@@ -1166,7 +1167,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 	/* SECONDARY (indirect) LIGHT PASS(ES) */
 	if (p_step_function) {
-		p_step_function(0.6, TTR("Integrate indirect lighting"), p_bake_userdata, true);
+		p_step_function(0.6, RTR("Integrate indirect lighting"), p_bake_userdata, true);
 	}
 
 	if (p_bounces > 0) {
@@ -1298,7 +1299,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 								int total = (atlas_slices * x_regions * y_regions * ray_iterations);
 								int percent = count * 100 / total;
 								float p = float(count) / total * 0.1;
-								p_step_function(0.6 + p, vformat(TTR("Bounce %d/%d: Integrate indirect lighting %d%%"), b + 1, p_bounces, percent), p_bake_userdata, false);
+								p_step_function(0.6 + p, vformat(RTR("Bounce %d/%d: Integrate indirect lighting %d%%"), b + 1, p_bounces, percent), p_bake_userdata, false);
 							}
 						}
 					}
@@ -1323,7 +1324,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 		light_probe_buffer = rd->storage_buffer_create(sizeof(float) * 4 * 9 * probe_positions.size());
 
 		if (p_step_function) {
-			p_step_function(0.7, TTR("Baking lightprobes"), p_bake_userdata, true);
+			p_step_function(0.7, RTR("Baking lightprobes"), p_bake_userdata, true);
 		}
 
 		Vector<RD::Uniform> uniforms;
@@ -1398,7 +1399,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 			if (p_step_function) {
 				int percent = i * 100 / ray_iterations;
 				float p = float(i) / ray_iterations * 0.1;
-				p_step_function(0.7 + p, vformat(TTR("Integrating light probes %d%%"), percent), p_bake_userdata, false);
+				p_step_function(0.7 + p, vformat(RTR("Integrating light probes %d%%"), percent), p_bake_userdata, false);
 			}
 		}
 
@@ -1434,7 +1435,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 
 	if (p_use_denoiser) {
 		if (p_step_function) {
-			p_step_function(0.8, TTR("Denoising"), p_bake_userdata, true);
+			p_step_function(0.8, RTR("Denoising"), p_bake_userdata, true);
 		}
 
 		Ref<LightmapDenoiser> denoiser = LightmapDenoiser::create();
@@ -1639,7 +1640,7 @@ LightmapperRD::BakeError LightmapperRD::bake(BakeQuality p_quality, bool p_use_d
 	}
 #endif
 	if (p_step_function) {
-		p_step_function(0.9, TTR("Retrieving textures"), p_bake_userdata, true);
+		p_step_function(0.9, RTR("Retrieving textures"), p_bake_userdata, true);
 	}
 
 	for (int i = 0; i < atlas_slices * (p_bake_sh ? 4 : 1); i++) {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -388,7 +388,7 @@ String CSharpLanguage::validate_path(const String &p_path) const {
 	List<String> keywords;
 	get_reserved_words(&keywords);
 	if (keywords.find(class_name)) {
-		return TTR("Class name can't be a reserved keyword");
+		return RTR("Class name can't be a reserved keyword");
 	}
 	return "";
 }

--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -437,7 +437,7 @@ TypedArray<String> AnimatedSprite2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (frames.is_null()) {
-		warnings.push_back(TTR("A SpriteFrames resource must be created or set in the \"Frames\" property in order for AnimatedSprite to display frames."));
+		warnings.push_back(RTR("A SpriteFrames resource must be created or set in the \"Frames\" property in order for AnimatedSprite to display frames."));
 	}
 
 	return warnings;

--- a/scene/2d/canvas_modulate.cpp
+++ b/scene/2d/canvas_modulate.cpp
@@ -86,7 +86,7 @@ TypedArray<String> CanvasModulate::get_configuration_warnings() const {
 		get_tree()->get_nodes_in_group("_canvas_modulate_" + itos(get_canvas().get_id()), &nodes);
 
 		if (nodes.size() > 1) {
-			warnings.push_back(TTR("Only one visible CanvasModulate is allowed per scene (or set of instantiated scenes). The first created one will work, while the rest will be ignored."));
+			warnings.push_back(RTR("Only one visible CanvasModulate is allowed per scene (or set of instantiated scenes). The first created one will work, while the rest will be ignored."));
 		}
 	}
 

--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -558,7 +558,7 @@ TypedArray<String> CollisionObject2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (shapes.is_empty()) {
-		warnings.push_back(TTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape2D or CollisionPolygon2D as a child to define its shape."));
+		warnings.push_back(RTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape2D or CollisionPolygon2D as a child to define its shape."));
 	}
 
 	return warnings;

--- a/scene/2d/collision_polygon_2d.cpp
+++ b/scene/2d/collision_polygon_2d.cpp
@@ -238,20 +238,20 @@ TypedArray<String> CollisionPolygon2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<CollisionObject2D>(get_parent())) {
-		warnings.push_back(TTR("CollisionPolygon2D only serves to provide a collision shape to a CollisionObject2D derived node. Please only use it as a child of Area2D, StaticBody2D, RigidDynamicBody2D, CharacterBody2D, etc. to give them a shape."));
+		warnings.push_back(RTR("CollisionPolygon2D only serves to provide a collision shape to a CollisionObject2D derived node. Please only use it as a child of Area2D, StaticBody2D, RigidDynamicBody2D, CharacterBody2D, etc. to give them a shape."));
 	}
 
 	int polygon_count = polygon.size();
 	if (polygon_count == 0) {
-		warnings.push_back(TTR("An empty CollisionPolygon2D has no effect on collision."));
+		warnings.push_back(RTR("An empty CollisionPolygon2D has no effect on collision."));
 	} else {
 		bool solids = build_mode == BUILD_SOLIDS;
 		if (solids) {
 			if (polygon_count < 3) {
-				warnings.push_back(TTR("Invalid polygon. At least 3 points are needed in 'Solids' build mode."));
+				warnings.push_back(RTR("Invalid polygon. At least 3 points are needed in 'Solids' build mode."));
 			}
 		} else if (polygon_count < 2) {
-			warnings.push_back(TTR("Invalid polygon. At least 2 points are needed in 'Segments' build mode."));
+			warnings.push_back(RTR("Invalid polygon. At least 2 points are needed in 'Segments' build mode."));
 		}
 	}
 

--- a/scene/2d/collision_shape_2d.cpp
+++ b/scene/2d/collision_shape_2d.cpp
@@ -171,16 +171,16 @@ TypedArray<String> CollisionShape2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<CollisionObject2D>(get_parent())) {
-		warnings.push_back(TTR("CollisionShape2D only serves to provide a collision shape to a CollisionObject2D derived node. Please only use it as a child of Area2D, StaticBody2D, RigidDynamicBody2D, CharacterBody2D, etc. to give them a shape."));
+		warnings.push_back(RTR("CollisionShape2D only serves to provide a collision shape to a CollisionObject2D derived node. Please only use it as a child of Area2D, StaticBody2D, RigidDynamicBody2D, CharacterBody2D, etc. to give them a shape."));
 	}
 	if (!shape.is_valid()) {
-		warnings.push_back(TTR("A shape must be provided for CollisionShape2D to function. Please create a shape resource for it!"));
+		warnings.push_back(RTR("A shape must be provided for CollisionShape2D to function. Please create a shape resource for it!"));
 	}
 
 	Ref<ConvexPolygonShape2D> convex = shape;
 	Ref<ConcavePolygonShape2D> concave = shape;
 	if (convex.is_valid() || concave.is_valid()) {
-		warnings.push_back(TTR("Polygon-based shapes are not meant be used nor edited directly through the CollisionShape2D node. Please use the CollisionPolygon2D node instead."));
+		warnings.push_back(RTR("Polygon-based shapes are not meant be used nor edited directly through the CollisionShape2D node. Please use the CollisionPolygon2D node instead."));
 	}
 
 	return warnings;

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -250,7 +250,7 @@ TypedArray<String> CPUParticles2D::get_configuration_warnings() const {
 	if (get_material().is_null() || (mat && !mat->get_particles_animation())) {
 		if (get_param_max(PARAM_ANIM_SPEED) != 0.0 || get_param_max(PARAM_ANIM_OFFSET) != 0.0 ||
 				get_param_curve(PARAM_ANIM_SPEED).is_valid() || get_param_curve(PARAM_ANIM_OFFSET).is_valid()) {
-			warnings.push_back(TTR("CPUParticles2D animation requires the usage of a CanvasItemMaterial with \"Particles Animation\" enabled."));
+			warnings.push_back(RTR("CPUParticles2D animation requires the usage of a CanvasItemMaterial with \"Particles Animation\" enabled."));
 		}
 	}
 

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -291,11 +291,11 @@ TypedArray<String> GPUParticles2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (RenderingServer::get_singleton()->is_low_end()) {
-		warnings.push_back(TTR("GPU-based particles are not supported by the OpenGL video driver.\nUse the CPUParticles2D node instead. You can use the \"Convert to CPUParticles2D\" option for this purpose."));
+		warnings.push_back(RTR("GPU-based particles are not supported by the OpenGL video driver.\nUse the CPUParticles2D node instead. You can use the \"Convert to CPUParticles2D\" option for this purpose."));
 	}
 
 	if (process_material.is_null()) {
-		warnings.push_back(TTR("A material to process the particles is not assigned, so no behavior is imprinted."));
+		warnings.push_back(RTR("A material to process the particles is not assigned, so no behavior is imprinted."));
 	} else {
 		CanvasItemMaterial *mat = Object::cast_to<CanvasItemMaterial>(get_material().ptr());
 
@@ -304,7 +304,7 @@ TypedArray<String> GPUParticles2D::get_configuration_warnings() const {
 			if (process &&
 					(process->get_param_max(ParticlesMaterial::PARAM_ANIM_SPEED) != 0.0 || process->get_param_max(ParticlesMaterial::PARAM_ANIM_OFFSET) != 0.0 ||
 							process->get_param_texture(ParticlesMaterial::PARAM_ANIM_SPEED).is_valid() || process->get_param_texture(ParticlesMaterial::PARAM_ANIM_OFFSET).is_valid())) {
-				warnings.push_back(TTR("Particles2D animation requires the usage of a CanvasItemMaterial with \"Particles Animation\" enabled."));
+				warnings.push_back(RTR("Particles2D animation requires the usage of a CanvasItemMaterial with \"Particles Animation\" enabled."));
 			}
 		}
 	}

--- a/scene/2d/joint_2d.cpp
+++ b/scene/2d/joint_2d.cpp
@@ -77,15 +77,15 @@ void Joint2D::_update_joint(bool p_only_free) {
 	bool valid = false;
 
 	if (node_a && !body_a && node_b && !body_b) {
-		warning = TTR("Node A and Node B must be PhysicsBody2Ds");
+		warning = RTR("Node A and Node B must be PhysicsBody2Ds");
 	} else if (node_a && !body_a) {
-		warning = TTR("Node A must be a PhysicsBody2D");
+		warning = RTR("Node A must be a PhysicsBody2D");
 	} else if (node_b && !body_b) {
-		warning = TTR("Node B must be a PhysicsBody2D");
+		warning = RTR("Node B must be a PhysicsBody2D");
 	} else if (!body_a || !body_b) {
-		warning = TTR("Joint is not connected to two PhysicsBody2Ds");
+		warning = RTR("Joint is not connected to two PhysicsBody2Ds");
 	} else if (body_a == body_b) {
-		warning = TTR("Node A and Node B must be different PhysicsBody2Ds");
+		warning = RTR("Node A and Node B must be different PhysicsBody2Ds");
 	} else {
 		warning = String();
 		valid = true;

--- a/scene/2d/light_2d.cpp
+++ b/scene/2d/light_2d.cpp
@@ -394,7 +394,7 @@ TypedArray<String> PointLight2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!texture.is_valid()) {
-		warnings.push_back(TTR("A texture with the shape of the light must be supplied to the \"Texture\" property."));
+		warnings.push_back(RTR("A texture with the shape of the light must be supplied to the \"Texture\" property."));
 	}
 
 	return warnings;

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -250,11 +250,11 @@ TypedArray<String> LightOccluder2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!occluder_polygon.is_valid()) {
-		warnings.push_back(TTR("An occluder polygon must be set (or drawn) for this occluder to take effect."));
+		warnings.push_back(RTR("An occluder polygon must be set (or drawn) for this occluder to take effect."));
 	}
 
 	if (occluder_polygon.is_valid() && occluder_polygon->get_polygon().size() == 0) {
-		warnings.push_back(TTR("The occluder polygon for this occluder is empty. Please draw a polygon."));
+		warnings.push_back(RTR("The occluder polygon for this occluder is empty. Please draw a polygon."));
 	}
 
 	return warnings;

--- a/scene/2d/navigation_agent_2d.cpp
+++ b/scene/2d/navigation_agent_2d.cpp
@@ -244,7 +244,7 @@ TypedArray<String> NavigationAgent2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<Node2D>(get_parent())) {
-		warnings.push_back(TTR("The NavigationAgent2D can be used only under a Node2D node."));
+		warnings.push_back(RTR("The NavigationAgent2D can be used only under a Node2D node."));
 	}
 
 	return warnings;

--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -100,7 +100,7 @@ TypedArray<String> NavigationObstacle2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<Node2D>(get_parent())) {
-		warnings.push_back(TTR("The NavigationObstacle2D only serves to provide collision avoidance to a Node2D object."));
+		warnings.push_back(RTR("The NavigationObstacle2D only serves to provide collision avoidance to a Node2D object."));
 	}
 
 	return warnings;

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -517,7 +517,7 @@ TypedArray<String> NavigationRegion2D::get_configuration_warnings() const {
 
 	if (is_visible_in_tree() && is_inside_tree()) {
 		if (!navpoly.is_valid()) {
-			warnings.push_back(TTR("A NavigationMesh resource must be set or created for this node to work. Please set a property or draw a polygon."));
+			warnings.push_back(RTR("A NavigationMesh resource must be set or created for this node to work. Please set a property or draw a polygon."));
 		}
 	}
 

--- a/scene/2d/parallax_layer.cpp
+++ b/scene/2d/parallax_layer.cpp
@@ -143,7 +143,7 @@ TypedArray<String> ParallaxLayer::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<ParallaxBackground>(get_parent())) {
-		warnings.push_back(TTR("ParallaxLayer node only works when set as child of a ParallaxBackground node."));
+		warnings.push_back(RTR("ParallaxLayer node only works when set as child of a ParallaxBackground node."));
 	}
 
 	return warnings;

--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -263,7 +263,7 @@ TypedArray<String> PathFollow2D::get_configuration_warnings() const {
 
 	if (is_visible_in_tree() && is_inside_tree()) {
 		if (!Object::cast_to<Path2D>(get_parent())) {
-			warnings.push_back(TTR("PathFollow2D only works when set as a child of a Path2D node."));
+			warnings.push_back(RTR("PathFollow2D only works when set as a child of a Path2D node."));
 		}
 	}
 

--- a/scene/2d/physical_bone_2d.cpp
+++ b/scene/2d/physical_bone_2d.cpp
@@ -110,15 +110,15 @@ TypedArray<String> PhysicalBone2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!parent_skeleton) {
-		warnings.push_back(TTR("A PhysicalBone2D only works with a Skeleton2D or another PhysicalBone2D as a parent node!"));
+		warnings.push_back(RTR("A PhysicalBone2D only works with a Skeleton2D or another PhysicalBone2D as a parent node!"));
 	}
 	if (parent_skeleton && bone2d_index <= -1) {
-		warnings.push_back(TTR("A PhysicalBone2D needs to be assigned to a Bone2D node in order to function! Please set a Bone2D node in the inspector."));
+		warnings.push_back(RTR("A PhysicalBone2D needs to be assigned to a Bone2D node in order to function! Please set a Bone2D node in the inspector."));
 	}
 	if (!child_joint) {
 		PhysicalBone2D *parent_bone = Object::cast_to<PhysicalBone2D>(get_parent());
 		if (parent_bone) {
-			warnings.push_back(TTR("A PhysicalBone2D node should have a Joint2D-based child node to keep bones connected! Please add a Joint2D-based node as a child to this node!"));
+			warnings.push_back(RTR("A PhysicalBone2D node should have a Joint2D-based child node to keep bones connected! Please add a Joint2D-based node as a child to this node!"));
 		}
 	}
 

--- a/scene/2d/physics_body_2d.cpp
+++ b/scene/2d/physics_body_2d.cpp
@@ -925,7 +925,7 @@ TypedArray<String> RigidDynamicBody2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = CollisionObject2D::get_configuration_warnings();
 
 	if (ABS(t.elements[0].length() - 1.0) > 0.05 || ABS(t.elements[1].length() - 1.0) > 0.05) {
-		warnings.push_back(TTR("Size changes to RigidDynamicBody2D will be overridden by the physics engine when running.\nChange the size in children collision shapes instead."));
+		warnings.push_back(RTR("Size changes to RigidDynamicBody2D will be overridden by the physics engine when running.\nChange the size in children collision shapes instead."));
 	}
 
 	return warnings;

--- a/scene/2d/remote_transform_2d.cpp
+++ b/scene/2d/remote_transform_2d.cpp
@@ -187,7 +187,7 @@ TypedArray<String> RemoteTransform2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!has_node(remote_node) || !Object::cast_to<Node2D>(get_node(remote_node))) {
-		warnings.push_back(TTR("Path property must point to a valid Node2D node to work."));
+		warnings.push_back(RTR("Path property must point to a valid Node2D node to work."));
 	}
 
 	return warnings;

--- a/scene/2d/shape_cast_2d.cpp
+++ b/scene/2d/shape_cast_2d.cpp
@@ -382,7 +382,7 @@ TypedArray<String> ShapeCast2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node2D::get_configuration_warnings();
 
 	if (shape.is_null()) {
-		warnings.push_back(TTR("This node cannot interact with other objects unless a Shape2D is assigned."));
+		warnings.push_back(RTR("This node cannot interact with other objects unless a Shape2D is assigned."));
 	}
 	return warnings;
 }

--- a/scene/2d/skeleton_2d.cpp
+++ b/scene/2d/skeleton_2d.cpp
@@ -438,14 +438,14 @@ TypedArray<String> Bone2D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 	if (!skeleton) {
 		if (parent_bone) {
-			warnings.push_back(TTR("This Bone2D chain should end at a Skeleton2D node."));
+			warnings.push_back(RTR("This Bone2D chain should end at a Skeleton2D node."));
 		} else {
-			warnings.push_back(TTR("A Bone2D only works with a Skeleton2D or another Bone2D as parent node."));
+			warnings.push_back(RTR("A Bone2D only works with a Skeleton2D or another Bone2D as parent node."));
 		}
 	}
 
 	if (rest == Transform2D(0, 0, 0, 0, 0, 0)) {
-		warnings.push_back(TTR("This bone lacks a proper REST pose. Go to the Skeleton2D node and set one."));
+		warnings.push_back(RTR("This bone lacks a proper REST pose. Go to the Skeleton2D node and set one."));
 	}
 
 	return warnings;

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -3586,7 +3586,7 @@ TypedArray<String> TileMap::get_configuration_warnings() const {
 	// Check if we have a non-sorted layer in a Z-index with a Y-sorted layer.
 	for (int layer = 0; layer < (int)layers.size(); layer++) {
 		if (!layers[layer].y_sort_enabled && y_sorted_z_index.has(layers[layer].z_index)) {
-			warnings.push_back(TTR("A Y-sorted layer has the same Z-index value as a not Y-sorted layer.\nThis may lead to unwanted behaviors, as a layer that is not Y-sorted will be Y-sorted as a whole with tiles from Y-sorted layers."));
+			warnings.push_back(RTR("A Y-sorted layer has the same Z-index value as a not Y-sorted layer.\nThis may lead to unwanted behaviors, as a layer that is not Y-sorted will be Y-sorted as a whole with tiles from Y-sorted layers."));
 			break;
 		}
 	}

--- a/scene/3d/bone_attachment_3d.cpp
+++ b/scene/3d/bone_attachment_3d.cpp
@@ -107,17 +107,17 @@ TypedArray<String> BoneAttachment3D::get_configuration_warnings() const {
 
 	if (use_external_skeleton) {
 		if (external_skeleton_node_cache.is_null()) {
-			warnings.append(TTR("External Skeleton3D node not set! Please set a path to an external Skeleton3D node."));
+			warnings.push_back(RTR("External Skeleton3D node not set! Please set a path to an external Skeleton3D node."));
 		}
 	} else {
 		Skeleton3D *parent = Object::cast_to<Skeleton3D>(get_parent());
 		if (!parent) {
-			warnings.append(TTR("Parent node is not a Skeleton3D node! Please use an external Skeleton3D if you intend to use the BoneAttachment3D without it being a child of a Skeleton3D node."));
+			warnings.push_back(RTR("Parent node is not a Skeleton3D node! Please use an external Skeleton3D if you intend to use the BoneAttachment3D without it being a child of a Skeleton3D node."));
 		}
 	}
 
 	if (bone_idx == -1) {
-		warnings.append(TTR("BoneAttachment3D node is not bound to any bones! Please select a bone to attach this node."));
+		warnings.push_back(RTR("BoneAttachment3D node is not bound to any bones! Please select a bone to attach this node."));
 	}
 
 	return warnings;

--- a/scene/3d/collision_object_3d.cpp
+++ b/scene/3d/collision_object_3d.cpp
@@ -689,7 +689,7 @@ TypedArray<String> CollisionObject3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (shapes.is_empty()) {
-		warnings.push_back(TTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape3D or CollisionPolygon3D as a child to define its shape."));
+		warnings.push_back(RTR("This node has no shape, so it can't collide or interact with other objects.\nConsider adding a CollisionShape3D or CollisionPolygon3D as a child to define its shape."));
 	}
 
 	return warnings;

--- a/scene/3d/collision_polygon_3d.cpp
+++ b/scene/3d/collision_polygon_3d.cpp
@@ -171,11 +171,11 @@ TypedArray<String> CollisionPolygon3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<CollisionObject3D>(get_parent())) {
-		warnings.push_back(TTR("CollisionPolygon3D only serves to provide a collision shape to a CollisionObject3D derived node. Please only use it as a child of Area3D, StaticBody3D, RigidDynamicBody3D, CharacterBody3D, etc. to give them a shape."));
+		warnings.push_back(RTR("CollisionPolygon3D only serves to provide a collision shape to a CollisionObject3D derived node. Please only use it as a child of Area3D, StaticBody3D, RigidDynamicBody3D, CharacterBody3D, etc. to give them a shape."));
 	}
 
 	if (polygon.is_empty()) {
-		warnings.push_back(TTR("An empty CollisionPolygon3D has no effect on collision."));
+		warnings.push_back(RTR("An empty CollisionPolygon3D has no effect on collision."));
 	}
 
 	return warnings;

--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -118,17 +118,17 @@ TypedArray<String> CollisionShape3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<CollisionObject3D>(get_parent())) {
-		warnings.push_back(TTR("CollisionShape3D only serves to provide a collision shape to a CollisionObject3D derived node. Please only use it as a child of Area3D, StaticBody3D, RigidDynamicBody3D, CharacterBody3D, etc. to give them a shape."));
+		warnings.push_back(RTR("CollisionShape3D only serves to provide a collision shape to a CollisionObject3D derived node. Please only use it as a child of Area3D, StaticBody3D, RigidDynamicBody3D, CharacterBody3D, etc. to give them a shape."));
 	}
 
 	if (!shape.is_valid()) {
-		warnings.push_back(TTR("A shape must be provided for CollisionShape3D to function. Please create a shape resource for it."));
+		warnings.push_back(RTR("A shape must be provided for CollisionShape3D to function. Please create a shape resource for it."));
 	}
 
 	if (shape.is_valid() &&
 			Object::cast_to<RigidDynamicBody3D>(get_parent()) &&
 			Object::cast_to<ConcavePolygonShape3D>(*shape)) {
-		warnings.push_back(TTR("ConcavePolygonShape3D doesn't support RigidDynamicBody3D in another mode than static."));
+		warnings.push_back(RTR("ConcavePolygonShape3D doesn't support RigidDynamicBody3D in another mode than static."));
 	}
 
 	return warnings;

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -206,11 +206,11 @@ TypedArray<String> CPUParticles3D::get_configuration_warnings() const {
 	anim_material_found = anim_material_found || (spat && spat->get_billboard_mode() == StandardMaterial3D::BILLBOARD_PARTICLES);
 
 	if (!mesh_found) {
-		warnings.push_back(TTR("Nothing is visible because no mesh has been assigned."));
+		warnings.push_back(RTR("Nothing is visible because no mesh has been assigned."));
 	}
 
 	if (!anim_material_found && (get_param_max(PARAM_ANIM_SPEED) != 0.0 || get_param_max(PARAM_ANIM_OFFSET) != 0.0 || get_param_curve(PARAM_ANIM_SPEED).is_valid() || get_param_curve(PARAM_ANIM_OFFSET).is_valid())) {
-		warnings.push_back(TTR("CPUParticles3D animation requires the usage of a StandardMaterial3D whose Billboard Mode is set to \"Particle Billboard\"."));
+		warnings.push_back(RTR("CPUParticles3D animation requires the usage of a StandardMaterial3D whose Billboard Mode is set to \"Particle Billboard\"."));
 	}
 
 	return warnings;

--- a/scene/3d/decal.cpp
+++ b/scene/3d/decal.cpp
@@ -163,15 +163,15 @@ TypedArray<String> Decal::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (textures[TEXTURE_ALBEDO].is_null() && textures[TEXTURE_NORMAL].is_null() && textures[TEXTURE_ORM].is_null() && textures[TEXTURE_EMISSION].is_null()) {
-		warnings.push_back(TTR("The decal has no textures loaded into any of its texture properties, and will therefore not be visible."));
+		warnings.push_back(RTR("The decal has no textures loaded into any of its texture properties, and will therefore not be visible."));
 	}
 
 	if ((textures[TEXTURE_NORMAL].is_valid() || textures[TEXTURE_ORM].is_valid()) && textures[TEXTURE_ALBEDO].is_null()) {
-		warnings.push_back(TTR("The decal has a Normal and/or ORM texture, but no Albedo texture is set.\nAn Albedo texture with an alpha channel is required to blend the normal/ORM maps onto the underlying surface.\nIf you don't want the Albedo texture to be visible, set Albedo Mix to 0."));
+		warnings.push_back(RTR("The decal has a Normal and/or ORM texture, but no Albedo texture is set.\nAn Albedo texture with an alpha channel is required to blend the normal/ORM maps onto the underlying surface.\nIf you don't want the Albedo texture to be visible, set Albedo Mix to 0."));
 	}
 
 	if (cull_mask == 0) {
-		warnings.push_back(TTR("The decal's Cull Mask has no bits enabled, which means the decal will not paint objects on any layer.\nTo resolve this, enable at least one bit in the Cull Mask property."));
+		warnings.push_back(RTR("The decal's Cull Mask has no bits enabled, which means the decal will not paint objects on any layer.\nTo resolve this, enable at least one bit in the Cull Mask property."));
 	}
 
 	return warnings;

--- a/scene/3d/gpu_particles_3d.cpp
+++ b/scene/3d/gpu_particles_3d.cpp
@@ -273,7 +273,7 @@ TypedArray<String> GPUParticles3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (RenderingServer::get_singleton()->is_low_end()) {
-		warnings.push_back(TTR("GPU-based particles are not supported by the OpenGL video driver.\nUse the CPUParticles3D node instead. You can use the \"Convert to CPUParticles3D\" option for this purpose."));
+		warnings.push_back(RTR("GPU-based particles are not supported by the OpenGL video driver.\nUse the CPUParticles3D node instead. You can use the \"Convert to CPUParticles3D\" option for this purpose."));
 	}
 
 	bool meshes_found = false;
@@ -300,17 +300,17 @@ TypedArray<String> GPUParticles3D::get_configuration_warnings() const {
 	}
 
 	if (!meshes_found) {
-		warnings.push_back(TTR("Nothing is visible because meshes have not been assigned to draw passes."));
+		warnings.push_back(RTR("Nothing is visible because meshes have not been assigned to draw passes."));
 	}
 
 	if (process_material.is_null()) {
-		warnings.push_back(TTR("A material to process the particles is not assigned, so no behavior is imprinted."));
+		warnings.push_back(RTR("A material to process the particles is not assigned, so no behavior is imprinted."));
 	} else {
 		const ParticlesMaterial *process = Object::cast_to<ParticlesMaterial>(process_material.ptr());
 		if (!anim_material_found && process &&
 				(process->get_param_max(ParticlesMaterial::PARAM_ANIM_SPEED) != 0.0 || process->get_param_max(ParticlesMaterial::PARAM_ANIM_OFFSET) != 0.0 ||
 						process->get_param_texture(ParticlesMaterial::PARAM_ANIM_SPEED).is_valid() || process->get_param_texture(ParticlesMaterial::PARAM_ANIM_OFFSET).is_valid())) {
-			warnings.push_back(TTR("Particles animation requires the usage of a BaseMaterial3D whose Billboard Mode is set to \"Particle Billboard\"."));
+			warnings.push_back(RTR("Particles animation requires the usage of a BaseMaterial3D whose Billboard Mode is set to \"Particle Billboard\"."));
 		}
 	}
 
@@ -352,15 +352,15 @@ TypedArray<String> GPUParticles3D::get_configuration_warnings() const {
 		}
 
 		if (dp_count && skin.is_valid()) {
-			warnings.push_back(TTR("Using Trail meshes with a skin causes Skin to override Trail poses. Suggest removing the Skin."));
+			warnings.push_back(RTR("Using Trail meshes with a skin causes Skin to override Trail poses. Suggest removing the Skin."));
 		} else if (dp_count == 0 && skin.is_null()) {
-			warnings.push_back(TTR("Trails active, but neither Trail meshes or a Skin were found."));
+			warnings.push_back(RTR("Trails active, but neither Trail meshes or a Skin were found."));
 		} else if (dp_count > 1) {
-			warnings.push_back(TTR("Only one Trail mesh is supported. If you want to use more than a single mesh, a Skin is needed (see documentation)."));
+			warnings.push_back(RTR("Only one Trail mesh is supported. If you want to use more than a single mesh, a Skin is needed (see documentation)."));
 		}
 
 		if ((dp_count || !skin.is_null()) && (missing_trails || no_materials)) {
-			warnings.push_back(TTR("Trails enabled, but one or more mesh materials are either missing or not set for trails rendering."));
+			warnings.push_back(RTR("Trails enabled, but one or more mesh materials are either missing or not set for trails rendering."));
 		}
 	}
 

--- a/scene/3d/joint_3d.cpp
+++ b/scene/3d/joint_3d.cpp
@@ -76,15 +76,15 @@ void Joint3D::_update_joint(bool p_only_free) {
 	PhysicsBody3D *body_b = Object::cast_to<PhysicsBody3D>(node_b);
 
 	if (node_a && !body_a && node_b && !body_b) {
-		warning = TTR("Node A and Node B must be PhysicsBody3Ds");
+		warning = RTR("Node A and Node B must be PhysicsBody3Ds");
 	} else if (node_a && !body_a) {
-		warning = TTR("Node A must be a PhysicsBody3D");
+		warning = RTR("Node A must be a PhysicsBody3D");
 	} else if (node_b && !body_b) {
-		warning = TTR("Node B must be a PhysicsBody3D");
+		warning = RTR("Node B must be a PhysicsBody3D");
 	} else if (!body_a && !body_b) {
-		warning = TTR("Joint is not connected to any PhysicsBody3Ds");
+		warning = RTR("Joint is not connected to any PhysicsBody3Ds");
 	} else if (body_a == body_b) {
-		warning = TTR("Node A and Node B must be different PhysicsBody3Ds");
+		warning = RTR("Node A and Node B must be different PhysicsBody3Ds");
 	} else {
 		warning = String();
 	}

--- a/scene/3d/light_3d.cpp
+++ b/scene/3d/light_3d.cpp
@@ -497,7 +497,7 @@ TypedArray<String> OmniLight3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!has_shadow() && get_projector().is_valid()) {
-		warnings.push_back(TTR("Projector texture only works with shadows active."));
+		warnings.push_back(RTR("Projector texture only works with shadows active."));
 	}
 
 	return warnings;
@@ -527,11 +527,11 @@ TypedArray<String> SpotLight3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (has_shadow() && get_param(PARAM_SPOT_ANGLE) >= 90.0) {
-		warnings.push_back(TTR("A SpotLight3D with an angle wider than 90 degrees cannot cast shadows."));
+		warnings.push_back(RTR("A SpotLight3D with an angle wider than 90 degrees cannot cast shadows."));
 	}
 
 	if (!has_shadow() && get_projector().is_valid()) {
-		warnings.push_back(TTR("Projector texture only works with shadows active."));
+		warnings.push_back(RTR("Projector texture only works with shadows active."));
 	}
 
 	return warnings;

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -635,7 +635,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 	bsud.to_percent = 0.8;
 
 	if (p_bake_step) {
-		p_bake_step(0.0, TTR("Finding meshes, lights and probes"), p_bake_userdata, true);
+		p_bake_step(0.0, RTR("Finding meshes, lights and probes"), p_bake_userdata, true);
 	}
 	/* STEP 1, FIND MESHES, LIGHTS AND PROBES */
 	Vector<Lightmapper::MeshData> mesh_data;
@@ -655,7 +655,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 		for (int m_i = 0; m_i < meshes_found.size(); m_i++) {
 			if (p_bake_step) {
 				float p = (float)(m_i) / meshes_found.size();
-				p_bake_step(p * 0.1, vformat(TTR("Preparing geometry %d/%d"), m_i, meshes_found.size()), p_bake_userdata, false);
+				p_bake_step(p * 0.1, vformat(RTR("Preparing geometry %d/%d"), m_i, meshes_found.size()), p_bake_userdata, false);
 			}
 
 			MeshesFound &mf = meshes_found.write[m_i];
@@ -790,7 +790,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 	/* STEP 2, CREATE PROBES */
 
 	if (p_bake_step) {
-		p_bake_step(0.3, TTR("Creating probes"), p_bake_userdata, true);
+		p_bake_step(0.3, RTR("Creating probes"), p_bake_userdata, true);
 	}
 
 	//bounds need to include the user probes
@@ -832,7 +832,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 		for (int i = 0; i < mesh_data.size(); i++) {
 			if (p_bake_step) {
 				float p = (float)(i) / mesh_data.size();
-				p_bake_step(0.3 + p * 0.1, vformat(TTR("Creating probes from mesh %d/%d"), i, mesh_data.size()), p_bake_userdata, false);
+				p_bake_step(0.3 + p * 0.1, vformat(RTR("Creating probes from mesh %d/%d"), i, mesh_data.size()), p_bake_userdata, false);
 			}
 
 			for (int j = 0; j < mesh_data[i].points.size(); j += 3) {
@@ -873,7 +873,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 
 	// Add everything to lightmapper
 	if (p_bake_step) {
-		p_bake_step(0.4, TTR("Preparing Lightmapper"), p_bake_userdata, true);
+		p_bake_step(0.4, RTR("Preparing Lightmapper"), p_bake_userdata, true);
 	}
 
 	{
@@ -907,7 +907,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 	// Add everything to lightmapper
 	if (environment_mode != ENVIRONMENT_MODE_DISABLED) {
 		if (p_bake_step) {
-			p_bake_step(4.1, TTR("Preparing Environment"), p_bake_userdata, true);
+			p_bake_step(4.1, RTR("Preparing Environment"), p_bake_userdata, true);
 		}
 
 		environment_transform = get_global_transform().basis;
@@ -1046,7 +1046,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 		//Obtain solved simplices
 
 		if (p_bake_step) {
-			p_bake_step(0.8, TTR("Generating Probe Volumes"), p_bake_userdata, true);
+			p_bake_step(0.8, RTR("Generating Probe Volumes"), p_bake_userdata, true);
 		}
 		Vector<Delaunay3D::OutputSimplex> solved_simplices = Delaunay3D::tetrahedralize(points);
 
@@ -1130,7 +1130,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 		}
 
 		if (p_bake_step) {
-			p_bake_step(0.9, TTR("Generating Probe Acceleration Structures"), p_bake_userdata, true);
+			p_bake_step(0.9, RTR("Generating Probe Acceleration Structures"), p_bake_userdata, true);
 		}
 
 		_compute_bsp_tree(points, bsp_planes, planes_tested, bsp_simplices, bsp_simplex_indices, bsp_nodes);

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -250,7 +250,7 @@ TypedArray<String> NavigationAgent3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<Node3D>(get_parent())) {
-		warnings.push_back(TTR("The NavigationAgent3D can be used only under a spatial node."));
+		warnings.push_back(RTR("The NavigationAgent3D can be used only under a spatial node."));
 	}
 
 	return warnings;

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -107,7 +107,7 @@ TypedArray<String> NavigationObstacle3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<Node3D>(get_parent())) {
-		warnings.push_back(TTR("The NavigationObstacle3D only serves to provide collision avoidance to a spatial object."));
+		warnings.push_back(RTR("The NavigationObstacle3D only serves to provide collision avoidance to a spatial object."));
 	}
 
 	return warnings;

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -181,7 +181,7 @@ TypedArray<String> NavigationRegion3D::get_configuration_warnings() const {
 
 	if (is_visible_in_tree() && is_inside_tree()) {
 		if (!navmesh.is_valid()) {
-			warnings.push_back(TTR("A NavigationMesh resource must be set or created for this node to work."));
+			warnings.push_back(RTR("A NavigationMesh resource must be set or created for this node to work."));
 		}
 	}
 

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -686,25 +686,25 @@ TypedArray<String> OccluderInstance3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!bool(GLOBAL_GET("rendering/occlusion_culling/use_occlusion_culling"))) {
-		warnings.push_back(TTR("Occlusion culling is disabled in the Project Settings, which means occlusion culling won't be performed in the root viewport.\nTo resolve this, open the Project Settings and enable Rendering > Occlusion Culling > Use Occlusion Culling."));
+		warnings.push_back(RTR("Occlusion culling is disabled in the Project Settings, which means occlusion culling won't be performed in the root viewport.\nTo resolve this, open the Project Settings and enable Rendering > Occlusion Culling > Use Occlusion Culling."));
 	}
 
 	if (bake_mask == 0) {
-		warnings.push_back(TTR("The Bake Mask has no bits enabled, which means baking will not produce any occluder meshes for this OccluderInstance3D.\nTo resolve this, enable at least one bit in the Bake Mask property."));
+		warnings.push_back(RTR("The Bake Mask has no bits enabled, which means baking will not produce any occluder meshes for this OccluderInstance3D.\nTo resolve this, enable at least one bit in the Bake Mask property."));
 	}
 
 	if (occluder.is_null()) {
-		warnings.push_back(TTR("No occluder mesh is defined in the Occluder property, so no occlusion culling will be performed using this OccluderInstance3D.\nTo resolve this, set the Occluder property to one of the primitive occluder types or bake the scene meshes by selecting the OccluderInstance3D and pressing the Bake Occluders button at the top of the 3D editor viewport."));
+		warnings.push_back(RTR("No occluder mesh is defined in the Occluder property, so no occlusion culling will be performed using this OccluderInstance3D.\nTo resolve this, set the Occluder property to one of the primitive occluder types or bake the scene meshes by selecting the OccluderInstance3D and pressing the Bake Occluders button at the top of the 3D editor viewport."));
 	} else {
 		Ref<ArrayOccluder3D> arr_occluder = occluder;
 		if (arr_occluder.is_valid() && arr_occluder->get_indices().size() < 3) {
 			// Setting a new ArrayOccluder3D from the inspector will create an empty occluder,
 			// so warn the user about this.
-			warnings.push_back(TTR("The occluder mesh has less than 3 vertices, so no occlusion culling will be performed using this OccluderInstance3D.\nTo generate a proper occluder mesh, select the OccluderInstance3D then use the Bake Occluders button at the top of the 3D editor viewport."));
+			warnings.push_back(RTR("The occluder mesh has less than 3 vertices, so no occlusion culling will be performed using this OccluderInstance3D.\nTo generate a proper occluder mesh, select the OccluderInstance3D then use the Bake Occluders button at the top of the 3D editor viewport."));
 		}
 		Ref<PolygonOccluder3D> poly_occluder = occluder;
 		if (poly_occluder.is_valid() && poly_occluder->get_polygon().size() < 3) {
-			warnings.push_back(TTR("The polygon occluder has less than 3 vertices, so no occlusion culling will be performed using this OccluderInstance3D.\nVertices can be added in the inspector or using the polygon editing tools at the top of the 3D editor viewport."));
+			warnings.push_back(RTR("The polygon occluder has less than 3 vertices, so no occlusion culling will be performed using this OccluderInstance3D.\nVertices can be added in the inspector or using the polygon editing tools at the top of the 3D editor viewport."));
 		}
 	}
 

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -253,11 +253,11 @@ TypedArray<String> PathFollow3D::get_configuration_warnings() const {
 
 	if (is_visible_in_tree() && is_inside_tree()) {
 		if (!Object::cast_to<Path3D>(get_parent())) {
-			warnings.push_back(TTR("PathFollow3D only works when set as a child of a Path3D node."));
+			warnings.push_back(RTR("PathFollow3D only works when set as a child of a Path3D node."));
 		} else {
 			Path3D *path = Object::cast_to<Path3D>(get_parent());
 			if (path->get_curve().is_valid() && !path->get_curve()->is_up_vector_enabled() && rotation_mode == ROTATION_ORIENTED) {
-				warnings.push_back(TTR("PathFollow3D's ROTATION_ORIENTED requires \"Up Vector\" to be enabled in its parent Path3D's Curve resource."));
+				warnings.push_back(RTR("PathFollow3D's ROTATION_ORIENTED requires \"Up Vector\" to be enabled in its parent Path3D's Curve resource."));
 			}
 		}
 	}

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -988,7 +988,7 @@ TypedArray<String> RigidDynamicBody3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (ABS(t.basis.get_axis(0).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(1).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(2).length() - 1.0) > 0.05) {
-		warnings.push_back(TTR("Size changes to RigidDynamicBody will be overridden by the physics engine when running.\nChange the size in children collision shapes instead."));
+		warnings.push_back(RTR("Size changes to RigidDynamicBody will be overridden by the physics engine when running.\nChange the size in children collision shapes instead."));
 	}
 
 	return warnings;

--- a/scene/3d/remote_transform_3d.cpp
+++ b/scene/3d/remote_transform_3d.cpp
@@ -182,7 +182,7 @@ TypedArray<String> RemoteTransform3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!has_node(remote_node) || !Object::cast_to<Node3D>(get_node(remote_node))) {
-		warnings.push_back(TTR("The \"Remote Path\" property must point to a valid Node3D or Node3D-derived node to work."));
+		warnings.push_back(RTR("The \"Remote Path\" property must point to a valid Node3D or Node3D-derived node to work."));
 	}
 
 	return warnings;

--- a/scene/3d/soft_dynamic_body_3d.cpp
+++ b/scene/3d/soft_dynamic_body_3d.cpp
@@ -378,12 +378,12 @@ TypedArray<String> SoftDynamicBody3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (mesh.is_null()) {
-		warnings.push_back(TTR("This body will be ignored until you set a mesh."));
+		warnings.push_back(RTR("This body will be ignored until you set a mesh."));
 	}
 
 	Transform3D t = get_transform();
 	if ((ABS(t.basis.get_axis(0).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(1).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(2).length() - 1.0) > 0.05)) {
-		warnings.push_back(TTR("Size changes to SoftDynamicBody3D will be overridden by the physics engine when running.\nChange the size in children collision shapes instead."));
+		warnings.push_back(RTR("Size changes to SoftDynamicBody3D will be overridden by the physics engine when running.\nChange the size in children collision shapes instead."));
 	}
 
 	return warnings;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -1200,7 +1200,7 @@ StringName AnimatedSprite3D::get_animation() const {
 TypedArray<String> AnimatedSprite3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = SpriteBase3D::get_configuration_warnings();
 	if (frames.is_null()) {
-		warnings.push_back(TTR("A SpriteFrames resource must be created or set in the \"Frames\" property in order for AnimatedSprite3D to display frames."));
+		warnings.push_back(RTR("A SpriteFrames resource must be created or set in the \"Frames\" property in order for AnimatedSprite3D to display frames."));
 	}
 
 	return warnings;

--- a/scene/3d/vehicle_body_3d.cpp
+++ b/scene/3d/vehicle_body_3d.cpp
@@ -109,7 +109,7 @@ TypedArray<String> VehicleWheel3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<VehicleBody3D>(get_parent())) {
-		warnings.push_back(TTR("VehicleWheel3D serves to provide a wheel system to a VehicleBody3D. Please use it as a child of a VehicleBody3D."));
+		warnings.push_back(RTR("VehicleWheel3D serves to provide a wheel system to a VehicleBody3D. Please use it as a child of a VehicleBody3D."));
 	}
 
 	return warnings;

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -389,15 +389,15 @@ TypedArray<String> GeometryInstance3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!Math::is_zero_approx(visibility_range_end) && visibility_range_end <= visibility_range_begin) {
-		warnings.push_back(TTR("The GeometryInstance3D visibility range's End distance is set to a non-zero value, but is lower than the Begin distance.\nThis means the GeometryInstance3D will never be visible.\nTo resolve this, set the End distance to 0 or to a value greater than the Begin distance."));
+		warnings.push_back(RTR("The GeometryInstance3D visibility range's End distance is set to a non-zero value, but is lower than the Begin distance.\nThis means the GeometryInstance3D will never be visible.\nTo resolve this, set the End distance to 0 or to a value greater than the Begin distance."));
 	}
 
 	if ((visibility_range_fade_mode == VISIBILITY_RANGE_FADE_SELF || visibility_range_fade_mode == VISIBILITY_RANGE_FADE_DEPENDENCIES) && !Math::is_zero_approx(visibility_range_begin) && Math::is_zero_approx(visibility_range_begin_margin)) {
-		warnings.push_back(TTR("The GeometryInstance3D is configured to fade in smoothly over distance, but the fade transition distance is set to 0.\nTo resolve this, increase Visibility Range Begin Margin above 0."));
+		warnings.push_back(RTR("The GeometryInstance3D is configured to fade in smoothly over distance, but the fade transition distance is set to 0.\nTo resolve this, increase Visibility Range Begin Margin above 0."));
 	}
 
 	if ((visibility_range_fade_mode == VISIBILITY_RANGE_FADE_SELF || visibility_range_fade_mode == VISIBILITY_RANGE_FADE_DEPENDENCIES) && !Math::is_zero_approx(visibility_range_end) && Math::is_zero_approx(visibility_range_end_margin)) {
-		warnings.push_back(TTR("The GeometryInstance3D is configured to fade out smoothly over distance, but the fade transition distance is set to 0.\nTo resolve this, increase Visibility Range End Margin above 0."));
+		warnings.push_back(RTR("The GeometryInstance3D is configured to fade out smoothly over distance, but the fade transition distance is set to 0.\nTo resolve this, increase Visibility Range End Margin above 0."));
 	}
 
 	return warnings;

--- a/scene/3d/voxel_gi.cpp
+++ b/scene/3d/voxel_gi.cpp
@@ -454,9 +454,9 @@ TypedArray<String> VoxelGI::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (RenderingServer::get_singleton()->is_low_end()) {
-		warnings.push_back(TTR("VoxelGIs are not supported by the OpenGL video driver.\nUse a LightmapGI instead."));
+		warnings.push_back(RTR("VoxelGIs are not supported by the OpenGL video driver.\nUse a LightmapGI instead."));
 	} else if (probe_data.is_null()) {
-		warnings.push_back(TTR("No VoxelGI data set, so this node is disabled. Bake static objects to enable GI."));
+		warnings.push_back(RTR("No VoxelGI data set, so this node is disabled. Bake static objects to enable GI."));
 	}
 	return warnings;
 }

--- a/scene/3d/world_environment.cpp
+++ b/scene/3d/world_environment.cpp
@@ -139,7 +139,7 @@ TypedArray<String> WorldEnvironment::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!environment.is_valid() && !camera_effects.is_valid()) {
-		warnings.push_back(TTR("To have any visible effect, WorldEnvironment requires its \"Environment\" property to contain an Environment, its \"Camera Effects\" property to contain a CameraEffects resource, or both."));
+		warnings.push_back(RTR("To have any visible effect, WorldEnvironment requires its \"Environment\" property to contain an Environment, its \"Camera Effects\" property to contain a CameraEffects resource, or both."));
 	}
 
 	if (!is_inside_tree()) {
@@ -151,7 +151,7 @@ TypedArray<String> WorldEnvironment::get_configuration_warnings() const {
 	}
 
 	if (camera_effects.is_valid() && get_viewport()->find_world_3d()->get_camera_effects() != camera_effects) {
-		warnings.push_back(TTR("Only one WorldEnvironment is allowed per scene (or set of instantiated scenes)."));
+		warnings.push_back(RTR("Only one WorldEnvironment is allowed per scene (or set of instantiated scenes)."));
 	}
 
 	return warnings;

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -95,7 +95,7 @@ TypedArray<String> XRCamera3D::get_configuration_warnings() const {
 		// must be child node of XROrigin3D!
 		XROrigin3D *origin = Object::cast_to<XROrigin3D>(get_parent());
 		if (origin == nullptr) {
-			warnings.push_back(TTR("XRCamera3D must have an XROrigin3D node as its parent."));
+			warnings.push_back(RTR("XRCamera3D must have an XROrigin3D node as its parent."));
 		};
 	}
 
@@ -423,15 +423,15 @@ TypedArray<String> XRNode3D::get_configuration_warnings() const {
 		// must be child node of XROrigin!
 		XROrigin3D *origin = Object::cast_to<XROrigin3D>(get_parent());
 		if (origin == nullptr) {
-			warnings.push_back(TTR("XRController3D must have an XROrigin3D node as its parent."));
+			warnings.push_back(RTR("XRController3D must have an XROrigin3D node as its parent."));
 		}
 
 		if (tracker_name == "") {
-			warnings.push_back(TTR("No tracker name is set."));
+			warnings.push_back(RTR("No tracker name is set."));
 		}
 
 		if (pose_name == "") {
-			warnings.push_back(TTR("No pose is set."));
+			warnings.push_back(RTR("No pose is set."));
 		}
 	}
 
@@ -589,13 +589,13 @@ TypedArray<String> XROrigin3D::get_configuration_warnings() const {
 
 	if (is_visible() && is_inside_tree()) {
 		if (tracked_camera == nullptr) {
-			warnings.push_back(TTR("XROrigin3D requires an XRCamera3D child node."));
+			warnings.push_back(RTR("XROrigin3D requires an XRCamera3D child node."));
 		}
 	}
 
 	bool xr_enabled = GLOBAL_GET("xr/shaders/enabled");
 	if (!xr_enabled) {
-		warnings.push_back(TTR("XR is not enabled in rendering project settings. Stereoscopic output is not supported unless this is enabled."));
+		warnings.push_back(RTR("XR is not enabled in rendering project settings. Stereoscopic output is not supported unless this is enabled."));
 	}
 
 	return warnings;

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1789,7 +1789,7 @@ Ref<AnimatedValuesBackup> AnimationPlayer::apply_reset(bool p_user_initiated) {
 bool AnimationPlayer::can_apply_reset() const {
 	return has_animation(SceneStringNames::get_singleton()->RESET) && playback.assigned != SceneStringNames::get_singleton()->RESET;
 }
-#endif
+#endif // TOOLS_ENABLED
 
 void AnimationPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_animation", "name", "animation"), &AnimationPlayer::add_animation);

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1641,18 +1641,18 @@ TypedArray<String> AnimationTree::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!root.is_valid()) {
-		warnings.push_back(TTR("No root AnimationNode for the graph is set."));
+		warnings.push_back(RTR("No root AnimationNode for the graph is set."));
 	}
 
 	if (!has_node(animation_player)) {
-		warnings.push_back(TTR("Path to an AnimationPlayer node containing animations is not set."));
+		warnings.push_back(RTR("Path to an AnimationPlayer node containing animations is not set."));
 	} else {
 		AnimationPlayer *player = Object::cast_to<AnimationPlayer>(get_node(animation_player));
 
 		if (!player) {
-			warnings.push_back(TTR("Path set for AnimationPlayer does not lead to an AnimationPlayer node."));
+			warnings.push_back(RTR("Path set for AnimationPlayer does not lead to an AnimationPlayer node."));
 		} else if (!player->has_node(player->get_root())) {
-			warnings.push_back(TTR("The AnimationPlayer root node is not a valid node."));
+			warnings.push_back(RTR("The AnimationPlayer root node is not a valid node."));
 		}
 	}
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -1221,7 +1221,7 @@ ColorPicker::ColorPicker() :
 
 	hhb->add_child(text_type);
 	text_type->set_text("#");
-	text_type->set_tooltip(TTR("Switch between hexadecimal and code values."));
+	text_type->set_tooltip(RTR("Switch between hexadecimal and code values."));
 	if (Engine::get_singleton()->is_editor_hint()) {
 		text_type->connect("pressed", callable_mp(this, &ColorPicker::_text_type_toggled));
 	} else {

--- a/scene/gui/container.cpp
+++ b/scene/gui/container.cpp
@@ -196,7 +196,7 @@ TypedArray<String> Container::get_configuration_warnings() const {
 	TypedArray<String> warnings = Control::get_configuration_warnings();
 
 	if (get_class() == "Container" && get_script().is_null()) {
-		warnings.push_back(TTR("Container by itself serves no purpose unless a script configures its children placement behavior.\nIf you don't intend to add a script, use a plain Control node instead."));
+		warnings.push_back(RTR("Container by itself serves no purpose unless a script configures its children placement behavior.\nIf you don't intend to add a script, use a plain Control node instead."));
 	}
 
 	return warnings;

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -3141,7 +3141,7 @@ TypedArray<String> Control::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (data.mouse_filter == MOUSE_FILTER_IGNORE && !data.tooltip.is_empty()) {
-		warnings.push_back(TTR("The Hint Tooltip won't be displayed as the control's Mouse Filter is set to \"Ignore\". To solve this, set the Mouse Filter to \"Stop\" or \"Pass\"."));
+		warnings.push_back(RTR("The Hint Tooltip won't be displayed as the control's Mouse Filter is set to \"Ignore\". To solve this, set the Mouse Filter to \"Stop\" or \"Pass\"."));
 	}
 
 	return warnings;

--- a/scene/gui/range.cpp
+++ b/scene/gui/range.cpp
@@ -34,7 +34,7 @@ TypedArray<String> Range::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (shared->exp_ratio && shared->min <= 0) {
-		warnings.push_back(TTR("If \"Exp Edit\" is enabled, \"Min Value\" must be greater than 0."));
+		warnings.push_back(RTR("If \"Exp Edit\" is enabled, \"Min Value\" must be greater than 0."));
 	}
 
 	return warnings;

--- a/scene/gui/scroll_container.cpp
+++ b/scene/gui/scroll_container.cpp
@@ -533,7 +533,7 @@ TypedArray<String> ScrollContainer::get_configuration_warnings() const {
 	}
 
 	if (found != 1) {
-		warnings.push_back(TTR("ScrollContainer is intended to work with a single child control.\nUse a container as child (VBox, HBox, etc.), or a Control and set the custom minimum size manually."));
+		warnings.push_back(RTR("ScrollContainer is intended to work with a single child control.\nUse a container as child (VBox, HBox, etc.), or a Control and set the custom minimum size manually."));
 	}
 
 	return warnings;

--- a/scene/gui/subviewport_container.cpp
+++ b/scene/gui/subviewport_container.cpp
@@ -234,7 +234,7 @@ TypedArray<String> SubViewportContainer::get_configuration_warnings() const {
 		}
 	}
 	if (!has_viewport) {
-		warnings.push_back(TTR("This node doesn't have a SubViewport as child, so it can't display its intended content.\nConsider adding a SubViewport as a child to provide something displayable."));
+		warnings.push_back(RTR("This node doesn't have a SubViewport as child, so it can't display its intended content.\nConsider adding a SubViewport as a child to provide something displayable."));
 	}
 
 	return warnings;

--- a/scene/main/shader_globals_override.cpp
+++ b/scene/main/shader_globals_override.cpp
@@ -277,7 +277,7 @@ TypedArray<String> ShaderGlobalsOverride::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!active) {
-		warnings.push_back(TTR("ShaderGlobalsOverride is not active because another node of the same type is in the scene."));
+		warnings.push_back(RTR("ShaderGlobalsOverride is not active because another node of the same type is in the scene."));
 	}
 
 	return warnings;

--- a/scene/main/timer.cpp
+++ b/scene/main/timer.cpp
@@ -184,7 +184,7 @@ TypedArray<String> Timer::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (wait_time < 0.05 - CMP_EPSILON) {
-		warnings.push_back(TTR("Very low timer wait times (< 0.05 seconds) may behave in significantly different ways depending on the rendered or physics frame rate.\nConsider using a script's process loop instead of relying on a Timer for very low wait times."));
+		warnings.push_back(RTR("Very low timer wait times (< 0.05 seconds) may behave in significantly different ways depending on the rendered or physics frame rate.\nConsider using a script's process loop instead of relying on a Timer for very low wait times."));
 	}
 
 	return warnings;

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2812,7 +2812,7 @@ TypedArray<String> Viewport::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (size.x == 0 || size.y == 0) {
-		warnings.push_back(TTR("Viewport size must be greater than 0 to render anything."));
+		warnings.push_back(RTR("Viewport size must be greater than 0 to render anything."));
 	}
 	return warnings;
 }

--- a/scene/resources/font.cpp
+++ b/scene/resources/font.cpp
@@ -741,9 +741,7 @@ Error FontData::load_bitmap_font(const String &p_path) {
 	oversampling = 1.0f;
 
 	FileAccessRef f = FileAccess::open(p_path, FileAccess::READ);
-	if (f == nullptr) {
-		ERR_FAIL_V_MSG(ERR_CANT_CREATE, TTR("Cannot open font from file ") + "\"" + p_path + "\".");
-	}
+	ERR_FAIL_COND_V_MSG(!f, ERR_CANT_CREATE, vformat(RTR("Cannot open font from file: %s."), p_path));
 
 	int base_size = 16;
 	int height = 0;
@@ -762,7 +760,7 @@ Error FontData::load_bitmap_font(const String &p_path) {
 	f->get_buffer((unsigned char *)&magic, 4);
 	if (magic[0] == 'B' && magic[1] == 'M' && magic[2] == 'F') {
 		// Binary BMFont file.
-		ERR_FAIL_COND_V_MSG(magic[3] != 3, ERR_CANT_CREATE, vformat(TTR("Version %d of BMFont is not supported."), (int)magic[3]));
+		ERR_FAIL_COND_V_MSG(magic[3] != 3, ERR_CANT_CREATE, vformat(RTR("Version %d of BMFont is not supported."), (int)magic[3]));
 
 		uint8_t block_type = f->get_8();
 		uint32_t block_size = f->get_32();
@@ -770,10 +768,10 @@ Error FontData::load_bitmap_font(const String &p_path) {
 			uint64_t off = f->get_position();
 			switch (block_type) {
 				case 1: /* info */ {
-					ERR_FAIL_COND_V_MSG(block_size < 15, ERR_CANT_CREATE, TTR("Invalid BMFont info block size."));
+					ERR_FAIL_COND_V_MSG(block_size < 15, ERR_CANT_CREATE, RTR("Invalid BMFont info block size."));
 					base_size = f->get_16();
 					uint8_t flags = f->get_8();
-					ERR_FAIL_COND_V_MSG(flags & 0x02, ERR_CANT_CREATE, TTR("Non-unicode version of BMFont is not supported."));
+					ERR_FAIL_COND_V_MSG(flags & 0x02, ERR_CANT_CREATE, RTR("Non-unicode version of BMFont is not supported."));
 					if (flags & (1 << 3)) {
 						st_flags |= TextServer::FONT_BOLD;
 					}
@@ -794,7 +792,7 @@ Error FontData::load_bitmap_font(const String &p_path) {
 					set_fixed_size(base_size);
 				} break;
 				case 2: /* common */ {
-					ERR_FAIL_COND_V_MSG(block_size != 15, ERR_CANT_CREATE, TTR("Invalid BMFont common block size."));
+					ERR_FAIL_COND_V_MSG(block_size != 15, ERR_CANT_CREATE, RTR("Invalid BMFont common block size."));
 					height = f->get_16();
 					ascent = f->get_16();
 					f->get_32(); // scale, skip
@@ -829,40 +827,40 @@ Error FontData::load_bitmap_font(const String &p_path) {
 								Ref<Image> img;
 								img.instantiate();
 								Error err = ImageLoader::load_image(file, img);
-								ERR_FAIL_COND_V_MSG(err != OK, ERR_FILE_CANT_READ, TTR("Can't load font texture: ") + "\"" + file + "\".");
+								ERR_FAIL_COND_V_MSG(err != OK, ERR_FILE_CANT_READ, vformat(RTR("Can't load font texture: %s."), file));
 
 								if (packed) {
 									if (ch[3] == 0) { // 4 x 8 bit monochrome, no outline
 										outline = 0;
-										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 										_convert_packed_8bit(img, page, base_size);
 									} else if ((ch[3] == 2) && (outline > 0)) { // 4 x 4 bit monochrome, gl + outline
-										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 										_convert_packed_4bit(img, page, base_size);
 									} else {
-										ERR_FAIL_V_MSG(ERR_CANT_CREATE, TTR("Unsupported BMFont texture format."));
+										ERR_FAIL_V_MSG(ERR_CANT_CREATE, RTR("Unsupported BMFont texture format."));
 									}
 								} else {
 									if ((ch[0] == 0) && (ch[1] == 0) && (ch[2] == 0) && (ch[3] == 0)) { // RGBA8 color, no outline
 										outline = 0;
-										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 										set_texture_image(0, Vector2i(base_size, 0), page, img);
 									} else if ((ch[0] == 2) && (ch[1] == 2) && (ch[2] == 2) && (ch[3] == 2) && (outline > 0)) { // RGBA4 color, gl + outline
-										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 										_convert_rgba_4bit(img, page, base_size);
 									} else if ((first_gl_ch >= 0) && (first_ol_ch >= 0) && (outline > 0)) { // 1 x 8 bit monochrome, gl + outline
-										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8 && img->get_format() != Image::FORMAT_L8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8 && img->get_format() != Image::FORMAT_L8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 										_convert_mono_8bit(img, page, first_gl_ch, base_size, 0);
 										_convert_mono_8bit(img, page, first_ol_ch, base_size, 1);
 									} else if ((first_cm_ch >= 0) && (outline > 0)) { // 1 x 4 bit monochrome, gl + outline
-										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8 && img->get_format() != Image::FORMAT_L8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8 && img->get_format() != Image::FORMAT_L8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 										_convert_mono_4bit(img, page, first_cm_ch, base_size, 1);
 									} else if (first_gl_ch >= 0) { // 1 x 8 bit monochrome, no outline
 										outline = 0;
-										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8 && img->get_format() != Image::FORMAT_L8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+										ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8 && img->get_format() != Image::FORMAT_L8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 										_convert_mono_8bit(img, page, first_gl_ch, base_size, 0);
 									} else {
-										ERR_FAIL_V_MSG(ERR_CANT_CREATE, TTR("Unsupported BMFont texture format."));
+										ERR_FAIL_V_MSG(ERR_CANT_CREATE, RTR("Unsupported BMFont texture format."));
 									}
 								}
 							}
@@ -899,7 +897,7 @@ Error FontData::load_bitmap_font(const String &p_path) {
 						int texture_idx = f->get_8();
 						uint8_t channel = f->get_8();
 
-						ERR_FAIL_COND_V_MSG(!packed && channel != 15, ERR_CANT_CREATE, TTR("Invalid glyph channel."));
+						ERR_FAIL_COND_V_MSG(!packed && channel != 15, ERR_CANT_CREATE, RTR("Invalid glyph channel."));
 						int ch_off = 0;
 						switch (channel) {
 							case 1:
@@ -941,7 +939,7 @@ Error FontData::load_bitmap_font(const String &p_path) {
 					}
 				} break;
 				default: {
-					ERR_FAIL_V_MSG(ERR_CANT_CREATE, TTR("Invalid BMFont block type."));
+					ERR_FAIL_V_MSG(ERR_CANT_CREATE, RTR("Invalid BMFont block type."));
 				} break;
 			}
 			f->seek(off + block_size);
@@ -1016,7 +1014,7 @@ Error FontData::load_bitmap_font(const String &p_path) {
 				if (keys.has("face")) {
 					font_name = keys["face"];
 				}
-				ERR_FAIL_COND_V_MSG((!keys.has("unicode") || keys["unicode"].to_int() != 1), ERR_CANT_CREATE, TTR("Non-unicode version of BMFont is not supported."));
+				ERR_FAIL_COND_V_MSG((!keys.has("unicode") || keys["unicode"].to_int() != 1), ERR_CANT_CREATE, RTR("Non-unicode version of BMFont is not supported."));
 			} else if (type == "common") {
 				if (keys.has("lineHeight")) {
 					height = keys["lineHeight"].to_int();
@@ -1062,39 +1060,39 @@ Error FontData::load_bitmap_font(const String &p_path) {
 						Ref<Image> img;
 						img.instantiate();
 						Error err = ImageLoader::load_image(file, img);
-						ERR_FAIL_COND_V_MSG(err != OK, ERR_FILE_CANT_READ, TTR("Can't load font texture: ") + "\"" + file + "\".");
+						ERR_FAIL_COND_V_MSG(err != OK, ERR_FILE_CANT_READ, vformat(RTR("Can't load font texture: %s."), file));
 						if (packed) {
 							if (ch[3] == 0) { // 4 x 8 bit monochrome, no outline
 								outline = 0;
-								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 								_convert_packed_8bit(img, page, base_size);
 							} else if ((ch[3] == 2) && (outline > 0)) { // 4 x 4 bit monochrome, gl + outline
-								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 								_convert_packed_4bit(img, page, base_size);
 							} else {
-								ERR_FAIL_V_MSG(ERR_CANT_CREATE, TTR("Unsupported BMFont texture format."));
+								ERR_FAIL_V_MSG(ERR_CANT_CREATE, RTR("Unsupported BMFont texture format."));
 							}
 						} else {
 							if ((ch[0] == 0) && (ch[1] == 0) && (ch[2] == 0) && (ch[3] == 0)) { // RGBA8 color, no outline
 								outline = 0;
-								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 								set_texture_image(0, Vector2i(base_size, 0), page, img);
 							} else if ((ch[0] == 2) && (ch[1] == 2) && (ch[2] == 2) && (ch[3] == 2) && (outline > 0)) { // RGBA4 color, gl + outline
-								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 								_convert_rgba_4bit(img, page, base_size);
 							} else if ((first_gl_ch >= 0) && (first_ol_ch >= 0) && (outline > 0)) { // 1 x 8 bit monochrome, gl + outline
-								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8 && img->get_format() != Image::FORMAT_L8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8 && img->get_format() != Image::FORMAT_L8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 								_convert_mono_8bit(img, page, first_gl_ch, base_size, 0);
 								_convert_mono_8bit(img, page, first_ol_ch, base_size, 1);
 							} else if ((first_cm_ch >= 0) && (outline > 0)) { // 1 x 4 bit monochrome, gl + outline
-								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8 && img->get_format() != Image::FORMAT_L8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8 && img->get_format() != Image::FORMAT_L8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 								_convert_mono_4bit(img, page, first_cm_ch, base_size, 1);
 							} else if (first_gl_ch >= 0) { // 1 x 8 bit monochrome, no outline
 								outline = 0;
-								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8 && img->get_format() != Image::FORMAT_L8, ERR_FILE_CANT_READ, TTR("Unsupported BMFont texture format."));
+								ERR_FAIL_COND_V_MSG(img->get_format() != Image::FORMAT_RGBA8 && img->get_format() != Image::FORMAT_L8, ERR_FILE_CANT_READ, RTR("Unsupported BMFont texture format."));
 								_convert_mono_8bit(img, page, first_gl_ch, base_size, 0);
 							} else {
-								ERR_FAIL_V_MSG(ERR_CANT_CREATE, TTR("Unsupported BMFont texture format."));
+								ERR_FAIL_V_MSG(ERR_CANT_CREATE, RTR("Unsupported BMFont texture format."));
 							}
 						}
 					}
@@ -1144,7 +1142,7 @@ Error FontData::load_bitmap_font(const String &p_path) {
 					channel = keys["chnl"].to_int();
 				}
 
-				ERR_FAIL_COND_V_MSG(!packed && channel != 15, ERR_CANT_CREATE, TTR("Invalid glyph channel."));
+				ERR_FAIL_COND_V_MSG(!packed && channel != 15, ERR_CANT_CREATE, RTR("Invalid glyph channel."));
 				int ch_off = 0;
 				switch (channel) {
 					case 1:

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -3106,7 +3106,7 @@ void VisualShaderNodeInput::_validate_property(PropertyInfo &property) const {
 		}
 
 		if (port_list.is_empty()) {
-			port_list = TTR("None");
+			port_list = RTR("None");
 		}
 		property.hint_string = port_list;
 	}
@@ -3649,7 +3649,7 @@ String VisualShaderNodeUniform::get_warning(Shader::Mode p_mode, VisualShader::T
 	List<String> keyword_list;
 	ShaderLanguage::get_keyword_list(&keyword_list);
 	if (keyword_list.find(uniform_name)) {
-		return TTR("Shader keywords cannot be used as uniform names.\nChoose another name.");
+		return RTR("Shader keywords cannot be used as uniform names.\nChoose another name.");
 	}
 	if (!is_qualifier_supported(qualifier)) {
 		String qualifier_str;
@@ -3665,11 +3665,11 @@ String VisualShaderNodeUniform::get_warning(Shader::Mode p_mode, VisualShader::T
 			default:
 				break;
 		}
-		return vformat(TTR("This uniform type does not support the '%s' qualifier."), qualifier_str);
+		return vformat(RTR("This uniform type does not support the '%s' qualifier."), qualifier_str);
 	} else if (qualifier == Qualifier::QUAL_GLOBAL) {
 		RS::GlobalVariableType gvt = RS::get_singleton()->global_variable_get_type(uniform_name);
 		if (gvt == RS::GLOBAL_VAR_TYPE_MAX) {
-			return vformat(TTR("Global uniform '%s' does not exist.\nCreate it in the Project Settings."), uniform_name);
+			return vformat(RTR("Global uniform '%s' does not exist.\nCreate it in the Project Settings."), uniform_name);
 		}
 		bool incompatible_type = false;
 		switch (gvt) {
@@ -3727,7 +3727,7 @@ String VisualShaderNodeUniform::get_warning(Shader::Mode p_mode, VisualShader::T
 				break;
 		}
 		if (incompatible_type) {
-			return vformat(TTR("Global uniform '%s' has an incompatible type for this kind of node.\nChange it in the Project Settings."), uniform_name);
+			return vformat(RTR("Global uniform '%s' has an incompatible type for this kind of node.\nChange it in the Project Settings."), uniform_name);
 		}
 	}
 

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -892,7 +892,7 @@ Vector<StringName> VisualShaderNodeTexture::get_editable_properties() const {
 
 String VisualShaderNodeTexture::get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const {
 	if (is_input_port_connected(2) && source != SOURCE_PORT) {
-		return TTR("The sampler port is connected but not used. Consider changing the source to 'SamplerPort'.");
+		return RTR("The sampler port is connected but not used. Consider changing the source to 'SamplerPort'.");
 	}
 
 	if (source == SOURCE_TEXTURE) {
@@ -917,12 +917,12 @@ String VisualShaderNodeTexture::get_warning(Shader::Mode p_mode, VisualShader::T
 
 	if (source == SOURCE_DEPTH && p_mode == Shader::MODE_SPATIAL && p_type == VisualShader::TYPE_FRAGMENT) {
 		if (get_output_port_for_preview() == 0) { // DEPTH_TEXTURE is not supported in preview(canvas_item) shader
-			return TTR("Invalid source for preview.");
+			return RTR("Invalid source for preview.");
 		}
 		return String(); // all good
 	}
 
-	return TTR("Invalid source for shader.");
+	return RTR("Invalid source for shader.");
 }
 
 void VisualShaderNodeTexture::_bind_methods() {
@@ -1255,7 +1255,7 @@ void VisualShaderNodeSample3D::_bind_methods() {
 
 String VisualShaderNodeSample3D::get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const {
 	if (is_input_port_connected(2) && source != SOURCE_PORT) {
-		return TTR("The sampler port is connected but not used. Consider changing the source to 'SamplerPort'.");
+		return RTR("The sampler port is connected but not used. Consider changing the source to 'SamplerPort'.");
 	}
 
 	if (source == SOURCE_TEXTURE) {
@@ -1264,7 +1264,7 @@ String VisualShaderNodeSample3D::get_warning(Shader::Mode p_mode, VisualShader::
 	if (source == SOURCE_PORT) {
 		return String(); // all good
 	}
-	return TTR("Invalid source for shader.");
+	return RTR("Invalid source for shader.");
 }
 
 VisualShaderNodeSample3D::VisualShaderNodeSample3D() {
@@ -1575,7 +1575,7 @@ Vector<StringName> VisualShaderNodeCubemap::get_editable_properties() const {
 
 String VisualShaderNodeCubemap::get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const {
 	if (is_input_port_connected(2) && source != SOURCE_PORT) {
-		return TTR("The sampler port is connected but not used. Consider changing the source to 'SamplerPort'.");
+		return RTR("The sampler port is connected but not used. Consider changing the source to 'SamplerPort'.");
 	}
 	return String();
 }
@@ -1967,7 +1967,7 @@ String VisualShaderNodeVectorOp::get_warning(Shader::Mode p_mode, VisualShader::
 	}
 
 	if (invalid_type) {
-		return TTR("Invalid operator for that type.");
+		return RTR("Invalid operator for that type.");
 	}
 
 	return String();
@@ -2741,7 +2741,7 @@ String VisualShaderNodeVectorFunc::get_warning(Shader::Mode p_mode, VisualShader
 	}
 
 	if (invalid_type) {
-		return TTR("Invalid function for that type.");
+		return RTR("Invalid function for that type.");
 	}
 
 	return String();
@@ -5586,10 +5586,10 @@ bool VisualShaderNodeTextureUniform::is_show_prop_names() const {
 
 Map<StringName, String> VisualShaderNodeTextureUniform::get_editable_properties_names() const {
 	Map<StringName, String> names;
-	names.insert("texture_type", TTR("Type"));
-	names.insert("color_default", TTR("Default Color"));
-	names.insert("texture_filter", TTR("Filter"));
-	names.insert("texture_repeat", TTR("Repeat"));
+	names.insert("texture_type", RTR("Type"));
+	names.insert("color_default", RTR("Default Color"));
+	names.insert("texture_filter", RTR("Filter"));
+	names.insert("texture_repeat", RTR("Repeat"));
 	return names;
 }
 
@@ -6458,7 +6458,7 @@ String VisualShaderNodeCompare::get_output_port_name(int p_port) const {
 String VisualShaderNodeCompare::get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const {
 	if (comparison_type == CTYPE_BOOLEAN || comparison_type == CTYPE_TRANSFORM) {
 		if (func > FUNC_NOT_EQUAL) {
-			return TTR("Invalid comparison function for that type.");
+			return RTR("Invalid comparison function for that type.");
 		}
 	}
 	return "";

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -76,7 +76,7 @@ Vector<StringName> VisualShaderNodeParticleEmitter::get_editable_properties() co
 
 Map<StringName, String> VisualShaderNodeParticleEmitter::get_editable_properties_names() const {
 	Map<StringName, String> names;
-	names.insert("mode_2d", TTR("2D Mode"));
+	names.insert("mode_2d", RTR("2D Mode"));
 	return names;
 }
 
@@ -707,10 +707,10 @@ Vector<StringName> VisualShaderNodeParticleMeshEmitter::get_editable_properties(
 Map<StringName, String> VisualShaderNodeParticleMeshEmitter::get_editable_properties_names() const {
 	Map<StringName, String> names = VisualShaderNodeParticleEmitter::get_editable_properties_names();
 
-	names.insert("mesh", TTR("Mesh"));
-	names.insert("use_all_surfaces", TTR("Use All Surfaces"));
+	names.insert("mesh", RTR("Mesh"));
+	names.insert("use_all_surfaces", RTR("Use All Surfaces"));
 	if (!use_all_surfaces) {
-		names.insert("surface_index", TTR("Surface Index"));
+		names.insert("surface_index", RTR("Surface Index"));
 	}
 
 	return names;


### PR DESCRIPTION
This ensures we don't use TTR in runtime code, as it's specifically meant
to source translations for the editor.

Draft as it includes #59631 as a prerequisite.