### PR TITLE
Add a setting to disable PCSS for directional and point light shadows

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1849,6 +1849,10 @@
 		<member name="rendering/shadows/directional_shadow/soft_shadow_quality.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/shadows/directional_shadow/soft_shadow_quality] on mobile devices, due to performance concerns or driver support.
 		</member>
+		<member name="rendering/shadows/directional_shadow/use_pcss" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], enables percentage-closer soft shadows for [DirectionalLight3D]s whose [member Light3D.light_angular_distance] is greater than [code]0.0[/code] (exclusive). PCSS makes shadows progressively blurrier as the distance between the object casting the shadow and the one receiving the shadow increases, which results in more realistic shadow appearance. However, PCSS has a significant cost on the GPU.
+			[b]Note:[/b] Disabling PCSS does not disable other effects related to [member Light3D.light_angular_distance] (such as the size of the sun increasing in the default sky materials).
+		</member>
 		<member name="rendering/shadows/shadow_atlas/16_bits" type="bool" setter="" getter="" default="true">
 		</member>
 		<member name="rendering/shadows/shadow_atlas/quadrant_0_subdiv" type="int" setter="" getter="" default="2">
@@ -1876,6 +1880,10 @@
 		</member>
 		<member name="rendering/shadows/shadows/soft_shadow_quality.mobile" type="int" setter="" getter="" default="0">
 			Lower-end override for [member rendering/shadows/shadows/soft_shadow_quality] on mobile devices, due to performance concerns or driver support.
+		</member>
+		<member name="rendering/shadows/shadows/use_pcss" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], enables percentage-closer soft shadows for [OmniLight3D]s and [SpotLight3D]s whose [member Light3D.light_size] is greater than [code]0.0[/code] (exclusive). PCSS makes shadows progressively blurrier as the distance between the object casting the shadow and the one receiving the shadow increases, which results in more realistic shadow appearance. However, PCSS has a significant cost on the GPU.
+			[b]Note:[/b] Disabling PCSS does not disable other effects related to [member Light3D.light_size] (such as the size of point lights increasing).
 		</member>
 		<member name="rendering/textures/decals/filter" type="int" setter="" getter="" default="3">
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -895,6 +895,14 @@
 			<description>
 			</description>
 		</method>
+		<method name="directional_shadow_set_use_pcss">
+			<return type="void" />
+			<argument index="0" name="enable" type="bool" />
+			<description>
+				If [code]enable[/code] is [code]true[/code], enables percentage-closer soft shadows for [DirectionalLight3D]s whose [member Light3D.light_angular_distance] is greater than [code]0.0[/code] (exclusive). PCSS makes shadows progressively blurrier as the distance between the object casting the shadow and the one receiving the shadow increases, which results in more realistic shadow appearance. However, PCSS has a significant cost on the GPU.
+				[b]Note:[/b] Disabling PCSS does not disable other effects related to [member Light3D.light_angular_distance] (such as the size of the sun increasing in the default sky materials).
+			</description>
+		</method>
 		<method name="environment_bake_panorama">
 			<return type="Image" />
 			<argument index="0" name="environment" type="RID" />
@@ -2749,6 +2757,14 @@
 			<return type="void" />
 			<argument index="0" name="quality" type="int" enum="RenderingServer.ShadowQuality" />
 			<description>
