### PR TITLE
OpenXR: catch null profile_def causing crash on startup

### DIFF
--- a/modules/openxr/editor/openxr_interaction_profile_editor.cpp
+++ b/modules/openxr/editor/openxr_interaction_profile_editor.cpp
@@ -209,6 +209,8 @@ void OpenXRInteractionProfileEditor::_add_io_path(VBoxContainer *p_container, co
 }
 
 void OpenXRInteractionProfileEditor::_update_interaction_profile() {
+	ERR_FAIL_NULL(profile_def);
+
 	// out with the old...
 	while (main_hb->get_child_count() > 0) {
 		memdelete(main_hb->get_child(0));


### PR DESCRIPTION
Catch null profile_def crash on project startup utilizing openxr action map, reproduced by starting godot4 openxr demo.

Simplified from: https://github.com/godotengine/godot/pull/60014#issue-1197028266 which added too much. Profile implementations are better handled by: https://github.com/godotengine/godot/pull/59940#issue-1194587015 