### PR TITLE
Disable attempting to allow dropping scenes above scene tree root

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -1222,8 +1222,9 @@ bool SceneTreeEditor::can_drop_data_fw(const Point2 &p_point, const Variant &p_d
 		return false;
 	}
 
+	TreeItem *root = tree->get_root();
 	int section = tree->get_drop_section_at_position(p_point);
-	if (section < -1 || (section == -1 && !item->get_parent())) {
+	if (section < -1 || (section == -1 && (item->get_parent() == root))) {
 		return false;
 	}
 


### PR DESCRIPTION
Closes #60292
Disallows dragging above the root node and subsequently silences error
