### PR TITLE
Physics Interpolation - add helper warnings

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -414,6 +414,10 @@
 		<member name="debug/settings/gdscript/max_call_stack" type="int" setter="" getter="" default="1024">
 			Maximum call stack allowed for debugging GDScript.
 		</member>
+		<member name="debug/settings/physics_interpolation/enable_warnings" type="bool" setter="" getter="" default="true">
+			If [code]true[/code], enables warnings which can help pinpoint where nodes are being incorrectly updated, which will result in incorrect interpolation and visual glitches.
+			When a node is being interpolated, it is essential that the transform is set during [method Node._physics_process] (during a physics tick) rather than [method Node._process] (during a frame).
+		</member>
 		<member name="debug/settings/profiler/max_functions" type="int" setter="" getter="" default="16384">
 			Maximum amount of functions per frame allowed when profiling.
 		</member>

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1224,6 +1224,8 @@ Error Main::setup(const char *execpath, int argc, char *argv[], bool p_second_ph
 	GLOBAL_DEF("debug/settings/stdout/print_fps", false);
 	GLOBAL_DEF("debug/settings/stdout/verbose_stdout", false);
 
+	GLOBAL_DEF("debug/settings/physics_interpolation/enable_warnings", true);
+
 	if (!OS::get_singleton()->_verbose_stdout) { // Not manually overridden.
 		OS::get_singleton()->_verbose_stdout = GLOBAL_GET("debug/settings/stdout/verbose_stdout");
 	}

--- a/servers/visual/rasterizer.cpp
+++ b/servers/visual/rasterizer.cpp
@@ -33,6 +33,10 @@
 #include "core/os/os.h"
 #include "core/print_string.h"
 
+#if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
+#include "core/project_settings.h"
+#endif
+
 Rasterizer *(*Rasterizer::_create_func)() = nullptr;
 
 Rasterizer *Rasterizer::create() {
@@ -350,6 +354,16 @@ void RasterizerStorage::multimesh_instance_set_transform(RID p_multimesh, int p_
 			ptr[11] = t.origin.z;
 
 			_multimesh_add_to_interpolation_lists(p_multimesh, *mmi);
+
+#if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
+			if (!Engine::get_singleton()->is_in_physics_frame()) {
+				static int32_t warn_count = 0;
+				warn_count++;
+				if (((warn_count % 2048) == 0) && GLOBAL_GET("debug/settings/physics_interpolation/enable_warnings")) {
+					WARN_PRINT("Interpolated MultiMesh transform should usually be set during physics process (possibly benign).");
+				}
+			}
+#endif
 			return;
 		}
 	}
@@ -498,6 +512,15 @@ void RasterizerStorage::multimesh_set_as_bulk_array_interpolated(RID p_multimesh
 		mmi->_data_prev = p_array_prev;
 		mmi->_data_curr = p_array;
 		_multimesh_add_to_interpolation_lists(p_multimesh, *mmi);
+#if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
+		if (!Engine::get_singleton()->is_in_physics_frame()) {
+			static int32_t warn_count = 0;
+			warn_count++;
+			if (((warn_count % 2048) == 0) && GLOBAL_GET("debug/settings/physics_interpolation/enable_warnings")) {
+				WARN_PRINT("Interpolated MultiMesh transform should usually be set during physics process (possibly benign).");
+			}
+		}
+#endif
 	}
 }
 
@@ -507,6 +530,15 @@ void RasterizerStorage::multimesh_set_as_bulk_array(RID p_multimesh, const PoolV
 		if (mmi->interpolated) {
 			mmi->_data_curr = p_array;
 			_multimesh_add_to_interpolation_lists(p_multimesh, *mmi);
+#if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
+			if (!Engine::get_singleton()->is_in_physics_frame()) {
+				static int32_t warn_count = 0;
+				warn_count++;
+				if (((warn_count % 2048) == 0) && GLOBAL_GET("debug/settings/physics_interpolation/enable_warnings")) {
+					WARN_PRINT("Interpolated MultiMesh transform should usually be set during physics process (possibly benign).");
+				}
+			}
+#endif
 			return;
 		}
 	}


### PR DESCRIPTION
When physics interpolation is active on a node, it is essential that transforms are updated during "_physics_process()" rather than "_process()" calls, for the interpolation to give the correct result.

This PR adds optional warnings for instances, cameras and multimeshes which can flag updates being incorrectly called, and thus make these problems much easier to fix.

The warnings only occur in DEBUG_ENABLED builds, and when physics interpolation is enabled, and can be switched on and off with project setting `debug/settings/physics_interpolation/enable_warnings`.

For instances, it prints the node name in the warning. For cameras and multimeshes there is no name available, this is unlikely to be a problem with cameras (as there is normally only 1 or 2) and the warning for multimesh is better than none at all. There is no objectID stored per multimesh currently. It could be made to store this, but is probably overkill for this warning feature.

When the warning is issued, the usual step to take is to examine the object scripts etc and move anything being updated in `_process()` to `_physics_process()`. Additionally some "magic" nodes (tweening etc) may move nodes automatically, these may similarly need to have their mode flipped to operate on physics tick rather than idle.

The warning uses the wording "usually", and "possible benign", because it is not a problem to occasionally move nodes about in e.g. `_ready()` or teleported as a result of an event in `_process()`. But usually when the warnings are showing a lot it will indicate a problem.

## Example output
> W 0:00:30.384   instance_set_transform: Interpolated Instance "SunCore" transform should usually be set during physics process (possibly benign).
W 0:00:32.788   instance_set_transform: Interpolated Instance "ChargeShockwave" transform should usually be set during physics process (possibly benign).
W 0:00:36.990   camera_set_transform: Interpolated Camera transform should usually be set during physics process (possibly benign).

## Notes
* There are no changes to functionality here, just additions of some optional warnings.
* The warnings only occur in DEBUG builds (i.e. mainly editor, and not the release templates).
* While testing @RPicster 's beat invaders game it became apparent it would be super helpful for users to be able to pinpoint where they are updating objects incorrectly, especially when converting existing projects, or for those new to physics interpolation.
* Warnings aren't excessively spammed, they are only sent every 2048 or so tries (usually every few seconds).
* The checking of the `project_settings` value are only done infrequently, so I'm not overly worried that these will create a performance issue at runtime. The alternative would be to cache the setting.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
