### PR TITLE
Fix TouchScreenButton error spam

### DIFF
--- a/scene/2d/touch_screen_button.cpp
+++ b/scene/2d/touch_screen_button.cpp
@@ -190,15 +190,13 @@ String TouchScreenButton::get_action() const {
 void TouchScreenButton::input(const Ref<InputEvent> &p_event) {
 	ERR_FAIL_COND(p_event.is_null());
 
-	if (!get_tree()) {
+	if (!is_visible_in_tree()) {
 		return;
 	}
 
 	if (p_event->get_device() != 0) {
 		return;
 	}
-
-	ERR_FAIL_COND(!is_visible_in_tree());
 
 	const InputEventScreenTouch *st = Object::cast_to<InputEventScreenTouch>(*p_event);
 


### PR DESCRIPTION
Fixes #47501
The reason it happened is that TouchScreenButton enables input based on visibility and it expected to be visible in its `input()` method. But the user can easily override this, like by adding `_input()` method to your script, which automatically enables input processing. We'd need to have `_input_internal()` to avoid such situations.

In any case, the error is not useful, so this PR simply silences it.