### PR TITLE
Remove or make private `FileAccess` `close()` methods.

### DIFF
--- a/core/io/file_access.h
+++ b/core/io/file_access.h
@@ -88,7 +88,6 @@ public:
 		WRITE_READ = 7,
 	};
 
-	virtual void close() = 0; ///< close a file
 	virtual bool is_open() const = 0; ///< true when file is open
 
 	virtual String get_path() const { return ""; } /// returns the path for the current open file

--- a/core/io/file_access_compressed.cpp
+++ b/core/io/file_access_compressed.cpp
@@ -97,10 +97,7 @@ Error FileAccessCompressed::open_after_magic(Ref<FileAccess> p_base) {
 
 Error FileAccessCompressed::_open(const String &p_path, int p_mode_flags) {
 	ERR_FAIL_COND_V(p_mode_flags == READ_WRITE, ERR_UNAVAILABLE);
-
-	if (f.is_valid()) {
-		close();
-	}
+	_close();
 
 	Error err;
 	f = FileAccess::open(p_path, p_mode_flags, &err);
@@ -134,7 +131,7 @@ Error FileAccessCompressed::_open(const String &p_path, int p_mode_flags) {
 	return OK;
 }
 
-void FileAccessCompressed::close() {
+void FileAccessCompressed::_close() {
 	if (f.is_null()) {
 		return;
 	}
@@ -373,7 +370,5 @@ Error FileAccessCompressed::_set_unix_permissions(const String &p_file, uint32_t
 }
 
 FileAccessCompressed::~FileAccessCompressed() {
-	if (f.is_valid()) {
-		close();
-	}
+	_close();
 }

--- a/core/io/file_access_compressed.h
+++ b/core/io/file_access_compressed.h
@@ -63,13 +63,14 @@ class FileAccessCompressed : public FileAccess {
 	mutable Vector<uint8_t> buffer;
 	Ref<FileAccess> f;
 
+	void _close();
+
 public:
 	void configure(const String &p_magic, Compression::Mode p_mode = Compression::MODE_ZSTD, uint32_t p_block_size = 4096);
 
 	Error open_after_magic(Ref<FileAccess> p_base);
 
 	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
 	virtual void seek(uint64_t p_position); ///< seek to a given position

--- a/core/io/file_access_encrypted.cpp
+++ b/core/io/file_access_encrypted.cpp
@@ -115,27 +115,11 @@ Error FileAccessEncrypted::_open(const String &p_path, int p_mode_flags) {
 	return OK;
 }
 
-void FileAccessEncrypted::close() {
+void FileAccessEncrypted::_close() {
 	if (file.is_null()) {
 		return;
 	}
 
-	_release();
-
-	file.unref();
-}
-
-void FileAccessEncrypted::release() {
-	if (file.is_null()) {
-		return;
-	}
-
-	_release();
-
-	file.unref();
-}
-
-void FileAccessEncrypted::_release() {
 	if (writing) {
 		Vector<uint8_t> compressed;
 		uint64_t len = data.size();
@@ -173,6 +157,8 @@ void FileAccessEncrypted::_release() {
 		file->store_buffer(compressed.ptr(), compressed.size());
 		data.clear();
 	}
+
+	file.unref();
 }
 
 bool FileAccessEncrypted::is_open() const {
@@ -309,7 +295,5 @@ Error FileAccessEncrypted::_set_unix_permissions(const String &p_file, uint32_t 
 }
 
 FileAccessEncrypted::~FileAccessEncrypted() {
-	if (file.is_valid()) {
-		close();
-	}
+	_close();
 }

--- a/core/io/file_access_encrypted.h
+++ b/core/io/file_access_encrypted.h
@@ -54,15 +54,13 @@ private:
 	mutable bool eofed = false;
 	bool use_magic = true;
 
-	void _release();
+	void _close();
 
 public:
 	Error open_and_parse(Ref<FileAccess> p_base, const Vector<uint8_t> &p_key, Mode p_mode, bool p_with_magic = true);
 	Error open_and_parse_password(Ref<FileAccess> p_base, const String &p_key, Mode p_mode);
 
 	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
-	virtual void release(); ///< finish and keep base file open
 	virtual bool is_open() const; ///< true when file is open
 
 	virtual String get_path() const; /// returns the path for the current open file

--- a/core/io/file_access_memory.cpp
+++ b/core/io/file_access_memory.cpp
@@ -94,10 +94,6 @@ Error FileAccessMemory::_open(const String &p_path, int p_mode_flags) {
 	return OK;
 }
 
-void FileAccessMemory::close() {
-	data = nullptr;
-}
-
 bool FileAccessMemory::is_open() const {
 	return data != nullptr;
 }

--- a/core/io/file_access_memory.h
+++ b/core/io/file_access_memory.h
@@ -46,7 +46,6 @@ public:
 
 	virtual Error open_custom(const uint8_t *p_data, uint64_t p_len); ///< open a file
 	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
 	virtual void seek(uint64_t p_position); ///< seek to a given position

--- a/core/io/file_access_network.cpp
+++ b/core/io/file_access_network.cpp
@@ -254,9 +254,8 @@ void FileAccessNetwork::_respond(uint64_t p_len, Error p_status) {
 
 Error FileAccessNetwork::_open(const String &p_path, int p_mode_flags) {
 	ERR_FAIL_COND_V(p_mode_flags != READ, ERR_UNAVAILABLE);
-	if (opened) {
-		close();
-	}
+	_close();
+
 	FileAccessNetworkClient *nc = FileAccessNetworkClient::singleton;
 	DEBUG_PRINT("open: " + p_path);
 
@@ -287,7 +286,7 @@ Error FileAccessNetwork::_open(const String &p_path, int p_mode_flags) {
 	return response;
 }
 
-void FileAccessNetwork::close() {
+void FileAccessNetwork::_close() {
 	if (!opened) {
 		return;
 	}
@@ -483,7 +482,7 @@ FileAccessNetwork::FileAccessNetwork() {
 }
 
 FileAccessNetwork::~FileAccessNetwork() {
-	close();
+	_close();
 
 	FileAccessNetworkClient *nc = FileAccessNetworkClient::singleton;
 	nc->lock_mutex();

--- a/core/io/file_access_network.h
+++ b/core/io/file_access_network.h
@@ -113,6 +113,7 @@ class FileAccessNetwork : public FileAccess {
 	void _queue_page(int32_t p_page) const;
 	void _respond(uint64_t p_len, Error p_status);
 	void _set_block(uint64_t p_offset, const Vector<uint8_t> &p_block);
+	void _close();
 
 public:
 	enum Command {
@@ -131,7 +132,6 @@ public:
 	};
 
 	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
 	virtual void seek(uint64_t p_position); ///< seek to a given position

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -226,10 +226,6 @@ Error FileAccessPack::_open(const String &p_path, int p_mode_flags) {
 	return ERR_UNAVAILABLE;
 }
 
-void FileAccessPack::close() {
-	f.unref();
-}
-
 bool FileAccessPack::is_open() const {
 	if (f.is_valid()) {
 		return f->is_open();

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -157,7 +157,6 @@ class FileAccessPack : public FileAccess {
 	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) { return FAILED; }
 
 public:
-	virtual void close();
 	virtual bool is_open() const;
 
 	virtual void seek(uint64_t p_position);

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -235,7 +235,7 @@ ZipArchive::~ZipArchive() {
 }
 
 Error FileAccessZip::_open(const String &p_path, int p_mode_flags) {
-	close();
+	_close();
 
 	ERR_FAIL_COND_V(p_mode_flags & FileAccess::WRITE, FAILED);
 	ZipArchive *arch = ZipArchive::get_singleton();
@@ -249,7 +249,7 @@ Error FileAccessZip::_open(const String &p_path, int p_mode_flags) {
 	return OK;
 }
 
-void FileAccessZip::close() {
+void FileAccessZip::_close() {
 	if (!zfile) {
 		return;
 	}
@@ -341,7 +341,7 @@ FileAccessZip::FileAccessZip(const String &p_path, const PackedData::PackedFile 
 }
 
 FileAccessZip::~FileAccessZip() {
-	close();
+	_close();
 }
 
 #endif // MINIZIP_ENABLED

--- a/core/io/file_access_zip.h
+++ b/core/io/file_access_zip.h
@@ -82,9 +82,10 @@ class FileAccessZip : public FileAccess {
 
 	mutable bool at_eof;
 
+	void _close();
+
 public:
 	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
 	virtual void seek(uint64_t p_position); ///< seek to a given position

--- a/core/io/pck_packer.cpp
+++ b/core/io/pck_packer.cpp
@@ -195,7 +195,8 @@ Error PCKPacker::flush(bool p_verbose) {
 	}
 
 	if (fae.is_valid()) {
-		fae->release();
+		fhead.unref();
+		fae.unref();
 	}
 
 	int header_padding = _get_pad(alignment, file->get_position());
@@ -216,7 +217,6 @@ Error PCKPacker::flush(bool p_verbose) {
 		Ref<FileAccess> src = FileAccess::open(files[i].src_path, FileAccess::READ);
 		uint64_t to_write = files[i].size;
 
-		fae.unref();
 		Ref<FileAccess> ftmp = file;
 		if (files[i].encrypted) {
 			fae.instantiate();
@@ -234,7 +234,8 @@ Error PCKPacker::flush(bool p_verbose) {
 		}
 
 		if (fae.is_valid()) {
-			fae->release();
+			ftmp.unref();
+			fae.unref();
 		}
 
 		int pad = _get_pad(alignment, file->get_position());

--- a/drivers/unix/file_access_unix.cpp
+++ b/drivers/unix/file_access_unix.cpp
@@ -71,10 +71,7 @@ void FileAccessUnix::check_errors() const {
 }
 
 Error FileAccessUnix::_open(const String &p_path, int p_mode_flags) {
-	if (f) {
-		fclose(f);
-	}
-	f = nullptr;
+	_close();
 
 	path_src = p_path;
 	path = fix_path(p_path);
@@ -148,7 +145,7 @@ Error FileAccessUnix::_open(const String &p_path, int p_mode_flags) {
 	return OK;
 }
 
-void FileAccessUnix::close() {
+void FileAccessUnix::_close() {
 	if (!f) {
 		return;
 	}
@@ -343,7 +340,7 @@ Ref<FileAccess> FileAccessUnix::create_libc() {
 CloseNotificationFunc FileAccessUnix::close_notification_func = nullptr;
 
 FileAccessUnix::~FileAccessUnix() {
-	close();
+	_close();
 }
 
 #endif

--- a/drivers/unix/file_access_unix.h
+++ b/drivers/unix/file_access_unix.h
@@ -50,12 +50,12 @@ class FileAccessUnix : public FileAccess {
 	String path_src;
 
 	static Ref<FileAccess> create_libc();
+	void _close();
 
 public:
 	static CloseNotificationFunc close_notification_func;
 
 	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
 	virtual String get_path() const; /// returns the path for the current open file

--- a/drivers/windows/file_access_windows.cpp
+++ b/drivers/windows/file_access_windows.cpp
@@ -59,11 +59,10 @@ void FileAccessWindows::check_errors() const {
 }
 
 Error FileAccessWindows::_open(const String &p_path, int p_mode_flags) {
+	_close();
+
 	path_src = p_path;
 	path = fix_path(p_path);
-	if (f) {
-		close();
-	}
 
 	const WCHAR *mode_string;
 
@@ -134,7 +133,7 @@ Error FileAccessWindows::_open(const String &p_path, int p_mode_flags) {
 	}
 }
 
-void FileAccessWindows::close() {
+void FileAccessWindows::_close() {
 	if (!f) {
 		return;
 	}
@@ -350,7 +349,7 @@ Error FileAccessWindows::_set_unix_permissions(const String &p_file, uint32_t p_
 }
 
 FileAccessWindows::~FileAccessWindows() {
-	close();
+	_close();
 }
 
 #endif // WINDOWS_ENABLED

--- a/drivers/windows/file_access_windows.h
+++ b/drivers/windows/file_access_windows.h
@@ -48,9 +48,10 @@ class FileAccessWindows : public FileAccess {
 	String path_src;
 	String save_path;
 
+	void _close();
+
 public:
 	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
 	virtual String get_path() const; /// returns the path for the current open file

--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -343,7 +343,8 @@ Error EditorExportPlatform::_save_pack_file(void *p_userdata, const String &p_pa
 	ftmp->store_buffer(p_data.ptr(), p_data.size());
 
 	if (fae.is_valid()) {
-		fae->release();
+		ftmp.unref();
+		fae.unref();
 	}
 
 	int pad = _get_pad(PCK_PADDING, pd->f->get_position());
@@ -1273,7 +1274,8 @@ Error EditorExportPlatform::save_pack(const Ref<EditorExportPreset> &p_preset, b
 	}
 
 	if (fae.is_valid()) {
-		fae->release();
+		fhead.unref();
+		fae.unref();
 	}
 
 	int header_padding = _get_pad(PCK_PADDING, f->get_position());

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -39,6 +39,8 @@ Ref<FileAccess> FileAccessAndroid::create_android() {
 }
 
 Error FileAccessAndroid::_open(const String &p_path, int p_mode_flags) {
+	_close();
+
 	String path = fix_path(p_path).simplify_path();
 	if (path.begins_with("/")) {
 		path = path.substr(1, path.length());
@@ -58,7 +60,7 @@ Error FileAccessAndroid::_open(const String &p_path, int p_mode_flags) {
 	return OK;
 }
 
-void FileAccessAndroid::close() {
+void FileAccessAndroid::_close() {
 	if (!a) {
 		return;
 	}
@@ -162,5 +164,5 @@ bool FileAccessAndroid::file_exists(const String &p_path) {
 }
 
 FileAccessAndroid::~FileAccessAndroid() {
-	close();
+	_close();
 }

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -44,11 +44,12 @@ class FileAccessAndroid : public FileAccess {
 	mutable uint64_t pos = 0;
 	mutable bool eof = false;
 
+	void _close();
+
 public:
 	static AAssetManager *asset_manager;
 
 	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
 	virtual bool is_open() const; ///< true when file is open
 
 	virtual void seek(uint64_t p_position); ///< seek to a given position


### PR DESCRIPTION
Calling `close()` method leave `FileAccess` in the unusable state, which can lead to errors. Since `FileAccess` is auto closing underlying native file in the destructor, it can be unreferenced instead.

After #59440 and #60166, `close` is no longer used anywhere in the code.
