### PR TITLE
Improve VisualScript search and instancing of nodes

### DIFF
--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -3390,6 +3390,8 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 				n->set_call_mode(VisualScriptFunctionCall::CALL_MODE_NODE_PATH);
 				n->set_base_path(drop_path);
 			}
+		} else {
+			n->set_call_mode(VisualScriptFunctionCall::CALL_MODE_INSTANCE);
 		}
 		if (drop_node) {
 			n->set_base_type(drop_node->get_class());
@@ -3702,8 +3704,13 @@ void VisualScriptEditor::_selected_connect_node(const String &p_text, const Stri
 		Object::cast_to<VisualScriptTypeCast>(vnode.ptr())->set_base_type(base_type);
 		Object::cast_to<VisualScriptTypeCast>(vnode.ptr())->set_base_script(base_script);
 	} else if (Object::cast_to<VisualScriptFunctionCall>(vnode.ptr())) {
-		Object::cast_to<VisualScriptFunctionCall>(vnode.ptr())->set_base_type(base_type);
-		Object::cast_to<VisualScriptFunctionCall>(vnode.ptr())->set_base_script(base_script);
+		if (base_type_map.has(base_type)) {
+			Object::cast_to<VisualScriptFunctionCall>(vnode.ptr())->set_basic_type(base_type_map[base_type]);
+			Object::cast_to<VisualScriptFunctionCall>(vnode.ptr())->set_call_mode(VisualScriptFunctionCall::CALL_MODE_BASIC_TYPE);
+		} else {
+			Object::cast_to<VisualScriptFunctionCall>(vnode.ptr())->set_base_type(base_type);
+			Object::cast_to<VisualScriptFunctionCall>(vnode.ptr())->set_base_script(base_script);
+		}
 	} else if (Object::cast_to<VisualScriptPropertySet>(vnode.ptr())) {
 		Object::cast_to<VisualScriptPropertySet>(vnode.ptr())->set_base_type(base_type);
 		Object::cast_to<VisualScriptPropertySet>(vnode.ptr())->set_base_script(base_script);
@@ -4751,6 +4758,35 @@ VisualScriptEditor::VisualScriptEditor() {
 	popup_menu->add_item(TTR("Duplicate"), EDIT_DUPLICATE_NODES);
 	popup_menu->add_item(TTR("Clear Copy Buffer"), EDIT_CLEAR_COPY_BUFFER);
 	popup_menu->connect("id_pressed", callable_mp(this, &VisualScriptEditor::_menu_option));
+
+	base_type_map.insert("String", Variant::STRING);
+	base_type_map.insert("Vector2", Variant::VECTOR2);
+	base_type_map.insert("Vector2i", Variant::VECTOR2I);
+	base_type_map.insert("Rect2", Variant::RECT2);
+	base_type_map.insert("Rect2i", Variant::RECT2I);
+	base_type_map.insert("Vector3", Variant::VECTOR3);
+	base_type_map.insert("Vector3i", Variant::VECTOR3I);
+	base_type_map.insert("Transform2D", Variant::TRANSFORM2D);
+	base_type_map.insert("Plane", Variant::PLANE);
+	base_type_map.insert("Quaternion", Variant::QUATERNION);
+	base_type_map.insert("AABB", Variant::AABB);
+	base_type_map.insert("Basis", Variant::BASIS);
+	base_type_map.insert("Transform3D", Variant::TRANSFORM3D);
+	base_type_map.insert("Color", Variant::COLOR);
+	base_type_map.insert("NodePath", Variant::NODE_PATH);
+	base_type_map.insert("RID", Variant::RID);
+	base_type_map.insert("Callable", Variant::CALLABLE);
+	base_type_map.insert("Dictionary", Variant::DICTIONARY);
+	base_type_map.insert("Array", Variant::ARRAY);
+	base_type_map.insert("PackedByteArray", Variant::PACKED_BYTE_ARRAY);
+	base_type_map.insert("PackedInt32Array", Variant::PACKED_INT32_ARRAY);
+	base_type_map.insert("PackedFloat32Array", Variant::PACKED_FLOAT32_ARRAY);
+	base_type_map.insert("PackedInt64Array", Variant::PACKED_INT64_ARRAY);
+	base_type_map.insert("PackedFloat64Array", Variant::PACKED_FLOAT64_ARRAY);
+	base_type_map.insert("PackedStringArray", Variant::PACKED_STRING_ARRAY);
+	base_type_map.insert("PackedVector2Array", Variant::PACKED_VECTOR2_ARRAY);
+	base_type_map.insert("PackedVector3Array", Variant::PACKED_VECTOR3_ARRAY);
+	base_type_map.insert("PackedColorArray", Variant::PACKED_COLOR_ARRAY);
 }
 
 VisualScriptEditor::~VisualScriptEditor() {

--- a/modules/visual_script/editor/visual_script_editor.h
+++ b/modules/visual_script/editor/visual_script_editor.h
@@ -144,6 +144,7 @@ class VisualScriptEditor : public ScriptEditorBase {
 
 	Map<StringName, Color> node_colors;
 	HashMap<StringName, Ref<StyleBox>> node_styles;
+	Map<StringName, Variant::Type> base_type_map;
 
 	void _update_graph_connections();
 	void _update_graph(int p_only_id = -1);

--- a/modules/visual_script/editor/visual_script_property_selector.cpp
+++ b/modules/visual_script/editor/visual_script_property_selector.cpp
@@ -86,6 +86,13 @@ void VisualScriptPropertySelector::_update_results_s(String p_string) {
 	_update_results();
 }
 
+void VisualScriptPropertySelector::_update_results_search_all() {
+	if (search_classes->is_pressed()) {
+		scope_combo->select(COMBO_ALL);
+	}
+	_update_results();
+}
+
 void VisualScriptPropertySelector::_update_results() {
 	_update_icons();
 	search_runner = Ref<SearchRunner>(memnew(SearchRunner(this, results_tree)));
@@ -167,7 +174,7 @@ void VisualScriptPropertySelector::select_method_from_base_type(const String &p_
 	search_properties->set_pressed(false);
 	search_theme_items->set_pressed(false);
 
-	scope_combo->select(2); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated"
+	scope_combo->select(COMBO_BASE);
 
 	results_tree->clear();
 	show_window(.5f);
@@ -201,8 +208,7 @@ void VisualScriptPropertySelector::select_from_base_type(const String &p_base, c
 	search_properties->set_pressed(true);
 	search_theme_items->set_pressed(false);
 
-	// When class is Input only show inheritors
-	scope_combo->select(0); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated"
+	scope_combo->select(COMBO_RELATED);
 
 	results_tree->clear();
 	show_window(.5f);
@@ -234,7 +240,7 @@ void VisualScriptPropertySelector::select_from_script(const Ref<Script> &p_scrip
 	search_properties->set_pressed(true);
 	search_theme_items->set_pressed(false);
 
-	scope_combo->select(2); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated"
+	scope_combo->select(COMBO_BASE);
 
 	results_tree->clear();
 	show_window(.5f);
@@ -264,7 +270,7 @@ void VisualScriptPropertySelector::select_from_basic_type(Variant::Type p_type, 
 	search_properties->set_pressed(true);
 	search_theme_items->set_pressed(false);
 
-	scope_combo->select(2); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated" //id5 "Search All"
+	scope_combo->select(COMBO_BASE);
 
 	results_tree->clear();
 	show_window(.5f);
@@ -294,7 +300,7 @@ void VisualScriptPropertySelector::select_from_action(const String &p_type, cons
 	search_properties->set_pressed(false);
 	search_theme_items->set_pressed(false);
 
-	scope_combo->select(0); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated" //id5 "Search All"
+	scope_combo->select(COMBO_RELATED);
 
 	results_tree->clear();
 	show_window(.5f);
@@ -330,7 +336,7 @@ void VisualScriptPropertySelector::select_from_instance(Object *p_instance, cons
 	search_properties->set_pressed(true);
 	search_theme_items->set_pressed(false);
 
-	scope_combo->select(2); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated" //id5 "Search All"
+	scope_combo->select(COMBO_BASE);
 
 	results_tree->clear();
 	show_window(.5f);
@@ -363,7 +369,7 @@ void VisualScriptPropertySelector::select_from_visual_script(const Ref<Script> &
 	search_properties->set_pressed(true);
 	search_theme_items->set_pressed(false);
 
-	scope_combo->select(2); //id0 = "Search Related" //id2 = "Search Base" //id3 = "Search Inheriters" //id4 = "Search Unrelated" //id5 "Search All"
+	scope_combo->select(COMBO_BASE);
 
 	results_tree->clear();
 	show_window(.5f);
@@ -418,7 +424,7 @@ VisualScriptPropertySelector::VisualScriptPropertySelector() {
 	search_classes = memnew(Button);
 	search_classes->set_flat(true);
 	search_classes->set_tooltip(TTR("Search Classes"));
-	search_classes->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_results));
+	search_classes->connect("pressed", callable_mp(this, &VisualScriptPropertySelector::_update_results_search_all));
 	search_classes->set_toggle_mode(true);
 	search_classes->set_pressed(true);
 	search_classes->set_focus_mode(Control::FOCUS_NONE);
@@ -739,49 +745,46 @@ bool VisualScriptPropertySelector::SearchRunner::_phase_node_classes_build() {
 	if (vs_nodes.is_empty()) {
 		return true;
 	}
-	String registerd_node_name = vs_nodes[0];
+	String registered_node_name = vs_nodes[0];
 	vs_nodes.pop_front();
 
-	Vector<String> path = registerd_node_name.split("/");
+	Vector<String> path = registered_node_name.split("/");
 	if (path[0] == "constants") {
-		_add_class_doc(registerd_node_name, "", "constants");
+		_add_class_doc(registered_node_name, "", "constants");
 	} else if (path[0] == "custom") {
-		_add_class_doc(registerd_node_name, "", "custom");
+		_add_class_doc(registered_node_name, "", "custom");
 	} else if (path[0] == "data") {
-		_add_class_doc(registerd_node_name, "", "data");
+		_add_class_doc(registered_node_name, "", "data");
 	} else if (path[0] == "flow_control") {
-		_add_class_doc(registerd_node_name, "", "flow_control");
+		_add_class_doc(registered_node_name, "", "flow_control");
 	} else if (path[0] == "functions") {
 		if (path[1] == "built_in") {
-			_add_class_doc(registerd_node_name, "functions", "built_in");
+			_add_class_doc(registered_node_name, "functions", "built_in");
 		} else if (path[1] == "by_type") {
-			if (search_flags & SEARCH_CLASSES) {
-				_add_class_doc(registerd_node_name, path[2], "by_type_class");
-			}
+			// No action is required.
+			// Using function references from ClassDB to remove confusion for users.
 		} else if (path[1] == "constructors") {
-			if (search_flags & SEARCH_CLASSES) {
-				_add_class_doc(registerd_node_name, path[2].substr(0, path[2].find_char('(')), "constructors_class");
-			}
+			_add_class_doc(registered_node_name, "", "constructors");
 		} else if (path[1] == "deconstruct") {
-			_add_class_doc(registerd_node_name, "", "deconstruct");
+			_add_class_doc(registered_node_name, "", "deconstruct");
 		} else if (path[1] == "wait") {
-			_add_class_doc(registerd_node_name, "functions", "yield");
+			_add_class_doc(registered_node_name, "functions", "yield");
 		} else {
-			_add_class_doc(registerd_node_name, "functions", "");
+			_add_class_doc(registered_node_name, "functions", "");
 		}
 	} else if (path[0] == "index") {
-		_add_class_doc(registerd_node_name, "", "index");
+		_add_class_doc(registered_node_name, "", "index");
 	} else if (path[0] == "operators") {
 		if (path[1] == "bitwise") {
-			_add_class_doc(registerd_node_name, "operators", "bitwise");
+			_add_class_doc(registered_node_name, "operators", "bitwise");
 		} else if (path[1] == "compare") {
-			_add_class_doc(registerd_node_name, "operators", "compare");
+			_add_class_doc(registered_node_name, "operators", "compare");
 		} else if (path[1] == "logic") {
-			_add_class_doc(registerd_node_name, "operators", "logic");
+			_add_class_doc(registered_node_name, "operators", "logic");
 		} else if (path[1] == "math") {
-			_add_class_doc(registerd_node_name, "operators", "math");
+			_add_class_doc(registered_node_name, "operators", "math");
 		} else {
-			_add_class_doc(registerd_node_name, "operators", "");
+			_add_class_doc(registered_node_name, "operators", "");
 		}
 	}
 	return false;

--- a/modules/visual_script/editor/visual_script_property_selector.h
+++ b/modules/visual_script/editor/visual_script_property_selector.h
@@ -62,6 +62,15 @@ class VisualScriptPropertySelector : public ConfirmationDialog {
 		SCOPE_ALL = SCOPE_BASE | SCOPE_INHERITERS | SCOPE_UNRELATED
 	};
 
+	enum ScopeCombo {
+		COMBO_RELATED,
+		COMBO_SEPARATOR,
+		COMBO_BASE,
+		COMBO_INHERITERS,
+		COMBO_UNRELATED,
+		COMBO_ALL,
+	};
+
 	LineEdit *search_box = nullptr;
 
 	Button *case_sensitive_button = nullptr;
@@ -88,6 +97,7 @@ class VisualScriptPropertySelector : public ConfirmationDialog {
 	void _sbox_input(const Ref<InputEvent> &p_ie);
 	void _update_results_i(int p_int);
 	void _update_results_s(String p_string);
+	void _update_results_search_all();
 	void _update_results();
 
 	void _confirmed();


### PR DESCRIPTION
Constructors were sorted under classes and are now sorted directly in the "constructors" category, making them independent of scope.
Fix https://github.com/godotengine/godot/issues/58070

BasicType methods are no longer generated from registered_node_names as VisualScriptNodes. Removing duplicates and confusion.
When the search_classes is selected the scope is automatically changed to SEARCH_ALL. This assumes the current scope is not sufficient.
Fix https://github.com/godotengine/godot/issues/58118
Possible Fix https://github.com/godotengine/godot/issues/58129
Possible Fix https://github.com/godotengine/godot/issues/58128

When dropping basic type methods the call_mode and basic_type integer are properly set.
