### PR TITLE
Close `FileAccess` before accessing it with `DirAccess`

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1153,6 +1153,8 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 	uint32_t ver_format = f->get_32();
 
 	if (ver_format < FORMAT_VERSION_CAN_RENAME_DEPS) {
+		fw.unref();
+
 		{
 			Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_FILESYSTEM);
 			da->remove(p_path + ".depren");
@@ -1294,6 +1296,8 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 	if (!all_ok) {
 		return ERR_CANT_CREATE;
 	}
+
+	fw.unref();
 
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	da->remove(p_path);

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -898,6 +898,8 @@ Error ResourceLoaderText::rename_dependencies(Ref<FileAccess> p_f, const String 
 		return ERR_CANT_CREATE;
 	}
 
+	fw.unref();
+
 	Ref<DirAccess> da = DirAccess::create(DirAccess::ACCESS_RESOURCES);
 	da->remove(p_path);
 	da->rename(p_path + ".depren", p_path);


### PR DESCRIPTION
Fixes #60412

Before renaming/removing the file, `unref()` the `FileAccess` to make sure it got flushed & closed.