### PR TITLE
Optimize animation library gltf import.

### DIFF
--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -305,3 +305,11 @@ AnimationPlayer *GLTFState::get_animation_player(int idx) {
 	ERR_FAIL_INDEX_V(idx, animation_players.size(), nullptr);
 	return animation_players[idx];
 }
+
+void GLTFState::set_discard_meshes_and_materials(bool p_discard_meshes_and_materials) {
+	discard_meshes_and_materials = p_discard_meshes_and_materials;
+}
+
+bool GLTFState::get_discard_meshes_and_materials() {
+	return discard_meshes_and_materials;
+}

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -62,6 +62,7 @@ class GLTFState : public Resource {
 	Vector<uint8_t> glb_data;
 
 	bool use_named_skin_binds = false;
+	bool discard_meshes_and_materials = false;
 
 	Vector<Ref<GLTFNode>> nodes;
 	Vector<Vector<uint8_t>> buffers;
@@ -111,6 +112,9 @@ public:
 
 	bool get_use_named_skin_binds();
 	void set_use_named_skin_binds(bool p_use_named_skin_binds);
+
+	bool get_discard_meshes_and_materials();
+	void set_discard_meshes_and_materials(bool p_discard_meshes_and_materials);
 
 	Array get_nodes();
 	void set_nodes(Array p_nodes);


### PR DESCRIPTION
This is a completed branch for adding animation library optimization to the gltf importer.

Was described to me as part of the animation library work.

Part of https://github.com/godotengine/godot-proposals/issues/4296.

TODO for a future pr: profile to see if it's worth removing meshes.