### PR TITLE
Make LineEdit's default max length 10,000 3.x

### DIFF
--- a/doc/classes/LineEdit.xml
+++ b/doc/classes/LineEdit.xml
@@ -131,7 +131,7 @@
 			If [code]true[/code], the [LineEdit] width will increase to stay longer than the [member text]. It will [b]not[/b] compress if the [member text] is shortened.
 		</member>
 		<member name="focus_mode" type="int" setter="set_focus_mode" getter="get_focus_mode" overrides="Control" enum="Control.FocusMode" default="2" />
-		<member name="max_length" type="int" setter="set_max_length" getter="get_max_length" default="0">
+		<member name="max_length" type="int" setter="set_max_length" getter="get_max_length" default="10000">
 			Maximum amount of characters that can be entered inside the [LineEdit]. If [code]0[/code], there is no limit.
 			When a limit is defined, characters that would exceed [member max_length] are truncated. This happens both for existing [member text] contents when setting the max length, or for new text inserted in the [LineEdit], including pasting. If any input text is truncated, the [signal text_change_rejected] signal is emitted with the truncated substring as parameter.
 			[b]Example:[/b]

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -2050,7 +2050,11 @@ LineEdit::LineEdit() {
 	cursor_pos = 0;
 	scroll_offset = 0;
 	window_has_focus = true;
-	max_length = 0;
+	if (&Engine::is_editor_hint) {
+		max_length = 10000;
+	} else {
+		max_length = 0;
+	}
 	pass = false;
 	secret_character = "*";
 	text_changed_dirty = false;


### PR DESCRIPTION
This will reduce LineEdit's default maximum size from unlimited to 10,000. This should be enough for the vast majority of people while also not causing the engine to become unresponsive.

This is the 3.x version of #60118
