### PR TITLE
Remove superfluous null check

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java
@@ -65,10 +65,6 @@ public abstract class FullScreenGodotApp extends FragmentActivity implements God
 		} else {
 			Log.v(TAG, "Creating new Godot fragment instance.");
 			godotFragment = initGodotInstance();
-			if (godotFragment == null) {
-				throw new IllegalStateException("Godot instance must be non-null.");
-			}
-
 			getSupportFragmentManager().beginTransaction().replace(R.id.godot_fragment_container, godotFragment).setPrimaryNavigationFragment(godotFragment).commitNowAllowingStateLoss();
 		}
 	}


### PR DESCRIPTION
`initGodotInstance()` is marked `@NonNull`:
https://github.com/godotengine/godot/blob/f4b0c7a1ea8d86c1dfd96478ca12ad1360903d9d/platform/android/java/lib/src/org/godotengine/godot/FullScreenGodotApp.java#L147-L150
Therefore, to check whether the returned value is `null` is superfluous.
This PR removes the superfluous `null` check after calling `initGodotInstance()`.
The PR can be cherry picked for 3.x.
