### PR TITLE
Add support for Live++ on Windows

### DIFF
--- a/methods.py
+++ b/methods.py
@@ -734,6 +734,7 @@ def generate_vs_project(env, num_jobs):
                     f"target={configuration_getter}",
                     "progress=no",
                     "tools=!tools!",
+                    "livepp=%s" % env["livepp"],
                     "-j%s" % num_jobs,
                 ]
 

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -34,6 +34,11 @@
 #include <locale.h>
 #include <stdio.h>
 
+#ifdef LIVEPP_PATH
+#include "API/LPP_API.h"
+HMODULE livePP;
+#endif
+
 // For export templates, add a section; the exporter will patch it to enclose
 // the data appended to the executable (bundled PCK)
 #ifndef TOOLS_ENABLED
@@ -136,6 +141,16 @@ char *wc_to_utf8(const wchar_t *wc) {
 }
 
 int widechar_main(int argc, wchar_t **argv) {
+#ifdef LIVEPP_PATH
+#define _MKSTR_L(x) _STR_L(x)
+#define _STR_L(x) L#x
+	livePP = lpp::lppLoadAndRegister(_MKSTR_L(LIVEPP_PATH), "Godot");
+	lpp::lppEnableAllCallingModulesSync(livePP);
+	lpp::lppInstallExceptionHandler(livePP);
+#undef _MKSTR_L
+#undef _STR_L
+#endif
+
 	OS_Windows os(nullptr);
 
 	setlocale(LC_CTYPE, "");
@@ -172,6 +187,11 @@ int widechar_main(int argc, wchar_t **argv) {
 		delete[] argv_utf8[i];
 	}
 	delete[] argv_utf8;
+
+#ifdef LIVEPP_PATH
+	lpp::lppShutdown(livePP);
+	::FreeLibrary(livePP);
+#endif
 
 	return os.get_exit_code();
 }

--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -53,6 +53,11 @@
 #include <regstr.h>
 #include <shlobj.h>
 
+#ifdef LIVEPP_PATH
+#include "API/LPP_API.h"
+extern HMODULE livePP;
+#endif
+
 extern "C" {
 __declspec(dllexport) DWORD NvOptimusEnablement = 1;
 __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
@@ -677,6 +682,9 @@ void OS_Windows::run() {
 		if (Main::iteration()) {
 			break;
 		}
+#ifdef LIVEPP_PATH
+		lpp::lppSyncPoint(livePP);
+#endif
 	}
 
 	main_loop->finalize();


### PR DESCRIPTION
The editor, compile, run iteration times when working on Godot engine or (custom) modules is quite high, ranging from 10-30 seconds on quite capable hardware. This makes working on C++ code less effective than it could be. Also, debug builds take a long time to start up, which further increases the time spent waiting for things to happen before new or fixed code can be evaluated.

[Live++](https://liveplusplus.tech/) is a proprietary tool for Windows that can help with this by allowing hot swapping code into a running executable like the Godot editor or a Godot game.

This pull request adds support for Live++ to Godot on Windows. It modifies the following files as follows:

1. `platform/windows/detect.py` checks if the `LIVEPP_PATH` environment variable is set, pointing to the Live++ installation, e.g. to `c:/tools/LivePP`. If set, the build sets a `CPPDEFINE` and an additional linker flag that adds a trampline area to functions, so Live++ can do its work.
2. `platform/windows/godot_windows.cpp` will include the Live++ header, and setup and tear-down Live++ when the `LIVEPP_PATH` define is set.
3.  `platform/windows/os_windows.cpp` also evaluates the `LIVEPP_PATH` define and calls into the Live++ sync point when set. This allows Live++ to swap out any recompiled functions.

I've created a demonstration video to show the improved workflow. Note the first 30 seconds of the video. That's the time it takes on this machine (while screen recording) to make a single line change, rebuild, and restart the Godot editor. Subsequently, code is changed, saved, and handed to Live++ for patching.

https://www.youtube.com/watch?v=2y8s7KZ1R3g&feature=youtu.be

I understand that adding calls to proprietary APIs is not something Godot will do. The reason for this pull request is more informal, so people looking to integrate Live++ with Godot have a starting point.

It might be possible to turn this functionality into a module or native extension. In this pull request's case, deeper integration was chosen, so Live++ can start-up as soon as possible, which is recommended as per the documentation.