### PR TITLE
[3.x] Add get_region_rid() to NavigationPolygonInstance and NavigationMeshInstance

### DIFF
--- a/doc/classes/NavigationMeshInstance.xml
+++ b/doc/classes/NavigationMeshInstance.xml
@@ -15,6 +15,12 @@
 				Bakes the [NavigationMesh]. The baking is done in a separate thread because navigation baking is not a cheap operation. This can be done at runtime. When it is completed, it automatically sets the new [NavigationMesh].
 			</description>
 		</method>
+		<method name="get_region_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of this region on the [NavigationServer]. Combined with [method NavigationServer.map_get_closest_point_owner] can be used to identify the [NavigationMeshInstance] closest to a point on the merged navigation map.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">

--- a/doc/classes/NavigationPolygonInstance.xml
+++ b/doc/classes/NavigationPolygonInstance.xml
@@ -7,6 +7,12 @@
 	<tutorials>
 	</tutorials>
 	<methods>
+		<method name="get_region_rid" qualifiers="const">
+			<return type="RID" />
+			<description>
+				Returns the [RID] of this region on the [Navigation2DServer]. Combined with [method Navigation2DServer.map_get_closest_point_owner] can be used to identify the [NavigationPolygonInstance] closest to a point on the merged navigation map.
+			</description>
+		</method>
 	</methods>
 	<members>
 		<member name="enabled" type="bool" setter="set_enabled" getter="is_enabled" default="true">

--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -381,6 +381,10 @@ bool NavigationPolygonInstance::is_enabled() const {
 	return enabled;
 }
 
+RID NavigationPolygonInstance::get_region_rid() const {
+	return region;
+}
+
 /////////////////////////////
 #ifdef TOOLS_ENABLED
 Rect2 NavigationPolygonInstance::_edit_get_rect() const {
@@ -531,6 +535,8 @@ void NavigationPolygonInstance::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &NavigationPolygonInstance::set_enabled);
 	ClassDB::bind_method(D_METHOD("is_enabled"), &NavigationPolygonInstance::is_enabled);
+
+	ClassDB::bind_method(D_METHOD("get_region_rid"), &NavigationPolygonInstance::get_region_rid);
 
 	ClassDB::bind_method(D_METHOD("_navpoly_changed"), &NavigationPolygonInstance::_navpoly_changed);
 

--- a/scene/2d/navigation_polygon.h
+++ b/scene/2d/navigation_polygon.h
@@ -116,6 +116,8 @@ public:
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;
 
+	RID get_region_rid() const;
+
 	void set_navigation_polygon(const Ref<NavigationPolygon> &p_navpoly);
 	Ref<NavigationPolygon> get_navigation_polygon() const;
 

--- a/scene/3d/navigation_mesh_instance.cpp
+++ b/scene/3d/navigation_mesh_instance.cpp
@@ -69,6 +69,10 @@ bool NavigationMeshInstance::is_enabled() const {
 	return enabled;
 }
 
+RID NavigationMeshInstance::get_region_rid() const {
+	return region;
+}
+
 /////////////////////////////
 
 void NavigationMeshInstance::_notification(int p_what) {
@@ -209,6 +213,8 @@ void NavigationMeshInstance::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_enabled", "enabled"), &NavigationMeshInstance::set_enabled);
 	ClassDB::bind_method(D_METHOD("is_enabled"), &NavigationMeshInstance::is_enabled);
+
+	ClassDB::bind_method(D_METHOD("get_region_rid"), &NavigationMeshInstance::get_region_rid);
 
 	ClassDB::bind_method(D_METHOD("bake_navigation_mesh"), &NavigationMeshInstance::bake_navigation_mesh);
 	ClassDB::bind_method(D_METHOD("_bake_finished", "nav_mesh"), &NavigationMeshInstance::_bake_finished);

--- a/scene/3d/navigation_mesh_instance.h
+++ b/scene/3d/navigation_mesh_instance.h
@@ -57,6 +57,8 @@ public:
 	void set_enabled(bool p_enabled);
 	bool is_enabled() const;
 
+	RID get_region_rid() const;
+
 	void set_navigation_mesh(const Ref<NavigationMesh> &p_navmesh);
 	Ref<NavigationMesh> get_navigation_mesh() const;
 


### PR DESCRIPTION
Godot 3.5 version of #60655

Adds functions to get the region RID assigned to a NavigationPolygonInstance / NavigationMeshInstance Node by the NavigationServer2D /NavigationServer.

Knowing the region RID is a requirement to make practical use of the RID returned/required by various NavigationServer functions like map_get_closest_point_owner().

The issues that this tries to resolve are only present in Godot 3.5 or higher. The backport of the new 4.0 navigationserver broke all the navigation related "owner" functions on a practical level. Those functions on versions before 3.5 returned the Navmesh holding Node in the SceneTree and are now returning an obscure RID that can't be mapped directly to a Node in the SceneTree. This made navigation addons that relied on identifying distinct navmeshes (e.g. my JumpLinks addon) unportable to Godot 3.5+ without a Godot custom build.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
