### PR TITLE
Style: Partially apply clang-tidy's `cppcoreguidelines-pro-type-member-init`

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks: 'clang-diagnostic-*,clang-analyzer-*,-*,modernize-redundant-void-arg,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-nullptr,readability-braces-around-statements,readability-redundant-member-init'
+Checks: 'clang-diagnostic-*,clang-analyzer-*,-*,cppcoreguidelines-pro-type-member-init,modernize-redundant-void-arg,modernize-use-bool-literals,modernize-use-default-member-init,modernize-use-nullptr,readability-braces-around-statements,readability-redundant-member-init'
 WarningsAsErrors: ''
 HeaderFilterRegex: ''
 AnalyzeTemporaryDtors: false
@@ -12,6 +12,10 @@ CheckOptions:
   - key:             cppcoreguidelines-explicit-virtual-functions.IgnoreDestructors
     value:           '1'
   - key:             cppcoreguidelines-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
+    value:           '1'
+  - key:             cppcoreguidelines-pro-type-member-init.IgnoreArrays
+    value:           '1'
+  - key:             cppcoreguidelines-pro-type-member-init.UseAssignment
     value:           '1'
   - key:             google-readability-function-size.StatementThreshold
     value:           '800'

--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -321,9 +321,9 @@ bool ProjectSettings::_get(const StringName &p_name, Variant &r_ret) const {
 
 struct _VCSort {
 	String name;
-	Variant::Type type;
-	int order;
-	uint32_t flags;
+	Variant::Type type = Variant::VARIANT_MAX;
+	int order = 0;
+	uint32_t flags = 0;
 
 	bool operator<(const _VCSort &p_vcs) const { return order == p_vcs.order ? name < p_vcs.name : order < p_vcs.order; }
 };

--- a/core/core_constants.cpp
+++ b/core/core_constants.cpp
@@ -41,7 +41,7 @@ struct _CoreConstant {
 	StringName enum_name;
 	bool ignore_value_in_docs = false;
 #endif
-	const char *name;
+	const char *name = nullptr;
 	int value = 0;
 
 	_CoreConstant() {}

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -113,10 +113,10 @@ private:
 	int mouse_from_touch_index = -1;
 
 	struct VelocityTrack {
-		uint64_t last_tick;
+		uint64_t last_tick = 0;
 		Vector2 velocity;
 		Vector2 accum;
-		float accum_t;
+		float accum_t = 0.0f;
 		float min_ref_frame;
 		float max_ref_frame;
 

--- a/core/io/file_access_network.h
+++ b/core/io/file_access_network.h
@@ -86,15 +86,15 @@ class FileAccessNetwork : public FileAccess {
 	Semaphore page_sem;
 	Mutex buffer_mutex;
 	bool opened = false;
-	uint64_t total_size;
+	uint64_t total_size = 0;
 	mutable uint64_t pos = 0;
-	int32_t id;
+	int32_t id = -1;
 	mutable bool eof_flag = false;
 	mutable int32_t last_page = -1;
 	mutable uint8_t *last_page_buff = nullptr;
 
-	int32_t page_size;
-	int32_t read_ahead;
+	int32_t page_size = 0;
+	int32_t read_ahead = 0;
 
 	mutable int waiting_on_page = -1;
 
@@ -108,7 +108,8 @@ class FileAccessNetwork : public FileAccess {
 
 	mutable Error response;
 
-	uint64_t exists_modtime;
+	uint64_t exists_modtime = 0;
+
 	friend class FileAccessNetworkClient;
 	void _queue_page(int32_t p_page) const;
 	void _respond(uint64_t p_len, Error p_status);

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -80,7 +80,7 @@ class FileAccessZip : public FileAccess {
 	unzFile zfile = nullptr;
 	unz_file_info64 file_info;
 
-	mutable bool at_eof;
+	mutable bool at_eof = false;
 
 	void _close();
 

--- a/core/io/ip.cpp
+++ b/core/io/ip.cpp
@@ -74,8 +74,7 @@ struct _IP_ResolverPrivate {
 	Semaphore sem;
 
 	Thread thread;
-	//Semaphore* semaphore;
-	bool thread_abort;
+	bool thread_abort = false;
 
 	void resolve_queues() {
 		for (int i = 0; i < IP::RESOLVER_MAX_QUERIES; i++) {

--- a/core/math/convex_hull.cpp
+++ b/core/math/convex_hull.cpp
@@ -666,7 +666,7 @@ public:
 		face_pool.reset(true);
 	}
 
-	Vertex *vertex_list;
+	Vertex *vertex_list = nullptr;
 
 	void compute(const Vector3 *p_coords, int32_t p_count);
 

--- a/core/math/geometry_2d.cpp
+++ b/core/math/geometry_2d.cpp
@@ -74,14 +74,14 @@ Vector<Vector<Vector2>> Geometry2D::decompose_polygon_in_convex(Vector<Point2> p
 struct _AtlasWorkRect {
 	Size2i s;
 	Point2i p;
-	int idx;
+	int idx = 0;
 	_FORCE_INLINE_ bool operator<(const _AtlasWorkRect &p_r) const { return s.width > p_r.s.width; };
 };
 
 struct _AtlasWorkRectResult {
 	Vector<_AtlasWorkRect> result;
-	int max_w;
-	int max_h;
+	int max_w = 0;
+	int max_h = 0;
 };
 
 void Geometry2D::make_atlas(const Vector<Size2i> &p_rects, Vector<Point2i> &r_result, Size2i &r_size) {

--- a/core/math/random_pcg.h
+++ b/core/math/random_pcg.h
@@ -61,8 +61,8 @@ static int __bsr_clz32(uint32_t x) {
 
 class RandomPCG {
 	pcg32_random_t pcg;
-	uint64_t current_seed; // The seed the current generator state started from.
-	uint64_t current_inc;
+	uint64_t current_seed = 0; // The seed the current generator state started from.
+	uint64_t current_inc = 0;
 
 public:
 	static const uint64_t DEFAULT_SEED = 12047754176567800795U;

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -54,7 +54,6 @@ class OS {
 	bool _single_window = false;
 	String _local_clipboard;
 	int _exit_code = EXIT_FAILURE; // unexpected exit is marked as failure
-	int _orientation;
 	bool _allow_hidpi = false;
 	bool _allow_layered = false;
 	bool _stdout_enabled = true;
@@ -68,7 +67,7 @@ class OS {
 	// for the user interface we keep a record of the current display driver
 	// so we can retrieve the rendering drivers available
 	int _display_driver_id = -1;
-	String _current_rendering_driver_name = "";
+	String _current_rendering_driver_name;
 
 protected:
 	void _set_logger(CompositeLogger *p_logger);

--- a/core/os/pool_allocator.h
+++ b/core/os/pool_allocator.h
@@ -77,20 +77,20 @@ private:
 
 	Entry *entry_array = nullptr;
 	int *entry_indices = nullptr;
-	int entry_max;
-	int entry_count;
+	int entry_max = 0;
+	int entry_count = 0;
 
 	uint8_t *pool = nullptr;
 	void *mem_ptr = nullptr;
-	int pool_size;
+	int pool_size = 0;
 
-	int free_mem;
-	int free_mem_peak;
+	int free_mem = 0;
+	int free_mem_peak = 0;
 
-	unsigned int check_count;
-	int align;
+	unsigned int check_count = 0;
+	int align = 1;
 
-	bool needs_locking;
+	bool needs_locking = false;
 
 	inline int entry_end(const Entry &p_entry) const {
 		return p_entry.pos + aligned(p_entry.len);

--- a/core/string/optimized_translation.cpp
+++ b/core/string/optimized_translation.cpp
@@ -37,9 +37,9 @@ extern "C" {
 }
 
 struct CompressedString {
-	int orig_len;
+	int orig_len = 0;
 	CharString compressed;
-	int offset;
+	int offset = 0;
 };
 
 void OptimizedTranslation::generate(const Ref<Translation> &p_from) {

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -949,20 +949,20 @@ struct _VariantCall {
 _VariantCall::ConstantData *_VariantCall::constant_data = nullptr;
 
 struct VariantBuiltInMethodInfo {
-	void (*call)(Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error);
-	Variant::ValidatedBuiltInMethod validated_call;
-	Variant::PTRBuiltInMethod ptrcall;
+	void (*call)(Variant *base, const Variant **p_args, int p_argcount, Variant &r_ret, const Vector<Variant> &p_defvals, Callable::CallError &r_error) = nullptr;
+	Variant::ValidatedBuiltInMethod validated_call = nullptr;
+	Variant::PTRBuiltInMethod ptrcall = nullptr;
 
 	Vector<Variant> default_arguments;
 	Vector<String> argument_names;
 
-	bool is_const;
-	bool is_static;
-	bool has_return_type;
-	bool is_vararg;
+	bool is_const = false;
+	bool is_static = false;
+	bool has_return_type = false;
+	bool is_vararg = false;
 	Variant::Type return_type;
-	int argument_count;
-	Variant::Type (*get_argument_type)(int p_arg);
+	int argument_count = 0;
+	Variant::Type (*get_argument_type)(int p_arg) = nullptr;
 };
 
 typedef OAHashMap<StringName, VariantBuiltInMethodInfo> BuiltinMethodMap;

--- a/core/variant/variant_construct.cpp
+++ b/core/variant/variant_construct.cpp
@@ -31,11 +31,11 @@
 #include "variant_construct.h"
 
 struct VariantConstructData {
-	void (*construct)(Variant &r_base, const Variant **p_args, Callable::CallError &r_error);
-	Variant::ValidatedConstructor validated_construct;
-	Variant::PTRConstructor ptr_construct;
-	Variant::Type (*get_argument_type)(int);
-	int argument_count;
+	void (*construct)(Variant &r_base, const Variant **p_args, Callable::CallError &r_error) = nullptr;
+	Variant::ValidatedConstructor validated_construct = nullptr;
+	Variant::PTRConstructor ptr_construct = nullptr;
+	Variant::Type (*get_argument_type)(int) = nullptr;
+	int argument_count = 0;
 	Vector<String> arg_names;
 };
 

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -805,16 +805,16 @@ INDEXED_SETGET_STRUCT_TYPED(PackedColorArray, Color)
 INDEXED_SETGET_STRUCT_DICT(Dictionary)
 
 struct VariantIndexedSetterGetterInfo {
-	void (*setter)(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob);
-	void (*getter)(const Variant *base, int64_t index, Variant *value, bool *oob);
+	void (*setter)(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) = nullptr;
+	void (*getter)(const Variant *base, int64_t index, Variant *value, bool *oob) = nullptr;
 
-	Variant::ValidatedIndexedSetter validated_setter;
-	Variant::ValidatedIndexedGetter validated_getter;
+	Variant::ValidatedIndexedSetter validated_setter = nullptr;
+	Variant::ValidatedIndexedGetter validated_getter = nullptr;
 
-	Variant::PTRIndexedSetter ptr_setter;
-	Variant::PTRIndexedGetter ptr_getter;
+	Variant::PTRIndexedSetter ptr_setter = nullptr;
+	Variant::PTRIndexedGetter ptr_getter = nullptr;
 
-	uint64_t (*get_indexed_size)(const Variant *base);
+	uint64_t (*get_indexed_size)(const Variant *base) = nullptr;
 
 	Variant::Type index_type;
 
@@ -1018,13 +1018,13 @@ struct VariantKeyedSetGetObject {
 };
 
 struct VariantKeyedSetterGetterInfo {
-	Variant::ValidatedKeyedSetter validated_setter;
-	Variant::ValidatedKeyedGetter validated_getter;
-	Variant::ValidatedKeyedChecker validated_checker;
+	Variant::ValidatedKeyedSetter validated_setter = nullptr;
+	Variant::ValidatedKeyedGetter validated_getter = nullptr;
+	Variant::ValidatedKeyedChecker validated_checker = nullptr;
 
-	Variant::PTRKeyedSetter ptr_setter;
-	Variant::PTRKeyedGetter ptr_getter;
-	Variant::PTRKeyedChecker ptr_checker;
+	Variant::PTRKeyedSetter ptr_setter = nullptr;
+	Variant::PTRKeyedGetter ptr_getter = nullptr;
+	Variant::PTRKeyedChecker ptr_checker = nullptr;
 
 	bool valid = false;
 };

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -1110,14 +1110,14 @@ static _FORCE_INLINE_ Variant::Type get_ret_type_helper(void (*p_func)(P...)) {
 	register_utility_function<Func_##m_func>(#m_func, m_args)
 
 struct VariantUtilityFunctionInfo {
-	void (*call_utility)(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error);
-	Variant::ValidatedUtilityFunction validated_call_utility;
-	Variant::PTRUtilityFunction ptr_call_utility;
+	void (*call_utility)(Variant *r_ret, const Variant **p_args, int p_argcount, Callable::CallError &r_error) = nullptr;
+	Variant::ValidatedUtilityFunction validated_call_utility = nullptr;
+	Variant::PTRUtilityFunction ptr_call_utility = nullptr;
 	Vector<String> argnames;
-	bool is_vararg;
-	bool returns_value;
-	int argcount;
-	Variant::Type (*get_arg_type)(int);
+	bool is_vararg = false;
+	bool returns_value = false;
+	int argcount = 0;
+	Variant::Type (*get_arg_type)(int) = nullptr;
 	Variant::Type return_type;
 	Variant::UtilityFunctionType type;
 };

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -53,7 +53,7 @@ public:
 	// RasterizerCanvasGLES3 *canvas;
 	// RasterizerSceneGLES3 *scene;
 
-	GLES3::Config *config;
+	GLES3::Config *config = nullptr;
 
 	struct Resources {
 		GLuint mipmap_blur_fbo;

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -141,7 +141,7 @@ private:
 	static bool shader_cache_save_debug;
 	bool shader_cache_dir_valid = false;
 
-	GLint max_image_units;
+	GLint max_image_units = 0;
 
 	enum StageType {
 		STAGE_TYPE_VERTEX,

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -51,47 +51,47 @@ private:
 	static Config *singleton;
 
 public:
-	bool use_nearest_mip_filter;
-	bool use_skeleton_software;
+	bool use_nearest_mip_filter = false;
+	bool use_skeleton_software = false;
 
-	int max_vertex_texture_image_units;
-	int max_texture_image_units;
-	int max_texture_size;
-	int max_uniform_buffer_size;
+	int max_vertex_texture_image_units = 0;
+	int max_texture_image_units = 0;
+	int max_texture_size = 0;
+	int max_uniform_buffer_size = 0;
 
 	// TODO implement wireframe in OpenGL
 	// bool generate_wireframes;
 
 	Set<String> extensions;
 
-	bool float_texture_supported;
-	bool s3tc_supported;
-	bool latc_supported;
-	bool rgtc_supported;
-	bool bptc_supported;
-	bool etc_supported;
-	bool etc2_supported;
-	bool srgb_decode_supported;
+	bool float_texture_supported = false;
+	bool s3tc_supported = false;
+	bool latc_supported = false;
+	bool rgtc_supported = false;
+	bool bptc_supported = false;
+	bool etc_supported = false;
+	bool etc2_supported = false;
+	bool srgb_decode_supported = false;
 
-	bool keep_original_textures;
+	bool keep_original_textures = false;
 
-	bool force_vertex_shading;
+	bool force_vertex_shading = false;
 
-	bool use_rgba_2d_shadows;
-	bool use_rgba_3d_shadows;
+	bool use_rgba_2d_shadows = false;
+	bool use_rgba_3d_shadows = false;
 
-	bool support_32_bits_indices;
-	bool support_write_depth;
-	bool support_half_float_vertices;
-	bool support_npot_repeat_mipmap;
-	bool support_depth_cubemaps;
-	bool support_shadow_cubemaps;
-	bool support_anisotropic_filter;
-	float anisotropic_level;
+	bool support_32_bits_indices = false;
+	bool support_write_depth = false;
+	bool support_half_float_vertices = false;
+	bool support_npot_repeat_mipmap = false;
+	bool support_depth_cubemaps = false;
+	bool support_shadow_cubemaps = false;
+	bool support_anisotropic_filter = false;
+	float anisotropic_level = 0.0f;
 
-	GLuint depth_internalformat;
-	GLuint depth_type;
-	GLuint depth_buffer_internalformat;
+	GLuint depth_internalformat = 0;
+	GLuint depth_type = 0;
+	GLuint depth_buffer_internalformat = 0;
 
 	// in some cases the legacy render didn't orphan. We will mark these
 	// so the user can switch orphaning off for them.

--- a/drivers/unix/dir_access_unix.h
+++ b/drivers/unix/dir_access_unix.h
@@ -46,8 +46,8 @@ class DirAccessUnix : public DirAccess {
 	static Ref<DirAccess> create_fs();
 
 	String current_dir;
-	bool _cisdir;
-	bool _cishidden;
+	bool _cisdir = false;
+	bool _cishidden = false;
 
 protected:
 	virtual String fix_unicode_name(const char *p_name) const { return String::utf8(p_name); }

--- a/drivers/vulkan/rendering_device_vulkan.h
+++ b/drivers/vulkan/rendering_device_vulkan.h
@@ -886,8 +886,8 @@ class RenderingDeviceVulkan : public RenderingDevice {
 	DrawList *draw_list = nullptr; // One for regular draw lists, multiple for split.
 	uint32_t draw_list_subpass_count = 0;
 	uint32_t draw_list_count = 0;
-	VkRenderPass draw_list_render_pass;
-	VkFramebuffer draw_list_vkframebuffer;
+	VkRenderPass draw_list_render_pass = VK_NULL_HANDLE;
+	VkFramebuffer draw_list_vkframebuffer = VK_NULL_HANDLE;
 #ifdef DEBUG_ENABLED
 	FramebufferFormatID draw_list_framebuffer_format = INVALID_ID;
 #endif

--- a/drivers/vulkan/vulkan_context.h
+++ b/drivers/vulkan/vulkan_context.h
@@ -185,27 +185,27 @@ private:
 	 */
 	bool enabled_debug_report = false;
 
-	PFN_vkCreateDebugUtilsMessengerEXT CreateDebugUtilsMessengerEXT;
-	PFN_vkDestroyDebugUtilsMessengerEXT DestroyDebugUtilsMessengerEXT;
-	PFN_vkSubmitDebugUtilsMessageEXT SubmitDebugUtilsMessageEXT;
-	PFN_vkCmdBeginDebugUtilsLabelEXT CmdBeginDebugUtilsLabelEXT;
-	PFN_vkCmdEndDebugUtilsLabelEXT CmdEndDebugUtilsLabelEXT;
-	PFN_vkCmdInsertDebugUtilsLabelEXT CmdInsertDebugUtilsLabelEXT;
-	PFN_vkSetDebugUtilsObjectNameEXT SetDebugUtilsObjectNameEXT;
-	PFN_vkCreateDebugReportCallbackEXT CreateDebugReportCallbackEXT;
-	PFN_vkDebugReportMessageEXT DebugReportMessageEXT;
-	PFN_vkDestroyDebugReportCallbackEXT DestroyDebugReportCallbackEXT;
-	PFN_vkGetPhysicalDeviceSurfaceSupportKHR fpGetPhysicalDeviceSurfaceSupportKHR;
-	PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR fpGetPhysicalDeviceSurfaceCapabilitiesKHR;
-	PFN_vkGetPhysicalDeviceSurfaceFormatsKHR fpGetPhysicalDeviceSurfaceFormatsKHR;
-	PFN_vkGetPhysicalDeviceSurfacePresentModesKHR fpGetPhysicalDeviceSurfacePresentModesKHR;
-	PFN_vkCreateSwapchainKHR fpCreateSwapchainKHR;
-	PFN_vkDestroySwapchainKHR fpDestroySwapchainKHR;
-	PFN_vkGetSwapchainImagesKHR fpGetSwapchainImagesKHR;
-	PFN_vkAcquireNextImageKHR fpAcquireNextImageKHR;
-	PFN_vkQueuePresentKHR fpQueuePresentKHR;
-	PFN_vkGetRefreshCycleDurationGOOGLE fpGetRefreshCycleDurationGOOGLE;
-	PFN_vkGetPastPresentationTimingGOOGLE fpGetPastPresentationTimingGOOGLE;
+	PFN_vkCreateDebugUtilsMessengerEXT CreateDebugUtilsMessengerEXT = nullptr;
+	PFN_vkDestroyDebugUtilsMessengerEXT DestroyDebugUtilsMessengerEXT = nullptr;
+	PFN_vkSubmitDebugUtilsMessageEXT SubmitDebugUtilsMessageEXT = nullptr;
+	PFN_vkCmdBeginDebugUtilsLabelEXT CmdBeginDebugUtilsLabelEXT = nullptr;
+	PFN_vkCmdEndDebugUtilsLabelEXT CmdEndDebugUtilsLabelEXT = nullptr;
+	PFN_vkCmdInsertDebugUtilsLabelEXT CmdInsertDebugUtilsLabelEXT = nullptr;
+	PFN_vkSetDebugUtilsObjectNameEXT SetDebugUtilsObjectNameEXT = nullptr;
+	PFN_vkCreateDebugReportCallbackEXT CreateDebugReportCallbackEXT = nullptr;
+	PFN_vkDebugReportMessageEXT DebugReportMessageEXT = nullptr;
+	PFN_vkDestroyDebugReportCallbackEXT DestroyDebugReportCallbackEXT = nullptr;
+	PFN_vkGetPhysicalDeviceSurfaceSupportKHR fpGetPhysicalDeviceSurfaceSupportKHR = nullptr;
+	PFN_vkGetPhysicalDeviceSurfaceCapabilitiesKHR fpGetPhysicalDeviceSurfaceCapabilitiesKHR = nullptr;
+	PFN_vkGetPhysicalDeviceSurfaceFormatsKHR fpGetPhysicalDeviceSurfaceFormatsKHR = nullptr;
+	PFN_vkGetPhysicalDeviceSurfacePresentModesKHR fpGetPhysicalDeviceSurfacePresentModesKHR = nullptr;
+	PFN_vkCreateSwapchainKHR fpCreateSwapchainKHR = nullptr;
+	PFN_vkDestroySwapchainKHR fpDestroySwapchainKHR = nullptr;
+	PFN_vkGetSwapchainImagesKHR fpGetSwapchainImagesKHR = nullptr;
+	PFN_vkAcquireNextImageKHR fpAcquireNextImageKHR = nullptr;
+	PFN_vkQueuePresentKHR fpQueuePresentKHR = nullptr;
+	PFN_vkGetRefreshCycleDurationGOOGLE fpGetRefreshCycleDurationGOOGLE = nullptr;
+	PFN_vkGetPastPresentationTimingGOOGLE fpGetPastPresentationTimingGOOGLE = nullptr;
 
 	VkDebugUtilsMessengerEXT dbg_messenger = VK_NULL_HANDLE;
 	VkDebugReportCallbackEXT dbg_debug_report = VK_NULL_HANDLE;

--- a/editor/animation_bezier_editor.h
+++ b/editor/animation_bezier_editor.h
@@ -53,7 +53,7 @@ class AnimationBezierTrackEdit : public Control {
 	float play_position_pos = 0;
 
 	Ref<Animation> animation;
-	int selected_track;
+	int selected_track = 0;
 
 	Vector<Rect2> view_rects;
 
@@ -98,8 +98,8 @@ class AnimationBezierTrackEdit : public Control {
 	bool moving_selection_attempt = false;
 	IntPair select_single_attempt;
 	bool moving_selection = false;
-	int moving_selection_from_key;
-	int moving_selection_from_track;
+	int moving_selection_from_key = 0;
+	int moving_selection_from_track = 0;
 
 	Vector2 moving_selection_offset;
 
@@ -114,7 +114,7 @@ class AnimationBezierTrackEdit : public Control {
 	int moving_handle_track = 0;
 	Vector2 moving_handle_left;
 	Vector2 moving_handle_right;
-	int moving_handle_mode; // value from Animation::HandleMode
+	int moving_handle_mode = 0; // value from Animation::HandleMode
 
 	void _clear_selection();
 	void _clear_selection_for_anim(const Ref<Animation> &p_anim);
@@ -136,8 +136,8 @@ class AnimationBezierTrackEdit : public Control {
 		Rect2 point_rect;
 		Rect2 in_rect;
 		Rect2 out_rect;
-		int track;
-		int key;
+		int track = 0;
+		int key = 0;
 	};
 
 	Vector<EditPoint> edit_points;

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1886,10 +1886,7 @@ void AnimationTimelineEdit::_bind_methods() {
 
 AnimationTimelineEdit::AnimationTimelineEdit() {
 	name_limit = 150 * EDSCALE;
-	zoom = nullptr;
-	track_edit = nullptr;
 
-	play_position_pos = 0;
 	play_position = memnew(Control);
 	play_position->set_mouse_filter(MOUSE_FILTER_PASS);
 	add_child(play_position);
@@ -3217,17 +3214,6 @@ void AnimationTrackEdit::_bind_methods() {
 }
 
 AnimationTrackEdit::AnimationTrackEdit() {
-	undo_redo = nullptr;
-	timeline = nullptr;
-	root = nullptr;
-	path = nullptr;
-	path_popup = nullptr;
-	menu = nullptr;
-	dropping_at = 0;
-
-	select_single_attempt = -1;
-
-	play_position_pos = 0;
 	play_position = memnew(Control);
 	play_position->set_mouse_filter(MOUSE_FILTER_PASS);
 	add_child(play_position);
@@ -6238,8 +6224,6 @@ void AnimationTrackEditor::_pick_track_filter_input(const Ref<InputEvent> &p_ie)
 }
 
 AnimationTrackEditor::AnimationTrackEditor() {
-	root = nullptr;
-
 	undo_redo = EditorNode::get_singleton()->get_undo_redo();
 
 	main_panel = memnew(PanelContainer);
@@ -6452,8 +6436,6 @@ AnimationTrackEditor::AnimationTrackEditor() {
 	insert_confirm_reset->set_text(TTR("Create RESET Track(s)", ""));
 	insert_confirm_reset->set_pressed(EDITOR_GET("editors/animation/default_create_reset_tracks"));
 	ichb->add_child(insert_confirm_reset);
-	key_edit = nullptr;
-	multi_key_edit = nullptr;
 
 	box_selection = memnew(Control);
 	add_child(box_selection);

--- a/editor/animation_track_editor.h
+++ b/editor/animation_track_editor.h
@@ -54,10 +54,10 @@ class AnimationTimelineEdit : public Range {
 
 	Ref<Animation> animation;
 	AnimationTrackEdit *track_edit = nullptr;
-	int name_limit;
+	int name_limit = 0;
 	Range *zoom = nullptr;
 	Range *h_scroll = nullptr;
-	float play_position_pos;
+	float play_position_pos = 0.0f;
 
 	HBoxContainer *len_hb = nullptr;
 	EditorSpinSlider *length = nullptr;
@@ -86,8 +86,8 @@ class AnimationTimelineEdit : public Range {
 
 	bool dragging_timeline = false;
 	bool dragging_hsize = false;
-	float dragging_hsize_from;
-	float dragging_hsize_at;
+	float dragging_hsize_from = 0.0f;
+	float dragging_hsize_at = 0.0f;
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	void _track_added(int p_track);
@@ -145,17 +145,18 @@ class AnimationTrackEdit : public Control {
 		MENU_KEY_ADD_RESET,
 		MENU_KEY_DELETE
 	};
+
 	AnimationTimelineEdit *timeline = nullptr;
 	UndoRedo *undo_redo = nullptr;
 	Popup *path_popup = nullptr;
 	LineEdit *path = nullptr;
 	Node *root = nullptr;
 	Control *play_position = nullptr; //separate control used to draw so updates for only position changed are much faster
-	float play_position_pos;
+	float play_position_pos = 0.0f;
 	NodePath node_path;
 
 	Ref<Animation> animation;
-	int track;
+	int track = 0;
 
 	Rect2 check_rect;
 	Rect2 path_rect;
@@ -187,12 +188,12 @@ class AnimationTrackEdit : public Control {
 
 	Ref<Texture2D> _get_key_type_icon() const;
 
-	mutable int dropping_at;
-	float insert_at_pos;
+	mutable int dropping_at = 0;
+	float insert_at_pos = 0.0f;
 	bool moving_selection_attempt = false;
-	int select_single_attempt;
+	int select_single_attempt = -1;
 	bool moving_selection = false;
-	float moving_selection_from_ofs;
+	float moving_selection_from_ofs = 0.0f;
 
 	bool in_group = false;
 	AnimationTrackEditor *editor = nullptr;
@@ -341,7 +342,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	PropertySelector *prop_selector = nullptr;
 	PropertySelector *method_selector = nullptr;
 	SceneTreeDialog *pick_track = nullptr;
-	int adding_track_type;
+	int adding_track_type = 0;
 	NodePath adding_track_path;
 
 	bool keying = false;
@@ -353,7 +354,7 @@ class AnimationTrackEditor : public VBoxContainer {
 		Variant value;
 		String query;
 		bool advance = false;
-	}; /* insert_data;*/
+	};
 
 	Label *insert_confirm_text = nullptr;
 	CheckBox *insert_confirm_bezier = nullptr;
@@ -388,8 +389,8 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	void _timeline_value_changed(double);
 
-	float insert_key_from_track_call_ofs;
-	int insert_key_from_track_call_track;
+	float insert_key_from_track_call_ofs = 0.0f;
+	int insert_key_from_track_call_track = 0;
 	void _insert_key_from_track(float p_ofs, int p_track);
 	void _add_method_key(const String &p_method);
 
@@ -415,7 +416,7 @@ class AnimationTrackEditor : public VBoxContainer {
 	void _key_deselected(int p_key, int p_track);
 
 	bool moving_selection = false;
-	float moving_selection_offset;
+	float moving_selection_offset = 0.0f;
 	void _move_selection_begin();
 	void _move_selection(float p_offset);
 	void _move_selection_commit();
@@ -459,7 +460,7 @@ class AnimationTrackEditor : public VBoxContainer {
 
 	void _edit_menu_about_to_popup();
 	void _edit_menu_pressed(int p_option);
-	int last_menu_track_opt;
+	int last_menu_track_opt = 0;
 
 	void _cleanup_animation(Ref<Animation> p_animation);
 

--- a/editor/animation_track_editor_plugins.cpp
+++ b/editor/animation_track_editor_plugins.cpp
@@ -966,7 +966,6 @@ void AnimationTrackEditTypeAudio::_bind_methods() {
 
 AnimationTrackEditTypeAudio::AnimationTrackEditTypeAudio() {
 	AudioStreamPreviewGenerator::get_singleton()->connect("preview_updated", callable_mp(this, &AnimationTrackEditTypeAudio::_preview_changed));
-	len_resizing = false;
 }
 
 bool AnimationTrackEditTypeAudio::can_drop_data(const Point2 &p_point, const Variant &p_data) const {

--- a/editor/animation_track_editor_plugins.h
+++ b/editor/animation_track_editor_plugins.h
@@ -115,10 +115,10 @@ class AnimationTrackEditTypeAudio : public AnimationTrackEdit {
 	void _preview_changed(ObjectID p_which);
 
 	bool len_resizing = false;
-	bool len_resizing_start;
-	int len_resizing_index;
-	float len_resizing_from_px;
-	float len_resizing_rel;
+	bool len_resizing_start = false;
+	int len_resizing_index = 0;
+	float len_resizing_from_px = 0.0f;
+	float len_resizing_rel = 0.0f;
 	bool over_drag_position = false;
 
 protected:

--- a/editor/code_editor.cpp
+++ b/editor/code_editor.cpp
@@ -657,10 +657,6 @@ void FindReplaceBar::_bind_methods() {
 }
 
 FindReplaceBar::FindReplaceBar() {
-	results_count = -1;
-	results_count_to_current = -1;
-	needs_to_count_results = true;
-
 	vbc_lineedit = memnew(VBoxContainer);
 	add_child(vbc_lineedit);
 	vbc_lineedit->set_alignment(BoxContainer::ALIGNMENT_CENTER);

--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -84,10 +84,10 @@ class FindReplaceBar : public HBoxContainer {
 
 	uint32_t flags = 0;
 
-	int result_line;
-	int result_col;
-	int results_count;
-	int results_count_to_current;
+	int result_line = 0;
+	int result_col = 0;
+	int results_count = -1;
+	int results_count_to_current = -1;
 
 	bool replace_all_mode = false;
 	bool preserve_cursor = false;

--- a/editor/connections_dialog.h
+++ b/editor/connections_dialog.h
@@ -111,7 +111,7 @@ private:
 	StringName signal;
 	LineEdit *dst_method = nullptr;
 	ConnectDialogBinds *cdbinds = nullptr;
-	bool edit_mode;
+	bool edit_mode = false;
 	NodePath dst_path;
 	VBoxContainer *vbc_right = nullptr;
 

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.h
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.h
@@ -111,9 +111,9 @@ private:
 	String _current_request;
 	Ref<DAPeer> _current_peer;
 
-	int breakpoint_id;
-	int stackframe_id;
-	int variable_id;
+	int breakpoint_id = 0;
+	int stackframe_id = 0;
+	int variable_id = 0;
 	List<DAP::Breakpoint> breakpoint_list;
 	Map<DAP::StackFrame, List<int>> stackframe_list;
 	Map<int, Array> variable_list;

--- a/editor/debugger/editor_performance_profiler.h
+++ b/editor/debugger/editor_performance_profiler.h
@@ -66,7 +66,7 @@ private:
 	Control *monitor_draw = nullptr;
 	Label *info_message = nullptr;
 	StringName marker_key;
-	int marker_frame;
+	int marker_frame = 0;
 	const int MARGIN = 4;
 	const int POINT_SEPARATION = 5;
 	const int MARKER_MARGIN = 2;

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -662,9 +662,6 @@ EditorProfiler::EditorProfiler() {
 
 	int metric_size = CLAMP(int(EDITOR_GET("debugger/profiler_frame_history_size")), 60, 1024);
 	frame_metrics.resize(metric_size);
-	total_metrics = 0;
-	last_metric = -1;
-	hover_metric = -1;
 
 	EDITOR_DEF("debugger/profiler_frame_max_functions", 64);
 
@@ -682,7 +679,4 @@ EditorProfiler::EditorProfiler() {
 
 	plot_sigs.insert("physics_frame_time");
 	plot_sigs.insert("category_frame_time");
-
-	seeking = false;
-	graph_height = 1;
 }

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -106,18 +106,18 @@ private:
 	SpinBox *cursor_metric_edit = nullptr;
 
 	Vector<Metric> frame_metrics;
-	int total_metrics;
-	int last_metric;
+	int total_metrics = 0;
+	int last_metric = -1;
 
-	int max_functions;
+	int max_functions = 0;
 
-	bool updating_frame;
+	bool updating_frame = false;
 
-	int hover_metric;
+	int hover_metric = -1;
 
-	float graph_height;
+	float graph_height = 1.0f;
 
-	bool seeking;
+	bool seeking = false;
 
 	Timer *frame_delay = nullptr;
 	Timer *plot_delay = nullptr;

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -782,7 +782,6 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	graph = memnew(TextureRect);
 	graph->set_ignore_texture_size(true);
 	graph->set_mouse_filter(MOUSE_FILTER_STOP);
-	//graph->set_ignore_mouse(false);
 	graph->connect("draw", callable_mp(this, &EditorVisualProfiler::_graph_tex_draw));
 	graph->connect("gui_input", callable_mp(this, &EditorVisualProfiler::_graph_tex_input));
 	graph->connect("mouse_exited", callable_mp(this, &EditorVisualProfiler::_graph_tex_mouse_exit));
@@ -792,11 +791,6 @@ EditorVisualProfiler::EditorVisualProfiler() {
 
 	int metric_size = CLAMP(int(EDITOR_GET("debugger/profiler_frame_history_size")), 60, 1024);
 	frame_metrics.resize(metric_size);
-	last_metric = -1;
-	//cursor_metric=-1;
-	hover_metric = -1;
-
-	//display_mode=DISPLAY_FRAME_TIME;
 
 	frame_delay = memnew(Timer);
 	frame_delay->set_wait_time(0.1);
@@ -809,12 +803,4 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	plot_delay->set_one_shot(true);
 	add_child(plot_delay);
 	plot_delay->connect("timeout", callable_mp(this, &EditorVisualProfiler::_update_plot));
-
-	seeking = false;
-	graph_height_cpu = 1;
-	graph_height_gpu = 1;
-
-	graph_limit = 1000 / 60.0;
-
-	//activate->set_disabled(true);
 }

--- a/editor/debugger/editor_visual_profiler.h
+++ b/editor/debugger/editor_visual_profiler.h
@@ -83,21 +83,20 @@ private:
 	SpinBox *cursor_metric_edit = nullptr;
 
 	Vector<Metric> frame_metrics;
-	int last_metric;
+	int last_metric = -1;
+
+	int hover_metric = -1;
 
 	StringName selected_area;
 
-	bool updating_frame;
+	bool updating_frame = false;
 
-	//int cursor_metric;
-	int hover_metric;
+	float graph_height_cpu = 1.0f;
+	float graph_height_gpu = 1.0f;
 
-	float graph_height_cpu;
-	float graph_height_gpu;
+	float graph_limit = 1000.0f / 60;
 
-	float graph_limit;
-
-	bool seeking;
+	bool seeking = false;
 
 	Timer *frame_delay = nullptr;
 	Timer *plot_delay = nullptr;

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1263,7 +1263,6 @@ void EditorAudioBuses::_bind_methods() {
 }
 
 EditorAudioBuses::EditorAudioBuses() {
-	drop_end = nullptr;
 	top_hb = memnew(HBoxContainer);
 	add_child(top_hb);
 

--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITORAUDIOBUSES_H
-#define EDITORAUDIOBUSES_H
+#ifndef EDITOR_AUDIO_BUSES_H
+#define EDITOR_AUDIO_BUSES_H
 
 #include "editor/editor_plugin.h"
 #include "scene/gui/box_container.h"
@@ -192,7 +192,7 @@ class EditorAudioBuses : public VBoxContainer {
 	void _new_layout();
 
 	EditorFileDialog *file_dialog = nullptr;
-	bool new_layout;
+	bool new_layout = false;
 
 	void _file_dialog_callback(const String &p_string);
 
@@ -275,4 +275,4 @@ public:
 	~AudioBusesEditorPlugin();
 };
 
-#endif // EDITORAUDIOBUSES_H
+#endif // EDITOR_AUDIO_BUSES_H

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1583,11 +1583,9 @@ bool EditorFileDialog::are_previews_enabled() {
 EditorFileDialog::EditorFileDialog() {
 	show_hidden_files = default_show_hidden_files;
 	display_mode = default_display_mode;
-	local_history_pos = 0;
 	VBoxContainer *vbc = memnew(VBoxContainer);
 	add_child(vbc);
 
-	mode = FILE_MODE_SAVE_FILE;
 	set_title(TTR("Save a File"));
 
 	ED_SHORTCUT("file_dialog/go_back", TTR("Go Back"), KeyModifierMask::ALT | Key::LEFT);
@@ -1795,7 +1793,6 @@ EditorFileDialog::EditorFileDialog() {
 	item_vb->add_child(file_box);
 
 	dir_access = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	access = ACCESS_RESOURCES;
 	_update_drives();
 
 	connect("confirmed", callable_mp(this, &EditorFileDialog::_action_pressed));
@@ -1808,7 +1805,6 @@ EditorFileDialog::EditorFileDialog() {
 	filter->connect("item_selected", callable_mp(this, &EditorFileDialog::_filter_selected));
 
 	confirm_save = memnew(ConfirmationDialog);
-	//confirm_save->set_as_top_level(true);
 	add_child(confirm_save);
 	confirm_save->connect("confirmed", callable_mp(this, &EditorFileDialog::_save_confirm_pressed));
 
@@ -1843,9 +1839,6 @@ EditorFileDialog::EditorFileDialog() {
 	if (register_func) {
 		register_func(this);
 	}
-
-	preview_wheel_timeout = 0;
-	preview_wheel_index = 0;
 }
 
 EditorFileDialog::~EditorFileDialog() {

--- a/editor/editor_file_dialog.h
+++ b/editor/editor_file_dialog.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef EDITORFILEDIALOG_H
-#define EDITORFILEDIALOG_H
+#ifndef EDITOR_FILE_DIALOG_H
+#define EDITOR_FILE_DIALOG_H
 
 #include "core/io/dir_access.h"
 #include "editor/plugins/editor_preview_plugins.h"
@@ -88,11 +88,11 @@ private:
 	LineEdit *makedirname = nullptr;
 
 	Button *makedir = nullptr;
-	Access access;
+	Access access = ACCESS_RESOURCES;
 
 	VBoxContainer *vbox = nullptr;
-	FileMode mode;
-	bool can_create_dir;
+	FileMode mode = FILE_MODE_SAVE_FILE;
+	bool can_create_dir = false;
 	LineEdit *dir = nullptr;
 
 	Button *dir_prev = nullptr;
@@ -130,15 +130,15 @@ private:
 	ItemList *recent = nullptr;
 
 	Vector<String> local_history;
-	int local_history_pos;
+	int local_history_pos = 0;
 	void _push_history();
 
 	Vector<String> filters;
 
 	bool previews_enabled = true;
 	bool preview_waiting = false;
-	int preview_wheel_index;
-	float preview_wheel_timeout;
+	int preview_wheel_index = 0;
+	float preview_wheel_timeout = 0.0f;
 
 	static bool default_show_hidden_files;
 	static DisplayMode default_display_mode;
@@ -257,4 +257,4 @@ VARIANT_ENUM_CAST(EditorFileDialog::FileMode);
 VARIANT_ENUM_CAST(EditorFileDialog::Access);
 VARIANT_ENUM_CAST(EditorFileDialog::DisplayMode);
 
-#endif // EDITORFILEDIALOG_H
+#endif // EDITOR_FILE_DIALOG_H

--- a/editor/editor_help.h
+++ b/editor/editor_help.h
@@ -56,7 +56,7 @@ class FindBar : public HBoxContainer {
 
 	RichTextLabel *rich_text_label = nullptr;
 
-	int results_count;
+	int results_count = 0;
 
 	void _hide_bar();
 
@@ -112,7 +112,7 @@ class EditorHelp : public VBoxContainer {
 	Map<String, int> constant_line;
 	Map<String, int> enum_line;
 	Map<String, Map<String, int>> enum_values_line;
-	int description_line;
+	int description_line = 0;
 
 	RichTextLabel *class_desc = nullptr;
 	HSplitContainer *h_split = nullptr;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5909,7 +5909,6 @@ EditorNode::EditorNode() {
 	}
 
 	singleton = this;
-	last_checked_version = 0;
 
 	TranslationServer::get_singleton()->set_enabled(false);
 	// Load settings.
@@ -6263,8 +6262,6 @@ EditorNode::EditorNode() {
 	dock_vb->add_child(dock_float);
 
 	dock_select_popup->reset_size();
-	dock_select_rect_over_idx = -1;
-	dock_popup_selected_idx = -1;
 
 	for (int i = 0; i < DOCK_SLOT_MAX; i++) {
 		dock_slot[i]->set_custom_minimum_size(Size2(170, 0) * EDSCALE);
@@ -6811,7 +6808,6 @@ EditorNode::EditorNode() {
 	// Define corresponding default layout.
 
 	const String docks_section = "docks";
-	overridden_default_layout = -1;
 	default_layout.instantiate();
 	// Dock numbers are based on DockSlot enum value + 1.
 	default_layout->set_value(docks_section, "dock_3", "Scene,Import");
@@ -6889,8 +6885,6 @@ EditorNode::EditorNode() {
 	log = memnew(EditorLog);
 	Button *output_button = add_bottom_panel_item(TTR("Output"), log);
 	log->set_tool_button(output_button);
-
-	old_split_ofs = 0;
 
 	center_split->connect("resized", callable_mp(this, &EditorNode::_vp_resized));
 
@@ -7157,7 +7151,6 @@ EditorNode::EditorNode() {
 	}
 	update_spinner_step_msec = OS::get_singleton()->get_ticks_msec();
 	update_spinner_step_frame = Engine::get_singleton()->get_frames_drawn();
-	update_spinner_step = 0;
 
 	editor_plugin_screen = nullptr;
 	editor_plugins_over = memnew(EditorPluginList);
@@ -7190,9 +7183,6 @@ EditorNode::EditorNode() {
 	open_imported->connect("confirmed", callable_mp(this, &EditorNode::_open_imported));
 	open_imported->connect("custom_action", callable_mp(this, &EditorNode::_inherit_imported));
 	gui_base->add_child(open_imported);
-
-	saved_version = 1;
-	_last_instantiated_scene = nullptr;
 
 	quick_open = memnew(EditorQuickOpen);
 	gui_base->add_child(quick_open);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -283,7 +283,7 @@ private:
 
 	ConfirmationDialog *video_restart_dialog = nullptr;
 
-	int rendering_driver_current;
+	int rendering_driver_current = 0;
 	String rendering_driver_request;
 
 	// Split containers.
@@ -305,12 +305,12 @@ private:
 	PopupMenu *scene_tabs_context_menu = nullptr;
 	Panel *tab_preview_panel = nullptr;
 	TextureRect *tab_preview = nullptr;
-	int tab_closing_idx;
+	int tab_closing_idx = 0;
 
 	bool exiting = false;
 	bool dimmed = false;
 
-	int old_split_ofs;
+	int old_split_ofs = 0;
 	VSplitContainer *top_split = nullptr;
 	HBoxContainer *bottom_hb = nullptr;
 	Control *vp_base = nullptr;
@@ -363,7 +363,7 @@ private:
 	EditorAbout *about = nullptr;
 	AcceptDialog *warning = nullptr;
 
-	int overridden_default_layout;
+	int overridden_default_layout = -1;
 	Ref<ConfigFile> default_layout;
 	PopupMenu *editor_layouts = nullptr;
 	EditorLayoutsDialog *layout_dialog = nullptr;
@@ -412,8 +412,8 @@ private:
 	TabContainer *dock_slot[DOCK_SLOT_MAX];
 	Timer *dock_drag_timer = nullptr;
 	bool docks_visible = true;
-	int dock_popup_selected_idx;
-	int dock_select_rect_over_idx;
+	int dock_popup_selected_idx = -1;
+	int dock_select_rect_over_idx = -1;
 
 	HBoxContainer *tabbar_container = nullptr;
 	Button *distraction_free = nullptr;
@@ -446,24 +446,24 @@ private:
 	bool unsaved_cache = true;
 	bool waiting_for_first_scan = true;
 
-	int current_menu_option;
+	int current_menu_option = 0;
 
 	SubViewport *scene_root = nullptr; // Root of the scene being edited.
 	Object *current = nullptr;
 
 	Ref<Resource> saving_resource;
 
-	uint64_t update_spinner_step_msec;
-	uint64_t update_spinner_step_frame;
-	int update_spinner_step;
+	uint64_t update_spinner_step_msec = 0;
+	uint64_t update_spinner_step_frame = 0;
+	int update_spinner_step = 0;
 
 	String _tmp_import_path;
 	String external_file;
 	String open_navigate;
 	String run_custom_filename;
 
-	uint64_t saved_version;
-	uint64_t last_checked_version;
+	uint64_t saved_version = 1;
+	uint64_t last_checked_version = 0;
 
 	DynamicFontImportSettings *fontdata_import_settings = nullptr;
 	SceneImportSettings *scene_import_settings = nullptr;

--- a/editor/editor_spin_slider.cpp
+++ b/editor/editor_spin_slider.cpp
@@ -656,10 +656,7 @@ void EditorSpinSlider::_ensure_input_popup() {
 }
 
 EditorSpinSlider::EditorSpinSlider() {
-	grabbing_spinner_dist_cache = 0;
-	pre_grab_value = 0;
 	set_focus_mode(FOCUS_ALL);
-	updown_offset = -1;
 	grabber = memnew(TextureRect);
 	add_child(grabber);
 	grabber->hide();
@@ -668,5 +665,4 @@ EditorSpinSlider::EditorSpinSlider() {
 	grabber->connect("mouse_entered", callable_mp(this, &EditorSpinSlider::_grabber_mouse_entered));
 	grabber->connect("mouse_exited", callable_mp(this, &EditorSpinSlider::_grabber_mouse_exited));
 	grabber->connect("gui_input", callable_mp(this, &EditorSpinSlider::_grabber_gui_input));
-	grabber_range = 1;
 }

--- a/editor/editor_spin_slider.h
+++ b/editor/editor_spin_slider.h
@@ -40,41 +40,42 @@ class EditorSpinSlider : public Range {
 
 	String label;
 	String suffix;
-	int updown_offset;
+	int updown_offset = -1;
 	bool hover_updown = false;
 	bool mouse_hover = false;
 
 	TextureRect *grabber = nullptr;
-	int grabber_range;
+	int grabber_range = 1;
 
 	bool mouse_over_spin = false;
 	bool mouse_over_grabber = false;
 	bool mousewheel_over_grabber = false;
 
 	bool grabbing_grabber = false;
-	int grabbing_from;
-	float grabbing_ratio;
+	int grabbing_from = 0;
+	float grabbing_ratio = 0.0f;
 
 	bool grabbing_spinner_attempt = false;
 	bool grabbing_spinner = false;
 
 	bool read_only = false;
-	float grabbing_spinner_dist_cache;
+	float grabbing_spinner_dist_cache = 0.0f;
 	Vector2 grabbing_spinner_mouse_pos;
-	double pre_grab_value;
+	double pre_grab_value = 0.0;
 
 	Popup *value_input_popup = nullptr;
 	LineEdit *value_input = nullptr;
 	bool value_input_just_closed = false;
 	bool value_input_dirty = false;
 
+	bool hide_slider = false;
+	bool flat = false;
+
 	void _grabber_gui_input(const Ref<InputEvent> &p_event);
 	void _value_input_closed();
 	void _value_input_submitted(const String &);
 	void _value_focus_exited();
 	void _value_input_gui_input(const Ref<InputEvent> &p_event);
-	bool hide_slider = false;
-	bool flat = false;
 
 	void _evaluate_input_text();
 

--- a/editor/fileserver/editor_file_server.cpp
+++ b/editor/fileserver/editor_file_server.cpp
@@ -311,9 +311,6 @@ void EditorFileServer::stop() {
 
 EditorFileServer::EditorFileServer() {
 	server.instantiate();
-	quit = false;
-	active = false;
-	cmd = CMD_NONE;
 	thread.start(_thread_start, this);
 
 	EDITOR_DEF("filesystem/file_server/port", 6010);

--- a/editor/fileserver/editor_file_server.h
+++ b/editor/fileserver/editor_file_server.h
@@ -63,12 +63,12 @@ class EditorFileServer : public Object {
 	Mutex wait_mutex;
 	Thread thread;
 	static void _thread_start(void *);
-	bool quit;
-	Command cmd;
+	bool quit = false;
+	Command cmd = CMD_NONE;
 
 	String password;
-	int port;
-	bool active;
+	int port = 0;
+	bool active = false;
 
 public:
 	void start();

--- a/editor/import/scene_import_settings.h
+++ b/editor/import/scene_import_settings.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef SCENEIMPORTSETTINGS_H
-#define SCENEIMPORTSETTINGS_H
+#ifndef SCENE_IMPORT_SETTINGS_H
+#define SCENE_IMPORT_SETTINGS_H
 
 #include "editor/import/resource_importer_scene.h"
 #include "scene/3d/camera_3d.h"
@@ -86,9 +86,9 @@ class SceneImportSettings : public ConfirmationDialog {
 
 	Ref<StandardMaterial3D> collider_mat;
 
-	float cam_rot_x;
-	float cam_rot_y;
-	float cam_zoom;
+	float cam_rot_x = 0.0f;
+	float cam_rot_y = 0.0f;
+	float cam_zoom = 0.0f;
 
 	void _update_scene();
 
@@ -176,7 +176,7 @@ class SceneImportSettings : public ConfirmationDialog {
 	void _menu_callback(int p_id);
 	void _save_dir_callback(const String &p_path);
 
-	int current_action;
+	int current_action = 0;
 
 	Vector<TreeItem *> save_path_items;
 
@@ -205,4 +205,4 @@ public:
 	~SceneImportSettings();
 };
 
-#endif // SCENEIMPORTSETTINGS_H
+#endif // SCENE_IMPORT_SETTINGS_H

--- a/editor/plugin_config_dialog.h
+++ b/editor/plugin_config_dialog.h
@@ -54,7 +54,7 @@ class PluginConfigDialog : public ConfirmationDialog {
 	TextureRect *subfolder_validation = nullptr;
 	TextureRect *script_validation = nullptr;
 
-	bool _edit_mode;
+	bool _edit_mode = false;
 
 	void _clear_fields();
 	void _on_confirmed();

--- a/editor/plugins/abstract_polygon_2d_editor.cpp
+++ b/editor/plugins/abstract_polygon_2d_editor.cpp
@@ -703,10 +703,8 @@ AbstractPolygon2DEditor::PosVertex AbstractPolygon2DEditor::closest_edge_point(c
 }
 
 AbstractPolygon2DEditor::AbstractPolygon2DEditor(bool p_wip_destructive) {
-	canvas_item_editor = nullptr;
 	undo_redo = EditorNode::get_undo_redo();
 
-	wip_active = false;
 	edited_point = PosVertex();
 	wip_destructive = p_wip_destructive;
 
@@ -736,8 +734,6 @@ AbstractPolygon2DEditor::AbstractPolygon2DEditor(bool p_wip_destructive) {
 	create_resource = memnew(ConfirmationDialog);
 	add_child(create_resource);
 	create_resource->get_ok_button()->set_text(TTR("Create"));
-
-	mode = MODE_EDIT;
 }
 
 void AbstractPolygon2DEditorPlugin::edit(Object *p_object) {

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -80,10 +80,10 @@ class AbstractPolygon2DEditor : public HBoxContainer {
 
 	Vector<Vector2> pre_move_edit;
 	Vector<Vector2> wip;
-	bool wip_active;
-	bool wip_destructive;
+	bool wip_active = false;
+	bool wip_destructive = false;
 
-	bool _polygon_editing_enabled;
+	bool _polygon_editing_enabled = false;
 
 	CanvasItemEditor *canvas_item_editor = nullptr;
 	Panel *panel = nullptr;
@@ -97,7 +97,7 @@ protected:
 		MODE_CONT,
 	};
 
-	int mode;
+	int mode = MODE_EDIT;
 
 	UndoRedo *undo_redo = nullptr;
 

--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -594,7 +594,6 @@ AnimationNodeBlendSpace1DEditor *AnimationNodeBlendSpace1DEditor::singleton = nu
 
 AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	singleton = this;
-	updating = false;
 
 	HBoxContainer *top_hb = memnew(HBoxContainer);
 	add_child(top_hb);
@@ -744,10 +743,6 @@ AnimationNodeBlendSpace1DEditor::AnimationNodeBlendSpace1DEditor() {
 	open_file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	open_file->connect("file_selected", callable_mp(this, &AnimationNodeBlendSpace1DEditor::_file_opened));
 	undo_redo = EditorNode::get_undo_redo();
-
-	selected_point = -1;
-	dragging_selected = false;
-	dragging_selected_attempt = false;
 
 	set_custom_minimum_size(Size2(0, 150 * EDSCALE));
 }

--- a/editor/plugins/animation_blend_space_1d_editor.h
+++ b/editor/plugins/animation_blend_space_1d_editor.h
@@ -65,14 +65,14 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	SpinBox *edit_value = nullptr;
 	Button *open_editor = nullptr;
 
-	int selected_point;
+	int selected_point = -1;
 
 	Control *blend_space_draw = nullptr;
 
 	PanelContainer *error_panel = nullptr;
 	Label *error_label = nullptr;
 
-	bool updating;
+	bool updating = false;
 
 	UndoRedo *undo_redo = nullptr;
 
@@ -90,11 +90,11 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	PopupMenu *menu = nullptr;
 	PopupMenu *animations_menu = nullptr;
 	Vector<String> animations_to_add;
-	float add_point_pos;
+	float add_point_pos = 0.0f;
 	Vector<real_t> points;
 
-	bool dragging_selected_attempt;
-	bool dragging_selected;
+	bool dragging_selected_attempt = false;
+	bool dragging_selected = false;
 	Vector2 drag_from;
 	Vector2 drag_ofs;
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1214,7 +1214,6 @@ AnimationNodeStateMachineEditor *AnimationNodeStateMachineEditor::singleton = nu
 
 AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	singleton = this;
-	updating = false;
 
 	HBoxContainer *top_hb = memnew(HBoxContainer);
 	add_child(top_hb);
@@ -1347,12 +1346,4 @@ AnimationNodeStateMachineEditor::AnimationNodeStateMachineEditor() {
 	open_file->set_file_mode(EditorFileDialog::FILE_MODE_OPEN_FILE);
 	open_file->connect("file_selected", callable_mp(this, &AnimationNodeStateMachineEditor::_file_opened));
 	undo_redo = EditorNode::get_undo_redo();
-
-	over_node_what = -1;
-	dragging_selected_attempt = false;
-	connecting = false;
-
-	last_active = false;
-
-	error_time = 0;
 }

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -74,7 +74,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	PanelContainer *error_panel = nullptr;
 	Label *error_label = nullptr;
 
-	bool updating;
+	bool updating = false;
 
 	UndoRedo *undo_redo = nullptr;
 
@@ -93,14 +93,14 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 
 	Vector2 add_node_pos;
 
-	bool dragging_selected_attempt;
-	bool dragging_selected;
+	bool dragging_selected_attempt = false;
+	bool dragging_selected = false;
 	Vector2 drag_from;
 	Vector2 drag_ofs;
 	StringName snap_x;
 	StringName snap_y;
 
-	bool connecting;
+	bool connecting = false;
 	StringName connecting_from;
 	Vector2 connecting_to;
 	StringName connecting_to_node;
@@ -139,7 +139,7 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	StringName selected_transition_to;
 
 	StringName over_node;
-	int over_node_what;
+	int over_node_what = -1;
 
 	String prev_name;
 	void _name_edited(const String &p_text);
@@ -155,15 +155,15 @@ class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	void _autoplay_selected();
 	void _end_selected();
 
-	bool last_active;
+	bool last_active = false;
 	StringName last_blend_from_node;
 	StringName last_current_node;
 	Vector<StringName> last_travel_path;
-	float last_play_pos;
-	float play_pos;
-	float current_length;
+	float last_play_pos = 0.0f;
+	float play_pos = 0.0f;
+	float current_length = 0.0f;
 
-	float error_time;
+	float error_time = 0.0f;
 	String error_text;
 
 	EditorFileDialog *open_file = nullptr;

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -60,9 +60,9 @@ class EditorAssetLibraryItem : public PanelContainer {
 	TextureRect *stars[5];
 	Label *price = nullptr;
 
-	int asset_id;
-	int category_id;
-	int author_id;
+	int asset_id = 0;
+	int category_id = 0;
+	int author_id = 0;
 
 	void _asset_clicked();
 	void _category_clicked();
@@ -102,7 +102,7 @@ class EditorAssetLibraryItemDescription : public ConfirmationDialog {
 
 	void set_image(int p_type, int p_index, const Ref<Texture2D> &p_image);
 
-	int asset_id;
+	int asset_id = 0;
 	String download_url;
 	String title;
 	String sha256;
@@ -146,7 +146,7 @@ class EditorAssetLibraryItemDownload : public MarginContainer {
 
 	int prev_status;
 
-	int asset_id;
+	int asset_id = 0;
 
 	bool external_install;
 

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -4888,14 +4888,6 @@ CanvasItemEditor::CanvasItemEditor() {
 	view_offset = Point2(-150 - RULER_WIDTH, -95 - RULER_WIDTH);
 	previous_update_view_offset = view_offset; // Moves the view a little bit to the left so that (0,0) is visible. The values a relative to a 16/10 screen
 
-	grid_offset = Point2();
-	grid_step = Point2(8, 8); // A power-of-two value works better as a default
-	primary_grid_steps = 8; // A power-of-two value works better as a default
-	grid_step_multiplier = 0;
-
-	snap_rotation_offset = 0;
-	snap_rotation_step = Math::deg2rad(15.0);
-	snap_scale_step = 0.1f;
 	snap_target[0] = SNAP_TARGET_NONE;
 	snap_target[1] = SNAP_TARGET_NONE;
 

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -180,7 +180,7 @@ private:
 		GRID_VISIBILITY_HIDE,
 	};
 
-	bool selection_menu_additive_selection;
+	bool selection_menu_additive_selection = false;
 
 	Tool tool = TOOL_SELECT;
 	Control *viewport = nullptr;
@@ -204,20 +204,20 @@ private:
 	bool show_edit_locks = true;
 	bool show_transformation_gizmos = true;
 
-	real_t zoom;
+	real_t zoom = 1.0;
 	Point2 view_offset;
 	Point2 previous_update_view_offset;
 
 	bool selected_from_canvas = false;
 
 	Point2 grid_offset;
-	Point2 grid_step;
-	int primary_grid_steps;
-	int grid_step_multiplier;
+	Point2 grid_step = Point2(8, 8); // A power-of-two value works better as a default.
+	int primary_grid_steps = 8;
+	int grid_step_multiplier = 0;
 
-	real_t snap_rotation_step;
-	real_t snap_rotation_offset;
-	real_t snap_scale_step;
+	real_t snap_rotation_step = 0.0;
+	real_t snap_rotation_offset = Math::deg2rad(15.0);
+	real_t snap_scale_step = 0.1f;
 	bool smart_snap_active = false;
 	bool grid_snap_active = false;
 
@@ -241,7 +241,7 @@ private:
 	bool pan_pressed = false;
 
 	bool ruler_tool_active = false;
-	Point2 ruler_tool_origin = Point2();
+	Point2 ruler_tool_origin;
 	Point2 node_create_position;
 
 	MenuOption last_option;
@@ -346,7 +346,7 @@ private:
 	bool is_hovering_h_guide = false;
 	bool is_hovering_v_guide = false;
 
-	bool updating_value_dialog;
+	bool updating_value_dialog = false;
 
 	Point2 box_selecting_to;
 

--- a/editor/plugins/mesh_library_editor_plugin.h
+++ b/editor/plugins/mesh_library_editor_plugin.h
@@ -47,8 +47,8 @@ class MeshLibraryEditor : public Control {
 	ConfirmationDialog *cd_remove = nullptr;
 	ConfirmationDialog *cd_update = nullptr;
 	EditorFileDialog *file = nullptr;
-	bool apply_xforms;
-	int to_erase;
+	bool apply_xforms = false;
+	int to_erase = 0;
 
 	enum {
 		MENU_OPTION_ADD_ITEM,
@@ -58,7 +58,7 @@ class MeshLibraryEditor : public Control {
 		MENU_OPTION_IMPORT_FROM_SCENE_APPLY_XFORMS
 	};
 
-	int option;
+	int option = 0;
 	void _import_scene_cbk(const String &p_str);
 	void _menu_cbk(int p_option);
 	void _menu_remove_confirm();

--- a/editor/plugins/multimesh_editor_plugin.h
+++ b/editor/plugins/multimesh_editor_plugin.h
@@ -46,7 +46,7 @@ class MultiMeshEditor : public Control {
 	AcceptDialog *err_dialog = nullptr;
 	MenuButton *options = nullptr;
 	MultiMeshInstance3D *_last_pp_node = nullptr;
-	bool browsing_source;
+	bool browsing_source = false;
 
 	Panel *panel = nullptr;
 	MultiMeshInstance3D *node = nullptr;

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -211,7 +211,7 @@ private:
 	Control *surface = nullptr;
 	SubViewport *viewport = nullptr;
 	Camera3D *camera = nullptr;
-	bool transforming;
+	bool transforming = false;
 	bool orthogonal;
 	bool auto_orthogonal;
 	bool lock_rotation;
@@ -271,7 +271,7 @@ private:
 
 	ObjectID clicked;
 	Vector<_RayResult> selection_results;
-	bool clicked_wants_append;
+	bool clicked_wants_append = false;
 	bool selection_in_progress = false;
 
 	PopupMenu *selection_menu = nullptr;
@@ -551,12 +551,12 @@ private:
 
 	RID origin;
 	RID origin_instance;
-	bool origin_enabled;
+	bool origin_enabled = false;
 	RID grid[3];
 	RID grid_instance[3];
 	bool grid_visible[3]; //currently visible
 	bool grid_enable[3]; //should be always visible if true
-	bool grid_enabled;
+	bool grid_enabled = false;
 	bool grid_init_draw = false;
 	Camera3D::Projection grid_camera_last_update_perspective = Camera3D::PROJECTION_PERSPECTIVE;
 	Vector3 grid_camera_last_update_position = Vector3();

--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -82,11 +82,11 @@ class Path2DEditor : public HBoxContainer {
 	};
 
 	Action action;
-	int action_point;
+	int action_point = 0;
 	Point2 moving_from;
 	Point2 moving_screen_from;
-	float orig_in_length;
-	float orig_out_length;
+	float orig_in_length = 0.0f;
+	float orig_out_length = 0.0f;
 	Vector2 edge_point;
 
 	void _mode_selected(int p_mode);

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -84,7 +84,7 @@ class Path3DEditorPlugin : public EditorPlugin {
 	void _mode_changed(int p_idx);
 	void _close_curve();
 	void _handle_option_pressed(int p_option);
-	bool handle_clicked;
+	bool handle_clicked = false;
 	bool mirror_handle_angle;
 	bool mirror_handle_length;
 

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -96,7 +96,7 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	SpinBox *bone_paint_radius = nullptr;
 	Label *bone_paint_radius_label = nullptr;
 	bool bone_painting;
-	int bone_painting_bone;
+	int bone_painting_bone = 0;
 	Vector<float> prev_weights;
 	Vector2 bone_paint_pos;
 	AcceptDialog *grid_settings = nullptr;
@@ -110,7 +110,7 @@ class Polygon2DEditor : public AbstractPolygon2DEditor {
 	Vector<Vector2> uv_create_uv_prev;
 	Vector<Vector2> uv_create_poly_prev;
 	Vector<Color> uv_create_colors_prev;
-	int uv_create_prev_internal_vertices;
+	int uv_create_prev_internal_vertices = 0;
 	Array uv_create_bones_prev;
 	Array polygons_prev;
 

--- a/editor/plugins/polygon_3d_editor_plugin.h
+++ b/editor/plugins/polygon_3d_editor_plugin.h
@@ -66,14 +66,14 @@ class Polygon3DEditor : public HBoxContainer {
 
 	MenuButton *options = nullptr;
 
-	int edited_point;
+	int edited_point = 0;
 	Vector2 edited_point_pos;
 	PackedVector2Array pre_move_edit;
 	PackedVector2Array wip;
 	bool wip_active;
 	bool snap_ignore;
 
-	float prev_depth;
+	float prev_depth = 0.0f;
 
 	void _wip_close();
 	void _polygon_draw();

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -249,7 +249,7 @@ class ScriptEditor : public PanelContainer {
 	MenuButton *debug_menu = nullptr;
 	PopupMenu *context_menu = nullptr;
 	Timer *autosave_timer = nullptr;
-	uint64_t idle;
+	uint64_t idle = 0;
 
 	PopupMenu *recent_scripts = nullptr;
 	PopupMenu *theme_submenu = nullptr;

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -114,7 +114,7 @@ class ShaderEditor : public PanelContainer {
 	MenuButton *help_menu = nullptr;
 	PopupMenu *context_menu = nullptr;
 	RichTextLabel *warnings_panel = nullptr;
-	uint64_t idle;
+	uint64_t idle = 0;
 
 	GotoLineDialog *goto_line_dialog = nullptr;
 	ConfirmationDialog *erase_tab_confirm = nullptr;

--- a/editor/plugins/skeleton_3d_editor_plugin.h
+++ b/editor/plugins/skeleton_3d_editor_plugin.h
@@ -131,7 +131,7 @@ class Skeleton3DEditor : public VBoxContainer {
 
 	EditorFileDialog *file_dialog = nullptr;
 
-	bool keyable;
+	bool keyable = false;
 
 	static Skeleton3DEditor *singleton;
 

--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -105,7 +105,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	EditorFileDialog *file_split_sheet = nullptr;
 	Set<int> frames_selected;
 	Set<int> frames_toggled_by_mouse_hover;
-	int last_frame_selected;
+	int last_frame_selected = 0;
 
 	float scale_ratio;
 	int thumbnail_default_size;

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -87,14 +87,14 @@ class TextureRegionEditor : public VBoxContainer {
 
 	Rect2 rect;
 	Rect2 rect_prev;
-	float prev_margin;
+	float prev_margin = 0.0f;
 	int edited_margin;
 	Map<RID, List<Rect2>> cache_map;
 	List<Rect2> autoslice_cache;
 	bool autoslice_is_dirty;
 
 	bool drag;
-	bool creating;
+	bool creating = false;
 	Vector2 drag_from;
 	int drag_index;
 

--- a/editor/plugins/tiles/tile_data_editors.h
+++ b/editor/plugins/tiles/tile_data_editors.h
@@ -108,8 +108,8 @@ private:
 		DRAG_TYPE_PAN,
 	};
 	DragType drag_type = DRAG_TYPE_NONE;
-	int drag_polygon_index;
-	int drag_point_index;
+	int drag_polygon_index = 0;
+	int drag_point_index = 0;
 	Vector2 drag_last_pos;
 	PackedVector2Array drag_old_polygon;
 
@@ -132,9 +132,9 @@ private:
 	Ref<Texture2D> background_texture;
 	Rect2 background_region;
 	Vector2 background_offset;
-	bool background_h_flip;
-	bool background_v_flip;
-	bool background_transpose;
+	bool background_h_flip = false;
+	bool background_v_flip = false;
+	bool background_transpose = false;
 	Color background_modulate;
 
 	Color polygon_color = Color(1.0, 0.0, 0.0);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -5864,7 +5864,7 @@ public:
 class VisualShaderNodePluginDefaultEditor : public VBoxContainer {
 	GDCLASS(VisualShaderNodePluginDefaultEditor, VBoxContainer);
 	Ref<Resource> parent_resource;
-	int node_id;
+	int node_id = 0;
 	VisualShader::Type shader_type;
 
 public:
@@ -5927,7 +5927,7 @@ public:
 		InspectorDock::get_inspector_singleton()->edit(p_resource.ptr());
 	}
 
-	bool updating;
+	bool updating = false;
 	Ref<VisualShaderNode> node;
 	Vector<EditorProperty *> properties;
 	Vector<Label *> prop_names;

--- a/editor/progress_dialog.h
+++ b/editor/progress_dialog.h
@@ -85,7 +85,7 @@ class ProgressDialog : public PopupPanel {
 	void _popup();
 
 	void _cancel_pressed();
-	bool cancelled;
+	bool cancelled = false;
 
 protected:
 	void _notification(int p_what);

--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -104,7 +104,7 @@ class CustomPropertyEditor : public PopupPanel {
 	Variant::Type type;
 	Variant v;
 	List<String> field_names;
-	int hint;
+	int hint = 0;
 	String hint_text;
 	HBoxContainer *value_hboxes[MAX_VALUE_EDITORS / 4];
 	VBoxContainer *value_vbox = nullptr;
@@ -120,7 +120,7 @@ class CustomPropertyEditor : public PopupPanel {
 	ColorPicker *color_picker = nullptr;
 	TextEdit *text_edit = nullptr;
 	bool read_only = false;
-	bool picking_viewport;
+	bool picking_viewport = false;
 	GridContainer *checks20gc = nullptr;
 	CheckBox *checks20[20];
 	SpinBox *spinbox = nullptr;

--- a/editor/property_selector.h
+++ b/editor/property_selector.h
@@ -50,7 +50,7 @@ class PropertySelector : public ConfirmationDialog {
 
 	EditorHelpBit *help_bit = nullptr;
 
-	bool properties;
+	bool properties = false;
 	String selected;
 	Variant::Type type;
 	String base_type;

--- a/editor/rename_dialog.h
+++ b/editor/rename_dialog.h
@@ -64,7 +64,7 @@ class RenameDialog : public ConfirmationDialog {
 
 	SceneTreeEditor *scene_tree_editor = nullptr;
 	UndoRedo *undo_redo = nullptr;
-	int global_count;
+	int global_count = 0;
 
 	LineEdit *lne_search = nullptr;
 	LineEdit *lne_replace = nullptr;
@@ -97,9 +97,9 @@ class RenameDialog : public ConfirmationDialog {
 
 	List<Pair<NodePath, String>> to_rename;
 	Node *preview_node = nullptr;
-	bool lock_preview_update;
+	bool lock_preview_update = false;
 	ErrorHandlerList eh;
-	bool has_errors;
+	bool has_errors = false;
 
 protected:
 	static void _bind_methods();

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -108,7 +108,7 @@ class SceneTreeDock : public VBoxContainer {
 	bool restore_script_editor_on_drag = false;
 	bool reset_create_dialog = false;
 
-	int current_option;
+	int current_option = 0;
 	CreateDialog *create_dialog = nullptr;
 #ifdef MODULE_REGEX_ENABLED
 	RenameDialog *rename_dialog = nullptr;

--- a/modules/cvtt/image_compress_cvtt.cpp
+++ b/modules/cvtt/image_compress_cvtt.cpp
@@ -46,7 +46,7 @@ struct CVTTCompressionJobParams {
 };
 
 struct CVTTCompressionRowTask {
-	const uint8_t *in_mm_bytes;
+	const uint8_t *in_mm_bytes = nullptr;
 	uint8_t *out_mm_bytes = nullptr;
 	int y_start = 0;
 	int width = 0;
@@ -55,7 +55,7 @@ struct CVTTCompressionRowTask {
 
 struct CVTTCompressionJobQueue {
 	CVTTCompressionJobParams job_params;
-	const CVTTCompressionRowTask *job_tasks;
+	const CVTTCompressionRowTask *job_tasks = nullptr;
 	uint32_t num_tasks = 0;
 	SafeNumeric<uint32_t> current_task;
 };

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -68,7 +68,7 @@ enum DDSFormat {
 };
 
 struct DDSFormatInfo {
-	const char *name;
+	const char *name = nullptr;
 	bool compressed = false;
 	bool palette = false;
 	uint32_t divisor = 0;

--- a/modules/gdscript/gdscript_utility_functions.cpp
+++ b/modules/gdscript/gdscript_utility_functions.cpp
@@ -545,7 +545,7 @@ struct GDScriptUtilityFunctionsDefinitions {
 };
 
 struct GDScriptUtilityFunctionInfo {
-	GDScriptUtilityFunctions::FunctionPtr function;
+	GDScriptUtilityFunctions::FunctionPtr function = nullptr;
 	MethodInfo info;
 	bool is_constant = false;
 };

--- a/modules/openxr/extensions/openxr_vulkan_extension.h
+++ b/modules/openxr/extensions/openxr_vulkan_extension.h
@@ -78,11 +78,11 @@ private:
 
 	bool check_graphics_api_support(XrVersion p_desired_version);
 
-	VkInstance vulkan_instance;
-	VkPhysicalDevice vulkan_physical_device;
-	VkDevice vulkan_device;
-	uint32_t vulkan_queue_family_index;
-	uint32_t vulkan_queue_index;
+	VkInstance vulkan_instance = nullptr;
+	VkPhysicalDevice vulkan_physical_device = nullptr;
+	VkDevice vulkan_device = nullptr;
+	uint32_t vulkan_queue_family_index = 0;
+	uint32_t vulkan_queue_index = 0;
 
 	XrResult xrGetVulkanGraphicsRequirements2KHR(XrInstance p_instance, XrSystemId p_system_id, XrGraphicsRequirementsVulkanKHR *p_graphics_requirements);
 	XrResult xrCreateVulkanInstanceKHR(XrInstance p_instance, const XrVulkanInstanceCreateInfoKHR *p_create_info, VkInstance *r_vulkan_instance, VkResult *r_vulkan_result);

--- a/modules/openxr/openxr_api.h
+++ b/modules/openxr/openxr_api.h
@@ -104,9 +104,9 @@ private:
 
 	// state
 	XrInstance instance = XR_NULL_HANDLE;
-	XrSystemId system_id;
+	XrSystemId system_id = 0;
 	String system_name;
-	uint32_t vendor_id;
+	uint32_t vendor_id = 0;
 	XrSystemTrackingProperties tracking_properties;
 	XrSession session = XR_NULL_HANDLE;
 	XrSessionState session_state = XR_SESSION_STATE_UNKNOWN;

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -878,8 +878,8 @@ _FORCE_INLINE_ TextServerAdvanced::FontTexturePosition TextServerAdvanced::find_
 
 struct MSContext {
 	msdfgen::Point2 position;
-	msdfgen::Shape *shape;
-	msdfgen::Contour *contour;
+	msdfgen::Shape *shape = nullptr;
+	msdfgen::Contour *contour = nullptr;
 };
 
 class DistancePixelConversion {

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -322,8 +322,8 @@ _FORCE_INLINE_ TextServerFallback::FontTexturePosition TextServerFallback::find_
 
 struct MSContext {
 	msdfgen::Point2 position;
-	msdfgen::Shape *shape;
-	msdfgen::Contour *contour;
+	msdfgen::Shape *shape = nullptr;
+	msdfgen::Contour *contour = nullptr;
 };
 
 class DistancePixelConversion {

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -99,7 +99,7 @@ class VideoStreamPlaybackTheora : public VideoStreamPlayback {
 
 	Ref<ImageTexture> texture;
 
-	AudioMixCallback mix_callback;
+	AudioMixCallback mix_callback = nullptr;
 	void *mix_udata = nullptr;
 	bool paused = false;
 

--- a/modules/visual_script/editor/visual_script_property_selector.h
+++ b/modules/visual_script/editor/visual_script_property_selector.h
@@ -173,8 +173,8 @@ class VisualScriptPropertySelector::SearchRunner : public RefCounted {
 	Control *ui_service = nullptr;
 	Tree *results_tree = nullptr;
 	String term;
-	int search_flags;
-	int scope_flags;
+	int search_flags = 0;
+	int scope_flags = 0;
 
 	Ref<Texture2D> empty_icon;
 	Color disabled_color;

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -1180,8 +1180,8 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 
 class VisualScriptNodeInstanceBuiltinFunc : public VisualScriptNodeInstance {
 public:
-	VisualScriptBuiltinFunc *node;
-	VisualScriptInstance *instance;
+	VisualScriptBuiltinFunc *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
 
 	VisualScriptBuiltinFunc::BuiltinFunc func;
 

--- a/modules/visual_script/visual_script_expression.cpp
+++ b/modules/visual_script/visual_script_expression.cpp
@@ -1299,8 +1299,8 @@ bool VisualScriptExpression::_compile_expression() {
 
 class VisualScriptNodeInstanceExpression : public VisualScriptNodeInstance {
 public:
-	VisualScriptInstance *instance;
-	VisualScriptExpression *expression;
+	VisualScriptInstance *instance = nullptr;
+	VisualScriptExpression *expression = nullptr;
 
 	//virtual int get_working_memory_size() const override { return 0; }
 	//execute by parsing the tree directly

--- a/modules/visual_script/visual_script_flow_control.cpp
+++ b/modules/visual_script/visual_script_flow_control.cpp
@@ -119,9 +119,9 @@ void VisualScriptReturn::_bind_methods() {
 
 class VisualScriptNodeInstanceReturn : public VisualScriptNodeInstance {
 public:
-	VisualScriptReturn *node;
-	VisualScriptInstance *instance;
-	bool with_value;
+	VisualScriptReturn *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
+	bool with_value = false;
 
 	virtual int get_working_memory_size() const override { return 1; }
 	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }
@@ -213,8 +213,8 @@ void VisualScriptCondition::_bind_methods() {
 
 class VisualScriptNodeInstanceCondition : public VisualScriptNodeInstance {
 public:
-	VisualScriptCondition *node;
-	VisualScriptInstance *instance;
+	VisualScriptCondition *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
 
 	//virtual int get_working_memory_size() const override { return 1; }
 	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }
@@ -293,8 +293,8 @@ void VisualScriptWhile::_bind_methods() {
 
 class VisualScriptNodeInstanceWhile : public VisualScriptNodeInstance {
 public:
-	VisualScriptWhile *node;
-	VisualScriptInstance *instance;
+	VisualScriptWhile *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
 
 	//virtual int get_working_memory_size() const override { return 1; }
 	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }
@@ -376,8 +376,8 @@ void VisualScriptIterator::_bind_methods() {
 
 class VisualScriptNodeInstanceIterator : public VisualScriptNodeInstance {
 public:
-	VisualScriptIterator *node;
-	VisualScriptInstance *instance;
+	VisualScriptIterator *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
 
 	virtual int get_working_memory_size() const override { return 2; }
 	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }
@@ -508,9 +508,9 @@ void VisualScriptSequence::_bind_methods() {
 
 class VisualScriptNodeInstanceSequence : public VisualScriptNodeInstance {
 public:
-	VisualScriptSequence *node;
-	VisualScriptInstance *instance;
-	int steps;
+	VisualScriptSequence *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
+	int steps = 0;
 
 	virtual int get_working_memory_size() const override { return 1; }
 	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }
@@ -596,8 +596,8 @@ String VisualScriptSwitch::get_text() const {
 
 class VisualScriptNodeInstanceSwitch : public VisualScriptNodeInstance {
 public:
-	VisualScriptInstance *instance;
-	int case_count;
+	VisualScriptInstance *instance = nullptr;
+	int case_count = 0;
 
 	//virtual int get_working_memory_size() const override { return 0; }
 	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }
@@ -774,7 +774,7 @@ VisualScriptTypeCast::TypeGuess VisualScriptTypeCast::guess_output_type(TypeGues
 
 class VisualScriptNodeInstanceTypeCast : public VisualScriptNodeInstance {
 public:
-	VisualScriptInstance *instance;
+	VisualScriptInstance *instance = nullptr;
 	StringName base_type;
 	String script;
 

--- a/modules/visual_script/visual_script_func_nodes.cpp
+++ b/modules/visual_script/visual_script_func_nodes.cpp
@@ -720,15 +720,15 @@ class VisualScriptNodeInstanceFunctionCall : public VisualScriptNodeInstance {
 public:
 	VisualScriptFunctionCall::CallMode call_mode;
 	NodePath node_path;
-	int input_args;
-	bool validate;
-	int returns;
+	int input_args = 0;
+	bool validate = false;
+	int returns = 0;
 	VisualScriptFunctionCall::RPCCallMode rpc_mode;
 	StringName function;
 	StringName singleton;
 
-	VisualScriptFunctionCall *node;
-	VisualScriptInstance *instance;
+	VisualScriptFunctionCall *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
 
 	//virtual int get_working_memory_size() const override { return 0; }
 	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }
@@ -1462,11 +1462,11 @@ public:
 	NodePath node_path;
 	StringName property;
 
-	VisualScriptPropertySet *node;
-	VisualScriptInstance *instance;
+	VisualScriptPropertySet *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
 	VisualScriptPropertySet::AssignOp assign_op;
 	StringName index;
-	bool needs_get;
+	bool needs_get = false;
 
 	//virtual int get_working_memory_size() const override { return 0; }
 	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }
@@ -2152,8 +2152,8 @@ public:
 	StringName property;
 	StringName index;
 
-	VisualScriptPropertyGet *node;
-	VisualScriptInstance *instance;
+	VisualScriptPropertyGet *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
 
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) override {
 		switch (call_mode) {
@@ -2362,9 +2362,9 @@ void VisualScriptEmitSignal::_bind_methods() {
 
 class VisualScriptNodeInstanceEmitSignal : public VisualScriptNodeInstance {
 public:
-	VisualScriptEmitSignal *node;
-	VisualScriptInstance *instance;
-	int argcount;
+	VisualScriptEmitSignal *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
+	int argcount = 0;
 	StringName name;
 
 	//virtual int get_working_memory_size() const override { return 0; }

--- a/modules/visual_script/visual_script_nodes.cpp
+++ b/modules/visual_script/visual_script_nodes.cpp
@@ -271,8 +271,8 @@ Multiplayer::RPCMode VisualScriptFunction::get_rpc_mode() const {
 
 class VisualScriptNodeInstanceFunction : public VisualScriptNodeInstance {
 public:
-	VisualScriptFunction *node;
-	VisualScriptInstance *instance;
+	VisualScriptFunction *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
 
 	//virtual int get_working_memory_size() const override { return 0; }
 
@@ -1097,7 +1097,7 @@ void VisualScriptOperator::_bind_methods() {
 
 class VisualScriptNodeInstanceOperator : public VisualScriptNodeInstance {
 public:
-	bool unary;
+	bool unary = false;
 	Variant::Operator op;
 
 	//virtual int get_working_memory_size() const override { return 0; }
@@ -1328,8 +1328,8 @@ void VisualScriptVariableGet::_bind_methods() {
 
 class VisualScriptNodeInstanceVariableGet : public VisualScriptNodeInstance {
 public:
-	VisualScriptVariableGet *node;
-	VisualScriptInstance *instance;
+	VisualScriptVariableGet *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
 	StringName variable;
 
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) override {
@@ -1438,8 +1438,8 @@ void VisualScriptVariableSet::_bind_methods() {
 
 class VisualScriptNodeInstanceVariableSet : public VisualScriptNodeInstance {
 public:
-	VisualScriptVariableSet *node;
-	VisualScriptInstance *instance;
+	VisualScriptVariableSet *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
 	StringName variable;
 
 	//virtual int get_working_memory_size() const override { return 0; }
@@ -1851,8 +1851,7 @@ int VisualScriptGlobalConstant::get_global_constant() {
 
 class VisualScriptNodeInstanceGlobalConstant : public VisualScriptNodeInstance {
 public:
-	int index;
-	//virtual int get_working_memory_size() const override { return 0; }
+	int index = 0;
 
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) override {
 		*p_outputs[0] = CoreConstants::get_global_constant_value(index);
@@ -1963,9 +1962,8 @@ StringName VisualScriptClassConstant::get_base_type() {
 
 class VisualScriptNodeInstanceClassConstant : public VisualScriptNodeInstance {
 public:
-	int value;
-	bool valid;
-	//virtual int get_working_memory_size() const override { return 0; }
+	int value = 0;
+	bool valid = false;
 
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) override {
 		if (!valid) {
@@ -2098,8 +2096,7 @@ Variant::Type VisualScriptBasicTypeConstant::get_basic_type() const {
 class VisualScriptNodeInstanceBasicTypeConstant : public VisualScriptNodeInstance {
 public:
 	Variant value;
-	bool valid;
-	//virtual int get_working_memory_size() const override { return 0; }
+	bool valid = false;
 
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) override {
 		if (!valid) {
@@ -2227,8 +2224,7 @@ VisualScriptMathConstant::MathConstant VisualScriptMathConstant::get_math_consta
 
 class VisualScriptNodeInstanceMathConstant : public VisualScriptNodeInstance {
 public:
-	float value;
-	//virtual int get_working_memory_size() const override { return 0; }
+	float value = 0.0f;
 
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) override {
 		*p_outputs[0] = value;
@@ -2320,7 +2316,7 @@ String VisualScriptEngineSingleton::get_singleton() {
 
 class VisualScriptNodeInstanceEngineSingleton : public VisualScriptNodeInstance {
 public:
-	Object *singleton;
+	Object *singleton = nullptr;
 
 	//virtual int get_working_memory_size() const override { return 0; }
 
@@ -2429,8 +2425,8 @@ NodePath VisualScriptSceneNode::get_node_path() {
 
 class VisualScriptNodeInstanceSceneNode : public VisualScriptNodeInstance {
 public:
-	VisualScriptSceneNode *node;
-	VisualScriptInstance *instance;
+	VisualScriptSceneNode *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
 	NodePath path;
 
 	//virtual int get_working_memory_size() const override { return 0; }
@@ -2610,8 +2606,8 @@ String VisualScriptSceneTree::get_caption() const {
 
 class VisualScriptNodeInstanceSceneTree : public VisualScriptNodeInstance {
 public:
-	VisualScriptSceneTree *node;
-	VisualScriptInstance *instance;
+	VisualScriptSceneTree *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
 
 	//virtual int get_working_memory_size() const override { return 0; }
 
@@ -2779,7 +2775,7 @@ String VisualScriptSelf::get_caption() const {
 
 class VisualScriptNodeInstanceSelf : public VisualScriptNodeInstance {
 public:
-	VisualScriptInstance *instance;
+	VisualScriptInstance *instance = nullptr;
 
 	//virtual int get_working_memory_size() const override { return 0; }
 
@@ -2965,11 +2961,11 @@ String VisualScriptCustomNode::get_category() const {
 
 class VisualScriptNodeInstanceCustomNode : public VisualScriptNodeInstance {
 public:
-	VisualScriptInstance *instance;
-	VisualScriptCustomNode *node;
-	int in_count;
-	int out_count;
-	int work_mem_size;
+	VisualScriptInstance *instance = nullptr;
+	VisualScriptCustomNode *node = nullptr;
+	int in_count = 0;
+	int out_count = 0;
+	int work_mem_size = 0;
 
 	virtual int get_working_memory_size() const override { return work_mem_size; }
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) override {
@@ -3161,10 +3157,10 @@ String VisualScriptSubCall::get_category() const {
 
 class VisualScriptNodeInstanceSubCall : public VisualScriptNodeInstance {
 public:
-	VisualScriptInstance *instance;
-	VisualScriptSubCall *subcall;
-	int input_args;
-	bool valid;
+	VisualScriptInstance *instance = nullptr;
+	VisualScriptSubCall *subcall = nullptr;
+	int input_args = 0;
+	bool valid = false;
 
 	//virtual int get_working_memory_size() const override { return 0; }
 
@@ -3281,7 +3277,7 @@ String VisualScriptComment::get_category() const {
 
 class VisualScriptNodeInstanceComment : public VisualScriptNodeInstance {
 public:
-	VisualScriptInstance *instance;
+	VisualScriptInstance *instance = nullptr;
 
 	//virtual int get_working_memory_size() const override { return 0; }
 
@@ -3380,9 +3376,9 @@ Dictionary VisualScriptConstructor::get_constructor() const {
 
 class VisualScriptNodeInstanceConstructor : public VisualScriptNodeInstance {
 public:
-	VisualScriptInstance *instance;
+	VisualScriptInstance *instance = nullptr;
 	Variant::Type type;
-	int argcount;
+	int argcount = 0;
 
 	//virtual int get_working_memory_size() const override { return 0; }
 
@@ -3497,7 +3493,7 @@ Variant::Type VisualScriptLocalVar::get_var_type() const {
 
 class VisualScriptNodeInstanceLocalVar : public VisualScriptNodeInstance {
 public:
-	VisualScriptInstance *instance;
+	VisualScriptInstance *instance = nullptr;
 	StringName name;
 
 	virtual int get_working_memory_size() const override { return 1; }
@@ -3604,7 +3600,7 @@ Variant::Type VisualScriptLocalVarSet::get_var_type() const {
 
 class VisualScriptNodeInstanceLocalVarSet : public VisualScriptNodeInstance {
 public:
-	VisualScriptInstance *instance;
+	VisualScriptInstance *instance = nullptr;
 	StringName name;
 
 	virtual int get_working_memory_size() const override { return 1; }
@@ -3728,7 +3724,7 @@ VisualScriptInputAction::Mode VisualScriptInputAction::get_action_mode() const {
 
 class VisualScriptNodeInstanceInputAction : public VisualScriptNodeInstance {
 public:
-	VisualScriptInstance *instance;
+	VisualScriptInstance *instance = nullptr;
 	StringName action;
 	VisualScriptInputAction::Mode mode;
 
@@ -3906,7 +3902,7 @@ Array VisualScriptDeconstruct::_get_elem_cache() const {
 
 class VisualScriptNodeInstanceDeconstruct : public VisualScriptNodeInstance {
 public:
-	VisualScriptInstance *instance;
+	VisualScriptInstance *instance = nullptr;
 	Vector<StringName> outputs;
 
 	//virtual int get_working_memory_size() const override { return 0; }

--- a/modules/visual_script/visual_script_yield_nodes.cpp
+++ b/modules/visual_script/visual_script_yield_nodes.cpp
@@ -93,7 +93,7 @@ String VisualScriptYield::get_text() const {
 class VisualScriptNodeInstanceYield : public VisualScriptNodeInstance {
 public:
 	VisualScriptYield::YieldMode mode;
-	double wait_time;
+	double wait_time = 0.0;
 
 	virtual int get_working_memory_size() const override { return 1; } //yield needs at least 1
 	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }
@@ -500,11 +500,11 @@ class VisualScriptNodeInstanceYieldSignal : public VisualScriptNodeInstance {
 public:
 	VisualScriptYieldSignal::CallMode call_mode;
 	NodePath node_path;
-	int output_args;
+	int output_args = 0;
 	StringName signal;
 
-	VisualScriptYieldSignal *node;
-	VisualScriptInstance *instance;
+	VisualScriptYieldSignal *node = nullptr;
+	VisualScriptInstance *instance = nullptr;
 
 	virtual int get_working_memory_size() const override { return 1; }
 	//virtual bool is_output_port_unsequenced(int p_idx) const { return false; }

--- a/modules/websocket/wsl_client.h
+++ b/modules/websocket/wsl_client.h
@@ -63,7 +63,7 @@ private:
 
 	String _key;
 	String _host;
-	uint16_t _port;
+	uint16_t _port = 0;
 	Array _ip_candidates;
 	Vector<String> _protocols;
 	bool _use_ssl = false;

--- a/platform/iphone/export/export_plugin.h
+++ b/platform/iphone/export/export_plugin.h
@@ -53,8 +53,6 @@
 class EditorExportPlatformIOS : public EditorExportPlatform {
 	GDCLASS(EditorExportPlatformIOS, EditorExportPlatform);
 
-	int version_code;
-
 	Ref<ImageTexture> logo;
 
 	// Plugins

--- a/platform/linuxbsd/detect_prime_x11.cpp
+++ b/platform/linuxbsd/detect_prime_x11.cpp
@@ -55,7 +55,7 @@
 typedef GLXContext (*GLXCREATECONTEXTATTRIBSARBPROC)(Display *, GLXFBConfig, GLXContext, Bool, const int *);
 
 struct vendor {
-	const char *glxvendor;
+	const char *glxvendor = nullptr;
 	int priority = 0;
 };
 

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -4531,23 +4531,10 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 
 	r_error = OK;
 
-	current_cursor = CURSOR_ARROW;
-	mouse_mode = MOUSE_MODE_VISIBLE;
-
 	for (int i = 0; i < CURSOR_MAX; i++) {
 		cursors[i] = None;
 		img[i] = nullptr;
 	}
-
-	xmbstring = nullptr;
-
-	last_click_ms = 0;
-	last_click_button_index = MouseButton::NONE;
-	last_click_pos = Point2i(-100, -100);
-
-	last_timestamp = 0;
-	last_mouse_pos_valid = false;
-	last_keyrelease_time = 0;
 
 	XInitThreads(); //always use threads
 
@@ -4583,8 +4570,6 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 	}
 
 	const char *err;
-	xrr_get_monitors = nullptr;
-	xrr_free_monitors = nullptr;
 	int xrandr_major = 0;
 	int xrandr_minor = 0;
 	int event_base, error_base;
@@ -4660,11 +4645,10 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 		XFree(imvalret);
 	}
 
-	/* Atorm internment */
+	/* Atom internment */
 	wm_delete = XInternAtom(x11_display, "WM_DELETE_WINDOW", true);
-	//Set Xdnd (drag & drop) support
+	// Set Xdnd (drag & drop) support.
 	xdnd_aware = XInternAtom(x11_display, "XdndAware", False);
-	xdnd_version = 5;
 	xdnd_enter = XInternAtom(x11_display, "XdndEnter", False);
 	xdnd_position = XInternAtom(x11_display, "XdndPosition", False);
 	xdnd_status = XInternAtom(x11_display, "XdndStatus", False);
@@ -4751,11 +4735,7 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 		}
 		driver_found = true;
 
-		//		gl_manager->set_use_vsync(current_videomode.use_vsync);
-
 		if (true) {
-			//		if (RasterizerGLES3::is_viable() == OK) {
-			//		RasterizerGLES3::register_config();
 			RasterizerGLES3::make_current();
 		} else {
 			memdelete(gl_manager);
@@ -4929,12 +4909,6 @@ DisplayServerX11::DisplayServerX11(const String &p_rendering_driver, WindowMode 
 		null_cursor = cursor;
 	}
 	cursor_set_shape(CURSOR_BUSY);
-
-	requested = None;
-
-	/*if (p_desired.layered) {
-		set_window_per_pixel_transparency_enabled(true);
-	}*/
 
 	XEvent xevent;
 	while (XPending(x11_display) > 0) {

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -100,8 +100,8 @@ class DisplayServerX11 : public DisplayServer {
 	Atom xdnd_finished;
 	Atom xdnd_selection;
 	Atom xdnd_aware;
-	Atom requested;
-	int xdnd_version;
+	Atom requested = None;
+	int xdnd_version = 5;
 
 #if defined(GLES3_ENABLED)
 	GLManager_X11 *gl_manager = nullptr;
@@ -174,21 +174,21 @@ class DisplayServerX11 : public DisplayServer {
 
 	String internal_clipboard;
 	String internal_clipboard_primary;
-	Window xdnd_source_window;
+	Window xdnd_source_window = 0;
 	::Display *x11_display;
 	char *xmbstring = nullptr;
-	int xmblen;
-	unsigned long last_timestamp;
-	::Time last_keyrelease_time;
+	int xmblen = 0;
+	unsigned long last_timestamp = 0;
+	::Time last_keyrelease_time = 0;
 	::XIM xim;
 	::XIMStyle xim_style;
 	static void _xim_destroy_callback(::XIM im, ::XPointer client_data,
 			::XPointer call_data);
 
 	Point2i last_mouse_pos;
-	bool last_mouse_pos_valid;
-	Point2i last_click_pos;
-	uint64_t last_click_ms;
+	bool last_mouse_pos_valid = false;
+	Point2i last_click_pos = Point2i(-100, -100);
+	uint64_t last_click_ms = 0;
 	MouseButton last_click_button_index = MouseButton::NONE;
 	MouseButton last_button_state = MouseButton::NONE;
 	bool app_focused = false;
@@ -221,7 +221,7 @@ class DisplayServerX11 : public DisplayServer {
 	void _get_key_modifier_state(unsigned int p_x11_state, Ref<InputEventWithModifiers> state);
 	void _flush_mouse_motion();
 
-	MouseMode mouse_mode;
+	MouseMode mouse_mode = MOUSE_MODE_VISIBLE;
 	Point2i center;
 
 	void _handle_key_event(WindowID p_window, XKeyEvent *p_event, LocalVector<XEvent> &p_events, uint32_t &p_event_index, bool p_echo = false);
@@ -233,30 +233,26 @@ class DisplayServerX11 : public DisplayServer {
 	String _clipboard_get(Atom p_source, Window x11_window) const;
 	void _clipboard_transfer_ownership(Atom p_source, Window x11_window) const;
 
-	//bool minimized;
-	//bool window_has_focus;
-	bool do_mouse_warp;
+	bool do_mouse_warp = false;
 
-	const char *cursor_theme;
-	int cursor_size;
+	const char *cursor_theme = nullptr;
+	int cursor_size = 0;
 	XcursorImage *img[CURSOR_MAX];
 	Cursor cursors[CURSOR_MAX];
 	Cursor null_cursor;
-	CursorShape current_cursor;
+	CursorShape current_cursor = CURSOR_ARROW;
 	Map<CursorShape, Vector<Variant>> cursors_cache;
 
-	bool layered_window;
+	bool layered_window = false;
 
 	String rendering_driver;
-	//bool window_focused;
-	//void set_wm_border(bool p_enabled);
 	void set_wm_fullscreen(bool p_enabled);
 	void set_wm_above(bool p_enabled);
 
 	typedef xrr_monitor_info *(*xrr_get_monitors_t)(Display *dpy, Window window, Bool get_active, int *nmonitors);
 	typedef void (*xrr_free_monitors_t)(xrr_monitor_info *monitors);
-	xrr_get_monitors_t xrr_get_monitors;
-	xrr_free_monitors_t xrr_free_monitors;
+	xrr_get_monitors_t xrr_get_monitors = nullptr;
+	xrr_free_monitors_t xrr_free_monitors = nullptr;
 	void *xrandr_handle = nullptr;
 	Bool xrandr_ext_ok;
 

--- a/platform/uwp/export/app_packager.h
+++ b/platform/uwp/export/app_packager.h
@@ -93,8 +93,8 @@ class AppxPackager {
 
 	Vector<FileMeta> file_metadata;
 
-	ZPOS64_T central_dir_offset;
-	ZPOS64_T end_of_central_dir_offset;
+	ZPOS64_T central_dir_offset = 0;
+	ZPOS64_T end_of_central_dir_offset = 0;
 	Vector<uint8_t> central_dir_data;
 
 	String hash_block(const uint8_t *p_block_data, size_t p_block_len);

--- a/scene/2d/area_2d.h
+++ b/scene/2d/area_2d.h
@@ -49,7 +49,7 @@ public:
 private:
 	SpaceOverride gravity_space_override = SPACE_OVERRIDE_DISABLED;
 	Vector2 gravity_vec;
-	real_t gravity;
+	real_t gravity = 0.0;
 	bool gravity_is_point = false;
 	real_t gravity_distance_scale = 0.0;
 

--- a/scene/2d/cpu_particles_2d.h
+++ b/scene/2d/cpu_particles_2d.h
@@ -137,7 +137,7 @@ private:
 	real_t randomness_ratio = 0.0;
 	double lifetime_randomness = 0.0;
 	double speed_scale = 1.0;
-	bool local_coords;
+	bool local_coords = false;
 	int fixed_fps = 0;
 	bool fractional_delta = true;
 

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -666,9 +666,6 @@ GPUParticles2D::GPUParticles2D() {
 	set_speed_scale(1);
 	set_fixed_fps(30);
 	set_collision_base_size(collision_base_size);
-#ifdef TOOLS_ENABLED
-	show_visibility_rect = false;
-#endif
 }
 
 GPUParticles2D::~GPUParticles2D() {

--- a/scene/2d/gpu_particles_2d.h
+++ b/scene/2d/gpu_particles_2d.h
@@ -47,20 +47,20 @@ public:
 private:
 	RID particles;
 
-	bool one_shot;
-	int amount;
-	double lifetime;
-	double pre_process_time;
-	real_t explosiveness_ratio;
-	real_t randomness_ratio;
-	double speed_scale;
+	bool one_shot = false;
+	int amount = 0;
+	double lifetime = 0.0;
+	double pre_process_time = 0.0;
+	real_t explosiveness_ratio = 0.0;
+	real_t randomness_ratio = 0.0;
+	double speed_scale = 0.0;
 	Rect2 visibility_rect;
-	bool local_coords;
-	int fixed_fps;
-	bool fractional_delta;
+	bool local_coords = false;
+	int fixed_fps = 0;
+	bool fractional_delta = false;
 	bool interpolate = true;
 #ifdef TOOLS_ENABLED
-	bool show_visibility_rect;
+	bool show_visibility_rect = false;
 #endif
 	Ref<Material> process_material;
 

--- a/scene/2d/light_occluder_2d.cpp
+++ b/scene/2d/light_occluder_2d.cpp
@@ -285,7 +285,6 @@ void LightOccluder2D::_bind_methods() {
 
 LightOccluder2D::LightOccluder2D() {
 	occluder = RS::get_singleton()->canvas_light_occluder_create();
-	mask = 1;
 
 	set_notify_transform(true);
 	set_as_sdf_collision(true);

--- a/scene/2d/light_occluder_2d.h
+++ b/scene/2d/light_occluder_2d.h
@@ -81,10 +81,9 @@ class LightOccluder2D : public Node2D {
 	GDCLASS(LightOccluder2D, Node2D);
 
 	RID occluder;
-	bool enabled;
-	int mask;
+	int mask = 1;
 	Ref<OccluderPolygon2D> occluder_polygon;
-	bool sdf_collision;
+	bool sdf_collision = false;
 	void _poly_changed();
 
 protected:

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -45,17 +45,17 @@ class NavigationAgent2D : public Node {
 	uint32_t navigable_layers = 1;
 
 	real_t target_desired_distance = 1.0;
-	real_t radius;
-	real_t neighbor_dist;
-	int max_neighbors;
-	real_t time_horizon;
-	real_t max_speed;
+	real_t radius = 0.0;
+	real_t neighbor_dist = 0.0;
+	int max_neighbors = 0;
+	real_t time_horizon = 0.0;
+	real_t max_speed = 0.0;
 
 	real_t path_max_distance = 3.0;
 
 	Vector2 target_location;
 	Vector<Vector2> navigation_path;
-	int nav_path_index;
+	int nav_path_index = 0;
 	bool velocity_submitted = false;
 	Vector2 prev_safe_velocity;
 	/// The submitted target velocity
@@ -63,7 +63,7 @@ class NavigationAgent2D : public Node {
 	bool target_reached = false;
 	bool navigation_finished = true;
 	// No initialized on purpose
-	uint32_t update_frame_id;
+	uint32_t update_frame_id = 0;
 
 protected:
 	static void _bind_methods();

--- a/scene/3d/area_3d.h
+++ b/scene/3d/area_3d.h
@@ -49,7 +49,7 @@ public:
 private:
 	SpaceOverride gravity_space_override = SPACE_OVERRIDE_DISABLED;
 	Vector3 gravity_vec;
-	real_t gravity;
+	real_t gravity = 0.0;
 	bool gravity_is_point = false;
 	real_t gravity_distance_scale = 0.0;
 
@@ -228,4 +228,4 @@ public:
 
 VARIANT_ENUM_CAST(Area3D::SpaceOverride);
 
-#endif // AREA__H
+#endif // AREA_3D_H

--- a/scene/3d/cpu_particles_3d.h
+++ b/scene/3d/cpu_particles_3d.h
@@ -174,9 +174,9 @@ private:
 	Vector<Color> emission_colors;
 	int emission_point_count = 0;
 	Vector3 emission_ring_axis;
-	real_t emission_ring_height;
-	real_t emission_ring_radius;
-	real_t emission_ring_inner_radius;
+	real_t emission_ring_height = 0.0;
+	real_t emission_ring_radius = 0.0;
+	real_t emission_ring_inner_radius = 0.0;
 
 	Ref<Curve> scale_curve_x;
 	Ref<Curve> scale_curve_y;

--- a/scene/3d/gpu_particles_3d.h
+++ b/scene/3d/gpu_particles_3d.h
@@ -61,16 +61,16 @@ private:
 	RID particles;
 
 	bool one_shot;
-	int amount;
-	double lifetime;
-	double pre_process_time;
-	real_t explosiveness_ratio;
-	real_t randomness_ratio;
-	double speed_scale;
+	int amount = 0;
+	double lifetime = 0.0;
+	double pre_process_time = 0.0;
+	real_t explosiveness_ratio = 0.0;
+	real_t randomness_ratio = 0.0;
+	double speed_scale = 0.0;
 	AABB visibility_aabb;
-	bool local_coords;
-	int fixed_fps;
-	bool fractional_delta;
+	bool local_coords = false;
+	int fixed_fps = 0;
+	bool fractional_delta = false;
 	bool interpolate = true;
 	NodePath sub_emitter;
 	real_t collision_base_size = 0.01;

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -45,19 +45,19 @@ class NavigationAgent3D : public Node {
 	uint32_t navigable_layers = 1;
 
 	real_t target_desired_distance = 1.0;
-	real_t radius;
+	real_t radius = 0.0;
 	real_t navigation_height_offset = 0.0;
-	bool ignore_y;
-	real_t neighbor_dist;
-	int max_neighbors;
-	real_t time_horizon;
-	real_t max_speed;
+	bool ignore_y = false;
+	real_t neighbor_dist = 0.0;
+	int max_neighbors = 0;
+	real_t time_horizon = 0.0;
+	real_t max_speed = 0.0;
 
 	real_t path_max_distance = 3.0;
 
 	Vector3 target_location;
 	Vector<Vector3> navigation_path;
-	int nav_path_index;
+	int nav_path_index = 0;
 	bool velocity_submitted = false;
 	Vector3 prev_safe_velocity;
 	/// The submitted target velocity
@@ -65,7 +65,7 @@ class NavigationAgent3D : public Node {
 	bool target_reached = false;
 	bool navigation_finished = true;
 	// No initialized on purpose
-	uint32_t update_frame_id;
+	uint32_t update_frame_id = 0;
 
 protected:
 	static void _bind_methods();

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -137,7 +137,7 @@ private:
 
 	bool animate_physical_bones = true;
 	Vector<Bone> bones;
-	bool process_order_dirty;
+	bool process_order_dirty = false;
 
 	Vector<int> parentless_bones;
 

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -101,10 +101,10 @@ protected:
 	uint32_t mesh_surface_offsets[RS::ARRAY_MAX];
 	PackedByteArray vertex_buffer;
 	PackedByteArray attribute_buffer;
-	uint32_t vertex_stride;
-	uint32_t attrib_stride;
-	uint32_t skin_stride;
-	uint32_t mesh_surface_format;
+	uint32_t vertex_stride = 0;
+	uint32_t attrib_stride = 0;
+	uint32_t skin_stride = 0;
+	uint32_t mesh_surface_format = 0;
 
 	void _queue_update();
 

--- a/scene/3d/vehicle_body_3d.cpp
+++ b/scene/3d/vehicle_body_3d.cpp
@@ -40,7 +40,7 @@ public:
 	Vector3 m_0MinvJt;
 	Vector3 m_1MinvJt;
 	//Optimization: can be stored in the w/last component of one of the vectors
-	real_t m_Adiag;
+	real_t m_Adiag = 0.0;
 
 	real_t getDiagonal() const { return m_Adiag; }
 

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -125,7 +125,7 @@ private:
 	VScrollBar *v_scroll = nullptr;
 
 	float port_grab_distance_horizontal = 0.0;
-	float port_grab_distance_vertical;
+	float port_grab_distance_vertical = 0.0;
 
 	Ref<ViewPanner> panner;
 	bool warped_panning = true;
@@ -142,7 +142,7 @@ private:
 	bool connecting_target = false;
 	Vector2 connecting_to;
 	String connecting_target_to;
-	int connecting_target_index;
+	int connecting_target_index = 0;
 	bool just_disconnected = false;
 	bool connecting_valid = false;
 	Vector2 click_pos;
@@ -155,8 +155,9 @@ private:
 
 	float zoom = 1.0;
 	float zoom_step = 1.2;
-	float zoom_min;
-	float zoom_max;
+	// Proper values set in constructor.
+	float zoom_min = 0.0;
+	float zoom_max = 0.0;
 
 	void _zoom_minus();
 	void _zoom_reset();
@@ -206,7 +207,7 @@ private:
 
 	Array _get_connection_list() const;
 
-	bool lines_on_bg;
+	bool lines_on_bg = false;
 
 	struct ConnType {
 		union {

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -230,7 +230,6 @@ private:
 	Rect2 last_vp_rect;
 
 	bool transparent_bg = false;
-	bool filter;
 	bool gen_mipmaps = false;
 
 	bool snap_controls_to_pixels = true;

--- a/scene/resources/canvas_item_material.h
+++ b/scene/resources/canvas_item_material.h
@@ -107,10 +107,10 @@ private:
 	LightMode light_mode = LIGHT_MODE_NORMAL;
 	bool particles_animation = false;
 
-	// Initialized in the constructor.
-	int particles_anim_h_frames;
-	int particles_anim_v_frames;
-	bool particles_anim_loop;
+	// Proper values set in constructor.
+	int particles_anim_h_frames = 0;
+	int particles_anim_v_frames = 0;
+	bool particles_anim_loop = false;
 
 protected:
 	static void _bind_methods();

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -449,36 +449,36 @@ private:
 	bool orm;
 
 	Color albedo;
-	float specular;
-	float metallic;
-	float roughness;
+	float specular = 0.0f;
+	float metallic = 0.0f;
+	float roughness = 0.0f;
 	Color emission;
-	float emission_energy;
-	float normal_scale;
-	float rim;
-	float rim_tint;
-	float clearcoat;
-	float clearcoat_roughness;
-	float anisotropy;
-	float heightmap_scale;
-	float subsurface_scattering_strength;
-	float transmittance_amount;
+	float emission_energy = 0.0f;
+	float normal_scale = 0.0f;
+	float rim = 0.0f;
+	float rim_tint = 0.0f;
+	float clearcoat = 0.0f;
+	float clearcoat_roughness = 0.0f;
+	float anisotropy = 0.0f;
+	float heightmap_scale = 0.0f;
+	float subsurface_scattering_strength = 0.0f;
+	float transmittance_amount = 0.0f;
 	Color transmittance_color;
-	float transmittance_depth;
-	float transmittance_boost;
+	float transmittance_depth = 0.0f;
+	float transmittance_boost = 0.0f;
 
 	Color backlight;
-	float refraction;
-	float point_size;
-	float alpha_scissor_threshold;
-	float alpha_hash_scale;
-	float alpha_antialiasing_edge;
+	float refraction = 0.0f;
+	float point_size = 0.0f;
+	float alpha_scissor_threshold = 0.0f;
+	float alpha_hash_scale = 0.0f;
+	float alpha_antialiasing_edge = 0.0f;
 	bool grow_enabled = false;
-	float ao_light_affect;
-	float grow;
-	int particles_anim_h_frames;
-	int particles_anim_v_frames;
-	bool particles_anim_loop;
+	float ao_light_affect = 0.0f;
+	float grow = 0.0f;
+	int particles_anim_h_frames = 0;
+	int particles_anim_v_frames = 0;
+	bool particles_anim_loop = false;
 	Transparency transparency = TRANSPARENCY_DISABLED;
 	ShadingMode shading_mode = SHADING_MODE_PER_PIXEL;
 
@@ -486,29 +486,29 @@ private:
 
 	Vector3 uv1_scale;
 	Vector3 uv1_offset;
-	float uv1_triplanar_sharpness;
+	float uv1_triplanar_sharpness = 0.0f;
 
 	Vector3 uv2_scale;
 	Vector3 uv2_offset;
-	float uv2_triplanar_sharpness;
+	float uv2_triplanar_sharpness = 0.0f;
 
 	DetailUV detail_uv = DETAIL_UV_1;
 
 	bool deep_parallax = false;
-	int deep_parallax_min_layers;
-	int deep_parallax_max_layers;
+	int deep_parallax_min_layers = 0;
+	int deep_parallax_max_layers = 0;
 	bool heightmap_parallax_flip_tangent = false;
 	bool heightmap_parallax_flip_binormal = false;
 
 	bool proximity_fade_enabled = false;
-	float proximity_fade_distance;
+	float proximity_fade_distance = 0.0f;
 
 	float msdf_pixel_range = 4.f;
 	float msdf_outline_size = 0.f;
 
 	DistanceFadeMode distance_fade = DISTANCE_FADE_DISABLED;
-	float distance_fade_max_distance;
-	float distance_fade_min_distance;
+	float distance_fade_max_distance = 0.0f;
+	float distance_fade_min_distance = 0.0f;
 
 	BlendMode blend_mode = BLEND_MODE_MIX;
 	BlendMode detail_blend_mode = BLEND_MODE_MIX;

--- a/scene/resources/particles_material.h
+++ b/scene/resources/particles_material.h
@@ -230,8 +230,8 @@ private:
 
 	bool is_initialized = false;
 	Vector3 direction;
-	float spread;
-	float flatness;
+	float spread = 0.0f;
+	float flatness = 0.0f;
 
 	float params_min[PARAM_MAX];
 	float params_max[PARAM_MAX];
@@ -244,34 +244,34 @@ private:
 	bool particle_flags[PARTICLE_FLAG_MAX];
 
 	EmissionShape emission_shape;
-	float emission_sphere_radius;
+	float emission_sphere_radius = 0.0f;
 	Vector3 emission_box_extents;
 	Ref<Texture2D> emission_point_texture;
 	Ref<Texture2D> emission_normal_texture;
 	Ref<Texture2D> emission_color_texture;
 	Vector3 emission_ring_axis;
-	real_t emission_ring_height;
-	real_t emission_ring_radius;
-	real_t emission_ring_inner_radius;
+	real_t emission_ring_height = 0.0f;
+	real_t emission_ring_radius = 0.0f;
+	real_t emission_ring_inner_radius = 0.0f;
 	int emission_point_count = 1;
 
-	bool anim_loop;
+	bool anim_loop = false;
 
 	Vector3 gravity;
 
-	double lifetime_randomness;
+	double lifetime_randomness = 0.0;
 
 	SubEmitterMode sub_emitter_mode;
-	double sub_emitter_frequency;
-	int sub_emitter_amount_at_end;
-	bool sub_emitter_keep_velocity;
+	double sub_emitter_frequency = 0.0;
+	int sub_emitter_amount_at_end = 0;
+	bool sub_emitter_keep_velocity = false;
 	//do not save emission points here
 
-	bool attractor_interaction_enabled;
-	bool collision_enabled;
-	bool collision_scale;
-	float collision_friction;
-	float collision_bounce;
+	bool attractor_interaction_enabled = false;
+	bool collision_enabled = false;
+	bool collision_scale = false;
+	float collision_friction = 0.0f;
+	float collision_bounce = 0.0f;
 
 protected:
 	static void _bind_methods();

--- a/scene/resources/skeleton_modification_2d_physicalbones.h
+++ b/scene/resources/skeleton_modification_2d_physicalbones.h
@@ -52,7 +52,7 @@ private:
 
 	bool _simulation_state_dirty = false;
 	TypedArray<StringName> _simulation_state_dirty_names;
-	bool _simulation_state_dirty_process;
+	bool _simulation_state_dirty_process = false;
 	void _update_simulation_state();
 
 protected:

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -40,19 +40,19 @@ class ProceduralSkyMaterial : public Material {
 private:
 	Color sky_top_color;
 	Color sky_horizon_color;
-	float sky_curve;
-	float sky_energy;
+	float sky_curve = 0.0f;
+	float sky_energy = 0.0f;
 	Ref<Texture2D> sky_cover;
 	Color sky_cover_modulate;
 
 	Color ground_bottom_color;
 	Color ground_horizon_color;
-	float ground_curve;
-	float ground_energy;
+	float ground_curve = 0.0f;
+	float ground_energy = 0.0f;
 
-	float sun_angle_max;
-	float sun_curve;
-	float dither_strength;
+	float sun_angle_max = 0.0f;
+	float sun_curve = 0.0f;
+	float dither_strength = 0.0f;
 
 	static Mutex shader_mutex;
 	static RID shader;
@@ -158,16 +158,16 @@ private:
 	static Mutex shader_mutex;
 	static RID shader;
 
-	float rayleigh;
+	float rayleigh = 0.0f;
 	Color rayleigh_color;
-	float mie;
-	float mie_eccentricity;
+	float mie = 0.0f;
+	float mie_eccentricity = 0.0f;
 	Color mie_color;
-	float turbidity;
-	float sun_disk_scale;
+	float turbidity = 0.0f;
+	float sun_disk_scale = 0.0f;
 	Color ground_color;
-	float exposure;
-	float dither_strength;
+	float exposure = 0.0f;
+	float dither_strength = 0.0f;
 	Ref<Texture2D> night_sky;
 	static void _update_shader();
 	mutable bool shader_set = false;

--- a/scene/resources/sphere_shape_3d.h
+++ b/scene/resources/sphere_shape_3d.h
@@ -35,7 +35,7 @@
 
 class SphereShape3D : public Shape3D {
 	GDCLASS(SphereShape3D, Shape3D);
-	float radius;
+	float radius = 1.0f;
 
 protected:
 	static void _bind_methods();

--- a/servers/audio/audio_filter_sw.cpp
+++ b/servers/audio/audio_filter_sw.cpp
@@ -211,15 +211,6 @@ float AudioFilterSW::get_response(float p_freq, Coeffs *p_coeffs) {
 	return H;
 }
 
-AudioFilterSW::AudioFilterSW() {
-	sampling_rate = 44100;
-	resonance = 0.5;
-	cutoff = 5000;
-	gain = 1.0;
-	mode = LOWPASS;
-	stages = 1;
-}
-
 AudioFilterSW::Processor::Processor() {
 	set_filter(nullptr);
 }

--- a/servers/audio/audio_filter_sw.h
+++ b/servers/audio/audio_filter_sw.h
@@ -36,11 +36,11 @@
 class AudioFilterSW {
 public:
 	struct Coeffs {
-		float a1, a2;
-		float b0, b1, b2;
-
-		//bool operator==(const Coeffs &p_rv) { return (FLOATS_EQ(a1,p_rv.a1) && FLOATS_EQ(a2,p_rv.a2) && FLOATS_EQ(b1,p_rv.b1) && FLOATS_EQ(b2,p_rv.b2) && FLOATS_EQ(b0,p_rv.b0) ); }
-		Coeffs() { a1 = a2 = b0 = b1 = b2 = 0.0; }
+		float a1 = 0.0f;
+		float a2 = 0.0f;
+		float b0 = 0.0f;
+		float b1 = 0.0f;
+		float b2 = 0.0f;
 	};
 
 	enum Mode {
@@ -52,14 +52,16 @@ public:
 		BANDLIMIT,
 		LOWSHELF,
 		HIGHSHELF
-
 	};
 
-	class Processor { // simple filter processor
-
+	class Processor { // Simple filter processor.
 		AudioFilterSW *filter = nullptr;
 		Coeffs coeffs;
-		float ha1, ha2, hb1, hb2; //history
+		// History.
+		float ha1 = 0.0f;
+		float ha2 = 0.0f;
+		float hb1 = 0.0f;
+		float hb2 = 0.0f;
 		Coeffs incr_coeffs;
 
 	public:
@@ -73,12 +75,12 @@ public:
 	};
 
 private:
-	float cutoff;
-	float resonance;
-	float gain;
-	float sampling_rate;
-	int stages;
-	Mode mode;
+	float cutoff = 5000.0f;
+	float resonance = 0.5f;
+	float gain = 1.0f;
+	float sampling_rate = 44100.0f;
+	int stages = 1;
+	Mode mode = LOWPASS;
 
 public:
 	float get_response(float p_freq, Coeffs *p_coeffs);
@@ -92,7 +94,7 @@ public:
 
 	void prepare_coefficients(Coeffs *p_coeffs);
 
-	AudioFilterSW();
+	AudioFilterSW() {}
 };
 
 /* inline methods */

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -709,10 +709,7 @@ void AudioStreamRandomizer::_bind_methods() {
 	BIND_ENUM_CONSTANT(PLAYBACK_SEQUENTIAL);
 }
 
-AudioStreamRandomizer::AudioStreamRandomizer() {
-	random_pitch_scale = 1.1;
-	random_volume_offset_db = 5;
-}
+AudioStreamRandomizer::AudioStreamRandomizer() {}
 
 void AudioStreamPlaybackRandomizer::start(float p_from_pos) {
 	playing = playback;

--- a/servers/audio/audio_stream.h
+++ b/servers/audio/audio_stream.h
@@ -78,7 +78,7 @@ class AudioStreamPlaybackResampled : public AudioStreamPlayback {
 
 	AudioFrame internal_buffer[INTERNAL_BUFFER_LEN + CUBIC_INTERP_HISTORY];
 	unsigned int internal_buffer_end = -1;
-	uint64_t mix_offset;
+	uint64_t mix_offset = 0;
 
 protected:
 	void begin_resample();
@@ -145,8 +145,8 @@ class AudioStreamPlaybackMicrophone : public AudioStreamPlaybackResampled {
 	GDCLASS(AudioStreamPlaybackMicrophone, AudioStreamPlaybackResampled);
 	friend class AudioStreamMicrophone;
 
-	bool active;
-	unsigned int input_ofs;
+	bool active = false;
+	unsigned int input_ofs = 0;
 
 	Ref<AudioStreamMicrophone> microphone;
 
@@ -194,8 +194,8 @@ private:
 
 	Set<AudioStreamPlaybackRandomizer *> playbacks;
 	Vector<PoolEntry> audio_stream_pool;
-	float random_pitch_scale;
-	float random_volume_offset_db;
+	float random_pitch_scale = 1.1f;
+	float random_volume_offset_db = 5.0f;
 
 	Ref<AudioStreamPlayback> instance_playback_random();
 	Ref<AudioStreamPlayback> instance_playback_no_repeats();

--- a/servers/audio/effects/audio_effect_stereo_enhance.cpp
+++ b/servers/audio/effects/audio_effect_stereo_enhance.cpp
@@ -29,7 +29,9 @@
 /*************************************************************************/
 
 #include "audio_effect_stereo_enhance.h"
+
 #include "servers/audio_server.h"
+
 void AudioEffectStereoEnhanceInstance::process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) {
 	float intensity = base->pan_pullout;
 	bool surround_mode = base->surround > 0;
@@ -140,8 +142,4 @@ void AudioEffectStereoEnhance::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "surround", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_surround", "get_surround");
 }
 
-AudioEffectStereoEnhance::AudioEffectStereoEnhance() {
-	pan_pullout = 1;
-	time_pullout = 0;
-	surround = 0;
-}
+AudioEffectStereoEnhance::AudioEffectStereoEnhance() {}

--- a/servers/audio/effects/audio_effect_stereo_enhance.h
+++ b/servers/audio/effects/audio_effect_stereo_enhance.h
@@ -28,8 +28,8 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef AUDIOEFFECTSTEREOENHANCE_H
-#define AUDIOEFFECTSTEREOENHANCE_H
+#ifndef AUDIO_EFFECT_STEREO_ENHANCE_H
+#define AUDIO_EFFECT_STEREO_ENHANCE_H
 
 #include "servers/audio/audio_effect.h"
 
@@ -45,8 +45,8 @@ class AudioEffectStereoEnhanceInstance : public AudioEffectInstance {
 	};
 
 	float *delay_ringbuff = nullptr;
-	unsigned int ringbuff_pos;
-	unsigned int ringbuff_mask;
+	unsigned int ringbuff_pos = 0;
+	unsigned int ringbuff_mask = 0;
 
 public:
 	virtual void process(const AudioFrame *p_src_frames, AudioFrame *p_dst_frames, int p_frame_count) override;
@@ -58,11 +58,11 @@ class AudioEffectStereoEnhance : public AudioEffect {
 	GDCLASS(AudioEffectStereoEnhance, AudioEffect);
 
 	friend class AudioEffectStereoEnhanceInstance;
-	float volume_db;
+	float volume_db = 0.0f;
 
-	float pan_pullout;
-	float time_pullout;
-	float surround;
+	float pan_pullout = 1.0f;
+	float time_pullout = 0.0f;
+	float surround = 0.0f;
 
 protected:
 	static void _bind_methods();
@@ -82,4 +82,4 @@ public:
 	AudioEffectStereoEnhance();
 };
 
-#endif // AUDIOEFFECTSTEREOENHANCE_H
+#endif // AUDIO_EFFECT_STEREO_ENHANCE_H

--- a/servers/audio/effects/reverb.cpp
+++ b/servers/audio/effects/reverb.cpp
@@ -28,8 +28,6 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-// Author: Juan Linietsky <reduzio@gmail.com>, (C) 2006
-
 #include "reverb.h"
 
 #include "core/math/math_funcs.h"

--- a/servers/audio/effects/reverb.h
+++ b/servers/audio/effects/reverb.h
@@ -77,10 +77,11 @@ private:
 	AllPass allpass[MAX_ALLPASS];
 	float *input_buffer = nullptr;
 	float *echo_buffer = nullptr;
-	int echo_buffer_size;
-	int echo_buffer_pos;
+	int echo_buffer_size = 0;
+	int echo_buffer_pos = 0;
 
-	float hpf_h1, hpf_h2 = 0;
+	float hpf_h1 = 0.0f;
+	float hpf_h2 = 0.0f;
 
 	struct Parameters {
 		float room_size;

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -164,17 +164,6 @@ Array AudioDriver::capture_get_device_list() {
 	return list;
 }
 
-AudioDriver::AudioDriver() {
-	_last_mix_time = 0;
-	_last_mix_frames = 0;
-	input_position = 0;
-	input_size = 0;
-
-#ifdef DEBUG_ENABLED
-	prof_time = 0;
-#endif
-}
-
 AudioDriverDummy AudioDriverManager::dummy_driver;
 AudioDriver *AudioDriverManager::drivers[MAX_DRIVERS] = {
 	&AudioDriverManager::dummy_driver,
@@ -1748,15 +1737,6 @@ void AudioServer::_bind_methods() {
 
 AudioServer::AudioServer() {
 	singleton = this;
-	mix_frames = 0;
-	channel_count = 0;
-	to_mix = 0;
-#ifdef DEBUG_ENABLED
-	prof_time = 0;
-#endif
-	mix_time = 0;
-	mix_size = 0;
-	playback_speed_scale = 1;
 }
 
 AudioServer::~AudioServer() {

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -48,18 +48,18 @@ class AudioStreamPlayback;
 
 class AudioDriver {
 	static AudioDriver *singleton;
-	uint64_t _last_mix_time;
-	uint64_t _last_mix_frames;
+	uint64_t _last_mix_time = 0;
+	uint64_t _last_mix_frames = 0;
 
 #ifdef DEBUG_ENABLED
-	uint64_t prof_ticks;
-	uint64_t prof_time;
+	uint64_t prof_ticks = 0;
+	uint64_t prof_time = 0;
 #endif
 
 protected:
 	Vector<int32_t> input_buffer;
-	unsigned int input_position;
-	unsigned int input_size;
+	unsigned int input_position = 0;
+	unsigned int input_size = 0;
 
 	void audio_server_process(int p_frames, int32_t *p_buffer, bool p_update_mix_time = true);
 	void update_mix_time(int p_frames);
@@ -121,7 +121,7 @@ public:
 	void reset_profiling_time() { prof_time = 0; }
 #endif
 
-	AudioDriver();
+	AudioDriver() {}
 	virtual ~AudioDriver() {}
 };
 
@@ -169,66 +169,61 @@ public:
 	typedef void (*AudioCallback)(void *p_userdata);
 
 private:
-	uint64_t mix_time;
-	int mix_size;
+	uint64_t mix_time = 0;
+	int mix_size = 0;
 
-	uint32_t buffer_size;
-	uint64_t mix_count;
-	uint64_t mix_frames;
+	uint32_t buffer_size = 0;
+	uint64_t mix_count = 0;
+	uint64_t mix_frames = 0;
 #ifdef DEBUG_ENABLED
-	uint64_t prof_time;
+	uint64_t prof_time = 0;
 #endif
 
-	float channel_disable_threshold_db;
-	uint32_t channel_disable_frames;
+	float channel_disable_threshold_db = 0.0f;
+	uint32_t channel_disable_frames = 0;
 
-	int channel_count;
-	int to_mix;
+	int channel_count = 0;
+	int to_mix = 0;
 
-	float playback_speed_scale;
+	float playback_speed_scale = 1.0f;
 
 	struct Bus {
 		StringName name;
-		bool solo;
-		bool mute;
-		bool bypass;
+		bool solo = false;
+		bool mute = false;
+		bool bypass = false;
 
-		bool soloed;
+		bool soloed = false;
 
-		//Each channel is a stereo pair.
+		// Each channel is a stereo pair.
 		struct Channel {
-			bool used;
-			bool active;
-			AudioFrame peak_volume;
+			bool used = false;
+			bool active = false;
+			AudioFrame peak_volume = AudioFrame(AUDIO_MIN_PEAK_DB, AUDIO_MIN_PEAK_DB);
 			Vector<AudioFrame> buffer;
 			Vector<Ref<AudioEffectInstance>> effect_instances;
-			uint64_t last_mix_with_audio;
-			Channel() {
-				last_mix_with_audio = 0;
-				used = false;
-				active = false;
-				peak_volume = AudioFrame(AUDIO_MIN_PEAK_DB, AUDIO_MIN_PEAK_DB);
-			}
+			uint64_t last_mix_with_audio = 0;
+			Channel() {}
 		};
 
 		Vector<Channel> channels;
 
 		struct Effect {
 			Ref<AudioEffect> effect;
-			bool enabled;
+			bool enabled = false;
 #ifdef DEBUG_ENABLED
-			uint64_t prof_time;
+			uint64_t prof_time = 0;
 #endif
 		};
 
 		Vector<Effect> effects;
-		float volume_db;
+		float volume_db = 0.0f;
 		StringName send;
-		int index_cache;
+		int index_cache = 0;
 	};
 
 	struct AudioStreamPlaybackBusDetails {
-		bool bus_active[MAX_BUSES_PER_PLAYBACK] = { false, false, false, false, false, false };
+		bool bus_active[MAX_BUSES_PER_PLAYBACK] = {};
 		StringName bus[MAX_BUSES_PER_PLAYBACK];
 		AudioFrame volume[MAX_BUSES_PER_PLAYBACK][MAX_CHANNELS_PER_BUS];
 	};
@@ -312,7 +307,7 @@ public:
 		ERR_FAIL_V(1);
 	}
 
-	//do not use from outside audio thread
+	// Do not use from outside audio thread.
 	bool thread_has_channel_mix_buffer(int p_bus, int p_buffer) const;
 	AudioFrame *thread_get_channel_mix_buffer(int p_bus, int p_buffer);
 	int thread_get_mix_buffer_size() const;
@@ -442,26 +437,21 @@ class AudioBusLayout : public Resource {
 
 	struct Bus {
 		StringName name;
-		bool solo;
-		bool mute;
-		bool bypass;
+		bool solo = false;
+		bool mute = false;
+		bool bypass = false;
 
 		struct Effect {
 			Ref<AudioEffect> effect;
-			bool enabled;
+			bool enabled = false;
 		};
 
 		Vector<Effect> effects;
 
-		float volume_db;
+		float volume_db = 0.0f;
 		StringName send;
 
-		Bus() {
-			solo = false;
-			mute = false;
-			bypass = false;
-			volume_db = 0;
-		}
+		Bus() {}
 	};
 
 	Vector<Bus> buses;

--- a/servers/physics_2d/godot_collision_solver_2d.cpp
+++ b/servers/physics_2d/godot_collision_solver_2d.cpp
@@ -140,7 +140,7 @@ struct _ConcaveCollisionInfo2D {
 	Vector2 motion_B;
 	real_t margin_A = 0.0;
 	real_t margin_B = 0.0;
-	GodotCollisionSolver2D::CallbackResult result_callback;
+	GodotCollisionSolver2D::CallbackResult result_callback = nullptr;
 	void *userdata = nullptr;
 	bool swap_result = false;
 	bool collided = false;

--- a/servers/physics_2d/godot_collision_solver_2d_sat.cpp
+++ b/servers/physics_2d/godot_collision_solver_2d_sat.cpp
@@ -33,7 +33,7 @@
 #include "core/math/geometry_2d.h"
 
 struct _CollectorCallback2D {
-	GodotCollisionSolver2D::CallbackResult callback;
+	GodotCollisionSolver2D::CallbackResult callback = nullptr;
 	void *userdata = nullptr;
 	bool swap = false;
 	bool collided = false;

--- a/servers/physics_3d/gjk_epa.cpp
+++ b/servers/physics_3d/gjk_epa.cpp
@@ -113,7 +113,7 @@ struct	MinkowskiDiff {
 	real_t margin_A = 0.0;
 	real_t margin_B = 0.0;
 
-	Vector3 (*get_support)(const GodotShape3D*, const Vector3&, real_t);
+	Vector3 (*get_support)(const GodotShape3D*, const Vector3&, real_t) = nullptr;
 
 	void Initialize(const GodotShape3D* shape0, const Transform3D& wtrs0, const real_t margin0,
 		const GodotShape3D* shape1, const Transform3D& wtrs1, const real_t margin1) {
@@ -191,13 +191,13 @@ struct	GJK
 		/* Fields		*/
 		tShape			m_shape;
 		Vector3		m_ray;
-		real_t		m_distance;
+		real_t		m_distance = 0.0f;
 		sSimplex		m_simplices[2];
 		sSV				m_store[4];
 		sSV*			m_free[4];
-		U				m_nfree;
-		U				m_current;
-		sSimplex*		m_simplex;
+		U				m_nfree = 0;
+		U				m_current = 0;
+		sSimplex*		m_simplex = nullptr;
 		eStatus::_		m_status;
 		/* Methods		*/
 		GJK()
@@ -548,12 +548,12 @@ struct	GJK
 		struct	sFace
 		{
 			Vector3	n;
-			real_t	d;
+			real_t	d = 0.0f;
 			sSV*		c[3];
 			sFace*		f[3];
 			sFace*		l[2];
 			U1			e[3];
-			U1			pass;
+			U1			pass = 0;
 		};
 		struct	sList
 		{
@@ -583,10 +583,10 @@ struct	GJK
 			eStatus::_		m_status;
 			GJK::sSimplex	m_result;
 			Vector3		m_normal;
-			real_t		m_depth;
+			real_t		m_depth = 0.0f;
 			sSV				m_sv_store[EPA_MAX_VERTICES];
 			sFace			m_fc_store[EPA_MAX_FACES];
-			U				m_nextsv;
+			U				m_nextsv = 0;
 			sList			m_hull;
 			sList			m_stock;
 			/* Methods		*/

--- a/servers/physics_3d/godot_collision_solver_3d.cpp
+++ b/servers/physics_3d/godot_collision_solver_3d.cpp
@@ -29,6 +29,7 @@
 /*************************************************************************/
 
 #include "godot_collision_solver_3d.h"
+
 #include "godot_collision_solver_3d_sat.h"
 #include "godot_soft_body_3d.h"
 
@@ -276,19 +277,20 @@ bool GodotCollisionSolver3D::solve_soft_body(const GodotShape3D *p_shape_A, cons
 }
 
 struct _ConcaveCollisionInfo {
-	const Transform3D *transform_A;
-	const GodotShape3D *shape_A;
-	const Transform3D *transform_B;
-	GodotCollisionSolver3D::CallbackResult result_callback;
-	void *userdata;
-	bool swap_result;
-	bool collided;
-	int aabb_tests;
-	int collisions;
-	bool tested;
-	real_t margin_A;
-	real_t margin_B;
-	Vector3 close_A, close_B;
+	const Transform3D *transform_A = nullptr;
+	const GodotShape3D *shape_A = nullptr;
+	const Transform3D *transform_B = nullptr;
+	GodotCollisionSolver3D::CallbackResult result_callback = nullptr;
+	void *userdata = nullptr;
+	bool swap_result = false;
+	bool collided = false;
+	int aabb_tests = 0;
+	int collisions = 0;
+	bool tested = false;
+	real_t margin_A = 0.0f;
+	real_t margin_B = 0.0f;
+	Vector3 close_A;
+	Vector3 close_B;
 };
 
 bool GodotCollisionSolver3D::concave_callback(void *p_userdata, GodotShape3D *p_convex) {

--- a/servers/physics_3d/godot_collision_solver_3d_sat.cpp
+++ b/servers/physics_3d/godot_collision_solver_3d_sat.cpp
@@ -68,7 +68,7 @@
  *************************************************************************/
 
 struct _CollectorCallback {
-	GodotCollisionSolver3D::CallbackResult callback;
+	GodotCollisionSolver3D::CallbackResult callback = nullptr;
 	void *userdata = nullptr;
 	bool swap = false;
 	bool collided = false;

--- a/servers/physics_3d/godot_shape_3d.cpp
+++ b/servers/physics_3d/godot_shape_3d.cpp
@@ -1438,7 +1438,7 @@ Vector3 GodotConcavePolygonShape3D::get_moment_of_inertia(real_t p_mass) const {
 struct _Volume_BVH_Element {
 	AABB aabb;
 	Vector3 center;
-	int face_index;
+	int face_index = 0;
 };
 
 struct _Volume_BVH_CompareX {
@@ -1461,10 +1461,10 @@ struct _Volume_BVH_CompareZ {
 
 struct _Volume_BVH {
 	AABB aabb;
-	_Volume_BVH *left;
-	_Volume_BVH *right;
+	_Volume_BVH *left = nullptr;
+	_Volume_BVH *right = nullptr;
 
-	int face_index;
+	int face_index = 0;
 };
 
 _Volume_BVH *_volume_build_bvh(_Volume_BVH_Element *p_elements, int p_size, int &count) {

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -452,8 +452,6 @@ RS::ShaderNativeSourceCode SceneShaderForwardClustered::ShaderData::get_native_s
 
 SceneShaderForwardClustered::ShaderData::ShaderData() :
 		shader_list_element(this) {
-	valid = false;
-	uses_screen_texture = false;
 }
 
 SceneShaderForwardClustered::ShaderData::~ShaderData() {

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.h
@@ -130,9 +130,9 @@ public:
 			ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE_AND_TO_ONE
 		};
 
-		bool valid;
+		bool valid = false;
 		RID version;
-		uint32_t vertex_input_mask;
+		uint32_t vertex_input_mask = 0;
 		PipelineCacheRD pipelines[CULL_VARIANT_MAX][RS::PRIMITIVE_MAX][PIPELINE_VERSION_MAX];
 		PipelineCacheRD color_pipelines[CULL_VARIANT_MAX][RS::PRIMITIVE_MAX][PIPELINE_COLOR_PASS_FLAG_COUNT];
 
@@ -142,7 +142,7 @@ public:
 		Vector<ShaderCompiler::GeneratedCode::Texture> texture_uniforms;
 
 		Vector<uint32_t> ubo_offsets;
-		uint32_t ubo_size;
+		uint32_t ubo_size = 0;
 
 		String code;
 		Map<StringName, Map<int, RID>> default_texture_params;
@@ -150,28 +150,28 @@ public:
 		DepthDraw depth_draw;
 		DepthTest depth_test;
 
-		bool uses_point_size;
-		bool uses_alpha;
-		bool uses_blend_alpha;
-		bool uses_alpha_clip;
-		bool uses_depth_pre_pass;
-		bool uses_discard;
-		bool uses_roughness;
-		bool uses_normal;
-		bool uses_particle_trails;
+		bool uses_point_size = false;
+		bool uses_alpha = false;
+		bool uses_blend_alpha = false;
+		bool uses_alpha_clip = false;
+		bool uses_depth_pre_pass = false;
+		bool uses_discard = false;
+		bool uses_roughness = false;
+		bool uses_normal = false;
+		bool uses_particle_trails = false;
 
-		bool unshaded;
-		bool uses_vertex;
-		bool uses_position;
-		bool uses_sss;
-		bool uses_transmittance;
-		bool uses_screen_texture;
-		bool uses_depth_texture;
-		bool uses_normal_texture;
-		bool uses_time;
-		bool writes_modelview_or_projection;
-		bool uses_world_coordinates;
-		Cull cull_mode;
+		bool unshaded = false;
+		bool uses_vertex = false;
+		bool uses_position = false;
+		bool uses_sss = false;
+		bool uses_transmittance = false;
+		bool uses_screen_texture = false;
+		bool uses_depth_texture = false;
+		bool uses_normal_texture = false;
+		bool uses_time = false;
+		bool writes_modelview_or_projection = false;
+		bool uses_world_coordinates = false;
+		Cull cull_mode = CULL_DISABLED;
 
 		uint64_t last_pass = 0;
 		uint32_t index = 0;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -415,8 +415,6 @@ RS::ShaderNativeSourceCode SceneShaderForwardMobile::ShaderData::get_native_sour
 
 SceneShaderForwardMobile::ShaderData::ShaderData() :
 		shader_list_element(this) {
-	valid = false;
-	uses_screen_texture = false;
 }
 
 SceneShaderForwardMobile::ShaderData::~ShaderData() {

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.h
@@ -97,9 +97,9 @@ public:
 			ALPHA_ANTIALIASING_ALPHA_TO_COVERAGE_AND_TO_ONE
 		};
 
-		bool valid;
+		bool valid = false;
 		RID version;
-		uint32_t vertex_input_mask;
+		uint32_t vertex_input_mask = 0;
 		PipelineCacheRD pipelines[CULL_VARIANT_MAX][RS::PRIMITIVE_MAX][SHADER_VERSION_MAX];
 
 		String path;
@@ -108,7 +108,7 @@ public:
 		Vector<ShaderCompiler::GeneratedCode::Texture> texture_uniforms;
 
 		Vector<uint32_t> ubo_offsets;
-		uint32_t ubo_size;
+		uint32_t ubo_size = 0;
 
 		String code;
 		Map<StringName, Map<int, RID>> default_texture_params;
@@ -116,26 +116,26 @@ public:
 		DepthDraw depth_draw;
 		DepthTest depth_test;
 
-		bool uses_point_size;
-		bool uses_alpha;
-		bool uses_blend_alpha;
-		bool uses_alpha_clip;
-		bool uses_depth_pre_pass;
-		bool uses_discard;
-		bool uses_roughness;
-		bool uses_normal;
-		bool uses_particle_trails;
+		bool uses_point_size = false;
+		bool uses_alpha = false;
+		bool uses_blend_alpha = false;
+		bool uses_alpha_clip = false;
+		bool uses_depth_pre_pass = false;
+		bool uses_discard = false;
+		bool uses_roughness = false;
+		bool uses_normal = false;
+		bool uses_particle_trails = false;
 
-		bool unshaded;
-		bool uses_vertex;
-		bool uses_sss;
-		bool uses_transmittance;
-		bool uses_screen_texture;
-		bool uses_depth_texture;
-		bool uses_normal_texture;
-		bool uses_time;
-		bool writes_modelview_or_projection;
-		bool uses_world_coordinates;
+		bool unshaded = false;
+		bool uses_vertex = false;
+		bool uses_sss = false;
+		bool uses_transmittance = false;
+		bool uses_screen_texture = false;
+		bool uses_depth_texture = false;
+		bool uses_normal_texture = false;
+		bool uses_time = false;
+		bool writes_modelview_or_projection = false;
+		bool uses_world_coordinates = false;
 
 		uint64_t last_pass = 0;
 		uint32_t index = 0;

--- a/servers/rendering/renderer_rd/pipeline_cache_rd.h
+++ b/servers/rendering/renderer_rd/pipeline_cache_rd.h
@@ -45,7 +45,7 @@ class PipelineCacheRD {
 	RD::PipelineMultisampleState multisample_state;
 	RD::PipelineDepthStencilState depth_stencil_state;
 	RD::PipelineColorBlendState blend_state;
-	int dynamic_state_flags;
+	int dynamic_state_flags = 0;
 	Vector<RD::PipelineSpecializationConstant> base_specialization_constants;
 
 	struct Version {

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.cpp
@@ -2232,12 +2232,6 @@ RS::ShaderNativeSourceCode RendererCanvasRenderRD::CanvasShaderData::get_native_
 	return canvas_singleton->shader.canvas_shader.version_get_native_source_code(version);
 }
 
-RendererCanvasRenderRD::CanvasShaderData::CanvasShaderData() {
-	valid = false;
-	uses_screen_texture = false;
-	uses_sdf = false;
-}
-
 RendererCanvasRenderRD::CanvasShaderData::~CanvasShaderData() {
 	RendererCanvasRenderRD *canvas_singleton = static_cast<RendererCanvasRenderRD *>(RendererCanvasRender::singleton);
 	ERR_FAIL_COND(!canvas_singleton);

--- a/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_canvas_render_rd.h
@@ -161,7 +161,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 			BLEND_MODE_DISABLED,
 		};
 
-		bool valid;
+		bool valid = false;
 		RID version;
 		PipelineVariants pipeline_variants;
 		String path;
@@ -170,7 +170,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		Vector<ShaderCompiler::GeneratedCode::Texture> texture_uniforms;
 
 		Vector<uint32_t> ubo_offsets;
-		uint32_t ubo_size;
+		uint32_t ubo_size = 0;
 
 		String code;
 		Map<StringName, Map<int, RID>> default_texture_params;
@@ -190,7 +190,7 @@ class RendererCanvasRenderRD : public RendererCanvasRender {
 		virtual Variant get_default_parameter(const StringName &p_parameter) const;
 		virtual RS::ShaderNativeSourceCode get_native_source_code() const;
 
-		CanvasShaderData();
+		CanvasShaderData() {}
 		virtual ~CanvasShaderData();
 	};
 

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.cpp
@@ -286,7 +286,6 @@ RendererCompositorRD::RendererCompositorRD() {
 	}
 
 	singleton = this;
-	time = 0;
 
 	texture_storage = memnew(RendererRD::TextureStorage);
 	material_storage = memnew(RendererRD::MaterialStorage);

--- a/servers/rendering/renderer_rd/renderer_compositor_rd.h
+++ b/servers/rendering/renderer_rd/renderer_compositor_rd.h
@@ -50,11 +50,11 @@ class RendererCompositorRD : public RendererCompositor {
 protected:
 	UniformSetCacheRD *uniform_set_cache = nullptr;
 	RendererCanvasRenderRD *canvas = nullptr;
-	RendererRD::LightStorage *light_storage;
-	RendererRD::MaterialStorage *material_storage;
-	RendererRD::MeshStorage *mesh_storage;
-	RendererRD::ParticlesStorage *particles_storage;
-	RendererRD::TextureStorage *texture_storage;
+	RendererRD::LightStorage *light_storage = nullptr;
+	RendererRD::MaterialStorage *material_storage = nullptr;
+	RendererRD::MeshStorage *mesh_storage = nullptr;
+	RendererRD::ParticlesStorage *particles_storage = nullptr;
+	RendererRD::TextureStorage *texture_storage = nullptr;
 	RendererStorageRD *storage = nullptr;
 	RendererSceneRenderRD *scene = nullptr;
 
@@ -92,8 +92,8 @@ protected:
 
 	Map<RID, RID> render_target_descriptors;
 
-	double time;
-	double delta;
+	double time = 0.0;
+	double delta = 0.0;
 
 	static uint64_t frame;
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -3976,10 +3976,6 @@ RS::ShaderNativeSourceCode RendererSceneRenderRD::FogShaderData::get_native_sour
 	return scene_singleton->volumetric_fog.shader.version_get_native_source_code(version);
 }
 
-RendererSceneRenderRD::FogShaderData::FogShaderData() {
-	valid = false;
-}
-
 RendererSceneRenderRD::FogShaderData::~FogShaderData() {
 	RendererSceneRenderRD *scene_singleton = static_cast<RendererSceneRenderRD *>(RendererSceneRenderRD::singleton);
 	ERR_FAIL_COND(!scene_singleton);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -47,10 +47,10 @@
 #include "servers/rendering/rendering_device.h"
 
 struct RenderDataRD {
-	RID render_buffers = RID();
+	RID render_buffers;
 
-	Transform3D cam_transform = Transform3D();
-	CameraMatrix cam_projection = CameraMatrix();
+	Transform3D cam_transform;
+	CameraMatrix cam_projection;
 	bool cam_orthogonal = false;
 
 	// For stereo rendering
@@ -67,18 +67,18 @@ struct RenderDataRD {
 	const PagedArray<RID> *decals = nullptr;
 	const PagedArray<RID> *lightmaps = nullptr;
 	const PagedArray<RID> *fog_volumes = nullptr;
-	RID environment = RID();
-	RID camera_effects = RID();
-	RID shadow_atlas = RID();
-	RID reflection_atlas = RID();
-	RID reflection_probe = RID();
+	RID environment;
+	RID camera_effects;
+	RID shadow_atlas;
+	RID reflection_atlas;
+	RID reflection_probe;
 	int reflection_probe_pass = 0;
 
 	float lod_distance_multiplier = 0.0;
-	Plane lod_camera_plane = Plane();
+	Plane lod_camera_plane;
 	float screen_mesh_lod_threshold = 0.0;
 
-	RID cluster_buffer = RID();
+	RID cluster_buffer;
 	uint32_t cluster_size = 0;
 	uint32_t cluster_max_elements = 0;
 
@@ -95,8 +95,8 @@ class RendererSceneRenderRD : public RendererSceneRender {
 protected:
 	RendererStorageRD *storage = nullptr;
 	RendererRD::ToneMapper *tone_mapper = nullptr;
-	double time;
-	double time_step = 0;
+	double time = 0.0;
+	double time_step = 0.0;
 
 	struct RenderBufferData {
 		virtual void configure(RID p_color_buffer, RID p_depth_buffer, RID p_target_buffer, int p_width, int p_height, RS::ViewportMSAA p_msaa, uint32_t p_view_count) = 0;
@@ -236,7 +236,7 @@ private:
 	struct DecalInstance {
 		RID decal;
 		Transform3D transform;
-		uint32_t cull_mask;
+		uint32_t cull_mask = 0;
 		ForwardID forward_id = -1;
 	};
 
@@ -256,7 +256,7 @@ private:
 	struct ShadowShrinkStage {
 		RID texture;
 		RID filter_texture;
-		uint32_t size;
+		uint32_t size = 0;
 	};
 
 	struct ShadowAtlas {
@@ -268,27 +268,20 @@ private:
 		};
 
 		struct Quadrant {
-			uint32_t subdivision;
+			uint32_t subdivision = 0;
 
 			struct Shadow {
 				RID owner;
-				uint64_t version;
-				uint64_t fog_version; // used for fog
-				uint64_t alloc_tick;
+				uint64_t version = 0;
+				uint64_t fog_version = 0; // used for fog
+				uint64_t alloc_tick = 0;
 
-				Shadow() {
-					version = 0;
-					fog_version = 0;
-					alloc_tick = 0;
-				}
+				Shadow() {}
 			};
 
 			Vector<Shadow> shadows;
 
-			Quadrant() {
-				subdivision = 0; //not in use
-			}
-
+			Quadrant() {}
 		} quadrants[4];
 
 		int size_order[4] = { 0, 1, 2, 3 };
@@ -337,7 +330,6 @@ private:
 		int size = 0;
 		bool use_16_bits = true;
 		int current_light = 0;
-
 	} directional_shadow;
 
 	void _update_directional_shadow_atlas();
@@ -910,7 +902,7 @@ private:
 	void _update_volumetric_fog(RID p_render_buffers, RID p_environment, const CameraMatrix &p_cam_projection, const Transform3D &p_cam_transform, RID p_shadow_atlas, int p_directional_light_count, bool p_use_directional_shadows, int p_positional_light_count, int p_voxel_gi_count, const PagedArray<RID> &p_fog_volumes);
 
 	struct FogShaderData : public RendererRD::ShaderData {
-		bool valid;
+		bool valid = false;
 		RID version;
 
 		RID pipeline;
@@ -918,13 +910,13 @@ private:
 		Vector<ShaderCompiler::GeneratedCode::Texture> texture_uniforms;
 
 		Vector<uint32_t> ubo_offsets;
-		uint32_t ubo_size;
+		uint32_t ubo_size = 0;
 
 		String path;
 		String code;
 		Map<StringName, Map<int, RID>> default_texture_params;
 
-		bool uses_time;
+		bool uses_time = false;
 
 		virtual void set_code(const String &p_Code);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index);
@@ -935,7 +927,8 @@ private:
 		virtual bool casts_shadows() const;
 		virtual Variant get_default_parameter(const StringName &p_parameter) const;
 		virtual RS::ShaderNativeSourceCode get_native_source_code() const;
-		FogShaderData();
+
+		FogShaderData() {}
 		virtual ~FogShaderData();
 	};
 

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
@@ -224,10 +224,6 @@ RS::ShaderNativeSourceCode RendererSceneSkyRD::SkyShaderData::get_native_source_
 	return scene_singleton->sky.sky_shader.shader.version_get_native_source_code(version);
 }
 
-RendererSceneSkyRD::SkyShaderData::SkyShaderData() {
-	valid = false;
-}
-
 RendererSceneSkyRD::SkyShaderData::~SkyShaderData() {
 	RendererSceneRenderRD *scene_singleton = static_cast<RendererSceneRenderRD *>(RendererSceneRenderRD::singleton);
 	ERR_FAIL_COND(!scene_singleton);

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.h
@@ -106,7 +106,7 @@ private:
 	};
 
 	struct SkyShaderData : public RendererRD::ShaderData {
-		bool valid;
+		bool valid = false;
 		RID version;
 
 		PipelineCacheRD pipelines[SKY_VERSION_MAX];
@@ -114,17 +114,17 @@ private:
 		Vector<ShaderCompiler::GeneratedCode::Texture> texture_uniforms;
 
 		Vector<uint32_t> ubo_offsets;
-		uint32_t ubo_size;
+		uint32_t ubo_size = 0;
 
 		String path;
 		String code;
 		Map<StringName, Map<int, RID>> default_texture_params;
 
-		bool uses_time;
-		bool uses_position;
-		bool uses_half_res;
-		bool uses_quarter_res;
-		bool uses_light;
+		bool uses_time = false;
+		bool uses_position = false;
+		bool uses_half_res = false;
+		bool uses_quarter_res = false;
+		bool uses_light = false;
 
 		virtual void set_code(const String &p_Code);
 		virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index);
@@ -135,7 +135,8 @@ private:
 		virtual bool casts_shadows() const;
 		virtual Variant get_default_parameter(const StringName &p_parameter) const;
 		virtual RS::ShaderNativeSourceCode get_native_source_code() const;
-		SkyShaderData();
+
+		SkyShaderData() {}
 		virtual ~SkyShaderData();
 	};
 

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.cpp
@@ -1664,10 +1664,6 @@ RS::ShaderNativeSourceCode ParticlesStorage::ParticlesShaderData::get_native_sou
 	return ParticlesStorage::get_singleton()->particles_shader.shader.version_get_native_source_code(version);
 }
 
-ParticlesStorage::ParticlesShaderData::ParticlesShaderData() {
-	valid = false;
-}
-
 ParticlesStorage::ParticlesShaderData::~ParticlesShaderData() {
 	//pipeline variants will clear themselves if shader is gone
 	if (version.is_valid()) {

--- a/servers/rendering/renderer_rd/storage_rd/particles_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/particles_storage.h
@@ -341,16 +341,15 @@ private:
 	/* Particle Shader */
 
 	struct ParticlesShaderData : public ShaderData {
-		bool valid;
+		bool valid = false;
 		RID version;
 		bool uses_collision = false;
 
-		//PipelineCacheRD pipelines[SKY_VERSION_MAX];
 		Map<StringName, ShaderLanguage::ShaderNode::Uniform> uniforms;
 		Vector<ShaderCompiler::GeneratedCode::Texture> texture_uniforms;
 
 		Vector<uint32_t> ubo_offsets;
-		uint32_t ubo_size;
+		uint32_t ubo_size = 0;
 
 		String path;
 		String code;
@@ -373,7 +372,7 @@ private:
 		virtual Variant get_default_parameter(const StringName &p_parameter) const;
 		virtual RS::ShaderNativeSourceCode get_native_source_code() const;
 
-		ParticlesShaderData();
+		ParticlesShaderData() {}
 		virtual ~ParticlesShaderData();
 	};
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -921,7 +921,7 @@ public:
 
 	RID_Owner<Instance, true> instance_owner;
 
-	uint32_t geometry_instance_pair_mask; // used in traditional forward, unnecessary on clustered
+	uint32_t geometry_instance_pair_mask = 0; // used in traditional forward, unnecessary on clustered
 
 	virtual RID instance_allocate();
 	virtual void instance_initialize(RID p_rid);

--- a/servers/rendering/shader_compiler.h
+++ b/servers/rendering/shader_compiler.h
@@ -106,8 +106,8 @@ private:
 	void _dump_function_deps(const ShaderLanguage::ShaderNode *p_node, const StringName &p_for_func, const Map<StringName, String> &p_func_code, String &r_to_add, Set<StringName> &added);
 	String _dump_node_code(const ShaderLanguage::Node *p_node, int p_level, GeneratedCode &r_gen_code, IdentifierActions &p_actions, const DefaultIdentifierActions &p_default_actions, bool p_assigning, bool p_scope = true);
 
-	const ShaderLanguage::ShaderNode *shader;
-	const ShaderLanguage::FunctionNode *function;
+	const ShaderLanguage::ShaderNode *shader = nullptr;
+	const ShaderLanguage::FunctionNode *function = nullptr;
 	StringName current_func_name;
 	StringName time_name;
 	Set<StringName> texture_functions;

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -874,11 +874,11 @@ private:
 
 	static const KeyWord keyword_list[];
 
-	GlobalVariableGetTypeFunc global_var_get_type_func;
+	GlobalVariableGetTypeFunc global_var_get_type_func = nullptr;
 
-	bool error_set;
+	bool error_set = false;
 	String error_str;
-	int error_line;
+	int error_line = 0;
 
 #ifdef DEBUG_ENABLED
 	struct Usage {
@@ -902,7 +902,7 @@ private:
 	List<ShaderWarning> warnings;
 
 	bool check_warnings = false;
-	uint32_t warning_flags;
+	uint32_t warning_flags = 0;
 
 	void _add_line_warning(ShaderWarning::Code p_code, const StringName &p_subject = "", const Vector<Variant> &p_extra_args = Vector<Variant>()) {
 		warnings.push_back(ShaderWarning(p_code, tk_line, p_subject, p_extra_args));
@@ -917,8 +917,8 @@ private:
 #endif // DEBUG_ENABLED
 
 	String code;
-	int char_idx;
-	int tk_line;
+	int char_idx = 0;
+	int tk_line = 0;
 
 	StringName current_function;
 	bool last_const = false;
@@ -1020,14 +1020,14 @@ private:
 	};
 
 	CompletionType completion_type;
-	int completion_line;
+	int completion_line = 0;
 	BlockNode *completion_block = nullptr;
 	DataType completion_base;
-	bool completion_base_array;
+	bool completion_base_array = false;
 	SubClassTag completion_class;
 	StringName completion_function;
 	StringName completion_struct;
-	int completion_argument;
+	int completion_argument = 0;
 
 	const Map<StringName, FunctionInfo> *stages = nullptr;
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -47,7 +47,7 @@ class RenderingServer : public Object {
 
 	static RenderingServer *singleton;
 
-	int mm_policy;
+	int mm_policy = 0;
 	bool render_loop_enabled = true;
 
 	Array _get_array_from_surface(uint32_t p_format, Vector<uint8_t> p_vertex_data, Vector<uint8_t> p_attrib_data, Vector<uint8_t> p_skin_data, int p_vertex_len, Vector<uint8_t> p_index_data, int p_index_len) const;


### PR DESCRIPTION
Didn't commit all the changes where it wants to initialize a struct
with `{}`. Should be reviewed in a separate PR.

Option `IgnoreArrays` enabled for now to be conservative, can be
disabled to see if it proposes more useful changes.

Also fixed manually a handful of other missing initializations / moved
some from constructors.
(The `clang-tidy` check only handles the members which did *not* have an explicit initialization in the constructor.)