### PR TITLE
Audio bus overhaul

### DIFF
--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -71,6 +71,8 @@ class EditorAudioBus : public PanelContainer {
 
 	OptionButton *send = nullptr;
 
+	OptionButton *type = nullptr;
+
 	PopupMenu *effect_options = nullptr;
 	PopupMenu *bus_popup = nullptr;
 	PopupMenu *delete_effect_popup = nullptr;
@@ -104,6 +106,7 @@ class EditorAudioBus : public PanelContainer {
 	void _mute_toggled();
 	void _bypass_toggled();
 	void _send_selected(int p_which);
+	void _type_selected(int p_which);
 	void _effect_edited();
 	void _effect_add(int p_which);
 	void _effect_selected();
@@ -130,6 +133,7 @@ protected:
 public:
 	void update_bus();
 	void update_send();
+	void update_type();
 
 	EditorAudioBus(EditorAudioBuses *p_buses = nullptr, bool p_is_master = false);
 };

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -133,6 +133,7 @@
 #include "editor/plugins/animation_tree_editor_plugin.h"
 #include "editor/plugins/asset_library_editor_plugin.h"
 #include "editor/plugins/audio_stream_editor_plugin.h"
+#include "editor/plugins/audio_stream_player_editor_plugin.h"
 #include "editor/plugins/audio_stream_randomizer_editor_plugin.h"
 #include "editor/plugins/camera_3d_editor_plugin.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
@@ -7053,6 +7054,7 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(TextureLayeredEditorPlugin));
 	add_editor_plugin(memnew(Texture3DEditorPlugin));
 	add_editor_plugin(memnew(AudioStreamEditorPlugin));
+	add_editor_plugin(memnew(AudioStreamPlayerEditorPlugin));
 	add_editor_plugin(memnew(AudioStreamRandomizerEditorPlugin));
 	add_editor_plugin(memnew(AudioBusesEditorPlugin(audio_bus_editor)));
 	add_editor_plugin(memnew(Skeleton3DEditorPlugin));

--- a/editor/plugins/audio_stream_player_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_player_editor_plugin.cpp
@@ -1,0 +1,121 @@
+/*************************************************************************/
+/*  audio_stream_player_plugin.cpp                                       */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "audio_stream_player_editor_plugin.h"
+
+#include "editor/editor_node.h"
+
+void AudioStreamPlayerEditorPlugin::edit(Object *p_object) {
+}
+
+bool AudioStreamPlayerEditorPlugin::handles(Object *p_object) const {
+	return false;
+}
+
+void AudioStreamPlayerEditorPlugin::make_visible(bool p_visible) {
+}
+
+void AudioStreamPlayerEditorPlugin::_move_send_array_element(Object *p_undo_redo, Object *p_edited, String p_array_prefix, int p_from_index, int p_to_pos) {
+	UndoRedo *undo_redo = Object::cast_to<UndoRedo>(p_undo_redo);
+	ERR_FAIL_COND(!undo_redo);
+
+	AudioStreamPlayer *player = Object::cast_to<AudioStreamPlayer>(p_edited);
+	if (!player) {
+		return;
+	}
+
+	// Compute the array indices to save.
+	int begin = 0;
+	int end;
+	if (p_array_prefix == "send_") {
+		end = player->get_sends_count();
+	} else {
+		ERR_FAIL_MSG("Invalid array prefix for AudioStreamPlayer.");
+	}
+	if (p_from_index < 0) {
+		// Adding new.
+		if (p_to_pos >= 0) {
+			begin = p_to_pos;
+		} else {
+			end = 0; // Nothing to save when adding at the end.
+		}
+	} else if (p_to_pos < 0) {
+		// Removing.
+		begin = p_from_index;
+	} else {
+		// Moving.
+		begin = MIN(p_from_index, p_to_pos);
+		end = MIN(MAX(p_from_index, p_to_pos) + 1, end);
+	}
+
+#define ADD_UNDO(obj, property) undo_redo->add_undo_property(obj, property, obj->get(property));
+	// Save layers' properties.
+	if (p_from_index < 0) {
+		undo_redo->add_undo_method(player, "remove_send", p_to_pos < 0 ? player->get_sends_count() : p_to_pos);
+	} else if (p_to_pos < 0) {
+		undo_redo->add_undo_method(player, "add_send", p_from_index);
+	}
+
+	List<PropertyInfo> properties;
+	player->get_property_list(&properties);
+	for (PropertyInfo pi : properties) {
+		if (pi.name.begins_with(p_array_prefix)) {
+			String str = pi.name.trim_prefix(p_array_prefix);
+			int to_char_index = 0;
+			while (to_char_index < str.length()) {
+				if (str[to_char_index] < '0' || str[to_char_index] > '9') {
+					break;
+				}
+				to_char_index++;
+			}
+			if (to_char_index > 0) {
+				int array_index = str.left(to_char_index).to_int();
+				if (array_index >= begin && array_index < end) {
+					ADD_UNDO(player, pi.name);
+				}
+			}
+		}
+	}
+#undef ADD_UNDO
+
+	if (p_from_index < 0) {
+		undo_redo->add_do_method(player, "add_send", p_to_pos);
+	} else if (p_to_pos < 0) {
+		undo_redo->add_do_method(player, "remove_send", p_from_index);
+	} else {
+		undo_redo->add_do_method(player, "move_send", p_from_index, p_to_pos);
+	}
+}
+
+AudioStreamPlayerEditorPlugin::AudioStreamPlayerEditorPlugin() {
+	EditorNode::get_singleton()->get_editor_data().add_move_array_element_function(SNAME("AudioStreamPlayer"), callable_mp(this, &AudioStreamPlayerEditorPlugin::_move_send_array_element));
+}
+
+AudioStreamPlayerEditorPlugin::~AudioStreamPlayerEditorPlugin() {}

