### PR TITLE
Improve locking safety for RID handles builds

### DIFF
--- a/core/rid_handle.h
+++ b/core/rid_handle.h
@@ -142,7 +142,7 @@ class RID_Database {
 	// is treated as a POD type.
 	TrackedPooledList<PoolElement, uint32_t, true, true> _pool;
 	bool _shutdown = false;
-	Mutex _mutex;
+	mutable Mutex _mutex;
 
 	// This is purely for printing the leaks at the end, as RID_Owners may be
 	// destroyed before the RID_Database is shutdown, so the RID_Data may be invalid
@@ -153,7 +153,7 @@ class RID_Database {
 	LocalVector<Leak> _leaks;
 
 	void register_leak(uint32_t p_line_number, uint32_t p_owner_name_id, const char *p_filename);
-	String _rid_to_string(const RID &p_rid, const PoolElement &p_pe);
+	String _rid_to_string(const RID &p_rid, const PoolElement &p_pe) const;
 
 public:
 	RID_Database();
@@ -169,10 +169,11 @@ public:
 	RID prime(const RID &p_rid, int p_line_number, const char *p_filename);
 
 	void handle_make_rid(RID &r_rid, RID_Data *p_data, RID_OwnerBase *p_owner);
-	RID_Data *handle_get(const RID &p_rid);
-	RID_Data *handle_getptr(const RID &p_rid);
-	RID_Data *handle_get_or_null(const RID &p_rid);
-	bool handle_owns(const RID &p_rid) const;
+	RID_Data *handle_get(const RID &p_rid) const;
+	RID_Data *handle_getptr(const RID &p_rid) const;
+	RID_Data *handle_get_or_null(const RID &p_rid) const;
+
+	bool handle_is_owner(const RID &p_rid, const RID_OwnerBase *p_owner) const;
 	void handle_free(const RID &p_rid);
 };
 
@@ -181,15 +182,7 @@ extern RID_Database g_rid_database;
 class RID_OwnerBase {
 protected:
 	bool _is_owner(const RID &p_rid) const {
-		const RID_Data *p = g_rid_database.handle_get_or_null(p_rid);
-		return (p && (p->_owner == this));
-	}
-
-	void _remove_owner(RID &p_rid) {
-		RID_Data *p = g_rid_database.handle_get_or_null(p_rid);
-		if (p) {
-			p->_owner = nullptr;
-		}
+		return g_rid_database.handle_is_owner(p_rid, this);
 	}
 
 	void _rid_print(const char *pszType, String sz, const RID &p_rid);
@@ -238,7 +231,6 @@ public:
 #ifdef RID_HANDLE_PRINT_LIFETIMES
 		_rid_print(_typename, "free_rid", p_rid);
 #endif
-		_remove_owner(p_rid);
 		g_rid_database.handle_free(p_rid);
 	}
 


### PR DESCRIPTION
Additional locks are added. This is primarily to cover a potential race condition where the pool is resized from another thread during a get operation.

## Notes
* This is compiled out of regular builds (so has no effect in vanilla Godot)
* It improves the thread safety of `rids=handles` and `rids=tracked_handles` builds.
* Only noticed this as we were discussing the handles builds in #60406.
* To my knowledge, these race condition haven't occurred for me in 5 months of use, but it is probably a good idea to close these possibilities.
* Luckily it doesn't seem to have much effect on performance adding the extra lock on the get. Godot 4 puts this lock on RID gets as well, probably for similar reasons.

Note that by design in Godot 3.x, the RID objects themselves aren't thread safe. The RID database itself is intended to be thread safe, but there's nothing to stop one thread e.g. deleting a RID object mid way while another thread is accessing that object.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
