### PR TITLE
Add Environment properties to control fog rendering on background sky

### DIFF
--- a/doc/classes/Environment.xml
+++ b/doc/classes/Environment.xml
@@ -94,7 +94,7 @@
 			The background mode. See [enum BGMode] for possible values.
 		</member>
 		<member name="fog_aerial_perspective" type="float" setter="set_fog_aerial_perspective" getter="get_fog_aerial_perspective" default="0.0">
-			Blend factor between the fog's color and the color of the background [Sky]. Must have [member background_mode] set to [constant BG_SKY].
+			If set above [code]0.0[/code] (exclusive), blends between the fog's color and the color of the background [Sky]. This has a small performance cost when set above [code]0.0[/code]. Must have [member background_mode] set to [constant BG_SKY].
 			This is useful to simulate [url=https://en.wikipedia.org/wiki/Aerial_perspective]aerial perspective[/url] in large scenes with low density fog. However, it is not very useful for high-density fog, as the sky will shine through. When set to [code]1.0[/code], the fog color comes completely from the [Sky]. If set to [code]0.0[/code], aerial perspective is disabled.
 		</member>
 		<member name="fog_density" type="float" setter="set_fog_density" getter="get_fog_density" default="0.01">
@@ -114,6 +114,10 @@
 		</member>
 		<member name="fog_light_energy" type="float" setter="set_fog_light_energy" getter="get_fog_light_energy" default="1.0">
 			The fog's brightness. Higher values result in brighter fog.
+		</member>
+		<member name="fog_sky_affect" type="float" setter="set_fog_sky_affect" getter="get_fog_sky_affect" default="1.0">
+			The factor to use when affecting the sky with non-volumetric fog. [code]1.0[/code] means that fog can fully obscure the sky. Lower values reduce the impact of fog on sky rendering, with [code]0.0[/code] not affecting sky rendering at all.
+			[b]Note:[/b] [member fog_sky_affect] has no visual effect if [member fog_aerial_perspective] is [code]1.0[/code].
 		</member>
 		<member name="fog_sun_scatter" type="float" setter="set_fog_sun_scatter" getter="get_fog_sun_scatter" default="0.0">
 			If set above [code]0.0[/code], renders the scene's directional light(s) in the fog color depending on the view angle. This can be used to give the impression that the sun is "piercing" through the fog.
@@ -326,6 +330,9 @@
 		</member>
 		<member name="volumetric_fog_length" type="float" setter="set_volumetric_fog_length" getter="get_volumetric_fog_length" default="64.0">
 			The distance over which the volumetric fog is computed. Increase to compute fog over a greater range, decrease to add more detail when a long range is not needed. For best quality fog, keep this as low as possible.
+		</member>
+		<member name="volumetric_fog_sky_affect" type="float" setter="set_volumetric_fog_sky_affect" getter="get_volumetric_fog_sky_affect" default="1.0">
+			The factor to use when affecting the sky with volumetric fog. [code]1.0[/code] means that volumetric fog can fully obscure the sky. Lower values reduce the impact of volumetric fog on sky rendering, with [code]0.0[/code] not affecting sky rendering at all.
 		</member>
 		<member name="volumetric_fog_temporal_reprojection_amount" type="float" setter="set_volumetric_fog_temporal_reprojection_amount" getter="get_volumetric_fog_temporal_reprojection_amount" default="0.9">
 			The amount by which to blend the last frame with the current frame. A higher number results in smoother volumetric fog, but makes "ghosting" much worse. A lower value reduces ghosting but can result in the per-frame temporal jitter becoming visible.

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -1000,6 +1000,7 @@
 			<param index="6" name="height" type="float" />
 			<param index="7" name="height_density" type="float" />
 			<param index="8" name="aerial_perspective" type="float" />
+			<param index="9" name="sky_affect" type="float" />
 			<description>
 			</description>
 		</method>
@@ -1167,6 +1168,7 @@
 			<param index="10" name="temporal_reprojection" type="bool" />
 			<param index="11" name="temporal_reprojection_amount" type="float" />
 			<param index="12" name="ambient_inject" type="float" />
+			<param index="13" name="sky_affect" type="float" />
 			<description>
 			</description>
 		</method>

--- a/scene/resources/environment.cpp
+++ b/scene/resources/environment.cpp
@@ -852,6 +852,15 @@ float Environment::get_fog_aerial_perspective() const {
 	return fog_aerial_perspective;
 }
 
+void Environment::set_fog_sky_affect(float p_sky_affect) {
+	fog_sky_affect = p_sky_affect;
+	_update_fog();
+}
+
+float Environment::get_fog_sky_affect() const {
+	return fog_sky_affect;
+}
+
 void Environment::_update_fog() {
 	RS::get_singleton()->environment_set_fog(
 			environment,
@@ -862,13 +871,28 @@ void Environment::_update_fog() {
 			fog_density,
 			fog_height,
 			fog_height_density,
-			fog_aerial_perspective);
+			fog_aerial_perspective,
+			fog_sky_affect);
 }
 
 // Volumetric Fog
 
 void Environment::_update_volumetric_fog() {
-	RS::get_singleton()->environment_set_volumetric_fog(environment, volumetric_fog_enabled, volumetric_fog_density, volumetric_fog_albedo, volumetric_fog_emission, volumetric_fog_emission_energy, volumetric_fog_anisotropy, volumetric_fog_length, volumetric_fog_detail_spread, volumetric_fog_gi_inject, volumetric_fog_temporal_reproject, volumetric_fog_temporal_reproject_amount, volumetric_fog_ambient_inject);
+	RS::get_singleton()->environment_set_volumetric_fog(
+			environment,
+			volumetric_fog_enabled,
+			volumetric_fog_density,
+			volumetric_fog_albedo,
+			volumetric_fog_emission,
+			volumetric_fog_emission_energy,
+			volumetric_fog_anisotropy,
+			volumetric_fog_length,
+			volumetric_fog_detail_spread,
+			volumetric_fog_gi_inject,
+			volumetric_fog_temporal_reproject,
+			volumetric_fog_temporal_reproject_amount,
+			volumetric_fog_ambient_inject,
+			volumetric_fog_sky_affect);
 }
 
 void Environment::set_volumetric_fog_enabled(bool p_enable) {
@@ -944,6 +968,15 @@ void Environment::set_volumetric_fog_ambient_inject(float p_ambient_inject) {
 }
 float Environment::get_volumetric_fog_ambient_inject() const {
 	return volumetric_fog_ambient_inject;
+}
+
+void Environment::set_volumetric_fog_sky_affect(float p_sky_affect) {
+	volumetric_fog_sky_affect = p_sky_affect;
+	_update_volumetric_fog();
+}
+
+float Environment::get_volumetric_fog_sky_affect() const {
+	return volumetric_fog_sky_affect;
 }
 
 void Environment::set_volumetric_fog_temporal_reprojection_enabled(bool p_enable) {
@@ -1419,6 +1452,9 @@ void Environment::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_fog_aerial_perspective", "aerial_perspective"), &Environment::set_fog_aerial_perspective);
 	ClassDB::bind_method(D_METHOD("get_fog_aerial_perspective"), &Environment::get_fog_aerial_perspective);
 
+	ClassDB::bind_method(D_METHOD("set_fog_sky_affect", "sky_affect"), &Environment::set_fog_sky_affect);
+	ClassDB::bind_method(D_METHOD("get_fog_sky_affect"), &Environment::get_fog_sky_affect);
+
 	ADD_GROUP("Fog", "fog_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "fog_enabled"), "set_fog_enabled", "is_fog_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "fog_light_color", PROPERTY_HINT_COLOR_NO_ALPHA), "set_fog_light_color", "get_fog_light_color");
@@ -1427,6 +1463,7 @@ void Environment::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_density", PROPERTY_HINT_RANGE, "0,1,0.0001,or_greater"), "set_fog_density", "get_fog_density");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_aerial_perspective", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_fog_aerial_perspective", "get_fog_aerial_perspective");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_sky_affect", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_fog_sky_affect", "get_fog_sky_affect");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_height", PROPERTY_HINT_RANGE, "-1024,1024,0.01,or_lesser,or_greater,suffix:m"), "set_fog_height", "get_fog_height");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fog_height_density", PROPERTY_HINT_RANGE, "-16,16,0.0001,or_lesser,or_greater"), "set_fog_height_density", "get_fog_height_density");
 
