### PR TITLE
Fix a possible race condition on popup close, that might cause multiple deletions of the same list item.

### DIFF
--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -3208,19 +3208,23 @@ Rect2i DisplayServerX11::window_get_popup_safe_rect(WindowID p_window) const {
 }
 
 void DisplayServerX11::popup_open(WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
 	WindowData &wd = windows[p_window];
 	if (wd.is_popup) {
-		// Close all popups, up to current popup parent, or every popup if new window is not transient.
+		// Find current popup parent, or root popup if new window is not transient.
+		List<WindowID>::Element *C = nullptr;
 		List<WindowID>::Element *E = popup_list.back();
 		while (E) {
 			if (wd.transient_parent != E->get() || wd.transient_parent == INVALID_WINDOW_ID) {
-				_send_window_event(windows[E->get()], DisplayServerX11::WINDOW_EVENT_CLOSE_REQUEST);
-				List<WindowID>::Element *F = E->prev();
-				popup_list.erase(E);
-				E = F;
+				C = E;
+				E = E->prev();
 			} else {
 				break;
 			}
+		}
+		if (C) {
+			_send_window_event(windows[C->get()], DisplayServerX11::WINDOW_EVENT_CLOSE_REQUEST);
 		}
 
 		time_since_popup = OS::get_singleton()->get_ticks_msec();
@@ -3229,16 +3233,22 @@ void DisplayServerX11::popup_open(WindowID p_window) {
 }
 
 void DisplayServerX11::popup_close(WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
 	List<WindowID>::Element *E = popup_list.find(p_window);
 	while (E) {
-		_send_window_event(windows[E->get()], DisplayServerX11::WINDOW_EVENT_CLOSE_REQUEST);
 		List<WindowID>::Element *F = E->next();
+		WindowID win_id = E->get();
 		popup_list.erase(E);
+
+		_send_window_event(windows[win_id], DisplayServerX11::WINDOW_EVENT_CLOSE_REQUEST);
 		E = F;
 	}
 }
 
 void DisplayServerX11::mouse_process_popups() {
+	_THREAD_SAFE_METHOD_
+
 	if (popup_list.is_empty()) {
 		return;
 	}
@@ -3259,7 +3269,9 @@ void DisplayServerX11::mouse_process_popups() {
 			Vector2i pos = Vector2i(root_attrs.x + root_x, root_attrs.y + root_y);
 			if ((pos != last_mouse_monitor_pos) || (mask != last_mouse_monitor_mask)) {
 				if (((mask & Button1Mask) || (mask & Button2Mask) || (mask & Button3Mask) || (mask & Button4Mask) || (mask & Button5Mask))) {
+					List<WindowID>::Element *C = nullptr;
 					List<WindowID>::Element *E = popup_list.back();
+					// Find top popup to close.
 					while (E) {
 						// Popup window area.
 						Rect2i win_rect = Rect2i(window_get_position(E->get()), window_get_size(E->get()));
@@ -3270,11 +3282,12 @@ void DisplayServerX11::mouse_process_popups() {
 						} else if (safe_rect != Rect2i() && safe_rect.has_point(pos)) {
 							break;
 						} else {
-							_send_window_event(windows[E->get()], DisplayServerX11::WINDOW_EVENT_CLOSE_REQUEST);
-							List<WindowID>::Element *F = E->prev();
-							popup_list.erase(E);
-							E = F;
+							C = E;
+							E = E->prev();
 						}
+					}
+					if (C) {
+						_send_window_event(windows[C->get()], DisplayServerX11::WINDOW_EVENT_CLOSE_REQUEST);
 					}
 				}
 			}

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -3000,20 +3000,24 @@ Rect2i DisplayServerOSX::window_get_popup_safe_rect(WindowID p_window) const {
 }
 
 void DisplayServerOSX::popup_open(WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
 	WindowData &wd = windows[p_window];
 	if (wd.is_popup) {
 		bool was_empty = popup_list.is_empty();
-		// Close all popups, up to current popup parent, or every popup if new window is not transient.
+		// Find current popup parent, or root popup if new window is not transient.
+		List<WindowID>::Element *C = nullptr;
 		List<WindowID>::Element *E = popup_list.back();
 		while (E) {
 			if (wd.transient_parent != E->get() || wd.transient_parent == INVALID_WINDOW_ID) {
-				send_window_event(windows[E->get()], DisplayServerOSX::WINDOW_EVENT_CLOSE_REQUEST);
-				List<WindowID>::Element *F = E->prev();
-				popup_list.erase(E);
-				E = F;
+				C = E;
+				E = E->prev();
 			} else {
 				break;
 			}
+		}
+		if (C) {
+			send_window_event(windows[C->get()], DisplayServerOSX::WINDOW_EVENT_CLOSE_REQUEST);
 		}
 
 		if (was_empty && popup_list.is_empty()) {
@@ -3026,12 +3030,16 @@ void DisplayServerOSX::popup_open(WindowID p_window) {
 }
 
 void DisplayServerOSX::popup_close(WindowID p_window) {
+	_THREAD_SAFE_METHOD_
+
 	bool was_empty = popup_list.is_empty();
 	List<WindowID>::Element *E = popup_list.find(p_window);
 	while (E) {
-		send_window_event(windows[E->get()], DisplayServerOSX::WINDOW_EVENT_CLOSE_REQUEST);
 		List<WindowID>::Element *F = E->next();
+		WindowID win_id = E->get();
 		popup_list.erase(E);
+
+		send_window_event(windows[win_id], DisplayServerOSX::WINDOW_EVENT_CLOSE_REQUEST);
 		E = F;
 	}
 	if (!was_empty && popup_list.is_empty()) {
@@ -3047,11 +3055,8 @@ void DisplayServerOSX::mouse_process_popups(bool p_close) {
 	if (p_close) {
 		// Close all popups.
 		List<WindowID>::Element *E = popup_list.front();
-		while (E) {
+		if (E) {
 			send_window_event(windows[E->get()], DisplayServerOSX::WINDOW_EVENT_CLOSE_REQUEST);
-			List<WindowID>::Element *F = E->next();
-			popup_list.erase(E);
-			E = F;
 		}
 		if (!was_empty) {
 			// Inform OS that all popups are closed.
@@ -3064,7 +3069,9 @@ void DisplayServerOSX::mouse_process_popups(bool p_close) {
 		}
 
 		Point2i pos = mouse_get_position();
+		List<WindowID>::Element *C = nullptr;
 		List<WindowID>::Element *E = popup_list.back();
+		// Find top popup to close.
 		while (E) {
 			// Popup window area.
 			Rect2i win_rect = Rect2i(window_get_position(E->get()), window_get_size(E->get()));
@@ -3075,11 +3082,12 @@ void DisplayServerOSX::mouse_process_popups(bool p_close) {
 			} else if (safe_rect != Rect2i() && safe_rect.has_point(pos)) {
 				break;
 			} else {
-				send_window_event(windows[E->get()], DisplayServerOSX::WINDOW_EVENT_CLOSE_REQUEST);
-				List<WindowID>::Element *F = E->prev();
-				popup_list.erase(E);
-				E = F;
+				C = E;
+				E = E->prev();
 			}
+		}
+		if (C) {
+			send_window_event(windows[C->get()], DisplayServerOSX::WINDOW_EVENT_CLOSE_REQUEST);
 		}
 		if (!was_empty && popup_list.is_empty()) {
 			// Inform OS that all popups are closed.


### PR DESCRIPTION
Depending on how fast OS processes a window close request, the window close event might arrive before the cleanup loop is finished (and delete the list item which is currently processed by the loop, causing invalid memory access).

So instead of removing nested popups directly, cleanup is changed to find the deepest popup to close, and send a close request to this window only, the rest (closing child popups) is handled by this window close event handler.

TODO:
- [x] Test on macOS.
- [x] Test on Windows.
- [x] Test on Linux.

Fixes: #59906