### PR TITLE
TrayBroker class for interaction with desktop services

### DIFF
--- a/core/io/tray_broker.cpp
+++ b/core/io/tray_broker.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  os_linuxbsd.h                                                        */
+/*  tray_broker.cpp                                                      */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,84 +28,26 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef OS_LINUXBSD_H
-#define OS_LINUXBSD_H
+#include "tray_broker.h"
 
-#include "core/input/input.h"
-#include "crash_handler_linuxbsd.h"
-#include "drivers/alsa/audio_driver_alsa.h"
-#include "drivers/alsamidi/midi_driver_alsamidi.h"
-#include "drivers/pulseaudio/audio_driver_pulseaudio.h"
-#include "drivers/unix/os_unix.h"
-#include "joypad_linux.h"
-#include "servers/audio_server.h"
-#include "tray_broker_dbus.h"
+TrayBroker *TrayBroker::singleton = nullptr;
 
-class OS_LinuxBSD : public OS_Unix {
-	virtual void delete_main_loop() override;
+TrayBroker *TrayBroker::get_singleton() {
+	return singleton;
+}
 
-	bool force_quit;
+TrayBroker *(*TrayBroker::_create)() = nullptr;
 
-#ifdef JOYDEV_ENABLED
-	JoypadLinux *joypad = nullptr;
-#endif
+TrayBroker *TrayBroker::create() {
+	ERR_FAIL_COND_V_MSG(singleton, nullptr, "TrayBroker singleton already exists.");
+	ERR_FAIL_COND_V(!_create, nullptr);
+	return _create();
+}
 
-#ifdef DBUS_ENABLED
-	TrayBrokerDBus *tb = nullptr;
-#endif
+void TrayBroker::_bind_methods() {}
 
-#ifdef ALSA_ENABLED
-	AudioDriverALSA driver_alsa;
-#endif
+TrayBroker::TrayBroker() {
+	singleton = this;
+}
 
-#ifdef ALSAMIDI_ENABLED
-	MIDIDriverALSAMidi driver_alsamidi;
-#endif
-
-#ifdef PULSEAUDIO_ENABLED
-	AudioDriverPulseAudio driver_pulseaudio;
-#endif
-
-	CrashHandler crash_handler;
-
-	MainLoop *main_loop = nullptr;
-
-protected:
-	virtual void initialize() override;
-	virtual void finalize() override;
-
-	virtual void initialize_joypads() override;
-
-	virtual void set_main_loop(MainLoop *p_main_loop) override;
-
-public:
-	virtual String get_name() const override;
-
-	virtual MainLoop *get_main_loop() const override;
-
-	virtual String get_config_path() const override;
-	virtual String get_data_path() const override;
-	virtual String get_cache_path() const override;
-
-	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;
-
-	virtual Error shell_open(String p_uri) override;
-
-	virtual String get_unique_id() const override;
-	virtual String get_processor_name() const override;
-
-	virtual void alert(const String &p_alert, const String &p_title = "ALERT!") override;
-
-	virtual bool _check_internal_feature_support(const String &p_feature) override;
-
-	void run();
-
-	virtual void disable_crash_handler() override;
-	virtual bool is_disable_crash_handler() const override;
-
-	virtual Error move_to_trash(const String &p_path) override;
-
-	OS_LinuxBSD();
-};
-
-#endif
+TrayBroker::~TrayBroker() {}

--- a/core/io/tray_broker.h
+++ b/core/io/tray_broker.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  os_linuxbsd.h                                                        */
+/*  tray_broker.h                                                        */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,84 +28,30 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#ifndef OS_LINUXBSD_H
-#define OS_LINUXBSD_H
+#ifndef TRAY_BROKER_H
+#define TRAY_BROKER_H
 
-#include "core/input/input.h"
-#include "crash_handler_linuxbsd.h"
-#include "drivers/alsa/audio_driver_alsa.h"
-#include "drivers/alsamidi/midi_driver_alsamidi.h"
-#include "drivers/pulseaudio/audio_driver_pulseaudio.h"
-#include "drivers/unix/os_unix.h"
-#include "joypad_linux.h"
-#include "servers/audio_server.h"
-#include "tray_broker_dbus.h"
+#include "core/object/class_db.h"
+#include "core/object/object.h"
 
