### PR TITLE
Improve descriptions for drag methods

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -665,7 +665,8 @@
 		<method name="is_drag_successful" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if drag operation is successful.
+				Returns [code]true[/code] if a drag operation is successful. Alternative to [method Viewport.gui_is_drag_successful].
+				Best used with [constant Node.NOTIFICATION_DRAG_END].
 			</description>
 		</method>
 		<method name="is_layout_rtl" qualifiers="const">

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -830,10 +830,13 @@
 			Notification received when the node is instantiated.
 		</constant>
 		<constant name="NOTIFICATION_DRAG_BEGIN" value="21">
-			Notification received when a drag begins.
+			Notification received when a drag operation begins. All nodes receive this notification, not only the dragged one.
+			Can be triggered either by dragging a [Control] that provides drag data (see [method Control._get_drag_data]) or using [method Control.force_drag].
+			Use [method Viewport.gui_get_drag_data] to get the dragged data.
 		</constant>
 		<constant name="NOTIFICATION_DRAG_END" value="22">
-			Notification received when a drag ends.
+			Notification received when a drag operation ends.
+			Use [method Viewport.gui_is_drag_successful] to check if the drag succeeded.
 		</constant>
 		<constant name="NOTIFICATION_PATH_RENAMED" value="23">
 			Notification received when the node's name or one of its parents' name is changed. This notification is [i]not[/i] received when the node is removed from the scene tree to be added to another parent later on.

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -122,6 +122,7 @@
 			<return type="bool" />
 			<description>
 				Returns [code]true[/code] if the viewport is currently performing a drag operation.
+				Alternative to [constant Node.NOTIFICATION_DRAG_BEGIN] and [constant Node.NOTIFICATION_DRAG_END] when you prefer polling the value.
 			</description>
 		</method>
 		<method name="gui_release_focus">


### PR DESCRIPTION
There seems to be a set of methods for dragging that are alternative to usual `_drop_data()` etc., but I noticed that their usage isn't documented very well. I added some words, so now there is more information.