### PR TITLE
Reset refresh countdown if pending update tree request

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3515,7 +3515,9 @@ void EditorInspector::_notification(int p_what) {
 				get_v_scroll_bar()->call_deferred(SNAME("set_value"), update_scroll_request);
 				update_scroll_request = -1;
 			}
-			if (refresh_countdown > 0) {
+			if (update_tree_pending) {
+				refresh_countdown = float(EditorSettings::get_singleton()->get("docks/property_editor/auto_refresh_interval"));
+			} else if (refresh_countdown > 0) {
 				refresh_countdown -= get_process_delta_time();
 				if (refresh_countdown <= 0) {
 					for (const KeyValue<StringName, List<EditorProperty *>> &F : editor_property_map) {


### PR DESCRIPTION
Fixes #60259
Supersedes #60288

An update tree request is pending once the property list changes. Regular property cache update comes before tree update:

* The cache will be rebuilt during tree update, so it's a waste of time to update it first.
* Since the property list is changed, some cached properties may no longer exist at this point in time. For ProjectSettings and EditorSettings objects, checking for nonexistent properties means emitting lots of warnings.

So this PR resets `refresh_countdown` when there is tree update pending.