### PR TITLE
Rename variable names for some singletons

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -120,10 +120,10 @@ static RenderingServer *rendering_server = nullptr;
 static CameraServer *camera_server = nullptr;
 static XRServer *xr_server = nullptr;
 static TextServerManager *tsman = nullptr;
-static PhysicsServer3D *physics_server = nullptr;
-static PhysicsServer2D *physics_2d_server = nullptr;
-static NavigationServer3D *navigation_server = nullptr;
-static NavigationServer2D *navigation_2d_server = nullptr;
+static PhysicsServer3D *physics_server_3d = nullptr;
+static PhysicsServer2D *physics_server_2d = nullptr;
+static NavigationServer3D *navigation_server_3d = nullptr;
+static NavigationServer2D *navigation_server_2d = nullptr;
 // We error out if setup2() doesn't turn this true
 static bool _start_success = false;
 
@@ -204,32 +204,32 @@ static String get_full_version_string() {
 // to have less code in main.cpp.
 void initialize_physics() {
 	/// 3D Physics Server
-	physics_server = PhysicsServer3DManager::new_server(
+	physics_server_3d = PhysicsServer3DManager::new_server(
 			ProjectSettings::get_singleton()->get(PhysicsServer3DManager::setting_property_name));
-	if (!physics_server) {
+	if (!physics_server_3d) {
 		// Physics server not found, Use the default physics
-		physics_server = PhysicsServer3DManager::new_default_server();
+		physics_server_3d = PhysicsServer3DManager::new_default_server();
 	}
-	ERR_FAIL_COND(!physics_server);
-	physics_server->init();
+	ERR_FAIL_COND(!physics_server_3d);
+	physics_server_3d->init();
 
 	/// 2D Physics server
-	physics_2d_server = PhysicsServer2DManager::new_server(
+	physics_server_2d = PhysicsServer2DManager::new_server(
 			ProjectSettings::get_singleton()->get(PhysicsServer2DManager::setting_property_name));
-	if (!physics_2d_server) {
+	if (!physics_server_2d) {
 		// Physics server not found, Use the default physics
-		physics_2d_server = PhysicsServer2DManager::new_default_server();
+		physics_server_2d = PhysicsServer2DManager::new_default_server();
 	}
-	ERR_FAIL_COND(!physics_2d_server);
-	physics_2d_server->init();
+	ERR_FAIL_COND(!physics_server_2d);
+	physics_server_2d->init();
 }
 
 void finalize_physics() {
-	physics_server->finish();
-	memdelete(physics_server);
+	physics_server_3d->finish();
+	memdelete(physics_server_3d);
 
-	physics_2d_server->finish();
-	memdelete(physics_2d_server);
+	physics_server_2d->finish();
+	memdelete(physics_server_2d);
 }
 
 void finalize_display() {
@@ -240,18 +240,18 @@ void finalize_display() {
 }
 
 void initialize_navigation_server() {
-	ERR_FAIL_COND(navigation_server != nullptr);
+	ERR_FAIL_COND(navigation_server_3d != nullptr);
 
-	navigation_server = NavigationServer3DManager::new_default_server();
-	navigation_2d_server = memnew(NavigationServer2D);
+	navigation_server_3d = NavigationServer3DManager::new_default_server();
+	navigation_server_2d = memnew(NavigationServer2D);
 }
 
 void finalize_navigation_server() {
-	memdelete(navigation_server);
-	navigation_server = nullptr;
+	memdelete(navigation_server_3d);
+	navigation_server_3d = nullptr;
 
-	memdelete(navigation_2d_server);
-	navigation_2d_server = nullptr;
+	memdelete(navigation_server_2d);
+	navigation_server_2d = nullptr;
 }
 
 //#define DEBUG_INIT

--- a/servers/physics_server_2d_wrap_mt.cpp
+++ b/servers/physics_server_2d_wrap_mt.cpp
@@ -37,7 +37,7 @@ void PhysicsServer2DWrapMT::thread_exit() {
 }
 
 void PhysicsServer2DWrapMT::thread_step(real_t p_delta) {
-	physics_2d_server->step(p_delta);
+	physics_server_2d->step(p_delta);
 	step_sem.post();
 }
 
@@ -50,7 +50,7 @@ void PhysicsServer2DWrapMT::_thread_callback(void *_instance) {
 void PhysicsServer2DWrapMT::thread_loop() {
 	server_thread = Thread::get_caller_id();
 
-	physics_2d_server->init();
+	physics_server_2d->init();
 
 	exit.clear();
 	step_thread_up.set();
@@ -61,7 +61,7 @@ void PhysicsServer2DWrapMT::thread_loop() {
 
 	command_queue.flush_all(); // flush all
 
-	physics_2d_server->finish();
+	physics_server_2d->finish();
 }
 
 /* EVENT QUEUING */
@@ -71,7 +71,7 @@ void PhysicsServer2DWrapMT::step(real_t p_step) {
 		command_queue.push(this, &PhysicsServer2DWrapMT::thread_step, p_step);
 	} else {
 		command_queue.flush_all(); //flush all pending from other threads
-		physics_2d_server->step(p_step);
+		physics_server_2d->step(p_step);
 	}
 }
 
@@ -83,15 +83,15 @@ void PhysicsServer2DWrapMT::sync() {
 			step_sem.wait(); //must not wait if a step was not issued
 		}
 	}
-	physics_2d_server->sync();
+	physics_server_2d->sync();
 }
 
 void PhysicsServer2DWrapMT::flush_queries() {
-	physics_2d_server->flush_queries();
+	physics_server_2d->flush_queries();
 }
 
 void PhysicsServer2DWrapMT::end_sync() {
-	physics_2d_server->end_sync();
+	physics_server_2d->end_sync();
 }
 
 void PhysicsServer2DWrapMT::init() {
@@ -102,7 +102,7 @@ void PhysicsServer2DWrapMT::init() {
 			OS::get_singleton()->delay_usec(1000);
 		}
 	} else {
-		physics_2d_server->init();
+		physics_server_2d->init();
 	}
 }
 
@@ -111,13 +111,13 @@ void PhysicsServer2DWrapMT::finish() {
 		command_queue.push(this, &PhysicsServer2DWrapMT::thread_exit);
 		thread.wait_to_finish();
 	} else {
-		physics_2d_server->finish();
+		physics_server_2d->finish();
 	}
 }
 
 PhysicsServer2DWrapMT::PhysicsServer2DWrapMT(PhysicsServer2D *p_contained, bool p_create_thread) :
 		command_queue(p_create_thread) {
-	physics_2d_server = p_contained;
+	physics_server_2d = p_contained;
 	create_thread = p_create_thread;
 
 	pool_max_size = GLOBAL_GET("memory/limits/multithreaded_server/rid_pool_prealloc");
@@ -132,6 +132,6 @@ PhysicsServer2DWrapMT::PhysicsServer2DWrapMT(PhysicsServer2D *p_contained, bool 
 }
 
 PhysicsServer2DWrapMT::~PhysicsServer2DWrapMT() {
-	memdelete(physics_2d_server);
+	memdelete(physics_server_2d);
 	//finish();
 }

--- a/servers/physics_server_2d_wrap_mt.h
+++ b/servers/physics_server_2d_wrap_mt.h
@@ -44,7 +44,7 @@
 #endif
 
 class PhysicsServer2DWrapMT : public PhysicsServer2D {
-	mutable PhysicsServer2D *physics_2d_server;
+	mutable PhysicsServer2D *physics_server_2d;
 
 	mutable CommandQueueMT command_queue;
 
@@ -71,7 +71,7 @@ class PhysicsServer2DWrapMT : public PhysicsServer2D {
 public:
 #define ServerName PhysicsServer2D
 #define ServerNameWrapMT PhysicsServer2DWrapMT
-#define server_name physics_2d_server
+#define server_name physics_server_2d
 #define WRITE_ACTION
 
 #include "servers/server_wrap_mt_common.h"
@@ -96,7 +96,7 @@ public:
 	//these work well, but should be used from the main thread only
 	bool shape_collide(RID p_shape_A, const Transform2D &p_xform_A, const Vector2 &p_motion_A, RID p_shape_B, const Transform2D &p_xform_B, const Vector2 &p_motion_B, Vector2 *r_results, int p_result_max, int &r_result_count) override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
-		return physics_2d_server->shape_collide(p_shape_A, p_xform_A, p_motion_A, p_shape_B, p_xform_B, p_motion_B, r_results, p_result_max, r_result_count);
+		return physics_server_2d->shape_collide(p_shape_A, p_xform_A, p_motion_A, p_shape_B, p_xform_B, p_motion_B, r_results, p_result_max, r_result_count);
 	}
 
 	/* SPACE API */
@@ -111,18 +111,18 @@ public:
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectSpaceState2D *space_get_direct_state(RID p_space) override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), nullptr);
-		return physics_2d_server->space_get_direct_state(p_space);
+		return physics_server_2d->space_get_direct_state(p_space);
 	}
 
 	FUNC2(space_set_debug_contacts, RID, int);
 	virtual Vector<Vector2> space_get_contacts(RID p_space) const override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), Vector<Vector2>());
