### PR TITLE
Physics interpolation - fix streaking when unhiding nodes

### DIFF
--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -97,7 +97,7 @@ void VisualInstance::_notification(int p_what) {
 
 		} break;
 		case NOTIFICATION_TRANSFORM_CHANGED: {
-			if (_is_vi_visible()) {
+			if (_is_vi_visible() || is_physics_interpolated_and_enabled()) {
 				if (!_is_using_identity_transform()) {
 					Transform gt = get_global_transform();
 					VisualServer::get_singleton()->instance_set_transform(instance, gt);
@@ -105,10 +105,8 @@ void VisualInstance::_notification(int p_what) {
 			}
 		} break;
 		case NOTIFICATION_RESET_PHYSICS_INTERPOLATION: {
-			if (_is_vi_visible()) {
-				if (is_physics_interpolated()) {
-					VisualServer::get_singleton()->instance_reset_physics_interpolation(instance);
-				}
+			if (_is_vi_visible() && is_physics_interpolated()) {
+				VisualServer::get_singleton()->instance_reset_physics_interpolation(instance);
 			}
 		} break;
 		case NOTIFICATION_EXIT_WORLD: {


### PR DESCRIPTION
The data flow to the VisualServer of current and previous transforms is essential for allowing correct interpolation. An optimization was present that disabled sending transforms when nodes were hidden, however this meant that when unhidden, nodes would interpolate incorrectly from the last transform received when hiding, rather than the up to date previous transform.

This PR disables the optimization and sends always sends transforms when a node is interpolated.

Fixes #60582

## Notes
* This is a quick and simple fix, but it does effectively undo the "invisible" optimization when interpolation is active, for what is effectively quite a rare case.
* I can probably make the fix more efficient at a later date, but in the meantime, this does fix the bug.
* Alternatively we could wait and leave the bug active.

## Teleporting
An alternative approach which has no performance implications is simply to `reset_physics_interpolation()` (teleport) whenever these nodes are unhidden. However teleport always means there will effectively be no interpolation for the first physics tick, which could result in a slight visual judder, especially for cases where nodes are hidden and unhidden frequently, so it would be nicer to use the fix in this PR or similar with no visual artifacts.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
