### PR TITLE
Add dithering to ProceduralSkyMaterial to combat banding

### DIFF
--- a/doc/classes/PhysicalSkyMaterial.xml
+++ b/doc/classes/PhysicalSkyMaterial.xml
@@ -12,7 +12,7 @@
 	</tutorials>
 	<members>
 		<member name="dither_strength" type="float" setter="set_dither_strength" getter="get_dither_strength" default="1.0">
-			Sets the amount of dithering to use. Dithering helps reduce banding that appears from the smooth changes in color in the sky. Use the lowest value possible, higher amounts may add fuzziness to the sky.
+			The amount of dithering to use. Dithering helps reduce banding that appears from the smooth changes in color in the sky. Use the lowest value possible for your given sky settings, as higher amounts may add fuzziness to the sky.
 		</member>
 		<member name="exposure" type="float" setter="set_exposure" getter="get_exposure" default="0.1">
 			Sets the exposure of the sky. Higher exposure values make the entire sky brighter.

--- a/doc/classes/ProceduralSkyMaterial.xml
+++ b/doc/classes/ProceduralSkyMaterial.xml
@@ -11,6 +11,9 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="dither_strength" type="float" setter="set_dither_strength" getter="get_dither_strength" default="1.0">
+			The amount of dithering to use. Dithering helps reduce banding that appears from the smooth changes in color in the sky. Use the lowest value possible for your given sky settings, as higher amounts may add fuzziness to the sky.
+		</member>
 		<member name="ground_bottom_color" type="Color" setter="set_ground_bottom_color" getter="get_ground_bottom_color" default="Color(0.2, 0.169, 0.133, 1)">
 			Color of the ground at the bottom. Blends with [member ground_horizon_color].
 		</member>

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -52,6 +52,7 @@ private:
 
 	float sun_angle_max;
 	float sun_curve;
+	float dither_strength;
 
 	static Mutex shader_mutex;
 	static RID shader;
@@ -97,6 +98,9 @@ public:
 
 	void set_sun_curve(float p_curve);
 	float get_sun_curve() const;
+
+	void set_dither_strength(float p_dither_strength);
+	float get_dither_strength() const;
 
 	virtual Shader::Mode get_shader_mode() const override;
 	virtual RID get_shader_rid() const override;


### PR DESCRIPTION
Dithering was already present in PhysicalSkyMaterial. This brings it to ProceduralSkyMaterial as well, with the same algorithm and default intensity.

This could be backported to `3.x` if desired, although dithering will have to be done on the CPU, which is slower.

## Preview

*Click to view at full size, then click again to view at 100% zoom. The images **must** be viewed at 100% zoom for a fair comparison.*

### Dither Strength = 0.0 (previous behavior)

![2022-04-09_18 22 01](https://user-images.githubusercontent.com/180032/162582677-faa07e2f-ce8d-4d82-b3a4-16b42fb3a3a9.png)

![2022-04-09_18 17 48](https://user-images.githubusercontent.com/180032/162582691-fed2737e-3661-4914-a2ba-5f0cc64298a4.png)

### Dither Strength = 1.0 (new default)

![2022-04-09_18 22 08](https://user-images.githubusercontent.com/180032/162582679-a7e89568-d592-4d37-9361-fb416fbc11c6.png)

![2022-04-09_18 17 58](https://user-images.githubusercontent.com/180032/162582694-2052016f-6924-4cbc-b23b-25636ef5b5eb.png)

