### PR TITLE
Revert "Fix that collision objects ignore canvas transform"

### DIFF
--- a/scene/2d/collision_object_2d.cpp
+++ b/scene/2d/collision_object_2d.cpp
@@ -81,7 +81,7 @@ void CollisionObject2D::_notification(int p_what) {
 				return;
 			}
 
-			Transform2D global_transform = get_global_transform_with_canvas();
+			Transform2D global_transform = get_global_transform();
 
 			if (area) {
 				PhysicsServer2D::get_singleton()->area_set_transform(rid, global_transform);


### PR DESCRIPTION
This reverts commit 5521b93750977b3c283672f478360b866e8de202.
fix #59850

This reverts #59737, which was intended as a fix for #58514.

In order to resolve issue #58514 properly, more work is needed: this includes changing transform calculations at multiple places, changing transform-caching, adjusting mouse positions and likely other implementation details, that would have to be investigated in detail.

Since #59850 seems to be more severe, I suggest to revert this PR, because it will take more time to create a proper fix for #58514.
