### PR TITLE
Fixed AnimationTree playing tracks despite track_is_enabled() being false

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -991,6 +991,10 @@ void AnimationTree::_process_graph(double p_delta) {
 
 				real_t blend = (*as.track_blends)[blend_idx] * weight;
 
+				if (!a->track_is_enabled(i)) {
+					continue; // do nothing if the track is disabled
+				}
+
 				switch (ttype) {
 					case Animation::TYPE_POSITION_3D: {
 #ifndef _3D_DISABLED


### PR DESCRIPTION
Editing `Animations` in an `AnimationPlayer` node allows toggling the enabled status of an animation track. Playing back the animation, tracks that are not enabled do not get processed. This is the case for `AnimationPlayer` and the deprecated `AnimationTreePlayer`.

This PR re-adds the check for making sure the animated track is enabled before performing any work when animating an `AnimationTree`.

Fixes #25537.