### PR TITLE
fix lines with ':' that end in comments causing auto indent

### DIFF
--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -994,7 +994,8 @@ void CodeEdit::_new_line(bool p_split_current_line, bool p_above) {
 			}
 
 			/* Make sure this is the last char, trailing whitespace or comments are okay. */
-			if (should_indent && (!is_whitespace(c) && is_in_comment(cl, cc) == -1)) {
+			/* Increment column for comments because the delimiter (#) should be ignored. */
+			if (should_indent && (!is_whitespace(c) && is_in_comment(cl, line_col + 1) == -1)) {
 				should_indent = false;
 			}
 		}

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -2179,7 +2179,23 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION(code_edit, "ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test: # string");
 			CHECK(code_edit->get_line(1) == "");
+			code_edit->remove_string_delimiter("#");
+
+			/* Non-whitespace prevents auto-indentation. */
+			code_edit->add_comment_delimiter("#", "");
+			code_edit->set_text("");
+			code_edit->insert_text_at_caret("test := 0 # comment");
+			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			CHECK(code_edit->get_line(0) == "test := 0 # comment");
+			CHECK(code_edit->get_line(1) == "");
 			code_edit->remove_comment_delimiter("#");
+
+			/* Even when there's no comments. */
+			code_edit->set_text("");
+			code_edit->insert_text_at_caret("test := 0");
+			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			CHECK(code_edit->get_line(0) == "test := 0");
+			CHECK(code_edit->get_line(1) == "");
 
 			/* If between brace pairs an extra line is added. */
 			code_edit->set_text("");
@@ -2256,7 +2272,23 @@ TEST_CASE("[SceneTree][CodeEdit] indent") {
 			SEND_GUI_ACTION(code_edit, "ui_text_newline");
 			CHECK(code_edit->get_line(0) == "test: # string");
 			CHECK(code_edit->get_line(1) == "");
+			code_edit->remove_string_delimiter("#");
+
+			/* Non-whitespace prevents auto-indentation. */
+			code_edit->add_comment_delimiter("#", "");
+			code_edit->set_text("");
+			code_edit->insert_text_at_caret("test := 0 # comment");
+			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			CHECK(code_edit->get_line(0) == "test := 0 # comment");
+			CHECK(code_edit->get_line(1) == "");
 			code_edit->remove_comment_delimiter("#");
+
+			/* Even when there's no comments. */
+			code_edit->set_text("");
+			code_edit->insert_text_at_caret("test := 0");
+			SEND_GUI_ACTION(code_edit, "ui_text_newline");
+			CHECK(code_edit->get_line(0) == "test := 0");
+			CHECK(code_edit->get_line(1) == "");
 
 			/* If between brace pairs an extra line is added. */
 			code_edit->set_text("");


### PR DESCRIPTION
Writing `var x := 5 #` then a newline would previously cause an automatic indentation. Now this is fixed.