-		return physics_2d_server->space_get_contacts(p_space);
+		return physics_server_2d->space_get_contacts(p_space);
 	}
 
 	virtual int space_get_contact_count(RID p_space) const override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), 0);
-		return physics_2d_server->space_get_contact_count(p_space);
+		return physics_server_2d->space_get_contact_count(p_space);
 	}
 
 	/* AREA API */
@@ -250,20 +250,20 @@ public:
 	FUNC3(body_set_force_integration_callback, RID, const Callable &, const Variant &);
 
 	bool body_collide_shape(RID p_body, int p_body_shape, RID p_shape, const Transform2D &p_shape_xform, const Vector2 &p_motion, Vector2 *r_results, int p_result_max, int &r_result_count) override {
-		return physics_2d_server->body_collide_shape(p_body, p_body_shape, p_shape, p_shape_xform, p_motion, r_results, p_result_max, r_result_count);
+		return physics_server_2d->body_collide_shape(p_body, p_body_shape, p_shape, p_shape_xform, p_motion, r_results, p_result_max, r_result_count);
 	}
 
 	FUNC2(body_set_pickable, RID, bool);
 
 	bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
-		return physics_2d_server->body_test_motion(p_body, p_parameters, r_result);
+		return physics_server_2d->body_test_motion(p_body, p_parameters, r_result);
 	}
 
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectBodyState2D *body_get_direct_state(RID p_body) override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), nullptr);
-		return physics_2d_server->body_get_direct_state(p_body);
+		return physics_server_2d->body_get_direct_state(p_body);
 	}
 
 	/* JOINT API */
