### PR TITLE
Fix incorrect placement of material sphere and mesh at the same time in material preview

### DIFF
--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -558,6 +558,8 @@ void SceneImportSettings::open_settings(const String &p_path, bool p_for_animati
 	node_map.clear();
 	defaults.clear();
 
+	mesh_preview->hide();
+
 	selected_id = "";
 	selected_type = "";
 


### PR DESCRIPTION
Fixes #60425 