@@ -1450,6 +1487,8 @@ void Environment::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_volumetric_fog_gi_inject"), &Environment::get_volumetric_fog_gi_inject);
 	ClassDB::bind_method(D_METHOD("set_volumetric_fog_ambient_inject", "enabled"), &Environment::set_volumetric_fog_ambient_inject);
 	ClassDB::bind_method(D_METHOD("get_volumetric_fog_ambient_inject"), &Environment::get_volumetric_fog_ambient_inject);
+	ClassDB::bind_method(D_METHOD("set_volumetric_fog_sky_affect", "sky_affect"), &Environment::set_volumetric_fog_sky_affect);
+	ClassDB::bind_method(D_METHOD("get_volumetric_fog_sky_affect"), &Environment::get_volumetric_fog_sky_affect);
 	ClassDB::bind_method(D_METHOD("set_volumetric_fog_temporal_reprojection_enabled", "enabled"), &Environment::set_volumetric_fog_temporal_reprojection_enabled);
 	ClassDB::bind_method(D_METHOD("is_volumetric_fog_temporal_reprojection_enabled"), &Environment::is_volumetric_fog_temporal_reprojection_enabled);
 	ClassDB::bind_method(D_METHOD("set_volumetric_fog_temporal_reprojection_amount", "temporal_reprojection_amount"), &Environment::set_volumetric_fog_temporal_reprojection_amount);
