### PR TITLE
Rename GDScript `class_name` keyword to `classname`

### DIFF
--- a/modules/gdscript/editor/script_templates/VisualShaderNodeCustom/basic.gd
+++ b/modules/gdscript/editor/script_templates/VisualShaderNodeCustom/basic.gd
@@ -1,7 +1,7 @@
 # meta-description: Visual shader's node plugin template
 
 @tool
-class_name VisualShaderNode_CLASS_
+classname VisualShaderNode_CLASS_
 extends _BASE_
 
 

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2018,7 +2018,7 @@ void GDScriptLanguage::get_reserved_words(List<String> *p_words) const {
 		"await",
 		"breakpoint",
 		"class",
-		"class_name",
+		"classname",
 		"extends",
 		"is",
 		"func",

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -536,13 +536,13 @@ void GDScriptParser::parse_program() {
 	for (bool should_break = false; !should_break;) {
 		// Order here doesn't matter, but there should be only one of each at most.
 		switch (current.type) {
-			case GDScriptTokenizer::Token::CLASS_NAME:
+			case GDScriptTokenizer::Token::CLASSNAME:
 				if (!annotation_stack.is_empty()) {
-					push_error(R"("class_name" should be used before annotations.)");
+					push_error(R"("classname" should be used before annotations.)");
 				}
 				advance();
 				if (head->identifier != nullptr) {
-					push_error(R"("class_name" can only be used once.)");
+					push_error(R"("classname" can only be used once per script.)");
 				} else {
 					parse_class_name();
 				}
@@ -553,7 +553,7 @@ void GDScriptParser::parse_program() {
 				}
 				advance();
 				if (head->extends_used) {
-					push_error(R"("extends" can only be used once.)");
+					push_error(R"("extends" can only be used once per script.)");
 				} else {
 					parse_extends();
 					end_statement("superclass");
@@ -647,7 +647,7 @@ GDScriptParser::ClassNode *GDScriptParser::parse_class() {
 }
 
 void GDScriptParser::parse_class_name() {
-	if (consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected identifier for the global class name after "class_name".)")) {
+	if (consume(GDScriptTokenizer::Token::IDENTIFIER, R"(Expected identifier for the global class name after "classname".)")) {
 		current_class->identifier = parse_identifier();
 	}
 

--- a/modules/gdscript/gdscript_tokenizer.cpp
+++ b/modules/gdscript/gdscript_tokenizer.cpp
@@ -98,7 +98,7 @@ static const char *token_names[] = {
 	"await", // AWAIT,
 	"breakpoint", // BREAKPOINT,
 	"class", // CLASS,
-	"class_name", // CLASS_NAME,
+	"classname", // CLASSNAME,
 	"const", // CONST,
 	"enum", // ENUM,
 	"extends", // EXTENDS,
@@ -178,7 +178,7 @@ bool GDScriptTokenizer::Token::is_node_name() const {
 		case AWAIT:
 		case BREAK:
 		case BREAKPOINT:
-		case CLASS_NAME:
+		case CLASSNAME:
 		case CLASS:
 		case CONST:
 		case CONTINUE:
@@ -456,7 +456,7 @@ GDScriptTokenizer::Token GDScriptTokenizer::potential_identifier() {
 	KEYWORD("breakpoint", Token::BREAKPOINT) \
 	KEYWORD_GROUP('c')                       \
 	KEYWORD("class", Token::CLASS)           \
-	KEYWORD("class_name", Token::CLASS_NAME) \
+	KEYWORD("classname", Token::CLASSNAME)   \
 	KEYWORD("const", Token::CONST)           \
 	KEYWORD("continue", Token::CONTINUE)     \
 	KEYWORD_GROUP('e')                       \

--- a/modules/gdscript/gdscript_tokenizer.h
+++ b/modules/gdscript/gdscript_tokenizer.h
@@ -109,7 +109,7 @@ public:
 			AWAIT,
 			BREAKPOINT,
 			CLASS,
-			CLASS_NAME,
+			CLASSNAME,
 			CONST,
 			ENUM,
 			EXTENDS,

--- a/modules/gdscript/tests/scripts/parser/errors/class_name_after_annotation.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/class_name_after_annotation.gd
@@ -1,6 +1,6 @@
-# Error here. `class_name` should be used *before* annotations, not after.
+# Error here. `classname` should be used *before* annotations, not after.
 @icon("res://path/to/optional/icon.svg")
-class_name HelloWorld
+classname HelloWorld
 
 func test():
 	pass

--- a/modules/gdscript/tests/scripts/parser/errors/class_name_after_annotation.out
+++ b/modules/gdscript/tests/scripts/parser/errors/class_name_after_annotation.out
@@ -1,2 +1,2 @@
 GDTEST_PARSER_ERROR
-"class_name" should be used before annotations.
+"classname" should be used before annotations.

--- a/modules/gdscript/tests/scripts/parser/features/class_name.gd
+++ b/modules/gdscript/tests/scripts/parser/features/class_name.gd
@@ -1,4 +1,4 @@
-class_name HelloWorld
+classname HelloWorld
 @icon("res://path/to/optional/icon.svg")
 
 func test():


### PR DESCRIPTION
`class_name` was the only GDScript keyword to contain an underscore.

Existing projects will need to rename the keyword or the scripts will fail to parse.

See https://github.com/godotengine/godot-proposals/issues/1842#issuecomment-1080743664.