### PR TITLE
Fix crash in AudioServer when switching audio devices with different audio channels count 

### DIFF
--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1343,6 +1343,7 @@ void AudioServer::init_channels_and_buffers() {
 		for (int j = 0; j < channel_count; j++) {
 			buses.write[i]->channels.write[j].buffer.resize(buffer_size);
 		}
+		_update_bus_effects(i);
 	}
 }
 


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/59778
