### PR TITLE
Allow TreeItem nodes to toggle visibility

### DIFF
--- a/doc/classes/TreeItem.xml
+++ b/doc/classes/TreeItem.xml
@@ -687,6 +687,10 @@
 		<member name="disable_folding" type="bool" setter="set_disable_folding" getter="is_folding_disabled">
 			If [code]true[/code], folding is disabled for this TreeItem.
 		</member>
+		<member name="visible" type="bool" setter="set_visible" getter="is_visible">
+			If [code]true[/code], the [TreeItem] is visible (default).
+			Note that if a [TreeItem] is set to not be visible, none of its children will be visible either.
+		</member>
 	</members>
 	<constants>
 		<constant name="CELL_MODE_STRING" value="0" enum="TreeCellMode">

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -124,6 +124,7 @@ private:
 	Vector<Cell> cells;
 
 	bool collapsed = false; // won't show children
+	bool visible = true;
 	bool disable_folding = false;
 	int custom_min_height = 0;
 
@@ -209,6 +210,9 @@ private:
 	void _propagate_check_through_children(int p_column, bool p_checked, bool p_emit_signal);
 	void _propagate_check_through_parents(int p_column, bool p_emit_signal);
 
+	TreeItem *_get_prev_visible(bool p_wrap = false);
+	TreeItem *_get_next_visible(bool p_wrap = false);
+
 public:
 	void set_text(int p_column, String p_text);
 	String get_text(int p_column) const;
@@ -273,6 +277,9 @@ public:
 	void set_collapsed(bool p_collapsed);
 	bool is_collapsed();
 
+	void set_visible(bool p_visible);
+	bool is_visible();
+
 	void uncollapse_tree();
 
 	void set_custom_minimum_height(int p_height);
@@ -335,6 +342,7 @@ public:
 	TreeItem *get_next_visible(bool p_wrap = false);
 
 	TreeItem *get_child(int p_idx);
+	int get_visible_child_count();
 	int get_child_count();
 	Array get_children();
 	int get_index();


### PR DESCRIPTION
closes https://github.com/godotengine/godot-proposals/issues/4309

I have attached an example godot project (it's pretty lazy and dirty without some optimisations but it's simply to show how the functionality works).

~[filtered_tree.zip](https://github.com/godotengine/godot/files/8456769/filtered_tree.zip)~
[filtered_tree2.zip](https://github.com/godotengine/godot/files/8602910/filtered_tree2.zip)


As far as I can see for testing, the functionality works really nicely. One thing that may be confusing for people using the property can be explained by an example:

Let's say I have a Tree with TreeItem's as follows (assuming a hidden root, and everything is current expanded):

Fruits
├─ apple
└─ pear
Vegetables
└─ cucumber

If I set `apple` to be invisible then it will not be drawn, and everything else will.
If I then set `Fruits` to be invisble then that branch will not be drawn.
If I then set `Fruits` to be visible I'd expect it to be drawn again and same with `pear`, but not apple.
This is how it will currently work, however, if I checked `pear.visible` when `Fruits.visible = false`, then it will be `true` since I am not propagating the value to children (so that if a parent TreeItem is made visible again, it doesn't cause unintentded changes of state of child TreeItems.

This could be slightly confusing to users, however it could be potentially clarified by documentation, or potentially have the `is_visible()` getter return a computed value based on the visibility of the parent(s).
Very open to discussion and suggestions regarding these points 😄 