@@ -1466,6 +1505,7 @@ void Environment::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volumetric_fog_length", PROPERTY_HINT_RANGE, "0,1024,0.01,or_greater"), "set_volumetric_fog_length", "get_volumetric_fog_length");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volumetric_fog_detail_spread", PROPERTY_HINT_EXP_EASING, "positive_only"), "set_volumetric_fog_detail_spread", "get_volumetric_fog_detail_spread");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volumetric_fog_ambient_inject", PROPERTY_HINT_RANGE, "0.0,16,0.01,exp"), "set_volumetric_fog_ambient_inject", "get_volumetric_fog_ambient_inject");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volumetric_fog_sky_affect", PROPERTY_HINT_RANGE, "0,1,0.001"), "set_volumetric_fog_sky_affect", "get_volumetric_fog_sky_affect");
 	ADD_SUBGROUP("Temporal Reprojection", "volumetric_fog_temporal_reprojection_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "volumetric_fog_temporal_reprojection_enabled"), "set_volumetric_fog_temporal_reprojection_enabled", "is_volumetric_fog_temporal_reprojection_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volumetric_fog_temporal_reprojection_amount", PROPERTY_HINT_RANGE, "0.5,0.99,0.001"), "set_volumetric_fog_temporal_reprojection_amount", "get_volumetric_fog_temporal_reprojection_amount");

--- a/scene/resources/environment.h
+++ b/scene/resources/environment.h
@@ -182,6 +182,7 @@ private:
 	float fog_height = 0.0;
 	float fog_height_density = 0.0; //can be negative to invert effect
 	float fog_aerial_perspective = 0.0;
+	float fog_sky_affect = 1.0;
 
 	void _update_fog();
 
@@ -196,6 +197,7 @@ private:
 	float volumetric_fog_detail_spread = 2.0;
 	float volumetric_fog_gi_inject = 1.0;
 	float volumetric_fog_ambient_inject = 0.0;
+	float volumetric_fog_sky_affect = 1.0;
 	bool volumetric_fog_temporal_reproject = true;
 	float volumetric_fog_temporal_reproject_amount = 0.9;
 	void _update_volumetric_fog();
@@ -385,6 +387,8 @@ public:
 	float get_fog_height_density() const;
 	void set_fog_aerial_perspective(float p_aerial_perspective);
 	float get_fog_aerial_perspective() const;
+	void set_fog_sky_affect(float p_sky_affect);
+	float get_fog_sky_affect() const;
 
 	// Volumetric Fog
 	void set_volumetric_fog_enabled(bool p_enable);
@@ -407,6 +411,8 @@ public:
 	float get_volumetric_fog_gi_inject() const;
 	void set_volumetric_fog_ambient_inject(float p_ambient_inject);
 	float get_volumetric_fog_ambient_inject() const;
+	void set_volumetric_fog_sky_affect(float p_sky_affect);
+	float get_volumetric_fog_sky_affect() const;
 	void set_volumetric_fog_temporal_reprojection_enabled(bool p_enable);
 	bool is_volumetric_fog_temporal_reprojection_enabled() const;
 	void set_volumetric_fog_temporal_reprojection_amount(float p_amount);

--- a/servers/rendering/renderer_rd/environment/sky.cpp
+++ b/servers/rendering/renderer_rd/environment/sky.cpp
@@ -1319,6 +1319,9 @@ void SkyRD::setup(RID p_env, RID p_render_buffers, const PagedArray<RID> &p_ligh
 	sky_scene_state.ubo.fog_light_color[2] = fog_color.b * fog_energy;
 	sky_scene_state.ubo.fog_sun_scatter = RendererSceneRenderRD::get_singleton()->environment_get_fog_sun_scatter(p_env);
 
+	sky_scene_state.ubo.fog_sky_affect = RendererSceneRenderRD::get_singleton()->environment_get_fog_sky_affect(p_env);
+	sky_scene_state.ubo.volumetric_fog_sky_affect = RendererSceneRenderRD::get_singleton()->environment_get_volumetric_fog_sky_affect(p_env);
+
 	RD::get_singleton()->buffer_update(sky_scene_state.uniform_buffer, 0, sizeof(SkySceneState::UBO), &sky_scene_state.ubo);
 }
 

--- a/servers/rendering/renderer_rd/environment/sky.h
+++ b/servers/rendering/renderer_rd/environment/sky.h
@@ -148,20 +148,23 @@ private:
 public:
 	struct SkySceneState {
 		struct UBO {
-			uint32_t volumetric_fog_enabled;
-			float volumetric_fog_inv_length;
-			float volumetric_fog_detail_spread;
+			uint32_t volumetric_fog_enabled; // 4 - 4
+			float volumetric_fog_inv_length; // 4 - 8
+			float volumetric_fog_detail_spread; // 4 - 12
+			float volumetric_fog_sky_affect; // 4 - 16
 
-			float fog_aerial_perspective;
+			uint32_t fog_enabled; // 4 - 20
+			float fog_sky_affect; // 4 - 24
+			float fog_density; // 4 - 28
+			float fog_sun_scatter; // 4 - 32
 
-			float fog_light_color[3];
-			float fog_sun_scatter;
+			float fog_light_color[3]; // 12 - 44
+			float fog_aerial_perspective; // 4 - 48
 
-			uint32_t fog_enabled;
-			float fog_density;
-
-			float z_far;
-			uint32_t directional_light_count;
+			float z_far; // 4 - 52
+			uint32_t directional_light_count; // 4 - 56
+			uint32_t pad1; // 4 - 60
+			uint32_t pad2; // 4 - 64
 		};
 
 		UBO ubo;

--- a/servers/rendering/renderer_rd/shaders/environment/sky.glsl
+++ b/servers/rendering/renderer_rd/shaders/environment/sky.glsl
@@ -83,20 +83,23 @@ layout(set = 0, binding = 1, std430) restrict readonly buffer GlobalShaderUnifor
 global_shader_uniforms;
 
 layout(set = 0, binding = 2, std140) uniform SceneData {
-	bool volumetric_fog_enabled;
-	float volumetric_fog_inv_length;
-	float volumetric_fog_detail_spread;
+	bool volumetric_fog_enabled; // 4 - 4
+	float volumetric_fog_inv_length; // 4 - 8
+	float volumetric_fog_detail_spread; // 4 - 12
+	float volumetric_fog_sky_affect; // 4 - 16
 
-	float fog_aerial_perspective;
+	bool fog_enabled; // 4 - 20
+	float fog_sky_affect; // 4 - 24
+	float fog_density; // 4 - 28
+	float fog_sun_scatter; // 4 - 32
 
-	vec3 fog_light_color;
-	float fog_sun_scatter;
+	vec3 fog_light_color; // 12 - 44
+	float fog_aerial_perspective; // 4 - 48
 
-	bool fog_enabled;
-	float fog_density;
-
-	float z_far;
-	uint directional_light_count;
+	float z_far; // 4 - 52
+	uint directional_light_count; // 4 - 56
+	uint pad1; // 4 - 60
+	uint pad2; // 4 - 64
 }
 scene_data;
 
@@ -169,9 +172,7 @@ vec4 fog_process(vec3 view, vec3 sky_color) {
 		}
 	}
 
-	float fog_amount = clamp(1.0 - exp(-scene_data.z_far * scene_data.fog_density), 0.0, 1.0);
-
-	return vec4(fog_color, fog_amount);
+	return vec4(fog_color, 1.0);
 }
 
 void main() {
@@ -228,12 +229,12 @@ void main() {
 	// Draw "fixed" fog before volumetric fog to ensure volumetric fog can appear in front of the sky.
 	if (scene_data.fog_enabled) {
 		vec4 fog = fog_process(cube_normal, frag_color.rgb);
-		frag_color.rgb = mix(frag_color.rgb, fog.rgb, fog.a);
+		frag_color.rgb = mix(frag_color.rgb, fog.rgb, fog.a * scene_data.fog_sky_affect);
 	}
 
 	if (scene_data.volumetric_fog_enabled) {
 		vec4 fog = volumetric_fog_process(uv);
-		frag_color.rgb = mix(frag_color.rgb, fog.rgb, fog.a);
+		frag_color.rgb = mix(frag_color.rgb, fog.rgb, fog.a * scene_data.volumetric_fog_sky_affect);
 	}
 
 	if (custom_fog.a > 0.0) {

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -159,7 +159,7 @@ public:
 	virtual uint64_t environment_get_auto_exposure_version(RID p_env) const = 0;
 
 	// Fog
-	virtual void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective) = 0;
+	virtual void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective, float p_sky_affect) = 0;
 
 	virtual bool environment_get_fog_enabled(RID p_env) const = 0;
 	virtual Color environment_get_fog_light_color(RID p_env) const = 0;
@@ -169,9 +169,10 @@ public:
 	virtual float environment_get_fog_height(RID p_env) const = 0;
 	virtual float environment_get_fog_height_density(RID p_env) const = 0;
 	virtual float environment_get_fog_aerial_perspective(RID p_env) const = 0;
+	virtual float environment_get_fog_sky_affect(RID p_env) const = 0;
 
 	// Volumetric Fog
-	virtual void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject) = 0;
+	virtual void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect) = 0;
 
 	virtual bool environment_get_volumetric_fog_enabled(RID p_env) const = 0;
 	virtual float environment_get_volumetric_fog_density(RID p_env) const = 0;
