### PR TITLE
Improved error msg for gdscript load_source_code

### DIFF
--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -1032,7 +1032,13 @@ Error GDScript::load_source_code(const String &p_path) {
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
 	if (err) {
-		ERR_FAIL_COND_V(err, err);
+		const char *err_name;
+		if (err < 0 || err >= ERR_MAX) {
+			err_name = "(invalid error code)";
+		} else {
+			err_name = error_names[err];
+		}
+		ERR_FAIL_COND_V_MSG(err, err, "Attempt to open script '" + p_path + "' resulted in error '" + err_name + "'.");
 	}
 
 	uint64_t len = f->get_length();


### PR DESCRIPTION
Had an unhelpful error output in my development:
`ERROR: Condition "err" is true. Returning: err
   at: load_source_code (modules/gdscript/gdscript.cpp:1035)`
The error itself wasn't the problem, it was the fact that I needed to change the godot source and recompile it to just figure out what the error was.

  I took the error_names code directly from [String error_string(Error)](https://github.com/godotengine/godot/blob/f4b0c7a1ea8d86c1dfd96478ca12ad1360903d9d/core/variant/variant_utility.cpp#L489) as there appears to be no header where it or any of the other methods in that VariantUtility structure are declared, and there is no other use of the [error_names array](https://github.com/godotengine/godot/blob/f4b0c7a1ea8d86c1dfd96478ca12ad1360903d9d/core/error/error_list.cpp#L33) anywhere else.

  It would seem best to refactor that function to the /core/error/error_list.(cpp/h), or even /core/error/error_macros.(cpp/h) files, but I'm a first-time contributor and it's the only use of the code.

