### PR TITLE
Changed signals of ItemList

### DIFF
--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -407,19 +407,26 @@
 		</member>
 	</members>
 	<signals>
+		<signal name="empty_clicked">
+			<argument index="0" name="at_position" type="Vector2" />
+			<argument index="1" name="mouse_button_index" type="int" />
+			<description>
+				Triggered when any mouse click is issued within the rect of the list but on empty space.
+			</description>
+		</signal>
 		<signal name="item_activated">
 			<argument index="0" name="index" type="int" />
 			<description>
 				Triggered when specified list item is activated via double-clicking or by pressing [kbd]Enter[/kbd].
 			</description>
 		</signal>
-		<signal name="item_rmb_selected">
+		<signal name="item_clicked">
 			<argument index="0" name="index" type="int" />
 			<argument index="1" name="at_position" type="Vector2" />
+			<argument index="2" name="mouse_button_index" type="int" />
 			<description>
-				Triggered when specified list item has been selected via right mouse clicking.
+				Triggered when specified list item has been clicked with any mouse button.
 				The click position is also provided to allow appropriate popup of context menus at the correct location.
-				[member allow_rmb_select] must be enabled.
 			</description>
 		</signal>
 		<signal name="item_selected">
@@ -434,18 +441,6 @@
 			<argument index="1" name="selected" type="bool" />
 			<description>
 				Triggered when a multiple selection is altered on a list allowing multiple selection.
-			</description>
-		</signal>
-		<signal name="nothing_selected">
-			<description>
-				Triggered when a left mouse click is issued within the rect of the list but on empty space.
-			</description>
-		</signal>
-		<signal name="rmb_clicked">
-			<argument index="0" name="at_position" type="Vector2" />
-			<description>
-				Triggered when a right mouse click is issued within the rect of the list but on empty space.
-				[member allow_rmb_select] must be enabled.
 			</description>
 		</signal>
 	</signals>

--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -271,7 +271,11 @@ DependencyEditor::DependencyEditor() {
 }
 
 /////////////////////////////////////