@@ -182,6 +183,7 @@ public:
 	virtual float environment_get_volumetric_fog_length(RID p_env) const = 0;
 	virtual float environment_get_volumetric_fog_detail_spread(RID p_env) const = 0;
 	virtual float environment_get_volumetric_fog_gi_inject(RID p_env) const = 0;
+	virtual float environment_get_volumetric_fog_sky_affect(RID p_env) const = 0;
 	virtual bool environment_get_volumetric_fog_temporal_reprojection(RID p_env) const = 0;
 	virtual float environment_get_volumetric_fog_temporal_reprojection_amount(RID p_env) const = 0;
 	virtual float environment_get_volumetric_fog_ambient_inject(RID p_env) const = 0;

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1129,13 +1129,14 @@ public:
 	PASS1RC(uint64_t, environment_get_auto_exposure_version, RID)
 
 	// Fog
-	PASS9(environment_set_fog, RID, bool, const Color &, float, float, float, float, float, float)
+	PASS10(environment_set_fog, RID, bool, const Color &, float, float, float, float, float, float, float)
 
 	PASS1RC(bool, environment_get_fog_enabled, RID)
 	PASS1RC(Color, environment_get_fog_light_color, RID)
 	PASS1RC(float, environment_get_fog_light_energy, RID)
 	PASS1RC(float, environment_get_fog_sun_scatter, RID)
 	PASS1RC(float, environment_get_fog_density, RID)
