### PR TITLE
Fix canvas_group not being freed in RendererCanvasCull::free

### DIFF
--- a/servers/rendering/renderer_canvas_cull.cpp
+++ b/servers/rendering/renderer_canvas_cull.cpp
@@ -1664,6 +1664,11 @@ bool RendererCanvasCull::free(RID p_rid) {
 		}
 		*/
 
+		if (canvas_item->canvas_group != nullptr) {
+			memdelete(canvas_item->canvas_group);
+			canvas_item->canvas_group = nullptr;
+		}
+
 		canvas_item_owner.free(p_rid);
 
 	} else if (canvas_light_owner.owns(p_rid)) {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

As pointed by qarmin in https://github.com/godotengine/godot/issues/53667#issuecomment-939853281 when freeing a `canvas_item` in `RendererCanvasCull::free` the associated `canvas_group` is not freed resulting in a memory leak.

Fixes #53667