### PR TITLE
Android: Update `resize` settings

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -863,6 +863,7 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 	bool classify_as_game = p_preset->get("package/classify_as_game");
 	bool retain_data_on_uninstall = p_preset->get("package/retain_data_on_uninstall");
 	bool exclude_from_recents = p_preset->get("package/exclude_from_recents");
+	bool is_resizeable = p_preset->get("screen/is_resizeable");
 
 	Vector<String> perms;
 	// Write permissions into the perms variable.
@@ -978,6 +979,10 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 
 					if (tname == "activity" && attrname == "excludeFromRecents") {
 						encode_uint32(exclude_from_recents, &p_manifest.write[iofs + 16]);
+					}
+
+					if (tname == "activity" && attrname == "resizeableActivity") {
+						encode_uint32(is_resizeable, &p_manifest.write[iofs + 16]);
 					}
 
 					if (tname == "supports-screens") {
@@ -1733,6 +1738,7 @@ void EditorExportPlatformAndroid::get_export_options(List<ExportOption> *r_optio
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/support_normal"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/support_large"), true));
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/support_xlarge"), true));
+	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "screen/is_resizeable"), false));
 
 	r_options->push_back(ExportOption(PropertyInfo(Variant::BOOL, "user_data_backup/allow"), false));
 

--- a/platform/android/export/gradle_export_util.cpp
+++ b/platform/android/export/gradle_export_util.cpp
@@ -253,11 +253,13 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset) {
 	String orientation = _get_android_orientation_label(DisplayServer::ScreenOrientation(int(GLOBAL_GET("display/window/handheld/orientation"))));
 	String manifest_activity_text = vformat(
 			"        <activity android:name=\"com.godot.game.GodotApp\" "
-			"tools:replace=\"android:screenOrientation,android:excludeFromRecents\" "
+			"tools:replace=\"android:screenOrientation,android:excludeFromRecents,android:resizeableActivity\" "
 			"android:excludeFromRecents=\"%s\" "
-			"android:screenOrientation=\"%s\">\n",
+			"android:screenOrientation=\"%s\" "
+			"android:resizeableActivity=\"%s\">\n",
 			bool_to_string(p_preset->get("package/exclude_from_recents")),
-			orientation);
+			orientation,
+			bool_to_string(p_preset->get("screen/is_resizeable")));
 	if (uses_xr) {
 		manifest_activity_text += "            <meta-data tools:node=\"replace\" android:name=\"com.oculus.vr.focusaware\" android:value=\"true\" />\n";
 	} else {

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -29,8 +29,7 @@
             android:name=".GodotProjectManager"
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:launchMode="singleTask"
-            android:resizeableActivity="false"
-            android:screenOrientation="landscape"
+            android:screenOrientation="userLandscape"
             android:exported="true"
             android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"
             android:process=":GodotProjectManager">
@@ -46,8 +45,7 @@
             android:configChanges="orientation|keyboardHidden|screenSize|smallestScreenSize|density|keyboard|navigation|screenLayout|uiMode"
             android:process=":GodotEditor"
             android:launchMode="singleTask"
-            android:resizeableActivity="false"
-            android:screenOrientation="landscape"
+            android:screenOrientation="userLandscape"
             android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
         </activity>
 
@@ -57,8 +55,7 @@
             android:label="@string/godot_project_name_string"
             android:process=":GodotGame"
             android:launchMode="singleTask"
-            android:resizeableActivity="false"
-            android:screenOrientation="landscape"
+            android:screenOrientation="userLandscape"
             android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
         </activity>
 

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -198,11 +198,14 @@ void GodotIOJavaWrapper::hide_vk() {
 }
 
 void GodotIOJavaWrapper::set_screen_orientation(int p_orient) {
+	// The Godot Android Editor sets its own orientation via its AndroidManifest
+#ifndef TOOLS_ENABLED
 	if (_set_screen_orientation) {
 		JNIEnv *env = get_jni_env();
 		ERR_FAIL_COND(env == nullptr);
 		env->CallVoidMethod(godot_io_instance, _set_screen_orientation, p_orient);
 	}
+#endif
 }
 
 int GodotIOJavaWrapper::get_screen_orientation() {


### PR DESCRIPTION
Update `resize` settings

- Unlock resizing for the Godot Editor
- Add an option to specify whether a game is resizeable for the Godot template

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
