### PR TITLE
Apply skin pose modifications to mesh gizmo collision

### DIFF
--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -142,8 +142,10 @@
 		</method>
 		<method name="generate_triangle_mesh" qualifiers="const">
 			<return type="TriangleMesh" />
+			<argument index="0" name="bone_transforms" type="Array" default="[]" />
 			<description>
 				Generate a [TriangleMesh] from the mesh. Considers only surfaces using one of these primitive types: [constant PRIMITIVE_TRIANGLES], [constant PRIMITIVE_TRIANGLE_STRIP].
+				If a non-empty array of [code]bone_transforms[/code] containing [Transform3D] are provided matching the mesh's bones and weights, the resulting [TriangleMesh] will be deformed based on this.
 			</description>
 		</method>
 		<method name="get_aabb" qualifiers="const">

--- a/scene/3d/mesh_instance_3d.cpp
+++ b/scene/3d/mesh_instance_3d.cpp
@@ -187,6 +187,8 @@ void MeshInstance3D::_resolve_skeleton_path() {
 	} else {
 		RenderingServer::get_singleton()->instance_attach_skeleton(get_instance(), RID());
 	}
+
+	update_gizmos();
 }
 
 void MeshInstance3D::set_skin(const Ref<Skin> &p_skin) {

--- a/scene/resources/mesh.h
+++ b/scene/resources/mesh.h
@@ -167,7 +167,7 @@ public:
 
 	Vector<Face3> get_faces() const;
 	Vector<Face3> get_surface_faces(int p_surface) const;
-	Ref<TriangleMesh> generate_triangle_mesh() const;
+	Ref<TriangleMesh> generate_triangle_mesh(const Array p_bone_transforms = Array()) const;
 	Ref<TriangleMesh> generate_surface_triangle_mesh(int p_surface) const;
 	void generate_debug_mesh_lines(Vector<Vector3> &r_lines);
 	void generate_debug_mesh_indices(Vector<Vector3> &r_points);


### PR DESCRIPTION
WIP PR to make to make skinned meshes selectable. Adds an optional skinning parameter to the Mesh class's generate_triangle_mesh function. Function seems to work, but need to add code to allow the gizmo to update itself based on the state of the skeleton and updates to the assigned Skin resource.

Would like to also add support for blendshapes too, but that can be a seperate PR I think