### PR TITLE
Proper (in)validation of negative values in datetime strings and datetime dicts

### DIFF
--- a/core/os/time.cpp
+++ b/core/os/time.cpp
@@ -97,12 +97,17 @@ VARIANT_ENUM_CAST(Time::Weekday);
 
 #define VALIDATE_YMDHMS(ret)                                                                                                                                              \
 	ERR_FAIL_COND_V_MSG(month == 0, ret, "Invalid month value of: " + itos(month) + ", months are 1-indexed and cannot be 0. See the Time.Month enum for valid values."); \
+	ERR_FAIL_COND_V_MSG(month < 0, ret, "Invalid month value of: " + itos(month) + ".");                                                                                  \
 	ERR_FAIL_COND_V_MSG(month > 12, ret, "Invalid month value of: " + itos(month) + ". See the Time.Month enum for valid values.");                                       \
 	ERR_FAIL_COND_V_MSG(hour > 23, ret, "Invalid hour value of: " + itos(hour) + ".");                                                                                    \
+	ERR_FAIL_COND_V_MSG(hour < 0, ret, "Invalid hour value of: " + itos(hour) + ".");                                                                                     \
 	ERR_FAIL_COND_V_MSG(minute > 59, ret, "Invalid minute value of: " + itos(minute) + ".");                                                                              \
+	ERR_FAIL_COND_V_MSG(minute < 0, ret, "Invalid minute value of: " + itos(minute) + ".");                                                                               \
 	ERR_FAIL_COND_V_MSG(second > 59, ret, "Invalid second value of: " + itos(second) + " (leap seconds are not supported).");                                             \
+	ERR_FAIL_COND_V_MSG(second < 0, ret, "Invalid second value of: " + itos(second) + ".");                                                                               \
+	ERR_FAIL_COND_V_MSG(day == 0, ret, "Invalid day value of: " + itos(day) + ", days are 1-indexed and cannot be 0.");                                                   \
+	ERR_FAIL_COND_V_MSG(day < 0, ret, "Invalid day value of: " + itos(day) + ".");                                                                                        \
 	/* Do this check after month is tested as valid. */                                                                                                                   \
-	ERR_FAIL_COND_V_MSG(day == 0, ret, "Invalid day value of: " + itos(month) + ", days are 1-indexed and cannot be 0.");                                                 \
 	uint8_t days_in_this_month = MONTH_DAYS_TABLE[IS_LEAP_YEAR(year)][month - 1];                                                                                         \
 	ERR_FAIL_COND_V_MSG(day > days_in_this_month, ret, "Invalid day value of: " + itos(day) + " which is larger than the maximum for this month, " + itos(days_in_this_month) + ".");
 
@@ -127,10 +132,10 @@ VARIANT_ENUM_CAST(Time::Weekday);
 #define PARSE_ISO8601_STRING(ret)                                                             \
 	int64_t year = UNIX_EPOCH_YEAR_AD;                                                        \
 	Month month = MONTH_JANUARY;                                                              \
-	uint8_t day = 1;                                                                          \
-	uint8_t hour = 0;                                                                         \
-	uint8_t minute = 0;                                                                       \
-	uint8_t second = 0;                                                                       \
+	int day = 1;                                                                              \
+	int hour = 0;                                                                             \
+	int minute = 0;                                                                           \
+	int second = 0;                                                                           \
 	{                                                                                         \
 		bool has_date = false, has_time = false;                                              \
 		String date, time;                                                                    \
@@ -178,11 +183,11 @@ VARIANT_ENUM_CAST(Time::Weekday);
 	/* Get all time values from the dictionary. If it doesn't exist, set the */                   \
 	/* values to the default values for Unix epoch (1970-01-01 00:00:00). */                      \
 	int64_t year = p_datetime.has(YEAR_KEY) ? int64_t(p_datetime[YEAR_KEY]) : UNIX_EPOCH_YEAR_AD; \
-	Month month = Month((p_datetime.has(MONTH_KEY)) ? uint8_t(p_datetime[MONTH_KEY]) : 1);        \
-	uint8_t day = p_datetime.has(DAY_KEY) ? uint8_t(p_datetime[DAY_KEY]) : 1;                     \
-	uint8_t hour = p_datetime.has(HOUR_KEY) ? uint8_t(p_datetime[HOUR_KEY]) : 0;                  \
-	uint8_t minute = p_datetime.has(MINUTE_KEY) ? uint8_t(p_datetime[MINUTE_KEY]) : 0;            \
-	uint8_t second = p_datetime.has(SECOND_KEY) ? uint8_t(p_datetime[SECOND_KEY]) : 0;
+	Month month = Month((p_datetime.has(MONTH_KEY)) ? int(p_datetime[MONTH_KEY]) : 1);            \
+	int day = p_datetime.has(DAY_KEY) ? int(p_datetime[DAY_KEY]) : 1;                             \
+	int hour = p_datetime.has(HOUR_KEY) ? int(p_datetime[HOUR_KEY]) : 0;                          \
+	int minute = p_datetime.has(MINUTE_KEY) ? int(p_datetime[MINUTE_KEY]) : 0;                    \
+	int second = p_datetime.has(SECOND_KEY) ? int(p_datetime[SECOND_KEY]) : 0;
 
 Time *Time::singleton = nullptr;
 

--- a/core/os/time.h
+++ b/core/os/time.h
@@ -51,7 +51,7 @@ class Time : public Object {
 public:
 	static Time *get_singleton();
 
-	enum Month : uint8_t {
+	enum Month {
 		/// Start at 1 to follow Windows SYSTEMTIME structure
 		/// https://msdn.microsoft.com/en-us/library/windows/desktop/ms724950(v=vs.85).aspx
 		MONTH_JANUARY = 1,


### PR DESCRIPTION
Resolves #60192. Works by changing type of hour, second, and minute in the PARSE_IS08601_STRING macro from uint8_t to int, allowing it to be read as negative, allowing it to be properly validated in the VALIDATE_YMDHMS macro. The same is done in the EXTRACT_FROM_DICTIONARY macro.