### PR TITLE
Fix wrong theme override default value

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -350,13 +350,13 @@ bool Control::_get(const StringName &p_name, Variant &r_ret) const {
 		r_ret = data.font_override.has(name) ? Variant(data.font_override[name]) : Variant();
 	} else if (sname.begins_with("theme_override_font_sizes/")) {
 		String name = sname.get_slicec('/', 1);
-		r_ret = data.font_size_override.has(name) ? Variant(data.font_size_override[name]) : Variant();
+		r_ret = data.font_size_override.has(name) ? Variant(data.font_size_override[name]) : Variant(0);
 	} else if (sname.begins_with("theme_override_colors/")) {
 		String name = sname.get_slicec('/', 1);
-		r_ret = data.color_override.has(name) ? Variant(data.color_override[name]) : Variant();
+		r_ret = data.color_override.has(name) ? Variant(data.color_override[name]) : Variant(Color());
 	} else if (sname.begins_with("theme_override_constants/")) {
 		String name = sname.get_slicec('/', 1);
-		r_ret = data.constant_override.has(name) ? Variant(data.constant_override[name]) : Variant();
+		r_ret = data.constant_override.has(name) ? Variant(data.constant_override[name]) : Variant(0);
 	} else {
 		return false;
 	}


### PR DESCRIPTION
When a theme property is not overridden, `Control` always return `null` for theme override item, even for none object items like color and constants. This makes checking these theme override items bring up the reset button.

| Before | After |
| --- | --- |
| ![Peek 2022-04-23 23-03](https://user-images.githubusercontent.com/372476/164911706-c7c57a91-be3f-4cb2-ba5d-44ff39820f7c.gif) | ![Peek 2022-04-23 23-05](https://user-images.githubusercontent.com/372476/164911777-a3aac1db-df98-46f8-9f41-ce0b66b463e5.gif) |