### PR TITLE
Improve autoload inheritance error message

### DIFF
--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -406,7 +406,7 @@ Node *EditorAutoloadSettings::_create_autoload(const String &p_path) {
 	} else if (script.is_valid()) {
 		StringName ibt = script->get_instance_base_type();
 		bool valid_type = ClassDB::is_parent_class(ibt, "Node");
-		ERR_FAIL_COND_V_MSG(!valid_type, nullptr, "Script does not inherit a Node: " + p_path + ".");
+		ERR_FAIL_COND_V_MSG(!valid_type, nullptr, "Script does not inherit from Node: " + p_path + ".");
 
 		Object *obj = ClassDB::instantiate(ibt);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2336,7 +2336,7 @@ bool Main::start() {
 					} else if (script_res.is_valid()) {
 						StringName ibt = script_res->get_instance_base_type();
 						bool valid_type = ClassDB::is_parent_class(ibt, "Node");
-						ERR_CONTINUE_MSG(!valid_type, "Script does not inherit a Node: " + info.path);
+						ERR_CONTINUE_MSG(!valid_type, "Script does not inherit from Node: " + info.path);
 
 						Object *obj = ClassDB::instantiate(ibt);
 

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -80,7 +80,7 @@ void init_autoloads() {
 		} else if (script.is_valid()) {
 			StringName ibt = script->get_instance_base_type();
 			bool valid_type = ClassDB::is_parent_class(ibt, "Node");
-			ERR_CONTINUE_MSG(!valid_type, "Script does not inherit a Node: " + info.path);
+			ERR_CONTINUE_MSG(!valid_type, "Script does not inherit from Node: " + info.path);
 
 			Object *obj = ClassDB::instantiate(ibt);
 


### PR DESCRIPTION
Autoloaded scripts should always inherit from `Node`. When you run a
project that tries to autoload a script which doesn’t inherit from `Node`,
then Godot gives an error.

Before this change, the error said “Script does not inherit a Node”.
That error message is a little bit misleading. If a class inherits a
`Node`, then one of its superclasses has a Node. If a class inherits
_from_ `Node`, then one of its superclasses is `Node`. This change corrects
that mistake.

Fixes #59884.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
