### PR TITLE
Fix and tweak labeled separator in `PopupMenu`

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -569,7 +569,7 @@
 			[Color] used for labeled separators' text. See [method add_separator].
 		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
-			The horizontal space between the item's name and the shortcut text/submenu arrow.
+			The horizontal space between the item's elements.
 		</theme_item>
 		<theme_item name="item_end_padding" data_type="constant" type="int" default="2">
 		</theme_item>

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -564,10 +564,8 @@ void PopupMenu::_draw_items() {
 		// Separator
 		item_ofs.x += items[i].h_ofs;
 		if (items[i].separator) {
-			int sep_h = separator->get_center_size().height + separator->get_minimum_size().height;
-			int sep_ofs = Math::floor((h - sep_h) / 2.0);
 			if (!text.is_empty() || !items[i].icon.is_null()) {
-				int content_size = items[i].text_buf->get_size().width;
+				int content_size = items[i].text_buf->get_size().width + hseparation * 2;
 				if (!items[i].icon.is_null()) {
 					content_size += icon_size.width + hseparation;
 				}
@@ -576,12 +574,18 @@ void PopupMenu::_draw_items() {
 				int content_left = content_center - content_size / 2;
 				int content_right = content_center + content_size / 2;
 				if (content_left > item_ofs.x) {
+					int sep_h = labeled_separator_left->get_center_size().height + labeled_separator_left->get_minimum_size().height;
+					int sep_ofs = Math::floor((h - sep_h) / 2.0);
 					labeled_separator_left->draw(ci, Rect2(item_ofs + Point2(0, sep_ofs), Size2(MAX(0, content_left - item_ofs.x), sep_h)));
 				}
 				if (content_right < display_width) {
+					int sep_h = labeled_separator_right->get_center_size().height + labeled_separator_right->get_minimum_size().height;
+					int sep_ofs = Math::floor((h - sep_h) / 2.0);
 					labeled_separator_right->draw(ci, Rect2(Point2(content_right, item_ofs.y + sep_ofs), Size2(MAX(0, display_width - content_right), sep_h)));
 				}
 			} else {
+				int sep_h = separator->get_center_size().height + separator->get_minimum_size().height;
+				int sep_ofs = Math::floor((h - sep_h) / 2.0);
 				separator->draw(ci, Rect2(item_ofs + Point2(0, sep_ofs), Size2(display_width, sep_h)));
 			}
 		}


### PR DESCRIPTION
- Fix normal separator influencing the positioning of the labeled separator.
- Make distance between labeled separator and text be defined by `hseparation`.

|Before:|After:|
|-|-|
|![Screenshot_20220413_175154](https://user-images.githubusercontent.com/30739239/163269944-fd6294e0-fed9-4bb6-81b6-1e9bde0af235.png)|![Screenshot_20220413_180011](https://user-images.githubusercontent.com/30739239/163269996-bea4279f-ce58-4081-8be4-760e6ab23ff1.png)|