### PR TITLE
Fix creation and reopening of built-in scripts

### DIFF
--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -1232,9 +1232,6 @@ void ScriptEditor::_menu_option(int p_option) {
 					if (ResourceLoader::get_resource_type(res_path) == "PackedScene") {
 						if (!EditorNode::get_singleton()->is_scene_open(res_path)) {
 							EditorNode::get_singleton()->load_scene(res_path);
-							script_editor->call_deferred(SNAME("_menu_option"), p_option);
-							previous_scripts.push_back(path); //repeat the operation
-							return;
 						}
 					} else {
 						EditorNode::get_singleton()->load_resource(res_path);
@@ -1250,7 +1247,6 @@ void ScriptEditor::_menu_option(int p_option) {
 
 				edit(scr);
 				file_dialog_option = -1;
-				return;
 			} else {
 				Error error;
 				Ref<TextFile> text_file = _load_text_file(path, &error);
@@ -1261,7 +1257,6 @@ void ScriptEditor::_menu_option(int p_option) {
 				if (text_file.is_valid()) {
 					edit(text_file);
 					file_dialog_option = -1;
-					return;
 				}
 			}
 		} break;
@@ -3960,7 +3955,7 @@ void ScriptEditorPlugin::edit(Object *p_object) {
 		Script *p_script = Object::cast_to<Script>(p_object);
 		String res_path = p_script->get_path().get_slice("::", 0);
 
-		if (p_script->is_built_in()) {
+		if (p_script->is_built_in() && !res_path.is_empty()) {
 			if (ResourceLoader::get_resource_type(res_path) == "PackedScene") {
 				if (!EditorNode::get_singleton()->is_scene_open(res_path)) {
 					EditorNode::get_singleton()->load_scene(res_path);


### PR DESCRIPTION
- Fixed error when creating a built-in script.
- Fixed built-in scripts not reopening together with the closed scenes when clicking "Reopen Closed Script".