### PR TITLE
[3.x] Free region RID when cleaning NavPoly in `TileMap`

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -38,6 +38,15 @@
 #include "servers/navigation_2d_server.h"
 #include "servers/physics_2d_server.h"
 
+void TileMap::Quadrant::clear_navpoly() {
+	for (Map<PosKey, Quadrant::NavPoly>::Element *E = navpoly_ids.front(); E; E = E->next()) {
+		RID region = E->get().region;
+		Navigation2DServer::get_singleton()->region_set_map(region, RID());
+		Navigation2DServer::get_singleton()->free(region);
+	}
+	navpoly_ids.clear();
+}
+
 int TileMap::_get_quadrant_size() const {
 	if (y_sort_mode) {
 		return 1;
@@ -79,10 +88,7 @@ void TileMap::_notification(int p_what) {
 			for (Map<PosKey, Quadrant>::Element *E = quadrant_map.front(); E; E = E->next()) {
 				Quadrant &q = E->get();
 				if (navigation) {
-					for (Map<PosKey, Quadrant::NavPoly>::Element *F = q.navpoly_ids.front(); F; F = F->next()) {
-						Navigation2DServer::get_singleton()->region_set_map(F->get().region, RID());
-					}
-					q.navpoly_ids.clear();
+					q.clear_navpoly();
 				}
 
 				if (collision_parent) {
@@ -376,10 +382,7 @@ void TileMap::update_dirty_quadrants() {
 		int shape_idx = 0;
 
 		if (navigation) {
-			for (Map<PosKey, Quadrant::NavPoly>::Element *E = q.navpoly_ids.front(); E; E = E->next()) {
-				Navigation2DServer::get_singleton()->region_set_map(E->get().region, RID());
-			}
-			q.navpoly_ids.clear();
+			q.clear_navpoly();
 		}
 
 		for (Map<PosKey, Quadrant::Occluder>::Element *E = q.occluder_instances.front(); E; E = E->next()) {
@@ -816,10 +819,7 @@ void TileMap::_erase_quadrant(Map<PosKey, Quadrant>::Element *Q) {
 	}
 
 	if (navigation) {
-		for (Map<PosKey, Quadrant::NavPoly>::Element *E = q.navpoly_ids.front(); E; E = E->next()) {
-			Navigation2DServer::get_singleton()->region_set_map(E->get().region, RID());
-		}
-		q.navpoly_ids.clear();
+		q.clear_navpoly();
 	}
 
 	for (Map<PosKey, Quadrant::Occluder>::Element *E = q.occluder_instances.front(); E; E = E->next()) {

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -150,6 +150,8 @@ private:
 
 		VSet<PosKey> cells;
 
+		void clear_navpoly();
+
 		void operator=(const Quadrant &q) {
 			pos = q.pos;
 			canvas_items = q.canvas_items;


### PR DESCRIPTION
Fixes #60011

Regions were not freed before clearing `navpoly_ids`.