### PR TITLE
Fix NaN comparision that leads to an infinite loop

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -277,7 +277,17 @@ void Control::_update_minimum_size() {
 	Size2 minsize = get_combined_minimum_size();
 	data.updating_last_minimum_size = false;
 
-	if (minsize != data.last_minimum_size) {
+	bool x_equal = minsize.x == data.last_minimum_size.x;
+	bool y_equal = minsize.y == data.last_minimum_size.y;
+
+	if (isnan(minsize.x) && isnan(data.last_minimum_size.x)) {
+		x_equal = true;
+	}
+	if (isnan(minsize.y) && isnan(data.last_minimum_size.y)) {
+		y_equal = true;
+	}
+
+	if (!x_equal || !y_equal) {
 		data.last_minimum_size = minsize;
 		_size_changed();
 		emit_signal(SceneStringNames::get_singleton()->minimum_size_changed);

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -172,6 +172,9 @@ void Control::set_custom_minimum_size(const Size2 &p_custom) {
 	if (p_custom == data.custom_minimum_size) {
 		return;
 	}
+	if (isnan(p_custom.x) || isnan(p_custom.y)) {
+		return;
+	}
 	data.custom_minimum_size = p_custom;
 	minimum_size_changed();
 }
@@ -277,17 +280,7 @@ void Control::_update_minimum_size() {
 	Size2 minsize = get_combined_minimum_size();
 	data.updating_last_minimum_size = false;
 
-	bool x_equal = minsize.x == data.last_minimum_size.x;
-	bool y_equal = minsize.y == data.last_minimum_size.y;
-
-	if (isnan(minsize.x) && isnan(data.last_minimum_size.x)) {
-		x_equal = true;
-	}
-	if (isnan(minsize.y) && isnan(data.last_minimum_size.y)) {
-		y_equal = true;
-	}
-
-	if (!x_equal || !y_equal) {
+	if (minsize != data.last_minimum_size) {
 		data.last_minimum_size = minsize;
 		_size_changed();
 		emit_signal(SceneStringNames::get_singleton()->minimum_size_changed);


### PR DESCRIPTION
Solves #60326 
Added the check so that `Control::_update_minimum_size()` can run to completion when `minsize` is set to `NaN`.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
