### PR TITLE
Remove last editor code dependencies in template build

### DIFF
--- a/.github/actions/godot-build/action.yml
+++ b/.github/actions/godot-build/action.yml
@@ -33,5 +33,6 @@ runs:
           SCONS_CACHE_LIMIT: ${{ inputs.scons-cache-limit }}
       run: |
         echo "Building with flags:" ${{ env.SCONSFLAGS }}
+        if ! ${{ inputs.tools }}; then rm -rf editor; fi  # Ensure we don't include editor code.
         scons p=${{ inputs.platform }} target=${{ inputs.target }} tools=${{ inputs.tools }} tests=${{ inputs.tests }} --jobs=2 ${{ env.SCONSFLAGS }}
         ls -l bin/

--- a/SConstruct
+++ b/SConstruct
@@ -48,8 +48,6 @@ _helper_module("methods", "methods.py")
 _helper_module("platform_methods", "platform_methods.py")
 _helper_module("version", "version.py")
 _helper_module("core.core_builders", "core/core_builders.py")
-_helper_module("editor.editor_builders", "editor/editor_builders.py")
-_helper_module("editor.template_builders", "editor/template_builders.py")
 _helper_module("main.main_builders", "main/main_builders.py")
 _helper_module("modules.modules_builders", "modules/modules_builders.py")
 
@@ -57,6 +55,10 @@ _helper_module("modules.modules_builders", "modules/modules_builders.py")
 import methods
 import glsl_builders
 import gles3_builders
+
+if methods.get_cmdline_bool("tools", True):
+    _helper_module("editor.editor_builders", "editor/editor_builders.py")
+    _helper_module("editor.template_builders", "editor/template_builders.py")
 
 # Scan possible build platforms
 

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -58,7 +58,6 @@
 #include "core/variant/variant.h"
 #include "core/version.h"
 #include "drivers/png/png_driver_common.h"
-#include "editor/import/resource_importer_scene.h"
 #include "scene/2d/node_2d.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
@@ -78,6 +77,9 @@
 #ifdef MODULE_GRIDMAP_ENABLED
 #include "modules/gridmap/grid_map.h"
 #endif // MODULE_GRIDMAP_ENABLED
+
+// FIXME: Hardcoded to avoid editor dependency.
+#define GLTF_IMPORT_USE_NAMED_SKIN_BINDS 16
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -5748,7 +5750,7 @@ void GLTFDocument::_generate_skeleton_bone_node(Ref<GLTFState> state, Node *scen
 }
 
 template <class T>
