### PR TITLE
[3.x] Fix event transform in ViewportContainer

### DIFF
--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -147,7 +147,7 @@ void ViewportContainer::_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	Transform2D xform = get_global_transform();
+	Transform2D xform = get_global_transform_with_canvas();
 
 	if (stretch) {
 		Transform2D scale_xf;
@@ -174,7 +174,7 @@ void ViewportContainer::_unhandled_input(const Ref<InputEvent> &p_event) {
 		return;
 	}
 
-	Transform2D xform = get_global_transform();
+	Transform2D xform = get_global_transform_with_canvas();
 
 	if (stretch) {
 		Transform2D scale_xf;


### PR DESCRIPTION
The transform in `ViewportContainer::_input` and `ViewportContainer::_unhandled_input` does not take the canvas transform into account.

fix #59887
3.x version of #59702