### PR TITLE
[3.x] Fix Copy Selection on editor_log

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -176,6 +176,7 @@ EditorLog::EditorLog() {
 	log->set_custom_minimum_size(Size2(0, 180) * EDSCALE);
 	log->set_v_size_flags(SIZE_EXPAND_FILL);
 	log->set_h_size_flags(SIZE_EXPAND_FILL);
+	log->set_deselect_on_focus_loss_enabled(false);
 	vb->add_child(log);
 	add_message(VERSION_FULL_NAME " (c) 2007-2022 Juan Linietsky, Ariel Manzur & Godot Contributors.");
 


### PR DESCRIPTION
After the addition of `deselect_on_focus_loss_enabled` to `RichTextLabel` the 'Copy Selection' button on editor log no longer works because clicking on the button will cause a focus loss and the text is deselected.

Setting `deselect_on_focus_loss_enabled` to `false` restore the correct button behavior.

Even if master if not affected from this problem, we can do the same change also in master branch, sometimes it might be useful to keep the text selected on output log panel even the focus is lost.
