### PR TITLE
Expose `move_to_trash()`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -483,6 +483,10 @@ void OS::dump_resources_to_file(const String &p_file) {
 	::OS::get_singleton()->dump_resources_to_file(p_file.utf8().get_data());
 }
 
+Error OS::move_to_trash(const String &p_path) const {
+	return ::OS::get_singleton()->move_to_trash(p_path);
+}
+
 String OS::get_user_data_dir() const {
 	return ::OS::get_singleton()->get_user_data_dir();
 }
@@ -597,6 +601,7 @@ void OS::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_static_memory_usage"), &OS::get_static_memory_usage);
 	ClassDB::bind_method(D_METHOD("get_static_memory_peak_usage"), &OS::get_static_memory_peak_usage);
 
+	ClassDB::bind_method(D_METHOD("move_to_trash", "path"), &OS::move_to_trash);
 	ClassDB::bind_method(D_METHOD("get_user_data_dir"), &OS::get_user_data_dir);
 	ClassDB::bind_method(D_METHOD("get_system_dir", "dir", "shared_storage"), &OS::get_system_dir, DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("get_config_dir"), &OS::get_config_dir);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -235,6 +235,7 @@ public:
 
 	String get_system_dir(SystemDir p_dir, bool p_shared_storage = true) const;
 
+	Error move_to_trash(const String &p_path) const;
 	String get_user_data_dir() const;
 	String get_config_dir() const;
 	String get_data_dir() const;

--- a/doc/classes/Directory.xml
+++ b/doc/classes/Directory.xml
@@ -196,7 +196,8 @@
 			<return type="int" enum="Error" />
 			<argument index="0" name="path" type="String" />
 			<description>
-				Deletes the target file or an empty directory. The argument can be relative to the current directory, or an absolute path. If the target directory is not empty, the operation will fail.
+				Permanently deletes the target file or an empty directory. The argument can be relative to the current directory, or an absolute path. If the target directory is not empty, the operation will fail.
+				If you don't want to delete the file/directory permanently, use [method OS.move_to_trash] instead.
 				Returns one of the [enum Error] code constants ([code]OK[/code] on success).
 			</description>
 		</method>

--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -455,6 +455,14 @@
 				[b]Note:[/b] This method is implemented on Android, iOS, Linux, macOS and Windows.
 			</description>
 		</method>
+		<method name="move_to_trash" qualifiers="const">
+			<return type="int" enum="Error" />
+			<argument index="0" name="path" type="String" />
+			<description>
+				Moves the file or directory to the system's recycle bin. See also [method Directory.remove].
+				[b]Note:[/b] If the user has disabled the recycle bin on their system, the file will be permanently deleted instead.
+			</description>
+		</method>
 		<method name="open_midi_inputs">
 			<return type="void" />
 			<description>


### PR DESCRIPTION
`move_to_trash()` is useful when you have some sort of file management in your game (e.g. in a level editor) or app. Deleting files permanently is undesired in such cases.