### PR TITLE
[3.x] Fix crash when passing null to AudioStreamPlayer::set_stream()

### DIFF
--- a/scene/2d/audio_stream_player_2d.cpp
+++ b/scene/2d/audio_stream_player_2d.cpp
@@ -272,7 +272,10 @@ void AudioStreamPlayer2D::_notification(int p_what) {
 
 void AudioStreamPlayer2D::set_stream(Ref<AudioStream> p_stream) {
 	// Instancing audio streams can cause large memory allocations, do it prior to AudioServer::lock.
-	Ref<AudioStreamPlayback> pre_instanced_playback = p_stream->instance_playback();
+	Ref<AudioStreamPlayback> pre_instanced_playback;
+	if (p_stream.is_valid()) {
+		pre_instanced_playback = p_stream->instance_playback();
+	}
 
 	AudioServer::get_singleton()->lock();
 

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -623,7 +623,10 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 
 void AudioStreamPlayer3D::set_stream(Ref<AudioStream> p_stream) {
 	// Instancing audio streams can cause large memory allocations, do it prior to AudioServer::lock.
-	Ref<AudioStreamPlayback> pre_instanced_playback = p_stream->instance_playback();
+	Ref<AudioStreamPlayback> pre_instanced_playback;
+	if (p_stream.is_valid()) {
+		pre_instanced_playback = p_stream->instance_playback();
+	}
 
 	AudioServer::get_singleton()->lock();
 

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -168,7 +168,10 @@ void AudioStreamPlayer::_notification(int p_what) {
 
 void AudioStreamPlayer::set_stream(Ref<AudioStream> p_stream) {
 	// Instancing audio streams can cause large memory allocations, do it prior to AudioServer::lock.
-	Ref<AudioStreamPlayback> pre_instanced_playback = p_stream->instance_playback();
+	Ref<AudioStreamPlayback> pre_instanced_playback;
+	if (p_stream.is_valid()) {
+		pre_instanced_playback = p_stream->instance_playback();
+	}
 
 	AudioServer::get_singleton()->lock();
 


### PR DESCRIPTION
Passing a null stream is valid, the meaning being to clear the current one without setting a new one.

I think this was just an overlook in recent changes.