### PR TITLE
Complete set_property_prefix in EditorInspector

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3583,7 +3583,11 @@ void EditorInspector::_vscroll_changed(double p_offset) {
 }
 
 void EditorInspector::set_property_prefix(const String &p_prefix) {
+	if (property_prefix == p_prefix) {
+		return;
+	}
 	property_prefix = p_prefix;
+	update_tree();
 }
 
 String EditorInspector::get_property_prefix() const {


### PR DESCRIPTION
Closes #60259.

Doesn't solve the problem completely, just makes it less prone to appearing.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
