### PR TITLE
Clip animation track keyframe rects

### DIFF
--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -339,11 +339,11 @@ void AnimationTrackEditAudio::draw_key(int p_index, float p_pixels_sec, int p_x,
 		Rect2 rect(Vector2(p_x, int(get_size().height - fh) / 2), Size2(fh, fh));
 
 		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
-		draw_rect(rect, color);
+		draw_rect_clipped(rect, color);
 
 		if (p_selected) {
 			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
-			draw_rect(rect, accent, false);
+			draw_rect_clipped(rect, accent, false);
 		}
 	}
 }
@@ -712,11 +712,11 @@ void AnimationTrackEditSubAnim::draw_key(int p_index, float p_pixels_sec, int p_
 		Rect2 rect(Vector2(p_x, int(get_size().height - fh) / 2), Size2(fh, fh));
 
 		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
-		draw_rect(rect, color);
+		draw_rect_clipped(rect, color);
 
 		if (p_selected) {
 			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
-			draw_rect(rect, accent, false);
+			draw_rect_clipped(rect, accent, false);
 		}
 	}
 }
@@ -1287,11 +1287,11 @@ void AnimationTrackEditTypeAnimation::draw_key(int p_index, float p_pixels_sec, 
 		Rect2 rect(Vector2(p_x, int(get_size().height - fh) / 2), Size2(fh, fh));
 
 		Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
-		draw_rect(rect, color);
+		draw_rect_clipped(rect, color);
 
 		if (p_selected) {
 			Color accent = get_theme_color(SNAME("accent_color"), SNAME("Editor"));
-			draw_rect(rect, accent, false);
+			draw_rect_clipped(rect, accent, false);
 		}
 	}
 }


### PR DESCRIPTION
Fixes #58868

* Empty keyframe for `current_animation` property of the `AnimationPlayer` itself.
* Empty keyframe for animation track of another `AnimationPlayer`.
* Empty keyframe for `playing` property of `AudioStreamPlayer` (when `stream` is valid).