### PR TITLE
Import scenes as AnimationLibrary

### DIFF
--- a/doc/classes/EditorSceneFormatImporter.xml
+++ b/doc/classes/EditorSceneFormatImporter.xml
@@ -29,16 +29,8 @@
 		<method name="_get_option_visibility" qualifiers="virtual const">
 			<return type="Variant" />
 			<argument index="0" name="path" type="String" />
-			<argument index="1" name="option" type="String" />
-			<description>
-			</description>
-		</method>
-		<method name="_import_animation" qualifiers="virtual">
-			<return type="Animation" />
-			<argument index="0" name="path" type="String" />
-			<argument index="1" name="flags" type="int" />
-			<argument index="2" name="options" type="Dictionary" />
-			<argument index="3" name="bake_fps" type="int" />
+			<argument index="1" name="for_animation" type="bool" />
+			<argument index="2" name="option" type="String" />
 			<description>
 			</description>
 		</method>
@@ -62,6 +54,8 @@
 		<constant name="IMPORT_GENERATE_TANGENT_ARRAYS" value="8">
 		</constant>
 		<constant name="IMPORT_USE_NAMED_SKIN_BINDS" value="16">
+		</constant>
+		<constant name="IMPORT_DISCARD_MESHES_AND_MATERIALS" value="32">
 		</constant>
 	</constants>
 </class>

--- a/doc/classes/EditorScenePostImportPlugin.xml
+++ b/doc/classes/EditorScenePostImportPlugin.xml
@@ -34,7 +34,8 @@
 		<method name="_get_internal_option_visibility" qualifiers="virtual const">
 			<return type="Variant" />
 			<argument index="0" name="category" type="int" />
-			<argument index="1" name="option" type="String" />
+			<argument index="1" name="for_animation" type="bool" />
+			<argument index="2" name="option" type="String" />
 			<description>
 				Return true or false whether a given option should be visible. Return null to ignore.
 			</description>
@@ -42,7 +43,8 @@
 		<method name="_get_option_visibility" qualifiers="virtual const">
 			<return type="Variant" />
 			<argument index="0" name="path" type="String" />
