### PR TITLE
Add Dictionary.merge()

### DIFF
--- a/core/variant/dictionary.cpp
+++ b/core/variant/dictionary.cpp
@@ -269,6 +269,14 @@ void Dictionary::clear() {
 	_p->variant_map.clear();
 }
 
+void Dictionary::merge(const Dictionary &p_dictionary, bool p_overwrite) {
+	for (const KeyValue<Variant, Variant> &E : p_dictionary._p->variant_map) {
+		if (p_overwrite || !has(E.key)) {
+			this->operator[](E.key) = E.value;
+		}
+	}
+}
+
 void Dictionary::_unref() const {
 	ERR_FAIL_COND(!_p);
 	if (_p->refcount.unref()) {

--- a/core/variant/dictionary.h
+++ b/core/variant/dictionary.h
@@ -62,6 +62,7 @@ public:
 	int size() const;
 	bool is_empty() const;
 	void clear();
+	void merge(const Dictionary &p_dictionary, bool p_overwrite = false);
 
 	bool has(const Variant &p_key) const;
 	bool has_all(const Array &p_keys) const;

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1808,6 +1808,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(Dictionary, size, sarray(), varray());
 	bind_method(Dictionary, is_empty, sarray(), varray());
 	bind_method(Dictionary, clear, sarray(), varray());
+	bind_method(Dictionary, merge, sarray("dictionary", "overwrite"), varray(false));
 	bind_method(Dictionary, has, sarray("key"), varray());
 	bind_method(Dictionary, has_all, sarray("keys"), varray());
 	bind_method(Dictionary, erase, sarray("key"), varray());

--- a/doc/classes/Dictionary.xml
+++ b/doc/classes/Dictionary.xml
@@ -291,6 +291,14 @@
 				Returns the list of keys in the [Dictionary].
 			</description>
 		</method>
+		<method name="merge">
+			<return type="void" />
+			<argument index="0" name="dictionary" type="Dictionary" />
+			<argument index="1" name="overwrite" type="bool" default="false" />
+			<description>
+				Adds elements from [code]dictionary[/code] to this [Dictionary]. By default, duplicate keys will not be copied over, unless [code]overwrite[/code] is [code]true[/code].
+			</description>
+		</method>
 		<method name="size" qualifiers="const">
 			<return type="int" />
 			<description>


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/3739, based on my comment here: https://github.com/godotengine/godot-proposals/issues/1756#issuecomment-721988595
with 2 differences:
- it modifies the Dictionary instead of creating a new one
- I added `overwrite` parameter