### PR TITLE
Unexpose editor_description

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -706,9 +706,6 @@
 		<member name="custom_multiplayer" type="MultiplayerAPI" setter="set_custom_multiplayer" getter="get_custom_multiplayer">
 			The override to the default [MultiplayerAPI]. Set to [code]null[/code] to use the default [SceneTree] one.
 		</member>
-		<member name="editor_description" type="String" setter="set_editor_description" getter="get_editor_description" default="&quot;&quot;">
-			Add a custom description to a node.
-		</member>
 		<member name="multiplayer" type="MultiplayerAPI" setter="" getter="get_multiplayer">
 			The [MultiplayerAPI] instance associated with this node. Either the [member custom_multiplayer], or the default SceneTree one (if inside tree).
 		</member>

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -1833,11 +1833,15 @@ String Node::get_scene_file_path() const {
 }
 
 void Node::set_editor_description(const String &p_editor_description) {
-	data.editor_description = p_editor_description;
+	if (p_editor_description.is_empty()) {
+		remove_meta("_editor_description_");
+	} else {
+		set_meta("_editor_description_", p_editor_description);
+	}
 }
 
 String Node::get_editor_description() const {
-	return data.editor_description;
+	return get_meta("_editor_description_", "");
 }
 
 void Node::set_editable_instance(Node *p_node, bool p_editable) {
@@ -2739,8 +2743,8 @@ void Node::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_custom_multiplayer", "api"), &Node::set_custom_multiplayer);
 	ClassDB::bind_method(D_METHOD("rpc_config", "method", "rpc_mode", "call_local", "transfer_mode", "channel"), &Node::rpc_config, DEFVAL(false), DEFVAL(Multiplayer::TRANSFER_MODE_RELIABLE), DEFVAL(0));
 
-	ClassDB::bind_method(D_METHOD("set_editor_description", "editor_description"), &Node::set_editor_description);
-	ClassDB::bind_method(D_METHOD("get_editor_description"), &Node::get_editor_description);
+	ClassDB::bind_method(D_METHOD("_set_editor_description", "editor_description"), &Node::set_editor_description);
+	ClassDB::bind_method(D_METHOD("_get_editor_description"), &Node::get_editor_description);
 
 	ClassDB::bind_method(D_METHOD("_set_import_path", "import_path"), &Node::set_import_path);
 	ClassDB::bind_method(D_METHOD("_get_import_path"), &Node::get_import_path);
@@ -2845,7 +2849,7 @@ void Node::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "process_priority"), "set_process_priority", "get_process_priority");
 
 	ADD_GROUP("Editor Description", "editor_");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT), "set_editor_description", "get_editor_description");
+	ADD_PROPERTY(PropertyInfo(Variant::STRING, "editor_description", PROPERTY_HINT_MULTILINE_TEXT, "", PROPERTY_USAGE_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_editor_description", "_get_editor_description");
 
 	GDVIRTUAL_BIND(_process, "delta");
 	GDVIRTUAL_BIND(_physics_process, "delta");

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -112,8 +112,6 @@ private:
 #ifdef TOOLS_ENABLED
 		NodePath import_path; // Path used when imported, used by scene editors to keep tracking.
 #endif
-		String editor_description;
-
 		Viewport *viewport = nullptr;
 
 		Map<StringName, GroupData> grouped;


### PR DESCRIPTION
`editor_description` was originally introduced as metadata, because its purpose is to annotate nodes with random editor-only notes that are also displayed in the scene tree dock (as tooltip). However due to problems with metas, it was later changed to a property in #46191, which also caused regression (#49648) due to not updated property flags (which was later fixed).

After the recent metadata rework, (almost) all problems about storing something in metadata are gone, so this PR restores it + also unexposes the access methods. Now you can only edit this property in the inspector, as there is no use to access it from code. Another property like that is `gizmo_extents` in Position2D.