### PR TITLE
Fix Callable::bind usage in connections_dialog.h and packed_scene.cpp

### DIFF
--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -93,8 +93,11 @@ public:
 			if (unbinds > 0) {
 				return Callable(target, method).unbind(unbinds);
 			} else if (!binds.is_empty()) {
-				const Variant *args = binds.ptr();
-				return Callable(target, method).bind(&args, binds.size());
+				const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * binds.size());
+				for (int i = 0; i < binds.size(); i++) {
+					argptrs[i] = &binds[i];
+				}
+				return Callable(target, method).bind(argptrs, binds.size());
 			} else {
 				return Callable(target, method);
 			}

--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -362,8 +362,11 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 				}
 			}
 
-			const Variant *args = binds.ptr();
-			callable = callable.bind(&args, binds.size());
+			const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * binds.size());
+			for (int j = 0; j < binds.size(); j++) {
+				argptrs[j] = &binds[j];
+			}
+			callable = callable.bind(argptrs, binds.size());
 		}
 
 		cfrom->connect(snames[c.signal], callable, varray(), CONNECT_PERSIST | c.flags);


### PR DESCRIPTION
Fixes #57057

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
