### PR TITLE
[3.x] Fix incorrect usage for some export variables

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4914,6 +4914,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 				if (autoexport && member.data_type.has_type) {
 					if (member.data_type.kind == DataType::BUILTIN) {
 						member._export.type = member.data_type.builtin_type;
+						member._export.usage |= PROPERTY_USAGE_SCRIPT_VARIABLE;
 					} else if (member.data_type.kind == DataType::NATIVE) {
 						if (ClassDB::is_parent_class(member.data_type.native_type, "Resource")) {
 							member._export.type = Variant::OBJECT;


### PR DESCRIPTION
Fixes #59157

`PROPERTY_USAGE_SCRIPT_VARIABLE` was not added when only a type hint exists and the type is non-Object.

```gdscript
export var foo := 42 # this works
export var foo: int  # not added for this
export var foo: int = 42 # not added, as long as the type is from the explicit type hint
```

---

An alternative way to fix this is don't bother adding that usage in the parser and always add it here:

https://github.com/godotengine/godot/blob/036f36b5f179b47feac24f065e3033afedd608f9/modules/gdscript/gdscript_compiler.cpp#L1961

That's also how `master` [adds the usage](https://github.com/godotengine/godot/blob/700ca5bb3c934df6aeecc280ea2741cbabd51f7a/modules/gdscript/gdscript_compiler.cpp#L2301-L2311).

I chose the current whitelist-like approach because I'm not sure if using the GDScript 2.0 approach will introduce any regression on `3.x`.
