### PR TITLE
Add documentation to CheckBox

### DIFF
--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -54,23 +54,25 @@
 			The check icon to display when the [CheckBox] is checked.
 		</theme_item>
 		<theme_item name="checked_disabled" data_type="icon" type="Texture2D">
-			The check icon to display when the [CheckBox] is checked and disabled.
+			The check icon to display when the [CheckBox] is checked and is disabled.
 		</theme_item>
 		<theme_item name="radio_checked" data_type="icon" type="Texture2D">
-			If the [CheckBox] is configured as a radio button, the icon to display when the [CheckBox] is checked.
+			The check icon to display when the [CheckBox] is configured as a radio button and is checked.
 		</theme_item>
 		<theme_item name="radio_checked_disabled" data_type="icon" type="Texture2D">
+			The check icon to display when the [CheckBox] is configured as a radio button, is disabled, and is unchecked.
 		</theme_item>
 		<theme_item name="radio_unchecked" data_type="icon" type="Texture2D">
-			If the [CheckBox] is configured as a radio button, the icon to display when the [CheckBox] is unchecked.
+			The check icon to display when the [CheckBox] is configured as a radio button and is unchecked.
 		</theme_item>
 		<theme_item name="radio_unchecked_disabled" data_type="icon" type="Texture2D">
+			The check icon to display when the [CheckBox] is configured as a radio button, is disabled, and is unchecked.
 		</theme_item>
 		<theme_item name="unchecked" data_type="icon" type="Texture2D">
 			The check icon to display when the [CheckBox] is unchecked.
 		</theme_item>
 		<theme_item name="unchecked_disabled" data_type="icon" type="Texture2D">
-			The check icon to display when the [CheckBox] is unchecked and disabled.
+			The check icon to display when the [CheckBox] is unchecked and is disabled.
 		</theme_item>
 		<theme_item name="disabled" data_type="style" type="StyleBox">
 			The [StyleBox] to display as a background when the [CheckBox] is disabled.


### PR DESCRIPTION
CheckBox was missing some theme documentation and some of the wording was inconsistent with the other descriptions.

Not sure if using is checked and is disabled is too verbose, but it seemed consistent with the [writing guidelines](https://docs.godotengine.org/en/stable/community/contributing/docs_writing_guidelines.html#use-if-true-to-describe-booleans).

Repost because I messed up the first one.