### PR TITLE
`NavMap::get_path` Fix not resetting `least_cost_id`

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -226,6 +226,7 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 			navigation_polys.push_back(np);
 			to_visit.clear();
 			to_visit.push_back(0);
+			least_cost_id = 0;
 
 			reachable_end = nullptr;
 
@@ -245,6 +246,8 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 			}
 		}
 
+		ERR_BREAK(least_cost_id == -1);
+
 		// Stores the further reachable end polygon, in case our goal is not reachable.
 		if (is_reachable) {
 			float d = navigation_polys[least_cost_id].entry.distance_to(p_destination);
@@ -253,8 +256,6 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 				reachable_end = navigation_polys[least_cost_id].poly;
 			}
 		}
-
-		ERR_BREAK(least_cost_id == -1);
 
 		// Check if we reached the end
 		if (navigation_polys[least_cost_id].poly == end_poly) {


### PR DESCRIPTION
`least_cost_id` wasn't appropriately reseted when resetting search state (which happens in case the point (within the navigation area) closest to the destination isn't reachable and thus a reachable point closest to the destination is set as the new `end_point` of the resulting path).

It could have resulted in undefined behavior as for `std::vector::operator []`: [Accessing a nonexistent element through this operator is undefined behavior.](https://en.cppreference.com/w/cpp/container/vector/operator_at) (`std::vector` is used for `navigation_polys`)

[Seems like it wasn't crashing but would spam errors](https://www.reddit.com/r/godot/comments/u2s0qy/error_with_navigation_in_godot_35_help/) (linked issue is for `3.5` but should be the same in here) on trying to erase a nonexistent entry from the Godot's `List`:
https://github.com/godotengine/godot/blob/12cb05b3040242deebb87262aed8c04218b69044/modules/navigation/nav_map.cpp#L198