### PR TITLE
Allow compiling editor with `target=release` for aggressive optimization

### DIFF
--- a/.github/workflows/linux_builds.yml
+++ b/.github/workflows/linux_builds.yml
@@ -26,7 +26,7 @@ jobs:
             tests: false # Disabled due freeze caused by mix Mono build and CI
             sconsflags: module_mono_enabled=yes mono_static=yes mono_glue=no
             doc-test: true
-            bin: "./bin/godot.linuxbsd.opt.tools.64.mono"
+            bin: "./bin/godot.linuxbsd.opt.debug.tools.64.mono"
             build-mono: true
             proj-conv: true
             artifact: true

--- a/.github/workflows/macos_builds.yml
+++ b/.github/workflows/macos_builds.yml
@@ -24,7 +24,7 @@ jobs:
             target: release_debug
             tools: true
             tests: true
-            bin: "./bin/godot.osx.opt.tools.64"
+            bin: "./bin/godot.osx.opt.debug.tools.64"
 
           - name: Template (target=release, tools=no)
             cache-name: macos-template

--- a/.github/workflows/windows_builds.yml
+++ b/.github/workflows/windows_builds.yml
@@ -29,7 +29,7 @@ jobs:
             tests: true
             # Skip debug symbols, they're way too big with MSVC.
             sconsflags: debug_symbols=no
-            bin: "./bin/godot.windows.opt.tools.64.exe"
+            bin: "./bin/godot.windows.opt.debug.tools.64.exe"
 
           - name: Template (target=release, tools=no)
             cache-name: windows-template

--- a/SConstruct
+++ b/SConstruct
@@ -356,7 +356,11 @@ env_base.platform_exporters = platform_exporters
 env_base.platform_apis = platform_apis
 
 # Build type defines - more platform-specific ones can be in detect.py.
-if env_base["target"] == "release_debug" or env_base["target"] == "debug":
+if (
+    (env_base["tools"] and env_base["target"] == "release")
+    or env_base["target"] == "release_debug"
+    or env_base["target"] == "debug"
+):
     # DEBUG_ENABLED enables debugging *features* and debug-only code, which is intended
     # to give *users* extra debugging information for their game development.
     env_base.Append(CPPDEFINES=["DEBUG_ENABLED"])
@@ -632,14 +636,16 @@ if selected_platform in platform_list:
 
     if env["target"] == "release":
         if env["tools"]:
-            print("ERROR: The editor can only be built with `target=debug` or `target=release_debug`.")
-            print("       Use `tools=no target=release` to build a release export template.")
-            Exit(255)
-        suffix += ".opt"
-        env.Append(CPPDEFINES=["NDEBUG"])
+            suffix += ".opt.tools"
+        else:
+            suffix += ".opt"
+            # Debugging functionality is required for editor builds.
+            # `target=release` will still use more aggressive optimization compared to `target=release_debug`,
+            # but the optimization won't be as aggressive as in non-editor builds.
+            env.Append(CPPDEFINES=["NDEBUG"])
     elif env["target"] == "release_debug":
         if env["tools"]:
-            suffix += ".opt.tools"
+            suffix += ".opt.debug.tools"
         else:
             suffix += ".opt.debug"
     else:

--- a/methods.py
+++ b/methods.py
@@ -652,7 +652,7 @@ def generate_vs_project(env, num_jobs):
             PLATFORMS = ["Win32", "x64"]
             PLATFORM_IDS = ["32", "64"]
             CONFIGURATIONS = ["debug", "release", "release_debug"]
