### PR TITLE
Add WebXRInterface.xr_standard_mapping flag to attempt to convert button/axis ids to match other AR/VR interfaces

### DIFF
--- a/modules/webxr/doc_classes/WebXRInterface.xml
+++ b/modules/webxr/doc_classes/WebXRInterface.xml
@@ -22,6 +22,9 @@
 
 		    webxr_interface = ARVRServer.find_interface("WebXR")
 		    if webxr_interface:
+		        # Map to the standard button/axis ids when possible.
+		        webxr_interface.xr_standard_mapping = true
+
 		        # WebXR uses a lot of asynchronous callbacks, so we connect to various
 		        # signals in order to receive them.
 		        webxr_interface.connect("session_supported", self, "_webxr_session_supported")
@@ -163,6 +166,10 @@
 		<member name="visibility_state" type="String" setter="" getter="get_visibility_state">
 			Indicates if the WebXR session's imagery is visible to the user.
 			Possible values come from [url=https://developer.mozilla.org/en-US/docs/Web/API/XRVisibilityState]WebXR's XRVisibilityState[/url], including [code]"hidden"[/code], [code]"visible"[/code], and [code]"visible-blurred"[/code].
+		</member>
+		<member name="xr_standard_mapping" type="bool" setter="set_xr_standard_mapping" getter="get_xr_standard_mapping">
+			If set to true, the button and axes ids will be converted to match the standard ids used by other AR/VR interfaces, when possible.
+			Otherwise, the ids will be passed through unaltered from WebXR.
 		</member>
 	</members>
 	<signals>

--- a/modules/webxr/godot_webxr.h
+++ b/modules/webxr/godot_webxr.h
@@ -80,8 +80,8 @@ extern void godot_webxr_sample_controller_data();
 extern int godot_webxr_get_controller_count();
 extern int godot_webxr_is_controller_connected(int p_controller);
 extern float *godot_webxr_get_controller_transform(int p_controller);
-extern int *godot_webxr_get_controller_buttons(int p_controller);
-extern int *godot_webxr_get_controller_axes(int p_controller);
+extern int *godot_webxr_get_controller_buttons(int p_controller, bool p_xr_standard_mapping);
+extern int *godot_webxr_get_controller_axes(int p_controller, bool p_xr_standard_mapping);
 extern int godot_webxr_get_controller_target_ray_mode(int p_controller);
 
 extern char *godot_webxr_get_visibility_state();

--- a/modules/webxr/webxr_interface.cpp
+++ b/modules/webxr/webxr_interface.cpp
@@ -46,6 +46,8 @@ void WebXRInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_controller_target_ray_mode", "controller_id"), &WebXRInterface::get_controller_target_ray_mode);
 	ClassDB::bind_method(D_METHOD("get_visibility_state"), &WebXRInterface::get_visibility_state);
 	ClassDB::bind_method(D_METHOD("get_bounds_geometry"), &WebXRInterface::get_bounds_geometry);
+	ClassDB::bind_method(D_METHOD("set_xr_standard_mapping"), &WebXRInterface::set_xr_standard_mapping);
+	ClassDB::bind_method(D_METHOD("get_xr_standard_mapping"), &WebXRInterface::get_xr_standard_mapping);
 
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "session_mode", PROPERTY_HINT_NONE), "set_session_mode", "get_session_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "required_features", PROPERTY_HINT_NONE), "set_required_features", "get_required_features");
@@ -54,6 +56,7 @@ void WebXRInterface::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "reference_space_type", PROPERTY_HINT_NONE), "", "get_reference_space_type");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "visibility_state", PROPERTY_HINT_NONE), "", "get_visibility_state");
 	ADD_PROPERTY(PropertyInfo(Variant::POOL_VECTOR3_ARRAY, "bounds_geometry", PROPERTY_HINT_NONE), "", "get_bounds_geometry");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "xr_standard_mapping", PROPERTY_HINT_NONE), "set_xr_standard_mapping", "get_xr_standard_mapping");
 
 	ADD_SIGNAL(MethodInfo("session_supported", PropertyInfo(Variant::STRING, "session_mode"), PropertyInfo(Variant::BOOL, "supported")));
 	ADD_SIGNAL(MethodInfo("session_started"));

--- a/modules/webxr/webxr_interface.h
+++ b/modules/webxr/webxr_interface.h
@@ -68,6 +68,8 @@ public:
 	virtual TargetRayMode get_controller_target_ray_mode(int p_controller_id) const = 0;
 	virtual String get_visibility_state() const = 0;
 	virtual PoolVector3Array get_bounds_geometry() const = 0;
+	virtual void set_xr_standard_mapping(bool p_xr_standard_mapping) = 0;
+	virtual bool get_xr_standard_mapping() const = 0;
 };
 
 VARIANT_ENUM_CAST(WebXRInterface::TargetRayMode);

