### PR TITLE
Remove argument name strings from release builds

### DIFF
--- a/core/object/class_db.cpp
+++ b/core/object/class_db.cpp
@@ -37,6 +37,8 @@
 #define OBJTYPE_RLOCK RWLockRead _rw_lockr_(lock);
 #define OBJTYPE_WLOCK RWLockWrite _rw_lockw_(lock);
 
+#ifdef DEBUG_METHODS_ENABLED
+
 MethodDefinition D_METHOD(const char *p_name) {
 	MethodDefinition md;
 	md.name = StaticCString::create(p_name);
@@ -223,6 +225,8 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 	md.args.write[12] = StaticCString::create(p_arg13);
 	return md;
 }
+
+#endif
 
 ClassDB::APIType ClassDB::current_api = API_CORE;
 
@@ -1420,8 +1424,13 @@ void ClassDB::bind_method_custom(const StringName &p_class, MethodBind *p_method
 	type->method_map[p_method->get_name()] = p_method;
 }
 
+#ifdef DEBUG_METHODS_ENABLED
 MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const MethodDefinition &method_name, const Variant **p_defs, int p_defcount) {
 	StringName mdname = method_name.name;
+#else
+MethodBind *ClassDB::bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const char *method_name, const Variant **p_defs, int p_defcount) {
+	StringName mdname = StaticCString::create(method_name);
+#endif
 
 	OBJTYPE_WLOCK;
 	ERR_FAIL_COND_V(!p_bind, nullptr);

--- a/core/object/class_db.h
+++ b/core/object/class_db.h
@@ -45,6 +45,8 @@
 
 #define DEFVAL(m_defval) (m_defval)
 
+#ifdef DEBUG_METHODS_ENABLED
+
 struct MethodDefinition {
 	StringName name;
 	Vector<StringName> args;
@@ -69,6 +71,14 @@ MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_
 MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_arg2, const char *p_arg3, const char *p_arg4, const char *p_arg5, const char *p_arg6, const char *p_arg7, const char *p_arg8, const char *p_arg9, const char *p_arg10, const char *p_arg11);
 MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_arg2, const char *p_arg3, const char *p_arg4, const char *p_arg5, const char *p_arg6, const char *p_arg7, const char *p_arg8, const char *p_arg9, const char *p_arg10, const char *p_arg11, const char *p_arg12);
 MethodDefinition D_METHOD(const char *p_name, const char *p_arg1, const char *p_arg2, const char *p_arg3, const char *p_arg4, const char *p_arg5, const char *p_arg6, const char *p_arg7, const char *p_arg8, const char *p_arg9, const char *p_arg10, const char *p_arg11, const char *p_arg12, const char *p_arg13);
+
+#else
+
+// When DEBUG_METHODS_ENABLED is set this will let the engine know
+// the argument names for easier debugging.
+#define D_METHOD(m_c, ...) m_c
+
+#endif
 
 class ClassDB {
 public:
@@ -134,7 +144,11 @@ public:
 	static HashMap<StringName, StringName> resource_base_extensions;
 	static HashMap<StringName, StringName> compat_classes;
 
+#ifdef DEBUG_METHODS_ENABLED
 	static MethodBind *bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const MethodDefinition &method_name, const Variant **p_defs, int p_defcount);
+#else
+	static MethodBind *bind_methodfi(uint32_t p_flags, MethodBind *p_bind, const char *method_name, const Variant **p_defs, int p_defcount);
+#endif
 
 	static APIType current_api;
 

--- a/core/object/method_bind.cpp
+++ b/core/object/method_bind.cpp
@@ -69,8 +69,6 @@ PropertyInfo MethodBind::get_argument_info(int p_argument) const {
 	PropertyInfo info = _gen_argument_type_info(p_argument);
 #ifdef DEBUG_METHODS_ENABLED
 	info.name = p_argument < arg_names.size() ? String(arg_names[p_argument]) : String("arg" + itos(p_argument));
-#else
-	info.name = String("arg" + itos(p_argument));
 #endif
 	return info;
 }


### PR DESCRIPTION
They are not needed in release, so we can remove them to reduce the binary size.

This is the same change I mentioned in the PR for 3.x: https://github.com/godotengine/godot/pull/59793#issuecomment-1086340803

For reference, these are the sizes I get in my machine (Intel macOS) compiled using production=yes and them stripped:

```
    master: 66930448 (63.83 MiB)
   This PR: 66094608 (63.03 MiB)
Difference:   835840 ( 0.80 MiB)
```

Which is about 1.25% reduction in size.

I was expecting a larger decrease in size given the difference I got in 3.x. Not sure if I'm missing something here.