### PR TITLE
Delay font texture update, until `draw` is called. Rasterize glyphs during shaping.

### DIFF
--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -159,6 +159,7 @@ class TextServerAdvanced : public TextServerExtension {
 		int texture_h = 0;
 		PackedInt32Array offsets;
 		Ref<ImageTexture> texture;
+		bool dirty = true;
 	};
 
 	struct FontTexturePosition {

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -127,6 +127,7 @@ class TextServerFallback : public TextServerExtension {
 		int texture_h = 0;
 		PackedInt32Array offsets;
 		Ref<ImageTexture> texture;
+		bool dirty = true;
 	};
 
 	struct FontTexturePosition {
@@ -343,8 +344,12 @@ public:
 	virtual bool has(const RID &p_rid) override;
 	virtual bool load_support_data(const String &p_filename) override;
 
-	virtual String get_support_data_filename() const override { return ""; };
-	virtual String get_support_data_info() const override { return "Not supported"; };
+	virtual String get_support_data_filename() const override {
+		return "";
+	};
+	virtual String get_support_data_info() const override {
+		return "Not supported";
+	};
 	virtual bool save_support_data(const String &p_filename) const override;
 
 	virtual bool is_locale_right_to_left(const String &p_locale) const override;


### PR DESCRIPTION
Should increase new font loading (and maybe startup times), font variation changes and rendering text with the glyph that was not used before. Instead of updating the texture when each new glyph is encountered, all glyphs updates are processed at once, and only when trying to draw.

Substantially, decreases the number of times font texture is uploaded to GPU. For Project Manager opening from `100` to `4`. And from `160` to `38` when opening simple project with some extra fonts used.