### PR TITLE
Make more import preset name translatable

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -198,12 +198,12 @@ int ResourceImporterTexture::get_preset_count() const {
 
 String ResourceImporterTexture::get_preset_name(int p_idx) const {
 	static const char *preset_names[] = {
-		"2D/3D (Auto-Detect)",
-		"2D",
-		"3D",
+		TTRC("2D/3D (Auto-Detect)"),
+		TTRC("2D"),
+		TTRC("3D"),
 	};
 
-	return preset_names[p_idx];
+	return TTRGET(preset_names[p_idx]);
 }
 
 void ResourceImporterTexture::get_import_options(const String &p_path, List<ImportOption> *r_options, int p_preset) const {


### PR DESCRIPTION
Some presets were already translatable:

* master: DynamicFont importer presets
* 3.x: Scene importer presets