### PR TITLE
Fix argument type generation with typed method binds

### DIFF
--- a/core/make_binders.py
+++ b/core/make_binders.py
@@ -70,7 +70,7 @@ public:
 #ifdef DEBUG_METHODS_ENABLED
 		_set_const($ifconst true$$ifnoconst false$);
 #endif
-		set_argument_count($argc$);
+		_generate_argument_types($argc$);
 
 		$ifret _set_returns(true); $
 	};


### PR DESCRIPTION
Fix a mistake in #59793 which causes the crash mentioned in https://github.com/godotengine/godot/pull/59793#issuecomment-1086620159