### PR TITLE
[3.x] Backport inspector preview for `BitMap`

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -117,6 +117,7 @@
 #include "editor/plugins/asset_library_editor_plugin.h"
 #include "editor/plugins/audio_stream_editor_plugin.h"
 #include "editor/plugins/baked_lightmap_editor_plugin.h"
+#include "editor/plugins/bit_map_editor_plugin.h"
 #include "editor/plugins/camera_editor_plugin.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/collision_polygon_2d_editor_plugin.h"
@@ -7016,6 +7017,7 @@ EditorNode::EditorNode() {
 	add_editor_plugin(memnew(ViewportPreviewEditorPlugin(this)));
 	add_editor_plugin(memnew(GradientTexture2DEditorPlugin(this)));
 	add_editor_plugin(memnew(RayCast2DEditorPlugin(this)));
+	add_editor_plugin(memnew(BitMapEditorPlugin(this)));
 
 	for (int i = 0; i < EditorPlugins::get_plugin_count(); i++) {
 		add_editor_plugin(EditorPlugins::create(i, this));

--- a/editor/plugins/bit_map_editor_plugin.cpp
+++ b/editor/plugins/bit_map_editor_plugin.cpp
@@ -1,0 +1,86 @@
+/*************************************************************************/
+/*  bit_map_editor_plugin.cpp                                            */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "bit_map_editor_plugin.h"
+
+#include "editor/editor_scale.h"
+
+void BitMapEditor::setup(const Ref<BitMap> &p_bitmap) {
+	Ref<ImageTexture> texture;
+	texture.instance();
+	texture->create_from_image(p_bitmap->convert_to_image());
+	texture->set_flags(texture->get_flags() & (~VisualServer::TEXTURE_FLAG_FILTER));
+	texture_rect->set_texture(texture);
+
+	size_label->set_text(vformat(String::utf8("%s×%s"), p_bitmap->get_size().width, p_bitmap->get_size().height));
+}
+
+BitMapEditor::BitMapEditor() {
+	texture_rect = memnew(TextureRect);
+	texture_rect->set_stretch_mode(TextureRect::STRETCH_KEEP_ASPECT_CENTERED);
+	texture_rect->set_custom_minimum_size(Size2(0, 250) * EDSCALE);
+	add_child(texture_rect);
+
+	size_label = memnew(Label);
+	size_label->set_align(Label::ALIGN_RIGHT);
+	add_child(size_label);
+
+	// Reduce extra padding on top and bottom of size label.
+	Ref<StyleBoxEmpty> stylebox;
+	stylebox.instance();
+	stylebox->set_default_margin(MARGIN_RIGHT, 4 * EDSCALE);
+	size_label->add_style_override("normal", stylebox);
+}
+
+///////////////////////
+
+bool EditorInspectorPluginBitMap::can_handle(Object *p_object) {
+	return Object::cast_to<BitMap>(p_object) != nullptr;
+}
+
+void EditorInspectorPluginBitMap::parse_begin(Object *p_object) {
+	BitMap *bitmap = Object::cast_to<BitMap>(p_object);
+	if (!bitmap) {
+		return;
+	}
+	Ref<BitMap> bm(bitmap);
+
+	BitMapEditor *editor = memnew(BitMapEditor);
+	editor->setup(bm);
+	add_custom_control(editor);
+}
+
+///////////////////////
+
+BitMapEditorPlugin::BitMapEditorPlugin(EditorNode *p_editor) {
+	Ref<EditorInspectorPluginBitMap> plugin;
+	plugin.instance();
+	add_inspector_plugin(plugin);
+}

--- a/editor/plugins/bit_map_editor_plugin.h
+++ b/editor/plugins/bit_map_editor_plugin.h
@@ -1,0 +1,64 @@
+/*************************************************************************/
+/*  bit_map_editor_plugin.h                                              */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef BIT_MAP_PREVIEW_EDITOR_PLUGIN_H
+#define BIT_MAP_PREVIEW_EDITOR_PLUGIN_H
+
+#include "editor/editor_plugin.h"
+#include "scene/resources/bit_map.h"
+
+class BitMapEditor : public VBoxContainer {
+	GDCLASS(BitMapEditor, VBoxContainer);
+
+	TextureRect *texture_rect = nullptr;
+	Label *size_label = nullptr;
+
+public:
+	void setup(const Ref<BitMap> &p_bitmap);
+
+	BitMapEditor();
+};
+
+class EditorInspectorPluginBitMap : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorPluginBitMap, EditorInspectorPlugin);
+
+public:
+	virtual bool can_handle(Object *p_object);
+	virtual void parse_begin(Object *p_object);
+};
+
+class BitMapEditorPlugin : public EditorPlugin {
+	GDCLASS(BitMapEditorPlugin, EditorPlugin);
+
+public:
+	BitMapEditorPlugin(EditorNode *p_editor);
+};
+
+#endif // BIT_MAP_PREVIEW_EDITOR_PLUGIN_H


### PR DESCRIPTION
Backport of #60008

Texture filtering is turned off on the `TextureRect` in `master`. It's set on `ImageTexture` instead here in `3.x`.