### PR TITLE
Add Gradient resource preview generator

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7084,6 +7084,7 @@ EditorNode::EditorNode() {
 	resource_preview->add_preview_generator(Ref<EditorMeshPreviewPlugin>(memnew(EditorMeshPreviewPlugin)));
 	resource_preview->add_preview_generator(Ref<EditorBitmapPreviewPlugin>(memnew(EditorBitmapPreviewPlugin)));
 	resource_preview->add_preview_generator(Ref<EditorFontPreviewPlugin>(memnew(EditorFontPreviewPlugin)));
+	resource_preview->add_preview_generator(Ref<EditorGradientPreviewPlugin>(memnew(EditorGradientPreviewPlugin)));
 
 	{
 		Ref<StandardMaterial3DConversionPlugin> spatial_mat_convert;

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -90,7 +90,8 @@ void EditorResourcePicker::_update_resource_preview(const String &p_path, const 
 	if (p_preview.is_valid()) {
 		preview_rect->set_offset(SIDE_LEFT, assign_button->get_icon()->get_width() + assign_button->get_theme_stylebox(SNAME("normal"))->get_default_margin(SIDE_LEFT) + get_theme_constant(SNAME("hseparation"), SNAME("Button")));
 
-		if (Ref<GradientTexture1D>(edited_resource).is_valid()) {
+		// Resource-specific stretching.
+		if (Ref<GradientTexture1D>(edited_resource).is_valid() || Ref<Gradient>(edited_resource).is_valid()) {
 			preview_rect->set_stretch_mode(TextureRect::STRETCH_SCALE);
 			assign_button->set_custom_minimum_size(Size2(1, 1));
 		} else {

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -904,3 +904,34 @@ EditorFontPreviewPlugin::~EditorFontPreviewPlugin() {
 	RS::get_singleton()->free(canvas);
 	RS::get_singleton()->free(viewport);
 }
+
+////////////////////////////////////////////////////////////////////////////
+
+static const real_t GRADIENT_PREVIEW_TEXTURE_SCALE_FACTOR = 4.0;
+
+bool EditorGradientPreviewPlugin::handles(const String &p_type) const {
+	return ClassDB::is_parent_class(p_type, "Gradient");
+}
+
+bool EditorGradientPreviewPlugin::generate_small_preview_automatically() const {
+	return true;
+}
+
+Ref<Texture2D> EditorGradientPreviewPlugin::generate(const RES &p_from, const Size2 &p_size) const {
+	Ref<Gradient> gradient = p_from;
+	if (gradient.is_valid()) {
+		Ref<GradientTexture1D> ptex;
+		ptex.instantiate();
+		ptex->set_width(p_size.width * GRADIENT_PREVIEW_TEXTURE_SCALE_FACTOR * EDSCALE);
+		ptex->set_gradient(gradient);
+
+		Ref<ImageTexture> itex;
+		itex.instantiate();
+		itex->create_from_image(ptex->get_image());
+		return itex;
+	}
+	return Ref<Texture2D>();
+}
+
+EditorGradientPreviewPlugin::EditorGradientPreviewPlugin() {
+}

--- a/editor/plugins/editor_preview_plugins.h
+++ b/editor/plugins/editor_preview_plugins.h
@@ -182,4 +182,15 @@ public:
 	EditorTileMapPatternPreviewPlugin();
 	~EditorTileMapPatternPreviewPlugin();
 };
+
+class EditorGradientPreviewPlugin : public EditorResourcePreviewGenerator {
+	GDCLASS(EditorGradientPreviewPlugin, EditorResourcePreviewGenerator);
+
+public:
+	virtual bool handles(const String &p_type) const override;
+	virtual bool generate_small_preview_automatically() const override;
+	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const override;
+
+	EditorGradientPreviewPlugin();
+};
 #endif // EDITORPREVIEWPLUGINS_H


### PR DESCRIPTION
This PR implements a resource preview generator for the `Gradient` resource, which is quite helpful when working with `Gradient`s separate from `GradientTexture1D/2D`. Having the resource expanded in the inspector takes up a lot of space and makes it more chaotic when you just wan't to see how the gradient looks like. (Also useful for saved gradient resources)

Examples:
FastNoiseLite
![grafik](https://user-images.githubusercontent.com/50084500/164283104-dd0dfb75-ca20-468f-9d4d-e452192f4c8c.png)

CPUParticles2D/3D
![grafik](https://user-images.githubusercontent.com/50084500/164283433-26030ae8-4aaa-4a61-9ca2-b6da276c7c8f.png)

Resource preview in FileSystem dock:
![grafik](https://user-images.githubusercontent.com/50084500/164283621-710ad041-8343-4301-bec1-815467028cf1.png)

