### PR TITLE
Add core types enums description to extension api json

### DIFF
--- a/core/extension/extension_api_dump.cpp
+++ b/core/extension/extension_api_dump.cpp
@@ -474,6 +474,38 @@ Dictionary NativeExtensionAPIDump::generate_extension_api() {
 				}
 			}
 			{
+				//enums
+				Array enums;
+
+				List<StringName> enum_names;
+				Variant::get_enums_for_type(type, &enum_names);
+				for (const StringName &enum_name : enum_names) {
+					Dictionary enum_dict;
+					enum_dict["name"] = String(enum_name);
+
+					List<StringName> enumeration_names;
+					Variant::get_enumerations_for_enum(type, enum_name, &enumeration_names);
+
+					Array values;
+
+					for (const StringName &enumeration : enumeration_names) {
+						Dictionary values_dict;
+						values_dict["name"] = String(enumeration);
+						values_dict["value"] = Variant::get_enum_value(type, enum_name, enumeration);
+						values.push_back(values_dict);
+					}
+
+					if (values.size()) {
+						enum_dict["values"] = values;
+					}
+					enums.push_back(enum_dict);
+				}
+
+				if (enums.size()) {
+					d["enums"] = enums;
+				}
+			}
+			{
 				//operators
 				Array operators;
 

--- a/core/variant/variant.h
+++ b/core/variant/variant.h
@@ -716,6 +716,10 @@ public:
 	static bool has_constant(Variant::Type p_type, const StringName &p_value);
 	static Variant get_constant_value(Variant::Type p_type, const StringName &p_value, bool *r_valid = nullptr);
 
+	static void get_enums_for_type(Variant::Type p_type, List<StringName> *p_enums);
+	static void get_enumerations_for_enum(Variant::Type p_type, StringName p_enum_name, List<StringName> *p_enumerations);
+	static int get_enum_value(Variant::Type p_type, StringName p_enum_name, StringName p_enumeration, bool *r_valid = nullptr);
+
 	typedef String (*ObjectDeConstruct)(const Variant &p_object, void *ud);
 	typedef void (*ObjectConstruct)(const String &p_text, void *ud, Variant &r_value);
 


### PR DESCRIPTION
This adds description of core types enums to extension api json.  
Enums are described the same way as global and common classes enums.  
