### PR TITLE
Fix Theme type group name capitalization in the inspector

### DIFF
--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -198,7 +198,15 @@ void Theme::_get_property_list(List<PropertyInfo> *p_list) const {
 
 	// Sort and store properties.
 	list.sort();
+	String prev_type;
 	for (const PropertyInfo &E : list) {
+		// Add groups for types so that their names are left unchanged in the inspector.
+		String current_type = E.name.get_slice("/", 0);
+		if (prev_type != current_type) {
+			p_list->push_back(PropertyInfo(Variant::NIL, current_type, PROPERTY_HINT_NONE, current_type + "/", PROPERTY_USAGE_GROUP));
+			prev_type = current_type;
+		}
+
 		p_list->push_back(E);
 	}
 }


### PR DESCRIPTION
Makes Theme type group names not be processed by the inspector, so that their names are left unchanged.

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/162669433-b6149456-08f3-401a-92b0-88a708893e5a.png) | ![image](https://user-images.githubusercontent.com/67974470/162669293-a380f06c-074c-45cf-87e8-c8bf3c720c53.png) |