### PR TITLE
[3.x] Retrieve primary monitor size in fullscreen mode

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -73,6 +73,12 @@ __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 typedef struct {
 	int count;
 	int screen;
+	HMONITOR monitor;
+} EnumScreenData;
+
+typedef struct {
+	int count;
+	int screen;
 	Size2 size;
 } EnumSizeData;
 
@@ -81,6 +87,16 @@ typedef struct {
 	int screen;
 	Point2 pos;
 } EnumPosData;
+
+static BOOL CALLBACK _MonitorEnumProcScreen(HMONITOR hMonitor, HDC hdcMonitor, LPRECT lprcMonitor, LPARAM dwData) {
+	EnumScreenData *data = (EnumScreenData *)dwData;
+	if (data->monitor == hMonitor) {
+		data->screen = data->count;
+	}
+
+	data->count++;
+	return TRUE;
+}
 
 static BOOL CALLBACK _MonitorEnumProcSize(HMONITOR hMonitor, HDC hdcMonitor, LPRECT lprcMonitor, LPARAM dwData) {
 	EnumSizeData *data = (EnumSizeData *)dwData;
@@ -1354,7 +1370,13 @@ Error OS_Windows::initialize(const VideoMode &p_desired, int p_video_driver, int
 
 		*/
 
-		EnumSizeData data = { 0, 0, Size2() };
+		// Get the primary monitor without providing hwnd
+		// Solution from https://devblogs.microsoft.com/oldnewthing/20070809-00/?p=25643
+		const POINT ptZero = { 0, 0 };
+		EnumScreenData primary_data = { 0, 0, MonitorFromPoint(ptZero, MONITOR_DEFAULTTOPRIMARY) };
+		EnumDisplayMonitors(NULL, NULL, _MonitorEnumProcScreen, (LPARAM)&primary_data);
+
+		EnumSizeData data = { 0, primary_data.screen, Size2() };
 		EnumDisplayMonitors(NULL, NULL, _MonitorEnumProcSize, (LPARAM)&data);
 
 		WindowRect.right = data.size.width;
@@ -1896,22 +1918,6 @@ int OS_Windows::get_screen_count() const {
 	int data = 0;
 	EnumDisplayMonitors(NULL, NULL, _MonitorEnumProcCount, (LPARAM)&data);
 	return data;
-}
-
-typedef struct {
-	int count;
-	int screen;
-	HMONITOR monitor;
-} EnumScreenData;
-
-static BOOL CALLBACK _MonitorEnumProcScreen(HMONITOR hMonitor, HDC hdcMonitor, LPRECT lprcMonitor, LPARAM dwData) {
-	EnumScreenData *data = (EnumScreenData *)dwData;
-	if (data->monitor == hMonitor) {
-		data->screen = data->count;
-	}
-
-	data->count++;
-	return TRUE;
 }
 
 int OS_Windows::get_current_screen() const {


### PR DESCRIPTION
* Fixes #21674

I noticed this issue (#21674) while participating in LD50 (with 3.4.4).
When fullscreen mode is set, the Windows export gives a wrong window size (not the primary monitor size) on my pc.
My monitor setup: primary 3840x2160 landscape mode, secondary 1920x1080 portrait mode

I tested it in 3.4.4 and v3.5.beta.custom_build [6d9cbcb05], this issue still exists.

So did some search and found a solution to get primary monitor whitout having window. (https://devblogs.microsoft.com/oldnewthing/20070809-00/?p=25643)

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
