### PR TITLE
Fix the issue causing the screen to be black after resuming when in low processor mode

### DIFF
--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -503,6 +503,8 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererResumed(JNI
 		return;
 	}
 
+	// We force redraw to ensure we render at least once when resuming the app.
+	Main::force_redraw();
 	if (os_android->get_main_loop()) {
 		os_android->get_main_loop()->notification(MainLoop::NOTIFICATION_APPLICATION_RESUMED);
 	}

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -187,10 +187,11 @@ bool OS_Android::main_loop_iterate(bool *r_should_swap_buffers) {
 		return false;
 	}
 	DisplayServerAndroid::get_singleton()->process_events();
+	uint64_t current_frames_drawn = Engine::get_singleton()->get_frames_drawn();
 	bool exit = Main::iteration();
 
 	if (r_should_swap_buffers) {
-		*r_should_swap_buffers = !is_in_low_processor_usage_mode() || RenderingServer::get_singleton()->has_changed();
+		*r_should_swap_buffers = !is_in_low_processor_usage_mode() || RenderingServer::get_singleton()->has_changed() || current_frames_drawn != Engine::get_singleton()->get_frames_drawn();
 	}
 
 	return exit;


### PR DESCRIPTION
This is done by forcing a redraw and buffers swap when resuming the app.

Fix #60465 

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
