### PR TITLE
Fix gizmos not being created on newly added nodes

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -7120,7 +7120,9 @@ void Node3DEditor::_request_gizmo(Object *p_obj) {
 				}
 			}
 		}
-		sp->update_gizmos();
+		if (!sp->get_gizmos().is_empty()) {
+			sp->update_gizmos();
+		}
 	}
 }
 

--- a/scene/3d/node_3d.cpp
+++ b/scene/3d/node_3d.cpp
@@ -181,15 +181,6 @@ void Node3D::_notification(int p_what) {
 #ifdef TOOLS_ENABLED
 			if (Engine::get_singleton()->is_editor_hint() && get_tree()->is_node_being_edited(this)) {
 				get_tree()->call_group_flags(0, SceneStringNames::get_singleton()->_spatial_editor_group, SceneStringNames::get_singleton()->_request_gizmo, this);
-				if (!data.gizmos_disabled) {
-					for (int i = 0; i < data.gizmos.size(); i++) {
-						data.gizmos.write[i]->create();
-						if (is_visible_in_tree()) {
-							data.gizmos.write[i]->redraw();
-						}
-						data.gizmos.write[i]->transform();
-					}
-				}
 			}
 #endif
 		} break;
@@ -427,6 +418,7 @@ void Node3D::update_gizmos() {
 	}
 
 	if (data.gizmos.is_empty()) {
+		get_tree()->call_group_flags(0, SceneStringNames::get_singleton()->_spatial_editor_group, SceneStringNames::get_singleton()->_request_gizmo, this);
 		return;
 	}
 	if (data.gizmos_dirty) {


### PR DESCRIPTION
Closes #60193 
Fixes the described issue by making it so that the update_gizmos function in Node3D will attempt to request gizmos from the Node3DEditor if none exist. A check is added to the request gizmo function to make sure gizmos have actually been assigned so that the function is not called recursively, and a block of code for creating, redrawing, and transform the gizmos once they have been assigned in the NOTIFICATION_ENTER_WORLD switch case has been removed since the same calls are made inside the add_gizmo function which is called from the Node3DEditor::_request_gizmo function (this silences a fail condition caused by calling create() after it has been called once)