### PR TITLE
Fixes variable nodes not showing updated name in visualscript editor

### DIFF
--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -228,6 +228,7 @@ private:
 	};
 
 	struct Variable {
+		Map<int, Ref<VisualScriptNode>> nodes;
 		PropertyInfo info;
 		Variant default_value;
 		bool _export;


### PR DESCRIPTION
Fixes #59449
_Due to different API `master` & `3.x`, separate PR has been made._ 

*Bugsquad edit:* `3.x` equivalent to #55291.

**Bug reason:**
`variable` and `custom_signal` nodes are not properly tracked by the `visual_script`, unlike `function` nodes.  This PR fixes that and also fixes whenever a `variable` is renamed, all of it's corresponding nodes are updated and show the new name.

**To produce the bug:**
- Create a variable in Visual Script Editor
- Drag and drop a setter/getter node of that variable
- Rename the variable in the editor
- The name of the existing setter/getter variable node does not change - (_Bug_)
- If you drop another setter/getter node of the same variable, that node will display the updated name. But the old node will not do the same.

**Results:**
_As you can see, now the new name of the variable is updated in the existing variable getter/setter nodes that are in the editor_

https://user-images.githubusercontent.com/41969735/162732898-e664ebde-f0c1-46c1-8ff1-5710fc9eb283.mp4

**Note:**
**Since it is a major change, this PR only fixes it for variable nodes**. **A separate PR has to be made for `custom_signal` nodes**