### PR TITLE
[macOS, 3.x] Fix OpenGL color space on HDR displays.

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1612,6 +1612,8 @@ Error OS_OSX::initialize(const VideoMode &p_desired, int p_video_driver, int p_a
 		[window_view setWantsBestResolutionOpenGLSurface:NO];
 	}
 
+	[window_object setColorSpace:[NSColorSpace sRGBColorSpace]];
+
 	//[window_object setTitle:[NSString stringWithUTF8String:"GodotEnginies"]];
 	[window_object setContentView:window_view];
 	[window_object setDelegate:window_delegate];


### PR DESCRIPTION
Same as #56717, but for 3.x.

![Screenshot 2022-04-13 at 10 39 36](https://user-images.githubusercontent.com/7645683/163125038-3d8d6aed-d6ee-4738-b4f3-0a5dc6e586ba.png)

