### PR TITLE
Improvements to files_dropped signal

### DIFF
--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -349,6 +349,15 @@
 			<argument index="0" name="files" type="PackedStringArray" />
 			<description>
 				Emitted when files are dragged from the OS file manager and dropped in the game window. The argument is a list of file paths.
+				Note that this method only works with non-embedded windows, i.e. the main window and [Window]-derived nodes when [member Viewport.gui_embed_subwindows] is disabled in the main viewport.
+				Example usage:
+				[codeblock]
+				func _ready():
+				    get_viewport().files_dropped.connect(on_files_dropped)
+
+				func on_files_dropped(files):
+				    print(files)
+				[/codeblock]
 			</description>
 		</signal>
 		<signal name="focus_entered">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5478,7 +5478,7 @@ void EditorNode::_global_menu_new_window(const Variant &p_tag) {
 	}
 }
 
-void EditorNode::_dropped_files(const Vector<String> &p_files, int p_screen) {
+void EditorNode::_dropped_files(const Vector<String> &p_files) {
 	String to_path = ProjectSettings::get_singleton()->globalize_path(FileSystemDock::get_singleton()->get_selected_path());
 
 	_add_dropped_files_recursive(p_files, to_path);

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -575,7 +575,7 @@ private:
 	void _open_recent_scene(int p_idx);
 	void _global_menu_scene(const Variant &p_tag);
 	void _global_menu_new_window(const Variant &p_tag);
-	void _dropped_files(const Vector<String> &p_files, int p_screen);
+	void _dropped_files(const Vector<String> &p_files);
 	void _add_dropped_files_recursive(const Vector<String> &p_files, String to_path);
 
 	void _update_from_settings();

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2402,7 +2402,7 @@ void ProjectManager::_install_project(const String &p_zip_path, const String &p_
 	npdialog->show_dialog();
 }
 
-void ProjectManager::_files_dropped(PackedStringArray p_files, int p_screen) {
+void ProjectManager::_files_dropped(PackedStringArray p_files) {
 	if (p_files.size() == 1 && p_files[0].ends_with(".zip")) {
 		const String file = p_files[0].get_file();
 		_install_project(p_files[0], file.substr(0, file.length() - 4).capitalize());

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -127,7 +127,7 @@ class ProjectManager : public Control {
 
 	void _dim_window();
 	virtual void shortcut_input(const Ref<InputEvent> &p_ev) override;
-	void _files_dropped(PackedStringArray p_files, int p_screen);
+	void _files_dropped(PackedStringArray p_files);
 
 	void _version_button_pressed();
 	void _on_order_option_changed(int p_idx);

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -981,7 +981,7 @@ void Window::_window_input_text(const String &p_text) {
 }
 
 void Window::_window_drop_files(const Vector<String> &p_files) {
-	emit_signal(SNAME("files_dropped"), p_files, current_screen);
+	emit_signal(SNAME("files_dropped"), p_files);
 }
 
 Viewport *Window::get_parent_viewport() const {


### PR DESCRIPTION
Closes #59251
- removed the useless `current_screen` argument from the signal (it's useless, and if you want it anyway just bind the window to your connection)
- improved docs, better stating how the signal works and adding an example