### PR TITLE
Added p_shape check to avoid engine crash in DisplayServer

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -851,6 +851,8 @@ void Input::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, co
 		return;
 	}
 
+	ERR_FAIL_INDEX(p_shape, CursorShape::CURSOR_MAX);
+
 	set_custom_mouse_cursor_func(p_cursor, p_shape, p_hotspot);
 }
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
The problem causing crash was not checking if p_shape is a value from ```enum CursorShape```.
Closes #60112