### PR TITLE
Use ThreadWorkPool instead of thread_process_array in NavMap [3.x]

### DIFF
--- a/core/os/os.h
+++ b/core/os/os.h
@@ -528,6 +528,7 @@ public:
 
 	virtual int get_processor_count() const;
 	virtual String get_processor_name() const;
+	virtual int get_default_thread_pool_size() const { return get_processor_count(); }
 
 	virtual String get_unique_id() const;
 

--- a/core/os/thread_work_pool.cpp
+++ b/core/os/thread_work_pool.cpp
@@ -1,0 +1,81 @@
+/*************************************************************************/
+/*  thread_work_pool.cpp                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "thread_work_pool.h"
+
+#include "core/os/os.h"
+
+void ThreadWorkPool::_thread_function(void *p_user) {
+	ThreadData *thread = static_cast<ThreadData *>(p_user);
+	while (true) {
+		thread->start.wait();
+		if (thread->exit.load()) {
+			break;
+		}
+		thread->work->work();
+		thread->completed.post();
+	}
+}
+
+void ThreadWorkPool::init(int p_thread_count) {
+	ERR_FAIL_COND(threads != nullptr);
+	if (p_thread_count < 0) {
+		p_thread_count = OS::get_singleton()->get_default_thread_pool_size();
+	}
+
+	thread_count = p_thread_count;
+	threads = memnew_arr(ThreadData, thread_count);
+
+	for (uint32_t i = 0; i < thread_count; i++) {
+		threads[i].exit.store(false);
+		threads[i].thread.start(&ThreadWorkPool::_thread_function, &threads[i]);
+	}
+}
+
+void ThreadWorkPool::finish() {
+	if (threads == nullptr) {
+		return;
+	}
+
+	for (uint32_t i = 0; i < thread_count; i++) {
+		threads[i].exit.store(true);
+		threads[i].start.post();
+	}
+	for (uint32_t i = 0; i < thread_count; i++) {
+		threads[i].thread.wait_to_finish();
+	}
+
+	memdelete_arr(threads);
+	threads = nullptr;
+}
+
+ThreadWorkPool::~ThreadWorkPool() {
+	finish();
+}

--- a/core/os/thread_work_pool.h
+++ b/core/os/thread_work_pool.h
@@ -1,0 +1,157 @@
+/*************************************************************************/
+/*  thread_work_pool.h                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef THREAD_WORK_POOL_H
+#define THREAD_WORK_POOL_H
+
+#include "core/os/memory.h"
+#include "core/os/semaphore.h"
+#include "core/os/thread.h"
+
+#include <atomic>
+
+class ThreadWorkPool {
+	std::atomic<uint32_t> index;
+
+	struct BaseWork {
+		std::atomic<uint32_t> *index = nullptr;
+		uint32_t max_elements = 0;
+		virtual void work() = 0;
+		virtual ~BaseWork() = default;
+	};
+
+	template <class C, class M, class U>
+	struct Work : public BaseWork {
+		C *instance;
+		M method;
+		U userdata;
+		virtual void work() override {
+			while (true) {
+				uint32_t work_index = index->fetch_add(1, std::memory_order_relaxed);
+				if (work_index >= max_elements) {
+					break;
+				}
+				(instance->*method)(work_index, userdata);
+			}
+		}
+	};
+
+	struct ThreadData {
+		Thread thread;
+		Semaphore start;
+		Semaphore completed;
+		std::atomic<bool> exit;
+		BaseWork *work = nullptr;
+	};
+
+	ThreadData *threads = nullptr;
+	uint32_t thread_count = 0;
+	uint32_t threads_working = 0;
+	BaseWork *current_work = nullptr;
+
+	static void _thread_function(void *p_user);
+
+public:
+	template <class C, class M, class U>
+	void begin_work(uint32_t p_elements, C *p_instance, M p_method, U p_userdata) {
+		ERR_FAIL_COND(!threads); //never initialized
+		ERR_FAIL_COND(current_work != nullptr);
+
+		index.store(0, std::memory_order_release);
+
+		Work<C, M, U> *w = memnew((Work<C, M, U>));
+		w->instance = p_instance;
+		w->userdata = p_userdata;
+		w->method = p_method;
+		w->index = &index;
+		w->max_elements = p_elements;
+
+		current_work = w;
+
+		threads_working = MIN(p_elements, thread_count);
+
+		for (uint32_t i = 0; i < threads_working; i++) {
+			threads[i].work = w;
+			threads[i].start.post();
+		}
+	}
+
+	bool is_working() const {
+		return current_work != nullptr;
+	}
+
+	bool is_done_dispatching() const {
+		ERR_FAIL_COND_V(current_work == nullptr, true);
+		return index.load(std::memory_order_acquire) >= current_work->max_elements;
+	}
+
+	uint32_t get_work_index() const {
+		ERR_FAIL_COND_V(current_work == nullptr, 0);
+		uint32_t idx = index.load(std::memory_order_acquire);
+		return MIN(idx, current_work->max_elements);
+	}
+
+	void end_work() {
+		ERR_FAIL_COND(current_work == nullptr);
+		for (uint32_t i = 0; i < threads_working; i++) {
+			threads[i].completed.wait();
+			threads[i].work = nullptr;
+		}
+
+		threads_working = 0;
+		memdelete(current_work);
+		current_work = nullptr;
+	}
+
+	template <class C, class M, class U>
+	void do_work(uint32_t p_elements, C *p_instance, M p_method, U p_userdata) {
+		switch (p_elements) {
+			case 0:
+				// Nothing to do, so do nothing.
+				break;
+			case 1:
+				// No value in pushing the work to another thread if it's a single job
+				// and we're going to wait for it to finish. Just run it right here.
+				(p_instance->*p_method)(0, p_userdata);
+				break;
+			default:
+				// Multiple jobs to do; commence threaded business.
+				begin_work(p_elements, p_instance, p_method, p_userdata);
+				end_work();
+		}
+	}
+
+	_FORCE_INLINE_ int get_thread_count() const { return thread_count; }
+	void init(int p_thread_count = -1);
+	void finish();
+	~ThreadWorkPool();
+};
+
+#endif // THREAD_POOL_H

--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -34,6 +34,7 @@
 #include "nav_rid.h"
 
 #include "core/math/math_defs.h"
+#include "core/os/thread_work_pool.h"
 #include "nav_utils.h"
 #include <KdTree.h>
 
@@ -83,8 +84,12 @@ class NavMap : public NavRid {
 	/// Change the id each time the map is updated.
 	uint32_t map_update_id;
 
+	/// Pooled threads for computing steps
+	ThreadWorkPool step_work_pool;
+
 public:
 	NavMap();
+	~NavMap();
 
 	void set_up(Vector3 p_up);
 	Vector3 get_up() const {


### PR DESCRIPTION
**3.x PR of #60359**

Finally, porting PR #60359 to 3.x was easier than anticipated. All because `core/templates/thread_work_pool.{h, cpp}` was easily ported (only required some copy and paste).

Note. This PR seems to work, but I do not know if I broke some rules, as `core/templates` didn't already exist.

As a benchmark, I used the minimal reproduction project of issue #56838 made by thoced. 
[NavigationAgentTest.zip](https://github.com/godotengine/godot/files/8509831/NavigationAgentTest.zip)

**Godot 3.x [master] (using `thread_process_array`), first minute, VSYNC disabled (Windows 10)**
![Capture d’écran 2022-04-19 001728](https://user-images.githubusercontent.com/270928/163920494-2840a5ba-ff01-4cad-b46f-8a4ccaf7303d.png)

**Godot 3.x [master] (using `ThreadWorkPool`), first minute, VSYNC disabled (Windows 10)**
![Capture d’écran 2022-04-19 002131](https://user-images.githubusercontent.com/270928/163920532-f90b97c2-4bc7-40db-b51a-400fba13dfc3.png)

As the addition of the new template, this pretty much confirms that a simple cherry-pick of #60359 wouldn't work for 3.x

Along with PR #60359, fixes #56838. But this needs testing.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
