### PR TITLE
Use ThreadWorkPool instead of thread_process_array in NavMap

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -30,7 +30,6 @@
 
 #include "nav_map.h"
 
-#include "core/os/threaded_array_processor.h"
 #include "nav_region.h"
 #include "rvo_agent.h"
 
@@ -674,7 +673,7 @@ void NavMap::compute_single_step(uint32_t index, RvoAgent **agent) {
 void NavMap::step(real_t p_deltatime) {
 	deltatime = p_deltatime;
 	if (controlled_agents.size() > 0) {
-		thread_process_array(
+		step_work_pool.do_work(
 				controlled_agents.size(),
 				this,
 				&NavMap::compute_single_step,
@@ -718,4 +717,12 @@ void NavMap::clip_path(const std::vector<gd::NavigationPoly> &p_navigation_polys
 			}
 		}
 	}
+}
+
+NavMap::NavMap() {
+	step_work_pool.init();
+}
+
+NavMap::~NavMap() {
+	step_work_pool.finish();
 }

--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -35,6 +35,7 @@
 
 #include "core/math/math_defs.h"
 #include "core/templates/map.h"
+#include "core/templates/thread_work_pool.h"
 #include "nav_utils.h"
 
 #include <KdTree.h>
@@ -80,8 +81,12 @@ class NavMap : public NavRid {
 	/// Change the id each time the map is updated.
 	uint32_t map_update_id = 0;
 
+	/// Pooled threads for computing steps
+	ThreadWorkPool step_work_pool;
+
 public:
-	NavMap() {}
+	NavMap();
+	~NavMap();
 
 	void set_up(Vector3 p_up);
 	Vector3 get_up() const {


### PR DESCRIPTION
**4.0 PR of #60366**

Following the investigations made by @lethiandev for issue #56838 about the performances of `thread_process_array` on Windows, I found out that NavMap was the only instance using this method in 4.0. So, I tried to use the new `ThreadWorkPool` to pool the threads instead of creating new ones each NavMap step.

As a benchmark, I used the minimal reproduction project of issue #60068 made by macryc. [4-navi-bug.zip](https://github.com/godotengine/godot/files/8507888/4-navi-bug.zip)

**Godot 4 alpha 6 (using `thread_process_array`), over 15 minutes, VSYNC disabled (Windows 10)**
![Capture d’écran 2022-04-18 153700](https://user-images.githubusercontent.com/270928/163869161-6a215ae7-e8fc-4c5f-9cce-40625d5fdbc1.png)

**Godot 4 alpha [master] (using `thread_process_array`), over 15 minutes, VSYNC disabled (Windows 10)**
![Capture d’écran 2022-04-18 162340](https://user-images.githubusercontent.com/270928/163872200-9da03dfc-5539-4a21-ae02-4208a7a1736a.png)

**Godot 4 alpha [master] (using `ThreadWorkPool`), over 15 minutes, VSYNC disabled (Windows 10)**
![Capture d’écran 2022-04-18 155441](https://user-images.githubusercontent.com/270928/163869168-b9363eff-9bd7-4cbb-a68f-8d046e3bd4ab.png)

Even if the use of `thread_process_array` in 4.0 does not seem to impact performances as much as suspected for 3.x, the performance gain of pooling threads seems apparent.

~Unfortunately, cherry-picking for 3.x will be difficult, as `ThreadWorkPool` does not exist. Is there a way to backport the template?~ Backport done in PR #60366. Along with it, should fix #50448 and should fix #56838, but more testing needs to be done.