### PR TITLE
Fix item reset behavior of `SkeletonModificationStack`

### DIFF
--- a/scene/resources/skeleton_modification_stack_2d.cpp
+++ b/scene/resources/skeleton_modification_stack_2d.cpp
@@ -182,12 +182,10 @@ void SkeletonModificationStack2D::delete_modification(int p_mod_idx) {
 void SkeletonModificationStack2D::set_modification(int p_mod_idx, Ref<SkeletonModification2D> p_mod) {
 	ERR_FAIL_INDEX(p_mod_idx, modifications.size());
 
-	if (p_mod == nullptr) {
-		modifications.insert(p_mod_idx, nullptr);
-	} else {
+	if (p_mod.is_valid()) {
 		p_mod->_setup_modification(this);
-		modifications.insert(p_mod_idx, p_mod);
 	}
+	modifications.write[p_mod_idx] = p_mod;
 
 #ifdef TOOLS_ENABLED
 	set_editor_gizmos_dirty(true);

--- a/scene/resources/skeleton_modification_stack_3d.cpp
+++ b/scene/resources/skeleton_modification_stack_3d.cpp
@@ -140,12 +140,10 @@ void SkeletonModificationStack3D::set_modification(int p_mod_idx, Ref<SkeletonMo
 	const int modifications_size = modifications.size();
 	ERR_FAIL_INDEX(p_mod_idx, modifications_size);
 
-	if (p_mod == nullptr) {
-		modifications.remove_at(p_mod_idx);
-	} else {
+	if (p_mod.is_valid()) {
 		p_mod->_setup_modification(this);
-		modifications[p_mod_idx] = p_mod;
 	}
+	modifications[p_mod_idx] = p_mod;
 }
 
 void SkeletonModificationStack3D::set_modification_count(int p_count) {


### PR DESCRIPTION
Resetting item in the "modifications" array of `SkeletonModificationStack2D` inserts an entry instead:

https://user-images.githubusercontent.com/372476/165886926-4e7053c8-6546-4606-a51b-686caf7de416.mp4

The 3D version is a bit better, but still have unexpected behavior: Resetting an item reduces the stack size, but it does not update the Inspector.

Since `set_modification()` is only used in `_set()`, this PR applies the regular "set index" logic here.

CC @TwistedTwigleg