### PR TITLE
Initialize OpenGL before rasterizers in GLES3

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1471,8 +1471,10 @@ RasterizerCanvasGLES3 *RasterizerCanvasGLES3::get_singleton() {
 	return singleton;
 }
 
-RasterizerCanvasGLES3::RasterizerCanvasGLES3() {
+RasterizerCanvasGLES3::RasterizerCanvasGLES3(RasterizerStorageGLES3 *p_storage) {
 	singleton = this;
+	storage = p_storage;
+	initialize();
 }
 
 RasterizerCanvasGLES3::~RasterizerCanvasGLES3() {

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -219,8 +219,6 @@ public:
 
 	typedef void Texture;
 
-	RasterizerSceneGLES3 *scene_render = nullptr;
-
 	RasterizerStorageGLES3 *storage = nullptr;
 
 	void _set_uniforms();
@@ -279,7 +277,7 @@ public:
 	void finalize();
 
 	static RasterizerCanvasGLES3 *get_singleton();
-	RasterizerCanvasGLES3();
+	RasterizerCanvasGLES3(RasterizerStorageGLES3 *storage);
 	~RasterizerCanvasGLES3();
 };
 

--- a/drivers/gles3/rasterizer_gles3.cpp
+++ b/drivers/gles3/rasterizer_gles3.cpp
@@ -102,10 +102,10 @@ void RasterizerGLES3::begin_frame(double frame_step) {
 	texture_storage->frame.count++;
 	texture_storage->frame.delta = frame_step;
 
-	storage.update_dirty_resources();
+	storage->update_dirty_resources();
 
-	storage.info.render_final = storage.info.render;
-	storage.info.render.reset();
+	storage->info.render_final = storage->info.render;
+	storage->info.render.reset();
 
 	//scene->iteration();
 }
@@ -196,10 +196,14 @@ typedef void (*DEBUGPROCARB)(GLenum source,
 typedef void (*DebugMessageCallbackARB)(DEBUGPROCARB callback, const void *userParam);
 
 void RasterizerGLES3::initialize() {
-	print_verbose("Using OpenGL video driver");
+	print_line("OpenGL Renderer: " + RS::get_singleton()->get_video_adapter_name());
 
-	texture_storage.set_main_thread_id(Thread::get_caller_id());
+	texture_storage->set_main_thread_id(Thread::get_caller_id());
+	// make sure the OS knows to only access the renderer from the main thread
+	OS::get_singleton()->set_render_main_thread_mode(OS::RENDER_MAIN_THREAD_ONLY);
+}
 
+RasterizerGLES3::RasterizerGLES3() {
 #ifdef GLAD_ENABLED
 	if (!gladLoadGL()) {
 		ERR_PRINT("Error initializing GLAD");
@@ -251,21 +255,28 @@ void RasterizerGLES3::initialize() {
 #endif // GLES_OVER_GL
 #endif // CAN_DEBUG
 
-	print_line("OpenGL Renderer: " + RS::get_singleton()->get_video_adapter_name());
-	storage.initialize();
-	canvas.initialize();
-	//	scene.initialize();
-
-	// make sure the OS knows to only access the renderer from the main thread
-	OS::get_singleton()->set_render_main_thread_mode(OS::RENDER_MAIN_THREAD_ONLY);
+	// OpenGL needs to be initialized before initializing the Rasterizers
+	config = memnew(GLES3::Config);
+	texture_storage = memnew(GLES3::TextureStorage);
+	material_storage = memnew(GLES3::MaterialStorage);
+	mesh_storage = memnew(GLES3::MeshStorage);
+	particles_storage = memnew(GLES3::ParticlesStorage);
+	light_storage = memnew(GLES3::LightStorage);
+	storage = memnew(RasterizerStorageGLES3);
+	canvas = memnew(RasterizerCanvasGLES3(storage));
+	scene = memnew(RasterizerSceneGLES3);
 }
 
-RasterizerGLES3::RasterizerGLES3() {
-	canvas.storage = &storage;
-	canvas.scene_render = &scene;
-	//storage.canvas = &canvas;
-	//scene.storage = &storage;
-	//storage.scene = &scene;
+RasterizerGLES3::~RasterizerGLES3() {
+	memdelete(scene);
+	memdelete(canvas);
+	memdelete(storage);
+	memdelete(light_storage);
+	memdelete(particles_storage);
+	memdelete(mesh_storage);
+	memdelete(material_storage);
+	memdelete(texture_storage);
+	memdelete(config);
 }
 
 void RasterizerGLES3::prepare_for_blitting_render_targets() {
@@ -327,12 +338,12 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 	}
 	glClear(GL_COLOR_BUFFER_BIT);
 
-	canvas.canvas_begin();
+	canvas->canvas_begin();
 
-	RID texture = texture_storage.texture_create();
+	RID texture = texture_storage->texture_create();
 	//texture_storage.texture_allocate(texture, p_image->get_width(), p_image->get_height(), 0, p_image->get_format(), VS::TEXTURE_TYPE_2D, p_use_filter ? VS::TEXTURE_FLAG_FILTER : 0);
-	texture_storage._texture_allocate_internal(texture, p_image->get_width(), p_image->get_height(), 0, p_image->get_format(), RenderingDevice::TEXTURE_TYPE_2D);
-	texture_storage.texture_set_data(texture, p_image);
+	texture_storage->_texture_allocate_internal(texture, p_image->get_width(), p_image->get_height(), 0, p_image->get_format(), RenderingDevice::TEXTURE_TYPE_2D);
+	texture_storage->texture_set_data(texture, p_image);
 
 	Rect2 imgrect(0, 0, p_image->get_width(), p_image->get_height());
 	Rect2 screenrect;
@@ -354,13 +365,13 @@ void RasterizerGLES3::set_boot_image(const Ref<Image> &p_image, const Color &p_c
 		screenrect.position += ((Size2(win_size.width, win_size.height) - screenrect.size) / 2.0).floor();
 	}
 
-	GLES3::Texture *t = texture_storage.get_texture(texture);
-	glActiveTexture(GL_TEXTURE0 + config.max_texture_image_units - 1);
+	GLES3::Texture *t = texture_storage->get_texture(texture);
+	glActiveTexture(GL_TEXTURE0 + config->max_texture_image_units - 1);
 	glBindTexture(GL_TEXTURE_2D, t->tex_id);
 	glBindTexture(GL_TEXTURE_2D, 0);
-	canvas.canvas_end();
+	canvas->canvas_end();
 
-	texture_storage.texture_free(texture);
+	texture_storage->texture_free(texture);
 
 	end_frame(true);
 }

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -52,27 +52,27 @@ private:
 	double time_total = 0.0;
 
 protected:
-	GLES3::Config config;
-	GLES3::TextureStorage texture_storage;
-	GLES3::MaterialStorage material_storage;
-	GLES3::MeshStorage mesh_storage;
-	GLES3::ParticlesStorage particles_storage;
-	GLES3::LightStorage light_storage;
-	RasterizerStorageGLES3 storage;
-	RasterizerCanvasGLES3 canvas;
-	RasterizerSceneGLES3 scene;
+	GLES3::Config *config = nullptr;
+	GLES3::TextureStorage *texture_storage = nullptr;
+	GLES3::MaterialStorage *material_storage = nullptr;
+	GLES3::MeshStorage *mesh_storage = nullptr;
+	GLES3::ParticlesStorage *particles_storage = nullptr;
+	GLES3::LightStorage *light_storage = nullptr;
+	RasterizerStorageGLES3 *storage = nullptr;
+	RasterizerCanvasGLES3 *canvas = nullptr;
+	RasterizerSceneGLES3 *scene = nullptr;
 
 	void _blit_render_target_to_screen(RID p_render_target, DisplayServer::WindowID p_screen, const Rect2 &p_screen_rect);
 
 public:
-	RendererLightStorage *get_light_storage() { return &light_storage; }
-	RendererMaterialStorage *get_material_storage() { return &material_storage; }
-	RendererMeshStorage *get_mesh_storage() { return &mesh_storage; }
-	RendererParticlesStorage *get_particles_storage() { return &particles_storage; }
-	RendererTextureStorage *get_texture_storage() { return &texture_storage; }
-	RendererStorage *get_storage() { return &storage; }
-	RendererCanvasRender *get_canvas() { return &canvas; }
-	RendererSceneRender *get_scene() { return &scene; }
+	RendererLightStorage *get_light_storage() { return light_storage; }
+	RendererMaterialStorage *get_material_storage() { return material_storage; }
+	RendererMeshStorage *get_mesh_storage() { return mesh_storage; }
+	RendererParticlesStorage *get_particles_storage() { return particles_storage; }
+	RendererTextureStorage *get_texture_storage() { return texture_storage; }
+	RendererStorage *get_storage() { return storage; }
+	RendererCanvasRender *get_canvas() { return canvas; }
+	RendererSceneRender *get_scene() { return scene; }
 
 	void set_boot_image(const Ref<Image> &p_image, const Color &p_color, bool p_scale, bool p_use_filter = true);
 
@@ -99,7 +99,7 @@ public:
 	double get_frame_delta_time() const { return delta; }
 
 	RasterizerGLES3();
-	~RasterizerGLES3() {}
+	~RasterizerGLES3();
 };
 
 #endif // GLES3_ENABLED

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -651,7 +651,6 @@ RenderingDevice::DeviceType RasterizerStorageGLES3::get_video_adapter_type() con
 
 void RasterizerStorageGLES3::initialize() {
 	config = GLES3::Config::get_singleton();
-	// config->initialize();
 
 	//picky requirements for these
 	config->support_shadow_cubemaps = config->support_depth_texture && config->support_write_depth && config->support_depth_cubemaps;
@@ -824,6 +823,7 @@ void RasterizerStorageGLES3::update_dirty_resources() {
 }
 
 RasterizerStorageGLES3::RasterizerStorageGLES3() {
+	initialize();
 }
 
 RasterizerStorageGLES3::~RasterizerStorageGLES3() {

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -39,18 +39,7 @@ Config *Config::singleton = nullptr;
 
 Config::Config() {
 	singleton = this;
-	should_orphan = true;
 
-	// If this is to early we need to change our code similar to what we're doing in RendererRD,
-	// and instantiate our storage classes when we are ready to do so in the order we want.
-	initialize();
-}
-
-Config::~Config() {
-	singleton = nullptr;
-}
-
-void Config::initialize() {
 	{
 		const GLubyte *extension_string = glGetString(GL_EXTENSIONS);
 
@@ -155,6 +144,10 @@ void Config::initialize() {
 	force_vertex_shading = false; //GLOBAL_GET("rendering/quality/shading/force_vertex_shading");
 	use_fast_texture_filter = false; //GLOBAL_GET("rendering/quality/filters/use_nearest_mipmap_filter");
 	// should_orphan = GLOBAL_GET("rendering/options/api_usage_legacy/orphan_buffers");
+}
+
+Config::~Config() {
+	singleton = nullptr;
 }
 
 #endif // GLES3_ENABLED

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -103,7 +103,6 @@ public:
 
 	Config();
 	~Config();
-	void initialize();
 };
 
 } // namespace GLES3


### PR DESCRIPTION
In the reorganization of the RendererStorage* classes the initialization order changed such that OpenGL function calls were being made before OpenGL was initialized resulting in a crash. 

This PR initializes OpenGL first, and then manually allocates the various rasterizer/storage classes after. In doing so, I switched the rasterizer/storage classes to using pointers to match the behaviour of the RendererRD equivalents. 