--- a/editor/plugins/audio_stream_player_editor_plugin.h
+++ b/editor/plugins/audio_stream_player_editor_plugin.h
@@ -1,0 +1,54 @@
+/*************************************************************************/
+/*  audio_stream_player_plugin.h                                         */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef AUDIO_STREAM_PLAYER_EDITOR_PLUGIN_H
+#define AUDIO_STREAM_PLAYER_EDITOR_PLUGIN_H
+
+#include "editor/editor_plugin.h"
+#include "scene/audio/audio_stream_player.h"
+
+class AudioStreamPlayerEditorPlugin : public EditorPlugin {
+	GDCLASS(AudioStreamPlayerEditorPlugin, EditorPlugin);
+
+private:
+	void _move_send_array_element(Object *p_undo_redo, Object *p_edited, String p_array_prefix, int p_from_index, int p_to_pos);
+
+public:
+	virtual String get_name() const override { return "AudioStreamPlayer"; }
+	bool has_main_screen() const override { return false; }
+	virtual void edit(Object *p_object) override;
+	virtual bool handles(Object *p_object) const override;
+	virtual void make_visible(bool p_visible) override;
+
+	AudioStreamPlayerEditorPlugin();
+	~AudioStreamPlayerEditorPlugin();
+};
+
+#endif // AUDIO_STREAM_PLAYER_EDITOR_PLUGIN_H

--- a/scene/2d/area_2d.cpp
+++ b/scene/2d/area_2d.cpp
@@ -477,40 +477,8 @@ bool Area2D::overlaps_body(Node *p_body) const {
 	return E->get().in_tree;
 }
 
