### PR TITLE
Checkbox state is taken into account when editing properties, undoing/redoing

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -146,7 +146,7 @@ public:
 	StringName get_edited_property();
 
 	virtual void update_property();
-	void update_revert_and_pin_status();
+	void update_editor_property_status();
 
 	virtual bool use_keying_next() const;
 

--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -56,7 +56,10 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 
 	UndoRedo *ur = EditorNode::get_undo_redo();
 
-	ur->create_action(TTR("MultiNode Set") + " " + String(name), UndoRedo::MERGE_ENDS);
+	// Null (nil or nullptr) means not set/overridden.
+	bool value_is_null = p_value.get_type() == Variant::NIL || (p_value.get_type() == Variant::OBJECT && p_value.is_null());
+
+	ur->create_action(vformat(value_is_null ? TTR("MultiNode Unset %s") : TTR("MultiNode Set %s"), name), UndoRedo::MERGE_ENDS);
 	for (const NodePath &E : nodes) {
 		if (!es->has_node(E)) {
 			continue;
@@ -87,8 +90,13 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 
 		ur->add_undo_property(n, name, n->get(name));
 	}
-	ur->add_do_method(InspectorDock::get_inspector_singleton(), "refresh");
-	ur->add_undo_method(InspectorDock::get_inspector_singleton(), "refresh");
+	if (name == "script") {
+		ur->add_do_method(InspectorDock::get_inspector_singleton(), "_edit_request_change", this, "scripts");
+		ur->add_undo_method(InspectorDock::get_inspector_singleton(), "_edit_request_change", this, "scripts");
+	} else {
+		ur->add_do_method(InspectorDock::get_inspector_singleton(), "_edit_request_change", this, name);
+		ur->add_undo_method(InspectorDock::get_inspector_singleton(), "_edit_request_change", this, name);
+	}
 
 	ur->commit_action();
 	return true;


### PR DESCRIPTION
Fixes #55455.

Previously, if the checkbox existed, it will be checked while the properties are overridden. But undo_redo does not record the state of the checkbox, so it may lead to strange behavior.

`autoclear` in `EditorInspector` seems to have the same effect as `checkable` in `EditorProperty` there, I'm not sure if there are other effects.

It seems to me that `Variant::is_null` means the type is `Variant::NIL` or the object is `nullptr`. 
Judging from the results of `Variant::is_null`, it may be more appropriate to change the name to `Variant::is_not_object` (`nullptr` is not object, just means Object Type).


`nullptr` means the **empty set** of the whole `Object` set, `Variant::NIL` means the **empty set** of the whole `Variant` set.

![relationship](https://user-images.githubusercontent.com/30386067/165091773-eafeeb0d-c86d-46af-bd94-1373f61c4d99.png)


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
