### PR TITLE
`mesh_surface_get_format_offset` and `mesh_surface_get_format_stride` should now print an error message instead of silently crashing

### DIFF
--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -848,6 +848,7 @@ Error VisualServer::_surface_set_data(Array p_arrays, uint32_t p_format, uint32_
 }
 
 uint32_t VisualServer::mesh_surface_get_format_offset(uint32_t p_format, int p_vertex_len, int p_index_len, int p_array_index) const {
+	ERR_FAIL_INDEX_V(p_array_index, ARRAY_MAX, 0);
 	uint32_t offsets[ARRAY_MAX];
 	uint32_t strides[ARRAY_MAX];
 	mesh_surface_make_offsets_from_format(p_format, p_vertex_len, p_index_len, offsets, strides);
@@ -855,6 +856,7 @@ uint32_t VisualServer::mesh_surface_get_format_offset(uint32_t p_format, int p_v
 }
 
 uint32_t VisualServer::mesh_surface_get_format_stride(uint32_t p_format, int p_vertex_len, int p_index_len, int p_array_index) const {
+	ERR_FAIL_INDEX_V(p_array_index, ARRAY_MAX, 0);
 	uint32_t offsets[ARRAY_MAX];
 	uint32_t strides[ARRAY_MAX];
 	mesh_surface_make_offsets_from_format(p_format, p_vertex_len, p_index_len, offsets, strides);


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

PR for [#60114](https://github.com/godotengine/godot/issues/60114) - currently it just prints an error message to the debugger and continues on. Tested with the example code provided by qarmin, but let me know if there's anything else I need to do (or should do instead). Thanks!