@@ -309,11 +309,11 @@ public:
 	virtual void finish() override;
 
 	virtual bool is_flushing_queries() const override {
-		return physics_2d_server->is_flushing_queries();
+		return physics_server_2d->is_flushing_queries();
 	}
 
 	int get_process_info(ProcessInfo p_info) override {
-		return physics_2d_server->get_process_info(p_info);
+		return physics_server_2d->get_process_info(p_info);
 	}
 
 	PhysicsServer2DWrapMT(PhysicsServer2D *p_contained, bool p_create_thread);

--- a/servers/physics_server_3d_wrap_mt.cpp
+++ b/servers/physics_server_3d_wrap_mt.cpp
@@ -37,7 +37,7 @@ void PhysicsServer3DWrapMT::thread_exit() {
 }
 
 void PhysicsServer3DWrapMT::thread_step(real_t p_delta) {
-	physics_3d_server->step(p_delta);
+	physics_server_3d->step(p_delta);
 	step_sem.post();
 }
 
@@ -50,7 +50,7 @@ void PhysicsServer3DWrapMT::_thread_callback(void *_instance) {
 void PhysicsServer3DWrapMT::thread_loop() {
 	server_thread = Thread::get_caller_id();
 
-	physics_3d_server->init();
+	physics_server_3d->init();
 
 	exit = false;
 	step_thread_up = true;
@@ -61,7 +61,7 @@ void PhysicsServer3DWrapMT::thread_loop() {
 
 	command_queue.flush_all(); // flush all
 
-	physics_3d_server->finish();
+	physics_server_3d->finish();
 }
 
 /* EVENT QUEUING */
@@ -71,7 +71,7 @@ void PhysicsServer3DWrapMT::step(real_t p_step) {
 		command_queue.push(this, &PhysicsServer3DWrapMT::thread_step, p_step);
 	} else {
 		command_queue.flush_all(); //flush all pending from other threads
-		physics_3d_server->step(p_step);
+		physics_server_3d->step(p_step);
 	}
 }
 
@@ -83,15 +83,15 @@ void PhysicsServer3DWrapMT::sync() {
 			step_sem.wait(); //must not wait if a step was not issued
 		}
 	}