-struct EditorSceneFormatImporterGLTFInterpolate {
+struct SceneFormatImporterGLTFInterpolate {
 	T lerp(const T &a, const T &b, float c) const {
 		return a + (b - a) * c;
 	}
@@ -5774,7 +5776,7 @@ struct EditorSceneFormatImporterGLTFInterpolate {
 
 // thank you for existing, partial specialization
 template <>
-struct EditorSceneFormatImporterGLTFInterpolate<Quaternion> {
+struct SceneFormatImporterGLTFInterpolate<Quaternion> {
 	Quaternion lerp(const Quaternion &a, const Quaternion &b, const float c) const {
 		ERR_FAIL_COND_V_MSG(!a.is_normalized(), Quaternion(), "The quaternion \"a\" must be normalized.");
 		ERR_FAIL_COND_V_MSG(!b.is_normalized(), Quaternion(), "The quaternion \"b\" must be normalized.");
@@ -5813,7 +5815,7 @@ T GLTFDocument::_interpolate_track(const Vector<real_t> &p_times, const Vector<T
 		idx++;
 	}
 
-	EditorSceneFormatImporterGLTFInterpolate<T> interp;
+	SceneFormatImporterGLTFInterpolate<T> interp;
 
 	switch (p_interp) {
 		case GLTFAnimation::INTERP_LINEAR: {
@@ -6906,7 +6908,7 @@ Node *GLTFDocument::generate_scene(Ref<GLTFState> state, int32_t p_bake_fps) {
 Error GLTFDocument::append_from_scene(Node *p_node, Ref<GLTFState> state, uint32_t p_flags, int32_t p_bake_fps) {
 	ERR_FAIL_COND_V(state.is_null(), FAILED);
 	state->use_named_skin_binds =
-			p_flags & EditorSceneFormatImporter::IMPORT_USE_NAMED_SKIN_BINDS;
+			p_flags & GLTF_IMPORT_USE_NAMED_SKIN_BINDS;
 
 	_convert_scene_node(state, p_node, -1, -1);
 	if (!state->buffers.size()) {
@@ -6926,7 +6928,7 @@ Error GLTFDocument::append_from_buffer(PackedByteArray p_bytes, String p_base_pa
 	// TODO Add missing texture and missing .bin file paths to r_missing_deps 2021-09-10 fire
 	Error err = FAILED;
 	state->use_named_skin_binds =
-			p_flags & EditorSceneFormatImporter::IMPORT_USE_NAMED_SKIN_BINDS;
+			p_flags & GLTF_IMPORT_USE_NAMED_SKIN_BINDS;
 	FileAccessMemory *file_access = memnew(FileAccessMemory);
 	file_access->open_custom(p_bytes.ptr(), p_bytes.size());
 	err = _parse(state, p_base_path.get_base_dir(), file_access, p_bake_fps);
@@ -7029,7 +7031,7 @@ Error GLTFDocument::append_from_file(String p_path, Ref<GLTFState> r_state, uint
 	}
 	r_state->filename = p_path.get_file().get_basename();
 	r_state->use_named_skin_binds =
-			p_flags & EditorSceneFormatImporter::IMPORT_USE_NAMED_SKIN_BINDS;
+			p_flags & GLTF_IMPORT_USE_NAMED_SKIN_BINDS;
 	Error err;
 	FileAccess *f = FileAccess::open(p_path, FileAccess::READ, &err);
 	ERR_FAIL_COND_V(err != OK, ERR_FILE_CANT_OPEN);

--- a/modules/gltf/gltf_mesh.h
+++ b/modules/gltf/gltf_mesh.h
@@ -32,7 +32,6 @@
 #define GLTF_MESH_H
 
 #include "core/io/resource.h"
-#include "editor/import/resource_importer_scene.h"
 #include "scene/3d/importer_mesh_instance_3d.h"
 #include "scene/resources/importer_mesh.h"
 #include "scene/resources/mesh.h"

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -32,7 +32,6 @@
 
 #include "core/object/message_queue.h"
 #include "core/variant/type_info.h"
-#include "editor/plugins/skeleton_3d_editor_plugin.h"
 #include "scene/3d/physics_body_3d.h"
 #include "scene/resources/skeleton_modification_3d.h"
 #include "scene/resources/surface_tool.h"

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -34,7 +34,6 @@
 #include "core/config/project_settings.h"
 #include "core/core_string_names.h"
 #include "core/io/resource_loader.h"
-#include "editor/editor_inspector.h"
 #include "scene/2d/node_2d.h"
 #include "scene/3d/node_3d.h"
 #include "scene/gui/control.h"

--- a/servers/audio/effects/audio_effect_record.cpp
+++ b/servers/audio/effects/audio_effect_record.cpp
@@ -30,6 +30,11 @@
 
 #include "audio_effect_record.h"
 
+#ifdef TOOLS_ENABLED
+// FIXME: This file shouldn't depend on editor stuff.
+#include "editor/import/resource_importer_wav.h"
+#endif
+
 void AudioEffectRecordInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
 	if (!is_recording) {
 		for (int i = 0; i < p_frame_count; i++) {
@@ -250,8 +255,12 @@ Ref<AudioStreamSample> AudioEffectRecord::get_recording() const {
 		Vector<uint8_t> bleft;
 		Vector<uint8_t> bright;
 
+#ifdef TOOLS_ENABLED
 		ResourceImporterWAV::_compress_ima_adpcm(left, bleft);
 		ResourceImporterWAV::_compress_ima_adpcm(right, bright);
+#else
+		ERR_PRINT("AudioEffectRecord cannot do IMA ADPCM compression at runtime.");
+#endif
 
 		int dl = bleft.size();
 		dst_data.resize(dl * 2);

--- a/servers/audio/effects/audio_effect_record.h
+++ b/servers/audio/effects/audio_effect_record.h
@@ -35,7 +35,6 @@
 #include "core/io/marshalls.h"
 #include "core/os/os.h"
 #include "core/os/thread.h"
-#include "editor/import/resource_importer_wav.h"
 #include "scene/resources/audio_stream_sample.h"
 #include "servers/audio/audio_effect.h"
 #include "servers/audio_server.h"


### PR DESCRIPTION
SConstruct change (+ previous PRs #59631 #59635 #59636) also makes it possible to outright delete the `editor` folder in a `tools=no` build, which we use in CI to ensure no invalid cross-dependencies are added.

Part of #53295.

Note that there are still `editor` dependencies in `scene` code, but the remaining ones are enclosed in `#ifdef TOOLS_ENABLED` i.e. they're only used in actual editor builds.