### PR TITLE
Distribute remaining pixel to expanding childs of GridContainer

### DIFF
--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -139,12 +139,46 @@ void GridContainer::_notification(int p_what) {
 			}
 
 			// Finally, fit the nodes.
-			int col_expand = col_expanded.size() > 0 ? remaining_space.width / col_expanded.size() : 0;
-			int row_expand = row_expanded.size() > 0 ? remaining_space.height / row_expanded.size() : 0;
+			int col_remaining_pixel = 0;
+			int col_expand = 0;
+			if (col_expanded.size() > 0) {
+				col_expand = remaining_space.width / col_expanded.size();
+				col_remaining_pixel = remaining_space.width - col_expanded.size() * col_expand;
+			}
+
+			int row_remaining_pixel = 0;
+			int row_expand = 0;
+			if (row_expanded.size() > 0) {
+				row_expand = remaining_space.height / row_expanded.size();
+				row_remaining_pixel = remaining_space.height - row_expanded.size() * row_expand;
+			}
+
 			bool rtl = is_layout_rtl();
 
 			int col_ofs = 0;
 			int row_ofs = 0;
+
+			// Calculate the index of rows and columns that receive the remaining pixel.
+			int col_remaining_pixel_index = 0;
+			for (int i = 0; i < max_col; i++) {
+				if (col_remaining_pixel == 0) {
+					break;
+				}
+				if (col_expanded.has(i)) {
+					col_remaining_pixel_index = i + 1;
+					col_remaining_pixel--;
+				}
+			}
+			int row_remaining_pixel_index = 0;
+			for (int i = 0; i < max_row; i++) {
+				if (row_remaining_pixel == 0) {
+					break;
+				}
+				if (row_expanded.has(i)) {
+					row_remaining_pixel_index = i + 1;
+					row_remaining_pixel--;
+				}
+			}
 
 			valid_controls_index = 0;
 			for (int i = 0; i < get_child_count(); i++) {
@@ -164,17 +198,30 @@ void GridContainer::_notification(int p_what) {
 					}
 					if (row > 0) {
 						row_ofs += (row_expanded.has(row - 1) ? row_expand : row_minh[row - 1]) + vsep;
+
+						if (row_expanded.has(row - 1) && row - 1 < row_remaining_pixel_index) {
+							// Apply the remaining pixel of the previous row.
+							row_ofs++;
+						}
 					}
 				}
 
+				Size2 s(col_expanded.has(col) ? col_expand : col_minw[col], row_expanded.has(row) ? row_expand : row_minh[row]);
+
+				// Add the remaining pixel to the expanding columns and rows, starting from left and top.
+				if (col_expanded.has(col) && col < col_remaining_pixel_index) {
+					s.x++;
+				}
+				if (row_expanded.has(row) && row < row_remaining_pixel_index) {
+					s.y++;
+				}
+
 				if (rtl) {
-					Size2 s(col_expanded.has(col) ? col_expand : col_minw[col], row_expanded.has(row) ? row_expand : row_minh[row]);
 					Point2 p(col_ofs - s.width, row_ofs);
 					fit_child_in_rect(c, Rect2(p, s));
 					col_ofs -= s.width + hsep;
 				} else {
 					Point2 p(col_ofs, row_ofs);
-					Size2 s(col_expanded.has(col) ? col_expand : col_minw[col], row_expanded.has(row) ? row_expand : row_minh[row]);
 					fit_child_in_rect(c, Rect2(p, s));
 					col_ofs += s.width + hsep;
 				}


### PR DESCRIPTION
fix #59780
Godot 4 MRP: [GridContainerBg.zip](https://github.com/godotengine/godot/files/8399599/GridContainerBg.zip)

This method consists of three steps:
1. Calculate the number of remaining pixel
2. Calculate the maximum column and row indices, that receive the remaining pixel
3. Add 1 pixel to each column and row until the respective maximum index