### PR TITLE
Fix issues with multiple bind patterns in match statement

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1863,7 +1863,7 @@ GDScriptParser::MatchBranchNode *GDScriptParser::parse_match_branch() {
 		if (pattern == nullptr) {
 			continue;
 		}
-		if (pattern->pattern_type == PatternNode::PT_BIND) {
+		if (pattern->binds.size() > 0) {
 			has_bind = true;
 		}
 		if (branch->patterns.size() > 0 && has_bind) {
@@ -1899,6 +1899,7 @@ GDScriptParser::MatchBranchNode *GDScriptParser::parse_match_branch() {
 
 		for (const StringName &E : binds) {
 			SuiteNode::Local local(branch->patterns[0]->binds[E], current_function);
+			local.type = SuiteNode::Local::PATTERN_BIND;
 			suite->add_local(local);
 		}
 	}

--- a/modules/gdscript/tests/scripts/parser/errors/match_multiple_variable_binds_in_branch.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/match_multiple_variable_binds_in_branch.gd
@@ -1,0 +1,4 @@
+func test():
+    match 1:
+        [[[var a]]], 2:
+            pass

--- a/modules/gdscript/tests/scripts/parser/errors/match_multiple_variable_binds_in_branch.out
+++ b/modules/gdscript/tests/scripts/parser/errors/match_multiple_variable_binds_in_branch.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Cannot use a variable bind with multiple patterns.

--- a/modules/gdscript/tests/scripts/parser/features/match_multiple_variable_binds_in_pattern.gd
+++ b/modules/gdscript/tests/scripts/parser/features/match_multiple_variable_binds_in_pattern.gd
@@ -1,0 +1,6 @@
+func test():
+    match [1, 2, 3]:
+        [var a, var b, var c]:
+            print(a == 1)
+            print(b == 2)
+            print(c == 3)

--- a/modules/gdscript/tests/scripts/parser/features/match_multiple_variable_binds_in_pattern.out
+++ b/modules/gdscript/tests/scripts/parser/features/match_multiple_variable_binds_in_pattern.out
@@ -1,0 +1,4 @@
+GDTEST_OK
+true
+true
+true


### PR DESCRIPTION
Fixes #59389
Fixes #59391

---

#59389 is caused by `SuiteNode::Local` structs automatically having the `FOR_VARIABLE` type when they are constructed from an `IdentifierNode` or a `StringName`:
https://github.com/godotengine/godot/blob/91d617718717d0ff1f00b477b8a128b694476756/modules/gdscript/gdscript_parser.h#L1015-L1016
Here, a `Local` is created as such and isn't adjusted to be of the correct type (`PATTERN_BIND`):
https://github.com/godotengine/godot/blob/91d617718717d0ff1f00b477b8a128b694476756/modules/gdscript/gdscript_parser.cpp#L1897-L1903
This prevents it from being added to `codegen.locals`:
https://github.com/godotengine/godot/blob/91d617718717d0ff1f00b477b8a128b694476756/modules/gdscript/gdscript_compiler.cpp#L1599-L1602

---

#59391 happens because the bind patterns that are nested in other patterns aren't accounted for when checking for multiple patterns in a single branch that have bind patterns in them:
https://github.com/godotengine/godot/blob/91d617718717d0ff1f00b477b8a128b694476756/modules/gdscript/gdscript_parser.cpp#L1866-L1871