### PR TITLE
Fix tscn not listed as Resource extension

### DIFF
--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1363,9 +1363,12 @@ void ResourceFormatLoaderText::get_recognized_extensions_for_type(const String &
 		return;
 	}
 
-	if (p_type == "PackedScene") {
+	if (ClassDB::is_parent_class("PackedScene", p_type)) {
 		p_extensions->push_back("tscn");
-	} else {
+	}
+
+	// Don't allow .tres for PackedScenes.
+	if (p_type != "PackedScene") {
 		p_extensions->push_back("tres");
 	}
 }


### PR DESCRIPTION
Fixes #7278
Other resource loaders use similar code.

I don't know why PackedScene is literally the only resource type that doesn't accept .tres, but I left it as it was.
EDIT:
But .res is available. Something is weird here.