### PR TITLE
Mention that grab_focus is more reliable deferred

### DIFF
--- a/doc/classes/Callable.xml
+++ b/doc/classes/Callable.xml
@@ -75,6 +75,10 @@
 			<return type="void" />
 			<description>
 				Calls the method represented by this [Callable] in deferred mode, i.e. during the idle frame. Arguments can be passed and should match the method's signature.
+				[codeblock]
+				func _ready():
+				    grab_focus.call_deferred()
+				[/codeblock]
 			</description>
 		</method>
 		<method name="get_method" qualifiers="const">

--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -553,6 +553,7 @@
 			<return type="void" />
 			<description>
 				Steal the focus from another control and become the focused control (see [member focus_mode]).
+				[b]Note[/b]: Using this method together with [method Callable.call_deferred] makes it more reliable, especially when called inside [method Node._ready].
 			</description>
 		</method>
 		<method name="has_focus" qualifiers="const">


### PR DESCRIPTION
Addresses issues like #57257
Even in editor's code `call_deferred(SNAME("grab_focus")` is quite common.

I also added an example usage for `call_deferred()` (which could be any method).