### PR TITLE
Improve handling for editor documentation search with blank searches

### DIFF
--- a/editor/editor_help_search.cpp
+++ b/editor/editor_help_search.cpp
@@ -331,7 +331,10 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 
 		// Match class name.
 		if (search_flags & SEARCH_CLASSES) {
-			match.name = term.is_empty() || _match_string(term, class_doc.name);
+			// If the search term is empty, add any classes which are not script docs or which don't start with
+			// a double-quotation. This will ensure that only C++ classes and explictly named classes will
+			// be added.
+			match.name = (term.is_empty() && (!class_doc.is_script_doc || class_doc.name[0] != '\"')) || _match_string(term, class_doc.name);
 		}
 
 		// Match members if the term is long enough.
@@ -398,6 +401,7 @@ bool EditorHelpSearch::Runner::_phase_match_classes() {
 				}
 			}
 		}
+		matches[class_doc.name] = match;
 	}
 
 	iterator_doc = iterator_doc->next();


### PR DESCRIPTION
Changes the behaviour of the EditorHelpSearch to ensure it includes all classes when the search term is blank (as it is in the 3.x branches). To be more specific though, when it is blank, it will only show classes which are either native C++ classes or script classes with an explicitly declared class_name. It does this by checking if a double quotation is the first character in the string (may be a bit hacky, but can't find a better way). This should make it easier for new users to find classes they may potentially want to use.