-			<argument index="1" name="option" type="String" />
+			<argument index="1" name="for_animation" type="bool" />
+			<argument index="2" name="option" type="String" />
 			<description>
 				Return true or false whether a given option should be visible. Return null to ignore.
 			</description>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5997,18 +5997,22 @@ EditorNode::EditorNode() {
 		import_scene.instantiate();
 		ResourceFormatImporter::get_singleton()->add_importer(import_scene);
 
+		Ref<ResourceImporterScene> import_animation;
+		import_animation = Ref<ResourceImporterScene>(memnew(ResourceImporterScene(true)));
+		ResourceFormatImporter::get_singleton()->add_importer(import_animation);
+
 		{
 			Ref<EditorSceneFormatImporterCollada> import_collada;
 			import_collada.instantiate();
-			import_scene->add_importer(import_collada);
+			ResourceImporterScene::add_importer(import_collada);
 
 			Ref<EditorOBJImporter> import_obj2;
 			import_obj2.instantiate();
-			import_scene->add_importer(import_obj2);
+			ResourceImporterScene::add_importer(import_obj2);
 
 			Ref<EditorSceneFormatImporterESCN> import_escn;
 			import_escn.instantiate();
-			import_scene->add_importer(import_escn);
+			ResourceImporterScene::add_importer(import_escn);
 		}
 
 		Ref<ResourceImporterBitMap> import_bitmap;
@@ -7245,6 +7249,7 @@ EditorNode::EditorNode() {
 EditorNode::~EditorNode() {
 	EditorInspector::cleanup_plugins();
 	EditorTranslationParser::get_singleton()->clean_parsers();
+	ResourceImporterScene::clean_up_importer_plugins();
 
 	remove_print_handler(&print_handler);
 	EditorHelp::cleanup_doc();

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -763,20 +763,20 @@ void EditorPlugin::remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_p
 
 void EditorPlugin::add_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer, bool p_first_priority) {
 	ERR_FAIL_COND(!p_importer.is_valid());
-	ResourceImporterScene::get_singleton()->add_importer(p_importer, p_first_priority);
+	ResourceImporterScene::add_importer(p_importer, p_first_priority);
 }
 
 void EditorPlugin::remove_scene_format_importer_plugin(const Ref<EditorSceneFormatImporter> &p_importer) {
 	ERR_FAIL_COND(!p_importer.is_valid());
-	ResourceImporterScene::get_singleton()->remove_importer(p_importer);
+	ResourceImporterScene::remove_importer(p_importer);
 }
 
 void EditorPlugin::add_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin, bool p_first_priority) {
-	ResourceImporterScene::get_singleton()->add_post_importer_plugin(p_plugin, p_first_priority);
+	ResourceImporterScene::add_post_importer_plugin(p_plugin, p_first_priority);
 }
 
 void EditorPlugin::remove_scene_post_import_plugin(const Ref<EditorScenePostImportPlugin> &p_plugin) {
-	ResourceImporterScene::get_singleton()->remove_post_importer_plugin(p_plugin);
+	ResourceImporterScene::remove_post_importer_plugin(p_plugin);
 }
 
 int find(const PackedStringArray &a, const String &v) {

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -989,7 +989,7 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 
 			{
 				List<String> importer_exts;
-				ResourceImporterScene::get_singleton()->get_recognized_extensions(&importer_exts);
+				ResourceImporterScene::get_scene_singleton()->get_recognized_extensions(&importer_exts);
 				String extension = fpath.get_extension();
 				for (const String &E : importer_exts) {
 					if (extension.nocasecmp_to(E) == 0) {
@@ -1000,7 +1000,27 @@ void FileSystemDock::_select_file(const String &p_path, bool p_select_in_favorit
 			}
 
 			if (is_imported) {
-				ResourceImporterScene::get_singleton()->show_advanced_options(fpath);
+				ResourceImporterScene::get_scene_singleton()->show_advanced_options(fpath);
+			} else {
+				EditorNode::get_singleton()->open_request(fpath);
+			}
+		} else if (ResourceLoader::get_resource_type(fpath) == "AnimationLibrary") {
+			bool is_imported = false;
+
+			{
+				List<String> importer_exts;
+				ResourceImporterScene::get_animation_singleton()->get_recognized_extensions(&importer_exts);
+				String extension = fpath.get_extension();
+				for (const String &E : importer_exts) {
+					if (extension.nocasecmp_to(E) == 0) {
+						is_imported = true;
+						break;
+					}
+				}
+			}
+
+			if (is_imported) {
+				ResourceImporterScene::get_animation_singleton()->show_advanced_options(fpath);
 			} else {
 				EditorNode::get_singleton()->open_request(fpath);
 			}

--- a/editor/import/editor_import_collada.cpp
+++ b/editor/import/editor_import_collada.cpp
@@ -1817,26 +1817,5 @@ Node *EditorSceneFormatImporterCollada::import_scene(const String &p_path, uint3
 	return state.scene;
 }
 
-Ref<Animation> EditorSceneFormatImporterCollada::import_animation(const String &p_path, uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps) {
-	ColladaImport state;
-
-	state.use_mesh_builtin_materials = false;
-
-	Error err = state.load(p_path, Collada::IMPORT_FLAG_ANIMATION, p_flags & EditorSceneFormatImporter::IMPORT_GENERATE_TANGENT_ARRAYS);
-	ERR_FAIL_COND_V_MSG(err != OK, RES(), "Cannot load animation from file '" + p_path + "'.");
-
-	state.create_animations(true);
-	if (state.scene) {
-		memdelete(state.scene);
-	}
-
-	if (state.animations.size() == 0) {
-		return Ref<Animation>();
-	}
-	Ref<Animation> anim = state.animations[0];
-
-	return anim;
-}
-
 EditorSceneFormatImporterCollada::EditorSceneFormatImporterCollada() {
 }

--- a/editor/import/editor_import_collada.h
+++ b/editor/import/editor_import_collada.h
@@ -40,7 +40,6 @@ public:
 	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps, List<String> *r_missing_deps = nullptr, Error *r_err = nullptr) override;
-	virtual Ref<Animation> import_animation(const String &p_path, uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps) override;
 
 	EditorSceneFormatImporterCollada();
 };

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -457,10 +457,6 @@ Node *EditorOBJImporter::import_scene(const String &p_path, uint32_t p_flags, co
 	return scene;
 }
 
-Ref<Animation> EditorOBJImporter::import_animation(const String &p_path, uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps) {
-	return Ref<Animation>();
-}
-
 void EditorOBJImporter::get_extensions(List<String> *r_extensions) const {
 	r_extensions->push_back("obj");
 }

--- a/editor/import/resource_importer_obj.h
+++ b/editor/import/resource_importer_obj.h
@@ -40,7 +40,6 @@ public:
 	virtual uint32_t get_import_flags() const override;
 	virtual void get_extensions(List<String> *r_extensions) const override;
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps, List<String> *r_missing_deps, Error *r_err = nullptr) override;
-	virtual Ref<Animation> import_animation(const String &p_path, uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps) override;
 
 	EditorOBJImporter();
 };

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -87,26 +87,13 @@ Node *EditorSceneFormatImporter::import_scene(const String &p_path, uint32_t p_f
 	ERR_FAIL_V(nullptr);
 }
 
-Ref<Animation> EditorSceneFormatImporter::import_animation(const String &p_path, uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps) {
-	Dictionary options_dict;
-	for (const KeyValue<StringName, Variant> &elem : p_options) {
-		options_dict[elem.key] = elem.value;
-	}
-	Ref<Animation> ret;
-	if (GDVIRTUAL_CALL(_import_animation, p_path, p_flags, options_dict, p_bake_fps, ret)) {
-		return ret;
-	}
-
-	ERR_FAIL_V(nullptr);
-}
-
 void EditorSceneFormatImporter::get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options) {
 	GDVIRTUAL_CALL(_get_import_options, p_path);
 }
 
