### PR TITLE
[3.x] Fix handling of async hidden render mode

### DIFF
--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -397,6 +397,7 @@ public:
 	void set_custom_shader_code(uint32_t p_code_id, const String &p_vertex, const String &p_vertex_globals, const String &p_fragment, const String &p_light, const String &p_fragment_globals, const String &p_uniforms, const Vector<StringName> &p_texture_uniforms, const Vector<CharString> &p_custom_defines, AsyncMode p_async_mode);
 	void set_custom_shader(uint32_t p_code_id);
 	void free_custom_shader(uint32_t p_code_id);
+	bool is_custom_code_ready_for_render(uint32_t p_code_id);
 
 	uint32_t get_version() const { return new_conditional_version.version; }
 	bool is_version_ubershader() const { return (new_conditional_version.version & VersionKey::UBERSHADER_FLAG); }


### PR DESCRIPTION
- Mute errors when conditioned shader is not ready yet [This is the specific issue in the bug report.]
- Avoid depth pre-pass on meshes that would end up black [This is for free. 😎]

Fixes #60105.