+			</description>
+		</method>
+		<method name="shadows_set_use_pcss">
+			<return type="void" />
+			<argument index="0" name="enable" type="bool" />
+			<description>
+				If [code]enable[/code] is [code]true[/code], enables percentage-closer soft shadows for [OmniLight3D]s and [SpotLight3D]s whose [member Light3D.light_size] is greater than [code]0.0[/code] (exclusive). PCSS makes shadows progressively blurrier as the distance between the object casting the shadow and the one receiving the shadow increases, which results in more realistic shadow appearance. However, PCSS has a significant cost on the GPU.
+				[b]Note:[/b] Disabling PCSS does not disable other effects related to [member Light3D.light_size] (such as the size of point lights increasing).
 			</description>
 		</method>
 		<method name="skeleton_allocate_data">

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -303,7 +303,13 @@ void RasterizerSceneGLES3::camera_effects_set_custom_exposure(RID p_camera_effec
 void RasterizerSceneGLES3::shadows_quality_set(RS::ShadowQuality p_quality) {
 }
 
+void RasterizerSceneGLES3::shadows_set_use_pcss(bool p_enable) {
+}
+
 void RasterizerSceneGLES3::directional_shadow_quality_set(RS::ShadowQuality p_quality) {
+}
+
+void RasterizerSceneGLES3::directional_shadow_set_use_pcss(bool p_enable) {
 }
 
 RID RasterizerSceneGLES3::light_instance_create(RID p_light) {

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -156,7 +156,9 @@ public:
 	void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) override;
 
 	void shadows_quality_set(RS::ShadowQuality p_quality) override;
+	void shadows_set_use_pcss(bool p_enable) override;
 	void directional_shadow_quality_set(RS::ShadowQuality p_quality) override;
+	void directional_shadow_set_use_pcss(bool p_enable) override;
 
 	RID light_instance_create(RID p_light) override;
 	void light_instance_set_transform(RID p_light_instance, const Transform3D &p_transform) override;

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -514,8 +514,12 @@ void EditorNode::_update_from_settings() {
 
 	RS::ShadowQuality shadows_quality = RS::ShadowQuality(int(GLOBAL_GET("rendering/shadows/shadows/soft_shadow_quality")));
 	RS::get_singleton()->shadows_quality_set(shadows_quality);
+	bool shadows_use_pcss = bool(GLOBAL_GET("rendering/shadows/shadows/use_pcss"));
+	RS::get_singleton()->shadows_set_use_pcss(shadows_use_pcss);
 	RS::ShadowQuality directional_shadow_quality = RS::ShadowQuality(int(GLOBAL_GET("rendering/shadows/directional_shadow/soft_shadow_quality")));
 	RS::get_singleton()->directional_shadow_quality_set(directional_shadow_quality);
+	bool directional_shadow_use_pcss = bool(GLOBAL_GET("rendering/shadows/directional_shadow/use_pcss"));
+	RS::get_singleton()->directional_shadow_set_use_pcss(directional_shadow_use_pcss);
 	float probe_update_speed = GLOBAL_GET("rendering/lightmapping/probe_capture/update_speed");
 	RS::get_singleton()->lightmap_set_probe_capture_update_speed(probe_update_speed);
 	RS::EnvironmentSDFGIFramesToConverge frames_to_converge = RS::EnvironmentSDFGIFramesToConverge(int(GLOBAL_GET("rendering/global_illumination/sdfgi/frames_to_converge")));

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -144,7 +144,9 @@ public:
 	void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) override {}
 
 	void shadows_quality_set(RS::ShadowQuality p_quality) override {}
+	void shadows_set_use_pcss(bool p_enable) override {}
 	void directional_shadow_quality_set(RS::ShadowQuality p_quality) override {}
+	void directional_shadow_set_use_pcss(bool p_enable) override {}
 
 	RID light_instance_create(RID p_light) override { return RID(); }
 	void light_instance_set_transform(RID p_light_instance, const Transform3D &p_transform) override {}

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -313,6 +313,8 @@ private:
 	RS::ShadowQuality directional_shadow_quality = RS::SHADOW_QUALITY_MAX;
 	float shadows_quality_radius = 1.0;
 	float directional_shadow_quality_radius = 1.0;
+	bool shadows_use_pcss = true;
+	bool directional_shadow_use_pcss = true;
 
 	float *directional_penumbra_shadow_kernel = nullptr;
 	float *directional_soft_shadow_kernel = nullptr;
@@ -1432,7 +1434,9 @@ public:
 	virtual void sub_surface_scattering_set_scale(float p_scale, float p_depth_scale) override;
 
 	virtual void shadows_quality_set(RS::ShadowQuality p_quality) override;
+	virtual void shadows_set_use_pcss(bool p_enable) override;
 	virtual void directional_shadow_quality_set(RS::ShadowQuality p_quality) override;
+	virtual void directional_shadow_set_use_pcss(bool p_enable) override;
 
 	virtual void decals_set_filter(RS::DecalFilter p_filter) override;
 	virtual void light_projectors_set_filter(RS::LightProjectorFilter p_filter) override;

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -184,7 +184,9 @@ public:
 	virtual void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) = 0;
 
 	virtual void shadows_quality_set(RS::ShadowQuality p_quality) = 0;
+	virtual void shadows_set_use_pcss(bool p_enable) = 0;
 	virtual void directional_shadow_quality_set(RS::ShadowQuality p_quality) = 0;
+	virtual void directional_shadow_set_use_pcss(bool p_enable) = 0;
 
 	virtual RID shadow_atlas_create() = 0;
 	virtual void shadow_atlas_set_size(RID p_atlas, int p_size, bool p_use_16_bits = true) = 0;

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1148,7 +1148,9 @@ public:
 	PASS3(camera_effects_set_custom_exposure, RID, bool, float)
 
 	PASS1(shadows_quality_set, RS::ShadowQuality)
+	PASS1(shadows_set_use_pcss, bool)
 	PASS1(directional_shadow_quality_set, RS::ShadowQuality)
+	PASS1(directional_shadow_set_use_pcss, bool)
 
 	PASS2(sdfgi_set_debug_probe_select, const Vector3 &, const Vector3 &)
 

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -167,7 +167,9 @@ public:
 	virtual void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) = 0;
 
 	virtual void shadows_quality_set(RS::ShadowQuality p_quality) = 0;
+	virtual void shadows_set_use_pcss(bool p_enable) = 0;
 	virtual void directional_shadow_quality_set(RS::ShadowQuality p_quality) = 0;
