### PR TITLE
Reduce width of arrow icons for the default theme in `PopupMenu`

### DIFF
--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -649,8 +649,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("unchecked", "PopupMenu", icons["unchecked"]);
 	theme->set_icon("radio_checked", "PopupMenu", icons["radio_checked"]);
 	theme->set_icon("radio_unchecked", "PopupMenu", icons["radio_unchecked"]);
-	theme->set_icon("submenu", "PopupMenu", icons["arrow_right"]);
-	theme->set_icon("submenu_mirrored", "PopupMenu", icons["arrow_left"]);
+	theme->set_icon("submenu", "PopupMenu", icons["popup_menu_arrow_right"]);
+	theme->set_icon("submenu_mirrored", "PopupMenu", icons["popup_menu_arrow_left"]);
 
 	theme->set_font("font", "PopupMenu", Ref<Font>());
 	theme->set_font_size("font_size", "PopupMenu", -1);

--- a/scene/resources/default_theme/popup_menu_arrow_left.svg
+++ b/scene/resources/default_theme/popup_menu_arrow_left.svg
@@ -1,0 +1,1 @@
+<svg clip-rule="evenodd" fill-rule="evenodd" height="16" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 8 16" width="8" xmlns="http://www.w3.org/2000/svg"><path d="m5.4999793 11-3-3 3-3" fill="none" stroke="#b2b2b2" stroke-opacity=".45" stroke-width="2"/></svg>

--- a/scene/resources/default_theme/popup_menu_arrow_right.svg
+++ b/scene/resources/default_theme/popup_menu_arrow_right.svg
@@ -1,0 +1,1 @@
+<svg clip-rule="evenodd" fill-rule="evenodd" height="16" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 8 16" width="8" xmlns="http://www.w3.org/2000/svg"><path d="m2.5000207 11 3-3-3-3" fill="none" stroke="#b2b2b2" stroke-opacity=".45" stroke-width="2"/></svg>


### PR DESCRIPTION
Currently, the submenu arrow for `PopupMenu` is a little too distant from the border, I slimmed the icon down a little to make it be closer:

|Before:|After:|
|-|-|
|![Screenshot_20220413_214718](https://user-images.githubusercontent.com/30739239/163303084-7c480d90-52d1-4e42-877d-2cfcb7d26abb.png)|![Screenshot_20220413_221123](https://user-images.githubusercontent.com/30739239/163303117-a0ff6b7b-ecba-4ce0-9fab-d21c07d0a0c3.png)|