### PR TITLE
Create NavMap thread pool only when it's used, to prevent creating excessive amount of running threads.

### DIFF
--- a/modules/navigation/nav_map.cpp
+++ b/modules/navigation/nav_map.cpp
@@ -673,6 +673,9 @@ void NavMap::compute_single_step(uint32_t index, RvoAgent **agent) {
 void NavMap::step(real_t p_deltatime) {
 	deltatime = p_deltatime;
 	if (controlled_agents.size() > 0) {
+		if (step_work_pool.get_thread_count() == 0) {
+			step_work_pool.init();
+		}
 		step_work_pool.do_work(
 				controlled_agents.size(),
 				this,
@@ -720,7 +723,6 @@ void NavMap::clip_path(const std::vector<gd::NavigationPoly> &p_navigation_polys
 }
 
 NavMap::NavMap() {
-	step_work_pool.init();
 }
 
 NavMap::~NavMap() {


### PR DESCRIPTION
Fixes crash caused by creation of thousands of useless thread on startup, see https://github.com/godotengine/godot/pull/60359#issuecomment-1109695492 for more details.
