### PR TITLE
Physics interpolation - Move out of Scenario

### DIFF
--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -115,10 +115,6 @@ void Camera::_notification(int p_what) {
 			if (current || first_camera) {
 				viewport->_camera_set(this);
 			}
-
-			ERR_FAIL_COND(get_world().is_null());
-			VisualServer::get_singleton()->camera_set_scenario(camera, get_world()->get_scenario());
-
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
 			_request_camera_update();
@@ -132,8 +128,6 @@ void Camera::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_EXIT_WORLD: {
-			VisualServer::get_singleton()->camera_set_scenario(camera, RID());
-
 			if (!get_tree()->is_node_being_edited(this)) {
 				if (is_current()) {
 					clear_current();

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -507,13 +507,7 @@ void SceneTree::set_physics_interpolation_enabled(bool p_enabled) {
 	}
 
 	_physics_interpolation_enabled = p_enabled;
-
-	if (root->get_world().is_valid()) {
-		RID scenario = root->get_world()->get_scenario();
-		if (scenario.is_valid()) {
-			VisualServer::get_singleton()->scenario_set_physics_interpolation_enabled(scenario, p_enabled);
-		}
-	}
+	VisualServer::get_singleton()->set_physics_interpolation_enabled(p_enabled);
 }
 
 bool SceneTree::is_physics_interpolation_enabled() const {
@@ -535,11 +529,8 @@ bool SceneTree::iteration(float p_time) {
 
 	current_frame++;
 
-	if (root->get_world().is_valid()) {
-		RID scenario = root->get_world()->get_scenario();
-		if (scenario.is_valid()) {
-			VisualServer::get_singleton()->scenario_tick(scenario);
-		}
+	if (_physics_interpolation_enabled) {
+		VisualServer::get_singleton()->tick();
 	}
 
 	// Any objects performing client physics interpolation
@@ -686,11 +677,8 @@ bool SceneTree::idle(float p_time) {
 
 #endif
 
-	if (root->get_world().is_valid()) {
-		RID scenario = root->get_world()->get_scenario();
-		if (scenario.is_valid()) {
-			VisualServer::get_singleton()->scenario_pre_draw(scenario, true);
-		}
+	if (_physics_interpolation_enabled) {
+		VisualServer::get_singleton()->pre_draw(true);
 	}
 
 	return _quit;

--- a/servers/visual/visual_server_raster.cpp
+++ b/servers/visual/visual_server_raster.cpp
@@ -94,14 +94,6 @@ void VisualServerRaster::request_frame_drawn_callback(Object *p_where, const Str
 	frame_drawn_callbacks.push_back(fdc);
 }
 
-void VisualServerRaster::scenario_tick(RID p_scenario) {
-	VSG::scene->_scenario_tick(p_scenario);
-}
-
-void VisualServerRaster::scenario_pre_draw(RID p_scenario, bool p_will_draw) {
-	VSG::scene->_scenario_pre_draw(p_scenario, p_will_draw);
-}
-
 void VisualServerRaster::draw(bool p_swap_buffers, double frame_step) {
 	//needs to be done before changes is reset to 0, to not force the editor to redraw
 	VS::get_singleton()->emit_signal("frame_pre_draw");

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -116,8 +116,12 @@ public:
 #define BIND4RC(m_r, m_name, m_type1, m_type2, m_type3, m_type4) \
 	m_r m_name(m_type1 arg1, m_type2 arg2, m_type3 arg3, m_type4 arg4) const { return BINDBASE->m_name(arg1, arg2, arg3, arg4); }
 
+#define BIND0N(m_name) \
+	void m_name() { BINDBASE->m_name(); }
 #define BIND1(m_name, m_type1) \
 	void m_name(m_type1 arg1) { DISPLAY_CHANGED BINDBASE->m_name(arg1); }
+#define BIND1N(m_name, m_type1) \
+	void m_name(m_type1 arg1) { BINDBASE->m_name(arg1); }
 #define BIND2(m_name, m_type1, m_type2) \
 	void m_name(m_type1 arg1, m_type2 arg2) { DISPLAY_CHANGED BINDBASE->m_name(arg1, arg2); }
 #define BIND2C(m_name, m_type1, m_type2) \
@@ -448,10 +452,14 @@ public:
 //from now on, calls forwarded to this singleton
 #define BINDBASE VSG::scene
 
+	/* EVENT QUEUING */
+
+	BIND0N(tick)
+	BIND1N(pre_draw, bool)
+
 	/* CAMERA API */
 
 	BIND0R(RID, camera_create)
-	BIND2(camera_set_scenario, RID, RID)
 	BIND4(camera_set_perspective, RID, float, float, float)
 	BIND4(camera_set_orthogonal, RID, float, float, float)
 	BIND5(camera_set_frustum, RID, float, Vector2, float, float)
@@ -548,10 +556,14 @@ public:
 	BIND7(environment_set_fog_depth, RID, bool, float, float, float, bool, float)
 	BIND5(environment_set_fog_height, RID, bool, float, float, float)
 
-	/* SCENARIO API */
-
 #undef BINDBASE
 #define BINDBASE VSG::scene
+
+	/* INTERPOLATION */
+
+	BIND1(set_physics_interpolation_enabled, bool)
+
+	/* SCENARIO API */
 
 	BIND0R(RID, scenario_create)
 
@@ -559,9 +571,9 @@ public:
 	BIND2(scenario_set_environment, RID, RID)
 	BIND3(scenario_set_reflection_atlas_size, RID, int, int)
 	BIND2(scenario_set_fallback_environment, RID, RID)
-	BIND2(scenario_set_physics_interpolation_enabled, RID, bool)
 
 	/* INSTANCING API */
+
 	BIND0R(RID, instance_create)
 
 	BIND2(instance_set_base, RID, RID)
@@ -583,7 +595,8 @@ public:
 
 	BIND2(instance_set_extra_visibility_margin, RID, real_t)
 
-	// Portals
+	/* PORTALS */
+
 	BIND2(instance_set_portal_mode, RID, InstancePortalMode)
 
 	BIND0R(RID, ghost_create)
@@ -596,13 +609,15 @@ public:
 	BIND4(portal_link, RID, RID, RID, bool)
 	BIND2(portal_set_active, RID, bool)
 
-	// Roomgroups
+	/* ROOMGROUPS */
+
 	BIND0R(RID, roomgroup_create)
 	BIND2(roomgroup_prepare, RID, ObjectID)
 	BIND2(roomgroup_set_scenario, RID, RID)
 	BIND2(roomgroup_add_room, RID, RID)
 
-	// Occluders
+	/* OCCLUDERS */
+
 	BIND0R(RID, occluder_instance_create)
 	BIND2(occluder_instance_set_scenario, RID, RID)
 	BIND2(occluder_instance_link_resource, RID, RID)
@@ -616,7 +631,8 @@ public:
 	BIND1(set_use_occlusion_culling, bool)
 	BIND1RC(Geometry::MeshData, occlusion_debug_get_current_polys, RID)
 
-	// Rooms
+	/* ROOMS */
+
 	BIND0R(RID, room_create)
 	BIND2(room_set_scenario, RID, RID)
 	BIND4(room_add_instance, RID, RID, const AABB &, const Vector<Vector3> &)
@@ -764,8 +780,6 @@ public:
 	virtual bool has_changed(ChangedPriority p_priority = CHANGED_PRIORITY_ANY) const;
 	virtual void init();
 	virtual void finish();
-	virtual void scenario_tick(RID p_scenario);
-	virtual void scenario_pre_draw(RID p_scenario, bool p_will_draw);
 
 	/* STATUS INFORMATION */
 

--- a/servers/visual/visual_server_wrap_mt.cpp
+++ b/servers/visual/visual_server_wrap_mt.cpp
@@ -36,18 +36,6 @@ void VisualServerWrapMT::thread_exit() {
 	exit.set();
 }
 
-void VisualServerWrapMT::thread_scenario_tick(RID p_scenario) {
-	if (!draw_pending.decrement()) {
-		visual_server->scenario_tick(p_scenario);
-	}
-}
-
-void VisualServerWrapMT::thread_scenario_pre_draw(RID p_scenario, bool p_will_draw) {
-	if (!draw_pending.decrement()) {
-		visual_server->scenario_pre_draw(p_scenario, p_will_draw);
-	}
-}
-
 void VisualServerWrapMT::thread_draw(bool p_swap_buffers, double frame_step) {
 	if (!draw_pending.decrement()) {
 		visual_server->draw(p_swap_buffers, frame_step);
@@ -91,24 +79,6 @@ void VisualServerWrapMT::sync() {
 		command_queue.push_and_sync(this, &VisualServerWrapMT::thread_flush);
 	} else {
 		command_queue.flush_all(); //flush all pending from other threads
-	}
-}
-
-void VisualServerWrapMT::scenario_tick(RID p_scenario) {
-	if (create_thread) {
-		draw_pending.increment();
-		command_queue.push(this, &VisualServerWrapMT::thread_scenario_tick, p_scenario);
-	} else {
-		visual_server->scenario_tick(p_scenario);
-	}
-}
-
-void VisualServerWrapMT::scenario_pre_draw(RID p_scenario, bool p_will_draw) {
-	if (create_thread) {
-		draw_pending.increment();
-		command_queue.push(this, &VisualServerWrapMT::thread_scenario_pre_draw, p_scenario, p_will_draw);
-	} else {
-		visual_server->scenario_pre_draw(p_scenario, p_will_draw);
 	}
 }
 

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -54,8 +54,6 @@ class VisualServerWrapMT : public VisualServer {
 	SafeNumeric<uint64_t> draw_pending;
 	void thread_draw(bool p_swap_buffers, double frame_step);
 	void thread_flush();
-	void thread_scenario_tick(RID p_scenario);
-	void thread_scenario_pre_draw(RID p_scenario, bool p_will_draw);
 
 	void thread_exit();
 
@@ -374,7 +372,6 @@ public:
 	/* CAMERA API */
 
 	FUNCRID(camera)
-	FUNC2(camera_set_scenario, RID, RID)
 	FUNC4(camera_set_perspective, RID, float, float, float)
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC5(camera_set_frustum, RID, float, Vector2, float, float)
@@ -468,15 +465,21 @@ public:
 	FUNC7(environment_set_fog_depth, RID, bool, float, float, float, bool, float)
 	FUNC5(environment_set_fog_height, RID, bool, float, float, float)
 
+	/* INTERPOLATION API */
+
+	FUNC1(set_physics_interpolation_enabled, bool)
+
+	/* SCENARIO API */
+
 	FUNCRID(scenario)
 
 	FUNC2(scenario_set_debug, RID, ScenarioDebugMode)
 	FUNC2(scenario_set_environment, RID, RID)
 	FUNC3(scenario_set_reflection_atlas_size, RID, int, int)
 	FUNC2(scenario_set_fallback_environment, RID, RID)
-	FUNC2(scenario_set_physics_interpolation_enabled, RID, bool)
 
 	/* INSTANCING API */
+
 	FUNCRID(instance)
 
 	FUNC2(instance_set_base, RID, RID)
@@ -498,7 +501,8 @@ public:
 
 	FUNC2(instance_set_extra_visibility_margin, RID, real_t)
 
-	// Portals
+	/* PORTALS API */
+
 	FUNC2(instance_set_portal_mode, RID, InstancePortalMode)
 
 	FUNCRID(ghost)
@@ -511,13 +515,15 @@ public:
 	FUNC4(portal_link, RID, RID, RID, bool)
 	FUNC2(portal_set_active, RID, bool)
 
-	// Roomgroups
+	/* ROOMGROUPS API */
+
 	FUNCRID(roomgroup)
 	FUNC2(roomgroup_prepare, RID, ObjectID)
 	FUNC2(roomgroup_set_scenario, RID, RID)
 	FUNC2(roomgroup_add_room, RID, RID)
 
-	// Occluders
+	/* OCCLUDERS API */
+
 	FUNCRID(occluder_instance)
 	FUNC2(occluder_instance_set_scenario, RID, RID)
 	FUNC2(occluder_instance_link_resource, RID, RID)
@@ -531,7 +537,8 @@ public:
 	FUNC1(set_use_occlusion_culling, bool)
 	FUNC1RC(Geometry::MeshData, occlusion_debug_get_current_polys, RID)
 
-	// Rooms
+	/* ROOMS API */
+
 	FUNCRID(room)
 	FUNC2(room_set_scenario, RID, RID)
 	FUNC4(room_add_instance, RID, RID, const AABB &, const Vector<Vector3> &)
@@ -674,8 +681,8 @@ public:
 	virtual void finish();
 	virtual void draw(bool p_swap_buffers, double frame_step);
 	virtual void sync();
-	virtual void scenario_tick(RID p_scenario);
-	virtual void scenario_pre_draw(RID p_scenario, bool p_will_draw);
+	FUNC0(tick)
+	FUNC1(pre_draw, bool)
 	FUNC1RC(bool, has_changed, ChangedPriority)
 
 	/* RENDER INFO */

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -619,7 +619,6 @@ public:
 	/* CAMERA API */
 
 	virtual RID camera_create() = 0;
-	virtual void camera_set_scenario(RID p_camera, RID p_scenario) = 0;
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
@@ -821,6 +820,10 @@ public:
 	virtual void environment_set_fog_depth(RID p_env, bool p_enable, float p_depth_begin, float p_depth_end, float p_depth_curve, bool p_transmit, float p_transmit_curve) = 0;
 	virtual void environment_set_fog_height(RID p_env, bool p_enable, float p_min_height, float p_max_height, float p_height_curve) = 0;
 
+	/* INTERPOLATION API */
+
+	virtual void set_physics_interpolation_enabled(bool p_enabled) = 0;
+
 	/* SCENARIO API */
 
 	virtual RID scenario_create() = 0;
@@ -837,7 +840,6 @@ public:
 	virtual void scenario_set_environment(RID p_scenario, RID p_environment) = 0;
 	virtual void scenario_set_reflection_atlas_size(RID p_scenario, int p_size, int p_subdiv) = 0;
 	virtual void scenario_set_fallback_environment(RID p_scenario, RID p_environment) = 0;
-	virtual void scenario_set_physics_interpolation_enabled(RID p_scenario, bool p_enabled) = 0;
 
 	/* INSTANCING API */
 
@@ -881,8 +883,8 @@ public:
 
 	virtual void instance_set_extra_visibility_margin(RID p_instance, real_t p_margin) = 0;
 
-	/* ROOMS AND PORTALS API */
-	// Portals
+	/* PORTALS API */
+
 	enum InstancePortalMode {
 		INSTANCE_PORTAL_MODE_STATIC, // not moving within a room
 		INSTANCE_PORTAL_MODE_DYNAMIC, //  moving within room
@@ -903,13 +905,15 @@ public:
 	virtual void portal_link(RID p_portal, RID p_room_from, RID p_room_to, bool p_two_way) = 0;
 	virtual void portal_set_active(RID p_portal, bool p_active) = 0;
 
-	// Roomgroups
+	/* ROOMGROUPS API */
+
 	virtual RID roomgroup_create() = 0;
 	virtual void roomgroup_prepare(RID p_roomgroup, ObjectID p_roomgroup_object_id) = 0;
 	virtual void roomgroup_set_scenario(RID p_roomgroup, RID p_scenario) = 0;
 	virtual void roomgroup_add_room(RID p_roomgroup, RID p_room) = 0;
 
-	// Occluders
+	/* OCCLUDERS API */
+
 	enum OccluderType {
 		OCCLUDER_TYPE_UNDEFINED,
 		OCCLUDER_TYPE_SPHERE,
@@ -931,7 +935,8 @@ public:
 	virtual void set_use_occlusion_culling(bool p_enable) = 0;
 	virtual Geometry::MeshData occlusion_debug_get_current_polys(RID p_scenario) const = 0;
 
-	// Rooms
+	/* ROOMS API */
+
 	enum RoomsDebugFeature {
 		ROOMS_DEBUG_SPRAWL,
 	};
@@ -1131,8 +1136,8 @@ public:
 	virtual bool has_changed(ChangedPriority p_priority = CHANGED_PRIORITY_ANY) const = 0;
 	virtual void init() = 0;
 	virtual void finish() = 0;
-	virtual void scenario_tick(RID p_scenario) = 0;
-	virtual void scenario_pre_draw(RID p_scenario, bool p_will_draw) = 0;
+	virtual void tick() = 0;
+	virtual void pre_draw(bool p_will_draw) = 0;
 
 	/* STATUS INFORMATION */
 


### PR DESCRIPTION
Move VisualServer interpolation data out of Scenario and into VisualServerScene, so the interpolation data and enabled status is now common to all Scenarios.

Fix physics interpolation in multithreaded mode by ensuring tick and pre-draw are called.

Fixes #59736
Alternative to #59875

## Notes
* When fixing the multithreading rendering, @reduz suggested we should move the interpolation data out of `Scenario` and have it global, so there is a global on or off. He suggested there should usually only be one `SceneTree`, and this should fit 99% use cases.
* This was actually the arrangement originally when developing the interpolation, but @jordo was keen to have it selectable per `SceneTree` for his game (further description is in  https://github.com/godotengine/godot/pull/59875#issuecomment-1095186784 )
* An alternative might be for `SceneTree`s to create a RID in the VisualServer and hang the interpolation data of this, thus making it selectable per SceneTree (there is currently no concept of a `SceneTree` in the VisualServer afaik)
* I'm happy to go with any of these approaches, this will have to be decided by jordo and reduz, I'm staying out of it as I don't have strong opinions :grin: . It is fairly easy for me to change either way.
* Just to be clear in this version, the interpolation data is hanging off of `VisualServerScene` thus is only global in the sense of `VisualServer` being a singleton, and thus if @jordo is creating several VisualServers, he may be able to independently turn interpolation on and off 
using the `VisualServer::set_physics_interpolation_enabled(bool)` function. I don't know enough about his version to know if this would work for his purpose.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
