### PR TITLE
Use lower shadow normal bias for distant directional shadow splits (reverted)

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -714,7 +714,9 @@ void LightStorage::update_light_buffers(RenderDataRD *p_render_data, const Paged
 						light_data.shadow_split_offsets[j] = split;
 						float bias_scale = light_instance->shadow_transform[j].bias_scale * light_data.soft_shadow_scale;
 						light_data.shadow_bias[j] = light->param[RS::LIGHT_PARAM_SHADOW_BIAS] / 100.0 * bias_scale;
-						light_data.shadow_normal_bias[j] = light->param[RS::LIGHT_PARAM_SHADOW_NORMAL_BIAS] * light_instance->shadow_transform[j].shadow_texel_size;
+						// Use lower shadow normal bias for distant splits, relative to the share taken by the split.
+						// This helps reduce peter-panning at a distance.
+						light_data.shadow_normal_bias[j] = light->param[RS::LIGHT_PARAM_SHADOW_NORMAL_BIAS] * light_instance->shadow_transform[j].shadow_texel_size * light_data.shadow_split_offsets[0] / split;
 						light_data.shadow_transmittance_bias[j] = light->param[RS::LIGHT_PARAM_TRANSMITTANCE_BIAS] / 100.0 * bias_scale;
 						light_data.shadow_z_range[j] = light_instance->shadow_transform[j].farplane;
 						light_data.shadow_range_begin[j] = light_instance->shadow_transform[j].range_begin;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/48776.

This reduces the visual discrepancy between shadow splits when Normal Bias is greater than 0. Shadow acne at a distance may be slightly more present, but if the bias and normal bias values are tuned to avoid acne up close, acne will usually not be present in distant splits.

Tested on desktop (PCSS + PCF) and mobile (PCF) backends, with and without Blend Splits enabled. Performance is identical compared to before.

**Testing project:** [test_shadow_splits.zip](https://github.com/user-attachments/files/18131989/test_shadow_splits.zip)

## Preview

### Stills (from the MRP)

#### Blend Splits disabled

Before | After
-|-
![Screenshot_20241213_222624](https://github.com/user-attachments/assets/e6612f2d-b566-4192-b4fd-b22d9979d6a1) | ![Screenshot_20241213_222851](https://github.com/user-attachments/assets/953f8e3d-30a5-45de-be87-648b084562e0)

#### Blend Splits enabled

Before | After
-|-
![Screenshot_20241213_222631](https://github.com/user-attachments/assets/9aff1622-604f-4d59-b09f-36630b19d76c) | ![Screenshot_20241213_222856](https://github.com/user-attachments/assets/ec24adaf-c73d-4fab-99fd-03e6d22ca31f)

### In motion

*Normal Bias was increased to 10 to exagerate the difference. Usually, the difference isn't as pronounced, but it can still be significant when using Normal Bias set to 2 as done in https://github.com/godotengine/godot/pull/55757.*

### Before

https://user-images.githubusercontent.com/180032/162993467-b17af410-587a-4f1d-b954-d213986f61fe.mp4

### After

https://user-images.githubusercontent.com/180032/162993523-77409f26-1b6e-433a-b516-99f0d7e70b3a.mp4