### PR TITLE
Fix screen_get_usable_rect returning display safe area

### DIFF
--- a/doc/classes/DisplayServer.xml
+++ b/doc/classes/DisplayServer.xml
@@ -107,8 +107,14 @@
 		<method name="get_display_cutouts" qualifiers="const">
 			<return type="Array" />
 			<description>
-				Returns an [Array] of [Rect2], each of which is the bounding rectangle for a display cutout or notch. These are non-functional areas on edge-to-edge screens used by cameras and sensors. Returns an empty array if the device does not have cutouts. See also [method screen_get_usable_rect].
+				Returns an [Array] of [Rect2], each of which is the bounding rectangle for a display cutout or notch. These are non-functional areas on edge-to-edge screens used by cameras and sensors. Returns an empty array if the device does not have cutouts. See also [method get_display_safe_area].
 				[b]Note:[/b] Currently only implemented on Android. Other platforms will return an empty array even if they do have display cutouts or notches.
+			</description>
+		</method>
+		<method name="get_display_safe_area" qualifiers="const">
+			<return type="Rect2i" />
+			<description>
+				Returns the unobscured area of the display where interactive controls should be rendered. See also [method get_display_cutouts].
 			</description>
 		</method>
 		<method name="get_name" qualifiers="const">

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -142,6 +142,12 @@ Array DisplayServerAndroid::get_display_cutouts() const {
 	return godot_io_java->get_display_cutouts();
 }
 