--- a/modules/webxr/webxr_interface_js.cpp
+++ b/modules/webxr/webxr_interface_js.cpp
@@ -204,6 +204,14 @@ PoolVector3Array WebXRInterfaceJS::get_bounds_geometry() const {
 	return ret;
 }
 
+void WebXRInterfaceJS::set_xr_standard_mapping(bool p_xr_standard_mapping) {
+	xr_standard_mapping = p_xr_standard_mapping;
+}
+
+bool WebXRInterfaceJS::get_xr_standard_mapping() const {
+	return xr_standard_mapping;
+}
+
 StringName WebXRInterfaceJS::get_name() const {
 	return "WebXR";
 };
@@ -417,7 +425,7 @@ void WebXRInterfaceJS::_update_tracker(int p_controller_id) {
 			free(tracker_matrix);
 		}
 
-		int *buttons = godot_webxr_get_controller_buttons(p_controller_id);
+		int *buttons = godot_webxr_get_controller_buttons(p_controller_id, xr_standard_mapping);
 		if (buttons) {
 			for (int i = 0; i < buttons[0]; i++) {
 				input->joy_button(joy_id, i, *((float *)buttons + (i + 1)));
@@ -425,7 +433,7 @@ void WebXRInterfaceJS::_update_tracker(int p_controller_id) {
 			free(buttons);
 		}
 
-		int *axes = godot_webxr_get_controller_axes(p_controller_id);
+		int *axes = godot_webxr_get_controller_axes(p_controller_id, xr_standard_mapping);
 		if (axes) {
 			WebXRInterface::TargetRayMode target_ray_mode = (WebXRInterface::TargetRayMode)godot_webxr_get_controller_target_ray_mode(p_controller_id);
 			if (target_ray_mode == WebXRInterface::TARGET_RAY_MODE_SCREEN) {
@@ -481,7 +489,7 @@ void WebXRInterfaceJS::_on_input_event(int p_event_type, int p_input_source) {
 				touching[touch_index] = (p_event_type == WEBXR_INPUT_EVENT_SELECTSTART);
 			}
 
-			int *axes = godot_webxr_get_controller_axes(p_input_source);
+			int *axes = godot_webxr_get_controller_axes(p_input_source, false);
 			if (axes) {
 				Vector2 joy_vector = _get_joy_vector_from_axes(axes);
 				Vector2 position = _get_screen_position_from_joy_vector(joy_vector);
@@ -554,8 +562,7 @@ Vector2 WebXRInterfaceJS::_get_joy_vector_from_axes(int *p_axes) {
 }
 
 Vector2 WebXRInterfaceJS::_get_screen_position_from_joy_vector(const Vector2 &p_joy_vector) {
-	// Invert the y-axis.
-	Vector2 position_percentage((p_joy_vector.x + 1.0f) / 2.0f, ((-p_joy_vector.y) + 1.0f) / 2.0f);
+	Vector2 position_percentage((p_joy_vector.x + 1.0f) / 2.0f, ((p_joy_vector.y) + 1.0f) / 2.0f);
 	Vector2 position = get_render_targetsize() * position_percentage;
 
 	return position;
@@ -567,6 +574,7 @@ void WebXRInterfaceJS::notification(int p_what) {
 
 WebXRInterfaceJS::WebXRInterfaceJS() {
 	initialized = false;
+	xr_standard_mapping = false;
 	session_mode = "inline";
 	requested_reference_space_types = "local";
 };

--- a/modules/webxr/webxr_interface_js.h
+++ b/modules/webxr/webxr_interface_js.h
@@ -46,6 +46,7 @@ class WebXRInterfaceJS : public WebXRInterface {
 
 private:
 	bool initialized;
+	bool xr_standard_mapping;
 
 	String session_mode;
 	String required_features;
@@ -80,6 +81,8 @@ public:
 	virtual TargetRayMode get_controller_target_ray_mode(int p_controller_id) const;
 	virtual String get_visibility_state() const;
 	virtual PoolVector3Array get_bounds_geometry() const;
+	virtual void set_xr_standard_mapping(bool p_xr_standard_mapping);
+	virtual bool get_xr_standard_mapping() const;
 
 	virtual StringName get_name() const;
 	virtual int get_capabilities() const;


### PR DESCRIPTION
The button and axis ids used by WebXR are different than other AR/VR interfaces, due in part to the fact that WebXR can handle input from a wider range of devices and input methods.

However, as discussed with @BastiaanOlij on Discord, it is possible to convert from WebXR's ids to the standard Godot ids in some cases, which is what this PR does.

The conversion will happen if `xr_standard_mapping` property on `WebXRInterface` is set to true. It's set to false by default, for backward compatibility, however, I could be convinced to use the opposite default.

In cases where we can't convert the ids, they are just passed through directly from WebXR. And, when we are converting, if there's more data than we know how to deal with, it's simply discarded.

**Note:** This PR is only against 3.x, similar to other recent WebXR PRs. Once it's possible to use WebXR on Godot 4.x, this functionality will be ported there.

_Related to #59949_