### PR TITLE
Rearrange TriangleMesh function to workaround MSVC compiler bug

### DIFF
--- a/core/math/triangle_mesh.cpp
+++ b/core/math/triangle_mesh.cpp
@@ -231,14 +231,14 @@ Vector3 TriangleMesh::get_area_normal(const AABB &p_aabb) const {
 			}
 			case VISIT_LEFT_BIT: {
 				stack[level] = (VISIT_RIGHT_BIT << VISITED_BIT_SHIFT) | node;
-				stack[level + 1] = b.left | TEST_AABB_BIT;
 				level++;
+				stack[level] = b.left | TEST_AABB_BIT;
 				continue;
 			}
 			case VISIT_RIGHT_BIT: {
 				stack[level] = (VISIT_DONE_BIT << VISITED_BIT_SHIFT) | node;
-				stack[level + 1] = b.right | TEST_AABB_BIT;
 				level++;
+				stack[level] = b.right | TEST_AABB_BIT;
 				continue;
 			}
 			case VISIT_DONE_BIT: {
@@ -331,14 +331,14 @@ bool TriangleMesh::intersect_segment(const Vector3 &p_begin, const Vector3 &p_en
 			}
 			case VISIT_LEFT_BIT: {
 				stack[level] = (VISIT_RIGHT_BIT << VISITED_BIT_SHIFT) | node;
-				stack[level + 1] = b.left | TEST_AABB_BIT;
 				level++;
+				stack[level] = b.left | TEST_AABB_BIT;
 				continue;
 			}
 			case VISIT_RIGHT_BIT: {
 				stack[level] = (VISIT_DONE_BIT << VISITED_BIT_SHIFT) | node;
-				stack[level + 1] = b.right | TEST_AABB_BIT;
 				level++;
+				stack[level] = b.right | TEST_AABB_BIT;
 				continue;
 			}
 			case VISIT_DONE_BIT: {
@@ -431,14 +431,14 @@ bool TriangleMesh::intersect_ray(const Vector3 &p_begin, const Vector3 &p_dir, V
 			}
 			case VISIT_LEFT_BIT: {
 				stack[level] = (VISIT_RIGHT_BIT << VISITED_BIT_SHIFT) | node;
-				stack[level + 1] = b.left | TEST_AABB_BIT;
 				level++;
+				stack[level] = b.left | TEST_AABB_BIT;
 				continue;
 			}
 			case VISIT_RIGHT_BIT: {
 				stack[level] = (VISIT_DONE_BIT << VISITED_BIT_SHIFT) | node;
-				stack[level + 1] = b.right | TEST_AABB_BIT;
 				level++;
+				stack[level] = b.right | TEST_AABB_BIT;
 				continue;
 			}
 			case VISIT_DONE_BIT: {
@@ -551,14 +551,14 @@ bool TriangleMesh::intersect_convex_shape(const Plane *p_planes, int p_plane_cou
 			}
 			case VISIT_LEFT_BIT: {
 				stack[level] = (VISIT_RIGHT_BIT << VISITED_BIT_SHIFT) | node;
-				stack[level + 1] = b.left | TEST_AABB_BIT;
 				level++;
+				stack[level] = b.left | TEST_AABB_BIT;
 				continue;
 			}
 			case VISIT_RIGHT_BIT: {
 				stack[level] = (VISIT_DONE_BIT << VISITED_BIT_SHIFT) | node;
-				stack[level + 1] = b.right | TEST_AABB_BIT;
 				level++;
+				stack[level] = b.right | TEST_AABB_BIT;
 				continue;
 			}
 			case VISIT_DONE_BIT: {
@@ -644,14 +644,14 @@ bool TriangleMesh::inside_convex_shape(const Plane *p_planes, int p_plane_count,
 			}
 			case VISIT_LEFT_BIT: {
 				stack[level] = (VISIT_RIGHT_BIT << VISITED_BIT_SHIFT) | node;
-				stack[level + 1] = b.left | TEST_AABB_BIT;
 				level++;
+				stack[level] = b.left | TEST_AABB_BIT;
 				continue;
 			}
 			case VISIT_RIGHT_BIT: {
 				stack[level] = (VISIT_DONE_BIT << VISITED_BIT_SHIFT) | node;
-				stack[level + 1] = b.right | TEST_AABB_BIT;
 				level++;
+				stack[level] = b.right | TEST_AABB_BIT;
 				continue;
 			}
 			case VISIT_DONE_BIT: {


### PR DESCRIPTION
Closes #59964

So, this bug is a bit weird. One the surface, there should be nothing wrong we the way the code is written other than it perhaps *looking* a little clunky, but it seems that raycast collision tests totally break when compiling with MSVC with release compiler optimisations (and maybe LLVM too; I'm still looking into this). Changing it to this appears to make it work, whereas previous you couldn't click-select nodes in the 3D viewport. I only noticed the issue with raycast tests, but I added the same change to all the functions for consistency and safety.

I kind of want to look into this more including comparing assembly output since this could be a good test case for a compiler bugs, and the implication of other bugs like this popping up feels concerning.

While this specific line appears to be the culprit for this bug, there are other potentially concerning aspects of these functions including what appears to the stack array leaking, and the fact that while I don't think it *should* be possible to overrun the stack given how the BVH is generated, it still gives warnings to the effect of potential stack overruns.