### PR TITLE
Create onready variables when dropping nodes and holding Ctrl

### DIFF
--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -3655,6 +3655,31 @@ bool String::is_absolute_path() const {
 	}
 }
 
+static _FORCE_INLINE_ bool _is_valid_identifier_bit(int p_index, char32_t p_char) {
+	if (p_index == 0 && is_digit(p_char)) {
+		return false; // No start with number plz.
+	}
+	return is_ascii_identifier_char(p_char);
+}
+
+String String::validate_identifier() const {
+	if (is_empty()) {
+		return "_"; // Empty string is not a valid identifier;
+	}
+
+	String result = *this;
+	int len = result.length();
+	char32_t *buffer = result.ptrw();
+
+	for (int i = 0; i < len; i++) {
+		if (!_is_valid_identifier_bit(i, buffer[i])) {
+			buffer[i] = '_';
+		}
+	}
+
+	return result;
+}
+
 bool String::is_valid_identifier() const {
 	int len = length();
 
@@ -3665,15 +3690,7 @@ bool String::is_valid_identifier() const {
 	const char32_t *str = &operator[](0);
 
 	for (int i = 0; i < len; i++) {
-		if (i == 0) {
-			if (is_digit(str[0])) {
-				return false; // no start with number plz
-			}
-		}
-
-		bool valid_char = is_ascii_identifier_char(str[i]);
-
-		if (!valid_char) {
+		if (!_is_valid_identifier_bit(i, str[i])) {
 			return false;
 		}
 	}

--- a/core/string/ustring.h
+++ b/core/string/ustring.h
@@ -427,6 +427,7 @@ public:
 	// node functions
 	static const String invalid_node_name_characters;
 	String validate_node_name() const;
+	String validate_identifier() const;
 
 	bool is_valid_identifier() const;
 	bool is_valid_int() const;

--- a/tests/core/string/test_string.h
+++ b/tests/core/string/test_string.h
@@ -1447,6 +1447,20 @@ TEST_CASE("[String] validate_node_name") {
 	CHECK(name_with_invalid_chars.validate_node_name() == "Name with invalid characters removed!");
 }
 
+TEST_CASE("[String] validate_identifier") {
+	String empty_string;
+	CHECK(empty_string.validate_identifier() == "_");
+
+	String numeric_only = "12345";
+	CHECK(numeric_only.validate_identifier() == "_2345");
+
+	String name_with_spaces = "Name with spaces";
+	CHECK(name_with_spaces.validate_identifier() == "Name_with_spaces");
+
+	String name_with_invalid_chars = String::utf8("Invalid characters:@*#&世界");
+	CHECK(name_with_invalid_chars.validate_identifier() == "Invalid_characters_______");
+}
+
 TEST_CASE("[String] Variant indexed get") {
 	Variant s = String("abcd");
 	bool valid = false;


### PR DESCRIPTION
Like Ctrl drop files adds `preload` to the path, this PR makes Ctrl drop nodes inserts onready variable code.

https://user-images.githubusercontent.com/372476/166238619-ebfacfa8-b7b4-4b0a-b852-f2a7b267918e.mp4

Proof of concept and closes https://github.com/godotengine/godot-proposals/issues/4482