### PR TITLE
Validate input in `NoiseTexture::set_seamless_blend_skirt()`

### DIFF
--- a/modules/noise/noise_texture.cpp
+++ b/modules/noise/noise_texture.cpp
@@ -241,6 +241,8 @@ bool NoiseTexture::get_seamless() {
 }
 
 void NoiseTexture::set_seamless_blend_skirt(real_t p_blend_skirt) {
+	ERR_FAIL_COND(p_blend_skirt < 0.05 || p_blend_skirt > 1);
+
 	if (p_blend_skirt == seamless_blend_skirt) {
 		return;
 	}


### PR DESCRIPTION
Fixes #60373

The range is from the property hint:

https://github.com/godotengine/godot/blob/7f384886ce65fb5deead17a3604a9f0b8917a9ee/modules/noise/noise_texture.cpp#L79