### PR TITLE
Tweak AudioStreamPlayer3D attenuation filter to be less aggressive

### DIFF
--- a/doc/classes/AudioStreamPlayer3D.xml
+++ b/doc/classes/AudioStreamPlayer3D.xml
@@ -53,7 +53,7 @@
 		<member name="attenuation_filter_cutoff_hz" type="float" setter="set_attenuation_filter_cutoff_hz" getter="get_attenuation_filter_cutoff_hz" default="5000.0">
 			Dampens audio using a low-pass filter above this frequency, in Hz. To disable the dampening effect entirely, set this to [code]20500[/code] as this frequency is above the human hearing limit.
 		</member>
-		<member name="attenuation_filter_db" type="float" setter="set_attenuation_filter_db" getter="get_attenuation_filter_db" default="-24.0">
+		<member name="attenuation_filter_db" type="float" setter="set_attenuation_filter_db" getter="get_attenuation_filter_db" default="-12.0">
 			Amount how much the filter affects the loudness, in decibels.
 		</member>
 		<member name="attenuation_model" type="int" setter="set_attenuation_model" getter="get_attenuation_model" enum="AudioStreamPlayer3D.AttenuationModel" default="0">
@@ -77,7 +77,7 @@
 		<member name="emission_angle_filter_attenuation_db" type="float" setter="set_emission_angle_filter_attenuation_db" getter="get_emission_angle_filter_attenuation_db" default="-12.0">
 			Dampens audio if camera is outside of [member emission_angle_degrees] and [member emission_angle_enabled] is set by this factor, in decibels.
 		</member>
-		<member name="max_db" type="float" setter="set_max_db" getter="get_max_db" default="3.0">
+		<member name="max_db" type="float" setter="set_max_db" getter="get_max_db" default="0.0">
 			Sets the absolute maximum of the soundlevel, in decibels.
 		</member>
 		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" default="0.0">

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -73,7 +73,7 @@ private:
 	AttenuationModel attenuation_model = ATTENUATION_INVERSE_DISTANCE;
 	float unit_db = 0.0;
 	float unit_size = 10.0;
-	float max_db = 3.0;
+	float max_db = 0.0;
 	float pitch_scale = 1.0;
 	// Internally used to take doppler tracking into account.
 	float actual_pitch_scale = 1.0;
@@ -103,7 +103,7 @@ private:
 	float emission_angle = 45.0;
 	float emission_angle_filter_attenuation_db = -12.0;
 	float attenuation_filter_cutoff_hz = 5000.0;
-	float attenuation_filter_db = -24.0;
+	float attenuation_filter_db = -12.0;
 
 	float linear_attenuation = 0;
 


### PR DESCRIPTION
Sounds should now be less muffled at a distance.

This also decreases the default Max Db to 0. This prevents sounds from becoming extremely loud when the camera gets very close to the sound's origin.

Related to https://github.com/godotengine/godot/issues/23485.