### PR TITLE
Animation State Machine: allow multiple transitions with the same from and to nodes

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -267,15 +267,10 @@ void AnimationNodeStateMachineEditor::_state_machine_gui_input(const Ref<InputEv
 			Ref<AnimationNodeStateMachine> anodesm = node;
 			Ref<AnimationNodeEndState> end_node = node;
 
-			if (state_machine->has_transition(connecting_from, connecting_to_node) && state_machine->can_edit_node(connecting_to_node) && !anodesm.is_valid()) {
-				EditorNode::get_singleton()->show_warning(TTR("Transition exists!"));
-				connecting = false;
+			if (anodesm.is_valid() || end_node.is_valid()) {
+				_open_connect_menu(mb->get_position());
 			} else {
-				if (anodesm.is_valid() || end_node.is_valid()) {
-					_open_connect_menu(mb->get_position());
-				} else {
-					_add_transition();
-				}
+				_add_transition();
 			}
 		} else {
 			_open_menu(mb->get_position());
@@ -1047,12 +1042,6 @@ void AnimationNodeStateMachineEditor::_connect_to(int p_index) {
 
 void AnimationNodeStateMachineEditor::_add_transition(const bool p_nested_action) {
 	if (connecting_from != StringName() && connecting_to_node != StringName()) {
-		if (state_machine->has_transition(connecting_from, connecting_to_node)) {
-			EditorNode::get_singleton()->show_warning("Transition exists!");
-			connecting = false;
-			return;
-		}
-
 		Ref<AnimationNodeStateMachineTransition> tr;
 		tr.instantiate();
 		tr->set_switch_mode(AnimationNodeStateMachineTransition::SwitchMode(transition_mode->get_selected()));

--- a/scene/animation/animation_node_state_machine.cpp
+++ b/scene/animation/animation_node_state_machine.cpp
@@ -948,10 +948,6 @@ void AnimationNodeStateMachine::add_transition(const StringName &p_from, const S
 	ERR_FAIL_COND(!_can_connect(to));
 	ERR_FAIL_COND(p_transition.is_null());
 
-	for (int i = 0; i < transitions.size(); i++) {
-		ERR_FAIL_COND(transitions[i].from == from && transitions[i].to == to);
-	}
-
 	if (path_from.size() > 1 || path_to.size() > 1) {
 		ERR_FAIL_COND(path_from[0] == path_to[0]);
 	}


### PR DESCRIPTION
I have a use case that is kind of hard to work around with the restriction of only one transition for each direction between two nodes. The simplified version is my character has attack and idle animation states, and I want to go back from attack to idle when either the animation is fully played, or the attack is interrupted for whatever reason. If I have only one transition with "At End", it seems I cant easily force interrupt the state to go to the next state.

So I hacked around a bit and allowed multiple transitions from and to the same nodes. Seems work for my case, but it's not the most performant code, and not thoroughly tested. I wonder if the use case is common enough that I should submit a pull request still :P
![transitions](https://user-images.githubusercontent.com/5029519/161547937-885a5a64-7944-4b86-93aa-7e511083004b.jpg)

Update 5/4/2022:
Changed the code to work with https://github.com/godotengine/godot/pull/24402 . So now the duplicate transtions can exist in a multi-transtion. The code change is now removing restrictions that don't allow transitions with the same from and to nodes.

So it now looks like this - transitions within the same multi transition, with the same from and to node, but different conditions.

![image](https://user-images.githubusercontent.com/5029519/166622530-f8aa9025-c2c0-4471-a01f-35e733d39bca.png)
![image](https://user-images.githubusercontent.com/5029519/166622906-30e66a14-fc63-4e88-93c6-8ada7aef2125.png)


