### PR TITLE
[AnimatedSprite] Add ability to duplicate animations

### DIFF
--- a/editor/plugins/sprite_frames_editor_plugin.h
+++ b/editor/plugins/sprite_frames_editor_plugin.h
@@ -74,6 +74,8 @@ class SpriteFramesEditor : public HSplitContainer {
 
 	Button *new_anim = nullptr;
 	Button *remove_anim = nullptr;
+	Button *duplicate_anim = nullptr;
+
 	LineEdit *anim_search_box = nullptr;
 
 	Tree *animations = nullptr;
@@ -137,6 +139,7 @@ class SpriteFramesEditor : public HSplitContainer {
 	void _animation_select();
 	void _animation_name_edited();
 	void _animation_add();
+	void _animation_duplicate();
 	void _animation_remove();
 	void _animation_remove_confirmed();
 	void _animation_search_text_changed(const String &p_text);


### PR DESCRIPTION
This PR supersedes #57949 with the additions that @Mickeon stated! 

Implements [#3942](https://github.com/godotengine/godot-proposals/issues/3942)

PS: 
* As I'm a new contributor, my code can be messed or not following rules, any review to the codebase is welcome!!!
* Cherrypick for 3.x

Edit:

Just added @Mickeon's idea, to use the duplicated animation's name:

![duplicate_2](https://user-images.githubusercontent.com/58845030/153617643-93e4913d-9c01-4904-83c1-a1912fc40dc2.gif)
