### PR TITLE
Add get_region_rid() to NavigationRegion2D and NavigationRegion3D 

### DIFF
--- a/doc/classes/NavigationRegion2D.xml
+++ b/doc/classes/NavigationRegion2D.xml
@@ -10,6 +10,14 @@
 	</description>
 	<tutorials>
 	</tutorials>
+	<methods>
+		<method name="get_region_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of this region on the [NavigationServer2D]. Combined with [method NavigationServer2D.map_get_closest_point_owner] can be used to identify the [NavigationRegion2D] closest to a point on the merged navigation map.
+			</description>
+		</method>
+	</methods>
 	<members>
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">
 			Determines if the [NavigationRegion2D] is enabled or disabled.

--- a/doc/classes/NavigationRegion3D.xml
+++ b/doc/classes/NavigationRegion3D.xml
@@ -16,6 +16,12 @@
 				Bakes the [NavigationMesh]. The baking is done in a separate thread because navigation baking is not a cheap operation. This can be done at runtime. When it is completed, it automatically sets the new [NavigationMesh].
 			</description>
 		</method>
+		<method name="get_region_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of this region on the [NavigationServer3D]. Combined with [method NavigationServer3D.map_get_closest_point_owner] can be used to identify the [NavigationRegion3D] closest to a point on the merged navigation map.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -387,6 +387,10 @@ uint32_t NavigationRegion2D::get_layers() const {
 	return NavigationServer2D::get_singleton()->region_get_layers(region);
 }
 
+RID NavigationRegion2D::get_region_rid() const {
+	return region;
+}
+
 /////////////////////////////
 #ifdef TOOLS_ENABLED
 Rect2 NavigationRegion2D::_edit_get_rect() const {
@@ -533,6 +537,8 @@ void NavigationRegion2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_layers", "layers"), &NavigationRegion2D::set_layers);
 	ClassDB::bind_method(D_METHOD("get_layers"), &NavigationRegion2D::get_layers);
+
+	ClassDB::bind_method(D_METHOD("get_region_rid"), &NavigationRegion2D::get_region_rid);
 
 	ClassDB::bind_method(D_METHOD("_navpoly_changed"), &NavigationRegion2D::_navpoly_changed);
 

--- a/scene/2d/navigation_region_2d.h
+++ b/scene/2d/navigation_region_2d.h
@@ -117,6 +117,8 @@ public:
 	void set_layers(uint32_t p_layers);
 	uint32_t get_layers() const;
 
+	RID get_region_rid() const;
+
 	void set_navigation_polygon(const Ref<NavigationPolygon> &p_navpoly);
 	Ref<NavigationPolygon> get_navigation_polygon() const;
 

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -73,6 +73,10 @@ uint32_t NavigationRegion3D::get_layers() const {
 	return NavigationServer3D::get_singleton()->region_get_layers(region);
 }
 
+RID NavigationRegion3D::get_region_rid() const {
+	return region;
+}
+
 /////////////////////////////
 
 void NavigationRegion3D::_notification(int p_what) {
@@ -197,6 +201,8 @@ void NavigationRegion3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_layers", "layers"), &NavigationRegion3D::set_layers);
 	ClassDB::bind_method(D_METHOD("get_layers"), &NavigationRegion3D::get_layers);
+
+	ClassDB::bind_method(D_METHOD("get_region_rid"), &NavigationRegion3D::get_region_rid);
 
 	ClassDB::bind_method(D_METHOD("bake_navigation_mesh"), &NavigationRegion3D::bake_navigation_mesh);
 	ClassDB::bind_method(D_METHOD("_bake_finished", "nav_mesh"), &NavigationRegion3D::_bake_finished);

--- a/scene/3d/navigation_region_3d.h
+++ b/scene/3d/navigation_region_3d.h
@@ -57,6 +57,8 @@ public:
 	void set_layers(uint32_t p_layers);
 	uint32_t get_layers() const;
 
+	RID get_region_rid() const;
+
 	void set_navigation_mesh(const Ref<NavigationMesh> &p_navmesh);
 	Ref<NavigationMesh> get_navigation_mesh() const;
 


### PR DESCRIPTION
Adds functions to get the region RID assigned to a NavigationRegion2D/3D Node by the NavigationServer2D/3D.

Knowing the region RID is a requirement to make practical use of the RID returned/required by various NavigationServer functions like map_get_closest_point_owner().

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
