### PR TITLE
Fix `map_get_path` aka `get_simple_path` behavior in 2D & 3D

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -351,11 +351,15 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 
 		// Add mid points
 		int np_id = least_cost_id;
-		while (np_id != -1) {
-			path.push_back(navigation_polys[np_id].entry);
+		while (np_id != -1 && navigation_polys[np_id].back_navigation_poly_id != -1) {
+			int prev = navigation_polys[np_id].back_navigation_edge;
+			int prev_n = (navigation_polys[np_id].back_navigation_edge + 1) % navigation_polys[np_id].poly->points.size();
+			Vector3 point = (navigation_polys[np_id].poly->points[prev].pos + navigation_polys[np_id].poly->points[prev_n].pos) * 0.5;
+			path.push_back(point);
 			np_id = navigation_polys[np_id].back_navigation_poly_id;
 		}
 
+		path.push_back(begin_point);
 		path.reverse();
 	}
 


### PR DESCRIPTION
Same as https://github.com/godotengine/godot/pull/58209 yet for `master`

2D After fix:
![2022-04-05-232204_4480x1440_scrot](https://user-images.githubusercontent.com/1207385/161852309-7e213688-d76e-42b3-b89b-62105f6ce230.png)

3D after fix:
![2022-04-05-232217_4480x1440_scrot](https://user-images.githubusercontent.com/1207385/161852325-2ffef7c6-c03e-4f21-9e8e-266d0683a5ab.png)
