### PR TITLE
Changed "pair" to "triplet" in Vector3 definition

### DIFF
--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -4,7 +4,7 @@
 		Vector used for 3D math using floating point coordinates.
 	</brief_description>
 	<description>
-		3-element structure that can be used to represent positions in 3D space or any other pair of numeric values.
+		3-element structure that can be used to represent positions in 3D space or any other triplet of numeric values.
 		It uses floating-point coordinates. See [Vector3i] for its integer counterpart.
 		[b]Note:[/b] In a boolean context, a Vector3 will evaluate to [code]false[/code] if it's equal to [code]Vector3(0, 0, 0)[/code]. Otherwise, a Vector3 will always evaluate to [code]true[/code].
 	</description>

--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -4,7 +4,7 @@
 		Vector used for 3D math using integer coordinates.
 	</brief_description>
 	<description>
-		3-element structure that can be used to represent positions in 3D space or any other pair of numeric values.
+		3-element structure that can be used to represent positions in 3D space or any other triplet of numeric values.
 		It uses integer coordinates and is therefore preferable to [Vector3] when exact precision is required.
 		[b]Note:[/b] In a boolean context, a Vector3i will evaluate to [code]false[/code] if it's equal to [code]Vector3i(0, 0, 0)[/code]. Otherwise, a Vector3i will always evaluate to [code]true[/code].
 	</description>


### PR DESCRIPTION
A Vector3 has specifically 3 components, and "pair" seems to contradict this. I'm not sure if "triplet" is the right alternative, perhaps "set" would be better?