### PR TITLE
Fixed rotated RootMotionView grid glitch

### DIFF
--- a/scene/animation/root_motion_view.cpp
+++ b/scene/animation/root_motion_view.cpp
@@ -114,9 +114,8 @@ void RootMotionView::_notification(int p_what) {
 			first = false;
 
 			transform.orthonormalize(); //don't want scale, too imprecise
-			transform.affine_invert();
 
-			accumulated = transform * accumulated;
+			accumulated = accumulated * transform;
 			accumulated.origin.x = Math::fposmod(accumulated.origin.x, cell_size);
 			if (zero_y) {
 				accumulated.origin.y = 0;
@@ -134,9 +133,9 @@ void RootMotionView::_notification(int p_what) {
 					Vector3 from(i * cell_size, 0, j * cell_size);
 					Vector3 from_i((i + 1) * cell_size, 0, j * cell_size);
 					Vector3 from_j(i * cell_size, 0, (j + 1) * cell_size);
-					from = accumulated.xform(from);
-					from_i = accumulated.xform(from_i);
-					from_j = accumulated.xform(from_j);
+					from = accumulated.xform_inv(from);
+					from_i = accumulated.xform_inv(from_i);
+					from_j = accumulated.xform_inv(from_j);
 
 					Color c = color, c_i = color, c_j = color;
 					c.a *= MAX(0, 1.0 - from.length() / radius);


### PR DESCRIPTION
Fixed #60342. It should be `fposmod()` in normal space, not in inverted space.

Before:

https://user-images.githubusercontent.com/61938263/165081164-2d79d39c-c341-4937-9de0-d6e379ea4b89.mov

After:

https://user-images.githubusercontent.com/61938263/165081251-e05b22a2-9177-4e7f-8dab-01aa7b4ce7c7.mov

[turn_rotation_root.zip](https://github.com/godotengine/godot/files/8554105/turn_rotation_root.zip)
