### PR TITLE
[3.x] Update Android Editor default display scale

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -1463,7 +1463,7 @@ String EditorSettings::get_editor_layouts_config() const {
 }
 
 float EditorSettings::get_auto_display_scale() const {
-#ifdef OSX_ENABLED
+#if defined(OSX_ENABLED) || defined(ANDROID_ENABLED)
 	return OS::get_singleton()->get_screen_max_scale();
 #else
 	const int screen = OS::get_singleton()->get_current_screen();

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.java
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotEditor.java
@@ -107,4 +107,18 @@ public class GodotEditor extends FullScreenGodotApp {
 		Intent newInstance = new Intent(this, targetClass).putExtra(COMMAND_LINE_PARAMS, args);
 		startActivity(newInstance);
 	}
+
+	@Override
+	public void setRequestedOrientation(int requestedOrientation) {
+		if (!overrideOrientationRequest()) {
+			super.setRequestedOrientation(requestedOrientation);
+		}
+	}
+
+	/**
+	 * The Godot Android Editor sets its own orientation via its AndroidManifest
+	 */
+	protected boolean overrideOrientationRequest() {
+		return true;
+	}
 }

--- a/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame.java
+++ b/platform/android/java/editor/src/main/java/org/godotengine/editor/GodotGame.java
@@ -34,4 +34,7 @@ package org.godotengine.editor;
  * Drives the 'run project' window of the Godot Editor.
  */
 public class GodotGame extends GodotEditor {
+	protected boolean overrideOrientationRequest() {
+		return false;
+	}
 }

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -222,8 +222,12 @@ public class GodotIO {
 	}
 
 	public int getScreenDPI() {
-		DisplayMetrics metrics = activity.getApplicationContext().getResources().getDisplayMetrics();
+		DisplayMetrics metrics = activity.getResources().getDisplayMetrics();
 		return (int)(metrics.density * 160f);
+	}
+
+	public float getScaledDensity() {
+		return activity.getResources().getDisplayMetrics().scaledDensity;
 	}
 
 	public double getScreenRefreshRate(double fallback) {

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -53,6 +53,7 @@ GodotIOJavaWrapper::GodotIOJavaWrapper(JNIEnv *p_env, jobject p_godot_io_instanc
 		_get_locale = p_env->GetMethodID(cls, "getLocale", "()Ljava/lang/String;");
 		_get_model = p_env->GetMethodID(cls, "getModel", "()Ljava/lang/String;");
 		_get_screen_DPI = p_env->GetMethodID(cls, "getScreenDPI", "()I");
+		_get_scaled_density = p_env->GetMethodID(cls, "getScaledDensity", "()F");
 		_get_screen_refresh_rate = p_env->GetMethodID(cls, "getScreenRefreshRate", "(D)D");
 		_get_window_safe_area = p_env->GetMethodID(cls, "getWindowSafeArea", "()[I"),
 		_get_unique_id = p_env->GetMethodID(cls, "getUniqueID", "()Ljava/lang/String;");
@@ -134,6 +135,16 @@ int GodotIOJavaWrapper::get_screen_dpi() {
 		return env->CallIntMethod(godot_io_instance, _get_screen_DPI);
 	} else {
 		return 160;
+	}
+}
+
+float GodotIOJavaWrapper::get_scaled_density() {
+	if (_get_scaled_density) {
+		JNIEnv *env = get_jni_env();
+		ERR_FAIL_COND_V(env == nullptr, 1.0f);
+		return env->CallFloatMethod(godot_io_instance, _get_scaled_density);
+	} else {
+		return 1.0f;
 	}
 }
 

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -51,6 +51,7 @@ private:
 	jmethodID _get_locale = 0;
 	jmethodID _get_model = 0;
 	jmethodID _get_screen_DPI = 0;
+	jmethodID _get_scaled_density = 0;
 	jmethodID _get_screen_refresh_rate = 0;
 	jmethodID _get_window_safe_area = 0;
 	jmethodID _get_unique_id = 0;
@@ -72,6 +73,7 @@ public:
 	String get_locale();
 	String get_model();
 	int get_screen_dpi();
+	float get_scaled_density();
 	void get_window_safe_area(int (&p_rect_xywh)[4]);
 	float get_screen_refresh_rate(float p_fallback);
 	String get_unique_id();

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -472,6 +472,14 @@ int OS_Android::get_screen_dpi(int p_screen) const {
 	return godot_io_java->get_screen_dpi();
 }
 
+float OS_Android::get_screen_scale(int p_screen) const {
+	return godot_io_java->get_scaled_density();
+}
+
+float OS_Android::get_screen_max_scale() const {
+	return get_screen_scale();
+}
+
 float OS_Android::get_screen_refresh_rate(int p_screen) const {
 	return godot_io_java->get_screen_refresh_rate(OS::get_singleton()->SCREEN_REFRESH_RATE_FALLBACK);
 }

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -157,6 +157,8 @@ public:
 	virtual bool has_clipboard() const;
 	virtual String get_model_name() const;
 	virtual int get_screen_dpi(int p_screen = 0) const;
+	virtual float get_screen_scale(int p_screen = -1) const;
+	virtual float get_screen_max_scale() const;
 	virtual float get_screen_refresh_rate(int p_screen = 0) const;
 
 	virtual bool get_window_per_pixel_transparency_enabled() const { return transparency_enabled; }


### PR DESCRIPTION
Updates  the editor display scale based on the device's scaled density

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
