### PR TITLE
remove escapes in gdscript test output

### DIFF
--- a/tests/test_macros.h
+++ b/tests/test_macros.h
@@ -63,22 +63,22 @@
 // Stringify all `Variant` compatible types for doctest output by default.
 // https://github.com/onqtam/doctest/blob/master/doc/markdown/stringification.md
 
-#define DOCTEST_STRINGIFY_VARIANT(m_type)                        \
-	template <>                                                  \
-	struct doctest::StringMaker<m_type> {                        \
-		static doctest::String convert(const m_type &p_val) {    \
-			const Variant val = p_val;                           \
-			return val.get_construct_string().utf8().get_data(); \
-		}                                                        \
+#define DOCTEST_STRINGIFY_VARIANT(m_type)                     \
+	template <>                                               \
+	struct doctest::StringMaker<m_type> {                     \
+		static doctest::String convert(const m_type &p_val) { \
+			const Variant val = p_val;                        \
+			return val.operator ::String().utf8().get_data(); \
+		}                                                     \
 	};
 
-#define DOCTEST_STRINGIFY_VARIANT_POINTER(m_type)                \
-	template <>                                                  \
-	struct doctest::StringMaker<m_type> {                        \
-		static doctest::String convert(const m_type *p_val) {    \
-			const Variant val = p_val;                           \
-			return val.get_construct_string().utf8().get_data(); \
-		}                                                        \
+#define DOCTEST_STRINGIFY_VARIANT_POINTER(m_type)             \
+	template <>                                               \
+	struct doctest::StringMaker<m_type> {                     \
+		static doctest::String convert(const m_type *p_val) { \
+			const Variant val = p_val;                        \
+			return val.operator ::String().utf8().get_data(); \
+		}                                                     \
 	};
 
 DOCTEST_STRINGIFY_VARIANT(Variant);


### PR DESCRIPTION
Minor annoyance when working on https://github.com/godotengine/godot/pull/60609

Before:
```
  logged: "/home/nathan/workspace/public/godot/modules/gdscript/tests/scripts/runtime/features/await_without_coroutine.gd"
          "GDTEST_OK
>> WARNING
>> Line: 4
>> REDUNDANT_AWAIT
>> \"await\" keyword not needed in this case, because the expression isn't a coroutine nor a signal.
awaited
"
```

After:
```
  logged: /home/nathan/workspace/public/godot/modules/gdscript/tests/scripts/runtime/features/await_without_coroutine.gd
          GDTEST_OK
>> WARNING
>> Line: 4
>> REDUNDANT_AWAIT
>> "await" keyword not needed in this case, because the expression isn't a coroutine nor a signal.
awaited
```