### PR TITLE
Redesign InputEvent editor and fix `Window.popup_centered()` rect calculation.

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -589,8 +589,6 @@ void InputEventConfigurationDialog::_notification(int p_what) {
 			icon_cache.joypad_button = get_theme_icon(SNAME("JoyButton"), SNAME("EditorIcons"));
 			icon_cache.joypad_axis = get_theme_icon(SNAME("JoyAxis"), SNAME("EditorIcons"));
 
-			mouse_detection_rect->set_color(get_theme_color(SNAME("dark_color_2"), SNAME("Editor")));
-
 			_update_input_list();
 		} break;
 	}
@@ -624,7 +622,7 @@ void InputEventConfigurationDialog::popup_and_configure(const Ref<InputEvent> &p
 		device_id_option->select(0);
 	}
 
-	popup_centered();
+	popup_centered(Size2(0, 400) * EDSCALE);
 }
 
 Ref<InputEvent> InputEventConfigurationDialog::get_event() const {
@@ -656,8 +654,8 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	event_as_text = memnew(Label);
 	event_as_text->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
 	vb->add_child(event_as_text);
-	// Mouse button detection rect (Mouse button event outside this ColorRect will be ignored)
-	mouse_detection_rect = memnew(ColorRect);
+	// Mouse button detection rect (Mouse button event outside this rect will be ignored)
+	mouse_detection_rect = memnew(Panel);
 	mouse_detection_rect->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	vb->add_child(mouse_detection_rect);
 	tab_container->add_child(vb);
@@ -1171,7 +1169,7 @@ void ActionMapEditor::update_action_list(const Vector<ActionInfo> &p_action_info
 
 void ActionMapEditor::show_message(const String &p_message) {
 	message->set_text(p_message);
-	message->popup_centered(Size2(300, 100) * EDSCALE);
+	message->popup_centered();
 }
 
 void ActionMapEditor::use_external_search_box(LineEdit *p_searchbox) {

--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -67,7 +67,7 @@ private:
 
 	// Listening for input
 	Label *event_as_text = nullptr;
-	ColorRect *mouse_detection_rect = nullptr;
+	Panel *mouse_detection_rect = nullptr;
 
 	// List of All Key/Mouse/Joypad input options.
 	int allowed_input_types;

--- a/editor/plugins/input_event_editor_plugin.cpp
+++ b/editor/plugins/input_event_editor_plugin.cpp
@@ -33,6 +33,15 @@
 void InputEventConfigContainer::_bind_methods() {
 }
 
+void InputEventConfigContainer::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			open_config_button->set_icon(get_theme_icon(SNAME("Edit"), SNAME("EditorIcons")));
+		} break;
+	}
+}
+
 void InputEventConfigContainer::_configure_pressed() {
 	config_dialog->popup_and_configure(input_event);
 }