-	physics_3d_server->sync();
+	physics_server_3d->sync();
 }
 
 void PhysicsServer3DWrapMT::flush_queries() {
-	physics_3d_server->flush_queries();
+	physics_server_3d->flush_queries();
 }
 
 void PhysicsServer3DWrapMT::end_sync() {
-	physics_3d_server->end_sync();
+	physics_server_3d->end_sync();
 }
 
 void PhysicsServer3DWrapMT::init() {
@@ -102,7 +102,7 @@ void PhysicsServer3DWrapMT::init() {
 			OS::get_singleton()->delay_usec(1000);
 		}
 	} else {
-		physics_3d_server->init();
+		physics_server_3d->init();
 	}
 }
 
@@ -111,13 +111,13 @@ void PhysicsServer3DWrapMT::finish() {
 		command_queue.push(this, &PhysicsServer3DWrapMT::thread_exit);
 		thread.wait_to_finish();
 	} else {
-		physics_3d_server->finish();
+		physics_server_3d->finish();
 	}
 }
 
 PhysicsServer3DWrapMT::PhysicsServer3DWrapMT(PhysicsServer3D *p_contained, bool p_create_thread) :
 		command_queue(p_create_thread) {
-	physics_3d_server = p_contained;
+	physics_server_3d = p_contained;
 	create_thread = p_create_thread;
 
 	pool_max_size = GLOBAL_GET("memory/limits/multithreaded_server/rid_pool_prealloc");
@@ -132,6 +132,6 @@ PhysicsServer3DWrapMT::PhysicsServer3DWrapMT(PhysicsServer3D *p_contained, bool 
 }
 
 PhysicsServer3DWrapMT::~PhysicsServer3DWrapMT() {
-	memdelete(physics_3d_server);
+	memdelete(physics_server_3d);
 	//finish();
 }

--- a/servers/physics_server_3d_wrap_mt.h
+++ b/servers/physics_server_3d_wrap_mt.h
@@ -43,7 +43,7 @@
 #endif
 
 class PhysicsServer3DWrapMT : public PhysicsServer3D {
-	mutable PhysicsServer3D *physics_3d_server;
+	mutable PhysicsServer3D *physics_server_3d;
 
 	mutable CommandQueueMT command_queue;
 
@@ -70,7 +70,7 @@ class PhysicsServer3DWrapMT : public PhysicsServer3D {
 public:
 #define ServerName PhysicsServer3D
 #define ServerNameWrapMT PhysicsServer3DWrapMT
-#define server_name physics_3d_server
+#define server_name physics_server_3d
 #define WRITE_ACTION
 
 #include "servers/server_wrap_mt_common.h"
@@ -100,7 +100,7 @@ public:
 	//these work well, but should be used from the main thread only
 	bool shape_collide(RID p_shape_A, const Transform &p_xform_A, const Vector3 &p_motion_A, RID p_shape_B, const Transform &p_xform_B, const Vector3 &p_motion_B, Vector3 *r_results, int p_result_max, int &r_result_count) {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
-		return physics_3d_server->shape_collide(p_shape_A, p_xform_A, p_motion_A, p_shape_B, p_xform_B, p_motion_B, r_results, p_result_max, r_result_count);
+		return physics_server_3d->shape_collide(p_shape_A, p_xform_A, p_motion_A, p_shape_B, p_xform_B, p_motion_B, r_results, p_result_max, r_result_count);
 	}
 #endif
 	/* SPACE API */
@@ -115,18 +115,18 @@ public:
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectSpaceState3D *space_get_direct_state(RID p_space) override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), nullptr);
-		return physics_3d_server->space_get_direct_state(p_space);
+		return physics_server_3d->space_get_direct_state(p_space);
 	}
 
 	FUNC2(space_set_debug_contacts, RID, int);
 	virtual Vector<Vector3> space_get_contacts(RID p_space) const override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), Vector<Vector3>());
