### PR TITLE
Expose Label3D and Sprite*3D material render priority properties.

### DIFF
--- a/doc/classes/Label3D.xml
+++ b/doc/classes/Label3D.xml
@@ -98,11 +98,21 @@
 		<member name="outline_modulate" type="Color" setter="set_outline_modulate" getter="get_outline_modulate" default="Color(0, 0, 0, 1)">
 			The tint of [Font]'s outline.
 		</member>
+		<member name="outline_render_priority" type="int" setter="set_outline_render_priority" getter="get_outline_render_priority" default="-1">
+			Sets the render priority for the text outline. Higher priority objects will be sorted in front of lower priority objects.
+			[b]Node:[/b] This only applies if [member alpha_cut] is set to [constant ALPHA_CUT_DISABLED] (default value).
+			[b]Note:[/b] This only applies to sorting of transparent objects. This will not impact how transparent objects are sorted relative to opaque objects. This is because opaque objects are not sorted, while transparent objects are sorted from back to front (subject to priority).
+		</member>
 		<member name="outline_size" type="int" setter="set_outline_size" getter="get_outline_size" default="0">
 			Text outline size.
 		</member>
 		<member name="pixel_size" type="float" setter="set_pixel_size" getter="get_pixel_size" default="0.01">
 			The size of one pixel's width on the label to scale it in 3D.
+		</member>
+		<member name="render_priority" type="int" setter="set_render_priority" getter="get_render_priority" default="0">
+			Sets the render priority for the text. Higher priority objects will be sorted in front of lower priority objects.
+			[b]Node:[/b] This only applies if [member alpha_cut] is set to [constant ALPHA_CUT_DISABLED] (default value).
+			[b]Note:[/b] This only applies to sorting of transparent objects. This will not impact how transparent objects are sorted relative to opaque objects. This is because opaque objects are not sorted, while transparent objects are sorted from back to front (subject to priority).
 		</member>
 		<member name="shaded" type="bool" setter="set_draw_flag" getter="get_draw_flag" default="false">
 			If [code]true[/code], the [Light3D] in the [Environment] has effects on the label.

--- a/doc/classes/SpriteBase3D.xml
+++ b/doc/classes/SpriteBase3D.xml
@@ -75,6 +75,11 @@
 		<member name="pixel_size" type="float" setter="set_pixel_size" getter="get_pixel_size" default="0.01">
 			The size of one pixel's width on the sprite to scale it in 3D.
 		</member>
+		<member name="render_priority" type="int" setter="set_render_priority" getter="get_render_priority" default="0">
+			Sets the render priority for the sprite. Higher priority objects will be sorted in front of lower priority objects.
+			[b]Node:[/b] This only applies if [member alpha_cut] is set to [constant ALPHA_CUT_DISABLED] (default value).
+			[b]Note:[/b] This only applies to sorting of transparent objects. This will not impact how transparent objects are sorted relative to opaque objects. This is because opaque objects are not sorted, while transparent objects are sorted from back to front (subject to priority).
+		</member>
 		<member name="shaded" type="bool" setter="set_draw_flag" getter="get_draw_flag" default="false">
 			If [code]true[/code], the [Light3D] in the [Environment] has effects on the sprite.
 		</member>

--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -69,6 +69,12 @@ void Label3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_uppercase", "enable"), &Label3D::set_uppercase);
 	ClassDB::bind_method(D_METHOD("is_uppercase"), &Label3D::is_uppercase);
 
+	ClassDB::bind_method(D_METHOD("set_render_priority", "priority"), &Label3D::set_render_priority);
+	ClassDB::bind_method(D_METHOD("get_render_priority"), &Label3D::get_render_priority);
+
+	ClassDB::bind_method(D_METHOD("set_outline_render_priority", "priority"), &Label3D::set_outline_render_priority);
+	ClassDB::bind_method(D_METHOD("get_outline_render_priority"), &Label3D::get_outline_render_priority);
+
 	ClassDB::bind_method(D_METHOD("set_font", "font"), &Label3D::set_font);
 	ClassDB::bind_method(D_METHOD("get_font"), &Label3D::get_font);
 
