### PR TITLE
[3.x] `SpaceBullet::recover_from_penetration`: skip compound shapes without child shapes

### DIFF
--- a/modules/bullet/space_bullet.cpp
+++ b/modules/bullet/space_bullet.cpp
@@ -1256,6 +1256,9 @@ bool SpaceBullet::recover_from_penetration(RigidBodyBullet *p_body, const btTran
 
 			if (otherObject->getCollisionShape()->isCompound()) {
 				const btCompoundShape *cs = static_cast<const btCompoundShape *>(otherObject->getCollisionShape());
+				if (cs->getNumChildShapes() == 0) {
+					continue; // No shapes to depenetrate from.
+				}
 				int shape_idx = recover_broad_result.results[i].compound_child_index;
 				ERR_FAIL_COND_V(shape_idx < 0 || shape_idx >= cs->getNumChildShapes(), false);
 


### PR DESCRIPTION
Before, this case would incorrectly be treated as an error, causing an early return, in particular skipping other possibly relevant shapes.

Fixes https://github.com/godotengine/godot/issues/59826 (which involves a GridMap without any collision shapes, causing depenetration from the floor to be skipped)