### PR TITLE
Use multiplication symbol in Texture size label

### DIFF
--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -70,7 +70,7 @@ void TexturePreview::_update_metadata_label_text() {
 		format = texture->get_class();
 	}
 
-	metadata_label->set_text(itos(texture->get_width()) + "x" + itos(texture->get_height()) + " " + format);
+	metadata_label->set_text(vformat(String::utf8("%s×%s %s"), itos(texture->get_width()), itos(texture->get_height()), format));
 }
 
 TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {


### PR DESCRIPTION
Replaces the `x` in the Texture inspector preview's size label with `×`, the Unicode multiplication symbol.

See https://github.com/godotengine/godot/pull/60008#discussion_r847653853