-            CONFIGURATION_IDS = ["tools", "opt", "opt.tools"]
+            CONFIGURATION_IDS = ["tools", "opt", "opt.debug.tools"]
 
             @staticmethod
             def for_every_variant(value):

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -169,12 +169,6 @@ def templateExcludedBuildTask() {
         logger.lifecycle("Excluding Android studio build tasks")
         for (String flavor : supportedFlavors) {
             for (String buildType : supportedTargetsMap.keySet()) {
-                if (buildType == "release" && flavor == "editor") {
-                    // The editor can't be used with target=release as debugging tools are then not
-                    // included, and it would crash on errors instead of reporting them.
-                    continue
-                }
-
                 for (String abi : selectedAbis) {
                     excludedTasks += ":lib:" + getSconsTaskName(flavor, buildType, abi)
                 }
@@ -214,11 +208,18 @@ def isAndroidStudio() {
     return sysProps != null && sysProps['idea.platform.prefix'] != null
 }
 
+task copyEditorReleaseBinaryToBin(type: Copy) {
+    dependsOn ':editor:assembleRelease'
+    from('editor/build/outputs/apk/release')
+    into(binDir)
+    include('android_editor_release.apk')
+}
+
 task copyEditorDebugBinaryToBin(type: Copy) {
     dependsOn ':editor:assembleDebug'
     from('editor/build/outputs/apk/debug')
     into(binDir)
-    include('android_editor.apk')
+    include('android_editor_debug.apk')
 }
 
 task copyEditorDevBinaryToBin(type: Copy) {
@@ -241,11 +242,6 @@ task generateGodotEditor {
     def tasks = []
 
     for (String target : supportedTargetsMap.keySet()) {
-        if (target == "release") {
-            // The editor can't be used with target=release as debugging tools are then not
-            // included, and it would crash on errors instead of reporting them.
-            continue
-        }
         File targetLibs = new File("lib/libs/tools/" + target)
         if (targetLibs != null
             && targetLibs.isDirectory()
@@ -295,7 +291,8 @@ task cleanGodotEditor(type: Delete) {
     delete("editor/build/outputs/apk")
 
     // Delete the Godot editor apks in the Godot bin directory
-    delete("$binDir/android_editor.apk")
+    delete("$binDir/android_editor_release.apk")
+    delete("$binDir/android_editor_debug.apk")
     delete("$binDir/android_editor_dev.apk")
 
     finalizedBy getTasksByName("clean", true)

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -44,16 +44,13 @@ android {
         }
 
         debug {
-            initWith release
-
             // Need to swap with the release signing config when this is ready for public release.
             signingConfig signingConfigs.debug
+            applicationIdSuffix ".debug"
         }
 
         release {
-            // This buildtype is disabled below.
-            // The editor can't be used with target=release only, as debugging tools are then not
-            // included, and it would crash on errors instead of reporting them.
+            initWith release
         }
     }
 
@@ -64,18 +61,9 @@ android {
         }
     }
 
-    // Disable 'release' buildtype.
-    // The editor can't be used with target=release only, as debugging tools are then not
-    // included, and it would crash on errors instead of reporting them.
-    variantFilter { variant ->
-        if (variant.buildType.name == "release") {
-            setIgnore(true)
-        }
-    }
-
     applicationVariants.all { variant ->
         variant.outputs.all { output ->
-            def suffix = variant.name == "dev" ? "_dev" : ""
+            def suffix = "_" + variant.name
             output.outputFileName = "android_editor${suffix}.apk"
         }
     }

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -83,15 +83,7 @@ android {
         // Editor jni library
         editorDebug.jniLibs.srcDirs = ['libs/tools/debug']
         editorDev.jniLibs.srcDirs = ['libs/tools/dev']
-    }
-
-    // Disable 'editorRelease'.
-    // The editor can't be used with target=release as debugging tools are then not
-    // included, and it would crash on errors instead of reporting them.
-    variantFilter { variant ->
-        if (variant.name == "editorRelease") {
-            setIgnore(true)
-        }
+        editorRelease.jniLibs.srcDirs = ['libs/tools/release']
     }
 
     libraryVariants.all { variant ->

--- a/platform/linuxbsd/detect.py
+++ b/platform/linuxbsd/detect.py
@@ -103,6 +103,7 @@ def configure(env):
 
     elif env["target"] == "release_debug":
         if env["optimize"] == "speed":  # optimize for speed (default)
+            # `-O2` is more friendly to debuggers than `-O3`, leading to better crash backtraces.
             env.Prepend(CCFLAGS=["-O2"])
         elif env["optimize"] == "size":  # optimize for size
             env.Prepend(CCFLAGS=["-Os"])

--- a/platform/osx/detect.py
+++ b/platform/osx/detect.py
@@ -86,6 +86,7 @@ def configure(env):
 
     elif env["target"] == "release_debug":
         if env["optimize"] == "speed":  # optimize for speed (default)
+            # `-O2` is more friendly to debuggers than `-O3`, leading to better crash backtraces.
             env.Prepend(CCFLAGS=["-O2"])
         elif env["optimize"] == "size":  # optimize for size
             env.Prepend(CCFLAGS=["-Os"])

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -322,26 +322,23 @@ def configure_mingw(env):
 
     if env["target"] == "release":
         env.Append(CCFLAGS=["-msse2"])
-
         if env["optimize"] == "speed":  # optimize for speed (default)
-            if env["bits"] == "64":
-                env.Append(CCFLAGS=["-O3"])
-            else:
-                env.Append(CCFLAGS=["-O2"])
+            env.Append(CCFLAGS=["-O3"])
         else:  # optimize for size
-            env.Prepend(CCFLAGS=["-Os"])
+            env.Append(CCFLAGS=["-Os"])
 
         if env["debug_symbols"]:
-            env.Prepend(CCFLAGS=["-g2"])
+            env.Append(CCFLAGS=["-g2"])
 
     elif env["target"] == "release_debug":
-        env.Append(CCFLAGS=["-O2"])
-        if env["debug_symbols"]:
-            env.Prepend(CCFLAGS=["-g2"])
         if env["optimize"] == "speed":  # optimize for speed (default)
+            # `-O2` is more friendly to debuggers than `-O3`, leading to better crash backtraces.
             env.Append(CCFLAGS=["-O2"])
         else:  # optimize for size
-            env.Prepend(CCFLAGS=["-Os"])
+            env.Append(CCFLAGS=["-Os"])
+
+        if env["debug_symbols"]:
+            env.Append(CCFLAGS=["-g2"])
 
     elif env["target"] == "debug":
         env.Append(CCFLAGS=["-g3"])


### PR DESCRIPTION
This keeps the required debug functionality enabled, but `-O3` is used instead of `-O2`.

The resulting binary is a few megabytes larger, but there are non-negligible run-time performance gains, including editor startup and shutdown speeds.

**Note: Binaries compiled with `tools=yes target=release_debug` will now use `.opt.debug.tools` suffix instead of `.opt.tools`. `tools=yes target=release` will use `.opt.tools` as before. Adjust your build/CI scripts accordingly.**

## Benchmark

### Time to open and quit project manager

#### Without link-time optimization

```yaml
❯ hyperfine -iw1 "bin/godot.linuxbsd.opt.tools.64 --quit" "bin/godot.linuxbsd.opt.debug.tools.64 --quit" 
Benchmark #1: bin/godot.linuxbsd.opt.tools.64 --quit
  Time (mean ± σ):      1.035 s ±  0.030 s    [User: 835.1 ms, System: 158.0 ms]
  Range (min … max):    1.010 s …  1.086 s    10 runs
 
Benchmark #2: bin/godot.linuxbsd.opt.debug.tools.64 --quit
  Time (mean ± σ):      1.082 s ±  0.023 s    [User: 873.1 ms, System: 156.3 ms]
  Range (min … max):    1.058 s …  1.120 s    10 runs
 
Summary
  'bin/godot.linuxbsd.opt.tools.64 --quit' ran
    1.04 ± 0.04 times faster than 'bin/godot.linuxbsd.opt.debug.tools.64 --quit'
```

#### With link-time optimization

```yaml
❯ hyperfine -iw1 "bin/godot.linuxbsd.opt.tools.64 --quit" "bin/godot.linuxbsd.opt.debug.tools.64 --quit" 
Benchmark #1: bin/godot.linuxbsd.opt.tools.64 --quit
  Time (mean ± σ):      1.077 s ±  0.039 s    [User: 858.8 ms, System: 163.1 ms]
  Range (min … max):    1.034 s …  1.127 s    10 runs
 
Benchmark #2: bin/godot.linuxbsd.opt.debug.tools.64 --quit
  Time (mean ± σ):      1.109 s ±  0.018 s    [User: 882.2 ms, System: 167.3 ms]
  Range (min … max):    1.080 s …  1.130 s    10 runs
 
Summary
  'bin/godot.linuxbsd.opt.tools.64 --quit' ran
    1.03 ± 0.04 times faster than 'bin/godot.linuxbsd.opt.debug.tools.64 --quit'
```

### Time to open and quit editor on empty project

#### Without link-time optimization

```yaml
❯ hyperfine -iw1 "bin/godot.linuxbsd.opt.tools.64 /tmp/4/project.godot --quit" "bin/godot.linuxbsd.opt.debug.tools.64 /tmp/4/project.godot --quit"
Benchmark #1: bin/godot.linuxbsd.opt.tools.64 /tmp/4/project.godot --quit
  Time (mean ± σ):      3.442 s ±  0.371 s    [User: 2.358 s, System: 0.256 s]
  Range (min … max):    3.141 s …  3.918 s    10 runs
 
Benchmark #2: bin/godot.linuxbsd.opt.debug.tools.64 /tmp/4/project.godot --quit
  Time (mean ± σ):      3.675 s ±  0.448 s    [User: 2.447 s, System: 0.275 s]
  Range (min … max):    3.032 s …  4.243 s    10 runs
 
Summary
  'bin/godot.linuxbsd.opt.tools.64 /tmp/4/project.godot --quit' ran
    1.07 ± 0.17 times faster than 'bin/godot.linuxbsd.opt.debug.tools.64 /tmp/4/project.godot --quit'
```

#### With link-time optimization

```yaml
❯ hyperfine -iw1 "bin/godot.linuxbsd.opt.tools.64 /tmp/4/project.godot --quit" "bin/godot.linuxbsd.opt.debug.tools.64 /tmp/4/project.godot --quit"
Benchmark #1: bin/godot.linuxbsd.opt.tools.64 /tmp/4/project.godot --quit
  Time (mean ± σ):      3.674 s ±  0.427 s    [User: 2.383 s, System: 0.300 s]
  Range (min … max):    2.989 s …  3.996 s    10 runs
 
Benchmark #2: bin/godot.linuxbsd.opt.debug.tools.64 /tmp/4/project.godot --quit
  Time (mean ± σ):      3.686 s ±  0.441 s    [User: 2.421 s, System: 0.292 s]
  Range (min … max):    3.090 s …  4.289 s    10 runs
 
Summary
  'bin/godot.linuxbsd.opt.tools.64 /tmp/4/project.godot --quit' ran
    1.00 ± 0.17 times faster than 'bin/godot.linuxbsd.opt.debug.tools.64 /tmp/4/project.godot --quit'
```

## Editor binary size comparison (after running `strip`)

### Without link-time optimization

- `tools=yes target=release_debug`: 107,600,752 bytes
- `tools=yes target=release`: 114,576,240 bytes

### With link-time optimization

- `tools=yes target=release_debug`: 105,827,256 bytes
- `tools=yes target=release`: 108,252,144 bytes