### PR TITLE
Cleanup metadata usage

### DIFF
--- a/core/core_string_names.cpp
+++ b/core/core_string_names.cpp
@@ -35,7 +35,6 @@ CoreStringNames *CoreStringNames::singleton = nullptr;
 CoreStringNames::CoreStringNames() :
 		_free(StaticCString::create("free")),
 		changed(StaticCString::create("changed")),
-		_meta(StaticCString::create("__meta__")),
 		_script(StaticCString::create("script")),
 		script_changed(StaticCString::create("script_changed")),
 		___pdcdata(StaticCString::create("___pdcdata")),

--- a/core/core_string_names.h
+++ b/core/core_string_names.h
@@ -52,7 +52,6 @@ public:
 
 	StringName _free;
 	StringName changed;
-	StringName _meta;
 	StringName _script;
 	StringName script_changed;
 	StringName ___pdcdata;

--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -136,10 +136,9 @@ void InputEventConfigurationDialog::_set_event(const Ref<InputEvent> &p_event, b
 				TreeItem *input_item = category->get_first_child();
 
 				if (input_item != nullptr) {
-					// has_type this should be always true, unless the tree structure has been misconfigured.
-					bool has_type = input_item->get_parent()->has_meta("__type");
-					int input_type = input_item->get_parent()->get_meta("__type");
-					if (!has_type) {
+					// input_type should always be > 0, unless the tree structure has been misconfigured.
+					int input_type = input_item->get_parent()->get_meta("__type", 0);
+					if (input_type == 0) {
 						return;
 					}
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1882,7 +1882,7 @@ void EditorNode::_dialog_action(String p_file) {
 			ProjectSettings::get_singleton()->save();
 			// TODO: Would be nice to show the project manager opened with the highlighted field.
 
-			if (pick_main_scene->has_meta("from_native") && (bool)pick_main_scene->get_meta("from_native")) {
+			if ((bool)pick_main_scene->get_meta("from_native", false)) {
 				run_native->resume_run_native();
 			} else {
 				_run(false, ""); // Automatically run the project.

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -576,7 +576,7 @@ Variant EditorSettingsDialog::get_drag_data_fw(const Point2 &p_point, Control *p
 	TreeItem *selected = shortcuts->get_selected();
 
 	// Only allow drag for events
-	if (!selected || !selected->has_meta("type") || selected->get_meta("type") != "event") {
+	if (!selected || (String)selected->get_meta("type", "") != "event") {
 		return Variant();
 	}
 
@@ -593,7 +593,7 @@ Variant EditorSettingsDialog::get_drag_data_fw(const Point2 &p_point, Control *p
 bool EditorSettingsDialog::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
 	TreeItem *selected = shortcuts->get_selected();
 	TreeItem *item = shortcuts->get_item_at_position(p_point);
-	if (!selected || !item || item == selected || !item->has_meta("type") || item->get_meta("type") != "event") {
+	if (!selected || !item || item == selected || (String)item->get_meta("type", "") != "event") {
 		return false;
 	}
 

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -715,13 +715,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 
 	bool isroot = p_node == p_root;
 
-	String import_id;
-
-	if (p_node->has_meta("import_id")) {
-		import_id = p_node->get_meta("import_id");
-	} else {
-		import_id = "PATH:" + p_root->get_path_to(p_node);
-	}
+	String import_id = p_node->get_meta("import_id", "PATH:" + p_root->get_path_to(p_node));
 
 	Dictionary node_settings;
 	if (p_node_data.has(import_id)) {
@@ -763,12 +757,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 				for (int i = 0; i < m->get_surface_count(); i++) {
 					Ref<Material> mat = m->get_surface_material(i);
 					if (mat.is_valid()) {
-						String mat_id;
-						if (mat->has_meta("import_id")) {
-							mat_id = mat->get_meta("import_id");
-						} else {
-							mat_id = mat->get_name();
-						}
+						String mat_id = mat->get_meta("import_id", mat->get_name());
 
 						if (!mat_id.is_empty() && p_material_data.has(mat_id)) {
 							Dictionary matdata = p_material_data[mat_id];
@@ -1591,13 +1580,7 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 				bool bake_lightmaps = p_light_bake_mode == LIGHT_BAKE_STATIC_LIGHTMAPS;
 				String save_to_file;
 
-				String mesh_id;
-
-				if (src_mesh_node->get_mesh()->has_meta("import_id")) {
-					mesh_id = src_mesh_node->get_mesh()->get_meta("import_id");
-				} else {
-					mesh_id = src_mesh_node->get_mesh()->get_name();
-				}
+				String mesh_id = src_mesh_node->get_mesh()->get_meta("import_id", src_mesh_node->get_mesh()->get_name());
 
 				if (!mesh_id.is_empty() && p_mesh_data.has(mesh_id)) {
 					Dictionary mesh_settings = p_mesh_data[mesh_id];

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -236,7 +236,7 @@ public:
 };
 
 bool CanvasItemEditor::_is_node_locked(const Node *p_node) {
-	return p_node->has_meta("_edit_lock_") && p_node->get_meta("_edit_lock_");
+	return p_node->get_meta("_edit_lock_", false);
 }
 
 bool CanvasItemEditor::_is_node_movable(const Node *p_node, bool p_popup_warning) {
@@ -420,16 +420,14 @@ Point2 CanvasItemEditor::snap_point(Point2 p_target, unsigned int p_modes, unsig
 	}
 
 	if (((is_snap_active && snap_guides && (p_modes & SNAP_GUIDES)) || (p_forced_modes & SNAP_GUIDES)) && fmod(rotation, (real_t)360.0) == 0.0) {
-		// Guides
-		if (EditorNode::get_singleton()->get_edited_scene() && EditorNode::get_singleton()->get_edited_scene()->has_meta("_edit_vertical_guides_")) {
-			Array vguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_vertical_guides_");
+		// Guides.
+		if (Node *scene = EditorNode::get_singleton()->get_edited_scene()) {
+			Array vguides = scene->get_meta("_edit_vertical_guides_", Array());
 			for (int i = 0; i < vguides.size(); i++) {
 				_snap_if_closer_float(p_target.x, output.x, snap_target[0], vguides[i], SNAP_TARGET_GUIDE);
 			}
-		}
 
-		if (EditorNode::get_singleton()->get_edited_scene() && EditorNode::get_singleton()->get_edited_scene()->has_meta("_edit_horizontal_guides_")) {
-			Array hguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_horizontal_guides_");
+			Array hguides = scene->get_meta("_edit_horizontal_guides_", Array());
 			for (int i = 0; i < hguides.size(); i++) {
 				_snap_if_closer_float(p_target.y, output.y, snap_target[1], hguides[i], SNAP_TARGET_GUIDE);
 			}
@@ -681,7 +679,7 @@ void CanvasItemEditor::_find_canvas_items_in_rect(const Rect2 &p_rect, Node *p_n
 	Node *scene = EditorNode::get_singleton()->get_edited_scene();
 
 	bool editable = p_node == scene || p_node->get_owner() == scene || p_node == scene->get_deepest_editable_node(p_node);
-	bool lock_children = p_node->has_meta("_edit_group_") && p_node->get_meta("_edit_group_");
+	bool lock_children = p_node->get_meta("_edit_group_", false);
 	bool locked = _is_node_locked(p_node);
 
 	if (!lock_children || !editable) {
@@ -1000,14 +998,8 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 		if (show_guides && show_rulers && EditorNode::get_singleton()->get_edited_scene()) {
 			Transform2D xform = viewport_scrollable->get_transform() * transform;
 			// Retrieve the guide lists
-			Array vguides;
-			if (EditorNode::get_singleton()->get_edited_scene()->has_meta("_edit_vertical_guides_")) {
-				vguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_vertical_guides_");
-			}
-			Array hguides;
-			if (EditorNode::get_singleton()->get_edited_scene()->has_meta("_edit_horizontal_guides_")) {
-				hguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_horizontal_guides_");
-			}
+			Array vguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_vertical_guides_", Array());
+			Array hguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_horizontal_guides_", Array());
 
 			// Hover over guides
 			real_t minimum = 1e20;
@@ -1100,14 +1092,8 @@ bool CanvasItemEditor::_gui_input_rulers_and_guides(const Ref<InputEvent> &p_eve
 				Transform2D xform = viewport_scrollable->get_transform() * transform;
 
 				// Retrieve the guide lists
-				Array vguides;
-				if (EditorNode::get_singleton()->get_edited_scene()->has_meta("_edit_vertical_guides_")) {
-					vguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_vertical_guides_");
-				}
-				Array hguides;
-				if (EditorNode::get_singleton()->get_edited_scene()->has_meta("_edit_horizontal_guides_")) {
-					hguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_horizontal_guides_");
-				}
+				Array vguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_vertical_guides_", Array());
+				Array hguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_horizontal_guides_", Array());
 
 				Point2 edited = snap_point(xform.affine_inverse().xform(b->get_position()), SNAP_GRID | SNAP_PIXEL | SNAP_OTHER_NODES);
 				if (drag_type == DRAG_V_GUIDE) {
@@ -2712,9 +2698,9 @@ void CanvasItemEditor::_draw_guides() {
 	Color guide_color = EditorSettings::get_singleton()->get("editors/2d/guides_color");
 	Transform2D xform = viewport_scrollable->get_transform() * transform;
 
-	// Guides already there
-	if (EditorNode::get_singleton()->get_edited_scene() && EditorNode::get_singleton()->get_edited_scene()->has_meta("_edit_vertical_guides_")) {
-		Array vguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_vertical_guides_");
+	// Guides already there.
+	if (Node *scene = EditorNode::get_singleton()->get_edited_scene()) {
+		Array vguides = scene->get_meta("_edit_vertical_guides_", Array());
 		for (int i = 0; i < vguides.size(); i++) {
 			if (drag_type == DRAG_V_GUIDE && i == dragged_guide_index) {
 				continue;
@@ -2722,10 +2708,8 @@ void CanvasItemEditor::_draw_guides() {
 			real_t x = xform.xform(Point2(vguides[i], 0)).x;
 			viewport->draw_line(Point2(x, 0), Point2(x, viewport->get_size().y), guide_color, Math::round(EDSCALE));
 		}
-	}
 
-	if (EditorNode::get_singleton()->get_edited_scene() && EditorNode::get_singleton()->get_edited_scene()->has_meta("_edit_horizontal_guides_")) {
-		Array hguides = EditorNode::get_singleton()->get_edited_scene()->get_meta("_edit_horizontal_guides_");
+		Array hguides = scene->get_meta("_edit_horizontal_guides_", Array());
 		for (int i = 0; i < hguides.size(); i++) {
 			if (drag_type == DRAG_H_GUIDE && i == dragged_guide_index) {
 				continue;
@@ -2735,7 +2719,7 @@ void CanvasItemEditor::_draw_guides() {
 		}
 	}
 
-	// Dragged guide
+	// Dragged guide.
 	Color text_color = get_theme_color(SNAME("font_color"), SNAME("Editor"));
 	Color outline_color = text_color.inverted();
 	const float outline_size = 2;

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -509,7 +509,7 @@ void ControlEditorToolbar::_set_anchors_and_offsets_to_keep_ratio() {
 			undo_redo->add_do_method(control, "set_anchor", SIDE_BOTTOM, bottom_right_anchor.y, false, true);
 			undo_redo->add_do_method(control, "set_meta", "_edit_use_anchors_", true);
 
-			const bool use_anchors = control->has_meta("_edit_use_anchors_") && control->get_meta("_edit_use_anchors_");
+			const bool use_anchors = control->get_meta("_edit_use_anchors_", false);
 			undo_redo->add_undo_method(control, "_edit_set_state", control->_edit_get_state());
 			if (use_anchors) {
 				undo_redo->add_undo_method(control, "set_meta", "_edit_use_anchors_", true);
@@ -617,7 +617,7 @@ void ControlEditorToolbar::_button_toggle_anchor_mode(bool p_status) {
 }
 
 bool ControlEditorToolbar::_is_node_locked(const Node *p_node) {
-	return p_node->has_meta("_edit_lock_") && p_node->get_meta("_edit_lock_");
+	return p_node->get_meta("_edit_lock_", false);
 }
 
 List<Control *> ControlEditorToolbar::_get_edited_controls(bool retrieve_locked, bool remove_controls_if_parent_in_selection) {
@@ -798,7 +798,7 @@ void ControlEditorToolbar::_selection_changed() {
 		}
 
 		nb_valid_controls++;
-		if (control->has_meta("_edit_use_anchors_") && control->get_meta("_edit_use_anchors_")) {
+		if (control->get_meta("_edit_use_anchors_", false)) {
 			nb_anchors_mode++;
 		}
 	}

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -1265,7 +1265,7 @@ void Node3DEditorViewport::_surface_focus_exit() {
 }
 
 bool Node3DEditorViewport ::_is_node_locked(const Node *p_node) {
-	return p_node->has_meta("_edit_lock_") && p_node->get_meta("_edit_lock_");
+	return p_node->get_meta("_edit_lock_", false);
 }
 
 void Node3DEditorViewport::_list_select(Ref<InputEventMouseButton> b) {

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1950,11 +1950,11 @@ void ScriptEditor::_update_script_colors() {
 		script_list->set_item_custom_bg_color(i, Color(0, 0, 0, 0));
 
 		if (script_temperature_enabled) {
-			if (!n->has_meta("__editor_pass")) {
+			int pass = n->get_meta("__editor_pass", -1);
+			if (pass < 0) {
 				continue;
 			}
 
-			int pass = n->get_meta("__editor_pass");
 			int h = edit_pass - pass;
 			if (h > hist_size) {
 				continue;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2318,24 +2318,6 @@ void SceneTreeDock::replace_node(Node *p_node, Node *p_by_node, bool p_keep_prop
 				continue;
 			}
 
-			if (E.name == "__meta__") {
-				Dictionary metadata = n->get(E.name);
-				if (metadata.has("_editor_description_")) {
-					newnode->set_meta("_editor_description_", metadata["_editor_description_"]);
-				}
-
-				if (Object::cast_to<CanvasItem>(newnode) || Object::cast_to<Node3D>(newnode)) {
-					if (metadata.has("_edit_group_") && metadata["_edit_group_"]) {
-						newnode->set_meta("_edit_group_", true);
-					}
-					if (metadata.has("_edit_lock_") && metadata["_edit_lock_"]) {
-						newnode->set_meta("_edit_lock_", true);
-					}
-				}
-
-				continue;
-			}
-
 			if (default_oldnode->get(E.name) != n->get(E.name)) {
 				newnode->set(E.name, n->get(E.name));
 			}

--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -355,13 +355,11 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		}
 
 		if (p_node->is_class("CanvasItem")) {
-			bool is_locked = p_node->has_meta("_edit_lock_"); //_edit_group_
-			if (is_locked) {
+			if (p_node->has_meta("_edit_lock_")) {
 				item->add_button(0, get_theme_icon(SNAME("Lock"), SNAME("EditorIcons")), BUTTON_LOCK, false, TTR("Node is locked.\nClick to unlock it."));
 			}
 
-			bool is_grouped = p_node->has_meta("_edit_group_");
-			if (is_grouped) {
+			if (p_node->has_meta("_edit_group_")) {
 				item->add_button(0, get_theme_icon(SNAME("Group"), SNAME("EditorIcons")), BUTTON_GROUP, false, TTR("Children are not selectable.\nClick to make selectable."));
 			}
 
@@ -389,13 +387,11 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 				p_node->connect("visibility_changed", callable_mp(this, &SceneTreeEditor::_node_visibility_changed), varray(p_node));
 			}
 		} else if (p_node->is_class("Node3D")) {
-			bool is_locked = p_node->has_meta("_edit_lock_");
-			if (is_locked) {
+			if (p_node->has_meta("_edit_lock_")) {
 				item->add_button(0, get_theme_icon(SNAME("Lock"), SNAME("EditorIcons")), BUTTON_LOCK, false, TTR("Node is locked.\nClick to unlock it."));
 			}
 
-			bool is_grouped = p_node->has_meta("_edit_group_");
-			if (is_grouped) {
+			if (p_node->has_meta("_edit_group_")) {
 				item->add_button(0, get_theme_icon(SNAME("Group"), SNAME("EditorIcons")), BUTTON_GROUP, false, TTR("Children are not selectable.\nClick to make selectable."));
 			}
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.cpp
+++ b/modules/gridmap/editor/grid_map_editor_plugin.cpp
@@ -957,7 +957,7 @@ void GridMapEditor::update_grid() {
 }
 
 void GridMapEditor::_draw_grids(const Vector3 &cell_size) {
-	Vector3 edited_floor = node->has_meta("_editor_floor_") ? node->get_meta("_editor_floor_") : Variant();
+	Vector3 edited_floor = node->get_meta("_editor_floor_", Vector3());
 
 	for (int i = 0; i < 3; i++) {
 		RS::get_singleton()->mesh_clear(grid[i]);

--- a/modules/visual_script/editor/visual_script_property_selector.cpp
+++ b/modules/visual_script/editor/visual_script_property_selector.cpp
@@ -109,11 +109,7 @@ void VisualScriptPropertySelector::_confirmed() {
 }
 
 void VisualScriptPropertySelector::_item_selected() {
-	if (results_tree->get_selected()->has_meta("description")) {
-		help_bit->set_text(results_tree->get_selected()->get_meta("description"));
-	} else {
-		help_bit->set_text("No description available");
-	}
+	help_bit->set_text(results_tree->get_selected()->get_meta("description", "No description available"));
 }
 
 void VisualScriptPropertySelector::_hide_requested() {

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1501,7 +1501,7 @@ void Control::_set_layout_mode(LayoutMode p_mode) {
 	bool list_changed = false;
 
 	if (p_mode == LayoutMode::LAYOUT_MODE_POSITION || p_mode == LayoutMode::LAYOUT_MODE_ANCHORS) {
-		if (has_meta("_edit_layout_mode") && (int)get_meta("_edit_layout_mode") != (int)p_mode) {
+		if ((int)get_meta("_edit_layout_mode", p_mode) != (int)p_mode) {
 			list_changed = true;
 		}
 
@@ -1646,7 +1646,7 @@ void Control::_set_anchors_layout_preset(int p_preset) {
 
 int Control::_get_anchors_layout_preset() const {
 	// If the custom preset was selected by user, use it.
-	if (has_meta("_edit_use_custom_anchors") && (bool)get_meta("_edit_use_custom_anchors")) {
+	if ((bool)get_meta("_edit_use_custom_anchors", false)) {
 		return -1;
 	}
 

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -523,7 +523,7 @@ void TabContainer::move_child_notify(Node *p_child) {
 	Control *c = Object::cast_to<Control>(p_child);
 	if (c && !c->is_set_as_top_level()) {
 		int old_idx = -1;
-		String tab_name = c->has_meta("_tab_name") ? String(c->get_meta("_tab_name")) : String(c->get_name());
+		String tab_name = String(c->get_meta("_tab_name", c->get_name()));
 
 		// Find the previous tab index of the control.
 		for (int i = 0; i < get_tab_count(); i++) {
@@ -556,9 +556,7 @@ void TabContainer::remove_child_notify(Node *p_child) {
 		update();
 	}
 
-	if (p_child->has_meta("_tab_name")) {
-		p_child->remove_meta("_tab_name");
-	}
+	p_child->remove_meta("_tab_name");
 	p_child->disconnect("renamed", callable_mp(this, &TabContainer::_refresh_tab_names));
 
 	// TabBar won't emit the "tab_changed" signal when not inside the tree.
@@ -679,9 +677,7 @@ void TabContainer::set_tab_title(int p_tab, const String &p_title) {
 	tab_bar->set_tab_title(p_tab, p_title);
 
 	if (p_title == child->get_name()) {
-		if (child->has_meta("_tab_name")) {
-			child->remove_meta("_tab_name");
-		}
+		child->remove_meta("_tab_name");
 	} else {
 		child->set_meta("_tab_name", p_title);
 	}

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2012,35 +2012,28 @@ Node *Node::get_deepest_editable_node(Node *p_start_node) const {
 #ifdef TOOLS_ENABLED
 void Node::set_property_pinned(const String &p_property, bool p_pinned) {
 	bool current_pinned = false;
-	bool has_pinned = has_meta("_edit_pinned_properties_");
-	Array pinned;
-	String psa = get_property_store_alias(p_property);
-	if (has_pinned) {
-		pinned = get_meta("_edit_pinned_properties_");
-		current_pinned = pinned.has(psa);
-	}
+	Array pinned = get_meta("_edit_pinned_properties_", Array());
+	StringName psa = get_property_store_alias(p_property);
+	current_pinned = pinned.has(psa);
 
 	if (current_pinned != p_pinned) {
 		if (p_pinned) {
 			pinned.append(psa);
-			if (!has_pinned) {
-				set_meta("_edit_pinned_properties_", pinned);
-			}
 		} else {
 			pinned.erase(psa);
-			if (pinned.is_empty()) {
-				remove_meta("_edit_pinned_properties_");
-			}
 		}
+	}
+
+	if (pinned.is_empty()) {
+		remove_meta("_edit_pinned_properties_");
+	} else {
+		set_meta("_edit_pinned_properties_", pinned);
 	}
 }
 
 bool Node::is_property_pinned(const StringName &p_property) const {
-	if (!has_meta("_edit_pinned_properties_")) {
-		return false;
-	}
-	Array pinned = get_meta("_edit_pinned_properties_");
-	String psa = get_property_store_alias(p_property);
+	Array pinned = get_meta("_edit_pinned_properties_", Array());
+	StringName psa = get_property_store_alias(p_property);
 	return pinned.has(psa);
 }
 


### PR DESCRIPTION
Follow-up to #58608 and #59452

This PR simplifies some code that uses meta, by removing `has_meta()` where possible without changing behavior. Also removes some dead code still referring to `__meta__`.

This also fixes property pinning that was broken after #59452