### PR TITLE
BUGFIX: Fix Control Parenting Issues

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -707,9 +707,17 @@ void Control::_notification(int p_notification) {
 #endif
 		} break;
 
-		case NOTIFICATION_ENTER_CANVAS: {
+		case NOTIFICATION_PARENTED: {
 			data.parent = Object::cast_to<Control>(get_parent());
 			data.parent_window = Object::cast_to<Window>(get_parent());
+		} break;
+
+		case NOTIFICATION_UNPARENTED: {
+			data.parent = nullptr;
+			data.parent_window = nullptr;
+		} break;
+
+		case NOTIFICATION_ENTER_CANVAS: {
 			data.is_rtl_dirty = true;
 
 			Node *parent = this; //meh
@@ -780,9 +788,7 @@ void Control::_notification(int p_notification) {
 				data.RI = nullptr;
 			}
 
-			data.parent = nullptr;
 			data.parent_canvas_item = nullptr;
-			data.parent_window = nullptr;
 			data.is_rtl_dirty = true;
 		} break;
 


### PR DESCRIPTION
`Control`'s internal parent/window was being set on canvas enter/exit instead of on notifications for parented/unparented.

This made it impossible to add a child to a control and then get its parent immediately after (as it was nullptr).

This is needed because the current API for adding in a dock tab and then settings its title requires you to add it, get its parent `TabContainer`, and then get its ID from the container and set its title. (I will probably add a better API for this later).