### PR TITLE
[3.x] `NavigationObstacle2D`: estimate agent radius only when configured to do so

### DIFF
--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -147,7 +147,7 @@ void NavigationObstacle2D::initialize_agent() {
 }
 
 void NavigationObstacle2D::reevaluate_agent_radius() {
-	if (!estimate_agent_radius()) {
+	if (!estimate_radius) {
 		Navigation2DServer::get_singleton()->agent_set_radius(agent, radius);
 	} else if (parent_node2d && parent_node2d->is_inside_tree()) {
 		Navigation2DServer::get_singleton()->agent_set_radius(agent, estimate_agent_radius());


### PR DESCRIPTION
It seems this was a typo in the backport.

Helps with https://github.com/godotengine/godot/issues/59833

There remains a further issue in both `3.x` and `master`: it is assumed that when you (the `NavigationObstacle2D`) and your parent are in the scene tree, then all your sibling `CollisionShape2D`'s are also in the tree. This is only true when the `NavigationObstacle2D` is *below* all of its `CollisionShape2D` siblings. This should be documented or solved independently from this PR (in `master` first).

cc @Duroxxigar
