### PR TITLE
Rename shader parameter uniform setter/getter methods for consistency

### DIFF
--- a/doc/classes/GeometryInstance3D.xml
+++ b/doc/classes/GeometryInstance3D.xml
@@ -9,7 +9,7 @@
 	<tutorials>
 	</tutorials>
 	<methods>
-		<method name="get_shader_instance_uniform" qualifiers="const">
+		<method name="get_instance_shader_uniform" qualifiers="const">
 			<return type="Variant" />
 			<argument index="0" name="uniform" type="StringName" />
 			<description>
@@ -22,7 +22,7 @@
 				Overrides the bounding box of this node with a custom one. To remove it, set an [AABB] with all fields set to zero.
 			</description>
 		</method>
-		<method name="set_shader_instance_uniform">
+		<method name="set_instance_shader_uniform">
 			<return type="void" />
 			<argument index="0" name="uniform" type="StringName" />
 			<argument index="1" name="value" type="Variant" />

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1391,21 +1391,21 @@
 				Once finished with your RID, you will want to free the RID using the RenderingServer's [method free_rid] static method.
 			</description>
 		</method>
-		<method name="instance_geometry_get_shader_parameter" qualifiers="const">
+		<method name="instance_geometry_get_shader_uniform" qualifiers="const">
 			<return type="Variant" />
 			<argument index="0" name="instance" type="RID" />
 			<argument index="1" name="parameter" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="instance_geometry_get_shader_parameter_default_value" qualifiers="const">
+		<method name="instance_geometry_get_shader_uniform_default_value" qualifiers="const">
 			<return type="Variant" />
 			<argument index="0" name="instance" type="RID" />
 			<argument index="1" name="parameter" type="StringName" />
 			<description>
 			</description>
 		</method>
-		<method name="instance_geometry_get_shader_parameter_list" qualifiers="const">
+		<method name="instance_geometry_get_shader_uniform_list" qualifiers="const">
 			<return type="Array" />
 			<argument index="0" name="instance" type="RID" />
 			<description>
@@ -1460,7 +1460,7 @@
 				Sets a material that will override the material for all surfaces on the mesh associated with this instance. Equivalent to [member GeometryInstance3D.material_override].
 			</description>
 		</method>
-		<method name="instance_geometry_set_shader_parameter">
+		<method name="instance_geometry_set_shader_uniform">
 			<return type="void" />
 			<argument index="0" name="instance" type="RID" />
 			<argument index="1" name="parameter" type="StringName" />
@@ -2741,7 +2741,7 @@
 			<description>
 			</description>
 		</method>
-		<method name="shader_get_param_list" qualifiers="const">
+		<method name="shader_get_shader_uniform_list" qualifiers="const">
 			<return type="Dictionary[]" />
 			<argument index="0" name="shader" type="RID" />
 			<description>

--- a/doc/classes/Shader.xml
+++ b/doc/classes/Shader.xml
@@ -26,7 +26,7 @@
 				Returns the shader mode for the shader, either [constant MODE_CANVAS_ITEM], [constant MODE_SPATIAL] or [constant MODE_PARTICLES].
 			</description>
 		</method>
-		<method name="has_param" qualifiers="const">
+		<method name="has_uniform" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="name" type="StringName" />
 			<description>

--- a/doc/classes/ShaderMaterial.xml
+++ b/doc/classes/ShaderMaterial.xml
@@ -10,7 +10,7 @@
 		<link title="Shaders documentation index">$DOCS_URL/tutorials/shaders/index.html</link>
 	</tutorials>
 	<methods>
-		<method name="get_shader_param" qualifiers="const">
+		<method name="get_shader_uniform" qualifiers="const">
 			<return type="Variant" />
 			<argument index="0" name="param" type="StringName" />
 			<description>
@@ -31,7 +31,7 @@
 				Returns the default value of the material property with given [code]name[/code].
 			</description>
 		</method>
-		<method name="set_shader_param">
+		<method name="set_shader_uniform">
 			<return type="void" />
 			<argument index="0" name="param" type="StringName" />
 			<argument index="1" name="value" type="Variant" />

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2522,11 +2522,11 @@ String MaterialStorage::shader_get_code(RID p_shader) const {
 	return shader->code;
 }
 
-void MaterialStorage::shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const {
+void MaterialStorage::shader_get_shader_uniform_list(RID p_shader, List<PropertyInfo> *p_param_list) const {
 	GLES3::Shader *shader = shader_owner.get_or_null(p_shader);
 	ERR_FAIL_COND(!shader);
 	if (shader->data) {
-		return shader->data->get_param_list(p_param_list);
+		return shader->data->get_shader_uniform_list(p_param_list);
 	}
 }
 
@@ -2758,14 +2758,14 @@ bool MaterialStorage::material_casts_shadows(RID p_material) {
 	return true; //by default everything casts shadows
 }
 
-void MaterialStorage::material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) {
+void MaterialStorage::material_get_instance_shader_uniforms(RID p_material, List<InstanceShaderParam> *r_parameters) {
 	GLES3::Material *material = material_owner.get_or_null(p_material);
 	ERR_FAIL_COND(!material);
 	if (material->shader && material->shader->data) {
 		material->shader->data->get_instance_param_list(r_parameters);
 
 		if (material->next_pass.is_valid()) {
-			material_get_instance_shader_parameters(material->next_pass, r_parameters);
+			material_get_instance_shader_uniforms(material->next_pass, r_parameters);
 		}
 	}
 }
@@ -2873,7 +2873,7 @@ void CanvasShaderData::set_default_texture_param(const StringName &p_name, RID p
 	}
 }
 
