### PR TITLE
Make Tween.interpolate_value() static

### DIFF
--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -266,7 +266,7 @@
 				- Greater than 1.0 (exclusive): Ease in
 				[/codeblock]
 				[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/ease_cheatsheet.png]ease() curve values cheatsheet[/url]
-				See also [method smoothstep]. If you need to perform more advanced transitions, use [Tween] or [AnimationPlayer].
+				See also [method smoothstep]. If you need to perform more advanced transitions, use [method Tween.interpolate_value].
 			</description>
 		</method>
 		<method name="error_string">

--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -6,7 +6,7 @@
 	<description>
 		Tweens are mostly useful for animations requiring a numerical property to be interpolated over a range of values. The name [i]tween[/i] comes from [i]in-betweening[/i], an animation technique where you specify [i]keyframes[/i] and the computer interpolates the frames that appear between them.
 		[Tween] is more suited than [AnimationPlayer] for animations where you don't know the final values in advance. For example, interpolating a dynamically-chosen camera zoom value is best done with a [Tween]; it would be difficult to do the same thing with an [AnimationPlayer] node. Tweens are also more light-weight than [AnimationPlayer], so they are very much suited for simple animations or general tasks that don't require visual tweaking provided by the editor. They can be used in a fire-and-forget manner for some logic that normally would be done by code. You can e.g. make something shoot periodically by using a looped [CallbackTweener] with a delay.
-		A [Tween] can be created by using either [method SceneTree.create_tween] or [method Node.create_tween]. [Tween]s created manually (i.e. by using [code]Tween.new()[/code]) are invalid. They can't be used for tweening values, but you can do manual interpolation with [method interpolate_value].
+		A [Tween] can be created by using either [method SceneTree.create_tween] or [method Node.create_tween]. [Tween]s created manually (i.e. by using [code]Tween.new()[/code]) are invalid and can't be used for tweening values.
 		A [Tween] animation is composed of a sequence of [Tweener]s, which by default are executed one after another. You can create a sequence by appending [Tweener]s to the [Tween]. Animating something with a [Tweener] is called tweening. Example tweening sequence looks like this:
 		[codeblock]
 		var tween = get_tree().create_tween()
@@ -79,7 +79,7 @@
 				[b]Note:[/code] As it results from accumulating frame deltas, the time returned after the [Tween] has finished animating will be slightly greater than the actual [Tween] duration.
 			</description>
 		</method>
-		<method name="interpolate_value">
+		<method name="interpolate_value" qualifiers="static">
 			<return type="Variant" />
 			<argument index="0" name="initial_value" type="Variant" />
 			<argument index="1" name="delta_value" type="Variant" />
@@ -105,7 +105,7 @@
 		<method name="is_valid">
 			<return type="bool" />
 			<description>
-				Returns whether the [Tween] is valid. A valid [Tween] is a [Tween] contained by the scene tree (i.e. the array from [method SceneTree.get_processed_tweens] will contain this [Tween]). [Tween] might become invalid when it has finished tweening or was killed, also when created with [code]Tween.new()[/code]. Invalid [Tween] can't have [Tweener]s appended, because it can't animate them. You can however still use [method interpolate_value].
+				Returns whether the [Tween] is valid. A valid [Tween] is a [Tween] contained by the scene tree (i.e. the array from [method SceneTree.get_processed_tweens] will contain this [Tween]). [Tween] might become invalid when it has finished tweening or was killed, also when created with [code]Tween.new()[/code]. Invalid [Tween] can't have [Tweener]s appended, because it can't animate them.
 			</description>
 		</method>
 		<method name="kill">

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -152,10 +152,6 @@ bool Tween::is_running() {
 	return running;
 }
 
-void Tween::set_valid(bool p_valid) {
-	valid = p_valid;
-}
-
 bool Tween::is_valid() {
 	return valid;
 }
@@ -648,7 +644,7 @@ void Tween::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("parallel"), &Tween::parallel);
 	ClassDB::bind_method(D_METHOD("chain"), &Tween::chain);
 
-	ClassDB::bind_method(D_METHOD("interpolate_value", "initial_value", "delta_value", "elapsed_time", "duration", "trans_type", "ease_type"), &Tween::interpolate_variant);
+	ClassDB::bind_static_method("Tween", D_METHOD("interpolate_value", "initial_value", "delta_value", "elapsed_time", "duration", "trans_type", "ease_type"), &Tween::interpolate_variant);
 
 	ADD_SIGNAL(MethodInfo("step_finished", PropertyInfo(Variant::INT, "idx")));
 	ADD_SIGNAL(MethodInfo("loop_finished", PropertyInfo(Variant::INT, "loop_count")));
@@ -677,6 +673,14 @@ void Tween::_bind_methods() {
 	BIND_ENUM_CONSTANT(EASE_OUT);
 	BIND_ENUM_CONSTANT(EASE_IN_OUT);
 	BIND_ENUM_CONSTANT(EASE_OUT_IN);
+}
+
+Tween::Tween() {
+	ERR_FAIL_MSG("Tween can't be created directly. Use create_tween() method.");
+}
+
+Tween::Tween(bool p_valid) {
+	valid = p_valid;
 }
 
 Ref<PropertyTweener> PropertyTweener::from(Variant p_value) {

--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -139,7 +139,6 @@ public:
 	void kill();
 
 	bool is_running();
-	void set_valid(bool p_valid);
 	bool is_valid();
 	void clear();
 
@@ -160,8 +159,8 @@ public:
 	Ref<Tween> parallel();
 	Ref<Tween> chain();
 
-	real_t run_equation(TransitionType p_trans_type, EaseType p_ease_type, real_t t, real_t b, real_t c, real_t d);
-	Variant interpolate_variant(Variant p_initial_val, Variant p_delta_val, float p_time, float p_duration, Tween::TransitionType p_trans, Tween::EaseType p_ease);
+	static real_t run_equation(TransitionType p_trans_type, EaseType p_ease_type, real_t t, real_t b, real_t c, real_t d);
+	static Variant interpolate_variant(Variant p_initial_val, Variant p_delta_val, float p_time, float p_duration, Tween::TransitionType p_trans, Tween::EaseType p_ease);
 	Variant calculate_delta_value(Variant p_intial_val, Variant p_final_val);
 
 	bool step(float p_delta);
@@ -169,7 +168,8 @@ public:
 	Node *get_bound_node() const;
 	float get_total_time() const;
 
-	Tween() {}
+	Tween();
+	Tween(bool p_valid);
 };
 
 VARIANT_ENUM_CAST(Tween::TweenPauseMode);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1113,9 +1113,7 @@ Ref<SceneTreeTimer> SceneTree::create_timer(double p_delay_sec, bool p_process_a
 }
 
 Ref<Tween> SceneTree::create_tween() {
-	Ref<Tween> tween;
-	tween.instantiate();
-	tween->set_valid(true);
+	Ref<Tween> tween = memnew(Tween(true));
 	tweens.push_back(tween);
 	return tween;
 }


### PR DESCRIPTION
This PR makes `Tween.interpolate_value()` a static method, so it can be used for interpolating anywhere in the code and is a nice alternative to the global `ease()` method (maybe it could be removed now?). Creating a Tween using `Tween.new()` is no longer a valid use-case, so doing so will now show an error.