### PR TITLE
Fix GraphNode not resizing with larger title

### DIFF
--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -393,7 +393,6 @@ void GraphNode::_notification(int p_what) {
 				w -= close->get_width();
 			}
 
-			title_buf->set_width(w);
 			title_buf->draw(get_canvas_item(), Point2(sb->get_margin(SIDE_LEFT) + title_h_offset, -title_buf->get_size().y + title_offset), title_color);
 			if (show_close) {
 				Vector2 cpos = Point2(w + sb->get_margin(SIDE_LEFT) + close_h_offset, -close->get_height() + close_offset);


### PR DESCRIPTION
Fixes #59924
So far it seems to work. @bruvzg also suggested `title_buf->set_text_overrun_behavior(TextLine::OVERRUN_NO_TRIMMING)`, not sure which would be best.