### PR TITLE
Allow toggling verbose mode at run-time

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -375,6 +375,10 @@ bool OS::is_stdout_verbose() const {
 	return ::OS::get_singleton()->is_stdout_verbose();
 }
 
+void OS::set_stdout_verbose(bool p_verbose) const {
+	::OS::get_singleton()->set_stdout_verbose(p_verbose);
+}
+
 void OS::dump_memory_to_file(const String &p_file) {
 	::OS::get_singleton()->dump_memory_to_file(p_file.utf8().get_data());
 }
@@ -593,6 +597,7 @@ void OS::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("is_userfs_persistent"), &OS::is_userfs_persistent);
 	ClassDB::bind_method(D_METHOD("is_stdout_verbose"), &OS::is_stdout_verbose);
+	ClassDB::bind_method(D_METHOD("set_stdout_verbose"), &OS::set_stdout_verbose);
 
 	ClassDB::bind_method(D_METHOD("can_use_threads"), &OS::can_use_threads);
 
@@ -635,11 +640,13 @@ void OS::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "low_processor_usage_mode"), "set_low_processor_usage_mode", "is_in_low_processor_usage_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "low_processor_usage_mode_sleep_usec"), "set_low_processor_usage_mode_sleep_usec", "get_low_processor_usage_mode_sleep_usec");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "stdout_verbose"), "set_stdout_verbose", "is_stdout_verbose");
 
 	// Those default values need to be specified for the docs generator,
 	// to avoid using values from the documentation writer's own OS instance.
 	ADD_PROPERTY_DEFAULT("low_processor_usage_mode", false);
 	ADD_PROPERTY_DEFAULT("low_processor_usage_mode_sleep_usec", 6900);
+	ADD_PROPERTY_DEFAULT("stdout_verbose", false);
 
 	BIND_ENUM_CONSTANT(VIDEO_DRIVER_VULKAN);
 	BIND_ENUM_CONSTANT(VIDEO_DRIVER_OPENGL_3);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -219,6 +219,7 @@ public:
 	bool is_userfs_persistent() const;
 
 	bool is_stdout_verbose() const;
+	void set_stdout_verbose(bool p_verbose) const;
 
 	int get_processor_count() const;
 	String get_processor_name() const;

--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -151,6 +151,10 @@ bool OS::is_stdout_verbose() const {
 	return _verbose_stdout;
 }
 
+void OS::set_stdout_verbose(bool p_verbose) {
+	_verbose_stdout = p_verbose;
+}
+
 bool OS::is_single_window() const {
 	return _single_window;
 }

--- a/core/os/os.h
+++ b/core/os/os.h
@@ -235,6 +235,8 @@ public:
 	virtual bool is_userfs_persistent() const { return true; }
 
 	bool is_stdout_verbose() const;
+	void set_stdout_verbose(bool p_verbose);
+
 	bool is_stdout_debug_enabled() const;
 
 	bool is_stdout_enabled() const;

--- a/doc/classes/@GlobalScope.xml
+++ b/doc/classes/@GlobalScope.xml
@@ -648,7 +648,7 @@
 		</method>
 		<method name="print_verbose" qualifiers="vararg">
 			<description>
-				If verbose mode is enabled ([method OS.is_stdout_verbose] returning [code]true[/code]), converts one or more arguments of any type to string in the best way possible and prints them to the console.
+				If verbose mode is enabled ([member OS.stdout_verbose] is [code]true[/code]), converts one or more arguments of any type to string in the best way possible and prints them to the console.
 			</description>
 		</method>
 		<method name="printerr" qualifiers="vararg">

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -443,12 +443,6 @@
 				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
 			</description>
 		</method>
-		<method name="is_stdout_verbose" qualifiers="const">
-			<return type="bool" />
-			<description>
-				Returns [code]true[/code] if the engine was executed with the [code]--verbose[/code] or [code]-v[/code] command line argument, or if [member ProjectSettings.debug/settings/stdout/verbose_stdout] is [code]true[/code]. See also [method @GlobalScope.print_verbose].
-			</description>
-		</method>
 		<method name="is_userfs_persistent" qualifiers="const">
 			<return type="bool" />
 			<description>
@@ -562,6 +556,9 @@
 		</member>
 		<member name="low_processor_usage_mode_sleep_usec" type="int" setter="set_low_processor_usage_mode_sleep_usec" getter="get_low_processor_usage_mode_sleep_usec" default="6900">
 			The amount of sleeping between frames when the low-processor usage mode is enabled (in microseconds). Higher values will result in lower CPU usage.
+		</member>
+		<member name="stdout_verbose" type="bool" setter="set_stdout_verbose" getter="is_stdout_verbose" default="false">
+			If [code]true[/code], prints more information to standard output when running. It displays information such as memory leaks, which scenes and resources are being loaded, etc. This can also be enabled using the [code]--verbose[/code] or [code]-v[/code] command line argument, even on an exported project. See also [member ProjectSettings.debug/settings/stdout/verbose_stdout] and [method @GlobalScope.print_verbose].
 		</member>
 	</members>
 	<constants>

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -451,7 +451,8 @@
 		<member name="debug/settings/stdout/print_gpu_profile" type="bool" setter="" getter="" default="false">
 		</member>
 		<member name="debug/settings/stdout/verbose_stdout" type="bool" setter="" getter="" default="false">
-			Print more information to standard output when running. It displays information such as memory leaks, which scenes and resources are being loaded, etc. This can also be enabled using the [code]--verbose[/code] or [code]-v[/code] command line argument, even on an exported project. See also [method OS.is_stdout_verbose] and [method @GlobalScope.print_verbose].
+			Print more information to standard output when running. It displays information such as memory leaks, which scenes and resources are being loaded, etc. This can also be enabled using the [code]--verbose[/code] or [code]-v[/code] command line argument, even on an exported project. See also [member OS.stdout_verbose] and [method @GlobalScope.print_verbose].
+			[b]Note:[/b] This property is only read when the project starts. To toggle verbose modef at runtime, set [member OS.stdout_verbose] instead.
 		</member>
 		<member name="debug/settings/visual_script/max_call_stack" type="int" setter="" getter="" default="1024">
 			Maximum call stack in visual scripting, to avoid infinite recursion.


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/60284.

This can be used to temporarily enable verbose mode in a project (or temporarily disable it). When debugging a project using lots of verbose prints, this is useful to prevent too many prints from being displayed when it's not needed.

This PR can be remade for `3.x` if desired.

This partially addresses https://github.com/godotengine/godot-proposals/issues/4574. (There's no Verbose toggle within the editor Output panel itself.)

**Testing project:** [test_verbose_runtime.zip](https://github.com/godotengine/godot/files/8565204/test_verbose_runtime.zip)