### PR TITLE
Add fbx2gltf support for importing .fbx files

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -553,9 +553,13 @@
 		<member name="editor/script/templates_search_path" type="String" setter="" getter="" default="&quot;res://script_templates&quot;">
 			Search path for project-specific script templates. Godot will search for script templates both in the editor-specific path and in this project-specific path.
 		</member>
-		<member name="filesystem/import/blend/enabled" type="bool" setter="" getter="" default="false">
-			If [code]true[/code], 3D scene files with the [code].blend[/code] extension will be imported by converting them to glTF 2.0.
+		<member name="filesystem/import/blend/enabled" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], Blender 3D scene files with the [code].blend[/code] extension will be imported by converting them to glTF 2.0.
 			This requires configuring a path to a Blender executable in the editor settings at [code]filesystem/import/blend/blender_path[/code]. Blender 3.0 or later is required.
+		</member>
+		<member name="filesystem/import/fbx/enabled" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], Autodesk FBX 3D scene files with the [code].fbx[/code] extension will be imported by converting them to glTF 2.0.
+			This requires configuring a path to a FBX2glTF executable in the editor settings at [code]filesystem/import/fbx/fbx2gltf_path[/code].
 		</member>
 		<member name="gui/common/default_scroll_deadzone" type="int" setter="" getter="" default="0">
 			Default value for [member ScrollContainer.scroll_deadzone], which will be used for all [ScrollContainer]s unless overridden.

--- a/modules/gltf/config.py
+++ b/modules/gltf/config.py
@@ -9,6 +9,7 @@ def configure(env):
 def get_doc_classes():
     return [
         "EditorSceneFormatImporterBlend",
+        "EditorSceneFormatImporterFBX",
         "EditorSceneFormatImporterGLTF",
         "GLTFAccessor",
         "GLTFAnimation",

--- a/modules/gltf/doc_classes/EditorSceneFormatImporterBlend.xml
+++ b/modules/gltf/doc_classes/EditorSceneFormatImporterBlend.xml
@@ -6,7 +6,7 @@
 	<description>
 		Imports Blender scenes in the [code].blend[/code] file format through the glTF 2.0 3D import pipeline. This importer requires Blender to be installed by the user, so that it can be used to export the scene as glTF 2.0.
 		The location of the Blender binary is set via the [code]filesystem/import/blend/blender_path[/code] editor setting.
-		This importer is only used if [member ProjectSettings.filesystem/import/blend/enabled] is enabled, otherwise [code].blend[/code] present in the project folder are not imported.
+		This importer is only used if [member ProjectSettings.filesystem/import/blend/enabled] is enabled, otherwise [code].blend[/code] files present in the project folder are not imported.
 		Blend import requires Blender 3.0.
 		Internally, the EditorSceneFormatImporterBlend uses the Blender glTF "Use Original" mode to reference external textures.
 	</description>

--- a/modules/gltf/doc_classes/EditorSceneFormatImporterFBX.xml
+++ b/modules/gltf/doc_classes/EditorSceneFormatImporterFBX.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="EditorSceneFormatImporterFBX" inherits="EditorSceneFormatImporter" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../doc/class.xsd">
+	<brief_description>
+		Importer for the [code].fbx[/code] scene file format.
+	</brief_description>
+	<description>
+		Imports Autodesk FBX 3D scenes by way of converting them to glTF 2.0 using the FBX2glTF command line tool.
+		The location of the FBX2glTF binary is set via the [code]filesystem/import/fbx/fbx2gltf_path[/code] editor setting.
+		This importer is only used if [member ProjectSettings.filesystem/import/fbx/enabled] is enabled, otherwise [code].fbx[/code] files present in the project folder are not imported.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/modules/gltf/editor/editor_scene_importer_fbx.cpp
+++ b/modules/gltf/editor/editor_scene_importer_fbx.cpp
@@ -1,0 +1,119 @@
+/*************************************************************************/
+/*  editor_scene_importer_fbx.cpp                                        */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "editor_scene_importer_fbx.h"
+
+#if TOOLS_ENABLED
+
+#include "../gltf_document.h"
+#include "../gltf_state.h"
+
+#include "core/config/project_settings.h"
+#include "editor/editor_settings.h"
+#include "scene/main/node.h"
+#include "scene/resources/animation.h"
+
+uint32_t EditorSceneFormatImporterFBX::get_import_flags() const {
+	return ImportFlags::IMPORT_SCENE | ImportFlags::IMPORT_ANIMATION;
+}
+
+void EditorSceneFormatImporterFBX::get_extensions(List<String> *r_extensions) const {
+	r_extensions->push_back("fbx");
+}
+
+Node *EditorSceneFormatImporterFBX::import_scene(const String &p_path, uint32_t p_flags,
+		const Map<StringName, Variant> &p_options, int p_bake_fps,
+		List<String> *r_missing_deps, Error *r_err) {
+	// Get global paths for source and sink.
+
+	const String source_global = ProjectSettings::get_singleton()->globalize_path(p_path);
+	const String sink = ProjectSettings::get_singleton()->get_imported_files_path().plus_file(
+			vformat("%s-%s.glb", p_path.get_file().get_basename(), p_path.md5_text()));
+	const String sink_global = ProjectSettings::get_singleton()->globalize_path(sink);
+
+	// Run fbx2gltf.
+
+	String fbx2gltf_path = EDITOR_GET("filesystem/import/fbx/fbx2gltf_path");
+
+	List<String> args;
+	args.push_back("--pbr-metallic-roughness");
+	args.push_back("--input");
+	args.push_back(vformat("\"%s\"", source_global));
+	args.push_back("--output");
+	args.push_back(vformat("\"%s\"", sink_global));
+	args.push_back("--binary");
+
+	String standard_out;
+	int ret;
+	OS::get_singleton()->execute(fbx2gltf_path, args, &standard_out, &ret, true);
+	print_verbose(fbx2gltf_path);
+	print_verbose(standard_out);
+
+	if (ret != 0) {
+		if (r_err) {
+			*r_err = ERR_SCRIPT_FAILED;
+		}
+		ERR_PRINT(vformat("FBX conversion to glTF failed with error: %d.", ret));
+		return nullptr;
+	}
+
+	// Import the generated glTF.
+
+	// Use GLTFDocument instead of glTF importer to keep image references.
+	Ref<GLTFDocument> gltf;
+	gltf.instantiate();
+	Ref<GLTFState> state;
+	state.instantiate();
+	print_verbose(vformat("glTF path: %s", sink));
+	Error err = gltf->append_from_file(sink, state, p_flags, p_bake_fps);
+	if (err != OK) {
+		if (r_err) {
+			*r_err = FAILED;
+		}
+		return nullptr;
+	}
+	return gltf->generate_scene(state, p_bake_fps);
+}
+
+Ref<Animation> EditorSceneFormatImporterFBX::import_animation(const String &p_path,
+		uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps) {
+	return Ref<Animation>();
+}
+
+Variant EditorSceneFormatImporterFBX::get_option_visibility(const String &p_path,
+		const String &p_option, const Map<StringName, Variant> &p_options) {
+	return true;
+}
+
+void EditorSceneFormatImporterFBX::get_import_options(const String &p_path,
+		List<ResourceImporter::ImportOption> *r_options) {
+}
+
+#endif // TOOLS_ENABLED

--- a/modules/gltf/editor/editor_scene_importer_fbx.h
+++ b/modules/gltf/editor/editor_scene_importer_fbx.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  gltf_mesh.cpp                                                        */
+/*  editor_scene_importer_fbx.h                                          */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,43 +28,33 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "gltf_mesh.h"
+#ifndef EDITOR_SCENE_IMPORTER_FBX_H
+#define EDITOR_SCENE_IMPORTER_FBX_H
 
-#include "scene/resources/importer_mesh.h"
+#ifdef TOOLS_ENABLED
 
-void GLTFMesh::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("get_mesh"), &GLTFMesh::get_mesh);
-	ClassDB::bind_method(D_METHOD("set_mesh", "mesh"), &GLTFMesh::set_mesh);
-	ClassDB::bind_method(D_METHOD("get_blend_weights"), &GLTFMesh::get_blend_weights);
-	ClassDB::bind_method(D_METHOD("set_blend_weights", "blend_weights"), &GLTFMesh::set_blend_weights);
-	ClassDB::bind_method(D_METHOD("get_instance_materials"), &GLTFMesh::get_instance_materials);
-	ClassDB::bind_method(D_METHOD("set_instance_materials", "instance_materials"), &GLTFMesh::set_instance_materials);
+#include "editor/import/resource_importer_scene.h"
 
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "mesh"), "set_mesh", "get_mesh");
-	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT32_ARRAY, "blend_weights"), "set_blend_weights", "get_blend_weights"); // Vector<float>
-	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "instance_materials"), "set_instance_materials", "get_instance_materials");
-}
+class Animation;
+class Node;
 
