### PR TITLE
Add support for per-handle colors to 3D editor gizmos

### DIFF
--- a/doc/classes/EditorNode3DGizmo.xml
+++ b/doc/classes/EditorNode3DGizmo.xml
@@ -127,9 +127,11 @@
 			<argument index="2" name="ids" type="PackedInt32Array" />
 			<argument index="3" name="billboard" type="bool" default="false" />
 			<argument index="4" name="secondary" type="bool" default="false" />
+			<argument index="5" name="handle_colors" type="PackedColorArray" default="PackedColorArray()" />
 			<description>
 				Adds a list of handles (points) which can be used to edit the properties of the gizmo's Node3D. The [code]ids[/code] argument can be used to specify a custom identifier for each handle, if an empty [code]Array[/code] is passed, the ids will be assigned automatically from the [code]handles[/code] argument order.
 				The [code]secondary[/code] argument marks the added handles as secondary, meaning they will normally have less selection priority than regular handles. When the user is holding the shift key secondary handles will switch to have higher priority than regular handles. This change in priority can be used to place multiple handles at the same point while still giving the user control on their selection.
+				If [code]handle_colors[/code] is not empty, it will be used to modulate the handle material's color on a per-handle basis. This is only effective if the [code]material[/code] has the [constant BaseMaterial3D.FLAG_ALBEDO_FROM_VERTEX_COLOR] flag enabled. If [code]handle_colors[/code] is not empty, the size of the [code]handle_colors[/code] array [i]must[/i] match the size of the [code]handles[/code] array.
 				There are virtual methods which will be called upon editing of these handles. Call this method during [method _redraw].
 			</description>
 		</method>

--- a/editor/icons/Editor3DHandle.svg
+++ b/editor/icons/Editor3DHandle.svg
@@ -1,1 +1,1 @@
-<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" fill-opacity=".29412" r="8"/><circle cx="8" cy="8" fill="#fff" r="7"/><circle cx="8" cy="8" fill="#ff5f5f" r="5"/></svg>
+<svg height="16" viewBox="0 0 16 16" width="16" xmlns="http://www.w3.org/2000/svg"><circle cx="8" cy="8" fill-opacity=".29412" r="8"/><circle cx="8" cy="8" fill="#fff" r="7"/><circle cx="8" cy="8" fill="#afafaf" r="5"/></svg>

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -393,7 +393,7 @@ void EditorNode3DGizmo::add_collision_segments(const Vector<Vector3> &p_lines) {
 	}
 }
 
