### PR TITLE
[3.x] Rename `NavigationServer`'s `free` method to `free_rid`

### DIFF
--- a/doc/classes/Navigation2DServer.xml
+++ b/doc/classes/Navigation2DServer.xml
@@ -109,9 +109,9 @@
 				Sets the current velocity of the agent.
 			</description>
 		</method>
-		<method name="free" qualifiers="const">
+		<method name="free_rid" qualifiers="const">
 			<return type="void" />
-			<argument index="0" name="object" type="RID" />
+			<argument index="0" name="rid" type="RID" />
 			<description>
 				Destroys the given RID.
 			</description>

--- a/doc/classes/NavigationServer.xml
+++ b/doc/classes/NavigationServer.xml
@@ -109,9 +109,9 @@
 				Sets the current velocity of the agent.
 			</description>
 		</method>
-		<method name="free" qualifiers="const">
+		<method name="free_rid" qualifiers="const">
 			<return type="void" />
-			<argument index="0" name="object" type="RID" />
+			<argument index="0" name="rid" type="RID" />
 			<description>
 				Destroys the given RID.
 			</description>

--- a/servers/navigation_2d_server.cpp
+++ b/servers/navigation_2d_server.cpp
@@ -160,7 +160,7 @@ void Navigation2DServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_is_map_changed", "agent"), &Navigation2DServer::agent_is_map_changed);
 	ClassDB::bind_method(D_METHOD("agent_set_callback", "agent", "receiver", "method", "userdata"), &Navigation2DServer::agent_set_callback, DEFVAL(Variant()));
 
-	ClassDB::bind_method(D_METHOD("free", "object"), &Navigation2DServer::free);
+	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &Navigation2DServer::free);
 }
 
 Navigation2DServer::Navigation2DServer() {

--- a/servers/navigation_server.cpp
+++ b/servers/navigation_server.cpp
@@ -73,7 +73,7 @@ void NavigationServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("agent_is_map_changed", "agent"), &NavigationServer::agent_is_map_changed);
 	ClassDB::bind_method(D_METHOD("agent_set_callback", "agent", "receiver", "method", "userdata"), &NavigationServer::agent_set_callback, DEFVAL(Variant()));
 
-	ClassDB::bind_method(D_METHOD("free", "object"), &NavigationServer::free);
+	ClassDB::bind_method(D_METHOD("free_rid", "rid"), &NavigationServer::free);
 
 	ClassDB::bind_method(D_METHOD("set_active", "active"), &NavigationServer::set_active);
 	ClassDB::bind_method(D_METHOD("process", "delta_time"), &NavigationServer::process);


### PR DESCRIPTION
`3.x` version of #60017

Unlike on `master`, `Object.free()` hides `NavigationServer.free()` here. So users are unable to free allocated RIDs.

> SCRIPT ERROR: Invalid call to function 'free' in base 'Navigation2DServer'. Expected 0 arguments.