### PR TITLE
Fix simultaneous touches for different touch types in iOS

### DIFF
--- a/platform/iphone/godot_view_gesture_recognizer.mm
+++ b/platform/iphone/godot_view_gesture_recognizer.mm
@@ -70,6 +70,7 @@ const CGFloat kGLGestureMovementDistance = 0.5;
 	self.cancelsTouchesInView = YES;
 	self.delaysTouchesBegan = YES;
 	self.delaysTouchesEnded = YES;
+	self.requiresExclusiveTouchType = NO;
 
 	self.delayTimeInterval = GLOBAL_GET("input_devices/pointing/ios/touch_delay");
 


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/60190.

It enables simultaneous touches for different touch types. For example, the user will be able to receive input events from both the apple pencil and the user finger.