+	virtual void directional_shadow_set_use_pcss(bool p_enable) = 0;
 
 	virtual RID light_instance_create(RID p_light) = 0;
 	virtual void light_instance_set_transform(RID p_light_instance, const Transform3D &p_transform) = 0;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -696,7 +696,9 @@ public:
 	FUNC3(camera_effects_set_custom_exposure, RID, bool, float)
 
 	FUNC1(shadows_quality_set, ShadowQuality);
+	FUNC1(shadows_set_use_pcss, bool);
 	FUNC1(directional_shadow_quality_set, ShadowQuality);
+	FUNC1(directional_shadow_set_use_pcss, bool);
 	FUNC1(decals_set_filter, RS::DecalFilter);
 	FUNC1(light_projectors_set_filter, RS::LightProjectorFilter);
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -1940,7 +1940,9 @@ void RenderingServer::_bind_methods() {
 	BIND_ENUM_CONSTANT(LIGHT_DIRECTIONAL_SKY_MODE_SKY_ONLY);
 
 	ClassDB::bind_method(D_METHOD("shadows_quality_set", "quality"), &RenderingServer::shadows_quality_set);
+	ClassDB::bind_method(D_METHOD("shadows_set_use_pcss", "enable"), &RenderingServer::shadows_set_use_pcss);
 	ClassDB::bind_method(D_METHOD("directional_shadow_quality_set", "quality"), &RenderingServer::directional_shadow_quality_set);
+	ClassDB::bind_method(D_METHOD("directional_shadow_set_use_pcss", "enable"), &RenderingServer::directional_shadow_set_use_pcss);
 	ClassDB::bind_method(D_METHOD("directional_shadow_atlas_set_size", "size", "is_16bits"), &RenderingServer::directional_shadow_atlas_set_size);
 
 	BIND_ENUM_CONSTANT(SHADOW_QUALITY_HARD);
@@ -2836,11 +2838,13 @@ RenderingServer::RenderingServer() {
 	GLOBAL_DEF("rendering/shadows/directional_shadow/soft_shadow_quality", 2);
 	GLOBAL_DEF("rendering/shadows/directional_shadow/soft_shadow_quality.mobile", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/directional_shadow/soft_shadow_quality", PropertyInfo(Variant::INT, "rendering/shadows/directional_shadow/soft_shadow_quality", PROPERTY_HINT_ENUM, "Hard (Fastest),Soft Very Low (Faster),Soft Low (Fast),Soft Medium (Average),Soft High (Slow),Soft Ultra (Slowest)"));
+	GLOBAL_DEF("rendering/shadows/directional_shadow/use_pcss", true);
 	GLOBAL_DEF("rendering/shadows/directional_shadow/16_bits", true);
 
 	GLOBAL_DEF("rendering/shadows/shadows/soft_shadow_quality", 2);
 	GLOBAL_DEF("rendering/shadows/shadows/soft_shadow_quality.mobile", 0);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/shadows/shadows/soft_shadow_quality", PropertyInfo(Variant::INT, "rendering/shadows/shadows/soft_shadow_quality", PROPERTY_HINT_ENUM, "Hard (Fastest),Soft Very Low (Faster),Soft Low (Fast),Soft Medium (Average),Soft High (Slow),Soft Ultra (Slowest)"));
+	GLOBAL_DEF("rendering/shadows/shadows/use_pcss", true);
 
 	GLOBAL_DEF("rendering/2d/shadow_atlas/size", 2048);
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -492,7 +492,9 @@ public:
 	};
 
 	virtual void shadows_quality_set(ShadowQuality p_quality) = 0;
+	virtual void shadows_set_use_pcss(bool p_enable) = 0;
 	virtual void directional_shadow_quality_set(ShadowQuality p_quality) = 0;
+	virtual void directional_shadow_set_use_pcss(bool p_enable) = 0;
 
 	enum LightProjectorFilter {
 		LIGHT_PROJECTOR_FILTER_NEAREST,


### PR DESCRIPTION
Disabling PCSS improves performance significantly if shadowed lights with a size (or angular distance) greater than 0 are visible in the scene.

There are two caveats with this setting I didn't manage to fix so far:

- Increasing Angular Distance will worsen shadow rendering quality when PCSS is disabled. It's not really noticeable at reasonable angular distance values (1-3).
- When using a point light with size > 0.0, disabling PCSS does not fully restore rendering performance compared to a point light with size = 0.0.
  - Searching for `light->uses_softshadow` might be the solution, but I'd like to keep the changes to the *light* rendering itself when PCSS is disabled (while not changing *shadow* rendering).

Nonetheless, this PR still improves performance when disabling the settings.

**Note:** This PR doesn't address https://github.com/godotengine/godot/issues/55882, as removing the PCSS codepaths entirely from the mobile renderer should be done instead.

**Testing project:** [test_pcss.zip](https://github.com/godotengine/godot/files/8459996/test_pcss.zip)
