### PR TITLE
Disallow setting editor-only metadata in the editor

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3723,6 +3723,8 @@ void EditorInspector::_check_meta_name(String name) {
 		error = TTR("Invalid metadata identifier.");
 	} else if (object->has_meta(name)) {
 		error = TTR("Metadata already exists.");
+	} else if (name[0] == '_') {
+		error = TTR("Names starting with _ are reserved for editor-only metadata.");
 	}
 
 	if (error != "") {


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Issue: https://github.com/godotengine/godot/issues/59852

![NotAllow](https://user-images.githubusercontent.com/50512341/162104909-0165cf48-2c7a-4027-9a08-dd4b0021c46c.png)

Metadata starts with `_` considered as editor-only metadata and disallowed as mentioned in the issue. 

A bit sorry for [Ayush-singla27](https://github.com/Ayush-singla27), it has been 3 days and it really just need a few lines of code (or maybe Ayush already make a PR and I don't know how to use github). This is, too, my first contribution to me beloved game engine.

<i>Bugsquad edit:</i>
- Fix #59852