### PR TITLE
Fix CPUParticles emission updating using physics interpolation

### DIFF
--- a/scene/3d/cpu_particles.h
+++ b/scene/3d/cpu_particles.h
@@ -212,6 +212,7 @@ private:
 	void _update_render_thread();
 
 	void _set_redraw(bool p_redraw);
+	void _set_particles_processing(bool p_enable);
 	void _refresh_interpolation_state();
 
 	void _fill_particle_data(const ParticleBase &p_source, float *r_dest, bool p_active) const {


### PR DESCRIPTION
When switching emission on and off, processing was always being switched on and off using internal_process, which was incorrect for using physics interpolation (where physics_process is the relevant one).

This PR correctly updates the process mode according to whether physics interpolation is being used.

Fixes bug mentioned by @mackatap in #52846 .

## Notes
* This is something I missed due to just testing with continuous emission. The on / off emission mechanisms were historically only doing this with `internal_process`, but they have to do this with `internal_physics_process` when interpolation is enabled.
* Also sets the initial processing state to on or off depending on the `emission` flag, rather than always setting processing to on at start, which is probably more correct for starting a `CPUParticles` in a non-emitting state.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
