### PR TITLE
Fix Control::warp_mouse to respect canvas transform

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2939,7 +2939,7 @@ Control::MouseFilter Control::get_mouse_filter() const {
 
 void Control::warp_mouse(const Point2 &p_position) {
 	ERR_FAIL_COND(!is_inside_tree());
-	get_viewport()->warp_mouse(get_global_transform().xform(p_position));
+	get_viewport()->warp_mouse(get_global_transform_with_canvas().xform(p_position));
 }
 
 bool Control::is_text_field() const {


### PR DESCRIPTION
Previously `Control::warp_mouse` did not include the canvas transform for its position calculation, which resulted in unexpected cursor relocation, when the canvas had a non-default `Transform2D`.