### PR TITLE
Replaced `loops_current` with `end_loop` in `AnimationNodeStateMachinePlayback`

### DIFF
--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -97,7 +97,7 @@ class AnimationNodeStateMachinePlayback : public Resource {
 
 	float len_current = 0.0;
 	float pos_current = 0.0;
-	int loops_current = 0;
+	bool end_loop = false;
 
 	StringName current;
 


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

First time committing to open source!

Fixes #59967

Found in `AnimationNodeStateMachinePlayback`

Private variable `loops_current` in was being used in the method `_travel` to calculate the end of a loop.
```
if (next_pos < pos_current) {
    loops_current++;
}
pos_current = next_pos; //looped
```
```
if (switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_AT_END) {
    goto_next = next_xfade >= (len_current - pos_current) || loops_current > 0;
```

This created an issue when an Advance Condition (atEnd) was changed from false to true when `loops_current > 0` (any time after the first loop). This caused an immediate transition instead of at the end of the animation loop.

Could not find any other use for `loops_current` so I replaced it with `end_loop` to solve this issue;


Relevent changes in `_travel`
```diff
{ //advance and loop check

	float next_pos = len_current - rem;

-	if (next_pos < pos_current) {
-		loops_current++;
-	}
+	end_loop = next_pos < pos_current;
	pos_current = next_pos; //looped
}


if (switch_mode == AnimationNodeStateMachineTransition::SWITCH_MODE_AT_END) {
-    goto_next = next_xfade >= (len_current - pos_current) || loops_current > 0;
-    if (loops_current > 0) {
+    goto_next = next_xfade >= (len_current - pos_current) || end_loop;
+    if (end_loop) {
......
}
```

First time contributing please inform me if I did anything out of conduct :)
