### PR TITLE
END key state on navigating lines for TextEdit

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1480,7 +1480,9 @@ void CodeEdit::fold_line(int p_line) {
 	/* Reset caret. */
 	if (_is_line_hidden(get_caret_line())) {
 		set_caret_line(p_line, false, false);
-		set_caret_column(get_line(p_line).length(), false);
+		if (caret.last_fit_x != INT_MAX) {
+			set_caret_column(get_line(p_line).length(), false);
+		}
 	}
 	update();
 }

--- a/scene/gui/text_edit.cpp
+++ b/scene/gui/text_edit.cpp
@@ -2350,6 +2350,8 @@ void TextEdit::_move_caret_to_line_end(bool p_select) {
 		set_caret_column(row_end_col);
 	}
 
+	caret.last_fit_x = INT_MAX;
+
 	if (p_select) {
 		_post_shift_selection();
 	}

--- a/scene/gui/text_edit.h
+++ b/scene/gui/text_edit.h
@@ -357,18 +357,6 @@ private:
 
 	int _get_char_pos_for_line(int p_px, int p_line, int p_wrap_index = 0) const;
 
-	/* Caret. */
-	struct Caret {
-		Point2 draw_pos;
-		bool visible = false;
-		int last_fit_x = 0;
-		int line = 0;
-		int column = 0;
-		int x_ofs = 0;
-		int line_ofs = 0;
-		int wrap_ofs = 0;
-	} caret;
-
 	bool setting_caret_line = false;
 	bool caret_pos_dirty = false;
 
@@ -572,6 +560,18 @@ private:
 	void _move_caret_document_end(bool p_select);
 
 protected:
+	/* Caret. */
+	struct Caret {
+		Point2 draw_pos;
+		bool visible = false;
+		int last_fit_x = 0;
+		int line = 0;
+		int column = 0;
+		int x_ofs = 0;
+		int line_ofs = 0;
+		int wrap_ofs = 0;
+	} caret;
+
 	void _notification(int p_what);
 
 	static void _bind_methods();

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -3388,6 +3388,35 @@ TEST_CASE("[SceneTree][CodeEdit] New Line") {
 	memdelete(code_edit);
 }
 
+TEST_CASE("[SceneTree][CodeEdit] End Key State") {
+	CodeEdit *code_edit = memnew(CodeEdit);
+	SceneTree::get_singleton()->get_root()->add_child(code_edit);
+	code_edit->grab_focus();
+
+	/* Check end key state. */
+	code_edit->set_text("shorter line:\n    longer line to test end key state\nmore longer line to test end key state");
+	code_edit->set_caret_line(0);
+	code_edit->set_caret_column(0);
+	SEND_GUI_ACTION(code_edit, "ui_text_caret_line_end");
+	SEND_GUI_ACTION(code_edit, "ui_text_caret_down");
+	CHECK(code_edit->get_caret_column() == code_edit->get_line(1).length());
+
+	/* Check clearing end key state. */
+	SEND_GUI_ACTION(code_edit, "ui_text_caret_up");
+	SEND_GUI_ACTION(code_edit, "ui_text_caret_left");
+	SEND_GUI_ACTION(code_edit, "ui_text_caret_right");
+	SEND_GUI_ACTION(code_edit, "ui_text_caret_down");
+	CHECK(code_edit->get_caret_column() - 1 == code_edit->get_line(0).length());
+
+	/* Check end key state behaviour on folded block. */
+	SEND_GUI_ACTION(code_edit, "ui_text_caret_line_end");
+	code_edit->fold_line(0);
+	SEND_GUI_ACTION(code_edit, "ui_text_caret_down");
+	CHECK(code_edit->get_caret_column() - 1 == code_edit->get_line(1).length());
+
+	memdelete(code_edit);
+}
+
 } // namespace TestCodeEdit
 
 #endif // TEST_CODE_EDIT_H


### PR DESCRIPTION
Meooowww... I made END key state for TextEdit.

Looks like this:
![godot-end-key-state](https://user-images.githubusercontent.com/1125150/163404738-8b6e8731-e54a-461d-a742-18d20c69d6a8.gif)