### PR TITLE
Rename RenderingServer global shader uniform methods to be more explicit

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1293,45 +1293,45 @@
 				If [code]half_resolution[/code] is [code]true[/code], renders [VoxelGI] and SDFGI ([member Environment.sdfgi_enabled]) buffers at halved resolution (e.g. 960×540 when the viewport size is 1920×1080). This improves performance significantly when VoxelGI or SDFGI is enabled, at the cost of artifacts that may be visible on polygon edges. The loss in quality becomes less noticeable as the viewport resolution increases. [LightmapGI] rendering is not affected by this setting. See also [member ProjectSettings.rendering/global_illumination/gi/use_half_resolution].
 			</description>
 		</method>
-		<method name="global_variable_add">
+		<method name="global_shader_uniform_add">
 			<return type="void" />
 			<argument index="0" name="name" type="StringName" />
-			<argument index="1" name="type" type="int" enum="RenderingServer.GlobalVariableType" />
+			<argument index="1" name="type" type="int" enum="RenderingServer.GlobalShaderUniformType" />
 			<argument index="2" name="default_value" type="Variant" />
 			<description>
 			</description>
 		</method>
-		<method name="global_variable_get" qualifiers="const">
+		<method name="global_shader_uniform_get" qualifiers="const">
 			<return type="Variant" />
 			<argument index="0" name="name" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="global_variable_get_list" qualifiers="const">
+		<method name="global_shader_uniform_get_list" qualifiers="const">
 			<return type="PackedStringArray" />
 			<description>
 			</description>
 		</method>
-		<method name="global_variable_get_type" qualifiers="const">
-			<return type="int" enum="RenderingServer.GlobalVariableType" />
+		<method name="global_shader_uniform_get_type" qualifiers="const">
+			<return type="int" enum="RenderingServer.GlobalShaderUniformType" />
 			<argument index="0" name="name" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="global_variable_remove">
+		<method name="global_shader_uniform_remove">
 			<return type="void" />
 			<argument index="0" name="name" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="global_variable_set">
+		<method name="global_shader_uniform_set">
 			<return type="void" />
 			<argument index="0" name="name" type="StringName" />
 			<argument index="1" name="value" type="Variant" />
 			<description>
 			</description>
 		</method>
-		<method name="global_variable_set_override">
+		<method name="global_shader_uniform_set_override">
 			<return type="void" />
 			<argument index="0" name="name" type="StringName" />
 			<argument index="1" name="value" type="Variant" />
@@ -4536,63 +4536,63 @@
 		<constant name="CANVAS_OCCLUDER_POLYGON_CULL_COUNTER_CLOCKWISE" value="2" enum="CanvasOccluderPolygonCullMode">
 			Culling of the canvas occluder is counterclockwise.
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_BOOL" value="0" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_BOOL" value="0" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_BVEC2" value="1" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_BVEC2" value="1" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_BVEC3" value="2" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_BVEC3" value="2" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_BVEC4" value="3" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_BVEC4" value="3" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_INT" value="4" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_INT" value="4" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_IVEC2" value="5" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_IVEC2" value="5" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_IVEC3" value="6" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_IVEC3" value="6" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_IVEC4" value="7" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_IVEC4" value="7" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_RECT2I" value="8" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_RECT2I" value="8" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_UINT" value="9" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_UINT" value="9" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_UVEC2" value="10" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_UVEC2" value="10" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_UVEC3" value="11" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_UVEC3" value="11" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_UVEC4" value="12" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_UVEC4" value="12" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_FLOAT" value="13" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_FLOAT" value="13" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_VEC2" value="14" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_VEC2" value="14" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_VEC3" value="15" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_VEC3" value="15" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_VEC4" value="16" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_VEC4" value="16" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_COLOR" value="17" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_COLOR" value="17" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_RECT2" value="18" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_RECT2" value="18" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_MAT2" value="19" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_MAT2" value="19" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_MAT3" value="20" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_MAT3" value="20" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_MAT4" value="21" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_MAT4" value="21" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_TRANSFORM_2D" value="22" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_TRANSFORM_2D" value="22" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_TRANSFORM" value="23" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_TRANSFORM" value="23" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_SAMPLER2D" value="24" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_SAMPLER2D" value="24" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_SAMPLER2DARRAY" value="25" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_SAMPLER2DARRAY" value="25" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_SAMPLER3D" value="26" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_SAMPLER3D" value="26" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_SAMPLERCUBE" value="27" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_SAMPLERCUBE" value="27" enum="GlobalShaderUniformType">
 		</constant>
-		<constant name="GLOBAL_VAR_TYPE_MAX" value="28" enum="GlobalVariableType">
+		<constant name="GLOBAL_VAR_TYPE_MAX" value="28" enum="GlobalShaderUniformType">
 		</constant>
 		<constant name="RENDERING_INFO_TOTAL_OBJECTS_IN_FRAME" value="0" enum="RenderingInfo">
 		</constant>

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -183,7 +183,7 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 		glBindBufferBase(GL_UNIFORM_BUFFER, BASE_UNIFORM_LOCATION, state.canvas_state_buffer);
 		glBufferData(GL_UNIFORM_BUFFER, sizeof(StateBuffer), &state_buffer, GL_STREAM_DRAW);
 
-		GLuint global_buffer = material_storage->global_variables_get_uniform_buffer();
+		GLuint global_buffer = material_storage->global_shader_uniforms_get_uniform_buffer();
 
 		glBindBufferBase(GL_UNIFORM_BUFFER, GLOBAL_UNIFORM_LOCATION, global_buffer);
 		glBindBuffer(GL_UNIFORM_BUFFER, 0);
