### PR TITLE
Fix resource dependence renaming.

### DIFF
--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1287,6 +1287,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		fw->store_8(b);
 		b = f->get_8();
 	}
+	f.unref();
 
 	bool all_ok = fw->get_error() == OK;
 


### PR DESCRIPTION
Fixes #60412

`ResourceLoaderText` is holding multiple copies of the `FileAccess` as well as `ResourceFormatLoaderText::rename_dependencies` have its own copy, so deleting old file and renaming new one is only possible when temporary copy of `ResourceLoaderText`  goes out of scope.