-Variant EditorSceneFormatImporter::get_option_visibility(const String &p_path, const String &p_option, const Map<StringName, Variant> &p_options) {
+Variant EditorSceneFormatImporter::get_option_visibility(const String &p_path, bool p_for_animation, const String &p_option, const Map<StringName, Variant> &p_options) {
 	Variant ret;
-	GDVIRTUAL_CALL(_get_option_visibility, p_path, p_option, ret);
+	GDVIRTUAL_CALL(_get_option_visibility, p_path, p_for_animation, p_option, ret);
 	return ret;
 }
 
@@ -114,15 +101,15 @@ void EditorSceneFormatImporter::_bind_methods() {
 	GDVIRTUAL_BIND(_get_import_flags);
 	GDVIRTUAL_BIND(_get_extensions);
 	GDVIRTUAL_BIND(_import_scene, "path", "flags", "options", "bake_fps");
-	GDVIRTUAL_BIND(_import_animation, "path", "flags", "options", "bake_fps");
 	GDVIRTUAL_BIND(_get_import_options, "path");
-	GDVIRTUAL_BIND(_get_option_visibility, "path", "option");
+	GDVIRTUAL_BIND(_get_option_visibility, "path", "for_animation", "option");
 
 	BIND_CONSTANT(IMPORT_SCENE);
 	BIND_CONSTANT(IMPORT_ANIMATION);
 	BIND_CONSTANT(IMPORT_FAIL_ON_MISSING_DEPENDENCIES);
 	BIND_CONSTANT(IMPORT_GENERATE_TANGENT_ARRAYS);
 	BIND_CONSTANT(IMPORT_USE_NAMED_SKIN_BINDS);
+	BIND_CONSTANT(IMPORT_DISCARD_MESHES_AND_MATERIALS);
 }
 
 /////////////////////////////////
@@ -179,10 +166,10 @@ void EditorScenePostImportPlugin::get_internal_import_options(InternalImportCate
 	GDVIRTUAL_CALL(_get_internal_import_options, p_category);
 	current_option_list = nullptr;
 }
-Variant EditorScenePostImportPlugin::get_internal_option_visibility(InternalImportCategory p_category, const String &p_option, const Map<StringName, Variant> &p_options) const {
+Variant EditorScenePostImportPlugin::get_internal_option_visibility(InternalImportCategory p_category, bool p_for_animation, const String &p_option, const Map<StringName, Variant> &p_options) const {
 	current_options = &p_options;
 	Variant ret;
-	GDVIRTUAL_CALL(_get_internal_option_visibility, p_category, p_option, ret);
+	GDVIRTUAL_CALL(_get_internal_option_visibility, p_category, p_for_animation, p_option, ret);
 	current_options = nullptr;
 	return ret;
 }
@@ -205,10 +192,10 @@ void EditorScenePostImportPlugin::get_import_options(const String &p_path, List<
 	GDVIRTUAL_CALL(_get_import_options, p_path);
 	current_option_list = nullptr;
 }
-Variant EditorScenePostImportPlugin::get_option_visibility(const String &p_path, const String &p_option, const Map<StringName, Variant> &p_options) const {
+Variant EditorScenePostImportPlugin::get_option_visibility(const String &p_path, bool p_for_animation, const String &p_option, const Map<StringName, Variant> &p_options) const {
 	current_options = &p_options;
 	Variant ret;
-	GDVIRTUAL_CALL(_get_option_visibility, p_path, p_option, ret);
+	GDVIRTUAL_CALL(_get_option_visibility, p_path, p_for_animation, p_option, ret);
 	current_options = nullptr;
 	return ret;
 }
@@ -231,11 +218,11 @@ void EditorScenePostImportPlugin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_import_option_advanced", "type", "name", "default_value", "hint", "hint_string", "usage_flags"), &EditorScenePostImportPlugin::add_import_option_advanced, DEFVAL(PROPERTY_HINT_NONE), DEFVAL(""), DEFVAL(PROPERTY_USAGE_DEFAULT));
 
 	GDVIRTUAL_BIND(_get_internal_import_options, "category");
-	GDVIRTUAL_BIND(_get_internal_option_visibility, "category", "option");
+	GDVIRTUAL_BIND(_get_internal_option_visibility, "category", "for_animation", "option");
 	GDVIRTUAL_BIND(_get_internal_option_update_view_required, "category", "option");
 	GDVIRTUAL_BIND(_internal_process, "category", "base_node", "node", "resource");
 	GDVIRTUAL_BIND(_get_import_options, "path");
-	GDVIRTUAL_BIND(_get_option_visibility, "path", "option");
+	GDVIRTUAL_BIND(_get_option_visibility, "path", "for_animation", "option");
 	GDVIRTUAL_BIND(_pre_process, "scene");
 	GDVIRTUAL_BIND(_post_process, "scene");
 
@@ -251,11 +238,11 @@ void EditorScenePostImportPlugin::_bind_methods() {
 /////////////////////////////////////////////////////////
 
 String ResourceImporterScene::get_importer_name() const {
-	return "scene";
+	return animation_importer ? "animation_library" : "scene";
 }
 
 String ResourceImporterScene::get_visible_name() const {
-	return "Scene";
+	return animation_importer ? "Animation Library" : "Scene";
 }
 
 void ResourceImporterScene::get_recognized_extensions(List<String> *p_extensions) const {
@@ -265,11 +252,11 @@ void ResourceImporterScene::get_recognized_extensions(List<String> *p_extensions
 }
 
 String ResourceImporterScene::get_save_extension() const {
-	return "scn";
+	return animation_importer ? "res" : "scn";
 }
 
 String ResourceImporterScene::get_resource_type() const {
-	return "PackedScene";
+	return animation_importer ? "AnimationLibrary" : "PackedScene";
 }
 
 int ResourceImporterScene::get_format_version() const {
@@ -277,10 +264,18 @@ int ResourceImporterScene::get_format_version() const {
 }
 
 bool ResourceImporterScene::get_option_visibility(const String &p_path, const String &p_option, const Map<StringName, Variant> &p_options) const {
-	if (p_option.begins_with("animation/")) {
+	if (animation_importer) {
+		if (p_option == "animation/import") { // Option ignored, animation always imported.
+			return false;
+		}
+	} else if (p_option.begins_with("animation/")) {
 		if (p_option != "animation/import" && !bool(p_options["animation/import"])) {
 			return false;
 		}
+	}
+
+	if (animation_importer && (p_option.begins_with("nodes/") || p_option.begins_with("meshes/") || p_option.begins_with("skins/"))) {
+		return false; // Nothing to do here for animations.
 	}
 
 	if (p_option == "meshes/lightmap_texel_size" && int(p_options["meshes/light_baking"]) != 2) {
@@ -289,14 +284,14 @@ bool ResourceImporterScene::get_option_visibility(const String &p_path, const St
 	}
 
 	for (int i = 0; i < post_importer_plugins.size(); i++) {
-		Variant ret = post_importer_plugins.write[i]->get_option_visibility(p_path, p_option, p_options);
+		Variant ret = post_importer_plugins.write[i]->get_option_visibility(p_path, animation_importer, p_option, p_options);
 		if (ret.get_type() == Variant::BOOL) {
 			return ret;
 		}
 	}
 
 	for (Ref<EditorSceneFormatImporter> importer : importers) {
-		Variant ret = importer->get_option_visibility(p_path, p_option, p_options);
+		Variant ret = importer->get_option_visibility(p_path, animation_importer, p_option, p_options);
 		if (ret.get_type() == Variant::BOOL) {
 			return ret;
 		}
@@ -1482,7 +1477,7 @@ bool ResourceImporterScene::get_internal_option_visibility(InternalImportCategor
 	}
 
 	for (int i = 0; i < post_importer_plugins.size(); i++) {
-		Variant ret = post_importer_plugins.write[i]->get_internal_option_visibility(EditorScenePostImportPlugin::InternalImportCategory(p_category), p_option, p_options);
+		Variant ret = post_importer_plugins.write[i]->get_internal_option_visibility(EditorScenePostImportPlugin::InternalImportCategory(p_category), animation_importer, p_option, p_options);
 		if (ret.get_type() == Variant::BOOL) {
 			return ret;
 		}
@@ -1974,8 +1969,13 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 
 	int import_flags = 0;
 
-	if (bool(p_options["animation/import"])) {
+	if (animation_importer) {
 		import_flags |= EditorSceneFormatImporter::IMPORT_ANIMATION;
+		import_flags |= EditorSceneFormatImporter::IMPORT_DISCARD_MESHES_AND_MATERIALS;
+	} else {
+		if (bool(p_options["animation/import"])) {
+			import_flags |= EditorSceneFormatImporter::IMPORT_ANIMATION;
+		}
 	}
 
 	if (bool(p_options["skins/use_named_skins"])) {
@@ -2139,11 +2139,35 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 
 	progress.step(TTR("Saving..."), 104);
 
-	Ref<PackedScene> packer = memnew(PackedScene);
-	packer->pack(scene);
-	print_verbose("Saving scene to: " + p_save_path + ".scn");
-	err = ResourceSaver::save(p_save_path + ".scn", packer); //do not take over, let the changed files reload themselves
-	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save scene to file '" + p_save_path + ".scn'.");
+	if (animation_importer) {
+		Ref<AnimationLibrary> library;
+		for (int i = 0; i < scene->get_child_count(); i++) {
+			AnimationPlayer *ap = Object::cast_to<AnimationPlayer>(scene->get_child(i));
+			if (ap) {
+				List<StringName> libs;
+				ap->get_animation_library_list(&libs);
+				if (libs.size()) {
+					library = ap->get_animation_library(libs.front()->get());
+					break;
+				}
+			}
+		}
+
+		if (!library.is_valid()) {
+			library.instantiate(); // Will be empty
+		}
+
+		print_verbose("Saving animation to: " + p_save_path + ".scn");
+		err = ResourceSaver::save(p_save_path + ".res", library); //do not take over, let the changed files reload themselves
+		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save animation to file '" + p_save_path + ".res'.");
+
+	} else {
+		Ref<PackedScene> packer = memnew(PackedScene);
+		packer->pack(scene);
+		print_verbose("Saving scene to: " + p_save_path + ".scn");
+		err = ResourceSaver::save(p_save_path + ".scn", packer); //do not take over, let the changed files reload themselves
+		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save scene to file '" + p_save_path + ".scn'.");
+	}
 
 	memdelete(scene);
 
@@ -2153,17 +2177,26 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 	return OK;
 }
 
-ResourceImporterScene *ResourceImporterScene::singleton = nullptr;
+ResourceImporterScene *ResourceImporterScene::scene_singleton = nullptr;
+ResourceImporterScene *ResourceImporterScene::animation_singleton = nullptr;
+
+Vector<Ref<EditorSceneFormatImporter>> ResourceImporterScene::importers;
+Vector<Ref<EditorScenePostImportPlugin>> ResourceImporterScene::post_importer_plugins;
 
 bool ResourceImporterScene::ResourceImporterScene::has_advanced_options() const {
 	return true;
 }
 void ResourceImporterScene::ResourceImporterScene::show_advanced_options(const String &p_path) {
-	SceneImportSettings::get_singleton()->open_settings(p_path);
+	SceneImportSettings::get_singleton()->open_settings(p_path, animation_importer);
 }
 
-ResourceImporterScene::ResourceImporterScene() {
-	singleton = this;
+ResourceImporterScene::ResourceImporterScene(bool p_animation_import) {
+	if (p_animation_import) {
+		animation_singleton = this;
+	} else {
+		scene_singleton = this;
+	}
+	animation_importer = p_animation_import;
 }
 
 void ResourceImporterScene::add_importer(Ref<EditorSceneFormatImporter> p_importer, bool p_first_priority) {
@@ -2192,6 +2225,11 @@ void ResourceImporterScene::remove_importer(Ref<EditorSceneFormatImporter> p_imp
 	importers.erase(p_importer);
 }
 
+void ResourceImporterScene::clean_up_importer_plugins() {
+	importers.clear();
+	post_importer_plugins.clear();
+}
+
 ///////////////////////////////////////
 
 uint32_t EditorSceneFormatImporterESCN::get_import_flags() const {
@@ -2211,8 +2249,4 @@ Node *EditorSceneFormatImporterESCN::import_scene(const String &p_path, uint32_t
 	ERR_FAIL_COND_V(!scene, nullptr);
 
 	return scene;
-}
-
-Ref<Animation> EditorSceneFormatImporterESCN::import_animation(const String &p_path, uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps) {
-	ERR_FAIL_V(Ref<Animation>());
 }

--- a/editor/import/scene_import_settings.h
+++ b/editor/import/scene_import_settings.h
@@ -189,12 +189,17 @@ class SceneImportSettings : public ConfirmationDialog {
 
 	void _load_default_subresource_settings(Map<StringName, Variant> &settings, const String &p_type, const String &p_import_id, ResourceImporterScene::InternalImportCategory p_category);
 
+	bool editing_animation = false;
+
+	Timer *update_view_timer;
+
 protected:
 	void _notification(int p_what);
 
 public:
+	bool is_editing_animation() const { return editing_animation; }
 	void update_view();
-	void open_settings(const String &p_path);
+	void open_settings(const String &p_path, bool p_for_animation = false);
 	static SceneImportSettings *get_singleton();
 	SceneImportSettings();
 	~SceneImportSettings();

--- a/modules/gltf/editor/editor_scene_importer_blend.cpp
+++ b/modules/gltf/editor/editor_scene_importer_blend.cpp
@@ -238,13 +238,12 @@ Node *EditorSceneFormatImporterBlend::import_scene(const String &p_path, uint32_
 	return gltf->generate_scene(state, p_bake_fps);
 }
 
-Ref<Animation> EditorSceneFormatImporterBlend::import_animation(const String &p_path, uint32_t p_flags,
-		const Map<StringName, Variant> &p_options, int p_bake_fps) {
-	return Ref<Animation>();
-}
-
-Variant EditorSceneFormatImporterBlend::get_option_visibility(const String &p_path, const String &p_option,
+Variant EditorSceneFormatImporterBlend::get_option_visibility(const String &p_path, bool p_for_animation, const String &p_option,
 		const Map<StringName, Variant> &p_options) {
+	if (p_path.get_extension().to_lower() != "blend") {
+		return true;
+	}
+
 	if (p_option.begins_with("animation/")) {
 		if (p_option != "animation/import" && !bool(p_options["animation/import"])) {
 			return false;
@@ -254,6 +253,9 @@ Variant EditorSceneFormatImporterBlend::get_option_visibility(const String &p_pa
 }
 
 void EditorSceneFormatImporterBlend::get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options) {
+	if (p_path.get_extension().to_lower() != "blend") {
+		return;
+	}
 #define ADD_OPTION_BOOL(PATH, VALUE) \
 	r_options->push_back(ResourceImporter::ImportOption(PropertyInfo(Variant::BOOL, SNAME(PATH)), VALUE));
 #define ADD_OPTION_ENUM(PATH, ENUM_HINT, VALUE) \

--- a/modules/gltf/editor/editor_scene_importer_blend.h
+++ b/modules/gltf/editor/editor_scene_importer_blend.h
@@ -68,11 +68,9 @@ public:
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const Map<StringName, Variant> &p_options, int p_bake_fps,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;
-	virtual Ref<Animation> import_animation(const String &p_path, uint32_t p_flags,
-			const Map<StringName, Variant> &p_options, int p_bake_fps) override;
 	virtual void get_import_options(const String &p_path,
 			List<ResourceImporter::ImportOption> *r_options) override;
-	virtual Variant get_option_visibility(const String &p_path, const String &p_option,
+	virtual Variant get_option_visibility(const String &p_path, bool p_for_animation, const String &p_option,
 			const Map<StringName, Variant> &p_options) override;
 };
 

--- a/modules/gltf/editor/editor_scene_importer_fbx.cpp
+++ b/modules/gltf/editor/editor_scene_importer_fbx.cpp
@@ -105,12 +105,7 @@ Node *EditorSceneFormatImporterFBX::import_scene(const String &p_path, uint32_t 
 	return gltf->generate_scene(state, p_bake_fps);
 }
 
-Ref<Animation> EditorSceneFormatImporterFBX::import_animation(const String &p_path,
-		uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps) {
-	return Ref<Animation>();
-}
-
-Variant EditorSceneFormatImporterFBX::get_option_visibility(const String &p_path,
+Variant EditorSceneFormatImporterFBX::get_option_visibility(const String &p_path, bool p_for_animation,
 		const String &p_option, const Map<StringName, Variant> &p_options) {
 	return true;
 }

--- a/modules/gltf/editor/editor_scene_importer_fbx.h
+++ b/modules/gltf/editor/editor_scene_importer_fbx.h
@@ -47,11 +47,9 @@ public:
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const Map<StringName, Variant> &p_options, int p_bake_fps,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;
-	virtual Ref<Animation> import_animation(const String &p_path, uint32_t p_flags,
-			const Map<StringName, Variant> &p_options, int p_bake_fps) override;
 	virtual void get_import_options(const String &p_path,
 			List<ResourceImporter::ImportOption> *r_options) override;
-	virtual Variant get_option_visibility(const String &p_path, const String &p_option,
+	virtual Variant get_option_visibility(const String &p_path, bool p_for_animation, const String &p_option,
 			const Map<StringName, Variant> &p_options) override;
 };
 

--- a/modules/gltf/editor/editor_scene_importer_gltf.cpp
+++ b/modules/gltf/editor/editor_scene_importer_gltf.cpp
@@ -64,9 +64,4 @@ Node *EditorSceneFormatImporterGLTF::import_scene(const String &p_path, uint32_t
 	return doc->generate_scene(state, p_bake_fps);
 }
 
-Ref<Animation> EditorSceneFormatImporterGLTF::import_animation(const String &p_path,
-		uint32_t p_flags, const Map<StringName, Variant> &p_options, int p_bake_fps) {
-	return Ref<Animation>();
-}
-
 #endif // TOOLS_ENABLED

--- a/modules/gltf/editor/editor_scene_importer_gltf.h
+++ b/modules/gltf/editor/editor_scene_importer_gltf.h
@@ -47,8 +47,6 @@ public:
 	virtual Node *import_scene(const String &p_path, uint32_t p_flags,
 			const Map<StringName, Variant> &p_options, int p_bake_fps,
 			List<String> *r_missing_deps, Error *r_err = nullptr) override;
-	virtual Ref<Animation> import_animation(const String &p_path, uint32_t p_flags,
-			const Map<StringName, Variant> &p_options, int p_bake_fps) override;
 };
 
 #endif // TOOLS_ENABLED

--- a/modules/gltf/register_types.cpp
+++ b/modules/gltf/register_types.cpp
@@ -60,7 +60,7 @@
 static void _editor_init() {
 	Ref<EditorSceneFormatImporterGLTF> import_gltf;
 	import_gltf.instantiate();
-	ResourceImporterScene::get_singleton()->add_importer(import_gltf);
+	ResourceImporterScene::add_importer(import_gltf);
 
 	// Blend to glTF importer.
 
@@ -72,7 +72,7 @@ static void _editor_init() {
 	if (blend_enabled) {
 		Ref<EditorSceneFormatImporterBlend> importer;
 		importer.instantiate();
-		ResourceImporterScene::get_singleton()->add_importer(importer);
+		ResourceImporterScene::add_importer(importer);
 
 		Ref<EditorFileSystemImportFormatSupportQueryBlend> blend_import_query;
 		blend_import_query.instantiate();
@@ -95,7 +95,7 @@ static void _editor_init() {
 		} else {
 			Ref<EditorSceneFormatImporterFBX> importer;
 			importer.instantiate();
-			ResourceImporterScene::get_singleton()->add_importer(importer);
+			ResourceImporterScene::add_importer(importer);
 		}
 	}
 }


### PR DESCRIPTION
Added the ability to import scenes as AnimationLibrary

* Completes implementation of https://github.com/godotengine/godot-proposals/issues/4296
* Helps if you want to export animations to a separate file (say a GLTF) to avoid re-importing/exporting them every time the model changes.
* Helps if you simply want to have animations using a dummy model, which can be shared across multiple models.

Creates a secondary scene importer used only for animations.

Screens of usage:

Simply choose any scene file and change the import type from Scene to AnimationLibrary:
![image](https://user-images.githubusercontent.com/6265307/163059258-53554c6a-e64a-44cf-8fee-3e56c1907dea.png)
Then, the resulting file can be imported into an existing animation player as a library:
![image](https://user-images.githubusercontent.com/6265307/163059356-743a038f-e4ba-4aec-9bc0-c6d36fe504f1.png)


**NOTE**: A new flag for scene importer: EditorSceneFormatImporter.IMPORT_DISCARD_MESHES_AND_MATERIALS has been added, to hint importers that they should skip meshes and animations (and hence make importing faster). It is not implemented in any importer yet, this should be done in a separate PR.

Bonus: A couple of bugs fixed in the advanced import settings regarding to option visibility.

bugsquad edit:

Fixes: https://github.com/godotengine/godot/issues/60060