-void Area2D::set_audio_bus_override(bool p_override) {
-	audio_bus_override = p_override;
-}
-
-bool Area2D::is_overriding_audio_bus() const {
-	return audio_bus_override;
-}
-
-void Area2D::set_audio_bus_name(const StringName &p_audio_bus) {
-	audio_bus = p_audio_bus;
-}
-
-StringName Area2D::get_audio_bus_name() const {
-	for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
-		if (AudioServer::get_singleton()->get_bus_name(i) == audio_bus) {
-			return audio_bus;
-		}
-	}
-	return "Master";
-}
-
 void Area2D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "audio_bus_name") {
-		String options;
-		for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
-			if (i > 0) {
-				options += ",";
-			}
-			String name = AudioServer::get_singleton()->get_bus_name(i);
-			options += name;
-		}
-
-		property.hint_string = options;
-	} else if (property.name.begins_with("gravity") && property.name != "gravity_space_override") {
+	if (property.name.begins_with("gravity") && property.name != "gravity_space_override") {
 		if (gravity_space_override == SPACE_OVERRIDE_DISABLED) {
 			property.usage = PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL;
 		} else {
@@ -581,12 +549,6 @@ void Area2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("overlaps_body", "body"), &Area2D::overlaps_body);
 	ClassDB::bind_method(D_METHOD("overlaps_area", "area"), &Area2D::overlaps_area);
 
-	ClassDB::bind_method(D_METHOD("set_audio_bus_name", "name"), &Area2D::set_audio_bus_name);
-	ClassDB::bind_method(D_METHOD("get_audio_bus_name"), &Area2D::get_audio_bus_name);
-
-	ClassDB::bind_method(D_METHOD("set_audio_bus_override", "enable"), &Area2D::set_audio_bus_override);
-	ClassDB::bind_method(D_METHOD("is_overriding_audio_bus"), &Area2D::is_overriding_audio_bus);
-
 	ADD_SIGNAL(MethodInfo("body_shape_entered", PropertyInfo(Variant::RID, "body_rid"), PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node2D"), PropertyInfo(Variant::INT, "body_shape_index"), PropertyInfo(Variant::INT, "local_shape_index")));
 	ADD_SIGNAL(MethodInfo("body_shape_exited", PropertyInfo(Variant::RID, "body_rid"), PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node2D"), PropertyInfo(Variant::INT, "body_shape_index"), PropertyInfo(Variant::INT, "local_shape_index")));
 	ADD_SIGNAL(MethodInfo("body_entered", PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node2D")));
@@ -616,10 +578,6 @@ void Area2D::_bind_methods() {
 	ADD_GROUP("Angular Damp", "angular_damp_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "angular_damp_space_override", PROPERTY_HINT_ENUM, "Disabled,Combine,Combine-Replace,Replace,Replace-Combine", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_UPDATE_ALL_IF_MODIFIED), "set_angular_damp_space_override_mode", "get_angular_damp_space_override_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "angular_damp", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater"), "set_angular_damp", "get_angular_damp");
-
-	ADD_GROUP("Audio Bus", "audio_bus_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_bus_override"), "set_audio_bus_override", "is_overriding_audio_bus");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "audio_bus_name", PROPERTY_HINT_ENUM, ""), "set_audio_bus_name", "get_audio_bus_name");
 
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_DISABLED);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_COMBINE);

--- a/scene/2d/area_2d.h
+++ b/scene/2d/area_2d.h
@@ -129,9 +129,6 @@ private:
 	Map<ObjectID, AreaState> area_map;
 	void _clear_monitoring();
 
-	bool audio_bus_override = false;
-	StringName audio_bus;
-
 protected:
 	void _notification(int p_what);
 	static void _bind_methods();
@@ -182,12 +179,6 @@ public:
 
 	bool overlaps_area(Node *p_area) const;
 	bool overlaps_body(Node *p_body) const;
-
-	void set_audio_bus_override(bool p_override);
-	bool is_overriding_audio_bus() const;
-
-	void set_audio_bus_name(const StringName &p_audio_bus);
-	StringName get_audio_bus_name() const;
 
 	Area2D();
 	~Area2D();

--- a/scene/2d/audio_stream_player_2d.h
+++ b/scene/2d/audio_stream_player_2d.h
@@ -70,7 +70,6 @@ private:
 	void _set_playing(bool p_enable);
 	bool _is_active() const;
 
-	StringName _get_actual_bus();
 	void _update_panning();
 	void _bus_layout_changed();
 

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -540,77 +540,8 @@ bool Area3D::overlaps_body(Node *p_body) const {
 	return E->get().in_tree;
 }
 
-void Area3D::set_audio_bus_override(bool p_override) {
-	audio_bus_override = p_override;
-}
-
-bool Area3D::is_overriding_audio_bus() const {
-	return audio_bus_override;
-}
-
-void Area3D::set_audio_bus_name(const StringName &p_audio_bus) {
-	audio_bus = p_audio_bus;
-}
-
-StringName Area3D::get_audio_bus_name() const {
-	for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
-		if (AudioServer::get_singleton()->get_bus_name(i) == audio_bus) {
-			return audio_bus;
-		}
-	}
-	return "Master";
-}
-
-void Area3D::set_use_reverb_bus(bool p_enable) {
-	use_reverb_bus = p_enable;
-}
-
-bool Area3D::is_using_reverb_bus() const {
-	return use_reverb_bus;
-}
-
-void Area3D::set_reverb_bus(const StringName &p_audio_bus) {
-	reverb_bus = p_audio_bus;
-}
-
-StringName Area3D::get_reverb_bus() const {
-	for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
-		if (AudioServer::get_singleton()->get_bus_name(i) == reverb_bus) {
-			return reverb_bus;
-		}
-	}
-	return "Master";
-}
-
-void Area3D::set_reverb_amount(float p_amount) {
-	reverb_amount = p_amount;
-}
-
-float Area3D::get_reverb_amount() const {
-	return reverb_amount;
-}
-
-void Area3D::set_reverb_uniformity(float p_uniformity) {
-	reverb_uniformity = p_uniformity;
-}
-
-float Area3D::get_reverb_uniformity() const {
-	return reverb_uniformity;
-}
-
 void Area3D::_validate_property(PropertyInfo &property) const {
-	if (property.name == "audio_bus_name" || property.name == "reverb_bus_name") {
-		String options;
-		for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
-			if (i > 0) {
-				options += ",";
-			}
-			String name = AudioServer::get_singleton()->get_bus_name(i);
-			options += name;
-		}
-
-		property.hint_string = options;
-	} else if (property.name.begins_with("gravity") && property.name != "gravity_space_override") {
+	if (property.name.begins_with("gravity") && property.name != "gravity_space_override") {
 		if (gravity_space_override == SPACE_OVERRIDE_DISABLED) {
 			property.usage = PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL;
 		} else {
@@ -692,24 +623,6 @@ void Area3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("overlaps_body", "body"), &Area3D::overlaps_body);
 	ClassDB::bind_method(D_METHOD("overlaps_area", "area"), &Area3D::overlaps_area);
 
-	ClassDB::bind_method(D_METHOD("set_audio_bus_override", "enable"), &Area3D::set_audio_bus_override);
-	ClassDB::bind_method(D_METHOD("is_overriding_audio_bus"), &Area3D::is_overriding_audio_bus);
-
-	ClassDB::bind_method(D_METHOD("set_audio_bus_name", "name"), &Area3D::set_audio_bus_name);
-	ClassDB::bind_method(D_METHOD("get_audio_bus_name"), &Area3D::get_audio_bus_name);
-
-	ClassDB::bind_method(D_METHOD("set_use_reverb_bus", "enable"), &Area3D::set_use_reverb_bus);
-	ClassDB::bind_method(D_METHOD("is_using_reverb_bus"), &Area3D::is_using_reverb_bus);
-
-	ClassDB::bind_method(D_METHOD("set_reverb_bus", "name"), &Area3D::set_reverb_bus);
-	ClassDB::bind_method(D_METHOD("get_reverb_bus"), &Area3D::get_reverb_bus);
-
-	ClassDB::bind_method(D_METHOD("set_reverb_amount", "amount"), &Area3D::set_reverb_amount);
-	ClassDB::bind_method(D_METHOD("get_reverb_amount"), &Area3D::get_reverb_amount);
-
-	ClassDB::bind_method(D_METHOD("set_reverb_uniformity", "amount"), &Area3D::set_reverb_uniformity);
-	ClassDB::bind_method(D_METHOD("get_reverb_uniformity"), &Area3D::get_reverb_uniformity);
-
 	ADD_SIGNAL(MethodInfo("body_shape_entered", PropertyInfo(Variant::RID, "body_rid"), PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node3D"), PropertyInfo(Variant::INT, "body_shape_index"), PropertyInfo(Variant::INT, "local_shape_index")));
 	ADD_SIGNAL(MethodInfo("body_shape_exited", PropertyInfo(Variant::RID, "body_rid"), PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node3D"), PropertyInfo(Variant::INT, "body_shape_index"), PropertyInfo(Variant::INT, "local_shape_index")));
 	ADD_SIGNAL(MethodInfo("body_entered", PropertyInfo(Variant::OBJECT, "body", PROPERTY_HINT_RESOURCE_TYPE, "Node3D")));
@@ -744,16 +657,6 @@ void Area3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "wind_force_magnitude", PROPERTY_HINT_RANGE, "0,10,0.001,or_greater"), "set_wind_force_magnitude", "get_wind_force_magnitude");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "wind_attenuation_factor", PROPERTY_HINT_RANGE, "0.0,3.0,0.001,or_greater"), "set_wind_attenuation_factor", "get_wind_attenuation_factor");
 	ADD_PROPERTY(PropertyInfo(Variant::NODE_PATH, "wind_source_path", PROPERTY_HINT_NODE_PATH_VALID_TYPES, "Node3D"), "set_wind_source_path", "get_wind_source_path");
-
-	ADD_GROUP("Audio Bus", "audio_bus_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "audio_bus_override"), "set_audio_bus_override", "is_overriding_audio_bus");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "audio_bus_name", PROPERTY_HINT_ENUM, ""), "set_audio_bus_name", "get_audio_bus_name");
-
-	ADD_GROUP("Reverb Bus", "reverb_bus_");
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "reverb_bus_enable"), "set_use_reverb_bus", "is_using_reverb_bus");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "reverb_bus_name", PROPERTY_HINT_ENUM, ""), "set_reverb_bus", "get_reverb_bus");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "reverb_bus_amount", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_reverb_amount", "get_reverb_amount");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "reverb_bus_uniformity", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_reverb_uniformity", "get_reverb_uniformity");
 
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_DISABLED);
 	BIND_ENUM_CONSTANT(SPACE_OVERRIDE_COMBINE);

