### PR TITLE
Miscellaneous `Tween` fixes

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -76,7 +76,7 @@
 			<return type="float" />
 			<description>
 				Returns the total time in seconds the [Tween] has been animating (i.e. time since it started, not counting pauses etc.). The time is affected by [method set_speed_scale] and [method stop] will reset it to [code]0[/code].
-				[b]Note:[/code] As it results from accumulating frame deltas, the time returned after the [Tween] has finished animating will be slightly greater than the actual [Tween] duration.
+				[b]Note:[/b] As it results from accumulating frame deltas, the time returned after the [Tween] has finished animating will be slightly greater than the actual [Tween] duration.
 			</description>
 		</method>
 		<method name="interpolate_value" qualifiers="static">
@@ -231,10 +231,10 @@
 				Example: creating an object that moves back and forth and jumps every few seconds.
 				[codeblock]
 				var tween = create_tween().set_loops()
-				tween.tween_property("position:x", 200, 1).as_relative()
+				tween.tween_property($Sprite, "position:x", 200.0, 1).as_relative()
 				tween.tween_callback(jump)
 				tween.tween_interval(2)
-				tween.tween_property("position:x", -200, 1).as_relative()
+				tween.tween_property($Sprite, "position:x", -200.0, 1).as_relative()
 				tween.tween_callback(jump)
 				tween.tween_interval(2)
 				[/codeblock]
@@ -274,16 +274,16 @@
 				Creates and appends a [PropertyTweener]. This method tweens a [code]property[/code] of an [code]object[/code] between an initial value and [code]final_val[/code] in a span of time equal to [code]duration[/code], in seconds. The initial value by default is a value at the time the tweening of the [PropertyTweener] start. For example:
 				[codeblock]
 				var tween = create_tween()
-				tween.tween_property($Sprite, "position", Vector2(100, 200)
-				tween.tween_property($Sprite, "position", Vector2(200, 300)
+				tween.tween_property($Sprite, "position", Vector2(100, 200), 1)
+				tween.tween_property($Sprite, "position", Vector2(200, 300), 1)
 				[/codeblock]
 				will move the sprite to position (100, 200) and then to (200, 300). If you use [method PropertyTweener.from] or [method PropertyTweener.from_current], the starting position will be overwritten by the given value instead. See other methods in [PropertyTweener] to see how the tweening can be tweaked further.
 				[b]Note:[/b] You can find the correct property name by hovering over the property in the Inspector. You can also provide the components of a property directly by using [code]"property:component"[/code] (eg. [code]position:x[/code]), where it would only apply to that particular component.
 				Example: moving object twice from the same position, with different transition types.
 				[codeblock]
 				var tween = create_tween()
-				tween.tween_property($Sprite, "position", Vector2.RIGHT * 300).as_relative().set_trans(Tween.TRANS_SINE)
-				tween.tween_property($Sprite, "position", Vector2.RIGHT * 300).as_relative().from_current().set_trans(Tween.TRANS_EXPO)
+				tween.tween_property($Sprite, "position", Vector2.RIGHT * 300, 1).as_relative().set_trans(Tween.TRANS_SINE)
+				tween.tween_property($Sprite, "position", Vector2.RIGHT * 300, 1).as_relative().from_current().set_trans(Tween.TRANS_EXPO)
 				[/codeblock]
 			</description>
 		</method>

--- a/doc/classes/Tweener.xml
+++ b/doc/classes/Tweener.xml
@@ -4,7 +4,7 @@
 		Abstract class for all Tweeners used by [Tween].
 	</brief_description>
 	<description>
-		Tweeners are objects that perform a specific animating task, e.g. interpolating a property or calling a method at a given time. A [Tweener] can't be created manually, you need to use a dedicated method from [Tween] or [Node].
+		Tweeners are objects that perform a specific animating task, e.g. interpolating a property or calling a method at a given time. A [Tweener] can't be created manually, you need to use a dedicated method from [Tween].
 	</description>
 	<tutorials>
 	</tutorials>

--- a/scene/animation/tween.cpp
+++ b/scene/animation/tween.cpp
@@ -850,7 +850,7 @@ bool CallbackTweener::step(float &r_delta) {
 		Callable::CallError ce;
 		callback.call(nullptr, 0, result, ce);
 		if (ce.error != Callable::CallError::CALL_OK) {
-			ERR_FAIL_V_MSG(false, "Error calling method from CallbackTweener: " + Variant::get_call_error_text(this, callback.get_method(), nullptr, 0, ce));
+			ERR_FAIL_V_MSG(false, "Error calling method from CallbackTweener: " + Variant::get_call_error_text(callback.get_object(), callback.get_method(), nullptr, 0, ce));
 		}
 
 		finished = true;
@@ -921,7 +921,7 @@ bool MethodTweener::step(float &r_delta) {
 	Callable::CallError ce;
 	callback.call(argptr, 1, result, ce);
 	if (ce.error != Callable::CallError::CALL_OK) {
-		ERR_FAIL_V_MSG(false, "Error calling method from MethodTweener: " + Variant::get_call_error_text(this, callback.get_method(), argptr, 1, ce));
+		ERR_FAIL_V_MSG(false, "Error calling method from MethodTweener: " + Variant::get_call_error_text(callback.get_object(), callback.get_method(), argptr, 1, ce));
 	}
 
 	if (time < duration) {


### PR DESCRIPTION
Fixed some issues found during my backport process, mostly in documentations.

In `tween_method()` and `tween_callback()`, fixes a bug where call error messages are using the wrong target object class.