### PR TITLE
[3.x] Remove get_data() from CowData

### DIFF
--- a/core/cowdata.h
+++ b/core/cowdata.h
@@ -78,13 +78,6 @@ private:
 		return reinterpret_cast<uint32_t *>(_ptr) - 1;
 	}
 
-	_FORCE_INLINE_ T *_get_data() const {
-		if (!_ptr) {
-			return nullptr;
-		}
-		return reinterpret_cast<T *>(_ptr);
-	}
-
 	_FORCE_INLINE_ size_t _get_alloc_size(size_t p_elements) const {
 		//return nearest_power_of_2_templated(p_elements*sizeof(T)+sizeof(SafeRefCount)+sizeof(int));
 		return next_power_of_2(p_elements * sizeof(T));
@@ -121,11 +114,11 @@ public:
 
 	_FORCE_INLINE_ T *ptrw() {
 		_copy_on_write();
-		return (T *)_get_data();
+		return _ptr;
 	}
 
 	_FORCE_INLINE_ const T *ptr() const {
-		return _get_data();
+		return _ptr;
 	}
 
 	_FORCE_INLINE_ int size() const {
@@ -143,19 +136,19 @@ public:
 	_FORCE_INLINE_ void set(int p_index, const T &p_elem) {
 		CRASH_BAD_INDEX(p_index, size());
 		_copy_on_write();
-		_get_data()[p_index] = p_elem;
+		_ptr[p_index] = p_elem;
 	}
 
 	_FORCE_INLINE_ T &get_m(int p_index) {
 		CRASH_BAD_INDEX(p_index, size());
 		_copy_on_write();
-		return _get_data()[p_index];
+		return _ptr[p_index];
 	}
 
 	_FORCE_INLINE_ const T &get(int p_index) const {
 		CRASH_BAD_INDEX(p_index, size());
 
-		return _get_data()[p_index];
+		return _ptr[p_index];
 	}
 
 	Error resize(int p_size);
@@ -242,7 +235,7 @@ uint32_t CowData<T>::_copy_on_write() {
 
 		} else {
 			for (uint32_t i = 0; i < current_size; i++) {
-				memnew_placement(&_data[i], T(_get_data()[i]));
+				memnew_placement(&_data[i], T(_ptr[i]));
 			}
 		}
 
@@ -301,10 +294,8 @@ Error CowData<T>::resize(int p_size) {
 		// construct the newly created elements
 
 		if (!__has_trivial_constructor(T)) {
-			T *elems = _get_data();
-
 			for (int i = *_get_size(); i < p_size; i++) {
-				memnew_placement(&elems[i], T);
+				memnew_placement(&_ptr[i], T);
 			}
 		}
 
@@ -314,7 +305,7 @@ Error CowData<T>::resize(int p_size) {
 		if (!__has_trivial_destructor(T)) {
 			// deinitialize no longer needed elements
 			for (uint32_t i = p_size; i < *_get_size(); i++) {
-				T *t = &_get_data()[i];
+				T *t = &_ptr[i];
 				t->~T();
 			}
 		}


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/60078
