### PR TITLE
Fix UndoRedo in Gradient editor

### DIFF
--- a/editor/plugins/gradient_editor_plugin.cpp
+++ b/editor/plugins/gradient_editor_plugin.cpp
@@ -55,7 +55,7 @@ void GradientEditor::_gradient_changed() {
 void GradientEditor::_ramp_changed() {
 	editing = true;
 	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
-	undo_redo->create_action(TTR("Gradient Edited"));
+	undo_redo->create_action(TTR("Gradient Edited"), UndoRedo::MERGE_ENDS);
 	undo_redo->add_do_method(gradient.ptr(), "set_offsets", get_offsets());
 	undo_redo->add_do_method(gradient.ptr(), "set_colors", get_colors());
 	undo_redo->add_do_method(gradient.ptr(), "set_interpolation_mode", get_interpolation_mode());


### PR DESCRIPTION
Fixes part of https://github.com/godotengine/godot/issues/60032

Makes the Gradient editor use the `MERGE_ENDS` mode for UndoRedo actions so that undo/redo actions go from the start/end, instead of every frame the mouse moved. 