+	PASS1RC(float, environment_get_fog_sky_affect, RID)
 	PASS1RC(float, environment_get_fog_height, RID)
 	PASS1RC(float, environment_get_fog_height_density, RID)
 	PASS1RC(float, environment_get_fog_aerial_perspective, RID)
@@ -1144,7 +1145,7 @@ public:
 	PASS1(environment_set_volumetric_fog_filter_active, bool)
 
 	// Volumentric Fog
-	PASS13(environment_set_volumetric_fog, RID, bool, float, const Color &, const Color &, float, float, float, float, float, bool, float, float)
+	PASS14(environment_set_volumetric_fog, RID, bool, float, const Color &, const Color &, float, float, float, float, float, bool, float, float, float)
 
 	PASS1RC(bool, environment_get_volumetric_fog_enabled, RID)
 	PASS1RC(float, environment_get_volumetric_fog_density, RID)
@@ -1155,6 +1156,7 @@ public:
 	PASS1RC(float, environment_get_volumetric_fog_length, RID)
 	PASS1RC(float, environment_get_volumetric_fog_detail_spread, RID)
 	PASS1RC(float, environment_get_volumetric_fog_gi_inject, RID)
+	PASS1RC(float, environment_get_volumetric_fog_sky_affect, RID)
 	PASS1RC(bool, environment_get_volumetric_fog_temporal_reprojection, RID)
 	PASS1RC(float, environment_get_volumetric_fog_temporal_reprojection_amount, RID)
 	PASS1RC(float, environment_get_volumetric_fog_ambient_inject, RID)

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -328,8 +328,8 @@ uint64_t RendererSceneRender::environment_get_auto_exposure_version(RID p_env) c
 
 // Fog
 