@@ -1570,7 +1570,7 @@ RasterizerCanvasGLES3::RasterizerCanvasGLES3() {
 	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
 	String global_defines;
-	global_defines += "#define MAX_GLOBAL_VARIABLES 256\n"; // TODO: this is arbitrary for now
+	global_defines += "#define MAX_GLOBAL_SHADER_UNIFORMS 256\n"; // TODO: this is arbitrary for now
 	global_defines += "#define MAX_LIGHTS " + itos(state.max_instances_per_batch) + "\n";
 	global_defines += "#define MAX_DRAW_DATA_INSTANCES " + itos(state.max_instances_per_batch) + "\n";
 

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1894,7 +1894,7 @@ void RasterizerSceneGLES3::render_scene(RID p_render_buffers, const CameraData *
 	// Fill Light lists here
 	//////////
 
-	GLuint global_buffer = GLES3::MaterialStorage::get_singleton()->global_variables_get_uniform_buffer();
+	GLuint global_buffer = GLES3::MaterialStorage::get_singleton()->global_shader_uniforms_get_uniform_buffer();
 	glBindBufferBase(GL_UNIFORM_BUFFER, SCENE_GLOBALS_UNIFORM_LOCATION, global_buffer);
 
 	Color clear_color;
@@ -2629,7 +2629,7 @@ RasterizerSceneGLES3::RasterizerSceneGLES3() {
 
 	{
 		String global_defines;
-		global_defines += "#define MAX_GLOBAL_VARIABLES 256\n"; // TODO: this is arbitrary for now
+		global_defines += "#define MAX_GLOBAL_SHADER_UNIFORMS 256\n"; // TODO: this is arbitrary for now
 		global_defines += "\n#define MAX_LIGHT_DATA_STRUCTS " + itos(config->max_renderable_lights) + "\n";
 		global_defines += "\n#define MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS " + itos(MAX_DIRECTIONAL_LIGHTS) + "\n";
 		global_defines += "\n#define MAX_FORWARD_LIGHTS " + itos(config->max_lights_per_object) + "\n";
@@ -2668,7 +2668,7 @@ void fragment() {
 		sky_globals.ggx_samples = GLOBAL_GET("rendering/reflections/sky_reflections/ggx_samples");
 
 		String global_defines;
-		global_defines += "#define MAX_GLOBAL_VARIABLES 256\n"; // TODO: this is arbitrary for now
+		global_defines += "#define MAX_GLOBAL_SHADER_UNIFORMS 256\n"; // TODO: this is arbitrary for now
 		global_defines += "\n#define MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS " + itos(sky_globals.max_directional_lights) + "\n";
 		material_storage->shaders.sky_shader.initialize(global_defines);
 		sky_globals.shader_default_version = material_storage->shaders.sky_shader.version_create();

--- a/drivers/gles3/shaders/canvas_uniforms_inc.glsl
+++ b/drivers/gles3/shaders/canvas_uniforms_inc.glsl
@@ -58,8 +58,8 @@ struct DrawData {
 	uvec4 lights;
 };
 
-layout(std140) uniform GlobalVariableData { //ubo:1
-	vec4 global_variables[MAX_GLOBAL_VARIABLES];
+layout(std140) uniform GlobalShaderUniformData { //ubo:1
+	vec4 global_shader_uniforms[MAX_GLOBAL_SHADER_UNIFORMS];
 };
 
 layout(std140) uniform CanvasData { //ubo:0

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -104,8 +104,8 @@ layout(location = 14) in highp vec4 instance_xform2;
 layout(location = 15) in highp uvec4 instance_color_custom_data; // Color packed into xy, Custom data into zw.
 #endif
 
-layout(std140) uniform GlobalVariableData { //ubo:1
-	vec4 global_variables[MAX_GLOBAL_VARIABLES];
+layout(std140) uniform GlobalShaderUniformData { //ubo:1
+	vec4 global_shader_uniforms[MAX_GLOBAL_SHADER_UNIFORMS];
 };
 
 layout(std140) uniform SceneData { // ubo:2
@@ -399,8 +399,8 @@ uniform samplerCube radiance_map; // texunit:-2
 
 #endif
 
-layout(std140) uniform GlobalVariableData { //ubo:1
-	vec4 global_variables[MAX_GLOBAL_VARIABLES];
+layout(std140) uniform GlobalShaderUniformData { //ubo:1
+	vec4 global_shader_uniforms[MAX_GLOBAL_SHADER_UNIFORMS];
 };
 
 	/* Material Uniforms */

--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -42,8 +42,8 @@ uniform sampler2D half_res; //texunit:-2
 uniform sampler2D quarter_res; //texunit:-3
 #endif
 
-layout(std140) uniform GlobalVariableData { //ubo:1
-	vec4 global_variables[MAX_GLOBAL_VARIABLES];
+layout(std140) uniform GlobalShaderUniformData { //ubo:1
+	vec4 global_shader_uniforms[MAX_GLOBAL_SHADER_UNIFORMS];
 };
 
 struct DirectionalLightData {

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -997,7 +997,7 @@ void MaterialData::update_uniform_buffer(const HashMap<StringName, ShaderLanguag
 
 		if (E.value.scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_GLOBAL) {
 			//this is a global variable, get the index to it
-			GlobalVariables::Variable *gv = material_storage->global_variables.variables.getptr(E.key);
+			GlobalShaderUniforms::Variable *gv = material_storage->global_shader_uniforms.variables.getptr(E.key);
 			uint32_t index = 0;
 			if (gv) {
 				index = gv->buffer_index;
@@ -1053,9 +1053,9 @@ void MaterialData::update_uniform_buffer(const HashMap<StringName, ShaderLanguag
 
 	if (uses_global_buffer != (global_buffer_E != nullptr)) {
 		if (uses_global_buffer) {
-			global_buffer_E = material_storage->global_variables.materials_using_buffer.push_back(self);
+			global_buffer_E = material_storage->global_shader_uniforms.materials_using_buffer.push_back(self);
 		} else {
-			material_storage->global_variables.materials_using_buffer.erase(global_buffer_E);
+			material_storage->global_shader_uniforms.materials_using_buffer.erase(global_buffer_E);
 			global_buffer_E = nullptr;
 		}
 	}
@@ -1066,20 +1066,20 @@ MaterialData::~MaterialData() {
 
 	if (global_buffer_E) {
 		//unregister global buffers
-		material_storage->global_variables.materials_using_buffer.erase(global_buffer_E);
+		material_storage->global_shader_uniforms.materials_using_buffer.erase(global_buffer_E);
 	}
 
 	if (global_texture_E) {
 		//unregister global textures
 
 		for (const KeyValue<StringName, uint64_t> &E : used_global_textures) {
-			GlobalVariables::Variable *v = material_storage->global_variables.variables.getptr(E.key);
+			GlobalShaderUniforms::Variable *v = material_storage->global_shader_uniforms.variables.getptr(E.key);
 			if (v) {
 				v->texture_materials.erase(self);
 			}
 		}
 		//unregister material from those using global textures
-		material_storage->global_variables.materials_using_texture.erase(global_texture_E);
+		material_storage->global_shader_uniforms.materials_using_texture.erase(global_texture_E);
 	}
 
 	if (uniform_buffer) {
@@ -1110,7 +1110,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 		if (p_texture_uniforms[i].global) {
 			uses_global_textures = true;
 
-			GlobalVariables::Variable *v = material_storage->global_variables.variables.getptr(uniform_name);
+			GlobalShaderUniforms::Variable *v = material_storage->global_shader_uniforms.variables.getptr(uniform_name);
 			if (v) {
 				if (v->buffer_index >= 0) {
 					WARN_PRINT("Shader uses global uniform texture '" + String(uniform_name) + "', but it changed type and is no longer a texture!.");
@@ -1282,7 +1282,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 			if (E.value != global_textures_pass) {
 				to_delete.push_back(E.key);
 
-				GlobalVariables::Variable *v = material_storage->global_variables.variables.getptr(E.key);
+				GlobalShaderUniforms::Variable *v = material_storage->global_shader_uniforms.variables.getptr(E.key);
 				if (v) {
 					v->texture_materials.erase(self);
 				}
@@ -1296,9 +1296,9 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 		//handle registering/unregistering global textures
 		if (uses_global_textures != (global_texture_E != nullptr)) {
 			if (uses_global_textures) {
-				global_texture_E = material_storage->global_variables.materials_using_texture.push_back(self);
+				global_texture_E = material_storage->global_shader_uniforms.materials_using_texture.push_back(self);
 			} else {
-				material_storage->global_variables.materials_using_texture.erase(global_texture_E);
+				material_storage->global_shader_uniforms.materials_using_texture.erase(global_texture_E);
 				global_texture_E = nullptr;
 			}
 		}
@@ -1365,22 +1365,22 @@ MaterialStorage::MaterialStorage() {
 	material_data_request_func[RS::SHADER_SKY] = _create_sky_material_func;
 	material_data_request_func[RS::SHADER_FOG] = nullptr;
 
-	static_assert(sizeof(GlobalVariables::Value) == 16);
+	static_assert(sizeof(GlobalShaderUniforms::Value) == 16);
 
-	global_variables.buffer_size = MAX(4096, (int)GLOBAL_GET("rendering/limits/global_shader_variables/buffer_size"));
-	if (global_variables.buffer_size > uint32_t(Config::get_singleton()->max_uniform_buffer_size)) {
-		global_variables.buffer_size = uint32_t(Config::get_singleton()->max_uniform_buffer_size);
+	global_shader_uniforms.buffer_size = MAX(4096, (int)GLOBAL_GET("rendering/limits/global_shader_variables/buffer_size"));
+	if (global_shader_uniforms.buffer_size > uint32_t(Config::get_singleton()->max_uniform_buffer_size)) {
+		global_shader_uniforms.buffer_size = uint32_t(Config::get_singleton()->max_uniform_buffer_size);
 		WARN_PRINT("Project setting: rendering/limits/global_shader_variables/buffer_size exceeds maximum uniform buffer size of: " + itos(Config::get_singleton()->max_uniform_buffer_size));
 	}
 
-	global_variables.buffer_values = memnew_arr(GlobalVariables::Value, global_variables.buffer_size);
-	memset(global_variables.buffer_values, 0, sizeof(GlobalVariables::Value) * global_variables.buffer_size);
-	global_variables.buffer_usage = memnew_arr(GlobalVariables::ValueUsage, global_variables.buffer_size);
-	global_variables.buffer_dirty_regions = memnew_arr(bool, global_variables.buffer_size / GlobalVariables::BUFFER_DIRTY_REGION_SIZE);
-	memset(global_variables.buffer_dirty_regions, 0, sizeof(bool) * global_variables.buffer_size / GlobalVariables::BUFFER_DIRTY_REGION_SIZE);
-	glGenBuffers(1, &global_variables.buffer);
-	glBindBuffer(GL_UNIFORM_BUFFER, global_variables.buffer);
-	glBufferData(GL_UNIFORM_BUFFER, sizeof(GlobalVariables::Value) * global_variables.buffer_size, nullptr, GL_DYNAMIC_DRAW);
+	global_shader_uniforms.buffer_values = memnew_arr(GlobalShaderUniforms::Value, global_shader_uniforms.buffer_size);
+	memset(global_shader_uniforms.buffer_values, 0, sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size);
+	global_shader_uniforms.buffer_usage = memnew_arr(GlobalShaderUniforms::ValueUsage, global_shader_uniforms.buffer_size);
+	global_shader_uniforms.buffer_dirty_regions = memnew_arr(bool, global_shader_uniforms.buffer_size / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE);
+	memset(global_shader_uniforms.buffer_dirty_regions, 0, sizeof(bool) * global_shader_uniforms.buffer_size / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE);
+	glGenBuffers(1, &global_shader_uniforms.buffer);
+	glBindBuffer(GL_UNIFORM_BUFFER, global_shader_uniforms.buffer);
+	glBufferData(GL_UNIFORM_BUFFER, sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size, nullptr, GL_DYNAMIC_DRAW);
 	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
 	{
@@ -1674,7 +1674,7 @@ ShaderCompiler::DefaultIdentifierActions actions;
 
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
-		actions.global_buffer_array_variable = "global_variables.data";
+		actions.global_buffer_array_variable = "global_shader_uniforms.data";
 
 		particles_shader.compiler.initialize(actions);
 		*/
@@ -1736,25 +1736,25 @@ ShaderCompiler::DefaultIdentifierActions actions;
 MaterialStorage::~MaterialStorage() {
 	//shaders.copy.version_free(shaders.copy_version);
 
-	memdelete_arr(global_variables.buffer_values);
-	memdelete_arr(global_variables.buffer_usage);
-	memdelete_arr(global_variables.buffer_dirty_regions);
-	glDeleteBuffers(1, &global_variables.buffer);
+	memdelete_arr(global_shader_uniforms.buffer_values);
+	memdelete_arr(global_shader_uniforms.buffer_usage);
+	memdelete_arr(global_shader_uniforms.buffer_dirty_regions);
+	glDeleteBuffers(1, &global_shader_uniforms.buffer);
 
 	singleton = nullptr;
 }
 
-/* GLOBAL VARIABLE API */
+/* GLOBAL SHADER UNIFORM API */
 
-int32_t MaterialStorage::_global_variable_allocate(uint32_t p_elements) {
+int32_t MaterialStorage::_global_shader_uniform_allocate(uint32_t p_elements) {
 	int32_t idx = 0;
-	while (idx + p_elements <= global_variables.buffer_size) {
-		if (global_variables.buffer_usage[idx].elements == 0) {
+	while (idx + p_elements <= global_shader_uniforms.buffer_size) {
+		if (global_shader_uniforms.buffer_usage[idx].elements == 0) {
 			bool valid = true;
 			for (uint32_t i = 1; i < p_elements; i++) {
-				if (global_variables.buffer_usage[idx + i].elements > 0) {
+				if (global_shader_uniforms.buffer_usage[idx + i].elements > 0) {
 					valid = false;
-					idx += i + global_variables.buffer_usage[idx + i].elements;
+					idx += i + global_shader_uniforms.buffer_usage[idx + i].elements;
 					break;
 				}
 			}
@@ -1765,17 +1765,17 @@ int32_t MaterialStorage::_global_variable_allocate(uint32_t p_elements) {
 
 			return idx;
 		} else {
-			idx += global_variables.buffer_usage[idx].elements;
+			idx += global_shader_uniforms.buffer_usage[idx].elements;
 		}
 	}
 
 	return -1;
 }
 
-void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::GlobalVariableType p_type, const Variant &p_value) {
+void MaterialStorage::_global_shader_uniform_store_in_buffer(int32_t p_index, RS::GlobalShaderUniformType p_type, const Variant &p_value) {
 	switch (p_type) {
 		case RS::GLOBAL_VAR_TYPE_BOOL: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			bool b = p_value;
 			bv.x = b ? 1.0 : 0.0;
 			bv.y = 0.0;
@@ -1784,7 +1784,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 
 		} break;
 		case RS::GLOBAL_VAR_TYPE_BVEC2: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			uint32_t bvec = p_value;
 			bv.x = (bvec & 1) ? 1.0 : 0.0;
 			bv.y = (bvec & 2) ? 1.0 : 0.0;
@@ -1792,7 +1792,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0.0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_BVEC3: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			uint32_t bvec = p_value;
 			bv.x = (bvec & 1) ? 1.0 : 0.0;
 			bv.y = (bvec & 2) ? 1.0 : 0.0;
@@ -1800,7 +1800,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0.0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_BVEC4: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			uint32_t bvec = p_value;
 			bv.x = (bvec & 1) ? 1.0 : 0.0;
 			bv.y = (bvec & 2) ? 1.0 : 0.0;
@@ -1808,7 +1808,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = (bvec & 8) ? 1.0 : 0.0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_INT: {
-			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueInt &bv = *(GlobalShaderUniforms::ValueInt *)&global_shader_uniforms.buffer_values[p_index];
 			int32_t v = p_value;
 			bv.x = v;
 			bv.y = 0;
@@ -1816,7 +1816,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_IVEC2: {
-			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueInt &bv = *(GlobalShaderUniforms::ValueInt *)&global_shader_uniforms.buffer_values[p_index];
 			Vector2i v = p_value;
 			bv.x = v.x;
 			bv.y = v.y;
@@ -1824,7 +1824,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_IVEC3: {
-			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueInt &bv = *(GlobalShaderUniforms::ValueInt *)&global_shader_uniforms.buffer_values[p_index];
 			Vector3i v = p_value;
 			bv.x = v.x;
 			bv.y = v.y;
@@ -1832,7 +1832,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_IVEC4: {
-			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueInt &bv = *(GlobalShaderUniforms::ValueInt *)&global_shader_uniforms.buffer_values[p_index];
 			Vector<int32_t> v = p_value;
 			bv.x = v.size() >= 1 ? v[0] : 0;
 			bv.y = v.size() >= 2 ? v[1] : 0;
@@ -1840,7 +1840,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = v.size() >= 4 ? v[3] : 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_RECT2I: {
-			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueInt &bv = *(GlobalShaderUniforms::ValueInt *)&global_shader_uniforms.buffer_values[p_index];
 			Rect2i v = p_value;
 			bv.x = v.position.x;
 			bv.y = v.position.y;
@@ -1848,7 +1848,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = v.size.y;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_UINT: {
-			GlobalVariables::ValueUInt &bv = *(GlobalVariables::ValueUInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueUInt &bv = *(GlobalShaderUniforms::ValueUInt *)&global_shader_uniforms.buffer_values[p_index];
 			uint32_t v = p_value;
 			bv.x = v;
 			bv.y = 0;
@@ -1856,7 +1856,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_UVEC2: {
-			GlobalVariables::ValueUInt &bv = *(GlobalVariables::ValueUInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueUInt &bv = *(GlobalShaderUniforms::ValueUInt *)&global_shader_uniforms.buffer_values[p_index];
 			Vector2i v = p_value;
 			bv.x = v.x;
 			bv.y = v.y;
@@ -1864,7 +1864,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_UVEC3: {
-			GlobalVariables::ValueUInt &bv = *(GlobalVariables::ValueUInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueUInt &bv = *(GlobalShaderUniforms::ValueUInt *)&global_shader_uniforms.buffer_values[p_index];
 			Vector3i v = p_value;
 			bv.x = v.x;
 			bv.y = v.y;
@@ -1872,7 +1872,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_UVEC4: {
-			GlobalVariables::ValueUInt &bv = *(GlobalVariables::ValueUInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueUInt &bv = *(GlobalShaderUniforms::ValueUInt *)&global_shader_uniforms.buffer_values[p_index];
 			Vector<int32_t> v = p_value;
 			bv.x = v.size() >= 1 ? v[0] : 0;
 			bv.y = v.size() >= 2 ? v[1] : 0;
@@ -1880,7 +1880,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = v.size() >= 4 ? v[3] : 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_FLOAT: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			float v = p_value;
 			bv.x = v;
 			bv.y = 0;
@@ -1888,7 +1888,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_VEC2: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			Vector2 v = p_value;
 			bv.x = v.x;
 			bv.y = v.y;
@@ -1896,7 +1896,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_VEC3: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			Vector3 v = p_value;
 			bv.x = v.x;
 			bv.y = v.y;
@@ -1904,7 +1904,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_VEC4: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			Plane v = p_value;
 			bv.x = v.normal.x;
 			bv.y = v.normal.y;
@@ -1912,14 +1912,14 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = v.d;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_COLOR: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			Color v = p_value;
 			bv.x = v.r;
 			bv.y = v.g;
 			bv.z = v.b;
 			bv.w = v.a;
 
-			GlobalVariables::Value &bv_linear = global_variables.buffer_values[p_index + 1];
+			GlobalShaderUniforms::Value &bv_linear = global_shader_uniforms.buffer_values[p_index + 1];
 			//v = v.srgb_to_linear();
 			bv_linear.x = v.r;
 			bv_linear.y = v.g;
@@ -1928,7 +1928,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 
 		} break;
 		case RS::GLOBAL_VAR_TYPE_RECT2: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			Rect2 v = p_value;
 			bv.x = v.position.x;
 			bv.y = v.position.y;
@@ -1936,7 +1936,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = v.size.y;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_MAT2: {
-			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value *bv = &global_shader_uniforms.buffer_values[p_index];
 			Vector<float> m2 = p_value;
 			if (m2.size() < 4) {
 				m2.resize(4);
@@ -1953,7 +1953,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 
 		} break;
 		case RS::GLOBAL_VAR_TYPE_MAT3: {
-			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value *bv = &global_shader_uniforms.buffer_values[p_index];
 			Basis v = p_value;
 			bv[0].x = v.rows[0][0];
 			bv[0].y = v.rows[1][0];
@@ -1972,7 +1972,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 
 		} break;
 		case RS::GLOBAL_VAR_TYPE_MAT4: {
-			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value *bv = &global_shader_uniforms.buffer_values[p_index];
 
 			Vector<float> m2 = p_value;
 			if (m2.size() < 16) {
@@ -2001,7 +2001,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 
 		} break;
 		case RS::GLOBAL_VAR_TYPE_TRANSFORM_2D: {
-			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value *bv = &global_shader_uniforms.buffer_values[p_index];
 			Transform2D v = p_value;
 			bv[0].x = v.columns[0][0];
 			bv[0].y = v.columns[0][1];
@@ -2020,7 +2020,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 
 		} break;
 		case RS::GLOBAL_VAR_TYPE_TRANSFORM: {
-			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value *bv = &global_shader_uniforms.buffer_values[p_index];
 			Transform3D v = p_value;
 			bv[0].x = v.basis.rows[0][0];
 			bv[0].y = v.basis.rows[1][0];
@@ -2049,15 +2049,15 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 	}
 }
 
-void MaterialStorage::_global_variable_mark_buffer_dirty(int32_t p_index, int32_t p_elements) {
+void MaterialStorage::_global_shader_uniform_mark_buffer_dirty(int32_t p_index, int32_t p_elements) {
 	int32_t prev_chunk = -1;
 
 	for (int32_t i = 0; i < p_elements; i++) {
-		int32_t chunk = (p_index + i) / GlobalVariables::BUFFER_DIRTY_REGION_SIZE;
+		int32_t chunk = (p_index + i) / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE;
 		if (chunk != prev_chunk) {
-			if (!global_variables.buffer_dirty_regions[chunk]) {
-				global_variables.buffer_dirty_regions[chunk] = true;
-				global_variables.buffer_dirty_region_count++;
+			if (!global_shader_uniforms.buffer_dirty_regions[chunk]) {
+				global_shader_uniforms.buffer_dirty_regions[chunk] = true;
+				global_shader_uniforms.buffer_dirty_region_count++;
 			}
 		}
 
@@ -2065,16 +2065,16 @@ void MaterialStorage::_global_variable_mark_buffer_dirty(int32_t p_index, int32_
 	}
 }
 
-void MaterialStorage::global_variable_add(const StringName &p_name, RS::GlobalVariableType p_type, const Variant &p_value) {
-	ERR_FAIL_COND(global_variables.variables.has(p_name));
-	GlobalVariables::Variable gv;
+void MaterialStorage::global_shader_uniform_add(const StringName &p_name, RS::GlobalShaderUniformType p_type, const Variant &p_value) {
+	ERR_FAIL_COND(global_shader_uniforms.variables.has(p_name));
+	GlobalShaderUniforms::Variable gv;
 	gv.type = p_type;
 	gv.value = p_value;
 	gv.buffer_index = -1;
 
 	if (p_type >= RS::GLOBAL_VAR_TYPE_SAMPLER2D) {
 		//is texture
-		global_variables.must_update_texture_materials = true; //normally there are none
+		global_shader_uniforms.must_update_texture_materials = true; //normally there are none
 	} else {
 		gv.buffer_elements = 1;
 		if (p_type == RS::GLOBAL_VAR_TYPE_COLOR || p_type == RS::GLOBAL_VAR_TYPE_MAT2) {
@@ -2091,56 +2091,56 @@ void MaterialStorage::global_variable_add(const StringName &p_name, RS::GlobalVa
 		}
 
 		//is vector, allocate in buffer and update index
-		gv.buffer_index = _global_variable_allocate(gv.buffer_elements);
+		gv.buffer_index = _global_shader_uniform_allocate(gv.buffer_elements);
 		ERR_FAIL_COND_MSG(gv.buffer_index < 0, vformat("Failed allocating global variable '%s' out of buffer memory. Consider increasing it in the Project Settings.", String(p_name)));
-		global_variables.buffer_usage[gv.buffer_index].elements = gv.buffer_elements;
-		_global_variable_store_in_buffer(gv.buffer_index, gv.type, gv.value);
-		_global_variable_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
+		global_shader_uniforms.buffer_usage[gv.buffer_index].elements = gv.buffer_elements;
+		_global_shader_uniform_store_in_buffer(gv.buffer_index, gv.type, gv.value);
+		_global_shader_uniform_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
 
-		global_variables.must_update_buffer_materials = true; //normally there are none
+		global_shader_uniforms.must_update_buffer_materials = true; //normally there are none
 	}
 
-	global_variables.variables[p_name] = gv;
+	global_shader_uniforms.variables[p_name] = gv;
 }
 
-void MaterialStorage::global_variable_remove(const StringName &p_name) {
-	if (!global_variables.variables.has(p_name)) {
+void MaterialStorage::global_shader_uniform_remove(const StringName &p_name) {
+	if (!global_shader_uniforms.variables.has(p_name)) {
 		return;
 	}
-	GlobalVariables::Variable &gv = global_variables.variables[p_name];
+	GlobalShaderUniforms::Variable &gv = global_shader_uniforms.variables[p_name];
 
 	if (gv.buffer_index >= 0) {
-		global_variables.buffer_usage[gv.buffer_index].elements = 0;
-		global_variables.must_update_buffer_materials = true;
+		global_shader_uniforms.buffer_usage[gv.buffer_index].elements = 0;
+		global_shader_uniforms.must_update_buffer_materials = true;
 	} else {
-		global_variables.must_update_texture_materials = true;
+		global_shader_uniforms.must_update_texture_materials = true;
 	}
 
-	global_variables.variables.erase(p_name);
+	global_shader_uniforms.variables.erase(p_name);
 }
 
-Vector<StringName> MaterialStorage::global_variable_get_list() const {
+Vector<StringName> MaterialStorage::global_shader_uniform_get_list() const {
 	if (!Engine::get_singleton()->is_editor_hint()) {
 		ERR_FAIL_V_MSG(Vector<StringName>(), "This function should never be used outside the editor, it can severely damage performance.");
 	}
 
 	Vector<StringName> names;
-	for (const KeyValue<StringName, GlobalVariables::Variable> &E : global_variables.variables) {
+	for (const KeyValue<StringName, GlobalShaderUniforms::Variable> &E : global_shader_uniforms.variables) {
 		names.push_back(E.key);
 	}
 	names.sort_custom<StringName::AlphCompare>();
 	return names;
 }
 
-void MaterialStorage::global_variable_set(const StringName &p_name, const Variant &p_value) {
-	ERR_FAIL_COND(!global_variables.variables.has(p_name));
-	GlobalVariables::Variable &gv = global_variables.variables[p_name];
+void MaterialStorage::global_shader_uniform_set(const StringName &p_name, const Variant &p_value) {
+	ERR_FAIL_COND(!global_shader_uniforms.variables.has(p_name));
+	GlobalShaderUniforms::Variable &gv = global_shader_uniforms.variables[p_name];
 	gv.value = p_value;
 	if (gv.override.get_type() == Variant::NIL) {
 		if (gv.buffer_index >= 0) {
 			//buffer
-			_global_variable_store_in_buffer(gv.buffer_index, gv.type, gv.value);
-			_global_variable_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
+			_global_shader_uniform_store_in_buffer(gv.buffer_index, gv.type, gv.value);
+			_global_shader_uniform_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
 		} else {
 			//texture
 			MaterialStorage *material_storage = MaterialStorage::get_singleton();
@@ -2153,26 +2153,26 @@ void MaterialStorage::global_variable_set(const StringName &p_name, const Varian
 	}
 }
 
-void MaterialStorage::global_variable_set_override(const StringName &p_name, const Variant &p_value) {
-	if (!global_variables.variables.has(p_name)) {
+void MaterialStorage::global_shader_uniform_set_override(const StringName &p_name, const Variant &p_value) {
+	if (!global_shader_uniforms.variables.has(p_name)) {
 		return; //variable may not exist
 	}
 
 	ERR_FAIL_COND(p_value.get_type() == Variant::OBJECT);
 
-	GlobalVariables::Variable &gv = global_variables.variables[p_name];
+	GlobalShaderUniforms::Variable &gv = global_shader_uniforms.variables[p_name];
 
 	gv.override = p_value;
 
 	if (gv.buffer_index >= 0) {
 		//buffer
 		if (gv.override.get_type() == Variant::NIL) {
-			_global_variable_store_in_buffer(gv.buffer_index, gv.type, gv.value);
+			_global_shader_uniform_store_in_buffer(gv.buffer_index, gv.type, gv.value);
 		} else {
-			_global_variable_store_in_buffer(gv.buffer_index, gv.type, gv.override);
+			_global_shader_uniform_store_in_buffer(gv.buffer_index, gv.type, gv.override);
 		}
 
-		_global_variable_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
+		_global_shader_uniform_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
 	} else {
 		//texture
 		MaterialStorage *material_storage = MaterialStorage::get_singleton();
@@ -2184,35 +2184,35 @@ void MaterialStorage::global_variable_set_override(const StringName &p_name, con
 	}
 }
 
-Variant MaterialStorage::global_variable_get(const StringName &p_name) const {
+Variant MaterialStorage::global_shader_uniform_get(const StringName &p_name) const {
 	if (!Engine::get_singleton()->is_editor_hint()) {
 		ERR_FAIL_V_MSG(Variant(), "This function should never be used outside the editor, it can severely damage performance.");
 	}
 
-	if (!global_variables.variables.has(p_name)) {
+	if (!global_shader_uniforms.variables.has(p_name)) {
 		return Variant();
 	}
 
-	return global_variables.variables[p_name].value;
+	return global_shader_uniforms.variables[p_name].value;
 }
 
-RS::GlobalVariableType MaterialStorage::global_variable_get_type_internal(const StringName &p_name) const {
-	if (!global_variables.variables.has(p_name)) {
+RS::GlobalShaderUniformType MaterialStorage::global_shader_uniform_get_type_internal(const StringName &p_name) const {
+	if (!global_shader_uniforms.variables.has(p_name)) {
 		return RS::GLOBAL_VAR_TYPE_MAX;
 	}
 
-	return global_variables.variables[p_name].type;
+	return global_shader_uniforms.variables[p_name].type;
 }
 
-RS::GlobalVariableType MaterialStorage::global_variable_get_type(const StringName &p_name) const {
+RS::GlobalShaderUniformType MaterialStorage::global_shader_uniform_get_type(const StringName &p_name) const {
 	if (!Engine::get_singleton()->is_editor_hint()) {
 		ERR_FAIL_V_MSG(RS::GLOBAL_VAR_TYPE_MAX, "This function should never be used outside the editor, it can severely damage performance.");
 	}
 
-	return global_variable_get_type_internal(p_name);
+	return global_shader_uniform_get_type_internal(p_name);
 }
 
-void MaterialStorage::global_variables_load_settings(bool p_load_textures) {
+void MaterialStorage::global_shader_uniforms_load_settings(bool p_load_textures) {
 	List<PropertyInfo> settings;
 	ProjectSettings::get_singleton()->get_property_list(&settings);
 
@@ -2257,11 +2257,11 @@ void MaterialStorage::global_variables_load_settings(bool p_load_textures) {
 				"samplerCube",
 			};
 
-			RS::GlobalVariableType gvtype = RS::GLOBAL_VAR_TYPE_MAX;
+			RS::GlobalShaderUniformType gvtype = RS::GLOBAL_VAR_TYPE_MAX;
 
 			for (int i = 0; i < RS::GLOBAL_VAR_TYPE_MAX; i++) {
 				if (global_var_type_names[i] == type) {
-					gvtype = RS::GlobalVariableType(i);
+					gvtype = RS::GlobalShaderUniformType(i);
 					break;
 				}
 			}
@@ -2283,47 +2283,47 @@ void MaterialStorage::global_variables_load_settings(bool p_load_textures) {
 				value = resource;
 			}
 
-			if (global_variables.variables.has(name)) {
+			if (global_shader_uniforms.variables.has(name)) {
 				//has it, update it
-				global_variable_set(name, value);
+				global_shader_uniform_set(name, value);
 			} else {
-				global_variable_add(name, gvtype, value);
+				global_shader_uniform_add(name, gvtype, value);
 			}
 		}
 	}
 }
 
-void MaterialStorage::global_variables_clear() {
-	global_variables.variables.clear();
+void MaterialStorage::global_shader_uniforms_clear() {
+	global_shader_uniforms.variables.clear();
 }
 
-GLuint MaterialStorage::global_variables_get_uniform_buffer() const {
-	return global_variables.buffer;
+GLuint MaterialStorage::global_shader_uniforms_get_uniform_buffer() const {
+	return global_shader_uniforms.buffer;
 }
 
-int32_t MaterialStorage::global_variables_instance_allocate(RID p_instance) {
-	ERR_FAIL_COND_V(global_variables.instance_buffer_pos.has(p_instance), -1);
-	int32_t pos = _global_variable_allocate(ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES);
-	global_variables.instance_buffer_pos[p_instance] = pos; //save anyway
+int32_t MaterialStorage::global_shader_uniforms_instance_allocate(RID p_instance) {
+	ERR_FAIL_COND_V(global_shader_uniforms.instance_buffer_pos.has(p_instance), -1);
+	int32_t pos = _global_shader_uniform_allocate(ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES);
+	global_shader_uniforms.instance_buffer_pos[p_instance] = pos; //save anyway
 	ERR_FAIL_COND_V_MSG(pos < 0, -1, "Too many instances using shader instance variables. Increase buffer size in Project Settings.");
-	global_variables.buffer_usage[pos].elements = ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES;
+	global_shader_uniforms.buffer_usage[pos].elements = ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES;
 	return pos;
 }
 
-void MaterialStorage::global_variables_instance_free(RID p_instance) {
-	ERR_FAIL_COND(!global_variables.instance_buffer_pos.has(p_instance));
-	int32_t pos = global_variables.instance_buffer_pos[p_instance];
+void MaterialStorage::global_shader_uniforms_instance_free(RID p_instance) {
+	ERR_FAIL_COND(!global_shader_uniforms.instance_buffer_pos.has(p_instance));
+	int32_t pos = global_shader_uniforms.instance_buffer_pos[p_instance];
 	if (pos >= 0) {
-		global_variables.buffer_usage[pos].elements = 0;
+		global_shader_uniforms.buffer_usage[pos].elements = 0;
 	}
-	global_variables.instance_buffer_pos.erase(p_instance);
+	global_shader_uniforms.instance_buffer_pos.erase(p_instance);
 }
 
-void MaterialStorage::global_variables_instance_update(RID p_instance, int p_index, const Variant &p_value) {
-	if (!global_variables.instance_buffer_pos.has(p_instance)) {
+void MaterialStorage::global_shader_uniforms_instance_update(RID p_instance, int p_index, const Variant &p_value) {
+	if (!global_shader_uniforms.instance_buffer_pos.has(p_instance)) {
 		return; //just not allocated, ignore
 	}
-	int32_t pos = global_variables.instance_buffer_pos[p_instance];
+	int32_t pos = global_shader_uniforms.instance_buffer_pos[p_instance];
 
 	if (pos < 0) {
 		return; //again, not allocated, ignore
@@ -2358,59 +2358,59 @@ void MaterialStorage::global_variables_instance_update(RID p_instance, int p_ind
 
 	pos += p_index;
 
-	_fill_std140_variant_ubo_value(datatype, 0, p_value, (uint8_t *)&global_variables.buffer_values[pos]);
-	_global_variable_mark_buffer_dirty(pos, 1);
+	_fill_std140_variant_ubo_value(datatype, 0, p_value, (uint8_t *)&global_shader_uniforms.buffer_values[pos]);
+	_global_shader_uniform_mark_buffer_dirty(pos, 1);
 }
 
-void MaterialStorage::_update_global_variables() {
+void MaterialStorage::_update_global_shader_uniforms() {
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
-	if (global_variables.buffer_dirty_region_count > 0) {
-		uint32_t total_regions = global_variables.buffer_size / GlobalVariables::BUFFER_DIRTY_REGION_SIZE;
-		if (total_regions / global_variables.buffer_dirty_region_count <= 4) {
+	if (global_shader_uniforms.buffer_dirty_region_count > 0) {
+		uint32_t total_regions = global_shader_uniforms.buffer_size / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE;
+		if (total_regions / global_shader_uniforms.buffer_dirty_region_count <= 4) {
 			// 25% of regions dirty, just update all buffer
-			glBindBuffer(GL_UNIFORM_BUFFER, global_variables.buffer);
-			glBufferData(GL_UNIFORM_BUFFER, sizeof(GlobalVariables::Value) * global_variables.buffer_size, global_variables.buffer_values, GL_DYNAMIC_DRAW);
+			glBindBuffer(GL_UNIFORM_BUFFER, global_shader_uniforms.buffer);
+			glBufferData(GL_UNIFORM_BUFFER, sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size, global_shader_uniforms.buffer_values, GL_DYNAMIC_DRAW);
 			glBindBuffer(GL_UNIFORM_BUFFER, 0);
-			memset(global_variables.buffer_dirty_regions, 0, sizeof(bool) * total_regions);
+			memset(global_shader_uniforms.buffer_dirty_regions, 0, sizeof(bool) * total_regions);
 		} else {
-			uint32_t region_byte_size = sizeof(GlobalVariables::Value) * GlobalVariables::BUFFER_DIRTY_REGION_SIZE;
-			glBindBuffer(GL_UNIFORM_BUFFER, global_variables.buffer);
+			uint32_t region_byte_size = sizeof(GlobalShaderUniforms::Value) * GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE;
+			glBindBuffer(GL_UNIFORM_BUFFER, global_shader_uniforms.buffer);
 			for (uint32_t i = 0; i < total_regions; i++) {
-				if (global_variables.buffer_dirty_regions[i]) {
-					glBufferSubData(GL_UNIFORM_BUFFER, i * region_byte_size, region_byte_size, &global_variables.buffer_values[i * GlobalVariables::BUFFER_DIRTY_REGION_SIZE]);
-					global_variables.buffer_dirty_regions[i] = false;
+				if (global_shader_uniforms.buffer_dirty_regions[i]) {
+					glBufferSubData(GL_UNIFORM_BUFFER, i * region_byte_size, region_byte_size, &global_shader_uniforms.buffer_values[i * GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE]);
+					global_shader_uniforms.buffer_dirty_regions[i] = false;
 				}
 			}
 			glBindBuffer(GL_UNIFORM_BUFFER, 0);
 		}
 
-		global_variables.buffer_dirty_region_count = 0;
+		global_shader_uniforms.buffer_dirty_region_count = 0;
 	}
 
-	if (global_variables.must_update_buffer_materials) {
+	if (global_shader_uniforms.must_update_buffer_materials) {
 		// only happens in the case of a buffer variable added or removed,
 		// so not often.
-		for (const RID &E : global_variables.materials_using_buffer) {
+		for (const RID &E : global_shader_uniforms.materials_using_buffer) {
 			Material *material = material_storage->get_material(E);
 			ERR_CONTINUE(!material); //wtf
 
 			material_storage->_material_queue_update(material, true, false);
 		}
 
-		global_variables.must_update_buffer_materials = false;
+		global_shader_uniforms.must_update_buffer_materials = false;
 	}
 
-	if (global_variables.must_update_texture_materials) {
+	if (global_shader_uniforms.must_update_texture_materials) {
 		// only happens in the case of a buffer variable added or removed,
 		// so not often.
-		for (const RID &E : global_variables.materials_using_texture) {
+		for (const RID &E : global_shader_uniforms.materials_using_texture) {
 			Material *material = material_storage->get_material(E);
 			ERR_CONTINUE(!material); //wtf
 
 			material_storage->_material_queue_update(material, false, true);
 		}
 
-		global_variables.must_update_texture_materials = false;
+		global_shader_uniforms.must_update_texture_materials = false;
 	}
 }
 

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -365,15 +365,15 @@ struct SceneMaterialData : public MaterialData {
 
 MaterialData *_create_scene_material_func(ShaderData *p_shader);
 
-/* Global variable structs */
-struct GlobalVariables {
+/* Global shader uniform structs */
+struct GlobalShaderUniforms {
 	enum {
 		BUFFER_DIRTY_REGION_SIZE = 1024
 	};
 	struct Variable {
 		HashSet<RID> texture_materials; // materials using this
 
-		RS::GlobalVariableType type;
+		RS::GlobalShaderUniformType type;
 		Variant value;
 		Variant override;
 		int32_t buffer_index; //for vectors
@@ -429,13 +429,13 @@ private:
 	friend struct MaterialData;
 	static MaterialStorage *singleton;
 
-	/* GLOBAL VARIABLE API */
+	/* GLOBAL SHADER UNIFORM API */
 
-	GlobalVariables global_variables;
+	GlobalShaderUniforms global_shader_uniforms;
 
-	int32_t _global_variable_allocate(uint32_t p_elements);
-	void _global_variable_store_in_buffer(int32_t p_index, RS::GlobalVariableType p_type, const Variant &p_value);
-	void _global_variable_mark_buffer_dirty(int32_t p_index, int32_t p_elements);
+	int32_t _global_shader_uniform_allocate(uint32_t p_elements);
+	void _global_shader_uniform_store_in_buffer(int32_t p_index, RS::GlobalShaderUniformType p_type, const Variant &p_value);
+	void _global_shader_uniform_mark_buffer_dirty(int32_t p_index, int32_t p_elements);
 
 	/* SHADER API */
 
@@ -508,28 +508,28 @@ public:
 		ShaderCompiler compiler_sky;
 	} shaders;
 
-	/* GLOBAL VARIABLE API */
+	/* GLOBAL SHADER UNIFORM API */
 
-	void _update_global_variables();
+	void _update_global_shader_uniforms();
 
-	virtual void global_variable_add(const StringName &p_name, RS::GlobalVariableType p_type, const Variant &p_value) override;
-	virtual void global_variable_remove(const StringName &p_name) override;
-	virtual Vector<StringName> global_variable_get_list() const override;
+	virtual void global_shader_uniform_add(const StringName &p_name, RS::GlobalShaderUniformType p_type, const Variant &p_value) override;
+	virtual void global_shader_uniform_remove(const StringName &p_name) override;
+	virtual Vector<StringName> global_shader_uniform_get_list() const override;
 
-	virtual void global_variable_set(const StringName &p_name, const Variant &p_value) override;
-	virtual void global_variable_set_override(const StringName &p_name, const Variant &p_value) override;
-	virtual Variant global_variable_get(const StringName &p_name) const override;
-	virtual RS::GlobalVariableType global_variable_get_type(const StringName &p_name) const override;
-	RS::GlobalVariableType global_variable_get_type_internal(const StringName &p_name) const;
+	virtual void global_shader_uniform_set(const StringName &p_name, const Variant &p_value) override;
+	virtual void global_shader_uniform_set_override(const StringName &p_name, const Variant &p_value) override;
+	virtual Variant global_shader_uniform_get(const StringName &p_name) const override;
+	virtual RS::GlobalShaderUniformType global_shader_uniform_get_type(const StringName &p_name) const override;
+	RS::GlobalShaderUniformType global_shader_uniform_get_type_internal(const StringName &p_name) const;
 
-	virtual void global_variables_load_settings(bool p_load_textures = true) override;
-	virtual void global_variables_clear() override;
+	virtual void global_shader_uniforms_load_settings(bool p_load_textures = true) override;
+	virtual void global_shader_uniforms_clear() override;
 
-	virtual int32_t global_variables_instance_allocate(RID p_instance) override;
-	virtual void global_variables_instance_free(RID p_instance) override;
-	virtual void global_variables_instance_update(RID p_instance, int p_index, const Variant &p_value) override;
+	virtual int32_t global_shader_uniforms_instance_allocate(RID p_instance) override;
+	virtual void global_shader_uniforms_instance_free(RID p_instance) override;
+	virtual void global_shader_uniforms_instance_update(RID p_instance, int p_index, const Variant &p_value) override;
 
-	GLuint global_variables_get_uniform_buffer() const;
+	GLuint global_shader_uniforms_get_uniform_buffer() const;
 
 	/* SHADER API */
 

--- a/drivers/gles3/storage/utilities.cpp
+++ b/drivers/gles3/storage/utilities.cpp
@@ -293,7 +293,7 @@ void Utilities::visibility_notifier_call(RID p_notifier, bool p_enter, bool p_de
 /* MISC */
 
 void Utilities::update_dirty_resources() {
-	MaterialStorage::get_singleton()->_update_global_variables();
+	MaterialStorage::get_singleton()->_update_global_shader_uniforms();
 	MaterialStorage::get_singleton()->_update_queued_materials();
 	//MeshStorage::get_singleton()->_update_dirty_skeletons();
 	MeshStorage::get_singleton()->_update_dirty_multimeshes();

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1035,7 +1035,7 @@ void EditorNode::_sources_changed(bool p_exist) {
 
 		// Reload the global shader variables, but this time
 		// loading textures, as they are now properly imported.
-		RenderingServer::get_singleton()->global_variables_load_settings(true);
+		RenderingServer::get_singleton()->global_shader_uniforms_load_settings(true);
 
 		// Start preview thread now that it's safe.
 		if (!singleton->cmdline_export_mode) {

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -309,9 +309,9 @@ void ShaderTextEditor::_check_shader_mode() {
 	}
 }
 
-static ShaderLanguage::DataType _get_global_variable_type(const StringName &p_variable) {
-	RS::GlobalVariableType gvt = RS::get_singleton()->global_variable_get_type(p_variable);
-	return (ShaderLanguage::DataType)RS::global_variable_type_get_shader_datatype(gvt);
+static ShaderLanguage::DataType _get_global_shader_uniform_type(const StringName &p_variable) {
+	RS::GlobalShaderUniformType gvt = RS::get_singleton()->global_shader_uniform_get_type(p_variable);
+	return (ShaderLanguage::DataType)RS::global_shader_uniform_type_get_shader_datatype(gvt);
 }
 
 static String complete_from_path;
@@ -358,7 +358,7 @@ void ShaderTextEditor::_code_complete_script(const String &p_code, List<ScriptLa
 	ShaderLanguage sl;
 	String calltip;
 	ShaderLanguage::ShaderCompileInfo info;
-	info.global_variable_type_func = _get_global_variable_type;
+	info.global_shader_uniform_type_func = _get_global_shader_uniform_type;
 
 	if (shader.is_null()) {
 		info.is_include = true;
@@ -448,7 +448,7 @@ void ShaderTextEditor::_validate_script() {
 		sl.set_warning_flags(flags);
 
 		ShaderLanguage::ShaderCompileInfo info;
-		info.global_variable_type_func = _get_global_variable_type;
+		info.global_shader_uniform_type_func = _get_global_shader_uniform_type;
 
 		if (shader.is_null()) {
 			info.is_include = true;

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -4563,9 +4563,9 @@ void VisualShaderEditor::_preview_size_changed() {
 	preview_vbox->set_custom_minimum_size(preview_window->get_size());
 }
 
-static ShaderLanguage::DataType _get_global_variable_type(const StringName &p_variable) {
-	RS::GlobalVariableType gvt = RS::get_singleton()->global_variable_get_type(p_variable);
-	return (ShaderLanguage::DataType)RS::global_variable_type_get_shader_datatype(gvt);
+static ShaderLanguage::DataType _get_global_shader_uniform_type(const StringName &p_variable) {
+	RS::GlobalShaderUniformType gvt = RS::get_singleton()->global_shader_uniform_get_type(p_variable);
+	return (ShaderLanguage::DataType)RS::global_shader_uniform_type_get_shader_datatype(gvt);
 }
 
 void VisualShaderEditor::_update_preview() {
@@ -4582,7 +4582,7 @@ void VisualShaderEditor::_update_preview() {
 	info.functions = ShaderTypes::get_singleton()->get_functions(RenderingServer::ShaderMode(visual_shader->get_mode()));
 	info.render_modes = ShaderTypes::get_singleton()->get_modes(RenderingServer::ShaderMode(visual_shader->get_mode()));
 	info.shader_types = ShaderTypes::get_singleton()->get_types();
-	info.global_variable_type_func = _get_global_variable_type;
+	info.global_shader_uniform_type_func = _get_global_shader_uniform_type;
 
 	ShaderLanguage sl;
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -669,10 +669,10 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 	autoload_settings->connect("autoload_changed", callable_mp(this, &ProjectSettingsEditor::queue_save));
 	tab_container->add_child(autoload_settings);
 
-	shaders_global_variables_editor = memnew(ShaderGlobalsEditor);
-	shaders_global_variables_editor->set_name(TTR("Shader Globals"));
-	shaders_global_variables_editor->connect("globals_changed", callable_mp(this, &ProjectSettingsEditor::queue_save));
-	tab_container->add_child(shaders_global_variables_editor);
+	shaders_global_shader_uniforms_editor = memnew(ShaderGlobalsEditor);
+	shaders_global_shader_uniforms_editor->set_name(TTR("Shader Globals"));
+	shaders_global_shader_uniforms_editor->connect("globals_changed", callable_mp(this, &ProjectSettingsEditor::queue_save));
+	tab_container->add_child(shaders_global_shader_uniforms_editor);
 
 	plugin_settings = memnew(EditorPluginSettings);
 	plugin_settings->set_name(TTR("Plugins"));

--- a/editor/project_settings_editor.h
+++ b/editor/project_settings_editor.h
@@ -55,7 +55,7 @@ class ProjectSettingsEditor : public AcceptDialog {
 	ActionMapEditor *action_map_editor = nullptr;
 	LocalizationEditor *localization_editor = nullptr;
 	EditorAutoloadSettings *autoload_settings = nullptr;
-	ShaderGlobalsEditor *shaders_global_variables_editor = nullptr;
+	ShaderGlobalsEditor *shaders_global_shader_uniforms_editor = nullptr;
 	EditorPluginSettings *plugin_settings = nullptr;
 
 	LineEdit *search_box = nullptr;

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -79,7 +79,7 @@ protected:
 	}
 
 	bool _set(const StringName &p_name, const Variant &p_value) {
-		Variant existing = RS::get_singleton()->global_variable_get(p_name);
+		Variant existing = RS::get_singleton()->global_shader_uniform_get(p_name);
 
 		if (existing.get_type() == Variant::NIL) {
 			return false;
@@ -88,9 +88,9 @@ protected:
 		UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 		undo_redo->create_action(TTR("Set Shader Global Variable"));
-		undo_redo->add_do_method(RS::get_singleton(), "global_variable_set", p_name, p_value);
-		undo_redo->add_undo_method(RS::get_singleton(), "global_variable_set", p_name, existing);
-		RS::GlobalVariableType type = RS::get_singleton()->global_variable_get_type(p_name);
+		undo_redo->add_do_method(RS::get_singleton(), "global_shader_uniform_set", p_name, p_value);
+		undo_redo->add_undo_method(RS::get_singleton(), "global_shader_uniform_set", p_name, existing);
+		RS::GlobalShaderUniformType type = RS::get_singleton()->global_shader_uniform_get_type(p_name);
 		Dictionary gv;
 		gv["type"] = global_var_type_names[type];
 		if (type >= RS::GLOBAL_VAR_TYPE_SAMPLER2D) {
@@ -117,17 +117,17 @@ protected:
 	}
 
 	bool _get(const StringName &p_name, Variant &r_ret) const {
-		r_ret = RS::get_singleton()->global_variable_get(p_name);
+		r_ret = RS::get_singleton()->global_shader_uniform_get(p_name);
 		return r_ret.get_type() != Variant::NIL;
 	}
 	void _get_property_list(List<PropertyInfo> *p_list) const {
 		Vector<StringName> variables;
-		variables = RS::get_singleton()->global_variable_get_list();
+		variables = RS::get_singleton()->global_shader_uniform_get_list();
 		for (int i = 0; i < variables.size(); i++) {
 			PropertyInfo pinfo;
 			pinfo.name = variables[i];
 
-			switch (RS::get_singleton()->global_variable_get_type(variables[i])) {
+			switch (RS::get_singleton()->global_shader_uniform_get_type(variables[i])) {
 				case RS::GLOBAL_VAR_TYPE_BOOL: {
 					pinfo.type = Variant::BOOL;
 				} break;
@@ -241,7 +241,7 @@ public:
 	}
 };
 
-static Variant create_var(RS::GlobalVariableType p_type) {
+static Variant create_var(RS::GlobalShaderUniformType p_type) {
 	switch (p_type) {
 		case RS::GLOBAL_VAR_TYPE_BOOL: {
 			return false;
@@ -376,12 +376,12 @@ static Variant create_var(RS::GlobalVariableType p_type) {
 void ShaderGlobalsEditor::_variable_added() {
 	String var = variable_name->get_text().strip_edges();
 	if (var.is_empty() || !var.is_valid_identifier()) {
-		EditorNode::get_singleton()->show_warning(TTR("Please specify a valid variable identifier name."));
+		EditorNode::get_singleton()->show_warning(TTR("Please specify a valid shader uniform identifier name."));
 		return;
 	}
 
-	if (RenderingServer::get_singleton()->global_variable_get(var).get_type() != Variant::NIL) {
-		EditorNode::get_singleton()->show_warning(vformat(TTR("Global variable '%s' already exists'"), var));
+	if (RenderingServer::get_singleton()->global_shader_uniform_get(var).get_type() != Variant::NIL) {
+		EditorNode::get_singleton()->show_warning(vformat(TTR("Global shader uniform '%s' already exists'"), var));
 		return;
 	}
 
@@ -395,11 +395,11 @@ void ShaderGlobalsEditor::_variable_added() {
 
 	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
-	Variant value = create_var(RS::GlobalVariableType(variable_type->get_selected()));
+	Variant value = create_var(RS::GlobalShaderUniformType(variable_type->get_selected()));
 
-	undo_redo->create_action(TTR("Add Shader Global Variable"));
-	undo_redo->add_do_method(RS::get_singleton(), "global_variable_add", var, RS::GlobalVariableType(variable_type->get_selected()), value);
-	undo_redo->add_undo_method(RS::get_singleton(), "global_variable_remove", var);
+	undo_redo->create_action(TTR("Add Shader Global Uniform"));
+	undo_redo->add_do_method(RS::get_singleton(), "global_shader_uniform_add", var, RS::GlobalShaderUniformType(variable_type->get_selected()), value);
+	undo_redo->add_undo_method(RS::get_singleton(), "global_shader_uniform_remove", var);
 	Dictionary gv;
 	gv["type"] = global_var_type_names[variable_type->get_selected()];
 	gv["value"] = value;
@@ -414,9 +414,9 @@ void ShaderGlobalsEditor::_variable_added() {
 void ShaderGlobalsEditor::_variable_deleted(const String &p_variable) {
 	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
-	undo_redo->create_action(TTR("Add Shader Global Variable"));
-	undo_redo->add_do_method(RS::get_singleton(), "global_variable_remove", p_variable);
-	undo_redo->add_undo_method(RS::get_singleton(), "global_variable_add", p_variable, RS::get_singleton()->global_variable_get_type(p_variable), RS::get_singleton()->global_variable_get(p_variable));
+	undo_redo->create_action(TTR("Add Shader Global Uniform"));
+	undo_redo->add_do_method(RS::get_singleton(), "global_shader_uniform_remove", p_variable);
+	undo_redo->add_undo_method(RS::get_singleton(), "global_shader_uniform_add", p_variable, RS::get_singleton()->global_shader_uniform_get_type(p_variable), RS::get_singleton()->global_shader_uniform_get(p_variable));
 
 	undo_redo->add_do_property(ProjectSettings::get_singleton(), "shader_globals/" + p_variable, Variant());
 	undo_redo->add_undo_property(ProjectSettings::get_singleton(), "shader_globals/" + p_variable, ProjectSettings::get_singleton()->get("shader_globals/" + p_variable));

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2098,7 +2098,7 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		// able to load resources, load the global shader variables.
 		// If running on editor, don't load the textures because the editor
 		// may want to import them first. Editor will reload those later.
-		rendering_server->global_variables_load_settings(!editor);
+		rendering_server->global_shader_uniforms_load_settings(!editor);
 	}
 
 	_start_success = true;
@@ -3011,7 +3011,7 @@ void Main::cleanup(bool p_force) {
 	RenderingServer::get_singleton()->sync();
 
 	//clear global shader variables before scene and other graphics stuff are deinitialized.
-	rendering_server->global_variables_clear();
+	rendering_server->global_shader_uniforms_clear();
 
 	if (xr_server) {
 		// Now that we're unregistering properly in plugins we need to keep access to xr_server for a little longer

--- a/scene/main/shader_globals_override.cpp
+++ b/scene/main/shader_globals_override.cpp
@@ -64,9 +64,9 @@ bool ShaderGlobalsOverride::_set(const StringName &p_name, const Variant &p_valu
 			if (active) {
 				if (o->override.get_type() == Variant::OBJECT) {
 					RID tex_rid = p_value;
-					RS::get_singleton()->global_variable_set_override(*r, tex_rid);
+					RS::get_singleton()->global_shader_uniform_set_override(*r, tex_rid);
 				} else {
-					RS::get_singleton()->global_variable_set_override(*r, p_value);
+					RS::get_singleton()->global_shader_uniform_set_override(*r, p_value);
 				}
 			}
 			o->in_use = p_value.get_type() != Variant::NIL;
@@ -93,13 +93,13 @@ bool ShaderGlobalsOverride::_get(const StringName &p_name, Variant &r_ret) const
 
 void ShaderGlobalsOverride::_get_property_list(List<PropertyInfo> *p_list) const {
 	Vector<StringName> variables;
-	variables = RS::get_singleton()->global_variable_get_list();
+	variables = RS::get_singleton()->global_shader_uniform_get_list();
 	for (int i = 0; i < variables.size(); i++) {
 		PropertyInfo pinfo;
 		pinfo.name = "params/" + variables[i];
 		pinfo.usage = PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_CHECKABLE;
 
-		switch (RS::get_singleton()->global_variable_get_type(variables[i])) {
+		switch (RS::get_singleton()->global_shader_uniform_get_type(variables[i])) {
 			case RS::GLOBAL_VAR_TYPE_BOOL: {
 				pinfo.type = Variant::BOOL;
 			} break;
@@ -234,9 +234,9 @@ void ShaderGlobalsOverride::_activate() {
 			if (o->in_use && o->override.get_type() != Variant::NIL) {
 				if (o->override.get_type() == Variant::OBJECT) {
 					RID tex_rid = o->override;
-					RS::get_singleton()->global_variable_set_override(E.key, tex_rid);
+					RS::get_singleton()->global_shader_uniform_set_override(E.key, tex_rid);
 				} else {
-					RS::get_singleton()->global_variable_set_override(E.key, o->override);
+					RS::get_singleton()->global_shader_uniform_set_override(E.key, o->override);
 				}
 			}
 
@@ -258,7 +258,7 @@ void ShaderGlobalsOverride::_notification(int p_what) {
 				for (const KeyValue<StringName, Override> &E : overrides) {
 					const Override *o = &E.value;
 					if (o->in_use) {
-						RS::get_singleton()->global_variable_set_override(E.key, Variant());
+						RS::get_singleton()->global_shader_uniform_set_override(E.key, Variant());
 					}
 				}
 			}

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -3751,7 +3751,7 @@ String VisualShaderNodeUniform::get_warning(Shader::Mode p_mode, VisualShader::T
 		}
 		return vformat(RTR("This uniform type does not support the '%s' qualifier."), qualifier_str);
 	} else if (qualifier == Qualifier::QUAL_GLOBAL) {
-		RS::GlobalVariableType gvt = RS::get_singleton()->global_variable_get_type(uniform_name);
+		RS::GlobalShaderUniformType gvt = RS::get_singleton()->global_shader_uniform_get_type(uniform_name);
 		if (gvt == RS::GLOBAL_VAR_TYPE_MAX) {
 			return vformat(RTR("Global uniform '%s' does not exist.\nCreate it in the Project Settings."), uniform_name);
 		}

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -38,23 +38,23 @@ namespace RendererDummy {
 
 class MaterialStorage : public RendererMaterialStorage {
 public:
-	/* GLOBAL VARIABLE API */
+	/* GLOBAL SHADER UNIFORM API */
 
-	virtual void global_variable_add(const StringName &p_name, RS::GlobalVariableType p_type, const Variant &p_value) override {}
-	virtual void global_variable_remove(const StringName &p_name) override {}
-	virtual Vector<StringName> global_variable_get_list() const override { return Vector<StringName>(); }
+	virtual void global_shader_uniform_add(const StringName &p_name, RS::GlobalShaderUniformType p_type, const Variant &p_value) override {}
+	virtual void global_shader_uniform_remove(const StringName &p_name) override {}
+	virtual Vector<StringName> global_shader_uniform_get_list() const override { return Vector<StringName>(); }
 
-	virtual void global_variable_set(const StringName &p_name, const Variant &p_value) override {}
-	virtual void global_variable_set_override(const StringName &p_name, const Variant &p_value) override {}
-	virtual Variant global_variable_get(const StringName &p_name) const override { return Variant(); }
-	virtual RS::GlobalVariableType global_variable_get_type(const StringName &p_name) const override { return RS::GLOBAL_VAR_TYPE_MAX; }
+	virtual void global_shader_uniform_set(const StringName &p_name, const Variant &p_value) override {}
+	virtual void global_shader_uniform_set_override(const StringName &p_name, const Variant &p_value) override {}
+	virtual Variant global_shader_uniform_get(const StringName &p_name) const override { return Variant(); }
+	virtual RS::GlobalShaderUniformType global_shader_uniform_get_type(const StringName &p_name) const override { return RS::GLOBAL_VAR_TYPE_MAX; }
 
-	virtual void global_variables_load_settings(bool p_load_textures = true) override {}
-	virtual void global_variables_clear() override {}
+	virtual void global_shader_uniforms_load_settings(bool p_load_textures = true) override {}
+	virtual void global_shader_uniforms_clear() override {}
 
-	virtual int32_t global_variables_instance_allocate(RID p_instance) override { return 0; }
-	virtual void global_variables_instance_free(RID p_instance) override {}
-	virtual void global_variables_instance_update(RID p_instance, int p_index, const Variant &p_value) override {}
+	virtual int32_t global_shader_uniforms_instance_allocate(RID p_instance) override { return 0; }
+	virtual void global_shader_uniforms_instance_free(RID p_instance) override {}
+	virtual void global_shader_uniforms_instance_update(RID p_instance, int p_index, const Variant &p_value) override {}
 
 	/* SHADER API */
 

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -276,7 +276,7 @@ ALBEDO = vec3(1.0);
 			RD::Uniform u;
 			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 2;
-			u.append_id(RendererRD::MaterialStorage::get_singleton()->global_variables_get_storage_buffer());
+			u.append_id(RendererRD::MaterialStorage::get_singleton()->global_shader_uniforms_get_storage_buffer());
 			uniforms.push_back(u);
 		}
 

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -912,7 +912,7 @@ void SkyRD::init() {
 
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
-		actions.global_buffer_array_variable = "global_variables.data";
+		actions.global_buffer_array_variable = "global_shader_uniforms.data";
 
 		sky_shader.compiler.initialize(actions);
 	}
@@ -970,7 +970,7 @@ void sky() {
 			RD::Uniform u;
 			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 1;
-			u.append_id(RendererRD::MaterialStorage::get_singleton()->global_variables_get_storage_buffer());
+			u.append_id(RendererRD::MaterialStorage::get_singleton()->global_shader_uniforms_get_storage_buffer());
 			uniforms.push_back(u);
 		}
 

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -2383,7 +2383,7 @@ void RenderForwardClustered::_update_render_base_uniform_set() {
 			RD::Uniform u;
 			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 14;
-			u.append_id(RendererRD::MaterialStorage::get_singleton()->global_variables_get_storage_buffer());
+			u.append_id(RendererRD::MaterialStorage::get_singleton()->global_shader_uniforms_get_storage_buffer());
 			uniforms.push_back(u);
 		}
 

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -788,7 +788,7 @@ void SceneShaderForwardClustered::init(const String p_defines) {
 
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
-		actions.global_buffer_array_variable = "global_variables.data";
+		actions.global_buffer_array_variable = "global_shader_uniforms.data";
 		actions.instance_uniform_index_variable = "instances.data[instance_index_interp].instance_uniforms_ofs";
 
 		compiler.initialize(actions);

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1332,7 +1332,7 @@ void RenderForwardMobile::_update_render_base_uniform_set() {
 			RD::Uniform u;
 			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 14;
-			u.append_id(RendererRD::MaterialStorage::get_singleton()->global_variables_get_storage_buffer());
+			u.append_id(RendererRD::MaterialStorage::get_singleton()->global_shader_uniforms_get_storage_buffer());
 			uniforms.push_back(u);
 		}
 

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -685,7 +685,7 @@ void SceneShaderForwardMobile::init(const String p_defines) {
 
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
-		actions.global_buffer_array_variable = "global_variables.data";
+		actions.global_buffer_array_variable = "global_shader_uniforms.data";
 		actions.instance_uniform_index_variable = "draw_call.instance_uniforms_ofs";
 
 		actions.apply_luminance_multiplier = true; // apply luminance multiplier to screen texture

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -1031,7 +1031,7 @@ RID RendererCanvasRenderRD::_create_base_uniform_set(RID p_to_render_target, boo
 		RD::Uniform u;
 		u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 		u.binding = 9;
-		u.append_id(RendererRD::MaterialStorage::get_singleton()->global_variables_get_storage_buffer());
+		u.append_id(RendererRD::MaterialStorage::get_singleton()->global_shader_uniforms_get_storage_buffer());
 		uniforms.push_back(u);
 	}
 
@@ -2469,7 +2469,7 @@ RendererCanvasRenderRD::RendererCanvasRenderRD() {
 		actions.default_repeat = ShaderLanguage::REPEAT_DISABLE;
 		actions.base_varying_index = 4;
 
-		actions.global_buffer_array_variable = "global_variables.data";
+		actions.global_buffer_array_variable = "global_shader_uniforms.data";
 
 		shader.compiler.initialize(actions);
 	}

--- a/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/canvas_uniforms_inc.glsl
@@ -138,10 +138,10 @@ layout(set = 0, binding = 7) uniform texture2D sdf_texture;
 
 layout(set = 0, binding = 8) uniform sampler material_samplers[12];
 
-layout(set = 0, binding = 9, std430) restrict readonly buffer GlobalVariableData {
+layout(set = 0, binding = 9, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
 }
-global_variables;
+global_shader_uniforms;
 
 /* SET1: Is reserved for the material */
 

--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -77,10 +77,10 @@ params;
 
 layout(set = 0, binding = 0) uniform sampler material_samplers[12];
 
-layout(set = 0, binding = 1, std430) restrict readonly buffer GlobalVariableData {
+layout(set = 0, binding = 1, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
 }
-global_variables;
+global_shader_uniforms;
 
 layout(set = 0, binding = 2, std140) uniform SceneData {
 	bool volumetric_fog_enabled;

--- a/servers/rendering/renderer_rd/shaders/environment/volumetric_fog.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/volumetric_fog.glsl
@@ -28,10 +28,10 @@ layout(local_size_x = 4, local_size_y = 4, local_size_z = 4) in;
 
 layout(set = 0, binding = 1) uniform sampler material_samplers[12];
 
-layout(set = 0, binding = 2, std430) restrict readonly buffer GlobalVariableData {
+layout(set = 0, binding = 2, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
 }
-global_variables;
+global_shader_uniforms;
 
 layout(push_constant, std430) uniform Params {
 	vec3 position;

--- a/servers/rendering/renderer_rd/shaders/particles.glsl
+++ b/servers/rendering/renderer_rd/shaders/particles.glsl
@@ -25,10 +25,10 @@ layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
 
 layout(set = 0, binding = 1) uniform sampler material_samplers[12];
 
-layout(set = 0, binding = 2, std430) restrict readonly buffer GlobalVariableData {
+layout(set = 0, binding = 2, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
 }
-global_variables;
+global_shader_uniforms;
 
 /* Set 1: FRAME AND PARTICLE DATA */
 

--- a/servers/rendering/renderer_rd/shaders/scene_forward_clustered_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_clustered_inc.glsl
@@ -129,10 +129,10 @@ layout(set = 0, binding = 13, std430) restrict readonly buffer Decals {
 }
 decals;
 
-layout(set = 0, binding = 14, std430) restrict readonly buffer GlobalVariableData {
+layout(set = 0, binding = 14, std430) restrict readonly buffer GlobalShaderUniformData {
 	vec4 data[];
 }
-global_variables;
+global_shader_uniforms;
 
 struct SDFVoxelGICascadeData {
 	vec3 position;

--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile_inc.glsl
@@ -118,10 +118,10 @@ layout(set = 0, binding = 13, std430) restrict readonly buffer Decals {
 }
 decals;
 
-layout(set = 0, binding = 14, std430) restrict readonly buffer GlobalVariableData {
+layout(set = 0, binding = 14, std430) restrict readonly buffer GlobalShaderUniformData {
 	highp vec4 data[];
 }
-global_variables;
+global_shader_uniforms;
 
 /* Set 1: Render Pass (changes per render pass) */
 

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -967,7 +967,7 @@ void MaterialData::update_uniform_buffer(const HashMap<StringName, ShaderLanguag
 
 		if (E.value.scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_GLOBAL) {
 			//this is a global variable, get the index to it
-			GlobalVariables::Variable *gv = material_storage->global_variables.variables.getptr(E.key);
+			GlobalShaderUniforms::Variable *gv = material_storage->global_shader_uniforms.variables.getptr(E.key);
 			uint32_t index = 0;
 			if (gv) {
 				index = gv->buffer_index;
@@ -1023,9 +1023,9 @@ void MaterialData::update_uniform_buffer(const HashMap<StringName, ShaderLanguag
 
 	if (uses_global_buffer != (global_buffer_E != nullptr)) {
 		if (uses_global_buffer) {
-			global_buffer_E = material_storage->global_variables.materials_using_buffer.push_back(self);
+			global_buffer_E = material_storage->global_shader_uniforms.materials_using_buffer.push_back(self);
 		} else {
-			material_storage->global_variables.materials_using_buffer.erase(global_buffer_E);
+			material_storage->global_shader_uniforms.materials_using_buffer.erase(global_buffer_E);
 			global_buffer_E = nullptr;
 		}
 	}
@@ -1036,20 +1036,20 @@ MaterialData::~MaterialData() {
 
 	if (global_buffer_E) {
 		//unregister global buffers
-		material_storage->global_variables.materials_using_buffer.erase(global_buffer_E);
+		material_storage->global_shader_uniforms.materials_using_buffer.erase(global_buffer_E);
 	}
 
 	if (global_texture_E) {
 		//unregister global textures
 
 		for (const KeyValue<StringName, uint64_t> &E : used_global_textures) {
-			GlobalVariables::Variable *v = material_storage->global_variables.variables.getptr(E.key);
+			GlobalShaderUniforms::Variable *v = material_storage->global_shader_uniforms.variables.getptr(E.key);
 			if (v) {
 				v->texture_materials.erase(self);
 			}
 		}
 		//unregister material from those using global textures
-		material_storage->global_variables.materials_using_texture.erase(global_texture_E);
+		material_storage->global_shader_uniforms.materials_using_texture.erase(global_texture_E);
 	}
 
 	if (uniform_buffer.is_valid()) {
@@ -1079,7 +1079,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 		if (p_texture_uniforms[i].global) {
 			uses_global_textures = true;
 
-			GlobalVariables::Variable *v = material_storage->global_variables.variables.getptr(uniform_name);
+			GlobalShaderUniforms::Variable *v = material_storage->global_shader_uniforms.variables.getptr(uniform_name);
 			if (v) {
 				if (v->buffer_index >= 0) {
 					WARN_PRINT("Shader uses global uniform texture '" + String(uniform_name) + "', but it changed type and is no longer a texture!.");
@@ -1249,7 +1249,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 			if (E.value != global_textures_pass) {
 				to_delete.push_back(E.key);
 
-				GlobalVariables::Variable *v = material_storage->global_variables.variables.getptr(E.key);
+				GlobalShaderUniforms::Variable *v = material_storage->global_shader_uniforms.variables.getptr(E.key);
 				if (v) {
 					v->texture_materials.erase(self);
 				}
@@ -1263,9 +1263,9 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 		//handle registering/unregistering global textures
 		if (uses_global_textures != (global_texture_E != nullptr)) {
 			if (uses_global_textures) {
-				global_texture_E = material_storage->global_variables.materials_using_texture.push_back(self);
+				global_texture_E = material_storage->global_shader_uniforms.materials_using_texture.push_back(self);
 			} else {
-				material_storage->global_variables.materials_using_texture.erase(global_texture_E);
+				material_storage->global_shader_uniforms.materials_using_texture.erase(global_texture_E);
 				global_texture_E = nullptr;
 			}
 		}
@@ -1497,22 +1497,22 @@ MaterialStorage::MaterialStorage() {
 		shader_data_request_func[i] = nullptr;
 	}
 
-	static_assert(sizeof(GlobalVariables::Value) == 16);
+	static_assert(sizeof(GlobalShaderUniforms::Value) == 16);
 
-	global_variables.buffer_size = MAX(4096, (int)GLOBAL_GET("rendering/limits/global_shader_variables/buffer_size"));
-	global_variables.buffer_values = memnew_arr(GlobalVariables::Value, global_variables.buffer_size);
-	memset(global_variables.buffer_values, 0, sizeof(GlobalVariables::Value) * global_variables.buffer_size);
-	global_variables.buffer_usage = memnew_arr(GlobalVariables::ValueUsage, global_variables.buffer_size);
-	global_variables.buffer_dirty_regions = memnew_arr(bool, global_variables.buffer_size / GlobalVariables::BUFFER_DIRTY_REGION_SIZE);
-	memset(global_variables.buffer_dirty_regions, 0, sizeof(bool) * global_variables.buffer_size / GlobalVariables::BUFFER_DIRTY_REGION_SIZE);
-	global_variables.buffer = RD::get_singleton()->storage_buffer_create(sizeof(GlobalVariables::Value) * global_variables.buffer_size);
+	global_shader_uniforms.buffer_size = MAX(4096, (int)GLOBAL_GET("rendering/limits/global_shader_variables/buffer_size"));
+	global_shader_uniforms.buffer_values = memnew_arr(GlobalShaderUniforms::Value, global_shader_uniforms.buffer_size);
+	memset(global_shader_uniforms.buffer_values, 0, sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size);
+	global_shader_uniforms.buffer_usage = memnew_arr(GlobalShaderUniforms::ValueUsage, global_shader_uniforms.buffer_size);
+	global_shader_uniforms.buffer_dirty_regions = memnew_arr(bool, global_shader_uniforms.buffer_size / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE);
+	memset(global_shader_uniforms.buffer_dirty_regions, 0, sizeof(bool) * global_shader_uniforms.buffer_size / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE);
+	global_shader_uniforms.buffer = RD::get_singleton()->storage_buffer_create(sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size);
 }
 
 MaterialStorage::~MaterialStorage() {
-	memdelete_arr(global_variables.buffer_values);
-	memdelete_arr(global_variables.buffer_usage);
-	memdelete_arr(global_variables.buffer_dirty_regions);
-	RD::get_singleton()->free(global_variables.buffer);
+	memdelete_arr(global_shader_uniforms.buffer_values);
+	memdelete_arr(global_shader_uniforms.buffer_usage);
+	memdelete_arr(global_shader_uniforms.buffer_dirty_regions);
+	RD::get_singleton()->free(global_shader_uniforms.buffer);
 
 	// buffers
 
@@ -1633,17 +1633,17 @@ void MaterialStorage::sampler_rd_configure_custom(float p_mipmap_bias) {
 	}
 }
 
-/* GLOBAL VARIABLE API */
+/* GLOBAL SHADER UNIFORM API */
 
-int32_t MaterialStorage::_global_variable_allocate(uint32_t p_elements) {
+int32_t MaterialStorage::_global_shader_uniform_allocate(uint32_t p_elements) {
 	int32_t idx = 0;
-	while (idx + p_elements <= global_variables.buffer_size) {
-		if (global_variables.buffer_usage[idx].elements == 0) {
+	while (idx + p_elements <= global_shader_uniforms.buffer_size) {
+		if (global_shader_uniforms.buffer_usage[idx].elements == 0) {
 			bool valid = true;
 			for (uint32_t i = 1; i < p_elements; i++) {
-				if (global_variables.buffer_usage[idx + i].elements > 0) {
+				if (global_shader_uniforms.buffer_usage[idx + i].elements > 0) {
 					valid = false;
-					idx += i + global_variables.buffer_usage[idx + i].elements;
+					idx += i + global_shader_uniforms.buffer_usage[idx + i].elements;
 					break;
 				}
 			}
@@ -1654,17 +1654,17 @@ int32_t MaterialStorage::_global_variable_allocate(uint32_t p_elements) {
 
 			return idx;
 		} else {
-			idx += global_variables.buffer_usage[idx].elements;
+			idx += global_shader_uniforms.buffer_usage[idx].elements;
 		}
 	}
 
 	return -1;
 }
 
-void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::GlobalVariableType p_type, const Variant &p_value) {
+void MaterialStorage::_global_shader_uniform_store_in_buffer(int32_t p_index, RS::GlobalShaderUniformType p_type, const Variant &p_value) {
 	switch (p_type) {
 		case RS::GLOBAL_VAR_TYPE_BOOL: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			bool b = p_value;
 			bv.x = b ? 1.0 : 0.0;
 			bv.y = 0.0;
@@ -1673,7 +1673,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 
 		} break;
 		case RS::GLOBAL_VAR_TYPE_BVEC2: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			uint32_t bvec = p_value;
 			bv.x = (bvec & 1) ? 1.0 : 0.0;
 			bv.y = (bvec & 2) ? 1.0 : 0.0;
@@ -1681,7 +1681,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0.0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_BVEC3: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			uint32_t bvec = p_value;
 			bv.x = (bvec & 1) ? 1.0 : 0.0;
 			bv.y = (bvec & 2) ? 1.0 : 0.0;
@@ -1689,7 +1689,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0.0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_BVEC4: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			uint32_t bvec = p_value;
 			bv.x = (bvec & 1) ? 1.0 : 0.0;
 			bv.y = (bvec & 2) ? 1.0 : 0.0;
@@ -1697,7 +1697,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = (bvec & 8) ? 1.0 : 0.0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_INT: {
-			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueInt &bv = *(GlobalShaderUniforms::ValueInt *)&global_shader_uniforms.buffer_values[p_index];
 			int32_t v = p_value;
 			bv.x = v;
 			bv.y = 0;
@@ -1705,7 +1705,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_IVEC2: {
-			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueInt &bv = *(GlobalShaderUniforms::ValueInt *)&global_shader_uniforms.buffer_values[p_index];
 			Vector2i v = p_value;
 			bv.x = v.x;
 			bv.y = v.y;
@@ -1713,7 +1713,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_IVEC3: {
-			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueInt &bv = *(GlobalShaderUniforms::ValueInt *)&global_shader_uniforms.buffer_values[p_index];
 			Vector3i v = p_value;
 			bv.x = v.x;
 			bv.y = v.y;
@@ -1721,7 +1721,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_IVEC4: {
-			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueInt &bv = *(GlobalShaderUniforms::ValueInt *)&global_shader_uniforms.buffer_values[p_index];
 			Vector<int32_t> v = p_value;
 			bv.x = v.size() >= 1 ? v[0] : 0;
 			bv.y = v.size() >= 2 ? v[1] : 0;
@@ -1729,7 +1729,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = v.size() >= 4 ? v[3] : 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_RECT2I: {
-			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueInt &bv = *(GlobalShaderUniforms::ValueInt *)&global_shader_uniforms.buffer_values[p_index];
 			Rect2i v = p_value;
 			bv.x = v.position.x;
 			bv.y = v.position.y;
@@ -1737,7 +1737,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = v.size.y;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_UINT: {
-			GlobalVariables::ValueUInt &bv = *(GlobalVariables::ValueUInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueUInt &bv = *(GlobalShaderUniforms::ValueUInt *)&global_shader_uniforms.buffer_values[p_index];
 			uint32_t v = p_value;
 			bv.x = v;
 			bv.y = 0;
@@ -1745,7 +1745,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_UVEC2: {
-			GlobalVariables::ValueUInt &bv = *(GlobalVariables::ValueUInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueUInt &bv = *(GlobalShaderUniforms::ValueUInt *)&global_shader_uniforms.buffer_values[p_index];
 			Vector2i v = p_value;
 			bv.x = v.x;
 			bv.y = v.y;
@@ -1753,7 +1753,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_UVEC3: {
-			GlobalVariables::ValueUInt &bv = *(GlobalVariables::ValueUInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueUInt &bv = *(GlobalShaderUniforms::ValueUInt *)&global_shader_uniforms.buffer_values[p_index];
 			Vector3i v = p_value;
 			bv.x = v.x;
 			bv.y = v.y;
@@ -1761,7 +1761,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_UVEC4: {
-			GlobalVariables::ValueUInt &bv = *(GlobalVariables::ValueUInt *)&global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::ValueUInt &bv = *(GlobalShaderUniforms::ValueUInt *)&global_shader_uniforms.buffer_values[p_index];
 			Vector<int32_t> v = p_value;
 			bv.x = v.size() >= 1 ? v[0] : 0;
 			bv.y = v.size() >= 2 ? v[1] : 0;
@@ -1769,7 +1769,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = v.size() >= 4 ? v[3] : 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_FLOAT: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			float v = p_value;
 			bv.x = v;
 			bv.y = 0;
@@ -1777,7 +1777,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_VEC2: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			Vector2 v = p_value;
 			bv.x = v.x;
 			bv.y = v.y;
@@ -1785,7 +1785,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_VEC3: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			Vector3 v = p_value;
 			bv.x = v.x;
 			bv.y = v.y;
@@ -1793,7 +1793,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = 0;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_VEC4: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			Plane v = p_value;
 			bv.x = v.normal.x;
 			bv.y = v.normal.y;
@@ -1801,14 +1801,14 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = v.d;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_COLOR: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			Color v = p_value;
 			bv.x = v.r;
 			bv.y = v.g;
 			bv.z = v.b;
 			bv.w = v.a;
 
-			GlobalVariables::Value &bv_linear = global_variables.buffer_values[p_index + 1];
+			GlobalShaderUniforms::Value &bv_linear = global_shader_uniforms.buffer_values[p_index + 1];
 			v = v.srgb_to_linear();
 			bv_linear.x = v.r;
 			bv_linear.y = v.g;
@@ -1817,7 +1817,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 
 		} break;
 		case RS::GLOBAL_VAR_TYPE_RECT2: {
-			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value &bv = global_shader_uniforms.buffer_values[p_index];
 			Rect2 v = p_value;
 			bv.x = v.position.x;
 			bv.y = v.position.y;
@@ -1825,7 +1825,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 			bv.w = v.size.y;
 		} break;
 		case RS::GLOBAL_VAR_TYPE_MAT2: {
-			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value *bv = &global_shader_uniforms.buffer_values[p_index];
 			Vector<float> m2 = p_value;
 			if (m2.size() < 4) {
 				m2.resize(4);
@@ -1842,7 +1842,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 
 		} break;
 		case RS::GLOBAL_VAR_TYPE_MAT3: {
-			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value *bv = &global_shader_uniforms.buffer_values[p_index];
 			Basis v = p_value;
 			bv[0].x = v.rows[0][0];
 			bv[0].y = v.rows[1][0];
@@ -1861,7 +1861,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 
 		} break;
 		case RS::GLOBAL_VAR_TYPE_MAT4: {
-			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value *bv = &global_shader_uniforms.buffer_values[p_index];
 
 			Vector<float> m2 = p_value;
 			if (m2.size() < 16) {
@@ -1890,7 +1890,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 
 		} break;
 		case RS::GLOBAL_VAR_TYPE_TRANSFORM_2D: {
-			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value *bv = &global_shader_uniforms.buffer_values[p_index];
 			Transform2D v = p_value;
 			bv[0].x = v.columns[0][0];
 			bv[0].y = v.columns[0][1];
@@ -1909,7 +1909,7 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 
 		} break;
 		case RS::GLOBAL_VAR_TYPE_TRANSFORM: {
-			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			GlobalShaderUniforms::Value *bv = &global_shader_uniforms.buffer_values[p_index];
 			Transform3D v = p_value;
 			bv[0].x = v.basis.rows[0][0];
 			bv[0].y = v.basis.rows[1][0];
@@ -1938,15 +1938,15 @@ void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::Glob
 	}
 }
 
-void MaterialStorage::_global_variable_mark_buffer_dirty(int32_t p_index, int32_t p_elements) {
+void MaterialStorage::_global_shader_uniform_mark_buffer_dirty(int32_t p_index, int32_t p_elements) {
 	int32_t prev_chunk = -1;
 
 	for (int32_t i = 0; i < p_elements; i++) {
-		int32_t chunk = (p_index + i) / GlobalVariables::BUFFER_DIRTY_REGION_SIZE;
+		int32_t chunk = (p_index + i) / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE;
 		if (chunk != prev_chunk) {
-			if (!global_variables.buffer_dirty_regions[chunk]) {
-				global_variables.buffer_dirty_regions[chunk] = true;
-				global_variables.buffer_dirty_region_count++;
+			if (!global_shader_uniforms.buffer_dirty_regions[chunk]) {
+				global_shader_uniforms.buffer_dirty_regions[chunk] = true;
+				global_shader_uniforms.buffer_dirty_region_count++;
 			}
 		}
 
@@ -1954,16 +1954,16 @@ void MaterialStorage::_global_variable_mark_buffer_dirty(int32_t p_index, int32_
 	}
 }
 
-void MaterialStorage::global_variable_add(const StringName &p_name, RS::GlobalVariableType p_type, const Variant &p_value) {
-	ERR_FAIL_COND(global_variables.variables.has(p_name));
-	GlobalVariables::Variable gv;
+void MaterialStorage::global_shader_uniform_add(const StringName &p_name, RS::GlobalShaderUniformType p_type, const Variant &p_value) {
+	ERR_FAIL_COND(global_shader_uniforms.variables.has(p_name));
+	GlobalShaderUniforms::Variable gv;
 	gv.type = p_type;
 	gv.value = p_value;
 	gv.buffer_index = -1;
 
 	if (p_type >= RS::GLOBAL_VAR_TYPE_SAMPLER2D) {
 		//is texture
-		global_variables.must_update_texture_materials = true; //normally there are none
+		global_shader_uniforms.must_update_texture_materials = true; //normally there are none
 	} else {
 		gv.buffer_elements = 1;
 		if (p_type == RS::GLOBAL_VAR_TYPE_COLOR || p_type == RS::GLOBAL_VAR_TYPE_MAT2) {
@@ -1980,56 +1980,56 @@ void MaterialStorage::global_variable_add(const StringName &p_name, RS::GlobalVa
 		}
 
 		//is vector, allocate in buffer and update index
-		gv.buffer_index = _global_variable_allocate(gv.buffer_elements);
+		gv.buffer_index = _global_shader_uniform_allocate(gv.buffer_elements);
 		ERR_FAIL_COND_MSG(gv.buffer_index < 0, vformat("Failed allocating global variable '%s' out of buffer memory. Consider increasing it in the Project Settings.", String(p_name)));
-		global_variables.buffer_usage[gv.buffer_index].elements = gv.buffer_elements;
-		_global_variable_store_in_buffer(gv.buffer_index, gv.type, gv.value);
-		_global_variable_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
+		global_shader_uniforms.buffer_usage[gv.buffer_index].elements = gv.buffer_elements;
+		_global_shader_uniform_store_in_buffer(gv.buffer_index, gv.type, gv.value);
+		_global_shader_uniform_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
 
-		global_variables.must_update_buffer_materials = true; //normally there are none
+		global_shader_uniforms.must_update_buffer_materials = true; //normally there are none
 	}
 
-	global_variables.variables[p_name] = gv;
+	global_shader_uniforms.variables[p_name] = gv;
 }
 
-void MaterialStorage::global_variable_remove(const StringName &p_name) {
-	if (!global_variables.variables.has(p_name)) {
+void MaterialStorage::global_shader_uniform_remove(const StringName &p_name) {
+	if (!global_shader_uniforms.variables.has(p_name)) {
 		return;
 	}
-	const GlobalVariables::Variable &gv = global_variables.variables[p_name];
+	const GlobalShaderUniforms::Variable &gv = global_shader_uniforms.variables[p_name];
 
 	if (gv.buffer_index >= 0) {
-		global_variables.buffer_usage[gv.buffer_index].elements = 0;
-		global_variables.must_update_buffer_materials = true;
+		global_shader_uniforms.buffer_usage[gv.buffer_index].elements = 0;
+		global_shader_uniforms.must_update_buffer_materials = true;
 	} else {
-		global_variables.must_update_texture_materials = true;
+		global_shader_uniforms.must_update_texture_materials = true;
 	}
 
-	global_variables.variables.erase(p_name);
+	global_shader_uniforms.variables.erase(p_name);
 }
 
-Vector<StringName> MaterialStorage::global_variable_get_list() const {
+Vector<StringName> MaterialStorage::global_shader_uniform_get_list() const {
 	if (!Engine::get_singleton()->is_editor_hint()) {
 		ERR_FAIL_V_MSG(Vector<StringName>(), "This function should never be used outside the editor, it can severely damage performance.");
 	}
 
 	Vector<StringName> names;
-	for (const KeyValue<StringName, GlobalVariables::Variable> &E : global_variables.variables) {
+	for (const KeyValue<StringName, GlobalShaderUniforms::Variable> &E : global_shader_uniforms.variables) {
 		names.push_back(E.key);
 	}
 	names.sort_custom<StringName::AlphCompare>();
 	return names;
 }
 
-void MaterialStorage::global_variable_set(const StringName &p_name, const Variant &p_value) {
-	ERR_FAIL_COND(!global_variables.variables.has(p_name));
-	GlobalVariables::Variable &gv = global_variables.variables[p_name];
+void MaterialStorage::global_shader_uniform_set(const StringName &p_name, const Variant &p_value) {
+	ERR_FAIL_COND(!global_shader_uniforms.variables.has(p_name));
+	GlobalShaderUniforms::Variable &gv = global_shader_uniforms.variables[p_name];
 	gv.value = p_value;
 	if (gv.override.get_type() == Variant::NIL) {
 		if (gv.buffer_index >= 0) {
 			//buffer
-			_global_variable_store_in_buffer(gv.buffer_index, gv.type, gv.value);
-			_global_variable_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
+			_global_shader_uniform_store_in_buffer(gv.buffer_index, gv.type, gv.value);
+			_global_shader_uniform_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
 		} else {
 			//texture
 			MaterialStorage *material_storage = MaterialStorage::get_singleton();
@@ -2042,26 +2042,26 @@ void MaterialStorage::global_variable_set(const StringName &p_name, const Varian
 	}
 }
 
-void MaterialStorage::global_variable_set_override(const StringName &p_name, const Variant &p_value) {
-	if (!global_variables.variables.has(p_name)) {
+void MaterialStorage::global_shader_uniform_set_override(const StringName &p_name, const Variant &p_value) {
+	if (!global_shader_uniforms.variables.has(p_name)) {
 		return; //variable may not exist
 	}
 
 	ERR_FAIL_COND(p_value.get_type() == Variant::OBJECT);
 
-	GlobalVariables::Variable &gv = global_variables.variables[p_name];
+	GlobalShaderUniforms::Variable &gv = global_shader_uniforms.variables[p_name];
 
 	gv.override = p_value;
 
 	if (gv.buffer_index >= 0) {
 		//buffer
 		if (gv.override.get_type() == Variant::NIL) {
-			_global_variable_store_in_buffer(gv.buffer_index, gv.type, gv.value);
+			_global_shader_uniform_store_in_buffer(gv.buffer_index, gv.type, gv.value);
 		} else {
-			_global_variable_store_in_buffer(gv.buffer_index, gv.type, gv.override);
+			_global_shader_uniform_store_in_buffer(gv.buffer_index, gv.type, gv.override);
 		}
 
-		_global_variable_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
+		_global_shader_uniform_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
 	} else {
 		//texture
 		MaterialStorage *material_storage = MaterialStorage::get_singleton();
@@ -2073,35 +2073,35 @@ void MaterialStorage::global_variable_set_override(const StringName &p_name, con
 	}
 }
 
-Variant MaterialStorage::global_variable_get(const StringName &p_name) const {
+Variant MaterialStorage::global_shader_uniform_get(const StringName &p_name) const {
 	if (!Engine::get_singleton()->is_editor_hint()) {
 		ERR_FAIL_V_MSG(Variant(), "This function should never be used outside the editor, it can severely damage performance.");
 	}
 
-	if (!global_variables.variables.has(p_name)) {
+	if (!global_shader_uniforms.variables.has(p_name)) {
 		return Variant();
 	}
 
-	return global_variables.variables[p_name].value;
+	return global_shader_uniforms.variables[p_name].value;
 }
 
-RS::GlobalVariableType MaterialStorage::global_variable_get_type_internal(const StringName &p_name) const {
-	if (!global_variables.variables.has(p_name)) {
+RS::GlobalShaderUniformType MaterialStorage::global_shader_uniform_get_type_internal(const StringName &p_name) const {
+	if (!global_shader_uniforms.variables.has(p_name)) {
 		return RS::GLOBAL_VAR_TYPE_MAX;
 	}
 
-	return global_variables.variables[p_name].type;
+	return global_shader_uniforms.variables[p_name].type;
 }
 
-RS::GlobalVariableType MaterialStorage::global_variable_get_type(const StringName &p_name) const {
+RS::GlobalShaderUniformType MaterialStorage::global_shader_uniform_get_type(const StringName &p_name) const {
 	if (!Engine::get_singleton()->is_editor_hint()) {
 		ERR_FAIL_V_MSG(RS::GLOBAL_VAR_TYPE_MAX, "This function should never be used outside the editor, it can severely damage performance.");
 	}
 
-	return global_variable_get_type_internal(p_name);
+	return global_shader_uniform_get_type_internal(p_name);
 }
 
-void MaterialStorage::global_variables_load_settings(bool p_load_textures) {
+void MaterialStorage::global_shader_uniforms_load_settings(bool p_load_textures) {
 	List<PropertyInfo> settings;
 	ProjectSettings::get_singleton()->get_property_list(&settings);
 
@@ -2146,11 +2146,11 @@ void MaterialStorage::global_variables_load_settings(bool p_load_textures) {
 				"samplerCube",
 			};
 
-			RS::GlobalVariableType gvtype = RS::GLOBAL_VAR_TYPE_MAX;
+			RS::GlobalShaderUniformType gvtype = RS::GLOBAL_VAR_TYPE_MAX;
 
 			for (int i = 0; i < RS::GLOBAL_VAR_TYPE_MAX; i++) {
 				if (global_var_type_names[i] == type) {
-					gvtype = RS::GlobalVariableType(i);
+					gvtype = RS::GlobalShaderUniformType(i);
 					break;
 				}
 			}
@@ -2172,47 +2172,47 @@ void MaterialStorage::global_variables_load_settings(bool p_load_textures) {
 				value = resource;
 			}
 
-			if (global_variables.variables.has(name)) {
+			if (global_shader_uniforms.variables.has(name)) {
 				//has it, update it
-				global_variable_set(name, value);
+				global_shader_uniform_set(name, value);
 			} else {
-				global_variable_add(name, gvtype, value);
+				global_shader_uniform_add(name, gvtype, value);
 			}
 		}
 	}
 }
 
-void MaterialStorage::global_variables_clear() {
-	global_variables.variables.clear(); //not right but for now enough
+void MaterialStorage::global_shader_uniforms_clear() {
+	global_shader_uniforms.variables.clear(); //not right but for now enough
 }
 
-RID MaterialStorage::global_variables_get_storage_buffer() const {
-	return global_variables.buffer;
+RID MaterialStorage::global_shader_uniforms_get_storage_buffer() const {
+	return global_shader_uniforms.buffer;
 }
 
-int32_t MaterialStorage::global_variables_instance_allocate(RID p_instance) {
-	ERR_FAIL_COND_V(global_variables.instance_buffer_pos.has(p_instance), -1);
-	int32_t pos = _global_variable_allocate(ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES);
-	global_variables.instance_buffer_pos[p_instance] = pos; //save anyway
+int32_t MaterialStorage::global_shader_uniforms_instance_allocate(RID p_instance) {
+	ERR_FAIL_COND_V(global_shader_uniforms.instance_buffer_pos.has(p_instance), -1);
+	int32_t pos = _global_shader_uniform_allocate(ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES);
+	global_shader_uniforms.instance_buffer_pos[p_instance] = pos; //save anyway
 	ERR_FAIL_COND_V_MSG(pos < 0, -1, "Too many instances using shader instance variables. Increase buffer size in Project Settings.");
-	global_variables.buffer_usage[pos].elements = ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES;
+	global_shader_uniforms.buffer_usage[pos].elements = ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES;
 	return pos;
 }
 
-void MaterialStorage::global_variables_instance_free(RID p_instance) {
-	ERR_FAIL_COND(!global_variables.instance_buffer_pos.has(p_instance));
-	int32_t pos = global_variables.instance_buffer_pos[p_instance];
+void MaterialStorage::global_shader_uniforms_instance_free(RID p_instance) {
+	ERR_FAIL_COND(!global_shader_uniforms.instance_buffer_pos.has(p_instance));
+	int32_t pos = global_shader_uniforms.instance_buffer_pos[p_instance];
 	if (pos >= 0) {
-		global_variables.buffer_usage[pos].elements = 0;
+		global_shader_uniforms.buffer_usage[pos].elements = 0;
 	}
-	global_variables.instance_buffer_pos.erase(p_instance);
+	global_shader_uniforms.instance_buffer_pos.erase(p_instance);
 }
 
-void MaterialStorage::global_variables_instance_update(RID p_instance, int p_index, const Variant &p_value) {
-	if (!global_variables.instance_buffer_pos.has(p_instance)) {
+void MaterialStorage::global_shader_uniforms_instance_update(RID p_instance, int p_index, const Variant &p_value) {
+	if (!global_shader_uniforms.instance_buffer_pos.has(p_instance)) {
 		return; //just not allocated, ignore
 	}
-	int32_t pos = global_variables.instance_buffer_pos[p_instance];
+	int32_t pos = global_shader_uniforms.instance_buffer_pos[p_instance];
 
 	if (pos < 0) {
 		return; //again, not allocated, ignore
@@ -2247,57 +2247,57 @@ void MaterialStorage::global_variables_instance_update(RID p_instance, int p_ind
 
 	pos += p_index;
 
-	_fill_std140_variant_ubo_value(datatype, 0, p_value, (uint8_t *)&global_variables.buffer_values[pos], true); //instances always use linear color in this renderer
-	_global_variable_mark_buffer_dirty(pos, 1);
+	_fill_std140_variant_ubo_value(datatype, 0, p_value, (uint8_t *)&global_shader_uniforms.buffer_values[pos], true); //instances always use linear color in this renderer
+	_global_shader_uniform_mark_buffer_dirty(pos, 1);
 }
 
-void MaterialStorage::_update_global_variables() {
+void MaterialStorage::_update_global_shader_uniforms() {
 	MaterialStorage *material_storage = MaterialStorage::get_singleton();
-	if (global_variables.buffer_dirty_region_count > 0) {
-		uint32_t total_regions = global_variables.buffer_size / GlobalVariables::BUFFER_DIRTY_REGION_SIZE;
-		if (total_regions / global_variables.buffer_dirty_region_count <= 4) {
+	if (global_shader_uniforms.buffer_dirty_region_count > 0) {
+		uint32_t total_regions = global_shader_uniforms.buffer_size / GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE;
+		if (total_regions / global_shader_uniforms.buffer_dirty_region_count <= 4) {
 			// 25% of regions dirty, just update all buffer
-			RD::get_singleton()->buffer_update(global_variables.buffer, 0, sizeof(GlobalVariables::Value) * global_variables.buffer_size, global_variables.buffer_values);
-			memset(global_variables.buffer_dirty_regions, 0, sizeof(bool) * total_regions);
+			RD::get_singleton()->buffer_update(global_shader_uniforms.buffer, 0, sizeof(GlobalShaderUniforms::Value) * global_shader_uniforms.buffer_size, global_shader_uniforms.buffer_values);
+			memset(global_shader_uniforms.buffer_dirty_regions, 0, sizeof(bool) * total_regions);
 		} else {
-			uint32_t region_byte_size = sizeof(GlobalVariables::Value) * GlobalVariables::BUFFER_DIRTY_REGION_SIZE;
+			uint32_t region_byte_size = sizeof(GlobalShaderUniforms::Value) * GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE;
 
 			for (uint32_t i = 0; i < total_regions; i++) {
-				if (global_variables.buffer_dirty_regions[i]) {
-					RD::get_singleton()->buffer_update(global_variables.buffer, i * region_byte_size, region_byte_size, &global_variables.buffer_values[i * GlobalVariables::BUFFER_DIRTY_REGION_SIZE]);
+				if (global_shader_uniforms.buffer_dirty_regions[i]) {
+					RD::get_singleton()->buffer_update(global_shader_uniforms.buffer, i * region_byte_size, region_byte_size, &global_shader_uniforms.buffer_values[i * GlobalShaderUniforms::BUFFER_DIRTY_REGION_SIZE]);
 
-					global_variables.buffer_dirty_regions[i] = false;
+					global_shader_uniforms.buffer_dirty_regions[i] = false;
 				}
 			}
 		}
 
-		global_variables.buffer_dirty_region_count = 0;
+		global_shader_uniforms.buffer_dirty_region_count = 0;
 	}
 
-	if (global_variables.must_update_buffer_materials) {
+	if (global_shader_uniforms.must_update_buffer_materials) {
 		// only happens in the case of a buffer variable added or removed,
 		// so not often.
-		for (const RID &E : global_variables.materials_using_buffer) {
+		for (const RID &E : global_shader_uniforms.materials_using_buffer) {
 			Material *material = material_storage->get_material(E);
 			ERR_CONTINUE(!material); //wtf
 
 			material_storage->_material_queue_update(material, true, false);
 		}
 
-		global_variables.must_update_buffer_materials = false;
+		global_shader_uniforms.must_update_buffer_materials = false;
 	}
 
-	if (global_variables.must_update_texture_materials) {
+	if (global_shader_uniforms.must_update_texture_materials) {
 		// only happens in the case of a buffer variable added or removed,
 		// so not often.
-		for (const RID &E : global_variables.materials_using_texture) {
+		for (const RID &E : global_shader_uniforms.materials_using_texture) {
 			Material *material = material_storage->get_material(E);
 			ERR_CONTINUE(!material); //wtf
 
 			material_storage->_material_queue_update(material, false, true);
 		}
 
-		global_variables.must_update_texture_materials = false;
+		global_shader_uniforms.must_update_texture_materials = false;
 	}
 }
 

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -135,15 +135,15 @@ struct Material {
 			update_element(this) {}
 };
 
-/* Global variable structs */
-struct GlobalVariables {
+/* Global shader uniform structs */
+struct GlobalShaderUniforms {
 	enum {
 		BUFFER_DIRTY_REGION_SIZE = 1024
 	};
 	struct Variable {
 		HashSet<RID> texture_materials; // materials using this
 
-		RS::GlobalVariableType type;
+		RS::GlobalShaderUniformType type;
 		Variant value;
 		Variant override;
 		int32_t buffer_index; //for vectors
@@ -209,13 +209,13 @@ private:
 	RID quad_index_buffer;
 	RID quad_index_array;
 
-	/* GLOBAL VARIABLE API */
+	/* GLOBAL SHADER UNIFORM API */
 
-	GlobalVariables global_variables;
+	GlobalShaderUniforms global_shader_uniforms;
 
-	int32_t _global_variable_allocate(uint32_t p_elements);
-	void _global_variable_store_in_buffer(int32_t p_index, RS::GlobalVariableType p_type, const Variant &p_value);
-	void _global_variable_mark_buffer_dirty(int32_t p_index, int32_t p_elements);
+	int32_t _global_shader_uniform_allocate(uint32_t p_elements);
+	void _global_shader_uniform_store_in_buffer(int32_t p_index, RS::GlobalShaderUniformType p_type, const Variant &p_value);
+	void _global_shader_uniform_mark_buffer_dirty(int32_t p_index, int32_t p_elements);
 
 	/* SHADER API */
 
@@ -333,28 +333,28 @@ public:
 
 	RID get_quad_index_array() { return quad_index_array; }
 
-	/* GLOBAL VARIABLE API */
+	/* GLOBAL SHADER UNIFORM API */
 
-	void _update_global_variables();
+	void _update_global_shader_uniforms();
 
-	virtual void global_variable_add(const StringName &p_name, RS::GlobalVariableType p_type, const Variant &p_value) override;
-	virtual void global_variable_remove(const StringName &p_name) override;
-	virtual Vector<StringName> global_variable_get_list() const override;
+	virtual void global_shader_uniform_add(const StringName &p_name, RS::GlobalShaderUniformType p_type, const Variant &p_value) override;
+	virtual void global_shader_uniform_remove(const StringName &p_name) override;
+	virtual Vector<StringName> global_shader_uniform_get_list() const override;
 
-	virtual void global_variable_set(const StringName &p_name, const Variant &p_value) override;
-	virtual void global_variable_set_override(const StringName &p_name, const Variant &p_value) override;
-	virtual Variant global_variable_get(const StringName &p_name) const override;
-	virtual RS::GlobalVariableType global_variable_get_type(const StringName &p_name) const override;
-	RS::GlobalVariableType global_variable_get_type_internal(const StringName &p_name) const;
+	virtual void global_shader_uniform_set(const StringName &p_name, const Variant &p_value) override;
+	virtual void global_shader_uniform_set_override(const StringName &p_name, const Variant &p_value) override;
+	virtual Variant global_shader_uniform_get(const StringName &p_name) const override;
+	virtual RS::GlobalShaderUniformType global_shader_uniform_get_type(const StringName &p_name) const override;
+	RS::GlobalShaderUniformType global_shader_uniform_get_type_internal(const StringName &p_name) const;
 
-	virtual void global_variables_load_settings(bool p_load_textures = true) override;
-	virtual void global_variables_clear() override;
+	virtual void global_shader_uniforms_load_settings(bool p_load_textures = true) override;
+	virtual void global_shader_uniforms_clear() override;
 
-	virtual int32_t global_variables_instance_allocate(RID p_instance) override;
-	virtual void global_variables_instance_free(RID p_instance) override;
-	virtual void global_variables_instance_update(RID p_instance, int p_index, const Variant &p_value) override;
+	virtual int32_t global_shader_uniforms_instance_allocate(RID p_instance) override;
+	virtual void global_shader_uniforms_instance_free(RID p_instance) override;
+	virtual void global_shader_uniforms_instance_update(RID p_instance, int p_index, const Variant &p_value) override;
 
-	RID global_variables_get_storage_buffer() const;
+	RID global_shader_uniforms_get_storage_buffer() const;
 
 	/* SHADER API */
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -112,7 +112,7 @@ ParticlesStorage::ParticlesStorage() {
 
 		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
 		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
-		actions.global_buffer_array_variable = "global_variables.data";
+		actions.global_buffer_array_variable = "global_shader_uniforms.data";
 
 		particles_shader.compiler.initialize(actions);
 	}
@@ -164,7 +164,7 @@ void process() {
 			RD::Uniform u;
 			u.uniform_type = RD::UNIFORM_TYPE_STORAGE_BUFFER;
 			u.binding = 2;
-			u.append_id(material_storage->global_variables_get_storage_buffer());
+			u.append_id(material_storage->global_shader_uniforms_get_storage_buffer());
 			uniforms.push_back(u);
 		}
 

--- a/servers/rendering/renderer_rd/storage_rd/utilities.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/utilities.cpp
@@ -272,7 +272,7 @@ String Utilities::get_captured_timestamp_name(uint32_t p_index) const {
 /* MISC */
 
 void Utilities::update_dirty_resources() {
-	MaterialStorage::get_singleton()->_update_global_variables(); //must do before materials, so it can queue them for update
+	MaterialStorage::get_singleton()->_update_global_shader_uniforms(); //must do before materials, so it can queue them for update
 	MaterialStorage::get_singleton()->_update_queued_materials();
 	MeshStorage::get_singleton()->_update_dirty_multimeshes();
 	MeshStorage::get_singleton()->_update_dirty_skeletons();

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -1441,7 +1441,7 @@ void RendererSceneCull::instance_geometry_set_shader_parameter(RID p_instance, c
 		E->value.value = p_value;
 		if (E->value.index >= 0 && instance->instance_allocated_shader_parameters) {
 			//update directly
-			RSG::material_storage->global_variables_instance_update(p_instance, E->value.index, p_value);
+			RSG::material_storage->global_shader_uniforms_instance_update(p_instance, E->value.index, p_value);
 		}
 	}
 }
@@ -3850,16 +3850,16 @@ void RendererSceneCull::_update_dirty_instance(Instance *p_instance) {
 			if (p_instance->instance_allocated_shader_parameters != (p_instance->instance_shader_parameters.size() > 0)) {
 				p_instance->instance_allocated_shader_parameters = (p_instance->instance_shader_parameters.size() > 0);
 				if (p_instance->instance_allocated_shader_parameters) {
-					p_instance->instance_allocated_shader_parameters_offset = RSG::material_storage->global_variables_instance_allocate(p_instance->self);
+					p_instance->instance_allocated_shader_parameters_offset = RSG::material_storage->global_shader_uniforms_instance_allocate(p_instance->self);
 					geom->geometry_instance->set_instance_shader_parameters_offset(p_instance->instance_allocated_shader_parameters_offset);
 
 					for (const KeyValue<StringName, Instance::InstanceShaderParameter> &E : p_instance->instance_shader_parameters) {
 						if (E.value.value.get_type() != Variant::NIL) {
-							RSG::material_storage->global_variables_instance_update(p_instance->self, E.value.index, E.value.value);
+							RSG::material_storage->global_shader_uniforms_instance_update(p_instance->self, E.value.index, E.value.value);
 						}
 					}
 				} else {
-					RSG::material_storage->global_variables_instance_free(p_instance->self);
+					RSG::material_storage->global_shader_uniforms_instance_free(p_instance->self);
 					p_instance->instance_allocated_shader_parameters_offset = -1;
 					geom->geometry_instance->set_instance_shader_parameters_offset(-1);
 				}
@@ -3955,7 +3955,7 @@ bool RendererSceneCull::free(RID p_rid) {
 
 		if (instance->instance_allocated_shader_parameters) {
 			//free the used shader parameters
-			RSG::material_storage->global_variables_instance_free(instance->self);
+			RSG::material_storage->global_shader_uniforms_instance_free(instance->self);
 		}
 		update_dirty_instances(); //in case something changed this
 

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -900,7 +900,7 @@ public:
 
 	FUNC1(canvas_set_shadow_texture_size, int)
 
-	/* GLOBAL VARIABLES */
+	/* GLOBAL SHADER UNIFORMS */
 
 #undef server_name
 #undef ServerName
@@ -908,16 +908,16 @@ public:
 #define ServerName RendererMaterialStorage
 #define server_name RSG::material_storage
 
-	FUNC3(global_variable_add, const StringName &, GlobalVariableType, const Variant &)
-	FUNC1(global_variable_remove, const StringName &)
-	FUNC0RC(Vector<StringName>, global_variable_get_list)
-	FUNC2(global_variable_set, const StringName &, const Variant &)
-	FUNC2(global_variable_set_override, const StringName &, const Variant &)
-	FUNC1RC(GlobalVariableType, global_variable_get_type, const StringName &)
-	FUNC1RC(Variant, global_variable_get, const StringName &)
+	FUNC3(global_shader_uniform_add, const StringName &, GlobalShaderUniformType, const Variant &)
+	FUNC1(global_shader_uniform_remove, const StringName &)
+	FUNC0RC(Vector<StringName>, global_shader_uniform_get_list)
+	FUNC2(global_shader_uniform_set, const StringName &, const Variant &)
+	FUNC2(global_shader_uniform_set_override, const StringName &, const Variant &)
+	FUNC1RC(GlobalShaderUniformType, global_shader_uniform_get_type, const StringName &)
+	FUNC1RC(Variant, global_shader_uniform_get, const StringName &)
 
-	FUNC1(global_variables_load_settings, bool)
-	FUNC0(global_variables_clear)
+	FUNC1(global_shader_uniforms_load_settings, bool)
+	FUNC0(global_shader_uniforms_clear)
 
 #undef server_name
 #undef ServerName

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -370,7 +370,7 @@ void ShaderCompiler::_dump_function_deps(const SL::ShaderNode *p_node, const Str
 	}
 }
 
-static String _get_global_variable_from_type_and_index(const String &p_buffer, const String &p_index, ShaderLanguage::DataType p_type) {
+static String _get_global_shader_uniform_from_type_and_index(const String &p_buffer, const String &p_index, ShaderLanguage::DataType p_type) {
 	switch (p_type) {
 		case ShaderLanguage::TYPE_BOOL: {
 			return "(" + p_buffer + "[" + p_index + "].x != 0.0)";
@@ -903,11 +903,11 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 						if (u.scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_GLOBAL) {
 							code = actions.base_uniform_string + _mkid(vnode->name); //texture, use as is
 							//global variable, this means the code points to an index to the global table
-							code = _get_global_variable_from_type_and_index(p_default_actions.global_buffer_array_variable, code, u.type);
+							code = _get_global_shader_uniform_from_type_and_index(p_default_actions.global_buffer_array_variable, code, u.type);
 						} else if (u.scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
 							//instance variable, index it as such
 							code = "(" + p_default_actions.instance_uniform_index_variable + "+" + itos(u.instance_index) + ")";
-							code = _get_global_variable_from_type_and_index(p_default_actions.global_buffer_array_variable, code, u.type);
+							code = _get_global_shader_uniform_from_type_and_index(p_default_actions.global_buffer_array_variable, code, u.type);
 						} else {
 							//regular uniform, index from UBO
 							code = actions.base_uniform_string + _mkid(vnode->name);
@@ -1003,11 +1003,11 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 						if (u.scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_GLOBAL) {
 							code = actions.base_uniform_string + _mkid(anode->name); //texture, use as is
 							//global variable, this means the code points to an index to the global table
-							code = _get_global_variable_from_type_and_index(p_default_actions.global_buffer_array_variable, code, u.type);
+							code = _get_global_shader_uniform_from_type_and_index(p_default_actions.global_buffer_array_variable, code, u.type);
 						} else if (u.scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
 							//instance variable, index it as such
 							code = "(" + p_default_actions.instance_uniform_index_variable + "+" + itos(u.instance_index) + ")";
-							code = _get_global_variable_from_type_and_index(p_default_actions.global_buffer_array_variable, code, u.type);
+							code = _get_global_shader_uniform_from_type_and_index(p_default_actions.global_buffer_array_variable, code, u.type);
 						} else {
 							//regular uniform, index from UBO
 							code = actions.base_uniform_string + _mkid(anode->name);
@@ -1309,8 +1309,8 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 }
 
 ShaderLanguage::DataType ShaderCompiler::_get_variable_type(const StringName &p_type) {
-	RS::GlobalVariableType gvt = RS::get_singleton()->global_variable_get_type(p_type);
-	return (ShaderLanguage::DataType)RS::global_variable_type_get_shader_datatype(gvt);
+	RS::GlobalShaderUniformType gvt = RS::get_singleton()->global_shader_uniform_get_type(p_type);
+	return (ShaderLanguage::DataType)RS::global_shader_uniform_type_get_shader_datatype(gvt);
 }
 
 Error ShaderCompiler::compile(RS::ShaderMode p_mode, const String &p_code, IdentifierActions *p_actions, const String &p_path, GeneratedCode &r_gen_code) {
@@ -1318,7 +1318,7 @@ Error ShaderCompiler::compile(RS::ShaderMode p_mode, const String &p_code, Ident
 	info.functions = ShaderTypes::get_singleton()->get_functions(p_mode);
 	info.render_modes = ShaderTypes::get_singleton()->get_modes(p_mode);
 	info.shader_types = ShaderTypes::get_singleton()->get_types();
-	info.global_variable_type_func = _get_variable_type;
+	info.global_shader_uniform_type_func = _get_variable_type;
 
 	Error err = parser.compile(p_code, info);
 

--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -8277,7 +8277,7 @@ Error ShaderLanguage::_parse_shader(const HashMap<StringName, FunctionInfo> &p_f
 				if (is_uniform) {
 					if (uniform_scope == ShaderNode::Uniform::SCOPE_GLOBAL && Engine::get_singleton()->is_editor_hint()) { // Type checking for global uniforms is not allowed outside the editor.
 						//validate global uniform
-						DataType gvtype = global_var_get_type_func(name);
+						DataType gvtype = global_shader_uniform_get_type_func(name);
 						if (gvtype == TYPE_MAX) {
 							_set_error(vformat(RTR("Global uniform '%s' does not exist. Create it in Project Settings."), String(name)));
 							return ERR_PARSE_ERROR;
@@ -9652,7 +9652,7 @@ Error ShaderLanguage::compile(const String &p_code, const ShaderCompileInfo &p_i
 	is_shader_inc = p_info.is_include;
 
 	code = p_code;
-	global_var_get_type_func = p_info.global_variable_type_func;
+	global_shader_uniform_get_type_func = p_info.global_shader_uniform_type_func;
 
 	varying_function_names = p_info.varying_function_names;
 
@@ -9681,7 +9681,7 @@ Error ShaderLanguage::complete(const String &p_code, const ShaderCompileInfo &p_
 	varying_function_names = p_info.varying_function_names;
 
 	nodes = nullptr;
-	global_var_get_type_func = p_info.global_variable_type_func;
+	global_shader_uniform_get_type_func = p_info.global_shader_uniform_type_func;
 
 	shader = alloc_node<ShaderNode>();
 	_parse_shader(p_info.functions, p_info.render_modes, p_info.shader_types);

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -869,7 +869,7 @@ public:
 	};
 	static bool has_builtin(const HashMap<StringName, ShaderLanguage::FunctionInfo> &p_functions, const StringName &p_name);
 
-	typedef DataType (*GlobalVariableGetTypeFunc)(const StringName &p_name);
+	typedef DataType (*GlobalShaderUniformGetTypeFunc)(const StringName &p_name);
 
 	struct FilePosition {
 		String file;
@@ -887,7 +887,7 @@ private:
 
 	static const KeyWord keyword_list[];
 
-	GlobalVariableGetTypeFunc global_var_get_type_func = nullptr;
+	GlobalShaderUniformGetTypeFunc global_shader_uniform_get_type_func = nullptr;
 
 	bool error_set = false;
 	String error_str;
@@ -1113,7 +1113,7 @@ public:
 		Vector<ModeInfo> render_modes;
 		VaryingFunctionNames varying_function_names = VaryingFunctionNames();
 		HashSet<String> shader_types;
-		GlobalVariableGetTypeFunc global_variable_type_func = nullptr;
+		GlobalShaderUniformGetTypeFunc global_shader_uniform_type_func = nullptr;
 		bool is_include = false;
 	};
 

--- a/servers/rendering/storage/material_storage.h
+++ b/servers/rendering/storage/material_storage.h
@@ -38,22 +38,22 @@ class RendererMaterialStorage {
 public:
 	virtual ~RendererMaterialStorage(){};
 
-	/* GLOBAL VARIABLE API */
-	virtual void global_variable_add(const StringName &p_name, RS::GlobalVariableType p_type, const Variant &p_value) = 0;
-	virtual void global_variable_remove(const StringName &p_name) = 0;
-	virtual Vector<StringName> global_variable_get_list() const = 0;
+	/* GLOBAL SHADER UNIFORM API */
+	virtual void global_shader_uniform_add(const StringName &p_name, RS::GlobalShaderUniformType p_type, const Variant &p_value) = 0;
+	virtual void global_shader_uniform_remove(const StringName &p_name) = 0;
+	virtual Vector<StringName> global_shader_uniform_get_list() const = 0;
 
-	virtual void global_variable_set(const StringName &p_name, const Variant &p_value) = 0;
-	virtual void global_variable_set_override(const StringName &p_name, const Variant &p_value) = 0;
-	virtual Variant global_variable_get(const StringName &p_name) const = 0;
-	virtual RS::GlobalVariableType global_variable_get_type(const StringName &p_name) const = 0;
+	virtual void global_shader_uniform_set(const StringName &p_name, const Variant &p_value) = 0;
+	virtual void global_shader_uniform_set_override(const StringName &p_name, const Variant &p_value) = 0;
+	virtual Variant global_shader_uniform_get(const StringName &p_name) const = 0;
+	virtual RS::GlobalShaderUniformType global_shader_uniform_get_type(const StringName &p_name) const = 0;
 
-	virtual void global_variables_load_settings(bool p_load_textures = true) = 0;
-	virtual void global_variables_clear() = 0;
+	virtual void global_shader_uniforms_load_settings(bool p_load_textures = true) = 0;
+	virtual void global_shader_uniforms_clear() = 0;
 
-	virtual int32_t global_variables_instance_allocate(RID p_instance) = 0;
-	virtual void global_variables_instance_free(RID p_instance) = 0;
-	virtual void global_variables_instance_update(RID p_instance, int p_index, const Variant &p_value) = 0;
+	virtual int32_t global_shader_uniforms_instance_allocate(RID p_instance) = 0;
+	virtual void global_shader_uniforms_instance_free(RID p_instance) = 0;
+	virtual void global_shader_uniforms_instance_update(RID p_instance, int p_index, const Variant &p_value) = 0;
 
 	/* SHADER API */
 	virtual RID shader_allocate() = 0;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1410,7 +1410,7 @@ Array RenderingServer::_mesh_surface_get_skeleton_aabb_bind(RID p_mesh, int p_su
 }
 #endif
 
-int RenderingServer::global_variable_type_get_shader_datatype(GlobalVariableType p_type) {
+int RenderingServer::global_shader_uniform_type_get_shader_datatype(GlobalShaderUniformType p_type) {
 	switch (p_type) {
 		case RS::GLOBAL_VAR_TYPE_BOOL:
 			return ShaderLanguage::TYPE_BOOL;
@@ -2690,15 +2690,15 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(CANVAS_OCCLUDER_POLYGON_CULL_CLOCKWISE);
 	BIND_ENUM_CONSTANT(CANVAS_OCCLUDER_POLYGON_CULL_COUNTER_CLOCKWISE);
 
-	/* GLOBAL VARIABLES */
+	/* GLOBAL SHADER UNIFORMS */
 
-	ClassDB::bind_method(D_METHOD("global_variable_add", "name", "type", "default_value"), &RenderingServer::global_variable_add);
-	ClassDB::bind_method(D_METHOD("global_variable_remove", "name"), &RenderingServer::global_variable_remove);
-	ClassDB::bind_method(D_METHOD("global_variable_get_list"), &RenderingServer::global_variable_get_list);
-	ClassDB::bind_method(D_METHOD("global_variable_set", "name", "value"), &RenderingServer::global_variable_set);
-	ClassDB::bind_method(D_METHOD("global_variable_set_override", "name", "value"), &RenderingServer::global_variable_set_override);
-	ClassDB::bind_method(D_METHOD("global_variable_get", "name"), &RenderingServer::global_variable_get);
-	ClassDB::bind_method(D_METHOD("global_variable_get_type", "name"), &RenderingServer::global_variable_get_type);
+	ClassDB::bind_method(D_METHOD("global_shader_uniform_add", "name", "type", "default_value"), &RenderingServer::global_shader_uniform_add);
+	ClassDB::bind_method(D_METHOD("global_shader_uniform_remove", "name"), &RenderingServer::global_shader_uniform_remove);
+	ClassDB::bind_method(D_METHOD("global_shader_uniform_get_list"), &RenderingServer::global_shader_uniform_get_list);
+	ClassDB::bind_method(D_METHOD("global_shader_uniform_set", "name", "value"), &RenderingServer::global_shader_uniform_set);
+	ClassDB::bind_method(D_METHOD("global_shader_uniform_set_override", "name", "value"), &RenderingServer::global_shader_uniform_set_override);
+	ClassDB::bind_method(D_METHOD("global_shader_uniform_get", "name"), &RenderingServer::global_shader_uniform_get);
+	ClassDB::bind_method(D_METHOD("global_shader_uniform_get_type", "name"), &RenderingServer::global_shader_uniform_get_type);
 
 	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_BOOL);
 	BIND_ENUM_CONSTANT(GLOBAL_VAR_TYPE_BVEC2);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1425,9 +1425,9 @@ public:
 
 	virtual void canvas_set_shadow_texture_size(int p_size) = 0;
 
-	/* GLOBAL VARIABLES */
+	/* GLOBAL SHADER UNIFORMS */
 
-	enum GlobalVariableType {
+	enum GlobalShaderUniformType {
 		GLOBAL_VAR_TYPE_BOOL,
 		GLOBAL_VAR_TYPE_BVEC2,
 		GLOBAL_VAR_TYPE_BVEC3,
@@ -1459,20 +1459,20 @@ public:
 		GLOBAL_VAR_TYPE_MAX
 	};
 
-	virtual void global_variable_add(const StringName &p_name, GlobalVariableType p_type, const Variant &p_value) = 0;
-	virtual void global_variable_remove(const StringName &p_name) = 0;
-	virtual Vector<StringName> global_variable_get_list() const = 0;
+	virtual void global_shader_uniform_add(const StringName &p_name, GlobalShaderUniformType p_type, const Variant &p_value) = 0;
+	virtual void global_shader_uniform_remove(const StringName &p_name) = 0;
+	virtual Vector<StringName> global_shader_uniform_get_list() const = 0;
 
-	virtual void global_variable_set(const StringName &p_name, const Variant &p_value) = 0;
-	virtual void global_variable_set_override(const StringName &p_name, const Variant &p_value) = 0;
+	virtual void global_shader_uniform_set(const StringName &p_name, const Variant &p_value) = 0;
+	virtual void global_shader_uniform_set_override(const StringName &p_name, const Variant &p_value) = 0;
 
-	virtual Variant global_variable_get(const StringName &p_name) const = 0;
-	virtual GlobalVariableType global_variable_get_type(const StringName &p_name) const = 0;
+	virtual Variant global_shader_uniform_get(const StringName &p_name) const = 0;
+	virtual GlobalShaderUniformType global_shader_uniform_get_type(const StringName &p_name) const = 0;
 
-	virtual void global_variables_load_settings(bool p_load_textures) = 0;
-	virtual void global_variables_clear() = 0;
+	virtual void global_shader_uniforms_load_settings(bool p_load_textures) = 0;
+	virtual void global_shader_uniforms_clear() = 0;
 
-	static int global_variable_type_get_shader_datatype(GlobalVariableType p_type);
+	static int global_shader_uniform_type_get_shader_datatype(GlobalShaderUniformType p_type);
 
 	/* FREE */
 
@@ -1648,7 +1648,7 @@ VARIANT_ENUM_CAST(RenderingServer::CanvasLightMode);
 VARIANT_ENUM_CAST(RenderingServer::CanvasLightBlendMode);
 VARIANT_ENUM_CAST(RenderingServer::CanvasLightShadowFilter);
 VARIANT_ENUM_CAST(RenderingServer::CanvasOccluderPolygonCullMode);
-VARIANT_ENUM_CAST(RenderingServer::GlobalVariableType);
+VARIANT_ENUM_CAST(RenderingServer::GlobalShaderUniformType);
 VARIANT_ENUM_CAST(RenderingServer::RenderingInfo);
 VARIANT_ENUM_CAST(RenderingServer::Features);
 VARIANT_ENUM_CAST(RenderingServer::CanvasTextureChannel);

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -257,7 +257,7 @@ struct GodotTestCaseListener : public doctest::IReporter {
 
 		if (RenderingServer::get_singleton()) {
 			RenderingServer::get_singleton()->sync();
-			RenderingServer::get_singleton()->global_variables_clear();
+			RenderingServer::get_singleton()->global_shader_uniforms_clear();
 			RenderingServer::get_singleton()->finish();
 			memdelete(RenderingServer::get_singleton());
 		}


### PR DESCRIPTION
The `global_shader_uniform` name is longer, but it makes it much easier to find the methods when searching in the class reference.

These methods aren't present in `3.x`, but some people may be using those from earlier 4.0 alphas already.

This closes https://github.com/godotengine/godot/issues/59645. See https://github.com/godotengine/godot/issues/54161#issuecomment-1086916469.

PS: What should we do about the ShaderGlobalsOverride node? It doesn't have any exposed properties or methods.
