### PR TITLE
Keep editor at normal priority on windows.

### DIFF
--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -3626,7 +3626,11 @@ DisplayServerWindows::DisplayServerWindows(const String &p_rendering_driver, Win
 	}
 #endif
 
-	if (!OS::get_singleton()->is_in_low_processor_usage_mode()) {
+	if (!Engine::get_singleton()->is_editor_hint() && !OS::get_singleton()->is_in_low_processor_usage_mode()) {
+		// Increase priority for projects that are not in low-processor mode (typically games)
+		// to reduce the risk of frame stuttering.
+		// This is not done for the editor to prevent importers or resource bakers
+		// from making the system unresponsive.
 		SetPriorityClass(GetCurrentProcess(), ABOVE_NORMAL_PRIORITY_CLASS);
 		DWORD index = 0;
 		HANDLE handle = AvSetMmThreadCharacteristics("Games", &index);


### PR DESCRIPTION
The multithreaded importer often causes system-wide hangs when importing more than 20 files at a time.
Running the editor at normal priority allows other applications on the system to be responsive during long imports.

This is a forward port of the change here by @Calinou :
https://github.com/godotengine/godot/compare/3.x...Calinou:windows-editor-use-normal-priority-3.x

I could find the existing PR for this, but this change is working well for me on master.