-void RendererSceneRender::environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective) {
-	environment_storage.environment_set_fog(p_env, p_enable, p_light_color, p_light_energy, p_sun_scatter, p_density, p_height, p_height_density, p_aerial_perspective);
+void RendererSceneRender::environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective, float p_sky_affect) {
+	environment_storage.environment_set_fog(p_env, p_enable, p_light_color, p_light_energy, p_sun_scatter, p_density, p_height, p_height_density, p_aerial_perspective, p_sky_affect);
 }
 
 bool RendererSceneRender::environment_get_fog_enabled(RID p_env) const {
@@ -352,6 +352,10 @@ float RendererSceneRender::environment_get_fog_density(RID p_env) const {
 	return environment_storage.environment_get_fog_density(p_env);
 }
 
+float RendererSceneRender::environment_get_fog_sky_affect(RID p_env) const {
+	return environment_storage.environment_get_fog_sky_affect(p_env);
+}
+
 float RendererSceneRender::environment_get_fog_height(RID p_env) const {
 	return environment_storage.environment_get_fog_height(p_env);
 }
@@ -366,8 +370,8 @@ float RendererSceneRender::environment_get_fog_aerial_perspective(RID p_env) con
 
 // Volumetric Fog
 
-void RendererSceneRender::environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject) {
-	environment_storage.environment_set_volumetric_fog(p_env, p_enable, p_density, p_albedo, p_emission, p_emission_energy, p_anisotropy, p_length, p_detail_spread, p_gi_inject, p_temporal_reprojection, p_temporal_reprojection_amount, p_ambient_inject);
+void RendererSceneRender::environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect) {
+	environment_storage.environment_set_volumetric_fog(p_env, p_enable, p_density, p_albedo, p_emission, p_emission_energy, p_anisotropy, p_length, p_detail_spread, p_gi_inject, p_temporal_reprojection, p_temporal_reprojection_amount, p_ambient_inject, p_sky_affect);
 }
 
 bool RendererSceneRender::environment_get_volumetric_fog_enabled(RID p_env) const {
@@ -404,6 +408,10 @@ float RendererSceneRender::environment_get_volumetric_fog_detail_spread(RID p_en
 
 float RendererSceneRender::environment_get_volumetric_fog_gi_inject(RID p_env) const {
 	return environment_storage.environment_get_volumetric_fog_gi_inject(p_env);
+}
+
+float RendererSceneRender::environment_get_volumetric_fog_sky_affect(RID p_env) const {
+	return environment_storage.environment_get_volumetric_fog_sky_affect(p_env);
 }
 
 bool RendererSceneRender::environment_get_volumetric_fog_temporal_reprojection(RID p_env) const {

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -131,18 +131,19 @@ public:
 	uint64_t environment_get_auto_exposure_version(RID p_env) const;
 
 	// Fog
-	void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective);
+	void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective, float p_sky_affect);
 	bool environment_get_fog_enabled(RID p_env) const;
 	Color environment_get_fog_light_color(RID p_env) const;
 	float environment_get_fog_light_energy(RID p_env) const;
 	float environment_get_fog_sun_scatter(RID p_env) const;
 	float environment_get_fog_density(RID p_env) const;
+	float environment_get_fog_sky_affect(RID p_env) const;
 	float environment_get_fog_height(RID p_env) const;
 	float environment_get_fog_height_density(RID p_env) const;
 	float environment_get_fog_aerial_perspective(RID p_env) const;
 
 	// Volumetric Fog
-	void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject);
+	void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect);
 	bool environment_get_volumetric_fog_enabled(RID p_env) const;
 	float environment_get_volumetric_fog_density(RID p_env) const;
 	Color environment_get_volumetric_fog_scattering(RID p_env) const;
@@ -152,6 +153,7 @@ public:
 	float environment_get_volumetric_fog_length(RID p_env) const;
 	float environment_get_volumetric_fog_detail_spread(RID p_env) const;
 	float environment_get_volumetric_fog_gi_inject(RID p_env) const;
+	float environment_get_volumetric_fog_sky_affect(RID p_env) const;
 	bool environment_get_volumetric_fog_temporal_reprojection(RID p_env) const;
 	float environment_get_volumetric_fog_temporal_reprojection_amount(RID p_env) const;
 	float environment_get_volumetric_fog_ambient_inject(RID p_env) const;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -693,8 +693,8 @@ public:
 
 	FUNC7(environment_set_adjustment, RID, bool, float, float, float, bool, RID)
 
-	FUNC9(environment_set_fog, RID, bool, const Color &, float, float, float, float, float, float)
-	FUNC13(environment_set_volumetric_fog, RID, bool, float, const Color &, const Color &, float, float, float, float, float, bool, float, float)
+	FUNC10(environment_set_fog, RID, bool, const Color &, float, float, float, float, float, float, float)
+	FUNC14(environment_set_volumetric_fog, RID, bool, float, const Color &, const Color &, float, float, float, float, float, bool, float, float, float)
 
 	FUNC2(environment_set_volumetric_fog_volume_size, int, int)
 	FUNC1(environment_set_volumetric_fog_filter_active, bool)

