### PR TITLE
Use forward-declarations in EditorPlugin where possible

### DIFF
--- a/editor/editor_audio_buses.h
+++ b/editor/editor_audio_buses.h
@@ -47,6 +47,7 @@
 #include "scene/gui/tree.h"
 
 class EditorAudioBuses;
+class EditorFileDialog;
 
 class EditorAudioBus : public PanelContainer {
 	GDCLASS(EditorAudioBus, PanelContainer);

--- a/editor/editor_build_profile.h
+++ b/editor/editor_build_profile.h
@@ -117,6 +117,7 @@ public:
 VARIANT_ENUM_CAST(EditorBuildProfile::BuildOption)
 VARIANT_ENUM_CAST(EditorBuildProfile::BuildOptionCategory)
 
+class EditorFileDialog;
 class EditorFileSystemDirectory;
 
 class EditorBuildProfileManager : public AcceptDialog {

--- a/editor/editor_feature_profile.h
+++ b/editor/editor_feature_profile.h
@@ -40,6 +40,8 @@
 #include "scene/gui/split_container.h"
 #include "scene/gui/tree.h"
 
+class EditorFileDialog;
+
 class EditorFeatureProfile : public RefCounted {
 	GDCLASS(EditorFeatureProfile, RefCounted);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -114,6 +114,7 @@
 #include "editor/import/audio_stream_import_settings.h"
 #include "editor/import/dynamic_font_import_settings.h"
 #include "editor/import/editor_import_collada.h"
+#include "editor/import/editor_import_plugin.h"
 #include "editor/import/resource_importer_bitmask.h"
 #include "editor/import/resource_importer_bmfont.h"
 #include "editor/import/resource_importer_csv_translation.h"

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -30,14 +30,18 @@
 
 #include "editor_plugin.h"
 
+#include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_command_palette.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_settings.h"
+#include "editor/editor_translation_parser.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/export/editor_export.h"
 #include "editor/filesystem_dock.h"
+#include "editor/import/editor_import_plugin.h"
+#include "editor/import/resource_importer_scene.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/node_3d_editor_plugin.h"
 #include "editor/plugins/script_editor_plugin.h"

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -32,32 +32,33 @@
 #define EDITOR_PLUGIN_H
 
 #include "core/io/config_file.h"
-#include "editor/debugger/editor_debugger_node.h"
-#include "editor/editor_inspector.h"
-#include "editor/editor_translation_parser.h"
-#include "editor/import/editor_import_plugin.h"
-#include "editor/import/resource_importer_scene.h"
-#include "editor/script_create_dialog.h"
 #include "scene/3d/camera_3d.h"
-#include "scene/main/node.h"
-#include "scene/resources/texture.h"
+#include "scene/gui/control.h"
 
 class Node3D;
-class Camera3D;
+class Button;
+class PopupMenu;
 class EditorCommandPalette;
-class EditorSelection;
 class EditorExport;
-class EditorSettings;
-class EditorImportPlugin;
 class EditorExportPlugin;
-class EditorNode3DGizmoPlugin;
-class EditorResourcePreview;
-class EditorUndoRedoManager;
 class EditorFileSystem;
-class EditorToolAddons;
+class EditorImportPlugin;
+class EditorInspector;
+class EditorInspectorPlugin;
+class EditorNode3DGizmoPlugin;
 class EditorPaths;
+class EditorResourcePreview;
+class EditorSceneFormatImporter;
+class EditorScenePostImportPlugin;
+class EditorSelection;
+class EditorSettings;
+class EditorToolAddons;
+class EditorTranslationParserPlugin;
+class EditorUndoRedoManager;
 class FileSystemDock;
+class ScriptCreateDialog;
 class ScriptEditor;
+class VBoxContainer;
 
 class EditorInterface : public Node {
 	GDCLASS(EditorInterface, Node);

--- a/editor/editor_run.cpp
+++ b/editor/editor_run.cpp
@@ -31,6 +31,7 @@
 #include "editor_run.h"
 
 #include "core/config/project_settings.h"
+#include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_node.h"
 #include "editor/editor_settings.h"
 #include "main/main.h"

--- a/editor/editor_undo_redo_manager.cpp
+++ b/editor/editor_undo_redo_manager.cpp
@@ -33,6 +33,7 @@
 #include "core/io/resource.h"
 #include "core/os/os.h"
 #include "core/templates/local_vector.h"
+#include "editor/debugger/editor_debugger_node.h"
 #include "editor/editor_log.h"
 #include "editor/editor_node.h"
 #include "scene/main/node.h"

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -42,6 +42,7 @@
 #include "editor/editor_resource_preview.h"
 #include "editor/editor_scale.h"
 #include "editor/editor_settings.h"
+#include "editor/import/resource_importer_scene.h"
 #include "editor/import_dock.h"
 #include "editor/scene_create_dialog.h"
 #include "editor/scene_tree_dock.h"

--- a/editor/import/audio_stream_import_settings.cpp
+++ b/editor/import/audio_stream_import_settings.cpp
@@ -32,6 +32,7 @@
 #include "editor/audio_stream_preview.h"
 #include "editor/editor_file_system.h"
 #include "editor/editor_scale.h"
+#include "scene/gui/check_box.h"
 
 AudioStreamImportSettings *AudioStreamImportSettings::singleton = nullptr;
 

--- a/editor/import/audio_stream_import_settings.h
+++ b/editor/import/audio_stream_import_settings.h
@@ -34,8 +34,11 @@
 #include "editor/editor_plugin.h"
 #include "scene/audio/audio_stream_player.h"
 #include "scene/gui/color_rect.h"
+#include "scene/gui/dialogs.h"
 #include "scene/gui/spin_box.h"
 #include "scene/resources/texture.h"
+
+class CheckBox;
 
 class AudioStreamImportSettings : public ConfirmationDialog {
 	GDCLASS(AudioStreamImportSettings, ConfirmationDialog);

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -36,6 +36,7 @@
 #include "editor/editor_plugin.h"
 #include "editor/editor_scale.h"
 #include "editor/project_settings_editor.h"
+#include "scene/gui/grid_container.h"
 
 void PluginConfigDialog::_clear_fields() {
 	name_edit->set_text("");

--- a/editor/plugins/abstract_polygon_2d_editor.h
+++ b/editor/plugins/abstract_polygon_2d_editor.h
@@ -36,6 +36,7 @@
 #include "scene/gui/box_container.h"
 
 class CanvasItemEditor;
+class ConfirmationDialog;
 
 class AbstractPolygon2DEditor : public HBoxContainer {
 	GDCLASS(AbstractPolygon2DEditor, HBoxContainer);

--- a/editor/plugins/animation_blend_space_1d_editor.h
+++ b/editor/plugins/animation_blend_space_1d_editor.h
@@ -40,7 +40,8 @@
 #include "scene/gui/separator.h"
 #include "scene/gui/tree.h"
 
-class EditorUndoRedoManager;
+class CheckBox;
+class PanelContainer;
 
 class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeBlendSpace1DEditor, AnimationTreeNodeEditorPlugin);

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -42,6 +42,7 @@
 #include "editor/editor_undo_redo_manager.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/animation/animation_player.h"
+#include "scene/gui/grid_container.h"
 #include "scene/gui/menu_button.h"
 #include "scene/gui/panel.h"
 #include "scene/main/window.h"

--- a/editor/plugins/animation_blend_space_2d_editor.h
+++ b/editor/plugins/animation_blend_space_2d_editor.h
@@ -40,6 +40,10 @@
 #include "scene/gui/separator.h"
 #include "scene/gui/tree.h"
 
+class CheckBox;
+class OptionButton;
+class PanelContainer;
+
 class EditorUndoRedoManager;
 
 class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {

--- a/editor/plugins/animation_blend_tree_editor_plugin.h
+++ b/editor/plugins/animation_blend_tree_editor_plugin.h
@@ -31,17 +31,22 @@
 #ifndef ANIMATION_BLEND_TREE_EDITOR_PLUGIN_H
 #define ANIMATION_BLEND_TREE_EDITOR_PLUGIN_H
 
-#include "editor/editor_plugin.h"
 #include "editor/plugins/animation_tree_editor_plugin.h"
 #include "scene/animation/animation_blend_tree.h"
 #include "scene/gui/button.h"
 #include "scene/gui/graph_edit.h"
+#include "scene/gui/panel_container.h"
 #include "scene/gui/popup.h"
 #include "scene/gui/tree.h"
 
+class AcceptDialog;
+class CheckBox;
 class ProgressBar;
 class EditorFileDialog;
+class EditorProperty;
 class EditorUndoRedoManager;
+class MenuButton;
+class PanelContainer;
 
 class AnimationNodeBlendTreeEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeBlendTreeEditor, AnimationTreeNodeEditorPlugin);

--- a/editor/plugins/animation_state_machine_editor.h
+++ b/editor/plugins/animation_state_machine_editor.h
@@ -31,16 +31,17 @@
 #ifndef ANIMATION_STATE_MACHINE_EDITOR_H
 #define ANIMATION_STATE_MACHINE_EDITOR_H
 
-#include "editor/editor_plugin.h"
 #include "editor/plugins/animation_tree_editor_plugin.h"
 #include "scene/animation/animation_node_state_machine.h"
-#include "scene/gui/button.h"
 #include "scene/gui/graph_edit.h"
 #include "scene/gui/popup.h"
 #include "scene/gui/tree.h"
 
+class ConfirmationDialog;
 class EditorFileDialog;
 class EditorUndoRedoManager;
+class OptionButton;
+class PanelContainer;
 
 class AnimationNodeStateMachineEditor : public AnimationTreeNodeEditorPlugin {
 	GDCLASS(AnimationNodeStateMachineEditor, AnimationTreeNodeEditorPlugin);

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -50,6 +50,9 @@
 #include "scene/gui/texture_button.h"
 #include "scene/main/http_request.h"
 
+class EditorFileDialog;
+class MenuButton;
+
 class EditorAssetLibraryItem : public PanelContainer {
 	GDCLASS(EditorAssetLibraryItem, PanelContainer);
 

--- a/editor/plugins/bit_map_editor_plugin.h
+++ b/editor/plugins/bit_map_editor_plugin.h
@@ -31,8 +31,11 @@
 #ifndef BIT_MAP_EDITOR_PLUGIN_H
 #define BIT_MAP_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "scene/resources/bit_map.h"
+
+class TextureRect;
 
 class BitMapEditor : public VBoxContainer {
 	GDCLASS(BitMapEditor, VBoxContainer);

--- a/editor/plugins/canvas_item_editor_plugin.h
+++ b/editor/plugins/canvas_item_editor_plugin.h
@@ -42,8 +42,11 @@
 #include "scene/gui/texture_rect.h"
 #include "scene/main/canvas_item.h"
 
+class AcceptDialog;
+class ConfirmationDialog;
 class EditorData;
 class CanvasItemEditorViewport;
+class MenuButton;
 class ViewPanner;
 
 class CanvasItemEditorSelectedItem : public Object {

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_settings.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
+#include "scene/gui/grid_container.h"
 #include "scene/gui/separator.h"
 
 // Inspector controls.

--- a/editor/plugins/control_editor_plugin.h
+++ b/editor/plugins/control_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef CONTROL_EDITOR_PLUGIN_H
 #define CONTROL_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "scene/gui/box_container.h"
 #include "scene/gui/button.h"
@@ -45,6 +46,7 @@
 #include "scene/gui/texture_rect.h"
 
 class EditorUndoRedoManager;
+class GridContainer;
 
 // Inspector controls.
 class ControlPositioningWarning : public MarginContainer {

--- a/editor/plugins/cpu_particles_2d_editor_plugin.h
+++ b/editor/plugins/cpu_particles_2d_editor_plugin.h
@@ -36,10 +36,13 @@
 #include "scene/2d/cpu_particles_2d.h"
 #include "scene/gui/box_container.h"
 
-class EditorPlugin;
+class CheckBox;
+class ConfirmationDialog;
 class SpinBox;
 class EditorFileDialog;
 class EditorUndoRedoManager;
+class MenuButton;
+class OptionButton;
 
 class CPUParticles2DEditorPlugin : public EditorPlugin {
 	GDCLASS(CPUParticles2DEditorPlugin, EditorPlugin);

--- a/editor/plugins/curve_editor_plugin.h
+++ b/editor/plugins/curve_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef CURVE_EDITOR_PLUGIN_H
 #define CURVE_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "editor/editor_resource_preview.h"
 #include "scene/resources/curve.h"

--- a/editor/plugins/gpu_particles_2d_editor_plugin.h
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.h
@@ -37,8 +37,12 @@
 #include "scene/gui/box_container.h"
 #include "scene/gui/spin_box.h"
 
+class CheckBox;
+class ConfirmationDialog;
 class EditorFileDialog;
 class EditorUndoRedoManager;
+class MenuButton;
+class OptionButton;
 
 class GPUParticles2DEditorPlugin : public EditorPlugin {
 	GDCLASS(GPUParticles2DEditorPlugin, EditorPlugin);

--- a/editor/plugins/gpu_particles_3d_editor_plugin.h
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.h
@@ -35,6 +35,10 @@
 #include "scene/3d/gpu_particles_3d.h"
 #include "scene/gui/spin_box.h"
 
+class ConfirmationDialog;
+class HBoxContainer;
+class MenuButton;
+class OptionButton;
 class SceneTreeDialog;
 
 class GPUParticles3DEditorBase : public Control {

--- a/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
+++ b/editor/plugins/gpu_particles_collision_sdf_editor_plugin.h
@@ -37,6 +37,7 @@
 
 struct EditorProgress;
 class EditorFileDialog;
+class HBoxContainer;
 
 class GPUParticlesCollisionSDF3DEditorPlugin : public EditorPlugin {
 	GDCLASS(GPUParticlesCollisionSDF3DEditorPlugin, EditorPlugin);

--- a/editor/plugins/gradient_editor_plugin.h
+++ b/editor/plugins/gradient_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef GRADIENT_EDITOR_PLUGIN_H
 #define GRADIENT_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "gradient_editor.h"
 

--- a/editor/plugins/gradient_texture_2d_editor_plugin.h
+++ b/editor/plugins/gradient_texture_2d_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef GRADIENT_TEXTURE_2D_EDITOR_PLUGIN_H
 #define GRADIENT_TEXTURE_2D_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "editor/editor_spin_slider.h"
 

--- a/editor/plugins/material_editor_plugin.h
+++ b/editor/plugins/material_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef MATERIAL_EDITOR_PLUGIN_H
 #define MATERIAL_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
 #include "scene/3d/camera_3d.h"

--- a/editor/plugins/mesh_editor_plugin.h
+++ b/editor/plugins/mesh_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef MESH_EDITOR_PLUGIN_H
 #define MESH_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "scene/3d/camera_3d.h"
 #include "scene/3d/light_3d.h"

--- a/editor/plugins/mesh_instance_3d_editor_plugin.h
+++ b/editor/plugins/mesh_instance_3d_editor_plugin.h
@@ -35,6 +35,10 @@
 #include "scene/3d/mesh_instance_3d.h"
 #include "scene/gui/spin_box.h"
 
+class AcceptDialog;
+class ConfirmationDialog;
+class MenuButton;
+
 class MeshInstance3DEditor : public Control {
 	GDCLASS(MeshInstance3DEditor, Control);
 

--- a/editor/plugins/multimesh_editor_plugin.h
+++ b/editor/plugins/multimesh_editor_plugin.h
@@ -36,6 +36,10 @@
 #include "scene/gui/slider.h"
 #include "scene/gui/spin_box.h"
 
+class AcceptDialog;
+class ConfirmationDialog;
+class MenuButton;
+class OptionButton;
 class SceneTreeDialog;
 
 class MultiMeshEditor : public Control {

--- a/editor/plugins/node_3d_editor_plugin.h
+++ b/editor/plugins/node_3d_editor_plugin.h
@@ -39,6 +39,7 @@
 #include "scene/3d/light_3d.h"
 #include "scene/3d/visual_instance_3d.h"
 #include "scene/3d/world_environment.h"
+#include "scene/gui/box_container.h"
 #include "scene/gui/color_picker.h"
 #include "scene/gui/panel_container.h"
 #include "scene/gui/spin_box.h"
@@ -47,9 +48,14 @@
 #include "scene/resources/fog_material.h"
 #include "scene/resources/sky_material.h"
 
+class AcceptDialog;
+class CheckBox;
+class ConfirmationDialog;
 class EditorData;
+class MenuButton;
 class Node3DEditor;
 class Node3DEditorViewport;
+class OptionButton;
 class SubViewportContainer;
 class DirectionalLight3D;
 class WorldEnvironment;

--- a/editor/plugins/path_2d_editor_plugin.h
+++ b/editor/plugins/path_2d_editor_plugin.h
@@ -33,10 +33,12 @@
 
 #include "editor/editor_plugin.h"
 #include "scene/2d/path_2d.h"
+#include "scene/gui/box_container.h"
 #include "scene/gui/separator.h"
 
 class CanvasItemEditor;
 class EditorUndoRedoManager;
+class MenuButton;
 
 class Path2DEditor : public HBoxContainer {
 	GDCLASS(Path2DEditor, HBoxContainer);

--- a/editor/plugins/path_3d_editor_plugin.h
+++ b/editor/plugins/path_3d_editor_plugin.h
@@ -37,6 +37,8 @@
 #include "scene/3d/path_3d.h"
 #include "scene/gui/separator.h"
 
+class MenuButton;
+
 class Path3DGizmo : public EditorNode3DGizmo {
 	GDCLASS(Path3DGizmo, EditorNode3DGizmo);
 

--- a/editor/plugins/polygon_2d_editor_plugin.h
+++ b/editor/plugins/polygon_2d_editor_plugin.h
@@ -33,11 +33,17 @@
 
 #include "editor/plugins/abstract_polygon_2d_editor.h"
 
+class AcceptDialog;
+class ButtonGroup;
+class HScrollBar;
 class HSlider;
+class MenuButton;
 class Panel;
 class ScrollContainer;
 class SpinBox;
+class TextureRect;
 class ViewPanner;
+class VScrollBar;
 
 class Polygon2DEditor : public AbstractPolygon2DEditor {
 	GDCLASS(Polygon2DEditor, AbstractPolygon2DEditor);

--- a/editor/plugins/polygon_3d_editor_plugin.h
+++ b/editor/plugins/polygon_3d_editor_plugin.h
@@ -34,10 +34,12 @@
 #include "editor/editor_plugin.h"
 #include "scene/3d/collision_polygon_3d.h"
 #include "scene/3d/mesh_instance_3d.h"
+#include "scene/gui/box_container.h"
 #include "scene/resources/immediate_mesh.h"
 
 class CanvasItemEditor;
 class EditorUndoRedoManager;
+class MenuButton;
 
 class Polygon3DEditor : public HBoxContainer {
 	GDCLASS(Polygon3DEditor, HBoxContainer);

--- a/editor/plugins/resource_preloader_editor_plugin.h
+++ b/editor/plugins/resource_preloader_editor_plugin.h
@@ -33,6 +33,7 @@
 
 #include "editor/editor_plugin.h"
 #include "scene/gui/dialogs.h"
+#include "scene/gui/panel_container.h"
 #include "scene/gui/tree.h"
 #include "scene/main/resource_preloader.h"
 

--- a/editor/plugins/root_motion_editor_plugin.cpp
+++ b/editor/plugins/root_motion_editor_plugin.cpp
@@ -30,6 +30,8 @@
 
 #include "root_motion_editor_plugin.h"
 #include "editor/editor_node.h"
+#include "scene/animation/animation_player.h"
+#include "scene/animation/animation_tree.h"
 #include "scene/main/window.h"
 
 void EditorPropertyRootMotion::_confirmed() {

--- a/editor/plugins/root_motion_editor_plugin.h
+++ b/editor/plugins/root_motion_editor_plugin.h
@@ -32,9 +32,8 @@
 #define ROOT_MOTION_EDITOR_PLUGIN_H
 
 #include "editor/editor_inspector.h"
-#include "editor/editor_spin_slider.h"
-#include "editor/property_selector.h"
-#include "scene/animation/animation_tree.h"
+
+class Tree;
 
 class EditorPropertyRootMotion : public EditorProperty {
 	GDCLASS(EditorPropertyRootMotion, EditorProperty);

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -48,6 +48,7 @@
 #include "scene/resources/text_file.h"
 
 class EditorFileDialog;
+class TextureRect;
 
 class EditorSyntaxHighlighter : public SyntaxHighlighter {
 	GDCLASS(EditorSyntaxHighlighter, SyntaxHighlighter)

--- a/editor/plugins/shader_editor_plugin.h
+++ b/editor/plugins/shader_editor_plugin.h
@@ -35,6 +35,7 @@
 
 class HSplitContainer;
 class ItemList;
+class MenuButton;
 class ShaderCreateDialog;
 class TabContainer;
 class TextShaderEditor;

--- a/editor/plugins/skeleton_2d_editor_plugin.h
+++ b/editor/plugins/skeleton_2d_editor_plugin.h
@@ -35,6 +35,9 @@
 #include "scene/2d/skeleton_2d.h"
 #include "scene/gui/spin_box.h"
 
+class AcceptDialog;
+class MenuButton;
+
 class Skeleton2DEditor : public Control {
 	GDCLASS(Skeleton2DEditor, Control);
 

--- a/editor/plugins/sprite_2d_editor_plugin.h
+++ b/editor/plugins/sprite_2d_editor_plugin.h
@@ -35,6 +35,10 @@
 #include "scene/2d/sprite_2d.h"
 #include "scene/gui/spin_box.h"
 
+class AcceptDialog;
+class ConfirmationDialog;
+class MenuButton;
+
 class Sprite2DEditor : public Control {
 	GDCLASS(Sprite2DEditor, Control);
 

--- a/editor/plugins/texture_3d_editor_plugin.h
+++ b/editor/plugins/texture_3d_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef TEXTURE_3D_EDITOR_PLUGIN_H
 #define TEXTURE_3D_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "scene/gui/spin_box.h"
 #include "scene/resources/shader.h"

--- a/editor/plugins/texture_editor_plugin.h
+++ b/editor/plugins/texture_editor_plugin.h
@@ -31,8 +31,12 @@
 #ifndef TEXTURE_EDITOR_PLUGIN_H
 #define TEXTURE_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
+#include "scene/gui/margin_container.h"
 #include "scene/resources/texture.h"
+
+class TextureRect;
 
 class TexturePreview : public MarginContainer {
 	GDCLASS(TexturePreview, MarginContainer);

--- a/editor/plugins/texture_layered_editor_plugin.h
+++ b/editor/plugins/texture_layered_editor_plugin.h
@@ -31,6 +31,7 @@
 #ifndef TEXTURE_LAYERED_EDITOR_PLUGIN_H
 #define TEXTURE_LAYERED_EDITOR_PLUGIN_H
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "scene/gui/spin_box.h"
 #include "scene/resources/shader.h"

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -32,6 +32,7 @@
 #define TEXTURE_REGION_EDITOR_PLUGIN_H
 
 #include "canvas_item_editor_plugin.h"
+#include "editor/editor_inspector.h"
 #include "editor/editor_plugin.h"
 #include "scene/2d/sprite_2d.h"
 #include "scene/3d/sprite_3d.h"
@@ -41,6 +42,7 @@
 
 class ViewPanner;
 class EditorUndoRedoManager;
+class OptionButton;
 
 class TextureRegionEditor : public AcceptDialog {
 	GDCLASS(TextureRegionEditor, AcceptDialog);

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -45,6 +45,8 @@
 #include "scene/resources/theme.h"
 
 class EditorFileDialog;
+class PanelContainer;
+class TabContainer;
 
 class ThemeItemImportTree : public VBoxContainer {
 	GDCLASS(ThemeItemImportTree, VBoxContainer);

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -32,20 +32,13 @@
 #define VISUAL_SHADER_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
+#include "editor/editor_properties.h"
 #include "editor/plugins/editor_resource_conversion_plugin.h"
 #include "scene/resources/visual_shader.h"
 
-class Button;
-class CodeEdit;
-class CodeHighlighter;
 class CurveEditor;
 class GraphEdit;
 class GraphNode;
-class PopupMenu;
-class PopupPanel;
-class RichTextLabel;
-class TextEdit;
-class Tree;
 
 class VisualShaderEditor;
 class EditorUndoRedoManager;

--- a/editor/plugins/voxel_gi_editor_plugin.h
+++ b/editor/plugins/voxel_gi_editor_plugin.h
@@ -37,6 +37,7 @@
 
 class EditorFileDialog;
 struct EditorProgress;
+class HBoxContainer;
 
 class VoxelGIEditorPlugin : public EditorPlugin {
 	GDCLASS(VoxelGIEditorPlugin, EditorPlugin);

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -46,6 +46,8 @@
 #include "scene/gui/tree.h"
 #include "scene_tree_editor.h"
 
+class TextureRect;
+
 #include "modules/modules_enabled.gen.h" // For regex.
 #ifdef MODULE_REGEX_ENABLED
 class RenameDialog;

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -85,6 +85,7 @@
 #endif
 
 #ifdef TOOLS_ENABLED
+#include "editor/debugger/editor_debugger_node.h"
 #include "editor/doc_data_class_path.gen.h"
 #include "editor/doc_tools.h"
 #include "editor/editor_node.h"

--- a/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
+++ b/modules/gltf/editor/editor_scene_exporter_gltf_plugin.h
@@ -36,6 +36,8 @@
 #include "editor/editor_plugin.h"
 #include "editor_scene_importer_gltf.h"
 
+class EditorFileDialog;
+
 class SceneExporterGLTFPlugin : public EditorPlugin {
 	GDCLASS(SceneExporterGLTFPlugin, EditorPlugin);
 

--- a/modules/gridmap/editor/grid_map_editor_plugin.h
+++ b/modules/gridmap/editor/grid_map_editor_plugin.h
@@ -35,11 +35,14 @@
 
 #include "../grid_map.h"
 #include "editor/editor_plugin.h"
+#include "scene/gui/box_container.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/slider.h"
 #include "scene/gui/spin_box.h"
 
+class ConfirmationDialog;
 class EditorUndoRedoManager;
+class MenuButton;
 class Node3DEditorPlugin;
 
 class GridMapEditor : public VBoxContainer {

--- a/modules/multiplayer/editor/replication_editor_plugin.cpp
+++ b/modules/multiplayer/editor/replication_editor_plugin.cpp
@@ -35,6 +35,7 @@
 #include "editor/editor_settings.h"
 #include "editor/editor_undo_redo_manager.h"
 #include "editor/inspector_dock.h"
+#include "editor/property_selector.h"
 #include "editor/scene_tree_editor.h"
 #include "modules/multiplayer/multiplayer_synchronizer.h"
 #include "scene/gui/dialogs.h"

--- a/modules/multiplayer/editor/replication_editor_plugin.h
+++ b/modules/multiplayer/editor/replication_editor_plugin.h
@@ -32,17 +32,17 @@
 #define REPLICATION_EDITOR_PLUGIN_H
 
 #include "editor/editor_plugin.h"
-
-#include "editor/editor_spin_slider.h"
-#include "editor/property_selector.h"
-
-#include "../scene_replication_config.h"
+#include "modules/multiplayer/scene_replication_config.h"
+#include "scene/gui/box_container.h"
 
 class ConfirmationDialog;
 class MultiplayerSynchronizer;
-class SceneTreeDialog;
+class AcceptDialog;
+class LineEdit;
 class Tree;
 class TreeItem;
+class PropertySelector;
+class SceneTreeDialog;
 
 class ReplicationEditor : public VBoxContainer {
 	GDCLASS(ReplicationEditor, VBoxContainer);

--- a/modules/navigation/editor/navigation_mesh_editor_plugin.h
+++ b/modules/navigation/editor/navigation_mesh_editor_plugin.h
@@ -35,6 +35,8 @@
 
 #include "editor/editor_plugin.h"
 
+class AcceptDialog;
+class HBoxContainer;
 class NavigationRegion3D;
 
 class NavigationMeshEditor : public Control {

--- a/modules/noise/editor/noise_editor_plugin.cpp
+++ b/modules/noise/editor/noise_editor_plugin.cpp
@@ -32,7 +32,9 @@
 
 #ifdef TOOLS_ENABLED
 
+#include "editor/editor_inspector.h"
 #include "editor/editor_scale.h"
+#include "scene/gui/texture_rect.h"
 
 #include "modules/noise/noise.h"
 #include "modules/noise/noise_texture_2d.h"


### PR DESCRIPTION
Extracted from #58506.
Follow up of #57306.
Follow up of #58136.

Reduce the number of EditorPlugin includes as much as possible (3 for now) to reduce the risks of recompiling all the editor plugins (so half the editor) by doing an unrelated changed. It probably speeds up a bit the compile time.

Also add some forward declarations in touched headers. 
