### PR TITLE
Rename `NavigationServer`'s `free` method to `free_rid`

### DIFF
--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -110,11 +110,11 @@
 				Sets the current velocity of the agent.
 			</description>
 		</method>
-		<method name="free" qualifiers="const">
+		<method name="free_rid" qualifiers="const">
 			<return type="void" />
-			<argument index="0" name="object" type="RID" />
+			<argument index="0" name="rid" type="RID" />
 			<description>
-				Destroy the RID
+				Destroys the given RID.
 			</description>
 		</method>
 		<method name="map_create" qualifiers="const">

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -110,11 +110,11 @@
 				Sets the current velocity of the agent.
 			</description>
 		</method>
-		<method name="free" qualifiers="const">
+		<method name="free_rid" qualifiers="const">
 			<return type="void" />
-			<argument index="0" name="object" type="RID" />
+			<argument index="0" name="rid" type="RID" />
 			<description>
-				Destroy the RID
+				Destroys the given RID.
 			</description>
 		</method>
 		<method name="map_create" qualifiers="const">

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -193,7 +193,7 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_is_map_changed", "agent"), &NavigationServer2D::agent_is_map_changed);
 	ClassDB::bind_method(D_METHOD("agent_set_callback", "agent", "receiver", "method", "userdata"), &NavigationServer2D::agent_set_callback, DEFVAL(Variant()));
 
-	ClassDB::bind_method(D_METHOD("free", "object"), &NavigationServer2D::free);
+	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer2D::free);
 
 	ADD_SIGNAL(MethodInfo("map_changed", PropertyInfo(Variant::RID, "map")));
 }

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -72,7 +72,7 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_is_map_changed", "agent"), &NavigationServer3D::agent_is_map_changed);
 	ClassDB::bind_method(D_METHOD("agent_set_callback", "agent", "receiver", "method", "userdata"), &NavigationServer3D::agent_set_callback, DEFVAL(Variant()));
 
-	ClassDB::bind_method(D_METHOD("free", "object"), &NavigationServer3D::free);
+	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer3D::free);
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &NavigationServer3D::set_active);
 	ClassDB::bind_method(D_METHOD("process", "delta_time"), &NavigationServer3D::process);


### PR DESCRIPTION
To be consistent with other servers.

Unlike on `3.x`, the `NavigationServer.free()` hides `Object.free()`.