### PR TITLE
Grid Xy and Yz Plane Spatial Editor Plugin View Menu Toggle and Shortcut

### DIFF
--- a/core/math/camera_matrix.cpp
+++ b/core/math/camera_matrix.cpp
@@ -123,6 +123,60 @@ void CameraMatrix::set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_
 	*this = *this * cm;
 }
 
+void CameraMatrix::set_oblique(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, Quat p_oblique_plane, bool p_flip_fov) {
+	if (p_flip_fov) {
+		p_fovy_degrees = get_fovy(p_fovy_degrees, 1.0 / p_aspect);
+	}
+
+	real_t sine, cotangent, deltaZ;
+	real_t radians = p_fovy_degrees / 2.0 * Math_PI / 180.0;
+
+	deltaZ = p_z_far - p_z_near;
+	sine = Math::sin(radians);
+
+	if ((deltaZ == 0) || (sine == 0) || (p_aspect == 0)) {
+		return;
+	}
+	cotangent = Math::cos(radians) / sine;
+
+	set_identity();
+
+	matrix[0][0] = cotangent / p_aspect;
+	matrix[1][1] = cotangent;
+	matrix[2][2] = -(p_z_far + p_z_near) / deltaZ;
+	matrix[2][3] = -1;
+	matrix[3][2] = -2 * p_z_near * p_z_far / deltaZ;
+	matrix[3][3] = 0;
+
+	// Here goes oblique magic!
+	// Eric Lengyel Solution: http://terathon.com/code/oblique.html
+	// i < 0 ? -1 : (i > 0 ? +1 : 0) = sign()
+	Quat q;
+
+	/* clang-format off */
+	q.x = ((
+		p_oblique_plane.x < 0 ? -1 :
+		p_oblique_plane.x > 0 ? +1 : 0
+		) + matrix[2][0]
+	) / matrix[0][0];
+
+	q.y = ((
+		p_oblique_plane.y < 0 ? -1 :
+		p_oblique_plane.y > 0 ? +1 : 0
+		) + matrix[2][1]
+	) / matrix[1][1];
+	/* clang-format on */
+
+	q.z = -1.0F;
+	q.w = (1.0F + matrix[2][2]) / matrix[3][2];
+
+	Quat c = p_oblique_plane * (2.0F / p_oblique_plane.dot(q));
+	matrix[0][2] = c.x;
+	matrix[1][2] = c.y;
+	matrix[2][2] = c.z + 1.0F;
+	matrix[3][2] = c.w;
+}
+
 void CameraMatrix::set_for_hmd(int p_eye, real_t p_aspect, real_t p_intraocular_dist, real_t p_display_width, real_t p_display_to_lens, real_t p_oversample, real_t p_z_near, real_t p_z_far) {
 	// we first calculate our base frustum on our values without taking our lens magnification into account.
 	real_t f1 = (p_intraocular_dist * 0.5) / p_display_to_lens;

--- a/core/math/camera_matrix.h
+++ b/core/math/camera_matrix.h
@@ -52,6 +52,7 @@ struct CameraMatrix {
 	void set_light_atlas_rect(const Rect2 &p_rect);
 	void set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, bool p_flip_fov = false);
 	void set_perspective(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, bool p_flip_fov, int p_eye, real_t p_intraocular_dist, real_t p_convergence_dist);
+	void set_oblique(real_t p_fovy_degrees, real_t p_aspect, real_t p_z_near, real_t p_z_far, Quat p_oblique_plane, bool p_flip_fov = false);
 	void set_for_hmd(int p_eye, real_t p_aspect, real_t p_intraocular_dist, real_t p_display_width, real_t p_display_to_lens, real_t p_oversample, real_t p_z_near, real_t p_z_far);
 	void set_orthogonal(real_t p_left, real_t p_right, real_t p_bottom, real_t p_top, real_t p_znear, real_t p_zfar);
 	void set_orthogonal(real_t p_size, real_t p_aspect, real_t p_znear, real_t p_zfar, bool p_flip_fov = false);

--- a/doc/classes/Camera.xml
+++ b/doc/classes/Camera.xml
@@ -103,6 +103,28 @@
 				Sets the camera projection to frustum mode (see [constant PROJECTION_FRUSTUM]), by specifying a [code]size[/code], an [code]offset[/code], and the [code]z_near[/code] and [code]z_far[/code] clip planes in world space units.
 			</description>
 		</method>
+		<method name="set_oblique">
+			<return type="void" />
+			<argument index="0" name="fov" type="float" />
+			<argument index="1" name="oblique_data" type="Dictionary" />
+			<argument index="2" name="z_near" type="float" />
+			<argument index="3" name="z_far" type="float" />
+			<description>
+				Sets the camera projection to perspective with oblique near clipping (see [constant PROJECTION_OBLIQUE]), by specifying a [code]fov[/code] (field of view) angle in degrees, the [code]oblique_data[/code] used to transform the projection frustum, and the [code]z_near[/code] and [code]z_far[/code] clip planes in world space before transformation.
+				[b]Note:[/b] [code]oblique_data[/code] is a dictionary containing the following fields:
+				[code]camera_gt[/code]: The camera global transform.
+				[code]normal[/code]: The desired normal vector of the plane.
+				[code]position[/code]: The world-space position of the plane relative to the camera
+				[code]offset[/code]: An adjustable offset for the oblique plane distance value
+			</description>
+		</method>
+		<method name="set_oblique_plane_from_transform">
+			<return type="void" />
+			<argument index="0" name="arg0" type="Transform" />
+			<description>
+				Sets the Oblique_normal and oblique_position values of an oblique projection camera using a transform origin and forward vector.
+			</description>
+		</method>
 		<method name="set_orthogonal">
 			<return type="void" />
 			<argument index="0" name="size" type="float" />
@@ -173,6 +195,15 @@
 		<member name="near" type="float" setter="set_znear" getter="get_znear" default="0.05">
 			The distance to the near culling boundary for this camera relative to its local Z axis.
 		</member>
+		<member name="oblique_normal" type="Vector3" setter="set_oblique_normal" getter="get_oblique_normal" default="Vector3( 0, 0, 0 )">
+			The desired normal vector of the world space plane used by an oblique camera as an oblique near clipping plane.
+		</member>
+		<member name="oblique_offset" type="float" setter="set_oblique_offset" getter="get_oblique_offset" default="0.0">
+			The an offset value for the oblique plane along it's forward vector.
+		</member>
+		<member name="oblique_position" type="Vector3" setter="set_oblique_position" getter="get_oblique_position" default="Vector3( 0, 0, 0 )">
+			The world space position of the plane used by an oblique camera as an oblique near clipping plane.
+		</member>
 		<member name="projection" type="int" setter="set_projection" getter="get_projection" enum="Camera.Projection" default="0">
 			The camera's projection mode. In [constant PROJECTION_PERSPECTIVE] mode, objects' Z distance from the camera's local space scales their perceived size.
 		</member>
@@ -192,6 +223,9 @@
 		</constant>
 		<constant name="PROJECTION_FRUSTUM" value="2" enum="Projection">
 			Frustum projection. This mode allows adjusting [member frustum_offset] to create "tilted frustum" effects.
+		</constant>
+		<constant name="PROJECTION_OBLIQUE" value="3" enum="Projection">
+			Oblique Near Plane projection. This mode allows adjusting the near clipping plane to align with a given world plane.
 		</constant>
 		<constant name="KEEP_WIDTH" value="0" enum="KeepAspect">
 			Preserves the horizontal aspect ratio; also known as Vert- scaling. This is usually the best option for projects running in portrait mode, as taller aspect ratios will benefit from a wider vertical FOV.

--- a/doc/classes/ItemList.xml
+++ b/doc/classes/ItemList.xml
@@ -317,6 +317,9 @@
 		<member name="auto_height" type="bool" setter="set_auto_height" getter="has_auto_height" default="false">
 			If [code]true[/code], the control will automatically resize the height to fit its content.
 		</member>
+        <member name="auto_width" type="bool" setter="set_auto_width" getter="has_auto_width" default="false">
+			If [code]true[/code], the control will automatically resize the width to fit its content.
+		</member>
 		<member name="fixed_column_width" type="int" setter="set_fixed_column_width" getter="get_fixed_column_width" default="0">
 			The width all columns will be adjusted to.
 			A value of zero disables the adjustment, each item will have a width equal to the width of its content and the columns will have an uneven width.

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -72,6 +72,20 @@
 				Sets camera to use frustum projection. This mode allows adjusting the [code]offset[/code] argument to create "tilted frustum" effects.
 			</description>
 		</method>
+		<method name="camera_set_oblique">
+			<return type="void" />
+			<argument index="0" name="camera" type="RID" />
+			<argument index="1" name="fovy_degrees" type="float" />
+			<argument index="2" name="camera_gt" type="Transform" />
+			<argument index="3" name="oblique_normal" type="Vector3" />
+			<argument index="4" name="oblique_position" type="Vector3" />
+			<argument index="5" name="oblique_offset" type="float" />
+			<argument index="6" name="z_near" type="float" />
+			<argument index="7" name="z_far" type="float" />
+			<description>
+				Sets camera to use oblique projection. This mode allows adjusting the [code]normal[/code], [code]position[/code], and [code]offset[/code] arguments to create an oblique near clipping plane.
+			</description>
+		</method>
 		<method name="camera_set_orthogonal">
 			<return type="void" />
 			<argument index="0" name="camera" type="RID" />

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -94,6 +94,7 @@ ScrollContainer *EditorAbout::_populate_list(const String &p_name, const List<St
 			il->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 			il->set_same_column_width(true);
 			il->set_auto_height(true);
+            il->set_auto_width(false);
 			il->set_mouse_filter(Control::MOUSE_FILTER_IGNORE);
 			il->add_constant_override("hseparation", 16 * EDSCALE);
 			while (*names_ptr) {

--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -4696,6 +4696,8 @@ Dictionary SpatialEditor::get_state() const {
 	d["viewports"] = vpdata;
 
 	d["show_grid"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(MENU_VIEW_GRID));
+    d["show_grid_xy"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(MENU_VIEW_GRID_XY));
+    d["show_grid_yz"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(MENU_VIEW_GRID_YZ));
 	d["show_origin"] = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(MENU_VIEW_ORIGIN));
 	d["fov"] = get_fov();
 	d["znear"] = get_znear();
@@ -5094,21 +5096,17 @@ void SpatialEditor::_menu_item_pressed(int p_option) {
 			view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(p_option), origin_enabled);
 		} break;
 		case MENU_VIEW_GRID: {
-			bool is_checked = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(p_option));
-
-			grid_enabled = !is_checked;
-
-			for (int i = 0; i < 3; ++i) {
-				if (grid_enable[i]) {
-					grid_visible[i] = grid_enabled;
-				}
-			}
-			_finish_grid();
-			_init_grid();
-
-			view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(p_option), grid_enabled);
-
+			
+            _toggle_view_grid_plane_options(p_option, grid_enabled);
 		} break;
