### PR TITLE
Discontinue exp map in blending

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -633,8 +633,7 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 								track_xform->bone_idx = bone_idx;
 								Transform3D rest = sk->get_bone_rest(bone_idx);
 								track_xform->init_loc = rest.origin;
-								track_xform->ref_rot = rest.basis.get_rotation_quaternion();
-								track_xform->init_rot = track_xform->ref_rot.log();
+								track_xform->init_rot = rest.basis.get_rotation_quaternion();
 								track_xform->init_scale = rest.basis.get_scale();
 							}
 						}
@@ -667,8 +666,7 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 										track_xform->init_loc = reset_anim->track_get_key_value(rt, 0);
 									} break;
 									case Animation::TYPE_ROTATION_3D: {
-										track_xform->ref_rot = reset_anim->track_get_key_value(rt, 0);
-										track_xform->init_rot = track_xform->ref_rot.log();
+										track_xform->init_rot = reset_anim->track_get_key_value(rt, 0);
 									} break;
 									case Animation::TYPE_SCALE_3D: {
 										track_xform->init_scale = reset_anim->track_get_key_value(rt, 0);
@@ -1144,7 +1142,7 @@ void AnimationTree::_process_graph(double p_delta) {
 										continue;
 									}
 									a->rotation_track_interpolate(i, (double)a->get_length(), &rot[1]);
-									t->rot += (rot[1].log() - rot[0].log()) * blend;
+									t->rot = (t->rot * Quaternion().slerp(rot[0].inverse() * rot[1], blend)).normalized();
 									prev_time = 0;
 								}
 							} else {
@@ -1154,7 +1152,7 @@ void AnimationTree::_process_graph(double p_delta) {
 										continue;
 									}
 									a->rotation_track_interpolate(i, 0, &rot[1]);
-									t->rot += (rot[1].log() - rot[0].log()) * blend;
+									t->rot = (t->rot * Quaternion().slerp(rot[0].inverse() * rot[1], blend)).normalized();
 									prev_time = 0;
 								}
 							}
@@ -1165,7 +1163,7 @@ void AnimationTree::_process_graph(double p_delta) {
 							}
 
 							a->rotation_track_interpolate(i, time, &rot[1]);
-							t->rot += (rot[1].log() - rot[0].log()) * blend;
+							t->rot = (t->rot * Quaternion().slerp(rot[0].inverse() * rot[1], blend)).normalized();
 							prev_time = !backward ? 0 : (double)a->get_length();
 
 						} else {
@@ -1182,10 +1180,7 @@ void AnimationTree::_process_graph(double p_delta) {
 								continue;
 							}
 
-							if (signbit(rot.dot(t->ref_rot))) {
-								rot = -rot;
-							}
-							t->rot += (rot.log() - t->init_rot) * blend;
+							t->rot = (t->rot * Quaternion().slerp(t->init_rot.inverse() * rot, blend)).normalized();
 						}
 #endif // _3D_DISABLED
 					} break;
@@ -1585,7 +1580,6 @@ void AnimationTree::_process_graph(double p_delta) {
 				case Animation::TYPE_POSITION_3D: {
 #ifndef _3D_DISABLED
 					TrackCacheTransform *t = static_cast<TrackCacheTransform *>(track);
-					t->rot = t->rot.exp();
 
 					if (t->root_motion) {
 						Transform3D xform;

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -198,8 +198,7 @@ private:
 		bool rot_used = false;
 		bool scale_used = false;
 		Vector3 init_loc = Vector3(0, 0, 0);
-		Quaternion ref_rot = Quaternion(0, 0, 0, 1);
-		Quaternion init_rot = Quaternion(0, 0, 0, 0);
+		Quaternion init_rot = Quaternion(0, 0, 0, 1);
 		Vector3 init_scale = Vector3(1, 1, 1);
 		Vector3 loc;
 		Quaternion rot;


### PR DESCRIPTION
Fixed #60306. Discontinue the use of exp map in blending.

The exp map can easily perform multiple quaternion blends. However, it really comes into its own when you need to compute two or more quaternions at the same time, such as when diverting the cubic interpolate formula in an issue like #57951, which is what we are trying to solve now.

In the blending process, quaternions are always complemented one by one by the iterator, so there is not much point in using exp map. The calculation cost is much lower, but the error is larger when there are large rotations, as in #60306. See #58043 and https://swkagami.hatenablog.com/entry/lie_03algebra for a description of the error of the exp map.

Actually, in fact I replaced slerp and confirmed before that it does more than 3 blends correctly.

Here is the video after the fix:

https://user-images.githubusercontent.com/61938263/163689061-1cd215d5-d4a8-46ae-ae97-348b3b03b663.mov

In the opening of the video above you can see that changing the connection order for blending more than 3 Nodes is not a problem, prior to 4.0.alpha4 these results were different and the calculations were not done correctly in the first place.

Earlier, reduz said there was a problem with slerp from an empty quaternion as in https://github.com/godotengine/godot/pull/34134#issuecomment-565527677, it was that a 180 degree rotation from the init quaternion from always could not be done. In fact, we can use any base quaternion by adding init_rot to the calculation, so we don't have to worry about that problem.