-Ref<ImporterMesh> GLTFMesh::get_mesh() {
-	return mesh;
-}
+class EditorSceneFormatImporterFBX : public EditorSceneFormatImporter {
+	GDCLASS(EditorSceneFormatImporterFBX, EditorSceneFormatImporter);
 
-void GLTFMesh::set_mesh(Ref<ImporterMesh> p_mesh) {
-	mesh = p_mesh;
-}
+public:
+	virtual uint32_t get_import_flags() const override;
+	virtual void get_extensions(List<String> *r_extensions) const override;
+	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
+			const Map<StringName, Variant> &p_options, int p_bake_fps,
+			List<String> *r_missing_deps, Error *r_err = nullptr) override;
+	virtual Ref<Animation> import_animation(const String &p_path, uint32_t p_flags,
+			const Map<StringName, Variant> &p_options, int p_bake_fps) override;
+	virtual void get_import_options(const String &p_path,
+			List<ResourceImporter::ImportOption> *r_options) override;
+	virtual Variant get_option_visibility(const String &p_path, const String &p_option,
+			const Map<StringName, Variant> &p_options) override;
+};
 
-Array GLTFMesh::get_instance_materials() {
-	return instance_materials;
-}
+#endif // TOOLS_ENABLED
 
-void GLTFMesh::set_instance_materials(Array p_instance_materials) {
-	instance_materials = p_instance_materials;
-}
-
-Vector<float> GLTFMesh::get_blend_weights() {
-	return blend_weights;
-}
-
-void GLTFMesh::set_blend_weights(Vector<float> p_blend_weights) {
-	blend_weights = p_blend_weights;
-}
+#endif // EDITOR_SCENE_IMPORTER_FBX_H

--- a/modules/gltf/gltf_mesh.h
+++ b/modules/gltf/gltf_mesh.h
@@ -55,4 +55,5 @@ public:
 	Array get_instance_materials();
 	void set_instance_materials(Array p_instance_materials);
 };
+
 #endif // GLTF_MESH_H


### PR DESCRIPTION
Lets you drag or place .fbx files in the project folder and it will import the files.

An editor setting sets the location of the fbx2gltf binary.

Pending a proposal. Need to discuss with reduz the details.

---

*Bugsquad edit:* A `3.x` backport will be considered, as it seems to really work much better than the current importer in 3.x.