### PR TITLE
Improve Tween infinite loop detection

### DIFF
--- a/scene/animation/tween.h
+++ b/scene/animation/tween.h
@@ -116,6 +116,9 @@ private:
 	bool valid = false;
 	bool default_parallel = false;
 	bool parallel_enabled = false;
+#ifdef DEBUG_ENABLED
+	bool is_infinite = false;
+#endif
 
 	typedef real_t (*interpolater)(real_t t, real_t b, real_t c, real_t d);
 	static interpolater interpolaters[TRANS_MAX][EASE_MAX];


### PR DESCRIPTION
Regression from #57372

This is a perfectly valid code:
```GDScript
var tween := create_tween().set_loops()
tween.tween_interval(0.1)
tween.tween_callback(func(): print("test"))
```
Previously it would be detected as infinite loop, because the second step has 0 time and the loop detection worked for Tween step. I changed the detection to work for the whole update and only trigger when the Tween actually looped during the step. Twice, to be sure.