### PR TITLE
Add mutable OAHashMap::lookup_ptr function to fix mutability.

### DIFF
--- a/core/templates/oa_hash_map.h
+++ b/core/templates/oa_hash_map.h
@@ -246,13 +246,17 @@ public:
 		return false;
 	}
 
-	/**
-	 * returns true if the value was found, false otherwise.
-	 *
-	 * if r_data is not nullptr then the value will be written to the object
-	 * it points to.
-	 */
-	TValue *lookup_ptr(const TKey &p_key) const {
+	const TValue *lookup_ptr(const TKey &p_key) const {
+		uint32_t pos = 0;
+		bool exists = _lookup_pos(p_key, pos);
+
+		if (exists) {
+			return &values[pos];
+		}
+		return nullptr;
+	}
+
+	TValue *lookup_ptr(const TKey &p_key) {
 		uint32_t pos = 0;
 		bool exists = _lookup_pos(p_key, pos);
 


### PR DESCRIPTION
Add mutable `OAHashMap::lookup_ptr` function to fix mutability.

This feature is already backported in this PR: https://github.com/godotengine/godot/pull/60421