### PR TITLE
Use an exponential representation for interface/inspector/default_float_step

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -6065,8 +6065,8 @@ EditorNode::EditorNode() {
 	EDITOR_DEF_RST("interface/scene_tabs/restore_scenes_on_load", true);
 	EDITOR_DEF_RST("interface/inspector/default_property_name_style", EditorPropertyNameProcessor::STYLE_CAPITALIZED);
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::INT, "interface/inspector/default_property_name_style", PROPERTY_HINT_ENUM, "Raw,Capitalized,Localized"));
-	EDITOR_DEF_RST("interface/inspector/default_float_step", 0.001);
-	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::FLOAT, "interface/inspector/default_float_step", PROPERTY_HINT_RANGE, "0,1,0"));
+	EDITOR_DEF_RST("interface/inspector/default_float_step_exponent", -3);
+	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::FLOAT, "interface/inspector/default_float_step_exponent", PROPERTY_HINT_RANGE, "-14,0,1"));
 	EDITOR_DEF_RST("interface/inspector/disable_folding", false);
 	EDITOR_DEF_RST("interface/inspector/auto_unfold_foreign_scenes", true);
 	EDITOR_DEF("interface/inspector/horizontal_vector2_editing", false);

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3404,7 +3404,7 @@ static EditorPropertyRangeHint _parse_range_hint(PropertyHint p_hint, const Stri
 }
 
 EditorProperty *EditorInspectorDefaultPlugin::get_editor_for_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide) {
-	double default_float_step = EDITOR_GET("interface/inspector/default_float_step");
+	double default_float_step = Math::pow(10.0, EDITOR_GET("interface/inspector/default_float_step_exponent"));
 
 	switch (p_type) {
 		// atomic types

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -872,7 +872,7 @@ void EditorPropertyDictionary::update_property() {
 
 		object->set_dict(dict);
 		VBoxContainer *add_vbox = nullptr;
-		double default_float_step = EDITOR_GET("interface/inspector/default_float_step");
+		double default_float_step = Math::pow(10.0, EDITOR_GET("interface/inspector/default_float_step_exponent"));
 
 		for (int i = 0; i < total_amount; i++) {
 			String prop_name;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -4074,7 +4074,7 @@ void Node3DEditorViewport::commit_transform() {
 void Node3DEditorViewport::update_transform(Point2 p_mousepos, bool p_shift) {
 	Vector3 ray_pos = _get_ray_pos(p_mousepos);
 	Vector3 ray = _get_ray(p_mousepos);
-	double snap = EDITOR_GET("interface/inspector/default_float_step");
+	double snap = Math::pow(10.0, EDITOR_GET("interface/inspector/default_float_step_exponent"));
 	int snap_step_decimals = Math::range_step_decimals(snap);
 
 	switch (_edit.mode) {


### PR DESCRIPTION
~~Previously, step was set to 0, making it impossible to drag to change the value.~~

It might be better to use a base 10 index here. For example `-3` means `0.001`, `-5` means `0.00001`.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Use exponential representation for this property instead, increase the range of precision that can be used. 

|| Before | After |
| :------: | :------: | :------: |
| Property | `interface/inspector/default_float_step` | `interface/inspector/default_float_step_exponent` |
| Hint_range | (0, 1, 0.001) [**hard-coded**] | (-14, 0, 1) [**hard-coded**] |
| Brief introduction | The property is limited by its hint range step  , valid value cannot be less than `0.001`, accurate to `3` decimals. | `10^E`,  accurate to `E` decimals. |


