### PR TITLE
Add MeshStorage to GLES3

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -439,7 +439,7 @@ bool RasterizerStorageGLES3::free(RID p_rid) {
 
 		multimesh_allocate(p_rid, 0, RS::MULTIMESH_TRANSFORM_3D, RS::MULTIMESH_COLOR_NONE);
 
-		update_dirty_multimeshes();
+		_update_dirty_multimeshes();
 
 		multimesh_owner.free(p_rid);
 		memdelete(multimesh);
@@ -692,6 +692,8 @@ uint64_t RasterizerStorageGLES3::get_rendering_info(RS::RenderingInfo p_info) {
 void RasterizerStorageGLES3::update_dirty_resources() {
 	GLES3::MaterialStorage::get_singleton()->_update_global_variables();
 	GLES3::MaterialStorage::get_singleton()->_update_queued_materials();
+	//GLES3::MeshStorage::get_singleton()->_update_dirty_skeletons();
+	GLES3::MeshStorage::get_singleton()->_update_dirty_multimeshes();
 }
 
 RasterizerStorageGLES3::RasterizerStorageGLES3() {

--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -42,6 +42,7 @@
 #include "servers/rendering/shader_language.h"
 #include "storage/config.h"
 #include "storage/material_storage.h"
+#include "storage/mesh_storage.h"
 #include "storage/texture_storage.h"
 
 // class RasterizerCanvasGLES3;

--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -31,6 +31,7 @@
 #ifdef GLES3_ENABLED
 
 #include "mesh_storage.h"
+#include "material_storage.h"
 
 using namespace GLES3;
 
@@ -51,34 +52,247 @@ MeshStorage::~MeshStorage() {
 /* MESH API */
 
 RID MeshStorage::mesh_allocate() {
-	return RID();
+	return mesh_owner.allocate_rid();
 }
 
 void MeshStorage::mesh_initialize(RID p_rid) {
+	mesh_owner.initialize_rid(p_rid, Mesh());
 }
 
 void MeshStorage::mesh_free(RID p_rid) {
+	mesh_clear(p_rid);
+	mesh_set_shadow_mesh(p_rid, RID());
+	Mesh *mesh = mesh_owner.get_or_null(p_rid);
+	mesh->dependency.deleted_notify(p_rid);
+	if (mesh->instances.size()) {
+		ERR_PRINT("deleting mesh with active instances");
+	}
+	if (mesh->shadow_owners.size()) {
+		for (Set<Mesh *>::Element *E = mesh->shadow_owners.front(); E; E = E->next()) {
+			Mesh *shadow_owner = E->get();
+			shadow_owner->shadow_mesh = RID();
+			shadow_owner->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MESH);
+		}
+	}
+	mesh_owner.free(p_rid);
 }
 
 void MeshStorage::mesh_set_blend_shape_count(RID p_mesh, int p_blend_shape_count) {
+	ERR_FAIL_COND(p_blend_shape_count < 0);
+
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND(!mesh);
+
+	ERR_FAIL_COND(mesh->surface_count > 0); //surfaces already exist
+	WARN_PRINT_ONCE("blend shapes not supported by GLES3 renderer yet");
+	mesh->blend_shape_count = p_blend_shape_count;
 }
 
 bool MeshStorage::mesh_needs_instance(RID p_mesh, bool p_has_skeleton) {
-	return false;
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND_V(!mesh, false);
+
+	return mesh->blend_shape_count > 0 || (mesh->has_bone_weights && p_has_skeleton);
 }
 
 void MeshStorage::mesh_add_surface(RID p_mesh, const RS::SurfaceData &p_surface) {
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND(!mesh);
+
+	ERR_FAIL_COND(mesh->surface_count == RS::MAX_MESH_SURFACES);
+
+#ifdef DEBUG_ENABLED
+	//do a validation, to catch errors first
+	{
+		uint32_t stride = 0;
+		uint32_t attrib_stride = 0;
+		uint32_t skin_stride = 0;
+
+		// TODO: I think this should be <=, but it is copied from RendererRD, will have to verify later
+		for (int i = 0; i < RS::ARRAY_WEIGHTS; i++) {
+			if ((p_surface.format & (1 << i))) {
+				switch (i) {
+					case RS::ARRAY_VERTEX: {
+						if (p_surface.format & RS::ARRAY_FLAG_USE_2D_VERTICES) {
+							stride += sizeof(float) * 2;
+						} else {
+							stride += sizeof(float) * 3;
+						}
+
+					} break;
+					case RS::ARRAY_NORMAL: {
+						stride += sizeof(int32_t);
+
+					} break;
+					case RS::ARRAY_TANGENT: {
+						stride += sizeof(int32_t);
+
+					} break;
+					case RS::ARRAY_COLOR: {
+						attrib_stride += sizeof(uint32_t);
+					} break;
+					case RS::ARRAY_TEX_UV: {
+						attrib_stride += sizeof(float) * 2;
+
+					} break;
+					case RS::ARRAY_TEX_UV2: {
+						attrib_stride += sizeof(float) * 2;
+
+					} break;
+					case RS::ARRAY_CUSTOM0:
+					case RS::ARRAY_CUSTOM1:
+					case RS::ARRAY_CUSTOM2:
+					case RS::ARRAY_CUSTOM3: {
+						int idx = i - RS::ARRAY_CUSTOM0;
+						uint32_t fmt_shift[RS::ARRAY_CUSTOM_COUNT] = { RS::ARRAY_FORMAT_CUSTOM0_SHIFT, RS::ARRAY_FORMAT_CUSTOM1_SHIFT, RS::ARRAY_FORMAT_CUSTOM2_SHIFT, RS::ARRAY_FORMAT_CUSTOM3_SHIFT };
+						uint32_t fmt = (p_surface.format >> fmt_shift[idx]) & RS::ARRAY_FORMAT_CUSTOM_MASK;
+						uint32_t fmtsize[RS::ARRAY_CUSTOM_MAX] = { 4, 4, 4, 8, 4, 8, 12, 16 };
+						attrib_stride += fmtsize[fmt];
+
+					} break;
+					case RS::ARRAY_WEIGHTS:
+					case RS::ARRAY_BONES: {
+						//uses a separate array
+						bool use_8 = p_surface.format & RS::ARRAY_FLAG_USE_8_BONE_WEIGHTS;
+						skin_stride += sizeof(int16_t) * (use_8 ? 16 : 8);
+					} break;
+				}
+			}
+		}
+
+		int expected_size = stride * p_surface.vertex_count;
+		ERR_FAIL_COND_MSG(expected_size != p_surface.vertex_data.size(), "Size of vertex data provided (" + itos(p_surface.vertex_data.size()) + ") does not match expected (" + itos(expected_size) + ")");
+
+		int bs_expected_size = expected_size * mesh->blend_shape_count;
+
+		ERR_FAIL_COND_MSG(bs_expected_size != p_surface.blend_shape_data.size(), "Size of blend shape data provided (" + itos(p_surface.blend_shape_data.size()) + ") does not match expected (" + itos(bs_expected_size) + ")");
+
+		int expected_attrib_size = attrib_stride * p_surface.vertex_count;
+		ERR_FAIL_COND_MSG(expected_attrib_size != p_surface.attribute_data.size(), "Size of attribute data provided (" + itos(p_surface.attribute_data.size()) + ") does not match expected (" + itos(expected_attrib_size) + ")");
+
+		if ((p_surface.format & RS::ARRAY_FORMAT_WEIGHTS) && (p_surface.format & RS::ARRAY_FORMAT_BONES)) {
+			expected_size = skin_stride * p_surface.vertex_count;
+			ERR_FAIL_COND_MSG(expected_size != p_surface.skin_data.size(), "Size of skin data provided (" + itos(p_surface.skin_data.size()) + ") does not match expected (" + itos(expected_size) + ")");
+		}
+	}
+
+#endif
+
+	Mesh::Surface *s = memnew(Mesh::Surface);
+
+	s->format = p_surface.format;
+	s->primitive = p_surface.primitive;
+
+	glGenBuffers(1, &s->vertex_buffer);
+	glBindBuffer(GL_ARRAY_BUFFER, s->vertex_buffer);
+	glBufferData(GL_ARRAY_BUFFER, p_surface.vertex_data.size(), p_surface.vertex_data.ptr(), (s->format & RS::ARRAY_FLAG_USE_DYNAMIC_UPDATE) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW);
+	glBindBuffer(GL_ARRAY_BUFFER, 0); //unbind
+	s->vertex_buffer_size = p_surface.vertex_data.size();
+
+	if (p_surface.attribute_data.size()) {
+		glGenBuffers(1, &s->attribute_buffer);
+		glBindBuffer(GL_ARRAY_BUFFER, s->attribute_buffer);
+		glBufferData(GL_ARRAY_BUFFER, p_surface.attribute_data.size(), p_surface.attribute_data.ptr(), (s->format & RS::ARRAY_FLAG_USE_DYNAMIC_UPDATE) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW);
+		glBindBuffer(GL_ARRAY_BUFFER, 0); //unbind
+	}
+	if (p_surface.skin_data.size()) {
+		glGenBuffers(1, &s->skin_buffer);
+		glBindBuffer(GL_ARRAY_BUFFER, s->skin_buffer);
+		glBufferData(GL_ARRAY_BUFFER, p_surface.skin_data.size(), p_surface.skin_data.ptr(), (s->format & RS::ARRAY_FLAG_USE_DYNAMIC_UPDATE) ? GL_DYNAMIC_DRAW : GL_STATIC_DRAW);
+		glBindBuffer(GL_ARRAY_BUFFER, 0); //unbind
+		s->skin_buffer_size = p_surface.skin_data.size();
+	}
+
+	s->vertex_count = p_surface.vertex_count;
+
+	if (p_surface.format & RS::ARRAY_FORMAT_BONES) {
+		mesh->has_bone_weights = true;
+	}
+
+	if (p_surface.index_count) {
+		bool is_index_16 = p_surface.vertex_count <= 65536;
+		glGenBuffers(1, &s->index_buffer);
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s->index_buffer);
+		glBufferData(GL_ELEMENT_ARRAY_BUFFER, p_surface.index_data.size(), p_surface.index_data.ptr(), GL_STATIC_DRAW);
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0); //unbind
+		s->index_count = p_surface.index_count;
+
+		if (p_surface.lods.size()) {
+			s->lods = memnew_arr(Mesh::Surface::LOD, p_surface.lods.size());
+			s->lod_count = p_surface.lods.size();
+
+			for (int i = 0; i < p_surface.lods.size(); i++) {
+				glGenBuffers(1, &s->lods[i].index_buffer);
+				glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s->lods[i].index_buffer);
+				glBufferData(GL_ELEMENT_ARRAY_BUFFER, p_surface.lods[i].index_data.size(), p_surface.lods[i].index_data.ptr(), GL_STATIC_DRAW);
+				glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0); //unbind
+				s->lods[i].edge_length = p_surface.lods[i].edge_length;
+				s->lods[i].index_count = p_surface.lods[i].index_data.size() / (is_index_16 ? 2 : 4);
+			}
+		}
+	}
+
+	s->aabb = p_surface.aabb;
+	s->bone_aabbs = p_surface.bone_aabbs; //only really useful for returning them.
+
+	if (mesh->blend_shape_count > 0) {
+		//s->blend_shape_buffer = RD::get_singleton()->storage_buffer_create(p_surface.blend_shape_data.size(), p_surface.blend_shape_data);
+	}
+
+	if (mesh->surface_count == 0) {
+		mesh->bone_aabbs = p_surface.bone_aabbs;
+		mesh->aabb = p_surface.aabb;
+	} else {
+		if (mesh->bone_aabbs.size() < p_surface.bone_aabbs.size()) {
+			// ArrayMesh::_surface_set_data only allocates bone_aabbs up to max_bone
+			// Each surface may affect different numbers of bones.
+			mesh->bone_aabbs.resize(p_surface.bone_aabbs.size());
+		}
+		for (int i = 0; i < p_surface.bone_aabbs.size(); i++) {
+			mesh->bone_aabbs.write[i].merge_with(p_surface.bone_aabbs[i]);
+		}
+		mesh->aabb.merge_with(p_surface.aabb);
+	}
+
+	s->material = p_surface.material;
+
+	mesh->surfaces = (Mesh::Surface **)memrealloc(mesh->surfaces, sizeof(Mesh::Surface *) * (mesh->surface_count + 1));
+	mesh->surfaces[mesh->surface_count] = s;
+	mesh->surface_count++;
+
+	for (MeshInstance *mi : mesh->instances) {
+		_mesh_instance_add_surface(mi, mesh, mesh->surface_count - 1);
+	}
+
+	mesh->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MESH);
+
+	for (Set<Mesh *>::Element *E = mesh->shadow_owners.front(); E; E = E->next()) {
+		Mesh *shadow_owner = E->get();
+		shadow_owner->shadow_mesh = RID();
+		shadow_owner->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MESH);
+	}
+
+	mesh->material_cache.clear();
 }
 
 int MeshStorage::mesh_get_blend_shape_count(RID p_mesh) const {
-	return 0;
+	const Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND_V(!mesh, -1);
+	return mesh->blend_shape_count;
 }
 
 void MeshStorage::mesh_set_blend_shape_mode(RID p_mesh, RS::BlendShapeMode p_mode) {
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND(!mesh);
+	ERR_FAIL_INDEX((int)p_mode, 2);
+
+	mesh->blend_shape_mode = p_mode;
 }
 
 RS::BlendShapeMode MeshStorage::mesh_get_blend_shape_mode(RID p_mesh) const {
-	return RS::BLEND_SHAPE_MODE_NORMALIZED;
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND_V(!mesh, RS::BLEND_SHAPE_MODE_NORMALIZED);
+	return mesh->blend_shape_mode;
 }
 
 void MeshStorage::mesh_surface_update_vertex_region(RID p_mesh, int p_surface, int p_offset, const Vector<uint8_t> &p_data) {
@@ -91,10 +305,21 @@ void MeshStorage::mesh_surface_update_skin_region(RID p_mesh, int p_surface, int
 }
 
 void MeshStorage::mesh_surface_set_material(RID p_mesh, int p_surface, RID p_material) {
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND(!mesh);
+	ERR_FAIL_UNSIGNED_INDEX((uint32_t)p_surface, mesh->surface_count);
+	mesh->surfaces[p_surface]->material = p_material;
+
+	mesh->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MATERIAL);
+	mesh->material_cache.clear();
 }
 
 RID MeshStorage::mesh_surface_get_material(RID p_mesh, int p_surface) const {
-	return RID();
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND_V(!mesh, RID());
+	ERR_FAIL_UNSIGNED_INDEX_V((uint32_t)p_surface, mesh->surface_count, RID());
+
+	return mesh->surfaces[p_surface]->material;
 }
 
 RS::SurfaceData MeshStorage::mesh_get_surface(RID p_mesh, int p_surface) const {
@@ -102,117 +327,1044 @@ RS::SurfaceData MeshStorage::mesh_get_surface(RID p_mesh, int p_surface) const {
 }
 
 int MeshStorage::mesh_get_surface_count(RID p_mesh) const {
-	return 1;
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND_V(!mesh, 0);
+	return mesh->surface_count;
 }
 
 void MeshStorage::mesh_set_custom_aabb(RID p_mesh, const AABB &p_aabb) {
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND(!mesh);
+	mesh->custom_aabb = p_aabb;
 }
 
 AABB MeshStorage::mesh_get_custom_aabb(RID p_mesh) const {
-	return AABB();
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND_V(!mesh, AABB());
+	return mesh->custom_aabb;
 }
 
 AABB MeshStorage::mesh_get_aabb(RID p_mesh, RID p_skeleton) {
-	return AABB();
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND_V(!mesh, AABB());
+
+	if (mesh->custom_aabb != AABB()) {
+		return mesh->custom_aabb;
+	}
+
+	Skeleton *skeleton = skeleton_owner.get_or_null(p_skeleton);
+
+	if (!skeleton || skeleton->size == 0) {
+		return mesh->aabb;
+	}
+
+	// Calculate AABB based on Skeleton
+
+	AABB aabb;
+
+	for (uint32_t i = 0; i < mesh->surface_count; i++) {
+		AABB laabb;
+		if ((mesh->surfaces[i]->format & RS::ARRAY_FORMAT_BONES) && mesh->surfaces[i]->bone_aabbs.size()) {
+			int bs = mesh->surfaces[i]->bone_aabbs.size();
+			const AABB *skbones = mesh->surfaces[i]->bone_aabbs.ptr();
+
+			int sbs = skeleton->size;
+			ERR_CONTINUE(bs > sbs);
+			const float *baseptr = skeleton->data.ptr();
+
+			bool first = true;
+
+			if (skeleton->use_2d) {
+				for (int j = 0; j < bs; j++) {
+					if (skbones[0].size == Vector3()) {
+						continue; //bone is unused
+					}
+
+					const float *dataptr = baseptr + j * 8;
+
+					Transform3D mtx;
+
+					mtx.basis.elements[0].x = dataptr[0];
+					mtx.basis.elements[1].x = dataptr[1];
+					mtx.origin.x = dataptr[3];
+
+					mtx.basis.elements[0].y = dataptr[4];
+					mtx.basis.elements[1].y = dataptr[5];
+					mtx.origin.y = dataptr[7];
+
+					AABB baabb = mtx.xform(skbones[j]);
+
+					if (first) {
+						laabb = baabb;
+						first = false;
+					} else {
+						laabb.merge_with(baabb);
+					}
+				}
+			} else {
+				for (int j = 0; j < bs; j++) {
+					if (skbones[0].size == Vector3()) {
+						continue; //bone is unused
+					}
+
+					const float *dataptr = baseptr + j * 12;
+
+					Transform3D mtx;
+
+					mtx.basis.elements[0][0] = dataptr[0];
+					mtx.basis.elements[0][1] = dataptr[1];
+					mtx.basis.elements[0][2] = dataptr[2];
+					mtx.origin.x = dataptr[3];
+					mtx.basis.elements[1][0] = dataptr[4];
+					mtx.basis.elements[1][1] = dataptr[5];
+					mtx.basis.elements[1][2] = dataptr[6];
+					mtx.origin.y = dataptr[7];
+					mtx.basis.elements[2][0] = dataptr[8];
+					mtx.basis.elements[2][1] = dataptr[9];
+					mtx.basis.elements[2][2] = dataptr[10];
+					mtx.origin.z = dataptr[11];
+
+					AABB baabb = mtx.xform(skbones[j]);
+					if (first) {
+						laabb = baabb;
+						first = false;
+					} else {
+						laabb.merge_with(baabb);
+					}
+				}
+			}
+
+			if (laabb.size == Vector3()) {
+				laabb = mesh->surfaces[i]->aabb;
+			}
+		} else {
+			laabb = mesh->surfaces[i]->aabb;
+		}
+
+		if (i == 0) {
+			aabb = laabb;
+		} else {
+			aabb.merge_with(laabb);
+		}
+	}
+
+	return aabb;
 }
 
 void MeshStorage::mesh_set_shadow_mesh(RID p_mesh, RID p_shadow_mesh) {
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND(!mesh);
+
+	Mesh *shadow_mesh = mesh_owner.get_or_null(mesh->shadow_mesh);
+	if (shadow_mesh) {
+		shadow_mesh->shadow_owners.erase(mesh);
+	}
+	mesh->shadow_mesh = p_shadow_mesh;
+
+	shadow_mesh = mesh_owner.get_or_null(mesh->shadow_mesh);
+
+	if (shadow_mesh) {
+		shadow_mesh->shadow_owners.insert(mesh);
+	}
+
+	mesh->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MESH);
 }
 
 void MeshStorage::mesh_clear(RID p_mesh) {
+	Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+	ERR_FAIL_COND(!mesh);
+	for (uint32_t i = 0; i < mesh->surface_count; i++) {
+		Mesh::Surface &s = *mesh->surfaces[i];
+
+		if (s.vertex_buffer != 0) {
+			glDeleteBuffers(1, &s.vertex_buffer);
+		}
+
+		if (s.version_count != 0) {
+			for (uint32_t j = 0; j < s.version_count; j++) {
+				glDeleteVertexArrays(1, &s.versions[j].vertex_array);
+			}
+		}
+
+		if (s.attribute_buffer != 0) {
+			glDeleteBuffers(1, &s.attribute_buffer);
+		}
+
+		if (s.skin_buffer != 0) {
+			glDeleteBuffers(1, &s.skin_buffer);
+		}
+
+		if (s.index_buffer != 0) {
+			glDeleteBuffers(1, &s.index_buffer);
+			glDeleteVertexArrays(1, &s.index_array);
+		}
+		memdelete(mesh->surfaces[i]);
+	}
+	if (mesh->surfaces) {
+		memfree(mesh->surfaces);
+	}
+
+	mesh->surfaces = nullptr;
+	mesh->surface_count = 0;
+	mesh->material_cache.clear();
+	//clear instance data
+	for (MeshInstance *mi : mesh->instances) {
+		_mesh_instance_clear(mi);
+	}
+	mesh->has_bone_weights = false;
+	mesh->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MESH);
+
+	for (Set<Mesh *>::Element *E = mesh->shadow_owners.front(); E; E = E->next()) {
+		Mesh *shadow_owner = E->get();
+		shadow_owner->shadow_mesh = RID();
+		shadow_owner->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MESH);
+	}
+}
+
+void MeshStorage::_mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint32_t p_input_mask, MeshInstance::Surface *mis) {
+	Mesh::Surface::Attrib attribs[RS::ARRAY_MAX];
+
+	int attributes_stride = 0;
+	int vertex_stride = 0;
+	int skin_stride = 0;
+
+	for (int i = 0; i < RS::ARRAY_INDEX; i++) {
+		if (!(s->format & (1 << i))) {
+			attribs[i].enabled = false;
+			attribs[i].integer = false;
+			continue;
+		}
+
+		attribs[i].enabled = true;
+		attribs[i].integer = false;
+
+		switch (i) {
+			case RS::ARRAY_VERTEX: {
+				attribs[i].offset = vertex_stride;
+				if (s->format & RS::ARRAY_FLAG_USE_2D_VERTICES) {
+					attribs[i].size = 2;
+				} else {
+					attribs[i].size = 3;
+				}
+				attribs[i].type = GL_FLOAT;
+				vertex_stride += attribs[i].size * sizeof(float);
+				attribs[i].normalized = GL_FALSE;
+			} break;
+			case RS::ARRAY_NORMAL: {
+				attribs[i].offset = vertex_stride;
+				// Will need to change to accommodate octahedral compression
+				attribs[i].size = 1;
+				attribs[i].type = GL_UNSIGNED_INT_2_10_10_10_REV;
+				vertex_stride += sizeof(float);
+				attribs[i].normalized = GL_TRUE;
+			} break;
+			case RS::ARRAY_TANGENT: {
+				attribs[i].offset = vertex_stride;
+				attribs[i].size = 1;
+				attribs[i].type = GL_UNSIGNED_INT_2_10_10_10_REV;
+				vertex_stride += sizeof(float);
+				attribs[i].normalized = GL_TRUE;
+			} break;
+			case RS::ARRAY_COLOR: {
+				attribs[i].offset = attributes_stride;
+				attribs[i].size = 4;
+				attribs[i].type = GL_UNSIGNED_BYTE;
+				attributes_stride += 4;
+				attribs[i].normalized = GL_TRUE;
+			} break;
+			case RS::ARRAY_TEX_UV: {
+				attribs[i].offset = attributes_stride;
+				attribs[i].size = 2;
+				attribs[i].type = GL_FLOAT;
+				attributes_stride += 2 * sizeof(float);
+				attribs[i].normalized = GL_FALSE;
+			} break;
+			case RS::ARRAY_TEX_UV2: {
+				attribs[i].offset = attributes_stride;
+				attribs[i].size = 2;
+				attribs[i].type = GL_FLOAT;
+				attributes_stride += 2 * sizeof(float);
+				attribs[i].normalized = GL_FALSE;
+			} break;
+			case RS::ARRAY_CUSTOM0:
+			case RS::ARRAY_CUSTOM1:
+			case RS::ARRAY_CUSTOM2:
+			case RS::ARRAY_CUSTOM3: {
+				attribs[i].offset = attributes_stride;
+
+				int idx = i - RS::ARRAY_CUSTOM0;
+				uint32_t fmt_shift[RS::ARRAY_CUSTOM_COUNT] = { RS::ARRAY_FORMAT_CUSTOM0_SHIFT, RS::ARRAY_FORMAT_CUSTOM1_SHIFT, RS::ARRAY_FORMAT_CUSTOM2_SHIFT, RS::ARRAY_FORMAT_CUSTOM3_SHIFT };
+				uint32_t fmt = (s->format >> fmt_shift[idx]) & RS::ARRAY_FORMAT_CUSTOM_MASK;
+				uint32_t fmtsize[RS::ARRAY_CUSTOM_MAX] = { 4, 4, 4, 8, 4, 8, 12, 16 };
+				GLenum gl_type[RS::ARRAY_CUSTOM_MAX] = { GL_UNSIGNED_BYTE, GL_BYTE, GL_HALF_FLOAT, GL_HALF_FLOAT, GL_FLOAT, GL_FLOAT, GL_FLOAT, GL_FLOAT };
+				GLboolean norm[RS::ARRAY_CUSTOM_MAX] = { GL_TRUE, GL_TRUE, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE };
+				attribs[i].type = gl_type[fmt];
+				attributes_stride += fmtsize[fmt];
+				attribs[i].size = fmtsize[fmt] / sizeof(float);
+				attribs[i].normalized = norm[fmt];
+			} break;
+			case RS::ARRAY_BONES: {
+				attribs[i].offset = skin_stride;
+				attribs[i].size = 4;
+				attribs[i].type = GL_UNSIGNED_SHORT;
+				attributes_stride += 4 * sizeof(uint16_t);
+				attribs[i].normalized = GL_FALSE;
+				attribs[i].integer = true;
+			} break;
+			case RS::ARRAY_WEIGHTS: {
+				attribs[i].offset = skin_stride;
+				attribs[i].size = 4;
+				attribs[i].type = GL_UNSIGNED_SHORT;
+				attributes_stride += 4 * sizeof(uint16_t);
+				attribs[i].normalized = GL_TRUE;
+			} break;
+		}
+	}
+
+	glGenVertexArrays(1, &v.vertex_array);
+	glBindVertexArray(v.vertex_array);
+
+	for (int i = 0; i < RS::ARRAY_INDEX; i++) {
+		if (!attribs[i].enabled) {
+			continue;
+		}
+		if (i <= RS::ARRAY_TANGENT) {
+			if (mis) {
+				glBindBuffer(GL_ARRAY_BUFFER, mis->vertex_buffer);
+			} else {
+				glBindBuffer(GL_ARRAY_BUFFER, s->vertex_buffer);
+			}
+		} else if (i <= RS::ARRAY_CUSTOM3) {
+			glBindBuffer(GL_ARRAY_BUFFER, s->attribute_buffer);
+		} else {
+			glBindBuffer(GL_ARRAY_BUFFER, s->skin_buffer);
+		}
+
+		if (attribs[i].integer) {
+			glVertexAttribIPointer(i, attribs[i].size, attribs[i].type, attribs[i].stride, CAST_INT_TO_UCHAR_PTR(attribs[i].offset));
+		} else {
+			glVertexAttribPointer(i, attribs[i].size, attribs[i].type, attribs[i].normalized, attribs[i].stride, CAST_INT_TO_UCHAR_PTR(attribs[i].offset));
+		}
+		glEnableVertexAttribArray(attribs[i].index);
+	}
+
+	// Do not bind index here as we want to switch between index buffers for LOD
+
+	glBindVertexArray(0);
+	glBindBuffer(GL_ARRAY_BUFFER, 0);
+
+	v.input_mask = p_input_mask;
 }
 
 /* MESH INSTANCE API */
 
 RID MeshStorage::mesh_instance_create(RID p_base) {
-	return RID();
+	Mesh *mesh = mesh_owner.get_or_null(p_base);
+	ERR_FAIL_COND_V(!mesh, RID());
+
+	RID rid = mesh_instance_owner.make_rid();
+	MeshInstance *mi = mesh_instance_owner.get_or_null(rid);
+
+	mi->mesh = mesh;
+
+	for (uint32_t i = 0; i < mesh->surface_count; i++) {
+		_mesh_instance_add_surface(mi, mesh, i);
+	}
+
+	mi->I = mesh->instances.push_back(mi);
+
+	mi->dirty = true;
+
+	return rid;
 }
 
 void MeshStorage::mesh_instance_free(RID p_rid) {
+	MeshInstance *mi = mesh_instance_owner.get_or_null(p_rid);
+	_mesh_instance_clear(mi);
+	mi->mesh->instances.erase(mi->I);
+	mi->I = nullptr;
+
+	mesh_instance_owner.free(p_rid);
 }
 
 void MeshStorage::mesh_instance_set_skeleton(RID p_mesh_instance, RID p_skeleton) {
+	MeshInstance *mi = mesh_instance_owner.get_or_null(p_mesh_instance);
+	if (mi->skeleton == p_skeleton) {
+		return;
+	}
+	mi->skeleton = p_skeleton;
+	mi->skeleton_version = 0;
+	mi->dirty = true;
 }
 
 void MeshStorage::mesh_instance_set_blend_shape_weight(RID p_mesh_instance, int p_shape, float p_weight) {
+	MeshInstance *mi = mesh_instance_owner.get_or_null(p_mesh_instance);
+	ERR_FAIL_COND(!mi);
+	ERR_FAIL_INDEX(p_shape, (int)mi->blend_weights.size());
+	mi->blend_weights[p_shape] = p_weight;
+	mi->weights_dirty = true;
+}
+
+void MeshStorage::_mesh_instance_clear(MeshInstance *mi) {
+	for (uint32_t i = 0; i < mi->surfaces.size(); i++) {
+		if (mi->surfaces[i].version_count != 0) {
+			for (uint32_t j = 0; j < mi->surfaces[i].version_count; j++) {
+				glDeleteVertexArrays(1, &mi->surfaces[i].versions[j].vertex_array);
+			}
+			memfree(mi->surfaces[i].versions);
+		}
+		if (mi->surfaces[i].vertex_buffer != 0) {
+			glDeleteBuffers(1, &mi->surfaces[i].vertex_buffer);
+		}
+	}
+	mi->surfaces.clear();
+
+	if (mi->blend_weights_buffer != 0) {
+		glDeleteBuffers(1, &mi->blend_weights_buffer);
+	}
+	mi->blend_weights.clear();
+	mi->weights_dirty = false;
+	mi->skeleton_version = 0;
+}
+
+void MeshStorage::_mesh_instance_add_surface(MeshInstance *mi, Mesh *mesh, uint32_t p_surface) {
+	if (mesh->blend_shape_count > 0 && mi->blend_weights_buffer == 0) {
+		mi->blend_weights.resize(mesh->blend_shape_count);
+		for (uint32_t i = 0; i < mi->blend_weights.size(); i++) {
+			mi->blend_weights[i] = 0;
+		}
+		// Todo allocate buffer for blend_weights and copy data to it
+		//mi->blend_weights_buffer = RD::get_singleton()->storage_buffer_create(sizeof(float) * mi->blend_weights.size(), mi->blend_weights.to_byte_array());
+
+		mi->weights_dirty = true;
+	}
+
+	MeshInstance::Surface s;
+	if (mesh->blend_shape_count > 0 || (mesh->surfaces[p_surface]->format & RS::ARRAY_FORMAT_BONES)) {
+		//surface warrants transform
+		//s.vertex_buffer = RD::get_singleton()->vertex_buffer_create(mesh->surfaces[p_surface]->vertex_buffer_size, Vector<uint8_t>(), true);
+	}
+
+	mi->surfaces.push_back(s);
+	mi->dirty = true;
 }
 
 void MeshStorage::mesh_instance_check_for_update(RID p_mesh_instance) {
+	MeshInstance *mi = mesh_instance_owner.get_or_null(p_mesh_instance);
+
+	bool needs_update = mi->dirty;
+
+	if (mi->weights_dirty && !mi->weight_update_list.in_list()) {
+		dirty_mesh_instance_weights.add(&mi->weight_update_list);
+		needs_update = true;
+	}
+
+	if (mi->array_update_list.in_list()) {
+		return;
+	}
+
+	if (!needs_update && mi->skeleton.is_valid()) {
+		Skeleton *sk = skeleton_owner.get_or_null(mi->skeleton);
+		if (sk && sk->version != mi->skeleton_version) {
+			needs_update = true;
+		}
+	}
+
+	if (needs_update) {
+		dirty_mesh_instance_arrays.add(&mi->array_update_list);
+	}
 }
 
 void MeshStorage::update_mesh_instances() {
+	while (dirty_mesh_instance_weights.first()) {
+		MeshInstance *mi = dirty_mesh_instance_weights.first()->self();
+
+		if (mi->blend_weights_buffer != 0) {
+			//RD::get_singleton()->buffer_update(mi->blend_weights_buffer, 0, mi->blend_weights.size() * sizeof(float), mi->blend_weights.ptr());
+		}
+		dirty_mesh_instance_weights.remove(&mi->weight_update_list);
+		mi->weights_dirty = false;
+	}
+	if (dirty_mesh_instance_arrays.first() == nullptr) {
+		return; //nothing to do
+	}
+
+	// Process skeletons and blend shapes using transform feedback
+	// TODO: Implement when working on skeletons and blend shapes
 }
 
 /* MULTIMESH API */
 
 RID MeshStorage::multimesh_allocate() {
-	return RID();
+	return multimesh_owner.allocate_rid();
 }
 
 void MeshStorage::multimesh_initialize(RID p_rid) {
+	multimesh_owner.initialize_rid(p_rid, MultiMesh());
 }
 
 void MeshStorage::multimesh_free(RID p_rid) {
+	_update_dirty_multimeshes();
+	multimesh_allocate_data(p_rid, 0, RS::MULTIMESH_TRANSFORM_2D);
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_rid);
+	multimesh->dependency.deleted_notify(p_rid);
+	multimesh_owner.free(p_rid);
 }
 
 void MeshStorage::multimesh_allocate_data(RID p_multimesh, int p_instances, RS::MultimeshTransformFormat p_transform_format, bool p_use_colors, bool p_use_custom_data) {
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND(!multimesh);
+
+	if (multimesh->instances == p_instances && multimesh->xform_format == p_transform_format && multimesh->uses_colors == p_use_colors && multimesh->uses_custom_data == p_use_custom_data) {
+		return;
+	}
+
+	if (multimesh->buffer) {
+		glDeleteBuffers(1, &multimesh->buffer);
+		multimesh->buffer = 0;
+	}
+
+	if (multimesh->data_cache_dirty_regions) {
+		memdelete_arr(multimesh->data_cache_dirty_regions);
+		multimesh->data_cache_dirty_regions = nullptr;
+		multimesh->data_cache_used_dirty_regions = 0;
+	}
+
+	multimesh->instances = p_instances;
+	multimesh->xform_format = p_transform_format;
+	multimesh->uses_colors = p_use_colors;
+	multimesh->color_offset_cache = p_transform_format == RS::MULTIMESH_TRANSFORM_2D ? 8 : 12;
+	multimesh->uses_custom_data = p_use_custom_data;
+	multimesh->custom_data_offset_cache = multimesh->color_offset_cache + (p_use_colors ? 4 : 0);
+	multimesh->stride_cache = multimesh->custom_data_offset_cache + (p_use_custom_data ? 4 : 0);
+	multimesh->buffer_set = false;
+
+	//print_line("allocate, elements: " + itos(p_instances) + " 2D: " + itos(p_transform_format == RS::MULTIMESH_TRANSFORM_2D) + " colors " + itos(multimesh->uses_colors) + " data " + itos(multimesh->uses_custom_data) + " stride " + itos(multimesh->stride_cache) + " total size " + itos(multimesh->stride_cache * multimesh->instances));
+	multimesh->data_cache = Vector<float>();
+	multimesh->aabb = AABB();
+	multimesh->aabb_dirty = false;
+	multimesh->visible_instances = MIN(multimesh->visible_instances, multimesh->instances);
+
+	if (multimesh->instances) {
+		glGenBuffers(1, &multimesh->buffer);
+		glBindBuffer(GL_ARRAY_BUFFER, multimesh->buffer);
+		glBufferData(GL_ARRAY_BUFFER, multimesh->instances * multimesh->stride_cache * sizeof(float), nullptr, GL_STATIC_DRAW);
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
+	}
+
+	multimesh->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MULTIMESH);
 }
 
 int MeshStorage::multimesh_get_instance_count(RID p_multimesh) const {
-	return 0;
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND_V(!multimesh, 0);
+	return multimesh->instances;
 }
 
 void MeshStorage::multimesh_set_mesh(RID p_multimesh, RID p_mesh) {
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND(!multimesh);
+	if (multimesh->mesh == p_mesh) {
+		return;
+	}
+	multimesh->mesh = p_mesh;
+
+	if (multimesh->instances == 0) {
+		return;
+	}
+
+	if (multimesh->data_cache.size()) {
+		//we have a data cache, just mark it dirty
+		_multimesh_mark_all_dirty(multimesh, false, true);
+	} else if (multimesh->instances) {
+		//need to re-create AABB unfortunately, calling this has a penalty
+		if (multimesh->buffer_set) {
+			// TODO add a function to RasterizerStorage to get data from a buffer
+			//Vector<uint8_t> buffer = RD::get_singleton()->buffer_get_data(multimesh->buffer);
+			//const uint8_t *r = buffer.ptr();
+			//const float *data = (const float *)r;
+			//_multimesh_re_create_aabb(multimesh, data, multimesh->instances);
+		}
+	}
+
+	multimesh->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MESH);
+}
+
+#define MULTIMESH_DIRTY_REGION_SIZE 512
+
+void MeshStorage::_multimesh_make_local(MultiMesh *multimesh) const {
+	if (multimesh->data_cache.size() > 0) {
+		return; //already local
+	}
+	ERR_FAIL_COND(multimesh->data_cache.size() > 0);
+	// this means that the user wants to load/save individual elements,
+	// for this, the data must reside on CPU, so just copy it there.
+	multimesh->data_cache.resize(multimesh->instances * multimesh->stride_cache);
+	{
+		float *w = multimesh->data_cache.ptrw();
+
+		if (multimesh->buffer_set) {
+			//Vector<uint8_t> buffer = RD::get_singleton()->buffer_get_data(multimesh->buffer);
+			{
+				//	const uint8_t *r = buffer.ptr();
+				//	memcpy(w, r, buffer.size());
+			}
+		} else {
+			memset(w, 0, (size_t)multimesh->instances * multimesh->stride_cache * sizeof(float));
+		}
+	}
+	uint32_t data_cache_dirty_region_count = (multimesh->instances - 1) / MULTIMESH_DIRTY_REGION_SIZE + 1;
+	multimesh->data_cache_dirty_regions = memnew_arr(bool, data_cache_dirty_region_count);
+	for (uint32_t i = 0; i < data_cache_dirty_region_count; i++) {
+		multimesh->data_cache_dirty_regions[i] = false;
+	}
+	multimesh->data_cache_used_dirty_regions = 0;
+}
+
+void MeshStorage::_multimesh_mark_dirty(MultiMesh *multimesh, int p_index, bool p_aabb) {
+	uint32_t region_index = p_index / MULTIMESH_DIRTY_REGION_SIZE;
+#ifdef DEBUG_ENABLED
+	uint32_t data_cache_dirty_region_count = (multimesh->instances - 1) / MULTIMESH_DIRTY_REGION_SIZE + 1;
+	ERR_FAIL_UNSIGNED_INDEX(region_index, data_cache_dirty_region_count); //bug
+#endif
+	if (!multimesh->data_cache_dirty_regions[region_index]) {
+		multimesh->data_cache_dirty_regions[region_index] = true;
+		multimesh->data_cache_used_dirty_regions++;
+	}
+
+	if (p_aabb) {
+		multimesh->aabb_dirty = true;
+	}
+
+	if (!multimesh->dirty) {
+		multimesh->dirty_list = multimesh_dirty_list;
+		multimesh_dirty_list = multimesh;
+		multimesh->dirty = true;
+	}
+}
+
+void MeshStorage::_multimesh_mark_all_dirty(MultiMesh *multimesh, bool p_data, bool p_aabb) {
+	if (p_data) {
+		uint32_t data_cache_dirty_region_count = (multimesh->instances - 1) / MULTIMESH_DIRTY_REGION_SIZE + 1;
+
+		for (uint32_t i = 0; i < data_cache_dirty_region_count; i++) {
+			if (!multimesh->data_cache_dirty_regions[i]) {
+				multimesh->data_cache_dirty_regions[i] = true;
+				multimesh->data_cache_used_dirty_regions++;
+			}
+		}
+	}
+
+	if (p_aabb) {
+		multimesh->aabb_dirty = true;
+	}
+
+	if (!multimesh->dirty) {
+		multimesh->dirty_list = multimesh_dirty_list;
+		multimesh_dirty_list = multimesh;
+		multimesh->dirty = true;
+	}
+}
+
+void MeshStorage::_multimesh_re_create_aabb(MultiMesh *multimesh, const float *p_data, int p_instances) {
+	ERR_FAIL_COND(multimesh->mesh.is_null());
+	AABB aabb;
+	AABB mesh_aabb = mesh_get_aabb(multimesh->mesh);
+	for (int i = 0; i < p_instances; i++) {
+		const float *data = p_data + multimesh->stride_cache * i;
+		Transform3D t;
+
+		if (multimesh->xform_format == RS::MULTIMESH_TRANSFORM_3D) {
+			t.basis.elements[0][0] = data[0];
+			t.basis.elements[0][1] = data[1];
+			t.basis.elements[0][2] = data[2];
+			t.origin.x = data[3];
+			t.basis.elements[1][0] = data[4];
+			t.basis.elements[1][1] = data[5];
+			t.basis.elements[1][2] = data[6];
+			t.origin.y = data[7];
+			t.basis.elements[2][0] = data[8];
+			t.basis.elements[2][1] = data[9];
+			t.basis.elements[2][2] = data[10];
+			t.origin.z = data[11];
+
+		} else {
+			t.basis.elements[0].x = data[0];
+			t.basis.elements[1].x = data[1];
+			t.origin.x = data[3];
+
+			t.basis.elements[0].y = data[4];
+			t.basis.elements[1].y = data[5];
+			t.origin.y = data[7];
+		}
+
+		if (i == 0) {
+			aabb = t.xform(mesh_aabb);
+		} else {
+			aabb.merge_with(t.xform(mesh_aabb));
+		}
+	}
+
+	multimesh->aabb = aabb;
 }
 
 void MeshStorage::multimesh_instance_set_transform(RID p_multimesh, int p_index, const Transform3D &p_transform) {
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND(!multimesh);
+	ERR_FAIL_INDEX(p_index, multimesh->instances);
+	ERR_FAIL_COND(multimesh->xform_format != RS::MULTIMESH_TRANSFORM_3D);
+
+	_multimesh_make_local(multimesh);
+
+	{
+		float *w = multimesh->data_cache.ptrw();
+
+		float *dataptr = w + p_index * multimesh->stride_cache;
+
+		dataptr[0] = p_transform.basis.elements[0][0];
+		dataptr[1] = p_transform.basis.elements[0][1];
+		dataptr[2] = p_transform.basis.elements[0][2];
+		dataptr[3] = p_transform.origin.x;
+		dataptr[4] = p_transform.basis.elements[1][0];
+		dataptr[5] = p_transform.basis.elements[1][1];
+		dataptr[6] = p_transform.basis.elements[1][2];
+		dataptr[7] = p_transform.origin.y;
+		dataptr[8] = p_transform.basis.elements[2][0];
+		dataptr[9] = p_transform.basis.elements[2][1];
+		dataptr[10] = p_transform.basis.elements[2][2];
+		dataptr[11] = p_transform.origin.z;
+	}
+
+	_multimesh_mark_dirty(multimesh, p_index, true);
 }
 
 void MeshStorage::multimesh_instance_set_transform_2d(RID p_multimesh, int p_index, const Transform2D &p_transform) {
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND(!multimesh);
+	ERR_FAIL_INDEX(p_index, multimesh->instances);
+	ERR_FAIL_COND(multimesh->xform_format != RS::MULTIMESH_TRANSFORM_2D);
+
+	_multimesh_make_local(multimesh);
+
+	{
+		float *w = multimesh->data_cache.ptrw();
+
+		float *dataptr = w + p_index * multimesh->stride_cache;
+
+		dataptr[0] = p_transform.elements[0][0];
+		dataptr[1] = p_transform.elements[1][0];
+		dataptr[2] = 0;
+		dataptr[3] = p_transform.elements[2][0];
+		dataptr[4] = p_transform.elements[0][1];
+		dataptr[5] = p_transform.elements[1][1];
+		dataptr[6] = 0;
+		dataptr[7] = p_transform.elements[2][1];
+	}
+
+	_multimesh_mark_dirty(multimesh, p_index, true);
 }
 
 void MeshStorage::multimesh_instance_set_color(RID p_multimesh, int p_index, const Color &p_color) {
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND(!multimesh);
+	ERR_FAIL_INDEX(p_index, multimesh->instances);
+	ERR_FAIL_COND(!multimesh->uses_colors);
+
+	_multimesh_make_local(multimesh);
+
+	{
+		float *w = multimesh->data_cache.ptrw();
+
+		float *dataptr = w + p_index * multimesh->stride_cache + multimesh->color_offset_cache;
+
+		dataptr[0] = p_color.r;
+		dataptr[1] = p_color.g;
+		dataptr[2] = p_color.b;
+		dataptr[3] = p_color.a;
+	}
+
+	_multimesh_mark_dirty(multimesh, p_index, false);
 }
 
 void MeshStorage::multimesh_instance_set_custom_data(RID p_multimesh, int p_index, const Color &p_color) {
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND(!multimesh);
+	ERR_FAIL_INDEX(p_index, multimesh->instances);
+	ERR_FAIL_COND(!multimesh->uses_custom_data);
+
+	_multimesh_make_local(multimesh);
+
+	{
+		float *w = multimesh->data_cache.ptrw();
+
+		float *dataptr = w + p_index * multimesh->stride_cache + multimesh->custom_data_offset_cache;
+
+		dataptr[0] = p_color.r;
+		dataptr[1] = p_color.g;
+		dataptr[2] = p_color.b;
+		dataptr[3] = p_color.a;
+	}
+
+	_multimesh_mark_dirty(multimesh, p_index, false);
 }
 
 RID MeshStorage::multimesh_get_mesh(RID p_multimesh) const {
-	return RID();
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND_V(!multimesh, RID());
+
+	return multimesh->mesh;
 }
 
 AABB MeshStorage::multimesh_get_aabb(RID p_multimesh) const {
-	return AABB();
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND_V(!multimesh, AABB());
+	if (multimesh->aabb_dirty) {
+		const_cast<MeshStorage *>(this)->_update_dirty_multimeshes();
+	}
+	return multimesh->aabb;
 }
 
 Transform3D MeshStorage::multimesh_instance_get_transform(RID p_multimesh, int p_index) const {
-	return Transform3D();
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND_V(!multimesh, Transform3D());
+	ERR_FAIL_INDEX_V(p_index, multimesh->instances, Transform3D());
+	ERR_FAIL_COND_V(multimesh->xform_format != RS::MULTIMESH_TRANSFORM_3D, Transform3D());
+
+	_multimesh_make_local(multimesh);
+
+	Transform3D t;
+	{
+		const float *r = multimesh->data_cache.ptr();
+
+		const float *dataptr = r + p_index * multimesh->stride_cache;
+
+		t.basis.elements[0][0] = dataptr[0];
+		t.basis.elements[0][1] = dataptr[1];
+		t.basis.elements[0][2] = dataptr[2];
+		t.origin.x = dataptr[3];
+		t.basis.elements[1][0] = dataptr[4];
+		t.basis.elements[1][1] = dataptr[5];
+		t.basis.elements[1][2] = dataptr[6];
+		t.origin.y = dataptr[7];
+		t.basis.elements[2][0] = dataptr[8];
+		t.basis.elements[2][1] = dataptr[9];
+		t.basis.elements[2][2] = dataptr[10];
+		t.origin.z = dataptr[11];
+	}
+
+	return t;
 }
 
 Transform2D MeshStorage::multimesh_instance_get_transform_2d(RID p_multimesh, int p_index) const {
-	return Transform2D();
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND_V(!multimesh, Transform2D());
+	ERR_FAIL_INDEX_V(p_index, multimesh->instances, Transform2D());
+	ERR_FAIL_COND_V(multimesh->xform_format != RS::MULTIMESH_TRANSFORM_2D, Transform2D());
+
+	_multimesh_make_local(multimesh);
+
+	Transform2D t;
+	{
+		const float *r = multimesh->data_cache.ptr();
+
+		const float *dataptr = r + p_index * multimesh->stride_cache;
+
+		t.elements[0][0] = dataptr[0];
+		t.elements[1][0] = dataptr[1];
+		t.elements[2][0] = dataptr[3];
+		t.elements[0][1] = dataptr[4];
+		t.elements[1][1] = dataptr[5];
+		t.elements[2][1] = dataptr[7];
+	}
+
+	return t;
 }
 
 Color MeshStorage::multimesh_instance_get_color(RID p_multimesh, int p_index) const {
-	return Color();
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND_V(!multimesh, Color());
+	ERR_FAIL_INDEX_V(p_index, multimesh->instances, Color());
+	ERR_FAIL_COND_V(!multimesh->uses_colors, Color());
+
+	_multimesh_make_local(multimesh);
+
+	Color c;
+	{
+		const float *r = multimesh->data_cache.ptr();
+
+		const float *dataptr = r + p_index * multimesh->stride_cache + multimesh->color_offset_cache;
+
+		c.r = dataptr[0];
+		c.g = dataptr[1];
+		c.b = dataptr[2];
+		c.a = dataptr[3];
+	}
+
+	return c;
 }
 
 Color MeshStorage::multimesh_instance_get_custom_data(RID p_multimesh, int p_index) const {
-	return Color();
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND_V(!multimesh, Color());
+	ERR_FAIL_INDEX_V(p_index, multimesh->instances, Color());
+	ERR_FAIL_COND_V(!multimesh->uses_custom_data, Color());
+
+	_multimesh_make_local(multimesh);
+
+	Color c;
+	{
+		const float *r = multimesh->data_cache.ptr();
+
+		const float *dataptr = r + p_index * multimesh->stride_cache + multimesh->custom_data_offset_cache;
+
+		c.r = dataptr[0];
+		c.g = dataptr[1];
+		c.b = dataptr[2];
+		c.a = dataptr[3];
+	}
+
+	return c;
 }
 
 void MeshStorage::multimesh_set_buffer(RID p_multimesh, const Vector<float> &p_buffer) {
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND(!multimesh);
+	ERR_FAIL_COND(p_buffer.size() != (multimesh->instances * (int)multimesh->stride_cache));
+
+	{
+		const float *r = p_buffer.ptr();
+		glBindBuffer(GL_ARRAY_BUFFER, multimesh->buffer);
+		glBufferData(GL_ARRAY_BUFFER, p_buffer.size() * sizeof(float), r, GL_STATIC_DRAW);
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
+		multimesh->buffer_set = true;
+	}
+
+	if (multimesh->data_cache.size()) {
+		//if we have a data cache, just update it
+		multimesh->data_cache = p_buffer;
+		{
+			//clear dirty since nothing will be dirty anymore
+			uint32_t data_cache_dirty_region_count = (multimesh->instances - 1) / MULTIMESH_DIRTY_REGION_SIZE + 1;
+			for (uint32_t i = 0; i < data_cache_dirty_region_count; i++) {
+				multimesh->data_cache_dirty_regions[i] = false;
+			}
+			multimesh->data_cache_used_dirty_regions = 0;
+		}
+
+		_multimesh_mark_all_dirty(multimesh, false, true); //update AABB
+	} else if (multimesh->mesh.is_valid()) {
+		//if we have a mesh set, we need to re-generate the AABB from the new data
+		const float *data = p_buffer.ptr();
+
+		_multimesh_re_create_aabb(multimesh, data, multimesh->instances);
+		multimesh->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_AABB);
+	}
 }
 
 Vector<float> MeshStorage::multimesh_get_buffer(RID p_multimesh) const {
-	return Vector<float>();
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND_V(!multimesh, Vector<float>());
+	if (multimesh->buffer == 0) {
+		return Vector<float>();
+	} else if (multimesh->data_cache.size()) {
+		return multimesh->data_cache;
+	} else {
+		//get from memory
+
+		//Vector<uint8_t> buffer = RD::get_singleton()->buffer_get_data(multimesh->buffer);
+		Vector<float> ret;
+		ret.resize(multimesh->instances * multimesh->stride_cache);
+		//{
+		//	float *w = ret.ptrw();
+		//	const uint8_t *r = buffer.ptr();
+		//	memcpy(w, r, buffer.size());
+		//}
+
+		return ret;
+	}
 }
 
 void MeshStorage::multimesh_set_visible_instances(RID p_multimesh, int p_visible) {
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND(!multimesh);
+	ERR_FAIL_COND(p_visible < -1 || p_visible > multimesh->instances);
+	if (multimesh->visible_instances == p_visible) {
+		return;
+	}
+
+	if (multimesh->data_cache.size()) {
+		//there is a data cache..
+		_multimesh_mark_all_dirty(multimesh, false, true);
+	}
+
+	multimesh->visible_instances = p_visible;
+
+	multimesh->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_MULTIMESH_VISIBLE_INSTANCES);
 }
 
 int MeshStorage::multimesh_get_visible_instances(RID p_multimesh) const {
-	return 0;
+	MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);
+	ERR_FAIL_COND_V(!multimesh, 0);
+	return multimesh->visible_instances;
+}
+
+void MeshStorage::_update_dirty_multimeshes() {
+	while (multimesh_dirty_list) {
+		MultiMesh *multimesh = multimesh_dirty_list;
+
+		if (multimesh->data_cache.size()) { //may have been cleared, so only process if it exists
+			const float *data = multimesh->data_cache.ptr();
+
+			uint32_t visible_instances = multimesh->visible_instances >= 0 ? multimesh->visible_instances : multimesh->instances;
+
+			if (multimesh->data_cache_used_dirty_regions) {
+				uint32_t data_cache_dirty_region_count = (multimesh->instances - 1) / MULTIMESH_DIRTY_REGION_SIZE + 1;
+				uint32_t visible_region_count = visible_instances == 0 ? 0 : (visible_instances - 1) / MULTIMESH_DIRTY_REGION_SIZE + 1;
+
+				GLint region_size = multimesh->stride_cache * MULTIMESH_DIRTY_REGION_SIZE * sizeof(float);
+
+				if (multimesh->data_cache_used_dirty_regions > 32 || multimesh->data_cache_used_dirty_regions > visible_region_count / 2) {
+					// If there too many dirty regions, or represent the majority of regions, just copy all, else transfer cost piles up too much
+					glBindBuffer(GL_ARRAY_BUFFER, multimesh->buffer);
+					glBufferData(GL_ARRAY_BUFFER, MIN(visible_region_count * region_size, multimesh->instances * (uint32_t)multimesh->stride_cache * (uint32_t)sizeof(float)), data, GL_STATIC_DRAW);
+					glBindBuffer(GL_ARRAY_BUFFER, 0);
+				} else {
+					// Not that many regions? update them all
+					// TODO: profile the performance cost on low end
+					glBindBuffer(GL_ARRAY_BUFFER, multimesh->buffer);
+					for (uint32_t i = 0; i < visible_region_count; i++) {
+						if (multimesh->data_cache_dirty_regions[i]) {
+							GLint offset = i * region_size;
+							GLint size = multimesh->stride_cache * (uint32_t)multimesh->instances * (uint32_t)sizeof(float);
+							uint32_t region_start_index = multimesh->stride_cache * MULTIMESH_DIRTY_REGION_SIZE * i;
+							glBufferSubData(GL_ARRAY_BUFFER, offset, MIN(region_size, size - offset), &data[region_start_index]);
+						}
+					}
+					glBindBuffer(GL_ARRAY_BUFFER, 0);
+				}
+
+				for (uint32_t i = 0; i < data_cache_dirty_region_count; i++) {
+					multimesh->data_cache_dirty_regions[i] = false;
+				}
+
+				multimesh->data_cache_used_dirty_regions = 0;
+			}
+
+			if (multimesh->aabb_dirty) {
+				//aabb is dirty..
+				_multimesh_re_create_aabb(multimesh, data, visible_instances);
+				multimesh->aabb_dirty = false;
+				multimesh->dependency.changed_notify(RendererStorage::DEPENDENCY_CHANGED_AABB);
+			}
+		}
+
+		multimesh_dirty_list = multimesh->dirty_list;
+
+		multimesh->dirty_list = nullptr;
+		multimesh->dirty = false;
+	}
+
+	multimesh_dirty_list = nullptr;
 }
 
 /* SKELETON API */

