### PR TITLE
Use IGN instead of white noise for sky dithering

### DIFF
--- a/doc/classes/PhysicalSkyMaterial.xml
+++ b/doc/classes/PhysicalSkyMaterial.xml
@@ -11,9 +11,6 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="dither_strength" type="float" setter="set_dither_strength" getter="get_dither_strength" default="1.0">
-			The amount of dithering to use. Dithering helps reduce banding that appears from the smooth changes in color in the sky. Use the lowest value possible for your given sky settings, as higher amounts may add fuzziness to the sky.
-		</member>
 		<member name="exposure" type="float" setter="set_exposure" getter="get_exposure" default="0.1">
 			Sets the exposure of the sky. Higher exposure values make the entire sky brighter.
 		</member>
@@ -43,6 +40,9 @@
 		</member>
 		<member name="turbidity" type="float" setter="set_turbidity" getter="get_turbidity" default="10.0">
 			Sets the thickness of the atmosphere. High turbidity creates a foggy-looking atmosphere, while a low turbidity results in a clearer atmosphere.
+		</member>
+		<member name="use_debanding" type="bool" setter="set_use_debanding" getter="get_use_debanding" default="true">
+			If [code]true[/code], enables debanding. Debanding adds a small amount of noise which helps reduce banding that appears from the smooth changes in color in the sky.
 		</member>
 	</members>
 </class>

--- a/doc/classes/ProceduralSkyMaterial.xml
+++ b/doc/classes/ProceduralSkyMaterial.xml
@@ -11,9 +11,6 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="dither_strength" type="float" setter="set_dither_strength" getter="get_dither_strength" default="1.0">
-			The amount of dithering to use. Dithering helps reduce banding that appears from the smooth changes in color in the sky. Use the lowest value possible for your given sky settings, as higher amounts may add fuzziness to the sky.
-		</member>
 		<member name="ground_bottom_color" type="Color" setter="set_ground_bottom_color" getter="get_ground_bottom_color" default="Color(0.2, 0.169, 0.133, 1)">
 			Color of the ground at the bottom. Blends with [member ground_horizon_color].
 		</member>
@@ -49,6 +46,9 @@
 		</member>
 		<member name="sun_curve" type="float" setter="set_sun_curve" getter="get_sun_curve" default="0.15">
 			How quickly the sun fades away between the edge of the sun disk and [member sun_angle_max].
+		</member>
+		<member name="use_debanding" type="bool" setter="set_use_debanding" getter="get_use_debanding" default="true">
+			If [code]true[/code], enables debanding. Debanding adds a small amount of noise which helps reduce banding that appears from the smooth changes in color in the sky.
 		</member>
 	</members>
 </class>

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1632,6 +1632,7 @@ ShaderCompiler::DefaultIdentifierActions actions;
 		actions.renames["SKY_COORDS"] = "panorama_coords";
 		actions.renames["SCREEN_UV"] = "uv";
 		actions.renames["TIME"] = "time";
+		actions.renames["FRAGCOORD"] = "gl_FragCoord";
 		actions.renames["PI"] = _MKSTR(Math_PI);
 		actions.renames["TAU"] = _MKSTR(Math_TAU);
 		actions.renames["E"] = _MKSTR(Math_E);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -5257,6 +5257,8 @@ VisualShaderEditor::VisualShaderEditor() {
 	add_options.push_back(AddOption("QuarterResColor", "Input", "Sky", "VisualShaderNodeInput", vformat(input_param_for_sky_shader_mode, "quarter_res_color", "QUARTER_RES_COLOR"), { "quarter_res_color" }, VisualShaderNode::PORT_TYPE_VECTOR_4D, TYPE_FLAGS_SKY, Shader::MODE_SKY));
 	add_options.push_back(AddOption("Radiance", "Input", "Sky", "VisualShaderNodeInput", vformat(input_param_for_sky_shader_mode, "radiance", "RADIANCE"), { "radiance" }, VisualShaderNode::PORT_TYPE_SAMPLER, TYPE_FLAGS_SKY, Shader::MODE_SKY));
 	add_options.push_back(AddOption("ScreenUV", "Input", "Sky", "VisualShaderNodeInput", vformat(input_param_for_sky_shader_mode, "screen_uv", "SCREEN_UV"), { "screen_uv" }, VisualShaderNode::PORT_TYPE_VECTOR_2D, TYPE_FLAGS_SKY, Shader::MODE_SKY));
+	add_options.push_back(AddOption("FragCoord", "Input", "Sky", "VisualShaderNodeInput", vformat(input_param_for_sky_shader_mode, "fragcoord", "FRAGCOORD"), { "fragcoord" }, VisualShaderNode::PORT_TYPE_VECTOR_4D, TYPE_FLAGS_SKY, Shader::MODE_SKY));
+
 	add_options.push_back(AddOption("SkyCoords", "Input", "Sky", "VisualShaderNodeInput", vformat(input_param_for_sky_shader_mode, "sky_coords", "SKY_COORDS"), { "sky_coords" }, VisualShaderNode::PORT_TYPE_VECTOR_2D, TYPE_FLAGS_SKY, Shader::MODE_SKY));
 	add_options.push_back(AddOption("Time", "Input", "Sky", "VisualShaderNodeInput", vformat(input_param_for_sky_shader_mode, "time", "TIME"), { "time" }, VisualShaderNode::PORT_TYPE_SCALAR, TYPE_FLAGS_SKY, Shader::MODE_SKY));
 

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -52,7 +52,7 @@ private:
 
 	float sun_angle_max = 0.0f;
 	float sun_curve = 0.0f;
-	float dither_strength = 0.0f;
+	bool use_debanding = true;
 
 	static Mutex shader_mutex;
 	static RID shader;
@@ -99,8 +99,8 @@ public:
 	void set_sun_curve(float p_curve);
 	float get_sun_curve() const;
 
-	void set_dither_strength(float p_dither_strength);
-	float get_dither_strength() const;
+	void set_use_debanding(bool p_use_debanding);
+	bool get_use_debanding() const;
 
 	virtual Shader::Mode get_shader_mode() const override;
 	virtual RID get_shader_rid() const override;
@@ -167,7 +167,7 @@ private:
 	float sun_disk_scale = 0.0f;
 	Color ground_color;
 	float exposure = 0.0f;
-	float dither_strength = 0.0f;
+	bool use_debanding = true;
 	Ref<Texture2D> night_sky;
 	static void _update_shader();
 	mutable bool shader_set = false;
@@ -203,8 +203,8 @@ public:
 	void set_exposure(float p_exposure);
 	float get_exposure() const;
 
-	void set_dither_strength(float p_dither_strength);
-	float get_dither_strength() const;
+	void set_use_debanding(bool p_use_debanding);
+	bool get_use_debanding() const;
 
 	void set_night_sky(const Ref<Texture2D> &p_night_sky);
 	Ref<Texture2D> get_night_sky() const;

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -2926,6 +2926,7 @@ const VisualShaderNodeInput::Port VisualShaderNodeInput::ports[] = {
 	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_VECTOR_4D, "quarter_res_color", "QUARTER_RES_COLOR" },
 	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_SAMPLER, "radiance", "RADIANCE" },
 	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_VECTOR_2D, "screen_uv", "SCREEN_UV" },
