### PR TITLE
Make LineEdit's default max length 10,000

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -203,7 +203,7 @@
 		<member name="language" type="String" setter="set_language" getter="get_language" default="&quot;&quot;">
 			Language code used for line-breaking and text shaping algorithms, if left empty current locale is used instead.
 		</member>
-		<member name="max_length" type="int" setter="set_max_length" getter="get_max_length" default="0">
+		<member name="max_length" type="int" setter="set_max_length" getter="get_max_length" default="10000">
 			Maximum amount of characters that can be entered inside the [LineEdit]. If [code]0[/code], there is no limit.
 			When a limit is defined, characters that would exceed [member max_length] are truncated. This happens both for existing [member text] contents when setting the max length, or for new text inserted in the [LineEdit], including pasting. If any input text is truncated, the [signal text_change_rejected] signal is emitted with the truncated substring as parameter.
 			[b]Example:[/b]

--- a/scene/gui/line_edit.h
+++ b/scene/gui/line_edit.h
@@ -100,7 +100,7 @@ private:
 
 	int caret_column = 0;
 	int scroll_offset = 0;
-	int max_length = 0; // 0 for no maximum.
+	int max_length = 10000; // 10,000 so it's not too big by default
 
 	Dictionary opentype_features;
 	String language;


### PR DESCRIPTION
This will reduce LineEdit's default maximum size from unlimited to 10,000. This should be enough for the vast majority of people while also not causing the engine to become unresponsive.

Resolves: #60107
