### PR TITLE
Add CI build with clang sanitizers, increase stack size to 30 MB for builds with sanitizers.

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -30,7 +30,7 @@ jobs:
             build-mono: true
             artifact: true
 
-          - name: Editor with doubles and sanitizers (target=debug, tools=yes, float=64, tests=yes, use_asan=yes, use_ubsan=yes)
+          - name: Editor with doubles and GCC sanitizers (target=debug, tools=yes, float=64, tests=yes, use_asan=yes, use_ubsan=yes)
             cache-name: linux-editor-double-sanitizers
             target: debug
             tools: true
@@ -41,6 +41,17 @@ jobs:
             # until both the upstream PR and the matching godot-cpp changes are merged.
             godot-cpp-test: true
             bin: "./bin/godot.linuxbsd.double.tools.64.san"
+            build-mono: false
+            # Skip 2GiB artifact speeding up action.
+            artifact: false
+
+          - name: Editor with clang sanitizers (target=debug, tools=yes, use_asan=yes, use_ubsan=yes, use_llvm=yes)
+            cache-name: linux-editor-llvm-sanitizers
+            target: debug
+            tools: true
+            tests: true
+            sconsflags: use_asan=yes use_ubsan=yes use_llvm=yes
+            bin: "./bin/godot.linuxbsd.tools.64.llvm.san"
             build-mono: false
             # Skip 2GiB artifact speeding up action.
             artifact: false
@@ -75,7 +86,8 @@ jobs:
           # The actual dependencies
           sudo apt-get install build-essential pkg-config libx11-dev libxcursor-dev \
               libxinerama-dev libgl1-mesa-dev libglu-dev libasound2-dev libpulse-dev \
-              libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip
+              libdbus-1-dev libudev-dev libxi-dev libxrandr-dev yasm xvfb wget unzip \
+              llvm
 
       - name: Setup Godot build cache
         uses: ./.github/actions/godot-cache

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -162,6 +162,7 @@ def configure(env):
 
     if env["use_ubsan"] or env["use_asan"] or env["use_lsan"] or env["use_tsan"] or env["use_msan"]:
         env.extra_suffix += ".san"
+        env.Append(CCFLAGS=["-DSANITIZERS_ENABLED"])
 
         if env["use_ubsan"]:
             env.Append(

--- a/platform/linuxbsd/godot_linuxbsd.cpp
+++ b/platform/linuxbsd/godot_linuxbsd.cpp
@@ -33,10 +33,20 @@
 #include <stdlib.h>
 #include <unistd.h>
 
+#if defined(SANITIZERS_ENABLED)
+#include <sys/resource.h>
+#endif
+
 #include "main/main.h"
 #include "os_linuxbsd.h"
 
 int main(int argc, char *argv[]) {
+#if defined(SANITIZERS_ENABLED)
+	// Note: Set stack size to be at least 30 MB (vs 8 MB default) to avoid overflow, address sanitizer can increase stack usage up to 3 times.
+	struct rlimit stack_lim = { 0x1E00000, 0x1E00000 };
+	setrlimit(RLIMIT_STACK, &stack_lim);
+#endif
+
 	OS_LinuxBSD os;
 
 	setlocale(LC_CTYPE, "");

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -127,6 +127,7 @@ def configure(env):
 
     if env["use_ubsan"] or env["use_asan"] or env["use_tsan"]:
         env.extra_suffix += ".san"
+        env.Append(CCFLAGS=["-DSANITIZERS_ENABLED"])
 
         if env["use_ubsan"]:
             env.Append(

--- a/platform/osx/godot_main_osx.mm
+++ b/platform/osx/godot_main_osx.mm
@@ -35,10 +35,20 @@
 #include <string.h>
 #include <unistd.h>
 
+#if defined(SANITIZERS_ENABLED)
+#include <sys/resource.h>
+#endif
+
 int main(int argc, char **argv) {
 #if defined(VULKAN_ENABLED)
 	// MoltenVK - enable full component swizzling support.
 	setenv("MVK_CONFIG_FULL_IMAGE_VIEW_SWIZZLE", "1", 1);
+#endif
+
+#if defined(SANITIZERS_ENABLED)
+	// Note: Set stack size to be at least 30 MB (vs 8 MB default) to avoid overflow, address sanitizer can increase stack usage up to 3 times.
+	struct rlimit stack_lim = { 0x1E00000, 0x1E00000 };
+	setrlimit(RLIMIT_STACK, &stack_lim);
 #endif
 
 	int first_arg = 1;


### PR DESCRIPTION
Alternative to #59751.

`clang` sanitizers are reporting a different set of issues, so it might be useful to have both it and GCC build with sanitizers to catch more errors.

Note: `clang` address sanitizer use a lot more stack than GCC one (or build without sanitizer). To prevent stack overflow in the long recursion GDScript test (`is_prime(9973)` call, with more ~100 levels of recursion) stack size is increased to 30 MB for builds with sanitizers.