### PR TITLE
Fixed leading spaces pushing text outside Label autowrap boundary

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -386,7 +386,6 @@ void Label::regenerate_word_cache() {
 	real_t space_width = font->get_char_size(' ').width;
 	int line_spacing = get_constant("line_spacing");
 	line_count = 1;
-
 	total_char_cache = 0;
 
 	WordCache *last = nullptr;

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -386,6 +386,9 @@ void Label::regenerate_word_cache() {
 	real_t space_width = font->get_char_size(' ').width;
 	int line_spacing = get_constant("line_spacing");
 	line_count = 1;
+
+	bool prev_insert_newline = false;
+	
 	total_char_cache = 0;
 
 	WordCache *last = nullptr;
@@ -413,6 +416,7 @@ void Label::regenerate_word_cache() {
 
 		if (current < 33) {
 			if (current_word_size > 0) {
+				prev_insert_newline = false;
 				WordCache *wc = memnew(WordCache);
 				if (word_cache) {
 					last->next = wc;
@@ -429,6 +433,7 @@ void Label::regenerate_word_cache() {
 				space_count = 0;
 			} else if ((i == xl_text.length() || current == '\n') && last != nullptr && space_count != 0) {
 				//in case there are trailing white spaces we add a placeholder word cache with just the spaces
+				prev_insert_newline = false;
 				WordCache *wc = memnew(WordCache);
 				if (word_cache) {
 					last->next = wc;
@@ -447,12 +452,19 @@ void Label::regenerate_word_cache() {
 
 			if (current == '\n') {
 				insert_newline = true;
+				prev_insert_newline = true;
 			} else if (current != ' ') {
 				total_char_cache++;
 			}
 
 			if (i < xl_text.length() && xl_text[i] == ' ') {
-				if (line_width > 0 || last == nullptr || last->char_pos != WordCache::CHAR_WRAPLINE) {
+				if (i == 0 || prev_insert_newline) {
+					if (current_word_size == 0) {
+						word_pos = i;
+					}
+					current_word_size += space_width;
+					line_width += space_width;
+				} else if (line_width > 0 || last == nullptr || last->char_pos != WordCache::CHAR_WRAPLINE) {
 					space_count++;
 					line_width += space_width;
 				} else {
@@ -462,6 +474,7 @@ void Label::regenerate_word_cache() {
 
 		} else {
 			// latin characters
+			prev_insert_newline = false;
 			if (current_word_size == 0) {
 				word_pos = i;
 			}

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -447,32 +447,12 @@ void Label::regenerate_word_cache() {
 
 			if (current == '\n') {
 				insert_newline = true;
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-				line_width = 0;
-=======
-				prev_insert_newline = true;
->>>>>>> d87902accb (Fix for leading space pushing text outside label boundary in autowrap mode problem)
-=======
-				line_width = 0;
->>>>>>> 18efb0d2b2 (Implemented fix without using local variable)
-=======
->>>>>>> 286fff2f6f (Removed one unneeded variable set statement)
 			} else if (current != ' ') {
 				total_char_cache++;
 			}
 
 			if (i < xl_text.length() && xl_text[i] == ' ') {
-<<<<<<< HEAD
-<<<<<<< HEAD
 				if (line_width == 0) {
-=======
-				if (i == 0 || prev_insert_newline) {
->>>>>>> d87902accb (Fix for leading space pushing text outside label boundary in autowrap mode problem)
-=======
-				if (line_width == 0) {
->>>>>>> 18efb0d2b2 (Implemented fix without using local variable)
 					if (current_word_size == 0) {
 						word_pos = i;
 					}

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -447,12 +447,38 @@ void Label::regenerate_word_cache() {
 
 			if (current == '\n') {
 				insert_newline = true;
+<<<<<<< HEAD
+<<<<<<< HEAD
+<<<<<<< HEAD
+				line_width = 0;
+=======
+				prev_insert_newline = true;
+>>>>>>> d87902accb (Fix for leading space pushing text outside label boundary in autowrap mode problem)
+=======
+				line_width = 0;
+>>>>>>> 18efb0d2b2 (Implemented fix without using local variable)
+=======
+>>>>>>> 286fff2f6f (Removed one unneeded variable set statement)
 			} else if (current != ' ') {
 				total_char_cache++;
 			}
 
 			if (i < xl_text.length() && xl_text[i] == ' ') {
-				if (line_width > 0 || last == nullptr || last->char_pos != WordCache::CHAR_WRAPLINE) {
+<<<<<<< HEAD
+<<<<<<< HEAD
+				if (line_width == 0) {
+=======
+				if (i == 0 || prev_insert_newline) {
+>>>>>>> d87902accb (Fix for leading space pushing text outside label boundary in autowrap mode problem)
+=======
+				if (line_width == 0) {
+>>>>>>> 18efb0d2b2 (Implemented fix without using local variable)
+					if (current_word_size == 0) {
+						word_pos = i;
+					}
+					current_word_size += space_width;
+					line_width += space_width;
+				} else if (line_width > 0 || last == nullptr || last->char_pos != WordCache::CHAR_WRAPLINE) {
 					space_count++;
 					line_width += space_width;
 				} else {

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -452,7 +452,17 @@ void Label::regenerate_word_cache() {
 			}
 
 			if (i < xl_text.length() && xl_text[i] == ' ') {
+<<<<<<< HEAD
 				if (line_width > 0 || last == nullptr || last->char_pos != WordCache::CHAR_WRAPLINE) {
+=======
+				if (line_width == 0) {
+					if (current_word_size == 0) {
+						word_pos = i;
+					}
+					current_word_size += space_width;
+					line_width += space_width;
+				} else if (line_width > 0 || last == nullptr || last->char_pos != WordCache::CHAR_WRAPLINE) {
+>>>>>>> 766e57a15c (Merge branch 'leading-space-new-3.x' of https://github.com/ZheisterCoding/godot into leading-space-new-3.x)
 					space_count++;
 					line_width += space_width;
 				} else {

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -447,7 +447,6 @@ void Label::regenerate_word_cache() {
 
 			if (current == '\n') {
 				insert_newline = true;
-				line_width = 0;
 			} else if (current != ' ') {
 				total_char_cache++;
 			}

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -447,12 +447,19 @@ void Label::regenerate_word_cache() {
 
 			if (current == '\n') {
 				insert_newline = true;
+				line_width = 0;
 			} else if (current != ' ') {
 				total_char_cache++;
 			}
 
 			if (i < xl_text.length() && xl_text[i] == ' ') {
-				if (line_width > 0 || last == nullptr || last->char_pos != WordCache::CHAR_WRAPLINE) {
+				if (line_width == 0) {
+					if (current_word_size == 0) {
+						word_pos = i;
+					}
+					current_word_size += space_width;
+					line_width += space_width;
+				} else if (line_width > 0 || last == nullptr || last->char_pos != WordCache::CHAR_WRAPLINE) {
 					space_count++;
 					line_width += space_width;
 				} else {

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -452,9 +452,6 @@ void Label::regenerate_word_cache() {
 			}
 
 			if (i < xl_text.length() && xl_text[i] == ' ') {
-<<<<<<< HEAD
-				if (line_width > 0 || last == nullptr || last->char_pos != WordCache::CHAR_WRAPLINE) {
-=======
 				if (line_width == 0) {
 					if (current_word_size == 0) {
 						word_pos = i;
@@ -462,7 +459,6 @@ void Label::regenerate_word_cache() {
 					current_word_size += space_width;
 					line_width += space_width;
 				} else if (line_width > 0 || last == nullptr || last->char_pos != WordCache::CHAR_WRAPLINE) {
->>>>>>> 766e57a15c (Merge branch 'leading-space-new-3.x' of https://github.com/ZheisterCoding/godot into leading-space-new-3.x)
 					space_count++;
 					line_width += space_width;
 				} else {

--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -387,8 +387,6 @@ void Label::regenerate_word_cache() {
 	int line_spacing = get_constant("line_spacing");
 	line_count = 1;
 
-	bool prev_insert_newline = false;
-	
 	total_char_cache = 0;
 
 	WordCache *last = nullptr;
@@ -416,7 +414,6 @@ void Label::regenerate_word_cache() {
 
 		if (current < 33) {
 			if (current_word_size > 0) {
-				prev_insert_newline = false;
 				WordCache *wc = memnew(WordCache);
 				if (word_cache) {
 					last->next = wc;
@@ -433,7 +430,6 @@ void Label::regenerate_word_cache() {
 				space_count = 0;
 			} else if ((i == xl_text.length() || current == '\n') && last != nullptr && space_count != 0) {
 				//in case there are trailing white spaces we add a placeholder word cache with just the spaces
-				prev_insert_newline = false;
 				WordCache *wc = memnew(WordCache);
 				if (word_cache) {
 					last->next = wc;
@@ -452,13 +448,13 @@ void Label::regenerate_word_cache() {
 
 			if (current == '\n') {
 				insert_newline = true;
-				prev_insert_newline = true;
+				line_width = 0;
 			} else if (current != ' ') {
 				total_char_cache++;
 			}
 
 			if (i < xl_text.length() && xl_text[i] == ' ') {
-				if (i == 0 || prev_insert_newline) {
+				if (line_width == 0) {
 					if (current_word_size == 0) {
 						word_pos = i;
 					}
@@ -474,7 +470,6 @@ void Label::regenerate_word_cache() {
 
 		} else {
 			// latin characters
-			prev_insert_newline = false;
 			if (current_word_size == 0) {
 				word_pos = i;
 			}


### PR DESCRIPTION
Fixed #59985 leading spaces autowrap boundary problem

Bug problem:
No condition for when the first character of the label is a space character

Fix:
Added an IF condition for when the first character or the entered new line is a space character
The autowrap boundary treat this space character as another dummy word in the WordCache linked list and proceed to function normally
Added a local boolean variable `prev_insert_newline` to address leading space in newline issue

_*note: last pull request has rebase problem_


https://user-images.githubusercontent.com/50128969/163237340-3d1f745b-c00f-4600-9a3e-ff5116bf2703.mp4


@timothyqiu 