### PR TITLE
Fix Project Manager hard crashes due to invalid access to Editor Nodes

### DIFF
--- a/editor/editor_dir_dialog.cpp
+++ b/editor/editor_dir_dialog.cpp
@@ -156,15 +156,18 @@ void EditorDirDialog::_make_dir_confirm() {
 
 	String dir = ti->get_metadata(0);
 
-	if (EditorFileSystem::get_singleton()->get_filesystem_path(dir + makedirname->get_text())) {
+	DirAccessRef d = DirAccess::open(dir);
+	ERR_FAIL_COND_MSG(!d, "Cannot open directory '" + dir + "'.");
+
+	const String stripped_dirname = makedirname->get_text().strip_edges();
+
+	if (d->dir_exists(stripped_dirname)) {
 		mkdirerr->set_text(TTR("Could not create folder. File with that name already exists."));
 		mkdirerr->popup_centered();
 		return;
 	}
 
-	DirAccessRef d = DirAccess::open(dir);
-	ERR_FAIL_COND_MSG(!d, "Cannot open directory '" + dir + "'.");
-	Error err = d->make_dir(makedirname->get_text());
+	Error err = d->make_dir(stripped_dirname);
 	if (err != OK) {
 		mkdirerr->popup_centered(Size2(250, 80) * EDSCALE);
 	} else {

--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -1099,16 +1099,18 @@ EditorFileDialog::Access EditorFileDialog::get_access() const {
 }
 
 void EditorFileDialog::_make_dir_confirm() {
-	if (EditorFileSystem::get_singleton()->get_filesystem_path(makedirname->get_text().strip_edges())) {
+	const String stripped_dirname = makedirname->get_text().strip_edges();
+
+	if (dir_access->dir_exists(stripped_dirname)) {
 		error_dialog->set_text(TTR("Could not create folder. File with that name already exists."));
 		error_dialog->popup_centered(Size2(250, 50) * EDSCALE);
 		makedirname->set_text(""); // Reset label.
 		return;
 	}
 
-	Error err = dir_access->make_dir(makedirname->get_text().strip_edges());
+	Error err = dir_access->make_dir(stripped_dirname);
 	if (err == OK) {
-		dir_access->change_dir(makedirname->get_text().strip_edges());
+		dir_access->change_dir(stripped_dirname);
 		invalidate();
 		update_filters();
 		update_dir();

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -1427,17 +1427,17 @@ void FileSystemDock::_make_dir_confirm() {
 		directory = directory.get_base_dir();
 	}
 
-	if (EditorFileSystem::get_singleton()->get_filesystem_path(directory + dir_name)) {
+	print_verbose("Making folder " + dir_name + " in " + directory);
+	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
+	Error err = da->change_dir(directory);
+	ERR_FAIL_COND_MSG(err != OK, "Cannot open directory '" + directory + "'.");
+
+	if (da->dir_exists(directory)) {
 		EditorNode::get_singleton()->show_warning(TTR("Could not create folder. File with that name already exists."));
 		return;
 	}
 
-	print_verbose("Making folder " + dir_name + " in " + directory);
-	DirAccessRef da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
-	Error err = da->change_dir(directory);
-	if (err == OK) {
-		err = da->make_dir(dir_name);
-	}
+	err = da->make_dir(dir_name);
 
 	if (err == OK) {
 		print_verbose("FileSystem: calling rescan.");


### PR DESCRIPTION
Resolves: https://github.com/godotengine/godot/issues/59869

Fixes incorrect usages in project manager referencing editor nodes from this PR: https://github.com/godotengine/godot/pull/59495

Unfortunately, while EditorFileSystem is a singleton, it is also a node that is supposed to be attached to the editor node tree. Its responsibility is more of a file system watch for the editor (should probably be renamed to avoid ambiguity).

Also did some minor cleanup for unnecessary string copies.