### PR TITLE
[3.x] Use less blur for distant directional shadow splits

### DIFF
--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -2141,11 +2141,13 @@ FRAGMENT_SHADER_CODE
 	if (depth_z < value) {
 		vec3 pssm_coord;
 		float pssm_fade = 0.0;
+		float blur_factor = 1.0;
 
 #ifdef LIGHT_USE_PSSM_BLEND //ubershader-skip
 		float pssm_blend;
 		vec3 pssm_coord2;
 		bool use_blend = true;
+		float blur_factor2 = 1.0;
 #endif //ubershader-skip
 
 #ifdef LIGHT_USE_PSSM4 //ubershader-runtime
@@ -2156,37 +2158,42 @@ FRAGMENT_SHADER_CODE
 				pssm_coord = splane.xyz / splane.w;
 
 #ifdef LIGHT_USE_PSSM_BLEND //ubershader-runtime
-
 				splane = (shadow_matrix2 * vec4(vertex, 1.0));
 				pssm_coord2 = splane.xyz / splane.w;
 				pssm_blend = smoothstep(0.0, shadow_split_offsets.x, depth_z);
+				blur_factor2 = shadow_split_offsets.x / shadow_split_offsets.y;
 #endif //ubershader-runtime
 
 			} else {
 				highp vec4 splane = (shadow_matrix2 * vec4(vertex, 1.0));
 				pssm_coord = splane.xyz / splane.w;
+				blur_factor = shadow_split_offsets.x / shadow_split_offsets.y;
 
 #ifdef LIGHT_USE_PSSM_BLEND //ubershader-runtime
 				splane = (shadow_matrix3 * vec4(vertex, 1.0));
 				pssm_coord2 = splane.xyz / splane.w;
 				pssm_blend = smoothstep(shadow_split_offsets.x, shadow_split_offsets.y, depth_z);
+				blur_factor2 = shadow_split_offsets.x / shadow_split_offsets.z;
 #endif //ubershader-runtime
 			}
 		} else {
 			if (depth_z < shadow_split_offsets.z) {
 				highp vec4 splane = (shadow_matrix3 * vec4(vertex, 1.0));
 				pssm_coord = splane.xyz / splane.w;
+				blur_factor = shadow_split_offsets.x / shadow_split_offsets.z;
 
 #ifdef LIGHT_USE_PSSM_BLEND //ubershader-runtime
 				splane = (shadow_matrix4 * vec4(vertex, 1.0));
 				pssm_coord2 = splane.xyz / splane.w;
 				pssm_blend = smoothstep(shadow_split_offsets.y, shadow_split_offsets.z, depth_z);
+				blur_factor2 = shadow_split_offsets.x / shadow_split_offsets.w;
 #endif //ubershader-runtime
 
 			} else {
 				highp vec4 splane = (shadow_matrix4 * vec4(vertex, 1.0));
 				pssm_coord = splane.xyz / splane.w;
 				pssm_fade = smoothstep(shadow_split_offsets.z, shadow_split_offsets.w, depth_z);
+				blur_factor = shadow_split_offsets.x / shadow_split_offsets.w;
 
 #ifdef LIGHT_USE_PSSM_BLEND //ubershader-runtime
 				use_blend = false;
@@ -2208,12 +2215,14 @@ FRAGMENT_SHADER_CODE
 			splane = (shadow_matrix2 * vec4(vertex, 1.0));
 			pssm_coord2 = splane.xyz / splane.w;
 			pssm_blend = smoothstep(0.0, shadow_split_offsets.x, depth_z);
+			blur_factor2 = shadow_split_offsets.x / shadow_split_offsets.y;
 #endif //ubershader-runtime
 
 		} else {
 			highp vec4 splane = (shadow_matrix2 * vec4(vertex, 1.0));
 			pssm_coord = splane.xyz / splane.w;
 			pssm_fade = smoothstep(shadow_split_offsets.x, shadow_split_offsets.y, depth_z);
+			blur_factor = shadow_split_offsets.x / shadow_split_offsets.y;
 #ifdef LIGHT_USE_PSSM_BLEND //ubershader-runtime
 			use_blend = false;
 
@@ -2233,12 +2242,12 @@ FRAGMENT_SHADER_CODE
 
 		//one one sample
 
-		float shadow = sample_shadow(directional_shadow, directional_shadow_pixel_size, pssm_coord.xy, pssm_coord.z, light_clamp);
+		float shadow = sample_shadow(directional_shadow, directional_shadow_pixel_size * blur_factor, pssm_coord.xy, pssm_coord.z, light_clamp);
 
 #ifdef LIGHT_USE_PSSM_BLEND //ubershader-runtime
 
 		if (use_blend) {
-			shadow = mix(shadow, sample_shadow(directional_shadow, directional_shadow_pixel_size, pssm_coord2.xy, pssm_coord2.z, light_clamp), pssm_blend);
+			shadow = mix(shadow, sample_shadow(directional_shadow, directional_shadow_pixel_size * blur_factor2, pssm_coord2.xy, pssm_coord2.z, light_clamp), pssm_blend);
 		}
 #endif //ubershader-runtime
 


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/48776.

This makes the transition between shadow splits less noticeable, especially when the expensive Blend Splits property is disabled.

This is only effective when the shadow filter mode is PCF5 or PCF13.

**Testing project:** [test_shadow_b_3.x.zip](https://github.com/godotengine/godot/files/8476975/test_shadow_b_3.x.zip)

## Preview

### GLES3 (PCF13)

| Before | After |
|-|-|
| ![2022-04-13_17 55 55](https://user-images.githubusercontent.com/180032/163221518-da8e222c-f7a2-48eb-9f2a-64c62fbe91f9.png) | ![2022-04-13_17 55 43](https://user-images.githubusercontent.com/180032/163221512-4985df74-79ed-4e81-8d01-c4b90fb08964.png) |

<details>
<summary>Old revision of this PR</summary>

### GLES3

| Before | After |
|-|-|
| ![2022-04-13_00 30 16](https://user-images.githubusercontent.com/180032/163066389-fa35ecca-808b-4718-8921-edd2d9e1c994.png) | ![2022-04-13_00 30 27](https://user-images.githubusercontent.com/180032/163066392-b572872a-9e3f-49b0-9ef4-21d9530e8e37.png) |

### GLES2

| Before | After |
|-|-|
| ![2022-04-13_00 29 10](https://user-images.githubusercontent.com/180032/163066383-6d9d76c6-bb39-4b3e-b577-48c6e212e3e2.png) | ![2022-04-13_00 29 24](https://user-images.githubusercontent.com/180032/163066386-d3b29e48-9e13-44e6-ae23-2a86cd1a301c.png) |
</details>