### PR TITLE
Fix Android double-tap not working.

### DIFF
--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -330,16 +330,15 @@ void AndroidInputHandler::_wheel_button_click(MouseButton event_buttons_mask, co
 	Input::get_singleton()->parse_input_event(evdd);
 }
 
-void AndroidInputHandler::process_double_tap(int event_android_button_mask, Point2 p_pos) {
-	MouseButton event_button_mask = _android_button_mask_to_godot_button_mask(event_android_button_mask);
+void AndroidInputHandler::process_double_tap(Point2 p_pos) {
 	Ref<InputEventMouseButton> ev;
 	ev.instantiate();
 	_set_key_modifier_state(ev);
 	ev->set_position(p_pos);
 	ev->set_global_position(p_pos);
-	ev->set_pressed(event_button_mask != MouseButton::NONE);
-	ev->set_button_index(_button_index_from_mask(event_button_mask));
-	ev->set_button_mask(event_button_mask);
+	ev->set_pressed(true);
+	ev->set_button_index(MouseButton::LEFT);
+	ev->set_button_mask(MouseButton::MASK_LEFT);
 	ev->set_double_click(true);
 	Input::get_singleton()->parse_input_event(ev);
 }

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -81,7 +81,7 @@ public:
 	void process_touch(int p_event, int p_pointer, const Vector<TouchPos> &p_points);
 	void process_hover(int p_type, Point2 p_pos);
 	void process_mouse_event(int input_device, int event_action, int event_android_buttons_mask, Point2 event_pos, float event_vertical_factor = 0, float event_horizontal_factor = 0);
-	void process_double_tap(int event_android_button_mask, Point2 p_pos);
+	void process_double_tap(Point2 p_pos);
 	void process_joy_event(JoypadEvent p_event);
 	void process_key_event(int p_keycode, int p_scancode, int p_unicode_char, bool p_pressed);
 };

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotLib.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotLib.java
@@ -111,7 +111,7 @@ public class GodotLib {
 	/**
 	 * Forward double_tap events from the main thread to the GL thread.
 	 */
-	public static native void doubleTap(int buttonMask, int x, int y);
+	public static native void doubleTap(int x, int y);
 
 	/**
 	 * Forward accelerometer sensor events from the main thread to the GL thread.

--- a/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/input/GodotGestureHandler.java
@@ -54,7 +54,6 @@ public class GodotGestureHandler extends GestureDetector.SimpleOnGestureListener
 	@Override
 	public boolean onDown(MotionEvent event) {
 		super.onDown(event);
-		//Log.i("GodotGesture", "onDown");
 		return true;
 	}
 
@@ -66,22 +65,18 @@ public class GodotGestureHandler extends GestureDetector.SimpleOnGestureListener
 
 	@Override
 	public void onLongPress(MotionEvent event) {
-		//Log.i("GodotGesture", "onLongPress");
 	}
 
 	@Override
 	public boolean onDoubleTap(MotionEvent event) {
-		//Log.i("GodotGesture", "onDoubleTap");
 		final int x = Math.round(event.getX());
 		final int y = Math.round(event.getY());
-		final int buttonMask = event.getButtonState();
-		GodotLib.doubleTap(buttonMask, x, y);
+		GodotLib.doubleTap(x, y);
 		return true;
 	}
 
 	@Override
 	public boolean onFling(MotionEvent event1, MotionEvent event2, float velocityX, float velocityY) {
-		//Log.i("GodotGesture", "onFling");
 		return true;
 	}
 }

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -297,12 +297,12 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_hover(JNIEnv *env, jc
 }
 
 // Called on the UI thread
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_doubleTap(JNIEnv *env, jclass clazz, jint p_button_mask, jint p_x, jint p_y) {
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_doubleTap(JNIEnv *env, jclass clazz, jint p_x, jint p_y) {
 	if (step.get() <= 0) {
 		return;
 	}
 
-	input_handler->process_double_tap(p_button_mask, Point2(p_x, p_y));
+	input_handler->process_double_tap(Point2(p_x, p_y));
 }
 
 // Called on the UI thread

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -35,7 +35,7 @@
 #include <jni.h>
 
 // These functions can be called from within JAVA and are the means by which our JAVA implementation calls back into our C++ code.
-// See java/src/org/godotengine/godot/GodotLib.java for the JAVA side of this (yes that's why we have the long names)
+// See java/lib/src/org/godotengine/godot/GodotLib.java for the JAVA side of this (yes that's why we have the long names)
 extern "C" {
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *env, jclass clazz, jobject activity, jobject godot_instance, jobject p_asset_manager, jboolean p_use_apk_expansion);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_ondestroy(JNIEnv *env, jclass clazz);
@@ -50,7 +50,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_touch__IIII_3F(JNIEnv
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_touch__IIII_3FI(JNIEnv *env, jclass clazz, jint input_device, jint ev, jint pointer, jint pointer_count, jfloatArray positions, jint buttons_mask);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_touch__IIII_3FIFF(JNIEnv *env, jclass clazz, jint input_device, jint ev, jint pointer, jint pointer_count, jfloatArray positions, jint buttons_mask, jfloat vertical_factor, jfloat horizontal_factor);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_hover(JNIEnv *env, jclass clazz, jint p_type, jfloat p_x, jfloat p_y);
-JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_doubleTap(JNIEnv *env, jclass clazz, jint p_button_mask, jint p_x, jint p_y);
+JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_doubleTap(JNIEnv *env, jclass clazz, jint p_x, jint p_y);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_key(JNIEnv *env, jclass clazz, jint p_keycode, jint p_scancode, jint p_unicode_char, jboolean p_pressed);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joybutton(JNIEnv *env, jclass clazz, jint p_device, jint p_button, jboolean p_pressed);
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_joyaxis(JNIEnv *env, jclass clazz, jint p_device, jint p_axis, jfloat p_value);


### PR DESCRIPTION
#37158 added the event's button state to Android's `onDoubleTap` gesture processing. However, the button state is always zero. This broke double tapping (#8151, #46100, #46101).

As per the [documentation](https://developer.android.com/reference/android/view/GestureDetector.SimpleOnGestureListener#onDoubleTap(android.view.MotionEvent)), the `onDoubleTap` notification is _"Triggered on the down event of second tap."_ Furthermore, since double-clicks are only detected on the left mouse button, even if the button state was correct, we can safely assume that the event `pressed` parameter will be `true`, `button_index` will be `MouseButton::LEFT` and `button_mask` will be `MASK_LEFT`.

Therefore this PR reverts #37158's addition of the button state to the Android `onDoubleTap` gesture processing.

Fixes #8151.
Provides a partial fix for #46100 and #46101 in as much as the output on Android will be
```
Event doubleclick = False, pressed = True, button_index = 1
Event doubleclick = False, pressed = False, button_index = 1
Event doubleclick = True, pressed = True, button_index = 1
Event doubleclick = False, pressed = True, button_index = 1
Event doubleclick = False, pressed = False, button_index = 1
```
vs the desktop output of:
```
Event doubleclick = False, pressed = True, button_index = 1
Event doubleclick = False, pressed = False, button_index = 1
Event doubleclick = True, pressed = True, button_index = 1
Event doubleclick = False, pressed = False, button_index = 1
```
In other words there is still an extra event, but at least there is a correct `doubleclick` event that can be detected appropriately.