### PR TITLE
Backport the vector oashmap functions

### DIFF
--- a/core/oa_hash_map.h
+++ b/core/oa_hash_map.h
@@ -237,6 +237,26 @@ public:
 		return false;
 	}
 
+	const TValue *lookup_ptr(const TKey &p_key) const {
+		uint32_t pos = 0;
+		bool exists = _lookup_pos(p_key, pos);
+
+		if (exists) {
+			return &values[pos];
+		}
+		return nullptr;
+	}
+
+	TValue *lookup_ptr(const TKey &p_key) {
+		uint32_t pos = 0;
+		bool exists = _lookup_pos(p_key, pos);
+
+		if (exists) {
+			return &values[pos];
+		}
+		return nullptr;
+	}
+
 	_FORCE_INLINE_ bool has(const TKey &p_key) const {
 		uint32_t _pos = 0;
 		return _lookup_pos(p_key, _pos);

--- a/core/vector.h
+++ b/core/vector.h
@@ -123,6 +123,41 @@ public:
 		return *this;
 	}
 
+	Vector<uint8_t> to_byte_array() const {
+		Vector<uint8_t> ret;
+		ret.resize(size() * sizeof(T));
+		memcpy(ret.ptrw(), ptr(), sizeof(T) * size());
+		return ret;
+	}
+
+	Vector<T> slice(int p_begin, int p_end = INT32_MAX) const {
+		Vector<T> result;
+
+		const int s = size();
+
+		int begin = CLAMP(p_begin, -s, s);
+		if (begin < 0) {
+			begin += s;
+		}
+		int end = CLAMP(p_end, -s, s);
+		if (end < 0) {
+			end += s;
+		}
+
+		ERR_FAIL_COND_V(begin > end, result);
+
+		int result_size = end - begin;
+		result.resize(result_size);
+
+		const T *const r = ptr();
+		T *const w = result.ptrw();
+		for (int i = 0; i < result_size; ++i) {
+			w[i] = r[begin + i];
+		}
+
+		return result;
+	}
+
 	_FORCE_INLINE_ ~Vector() {}
 };
 


### PR DESCRIPTION
This PR backports:
- The Vector::slice function https://github.com/godotengine/godot/blob/master/core/templates/vector.h#L151-L177
- The Vector::to_byte_array https://github.com/godotengine/godot/blob/master/core/templates/vector.h#L144-L149
- The OAHashMap::lookup_ptr https://github.com/godotengine/godot/blob/master/core/templates/oa_hash_map.h#L255-L263