### PR TITLE
Update link to vector2_angle_to_point.png

### DIFF
--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -52,7 +52,7 @@
 			<argument index="0" name="to" type="Vector2" />
 			<description>
 				Returns the angle between the line connecting the two points and the X axis, in radians.
-				[url=https://raw.githubusercontent.com/godotengine/godot-docs/master/img/vector2_angle_to_point.png]Illustration of the returned angle.[/url]
+				[url=https://raw.githubusercontent.com/godotengine/godot-docs/stable/img/vector2_angle_to_point.png]Illustration of the returned angle.[/url]
 			</description>
 		</method>
 		<method name="aspect">


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

This changes the link to point to the image added in godotengine/godot-docs#5777 to be consistent with the actual behavior in 3.x