### PR TITLE
Fix opaqueness of Sprite2D

### DIFF
--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -309,9 +309,6 @@ bool Sprite2D::is_pixel_opaque(const Point2 &p_point) const {
 		q.y = 1.0f - q.y;
 	}
 	q = q * src_rect.size + src_rect.position;
-#ifndef _MSC_VER
-#warning this need to be obtained from CanvasItem new repeat mode (but it needs to guess it from hierarchy, need to add a function for that)
-#endif
 
 	int texture_repeat = get_texture_repeat();
 

--- a/scene/2d/sprite_2d.cpp
+++ b/scene/2d/sprite_2d.cpp
@@ -312,8 +312,12 @@ bool Sprite2D::is_pixel_opaque(const Point2 &p_point) const {
 #ifndef _MSC_VER
 #warning this need to be obtained from CanvasItem new repeat mode (but it needs to guess it from hierarchy, need to add a function for that)
 #endif
-	bool is_repeat = false;
-	bool is_mirrored_repeat = false;
+
+	int texture_repeat = get_texture_repeat();
+
+	bool is_repeat = (texture_repeat >= TEXTURE_REPEAT_ENABLED);
+	bool is_mirrored_repeat = (texture_repeat == TEXTURE_REPEAT_MIRROR);
+
 	if (is_repeat) {
 		int mirror_x = 0;
 		int mirror_y = 0;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Completed repeat mode compatibility in Sprite2D nodes with appropriate assignments.

*Bugsquad edit: This closes https://github.com/godotengine/godot/issues/60141.*