### PR TITLE
Simplify FBX importer project settings registering

### DIFF
--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -125,6 +125,7 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["dtls"] = "DTLS";
 	capitalize_string_remaps["etc"] = "ETC";
 	capitalize_string_remaps["etc2"] = "ETC2";
+	capitalize_string_remaps["fbx"] = "FBX";
 	capitalize_string_remaps["fft"] = "FFT";
 	capitalize_string_remaps["fov"] = "FOV";
 	capitalize_string_remaps["fps"] = "FPS";

--- a/modules/fbx/editor_scene_importer_fbx.cpp
+++ b/modules/fbx/editor_scene_importer_fbx.cpp
@@ -58,24 +58,8 @@
 
 void EditorSceneFormatImporterFBX::get_extensions(List<String> *r_extensions) const {
 	// register FBX as the one and only format for FBX importing
-	const String import_setting_string = "filesystem/import/fbx/";
-	const String fbx_str = "fbx";
-	Vector<String> exts;
-	exts.push_back(fbx_str);
-	_register_project_setting_import(fbx_str, import_setting_string, exts, r_extensions, true);
-}
-
-void EditorSceneFormatImporterFBX::_register_project_setting_import(const String generic,
-		const String import_setting_string,
-		const Vector<String> &exts,
-		List<String> *r_extensions,
-		const bool p_enabled) const {
-	const String use_generic = "use_" + generic;
-	_GLOBAL_DEF(import_setting_string + use_generic, p_enabled, true);
-	if (ProjectSettings::get_singleton()->get(import_setting_string + use_generic)) {
-		for (int32_t i = 0; i < exts.size(); i++) {
-			r_extensions->push_back(exts[i]);
-		}
+	if (GLOBAL_GET("filesystem/import/fbx/use_fbx")) {
+		r_extensions->push_back("fbx");
 	}
 }
 
@@ -1472,4 +1456,8 @@ Ref<Animation> EditorSceneFormatImporterFBX::import_animation(const String &p_pa
 		uint32_t p_flags, const Map<StringName, Variant> &p_options,
 		int p_bake_fps) {
 	return Ref<Animation>();
+}
+
+EditorSceneFormatImporterFBX::EditorSceneFormatImporterFBX() {
+	_GLOBAL_DEF("filesystem/import/fbx/use_fbx", true, true);
 }

--- a/modules/fbx/editor_scene_importer_fbx.h
+++ b/modules/fbx/editor_scene_importer_fbx.h
@@ -119,10 +119,9 @@ private:
 
 	template <class T>
 	T _interpolate_track(const Vector<float> &p_times, const Vector<T> &p_values, float p_time, AssetImportAnimation::Interpolation p_interp);
-	void _register_project_setting_import(const String generic, const String import_setting_string, const Vector<String> &exts, List<String> *r_extensions, const bool p_enabled) const;
 
 public:
-	EditorSceneFormatImporterFBX() {}
+	EditorSceneFormatImporterFBX();
 	~EditorSceneFormatImporterFBX() {}
 
 	virtual void get_extensions(List<String> *r_extensions) const override;


### PR DESCRIPTION
`EditorSceneFormatImporterFBX` implements its extension setting in a flexible but complex way. It's too much for a single extension/setting, and prevents the project setting from being parsed by `extract.py`.