### PR TITLE
Fix group names in FastNoise and Gradient

### DIFF
--- a/modules/noise/fastnoise_lite.cpp
+++ b/modules/noise/fastnoise_lite.cpp
@@ -484,7 +484,7 @@ void FastNoiseLite::_bind_methods() {
 
 	// Domain warp.
 
-	ADD_GROUP("Domain warp", "domain_warp_");
+	ADD_GROUP("Domain Warp", "domain_warp_");
 
 	ClassDB::bind_method(D_METHOD("set_domain_warp_enabled", "domain_warp_enabled"), &FastNoiseLite::set_domain_warp_enabled);
 	ClassDB::bind_method(D_METHOD("is_domain_warp_enabled"), &FastNoiseLite::is_domain_warp_enabled);

--- a/scene/resources/gradient.cpp
+++ b/scene/resources/gradient.cpp
@@ -71,7 +71,7 @@ void Gradient::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "interpolation_mode", PROPERTY_HINT_ENUM, "Linear,Constant,Cubic"), "set_interpolation_mode", "get_interpolation_mode");
 
-	ADD_GROUP("Raw data", "");
+	ADD_GROUP("Raw Data", "");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_FLOAT32_ARRAY, "offsets"), "set_offsets", "get_offsets");
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_COLOR_ARRAY, "colors"), "set_colors", "get_colors");
 


### PR DESCRIPTION
* Changes the "Domain warp" group to "Domain Warp" in FastNoise.
* Changes the "Raw data" group to "Raw Data" in Gradient.