### PR TITLE
Hide the first `--print-fps` outputs after the engine has started

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2634,6 +2634,7 @@ bool Main::start() {
 
 uint64_t Main::last_ticks = 0;
 uint32_t Main::frames = 0;
+uint32_t Main::hide_print_fps_attempts = 3;
 uint32_t Main::frame = 0;
 bool Main::force_redraw_requested = false;
 int Main::iterating = 0;
@@ -2774,12 +2775,17 @@ bool Main::iteration() {
 	Engine::get_singleton()->_process_frames++;
 
 	if (frame > 1000000) {
-		if (editor || project_manager) {
-			if (print_fps) {
-				print_line(vformat("Editor FPS: %d (%s mspf)", frames, rtos(1000.0 / frames).pad_decimals(2)));
+		// Wait a few seconds before printing FPS, as FPS reporting just after the engine has started is inaccurate.
+		if (hide_print_fps_attempts == 0) {
+			if (editor || project_manager) {
+				if (print_fps) {
+					print_line(vformat("Editor FPS: %d (%s mspf)", frames, rtos(1000.0 / frames).pad_decimals(2)));
+				}
+			} else if (print_fps || GLOBAL_GET("debug/settings/stdout/print_fps")) {
+				print_line(vformat("Project FPS: %d (%s mspf)", frames, rtos(1000.0 / frames).pad_decimals(2)));
 			}
-		} else if (GLOBAL_GET("debug/settings/stdout/print_fps") || print_fps) {
-			print_line(vformat("Project FPS: %d (%s mspf)", frames, rtos(1000.0 / frames).pad_decimals(2)));
+		} else {
+			hide_print_fps_attempts--;
 		}
 
 		Engine::get_singleton()->_fps = frames;

--- a/main/main.h
+++ b/main/main.h
@@ -38,6 +38,7 @@
 class Main {
 	static void print_help(const char *p_binary);
 	static uint64_t last_ticks;
+	static uint32_t hide_print_fps_attempts;
 	static uint32_t frames;
 	static uint32_t frame;
 	static bool force_redraw_requested;


### PR DESCRIPTION
The first 2 or 3 prints are inaccurate since the engine has just started at that point.

This does not affect editor monitors, only the command line printing.

## Preview

### Before

```
Godot Engine v4.0.alpha.custom_build.5974e1432 - https://godotengine.org
Vulkan API 1.2.189 - Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 1080
Requested V-Sync mode: Enabled - FPS will likely be capped to the monitor refresh rate.

Editor FPS: 1 (1000.00 mspf)
Editor FPS: 1 (1000.00 mspf)
Editor FPS: 130 (7.69 mspf)
Editor FPS: 145 (6.89 mspf)
Editor FPS: 145 (6.89 mspf)
Editor FPS: 145 (6.89 mspf)
```

### After

```
Godot Engine v4.0.alpha.custom_build.5974e1432 - https://godotengine.org
Vulkan API 1.2.189 - Using Vulkan Device #0: NVIDIA - NVIDIA GeForce GTX 1080
Requested V-Sync mode: Enabled - FPS will likely be capped to the monitor refresh rate.

Editor FPS: 145 (6.89 mspf)
Editor FPS: 145 (6.89 mspf)
Editor FPS: 145 (6.89 mspf)
```