### PR TITLE
Improve error messages when creating Images from code

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -1944,12 +1944,15 @@ Vector<uint8_t> Image::get_data() const {
 }
 
 void Image::create(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
-	ERR_FAIL_COND_MSG(p_width <= 0, "Image width must be greater than 0.");
-	ERR_FAIL_COND_MSG(p_height <= 0, "Image height must be greater than 0.");
-	ERR_FAIL_COND_MSG(p_width > MAX_WIDTH, "Image width cannot be greater than " + itos(MAX_WIDTH) + ".");
-	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT, "Image height cannot be greater than " + itos(MAX_HEIGHT) + ".");
-	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS, "Too many pixels for image, maximum is " + itos(MAX_PIXELS));
-	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, "Image format out of range, please see Image's Format enum.");
+	ERR_FAIL_COND_MSG(p_width <= 0, "The Image width specified (" + itos(p_width) + " pixels) must be greater than 0 pixels.");
+	ERR_FAIL_COND_MSG(p_height <= 0, "The Image height specified (" + itos(p_height) + " pixels) must be greater than 0 pixels.");
+	ERR_FAIL_COND_MSG(p_width > MAX_WIDTH,
+			"The Image width specified (" + itos(p_width) + " pixels) cannot be greater than " + itos(MAX_WIDTH) + "pixels.");
+	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT,
+			"The Image height specified (" + itos(p_height) + " pixels) cannot be greater than " + itos(MAX_HEIGHT) + "pixels.");
+	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS,
+			"Too many pixels for Image. Maximum is " + itos(MAX_WIDTH) + "x" + itos(MAX_HEIGHT) + " = " + itos(MAX_PIXELS) + "pixels.");
+	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, "The Image format specified (" + itos(p_format) + ") is out of range. See Image's Format enum.");
 
 	int mm = 0;
 	int size = _get_dst_image_size(p_width, p_height, p_format, mm, p_use_mipmaps ? -1 : 0);
@@ -1967,17 +1970,34 @@ void Image::create(int p_width, int p_height, bool p_use_mipmaps, Format p_forma
 }
 
 void Image::create(int p_width, int p_height, bool p_use_mipmaps, Format p_format, const Vector<uint8_t> &p_data) {
-	ERR_FAIL_COND_MSG(p_width <= 0, "Image width must be greater than 0.");
-	ERR_FAIL_COND_MSG(p_height <= 0, "Image height must be greater than 0.");
-	ERR_FAIL_COND_MSG(p_width > MAX_WIDTH, "Image width cannot be greater than " + itos(MAX_WIDTH) + ".");
-	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT, "Image height cannot be greater than " + itos(MAX_HEIGHT) + ".");
-	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS, "Too many pixels for image, maximum is " + itos(MAX_PIXELS));
-	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, "Image format out of range, please see Image's Format enum.");
+	ERR_FAIL_COND_MSG(p_width <= 0, "The Image width specified (" + itos(p_width) + " pixels) must be greater than 0 pixels.");
+	ERR_FAIL_COND_MSG(p_height <= 0, "The Image height specified (" + itos(p_height) + " pixels) must be greater than 0 pixels.");
+	ERR_FAIL_COND_MSG(p_width > MAX_WIDTH,
+			"The Image width specified (" + itos(p_width) + " pixels) cannot be greater than " + itos(MAX_WIDTH) + " pixels.");
+	ERR_FAIL_COND_MSG(p_height > MAX_HEIGHT,
+			"The Image height specified (" + itos(p_height) + " pixels) cannot be greater than " + itos(MAX_HEIGHT) + " pixels.");
+	ERR_FAIL_COND_MSG(p_width * p_height > MAX_PIXELS,
+			"Too many pixels for Image. Maximum is " + itos(MAX_WIDTH) + "x" + itos(MAX_HEIGHT) + " = " + itos(MAX_PIXELS) + "pixels .");
+	ERR_FAIL_INDEX_MSG(p_format, FORMAT_MAX, "The Image format specified (" + itos(p_format) + ") is out of range. See Image's Format enum.");
 
 	int mm;
 	int size = _get_dst_image_size(p_width, p_height, p_format, mm, p_use_mipmaps ? -1 : 0);
 
-	ERR_FAIL_COND_MSG(p_data.size() != size, "Expected data size of " + itos(size) + " bytes in Image::create(), got instead " + itos(p_data.size()) + " bytes.");
+	if (unlikely(p_data.size() != size)) {
+		String description_mipmaps;
+		if (p_use_mipmaps) {
+			const int num_mipmaps = get_image_required_mipmaps(p_width, p_height, p_format);
+			if (num_mipmaps != 1) {
+				description_mipmaps = vformat("with %d mipmaps", num_mipmaps);
+			} else {
+				description_mipmaps = "with 1 mipmap";
+			}
+		} else {
+			description_mipmaps = "without mipmaps";
+		}
+		const String description = vformat("%dx%dx%d (%s)", p_width, p_height, get_format_pixel_size(p_format), description_mipmaps);
+		ERR_FAIL_MSG(vformat("Expected Image data size of %s = %d bytes, got %d bytes instead.", description, size, p_data.size()));
+	}
 
 	height = p_height;
 	width = p_width;


### PR DESCRIPTION
The rationale behind the expected number of bytes is now displayed in clear (width, height, format, number of mipmaps expected if any).

Requested by @2shady4u :slightly_smiling_face:

## Preview

<details>
<summary>Testing script</summary>

```gdscript
extends Node2D


func _ready():
	var image = Image.new()
	var data = PackedByteArray()
	image.create_from_data(512, 512, false, Image.FORMAT_RGB8, data)

	var image2 = Image.new()
	image2.create_from_data(320, 200, true, Image.FORMAT_L8, data)
	
	var image_small = Image.new()
	image_small.create_from_data(2, 2, true, Image.FORMAT_RGBE9995, data)

	var image_large = Image.new()
	image_large.create(16385, 1, false, Image.FORMAT_L8)
	
	var image_zero = Image.new()
	image_zero.create(0, 0, false, Image.FORMAT_L8)
	
	var image_invalid_format = Image.new()
	image_invalid_format.create(256, 256, false, 9999)
```
</details>

### Before

```
ERROR: Expected data size of 786432 bytes in Image::create(), got instead 0 bytes.
   at: create (core/io/image.cpp:1980)
ERROR: Expected data size of 85318 bytes in Image::create(), got instead 0 bytes.
   at: create (core/io/image.cpp:1980)
ERROR: Expected data size of 20 bytes in Image::create(), got instead 0 bytes.
   at: create (core/io/image.cpp:1980)
ERROR: Image width must be greater than 0.
   at: create (core/io/image.cpp:1947)
ERROR: Image format out of range, please see Image's Format enum.
   at: create (core/io/image.cpp:1952)
```

### After

```
ERROR: Expected Image data size of 512x512x3 (without mipmaps) = 786432 bytes, got 0 bytes instead.
   at: create (core/io/image.cpp:1999)
ERROR: Expected Image data size of 320x200x1 (with 8 mipmaps) = 85318 bytes, got 0 bytes instead.
   at: create (core/io/image.cpp:1999)
ERROR: Expected Image data size of 2x2x4 (with 1 mipmap) = 20 bytes, got 0 bytes instead.
   at: create (core/io/image.cpp:1999)
ERROR: The Image width specified (0 pixels) must be greater than 0 pixels.
   at: create (core/io/image.cpp:1947)
ERROR: The Image format specified (9999) is out of range. See Image's Format enum.
   at: create (core/io/image.cpp:1955)
```