### PR TITLE
Fix that collision objects ignore canvas transform

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -81,7 +81,7 @@ void CollisionObject2D::_notification(int p_what) {
 				return;
 			}
 
-			Transform2D global_transform = get_global_transform();
+			Transform2D global_transform = get_global_transform_with_canvas();
 
 			if (area) {
 				PhysicsServer2D::get_singleton()->area_set_transform(rid, global_transform);


### PR DESCRIPTION
This aligns collision areas with visual areas within a viewport

fix #58514