+	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_VECTOR_4D, "fragcoord", "FRAGCOORD" },
 	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_VECTOR_2D, "sky_coords", "SKY_COORDS" },
 	{ Shader::MODE_SKY, VisualShader::TYPE_SKY, VisualShaderNode::PORT_TYPE_SCALAR, "time", "TIME" },
 

--- a/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_sky_rd.cpp
@@ -846,6 +846,7 @@ void RendererSceneSkyRD::init(RendererStorageRD *p_storage) {
 		actions.renames["POSITION"] = "params.position_multiplier.xyz";
 		actions.renames["SKY_COORDS"] = "panorama_coords";
 		actions.renames["SCREEN_UV"] = "uv";
+		actions.renames["FRAGCOORD"] = "gl_FragCoord";
 		actions.renames["TIME"] = "params.time";
 		actions.renames["PI"] = _MKSTR(Math_PI);
 		actions.renames["TAU"] = _MKSTR(Math_TAU);

--- a/servers/rendering/shader_types.cpp
+++ b/servers/rendering/shader_types.cpp
@@ -422,6 +422,7 @@ ShaderTypes::ShaderTypes() {
 	shader_modes[RS::SHADER_SKY].functions["sky"].built_ins["ALPHA"] = ShaderLanguage::TYPE_FLOAT;
 	shader_modes[RS::SHADER_SKY].functions["sky"].built_ins["EYEDIR"] = constt(ShaderLanguage::TYPE_VEC3);
 	shader_modes[RS::SHADER_SKY].functions["sky"].built_ins["SCREEN_UV"] = constt(ShaderLanguage::TYPE_VEC2);
+	shader_modes[RS::SHADER_SKY].functions["sky"].built_ins["FRAGCOORD"] = constt(ShaderLanguage::TYPE_VEC4);
 	shader_modes[RS::SHADER_SKY].functions["sky"].built_ins["SKY_COORDS"] = constt(ShaderLanguage::TYPE_VEC2);
 	shader_modes[RS::SHADER_SKY].functions["sky"].built_ins["HALF_RES_COLOR"] = constt(ShaderLanguage::TYPE_VEC4);
 	shader_modes[RS::SHADER_SKY].functions["sky"].built_ins["QUARTER_RES_COLOR"] = constt(ShaderLanguage::TYPE_VEC4);


### PR DESCRIPTION
Inspired by #60070 I decided to revisit my choice to use white noise for dither in PhysicalSkyMaterial. I felt that better results should be posible without introducing as much noise into the image. As it turns out it is possible with our friend "interleaved gradient noise". 

Previously you needed to boost the dithering amount in order to fully eliminate banding. Now the default works even better and introduces less visible noise.

In order to use interleaved gradient noise I had to expose gl_FragCoord to Sky shaders.

This change is especially helpful for the GLES3 and Vulkan-mobile backends as they don't use HDR framebuffers.

_Before: PhysicalSkyMaterial dithering set to default(1) Vulkan-mobile_
![Screenshot from 2022-04-29 14-23-17](https://user-images.githubusercontent.com/16521339/166071425-4f831ea1-342a-42b4-8d53-3be923bec858.png)

_After: PhysicalSkyMaterial dither set to default(1) Vulkan-mobile_
![Screenshot from 2022-04-29 14-24-37](https://user-images.githubusercontent.com/16521339/166071403-dbd7a56b-5f7f-400f-8260-1f404af08406.png)


