### PR TITLE
Fix path handling in FBX and Blend importers

### DIFF
--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -62,10 +62,11 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 		List<String> *r_missing_deps, Error *r_err) {
 	// Get global paths for source and sink.
 
-	const String source_global = ProjectSettings::get_singleton()->globalize_path(p_path);
+	// Escape paths to be valid Python strings to embed in the script.
+	const String source_global = ProjectSettings::get_singleton()->globalize_path(p_path).c_escape();
 	const String sink = ProjectSettings::get_singleton()->get_imported_files_path().plus_file(
 			vformat("%s-%s.gltf", p_path.get_file().get_basename(), p_path.md5_text()));
-	const String sink_global = ProjectSettings::get_singleton()->globalize_path(sink);
+	const String sink_global = ProjectSettings::get_singleton()->globalize_path(sink).c_escape();
 
 	// Handle configuration options.
 

--- a/modules/gltf/editor/editor_scene_importer_fbx.cpp
+++ b/modules/gltf/editor/editor_scene_importer_fbx.cpp
@@ -53,10 +53,13 @@ Node *EditorSceneFormatImporterFBX::import_scene(const String &p_path, uint32_t 
 		List<String> *r_missing_deps, Error *r_err) {
 	// Get global paths for source and sink.
 
-	const String source_global = ProjectSettings::get_singleton()->globalize_path(p_path);
+	// Don't use `c_escape()` as it can generate broken paths. These paths will be
+	// enclosed in double quotes by OS::execute(), so we only need to escape those.
+	// `c_escape_multiline()` seems to do this (escapes `\` and `"` only).
+	const String source_global = ProjectSettings::get_singleton()->globalize_path(p_path).c_escape_multiline();
 	const String sink = ProjectSettings::get_singleton()->get_imported_files_path().plus_file(
 			vformat("%s-%s.glb", p_path.get_file().get_basename(), p_path.md5_text()));
-	const String sink_global = ProjectSettings::get_singleton()->globalize_path(sink);
+	const String sink_global = ProjectSettings::get_singleton()->globalize_path(sink).c_escape_multiline();
 
 	// Run fbx2gltf.
 
@@ -65,9 +68,9 @@ Node *EditorSceneFormatImporterFBX::import_scene(const String &p_path, uint32_t 
 	List<String> args;
 	args.push_back("--pbr-metallic-roughness");
 	args.push_back("--input");
-	args.push_back(vformat("\"%s\"", source_global));
+	args.push_back(source_global);
 	args.push_back("--output");
-	args.push_back(vformat("\"%s\"", sink_global));
+	args.push_back(sink_global);
 	args.push_back("--binary");
 
 	String standard_out;


### PR DESCRIPTION
Fixes #59996 (confirmed buggy both on Linux and Windows, and fixed by this PR).

It's now successful with the following names:

![image](https://user-images.githubusercontent.com/4701338/162324354-d8ea91f7-e037-497e-a186-8a1b4eeddddd.png)

It still fails with names that contain either `"` or `\n` (as two characters, not an actual newline), but that's a pre-existing Godot bug in the import system which affects other importers too. *Edit:* Reported as #60000.