-		return physics_3d_server->space_get_contacts(p_space);
+		return physics_server_3d->space_get_contacts(p_space);
 	}
 
 	virtual int space_get_contact_count(RID p_space) const override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), 0);
-		return physics_3d_server->space_get_contact_count(p_space);
+		return physics_server_3d->space_get_contact_count(p_space);
 	}
 
 	/* AREA API */
@@ -256,13 +256,13 @@ public:
 
 	bool body_test_motion(RID p_body, const MotionParameters &p_parameters, MotionResult *r_result = nullptr) override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), false);
-		return physics_3d_server->body_test_motion(p_body, p_parameters, r_result);
+		return physics_server_3d->body_test_motion(p_body, p_parameters, r_result);
 	}
 
 	// this function only works on physics process, errors and returns null otherwise
 	PhysicsDirectBodyState3D *body_get_direct_state(RID p_body) override {
 		ERR_FAIL_COND_V(main_thread != Thread::get_caller_id(), nullptr);
-		return physics_3d_server->body_get_direct_state(p_body);
+		return physics_server_3d->body_get_direct_state(p_body);
 	}
 
 	/* SOFT BODY API */
@@ -385,11 +385,11 @@ public:
 	virtual void finish() override;
 
 	virtual bool is_flushing_queries() const override {
-		return physics_3d_server->is_flushing_queries();
+		return physics_server_3d->is_flushing_queries();
 	}
 
 	int get_process_info(ProcessInfo p_info) override {
-		return physics_3d_server->get_process_info(p_info);
+		return physics_server_3d->get_process_info(p_info);
 	}
 
 	PhysicsServer3DWrapMT(PhysicsServer3D *p_contained, bool p_create_thread);

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -85,17 +85,17 @@ ShaderTypes *shader_types = nullptr;
 PhysicsServer3D *_createGodotPhysics3DCallback() {
 	bool using_threads = GLOBAL_GET("physics/3d/run_on_separate_thread");
 
-	PhysicsServer3D *physics_server = memnew(GodotPhysicsServer3D(using_threads));
+	PhysicsServer3D *physics_server_3d = memnew(GodotPhysicsServer3D(using_threads));
 
-	return memnew(PhysicsServer3DWrapMT(physics_server, using_threads));
+	return memnew(PhysicsServer3DWrapMT(physics_server_3d, using_threads));
 }
 
 PhysicsServer2D *_createGodotPhysics2DCallback() {
 	bool using_threads = GLOBAL_GET("physics/2d/run_on_separate_thread");
 
-	PhysicsServer2D *physics_server = memnew(GodotPhysicsServer2D(using_threads));
+	PhysicsServer2D *physics_server_2d = memnew(GodotPhysicsServer2D(using_threads));
 
-	return memnew(PhysicsServer2DWrapMT(physics_server, using_threads));
+	return memnew(PhysicsServer2DWrapMT(physics_server_2d, using_threads));
 }
 
 static bool has_server_feature_callback(const String &p_feature) {

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -160,10 +160,10 @@ struct GodotTestCaseListener : public doctest::IReporter {
 
 	SignalWatcher *signal_watcher = nullptr;
 
-	PhysicsServer3D *physics_3d_server = nullptr;
-	PhysicsServer2D *physics_2d_server = nullptr;
-	NavigationServer3D *navigation_3d_server = nullptr;
-	NavigationServer2D *navigation_2d_server = nullptr;
+	PhysicsServer3D *physics_server_3d = nullptr;
+	PhysicsServer2D *physics_server_2d = nullptr;
+	NavigationServer3D *navigation_server_3d = nullptr;
+	NavigationServer2D *navigation_server_2d = nullptr;
 
 	void test_case_start(const doctest::TestCaseData &p_in) override {
 		SignalWatcher::get_singleton()->_clear_signals();
@@ -190,14 +190,14 @@ struct GodotTestCaseListener : public doctest::IReporter {
 			RenderingServerDefault::get_singleton()->init();
 			RenderingServerDefault::get_singleton()->set_render_loop_enabled(false);
 
-			physics_3d_server = PhysicsServer3DManager::new_default_server();
-			physics_3d_server->init();
+			physics_server_3d = PhysicsServer3DManager::new_default_server();
+			physics_server_3d->init();
 
-			physics_2d_server = PhysicsServer2DManager::new_default_server();
-			physics_2d_server->init();
+			physics_server_2d = PhysicsServer2DManager::new_default_server();
+			physics_server_2d->init();
 
-			navigation_3d_server = NavigationServer3DManager::new_default_server();
-			navigation_2d_server = memnew(NavigationServer2D);
+			navigation_server_3d = NavigationServer3DManager::new_default_server();
+			navigation_server_2d = memnew(NavigationServer2D);
 
 			memnew(InputMap);
 			InputMap::get_singleton()->load_default();
@@ -225,26 +225,26 @@ struct GodotTestCaseListener : public doctest::IReporter {
 
 		clear_default_theme();
 
-		if (navigation_3d_server) {
-			memdelete(navigation_3d_server);
-			navigation_3d_server = nullptr;
+		if (navigation_server_3d) {
+			memdelete(navigation_server_3d);
+			navigation_server_3d = nullptr;
 		}
 
-		if (navigation_2d_server) {
-			memdelete(navigation_2d_server);
-			navigation_2d_server = nullptr;
+		if (navigation_server_2d) {
+			memdelete(navigation_server_2d);
+			navigation_server_2d = nullptr;
 		}
 
-		if (physics_3d_server) {
-			physics_3d_server->finish();
-			memdelete(physics_3d_server);
-			physics_3d_server = nullptr;
+		if (physics_server_3d) {
+			physics_server_3d->finish();
+			memdelete(physics_server_3d);
+			physics_server_3d = nullptr;
 		}
 
-		if (physics_2d_server) {
-			physics_2d_server->finish();
-			memdelete(physics_2d_server);
-			physics_2d_server = nullptr;
+		if (physics_server_2d) {
+			physics_server_2d->finish();
+			memdelete(physics_server_2d);
+			physics_server_2d = nullptr;
 		}
 
 		if (Input::get_singleton()) {


### PR DESCRIPTION
The classes were renamed awhile ago, but the variable names were forgotten.

* `physics_2d_server` -> `physics_server_2d`
* `physics_3d_server` -> `physics_server_3d`
* `navigation_2d_server` -> `navigation_server_2d`
* `navigation_3d_server` -> `navigation_server_3d`