### PR TITLE
[3.x] Add `color_ramp` to OpenSimplexNoise

### DIFF
--- a/modules/opensimplex/doc_classes/NoiseTexture.xml
+++ b/modules/opensimplex/doc_classes/NoiseTexture.xml
@@ -24,6 +24,9 @@
 		<member name="bump_strength" type="float" setter="set_bump_strength" getter="get_bump_strength" default="8.0">
 			Strength of the bump maps used in this texture. A higher value will make the bump maps appear larger while a lower value will make them appear softer.
 		</member>
+		<member name="color_ramp" type="Gradient" setter="set_color_ramp" getter="get_color_ramp">
+			A [Gradient] which is used to map the luminance of each pixel to a color value.
+		</member>
 		<member name="flags" type="int" setter="set_flags" getter="get_flags" overrides="Texture" default="7" />
 		<member name="height" type="int" setter="set_height" getter="get_height" default="512">
 			Height of the generated texture.

--- a/modules/opensimplex/icons/icon_noise_texture.svg
+++ b/modules/opensimplex/icons/icon_noise_texture.svg
@@ -1,3 +1,1 @@
-<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-<path d="m2 1c-0.55228 0-1 0.44772-1 1v12c0 0.55228 0.44772 1 1 1h12c0.55228 0 1-0.44772 1-1v-12c0-0.55228-0.44772-1-1-1zm1 2h10v8h-10zm3 1v2h2v-2zm2 2v2h2v2h2v-6h-2v2zm0 2h-2v-2h-2v4h4z" fill="#e0e0e0" fill-opacity=".99608"/>
-</svg>
+<svg width="16" height="16" version="1.1" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg"><path d="m2 1c-0.55228 0-1 0.44772-1 1v12c0 0.55228 0.44772 1 1 1h12c0.55228 0 1-0.44772 1-1v-12c0-0.55228-0.44772-1-1-1zm1 2h10v8h-10zm3 1v2h2v-2zm2 2v2h2v2h2v-6h-2v2zm0 2h-2v-2h-2v4h4z" fill="#e0e0e0"/></svg>

--- a/modules/opensimplex/noise_texture.h
+++ b/modules/opensimplex/noise_texture.h
@@ -60,6 +60,7 @@ private:
 	bool seamless;
 	bool as_normalmap;
 	float bump_strength;
+	Ref<Gradient> color_ramp;
 
 	void _thread_done(const Ref<Image> &p_image);
 	static void _thread_function(void *p_ud);
@@ -68,6 +69,8 @@ private:
 	Ref<Image> _generate_texture();
 	void _update_texture();
 	void _set_texture_data(const Ref<Image> &p_image);
+
+	Ref<Image> _modulate_with_gradient(Ref<Image> p_image, Ref<Gradient> p_gradient);
 
 protected:
 	static void _bind_methods();
@@ -84,13 +87,16 @@ public:
 	Vector2 get_noise_offset() const;
 
 	void set_seamless(bool p_seamless);
-	bool get_seamless();
+	bool get_seamless() const;
 
 	void set_as_normalmap(bool p_as_normalmap);
-	bool is_normalmap();
+	bool is_normalmap() const;
 
 	void set_bump_strength(float p_bump_strength);
-	float get_bump_strength();
+	float get_bump_strength() const;
+
+	void set_color_ramp(const Ref<Gradient> &p_gradient);
+	Ref<Gradient> get_color_ramp() const;
 
 	int get_width() const;
 	int get_height() const;


### PR DESCRIPTION
Adds a `color_ramp` property to OpenSimplexNoise. `color_ramp` was added to the new FastNoiseLite resource in https://github.com/godotengine/godot/pull/56718, but that cannot be backported because it breaks compatibility.

![image](https://user-images.githubusercontent.com/67974470/163483176-668f7d2f-ae8f-4d31-9a15-881c7c4f44b9.png)
