### PR TITLE
Fix custom class icon when it inherits from a script

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4095,22 +4095,28 @@ Ref<Texture2D> EditorNode::get_class_icon(const String &p_class, const String &p
 	ERR_FAIL_COND_V_MSG(p_class.is_empty(), nullptr, "Class name cannot be empty.");
 
 	if (ScriptServer::is_global_class(p_class)) {
-		Ref<ImageTexture> icon;
-		Ref<Script> script = EditorNode::get_editor_data().script_class_load_script(p_class);
-		StringName name = p_class;
+		String class_name = p_class;
+		Ref<Script> script = EditorNode::get_editor_data().script_class_load_script(class_name);
 
-		while (script.is_valid()) {
-			name = EditorNode::get_editor_data().script_class_get_name(script->get_path());
-			String current_icon_path = EditorNode::get_editor_data().script_class_get_icon_path(name);
-			icon = _load_custom_class_icon(current_icon_path);
+		while (true) {
+			String icon_path = EditorNode::get_editor_data().script_class_get_icon_path(class_name);
+			Ref<Texture> icon = _load_custom_class_icon(icon_path);
 			if (icon.is_valid()) {
-				return icon;
+				return icon; // Current global class has icon.
 			}
-			script = script->get_base_script();
-		}
 
-		if (icon.is_null()) {
-			icon = gui_base->get_theme_icon(ScriptServer::get_global_class_base(name), SNAME("EditorIcons"));
+			// Find next global class along the inheritance chain.
+			do {
+				Ref<Script> base_script = script->get_base_script();
+				if (base_script.is_null()) {
+					// We've reached a native class, use its icon.
+					String base_type;
+					script->get_language()->get_global_class_name(script->get_path(), &base_type);
+					return gui_base->get_theme_icon(base_type, "EditorIcons");
+				}
+				script = base_script;
+				class_name = EditorNode::get_editor_data().script_class_get_name(script->get_path());
+			} while (class_name.is_empty());
 		}
 	}
 


### PR DESCRIPTION
Scripts with `class_name` are displayed in the Create Dialog. If such class does not define an icon and it inherits from a plain script (`extends "res://Base.gd"`), the icon will not be displayed correctly in the Create Dialog, and an error will be printed:

```
ERROR: Condition "!global_classes.has(p_class)" is true. Returning: String()
```

* On `master`: It always show a grey generic `Node` icon, even if the class eventually inherits from other nodes like `AudioStreamPlayer`.
* On `3.x`: It always show nothing (empty icon).

_Edit:_ actually, that error is also shown when the global class inherits directly from a built-in class.