### PR TITLE
[3.x] Fix crash in AudioServer when switching audio devices with different audio channels count

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -929,6 +929,7 @@ void AudioServer::init_channels_and_buffers() {
 		for (int j = 0; j < channel_count; j++) {
 			buses.write[i]->channels.write[j].buffer.resize(buffer_size);
 		}
+		_update_bus_effects(i);
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/52275 

Switching audio devices with different audio channels count caused crashes in `AudioServer::_mix_step()` because it tried to access non-existent effects instances in `bus->channels[k].effect_instances`. `AudioServer::init_channels_and_buffers()` is called if there is change in `get_channel_count()`. The update of effects (creating new effects instances) on new channels was missing here.