--- a/drivers/gles3/storage/mesh_storage.h
+++ b/drivers/gles3/storage/mesh_storage.h
@@ -38,11 +38,201 @@
 #include "core/templates/self_list.h"
 #include "servers/rendering/storage/mesh_storage.h"
 
+#include "platform_config.h"
+#ifndef OPENGL_INCLUDE_H
+#include <GLES3/gl3.h>
+#else
+#include OPENGL_INCLUDE_H
+#endif
+
 namespace GLES3 {
+
+struct MeshInstance;
+
+struct Mesh {
+	struct Surface {
+		struct Attrib {
+			bool enabled;
+			bool integer;
+			GLuint index;
+			GLint size;
+			GLenum type;
+			GLboolean normalized;
+			GLsizei stride;
+			uint32_t offset;
+		};
+		RS::PrimitiveType primitive = RS::PRIMITIVE_POINTS;
+		uint32_t format = 0;
+
+		GLuint vertex_buffer = 0;
+		GLuint attribute_buffer = 0;
+		GLuint skin_buffer = 0;
+		uint32_t vertex_count = 0;
+		uint32_t vertex_buffer_size = 0;
+		uint32_t skin_buffer_size = 0;
+
+		// Cache vertex arrays so they can be created
+		struct Version {
+			uint32_t input_mask = 0;
+			GLuint vertex_array;
+
+			Attrib attribs[RS::ARRAY_MAX];
+		};
+
+		SpinLock version_lock; //needed to access versions
+		Version *versions = nullptr; //allocated on demand
+		uint32_t version_count = 0;
+
+		GLuint index_buffer = 0;
+		GLuint index_array = 0;
+		uint32_t index_count = 0;
+
+		struct LOD {
+			float edge_length = 0.0;
+			uint32_t index_count = 0;
+			GLuint index_buffer;
+		};
+
+		LOD *lods = nullptr;
+		uint32_t lod_count = 0;
+
+		AABB aabb;
+
+		Vector<AABB> bone_aabbs;
+
+		GLuint blend_shape_buffer = 0;
+
+		RID material;
+	};
+
+	uint32_t blend_shape_count = 0;
+	RS::BlendShapeMode blend_shape_mode = RS::BLEND_SHAPE_MODE_NORMALIZED;
+
+	Surface **surfaces = nullptr;
+	uint32_t surface_count = 0;
+
+	Vector<AABB> bone_aabbs;
+
+	bool has_bone_weights = false;
+
+	AABB aabb;
+	AABB custom_aabb;
+
+	Vector<RID> material_cache;
+
+	List<MeshInstance *> instances;
+
+	RID shadow_mesh;
+	Set<Mesh *> shadow_owners;
+
+	RendererStorage::Dependency dependency;
+};
+
+/* Mesh Instance */
+
+struct MeshInstance {
+	Mesh *mesh = nullptr;
+	RID skeleton;
+	struct Surface {
+		GLuint vertex_buffer = 0;
+
+		Mesh::Surface::Version *versions = nullptr; //allocated on demand
+		uint32_t version_count = 0;
+	};
+	LocalVector<Surface> surfaces;
+	LocalVector<float> blend_weights;
+
+	GLuint blend_weights_buffer = 0;
+	List<MeshInstance *>::Element *I = nullptr; //used to erase itself
+	uint64_t skeleton_version = 0;
+	bool dirty = false;
+	bool weights_dirty = false;
+	SelfList<MeshInstance> weight_update_list;
+	SelfList<MeshInstance> array_update_list;
+	MeshInstance() :
+			weight_update_list(this), array_update_list(this) {}
+};
+
+/* MultiMesh */
+
+struct MultiMesh {
+	RID mesh;
+	int instances = 0;
+	RS::MultimeshTransformFormat xform_format = RS::MULTIMESH_TRANSFORM_3D;
+	bool uses_colors = false;
+	bool uses_custom_data = false;
+	int visible_instances = -1;
+	AABB aabb;
+	bool aabb_dirty = false;
+	bool buffer_set = false;
+	uint32_t stride_cache = 0;
+	uint32_t color_offset_cache = 0;
+	uint32_t custom_data_offset_cache = 0;
+
+	Vector<float> data_cache; //used if individual setting is used
+	bool *data_cache_dirty_regions = nullptr;
+	uint32_t data_cache_used_dirty_regions = 0;
+
+	GLuint buffer;
+
+	bool dirty = false;
+	MultiMesh *dirty_list = nullptr;
+
+	RendererStorage::Dependency dependency;
+};
+
+struct Skeleton {
+	bool use_2d = false;
+	int size = 0;
+	Vector<float> data;
+	GLuint buffer = 0;
+
+	bool dirty = false;
+	Skeleton *dirty_list = nullptr;
+	Transform2D base_transform_2d;
+
+	uint64_t version = 1;
+
+	RendererStorage::Dependency dependency;
+};
 
 class MeshStorage : public RendererMeshStorage {
 private:
 	static MeshStorage *singleton;
+
+	/* Mesh */
+
+	mutable RID_Owner<Mesh, true> mesh_owner;
+
+	void _mesh_surface_generate_version_for_input_mask(Mesh::Surface::Version &v, Mesh::Surface *s, uint32_t p_input_mask, MeshInstance::Surface *mis = nullptr);
+
+	/* Mesh Instance API */
+
+	mutable RID_Owner<MeshInstance> mesh_instance_owner;
+
+	void _mesh_instance_clear(MeshInstance *mi);
+	void _mesh_instance_add_surface(MeshInstance *mi, Mesh *mesh, uint32_t p_surface);
+	SelfList<MeshInstance>::List dirty_mesh_instance_weights;
+	SelfList<MeshInstance>::List dirty_mesh_instance_arrays;
+
+	/* MultiMesh */
+
+	mutable RID_Owner<MultiMesh, true> multimesh_owner;
+
+	MultiMesh *multimesh_dirty_list = nullptr;
+
+	_FORCE_INLINE_ void _multimesh_make_local(MultiMesh *multimesh) const;
+	_FORCE_INLINE_ void _multimesh_mark_dirty(MultiMesh *multimesh, int p_index, bool p_aabb);
+	_FORCE_INLINE_ void _multimesh_mark_all_dirty(MultiMesh *multimesh, bool p_data, bool p_aabb);
+	_FORCE_INLINE_ void _multimesh_re_create_aabb(MultiMesh *multimesh, const float *p_data, int p_instances);
+
+	/* Skeleton */
+
+	mutable RID_Owner<Skeleton, true> skeleton_owner;
+
+	Skeleton *skeleton_dirty_list = nullptr;
+
+	_FORCE_INLINE_ void _skeleton_make_dirty(Skeleton *skeleton);
 
 public:
 	static MeshStorage *get_singleton();
@@ -51,6 +241,9 @@ public:
 	virtual ~MeshStorage();
 
 	/* MESH API */
+
+	Mesh *get_mesh(RID p_rid) { return mesh_owner.get_or_null(p_rid); };
+	bool owns_mesh(RID p_rid) { return mesh_owner.owns(p_rid); };
 
 	virtual RID mesh_allocate() override;
 	virtual void mesh_initialize(RID p_rid) override;
@@ -83,6 +276,116 @@ public:
 	virtual void mesh_set_shadow_mesh(RID p_mesh, RID p_shadow_mesh) override;
 	virtual void mesh_clear(RID p_mesh) override;
 
+	_FORCE_INLINE_ const RID *mesh_get_surface_count_and_materials(RID p_mesh, uint32_t &r_surface_count) {
+		Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+		ERR_FAIL_COND_V(!mesh, nullptr);
+		r_surface_count = mesh->surface_count;
+		if (r_surface_count == 0) {
+			return nullptr;
+		}
+		if (mesh->material_cache.is_empty()) {
+			mesh->material_cache.resize(mesh->surface_count);
+			for (uint32_t i = 0; i < r_surface_count; i++) {
+				mesh->material_cache.write[i] = mesh->surfaces[i]->material;
+			}
+		}
+
+		return mesh->material_cache.ptr();
+	}
+
+	_FORCE_INLINE_ void *mesh_get_surface(RID p_mesh, uint32_t p_surface_index) {
+		Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+		ERR_FAIL_COND_V(!mesh, nullptr);
+		ERR_FAIL_UNSIGNED_INDEX_V(p_surface_index, mesh->surface_count, nullptr);
+
+		return mesh->surfaces[p_surface_index];
+	}
+
+	_FORCE_INLINE_ RID mesh_get_shadow_mesh(RID p_mesh) {
+		Mesh *mesh = mesh_owner.get_or_null(p_mesh);
+		ERR_FAIL_COND_V(!mesh, RID());
+
+		return mesh->shadow_mesh;
+	}
+
+	_FORCE_INLINE_ RS::PrimitiveType mesh_surface_get_primitive(void *p_surface) {
+		Mesh::Surface *surface = reinterpret_cast<Mesh::Surface *>(p_surface);
+		return surface->primitive;
+	}
+
+	_FORCE_INLINE_ bool mesh_surface_has_lod(void *p_surface) const {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+		return s->lod_count > 0;
+	}
+
+	_FORCE_INLINE_ uint32_t mesh_surface_get_vertices_drawn_count(void *p_surface) const {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+		return s->index_count ? s->index_count : s->vertex_count;
+	}
+
+	_FORCE_INLINE_ uint32_t mesh_surface_get_lod(void *p_surface, float p_model_scale, float p_distance_threshold, float p_mesh_lod_threshold, uint32_t *r_index_count = nullptr) const {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+
+		int32_t current_lod = -1;
+		if (r_index_count) {
+			*r_index_count = s->index_count;
+		}
+		for (uint32_t i = 0; i < s->lod_count; i++) {
+			float screen_size = s->lods[i].edge_length * p_model_scale / p_distance_threshold;
+			if (screen_size > p_mesh_lod_threshold) {
+				break;
+			}
+			current_lod = i;
+		}
+		if (current_lod == -1) {
+			return 0;
+		} else {
+			if (r_index_count) {
+				*r_index_count = s->lods[current_lod].index_count;
+			}
+			return current_lod + 1;
+		}
+	}
+
+	_FORCE_INLINE_ GLuint mesh_surface_get_index_buffer(void *p_surface, uint32_t p_lod) const {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+
+		if (p_lod == 0) {
+			return s->index_buffer;
+		} else {
+			return s->lods[p_lod - 1].index_buffer;
+		}
+	}
+
+	// Use this to cache Vertex Array Objects so they are only generated once
+	_FORCE_INLINE_ void mesh_surface_get_vertex_arrays_and_format(void *p_surface, uint32_t p_input_mask, GLuint &r_vertex_array_gl) {
+		Mesh::Surface *s = reinterpret_cast<Mesh::Surface *>(p_surface);
+
+		s->version_lock.lock();
+
+		//there will never be more than, at much, 3 or 4 versions, so iterating is the fastest way
+
+		for (uint32_t i = 0; i < s->version_count; i++) {
+			if (s->versions[i].input_mask != p_input_mask) {
+				continue;
+			}
+			//we have this version, hooray
+			r_vertex_array_gl = s->versions[i].vertex_array;
+			s->version_lock.unlock();
+			return;
+		}
+
+		uint32_t version = s->version_count;
+		s->version_count++;
+		s->versions = (Mesh::Surface::Version *)memrealloc(s->versions, sizeof(Mesh::Surface::Version) * s->version_count);
+
+		_mesh_surface_generate_version_for_input_mask(s->versions[version], s, p_input_mask);
+
+		r_vertex_array_gl = s->versions[version].vertex_array;
+
+		s->version_lock.unlock();
+	}
+
 	/* MESH INSTANCE API */
 
 	virtual RID mesh_instance_create(RID p_base) override;
@@ -92,45 +395,41 @@ public:
 	virtual void mesh_instance_check_for_update(RID p_mesh_instance) override;
 	virtual void update_mesh_instances() override;
 
+	_FORCE_INLINE_ void mesh_instance_surface_get_vertex_arrays_and_format(RID p_mesh_instance, uint32_t p_surface_index, uint32_t p_input_mask, GLuint &r_vertex_array_gl) {
+		MeshInstance *mi = mesh_instance_owner.get_or_null(p_mesh_instance);
+		ERR_FAIL_COND(!mi);
+		Mesh *mesh = mi->mesh;
+		ERR_FAIL_UNSIGNED_INDEX(p_surface_index, mesh->surface_count);
+
+		MeshInstance::Surface *mis = &mi->surfaces[p_surface_index];
+		Mesh::Surface *s = mesh->surfaces[p_surface_index];
+
+		s->version_lock.lock();
+
+		//there will never be more than, at much, 3 or 4 versions, so iterating is the fastest way
+
+		for (uint32_t i = 0; i < mis->version_count; i++) {
+			if (mis->versions[i].input_mask != p_input_mask) {
+				continue;
+			}
+			//we have this version, hooray
+			r_vertex_array_gl = mis->versions[i].vertex_array;
+			s->version_lock.unlock();
+			return;
+		}
+
+		uint32_t version = mis->version_count;
+		mis->version_count++;
+		mis->versions = (Mesh::Surface::Version *)memrealloc(mis->versions, sizeof(Mesh::Surface::Version) * mis->version_count);
+
+		_mesh_surface_generate_version_for_input_mask(mis->versions[version], s, p_input_mask, mis);
+
+		r_vertex_array_gl = mis->versions[version].vertex_array;
+
+		s->version_lock.unlock();
+	}
+
 	/* MULTIMESH API */
-
-	struct MultiMesh {
-		RID mesh;
-		int instances = 0;
-		RS::MultimeshTransformFormat xform_format = RS::MULTIMESH_TRANSFORM_3D;
-		bool uses_colors = false;
-		bool uses_custom_data = false;
-		int visible_instances = -1;
-		AABB aabb;
-		bool aabb_dirty = false;
-		bool buffer_set = false;
-		uint32_t stride_cache = 0;
-		uint32_t color_offset_cache = 0;
-		uint32_t custom_data_offset_cache = 0;
-
-		Vector<float> data_cache; //used if individual setting is used
-		bool *data_cache_dirty_regions = nullptr;
-		uint32_t data_cache_used_dirty_regions = 0;
-
-		RID buffer; //storage buffer
-		RID uniform_set_3d;
-		RID uniform_set_2d;
-
-		bool dirty = false;
-		MultiMesh *dirty_list = nullptr;
-
-		RendererStorage::Dependency dependency;
-	};
-
-	mutable RID_Owner<MultiMesh, true> multimesh_owner;
-
-	MultiMesh *multimesh_dirty_list = nullptr;
-
-	_FORCE_INLINE_ void _multimesh_make_local(MultiMesh *multimesh) const;
-	_FORCE_INLINE_ void _multimesh_mark_dirty(MultiMesh *multimesh, int p_index, bool p_aabb);
-	_FORCE_INLINE_ void _multimesh_mark_all_dirty(MultiMesh *multimesh, bool p_data, bool p_aabb);
-	_FORCE_INLINE_ void _multimesh_re_create_aabb(MultiMesh *multimesh, const float *p_data, int p_instances);
-	void _update_dirty_multimeshes();
 
 	virtual RID multimesh_allocate() override;
 	virtual void multimesh_initialize(RID p_rid) override;
@@ -156,6 +455,8 @@ public:
 
 	virtual void multimesh_set_visible_instances(RID p_multimesh, int p_visible) override;
 	virtual int multimesh_get_visible_instances(RID p_multimesh) const override;
+
+	void _update_dirty_multimeshes();
 
 	_FORCE_INLINE_ RS::MultimeshTransformFormat multimesh_get_transform_format(RID p_multimesh) const {
 		MultiMesh *multimesh = multimesh_owner.get_or_null(p_multimesh);


### PR DESCRIPTION
This PR provides the initial framework for the Mesh storage functions. I have adapted the RD api to GLES3 for the most part that will work very well, but there are a few places where we will want to do some testing to ensure that we are getting the best performance possible. 

In particular, I am worried that the way we pull data from the GPU in the MultiMesh API and the way we upload dirty sections in the MultiMesh API may prove to be too slow on old hardware. 

That being said, it is more important to get things working right now. 

This PR compiles, but I can't test it until after #60503 is merged. 
