### PR TITLE
[CI, Test] Add debug macOS editor build with sanitizers.

### DIFF
--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -26,6 +26,14 @@ jobs:
             tests: true
             bin: "./bin/godot.osx.opt.tools.64"
 
+          - name: Editor with sanitizers (target=debug, tools=yes, tests=yes, use_asan=yes, use_ubsan=yes)
+            cache-name: macos-editor
+            target: debug
+            sconsflags: float=64 use_asan=yes use_ubsan=yes
+            tools: true
+            tests: true
+            bin: "./bin/godot.osx.tools.64.san"
+
           - name: Template (target=release, tools=no)
             cache-name: macos-template
             target: release

--- a/core/object/method_bind.h
+++ b/core/object/method_bind.h
@@ -214,7 +214,7 @@ public:
 
 private:
 	PropertyInfo _gen_return_type_info() const {
-		return reinterpret_cast<const Derived *>(this)->_gen_return_type_info_impl();
+		return Derived::_gen_return_type_info_impl();
 	}
 };
 
@@ -237,7 +237,7 @@ public:
 	}
 
 private:
-	PropertyInfo _gen_return_type_info_impl() const {
+	static PropertyInfo _gen_return_type_info_impl() {
 		return {};
 	}
 };
@@ -267,7 +267,7 @@ public:
 	}
 
 private:
-	PropertyInfo _gen_return_type_info_impl() const {
+	static PropertyInfo _gen_return_type_info_impl() {
 		return GetTypeInfo<R>::get_class_info();
 	}
 };

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -824,7 +824,7 @@ Error GDScript::reload(bool p_keep_state) {
 
 // Loading a template, don't parse.
 #ifdef TOOLS_ENABLED
-	if (basedir.begins_with(EditorSettings::get_singleton()->get_project_script_templates_dir())) {
+	if (EditorSettings::get_singleton() && basedir.begins_with(EditorSettings::get_singleton()->get_project_script_templates_dir())) {
 		return OK;
 	}
 #endif


### PR DESCRIPTION
`clang` on macOS seems to detect different issues than `GCC` on Linux.