### PR TITLE
Partially document AudioEffectStereoEnhance

### DIFF
--- a/doc/classes/AudioEffectStereoEnhance.xml
+++ b/doc/classes/AudioEffectStereoEnhance.xml
@@ -1,13 +1,16 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="AudioEffectStereoEnhance" inherits="AudioEffect" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
+		An audio effect that can be used to adjust the intensity of stereo panning.
 	</brief_description>
 	<description>
+		An audio effect that can be used to adjust the intensity of stereo panning.
 	</description>
 	<tutorials>
 	</tutorials>
 	<members>
 		<member name="pan_pullout" type="float" setter="set_pan_pullout" getter="get_pan_pullout" default="1.0">
+			Values greater than 1.0 increase intensity of any panning on audio passing through this effect, whereas values less than 1.0 will decrease the panning intensity. A value of 0.0 will downmix audio to mono.
 		</member>
 		<member name="surround" type="float" setter="set_surround" getter="get_surround" default="0.0">
 		</member>


### PR DESCRIPTION
This should help guide users who are looking for a way to downmix audio to mono. To be perfectly honest I don't actually understand the properties that I've left undocumented, and I'm on an airplane right now so I can't play around with it to figure out what they do. But partial documentation is still better than no documentation.