### PR TITLE
Only allow 'Make Local' command on instanced owned by the current scene

### DIFF
--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1007,6 +1007,7 @@ void SceneTreeDock::_tool_selected(int p_tool, bool p_confirm_override) {
 						break;
 					}
 
+					ERR_FAIL_COND(node->get_owner() != root);
 					ERR_FAIL_COND(node->get_scene_file_path().is_empty());
 					undo_redo->create_action(TTR("Make Local"));
 					undo_redo->add_do_method(node, "set_scene_file_path", "");
@@ -2796,7 +2797,9 @@ void SceneTreeDock::_tree_rmb(const Vector2 &p_menu_pos) {
 				if (profile_allow_editing) {
 					menu->add_check_item(TTR("Editable Children"), TOOL_SCENE_EDITABLE_CHILDREN);
 					menu->add_check_item(TTR("Load As Placeholder"), TOOL_SCENE_USE_PLACEHOLDER);
-					menu->add_item(TTR("Make Local"), TOOL_SCENE_MAKE_LOCAL);
+					if (selection[0]->get_owner() == EditorNode::get_singleton()->get_edited_scene()) {
+						menu->add_item(TTR("Make Local"), TOOL_SCENE_MAKE_LOCAL);
+					}
 				}
 				menu->add_icon_item(get_theme_icon(SNAME("Load"), SNAME("EditorIcons")), TTR("Open in Editor"), TOOL_SCENE_OPEN);
 				if (profile_allow_editing) {


### PR DESCRIPTION
Prevents issues with users using the 'Make Local' command on editable children by only allowing the command to be used on instanced owned by the current scene