@@ -126,6 +132,8 @@ void Label3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alpha_cut", PROPERTY_HINT_ENUM, "Disabled,Discard,Opaque Pre-Pass"), "set_alpha_cut_mode", "get_alpha_cut_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "alpha_scissor_threshold", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_alpha_scissor_threshold", "get_alpha_scissor_threshold");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_priority", PROPERTY_HINT_RANGE, itos(RS::MATERIAL_RENDER_PRIORITY_MIN) + "," + itos(RS::MATERIAL_RENDER_PRIORITY_MAX) + ",1"), "set_render_priority", "get_render_priority");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "outline_render_priority", PROPERTY_HINT_RANGE, itos(RS::MATERIAL_RENDER_PRIORITY_MIN) + "," + itos(RS::MATERIAL_RENDER_PRIORITY_MAX) + ",1"), "set_outline_render_priority", "get_outline_render_priority");
 
 	ADD_GROUP("Text", "");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "modulate"), "set_modulate", "get_modulate");
@@ -580,13 +588,13 @@ void Label3D::_shape() {
 			// Outline surfaces.
 			Vector2 ol_offset = offset;
 			for (int j = 0; j < gl_size; j++) {
-				_generate_glyph_surfaces(glyphs[j], ol_offset, outline_modulate, -1, outline_size);
+				_generate_glyph_surfaces(glyphs[j], ol_offset, outline_modulate, outline_render_priority, outline_size);
 			}
 		}
 
 		// Main text surfaces.
 		for (int j = 0; j < gl_size; j++) {
-			_generate_glyph_surfaces(glyphs[j], offset, modulate, 0);
+			_generate_glyph_surfaces(glyphs[j], offset, modulate, render_priority);
 		}
 		offset.y -= (TS->shaped_text_get_descent(lines_rid[i]) + line_spacing + font->get_spacing(TextServer::SPACING_BOTTOM)) * pixel_size;
 	}
