### PR TITLE
BoxContainer description to point to the "Using Containers" page

### DIFF
--- a/doc/classes/AspectRatioContainer.xml
+++ b/doc/classes/AspectRatioContainer.xml
@@ -7,6 +7,7 @@
 		Arranges child controls in a way to preserve their aspect ratio automatically whenever the container is resized. Solves the problem where the container size is dynamic and the contents' size needs to adjust accordingly without losing proportions.
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<members>
 		<member name="alignment_horizontal" type="int" setter="set_alignment_horizontal" getter="get_alignment_horizontal" enum="AspectRatioContainer.AlignmentMode" default="1">

--- a/doc/classes/BoxContainer.xml
+++ b/doc/classes/BoxContainer.xml
@@ -7,6 +7,7 @@
 		Arranges child [Control] nodes vertically or horizontally, and rearranges them automatically when their minimum size changes.
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<methods>
 		<method name="add_spacer">

--- a/doc/classes/CenterContainer.xml
+++ b/doc/classes/CenterContainer.xml
@@ -7,6 +7,7 @@
 		CenterContainer keeps children controls centered. This container keeps all children to their minimum size, in the center.
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<members>
 		<member name="use_top_left" type="bool" setter="set_use_top_left" getter="is_using_top_left" default="false">

--- a/doc/classes/Container.xml
+++ b/doc/classes/Container.xml
@@ -8,6 +8,7 @@
 		A Control can inherit this to create custom container classes.
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<methods>
 		<method name="_get_allowed_size_flags_horizontal" qualifiers="virtual const">

--- a/doc/classes/GridContainer.xml
+++ b/doc/classes/GridContainer.xml
@@ -9,6 +9,7 @@
 		[b]Note:[/b] GridContainer only works with child nodes inheriting from Control. It won't rearrange child nodes inheriting from Node2D.
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 		<link title="OS Test Demo">https://godotengine.org/asset-library/asset/677</link>
 	</tutorials>
 	<members>

--- a/doc/classes/HBoxContainer.xml
+++ b/doc/classes/HBoxContainer.xml
@@ -7,6 +7,7 @@
 		Horizontal box container. See [BoxContainer].
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<theme_items>
 		<theme_item name="separation" data_type="constant" type="int" default="4">

--- a/doc/classes/HSplitContainer.xml
+++ b/doc/classes/HSplitContainer.xml
@@ -7,6 +7,7 @@
 		Horizontal split container. See [SplitContainer]. This goes from left to right.
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<theme_items>
 		<theme_item name="autohide" data_type="constant" type="int" default="1">

--- a/doc/classes/MarginContainer.xml
+++ b/doc/classes/MarginContainer.xml
@@ -26,6 +26,7 @@
 		[/codeblocks]
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<theme_items>
 		<theme_item name="margin_bottom" data_type="constant" type="int" default="0">

--- a/doc/classes/PanelContainer.xml
+++ b/doc/classes/PanelContainer.xml
@@ -7,6 +7,7 @@
 		Panel container type. This container fits controls inside of the delimited area of a stylebox. It's useful for giving controls an outline.
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 		<link title="2D Role Playing Game Demo">https://godotengine.org/asset-library/asset/520</link>
 	</tutorials>
 	<members>

--- a/doc/classes/ScrollContainer.xml
+++ b/doc/classes/ScrollContainer.xml
@@ -9,6 +9,7 @@
 		Works great with a [Panel] control. You can set [code]EXPAND[/code] on the children's size flags, so they will upscale to the ScrollContainer's size if it's larger (scroll is invisible for the chosen dimension).
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<methods>
 		<method name="ensure_control_visible">

--- a/doc/classes/SplitContainer.xml
+++ b/doc/classes/SplitContainer.xml
@@ -7,6 +7,7 @@
 		Container for splitting two [Control]s vertically or horizontally, with a grabber that allows adjusting the split offset or ratio.
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<methods>
 		<method name="clamp_split_offset">

--- a/doc/classes/TabContainer.xml
+++ b/doc/classes/TabContainer.xml
@@ -9,6 +9,7 @@
 		[b]Note:[/b] The drawing of the clickable tabs themselves is handled by this node. Adding [TabBar]s as children is not needed.
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<methods>
 		<method name="get_current_tab_control" qualifiers="const">

--- a/doc/classes/VBoxContainer.xml
+++ b/doc/classes/VBoxContainer.xml
@@ -7,6 +7,7 @@
 		Vertical box container. See [BoxContainer].
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 		<link title="3D Voxel Demo">https://godotengine.org/asset-library/asset/676</link>
 	</tutorials>
 	<theme_items>

--- a/doc/classes/VSplitContainer.xml
+++ b/doc/classes/VSplitContainer.xml
@@ -7,6 +7,7 @@
 		Vertical split container. See [SplitContainer]. This goes from top to bottom.
 	</description>
 	<tutorials>
+		<link title="GUI containers">$DOCS_URL/tutorials/ui/gui_containers.html</link>
 	</tutorials>
 	<theme_items>
 		<theme_item name="autohide" data_type="constant" type="int" default="1">


### PR DESCRIPTION
Add a link to the page discussing Containers in general.

Users happening across this page may not already know the intent of Containers, or which others are available.  Someone has already written a helpful page with that information ("Using Containers"); this change just adds a link to it.

If this edit is acceptable, I can make similar one-line changes to the other ten Container-derived classes that may benefit.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
