### PR TITLE
Fix AnimationLibrary name validation

### DIFF
--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -55,17 +55,15 @@ void AnimationLibraryEditor::_add_library_validate(const String &p_name) {
 		ERR_FAIL_COND(al.is_null());
 		if (p_name == "") {
 			error = TTR("Animation name can't be empty.");
-
-		} else if (String(p_name).contains("/") || String(p_name).contains(":") || String(p_name).contains(",") || String(p_name).contains("[")) {
+		} else if (!AnimationLibrary::is_valid_name(p_name)) {
 			error = TTR("Animation name contains invalid characters: '/', ':', ',' or '['.");
 		} else if (al->has_animation(p_name)) {
 			error = TTR("Animation with the same name already exists.");
 		}
-
 	} else {
 		if (p_name == "" && bool(player->call("has_animation_library", ""))) {
 			error = TTR("Enter a library name.");
-		} else if (String(p_name).contains("/") || String(p_name).contains(":") || String(p_name).contains(",") || String(p_name).contains("[")) {
+		} else if (!AnimationLibrary::is_valid_name(p_name)) {
 			error = TTR("Library name contains invalid characters: '/', ':', ',' or '['.");
 		} else if (bool(player->call("has_animation_library", p_name))) {
 			error = TTR("Library with the same name already exists.");
@@ -258,7 +256,7 @@ void AnimationLibraryEditor::_load_file(String p_path) {
 				}
 			}
 
-			String name = p_path.get_file().get_basename();
+			String name = AnimationLibrary::validate_name(p_path.get_file().get_basename());
 
 			int attempt = 1;
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -427,7 +427,7 @@ void AnimationPlayerEditor::_animation_name_edited() {
 	player->stop();
 
 	String new_name = name->get_text();
-	if (new_name.is_empty() || new_name.contains(":") || new_name.contains("/")) {
+	if (!AnimationLibrary::is_valid_name(new_name)) {
 		error_dialog->set_text(TTR("Invalid animation name!"));
 		error_dialog->popup_centered();
 		return;

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -30,8 +30,25 @@
 
 #include "animation_library.h"
 
+bool AnimationLibrary::is_valid_name(const String &p_name) {
+	return !(p_name.is_empty() || p_name.contains("/") || p_name.contains(":") || p_name.contains(",") || p_name.contains("["));
+}
+
+String AnimationLibrary::validate_name(const String &p_name) {
+	if (p_name.is_empty()) {
+		return "_"; // Should always return a valid name.
+	}
+
+	String name = p_name;
+	const char *characters = "/:,[";
+	for (const char *p = characters; *p; p++) {
+		name = name.replace(String::chr(*p), "_");
+	}
+	return name;
+}
+
 Error AnimationLibrary::add_animation(const StringName &p_name, const Ref<Animation> &p_animation) {
-	ERR_FAIL_COND_V_MSG(String(p_name).contains("/") || String(p_name).contains(":") || String(p_name).contains(",") || String(p_name).contains("["), ERR_INVALID_PARAMETER, "Invalid animation name: " + String(p_name) + ".");
+	ERR_FAIL_COND_V_MSG(!is_valid_name(p_name), ERR_INVALID_PARAMETER, "Invalid animation name: '" + String(p_name) + "'.");
 	ERR_FAIL_COND_V(p_animation.is_null(), ERR_INVALID_PARAMETER);
 
 	if (animations.has(p_name)) {
@@ -55,7 +72,7 @@ void AnimationLibrary::remove_animation(const StringName &p_name) {
 
 void AnimationLibrary::rename_animation(const StringName &p_name, const StringName &p_new_name) {
 	ERR_FAIL_COND(!animations.has(p_name));
-	ERR_FAIL_COND_MSG(String(p_new_name).contains("/") || String(p_new_name).contains(":") || String(p_new_name).contains(",") || String(p_new_name).contains("["), "Invalid animation name: " + String(p_new_name) + ".");
+	ERR_FAIL_COND_MSG(!is_valid_name(p_new_name), "Invalid animation name: '" + String(p_new_name) + "'.");
 	ERR_FAIL_COND(animations.has(p_new_name));
 
 	animations.insert(p_new_name, animations[p_name]);

--- a/scene/resources/animation_library.h
+++ b/scene/resources/animation_library.h
@@ -49,6 +49,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	static bool is_valid_name(const String &p_name);
+	static String validate_name(const String &p_name);
+
 	Error add_animation(const StringName &p_name, const Ref<Animation> &p_animation);
 	void remove_animation(const StringName &p_name);
 	void rename_animation(const StringName &p_name, const StringName &p_new_name);


### PR DESCRIPTION
Issues fixed:

1. Empty Animation name is not allowed by editor, but the AnimationLibrary API allows empty Animation names.
2. Renaming in Animation editor allows `,` and `[`, but they are forbidden in AnimationLibrary.
3. When using "Load Library", it automatically uses the file's basename as the library name. The name is not validated, resulting in errors.

This PR adds two static function in `AnimationLibrary`:

* `is_valid_name()` to check for invalid name. So we don't have to repeat forbidden characters everywhere.
* `validate_name()` to turn any string into a valid name by replacing forbidden characters with an underscore.