-class OS_LinuxBSD : public OS_Unix {
-	virtual void delete_main_loop() override;
-
-	bool force_quit;
-
-#ifdef JOYDEV_ENABLED
-	JoypadLinux *joypad = nullptr;
-#endif
-
-#ifdef DBUS_ENABLED
-	TrayBrokerDBus *tb = nullptr;
-#endif
-
-#ifdef ALSA_ENABLED
-	AudioDriverALSA driver_alsa;
-#endif
-
-#ifdef ALSAMIDI_ENABLED
-	MIDIDriverALSAMidi driver_alsamidi;
-#endif
-
-#ifdef PULSEAUDIO_ENABLED
-	AudioDriverPulseAudio driver_pulseaudio;
-#endif
-
-	CrashHandler crash_handler;
-
-	MainLoop *main_loop = nullptr;
+class TrayBroker : public Object {
+	GDCLASS(TrayBroker, Object);
 
 protected:
-	virtual void initialize() override;
-	virtual void finalize() override;
+	static TrayBroker *singleton;
+	static void _bind_methods();
 
-	virtual void initialize_joypads() override;
-
-	virtual void set_main_loop(MainLoop *p_main_loop) override;
+	static TrayBroker *(*_create)();
 
 public:
-	virtual String get_name() const override;
+	static TrayBroker *get_singleton();
 
-	virtual MainLoop *get_main_loop() const override;
+	static TrayBroker *create();
 
-	virtual String get_config_path() const override;
-	virtual String get_data_path() const override;
-	virtual String get_cache_path() const override;
+	virtual void request_notification_permission() = 0;
 
-	virtual String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const override;
-
-	virtual Error shell_open(String p_uri) override;
-
-	virtual String get_unique_id() const override;
-	virtual String get_processor_name() const override;
-
-	virtual void alert(const String &p_alert, const String &p_title = "ALERT!") override;
-
-	virtual bool _check_internal_feature_support(const String &p_feature) override;
-
-	void run();
-
-	virtual void disable_crash_handler() override;
-	virtual bool is_disable_crash_handler() const override;
-
-	virtual Error move_to_trash(const String &p_path) override;
-
-	OS_LinuxBSD();
+	TrayBroker();
+	~TrayBroker();
 };
 
-#endif
+#endif // TRAY_BROKER_H

--- a/core/register_core_types.cpp
+++ b/core/register_core_types.cpp
@@ -60,6 +60,7 @@
 #include "core/io/stream_peer_ssl.h"
 #include "core/io/tcp_server.h"
 #include "core/io/translation_loader_po.h"
+#include "core/io/tray_broker.h"
 #include "core/io/udp_server.h"
 #include "core/io/xml_parser.h"
 #include "core/math/a_star.h"
@@ -96,6 +97,8 @@ static core_bind::Marshalls *_marshalls = nullptr;
 static core_bind::EngineDebugger *_engine_debugger = nullptr;
 
 static IP *ip = nullptr;
+
+static TrayBroker *tb = nullptr;
 
 static core_bind::Geometry2D *_geometry_2d = nullptr;
 static core_bind::Geometry3D *_geometry_3d = nullptr;
@@ -189,6 +192,8 @@ void register_core_types() {
 
 	ClassDB::register_custom_instance_class<HTTPClient>();
 
+	GDREGISTER_ABSTRACT_CLASS(TrayBroker);
+
 	// Crypto
 	GDREGISTER_CLASS(HashingContext);
 	GDREGISTER_CLASS(AESContext);
@@ -256,6 +261,8 @@ void register_core_types() {
 
 	ip = IP::create();
 
+	tb = TrayBroker::create();
+
 	_geometry_2d = memnew(core_bind::Geometry2D);
 	_geometry_3d = memnew(core_bind::Geometry3D);
 
@@ -285,6 +292,7 @@ void register_core_settings() {
 void register_core_singletons() {
 	GDREGISTER_CLASS(ProjectSettings);
 	GDREGISTER_ABSTRACT_CLASS(IP);
+	GDREGISTER_ABSTRACT_CLASS(TrayBroker);
 	GDREGISTER_CLASS(core_bind::Geometry2D);
 	GDREGISTER_CLASS(core_bind::Geometry3D);
 	GDREGISTER_CLASS(core_bind::ResourceLoader);
@@ -370,6 +378,10 @@ void unregister_core_types() {
 
 	if (ip) {
 		memdelete(ip);
+	}
+
+	if (tb) {
+		memdelete(tb);
 	}
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_native_extension);

--- a/core/templates/optional.h
+++ b/core/templates/optional.h
@@ -1,0 +1,143 @@
+/*************************************************************************/
+/*  optional.h                                                           */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef OPTIONAL_H
+#define OPTIONAL_H
+
+/**
+ * @class Optional
+ * Optional value container. Represents optional objects which may or may not contain a valid value.
+ */
+
+#include <initializer_list>
+
+struct NullOpt {
+	struct init {};
+	constexpr NullOpt(init){};
+};
+constexpr NullOpt nullopt{ NullOpt::init{} };
+
+constexpr struct TrivialInit {
+} trivial_init{};
+
+template <typename T>
+union OptionalStorage {
+	unsigned char dummy;
+	T value;
+
+	constexpr OptionalStorage(TrivialInit) :
+			dummy(){};
+
+	template <class... Args>
+	_FORCE_INLINE_ OptionalStorage(const Args &&...p_args) :
+			value(T(p_args...)) {}
+
+	_FORCE_INLINE_ OptionalStorage() :
+			value() {}
+
+	_FORCE_INLINE_ ~OptionalStorage() {}
+};
+
+template <typename T>
+class Optional {
+public:
+	typedef T ValueType;
+
+	_FORCE_INLINE_ Optional() :
+			_data(trivial_init), _ptr(nullptr) {}
+	_FORCE_INLINE_ Optional(NullOpt) :
+			_data(trivial_init), _ptr(nullptr) {}
+	_FORCE_INLINE_ Optional(const Optional &other) :
+			_data(trivial_init), _ptr(other ? new (&_data) ValueType(*other) : nullptr) {}
+	_FORCE_INLINE_ explicit Optional(const ValueType &value) :
+			_data(value), _ptr(&_data) {}
+
+	_FORCE_INLINE_ ~Optional() {
+		if (_ptr) {
+			_ptr->ValueType::~ValueType();
+		}
+	}
+
+	_FORCE_INLINE_ ValueType const &operator*() const {
+		return *_ptr;
+	}
+
+	_FORCE_INLINE_ ValueType &operator*() {
+		return *_ptr;
+	}
+
+	_FORCE_INLINE_ ValueType const *operator->() const {
+		return _ptr;
+	}
+
+	_FORCE_INLINE_ ValueType *operator->() {
+		return _ptr;
+	}
+
+	_FORCE_INLINE_ Optional &operator=(NullOpt) {
+		clear();
+		return *this;
+	}
+
+	_FORCE_INLINE_ Optional &operator=(Optional const &other) {
+		if (_ptr && !other._ptr) {
+			clear();
+		} else if (!_ptr && other._ptr) {
+			_ptr = new (&_data) ValueType(*other);
+		} else if (_ptr && other._ptr) {
+			*_ptr = *other;
+		}
+		return *this;
+	}
+
+	_FORCE_INLINE_ Optional &operator=(ValueType const &value) {
+		if (_ptr) {
+			*_ptr = value;
+		} else {
+			_ptr = new (&_data) ValueType(value);
+		}
+		return *this;
+	}
+
+	_FORCE_INLINE_ operator bool() const { return _ptr; }
+
+private:
+	OptionalStorage<ValueType> _data;
+	ValueType *_ptr;
+
+	_FORCE_INLINE_ void clear() {
+		if (_ptr) {
+			_ptr->ValueType::~ValueType();
+			_ptr = nullptr;
+		}
+	}
+};
+
+#endif // OPTIONAL_H

--- a/doc/classes/TrayBroker.xml
+++ b/doc/classes/TrayBroker.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<class name="TrayBroker" inherits="Object" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+	<brief_description>
+		Broker agent for native communication with desktop.
+	</brief_description>
+	<description>
+		Desktop components such as native file picker dialogs and notifications need to communicate with the desktop so they can be used inside the engine.
+		This is a singleton tasked with doing communications with the desktop through the native methods (e.g. DBus for LinuxBSD and WinAPI for Windows platforms) and provides a broker end for engine classes (hence the name [TrayBroker]) so these use an unified and reusable interface.
+	</description>
+	<tutorials>
+	</tutorials>
+</class>

--- a/platform/linuxbsd/SCsub
+++ b/platform/linuxbsd/SCsub
@@ -10,6 +10,7 @@ common_linuxbsd = [
     "os_linuxbsd.cpp",
     "joypad_linux.cpp",
     "freedesktop_screensaver.cpp",
+    "tray_broker_dbus.cpp",
 ]
 
 if "x11" in env and env["x11"]:

--- a/platform/linuxbsd/os_linuxbsd.cpp
+++ b/platform/linuxbsd/os_linuxbsd.cpp
@@ -33,6 +33,7 @@
 #include "core/io/dir_access.h"
 #include "main/main.h"
 #include "servers/display_server.h"
+#include "tray_broker_dbus.h"
 
 #ifdef X11_ENABLED
 #include "display_server_x11.h"
@@ -120,6 +121,10 @@ void OS_LinuxBSD::initialize() {
 	crash_handler.initialize();
 
 	OS_Unix::initialize_core();
+
+#ifdef DBUS_ENABLED
+	TrayBrokerDBus::make_default();
+#endif
 }
 
 void OS_LinuxBSD::initialize_joypads() {
@@ -348,8 +353,15 @@ void OS_LinuxBSD::run() {
 	//int frames=0;
 	//uint64_t frame=0;
 
+#ifdef DBUS_ENABLED
+	tb = reinterpret_cast<TrayBrokerDBus *>(TrayBroker::get_singleton());
+#endif
+
 	while (!force_quit) {
 		DisplayServer::get_singleton()->process_events(); // get rid of pending events
+#ifdef DBUS_ENABLED
+		tb->process_messages();
+#endif
 #ifdef JOYDEV_ENABLED
 		joypad->process_joypads();
 #endif

--- a/platform/linuxbsd/tray_broker_dbus.cpp
+++ b/platform/linuxbsd/tray_broker_dbus.cpp
@@ -1,0 +1,604 @@
+/*************************************************************************/
+/*  tray_broker_dbus.cpp                                                 */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "tray_broker_dbus.h"
+
+#ifdef DBUS_ENABLED
+
+#include "core/templates/hash_map.h"
+#include "core/variant/dictionary.h"
+
+#include <dbus/dbus.h>
+
+#include <poll.h>
+
+Error _append_dbus_container(DBusMessageIter *iter, struct _dbus_msg_tuple *t) {
+	Error err = OK;
+	auto sub_iter = reinterpret_cast<DBusMessageIter *>(t->value);
+	int32_t type = t->type;
+	bool dict = false;
+
+	if (type == DBUS_TYPE_DICT_ENTRY) {
+		dict = true;
+		type = DBUS_TYPE_ARRAY;
+	}
+
+	if (!dbus_message_iter_open_container(iter, type, t->signature, sub_iter)) {
+		return ERR_OUT_OF_MEMORY;
+	}
+
+	if (t->sub) {
+		dbus_bool_t container = dbus_type_is_container(t->sub->type);
+
+		if (dict) {
+			if (t->sub->type == DBUS_TYPE_INVALID) {
+				dbus_message_iter_close_container(iter, sub_iter);
+				return OK;
+			}
+
+			if (!(t->sub + 1)->value || (t->sub + 1)->type == DBUS_TYPE_INVALID) {
+				dbus_message_iter_close_container(iter, sub_iter);
+				return ERR_INVALID_PARAMETER;
+			}
+
+			container = dbus_type_is_container((t->sub + 1)->type);
+
+			for (_dbus_msg_tuple *s = t->sub; s->value && s->type != DBUS_TYPE_INVALID; s += 2) {
+				DBusMessageIter pair_iter;
+				_dbus_msg_tuple *n = s + 1;
+
+				if (!n->value || n->type == DBUS_TYPE_INVALID) {
+					dbus_message_iter_close_container(iter, sub_iter);
+					return ERR_INVALID_PARAMETER;
+				}
+
+				if (!dbus_message_iter_open_container(sub_iter, DBUS_TYPE_DICT_ENTRY, t->signature, &pair_iter)) {
+					dbus_message_iter_close_container(iter, sub_iter);
+					return ERR_OUT_OF_MEMORY;
+				}
+
+				if (!dbus_message_iter_append_basic(&pair_iter, s->type, s->value)) {
+					dbus_message_iter_close_container(sub_iter, &pair_iter);
+					dbus_message_iter_close_container(iter, sub_iter);
+					return ERR_OUT_OF_MEMORY;
+				}
+
+				if (container) {
+					auto val_iter = reinterpret_cast<DBusMessageIter *>(n->value);
+					if (!dbus_message_iter_open_container(&pair_iter, n->type, n->signature, val_iter)) {
+						dbus_message_iter_close_container(sub_iter, &pair_iter);
+						dbus_message_iter_close_container(iter, sub_iter);
+						return err;
+					}
+					err = _append_dbus_container(val_iter, n->sub);
+					dbus_message_iter_close_container(&pair_iter, val_iter);
+					if (err) {
+						dbus_message_iter_close_container(sub_iter, &pair_iter);
+						dbus_message_iter_close_container(iter, sub_iter);
+						return err;
+					}
+				} else {
+					if (!dbus_message_iter_append_basic(&pair_iter, n->type, n->value)) {
+						dbus_message_iter_close_container(&pair_iter, iter);
+						dbus_message_iter_close_container(iter, sub_iter);
+						return ERR_OUT_OF_MEMORY;
+					}
+				}
+
+				dbus_message_iter_close_container(&pair_iter, iter);
+			}
+		} else if (type == DBUS_TYPE_ARRAY) {
+			for (_dbus_msg_tuple *s = t->sub; s->value; ++s) {
+				if (container) {
+					err = _append_dbus_container(sub_iter, t->sub);
+					if (err) {
+						return err;
+					}
+				} else {
+					if (!dbus_message_iter_append_basic(iter, s->type, s->value)) {
+						dbus_message_iter_close_container(iter, sub_iter);
+						return ERR_OUT_OF_MEMORY;
+					}
+				}
+			}
+		} else if (type == DBUS_TYPE_VARIANT) {
+			if (container) {
+				err = _append_dbus_container(sub_iter, t->sub);
+				if (err) {
+					return err;
+				}
+			} else {
+				if (!dbus_message_iter_append_basic(iter, t->type, t->value)) {
+					dbus_message_iter_close_container(iter, sub_iter);
+					return ERR_OUT_OF_MEMORY;
+				}
+			}
+		} else {
+			return ERR_INVALID_PARAMETER;
+		}
+	}
+
+	dbus_message_iter_close_container(iter, sub_iter);
+
+	return OK;
+}
+
+Error _append_dbus_msg_tuple(DBusMessageIter *iter, struct _dbus_msg_tuple *args) {
+	for (_dbus_msg_tuple *t = args; t->value; ++t) {
+		int type = t->type;
+		if (t->category == ValueCategory::DBUS) {
+			if (type == DBUS_TYPE_ARRAY) {
+				if (t->sub && dbus_type_is_basic(t->sub->type)) {
+					auto arr = reinterpret_cast<_dbus_fixed_arr *>(t->sub->value);
+					dbus_message_iter_append_fixed_array(reinterpret_cast<DBusMessageIter *>(t->value), t->sub->type, arr->data, arr->len);
+				} else {
+					_append_dbus_container(iter, t);
+				}
+			} else if (dbus_type_is_container(t->type)) {
+				_append_dbus_container(iter, t);
+			} else if (!dbus_message_iter_append_basic(iter, type, t->value)) {
+				return ERR_OUT_OF_MEMORY;
+			}
+		} else if (t->category == ValueCategory::GODOT) {
+			// TODO: implement serialization of objects like images
+			ERR_FAIL_V_MSG(ERR_INVALID_PARAMETER, "serialization of Godot classes has yet to be implemented");
+		}
+	}
+
+	return OK;
+}
+
+Error _unmarshall_dbus_basic(DBusMessageIter *iter, Variant &res) {
+	int32_t type = dbus_message_iter_get_arg_type(iter);
+	switch (type) {
+		case DBUS_TYPE_OBJECT_PATH:
+		case DBUS_TYPE_SIGNATURE:
+		case DBUS_TYPE_STRING: {
+			const char *str;
+			dbus_message_iter_get_basic(iter, &str);
+			res = String(str);
+			break;
+		}
+		case DBUS_TYPE_BYTE: {
+			uint8_t byte;
+			dbus_message_iter_get_basic(iter, &byte);
+			res = byte;
+			break;
+		}
+		case DBUS_TYPE_BOOLEAN: {
+			bool boolean;
+			dbus_message_iter_get_basic(iter, &boolean);
+			res = boolean;
+			break;
+		}
+		case DBUS_TYPE_INT16: {
+			int16_t num;
+			dbus_message_iter_get_basic(iter, &num);
+			res = num;
+			break;
+		}
+		case DBUS_TYPE_UINT16: {
+			uint16_t num;
+			dbus_message_iter_get_basic(iter, &num);
+			res = num;
+			break;
+		}
+		case DBUS_TYPE_INT32: {
+			int32_t num;
+			dbus_message_iter_get_basic(iter, &num);
+			res = num;
+			break;
+		}
+		case DBUS_TYPE_UINT32: {
+			uint32_t num;
+			dbus_message_iter_get_basic(iter, &num);
+			res = num;
+			break;
+		}
+		case DBUS_TYPE_INT64: {
+			int64_t num;
+			dbus_message_iter_get_basic(iter, &num);
+			res = num;
+			break;
+		}
+		case DBUS_TYPE_UINT64: {
+			uint64_t num;
+			dbus_message_iter_get_basic(iter, &num);
+			res = num;
+			break;
+		}
+		case DBUS_TYPE_DOUBLE: {
+			double num;
+			dbus_message_iter_get_basic(iter, &num);
+			res = num;
+			break;
+		}
+		default: {
+			return ERR_INVALID_PARAMETER;
+		}
+	}
+
+	return OK;
+}
+
+Error _unmarshall_dbus_dictionary(DBusMessageIter *iter, Dictionary &res) {
+	Error err = OK;
+	DBusMessageIter pair_iter, var_iter, sub_iter;
+
+	int32_t type = dbus_message_iter_get_arg_type(iter);
+	while (type != DBUS_TYPE_INVALID) {
+		const char *key;
+
+		dbus_message_iter_recurse(iter, &pair_iter);
+
+		if (dbus_message_iter_get_arg_type(&pair_iter) != DBUS_TYPE_STRING) {
+			return ERR_INVALID_PARAMETER;
+		}
+		dbus_message_iter_get_basic(&pair_iter, &key);
+		dbus_message_iter_next(&pair_iter);
+
+		int32_t sub_type = dbus_message_iter_get_arg_type(&pair_iter);
+		if (sub_type == DBUS_TYPE_INVALID) {
+			res[String(key)] = Variant();
+		} else if (sub_type == DBUS_TYPE_VARIANT) {
+			dbus_message_iter_recurse(&pair_iter, &var_iter);
+			int32_t var_type = dbus_message_iter_get_arg_type(&var_iter);
+			if (var_type == DBUS_TYPE_INVALID) {
+				res[String(key)] = Variant();
+			} else if (dbus_type_is_container(var_type)) {
+				Vector<Variant> sub_res;
+				dbus_message_iter_recurse(&var_iter, &sub_iter);
+				err = _unmarshall_dbus_container(&sub_iter, sub_res);
+				res[String(key)] = sub_res;
+			} else {
+				Variant sub_res;
+				err = _unmarshall_dbus_basic(&var_iter, sub_res);
+				res[String(key)] = sub_res;
+			}
+		} else if (dbus_type_is_container(sub_type)) {
+			Vector<Variant> sub_res;
+			dbus_message_iter_recurse(&pair_iter, &sub_iter);
+			err = _unmarshall_dbus_container(&sub_iter, sub_res);
+			res[String(key)] = sub_res;
+		} else {
+			Variant sub_res;
+			err = _unmarshall_dbus_basic(&sub_iter, sub_res);
+			res[String(key)] = sub_res;
+		}
+
+		if (err) {
+			break;
+		}
+
+		dbus_message_iter_next(iter);
+		type = dbus_message_iter_get_arg_type(iter);
+	}
+
+	return err;
+}
+
+Error _unmarshall_dbus_container(DBusMessageIter *iter, Vector<Variant> &res) {
+	Error err = OK;
+
+	int32_t type = dbus_message_iter_get_arg_type(iter);
+	while (type != DBUS_TYPE_INVALID) {
+		switch (type) {
+			case DBUS_TYPE_DICT_ENTRY: {
+				// although unlikely to reach this case dict entries are only contained by arrays
+				err = ERR_INVALID_PARAMETER;
+				break;
+			}
+			case DBUS_TYPE_ARRAY: {
+				DBusMessageIter sub_iter;
+				dbus_message_iter_recurse(iter, &sub_iter);
+				int32_t sub_type = dbus_message_iter_get_arg_type(&sub_iter);
+				if (sub_type == DBUS_TYPE_INVALID) {
+					res.append(Vector<Variant>());
+				} else if (sub_type == DBUS_TYPE_DICT_ENTRY) {
+					Dictionary sub;
+					err = _unmarshall_dbus_dictionary(&sub_iter, sub);
+					res.append(sub);
+				} else if (dbus_type_is_container(sub_type)) {
+					err = _unmarshall_dbus_container(&sub_iter, res);
+				} else {
+					Variant sub_res;
+					err = _unmarshall_dbus_basic(&sub_iter, sub_res);
+					res.append(sub_res);
+				}
+				break;
+			}
+			case DBUS_TYPE_VARIANT: {
+				DBusMessageIter sub_iter;
+				dbus_message_iter_recurse(iter, &sub_iter);
+				int32_t sub_type = dbus_message_iter_get_arg_type(&sub_iter);
+				if (sub_type == DBUS_TYPE_INVALID) {
+					res.append(Variant());
+				} else if (dbus_type_is_container(sub_type)) {
+					err = _unmarshall_dbus_container(&sub_iter, res);
+				} else {
+					Variant sub_res;
+					err = _unmarshall_dbus_basic(&sub_iter, sub_res);
+					res.append(sub_res);
+				}
+				break;
+			}
+			case DBUS_TYPE_STRUCT: {
+				DBusMessageIter sub_iter;
+				Vector<Variant> sub;
+				dbus_message_iter_recurse(iter, &sub_iter);
+				err = _unmarshall_dbus_container(&sub_iter, sub);
+				if (err) {
+					return err;
+				}
+				res.append(sub);
+				break;
+			}
+			default: {
+				if (dbus_type_is_basic(type)) {
+					Variant sub_res;
+					err = _unmarshall_dbus_basic(iter, sub_res);
+					res.append(sub_res);
+				}
+				break;
+			}
+		}
+
+		if (err) {
+			break;
+		}
+
+		dbus_message_iter_next(iter);
+		type = dbus_message_iter_get_arg_type(iter);
+	}
+
+	return err;
+}
+
+dbus_bool_t TrayBrokerDBus::ReadActuator::handle() {
+	if (!dbus_watch_handle(watch, DBUS_WATCH_READABLE)) {
+		return 0;
+	}
+
+	return TrayBrokerDBus::dispatch(bus);
+}
+
+dbus_bool_t TrayBrokerDBus::WriteActuator::handle() {
+	return dbus_watch_handle(watch, DBUS_WATCH_WRITABLE);
+}
+
+void TrayBrokerDBus::SignalDBus::emit(DBusMessage *msg) {
+	cb(msg, p_userdata);
+}
+
+dbus_bool_t TrayBrokerDBus::dispatch(DBusConnection *bus) {
+	DBusDispatchStatus status = dbus_connection_get_dispatch_status(bus);
+
+	while (status == DBUS_DISPATCH_DATA_REMAINS) {
+		status = dbus_connection_dispatch(bus);
+	}
+
+	if (status == DBUS_DISPATCH_NEED_MEMORY) {
+		return 0;
+	}
+
+	return 1;
+}
+
+void TrayBrokerDBus::dispatch_status(DBusConnection *bus, DBusDispatchStatus status, void *user_data) {
+	if (status == DBUS_DISPATCH_DATA_REMAINS) {
+		dispatch(bus);
+	}
+}
+
+void TrayBrokerDBus::send_dispatch(Actuator &act, short flag) {
+	act.handle();
+}
+
+dbus_bool_t TrayBrokerDBus::add_watch(DBusWatch *w, void *user_data) {
+	auto tb = reinterpret_cast<TrayBrokerDBus *>(user_data);
+	uint32_t flags = dbus_watch_get_flags(w);
+	int32_t fd = dbus_watch_get_unix_fd(w);
+
+	WatchActuator *act = tb->acts.getptr(fd);
+	if (!act) {
+		act = &tb->acts.set(fd, WatchActuator{ nullopt, nullopt })->value();
+	}
+	if (flags & DBUS_WATCH_READABLE) {
+		act->r = ReadActuator(tb->bus, w, POLLIN);
+	}
+	if (flags & DBUS_WATCH_WRITABLE) {
+		act->w = WriteActuator(tb->bus, w, POLLOUT);
+	}
+
+	return 1;
+}
+
+void TrayBrokerDBus::remove_watch(DBusWatch *w, void *p_userdata) {
+	auto tb = reinterpret_cast<TrayBrokerDBus *>(p_userdata);
+	uint32_t flags = dbus_watch_get_flags(w);
+	int32_t fd = dbus_watch_get_unix_fd(w);
+
+	WatchActuator &act = tb->acts[fd];
+	if (flags & DBUS_WATCH_READABLE) {
+		if (!act.w) {
+			tb->acts.erase(fd);
+		} else {
+			act.r = nullopt;
+		}
+	}
+	if (flags & DBUS_WATCH_WRITABLE) {
+		if (!act.r) {
+			tb->acts.erase(fd);
+		} else {
+			act.w = nullopt;
+		}
+	}
+}
+
+void TrayBrokerDBus::toggle_watch(DBusWatch *w, void *user_data) {
+	if (dbus_watch_get_enabled(w)) {
+		add_watch(w, user_data);
+	} else {
+		remove_watch(w, user_data);
+	}
+}
+
+DBusHandlerResult TrayBrokerDBus::signal_filter(DBusConnection *bus, DBusMessage *msg, void *p_userdata) {
+	auto tb = reinterpret_cast<TrayBrokerDBus *>(p_userdata);
+	const char *path = dbus_message_get_path(msg);
+
+	switch (dbus_message_get_type(msg)) {
+		case DBUS_MESSAGE_TYPE_SIGNAL: {
+			auto signal = tb->signals.getptr(path);
+			if (signal) {
+				signal->emit(msg);
+				return DBUS_HANDLER_RESULT_HANDLED;
+			}
+			break;
+		}
+			// TODO: Handle method calls for things like the tray icon
+	}
+
+	return DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+}
+
+void TrayBrokerDBus::make_default() {
+	_create = _create_dbus;
+}
+
+TrayBroker *TrayBrokerDBus::_create_dbus() {
+	return memnew(TrayBrokerDBus);
+}
+
+bool TrayBrokerDBus::add_signal(const String &path, Callback cb, void *p_userdata) {
+	return signals.set(path, SignalDBus(cb, p_userdata));
+}
+
+void TrayBrokerDBus::remove_signal(const String &path) {
+	signals.erase(path);
+}
+
+void TrayBrokerDBus::request_notification_permission() {
+}
+
+void TrayBrokerDBus::process_messages() {
+	if (!acts.is_empty()) {
+		int ret;
+		struct timespec to = { 0, 10000 };
+
+		List<int> act_l;
+		acts.get_key_list(&act_l);
+
+		size_t nfds = 0;
+		for (List<int>::Element *a = act_l.front(); a; a = a->next()) {
+			int fd = a->get();
+			if (fd < 0) {
+				continue;
+			}
+			auto act = acts[fd];
+			if (act.r) {
+				++nfds;
+			}
+			if (act.w) {
+				++nfds;
+			}
+		}
+
+		Vector<pollfd> pfds;
+		pfds.resize(nfds);
+		for (List<int>::Element *a = act_l.front(); a; a = a->next()) {
+			int fd = a->get();
+			if (fd < 0) {
+				continue;
+			}
+			const WatchActuator &act = acts[fd];
+			if (act.r) {
+				pollfd pfd = { fd, act.r->flag, 0 };
+				pfds.push_back(pfd);
+			}
+			if (act.w) {
+				pollfd pfd = { fd, act.w->flag, 0 };
+				pfds.push_back(pfd);
+			}
+		}
+
+		ret = ppoll(pfds.ptrw(), pfds.size(), &to, NULL);
+
+		if (ret > 0) {
+			for (int f = 0; f < pfds.size(); ++f) {
+				const struct pollfd &pfd = pfds[f];
+				if (pfd.revents == 0 || pfd.revents & POLLNVAL) {
+					continue;
+				}
+				auto it = acts.getptr(pfd.fd);
+				if (!it) {
+					continue;
+				}
+				if (pfd.revents & POLLIN) {
+					send_dispatch(*it->r, pfd.revents);
+				}
+				if (pfd.revents & POLLOUT) {
+					send_dispatch(*it->w, pfd.revents);
+				}
+			}
+		}
+	}
+}
+
+TrayBrokerDBus::TrayBrokerDBus() {
+	dbus_error_init(&error);
+
+	bus = dbus_bus_get(DBUS_BUS_SESSION, &error);
+	if (!bus) {
+		ERR_FAIL_MSG("Couldn't create DBus connection");
+	}
+	if (dbus_error_is_set(&error)) {
+		ERR_FAIL_MSG(String("Getting DBus bus returned ") + error.message);
+	}
+
+	dbus_connection_set_dispatch_status_function(bus, dispatch_status, this, nullptr);
+
+	dbus_connection_set_watch_functions(bus, add_watch, remove_watch, toggle_watch, this, nullptr);
+
+	dbus_connection_add_filter(bus, signal_filter, this, nullptr);
+}
+
+DBusConnection *TrayBrokerDBus::get_bus() {
+	return bus;
+}
+
+TrayBrokerDBus::~TrayBrokerDBus() {
+	if (bus) {
+		dbus_connection_flush(bus);
+		dbus_connection_unref(bus);
+	}
+}
+
+#endif // DBUS_ENABLED

--- a/platform/linuxbsd/tray_broker_dbus.h
+++ b/platform/linuxbsd/tray_broker_dbus.h
@@ -1,0 +1,169 @@
+/*************************************************************************/
+/*  tray_broker_dbus.h                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef TRAY_BROKER_DBUS_H
+#define TRAY_BROKER_DBUS_H
+
+#ifdef DBUS_ENABLED
+
+#include "core/error/error_list.h"
+#include "core/io/tray_broker.h"
+#include "core/templates/hash_map.h"
+#include "core/templates/optional.h"
+#include "core/templates/vector.h"
+#include "core/variant/variant.h"
+#include <dbus/dbus.h>
+#include <cstdint>
+
+struct _dbus_fixed_arr {
+	void *data;
+	int32_t len;
+};
+
+struct _dbus_msg_tuple {
+	int32_t type;
+	int32_t category;
+	void *value;
+	const char *signature;
+	struct _dbus_msg_tuple *sub;
+};
+
+enum ValueCategory {
+	DBUS,
+	GODOT,
+};
+
+enum ValueType {
+	IMAGE,
+	BITMAP,
+};
+
+Error _append_dbus_container(DBusMessageIter *iter, struct _dbus_msg_tuple *t);
+Error _append_dbus_msg_tuple(DBusMessageIter *iter, struct _dbus_msg_tuple *args);
+Error _unmarshall_dbus_basic(DBusMessageIter *iter, Vector<Variant> &res);
+Error _unmarshall_dbus_container(DBusMessageIter *iter, Vector<Variant> &res);
+
+typedef int ReadActuator;
+
+typedef int WriteActuator;
+
+typedef int ErrorActuator;
+
+class TrayBrokerDBus : public TrayBroker {
+	GDCLASS(TrayBrokerDBus, TrayBroker);
+
+public:
+	typedef void (*Callback)(DBusMessage *msg, void *p_userdata);
+
+private:
+	class Actuator {
+	public:
+		DBusConnection *bus;
+		DBusWatch *watch;
+		short flag;
+
+		virtual dbus_bool_t handle() = 0;
+
+		Actuator(DBusConnection *b, DBusWatch *w, short f) :
+				bus(b), watch(w), flag(f) {}
+		virtual ~Actuator() {}
+	};
+
+	class ReadActuator : public Actuator {
+	public:
+		virtual dbus_bool_t handle() override;
+
+		ReadActuator(DBusConnection *b, DBusWatch *w, short f) :
+				Actuator(b, w, f) {}
+		virtual ~ReadActuator() {}
+	};
+
+	class WriteActuator : public Actuator {
+	public:
+		virtual dbus_bool_t handle() override;
+
+		WriteActuator(DBusConnection *b, DBusWatch *w, short f) :
+				Actuator(b, w, f) {}
+		virtual ~WriteActuator() {}
+	};
+
+	struct WatchActuator {
+		Optional<TrayBrokerDBus::ReadActuator> r;
+		Optional<TrayBrokerDBus::WriteActuator> w;
+	};
+
+	struct SignalDBus {
+		Callback cb;
+		void *p_userdata;
+
+		void emit(DBusMessage *msg);
+
+		SignalDBus() :
+				cb(nullptr), p_userdata(nullptr) {}
+
+		SignalDBus(Callback c, void *p) :
+				cb(c), p_userdata(p) {}
+	};
+
+private:
+	DBusConnection *bus;
+	DBusError error;
+	HashMap<int, WatchActuator> acts;
+	HashMap<String, SignalDBus> signals;
+
+	static TrayBroker *_create_dbus();
+
+	static dbus_bool_t dispatch(DBusConnection *bus);
+	static void dispatch_status(DBusConnection *bus, DBusDispatchStatus status, void *user_data);
+	static void send_dispatch(Actuator &act, short flag);
+
+	static dbus_bool_t add_watch(DBusWatch *w, void *user_data);
+	static void remove_watch(DBusWatch *w, void *user_data);
+	static void toggle_watch(DBusWatch *w, void *user_data);
+
+	static DBusHandlerResult signal_filter(DBusConnection *bus, DBusMessage *msg, void *user_data);
+
+public:
+	DBusConnection *get_bus();
+	static void make_default();
+	void process_messages();
+
+	bool add_signal(const String &path, Callback cb, void *user_data);
+	void remove_signal(const String &path);
+
+	virtual void request_notification_permission() override;
+
+	TrayBrokerDBus();
+	~TrayBrokerDBus();
+};
+
+#endif // DBUS_ENABLED
+
+#endif // TRAY_BROKER_DBUS_H


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Both native file picker dialogs (godotengine/godot-proposals#1123) and notifications (godotengine/godot-proposals#1338) need to communicate with the desktop so they can be used inside the engine.
I found that doing the interaction in `OS` might be cumbersome so instead this PR proposes a new singleton tasked with doing communications with the desktop through the native methods (e.g. DBus for LinuxBSD and WinAPI for Windows platforms).
It is essentially a broker end for engine classes (hence the name `TrayBroker`) so these use an unified and reusable interface.

This was tested via implementing a `Notification` class and sending notifications from GDScript.

The LinuxBSD version of `TrayBroker` requires an `Optional` class for uninitialized values in the event poller.
