### PR TITLE
[3.x] Fix memory leak when handling Linux primary clipboard

### DIFF
--- a/platform/x11/os_x11.cpp
+++ b/platform/x11/os_x11.cpp
@@ -2229,7 +2229,7 @@ Atom OS_X11::_process_selection_request_target(Atom p_target, Window p_requestor
 		// is the owner during a selection request.
 		CharString clip;
 		static const char *target_type = "PRIMARY";
-		if (p_selection != None && String(XGetAtomName(x11_display, p_selection)) == target_type) {
+		if (p_selection != None && get_atom_name(x11_display, p_selection) == target_type) {
 			clip = OS::get_clipboard_primary().utf8();
 		} else {
 			clip = OS::get_clipboard().utf8();


### PR DESCRIPTION
`XGetAtomName` needs a `XFree`, uses the wrapped version instead.

`master` does not need this because it's already covered in #58742. This `XGetAtomName` on `3.x` was included in an old PR that's merged recently.