+Rect2i DisplayServerAndroid::get_display_safe_area() const {
+	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
+	ERR_FAIL_NULL_V(godot_io_java, Rect2i());
+	return godot_io_java->get_display_safe_area();
+}
+
 void DisplayServerAndroid::screen_set_keep_on(bool p_enable) {
 	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
 	ERR_FAIL_COND(!godot_java);
@@ -183,11 +189,8 @@ Size2i DisplayServerAndroid::screen_get_size(int p_screen) const {
 }
 
 Rect2i DisplayServerAndroid::screen_get_usable_rect(int p_screen) const {
-	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
-	ERR_FAIL_COND_V(!godot_io_java, Rect2i());
-	int xywh[4];
-	godot_io_java->screen_get_usable_rect(xywh);
-	return Rect2i(xywh[0], xywh[1], xywh[2], xywh[3]);
+	Size2i display_size = OS_Android::get_singleton()->get_display_size();
+	return Rect2i(0, 0, display_size.width, display_size.height);
 }
 
 int DisplayServerAndroid::screen_get_dpi(int p_screen) const {

--- a/platform/android/display_server_android.h
+++ b/platform/android/display_server_android.h
@@ -105,6 +105,7 @@ public:
 	virtual bool clipboard_has() const override;
 
 	virtual Array get_display_cutouts() const override;
+	virtual Rect2i get_display_safe_area() const override;
 
 	virtual void screen_set_keep_on(bool p_enable) override;
 	virtual bool screen_is_kept_on() const override;

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -240,7 +240,7 @@ public class GodotIO {
 		return fallback;
 	}
 
-	public int[] screenGetUsableRect() {
+	public int[] getDisplaySafeArea() {
 		DisplayMetrics metrics = activity.getResources().getDisplayMetrics();
 		Display display = activity.getWindowManager().getDefaultDisplay();
 		Point size = new Point();

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -37,6 +37,7 @@
 #include <android/log.h>
 #include <jni.h>
 
+#include "core/math/rect2i.h"
 #include "core/variant/array.h"
 #include "string_android.h"
 
@@ -50,12 +51,12 @@ private:
 	jmethodID _get_cache_dir = 0;
 	jmethodID _get_data_dir = 0;
 	jmethodID _get_display_cutouts = 0;
+	jmethodID _get_display_safe_area = 0;
 	jmethodID _get_locale = 0;
 	jmethodID _get_model = 0;
 	jmethodID _get_screen_DPI = 0;
 	jmethodID _get_scaled_density = 0;
 	jmethodID _get_screen_refresh_rate = 0;
-	jmethodID _screen_get_usable_rect = 0;
 	jmethodID _get_unique_id = 0;
 	jmethodID _show_keyboard = 0;
 	jmethodID _hide_keyboard = 0;
@@ -77,8 +78,8 @@ public:
 	int get_screen_dpi();
 	float get_scaled_density();
 	float get_screen_refresh_rate(float fallback);
-	void screen_get_usable_rect(int (&p_rect_xywh)[4]);
 	Array get_display_cutouts();
+	Rect2i get_display_safe_area();
 	String get_unique_id();
 	bool has_vk();
 	void show_vk(const String &p_existing, bool p_multiline, int p_max_input_length, int p_cursor_start, int p_cursor_end);

--- a/platform/iphone/display_server_iphone.h
+++ b/platform/iphone/display_server_iphone.h
@@ -134,6 +134,8 @@ public:
 	virtual void tts_resume() override;
 	virtual void tts_stop() override;
 
+	virtual Rect2i get_display_safe_area() const override;
+
 	virtual int get_screen_count() const override;
 	virtual Point2i screen_get_position(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;
 	virtual Size2i screen_get_size(int p_screen = SCREEN_OF_MAIN_WINDOW) const override;

--- a/platform/iphone/display_server_iphone.mm
+++ b/platform/iphone/display_server_iphone.mm
@@ -360,6 +360,22 @@ void DisplayServerIPhone::tts_stop() {
 	[tts stopSpeaking];
 }
 
+Rect2i DisplayServerIPhone::get_display_safe_area() const {
+	if (@available(iOS 11, *)) {
+		UIEdgeInsets insets = UIEdgeInsetsZero;
+		UIView *view = AppDelegate.viewController.godotView;
+		if ([view respondsToSelector:@selector(safeAreaInsets)]) {
+			insets = [view safeAreaInsets];
+		}
+		float scale = screen_get_scale();
+		Size2i insets_position = Size2i(insets.left, insets.top) * scale;
+		Size2i insets_size = Size2i(insets.left + insets.right, insets.top + insets.bottom) * scale;
+		return Rect2i(screen_get_position() + insets_position, screen_get_size() - insets_size);
+	} else {
+		return Rect2i(screen_get_position(), screen_get_size());
+	}
+}
+
 int DisplayServerIPhone::get_screen_count() const {
 	return 1;
 }
@@ -379,22 +395,7 @@ Size2i DisplayServerIPhone::screen_get_size(int p_screen) const {
 }
 
 Rect2i DisplayServerIPhone::screen_get_usable_rect(int p_screen) const {
-	if (@available(iOS 11, *)) {
-		UIEdgeInsets insets = UIEdgeInsetsZero;
-		UIView *view = AppDelegate.viewController.godotView;
-
-		if ([view respondsToSelector:@selector(safeAreaInsets)]) {
-			insets = [view safeAreaInsets];
-		}
-
-		float scale = screen_get_scale(p_screen);
-		Size2i insets_position = Size2i(insets.left, insets.top) * scale;
-		Size2i insets_size = Size2i(insets.left + insets.right, insets.top + insets.bottom) * scale;
-
-		return Rect2i(screen_get_position(p_screen) + insets_position, screen_get_size(p_screen) - insets_size);
-	} else {
-		return Rect2i(screen_get_position(p_screen), screen_get_size(p_screen));
-	}
+	return Rect2i(screen_get_position(p_screen), screen_get_size(p_screen));
 }
 
 int DisplayServerIPhone::screen_get_dpi(int p_screen) const {

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -580,6 +580,7 @@ void DisplayServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("clipboard_get_primary"), &DisplayServer::clipboard_get_primary);
 
 	ClassDB::bind_method(D_METHOD("get_display_cutouts"), &DisplayServer::get_display_cutouts);
+	ClassDB::bind_method(D_METHOD("get_display_safe_area"), &DisplayServer::get_display_safe_area);
 
 	ClassDB::bind_method(D_METHOD("get_screen_count"), &DisplayServer::get_screen_count);
 	ClassDB::bind_method(D_METHOD("screen_get_position", "screen"), &DisplayServer::screen_get_position, DEFVAL(SCREEN_OF_MAIN_WINDOW));

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -229,6 +229,7 @@ public:
 	virtual String clipboard_get_primary() const;
 
 	virtual Array get_display_cutouts() const { return Array(); }
+	virtual Rect2i get_display_safe_area() const { return screen_get_usable_rect(); }
 
 	enum {
 		SCREEN_OF_MAIN_WINDOW = -1


### PR DESCRIPTION
When creating #60551, I noticed that #40761 (for iPhone) and #43104 (for Android) had aimed to reimplement the 3.x [`OS.get_window_safe_area()`](https://docs.godotengine.org/en/stable/classes/class_os.html#class-os-method-get-window-safe-area) method. However, instead of recreating the method, they've incorrectly redefined `DisplayServer.screen_get_usable_rect(screen)`, which should return the usable rectangle for the specified screen. On Android and iPhone this should be the full screen not the safe area.

This PR creates the `DisplayServer.get_display_safe_area()`, which returns the rectangle that is not obscured by cutouts, notches, inserts used by cameras and sensors on some devices, or the full screen rectangle if there are no obstructions, and reverts the changes made to `DisplayServer.screen_get_usable_rect(screen)` on the Android and iPhone platforms.