### PR TITLE
[3.x] Fix crash in `GodotNavigationServer::map_get_path`, fixes #60413

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -156,10 +156,10 @@ Vector<Vector3> NavMap::get_path(Vector3 p_origin, Vector3 p_destination, bool p
 
 	while (found_route == false) {
 		{
-			gd::NavigationPoly *least_cost_poly = &navigation_polys[least_cost_id];
-
 			// Takes the current least_cost_poly neighbors and compute the traveled_distance of each
 			for (size_t i = 0; i < navigation_polys[least_cost_id].poly->edges.size(); i++) {
+				gd::NavigationPoly *least_cost_poly = &navigation_polys[least_cost_id];
+
 				const gd::Edge &edge = least_cost_poly->poly->edges[i];
 				if (!edge.other_polygon)
 					continue;


### PR DESCRIPTION
fixes #60413

the problem was that the line:
```
gd::NavigationPoly *least_cost_poly = &navigation_polys[least_cost_id];
```
was moved out from the `for` loop begin while in the loop we have such a statement:
```
navigation_polys.push_back(new_navigation_poly);
```
which may lead to vector's memory reallocation in which case pointers to elements (like e.g. `gd::NavigationPoly *least_cost_poly = &navigation_polys[least_cost_id]`) are invalidated