### PR TITLE
[3.x] Fix incorrect notifications for MOUSE_ENTER/EXIT

### DIFF
--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2144,6 +2144,18 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 			over = _gui_find_control(mpos);
 		}
 
+		if (over != gui.mouse_over) {
+			_drop_mouse_over();
+
+			_gui_cancel_tooltip();
+
+			if (over) {
+				_gui_call_notification(over, Control::NOTIFICATION_MOUSE_ENTER);
+			}
+		}
+
+		gui.mouse_over = over;
+
 		if (gui.drag_data.get_type() == Variant::NIL && over && !gui.modal_stack.empty()) {
 			Control *top = gui.modal_stack.back()->get();
 
@@ -2179,18 +2191,6 @@ void Viewport::_gui_input_event(Ref<InputEvent> p_event) {
 				}
 			}
 		}
-
-		if (over != gui.mouse_over) {
-			_drop_mouse_over();
-
-			_gui_cancel_tooltip();
-
-			if (over) {
-				_gui_call_notification(over, Control::NOTIFICATION_MOUSE_ENTER);
-			}
-		}
-
-		gui.mouse_over = over;
 
 		Control *drag_preview = _gui_get_drag_preview();
 		if (drag_preview) {


### PR DESCRIPTION
Solves #60328 

`over = nullptr` (line 2178) incorrectly triggers the condition `if (over != gui.mouse_over)` (line 2183) otherwise.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