--- a/servers/rendering/storage/environment_storage.cpp
+++ b/servers/rendering/storage/environment_storage.cpp
@@ -244,7 +244,7 @@ uint64_t RendererEnvironmentStorage::environment_get_auto_exposure_version(RID p
 
 // Fog
 
-void RendererEnvironmentStorage::environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_fog_aerial_perspective) {
+void RendererEnvironmentStorage::environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_fog_aerial_perspective, float p_sky_affect) {
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_COND(!env);
 	env->fog_enabled = p_enable;
@@ -255,6 +255,7 @@ void RendererEnvironmentStorage::environment_set_fog(RID p_env, bool p_enable, c
 	env->fog_height = p_height;
 	env->fog_height_density = p_height_density;
 	env->fog_aerial_perspective = p_fog_aerial_perspective;
+	env->fog_sky_affect = p_sky_affect;
 }
 
 bool RendererEnvironmentStorage::environment_get_fog_enabled(RID p_env) const {
@@ -305,9 +306,15 @@ float RendererEnvironmentStorage::environment_get_fog_aerial_perspective(RID p_e
 	return env->fog_aerial_perspective;
 }
 
+float RendererEnvironmentStorage::environment_get_fog_sky_affect(RID p_env) const {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND_V(!env, 0.0);
+	return env->fog_sky_affect;
+}
+
 // Volumetric Fog
 
-void RendererEnvironmentStorage::environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject) {
+void RendererEnvironmentStorage::environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect) {
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_COND(!env);
 	env->volumetric_fog_enabled = p_enable;
@@ -322,6 +329,7 @@ void RendererEnvironmentStorage::environment_set_volumetric_fog(RID p_env, bool 
 	env->volumetric_fog_temporal_reprojection = p_temporal_reprojection;
 	env->volumetric_fog_temporal_reprojection_amount = p_temporal_reprojection_amount;
 	env->volumetric_fog_ambient_inject = p_ambient_inject;
+	env->volumetric_fog_sky_affect = p_sky_affect;
 }
 
 bool RendererEnvironmentStorage::environment_get_volumetric_fog_enabled(RID p_env) const {
@@ -376,6 +384,12 @@ float RendererEnvironmentStorage::environment_get_volumetric_fog_gi_inject(RID p
 	Environment *env = environment_owner.get_or_null(p_env);
 	ERR_FAIL_COND_V(!env, 0.0);
 	return env->volumetric_fog_gi_inject;
+}
+
+float RendererEnvironmentStorage::environment_get_volumetric_fog_sky_affect(RID p_env) const {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND_V(!env, 0.0);
+	return env->volumetric_fog_sky_affect;
 }
 
 bool RendererEnvironmentStorage::environment_get_volumetric_fog_temporal_reprojection(RID p_env) const {

--- a/servers/rendering/storage/environment_storage.h
+++ b/servers/rendering/storage/environment_storage.h
@@ -71,6 +71,7 @@ private:
 		float fog_light_energy = 1.0;
 		float fog_sun_scatter = 0.0;
 		float fog_density = 0.01;
+		float fog_sky_affect = 1.0;
 		float fog_height = 0.0;
 		float fog_height_density = 0.0; //can be negative to invert effect
 		float fog_aerial_perspective = 0.0;
@@ -86,6 +87,7 @@ private:
 		float volumetric_fog_detail_spread = 2.0;
 		float volumetric_fog_gi_inject = 1.0;
 		float volumetric_fog_ambient_inject = 0.0;
+		float volumetric_fog_sky_affect = 1.0;
 		bool volumetric_fog_temporal_reprojection = true;
 		float volumetric_fog_temporal_reprojection_amount = 0.9;
 
@@ -202,18 +204,19 @@ public:
 	uint64_t environment_get_auto_exposure_version(RID p_env) const;
 
 	// Fog
-	void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective);
+	void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective, float p_sky_affect);
 	bool environment_get_fog_enabled(RID p_env) const;
 	Color environment_get_fog_light_color(RID p_env) const;
 	float environment_get_fog_light_energy(RID p_env) const;
 	float environment_get_fog_sun_scatter(RID p_env) const;
 	float environment_get_fog_density(RID p_env) const;
+	float environment_get_fog_sky_affect(RID p_env) const;
 	float environment_get_fog_height(RID p_env) const;
 	float environment_get_fog_height_density(RID p_env) const;
 	float environment_get_fog_aerial_perspective(RID p_env) const;
 
 	// Volumetric Fog
-	void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject);
+	void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect);
 	bool environment_get_volumetric_fog_enabled(RID p_env) const;
 	float environment_get_volumetric_fog_density(RID p_env) const;
 	Color environment_get_volumetric_fog_scattering(RID p_env) const;
@@ -223,6 +226,7 @@ public:
 	float environment_get_volumetric_fog_length(RID p_env) const;
 	float environment_get_volumetric_fog_detail_spread(RID p_env) const;
 	float environment_get_volumetric_fog_gi_inject(RID p_env) const;
