### PR TITLE
Unzip success breaks read loop in Export Template and Project Manager

### DIFF
--- a/editor/export_template_manager.cpp
+++ b/editor/export_template_manager.cpp
@@ -404,9 +404,7 @@ bool ExportTemplateManager::_install_file_selected(const String &p_file, bool p_
 			// Read.
 			unzOpenCurrentFile(pkg);
 			ret = unzReadCurrentFile(pkg, data.ptrw(), data.size());
-			if (ret != UNZ_OK) {
-				break;
-			}
+			ERR_BREAK_MSG(ret < 0, vformat("An error occurred while attempting to read from file: %s. This file will not be used.", file));
 			unzCloseCurrentFile(pkg);
 
 			String data_str;
@@ -478,9 +476,7 @@ bool ExportTemplateManager::_install_file_selected(const String &p_file, bool p_
 		// Read
 		unzOpenCurrentFile(pkg);
 		ret = unzReadCurrentFile(pkg, data.ptrw(), data.size());
-		if (ret != UNZ_OK) {
-			break;
-		}
+		ERR_BREAK_MSG(ret < 0, vformat("An error occurred while attempting to read from file: %s. This file will not be used.", file));
 		unzCloseCurrentFile(pkg);
 
 		String base_dir = file_path.get_base_dir().trim_suffix("/");

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -557,9 +557,7 @@ private:
 							//read
 							unzOpenCurrentFile(pkg);
 							ret = unzReadCurrentFile(pkg, data.ptrw(), data.size());
-							if (ret != UNZ_OK) {
-								break;
-							}
+							ERR_BREAK_MSG(ret < 0, vformat("An error occurred while attempting to read from file: %s. This file will not be used.", rel_path));
 							unzCloseCurrentFile(pkg);
 
 							Ref<FileAccess> f = FileAccess::open(dir.plus_file(rel_path), FileAccess::WRITE);


### PR DESCRIPTION
`unzReadCurrentFile(3)` returns number of bytes copied to buffer. **Bug:** The current code misinterprets that return, and only processes the file if no bytes were copied (`UNZ_OK` is a _#define_ equal to **0**).

I've altered the break to occur only on unsuccessful read, (when `unzReadCurrentFile(3)` returns _less than_ zero), and added an error message for when an unsuccessful read occurs.

This read problem was introduced in #59911, as a suggestion from cppcheck.

I thought it best to use "0" seeing as the return is a value (# bytes copied) and not an enumeration.
I left it at _less than 0_ because 0 bytes copied is still a successful read, it just means unz read `EOF` right away. If a non-zero amount of bytes were needed, I figure that would be handled somewhere higher up.

_Issue occurs in bleeding edge build of 4.0_

Please feel free to make suggestions! Thank you! 🍲
