### PR TITLE
Rename theme properties to include underscores between words

### DIFF
--- a/doc/classes/Button.xml
+++ b/doc/classes/Button.xml
@@ -78,7 +78,7 @@
 		</member>
 		<member name="icon" type="Texture2D" setter="set_button_icon" getter="get_button_icon">
 			Button's icon, if text is present the icon will be placed before the text.
-			To edit margin and spacing of the icon, use [theme_item hseparation] theme property and [code]content_margin_*[/code] properties of the used [StyleBox]es.
+			To edit margin and spacing of the icon, use [theme_item h_separation] theme property and [code]content_margin_*[/code] properties of the used [StyleBox]es.
 		</member>
 		<member name="icon_alignment" type="int" setter="set_icon_alignment" getter="get_icon_alignment" enum="HorizontalAlignment" default="0">
 			Specifies if the icon should be aligned to the left, right, or center of a button. Uses the same [enum @GlobalScope.HorizontalAlignment] constants as the text alignment. If centered, text will draw on top of the icon.
@@ -133,7 +133,7 @@
 		<theme_item name="icon_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Icon modulate [Color] used when the [Button] is being pressed.
 		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="2">
+		<theme_item name="h_separation" data_type="constant" type="int" default="2">
 			The horizontal space between [Button]'s icon and text.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">

--- a/doc/classes/CheckBox.xml
+++ b/doc/classes/CheckBox.xml
@@ -35,10 +35,10 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckBox] text's font color when it's pressed.
 		</theme_item>
-		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
+		<theme_item name="check_v_adjust" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the check icons (in pixels).
 		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="4">
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The separation between the check icon and the text (in pixels).
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">

--- a/doc/classes/CheckButton.xml
+++ b/doc/classes/CheckButton.xml
@@ -35,10 +35,10 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The [CheckButton] text's font color when it's pressed.
 		</theme_item>
-		<theme_item name="check_vadjust" data_type="constant" type="int" default="0">
+		<theme_item name="check_v_adjust" data_type="constant" type="int" default="0">
 			The vertical offset used when rendering the toggle icons (in pixels).
 		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="4">
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The separation between the toggle icon and the text (in pixels).
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">

--- a/doc/classes/ColorPickerButton.xml
+++ b/doc/classes/ColorPickerButton.xml
@@ -74,7 +74,7 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(0.8, 0.8, 0.8, 1)">
 			Text [Color] used when the [ColorPickerButton] is being pressed.
 		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="2">
+		<theme_item name="h_separation" data_type="constant" type="int" default="2">
 			The horizontal space between [ColorPickerButton]'s icon and text.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">

--- a/doc/classes/GraphEdit.xml
+++ b/doc/classes/GraphEdit.xml
@@ -342,7 +342,7 @@
 			</description>
 		</signal>
 		<signal name="scroll_offset_changed">
-			<argument index="0" name="ofs" type="Vector2" />
+			<argument index="0" name="offset" type="Vector2" />
 			<description>
 				Emitted when the scroll offset is changed by the user. It will not be emitted when changed in code.
 			</description>

--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -331,7 +331,7 @@
 		<theme_item name="comment" data_type="style" type="StyleBox">
 			The [StyleBox] used when [member comment] is enabled.
 		</theme_item>
-		<theme_item name="commentfocus" data_type="style" type="StyleBox">
+		<theme_item name="comment_focus" data_type="style" type="StyleBox">
 			The [StyleBox] used when [member comment] is enabled and the [GraphNode] is focused.
 		</theme_item>
 		<theme_item name="frame" data_type="style" type="StyleBox">
@@ -340,7 +340,7 @@
 		<theme_item name="position" data_type="style" type="StyleBox">
 			The background used when [member overlay] is set to [constant OVERLAY_POSITION].
 		</theme_item>
-		<theme_item name="selectedframe" data_type="style" type="StyleBox">
+		<theme_item name="selected_frame" data_type="style" type="StyleBox">
 			The background used when the [GraphNode] is selected.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/GridContainer.xml
+++ b/doc/classes/GridContainer.xml
@@ -17,10 +17,10 @@
 		</member>
 	</members>
 	<theme_items>
-		<theme_item name="hseparation" data_type="constant" type="int" default="4">
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal separation of children nodes.
 		</theme_item>
-		<theme_item name="vseparation" data_type="constant" type="int" default="4">
+		<theme_item name="v_separation" data_type="constant" type="int" default="4">
 			The vertical separation of children nodes.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/HFlowContainer.xml
+++ b/doc/classes/HFlowContainer.xml
@@ -9,10 +9,10 @@
 	<tutorials>
 	</tutorials>
 	<theme_items>
-		<theme_item name="hseparation" data_type="constant" type="int" default="4">
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal separation of children nodes.
 		</theme_item>
-		<theme_item name="vseparation" data_type="constant" type="int" default="4">
+		<theme_item name="v_separation" data_type="constant" type="int" default="4">
 			The vertical separation of children nodes.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -476,7 +476,7 @@
 		<theme_item name="guide_color" data_type="color" type="Color" default="Color(0, 0, 0, 0.1)">
 			[Color] of the guideline. The guideline is a line drawn between each row of items.
 		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="4">
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal spacing between items.
 		</theme_item>
 		<theme_item name="icon_margin" data_type="constant" type="int" default="4">
@@ -488,7 +488,7 @@
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the item text outline.
 		</theme_item>
-		<theme_item name="vseparation" data_type="constant" type="int" default="2">
+		<theme_item name="v_separation" data_type="constant" type="int" default="2">
 			The vertical spacing between items.
 		</theme_item>
 		<theme_item name="font" data_type="font" type="Font">

--- a/doc/classes/MenuButton.xml
+++ b/doc/classes/MenuButton.xml
@@ -64,7 +64,7 @@
 		<theme_item name="font_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			Text [Color] used when the [MenuButton] is being pressed.
 		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="3">
+		<theme_item name="h_separation" data_type="constant" type="int" default="3">
 			The horizontal space between [MenuButton]'s icon and text.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -238,7 +238,7 @@
 		<theme_item name="arrow_margin" data_type="constant" type="int" default="4">
 			The horizontal space between the arrow icon and the right edge of the button.
 		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="2">
+		<theme_item name="h_separation" data_type="constant" type="int" default="2">
 			The horizontal space between [OptionButton]'s icon and text.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -571,7 +571,7 @@
 		<theme_item name="font_separator_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the labeled separator.
 		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="4">
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal space between the item's elements.
 		</theme_item>
 		<theme_item name="item_end_padding" data_type="constant" type="int" default="2">
@@ -584,7 +584,7 @@
 		<theme_item name="separator_outline_size" data_type="constant" type="int" default="0">
 			The size of the labeled separator text outline.
 		</theme_item>
-		<theme_item name="vseparation" data_type="constant" type="int" default="4">
+		<theme_item name="v_separation" data_type="constant" type="int" default="4">
 			The vertical space between each menu item.
 		</theme_item>
 		<theme_item name="font" data_type="font" type="Font">

--- a/doc/classes/RichTextLabel.xml
+++ b/doc/classes/RichTextLabel.xml
@@ -667,10 +667,10 @@
 		<theme_item name="shadow_outline_size" data_type="constant" type="int" default="1">
 			The size of the shadow outline.
 		</theme_item>
-		<theme_item name="table_hseparation" data_type="constant" type="int" default="3">
+		<theme_item name="table_h_separation" data_type="constant" type="int" default="3">
 			The horizontal separation of elements in a table.
 		</theme_item>
-		<theme_item name="table_vseparation" data_type="constant" type="int" default="3">
+		<theme_item name="table_v_separation" data_type="constant" type="int" default="3">
 			The vertical separation of elements in a table.
 		</theme_item>
 		<theme_item name="bold_font" data_type="font" type="Font">

--- a/doc/classes/TabBar.xml
+++ b/doc/classes/TabBar.xml
@@ -338,7 +338,7 @@
 		<theme_item name="font_unselected_color" data_type="color" type="Color" default="Color(0.7, 0.7, 0.7, 1)">
 			Font color of the other, unselected tabs.
 		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="4">
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal separation between the elements inside tabs.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">

--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -522,7 +522,7 @@
 		<theme_item name="draw_relationship_lines" data_type="constant" type="int" default="0">
 			Draws the relationship lines if not zero, this acts as a boolean. Relationship lines are drawn at the start of child items to show hierarchy.
 		</theme_item>
-		<theme_item name="hseparation" data_type="constant" type="int" default="4">
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal space between item cells. This is also used as the margin at the start of an item when folding is disabled.
 		</theme_item>
 		<theme_item name="item_margin" data_type="constant" type="int" default="16">
@@ -546,7 +546,7 @@
 		<theme_item name="scroll_speed" data_type="constant" type="int" default="12">
 			The speed of border scrolling.
 		</theme_item>
-		<theme_item name="vseparation" data_type="constant" type="int" default="4">
+		<theme_item name="v_separation" data_type="constant" type="int" default="4">
 			The vertical padding inside each item, i.e. the distance between the item's content and top/bottom border.
 		</theme_item>
 		<theme_item name="font" data_type="font" type="Font">

--- a/doc/classes/VFlowContainer.xml
+++ b/doc/classes/VFlowContainer.xml
@@ -9,10 +9,10 @@
 	<tutorials>
 	</tutorials>
 	<theme_items>
-		<theme_item name="hseparation" data_type="constant" type="int" default="4">
+		<theme_item name="h_separation" data_type="constant" type="int" default="4">
 			The horizontal separation of children nodes.
 		</theme_item>
-		<theme_item name="vseparation" data_type="constant" type="int" default="4">
+		<theme_item name="v_separation" data_type="constant" type="int" default="4">
 			The vertical separation of children nodes.
 		</theme_item>
 	</theme_items>

--- a/doc/classes/Window.xml
+++ b/doc/classes/Window.xml
@@ -467,9 +467,9 @@
 		<theme_item name="title_outline_modulate" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The color of the title outline.
 		</theme_item>
-		<theme_item name="close_h_ofs" data_type="constant" type="int" default="18">
+		<theme_item name="close_h_offset" data_type="constant" type="int" default="18">
 		</theme_item>
-		<theme_item name="close_v_ofs" data_type="constant" type="int" default="24">
+		<theme_item name="close_v_offset" data_type="constant" type="int" default="24">
 		</theme_item>
 		<theme_item name="resize_margin" data_type="constant" type="int" default="4">
 		</theme_item>

