### PR TITLE
fix descriptions of map_to_world/world_to_map

### DIFF
--- a/modules/gridmap/doc_classes/GridMap.xml
+++ b/modules/gridmap/doc_classes/GridMap.xml
@@ -97,7 +97,7 @@
 			<return type="Vector3" />
 			<argument index="0" name="map_position" type="Vector3i" />
 			<description>
-				Returns the position of a grid cell in the GridMap's local coordinate space.
+				Returns the world position for the given grid cell coordinates.
 			</description>
 		</method>
 		<method name="resource_changed">
@@ -137,8 +137,7 @@
 			<return type="Vector3i" />
 			<argument index="0" name="world_position" type="Vector3" />
 			<description>
-				Returns the coordinates of the grid cell containing the given point.
-				[code]pos[/code] should be in the GridMap's local coordinate space.
+				Returns the grid coordinates of the grid cell located at the given world position.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
The description of map_to_world was explaining the method world_to_map and vice versa. Also I think these descriptions were pretty confusing.

I swapped the descriptions to match the actual methods and tried to make their functionality more clear.