### PR TITLE
Remove `Array` link in description of `Packed*Array`

### DIFF
--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PackedByteArray" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A packed [Array] of bytes.
+		A packed array of bytes.
 	</brief_description>
 	<description>
-		An [Array] specifically designed to hold bytes. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold bytes. Packs data tightly, so it saves memory for large array sizes.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PackedColorArray" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A packed [Array] of [Color]s.
+		A packed array of [Color]s.
 	</brief_description>
 	<description>
-		An [Array] specifically designed to hold [Color]. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold [Color]. Packs data tightly, so it saves memory for large array sizes.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PackedFloat32Array" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A packed [Array] of 32-bit floating-point values.
+		A packed array of 32-bit floating-point values.
 	</brief_description>
 	<description>
-		An [Array] specifically designed to hold 32-bit floating-point values. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold 32-bit floating-point values. Packs data tightly, so it saves memory for large array sizes.
 		If you need to pack 64-bit floats tightly, see [PackedFloat64Array].
 	</description>
 	<tutorials>

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PackedFloat64Array" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A packed [Array] of 64-bit floating-point values.
+		A packed array of 64-bit floating-point values.
 	</brief_description>
 	<description>
-		An [Array] specifically designed to hold 64-bit floating-point values. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold 64-bit floating-point values. Packs data tightly, so it saves memory for large array sizes.
 		If you only need to pack 32-bit floats tightly, see [PackedFloat32Array] for a more memory-friendly alternative.
 	</description>
 	<tutorials>

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PackedInt32Array" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A packed [Array] of 32-bit integers.
+		A packed array of 32-bit integers.
 	</brief_description>
 	<description>
-		An [Array] specifically designed to hold 32-bit integer values. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold 32-bit integer values. Packs data tightly, so it saves memory for large array sizes.
 		[b]Note:[/b] This type stores signed 32-bit integers, which means it can take values in the interval [code][-2^31, 2^31 - 1][/code], i.e. [code][-2147483648, 2147483647][/code]. Exceeding those bounds will wrap around. In comparison, [int] uses signed 64-bit integers which can hold much larger values. If you need to pack 64-bit integers tightly, see [PackedInt64Array].
 	</description>
 	<tutorials>

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PackedInt64Array" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A packed [Array] of 64-bit integers.
+		A packed array of 64-bit integers.
 	</brief_description>
 	<description>
-		An [Array] specifically designed to hold 64-bit integer values. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold 64-bit integer values. Packs data tightly, so it saves memory for large array sizes.
 		[b]Note:[/b] This type stores signed 64-bit integers, which means it can take values in the interval [code][-2^63, 2^63 - 1][/code], i.e. [code][-9223372036854775808, 9223372036854775807][/code]. Exceeding those bounds will wrap around. If you only need to pack 32-bit integers tightly, see [PackedInt32Array] for a more memory-friendly alternative.
 	</description>
 	<tutorials>

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PackedStringArray" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A packed [Array] of [String]s.
+		A packed array of [String]s.
 	</brief_description>
 	<description>
-		An [Array] specifically designed to hold [String]s. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold [String]s. Packs data tightly, so it saves memory for large array sizes.
 	</description>
 	<tutorials>
 		<link title="OS Test Demo">https://godotengine.org/asset-library/asset/677</link>

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PackedVector2Array" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A packed [Array] of [Vector2]s.
+		A packed array of [Vector2]s.
 	</brief_description>
 	<description>
-		An [Array] specifically designed to hold [Vector2]. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold [Vector2]. Packs data tightly, so it saves memory for large array sizes.
 	</description>
 	<tutorials>
 		<link title="2D Navigation Astar Demo">https://godotengine.org/asset-library/asset/519</link>

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <class name="PackedVector3Array" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
-		A packed [Array] of [Vector3]s.
+		A packed array of [Vector3]s.
 	</brief_description>
 	<description>
-		An [Array] specifically designed to hold [Vector3]. Packs data tightly, so it saves memory for large array sizes.
+		An array specifically designed to hold [Vector3]. Packs data tightly, so it saves memory for large array sizes.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
```diff
- A packed [Array] of bytes.
+ A packed array of bytes.
```

`Packed*Array` and `Array` are different types.

The previous description sounds like `Packed*Array` inherit from `Array`.