### PR TITLE
[3.x] Set tilt for iOS Pencil

### DIFF
--- a/platform/iphone/godot_view.mm
+++ b/platform/iphone/godot_view.mm
@@ -361,10 +361,11 @@ static const int max_touches = 8;
 			CGPoint touchPoint = [touch locationInView:self];
 			CGPoint prev_point = [touch previousLocationInView:self];
 			CGFloat force = touch.force;
-			// Vector2 tilt = touch.azimuthUnitVector;
+			CGVector tilt = [touch azimuthUnitVectorInView:self];
 
 			if (touch.type == UITouchTypeStylus) {
-				OSIPhone::get_singleton()->pencil_drag(tid, prev_point.x * self.contentScaleFactor, prev_point.y * self.contentScaleFactor, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor, force);
+				OSIPhone::get_singleton()->pencil_drag(tid, prev_point.x * self.contentScaleFactor, prev_point.y * self.contentScaleFactor, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor, force,
+					Vector2(tilt.dx, tilt.dy));
 			} else {
 				OSIPhone::get_singleton()->touch_drag(tid, prev_point.x * self.contentScaleFactor, prev_point.y * self.contentScaleFactor, touchPoint.x * self.contentScaleFactor, touchPoint.y * self.contentScaleFactor);
 			}

--- a/platform/iphone/os_iphone.h
+++ b/platform/iphone/os_iphone.h
@@ -135,6 +135,7 @@ public:
 	void pencil_press(int p_idx, int p_x, int p_y, bool p_pressed, bool p_doubleclick);
 	void touch_press(int p_idx, int p_x, int p_y, bool p_pressed, bool p_doubleclick);
 	void pencil_drag(int p_idx, int p_prev_x, int p_prev_y, int p_x, int p_y, float p_force);
+	void pencil_drag(int p_idx, int p_prev_x, int p_prev_y, int p_x, int p_y, float p_force, Vector2 tilt);
 	void touch_drag(int p_idx, int p_prev_x, int p_prev_y, int p_x, int p_y);
 	void touches_cancelled(int p_idx);
 	void pencil_cancelled(int p_idx);

--- a/platform/iphone/os_iphone.mm
+++ b/platform/iphone/os_iphone.mm
@@ -238,6 +238,17 @@ void OSIPhone::pencil_drag(int p_idx, int p_prev_x, int p_prev_y, int p_x, int p
 	perform_event(ev);
 };
 
+void OSIPhone::pencil_drag(int p_idx, int p_prev_x, int p_prev_y, int p_x, int p_y, float p_force, Vector2 tilt) {
+	Ref<InputEventMouseMotion> ev;
+	ev.instance();
+	ev->set_pressure(p_force);
+	ev->set_position(Vector2(p_x, p_y));
+	ev->set_global_position(Vector2(p_x, p_y));
+	ev->set_relative(Vector2(p_x - p_prev_x, p_y - p_prev_y));
+	ev->set_tilt(tilt);
+	perform_event(ev);
+};
+
 void OSIPhone::pencil_cancelled(int p_idx) {
 	pencil_press(p_idx, -1, -1, false, false);
 }


### PR DESCRIPTION
Targeting branch `3.4` as there is no `UITouchTypeStylus` in `master` (are we going to cherry-pick related commits to master or do we plan something different?).

I've tested it locally and I am able to see the value of it in `event.tilt` using GDScript.