--- a/editor/animation_bezier_editor.cpp
+++ b/editor/animation_bezier_editor.cpp
@@ -250,8 +250,8 @@ void AnimationBezierTrackEdit::_notification(int p_what) {
 			Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
 			int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 			Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
-			int hsep = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
-			int vsep = get_theme_constant(SNAME("vseparation"), SNAME("ItemList"));
+			int hsep = get_theme_constant(SNAME("h_separation"), SNAME("ItemList"));
+			int vsep = get_theme_constant(SNAME("v_separation"), SNAME("ItemList"));
 			Color linecolor = color;
 			linecolor.a = 0.2;
 
@@ -1585,14 +1585,14 @@ void AnimationBezierTrackEdit::_bind_methods() {
 
 	ADD_SIGNAL(MethodInfo("timeline_changed", PropertyInfo(Variant::FLOAT, "position"), PropertyInfo(Variant::BOOL, "drag")));
 	ADD_SIGNAL(MethodInfo("remove_request", PropertyInfo(Variant::INT, "track")));
-	ADD_SIGNAL(MethodInfo("insert_key", PropertyInfo(Variant::FLOAT, "ofs")));
+	ADD_SIGNAL(MethodInfo("insert_key", PropertyInfo(Variant::FLOAT, "offset")));
 	ADD_SIGNAL(MethodInfo("select_key", PropertyInfo(Variant::INT, "track"), PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::BOOL, "single")));
 	ADD_SIGNAL(MethodInfo("deselect_key", PropertyInfo(Variant::INT, "track"), PropertyInfo(Variant::INT, "index")));
 	ADD_SIGNAL(MethodInfo("clear_selection"));
 	ADD_SIGNAL(MethodInfo("close_request"));
 
 	ADD_SIGNAL(MethodInfo("move_selection_begin"));
-	ADD_SIGNAL(MethodInfo("move_selection", PropertyInfo(Variant::FLOAT, "ofs")));
+	ADD_SIGNAL(MethodInfo("move_selection", PropertyInfo(Variant::FLOAT, "offset")));
 	ADD_SIGNAL(MethodInfo("move_selection_commit"));
 	ADD_SIGNAL(MethodInfo("move_selection_cancel"));
 }

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -1981,7 +1981,7 @@ void AnimationTrackEdit::_notification(int p_what) {
 			Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
 			int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
 			Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
-			int hsep = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
+			int hsep = get_theme_constant(SNAME("h_separation"), SNAME("ItemList"));
 			Color linecolor = color;
 			linecolor.a = 0.2;
 
@@ -2462,7 +2462,7 @@ Size2 AnimationTrackEdit::get_minimum_size() const {
 	Ref<Texture2D> texture = get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
 	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
 	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
-	int separation = get_theme_constant(SNAME("vseparation"), SNAME("ItemList"));
+	int separation = get_theme_constant(SNAME("v_separation"), SNAME("ItemList"));
 
 	int max_h = MAX(texture->get_height(), font->get_height(font_size));
 	max_h = MAX(max_h, get_key_height());
@@ -3201,13 +3201,13 @@ void AnimationTrackEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("timeline_changed", PropertyInfo(Variant::FLOAT, "position"), PropertyInfo(Variant::BOOL, "drag"), PropertyInfo(Variant::BOOL, "timeline_only")));
 	ADD_SIGNAL(MethodInfo("remove_request", PropertyInfo(Variant::INT, "track")));
 	ADD_SIGNAL(MethodInfo("dropped", PropertyInfo(Variant::INT, "from_track"), PropertyInfo(Variant::INT, "to_track")));
-	ADD_SIGNAL(MethodInfo("insert_key", PropertyInfo(Variant::FLOAT, "ofs")));
+	ADD_SIGNAL(MethodInfo("insert_key", PropertyInfo(Variant::FLOAT, "offset")));
 	ADD_SIGNAL(MethodInfo("select_key", PropertyInfo(Variant::INT, "index"), PropertyInfo(Variant::BOOL, "single")));
 	ADD_SIGNAL(MethodInfo("deselect_key", PropertyInfo(Variant::INT, "index")));
 	ADD_SIGNAL(MethodInfo("bezier_edit"));
 
 	ADD_SIGNAL(MethodInfo("move_selection_begin"));
-	ADD_SIGNAL(MethodInfo("move_selection", PropertyInfo(Variant::FLOAT, "ofs")));
+	ADD_SIGNAL(MethodInfo("move_selection", PropertyInfo(Variant::FLOAT, "offset")));
 	ADD_SIGNAL(MethodInfo("move_selection_commit"));
 	ADD_SIGNAL(MethodInfo("move_selection_cancel"));
 
@@ -3287,7 +3287,7 @@ void AnimationTrackEditGroup::_notification(int p_what) {
 		case NOTIFICATION_DRAW: {
 			Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
 			int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
-			int separation = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
+			int separation = get_theme_constant(SNAME("h_separation"), SNAME("ItemList"));
 			Color color = get_theme_color(SNAME("font_color"), SNAME("Label"));
 
 			if (root && root->has_node(node)) {
@@ -3333,7 +3333,7 @@ void AnimationTrackEditGroup::set_type_and_name(const Ref<Texture2D> &p_type, co
 Size2 AnimationTrackEditGroup::get_minimum_size() const {
 	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Label"));
 	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Label"));
-	int separation = get_theme_constant(SNAME("vseparation"), SNAME("ItemList"));
+	int separation = get_theme_constant(SNAME("v_separation"), SNAME("ItemList"));
 
 	return Vector2(0, MAX(font->get_height(font_size), icon->get_height()) + separation);
 }

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -99,7 +99,7 @@ ScrollContainer *EditorAbout::_populate_list(const String &p_name, const List<St
 			il->set_same_column_width(true);
 			il->set_auto_height(true);
 			il->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
-			il->add_theme_constant_override("hseparation", 16 * EDSCALE);
+			il->add_theme_constant_override("h_separation", 16 * EDSCALE);
 			while (*names_ptr) {
 				il->add_item(String::utf8(*names_ptr++), nullptr, false);
 			}

--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -56,8 +56,8 @@ void EditorHelp::_update_theme() {
 
 	class_desc->add_theme_color_override("selection_color", get_theme_color(SNAME("selection_color"), SNAME("EditorHelp")));
 	class_desc->add_theme_constant_override("line_separation", get_theme_constant(SNAME("line_separation"), SNAME("EditorHelp")));
-	class_desc->add_theme_constant_override("table_hseparation", get_theme_constant(SNAME("table_hseparation"), SNAME("EditorHelp")));
-	class_desc->add_theme_constant_override("table_vseparation", get_theme_constant(SNAME("table_vseparation"), SNAME("EditorHelp")));
+	class_desc->add_theme_constant_override("table_h_separation", get_theme_constant(SNAME("table_h_separation"), SNAME("EditorHelp")));
+	class_desc->add_theme_constant_override("table_v_separation", get_theme_constant(SNAME("table_v_separation"), SNAME("EditorHelp")));
 
 	doc_font = get_theme_font(SNAME("doc"), SNAME("EditorFonts"));
 	doc_bold_font = get_theme_font(SNAME("doc_bold"), SNAME("EditorFonts"));

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -96,11 +96,11 @@ Size2 EditorProperty::get_minimum_size() const {
 
 	if (checkable) {
 		Ref<Texture2D> check = get_theme_icon(SNAME("checked"), SNAME("CheckBox"));
-		ms.width += check->get_width() + get_theme_constant(SNAME("hseparation"), SNAME("CheckBox")) + get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
+		ms.width += check->get_width() + get_theme_constant(SNAME("h_separation"), SNAME("CheckBox")) + get_theme_constant(SNAME("hseparator"), SNAME("Tree"));
 	}
 
 	if (bottom_editor != nullptr && bottom_editor->is_visible()) {
-		ms.height += get_theme_constant(SNAME("vseparation"));
+		ms.height += get_theme_constant(SNAME("v_separation"));
 		Size2 bems = bottom_editor->get_combined_minimum_size();
 		//bems.width += get_constant("item_margin", "Tree");
 		ms.height += bems.height;
@@ -169,7 +169,7 @@ void EditorProperty::_notification(int p_what) {
 				if (bottom_editor) {
 					int m = 0; //get_constant("item_margin", "Tree");
 
-					bottom_rect = Rect2(m, rect.size.height + get_theme_constant(SNAME("vseparation")), size.width - m, bottom_editor->get_combined_minimum_size().height);
+					bottom_rect = Rect2(m, rect.size.height + get_theme_constant(SNAME("v_separation")), size.width - m, bottom_editor->get_combined_minimum_size().height);
 				}
 
 				if (keying) {
@@ -297,7 +297,7 @@ void EditorProperty::_notification(int p_what) {
 				} else {
 					draw_texture(checkbox, check_rect.position, color2);
 				}
-				int check_ofs = get_theme_constant(SNAME("hseparator"), SNAME("Tree")) + checkbox->get_width() + get_theme_constant(SNAME("hseparation"), SNAME("CheckBox"));
+				int check_ofs = get_theme_constant(SNAME("hseparator"), SNAME("Tree")) + checkbox->get_width() + get_theme_constant(SNAME("h_separation"), SNAME("CheckBox"));
 				ofs += check_ofs;
 				text_limit -= check_ofs;
 			} else {
@@ -1083,7 +1083,7 @@ void EditorInspectorCategory::_notification(int p_what) {
 			Ref<Font> font = get_theme_font(SNAME("bold"), SNAME("EditorFonts"));
 			int font_size = get_theme_font_size(SNAME("bold_size"), SNAME("EditorFonts"));
 
-			int hs = get_theme_constant(SNAME("hseparation"), SNAME("Tree"));
+			int hs = get_theme_constant(SNAME("h_separation"), SNAME("Tree"));
 
 			int w = font->get_string_size(label, font_size).width;
 			if (icon.is_valid()) {
@@ -1118,7 +1118,7 @@ Size2 EditorInspectorCategory::get_minimum_size() const {
 	if (icon.is_valid()) {
 		ms.height = MAX(icon->get_height(), ms.height);
 	}
-	ms.height += get_theme_constant(SNAME("vseparation"), SNAME("Tree"));
+	ms.height += get_theme_constant(SNAME("v_separation"), SNAME("Tree"));
 
 	return ms;
 }
@@ -1178,7 +1178,7 @@ void EditorInspectorSection::_notification(int p_what) {
 			if (arrow.is_valid()) {
 				header_height = MAX(header_height, arrow->get_height());
 			}
-			header_height += get_theme_constant(SNAME("vseparation"), SNAME("Tree"));
+			header_height += get_theme_constant(SNAME("v_separation"), SNAME("Tree"));
 
 			int inspector_margin = get_theme_constant(SNAME("inspector_margin"), SNAME("Editor"));
 			int section_indent_size = get_theme_constant(SNAME("indent_size"), SNAME("EditorInspectorSection"));
@@ -1231,7 +1231,7 @@ void EditorInspectorSection::_notification(int p_what) {
 			if (arrow.is_valid()) {
 				header_height = MAX(header_height, arrow->get_height());
 			}
-			header_height += get_theme_constant(SNAME("vseparation"), SNAME("Tree"));
+			header_height += get_theme_constant(SNAME("v_separation"), SNAME("Tree"));
 
 			int section_indent = 0;
 			int section_indent_size = get_theme_constant(SNAME("indent_size"), SNAME("EditorInspectorSection"));
@@ -1360,7 +1360,7 @@ Size2 EditorInspectorSection::get_minimum_size() const {
 
 	Ref<Font> font = get_theme_font(SNAME("font"), SNAME("Tree"));
 	int font_size = get_theme_font_size(SNAME("font_size"), SNAME("Tree"));
-	ms.height += font->get_height(font_size) + get_theme_constant(SNAME("vseparation"), SNAME("Tree"));
+	ms.height += font->get_height(font_size) + get_theme_constant(SNAME("v_separation"), SNAME("Tree"));
 	ms.width += get_theme_constant(SNAME("inspector_margin"), SNAME("Editor"));
 
 	int section_indent_size = get_theme_constant(SNAME("indent_size"), SNAME("EditorInspectorSection"));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -388,7 +388,7 @@ void EditorNode::_update_scene_tabs() {
 		}
 
 		Rect2 last_tab = scene_tabs->get_tab_rect(scene_tabs->get_tab_count() - 1);
-		int hsep = scene_tabs->get_theme_constant(SNAME("hseparation"));
+		int hsep = scene_tabs->get_theme_constant(SNAME("h_separation"));
 		if (scene_tabs->is_layout_rtl()) {
 			scene_tab_add->set_position(Point2(last_tab.position.x - scene_tab_add->get_size().x - hsep, last_tab.position.y));
 		} else {

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -3118,12 +3118,12 @@ void EditorPropertyResource::_update_property_bg() {
 		add_theme_style_override("bg", get_theme_stylebox("sub_inspector_property_bg" + itos(count_subinspectors), SNAME("Editor")));
 
 		add_theme_constant_override("font_offset", get_theme_constant(SNAME("sub_inspector_font_offset"), SNAME("Editor")));
-		add_theme_constant_override("vseparation", 0);
+		add_theme_constant_override("v_separation", 0);
 	} else {
 		add_theme_color_override("property_color", get_theme_color(SNAME("property_color"), SNAME("EditorProperty")));
 		add_theme_style_override("bg_selected", get_theme_stylebox(SNAME("bg_selected"), SNAME("EditorProperty")));
 		add_theme_style_override("bg", get_theme_stylebox(SNAME("bg"), SNAME("EditorProperty")));
-		add_theme_constant_override("vseparation", get_theme_constant(SNAME("vseparation"), SNAME("EditorProperty")));
+		add_theme_constant_override("v_separation", get_theme_constant(SNAME("v_separation"), SNAME("EditorProperty")));
 		add_theme_constant_override("font_offset", get_theme_constant(SNAME("font_offset"), SNAME("EditorProperty")));
 	}
 

--- a/editor/editor_property_name_processor.cpp
+++ b/editor/editor_property_name_processor.cpp
@@ -117,12 +117,9 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["bvh"] = "BVH";
 	capitalize_string_remaps["ca"] = "CA";
 	capitalize_string_remaps["cd"] = "CD";
-	capitalize_string_remaps["commentfocus"] = "Comment Focus";
 	capitalize_string_remaps["cpu"] = "CPU";
 	capitalize_string_remaps["csg"] = "CSG";
 	capitalize_string_remaps["db"] = "dB";
-	capitalize_string_remaps["defaultfocus"] = "Default Focus";
-	capitalize_string_remaps["defaultframe"] = "Default Frame";
 	capitalize_string_remaps["dof"] = "DoF";
 	capitalize_string_remaps["dpi"] = "DPI";
 	capitalize_string_remaps["dtls"] = "DTLS";
@@ -152,7 +149,6 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["hidpi"] = "hiDPI";
 	capitalize_string_remaps["hipass"] = "High-pass";
 	capitalize_string_remaps["hl"] = "HL";
-	capitalize_string_remaps["hseparation"] = "H Separation";
 	capitalize_string_remaps["hsv"] = "HSV";
 	capitalize_string_remaps["html"] = "HTML";
 	capitalize_string_remaps["http"] = "HTTP";
@@ -184,8 +180,6 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	//capitalize_string_remaps["msec"] = "(msec)"; // Unit.
 	capitalize_string_remaps["msaa"] = "MSAA";
 	capitalize_string_remaps["nfc"] = "NFC";
-	capitalize_string_remaps["normalmap"] = "Normal Map";
-	capitalize_string_remaps["ofs"] = "Offset";
 	capitalize_string_remaps["ok"] = "OK";
 	capitalize_string_remaps["opengl"] = "OpenGL";
 	capitalize_string_remaps["opentype"] = "OpenType";
@@ -204,7 +198,6 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["sdfgi"] = "SDFGI";
 	capitalize_string_remaps["sdk"] = "SDK";
 	capitalize_string_remaps["sec"] = "(sec)"; // Unit.
-	capitalize_string_remaps["selectedframe"] = "Selected Frame";
 	capitalize_string_remaps["sms"] = "SMS";
 	capitalize_string_remaps["srgb"] = "sRGB";
 	capitalize_string_remaps["ssao"] = "SSAO";
@@ -227,11 +220,9 @@ EditorPropertyNameProcessor::EditorPropertyNameProcessor() {
 	capitalize_string_remaps["uv1"] = "UV1";
 	capitalize_string_remaps["uv2"] = "UV2";
 	capitalize_string_remaps["uwp"] = "UWP";
-	capitalize_string_remaps["vadjust"] = "V Adjust";
 	capitalize_string_remaps["vector2"] = "Vector2";
 	capitalize_string_remaps["vpn"] = "VPN";
 	capitalize_string_remaps["vram"] = "VRAM";
-	capitalize_string_remaps["vseparation"] = "V Separation";
 	capitalize_string_remaps["vsync"] = "V-Sync";
 	capitalize_string_remaps["wap"] = "WAP";
 	capitalize_string_remaps["webp"] = "WebP";

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -88,7 +88,7 @@ void EditorResourcePicker::_update_resource_preview(const String &p_path, const 
 	}
 
 	if (p_preview.is_valid()) {
-		preview_rect->set_offset(SIDE_LEFT, assign_button->get_icon()->get_width() + assign_button->get_theme_stylebox(SNAME("normal"))->get_default_margin(SIDE_LEFT) + get_theme_constant(SNAME("hseparation"), SNAME("Button")));
+		preview_rect->set_offset(SIDE_LEFT, assign_button->get_icon()->get_width() + assign_button->get_theme_stylebox(SNAME("normal"))->get_default_margin(SIDE_LEFT) + get_theme_constant(SNAME("h_separation"), SNAME("Button")));
 
 		if (Ref<GradientTexture1D>(edited_resource).is_valid()) {
 			preview_rect->set_stretch_mode(TextureRect::STRETCH_SCALE);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -762,7 +762,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("arrow", "OptionButton", theme->get_icon(SNAME("GuiOptionArrow"), SNAME("EditorIcons")));
 	theme->set_constant("arrow_margin", "OptionButton", widget_default_margin.x - 2 * EDSCALE);
 	theme->set_constant("modulate_arrow", "OptionButton", true);
-	theme->set_constant("hseparation", "OptionButton", 4 * EDSCALE);
+	theme->set_constant("h_separation", "OptionButton", 4 * EDSCALE);
 
 	// CheckButton
 	theme->set_stylebox("normal", "CheckButton", style_menu);
@@ -788,8 +788,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("icon_hover_color", "CheckButton", icon_hover_color);
 	theme->set_color("icon_focus_color", "CheckButton", icon_focus_color);
 
-	theme->set_constant("hseparation", "CheckButton", 8 * EDSCALE);
-	theme->set_constant("check_vadjust", "CheckButton", 0 * EDSCALE);
+	theme->set_constant("h_separation", "CheckButton", 8 * EDSCALE);
+	theme->set_constant("check_v_adjust", "CheckButton", 0 * EDSCALE);
 
 	// Checkbox
 	Ref<StyleBoxFlat> sb_checkbox = style_menu->duplicate();
@@ -819,8 +819,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("icon_hover_color", "CheckBox", icon_hover_color);
 	theme->set_color("icon_focus_color", "CheckBox", icon_focus_color);
 
-	theme->set_constant("hseparation", "CheckBox", 8 * EDSCALE);
-	theme->set_constant("check_vadjust", "CheckBox", 0 * EDSCALE);
+	theme->set_constant("h_separation", "CheckBox", 8 * EDSCALE);
+	theme->set_constant("check_v_adjust", "CheckBox", 0 * EDSCALE);
 
 	// PopupDialog
 	theme->set_stylebox("panel", "PopupDialog", style_popup);
@@ -868,12 +868,12 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("visibility_visible", "PopupMenu", theme->get_icon(SNAME("GuiVisibilityVisible"), SNAME("EditorIcons")));
 	theme->set_icon("visibility_xray", "PopupMenu", theme->get_icon(SNAME("GuiVisibilityXray"), SNAME("EditorIcons")));
 
-	// Force the vseparation to be even so that the spacing on top and bottom is even.
+	// Force the v_separation to be even so that the spacing on top and bottom is even.
 	// If the vsep is odd and cannot be split into 2 even groups (of pixels), then it will be lopsided.
 	// We add 2 to the vsep to give it some extra spacing which looks a bit more modern (see Windows, for example)
 	int vsep_base = extra_spacing + default_margin_size + 2;
 	int force_even_vsep = vsep_base + (vsep_base % 2);
-	theme->set_constant("vseparation", "PopupMenu", force_even_vsep * EDSCALE);
+	theme->set_constant("v_separation", "PopupMenu", force_even_vsep * EDSCALE);
 	theme->set_constant("item_start_padding", "PopupMenu", popup_menu_margin_size * EDSCALE);
 	theme->set_constant("item_end_padding", "PopupMenu", popup_menu_margin_size * EDSCALE);
 
@@ -929,7 +929,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("font_offset", "EditorProperty", 8 * EDSCALE);
 	theme->set_stylebox("bg_selected", "EditorProperty", style_property_bg);
 	theme->set_stylebox("bg", "EditorProperty", Ref<StyleBoxEmpty>(memnew(StyleBoxEmpty)));
-	theme->set_constant("vseparation", "EditorProperty", (extra_spacing + default_margin_size) * EDSCALE);
+	theme->set_constant("v_separation", "EditorProperty", (extra_spacing + default_margin_size) * EDSCALE);
 	theme->set_color("warning_color", "EditorProperty", warning_color);
 	theme->set_color("property_color", "EditorProperty", property_color);
 	theme->set_color("readonly_color", "EditorProperty", readonly_color);
@@ -977,8 +977,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_selected_color", "Tree", mono_color);
 	theme->set_color("title_button_color", "Tree", font_color);
 	theme->set_color("drop_position_color", "Tree", accent_color);
-	theme->set_constant("vseparation", "Tree", widget_default_margin.y - EDSCALE);
-	theme->set_constant("hseparation", "Tree", 6 * EDSCALE);
+	theme->set_constant("v_separation", "Tree", widget_default_margin.y - EDSCALE);
+	theme->set_constant("h_separation", "Tree", 6 * EDSCALE);
 	theme->set_constant("guide_width", "Tree", border_width);
 	theme->set_constant("item_margin", "Tree", 3 * default_margin_size * EDSCALE);
 	theme->set_constant("button_margin", "Tree", default_margin_size * EDSCALE);
@@ -1068,8 +1068,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("font_color", "ItemList", font_color);
 	theme->set_color("font_selected_color", "ItemList", mono_color);
 	theme->set_color("guide_color", "ItemList", guide_color);
-	theme->set_constant("vseparation", "ItemList", widget_default_margin.y - EDSCALE);
-	theme->set_constant("hseparation", "ItemList", 6 * EDSCALE);
+	theme->set_constant("v_separation", "ItemList", widget_default_margin.y - EDSCALE);
+	theme->set_constant("h_separation", "ItemList", 6 * EDSCALE);
 	theme->set_constant("icon_margin", "ItemList", 6 * EDSCALE);
 	theme->set_constant("line_separation", "ItemList", 3 * EDSCALE);
 
@@ -1103,7 +1103,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("decrement_highlight", "TabContainer", theme->get_icon(SNAME("GuiScrollArrowLeftHl"), SNAME("EditorIcons")));
 	theme->set_icon("drop_mark", "TabContainer", theme->get_icon(SNAME("GuiTabDropMark"), SNAME("EditorIcons")));
 	theme->set_icon("drop_mark", "TabBar", theme->get_icon(SNAME("GuiTabDropMark"), SNAME("EditorIcons")));
-	theme->set_constant("hseparation", "TabBar", 4 * EDSCALE);
+	theme->set_constant("h_separation", "TabBar", 4 * EDSCALE);
 
 	// Content of each tab
 	Ref<StyleBoxFlat> style_content_panel = style_default->duplicate();
@@ -1234,14 +1234,14 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("margin_top", "MarginContainer", 0);
 	theme->set_constant("margin_right", "MarginContainer", 0);
 	theme->set_constant("margin_bottom", "MarginContainer", 0);
-	theme->set_constant("hseparation", "GridContainer", default_margin_size * EDSCALE);
-	theme->set_constant("vseparation", "GridContainer", default_margin_size * EDSCALE);
-	theme->set_constant("hseparation", "FlowContainer", default_margin_size * EDSCALE);
-	theme->set_constant("vseparation", "FlowContainer", default_margin_size * EDSCALE);
-	theme->set_constant("hseparation", "HFlowContainer", default_margin_size * EDSCALE);
-	theme->set_constant("vseparation", "HFlowContainer", default_margin_size * EDSCALE);
-	theme->set_constant("hseparation", "VFlowContainer", default_margin_size * EDSCALE);
-	theme->set_constant("vseparation", "VFlowContainer", default_margin_size * EDSCALE);
+	theme->set_constant("h_separation", "GridContainer", default_margin_size * EDSCALE);
+	theme->set_constant("v_separation", "GridContainer", default_margin_size * EDSCALE);
+	theme->set_constant("h_separation", "FlowContainer", default_margin_size * EDSCALE);
+	theme->set_constant("v_separation", "FlowContainer", default_margin_size * EDSCALE);
+	theme->set_constant("h_separation", "HFlowContainer", default_margin_size * EDSCALE);
+	theme->set_constant("v_separation", "HFlowContainer", default_margin_size * EDSCALE);
+	theme->set_constant("h_separation", "VFlowContainer", default_margin_size * EDSCALE);
+	theme->set_constant("v_separation", "VFlowContainer", default_margin_size * EDSCALE);
 
 	// Window
 
@@ -1261,8 +1261,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("title_color", "Window", font_color);
 	theme->set_icon("close", "Window", theme->get_icon(SNAME("GuiClose"), SNAME("EditorIcons")));
 	theme->set_icon("close_pressed", "Window", theme->get_icon(SNAME("GuiClose"), SNAME("EditorIcons")));
-	theme->set_constant("close_h_ofs", "Window", 22 * EDSCALE);
-	theme->set_constant("close_v_ofs", "Window", 20 * EDSCALE);
+	theme->set_constant("close_h_offset", "Window", 22 * EDSCALE);
+	theme->set_constant("close_v_offset", "Window", 20 * EDSCALE);
 	theme->set_constant("title_height", "Window", 24 * EDSCALE);
 	theme->set_constant("resize_margin", "Window", 4 * EDSCALE);
 	theme->set_font("title_font", "Window", theme->get_font(SNAME("title"), SNAME("EditorFonts")));
@@ -1346,8 +1346,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("code_color", "EditorHelp", accent_color.lerp(mono_color, 0.6));
 	theme->set_color("kbd_color", "EditorHelp", accent_color.lerp(property_color, 0.6));
 	theme->set_constant("line_separation", "EditorHelp", Math::round(6 * EDSCALE));
-	theme->set_constant("table_hseparation", "EditorHelp", 16 * EDSCALE);
-	theme->set_constant("table_vseparation", "EditorHelp", 6 * EDSCALE);
+	theme->set_constant("table_h_separation", "EditorHelp", 16 * EDSCALE);
+	theme->set_constant("table_v_separation", "EditorHelp", 6 * EDSCALE);
 
 	// Panel
 	theme->set_stylebox("panel", "Panel", make_flat_stylebox(dark_color_1, 6, 4, 6, 4, corner_width));
@@ -1486,13 +1486,13 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	graphsbcommentselected->set_border_width(SIDE_TOP, 24 * EDSCALE);
 
 	theme->set_stylebox("frame", "GraphNode", graphsb);
-	theme->set_stylebox("selectedframe", "GraphNode", graphsbselected);
+	theme->set_stylebox("selected_frame", "GraphNode", graphsbselected);
 	theme->set_stylebox("comment", "GraphNode", graphsbcomment);
-	theme->set_stylebox("commentfocus", "GraphNode", graphsbcommentselected);
+	theme->set_stylebox("comment_focus", "GraphNode", graphsbcommentselected);
 	theme->set_stylebox("breakpoint", "GraphNode", graphsbbreakpoint);
 	theme->set_stylebox("position", "GraphNode", graphsbposition);
 	theme->set_stylebox("state_machine_frame", "GraphNode", smgraphsb);
-	theme->set_stylebox("state_machine_selectedframe", "GraphNode", smgraphsbselected);
+	theme->set_stylebox("state_machine_selected_frame", "GraphNode", smgraphsbselected);
 
 	Color default_node_color = dark_color_1.inverted();
 	theme->set_color("title_color", "GraphNode", default_node_color);
@@ -1512,7 +1512,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_icon("port", "GraphNode", theme->get_icon(SNAME("GuiGraphNodePort"), SNAME("EditorIcons")));
 
 	// GridContainer
-	theme->set_constant("vseparation", "GridContainer", Math::round(widget_default_margin.y - 2 * EDSCALE));
+	theme->set_constant("v_separation", "GridContainer", Math::round(widget_default_margin.y - 2 * EDSCALE));
 
 	// FileDialog
 	theme->set_icon("folder", "FileDialog", theme->get_icon(SNAME("Folder"), SNAME("EditorIcons")));

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -1577,7 +1577,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	}
 	glyph_table->add_theme_style_override("selected", glyph_table->get_theme_stylebox(SNAME("bg")));
 	glyph_table->add_theme_style_override("selected_focus", glyph_table->get_theme_stylebox(SNAME("bg")));
-	glyph_table->add_theme_constant_override("hseparation", 0);
+	glyph_table->add_theme_constant_override("h_separation", 0);
 	glyph_table->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	glyph_table->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -558,7 +558,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 	Ref<AnimationNodeStateMachinePlayback> playback = AnimationTreeEditor::get_singleton()->get_tree()->get(AnimationTreeEditor::get_singleton()->get_base_path() + "playback");
 
 	Ref<StyleBox> style = get_theme_stylebox(SNAME("state_machine_frame"), SNAME("GraphNode"));
-	Ref<StyleBox> style_selected = get_theme_stylebox(SNAME("state_machine_selectedframe"), SNAME("GraphNode"));
+	Ref<StyleBox> style_selected = get_theme_stylebox(SNAME("state_machine_selected_frame"), SNAME("GraphNode"));
 
 	Ref<Font> font = get_theme_font(SNAME("title_font"), SNAME("GraphNode"));
 	int font_size = get_theme_font_size(SNAME("title_font_size"), SNAME("GraphNode"));

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1190,8 +1190,8 @@ void EditorAssetLibrary::_http_request_completed(int p_status, int p_code, const
 
 			asset_items = memnew(GridContainer);
 			asset_items->set_columns(2);
-			asset_items->add_theme_constant_override("hseparation", 10 * EDSCALE);
-			asset_items->add_theme_constant_override("vseparation", 10 * EDSCALE);
+			asset_items->add_theme_constant_override("h_separation", 10 * EDSCALE);
+			asset_items->add_theme_constant_override("v_separation", 10 * EDSCALE);
 
 			library_vb->add_child(asset_items);
 
@@ -1502,8 +1502,8 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	asset_items = memnew(GridContainer);
 	asset_items->set_columns(2);
-	asset_items->add_theme_constant_override("hseparation", 10 * EDSCALE);
-	asset_items->add_theme_constant_override("vseparation", 10 * EDSCALE);
+	asset_items->add_theme_constant_override("h_separation", 10 * EDSCALE);
+	asset_items->add_theme_constant_override("v_separation", 10 * EDSCALE);
 
 	library_vb->add_child(asset_items);
 

--- a/editor/plugins/debugger_editor_plugin.cpp
+++ b/editor/plugins/debugger_editor_plugin.cpp
@@ -55,7 +55,7 @@ DebuggerEditorPlugin::DebuggerEditorPlugin(MenuButton *p_debug_menu) {
 	EditorDebuggerNode *debugger = memnew(EditorDebuggerNode);
 	Button *db = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Debugger"), debugger);
 	// Add separation for the warning/error icon that is displayed later.
-	db->add_theme_constant_override("hseparation", 6 * EDSCALE);
+	db->add_theme_constant_override("h_separation", 6 * EDSCALE);
 	debugger->set_tool_button(db);
 
 	// Main editor debug menu.

--- a/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
+++ b/editor/plugins/tiles/tile_set_atlas_source_editor.cpp
@@ -610,8 +610,8 @@ void TileSetAtlasSourceEditor::_update_tile_data_editors() {
 	}
 
 	// Theming.
-	tile_data_editors_tree->add_theme_constant_override("vseparation", 1);
-	tile_data_editors_tree->add_theme_constant_override("hseparation", 3);
+	tile_data_editors_tree->add_theme_constant_override("v_separation", 1);
+	tile_data_editors_tree->add_theme_constant_override("h_separation", 3);
 
 	Color group_color = get_theme_color(SNAME("prop_category"), SNAME("Editor"));
 

--- a/modules/visual_script/doc_classes/VisualScript.xml
+++ b/modules/visual_script/doc_classes/VisualScript.xml
@@ -316,7 +316,7 @@
 		</method>
 		<method name="set_scroll">
 			<return type="void" />
-			<argument index="0" name="ofs" type="Vector2" />
+			<argument index="0" name="offset" type="Vector2" />
 			<description>
 				Set the screen center to the given position.
 			</description>

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -1118,7 +1118,7 @@ void VisualScript::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("has_function", "name"), &VisualScript::has_function);
 	ClassDB::bind_method(D_METHOD("remove_function", "name"), &VisualScript::remove_function);
 	ClassDB::bind_method(D_METHOD("rename_function", "name", "new_name"), &VisualScript::rename_function);
-	ClassDB::bind_method(D_METHOD("set_scroll", "ofs"), &VisualScript::set_scroll);
+	ClassDB::bind_method(D_METHOD("set_scroll", "offset"), &VisualScript::set_scroll);
 	ClassDB::bind_method(D_METHOD("get_scroll"), &VisualScript::get_scroll);
 
 	ClassDB::bind_method(D_METHOD("add_node", "id", "node", "position"), &VisualScript::add_node, DEFVAL(Point2()));

--- a/scene/2d/parallax_background.cpp
+++ b/scene/2d/parallax_background.cpp
@@ -163,15 +163,15 @@ Vector2 ParallaxBackground::get_final_offset() const {
 
 void ParallaxBackground::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_camera_moved"), &ParallaxBackground::_camera_moved);
-	ClassDB::bind_method(D_METHOD("set_scroll_offset", "ofs"), &ParallaxBackground::set_scroll_offset);
+	ClassDB::bind_method(D_METHOD("set_scroll_offset", "offset"), &ParallaxBackground::set_scroll_offset);
 	ClassDB::bind_method(D_METHOD("get_scroll_offset"), &ParallaxBackground::get_scroll_offset);
-	ClassDB::bind_method(D_METHOD("set_scroll_base_offset", "ofs"), &ParallaxBackground::set_scroll_base_offset);
+	ClassDB::bind_method(D_METHOD("set_scroll_base_offset", "offset"), &ParallaxBackground::set_scroll_base_offset);
 	ClassDB::bind_method(D_METHOD("get_scroll_base_offset"), &ParallaxBackground::get_scroll_base_offset);
 	ClassDB::bind_method(D_METHOD("set_scroll_base_scale", "scale"), &ParallaxBackground::set_scroll_base_scale);
 	ClassDB::bind_method(D_METHOD("get_scroll_base_scale"), &ParallaxBackground::get_scroll_base_scale);
-	ClassDB::bind_method(D_METHOD("set_limit_begin", "ofs"), &ParallaxBackground::set_limit_begin);
+	ClassDB::bind_method(D_METHOD("set_limit_begin", "offset"), &ParallaxBackground::set_limit_begin);
 	ClassDB::bind_method(D_METHOD("get_limit_begin"), &ParallaxBackground::get_limit_begin);
-	ClassDB::bind_method(D_METHOD("set_limit_end", "ofs"), &ParallaxBackground::set_limit_end);
+	ClassDB::bind_method(D_METHOD("set_limit_end", "offset"), &ParallaxBackground::set_limit_end);
 	ClassDB::bind_method(D_METHOD("get_limit_end"), &ParallaxBackground::get_limit_end);
 	ClassDB::bind_method(D_METHOD("set_ignore_camera_zoom", "ignore"), &ParallaxBackground::set_ignore_camera_zoom);
 	ClassDB::bind_method(D_METHOD("is_ignore_camera_zoom"), &ParallaxBackground::is_ignore_camera_zoom);

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -475,9 +475,9 @@ void Camera3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_near", "near"), &Camera3D::set_near);
 	ClassDB::bind_method(D_METHOD("get_projection"), &Camera3D::get_projection);
 	ClassDB::bind_method(D_METHOD("set_projection", "mode"), &Camera3D::set_projection);
-	ClassDB::bind_method(D_METHOD("set_h_offset", "ofs"), &Camera3D::set_h_offset);
+	ClassDB::bind_method(D_METHOD("set_h_offset", "offset"), &Camera3D::set_h_offset);
 	ClassDB::bind_method(D_METHOD("get_h_offset"), &Camera3D::get_h_offset);
-	ClassDB::bind_method(D_METHOD("set_v_offset", "ofs"), &Camera3D::set_v_offset);
+	ClassDB::bind_method(D_METHOD("set_v_offset", "offset"), &Camera3D::set_v_offset);
 	ClassDB::bind_method(D_METHOD("get_v_offset"), &Camera3D::get_v_offset);
 	ClassDB::bind_method(D_METHOD("set_cull_mask", "mask"), &Camera3D::set_cull_mask);
 	ClassDB::bind_method(D_METHOD("get_cull_mask"), &Camera3D::get_cull_mask);

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -53,7 +53,7 @@ Size2 Button::get_minimum_size() const {
 			if (icon_alignment != HORIZONTAL_ALIGNMENT_CENTER) {
 				minsize.width += _icon->get_width();
 				if (!xl_text.is_empty()) {
-					minsize.width += get_theme_constant(SNAME("hseparation"));
+					minsize.width += get_theme_constant(SNAME("h_separation"));
 				}
 			} else {
 				minsize.width = MAX(minsize.width, _icon->get_width());
@@ -244,21 +244,21 @@ void Button::_notification(int p_what) {
 				if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_LEFT) {
 					style_offset.x = style->get_margin(SIDE_LEFT);
 					if (_internal_margin[SIDE_LEFT] > 0) {
-						icon_ofs_region = _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("hseparation"));
+						icon_ofs_region = _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("h_separation"));
 					}
 				} else if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_CENTER) {
 					style_offset.x = 0.0;
 				} else if (icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_RIGHT) {
 					style_offset.x = -style->get_margin(SIDE_RIGHT);
 					if (_internal_margin[SIDE_RIGHT] > 0) {
-						icon_ofs_region = -_internal_margin[SIDE_RIGHT] - get_theme_constant(SNAME("hseparation"));
+						icon_ofs_region = -_internal_margin[SIDE_RIGHT] - get_theme_constant(SNAME("h_separation"));
 					}
 				}
 				style_offset.y = style->get_margin(SIDE_TOP);
 
 				if (expand_icon) {
 					Size2 _size = get_size() - style->get_offset() * 2;
-					_size.width -= get_theme_constant(SNAME("hseparation")) + icon_ofs_region;
+					_size.width -= get_theme_constant(SNAME("h_separation")) + icon_ofs_region;
 					if (!clip_text && icon_align_rtl_checked != HORIZONTAL_ALIGNMENT_CENTER) {
 						_size.width -= text_buf->get_size().width;
 					}
@@ -286,7 +286,7 @@ void Button::_notification(int p_what) {
 				}
 			}
 
-			Point2 icon_ofs = !_icon.is_null() ? Point2(icon_region.size.width + get_theme_constant(SNAME("hseparation")), 0) : Point2();
+			Point2 icon_ofs = !_icon.is_null() ? Point2(icon_region.size.width + get_theme_constant(SNAME("h_separation")), 0) : Point2();
 			if (align_rtl_checked == HORIZONTAL_ALIGNMENT_CENTER && icon_align_rtl_checked == HORIZONTAL_ALIGNMENT_CENTER) {
 				icon_ofs.x = 0.0;
 			}
@@ -296,10 +296,10 @@ void Button::_notification(int p_what) {
 			int text_width = MAX(1, clip_text ? MIN(text_clip, text_buf->get_size().x) : text_buf->get_size().x);
 
 			if (_internal_margin[SIDE_LEFT] > 0) {
-				text_clip -= _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("hseparation"));
+				text_clip -= _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("h_separation"));
 			}
 			if (_internal_margin[SIDE_RIGHT] > 0) {
-				text_clip -= _internal_margin[SIDE_RIGHT] + get_theme_constant(SNAME("hseparation"));
+				text_clip -= _internal_margin[SIDE_RIGHT] + get_theme_constant(SNAME("h_separation"));
 			}
 
 			Point2 text_ofs = (size - style->get_minimum_size() - icon_ofs - text_buf->get_size() - Point2(_internal_margin[SIDE_RIGHT] - _internal_margin[SIDE_LEFT], 0)) / 2.0;
@@ -313,7 +313,7 @@ void Button::_notification(int p_what) {
 						icon_ofs.x = 0.0;
 					}
 					if (_internal_margin[SIDE_LEFT] > 0) {
-						text_ofs.x = style->get_margin(SIDE_LEFT) + icon_ofs.x + _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("hseparation"));
+						text_ofs.x = style->get_margin(SIDE_LEFT) + icon_ofs.x + _internal_margin[SIDE_LEFT] + get_theme_constant(SNAME("h_separation"));
 					} else {
 						text_ofs.x = style->get_margin(SIDE_LEFT) + icon_ofs.x;
 					}
@@ -330,7 +330,7 @@ void Button::_notification(int p_what) {
 				} break;
 				case HORIZONTAL_ALIGNMENT_RIGHT: {
 					if (_internal_margin[SIDE_RIGHT] > 0) {
-						text_ofs.x = size.x - style->get_margin(SIDE_RIGHT) - text_width - _internal_margin[SIDE_RIGHT] - get_theme_constant(SNAME("hseparation"));
+						text_ofs.x = size.x - style->get_margin(SIDE_RIGHT) - text_width - _internal_margin[SIDE_RIGHT] - get_theme_constant(SNAME("h_separation"));
 					} else {
 						text_ofs.x = size.x - style->get_margin(SIDE_RIGHT) - text_width;
 					}

--- a/scene/gui/check_box.cpp
+++ b/scene/gui/check_box.cpp
@@ -75,7 +75,7 @@ Size2 CheckBox::get_minimum_size() const {
 	Size2 tex_size = get_icon_size();
 	minsize.width += tex_size.width;
 	if (get_text().length() > 0) {
-		minsize.width += get_theme_constant(SNAME("hseparation"));
+		minsize.width += get_theme_constant(SNAME("h_separation"));
 	}
 	Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
 	minsize.height = MAX(minsize.height, tex_size.height + sb->get_margin(SIDE_TOP) + sb->get_margin(SIDE_BOTTOM));
@@ -110,7 +110,7 @@ void CheckBox::_notification(int p_what) {
 			} else {
 				ofs.x = sb->get_margin(SIDE_LEFT);
 			}
-			ofs.y = int((get_size().height - get_icon_size().height) / 2) + get_theme_constant(SNAME("check_vadjust"));
+			ofs.y = int((get_size().height - get_icon_size().height) / 2) + get_theme_constant(SNAME("check_v_adjust"));
 
 			if (is_pressed()) {
 				on->draw(ci, ofs);

--- a/scene/gui/check_button.cpp
+++ b/scene/gui/check_button.cpp
@@ -52,7 +52,7 @@ Size2 CheckButton::get_minimum_size() const {
 	Size2 tex_size = get_icon_size();
 	minsize.width += tex_size.width;
 	if (get_text().length() > 0) {
-		minsize.width += get_theme_constant(SNAME("hseparation"));
+		minsize.width += get_theme_constant(SNAME("h_separation"));
 	}
 	Ref<StyleBox> sb = get_theme_stylebox(SNAME("normal"));
 	minsize.height = MAX(minsize.height, tex_size.height + sb->get_margin(SIDE_TOP) + sb->get_margin(SIDE_BOTTOM));
@@ -100,7 +100,7 @@ void CheckButton::_notification(int p_what) {
 			} else {
 				ofs.x = get_size().width - (tex_size.width + sb->get_margin(SIDE_RIGHT));
 			}
-			ofs.y = (get_size().height - tex_size.height) / 2 + get_theme_constant(SNAME("check_vadjust"));
+			ofs.y = (get_size().height - tex_size.height) / 2 + get_theme_constant(SNAME("check_v_adjust"));
 
 			if (is_pressed()) {
 				on->draw(ci, ofs);

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -106,7 +106,7 @@ void CodeEdit::_notification(int p_what) {
 
 				const int code_completion_options_count = code_completion_options.size();
 				const int lines = MIN(code_completion_options_count, code_completion_max_lines);
-				const int icon_hsep = get_theme_constant(SNAME("hseparation"), SNAME("ItemList"));
+				const int icon_hsep = get_theme_constant(SNAME("h_separation"), SNAME("ItemList"));
 				const Size2 icon_area_size(row_height, row_height);
 
 				code_completion_rect.size.width = code_completion_longest_line + icon_hsep + icon_area_size.width + 2;

--- a/scene/gui/color_picker.cpp
+++ b/scene/gui/color_picker.cpp
@@ -436,7 +436,7 @@ ColorPicker::PickerShapeType ColorPicker::get_picker_shape() const {
 }
 
 inline int ColorPicker::_get_preset_size() {
-	return (int(get_minimum_size().width) - (preset_container->get_theme_constant(SNAME("hseparation")) * (preset_column_count - 1))) / preset_column_count;
+	return (int(get_minimum_size().width) - (preset_container->get_theme_constant(SNAME("h_separation")) * (preset_column_count - 1))) / preset_column_count;
 }
 
 void ColorPicker::_add_preset_button(int p_size, const Color &p_color) {

--- a/scene/gui/flow_container.cpp
+++ b/scene/gui/flow_container.cpp
@@ -44,8 +44,8 @@ void FlowContainer::_resort() {
 		return;
 	}
 
-	int separation_horizontal = get_theme_constant(SNAME("hseparation"));
-	int separation_vertical = get_theme_constant(SNAME("vseparation"));
+	int separation_horizontal = get_theme_constant(SNAME("h_separation"));
+	int separation_vertical = get_theme_constant(SNAME("v_separation"));
 
 	bool rtl = is_layout_rtl();
 

--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -981,7 +981,7 @@ void GraphEdit::_minimap_draw() {
 		Ref<StyleBoxFlat> sb_minimap = minimap->get_theme_stylebox(SNAME("node"))->duplicate();
 
 		// Override default values with colors provided by the GraphNode's stylebox, if possible.
-		Ref<StyleBoxFlat> sbf = gn->get_theme_stylebox(gn->is_selected() ? "commentfocus" : "comment");
+		Ref<StyleBoxFlat> sbf = gn->get_theme_stylebox(gn->is_selected() ? "comment_focus" : "comment");
 		if (sbf.is_valid()) {
 			Color node_color = sbf->get_bg_color();
 			sb_minimap->set_bg_color(node_color);
@@ -1004,7 +1004,7 @@ void GraphEdit::_minimap_draw() {
 		Ref<StyleBoxFlat> sb_minimap = minimap->get_theme_stylebox(SNAME("node"))->duplicate();
 
 		// Override default values with colors provided by the GraphNode's stylebox, if possible.
-		Ref<StyleBoxFlat> sbf = gn->get_theme_stylebox(gn->is_selected() ? "selectedframe" : "frame");
+		Ref<StyleBoxFlat> sbf = gn->get_theme_stylebox(gn->is_selected() ? "selected_frame" : "frame");
 		if (sbf.is_valid()) {
 			Color node_color = sbf->get_border_color();
 			sb_minimap->set_bg_color(node_color);
@@ -2194,7 +2194,7 @@ void GraphEdit::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clear_connections"), &GraphEdit::clear_connections);
 	ClassDB::bind_method(D_METHOD("force_connection_drag_end"), &GraphEdit::force_connection_drag_end);
 	ClassDB::bind_method(D_METHOD("get_scroll_ofs"), &GraphEdit::get_scroll_ofs);
-	ClassDB::bind_method(D_METHOD("set_scroll_ofs", "ofs"), &GraphEdit::set_scroll_ofs);
+	ClassDB::bind_method(D_METHOD("set_scroll_ofs", "offset"), &GraphEdit::set_scroll_ofs);
 
 	ClassDB::bind_method(D_METHOD("add_valid_right_disconnect_type", "type"), &GraphEdit::add_valid_right_disconnect_type);
 	ClassDB::bind_method(D_METHOD("remove_valid_right_disconnect_type", "type"), &GraphEdit::remove_valid_right_disconnect_type);
@@ -2293,7 +2293,7 @@ void GraphEdit::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("delete_nodes_request"));
 	ADD_SIGNAL(MethodInfo("begin_node_move"));
 	ADD_SIGNAL(MethodInfo("end_node_move"));
-	ADD_SIGNAL(MethodInfo("scroll_offset_changed", PropertyInfo(Variant::VECTOR2, "ofs")));
+	ADD_SIGNAL(MethodInfo("scroll_offset_changed", PropertyInfo(Variant::VECTOR2, "offset")));
 	ADD_SIGNAL(MethodInfo("connection_drag_started", PropertyInfo(Variant::STRING, "from"), PropertyInfo(Variant::STRING, "slot"), PropertyInfo(Variant::BOOL, "is_output")));
 	ADD_SIGNAL(MethodInfo("connection_drag_ended"));
 

--- a/scene/gui/graph_node.cpp
+++ b/scene/gui/graph_node.cpp
@@ -351,10 +351,10 @@ void GraphNode::_notification(int p_what) {
 			Ref<StyleBox> sb;
 
 			if (comment) {
-				sb = get_theme_stylebox(selected ? "commentfocus" : "comment");
+				sb = get_theme_stylebox(selected ? "comment_focus" : "comment");
 
 			} else {
-				sb = get_theme_stylebox(selected ? "selectedframe" : "frame");
+				sb = get_theme_stylebox(selected ? "selected_frame" : "frame");
 			}
 
 			//sb=sb->duplicate();

--- a/scene/gui/grid_container.cpp
+++ b/scene/gui/grid_container.cpp
@@ -38,8 +38,8 @@ void GridContainer::_notification(int p_what) {
 			Set<int> col_expanded; // Columns which have the SIZE_EXPAND flag set.
 			Set<int> row_expanded; // Rows which have the SIZE_EXPAND flag set.
 
-			int hsep = get_theme_constant(SNAME("hseparation"));
-			int vsep = get_theme_constant(SNAME("vseparation"));
+			int hsep = get_theme_constant(SNAME("h_separation"));
+			int vsep = get_theme_constant(SNAME("v_separation"));
 			int max_col = MIN(get_child_count(), columns);
 			int max_row = ceil((float)get_child_count() / (float)columns);
 
@@ -217,8 +217,8 @@ Size2 GridContainer::get_minimum_size() const {
 	Map<int, int> col_minw;
 	Map<int, int> row_minh;
 
-	int hsep = get_theme_constant(SNAME("hseparation"));
-	int vsep = get_theme_constant(SNAME("vseparation"));
+	int hsep = get_theme_constant(SNAME("h_separation"));
+	int vsep = get_theme_constant(SNAME("v_separation"));
 
 	int max_row = 0;
 	int max_col = 0;

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -937,8 +937,8 @@ void ItemList::_notification(int p_what) {
 
 			draw_style_box(bg, Rect2(Point2(), size));
 
-			int hseparation = get_theme_constant(SNAME("hseparation"));
-			int vseparation = get_theme_constant(SNAME("vseparation"));
+			int hseparation = get_theme_constant(SNAME("h_separation"));
+			int vseparation = get_theme_constant(SNAME("v_separation"));
 			int icon_margin = get_theme_constant(SNAME("icon_margin"));
 			int line_separation = get_theme_constant(SNAME("line_separation"));
 			Color font_outline_color = get_theme_color(SNAME("font_outline_color"));

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -42,7 +42,7 @@ Size2 OptionButton::get_minimum_size() const {
 		const Size2 arrow_size = Control::get_theme_icon(SNAME("arrow"))->get_size();
 
 		Size2 content_size = minsize - padding;
-		content_size.width += arrow_size.width + get_theme_constant(SNAME("hseparation"));
+		content_size.width += arrow_size.width + get_theme_constant(SNAME("h_separation"));
 		content_size.height = MAX(content_size.height, arrow_size.height);
 
 		minsize = content_size + padding;

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -47,8 +47,8 @@ String PopupMenu::_get_accel_text(const Item &p_item) const {
 }
 
 Size2 PopupMenu::_get_contents_minimum_size() const {
-	int vseparation = get_theme_constant(SNAME("vseparation"));
-	int hseparation = get_theme_constant(SNAME("hseparation"));
+	int vseparation = get_theme_constant(SNAME("v_separation"));
+	int hseparation = get_theme_constant(SNAME("h_separation"));
 
 	Size2 minsize = get_theme_stylebox(SNAME("panel"))->get_minimum_size(); // Accounts for margin in the margin container
 	minsize.x += scroll_container->get_v_scroll_bar()->get_size().width * 2; // Adds a buffer so that the scrollbar does not render over the top of content
@@ -129,7 +129,7 @@ int PopupMenu::_get_item_height(int p_item) const {
 }
 
 int PopupMenu::_get_items_total_height() const {
-	int vsep = get_theme_constant(SNAME("vseparation"));
+	int vsep = get_theme_constant(SNAME("v_separation"));
 
 	// Get total height of all items by taking max of icon height and font height
 	int items_total_height = 0;
@@ -148,7 +148,7 @@ int PopupMenu::_get_mouse_over(const Point2 &p_over) const {
 
 	Ref<StyleBox> style = get_theme_stylebox(SNAME("panel")); // Accounts for margin in the margin container
 
-	int vseparation = get_theme_constant(SNAME("vseparation"));
+	int vseparation = get_theme_constant(SNAME("v_separation"));
 
 	Point2 ofs = style->get_offset() + Point2(0, vseparation / 2);
 
@@ -179,7 +179,7 @@ void PopupMenu::_activate_submenu(int p_over, bool p_by_keyboard) {
 	}
 
 	Ref<StyleBox> style = get_theme_stylebox(SNAME("panel"));
-	int vsep = get_theme_constant(SNAME("vseparation"));
+	int vsep = get_theme_constant(SNAME("v_separation"));
 
 	Point2 this_pos = get_position();
 	Rect2 this_rect(this_pos, get_size());
@@ -504,8 +504,8 @@ void PopupMenu::_draw_items() {
 	Ref<StyleBox> labeled_separator_left = get_theme_stylebox(SNAME("labeled_separator_left"));
 	Ref<StyleBox> labeled_separator_right = get_theme_stylebox(SNAME("labeled_separator_right"));
 
-	int vseparation = get_theme_constant(SNAME("vseparation"));
-	int hseparation = get_theme_constant(SNAME("hseparation"));
+	int vseparation = get_theme_constant(SNAME("v_separation"));
+	int hseparation = get_theme_constant(SNAME("h_separation"));
 	Color font_color = get_theme_color(SNAME("font_color"));
 	Color font_disabled_color = get_theme_color(SNAME("font_disabled_color"));
 	Color font_accelerator_color = get_theme_color(SNAME("font_accelerator_color"));

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -270,8 +270,8 @@ void RichTextLabel::_resize_line(ItemFrame *p_frame, int p_line, const Ref<Font>
 		switch (it->type) {
 			case ITEM_TABLE: {
 				ItemTable *table = static_cast<ItemTable *>(it);
-				int hseparation = get_theme_constant(SNAME("table_hseparation"));
-				int vseparation = get_theme_constant(SNAME("table_vseparation"));
+				int hseparation = get_theme_constant(SNAME("table_h_separation"));
+				int vseparation = get_theme_constant(SNAME("table_v_separation"));
 				int col_count = table->columns.size();
 
 				for (int i = 0; i < col_count; i++) {
@@ -518,8 +518,8 @@ void RichTextLabel::_shape_line(ItemFrame *p_frame, int p_line, const Ref<Font> 
 			} break;
 			case ITEM_TABLE: {
 				ItemTable *table = static_cast<ItemTable *>(it);
-				int hseparation = get_theme_constant(SNAME("table_hseparation"));
-				int vseparation = get_theme_constant(SNAME("table_vseparation"));
+				int hseparation = get_theme_constant(SNAME("table_h_separation"));
+				int vseparation = get_theme_constant(SNAME("table_v_separation"));
 				int col_count = table->columns.size();
 				int t_char_count = 0;
 				// Set minimums to zero.
@@ -853,7 +853,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 						Color odd_row_bg = get_theme_color(SNAME("table_odd_row_bg"));
 						Color even_row_bg = get_theme_color(SNAME("table_even_row_bg"));
 						Color border = get_theme_color(SNAME("table_border"));
-						int hseparation = get_theme_constant(SNAME("table_hseparation"));
+						int hseparation = get_theme_constant(SNAME("table_h_separation"));
 						int col_count = table->columns.size();
 						int row_count = table->rows.size();
 
@@ -1390,8 +1390,8 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 				if (p_click.y >= rect.position.y && p_click.y <= rect.position.y + rect.size.y) {
 					switch (it->type) {
 						case ITEM_TABLE: {
-							int hseparation = get_theme_constant(SNAME("table_hseparation"));
-							int vseparation = get_theme_constant(SNAME("table_vseparation"));
+							int hseparation = get_theme_constant(SNAME("table_h_separation"));
+							int vseparation = get_theme_constant(SNAME("table_v_separation"));
 
 							ItemTable *table = static_cast<ItemTable *>(it);
 
@@ -1449,7 +1449,7 @@ float RichTextLabel::_find_click_in_line(ItemFrame *p_frame, int p_line, const V
 		}
 		Rect2 rect = Rect2(p_ofs + off - Vector2(0, TS->shaped_text_get_ascent(rid)) - p_frame->padding.position, TS->shaped_text_get_size(rid) + p_frame->padding.position + p_frame->padding.size);
 		if (p_table) {
-			rect.size.y += get_theme_constant(SNAME("table_vseparation"));
+			rect.size.y += get_theme_constant(SNAME("table_v_separation"));
 		}
 
 		if (p_click.y >= rect.position.y && p_click.y <= rect.position.y + rect.size.y) {

--- a/scene/gui/tab_bar.cpp
+++ b/scene/gui/tab_bar.cpp
@@ -49,7 +49,7 @@ Size2 TabBar::get_minimum_size() const {
 	Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
 	Ref<StyleBox> button_highlight = get_theme_stylebox(SNAME("button_highlight"));
 	Ref<Texture2D> close = get_theme_icon(SNAME("close"));
-	int hseparation = get_theme_constant(SNAME("hseparation"));
+	int hseparation = get_theme_constant(SNAME("h_separation"));
 
 	int y_margin = MAX(MAX(tab_unselected->get_minimum_size().height, tab_selected->get_minimum_size().height), tab_disabled->get_minimum_size().height);
 
@@ -477,7 +477,7 @@ void TabBar::_draw_tab(Ref<StyleBox> &p_tab_style, Color &p_font_color, int p_in
 
 	Color font_outline_color = get_theme_color(SNAME("font_outline_color"));
 	int outline_size = get_theme_constant(SNAME("outline_size"));
-	int hseparation = get_theme_constant(SNAME("hseparation"));
+	int hseparation = get_theme_constant(SNAME("h_separation"));
 
 	Rect2 sb_rect = Rect2(p_x, 0, tabs[p_index].size_cache, get_size().height);
 	p_tab_style->draw(ci, sb_rect);
@@ -1272,7 +1272,7 @@ int TabBar::get_tab_width(int p_idx) const {
 	Ref<StyleBox> tab_unselected = get_theme_stylebox(SNAME("tab_unselected"));
 	Ref<StyleBox> tab_selected = get_theme_stylebox(SNAME("tab_selected"));
 	Ref<StyleBox> tab_disabled = get_theme_stylebox(SNAME("tab_disabled"));
-	int hseparation = get_theme_constant(SNAME("hseparation"));
+	int hseparation = get_theme_constant(SNAME("h_separation"));
 
 	Ref<StyleBox> style;
 

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -209,7 +209,7 @@ void TabContainer::_on_theme_changed() {
 	tab_bar->add_theme_color_override(SNAME("font_outline_color"), get_theme_color(SNAME("font_outline_color")));
 	tab_bar->add_theme_font_override(SNAME("font"), get_theme_font(SNAME("font")));
 	tab_bar->add_theme_constant_override(SNAME("font_size"), get_theme_constant(SNAME("font_size")));
-	tab_bar->add_theme_constant_override(SNAME("hseparation"), get_theme_constant(SNAME("icon_separation")));
+	tab_bar->add_theme_constant_override(SNAME("h_separation"), get_theme_constant(SNAME("icon_separation")));
 	tab_bar->add_theme_constant_override(SNAME("outline_size"), get_theme_constant(SNAME("outline_size")));
 
 	_update_margins();

--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1412,8 +1412,8 @@ void Tree::update_cache() {
 	cache.font_color = get_theme_color(SNAME("font_color"));
 	cache.font_selected_color = get_theme_color(SNAME("font_selected_color"));
 	cache.drop_position_color = get_theme_color(SNAME("drop_position_color"));
-	cache.hseparation = get_theme_constant(SNAME("hseparation"));
-	cache.vseparation = get_theme_constant(SNAME("vseparation"));
+	cache.hseparation = get_theme_constant(SNAME("h_separation"));
+	cache.vseparation = get_theme_constant(SNAME("v_separation"));
 	cache.item_margin = get_theme_constant(SNAME("item_margin"));
 	cache.button_margin = get_theme_constant(SNAME("button_margin"));
 

--- a/scene/main/canvas_item.cpp
+++ b/scene/main/canvas_item.cpp
@@ -1293,7 +1293,7 @@ void CanvasTexture::_bind_methods() {
 
 	ADD_GROUP("Diffuse", "diffuse_");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "diffuse_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_diffuse_texture", "get_diffuse_texture");
-	ADD_GROUP("Normalmap", "normal_");
+	ADD_GROUP("NormalMap", "normal_");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "normal_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_normal_texture", "get_normal_texture");
 	ADD_GROUP("Specular", "specular_");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "specular_texture", PROPERTY_HINT_RESOURCE_TYPE, "Texture2D"), "set_specular_texture", "get_specular_texture");

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -239,8 +239,8 @@ void Viewport::_sub_window_update(Window *p_window) {
 		int font_size = p_window->get_theme_font_size(SNAME("title_font_size"));
 		Color title_color = p_window->get_theme_color(SNAME("title_color"));
 		int title_height = p_window->get_theme_constant(SNAME("title_height"));
-		int close_h_ofs = p_window->get_theme_constant(SNAME("close_h_ofs"));
-		int close_v_ofs = p_window->get_theme_constant(SNAME("close_v_ofs"));
+		int close_h_ofs = p_window->get_theme_constant(SNAME("close_h_offset"));
+		int close_v_ofs = p_window->get_theme_constant(SNAME("close_v_offset"));
 
 		TextLine title_text = TextLine(p_window->atr(p_window->get_title()), title_font, font_size, Dictionary(), TranslationServer::get_singleton()->get_tool_locale());
 		title_text.set_width(r.size.width - panel->get_minimum_size().x - close_h_ofs);
@@ -2583,8 +2583,8 @@ bool Viewport::_sub_windows_forward_input(const Ref<InputEvent> &p_event) {
 				if (title_bar.has_point(mb->get_position())) {
 					click_on_window = true;
 
-					int close_h_ofs = sw.window->get_theme_constant(SNAME("close_h_ofs"));
-					int close_v_ofs = sw.window->get_theme_constant(SNAME("close_v_ofs"));
+					int close_h_ofs = sw.window->get_theme_constant(SNAME("close_h_offset"));
+					int close_v_ofs = sw.window->get_theme_constant(SNAME("close_v_offset"));
 					Ref<Texture2D> close_icon = sw.window->get_theme_icon(SNAME("close"));
 
 					Rect2 close_rect;

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -177,7 +177,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("icon_focus_color", "Button", Color(1, 1, 1, 1));
 	theme->set_color("icon_disabled_color", "Button", Color(1, 1, 1, 0.4));
 
-	theme->set_constant("hseparation", "Button", 2 * scale);
+	theme->set_constant("h_separation", "Button", 2 * scale);
 
 	// LinkButton
 
@@ -230,7 +230,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_disabled_color", "OptionButton", control_font_disabled_color);
 	theme->set_color("font_outline_color", "OptionButton", Color(1, 1, 1));
 
-	theme->set_constant("hseparation", "OptionButton", 2 * scale);
+	theme->set_constant("h_separation", "OptionButton", 2 * scale);
 	theme->set_constant("arrow_margin", "OptionButton", 4 * scale);
 	theme->set_constant("outline_size", "OptionButton", 0);
 
@@ -252,7 +252,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_disabled_color", "MenuButton", Color(1, 1, 1, 0.3));
 	theme->set_color("font_outline_color", "MenuButton", Color(1, 1, 1));
 
-	theme->set_constant("hseparation", "MenuButton", 3 * scale);
+	theme->set_constant("h_separation", "MenuButton", 3 * scale);
 	theme->set_constant("outline_size", "MenuButton", 0);
 
 	// CheckBox
@@ -295,8 +295,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_disabled_color", "CheckBox", control_font_disabled_color);
 	theme->set_color("font_outline_color", "CheckBox", Color(1, 1, 1));
 
-	theme->set_constant("hseparation", "CheckBox", 4 * scale);
-	theme->set_constant("check_vadjust", "CheckBox", 0 * scale);
+	theme->set_constant("h_separation", "CheckBox", 4 * scale);
+	theme->set_constant("check_v_adjust", "CheckBox", 0 * scale);
 	theme->set_constant("outline_size", "CheckBox", 0);
 
 	// CheckButton
@@ -335,8 +335,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_disabled_color", "CheckButton", control_font_disabled_color);
 	theme->set_color("font_outline_color", "CheckButton", Color(1, 1, 1));
 
-	theme->set_constant("hseparation", "CheckButton", 4 * scale);
-	theme->set_constant("check_vadjust", "CheckButton", 0 * scale);
+	theme->set_constant("h_separation", "CheckButton", 4 * scale);
+	theme->set_constant("check_v_adjust", "CheckButton", 0 * scale);
 	theme->set_constant("outline_size", "CheckButton", 0);
 
 	// Label
@@ -582,8 +582,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_icon("close", "Window", icons["close"]);
 	theme->set_icon("close_pressed", "Window", icons["close_hl"]);
-	theme->set_constant("close_h_ofs", "Window", 18 * scale);
-	theme->set_constant("close_v_ofs", "Window", 24 * scale);
+	theme->set_constant("close_h_offset", "Window", 18 * scale);
+	theme->set_constant("close_v_offset", "Window", 24 * scale);
 
 	// Dialogs
 
@@ -665,8 +665,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_outline_color", "PopupMenu", Color(1, 1, 1));
 	theme->set_color("font_separator_outline_color", "PopupMenu", Color(1, 1, 1));
 
-	theme->set_constant("hseparation", "PopupMenu", 4 * scale);
-	theme->set_constant("vseparation", "PopupMenu", 4 * scale);
+	theme->set_constant("h_separation", "PopupMenu", 4 * scale);
+	theme->set_constant("v_separation", "PopupMenu", 4 * scale);
 	theme->set_constant("outline_size", "PopupMenu", 0);
 	theme->set_constant("separator_outline_size", "PopupMenu", 0);
 	theme->set_constant("item_start_padding", "PopupMenu", 2 * scale);
@@ -688,9 +688,9 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	graphnode_position->set_border_color(Color(0.98, 0.89, 0.27));
 
 	theme->set_stylebox("frame", "GraphNode", graphnode_normal);
-	theme->set_stylebox("selectedframe", "GraphNode", graphnode_selected);
+	theme->set_stylebox("selected_frame", "GraphNode", graphnode_selected);
 	theme->set_stylebox("comment", "GraphNode", graphnode_comment_normal);
-	theme->set_stylebox("commentfocus", "GraphNode", graphnode_comment_selected);
+	theme->set_stylebox("comment_focus", "GraphNode", graphnode_comment_selected);
 	theme->set_stylebox("breakpoint", "GraphNode", graphnode_breakpoint);
 	theme->set_stylebox("position", "GraphNode", graphnode_position);
 
@@ -746,8 +746,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("children_hl_line_color", "Tree", Color(0.27, 0.27, 0.27));
 	theme->set_color("custom_button_font_highlight", "Tree", control_font_hover_color);
 
-	theme->set_constant("hseparation", "Tree", 4 * scale);
-	theme->set_constant("vseparation", "Tree", 4 * scale);
+	theme->set_constant("h_separation", "Tree", 4 * scale);
+	theme->set_constant("v_separation", "Tree", 4 * scale);
 	theme->set_constant("item_margin", "Tree", 16 * scale);
 	theme->set_constant("button_margin", "Tree", 4 * scale);
 	theme->set_constant("draw_relationship_lines", "Tree", 0);
@@ -764,8 +764,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 
 	theme->set_stylebox("bg", "ItemList", make_flat_stylebox(style_normal_color));
 	theme->set_stylebox("bg_focus", "ItemList", focus);
-	theme->set_constant("hseparation", "ItemList", 4);
-	theme->set_constant("vseparation", "ItemList", 2);
+	theme->set_constant("h_separation", "ItemList", 4);
+	theme->set_constant("v_separation", "ItemList", 2);
 	theme->set_constant("icon_margin", "ItemList", 4);
 	theme->set_constant("line_separation", "ItemList", 2 * scale);
 
@@ -846,7 +846,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_outline_color", "TabBar", Color(1, 1, 1));
 	theme->set_color("drop_mark_color", "TabBar", Color(1, 1, 1));
 
-	theme->set_constant("hseparation", "TabBar", 4 * scale);
+	theme->set_constant("h_separation", "TabBar", 4 * scale);
 	theme->set_constant("outline_size", "TabBar", 0);
 
 	// Separators
@@ -896,7 +896,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_disabled_color", "ColorPickerButton", Color(0.9, 0.9, 0.9, 0.3));
 	theme->set_color("font_outline_color", "ColorPickerButton", Color(1, 1, 1));
 
-	theme->set_constant("hseparation", "ColorPickerButton", 2 * scale);
+	theme->set_constant("h_separation", "ColorPickerButton", 2 * scale);
 	theme->set_constant("outline_size", "ColorPickerButton", 0);
 
 	// ColorPresetButton
@@ -956,8 +956,8 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("shadow_outline_size", "RichTextLabel", 1 * scale);
 
 	theme->set_constant("line_separation", "RichTextLabel", 0 * scale);
-	theme->set_constant("table_hseparation", "RichTextLabel", 3 * scale);
-	theme->set_constant("table_vseparation", "RichTextLabel", 3 * scale);
+	theme->set_constant("table_h_separation", "RichTextLabel", 3 * scale);
+	theme->set_constant("table_v_separation", "RichTextLabel", 3 * scale);
 
 	theme->set_constant("outline_size", "RichTextLabel", 0);
 
@@ -976,16 +976,16 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("margin_top", "MarginContainer", 0 * scale);
 	theme->set_constant("margin_right", "MarginContainer", 0 * scale);
 	theme->set_constant("margin_bottom", "MarginContainer", 0 * scale);
-	theme->set_constant("hseparation", "GridContainer", 4 * scale);
-	theme->set_constant("vseparation", "GridContainer", 4 * scale);
+	theme->set_constant("h_separation", "GridContainer", 4 * scale);
+	theme->set_constant("v_separation", "GridContainer", 4 * scale);
 	theme->set_constant("separation", "HSplitContainer", 12 * scale);
 	theme->set_constant("separation", "VSplitContainer", 12 * scale);
 	theme->set_constant("autohide", "HSplitContainer", 1 * scale);
 	theme->set_constant("autohide", "VSplitContainer", 1 * scale);
-	theme->set_constant("hseparation", "HFlowContainer", 4 * scale);
-	theme->set_constant("vseparation", "HFlowContainer", 4 * scale);
-	theme->set_constant("hseparation", "VFlowContainer", 4 * scale);
-	theme->set_constant("vseparation", "VFlowContainer", 4 * scale);
+	theme->set_constant("h_separation", "HFlowContainer", 4 * scale);
+	theme->set_constant("v_separation", "HFlowContainer", 4 * scale);
+	theme->set_constant("h_separation", "VFlowContainer", 4 * scale);
+	theme->set_constant("v_separation", "VFlowContainer", 4 * scale);
 
 	theme->set_stylebox("panel", "PanelContainer", make_flat_stylebox(style_normal_color, 0, 0, 0, 0));
 


### PR DESCRIPTION
See https://github.com/godotengine/godot/issues/54161#issuecomment-1086010102

Renames several theme properties to include an underscore between words and changes "ofs" to "offset" in a few other theme properties.

| Before | After |
---|---
| check_vadjust | check_v_adjust |
| close_h_ofs | close_h_offset |
| close_v_ofs | close_v_offset |
| commentfocus | comment_focus |
| hseparation | h_separation |
| ofs | offset |
| selectedframe | selected_frame |
| state_machine_selectedframe | state_machine_selected_frame |
| table_hseparation | table_h_separation |
| table_vseparation | table_v_separation |
| vseparation | v_separation |
