### PR TITLE
TileMap: Use const ref for all Vector2 parameters

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -852,7 +852,7 @@ void TileMap::_make_quadrant_dirty(Map<PosKey, Quadrant>::Element *Q, bool updat
 	}
 }
 
-void TileMap::set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x, bool p_flip_y, bool p_transpose, Vector2 p_autotile_coord) {
+void TileMap::set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x, bool p_flip_y, bool p_transpose, const Vector2 &p_autotile_coord) {
 	set_cell(p_pos.x, p_pos.y, p_tile, p_flip_x, p_flip_y, p_transpose, p_autotile_coord);
 }
 
@@ -863,7 +863,7 @@ void TileMap::_set_celld(const Vector2 &p_pos, const Dictionary &p_data) {
 	call("set_cell", args, 7, ce);
 }
 
-void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_y, bool p_transpose, Vector2 p_autotile_coord) {
+void TileMap::set_cell(int p_x, int p_y, int p_tile, bool p_flip_x, bool p_flip_y, bool p_transpose, const Vector2 &p_autotile_coord) {
 	PosKey pk(p_x, p_y);
 
 	Map<PosKey, Cell>::Element *E = tile_map.find(pk);

--- a/scene/2d/tile_map.h
+++ b/scene/2d/tile_map.h
@@ -256,7 +256,7 @@ public:
 	void set_quadrant_size(int p_size);
 	int get_quadrant_size() const;
 
-	void set_cell(int p_x, int p_y, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false, Vector2 p_autotile_coord = Vector2());
+	void set_cell(int p_x, int p_y, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false, const Vector2 &p_autotile_coord = Vector2());
 	int get_cell(int p_x, int p_y) const;
 	bool is_cell_x_flipped(int p_x, int p_y) const;
 	bool is_cell_y_flipped(int p_x, int p_y) const;
@@ -265,7 +265,7 @@ public:
 	Vector2 get_cell_autotile_coord(int p_x, int p_y) const;
 
 	void _set_celld(const Vector2 &p_pos, const Dictionary &p_data);
-	void set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false, Vector2 p_autotile_coord = Vector2());
+	void set_cellv(const Vector2 &p_pos, int p_tile, bool p_flip_x = false, bool p_flip_y = false, bool p_transpose = false, const Vector2 &p_autotile_coord = Vector2());
 	int get_cellv(const Vector2 &p_pos) const;
 
 	void make_bitmask_area_dirty(const Vector2 &p_pos);

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -469,9 +469,9 @@ TileSet::TileMode TileSet::tile_get_tile_mode(int p_id) const {
 	return tile_map[p_id].tile_mode;
 }
 
-void TileSet::autotile_set_icon_coordinate(int p_id, Vector2 coord) {
+void TileSet::autotile_set_icon_coordinate(int p_id, const Vector2 &p_coord) {
 	ERR_FAIL_COND_MSG(!tile_map.has(p_id), vformat("The TileSet doesn't have a tile with ID '%d'.", p_id));
-	tile_map[p_id].autotile_data.icon_coord = coord;
+	tile_map[p_id].autotile_data.icon_coord = p_coord;
 	emit_changed();
 }
 
@@ -492,7 +492,7 @@ int TileSet::autotile_get_spacing(int p_id) const {
 	return tile_map[p_id].autotile_data.spacing;
 }
 
-void TileSet::autotile_set_size(int p_id, Size2 p_size) {
+void TileSet::autotile_set_size(int p_id, const Size2 &p_size) {
 	ERR_FAIL_COND_MSG(!tile_map.has(p_id), vformat("The TileSet doesn't have a tile with ID '%d'.", p_id));
 	ERR_FAIL_COND(p_size.x <= 0 || p_size.y <= 0);
 	tile_map[p_id].autotile_data.size = p_size;
@@ -550,7 +550,7 @@ const Map<Vector2, int> &TileSet::autotile_get_z_index_map(int p_id) const {
 	return tile_map[p_id].autotile_data.z_index_map;
 }
 
-void TileSet::autotile_set_bitmask(int p_id, Vector2 p_coord, uint32_t p_flag) {
+void TileSet::autotile_set_bitmask(int p_id, const Vector2 &p_coord, uint32_t p_flag) {
 	ERR_FAIL_COND_MSG(!tile_map.has(p_id), vformat("The TileSet doesn't have a tile with ID '%d'.", p_id));
 	if (p_flag == 0) {
 		if (tile_map[p_id].autotile_data.flags.has(p_coord)) {
@@ -561,7 +561,7 @@ void TileSet::autotile_set_bitmask(int p_id, Vector2 p_coord, uint32_t p_flag) {
 	}
 }
 
-uint32_t TileSet::autotile_get_bitmask(int p_id, Vector2 p_coord) {
+uint32_t TileSet::autotile_get_bitmask(int p_id, const Vector2 &p_coord) {
 	ERR_FAIL_COND_V_MSG(!tile_map.has(p_id), 0, vformat("The TileSet doesn't have a tile with ID '%d'.", p_id));
 	if (!tile_map[p_id].autotile_data.flags.has(p_coord)) {
 		return 0;

--- a/scene/resources/tile_set.h
+++ b/scene/resources/tile_set.h
@@ -171,13 +171,13 @@ public:
 	void tile_set_tile_mode(int p_id, TileMode p_tile_mode);
 	TileMode tile_get_tile_mode(int p_id) const;
 
-	void autotile_set_icon_coordinate(int p_id, Vector2 coord);
+	void autotile_set_icon_coordinate(int p_id, const Vector2 &coord);
 	Vector2 autotile_get_icon_coordinate(int p_id) const;
 
 	void autotile_set_spacing(int p_id, int p_spacing);
 	int autotile_get_spacing(int p_id) const;
 
-	void autotile_set_size(int p_id, Size2 p_size);
+	void autotile_set_size(int p_id, const Size2 &p_size);
 	Size2 autotile_get_size(int p_id) const;
 
 	void autotile_clear_bitmask_map(int p_id);
@@ -189,8 +189,8 @@ public:
 	int autotile_get_z_index(int p_id, const Vector2 &p_coord);
 	const Map<Vector2, int> &autotile_get_z_index_map(int p_id) const;
 
-	void autotile_set_bitmask(int p_id, Vector2 p_coord, uint32_t p_flag);
-	uint32_t autotile_get_bitmask(int p_id, Vector2 p_coord);
+	void autotile_set_bitmask(int p_id, const Vector2 &p_coord, uint32_t p_flag);
+	uint32_t autotile_get_bitmask(int p_id, const Vector2 &p_coord);
 	const Map<Vector2, uint32_t> &autotile_get_bitmask_map(int p_id);
 	Vector2 autotile_get_subtile_for_bitmask(int p_id, uint16_t p_bitmask, const Node *p_tilemap_node = nullptr, const Vector2 &p_tile_location = Vector2());
 	Vector2 atlastile_get_subtile_by_priority(int p_id, const Node *p_tilemap_node = nullptr, const Vector2 &p_tile_location = Vector2());


### PR DESCRIPTION
Might optimize things slightly and possibly fix #58663, though I couldn't reproduce the regression.