### PR TITLE
Fix some issues found by clang sanitizers.

### DIFF
--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -214,7 +214,7 @@ public:
 
 private:
 	PropertyInfo _gen_return_type_info() const {
-		return reinterpret_cast<const Derived *>(this)->_gen_return_type_info_impl();
+		return Derived::_gen_return_type_info_impl();
 	}
 };
 
@@ -237,7 +237,7 @@ public:
 	}
 
 private:
-	PropertyInfo _gen_return_type_info_impl() const {
+	static PropertyInfo _gen_return_type_info_impl() {
 		return {};
 	}
 };
@@ -267,7 +267,7 @@ public:
 	}
 
 private:
-	PropertyInfo _gen_return_type_info_impl() const {
+	static PropertyInfo _gen_return_type_info_impl() {
 		return GetTypeInfo<R>::get_class_info();
 	}
 };

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -824,7 +824,7 @@ Error GDScript::reload(bool p_keep_state) {
 
 // Loading a template, don't parse.
 #ifdef TOOLS_ENABLED
-	if (basedir.begins_with(EditorSettings::get_singleton()->get_project_script_templates_dir())) {
+	if (EditorSettings::get_singleton() && basedir.begins_with(EditorSettings::get_singleton()->get_project_script_templates_dir())) {
 		return OK;
 	}
 #endif


### PR DESCRIPTION
Fixes #59741
Fixes crash of the `--test` run, due to dereferencing of unset `EditorSettings::get_singleton()`.

```
modules/gdscript/gdscript.cpp:827:59: runtime error: member call on null pointer of type 'EditorSettings'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior modules/gdscript/gdscript.cpp:827:59 in
editor/editor_settings.cpp:1115:24: runtime error: member call on null pointer of type 'const EditorSettings *'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior editor/editor_settings.cpp:1115:24 in
```