### PR TITLE
Add margins to Array and Dictionary editors

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -217,11 +217,11 @@ void EditorPropertyArray::update_property() {
 	if (array.get_type() == Variant::NIL) {
 		edit->set_text(vformat(TTR("(Nil) %s"), array_type_name));
 		edit->set_pressed(false);
-		if (vbox) {
+		if (container) {
 			set_bottom_editor(nullptr);
-			memdelete(vbox);
+			memdelete(container);
 			button_add_item = nullptr;
-			vbox = nullptr;
+			container = nullptr;
 		}
 		return;
 	}
@@ -241,10 +241,14 @@ void EditorPropertyArray::update_property() {
 	if (unfolded) {
 		updating = true;
 
-		if (!vbox) {
-			vbox = memnew(VBoxContainer);
-			add_child(vbox);
-			set_bottom_editor(vbox);
+		if (!container) {
+			container = memnew(MarginContainer);
+			container->set_theme_type_variation("MarginContainer4px");
+			add_child(container);
+			set_bottom_editor(container);
+
+			VBoxContainer *vbox = memnew(VBoxContainer);
+			container->add_child(vbox);
 
 			HBoxContainer *hbox = memnew(HBoxContainer);
 			vbox->add_child(hbox);
@@ -372,11 +376,11 @@ void EditorPropertyArray::update_property() {
 		updating = false;
 
 	} else {
-		if (vbox) {
+		if (container) {
 			set_bottom_editor(nullptr);
-			memdelete(vbox);
+			memdelete(container);
 			button_add_item = nullptr;
-			vbox = nullptr;
+			container = nullptr;
 		}
 	}
 }
@@ -687,7 +691,7 @@ EditorPropertyArray::EditorPropertyArray() {
 	add_child(edit);
 	add_focusable(edit);
 
-	vbox = nullptr;
+	container = nullptr;
 	property_vbox = nullptr;
 	size_slider = nullptr;
 	button_add_item = nullptr;
@@ -791,11 +795,11 @@ void EditorPropertyDictionary::update_property() {
 	if (updated_val.get_type() == Variant::NIL) {
 		edit->set_text(TTR("Dictionary (Nil)")); // This provides symmetry with the array property.
 		edit->set_pressed(false);
-		if (vbox) {
+		if (container) {
 			set_bottom_editor(nullptr);
-			memdelete(vbox);
+			memdelete(container);
 			button_add_item = nullptr;
-			vbox = nullptr;
+			container = nullptr;
 		}
 		return;
 	}
@@ -812,10 +816,14 @@ void EditorPropertyDictionary::update_property() {
 	if (unfolded) {
 		updating = true;
 
-		if (!vbox) {
-			vbox = memnew(VBoxContainer);
-			add_child(vbox);
-			set_bottom_editor(vbox);
+		if (!container) {
+			container = memnew(MarginContainer);
+			container->set_theme_type_variation("MarginContainer4px");
+			add_child(container);
+			set_bottom_editor(container);
+
+			VBoxContainer *vbox = memnew(VBoxContainer);
+			container->add_child(vbox);
 
 			property_vbox = memnew(VBoxContainer);
 			property_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1116,11 +1124,11 @@ void EditorPropertyDictionary::update_property() {
 		updating = false;
 
 	} else {
-		if (vbox) {
+		if (container) {
 			set_bottom_editor(nullptr);
-			memdelete(vbox);
+			memdelete(container);
 			button_add_item = nullptr;
-			vbox = nullptr;
+			container = nullptr;
 		}
 	}
 }
@@ -1188,7 +1196,7 @@ EditorPropertyDictionary::EditorPropertyDictionary() {
 	add_child(edit);
 	add_focusable(edit);
 
-	vbox = nullptr;
+	container = nullptr;
 	button_add_item = nullptr;
 	paginator = nullptr;
 	change_type = memnew(PopupMenu);
@@ -1250,11 +1258,11 @@ void EditorPropertyLocalizableString::update_property() {
 	if (updated_val.get_type() == Variant::NIL) {
 		edit->set_text(TTR("Localizable String (Nil)")); // This provides symmetry with the array property.
 		edit->set_pressed(false);
-		if (vbox) {
+		if (container) {
 			set_bottom_editor(nullptr);
-			memdelete(vbox);
+			memdelete(container);
 			button_add_item = nullptr;
-			vbox = nullptr;
+			container = nullptr;
 		}
 		return;
 	}
@@ -1271,10 +1279,14 @@ void EditorPropertyLocalizableString::update_property() {
 	if (unfolded) {
 		updating = true;
 
-		if (!vbox) {
-			vbox = memnew(VBoxContainer);
-			add_child(vbox);
-			set_bottom_editor(vbox);
+		if (!container) {
+			container = memnew(MarginContainer);
+			container->set_theme_type_variation("MarginContainer4px");
+			add_child(container);
+			set_bottom_editor(container);
+
+			VBoxContainer *vbox = memnew(VBoxContainer);
+			container->add_child(vbox);
 
 			property_vbox = memnew(VBoxContainer);
 			property_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
@@ -1351,11 +1363,11 @@ void EditorPropertyLocalizableString::update_property() {
 		updating = false;
 
 	} else {
-		if (vbox) {
+		if (container) {
 			set_bottom_editor(nullptr);
-			memdelete(vbox);
+			memdelete(container);
 			button_add_item = nullptr;
-			vbox = nullptr;
+			container = nullptr;
 		}
 	}
 }
@@ -1410,7 +1422,7 @@ EditorPropertyLocalizableString::EditorPropertyLocalizableString() {
 	add_child(edit);
 	add_focusable(edit);
 
-	vbox = nullptr;
+	container = nullptr;
 	button_add_item = nullptr;
 	paginator = nullptr;
 	updating = false;

--- a/editor/editor_properties_array_dict.h
+++ b/editor/editor_properties_array_dict.h
@@ -89,7 +89,7 @@ class EditorPropertyArray : public EditorProperty {
 	int page_index = 0;
 	int changing_type_index;
 	Button *edit = nullptr;
-	VBoxContainer *vbox = nullptr;
+	MarginContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
 	EditorSpinSlider *size_slider = nullptr;
 	Button *button_add_item = nullptr;
@@ -146,9 +146,9 @@ class EditorPropertyDictionary : public EditorProperty {
 	int page_index = 0;
 	int changing_type_index;
 	Button *edit = nullptr;
-	VBoxContainer *vbox = nullptr;
+	MarginContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
-	EditorSpinSlider *size_slider = nullptr;
+	EditorSpinSlider *size_sliderv;
 	Button *button_add_item = nullptr;
 	EditorPaginator *paginator = nullptr;
 
@@ -181,7 +181,7 @@ class EditorPropertyLocalizableString : public EditorProperty {
 	int page_length = 20;
 	int page_index = 0;
 	Button *edit = nullptr;
-	VBoxContainer *vbox = nullptr;
+	MarginContainer *container = nullptr;
 	VBoxContainer *property_vbox = nullptr;
 	EditorSpinSlider *size_slider = nullptr;
 	Button *button_add_item = nullptr;

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1283,6 +1283,13 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("h_separation", "VFlowContainer", default_margin_size * EDSCALE);
 	theme->set_constant("v_separation", "VFlowContainer", default_margin_size * EDSCALE);
 
+	// Custom theme type for MarginContainer with 4px margins.
+	theme->set_type_variation("MarginContainer4px", "MarginContainer");
+	theme->set_constant("margin_left", "MarginContainer4px", 4 * EDSCALE);
+	theme->set_constant("margin_top", "MarginContainer4px", 4 * EDSCALE);
+	theme->set_constant("margin_right", "MarginContainer4px", 4 * EDSCALE);
+	theme->set_constant("margin_bottom", "MarginContainer4px", 4 * EDSCALE);
+
 	// Window
 
 	// Prevent corner artifacts between window title and body.
@@ -1626,7 +1633,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("preview_picker_label", "ThemeEditor", theme_preview_picker_label_sb);
 
 	// Dictionary editor add item.
-	theme->set_stylebox("DictionaryAddItem", "EditorStyles", make_flat_stylebox(prop_subsection_color, 4, 4, 4, 4, corner_radius));
+	// Expand to the left and right by 4px to compensate for the dictionary editor margins.
+	Ref<StyleBoxFlat> style_dictionary_add_item = make_flat_stylebox(prop_subsection_color, 0, 4, 0, 4, corner_radius);
+	style_dictionary_add_item->set_expand_margin_size(SIDE_LEFT, 4 * EDSCALE);
+	style_dictionary_add_item->set_expand_margin_size(SIDE_RIGHT, 4 * EDSCALE);
+	theme->set_stylebox("DictionaryAddItem", "EditorStyles", style_dictionary_add_item);
 
 	// adaptive script theme constants
 	// for comments and elements with lower relevance


### PR DESCRIPTION
Adds margins to the Array, Dictionary, and Localized String property editors so that buttons aren't stuck to the edge. This also makes buttons in the Dictionary editor align horizontally.

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/161309224-ffae0562-9c83-4a27-976f-4259ccedfcfa.png) | ![image](https://user-images.githubusercontent.com/67974470/161308538-8ed2ed62-ecfc-43a0-8d76-4e03472cdf21.png) |