### PR TITLE
Fix item_collapsed signal being triggered without user input

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -192,6 +192,7 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 		bool collapsed = p_node->is_displayed_folded();
 		if (collapsed) {
 			item->set_collapsed(true);
+			_cell_collapsed(item);
 		}
 	}
 
@@ -762,6 +763,7 @@ void SceneTreeEditor::set_selected(Node *p_node, bool p_emit_selected) {
 			TreeItem *node = item->get_parent();
 			while (node && node != tree->get_root()) {
 				node->set_collapsed(false);
+				_cell_collapsed(node);
 				node = node->get_parent();
 			}
 			item->select(0);

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -537,7 +537,6 @@ void TreeItem::set_collapsed(bool p_collapsed) {
 	}
 
 	_changed_notify();
-	tree->emit_signal(SNAME("item_collapsed"), this);
 }
 
 bool TreeItem::is_collapsed() {
@@ -2398,6 +2397,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 
 		if (!p_item->disable_folding && !hide_folding && p_item->first_child && (p_pos.x >= x_ofs && p_pos.x < (x_ofs + cache.item_margin))) {
 			p_item->set_collapsed(!p_item->is_collapsed());
+			emit_signal(SNAME("item_collapsed"), p_item);
 			return -1;
 		}
 
@@ -2449,6 +2449,7 @@ int Tree::propagate_mouse_event(const Point2i &p_pos, int x_ofs, int y_ofs, int 
 
 		if (!p_item->disable_folding && !hide_folding && !p_item->cells[col].editable && !p_item->cells[col].selectable && p_item->get_first_child()) {
 			p_item->set_collapsed(!p_item->is_collapsed());
+			emit_signal(SNAME("item_collapsed"), p_item);
 			return -1; //collapse/uncollapse because nothing can be done with item
 		}
 
@@ -2813,6 +2814,7 @@ void Tree::_go_left() {
 	if (selected_col == 0) {
 		if (selected_item->get_first_child() != nullptr && !selected_item->is_collapsed()) {
 			selected_item->set_collapsed(true);
+			emit_signal(SNAME("item_collapsed"), selected_item);
 		} else {
 			if (columns.size() == 1) { // goto parent with one column
 				TreeItem *parent = selected_item->get_parent();
@@ -2841,6 +2843,7 @@ void Tree::_go_right() {
 	if (selected_col == (columns.size() - 1)) {
 		if (selected_item->get_first_child() != nullptr && selected_item->is_collapsed()) {
 			selected_item->set_collapsed(false);
+			emit_signal(SNAME("item_collapsed"), selected_item);
 		} else if (selected_item->get_next_visible()) {
 			selected_col = 0;
 			_go_down();
@@ -2958,9 +2961,11 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 		}
 		if (k.is_valid() && k->is_alt_pressed()) {
 			selected_item->set_collapsed(false);
+			emit_signal(SNAME("item_collapsed"), selected_item);
 			TreeItem *next = selected_item->get_first_child();
 			while (next && next != selected_item->next) {
 				next->set_collapsed(false);
+				emit_signal(SNAME("item_collapsed"), next);
 				next = next->get_next_visible();
 			}
 		} else {
@@ -2977,9 +2982,11 @@ void Tree::gui_input(const Ref<InputEvent> &p_event) {
 
 		if (k.is_valid() && k->is_alt_pressed()) {
 			selected_item->set_collapsed(true);
+			emit_signal(SNAME("item_collapsed"), selected_item);
 			TreeItem *next = selected_item->get_first_child();
 			while (next && next != selected_item->next) {
 				next->set_collapsed(true);
+				emit_signal(SNAME("item_collapsed"), next);
 				next = next->get_next_visible();
 			}
 		} else {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/60206.

I did a quick pass on the editor code to check in which places functions connected to `item_collapsed` would have been triggered and added explicit calls there.

There are not a lot of them because, most of the time, a check had to be added at the beginning of the function like I described in the above issue. Things like:
```
void SceneTreeEditor::_cell_collapsed(Object *p_obj) {
	if (updating_tree) {
		return;
	}
	...
```
I guess that, in some of those situations, the check could be removed, but that might require a little bit bigger refactor of the tree class to avoid all user inputs triggering unwanted signals.
