### PR TITLE
Rename `--export` command line argument to `--export-release`

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -407,10 +407,11 @@ void Main::print_help(const char *p_binary) {
 	OS::get_singleton()->print("  -s, --script <script>                        Run a script.\n");
 	OS::get_singleton()->print("  --check-only                                 Only parse for errors and quit (use with --script).\n");
 #ifdef TOOLS_ENABLED
-	OS::get_singleton()->print("  --export <preset> <path>                     Export the project using the given preset and matching release template. The preset name should match one defined in export_presets.cfg.\n");
-	OS::get_singleton()->print("                                               <path> should be absolute or relative to the project directory, and include the filename for the binary (e.g. 'builds/game.exe'). The target directory should exist.\n");
-	OS::get_singleton()->print("  --export-debug <preset> <path>               Same as --export, but using the debug template.\n");
-	OS::get_singleton()->print("  --export-pack <preset> <path>                Same as --export, but only export the game pack for the given preset. The <path> extension determines whether it will be in PCK or ZIP format.\n");
+	OS::get_singleton()->print("  --export-release <preset> <path>             Export the project in release mode using the given preset and output path. The preset name should match one defined in export_presets.cfg.\n");
+	OS::get_singleton()->print("                                               <path> should be absolute or relative to the project directory, and include the filename for the binary (e.g. 'builds/game.exe').\n");
+	OS::get_singleton()->print("                                               The target directory must exist.\n");
+	OS::get_singleton()->print("  --export-debug <preset> <path>               Export the project in debug mode using the given preset and output path. The preset name should match one defined in export_presets.cfg.\n");
+	OS::get_singleton()->print("  --export-pack <preset> <path>                Export the project data only using the given preset and output path. The <path> extension determines whether it will be in PCK or ZIP format.\n");
 	OS::get_singleton()->print("  --convert-3to4 [<max_file_kb>] [<max_line_size>]              Converts project from Godot 3.x to Godot 4.x.\n");
 	OS::get_singleton()->print("  --validate-conversion-3to4 [<max_file_kb>] [<max_line_size>]  Shows what elements will be renamed when converting project from Godot 3.x to Godot 4.x.\n");
 	OS::get_singleton()->print("  --doctool [<path>]                           Dump the engine API reference to the given <path> (defaults to current dir) in XML format, merging if existing files are found.\n");
@@ -1077,7 +1078,7 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 			// run the project instead of a cmdline tool.
 			// Needs full refactoring to fix properly.
 			main_args.push_back(I->get());
-		} else if (I->get() == "--export" || I->get() == "--export-debug" ||
+		} else if (I->get() == "--export-release" || I->get() == "--export-debug" ||
 				I->get() == "--export-pack") { // Export project
 			// Actually handling is done in start().
 			editor = true;
@@ -2473,7 +2474,7 @@ bool Main::start() {
 					doc_tool_path = ".";
 					parsed_pair = false;
 				}
-			} else if (args[i] == "--export") {
+			} else if (args[i] == "--export-release") {
 				editor = true; //needs editor
 				_export_preset = args[i + 1];
 			} else if (args[i] == "--export-debug") {

--- a/misc/dist/linux/godot.6
+++ b/misc/dist/linux/godot.6
@@ -130,16 +130,22 @@ Run a script.
 \fB\-\-check\-only\fR
 Only parse for errors and quit (use with --script).
 .TP
-\fB\-\-export\fR <preset> <path>
-Export the project using the given preset and matching release template. The preset name should match one defined in export_presets.cfg.
+\fB\-\-export\-release\fR <preset> <path>
+Export the project in release mode using the given preset and output path. The preset name should match one defined in export_presets.cfg.
 .br
-<path> should be absolute or relative to the project directory, and include the filename for the binary (e.g. 'builds/game.exe'). The target directory should exist.
+<path> should be absolute or relative to the project directory, and include the filename for the binary (e.g. 'builds/game.exe').
+.br
+The target directory must exist.
 .TP
 \fB\-\-export\-debug\fR <preset> <path>
-Same as \-\-export, but using the debug template.
+Export the project in debug mode using the given preset and output path. The preset name should match one defined in export_presets.cfg.
+.br
+<path> should be absolute or relative to the project directory, and include the filename for the binary (e.g. 'builds/game.exe').
+.br
+The target directory must exist.
 .TP
 \fB\-\-export\-pack\fR <preset> <path>
-Same as \-\-export, but only export the game pack for the given preset. The <path> extension determines whether it will be in PCK or ZIP format.
+Export the project data only using the given preset and output path. The <path> extension determines whether it will be in PCK or ZIP format.
 .TP
 \fB\-\-doctool\fR <path>
 Dump the engine API reference to the given <path> in XML format, merging if existing files are found.

--- a/misc/dist/shell/_godot.zsh-completion
+++ b/misc/dist/shell/_godot.zsh-completion
@@ -76,9 +76,9 @@ _arguments \
   '--print-fps[print the frames per second to the stdout]' \
   '(-s, --script)'{-s,--script}'[run a script]:path to script:_files' \
   '--check-only[only parse for errors and quit (use with --script)]' \
-  '--export[export the project using the given preset and matching release template]:export preset name then path' \
-  '--export-debug[same as --export, but using the debug template]:export preset name then path' \
-  '--export-pack[same as --export, but only export the game pack for the given preset]:export preset name then path' \
+  '--export-release[export the project in release mode using the given preset and output path]:export preset name then path' \
+  '--export-debug[export the project in debug mode using the given preset and output path]:export preset name then path' \
+  '--export-pack[export the project data only as a PCK or ZIP file using the given preset and output path]:export preset name then path' \
   '--convert-3to4[converts project from Godot 3.x to Godot 4.x]' \
   '--validate-conversion-3to4[shows what elements will be renamed when converting project from Godot 3.x to Godot 4.x]' \
   '--doctool[dump the engine API reference to the given path in XML format, merging if existing files are found]:path to base Godot build directory (optional):_dirs' \

--- a/misc/dist/shell/godot.bash-completion
+++ b/misc/dist/shell/godot.bash-completion
@@ -78,7 +78,7 @@ _complete_godot_options() {
 --print-fps
 --script
 --check-only
---export
+--export-release
 --export-debug
 --export-pack
 --convert-3to4

--- a/misc/dist/shell/godot.fish
+++ b/misc/dist/shell/godot.fish
@@ -98,9 +98,9 @@ complete -c godot -l print-fps -d "Print the frames per second to the stdout"
 # Standalone tools:
 complete -c godot -s s -l script -d "Run a script" -r
 complete -c godot -l check-only -d "Only parse for errors and quit (use with --script)"
-complete -c godot -l export -d "Export the project using the given preset and matching release template" -x
-complete -c godot -l export-debug -d "Same as --export, but using the debug template" -x
-complete -c godot -l export-pack -d "Same as --export, but only export the game pack for the given preset" -x
+complete -c godot -l export-release -d "Export the project in release mode using the given preset and output path" -x
+complete -c godot -l export-debug -d "Export the project in debug mode using the given preset and output path" -x
+complete -c godot -l export-pack -d "Export the project data only as a PCK or ZIP file using the given preset and output path" -x
 complete -c godot -l convert-3to4 -d "Converts project from Godot 3.x to Godot 4.x"
 complete -c godot -l validate-conversion-3to4 -d "Shows what elements will be renamed when converting project from Godot 3.x to Godot 4.x"
 complete -c godot -l doctool -d "Dump the engine API reference to the given path in XML format, merging if existing files are found" -r


### PR DESCRIPTION
This makes the action of exporting to release mode more explicit.

Command line help was also reformatted to avoid requiring soft wrapping on anything but the widest displays.

This closes https://github.com/godotengine/godot-proposals/issues/4404.