### PR TITLE
Add `font_separator` and related properties to `PopupMenu`

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -568,6 +568,9 @@
 		<theme_item name="font_separator_color" data_type="color" type="Color" default="Color(0.875, 0.875, 0.875, 1)">
 			[Color] used for labeled separators' text. See [method add_separator].
 		</theme_item>
+		<theme_item name="font_separator_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			The tint of text outline of the labeled separator.
+		</theme_item>
 		<theme_item name="hseparation" data_type="constant" type="int" default="4">
 			The horizontal space between the item's elements.
 		</theme_item>
@@ -578,11 +581,20 @@
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the item text outline.
 		</theme_item>
+		<theme_item name="separator_outline_size" data_type="constant" type="int" default="0">
+			The size of the labeled separator text outline.
+		</theme_item>
 		<theme_item name="vseparation" data_type="constant" type="int" default="4">
 			The vertical space between each menu item.
 		</theme_item>
 		<theme_item name="font" data_type="font" type="Font">
 			[Font] used for the menu items.
+		</theme_item>
+		<theme_item name="font_separator" data_type="font" type="Font">
+			[Font] used for the labeled separator.
+		</theme_item>
+		<theme_item name="font_separator_size" data_type="font_size" type="int">
+			Font size of the labeled separator.
 		</theme_item>
 		<theme_item name="font_size" data_type="font_size" type="int">
 			Font size of the menu items.

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -635,23 +635,28 @@ void PopupMenu::_draw_items() {
 			}
 		}
 
-		// Text
 		Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
 		int outline_size = get_theme_constant(SNAME("outline_size"));
+
+		// Text
 		if (items[i].separator) {
+			Color font_separator_outline_color = get_theme_color(SNAME("font_separator_outline_color"));
+			int separator_outline_size = get_theme_constant(SNAME("separator_outline_size"));
+
 			if (!text.is_empty()) {
 				Vector2 text_pos = Point2(separator_ofs, item_ofs.y + Math::floor((h - items[i].text_buf->get_size().y) / 2.0));
 				if (!rtl && !items[i].icon.is_null()) {
 					text_pos.x += icon_size.width + hseparation;
 				}
 
-				if (outline_size > 0 && font_outline_color.a > 0) {
-					items[i].text_buf->draw_outline(ci, text_pos, outline_size, font_outline_color);
+				if (separator_outline_size > 0 && font_separator_outline_color.a > 0) {
+					items[i].text_buf->draw_outline(ci, text_pos, separator_outline_size, font_separator_outline_color);
 				}
 				items[i].text_buf->draw(ci, text_pos, font_separator_color);
 			}
 		} else {
 			item_ofs.x += icon_ofs + check_ofs;
+
 			if (rtl) {
 				Vector2 text_pos = Size2(control->get_size().width - items[i].text_buf->get_size().width - item_ofs.x, item_ofs.y) + Point2(0, Math::floor((h - items[i].text_buf->get_size().y) / 2.0));
 				if (outline_size > 0 && font_outline_color.a > 0) {
@@ -724,8 +729,8 @@ void PopupMenu::_shape_item(int p_item) {
 	if (items.write[p_item].dirty) {
 		items.write[p_item].text_buf->clear();
 
-		Ref<Font> font = get_theme_font(SNAME("font"));
-		int font_size = get_theme_font_size(SNAME("font_size"));
+		Ref<Font> font = get_theme_font(items[p_item].separator ? SNAME("font_separator") : SNAME("font"));
+		int font_size = get_theme_font_size(items[p_item].separator ? SNAME("font_separator_size") : SNAME("font_size"));
 
 		if (items[p_item].text_direction == Control::TEXT_DIRECTION_INHERITED) {
 			items.write[p_item].text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -653,7 +653,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("submenu_mirrored", "PopupMenu", icons["arrow_left"]);
 
 	theme->set_font("font", "PopupMenu", Ref<Font>());
+	theme->set_font("font_separator", "PopupMenu", Ref<Font>());
 	theme->set_font_size("font_size", "PopupMenu", -1);
+	theme->set_font_size("font_separator_size", "PopupMenu", -1);
 
 	theme->set_color("font_color", "PopupMenu", control_font_color);
 	theme->set_color("font_accelerator_color", "PopupMenu", Color(0.7, 0.7, 0.7, 0.8));
@@ -661,10 +663,12 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_hover_color", "PopupMenu", control_font_color);
 	theme->set_color("font_separator_color", "PopupMenu", control_font_color);
 	theme->set_color("font_outline_color", "PopupMenu", Color(1, 1, 1));
+	theme->set_color("font_separator_outline_color", "PopupMenu", Color(1, 1, 1));
 
 	theme->set_constant("hseparation", "PopupMenu", 4 * scale);
 	theme->set_constant("vseparation", "PopupMenu", 4 * scale);
 	theme->set_constant("outline_size", "PopupMenu", 0);
+	theme->set_constant("separator_outline_size", "PopupMenu", 0);
 	theme->set_constant("item_start_padding", "PopupMenu", 2 * scale);
 	theme->set_constant("item_end_padding", "PopupMenu", 2 * scale);
 


### PR DESCRIPTION
This add a theme property to define the font used for labeled separators, as well as its size and outline looks. It's a good theming option to have to make the text in separators stand out from the text of other items.