### PR TITLE
[TextServer] Fix long selection performance.

### DIFF
--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -979,6 +979,14 @@ TextServer::Direction TextServer::shaped_text_get_dominant_direction_in_range(co
 	}
 }
 
+_FORCE_INLINE_ void _push_range(Vector<Vector2> &r_vector, real_t p_start, real_t p_end) {
+	if (!r_vector.is_empty() && Math::is_equal_approx(r_vector[r_vector.size() - 1].y, p_start, (real_t)UNIT_EPSILON)) {
+		r_vector.write[r_vector.size() - 1].y = p_end;
+	} else {
+		r_vector.push_back(Vector2(p_start, p_end));
+	}
+}
+
 Vector<Vector2> TextServer::shaped_text_get_selection(const RID &p_shaped, int64_t p_start, int64_t p_end) const {
 	Vector<Vector2> ranges;
 
@@ -1003,7 +1011,7 @@ Vector<Vector2> TextServer::shaped_text_get_selection(const RID &p_shaped, int64
 						for (int j = 0; j < glyphs[i].count; j++) {
 							advance += glyphs[i + j].advance;
 						}
-						ranges.push_back(Vector2(off, off + advance));
+						_push_range(ranges, off, off + advance);
 					}
 					// Only start of grapheme is in selection range.
 					if (glyphs[i].start >= start && glyphs[i].end > end) {
@@ -1013,9 +1021,9 @@ Vector<Vector2> TextServer::shaped_text_get_selection(const RID &p_shaped, int64
 						}
 						real_t char_adv = advance / (real_t)(glyphs[i].end - glyphs[i].start);
 						if ((glyphs[i].flags & GRAPHEME_IS_RTL) == GRAPHEME_IS_RTL) {
-							ranges.push_back(Vector2(off + char_adv * (glyphs[i].end - end), off + advance));
+							_push_range(ranges, off + char_adv * (glyphs[i].end - end), off + advance);
 						} else {
-							ranges.push_back(Vector2(off, off + char_adv * (end - glyphs[i].start)));
+							_push_range(ranges, off, off + char_adv * (end - glyphs[i].start));
 						}
 					}
 					// Only end of grapheme is in selection range.
@@ -1026,9 +1034,9 @@ Vector<Vector2> TextServer::shaped_text_get_selection(const RID &p_shaped, int64
 						}
 						real_t char_adv = advance / (real_t)(glyphs[i].end - glyphs[i].start);
 						if ((glyphs[i].flags & GRAPHEME_IS_RTL) == GRAPHEME_IS_RTL) {
-							ranges.push_back(Vector2(off, off + char_adv * (glyphs[i].end - start)));
+							_push_range(ranges, off, off + char_adv * (glyphs[i].end - start));
 						} else {
-							ranges.push_back(Vector2(off + char_adv * (start - glyphs[i].start), off + advance));
+							_push_range(ranges, off + char_adv * (start - glyphs[i].start), off + advance);
 						}
 					}
 					// Selection range is within grapheme.
@@ -1039,34 +1047,15 @@ Vector<Vector2> TextServer::shaped_text_get_selection(const RID &p_shaped, int64
 						}
 						real_t char_adv = advance / (real_t)(glyphs[i].end - glyphs[i].start);
 						if ((glyphs[i].flags & GRAPHEME_IS_RTL) == GRAPHEME_IS_RTL) {
-							ranges.push_back(Vector2(off + char_adv * (glyphs[i].end - end), off + char_adv * (glyphs[i].end - start)));
+							_push_range(ranges, off + char_adv * (glyphs[i].end - end), off + char_adv * (glyphs[i].end - start));
 						} else {
-							ranges.push_back(Vector2(off + char_adv * (start - glyphs[i].start), off + char_adv * (end - glyphs[i].start)));
+							_push_range(ranges, off + char_adv * (start - glyphs[i].start), off + char_adv * (end - glyphs[i].start));
 						}
 					}
 				}
 			}
 			off += glyphs[i].advance;
 		}
-	}
-
-	// Merge intersecting ranges.
-	int i = 0;
-	while (i < ranges.size()) {
-		i++;
-	}
-	i = 0;
-	while (i < ranges.size()) {
-		int j = i + 1;
-		while (j < ranges.size()) {
-			if (Math::is_equal_approx(ranges[i].y, ranges[j].x, (real_t)UNIT_EPSILON)) {
-				ranges.write[i].y = ranges[j].y;
-				ranges.remove_at(j);
-				continue;
-			}
-			j++;
-		}
-		i++;
 	}
 
 	return ranges;


### PR DESCRIPTION
Fixes #60107

Nested loop is not necessary since selection ranges are calculated sequentially, and merge can be done in place. And it seems to be incorrectly rebased at some point, adding a useless loop.

Selection, `Ctrl+A`, or cursor movement on million chars long text in the `LineEdit` should be instant, pasting it and doing any edit takes about two seconds (which is expected). With text that long, carets/selection are shifted (I'll take a look, but it's probably just limitation of `Vector2` precision limitation).