+        case MENU_VIEW_GRID_XY: {
+            
+            _toggle_view_grid_plane_options(p_option, grid_enable[0], "editors/3d/grid_xy_plane");
+        } break;
+        case MENU_VIEW_GRID_YZ: {
+            
+            _toggle_view_grid_plane_options(p_option, grid_enable[1], "editors/3d/grid_yz_plane");
+        } break;
 		case MENU_VIEW_PORTAL_CULLING: {
 			bool is_checked = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(p_option));
 			RoomManager::static_rooms_set_active(!is_checked);
@@ -5751,6 +5749,22 @@ void SpatialEditor::_update_gizmos_menu_theme() {
 				break;
 		}
 	}
+}
+
+void SpatialEditor::_toggle_view_grid_plane_options(int p_option, bool &p_grid_plane_option, String p_editor_path) {
+    bool is_checked = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(p_option));
+
+    p_grid_plane_option = !is_checked;
+    if (p_editor_path.length()) EditorSettings::get_singleton()->set(p_editor_path, p_grid_plane_option);
+    for (int i = 0; i < 3; ++i) {
+        if (grid_enable[i]) {
+            grid_visible[i] = grid_enable[i];
+        }
+    }
+    _finish_grid();
+    _init_grid();
+
+    view_menu->get_popup()->set_item_checked(view_menu->get_popup()->get_item_index(p_option), p_grid_plane_option);
 }
 
 void SpatialEditor::_init_grid() {
@@ -6619,6 +6633,8 @@ SpatialEditor::SpatialEditor(EditorNode *p_editor) {
 	p->add_separator();
 	p->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_origin", TTR("View Origin")), MENU_VIEW_ORIGIN);
 	p->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_grid", TTR("View Grid"), KEY_MASK_CMD + KEY_G), MENU_VIEW_GRID);
+    p->add_check_shortcut(ED_SHORTCUT("editors/3d/grid_xy_plane", TTR("Grid Xy Plane"), KEY_MASK_CMD + KEY_BRACKETLEFT), MENU_VIEW_GRID_XY);
+	p->add_check_shortcut(ED_SHORTCUT("editors/3d/grid_yz_plane", TTR("Grid Yz Plane"), KEY_MASK_CMD + KEY_BRACKETRIGHT), MENU_VIEW_GRID_YZ);
 	p->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_portal_culling", TTR("View Portal Culling"), KEY_MASK_ALT | KEY_P), MENU_VIEW_PORTAL_CULLING);
 	p->add_check_shortcut(ED_SHORTCUT("spatial_editor/view_occlusion_culling", TTR("View Occlusion Culling")), MENU_VIEW_OCCLUSION_CULLING);
 

--- a/editor/plugins/spatial_editor_plugin.h
+++ b/editor/plugins/spatial_editor_plugin.h
@@ -652,6 +652,8 @@ private:
 		MENU_VIEW_USE_4_VIEWPORTS,
 		MENU_VIEW_ORIGIN,
 		MENU_VIEW_GRID,
+        MENU_VIEW_GRID_XY,
+        MENU_VIEW_GRID_YZ,
 		MENU_VIEW_PORTAL_CULLING,
 		MENU_VIEW_OCCLUSION_CULLING,
 		MENU_VIEW_GIZMOS_3D_ICONS,
@@ -717,6 +719,7 @@ private:
 	void _update_context_menu_stylebox();
 	void _update_gizmos_menu();
 	void _update_gizmos_menu_theme();
+    void _toggle_view_grid_plane_options(int p_option, bool &p_grid_plane_option, String p_editor_path ="");
 	void _init_grid();
 	void _finish_indicators();
 	void _finish_grid();

--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -1440,7 +1440,29 @@ void CameraSpatialGizmoPlugin::redraw(EditorSpatialGizmo *p_gizmo) {
 			nside.x *= 0.25;
 			Vector3 tup(0, up.y * 3 / 2, side.z);
 			ADD_TRIANGLE(tup + offset, side + up + offset, nside + up + offset);
-		}
+
+		} break;
+		case Camera::PROJECTION_OBLIQUE: {
+			// The real FOV is halved for accurate representation
+			float fov = camera->get_fov() / 2.0;
+
+			Vector3 side = Vector3(Math::sin(Math::deg2rad(fov)), 0, -Math::cos(Math::deg2rad(fov)));
+			Vector3 nside = side;
+			nside.x = -nside.x;
+			Vector3 up = Vector3(0, side.x, 0);
+
+			ADD_TRIANGLE(Vector3(), side + up, side - up);
+			ADD_TRIANGLE(Vector3(), nside + up, nside - up);
+			ADD_TRIANGLE(Vector3(), side + up, nside + up);
+			ADD_TRIANGLE(Vector3(), side - up, nside - up);
+
+			handles.push_back(side);
+			side.x *= 0.25;
+			nside.x *= 0.25;
+			Vector3 tup(0, up.y * 3 / 2, side.z);
+			ADD_TRIANGLE(tup, side + up, nside + up);
+
+		} break;
 	}
 
 #undef ADD_TRIANGLE

