### PR TITLE
Store editor version in project.godot

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -687,6 +687,8 @@ Error ProjectSettings::_load_settings_text(const String &p_path) {
 			if (section.is_empty() && assign == "config_version") {
 				config_version = value;
 				ERR_FAIL_COND_V_MSG(config_version > CONFIG_VERSION, ERR_FILE_CANT_OPEN, vformat("Can't open project at '%s', its `config_version` (%d) is from a more recent and incompatible version of the engine. Expected config version: %d.", p_path, config_version, CONFIG_VERSION));
+			} else if (section.is_empty() && assign == "editor_version") {
+				// Ignore for now, the same as config_version is not passed to set().
 			} else {
 				if (section.is_empty()) {
 					set(assign, value);
@@ -847,6 +849,7 @@ Error ProjectSettings::_save_settings_text(const String &p_file, const Map<Strin
 	file->store_line("");
 
 	file->store_string("config_version=" + itos(CONFIG_VERSION) + "\n");
+	file->store_string("editor_version=\"" + String(VERSION_NUMBER) + "\"\n");
 	if (!p_custom_features.is_empty()) {
 		file->store_string("custom_features=\"" + p_custom_features + "\"\n");
 	}


### PR DESCRIPTION
Backward compatible/neutral soution for https://github.com/godotengine/godot-proposals/issues/4355

Automatically adds current editor version right below the `config_version` in project.godot.

While it's true, that editor version in Godot 4.0 is appended to `application/config/features`, features were not backported to 3.x and I'm not sure if it is the right place for editor version anyway. It's not obvious that "4.0" in `application/config/features` array means editor version 4.0. Applying simple, universal and more human readable solution seems like a good first step to use it in future PRs (to show editor version in project manager, to warn the user about version difference).

Also storing version at the top prevents moving it up and down depending on the order and count of settings  in other sections. It's more convenient from the perspective of reading the text file or comparing diffs in version control tool.

![obraz](https://user-images.githubusercontent.com/1554127/162165147-ca18a616-6c1a-41c5-a45b-9cc3eeb33920.png)