### PR TITLE
Fix `NoiseTexture._generate_texture` crash

### DIFF
--- a/modules/noise/noise.h
+++ b/modules/noise/noise.h
@@ -101,6 +101,7 @@ class Noise : public Resource {
 		on Source it's translated to
 		corner of Q1/s3 unless the ALT_XY modulo moves it to Q4
 		*/
+		ERR_FAIL_COND_V(p_blend_skirt < 0, Ref<Image>());
 
 		int skirt_width = MAX(1, p_width * p_blend_skirt);
 		int skirt_height = MAX(1, p_height * p_blend_skirt);


### PR DESCRIPTION
Fixes #59915 .

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
