### PR TITLE
PathFollow2D and PathFollow3D: don't set offset to NaN for looping path of length zero

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -311,7 +311,7 @@ void PathFollow2D::set_offset(real_t p_offset) {
 		if (path->get_curve().is_valid()) {
 			real_t path_length = path->get_curve()->get_baked_length();
 
-			if (loop) {
+			if (loop && path_length) {
 				offset = Math::fposmod(offset, path_length);
 				if (!Math::is_zero_approx(p_offset) && Math::is_zero_approx(offset)) {
 					offset = path_length;

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -310,7 +310,7 @@ void PathFollow3D::set_offset(real_t p_offset) {
 		if (path->get_curve().is_valid()) {
 			real_t path_length = path->get_curve()->get_baked_length();
 
-			if (loop) {
+			if (loop && path_length) {
 				offset = Math::fposmod(offset, path_length);
 				if (!Math::is_zero_approx(p_offset) && Math::is_zero_approx(offset)) {
 					offset = path_length;


### PR DESCRIPTION
This uses the same approach as seen in 

https://github.com/godotengine/godot/blob/690fefe43ee74c0ae3ed5642f3aefbeb711f9d1c/scene/animation/animation_blend_tree.cpp#L120-L122

to avoid setting the `offset` to `-nan` in `PathFollow2D` and `PathFollow3D`.

Fixes https://github.com/godotengine/godot/issues/60318