### PR TITLE
[3.x] Fix undo history for function name autocompletion

### DIFF
--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -6793,13 +6793,13 @@ void TextEdit::_confirm_completion() {
 
 	if (last_completion_char == '(') {
 		if (next_char == last_completion_char) {
-			_base_remove_text(cursor.line, cursor.column - 1, cursor.line, cursor.column);
+			_remove_text(cursor.line, cursor.column - 1, cursor.line, cursor.column);
 		} else if (auto_brace_completion_enabled) {
 			insert_text_at_cursor(")");
 			cursor.column--;
 		}
 	} else if (last_completion_char == ')' && next_char == '(') {
-		_base_remove_text(cursor.line, cursor.column - 2, cursor.line, cursor.column);
+		_remove_text(cursor.line, cursor.column - 2, cursor.line, cursor.column);
 		if (line[cursor.column + 1] != ')') {
 			cursor.column--;
 		}


### PR DESCRIPTION
Fixes #59805.

* Complete `get_node` at `get_no|("path")`. It became `get_no"path")` after undo.
* Complete `raise` at `rai|()`. It became `rai` after undo.

The removal of additional parenthesis were not added to undo history.

It's OK on `master`.