### PR TITLE
Add a property hint for AspectRatioContainer's `ratio` property (3.x)

### DIFF
--- a/scene/gui/aspect_ratio_container.cpp
+++ b/scene/gui/aspect_ratio_container.cpp
@@ -149,7 +149,7 @@ void AspectRatioContainer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_alignment_vertical", "alignment_vertical"), &AspectRatioContainer::set_alignment_vertical);
 	ClassDB::bind_method(D_METHOD("get_alignment_vertical"), &AspectRatioContainer::get_alignment_vertical);
 
-	ADD_PROPERTY(PropertyInfo(Variant::REAL, "ratio"), "set_ratio", "get_ratio");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "ratio", PROPERTY_HINT_RANGE, "0.001,10.0,0.0001,or_greater"), "set_ratio", "get_ratio");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "stretch_mode", PROPERTY_HINT_ENUM, "Width controls height,Height controls width,Fit,Cover"), "set_stretch_mode", "get_stretch_mode");
 
 	ADD_GROUP("Alignment", "alignment_");


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/60329.

Zero or negative ratios are not valid, so the property hint prevents choosing such values.

The property hint allows using 4 decimals so that common aspect ratios like 16/9 can be specified with a good level of precision.