### PR TITLE
Fix encoder_sources compile warning

### DIFF
--- a/modules/basis_universal/SCsub
+++ b/modules/basis_universal/SCsub
@@ -13,7 +13,6 @@ thirdparty_obj = []
 thirdparty_dir = "#thirdparty/basis_universal/"
 # Sync list with upstream CMakeLists.txt
 encoder_sources = [
-    "basisu_uastc_enc.cpp",
     "basisu_backend.cpp",
     "basisu_basis_file.cpp",
     "basisu_bc7enc.cpp",


### PR DESCRIPTION
basisu_uastc_enc.cpp was included twice in encoder_sources and caused this compiler warning:

```
WARNING: Object "['/compile_directory/godot/thirdparty/basis_universal/encoder/basisu_uastc_enc.linuxbsd.opt.tools.64.llvm.o']" already included in environment sources.
```
