### PR TITLE
Check for null when retrieving clip data item text on Android

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -663,14 +663,13 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 	}
 
 	public String getClipboard() {
-		String copiedText = "";
-
-		if (mClipboard.hasPrimaryClip()) {
-			ClipData.Item item = mClipboard.getPrimaryClip().getItemAt(0);
-			copiedText = item.getText().toString();
-		}
-
-		return copiedText;
+		ClipData clipData = mClipboard.getPrimaryClip();
+		if (clipData == null)
+			return "";
+		CharSequence text = clipData.getItemAt(0).getText();
+		if (text == null)
+			return "";
+		return text.toString();
 	}
 
 	public void setClipboard(String p_text) {


### PR DESCRIPTION
Android's clipboard's [`ClipData.Item`](https://developer.android.com/reference/android/content/ClipData.Item) can contain three types of data: text, intent or uri. Therefore, when retrieving a particular type of data (in our case text), it's important to check whether or not it is `null`.
This PR checks whether `CheckData.Item`'s `getText()` returns `null` before trying to convert it into a `String`.

Fixes #60562.
Can be cherry-picked onto 3.x.
