### PR TITLE
[3.x] Fix crash when using `Camera2D::set_custom_viewport()`

### DIFF
--- a/scene/2d/camera_2d.cpp
+++ b/scene/2d/camera_2d.cpp
@@ -583,6 +583,10 @@ void Camera2D::set_custom_viewport(Node *p_viewport) {
 		remove_from_group(canvas_group_name);
 	}
 
+	if (custom_viewport && !ObjectDB::get_instance(custom_viewport_id)) {
+		viewport = nullptr;
+	}
+
 	custom_viewport = Object::cast_to<Viewport>(p_viewport);
 
 	if (custom_viewport) {


### PR DESCRIPTION
Fixes #59692

`_setup_viewport()` is called when entering tree or when setting custom viewport. It will first disconnect signals from the current `viewport` and assign a new value for it. It crashes if `viewport` is a custom viewport and is already freed.

This PR clears `viewport` when the current custom viewport is invalid, before assigning a new custom viewport.

`master` does not have this issue because it does not connect Viewport signals in Camera2D.