### PR TITLE
Fix Viewport root order after Node2D raise

### DIFF
--- a/scene/2d/node_2d.cpp
+++ b/scene/2d/node_2d.cpp
@@ -30,6 +30,8 @@
 
 #include "node_2d.h"
 
+#include "scene/main/viewport.h"
+
 #ifdef TOOLS_ENABLED
 Dictionary Node2D::_edit_get_state() const {
 	Dictionary state;
@@ -387,6 +389,16 @@ void Node2D::set_y_sort_enabled(bool p_enabled) {
 
 bool Node2D::is_y_sort_enabled() const {
 	return y_sort_enabled;
+}
+
+void Node2D::_notification(int p_notification) {
+	switch (p_notification) {
+		case NOTIFICATION_MOVED_IN_PARENT: {
+			if (get_viewport()) {
+				get_viewport()->gui_set_root_order_dirty();
+			}
+		} break;
+	}
 }
 
 void Node2D::_bind_methods() {

--- a/scene/2d/node_2d.h
+++ b/scene/2d/node_2d.h
@@ -53,6 +53,7 @@ class Node2D : public CanvasItem {
 	void _update_xform_values();
 
 protected:
+	void _notification(int p_notification);
 	static void _bind_methods();
 
 public:

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2921,7 +2921,7 @@ void Control::_notification(int p_notification) {
 			queue_redraw();
 
 			if (data.RI) {
-				get_viewport()->_gui_set_root_order_dirty();
+				get_viewport()->gui_set_root_order_dirty();
 			}
 		} break;
 

--- a/scene/main/canvas_layer.cpp
+++ b/scene/main/canvas_layer.cpp
@@ -38,7 +38,7 @@ void CanvasLayer::set_layer(int p_xform) {
 	layer = p_xform;
 	if (viewport.is_valid()) {
 		RenderingServer::get_singleton()->viewport_set_canvas_stacking(viewport, canvas, layer, get_index());
-		vp->_gui_set_root_order_dirty();
+		vp->gui_set_root_order_dirty();
 	}
 }
 

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2094,7 +2094,7 @@ List<Control *>::Element *Viewport::_gui_add_root_control(Control *p_control) {
 	return gui.roots.push_back(p_control);
 }
 
-void Viewport::_gui_set_root_order_dirty() {
+void Viewport::gui_set_root_order_dirty() {
 	gui.roots_order_dirty = true;
 }
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -455,8 +455,6 @@ private:
 
 	void _update_canvas_items(Node *p_node);
 
-	void _gui_set_root_order_dirty();
-
 	friend class Window;
 
 	void _sub_window_update_order();
@@ -512,6 +510,8 @@ public:
 	Transform2D get_global_canvas_transform() const;
 
 	Transform2D get_final_transform() const;
+
+	void gui_set_root_order_dirty();
 
 	void set_transparent_background(bool p_enable);
 	bool has_transparent_background() const;


### PR DESCRIPTION
fix #44138

After raising a `Node2D`, the Viewport root nodes need to be recalculated.

Updated 2022-10-22: remove need for friend class by making `gui_set_root_order_dirty` public; rebase to master.
Updated 2022-11-02: resolve merge conflict with #59479.