### PR TITLE
Fix Visual Script's jump to function relative to zoom

### DIFF
--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -2727,7 +2727,7 @@ void VisualScriptEditor::_center_on_node(int p_id) {
 
 	if (gn) {
 		gn->set_selected(true);
-		Vector2 new_scroll = gn->get_position_offset() - graph->get_size() * 0.5 + gn->get_size() * 0.5;
+		Vector2 new_scroll = gn->get_position_offset() * graph->get_zoom() - graph->get_size() * 0.5 + gn->get_size() * 0.5;
 		graph->set_scroll_ofs(new_scroll);
 		script->set_scroll(new_scroll / EDSCALE);
 		script->set_edited(true);


### PR DESCRIPTION
When double-clicking on a function name the graph will now correctly jump to the function relative to the zoom ratio.

https://user-images.githubusercontent.com/62965063/162406169-c55e2b6a-c440-4a92-a910-5fe495fd8337.mp4

Resolves: #58849
