### PR TITLE
Add enum hint for `Animation.loop_mode`

### DIFF
--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -3828,7 +3828,7 @@ void Animation::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("compress", "page_size", "fps", "split_tolerance"), &Animation::compress, DEFVAL(8192), DEFVAL(120), DEFVAL(4.0));
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "length", PROPERTY_HINT_RANGE, "0.001,99999,0.001"), "set_length", "get_length");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "loop_mode"), "set_loop_mode", "get_loop_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "loop_mode", PROPERTY_HINT_ENUM, "None,Linear,Ping-Pong"), "set_loop_mode", "get_loop_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "step", PROPERTY_HINT_RANGE, "0,4096,0.001"), "set_step", "get_step");
 
 	ADD_SIGNAL(MethodInfo("tracks_changed"));


### PR DESCRIPTION
Adds an enum hint to `Animation.loop_mode` so that it displays as an enum in the inspector instead of an int. This matches the `Animation.LoopMode` enum.

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/162336194-37107720-bdcf-4174-8f19-3218e20191b4.png) | ![image](https://user-images.githubusercontent.com/67974470/162336106-0e4668fa-3c42-48ff-bfc3-298fe8bee851.png) |