### PR TITLE
Make JSON methods static

### DIFF
--- a/core/io/json.cpp
+++ b/core/io/json.cpp
@@ -528,11 +528,6 @@ Error JSON::_parse_string(const String &p_json, Variant &r_ret, String &r_err_st
 	return err;
 }
 
-String JSON::stringify(const Variant &p_var, const String &p_indent, bool p_sort_keys, bool p_full_precision) {
-	HashSet<const void *> markers;
-	return _stringify(p_var, p_indent, 0, p_sort_keys, markers, p_full_precision);
-}
-
 Error JSON::parse(const String &p_json_string) {
 	Error err = _parse_string(p_json_string, data, err_str, err_line);
 	if (err == Error::OK) {
@@ -541,8 +536,24 @@ Error JSON::parse(const String &p_json_string) {
 	return err;
 }
 
+String JSON::stringify(const Variant &p_var, const String &p_indent, bool p_sort_keys, bool p_full_precision) {
+	Ref<JSON> jason;
+	jason.instantiate();
+	HashSet<const void *> markers;
+	return jason->_stringify(p_var, p_indent, 0, p_sort_keys, markers, p_full_precision);
+}
+
+Variant JSON::parse_string(const String &p_json_string) {
+	Ref<JSON> jason;
+	jason.instantiate();
+	Error error = jason->parse(p_json_string);
+	ERR_FAIL_COND_V_MSG(error != Error::OK, Variant(), vformat("Parse JSON failed. Error at line %d: %s", jason->get_error_line(), jason->get_error_message()));
+	return jason->get_data();
+}
+
 void JSON::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("stringify", "data", "indent", "sort_keys", "full_precision"), &JSON::stringify, DEFVAL(""), DEFVAL(true), DEFVAL(false));
+	ClassDB::bind_static_method("JSON", D_METHOD("stringify", "data", "indent", "sort_keys", "full_precision"), &JSON::stringify, DEFVAL(""), DEFVAL(true), DEFVAL(false));
+	ClassDB::bind_static_method("JSON", D_METHOD("parse_string", "json_string"), &JSON::parse_string);
 	ClassDB::bind_method(D_METHOD("parse", "json_string"), &JSON::parse);
 
 	ClassDB::bind_method(D_METHOD("get_data"), &JSON::get_data);

--- a/core/io/json.h
+++ b/core/io/json.h
@@ -81,8 +81,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	String stringify(const Variant &p_var, const String &p_indent = "", bool p_sort_keys = true, bool p_full_precision = false);
 	Error parse(const String &p_json_string);
+	static String stringify(const Variant &p_var, const String &p_indent = "", bool p_sort_keys = true, bool p_full_precision = false);
+	static Variant parse_string(const String &p_json_string);
 
 	inline Variant get_data() const { return data; }
 	inline int get_error_line() const { return err_line; }

--- a/doc/classes/JSON.xml
+++ b/doc/classes/JSON.xml
@@ -10,8 +10,7 @@
 		[b]Example[/b]
 		[codeblock]
 		var data_to_send = ["a", "b", "c"]
-		var json = JSON.new()
-		var json_string = json.stringify(data_to_send)
+		var json_string = JSON.stringify(data_to_send)
 		# Save data
 		# ...
 		# Retrieve data
@@ -24,6 +23,10 @@
 		        print("Unexpected data")
 		else:
 		    print("JSON Parse Error: ", json.get_error_message(), " in ", json_string, " at line ", json.get_error_line())
+		[/codeblock]
+		Alternatively, you can parse string using the static [method parse_string] method, but it doesn't allow to handle errors.
+		[codeblock]
+		var data = JSON.parse_string(json_string) # Returns null if parsing failed.
 		[/codeblock]
 	</description>
 	<tutorials>
@@ -54,9 +57,17 @@
 			<description>
 				Attempts to parse the [param json_string] provided.
 				Returns an [enum Error]. If the parse was successful, it returns [code]OK[/code] and the result can be retrieved using [method get_data]. If unsuccessful, use [method get_error_line] and [method get_error_message] for identifying the source of the failure.
+				Non-static variant of [method parse_string], if you want custom error handling.
 			</description>
 		</method>
-		<method name="stringify">
+		<method name="parse_string" qualifiers="static">
+			<return type="Variant" />
+			<param index="0" name="json_string" type="String" />
+			<description>
+				Attempts to parse the [param json_string] provided and returns the parsed data. Returns [code]null[/code] if parse failed.
+			</description>
+		</method>
+		<method name="stringify" qualifiers="static">
 			<return type="String" />
 			<param index="0" name="data" type="Variant" />
 			<param index="1" name="indent" type="String" default="&quot;&quot;" />


### PR DESCRIPTION
Changed `stringify` to static and added `parse_string` static method. It returns data or returns null if fails and prints error:
```GDScript
print(JSON.parse_string(file.get_as_text()))
```
![image](https://user-images.githubusercontent.com/2223172/165121746-a48ac1ec-384c-48a1-a13e-8b144830e393.png)
