### PR TITLE
Make editable children use warning color instead of disabled color

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -229,7 +229,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		}
 	} else if (part_of_subscene) {
 		if (valid_types.size() == 0) {
-			item->set_custom_color(0, get_theme_color(SNAME("disabled_font_color"), SNAME("Editor")));
+			item->set_custom_color(0, get_theme_color(SNAME("warning_color"), SNAME("Editor")));
 		}
 	} else if (marked.has(p_node)) {
 		String node_name = p_node->get_name();


### PR DESCRIPTION
Okay, so while there may have be some confusion over when is and isn't appropriate to use the warning colour, I feel very confident that it makes complete sense to use it here: it's consistent with its usage in the inspector to make it clear that changes to properties could be lost on editable children and automatically feels more appropiate than the usage of the colour usaged to signify things are disabled. It will also address the design discontinuity I raised in this PR #58481
![godot windows tools 64_vM6be10YeS](https://user-images.githubusercontent.com/12756047/162860388-3d4d81e5-9ed5-4e68-b3fb-c143baebec12.png)