### PR TITLE
[3.x] Expose get_selected_text() in RichTextLabel

### DIFF
--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -66,6 +66,12 @@
 				Returns the total number of newlines in the tag stack's text tags. Considers wrapped text as one line.
 			</description>
 		</method>
+		<method name="get_selected_text">
+			<return type="String" />
+			<description>
+				Returns the current selection text. Does not include BBCodes.
+			</description>
+		</method>
 		<method name="get_total_character_count" qualifiers="const">
 			<return type="int" />
 			<description>

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -2815,6 +2815,7 @@ void RichTextLabel::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("pop"), &RichTextLabel::pop);
 
 	ClassDB::bind_method(D_METHOD("clear"), &RichTextLabel::clear);
+	ClassDB::bind_method(D_METHOD("get_selected_text"), &RichTextLabel::get_selected_text);
 	ClassDB::bind_method(D_METHOD("deselect"), &RichTextLabel::deselect);
 
 	ClassDB::bind_method(D_METHOD("set_meta_underline", "enable"), &RichTextLabel::set_meta_underline);


### PR DESCRIPTION
Expose get_selected_text() in RichTextLabel for 3.x branch
