### PR TITLE
Add a note about 2D-collisions in different canvases to documentation

### DIFF
--- a/doc/classes/CollisionObject2D.xml
+++ b/doc/classes/CollisionObject2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		CollisionObject2D is the base class for 2D physics objects. It can hold any number of 2D collision [Shape2D]s. Each shape must be assigned to a [i]shape owner[/i]. The CollisionObject2D can have any number of shape owners. Shape owners are not nodes and do not appear in the editor, but are accessible through code using the [code]shape_owner_*[/code] methods.
+		[b]Note:[/b] Only collisions between objects within the same canvas ([Viewport] canvas or [CanvasLayer]) are supported. The behavior of collisions between objects in different canvases is undefined.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Describe current behavior of collisions between objects in different canvases in documentation of `CollisionObject2D`.

fix documentation part of #58514.
