### PR TITLE
Overhaul GLES3: Add basis for 3D renderer, overhaul materials and textures

### DIFF
--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -117,6 +117,7 @@ void RasterizerCanvasGLES3::_update_transform_to_mat4(const Transform3D &p_trans
 
 void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_item_list, const Color &p_modulate, Light *p_light_list, Light *p_directional_list, const Transform2D &p_canvas_transform, RS::CanvasItemTextureFilter p_default_filter, RS::CanvasItemTextureRepeat p_default_repeat, bool p_snap_2d_vertices_to_pixel, bool &r_sdf_used) {
 	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
+	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
 
 	texture_storage->frame.current_rt = nullptr;
 
@@ -155,7 +156,7 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 		state_buffer.screen_pixel_size[0] = 1.0 / render_target_size.x;
 		state_buffer.screen_pixel_size[1] = 1.0 / render_target_size.y;
 
-		state_buffer.time = texture_storage->frame.time;
+		state_buffer.time = state.time;
 		state_buffer.use_pixel_snap = p_snap_2d_vertices_to_pixel;
 
 		state_buffer.directional_light_count = 0; //directional_light_count;
@@ -178,8 +179,12 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 
 		//print_line("w: " + itos(ssize.width) + " s: " + rtos(canvas_scale));
 		state_buffer.tex_to_sdf = 1.0 / ((canvas_scale.x + canvas_scale.y) * 0.5);
-		glBindBufferBase(GL_UNIFORM_BUFFER, 0, state.canvas_state_buffer);
+		glBindBufferBase(GL_UNIFORM_BUFFER, BASE_UNIFORM_BUFFER_OBJECT, state.canvas_state_buffer);
 		glBufferData(GL_UNIFORM_BUFFER, sizeof(StateBuffer), &state_buffer, GL_STREAM_DRAW);
+
+		GLuint global_buffer = material_storage->global_variables_get_uniform_buffer();
+
+		glBindBufferBase(GL_UNIFORM_BUFFER, GLOBAL_UNIFORM_BUFFER_OBJECT, global_buffer);
 		glBindBuffer(GL_UNIFORM_BUFFER, 0);
 	}
 
@@ -197,8 +202,6 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 	r_sdf_used = false;
 	int item_count = 0;
 
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, storage->resources.white_tex);
 	Item *ci = p_item_list;
 	while (ci) {
 		// just add all items for now
@@ -215,7 +218,6 @@ void RasterizerCanvasGLES3::canvas_render_items(RID p_to_render_target, Item *p_
 }
 
 void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_count, const Transform2D &p_canvas_transform_inverse, Light *p_lights, bool p_to_backbuffer) {
-	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
 	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
 	Item *current_clip = nullptr;
 
@@ -229,88 +231,31 @@ void RasterizerCanvasGLES3::_render_items(RID p_to_render_target, int p_item_cou
 	RID prev_material;
 	uint32_t index = 0;
 
+	state.current_shader_version = state.canvas_shader_default_version;
+
 	for (int i = 0; i < p_item_count; i++) {
 		Item *ci = items[i];
 
 		RID material = ci->material_owner == nullptr ? ci->material : ci->material_owner->material;
-		GLES3::Material *material_ptr = material_storage->get_material(material);
 
 		if (material.is_null() && ci->canvas_group != nullptr) {
 			material = default_canvas_group_material;
 		}
 
 		if (material != prev_material) {
-			GLES3::Shader *shader_ptr = nullptr;
-
-			if (material_ptr) {
-				shader_ptr = material_ptr->shader;
-
-				if (shader_ptr && shader_ptr->mode != RS::SHADER_CANVAS_ITEM) {
-					shader_ptr = nullptr; // not a canvas item shader, don't use.
-				}
+			GLES3::CanvasMaterialData *material_data = nullptr;
+			if (material.is_valid()) {
+				material_data = static_cast<GLES3::CanvasMaterialData *>(material_storage->material_get_data(material, RS::SHADER_CANVAS_ITEM));
 			}
-
-			if (shader_ptr) {
-				if (true) { //check that shader has changed
-					if (shader_ptr->canvas_item.uses_time) {
-						RenderingServerDefault::redraw_request();
-					}
-					//state.canvas_shader.version_bind_shader(shader_ptr->version, CanvasShaderGLES3::MODE_QUAD);
-					state.current_shader_version = shader_ptr->version;
+			if (material_data) {
+				if (material_data->shader_data->version.is_valid() && material_data->shader_data->valid) {
+					// Bind uniform buffer and textures
+					material_data->bind_uniforms();
+					state.current_shader_version = material_data->shader_data->version;
+				} else {
+					state.current_shader_version = state.canvas_shader_default_version;
 				}
-
-				int tc = material_ptr->textures.size();
-				Pair<StringName, RID> *textures = material_ptr->textures.ptrw();
-
-				ShaderCompiler::GeneratedCode::Texture *texture_uniforms = shader_ptr->texture_uniforms.ptrw();
-
-				for (int ti = 0; ti < tc; i++) {
-					glActiveTexture(GL_TEXTURE0 + ti);
-
-					GLES3::Texture *t = texture_storage->get_texture(textures[ti].second);
-
-					if (!t) {
-						switch (texture_uniforms[i].hint) {
-							case ShaderLanguage::ShaderNode::Uniform::HINT_BLACK_ALBEDO:
-							case ShaderLanguage::ShaderNode::Uniform::HINT_BLACK: {
-								glBindTexture(GL_TEXTURE_2D, storage->resources.black_tex);
-							} break;
-							case ShaderLanguage::ShaderNode::Uniform::HINT_ANISOTROPY: {
-								glBindTexture(GL_TEXTURE_2D, storage->resources.aniso_tex);
-							} break;
-							case ShaderLanguage::ShaderNode::Uniform::HINT_NORMAL: {
-								glBindTexture(GL_TEXTURE_2D, storage->resources.normal_tex);
-							} break;
-							default: {
-								glBindTexture(GL_TEXTURE_2D, storage->resources.white_tex);
-							} break;
-						}
-
-						continue;
-					}
-
-					//Set texture filter and repeat texture_uniforms[i].filter texture_uniforms[i].repeat
-
-					if (t->redraw_if_visible) {
-						RenderingServerDefault::redraw_request();
-					}
-
-					t = t->get_ptr();
-
-#ifdef TOOLS_ENABLED
-					if (t->detect_normal && texture_uniforms[i].hint == ShaderLanguage::ShaderNode::Uniform::HINT_NORMAL) {
-						t->detect_normal(t->detect_normal_ud);
-					}
-#endif
-					if (t->render_target) {
-						t->render_target->used_in_frame = true;
-					}
-
-					glBindTexture(t->target, t->tex_id);
-				}
-
 			} else {
-				//state.canvas_shader.version_bind_shader(state.canvas_shader_default_version, CanvasShaderGLES3::MODE_QUAD);
 				state.current_shader_version = state.canvas_shader_default_version;
 			}
 			prev_material = material;
@@ -389,7 +334,7 @@ void RasterizerCanvasGLES3::_render_item(RID p_render_target, const Item *p_item
 					state.current_command = Item::Command::TYPE_RECT;
 				}
 				_bind_canvas_texture(rect->texture, current_filter, current_repeat, r_index, last_texture, texpixel_size);
-				state.canvas_shader.version_bind_shader(state.current_shader_version, CanvasShaderGLES3::MODE_QUAD);
+				GLES3::MaterialStorage::get_singleton()->shaders.canvas_shader.version_bind_shader(state.current_shader_version, CanvasShaderGLES3::MODE_QUAD);
 
 				Rect2 src_rect;
 				Rect2 dst_rect;
@@ -552,7 +497,7 @@ void RasterizerCanvasGLES3::_render_item(RID p_render_target, const Item *p_item
 					state.current_command = Item::Command::TYPE_POLYGON;
 				}
 				_bind_canvas_texture(polygon->texture, current_filter, current_repeat, r_index, last_texture, texpixel_size);
-				state.canvas_shader.version_bind_shader(state.current_shader_version, CanvasShaderGLES3::MODE_ATTRIBUTES);
+				GLES3::MaterialStorage::get_singleton()->shaders.canvas_shader.version_bind_shader(state.current_shader_version, CanvasShaderGLES3::MODE_ATTRIBUTES);
 
 				state.current_primitive = polygon->primitive;
 				state.instance_data_array[r_index].modulation[0] = base_color.r;
@@ -566,16 +511,18 @@ void RasterizerCanvasGLES3::_render_item(RID p_render_target, const Item *p_item
 					state.instance_data_array[r_index].ninepatch_margins[j] = 0;
 				}
 
-				// If the previous operation is not done yet, allocated a new buffer
-				GLint syncStatus;
-				glGetSynciv(state.fences[state.current_buffer], GL_SYNC_STATUS, sizeof(GLint), nullptr, &syncStatus);
-				if (syncStatus == GL_UNSIGNALED) {
-					_allocate_instance_data_buffer();
-				} else {
-					glDeleteSync(state.fences[state.current_buffer]);
+				// If the previous operation is not done yet, allocate a new buffer
+				if (state.fences[state.current_buffer] != GLsync()) {
+					GLint syncStatus;
+					glGetSynciv(state.fences[state.current_buffer], GL_SYNC_STATUS, sizeof(GLint), nullptr, &syncStatus);
+					if (syncStatus == GL_UNSIGNALED) {
+						_allocate_instance_data_buffer();
+					} else {
+						glDeleteSync(state.fences[state.current_buffer]);
+					}
 				}
 
-				glBindBufferBase(GL_UNIFORM_BUFFER, 3, state.canvas_instance_data_buffers[state.current_buffer]);
+				glBindBufferBase(GL_UNIFORM_BUFFER, INSTANCE_UNIFORM_BUFFER_OBJECT, state.canvas_instance_data_buffers[state.current_buffer]);
 #ifdef JAVASCRIPT_ENABLED
 				//WebGL 2.0 does not support mapping buffers, so use slow glBufferData instead
 				glBufferData(GL_UNIFORM_BUFFER, sizeof(InstanceData), &state.instance_data_array[0], GL_DYNAMIC_DRAW);
@@ -609,7 +556,7 @@ void RasterizerCanvasGLES3::_render_item(RID p_render_target, const Item *p_item
 					state.current_command = Item::Command::TYPE_PRIMITIVE;
 				}
 				_bind_canvas_texture(RID(), current_filter, current_repeat, r_index, last_texture, texpixel_size);
-				state.canvas_shader.version_bind_shader(state.current_shader_version, CanvasShaderGLES3::MODE_PRIMITIVE);
+				GLES3::MaterialStorage::get_singleton()->shaders.canvas_shader.version_bind_shader(state.current_shader_version, CanvasShaderGLES3::MODE_PRIMITIVE);
 
 				for (uint32_t j = 0; j < MIN(3u, primitive->point_count); j++) {
 					state.instance_data_array[r_index].points[j * 2 + 0] = primitive->points[j].x;
@@ -771,15 +718,17 @@ void RasterizerCanvasGLES3::_render_item(RID p_render_target, const Item *p_item
 void RasterizerCanvasGLES3::_render_batch(uint32_t &r_index) {
 	if (state.end_batch && r_index > 0) {
 		// If the previous operation is not done yet, allocate a new buffer
-		GLint syncStatus;
-		glGetSynciv(state.fences[state.current_buffer], GL_SYNC_STATUS, sizeof(GLint), nullptr, &syncStatus);
-		if (syncStatus == GL_UNSIGNALED) {
-			_allocate_instance_data_buffer();
-		} else {
-			glDeleteSync(state.fences[state.current_buffer]);
+		if (state.fences[state.current_buffer] != GLsync()) {
+			GLint syncStatus;
+			glGetSynciv(state.fences[state.current_buffer], GL_SYNC_STATUS, sizeof(GLint), nullptr, &syncStatus);
+			if (syncStatus == GL_UNSIGNALED) {
+				_allocate_instance_data_buffer();
+			} else {
+				glDeleteSync(state.fences[state.current_buffer]);
+			}
 		}
 
-		glBindBufferBase(GL_UNIFORM_BUFFER, 3, state.canvas_instance_data_buffers[state.current_buffer]);
+		glBindBufferBase(GL_UNIFORM_BUFFER, INSTANCE_UNIFORM_BUFFER_OBJECT, state.canvas_instance_data_buffers[state.current_buffer]);
 #ifdef JAVASCRIPT_ENABLED
 		//WebGL 2.0 does not support mapping buffers, so use slow glBufferData instead
 		glBufferData(GL_UNIFORM_BUFFER, sizeof(InstanceData) * r_index, state.instance_data_array, GL_DYNAMIC_DRAW);
@@ -903,7 +852,8 @@ void RasterizerCanvasGLES3::canvas_begin() {
 	reset_canvas();
 
 	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(GL_TEXTURE_2D, storage->resources.white_tex);
+	GLES3::Texture *tex = texture_storage->get_texture(texture_storage->texture_gl_get_default(GLES3::DEFAULT_GL_TEXTURE_WHITE));
+	glBindTexture(GL_TEXTURE_2D, tex->tex_id);
 }
 
 void RasterizerCanvasGLES3::canvas_end() {
@@ -961,11 +911,9 @@ void RasterizerCanvasGLES3::_bind_canvas_texture(RID p_texture, RS::CanvasItemTe
 		ct->size_cache = Size2i(1, 1);
 
 		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, storage->resources.white_tex);
-
+		GLES3::Texture *tex = texture_storage->get_texture(texture_storage->texture_gl_get_default(GLES3::DEFAULT_GL_TEXTURE_WHITE));
+		glBindTexture(GL_TEXTURE_2D, tex->tex_id);
 	} else {
-		texture = texture->get_ptr();
-
 		glActiveTexture(GL_TEXTURE0);
 		glBindTexture(GL_TEXTURE_2D, texture->tex_id);
 
@@ -973,8 +921,8 @@ void RasterizerCanvasGLES3::_bind_canvas_texture(RID p_texture, RS::CanvasItemTe
 		state.current_tex_ptr = texture;
 		ct->size_cache = Size2i(texture->width, texture->height);
 
-		texture->GLSetFilter(GL_TEXTURE_2D, filter);
-		texture->GLSetRepeat(GL_TEXTURE_2D, repeat);
+		texture->gl_set_filter(filter);
+		texture->gl_set_repeat(repeat);
 	}
 
 	GLES3::Texture *normal_map = texture_storage->get_texture(ct->normal_map);
@@ -983,17 +931,16 @@ void RasterizerCanvasGLES3::_bind_canvas_texture(RID p_texture, RS::CanvasItemTe
 		state.current_normal = RID();
 		ct->use_normal_cache = false;
 		glActiveTexture(GL_TEXTURE0 + GLES3::Config::get_singleton()->max_texture_image_units - 6);
-		glBindTexture(GL_TEXTURE_2D, storage->resources.normal_tex);
+		GLES3::Texture *tex = texture_storage->get_texture(texture_storage->texture_gl_get_default(GLES3::DEFAULT_GL_TEXTURE_NORMAL));
+		glBindTexture(GL_TEXTURE_2D, tex->tex_id);
 
 	} else {
-		normal_map = normal_map->get_ptr();
-
 		glActiveTexture(GL_TEXTURE0 + storage->config->max_texture_image_units - 6);
 		glBindTexture(GL_TEXTURE_2D, normal_map->tex_id);
 		state.current_normal = ct->normal_map;
 		ct->use_normal_cache = true;
-		texture->GLSetFilter(GL_TEXTURE_2D, filter);
-		texture->GLSetRepeat(GL_TEXTURE_2D, repeat);
+		texture->gl_set_filter(filter);
+		texture->gl_set_repeat(repeat);
 	}
 
 	GLES3::Texture *specular_map = texture_storage->get_texture(ct->specular);
@@ -1002,17 +949,15 @@ void RasterizerCanvasGLES3::_bind_canvas_texture(RID p_texture, RS::CanvasItemTe
 		state.current_specular = RID();
 		ct->use_specular_cache = false;
 		glActiveTexture(GL_TEXTURE0 + storage->config->max_texture_image_units - 7);
-		glBindTexture(GL_TEXTURE_2D, storage->resources.white_tex);
-
+		GLES3::Texture *tex = texture_storage->get_texture(texture_storage->texture_gl_get_default(GLES3::DEFAULT_GL_TEXTURE_WHITE));
+		glBindTexture(GL_TEXTURE_2D, tex->tex_id);
 	} else {
-		specular_map = specular_map->get_ptr();
-
 		glActiveTexture(GL_TEXTURE0 + storage->config->max_texture_image_units - 7);
 		glBindTexture(GL_TEXTURE_2D, specular_map->tex_id);
 		state.current_specular = ct->specular;
 		ct->use_specular_cache = true;
-		texture->GLSetFilter(GL_TEXTURE_2D, filter);
-		texture->GLSetRepeat(GL_TEXTURE_2D, repeat);
+		texture->gl_set_filter(filter);
+		texture->gl_set_repeat(repeat);
 	}
 
 	if (ct->use_specular_cache) {
@@ -1260,7 +1205,19 @@ void RasterizerCanvasGLES3::_allocate_instance_data_buffer() {
 	glBindBuffer(GL_UNIFORM_BUFFER, 0);
 }
 
-void RasterizerCanvasGLES3::initialize() {
+void RasterizerCanvasGLES3::set_time(double p_time) {
+	state.time = p_time;
+}
+
+RasterizerCanvasGLES3 *RasterizerCanvasGLES3::singleton = nullptr;
+
+RasterizerCanvasGLES3 *RasterizerCanvasGLES3::get_singleton() {
+	return singleton;
+}
+
+RasterizerCanvasGLES3::RasterizerCanvasGLES3(RasterizerStorageGLES3 *p_storage) {
+	singleton = this;
+	storage = p_storage;
 	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
 	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
 
@@ -1386,9 +1343,7 @@ void RasterizerCanvasGLES3::initialize() {
 	}
 
 	//state.canvas_shadow_shader.init();
-
-	int uniform_max_size;
-	glGetIntegerv(GL_MAX_UNIFORM_BLOCK_SIZE, &uniform_max_size);
+	int uniform_max_size = storage->config->max_uniform_buffer_size;
 	if (uniform_max_size < 65536) {
 		state.max_lights_per_render = 64;
 		state.max_instances_per_batch = 128;
@@ -1402,6 +1357,7 @@ void RasterizerCanvasGLES3::initialize() {
 	state.fences.resize(64);
 	glGenBuffers(64, state.canvas_instance_data_buffers.ptr());
 	for (int i = 0; i < 64; i++) {
+		state.fences[i] = GLsync();
 		glBindBuffer(GL_UNIFORM_BUFFER, state.canvas_instance_data_buffers[i]);
 		glBufferData(GL_UNIFORM_BUFFER, sizeof(InstanceData) * state.max_instances_per_batch, nullptr, GL_DYNAMIC_DRAW);
 	}
@@ -1419,9 +1375,9 @@ void RasterizerCanvasGLES3::initialize() {
 	global_defines += "#define MAX_LIGHTS " + itos(state.max_instances_per_batch) + "\n";
 	global_defines += "#define MAX_DRAW_DATA_INSTANCES " + itos(state.max_instances_per_batch) + "\n";
 
-	state.canvas_shader.initialize(global_defines);
-	state.canvas_shader_default_version = state.canvas_shader.version_create();
-	state.canvas_shader.version_bind_shader(state.canvas_shader_default_version, CanvasShaderGLES3::MODE_QUAD);
+	GLES3::MaterialStorage::get_singleton()->shaders.canvas_shader.initialize(global_defines);
+	state.canvas_shader_default_version = GLES3::MaterialStorage::get_singleton()->shaders.canvas_shader.version_create();
+	GLES3::MaterialStorage::get_singleton()->shaders.canvas_shader.version_bind_shader(state.canvas_shader_default_version, CanvasShaderGLES3::MODE_QUAD);
 
 	//state.canvas_shader.set_conditional(CanvasOldShaderGLES3::USE_RGBA_SHADOWS, storage->config->use_rgba_2d_shadows);
 
@@ -1463,32 +1419,19 @@ void fragment() {
 	state.using_transparent_rt = false;
 	state.using_skeleton = false;
 	state.current_shader_version = state.canvas_shader_default_version;
-}
-
-RasterizerCanvasGLES3 *RasterizerCanvasGLES3::singleton = nullptr;
-
-RasterizerCanvasGLES3 *RasterizerCanvasGLES3::get_singleton() {
-	return singleton;
-}
-
-RasterizerCanvasGLES3::RasterizerCanvasGLES3(RasterizerStorageGLES3 *p_storage) {
-	singleton = this;
-	storage = p_storage;
-	initialize();
+	state.time = 0.0;
 }
 
 RasterizerCanvasGLES3::~RasterizerCanvasGLES3() {
 	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
 	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
 
-	state.canvas_shader.version_free(state.canvas_shader_default_version);
+	GLES3::MaterialStorage::get_singleton()->shaders.canvas_shader.version_free(state.canvas_shader_default_version);
 	material_storage->material_free(default_canvas_group_material);
 	material_storage->shader_free(default_canvas_group_shader);
 	texture_storage->canvas_texture_free(default_canvas_texture);
 	singleton = nullptr;
-}
 
-void RasterizerCanvasGLES3::finalize() {
 	glDeleteBuffers(1, &data.canvas_quad_vertices);
 	glDeleteVertexArrays(1, &data.canvas_quad_array);
 

--- a/drivers/gles3/rasterizer_canvas_gles3.h
+++ b/drivers/gles3/rasterizer_canvas_gles3.h
@@ -54,13 +54,6 @@ class RasterizerCanvasGLES3 : public RendererCanvasRender {
 	_FORCE_INLINE_ void _update_transform_to_mat4(const Transform3D &p_transform, float *p_mat4);
 
 	enum {
-		BASE_UNIFORM_BUFFER_OBJECT = 0,
-		MATERIAL_UNIFORM_BUFFER_OBJECT = 1,
-		TRANSFORMS_UNIFORM_BUFFER_OBJECT = 2,
-		CANVAS_TEXTURE_UNIFORM_BUFFER_OBJECT = 3,
-	};
-
-	enum {
 
 		FLAGS_INSTANCING_MASK = 0x7F,
 		FLAGS_INSTANCING_HAS_COLORS = (1 << 7),
@@ -104,6 +97,15 @@ class RasterizerCanvasGLES3 : public RendererCanvasRender {
 	};
 
 public:
+	//TODO move to Material storage
+	enum {
+		BASE_UNIFORM_BUFFER_OBJECT = 0,
+		GLOBAL_UNIFORM_BUFFER_OBJECT = 1,
+		LIGHT_UNIFORM_BUFFER_OBJECT = 2,
+		INSTANCE_UNIFORM_BUFFER_OBJECT = 3,
+		MATERIAL_UNIFORM_BUFFER_OBJECT = 4,
+	};
+
 	struct StateBuffer {
 		float canvas_transform[16];
 		float screen_transform[16];
@@ -170,7 +172,7 @@ public:
 
 		InstanceData *instance_data_array = nullptr;
 		bool canvas_texscreen_used;
-		CanvasShaderGLES3 canvas_shader;
+		//CanvasShaderGLES3 canvas_shader;
 		RID canvas_shader_current_version;
 		RID canvas_shader_default_version;
 		//CanvasShadowShaderGLES3 canvas_shadow_shader;
@@ -202,6 +204,8 @@ public:
 		bool using_transparent_rt;
 
 		// FROM RD Renderer
+
+		double time = 0.0;
 
 		uint32_t max_lights_per_render;
 		uint32_t max_lights_per_item;
@@ -273,11 +277,10 @@ public:
 	void _end_batch(uint32_t &p_max_index);
 	void _allocate_instance_data_buffer();
 
-	void initialize();
-	void finalize();
+	void set_time(double p_time);
 
 	static RasterizerCanvasGLES3 *get_singleton();
-	RasterizerCanvasGLES3(RasterizerStorageGLES3 *storage);
+	RasterizerCanvasGLES3(RasterizerStorageGLES3 *p_storage);
 	~RasterizerCanvasGLES3();
 };
 

--- a/drivers/gles3/rasterizer_gles3.h
+++ b/drivers/gles3/rasterizer_gles3.h
@@ -84,7 +84,7 @@ public:
 
 	void end_frame(bool p_swap_buffers);
 
-	void finalize() {}
+	void finalize();
 
 	static RendererCompositor *_create_current() {
 		return memnew(RasterizerGLES3);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -29,10 +29,18 @@
 /*************************************************************************/
 
 #include "rasterizer_scene_gles3.h"
+#include "core/config/project_settings.h"
+#include "servers/rendering/rendering_server_default.h"
 
 #ifdef GLES3_ENABLED
 
-// TODO: 3D support not implemented yet.
+uint64_t RasterizerSceneGLES3::auto_exposure_counter = 2;
+
+RasterizerSceneGLES3 *RasterizerSceneGLES3::singleton = nullptr;
+
+RasterizerSceneGLES3 *RasterizerSceneGLES3::get_singleton() {
+	return singleton;
+}
 
 RasterizerSceneGLES3::GeometryInstance *RasterizerSceneGLES3::geometry_instance_create(RID p_base) {
 	return nullptr;
@@ -137,39 +145,130 @@ int RasterizerSceneGLES3::get_directional_light_shadow_size(RID p_light_intance)
 void RasterizerSceneGLES3::set_directional_shadow_count(int p_count) {
 }
 
-/* SDFGI UPDATE */
-
-void RasterizerSceneGLES3::sdfgi_update(RID p_render_buffers, RID p_environment, const Vector3 &p_world_position) {
-}
-
-int RasterizerSceneGLES3::sdfgi_get_pending_region_count(RID p_render_buffers) const {
-	return 0;
-}
-
-AABB RasterizerSceneGLES3::sdfgi_get_pending_region_bounds(RID p_render_buffers, int p_region) const {
-	return AABB();
-}
-
-uint32_t RasterizerSceneGLES3::sdfgi_get_pending_region_cascade(RID p_render_buffers, int p_region) const {
-	return 0;
-}
-
 /* SKY API */
 
+void RasterizerSceneGLES3::Sky::free() {
+	if (radiance != 0) {
+		glDeleteTextures(1, &radiance);
+		radiance = 0;
+		glDeleteFramebuffers(1, &radiance_framebuffer);
+		radiance_framebuffer = 0;
+	}
+}
+
 RID RasterizerSceneGLES3::sky_allocate() {
-	return RID();
+	return sky_owner.allocate_rid();
 }
 
 void RasterizerSceneGLES3::sky_initialize(RID p_rid) {
+	sky_owner.initialize_rid(p_rid);
 }
 
 void RasterizerSceneGLES3::sky_set_radiance_size(RID p_sky, int p_radiance_size) {
+	Sky *sky = sky_owner.get_or_null(p_sky);
+	ERR_FAIL_COND(!sky);
+	ERR_FAIL_COND_MSG(p_radiance_size < 32 || p_radiance_size > 2048, "Sky radiance size must be between 32 and 2048");
+
+	if (sky->radiance_size == p_radiance_size) {
+		return; // No need to update
+	}
+
+	sky->radiance_size = p_radiance_size;
+
+	sky->free();
 }
 
-void RasterizerSceneGLES3::sky_set_mode(RID p_sky, RS::SkyMode p_samples) {
+void RasterizerSceneGLES3::sky_set_mode(RID p_sky, RS::SkyMode p_mode) {
+	Sky *sky = sky_owner.get_or_null(p_sky);
+	ERR_FAIL_COND(!sky);
+
+	if (sky->mode == p_mode) {
+		return;
+	}
+
+	sky->mode = p_mode;
+
+	if (sky->mode == RS::SKY_MODE_REALTIME) {
+		WARN_PRINT_ONCE("The OpenGL renderer does not support the Real Time Sky Update Mode yet. Please use High Quality Mode instead");
+	}
 }
 
 void RasterizerSceneGLES3::sky_set_material(RID p_sky, RID p_material) {
+	Sky *sky = sky_owner.get_or_null(p_sky);
+	ERR_FAIL_COND(!sky);
+
+	if (sky->material == p_material) {
+		return;
+	}
+
+	sky->material = p_material;
+}
+
+void RasterizerSceneGLES3::_invalidate_sky(Sky *p_sky) {
+	if (!p_sky->dirty) {
+		p_sky->dirty = true;
+		p_sky->dirty_list = dirty_sky_list;
+		dirty_sky_list = p_sky;
+	}
+}
+
+void RasterizerSceneGLES3::_update_dirty_skys() {
+	Sky *sky = dirty_sky_list;
+
+	while (sky) {
+		if (sky->radiance == 0) {
+			//int mipmaps = Image::get_image_required_mipmaps(sky->radiance_size, sky->radiance_size, Image::FORMAT_RGBAH) + 1;
+
+			//uint32_t w = sky->radiance_size, h = sky->radiance_size;
+			//int layers = sky_globals.roughness_layers;
+			glGenFramebuffers(1, &sky->radiance_framebuffer);
+
+			glGenTextures(1, &sky->radiance);
+		}
+
+		sky->reflection_dirty = true;
+		sky->processing_layer = 0;
+
+		Sky *next = sky->dirty_list;
+		sky->dirty_list = nullptr;
+		sky->dirty = false;
+		sky = next;
+	}
+
+	dirty_sky_list = nullptr;
+}
+
+void RasterizerSceneGLES3::_draw_sky(Sky *p_sky, const CameraMatrix &p_projection, const Transform3D &p_transform, float p_custom_fov, float p_energy, const Basis &p_sky_orientation) {
+	ERR_FAIL_COND(!p_sky);
+
+	glDepthMask(GL_TRUE);
+	glEnable(GL_DEPTH_TEST);
+	glDisable(GL_CULL_FACE);
+	glDisable(GL_BLEND);
+	glDepthFunc(GL_LEQUAL);
+	glColorMask(1, 1, 1, 1);
+
+	//state.sky_shader.version_bind_shader(sky_globals.default_shader, SkyShaderGLES3::MODE_BACKGROUND);
+	//glBindBufferBase(GL_UNIFORM_BUFFER, 0, state.canvas_instance_data_buffers[state.current_buffer]); // Canvas data updated here
+	//glBindBufferBase(GL_UNIFORM_BUFFER, 1, state.canvas_instance_data_buffers[state.current_buffer]); // Global data
+	//glBindBufferBase(GL_UNIFORM_BUFFER, 2, state.canvas_instance_data_buffers[state.current_buffer]); // Directional light data
+	//glBindBufferBase(GL_UNIFORM_BUFFER, 3, state.canvas_instance_data_buffers[state.current_buffer]); // Material uniforms
+
+	// Camera
+	CameraMatrix camera;
+
+	if (p_custom_fov) {
+		float near_plane = p_projection.get_z_near();
+		float far_plane = p_projection.get_z_far();
+		float aspect = p_projection.get_aspect();
+
+		camera.set_perspective(p_custom_fov, aspect, near_plane, far_plane);
+
+	} else {
+		camera = p_projection;
+	}
+
+	glDrawArrays(GL_TRIANGLES, 0, 3);
 }
 
 Ref<Image> RasterizerSceneGLES3::sky_bake_panorama(RID p_sky, float p_energy, bool p_bake_irradiance, const Size2i &p_size) {
@@ -179,52 +278,107 @@ Ref<Image> RasterizerSceneGLES3::sky_bake_panorama(RID p_sky, float p_energy, bo
 /* ENVIRONMENT API */
 
 RID RasterizerSceneGLES3::environment_allocate() {
-	return RID();
+	return environment_owner.allocate_rid();
 }
 
 void RasterizerSceneGLES3::environment_initialize(RID p_rid) {
+	environment_owner.initialize_rid(p_rid);
 }
 
 void RasterizerSceneGLES3::environment_set_background(RID p_env, RS::EnvironmentBG p_bg) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
+	env->background = p_bg;
 }
 
 void RasterizerSceneGLES3::environment_set_sky(RID p_env, RID p_sky) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
+	env->sky = p_sky;
 }
 
 void RasterizerSceneGLES3::environment_set_sky_custom_fov(RID p_env, float p_scale) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
+	env->sky_custom_fov = p_scale;
 }
 
 void RasterizerSceneGLES3::environment_set_sky_orientation(RID p_env, const Basis &p_orientation) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
+	env->sky_orientation = p_orientation;
 }
 
 void RasterizerSceneGLES3::environment_set_bg_color(RID p_env, const Color &p_color) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
+	env->bg_color = p_color;
 }
 
 void RasterizerSceneGLES3::environment_set_bg_energy(RID p_env, float p_energy) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
+	env->bg_energy = p_energy;
 }
 
 void RasterizerSceneGLES3::environment_set_canvas_max_layer(RID p_env, int p_max_layer) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
+	env->canvas_max_layer = p_max_layer;
 }
 
 void RasterizerSceneGLES3::environment_set_ambient_light(RID p_env, const Color &p_color, RS::EnvironmentAmbientSource p_ambient, float p_energy, float p_sky_contribution, RS::EnvironmentReflectionSource p_reflection_source) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
+	env->ambient_light = p_color;
+	env->ambient_source = p_ambient;
+	env->ambient_light_energy = p_energy;
+	env->ambient_sky_contribution = p_sky_contribution;
+	env->reflection_source = p_reflection_source;
 }
 
 void RasterizerSceneGLES3::environment_set_glow(RID p_env, bool p_enable, Vector<float> p_levels, float p_intensity, float p_strength, float p_mix, float p_bloom_threshold, RS::EnvironmentGlowBlendMode p_blend_mode, float p_hdr_bleed_threshold, float p_hdr_bleed_scale, float p_hdr_luminance_cap, float p_glow_map_strength, RID p_glow_map) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
+	ERR_FAIL_COND_MSG(p_levels.size() != 7, "Size of array of glow levels must be 7");
+	env->glow_enabled = p_enable;
+	env->glow_levels = p_levels;
+	env->glow_intensity = p_intensity;
+	env->glow_strength = p_strength;
+	env->glow_mix = p_mix;
+	env->glow_bloom = p_bloom_threshold;
+	env->glow_blend_mode = p_blend_mode;
+	env->glow_hdr_bleed_threshold = p_hdr_bleed_threshold;
+	env->glow_hdr_bleed_scale = p_hdr_bleed_scale;
+	env->glow_hdr_luminance_cap = p_hdr_luminance_cap;
+	env->glow_map_strength = p_glow_map_strength;
+	env->glow_map = p_glow_map;
 }
 
 void RasterizerSceneGLES3::environment_glow_set_use_bicubic_upscale(bool p_enable) {
+	glow_bicubic_upscale = p_enable;
 }
 
 void RasterizerSceneGLES3::environment_glow_set_use_high_quality(bool p_enable) {
+	glow_high_quality = p_enable;
 }
 
 void RasterizerSceneGLES3::environment_set_ssr(RID p_env, bool p_enable, int p_max_steps, float p_fade_int, float p_fade_out, float p_depth_tolerance) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
+	env->ssr_enabled = p_enable;
+	env->ssr_max_steps = p_max_steps;
+	env->ssr_fade_in = p_fade_int;
+	env->ssr_fade_out = p_fade_out;
+	env->ssr_depth_tolerance = p_depth_tolerance;
 }
 
 void RasterizerSceneGLES3::environment_set_ssr_roughness_quality(RS::EnvironmentSSRRoughnessQuality p_quality) {
 }
 
 void RasterizerSceneGLES3::environment_set_ssao(RID p_env, bool p_enable, float p_radius, float p_intensity, float p_power, float p_detail, float p_horizon, float p_sharpness, float p_light_affect, float p_ao_channel_affect) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
 }
 
 void RasterizerSceneGLES3::environment_set_ssao_quality(RS::EnvironmentSSAOQuality p_quality, bool p_half_size, float p_adaptive_target, int p_blur_passes, float p_fadeout_from, float p_fadeout_to) {
@@ -248,12 +402,43 @@ void RasterizerSceneGLES3::environment_set_sdfgi_frames_to_update_light(RS::Envi
 }
 
 void RasterizerSceneGLES3::environment_set_tonemap(RID p_env, RS::EnvironmentToneMapper p_tone_mapper, float p_exposure, float p_white, bool p_auto_exposure, float p_min_luminance, float p_max_luminance, float p_auto_exp_speed, float p_auto_exp_scale) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
+	env->exposure = p_exposure;
+	env->tone_mapper = p_tone_mapper;
+	if (!env->auto_exposure && p_auto_exposure) {
+		env->auto_exposure_version = ++auto_exposure_counter;
+	}
+	env->auto_exposure = p_auto_exposure;
+	env->white = p_white;
+	env->min_luminance = p_min_luminance;
+	env->max_luminance = p_max_luminance;
+	env->auto_exp_speed = p_auto_exp_speed;
+	env->auto_exp_scale = p_auto_exp_scale;
 }
 
 void RasterizerSceneGLES3::environment_set_adjustment(RID p_env, bool p_enable, float p_brightness, float p_contrast, float p_saturation, bool p_use_1d_color_correction, RID p_color_correction) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
+	env->adjustments_enabled = p_enable;
+	env->adjustments_brightness = p_brightness;
+	env->adjustments_contrast = p_contrast;
+	env->adjustments_saturation = p_saturation;
+	env->use_1d_color_correction = p_use_1d_color_correction;
+	env->color_correction = p_color_correction;
 }
 
 void RasterizerSceneGLES3::environment_set_fog(RID p_env, bool p_enable, const Color &p_light_color, float p_light_energy, float p_sun_scatter, float p_density, float p_height, float p_height_density, float p_aerial_perspective) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND(!env);
+	env->fog_enabled = p_enable;
+	env->fog_light_color = p_light_color;
+	env->fog_light_energy = p_light_energy;
+	env->fog_sun_scatter = p_sun_scatter;
+	env->fog_density = p_density;
+	env->fog_height = p_height;
+	env->fog_height_density = p_height_density;
+	env->fog_aerial_perspective = p_aerial_perspective;
 }
 
 void RasterizerSceneGLES3::environment_set_volumetric_fog(RID p_env, bool p_enable, float p_density, const Color &p_albedo, const Color &p_emission, float p_emission_energy, float p_anisotropy, float p_length, float p_detail_spread, float p_gi_inject, bool p_temporal_reprojection, float p_temporal_reprojection_amount, float p_ambient_inject) {
@@ -266,19 +451,25 @@ void RasterizerSceneGLES3::environment_set_volumetric_fog_filter_active(bool p_e
 }
 
 Ref<Image> RasterizerSceneGLES3::environment_bake_panorama(RID p_env, bool p_bake_irradiance, const Size2i &p_size) {
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND_V(!env, Ref<Image>());
 	return Ref<Image>();
 }
 
 bool RasterizerSceneGLES3::is_environment(RID p_env) const {
-	return false;
+	return environment_owner.owns(p_env);
 }
 
 RS::EnvironmentBG RasterizerSceneGLES3::environment_get_background(RID p_env) const {
-	return RS::ENV_BG_KEEP;
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND_V(!env, RS::ENV_BG_MAX);
+	return env->background;
 }
 
 int RasterizerSceneGLES3::environment_get_canvas_max_layer(RID p_env) const {
-	return 0;
+	Environment *env = environment_owner.get_or_null(p_env);
+	ERR_FAIL_COND_V(!env, 0);
+	return env->canvas_max_layer;
 }
 
 RID RasterizerSceneGLES3::camera_effects_allocate() {
@@ -409,6 +600,148 @@ void RasterizerSceneGLES3::voxel_gi_set_quality(RS::VoxelGIQuality) {
 }
 
 void RasterizerSceneGLES3::render_scene(RID p_render_buffers, const CameraData *p_camera_data, const PagedArray<GeometryInstance *> &p_instances, const PagedArray<RID> &p_lights, const PagedArray<RID> &p_reflection_probes, const PagedArray<RID> &p_voxel_gi_instances, const PagedArray<RID> &p_decals, const PagedArray<RID> &p_lightmaps, const PagedArray<RID> &p_fog_volumes, RID p_environment, RID p_camera_effects, RID p_shadow_atlas, RID p_occluder_debug_tex, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass, float p_screen_mesh_lod_threshold, const RenderShadowData *p_render_shadows, int p_render_shadow_count, const RenderSDFGIData *p_render_sdfgi_regions, int p_render_sdfgi_region_count, const RenderSDFGIUpdateData *p_sdfgi_update_data, RendererScene::RenderInfo *r_render_info) {
+	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
+	RENDER_TIMESTAMP("Setup 3D Scene");
+	// assign render data
+	// Use the format from rendererRD
+	RenderDataGLES3 render_data;
+	{
+		render_data.render_buffers = p_render_buffers;
+
+		// Our first camera is used by default
+		render_data.cam_transform = p_camera_data->main_transform;
+		render_data.cam_projection = p_camera_data->main_projection;
+		render_data.view_projection[0] = p_camera_data->main_projection;
+		render_data.cam_ortogonal = p_camera_data->is_ortogonal;
+
+		render_data.view_count = p_camera_data->view_count;
+		for (uint32_t v = 0; v < p_camera_data->view_count; v++) {
+			render_data.view_projection[v] = p_camera_data->view_projection[v];
+		}
+
+		render_data.z_near = p_camera_data->main_projection.get_z_near();
+		render_data.z_far = p_camera_data->main_projection.get_z_far();
+
+		render_data.instances = &p_instances;
+		render_data.lights = &p_lights;
+		render_data.reflection_probes = &p_reflection_probes;
+		//render_data.voxel_gi_instances = &p_voxel_gi_instances;
+		//render_data.decals = &p_decals;
+		//render_data.lightmaps = &p_lightmaps;
+		//render_data.fog_volumes = &p_fog_volumes;
+		render_data.environment = p_environment;
+		render_data.camera_effects = p_camera_effects;
+		render_data.shadow_atlas = p_shadow_atlas;
+		render_data.reflection_atlas = p_reflection_atlas;
+		render_data.reflection_probe = p_reflection_probe;
+		render_data.reflection_probe_pass = p_reflection_probe_pass;
+
+		// this should be the same for all cameras..
+		render_data.lod_distance_multiplier = p_camera_data->main_projection.get_lod_multiplier();
+		render_data.lod_camera_plane = Plane(-p_camera_data->main_transform.basis.get_axis(Vector3::AXIS_Z), p_camera_data->main_transform.get_origin());
+
+		if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_DISABLE_LOD) {
+			render_data.screen_mesh_lod_threshold = 0.0;
+		} else {
+			render_data.screen_mesh_lod_threshold = p_screen_mesh_lod_threshold;
+		}
+		render_data.render_info = r_render_info;
+	}
+
+	PagedArray<RID> empty;
+
+	if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_UNSHADED) {
+		render_data.lights = &empty;
+		render_data.reflection_probes = &empty;
+	}
+
+	RenderBuffers *rb = nullptr;
+	//RasterizerStorageGLES3::RenderTarget *rt = nullptr;
+	if (p_render_buffers.is_valid()) {
+		rb = render_buffers_owner.get_or_null(p_render_buffers);
+		ERR_FAIL_COND(!rb);
+		//rt = texture_storage->render_target_owner.get_or_null(rb->render_target);
+		//ERR_FAIL_COND(!rt);
+	}
+
+	Color clear_color;
+	if (p_render_buffers.is_valid()) {
+		clear_color = texture_storage->render_target_get_clear_request_color(rb->render_target);
+	} else {
+		clear_color = storage->get_default_clear_color();
+	}
+
+	Environment *env = environment_owner.get_or_null(p_environment);
+
+	bool fb_cleared = false;
+
+	glDepthFunc(GL_LEQUAL);
+
+	/* Depth Prepass */
+
+	glBindFramebuffer(GL_FRAMEBUFFER, rb->framebuffer);
+
+	if (!fb_cleared) {
+		glClearDepth(1.0f);
+		glClear(GL_DEPTH_BUFFER_BIT);
+	}
+
+	bool draw_sky = false;
+	bool keep_color = false;
+
+	if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_OVERDRAW) {
+		clear_color = Color(0, 0, 0, 1);
+	}
+	if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_OVERDRAW) {
+		clear_color = Color(0, 0, 0, 1); //in overdraw mode, BG should always be black
+	} else if (is_environment(p_environment)) {
+		RS::EnvironmentBG bg_mode = environment_get_background(p_environment);
+		float bg_energy = env->bg_energy; //environment_get_bg_energy(p_environment);
+		switch (bg_mode) {
+			case RS::ENV_BG_CLEAR_COLOR: {
+				clear_color.r *= bg_energy;
+				clear_color.g *= bg_energy;
+				clear_color.b *= bg_energy;
+			} break;
+			case RS::ENV_BG_COLOR: {
+				clear_color = env->bg_color; //environment_get_bg_color(p_environment);
+				clear_color.r *= bg_energy;
+				clear_color.g *= bg_energy;
+				clear_color.b *= bg_energy;
+			} break;
+			case RS::ENV_BG_SKY: {
+				draw_sky = true;
+			} break;
+			case RS::ENV_BG_CANVAS: {
+				keep_color = true;
+			} break;
+			case RS::ENV_BG_KEEP: {
+				keep_color = true;
+			} break;
+			case RS::ENV_BG_CAMERA_FEED: {
+			} break;
+			default: {
+			}
+		}
+	}
+
+	if (!keep_color) {
+		glClearBufferfv(GL_COLOR, 0, clear_color.components);
+	}
+
+	if (draw_sky) {
+		//_draw_sky(sky, render_data.cam_projection, render_data.cam_transform, env->sky_custom_fov, env->bg_energy, env->sky_orientation);
+	}
+
+	if (p_render_buffers.is_valid()) {
+		/*
+		RENDER_TIMESTAMP("Tonemap");
+		_render_buffers_post_process_and_tonemap(&render_data);
+		*/
+
+		_render_buffers_debug_draw(p_render_buffers, p_shadow_atlas, p_occluder_debug_tex);
+	}
+	texture_storage->render_target_disable_clear_request(rb->render_target);
 }
 
 void RasterizerSceneGLES3::render_material(const Transform3D &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, const PagedArray<GeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) {
@@ -417,20 +750,203 @@ void RasterizerSceneGLES3::render_material(const Transform3D &p_cam_transform, c
 void RasterizerSceneGLES3::render_particle_collider_heightfield(RID p_collider, const Transform3D &p_transform, const PagedArray<GeometryInstance *> &p_instances) {
 }
 
-void RasterizerSceneGLES3::set_scene_pass(uint64_t p_pass) {
-}
-
 void RasterizerSceneGLES3::set_time(double p_time, double p_step) {
+	time = p_time;
+	time_step = p_step;
 }
 
 void RasterizerSceneGLES3::set_debug_draw_mode(RS::ViewportDebugDraw p_debug_draw) {
+	debug_draw = p_debug_draw;
 }
 
 RID RasterizerSceneGLES3::render_buffers_create() {
-	return RID();
+	RenderBuffers rb;
+	return render_buffers_owner.make_rid(rb);
 }
 
+/* BACK FBO */
+/* For MSAA */
+/*
+#ifndef JAVASCRIPT_ENABLED
+	if (rt->msaa >= RS::VIEWPORT_MSAA_2X && rt->msaa <= RS::VIEWPORT_MSAA_8X) {
+		rt->multisample_active = true;
+
+		static const int msaa_value[] = { 0, 2, 4, 8, 16 };
+		int msaa = msaa_value[rt->msaa];
+
+		int max_samples = 0;
+		glGetIntegerv(GL_MAX_SAMPLES, &max_samples);
+		if (msaa > max_samples) {
+			WARN_PRINT("MSAA must be <= GL_MAX_SAMPLES, falling-back to GL_MAX_SAMPLES = " + itos(max_samples));
+			msaa = max_samples;
+		}
+
+		//regular fbo
+		glGenFramebuffers(1, &rt->multisample_fbo);
+		bind_framebuffer(rt->multisample_fbo);
+
+		glGenRenderbuffers(1, &rt->multisample_depth);
+		glBindRenderbuffer(GL_RENDERBUFFER, rt->multisample_depth);
+		glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa, config.depth_buffer_internalformat, rt->size.x, rt->size.y);
+
+		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->multisample_depth);
+
+		glGenRenderbuffers(1, &rt->multisample_color);
+		glBindRenderbuffer(GL_RENDERBUFFER, rt->multisample_color);
+		glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa, color_internal_format, rt->size.x, rt->size.y);
+
+		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rt->multisample_color);
+
+		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+
+		if (status != GL_FRAMEBUFFER_COMPLETE) {
+			// Delete allocated resources and default to no MSAA
+			WARN_PRINT_ONCE("Cannot allocate back framebuffer for MSAA");
+			printf("err status: %x\n", status);
+			rt->multisample_active = false;
+
+			glDeleteFramebuffers(1, &rt->multisample_fbo);
+			rt->multisample_fbo = 0;
+
+			glDeleteRenderbuffers(1, &rt->multisample_depth);
+			rt->multisample_depth = 0;
+
+			glDeleteRenderbuffers(1, &rt->multisample_color);
+			rt->multisample_color = 0;
+		}
+
+		glBindRenderbuffer(GL_RENDERBUFFER, 0);
+		bind_framebuffer(0);
+
+	} else
+#endif // JAVASCRIPT_ENABLED
+	{
+		rt->multisample_active = false;
+	}
+	*/
+
+// copy texscreen buffers
+//	if (!(rt->flags[RendererStorage::RENDER_TARGET_NO_SAMPLING])) {
+/*
+if (false) {
+glGenTextures(1, &rt->copy_screen_effect.color);
+glBindTexture(GL_TEXTURE_2D, rt->copy_screen_effect.color);
+
+if (rt->flags[RendererStorage::RENDER_TARGET_TRANSPARENT]) {
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, rt->size.x, rt->size.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+} else {
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, rt->size.x, rt->size.y, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
+}
+
+glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+glGenFramebuffers(1, &rt->copy_screen_effect.fbo);
+bind_framebuffer(rt->copy_screen_effect.fbo);
+glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->copy_screen_effect.color, 0);
+
+glClearColor(0, 0, 0, 0);
+glClear(GL_COLOR_BUFFER_BIT);
+
+GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+if (status != GL_FRAMEBUFFER_COMPLETE) {
+	_clear_render_target(rt);
+	ERR_FAIL_COND(status != GL_FRAMEBUFFER_COMPLETE);
+}
+}
+*/
+
 void RasterizerSceneGLES3::render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_fsr_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_debanding, uint32_t p_view_count) {
+	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
+
+	RenderBuffers *rb = render_buffers_owner.get_or_null(p_render_buffers);
+	ERR_FAIL_COND(!rb);
+
+	//rb->internal_width = p_internal_width; // ignore for now
+	//rb->internal_height = p_internal_height;
+	rb->width = p_width;
+	rb->height = p_height;
+	//rb->fsr_sharpness = p_fsr_sharpness;
+	rb->render_target = p_render_target;
+	//rb->msaa = p_msaa;
+	//rb->screen_space_aa = p_screen_space_aa;
+	//rb->use_debanding = p_use_debanding;
+	//rb->view_count = p_view_count;
+
+	_free_render_buffer_data(rb);
+
+	GLES3::RenderTarget *rt = texture_storage->get_render_target(p_render_target);
+
+	// framebuffer
+	glGenFramebuffers(1, &rb->framebuffer);
+	glBindFramebuffer(GL_FRAMEBUFFER, rb->framebuffer);
+
+	glBindTexture(GL_TEXTURE_2D, rt->color);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->color, 0);
+
+	glGenTextures(1, &rb->depth_texture);
+	glBindTexture(GL_TEXTURE_2D, rb->depth_texture);
+
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT, rt->size.x, rt->size.y, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_INT, nullptr);
+
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rb->depth_texture, 0);
+
+	GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+
+	glBindTexture(GL_TEXTURE_2D, 0);
+	glBindFramebuffer(GL_FRAMEBUFFER, texture_storage->system_fbo);
+
+	if (status != GL_FRAMEBUFFER_COMPLETE) {
+		_free_render_buffer_data(rb);
+		WARN_PRINT("Could not create 3D renderbuffer, status: " + texture_storage->get_framebuffer_error(status));
+		return;
+	}
+}
+
+void RasterizerSceneGLES3::_free_render_buffer_data(RenderBuffers *rb) {
+	if (rb->depth_texture) {
+		glDeleteTextures(1, &rb->depth_texture);
+		rb->depth_texture = 0;
+	}
+	if (rb->framebuffer) {
+		glDeleteFramebuffers(1, &rb->framebuffer);
+		rb->framebuffer = 0;
+	}
+}
+
+//clear render buffers
+/*
+
+
+		if (rt->copy_screen_effect.color) {
+		glDeleteFramebuffers(1, &rt->copy_screen_effect.fbo);
+		rt->copy_screen_effect.fbo = 0;
+
+		glDeleteTextures(1, &rt->copy_screen_effect.color);
+		rt->copy_screen_effect.color = 0;
+	}
+
+	if (rt->multisample_active) {
+		glDeleteFramebuffers(1, &rt->multisample_fbo);
+		rt->multisample_fbo = 0;
+
+		glDeleteRenderbuffers(1, &rt->multisample_depth);
+		rt->multisample_depth = 0;
+
+		glDeleteRenderbuffers(1, &rt->multisample_color);
+
+		rt->multisample_color = 0;
+	}
+*/
+
+void RasterizerSceneGLES3::_render_buffers_debug_draw(RID p_render_buffers, RID p_shadow_atlas, RID p_occlusion_buffer) {
 }
 
 void RasterizerSceneGLES3::gi_set_use_half_resolution(bool p_enable) {
@@ -454,10 +970,27 @@ TypedArray<Image> RasterizerSceneGLES3::bake_render_uv2(RID p_base, const Vector
 }
 
 bool RasterizerSceneGLES3::free(RID p_rid) {
-	return false;
+	if (environment_owner.owns(p_rid)) {
+		environment_owner.free(p_rid);
+	} else if (sky_owner.owns(p_rid)) {
+		Sky *sky = sky_owner.get_or_null(p_rid);
+		ERR_FAIL_COND_V(!sky, false);
+		sky->free();
+		sky_owner.free(p_rid);
+	} else if (render_buffers_owner.owns(p_rid)) {
+		RenderBuffers *rb = render_buffers_owner.get_or_null(p_rid);
+		ERR_FAIL_COND_V(!rb, false);
+		_free_render_buffer_data(rb);
+		render_buffers_owner.free(p_rid);
+
+	} else {
+		return false;
+	}
+	return true;
 }
 
 void RasterizerSceneGLES3::update() {
+	_update_dirty_skys();
 }
 
 void RasterizerSceneGLES3::sdfgi_set_debug_probe_select(const Vector3 &p_position, const Vector3 &p_dir) {
@@ -469,7 +1002,48 @@ void RasterizerSceneGLES3::decals_set_filter(RS::DecalFilter p_filter) {
 void RasterizerSceneGLES3::light_projectors_set_filter(RS::LightProjectorFilter p_filter) {
 }
 
-RasterizerSceneGLES3::RasterizerSceneGLES3() {
+RasterizerSceneGLES3::RasterizerSceneGLES3(RasterizerStorageGLES3 *p_storage) {
+	GLES3::MaterialStorage *material_storage = GLES3::MaterialStorage::get_singleton();
+	storage = p_storage;
+
+	{
+		// Initialize Sky stuff
+		sky_globals.roughness_layers = GLOBAL_GET("rendering/reflections/sky_reflections/roughness_layers");
+		sky_globals.ggx_samples = GLOBAL_GET("rendering/reflections/sky_reflections/ggx_samples");
+
+		String global_defines;
+		global_defines += "#define MAX_GLOBAL_VARIABLES 256\n"; // TODO: this is arbitrary for now
+		global_defines += "\n#define MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS " + itos(sky_globals.max_directional_lights) + "\n";
+		state.sky_shader.initialize(global_defines);
+		sky_globals.shader_default_version = state.sky_shader.version_create();
+		state.sky_shader.version_bind_shader(sky_globals.shader_default_version, SkyShaderGLES3::MODE_BACKGROUND);
+	}
+
+	{
+		sky_globals.default_shader = material_storage->shader_allocate();
+
+		material_storage->shader_initialize(sky_globals.default_shader);
+
+		material_storage->shader_set_code(sky_globals.default_shader, R"(
+// Default sky shader.
+
+shader_type sky;
+
+void sky() {
+	COLOR = vec3(0.0);
+}
+)");
+		sky_globals.default_material = material_storage->material_allocate();
+		material_storage->material_initialize(sky_globals.default_material);
+
+		material_storage->material_set_shader(sky_globals.default_material, sky_globals.default_shader);
+	}
+}
+
+RasterizerSceneGLES3::~RasterizerSceneGLES3() {
+	state.sky_shader.version_free(sky_globals.shader_default_version);
+	storage->free(sky_globals.default_material);
+	storage->free(sky_globals.default_shader);
 }
 
 #endif // GLES3_ENABLED

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -36,15 +36,314 @@
 #include "core/math/camera_matrix.h"
 #include "core/templates/rid_owner.h"
 #include "core/templates/self_list.h"
+#include "rasterizer_storage_gles3.h"
 #include "scene/resources/mesh.h"
 #include "servers/rendering/renderer_compositor.h"
 #include "servers/rendering/renderer_scene_render.h"
 #include "servers/rendering_server.h"
+#include "shader_gles3.h"
+#include "shaders/sky.glsl.gen.h"
+
+// Copied from renderer_scene_render_rd
+struct RenderDataGLES3 {
+	RID render_buffers = RID();
+
+	Transform3D cam_transform = Transform3D();
+	CameraMatrix cam_projection = CameraMatrix();
+	bool cam_ortogonal = false;
+
+	// For stereo rendering
+	uint32_t view_count = 1;
+	CameraMatrix view_projection[RendererSceneRender::MAX_RENDER_VIEWS];
+
+	float z_near = 0.0;
+	float z_far = 0.0;
+
+	const PagedArray<RendererSceneRender::GeometryInstance *> *instances = nullptr;
+	const PagedArray<RID> *lights = nullptr;
+	const PagedArray<RID> *reflection_probes = nullptr;
+	//const PagedArray<RID> *voxel_gi_instances = nullptr;
+	//const PagedArray<RID> *decals = nullptr;
+	//const PagedArray<RID> *lightmaps = nullptr;
+	//const PagedArray<RID> *fog_volumes = nullptr;
+	RID environment = RID();
+	RID camera_effects = RID();
+	RID shadow_atlas = RID();
+	RID reflection_atlas = RID();
+	RID reflection_probe = RID();
+	int reflection_probe_pass = 0;
+
+	float lod_distance_multiplier = 0.0;
+	Plane lod_camera_plane = Plane();
+	float screen_mesh_lod_threshold = 0.0;
+
+	uint32_t directional_light_count = 0;
+
+	RendererScene::RenderInfo *render_info = nullptr;
+};
+
+class RasterizerStorageGLES3;
+class RasterizerCanvasGLES3;
 
 class RasterizerSceneGLES3 : public RendererSceneRender {
+private:
+	static RasterizerSceneGLES3 *singleton;
+	RS::ViewportDebugDraw debug_draw = RS::VIEWPORT_DEBUG_DRAW_DISABLED;
+	uint64_t scene_pass = 0;
+
+	/* Sky */
+	struct SkyGlobals {
+		RID shader_current_version;
+		RID shader_default_version;
+		RID default_material;
+		RID default_shader;
+		uint32_t max_directional_lights = 4;
+		uint32_t roughness_layers = 8;
+		uint32_t ggx_samples = 128;
+	} sky_globals;
+
+protected:
+	double time;
+	double time_step = 0;
+
+	struct RenderBuffers {
+		int internal_width = 0;
+		int internal_height = 0;
+		int width = 0;
+		int height = 0;
+		//float fsr_sharpness = 0.2f;
+		RS::ViewportMSAA msaa = RS::VIEWPORT_MSAA_DISABLED;
+		//RS::ViewportScreenSpaceAA screen_space_aa = RS::VIEWPORT_SCREEN_SPACE_AA_DISABLED;
+		//bool use_debanding = false;
+		//uint32_t view_count = 1;
+
+		RID render_target;
+		GLuint internal_texture = 0; // Used for rendering when post effects are enabled
+		GLuint depth_texture = 0; // Main depth texture
+		GLuint framebuffer = 0; // Main framebuffer, contains internal_texture and depth_texture or render_target->color and depth_texture
+
+		//built-in textures used for ping pong image processing and blurring
+		struct Blur {
+			RID texture;
+
+			struct Mipmap {
+				RID texture;
+				int width;
+				int height;
+				GLuint fbo;
+			};
+
+			Vector<Mipmap> mipmaps;
+		};
+
+		Blur blur[2]; //the second one starts from the first mipmap
+
+		/*
+		GLuint fbo = 0;
+		GLuint color = 0;
+		GLuint depth = 0;
+
+		GLuint multisample_fbo = 0;
+		GLuint multisample_color = 0;
+		GLuint multisample_depth = 0;
+		bool multisample_active = false;
+
+		struct Effect {
+			GLuint fbo = 0;
+			int width = 0;
+			int height = 0;
+
+			GLuint color = 0;
+
+			Effect() {
+			}
+		};
+
+		Effect copy_screen_effect;
+
+		struct MipMaps {
+			struct Size {
+				GLuint fbo;
+				GLuint color;
+				int width;
+				int height;
+			};
+
+			Vector<Size> sizes;
+			GLuint color = 0;
+			int levels = 0;
+
+			MipMaps() {
+			}
+		};
+
+		MipMaps mip_maps[2];
+
+		*/
+	};
+
+	bool screen_space_roughness_limiter = false;
+	float screen_space_roughness_limiter_amount = 0.25;
+	float screen_space_roughness_limiter_limit = 0.18;
+
+	mutable RID_Owner<RenderBuffers, true> render_buffers_owner;
+
+	void _free_render_buffer_data(RenderBuffers *rb);
+	void _allocate_blur_textures(RenderBuffers *rb);
+	void _allocate_depth_backbuffer_textures(RenderBuffers *rb);
+
+	void _render_buffers_debug_draw(RID p_render_buffers, RID p_shadow_atlas, RID p_occlusion_buffer);
+
+	/* Environment */
+
+	struct Environment {
+		// BG
+		RS::EnvironmentBG background = RS::ENV_BG_CLEAR_COLOR;
+		RID sky;
+		float sky_custom_fov = 0.0;
+		Basis sky_orientation;
+		Color bg_color;
+		float bg_energy = 1.0;
+		int canvas_max_layer = 0;
+		RS::EnvironmentAmbientSource ambient_source = RS::ENV_AMBIENT_SOURCE_BG;
+		Color ambient_light;
+		float ambient_light_energy = 1.0;
+		float ambient_sky_contribution = 1.0;
+		RS::EnvironmentReflectionSource reflection_source = RS::ENV_REFLECTION_SOURCE_BG;
+		Color ao_color;
+
+		/// Tonemap
+
+		RS::EnvironmentToneMapper tone_mapper;
+		float exposure = 1.0;
+		float white = 1.0;
+		bool auto_exposure = false;
+		float min_luminance = 0.2;
+		float max_luminance = 8.0;
+		float auto_exp_speed = 0.2;
+		float auto_exp_scale = 0.5;
+		uint64_t auto_exposure_version = 0;
+
+		// Fog
+		bool fog_enabled = false;
+		Color fog_light_color = Color(0.5, 0.6, 0.7);
+		float fog_light_energy = 1.0;
+		float fog_sun_scatter = 0.0;
+		float fog_density = 0.001;
+		float fog_height = 0.0;
+		float fog_height_density = 0.0; //can be negative to invert effect
+		float fog_aerial_perspective = 0.0;
+
+		/// Glow
+		bool glow_enabled = false;
+		Vector<float> glow_levels;
+		float glow_intensity = 0.8;
+		float glow_strength = 1.0;
+		float glow_bloom = 0.0;
+		float glow_mix = 0.01;
+		RS::EnvironmentGlowBlendMode glow_blend_mode = RS::ENV_GLOW_BLEND_MODE_SOFTLIGHT;
+		float glow_hdr_bleed_threshold = 1.0;
+		float glow_hdr_luminance_cap = 12.0;
+		float glow_hdr_bleed_scale = 2.0;
+		float glow_map_strength = 1.0;
+		RID glow_map = RID();
+
+		/// SSAO
+		bool ssao_enabled = false;
+		float ssao_radius = 1.0;
+		float ssao_intensity = 2.0;
+		float ssao_power = 1.5;
+		float ssao_detail = 0.5;
+		float ssao_horizon = 0.06;
+		float ssao_sharpness = 0.98;
+		float ssao_direct_light_affect = 0.0;
+		float ssao_ao_channel_affect = 0.0;
+
+		/// SSR
+		bool ssr_enabled = false;
+		int ssr_max_steps = 64;
+		float ssr_fade_in = 0.15;
+		float ssr_fade_out = 2.0;
+		float ssr_depth_tolerance = 0.2;
+
+		/// Adjustments
+		bool adjustments_enabled = false;
+		float adjustments_brightness = 1.0f;
+		float adjustments_contrast = 1.0f;
+		float adjustments_saturation = 1.0f;
+		bool use_1d_color_correction = false;
+		RID color_correction = RID();
+	};
+
+	RS::EnvironmentSSAOQuality ssao_quality = RS::ENV_SSAO_QUALITY_MEDIUM;
+	bool ssao_half_size = false;
+	bool ssao_using_half_size = false;
+	float ssao_adaptive_target = 0.5;
+	int ssao_blur_passes = 2;
+	float ssao_fadeout_from = 50.0;
+	float ssao_fadeout_to = 300.0;
+
+	bool glow_bicubic_upscale = false;
+	bool glow_high_quality = false;
+	RS::EnvironmentSSRRoughnessQuality ssr_roughness_quality = RS::ENV_SSR_ROUGHNESS_QUALITY_LOW;
+
+	static uint64_t auto_exposure_counter;
+
+	mutable RID_Owner<Environment, true> environment_owner;
+
+	/* Sky */
+
+	struct Sky {
+		// Screen Buffers
+		GLuint half_res_pass = 0;
+		GLuint half_res_framebuffer = 0;
+		GLuint quarter_res_pass = 0;
+		GLuint quarter_res_framebuffer = 0;
+		Size2i screen_size = Size2i(0, 0);
+
+		// Radiance Cubemap
+		GLuint radiance = 0;
+		GLuint radiance_framebuffer = 0;
+
+		RID material;
+		RID uniform_buffer;
+
+		int radiance_size = 256;
+
+		RS::SkyMode mode = RS::SKY_MODE_AUTOMATIC;
+
+		//ReflectionData reflection;
+		bool reflection_dirty = false;
+		bool dirty = false;
+		int processing_layer = 0;
+		Sky *dirty_list = nullptr;
+
+		//State to track when radiance cubemap needs updating
+		//SkyMaterialData *prev_material;
+		Vector3 prev_position = Vector3(0.0, 0.0, 0.0);
+		float prev_time = 0.0f;
+
+		void free();
+		bool set_radiance_size(int p_radiance_size);
+		bool set_mode(RS::SkyMode p_mode);
+		bool set_material(RID p_material);
+		Ref<Image> bake_panorama(float p_energy, int p_roughness_layers, const Size2i &p_size);
+	};
+
+	Sky *dirty_sky_list = nullptr;
+	mutable RID_Owner<Sky, true> sky_owner;
+
+	void _invalidate_sky(Sky *p_sky);
+	void _update_dirty_skys();
+	void _draw_sky(Sky *p_sky, const CameraMatrix &p_projection, const Transform3D &p_transform, float p_custom_fov, float p_energy, const Basis &p_sky_orientation);
+
 public:
+	RasterizerStorageGLES3 *storage;
+	RasterizerCanvasGLES3 *canvas;
+
+	// References to shaders are needed in public space so they can be accessed in RasterizerStorageGLES3
 	struct State {
-		//SceneShaderGLES3 scene_shader;
+		SkyShaderGLES3 sky_shader;
 	} state;
 
 	GeometryInstance *geometry_instance_create(RID p_base) override;
@@ -88,17 +387,17 @@ public:
 
 	/* SDFGI UPDATE */
 
-	void sdfgi_update(RID p_render_buffers, RID p_environment, const Vector3 &p_world_position) override;
-	int sdfgi_get_pending_region_count(RID p_render_buffers) const override;
-	AABB sdfgi_get_pending_region_bounds(RID p_render_buffers, int p_region) const override;
-	uint32_t sdfgi_get_pending_region_cascade(RID p_render_buffers, int p_region) const override;
+	void sdfgi_update(RID p_render_buffers, RID p_environment, const Vector3 &p_world_position) override {}
+	int sdfgi_get_pending_region_count(RID p_render_buffers) const override { return 0; }
+	AABB sdfgi_get_pending_region_bounds(RID p_render_buffers, int p_region) const override { return AABB(); }
+	uint32_t sdfgi_get_pending_region_cascade(RID p_render_buffers, int p_region) const override { return 0; }
 
 	/* SKY API */
 
 	RID sky_allocate() override;
 	void sky_initialize(RID p_rid) override;
 	void sky_set_radiance_size(RID p_sky, int p_radiance_size) override;
-	void sky_set_mode(RID p_sky, RS::SkyMode p_samples) override;
+	void sky_set_mode(RID p_sky, RS::SkyMode p_mode) override;
 	void sky_set_material(RID p_sky, RID p_material) override;
 	Ref<Image> sky_bake_panorama(RID p_sky, float p_energy, bool p_bake_irradiance, const Size2i &p_size) override;
 
@@ -199,9 +498,19 @@ public:
 	void render_material(const Transform3D &p_cam_transform, const CameraMatrix &p_cam_projection, bool p_cam_ortogonal, const PagedArray<GeometryInstance *> &p_instances, RID p_framebuffer, const Rect2i &p_region) override;
 	void render_particle_collider_heightfield(RID p_collider, const Transform3D &p_transform, const PagedArray<GeometryInstance *> &p_instances) override;
 
-	void set_scene_pass(uint64_t p_pass) override;
+	void set_scene_pass(uint64_t p_pass) override {
+		scene_pass = p_pass;
+	}
+
+	_FORCE_INLINE_ uint64_t get_scene_pass() {
+		return scene_pass;
+	}
+
 	void set_time(double p_time, double p_step) override;
 	void set_debug_draw_mode(RS::ViewportDebugDraw p_debug_draw) override;
+	_FORCE_INLINE_ RS::ViewportDebugDraw get_debug_draw_mode() const {
+		return debug_draw;
+	}
 
 	RID render_buffers_create() override;
 	void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_fsr_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_debanding, uint32_t p_view_count) override;
@@ -222,7 +531,9 @@ public:
 	void decals_set_filter(RS::DecalFilter p_filter) override;
 	void light_projectors_set_filter(RS::LightProjectorFilter p_filter) override;
 
-	RasterizerSceneGLES3();
+	static RasterizerSceneGLES3 *get_singleton();
+	RasterizerSceneGLES3(RasterizerStorageGLES3 *p_storage);
+	~RasterizerSceneGLES3();
 };
 
 #endif // GLES3_ENABLED

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -38,24 +38,6 @@
 #include "rasterizer_scene_gles3.h"
 #include "servers/rendering/shader_language.h"
 
-void RasterizerStorageGLES3::bind_quad_array() const {
-	//glBindBuffer(GL_ARRAY_BUFFER, resources.quadie);
-	//glVertexAttribPointer(RS::ARRAY_VERTEX, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 4, 0);
-	//glVertexAttribPointer(RS::ARRAY_TEX_UV, 2, GL_FLOAT, GL_FALSE, sizeof(float) * 4, CAST_INT_TO_UCHAR_PTR(8));
-
-	//glEnableVertexAttribArray(RS::ARRAY_VERTEX);
-	//glEnableVertexAttribArray(RS::ARRAY_TEX_UV);
-}
-
-RID RasterizerStorageGLES3::sky_create() {
-	Sky *sky = memnew(Sky);
-	sky->radiance = 0;
-	return sky_owner.make_rid(sky);
-}
-
-void RasterizerStorageGLES3::sky_set_texture(RID p_sky, RID p_panorama, int p_radiance_size) {
-}
-
 void RasterizerStorageGLES3::base_update_dependency(RID p_base, DependencyTracker *p_instance) {
 }
 
@@ -236,13 +218,9 @@ RID RasterizerStorageGLES3::canvas_light_shadow_buffer_create(int p_width) {
 	glGenTextures(1, &cls->distance);
 	glBindTexture(GL_TEXTURE_2D, cls->distance);
 	if (config->use_rgba_2d_shadows) {
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, cls->size, cls->height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8, cls->size, cls->height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 	} else {
-#ifdef GLES_OVER_GL
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, cls->size, cls->height, 0, _RED_OES, GL_FLOAT, nullptr);
-#else
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_FLOAT, cls->size, cls->height, 0, _RED_OES, GL_FLOAT, NULL);
-#endif
+		glTexImage2D(GL_TEXTURE_2D, 0, GL_R32F, cls->size, cls->height, 0, GL_RED, GL_FLOAT, nullptr);
 	}
 
 	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
@@ -395,13 +373,6 @@ bool RasterizerStorageGLES3::free(RID p_rid) {
 	} else if (GLES3::TextureStorage::get_singleton()->owns_canvas_texture(p_rid)) {
 		GLES3::TextureStorage::get_singleton()->canvas_texture_free(p_rid);
 		return true;
-	} else if (sky_owner.owns(p_rid)) {
-		Sky *sky = sky_owner.get_or_null(p_rid);
-		sky_set_texture(p_rid, RID(), 256);
-		sky_owner.free(p_rid);
-		memdelete(sky);
-
-		return true;
 	} else if (GLES3::MaterialStorage::get_singleton()->owns_shader(p_rid)) {
 		GLES3::MaterialStorage::get_singleton()->shader_free(p_rid);
 		return true;
@@ -535,16 +506,23 @@ bool RasterizerStorageGLES3::free(RID p_rid) {
 }
 
 bool RasterizerStorageGLES3::has_os_feature(const String &p_feature) const {
+	if (p_feature == "rgtc") {
+		return config->rgtc_supported;
+	}
+
 	if (p_feature == "s3tc") {
 		return config->s3tc_supported;
 	}
 
+	if (p_feature == "bptc") {
+		return config->bptc_supported;
+	}
 	if (p_feature == "etc") {
 		return config->etc_supported;
 	}
 
-	if (p_feature == "skinning_fallback") {
-		return config->use_skeleton_software;
+	if (p_feature == "etc2") {
+		return config->etc2_supported;
 	}
 
 	return false;
@@ -652,100 +630,6 @@ RenderingDevice::DeviceType RasterizerStorageGLES3::get_video_adapter_type() con
 void RasterizerStorageGLES3::initialize() {
 	config = GLES3::Config::get_singleton();
 
-	//picky requirements for these
-	config->support_shadow_cubemaps = config->support_depth_texture && config->support_write_depth && config->support_depth_cubemaps;
-
-	// the use skeleton software path should be used if either float texture is not supported,
-	// OR max_vertex_texture_image_units is zero
-	config->use_skeleton_software = (config->float_texture_supported == false) || (config->max_vertex_texture_image_units == 0);
-
-	{
-		// quad for copying stuff
-
-		glGenBuffers(1, &resources.quadie);
-		glBindBuffer(GL_ARRAY_BUFFER, resources.quadie);
-		{
-			const float qv[16] = {
-				-1,
-				-1,
-				0,
-				0,
-				-1,
-				1,
-				0,
-				1,
-				1,
-				1,
-				1,
-				1,
-				1,
-				-1,
-				1,
-				0,
-			};
-
-			glBufferData(GL_ARRAY_BUFFER, sizeof(float) * 16, qv, GL_STATIC_DRAW);
-		}
-
-		glBindBuffer(GL_ARRAY_BUFFER, 0);
-	}
-
-	{
-		//default textures
-
-		glGenTextures(1, &resources.white_tex);
-		unsigned char whitetexdata[8 * 8 * 3];
-		for (int i = 0; i < 8 * 8 * 3; i++) {
-			whitetexdata[i] = 255;
-		}
-
-		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, resources.white_tex);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 8, 8, 0, GL_RGB, GL_UNSIGNED_BYTE, whitetexdata);
-		glGenerateMipmap(GL_TEXTURE_2D);
-		glBindTexture(GL_TEXTURE_2D, 0);
-
-		glGenTextures(1, &resources.black_tex);
-		unsigned char blacktexdata[8 * 8 * 3];
-		for (int i = 0; i < 8 * 8 * 3; i++) {
-			blacktexdata[i] = 0;
-		}
-
-		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, resources.black_tex);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 8, 8, 0, GL_RGB, GL_UNSIGNED_BYTE, blacktexdata);
-		glGenerateMipmap(GL_TEXTURE_2D);
-		glBindTexture(GL_TEXTURE_2D, 0);
-
-		glGenTextures(1, &resources.normal_tex);
-		unsigned char normaltexdata[8 * 8 * 3];
-		for (int i = 0; i < 8 * 8 * 3; i += 3) {
-			normaltexdata[i + 0] = 128;
-			normaltexdata[i + 1] = 128;
-			normaltexdata[i + 2] = 255;
-		}
-
-		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, resources.normal_tex);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 8, 8, 0, GL_RGB, GL_UNSIGNED_BYTE, normaltexdata);
-		glGenerateMipmap(GL_TEXTURE_2D);
-		glBindTexture(GL_TEXTURE_2D, 0);
-
-		glGenTextures(1, &resources.aniso_tex);
-		unsigned char anisotexdata[8 * 8 * 3];
-		for (int i = 0; i < 8 * 8 * 3; i += 3) {
-			anisotexdata[i + 0] = 255;
-			anisotexdata[i + 1] = 128;
-			anisotexdata[i + 2] = 0;
-		}
-
-		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, resources.aniso_tex);
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, 8, 8, 0, GL_RGB, GL_UNSIGNED_BYTE, anisotexdata);
-		glGenerateMipmap(GL_TEXTURE_2D);
-		glBindTexture(GL_TEXTURE_2D, 0);
-	}
-
 	// skeleton buffer
 	{
 		resources.skeleton_transform_buffer_size = 0;
@@ -754,35 +638,33 @@ void RasterizerStorageGLES3::initialize() {
 
 	// radical inverse vdc cache texture
 	// used for cubemap filtering
-	if (true /*||config->float_texture_supported*/) { //uint8 is similar and works everywhere
-		glGenTextures(1, &resources.radical_inverse_vdc_cache_tex);
+	glGenTextures(1, &resources.radical_inverse_vdc_cache_tex);
 
-		glActiveTexture(GL_TEXTURE0);
-		glBindTexture(GL_TEXTURE_2D, resources.radical_inverse_vdc_cache_tex);
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, resources.radical_inverse_vdc_cache_tex);
+	/*
+	uint8_t radical_inverse[512];
 
-		uint8_t radical_inverse[512];
+	for (uint32_t i = 0; i < 512; i++) {
+		uint32_t bits = i;
 
-		for (uint32_t i = 0; i < 512; i++) {
-			uint32_t bits = i;
+		bits = (bits << 16) | (bits >> 16);
+		bits = ((bits & 0x55555555) << 1) | ((bits & 0xAAAAAAAA) >> 1);
+		bits = ((bits & 0x33333333) << 2) | ((bits & 0xCCCCCCCC) >> 2);
+		bits = ((bits & 0x0F0F0F0F) << 4) | ((bits & 0xF0F0F0F0) >> 4);
+		bits = ((bits & 0x00FF00FF) << 8) | ((bits & 0xFF00FF00) >> 8);
 
-			bits = (bits << 16) | (bits >> 16);
-			bits = ((bits & 0x55555555) << 1) | ((bits & 0xAAAAAAAA) >> 1);
-			bits = ((bits & 0x33333333) << 2) | ((bits & 0xCCCCCCCC) >> 2);
-			bits = ((bits & 0x0F0F0F0F) << 4) | ((bits & 0xF0F0F0F0) >> 4);
-			bits = ((bits & 0x00FF00FF) << 8) | ((bits & 0xFF00FF00) >> 8);
-
-			float value = float(bits) * 2.3283064365386963e-10;
-			radical_inverse[i] = uint8_t(CLAMP(value * 255.0, 0, 255));
-		}
-
-		glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, 512, 1, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, radical_inverse);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST); //need this for proper sampling
-
-		glBindTexture(GL_TEXTURE_2D, 0);
+		float value = float(bits) * 2.3283064365386963e-10;
+		radical_inverse[i] = uint8_t(CLAMP(value * 255.0, 0, 255));
 	}
+
+	//glTexImage2D(GL_TEXTURE_2D, 0, GL_LUMINANCE, 512, 1, 0, GL_LUMINANCE, GL_UNSIGNED_BYTE, radical_inverse);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST); //need this for proper sampling
+	*/
+	glBindTexture(GL_TEXTURE_2D, 0);
 
 	{
 		glGenFramebuffers(1, &resources.mipmap_blur_fbo);
@@ -790,13 +672,7 @@ void RasterizerStorageGLES3::initialize() {
 	}
 
 #ifdef GLES_OVER_GL
-	//this needs to be enabled manually in OpenGL 2.1
-
-	if (config->extensions.has("GL_ARB_seamless_cube_map")) {
-		glEnable(_EXT_TEXTURE_CUBE_MAP_SEAMLESS);
-	}
-	glEnable(GL_POINT_SPRITE);
-	glEnable(GL_VERTEX_PROGRAM_POINT_SIZE);
+	glEnable(GL_PROGRAM_POINT_SIZE);
 #endif
 }
 
@@ -804,10 +680,8 @@ void RasterizerStorageGLES3::finalize() {
 }
 
 void RasterizerStorageGLES3::_copy_screen() {
-	bind_quad_array();
 	glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
 }
-
 void RasterizerStorageGLES3::update_memory_info() {
 }
 
@@ -816,10 +690,8 @@ uint64_t RasterizerStorageGLES3::get_rendering_info(RS::RenderingInfo p_info) {
 }
 
 void RasterizerStorageGLES3::update_dirty_resources() {
-	GLES3::MaterialStorage::get_singleton()->update_dirty_shaders();
-	GLES3::MaterialStorage::get_singleton()->update_dirty_materials();
-	//	update_dirty_skeletons();
-	//	update_dirty_multimeshes();
+	GLES3::MaterialStorage::get_singleton()->_update_global_variables();
+	GLES3::MaterialStorage::get_singleton()->_update_queued_materials();
 }
 
 RasterizerStorageGLES3::RasterizerStorageGLES3() {

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -55,18 +55,11 @@ public:
 	GLES3::Config *config;
 
 	struct Resources {
-		GLuint white_tex;
-		GLuint black_tex;
-		GLuint normal_tex;
-		GLuint aniso_tex;
-
 		GLuint mipmap_blur_fbo;
 		GLuint mipmap_blur_color;
 
 		GLuint radical_inverse_vdc_cache_tex;
 		bool use_rgba_2d_shadows;
-
-		GLuint quadie;
 
 		size_t skeleton_transform_buffer_size;
 		GLuint skeleton_transform_buffer;
@@ -107,28 +100,12 @@ public:
 
 	} info;
 
-	void bind_quad_array() const;
-
 	/////////////////////////////////////////////////////////////////////////////////////////
 	//////////////////////////////////API////////////////////////////////////////////////////
 	/////////////////////////////////////////////////////////////////////////////////////////
 
 public:
 	virtual void base_update_dependency(RID p_base, DependencyTracker *p_instance) override;
-
-	/* SKY API */
-	// not sure if used in godot 4?
-	struct Sky {
-		RID self;
-		RID panorama;
-		GLuint radiance;
-		int radiance_size;
-	};
-
-	mutable RID_PtrOwner<Sky> sky_owner;
-
-	RID sky_create();
-	void sky_set_texture(RID p_sky, RID p_panorama, int p_radiance_size);
 
 	/* VOXEL GI API */
 
@@ -278,6 +255,9 @@ public:
 	void buffer_orphan_and_upload(unsigned int p_buffer_size, unsigned int p_offset, unsigned int p_data_size, const void *p_data, GLenum p_target = GL_ARRAY_BUFFER, GLenum p_usage = GL_DYNAMIC_DRAW, bool p_optional_orphan = false) const;
 	bool safe_buffer_sub_data(unsigned int p_total_buffer_size, GLenum p_target, unsigned int p_offset, unsigned int p_data_size, const void *p_data, unsigned int &r_offset_after) const;
 
+	//bool validate_framebuffer(); // Validate currently bound framebuffer, does not touch global state
+	String get_framebuffer_error(GLenum p_status);
+
 	RasterizerStorageGLES3();
 	~RasterizerStorageGLES3();
 };
@@ -317,6 +297,21 @@ inline void RasterizerStorageGLES3::buffer_orphan_and_upload(unsigned int p_buff
 #endif
 	}
 	glBufferSubData(p_target, p_offset, p_data_size, p_data);
+}
+
+inline String RasterizerStorageGLES3::get_framebuffer_error(GLenum p_status) {
+#ifdef DEBUG_ENABLED
+	if (p_status == GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT) {
+		return "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT";
+	} else if (p_status == GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT) {
+		return "GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT";
+	} else if (p_status == GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER) {
+		return "GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER";
+	} else if (p_status == GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER) {
+		return "GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER";
+	}
+#endif
+	return itos(p_status);
 }
 
 #endif // GLES3_ENABLED

--- a/drivers/gles3/shader_gles3.cpp
+++ b/drivers/gles3/shader_gles3.cpp
@@ -165,6 +165,7 @@ void ShaderGLES3::_build_variant_code(StringBuilder &builder, uint32_t p_variant
 	builder.append("\n"); //make sure defines begin at newline
 	builder.append(general_defines.get_data());
 	builder.append(variant_defines[p_variant]);
+	builder.append("\n");
 	for (int j = 0; j < p_version->custom_defines.size(); j++) {
 		builder.append(p_version->custom_defines[j].get_data());
 	}
@@ -327,7 +328,7 @@ void ShaderGLES3::_compile_specialization(Version::Specialization &spec, uint32_
 			glDeleteProgram(spec.id);
 			spec.id = 0;
 
-			ERR_PRINT("No OpenGL program link log. What the frick?");
+			ERR_PRINT("No OpenGL program link log. Something is wrong.");
 			ERR_FAIL();
 		}
 
@@ -552,9 +553,11 @@ void ShaderGLES3::_clear_version(Version *p_version) {
 
 	for (int i = 0; i < variant_count; i++) {
 		for (OAHashMap<uint64_t, Version::Specialization>::Iterator it = p_version->variants[i].iter(); it.valid; it = p_version->variants[i].next_iter(it)) {
-			glDeleteShader(it.value->vert_id);
-			glDeleteShader(it.value->frag_id);
-			glDeleteProgram(it.value->id);
+			if (it.value->id != 0) {
+				glDeleteShader(it.value->vert_id);
+				glDeleteShader(it.value->frag_id);
+				glDeleteProgram(it.value->id);
+			}
 		}
 	}
 

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -111,7 +111,7 @@ private:
 	void _clear_version(Version *p_version);
 	void _initialize_version(Version *p_version);
 
-	RID_Owner<Version> version_owner;
+	RID_Owner<Version, true> version_owner;
 
 	struct StageTemplate {
 		struct Chunk {

--- a/drivers/gles3/shaders/SCsub
+++ b/drivers/gles3/shaders/SCsub
@@ -5,3 +5,4 @@ Import("env")
 if "GLES3_GLSL" in env["BUILDERS"]:
     env.GLES3_GLSL("canvas.glsl")
     env.GLES3_GLSL("copy.glsl")
+    env.GLES3_GLSL("sky.glsl")

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -286,7 +286,7 @@ in vec2 pixel_size_interp;
 layout(location = 0) out vec4 frag_color;
 
 #ifdef MATERIAL_UNIFORMS_USED
-uniform MaterialUniforms{
+layout(std140) uniform MaterialUniforms{
 //ubo:4
 
 #MATERIAL_UNIFORMS

--- a/drivers/gles3/shaders/sky.glsl
+++ b/drivers/gles3/shaders/sky.glsl
@@ -1,0 +1,179 @@
+/* clang-format off */
+#[modes]
+
+mode_background =
+mode_half_res = #define USE_HALF_RES_PASS
+mode_quarter_res = #define USE_QUARTER_RES_PASS
+mode_cubemap = #define USE_CUBEMAP_PASS
+mode_cubemap_half_res = #define USE_CUBEMAP_PASS \n#define USE_HALF_RES_PASS
+mode_cubemap_quarter_res = #define USE_CUBEMAP_PASS \n#define USE_QUARTER_RES_PASS
+
+#[specializations]
+
+#[vertex]
+
+#ifdef USE_GLES_OVER_GL
+#define lowp
+#define mediump
+#define highp
+#else
+precision highp float;
+precision highp int;
+#endif
+
+out vec2 uv_interp;
+/* clang-format on */
+
+void main() {
+	// One big triangle to cover the whole screen
+	vec2 base_arr[3] = vec2[](vec2(-1.0, -2.0), vec2(-1.0, 2.0), vec2(2.0, 2.0));
+	uv_interp = base_arr[gl_VertexID];
+	gl_Position = vec4(uv_interp, 1.0, 1.0);
+}
+
+/* clang-format off */
+#[fragment]
+
+#define M_PI 3.14159265359
+
+#ifdef USE_GLES_OVER_GL
+#define lowp
+#define mediump
+#define highp
+#else
+#if defined(USE_HIGHP_PRECISION)
+precision highp float;
+precision highp int;
+#else
+precision mediump float;
+precision mediump int;
+#endif
+#endif
+
+in vec2 uv_interp;
+
+/* clang-format on */
+
+uniform samplerCube radiance; //texunit:-1
+#ifdef USE_CUBEMAP_PASS
+uniform samplerCube half_res; //texunit:-2
+uniform samplerCube quarter_res; //texunit:-3
+#else
+uniform sampler2D half_res; //texunit:-2
+uniform sampler2D quarter_res; //texunit:-3
+#endif
+
+layout(std140) uniform CanvasData { //ubo:0
+	mat3 orientation;
+	vec4 projection;
+	vec4 position_multiplier;
+	float time;
+	float luminance_multiplier;
+	float pad1;
+	float pad2;
+};
+
+layout(std140) uniform GlobalVariableData { //ubo:1
+	vec4 global_variables[MAX_GLOBAL_VARIABLES];
+};
+
+struct DirectionalLightData {
+	vec4 direction_energy;
+	vec4 color_size;
+	bool enabled;
+};
+
+layout(std140) uniform DirectionalLights { //ubo:2
+	DirectionalLightData data[MAX_DIRECTIONAL_LIGHT_DATA_STRUCTS];
+}
+directional_lights;
+
+#ifdef MATERIAL_UNIFORMS_USED
+layout(std140) uniform MaterialUniforms{
+//ubo:3
+
+#MATERIAL_UNIFORMS
+
+} material;
+#endif
+
+#GLOBALS
+
+#ifdef USE_CUBEMAP_PASS
+#define AT_CUBEMAP_PASS true
+#else
+#define AT_CUBEMAP_PASS false
+#endif
+
+#ifdef USE_HALF_RES_PASS
+#define AT_HALF_RES_PASS true
+#else
+#define AT_HALF_RES_PASS false
+#endif
+
+#ifdef USE_QUARTER_RES_PASS
+#define AT_QUARTER_RES_PASS true
+#else
+#define AT_QUARTER_RES_PASS false
+#endif
+
+layout(location = 0) out vec4 frag_color;
+
+void main() {
+	vec3 cube_normal;
+	cube_normal.z = -1.0;
+	cube_normal.x = (uv_interp.x + projection.x) / projection.y;
+	cube_normal.y = (-uv_interp.y - projection.z) / projection.w;
+	cube_normal = mat3(orientation) * cube_normal;
+	cube_normal.z = -cube_normal.z;
+	cube_normal = normalize(cube_normal);
+
+	vec2 uv = uv_interp * 0.5 + 0.5;
+
+	vec2 panorama_coords = vec2(atan(cube_normal.x, cube_normal.z), acos(cube_normal.y));
+
+	if (panorama_coords.x < 0.0) {
+		panorama_coords.x += M_PI * 2.0;
+	}
+
+	panorama_coords /= vec2(M_PI * 2.0, M_PI);
+
+	vec3 color = vec3(0.0, 0.0, 0.0);
+	float alpha = 1.0; // Only available to subpasses
+	vec4 half_res_color = vec4(1.0);
+	vec4 quarter_res_color = vec4(1.0);
+	vec4 custom_fog = vec4(0.0);
+
+#ifdef USE_CUBEMAP_PASS
+	vec3 inverted_cube_normal = cube_normal;
+	inverted_cube_normal.z *= -1.0;
+#ifdef USES_HALF_RES_COLOR
+	half_res_color = texture(samplerCube(half_res, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), inverted_cube_normal) * luminance_multiplier;
+#endif
+#ifdef USES_QUARTER_RES_COLOR
+	quarter_res_color = texture(samplerCube(quarter_res, material_samplers[SAMPLER_LINEAR_WITH_MIPMAPS_CLAMP]), inverted_cube_normal) * luminance_multiplier;
+#endif
+#else
+#ifdef USES_HALF_RES_COLOR
+	half_res_color = textureLod(sampler2D(half_res, material_samplers[SAMPLER_LINEAR_CLAMP]), uv, 0.0) * luminance_multiplier;
+#endif
+#ifdef USES_QUARTER_RES_COLOR
+	quarter_res_color = textureLod(sampler2D(quarter_res, material_samplers[SAMPLER_LINEAR_CLAMP]), uv, 0.0) * luminance_multiplier;
+#endif
+#endif
+
+	{
+
+#CODE : SKY
+
+	}
+
+	frag_color.rgb = color * position_multiplier.w / luminance_multiplier;
+	frag_color.a = alpha;
+
+	// Blending is disabled for Sky, so alpha doesn't blend
+	// alpha is used for subsurface scattering so make sure it doesn't get applied to Sky
+	if (!AT_CUBEMAP_PASS && !AT_HALF_RES_PASS && !AT_QUARTER_RES_PASS) {
+		frag_color.a = 0.0;
+	}
+}

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -51,13 +51,13 @@ private:
 	static Config *singleton;
 
 public:
-	bool shrink_textures_x2;
-	bool use_fast_texture_filter;
+	bool use_nearest_mip_filter;
 	bool use_skeleton_software;
 
 	int max_vertex_texture_image_units;
 	int max_texture_image_units;
 	int max_texture_size;
+	int max_uniform_buffer_size;
 
 	// TODO implement wireframe in OpenGL
 	// bool generate_wireframes;
@@ -84,12 +84,10 @@ public:
 	bool support_write_depth;
 	bool support_half_float_vertices;
 	bool support_npot_repeat_mipmap;
-	bool support_depth_texture;
 	bool support_depth_cubemaps;
-
 	bool support_shadow_cubemaps;
-
-	bool render_to_mipmap_supported;
+	bool support_anisotropic_filter;
+	float anisotropic_level;
 
 	GLuint depth_internalformat;
 	GLuint depth_type;

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -30,13 +30,1207 @@
 
 #ifdef GLES3_ENABLED
 
-#include "material_storage.h"
+#include "core/config/project_settings.h"
+
 #include "config.h"
+#include "material_storage.h"
 #include "texture_storage.h"
 
 #include "drivers/gles3/rasterizer_canvas_gles3.h"
 
 using namespace GLES3;
+
+///////////////////////////////////////////////////////////////////////////
+// UBI helper functions
+
+_FORCE_INLINE_ static void _fill_std140_variant_ubo_value(ShaderLanguage::DataType type, int p_array_size, const Variant &value, uint8_t *data, bool p_linear_color) {
+	switch (type) {
+		case ShaderLanguage::TYPE_BOOL: {
+			uint32_t *gui = (uint32_t *)data;
+
+			if (p_array_size > 0) {
+				const PackedInt32Array &ba = value;
+				int s = ba.size();
+				const int *r = ba.ptr();
+
+				for (int i = 0, j = 0; i < p_array_size; i++, j += 4) {
+					if (i < s) {
+						gui[j] = (r[i] != 0) ? 1 : 0;
+					} else {
+						gui[j] = 0;
+					}
+					gui[j + 1] = 0; // ignored
+					gui[j + 2] = 0; // ignored
+					gui[j + 3] = 0; // ignored
+				}
+			} else {
+				bool v = value;
+				gui[0] = v ? 1 : 0;
+			}
+		} break;
+		case ShaderLanguage::TYPE_BVEC2: {
+			uint32_t *gui = (uint32_t *)data;
+
+			if (p_array_size > 0) {
+				const PackedInt32Array &ba = value;
+				int s = ba.size();
+				const int *r = ba.ptr();
+				int count = 2 * p_array_size;
+
+				for (int i = 0, j = 0; i < count; i += 2, j += 4) {
+					if (i < s) {
+						gui[j] = r[i] ? 1 : 0;
+						gui[j + 1] = r[i + 1] ? 1 : 0;
+					} else {
+						gui[j] = 0;
+						gui[j + 1] = 0;
+					}
+					gui[j + 2] = 0; // ignored
+					gui[j + 3] = 0; // ignored
+				}
+			} else {
+				int v = value;
+				gui[0] = v & 1 ? 1 : 0;
+				gui[1] = v & 2 ? 1 : 0;
+			}
+		} break;
+		case ShaderLanguage::TYPE_BVEC3: {
+			uint32_t *gui = (uint32_t *)data;
+
+			if (p_array_size > 0) {
+				const PackedInt32Array &ba = value;
+				int s = ba.size();
+				const int *r = ba.ptr();
+				int count = 3 * p_array_size;
+
+				for (int i = 0, j = 0; i < count; i += 3, j += 4) {
+					if (i < s) {
+						gui[j] = r[i] ? 1 : 0;
+						gui[j + 1] = r[i + 1] ? 1 : 0;
+						gui[j + 2] = r[i + 2] ? 1 : 0;
+					} else {
+						gui[j] = 0;
+						gui[j + 1] = 0;
+						gui[j + 2] = 0;
+					}
+					gui[j + 3] = 0; // ignored
+				}
+			} else {
+				int v = value;
+				gui[0] = (v & 1) ? 1 : 0;
+				gui[1] = (v & 2) ? 1 : 0;
+				gui[2] = (v & 4) ? 1 : 0;
+			}
+		} break;
+		case ShaderLanguage::TYPE_BVEC4: {
+			uint32_t *gui = (uint32_t *)data;
+
+			if (p_array_size > 0) {
+				const PackedInt32Array &ba = value;
+				int s = ba.size();
+				const int *r = ba.ptr();
+				int count = 4 * p_array_size;
+
+				for (int i = 0; i < count; i += 4) {
+					if (i < s) {
+						gui[i] = r[i] ? 1 : 0;
+						gui[i + 1] = r[i + 1] ? 1 : 0;
+						gui[i + 2] = r[i + 2] ? 1 : 0;
+						gui[i + 3] = r[i + 3] ? 1 : 0;
+					} else {
+						gui[i] = 0;
+						gui[i + 1] = 0;
+						gui[i + 2] = 0;
+						gui[i + 3] = 0;
+					}
+				}
+			} else {
+				int v = value;
+				gui[0] = (v & 1) ? 1 : 0;
+				gui[1] = (v & 2) ? 1 : 0;
+				gui[2] = (v & 4) ? 1 : 0;
+				gui[3] = (v & 8) ? 1 : 0;
+			}
+		} break;
+		case ShaderLanguage::TYPE_INT: {
+			int32_t *gui = (int32_t *)data;
+
+			if (p_array_size > 0) {
+				Vector<int> iv = value;
+				int s = iv.size();
+				const int *r = iv.ptr();
+
+				for (int i = 0, j = 0; i < p_array_size; i++, j += 4) {
+					if (i < s) {
+						gui[j] = r[i];
+					} else {
+						gui[j] = 0;
+					}
+					gui[j + 1] = 0; // ignored
+					gui[j + 2] = 0; // ignored
+					gui[j + 3] = 0; // ignored
+				}
+			} else {
+				int v = value;
+				gui[0] = v;
+			}
+		} break;
+		case ShaderLanguage::TYPE_IVEC2: {
+			Vector<int> iv = value;
+			int s = iv.size();
+			int32_t *gui = (int32_t *)data;
+
+			if (p_array_size <= 0) {
+				p_array_size = 1;
+			}
+			int count = 2 * p_array_size;
+
+			const int *r = iv.ptr();
+			for (int i = 0, j = 0; i < count; i += 2, j += 4) {
+				if (i < s) {
+					gui[j] = r[i];
+					gui[j + 1] = r[i + 1];
+				} else {
+					gui[j] = 0;
+					gui[j + 1] = 0;
+				}
+				gui[j + 2] = 0; // ignored
+				gui[j + 3] = 0; // ignored
+			}
+		} break;
+		case ShaderLanguage::TYPE_IVEC3: {
+			Vector<int> iv = value;
+			int s = iv.size();
+			int32_t *gui = (int32_t *)data;
+
+			if (p_array_size <= 0) {
+				p_array_size = 1;
+			}
+			int count = 3 * p_array_size;
+
+			const int *r = iv.ptr();
+			for (int i = 0, j = 0; i < count; i += 3, j += 4) {
+				if (i < s) {
+					gui[j] = r[i];
+					gui[j + 1] = r[i + 1];
+					gui[j + 2] = r[i + 2];
+				} else {
+					gui[j] = 0;
+					gui[j + 1] = 0;
+					gui[j + 2] = 0;
+				}
+				gui[j + 3] = 0; // ignored
+			}
+		} break;
+		case ShaderLanguage::TYPE_IVEC4: {
+			Vector<int> iv = value;
+			int s = iv.size();
+			int32_t *gui = (int32_t *)data;
+
+			if (p_array_size <= 0) {
+				p_array_size = 1;
+			}
+			int count = 4 * p_array_size;
+
+			const int *r = iv.ptr();
+			for (int i = 0; i < count; i += 4) {
+				if (i < s) {
+					gui[i] = r[i];
+					gui[i + 1] = r[i + 1];
+					gui[i + 2] = r[i + 2];
+					gui[i + 3] = r[i + 3];
+				} else {
+					gui[i] = 0;
+					gui[i + 1] = 0;
+					gui[i + 2] = 0;
+					gui[i + 3] = 0;
+				}
+			}
+		} break;
+		case ShaderLanguage::TYPE_UINT: {
+			uint32_t *gui = (uint32_t *)data;
+
+			if (p_array_size > 0) {
+				Vector<int> iv = value;
+				int s = iv.size();
+				const int *r = iv.ptr();
+
+				for (int i = 0, j = 0; i < p_array_size; i++, j += 4) {
+					if (i < s) {
+						gui[j] = r[i];
+					} else {
+						gui[j] = 0;
+					}
+					gui[j + 1] = 0; // ignored
+					gui[j + 2] = 0; // ignored
+					gui[j + 3] = 0; // ignored
+				}
+			} else {
+				int v = value;
+				gui[0] = v;
+			}
+		} break;
+		case ShaderLanguage::TYPE_UVEC2: {
+			Vector<int> iv = value;
+			int s = iv.size();
+			uint32_t *gui = (uint32_t *)data;
+
+			if (p_array_size <= 0) {
+				p_array_size = 1;
+			}
+			int count = 2 * p_array_size;
+
+			const int *r = iv.ptr();
+			for (int i = 0, j = 0; i < count; i += 2, j += 4) {
+				if (i < s) {
+					gui[j] = r[i];
+					gui[j + 1] = r[i + 1];
+				} else {
+					gui[j] = 0;
+					gui[j + 1] = 0;
+				}
+				gui[j + 2] = 0; // ignored
+				gui[j + 3] = 0; // ignored
+			}
+		} break;
+		case ShaderLanguage::TYPE_UVEC3: {
+			Vector<int> iv = value;
+			int s = iv.size();
+			uint32_t *gui = (uint32_t *)data;
+
+			if (p_array_size <= 0) {
+				p_array_size = 1;
+			}
+			int count = 3 * p_array_size;
+
+			const int *r = iv.ptr();
+			for (int i = 0, j = 0; i < count; i += 3, j += 4) {
+				if (i < s) {
+					gui[j] = r[i];
+					gui[j + 1] = r[i + 1];
+					gui[j + 2] = r[i + 2];
+				} else {
+					gui[j] = 0;
+					gui[j + 1] = 0;
+					gui[j + 2] = 0;
+				}
+				gui[j + 3] = 0; // ignored
+			}
+		} break;
+		case ShaderLanguage::TYPE_UVEC4: {
+			Vector<int> iv = value;
+			int s = iv.size();
+			uint32_t *gui = (uint32_t *)data;
+
+			if (p_array_size <= 0) {
+				p_array_size = 1;
+			}
+			int count = 4 * p_array_size;
+
+			const int *r = iv.ptr();
+			for (int i = 0; i < count; i++) {
+				if (i < s) {
+					gui[i] = r[i];
+					gui[i + 1] = r[i + 1];
+					gui[i + 2] = r[i + 2];
+					gui[i + 3] = r[i + 3];
+				} else {
+					gui[i] = 0;
+					gui[i + 1] = 0;
+					gui[i + 2] = 0;
+					gui[i + 3] = 0;
+				}
+			}
+		} break;
+		case ShaderLanguage::TYPE_FLOAT: {
+			float *gui = (float *)data;
+
+			if (p_array_size > 0) {
+				const PackedFloat32Array &a = value;
+				int s = a.size();
+
+				for (int i = 0, j = 0; i < p_array_size; i++, j += 4) {
+					if (i < s) {
+						gui[j] = a[i];
+					} else {
+						gui[j] = 0;
+					}
+					gui[j + 1] = 0; // ignored
+					gui[j + 2] = 0; // ignored
+					gui[j + 3] = 0; // ignored
+				}
+			} else {
+				float v = value;
+				gui[0] = v;
+			}
+		} break;
+		case ShaderLanguage::TYPE_VEC2: {
+			float *gui = (float *)data;
+
+			if (p_array_size > 0) {
+				const PackedVector2Array &a = value;
+				int s = a.size();
+
+				for (int i = 0, j = 0; i < p_array_size; i++, j += 4) {
+					if (i < s) {
+						gui[j] = a[i].x;
+						gui[j + 1] = a[i].y;
+					} else {
+						gui[j] = 0;
+						gui[j + 1] = 0;
+					}
+					gui[j + 2] = 0; // ignored
+					gui[j + 3] = 0; // ignored
+				}
+			} else {
+				Vector2 v = value;
+				gui[0] = v.x;
+				gui[1] = v.y;
+			}
+		} break;
+		case ShaderLanguage::TYPE_VEC3: {
+			float *gui = (float *)data;
+
+			if (p_array_size > 0) {
+				const PackedVector3Array &a = value;
+				int s = a.size();
+
+				for (int i = 0, j = 0; i < p_array_size; i++, j += 4) {
+					if (i < s) {
+						gui[j] = a[i].x;
+						gui[j + 1] = a[i].y;
+						gui[j + 2] = a[i].z;
+					} else {
+						gui[j] = 0;
+						gui[j + 1] = 0;
+						gui[j + 2] = 0;
+					}
+					gui[j + 3] = 0; // ignored
+				}
+			} else {
+				Vector3 v = value;
+				gui[0] = v.x;
+				gui[1] = v.y;
+				gui[2] = v.z;
+			}
+		} break;
+		case ShaderLanguage::TYPE_VEC4: {
+			float *gui = (float *)data;
+
+			if (p_array_size > 0) {
+				if (value.get_type() == Variant::PACKED_COLOR_ARRAY) {
+					const PackedColorArray &a = value;
+					int s = a.size();
+
+					for (int i = 0, j = 0; i < p_array_size; i++, j += 4) {
+						if (i < s) {
+							Color color = a[i];
+							if (p_linear_color) {
+								color = color.srgb_to_linear();
+							}
+							gui[j] = color.r;
+							gui[j + 1] = color.g;
+							gui[j + 2] = color.b;
+							gui[j + 3] = color.a;
+						} else {
+							gui[j] = 0;
+							gui[j + 1] = 0;
+							gui[j + 2] = 0;
+							gui[j + 3] = 0;
+						}
+					}
+				} else {
+					const PackedFloat32Array &a = value;
+					int s = a.size();
+					int count = 4 * p_array_size;
+
+					for (int i = 0; i < count; i += 4) {
+						if (i + 3 < s) {
+							gui[i] = a[i];
+							gui[i + 1] = a[i + 1];
+							gui[i + 2] = a[i + 2];
+							gui[i + 3] = a[i + 3];
+						} else {
+							gui[i] = 0;
+							gui[i + 1] = 0;
+							gui[i + 2] = 0;
+							gui[i + 3] = 0;
+						}
+					}
+				}
+			} else {
+				if (value.get_type() == Variant::COLOR) {
+					Color v = value;
+
+					if (p_linear_color) {
+						v = v.srgb_to_linear();
+					}
+
+					gui[0] = v.r;
+					gui[1] = v.g;
+					gui[2] = v.b;
+					gui[3] = v.a;
+				} else if (value.get_type() == Variant::RECT2) {
+					Rect2 v = value;
+
+					gui[0] = v.position.x;
+					gui[1] = v.position.y;
+					gui[2] = v.size.x;
+					gui[3] = v.size.y;
+				} else if (value.get_type() == Variant::QUATERNION) {
+					Quaternion v = value;
+
+					gui[0] = v.x;
+					gui[1] = v.y;
+					gui[2] = v.z;
+					gui[3] = v.w;
+				} else {
+					Plane v = value;
+
+					gui[0] = v.normal.x;
+					gui[1] = v.normal.y;
+					gui[2] = v.normal.z;
+					gui[3] = v.d;
+				}
+			}
+		} break;
+		case ShaderLanguage::TYPE_MAT2: {
+			float *gui = (float *)data;
+
+			if (p_array_size > 0) {
+				const PackedFloat32Array &a = value;
+				int s = a.size();
+
+				for (int i = 0, j = 0; i < p_array_size * 4; i += 4, j += 8) {
+					if (i + 3 < s) {
+						gui[j] = a[i];
+						gui[j + 1] = a[i + 1];
+
+						gui[j + 4] = a[i + 2];
+						gui[j + 5] = a[i + 3];
+					} else {
+						gui[j] = 1;
+						gui[j + 1] = 0;
+
+						gui[j + 4] = 0;
+						gui[j + 5] = 1;
+					}
+					gui[j + 2] = 0; // ignored
+					gui[j + 3] = 0; // ignored
+					gui[j + 6] = 0; // ignored
+					gui[j + 7] = 0; // ignored
+				}
+			} else {
+				Transform2D v = value;
+
+				//in std140 members of mat2 are treated as vec4s
+				gui[0] = v.elements[0][0];
+				gui[1] = v.elements[0][1];
+				gui[2] = 0; // ignored
+				gui[3] = 0; // ignored
+
+				gui[4] = v.elements[1][0];
+				gui[5] = v.elements[1][1];
+				gui[6] = 0; // ignored
+				gui[7] = 0; // ignored
+			}
+		} break;
+		case ShaderLanguage::TYPE_MAT3: {
+			float *gui = (float *)data;
+
+			if (p_array_size > 0) {
+				const PackedFloat32Array &a = value;
+				int s = a.size();
+
+				for (int i = 0, j = 0; i < p_array_size * 9; i += 9, j += 12) {
+					if (i + 8 < s) {
+						gui[j] = a[i];
+						gui[j + 1] = a[i + 1];
+						gui[j + 2] = a[i + 2];
+
+						gui[j + 4] = a[i + 3];
+						gui[j + 5] = a[i + 4];
+						gui[j + 6] = a[i + 5];
+
+						gui[j + 8] = a[i + 6];
+						gui[j + 9] = a[i + 7];
+						gui[j + 10] = a[i + 8];
+					} else {
+						gui[j] = 1;
+						gui[j + 1] = 0;
+						gui[j + 2] = 0;
+
+						gui[j + 4] = 0;
+						gui[j + 5] = 1;
+						gui[j + 6] = 0;
+
+						gui[j + 8] = 0;
+						gui[j + 9] = 0;
+						gui[j + 10] = 1;
+					}
+					gui[j + 3] = 0; // ignored
+					gui[j + 7] = 0; // ignored
+					gui[j + 11] = 0; // ignored
+				}
+			} else {
+				Basis v = value;
+				gui[0] = v.elements[0][0];
+				gui[1] = v.elements[1][0];
+				gui[2] = v.elements[2][0];
+				gui[3] = 0; // ignored
+
+				gui[4] = v.elements[0][1];
+				gui[5] = v.elements[1][1];
+				gui[6] = v.elements[2][1];
+				gui[7] = 0; // ignored
+
+				gui[8] = v.elements[0][2];
+				gui[9] = v.elements[1][2];
+				gui[10] = v.elements[2][2];
+				gui[11] = 0; // ignored
+			}
+		} break;
+		case ShaderLanguage::TYPE_MAT4: {
+			float *gui = (float *)data;
+
+			if (p_array_size > 0) {
+				const PackedFloat32Array &a = value;
+				int s = a.size();
+
+				for (int i = 0; i < p_array_size * 16; i += 16) {
+					if (i + 15 < s) {
+						gui[i] = a[i];
+						gui[i + 1] = a[i + 1];
+						gui[i + 2] = a[i + 2];
+						gui[i + 3] = a[i + 3];
+
+						gui[i + 4] = a[i + 4];
+						gui[i + 5] = a[i + 5];
+						gui[i + 6] = a[i + 6];
+						gui[i + 7] = a[i + 7];
+
+						gui[i + 8] = a[i + 8];
+						gui[i + 9] = a[i + 9];
+						gui[i + 10] = a[i + 10];
+						gui[i + 11] = a[i + 11];
+
+						gui[i + 12] = a[i + 12];
+						gui[i + 13] = a[i + 13];
+						gui[i + 14] = a[i + 14];
+						gui[i + 15] = a[i + 15];
+					} else {
+						gui[i] = 1;
+						gui[i + 1] = 0;
+						gui[i + 2] = 0;
+						gui[i + 3] = 0;
+
+						gui[i + 4] = 0;
+						gui[i + 5] = 1;
+						gui[i + 6] = 0;
+						gui[i + 7] = 0;
+
+						gui[i + 8] = 0;
+						gui[i + 9] = 0;
+						gui[i + 10] = 1;
+						gui[i + 11] = 0;
+
+						gui[i + 12] = 0;
+						gui[i + 13] = 0;
+						gui[i + 14] = 0;
+						gui[i + 15] = 1;
+					}
+				}
+			} else {
+				Transform3D v = value;
+				gui[0] = v.basis.elements[0][0];
+				gui[1] = v.basis.elements[1][0];
+				gui[2] = v.basis.elements[2][0];
+				gui[3] = 0;
+
+				gui[4] = v.basis.elements[0][1];
+				gui[5] = v.basis.elements[1][1];
+				gui[6] = v.basis.elements[2][1];
+				gui[7] = 0;
+
+				gui[8] = v.basis.elements[0][2];
+				gui[9] = v.basis.elements[1][2];
+				gui[10] = v.basis.elements[2][2];
+				gui[11] = 0;
+
+				gui[12] = v.origin.x;
+				gui[13] = v.origin.y;
+				gui[14] = v.origin.z;
+				gui[15] = 1;
+			}
+		} break;
+		default: {
+		}
+	}
+}
+
+_FORCE_INLINE_ static void _fill_std140_ubo_value(ShaderLanguage::DataType type, const Vector<ShaderLanguage::ConstantNode::Value> &value, uint8_t *data) {
+	switch (type) {
+		case ShaderLanguage::TYPE_BOOL: {
+			uint32_t *gui = (uint32_t *)data;
+			*gui = value[0].boolean ? 1 : 0;
+		} break;
+		case ShaderLanguage::TYPE_BVEC2: {
+			uint32_t *gui = (uint32_t *)data;
+			gui[0] = value[0].boolean ? 1 : 0;
+			gui[1] = value[1].boolean ? 1 : 0;
+
+		} break;
+		case ShaderLanguage::TYPE_BVEC3: {
+			uint32_t *gui = (uint32_t *)data;
+			gui[0] = value[0].boolean ? 1 : 0;
+			gui[1] = value[1].boolean ? 1 : 0;
+			gui[2] = value[2].boolean ? 1 : 0;
+
+		} break;
+		case ShaderLanguage::TYPE_BVEC4: {
+			uint32_t *gui = (uint32_t *)data;
+			gui[0] = value[0].boolean ? 1 : 0;
+			gui[1] = value[1].boolean ? 1 : 0;
+			gui[2] = value[2].boolean ? 1 : 0;
+			gui[3] = value[3].boolean ? 1 : 0;
+
+		} break;
+		case ShaderLanguage::TYPE_INT: {
+			int32_t *gui = (int32_t *)data;
+			gui[0] = value[0].sint;
+
+		} break;
+		case ShaderLanguage::TYPE_IVEC2: {
+			int32_t *gui = (int32_t *)data;
+
+			for (int i = 0; i < 2; i++) {
+				gui[i] = value[i].sint;
+			}
+
+		} break;
+		case ShaderLanguage::TYPE_IVEC3: {
+			int32_t *gui = (int32_t *)data;
+
+			for (int i = 0; i < 3; i++) {
+				gui[i] = value[i].sint;
+			}
+
+		} break;
+		case ShaderLanguage::TYPE_IVEC4: {
+			int32_t *gui = (int32_t *)data;
+
+			for (int i = 0; i < 4; i++) {
+				gui[i] = value[i].sint;
+			}
+
+		} break;
+		case ShaderLanguage::TYPE_UINT: {
+			uint32_t *gui = (uint32_t *)data;
+			gui[0] = value[0].uint;
+
+		} break;
+		case ShaderLanguage::TYPE_UVEC2: {
+			int32_t *gui = (int32_t *)data;
+
+			for (int i = 0; i < 2; i++) {
+				gui[i] = value[i].uint;
+			}
+		} break;
+		case ShaderLanguage::TYPE_UVEC3: {
+			int32_t *gui = (int32_t *)data;
+
+			for (int i = 0; i < 3; i++) {
+				gui[i] = value[i].uint;
+			}
+
+		} break;
+		case ShaderLanguage::TYPE_UVEC4: {
+			int32_t *gui = (int32_t *)data;
+
+			for (int i = 0; i < 4; i++) {
+				gui[i] = value[i].uint;
+			}
+		} break;
+		case ShaderLanguage::TYPE_FLOAT: {
+			float *gui = (float *)data;
+			gui[0] = value[0].real;
+
+		} break;
+		case ShaderLanguage::TYPE_VEC2: {
+			float *gui = (float *)data;
+
+			for (int i = 0; i < 2; i++) {
+				gui[i] = value[i].real;
+			}
+
+		} break;
+		case ShaderLanguage::TYPE_VEC3: {
+			float *gui = (float *)data;
+
+			for (int i = 0; i < 3; i++) {
+				gui[i] = value[i].real;
+			}
+
+		} break;
+		case ShaderLanguage::TYPE_VEC4: {
+			float *gui = (float *)data;
+
+			for (int i = 0; i < 4; i++) {
+				gui[i] = value[i].real;
+			}
+		} break;
+		case ShaderLanguage::TYPE_MAT2: {
+			float *gui = (float *)data;
+
+			//in std140 members of mat2 are treated as vec4s
+			gui[0] = value[0].real;
+			gui[1] = value[1].real;
+			gui[2] = 0;
+			gui[3] = 0;
+			gui[4] = value[2].real;
+			gui[5] = value[3].real;
+			gui[6] = 0;
+			gui[7] = 0;
+		} break;
+		case ShaderLanguage::TYPE_MAT3: {
+			float *gui = (float *)data;
+
+			gui[0] = value[0].real;
+			gui[1] = value[1].real;
+			gui[2] = value[2].real;
+			gui[3] = 0;
+			gui[4] = value[3].real;
+			gui[5] = value[4].real;
+			gui[6] = value[5].real;
+			gui[7] = 0;
+			gui[8] = value[6].real;
+			gui[9] = value[7].real;
+			gui[10] = value[8].real;
+			gui[11] = 0;
+		} break;
+		case ShaderLanguage::TYPE_MAT4: {
+			float *gui = (float *)data;
+
+			for (int i = 0; i < 16; i++) {
+				gui[i] = value[i].real;
+			}
+		} break;
+		default: {
+		}
+	}
+}
+
+_FORCE_INLINE_ static void _fill_std140_ubo_empty(ShaderLanguage::DataType type, int p_array_size, uint8_t *data) {
+	if (p_array_size <= 0) {
+		p_array_size = 1;
+	}
+
+	switch (type) {
+		case ShaderLanguage::TYPE_BOOL:
+		case ShaderLanguage::TYPE_INT:
+		case ShaderLanguage::TYPE_UINT:
+		case ShaderLanguage::TYPE_FLOAT: {
+			memset(data, 0, 4 * p_array_size);
+		} break;
+		case ShaderLanguage::TYPE_BVEC2:
+		case ShaderLanguage::TYPE_IVEC2:
+		case ShaderLanguage::TYPE_UVEC2:
+		case ShaderLanguage::TYPE_VEC2: {
+			memset(data, 0, 8 * p_array_size);
+		} break;
+		case ShaderLanguage::TYPE_BVEC3:
+		case ShaderLanguage::TYPE_IVEC3:
+		case ShaderLanguage::TYPE_UVEC3:
+		case ShaderLanguage::TYPE_VEC3:
+		case ShaderLanguage::TYPE_BVEC4:
+		case ShaderLanguage::TYPE_IVEC4:
+		case ShaderLanguage::TYPE_UVEC4:
+		case ShaderLanguage::TYPE_VEC4: {
+			memset(data, 0, 16 * p_array_size);
+		} break;
+		case ShaderLanguage::TYPE_MAT2: {
+			memset(data, 0, 32 * p_array_size);
+		} break;
+		case ShaderLanguage::TYPE_MAT3: {
+			memset(data, 0, 48 * p_array_size);
+		} break;
+		case ShaderLanguage::TYPE_MAT4: {
+			memset(data, 0, 64 * p_array_size);
+		} break;
+
+		default: {
+		}
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////
+// MaterialData
+
+void MaterialData::update_uniform_buffer(const Map<StringName, ShaderLanguage::ShaderNode::Uniform> &p_uniforms, const uint32_t *p_uniform_offsets, const Map<StringName, Variant> &p_parameters, uint8_t *p_buffer, uint32_t p_buffer_size, bool p_use_linear_color) {
+	MaterialStorage *material_storage = MaterialStorage::get_singleton();
+	bool uses_global_buffer = false;
+
+	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : p_uniforms) {
+		if (E.value.order < 0) {
+			continue; // texture, does not go here
+		}
+
+		if (E.value.scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
+			continue; //instance uniforms don't appear in the buffer
+		}
+
+		if (E.value.scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_GLOBAL) {
+			//this is a global variable, get the index to it
+			GlobalVariables::Variable *gv = material_storage->global_variables.variables.getptr(E.key);
+			uint32_t index = 0;
+			if (gv) {
+				index = gv->buffer_index;
+			} else {
+				WARN_PRINT("Shader uses global uniform '" + E.key + "', but it was removed at some point. Material will not display correctly.");
+			}
+
+			uint32_t offset = p_uniform_offsets[E.value.order];
+			uint32_t *intptr = (uint32_t *)&p_buffer[offset];
+			*intptr = index;
+			uses_global_buffer = true;
+			continue;
+		}
+
+		//regular uniform
+		uint32_t offset = p_uniform_offsets[E.value.order];
+#ifdef DEBUG_ENABLED
+		uint32_t size = 0U;
+		// The following code enforces a 16-byte alignment of uniform arrays.
+		if (E.value.array_size > 0) {
+			size = ShaderLanguage::get_datatype_size(E.value.type) * E.value.array_size;
+			int m = (16 * E.value.array_size);
+			if ((size % m) != 0U) {
+				size += m - (size % m);
+			}
+		} else {
+			size = ShaderLanguage::get_datatype_size(E.value.type);
+		}
+		ERR_CONTINUE(offset + size > p_buffer_size);
+#endif
+		uint8_t *data = &p_buffer[offset];
+		const Map<StringName, Variant>::Element *V = p_parameters.find(E.key);
+
+		if (V) {
+			//user provided
+			_fill_std140_variant_ubo_value(E.value.type, E.value.array_size, V->get(), data, p_use_linear_color);
+
+		} else if (E.value.default_value.size()) {
+			//default value
+			_fill_std140_ubo_value(E.value.type, E.value.default_value, data);
+			//value=E.value.default_value;
+		} else {
+			//zero because it was not provided
+			if (E.value.type == ShaderLanguage::TYPE_VEC4 && E.value.hint == ShaderLanguage::ShaderNode::Uniform::HINT_COLOR) {
+				//colors must be set as black, with alpha as 1.0
+				_fill_std140_variant_ubo_value(E.value.type, E.value.array_size, Color(0, 0, 0, 1), data, p_use_linear_color);
+			} else {
+				//else just zero it out
+				_fill_std140_ubo_empty(E.value.type, E.value.array_size, data);
+			}
+		}
+	}
+
+	if (uses_global_buffer != (global_buffer_E != nullptr)) {
+		if (uses_global_buffer) {
+			global_buffer_E = material_storage->global_variables.materials_using_buffer.push_back(self);
+		} else {
+			material_storage->global_variables.materials_using_buffer.erase(global_buffer_E);
+			global_buffer_E = nullptr;
+		}
+	}
+}
+
+MaterialData::~MaterialData() {
+	MaterialStorage *material_storage = MaterialStorage::get_singleton();
+
+	if (global_buffer_E) {
+		//unregister global buffers
+		material_storage->global_variables.materials_using_buffer.erase(global_buffer_E);
+	}
+
+	if (global_texture_E) {
+		//unregister global textures
+
+		for (const KeyValue<StringName, uint64_t> &E : used_global_textures) {
+			GlobalVariables::Variable *v = material_storage->global_variables.variables.getptr(E.key);
+			if (v) {
+				v->texture_materials.erase(self);
+			}
+		}
+		//unregister material from those using global textures
+		material_storage->global_variables.materials_using_texture.erase(global_texture_E);
+	}
+
+	if (uniform_buffer) {
+		glDeleteBuffers(1, &uniform_buffer);
+	}
+}
+
+void MaterialData::update_textures(const Map<StringName, Variant> &p_parameters, const Map<StringName, Map<int, RID>> &p_default_textures, const Vector<ShaderCompiler::GeneratedCode::Texture> &p_texture_uniforms, RID *p_textures, bool p_use_linear_color) {
+	TextureStorage *texture_storage = TextureStorage::get_singleton();
+	MaterialStorage *material_storage = MaterialStorage::get_singleton();
+
+#ifdef TOOLS_ENABLED
+	Texture *roughness_detect_texture = nullptr;
+	RS::TextureDetectRoughnessChannel roughness_channel = RS::TEXTURE_DETECT_ROUGHNESS_R;
+	Texture *normal_detect_texture = nullptr;
+#endif
+
+	bool uses_global_textures = false;
+	global_textures_pass++;
+
+	for (int i = 0, k = 0; i < p_texture_uniforms.size(); i++) {
+		const StringName &uniform_name = p_texture_uniforms[i].name;
+		int uniform_array_size = p_texture_uniforms[i].array_size;
+
+		Vector<RID> textures;
+
+		if (p_texture_uniforms[i].global) {
+			uses_global_textures = true;
+
+			GlobalVariables::Variable *v = material_storage->global_variables.variables.getptr(uniform_name);
+			if (v) {
+				if (v->buffer_index >= 0) {
+					WARN_PRINT("Shader uses global uniform texture '" + String(uniform_name) + "', but it changed type and is no longer a texture!.");
+
+				} else {
+					Map<StringName, uint64_t>::Element *E = used_global_textures.find(uniform_name);
+					if (!E) {
+						E = used_global_textures.insert(uniform_name, global_textures_pass);
+						v->texture_materials.insert(self);
+					} else {
+						E->get() = global_textures_pass;
+					}
+
+					textures.push_back(v->override.get_type() != Variant::NIL ? v->override : v->value);
+				}
+
+			} else {
+				WARN_PRINT("Shader uses global uniform texture '" + String(uniform_name) + "', but it was removed at some point. Material will not display correctly.");
+			}
+		} else {
+			const Map<StringName, Variant>::Element *V = p_parameters.find(uniform_name);
+			if (V) {
+				if (V->get().is_array()) {
+					Array array = (Array)V->get();
+					if (uniform_array_size > 0) {
+						for (int j = 0; j < array.size(); j++) {
+							textures.push_back(array[j]);
+						}
+					} else {
+						if (array.size() > 0) {
+							textures.push_back(array[0]);
+						}
+					}
+				} else {
+					textures.push_back(V->get());
+				}
+			}
+
+			if (uniform_array_size > 0) {
+				if (textures.size() < uniform_array_size) {
+					const Map<StringName, Map<int, RID>>::Element *W = p_default_textures.find(uniform_name);
+					for (int j = textures.size(); j < uniform_array_size; j++) {
+						if (W && W->get().has(j)) {
+							textures.push_back(W->get()[j]);
+						} else {
+							textures.push_back(RID());
+						}
+					}
+				}
+			} else if (textures.is_empty()) {
+				const Map<StringName, Map<int, RID>>::Element *W = p_default_textures.find(uniform_name);
+				if (W && W->get().has(0)) {
+					textures.push_back(W->get()[0]);
+				}
+			}
+		}
+
+		RID gl_texture = texture_storage->texture_gl_get_default(DEFAULT_GL_TEXTURE_WHITE);
+
+		if (textures.is_empty()) {
+			//check default usage
+			switch (p_texture_uniforms[i].type) {
+				case ShaderLanguage::TYPE_ISAMPLER2D:
+				case ShaderLanguage::TYPE_USAMPLER2D:
+				case ShaderLanguage::TYPE_SAMPLER2D: {
+					switch (p_texture_uniforms[i].hint) {
+						case ShaderLanguage::ShaderNode::Uniform::HINT_BLACK:
+						case ShaderLanguage::ShaderNode::Uniform::HINT_BLACK_ALBEDO: {
+							gl_texture = texture_storage->texture_gl_get_default(DEFAULT_GL_TEXTURE_BLACK);
+						} break;
+						case ShaderLanguage::ShaderNode::Uniform::HINT_ANISOTROPY: {
+							gl_texture = texture_storage->texture_gl_get_default(DEFAULT_GL_TEXTURE_ANISO);
+						} break;
+						case ShaderLanguage::ShaderNode::Uniform::HINT_NORMAL: {
+							gl_texture = texture_storage->texture_gl_get_default(DEFAULT_GL_TEXTURE_NORMAL);
+						} break;
+						case ShaderLanguage::ShaderNode::Uniform::HINT_ROUGHNESS_NORMAL: {
+							gl_texture = texture_storage->texture_gl_get_default(DEFAULT_GL_TEXTURE_NORMAL);
+						} break;
+						default: {
+							gl_texture = texture_storage->texture_gl_get_default(DEFAULT_GL_TEXTURE_WHITE);
+						} break;
+					}
+				} break;
+
+				case ShaderLanguage::TYPE_SAMPLERCUBE: {
+					switch (p_texture_uniforms[i].hint) {
+						case ShaderLanguage::ShaderNode::Uniform::HINT_BLACK:
+						case ShaderLanguage::ShaderNode::Uniform::HINT_BLACK_ALBEDO: {
+							gl_texture = texture_storage->texture_gl_get_default(DEFAULT_GL_TEXTURE_CUBEMAP_BLACK);
+						} break;
+						default: {
+							gl_texture = texture_storage->texture_gl_get_default(DEFAULT_GL_TEXTURE_CUBEMAP_WHITE);
+						} break;
+					}
+				} break;
+				case ShaderLanguage::TYPE_SAMPLERCUBEARRAY: {
+					ERR_PRINT_ONCE("Type: SamplerCubeArray not supported in OpenGL renderer, please use another type.");
+				} break;
+
+				case ShaderLanguage::TYPE_ISAMPLER3D:
+				case ShaderLanguage::TYPE_USAMPLER3D:
+				case ShaderLanguage::TYPE_SAMPLER3D: {
+					switch (p_texture_uniforms[i].hint) {
+						case ShaderLanguage::ShaderNode::Uniform::HINT_BLACK:
+						case ShaderLanguage::ShaderNode::Uniform::HINT_BLACK_ALBEDO: {
+							gl_texture = texture_storage->texture_gl_get_default(DEFAULT_GL_TEXTURE_3D_BLACK);
+						} break;
+						default: {
+							gl_texture = texture_storage->texture_gl_get_default(DEFAULT_GL_TEXTURE_3D_WHITE);
+						} break;
+					}
+				} break;
+
+				case ShaderLanguage::TYPE_ISAMPLER2DARRAY:
+				case ShaderLanguage::TYPE_USAMPLER2DARRAY:
+				case ShaderLanguage::TYPE_SAMPLER2DARRAY: {
+					gl_texture = texture_storage->texture_gl_get_default(DEFAULT_GL_TEXTURE_2D_ARRAY_WHITE);
+				} break;
+
+				default: {
+				}
+			}
+#ifdef TOOLS_ENABLED
+			if (roughness_detect_texture && normal_detect_texture && !normal_detect_texture->path.is_empty()) {
+				roughness_detect_texture->detect_roughness_callback(roughness_detect_texture->detect_roughness_callback_ud, normal_detect_texture->path, roughness_channel);
+			}
+#endif
+			if (uniform_array_size > 0) {
+				for (int j = 0; j < uniform_array_size; j++) {
+					p_textures[k++] = gl_texture;
+				}
+			} else {
+				p_textures[k++] = gl_texture;
+			}
+		} else {
+			//bool srgb = p_use_linear_color && (p_texture_uniforms[i].hint == ShaderLanguage::ShaderNode::Uniform::HINT_ALBEDO || p_texture_uniforms[i].hint == ShaderLanguage::ShaderNode::Uniform::HINT_BLACK_ALBEDO);
+
+			for (int j = 0; j < textures.size(); j++) {
+				Texture *tex = TextureStorage::get_singleton()->get_texture(textures[j]);
+
+				if (tex) {
+					gl_texture = textures[j];
+#ifdef TOOLS_ENABLED
+					if (tex->detect_3d_callback && p_use_linear_color) {
+						tex->detect_3d_callback(tex->detect_3d_callback_ud);
+					}
+					if (tex->detect_normal_callback && (p_texture_uniforms[i].hint == ShaderLanguage::ShaderNode::Uniform::HINT_NORMAL || p_texture_uniforms[i].hint == ShaderLanguage::ShaderNode::Uniform::HINT_ROUGHNESS_NORMAL)) {
+						if (p_texture_uniforms[i].hint == ShaderLanguage::ShaderNode::Uniform::HINT_ROUGHNESS_NORMAL) {
+							normal_detect_texture = tex;
+						}
+						tex->detect_normal_callback(tex->detect_normal_callback_ud);
+					}
+					if (tex->detect_roughness_callback && (p_texture_uniforms[i].hint >= ShaderLanguage::ShaderNode::Uniform::HINT_ROUGHNESS_R || p_texture_uniforms[i].hint <= ShaderLanguage::ShaderNode::Uniform::HINT_ROUGHNESS_GRAY)) {
+						//find the normal texture
+						roughness_detect_texture = tex;
+						roughness_channel = RS::TextureDetectRoughnessChannel(p_texture_uniforms[i].hint - ShaderLanguage::ShaderNode::Uniform::HINT_ROUGHNESS_R);
+					}
+#endif
+				}
+#ifdef TOOLS_ENABLED
+				if (roughness_detect_texture && normal_detect_texture && !normal_detect_texture->path.is_empty()) {
+					roughness_detect_texture->detect_roughness_callback(roughness_detect_texture->detect_roughness_callback_ud, normal_detect_texture->path, roughness_channel);
+				}
+#endif
+				p_textures[k++] = gl_texture;
+			}
+		}
+	}
+	{
+		//for textures no longer used, unregister them
+		List<Map<StringName, uint64_t>::Element *> to_delete;
+		for (Map<StringName, uint64_t>::Element *E = used_global_textures.front(); E; E = E->next()) {
+			if (E->get() != global_textures_pass) {
+				to_delete.push_back(E);
+
+				GlobalVariables::Variable *v = material_storage->global_variables.variables.getptr(E->key());
+				if (v) {
+					v->texture_materials.erase(self);
+				}
+			}
+		}
+
+		while (to_delete.front()) {
+			used_global_textures.erase(to_delete.front()->get());
+			to_delete.pop_front();
+		}
+		//handle registering/unregistering global textures
+		if (uses_global_textures != (global_texture_E != nullptr)) {
+			if (uses_global_textures) {
+				global_texture_E = material_storage->global_variables.materials_using_texture.push_back(self);
+			} else {
+				material_storage->global_variables.materials_using_texture.erase(global_texture_E);
+				global_texture_E = nullptr;
+			}
+		}
+	}
+}
+
+void MaterialData::update_parameters_internal(const Map<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty, const Map<StringName, ShaderLanguage::ShaderNode::Uniform> &p_uniforms, const uint32_t *p_uniform_offsets, const Vector<ShaderCompiler::GeneratedCode::Texture> &p_texture_uniforms, const Map<StringName, Map<int, RID>> &p_default_texture_params, uint32_t p_ubo_size) {
+	if ((uint32_t)ubo_data.size() != p_ubo_size) {
+		p_uniform_dirty = true;
+		if (!uniform_buffer) {
+			glGenBuffers(1, &uniform_buffer);
+		}
+
+		ubo_data.resize(p_ubo_size);
+		if (ubo_data.size()) {
+			memset(ubo_data.ptrw(), 0, ubo_data.size()); //clear
+		}
+	}
+
+	//check whether buffer changed
+	if (p_uniform_dirty && ubo_data.size()) {
+		update_uniform_buffer(p_uniforms, p_uniform_offsets, p_parameters, ubo_data.ptrw(), ubo_data.size(), true);
+		glBindBuffer(GL_UNIFORM_BUFFER, uniform_buffer);
+		glBufferData(GL_UNIFORM_BUFFER, ubo_data.size(), ubo_data.ptrw(), GL_DYNAMIC_DRAW);
+		glBindBuffer(GL_UNIFORM_BUFFER, 0);
+	}
+
+	uint32_t tex_uniform_count = 0U;
+	for (int i = 0; i < p_texture_uniforms.size(); i++) {
+		tex_uniform_count += uint32_t(p_texture_uniforms[i].array_size > 0 ? p_texture_uniforms[i].array_size : 1);
+	}
+
+	if ((uint32_t)texture_cache.size() != tex_uniform_count || p_textures_dirty) {
+		texture_cache.resize(tex_uniform_count);
+		p_textures_dirty = true;
+	}
+
+	if (p_textures_dirty && tex_uniform_count) {
+		update_textures(p_parameters, p_default_texture_params, p_texture_uniforms, texture_cache.ptrw(), true);
+	}
+}
+
+///////////////////////////////////////////////////////////////////////////
+// Material Storage
 
 MaterialStorage *MaterialStorage::singleton = nullptr;
 
@@ -47,120 +1241,1127 @@ MaterialStorage *MaterialStorage::get_singleton() {
 MaterialStorage::MaterialStorage() {
 	singleton = this;
 
-	shaders.copy.initialize();
-	shaders.copy_version = shaders.copy.version_create(); //TODO
-	shaders.copy.version_bind_shader(shaders.copy_version, CopyShaderGLES3::MODE_COPY_SECTION);
+	shader_data_request_func[RS::SHADER_SPATIAL] = nullptr;
+	shader_data_request_func[RS::SHADER_CANVAS_ITEM] = _create_canvas_shader_func;
+	shader_data_request_func[RS::SHADER_PARTICLES] = nullptr;
+	shader_data_request_func[RS::SHADER_SKY] = nullptr;
+	shader_data_request_func[RS::SHADER_FOG] = nullptr;
+
+	material_data_request_func[RS::SHADER_SPATIAL] = nullptr;
+	material_data_request_func[RS::SHADER_CANVAS_ITEM] = _create_canvas_material_func;
+	material_data_request_func[RS::SHADER_PARTICLES] = nullptr;
+	material_data_request_func[RS::SHADER_SKY] = nullptr;
+	material_data_request_func[RS::SHADER_FOG] = nullptr;
+
+	static_assert(sizeof(GlobalVariables::Value) == 16);
+
+	global_variables.buffer_size = MAX(4096, (int)GLOBAL_GET("rendering/limits/global_shader_variables/buffer_size"));
+	if (global_variables.buffer_size > uint32_t(Config::get_singleton()->max_uniform_buffer_size)) {
+		global_variables.buffer_size = uint32_t(Config::get_singleton()->max_uniform_buffer_size);
+		WARN_PRINT("Project setting: rendering/limits/global_shader_variables/buffer_size exceeds maximum uniform buffer size of: " + itos(Config::get_singleton()->max_uniform_buffer_size));
+	}
+
+	global_variables.buffer_values = memnew_arr(GlobalVariables::Value, global_variables.buffer_size);
+	memset(global_variables.buffer_values, 0, sizeof(GlobalVariables::Value) * global_variables.buffer_size);
+	global_variables.buffer_usage = memnew_arr(GlobalVariables::ValueUsage, global_variables.buffer_size);
+	global_variables.buffer_dirty_regions = memnew_arr(bool, global_variables.buffer_size / GlobalVariables::BUFFER_DIRTY_REGION_SIZE);
+	memset(global_variables.buffer_dirty_regions, 0, sizeof(bool) * global_variables.buffer_size / GlobalVariables::BUFFER_DIRTY_REGION_SIZE);
+	glGenBuffers(1, &global_variables.buffer);
+	glBindBuffer(GL_UNIFORM_BUFFER, global_variables.buffer);
+	glBufferData(GL_UNIFORM_BUFFER, sizeof(GlobalVariables::Value) * global_variables.buffer_size, nullptr, GL_DYNAMIC_DRAW);
+	glBindBuffer(GL_UNIFORM_BUFFER, 0);
+
+	{
+		// Setup CanvasItem compiler
+		ShaderCompiler::DefaultIdentifierActions actions;
+
+		actions.renames["VERTEX"] = "vertex";
+		actions.renames["LIGHT_VERTEX"] = "light_vertex";
+		actions.renames["SHADOW_VERTEX"] = "shadow_vertex";
+		actions.renames["UV"] = "uv";
+		actions.renames["POINT_SIZE"] = "gl_PointSize";
+
+		actions.renames["MODEL_MATRIX"] = "model_matrix";
+		actions.renames["CANVAS_MATRIX"] = "canvas_data.canvas_transform";
+		actions.renames["SCREEN_MATRIX"] = "canvas_data.screen_transform";
+		actions.renames["TIME"] = "canvas_data.time";
+		actions.renames["PI"] = _MKSTR(Math_PI);
+		actions.renames["TAU"] = _MKSTR(Math_TAU);
+		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["AT_LIGHT_PASS"] = "false";
+		actions.renames["INSTANCE_CUSTOM"] = "instance_custom";
+
+		actions.renames["COLOR"] = "color";
+		actions.renames["NORMAL"] = "normal";
+		actions.renames["NORMAL_MAP"] = "normal_map";
+		actions.renames["NORMAL_MAP_DEPTH"] = "normal_map_depth";
+		actions.renames["TEXTURE"] = "color_texture";
+		actions.renames["TEXTURE_PIXEL_SIZE"] = "draw_data.color_texture_pixel_size";
+		actions.renames["NORMAL_TEXTURE"] = "normal_texture";
+		actions.renames["SPECULAR_SHININESS_TEXTURE"] = "specular_texture";
+		actions.renames["SPECULAR_SHININESS"] = "specular_shininess";
+		actions.renames["SCREEN_UV"] = "screen_uv";
+		actions.renames["SCREEN_TEXTURE"] = "screen_texture";
+		actions.renames["SCREEN_PIXEL_SIZE"] = "canvas_data.screen_pixel_size";
+		actions.renames["FRAGCOORD"] = "gl_FragCoord";
+		actions.renames["POINT_COORD"] = "gl_PointCoord";
+		actions.renames["INSTANCE_ID"] = "gl_InstanceIndex";
+		actions.renames["VERTEX_ID"] = "gl_VertexIndex";
+
+		actions.renames["LIGHT_POSITION"] = "light_position";
+		actions.renames["LIGHT_COLOR"] = "light_color";
+		actions.renames["LIGHT_ENERGY"] = "light_energy";
+		actions.renames["LIGHT"] = "light";
+		actions.renames["SHADOW_MODULATE"] = "shadow_modulate";
+
+		actions.renames["texture_sdf"] = "texture_sdf";
+		actions.renames["texture_sdf_normal"] = "texture_sdf_normal";
+		actions.renames["sdf_to_screen_uv"] = "sdf_to_screen_uv";
+		actions.renames["screen_uv_to_sdf"] = "screen_uv_to_sdf";
+
+		actions.usage_defines["COLOR"] = "#define COLOR_USED\n";
+		actions.usage_defines["SCREEN_TEXTURE"] = "#define SCREEN_TEXTURE_USED\n";
+		actions.usage_defines["SCREEN_UV"] = "#define SCREEN_UV_USED\n";
+		actions.usage_defines["SCREEN_PIXEL_SIZE"] = "@SCREEN_UV";
+		actions.usage_defines["NORMAL"] = "#define NORMAL_USED\n";
+		actions.usage_defines["NORMAL_MAP"] = "#define NORMAL_MAP_USED\n";
+		actions.usage_defines["LIGHT"] = "#define LIGHT_SHADER_CODE_USED\n";
+
+		actions.render_mode_defines["skip_vertex_transform"] = "#define SKIP_TRANSFORM_USED\n";
+		actions.render_mode_defines["unshaded"] = "#define MODE_UNSHADED\n";
+		actions.render_mode_defines["light_only"] = "#define MODE_LIGHT_ONLY\n";
+
+		actions.base_texture_binding_index = 1;
+		actions.base_uniform_string = "";
+		actions.global_buffer_array_variable = "";
+
+		shaders.compiler_canvas.initialize(actions);
+	}
+
+	{
+		// Setup Scene compiler
+		/*
+		//shader compiler
+		ShaderCompiler::DefaultIdentifierActions actions;
+
+		actions.renames["MODEL_MATRIX"] = "model_matrix";
+		actions.renames["MODEL_NORMAL_MATRIX"] = "model_normal_matrix";
+		actions.renames["VIEW_MATRIX"] = "scene_data.view_matrix";
+		actions.renames["INV_VIEW_MATRIX"] = "scene_data.inv_view_matrix";
+		actions.renames["PROJECTION_MATRIX"] = "projection_matrix";
+		actions.renames["INV_PROJECTION_MATRIX"] = "inv_projection_matrix";
+		actions.renames["MODELVIEW_MATRIX"] = "modelview";
+		actions.renames["MODELVIEW_NORMAL_MATRIX"] = "modelview_normal";
+
+		actions.renames["VERTEX"] = "vertex";
+		actions.renames["NORMAL"] = "normal";
+		actions.renames["TANGENT"] = "tangent";
+		actions.renames["BINORMAL"] = "binormal";
+		actions.renames["POSITION"] = "position";
+		actions.renames["UV"] = "uv_interp";
+		actions.renames["UV2"] = "uv2_interp";
+		actions.renames["COLOR"] = "color_interp";
+		actions.renames["POINT_SIZE"] = "gl_PointSize";
+		actions.renames["INSTANCE_ID"] = "gl_InstanceIndex";
+		actions.renames["VERTEX_ID"] = "gl_VertexIndex";
+
+		actions.renames["ALPHA_SCISSOR_THRESHOLD"] = "alpha_scissor_threshold";
+		actions.renames["ALPHA_HASH_SCALE"] = "alpha_hash_scale";
+		actions.renames["ALPHA_ANTIALIASING_EDGE"] = "alpha_antialiasing_edge";
+		actions.renames["ALPHA_TEXTURE_COORDINATE"] = "alpha_texture_coordinate";
+
+		//builtins
+
+		actions.renames["TIME"] = "scene_data.time";
+		actions.renames["PI"] = _MKSTR(Math_PI);
+		actions.renames["TAU"] = _MKSTR(Math_TAU);
+		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["VIEWPORT_SIZE"] = "scene_data.viewport_size";
+
+		actions.renames["FRAGCOORD"] = "gl_FragCoord";
+		actions.renames["FRONT_FACING"] = "gl_FrontFacing";
+		actions.renames["NORMAL_MAP"] = "normal_map";
+		actions.renames["NORMAL_MAP_DEPTH"] = "normal_map_depth";
+		actions.renames["ALBEDO"] = "albedo";
+		actions.renames["ALPHA"] = "alpha";
+		actions.renames["METALLIC"] = "metallic";
+		actions.renames["SPECULAR"] = "specular";
+		actions.renames["ROUGHNESS"] = "roughness";
+		actions.renames["RIM"] = "rim";
+		actions.renames["RIM_TINT"] = "rim_tint";
+		actions.renames["CLEARCOAT"] = "clearcoat";
+		actions.renames["CLEARCOAT_ROUGHNESS"] = "clearcoat_roughness";
+		actions.renames["ANISOTROPY"] = "anisotropy";
+		actions.renames["ANISOTROPY_FLOW"] = "anisotropy_flow";
+		actions.renames["SSS_STRENGTH"] = "sss_strength";
+		actions.renames["SSS_TRANSMITTANCE_COLOR"] = "transmittance_color";
+		actions.renames["SSS_TRANSMITTANCE_DEPTH"] = "transmittance_depth";
+		actions.renames["SSS_TRANSMITTANCE_BOOST"] = "transmittance_boost";
+		actions.renames["BACKLIGHT"] = "backlight";
+		actions.renames["AO"] = "ao";
+		actions.renames["AO_LIGHT_AFFECT"] = "ao_light_affect";
+		actions.renames["EMISSION"] = "emission";
+		actions.renames["POINT_COORD"] = "gl_PointCoord";
+		actions.renames["INSTANCE_CUSTOM"] = "instance_custom";
+		actions.renames["SCREEN_UV"] = "screen_uv";
+		actions.renames["SCREEN_TEXTURE"] = "color_buffer";
+		actions.renames["DEPTH_TEXTURE"] = "depth_buffer";
+		actions.renames["NORMAL_ROUGHNESS_TEXTURE"] = "normal_roughness_buffer";
+		actions.renames["DEPTH"] = "gl_FragDepth";
+		actions.renames["OUTPUT_IS_SRGB"] = "true";
+		actions.renames["FOG"] = "custom_fog";
+		actions.renames["RADIANCE"] = "custom_radiance";
+		actions.renames["IRRADIANCE"] = "custom_irradiance";
+		actions.renames["BONE_INDICES"] = "bone_attrib";
+		actions.renames["BONE_WEIGHTS"] = "weight_attrib";
+		actions.renames["CUSTOM0"] = "custom0_attrib";
+		actions.renames["CUSTOM1"] = "custom1_attrib";
+		actions.renames["CUSTOM2"] = "custom2_attrib";
+		actions.renames["CUSTOM3"] = "custom3_attrib";
+		actions.renames["OUTPUT_IS_SRGB"] = "SHADER_IS_SRGB";
+
+		actions.renames["VIEW_INDEX"] = "ViewIndex";
+		actions.renames["VIEW_MONO_LEFT"] = "0";
+		actions.renames["VIEW_RIGHT"] = "1";
+
+		//for light
+		actions.renames["VIEW"] = "view";
+		actions.renames["LIGHT_COLOR"] = "light_color";
+		actions.renames["LIGHT"] = "light";
+		actions.renames["ATTENUATION"] = "attenuation";
+		actions.renames["DIFFUSE_LIGHT"] = "diffuse_light";
+		actions.renames["SPECULAR_LIGHT"] = "specular_light";
+
+		actions.usage_defines["NORMAL"] = "#define NORMAL_USED\n";
+		actions.usage_defines["TANGENT"] = "#define TANGENT_USED\n";
+		actions.usage_defines["BINORMAL"] = "@TANGENT";
+		actions.usage_defines["RIM"] = "#define LIGHT_RIM_USED\n";
+		actions.usage_defines["RIM_TINT"] = "@RIM";
+		actions.usage_defines["CLEARCOAT"] = "#define LIGHT_CLEARCOAT_USED\n";
+		actions.usage_defines["CLEARCOAT_ROUGHNESS"] = "@CLEARCOAT";
+		actions.usage_defines["ANISOTROPY"] = "#define LIGHT_ANISOTROPY_USED\n";
+		actions.usage_defines["ANISOTROPY_FLOW"] = "@ANISOTROPY";
+		actions.usage_defines["AO"] = "#define AO_USED\n";
+		actions.usage_defines["AO_LIGHT_AFFECT"] = "#define AO_USED\n";
+		actions.usage_defines["UV"] = "#define UV_USED\n";
+		actions.usage_defines["UV2"] = "#define UV2_USED\n";
+		actions.usage_defines["BONE_INDICES"] = "#define BONES_USED\n";
+		actions.usage_defines["BONE_WEIGHTS"] = "#define WEIGHTS_USED\n";
+		actions.usage_defines["CUSTOM0"] = "#define CUSTOM0_USED\n";
+		actions.usage_defines["CUSTOM1"] = "#define CUSTOM1_USED\n";
+		actions.usage_defines["CUSTOM2"] = "#define CUSTOM2_USED\n";
+		actions.usage_defines["CUSTOM3"] = "#define CUSTOM3_USED\n";
+		actions.usage_defines["NORMAL_MAP"] = "#define NORMAL_MAP_USED\n";
+		actions.usage_defines["NORMAL_MAP_DEPTH"] = "@NORMAL_MAP";
+		actions.usage_defines["COLOR"] = "#define COLOR_USED\n";
+		actions.usage_defines["INSTANCE_CUSTOM"] = "#define ENABLE_INSTANCE_CUSTOM\n";
+		actions.usage_defines["POSITION"] = "#define OVERRIDE_POSITION\n";
+
+		actions.usage_defines["ALPHA_SCISSOR_THRESHOLD"] = "#define ALPHA_SCISSOR_USED\n";
+		actions.usage_defines["ALPHA_HASH_SCALE"] = "#define ALPHA_HASH_USED\n";
+		actions.usage_defines["ALPHA_ANTIALIASING_EDGE"] = "#define ALPHA_ANTIALIASING_EDGE_USED\n";
+		actions.usage_defines["ALPHA_TEXTURE_COORDINATE"] = "@ALPHA_ANTIALIASING_EDGE";
+
+		actions.usage_defines["SSS_STRENGTH"] = "#define ENABLE_SSS\n";
+		actions.usage_defines["SSS_TRANSMITTANCE_DEPTH"] = "#define ENABLE_TRANSMITTANCE\n";
+		actions.usage_defines["BACKLIGHT"] = "#define LIGHT_BACKLIGHT_USED\n";
+		actions.usage_defines["SCREEN_TEXTURE"] = "#define SCREEN_TEXTURE_USED\n";
+		actions.usage_defines["SCREEN_UV"] = "#define SCREEN_UV_USED\n";
+
+		actions.usage_defines["DIFFUSE_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
+		actions.usage_defines["SPECULAR_LIGHT"] = "#define USE_LIGHT_SHADER_CODE\n";
+
+		actions.usage_defines["FOG"] = "#define CUSTOM_FOG_USED\n";
+		actions.usage_defines["RADIANCE"] = "#define CUSTOM_RADIANCE_USED\n";
+		actions.usage_defines["IRRADIANCE"] = "#define CUSTOM_IRRADIANCE_USED\n";
+
+		actions.render_mode_defines["skip_vertex_transform"] = "#define SKIP_TRANSFORM_USED\n";
+		actions.render_mode_defines["world_vertex_coords"] = "#define VERTEX_WORLD_COORDS_USED\n";
+		actions.render_mode_defines["ensure_correct_normals"] = "#define ENSURE_CORRECT_NORMALS\n";
+		actions.render_mode_defines["cull_front"] = "#define DO_SIDE_CHECK\n";
+		actions.render_mode_defines["cull_disabled"] = "#define DO_SIDE_CHECK\n";
+		actions.render_mode_defines["particle_trails"] = "#define USE_PARTICLE_TRAILS\n";
+		actions.render_mode_defines["depth_draw_opaque"] = "#define USE_OPAQUE_PREPASS\n";
+
+		bool force_lambert = GLOBAL_GET("rendering/shading/overrides/force_lambert_over_burley");
+
+		if (!force_lambert) {
+			actions.render_mode_defines["diffuse_burley"] = "#define DIFFUSE_BURLEY\n";
+		}
+
+		actions.render_mode_defines["diffuse_lambert_wrap"] = "#define DIFFUSE_LAMBERT_WRAP\n";
+		actions.render_mode_defines["diffuse_toon"] = "#define DIFFUSE_TOON\n";
+
+		actions.render_mode_defines["sss_mode_skin"] = "#define SSS_MODE_SKIN\n";
+
+		actions.render_mode_defines["specular_schlick_ggx"] = "#define SPECULAR_SCHLICK_GGX\n";
+
+		actions.custom_samplers["SCREEN_TEXTURE"] = "material_samplers[3]"; // linear filter with mipmaps
+		actions.custom_samplers["DEPTH_TEXTURE"] = "material_samplers[3]";
+		actions.custom_samplers["NORMAL_ROUGHNESS_TEXTURE"] = "material_samplers[1]"; // linear filter
+
+		actions.render_mode_defines["specular_toon"] = "#define SPECULAR_TOON\n";
+		actions.render_mode_defines["specular_disabled"] = "#define SPECULAR_DISABLED\n";
+		actions.render_mode_defines["shadows_disabled"] = "#define SHADOWS_DISABLED\n";
+		actions.render_mode_defines["ambient_light_disabled"] = "#define AMBIENT_LIGHT_DISABLED\n";
+		actions.render_mode_defines["shadow_to_opacity"] = "#define USE_SHADOW_TO_OPACITY\n";
+		actions.render_mode_defines["unshaded"] = "#define MODE_UNSHADED\n";
+
+		actions.sampler_array_name = "material_samplers";
+		actions.base_texture_binding_index = 1;
+		actions.texture_layout_set = RenderForwardClustered::MATERIAL_UNIFORM_SET;
+		actions.base_uniform_string = "material.";
+		actions.base_varying_index = 10;
+
+		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
+		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
+		actions.global_buffer_array_variable = "global_variables.data";
+		actions.instance_uniform_index_variable = "instances.data[instance_index].instance_uniforms_ofs";
+
+		compiler.initialize(actions);
+		*/
+	}
+
+	{
+		// Setup Particles compiler
+		/*
+ShaderCompiler::DefaultIdentifierActions actions;
+
+		actions.renames["COLOR"] = "PARTICLE.color";
+		actions.renames["VELOCITY"] = "PARTICLE.velocity";
+		//actions.renames["MASS"] = "mass"; ?
+		actions.renames["ACTIVE"] = "particle_active";
+		actions.renames["RESTART"] = "restart";
+		actions.renames["CUSTOM"] = "PARTICLE.custom";
+		for (int i = 0; i < ParticlesShader::MAX_USERDATAS; i++) {
+			String udname = "USERDATA" + itos(i + 1);
+			actions.renames[udname] = "PARTICLE.userdata" + itos(i + 1);
+			actions.usage_defines[udname] = "#define USERDATA" + itos(i + 1) + "_USED\n";
+		}
+		actions.renames["TRANSFORM"] = "PARTICLE.xform";
+		actions.renames["TIME"] = "frame_history.data[0].time";
+		actions.renames["PI"] = _MKSTR(Math_PI);
+		actions.renames["TAU"] = _MKSTR(Math_TAU);
+		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["LIFETIME"] = "params.lifetime";
+		actions.renames["DELTA"] = "local_delta";
+		actions.renames["NUMBER"] = "particle_number";
+		actions.renames["INDEX"] = "index";
+		//actions.renames["GRAVITY"] = "current_gravity";
+		actions.renames["EMISSION_TRANSFORM"] = "FRAME.emission_transform";
+		actions.renames["RANDOM_SEED"] = "FRAME.random_seed";
+		actions.renames["FLAG_EMIT_POSITION"] = "EMISSION_FLAG_HAS_POSITION";
+		actions.renames["FLAG_EMIT_ROT_SCALE"] = "EMISSION_FLAG_HAS_ROTATION_SCALE";
+		actions.renames["FLAG_EMIT_VELOCITY"] = "EMISSION_FLAG_HAS_VELOCITY";
+		actions.renames["FLAG_EMIT_COLOR"] = "EMISSION_FLAG_HAS_COLOR";
+		actions.renames["FLAG_EMIT_CUSTOM"] = "EMISSION_FLAG_HAS_CUSTOM";
+		actions.renames["RESTART_POSITION"] = "restart_position";
+		actions.renames["RESTART_ROT_SCALE"] = "restart_rotation_scale";
+		actions.renames["RESTART_VELOCITY"] = "restart_velocity";
+		actions.renames["RESTART_COLOR"] = "restart_color";
+		actions.renames["RESTART_CUSTOM"] = "restart_custom";
+		actions.renames["emit_subparticle"] = "emit_subparticle";
+		actions.renames["COLLIDED"] = "collided";
+		actions.renames["COLLISION_NORMAL"] = "collision_normal";
+		actions.renames["COLLISION_DEPTH"] = "collision_depth";
+		actions.renames["ATTRACTOR_FORCE"] = "attractor_force";
+
+		actions.render_mode_defines["disable_force"] = "#define DISABLE_FORCE\n";
+		actions.render_mode_defines["disable_velocity"] = "#define DISABLE_VELOCITY\n";
+		actions.render_mode_defines["keep_data"] = "#define ENABLE_KEEP_DATA\n";
+		actions.render_mode_defines["collision_use_scale"] = "#define USE_COLLISON_SCALE\n";
+
+		actions.sampler_array_name = "material_samplers";
+		actions.base_texture_binding_index = 1;
+		actions.texture_layout_set = 3;
+		actions.base_uniform_string = "material.";
+		actions.base_varying_index = 10;
+
+		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
+		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
+		actions.global_buffer_array_variable = "global_variables.data";
+
+		particles_shader.compiler.initialize(actions);
+		*/
+	}
+
+	{
+		// Setup Sky compiler
+		ShaderCompiler::DefaultIdentifierActions actions;
+
+		actions.renames["COLOR"] = "color";
+		actions.renames["ALPHA"] = "alpha";
+		actions.renames["EYEDIR"] = "cube_normal";
+		actions.renames["POSITION"] = "params.position_multiplier.xyz";
+		actions.renames["SKY_COORDS"] = "panorama_coords";
+		actions.renames["SCREEN_UV"] = "uv";
+		actions.renames["TIME"] = "params.time";
+		actions.renames["PI"] = _MKSTR(Math_PI);
+		actions.renames["TAU"] = _MKSTR(Math_TAU);
+		actions.renames["E"] = _MKSTR(Math_E);
+		actions.renames["HALF_RES_COLOR"] = "half_res_color";
+		actions.renames["QUARTER_RES_COLOR"] = "quarter_res_color";
+		actions.renames["RADIANCE"] = "radiance";
+		actions.renames["FOG"] = "custom_fog";
+		actions.renames["LIGHT0_ENABLED"] = "directional_lights.data[0].enabled";
+		actions.renames["LIGHT0_DIRECTION"] = "directional_lights.data[0].direction_energy.xyz";
+		actions.renames["LIGHT0_ENERGY"] = "directional_lights.data[0].direction_energy.w";
+		actions.renames["LIGHT0_COLOR"] = "directional_lights.data[0].color_size.xyz";
+		actions.renames["LIGHT0_SIZE"] = "directional_lights.data[0].color_size.w";
+		actions.renames["LIGHT1_ENABLED"] = "directional_lights.data[1].enabled";
+		actions.renames["LIGHT1_DIRECTION"] = "directional_lights.data[1].direction_energy.xyz";
+		actions.renames["LIGHT1_ENERGY"] = "directional_lights.data[1].direction_energy.w";
+		actions.renames["LIGHT1_COLOR"] = "directional_lights.data[1].color_size.xyz";
+		actions.renames["LIGHT1_SIZE"] = "directional_lights.data[1].color_size.w";
+		actions.renames["LIGHT2_ENABLED"] = "directional_lights.data[2].enabled";
+		actions.renames["LIGHT2_DIRECTION"] = "directional_lights.data[2].direction_energy.xyz";
+		actions.renames["LIGHT2_ENERGY"] = "directional_lights.data[2].direction_energy.w";
+		actions.renames["LIGHT2_COLOR"] = "directional_lights.data[2].color_size.xyz";
+		actions.renames["LIGHT2_SIZE"] = "directional_lights.data[2].color_size.w";
+		actions.renames["LIGHT3_ENABLED"] = "directional_lights.data[3].enabled";
+		actions.renames["LIGHT3_DIRECTION"] = "directional_lights.data[3].direction_energy.xyz";
+		actions.renames["LIGHT3_ENERGY"] = "directional_lights.data[3].direction_energy.w";
+		actions.renames["LIGHT3_COLOR"] = "directional_lights.data[3].color_size.xyz";
+		actions.renames["LIGHT3_SIZE"] = "directional_lights.data[3].color_size.w";
+		actions.renames["AT_CUBEMAP_PASS"] = "AT_CUBEMAP_PASS";
+		actions.renames["AT_HALF_RES_PASS"] = "AT_HALF_RES_PASS";
+		actions.renames["AT_QUARTER_RES_PASS"] = "AT_QUARTER_RES_PASS";
+		actions.custom_samplers["RADIANCE"] = "material_samplers[3]";
+		actions.usage_defines["HALF_RES_COLOR"] = "\n#define USES_HALF_RES_COLOR\n";
+		actions.usage_defines["QUARTER_RES_COLOR"] = "\n#define USES_QUARTER_RES_COLOR\n";
+		actions.render_mode_defines["disable_fog"] = "#define DISABLE_FOG\n";
+
+		actions.sampler_array_name = "material_samplers";
+		actions.base_texture_binding_index = 1;
+		actions.texture_layout_set = 1;
+		actions.base_uniform_string = "material.";
+		actions.base_varying_index = 10;
+
+		actions.default_filter = ShaderLanguage::FILTER_LINEAR_MIPMAP;
+		actions.default_repeat = ShaderLanguage::REPEAT_ENABLE;
+		actions.global_buffer_array_variable = "global_variables";
+
+		shaders.compiler_sky.initialize(actions);
+	}
+
+	//shaders.copy.initialize();
+	//shaders.copy_version = shaders.copy.version_create(); //TODO
+	//shaders.copy.version_bind_shader(shaders.copy_version, CopyShaderGLES3::MODE_COPY_SECTION);
 	//shaders.cubemap_filter.init();
 	//bool ggx_hq = GLOBAL_GET("rendering/quality/reflections/high_quality_ggx");
 	//shaders.cubemap_filter.set_conditional(CubemapFilterShaderGLES3::LOW_QUALITY, !ggx_hq);
 }
 
 MaterialStorage::~MaterialStorage() {
-	shaders.copy.version_free(shaders.copy_version);
+	//shaders.copy.version_free(shaders.copy_version);
+
+	memdelete_arr(global_variables.buffer_values);
+	memdelete_arr(global_variables.buffer_usage);
+	memdelete_arr(global_variables.buffer_dirty_regions);
+	glDeleteBuffers(1, &global_variables.buffer);
 
 	singleton = nullptr;
 }
 
 /* GLOBAL VARIABLE API */
 
+int32_t MaterialStorage::_global_variable_allocate(uint32_t p_elements) {
+	int32_t idx = 0;
+	while (idx + p_elements <= global_variables.buffer_size) {
+		if (global_variables.buffer_usage[idx].elements == 0) {
+			bool valid = true;
+			for (uint32_t i = 1; i < p_elements; i++) {
+				if (global_variables.buffer_usage[idx + i].elements > 0) {
+					valid = false;
+					idx += i + global_variables.buffer_usage[idx + i].elements;
+					break;
+				}
+			}
+
+			if (!valid) {
+				continue; //if not valid, idx is in new position
+			}
+
+			return idx;
+		} else {
+			idx += global_variables.buffer_usage[idx].elements;
+		}
+	}
+
+	return -1;
+}
+
+void MaterialStorage::_global_variable_store_in_buffer(int32_t p_index, RS::GlobalVariableType p_type, const Variant &p_value) {
+	switch (p_type) {
+		case RS::GLOBAL_VAR_TYPE_BOOL: {
+			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			bool b = p_value;
+			bv.x = b ? 1.0 : 0.0;
+			bv.y = 0.0;
+			bv.z = 0.0;
+			bv.w = 0.0;
+
+		} break;
+		case RS::GLOBAL_VAR_TYPE_BVEC2: {
+			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			uint32_t bvec = p_value;
+			bv.x = (bvec & 1) ? 1.0 : 0.0;
+			bv.y = (bvec & 2) ? 1.0 : 0.0;
+			bv.z = 0.0;
+			bv.w = 0.0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_BVEC3: {
+			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			uint32_t bvec = p_value;
+			bv.x = (bvec & 1) ? 1.0 : 0.0;
+			bv.y = (bvec & 2) ? 1.0 : 0.0;
+			bv.z = (bvec & 4) ? 1.0 : 0.0;
+			bv.w = 0.0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_BVEC4: {
+			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			uint32_t bvec = p_value;
+			bv.x = (bvec & 1) ? 1.0 : 0.0;
+			bv.y = (bvec & 2) ? 1.0 : 0.0;
+			bv.z = (bvec & 4) ? 1.0 : 0.0;
+			bv.w = (bvec & 8) ? 1.0 : 0.0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_INT: {
+			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			int32_t v = p_value;
+			bv.x = v;
+			bv.y = 0;
+			bv.z = 0;
+			bv.w = 0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_IVEC2: {
+			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			Vector2i v = p_value;
+			bv.x = v.x;
+			bv.y = v.y;
+			bv.z = 0;
+			bv.w = 0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_IVEC3: {
+			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			Vector3i v = p_value;
+			bv.x = v.x;
+			bv.y = v.y;
+			bv.z = v.z;
+			bv.w = 0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_IVEC4: {
+			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			Vector<int32_t> v = p_value;
+			bv.x = v.size() >= 1 ? v[0] : 0;
+			bv.y = v.size() >= 2 ? v[1] : 0;
+			bv.z = v.size() >= 3 ? v[2] : 0;
+			bv.w = v.size() >= 4 ? v[3] : 0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_RECT2I: {
+			GlobalVariables::ValueInt &bv = *(GlobalVariables::ValueInt *)&global_variables.buffer_values[p_index];
+			Rect2i v = p_value;
+			bv.x = v.position.x;
+			bv.y = v.position.y;
+			bv.z = v.size.x;
+			bv.w = v.size.y;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_UINT: {
+			GlobalVariables::ValueUInt &bv = *(GlobalVariables::ValueUInt *)&global_variables.buffer_values[p_index];
+			uint32_t v = p_value;
+			bv.x = v;
+			bv.y = 0;
+			bv.z = 0;
+			bv.w = 0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_UVEC2: {
+			GlobalVariables::ValueUInt &bv = *(GlobalVariables::ValueUInt *)&global_variables.buffer_values[p_index];
+			Vector2i v = p_value;
+			bv.x = v.x;
+			bv.y = v.y;
+			bv.z = 0;
+			bv.w = 0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_UVEC3: {
+			GlobalVariables::ValueUInt &bv = *(GlobalVariables::ValueUInt *)&global_variables.buffer_values[p_index];
+			Vector3i v = p_value;
+			bv.x = v.x;
+			bv.y = v.y;
+			bv.z = v.z;
+			bv.w = 0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_UVEC4: {
+			GlobalVariables::ValueUInt &bv = *(GlobalVariables::ValueUInt *)&global_variables.buffer_values[p_index];
+			Vector<int32_t> v = p_value;
+			bv.x = v.size() >= 1 ? v[0] : 0;
+			bv.y = v.size() >= 2 ? v[1] : 0;
+			bv.z = v.size() >= 3 ? v[2] : 0;
+			bv.w = v.size() >= 4 ? v[3] : 0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_FLOAT: {
+			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			float v = p_value;
+			bv.x = v;
+			bv.y = 0;
+			bv.z = 0;
+			bv.w = 0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_VEC2: {
+			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			Vector2 v = p_value;
+			bv.x = v.x;
+			bv.y = v.y;
+			bv.z = 0;
+			bv.w = 0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_VEC3: {
+			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			Vector3 v = p_value;
+			bv.x = v.x;
+			bv.y = v.y;
+			bv.z = v.z;
+			bv.w = 0;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_VEC4: {
+			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			Plane v = p_value;
+			bv.x = v.normal.x;
+			bv.y = v.normal.y;
+			bv.z = v.normal.z;
+			bv.w = v.d;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_COLOR: {
+			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			Color v = p_value;
+			bv.x = v.r;
+			bv.y = v.g;
+			bv.z = v.b;
+			bv.w = v.a;
+
+			GlobalVariables::Value &bv_linear = global_variables.buffer_values[p_index + 1];
+			v = v.srgb_to_linear();
+			bv_linear.x = v.r;
+			bv_linear.y = v.g;
+			bv_linear.z = v.b;
+			bv_linear.w = v.a;
+
+		} break;
+		case RS::GLOBAL_VAR_TYPE_RECT2: {
+			GlobalVariables::Value &bv = global_variables.buffer_values[p_index];
+			Rect2 v = p_value;
+			bv.x = v.position.x;
+			bv.y = v.position.y;
+			bv.z = v.size.x;
+			bv.w = v.size.y;
+		} break;
+		case RS::GLOBAL_VAR_TYPE_MAT2: {
+			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			Vector<float> m2 = p_value;
+			if (m2.size() < 4) {
+				m2.resize(4);
+			}
+			bv[0].x = m2[0];
+			bv[0].y = m2[1];
+			bv[0].z = 0;
+			bv[0].w = 0;
+
+			bv[1].x = m2[2];
+			bv[1].y = m2[3];
+			bv[1].z = 0;
+			bv[1].w = 0;
+
+		} break;
+		case RS::GLOBAL_VAR_TYPE_MAT3: {
+			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			Basis v = p_value;
+			bv[0].x = v.elements[0][0];
+			bv[0].y = v.elements[1][0];
+			bv[0].z = v.elements[2][0];
+			bv[0].w = 0;
+
+			bv[1].x = v.elements[0][1];
+			bv[1].y = v.elements[1][1];
+			bv[1].z = v.elements[2][1];
+			bv[1].w = 0;
+
+			bv[2].x = v.elements[0][2];
+			bv[2].y = v.elements[1][2];
+			bv[2].z = v.elements[2][2];
+			bv[2].w = 0;
+
+		} break;
+		case RS::GLOBAL_VAR_TYPE_MAT4: {
+			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+
+			Vector<float> m2 = p_value;
+			if (m2.size() < 16) {
+				m2.resize(16);
+			}
+
+			bv[0].x = m2[0];
+			bv[0].y = m2[1];
+			bv[0].z = m2[2];
+			bv[0].w = m2[3];
+
+			bv[1].x = m2[4];
+			bv[1].y = m2[5];
+			bv[1].z = m2[6];
+			bv[1].w = m2[7];
+
+			bv[2].x = m2[8];
+			bv[2].y = m2[9];
+			bv[2].z = m2[10];
+			bv[2].w = m2[11];
+
+			bv[3].x = m2[12];
+			bv[3].y = m2[13];
+			bv[3].z = m2[14];
+			bv[3].w = m2[15];
+
+		} break;
+		case RS::GLOBAL_VAR_TYPE_TRANSFORM_2D: {
+			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			Transform2D v = p_value;
+			bv[0].x = v.elements[0][0];
+			bv[0].y = v.elements[0][1];
+			bv[0].z = 0;
+			bv[0].w = 0;
+
+			bv[1].x = v.elements[1][0];
+			bv[1].y = v.elements[1][1];
+			bv[1].z = 0;
+			bv[1].w = 0;
+
+			bv[2].x = v.elements[2][0];
+			bv[2].y = v.elements[2][1];
+			bv[2].z = 1;
+			bv[2].w = 0;
+
+		} break;
+		case RS::GLOBAL_VAR_TYPE_TRANSFORM: {
+			GlobalVariables::Value *bv = &global_variables.buffer_values[p_index];
+			Transform3D v = p_value;
+			bv[0].x = v.basis.elements[0][0];
+			bv[0].y = v.basis.elements[1][0];
+			bv[0].z = v.basis.elements[2][0];
+			bv[0].w = 0;
+
+			bv[1].x = v.basis.elements[0][1];
+			bv[1].y = v.basis.elements[1][1];
+			bv[1].z = v.basis.elements[2][1];
+			bv[1].w = 0;
+
+			bv[2].x = v.basis.elements[0][2];
+			bv[2].y = v.basis.elements[1][2];
+			bv[2].z = v.basis.elements[2][2];
+			bv[2].w = 0;
+
+			bv[3].x = v.origin.x;
+			bv[3].y = v.origin.y;
+			bv[3].z = v.origin.z;
+			bv[3].w = 1;
+
+		} break;
+		default: {
+			ERR_FAIL();
+		}
+	}
+}
+
+void MaterialStorage::_global_variable_mark_buffer_dirty(int32_t p_index, int32_t p_elements) {
+	int32_t prev_chunk = -1;
+
+	for (int32_t i = 0; i < p_elements; i++) {
+		int32_t chunk = (p_index + i) / GlobalVariables::BUFFER_DIRTY_REGION_SIZE;
+		if (chunk != prev_chunk) {
+			if (!global_variables.buffer_dirty_regions[chunk]) {
+				global_variables.buffer_dirty_regions[chunk] = true;
+				global_variables.buffer_dirty_region_count++;
+			}
+		}
+
+		prev_chunk = chunk;
+	}
+}
+
 void MaterialStorage::global_variable_add(const StringName &p_name, RS::GlobalVariableType p_type, const Variant &p_value) {
+	ERR_FAIL_COND(global_variables.variables.has(p_name));
+	GlobalVariables::Variable gv;
+	gv.type = p_type;
+	gv.value = p_value;
+	gv.buffer_index = -1;
+
+	if (p_type >= RS::GLOBAL_VAR_TYPE_SAMPLER2D) {
+		//is texture
+		global_variables.must_update_texture_materials = true; //normally there are none
+	} else {
+		gv.buffer_elements = 1;
+		if (p_type == RS::GLOBAL_VAR_TYPE_COLOR || p_type == RS::GLOBAL_VAR_TYPE_MAT2) {
+			//color needs to elements to store srgb and linear
+			gv.buffer_elements = 2;
+		}
+		if (p_type == RS::GLOBAL_VAR_TYPE_MAT3 || p_type == RS::GLOBAL_VAR_TYPE_TRANSFORM_2D) {
+			//color needs to elements to store srgb and linear
+			gv.buffer_elements = 3;
+		}
+		if (p_type == RS::GLOBAL_VAR_TYPE_MAT4 || p_type == RS::GLOBAL_VAR_TYPE_TRANSFORM) {
+			//color needs to elements to store srgb and linear
+			gv.buffer_elements = 4;
+		}
+
+		//is vector, allocate in buffer and update index
+		gv.buffer_index = _global_variable_allocate(gv.buffer_elements);
+		ERR_FAIL_COND_MSG(gv.buffer_index < 0, vformat("Failed allocating global variable '%s' out of buffer memory. Consider increasing it in the Project Settings.", String(p_name)));
+		global_variables.buffer_usage[gv.buffer_index].elements = gv.buffer_elements;
+		_global_variable_store_in_buffer(gv.buffer_index, gv.type, gv.value);
+		_global_variable_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
+
+		global_variables.must_update_buffer_materials = true; //normally there are none
+	}
+
+	global_variables.variables[p_name] = gv;
 }
 
 void MaterialStorage::global_variable_remove(const StringName &p_name) {
+	if (!global_variables.variables.has(p_name)) {
+		return;
+	}
+	GlobalVariables::Variable &gv = global_variables.variables[p_name];
+
+	if (gv.buffer_index >= 0) {
+		global_variables.buffer_usage[gv.buffer_index].elements = 0;
+		global_variables.must_update_buffer_materials = true;
+	} else {
+		global_variables.must_update_texture_materials = true;
+	}
+
+	global_variables.variables.erase(p_name);
 }
 
 Vector<StringName> MaterialStorage::global_variable_get_list() const {
-	return Vector<StringName>();
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		ERR_FAIL_V_MSG(Vector<StringName>(), "This function should never be used outside the editor, it can severely damage performance.");
+	}
+
+	const StringName *K = nullptr;
+	Vector<StringName> names;
+	while ((K = global_variables.variables.next(K))) {
+		names.push_back(*K);
+	}
+	names.sort_custom<StringName::AlphCompare>();
+	return names;
 }
 
 void MaterialStorage::global_variable_set(const StringName &p_name, const Variant &p_value) {
+	ERR_FAIL_COND(!global_variables.variables.has(p_name));
+	GlobalVariables::Variable &gv = global_variables.variables[p_name];
+	gv.value = p_value;
+	if (gv.override.get_type() == Variant::NIL) {
+		if (gv.buffer_index >= 0) {
+			//buffer
+			_global_variable_store_in_buffer(gv.buffer_index, gv.type, gv.value);
+			_global_variable_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
+		} else {
+			//texture
+			MaterialStorage *material_storage = MaterialStorage::get_singleton();
+			for (Set<RID>::Element *E = gv.texture_materials.front(); E; E = E->next()) {
+				Material *material = material_storage->get_material(E->get());
+				ERR_CONTINUE(!material);
+				material_storage->_material_queue_update(material, false, true);
+			}
+		}
+	}
 }
 
 void MaterialStorage::global_variable_set_override(const StringName &p_name, const Variant &p_value) {
+	if (!global_variables.variables.has(p_name)) {
+		return; //variable may not exist
+	}
+
+	ERR_FAIL_COND(p_value.get_type() == Variant::OBJECT);
+
+	GlobalVariables::Variable &gv = global_variables.variables[p_name];
+
+	gv.override = p_value;
+
+	if (gv.buffer_index >= 0) {
+		//buffer
+		if (gv.override.get_type() == Variant::NIL) {
+			_global_variable_store_in_buffer(gv.buffer_index, gv.type, gv.value);
+		} else {
+			_global_variable_store_in_buffer(gv.buffer_index, gv.type, gv.override);
+		}
+
+		_global_variable_mark_buffer_dirty(gv.buffer_index, gv.buffer_elements);
+	} else {
+		//texture
+		MaterialStorage *material_storage = MaterialStorage::get_singleton();
+		for (Set<RID>::Element *E = gv.texture_materials.front(); E; E = E->next()) {
+			Material *material = material_storage->get_material(E->get());
+			ERR_CONTINUE(!material);
+			material_storage->_material_queue_update(material, false, true);
+		}
+	}
 }
 
 Variant MaterialStorage::global_variable_get(const StringName &p_name) const {
-	return Variant();
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		ERR_FAIL_V_MSG(Variant(), "This function should never be used outside the editor, it can severely damage performance.");
+	}
+
+	if (!global_variables.variables.has(p_name)) {
+		return Variant();
+	}
+
+	return global_variables.variables[p_name].value;
+}
+
+RS::GlobalVariableType MaterialStorage::global_variable_get_type_internal(const StringName &p_name) const {
+	if (!global_variables.variables.has(p_name)) {
+		return RS::GLOBAL_VAR_TYPE_MAX;
+	}
+
+	return global_variables.variables[p_name].type;
 }
 
 RS::GlobalVariableType MaterialStorage::global_variable_get_type(const StringName &p_name) const {
-	return RS::GLOBAL_VAR_TYPE_MAX;
+	if (!Engine::get_singleton()->is_editor_hint()) {
+		ERR_FAIL_V_MSG(RS::GLOBAL_VAR_TYPE_MAX, "This function should never be used outside the editor, it can severely damage performance.");
+	}
+
+	return global_variable_get_type_internal(p_name);
 }
 
 void MaterialStorage::global_variables_load_settings(bool p_load_textures) {
+	List<PropertyInfo> settings;
+	ProjectSettings::get_singleton()->get_property_list(&settings);
+
+	for (const PropertyInfo &E : settings) {
+		if (E.name.begins_with("shader_globals/")) {
+			StringName name = E.name.get_slice("/", 1);
+			Dictionary d = ProjectSettings::get_singleton()->get(E.name);
+
+			ERR_CONTINUE(!d.has("type"));
+			ERR_CONTINUE(!d.has("value"));
+
+			String type = d["type"];
+
+			static const char *global_var_type_names[RS::GLOBAL_VAR_TYPE_MAX] = {
+				"bool",
+				"bvec2",
+				"bvec3",
+				"bvec4",
+				"int",
+				"ivec2",
+				"ivec3",
+				"ivec4",
+				"rect2i",
+				"uint",
+				"uvec2",
+				"uvec3",
+				"uvec4",
+				"float",
+				"vec2",
+				"vec3",
+				"vec4",
+				"color",
+				"rect2",
+				"mat2",
+				"mat3",
+				"mat4",
+				"transform_2d",
+				"transform",
+				"sampler2D",
+				"sampler2DArray",
+				"sampler3D",
+				"samplerCube",
+			};
+
+			RS::GlobalVariableType gvtype = RS::GLOBAL_VAR_TYPE_MAX;
+
+			for (int i = 0; i < RS::GLOBAL_VAR_TYPE_MAX; i++) {
+				if (global_var_type_names[i] == type) {
+					gvtype = RS::GlobalVariableType(i);
+					break;
+				}
+			}
+
+			ERR_CONTINUE(gvtype == RS::GLOBAL_VAR_TYPE_MAX); //type invalid
+
+			Variant value = d["value"];
+
+			if (gvtype >= RS::GLOBAL_VAR_TYPE_SAMPLER2D) {
+				//textire
+				if (!p_load_textures) {
+					value = RID();
+					continue;
+				}
+
+				String path = value;
+				RES resource = ResourceLoader::load(path);
+				ERR_CONTINUE(resource.is_null());
+				value = resource;
+			}
+
+			if (global_variables.variables.has(name)) {
+				//has it, update it
+				global_variable_set(name, value);
+			} else {
+				global_variable_add(name, gvtype, value);
+			}
+		}
+	}
 }
 
 void MaterialStorage::global_variables_clear() {
+	global_variables.variables.clear();
+}
+
+GLuint MaterialStorage::global_variables_get_uniform_buffer() const {
+	return global_variables.buffer;
 }
 
 int32_t MaterialStorage::global_variables_instance_allocate(RID p_instance) {
-	return 0;
+	ERR_FAIL_COND_V(global_variables.instance_buffer_pos.has(p_instance), -1);
+	int32_t pos = _global_variable_allocate(ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES);
+	global_variables.instance_buffer_pos[p_instance] = pos; //save anyway
+	ERR_FAIL_COND_V_MSG(pos < 0, -1, "Too many instances using shader instance variables. Increase buffer size in Project Settings.");
+	global_variables.buffer_usage[pos].elements = ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES;
+	return pos;
 }
 
 void MaterialStorage::global_variables_instance_free(RID p_instance) {
+	ERR_FAIL_COND(!global_variables.instance_buffer_pos.has(p_instance));
+	int32_t pos = global_variables.instance_buffer_pos[p_instance];
+	if (pos >= 0) {
+		global_variables.buffer_usage[pos].elements = 0;
+	}
+	global_variables.instance_buffer_pos.erase(p_instance);
 }
 
 void MaterialStorage::global_variables_instance_update(RID p_instance, int p_index, const Variant &p_value) {
+	if (!global_variables.instance_buffer_pos.has(p_instance)) {
+		return; //just not allocated, ignore
+	}
+	int32_t pos = global_variables.instance_buffer_pos[p_instance];
+
+	if (pos < 0) {
+		return; //again, not allocated, ignore
+	}
+	ERR_FAIL_INDEX(p_index, ShaderLanguage::MAX_INSTANCE_UNIFORM_INDICES);
+	ERR_FAIL_COND_MSG(p_value.get_type() > Variant::COLOR, "Unsupported variant type for instance parameter: " + Variant::get_type_name(p_value.get_type())); //anything greater not supported
+
+	ShaderLanguage::DataType datatype_from_value[Variant::COLOR + 1] = {
+		ShaderLanguage::TYPE_MAX, //nil
+		ShaderLanguage::TYPE_BOOL, //bool
+		ShaderLanguage::TYPE_INT, //int
+		ShaderLanguage::TYPE_FLOAT, //float
+		ShaderLanguage::TYPE_MAX, //string
+		ShaderLanguage::TYPE_VEC2, //vec2
+		ShaderLanguage::TYPE_IVEC2, //vec2i
+		ShaderLanguage::TYPE_VEC4, //rect2
+		ShaderLanguage::TYPE_IVEC4, //rect2i
+		ShaderLanguage::TYPE_VEC3, // vec3
+		ShaderLanguage::TYPE_IVEC3, //vec3i
+		ShaderLanguage::TYPE_MAX, //xform2d not supported here
+		ShaderLanguage::TYPE_VEC4, //plane
+		ShaderLanguage::TYPE_VEC4, //quat
+		ShaderLanguage::TYPE_MAX, //aabb not supported here
+		ShaderLanguage::TYPE_MAX, //basis not supported here
+		ShaderLanguage::TYPE_MAX, //xform not supported here
+		ShaderLanguage::TYPE_VEC4 //color
+	};
+
+	ShaderLanguage::DataType datatype = datatype_from_value[p_value.get_type()];
+
+	ERR_FAIL_COND_MSG(datatype == ShaderLanguage::TYPE_MAX, "Unsupported variant type for instance parameter: " + Variant::get_type_name(p_value.get_type())); //anything greater not supported
+
+	pos += p_index;
+
+	_fill_std140_variant_ubo_value(datatype, 0, p_value, (uint8_t *)&global_variables.buffer_values[pos], true); //instances always use linear color in this renderer
+	_global_variable_mark_buffer_dirty(pos, 1);
+}
+
+void MaterialStorage::_update_global_variables() {
+	MaterialStorage *material_storage = MaterialStorage::get_singleton();
+	if (global_variables.buffer_dirty_region_count > 0) {
+		uint32_t total_regions = global_variables.buffer_size / GlobalVariables::BUFFER_DIRTY_REGION_SIZE;
+		if (total_regions / global_variables.buffer_dirty_region_count <= 4) {
+			// 25% of regions dirty, just update all buffer
+			glBindBuffer(GL_UNIFORM_BUFFER, global_variables.buffer);
+			glBufferData(GL_UNIFORM_BUFFER, sizeof(GlobalVariables::Value) * global_variables.buffer_size, global_variables.buffer_values, GL_DYNAMIC_DRAW);
+			glBindBuffer(GL_UNIFORM_BUFFER, 0);
+			memset(global_variables.buffer_dirty_regions, 0, sizeof(bool) * total_regions);
+		} else {
+			uint32_t region_byte_size = sizeof(GlobalVariables::Value) * GlobalVariables::BUFFER_DIRTY_REGION_SIZE;
+			glBindBuffer(GL_UNIFORM_BUFFER, global_variables.buffer);
+			for (uint32_t i = 0; i < total_regions; i++) {
+				if (global_variables.buffer_dirty_regions[i]) {
+					glBufferSubData(GL_UNIFORM_BUFFER, i * region_byte_size, region_byte_size, &global_variables.buffer_values[i * GlobalVariables::BUFFER_DIRTY_REGION_SIZE]);
+					global_variables.buffer_dirty_regions[i] = false;
+				}
+			}
+			glBindBuffer(GL_UNIFORM_BUFFER, 0);
+		}
+
+		global_variables.buffer_dirty_region_count = 0;
+	}
+
+	if (global_variables.must_update_buffer_materials) {
+		// only happens in the case of a buffer variable added or removed,
+		// so not often.
+		for (const RID &E : global_variables.materials_using_buffer) {
+			Material *material = material_storage->get_material(E);
+			ERR_CONTINUE(!material); //wtf
+
+			material_storage->_material_queue_update(material, true, false);
+		}
+
+		global_variables.must_update_buffer_materials = false;
+	}
+
+	if (global_variables.must_update_texture_materials) {
+		// only happens in the case of a buffer variable added or removed,
+		// so not often.
+		for (const RID &E : global_variables.materials_using_texture) {
+			Material *material = material_storage->get_material(E);
+			ERR_CONTINUE(!material); //wtf
+
+			material_storage->_material_queue_update(material, false, true);
+		}
+
+		global_variables.must_update_texture_materials = false;
+	}
 }
 
 /* SHADER API */
 
-void MaterialStorage::_shader_make_dirty(GLES3::Shader *p_shader) {
-	if (p_shader->dirty_list.in_list()) {
-		return;
-	}
-
-	_shader_dirty_list.add(&p_shader->dirty_list);
-}
-
 RID MaterialStorage::shader_allocate() {
-	GLES3::Shader *shader = memnew(GLES3::Shader);
-	shader->mode = RS::SHADER_CANVAS_ITEM;
-	//shader->shader = &scene->state.scene_shader;
-	RID rid = shader_owner.make_rid(shader);
-	_shader_make_dirty(shader);
-	shader->self = rid;
-
-	return rid;
+	return shader_owner.allocate_rid();
 }
 
 void MaterialStorage::shader_initialize(RID p_rid) {
-	// noop
+	Shader shader;
+	shader.data = nullptr;
+	shader.mode = RS::SHADER_MAX;
+
+	shader_owner.initialize_rid(p_rid, shader);
 }
-
-//RID MaterialStorage::shader_create() {
-//	GLES3::Shader *shader = memnew(GLES3::Shader);
-//	shader->mode = RS::SHADER_SPATIAL;
-//	shader->shader = &scene->state.scene_shader;
-//	RID rid = shader_owner.make_rid(shader);
-//	_shader_make_dirty(shader);
-//	shader->self = rid;
-
-//	return rid;
-//}
 
 void MaterialStorage::shader_free(RID p_rid) {
 	GLES3::Shader *shader = shader_owner.get_or_null(p_rid);
+	ERR_FAIL_COND(!shader);
 
-	if (shader->shader && shader->version.is_valid()) {
-		shader->shader->version_free(shader->version);
+	//make material unreference this
+	while (shader->owners.size()) {
+		material_set_shader(shader->owners.front()->get()->self, RID());
 	}
 
-	if (shader->dirty_list.in_list()) {
-		_shader_dirty_list.remove(&shader->dirty_list);
+	//clear data if exists
+	if (shader->data) {
+		memdelete(shader->data);
 	}
-
-	while (shader->materials.first()) {
-		GLES3::Material *m = shader->materials.first()->self();
-
-		m->shader = nullptr;
-		_material_make_dirty(m);
-
-		shader->materials.remove(shader->materials.first());
-	}
-
 	shader_owner.free(p_rid);
-	memdelete(shader);
 }
 
 void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
@@ -170,545 +2371,234 @@ void MaterialStorage::shader_set_code(RID p_shader, const String &p_code) {
 	shader->code = p_code;
 
 	String mode_string = ShaderLanguage::get_shader_type(p_code);
-	RS::ShaderMode mode;
 
+	RS::ShaderMode new_mode;
 	if (mode_string == "canvas_item") {
-		mode = RS::SHADER_CANVAS_ITEM;
-	} else if (mode_string == "particles") {
-		mode = RS::SHADER_PARTICLES;
-	} else if (mode_string == "sky") {
-		mode = RS::SHADER_SKY;
+		new_mode = RS::SHADER_CANVAS_ITEM;
+		//} else if (mode_string == "particles") {
+		//	new_mode = RS::SHADER_PARTICLES;
 	} else if (mode_string == "spatial") {
-		mode = RS::SHADER_SPATIAL;
+		new_mode = RS::SHADER_SPATIAL;
+	} else if (mode_string == "sky") {
+		new_mode = RS::SHADER_SKY;
+		//} else if (mode_string == "fog") {
+		//	new_mode = RS::SHADER_FOG;
 	} else {
-		mode = RS::SHADER_MAX;
+		new_mode = RS::SHADER_MAX;
 		ERR_PRINT("shader type " + mode_string + " not supported in OpenGL renderer");
 	}
 
-	if (shader->version.is_valid() && mode != shader->mode) {
-		shader->shader->version_free(shader->version);
-		shader->version = RID();
+	if (new_mode != shader->mode) {
+		if (shader->data) {
+			memdelete(shader->data);
+			shader->data = nullptr;
+		}
+
+		for (Set<Material *>::Element *E = shader->owners.front(); E; E = E->next()) {
+			Material *material = E->get();
+			material->shader_mode = new_mode;
+			if (material->data) {
+				memdelete(material->data);
+				material->data = nullptr;
+			}
+		}
+
+		shader->mode = new_mode;
+
+		if (new_mode < RS::SHADER_MAX && shader_data_request_func[new_mode]) {
+			shader->data = shader_data_request_func[new_mode]();
+		} else {
+			shader->mode = RS::SHADER_MAX; //invalid
+		}
+
+		for (Set<Material *>::Element *E = shader->owners.front(); E; E = E->next()) {
+			Material *material = E->get();
+			if (shader->data) {
+				material->data = material_data_request_func[new_mode](shader->data);
+				material->data->self = material->self;
+				material->data->set_next_pass(material->next_pass);
+				material->data->set_render_priority(material->priority);
+			}
+			material->shader_mode = new_mode;
+		}
+
+		if (shader->data) {
+			for (const KeyValue<StringName, Map<int, RID>> &E : shader->default_texture_parameter) {
+				for (const KeyValue<int, RID> &E2 : E.value) {
+					shader->data->set_default_texture_param(E.key, E2.value, E2.key);
+				}
+			}
+		}
 	}
 
-	shader->mode = mode;
-
-	// TODO handle all shader types
-	if (mode == RS::SHADER_CANVAS_ITEM) {
-		shader->shader = &RasterizerCanvasGLES3::get_singleton()->state.canvas_shader;
-	} else if (mode == RS::SHADER_SPATIAL) {
-		//shader->shader = &scene->state.scene_shader;
-	} else if (mode == RS::SHADER_PARTICLES) {
-	} else if (mode == RS::SHADER_SKY) {
-	} else {
-		return;
+	if (shader->data) {
+		shader->data->set_code(p_code);
 	}
 
-	if (shader->version.is_null() && shader->shader) {
-		shader->version = shader->shader->version_create();
+	for (Set<Material *>::Element *E = shader->owners.front(); E; E = E->next()) {
+		Material *material = E->get();
+		material->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MATERIAL);
+		_material_queue_update(material, true, true);
 	}
-
-	_shader_make_dirty(shader);
 }
 
 String MaterialStorage::shader_get_code(RID p_shader) const {
 	const GLES3::Shader *shader = shader_owner.get_or_null(p_shader);
-	ERR_FAIL_COND_V(!shader, "");
-
+	ERR_FAIL_COND_V(!shader, String());
 	return shader->code;
 }
 
 void MaterialStorage::shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const {
 	GLES3::Shader *shader = shader_owner.get_or_null(p_shader);
 	ERR_FAIL_COND(!shader);
-
-	if (shader->dirty_list.in_list()) {
-		_update_shader(shader);
-	}
-
-	Map<int, StringName> order;
-
-	for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = shader->uniforms.front(); E; E = E->next()) {
-		if (E->get().texture_order >= 0) {
-			order[E->get().texture_order + 100000] = E->key();
-		} else {
-			order[E->get().order] = E->key();
-		}
-	}
-
-	for (Map<int, StringName>::Element *E = order.front(); E; E = E->next()) {
-		PropertyInfo pi;
-		ShaderLanguage::ShaderNode::Uniform &u = shader->uniforms[E->get()];
-
-		pi.name = E->get();
-
-		switch (u.type) {
-			case ShaderLanguage::TYPE_VOID: {
-				pi.type = Variant::NIL;
-			} break;
-
-			case ShaderLanguage::TYPE_BOOL: {
-				pi.type = Variant::BOOL;
-			} break;
-
-			// bool vectors
-			case ShaderLanguage::TYPE_BVEC2: {
-				pi.type = Variant::INT;
-				pi.hint = PROPERTY_HINT_FLAGS;
-				pi.hint_string = "x,y";
-			} break;
-			case ShaderLanguage::TYPE_BVEC3: {
-				pi.type = Variant::INT;
-				pi.hint = PROPERTY_HINT_FLAGS;
-				pi.hint_string = "x,y,z";
-			} break;
-			case ShaderLanguage::TYPE_BVEC4: {
-				pi.type = Variant::INT;
-				pi.hint = PROPERTY_HINT_FLAGS;
-				pi.hint_string = "x,y,z,w";
-			} break;
-
-				// int stuff
-			case ShaderLanguage::TYPE_UINT:
-			case ShaderLanguage::TYPE_INT: {
-				pi.type = Variant::INT;
-
-				if (u.hint == ShaderLanguage::ShaderNode::Uniform::HINT_RANGE) {
-					pi.hint = PROPERTY_HINT_RANGE;
-					pi.hint_string = rtos(u.hint_range[0]) + "," + rtos(u.hint_range[1]) + "," + rtos(u.hint_range[2]);
-				}
-			} break;
-
-			case ShaderLanguage::TYPE_IVEC2:
-			case ShaderLanguage::TYPE_UVEC2:
-			case ShaderLanguage::TYPE_IVEC3:
-			case ShaderLanguage::TYPE_UVEC3:
-			case ShaderLanguage::TYPE_IVEC4:
-			case ShaderLanguage::TYPE_UVEC4: {
-				// not sure what this should be in godot 4
-				//				pi.type = Variant::POOL_INT_ARRAY;
-				pi.type = Variant::PACKED_INT32_ARRAY;
-			} break;
-
-			case ShaderLanguage::TYPE_FLOAT: {
-				pi.type = Variant::FLOAT;
-				if (u.hint == ShaderLanguage::ShaderNode::Uniform::HINT_RANGE) {
-					pi.hint = PROPERTY_HINT_RANGE;
-					pi.hint_string = rtos(u.hint_range[0]) + "," + rtos(u.hint_range[1]) + "," + rtos(u.hint_range[2]);
-				}
-			} break;
-
-			case ShaderLanguage::TYPE_VEC2: {
-				pi.type = Variant::VECTOR2;
-			} break;
-			case ShaderLanguage::TYPE_VEC3: {
-				pi.type = Variant::VECTOR3;
-			} break;
-
-			case ShaderLanguage::TYPE_VEC4: {
-				if (u.hint == ShaderLanguage::ShaderNode::Uniform::HINT_COLOR) {
-					pi.type = Variant::COLOR;
-				} else {
-					pi.type = Variant::QUATERNION;
-				}
-			} break;
-
-			case ShaderLanguage::TYPE_MAT2: {
-				pi.type = Variant::TRANSFORM2D;
-			} break;
-
-			case ShaderLanguage::TYPE_MAT3: {
-				pi.type = Variant::BASIS;
-			} break;
-
-			case ShaderLanguage::TYPE_MAT4: {
-				pi.type = Variant::TRANSFORM3D;
-			} break;
-
-			case ShaderLanguage::TYPE_SAMPLER2D:
-				//			case ShaderLanguage::TYPE_SAMPLEREXT:
-			case ShaderLanguage::TYPE_ISAMPLER2D:
-			case ShaderLanguage::TYPE_USAMPLER2D: {
-				pi.type = Variant::OBJECT;
-				pi.hint = PROPERTY_HINT_RESOURCE_TYPE;
-				pi.hint_string = "Texture";
-			} break;
-
-			case ShaderLanguage::TYPE_SAMPLERCUBE: {
-				pi.type = Variant::OBJECT;
-				pi.hint = PROPERTY_HINT_RESOURCE_TYPE;
-				pi.hint_string = "CubeMap";
-			} break;
-
-			case ShaderLanguage::TYPE_SAMPLER2DARRAY:
-			case ShaderLanguage::TYPE_ISAMPLER2DARRAY:
-			case ShaderLanguage::TYPE_USAMPLER2DARRAY:
-			case ShaderLanguage::TYPE_SAMPLER3D:
-			case ShaderLanguage::TYPE_ISAMPLER3D:
-			case ShaderLanguage::TYPE_USAMPLER3D: {
-				// Not implemented in OpenGL
-			} break;
-				// new for godot 4
-			case ShaderLanguage::TYPE_SAMPLERCUBEARRAY:
-			case ShaderLanguage::TYPE_STRUCT:
-			case ShaderLanguage::TYPE_MAX: {
-			} break;
-		}
-
-		p_param_list->push_back(pi);
+	if (shader->data) {
+		return shader->data->get_param_list(p_param_list);
 	}
 }
 
 void MaterialStorage::shader_set_default_texture_param(RID p_shader, const StringName &p_name, RID p_texture, int p_index) {
 	GLES3::Shader *shader = shader_owner.get_or_null(p_shader);
 	ERR_FAIL_COND(!shader);
-	ERR_FAIL_COND(p_texture.is_valid() && !TextureStorage::get_singleton()->owns_texture(p_texture));
 
-	if (!p_texture.is_valid()) {
-		if (shader->default_textures.has(p_name) && shader->default_textures[p_name].has(p_index)) {
-			shader->default_textures[p_name].erase(p_index);
+	if (p_texture.is_valid() && TextureStorage::get_singleton()->owns_texture(p_texture)) {
+		if (!shader->default_texture_parameter.has(p_name)) {
+			shader->default_texture_parameter[p_name] = Map<int, RID>();
+		}
+		shader->default_texture_parameter[p_name][p_index] = p_texture;
+	} else {
+		if (shader->default_texture_parameter.has(p_name) && shader->default_texture_parameter[p_name].has(p_index)) {
+			shader->default_texture_parameter[p_name].erase(p_index);
 
-			if (shader->default_textures[p_name].is_empty()) {
-				shader->default_textures.erase(p_name);
+			if (shader->default_texture_parameter[p_name].is_empty()) {
+				shader->default_texture_parameter.erase(p_name);
 			}
 		}
-	} else {
-		if (!shader->default_textures.has(p_name)) {
-			shader->default_textures[p_name] = Map<int, RID>();
-		}
-		shader->default_textures[p_name][p_index] = p_texture;
 	}
-
-	_shader_make_dirty(shader);
+	if (shader->data) {
+		shader->data->set_default_texture_param(p_name, p_texture, p_index);
+	}
+	for (Set<Material *>::Element *E = shader->owners.front(); E; E = E->next()) {
+		Material *material = E->get();
+		_material_queue_update(material, false, true);
+	}
 }
 
 RID MaterialStorage::shader_get_default_texture_param(RID p_shader, const StringName &p_name, int p_index) const {
 	const GLES3::Shader *shader = shader_owner.get_or_null(p_shader);
 	ERR_FAIL_COND_V(!shader, RID());
-
-	if (shader->default_textures.has(p_name) && shader->default_textures[p_name].has(p_index)) {
-		return shader->default_textures[p_name][p_index];
+	if (shader->default_texture_parameter.has(p_name) && shader->default_texture_parameter[p_name].has(p_index)) {
+		return shader->default_texture_parameter[p_name][p_index];
 	}
 
 	return RID();
 }
 
-void MaterialStorage::_update_shader(GLES3::Shader *p_shader) const {
-	_shader_dirty_list.remove(&p_shader->dirty_list);
-
-	p_shader->valid = false;
-
-	p_shader->uniforms.clear();
-
-	if (p_shader->code.is_empty()) {
-		return; //just invalid, but no error
+Variant MaterialStorage::shader_get_param_default(RID p_shader, const StringName &p_param) const {
+	Shader *shader = shader_owner.get_or_null(p_shader);
+	ERR_FAIL_COND_V(!shader, Variant());
+	if (shader->data) {
+		return shader->data->get_default_parameter(p_param);
 	}
-
-	ShaderCompiler::GeneratedCode gen_code;
-	ShaderCompiler::IdentifierActions *actions = nullptr;
-
-	switch (p_shader->mode) {
-		case RS::SHADER_CANVAS_ITEM: {
-			p_shader->canvas_item.light_mode = GLES3::Shader::CanvasItem::LIGHT_MODE_NORMAL;
-			p_shader->canvas_item.blend_mode = GLES3::Shader::CanvasItem::BLEND_MODE_MIX;
-
-			p_shader->canvas_item.uses_screen_texture = false;
-			p_shader->canvas_item.uses_screen_uv = false;
-			p_shader->canvas_item.uses_time = false;
-			p_shader->canvas_item.uses_modulate = false;
-			p_shader->canvas_item.uses_color = false;
-			p_shader->canvas_item.uses_vertex = false;
-
-			p_shader->canvas_item.uses_model_matrix = false;
-			p_shader->canvas_item.uses_extra_matrix = false;
-			p_shader->canvas_item.uses_projection_matrix = false;
-			p_shader->canvas_item.uses_instance_custom = false;
-
-			shaders.actions_canvas.render_mode_values["blend_add"] = Pair<int *, int>(&p_shader->canvas_item.blend_mode, GLES3::Shader::CanvasItem::BLEND_MODE_ADD);
-			shaders.actions_canvas.render_mode_values["blend_mix"] = Pair<int *, int>(&p_shader->canvas_item.blend_mode, GLES3::Shader::CanvasItem::BLEND_MODE_MIX);
-			shaders.actions_canvas.render_mode_values["blend_sub"] = Pair<int *, int>(&p_shader->canvas_item.blend_mode, GLES3::Shader::CanvasItem::BLEND_MODE_SUB);
-			shaders.actions_canvas.render_mode_values["blend_mul"] = Pair<int *, int>(&p_shader->canvas_item.blend_mode, GLES3::Shader::CanvasItem::BLEND_MODE_MUL);
-			shaders.actions_canvas.render_mode_values["blend_premul_alpha"] = Pair<int *, int>(&p_shader->canvas_item.blend_mode, GLES3::Shader::CanvasItem::BLEND_MODE_PMALPHA);
-
-			shaders.actions_canvas.render_mode_values["unshaded"] = Pair<int *, int>(&p_shader->canvas_item.light_mode, GLES3::Shader::CanvasItem::LIGHT_MODE_UNSHADED);
-			shaders.actions_canvas.render_mode_values["light_only"] = Pair<int *, int>(&p_shader->canvas_item.light_mode, GLES3::Shader::CanvasItem::LIGHT_MODE_LIGHT_ONLY);
-
-			shaders.actions_canvas.usage_flag_pointers["SCREEN_UV"] = &p_shader->canvas_item.uses_screen_uv;
-			shaders.actions_canvas.usage_flag_pointers["SCREEN_PIXEL_SIZE"] = &p_shader->canvas_item.uses_screen_uv;
-			shaders.actions_canvas.usage_flag_pointers["SCREEN_TEXTURE"] = &p_shader->canvas_item.uses_screen_texture;
-			shaders.actions_canvas.usage_flag_pointers["TIME"] = &p_shader->canvas_item.uses_time;
-			shaders.actions_canvas.usage_flag_pointers["MODULATE"] = &p_shader->canvas_item.uses_modulate;
-			shaders.actions_canvas.usage_flag_pointers["COLOR"] = &p_shader->canvas_item.uses_color;
-
-			shaders.actions_canvas.usage_flag_pointers["VERTEX"] = &p_shader->canvas_item.uses_vertex;
-
-			shaders.actions_canvas.usage_flag_pointers["MODEL_MATRIX"] = &p_shader->canvas_item.uses_model_matrix;
-			shaders.actions_canvas.usage_flag_pointers["EXTRA_MATRIX"] = &p_shader->canvas_item.uses_extra_matrix;
-			shaders.actions_canvas.usage_flag_pointers["PROJECTION_MATRIX"] = &p_shader->canvas_item.uses_projection_matrix;
-			shaders.actions_canvas.usage_flag_pointers["INSTANCE_CUSTOM"] = &p_shader->canvas_item.uses_instance_custom;
-
-			actions = &shaders.actions_canvas;
-			actions->uniforms = &p_shader->uniforms;
-		} break;
-
-		case RS::SHADER_SPATIAL: {
-			// TODO remove once 3D is added back
-			return;
-			p_shader->spatial.blend_mode = GLES3::Shader::Spatial::BLEND_MODE_MIX;
-			p_shader->spatial.depth_draw_mode = GLES3::Shader::Spatial::DEPTH_DRAW_OPAQUE;
-			p_shader->spatial.cull_mode = GLES3::Shader::Spatial::CULL_MODE_BACK;
-			p_shader->spatial.uses_alpha = false;
-			p_shader->spatial.uses_alpha_scissor = false;
-			p_shader->spatial.uses_discard = false;
-			p_shader->spatial.unshaded = false;
-			p_shader->spatial.no_depth_test = false;
-			p_shader->spatial.uses_sss = false;
-			p_shader->spatial.uses_time = false;
-			p_shader->spatial.uses_vertex_lighting = false;
-			p_shader->spatial.uses_screen_texture = false;
-			p_shader->spatial.uses_depth_texture = false;
-			p_shader->spatial.uses_vertex = false;
-			p_shader->spatial.uses_tangent = false;
-			p_shader->spatial.uses_ensure_correct_normals = false;
-			p_shader->spatial.writes_modelview_or_projection = false;
-			p_shader->spatial.uses_world_coordinates = false;
-
-			shaders.actions_scene.render_mode_values["blend_add"] = Pair<int *, int>(&p_shader->spatial.blend_mode, GLES3::Shader::Spatial::BLEND_MODE_ADD);
-			shaders.actions_scene.render_mode_values["blend_mix"] = Pair<int *, int>(&p_shader->spatial.blend_mode, GLES3::Shader::Spatial::BLEND_MODE_MIX);
-			shaders.actions_scene.render_mode_values["blend_sub"] = Pair<int *, int>(&p_shader->spatial.blend_mode, GLES3::Shader::Spatial::BLEND_MODE_SUB);
-			shaders.actions_scene.render_mode_values["blend_mul"] = Pair<int *, int>(&p_shader->spatial.blend_mode, GLES3::Shader::Spatial::BLEND_MODE_MUL);
-
-			shaders.actions_scene.render_mode_values["depth_draw_opaque"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, GLES3::Shader::Spatial::DEPTH_DRAW_OPAQUE);
-			shaders.actions_scene.render_mode_values["depth_draw_always"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, GLES3::Shader::Spatial::DEPTH_DRAW_ALWAYS);
-			shaders.actions_scene.render_mode_values["depth_draw_never"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, GLES3::Shader::Spatial::DEPTH_DRAW_NEVER);
-			shaders.actions_scene.render_mode_values["depth_draw_alpha_prepass"] = Pair<int *, int>(&p_shader->spatial.depth_draw_mode, GLES3::Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS);
-
-			shaders.actions_scene.render_mode_values["cull_front"] = Pair<int *, int>(&p_shader->spatial.cull_mode, GLES3::Shader::Spatial::CULL_MODE_FRONT);
-			shaders.actions_scene.render_mode_values["cull_back"] = Pair<int *, int>(&p_shader->spatial.cull_mode, GLES3::Shader::Spatial::CULL_MODE_BACK);
-			shaders.actions_scene.render_mode_values["cull_disabled"] = Pair<int *, int>(&p_shader->spatial.cull_mode, GLES3::Shader::Spatial::CULL_MODE_DISABLED);
-
-			shaders.actions_scene.render_mode_flags["unshaded"] = &p_shader->spatial.unshaded;
-			shaders.actions_scene.render_mode_flags["depth_test_disable"] = &p_shader->spatial.no_depth_test;
-
-			shaders.actions_scene.render_mode_flags["vertex_lighting"] = &p_shader->spatial.uses_vertex_lighting;
-
-			shaders.actions_scene.render_mode_flags["world_vertex_coords"] = &p_shader->spatial.uses_world_coordinates;
-
-			shaders.actions_scene.render_mode_flags["ensure_correct_normals"] = &p_shader->spatial.uses_ensure_correct_normals;
-
-			shaders.actions_scene.usage_flag_pointers["ALPHA"] = &p_shader->spatial.uses_alpha;
-			shaders.actions_scene.usage_flag_pointers["ALPHA_SCISSOR"] = &p_shader->spatial.uses_alpha_scissor;
-
-			shaders.actions_scene.usage_flag_pointers["SSS_STRENGTH"] = &p_shader->spatial.uses_sss;
-			shaders.actions_scene.usage_flag_pointers["DISCARD"] = &p_shader->spatial.uses_discard;
-			shaders.actions_scene.usage_flag_pointers["SCREEN_TEXTURE"] = &p_shader->spatial.uses_screen_texture;
-			shaders.actions_scene.usage_flag_pointers["DEPTH_TEXTURE"] = &p_shader->spatial.uses_depth_texture;
-			shaders.actions_scene.usage_flag_pointers["TIME"] = &p_shader->spatial.uses_time;
-
-			// Use of any of these BUILTINS indicate the need for transformed tangents.
-			// This is needed to know when to transform tangents in software skinning.
-			shaders.actions_scene.usage_flag_pointers["TANGENT"] = &p_shader->spatial.uses_tangent;
-			shaders.actions_scene.usage_flag_pointers["NORMALMAP"] = &p_shader->spatial.uses_tangent;
-
-			shaders.actions_scene.write_flag_pointers["MODELVIEW_MATRIX"] = &p_shader->spatial.writes_modelview_or_projection;
-			shaders.actions_scene.write_flag_pointers["PROJECTION_MATRIX"] = &p_shader->spatial.writes_modelview_or_projection;
-			shaders.actions_scene.write_flag_pointers["VERTEX"] = &p_shader->spatial.uses_vertex;
-
-			actions = &shaders.actions_scene;
-			actions->uniforms = &p_shader->uniforms;
-		} break;
-
-		default: {
-			return;
-		} break;
-	}
-
-	Error err = shaders.compiler.compile(p_shader->mode, p_shader->code, actions, p_shader->path, gen_code);
-	if (err != OK) {
-		return;
-	}
-
-	Vector<StringName> texture_uniform_names;
-	for (int i = 0; i < gen_code.texture_uniforms.size(); i++) {
-		texture_uniform_names.push_back(gen_code.texture_uniforms[i].name);
-	}
-
-	p_shader->shader->version_set_code(p_shader->version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines, texture_uniform_names);
-
-	p_shader->texture_uniforms = gen_code.texture_uniforms;
-
-	p_shader->uses_vertex_time = gen_code.uses_vertex_time;
-	p_shader->uses_fragment_time = gen_code.uses_fragment_time;
-
-	for (SelfList<GLES3::Material> *E = p_shader->materials.first(); E; E = E->next()) {
-		_material_make_dirty(E->self());
-	}
-
-	p_shader->valid = true;
+	return Variant();
 }
 
-void MaterialStorage::update_dirty_shaders() {
-	while (_shader_dirty_list.first()) {
-		_update_shader(_shader_dirty_list.first()->self());
+RS::ShaderNativeSourceCode MaterialStorage::shader_get_native_source_code(RID p_shader) const {
+	Shader *shader = shader_owner.get_or_null(p_shader);
+	ERR_FAIL_COND_V(!shader, RS::ShaderNativeSourceCode());
+	if (shader->data) {
+		return shader->data->get_native_source_code();
 	}
+	return RS::ShaderNativeSourceCode();
 }
 
 /* MATERIAL API */
 
-void MaterialStorage::_material_make_dirty(GLES3::Material *p_material) const {
-	if (p_material->dirty_list.in_list()) {
+void MaterialStorage::_material_queue_update(Material *material, bool p_uniform, bool p_texture) {
+	material->uniform_dirty = material->uniform_dirty || p_uniform;
+	material->texture_dirty = material->texture_dirty || p_texture;
+
+	if (material->update_element.in_list()) {
 		return;
 	}
 
-	_material_dirty_list.add(&p_material->dirty_list);
+	material_update_list.add(&material->update_element);
 }
 
-void MaterialStorage::_update_material(GLES3::Material *p_material) {
-	if (p_material->dirty_list.in_list()) {
-		_material_dirty_list.remove(&p_material->dirty_list);
-	}
+void MaterialStorage::_update_queued_materials() {
+	while (material_update_list.first()) {
+		Material *material = material_update_list.first()->self();
 
-	if (p_material->shader && p_material->shader->dirty_list.in_list()) {
-		_update_shader(p_material->shader);
-	}
-
-	if (p_material->shader && !p_material->shader->valid) {
-		return;
-	}
-
-	{
-		if (p_material->shader && p_material->shader->mode == RS::SHADER_SPATIAL) {
-			bool can_cast_shadow = false;
-			bool is_animated = false;
-
-			if (p_material->shader->spatial.blend_mode == GLES3::Shader::Spatial::BLEND_MODE_MIX &&
-
-					(!p_material->shader->spatial.uses_alpha || p_material->shader->spatial.depth_draw_mode == Shader::Spatial::DEPTH_DRAW_ALPHA_PREPASS)) {
-				can_cast_shadow = true;
-			}
-
-			if (p_material->shader->spatial.uses_discard && p_material->shader->uses_fragment_time) {
-				is_animated = true;
-			}
-
-			if (p_material->shader->spatial.uses_vertex && p_material->shader->uses_vertex_time) {
-				is_animated = true;
-			}
-
-			if (can_cast_shadow != p_material->can_cast_shadow_cache || is_animated != p_material->is_animated_cache) {
-				p_material->can_cast_shadow_cache = can_cast_shadow;
-				p_material->is_animated_cache = is_animated;
-
-				/*
-				for (Map<Geometry *, int>::Element *E = p_material->geometry_owners.front(); E; E = E->next()) {
-					E->key()->material_changed_notify();
-				}
-
-				for (Map<InstanceBaseDependency *, int>::Element *E = p_material->instance_owners.front(); E; E = E->next()) {
-					E->key()->base_changed(false, true);
-				}
-				*/
-			}
+		if (material->data) {
+			material->data->update_parameters(material->params, material->uniform_dirty, material->texture_dirty);
 		}
-	}
+		material->texture_dirty = false;
+		material->uniform_dirty = false;
 
-	// uniforms and other things will be set in the use_material method in ShaderGLES3
-
-	if (p_material->shader && p_material->shader->texture_uniforms.size() > 0) {
-		p_material->textures.resize(p_material->shader->texture_uniforms.size());
-
-		for (Map<StringName, ShaderLanguage::ShaderNode::Uniform>::Element *E = p_material->shader->uniforms.front(); E; E = E->next()) {
-			if (E->get().texture_order < 0) {
-				continue; // not a texture, does not go here
-			}
-
-			RID texture;
-
-			Map<StringName, Variant>::Element *V = p_material->params.find(E->key());
-
-			if (V) {
-				texture = V->get();
-			}
-
-			if (!texture.is_valid()) {
-				Map<StringName, Map<int, RID>>::Element *W = p_material->shader->default_textures.find(E->key());
-
-				// TODO: make texture uniform array properly works with GLES3
-				if (W && W->get().has(0)) {
-					texture = W->get()[0];
-				}
-			}
-
-			p_material->textures.write[E->get().texture_order] = Pair<StringName, RID>(E->key(), texture);
-		}
-	} else {
-		p_material->textures.clear();
+		material_update_list.remove(&material->update_element);
 	}
 }
 
 RID MaterialStorage::material_allocate() {
-	GLES3::Material *material = memnew(GLES3::Material);
-	return material_owner.make_rid(material);
+	return material_owner.allocate_rid();
 }
 
 void MaterialStorage::material_initialize(RID p_rid) {
+	material_owner.initialize_rid(p_rid);
+	Material *material = material_owner.get_or_null(p_rid);
+	material->self = p_rid;
 }
 
-//RID MaterialStorage::material_create() {
-//	Material *material = memnew(Material);
-
-//	return material_owner.make_rid(material);
-//}
-
 void MaterialStorage::material_free(RID p_rid) {
-	GLES3::Material *m = material_owner.get_or_null(p_rid);
+	Material *material = material_owner.get_or_null(p_rid);
+	ERR_FAIL_COND(!material);
 
-	if (m->shader) {
-		m->shader->materials.remove(&m->list);
-	}
-
-	/*
-	for (Map<Geometry *, int>::Element *E = m->geometry_owners.front(); E; E = E->next()) {
-		Geometry *g = E->key();
-		g->material = RID();
-	}
-
-	for (Map<InstanceBaseDependency *, int>::Element *E = m->instance_owners.front(); E; E = E->next()) {
-		InstanceBaseDependency *ins = E->key();
-
-		if (ins->material_override == p_rid) {
-			ins->material_override = RID();
-		}
-
-		for (int i = 0; i < ins->materials.size(); i++) {
-			if (ins->materials[i] == p_rid) {
-				ins->materials.write[i] = RID();
-			}
-		}
-	}
-*/
+	material_set_shader(p_rid, RID()); //clean up shader
+	material->dependency.deleted_notify(p_rid);
 
 	material_owner.free(p_rid);
-	memdelete(m);
 }
 
 void MaterialStorage::material_set_shader(RID p_material, RID p_shader) {
 	GLES3::Material *material = material_owner.get_or_null(p_material);
 	ERR_FAIL_COND(!material);
 
-	GLES3::Shader *shader = get_shader(p_shader);
+	if (material->data) {
+		memdelete(material->data);
+		material->data = nullptr;
+	}
 
 	if (material->shader) {
-		// if a shader is present, remove the old shader
-		material->shader->materials.remove(&material->list);
+		material->shader->owners.erase(material);
+		material->shader = nullptr;
+		material->shader_mode = RS::SHADER_MAX;
 	}
 
+	if (p_shader.is_null()) {
+		material->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MATERIAL);
+		material->shader_id = 0;
+		return;
+	}
+
+	Shader *shader = get_shader(p_shader);
+	ERR_FAIL_COND(!shader);
 	material->shader = shader;
+	material->shader_mode = shader->mode;
+	material->shader_id = p_shader.get_local_index();
+	shader->owners.insert(material);
 
-	if (shader) {
-		shader->materials.add(&material->list);
+	if (shader->mode == RS::SHADER_MAX) {
+		return;
 	}
 
-	_material_make_dirty(material);
+	ERR_FAIL_COND(shader->data == nullptr);
+
+	material->data = material_data_request_func[shader->mode](shader->data);
+	material->data->self = p_material;
+	material->data->set_next_pass(material->next_pass);
+	material->data->set_render_priority(material->priority);
+	//updating happens later
+	material->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MATERIAL);
+	_material_queue_update(material, true, true);
 }
 
 void MaterialStorage::material_set_param(RID p_material, const StringName &p_param, const Variant &p_value) {
@@ -718,28 +2608,42 @@ void MaterialStorage::material_set_param(RID p_material, const StringName &p_par
 	if (p_value.get_type() == Variant::NIL) {
 		material->params.erase(p_param);
 	} else {
+		ERR_FAIL_COND(p_value.get_type() == Variant::OBJECT); //object not allowed
 		material->params[p_param] = p_value;
 	}
 
-	_material_make_dirty(material);
+	if (material->shader && material->shader->data) { //shader is valid
+		bool is_texture = material->shader->data->is_param_texture(p_param);
+		_material_queue_update(material, !is_texture, is_texture);
+	} else {
+		_material_queue_update(material, true, true);
+	}
 }
 
 Variant MaterialStorage::material_get_param(RID p_material, const StringName &p_param) const {
 	const GLES3::Material *material = material_owner.get_or_null(p_material);
-	ERR_FAIL_COND_V(!material, RID());
-
+	ERR_FAIL_COND_V(!material, Variant());
 	if (material->params.has(p_param)) {
 		return material->params[p_param];
+	} else {
+		return Variant();
 	}
-
-	return material_get_param_default(p_material, p_param);
 }
 
 void MaterialStorage::material_set_next_pass(RID p_material, RID p_next_material) {
 	GLES3::Material *material = material_owner.get_or_null(p_material);
 	ERR_FAIL_COND(!material);
 
+	if (material->next_pass == p_next_material) {
+		return;
+	}
+
 	material->next_pass = p_next_material;
+	if (material->data) {
+		material->data->set_next_pass(p_next_material);
+	}
+
+	material->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MATERIAL);
 }
 
 void MaterialStorage::material_set_render_priority(RID p_material, int priority) {
@@ -748,167 +2652,300 @@ void MaterialStorage::material_set_render_priority(RID p_material, int priority)
 
 	GLES3::Material *material = material_owner.get_or_null(p_material);
 	ERR_FAIL_COND(!material);
-
-	material->render_priority = priority;
+	material->priority = priority;
+	if (material->data) {
+		material->data->set_render_priority(priority);
+	}
 }
 
 bool MaterialStorage::material_is_animated(RID p_material) {
 	GLES3::Material *material = material_owner.get_or_null(p_material);
 	ERR_FAIL_COND_V(!material, false);
-	if (material->dirty_list.in_list()) {
-		_update_material(material);
+	if (material->shader && material->shader->data) {
+		if (material->shader->data->is_animated()) {
+			return true;
+		} else if (material->next_pass.is_valid()) {
+			return material_is_animated(material->next_pass);
+		}
 	}
-
-	bool animated = material->is_animated_cache;
-	if (!animated && material->next_pass.is_valid()) {
-		animated = material_is_animated(material->next_pass);
-	}
-	return animated;
+	return false; //by default nothing is animated
 }
 
 bool MaterialStorage::material_casts_shadows(RID p_material) {
 	GLES3::Material *material = material_owner.get_or_null(p_material);
-	ERR_FAIL_COND_V(!material, false);
-	if (material->dirty_list.in_list()) {
-		_update_material(material);
+	ERR_FAIL_COND_V(!material, true);
+	if (material->shader && material->shader->data) {
+		if (material->shader->data->casts_shadows()) {
+			return true;
+		} else if (material->next_pass.is_valid()) {
+			return material_casts_shadows(material->next_pass);
+		}
 	}
-
-	bool casts_shadows = material->can_cast_shadow_cache;
-
-	if (!casts_shadows && material->next_pass.is_valid()) {
-		casts_shadows = material_casts_shadows(material->next_pass);
-	}
-
-	return casts_shadows;
+	return true; //by default everything casts shadows
 }
 
-Variant MaterialStorage::material_get_param_default(RID p_material, const StringName &p_param) const {
-	const GLES3::Material *material = material_owner.get_or_null(p_material);
-	ERR_FAIL_COND_V(!material, Variant());
+void MaterialStorage::material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) {
+	GLES3::Material *material = material_owner.get_or_null(p_material);
+	ERR_FAIL_COND(!material);
+	if (material->shader && material->shader->data) {
+		material->shader->data->get_instance_param_list(r_parameters);
 
-	if (material->shader) {
-		if (material->shader->uniforms.has(p_param)) {
-			ShaderLanguage::ShaderNode::Uniform uniform = material->shader->uniforms[p_param];
-			Vector<ShaderLanguage::ConstantNode::Value> default_value = uniform.default_value;
-			return ShaderLanguage::constant_value_to_variant(default_value, uniform.type, uniform.hint);
+		if (material->next_pass.is_valid()) {
+			material_get_instance_shader_parameters(material->next_pass, r_parameters);
 		}
+	}
+}
+
+void MaterialStorage::material_update_dependency(RID p_material, RendererStorage::DependencyTracker *p_instance) {
+	Material *material = material_owner.get_or_null(p_material);
+	ERR_FAIL_COND(!material);
+	p_instance->update_dependency(&material->dependency);
+	if (material->next_pass.is_valid()) {
+		material_update_dependency(material->next_pass, p_instance);
+	}
+}
+
+// Canvas Shader Data
+void CanvasShaderData::set_code(const String &p_code) {
+	// compile the shader
+
+	code = p_code;
+	valid = false;
+	ubo_size = 0;
+	uniforms.clear();
+	uses_screen_texture = false;
+	uses_sdf = false;
+	uses_time = false;
+
+	if (code.is_empty()) {
+		return; //just invalid, but no error
+	}
+
+	ShaderCompiler::GeneratedCode gen_code;
+
+	int blend_mode = BLEND_MODE_MIX;
+	uses_screen_texture = false;
+
+	ShaderCompiler::IdentifierActions actions;
+	actions.entry_point_stages["vertex"] = ShaderCompiler::STAGE_VERTEX;
+	actions.entry_point_stages["fragment"] = ShaderCompiler::STAGE_FRAGMENT;
+	actions.entry_point_stages["light"] = ShaderCompiler::STAGE_FRAGMENT;
+
+	actions.render_mode_values["blend_add"] = Pair<int *, int>(&blend_mode, BLEND_MODE_ADD);
+	actions.render_mode_values["blend_mix"] = Pair<int *, int>(&blend_mode, BLEND_MODE_MIX);
+	actions.render_mode_values["blend_sub"] = Pair<int *, int>(&blend_mode, BLEND_MODE_SUB);
+	actions.render_mode_values["blend_mul"] = Pair<int *, int>(&blend_mode, BLEND_MODE_MUL);
+	actions.render_mode_values["blend_premul_alpha"] = Pair<int *, int>(&blend_mode, BLEND_MODE_PMALPHA);
+	actions.render_mode_values["blend_disabled"] = Pair<int *, int>(&blend_mode, BLEND_MODE_DISABLED);
+
+	actions.usage_flag_pointers["SCREEN_TEXTURE"] = &uses_screen_texture;
+	actions.usage_flag_pointers["texture_sdf"] = &uses_sdf;
+	actions.usage_flag_pointers["TIME"] = &uses_time;
+
+	actions.uniforms = &uniforms;
+	Error err = MaterialStorage::get_singleton()->shaders.compiler_canvas.compile(RS::SHADER_CANVAS_ITEM, code, &actions, path, gen_code);
+	ERR_FAIL_COND_MSG(err != OK, "Shader compilation failed.");
+
+	if (version.is_null()) {
+		version = MaterialStorage::get_singleton()->shaders.canvas_shader.version_create();
+	}
+
+#if 0
+	print_line("**compiling shader:");
+	print_line("**defines:\n");
+	for (int i = 0; i < gen_code.defines.size(); i++) {
+		print_line(gen_code.defines[i]);
+	}
+	print_line("\n**uniforms:\n" + gen_code.uniforms);
+	print_line("\n**vertex_globals:\n" + gen_code.vertex_global);
+	print_line("\n**vertex_code:\n" + gen_code.vertex);
+	print_line("\n**fragment_globals:\n" + gen_code.fragment_global);
+	print_line("\n**fragment_code:\n" + gen_code.fragment);
+	print_line("\n**light_code:\n" + gen_code.light);
+#endif
+
+	Vector<StringName> texture_uniform_names;
+	for (int i = 0; i < gen_code.texture_uniforms.size(); i++) {
+		texture_uniform_names.push_back(gen_code.texture_uniforms[i].name);
+	}
+
+	MaterialStorage::get_singleton()->shaders.canvas_shader.version_set_code(version, gen_code.code, gen_code.uniforms, gen_code.stage_globals[ShaderCompiler::STAGE_VERTEX], gen_code.stage_globals[ShaderCompiler::STAGE_FRAGMENT], gen_code.defines, texture_uniform_names);
+	ERR_FAIL_COND(!MaterialStorage::get_singleton()->shaders.canvas_shader.version_is_valid(version));
+
+	ubo_size = gen_code.uniform_total_size;
+	ubo_offsets = gen_code.uniform_offsets;
+	texture_uniforms = gen_code.texture_uniforms;
+
+	valid = true;
+}
+
+void CanvasShaderData::set_default_texture_param(const StringName &p_name, RID p_texture, int p_index) {
+	if (!p_texture.is_valid()) {
+		if (default_texture_params.has(p_name) && default_texture_params[p_name].has(p_index)) {
+			default_texture_params[p_name].erase(p_index);
+
+			if (default_texture_params[p_name].is_empty()) {
+				default_texture_params.erase(p_name);
+			}
+		}
+	} else {
+		if (!default_texture_params.has(p_name)) {
+			default_texture_params[p_name] = Map<int, RID>();
+		}
+		default_texture_params[p_name][p_index] = p_texture;
+	}
+}
+
+void CanvasShaderData::get_param_list(List<PropertyInfo> *p_param_list) const {
+	Map<int, StringName> order;
+
+	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {
+		if (E.value.scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_LOCAL) {
+			continue;
+		}
+		if (E.value.texture_order >= 0) {
+			order[E.value.texture_order + 100000] = E.key;
+		} else {
+			order[E.value.order] = E.key;
+		}
+	}
+
+	for (const KeyValue<int, StringName> &E : order) {
+		PropertyInfo pi = ShaderLanguage::uniform_to_property_info(uniforms[E.value]);
+		pi.name = E.value;
+		p_param_list->push_back(pi);
+	}
+}
+
+void CanvasShaderData::get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const {
+	for (const KeyValue<StringName, ShaderLanguage::ShaderNode::Uniform> &E : uniforms) {
+		if (E.value.scope != ShaderLanguage::ShaderNode::Uniform::SCOPE_INSTANCE) {
+			continue;
+		}
+
+		RendererMaterialStorage::InstanceShaderParam p;
+		p.info = ShaderLanguage::uniform_to_property_info(E.value);
+		p.info.name = E.key; //supply name
+		p.index = E.value.instance_index;
+		p.default_value = ShaderLanguage::constant_value_to_variant(E.value.default_value, E.value.type, E.value.array_size, E.value.hint);
+		p_param_list->push_back(p);
+	}
+}
+
+bool CanvasShaderData::is_param_texture(const StringName &p_param) const {
+	if (!uniforms.has(p_param)) {
+		return false;
+	}
+
+	return uniforms[p_param].texture_order >= 0;
+}
+
+bool CanvasShaderData::is_animated() const {
+	return false;
+}
+
+bool CanvasShaderData::casts_shadows() const {
+	return false;
+}
+
+Variant CanvasShaderData::get_default_parameter(const StringName &p_parameter) const {
+	if (uniforms.has(p_parameter)) {
+		ShaderLanguage::ShaderNode::Uniform uniform = uniforms[p_parameter];
+		Vector<ShaderLanguage::ConstantNode::Value> default_value = uniform.default_value;
+		return ShaderLanguage::constant_value_to_variant(default_value, uniform.type, uniform.array_size, uniform.hint);
 	}
 	return Variant();
 }
 
-void MaterialStorage::update_dirty_materials() {
-	while (_material_dirty_list.first()) {
-		GLES3::Material *material = _material_dirty_list.first()->self();
-		_update_material(material);
+RS::ShaderNativeSourceCode CanvasShaderData::get_native_source_code() const {
+	return MaterialStorage::get_singleton()->shaders.canvas_shader.version_get_native_source_code(version);
+}
+
+CanvasShaderData::CanvasShaderData() {
+	valid = false;
+	uses_screen_texture = false;
+	uses_sdf = false;
+}
+
+CanvasShaderData::~CanvasShaderData() {
+	if (version.is_valid()) {
+		MaterialStorage::get_singleton()->shaders.canvas_shader.version_free(version);
 	}
 }
 
-/* are these still used? */
-RID MaterialStorage::material_get_shader(RID p_material) const {
-	const GLES3::Material *material = material_owner.get_or_null(p_material);
-	ERR_FAIL_COND_V(!material, RID());
-
-	if (material->shader) {
-		return material->shader->self;
-	}
-
-	return RID();
+GLES3::ShaderData *GLES3::_create_canvas_shader_func() {
+	CanvasShaderData *shader_data = memnew(CanvasShaderData);
+	return shader_data;
 }
 
-void MaterialStorage::material_set_line_width(RID p_material, float p_width) {
-	GLES3::Material *material = material_owner.get_or_null(p_material);
-	ERR_FAIL_COND(!material);
-
-	material->line_width = p_width;
+void CanvasMaterialData::update_parameters(const Map<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty) {
+	return update_parameters_internal(p_parameters, p_uniform_dirty, p_textures_dirty, shader_data->uniforms, shader_data->ubo_offsets.ptr(), shader_data->texture_uniforms, shader_data->default_texture_params, shader_data->ubo_size);
 }
 
-bool MaterialStorage::material_uses_tangents(RID p_material) {
-	GLES3::Material *material = material_owner.get_or_null(p_material);
-	ERR_FAIL_COND_V(!material, false);
+// Look up table to translate ShaderLanguage::DataType to GL_TEXTURE_*
+static const GLenum target_from_type[ShaderLanguage::TYPE_MAX] = {
+	GL_TEXTURE_2D, // TYPE_VOID,
+	GL_TEXTURE_2D, // TYPE_BOOL,
+	GL_TEXTURE_2D, // TYPE_BVEC2,
+	GL_TEXTURE_2D, // TYPE_BVEC3,
+	GL_TEXTURE_2D, // TYPE_BVEC4,
+	GL_TEXTURE_2D, // TYPE_INT,
+	GL_TEXTURE_2D, // TYPE_IVEC2,
+	GL_TEXTURE_2D, // TYPE_IVEC3,
+	GL_TEXTURE_2D, // TYPE_IVEC4,
+	GL_TEXTURE_2D, // TYPE_UINT,
+	GL_TEXTURE_2D, // TYPE_UVEC2,
+	GL_TEXTURE_2D, // TYPE_UVEC3,
+	GL_TEXTURE_2D, // TYPE_UVEC4,
+	GL_TEXTURE_2D, // TYPE_FLOAT,
+	GL_TEXTURE_2D, // TYPE_VEC2,
+	GL_TEXTURE_2D, // TYPE_VEC3,
+	GL_TEXTURE_2D, // TYPE_VEC4,
+	GL_TEXTURE_2D, // TYPE_MAT2,
+	GL_TEXTURE_2D, // TYPE_MAT3,
+	GL_TEXTURE_2D, // TYPE_MAT4,
+	GL_TEXTURE_2D, // TYPE_SAMPLER2D,
+	GL_TEXTURE_2D, // TYPE_ISAMPLER2D,
+	GL_TEXTURE_2D, // TYPE_USAMPLER2D,
+	GL_TEXTURE_2D_ARRAY, // TYPE_SAMPLER2DARRAY,
+	GL_TEXTURE_2D_ARRAY, // TYPE_ISAMPLER2DARRAY,
+	GL_TEXTURE_2D_ARRAY, // TYPE_USAMPLER2DARRAY,
+	GL_TEXTURE_3D, // TYPE_SAMPLER3D,
+	GL_TEXTURE_3D, // TYPE_ISAMPLER3D,
+	GL_TEXTURE_3D, // TYPE_USAMPLER3D,
+	GL_TEXTURE_CUBE_MAP, // TYPE_SAMPLERCUBE,
+	GL_TEXTURE_CUBE_MAP, // TYPE_SAMPLERCUBEARRAY,
+	GL_TEXTURE_2D, // TYPE_STRUCT
+};
 
-	if (!material->shader) {
-		return false;
-	}
+void CanvasMaterialData::bind_uniforms() {
+	// Bind Material Uniforms
+	glBindBufferBase(GL_UNIFORM_BUFFER, RasterizerCanvasGLES3::MATERIAL_UNIFORM_BUFFER_OBJECT, uniform_buffer);
 
-	if (material->shader->dirty_list.in_list()) {
-		_update_shader(material->shader);
-	}
+	RID *textures = texture_cache.ptrw();
+	ShaderCompiler::GeneratedCode::Texture *texture_uniforms = shader_data->texture_uniforms.ptrw();
+	for (int ti = 0; ti < texture_cache.size(); ti++) {
+		Texture *texture = TextureStorage::get_singleton()->get_texture(textures[ti]);
+		glActiveTexture(GL_TEXTURE1 + ti);
+		glBindTexture(target_from_type[texture_uniforms[ti].type], texture->tex_id);
 
-	return material->shader->spatial.uses_tangent;
-}
-
-bool MaterialStorage::material_uses_ensure_correct_normals(RID p_material) {
-	GLES3::Material *material = material_owner.get_or_null(p_material);
-	ERR_FAIL_COND_V(!material, false);
-
-	if (!material->shader) {
-		return false;
-	}
-
-	if (material->shader->dirty_list.in_list()) {
-		_update_shader(material->shader);
-	}
-
-	return material->shader->spatial.uses_ensure_correct_normals;
-}
-
-void MaterialStorage::material_add_instance_owner(RID p_material, RendererStorage::DependencyTracker *p_instance) {
-	/*
-	GLES3::Material *material = material_owner.get_or_null(p_material);
-	ERR_FAIL_COND(!material);
-
-	Map<InstanceBaseDependency *, int>::Element *E = material->instance_owners.find(p_instance);
-	if (E) {
-		E->get()++;
-	} else {
-		material->instance_owners[p_instance] = 1;
-	}
-*/
-}
-
-void MaterialStorage::material_remove_instance_owner(RID p_material, RendererStorage::DependencyTracker *p_instance) {
-	/*
-	GLES3::Material *material = material_owner.get_or_null(p_material);
-	ERR_FAIL_COND(!material);
-
-	Map<InstanceBaseDependency *, int>::Element *E = material->instance_owners.find(p_instance);
-	ERR_FAIL_COND(!E);
-
-	E->get()--;
-
-	if (E->get() == 0) {
-		material->instance_owners.erase(E);
-	}
-*/
-}
-
-/*
-void MaterialStorage::_material_add_geometry(RID p_material, Geometry *p_geometry) {
-	GLES3::Material *material = material_owner.get_or_null(p_material);
-	ERR_FAIL_COND(!material);
-
-	Map<Geometry *, int>::Element *I = material->geometry_owners.find(p_geometry);
-
-	if (I) {
-		I->get()++;
-	} else {
-		material->geometry_owners[p_geometry] = 1;
+		// Set sampler state here as the same texture can be used in multiple places with different flags
+		// Need to convert sampler state from ShaderLanguage::Texture* to RS::CanvasItemTexture*
+		RS::CanvasItemTextureFilter filter = RS::CanvasItemTextureFilter((int(texture_uniforms[ti].filter) + 1) % RS::CANVAS_ITEM_TEXTURE_FILTER_MAX);
+		RS::CanvasItemTextureRepeat repeat = RS::CanvasItemTextureRepeat((int(texture_uniforms[ti].repeat) + 1) % RS::CANVAS_ITEM_TEXTURE_REPEAT_MIRROR);
+		texture->gl_set_filter(filter);
+		texture->gl_set_repeat(repeat);
 	}
 }
 
-void MaterialStorage::_material_remove_geometry(RID p_material, Geometry *p_geometry) {
-	GLES3::Material *material = material_owner.get_or_null(p_material);
-	ERR_FAIL_COND(!material);
-
-	Map<Geometry *, int>::Element *I = material->geometry_owners.find(p_geometry);
-	ERR_FAIL_COND(!I);
-
-	I->get()--;
-
-	if (I->get() == 0) {
-		material->geometry_owners.erase(I);
-	}
+CanvasMaterialData::~CanvasMaterialData() {
 }
-*/
+
+GLES3::MaterialData *GLES3::_create_canvas_material_func(ShaderData *p_shader) {
+	CanvasMaterialData *material_data = memnew(CanvasMaterialData);
+	material_data->shader_data = static_cast<CanvasShaderData *>(p_shader);
+	//update will happen later anyway so do nothing.
+	return material_data;
+}
 
 #endif // !GLES3_ENABLED

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -44,193 +44,246 @@
 
 #include "drivers/gles3/shaders/copy.glsl.gen.h"
 
+#include "../shaders/canvas.glsl.gen.h"
+#include "../shaders/sky.glsl.gen.h"
+
 namespace GLES3 {
 
 /* SHADER Structs */
 
 struct Shaders {
-	ShaderCompiler compiler;
+	CanvasShaderGLES3 canvas_shader;
+	SkyShaderGLES3 sky_shader;
 
-	CopyShaderGLES3 copy;
-	RID copy_version;
-	//CubemapFilterShaderGLES3 cubemap_filter;
-
-	ShaderCompiler::IdentifierActions actions_canvas;
-	ShaderCompiler::IdentifierActions actions_scene;
-	ShaderCompiler::IdentifierActions actions_particles;
+	ShaderCompiler compiler_canvas;
+	ShaderCompiler compiler_scene;
+	ShaderCompiler compiler_particles;
+	ShaderCompiler compiler_sky;
 };
+
+struct ShaderData {
+	virtual void set_code(const String &p_Code) = 0;
+	virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index) = 0;
+	virtual void get_param_list(List<PropertyInfo> *p_param_list) const = 0;
+
+	virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const = 0;
+	virtual bool is_param_texture(const StringName &p_param) const = 0;
+	virtual bool is_animated() const = 0;
+	virtual bool casts_shadows() const = 0;
+	virtual Variant get_default_parameter(const StringName &p_parameter) const = 0;
+	virtual RS::ShaderNativeSourceCode get_native_source_code() const { return RS::ShaderNativeSourceCode(); }
+
+	virtual ~ShaderData() {}
+};
+
+typedef ShaderData *(*ShaderDataRequestFunction)();
 
 struct Material;
 
 struct Shader {
-	RID self;
-
-	RS::ShaderMode mode;
-	ShaderGLES3 *shader = nullptr;
+	ShaderData *data = nullptr;
 	String code;
-	SelfList<Material>::List materials;
-
-	Map<StringName, ShaderLanguage::ShaderNode::Uniform> uniforms;
-
-	RID version;
-
-	SelfList<Shader> dirty_list;
-
-	Map<StringName, Map<int, RID>> default_textures;
-
-	Vector<ShaderCompiler::GeneratedCode::Texture> texture_uniforms;
-
-	bool valid;
-
-	String path;
-
-	uint32_t index;
-	uint64_t last_pass;
-
-	struct CanvasItem {
-		enum BlendMode {
-			BLEND_MODE_MIX,
-			BLEND_MODE_ADD,
-			BLEND_MODE_SUB,
-			BLEND_MODE_MUL,
-			BLEND_MODE_PMALPHA,
-		};
-
-		int blend_mode;
-
-		enum LightMode {
-			LIGHT_MODE_NORMAL,
-			LIGHT_MODE_UNSHADED,
-			LIGHT_MODE_LIGHT_ONLY
-		};
-
-		int light_mode;
-
-		bool uses_screen_texture;
-		bool uses_screen_uv;
-		bool uses_time;
-		bool uses_modulate;
-		bool uses_color;
-		bool uses_vertex;
-
-		// all these should disable item joining if used in a custom shader
-		bool uses_model_matrix;
-		bool uses_extra_matrix;
-		bool uses_projection_matrix;
-		bool uses_instance_custom;
-
-	} canvas_item;
-
-	struct Spatial {
-		enum BlendMode {
-			BLEND_MODE_MIX,
-			BLEND_MODE_ADD,
-			BLEND_MODE_SUB,
-			BLEND_MODE_MUL,
-		};
-
-		int blend_mode;
-
-		enum DepthDrawMode {
-			DEPTH_DRAW_OPAQUE,
-			DEPTH_DRAW_ALWAYS,
-			DEPTH_DRAW_NEVER,
-			DEPTH_DRAW_ALPHA_PREPASS,
-		};
-
-		int depth_draw_mode;
-
-		enum CullMode {
-			CULL_MODE_FRONT,
-			CULL_MODE_BACK,
-			CULL_MODE_DISABLED,
-		};
-
-		int cull_mode;
-
-		bool uses_alpha;
-		bool uses_alpha_scissor;
-		bool unshaded;
-		bool no_depth_test;
-		bool uses_vertex;
-		bool uses_discard;
-		bool uses_sss;
-		bool uses_screen_texture;
-		bool uses_depth_texture;
-		bool uses_time;
-		bool uses_tangent;
-		bool uses_ensure_correct_normals;
-		bool writes_modelview_or_projection;
-		bool uses_vertex_lighting;
-		bool uses_world_coordinates;
-
-	} spatial;
-
-	struct Particles {
-	} particles;
-
-	bool uses_vertex_time;
-	bool uses_fragment_time;
-
-	Shader() :
-			dirty_list(this) {
-		shader = nullptr;
-		valid = false;
-		version = RID();
-		last_pass = 0;
-	}
+	RS::ShaderMode mode;
+	Map<StringName, Map<int, RID>> default_texture_parameter;
+	Set<Material *> owners;
 };
 
-/* MATERIAL Structs */
+/* Material structs */
+
+struct MaterialData {
+	void update_uniform_buffer(const Map<StringName, ShaderLanguage::ShaderNode::Uniform> &p_uniforms, const uint32_t *p_uniform_offsets, const Map<StringName, Variant> &p_parameters, uint8_t *p_buffer, uint32_t p_buffer_size, bool p_use_linear_color);
+	void update_textures(const Map<StringName, Variant> &p_parameters, const Map<StringName, Map<int, RID>> &p_default_textures, const Vector<ShaderCompiler::GeneratedCode::Texture> &p_texture_uniforms, RID *p_textures, bool p_use_linear_color);
+
+	virtual void set_render_priority(int p_priority) = 0;
+	virtual void set_next_pass(RID p_pass) = 0;
+	virtual void update_parameters(const Map<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty) = 0;
+	virtual void bind_uniforms() = 0;
+	virtual ~MaterialData();
+
+	// Used internally by all Materials
+	void update_parameters_internal(const Map<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty, const Map<StringName, ShaderLanguage::ShaderNode::Uniform> &p_uniforms, const uint32_t *p_uniform_offsets, const Vector<ShaderCompiler::GeneratedCode::Texture> &p_texture_uniforms, const Map<StringName, Map<int, RID>> &p_default_texture_params, uint32_t p_ubo_size);
+
+protected:
+	Vector<uint8_t> ubo_data;
+	GLuint uniform_buffer = GLuint(0);
+	Vector<RID> texture_cache;
+
+private:
+	friend class MaterialStorage;
+	RID self;
+	List<RID>::Element *global_buffer_E = nullptr;
+	List<RID>::Element *global_texture_E = nullptr;
+	uint64_t global_textures_pass = 0;
+	Map<StringName, uint64_t> used_global_textures;
+
+	//internally by update_parameters_internal
+};
+
+typedef MaterialData *(*MaterialDataRequestFunction)(ShaderData *);
 
 struct Material {
 	RID self;
+	MaterialData *data = nullptr;
 	Shader *shader = nullptr;
+	//shortcut to shader data and type
+	RS::ShaderMode shader_mode = RS::SHADER_MAX;
+	uint32_t shader_id = 0;
+	bool uniform_dirty = false;
+	bool texture_dirty = false;
 	Map<StringName, Variant> params;
-	SelfList<Material> list;
-	SelfList<Material> dirty_list;
-	Vector<Pair<StringName, RID>> textures;
-	float line_width;
-	int render_priority;
-
+	int32_t priority = 0;
 	RID next_pass;
+	SelfList<Material> update_element;
 
-	uint32_t index;
-	uint64_t last_pass;
-
-	//		Map<Geometry *, int> geometry_owners;
-	//		Map<InstanceBaseDependency *, int> instance_owners;
-
-	bool can_cast_shadow_cache;
-	bool is_animated_cache;
+	RendererStorage::Dependency dependency;
 
 	Material() :
-			list(this),
-			dirty_list(this) {
-		can_cast_shadow_cache = false;
-		is_animated_cache = false;
-		shader = nullptr;
-		line_width = 1.0;
-		last_pass = 0;
-		render_priority = 0;
-	}
+			update_element(this) {}
+};
+
+// CanvasItem Materials
+
+struct CanvasShaderData : public ShaderData {
+	enum BlendMode { //used internally
+		BLEND_MODE_MIX,
+		BLEND_MODE_ADD,
+		BLEND_MODE_SUB,
+		BLEND_MODE_MUL,
+		BLEND_MODE_PMALPHA,
+		BLEND_MODE_DISABLED,
+	};
+
+	bool valid;
+	RID version;
+	//PipelineVariants pipeline_variants;
+	String path;
+
+	Map<StringName, ShaderLanguage::ShaderNode::Uniform> uniforms;
+	Vector<ShaderCompiler::GeneratedCode::Texture> texture_uniforms;
+
+	Vector<uint32_t> ubo_offsets;
+	uint32_t ubo_size;
+
+	String code;
+	Map<StringName, Map<int, RID>> default_texture_params;
+
+	bool uses_screen_texture = false;
+	bool uses_sdf = false;
+	bool uses_time = false;
+
+	virtual void set_code(const String &p_Code);
+	virtual void set_default_texture_param(const StringName &p_name, RID p_texture, int p_index);
+	virtual void get_param_list(List<PropertyInfo> *p_param_list) const;
+	virtual void get_instance_param_list(List<RendererMaterialStorage::InstanceShaderParam> *p_param_list) const;
+
+	virtual bool is_param_texture(const StringName &p_param) const;
+	virtual bool is_animated() const;
+	virtual bool casts_shadows() const;
+	virtual Variant get_default_parameter(const StringName &p_parameter) const;
+	virtual RS::ShaderNativeSourceCode get_native_source_code() const;
+
+	CanvasShaderData();
+	virtual ~CanvasShaderData();
+};
+
+ShaderData *_create_canvas_shader_func();
+
+struct CanvasMaterialData : public MaterialData {
+	CanvasShaderData *shader_data = nullptr;
+
+	virtual void set_render_priority(int p_priority) {}
+	virtual void set_next_pass(RID p_pass) {}
+	virtual void update_parameters(const Map<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty);
+	virtual void bind_uniforms();
+	virtual ~CanvasMaterialData();
+};
+
+MaterialData *_create_canvas_material_func(ShaderData *p_shader);
+
+/* Global variable structs */
+struct GlobalVariables {
+	enum {
+		BUFFER_DIRTY_REGION_SIZE = 1024
+	};
+	struct Variable {
+		Set<RID> texture_materials; // materials using this
+
+		RS::GlobalVariableType type;
+		Variant value;
+		Variant override;
+		int32_t buffer_index; //for vectors
+		int32_t buffer_elements; //for vectors
+	};
+
+	HashMap<StringName, Variable> variables;
+
+	struct Value {
+		float x;
+		float y;
+		float z;
+		float w;
+	};
+
+	struct ValueInt {
+		int32_t x;
+		int32_t y;
+		int32_t z;
+		int32_t w;
+	};
+
+	struct ValueUInt {
+		uint32_t x;
+		uint32_t y;
+		uint32_t z;
+		uint32_t w;
+	};
+
+	struct ValueUsage {
+		uint32_t elements = 0;
+	};
+
+	List<RID> materials_using_buffer;
+	List<RID> materials_using_texture;
+
+	GLuint buffer = GLuint(0);
+	Value *buffer_values = nullptr;
+	ValueUsage *buffer_usage = nullptr;
+	bool *buffer_dirty_regions = nullptr;
+	uint32_t buffer_dirty_region_count = 0;
+
+	uint32_t buffer_size;
+
+	bool must_update_texture_materials = false;
+	bool must_update_buffer_materials = false;
+
+	HashMap<RID, int32_t> instance_buffer_pos;
 };
 
 class MaterialStorage : public RendererMaterialStorage {
 private:
+	friend struct MaterialData;
 	static MaterialStorage *singleton;
+
+	/* GLOBAL VARIABLE API */
+
+	GlobalVariables global_variables;
+
+	int32_t _global_variable_allocate(uint32_t p_elements);
+	void _global_variable_store_in_buffer(int32_t p_index, RS::GlobalVariableType p_type, const Variant &p_value);
+	void _global_variable_mark_buffer_dirty(int32_t p_index, int32_t p_elements);
 
 	/* SHADER API */
 
-	mutable Shaders shaders;
-
-	mutable RID_PtrOwner<Shader> shader_owner;
-	mutable SelfList<Shader>::List _shader_dirty_list;
+	ShaderDataRequestFunction shader_data_request_func[RS::SHADER_MAX];
+	mutable RID_Owner<Shader, true> shader_owner;
 
 	/* MATERIAL API */
+	MaterialDataRequestFunction material_data_request_func[RS::SHADER_MAX];
+	mutable RID_Owner<Material, true> material_owner;
 
-	mutable SelfList<Material>::List _material_dirty_list;
-	mutable RID_PtrOwner<Material> material_owner;
+	SelfList<Material>::List material_update_list;
+
+	//static void _material_uniform_set_erased(void *p_material);
 
 public:
 	static MaterialStorage *get_singleton();
@@ -238,7 +291,11 @@ public:
 	MaterialStorage();
 	virtual ~MaterialStorage();
 
+	Shaders shaders;
+
 	/* GLOBAL VARIABLE API */
+
+	void _update_global_variables();
 
 	virtual void global_variable_add(const StringName &p_name, RS::GlobalVariableType p_type, const Variant &p_value) override;
 	virtual void global_variable_remove(const StringName &p_name) override;
@@ -248,6 +305,7 @@ public:
 	virtual void global_variable_set_override(const StringName &p_name, const Variant &p_value) override;
 	virtual Variant global_variable_get(const StringName &p_name) const override;
 	virtual RS::GlobalVariableType global_variable_get_type(const StringName &p_name) const override;
+	RS::GlobalVariableType global_variable_get_type_internal(const StringName &p_name) const;
 
 	virtual void global_variables_load_settings(bool p_load_textures = true) override;
 	virtual void global_variables_clear() override;
@@ -255,6 +313,8 @@ public:
 	virtual int32_t global_variables_instance_allocate(RID p_instance) override;
 	virtual void global_variables_instance_free(RID p_instance) override;
 	virtual void global_variables_instance_update(RID p_instance, int p_index, const Variant &p_value) override;
+
+	GLuint global_variables_get_uniform_buffer() const;
 
 	/* SHADER API */
 
@@ -267,68 +327,56 @@ public:
 	virtual void shader_initialize(RID p_rid) override;
 	virtual void shader_free(RID p_rid) override;
 
-	//RID shader_create() override;
-
 	virtual void shader_set_code(RID p_shader, const String &p_code) override;
 	virtual String shader_get_code(RID p_shader) const override;
 	virtual void shader_get_param_list(RID p_shader, List<PropertyInfo> *p_param_list) const override;
 
 	virtual void shader_set_default_texture_param(RID p_shader, const StringName &p_name, RID p_texture, int p_index) override;
 	virtual RID shader_get_default_texture_param(RID p_shader, const StringName &p_name, int p_index) const override;
+	virtual Variant shader_get_param_default(RID p_shader, const StringName &p_param) const override;
 
-	virtual RS::ShaderNativeSourceCode shader_get_native_source_code(RID p_shader) const override { return RS::ShaderNativeSourceCode(); };
-
-	void _update_shader(Shader *p_shader) const;
-	void update_dirty_shaders();
-
-	// new
-	Variant shader_get_param_default(RID p_material, const StringName &p_param) const override { return Variant(); }
+	virtual RS::ShaderNativeSourceCode shader_get_native_source_code(RID p_shader) const override;
 
 	/* MATERIAL API */
 
 	Material *get_material(RID p_rid) { return material_owner.get_or_null(p_rid); };
 	bool owns_material(RID p_rid) { return material_owner.owns(p_rid); };
 
-	void _material_make_dirty(Material *p_material) const;
+	void _material_queue_update(Material *material, bool p_uniform, bool p_texture);
+	void _update_queued_materials();
 
-	//	void _material_add_geometry(RID p_material, Geometry *p_geometry);
-	//	void _material_remove_geometry(RID p_material, Geometry *p_geometry);
-
-	void _update_material(Material *p_material);
-
-	// new
-	virtual void material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) override {}
-	virtual void material_update_dependency(RID p_material, RendererStorage::DependencyTracker *p_instance) override {}
-
-	// old
 	virtual RID material_allocate() override;
 	virtual void material_initialize(RID p_rid) override;
-
 	virtual void material_free(RID p_rid) override;
 
-	//RID material_create() override;
-
 	virtual void material_set_shader(RID p_material, RID p_shader) override;
-	virtual RID material_get_shader(RID p_material) const;
 
 	virtual void material_set_param(RID p_material, const StringName &p_param, const Variant &p_value) override;
 	virtual Variant material_get_param(RID p_material, const StringName &p_param) const override;
-	virtual Variant material_get_param_default(RID p_material, const StringName &p_param) const;
 
-	void material_set_line_width(RID p_material, float p_width);
 	virtual void material_set_next_pass(RID p_material, RID p_next_material) override;
+	virtual void material_set_render_priority(RID p_material, int priority) override;
 
 	virtual bool material_is_animated(RID p_material) override;
 	virtual bool material_casts_shadows(RID p_material) override;
-	bool material_uses_tangents(RID p_material);
-	bool material_uses_ensure_correct_normals(RID p_material);
 
-	void material_add_instance_owner(RID p_material, RendererStorage::DependencyTracker *p_instance);
-	void material_remove_instance_owner(RID p_material, RendererStorage::DependencyTracker *p_instance);
+	virtual void material_get_instance_shader_parameters(RID p_material, List<InstanceShaderParam> *r_parameters) override;
 
-	void material_set_render_priority(RID p_material, int priority) override;
+	virtual void material_update_dependency(RID p_material, RendererStorage::DependencyTracker *p_instance) override;
 
-	void update_dirty_materials();
+	_FORCE_INLINE_ uint32_t material_get_shader_id(RID p_material) {
+		Material *material = material_owner.get_or_null(p_material);
+		return material->shader_id;
+	}
+
+	_FORCE_INLINE_ MaterialData *material_get_data(RID p_material, RS::ShaderMode p_shader_mode) {
+		Material *material = material_owner.get_or_null(p_material);
+		if (!material || material->shader_mode != p_shader_mode) {
+			return nullptr;
+		} else {
+			return material->data;
+		}
+	}
 };
 
 } // namespace GLES3

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -41,87 +41,152 @@ TextureStorage *TextureStorage::get_singleton() {
 	return singleton;
 }
 
+static const GLenum _cube_side_enum[6] = {
+	GL_TEXTURE_CUBE_MAP_NEGATIVE_X,
+	GL_TEXTURE_CUBE_MAP_POSITIVE_X,
+	GL_TEXTURE_CUBE_MAP_NEGATIVE_Y,
+	GL_TEXTURE_CUBE_MAP_POSITIVE_Y,
+	GL_TEXTURE_CUBE_MAP_NEGATIVE_Z,
+	GL_TEXTURE_CUBE_MAP_POSITIVE_Z,
+};
+
 TextureStorage::TextureStorage() {
 	singleton = this;
 
 	system_fbo = 0;
 
-	frame.count = 0;
-	frame.delta = 0;
 	frame.current_rt = nullptr;
-	frame.clear_request = false;
 
-	Config *config = Config::get_singleton();
+	{ //create default textures
+		{ // White Textures
 
-	//determine formats for depth textures (or renderbuffers)
-	if (config->support_depth_texture) {
-		// Will use texture for depth
-		// have to manually see if we can create a valid framebuffer texture using UNSIGNED_INT,
-		// as there is no extension to test for this.
-		GLuint fbo;
-		glGenFramebuffers(1, &fbo);
-		glBindFramebuffer(GL_FRAMEBUFFER, fbo);
-		GLuint depth;
-		glGenTextures(1, &depth);
-		glBindTexture(GL_TEXTURE_2D, depth);
-		glTexImage2D(GL_TEXTURE_2D, 0, config->depth_internalformat, 32, 32, 0, GL_DEPTH_COMPONENT, config->depth_type, nullptr);
+			Ref<Image> image;
+			image.instantiate();
+			image->create(4, 4, false, Image::FORMAT_RGBA8);
+			image->fill(Color(1, 1, 1, 1));
 
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+			default_gl_textures[DEFAULT_GL_TEXTURE_WHITE] = texture_allocate();
+			texture_2d_initialize(default_gl_textures[DEFAULT_GL_TEXTURE_WHITE], image);
 
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depth, 0);
+			Vector<Ref<Image>> images;
+			images.push_back(image);
 
-		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
+			default_gl_textures[DEFAULT_GL_TEXTURE_2D_ARRAY_WHITE] = texture_allocate();
+			texture_2d_layered_initialize(default_gl_textures[DEFAULT_GL_TEXTURE_2D_ARRAY_WHITE], images, RS::TEXTURE_LAYERED_2D_ARRAY);
 
-		glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
-		glDeleteFramebuffers(1, &fbo);
-		glBindTexture(GL_TEXTURE_2D, 0);
-		glDeleteTextures(1, &depth);
-
-		if (status != GL_FRAMEBUFFER_COMPLETE) {
-			// If it fails, test to see if it supports a framebuffer texture using UNSIGNED_SHORT
-			// This is needed because many OSX devices don't support either UNSIGNED_INT or UNSIGNED_SHORT
-#ifdef GLES_OVER_GL
-			config->depth_internalformat = GL_DEPTH_COMPONENT16;
-#else
-			// OES_depth_texture extension only specifies GL_DEPTH_COMPONENT.
-			config->depth_internalformat = GL_DEPTH_COMPONENT;
-#endif
-			config->depth_type = GL_UNSIGNED_SHORT;
-
-			glGenFramebuffers(1, &fbo);
-			glBindFramebuffer(GL_FRAMEBUFFER, fbo);
-
-			glGenTextures(1, &depth);
-			glBindTexture(GL_TEXTURE_2D, depth);
-			glTexImage2D(GL_TEXTURE_2D, 0, config->depth_internalformat, 32, 32, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT, nullptr);
-
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, depth, 0);
-
-			status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-			if (status != GL_FRAMEBUFFER_COMPLETE) {
-				//if it fails again depth textures aren't supported, use rgba shadows and renderbuffer for depth
-				config->support_depth_texture = false;
-				config->use_rgba_3d_shadows = true;
+			for (int i = 0; i < 3; i++) {
+				images.push_back(image);
 			}
 
-			glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
-			glDeleteFramebuffers(1, &fbo);
-			glBindTexture(GL_TEXTURE_2D, 0);
-			glDeleteTextures(1, &depth);
+			default_gl_textures[DEFAULT_GL_TEXTURE_3D_WHITE] = texture_allocate();
+			texture_3d_initialize(default_gl_textures[DEFAULT_GL_TEXTURE_3D_WHITE], image->get_format(), 4, 4, 4, false, images);
+
+			for (int i = 0; i < 2; i++) {
+				images.push_back(image);
+			}
+
+			default_gl_textures[DEFAULT_GL_TEXTURE_CUBEMAP_WHITE] = texture_allocate();
+			texture_2d_layered_initialize(default_gl_textures[DEFAULT_GL_TEXTURE_CUBEMAP_WHITE], images, RS::TEXTURE_LAYERED_CUBEMAP);
+		}
+
+		{ // black
+			Ref<Image> image;
+			image.instantiate();
+			image->create(4, 4, false, Image::FORMAT_RGBA8);
+			image->fill(Color(0, 0, 0, 1));
+
+			default_gl_textures[DEFAULT_GL_TEXTURE_BLACK] = texture_allocate();
+			texture_2d_initialize(default_gl_textures[DEFAULT_GL_TEXTURE_BLACK], image);
+
+			Vector<Ref<Image>> images;
+
+			for (int i = 0; i < 4; i++) {
+				images.push_back(image);
+			}
+
+			default_gl_textures[DEFAULT_GL_TEXTURE_3D_BLACK] = texture_allocate();
+			texture_3d_initialize(default_gl_textures[DEFAULT_GL_TEXTURE_3D_BLACK], image->get_format(), 4, 4, 4, false, images);
+
+			for (int i = 0; i < 2; i++) {
+				images.push_back(image);
+			}
+			default_gl_textures[DEFAULT_GL_TEXTURE_CUBEMAP_BLACK] = texture_allocate();
+			texture_2d_layered_initialize(default_gl_textures[DEFAULT_GL_TEXTURE_CUBEMAP_BLACK], images, RS::TEXTURE_LAYERED_CUBEMAP);
+		}
+
+		{
+			Ref<Image> image;
+			image.instantiate();
+			image->create(4, 4, false, Image::FORMAT_RGBA8);
+			image->fill(Color(0.5, 0.5, 1, 1));
+
+			default_gl_textures[DEFAULT_GL_TEXTURE_NORMAL] = texture_allocate();
+			texture_2d_initialize(default_gl_textures[DEFAULT_GL_TEXTURE_NORMAL], image);
+		}
+
+		{
+			Ref<Image> image;
+			image.instantiate();
+			image->create(4, 4, false, Image::FORMAT_RGBA8);
+			image->fill(Color(1.0, 0.5, 1, 1));
+
+			default_gl_textures[DEFAULT_GL_TEXTURE_ANISO] = texture_allocate();
+			texture_2d_initialize(default_gl_textures[DEFAULT_GL_TEXTURE_ANISO], image);
+		}
+
+		{
+			unsigned char pixel_data[4 * 4 * 4];
+			for (int i = 0; i < 16; i++) {
+				pixel_data[i * 4 + 0] = 0;
+				pixel_data[i * 4 + 1] = 0;
+				pixel_data[i * 4 + 2] = 0;
+				pixel_data[i * 4 + 3] = 0;
+			}
+
+			default_gl_textures[DEFAULT_GL_TEXTURE_2D_UINT] = texture_allocate();
+			Texture texture;
+			texture.width = 4;
+			texture.height = 4;
+			texture.format = Image::FORMAT_RGBA8;
+			texture.type = Texture::TYPE_2D;
+			texture.target = GL_TEXTURE_2D;
+			texture.active = true;
+			glGenTextures(1, &texture.tex_id);
+			texture_owner.initialize_rid(default_gl_textures[DEFAULT_GL_TEXTURE_2D_UINT], texture);
+
+			glBindTexture(GL_TEXTURE_2D, texture.tex_id);
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA8UI, 4, 4, 0, GL_RGBA_INTEGER, GL_UNSIGNED_BYTE, pixel_data);
+			texture.gl_set_filter(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST);
+		}
+		{
+			uint16_t pixel_data[4 * 4];
+			for (int i = 0; i < 16; i++) {
+				pixel_data[i] = Math::make_half_float(1.0f);
+			}
+
+			default_gl_textures[DEFAULT_GL_TEXTURE_DEPTH] = texture_allocate();
+			Texture texture;
+			texture.width = 4;
+			texture.height = 4;
+			texture.format = Image::FORMAT_RGBA8;
+			texture.type = Texture::TYPE_2D;
+			texture.target = GL_TEXTURE_2D;
+			texture.active = true;
+			glGenTextures(1, &texture.tex_id);
+			texture_owner.initialize_rid(default_gl_textures[DEFAULT_GL_TEXTURE_DEPTH], texture);
+
+			glBindTexture(GL_TEXTURE_2D, texture.tex_id);
+			glTexImage2D(GL_TEXTURE_2D, 0, GL_DEPTH_COMPONENT16, 4, 4, 0, GL_DEPTH_COMPONENT, GL_UNSIGNED_SHORT, pixel_data);
+			texture.gl_set_filter(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST);
 		}
 	}
 }
 
 TextureStorage::~TextureStorage() {
 	singleton = nullptr;
+	for (int i = 0; i < DEFAULT_GL_TEXTURE_MAX; i++) {
+		texture_free(default_gl_textures[i]);
+	}
 }
 
 void TextureStorage::set_main_thread_id(Thread::ID p_id) {
@@ -188,15 +253,6 @@ void TextureStorage::canvas_texture_set_texture_repeat(RID p_canvas_texture, RS:
 }
 
 /* Texture API */
-
-static const GLenum _cube_side_enum[6] = {
-	GL_TEXTURE_CUBE_MAP_NEGATIVE_X,
-	GL_TEXTURE_CUBE_MAP_POSITIVE_X,
-	GL_TEXTURE_CUBE_MAP_NEGATIVE_Y,
-	GL_TEXTURE_CUBE_MAP_POSITIVE_Y,
-	GL_TEXTURE_CUBE_MAP_NEGATIVE_Z,
-	GL_TEXTURE_CUBE_MAP_POSITIVE_Z,
-};
 
 Ref<Image> TextureStorage::_get_gl_image_and_format(const Ref<Image> &p_image, Image::Format p_format, uint32_t p_flags, Image::Format &r_real_format, GLenum &r_gl_format, GLenum &r_gl_internal_format, GLenum &r_gl_type, bool &r_compressed, bool p_force_decompress) const {
 	Config *config = Config::get_singleton();
@@ -547,250 +603,151 @@ Ref<Image> TextureStorage::_get_gl_image_and_format(const Ref<Image> &p_image, I
 	return p_image;
 }
 
-void TextureStorage::_texture_set_state_from_flags(Texture *p_tex) {
-	// Config *config = Config::get_singleton();
-
-	if ((p_tex->flags & TEXTURE_FLAG_MIPMAPS) && !p_tex->ignore_mipmaps) {
-		if (p_tex->flags & TEXTURE_FLAG_FILTER) {
-			// these do not exactly correspond ...
-			p_tex->GLSetFilter(p_tex->target, RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS);
-			//texture->glTexParam_MinFilter(texture->target, config->use_fast_texture_filter ? GL_LINEAR_MIPMAP_NEAREST : GL_LINEAR_MIPMAP_LINEAR);
-		} else {
-			p_tex->GLSetFilter(p_tex->target, RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS);
-			//texture->glTexParam_MinFilter(texture->target, config->use_fast_texture_filter ? GL_NEAREST_MIPMAP_NEAREST : GL_NEAREST_MIPMAP_LINEAR);
-		}
-	} else {
-		if (p_tex->flags & TEXTURE_FLAG_FILTER) {
-			p_tex->GLSetFilter(p_tex->target, RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR);
-			//texture->glTexParam_MinFilter(texture->target, GL_LINEAR);
-		} else {
-			p_tex->GLSetFilter(p_tex->target, RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST);
-			//texture->glTexParam_MinFilter(texture->target, GL_NEAREST);
-		}
-	}
-
-	if (((p_tex->flags & TEXTURE_FLAG_REPEAT) || (p_tex->flags & TEXTURE_FLAG_MIRRORED_REPEAT)) && p_tex->target != GL_TEXTURE_CUBE_MAP) {
-		if (p_tex->flags & TEXTURE_FLAG_MIRRORED_REPEAT) {
-			p_tex->GLSetRepeat(p_tex->target, RS::CANVAS_ITEM_TEXTURE_REPEAT_MIRROR);
-		} else {
-			p_tex->GLSetRepeat(p_tex->target, RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED);
-		}
-	} else {
-		p_tex->GLSetRepeat(p_tex->target, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);
-	}
-}
-
-void TextureStorage::_texture_allocate_internal(RID p_texture, int p_width, int p_height, int p_depth_3d, Image::Format p_format, RenderingDevice::TextureType p_type, uint32_t p_flags) {
-	//	GLenum format;
-	//	GLenum internal_format;
-	//	GLenum type;
-
-	//	bool compressed = false;
-
-	// Config *config = Config::get_singleton();
-
-	if (p_flags & TEXTURE_FLAG_USED_FOR_STREAMING) {
-		p_flags &= ~TEXTURE_FLAG_MIPMAPS; // no mipies for video
-	}
-
-	Texture *texture = texture_owner.get_or_null(p_texture);
-	ERR_FAIL_COND(!texture);
-	texture->width = p_width;
-	texture->height = p_height;
-	texture->format = p_format;
-	texture->flags = p_flags;
-	texture->stored_cube_sides = 0;
-	texture->type = p_type;
-
-	switch (p_type) {
-		case RenderingDevice::TEXTURE_TYPE_2D: {
-			texture->target = GL_TEXTURE_2D;
-			texture->images.resize(1);
-		} break;
-			//		case RenderingDevice::TEXTURE_TYPE_EXTERNAL: {
-			//#ifdef ANDROID_ENABLED
-			//			texture->target = _GL_TEXTURE_EXTERNAL_OES;
-			//#else
-			//			texture->target = GL_TEXTURE_2D;
-			//#endif
-			//			texture->images.resize(0);
-			//		} break;
-		case RenderingDevice::TEXTURE_TYPE_CUBE: {
-			texture->target = GL_TEXTURE_CUBE_MAP;
-			texture->images.resize(6);
-		} break;
-		case RenderingDevice::TEXTURE_TYPE_2D_ARRAY:
-		case RenderingDevice::TEXTURE_TYPE_3D: {
-			texture->target = GL_TEXTURE_3D;
-			ERR_PRINT("3D textures and Texture Arrays are not supported in OpenGL. Please switch to the Vulkan backend.");
-			return;
-		} break;
-		default: {
-			ERR_PRINT("Unknown texture type!");
-			return;
-		}
-	}
-
-#if 0
-	//		if (p_type != RS::TEXTURE_TYPE_EXTERNAL) {
-	if (p_type == RenderingDevice::TEXTURE_TYPE_2D) {
-		texture->alloc_width = texture->width;
-		texture->alloc_height = texture->height;
-		texture->resize_to_po2 = false;
-		if (!config->support_npot_repeat_mipmap) {
-			int po2_width = next_power_of_2(p_width);
-			int po2_height = next_power_of_2(p_height);
-
-			bool is_po2 = p_width == po2_width && p_height == po2_height;
-
-			if (!is_po2 && (p_flags & TEXTURE_FLAG_REPEAT || p_flags & TEXTURE_FLAG_MIPMAPS)) {
-				if (p_flags & TEXTURE_FLAG_USED_FOR_STREAMING) {
-					//not supported
-					ERR_PRINT("Streaming texture for non power of 2 or has mipmaps on this hardware: " + texture->path + "'. Mipmaps and repeat disabled.");
-					texture->flags &= ~(TEXTURE_FLAG_REPEAT | TEXTURE_FLAG_MIPMAPS);
-				} else {
-					texture->alloc_height = po2_height;
-					texture->alloc_width = po2_width;
-					texture->resize_to_po2 = true;
-				}
-			}
-		}
-
-		GLenum format;
-		GLenum internal_format;
-		GLenum type;
-		bool compressed = false;
-
-		Image::Format real_format;
-		_get_gl_image_and_format(Ref<Image>(),
-				texture->format,
-				texture->flags,
-				real_format,
-				format,
-				internal_format,
-				type,
-				compressed,
-				texture->resize_to_po2);
-
-		texture->gl_format_cache = format;
-		texture->gl_type_cache = type;
-		texture->gl_internal_format_cache = internal_format;
-		texture->data_size = 0;
-		texture->mipmaps = 1;
-
-		texture->compressed = compressed;
-	}
-#endif
-
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(texture->target, texture->tex_id);
-
-	//	if (p_type == RS::TEXTURE_TYPE_EXTERNAL) {
-	//		glTexParameteri(texture->target, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-	//		glTexParameteri(texture->target, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-	//		glTexParameteri(texture->target, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-	//		glTexParameteri(texture->target, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-	//	} else if (p_flags & TEXTURE_FLAG_USED_FOR_STREAMING) {
-	//		//prealloc if video
-	//		glTexImage2D(texture->target, 0, internal_format, texture->alloc_width, texture->alloc_height, 0, format, type, NULL);
-	//	}
-
-	texture->active = true;
-}
-
-RID TextureStorage::texture_create() {
-	ERR_FAIL_COND_V(!_is_main_thread(), RID());
-
-	Texture *texture = memnew(Texture);
-	ERR_FAIL_COND_V(!texture, RID());
-	glGenTextures(1, &texture->tex_id);
-	texture->active = false;
-	texture->total_data_size = 0;
-
-	return texture_owner.make_rid(texture);
-}
-
 RID TextureStorage::texture_allocate() {
-	RID id = texture_create();
-	ERR_FAIL_COND_V(id == RID(), id);
-	return id;
+	return texture_owner.allocate_rid();
 }
 
-void TextureStorage::texture_free(RID p_rid) {
-	Texture *t = texture_owner.get_or_null(p_rid);
+void TextureStorage::texture_free(RID p_texture) {
+	Texture *t = texture_owner.get_or_null(p_texture);
+	ERR_FAIL_COND(!t);
+	ERR_FAIL_COND(t->is_render_target);
 
-	// can't free a render target texture
-	ERR_FAIL_COND(t->render_target);
 	if (t->canvas_texture) {
 		memdelete(t->canvas_texture);
 	}
 
-	// info.texture_mem -= t->total_data_size; // TODO make this work again!!
-	texture_owner.free(p_rid);
-	memdelete(t);
+	if (t->tex_id != 0) {
+		glDeleteTextures(1, &t->tex_id);
+		t->tex_id = 0;
+	}
+
+	if (t->is_proxy && t->proxy_to.is_valid()) {
+		Texture *proxy_to = texture_owner.get_or_null(t->proxy_to);
+		if (proxy_to) {
+			proxy_to->proxies.erase(p_texture);
+		}
+	}
+
+	//decal_atlas_remove_texture(p_texture);
+
+	for (int i = 0; i < t->proxies.size(); i++) {
+		Texture *p = texture_owner.get_or_null(t->proxies[i]);
+		ERR_CONTINUE(!p);
+		p->proxy_to = RID();
+		p->tex_id = 0;
+	}
+
+	texture_owner.free(p_texture);
 }
 
 void TextureStorage::texture_2d_initialize(RID p_texture, const Ref<Image> &p_image) {
-	Texture *tex = texture_owner.get_or_null(p_texture);
-	ERR_FAIL_COND(!tex);
-
-	int w = p_image->get_width();
-	int h = p_image->get_height();
-
-	_texture_allocate_internal(p_texture, w, h, 1, p_image->get_format(), RenderingDevice::TEXTURE_TYPE_2D, 0);
+	Texture texture;
+	texture.width = p_image->get_width();
+	texture.height = p_image->get_height();
+	texture.format = p_image->get_format();
+	texture.type = Texture::TYPE_2D;
+	texture.target = GL_TEXTURE_2D;
+	texture.image_cache_2d = p_image; //TODO, remove this once texture_2d_get is implemented
+	texture.active = true;
+	glGenTextures(1, &texture.tex_id);
+	texture_owner.initialize_rid(p_texture, texture);
 	texture_set_data(p_texture, p_image);
 }
 
 void TextureStorage::texture_2d_layered_initialize(RID p_texture, const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) {
+	texture_owner.initialize_rid(p_texture, Texture());
 }
 
 void TextureStorage::texture_3d_initialize(RID p_texture, Image::Format, int p_width, int p_height, int p_depth, bool p_mipmaps, const Vector<Ref<Image>> &p_data) {
+	texture_owner.initialize_rid(p_texture, Texture());
 }
 
+// Called internally when texture_proxy_create(p_base) is called.
+// Note: p_base is the root and p_texture is the proxy.
 void TextureStorage::texture_proxy_initialize(RID p_texture, RID p_base) {
-	texture_set_proxy(p_texture, p_base);
+	Texture *texture = texture_owner.get_or_null(p_base);
+	ERR_FAIL_COND(!texture);
+	Texture proxy_tex;
+	proxy_tex.copy_from(*texture);
+	proxy_tex.proxy_to = p_base;
+	proxy_tex.is_render_target = false;
+	proxy_tex.is_proxy = true;
+	proxy_tex.proxies.clear();
+	texture->proxies.push_back(p_texture);
+	texture_owner.initialize_rid(p_texture, proxy_tex);
 }
-
-//RID TextureStorage::texture_2d_create(const Ref<Image> &p_image) {
-//	RID id = texture_create();
-//	ERR_FAIL_COND_V(id == RID(), id);
-
-//	int w = p_image->get_width();
-//	int h = p_image->get_height();
-
-//	texture_allocate(id, w, h, 1, p_image->get_format(), RenderingDevice::TEXTURE_TYPE_2D, 0);
-
-//	texture_set_data(id, p_image);
-
-//	return id;
-//}
-
-//RID TextureStorage::texture_2d_layered_create(const Vector<Ref<Image>> &p_layers, RS::TextureLayeredType p_layered_type) {
-//	return RID();
-//}
-
-//void TextureStorage::texture_2d_update_immediate(RID p_texture, const Ref<Image> &p_image, int p_layer) {
-//	// only 1 layer so far
-//	texture_set_data(p_texture, p_image);
-//}
 
 void TextureStorage::texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer) {
 	// only 1 layer so far
 	texture_set_data(p_texture, p_image);
+#ifdef TOOLS_ENABLED
+	Texture *tex = texture_owner.get_or_null(p_texture);
+
+	tex->image_cache_2d.unref();
+#endif
+}
+
+void TextureStorage::texture_proxy_update(RID p_texture, RID p_proxy_to) {
 }
 
 void TextureStorage::texture_2d_placeholder_initialize(RID p_texture) {
+	//this could be better optimized to reuse an existing image , done this way
+	//for now to get it working
+	Ref<Image> image;
+	image.instantiate();
+	image->create(4, 4, false, Image::FORMAT_RGBA8);
+	image->fill(Color(1, 0, 1, 1));
+
+	texture_2d_initialize(p_texture, image);
 }
 
 void TextureStorage::texture_2d_layered_placeholder_initialize(RID p_texture, RenderingServer::TextureLayeredType p_layered_type) {
+	//this could be better optimized to reuse an existing image , done this way
+	//for now to get it working
+	Ref<Image> image;
+	image.instantiate();
+	image->create(4, 4, false, Image::FORMAT_RGBA8);
+	image->fill(Color(1, 0, 1, 1));
+
+	Vector<Ref<Image>> images;
+	if (p_layered_type == RS::TEXTURE_LAYERED_2D_ARRAY) {
+		images.push_back(image);
+	} else {
+		//cube
+		for (int i = 0; i < 6; i++) {
+			images.push_back(image);
+		}
+	}
+
+	texture_2d_layered_initialize(p_texture, images, p_layered_type);
 }
 
 void TextureStorage::texture_3d_placeholder_initialize(RID p_texture) {
+	//this could be better optimized to reuse an existing image , done this way
+	//for now to get it working
+	Ref<Image> image;
+	image.instantiate();
+	image->create(4, 4, false, Image::FORMAT_RGBA8);
+	image->fill(Color(1, 0, 1, 1));
+
+	Vector<Ref<Image>> images;
+	//cube
+	for (int i = 0; i < 4; i++) {
+		images.push_back(image);
+	}
+
+	texture_3d_initialize(p_texture, Image::FORMAT_RGBA8, 4, 4, 4, false, images);
 }
 
 Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 	Texture *tex = texture_owner.get_or_null(p_texture);
 	ERR_FAIL_COND_V(!tex, Ref<Image>());
+
+#ifdef TOOLS_ENABLED
+	if (tex->image_cache_2d.is_valid() && !tex->is_render_target) {
+		return tex->image_cache_2d;
+	}
+#endif
 
 	/*
 #ifdef TOOLS_ENABLED
@@ -814,39 +771,70 @@ Ref<Image> TextureStorage::texture_2d_get(RID p_texture) const {
 	}
 #endif
 */
-	ERR_FAIL_COND_V(!tex->images.size(), Ref<Image>());
 
-	return tex->images[0];
+	/*
+	#ifdef TOOLS_ENABLED
+		if (Engine::get_singleton()->is_editor_hint() && !tex->is_render_target) {
+			tex->image_cache_2d = image;
+		}
+	#endif
+	*/
 
 	//	return image;
 
-	//	return Ref<Image>();
+	return Ref<Image>();
 }
 
 void TextureStorage::texture_replace(RID p_texture, RID p_by_texture) {
 	Texture *tex_to = texture_owner.get_or_null(p_texture);
 	ERR_FAIL_COND(!tex_to);
+	ERR_FAIL_COND(tex_to->is_proxy); //can't replace proxy
 	Texture *tex_from = texture_owner.get_or_null(p_by_texture);
 	ERR_FAIL_COND(!tex_from);
+	ERR_FAIL_COND(tex_from->is_proxy); //can't replace proxy
 
-	tex_to->destroy();
-	tex_to->copy_from(*tex_from);
-
-	// copy image data and upload to GL
-	tex_to->images.resize(tex_from->images.size());
-
-	for (int n = 0; n < tex_from->images.size(); n++) {
-		texture_set_data(p_texture, tex_from->images[n], n);
+	if (tex_to == tex_from) {
+		return;
 	}
 
-	texture_free(p_by_texture);
+	if (tex_to->canvas_texture) {
+		memdelete(tex_to->canvas_texture);
+		tex_to->canvas_texture = nullptr;
+	}
+
+	if (tex_to->tex_id) {
+		glDeleteTextures(1, &tex_to->tex_id);
+		tex_to->tex_id = 0;
+	}
+
+	Vector<RID> proxies_to_update = tex_to->proxies;
+	Vector<RID> proxies_to_redirect = tex_from->proxies;
+
+	tex_to->copy_from(*tex_from);
+
+	tex_to->proxies = proxies_to_update; //restore proxies, so they can be updated
+
+	if (tex_to->canvas_texture) {
+		tex_to->canvas_texture->diffuse = p_texture; //update
+	}
+
+	for (int i = 0; i < proxies_to_update.size(); i++) {
+		texture_proxy_update(proxies_to_update[i], p_texture);
+	}
+	for (int i = 0; i < proxies_to_redirect.size(); i++) {
+		texture_proxy_update(proxies_to_redirect[i], p_texture);
+	}
+	//delete last, so proxies can be updated
+	texture_owner.free(p_by_texture);
+
+	//decal_atlas_mark_dirty_on_texture(p_texture);
 }
 
 void TextureStorage::texture_set_size_override(RID p_texture, int p_width, int p_height) {
 	Texture *texture = texture_owner.get_or_null(p_texture);
 
 	ERR_FAIL_COND(!texture);
-	ERR_FAIL_COND(texture->render_target);
+	ERR_FAIL_COND(texture->is_render_target);
 
 	ERR_FAIL_COND(p_width <= 0 || p_width > 16384);
 	ERR_FAIL_COND(p_height <= 0 || p_height > 16384);
@@ -873,8 +861,8 @@ void TextureStorage::texture_set_detect_3d_callback(RID p_texture, RS::TextureDe
 	Texture *texture = texture_owner.get_or_null(p_texture);
 	ERR_FAIL_COND(!texture);
 
-	texture->detect_3d = p_callback;
-	texture->detect_3d_ud = p_userdata;
+	texture->detect_3d_callback = p_callback;
+	texture->detect_3d_callback_ud = p_userdata;
 }
 
 void TextureStorage::texture_set_detect_srgb_callback(RID p_texture, RS::TextureDetectCallback p_callback, void *p_userdata) {
@@ -889,8 +877,16 @@ void TextureStorage::texture_set_detect_normal_callback(RID p_texture, RS::Textu
 	Texture *texture = texture_owner.get_or_null(p_texture);
 	ERR_FAIL_COND(!texture);
 
-	texture->detect_normal = p_callback;
-	texture->detect_normal_ud = p_userdata;
+	texture->detect_normal_callback = p_callback;
+	texture->detect_normal_callback_ud = p_userdata;
+}
+
+void TextureStorage::texture_set_detect_roughness_callback(RID p_texture, RS::TextureDetectRoughnessCallback p_callback, void *p_userdata) {
+	Texture *texture = texture_owner.get_or_null(p_texture);
+	ERR_FAIL_COND(!texture);
+
+	texture->detect_roughness_callback = p_callback;
+	texture->detect_roughness_callback_ud = p_userdata;
 }
 
 void TextureStorage::texture_debug_usage(List<RS::TextureInfo> *r_info) {
@@ -923,47 +919,16 @@ void TextureStorage::texture_set_force_redraw_if_visible(RID p_texture, bool p_e
 Size2 TextureStorage::texture_size_with_proxy(RID p_texture) {
 	const Texture *texture = texture_owner.get_or_null(p_texture);
 	ERR_FAIL_COND_V(!texture, Size2());
-	if (texture->proxy) {
-		return Size2(texture->proxy->width, texture->proxy->height);
+	if (texture->is_proxy) {
+		const Texture *proxy = texture_owner.get_or_null(texture->proxy_to);
+		return Size2(proxy->width, proxy->height);
 	} else {
 		return Size2(texture->width, texture->height);
 	}
 }
 
-// example use in 3.2
-// VS::get_singleton()->texture_set_proxy(default_texture->proxy, texture_rid);
-
-// p_proxy is the source (pre-existing) texture?
-// and p_texture is the one that is being made into a proxy?
-//This naming is confusing. Comments!!!
-
-// The naming of the parameters seemed to be reversed?
-// The p_proxy is the source texture
-// and p_texture is actually the proxy????
-
-void TextureStorage::texture_set_proxy(RID p_texture, RID p_proxy) {
-	Texture *texture = texture_owner.get_or_null(p_texture);
-	ERR_FAIL_COND(!texture);
-
-	if (texture->proxy) {
-		texture->proxy->proxy_owners.erase(texture);
-		texture->proxy = nullptr;
-	}
-
-	if (p_proxy.is_valid()) {
-		Texture *proxy = texture_owner.get_or_null(p_proxy);
-		ERR_FAIL_COND(!proxy);
-		ERR_FAIL_COND(proxy == texture);
-		proxy->proxy_owners.insert(texture);
-		texture->proxy = proxy;
-	}
-}
-
 void TextureStorage::texture_set_data(RID p_texture, const Ref<Image> &p_image, int p_layer) {
-	Config *config = Config::get_singleton();
 	Texture *texture = texture_owner.get_or_null(p_texture);
-
-	ERR_FAIL_COND(!_is_main_thread());
 
 	ERR_FAIL_COND(!texture);
 	if (texture->target == GL_TEXTURE_3D) {
@@ -971,7 +936,7 @@ void TextureStorage::texture_set_data(RID p_texture, const Ref<Image> &p_image, 
 		return;
 	}
 	ERR_FAIL_COND(!texture->active);
-	ERR_FAIL_COND(texture->render_target);
+	ERR_FAIL_COND(texture->is_render_target);
 	ERR_FAIL_COND(p_image.is_null());
 	ERR_FAIL_COND(texture->format != p_image->get_format());
 
@@ -985,14 +950,10 @@ void TextureStorage::texture_set_data(RID p_texture, const Ref<Image> &p_image, 
 	GLenum internal_format;
 	bool compressed = false;
 
-	if (config->keep_original_textures && !(texture->flags & TEXTURE_FLAG_USED_FOR_STREAMING)) {
-		texture->images.write[p_layer] = p_image;
-	}
-
 	// print_line("texture_set_data width " + itos (p_image->get_width()) + " height " + itos(p_image->get_height()));
 
 	Image::Format real_format;
-	Ref<Image> img = _get_gl_image_and_format(p_image, p_image->get_format(), texture->flags, real_format, format, internal_format, type, compressed, texture->resize_to_po2);
+	Ref<Image> img = _get_gl_image_and_format(p_image, p_image->get_format(), 0, real_format, format, internal_format, type, compressed, texture->resize_to_po2);
 
 	if (texture->resize_to_po2) {
 		if (p_image->is_compressed()) {
@@ -1005,29 +966,16 @@ void TextureStorage::texture_set_data(RID p_texture, const Ref<Image> &p_image, 
 		img->resize_to_po2(false);
 	}
 
-	if (config->shrink_textures_x2 && (p_image->has_mipmaps() || !p_image->is_compressed()) && !(texture->flags & TEXTURE_FLAG_USED_FOR_STREAMING)) {
-		texture->alloc_height = MAX(1, texture->alloc_height / 2);
-		texture->alloc_width = MAX(1, texture->alloc_width / 2);
-
-		if (texture->alloc_width == img->get_width() / 2 && texture->alloc_height == img->get_height() / 2) {
-			img->shrink_x2();
-		} else if (img->get_format() <= Image::FORMAT_RGBA8) {
-			img->resize(texture->alloc_width, texture->alloc_height, Image::INTERPOLATE_BILINEAR);
-		}
-	}
-
 	GLenum blit_target = (texture->target == GL_TEXTURE_CUBE_MAP) ? _cube_side_enum[p_layer] : GL_TEXTURE_2D;
 
-	texture->data_size = img->get_data().size();
 	Vector<uint8_t> read = img->get_data();
 
 	glActiveTexture(GL_TEXTURE0);
 	glBindTexture(texture->target, texture->tex_id);
 
-	texture->ignore_mipmaps = compressed && !img->has_mipmaps();
-
-	// set filtering and repeat state
-	_texture_set_state_from_flags(texture);
+	// set filtering and repeat state to default
+	texture->gl_set_filter(RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST);
+	texture->gl_set_repeat(RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED);
 
 	//set swizle for older format compatibility
 #ifdef GLES_OVER_GL
@@ -1055,7 +1003,7 @@ void TextureStorage::texture_set_data(RID p_texture, const Ref<Image> &p_image, 
 	}
 #endif
 
-	int mipmaps = ((texture->flags & TEXTURE_FLAG_MIPMAPS) && img->has_mipmaps()) ? img->get_mipmap_count() + 1 : 1;
+	int mipmaps = img->has_mipmaps() ? img->get_mipmap_count() + 1 : 1;
 
 	int w = img->get_width();
 	int h = img->get_height();
@@ -1075,11 +1023,7 @@ void TextureStorage::texture_set_data(RID p_texture, const Ref<Image> &p_image, 
 			glCompressedTexImage2D(blit_target, i, internal_format, bw, bh, 0, size, &read[ofs]);
 		} else {
 			glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-			if (texture->flags & TEXTURE_FLAG_USED_FOR_STREAMING) {
-				glTexSubImage2D(blit_target, i, 0, 0, w, h, format, type, &read[ofs]);
-			} else {
-				glTexImage2D(blit_target, i, internal_format, w, h, 0, format, type, &read[ofs]);
-			}
+			glTexImage2D(blit_target, i, internal_format, w, h, 0, format, type, &read[ofs]);
 		}
 
 		tsize += size;
@@ -1096,17 +1040,16 @@ void TextureStorage::texture_set_data(RID p_texture, const Ref<Image> &p_image, 
 
 	texture->stored_cube_sides |= (1 << p_layer);
 
-	if ((texture->flags & TEXTURE_FLAG_MIPMAPS) && mipmaps == 1 && !texture->ignore_mipmaps && (texture->type != RenderingDevice::TEXTURE_TYPE_CUBE || texture->stored_cube_sides == (1 << 6) - 1)) {
-		//generate mipmaps if they were requested and the image does not contain them
-		glGenerateMipmap(texture->target);
-	}
+	//if ((texture->flags & TEXTURE_FLAG_MIPMAPS) && mipmaps == 1 && !texture->ignore_mipmaps && (texture->type != RenderingDevice::TEXTURE_TYPE_CUBE || texture->stored_cube_sides == (1 << 6) - 1)) {
+	//generate mipmaps if they were requested and the image does not contain them
+	//	glGenerateMipmap(texture->target);
+	//}
 
 	texture->mipmaps = mipmaps;
 }
 
 void TextureStorage::texture_set_data_partial(RID p_texture, const Ref<Image> &p_image, int src_x, int src_y, int src_w, int src_h, int dst_x, int dst_y, int p_dst_mip, int p_layer) {
-	// TODO
-	ERR_PRINT("Not implemented (ask Karroffel to do it :p)");
+	ERR_PRINT("Not implemented yet, sorry :(");
 }
 
 /*
@@ -1117,9 +1060,6 @@ Ref<Image> TextureStorage::texture_get_data(RID p_texture, int p_layer) const {
 	ERR_FAIL_COND_V(!texture->active, Ref<Image>());
 	ERR_FAIL_COND_V(texture->data_size == 0 && !texture->render_target, Ref<Image>());
 
-	if (texture->type == RS::TEXTURE_TYPE_CUBEMAP && p_layer < 6 && p_layer >= 0 && !texture->images[p_layer].is_null()) {
-		return texture->images[p_layer];
-	}
 
 #ifdef GLES_OVER_GL
 
@@ -1234,49 +1174,12 @@ Ref<Image> TextureStorage::texture_get_data(RID p_texture, int p_layer) const {
 }
 */
 
-void TextureStorage::texture_set_flags(RID p_texture, uint32_t p_flags) {
-	Texture *texture = texture_owner.get_or_null(p_texture);
-	ERR_FAIL_COND(!texture);
-
-	bool had_mipmaps = texture->flags & TEXTURE_FLAG_MIPMAPS;
-
-	texture->flags = p_flags;
-
-	glActiveTexture(GL_TEXTURE0);
-	glBindTexture(texture->target, texture->tex_id);
-
-	// set filtering and repeat state
-	_texture_set_state_from_flags(texture);
-
-	if ((texture->flags & TEXTURE_FLAG_MIPMAPS) && !texture->ignore_mipmaps) {
-		if (!had_mipmaps && texture->mipmaps == 1) {
-			glGenerateMipmap(texture->target);
-		}
-	}
-}
-
-uint32_t TextureStorage::texture_get_flags(RID p_texture) const {
-	Texture *texture = texture_owner.get_or_null(p_texture);
-
-	ERR_FAIL_COND_V(!texture, 0);
-
-	return texture->flags;
-}
-
 Image::Format TextureStorage::texture_get_format(RID p_texture) const {
 	Texture *texture = texture_owner.get_or_null(p_texture);
 
 	ERR_FAIL_COND_V(!texture, Image::FORMAT_L8);
 
 	return texture->format;
-}
-
-RenderingDevice::TextureType TextureStorage::texture_get_type(RID p_texture) const {
-	Texture *texture = texture_owner.get_or_null(p_texture);
-
-	ERR_FAIL_COND_V(!texture, RenderingDevice::TEXTURE_TYPE_2D);
-
-	return texture->type;
 }
 
 uint32_t TextureStorage::texture_get_texid(RID p_texture) const {
@@ -1320,16 +1223,8 @@ void TextureStorage::texture_bind(RID p_texture, uint32_t p_texture_no) {
 	glBindTexture(texture->target, texture->tex_id);
 }
 
-void TextureStorage::texture_set_shrink_all_x2_on_set_data(bool p_enable) {
-	Config::get_singleton()->shrink_textures_x2 = p_enable;
-}
-
 RID TextureStorage::texture_create_radiance_cubemap(RID p_source, int p_resolution) const {
 	return RID();
-}
-
-void TextureStorage::textures_keep_original(bool p_enable) {
-	Config::get_singleton()->keep_original_textures = p_enable;
 }
 
 /* DECAL API */
@@ -1382,32 +1277,29 @@ void TextureStorage::_set_current_render_target(RID p_render_target) {
 	if (rt) {
 		if (rt->allocate_is_dirty) {
 			rt->allocate_is_dirty = false;
-			_render_target_allocate(rt);
+			//_clear_render_target(rt);
+			//_update_render_target(rt);
 		}
 
 		frame.current_rt = rt;
 		ERR_FAIL_COND(!rt);
-		frame.clear_request = false;
 
-		glViewport(0, 0, rt->width, rt->height);
+		glViewport(rt->position.x, rt->position.y, rt->size.x, rt->size.y);
 
-		_dims.rt_width = rt->width;
-		_dims.rt_height = rt->height;
-		_dims.win_width = rt->width;
-		_dims.win_height = rt->height;
+		_dims.rt_width = rt->size.x;
+		_dims.rt_height = rt->size.y;
+		_dims.win_width = rt->size.x;
+		_dims.win_height = rt->size.y;
 
 	} else {
 		frame.current_rt = nullptr;
-		frame.clear_request = false;
 		glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
 	}
 }
 
-void TextureStorage::_render_target_allocate(RenderTarget *rt) {
-	Config *config = Config::get_singleton();
-
+void TextureStorage::_update_render_target(RenderTarget *rt) {
 	// do not allocate a render target with no size
-	if (rt->width <= 0 || rt->height <= 0) {
+	if (rt->size.x <= 0 || rt->size.y <= 0) {
 		return;
 	}
 
@@ -1417,31 +1309,13 @@ void TextureStorage::_render_target_allocate(RenderTarget *rt) {
 		return;
 	}
 
-	GLuint color_internal_format;
-	GLuint color_format;
-	GLuint color_type = GL_UNSIGNED_BYTE;
-	Image::Format image_format;
+	rt->color_internal_format = rt->flags[RENDER_TARGET_TRANSPARENT] ? GL_RGBA8 : GL_RGB10_A2;
+	rt->color_format = GL_RGBA;
+	rt->image_format = Image::FORMAT_RGBA8;
 
-	if (rt->flags[TextureStorage::RENDER_TARGET_TRANSPARENT]) {
-#ifdef GLES_OVER_GL
-		color_internal_format = GL_RGBA8;
-#else
-		color_internal_format = GL_RGBA;
-#endif
-		color_format = GL_RGBA;
-		image_format = Image::FORMAT_RGBA8;
-	} else {
-#ifdef GLES_OVER_GL
-		color_internal_format = GL_RGB8;
-#else
-		color_internal_format = GL_RGB;
-#endif
-		color_format = GL_RGB;
-		image_format = Image::FORMAT_RGB8;
-	}
-
-	rt->used_dof_blur_near = false;
-	rt->mip_maps_allocated = false;
+	glDisable(GL_SCISSOR_TEST);
+	glColorMask(1, 1, 1, 1);
+	glDepthMask(GL_FALSE);
 
 	{
 		/* Front FBO */
@@ -1457,180 +1331,52 @@ void TextureStorage::_render_target_allocate(RenderTarget *rt) {
 		glGenTextures(1, &rt->color);
 		glBindTexture(GL_TEXTURE_2D, rt->color);
 
-		glTexImage2D(GL_TEXTURE_2D, 0, color_internal_format, rt->width, rt->height, 0, color_format, color_type, nullptr);
+		glTexImage2D(GL_TEXTURE_2D, 0, rt->color_internal_format, rt->size.x, rt->size.y, 0, rt->color_format, rt->color_type, nullptr);
 
-		if (texture->flags & TEXTURE_FLAG_FILTER) {
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		} else {
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		}
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
 		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->color, 0);
 
-		// depth
-
-		if (config->support_depth_texture) {
-			glGenTextures(1, &rt->depth);
-			glBindTexture(GL_TEXTURE_2D, rt->depth);
-			glTexImage2D(GL_TEXTURE_2D, 0, config->depth_internalformat, rt->width, rt->height, 0, GL_DEPTH_COMPONENT, config->depth_type, nullptr);
-
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth, 0);
-		} else {
-			glGenRenderbuffers(1, &rt->depth);
-			glBindRenderbuffer(GL_RENDERBUFFER, rt->depth);
-
-			glRenderbufferStorage(GL_RENDERBUFFER, config->depth_buffer_internalformat, rt->width, rt->height);
-
-			glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->depth);
-		}
-
 		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
 
 		if (status != GL_FRAMEBUFFER_COMPLETE) {
 			glDeleteFramebuffers(1, &rt->fbo);
-			if (config->support_depth_texture) {
-				glDeleteTextures(1, &rt->depth);
-			} else {
-				glDeleteRenderbuffers(1, &rt->depth);
-			}
-
 			glDeleteTextures(1, &rt->color);
 			rt->fbo = 0;
-			rt->width = 0;
-			rt->height = 0;
+			rt->size.x = 0;
+			rt->size.y = 0;
 			rt->color = 0;
-			rt->depth = 0;
 			texture->tex_id = 0;
 			texture->active = false;
-			WARN_PRINT("Could not create framebuffer!!");
+			WARN_PRINT("Could not create render target, status: " + get_framebuffer_error(status));
 			return;
 		}
 
-		texture->format = image_format;
-		texture->gl_format_cache = color_format;
+		texture->format = rt->image_format;
+		texture->gl_format_cache = rt->color_format;
 		texture->gl_type_cache = GL_UNSIGNED_BYTE;
-		texture->gl_internal_format_cache = color_internal_format;
+		texture->gl_internal_format_cache = rt->color_internal_format;
 		texture->tex_id = rt->color;
-		texture->width = rt->width;
-		texture->alloc_width = rt->width;
-		texture->height = rt->height;
-		texture->alloc_height = rt->height;
+		texture->width = rt->size.x;
+		texture->alloc_width = rt->size.x;
+		texture->height = rt->size.y;
+		texture->alloc_height = rt->size.y;
 		texture->active = true;
-
-		texture_set_flags(rt->texture, texture->flags);
-	}
-
-	/* BACK FBO */
-	/* For MSAA */
-
-#ifndef JAVASCRIPT_ENABLED
-	if (rt->msaa >= RS::VIEWPORT_MSAA_2X && rt->msaa <= RS::VIEWPORT_MSAA_8X) {
-		rt->multisample_active = true;
-
-		static const int msaa_value[] = { 0, 2, 4, 8, 16 };
-		int msaa = msaa_value[rt->msaa];
-
-		int max_samples = 0;
-		glGetIntegerv(GL_MAX_SAMPLES, &max_samples);
-		if (msaa > max_samples) {
-			WARN_PRINT("MSAA must be <= GL_MAX_SAMPLES, falling-back to GL_MAX_SAMPLES = " + itos(max_samples));
-			msaa = max_samples;
-		}
-
-		//regular fbo
-		glGenFramebuffers(1, &rt->multisample_fbo);
-		glBindFramebuffer(GL_FRAMEBUFFER, rt->multisample_fbo);
-
-		glGenRenderbuffers(1, &rt->multisample_depth);
-		glBindRenderbuffer(GL_RENDERBUFFER, rt->multisample_depth);
-		glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa, config->depth_buffer_internalformat, rt->width, rt->height);
-
-		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->multisample_depth);
-
-		glGenRenderbuffers(1, &rt->multisample_color);
-		glBindRenderbuffer(GL_RENDERBUFFER, rt->multisample_color);
-		glRenderbufferStorageMultisample(GL_RENDERBUFFER, msaa, color_internal_format, rt->width, rt->height);
-
-		glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_RENDERBUFFER, rt->multisample_color);
-
-		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-
-		if (status != GL_FRAMEBUFFER_COMPLETE) {
-			// Delete allocated resources and default to no MSAA
-			WARN_PRINT_ONCE("Cannot allocate back framebuffer for MSAA");
-			printf("err status: %x\n", status);
-			rt->multisample_active = false;
-
-			glDeleteFramebuffers(1, &rt->multisample_fbo);
-			rt->multisample_fbo = 0;
-
-			glDeleteRenderbuffers(1, &rt->multisample_depth);
-			rt->multisample_depth = 0;
-
-			glDeleteRenderbuffers(1, &rt->multisample_color);
-			rt->multisample_color = 0;
-		}
-
-		glBindRenderbuffer(GL_RENDERBUFFER, 0);
-		glBindFramebuffer(GL_FRAMEBUFFER, 0);
-
-	} else
-#endif // JAVASCRIPT_ENABLED
-	{
-		rt->multisample_active = false;
 	}
 
 	glClearColor(0, 0, 0, 0);
-	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
+	glClear(GL_COLOR_BUFFER_BIT);
 
-	// copy texscreen buffers
-	//	if (!(rt->flags[TextureStorage::RENDER_TARGET_NO_SAMPLING])) {
-	if (true) {
-		glGenTextures(1, &rt->copy_screen_effect.color);
-		glBindTexture(GL_TEXTURE_2D, rt->copy_screen_effect.color);
-
-		if (rt->flags[TextureStorage::RENDER_TARGET_TRANSPARENT]) {
-			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, rt->width, rt->height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
-		} else {
-			glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, rt->width, rt->height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
-		}
-
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-		glGenFramebuffers(1, &rt->copy_screen_effect.fbo);
-		glBindFramebuffer(GL_FRAMEBUFFER, rt->copy_screen_effect.fbo);
-		glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->copy_screen_effect.color, 0);
-
-		glClearColor(0, 0, 0, 0);
-		glClear(GL_COLOR_BUFFER_BIT);
-
-		GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
-		if (status != GL_FRAMEBUFFER_COMPLETE) {
-			_render_target_clear(rt);
-			ERR_FAIL_COND(status != GL_FRAMEBUFFER_COMPLETE);
-		}
-	}
-
-	// Allocate mipmap chains for post_process effects
-	//	if (!rt->flags[RendererStorage::RENDER_TARGET_NO_3D] && rt->width >= 2 && rt->height >= 2) {
-	if (rt->width >= 2 && rt->height >= 2) {
+	// Allocate mipmap chains for full screen blur
+	if (rt->size.x >= 2 && rt->size.y >= 2) {
 		for (int i = 0; i < 2; i++) {
 			ERR_FAIL_COND(rt->mip_maps[i].sizes.size());
-			int w = rt->width;
-			int h = rt->height;
+			int w = rt->size.x;
+			int h = rt->size.y;
 
 			if (i > 0) {
 				w >>= 1;
@@ -1638,8 +1384,8 @@ void TextureStorage::_render_target_allocate(RenderTarget *rt) {
 			}
 
 			int level = 0;
-			int fb_w = w;
-			int fb_h = h;
+			GLsizei width = w;
+			GLsizei height = h;
 
 			while (true) {
 				RenderTarget::MipMaps::Size mm;
@@ -1657,97 +1403,52 @@ void TextureStorage::_render_target_allocate(RenderTarget *rt) {
 				level++;
 			}
 
-			GLsizei width = fb_w;
-			GLsizei height = fb_h;
+			glGenTextures(1, &rt->mip_maps[i].color);
+			glBindTexture(GL_TEXTURE_2D, rt->mip_maps[i].color);
 
-			if (config->render_to_mipmap_supported) {
-				glGenTextures(1, &rt->mip_maps[i].color);
-				glBindTexture(GL_TEXTURE_2D, rt->mip_maps[i].color);
-
-				for (int l = 0; l < level + 1; l++) {
-					glTexImage2D(GL_TEXTURE_2D, l, color_internal_format, width, height, 0, color_format, color_type, nullptr);
-					width = MAX(1, (width / 2));
-					height = MAX(1, (height / 2));
-				}
-#ifdef GLES_OVER_GL
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, level);
-#endif
-			} else {
-				// Can't render to specific levels of a mipmap in ES 2.0 or Webgl so create a texture for each level
-				for (int l = 0; l < level + 1; l++) {
-					glGenTextures(1, &rt->mip_maps[i].sizes.write[l].color);
-					glBindTexture(GL_TEXTURE_2D, rt->mip_maps[i].sizes[l].color);
-					glTexImage2D(GL_TEXTURE_2D, 0, color_internal_format, width, height, 0, color_format, color_type, nullptr);
-					width = MAX(1, (width / 2));
-					height = MAX(1, (height / 2));
-					glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-					glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
-					glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-					glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-				}
+			for (int l = 0; l < level + 1; l++) {
+				glTexImage2D(GL_TEXTURE_2D, l, rt->color_internal_format, width, height, 0, rt->color_format, rt->color_type, nullptr);
+				width = MAX(1, (width / 2));
+				height = MAX(1, (height / 2));
 			}
-
-			glDisable(GL_SCISSOR_TEST);
-			glColorMask(1, 1, 1, 1);
-			glDepthMask(GL_TRUE);
+#ifdef GLES_OVER_GL
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_BASE_LEVEL, 0);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAX_LEVEL, level);
+#endif
 
 			for (int j = 0; j < rt->mip_maps[i].sizes.size(); j++) {
 				RenderTarget::MipMaps::Size &mm = rt->mip_maps[i].sizes.write[j];
 
 				glGenFramebuffers(1, &mm.fbo);
-				glBindFramebuffer(GL_FRAMEBUFFER, mm.fbo);
+				bind_framebuffer(mm.fbo);
 
-				if (config->render_to_mipmap_supported) {
-					glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->mip_maps[i].color, j);
-				} else {
-					glBindTexture(GL_TEXTURE_2D, rt->mip_maps[i].sizes[j].color);
-					glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->mip_maps[i].sizes[j].color, 0);
-				}
-
-				bool used_depth = false;
-				if (j == 0 && i == 0) { //use always
-					if (config->support_depth_texture) {
-						glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth, 0);
-					} else {
-						glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->depth);
-					}
-					used_depth = true;
-				}
+				glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, rt->mip_maps[i].color, j);
 
 				GLenum status = glCheckFramebufferStatus(GL_FRAMEBUFFER);
 				if (status != GL_FRAMEBUFFER_COMPLETE) {
-					WARN_PRINT_ONCE("Cannot allocate mipmaps for 3D post processing effects");
-					glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
+					WARN_PRINT_ONCE("Cannot allocate mipmaps for canvas screen blur. Status: " + get_framebuffer_error(status));
+					bind_framebuffer_system();
 					return;
 				}
 
 				glClearColor(1.0, 0.0, 1.0, 0.0);
 				glClear(GL_COLOR_BUFFER_BIT);
-				if (used_depth) {
-					glClearDepth(1.0);
-					glClear(GL_DEPTH_BUFFER_BIT);
-				}
 			}
 
 			rt->mip_maps[i].levels = level;
 
-			if (config->render_to_mipmap_supported) {
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-			}
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 		}
 		rt->mip_maps_allocated = true;
 	}
 
-	glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
+	bind_framebuffer_system();
 }
 
-void TextureStorage::_render_target_clear(RenderTarget *rt) {
-	Config *config = Config::get_singleton();
-
+void TextureStorage::_clear_render_target(RenderTarget *rt) {
 	// there is nothing to clear when DIRECT_TO_SCREEN is used
 	if (rt->flags[RENDER_TARGET_DIRECT_TO_SCREEN]) {
 		return;
@@ -1757,8 +1458,9 @@ void TextureStorage::_render_target_clear(RenderTarget *rt) {
 		glDeleteFramebuffers(1, &rt->fbo);
 		glDeleteTextures(1, &rt->color);
 		rt->fbo = 0;
+		rt->color = 0;
 	}
-
+	/*
 	if (rt->external.fbo != 0) {
 		// free this
 		glDeleteFramebuffers(1, &rt->external.fbo);
@@ -1775,16 +1477,7 @@ void TextureStorage::_render_target_clear(RenderTarget *rt) {
 
 		rt->external.fbo = 0;
 	}
-
-	if (rt->depth) {
-		if (config->support_depth_texture) {
-			glDeleteTextures(1, &rt->depth);
-		} else {
-			glDeleteRenderbuffers(1, &rt->depth);
-		}
-
-		rt->depth = 0;
-	}
+	*/
 
 	Texture *tex = get_texture(rt->texture);
 	tex->alloc_height = 0;
@@ -1793,19 +1486,10 @@ void TextureStorage::_render_target_clear(RenderTarget *rt) {
 	tex->height = 0;
 	tex->active = false;
 
-	if (rt->copy_screen_effect.color) {
-		glDeleteFramebuffers(1, &rt->copy_screen_effect.fbo);
-		rt->copy_screen_effect.fbo = 0;
-
-		glDeleteTextures(1, &rt->copy_screen_effect.color);
-		rt->copy_screen_effect.color = 0;
-	}
-
 	for (int i = 0; i < 2; i++) {
 		if (rt->mip_maps[i].sizes.size()) {
 			for (int j = 0; j < rt->mip_maps[i].sizes.size(); j++) {
 				glDeleteFramebuffers(1, &rt->mip_maps[i].sizes[j].fbo);
-				glDeleteTextures(1, &rt->mip_maps[i].sizes[j].color);
 			}
 
 			glDeleteTextures(1, &rt->mip_maps[i].color);
@@ -1814,86 +1498,62 @@ void TextureStorage::_render_target_clear(RenderTarget *rt) {
 			rt->mip_maps[i].color = 0;
 		}
 	}
-
-	if (rt->multisample_active) {
-		glDeleteFramebuffers(1, &rt->multisample_fbo);
-		rt->multisample_fbo = 0;
-
-		glDeleteRenderbuffers(1, &rt->multisample_depth);
-		rt->multisample_depth = 0;
-
-		glDeleteRenderbuffers(1, &rt->multisample_color);
-
-		rt->multisample_color = 0;
-	}
 }
 
 RID TextureStorage::render_target_create() {
-	RenderTarget *rt = memnew(RenderTarget);
-	Texture *t = memnew(Texture);
+	RenderTarget render_target;
+	//render_target.was_used = false;
+	render_target.clear_requested = false;
 
-	t->type = RenderingDevice::TEXTURE_TYPE_2D;
-	t->flags = 0;
-	t->width = 0;
-	t->height = 0;
-	t->alloc_height = 0;
-	t->alloc_width = 0;
-	t->format = Image::FORMAT_R8;
-	t->target = GL_TEXTURE_2D;
-	t->gl_format_cache = 0;
-	t->gl_internal_format_cache = 0;
-	t->gl_type_cache = 0;
-	t->data_size = 0;
-	t->total_data_size = 0;
-	t->ignore_mipmaps = false;
-	t->compressed = false;
-	t->mipmaps = 1;
-	t->active = true;
-	t->tex_id = 0;
-	t->render_target = rt;
+	for (int i = 0; i < RENDER_TARGET_FLAG_MAX; i++) {
+		render_target.flags[i] = false;
+	}
+	Texture t;
+	t.active = true;
+	t.render_target = &render_target;
+	t.is_render_target = true;
 
-	rt->texture = make_rid(t);
-	return render_target_owner.make_rid(rt);
+	render_target.texture = texture_owner.make_rid(t);
+	_update_render_target(&render_target);
+	return render_target_owner.make_rid(render_target);
 }
 
 void TextureStorage::render_target_free(RID p_rid) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_rid);
-	_render_target_clear(rt);
+	_clear_render_target(rt);
 
 	Texture *t = get_texture(rt->texture);
 	if (t) {
+		t->is_render_target = false;
 		texture_free(rt->texture);
-		memdelete(t);
+		//memdelete(t);
 	}
 	render_target_owner.free(p_rid);
-	memdelete(rt);
 }
 
 void TextureStorage::render_target_set_position(RID p_render_target, int p_x, int p_y) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_COND(!rt);
 
-	rt->x = p_x;
-	rt->y = p_y;
+	rt->position = Point2i(p_x, p_y);
 }
 
 void TextureStorage::render_target_set_size(RID p_render_target, int p_width, int p_height, uint32_t p_view_count) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_COND(!rt);
 
-	if (p_width == rt->width && p_height == rt->height) {
+	if (p_width == rt->size.x && p_height == rt->size.y) {
 		return;
 	}
 
-	_render_target_clear(rt);
+	_clear_render_target(rt);
 
-	rt->width = p_width;
-	rt->height = p_height;
+	rt->size = Size2i(p_width, p_height);
 
 	// print_line("render_target_set_size " + itos(p_render_target.get_id()) + ", w " + itos(p_width) + " h " + itos(p_height));
 
 	rt->allocate_is_dirty = true;
-	//_render_target_allocate(rt);
+	_update_render_target(rt);
 }
 
 // TODO: convert to Size2i internally
@@ -1901,7 +1561,7 @@ Size2i TextureStorage::render_target_get_size(RID p_render_target) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_COND_V(!rt, Size2());
 
-	return Size2i(rt->width, rt->height);
+	return rt->size;
 }
 
 RID TextureStorage::render_target_get_texture(RID p_render_target) {
@@ -1918,8 +1578,6 @@ RID TextureStorage::render_target_get_texture(RID p_render_target) {
 void TextureStorage::render_target_set_external_texture(RID p_render_target, unsigned int p_texture_id) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_COND(!rt);
-
-	Config *config = Config::get_singleton();
 
 	if (p_texture_id == 0) {
 		if (rt->external.fbo != 0) {
@@ -1939,7 +1597,7 @@ void TextureStorage::render_target_set_external_texture(RID p_render_target, uns
 			t->height = 0;
 			t->active = false;
 			texture_free(rt->external.texture);
-			memdelete(t);
+			//memdelete(t);
 
 			rt->external.fbo = 0;
 			rt->external.color = 0;
@@ -1956,8 +1614,7 @@ void TextureStorage::render_target_set_external_texture(RID p_render_target, uns
 			// allocate a texture
 			t = memnew(Texture);
 
-			t->type = RenderingDevice::TEXTURE_TYPE_2D;
-			t->flags = 0;
+			t->type = Texture::TYPE_2D;
 			t->width = 0;
 			t->height = 0;
 			t->alloc_height = 0;
@@ -1967,17 +1624,15 @@ void TextureStorage::render_target_set_external_texture(RID p_render_target, uns
 			t->gl_format_cache = 0;
 			t->gl_internal_format_cache = 0;
 			t->gl_type_cache = 0;
-			t->data_size = 0;
-			t->compressed = false;
 			t->srgb = false;
 			t->total_data_size = 0;
-			t->ignore_mipmaps = false;
 			t->mipmaps = 1;
 			t->active = true;
 			t->tex_id = 0;
 			t->render_target = rt;
+			t->is_render_target = true;
 
-			rt->external.texture = make_rid(t);
+			//rt->external.texture = make_rid(t);
 
 		} else {
 			// bind our frame buffer
@@ -1992,22 +1647,15 @@ void TextureStorage::render_target_set_external_texture(RID p_render_target, uns
 		rt->external.color = p_texture_id;
 
 		// size shouldn't be different
-		t->width = rt->width;
-		t->height = rt->height;
-		t->alloc_height = rt->width;
-		t->alloc_width = rt->height;
+		t->width = rt->size.x;
+		t->height = rt->size.y;
+		t->alloc_height = rt->size.x;
+		t->alloc_width = rt->size.y;
 
 		// Switch our texture on our frame buffer
 		{
 			// set our texture as the destination for our framebuffer
 			glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, p_texture_id, 0);
-
-			// seeing we're rendering into this directly, better also use our depth buffer, just use our existing one :)
-			if (config->support_depth_texture) {
-				glFramebufferTexture2D(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_TEXTURE_2D, rt->depth, 0);
-			} else {
-				glFramebufferRenderbuffer(GL_FRAMEBUFFER, GL_DEPTH_ATTACHMENT, GL_RENDERBUFFER, rt->depth);
-			}
 		}
 
 		// check status and unbind
@@ -2015,7 +1663,7 @@ void TextureStorage::render_target_set_external_texture(RID p_render_target, uns
 		glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
 
 		if (status != GL_FRAMEBUFFER_COMPLETE) {
-			printf("framebuffer fail, status: %x\n", status);
+			WARN_PRINT("framebuffer fail, status: " + get_framebuffer_error(status));
 		}
 
 		ERR_FAIL_COND(status != GL_FRAMEBUFFER_COMPLETE);
@@ -2029,26 +1677,19 @@ void TextureStorage::render_target_set_flag(RID p_render_target, RenderTargetFla
 	// When setting DIRECT_TO_SCREEN, you need to clear before the value is set, but allocate after as
 	// those functions change how they operate depending on the value of DIRECT_TO_SCREEN
 	if (p_flag == RENDER_TARGET_DIRECT_TO_SCREEN && p_value != rt->flags[RENDER_TARGET_DIRECT_TO_SCREEN]) {
-		_render_target_clear(rt);
+		_clear_render_target(rt);
 		rt->flags[p_flag] = p_value;
-		_render_target_allocate(rt);
+		_update_render_target(rt);
 	}
 
 	rt->flags[p_flag] = p_value;
 
 	switch (p_flag) {
-		case RENDER_TARGET_TRANSPARENT:
-			/*
-		case RENDER_TARGET_HDR:
-		case RENDER_TARGET_NO_3D:
-		case RENDER_TARGET_NO_SAMPLING:
-		case RENDER_TARGET_NO_3D_EFFECTS: */
-			{
-				//must reset for these formats
-				_render_target_clear(rt);
-				_render_target_allocate(rt);
-			}
-			break;
+		case RENDER_TARGET_TRANSPARENT: {
+			//must reset for these formats
+			_clear_render_target(rt);
+			_update_render_target(rt);
+		} break;
 		default: {
 		}
 	}
@@ -2068,46 +1709,11 @@ void TextureStorage::render_target_clear_used(RID p_render_target) {
 	rt->used_in_frame = false;
 }
 
-void TextureStorage::render_target_set_msaa(RID p_render_target, RS::ViewportMSAA p_msaa) {
-	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
-	ERR_FAIL_COND(!rt);
-
-	if (rt->msaa == p_msaa) {
-		return;
-	}
-
-	_render_target_clear(rt);
-	rt->msaa = p_msaa;
-	_render_target_allocate(rt);
-}
-
-void TextureStorage::render_target_set_use_fxaa(RID p_render_target, bool p_fxaa) {
-	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
-	ERR_FAIL_COND(!rt);
-
-	rt->use_fxaa = p_fxaa;
-}
-
-void TextureStorage::render_target_set_use_debanding(RID p_render_target, bool p_debanding) {
-	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
-	ERR_FAIL_COND(!rt);
-
-	if (p_debanding) {
-		WARN_PRINT_ONCE("Debanding is not supported in the OpenGL backend. Switch to the Vulkan backend and make sure HDR is enabled.");
-	}
-
-	rt->use_debanding = p_debanding;
-}
-
 void TextureStorage::render_target_request_clear(RID p_render_target, const Color &p_clear_color) {
 	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
 	ERR_FAIL_COND(!rt);
 	rt->clear_requested = true;
 	rt->clear_color = p_clear_color;
-
-	//	ERR_FAIL_COND(!frame.current_rt);
-	//	frame.clear_request = true;
-	//	frame.clear_request_color = p_color;
 }
 
 bool TextureStorage::render_target_is_clear_requested(RID p_render_target) {
@@ -2128,6 +1734,14 @@ void TextureStorage::render_target_disable_clear_request(RID p_render_target) {
 }
 
 void TextureStorage::render_target_do_clear_request(RID p_render_target) {
+	RenderTarget *rt = render_target_owner.get_or_null(p_render_target);
+	ERR_FAIL_COND(!rt);
+	if (!rt->clear_requested) {
+		return;
+	}
+
+	glClearBufferfv(GL_COLOR, 0, rt->clear_color.components);
+	rt->clear_requested = false;
 }
 
 void TextureStorage::render_target_set_sdf_size_and_scale(RID p_render_target, RS::ViewportSDFOversize p_size, RS::ViewportSDFScale p_scale) {

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -49,6 +49,9 @@
 
 namespace GLES3 {
 
+#define _GL_TEXTURE_MAX_ANISOTROPY_EXT 0x84FE
+#define _GL_MAX_TEXTURE_MAX_ANISOTROPY_EXT 0x84FF
+
 #define _EXT_COMPRESSED_RGBA_S3TC_DXT1_EXT 0x83F1
 #define _EXT_COMPRESSED_RGBA_S3TC_DXT3_EXT 0x83F2
 #define _EXT_COMPRESSED_RGBA_S3TC_DXT5_EXT 0x83F3
@@ -86,15 +89,20 @@ namespace GLES3 {
 #define glClearDepth glClearDepthf
 #endif //!GLES_OVER_GL
 
-enum OpenGLTextureFlags {
-	TEXTURE_FLAG_MIPMAPS = 1, /// Enable automatic mipmap generation - when available
-	TEXTURE_FLAG_REPEAT = 2, /// Repeat texture (Tiling), otherwise Clamping
-	TEXTURE_FLAG_FILTER = 4, /// Create texture with linear (or available) filter
-	TEXTURE_FLAG_ANISOTROPIC_FILTER = 8,
-	TEXTURE_FLAG_CONVERT_TO_LINEAR = 16,
-	TEXTURE_FLAG_MIRRORED_REPEAT = 32, /// Repeat texture, with alternate sections mirrored
-	TEXTURE_FLAG_USED_FOR_STREAMING = 2048,
-	TEXTURE_FLAGS_DEFAULT = TEXTURE_FLAG_REPEAT | TEXTURE_FLAG_MIPMAPS | TEXTURE_FLAG_FILTER
+enum DefaultGLTexture {
+	DEFAULT_GL_TEXTURE_WHITE,
+	DEFAULT_GL_TEXTURE_BLACK,
+	DEFAULT_GL_TEXTURE_NORMAL,
+	DEFAULT_GL_TEXTURE_ANISO,
+	DEFAULT_GL_TEXTURE_DEPTH,
+	DEFAULT_GL_TEXTURE_CUBEMAP_BLACK,
+	//DEFAULT_GL_TEXTURE_CUBEMAP_ARRAY_BLACK, // Cubemap Arrays not supported in GL 3.3 or GL ES 3.0
+	DEFAULT_GL_TEXTURE_CUBEMAP_WHITE,
+	DEFAULT_GL_TEXTURE_3D_WHITE,
+	DEFAULT_GL_TEXTURE_3D_BLACK,
+	DEFAULT_GL_TEXTURE_2D_ARRAY_WHITE,
+	DEFAULT_GL_TEXTURE_2D_UINT,
+	DEFAULT_GL_TEXTURE_MAX
 };
 
 struct CanvasTexture {
@@ -118,99 +126,81 @@ struct RenderTarget;
 struct Texture {
 	RID self;
 
-	Texture *proxy = nullptr;
-	Set<Texture *> proxy_owners;
+	bool is_proxy = false;
+	bool is_render_target = false;
+
+	RID proxy_to = RID();
+	Vector<RID> proxies;
 
 	String path;
-	uint32_t flags;
-	int width, height, depth;
-	int alloc_width, alloc_height;
-	Image::Format format;
-	RenderingDevice::TextureType type;
+	int width = 0;
+	int height = 0;
+	int depth = 0;
+	int mipmaps = 1;
+	int layers = 1;
+	int alloc_width = 0;
+	int alloc_height = 0;
+	Image::Format format = Image::FORMAT_R8;
 
-	GLenum target;
-	GLenum gl_format_cache;
-	GLenum gl_internal_format_cache;
-	GLenum gl_type_cache;
+	enum Type {
+		TYPE_2D,
+		TYPE_LAYERED,
+		TYPE_3D
+	};
 
-	int data_size;
-	int total_data_size;
-	bool ignore_mipmaps;
+	Type type;
+	RS::TextureLayeredType layered_type = RS::TEXTURE_LAYERED_2D_ARRAY;
 
-	bool compressed;
+	GLenum target = GL_TEXTURE_2D;
+	GLenum gl_format_cache = 0;
+	GLenum gl_internal_format_cache = 0;
+	GLenum gl_type_cache = 0;
 
-	bool srgb;
+	int total_data_size = 0;
 
-	int mipmaps;
+	bool compressed = false;
 
-	bool resize_to_po2;
+	bool srgb = false;
 
-	bool active;
-	GLenum tex_id;
+	bool resize_to_po2 = false;
 
-	uint16_t stored_cube_sides;
+	bool active = false;
+	GLuint tex_id = 0;
+
+	uint16_t stored_cube_sides = 0;
 
 	RenderTarget *render_target = nullptr;
 
-	Vector<Ref<Image>> images;
+	Ref<Image> image_cache_2d;
 
-	bool redraw_if_visible;
+	bool redraw_if_visible = false;
 
-	RS::TextureDetectCallback detect_3d;
-	void *detect_3d_ud = nullptr;
+	RS::TextureDetectCallback detect_3d_callback = nullptr;
+	void *detect_3d_callback_ud = nullptr;
 
-	RS::TextureDetectCallback detect_srgb;
+	RS::TextureDetectCallback detect_srgb = nullptr;
 	void *detect_srgb_ud = nullptr;
 
-	RS::TextureDetectCallback detect_normal;
-	void *detect_normal_ud = nullptr;
+	RS::TextureDetectCallback detect_normal_callback = nullptr;
+	void *detect_normal_callback_ud = nullptr;
+
+	RS::TextureDetectRoughnessCallback detect_roughness_callback = nullptr;
+	void *detect_roughness_callback_ud = nullptr;
 
 	CanvasTexture *canvas_texture = nullptr;
 
-	// some silly opengl shenanigans where
-	// texture coords start from bottom left, means we need to draw render target textures upside down
-	// to be compatible with vulkan etc.
-	bool is_upside_down() const {
-		if (proxy) {
-			return proxy->is_upside_down();
-		}
-
-		return render_target != nullptr;
-	}
-
-	Texture() {
-		create();
-	}
-
-	_ALWAYS_INLINE_ Texture *get_ptr() {
-		if (proxy) {
-			return proxy; //->get_ptr(); only one level of indirection, else not inlining possible.
-		} else {
-			return this;
-		}
-	}
-
-	~Texture() {
-		destroy();
-
-		if (tex_id != 0) {
-			glDeleteTextures(1, &tex_id);
-		}
-	}
-
 	void copy_from(const Texture &o) {
-		proxy = o.proxy;
-		flags = o.flags;
+		proxy_to = o.proxy_to;
+		is_proxy = o.is_proxy;
 		width = o.width;
 		height = o.height;
 		alloc_width = o.alloc_width;
 		alloc_height = o.alloc_height;
 		format = o.format;
 		type = o.type;
+		layered_type = o.layered_type;
 		target = o.target;
-		data_size = o.data_size;
 		total_data_size = o.total_data_size;
-		ignore_mipmaps = o.ignore_mipmaps;
 		compressed = o.compressed;
 		mipmaps = o.mipmaps;
 		resize_to_po2 = o.resize_to_po2;
@@ -218,102 +208,95 @@ struct Texture {
 		tex_id = o.tex_id;
 		stored_cube_sides = o.stored_cube_sides;
 		render_target = o.render_target;
+		is_render_target = o.is_render_target;
 		redraw_if_visible = o.redraw_if_visible;
-		detect_3d = o.detect_3d;
-		detect_3d_ud = o.detect_3d_ud;
+		detect_3d_callback = o.detect_3d_callback;
+		detect_3d_callback_ud = o.detect_3d_callback_ud;
 		detect_srgb = o.detect_srgb;
 		detect_srgb_ud = o.detect_srgb_ud;
-		detect_normal = o.detect_normal;
-		detect_normal_ud = o.detect_normal_ud;
-
-		images.clear();
-	}
-
-	void create() {
-		proxy = nullptr;
-		flags = 0;
-		width = 0;
-		height = 0;
-		alloc_width = 0;
-		alloc_height = 0;
-		format = Image::FORMAT_L8;
-		type = RenderingDevice::TEXTURE_TYPE_2D;
-		target = 0;
-		data_size = 0;
-		total_data_size = 0;
-		ignore_mipmaps = false;
-		compressed = false;
-		mipmaps = 0;
-		resize_to_po2 = false;
-		active = false;
-		tex_id = 0;
-		stored_cube_sides = 0;
-		render_target = nullptr;
-		redraw_if_visible = false;
-		detect_3d = nullptr;
-		detect_3d_ud = nullptr;
-		detect_srgb = nullptr;
-		detect_srgb_ud = nullptr;
-		detect_normal = nullptr;
-		detect_normal_ud = nullptr;
-	}
-	void destroy() {
-		images.clear();
-
-		for (Set<Texture *>::Element *E = proxy_owners.front(); E; E = E->next()) {
-			E->get()->proxy = nullptr;
-		}
-
-		if (proxy) {
-			proxy->proxy_owners.erase(this);
-		}
+		detect_normal_callback = o.detect_normal_callback;
+		detect_normal_callback_ud = o.detect_normal_callback_ud;
+		detect_roughness_callback = o.detect_roughness_callback;
+		detect_roughness_callback_ud = o.detect_roughness_callback_ud;
 	}
 
 	// texture state
-	void GLSetFilter(GLenum p_target, RS::CanvasItemTextureFilter p_filter) {
+	void gl_set_filter(RS::CanvasItemTextureFilter p_filter) {
 		if (p_filter == state_filter) {
 			return;
 		}
+		Config *config = Config::get_singleton();
 		state_filter = p_filter;
-		GLint pmin = GL_LINEAR; // param min
-		GLint pmag = GL_LINEAR; // param mag
+		GLenum pmin = GL_NEAREST; // param min
+		GLenum pmag = GL_NEAREST; // param mag
+		GLint max_lod = 1000;
+		bool use_anisotropy = false;
 		switch (state_filter) {
-			default: {
-			} break;
-			case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS: {
-				pmin = GL_LINEAR_MIPMAP_LINEAR;
-				pmag = GL_LINEAR;
-			} break;
 			case RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST: {
 				pmin = GL_NEAREST;
 				pmag = GL_NEAREST;
+				max_lod = 0;
 			} break;
+			case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR: {
+				pmin = GL_LINEAR;
+				pmag = GL_LINEAR;
+				max_lod = 0;
+			} break;
+			case RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS_ANISOTROPIC: {
+				use_anisotropy = true;
+			};
+				[[fallthrough]];
 			case RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS: {
-				pmin = GL_NEAREST_MIPMAP_NEAREST;
 				pmag = GL_NEAREST;
+				if (config->use_nearest_mip_filter) {
+					pmin = GL_NEAREST_MIPMAP_NEAREST;
+				} else {
+					pmin = GL_NEAREST_MIPMAP_LINEAR;
+				}
+			} break;
+			case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS_ANISOTROPIC: {
+				use_anisotropy = true;
+			};
+				[[fallthrough]];
+			case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS: {
+				pmag = GL_LINEAR;
+				if (config->use_nearest_mip_filter) {
+					pmin = GL_LINEAR_MIPMAP_NEAREST;
+
+				} else {
+					pmin = GL_LINEAR_MIPMAP_LINEAR;
+				}
+			} break;
+			default: {
 			} break;
 		}
-		glTexParameteri(p_target, GL_TEXTURE_MIN_FILTER, pmin);
-		glTexParameteri(p_target, GL_TEXTURE_MAG_FILTER, pmag);
+		glTexParameteri(target, GL_TEXTURE_MIN_FILTER, pmin);
+		glTexParameteri(target, GL_TEXTURE_MAG_FILTER, pmag);
+		glTexParameteri(target, GL_TEXTURE_BASE_LEVEL, 0);
+		glTexParameteri(target, GL_TEXTURE_MAX_LEVEL, max_lod);
+		if (config->support_anisotropic_filter && use_anisotropy) {
+			glTexParameterf(target, _GL_TEXTURE_MAX_ANISOTROPY_EXT, config->anisotropic_level);
+		}
 	}
-	void GLSetRepeat(GLenum p_target, RS::CanvasItemTextureRepeat p_repeat) {
+	void gl_set_repeat(RS::CanvasItemTextureRepeat p_repeat) {
 		if (p_repeat == state_repeat) {
 			return;
 		}
 		state_repeat = p_repeat;
-		GLint prep = GL_CLAMP_TO_EDGE; // parameter repeat
+		GLenum prep = GL_CLAMP_TO_EDGE; // parameter repeat
 		switch (state_repeat) {
-			default: {
-			} break;
 			case RS::CANVAS_ITEM_TEXTURE_REPEAT_ENABLED: {
 				prep = GL_REPEAT;
 			} break;
 			case RS::CANVAS_ITEM_TEXTURE_REPEAT_MIRROR: {
 				prep = GL_MIRRORED_REPEAT;
 			} break;
+			default: {
+			} break;
 		}
-		glTexParameteri(p_target, GL_TEXTURE_WRAP_S, prep);
-		glTexParameteri(p_target, GL_TEXTURE_WRAP_T, prep);
+		glTexParameteri(target, GL_TEXTURE_WRAP_T, prep);
+		glTexParameteri(target, GL_TEXTURE_WRAP_R, prep);
+		glTexParameteri(target, GL_TEXTURE_WRAP_S, prep);
 	}
 
 private:
@@ -322,54 +305,46 @@ private:
 };
 
 struct RenderTarget {
-	RID self;
-	GLuint fbo = 0;
-	GLuint color = 0;
-	GLuint depth = 0;
-
-	GLuint multisample_fbo = 0;
-	GLuint multisample_color = 0;
-	GLuint multisample_depth = 0;
-	bool multisample_active = false;
-
-	struct Effect {
-		GLuint fbo = 0;
-		int width = 0;
-		int height = 0;
-
-		GLuint color = 0;
-	};
-
-	Effect copy_screen_effect;
-
 	struct MipMaps {
 		struct Size {
-			GLuint fbo = 0;
-			GLuint color = 0;
-			int width = 0;
-			int height = 0;
+			GLuint fbo;
+			int width;
+			int height;
 		};
 
 		Vector<Size> sizes;
 		GLuint color = 0;
 		int levels = 0;
-	};
 
-	MipMaps mip_maps[2];
+		MipMaps() {
+		}
+	};
 
 	struct External {
 		GLuint fbo = 0;
 		GLuint color = 0;
 		GLuint depth = 0;
 		RID texture;
+
+		External() {
+		}
 	} external;
 
-	int x = 0;
-	int y = 0;
-	int width = 0;
-	int height = 0;
+	Point2i position = Point2i(0, 0);
+	Size2i size = Size2i(0, 0);
+	RID self;
+	GLuint fbo = 0;
+	GLuint color = 0;
 
-	bool flags[RendererTextureStorage::RENDER_TARGET_FLAG_MAX] = {};
+	GLuint color_internal_format = GL_RGBA8;
+	GLuint color_format = GL_RGBA;
+	GLuint color_type = GL_UNSIGNED_BYTE;
+	Image::Format image_format = Image::FORMAT_RGBA8;
+
+	MipMaps mip_maps[2];
+	bool mip_maps_allocated = false;
+
+	bool flags[RendererTextureStorage::RENDER_TARGET_FLAG_MAX];
 
 	// instead of allocating sized render targets immediately,
 	// defer this for faster startup
@@ -377,13 +352,7 @@ struct RenderTarget {
 	bool used_in_frame = false;
 	RS::ViewportMSAA msaa = RS::VIEWPORT_MSAA_DISABLED;
 
-	bool use_fxaa = false;
-	bool use_debanding = false;
-
 	RID texture;
-
-	bool used_dof_blur_near = false;
-	bool mip_maps_allocated = false;
 
 	Color clear_color = Color(1, 1, 1, 1);
 	bool clear_requested = false;
@@ -392,13 +361,14 @@ struct RenderTarget {
 		for (int i = 0; i < RendererTextureStorage::RENDER_TARGET_FLAG_MAX; ++i) {
 			flags[i] = false;
 		}
-		external.fbo = 0;
 	}
 };
 
 class TextureStorage : public RendererTextureStorage {
 private:
 	static TextureStorage *singleton;
+
+	RID default_gl_textures[DEFAULT_GL_TEXTURE_MAX];
 
 	Thread::ID _main_thread_id = 0;
 	bool _is_main_thread();
@@ -409,16 +379,13 @@ private:
 
 	/* Texture API */
 
-	mutable RID_PtrOwner<Texture> texture_owner;
+	mutable RID_Owner<Texture> texture_owner;
 
 	Ref<Image> _get_gl_image_and_format(const Ref<Image> &p_image, Image::Format p_format, uint32_t p_flags, Image::Format &r_real_format, GLenum &r_gl_format, GLenum &r_gl_internal_format, GLenum &r_gl_type, bool &r_compressed, bool p_force_decompress) const;
-	void _texture_set_state_from_flags(Texture *p_tex);
-
-	void texture_set_proxy(RID p_texture, RID p_proxy);
 
 	/* Render Target API */
 
-	mutable RID_PtrOwner<RenderTarget> render_target_owner;
+	mutable RID_Owner<RenderTarget> render_target_owner;
 
 	// make access easier to these
 	struct Dimensions {
@@ -443,6 +410,10 @@ public:
 	TextureStorage();
 	virtual ~TextureStorage();
 
+	_FORCE_INLINE_ RID texture_gl_get_default(DefaultGLTexture p_texture) {
+		return default_gl_textures[p_texture];
+	}
+
 	/* Canvas Texture API */
 
 	CanvasTexture *get_canvas_texture(RID p_rid) { return canvas_texture_owner.get_or_null(p_rid); };
@@ -460,16 +431,20 @@ public:
 
 	/* Texture API */
 
-	Texture *get_texture(RID p_rid) { return texture_owner.get_or_null(p_rid); };
+	Texture *get_texture(RID p_rid) {
+		Texture *texture = texture_owner.get_or_null(p_rid);
+		if (texture && texture->is_proxy) {
+			return texture_owner.get_or_null(texture->proxy_to);
+		}
+		return texture;
+	};
 	bool owns_texture(RID p_rid) { return texture_owner.owns(p_rid); };
-	RID make_rid(Texture *p_texture) { return texture_owner.make_rid(p_texture); };
 
 	void set_main_thread_id(Thread::ID p_id);
 
 	virtual bool can_create_resources_async() const override;
 
 	RID texture_create();
-	void _texture_allocate_internal(RID p_texture, int p_width, int p_height, int p_depth_3d, Image::Format p_format, RenderingDevice::TextureType p_type, uint32_t p_flags = TEXTURE_FLAGS_DEFAULT);
 
 	virtual RID texture_allocate() override;
 	virtual void texture_free(RID p_rid) override;
@@ -481,7 +456,7 @@ public:
 
 	virtual void texture_2d_update(RID p_texture, const Ref<Image> &p_image, int p_layer = 0) override;
 	virtual void texture_3d_update(RID p_texture, const Vector<Ref<Image>> &p_data) override{};
-	virtual void texture_proxy_update(RID p_proxy, RID p_base) override{};
+	virtual void texture_proxy_update(RID p_proxy, RID p_base) override;
 
 	//these two APIs can be used together or in combination with the others.
 	virtual void texture_2d_placeholder_initialize(RID p_texture) override;
@@ -501,7 +476,7 @@ public:
 	virtual void texture_set_detect_3d_callback(RID p_texture, RS::TextureDetectCallback p_callback, void *p_userdata) override;
 	void texture_set_detect_srgb_callback(RID p_texture, RS::TextureDetectCallback p_callback, void *p_userdata);
 	virtual void texture_set_detect_normal_callback(RID p_texture, RS::TextureDetectCallback p_callback, void *p_userdata) override;
-	virtual void texture_set_detect_roughness_callback(RID p_texture, RS::TextureDetectRoughnessCallback p_callback, void *p_userdata) override{};
+	virtual void texture_set_detect_roughness_callback(RID p_texture, RS::TextureDetectRoughnessCallback p_callback, void *p_userdata) override;
 
 	virtual void texture_debug_usage(List<RS::TextureInfo> *r_info) override;
 
@@ -512,18 +487,14 @@ public:
 	void texture_set_data(RID p_texture, const Ref<Image> &p_image, int p_layer = 0);
 	void texture_set_data_partial(RID p_texture, const Ref<Image> &p_image, int src_x, int src_y, int src_w, int src_h, int dst_x, int dst_y, int p_dst_mip, int p_layer = 0);
 	//Ref<Image> texture_get_data(RID p_texture, int p_layer = 0) const;
-	void texture_set_flags(RID p_texture, uint32_t p_flags);
-	uint32_t texture_get_flags(RID p_texture) const;
+	void texture_set_sampler(RID p_texture, RS::CanvasItemTextureFilter p_filter, RS::CanvasItemTextureRepeat p_repeat);
 	Image::Format texture_get_format(RID p_texture) const;
-	RenderingDevice::TextureType texture_get_type(RID p_texture) const;
 	uint32_t texture_get_texid(RID p_texture) const;
 	uint32_t texture_get_width(RID p_texture) const;
 	uint32_t texture_get_height(RID p_texture) const;
 	uint32_t texture_get_depth(RID p_texture) const;
 	void texture_bind(RID p_texture, uint32_t p_texture_no);
-	void texture_set_shrink_all_x2_on_set_data(bool p_enable);
 	RID texture_create_radiance_cubemap(RID p_source, int p_resolution = -1) const;
-	void textures_keep_original(bool p_enable);
 
 	/* DECAL API */
 
@@ -550,29 +521,18 @@ public:
 
 	static GLuint system_fbo;
 
+	// TODO this should be moved back to storage or removed
 	struct Frame {
 		GLES3::RenderTarget *current_rt;
-
-		// these 2 may have been superseded by the equivalents in the render target.
-		// these may be able to be removed.
-		bool clear_request;
-		Color clear_request_color;
-
-		float time;
-		float delta;
-		uint64_t count;
-
-		Frame() {
-			//			current_rt = nullptr;
-			//			clear_request = false;
-		}
 	} frame;
 
 	RenderTarget *get_render_target(RID p_rid) { return render_target_owner.get_or_null(p_rid); };
 	bool owns_render_target(RID p_rid) { return render_target_owner.owns(p_rid); };
 
-	void _render_target_clear(RenderTarget *rt);
-	void _render_target_allocate(RenderTarget *rt);
+	// TODO these internals should be private
+	void _clear_render_target(RenderTarget *rt);
+	void _update_render_target(RenderTarget *rt);
+	void _create_render_target_backbuffer(RenderTarget *rt);
 	void _set_current_render_target(RID p_render_target);
 
 	virtual RID render_target_create() override;
@@ -586,9 +546,6 @@ public:
 	virtual void render_target_set_flag(RID p_render_target, RenderTargetFlags p_flag, bool p_value) override;
 	virtual bool render_target_was_used(RID p_render_target) override;
 	void render_target_clear_used(RID p_render_target);
-	void render_target_set_msaa(RID p_render_target, RS::ViewportMSAA p_msaa);
-	void render_target_set_use_fxaa(RID p_render_target, bool p_fxaa);
-	void render_target_set_use_debanding(RID p_render_target, bool p_debanding);
 
 	// new
 	void render_target_set_as_unused(RID p_render_target) override {
@@ -604,7 +561,32 @@ public:
 	void render_target_set_sdf_size_and_scale(RID p_render_target, RS::ViewportSDFOversize p_size, RS::ViewportSDFScale p_scale) override;
 	Rect2i render_target_get_sdf_rect(RID p_render_target) const override;
 	void render_target_mark_sdf_enabled(RID p_render_target, bool p_enabled) override;
+
+	void bind_framebuffer(GLuint framebuffer) {
+		glBindFramebuffer(GL_FRAMEBUFFER, framebuffer);
+	}
+
+	void bind_framebuffer_system() {
+		glBindFramebuffer(GL_FRAMEBUFFER, GLES3::TextureStorage::system_fbo);
+	}
+
+	String get_framebuffer_error(GLenum p_status);
 };
+
+inline String TextureStorage::get_framebuffer_error(GLenum p_status) {
+#ifdef DEBUG_ENABLED
+	if (p_status == GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT) {
+		return "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT";
+	} else if (p_status == GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT) {
+		return "GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT";
+	} else if (p_status == GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER) {
+		return "GL_FRAMEBUFFER_INCOMPLETE_DRAW_BUFFER";
+	} else if (p_status == GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER) {
+		return "GL_FRAMEBUFFER_INCOMPLETE_READ_BUFFER";
+	}
+#endif
+	return itos(p_status);
+}
 
 } // namespace GLES3
 


### PR DESCRIPTION
This PR significantly cleans up the GLES3 code. 

I started out working to add the basics for the 3D renderer and got side tracked overhauling things that sorely needed to be overhauled, namely, materials, shaders, render_targets, and textures. 

~There are still a few things to be done before this PR is ready to merge~
~1. Textures need to actually make use of the filtering and repeat flags~
~2. I need to verify that shaderMaterials are actually working.~ 

In terms of 3D rendering. This PR makes it so that you can change the background colour of the 3D viewport and nothing else. 

This PR fixes some of the obvious problems we were having with subViewports in GLES3.

Overall this PR substantially improves the stability of the GLES3 backend. There is plenty more work to be done, but with this I can now move on to meshes and spatial shaders.