-void EditorNode3DGizmo::add_handles(const Vector<Vector3> &p_handles, const Ref<Material> &p_material, const Vector<int> &p_ids, bool p_billboard, bool p_secondary) {
+void EditorNode3DGizmo::add_handles(const Vector<Vector3> &p_handles, const Ref<Material> &p_material, const Vector<int> &p_ids, bool p_billboard, bool p_secondary, const Vector<Color> &p_handle_colors) {
 	billboard_handle = p_billboard;
 
 	if (!is_selected() || !is_editable()) {
@@ -406,6 +406,10 @@ void EditorNode3DGizmo::add_handles(const Vector<Vector3> &p_handles, const Ref<
 		ERR_FAIL_COND_MSG((!handles.is_empty() && !handle_ids.is_empty()) || (!secondary_handles.is_empty() && !secondary_handle_ids.is_empty()), "Fail");
 	} else {
 		ERR_FAIL_COND_MSG(handles.size() != handle_ids.size() || secondary_handles.size() != secondary_handle_ids.size(), "Fail");
+	}
+
+	if (!p_handle_colors.is_empty()) {
+		ERR_FAIL_COND_MSG(p_handles.size() != p_handle_colors.size(), vformat("The size of the handle colors array (%d items) must match the size of the handles array (%d items), or it must be empty to disable per-handle coloring.", p_handle_colors.size(), p_handles.size()));
 	}
 
 	bool is_current_hover_gizmo = Node3DEditor::get_singleton()->get_current_hover_gizmo() == this;
@@ -423,14 +427,16 @@ void EditorNode3DGizmo::add_handles(const Vector<Vector3> &p_handles, const Ref<
 		colors.resize(p_handles.size());
 		Color *w = colors.ptrw();
 		for (int i = 0; i < p_handles.size(); i++) {
-			Color col(1, 1, 1, 1);
-			if (is_handle_highlighted(i, p_secondary)) {
-				col = Color(0, 0, 1, 0.9);
+			Color col;
+			if (!p_handle_colors.is_empty()) {
+				col = Color(1, 1, 1, 0.9) * p_handle_colors[i];
+			} else {
+				col = Color(1, 1, 1, 0.9);
 			}
 
-			int id = p_ids.is_empty() ? i : p_ids[i];
-			if (!is_current_hover_gizmo || current_hover_handle != id || p_secondary != current_hover_handle_secondary) {
-				col.a = 0.8;
+			const int id = p_ids.is_empty() ? i : p_ids[i];
+			if ((is_current_hover_gizmo && current_hover_handle == id && p_secondary == current_hover_handle_secondary) || is_handle_highlighted(i, p_secondary)) {
+				col = col.from_hsv(col.get_h(), 0.25, 1.0, 1);
 			}
 
 			w[i] = col;
@@ -832,7 +838,7 @@ void EditorNode3DGizmo::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("add_collision_segments", "segments"), &EditorNode3DGizmo::add_collision_segments);
 	ClassDB::bind_method(D_METHOD("add_collision_triangles", "triangles"), &EditorNode3DGizmo::add_collision_triangles);
 	ClassDB::bind_method(D_METHOD("add_unscaled_billboard", "material", "default_scale", "modulate"), &EditorNode3DGizmo::add_unscaled_billboard, DEFVAL(1), DEFVAL(Color(1, 1, 1)));
-	ClassDB::bind_method(D_METHOD("add_handles", "handles", "material", "ids", "billboard", "secondary"), &EditorNode3DGizmo::add_handles, DEFVAL(false), DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("add_handles", "handles", "material", "ids", "billboard", "secondary", "handle_colors"), &EditorNode3DGizmo::add_handles, DEFVAL(false), DEFVAL(false), DEFVAL(Vector<Color>()));
 	ClassDB::bind_method(D_METHOD("set_spatial_node", "node"), &EditorNode3DGizmo::_set_spatial_node);
 	ClassDB::bind_method(D_METHOD("get_spatial_node"), &EditorNode3DGizmo::get_spatial_node);
 	ClassDB::bind_method(D_METHOD("get_plugin"), &EditorNode3DGizmo::get_plugin);

--- a/editor/plugins/node_3d_editor_gizmos.h
+++ b/editor/plugins/node_3d_editor_gizmos.h
@@ -98,7 +98,7 @@ public:
 	void add_collision_segments(const Vector<Vector3> &p_lines);
 	void add_collision_triangles(const Ref<TriangleMesh> &p_tmesh);
 	void add_unscaled_billboard(const Ref<Material> &p_material, real_t p_scale = 1, const Color &p_modulate = Color(1, 1, 1));
-	void add_handles(const Vector<Vector3> &p_handles, const Ref<Material> &p_material, const Vector<int> &p_ids = Vector<int>(), bool p_billboard = false, bool p_secondary = false);
+	void add_handles(const Vector<Vector3> &p_handles, const Ref<Material> &p_material, const Vector<int> &p_ids = Vector<int>(), bool p_billboard = false, bool p_secondary = false, const Vector<Color> &p_handle_colors = Vector<Color>());
 	void add_solid_box(Ref<Material> &p_material, Vector3 p_size, Vector3 p_position = Vector3(), const Transform3D &p_xform = Transform3D());
 
 	virtual bool is_handle_highlighted(int p_id, bool p_secondary) const;

--- a/modules/csg/editor/csg_gizmos.cpp
+++ b/modules/csg/editor/csg_gizmos.cpp
@@ -32,6 +32,7 @@
 
 #ifdef TOOLS_ENABLED
 
+#include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "scene/3d/camera_3d.h"
@@ -401,7 +402,13 @@ void CSGShape3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 			handles.push_back(h);
 		}
 
-		p_gizmo->add_handles(handles, handles_material);
+		const Vector<Color> colors = {
+			EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("axis_x_color"), SNAME("Editor")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("axis_y_color"), SNAME("Editor")),
+			EditorNode::get_singleton()->get_gui_base()->get_theme_color(SNAME("axis_z_color"), SNAME("Editor")),
+		};
+
+		p_gizmo->add_handles(handles, handles_material, Vector<int>(), false, false, colors);
 	}
 
 	if (Object::cast_to<CSGCylinder3D>(cs)) {


### PR DESCRIPTION
This can be used to color handles depending on the axis they modify, their purpose, and more. This is accessible from the scripting API. As a bonus, the hover feedback is now much more noticeable.

In the editor itself, this is only used in CSGBox3D for now.

Per-handle colors are optional. Gizmos not using per-handle colors will use a default gray color.

**Note:** Marked as draft, since I'd like to add per-handle colors to various built-in 3D nodes before this can be merged.

## Preview

### Per-handle color

https://user-images.githubusercontent.com/180032/164915383-4be0d927-660f-45af-8824-678de3f5642f.mp4

### Default handle color

https://user-images.githubusercontent.com/180032/164915403-9574d1f4-024d-449d-8fd6-4306ccb9d3c5.mp4