-void DependencyEditorOwners::_list_rmb_select(int p_item, const Vector2 &p_pos) {
+void DependencyEditorOwners::_list_rmb_clicked(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index) {
+	if (p_mouse_button_index != MouseButton::RIGHT) {
+		return;
+	}
+
 	file_options->clear();
 	file_options->reset_size();
 	if (p_item >= 0) {
@@ -352,7 +356,7 @@ DependencyEditorOwners::DependencyEditorOwners() {
 
 	owners = memnew(ItemList);
 	owners->set_select_mode(ItemList::SELECT_SINGLE);
-	owners->connect("item_rmb_selected", callable_mp(this, &DependencyEditorOwners::_list_rmb_select));
+	owners->connect("item_clicked", callable_mp(this, &DependencyEditorOwners::_list_rmb_clicked));
 	owners->connect("item_activated", callable_mp(this, &DependencyEditorOwners::_select_file));
 	owners->set_allow_rmb_select(true);
 	add_child(owners);

--- a/editor/dependency_editor.h
+++ b/editor/dependency_editor.h
@@ -78,7 +78,7 @@ class DependencyEditorOwners : public AcceptDialog {
 	void _fill_owners(EditorFileSystemDirectory *efsd);
 
 	static void _bind_methods();
-	void _list_rmb_select(int p_item, const Vector2 &p_pos);
+	void _list_rmb_clicked(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index);
 	void _select_file(int p_idx);
 	void _file_option(int p_option);
 

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -529,7 +529,11 @@ void EditorFileDialog::_multi_selected(int p_item, bool p_selected) {
 	get_ok_button()->set_disabled(_is_open_should_be_disabled());
 }
 
-void EditorFileDialog::_items_clear_selection() {
+void EditorFileDialog::_items_clear_selection(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index) {
+	if (p_mouse_button_index != MouseButton::LEFT) {
+		return;
+	}
+
 	item_list->deselect_all();
 
 	// If nothing is selected, then block Open button.
@@ -583,7 +587,11 @@ void EditorFileDialog::_item_dc_selected(int p_item) {
 	}
 }
 
-void EditorFileDialog::_item_list_item_rmb_selected(int p_item, const Vector2 &p_pos) {
+void EditorFileDialog::_item_list_item_rmb_clicked(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index) {
+	if (p_mouse_button_index != MouseButton::RIGHT) {
+		return;
+	}
+
 	// Right click on specific file(s) or folder(s).
 	item_menu->clear();
 	item_menu->reset_size();
@@ -624,10 +632,18 @@ void EditorFileDialog::_item_list_item_rmb_selected(int p_item, const Vector2 &p
 	}
 }
 
-void EditorFileDialog::_item_list_rmb_clicked(const Vector2 &p_pos) {
-	// Right click on folder background. Deselect all files so that actions are applied on the current folder.
+void EditorFileDialog::_item_list_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index) {
+	if (p_mouse_button_index != MouseButton::RIGHT && p_mouse_button_index != MouseButton::LEFT) {
+		return;
+	}
+
+	// Left or right click on folder background. Deselect all files so that actions are applied on the current folder.
 	for (int i = 0; i < item_list->get_item_count(); i++) {
 		item_list->deselect(i);
+	}
+
+	if (p_mouse_button_index != MouseButton::RIGHT) {
+		return;
 	}
 
 	item_menu->clear();
@@ -1753,8 +1769,8 @@ EditorFileDialog::EditorFileDialog() {
 
 	item_list = memnew(ItemList);
 	item_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
-	item_list->connect("item_rmb_selected", callable_mp(this, &EditorFileDialog::_item_list_item_rmb_selected));
-	item_list->connect("rmb_clicked", callable_mp(this, &EditorFileDialog::_item_list_rmb_clicked));
+	item_list->connect("item_clicked", callable_mp(this, &EditorFileDialog::_item_list_item_rmb_clicked));
+	item_list->connect("empty_clicked", callable_mp(this, &EditorFileDialog::_item_list_empty_clicked));
 	item_list->set_allow_rmb_select(true);
 
 	list_vb->add_child(item_list);
@@ -1799,7 +1815,7 @@ EditorFileDialog::EditorFileDialog() {
 	item_list->connect("item_selected", callable_mp(this, &EditorFileDialog::_item_selected), varray(), CONNECT_DEFERRED);
 	item_list->connect("multi_selected", callable_mp(this, &EditorFileDialog::_multi_selected), varray(), CONNECT_DEFERRED);
 	item_list->connect("item_activated", callable_mp(this, &EditorFileDialog::_item_dc_selected), varray());
-	item_list->connect("nothing_selected", callable_mp(this, &EditorFileDialog::_items_clear_selection));
+	item_list->connect("empty_clicked", callable_mp(this, &EditorFileDialog::_items_clear_selection));
 	dir->connect("text_submitted", callable_mp(this, &EditorFileDialog::_dir_submitted));
 	file->connect("text_submitted", callable_mp(this, &EditorFileDialog::_file_submitted));
 	filter->connect("item_selected", callable_mp(this, &EditorFileDialog::_filter_selected));

--- a/editor/editor_file_dialog.h
+++ b/editor/editor_file_dialog.h
@@ -165,11 +165,11 @@ private:
 
 	void _item_selected(int p_item);
 	void _multi_selected(int p_item, bool p_selected);
-	void _items_clear_selection();
+	void _items_clear_selection(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index);
 	void _item_dc_selected(int p_item);
 
-	void _item_list_item_rmb_selected(int p_item, const Vector2 &p_pos);
-	void _item_list_rmb_clicked(const Vector2 &p_pos);
+	void _item_list_item_rmb_clicked(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index);
+	void _item_list_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index);
 	void _item_menu_id_pressed(int p_option);
 
 	void _select_drive(int p_idx);

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2637,7 +2637,11 @@ void FileSystemDock::_tree_empty_selected() {
 	tree->deselect_all();
 }
 
-void FileSystemDock::_file_list_rmb_select(int p_item, const Vector2 &p_pos) {
+void FileSystemDock::_file_list_rmb_clicked(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index) {
+	if (p_mouse_button_index != MouseButton::RIGHT) {
+		return;
+	}
+
 	// Right click is pressed in the file list.
 	Vector<String> paths;
 	for (int i = 0; i < files->get_item_count(); i++) {
@@ -3128,7 +3132,7 @@ FileSystemDock::FileSystemDock() {
 	files->set_v_size_flags(SIZE_EXPAND_FILL);
 	files->set_select_mode(ItemList::SELECT_MULTI);
 	files->set_drag_forwarding(this);
-	files->connect("item_rmb_selected", callable_mp(this, &FileSystemDock::_file_list_rmb_select));
+	files->connect("item_clicked", callable_mp(this, &FileSystemDock::_file_list_rmb_clicked));
 	files->connect("gui_input", callable_mp(this, &FileSystemDock::_file_list_gui_input));
 	files->connect("multi_selected", callable_mp(this, &FileSystemDock::_file_multi_selected));
 	files->connect("rmb_clicked", callable_mp(this, &FileSystemDock::_file_list_rmb_pressed));

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -260,7 +260,7 @@ private:
 	void _file_and_folders_fill_popup(PopupMenu *p_popup, Vector<String> p_paths, bool p_display_path_dependent_options = true);
 	void _tree_rmb_select(const Vector2 &p_pos);
 	void _tree_rmb_empty(const Vector2 &p_pos);
-	void _file_list_rmb_select(int p_item, const Vector2 &p_pos);
+	void _file_list_rmb_clicked(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index);
 	void _file_list_rmb_pressed(const Vector2 &p_pos);
 	void _tree_empty_selected();
 

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -443,7 +443,11 @@ void TileMapEditorTilesPlugin::_scenes_list_multi_selected(int p_index, bool p_s
 	_update_selection_pattern_from_tileset_tiles_selection();
 }
 
-void TileMapEditorTilesPlugin::_scenes_list_nothing_selected() {
+void TileMapEditorTilesPlugin::_scenes_list_lmb_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index) {
+	if (p_mouse_button_index != MouseButton::LEFT) {
+		return;
+	}
+
 	scene_tiles_list->deselect_all();
 	tile_set_selection.clear();
 	tile_map_selection.clear();
@@ -1508,6 +1512,11 @@ void TileMapEditorTilesPlugin::_fix_invalid_tiles_in_tile_map_selection() {
 		tile_map_selection.erase(cell);
 	}
 }
+void TileMapEditorTilesPlugin::patterns_item_list_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index) {
+	if (p_mouse_button_index == MouseButton::LEFT) {
+		_update_selection_pattern_from_tileset_pattern_selection();
+	}
+}
 
 void TileMapEditorTilesPlugin::_update_selection_pattern_from_tilemap_selection() {
 	TileMap *tile_map = Object::cast_to<TileMap>(ObjectDB::get_instance(tile_map_id));
@@ -2221,7 +2230,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	scene_tiles_list->set_drag_forwarding(this);
 	scene_tiles_list->set_select_mode(ItemList::SELECT_MULTI);
 	scene_tiles_list->connect("multi_selected", callable_mp(this, &TileMapEditorTilesPlugin::_scenes_list_multi_selected));
-	scene_tiles_list->connect("nothing_selected", callable_mp(this, &TileMapEditorTilesPlugin::_scenes_list_nothing_selected));
+	scene_tiles_list->connect("empty_clicked", callable_mp(this, &TileMapEditorTilesPlugin::_scenes_list_lmb_empty_clicked));
 	scene_tiles_list->set_texture_filter(CanvasItem::TEXTURE_FILTER_NEAREST);
 	atlas_sources_split_container->add_child(scene_tiles_list);
 
@@ -2251,7 +2260,7 @@ TileMapEditorTilesPlugin::TileMapEditorTilesPlugin() {
 	patterns_item_list->connect("gui_input", callable_mp(this, &TileMapEditorTilesPlugin::_patterns_item_list_gui_input));
 	patterns_item_list->connect("item_selected", callable_mp(this, &TileMapEditorTilesPlugin::_update_selection_pattern_from_tileset_pattern_selection).unbind(1));
 	patterns_item_list->connect("item_activated", callable_mp(this, &TileMapEditorTilesPlugin::_update_selection_pattern_from_tileset_pattern_selection));
-	patterns_item_list->connect("nothing_selected", callable_mp(this, &TileMapEditorTilesPlugin::_update_selection_pattern_from_tileset_pattern_selection));
+	patterns_item_list->connect("empty_clicked", callable_mp(this, &TileMapEditorTilesPlugin::patterns_item_list_empty_clicked));
 	patterns_bottom_panel->add_child(patterns_item_list);
 
 	patterns_help_label = memnew(Label);

--- a/editor/plugins/tiles/tile_map_editor.h
+++ b/editor/plugins/tiles/tile_map_editor.h
@@ -144,6 +144,8 @@ private:
 	void _update_fix_selected_and_hovered();
 	void _fix_invalid_tiles_in_tile_map_selection();
 
+	void patterns_item_list_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index);
+
 	///// Bottom panel common ////
 	void _tab_changed();
 
@@ -187,7 +189,7 @@ private:
 	void _update_scenes_collection_view();
 	void _scene_thumbnail_done(const String &p_path, const Ref<Texture2D> &p_preview, const Ref<Texture2D> &p_small_preview, Variant p_ud);
 	void _scenes_list_multi_selected(int p_index, bool p_selected);
-	void _scenes_list_nothing_selected();
+	void _scenes_list_lmb_empty_clicked(const Vector2 &p_pos, MouseButton p_mouse_button_index);
 
 	///// Bottom panel patterns ////
 	VBoxContainer *patterns_bottom_panel = nullptr;

--- a/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
+++ b/editor/plugins/tiles/tile_proxies_manager_dialog.cpp
@@ -33,7 +33,11 @@
 #include "editor/editor_node.h"
 #include "editor/editor_scale.h"
 
-void TileProxiesManagerDialog::_right_clicked(int p_item, Vector2 p_local_mouse_pos, Object *p_item_list) {
+void TileProxiesManagerDialog::_right_clicked(int p_item, Vector2 p_local_mouse_pos, Object *p_item_list, MouseButton p_mouse_button_index) {
+	if (p_mouse_button_index != MouseButton::RIGHT) {
+		return;
+	}
+
 	ItemList *item_list = Object::cast_to<ItemList>(p_item_list);
 	popup_menu->reset_size();
 	popup_menu->set_position(get_position() + item_list->get_global_mouse_position());
@@ -336,7 +340,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	source_level_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	source_level_list->set_select_mode(ItemList::SELECT_MULTI);
 	source_level_list->set_allow_rmb_select(true);
-	source_level_list->connect("item_rmb_selected", callable_mp(this, &TileProxiesManagerDialog::_right_clicked), varray(source_level_list));
+	source_level_list->connect("item_clicked", callable_mp(this, &TileProxiesManagerDialog::_right_clicked), varray(source_level_list));
 	vbox_container->add_child(source_level_list);
 
 	Label *coords_level_label = memnew(Label);
@@ -347,7 +351,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	coords_level_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	coords_level_list->set_select_mode(ItemList::SELECT_MULTI);
 	coords_level_list->set_allow_rmb_select(true);
-	coords_level_list->connect("item_rmb_selected", callable_mp(this, &TileProxiesManagerDialog::_right_clicked), varray(coords_level_list));
+	coords_level_list->connect("item_clicked", callable_mp(this, &TileProxiesManagerDialog::_right_clicked), varray(coords_level_list));
 	vbox_container->add_child(coords_level_list);
 
 	Label *alternative_level_label = memnew(Label);
@@ -358,7 +362,7 @@ TileProxiesManagerDialog::TileProxiesManagerDialog() {
 	alternative_level_list->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	alternative_level_list->set_select_mode(ItemList::SELECT_MULTI);
 	alternative_level_list->set_allow_rmb_select(true);
-	alternative_level_list->connect("item_rmb_selected", callable_mp(this, &TileProxiesManagerDialog::_right_clicked), varray(alternative_level_list));
+	alternative_level_list->connect("item_clicked", callable_mp(this, &TileProxiesManagerDialog::_right_clicked), varray(alternative_level_list));
 	vbox_container->add_child(alternative_level_list);
 
 	popup_menu = memnew(PopupMenu);

--- a/editor/plugins/tiles/tile_proxies_manager_dialog.h
+++ b/editor/plugins/tiles/tile_proxies_manager_dialog.h
@@ -61,7 +61,7 @@ private:
 	EditorPropertyInteger *alternative_to_property_editor = nullptr;
 
 	PopupMenu *popup_menu = nullptr;
-	void _right_clicked(int p_item, Vector2 p_local_mouse_pos, Object *p_item_list);
+	void _right_clicked(int p_item, Vector2 p_local_mouse_pos, Object *p_item_list, MouseButton p_mouse_button_index);
 	void _menu_id_pressed(int p_id);
 	void _delete_selected_bindings();
 	void _update_lists();

--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildOutputView.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildOutputView.cs
@@ -334,8 +334,13 @@ namespace GodotTools.Build
             }
         }
 
-        private void IssuesListRmbSelected(int index, Vector2 atPosition)
+        private void IssuesListClicked(int index, Vector2 atPosition, int mouseButtonIndex)
         {
+            if (mouseButtonIndex != (int)MouseButton.Right)
+            {
+                return;
+            }
+
             _ = index; // Unused
 
             _issuesListContextMenu.Clear();
@@ -375,7 +380,7 @@ namespace GodotTools.Build
             };
             _issuesList.ItemActivated += IssueActivated;
             _issuesList.AllowRmbSelect = true;
-            _issuesList.ItemRmbSelected += IssuesListRmbSelected;
+            _issuesList.ItemClicked += IssuesListClicked;
             hsc.AddChild(_issuesList);
 
             _issuesListContextMenu = new PopupMenu();


### PR DESCRIPTION
- Fixes #23465
- Fixes https://github.com/godotengine/godot-proposals/issues/3397
- Alternative of #55381 

Changes in signals:
`item_rmb_selected(item, position)` -> `item_mouse_clicked(item, position, mouse_button)`
`rmb_clicked(position)` + `nothing_selected` ->  `empty_clicked(position, mouse_button)`