--- a/scene/3d/camera.cpp
+++ b/scene/3d/camera.cpp
@@ -47,7 +47,14 @@ void Camera::_update_camera_mode() {
 	switch (mode) {
 		case PROJECTION_PERSPECTIVE: {
 			set_perspective(fov, near, far);
-
+		} break;
+		case PROJECTION_OBLIQUE: {
+			Dictionary ob_data = Dictionary();
+			ob_data["camera_gt"] = get_global_transform();
+			ob_data["normal"] = oblique_normal;
+			ob_data["position"] = oblique_position;
+			ob_data["offset"] = oblique_offset;
+			set_oblique(fov, ob_data, near, far);
 		} break;
 		case PROJECTION_ORTHOGONAL: {
 			set_orthogonal(size, near, far);
@@ -60,7 +67,7 @@ void Camera::_update_camera_mode() {
 
 void Camera::_validate_property(PropertyInfo &p_property) const {
 	if (p_property.name == "fov") {
-		if (mode != PROJECTION_PERSPECTIVE) {
+		if (mode != PROJECTION_PERSPECTIVE && mode != PROJECTION_OBLIQUE) {
 			p_property.usage = PROPERTY_USAGE_NOEDITOR;
 		}
 	} else if (p_property.name == "size") {
@@ -69,6 +76,10 @@ void Camera::_validate_property(PropertyInfo &p_property) const {
 		}
 	} else if (p_property.name == "frustum_offset") {
 		if (mode != PROJECTION_FRUSTUM) {
+			p_property.usage = PROPERTY_USAGE_NOEDITOR;
+		}
+	} else if (p_property.name == "oblique_normal" || p_property.name == "oblique_position" || p_property.name == "oblique_offset") {
+		if (mode != PROJECTION_OBLIQUE) {
 			p_property.usage = PROPERTY_USAGE_NOEDITOR;
 		}
 	}
@@ -170,6 +181,28 @@ void Camera::set_perspective(float p_fovy_degrees, float p_z_near, float p_z_far
 	update_gizmo();
 	force_change = false;
 }
+void Camera::set_oblique(float p_fovy_degrees, const Dictionary &p_oblique_data, float p_z_near, float p_z_far) {
+	if (!force_change && fov == p_fovy_degrees && p_z_near == near && p_z_far == far && mode == PROJECTION_OBLIQUE) {
+		return;
+	}
+
+	if (!force_change && (Vector3)p_oblique_data["normal"] == oblique_normal && (Vector3)p_oblique_data["position"] == oblique_position && (float)p_oblique_data["offset"] == oblique_offset) {
+		return;
+	}
+
+	fov = p_fovy_degrees;
+	oblique_normal = p_oblique_data["normal"];
+	oblique_position = p_oblique_data["position"];
+	oblique_offset = p_oblique_data["offset"];
+	near = p_z_near;
+	far = p_z_far;
+	mode = PROJECTION_OBLIQUE;
+
+	VisualServer::get_singleton()->camera_set_oblique(camera, fov, p_oblique_data["camera_gt"], p_oblique_data["normal"], p_oblique_data["position"], p_oblique_data["offset"], near, far);
+	update_gizmo();
+	force_change = false;
+}
+
 void Camera::set_orthogonal(float p_size, float p_z_near, float p_z_far) {
 	if (!force_change && size == p_size && p_z_near == near && p_z_far == far && mode == PROJECTION_ORTHOGONAL) {
 		return;
@@ -204,7 +237,7 @@ void Camera::set_frustum(float p_size, Vector2 p_offset, float p_z_near, float p
 }
 
 void Camera::set_projection(Camera::Projection p_mode) {
-	if (p_mode == PROJECTION_PERSPECTIVE || p_mode == PROJECTION_ORTHOGONAL || p_mode == PROJECTION_FRUSTUM) {
+	if (p_mode == PROJECTION_PERSPECTIVE || p_mode == PROJECTION_OBLIQUE || p_mode == PROJECTION_ORTHOGONAL || p_mode == PROJECTION_FRUSTUM) {
 		mode = p_mode;
 		_update_camera_mode();
 		_change_notify();
@@ -463,6 +496,7 @@ void Camera::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_position_behind", "world_point"), &Camera::is_position_behind);
 	ClassDB::bind_method(D_METHOD("project_position", "screen_point", "z_depth"), &Camera::project_position);
 	ClassDB::bind_method(D_METHOD("set_perspective", "fov", "z_near", "z_far"), &Camera::set_perspective);
+	ClassDB::bind_method(D_METHOD("set_oblique", "fov", "oblique_data", "z_near", "z_far"), &Camera::set_oblique);
 	ClassDB::bind_method(D_METHOD("set_orthogonal", "size", "z_near", "z_far"), &Camera::set_orthogonal);
 	ClassDB::bind_method(D_METHOD("set_frustum", "size", "offset", "z_near", "z_far"), &Camera::set_frustum);
 	ClassDB::bind_method(D_METHOD("make_current"), &Camera::make_current);
@@ -471,11 +505,18 @@ void Camera::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_current"), &Camera::is_current);
 	ClassDB::bind_method(D_METHOD("get_camera_transform"), &Camera::get_camera_transform);
 	ClassDB::bind_method(D_METHOD("get_fov"), &Camera::get_fov);
+	ClassDB::bind_method(D_METHOD("get_oblique_normal"), &Camera::get_oblique_normal);
+	ClassDB::bind_method(D_METHOD("get_oblique_position"), &Camera::get_oblique_position);
+	ClassDB::bind_method(D_METHOD("get_oblique_offset"), &Camera::get_oblique_offset);
 	ClassDB::bind_method(D_METHOD("get_frustum_offset"), &Camera::get_frustum_offset);
 	ClassDB::bind_method(D_METHOD("get_size"), &Camera::get_size);
 	ClassDB::bind_method(D_METHOD("get_zfar"), &Camera::get_zfar);
 	ClassDB::bind_method(D_METHOD("get_znear"), &Camera::get_znear);
 	ClassDB::bind_method(D_METHOD("set_fov"), &Camera::set_fov);
+	ClassDB::bind_method(D_METHOD("set_oblique_normal"), &Camera::set_oblique_normal);
+	ClassDB::bind_method(D_METHOD("set_oblique_position"), &Camera::set_oblique_position);
+	ClassDB::bind_method(D_METHOD("set_oblique_plane_from_transform"), &Camera::set_oblique_plane_from_transform);
+	ClassDB::bind_method(D_METHOD("set_oblique_offset"), &Camera::set_oblique_offset);
 	ClassDB::bind_method(D_METHOD("set_frustum_offset"), &Camera::set_frustum_offset);
 	ClassDB::bind_method(D_METHOD("set_size"), &Camera::set_size);
 	ClassDB::bind_method(D_METHOD("set_zfar"), &Camera::set_zfar);
@@ -508,9 +549,12 @@ void Camera::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "h_offset"), "set_h_offset", "get_h_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "v_offset"), "set_v_offset", "get_v_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "doppler_tracking", PROPERTY_HINT_ENUM, "Disabled,Idle,Physics"), "set_doppler_tracking", "get_doppler_tracking");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "projection", PROPERTY_HINT_ENUM, "Perspective,Orthogonal,Frustum"), "set_projection", "get_projection");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "projection", PROPERTY_HINT_ENUM, "Perspective,Orthogonal,Frustum,Oblique"), "set_projection", "get_projection");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "current"), "set_current", "is_current");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "fov", PROPERTY_HINT_RANGE, "1,179,0.1"), "set_fov", "get_fov");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "oblique_normal"), "set_oblique_normal", "get_oblique_normal");
+	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "oblique_position"), "set_oblique_position", "get_oblique_position");
+	ADD_PROPERTY(PropertyInfo(Variant::REAL, "oblique_offset"), "set_oblique_offset", "get_oblique_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "size", PROPERTY_HINT_RANGE, "0.1,16384,0.01"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "frustum_offset"), "set_frustum_offset", "get_frustum_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::REAL, "near", PROPERTY_HINT_EXP_RANGE, "0.01,8192,0.01,or_greater"), "set_znear", "get_znear");
@@ -519,6 +563,7 @@ void Camera::_bind_methods() {
 	BIND_ENUM_CONSTANT(PROJECTION_PERSPECTIVE);
 	BIND_ENUM_CONSTANT(PROJECTION_ORTHOGONAL);
 	BIND_ENUM_CONSTANT(PROJECTION_FRUSTUM);
+	BIND_ENUM_CONSTANT(PROJECTION_OBLIQUE);
 
 	BIND_ENUM_CONSTANT(KEEP_WIDTH);
 	BIND_ENUM_CONSTANT(KEEP_HEIGHT);
@@ -530,6 +575,18 @@ void Camera::_bind_methods() {
 
 float Camera::get_fov() const {
 	return fov;
+}
+
+Vector3 Camera::get_oblique_normal() const {
+	return oblique_normal;
+}
+
+Vector3 Camera::get_oblique_position() const {
+	return oblique_position;
+}
+
+float Camera::get_oblique_offset() const {
+	return oblique_offset;
 }
 
 float Camera::get_size() const {
@@ -557,6 +614,31 @@ void Camera::set_fov(float p_fov) {
 	fov = p_fov;
 	_update_camera_mode();
 	_change_notify("fov");
+}
+
+void Camera::set_oblique_normal(Vector3 p_oblique_normal) {
+	oblique_normal = p_oblique_normal;
+	_update_camera_mode();
+	_change_notify("oblique_plane");
+}
+
+void Camera::set_oblique_position(Vector3 p_oblique_position) {
+	oblique_position = p_oblique_position;
+	_update_camera_mode();
+	_change_notify("oblique_plane");
+}
+
+void Camera::set_oblique_offset(float p_oblique_offset) {
+	oblique_offset = p_oblique_offset;
+	_update_camera_mode();
+	_change_notify("oblique_offset");
+}
+
+void Camera::set_oblique_plane_from_transform(Transform p_oblique_transform) {
+	set_oblique_normal(p_oblique_transform.basis.get_column(2));
+	set_oblique_position(p_oblique_transform.origin);
+	_update_camera_mode();
+	_change_notify("oblique_plane");
 }
 
 void Camera::set_size(float p_size) {
@@ -648,6 +730,9 @@ Camera::Camera() {
 	camera = VisualServer::get_singleton()->camera_create();
 	size = 1;
 	fov = 0;
+	oblique_normal = Vector3();
+	oblique_position = Vector3();
+	oblique_offset = 0;
 	frustum_offset = Vector2();
 	near = 0;
 	far = 0;

--- a/scene/3d/camera.h
+++ b/scene/3d/camera.h
@@ -44,7 +44,8 @@ public:
 
 		PROJECTION_PERSPECTIVE,
 		PROJECTION_ORTHOGONAL,
-		PROJECTION_FRUSTUM
+		PROJECTION_FRUSTUM,
+		PROJECTION_OBLIQUE
 	};
 
 	enum KeepAspect {
@@ -66,6 +67,9 @@ private:
 	Projection mode;
 
 	float fov;
+	Vector3 oblique_normal;
+	Vector3 oblique_position;
+	float oblique_offset;
 	float size;
 	Vector2 frustum_offset;
 	float near, far;
@@ -107,6 +111,7 @@ public:
 	};
 
 	void set_perspective(float p_fovy_degrees, float p_z_near, float p_z_far);
+	void set_oblique(float p_fovy_degrees, const Dictionary &p_oblique_data, float p_z_near, float p_z_far);
 	void set_orthogonal(float p_size, float p_z_near, float p_z_far);
 	void set_frustum(float p_size, Vector2 p_offset, float p_z_near, float p_z_far);
 	void set_projection(Camera::Projection p_mode);
@@ -119,6 +124,9 @@ public:
 	RID get_camera() const;
 
 	float get_fov() const;
+	Vector3 get_oblique_normal() const;
+	Vector3 get_oblique_position() const;
+	float get_oblique_offset() const;
 	float get_size() const;
 	float get_zfar() const;
 	float get_znear() const;
@@ -127,6 +135,10 @@ public:
 	Projection get_projection() const;
 
 	void set_fov(float p_fov);
+	void set_oblique_normal(Vector3 p_oblique_normal);
+	void set_oblique_position(Vector3 p_oblique_position);
+	void set_oblique_offset(float p_oblique_offset);
+	void set_oblique_plane_from_transform(Transform p_oblique_plane_transform);
 	void set_size(float p_size);
 	void set_zfar(float p_zfar);
 	void set_znear(float p_znear);

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -813,7 +813,6 @@ void ItemList::_notification(int p_what) {
 
 				if (items[i].text != "") {
 					Size2 s = font->get_string_size(items[i].text);
-					//s.width=MIN(s.width,fixed_column_width);
 
 					if (icon_mode == ICON_MODE_TOP) {
 						minsize.x = MAX(minsize.x, s.width);
@@ -854,6 +853,7 @@ void ItemList::_notification(int p_what) {
 				bool all_fit = true;
 				Vector2 ofs;
 				int col = 0;
+                int max_w = 0;
 				int max_h = 0;
 				separators.clear();
 				for (int i = 0; i < items.size(); i++) {
@@ -868,6 +868,7 @@ void ItemList::_notification(int p_what) {
 						items.write[i].rect_cache.size.x = max_column_width;
 					}
 					items.write[i].rect_cache.position = ofs;
+                    max_w = MAX(max_w, items[i].rect_cache.size.x);
 					max_h = MAX(max_h, items[i].rect_cache.size.y);
 					ofs.x += items[i].rect_cache.size.x + hseparation;
 					col++;
@@ -894,7 +895,10 @@ void ItemList::_notification(int p_what) {
 				if (all_fit) {
 					float page = MAX(0, size.height - bg->get_minimum_size().height);
 					float max = MAX(page, ofs.y + max_h);
-					if (auto_height) {
+					if (auto_width) {
+						auto_width_value = ofs.x + max_w + bg->get_minimum_size().width;
+                    }
+                    if (auto_height) {
 						auto_height_value = ofs.y + max_h + bg->get_minimum_size().height;
 					}
 					scroll_bar->set_max(max);
@@ -1331,14 +1335,24 @@ Array ItemList::_get_items() const {
 }
 
 Size2 ItemList::get_minimum_size() const {
-	if (auto_height) {
-		return Size2(0, auto_height_value);
+	if (auto_width || auto_height) {
+		return Size2(auto_width_value, auto_height_value);
 	}
 	return Size2();
 }
 
 void ItemList::set_autoscroll_to_bottom(const bool p_enable) {
 	do_autoscroll_to_bottom = p_enable;
+}
+
+void ItemList::set_auto_width(bool p_enable) {
+	auto_width = p_enable;
+	shape_changed = true;
+	update();
+}
+
+bool ItemList::has_auto_width() const {
+	return auto_width;
 }
 
 void ItemList::set_auto_height(bool p_enable) {
@@ -1436,6 +1450,9 @@ void ItemList::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_allow_reselect", "allow"), &ItemList::set_allow_reselect);
 	ClassDB::bind_method(D_METHOD("get_allow_reselect"), &ItemList::get_allow_reselect);
 
+    ClassDB::bind_method(D_METHOD("set_auto_width", "enable"), &ItemList::set_auto_width);
+	ClassDB::bind_method(D_METHOD("has_auto_width"), &ItemList::has_auto_width);
+
 	ClassDB::bind_method(D_METHOD("set_auto_height", "enable"), &ItemList::set_auto_height);
 	ClassDB::bind_method(D_METHOD("has_auto_height"), &ItemList::has_auto_height);
 
@@ -1459,6 +1476,7 @@ void ItemList::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_reselect"), "set_allow_reselect", "get_allow_reselect");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_rmb_select"), "set_allow_rmb_select", "get_allow_rmb_select");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_text_lines", PROPERTY_HINT_RANGE, "1,10,1,or_greater"), "set_max_text_lines", "get_max_text_lines");
+    ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_width"), "set_auto_width", "has_auto_width");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_height"), "set_auto_height", "has_auto_height");
 	ADD_GROUP("Columns", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_columns", PROPERTY_HINT_RANGE, "0,10,1,or_greater"), "set_max_columns", "get_max_columns");
@@ -1496,6 +1514,8 @@ ItemList::ItemList() {
 	same_column_width = false;
 	max_text_lines = 1;
 	max_columns = 1;
+    auto_width = false;
+	auto_width_value = 0.0f;
 	auto_height = false;
 	auto_height_value = 0.0f;
 

--- a/scene/gui/item_list.h
+++ b/scene/gui/item_list.h
@@ -80,6 +80,9 @@ private:
 	bool ensure_selected_visible;
 	bool same_column_width;
 
+    bool auto_width;
+	float auto_width_value;
+
 	bool auto_height;
 	float auto_height_value;
 
@@ -221,6 +224,9 @@ public:
 	void set_icon_scale(real_t p_scale);
 	real_t get_icon_scale() const;
 
+    void set_auto_width(bool p_enable);
+	bool has_auto_width() const;
+    
 	void set_auto_height(bool p_enable);
 	bool has_auto_height() const;
 

--- a/scene/resources/material.h
+++ b/scene/resources/material.h
@@ -126,7 +126,6 @@ public:
 		TEXTURE_DETAIL_ALBEDO,
 		TEXTURE_DETAIL_NORMAL,
 		TEXTURE_MAX
-
 	};
 
 	enum DetailUV {
@@ -255,6 +254,7 @@ private:
 			uint64_t grow : 1;
 			uint64_t proximity_fade : 1;
 			uint64_t distance_fade : 2;
+            uint64_t clip_plane : 1;
 			uint64_t emission_op : 1;
 			uint64_t texture_metallic : 1;
 			uint64_t texture_roughness : 1;
@@ -301,6 +301,7 @@ private:
 		mk.grow = grow_enabled;
 		mk.proximity_fade = proximity_fade_enabled;
 		mk.distance_fade = distance_fade;
+        mk.clip_plane = clip_plane_enabled;
 		mk.emission_op = emission_op;
 		mk.texture_metallic = textures[TEXTURE_METALLIC].is_valid() ? 1 : 0;
 		mk.texture_roughness = textures[TEXTURE_ROUGHNESS].is_valid() ? 1 : 0;
@@ -342,6 +343,7 @@ private:
 		StringName proximity_fade_distance;
 		StringName distance_fade_min;
 		StringName distance_fade_max;
+        StringName clip_plane;
 		StringName ao_light_affect;
 
 		StringName metallic_texture_channel;
@@ -415,6 +417,9 @@ private:
 	DistanceFadeMode distance_fade;
 	float distance_fade_max_distance;
 	float distance_fade_min_distance;
+
+    bool clip_plane_enabled;
+    Plane clip_plane;
 
 	BlendMode blend_mode;
 	BlendMode detail_blend_mode;
@@ -609,6 +614,12 @@ public:
 
 	void set_distance_fade_min_distance(float p_distance);
 	float get_distance_fade_min_distance() const;
+    
+    void set_clip_plane(bool p_enable);
+    bool is_clip_plane_enabled() const;
+
+    void set_clipping_plane(Plane p_clip_plane);
+    Plane get_clipping_plane() const;
 
 	void set_emission_operator(EmissionOperator p_op);
 	EmissionOperator get_emission_operator() const;

--- a/servers/visual/visual_server_raster.h
+++ b/servers/visual/visual_server_raster.h
@@ -435,6 +435,7 @@ public:
 
 	BIND0R(RID, camera_create)
 	BIND4(camera_set_perspective, RID, float, float, float)
+	BIND8(camera_set_oblique, RID, float, const Transform &, const Vector3 &, const Vector3 &, float, float, float)
 	BIND4(camera_set_orthogonal, RID, float, float, float)
 	BIND5(camera_set_frustum, RID, float, Vector2, float, float)
 	BIND2(camera_set_transform, RID, const Transform &)

--- a/servers/visual/visual_server_scene.cpp
+++ b/servers/visual/visual_server_scene.cpp
@@ -52,6 +52,21 @@ void VisualServerScene::camera_set_perspective(RID p_camera, float p_fovy_degree
 	camera->zfar = p_z_far;
 }
 
+void VisualServerScene::camera_set_oblique(RID p_camera, float p_fovy_degrees, const Transform &p_camera_gt, const Vector3 &p_ob_normal, const Vector3 &p_ob_position, float p_ob_offset, float p_z_near, float p_z_far) {
+	int dot = int(p_ob_normal.dot(p_ob_position - p_camera_gt.origin) >= 0.0f ? 1.0f : -1.0f);
+	Vector3 cam_space_pos = p_camera_gt.inverse().xform(p_ob_position);
+	Vector3 cam_space_normal = p_camera_gt.basis.inverse().xform(p_ob_normal) * dot;
+	real_t cam_space_dst = -cam_space_pos.dot(cam_space_normal) + p_ob_offset;
+
+	Camera *camera = camera_owner.get(p_camera);
+	ERR_FAIL_COND(!camera);
+	camera->type = Camera::OBLIQUE;
+	camera->fov = p_fovy_degrees;
+	camera->oblique_plane = Plane(cam_space_normal, cam_space_dst);
+	camera->znear = p_z_near;
+	camera->zfar = p_z_far;
+}
+
 void VisualServerScene::camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) {
 	Camera *camera = camera_owner.get(p_camera);
 	ERR_FAIL_COND(!camera);
@@ -2365,7 +2380,17 @@ void VisualServerScene::render_camera(RID p_camera, RID p_scenario, Size2 p_view
 					camera->zfar,
 					camera->vaspect);
 			ortho = false;
-
+		} break;
+		case Camera::OBLIQUE: {
+			Quat oblique_plane = Quat(camera->oblique_plane.normal.x, camera->oblique_plane.normal.y, camera->oblique_plane.normal.z, camera->oblique_plane.d);
+			camera_matrix.set_oblique(
+					camera->fov,
+					p_viewport_size.width / (float)p_viewport_size.height,
+					camera->znear,
+					camera->zfar,
+					oblique_plane,
+					camera->vaspect);
+			ortho = false;
 		} break;
 		case Camera::FRUSTUM: {
 			camera_matrix.set_frustum(

--- a/servers/visual/visual_server_scene.h
+++ b/servers/visual/visual_server_scene.h
@@ -63,10 +63,12 @@ public:
 		enum Type {
 			PERSPECTIVE,
 			ORTHOGONAL,
-			FRUSTUM
+			FRUSTUM,
+			OBLIQUE
 		};
 		Type type;
 		float fov;
+		Plane oblique_plane;
 		float znear, zfar;
 		float size;
 		Vector2 offset;
@@ -94,6 +96,7 @@ public:
 
 	virtual RID camera_create();
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far);
+	virtual void camera_set_oblique(RID p_camera, float p_fovy_degrees, const Transform &p_camera_gt, const Vector3 &p_ob_normal, const Vector3 &p_ob_position, float p_ob_offset, float p_z_near, float p_z_far);
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far);
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far);
 	virtual void camera_set_transform(RID p_camera, const Transform &p_transform);

--- a/servers/visual/visual_server_wrap_mt.h
+++ b/servers/visual/visual_server_wrap_mt.h
@@ -366,6 +366,7 @@ public:
 
 	FUNCRID(camera)
 	FUNC4(camera_set_perspective, RID, float, float, float)
+	FUNC8(camera_set_oblique, RID, float, const Transform &, const Vector3 &, const Vector3 &, float, float, float)
 	FUNC4(camera_set_orthogonal, RID, float, float, float)
 	FUNC5(camera_set_frustum, RID, float, Vector2, float, float)
 	FUNC2(camera_set_transform, RID, const Transform &)

--- a/servers/visual_server.cpp
+++ b/servers/visual_server.cpp
@@ -2048,6 +2048,7 @@ void VisualServer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("camera_create"), &VisualServer::camera_create);
 	ClassDB::bind_method(D_METHOD("camera_set_perspective", "camera", "fovy_degrees", "z_near", "z_far"), &VisualServer::camera_set_perspective);
+	ClassDB::bind_method(D_METHOD("camera_set_oblique", "camera", "fovy_degrees", "camera_gt", "oblique_normal", "oblique_position", "oblique_offset", "z_near", "z_far"), &VisualServer::camera_set_oblique);
 	ClassDB::bind_method(D_METHOD("camera_set_orthogonal", "camera", "size", "z_near", "z_far"), &VisualServer::camera_set_orthogonal);
 	ClassDB::bind_method(D_METHOD("camera_set_frustum", "camera", "size", "offset", "z_near", "z_far"), &VisualServer::camera_set_frustum);
 	ClassDB::bind_method(D_METHOD("camera_set_transform", "camera", "transform"), &VisualServer::camera_set_transform);

--- a/servers/visual_server.h
+++ b/servers/visual_server.h
@@ -609,6 +609,7 @@ public:
 
 	virtual RID camera_create() = 0;
 	virtual void camera_set_perspective(RID p_camera, float p_fovy_degrees, float p_z_near, float p_z_far) = 0;
+	virtual void camera_set_oblique(RID p_camera, float p_fovy_degrees, const Transform &p_camera_gt, const Vector3 &p_ob_normal, const Vector3 &p_ob_position, float p_ob_offset, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_orthogonal(RID p_camera, float p_size, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_frustum(RID p_camera, float p_size, Vector2 p_offset, float p_z_near, float p_z_far) = 0;
 	virtual void camera_set_transform(RID p_camera, const Transform &p_transform) = 0;


### PR DESCRIPTION
adds 2 'View Menu' toggle buttons to en-/dis-able the xy, and yz view grids. 

also adds keyboard shortcuts for fast toggle operation:
Grid Xy Plane: with shortcut 'ctrl + ['
Grid Yz Plane: with shortcut 'ctrl + ]'

![image](https://user-images.githubusercontent.com/40372043/164535862-71500202-cf63-45b2-8699-36f108b3ab8b.png)


See proposal for initial details: https://github.com/godotengine/godot-proposals/issues/4128



**Note: 
Targeting 3.4, unsure if 3.x is more suitable in the future as I primarily develop features for my own use on the most recent stable branch.

I do intend to learn how to target master by communicating in the developer chat.
I've just been sitting on this for 2 months waiting for school to end, and no mention of targeting master was made in the proposal phase.

Cheers!