### PR TITLE
Fix specialization constant updates in color passes

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -824,6 +824,9 @@ void SceneShaderForwardClustered::set_default_specialization_constants(const Vec
 				for (int k = 0; k < SHADER_VERSION_MAX; k++) {
 					E->self()->pipelines[i][j][k].update_specialization_constants(default_specialization_constants);
 				}
+				for (int k = 0; k < PIPELINE_COLOR_PASS_FLAG_COUNT; k++) {
+					E->self()->color_pipelines[i][j][k].update_specialization_constants(default_specialization_constants);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The color pass specialization constants were not being updated after splitting them to their own array.

Fixes #60132.
