### PR TITLE
[3.x] Sort based on camera position when using perspective camera

### DIFF
--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -3171,7 +3171,11 @@ void VisualServerScene::_prepare_scene(const Transform p_cam_transform, const Ca
 
 		if (((1 << ins->base_type) & VS::INSTANCE_GEOMETRY_MASK) && ins->visible && ins->cast_shadows != VS::SHADOW_CASTING_SETTING_SHADOWS_ONLY) {
 			Vector3 aabb_center = ins->transformed_aabb.position + (ins->transformed_aabb.size * 0.5);
-			ins->depth = near_plane.distance_to(aabb_center);
+			if (p_cam_orthogonal) {
+				ins->depth = near_plane.distance_to(aabb_center);
+			} else {
+				ins->depth = p_cam_transform.origin.distance_to(aabb_center);
+			}
 			ins->depth_layer = CLAMP(int(ins->depth * 16 / z_far), 0, 15);
 		}
 	}


### PR DESCRIPTION
Fixes a sorting bug reported on RocketChat and likely other reported sorting issues.

The core of the problem here is that sorting appeared to be dependant on view angle. This is because Godot is calculating distance based on the distance to the near plane instead of distance to the camera origin. When using a perspective camera, sorting should take place based on distance to the camera origin rather than distance to the camera plane. 

This is a small change with big consequences and needs a lot of testing before being merged. 

A similar change needs to be made in 4.0 as well (likely in multiple places see: #60253)

Here is how it worked in Godot 2 https://github.com/godotengine/godot/blob/820dd1d0016763cda6177104e66e09c8634150be/drivers/gles2/rasterizer_gles2.cpp#L4853-L4857

Here is how it works in Ogre:
https://github.com/OGRECave/ogre/blob/d302dee15b389cb916dfa13b1e4e55cd8cffaa55/OgreMain/src/OgreNode.cpp#L663-L670

The Unity Docs also suggest using the near plane for sorting when using an orthogonal camera and the origin for perspective https://docs.unity3d.com/ScriptReference/Camera-transparencySortMode.html

<details>
  <summary>Drawing of the problem with distance to plane</summary>
  
![Quick sheets](https://user-images.githubusercontent.com/16521339/164114307-e8b0e2d1-157e-4963-ac4c-8456c99d81ff.png)

</details>
