### PR TITLE
Fix "File must be opened" error with File.open()

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -1072,7 +1072,6 @@ Error File::open_compressed(const String &p_path, ModeFlags p_mode_flags, Compre
 }
 
 Error File::open(const String &p_path, ModeFlags p_mode_flags) {
-	close();
 	Error err;
 	f = FileAccess::open(p_path, p_mode_flags, &err);
 	if (f.is_valid()) {


### PR DESCRIPTION
Fixes #60188 
Simplest fix I could think of, I don't think it would have any side effects. But unsure if this is the best way to do it, feedback welcome.