### PR TITLE
Fix type name typo in Debug Adapter Protocol

### DIFF
--- a/doc/classes/Vector3i.xml
+++ b/doc/classes/Vector3i.xml
@@ -161,7 +161,7 @@
 			<description>
 				Gets the remainder of each component of the [Vector3i] with the the given [int]. This operation uses truncated division, which is often not desired as it does not work well with negative numbers. Consider using [method @GlobalScope.posmod] instead if you want to handle negative numbers.
 				[codeblock]
-				print(Vector2i(10, -20, 30) % 7) # Prints "(3, -6, 2)"
+				print(Vector3i(10, -20, 30) % 7) # Prints "(3, -6, 2)"
 				[/codeblock]
 			</description>
 		</operator>

--- a/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
+++ b/editor/debugger/debug_adapter/debug_adapter_protocol.cpp
@@ -349,14 +349,14 @@ int DebugAdapterProtocol::parse_variant(const Variant &p_var) {
 		case Variant::BASIS: {
 			int id = variable_id++;
 			Basis basis = p_var;
-			const String type_vec2 = Variant::get_type_name(Variant::VECTOR2);
+			const String type_vec3 = Variant::get_type_name(Variant::VECTOR3);
 			DAP::Variable x, y, z;
 			x.name = "x";
 			y.name = "y";
 			z.name = "z";
-			x.type = type_vec2;
-			y.type = type_vec2;
-			z.type = type_vec2;
+			x.type = type_vec3;
+			y.type = type_vec3;
+			z.type = type_vec3;
 			x.value = basis.elements[0];
 			y.value = basis.elements[1];
 			z.value = basis.elements[2];

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2085,7 +2085,7 @@ EditorPropertyRect2i::EditorPropertyRect2i(bool p_force_wide) {
 	}
 }
 
-///////////////////// VECTOR3i /////////////////////////
+///////////////////// VECTOR3I /////////////////////////
 
 void EditorPropertyVector3i::_set_read_only(bool p_read_only) {
 	for (int i = 0; i < 3; i++) {
@@ -2618,7 +2618,7 @@ EditorPropertyBasis::EditorPropertyBasis() {
 	set_bottom_editor(g);
 }
 
-///////////////////// TRANSFORM /////////////////////////
+///////////////////// TRANSFORM3D /////////////////////////
 
 void EditorPropertyTransform3D::_set_read_only(bool p_read_only) {
 	for (int i = 0; i < 12; i++) {


### PR DESCRIPTION
Basis is made of Vector3, not Vector2.

I also threw in some other typo fixes, just comments and documentation.