### PR TITLE
Physics interpolation - Fix multithreaded rendering

### DIFF
--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -535,7 +535,7 @@ bool SceneTree::iteration(float p_time) {
 
 	current_frame++;
 
-	if (root->get_world().is_valid()) {
+	if (_physics_interpolation_enabled && root->get_world().is_valid()) {
 		RID scenario = root->get_world()->get_scenario();
 		if (scenario.is_valid()) {
 			VisualServer::get_singleton()->scenario_tick(scenario);
@@ -686,7 +686,7 @@ bool SceneTree::idle(float p_time) {
 
 #endif
 
-	if (root->get_world().is_valid()) {
+	if (_physics_interpolation_enabled && root->get_world().is_valid()) {
 		RID scenario = root->get_world()->get_scenario();
 		if (scenario.is_valid()) {
 			VisualServer::get_singleton()->scenario_pre_draw(scenario, true);

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -94,14 +94,6 @@ void VisualServerRaster::request_frame_drawn_callback(Object *p_where, const Str
 	frame_drawn_callbacks.push_back(fdc);
 }
 
-void VisualServerRaster::scenario_tick(RID p_scenario) {
-	VSG::scene->_scenario_tick(p_scenario);
-}
-
-void VisualServerRaster::scenario_pre_draw(RID p_scenario, bool p_will_draw) {
-	VSG::scene->_scenario_pre_draw(p_scenario, p_will_draw);
-}
-
 void VisualServerRaster::draw(bool p_swap_buffers, double frame_step) {
 	//needs to be done before changes is reset to 0, to not force the editor to redraw
 	VS::get_singleton()->emit_signal("frame_pre_draw");

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -118,10 +118,14 @@ public:
 
 #define BIND1(m_name, m_type1) \
 	void m_name(m_type1 arg1) { DISPLAY_CHANGED BINDBASE->m_name(arg1); }
+#define BIND1N(m_name, m_type1) \
+	void m_name(m_type1 arg1) { BINDBASE->m_name(arg1); }
 #define BIND2(m_name, m_type1, m_type2) \
 	void m_name(m_type1 arg1, m_type2 arg2) { DISPLAY_CHANGED BINDBASE->m_name(arg1, arg2); }
 #define BIND2C(m_name, m_type1, m_type2) \
 	void m_name(m_type1 arg1, m_type2 arg2) const { BINDBASE->m_name(arg1, arg2); }
+#define BIND2N(m_name, m_type1, m_type2) \
+	void m_name(m_type1 arg1, m_type2 arg2) { BINDBASE->m_name(arg1, arg2); }
 #define BIND3(m_name, m_type1, m_type2, m_type3) \
 	void m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3) { DISPLAY_CHANGED BINDBASE->m_name(arg1, arg2, arg3); }
 #define BIND4(m_name, m_type1, m_type2, m_type3, m_type4) \
@@ -149,7 +153,6 @@ public:
 #define BINDBASE VSG::storage
 
 	/* TEXTURE API */
-
 	BIND0R(RID, texture_create)
 	BIND7(texture_allocate, RID, int, int, int, Image::Format, TextureType, uint32_t)
 	BIND3(texture_set_data, RID, const Ref<Image> &, int)
@@ -447,6 +450,11 @@ public:
 #undef BINDBASE
 //from now on, calls forwarded to this singleton
 #define BINDBASE VSG::scene
+
+	/* EVENT QUEUING */
+
+	BIND1N(scenario_tick, RID)
+	BIND2N(scenario_pre_draw, RID, bool)
 
 	/* CAMERA API */
 
@@ -764,8 +772,6 @@ public:
 	virtual bool has_changed(ChangedPriority p_priority = CHANGED_PRIORITY_ANY) const;
 	virtual void init();
 	virtual void finish();
-	virtual void scenario_tick(RID p_scenario);
-	virtual void scenario_pre_draw(RID p_scenario, bool p_will_draw);
 
 	/* STATUS INFORMATION */
 

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -476,7 +476,7 @@ void VisualServerScene::scenario_set_physics_interpolation_enabled(RID p_scenari
 	scenario->_interpolation_data.interpolation_enabled = p_enabled;
 }
 
-void VisualServerScene::_scenario_tick(RID p_scenario) {
+void VisualServerScene::scenario_tick(RID p_scenario) {
 	Scenario *scenario = scenario_owner.get(p_scenario);
 	ERR_FAIL_COND(!scenario);
 
@@ -485,7 +485,7 @@ void VisualServerScene::_scenario_tick(RID p_scenario) {
 	}
 }
 
-void VisualServerScene::_scenario_pre_draw(RID p_scenario, bool p_will_draw) {
+void VisualServerScene::scenario_pre_draw(RID p_scenario, bool p_will_draw) {
 	Scenario *scenario = scenario_owner.get(p_scenario);
 	ERR_FAIL_COND(!scenario);
 

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -306,8 +306,8 @@ public:
 	virtual void scenario_set_fallback_environment(RID p_scenario, RID p_environment);
 	virtual void scenario_set_reflection_atlas_size(RID p_scenario, int p_size, int p_subdiv);
 	virtual void scenario_set_physics_interpolation_enabled(RID p_scenario, bool p_enabled);
-	void _scenario_tick(RID p_scenario);
-	void _scenario_pre_draw(RID p_scenario, bool p_will_draw);
+	void scenario_tick(RID p_scenario);
+	void scenario_pre_draw(RID p_scenario, bool p_will_draw);
 
 	/* INSTANCING API */
 

--- a/servers/visual/visual_server_wrap_mt.cpp
+++ b/servers/visual/visual_server_wrap_mt.cpp
@@ -36,18 +36,6 @@ void VisualServerWrapMT::thread_exit() {
 	exit.set();
 }
 
-void VisualServerWrapMT::thread_scenario_tick(RID p_scenario) {
-	if (!draw_pending.decrement()) {
-		visual_server->scenario_tick(p_scenario);
-	}
-}
-
-void VisualServerWrapMT::thread_scenario_pre_draw(RID p_scenario, bool p_will_draw) {
-	if (!draw_pending.decrement()) {
-		visual_server->scenario_pre_draw(p_scenario, p_will_draw);
-	}
-}
-
 void VisualServerWrapMT::thread_draw(bool p_swap_buffers, double frame_step) {
 	if (!draw_pending.decrement()) {
 		visual_server->draw(p_swap_buffers, frame_step);
@@ -91,24 +79,6 @@ void VisualServerWrapMT::sync() {
 		command_queue.push_and_sync(this, &VisualServerWrapMT::thread_flush);
 	} else {
 		command_queue.flush_all(); //flush all pending from other threads
-	}
-}
-
-void VisualServerWrapMT::scenario_tick(RID p_scenario) {
-	if (create_thread) {
-		draw_pending.increment();
-		command_queue.push(this, &VisualServerWrapMT::thread_scenario_tick, p_scenario);
-	} else {
-		visual_server->scenario_tick(p_scenario);
-	}
-}
-
-void VisualServerWrapMT::scenario_pre_draw(RID p_scenario, bool p_will_draw) {
-	if (create_thread) {
-		draw_pending.increment();
-		command_queue.push(this, &VisualServerWrapMT::thread_scenario_pre_draw, p_scenario, p_will_draw);
-	} else {
-		visual_server->scenario_pre_draw(p_scenario, p_will_draw);
 	}
 }
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -669,13 +669,13 @@ public:
 	/* EVENT QUEUING */
 
 	FUNC3(request_frame_drawn_callback, Object *, const StringName &, const Variant &)
+	FUNC1(scenario_tick, RID)
+	FUNC2(scenario_pre_draw, RID, bool)
 
 	virtual void init();
 	virtual void finish();
 	virtual void draw(bool p_swap_buffers, double frame_step);
 	virtual void sync();
-	virtual void scenario_tick(RID p_scenario);
-	virtual void scenario_pre_draw(RID p_scenario, bool p_will_draw);
 	FUNC1RC(bool, has_changed, ChangedPriority)
 
 	/* RENDER INFO */


### PR DESCRIPTION
Fixes physics interpolation ticking and pre-draw not working in multithreaded rendering mode.

Fixes #59736

I moved the interpolation tick and frame updates to use the regular VisualServer macros, as discussed in the PR meeting. This worked fine in game, but I noticed a problem - the regular macros call `DISPLAY_CHANGED` and thus force a continuous screen redraw, particularly in the editor, as they are called on every physics tick and every frame.

So rather than go back to the more verbose previous approach, I've simply added two new `BIND1` type macros which don't call `DISPLAY_CHANGED`. This seems to work and prevents the editor constantly updating.

I've done some research and debugging and worked out that in multithreaded mode it calls _both_ the `FUNC1` type macros _and_ the `BIND1` type macros. This explains why the PR works in both single threaded and multithreaded mode and confirms it is the correct fix.

I've also added a `_physics_interpolation_enabled` check in `scene_tree.cpp` before it calls the update functions, as they are currently only used for physics interpolation, just as an extra safety measure to ensure we aren't doing any extra processing when interpolation is switched off. If we end up using these functions for things in addition to the physics interpolation then we can remove this from the if check.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
