### PR TITLE
Changed print_line macro to a function

### DIFF
--- a/core/string/print_string.h
+++ b/core/string/print_string.h
@@ -61,6 +61,14 @@ extern bool _print_error_enabled;
 extern void __print_line(String p_string);
 extern void print_error(String p_string);
 extern void print_verbose(String p_string);
-#define print_line(...) __print_line(stringify_variants(__VA_ARGS__))
+
+inline void print_line(Variant v) {
+	__print_line(stringify_variants(v));
+}
+
+template <typename... Args>
+void print_line(Variant p_var, Args... p_args) {
+	__print_line(stringify_variants(p_var, p_args...));
+}
 
 #endif // PRINT_STRING_H


### PR DESCRIPTION
Before you could not name or call anything else "print_line".