### PR TITLE
[3.x] Fixed potential cyclic resource inclusion message for cs files

### DIFF
--- a/core/io/resource_loader.cpp
+++ b/core/io/resource_loader.cpp
@@ -360,6 +360,8 @@ RES ResourceLoader::load(const String &p_path, const String &p_type_hint, bool p
 			}
 		}
 		ResourceCache::lock.read_unlock();
+	} else if (ResourceCache::has(local_path)) {
+		ResourceCache::forget(local_path);
 	}
 
 	bool xl_remapped = false;

--- a/core/resource.cpp
+++ b/core/resource.cpp
@@ -450,6 +450,16 @@ Resource *ResourceCache::get(const String &p_path) {
 
 	return *res;
 }
+void ResourceCache::forget(const String &p_path) {
+	lock.write_lock();
+	if (!resources.has(p_path)) {
+		lock.write_unlock();
+		ERR_FAIL_MSG("Cannot forget a cached resource " + p_path + " as it was not present in the cache!");
+		return;
+	}
+	resources.erase(p_path);
+	lock.write_unlock();
+}
 
 void ResourceCache::get_cached_resources(List<Ref<Resource>> *p_resources) {
 	lock.read_lock();

--- a/core/resource.h
+++ b/core/resource.h
@@ -159,6 +159,7 @@ public:
 	static void reload_externals();
 	static bool has(const String &p_path);
 	static Resource *get(const String &p_path);
+	static void forget(const String &p_path); // Removes a resource from cache
 	static void dump(const char *p_file = nullptr, bool p_short = false);
 	static void get_cached_resources(List<Ref<Resource>> *p_resources);
 	static int get_cached_resource_count();


### PR DESCRIPTION
Fixes #27257.

I do realize that it's been closed in favour of #57211, however I believe that 4.0 deserves its own fix, as it has a mechanism for preventing such error messages, for whatever reason it's just not applied to cs files. I intend to make another fix and pull request for 4.0. 

Essentially, every time the editor is refocused, all .cs scripts get checked for changes, and then if any are found, the specific script is loaded, and then *its contents are copied to the old script*. Since the old script remains loaded (and cached), an error is raised, informing of a potential cyclic resource inclusion. 

I've added the ability to purge a file from the cache, and call it before loading the modified script file (if necessary). Currently, I intend to include this function in the 4.0 fix for the sake of feature-parity, though I don't intend to use it.

I'd like to note that even though this is a rather minor bug, anyone using C# is pretty much guaranteed to encounter it, cluttering the output tab and confusing newcomers. 
