### PR TITLE
Fixed potential cyclic resource inclusion message for cs files

### DIFF
--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -3602,7 +3602,7 @@ RES ResourceFormatLoaderCSharpScript::load(const String &p_path, const String &p
 	ERR_FAIL_COND_V_MSG(err != OK, RES(), "Cannot load C# script file '" + p_path + "'.");
 #endif
 
-	script->set_path(p_original_path);
+	script->set_path(p_original_path, (p_cache_mode == CacheMode::CACHE_MODE_IGNORE));
 
 	script->reload();
 


### PR DESCRIPTION
Fixes #57211.

Related to #60574,  but specific to 4.0. Uses the CacheMode enum instead of removing resources from the cache. I carried over ResourceCache::forget from my 3.x fix, however this is merely for feature (if it could be called that) parity. The real fix is contained in csharp_script.cpp.