--- a/scene/3d/area_3d.h
+++ b/scene/3d/area_3d.h
@@ -133,14 +133,6 @@ private:
 	Map<ObjectID, AreaState> area_map;
 	void _clear_monitoring();
 
-	bool audio_bus_override = false;
-	StringName audio_bus = "Master";
-
-	bool use_reverb_bus = false;
-	StringName reverb_bus = "Master";
-	float reverb_amount = 0.0;
-	float reverb_uniformity = 0.0;
-
 	void _validate_property(PropertyInfo &property) const override;
 
 	void _initialize_wind();
@@ -203,24 +195,6 @@ public:
 
 	bool overlaps_area(Node *p_area) const;
 	bool overlaps_body(Node *p_body) const;
-
-	void set_audio_bus_override(bool p_override);
-	bool is_overriding_audio_bus() const;
-
-	void set_audio_bus_name(const StringName &p_audio_bus);
-	StringName get_audio_bus_name() const;
-
-	void set_use_reverb_bus(bool p_enable);
-	bool is_using_reverb_bus() const;
-
-	void set_reverb_bus(const StringName &p_audio_bus);
-	StringName get_reverb_bus() const;
-
-	void set_reverb_amount(float p_amount);
-	float get_reverb_amount() const;
-
-	void set_reverb_uniformity(float p_uniformity);
-	float get_reverb_uniformity() const;
 
 	Area3D();
 	~Area3D();

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -323,9 +323,9 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 		}
 
 		linear_attenuation = Math::db2linear(db_att);
-		for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
-			AudioServer::get_singleton()->set_playback_highshelf_params(playback, linear_attenuation, attenuation_filter_cutoff_hz);
-		}
+		// for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
+		// 	AudioServer::get_singleton()->set_playback_highshelf_params(playback, linear_attenuation, attenuation_filter_cutoff_hz);
+		// }
 		//TODO: The lower the second parameter (tightness) the more the sound will "enclose" the listener (more undirected / playing from
 		//      speakers not facing the source) - this could be made distance dependent.
 		_calc_output_vol(local_pos.normalized(), 4.0, output_volume_vector);

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -91,8 +91,6 @@ private:
 
 	void _set_playing(bool p_enable);
 	bool _is_active() const;
