### PR TITLE
Fixed leading spaces pushing text outside Label autowrap boundary problem

### DIFF
--- a/scene/gui/label.cpp
+++ b/scene/gui/label.cpp
@@ -452,7 +452,13 @@ void Label::regenerate_word_cache() {
 			}
 
 			if (i < xl_text.length() && xl_text[i] == ' ') {
-				if (line_width > 0 || last == nullptr || last->char_pos != WordCache::CHAR_WRAPLINE) {
+				if (line_width == 0) {
+					if (current_word_size == 0) {
+						word_pos = i;
+					}
+					current_word_size += space_width;
+					line_width += space_width;
+				} else if (line_width > 0 || last == nullptr || last->char_pos != WordCache::CHAR_WRAPLINE) {
 					space_count++;
 					line_width += space_width;
 				} else {


### PR DESCRIPTION
Fixed #59985  leading spaces autowrap boundary problem

Bug problem:
No condition for when the first character of the label is a space character

Fix:
Added an IF condition for when the first character is a space character
The autowrap boundary treat this space character as another dummy word in the WordCache linked list and proceed to function normally

_*Note: this pull request should hopefully be final_

https://user-images.githubusercontent.com/50128969/163352521-feb6262a-ea24-4cdc-beed-706a9c13fc4f.mp4

@timothyqiu 