### PR TITLE
Increase compiler optimization when using `target=release` on iOS/Android

### DIFF
--- a/platform/android/detect.py
+++ b/platform/android/detect.py
@@ -188,8 +188,11 @@ def configure(env):
 
     if env["target"].startswith("release"):
         if env["optimize"] == "speed":  # optimize for speed (default)
-            env.Append(LINKFLAGS=["-O2"])
-            env.Append(CCFLAGS=["-O2", "-fomit-frame-pointer"])
+            # `-O2` is more friendly to debuggers than `-O3`, leading to better crash backtraces
+            # when using `target=release_debug`.
+            opt = "-O3" if env["target"] == "release" else "-O2"
+            env.Append(LINKFLAGS=[opt])
+            env.Append(CCFLAGS=[opt, "-fomit-frame-pointer"])
         elif env["optimize"] == "size":  # optimize for size
             env.Append(CCFLAGS=["-Os"])
             env.Append(LINKFLAGS=["-Os"])

--- a/platform/iphone/detect.py
+++ b/platform/iphone/detect.py
@@ -47,8 +47,11 @@ def configure(env):
     if env["target"].startswith("release"):
         env.Append(CPPDEFINES=["NDEBUG", ("NS_BLOCK_ASSERTIONS", 1)])
         if env["optimize"] == "speed":  # optimize for speed (default)
-            env.Append(CCFLAGS=["-O2", "-ftree-vectorize", "-fomit-frame-pointer"])
-            env.Append(LINKFLAGS=["-O2"])
+            # `-O2` is more friendly to debuggers than `-O3`, leading to better crash backtraces
+            # when using `target=release_debug`.
+            opt = "-O3" if env["target"] == "release" else "-O2"
+            env.Append(CCFLAGS=[opt, "-ftree-vectorize", "-fomit-frame-pointer"])
+            env.Append(LINKFLAGS=[opt])
         elif env["optimize"] == "size":  # optimize for size
             env.Append(CCFLAGS=["-Os", "-ftree-vectorize"])
             env.Append(LINKFLAGS=["-Os"])


### PR DESCRIPTION
This improves performance on projects exported in release mode on iOS and Android, at the cost of slightly increased binary sizes.

Note that this may not be safe to cherry-pick to `3.x` on iOS (assuming the bug mentioned in https://github.com/godotengine/godot-proposals/issues/1987 was fixed in the GDScript rewrite in `master`).