### PR TITLE
Added documentation comments to the .NET library

### DIFF
--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/AssemblyHasScriptsAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/AssemblyHasScriptsAttribute.cs
@@ -2,17 +2,27 @@ using System;
 
 namespace Godot
 {
+    /// <summary>
+    /// An attribute that determines if an assembly has scripts. If so, what types of scripts the assembly has.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Assembly)]
     public class AssemblyHasScriptsAttribute : Attribute
     {
         private readonly bool requiresLookup;
         private readonly System.Type[] scriptTypes;
 
+        /// <summary>
+        /// Constructs a new AssemblyHasScriptsAttribute instance.
+        /// </summary>
         public AssemblyHasScriptsAttribute()
         {
             requiresLookup = true;
         }
 
+        /// <summary>
+        /// Constructs a new AssemblyHasScriptsAttribute instance.
+        /// </summary>
+        /// <param name="scriptTypes">The specified type(s) of scripts.</param>
         public AssemblyHasScriptsAttribute(System.Type[] scriptTypes)
         {
             requiresLookup = false;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/DisableGodotGeneratorsAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/DisableGodotGeneratorsAttribute.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace Godot
 {
+    /// <summary>
+    /// An attribute that disables Godot Generators.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class)]
     public class DisableGodotGeneratorsAttribute : Attribute { }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
@@ -2,12 +2,20 @@ using System;
 
 namespace Godot
 {
+    /// <summary>
+    /// An attribute used to export objects.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
     public class ExportAttribute : Attribute
     {
         private PropertyHint hint;
         private string hintString;
 
+        /// <summary>
+        /// Constructs a new ExportAttribute Instance.
+        /// </summary>
+        /// <param name="hint">A hint to the exported object.</param>
+        /// <param name="hintString">A string representing the exported object.</param>
         public ExportAttribute(PropertyHint hint = PropertyHint.None, string hintString = "")
         {
             this.hint = hint;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GodotMethodAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GodotMethodAttribute.cs
@@ -2,6 +2,9 @@ using System;
 
 namespace Godot
 {
+    /// <summary>
+    /// An attribute for a method.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     internal class GodotMethodAttribute : Attribute
     {
@@ -9,6 +12,10 @@ namespace Godot
 
         public string MethodName { get { return methodName; } }
 
+        /// <summary>
+        /// Constructs a new GodotMethodAttribute instance.
+        /// </summary>
+        /// <param name="methodName">The name of the method.</param>
         public GodotMethodAttribute(string methodName)
         {
             this.methodName = methodName;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RPCAttributes.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RPCAttributes.cs
@@ -2,9 +2,15 @@ using System;
 
 namespace Godot
 {
+    /// <summary>
+    /// Constructs a new AnyPeerAttribute instance. Members with the AnyPeerAttribute are given authority over their own player.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class AnyPeerAttribute : Attribute { }
 
+    /// <summary>
+    /// Constructs a new AuthorityAttribute instance. Members with the AuthorityAttribute are given authority over the game.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Method)]
     public class AuthorityAttribute : Attribute { }
 }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ScriptPathAttribute.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ScriptPathAttribute.cs
@@ -2,11 +2,18 @@ using System;
 
 namespace Godot
 {
+    /// <summary>
+    /// An attribute that contains the path to the object's script.
+    /// </summary>
     [AttributeUsage(AttributeTargets.Class, AllowMultiple = true)]
     public class ScriptPathAttribute : Attribute
     {
         private string path;
 
+        /// <summary>
+        /// Constructs a new ScriptPathAttribute instance.
+        /// </summary>
+        /// <param name="path">The file path to the script</param>
         public ScriptPathAttribute(string path)
         {
             this.path = path;

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Dispatcher.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Dispatcher.cs
@@ -4,9 +4,16 @@ namespace Godot
 {
     public static class Dispatcher
     {
+        /// <summary>
+        /// Implements an external instance of GodotTaskScheduler.
+        /// </summary>
+        /// <returns>A GodotTaskScheduler instance.</returns>
         [MethodImpl(MethodImplOptions.InternalCall)]
         private static extern GodotTaskScheduler godot_icall_DefaultGodotTaskScheduler();
 
+        /// <summary>
+        /// Initializes the synchronization context as the context of the GodotTaskScheduler.
+        /// </summary>
         public static GodotSynchronizationContext SynchronizationContext =>
             godot_icall_DefaultGodotTaskScheduler().Context;
     }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotSynchronizationContext.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotSynchronizationContext.cs
@@ -14,6 +14,9 @@ namespace Godot
             _queue.Add(new KeyValuePair<SendOrPostCallback, object>(d, state));
         }
 
+        /// <summary>
+        /// Calls the Key method on each workItem object in the _queue to activate their callbacks.
+        /// </summary>
         public void ExecutePendingContinuations()
         {
             while (_queue.TryTake(out var workItem))

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTaskScheduler.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTaskScheduler.cs
@@ -6,11 +6,25 @@ using System.Threading.Tasks;
 
 namespace Godot
 {
+    /// <summary>
+    /// GodotTaskScheduler contains a linked list of tasks to perform as a queue. Methods
+    /// within the class are used to control the queue and perform the contained tasks.
+    /// </summary>
     public class GodotTaskScheduler : TaskScheduler
     {
+        /// <summary>
+        /// The current synchronization context.
+        /// </summary>
         internal GodotSynchronizationContext Context { get; }
+
+        /// <summary>
+        /// The queue of tasks for the task scheduler.
+        /// </summary>
         private readonly LinkedList<Task> _tasks = new LinkedList<Task>();
 
+        /// <summary>
+        /// Constructs a new GodotTaskScheduler instance.
+        /// </summary>
         public GodotTaskScheduler()
         {
             Context = new GodotSynchronizationContext();
@@ -53,12 +67,19 @@ namespace Godot
             }
         }
 
+        /// <summary>
+        /// Executes all queued tasks and pending tasks from the current context.
+        /// </summary>
         public void Activate()
         {
             ExecuteQueuedTasks();
             Context.ExecutePendingContinuations();
         }
 
+        /// <summary>
+        /// Loops through and attempts to execute each task in _tasks.
+        /// </summary>
+        /// <exception cref="InvalidOperationException"></exception>
         private void ExecuteQueuedTasks()
         {
             while (true)

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaitable.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaitable.cs
@@ -1,10 +1,17 @@
 namespace Godot
 {
+    /// <summary>
+    /// An interface that requires a GetAwaiter() method to get a reference to the Awaiter.
+    /// </summary>
     public interface IAwaitable
     {
         IAwaiter GetAwaiter();
     }
 
+    /// <summary>
+    /// A templated interface that requires a GetAwaiter() method to get a reference to the Awaiter.
+    /// </summary>
+    /// <typeparam name="TResult">A reference to the result to be passed out.</typeparam>
     public interface IAwaitable<out TResult>
     {
         IAwaiter<TResult> GetAwaiter();

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
@@ -2,6 +2,9 @@ using System.Runtime.CompilerServices;
 
 namespace Godot
 {
+    /// <summary>
+    /// An interface that requires a boolean for completion status and a method that gets the result of completion.
+    /// </summary>
     public interface IAwaiter : INotifyCompletion
     {
         bool IsCompleted { get; }
@@ -9,6 +12,10 @@ namespace Godot
         void GetResult();
     }
 
+    /// <summary>
+    /// A templated interface that requires a boolean for completion status and a method that gets the result of completion and returns it.
+    /// </summary>
+    /// <typeparam name="TResult">A reference to the result to be passed out.</typeparam>
     public interface IAwaiter<out TResult> : INotifyCompletion
     {
         bool IsCompleted { get; }

--- a/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/ISerializationListener.cs
+++ b/modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/ISerializationListener.cs
@@ -1,5 +1,8 @@
 namespace Godot
 {
+    /// <summary>
+    /// An interface that requires methods for before and after serialization.
+    /// </summary>
     public interface ISerializationListener
     {
         void OnBeforeSerialize();


### PR DESCRIPTION
Contributing to the issue from #39703. Documentation comments have been added to the .NET library.

**Comments have been added for the following:**
modules/mono/glue/GodotSharp/GodotSharp/Core/GodotTaskScheduler.cs
modules/mono/glue/GodotSharp/GodotSharp/Core/GodotSynchronizationContext.cs
modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/AssemblyHasScriptsAttribute.cs
modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/DisableGodotGeneratorsAttribute.cs
modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ExportAttribute.cs
modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/GodotMethodAttribute.cs
modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/ScriptPathAttribute.cs

The following files still require comments. However, I did not complete them due to myself being unsure about their function.
modules/mono/glue/GodotSharp/GodotSharp/Core/Dispatcher.cs
modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaitable.cs
modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/IAwaiter.cs
modules/mono/glue/GodotSharp/GodotSharp/Core/Interfaces/ISerializationListener.cs
modules/mono/glue/GodotSharp/GodotSharp/Core/Attributes/RPCAttributes.cs

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