+	float environment_get_volumetric_fog_sky_affect(RID p_env) const;
 	bool environment_get_volumetric_fog_temporal_reprojection(RID p_env) const;
 	float environment_get_volumetric_fog_temporal_reprojection_amount(RID p_env) const;
 	float environment_get_volumetric_fog_ambient_inject(RID p_env) const;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2333,9 +2333,9 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("environment_set_adjustment", "env", "enable", "brightness", "contrast", "saturation", "use_1d_color_correction", "color_correction"), &RenderingServer::environment_set_adjustment);
 	ClassDB::bind_method(D_METHOD("environment_set_ssr", "env", "enable", "max_steps", "fade_in", "fade_out", "depth_tolerance"), &RenderingServer::environment_set_ssr);
 	ClassDB::bind_method(D_METHOD("environment_set_ssao", "env", "enable", "radius", "intensity", "power", "detail", "horizon", "sharpness", "light_affect", "ao_channel_affect"), &RenderingServer::environment_set_ssao);
-	ClassDB::bind_method(D_METHOD("environment_set_fog", "env", "enable", "light_color", "light_energy", "sun_scatter", "density", "height", "height_density", "aerial_perspective"), &RenderingServer::environment_set_fog);
+	ClassDB::bind_method(D_METHOD("environment_set_fog", "env", "enable", "light_color", "light_energy", "sun_scatter", "density", "height", "height_density", "aerial_perspective", "sky_affect"), &RenderingServer::environment_set_fog);
 	ClassDB::bind_method(D_METHOD("environment_set_sdfgi", "env", "enable", "cascades", "min_cell_size", "y_scale", "use_occlusion", "bounce_feedback", "read_sky", "energy", "normal_bias", "probe_bias"), &RenderingServer::environment_set_sdfgi);
-	ClassDB::bind_method(D_METHOD("environment_set_volumetric_fog", "env", "enable", "density", "albedo", "emission", "emission_energy", "anisotropy", "length", "p_detail_spread", "gi_inject", "temporal_reprojection", "temporal_reprojection_amount", "ambient_inject"), &RenderingServer::environment_set_volumetric_fog);
+	ClassDB::bind_method(D_METHOD("environment_set_volumetric_fog", "env", "enable", "density", "albedo", "emission", "emission_energy", "anisotropy", "length", "p_detail_spread", "gi_inject", "temporal_reprojection", "temporal_reprojection_amount", "ambient_inject", "sky_affect"), &RenderingServer::environment_set_volumetric_fog);
 
 	ClassDB::bind_method(D_METHOD("environment_glow_set_use_bicubic_upscale", "enable"), &RenderingServer::environment_glow_set_use_bicubic_upscale);
 	ClassDB::bind_method(D_METHOD("environment_glow_set_use_high_quality", "enable"), &RenderingServer::environment_glow_set_use_high_quality);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1117,9 +1117,9 @@ public:
 
 	virtual void environment_set_sdfgi_frames_to_update_light(EnvironmentSDFGIFramesToUpdateLight p_update) = 0;
 
-	virtual void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective) = 0;
+	virtual void environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective, float p_sky_affect) = 0;
 
-	virtual void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject) = 0;
+	virtual void environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject, float p_sky_affect) = 0;
 	virtual void environment_set_volumetric_fog_volume_size(int p_size, int p_depth) = 0;
 	virtual void environment_set_volumetric_fog_filter_active(bool p_enable) = 0;
 


### PR DESCRIPTION
Values lower than 1.0 can be used to make the fog rendering not fully obstruct the sky. This can be desired when using fog as a purely atmospheric effect, without intending to use fog for open world fog fading.

When set to 0.0, fog rendering behavior will be similar to Godot 3.x where sky rendering was never affected by fog.

Fixed fog sky density no longer depends on the camera Z-far distance, which is more friendly to setups where this distance can change at run-time or depending on the user's graphics settings.

This closes https://github.com/godotengine/godot-proposals/issues/4102.

**Testing project:** [test_fog_sky_affect.zip](https://github.com/godotengine/godot/files/8476456/test_fog_sky_affect.zip)

## Preview

*Both fixed fog and volumetric fog are enabled here.*

### Fog Sky Affect = 1.0 (default)

![2022-04-12_22 46 40](https://user-images.githubusercontent.com/180032/163051075-7fdb234c-c3a5-4175-bff5-f144190de2f0.png)

### Fog Sky Affect = 0.5

![2022-04-12_22 46 33](https://user-images.githubusercontent.com/180032/163051066-0073779a-9fdf-4a15-9b1a-27e510e2c75c.png)

### Fog Sky Affect = 0.0

![2022-04-12_22 46 45](https://user-images.githubusercontent.com/180032/163051081-21acfc97-71c2-487c-86b3-bbe39ab67e35.png)