-	StringName _get_actual_bus();
-	Area3D *_get_overriding_area();
 	Vector<AudioFrame> _update_panning();
 
 	void _bus_layout_changed();

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -560,6 +560,7 @@ void AudioStreamPlayer::_bind_methods() {
 }
 
 AudioStreamPlayer::AudioStreamPlayer() {
+	add_send(0);
 	AudioServer::get_singleton()->connect("bus_layout_changed", callable_mp(this, &AudioStreamPlayer::_bus_layout_changed));
 }
 

--- a/scene/audio/audio_stream_player.cpp
+++ b/scene/audio/audio_stream_player.cpp
@@ -95,10 +95,7 @@ Ref<AudioStream> AudioStreamPlayer::get_stream() const {
 void AudioStreamPlayer::set_volume_db(float p_volume) {
 	volume_db = p_volume;
 
-	Vector<AudioFrame> volume_vector = _get_volume_vector();
-	for (Ref<AudioStreamPlayback> &playback : stream_playbacks) {
-		AudioServer::get_singleton()->set_playback_all_bus_volumes_linear(playback, volume_vector);
-	}
+	update_sends_internal();
 }
 
 float AudioStreamPlayer::get_volume_db() const {
@@ -139,7 +136,7 @@ void AudioStreamPlayer::play(float p_from_pos) {
 	Ref<AudioStreamPlayback> stream_playback = stream->instance_playback();
 	ERR_FAIL_COND_MSG(stream_playback.is_null(), "Failed to instantiate playback.");
 
-	AudioServer::get_singleton()->start_playback_stream(stream_playback, bus, _get_volume_vector(), p_from_pos, pitch_scale);
+	AudioServer::get_singleton()->start_playback_stream(stream_playback, get_sends_internal(), p_from_pos, pitch_scale);
 	stream_playbacks.push_back(stream_playback);
 	active.set();
 	set_process_internal(true);
@@ -180,22 +177,6 @@ float AudioStreamPlayer::get_playback_position() {
 		return AudioServer::get_singleton()->get_playback_position(stream_playbacks[stream_playbacks.size() - 1]);
 	}
 	return 0;
-}
-
-void AudioStreamPlayer::set_bus(const StringName &p_bus) {
-	bus = p_bus;
-	for (const Ref<AudioStreamPlayback> &playback : stream_playbacks) {
-		AudioServer::get_singleton()->set_playback_bus_exclusive(playback, p_bus, _get_volume_vector());
-	}
-}
-
-StringName AudioStreamPlayer::get_bus() const {
-	for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
-		if (AudioServer::get_singleton()->get_bus_name(i) == String(bus)) {
-			return bus;
-		}
-	}
-	return SNAME("Master");
 }
 
 void AudioStreamPlayer::set_autoplay(bool p_enable) {
@@ -246,7 +227,7 @@ bool AudioStreamPlayer::get_stream_paused() const {
 	return false;
 }
 
-Vector<AudioFrame> AudioStreamPlayer::_get_volume_vector() {
+Vector<AudioFrame> AudioStreamPlayer::_get_volume_vector() const {
 	Vector<AudioFrame> volume_vector;
 	// We need at most four stereo pairs (for 7.1 systems).
 	volume_vector.resize(4);
@@ -284,7 +265,7 @@ Vector<AudioFrame> AudioStreamPlayer::_get_volume_vector() {
 }
 
 void AudioStreamPlayer::_validate_property(PropertyInfo &property) const {
-	if (property.name == "bus") {
+	if (property.name.ends_with("/send")) {
 		String options;
 		for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
 			if (i > 0) {
@@ -304,11 +285,213 @@ void AudioStreamPlayer::_bus_layout_changed() {
 	notify_property_list_changed();
 }
 
+void AudioStreamPlayer::add_send(int p_index) {
+	if (p_index < 0) {
+		p_index = sends.size();
+	}
+	ERR_FAIL_COND(p_index > sends.size());
+	SendEntry entry{ SNAME("Master"), 1.0f };
+	sends.insert(p_index, entry);
+	emit_signal(SNAME("changed"));
+	update_sends_internal();
+	notify_property_list_changed();
+}
+
+void AudioStreamPlayer::move_send(int p_index_from, int p_index_to) {
+	ERR_FAIL_COND(p_index_from < 0);
+	ERR_FAIL_COND(p_index_from >= sends.size());
+	ERR_FAIL_COND(p_index_to < 0);
+	ERR_FAIL_COND(p_index_to > sends.size());
+	sends.insert(p_index_to, sends[p_index_from]);
+	// If 'from' is strictly after 'to' we need to increment the index by one because of the insertion.
+	if (p_index_from > p_index_to) {
+		p_index_from++;
+	}
+	sends.remove_at(p_index_from);
+	emit_signal(SNAME("changed"));
+	update_sends_internal();
+	notify_property_list_changed();
+}
+
+void AudioStreamPlayer::remove_send(int p_index) {
+	ERR_FAIL_COND(p_index < 0);
+	ERR_FAIL_COND(p_index >= sends.size());
+	sends.remove_at(p_index);
+	if (sends.size() == 0) {
+		add_send(0); // Don't let the user remove all sends.
+	} else {
+		emit_signal(SNAME("changed"));
+		update_sends_internal();
+		notify_property_list_changed();
+	}
+}
+
+void AudioStreamPlayer::set_send(int p_index, StringName p_send_name) {
+	ERR_FAIL_COND(p_index < 0);
+	ERR_FAIL_COND(p_index >= sends.size());
+	sends.write[p_index].send = p_send_name;
+	update_sends_internal();
+}
+
+StringName AudioStreamPlayer::get_send(int p_index) const {
+	ERR_FAIL_COND_V(p_index < 0, SNAME(""));
+	ERR_FAIL_COND_V(p_index >= sends.size(), SNAME(""));
+	return sends[p_index].send;
+}
+
+void AudioStreamPlayer::set_send_loudness_scale(int p_index, float p_loudness_scale) {
+	ERR_FAIL_COND(p_index < 0);
+	ERR_FAIL_COND(p_index >= sends.size());
+	if (p_loudness_scale < 0) {
+		p_loudness_scale = 0;
+	}
+	sends.write[p_index].loudness_scale = p_loudness_scale;
+	update_sends_internal();
+}
+
+float AudioStreamPlayer::get_send_loudness_scale(int p_index) const {
+	ERR_FAIL_COND_V(p_index < 0, 0.0f);
+	ERR_FAIL_COND_V(p_index >= sends.size(), 0.0f);
+	return sends[p_index].loudness_scale;
+}
+
+int AudioStreamPlayer::find_send_index_by_name(StringName p_send_name) const {
+	for (int send_idx = 0; send_idx < sends.size(); send_idx++) {
+		if (sends[send_idx].send == p_send_name) {
+			return send_idx;
+		}
+	}
+	return -1;
+}
+
+void AudioStreamPlayer::set_sends_count(int p_count) {
+	if (p_count >= 1) {
+		sends.resize(p_count);
+	} else {
+		sends.resize(0);
+		add_send(0);
+	}
+	emit_signal(SNAME("changed"));
+	update_sends_internal();
+	notify_property_list_changed();
+}
+
+int AudioStreamPlayer::get_sends_count() const {
+	return sends.size();
+}
+
+Map<StringName, Vector<AudioFrame>> AudioStreamPlayer::get_sends_internal() const {
+	// If the user set up this player to send multiple times to the same bus, add the loudness together.
+	Map<StringName, float> per_send_loudness_scale_total;
+	for (int send_idx = 0; send_idx < sends.size(); send_idx++) {
+		per_send_loudness_scale_total[sends[send_idx].send] += sends[send_idx].loudness_scale;
+	}
+	// Set up each volume vector according to the totals.
+	Map<StringName, Vector<AudioFrame>> per_send_volume_vector;
+	for (KeyValue<StringName, float> pair : per_send_loudness_scale_total) {
+		Vector<AudioFrame> volume_vector = _get_volume_vector();
+		for (AudioFrame &volume : volume_vector) {
+			volume *= pair.value;
+		}
+		per_send_volume_vector[pair.key] = volume_vector;
+	}
+	return per_send_volume_vector;
+}
+
+void AudioStreamPlayer::update_sends_internal() {
+#ifdef TOOLS_ENABLED
+	update_configuration_warnings();
+#endif
+	Map<StringName, Vector<AudioFrame>> sends_volume_linear = get_sends_internal();
+	for (Ref<AudioStreamPlayback> playback : stream_playbacks) {
+		AudioServer::get_singleton()->set_playback_bus_volumes_linear(playback, sends_volume_linear);
+	}
+}
+
 Ref<AudioStreamPlayback> AudioStreamPlayer::get_stream_playback() {
 	if (!stream_playbacks.is_empty()) {
 		return stream_playbacks[stream_playbacks.size() - 1];
 	}
 	return nullptr;
+}
+
+TypedArray<String> AudioStreamPlayer::get_configuration_warnings() const {
+	float total_loudness = 0;
+	for (int send_idx = 0; send_idx < sends.size(); send_idx++) {
+		total_loudness += sends[send_idx].loudness_scale;
+	}
+	TypedArray<String> warnings;
+	if (total_loudness == 0) {
+		warnings.append("This player node is not configured to send audio to a bus (or the sends are configured to be silent).");
+	}
+	return warnings;
+}
+
+bool AudioStreamPlayer::_get(const StringName &p_name, Variant &r_ret) const {
+	if (Node::_get(p_name, r_ret)) {
+		return true;
+	}
+	Vector<String> components = String(p_name).split("/", true, 2);
+	if (components.size() == 2 && components[0].begins_with("send_") && components[0].trim_prefix("send_").is_valid_int()) {
+		int index = components[0].trim_prefix("send_").to_int();
+		if (index < 0 || index >= (int)sends.size()) {
+			return false;
+		}
+
+		if (components[1] == "send") {
+			r_ret = get_send(index);
+			return true;
+		} else if (components[1] == "loudness_scale") {
+			r_ret = get_send_loudness_scale(index);
+			return true;
+		} else {
+			return false;
+		}
+	}
+	return false;
+}
+
+bool AudioStreamPlayer::_set(const StringName &p_name, const Variant &p_value) {
+	if (Node::_set(p_name, p_value)) {
+		return true;
+	}
+	Vector<String> components = String(p_name).split("/", true, 2);
+	if (components.size() == 2 && components[0].begins_with("send_") && components[0].trim_prefix("send_").is_valid_int()) {
+		int index = components[0].trim_prefix("send_").to_int();
+		if (index < 0 || index >= (int)sends.size()) {
+			return false;
+		}
+
+		if (components[1] == "send") {
+			set_send(index, p_value);
+			return true;
+		} else if (components[1] == "loudness_scale") {
+			set_send_loudness_scale(index, p_value);
+			return true;
+		} else {
+			return false;
+		}
+	}
+	return false;
+}
+
+void AudioStreamPlayer::_get_property_list(List<PropertyInfo> *p_list) const {
+	Node::_get_property_list(p_list);
+
+	String bus_hint_string;
+	for (int i = 0; i < AudioServer::get_singleton()->get_bus_count(); i++) {
+		if (i > 0) {
+			bus_hint_string += ",";
+		}
+		String name = AudioServer::get_singleton()->get_bus_name(i);
+		bus_hint_string += name;
+	}
+
+	p_list->push_back(PropertyInfo(Variant::NIL, "Sends", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_GROUP));
+	for (int i = 0; i < sends.size(); i++) {
+		p_list->push_back(PropertyInfo(Variant::STRING_NAME, vformat("send_%d/send", i), PROPERTY_HINT_ENUM, bus_hint_string));
+		p_list->push_back(PropertyInfo(Variant::FLOAT, vformat("send_%d/loudness_scale", i), PROPERTY_HINT_RANGE, "0,2,0.001,or_greater"));
+	}
 }
 
 void AudioStreamPlayer::_bind_methods() {
@@ -328,9 +511,6 @@ void AudioStreamPlayer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_playing"), &AudioStreamPlayer::is_playing);
 	ClassDB::bind_method(D_METHOD("get_playback_position"), &AudioStreamPlayer::get_playback_position);
 
-	ClassDB::bind_method(D_METHOD("set_bus", "bus"), &AudioStreamPlayer::set_bus);
-	ClassDB::bind_method(D_METHOD("get_bus"), &AudioStreamPlayer::get_bus);
-
 	ClassDB::bind_method(D_METHOD("set_autoplay", "enable"), &AudioStreamPlayer::set_autoplay);
 	ClassDB::bind_method(D_METHOD("is_autoplay_enabled"), &AudioStreamPlayer::is_autoplay_enabled);
 
@@ -348,6 +528,19 @@ void AudioStreamPlayer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_stream_playback"), &AudioStreamPlayer::get_stream_playback);
 
+	ClassDB::bind_method(D_METHOD("add_send", "index"), &AudioStreamPlayer::add_send);
+	ClassDB::bind_method(D_METHOD("move_send", "index_from", "index_to"), &AudioStreamPlayer::move_send);
+	ClassDB::bind_method(D_METHOD("remove_send", "index"), &AudioStreamPlayer::remove_send);
+
+	ClassDB::bind_method(D_METHOD("set_send", "index", "send_name"), &AudioStreamPlayer::set_send);
+	ClassDB::bind_method(D_METHOD("get_send", "index"), &AudioStreamPlayer::get_send);
+	ClassDB::bind_method(D_METHOD("set_send_loudness_scale", "index", "loudness_scale"), &AudioStreamPlayer::set_send_loudness_scale);
+	ClassDB::bind_method(D_METHOD("get_send_loudness_scale", "index"), &AudioStreamPlayer::get_send_loudness_scale);
+	ClassDB::bind_method(D_METHOD("find_send_index_by_name", "send_name"), &AudioStreamPlayer::find_send_index_by_name);
+	ClassDB::bind_method(D_METHOD("set_sends_count", "count"), &AudioStreamPlayer::set_sends_count);
+	ClassDB::bind_method(D_METHOD("get_sends_count"), &AudioStreamPlayer::get_sends_count);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "sends_count", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_sends_count", "get_sends_count");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "stream", PROPERTY_HINT_RESOURCE_TYPE, "AudioStream"), "set_stream", "get_stream");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "volume_db", PROPERTY_HINT_RANGE, "-80,24"), "set_volume_db", "get_volume_db");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "pitch_scale", PROPERTY_HINT_RANGE, "0.01,4,0.01,or_greater"), "set_pitch_scale", "get_pitch_scale");
@@ -356,7 +549,8 @@ void AudioStreamPlayer::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stream_paused", PROPERTY_HINT_NONE, ""), "set_stream_paused", "get_stream_paused");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mix_target", PROPERTY_HINT_ENUM, "Stereo,Surround,Center"), "set_mix_target", "get_mix_target");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "max_polyphony", PROPERTY_HINT_NONE, ""), "set_max_polyphony", "get_max_polyphony");
-	ADD_PROPERTY(PropertyInfo(Variant::STRING_NAME, "bus", PROPERTY_HINT_ENUM, ""), "set_bus", "get_bus");
+
+	ADD_ARRAY("sends", "send_");
 
 	ADD_SIGNAL(MethodInfo("finished"));
 

--- a/scene/audio/audio_stream_player.h
+++ b/scene/audio/audio_stream_player.h
@@ -46,6 +46,11 @@ public:
 	};
 
 private:
+	struct SendEntry {
+		StringName send;
+		float loudness_scale;
+	};
+
 	Vector<Ref<AudioStreamPlayback>> stream_playbacks;
 	Ref<AudioStream> stream;
 
@@ -54,7 +59,7 @@ private:
 	float pitch_scale = 1.0;
 	float volume_db = 0.0;
 	bool autoplay = false;
-	StringName bus = SNAME("Master");
+	Vector<SendEntry> sends;
 	int max_polyphony = 1;
 
 	MixTarget mix_target = MIX_TARGET_STEREO;
@@ -69,11 +74,15 @@ private:
 	void _bus_layout_changed();
 	void _mix_to_bus(const AudioFrame *p_frames, int p_amount);
 
-	Vector<AudioFrame> _get_volume_vector();
+	Vector<AudioFrame> _get_volume_vector() const;
 
 protected:
+	void _get_property_list(List<PropertyInfo> *p_list) const;
 	void _validate_property(PropertyInfo &property) const override;
 	void _notification(int p_what);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	bool _set(const StringName &p_name, const Variant &p_value);
+	virtual TypedArray<String> get_configuration_warnings() const override;
 	static void _bind_methods();
 
 public:
@@ -95,8 +104,25 @@ public:
 	bool is_playing() const;
 	float get_playback_position();
 
-	void set_bus(const StringName &p_bus);
-	StringName get_bus() const;
+	// Used for the editor plugin that faciliates editing of sends.
+	void add_send(int p_index);
+	void move_send(int p_index_from, int p_index_to);
+	void remove_send(int p_index);
+
+	// Send controls exposed to script.
+	void set_send(int p_index, StringName p_send_name);
+	StringName get_send(int p_index) const;
+	void set_send_loudness_scale(int p_index, float p_loudness_scale);
+	float get_send_loudness_scale(int p_index) const;
+
+	// Convenience method primarily for script.
+	int find_send_index_by_name(StringName p_send_name) const;
+
+	void set_sends_count(int p_count);
+	int get_sends_count() const;
+
+	Map<StringName, Vector<AudioFrame>> get_sends_internal() const;
+	void update_sends_internal();
 
 	void set_autoplay(bool p_enable);
 	bool is_autoplay_enabled();

--- a/servers/audio_server.cpp
+++ b/servers/audio_server.cpp
@@ -1181,15 +1181,6 @@ void AudioServer::stop_playback_stream(Ref<AudioStreamPlayback> p_playback) {
 	} while (!playback_node->state.compare_exchange_strong(old_state, new_state));
 }
 
-void AudioServer::set_playback_bus_exclusive(Ref<AudioStreamPlayback> p_playback, StringName p_bus, Vector<AudioFrame> p_volumes) {
-	ERR_FAIL_COND(p_volumes.size() != MAX_CHANNELS_PER_BUS);
-
-	Map<StringName, Vector<AudioFrame>> map;
-	map[p_bus] = p_volumes;
-
-	set_playback_bus_volumes_linear(p_playback, map);
-}
-
 void AudioServer::set_playback_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, Map<StringName, Vector<AudioFrame>> p_bus_volumes) {
 	ERR_FAIL_COND(p_bus_volumes.size() > MAX_BUSES_PER_PLAYBACK);
 

--- a/servers/audio_server.h
+++ b/servers/audio_server.h
@@ -373,7 +373,6 @@ public:
 	void start_playback_stream(Ref<AudioStreamPlayback> p_playback, Map<StringName, Vector<AudioFrame>> p_bus_volumes, float p_start_time = 0, float p_pitch_scale = 1, float p_highshelf_gain = 0, float p_attenuation_cutoff_hz = 0);
 	void stop_playback_stream(Ref<AudioStreamPlayback> p_playback);
 
-	void set_playback_bus_exclusive(Ref<AudioStreamPlayback> p_playback, StringName p_bus, Vector<AudioFrame> p_volumes);
 	void set_playback_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, Map<StringName, Vector<AudioFrame>> p_bus_volumes);
 	void set_playback_all_bus_volumes_linear(Ref<AudioStreamPlayback> p_playback, Vector<AudioFrame> p_volumes);
 	void set_playback_pitch_scale(Ref<AudioStreamPlayback> p_playback, float p_pitch_scale);


### PR DESCRIPTION
Audio bus overhaul in support of HRTF/improved spatial audio. The key change in this PR is that some buses can now apply effects _before_ mixing instead of after, which allows things like HRTFs, improved attenuation features, etc to be implemented as a new kind of AudioEffect, instead of creating new concepts inside of the engine just for those features.

The beauty of this change is that it's all just an effect. A new, special kind of effect that keeps track of listener location, audio source location, etc, but an effect all the same. See https://github.com/godotengine/godot-proposals/issues/4435 for details.