### PR TITLE
[3.x] Migrate property capitalization settings to property name style

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6034,6 +6034,19 @@ EditorNode::EditorNode() {
 	EDITOR_DEF("version_control/ssh_private_key_path", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "version_control/ssh_private_key_path", PROPERTY_HINT_GLOBAL_FILE));
 
+	// Migrate from old editor setting.
+	{
+		const StringName legacy = "interface/inspector/capitalize_properties";
+		const StringName replacement = "interface/inspector/default_property_name_style";
+		EditorSettings *settings = EditorSettings::get_singleton();
+		if (settings->has_setting(legacy)) {
+			if (!settings->property_can_revert(replacement) && !settings->get(legacy)) {
+				settings->set(replacement, EditorPropertyNameProcessor::STYLE_RAW);
+			}
+			settings->erase(legacy);
+		}
+	}
+
 	theme_base = memnew(Control);
 	add_child(theme_base);
 	theme_base->set_anchors_and_margins_preset(Control::PRESET_WIDE);


### PR DESCRIPTION
Editor setting `interface/inspector/capitalize_properties` is superseded by `interface/inspector/default_property_name_style` in 3.5.

This PR smooths the transition by:

1. Set "default property name style" to Raw (in case my English is broken, its value got updated, not its default value) if it has not been modified by the user and the legacy setting is set to false.
2. Remove the legacy setting. So you won't see the unused & unlocalized setting in Editor Settings dialog.

A `master` version is not provided because it's expected to break things there ;)