### PR TITLE
Add missing newlines to the generated `default_env.tres` in new projects

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -482,7 +482,9 @@ private:
 							set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
 						} else {
 							f->store_line("[gd_resource type=\"Environment\" load_steps=2 format=2]");
+							f->store_line("");
 							f->store_line("[sub_resource type=\"ProceduralSky\" id=1]");
+							f->store_line("");
 							f->store_line("[resource]");
 							f->store_line("background_mode = 2");
 							f->store_line("background_sky = SubResource( 1 )");


### PR DESCRIPTION
This prevents unnecessary whitespace changes in VCS diffs when saving a scene for the first time in a new project.

This closes https://github.com/godotengine/godot/issues/59809.

**Note:** `master` doesn't have `default_env.tres` anymore, so this PR targets `3.x`.