@@ -45,12 +54,6 @@ void InputEventConfigContainer::_config_dialog_confirmed() {
 	Ref<InputEvent> ie = config_dialog->get_event();
 	input_event->copy_from(ie);
 	_event_changed();
-}
-
-Size2 InputEventConfigContainer::get_minimum_size() const {
-	// Don't bother with a minimum x size for the control - we don't want the inspector
-	// to jump in size if a long text is placed in the label (e.g. Joypad Axis description)
-	return Size2(0, HBoxContainer::get_minimum_size().y);
 }
 
 void InputEventConfigContainer::set_event(const Ref<InputEvent> &p_event) {
@@ -75,28 +78,25 @@ void InputEventConfigContainer::set_event(const Ref<InputEvent> &p_event) {
 }
 
 InputEventConfigContainer::InputEventConfigContainer() {
-	MarginContainer *mc = memnew(MarginContainer);
-	mc->add_theme_constant_override("margin_left", 10);
-	mc->add_theme_constant_override("margin_right", 10);
-	mc->add_theme_constant_override("margin_top", 10);
-	mc->add_theme_constant_override("margin_bottom", 10);
-	add_child(mc);
-
-	HBoxContainer *hb = memnew(HBoxContainer);
-	mc->add_child(hb);
+	input_event_text = memnew(Label);
+	input_event_text->set_h_size_flags(SIZE_EXPAND_FILL);
+	input_event_text->set_autowrap_mode(Label::AutowrapMode::AUTOWRAP_WORD_SMART);
+	input_event_text->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	add_child(input_event_text);
 
 	open_config_button = memnew(Button);
 	open_config_button->set_text(TTR("Configure"));
 	open_config_button->connect("pressed", callable_mp(this, &InputEventConfigContainer::_configure_pressed));
-	hb->add_child(open_config_button);
+	add_child(open_config_button);
 
-	input_event_text = memnew(Label);
-	hb->add_child(input_event_text);
+	add_child(memnew(Control));
 
 	config_dialog = memnew(InputEventConfigurationDialog);
 	config_dialog->connect("confirmed", callable_mp(this, &InputEventConfigContainer::_config_dialog_confirmed));
 	add_child(config_dialog);
 }
+
+///////////////////////
 
 bool EditorInspectorPluginInputEvent::can_handle(Object *p_object) {
 	Ref<InputEventKey> k = Ref<InputEventKey>(p_object);
@@ -114,6 +114,8 @@ void EditorInspectorPluginInputEvent::parse_begin(Object *p_object) {
 	picker_controls->set_event(ie);
 	add_custom_control(picker_controls);
 }
+
+///////////////////////
 
 InputEventEditorPlugin::InputEventEditorPlugin() {
 	Ref<EditorInspectorPluginInputEvent> plugin;

--- a/editor/plugins/input_event_editor_plugin.h
+++ b/editor/plugins/input_event_editor_plugin.h
@@ -35,8 +35,8 @@
 #include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 
-class InputEventConfigContainer : public HBoxContainer {
-	GDCLASS(InputEventConfigContainer, HBoxContainer);
+class InputEventConfigContainer : public VBoxContainer {
+	GDCLASS(InputEventConfigContainer, VBoxContainer);
 
 	Label *input_event_text = nullptr;
 	Button *open_config_button = nullptr;
@@ -50,10 +50,10 @@ class InputEventConfigContainer : public HBoxContainer {
 	void _event_changed();
 
 protected:
+	void _notification(int p_what);
 	static void _bind_methods();
 
 public:
-	virtual Size2 get_minimum_size() const override;
 	void set_event(const Ref<InputEvent> &p_event);
 
 	InputEventConfigContainer();

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1066,11 +1066,9 @@ void Window::popup_centered(const Size2i &p_minsize) {
 	}
 
 	Rect2i popup_rect;
-	if (p_minsize == Size2i()) {
-		popup_rect.size = _get_contents_minimum_size();
-	} else {
-		popup_rect.size = p_minsize;
-	}
+	Size2 contents_minsize = _get_contents_minimum_size();
+	popup_rect.size.x = MAX(p_minsize.x, contents_minsize.x);
+	popup_rect.size.y = MAX(p_minsize.y, contents_minsize.y);
 	popup_rect.position = parent_rect.position + (parent_rect.size - popup_rect.size) / 2;
 
 	popup(popup_rect);


### PR DESCRIPTION
- InputEvent editor: use vertical layout and add text wrapping
- InputEvent configuration popup: Increase the default window height so that the input list is usable
- Fix Input Map warning message size
- Fix `Window.popup_centered()` rect calculation when the size is less than the window's minimum size
  - Before, unless the requested size is `(0, 0)`, it would use the requested size even if it was smaller than the window's minimum size. This resulted in windows not being centered when the requested size is less than the window's min size because its size would be immediately updated after opening. Now, it takes the max of the window's min size and the requested size, which means windows will always be centered when using `Window.popup_centered()`.
  - This also allows for defining a size for only one axis; e.g. `Window.popup_centered(Vector2(0, 500))` will now be centered horizontally.

| Before | After |
:---:|:---:
| ![image](https://user-images.githubusercontent.com/67974470/162591777-fa446cf2-3f64-4410-945a-9eeafeb82a23.png) | ![image](https://user-images.githubusercontent.com/67974470/162591732-0314f5cf-9a79-4901-8f52-b6c906eb3253.png) |
| ![image](https://user-images.githubusercontent.com/67974470/162591784-9bf0e782-32d7-41ea-9931-2537fb18ada6.png) | ![image](https://user-images.githubusercontent.com/67974470/162591747-9b46b638-a187-4600-93d8-333cab4bc758.png) |
| ![image](https://user-images.githubusercontent.com/67974470/162591950-c5a1ef87-b2b5-4665-a9bd-b26960c43586.png) | ![image](https://user-images.githubusercontent.com/67974470/163024693-bb78599b-fdf4-45b2-8371-3e7244ce66dc.png) |

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/53382