### PR TITLE
Show the 3D transform gizmo in the center when otherwise offscreen

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -256,7 +256,7 @@ private:
 	};
 
 	void _update_name();
-	void _compute_edit(const Point2 &p_point);
+	void _compute_edit(const Point2 &p_point, const bool p_auto_center = true);
 	void _clear_selected();
 	void _select_clicked(bool p_allow_locked);
 	ObjectID _select_ray(const Point2 &p_pos) const;
@@ -539,6 +539,35 @@ class Node3DEditor : public VBoxContainer {
 public:
 	static const unsigned int VIEWPORTS_COUNT = 4;
 
+	enum MenuOption {
+		MENU_GROUP_SELECTED,
+		MENU_KEEP_GIZMO_ONSCREEN,
+		MENU_LOCK_SELECTED,
+		MENU_SNAP_TO_FLOOR,
+		MENU_TOOL_LIST_SELECT,
+		MENU_TOOL_LOCAL_COORDS,
+		MENU_TOOL_MOVE,
+		MENU_TOOL_OVERRIDE_CAMERA,
+		MENU_TOOL_ROTATE,
+		MENU_TOOL_SCALE,
+		MENU_TOOL_SELECT,
+		MENU_TOOL_USE_SNAP,
+		MENU_TRANSFORM_CONFIGURE_SNAP,
+		MENU_TRANSFORM_DIALOG,
+		MENU_UNGROUP_SELECTED,
+		MENU_UNLOCK_SELECTED,
+		MENU_VIEW_CAMERA_SETTINGS,
+		MENU_VIEW_GIZMOS_3D_ICONS,
+		MENU_VIEW_GRID,
+		MENU_VIEW_ORIGIN,
+		MENU_VIEW_USE_1_VIEWPORT,
+		MENU_VIEW_USE_2_VIEWPORTS,
+		MENU_VIEW_USE_2_VIEWPORTS_ALT,
+		MENU_VIEW_USE_3_VIEWPORTS,
+		MENU_VIEW_USE_3_VIEWPORTS_ALT,
+		MENU_VIEW_USE_4_VIEWPORTS,
+	};
+
 	enum ToolMode {
 		TOOL_MODE_SELECT,
 		TOOL_MODE_MOVE,
@@ -557,7 +586,6 @@ public:
 		TOOL_OPT_USE_SNAP,
 		TOOL_OPT_OVERRIDE_CAMERA,
 		TOOL_OPT_MAX
-
 	};
 
 private:
@@ -585,6 +613,7 @@ private:
 	Camera3D::ProjectionType grid_camera_last_update_perspective = Camera3D::PROJECTION_PERSPECTIVE;
 	Vector3 grid_camera_last_update_position;
 
+	bool keep_gizmo_onscreen = true;
 	Ref<ArrayMesh> move_gizmo[3], move_plane_gizmo[3], rotate_gizmo[4], scale_gizmo[3], scale_plane_gizmo[3], axis_gizmo[3];
 	Ref<StandardMaterial3D> gizmo_color[3];
 	Ref<StandardMaterial3D> plane_gizmo_color[3];
@@ -623,36 +652,9 @@ private:
 	struct Gizmo {
 		bool visible = false;
 		real_t scale = 0;
+		Vector3 target_center;
 		Transform3D transform;
 	} gizmo;
-
-	enum MenuOption {
-		MENU_TOOL_SELECT,
-		MENU_TOOL_MOVE,
-		MENU_TOOL_ROTATE,
-		MENU_TOOL_SCALE,
-		MENU_TOOL_LIST_SELECT,
-		MENU_TOOL_LOCAL_COORDS,
-		MENU_TOOL_USE_SNAP,
-		MENU_TOOL_OVERRIDE_CAMERA,
-		MENU_TRANSFORM_CONFIGURE_SNAP,
-		MENU_TRANSFORM_DIALOG,
-		MENU_VIEW_USE_1_VIEWPORT,
-		MENU_VIEW_USE_2_VIEWPORTS,
-		MENU_VIEW_USE_2_VIEWPORTS_ALT,
-		MENU_VIEW_USE_3_VIEWPORTS,
-		MENU_VIEW_USE_3_VIEWPORTS_ALT,
-		MENU_VIEW_USE_4_VIEWPORTS,
-		MENU_VIEW_ORIGIN,
-		MENU_VIEW_GRID,
-		MENU_VIEW_GIZMOS_3D_ICONS,
-		MENU_VIEW_CAMERA_SETTINGS,
-		MENU_LOCK_SELECTED,
-		MENU_UNLOCK_SELECTED,
-		MENU_GROUP_SELECTED,
-		MENU_UNGROUP_SELECTED,
-		MENU_SNAP_TO_FLOOR
-	};
 
 	Button *tool_button[TOOL_MAX];
 	Button *tool_option_button[TOOL_OPT_MAX];
@@ -816,7 +818,10 @@ public:
 	float get_zfar() const { return settings_zfar->get_value(); }
 	float get_fov() const { return settings_fov->get_value(); }
 
+	Vector3 get_gizmo_target_center() const { return gizmo.target_center; }
 	Transform3D get_gizmo_transform() const { return gizmo.transform; }
+	void set_gizmo_transform(const Transform3D &p_transform) { gizmo.transform = p_transform; }
+	bool is_keep_gizmo_onscreen_enabled() const { return keep_gizmo_onscreen; }
 	bool is_gizmo_visible() const;
 
 	ToolMode get_tool_mode() const { return tool_mode; }


### PR DESCRIPTION
Salvaging https://github.com/godotengine/godot/pull/48307

See also https://github.com/godotengine/godot/issues/57839

Fixes: https://github.com/godotengine/godot-proposals/issues/2673