### PR TITLE
Fixed wrong init value of root motion rotation

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -999,7 +999,7 @@ void AnimationTree::_process_graph(double p_delta) {
 							if (t->process_pass != process_pass) {
 								t->process_pass = process_pass;
 								t->loc = Vector3(0, 0, 0);
-								t->rot = Quaternion(0, 0, 0, 0);
+								t->rot = Quaternion(0, 0, 0, 1);
 								t->scale = Vector3(0, 0, 0);
 							}
 							double prev_time = time - delta;
@@ -1095,7 +1095,7 @@ void AnimationTree::_process_graph(double p_delta) {
 							if (t->process_pass != process_pass) {
 								t->process_pass = process_pass;
 								t->loc = Vector3(0, 0, 0);
-								t->rot = Quaternion(0, 0, 0, 0);
+								t->rot = Quaternion(0, 0, 0, 1);
 								t->scale = Vector3(0, 0, 0);
 							}
 							double prev_time = time - delta;
@@ -1191,7 +1191,7 @@ void AnimationTree::_process_graph(double p_delta) {
 							if (t->process_pass != process_pass) {
 								t->process_pass = process_pass;
 								t->loc = Vector3(0, 0, 0);
-								t->rot = Quaternion(0, 0, 0, 0);
+								t->rot = Quaternion(0, 0, 0, 1);
 								t->scale = Vector3(0, 0, 0);
 							}
 							double prev_time = time - delta;


### PR DESCRIPTION
Sorry, self follow up in #60308.

Since rot is no longer a log space, the initial value of w must be 1.