### PR TITLE
Fix incorrect parsing array's `length()` at return statement in shader

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -5144,7 +5144,6 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						if (!call_expression) {
 							return nullptr;
 						}
-						data_type = call_expression->get_datatype();
 					} else if (tk.type == TK_BRACKET_OPEN) { // indexing
 						index_expression = _parse_and_reduce_expression(p_block, p_function_info);
 						if (!index_expression) {
@@ -5598,15 +5597,13 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 						if (p_block != nullptr) {
 							p_block->block_tag = SubClassTag::TAG_ARRAY;
 						}
-						Node *call_expression = _parse_and_reduce_expression(p_block, p_function_info);
+						mn->call_expression = _parse_and_reduce_expression(p_block, p_function_info);
 						if (p_block != nullptr) {
 							p_block->block_tag = SubClassTag::TAG_GLOBAL;
 						}
-						if (!call_expression) {
+						if (!mn->call_expression) {
 							return nullptr;
 						}
-						mn->datatype = call_expression->get_datatype();
-						mn->call_expression = call_expression;
 					} else if (tk.type == TK_BRACKET_OPEN) {
 						Node *index_expression = _parse_and_reduce_expression(p_block, p_function_info);
 						if (!index_expression) {

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -451,8 +451,8 @@ public:
 		int array_size = 0;
 		bool is_local = false;
 
-		virtual DataType get_datatype() const override { return datatype_cache; }
-		virtual String get_datatype_name() const override { return String(struct_name); }
+		virtual DataType get_datatype() const override { return call_expression ? call_expression->get_datatype() : datatype_cache; }
+		virtual String get_datatype_name() const override { return call_expression ? call_expression->get_datatype_name() : String(struct_name); }
 		virtual int get_array_size() const override { return (index_expression || call_expression) ? 0 : array_size; }
 		virtual bool is_indexed() const override { return index_expression != nullptr; }
 
@@ -558,8 +558,8 @@ public:
 		Node *call_expression = nullptr;
 		bool has_swizzling_duplicates = false;
 
-		virtual DataType get_datatype() const override { return datatype; }
-		virtual String get_datatype_name() const override { return String(struct_name); }
+		virtual DataType get_datatype() const override { return call_expression ? call_expression->get_datatype() : datatype; }
+		virtual String get_datatype_name() const override { return call_expression ? call_expression->get_datatype_name() : String(struct_name); }
 		virtual int get_array_size() const override { return (index_expression || call_expression) ? 0 : array_size; }
 		virtual bool is_indexed() const override { return index_expression != nullptr || call_expression != nullptr; }
 


### PR DESCRIPTION
Fix the errors in the following shader:

```
shader_type spatial;

struct A {
	vec3 colors[2];
};

struct B {
	A colors[2];
};

const B test = B(
	{
		A({vec3(1, 1, 1), vec3(1, 1, 1)}),
		A({vec3(1, 1, 1), vec3(1, 1, 1)})
	}
);

const B test2[1] = {
	B({A({vec3(1, 1, 1), vec3(1, 1, 1)}),
		A({vec3(1, 1, 1), vec3(1, 1, 1)})})
};

int foo(){
	// ERROR CODE PLACED BELOW

	return test2[0].colors.length();
	return test2.length();
}

void fragment() {
	ALBEDO = vec3(1,  0, 0);
}
```