### PR TITLE
Fix DynamicBVH crash after #59867

### DIFF
--- a/core/math/dynamic_bvh.h
+++ b/core/math/dynamic_bvh.h
@@ -183,7 +183,7 @@ private:
 		Node *parent = nullptr;
 		union {
 			Node *childs[2];
-			void *data = nullptr;
+			void *data;
 		};
 
 		_FORCE_INLINE_ bool is_leaf() const { return childs[1] == nullptr; }
@@ -215,7 +215,10 @@ private:
 			return axis.dot(volume.get_center() - org) <= 0;
 		}
 
-		Node() {}
+		Node() {
+			childs[0] = nullptr;
+			childs[1] = nullptr;
+		}
 	};
 
 	PagedAllocator<Node> node_allocator;


### PR DESCRIPTION
I made a wrong assumption that initialization the other pointer in the
union would properly initialize the `childs` array.

Fixup to #59867.