@@ -730,6 +738,30 @@ void Label3D::set_uppercase(bool p_uppercase) {
 
 bool Label3D::is_uppercase() const {
 	return uppercase;
+}
+
+void Label3D::set_render_priority(int p_priority) {
+	ERR_FAIL_COND(p_priority < RS::MATERIAL_RENDER_PRIORITY_MIN || p_priority > RS::MATERIAL_RENDER_PRIORITY_MAX);
+	if (render_priority != p_priority) {
+		render_priority = p_priority;
+		_queue_update();
+	}
+}
+
+int Label3D::get_render_priority() const {
+	return render_priority;
+}
+
+void Label3D::set_outline_render_priority(int p_priority) {
+	ERR_FAIL_COND(p_priority < RS::MATERIAL_RENDER_PRIORITY_MIN || p_priority > RS::MATERIAL_RENDER_PRIORITY_MAX);
+	if (outline_render_priority != p_priority) {
+		outline_render_priority = p_priority;
+		_queue_update();
+	}
+}
+
+int Label3D::get_outline_render_priority() const {
+	return outline_render_priority;
 }
 
 void Label3D::_font_changed() {

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -98,6 +98,8 @@ private:
 	Ref<Font> font_override;
 	Color modulate = Color(1, 1, 1, 1);
 	Point2 lbl_offset;
+	int outline_render_priority = -1;
+	int render_priority = 0;
 
 	int outline_size = 0;
 	Color outline_modulate = Color(0, 0, 0, 1);
@@ -149,6 +151,12 @@ public:
 
 	void set_vertical_alignment(VerticalAlignment p_alignment);
 	VerticalAlignment get_vertical_alignment() const;
+
+	void set_render_priority(int p_priority);
+	int get_render_priority() const;
+
+	void set_outline_render_priority(int p_priority);
+	int get_outline_render_priority() const;
 
 	void set_text(const String &p_string);
 	String get_text() const;

--- a/scene/3d/sprite_3d.cpp
+++ b/scene/3d/sprite_3d.cpp
@@ -134,6 +134,16 @@ Color SpriteBase3D::get_modulate() const {
 	return modulate;
 }
 
+void SpriteBase3D::set_render_priority(int p_priority) {
+	ERR_FAIL_COND(p_priority < RS::MATERIAL_RENDER_PRIORITY_MIN || p_priority > RS::MATERIAL_RENDER_PRIORITY_MAX);
+	render_priority = p_priority;
+	_queue_update();
+}
+
+int SpriteBase3D::get_render_priority() const {
+	return render_priority;
+}
+
 void SpriteBase3D::set_pixel_size(real_t p_amount) {
 	pixel_size = p_amount;
 	_queue_update();
@@ -295,6 +305,9 @@ void SpriteBase3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_modulate", "modulate"), &SpriteBase3D::set_modulate);
 	ClassDB::bind_method(D_METHOD("get_modulate"), &SpriteBase3D::get_modulate);
 
+	ClassDB::bind_method(D_METHOD("set_render_priority", "priority"), &SpriteBase3D::set_render_priority);
+	ClassDB::bind_method(D_METHOD("get_render_priority"), &SpriteBase3D::get_render_priority);
+
 	ClassDB::bind_method(D_METHOD("set_pixel_size", "pixel_size"), &SpriteBase3D::set_pixel_size);
 	ClassDB::bind_method(D_METHOD("get_pixel_size"), &SpriteBase3D::get_pixel_size);
 
@@ -335,6 +348,7 @@ void SpriteBase3D::_bind_methods() {
 	ADD_PROPERTYI(PropertyInfo(Variant::BOOL, "fixed_size"), "set_draw_flag", "get_draw_flag", FLAG_FIXED_SIZE);
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "alpha_cut", PROPERTY_HINT_ENUM, "Disabled,Discard,Opaque Pre-Pass"), "set_alpha_cut_mode", "get_alpha_cut_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "texture_filter", PROPERTY_HINT_ENUM, "Nearest,Linear,Nearest Mipmap,Linear Mipmap,Nearest Mipmap Anisotropic,Linear Mipmap Anisotropic"), "set_texture_filter", "get_texture_filter");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "render_priority", PROPERTY_HINT_RANGE, itos(RS::MATERIAL_RENDER_PRIORITY_MIN) + "," + itos(RS::MATERIAL_RENDER_PRIORITY_MAX) + ",1"), "set_render_priority", "get_render_priority");
 
 	BIND_ENUM_CONSTANT(FLAG_TRANSPARENT);
 	BIND_ENUM_CONSTANT(FLAG_SHADED);
@@ -613,6 +627,10 @@ void Sprite3D::_draw() {
 	if (last_texture != texture->get_rid()) {
 		RS::get_singleton()->material_set_param(get_material(), "texture_albedo", texture->get_rid());
 		last_texture = texture->get_rid();
+	}
+	if (get_alpha_cut_mode() == ALPHA_CUT_DISABLED) {
+		RS::get_singleton()->material_set_render_priority(get_material(), get_render_priority());
+		RS::get_singleton()->mesh_surface_set_material(mesh, 0, get_material());
 	}
 }
 
@@ -975,6 +993,10 @@ void AnimatedSprite3D::_draw() {
 	if (last_texture != texture->get_rid()) {
 		RS::get_singleton()->material_set_param(get_material(), "texture_albedo", texture->get_rid());
 		last_texture = texture->get_rid();
+	}
+	if (get_alpha_cut_mode() == ALPHA_CUT_DISABLED) {
+		RS::get_singleton()->material_set_render_priority(get_material(), get_render_priority());
+		RS::get_singleton()->mesh_surface_set_material(mesh, 0, get_material());
 	}
 }
 

--- a/scene/3d/sprite_3d.h
+++ b/scene/3d/sprite_3d.h
@@ -71,6 +71,7 @@ private:
 	bool vflip = false;
 
 	Color modulate = Color(1, 1, 1, 1);
+	int render_priority = 0;
 
 	Vector3::Axis axis = Vector3::AXIS_Z;
 	real_t pixel_size = 0.01;
@@ -119,6 +120,9 @@ public:
 
 	void set_flip_v(bool p_flip);
 	bool is_flipped_v() const;
+
+	void set_render_priority(int p_priority);
+	int get_render_priority() const;
 
 	void set_modulate(const Color &p_color);
 	Color get_modulate() const;


### PR DESCRIPTION
Implements https://github.com/godotengine/godot-proposals/issues/4468

Exposes material render priority properties, to allow stacking sprites and labels with the pre-defined order and avoid z-fighting.

*Two labels with the different outlines and sprite stacked together, in a normal and billboard mode*

https://user-images.githubusercontent.com/7645683/166099075-ed28c89d-4885-4703-9863-4dc7d5442072.mov