-void CanvasShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
+void CanvasShaderData::get_shader_uniform_list(List<PropertyInfo> *p_param_list) const {
 	HashMap<int, StringName> order;
 
 	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {
@@ -3110,7 +3110,7 @@ void SkyShaderData::set_default_texture_param(const StringName &p_name, RID p_te
 	}
 }
 
-void SkyShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
+void SkyShaderData::get_shader_uniform_list(List<PropertyInfo> *p_param_list) const {
 	RBMap<int, StringName> order;
 
 	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {
@@ -3435,7 +3435,7 @@ void SceneShaderData::set_default_texture_param(const StringName &p_name, RID p_
 	}
 }
 
-void SceneShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
+void SceneShaderData::get_shader_uniform_list(List<PropertyInfo> *p_param_list) const {
 	RBMap<int, StringName> order;
 
 	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -54,7 +54,7 @@ namespace GLES3 {
 struct ShaderData {
 	virtual void set_code(const String &p_Code) = 0;
 	virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index) = 0;
-	virtual void get_param_list(List<PropertyInfo> *p_param_list) const = 0;
+	virtual void get_shader_uniform_list(List<PropertyInfo> *p_param_list) const = 0;
 
 	virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const = 0;
 	virtual bool is_param_texture(const StringName &p_param) const = 0;
@@ -164,7 +164,7 @@ struct CanvasShaderData : public ShaderData {
 
 	virtual void set_code(const String &p_Code);
 	virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index);
-	virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+	virtual void get_shader_uniform_list(List<PropertyInfo> *p_param_list) const;
 	virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
 
 	virtual bool is_param_texture(const StringName &p_param) const;
@@ -215,7 +215,7 @@ struct SkyShaderData : public ShaderData {
 
 	virtual void set_code(const String &p_Code);
 	virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index);
-	virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+	virtual void get_shader_uniform_list(List<PropertyInfo> *p_param_list) const;
 	virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
 	virtual bool is_param_texture(const StringName &p_param) const;
 	virtual bool is_animated() const;
@@ -335,7 +335,7 @@ struct SceneShaderData : public ShaderData {
 
 	virtual void set_code(const String &p_Code);
 	virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index);
-	virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+	virtual void get_shader_uniform_list(List<PropertyInfo> *p_param_list) const;
 	virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
 
 	virtual bool is_param_texture(const StringName &p_param) const;
@@ -545,7 +545,7 @@ public:
 	virtual void shader_set_code(RID p_shader, const String &p_code) override;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) override;
 	virtual String shader_get_code(RID p_shader) const override;
-	virtual void shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const override;
+	virtual void shader_get_shader_uniform_list(RID p_shader, List<PropertyInfo> *p_param_list) const override;
 
 	virtual void shader_set_default_texture_param(RID p_shader, const StringName &p_name, RID p_texture, int p_index) override;
 	virtual RID shader_get_default_texture_param(RID p_shader, const StringName &p_name, int p_index) const override;
@@ -576,7 +576,7 @@ public:
 	virtual bool material_is_animated(RID p_material) override;
 	virtual bool material_casts_shadows(RID p_material) override;
 
-	virtual void material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) override;
+	virtual void material_get_instance_shader_uniforms(RID p_material, List<InstanceShaderParam> *r_parameters) override;
 
 	virtual void material_update_dependency(RID p_material, DependencyTracker *p_instance) override;
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1426,19 +1426,19 @@ void AnimationPlayerEditor::_prepare_onion_layers_2() {
 	// Render every past/future step with the capture shader.
 
 	RS::get_singleton()->canvas_item_set_material(onion.capture.canvas_item, onion.capture.material->get_rid());
-	onion.capture.material->set_shader_param("bkg_color", GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
-	onion.capture.material->set_shader_param("differences_only", onion.differences_only);
-	onion.capture.material->set_shader_param("present", onion.differences_only ? RS::get_singleton()->viewport_get_texture(present_rid) : RID());
+	onion.capture.material->set_shader_uniform("bkg_color", GLOBAL_GET("rendering/environment/defaults/default_clear_color"));
+	onion.capture.material->set_shader_uniform("differences_only", onion.differences_only);
+	onion.capture.material->set_shader_uniform("present", onion.differences_only ? RS::get_singleton()->viewport_get_texture(present_rid) : RID());
 
 	int step_off_a = onion.past ? -onion.steps : 0;
 	int step_off_b = onion.future ? onion.steps : 0;
 	int cidx = 0;
-	onion.capture.material->set_shader_param("dir_color", onion.force_white_modulate ? Color(1, 1, 1) : Color(EDITOR_GET("editors/animation/onion_layers_past_color")));
+	onion.capture.material->set_shader_uniform("dir_color", onion.force_white_modulate ? Color(1, 1, 1) : Color(EDITOR_GET("editors/animation/onion_layers_past_color")));
 	for (int step_off = step_off_a; step_off <= step_off_b; step_off++) {
 		if (step_off == 0) {
 			// Skip present step and switch to the color of future.
 			if (!onion.force_white_modulate) {
-				onion.capture.material->set_shader_param("dir_color", EDITOR_GET("editors/animation/onion_layers_future_color"));
+				onion.capture.material->set_shader_uniform("dir_color", EDITOR_GET("editors/animation/onion_layers_future_color"));
 			}
 			continue;
 		}

--- a/editor/plugins/material_editor_plugin.cpp
+++ b/editor/plugins/material_editor_plugin.cpp
@@ -340,17 +340,17 @@ Ref<Resource> StandardMaterial3DConversionPlugin::convert(const Ref<Resource> &p
 	smat->set_shader(shader);
 
 	List<PropertyInfo> params;
-	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
+	RS::get_singleton()->shader_get_shader_uniform_list(mat->get_shader_rid(), &params);
 
 	for (const PropertyInfo &E : params) {
 		// Texture parameter has to be treated specially since StandardMaterial3D saved it
 		// as RID but ShaderMaterial needs Texture itself
 		Ref<Texture2D> texture = mat->get_texture_by_name(E.name);
 		if (texture.is_valid()) {
-			smat->set_shader_param(E.name, texture);
+			smat->set_shader_uniform(E.name, texture);
 		} else {
 			Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
-			smat->set_shader_param(E.name, value);
+			smat->set_shader_uniform(E.name, value);
 		}
 	}
 
@@ -386,17 +386,17 @@ Ref<Resource> ORMMaterial3DConversionPlugin::convert(const Ref<Resource> &p_reso
 	smat->set_shader(shader);
 
 	List<PropertyInfo> params;
-	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
+	RS::get_singleton()->shader_get_shader_uniform_list(mat->get_shader_rid(), &params);
 
 	for (const PropertyInfo &E : params) {
 		// Texture parameter has to be treated specially since ORMMaterial3D saved it
 		// as RID but ShaderMaterial needs Texture itself
 		Ref<Texture2D> texture = mat->get_texture_by_name(E.name);
 		if (texture.is_valid()) {
-			smat->set_shader_param(E.name, texture);
+			smat->set_shader_uniform(E.name, texture);
 		} else {
 			Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
-			smat->set_shader_param(E.name, value);
+			smat->set_shader_uniform(E.name, value);
 		}
 	}
 
@@ -432,11 +432,11 @@ Ref<Resource> ParticlesMaterialConversionPlugin::convert(const Ref<Resource> &p_
 	smat->set_shader(shader);
 
 	List<PropertyInfo> params;
-	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
+	RS::get_singleton()->shader_get_shader_uniform_list(mat->get_shader_rid(), &params);
 
 	for (const PropertyInfo &E : params) {
 		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
-		smat->set_shader_param(E.name, value);
+		smat->set_shader_uniform(E.name, value);
 	}
 
 	smat->set_render_priority(mat->get_render_priority());
@@ -471,11 +471,11 @@ Ref<Resource> CanvasItemMaterialConversionPlugin::convert(const Ref<Resource> &p
 	smat->set_shader(shader);
 
 	List<PropertyInfo> params;
-	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
+	RS::get_singleton()->shader_get_shader_uniform_list(mat->get_shader_rid(), &params);
 
 	for (const PropertyInfo &E : params) {
 		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
-		smat->set_shader_param(E.name, value);
+		smat->set_shader_uniform(E.name, value);
 	}
 
 	smat->set_render_priority(mat->get_render_priority());
@@ -510,11 +510,11 @@ Ref<Resource> ProceduralSkyMaterialConversionPlugin::convert(const Ref<Resource>
 	smat->set_shader(shader);
 
 	List<PropertyInfo> params;
-	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
+	RS::get_singleton()->shader_get_shader_uniform_list(mat->get_shader_rid(), &params);
 
 	for (const PropertyInfo &E : params) {
 		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
-		smat->set_shader_param(E.name, value);
+		smat->set_shader_uniform(E.name, value);
 	}
 
 	smat->set_render_priority(mat->get_render_priority());
@@ -549,11 +549,11 @@ Ref<Resource> PanoramaSkyMaterialConversionPlugin::convert(const Ref<Resource> &
 	smat->set_shader(shader);
 
 	List<PropertyInfo> params;
-	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
+	RS::get_singleton()->shader_get_shader_uniform_list(mat->get_shader_rid(), &params);
 
 	for (const PropertyInfo &E : params) {
 		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
-		smat->set_shader_param(E.name, value);
+		smat->set_shader_uniform(E.name, value);
 	}
 
 	smat->set_render_priority(mat->get_render_priority());
@@ -588,11 +588,11 @@ Ref<Resource> PhysicalSkyMaterialConversionPlugin::convert(const Ref<Resource> &
 	smat->set_shader(shader);
 
 	List<PropertyInfo> params;
-	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
+	RS::get_singleton()->shader_get_shader_uniform_list(mat->get_shader_rid(), &params);
 
 	for (const PropertyInfo &E : params) {
 		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
-		smat->set_shader_param(E.name, value);
+		smat->set_shader_uniform(E.name, value);
 	}
 
 	smat->set_render_priority(mat->get_render_priority());
@@ -627,11 +627,11 @@ Ref<Resource> FogMaterialConversionPlugin::convert(const Ref<Resource> &p_resour
 	smat->set_shader(shader);
 
 	List<PropertyInfo> params;
-	RS::get_singleton()->shader_get_param_list(mat->get_shader_rid(), &params);
+	RS::get_singleton()->shader_get_shader_uniform_list(mat->get_shader_rid(), &params);
 
 	for (const PropertyInfo &E : params) {
 		Variant value = RS::get_singleton()->material_get_param(mat->get_rid(), E.name);
-		smat->set_shader_param(E.name, value);
+		smat->set_shader_uniform(E.name, value);
 	}
 
 	smat->set_render_priority(mat->get_render_priority());

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -6408,7 +6408,7 @@ void fragment() {
 				Ref<ShaderMaterial> rotate_mat = memnew(ShaderMaterial);
 				rotate_mat->set_render_priority(Material::RENDER_PRIORITY_MAX);
 				rotate_mat->set_shader(rotate_shader);
-				rotate_mat->set_shader_param("albedo", col);
+				rotate_mat->set_shader_uniform("albedo", col);
 				rotate_gizmo_color[i] = rotate_mat;
 
 				Array arrays = surftool->commit_to_arrays();
@@ -6416,7 +6416,7 @@ void fragment() {
 				rotate_gizmo[i]->surface_set_material(0, rotate_mat);
 
 				Ref<ShaderMaterial> rotate_mat_hl = rotate_mat->duplicate();
-				rotate_mat_hl->set_shader_param("albedo", albedo);
+				rotate_mat_hl->set_shader_uniform("albedo", albedo);
 				rotate_gizmo_color_hl[i] = rotate_mat_hl;
 
 				if (i == 2) { // Rotation white outline
@@ -6457,7 +6457,7 @@ void fragment() {
 )");
 
 					border_mat->set_shader(border_shader);
-					border_mat->set_shader_param("albedo", Color(0.75, 0.75, 0.75, col.a / 3.0));
+					border_mat->set_shader_uniform("albedo", Color(0.75, 0.75, 0.75, col.a / 3.0));
 
 					rotate_gizmo[3] = Ref<ArrayMesh>(memnew(ArrayMesh));
 					rotate_gizmo[3]->add_surface_from_arrays(Mesh::PRIMITIVE_TRIANGLES, arrays);
@@ -6710,8 +6710,8 @@ void Node3DEditor::_init_grid() {
 		fade_size = CLAMP(fade_size, min_fade_size, max_fade_size);
 
 		real_t grid_fade_size = (grid_size - primary_grid_steps) * fade_size;
-		grid_mat[c]->set_shader_param("grid_size", grid_fade_size);
-		grid_mat[c]->set_shader_param("orthogonal", orthogonal);
+		grid_mat[c]->set_shader_uniform("grid_size", grid_fade_size);
+		grid_mat[c]->set_shader_uniform("orthogonal", orthogonal);
 
 		// Cache these so we don't have to re-access memory.
 		Vector<Vector3> &ref_grid = grid_points[c];
@@ -7559,9 +7559,9 @@ void Node3DEditor::_sun_direction_draw() {
 	sun_direction->draw_rect(Rect2(Vector2(), sun_direction->get_size()), Color(1, 1, 1, 1));
 	Vector3 z_axis = preview_sun->get_transform().basis.get_column(Vector3::AXIS_Z);
 	z_axis = get_editor_viewport(0)->camera->get_camera_transform().basis.xform_inv(z_axis);
-	sun_direction_material->set_shader_param("sun_direction", Vector3(z_axis.x, -z_axis.y, z_axis.z));
+	sun_direction_material->set_shader_uniform("sun_direction", Vector3(z_axis.x, -z_axis.y, z_axis.z));
 	Color color = sun_color->get_pick_color() * sun_energy->get_value();
-	sun_direction_material->set_shader_param("sun_color", Vector3(color.r, color.g, color.b));
+	sun_direction_material->set_shader_uniform("sun_color", Vector3(color.r, color.g, color.b));
 }
 
 void Node3DEditor::_preview_settings_changed() {
@@ -8162,8 +8162,8 @@ void fragment() {
 )");
 		sun_direction_material.instantiate();
 		sun_direction_material->set_shader(sun_direction_shader);
-		sun_direction_material->set_shader_param("sun_direction", Vector3(0, 0, 1));
-		sun_direction_material->set_shader_param("sun_color", Vector3(1, 1, 1));
+		sun_direction_material->set_shader_uniform("sun_direction", Vector3(0, 0, 1));
+		sun_direction_material->set_shader_uniform("sun_color", Vector3(1, 1, 1));
 		sun_direction->set_material(sun_direction_material);
 
 		HBoxContainer *sun_angle_hbox = memnew(HBoxContainer);

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -921,8 +921,8 @@ void fragment() {
 )");
 	handle_material->set_shader(handle_shader);
 	Ref<Texture2D> handle = EditorNode::get_singleton()->get_gui_base()->get_theme_icon(SNAME("EditorBoneHandle"), SNAME("EditorIcons"));
-	handle_material->set_shader_param("point_size", handle->get_width());
-	handle_material->set_shader_param("texture_albedo", handle);
+	handle_material->set_shader_uniform("point_size", handle->get_width());
+	handle_material->set_shader_uniform("texture_albedo", handle);
 
 	handles_mesh_instance = memnew(MeshInstance3D);
 	handles_mesh_instance->set_cast_shadows_setting(GeometryInstance3D::SHADOW_CASTING_SETTING_OFF);

--- a/editor/plugins/texture_3d_editor_plugin.cpp
+++ b/editor/plugins/texture_3d_editor_plugin.cpp
@@ -57,8 +57,8 @@ void Texture3DEditor::_texture_changed() {
 }
 
 void Texture3DEditor::_update_material() {
-	material->set_shader_param("layer", (layer->get_value() + 0.5) / texture->get_depth());
-	material->set_shader_param("tex", texture->get_rid());
+	material->set_shader_uniform("layer", (layer->get_value() + 0.5) / texture->get_depth());
+	material->set_shader_uniform("tex", texture->get_rid());
 
 	String format = Image::get_format_name(texture->get_format());
 

--- a/editor/plugins/texture_layered_editor_plugin.cpp
+++ b/editor/plugins/texture_layered_editor_plugin.cpp
@@ -68,9 +68,9 @@ void TextureLayeredEditor::_texture_changed() {
 }
 
 void TextureLayeredEditor::_update_material() {
-	materials[0]->set_shader_param("layer", layer->get_value());
-	materials[2]->set_shader_param("layer", layer->get_value());
-	materials[texture->get_layered_type()]->set_shader_param("tex", texture->get_rid());
+	materials[0]->set_shader_uniform("layer", layer->get_value());
+	materials[2]->set_shader_uniform("layer", layer->get_value());
+	materials[texture->get_layered_type()]->set_shader_uniform("tex", texture->get_rid());
 
 	Vector3 v(1, 1, 1);
 	v.normalize();
@@ -79,10 +79,10 @@ void TextureLayeredEditor::_update_material() {
 	b.rotate(Vector3(1, 0, 0), x_rot);
 	b.rotate(Vector3(0, 1, 0), y_rot);
 
-	materials[1]->set_shader_param("normal", v);
-	materials[1]->set_shader_param("rot", b);
-	materials[2]->set_shader_param("normal", v);
-	materials[2]->set_shader_param("rot", b);
+	materials[1]->set_shader_uniform("normal", v);
+	materials[1]->set_shader_uniform("rot", b);
+	materials[2]->set_shader_uniform("normal", v);
+	materials[2]->set_shader_uniform("rot", b);
 
 	String format = Image::get_format_name(texture->get_format());
 

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -6228,7 +6228,7 @@ void VisualShaderNodePortPreview::_shader_changed() {
 		}
 		if (src_mat && src_mat->get_shader().is_valid()) {
 			List<PropertyInfo> params;
-			src_mat->get_shader()->get_param_list(&params);
+			src_mat->get_shader()->get_shader_uniform_list(&params);
 			for (const PropertyInfo &E : params) {
 				material->set(E.name, src_mat->get(E.name));
 			}

--- a/modules/mono/editor/code_completion.cpp
+++ b/modules/mono/editor/code_completion.cpp
@@ -172,7 +172,7 @@ PackedStringArray get_code_completion(CompletionKind p_kind, const String &p_scr
 			}
 		} break;
 		case CompletionKind::SHADER_PARAMS: {
-			print_verbose("Shared params completion for C# not implemented.");
+			print_verbose("Shader uniforms completion for C# is not implemented yet.");
 		} break;
 		case CompletionKind::SIGNALS: {
 			Ref<Script> script = ResourceLoader::load(p_script_file.simplify_path());

--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -227,8 +227,8 @@ const StringName *GeometryInstance3D::_instance_uniform_get_remap(const StringNa
 	StringName *r = instance_uniform_property_remap.getptr(p_name);
 	if (!r) {
 		String s = p_name;
-		if (s.begins_with("shader_params/")) {
-			StringName name = s.replace("shader_params/", "");
+		if (s.begins_with("shader_uniforms/")) {
+			StringName name = s.replace("shader_uniforms/", "");
 			instance_uniform_property_remap[p_name] = name;
 			return instance_uniform_property_remap.getptr(p_name);
 		}
@@ -242,7 +242,7 @@ const StringName *GeometryInstance3D::_instance_uniform_get_remap(const StringNa
 bool GeometryInstance3D::_set(const StringName &p_name, const Variant &p_value) {
 	const StringName *r = _instance_uniform_get_remap(p_name);
 	if (r) {
-		set_shader_instance_uniform(*r, p_value);
+		set_instance_shader_uniform(*r, p_value);
 		return true;
 	}
 #ifndef DISABLE_DEPRECATED
@@ -262,7 +262,7 @@ bool GeometryInstance3D::_set(const StringName &p_name, const Variant &p_value) 
 bool GeometryInstance3D::_get(const StringName &p_name, Variant &r_ret) const {
 	const StringName *r = _instance_uniform_get_remap(p_name);
 	if (r) {
-		r_ret = get_shader_instance_uniform(*r);
+		r_ret = get_instance_shader_uniform(*r);
 		return true;
 	}
 
@@ -271,10 +271,10 @@ bool GeometryInstance3D::_get(const StringName &p_name, Variant &r_ret) const {
 
 void GeometryInstance3D::_get_property_list(List<PropertyInfo> *p_list) const {
 	List<PropertyInfo> pinfo;
-	RS::get_singleton()->instance_geometry_get_shader_parameter_list(get_instance(), &pinfo);
+	RS::get_singleton()->instance_geometry_get_shader_uniform_list(get_instance(), &pinfo);
 	for (PropertyInfo &pi : pinfo) {
 		bool has_def_value = false;
-		Variant def_value = RS::get_singleton()->instance_geometry_get_shader_parameter_default_value(get_instance(), pi.name);
+		Variant def_value = RS::get_singleton()->instance_geometry_get_shader_uniform_default_value(get_instance(), pi.name);
 		if (def_value.get_type() != Variant::NIL) {
 			has_def_value = true;
 		}
@@ -284,7 +284,7 @@ void GeometryInstance3D::_get_property_list(List<PropertyInfo> *p_list) const {
 			pi.usage = PROPERTY_USAGE_EDITOR | (has_def_value ? PROPERTY_USAGE_CHECKABLE : PROPERTY_USAGE_NONE); //do not save if not changed
 		}
 
-		pi.name = "shader_params/" + pi.name;
+		pi.name = "shader_uniforms/" + pi.name;
 		p_list->push_back(pi);
 	}
 }
@@ -319,24 +319,24 @@ float GeometryInstance3D::get_lod_bias() const {
 	return lod_bias;
 }
 
-void GeometryInstance3D::set_shader_instance_uniform(const StringName &p_uniform, const Variant &p_value) {
+void GeometryInstance3D::set_instance_shader_uniform(const StringName &p_uniform, const Variant &p_value) {
 	if (p_value.get_type() == Variant::NIL) {
-		Variant def_value = RS::get_singleton()->instance_geometry_get_shader_parameter_default_value(get_instance(), p_uniform);
-		RS::get_singleton()->instance_geometry_set_shader_parameter(get_instance(), p_uniform, def_value);
+		Variant def_value = RS::get_singleton()->instance_geometry_get_shader_uniform_default_value(get_instance(), p_uniform);
+		RS::get_singleton()->instance_geometry_set_shader_uniform(get_instance(), p_uniform, def_value);
 		instance_uniforms.erase(p_value);
 	} else {
 		instance_uniforms[p_uniform] = p_value;
 		if (p_value.get_type() == Variant::OBJECT) {
 			RID tex_id = p_value;
-			RS::get_singleton()->instance_geometry_set_shader_parameter(get_instance(), p_uniform, tex_id);
+			RS::get_singleton()->instance_geometry_set_shader_uniform(get_instance(), p_uniform, tex_id);
 		} else {
-			RS::get_singleton()->instance_geometry_set_shader_parameter(get_instance(), p_uniform, p_value);
+			RS::get_singleton()->instance_geometry_set_shader_uniform(get_instance(), p_uniform, p_value);
 		}
 	}
 }
 
-Variant GeometryInstance3D::get_shader_instance_uniform(const StringName &p_uniform) const {
-	return RS::get_singleton()->instance_geometry_get_shader_parameter(get_instance(), p_uniform);
+Variant GeometryInstance3D::get_instance_shader_uniform(const StringName &p_uniform) const {
+	return RS::get_singleton()->instance_geometry_get_shader_uniform(get_instance(), p_uniform);
 }
 
 void GeometryInstance3D::set_custom_aabb(AABB aabb) {
@@ -434,8 +434,8 @@ void GeometryInstance3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_visibility_range_fade_mode", "mode"), &GeometryInstance3D::set_visibility_range_fade_mode);
 	ClassDB::bind_method(D_METHOD("get_visibility_range_fade_mode"), &GeometryInstance3D::get_visibility_range_fade_mode);
 
-	ClassDB::bind_method(D_METHOD("set_shader_instance_uniform", "uniform", "value"), &GeometryInstance3D::set_shader_instance_uniform);
-	ClassDB::bind_method(D_METHOD("get_shader_instance_uniform", "uniform"), &GeometryInstance3D::get_shader_instance_uniform);
+	ClassDB::bind_method(D_METHOD("set_instance_shader_uniform", "uniform", "value"), &GeometryInstance3D::set_instance_shader_uniform);
+	ClassDB::bind_method(D_METHOD("get_instance_shader_uniform", "uniform"), &GeometryInstance3D::get_instance_shader_uniform);
 
 	ClassDB::bind_method(D_METHOD("set_extra_cull_margin", "margin"), &GeometryInstance3D::set_extra_cull_margin);
 	ClassDB::bind_method(D_METHOD("get_extra_cull_margin"), &GeometryInstance3D::get_extra_cull_margin);

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -178,8 +178,8 @@ public:
 	void set_lightmap_scale(LightmapScale p_scale);
 	LightmapScale get_lightmap_scale() const;
 
-	void set_shader_instance_uniform(const StringName &p_uniform, const Variant &p_value);
-	Variant get_shader_instance_uniform(const StringName &p_uniform) const;
+	void set_instance_shader_uniform(const StringName &p_uniform, const Variant &p_value);
+	Variant get_instance_shader_uniform(const StringName &p_uniform) const;
 
 	void set_custom_aabb(AABB aabb);
 

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -847,7 +847,7 @@ void ColorPicker::_hsv_draw(int p_which, Control *c) {
 	} else if (p_which == 2) {
 		c->draw_rect(Rect2(Point2(), c->get_size()), Color(1, 1, 1));
 		if (actual_shape == SHAPE_VHS_CIRCLE || actual_shape == SHAPE_OKHSL_CIRCLE) {
-			circle_mat->set_shader_param("v", v);
+			circle_mat->set_shader_uniform("v", v);
 		}
 	}
 }

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -154,18 +154,18 @@ Material::~Material() {
 
 bool ShaderMaterial::_set(const StringName &p_name, const Variant &p_value) {
 	if (shader.is_valid()) {
-		StringName pr = shader->remap_param(p_name);
+		StringName pr = shader->remap_uniform(p_name);
 		if (!pr) {
 			String n = p_name;
 			if (n.find("param/") == 0) { //backwards compatibility
 				pr = n.substr(6, n.length());
 			}
-			if (n.find("shader_param/") == 0) { //backwards compatibility
-				pr = n.replace_first("shader_param/", "");
+			if (n.find("shader_uniform/") == 0) { //backwards compatibility
+				pr = n.replace_first("shader_uniform/", "");
 			}
 		}
 		if (pr) {
-			set_shader_param(pr, p_value);
+			set_shader_uniform(pr, p_value);
 			return true;
 		}
 	}
@@ -175,14 +175,14 @@ bool ShaderMaterial::_set(const StringName &p_name, const Variant &p_value) {
 
 bool ShaderMaterial::_get(const StringName &p_name, Variant &r_ret) const {
 	if (shader.is_valid()) {
-		StringName pr = shader->remap_param(p_name);
+		StringName pr = shader->remap_uniform(p_name);
 		if (!pr) {
 			String n = p_name;
 			if (n.find("param/") == 0) { //backwards compatibility
 				pr = n.substr(6, n.length());
 			}
-			if (n.find("shader_param/") == 0) { //backwards compatibility
-				pr = n.replace_first("shader_param/", "");
+			if (n.find("shader_uniform/") == 0) { //backwards compatibility
+				pr = n.replace_first("shader_uniform/", "");
 			}
 		}
 
@@ -203,7 +203,7 @@ bool ShaderMaterial::_get(const StringName &p_name, Variant &r_ret) const {
 void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 	if (!shader.is_null()) {
 		List<PropertyInfo> list;
-		shader->get_param_list(&list, true);
+		shader->get_shader_uniform_list(&list, true);
 
 		HashMap<String, HashMap<String, List<PropertyInfo>>> groups;
 		{
@@ -299,7 +299,7 @@ void ShaderMaterial::_get_property_list(List<PropertyInfo> *p_list) const {
 
 bool ShaderMaterial::property_can_revert(const String &p_name) {
 	if (shader.is_valid()) {
-		StringName pr = shader->remap_param(p_name);
+		StringName pr = shader->remap_uniform(p_name);
 		if (pr) {
 			Variant default_value = RenderingServer::get_singleton()->shader_get_param_default(shader->get_rid(), pr);
 			Variant current_value;
@@ -313,7 +313,7 @@ bool ShaderMaterial::property_can_revert(const String &p_name) {
 Variant ShaderMaterial::property_get_revert(const String &p_name) {
 	Variant r_ret;
 	if (shader.is_valid()) {
-		StringName pr = shader->remap_param(p_name);
+		StringName pr = shader->remap_uniform(p_name);
 		if (pr) {
 			r_ret = RenderingServer::get_singleton()->shader_get_param_default(shader->get_rid(), pr);
 		}
@@ -349,7 +349,7 @@ Ref<Shader> ShaderMaterial::get_shader() const {
 	return shader;
 }
 
-void ShaderMaterial::set_shader_param(const StringName &p_param, const Variant &p_value) {
+void ShaderMaterial::set_shader_uniform(const StringName &p_param, const Variant &p_value) {
 	if (p_value.get_type() == Variant::NIL) {
 		param_cache.erase(p_param);
 		RS::get_singleton()->material_set_param(_get_material(), p_param, Variant());
@@ -369,7 +369,7 @@ void ShaderMaterial::set_shader_param(const StringName &p_param, const Variant &
 	}
 }
 
-Variant ShaderMaterial::get_shader_param(const StringName &p_param) const {
+Variant ShaderMaterial::get_shader_uniform(const StringName &p_param) const {
 	if (param_cache.has(p_param)) {
 		return param_cache[p_param];
 	} else {
@@ -384,8 +384,8 @@ void ShaderMaterial::_shader_changed() {
 void ShaderMaterial::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_shader", "shader"), &ShaderMaterial::set_shader);
 	ClassDB::bind_method(D_METHOD("get_shader"), &ShaderMaterial::get_shader);
-	ClassDB::bind_method(D_METHOD("set_shader_param", "param", "value"), &ShaderMaterial::set_shader_param);
-	ClassDB::bind_method(D_METHOD("get_shader_param", "param"), &ShaderMaterial::get_shader_param);
+	ClassDB::bind_method(D_METHOD("set_shader_uniform", "param", "value"), &ShaderMaterial::set_shader_uniform);
+	ClassDB::bind_method(D_METHOD("get_shader_uniform", "param"), &ShaderMaterial::get_shader_uniform);
 	ClassDB::bind_method(D_METHOD("property_can_revert", "name"), &ShaderMaterial::property_can_revert);
 	ClassDB::bind_method(D_METHOD("property_get_revert", "name"), &ShaderMaterial::property_get_revert);
 
@@ -394,12 +394,12 @@ void ShaderMaterial::_bind_methods() {
 
 void ShaderMaterial::get_argument_options(const StringName &p_function, int p_idx, List<String> *r_options) const {
 	String f = p_function.operator String();
-	if ((f == "get_shader_param" || f == "set_shader_param") && p_idx == 0) {
+	if ((f == "get_shader_uniform" || f == "set_shader_uniform") && p_idx == 0) {
 		if (shader.is_valid()) {
 			List<PropertyInfo> pl;
-			shader->get_param_list(&pl);
+			shader->get_shader_uniform_list(&pl);
 			for (const PropertyInfo &E : pl) {
-				r_options->push_back(E.name.replace_first("shader_param/", "").quote());
+				r_options->push_back(E.name.replace_first("shader_uniform/", "").quote());
 			}
 		}
 	}

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -115,8 +115,8 @@ public:
 	void set_shader(const Ref<Shader> &p_shader);
 	Ref<Shader> get_shader() const;
 
-	void set_shader_param(const StringName &p_param, const Variant &p_value);
-	Variant get_shader_param(const StringName &p_param) const;
+	void set_shader_uniform(const StringName &p_param, const Variant &p_value);
+	Variant get_shader_uniform(const StringName &p_param) const;
 
 	virtual Shader::Mode get_shader_mode() const override;
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -103,11 +103,11 @@ String Shader::get_code() const {
 	return code;
 }
 
-void Shader::get_param_list(List<PropertyInfo> *p_params, bool p_get_groups) const {
+void Shader::get_shader_uniform_list(List<PropertyInfo> *p_params, bool p_get_groups) const {
 	_update_shader();
 
 	List<PropertyInfo> local;
-	RenderingServer::get_singleton()->shader_get_param_list(shader, &local);
+	RenderingServer::get_singleton()->shader_get_shader_uniform_list(shader, &local);
 	params_cache.clear();
 	params_cache_dirty = false;
 
@@ -176,8 +176,8 @@ bool Shader::is_text_shader() const {
 	return true;
 }
 
-bool Shader::has_param(const StringName &p_param) const {
-	return params_cache.has("shader_param/" + p_param);
+bool Shader::has_uniform(const StringName &p_param) const {
+	return params_cache.has("shader_uniform/" + p_param);
 }
 
 void Shader::_update_shader() const {
@@ -192,7 +192,7 @@ void Shader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_default_texture_param", "param", "texture", "index"), &Shader::set_default_texture_param, DEFVAL(0));
 	ClassDB::bind_method(D_METHOD("get_default_texture_param", "param", "index"), &Shader::get_default_texture_param, DEFVAL(0));
 
-	ClassDB::bind_method(D_METHOD("has_param", "name"), &Shader::has_param);
+	ClassDB::bind_method(D_METHOD("has_uniform", "name"), &Shader::has_uniform);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "code", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_code", "get_code");
 

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -78,21 +78,21 @@ public:
 	void set_code(const String &p_code);
 	String get_code() const;
 
-	void get_param_list(List<PropertyInfo> *p_params, bool p_get_groups = false) const;
-	bool has_param(const StringName &p_param) const;
+	void get_shader_uniform_list(List<PropertyInfo> *p_params, bool p_get_groups = false) const;
+	bool has_uniform(const StringName &p_param) const;
 
-	void set_default_texture_param(const StringName &p_param, const Ref<Texture2D> &p_texture, int p_index = 0);
-	Ref<Texture2D> get_default_texture_param(const StringName &p_param, int p_index = 0) const;
+	void set_default_texture_param(const StringName &p_uniform, const Ref<Texture2D> &p_texture, int p_index = 0);
+	Ref<Texture2D> get_default_texture_param(const StringName &p_uniform, int p_index = 0) const;
 	void get_default_texture_param_list(List<StringName> *r_textures) const;
 
 	virtual bool is_text_shader() const;
 
-	_FORCE_INLINE_ StringName remap_param(const StringName &p_param) const {
+	_FORCE_INLINE_ StringName remap_uniform(const StringName &p_uniform) const {
 		if (params_cache_dirty) {
-			get_param_list(nullptr);
+			get_shader_uniform_list(nullptr);
 		}
 
-		const HashMap<StringName, StringName>::Iterator E = params_cache.find(p_param);
+		const HashMap<StringName, StringName>::Iterator E = params_cache.find(p_uniform);
 		if (E) {
 			return E->value;
 		}

--- a/servers/rendering/dummy/storage/material_storage.h
+++ b/servers/rendering/dummy/storage/material_storage.h
@@ -66,7 +66,7 @@ public:
 	virtual void shader_set_path_hint(RID p_shader, const String &p_code) override {}
 
 	virtual String shader_get_code(RID p_shader) const override { return ""; }
-	virtual void shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const override {}
+	virtual void shader_get_shader_uniform_list(RID p_shader, List<PropertyInfo> *p_param_list) const override {}
 
 	virtual void shader_set_default_texture_param(RID p_shader, const StringName &p_name, RID p_texture, int p_index) override {}
 	virtual RID shader_get_default_texture_param(RID p_shader, const StringName &p_name, int p_index) const override { return RID(); }
@@ -89,7 +89,7 @@ public:
 
 	virtual bool material_is_animated(RID p_material) override { return false; }
 	virtual bool material_casts_shadows(RID p_material) override { return false; }
-	virtual void material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) override {}
+	virtual void material_get_instance_shader_uniforms(RID p_material, List<InstanceShaderParam> *r_parameters) override {}
 	virtual void material_update_dependency(RID p_material, DependencyTracker *p_instance) override {}
 };
 

--- a/servers/rendering/renderer_geometry_instance.cpp
+++ b/servers/rendering/renderer_geometry_instance.cpp
@@ -117,8 +117,8 @@ void RenderGeometryInstanceBase::set_use_dynamic_gi(bool p_enable) {
 	_mark_dirty();
 }
 
-void RenderGeometryInstanceBase::set_instance_shader_parameters_offset(int32_t p_offset) {
-	shader_parameters_offset = p_offset;
+void RenderGeometryInstanceBase::set_instance_shader_uniforms_offset(int32_t p_offset) {
+	shader_uniforms_offset = p_offset;
 
 	_mark_dirty();
 }

--- a/servers/rendering/renderer_geometry_instance.h
+++ b/servers/rendering/renderer_geometry_instance.h
@@ -59,7 +59,7 @@ public:
 	virtual void set_use_dynamic_gi(bool p_enable) = 0;
 	virtual void set_use_lightmap(RID p_lightmap_instance, const Rect2 &p_lightmap_uv_scale, int p_lightmap_slice_index) = 0;
 	virtual void set_lightmap_capture(const Color *p_sh9) = 0;
-	virtual void set_instance_shader_parameters_offset(int32_t p_offset) = 0;
+	virtual void set_instance_shader_uniforms_offset(int32_t p_offset) = 0;
 	virtual void set_cast_double_sided_shadows(bool p_enable) = 0;
 
 	virtual Transform3D get_transform() = 0;
@@ -104,7 +104,7 @@ public:
 	float parent_fade_alpha = 1.0;
 	float force_alpha = 1.0;
 
-	int32_t shader_parameters_offset = -1;
+	int32_t shader_uniforms_offset = -1;
 
 	struct Data {
 		//data used less often goes into regular heap
@@ -140,7 +140,7 @@ public:
 	virtual void set_transparency(float p_transparency) override;
 	virtual void set_use_baked_light(bool p_enable) override;
 	virtual void set_use_dynamic_gi(bool p_enable) override;
-	virtual void set_instance_shader_parameters_offset(int32_t p_offset) override;
+	virtual void set_instance_shader_uniforms_offset(int32_t p_offset) override;
 	virtual void set_cast_double_sided_shadows(bool p_enable) override;
 
 	virtual Transform3D get_transform() override;

--- a/servers/rendering/renderer_rd/environment/fog.cpp
+++ b/servers/rendering/renderer_rd/environment/fog.cpp
@@ -378,7 +378,7 @@ void Fog::FogShaderData::set_default_texture_param(const StringName &p_name, RID
 	}
 }
 
-void Fog::FogShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
+void Fog::FogShaderData::get_shader_uniform_list(List<PropertyInfo> *p_param_list) const {
 	RBMap<int, StringName> order;
 
 	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {

--- a/servers/rendering/renderer_rd/environment/fog.h
+++ b/servers/rendering/renderer_rd/environment/fog.h
@@ -200,7 +200,7 @@ private:
 		virtual void set_path_hint(const String &p_hint);
 		virtual void set_code(const String &p_Code);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index);
-		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+		virtual void get_shader_uniform_list(List<PropertyInfo> *p_param_list) const;
 		virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
 		virtual bool is_param_texture(const StringName &p_param) const;
 		virtual bool is_animated() const;

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -164,7 +164,7 @@ void SkyRD::SkyShaderData::set_default_texture_param(const StringName &p_name, R
 	}
 }
 
-void SkyRD::SkyShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
+void SkyRD::SkyShaderData::get_shader_uniform_list(List<PropertyInfo> *p_param_list) const {
 	HashMap<int, StringName> order;
 
 	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -131,7 +131,7 @@ private:
 		virtual void set_code(const String &p_Code);
 		virtual void set_path_hint(const String &p_hint);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index);
-		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+		virtual void get_shader_uniform_list(List<PropertyInfo> *p_param_list) const;
 		virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
 		virtual bool is_param_texture(const StringName &p_param) const;
 		virtual bool is_animated() const;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1076,7 +1076,7 @@ void RenderForwardClustered::_fill_instance_data(RenderListType p_render_list, i
 		instance_data.flags = inst->flags_cache;
 		instance_data.gi_offset = inst->gi_offset_cache;
 		instance_data.layer_mask = inst->layer_mask;
-		instance_data.instance_uniforms_ofs = uint32_t(inst->shader_parameters_offset);
+		instance_data.instance_uniforms_ofs = uint32_t(inst->shader_uniforms_offset);
 		instance_data.lightmap_uv_scale[0] = inst->lightmap_uv_scale.position.x;
 		instance_data.lightmap_uv_scale[1] = inst->lightmap_uv_scale.position.y;
 		instance_data.lightmap_uv_scale[2] = inst->lightmap_uv_scale.size.x;

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -392,7 +392,7 @@ void SceneShaderForwardClustered::ShaderData::set_default_texture_param(const St
 	}
 }
 
-void SceneShaderForwardClustered::ShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
+void SceneShaderForwardClustered::ShaderData::get_shader_uniform_list(List<PropertyInfo> *p_param_list) const {
 	HashMap<int, StringName> order;
 
 	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -182,7 +182,7 @@ public:
 		virtual void set_code(const String &p_Code);
 		virtual void set_path_hint(const String &p_path);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index);
-		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+		virtual void get_shader_uniform_list(List<PropertyInfo> *p_param_list) const;
 		void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
 
 		virtual bool is_param_texture(const StringName &p_param) const;

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1903,7 +1903,7 @@ void RenderForwardMobile::_render_list_template(RenderingDevice::DrawListID p_dr
 		push_constant.flags = inst->flags_cache;
 		push_constant.gi_offset = inst->gi_offset_cache;
 		push_constant.layer_mask = inst->layer_mask;
-		push_constant.instance_uniforms_ofs = uint32_t(inst->shader_parameters_offset);
+		push_constant.instance_uniforms_ofs = uint32_t(inst->shader_uniforms_offset);
 
 		if (p_params->pass_mode == PASS_MODE_DEPTH_MATERIAL) {
 			// abuse lightmap_uv_scale[0] here, should not be needed here

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -349,7 +349,7 @@ void SceneShaderForwardMobile::ShaderData::set_default_texture_param(const Strin
 	}
 }
 
-void SceneShaderForwardMobile::ShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
+void SceneShaderForwardMobile::ShaderData::get_shader_uniform_list(List<PropertyInfo> *p_param_list) const {
 	HashMap<int, StringName> order;
 
 	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -142,7 +142,7 @@ public:
 		virtual void set_path_hint(const String &p_path);
 
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index);
-		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+		virtual void get_shader_uniform_list(List<PropertyInfo> *p_param_list) const;
 		void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
 
 		virtual bool is_param_texture(const StringName &p_param) const;

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2171,7 +2171,7 @@ void RendererCanvasRenderRD::CanvasShaderData::set_default_texture_param(const S
 	}
 }
 
-void RendererCanvasRenderRD::CanvasShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
+void RendererCanvasRenderRD::CanvasShaderData::get_shader_uniform_list(List<PropertyInfo> *p_param_list) const {
 	HashMap<int, StringName> order;
 
 	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -180,7 +180,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		virtual void set_code(const String &p_Code);
 		virtual void set_path_hint(const String &p_path);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index);
-		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+		virtual void get_shader_uniform_list(List<PropertyInfo> *p_param_list) const;
 		virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
 
 		virtual bool is_param_texture(const StringName &p_param) const;

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -2406,11 +2406,11 @@ String MaterialStorage::shader_get_code(RID p_shader) const {
 	return shader->code;
 }
 
-void MaterialStorage::shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const {
+void MaterialStorage::shader_get_shader_uniform_list(RID p_shader, List<PropertyInfo> *p_param_list) const {
 	Shader *shader = shader_owner.get_or_null(p_shader);
 	ERR_FAIL_COND(!shader);
 	if (shader->data) {
-		return shader->data->get_param_list(p_param_list);
+		return shader->data->get_shader_uniform_list(p_param_list);
 	}
 }
 
@@ -2672,14 +2672,14 @@ bool MaterialStorage::material_casts_shadows(RID p_material) {
 	return true; //by default everything casts shadows
 }
 
-void MaterialStorage::material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) {
+void MaterialStorage::material_get_instance_shader_uniforms(RID p_material, List<InstanceShaderParam> *r_parameters) {
 	Material *material = material_owner.get_or_null(p_material);
 	ERR_FAIL_COND(!material);
 	if (material->shader && material->shader->data) {
 		material->shader->data->get_instance_param_list(r_parameters);
 
 		if (material->next_pass.is_valid()) {
-			material_get_instance_shader_parameters(material->next_pass, r_parameters);
+			material_get_instance_shader_uniforms(material->next_pass, r_parameters);
 		}
 	}
 }

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.h
@@ -57,7 +57,7 @@ public:
 		virtual void set_code(const String &p_Code) = 0;
 		virtual void set_path_hint(const String &p_hint) = 0;
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index) = 0;
-		virtual void get_param_list(List<PropertyInfo> *p_param_list) const = 0;
+		virtual void get_shader_uniform_list(List<PropertyInfo> *p_param_list) const = 0;
 
 		virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const = 0;
 		virtual bool is_param_texture(const StringName &p_param) const = 0;
@@ -362,7 +362,7 @@ public:
 	virtual void shader_set_code(RID p_shader, const String &p_code) override;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) override;
 	virtual String shader_get_code(RID p_shader) const override;
-	virtual void shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const override;
+	virtual void shader_get_shader_uniform_list(RID p_shader, List<PropertyInfo> *p_param_list) const override;
 
 	virtual void shader_set_default_texture_param(RID p_shader, const StringName &p_name, RID p_texture, int p_index) override;
 	virtual RID shader_get_default_texture_param(RID p_shader, const StringName &p_name, int p_index) const override;
@@ -394,7 +394,7 @@ public:
 	virtual bool material_is_animated(RID p_material) override;
 	virtual bool material_casts_shadows(RID p_material) override;
 
-	virtual void material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) override;
+	virtual void material_get_instance_shader_uniforms(RID p_material, List<InstanceShaderParam> *r_parameters) override;
 
 	virtual void material_update_dependency(RID p_material, DependencyTracker *p_instance) override;
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1603,7 +1603,7 @@ void ParticlesStorage::ParticlesShaderData::set_default_texture_param(const Stri
 	}
 }
 
-void ParticlesStorage::ParticlesShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
+void ParticlesStorage::ParticlesShaderData::get_shader_uniform_list(List<PropertyInfo> *p_param_list) const {
 	HashMap<int, StringName> order;
 
 	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -337,7 +337,7 @@ private:
 		virtual void set_code(const String &p_Code);
 		virtual void set_path_hint(const String &p_hint);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index);
-		virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+		virtual void get_shader_uniform_list(List<PropertyInfo> *p_param_list) const;
 		virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
 		virtual bool is_param_texture(const StringName &p_param) const;
 		virtual bool is_animated() const;

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -100,10 +100,10 @@ public:
 	virtual void instance_geometry_set_visibility_range(RID p_instance, float p_min, float p_max, float p_min_margin, float p_max_margin, RS::VisibilityRangeFadeMode p_fade_mode) = 0;
 	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index) = 0;
 	virtual void instance_geometry_set_lod_bias(RID p_instance, float p_lod_bias) = 0;
-	virtual void instance_geometry_set_shader_parameter(RID p_instance, const StringName &p_parameter, const Variant &p_value) = 0;
-	virtual void instance_geometry_get_shader_parameter_list(RID p_instance, List<PropertyInfo> *p_parameters) const = 0;
-	virtual Variant instance_geometry_get_shader_parameter(RID p_instance, const StringName &p_parameter) const = 0;
-	virtual Variant instance_geometry_get_shader_parameter_default_value(RID p_instance, const StringName &p_parameter) const = 0;
+	virtual void instance_geometry_set_shader_uniform(RID p_instance, const StringName &p_parameter, const Variant &p_value) = 0;
+	virtual void instance_geometry_get_shader_uniform_list(RID p_instance, List<PropertyInfo> *p_parameters) const = 0;
+	virtual Variant instance_geometry_get_shader_uniform(RID p_instance, const StringName &p_parameter) const = 0;
+	virtual Variant instance_geometry_get_shader_uniform_default_value(RID p_instance, const StringName &p_parameter) const = 0;
 
 	virtual void directional_shadow_atlas_set_size(int p_size, bool p_16_bits = true) = 0;
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -426,9 +426,9 @@ public:
 			PropertyInfo info;
 		};
 
-		HashMap<StringName, InstanceShaderParameter> instance_shader_parameters;
-		bool instance_allocated_shader_parameters = false;
-		int32_t instance_allocated_shader_parameters_offset = -1;
+		HashMap<StringName, InstanceShaderParameter> instance_shader_uniforms;
+		bool instance_allocated_shader_uniforms = false;
+		int32_t instance_allocated_shader_uniforms_offset = -1;
 
 		//
 
@@ -967,12 +967,12 @@ public:
 	virtual void instance_geometry_set_lightmap(RID p_instance, RID p_lightmap, const Rect2 &p_lightmap_uv_scale, int p_slice_index);
 	virtual void instance_geometry_set_lod_bias(RID p_instance, float p_lod_bias);
 
-	void _update_instance_shader_parameters_from_material(HashMap<StringName, Instance::InstanceShaderParameter> &isparams, const HashMap<StringName, Instance::InstanceShaderParameter> &existing_isparams, RID p_material);
+	void _update_instance_shader_uniforms_from_material(HashMap<StringName, Instance::InstanceShaderParameter> &isparams, const HashMap<StringName, Instance::InstanceShaderParameter> &existing_isparams, RID p_material);
 
-	virtual void instance_geometry_set_shader_parameter(RID p_instance, const StringName &p_parameter, const Variant &p_value);
-	virtual void instance_geometry_get_shader_parameter_list(RID p_instance, List<PropertyInfo> *p_parameters) const;
-	virtual Variant instance_geometry_get_shader_parameter(RID p_instance, const StringName &p_parameter) const;
-	virtual Variant instance_geometry_get_shader_parameter_default_value(RID p_instance, const StringName &p_parameter) const;
+	virtual void instance_geometry_set_shader_uniform(RID p_instance, const StringName &p_parameter, const Variant &p_value);
+	virtual void instance_geometry_get_shader_uniform_list(RID p_instance, List<PropertyInfo> *p_parameters) const;
+	virtual Variant instance_geometry_get_shader_uniform(RID p_instance, const StringName &p_parameter) const;
+	virtual Variant instance_geometry_get_shader_uniform_default_value(RID p_instance, const StringName &p_parameter) const;
 
 	_FORCE_INLINE_ void _update_instance(Instance *p_instance);
 	_FORCE_INLINE_ void _update_instance_aabb(Instance *p_instance);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -227,7 +227,7 @@ public:
 	FUNC2(shader_set_path_hint, RID, const String &)
 	FUNC1RC(String, shader_get_code, RID)
 
-	FUNC2SC(shader_get_param_list, RID, List<PropertyInfo> *)
+	FUNC2SC(shader_get_shader_uniform_list, RID, List<PropertyInfo> *)
 
 	FUNC4(shader_set_default_texture_param, RID, const StringName &, RID, int)
 	FUNC3RC(RID, shader_get_default_texture_param, RID, const StringName &, int)
@@ -773,10 +773,10 @@ public:
 	FUNC4(instance_geometry_set_lightmap, RID, RID, const Rect2 &, int)
 	FUNC2(instance_geometry_set_lod_bias, RID, float)
 	FUNC2(instance_geometry_set_transparency, RID, float)
-	FUNC3(instance_geometry_set_shader_parameter, RID, const StringName &, const Variant &)
-	FUNC2RC(Variant, instance_geometry_get_shader_parameter, RID, const StringName &)
-	FUNC2RC(Variant, instance_geometry_get_shader_parameter_default_value, RID, const StringName &)
-	FUNC2C(instance_geometry_get_shader_parameter_list, RID, List<PropertyInfo> *)
+	FUNC3(instance_geometry_set_shader_uniform, RID, const StringName &, const Variant &)
+	FUNC2RC(Variant, instance_geometry_get_shader_uniform, RID, const StringName &)
+	FUNC2RC(Variant, instance_geometry_get_shader_uniform_default_value, RID, const StringName &)
+	FUNC2C(instance_geometry_get_shader_uniform_list, RID, List<PropertyInfo> *)
 
 	FUNC3R(TypedArray<Image>, bake_render_uv2, RID, const Vector<RID> &, const Size2i &)
 

--- a/servers/rendering/storage/material_storage.h
+++ b/servers/rendering/storage/material_storage.h
@@ -63,7 +63,7 @@ public:
 	virtual void shader_set_code(RID p_shader, const String &p_code) = 0;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) = 0;
 	virtual String shader_get_code(RID p_shader) const = 0;
-	virtual void shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const = 0;
+	virtual void shader_get_shader_uniform_list(RID p_shader, List<PropertyInfo> *p_param_list) const = 0;
 
 	virtual void shader_set_default_texture_param(RID p_shader, const StringName &p_name, RID p_texture, int p_index) = 0;
 	virtual RID shader_get_default_texture_param(RID p_shader, const StringName &p_name, int p_index) const = 0;
@@ -94,7 +94,7 @@ public:
 		Variant default_value;
 	};
 
-	virtual void material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) = 0;
+	virtual void material_get_instance_shader_uniforms(RID p_material, List<InstanceShaderParam> *r_parameters) = 0;
 
 	virtual void material_update_dependency(RID p_material, DependencyTracker *p_instance) = 0;
 };

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1500,9 +1500,9 @@ TypedArray<Image> RenderingServer::_texture_3d_get(RID p_texture) const {
 	return ret;
 }
 
-TypedArray<Dictionary> RenderingServer::_shader_get_param_list(RID p_shader) const {
+TypedArray<Dictionary> RenderingServer::_shader_get_shader_uniform_list(RID p_shader) const {
 	List<PropertyInfo> l;
-	shader_get_param_list(p_shader, &l);
+	shader_get_shader_uniform_list(p_shader, &l);
 	return convert_property_list(&l);
 }
 
@@ -1625,9 +1625,9 @@ Dictionary RenderingServer::_mesh_get_surface(RID p_mesh, int p_idx) {
 	return d;
 }
 
-Array RenderingServer::_instance_geometry_get_shader_parameter_list(RID p_instance) const {
+Array RenderingServer::_instance_geometry_get_shader_uniform_list(RID p_instance) const {
 	List<PropertyInfo> params;
-	instance_geometry_get_shader_parameter_list(p_instance, &params);
+	instance_geometry_get_shader_uniform_list(p_instance, &params);
 	return convert_property_list(&params);
 }
 
@@ -1701,7 +1701,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("shader_set_code", "shader", "code"), &RenderingServer::shader_set_code);
 	ClassDB::bind_method(D_METHOD("shader_set_path_hint", "shader", "path"), &RenderingServer::shader_set_path_hint);
 	ClassDB::bind_method(D_METHOD("shader_get_code", "shader"), &RenderingServer::shader_get_code);
-	ClassDB::bind_method(D_METHOD("shader_get_param_list", "shader"), &RenderingServer::_shader_get_param_list);
+	ClassDB::bind_method(D_METHOD("shader_get_shader_uniform_list", "shader"), &RenderingServer::_shader_get_shader_uniform_list);
 	ClassDB::bind_method(D_METHOD("shader_get_param_default", "shader", "param"), &RenderingServer::shader_get_param_default);
 
 	ClassDB::bind_method(D_METHOD("shader_set_default_texture_param", "shader", "param", "texture", "index"), &RenderingServer::shader_set_default_texture_param, DEFVAL(0));
@@ -2484,10 +2484,10 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_lightmap", "instance", "lightmap", "lightmap_uv_scale", "lightmap_slice"), &RenderingServer::instance_geometry_set_lightmap);
 	ClassDB::bind_method(D_METHOD("instance_geometry_set_lod_bias", "instance", "lod_bias"), &RenderingServer::instance_geometry_set_lod_bias);
 
-	ClassDB::bind_method(D_METHOD("instance_geometry_set_shader_parameter", "instance", "parameter", "value"), &RenderingServer::instance_geometry_set_shader_parameter);
-	ClassDB::bind_method(D_METHOD("instance_geometry_get_shader_parameter", "instance", "parameter"), &RenderingServer::instance_geometry_get_shader_parameter);
-	ClassDB::bind_method(D_METHOD("instance_geometry_get_shader_parameter_default_value", "instance", "parameter"), &RenderingServer::instance_geometry_get_shader_parameter_default_value);
-	ClassDB::bind_method(D_METHOD("instance_geometry_get_shader_parameter_list", "instance"), &RenderingServer::_instance_geometry_get_shader_parameter_list);
+	ClassDB::bind_method(D_METHOD("instance_geometry_set_shader_uniform", "instance", "parameter", "value"), &RenderingServer::instance_geometry_set_shader_uniform);
+	ClassDB::bind_method(D_METHOD("instance_geometry_get_shader_uniform", "instance", "parameter"), &RenderingServer::instance_geometry_get_shader_uniform);
+	ClassDB::bind_method(D_METHOD("instance_geometry_get_shader_uniform_default_value", "instance", "parameter"), &RenderingServer::instance_geometry_get_shader_uniform_default_value);
+	ClassDB::bind_method(D_METHOD("instance_geometry_get_shader_uniform_list", "instance"), &RenderingServer::_instance_geometry_get_shader_uniform_list);
 
 	ClassDB::bind_method(D_METHOD("instances_cull_aabb", "aabb", "scenario"), &RenderingServer::_instances_cull_aabb_bind, DEFVAL(RID()));
 	ClassDB::bind_method(D_METHOD("instances_cull_ray", "from", "to", "scenario"), &RenderingServer::_instances_cull_ray_bind, DEFVAL(RID()));

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -170,7 +170,7 @@ public:
 	virtual void shader_set_code(RID p_shader, const String &p_code) = 0;
 	virtual void shader_set_path_hint(RID p_shader, const String &p_path) = 0;
 	virtual String shader_get_code(RID p_shader) const = 0;
-	virtual void shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const = 0;
+	virtual void shader_get_shader_uniform_list(RID p_shader, List<PropertyInfo> *p_param_list) const = 0;
 	virtual Variant shader_get_param_default(RID p_shader, const StringName &p_param) const = 0;
 
 	virtual void shader_set_default_texture_param(RID p_shader, const StringName &p_name, RID p_texture, int p_index = 0) = 0;
@@ -1244,10 +1244,10 @@ public:
 	virtual void instance_geometry_set_lod_bias(RID p_instance, float p_lod_bias) = 0;
 	virtual void instance_geometry_set_transparency(RID p_instance, float p_transparency) = 0;
 
-	virtual void instance_geometry_set_shader_parameter(RID p_instance, const StringName &, const Variant &p_value) = 0;
-	virtual Variant instance_geometry_get_shader_parameter(RID p_instance, const StringName &) const = 0;
-	virtual Variant instance_geometry_get_shader_parameter_default_value(RID p_instance, const StringName &) const = 0;
-	virtual void instance_geometry_get_shader_parameter_list(RID p_instance, List<PropertyInfo> *p_parameters) const = 0;
+	virtual void instance_geometry_set_shader_uniform(RID p_instance, const StringName &, const Variant &p_value) = 0;
+	virtual Variant instance_geometry_get_shader_uniform(RID p_instance, const StringName &) const = 0;
+	virtual Variant instance_geometry_get_shader_uniform_default_value(RID p_instance, const StringName &) const = 0;
+	virtual void instance_geometry_get_shader_uniform_list(RID p_instance, List<PropertyInfo> *p_parameters) const = 0;
 
 	/* Bake 3D objects */
 
@@ -1571,11 +1571,11 @@ private:
 	RID _texture_3d_create(Image::Format p_format, int p_width, int p_height, int p_depth, bool p_mipmaps, const TypedArray<Image> &p_data);
 	void _texture_3d_update(RID p_texture, const TypedArray<Image> &p_data);
 	TypedArray<Image> _texture_3d_get(RID p_texture) const;
-	TypedArray<Dictionary> _shader_get_param_list(RID p_shader) const;
+	TypedArray<Dictionary> _shader_get_shader_uniform_list(RID p_shader) const;
 	RID _mesh_create_from_surfaces(const TypedArray<Dictionary> &p_surfaces, int p_blend_shape_count);
 	void _mesh_add_surface(RID p_mesh, const Dictionary &p_surface);
 	Dictionary _mesh_get_surface(RID p_mesh, int p_idx);
-	Array _instance_geometry_get_shader_parameter_list(RID p_instance) const;
+	Array _instance_geometry_get_shader_uniform_list(RID p_instance) const;
 	TypedArray<Image> _bake_render_uv2(RID p_base, const TypedArray<RID> &p_material_overrides, const Size2i &p_image_size);
 	void _particles_set_trail_bind_poses(RID p_particles, const TypedArray<Transform3D> &p_bind_poses);
 };


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/59840.

`shader_uniform` is now consistenly used across both per-shader and per-instance shader uniform methods. This makes methods easier to find in the class reference when looking for them.

See https://github.com/godotengine/godot/issues/54161#issuecomment-1086916469.