### PR TITLE
Remove `RES` and `REF` typedefs in favor of spelled out `Ref<>`

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -58,15 +58,15 @@ ResourceLoader::ThreadLoadStatus ResourceLoader::load_threaded_get_status(const 
 	return (ThreadLoadStatus)tls;
 }
 
-RES ResourceLoader::load_threaded_get(const String &p_path) {
+Ref<Resource> ResourceLoader::load_threaded_get(const String &p_path) {
 	Error error;
-	RES res = ::ResourceLoader::load_threaded_get(p_path, &error);
+	Ref<Resource> res = ::ResourceLoader::load_threaded_get(p_path, &error);
 	return res;
 }
 
-RES ResourceLoader::load(const String &p_path, const String &p_type_hint, CacheMode p_cache_mode) {
+Ref<Resource> ResourceLoader::load(const String &p_path, const String &p_type_hint, CacheMode p_cache_mode) {
 	Error err = OK;
-	RES ret = ::ResourceLoader::load(p_path, p_type_hint, ResourceFormatLoader::CacheMode(p_cache_mode), &err);
+	Ref<Resource> ret = ::ResourceLoader::load(p_path, p_type_hint, ResourceFormatLoader::CacheMode(p_cache_mode), &err);
 
 	ERR_FAIL_COND_V_MSG(err != OK, ret, "Error loading resource: '" + p_path + "'.");
 	return ret;
@@ -137,12 +137,12 @@ void ResourceLoader::_bind_methods() {
 
 ////// ResourceSaver //////
 
-Error ResourceSaver::save(const String &p_path, const RES &p_resource, uint32_t p_flags) {
+Error ResourceSaver::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
 	ERR_FAIL_COND_V_MSG(p_resource.is_null(), ERR_INVALID_PARAMETER, "Can't save empty resource to path '" + String(p_path) + "'.");
 	return ::ResourceSaver::save(p_path, p_resource, p_flags);
 }
 
-Vector<String> ResourceSaver::get_recognized_extensions(const RES &p_resource) {
+Vector<String> ResourceSaver::get_recognized_extensions(const Ref<Resource> &p_resource) {
 	ERR_FAIL_COND_V_MSG(p_resource.is_null(), Vector<String>(), "It's not a reference to a valid Resource object.");
 	List<String> exts;
 	::ResourceSaver::get_recognized_extensions(p_resource, &exts);
@@ -1970,7 +1970,7 @@ Variant ClassDB::instantiate(const StringName &p_class) const {
 
 	RefCounted *r = Object::cast_to<RefCounted>(obj);
 	if (r) {
-		return REF(r);
+		return Ref<RefCounted>(r);
 	} else {
 		return obj;
 	}

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -73,9 +73,9 @@ public:
 
 	Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false);
 	ThreadLoadStatus load_threaded_get_status(const String &p_path, Array r_progress = Array());
-	RES load_threaded_get(const String &p_path);
+	Ref<Resource> load_threaded_get(const String &p_path);
 
-	RES load(const String &p_path, const String &p_type_hint = "", CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	Ref<Resource> load(const String &p_path, const String &p_type_hint = "", CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	Vector<String> get_recognized_extensions_for_type(const String &p_type);
 	void set_abort_on_missing_resources(bool p_abort);
 	PackedStringArray get_dependencies(const String &p_path);
@@ -107,8 +107,8 @@ public:
 
 	static ResourceSaver *get_singleton() { return singleton; }
 
-	Error save(const String &p_path, const RES &p_resource, uint32_t p_flags);
-	Vector<String> get_recognized_extensions(const RES &p_resource);
+	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags);
+	Vector<String> get_recognized_extensions(const Ref<Resource> &p_resource);
 
 	ResourceSaver() { singleton = this; }
 };

--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -141,7 +141,7 @@ void Crypto::_bind_methods() {
 
 /// Resource loader/saver
 
-RES ResourceFormatLoaderCrypto::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Ref<Resource> ResourceFormatLoaderCrypto::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	String el = p_path.get_extension().to_lower();
 	if (el == "crt") {
 		X509Certificate *cert = X509Certificate::create();
@@ -185,7 +185,7 @@ String ResourceFormatLoaderCrypto::get_resource_type(const String &p_path) const
 	return "";
 }
 
-Error ResourceFormatSaverCrypto::save(const String &p_path, const RES &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverCrypto::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
 	Error err;
 	Ref<X509Certificate> cert = p_resource;
 	Ref<CryptoKey> key = p_resource;
@@ -201,7 +201,7 @@ Error ResourceFormatSaverCrypto::save(const String &p_path, const RES &p_resourc
 	return OK;
 }
 
-void ResourceFormatSaverCrypto::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaverCrypto::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
 	const X509Certificate *cert = Object::cast_to<X509Certificate>(*p_resource);
 	const CryptoKey *key = Object::cast_to<CryptoKey>(*p_resource);
 	if (cert) {
@@ -215,6 +215,6 @@ void ResourceFormatSaverCrypto::get_recognized_extensions(const RES &p_resource,
 	}
 }
 
-bool ResourceFormatSaverCrypto::recognize(const RES &p_resource) const {
+bool ResourceFormatSaverCrypto::recognize(const Ref<Resource> &p_resource) const {
 	return Object::cast_to<X509Certificate>(*p_resource) || Object::cast_to<CryptoKey>(*p_resource);
 }

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -117,7 +117,7 @@ public:
 
 class ResourceFormatLoaderCrypto : public ResourceFormatLoader {
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;
@@ -125,9 +125,9 @@ public:
 
 class ResourceFormatSaverCrypto : public ResourceFormatSaver {
 public:
-	virtual Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = 0);
-	virtual void get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const;
-	virtual bool recognize(const RES &p_resource) const;
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
+	virtual bool recognize(const Ref<Resource> &p_resource) const;
 };
 
 #endif // CRYPTO_H

--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -356,7 +356,7 @@ void NativeExtension::initialize_native_extensions() {
 	gdnative_interface.classdb_unregister_extension_class = _unregister_extension_class;
 }
 
-RES NativeExtensionResourceLoader::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Ref<Resource> NativeExtensionResourceLoader::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	Ref<ConfigFile> config;
 	config.instantiate();
 
@@ -367,14 +367,14 @@ RES NativeExtensionResourceLoader::load(const String &p_path, const String &p_or
 	}
 
 	if (err != OK) {
-		return RES();
+		return Ref<Resource>();
 	}
 
 	if (!config->has_section_key("configuration", "entry_symbol")) {
 		if (r_error) {
 			*r_error = ERR_INVALID_DATA;
 		}
-		return RES();
+		return Ref<Resource>();
 	}
 
 	String entry_symbol = config->get_value("configuration", "entry_symbol");
@@ -406,7 +406,7 @@ RES NativeExtensionResourceLoader::load(const String &p_path, const String &p_or
 		if (r_error) {
 			*r_error = ERR_FILE_NOT_FOUND;
 		}
-		return RES();
+		return Ref<Resource>();
 	}
 
 	if (!library_path.is_resource_file()) {
@@ -423,7 +423,7 @@ RES NativeExtensionResourceLoader::load(const String &p_path, const String &p_or
 	}
 
 	if (err != OK) {
-		return RES();
+		return Ref<Resource>();
 	}
 
 	return lib;

--- a/core/extension/native_extension.h
+++ b/core/extension/native_extension.h
@@ -90,7 +90,7 @@ VARIANT_ENUM_CAST(NativeExtension::InitializationLevel)
 
 class NativeExtensionResourceLoader : public ResourceFormatLoader {
 public:
-	virtual RES load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -74,7 +74,7 @@ void (*Input::set_mouse_mode_func)(Input::MouseMode) = nullptr;
 Input::MouseMode (*Input::get_mouse_mode_func)() = nullptr;
 void (*Input::warp_mouse_func)(const Vector2 &p_position) = nullptr;
 Input::CursorShape (*Input::get_current_cursor_shape_func)() = nullptr;
-void (*Input::set_custom_mouse_cursor_func)(const RES &, Input::CursorShape, const Vector2 &) = nullptr;
+void (*Input::set_custom_mouse_cursor_func)(const Ref<Resource> &, Input::CursorShape, const Vector2 &) = nullptr;
 
 Input *Input::get_singleton() {
 	return singleton;
@@ -850,7 +850,7 @@ Input::CursorShape Input::get_current_cursor_shape() const {
 	return get_current_cursor_shape_func();
 }
 
-void Input::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
+void Input::set_custom_mouse_cursor(const Ref<Resource> &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
 	if (Engine::get_singleton()->is_editor_hint()) {
 		return;
 	}

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -219,7 +219,7 @@ private:
 	static void (*warp_mouse_func)(const Vector2 &p_position);
 
 	static CursorShape (*get_current_cursor_shape_func)();
-	static void (*set_custom_mouse_cursor_func)(const RES &, CursorShape, const Vector2 &);
+	static void (*set_custom_mouse_cursor_func)(const Ref<Resource> &, CursorShape, const Vector2 &);
 
 	EventDispatchFunc event_dispatch_function = nullptr;
 
@@ -305,7 +305,7 @@ public:
 	CursorShape get_default_cursor_shape() const;
 	void set_default_cursor_shape(CursorShape p_shape);
 	CursorShape get_current_cursor_shape() const;
-	void set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape = Input::CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
+	void set_custom_mouse_cursor(const Ref<Resource> &p_cursor, CursorShape p_shape = Input::CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
 
 	void parse_mapping(String p_mapping);
 	void joy_button(int p_device, JoyButton p_button, bool p_pressed);

--- a/core/io/image_loader.cpp
+++ b/core/io/image_loader.cpp
@@ -111,13 +111,13 @@ void ImageLoader::cleanup() {
 
 /////////////////
 
-RES ResourceFormatLoaderImage::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Ref<Resource> ResourceFormatLoaderImage::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	if (f.is_null()) {
 		if (r_error) {
 			*r_error = ERR_CANT_OPEN;
 		}
-		return RES();
+		return Ref<Resource>();
 	}
 
 	uint8_t header[4] = { 0, 0, 0, 0 };
@@ -128,7 +128,7 @@ RES ResourceFormatLoaderImage::load(const String &p_path, const String &p_origin
 		if (r_error) {
 			*r_error = ERR_FILE_UNRECOGNIZED;
 		}
-		ERR_FAIL_V(RES());
+		ERR_FAIL_V(Ref<Resource>());
 	}
 
 	String extension = f->get_pascal_string();
@@ -146,7 +146,7 @@ RES ResourceFormatLoaderImage::load(const String &p_path, const String &p_origin
 		if (r_error) {
 			*r_error = ERR_FILE_UNRECOGNIZED;
 		}
-		ERR_FAIL_V(RES());
+		ERR_FAIL_V(Ref<Resource>());
 	}
 
 	Ref<Image> image;
@@ -158,7 +158,7 @@ RES ResourceFormatLoaderImage::load(const String &p_path, const String &p_origin
 		if (r_error) {
 			*r_error = err;
 		}
-		return RES();
+		return Ref<Resource>();
 	}
 
 	if (r_error) {

--- a/core/io/image_loader.h
+++ b/core/io/image_loader.h
@@ -72,7 +72,7 @@ public:
 
 class ResourceFormatLoaderImage : public ResourceFormatLoader {
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/core/io/marshalls.cpp
+++ b/core/io/marshalls.cpp
@@ -601,7 +601,7 @@ Error decode_variant(Variant &r_variant, const uint8_t *p_buffer, int p_len, int
 					}
 
 					if (Object::cast_to<RefCounted>(obj)) {
-						REF ref = REF(Object::cast_to<RefCounted>(obj));
+						Ref<RefCounted> ref = Ref<RefCounted>(Object::cast_to<RefCounted>(obj));
 						r_variant = ref;
 					} else {
 						r_variant = obj;

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -208,13 +208,13 @@ Ref<Resource> Resource::duplicate_for_local_scene(Node *p_for_scene, Map<Ref<Res
 		}
 		Variant p = get(E.name);
 		if (p.get_type() == Variant::OBJECT) {
-			RES sr = p;
+			Ref<Resource> sr = p;
 			if (sr.is_valid()) {
 				if (sr->is_local_to_scene()) {
 					if (remap_cache.has(sr)) {
 						p = remap_cache[sr];
 					} else {
-						RES dupe = sr->duplicate_for_local_scene(p_for_scene, remap_cache);
+						Ref<Resource> dupe = sr->duplicate_for_local_scene(p_for_scene, remap_cache);
 						p = dupe;
 						remap_cache[sr] = dupe;
 					}
@@ -240,7 +240,7 @@ void Resource::configure_for_local_scene(Node *p_for_scene, Map<Ref<Resource>, R
 		}
 		Variant p = get(E.name);
 		if (p.get_type() == Variant::OBJECT) {
-			RES sr = p;
+			Ref<Resource> sr = p;
 			if (sr.is_valid()) {
 				if (sr->is_local_to_scene()) {
 					if (!remap_cache.has(sr)) {
@@ -269,7 +269,7 @@ Ref<Resource> Resource::duplicate(bool p_subresources) const {
 		if ((p.get_type() == Variant::DICTIONARY || p.get_type() == Variant::ARRAY)) {
 			r->set(E.name, p.duplicate(p_subresources));
 		} else if (p.get_type() == Variant::OBJECT && (p_subresources || (E.usage & PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE))) {
-			RES sr = p;
+			Ref<Resource> sr = p;
 			if (sr.is_valid()) {
 				r->set(E.name, sr->duplicate(p_subresources));
 			}
@@ -321,7 +321,7 @@ void Resource::notify_change_to_owners() {
 		Object *obj = ObjectDB::get_instance(E->get());
 		ERR_CONTINUE_MSG(!obj, "Object was deleted, while still owning a resource."); //wtf
 		//TODO store string
-		obj->call("resource_changed", RES(this));
+		obj->call("resource_changed", Ref<Resource>(this));
 	}
 }
 
@@ -335,7 +335,7 @@ uint32_t Resource::hash_edited_version() const {
 
 	for (const PropertyInfo &E : plist) {
 		if (E.usage & PROPERTY_USAGE_STORAGE && E.type == Variant::OBJECT && E.hint == PROPERTY_HINT_RESOURCE_TYPE) {
-			RES res = get(E.name);
+			Ref<Resource> res = get(E.name);
 			if (res.is_valid()) {
 				hash = hash_djb2_one_32(res->hash_edited_version(), hash);
 			}

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -150,8 +150,6 @@ public:
 	~Resource();
 };
 
-typedef Ref<Resource> RES;
-
 class ResourceCache {
 	friend class Resource;
 	friend class ResourceLoader; //need the lock

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -50,7 +50,7 @@ class ResourceLoaderBinary {
 	ResourceUID::ID uid = ResourceUID::INVALID_ID;
 
 	Vector<char> str_buf;
-	List<RES> resource_cache;
+	List<Ref<Resource>> resource_cache;
 
 	Vector<StringName> string_map;
 
@@ -60,7 +60,7 @@ class ResourceLoaderBinary {
 		String path;
 		String type;
 		ResourceUID::ID uid = ResourceUID::INVALID_ID;
-		RES cache;
+		Ref<Resource> cache;
 	};
 
 	bool using_named_scene_ids = false;
@@ -75,7 +75,7 @@ class ResourceLoaderBinary {
 	};
 
 	Vector<IntResource> internal_resources;
-	Map<String, RES> internal_index_cache;
+	Map<String, Ref<Resource>> internal_index_cache;
 
 	String get_unicode_string();
 	void _advance_padding(uint32_t p_len);
@@ -89,7 +89,7 @@ class ResourceLoaderBinary {
 
 	Error parse_variant(Variant &r_v);
 
-	Map<String, RES> dependency_cache;
+	Map<String, Ref<Resource>> dependency_cache;
 
 public:
 	void set_local_path(const String &p_local_path);
@@ -107,7 +107,7 @@ public:
 
 class ResourceFormatLoaderBinary : public ResourceFormatLoader {
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
@@ -127,20 +127,20 @@ class ResourceFormatSaverBinaryInstance {
 	bool big_endian;
 	bool takeover_paths;
 	String magic;
-	Set<RES> resource_set;
+	Set<Ref<Resource>> resource_set;
 
 	struct NonPersistentKey { //for resource properties generated on the fly
-		RES base;
+		Ref<Resource> base;
 		StringName property;
 		bool operator<(const NonPersistentKey &p_key) const { return base == p_key.base ? property < p_key.property : base < p_key.base; }
 	};
 
-	Map<NonPersistentKey, RES> non_persistent_map;
+	Map<NonPersistentKey, Ref<Resource>> non_persistent_map;
 	Map<StringName, int> string_map;
 	Vector<StringName> strings;
 
-	Map<RES, int> external_resources;
-	List<RES> saved_resources;
+	Map<Ref<Resource>, int> external_resources;
+	List<Ref<Resource>> saved_resources;
 
 	struct Property {
 		int name_idx;
@@ -167,16 +167,16 @@ public:
 		// Amount of reserved 32-bit fields in resource header
 		RESERVED_FIELDS = 11
 	};
-	Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = 0);
-	static void write_variant(Ref<FileAccess> f, const Variant &p_property, Map<RES, int> &resource_map, Map<RES, int> &external_resources, Map<StringName, int> &string_map, const PropertyInfo &p_hint = PropertyInfo());
+	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	static void write_variant(Ref<FileAccess> f, const Variant &p_property, Map<Ref<Resource>, int> &resource_map, Map<Ref<Resource>, int> &external_resources, Map<StringName, int> &string_map, const PropertyInfo &p_hint = PropertyInfo());
 };
 
 class ResourceFormatSaverBinary : public ResourceFormatSaver {
 public:
 	static ResourceFormatSaverBinary *singleton;
-	virtual Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = 0);
-	virtual bool recognize(const RES &p_resource) const;
-	virtual void get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const;
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual bool recognize(const Ref<Resource> &p_resource) const;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 
 	ResourceFormatSaverBinary();
 };

--- a/core/io/resource_importer.cpp
+++ b/core/io/resource_importer.cpp
@@ -114,7 +114,7 @@ Error ResourceFormatImporter::_get_path_and_type(const String &p_path, PathAndTy
 	return OK;
 }
 
-RES ResourceFormatImporter::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Ref<Resource> ResourceFormatImporter::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	PathAndType pat;
 	Error err = _get_path_and_type(p_path, pat);
 
@@ -123,10 +123,10 @@ RES ResourceFormatImporter::load(const String &p_path, const String &p_original_
 			*r_error = err;
 		}
 
-		return RES();
+		return Ref<Resource>();
 	}
 
-	RES res = ResourceLoader::_load(pat.path, p_path, pat.type, p_cache_mode, r_error, p_use_sub_threads, r_progress);
+	Ref<Resource> res = ResourceLoader::_load(pat.path, p_path, pat.type, p_cache_mode, r_error, p_use_sub_threads, r_progress);
 
 #ifdef TOOLS_ENABLED
 	if (res.is_valid()) {

--- a/core/io/resource_importer.h
+++ b/core/io/resource_importer.h
@@ -58,7 +58,7 @@ class ResourceFormatImporter : public ResourceFormatLoader {
 
 public:
 	static ResourceFormatImporter *get_singleton() { return singleton; }
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;
 	virtual bool recognize_path(const String &p_path, const String &p_for_type = String()) const;

--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -61,7 +61,7 @@ protected:
 	GDVIRTUAL4RC(Variant, _load, String, String, bool, int)
 
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual bool exists(const String &p_path) const;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;
@@ -85,7 +85,7 @@ typedef void (*ResourceLoadErrorNotify)(void *p_ud, const String &p_text);
 typedef void (*DependencyErrorNotify)(void *p_ud, const String &p_loading, const String &p_which, const String &p_type);
 
 typedef Error (*ResourceLoaderImport)(const String &p_path);
-typedef void (*ResourceLoadedCallback)(RES p_resource, const String &p_path);
+typedef void (*ResourceLoadedCallback)(Ref<Resource> p_resource, const String &p_path);
 
 class ResourceLoader {
 	enum {
@@ -121,7 +121,7 @@ private:
 	friend class ResourceFormatImporter;
 	friend class ResourceInteractiveLoader;
 	// Internal load function.
-	static RES _load(const String &p_path, const String &p_original_path, const String &p_type_hint, ResourceFormatLoader::CacheMode p_cache_mode, Error *r_error, bool p_use_sub_threads, float *r_progress);
+	static Ref<Resource> _load(const String &p_path, const String &p_original_path, const String &p_type_hint, ResourceFormatLoader::CacheMode p_cache_mode, Error *r_error, bool p_use_sub_threads, float *r_progress);
 
 	static ResourceLoadedCallback _loaded_callback;
 
@@ -138,7 +138,7 @@ private:
 		ThreadLoadStatus status = THREAD_LOAD_IN_PROGRESS;
 		ResourceFormatLoader::CacheMode cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE;
 		Error error = OK;
-		RES resource;
+		Ref<Resource> resource;
 		bool xl_remapped = false;
 		bool use_sub_threads = false;
 		bool start_next = true;
@@ -161,9 +161,9 @@ private:
 public:
 	static Error load_threaded_request(const String &p_path, const String &p_type_hint = "", bool p_use_sub_threads = false, ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE, const String &p_source_resource = String());
 	static ThreadLoadStatus load_threaded_get_status(const String &p_path, float *r_progress = nullptr);
-	static RES load_threaded_get(const String &p_path, Error *r_error = nullptr);
+	static Ref<Resource> load_threaded_get(const String &p_path, Error *r_error = nullptr);
 
-	static RES load(const String &p_path, const String &p_type_hint = "", ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE, Error *r_error = nullptr);
+	static Ref<Resource> load(const String &p_path, const String &p_type_hint = "", ResourceFormatLoader::CacheMode p_cache_mode = ResourceFormatLoader::CACHE_MODE_REUSE, Error *r_error = nullptr);
 	static bool exists(const String &p_path, const String &p_type_hint = "");
 
 	static void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions);

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -41,7 +41,7 @@ bool ResourceSaver::timestamp_on_save = false;
 ResourceSavedCallback ResourceSaver::save_callback = nullptr;
 ResourceSaverGetResourceIDForPath ResourceSaver::save_get_id_for_path = nullptr;
 
-Error ResourceFormatSaver::save(const String &p_path, const RES &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaver::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
 	int64_t res;
 	if (GDVIRTUAL_CALL(_save, p_path, p_resource, p_flags, res)) {
 		return (Error)res;
@@ -50,7 +50,7 @@ Error ResourceFormatSaver::save(const String &p_path, const RES &p_resource, uin
 	return ERR_METHOD_NOT_FOUND;
 }
 
-bool ResourceFormatSaver::recognize(const RES &p_resource) const {
+bool ResourceFormatSaver::recognize(const Ref<Resource> &p_resource) const {
 	bool success;
 	if (GDVIRTUAL_CALL(_recognize, p_resource, success)) {
 		return success;
@@ -59,7 +59,7 @@ bool ResourceFormatSaver::recognize(const RES &p_resource) const {
 	return false;
 }
 
-void ResourceFormatSaver::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaver::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
 	PackedStringArray exts;
 	if (GDVIRTUAL_CALL(_get_recognized_extensions, p_resource, exts)) {
 		const String *r = exts.ptr();
@@ -75,7 +75,7 @@ void ResourceFormatSaver::_bind_methods() {
 	GDVIRTUAL_BIND(_get_recognized_extensions, "resource");
 }
 
-Error ResourceSaver::save(const String &p_path, const RES &p_resource, uint32_t p_flags) {
+Error ResourceSaver::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
 	String extension = p_path.get_extension();
 	Error err = ERR_FILE_UNRECOGNIZED;
 
@@ -102,7 +102,7 @@ Error ResourceSaver::save(const String &p_path, const RES &p_resource, uint32_t 
 
 		String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 
-		RES rwcopy = p_resource;
+		Ref<Resource> rwcopy = p_resource;
 		if (p_flags & FLAG_CHANGE_PATH) {
 			rwcopy->set_path(local_path);
 		}
@@ -139,7 +139,7 @@ void ResourceSaver::set_save_callback(ResourceSavedCallback p_callback) {
 	save_callback = p_callback;
 }
 
-void ResourceSaver::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) {
+void ResourceSaver::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) {
 	for (int i = 0; i < saver_count; i++) {
 		saver[i]->get_recognized_extensions(p_resource, p_extensions);
 	}

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -41,14 +41,14 @@ class ResourceFormatSaver : public RefCounted {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL3R(int64_t, _save, String, RES, uint32_t)
-	GDVIRTUAL1RC(bool, _recognize, RES)
-	GDVIRTUAL1RC(Vector<String>, _get_recognized_extensions, RES)
+	GDVIRTUAL3R(int64_t, _save, String, Ref<Resource>, uint32_t)
+	GDVIRTUAL1RC(bool, _recognize, Ref<Resource>)
+	GDVIRTUAL1RC(Vector<String>, _get_recognized_extensions, Ref<Resource>)
 
 public:
-	virtual Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = 0);
-	virtual bool recognize(const RES &p_resource) const;
-	virtual void get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const;
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual bool recognize(const Ref<Resource> &p_resource) const;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 
 	virtual ~ResourceFormatSaver() {}
 };
@@ -81,8 +81,8 @@ public:
 		FLAG_REPLACE_SUBRESOURCE_PATHS = 64,
 	};
 
-	static Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = (uint32_t)FLAG_NONE);
-	static void get_recognized_extensions(const RES &p_resource, List<String> *p_extensions);
+	static Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = (uint32_t)FLAG_NONE);
+	static void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions);
 	static void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front = false);
 	static void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);
 

--- a/core/io/translation_loader_po.h
+++ b/core/io/translation_loader_po.h
@@ -37,8 +37,8 @@
 
 class TranslationLoaderPO : public ResourceFormatLoader {
 public:
-	static RES load_translation(Ref<FileAccess> f, Error *r_error = nullptr);
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	static Ref<Resource> load_translation(Ref<FileAccess> f, Error *r_error = nullptr);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -1476,7 +1476,7 @@ String Object::tr_n(const StringName &p_message, const StringName &p_message_plu
 void Object::_clear_internal_resource_paths(const Variant &p_var) {
 	switch (p_var.get_type()) {
 		case Variant::OBJECT: {
-			RES r = p_var;
+			Ref<Resource> r = p_var;
 			if (!r.is_valid()) {
 				return;
 			}

--- a/core/object/ref_counted.cpp
+++ b/core/object/ref_counted.cpp
@@ -108,7 +108,7 @@ Variant WeakRef::get_ref() const {
 	}
 	RefCounted *r = cast_to<RefCounted>(obj);
 	if (r) {
-		return REF(r);
+		return Ref<RefCounted>(r);
 	}
 
 	return obj;
@@ -118,7 +118,7 @@ void WeakRef::set_obj(Object *p_object) {
 	ref = p_object ? p_object->get_instance_id() : ObjectID();
 }
 
-void WeakRef::set_ref(const REF &p_ref) {
+void WeakRef::set_ref(const Ref<RefCounted> &p_ref) {
 	ref = p_ref.is_valid() ? p_ref->get_instance_id() : ObjectID();
 }
 

--- a/core/object/ref_counted.h
+++ b/core/object/ref_counted.h
@@ -234,8 +234,6 @@ public:
 	}
 };
 
-typedef Ref<RefCounted> REF;
-
 class WeakRef : public RefCounted {
 	GDCLASS(WeakRef, RefCounted);
 
@@ -247,7 +245,7 @@ protected:
 public:
 	Variant get_ref() const;
 	void set_obj(Object *p_object);
-	void set_ref(const REF &p_ref);
+	void set_ref(const Ref<RefCounted> &p_ref);
 
 	WeakRef() {}
 };

--- a/core/object/script_language.h
+++ b/core/object/script_language.h
@@ -323,7 +323,7 @@ public:
 		String display;
 		String insert_text;
 		Color font_color;
-		RES icon;
+		Ref<Resource> icon;
 		Variant default_value;
 		Vector<Pair<int, int>> matches;
 		int location = LOCATION_OTHER;

--- a/core/variant/variant_parser.cpp
+++ b/core/variant/variant_parser.cpp
@@ -806,7 +806,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				return ERR_PARSE_ERROR;
 			}
 
-			REF ref = REF(Object::cast_to<RefCounted>(obj));
+			Ref<RefCounted> ref = Ref<RefCounted>(Object::cast_to<RefCounted>(obj));
 
 			get_token(p_stream, token, line, r_err_str);
 			if (token.type != TK_COMMA) {
@@ -887,7 +887,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 			}
 
 			if (p_res_parser && id == "Resource" && p_res_parser->func) {
-				RES res;
+				Ref<Resource> res;
 				Error err = p_res_parser->func(p_res_parser->userdata, p_stream, res, line, r_err_str);
 				if (err) {
 					return err;
@@ -895,7 +895,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 
 				value = res;
 			} else if (p_res_parser && id == "ExtResource" && p_res_parser->ext_func) {
-				RES res;
+				Ref<Resource> res;
 				Error err = p_res_parser->ext_func(p_res_parser->userdata, p_stream, res, line, r_err_str);
 				if (err) {
 					return err;
@@ -903,7 +903,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 
 				value = res;
 			} else if (p_res_parser && id == "SubResource" && p_res_parser->sub_func) {
-				RES res;
+				Ref<Resource> res;
 				Error err = p_res_parser->sub_func(p_res_parser->userdata, p_stream, res, line, r_err_str);
 				if (err) {
 					return err;
@@ -914,7 +914,7 @@ Error VariantParser::parse_value(Token &token, Variant &value, Stream *p_stream,
 				get_token(p_stream, token, line, r_err_str);
 				if (token.type == TK_STRING) {
 					String path = token.value;
-					RES res = ResourceLoader::load(path);
+					Ref<Resource> res = ResourceLoader::load(path);
 					if (res.is_null()) {
 						r_err_str = "Can't load resource at path: '" + path + "'.";
 						return ERR_PARSE_ERROR;
@@ -1624,7 +1624,7 @@ Error VariantWriter::write(const Variant &p_variant, StoreStringFunc p_store_str
 				break; // don't save it
 			}
 
-			RES res = p_variant;
+			Ref<Resource> res = p_variant;
 			if (res.is_valid()) {
 				//is resource
 				String res_text;

--- a/core/variant/variant_parser.h
+++ b/core/variant/variant_parser.h
@@ -138,7 +138,7 @@ public:
 class VariantWriter {
 public:
 	typedef Error (*StoreStringFunc)(void *ud, const String &p_string);
-	typedef String (*EncodeResourceFunc)(void *ud, const RES &p_resource);
+	typedef String (*EncodeResourceFunc)(void *ud, const Ref<Resource> &p_resource);
 
 	static Error write(const Variant &p_variant, StoreStringFunc p_store_string_func, void *p_store_string_ud, EncodeResourceFunc p_encode_res_func, void *p_encode_res_ud, int recursion_count = 0);
 	static Error write_to_string(const Variant &p_variant, String &r_string, EncodeResourceFunc p_encode_res_func = nullptr, void *p_encode_res_ud = nullptr);

--- a/core/variant/variant_utility.cpp
+++ b/core/variant/variant_utility.cpp
@@ -435,7 +435,7 @@ struct VariantUtilityFunctions {
 			r_error.error = Callable::CallError::CALL_OK;
 			if (obj.is_ref_counted()) {
 				Ref<WeakRef> wref = memnew(WeakRef);
-				REF r = obj;
+				Ref<RefCounted> r = obj;
 				if (r.is_valid()) {
 					wref->set_ref(r);
 				}

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -2232,7 +2232,7 @@ void MaterialStorage::global_variables_load_settings(bool p_load_textures) {
 				}
 
 				String path = value;
-				RES resource = ResourceLoader::load(path);
+				Ref<Resource> resource = ResourceLoader::load(path);
 				ERR_CONTINUE(resource.is_null());
 				value = resource;
 			}

--- a/drivers/gles3/texture_loader_gles3.cpp
+++ b/drivers/gles3/texture_loader_gles3.cpp
@@ -37,7 +37,7 @@
 
 #include <string.h>
 
-RES ResourceFormatGLES2Texture::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Ref<Resource> ResourceFormatGLES2Texture::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	unsigned int width = 8;
 	unsigned int height = 8;
 

--- a/drivers/gles3/texture_loader_gles3.h
+++ b/drivers/gles3/texture_loader_gles3.h
@@ -38,7 +38,7 @@
 
 class ResourceFormatGLES2Texture : public ResourceFormatLoader {
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -35,7 +35,7 @@
 #include "drivers/png/png_driver_common.h"
 #include "scene/resources/texture.h"
 
-Error ResourceSaverPNG::save(const String &p_path, const RES &p_resource, uint32_t p_flags) {
+Error ResourceSaverPNG::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
 	Ref<ImageTexture> texture = p_resource;
 
 	ERR_FAIL_COND_V_MSG(!texture.is_valid(), ERR_INVALID_PARAMETER, "Can't save invalid texture as PNG.");
@@ -72,11 +72,11 @@ Vector<uint8_t> ResourceSaverPNG::save_image_to_buffer(const Ref<Image> &p_img) 
 	return buffer;
 }
 
-bool ResourceSaverPNG::recognize(const RES &p_resource) const {
+bool ResourceSaverPNG::recognize(const Ref<Resource> &p_resource) const {
 	return (p_resource.is_valid() && p_resource->is_class("ImageTexture"));
 }
 
-void ResourceSaverPNG::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {
+void ResourceSaverPNG::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
 	if (Object::cast_to<ImageTexture>(*p_resource)) {
 		p_extensions->push_back("png");
 	}

--- a/drivers/png/resource_saver_png.h
+++ b/drivers/png/resource_saver_png.h
@@ -39,9 +39,9 @@ public:
 	static Error save_image(const String &p_path, const Ref<Image> &p_img);
 	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img);
 
-	virtual Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = 0);
-	virtual bool recognize(const RES &p_resource) const;
-	virtual void get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const;
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual bool recognize(const Ref<Resource> &p_resource) const;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 
 	ResourceSaverPNG();
 };

--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -358,7 +358,7 @@ public:
 
 					setting = true;
 					undo_redo->create_action(TTR("Anim Change Keyframe Value"), UndoRedo::MERGE_ENDS);
-					RES prev = animation->audio_track_get_key_stream(track, key);
+					Ref<Resource> prev = animation->audio_track_get_key_stream(track, key);
 					undo_redo->add_do_method(animation.ptr(), "audio_track_set_key_stream", track, key, stream);
 					undo_redo->add_undo_method(animation.ptr(), "audio_track_set_key_stream", track, key, prev);
 					undo_redo->add_do_method(this, "_update_obj", animation);
@@ -992,7 +992,7 @@ public:
 								setting = true;
 								undo_redo->create_action(TTR("Anim Multi Change Keyframe Value"), UndoRedo::MERGE_ENDS);
 							}
-							RES prev = animation->audio_track_get_key_stream(track, key);
+							Ref<Resource> prev = animation->audio_track_get_key_stream(track, key);
 							undo_redo->add_do_method(animation.ptr(), "audio_track_set_key_stream", track, key, stream);
 							undo_redo->add_undo_method(animation.ptr(), "audio_track_set_key_stream", track, key, prev);
 							update_obj = true;
@@ -2528,7 +2528,7 @@ bool AnimationTrackEdit::_is_value_key_valid(const Variant &p_key_value, Variant
 		return false;
 	}
 
-	RES res;
+	Ref<Resource> res;
 	Vector<StringName> leftover_path;
 	Node *node = root->get_node_and_resource(animation->track_get_path(track), res, leftover_path);
 
@@ -2689,7 +2689,7 @@ String AnimationTrackEdit::get_tooltip(const Point2 &p_pos) const {
 				} break;
 				case Animation::TYPE_AUDIO: {
 					String stream_name = "null";
-					RES stream = animation->audio_track_get_key_stream(track, key_idx);
+					Ref<Resource> stream = animation->audio_track_get_key_stream(track, key_idx);
 					if (stream.is_valid()) {
 						if (stream->get_path().is_resource_file()) {
 							stream_name = stream->get_path().get_file();
@@ -4114,7 +4114,7 @@ PropertyInfo AnimationTrackEditor::_find_hint_for_track(int p_idx, NodePath &r_b
 		return PropertyInfo();
 	}
 
-	RES res;
+	Ref<Resource> res;
 	Vector<StringName> leftover_path;
 	Node *node = root->get_node_and_resource(path, res, leftover_path, true);
 
@@ -4410,7 +4410,7 @@ void AnimationTrackEditor::_update_tracks() {
 			NodePath path = animation->track_get_path(i);
 
 			if (root && root->has_node_and_resource(path)) {
-				RES res;
+				Ref<Resource> res;
 				NodePath base_path;
 				Vector<StringName> leftover_path;
 				Node *node = root->get_node_and_resource(path, res, leftover_path, true);
@@ -5016,7 +5016,7 @@ void AnimationTrackEditor::_insert_key_from_track(float p_ofs, int p_track) {
 		} break;
 		case Animation::TYPE_AUDIO: {
 			Dictionary ak;
-			ak["stream"] = RES();
+			ak["stream"] = Ref<Resource>();
 			ak["start_offset"] = 0;
 			ak["end_offset"] = 0;
 
@@ -6015,7 +6015,7 @@ void AnimationTrackEditor::_cleanup_animation(Ref<Animation> p_animation) {
 		Variant::Type valid_type = Variant::NIL;
 		Object *obj = nullptr;
 
-		RES res;
+		Ref<Resource> res;
 		Vector<StringName> leftover_path;
 
 		Node *node = root->get_node_and_resource(p_animation->track_get_path(i), res, leftover_path);

--- a/editor/debugger/editor_debugger_inspector.cpp
+++ b/editor/debugger/editor_debugger_inspector.cpp
@@ -157,7 +157,7 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 				if (path.contains("::")) {
 					// built-in resource
 					String base_path = path.get_slice("::", 0);
-					RES dependency = ResourceLoader::load(base_path);
+					Ref<Resource> dependency = ResourceLoader::load(base_path);
 					if (dependency.is_valid()) {
 						remote_dependencies.insert(dependency);
 					}
@@ -166,7 +166,7 @@ ObjectID EditorDebuggerInspector::add_object(const Array &p_arr) {
 
 				if (pinfo.hint_string == "Script") {
 					if (debugObj->get_script() != var) {
-						debugObj->set_script(REF());
+						debugObj->set_script(Ref<RefCounted>());
 						Ref<Script> script(var);
 						if (!script.is_null()) {
 							ScriptInstance *script_instance = script->placeholder_instance_create(debugObj);

--- a/editor/debugger/editor_debugger_inspector.h
+++ b/editor/debugger/editor_debugger_inspector.h
@@ -69,7 +69,7 @@ class EditorDebuggerInspector : public EditorInspector {
 private:
 	ObjectID inspected_object_id;
 	Map<ObjectID, EditorDebuggerRemoteObject *> remote_objects;
-	Set<RES> remote_dependencies;
+	Set<Ref<Resource>> remote_dependencies;
 	EditorDebuggerRemoteObject *variables = nullptr;
 
 	void _object_selected(ObjectID p_object);

--- a/editor/debugger/editor_debugger_node.h
+++ b/editor/debugger/editor_debugger_node.h
@@ -124,7 +124,7 @@ protected:
 	void _remote_object_requested(ObjectID p_id, int p_debugger);
 	void _save_node_requested(ObjectID p_id, const String &p_file, int p_debugger);
 
-	void _clear_execution(REF p_script) {
+	void _clear_execution(Ref<RefCounted> p_script) {
 		emit_signal(SNAME("clear_execution"), p_script);
 	}
 

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -396,7 +396,7 @@ void EditorAutoloadSettings::_autoload_text_changed(const String p_name) {
 }
 
 Node *EditorAutoloadSettings::_create_autoload(const String &p_path) {
-	RES res = ResourceLoader::load(p_path);
+	Ref<Resource> res = ResourceLoader::load(p_path);
 	ERR_FAIL_COND_V_MSG(res.is_null(), nullptr, "Can't autoload: " + p_path + ".");
 	Node *n = nullptr;
 	Ref<PackedScene> scn = res;

--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -82,7 +82,7 @@ void EditorSelectionHistory::add_object(ObjectID p_object, const String &p_prope
 	RefCounted *r = Object::cast_to<RefCounted>(obj);
 	_Object o;
 	if (r) {
-		o.ref = REF(r);
+		o.ref = Ref<RefCounted>(r);
 	}
 	o.object = p_object;
 	o.property = p_property;

--- a/editor/editor_data.h
+++ b/editor/editor_data.h
@@ -46,7 +46,7 @@ class EditorPlugin;
 class EditorSelectionHistory {
 	// Stores the object & property (if relevant).
 	struct _Object {
-		REF ref;
+		Ref<RefCounted> ref;
 		ObjectID object;
 		String property;
 		bool inspector_only = false;

--- a/editor/editor_folding.cpp
+++ b/editor/editor_folding.cpp
@@ -48,7 +48,7 @@ Vector<String> EditorFolding::_get_unfolds(const Object *p_object) {
 	return sections;
 }
 
-void EditorFolding::save_resource_folding(const RES &p_resource, const String &p_path) {
+void EditorFolding::save_resource_folding(const Ref<Resource> &p_resource, const String &p_path) {
 	Ref<ConfigFile> config;
 	config.instantiate();
 	Vector<String> unfolds = _get_unfolds(p_resource.ptr());
@@ -68,7 +68,7 @@ void EditorFolding::_set_unfolds(Object *p_object, const Vector<String> &p_unfol
 	}
 }
 
-void EditorFolding::load_resource_folding(RES p_resource, const String &p_path) {
+void EditorFolding::load_resource_folding(Ref<Resource> p_resource, const String &p_path) {
 	Ref<ConfigFile> config;
 	config.instantiate();
 
@@ -87,7 +87,7 @@ void EditorFolding::load_resource_folding(RES p_resource, const String &p_path) 
 	_set_unfolds(p_resource.ptr(), unfolds);
 }
 
-void EditorFolding::_fill_folds(const Node *p_root, const Node *p_node, Array &p_folds, Array &resource_folds, Array &nodes_folded, Set<RES> &resources) {
+void EditorFolding::_fill_folds(const Node *p_root, const Node *p_node, Array &p_folds, Array &resource_folds, Array &nodes_folded, Set<Ref<Resource>> &resources) {
 	if (p_root != p_node) {
 		if (!p_node->get_owner()) {
 			return; //not owned, bye
@@ -112,7 +112,7 @@ void EditorFolding::_fill_folds(const Node *p_root, const Node *p_node, Array &p
 	for (const PropertyInfo &E : plist) {
 		if (E.usage & PROPERTY_USAGE_EDITOR) {
 			if (E.type == Variant::OBJECT) {
-				RES res = p_node->get(E.name);
+				Ref<Resource> res = p_node->get(E.name);
 				if (res.is_valid() && !resources.has(res) && !res->get_path().is_empty() && !res->get_path().is_resource_file()) {
 					Vector<String> res_unfolds = _get_unfolds(res.ptr());
 					resource_folds.push_back(res->get_path());
@@ -140,7 +140,7 @@ void EditorFolding::save_scene_folding(const Node *p_scene, const String &p_path
 	config.instantiate();
 
 	Array unfolds, res_unfolds;
-	Set<RES> resources;
+	Set<Ref<Resource>> resources;
 	Array nodes_folded;
 	_fill_folds(p_scene, p_scene, unfolds, res_unfolds, nodes_folded, resources);
 
@@ -193,9 +193,9 @@ void EditorFolding::load_scene_folding(Node *p_scene, const String &p_path) {
 
 	for (int i = 0; i < res_unfolds.size(); i += 2) {
 		String path2 = res_unfolds[i];
-		RES res;
+		Ref<Resource> res;
 		if (ResourceCache::has(path2)) {
-			res = RES(ResourceCache::get(path2));
+			res = Ref<Resource>(ResourceCache::get(path2));
 		}
 		if (res.is_null()) {
 			continue;
@@ -220,7 +220,7 @@ bool EditorFolding::has_folding_data(const String &p_path) {
 	return FileAccess::exists(file);
 }
 
-void EditorFolding::_do_object_unfolds(Object *p_object, Set<RES> &resources) {
+void EditorFolding::_do_object_unfolds(Object *p_object, Set<Ref<Resource>> &resources) {
 	List<PropertyInfo> plist;
 	p_object->get_property_list(&plist);
 	String group_base;
@@ -261,7 +261,7 @@ void EditorFolding::_do_object_unfolds(Object *p_object, Set<RES> &resources) {
 			}
 
 			if (E.type == Variant::OBJECT) {
-				RES res = p_object->get(E.name);
+				Ref<Resource> res = p_object->get(E.name);
 				if (res.is_valid() && !resources.has(res) && !res->get_path().is_empty() && !res->get_path().is_resource_file()) {
 					resources.insert(res);
 					_do_object_unfolds(res.ptr(), resources);
@@ -275,7 +275,7 @@ void EditorFolding::_do_object_unfolds(Object *p_object, Set<RES> &resources) {
 	}
 }
 
-void EditorFolding::_do_node_unfolds(Node *p_root, Node *p_node, Set<RES> &resources) {
+void EditorFolding::_do_node_unfolds(Node *p_root, Node *p_node, Set<Ref<Resource>> &resources) {
 	if (p_root != p_node) {
 		if (!p_node->get_owner()) {
 			return; //not owned, bye
@@ -293,7 +293,7 @@ void EditorFolding::_do_node_unfolds(Node *p_root, Node *p_node, Set<RES> &resou
 }
 
 void EditorFolding::unfold_scene(Node *p_scene) {
-	Set<RES> resources;
+	Set<Ref<Resource>> resources;
 	_do_node_unfolds(p_scene, p_scene, resources);
 }
 

--- a/editor/editor_folding.h
+++ b/editor/editor_folding.h
@@ -37,14 +37,14 @@ class EditorFolding {
 	Vector<String> _get_unfolds(const Object *p_object);
 	void _set_unfolds(Object *p_object, const Vector<String> &p_unfolds);
 
-	void _fill_folds(const Node *p_root, const Node *p_node, Array &p_folds, Array &resource_folds, Array &nodes_folded, Set<RES> &resources);
+	void _fill_folds(const Node *p_root, const Node *p_node, Array &p_folds, Array &resource_folds, Array &nodes_folded, Set<Ref<Resource>> &resources);
 
-	void _do_object_unfolds(Object *p_object, Set<RES> &resources);
-	void _do_node_unfolds(Node *p_root, Node *p_node, Set<RES> &resources);
+	void _do_object_unfolds(Object *p_object, Set<Ref<Resource>> &resources);
+	void _do_node_unfolds(Node *p_root, Node *p_node, Set<Ref<Resource>> &resources);
 
 public:
-	void save_resource_folding(const RES &p_resource, const String &p_path);
-	void load_resource_folding(RES p_resource, const String &p_path);
+	void save_resource_folding(const Ref<Resource> &p_resource, const String &p_path);
+	void load_resource_folding(Ref<Resource> p_resource, const String &p_path);
 
 	void save_scene_folding(const Node *p_scene, const String &p_path);
 	void load_scene_folding(Node *p_scene, const String &p_path);

--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -3472,7 +3472,7 @@ void EditorInspector::_object_id_selected(const String &p_path, ObjectID p_id) {
 	emit_signal(SNAME("object_id_selected"), p_id);
 }
 
-void EditorInspector::_resource_selected(const String &p_path, RES p_resource) {
+void EditorInspector::_resource_selected(const String &p_path, Ref<Resource> p_resource) {
 	emit_signal(SNAME("resource_selected"), p_resource, p_path);
 }
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -490,7 +490,7 @@ class EditorInspector : public ScrollContainer {
 	void _property_checked(const String &p_path, bool p_checked);
 	void _property_pinned(const String &p_path, bool p_pinned);
 
-	void _resource_selected(const String &p_path, RES p_resource);
+	void _resource_selected(const String &p_path, Ref<Resource> p_resource);
 	void _property_selected(const String &p_path, int p_focusable);
 	void _object_id_selected(const String &p_path, ObjectID p_id);
 

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1178,7 +1178,7 @@ Error EditorNode::load_resource(const String &p_resource, bool p_ignore_broken_d
 
 	Error err;
 
-	RES res;
+	Ref<Resource> res;
 	if (ResourceLoader::exists(p_resource, "")) {
 		res = ResourceLoader::load(p_resource, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
 	} else if (textfile_extensions.has(p_resource.get_extension())) {
@@ -1420,7 +1420,7 @@ void EditorNode::_set_scene_metadata(const String &p_file, int p_idx) {
 	ERR_FAIL_COND_MSG(err != OK, "Cannot save config file to '" + path + "'.");
 }
 
-bool EditorNode::_find_and_save_resource(RES p_res, Map<RES, bool> &processed, int32_t flags) {
+bool EditorNode::_find_and_save_resource(Ref<Resource> p_res, Map<Ref<Resource>, bool> &processed, int32_t flags) {
 	if (p_res.is_null()) {
 		return false;
 	}
@@ -1446,7 +1446,7 @@ bool EditorNode::_find_and_save_resource(RES p_res, Map<RES, bool> &processed, i
 	}
 }
 
-bool EditorNode::_find_and_save_edited_subresources(Object *obj, Map<RES, bool> &processed, int32_t flags) {
+bool EditorNode::_find_and_save_edited_subresources(Object *obj, Map<Ref<Resource>, bool> &processed, int32_t flags) {
 	bool ret_changed = false;
 	List<PropertyInfo> pi;
 	obj->get_property_list(&pi);
@@ -1457,7 +1457,7 @@ bool EditorNode::_find_and_save_edited_subresources(Object *obj, Map<RES, bool> 
 
 		switch (E.type) {
 			case Variant::OBJECT: {
-				RES res = obj->get(E.name);
+				Ref<Resource> res = obj->get(E.name);
 
 				if (_find_and_save_resource(res, processed, flags)) {
 					ret_changed = true;
@@ -1469,7 +1469,7 @@ bool EditorNode::_find_and_save_edited_subresources(Object *obj, Map<RES, bool> 
 				int len = varray.size();
 				for (int i = 0; i < len; i++) {
 					const Variant &v = varray.get(i);
-					RES res = v;
+					Ref<Resource> res = v;
 					if (_find_and_save_resource(res, processed, flags)) {
 						ret_changed = true;
 					}
@@ -1482,7 +1482,7 @@ bool EditorNode::_find_and_save_edited_subresources(Object *obj, Map<RES, bool> 
 				d.get_key_list(&keys);
 				for (const Variant &F : keys) {
 					Variant v = d[F];
-					RES res = v;
+					Ref<Resource> res = v;
 					if (_find_and_save_resource(res, processed, flags)) {
 						ret_changed = true;
 					}
@@ -1496,7 +1496,7 @@ bool EditorNode::_find_and_save_edited_subresources(Object *obj, Map<RES, bool> 
 	return ret_changed;
 }
 
-void EditorNode::_save_edited_subresources(Node *scene, Map<RES, bool> &processed, int32_t flags) {
+void EditorNode::_save_edited_subresources(Node *scene, Map<Ref<Resource>, bool> &processed, int32_t flags) {
 	_find_and_save_edited_subresources(scene, processed, flags);
 
 	for (int i = 0; i < scene->get_child_count(); i++) {
@@ -1637,7 +1637,7 @@ static bool _find_edited_resources(const Ref<Resource> &p_resource, Set<Ref<Reso
 
 	for (const PropertyInfo &E : plist) {
 		if (E.type == Variant::OBJECT && E.usage & PROPERTY_USAGE_STORAGE && !(E.usage & PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT)) {
-			RES res = p_resource->get(E.name);
+			Ref<Resource> res = p_resource->get(E.name);
 			if (res.is_null()) {
 				continue;
 			}
@@ -2043,7 +2043,7 @@ bool EditorNode::item_has_editor(Object *p_object) {
 	return editor_data.get_subeditors(p_object).size() > 0;
 }
 
-void EditorNode::edit_item_resource(RES p_resource) {
+void EditorNode::edit_item_resource(Ref<Resource> p_resource) {
 	edit_item(p_resource.ptr());
 }
 
@@ -2128,7 +2128,7 @@ void EditorNode::_save_default_environment() {
 	Ref<Environment> fallback = get_tree()->get_root()->get_world_3d()->get_fallback_environment();
 
 	if (fallback.is_valid() && fallback->get_path().is_resource_file()) {
-		Map<RES, bool> processed;
+		Map<Ref<Resource>, bool> processed;
 		_find_and_save_edited_subresources(fallback.ptr(), processed, 0);
 		save_resource_in_path(fallback, fallback->get_path());
 	}
@@ -2166,7 +2166,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 	ObjectID current = editor_history.get_current();
 	Object *current_obj = current.is_valid() ? ObjectDB::get_instance(current) : nullptr;
 
-	RES res = Object::cast_to<Resource>(current_obj);
+	Ref<Resource> res = Object::cast_to<Resource>(current_obj);
 	if (p_skip_foreign && res.is_valid()) {
 		if (res->get_path().find("::") > -1 && res->get_path().get_slice("::", 0) != editor_data.get_scene_path(get_current_tab())) {
 			// Trying to edit resource that belongs to another scene; abort.
@@ -3762,7 +3762,7 @@ void EditorNode::open_request(const String &p_path) {
 	load_scene(p_path); // As it will be opened in separate tab.
 }
 
-void EditorNode::edit_foreign_resource(RES p_resource) {
+void EditorNode::edit_foreign_resource(Ref<Resource> p_resource) {
 	load_scene(p_resource->get_path().get_slice("::", 0));
 	InspectorDock::get_singleton()->call_deferred("edit_resource", p_resource);
 }
@@ -5699,7 +5699,7 @@ void EditorNode::_rendering_driver_selected(int p_which) {
 	_update_rendering_driver_color();
 }
 
-void EditorNode::_resource_saved(RES p_resource, const String &p_path) {
+void EditorNode::_resource_saved(Ref<Resource> p_resource, const String &p_path) {
 	if (EditorFileSystem::get_singleton()) {
 		EditorFileSystem::get_singleton()->update_file(p_path);
 	}
@@ -5707,7 +5707,7 @@ void EditorNode::_resource_saved(RES p_resource, const String &p_path) {
 	singleton->editor_folding.save_resource_folding(p_resource, p_path);
 }
 
-void EditorNode::_resource_loaded(RES p_resource, const String &p_path) {
+void EditorNode::_resource_loaded(Ref<Resource> p_resource, const String &p_path) {
 	singleton->editor_folding.load_resource_folding(p_resource, p_path);
 }
 
@@ -5905,7 +5905,7 @@ EditorNode::EditorNode() {
 			// Only if no touchscreen ui hint, disable emulation just in case.
 			id->set_emulate_touch_from_mouse(false);
 		}
-		DisplayServer::get_singleton()->cursor_set_custom_image(RES());
+		DisplayServer::get_singleton()->cursor_set_custom_image(Ref<Resource>());
 	}
 
 	singleton = this;

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -503,8 +503,8 @@ private:
 	static void _file_access_close_error_notify(const String &p_str);
 
 	static void _print_handler(void *p_this, const String &p_string, bool p_error);
-	static void _resource_saved(RES p_resource, const String &p_path);
-	static void _resource_loaded(RES p_resource, const String &p_path);
+	static void _resource_saved(Ref<Resource> p_resource, const String &p_path);
+	static void _resource_loaded(Ref<Resource> p_resource, const String &p_path);
 
 	void _build_icon_type_cache();
 
@@ -593,9 +593,9 @@ private:
 
 	void _remove_edited_scene(bool p_change_tab = true);
 	void _remove_scene(int index, bool p_change_tab = true);
-	bool _find_and_save_resource(RES p_res, Map<RES, bool> &processed, int32_t flags);
-	bool _find_and_save_edited_subresources(Object *obj, Map<RES, bool> &processed, int32_t flags);
-	void _save_edited_subresources(Node *scene, Map<RES, bool> &processed, int32_t flags);
+	bool _find_and_save_resource(Ref<Resource> p_res, Map<Ref<Resource>, bool> &processed, int32_t flags);
+	bool _find_and_save_edited_subresources(Object *obj, Map<Ref<Resource>, bool> &processed, int32_t flags);
+	void _save_edited_subresources(Node *scene, Map<Ref<Resource>, bool> &processed, int32_t flags);
 	void _mark_unsaved_scenes();
 
 	void _find_node_types(Node *p_node, int &count_2d, int &count_3d);
@@ -755,14 +755,14 @@ public:
 
 	void push_item(Object *p_object, const String &p_property = "", bool p_inspector_only = false);
 	void edit_item(Object *p_object);
-	void edit_item_resource(RES p_resource);
+	void edit_item_resource(Ref<Resource> p_resource);
 	bool item_has_editor(Object *p_object);
 	void hide_top_editors();
 
 	void select_editor_by_name(const String &p_name);
 
 	void open_request(const String &p_path);
-	void edit_foreign_resource(RES p_resource);
+	void edit_foreign_resource(Ref<Resource> p_resource);
 
 	bool is_changing_scene() const;
 

--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2974,7 +2974,7 @@ void EditorPropertyResource::_set_read_only(bool p_read_only) {
 	resource_picker->set_editable(!p_read_only);
 };
 
-void EditorPropertyResource::_resource_selected(const RES &p_resource, bool p_edit) {
+void EditorPropertyResource::_resource_selected(const Ref<Resource> &p_resource, bool p_edit) {
 	if (p_resource->is_built_in() && !p_resource->get_path().is_empty()) {
 		String parent = p_resource->get_path().get_slice("::", 0);
 		List<String> extensions;
@@ -2996,7 +2996,7 @@ void EditorPropertyResource::_resource_selected(const RES &p_resource, bool p_ed
 	}
 }
 
-void EditorPropertyResource::_resource_changed(const RES &p_resource) {
+void EditorPropertyResource::_resource_changed(const Ref<Resource> &p_resource) {
 	// Make visual script the correct type.
 	Ref<Script> s = p_resource;
 	if (get_edited_object() && s.is_valid()) {
@@ -3009,14 +3009,14 @@ void EditorPropertyResource::_resource_changed(const RES &p_resource) {
 		Resource *r = Object::cast_to<Resource>(get_edited_object());
 		if (r && r->get_path().is_resource_file()) {
 			EditorNode::get_singleton()->show_warning(TTR("Can't create a ViewportTexture on resources saved as a file.\nResource needs to belong to a scene."));
-			emit_changed(get_edited_property(), RES());
+			emit_changed(get_edited_property(), Ref<Resource>());
 			update_property();
 			return;
 		}
 
 		if (r && !r->is_local_to_scene()) {
 			EditorNode::get_singleton()->show_warning(TTR("Can't create a ViewportTexture on this resource because it's not set as local to scene.\nPlease switch on the 'local to scene' property on it (and all resources containing it up to a node)."));
-			emit_changed(get_edited_property(), RES());
+			emit_changed(get_edited_property(), Ref<Resource>());
 			update_property();
 			return;
 		}
@@ -3051,7 +3051,7 @@ void EditorPropertyResource::_sub_inspector_property_keyed(const String &p_prope
 	emit_signalp(SNAME("property_keyed_with_value"), argp, 3);
 }
 
-void EditorPropertyResource::_sub_inspector_resource_selected(const RES &p_resource, const String &p_property) {
+void EditorPropertyResource::_sub_inspector_resource_selected(const Ref<Resource> &p_resource, const String &p_property) {
 	emit_signal(SNAME("resource_selected"), String(get_edited_property()) + ":" + p_property, p_resource);
 }
 
@@ -3060,7 +3060,7 @@ void EditorPropertyResource::_sub_inspector_object_id_selected(int p_id) {
 }
 
 void EditorPropertyResource::_open_editor_pressed() {
-	RES res = get_edited_object()->get(get_edited_property());
+	Ref<Resource> res = get_edited_object()->get(get_edited_property());
 	if (res.is_valid()) {
 		// May clear the editor so do it deferred.
 		EditorNode::get_singleton()->call_deferred(SNAME("edit_item_resource"), res);
@@ -3072,7 +3072,7 @@ void EditorPropertyResource::_fold_other_editors(Object *p_self) {
 		return;
 	}
 
-	RES res = get_edited_object()->get(get_edited_property());
+	Ref<Resource> res = get_edited_object()->get(get_edited_property());
 	if (!res.is_valid()) {
 		return;
 	}
@@ -3218,7 +3218,7 @@ void EditorPropertyResource::setup(Object *p_object, const String &p_path, const
 }
 
 void EditorPropertyResource::update_property() {
-	RES res = get_edited_object()->get(get_edited_property());
+	Ref<Resource> res = get_edited_object()->get(get_edited_property());
 
 	if (use_sub_inspector) {
 		if (res.is_valid() != resource_picker->is_toggle_mode()) {

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -724,13 +724,13 @@ class EditorPropertyResource : public EditorProperty {
 	bool updating_theme = false;
 	bool opened_editor = false;
 
-	void _resource_selected(const RES &p_resource, bool p_edit);
-	void _resource_changed(const RES &p_resource);
+	void _resource_selected(const Ref<Resource> &p_resource, bool p_edit);
+	void _resource_changed(const Ref<Resource> &p_resource);
 
 	void _viewport_selected(const NodePath &p_path);
 
 	void _sub_inspector_property_keyed(const String &p_property, const Variant &p_value, bool p_advance);
-	void _sub_inspector_resource_selected(const RES &p_resource, const String &p_property);
+	void _sub_inspector_resource_selected(const Ref<Resource> &p_resource, const String &p_property);
 	void _sub_inspector_object_id_selected(int p_id);
 
 	void _open_editor_pressed();

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -455,7 +455,7 @@ void EditorPropertyArray::drop_data_fw(const Point2 &p_point, const Variant &p_d
 		for (int i = 0; i < files.size(); i++) {
 			String file = files[i];
 
-			RES res = ResourceLoader::load(file);
+			Ref<Resource> res = ResourceLoader::load(file);
 			if (res.is_valid()) {
 				array.call("push_back", res);
 			}

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -50,7 +50,7 @@ void EditorResourcePicker::_update_resource() {
 	preview_rect->set_texture(Ref<Texture2D>());
 	assign_button->set_custom_minimum_size(Size2(1, 1));
 
-	if (edited_resource == RES()) {
+	if (edited_resource == Ref<Resource>()) {
 		assign_button->set_icon(Ref<Texture2D>());
 		assign_button->set_text(TTR("[empty]"));
 		assign_button->set_tooltip("");
@@ -117,7 +117,7 @@ void EditorResourcePicker::_resource_selected() {
 }
 
 void EditorResourcePicker::_file_selected(const String &p_path) {
-	RES loaded_resource = ResourceLoader::load(p_path);
+	Ref<Resource> loaded_resource = ResourceLoader::load(p_path);
 	ERR_FAIL_COND_MSG(loaded_resource.is_null(), "Cannot load resource from path '" + p_path + "'.");
 
 	if (!base_type.is_empty()) {
@@ -184,7 +184,7 @@ void EditorResourcePicker::_update_menu_items() {
 	}
 
 	// Add options to copy/paste resource.
-	RES cb = EditorSettings::get_singleton()->get_resource_clipboard();
+	Ref<Resource> cb = EditorSettings::get_singleton()->get_resource_clipboard();
 	bool paste_valid = false;
 	if (cb.is_valid()) {
 		if (base_type.is_empty()) {
@@ -278,7 +278,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 		} break;
 
 		case OBJ_MENU_CLEAR: {
-			edited_resource = RES();
+			edited_resource = Ref<Resource>();
 			emit_signal(SNAME("resource_changed"), edited_resource);
 			_update_resource();
 		} break;
@@ -391,7 +391,7 @@ void EditorResourcePicker::_edit_menu_cbk(int p_which) {
 
 			EditorNode::get_editor_data().instantiate_object_properties(obj);
 
-			edited_resource = RES(resp);
+			edited_resource = Ref<Resource>(resp);
 			emit_signal(SNAME("resource_changed"), edited_resource);
 			_update_resource();
 		} break;
@@ -809,9 +809,9 @@ Vector<String> EditorResourcePicker::get_allowed_types() const {
 	return types;
 }
 
-void EditorResourcePicker::set_edited_resource(RES p_resource) {
+void EditorResourcePicker::set_edited_resource(Ref<Resource> p_resource) {
 	if (!p_resource.is_valid()) {
-		edited_resource = RES();
+		edited_resource = Ref<Resource>();
 		_update_resource();
 		return;
 	}
@@ -837,7 +837,7 @@ void EditorResourcePicker::set_edited_resource(RES p_resource) {
 	_update_resource();
 }
 
-RES EditorResourcePicker::get_edited_resource() {
+Ref<Resource> EditorResourcePicker::get_edited_resource() {
 	return edited_resource;
 }
 

--- a/editor/editor_resource_picker.h
+++ b/editor/editor_resource_picker.h
@@ -45,7 +45,7 @@ class EditorResourcePicker : public HBoxContainer {
 	static HashMap<StringName, List<StringName>> allowed_types_cache;
 
 	String base_type;
-	RES edited_resource;
+	Ref<Resource> edited_resource;
 
 	bool editable = true;
 	bool dropping = false;
@@ -113,8 +113,8 @@ public:
 	String get_base_type() const;
 	Vector<String> get_allowed_types() const;
 
-	void set_edited_resource(RES p_resource);
-	RES get_edited_resource();
+	void set_edited_resource(Ref<Resource> p_resource);
+	Ref<Resource> get_edited_resource();
 
 	void set_toggle_mode(bool p_enable);
 	bool is_toggle_mode() const;

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -48,7 +48,7 @@ bool EditorResourcePreviewGenerator::handles(const String &p_type) const {
 	ERR_FAIL_V_MSG(false, "EditorResourcePreviewGenerator::_handles needs to be overridden.");
 }
 
-Ref<Texture2D> EditorResourcePreviewGenerator::generate(const RES &p_from, const Size2 &p_size) const {
+Ref<Texture2D> EditorResourcePreviewGenerator::generate(const Ref<Resource> &p_from, const Size2 &p_size) const {
 	Ref<Texture2D> preview;
 	if (GDVIRTUAL_CALL(_generate, p_from, p_size, preview)) {
 		return preview;
@@ -62,7 +62,7 @@ Ref<Texture2D> EditorResourcePreviewGenerator::generate_from_path(const String &
 		return preview;
 	}
 
-	RES res = ResourceLoader::load(p_path);
+	Ref<Resource> res = ResourceLoader::load(p_path);
 	if (!res.is_valid()) {
 		return res;
 	}

--- a/editor/editor_resource_preview.h
+++ b/editor/editor_resource_preview.h
@@ -44,14 +44,14 @@ protected:
 	static void _bind_methods();
 
 	GDVIRTUAL1RC(bool, _handles, String)
-	GDVIRTUAL2RC(Ref<Texture2D>, _generate, RES, Vector2i)
+	GDVIRTUAL2RC(Ref<Texture2D>, _generate, Ref<Resource>, Vector2i)
 	GDVIRTUAL2RC(Ref<Texture2D>, _generate_from_path, String, Vector2i)
 	GDVIRTUAL0RC(bool, _generate_small_preview_automatically)
 	GDVIRTUAL0RC(bool, _can_generate_small_preview)
 
 public:
 	virtual bool handles(const String &p_type) const;
-	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const;
+	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size) const;
 	virtual Ref<Texture2D> generate_from_path(const String &p_path, const Size2 &p_size) const;
 
 	virtual bool generate_small_preview_automatically() const;

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -2080,7 +2080,7 @@ void FileSystemDock::_resource_created() {
 	}
 
 	EditorNode::get_singleton()->push_item(r);
-	EditorNode::get_singleton()->save_resource_as(RES(r), fpath);
+	EditorNode::get_singleton()->save_resource_as(Ref<Resource>(r), fpath);
 }
 
 void FileSystemDock::_search_changed(const String &p_text, const Control *p_from) {

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -181,7 +181,7 @@ Variant EditorScenePostImportPlugin::get_internal_option_update_view_required(In
 	return ret;
 }
 
-void EditorScenePostImportPlugin::internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, RES p_resource, const Dictionary &p_options) {
+void EditorScenePostImportPlugin::internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, Ref<Resource> p_resource, const Dictionary &p_options) {
 	current_options_dict = &p_options;
 	GDVIRTUAL_CALL(_internal_process, p_category, p_base_scene, p_node, p_resource);
 	current_options_dict = nullptr;
@@ -736,7 +736,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 	{
 		ObjectID node_id = p_node->get_instance_id();
 		for (int i = 0; i < post_importer_plugins.size(); i++) {
-			post_importer_plugins.write[i]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_NODE, p_root, p_node, RES(), node_settings);
+			post_importer_plugins.write[i]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_NODE, p_root, p_node, Ref<Resource>(), node_settings);
 			if (ObjectDB::get_instance(node_id) == nullptr) { //may have been erased, so do not continue
 				break;
 			}
@@ -746,7 +746,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 	if (Object::cast_to<ImporterMeshInstance3D>(p_node)) {
 		ObjectID node_id = p_node->get_instance_id();
 		for (int i = 0; i < post_importer_plugins.size(); i++) {
-			post_importer_plugins.write[i]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE, p_root, p_node, RES(), node_settings);
+			post_importer_plugins.write[i]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_MESH_3D_NODE, p_root, p_node, Ref<Resource>(), node_settings);
 			if (ObjectDB::get_instance(node_id) == nullptr) { //may have been erased, so do not continue
 				break;
 			}
@@ -953,7 +953,7 @@ Node *ResourceImporterScene::_post_fix_node(Node *p_node, Node *p_root, Map<Ref<
 		}
 
 		for (int i = 0; i < post_importer_plugins.size(); i++) {
-			post_importer_plugins.write[i]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_ANIMATION_NODE, p_root, p_node, RES(), node_settings);
+			post_importer_plugins.write[i]->internal_process(EditorScenePostImportPlugin::INTERNAL_IMPORT_CATEGORY_ANIMATION_NODE, p_root, p_node, Ref<Resource>(), node_settings);
 		}
 
 		bool use_optimizer = node_settings["optimizer/enabled"];

--- a/editor/import/resource_importer_scene.h
+++ b/editor/import/resource_importer_scene.h
@@ -119,7 +119,7 @@ protected:
 	GDVIRTUAL1(_get_internal_import_options, int)
 	GDVIRTUAL3RC(Variant, _get_internal_option_visibility, int, bool, String)
 	GDVIRTUAL2RC(Variant, _get_internal_option_update_view_required, int, String)
-	GDVIRTUAL4(_internal_process, int, Node *, Node *, RES)
+	GDVIRTUAL4(_internal_process, int, Node *, Node *, Ref<Resource>)
 	GDVIRTUAL1(_get_import_options, String)
 	GDVIRTUAL3RC(Variant, _get_option_visibility, String, bool, String)
 	GDVIRTUAL1(_pre_process, Node *)
@@ -136,7 +136,7 @@ public:
 	virtual Variant get_internal_option_visibility(InternalImportCategory p_category, bool p_for_animation, const String &p_option, const Map<StringName, Variant> &p_options) const;
 	virtual Variant get_internal_option_update_view_required(InternalImportCategory p_category, const String &p_option, const Map<StringName, Variant> &p_options) const;
 
-	virtual void internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, RES p_resource, const Dictionary &p_options);
+	virtual void internal_process(InternalImportCategory p_category, Node *p_base_scene, Node *p_node, Ref<Resource> p_resource, const Dictionary &p_options);
 
 	virtual void get_import_options(const String &p_path, List<ResourceImporter::ImportOption> *r_options);
 	virtual Variant get_option_visibility(const String &p_path, bool p_for_animation, const String &p_option, const Map<StringName, Variant> &p_options) const;

--- a/editor/inspector_dock.cpp
+++ b/editor/inspector_dock.cpp
@@ -117,8 +117,8 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 						}
 
 						Variant v = current->get(E->get().name);
-						REF ref = v;
-						RES res = ref;
+						Ref<RefCounted> ref = v;
+						Ref<Resource> res = ref;
 						if (v.is_ref_counted() && ref.is_valid() && res.is_valid()) {
 							// Valid resource which would be duplicated if action is confirmed.
 							resource_propnames.append(E->get().name);
@@ -149,7 +149,7 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 				if (current) {
 					List<PropertyInfo> props;
 					current->get_property_list(&props);
-					Map<RES, RES> duplicates;
+					Map<Ref<Resource>, Ref<Resource>> duplicates;
 					for (const PropertyInfo &prop_info : props) {
 						if (!(prop_info.usage & PROPERTY_USAGE_STORAGE)) {
 							continue;
@@ -157,9 +157,9 @@ void InspectorDock::_menu_option_confirm(int p_option, bool p_confirmed) {
 
 						Variant v = current->get(prop_info.name);
 						if (v.is_ref_counted()) {
-							REF ref = v;
+							Ref<RefCounted> ref = v;
 							if (ref.is_valid()) {
-								RES res = ref;
+								Ref<Resource> res = ref;
 								if (res.is_valid()) {
 									if (!duplicates.has(res)) {
 										duplicates[res] = res->duplicate();
@@ -231,7 +231,7 @@ void InspectorDock::_load_resource(const String &p_type) {
 }
 
 void InspectorDock::_resource_file_selected(String p_file) {
-	RES res;
+	Ref<Resource> res;
 	if (ResourceLoader::exists(p_file, "")) {
 		res = ResourceLoader::load(p_file);
 	} else {
@@ -255,7 +255,7 @@ void InspectorDock::_save_resource(bool save_as) {
 
 	ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj));
 
-	RES current_res = RES(Object::cast_to<Resource>(current_obj));
+	Ref<Resource> current_res = Ref<Resource>(Object::cast_to<Resource>(current_obj));
 
 	if (save_as) {
 		EditorNode::get_singleton()->save_resource_as(current_res);
@@ -270,7 +270,7 @@ void InspectorDock::_unref_resource() {
 
 	ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj));
 
-	RES current_res = RES(Object::cast_to<Resource>(current_obj));
+	Ref<Resource> current_res = Ref<Resource>(Object::cast_to<Resource>(current_obj));
 	current_res->set_path("");
 	EditorNode::get_singleton()->edit_current();
 }
@@ -281,20 +281,20 @@ void InspectorDock::_copy_resource() {
 
 	ERR_FAIL_COND(!Object::cast_to<Resource>(current_obj));
 
-	RES current_res = RES(Object::cast_to<Resource>(current_obj));
+	Ref<Resource> current_res = Ref<Resource>(Object::cast_to<Resource>(current_obj));
 
 	EditorSettings::get_singleton()->set_resource_clipboard(current_res);
 }
 
 void InspectorDock::_paste_resource() {
-	RES r = EditorSettings::get_singleton()->get_resource_clipboard();
+	Ref<Resource> r = EditorSettings::get_singleton()->get_resource_clipboard();
 	if (r.is_valid()) {
 		EditorNode::get_singleton()->push_item(EditorSettings::get_singleton()->get_resource_clipboard().ptr(), String());
 	}
 }
 
 void InspectorDock::_prepare_resource_extra_popup() {
-	RES r = EditorSettings::get_singleton()->get_resource_clipboard();
+	Ref<Resource> r = EditorSettings::get_singleton()->get_resource_clipboard();
 	PopupMenu *popup = resource_extra_button->get_popup();
 	popup->set_item_disabled(popup->get_item_index(RESOURCE_EDIT_CLIPBOARD), r.is_null());
 }
@@ -370,12 +370,12 @@ void InspectorDock::_resource_created() {
 	EditorNode::get_singleton()->push_item(r);
 }
 
-void InspectorDock::_resource_selected(const RES &p_res, const String &p_property) {
+void InspectorDock::_resource_selected(const Ref<Resource> &p_res, const String &p_property) {
 	if (p_res.is_null()) {
 		return;
 	}
 
-	RES r = p_res;
+	Ref<Resource> r = p_res;
 	EditorNode::get_singleton()->push_item(r.operator->(), p_property);
 }
 

--- a/editor/inspector_dock.h
+++ b/editor/inspector_dock.h
@@ -118,7 +118,7 @@ class InspectorDock : public VBoxContainer {
 
 	void _warning_pressed();
 	void _resource_created();
-	void _resource_selected(const RES &p_res, const String &p_property);
+	void _resource_selected(const Ref<Resource> &p_res, const String &p_property);
 	void _edit_forward();
 	void _edit_back();
 	void _menu_collapseall();

--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -5393,7 +5393,7 @@ void CanvasItemEditorViewport::_create_preview(const Vector<String> &files) cons
 	bool add_preview = false;
 	for (int i = 0; i < files.size(); i++) {
 		String path = files[i];
-		RES res = ResourceLoader::load(path);
+		Ref<Resource> res = ResourceLoader::load(path);
 		ERR_FAIL_COND(res.is_null());
 		Ref<Texture2D> texture = Ref<Texture2D>(Object::cast_to<Texture2D>(*res));
 		Ref<PackedScene> scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*res));
@@ -5588,7 +5588,7 @@ void CanvasItemEditorViewport::_perform_drop_data() {
 
 	for (int i = 0; i < selected_files.size(); i++) {
 		String path = selected_files[i];
-		RES res = ResourceLoader::load(path);
+		Ref<Resource> res = ResourceLoader::load(path);
 		if (res.is_null()) {
 			continue;
 		}
@@ -5643,7 +5643,7 @@ bool CanvasItemEditorViewport::can_drop_data(const Point2 &p_point, const Varian
 			for (int i = 0; i < files.size(); i++) {
 				// Check if dragged files with texture or scene extension can be created at least once.
 				if (texture_extensions.find(files[i].get_extension()) || scene_extensions.find(files[i].get_extension())) {
-					RES res = ResourceLoader::load(files[i]);
+					Ref<Resource> res = ResourceLoader::load(files[i]);
 					if (res.is_null()) {
 						continue;
 					}

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -79,7 +79,7 @@ bool EditorTexturePreviewPlugin::generate_small_preview_automatically() const {
 	return true;
 }
 
-Ref<Texture2D> EditorTexturePreviewPlugin::generate(const RES &p_from, const Size2 &p_size) const {
+Ref<Texture2D> EditorTexturePreviewPlugin::generate(const Ref<Resource> &p_from, const Size2 &p_size) const {
 	Ref<Image> img;
 	Ref<AtlasTexture> atex = p_from;
 	if (atex.is_valid()) {
@@ -145,7 +145,7 @@ bool EditorImagePreviewPlugin::handles(const String &p_type) const {
 	return p_type == "Image";
 }
 
-Ref<Texture2D> EditorImagePreviewPlugin::generate(const RES &p_from, const Size2 &p_size) const {
+Ref<Texture2D> EditorImagePreviewPlugin::generate(const Ref<Resource> &p_from, const Size2 &p_size) const {
 	Ref<Image> img = p_from;
 
 	if (img.is_null() || img->is_empty()) {
@@ -194,7 +194,7 @@ bool EditorBitmapPreviewPlugin::handles(const String &p_type) const {
 	return ClassDB::is_parent_class(p_type, "BitMap");
 }
 
-Ref<Texture2D> EditorBitmapPreviewPlugin::generate(const RES &p_from, const Size2 &p_size) const {
+Ref<Texture2D> EditorBitmapPreviewPlugin::generate(const Ref<Resource> &p_from, const Size2 &p_size) const {
 	Ref<BitMap> bm = p_from;
 
 	if (bm->get_size() == Size2()) {
@@ -261,7 +261,7 @@ bool EditorPackedScenePreviewPlugin::handles(const String &p_type) const {
 	return ClassDB::is_parent_class(p_type, "PackedScene");
 }
 
-Ref<Texture2D> EditorPackedScenePreviewPlugin::generate(const RES &p_from, const Size2 &p_size) const {
+Ref<Texture2D> EditorPackedScenePreviewPlugin::generate(const Ref<Resource> &p_from, const Size2 &p_size) const {
 	return generate_from_path(p_from->get_path(), p_size);
 }
 
@@ -316,7 +316,7 @@ bool EditorMaterialPreviewPlugin::generate_small_preview_automatically() const {
 	return true;
 }
 
-Ref<Texture2D> EditorMaterialPreviewPlugin::generate(const RES &p_from, const Size2 &p_size) const {
+Ref<Texture2D> EditorMaterialPreviewPlugin::generate(const Ref<Resource> &p_from, const Size2 &p_size) const {
 	Ref<Material> material = p_from;
 	ERR_FAIL_COND_V(material.is_null(), Ref<Texture2D>());
 
@@ -467,7 +467,7 @@ bool EditorScriptPreviewPlugin::handles(const String &p_type) const {
 	return ClassDB::is_parent_class(p_type, "Script");
 }
 
-Ref<Texture2D> EditorScriptPreviewPlugin::generate(const RES &p_from, const Size2 &p_size) const {
+Ref<Texture2D> EditorScriptPreviewPlugin::generate(const Ref<Resource> &p_from, const Size2 &p_size) const {
 	Ref<Script> scr = p_from;
 	if (scr.is_null()) {
 		return Ref<Texture2D>();
@@ -609,7 +609,7 @@ bool EditorAudioStreamPreviewPlugin::handles(const String &p_type) const {
 	return ClassDB::is_parent_class(p_type, "AudioStream");
 }
 
-Ref<Texture2D> EditorAudioStreamPreviewPlugin::generate(const RES &p_from, const Size2 &p_size) const {
+Ref<Texture2D> EditorAudioStreamPreviewPlugin::generate(const Ref<Resource> &p_from, const Size2 &p_size) const {
 	Ref<AudioStream> stream = p_from;
 	ERR_FAIL_COND_V(stream.is_null(), Ref<Texture2D>());
 
@@ -703,7 +703,7 @@ bool EditorMeshPreviewPlugin::handles(const String &p_type) const {
 	return ClassDB::is_parent_class(p_type, "Mesh"); // Any mesh.
 }
 
-Ref<Texture2D> EditorMeshPreviewPlugin::generate(const RES &p_from, const Size2 &p_size) const {
+Ref<Texture2D> EditorMeshPreviewPlugin::generate(const Ref<Resource> &p_from, const Size2 &p_size) const {
 	Ref<Mesh> mesh = p_from;
 	ERR_FAIL_COND_V(mesh.is_null(), Ref<Texture2D>());
 
@@ -816,7 +816,7 @@ bool EditorFontPreviewPlugin::handles(const String &p_type) const {
 }
 
 Ref<Texture2D> EditorFontPreviewPlugin::generate_from_path(const String &p_path, const Size2 &p_size) const {
-	RES res = ResourceLoader::load(p_path);
+	Ref<Resource> res = ResourceLoader::load(p_path);
 	ERR_FAIL_COND_V(res.is_null(), Ref<Texture2D>());
 	Ref<Font> sampled_font;
 	if (res->is_class("Font")) {
@@ -877,7 +877,7 @@ Ref<Texture2D> EditorFontPreviewPlugin::generate_from_path(const String &p_path,
 	return ptex;
 }
 
-Ref<Texture2D> EditorFontPreviewPlugin::generate(const RES &p_from, const Size2 &p_size) const {
+Ref<Texture2D> EditorFontPreviewPlugin::generate(const Ref<Resource> &p_from, const Size2 &p_size) const {
 	String path = p_from->get_path();
 	if (!FileAccess::exists(path)) {
 		return Ref<Texture2D>();
@@ -917,7 +917,7 @@ bool EditorGradientPreviewPlugin::generate_small_preview_automatically() const {
 	return true;
 }
 
-Ref<Texture2D> EditorGradientPreviewPlugin::generate(const RES &p_from, const Size2 &p_size) const {
+Ref<Texture2D> EditorGradientPreviewPlugin::generate(const Ref<Resource> &p_from, const Size2 &p_size) const {
 	Ref<Gradient> gradient = p_from;
 	if (gradient.is_valid()) {
 		Ref<GradientTexture1D> ptex;

--- a/editor/plugins/editor_preview_plugins.h
+++ b/editor/plugins/editor_preview_plugins.h
@@ -42,7 +42,7 @@ class EditorTexturePreviewPlugin : public EditorResourcePreviewGenerator {
 public:
 	virtual bool handles(const String &p_type) const override;
 	virtual bool generate_small_preview_automatically() const override;
-	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const override;
+	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size) const override;
 
 	EditorTexturePreviewPlugin();
 };
@@ -53,7 +53,7 @@ class EditorImagePreviewPlugin : public EditorResourcePreviewGenerator {
 public:
 	virtual bool handles(const String &p_type) const override;
 	virtual bool generate_small_preview_automatically() const override;
-	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const override;
+	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size) const override;
 
 	EditorImagePreviewPlugin();
 };
@@ -64,7 +64,7 @@ class EditorBitmapPreviewPlugin : public EditorResourcePreviewGenerator {
 public:
 	virtual bool handles(const String &p_type) const override;
 	virtual bool generate_small_preview_automatically() const override;
-	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const override;
+	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size) const override;
 
 	EditorBitmapPreviewPlugin();
 };
@@ -72,7 +72,7 @@ public:
 class EditorPackedScenePreviewPlugin : public EditorResourcePreviewGenerator {
 public:
 	virtual bool handles(const String &p_type) const;
-	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const;
+	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size) const;
 	virtual Ref<Texture2D> generate_from_path(const String &p_path, const Size2 &p_size) const;
 
 	EditorPackedScenePreviewPlugin();
@@ -99,7 +99,7 @@ class EditorMaterialPreviewPlugin : public EditorResourcePreviewGenerator {
 public:
 	virtual bool handles(const String &p_type) const override;
 	virtual bool generate_small_preview_automatically() const override;
-	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const override;
+	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size) const override;
 
 	EditorMaterialPreviewPlugin();
 	~EditorMaterialPreviewPlugin();
@@ -108,7 +108,7 @@ public:
 class EditorScriptPreviewPlugin : public EditorResourcePreviewGenerator {
 public:
 	virtual bool handles(const String &p_type) const;
-	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const;
+	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size) const;
 
 	EditorScriptPreviewPlugin();
 };
@@ -116,7 +116,7 @@ public:
 class EditorAudioStreamPreviewPlugin : public EditorResourcePreviewGenerator {
 public:
 	virtual bool handles(const String &p_type) const;
-	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const;
+	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size) const;
 
 	EditorAudioStreamPreviewPlugin();
 };
@@ -140,7 +140,7 @@ class EditorMeshPreviewPlugin : public EditorResourcePreviewGenerator {
 
 public:
 	virtual bool handles(const String &p_type) const override;
-	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const override;
+	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size) const override;
 
 	EditorMeshPreviewPlugin();
 	~EditorMeshPreviewPlugin();
@@ -160,7 +160,7 @@ class EditorFontPreviewPlugin : public EditorResourcePreviewGenerator {
 
 public:
 	virtual bool handles(const String &p_type) const override;
-	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const override;
+	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size) const override;
 	virtual Ref<Texture2D> generate_from_path(const String &p_path, const Size2 &p_size) const override;
 
 	EditorFontPreviewPlugin();
@@ -177,7 +177,7 @@ class EditorTileMapPatternPreviewPlugin : public EditorResourcePreviewGenerator 
 
 public:
 	virtual bool handles(const String &p_type) const override;
-	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const override;
+	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size) const override;
 
 	EditorTileMapPatternPreviewPlugin();
 	~EditorTileMapPatternPreviewPlugin();
@@ -189,7 +189,7 @@ class EditorGradientPreviewPlugin : public EditorResourcePreviewGenerator {
 public:
 	virtual bool handles(const String &p_type) const override;
 	virtual bool generate_small_preview_automatically() const override;
-	virtual Ref<Texture2D> generate(const RES &p_from, const Size2 &p_size) const override;
+	virtual Ref<Texture2D> generate(const Ref<Resource> &p_from, const Size2 &p_size) const override;
 
 	EditorGradientPreviewPlugin();
 };

--- a/editor/plugins/light_occluder_2d_editor_plugin.cpp
+++ b/editor/plugins/light_occluder_2d_editor_plugin.cpp
@@ -96,7 +96,7 @@ void LightOccluder2DEditor::_create_resource() {
 
 	undo_redo->create_action(TTR("Create Occluder Polygon"));
 	undo_redo->add_do_method(node, "set_occluder_polygon", Ref<OccluderPolygon2D>(memnew(OccluderPolygon2D)));
-	undo_redo->add_undo_method(node, "set_occluder_polygon", Variant(REF()));
+	undo_redo->add_undo_method(node, "set_occluder_polygon", Variant(Ref<RefCounted>()));
 	undo_redo->commit_action();
 
 	_menu_option(MODE_CREATE);

--- a/editor/plugins/navigation_polygon_editor_plugin.cpp
+++ b/editor/plugins/navigation_polygon_editor_plugin.cpp
@@ -106,7 +106,7 @@ void NavigationPolygonEditor::_create_resource() {
 
 	undo_redo->create_action(TTR("Create Navigation Polygon"));
 	undo_redo->add_do_method(node, "set_navigation_polygon", Ref<NavigationPolygon>(memnew(NavigationPolygon)));
-	undo_redo->add_undo_method(node, "set_navigation_polygon", Variant(REF()));
+	undo_redo->add_undo_method(node, "set_navigation_polygon", Variant(Ref<RefCounted>()));
 	undo_redo->commit_action();
 
 	_menu_option(MODE_CREATE);

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -2990,7 +2990,7 @@ void Node3DEditorViewport::_menu_option(int p_option) {
 			bool current = view_menu->get_popup()->is_item_checked(idx);
 			current = !current;
 			if (current) {
-				camera->set_environment(RES());
+				camera->set_environment(Ref<Resource>());
 			} else {
 				camera->set_environment(Node3DEditor::get_singleton()->get_viewport_environment());
 			}
@@ -3767,7 +3767,7 @@ Node *Node3DEditorViewport::_sanitize_preview_node(Node *p_node) const {
 void Node3DEditorViewport::_create_preview(const Vector<String> &files) const {
 	for (int i = 0; i < files.size(); i++) {
 		String path = files[i];
-		RES res = ResourceLoader::load(path);
+		Ref<Resource> res = ResourceLoader::load(path);
 		ERR_CONTINUE(res.is_null());
 		Ref<PackedScene> scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*res));
 		Ref<Mesh> mesh = Ref<Mesh>(Object::cast_to<Mesh>(*res));
@@ -3818,7 +3818,7 @@ bool Node3DEditorViewport::_cyclical_dependency_exists(const String &p_target_sc
 }
 
 bool Node3DEditorViewport::_create_instance(Node *parent, String &path, const Point2 &p_point) {
-	RES res = ResourceLoader::load(path);
+	Ref<Resource> res = ResourceLoader::load(path);
 	ERR_FAIL_COND_V(res.is_null(), false);
 
 	Ref<PackedScene> scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*res));
@@ -3908,7 +3908,7 @@ void Node3DEditorViewport::_perform_drop_data() {
 
 	for (int i = 0; i < selected_files.size(); i++) {
 		String path = selected_files[i];
-		RES res = ResourceLoader::load(path);
+		Ref<Resource> res = ResourceLoader::load(path);
 		if (res.is_null()) {
 			continue;
 		}
@@ -3951,7 +3951,7 @@ bool Node3DEditorViewport::can_drop_data_fw(const Point2 &p_point, const Variant
 			for (int i = 0; i < files.size(); i++) {
 				// Check if dragged files with mesh or scene extension can be created at least once.
 				if (mesh_extensions.find(files[i].get_extension()) || scene_extensions.find(files[i].get_extension())) {
-					RES res = ResourceLoader::load(files[i]);
+					Ref<Resource> res = ResourceLoader::load(files[i]);
 					if (res.is_null()) {
 						continue;
 					}

--- a/editor/plugins/packed_scene_translation_parser_plugin.cpp
+++ b/editor/plugins/packed_scene_translation_parser_plugin.cpp
@@ -43,7 +43,7 @@ Error PackedSceneEditorTranslationParserPlugin::parse_file(const String &p_path,
 	// These properties are translated with the tr() function in the C++ code when being set or updated.
 
 	Error err;
-	RES loaded_res = ResourceLoader::load(p_path, "PackedScene", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
+	Ref<Resource> loaded_res = ResourceLoader::load(p_path, "PackedScene", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
 	if (err) {
 		ERR_PRINT("Failed to load " + p_path);
 		return err;

--- a/editor/plugins/resource_preloader_editor_plugin.cpp
+++ b/editor/plugins/resource_preloader_editor_plugin.cpp
@@ -50,7 +50,7 @@ void ResourcePreloaderEditor::_files_load_request(const Vector<String> &p_paths)
 	for (int i = 0; i < p_paths.size(); i++) {
 		String path = p_paths[i];
 
-		RES resource;
+		Ref<Resource> resource;
 		resource = ResourceLoader::load(path);
 
 		if (resource.is_null()) {
@@ -113,7 +113,7 @@ void ResourcePreloaderEditor::_item_edited() {
 			return;
 		}
 
-		RES samp = preloader->get_resource(old_name);
+		Ref<Resource> samp = preloader->get_resource(old_name);
 		undo_redo->create_action(TTR("Rename Resource"));
 		undo_redo->add_do_method(preloader, "remove_resource", old_name);
 		undo_redo->add_do_method(preloader, "add_resource", new_name, samp);
@@ -135,7 +135,7 @@ void ResourcePreloaderEditor::_remove_resource(const String &p_to_remove) {
 }
 
 void ResourcePreloaderEditor::_paste_pressed() {
-	RES r = EditorSettings::get_singleton()->get_resource_clipboard();
+	Ref<Resource> r = EditorSettings::get_singleton()->get_resource_clipboard();
 	if (!r.is_valid()) {
 		dialog->set_text(TTR("Resource clipboard is empty!"));
 		dialog->set_title(TTR("Error!"));
@@ -190,7 +190,7 @@ void ResourcePreloaderEditor::_update_library() {
 		ti->set_text(0, E);
 		ti->set_metadata(0, E);
 
-		RES r = preloader->get_resource(E);
+		Ref<Resource> r = preloader->get_resource(E);
 
 		ERR_CONTINUE(r.is_null());
 
@@ -222,7 +222,7 @@ void ResourcePreloaderEditor::_cell_button_pressed(Object *p_item, int p_column,
 		EditorInterface::get_singleton()->open_scene_from_path(rpath);
 
 	} else if (p_id == BUTTON_EDIT_RESOURCE) {
-		RES r = preloader->get_resource(item->get_text(0));
+		Ref<Resource> r = preloader->get_resource(item->get_text(0));
 		EditorInterface::get_singleton()->edit_resource(r);
 
 	} else if (p_id == BUTTON_REMOVE) {
@@ -249,7 +249,7 @@ Variant ResourcePreloaderEditor::get_drag_data_fw(const Point2 &p_point, Control
 
 	String name = ti->get_metadata(0);
 
-	RES res = preloader->get_resource(name);
+	Ref<Resource> res = preloader->get_resource(name);
 	if (!res.is_valid()) {
 		return Variant();
 	}
@@ -269,7 +269,7 @@ bool ResourcePreloaderEditor::can_drop_data_fw(const Point2 &p_point, const Vari
 	}
 
 	if (String(d["type"]) == "resource" && d.has("resource")) {
-		RES r = d["resource"];
+		Ref<Resource> r = d["resource"];
 
 		return r.is_valid();
 	}
@@ -294,7 +294,7 @@ void ResourcePreloaderEditor::drop_data_fw(const Point2 &p_point, const Variant 
 	}
 
 	if (String(d["type"]) == "resource" && d.has("resource")) {
-		RES r = d["resource"];
+		Ref<Resource> r = d["resource"];
 
 		if (r.is_valid()) {
 			String basename;

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -232,7 +232,7 @@ void ScriptEditorBase::_bind_methods() {
 class EditorScriptCodeCompletionCache : public ScriptCodeCompletionCache {
 	struct Cache {
 		uint64_t time_loaded = 0;
-		RES cache;
+		Ref<Resource> cache;
 	};
 
 	Map<String, Cache> cached;
@@ -258,7 +258,7 @@ public:
 		}
 	}
 
-	virtual RES get_cached_resource(const String &p_path) {
+	virtual Ref<Resource> get_cached_resource(const String &p_path) {
 		Map<String, Cache>::Element *E = cached.find(p_path);
 		if (!E) {
 			Cache c;
@@ -428,7 +428,7 @@ void ScriptEditor::_goto_script_line2(int p_line) {
 	}
 }
 
-void ScriptEditor::_goto_script_line(REF p_script, int p_line) {
+void ScriptEditor::_goto_script_line(Ref<RefCounted> p_script, int p_line) {
 	Ref<Script> script = Object::cast_to<Script>(*p_script);
 	if (script.is_valid() && (script->has_source_code() || script->get_path().is_resource_file())) {
 		if (edit(p_script, p_line, 0)) {
@@ -444,7 +444,7 @@ void ScriptEditor::_goto_script_line(REF p_script, int p_line) {
 	}
 }
 
-void ScriptEditor::_set_execution(REF p_script, int p_line) {
+void ScriptEditor::_set_execution(Ref<RefCounted> p_script, int p_line) {
 	Ref<Script> script = Object::cast_to<Script>(*p_script);
 	if (script.is_valid() && (script->has_source_code() || script->get_path().is_resource_file())) {
 		for (int i = 0; i < tab_container->get_tab_count(); i++) {
@@ -460,7 +460,7 @@ void ScriptEditor::_set_execution(REF p_script, int p_line) {
 	}
 }
 
-void ScriptEditor::_clear_execution(REF p_script) {
+void ScriptEditor::_clear_execution(Ref<RefCounted> p_script) {
 	Ref<Script> script = Object::cast_to<Script>(*p_script);
 	if (script.is_valid() && (script->has_source_code() || script->get_path().is_resource_file())) {
 		for (int i = 0; i < tab_container->get_tab_count(); i++) {
@@ -476,7 +476,7 @@ void ScriptEditor::_clear_execution(REF p_script) {
 	}
 }
 
-void ScriptEditor::_set_breakpoint(REF p_script, int p_line, bool p_enabled) {
+void ScriptEditor::_set_breakpoint(Ref<RefCounted> p_script, int p_line, bool p_enabled) {
 	Ref<Script> script = Object::cast_to<Script>(*p_script);
 	if (script.is_valid() && (script->has_source_code() || script->get_path().is_resource_file())) {
 		// Update if open.
@@ -758,7 +758,7 @@ void ScriptEditor::_close_tab(int p_idx, bool p_save, bool p_history_back) {
 
 	ScriptEditorBase *current = Object::cast_to<ScriptEditorBase>(tselected);
 	if (current) {
-		RES file = current->get_edited_resource();
+		Ref<Resource> file = current->get_edited_resource();
 		if (p_save && file.is_valid()) {
 			// Do not try to save internal scripts, but prompt to save in-memory
 			// scripts which are not saved to disk yet (have empty path).
@@ -849,7 +849,7 @@ void ScriptEditor::_close_docs_tab() {
 void ScriptEditor::_copy_script_path() {
 	ScriptEditorBase *se = _get_current_editor();
 	if (se) {
-		RES script = se->get_edited_resource();
+		Ref<Resource> script = se->get_edited_resource();
 		DisplayServer::get_singleton()->clipboard_set(script->get_path());
 	}
 }
@@ -906,7 +906,7 @@ void ScriptEditor::_resave_scripts(const String &p_str) {
 			continue;
 		}
 
-		RES script = se->get_edited_resource();
+		Ref<Resource> script = se->get_edited_resource();
 
 		if (script->is_built_in()) {
 			continue; //internal script, who cares
@@ -947,7 +947,7 @@ void ScriptEditor::_reload_scripts() {
 			continue;
 		}
 
-		RES edited_res = se->get_edited_resource();
+		Ref<Resource> edited_res = se->get_edited_resource();
 
 		if (edited_res->is_built_in()) {
 			continue; //internal script, who cares
@@ -991,7 +991,7 @@ void ScriptEditor::_res_saved_callback(const Ref<Resource> &p_res) {
 			continue;
 		}
 
-		RES script = se->get_edited_resource();
+		Ref<Resource> script = se->get_edited_resource();
 
 		if (script == p_res) {
 			se->tag_saved_version();
@@ -1010,7 +1010,7 @@ void ScriptEditor::_scene_saved_callback(const String &p_path) {
 			continue;
 		}
 
-		RES edited_res = se->get_edited_resource();
+		Ref<Resource> edited_res = se->get_edited_resource();
 
 		if (!edited_res->is_built_in()) {
 			continue; // External script, who cares.
@@ -1039,7 +1039,7 @@ void ScriptEditor::_live_auto_reload_running_scripts() {
 	EditorDebuggerNode::get_singleton()->reload_scripts();
 }
 
-bool ScriptEditor::_test_script_times_on_disk(RES p_for_script) {
+bool ScriptEditor::_test_script_times_on_disk(Ref<Resource> p_for_script) {
 	disk_changed_list->clear();
 	TreeItem *r = disk_changed_list->create_item();
 	disk_changed_list->set_hide_root(true);
@@ -1051,7 +1051,7 @@ bool ScriptEditor::_test_script_times_on_disk(RES p_for_script) {
 	for (int i = 0; i < tab_container->get_tab_count(); i++) {
 		ScriptEditorBase *se = Object::cast_to<ScriptEditorBase>(tab_container->get_tab_control(i));
 		if (se) {
-			RES edited_res = se->get_edited_resource();
+			Ref<Resource> edited_res = se->get_edited_resource();
 			if (p_for_script.is_valid() && edited_res.is_valid() && p_for_script != edited_res) {
 				continue;
 			}
@@ -1117,7 +1117,7 @@ void ScriptEditor::_file_dialog_action(String p_file) {
 		case FILE_SAVE_AS: {
 			ScriptEditorBase *current = _get_current_editor();
 			if (current) {
-				RES resource = current->get_edited_resource();
+				Ref<Resource> resource = current->get_edited_resource();
 				String path = ProjectSettings::get_singleton()->localize_path(p_file);
 				Error err = _save_text_file(resource, path);
 
@@ -1323,7 +1323,7 @@ void ScriptEditor::_menu_option(int p_option) {
 					}
 				}
 
-				RES resource = current->get_edited_resource();
+				Ref<Resource> resource = current->get_edited_resource();
 				Ref<TextFile> text_file = resource;
 				Ref<Script> script = resource;
 
@@ -1413,7 +1413,7 @@ void ScriptEditor::_menu_option(int p_option) {
 				_copy_script_path();
 			} break;
 			case SHOW_IN_FILE_SYSTEM: {
-				const RES script = current->get_edited_resource();
+				const Ref<Resource> script = current->get_edited_resource();
 				String path = script->get_path();
 				if (!path.is_empty()) {
 					if (script->is_built_in()) {
@@ -2188,7 +2188,7 @@ Ref<TextFile> ScriptEditor::_load_text_file(const String &p_path, Error *r_error
 	Ref<TextFile> text_res(text_file);
 	Error err = text_file->load_text(path);
 
-	ERR_FAIL_COND_V_MSG(err != OK, RES(), "Cannot load text file '" + path + "'.");
+	ERR_FAIL_COND_V_MSG(err != OK, Ref<Resource>(), "Cannot load text file '" + path + "'.");
 
 	text_file->set_file_path(local_path);
 	text_file->set_path(local_path, true);
@@ -2230,7 +2230,7 @@ Error ScriptEditor::_save_text_file(Ref<TextFile> p_text_file, const String &p_p
 	return OK;
 }
 
-bool ScriptEditor::edit(const RES &p_resource, int p_line, int p_col, bool p_grab_focus) {
+bool ScriptEditor::edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus) {
 	if (p_resource.is_null()) {
 		return false;
 	}
@@ -2447,7 +2447,7 @@ void ScriptEditor::save_current_script() {
 		}
 	}
 
-	RES resource = current->get_edited_resource();
+	Ref<Resource> resource = current->get_edited_resource();
 	Ref<TextFile> text_file = resource;
 	Ref<Script> script = resource;
 
@@ -2516,7 +2516,7 @@ void ScriptEditor::save_all_scripts() {
 			continue;
 		}
 
-		RES edited_res = se->get_edited_resource();
+		Ref<Resource> edited_res = se->get_edited_resource();
 		if (edited_res.is_valid()) {
 			se->apply_code();
 		}
@@ -2589,14 +2589,14 @@ void ScriptEditor::open_text_file_create_dialog(const String &p_base_path, const
 	open_textfile_after_create = false;
 }
 
-RES ScriptEditor::open_file(const String &p_file) {
+Ref<Resource> ScriptEditor::open_file(const String &p_file) {
 	List<String> extensions;
 	ResourceLoader::get_recognized_extensions_for_type("Script", &extensions);
 	if (extensions.find(p_file.get_extension())) {
 		Ref<Script> scr = ResourceLoader::load(p_file);
 		if (!scr.is_valid()) {
 			EditorNode::get_singleton()->show_warning(TTR("Could not load file at:") + "\n\n" + p_file, TTR("Error!"));
-			return RES();
+			return Ref<Resource>();
 		}
 
 		edit(scr);
@@ -2607,14 +2607,14 @@ RES ScriptEditor::open_file(const String &p_file) {
 	Ref<TextFile> text_file = _load_text_file(p_file, &error);
 	if (error != OK) {
 		EditorNode::get_singleton()->show_warning(TTR("Could not load file at:") + "\n\n" + p_file, TTR("Error!"));
-		return RES();
+		return Ref<Resource>();
 	}
 
 	if (text_file.is_valid()) {
 		edit(text_file);
 		return text_file;
 	}
-	return RES();
+	return Ref<Resource>();
 }
 
 void ScriptEditor::_editor_stop() {
@@ -2980,7 +2980,7 @@ void ScriptEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data, Co
 				continue;
 			}
 
-			RES res = open_file(file);
+			Ref<Resource> res = open_file(file);
 			if (res.is_valid()) {
 				if (tab_container->get_tab_count() > num_tabs_before) {
 					tab_container->move_child(tab_container->get_tab_control(tab_container->get_tab_count() - 1), new_index);
@@ -3533,7 +3533,7 @@ void ScriptEditor::_on_replace_in_files_requested(String text) {
 
 void ScriptEditor::_on_find_in_files_result_selected(String fpath, int line_number, int begin, int end) {
 	if (ResourceLoader::exists(fpath)) {
-		RES res = ResourceLoader::load(fpath);
+		Ref<Resource> res = ResourceLoader::load(fpath);
 
 		if (fpath.get_extension() == "gdshader") {
 			ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_singleton()->get_editor_data().get_editor("Shader"));

--- a/editor/plugins/script_editor_plugin.h
+++ b/editor/plugins/script_editor_plugin.h
@@ -53,7 +53,7 @@ class EditorSyntaxHighlighter : public SyntaxHighlighter {
 	GDCLASS(EditorSyntaxHighlighter, SyntaxHighlighter)
 
 private:
-	REF edited_resourse;
+	Ref<RefCounted> edited_resourse;
 
 protected:
 	static void _bind_methods();
@@ -65,8 +65,8 @@ public:
 	virtual String _get_name() const;
 	virtual Array _get_supported_languages() const;
 
-	void _set_edited_resource(const RES &p_res) { edited_resourse = p_res; }
-	REF _get_edited_resource() { return edited_resourse; }
+	void _set_edited_resource(const Ref<Resource> &p_res) { edited_resourse = p_res; }
+	Ref<RefCounted> _get_edited_resource() { return edited_resourse; }
 
 	virtual Ref<EditorSyntaxHighlighter> _create() const;
 };
@@ -136,9 +136,9 @@ public:
 	virtual void set_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) = 0;
 
 	virtual void apply_code() = 0;
-	virtual RES get_edited_resource() const = 0;
+	virtual Ref<Resource> get_edited_resource() const = 0;
 	virtual Vector<String> get_functions() = 0;
-	virtual void set_edited_resource(const RES &p_res) = 0;
+	virtual void set_edited_resource(const Ref<Resource> &p_res) = 0;
 	virtual void enable_editor() = 0;
 	virtual void reload_text() = 0;
 	virtual String get_name() = 0;
@@ -179,7 +179,7 @@ public:
 	ScriptEditorBase() {}
 };
 
-typedef ScriptEditorBase *(*CreateScriptEditorFunc)(const RES &p_resource);
+typedef ScriptEditorBase *(*CreateScriptEditorFunc)(const Ref<Resource> &p_resource);
 
 class EditorScriptCodeCompletionCache;
 class FindInFilesDialog;
@@ -330,7 +330,7 @@ class ScriptEditor : public PanelContainer {
 	void _resave_scripts(const String &p_str);
 	void _reload_scripts();
 
-	bool _test_script_times_on_disk(RES p_for_script = Ref<Resource>());
+	bool _test_script_times_on_disk(Ref<Resource> p_for_script = Ref<Resource>());
 
 	void _add_recent_script(String p_path);
 	void _update_recent_scripts();
@@ -377,12 +377,12 @@ class ScriptEditor : public PanelContainer {
 	bool convert_indent_on_save;
 
 	void _goto_script_line2(int p_line);
-	void _goto_script_line(REF p_script, int p_line);
-	void _set_execution(REF p_script, int p_line);
-	void _clear_execution(REF p_script);
+	void _goto_script_line(Ref<RefCounted> p_script, int p_line);
+	void _set_execution(Ref<RefCounted> p_script, int p_line);
+	void _clear_execution(Ref<RefCounted> p_script);
 	void _breaked(bool p_breaked, bool p_can_debug);
 	void _script_created(Ref<Script> p_script);
-	void _set_breakpoint(REF p_scrpt, int p_line, bool p_enabled);
+	void _set_breakpoint(Ref<RefCounted> p_scrpt, int p_line, bool p_enabled);
 	void _clear_breakpoints();
 	Array _get_cached_breakpoints_for_script(const String &p_path) const;
 
@@ -481,12 +481,12 @@ public:
 	void apply_scripts() const;
 	void open_script_create_dialog(const String &p_base_name, const String &p_base_path);
 	void open_text_file_create_dialog(const String &p_base_path, const String &p_base_name = "");
-	RES open_file(const String &p_file);
+	Ref<Resource> open_file(const String &p_file);
 
 	void ensure_select_current();
 
-	_FORCE_INLINE_ bool edit(const RES &p_resource, bool p_grab_focus = true) { return edit(p_resource, -1, 0, p_grab_focus); }
-	bool edit(const RES &p_resource, int p_line, int p_col, bool p_grab_focus = true);
+	_FORCE_INLINE_ bool edit(const Ref<Resource> &p_resource, bool p_grab_focus = true) { return edit(p_resource, -1, 0, p_grab_focus); }
+	bool edit(const Ref<Resource> &p_resource, int p_line, int p_col, bool p_grab_focus = true);
 
 	void get_breakpoints(List<String> *p_breakpoints);
 

--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -133,11 +133,11 @@ void ScriptTextEditor::apply_code() {
 	code_editor->get_text_editor()->get_syntax_highlighter()->update_cache();
 }
 
-RES ScriptTextEditor::get_edited_resource() const {
+Ref<Resource> ScriptTextEditor::get_edited_resource() const {
 	return script;
 }
 
-void ScriptTextEditor::set_edited_resource(const RES &p_res) {
+void ScriptTextEditor::set_edited_resource(const Ref<Resource> &p_res) {
 	ERR_FAIL_COND(script.is_valid());
 	ERR_FAIL_COND(p_res.is_null());
 
@@ -1998,7 +1998,7 @@ ScriptTextEditor::~ScriptTextEditor() {
 	}
 }
 
-static ScriptEditorBase *create_editor(const RES &p_resource) {
+static ScriptEditorBase *create_editor(const Ref<Resource> &p_resource) {
 	if (Object::cast_to<Script>(*p_resource)) {
 		return memnew(ScriptTextEditor);
 	}

--- a/editor/plugins/script_text_editor.h
+++ b/editor/plugins/script_text_editor.h
@@ -205,8 +205,8 @@ public:
 	void update_toggle_scripts_button() override;
 
 	virtual void apply_code() override;
-	virtual RES get_edited_resource() const override;
-	virtual void set_edited_resource(const RES &p_res) override;
+	virtual Ref<Resource> get_edited_resource() const override;
+	virtual void set_edited_resource(const Ref<Resource> &p_res) override;
 	virtual void enable_editor() override;
 	virtual Vector<String> get_functions() override;
 	virtual void reload_text() override;

--- a/editor/plugins/sprite_frames_editor_plugin.cpp
+++ b/editor/plugins/sprite_frames_editor_plugin.cpp
@@ -1012,7 +1012,7 @@ Variant SpriteFramesEditor::get_drag_data_fw(const Point2 &p_point, Control *p_f
 		return Variant();
 	}
 
-	RES frame = frames->get_frame(edited_anim, idx);
+	Ref<Resource> frame = frames->get_frame(edited_anim, idx);
 
 	if (frame.is_null()) {
 		return Variant();
@@ -1036,7 +1036,7 @@ bool SpriteFramesEditor::can_drop_data_fw(const Point2 &p_point, const Variant &
 	}
 
 	if (String(d["type"]) == "resource" && d.has("resource")) {
-		RES r = d["resource"];
+		Ref<Resource> r = d["resource"];
 
 		Ref<Texture2D> texture = r;
 
@@ -1080,7 +1080,7 @@ void SpriteFramesEditor::drop_data_fw(const Point2 &p_point, const Variant &p_da
 	int at_pos = tree->get_item_at_position(p_point, true);
 
 	if (String(d["type"]) == "resource" && d.has("resource")) {
-		RES r = d["resource"];
+		Ref<Resource> r = d["resource"];
 
 		Ref<Texture2D> texture = r;
 

--- a/editor/plugins/text_editor.cpp
+++ b/editor/plugins/text_editor.cpp
@@ -89,11 +89,11 @@ Ref<Texture2D> TextEditor::get_theme_icon() {
 	return EditorNode::get_singleton()->get_object_icon(text_file.ptr(), "");
 }
 
-RES TextEditor::get_edited_resource() const {
+Ref<Resource> TextEditor::get_edited_resource() const {
 	return text_file;
 }
 
-void TextEditor::set_edited_resource(const RES &p_res) {
+void TextEditor::set_edited_resource(const Ref<Resource> &p_res) {
 	ERR_FAIL_COND(text_file.is_valid());
 	ERR_FAIL_COND(p_res.is_null());
 
@@ -412,7 +412,7 @@ void TextEditor::_convert_case(CodeTextEditor::CaseStyle p_case) {
 	code_editor->convert_case(p_case);
 }
 
-static ScriptEditorBase *create_editor(const RES &p_resource) {
+static ScriptEditorBase *create_editor(const Ref<Resource> &p_resource) {
 	if (Object::cast_to<TextFile>(*p_resource)) {
 		return memnew(TextEditor);
 	}

--- a/editor/plugins/text_editor.h
+++ b/editor/plugins/text_editor.h
@@ -109,8 +109,8 @@ public:
 
 	virtual String get_name() override;
 	virtual Ref<Texture2D> get_theme_icon() override;
-	virtual RES get_edited_resource() const override;
-	virtual void set_edited_resource(const RES &p_res) override;
+	virtual Ref<Resource> get_edited_resource() const override;
+	virtual void set_edited_resource(const Ref<Resource> &p_res) override;
 	virtual void enable_editor() override;
 	virtual void reload_text() override;
 	virtual void apply_code() override;

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -2537,7 +2537,7 @@ void ThemeTypeEditor::_update_type_items() {
 				if (edited_theme->has_font(E.key(), edited_type)) {
 					item_editor->set_edited_resource(edited_theme->get_font(E.key(), edited_type));
 				} else {
-					item_editor->set_edited_resource(RES());
+					item_editor->set_edited_resource(Ref<Resource>());
 				}
 				item_editor->connect("resource_selected", callable_mp(this, &ThemeTypeEditor::_edit_resource_item));
 				item_editor->connect("resource_changed", callable_mp(this, &ThemeTypeEditor::_font_item_changed), varray(E.key()));
@@ -2545,7 +2545,7 @@ void ThemeTypeEditor::_update_type_items() {
 				if (Theme::get_default()->has_font(E.key(), edited_type)) {
 					item_editor->set_edited_resource(Theme::get_default()->get_font(E.key(), edited_type));
 				} else {
-					item_editor->set_edited_resource(RES());
+					item_editor->set_edited_resource(Ref<Resource>());
 				}
 				item_editor->set_editable(false);
 			}
@@ -2608,7 +2608,7 @@ void ThemeTypeEditor::_update_type_items() {
 				if (edited_theme->has_icon(E.key(), edited_type)) {
 					item_editor->set_edited_resource(edited_theme->get_icon(E.key(), edited_type));
 				} else {
-					item_editor->set_edited_resource(RES());
+					item_editor->set_edited_resource(Ref<Resource>());
 				}
 				item_editor->connect("resource_selected", callable_mp(this, &ThemeTypeEditor::_edit_resource_item));
 				item_editor->connect("resource_changed", callable_mp(this, &ThemeTypeEditor::_icon_item_changed), varray(E.key()));
@@ -2616,7 +2616,7 @@ void ThemeTypeEditor::_update_type_items() {
 				if (Theme::get_default()->has_icon(E.key(), edited_type)) {
 					item_editor->set_edited_resource(Theme::get_default()->get_icon(E.key(), edited_type));
 				} else {
-					item_editor->set_edited_resource(RES());
+					item_editor->set_edited_resource(Ref<Resource>());
 				}
 				item_editor->set_editable(false);
 			}
@@ -2655,7 +2655,7 @@ void ThemeTypeEditor::_update_type_items() {
 			if (edited_theme->has_stylebox(leading_stylebox.item_name, edited_type)) {
 				item_editor->set_edited_resource(leading_stylebox.stylebox);
 			} else {
-				item_editor->set_edited_resource(RES());
+				item_editor->set_edited_resource(Ref<Resource>());
 			}
 			item_editor->connect("resource_selected", callable_mp(this, &ThemeTypeEditor::_edit_resource_item));
 			item_editor->connect("resource_changed", callable_mp(this, &ThemeTypeEditor::_stylebox_item_changed), varray(leading_stylebox.item_name));
@@ -2680,7 +2680,7 @@ void ThemeTypeEditor::_update_type_items() {
 				if (edited_theme->has_stylebox(E.key(), edited_type)) {
 					item_editor->set_edited_resource(edited_theme->get_stylebox(E.key(), edited_type));
 				} else {
-					item_editor->set_edited_resource(RES());
+					item_editor->set_edited_resource(Ref<Resource>());
 				}
 				item_editor->connect("resource_selected", callable_mp(this, &ThemeTypeEditor::_edit_resource_item));
 				item_editor->connect("resource_changed", callable_mp(this, &ThemeTypeEditor::_stylebox_item_changed), varray(E.key()));
@@ -2696,7 +2696,7 @@ void ThemeTypeEditor::_update_type_items() {
 				if (Theme::get_default()->has_stylebox(E.key(), edited_type)) {
 					item_editor->set_edited_resource(Theme::get_default()->get_stylebox(E.key(), edited_type));
 				} else {
-					item_editor->set_edited_resource(RES());
+					item_editor->set_edited_resource(Ref<Resource>());
 				}
 				item_editor->set_editable(false);
 			}
@@ -3065,7 +3065,7 @@ void ThemeTypeEditor::_font_size_item_changed(float p_value, String p_item_name)
 	ur->commit_action();
 }
 
-void ThemeTypeEditor::_edit_resource_item(RES p_resource, bool p_edit) {
+void ThemeTypeEditor::_edit_resource_item(Ref<Resource> p_resource, bool p_edit) {
 	EditorNode::get_singleton()->edit_resource(p_resource);
 }
 
@@ -3131,7 +3131,7 @@ void ThemeTypeEditor::_change_pinned_stylebox() {
 
 		Ref<StyleBox> new_stylebox = edited_theme->get_stylebox(leading_stylebox.item_name, edited_type);
 		leading_stylebox.stylebox = new_stylebox;
-		leading_stylebox.ref_stylebox = (new_stylebox.is_valid() ? new_stylebox->duplicate() : RES());
+		leading_stylebox.ref_stylebox = (new_stylebox.is_valid() ? new_stylebox->duplicate() : Ref<Resource>());
 
 		if (leading_stylebox.stylebox.is_valid()) {
 			new_stylebox->connect("changed", callable_mp(this, &ThemeTypeEditor::_update_stylebox_from_leading));
@@ -3169,7 +3169,7 @@ void ThemeTypeEditor::_pin_leading_stylebox(String p_item_name, Ref<StyleBox> p_
 	leader.pinned = true;
 	leader.item_name = p_item_name;
 	leader.stylebox = p_stylebox;
-	leader.ref_stylebox = (p_stylebox.is_valid() ? p_stylebox->duplicate() : RES());
+	leader.ref_stylebox = (p_stylebox.is_valid() ? p_stylebox->duplicate() : Ref<Resource>());
 
 	leading_stylebox = leader;
 	if (p_stylebox.is_valid()) {

--- a/editor/plugins/theme_editor_plugin.h
+++ b/editor/plugins/theme_editor_plugin.h
@@ -384,7 +384,7 @@ class ThemeTypeEditor : public MarginContainer {
 	void _color_item_changed(Color p_value, String p_item_name);
 	void _constant_item_changed(float p_value, String p_item_name);
 	void _font_size_item_changed(float p_value, String p_item_name);
-	void _edit_resource_item(RES p_resource, bool p_edit);
+	void _edit_resource_item(Ref<Resource> p_resource, bool p_edit);
 	void _font_item_changed(Ref<Font> p_value, String p_item_name);
 	void _icon_item_changed(Ref<Texture2D> p_value, String p_item_name);
 	void _stylebox_item_changed(Ref<StyleBox> p_value, String p_item_name);

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -5881,18 +5881,18 @@ public:
 		undo_redo->add_undo_property(node.ptr(), p_property, node->get(p_property));
 
 		if (p_value.get_type() == Variant::OBJECT) {
-			RES prev_res = node->get(p_property);
-			RES curr_res = p_value;
+			Ref<Resource> prev_res = node->get(p_property);
+			Ref<Resource> curr_res = p_value;
 
 			if (curr_res.is_null()) {
-				undo_redo->add_do_method(this, "_open_inspector", (RES)parent_resource.ptr());
+				undo_redo->add_do_method(this, "_open_inspector", (Ref<Resource>)parent_resource.ptr());
 			} else {
-				undo_redo->add_do_method(this, "_open_inspector", (RES)curr_res.ptr());
+				undo_redo->add_do_method(this, "_open_inspector", (Ref<Resource>)curr_res.ptr());
 			}
 			if (!prev_res.is_null()) {
-				undo_redo->add_undo_method(this, "_open_inspector", (RES)prev_res.ptr());
+				undo_redo->add_undo_method(this, "_open_inspector", (Ref<Resource>)prev_res.ptr());
 			} else {
-				undo_redo->add_undo_method(this, "_open_inspector", (RES)parent_resource.ptr());
+				undo_redo->add_undo_method(this, "_open_inspector", (Ref<Resource>)parent_resource.ptr());
 			}
 		}
 		if (p_property != "constant") {
@@ -5919,11 +5919,11 @@ public:
 		}
 	}
 
-	void _resource_selected(const String &p_path, RES p_resource) {
+	void _resource_selected(const String &p_path, Ref<Resource> p_resource) {
 		_open_inspector(p_resource);
 	}
 
-	void _open_inspector(RES p_resource) {
+	void _open_inspector(Ref<Resource> p_resource) {
 		InspectorDock::get_inspector_singleton()->edit(p_resource.ptr());
 	}
 

--- a/editor/plugins/visual_shader_editor_plugin.h
+++ b/editor/plugins/visual_shader_editor_plugin.h
@@ -48,7 +48,7 @@ class VisualShaderNodePlugin : public RefCounted {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL2RC(Object *, _create_editor, RES, Ref<VisualShaderNode>)
+	GDVIRTUAL2RC(Object *, _create_editor, Ref<Resource>, Ref<VisualShaderNode>)
 
 public:
 	virtual Control *create_editor(const Ref<Resource> &p_parent_resource, const Ref<VisualShaderNode> &p_node);

--- a/editor/property_editor.cpp
+++ b/editor/property_editor.cpp
@@ -85,7 +85,7 @@ bool EditorResourceConversionPlugin::handles(const Ref<Resource> &p_resource) co
 }
 
 Ref<Resource> EditorResourceConversionPlugin::convert(const Ref<Resource> &p_resource) const {
-	RES ret;
+	Ref<Resource> ret;
 	if (GDVIRTUAL_CALL(_convert, p_resource, ret)) {
 		return ret;
 	}
@@ -151,7 +151,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 				} break;
 
 				case OBJ_MENU_EDIT: {
-					REF r = v;
+					Ref<RefCounted> r = v;
 
 					if (!r.is_null()) {
 						emit_signal(SNAME("resource_edit_request"));
@@ -223,7 +223,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 
 				} break;
 				case OBJ_MENU_SHOW_IN_FILE_SYSTEM: {
-					RES r = v;
+					Ref<Resource> r = v;
 					FileSystemDock *file_system_dock = FileSystemDock::get_singleton();
 					file_system_dock->navigate_to_path(r->get_path());
 					// Ensure that the FileSystem dock is visible.
@@ -234,7 +234,7 @@ void CustomPropertyEditor::_menu_option(int p_which) {
 					if (p_which >= CONVERT_BASE_ID) {
 						int to_type = p_which - CONVERT_BASE_ID;
 
-						Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(RES(v));
+						Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(Ref<Resource>(v));
 
 						ERR_FAIL_INDEX(to_type, conversions.size());
 
@@ -928,19 +928,19 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 
 			menu->add_item(TTR("Load"), OBJ_MENU_LOAD);
 
-			if (!RES(v).is_null()) {
+			if (!Ref<Resource>(v).is_null()) {
 				menu->add_item(TTR("Edit"), OBJ_MENU_EDIT);
 				menu->add_item(TTR("Clear"), OBJ_MENU_CLEAR);
 				menu->add_item(TTR("Make Unique"), OBJ_MENU_MAKE_UNIQUE);
 
-				RES r = v;
+				Ref<Resource> r = v;
 				if (r.is_valid() && r->get_path().is_resource_file()) {
 					menu->add_separator();
 					menu->add_item(TTR("Show in FileSystem"), OBJ_MENU_SHOW_IN_FILE_SYSTEM);
 				}
 			}
 
-			RES cb = EditorSettings::get_singleton()->get_resource_clipboard();
+			Ref<Resource> cb = EditorSettings::get_singleton()->get_resource_clipboard();
 			bool paste_valid = false;
 			if (cb.is_valid()) {
 				if (hint_text.is_empty()) {
@@ -955,10 +955,10 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				}
 			}
 
-			if (!RES(v).is_null() || paste_valid) {
+			if (!Ref<Resource>(v).is_null() || paste_valid) {
 				menu->add_separator();
 
-				if (!RES(v).is_null()) {
+				if (!Ref<Resource>(v).is_null()) {
 					menu->add_item(TTR("Copy"), OBJ_MENU_COPY);
 				}
 
@@ -967,8 +967,8 @@ bool CustomPropertyEditor::edit(Object *p_owner, const String &p_name, Variant::
 				}
 			}
 
-			if (!RES(v).is_null()) {
-				Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(RES(v));
+			if (!Ref<Resource>(v).is_null()) {
+				Vector<Ref<EditorResourceConversionPlugin>> conversions = EditorNode::get_singleton()->find_resource_conversion_plugin(Ref<Resource>(v));
 				if (conversions.size()) {
 					menu->add_separator();
 				}
@@ -1029,7 +1029,7 @@ void CustomPropertyEditor::_file_selected(String p_file) {
 		case Variant::OBJECT: {
 			String type = (hint == PROPERTY_HINT_RESOURCE_TYPE) ? hint_text : String();
 
-			RES res = ResourceLoader::load(p_file, type);
+			Ref<Resource> res = ResourceLoader::load(p_file, type);
 			if (res.is_null()) {
 				error->set_text(TTR("Error loading file: Not a resource!"));
 				error->popup_centered();
@@ -1312,7 +1312,7 @@ void CustomPropertyEditor::_action_pressed(int p_which) {
 				file->popup_file_dialog();
 
 			} else if (p_which == 2) {
-				RES r = v;
+				Ref<Resource> r = v;
 
 				if (!r.is_null()) {
 					emit_signal(SNAME("resource_edit_request"));

--- a/editor/property_editor.h
+++ b/editor/property_editor.h
@@ -58,8 +58,8 @@ protected:
 	static void _bind_methods();
 
 	GDVIRTUAL0RC(String, _converts_to)
-	GDVIRTUAL1RC(bool, _handles, RES)
-	GDVIRTUAL1RC(RES, _convert, RES)
+	GDVIRTUAL1RC(bool, _handles, Ref<Resource>)
+	GDVIRTUAL1RC(Ref<Resource>, _convert, Ref<Resource>)
 
 public:
 	virtual String converts_to() const;

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -1153,7 +1153,7 @@ void SceneTreeDock::_property_selected(int p_idx) {
 	property_drop_node = nullptr;
 }
 
-void SceneTreeDock::_perform_property_drop(Node *p_node, String p_property, RES p_res) {
+void SceneTreeDock::_perform_property_drop(Node *p_node, String p_property, Ref<Resource> p_res) {
 	editor_data->get_undo_redo().create_action(vformat(TTR("Set %s"), p_property));
 	editor_data->get_undo_redo().add_do_property(p_node, p_property, p_res);
 	editor_data->get_undo_redo().add_undo_property(p_node, p_property, p_node->get(p_property));
@@ -3056,14 +3056,14 @@ List<Node *> SceneTreeDock::paste_nodes() {
 	ur.create_action(TTR("Paste Node(s)"));
 	ur.add_do_method(editor_selection, "clear");
 
-	Map<RES, RES> resource_remap;
+	Map<Ref<Resource>, Ref<Resource>> resource_remap;
 	String target_scene;
 	if (edited_scene) {
 		target_scene = edited_scene->get_scene_file_path();
 	}
 	if (target_scene != clipboard_source_scene) {
 		if (!clipboard_resource_remap.has(target_scene)) {
-			Map<RES, RES> remap;
+			Map<Ref<Resource>, Ref<Resource>> remap;
 			for (Node *E : node_clipboard) {
 				_create_remap_for_node(E, remap);
 			}
@@ -3259,7 +3259,7 @@ void SceneTreeDock::_clear_clipboard() {
 	clipboard_resource_remap.clear();
 }
 
-void SceneTreeDock::_create_remap_for_node(Node *p_node, Map<RES, RES> &r_remap) {
+void SceneTreeDock::_create_remap_for_node(Node *p_node, Map<Ref<Resource>, Ref<Resource>> &r_remap) {
 	List<PropertyInfo> props;
 	p_node->get_property_list(&props);
 
@@ -3273,7 +3273,7 @@ void SceneTreeDock::_create_remap_for_node(Node *p_node, Map<RES, RES> &r_remap)
 
 		Variant v = p_node->get(E.name);
 		if (v.is_ref_counted()) {
-			RES res = v;
+			Ref<Resource> res = v;
 			if (res.is_valid()) {
 				if (!states_stack_ready) {
 					states_stack = PropertyUtils::get_node_states_stack(p_node);
@@ -3298,7 +3298,7 @@ void SceneTreeDock::_create_remap_for_node(Node *p_node, Map<RES, RES> &r_remap)
 	}
 }
 
-void SceneTreeDock::_create_remap_for_resource(RES p_resource, Map<RES, RES> &r_remap) {
+void SceneTreeDock::_create_remap_for_resource(Ref<Resource> p_resource, Map<Ref<Resource>, Ref<Resource>> &r_remap) {
 	r_remap[p_resource] = p_resource->duplicate();
 
 	List<PropertyInfo> props;
@@ -3311,7 +3311,7 @@ void SceneTreeDock::_create_remap_for_resource(RES p_resource, Map<RES, RES> &r_
 
 		Variant v = p_resource->get(E.name);
 		if (v.is_ref_counted()) {
-			RES res = v;
+			Ref<Resource> res = v;
 			if (res.is_valid()) {
 				if (res->is_built_in() && !r_remap.has(res)) {
 					_create_remap_for_resource(res, r_remap);

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -138,14 +138,14 @@ class SceneTreeDock : public VBoxContainer {
 
 	Node *property_drop_node = nullptr;
 	String resource_drop_path;
-	void _perform_property_drop(Node *p_node, String p_property, RES p_res);
+	void _perform_property_drop(Node *p_node, String p_property, Ref<Resource> p_res);
 
 	EditorData *editor_data = nullptr;
 	EditorSelection *editor_selection = nullptr;
 
 	List<Node *> node_clipboard;
 	String clipboard_source_scene;
-	HashMap<String, Map<RES, RES>> clipboard_resource_remap;
+	HashMap<String, Map<Ref<Resource>, Ref<Resource>>> clipboard_resource_remap;
 
 	ScriptCreateDialog *script_create_dialog = nullptr;
 	ShaderCreateDialog *shader_create_dialog = nullptr;
@@ -258,8 +258,8 @@ class SceneTreeDock : public VBoxContainer {
 	void _feature_profile_changed();
 
 	void _clear_clipboard();
-	void _create_remap_for_node(Node *p_node, Map<RES, RES> &r_remap);
-	void _create_remap_for_resource(RES p_resource, Map<RES, RES> &r_remap);
+	void _create_remap_for_node(Node *p_node, Map<Ref<Resource>, Ref<Resource>> &r_remap);
+	void _create_remap_for_resource(Ref<Resource> p_resource, Map<Ref<Resource>, Ref<Resource>> &r_remap);
 
 	bool profile_allow_editing = true;
 	bool profile_allow_script_editing = true;

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -398,7 +398,7 @@ void ScriptCreateDialog::_create_new() {
 
 void ScriptCreateDialog::_load_exist() {
 	String path = file_path->get_text();
-	RES p_script = ResourceLoader::load(path, "Script");
+	Ref<Resource> p_script = ResourceLoader::load(path, "Script");
 	if (p_script.is_null()) {
 		alert->set_text(vformat(TTR("Error loading script from %s"), path));
 		alert->popup_centered();

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -135,7 +135,7 @@ void ShaderCreateDialog::ok_pressed() {
 }
 
 void ShaderCreateDialog::_create_new() {
-	RES shader;
+	Ref<Resource> shader;
 
 	if (language_menu->get_selected() == int(SHADER_TYPE_TEXT)) {
 		Ref<Shader> text_shader;
@@ -205,7 +205,7 @@ void ShaderCreateDialog::_create_new() {
 
 void ShaderCreateDialog::_load_exist() {
 	String path = file_path->get_text();
-	RES p_shader = ResourceLoader::load(path, "Shader");
+	Ref<Resource> p_shader = ResourceLoader::load(path, "Shader");
 	if (p_shader.is_null()) {
 		alert->set_text(vformat(TTR("Error loading shader from %s"), path));
 		alert->popup_centered();

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -94,7 +94,7 @@ protected:
 		Dictionary gv;
 		gv["type"] = global_var_type_names[type];
 		if (type >= RS::GLOBAL_VAR_TYPE_SAMPLER2D) {
-			RES res = p_value;
+			Ref<Resource> res = p_value;
 			if (res.is_valid()) {
 				gv["value"] = res->get_path();
 			} else {

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2324,7 +2324,7 @@ bool Main::start() {
 				for (OrderedHashMap<StringName, ProjectSettings::AutoloadInfo>::Element E = autoloads.front(); E; E = E.next()) {
 					const ProjectSettings::AutoloadInfo &info = E.get();
 
-					RES res = ResourceLoader::load(info.path);
+					Ref<Resource> res = ResourceLoader::load(info.path);
 					ERR_CONTINUE_MSG(res.is_null(), "Can't autoload: " + info.path);
 					Node *n = nullptr;
 					Ref<PackedScene> scn = res;

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -94,7 +94,7 @@ static const DDSFormatInfo dds_format_info[DDS_MAX] = {
 	{ "GRAYSCALE_ALPHA", false, false, 1, 2, Image::FORMAT_LA8 }
 };
 
-RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Ref<Resource> ResourceFormatDDS::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	if (r_error) {
 		*r_error = ERR_CANT_OPEN;
 	}
@@ -102,7 +102,7 @@ RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path,
 	Error err;
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ, &err);
 	if (f.is_null()) {
-		return RES();
+		return Ref<Resource>();
 	}
 
 	Ref<FileAccess> fref(f);
@@ -110,7 +110,7 @@ RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path,
 		*r_error = ERR_FILE_CORRUPT;
 	}
 
-	ERR_FAIL_COND_V_MSG(err != OK, RES(), "Unable to open DDS texture file '" + p_path + "'.");
+	ERR_FAIL_COND_V_MSG(err != OK, Ref<Resource>(), "Unable to open DDS texture file '" + p_path + "'.");
 
 	uint32_t magic = f->get_32();
 	uint32_t hsize = f->get_32();
@@ -131,7 +131,7 @@ RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path,
 	// We don't check DDSD_CAPS or DDSD_PIXELFORMAT, as they're mandatory when writing,
 	// but non-mandatory when reading (as some writers don't set them)...
 	if (magic != DDS_MAGIC || hsize != 124) {
-		ERR_FAIL_V_MSG(RES(), "Invalid or unsupported DDS texture file '" + p_path + "'.");
+		ERR_FAIL_V_MSG(Ref<Resource>(), "Invalid or unsupported DDS texture file '" + p_path + "'.");
 	}
 
 	/* uint32_t format_size = */ f->get_32();
@@ -204,7 +204,7 @@ RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path,
 		dds_format = DDS_BGR565;
 	} else {
 		printf("unrecognized fourcc %x format_flags: %x - rgbbits %i - red_mask %x green mask %x blue mask %x alpha mask %x\n", format_fourcc, format_flags, format_rgb_bits, format_red_mask, format_green_mask, format_blue_mask, format_alpha_mask);
-		ERR_FAIL_V_MSG(RES(), "Unrecognized or unsupported color layout in DDS '" + p_path + "'.");
+		ERR_FAIL_V_MSG(Ref<Resource>(), "Unrecognized or unsupported color layout in DDS '" + p_path + "'.");
 	}
 
 	if (!(flags & DDSD_MIPMAPCOUNT)) {
@@ -221,8 +221,8 @@ RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path,
 		//compressed bc
 
 		uint32_t size = MAX(info.divisor, w) / info.divisor * MAX(info.divisor, h) / info.divisor * info.block_size;
-		ERR_FAIL_COND_V(size != pitch, RES());
-		ERR_FAIL_COND_V(!(flags & DDSD_LINEARSIZE), RES());
+		ERR_FAIL_COND_V(size != pitch, Ref<Resource>());
+		ERR_FAIL_COND_V(!(flags & DDSD_LINEARSIZE), Ref<Resource>());
 
 		for (uint32_t i = 1; i < mipmaps; i++) {
 			w = MAX(1u, w >> 1);
@@ -238,11 +238,11 @@ RES ResourceFormatDDS::load(const String &p_path, const String &p_original_path,
 
 	} else if (info.palette) {
 		//indexed
-		ERR_FAIL_COND_V(!(flags & DDSD_PITCH), RES());
-		ERR_FAIL_COND_V(format_rgb_bits != 8, RES());
+		ERR_FAIL_COND_V(!(flags & DDSD_PITCH), Ref<Resource>());
+		ERR_FAIL_COND_V(format_rgb_bits != 8, Ref<Resource>());
 
 		uint32_t size = pitch * height;
-		ERR_FAIL_COND_V(size != width * height * info.block_size, RES());
+		ERR_FAIL_COND_V(size != width * height * info.block_size, Ref<Resource>());
 
 		uint8_t palette[256 * 4];
 		f->get_buffer(palette, 256 * 4);

--- a/modules/dds/texture_loader_dds.h
+++ b/modules/dds/texture_loader_dds.h
@@ -36,7 +36,7 @@
 
 class ResourceFormatDDS : public ResourceFormatLoader {
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
+++ b/modules/gdscript/editor/gdscript_translation_parser_plugin.cpp
@@ -44,7 +44,7 @@ Error GDScriptEditorTranslationParserPlugin::parse_file(const String &p_path, Ve
 	// Search strings in AssignmentNode -> text = "__", hint_tooltip = "__" etc.
 
 	Error err;
-	RES loaded_res = ResourceLoader::load(p_path, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
+	Ref<Resource> loaded_res = ResourceLoader::load(p_path, "", ResourceFormatLoader::CACHE_MODE_REUSE, &err);
 	if (err) {
 		ERR_PRINT("Failed to load " + p_path);
 		return err;

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -82,7 +82,7 @@ Variant GDScriptNativeClass::_new() {
 
 	RefCounted *rc = Object::cast_to<RefCounted>(o);
 	if (rc) {
-		return REF(rc);
+		return Ref<RefCounted>(rc);
 	} else {
 		return o;
 	}
@@ -195,7 +195,7 @@ Variant GDScript::_new(const Variant **p_args, int p_argcount, Callable::CallErr
 	}
 
 	r_error.error = Callable::CallError::CALL_OK;
-	REF ref;
+	Ref<RefCounted> ref;
 	Object *owner = nullptr;
 
 	GDScript *_baseptr = this;
@@ -213,7 +213,7 @@ Variant GDScript::_new(const Variant **p_args, int p_argcount, Callable::CallErr
 
 	RefCounted *r = Object::cast_to<RefCounted>(owner);
 	if (r) {
-		ref = REF(r);
+		ref = Ref<RefCounted>(r);
 	}
 
 	GDScriptInstance *instance = _create_instance(p_args, p_argcount, owner, r != nullptr, r_error);
@@ -2292,7 +2292,7 @@ Ref<GDScript> GDScriptLanguage::get_orphan_subclass(const String &p_qualified_na
 
 /*************** RESOURCE ***************/
 
-RES ResourceFormatLoaderGDScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Ref<Resource> ResourceFormatLoaderGDScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	if (r_error) {
 		*r_error = ERR_FILE_CANT_OPEN;
 	}
@@ -2353,7 +2353,7 @@ void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<S
 	}
 }
 
-Error ResourceFormatSaverGDScript::save(const String &p_path, const RES &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverGDScript::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
 	Ref<GDScript> sqscr = p_resource;
 	ERR_FAIL_COND_V(sqscr.is_null(), ERR_INVALID_PARAMETER);
 
@@ -2378,12 +2378,12 @@ Error ResourceFormatSaverGDScript::save(const String &p_path, const RES &p_resou
 	return OK;
 }
 
-void ResourceFormatSaverGDScript::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaverGDScript::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
 	if (Object::cast_to<GDScript>(*p_resource)) {
 		p_extensions->push_back("gd");
 	}
 }
 
-bool ResourceFormatSaverGDScript::recognize(const RES &p_resource) const {
+bool ResourceFormatSaverGDScript::recognize(const Ref<Resource> &p_resource) const {
 	return Object::cast_to<GDScript>(*p_resource) != nullptr;
 }

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -512,7 +512,7 @@ public:
 
 class ResourceFormatLoaderGDScript : public ResourceFormatLoader {
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;
@@ -521,9 +521,9 @@ public:
 
 class ResourceFormatSaverGDScript : public ResourceFormatSaver {
 public:
-	virtual Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = 0);
-	virtual void get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const;
-	virtual bool recognize(const RES &p_resource) const;
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
+	virtual bool recognize(const Ref<Resource> &p_resource) const;
 };
 
 #endif // GDSCRIPT_H

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -356,7 +356,7 @@ GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &code
 					class_node = class_node->outer;
 				}
 
-				RES res;
+				Ref<Resource> res;
 
 				if (class_node->identifier && class_node->identifier->name == identifier) {
 					res = Ref<GDScript>(main_script);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -3106,7 +3106,7 @@ static Error _lookup_symbol_from_base(const GDScriptParser::DataType &p_base, co
 				}
 
 				Variant v;
-				REF v_ref;
+				Ref<RefCounted> v_ref;
 				if (base_type.builtin_type == Variant::OBJECT) {
 					v_ref.instantiate();
 					v = v_ref;

--- a/modules/gdscript/language_server/gdscript_extend_parser.cpp
+++ b/modules/gdscript/language_server/gdscript_extend_parser.cpp
@@ -212,7 +212,7 @@ void ExtendGDScriptParser::parse_class_symbol(const GDScriptParser::ClassNode *p
 				const Variant &default_value = m.constant->initializer->reduced_value;
 				String value_text;
 				if (default_value.get_type() == Variant::OBJECT) {
-					RES res = default_value;
+					Ref<Resource> res = default_value;
 					if (res.is_valid() && !res->get_path().is_empty()) {
 						value_text = "preload(\"" + res->get_path() + "\")";
 						if (symbol.documentation.is_empty()) {

--- a/modules/gdscript/language_server/gdscript_workspace.cpp
+++ b/modules/gdscript/language_server/gdscript_workspace.cpp
@@ -560,7 +560,7 @@ Node *GDScriptWorkspace::_get_owner_scene_node(String p_path) {
 
 	for (int i = 0; i < owners.size(); i++) {
 		NodePath owner_path = owners[i];
-		RES owner_res = ResourceLoader::load(owner_path);
+		Ref<Resource> owner_res = ResourceLoader::load(owner_path);
 		if (Object::cast_to<PackedScene>(owner_res.ptr())) {
 			Ref<PackedScene> owner_packed_scene = Ref<PackedScene>(Object::cast_to<PackedScene>(*owner_res));
 			owner_scene_node = owner_packed_scene->instantiate();

--- a/modules/gdscript/tests/gdscript_test_runner.cpp
+++ b/modules/gdscript/tests/gdscript_test_runner.cpp
@@ -70,7 +70,7 @@ void init_autoloads() {
 			continue;
 		}
 
-		RES res = ResourceLoader::load(info.path);
+		Ref<Resource> res = ResourceLoader::load(info.path);
 		ERR_CONTINUE_MSG(res.is_null(), "Can't autoload: " + info.path);
 		Node *n = nullptr;
 		Ref<PackedScene> scn = res;

--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -797,7 +797,7 @@ void GridMap::clear() {
 	clear_baked_meshes();
 }
 
-void GridMap::resource_changed(const RES &p_res) {
+void GridMap::resource_changed(const Ref<Resource> &p_res) {
 	_recreate_octant_data();
 }
 

--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -181,7 +181,7 @@ class GridMap : public Node3D {
 	void _queue_octants_dirty();
 	void _update_octants_callback();
 
-	void resource_changed(const RES &p_res);
+	void resource_changed(const Ref<Resource> &p_res);
 
 	void _clear_internal();
 

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -924,7 +924,7 @@ void CSharpLanguage::reload_assemblies(bool p_soft_reload) {
 	for (Ref<CSharpScript> &script : scripts) {
 		while (script->instances.front()) {
 			Object *obj = script->instances.front()->get();
-			obj->set_script(REF()); // Remove script and existing script instances (placeholder are not removed before domain reload)
+			obj->set_script(Ref<RefCounted>()); // Remove script and existing script instances (placeholder are not removed before domain reload)
 		}
 
 		script->_clear();
@@ -3221,10 +3221,10 @@ Variant CSharpScript::_new(const Variant **p_args, int p_argcount, Callable::Cal
 
 	Object *owner = ClassDB::instantiate(NATIVE_GDMONOCLASS_NAME(native));
 
-	REF ref;
+	Ref<RefCounted> ref;
 	RefCounted *r = Object::cast_to<RefCounted>(owner);
 	if (r) {
-		ref = REF(r);
+		ref = Ref<RefCounted>(r);
 	}
 
 	CSharpInstance *instance = _create_instance(p_args, p_argcount, owner, r != nullptr, r_error);
@@ -3586,7 +3586,7 @@ void CSharpScript::get_members(Set<StringName> *p_members) {
 
 /*************** RESOURCE ***************/
 
-RES ResourceFormatLoaderCSharpScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Ref<Resource> ResourceFormatLoaderCSharpScript::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	if (r_error) {
 		*r_error = ERR_FILE_CANT_OPEN;
 	}
@@ -3599,7 +3599,7 @@ RES ResourceFormatLoaderCSharpScript::load(const String &p_path, const String &p
 
 #if defined(DEBUG_ENABLED) || defined(TOOLS_ENABLED)
 	Error err = script->load_source_code(p_path);
-	ERR_FAIL_COND_V_MSG(err != OK, RES(), "Cannot load C# script file '" + p_path + "'.");
+	ERR_FAIL_COND_V_MSG(err != OK, Ref<Resource>(), "Cannot load C# script file '" + p_path + "'.");
 #endif
 
 	script->set_path(p_original_path);
@@ -3625,7 +3625,7 @@ String ResourceFormatLoaderCSharpScript::get_resource_type(const String &p_path)
 	return p_path.get_extension().to_lower() == "cs" ? CSharpLanguage::get_singleton()->get_type() : "";
 }
 
-Error ResourceFormatSaverCSharpScript::save(const String &p_path, const RES &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverCSharpScript::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
 	Ref<CSharpScript> sqscr = p_resource;
 	ERR_FAIL_COND_V(sqscr.is_null(), ERR_INVALID_PARAMETER);
 
@@ -3662,13 +3662,13 @@ Error ResourceFormatSaverCSharpScript::save(const String &p_path, const RES &p_r
 	return OK;
 }
 
-void ResourceFormatSaverCSharpScript::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaverCSharpScript::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
 	if (Object::cast_to<CSharpScript>(p_resource.ptr())) {
 		p_extensions->push_back("cs");
 	}
 }
 
-bool ResourceFormatSaverCSharpScript::recognize(const RES &p_resource) const {
+bool ResourceFormatSaverCSharpScript::recognize(const Ref<Resource> &p_resource) const {
 	return Object::cast_to<CSharpScript>(p_resource.ptr()) != nullptr;
 }
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -534,7 +534,7 @@ public:
 
 class ResourceFormatLoaderCSharpScript : public ResourceFormatLoader {
 public:
-	RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
+	Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
 	void get_recognized_extensions(List<String> *p_extensions) const override;
 	bool handles_type(const String &p_type) const override;
 	String get_resource_type(const String &p_path) const override;
@@ -542,9 +542,9 @@ public:
 
 class ResourceFormatSaverCSharpScript : public ResourceFormatSaver {
 public:
-	Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = 0) override;
-	void get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const override;
-	bool recognize(const RES &p_resource) const override;
+	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0) override;
+	void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	bool recognize(const Ref<Resource> &p_resource) const override;
 };
 
 #endif // CSHARP_SCRIPT_H

--- a/modules/mono/glue/base_object_glue.cpp
+++ b/modules/mono/glue/base_object_glue.cpp
@@ -148,7 +148,7 @@ MonoObject *godot_icall_Object_weakref(Object *p_ptr) {
 	RefCounted *rc = Object::cast_to<RefCounted>(p_ptr);
 
 	if (rc) {
-		REF r = rc;
+		Ref<RefCounted> r = rc;
 		if (!r.is_valid()) {
 			return nullptr;
 		}

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -669,13 +669,13 @@ void VideoStreamTheora::_bind_methods() {
 
 ////////////
 
-RES ResourceFormatLoaderTheora::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Ref<Resource> ResourceFormatLoaderTheora::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	Ref<FileAccess> f = FileAccess::open(p_path, FileAccess::READ);
 	if (f.is_null()) {
 		if (r_error) {
 			*r_error = ERR_CANT_OPEN;
 		}
-		return RES();
+		return Ref<Resource>();
 	}
 
 	VideoStreamTheora *stream = memnew(VideoStreamTheora);

--- a/modules/theora/video_stream_theora.h
+++ b/modules/theora/video_stream_theora.h
@@ -186,7 +186,7 @@ public:
 
 class ResourceFormatLoaderTheora : public ResourceFormatLoader {
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -2611,11 +2611,11 @@ void VisualScriptEditor::_button_resource_previewed(const String &p_path, const 
 void VisualScriptEditor::apply_code() {
 }
 
-RES VisualScriptEditor::get_edited_resource() const {
+Ref<Resource> VisualScriptEditor::get_edited_resource() const {
 	return script;
 }
 
-void VisualScriptEditor::set_edited_resource(const RES &p_res) {
+void VisualScriptEditor::set_edited_resource(const Ref<Resource> &p_res) {
 	ERR_FAIL_COND(script.is_valid());
 	ERR_FAIL_COND(p_res.is_null());
 	script = p_res;
@@ -4795,7 +4795,7 @@ VisualScriptEditor::~VisualScriptEditor() {
 	memdelete(variable_editor);
 }
 
-static ScriptEditorBase *create_editor(const RES &p_resource) {
+static ScriptEditorBase *create_editor(const Ref<Resource> &p_resource) {
 	if (Object::cast_to<VisualScript>(*p_resource)) {
 		return memnew(VisualScriptEditor);
 	}
@@ -4839,7 +4839,7 @@ Ref<VisualScriptNode> VisualScriptCustomNodes::create_node_custom(const String &
 }
 
 VisualScriptCustomNodes *VisualScriptCustomNodes::singleton = nullptr;
-Map<String, REF> VisualScriptCustomNodes::custom_nodes;
+Map<String, Ref<RefCounted>> VisualScriptCustomNodes::custom_nodes;
 
 VisualScriptCustomNodes::VisualScriptCustomNodes() {
 	singleton = this;

--- a/modules/visual_script/editor/visual_script_editor.h
+++ b/modules/visual_script/editor/visual_script_editor.h
@@ -303,8 +303,8 @@ public:
 	virtual void set_syntax_highlighter(Ref<EditorSyntaxHighlighter> p_highlighter) override;
 
 	virtual void apply_code() override;
-	virtual RES get_edited_resource() const override;
-	virtual void set_edited_resource(const RES &p_res) override;
+	virtual Ref<Resource> get_edited_resource() const override;
+	virtual void set_edited_resource(const Ref<Resource> &p_res) override;
 	virtual void enable_editor() override;
 	virtual Vector<String> get_functions() override;
 	virtual void reload_text() override;
@@ -359,7 +359,7 @@ protected:
 	static void _bind_methods();
 	static VisualScriptCustomNodes *singleton;
 
-	static Map<String, REF> custom_nodes;
+	static Map<String, Ref<RefCounted>> custom_nodes;
 	static Ref<VisualScriptNode> create_node_custom(const String &p_name);
 
 public:

--- a/modules/visual_script/visual_script_builtin_funcs.cpp
+++ b/modules/visual_script/visual_script_builtin_funcs.cpp
@@ -989,7 +989,7 @@ void VisualScriptBuiltinFunc::exec_func(BuiltinFunc p_func, const Variant **p_in
 			}
 
 			if (p_inputs[0]->is_ref_counted()) {
-				REF r = *p_inputs[0];
+				Ref<RefCounted> r = *p_inputs[0];
 				if (!r.is_valid()) {
 					return;
 				}

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -371,7 +371,7 @@ DisplayServer::CursorShape DisplayServerJavaScript::cursor_get_shape() const {
 	return cursor_shape;
 }
 
-void DisplayServerJavaScript::cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
+void DisplayServerJavaScript::cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
 	if (p_cursor.is_valid()) {
 		Ref<Texture2D> texture = p_cursor;
 		Ref<AtlasTexture> atlas_texture = p_cursor;

--- a/platform/javascript/display_server_javascript.h
+++ b/platform/javascript/display_server_javascript.h
@@ -134,7 +134,7 @@ public:
 	// cursor
 	virtual void cursor_set_shape(CursorShape p_shape) override;
 	virtual CursorShape cursor_get_shape() const override;
-	virtual void cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2()) override;
+	virtual void cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2()) override;
 
 	// mouse
 	virtual void mouse_set_mode(MouseMode p_mode) override;

--- a/platform/javascript/http_client_javascript.cpp
+++ b/platform/javascript/http_client_javascript.cpp
@@ -76,7 +76,7 @@ void HTTPClientJavaScript::set_connection(const Ref<StreamPeer> &p_connection) {
 }
 
 Ref<StreamPeer> HTTPClientJavaScript::get_connection() const {
-	ERR_FAIL_V_MSG(REF(), "Accessing an HTTPClientJavaScript's StreamPeer is not supported for the HTML5 platform.");
+	ERR_FAIL_V_MSG(Ref<RefCounted>(), "Accessing an HTTPClientJavaScript's StreamPeer is not supported for the HTML5 platform.");
 }
 
 Error HTTPClientJavaScript::request(Method p_method, const String &p_url, const Vector<String> &p_headers, const uint8_t *p_body, int p_body_len) {

--- a/platform/linuxbsd/display_server_x11.cpp
+++ b/platform/linuxbsd/display_server_x11.cpp
@@ -2356,7 +2356,7 @@ DisplayServerX11::CursorShape DisplayServerX11::cursor_get_shape() const {
 	return current_cursor;
 }
 
-void DisplayServerX11::cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
+void DisplayServerX11::cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
 	_THREAD_SAFE_METHOD_
 
 	if (p_cursor.is_valid()) {

--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -407,7 +407,7 @@ public:
 
 	virtual void cursor_set_shape(CursorShape p_shape) override;
 	virtual CursorShape cursor_get_shape() const override;
-	virtual void cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) override;
+	virtual void cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) override;
 
 	virtual int keyboard_get_layout_count() const override;
 	virtual int keyboard_get_current_layout() const override;

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -372,7 +372,7 @@ public:
 	void cursor_update_shape();
 	virtual void cursor_set_shape(CursorShape p_shape) override;
 	virtual CursorShape cursor_get_shape() const override;
-	virtual void cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2()) override;
+	virtual void cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2()) override;
 
 	virtual bool get_swap_cancel_ok() override;
 

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -2674,7 +2674,7 @@ DisplayServerOSX::CursorShape DisplayServerOSX::cursor_get_shape() const {
 	return cursor_shape;
 }
 
-void DisplayServerOSX::cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
+void DisplayServerOSX::cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
 	_THREAD_SAFE_METHOD_
 
 	if (p_cursor.is_valid()) {

--- a/platform/uwp/os_uwp.cpp
+++ b/platform/uwp/os_uwp.cpp
@@ -631,7 +631,7 @@ OS::CursorShape OS_UWP::get_cursor_shape() const {
 	return cursor_shape;
 }
 
-void OS_UWP::set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
+void OS_UWP::set_custom_mouse_cursor(const Ref<Resource> &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
 	// TODO
 }
 

--- a/platform/uwp/os_uwp.h
+++ b/platform/uwp/os_uwp.h
@@ -208,7 +208,7 @@ public:
 
 	void set_cursor_shape(CursorShape p_shape);
 	CursorShape get_cursor_shape() const;
-	virtual void set_custom_mouse_cursor(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot);
+	virtual void set_custom_mouse_cursor(const Ref<Resource> &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot);
 	void set_icon(const Ref<Image> &p_icon);
 
 	virtual String get_executable_path() const;

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -1490,7 +1490,7 @@ void DisplayServerWindows::GetMaskBitmaps(HBITMAP hSourceBitmap, COLORREF clrTra
 	DeleteDC(hMainDC);
 }
 
-void DisplayServerWindows::cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
+void DisplayServerWindows::cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
 	_THREAD_SAFE_METHOD_
 
 	if (p_cursor.is_valid()) {

--- a/platform/windows/display_server_windows.h
+++ b/platform/windows/display_server_windows.h
@@ -561,7 +561,7 @@ public:
 
 	virtual void cursor_set_shape(CursorShape p_shape) override;
 	virtual CursorShape cursor_get_shape() const override;
-	virtual void cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2()) override;
+	virtual void cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2()) override;
 
 	virtual bool get_swap_cancel_ok() override;
 

--- a/scene/3d/collision_shape_3d.cpp
+++ b/scene/3d/collision_shape_3d.cpp
@@ -110,7 +110,7 @@ void CollisionShape3D::_notification(int p_what) {
 	}
 }
 
-void CollisionShape3D::resource_changed(RES res) {
+void CollisionShape3D::resource_changed(Ref<Resource> res) {
 	update_gizmos();
 }
 

--- a/scene/3d/collision_shape_3d.h
+++ b/scene/3d/collision_shape_3d.h
@@ -43,7 +43,7 @@ class CollisionShape3D : public Node3D {
 	uint32_t owner_id = 0;
 	CollisionObject3D *parent = nullptr;
 
-	void resource_changed(RES res);
+	void resource_changed(Ref<Resource> res);
 	bool disabled = false;
 
 protected:

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -284,7 +284,7 @@ void AnimationPlayer::_ensure_node_caches(AnimationData *p_anim, Node *p_root_ov
 
 	for (int i = 0; i < a->get_track_count(); i++) {
 		p_anim->node_cache.write[i] = nullptr;
-		RES resource;
+		Ref<Resource> resource;
 		Vector<StringName> leftover_path;
 		Node *child = parent->get_node_and_resource(a->track_get_path(i), resource, leftover_path);
 		ERR_CONTINUE_MSG(!child, "On Animation: '" + p_anim->name + "', couldn't resolve track:  '" + String(a->track_get_path(i)) + "'."); // couldn't find the child node

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -94,7 +94,7 @@ private:
 	struct TrackNodeCache {
 		NodePath path;
 		uint32_t id = 0;
-		RES resource;
+		Ref<Resource> resource;
 		Node *node = nullptr;
 		Node2D *node_2d = nullptr;
 #ifndef _3D_DISABLED

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -570,7 +570,7 @@ bool AnimationTree::_update_caches(AnimationPlayer *player) {
 			}
 
 			if (!track) {
-				RES resource;
+				Ref<Resource> resource;
 				Vector<StringName> leftover_path;
 				Node *child = parent->get_node_and_resource(path, resource, leftover_path);
 

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -467,7 +467,7 @@ void SceneDebuggerObject::serialize(Array &r_arr, int p_max_size) {
 		const PropertyInfo &pi = properties[i].first;
 		Variant &var = properties[i].second;
 
-		RES res = var;
+		Ref<Resource> res = var;
 
 		Array prop;
 		prop.push_back(pi.name);
@@ -529,7 +529,7 @@ void SceneDebuggerObject::deserialize(const Array &p_arr) {
 
 		if (pinfo.type == Variant::OBJECT) {
 			if (var.is_zero()) {
-				var = RES();
+				var = Ref<Resource>();
 			} else if (var.get_type() == Variant::OBJECT) {
 				if (((Object *)var)->is_class("EncodedObjectAsID")) {
 					var = Object::cast_to<EncodedObjectAsID>(var)->get_object_id();
@@ -646,7 +646,7 @@ void LiveEditor::_node_set_func(int p_id, const StringName &p_prop, const Varian
 }
 
 void LiveEditor::_node_set_res_func(int p_id, const StringName &p_prop, const String &p_value) {
-	RES r = ResourceLoader::load(p_value);
+	Ref<Resource> r = ResourceLoader::load(p_value);
 	if (!r.is_valid()) {
 		return;
 	}
@@ -701,7 +701,7 @@ void LiveEditor::_res_set_func(int p_id, const StringName &p_prop, const Variant
 		return;
 	}
 
-	RES r = ResourceCache::get(resp);
+	Ref<Resource> r = ResourceCache::get(resp);
 	if (!r.is_valid()) {
 		return;
 	}
@@ -710,7 +710,7 @@ void LiveEditor::_res_set_func(int p_id, const StringName &p_prop, const Variant
 }
 
 void LiveEditor::_res_set_res_func(int p_id, const StringName &p_prop, const String &p_value) {
-	RES r = ResourceLoader::load(p_value);
+	Ref<Resource> r = ResourceLoader::load(p_value);
 	if (!r.is_valid()) {
 		return;
 	}
@@ -728,7 +728,7 @@ void LiveEditor::_res_call_func(int p_id, const StringName &p_method, const Vari
 		return;
 	}
 
-	RES r = ResourceCache::get(resp);
+	Ref<Resource> r = ResourceCache::get(resp);
 	if (!r.is_valid()) {
 		return;
 	}

--- a/scene/gui/code_edit.cpp
+++ b/scene/gui/code_edit.cpp
@@ -1818,7 +1818,7 @@ void CodeEdit::request_code_completion(bool p_force) {
 	}
 }
 
-void CodeEdit::add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color, const RES &p_icon, const Variant &p_value) {
+void CodeEdit::add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color, const Ref<Resource> &p_icon, const Variant &p_value) {
 	ScriptLanguage::CodeCompletionOption completion_option;
 	completion_option.kind = (ScriptLanguage::CodeCompletionKind)p_type;
 	completion_option.display = p_display_text;
@@ -2196,7 +2196,7 @@ void CodeEdit::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_text_for_code_completion"), &CodeEdit::get_text_for_code_completion);
 	ClassDB::bind_method(D_METHOD("request_code_completion", "force"), &CodeEdit::request_code_completion, DEFVAL(false));
-	ClassDB::bind_method(D_METHOD("add_code_completion_option", "type", "display_text", "insert_text", "text_color", "icon", "value"), &CodeEdit::add_code_completion_option, DEFVAL(Color(1, 1, 1)), DEFVAL(RES()), DEFVAL(Variant::NIL));
+	ClassDB::bind_method(D_METHOD("add_code_completion_option", "type", "display_text", "insert_text", "text_color", "icon", "value"), &CodeEdit::add_code_completion_option, DEFVAL(Color(1, 1, 1)), DEFVAL(Ref<Resource>()), DEFVAL(Variant::NIL));
 	ClassDB::bind_method(D_METHOD("update_code_completion_options", "force"), &CodeEdit::update_code_completion_options);
 	ClassDB::bind_method(D_METHOD("get_code_completion_options"), &CodeEdit::get_code_completion_options);
 	ClassDB::bind_method(D_METHOD("get_code_completion_option", "index"), &CodeEdit::get_code_completion_option);

--- a/scene/gui/code_edit.h
+++ b/scene/gui/code_edit.h
@@ -398,7 +398,7 @@ public:
 
 	void request_code_completion(bool p_force = false);
 
-	void add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const RES &p_icon = RES(), const Variant &p_value = Variant::NIL);
+	void add_code_completion_option(CodeCompletionKind p_type, const String &p_display_text, const String &p_insert_text, const Color &p_text_color = Color(1, 1, 1), const Ref<Resource> &p_icon = Ref<Resource>(), const Variant &p_value = Variant::NIL);
 	void update_code_completion_options(bool p_forced = false);
 
 	TypedArray<Dictionary> get_code_completion_options() const;

--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2288,10 +2288,10 @@ Node *Node::duplicate(int p_flags) const {
 
 #ifdef TOOLS_ENABLED
 Node *Node::duplicate_from_editor(Map<const Node *, Node *> &r_duplimap) const {
-	return duplicate_from_editor(r_duplimap, Map<RES, RES>());
+	return duplicate_from_editor(r_duplimap, Map<Ref<Resource>, Ref<Resource>>());
 }
 
-Node *Node::duplicate_from_editor(Map<const Node *, Node *> &r_duplimap, const Map<RES, RES> &p_resource_remap) const {
+Node *Node::duplicate_from_editor(Map<const Node *, Node *> &r_duplimap, const Map<Ref<Resource>, Ref<Resource>> &p_resource_remap) const {
 	Node *dupe = _duplicate(DUPLICATE_SIGNALS | DUPLICATE_GROUPS | DUPLICATE_SCRIPTS | DUPLICATE_USE_INSTANCING | DUPLICATE_FROM_EDITOR, &r_duplimap);
 
 	// This is used by SceneTreeDock's paste functionality. When pasting to foreign scene, resources are duplicated.
@@ -2307,7 +2307,7 @@ Node *Node::duplicate_from_editor(Map<const Node *, Node *> &r_duplimap, const M
 	return dupe;
 }
 
-void Node::remap_node_resources(Node *p_node, const Map<RES, RES> &p_resource_remap) const {
+void Node::remap_node_resources(Node *p_node, const Map<Ref<Resource>, Ref<Resource>> &p_resource_remap) const {
 	List<PropertyInfo> props;
 	p_node->get_property_list(&props);
 
@@ -2318,7 +2318,7 @@ void Node::remap_node_resources(Node *p_node, const Map<RES, RES> &p_resource_re
 
 		Variant v = p_node->get(E.name);
 		if (v.is_ref_counted()) {
-			RES res = v;
+			Ref<Resource> res = v;
 			if (res.is_valid()) {
 				if (p_resource_remap.has(res)) {
 					p_node->set(E.name, p_resource_remap[res]);
@@ -2333,7 +2333,7 @@ void Node::remap_node_resources(Node *p_node, const Map<RES, RES> &p_resource_re
 	}
 }
 
-void Node::remap_nested_resources(RES p_resource, const Map<RES, RES> &p_resource_remap) const {
+void Node::remap_nested_resources(Ref<Resource> p_resource, const Map<Ref<Resource>, Ref<Resource>> &p_resource_remap) const {
 	List<PropertyInfo> props;
 	p_resource->get_property_list(&props);
 
@@ -2344,7 +2344,7 @@ void Node::remap_nested_resources(RES p_resource, const Map<RES, RES> &p_resourc
 
 		Variant v = p_resource->get(E.name);
 		if (v.is_ref_counted()) {
-			RES res = v;
+			Ref<Resource> res = v;
 			if (res.is_valid()) {
 				if (p_resource_remap.has(res)) {
 					p_resource->set(E.name, p_resource_remap[res]);
@@ -2493,7 +2493,7 @@ bool Node::has_node_and_resource(const NodePath &p_path) const {
 	if (!has_node(p_path)) {
 		return false;
 	}
-	RES res;
+	Ref<Resource> res;
 	Vector<StringName> leftover_path;
 	Node *node = get_node_and_resource(p_path, res, leftover_path, false);
 
@@ -2501,7 +2501,7 @@ bool Node::has_node_and_resource(const NodePath &p_path) const {
 }
 
 Array Node::_get_node_and_resource(const NodePath &p_path) {
-	RES res;
+	Ref<Resource> res;
 	Vector<StringName> leftover_path;
 	Node *node = get_node_and_resource(p_path, res, leftover_path, false);
 	Array result;
@@ -2523,9 +2523,9 @@ Array Node::_get_node_and_resource(const NodePath &p_path) {
 	return result;
 }
 
-Node *Node::get_node_and_resource(const NodePath &p_path, RES &r_res, Vector<StringName> &r_leftover_subpath, bool p_last_is_property) const {
+Node *Node::get_node_and_resource(const NodePath &p_path, Ref<Resource> &r_res, Vector<StringName> &r_leftover_subpath, bool p_last_is_property) const {
 	Node *node = get_node(p_path);
-	r_res = RES();
+	r_res = Ref<Resource>();
 	r_leftover_subpath = Vector<StringName>();
 	if (!node) {
 		return nullptr;
@@ -2541,7 +2541,7 @@ Node *Node::get_node_and_resource(const NodePath &p_path, RES &r_res, Vector<Str
 				return nullptr;
 			}
 
-			RES new_res = new_res_v;
+			Ref<Resource> new_res = new_res_v;
 
 			if (new_res.is_null()) { // No longer a resource, assume property
 				break;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -313,7 +313,7 @@ public:
 	Node *find_child(const String &p_pattern, bool p_recursive = true, bool p_owned = true) const;
 	TypedArray<Node> find_children(const String &p_pattern, const String &p_type = "", bool p_recursive = true, bool p_owned = true) const;
 	bool has_node_and_resource(const NodePath &p_path) const;
-	Node *get_node_and_resource(const NodePath &p_path, RES &r_res, Vector<StringName> &r_leftover_subpath, bool p_last_is_property = true) const;
+	Node *get_node_and_resource(const NodePath &p_path, Ref<Resource> &r_res, Vector<StringName> &r_leftover_subpath, bool p_last_is_property = true) const;
 
 	Node *get_parent() const;
 	Node *find_parent(const String &p_pattern) const;
@@ -421,9 +421,9 @@ public:
 	Node *duplicate(int p_flags = DUPLICATE_GROUPS | DUPLICATE_SIGNALS | DUPLICATE_SCRIPTS) const;
 #ifdef TOOLS_ENABLED
 	Node *duplicate_from_editor(Map<const Node *, Node *> &r_duplimap) const;
-	Node *duplicate_from_editor(Map<const Node *, Node *> &r_duplimap, const Map<RES, RES> &p_resource_remap) const;
-	void remap_node_resources(Node *p_node, const Map<RES, RES> &p_resource_remap) const;
-	void remap_nested_resources(RES p_resource, const Map<RES, RES> &p_resource_remap) const;
+	Node *duplicate_from_editor(Map<const Node *, Node *> &r_duplimap, const Map<Ref<Resource>, Ref<Resource>> &p_resource_remap) const;
+	void remap_node_resources(Node *p_node, const Map<Ref<Resource>, Ref<Resource>> &p_resource_remap) const;
+	void remap_nested_resources(Ref<Resource> p_resource, const Map<Ref<Resource>, Ref<Resource>> &p_resource_remap) const;
 #endif
 
 	// used by editors, to save what has changed only

--- a/scene/main/resource_preloader.cpp
+++ b/scene/main/resource_preloader.cpp
@@ -41,7 +41,7 @@ void ResourcePreloader::_set_resources(const Array &p_data) {
 
 	for (int i = 0; i < resdata.size(); i++) {
 		String name = names[i];
-		RES resource = resdata[i];
+		Ref<Resource> resource = resdata[i];
 		ERR_CONTINUE(!resource.is_valid());
 		resources[name] = resource;
 
@@ -57,7 +57,7 @@ Array ResourcePreloader::_get_resources() const {
 
 	Set<String> sorted_names;
 
-	for (const KeyValue<StringName, RES> &E : resources) {
+	for (const KeyValue<StringName, Ref<Resource>> &E : resources) {
 		sorted_names.insert(E.key);
 	}
 
@@ -74,7 +74,7 @@ Array ResourcePreloader::_get_resources() const {
 	return res;
 }
 
-void ResourcePreloader::add_resource(const StringName &p_name, const RES &p_resource) {
+void ResourcePreloader::add_resource(const StringName &p_name, const Ref<Resource> &p_resource) {
 	ERR_FAIL_COND(p_resource.is_null());
 	if (resources.has(p_name)) {
 		StringName new_name;
@@ -104,7 +104,7 @@ void ResourcePreloader::remove_resource(const StringName &p_name) {
 void ResourcePreloader::rename_resource(const StringName &p_from_name, const StringName &p_to_name) {
 	ERR_FAIL_COND(!resources.has(p_from_name));
 
-	RES res = resources[p_from_name];
+	Ref<Resource> res = resources[p_from_name];
 
 	resources.erase(p_from_name);
 	add_resource(p_to_name, res);
@@ -114,8 +114,8 @@ bool ResourcePreloader::has_resource(const StringName &p_name) const {
 	return resources.has(p_name);
 }
 
-RES ResourcePreloader::get_resource(const StringName &p_name) const {
-	ERR_FAIL_COND_V(!resources.has(p_name), RES());
+Ref<Resource> ResourcePreloader::get_resource(const StringName &p_name) const {
+	ERR_FAIL_COND_V(!resources.has(p_name), Ref<Resource>());
 	return resources[p_name];
 }
 
@@ -123,7 +123,7 @@ Vector<String> ResourcePreloader::_get_resource_list() const {
 	Vector<String> res;
 	res.resize(resources.size());
 	int i = 0;
-	for (Map<StringName, RES>::Element *E = resources.front(); E; E = E->next(), i++) {
+	for (Map<StringName, Ref<Resource>>::Element *E = resources.front(); E; E = E->next(), i++) {
 		res.set(i, E->key());
 	}
 
@@ -131,7 +131,7 @@ Vector<String> ResourcePreloader::_get_resource_list() const {
 }
 
 void ResourcePreloader::get_resource_list(List<StringName> *p_list) {
-	for (const KeyValue<StringName, RES> &E : resources) {
+	for (const KeyValue<StringName, Ref<Resource>> &E : resources) {
 		p_list->push_back(E.key);
 	}
 }

--- a/scene/main/resource_preloader.h
+++ b/scene/main/resource_preloader.h
@@ -36,7 +36,7 @@
 class ResourcePreloader : public Node {
 	GDCLASS(ResourcePreloader, Node);
 
-	Map<StringName, RES> resources;
+	Map<StringName, Ref<Resource>> resources;
 
 	void _set_resources(const Array &p_data);
 	Array _get_resources() const;
@@ -46,11 +46,11 @@ protected:
 	static void _bind_methods();
 
 public:
-	void add_resource(const StringName &p_name, const RES &p_resource);
+	void add_resource(const StringName &p_name, const Ref<Resource> &p_resource);
 	void remove_resource(const StringName &p_name);
 	void rename_resource(const StringName &p_from_name, const StringName &p_to_name);
 	bool has_resource(const StringName &p_name) const;
-	RES get_resource(const StringName &p_name) const;
+	Ref<Resource> get_resource(const StringName &p_name) const;
 
 	void get_resource_list(List<StringName> *p_list);
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -3455,7 +3455,7 @@ real_t Animation::bezier_track_interpolate(int p_track, double p_time) const {
 	return low_pos.lerp(high_pos, c).y;
 }
 
-int Animation::audio_track_insert_key(int p_track, double p_time, const RES &p_stream, real_t p_start_offset, real_t p_end_offset) {
+int Animation::audio_track_insert_key(int p_track, double p_time, const Ref<Resource> &p_stream, real_t p_start_offset, real_t p_end_offset) {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND_V(t->type != TYPE_AUDIO, -1);
@@ -3481,7 +3481,7 @@ int Animation::audio_track_insert_key(int p_track, double p_time, const RES &p_s
 	return key;
 }
 
-void Animation::audio_track_set_key_stream(int p_track, int p_key, const RES &p_stream) {
+void Animation::audio_track_set_key_stream(int p_track, int p_key, const Ref<Resource> &p_stream) {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	Track *t = tracks[p_track];
 	ERR_FAIL_COND(t->type != TYPE_AUDIO);
@@ -3531,14 +3531,14 @@ void Animation::audio_track_set_key_end_offset(int p_track, int p_key, real_t p_
 	emit_changed();
 }
 
-RES Animation::audio_track_get_key_stream(int p_track, int p_key) const {
-	ERR_FAIL_INDEX_V(p_track, tracks.size(), RES());
+Ref<Resource> Animation::audio_track_get_key_stream(int p_track, int p_key) const {
+	ERR_FAIL_INDEX_V(p_track, tracks.size(), Ref<Resource>());
 	const Track *t = tracks[p_track];
-	ERR_FAIL_COND_V(t->type != TYPE_AUDIO, RES());
+	ERR_FAIL_COND_V(t->type != TYPE_AUDIO, Ref<Resource>());
 
 	const AudioTrack *at = static_cast<const AudioTrack *>(t);
 
-	ERR_FAIL_INDEX_V(p_key, at->values.size(), RES());
+	ERR_FAIL_INDEX_V(p_key, at->values.size(), Ref<Resource>());
 
 	return at->values[p_key].value.stream;
 }

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -180,7 +180,7 @@ private:
 	/* AUDIO TRACK */
 
 	struct AudioKey {
-		RES stream;
+		Ref<Resource> stream;
 		real_t start_offset = 0.0; //offset from start
 		real_t end_offset = 0.0; //offset from end, if 0 then full length or infinite
 		AudioKey() {
@@ -436,11 +436,11 @@ public:
 
 	real_t bezier_track_interpolate(int p_track, double p_time) const;
 
-	int audio_track_insert_key(int p_track, double p_time, const RES &p_stream, real_t p_start_offset = 0, real_t p_end_offset = 0);
-	void audio_track_set_key_stream(int p_track, int p_key, const RES &p_stream);
+	int audio_track_insert_key(int p_track, double p_time, const Ref<Resource> &p_stream, real_t p_start_offset = 0, real_t p_end_offset = 0);
+	void audio_track_set_key_stream(int p_track, int p_key, const Ref<Resource> &p_stream);
 	void audio_track_set_key_start_offset(int p_track, int p_key, real_t p_offset);
 	void audio_track_set_key_end_offset(int p_track, int p_key, real_t p_offset);
-	RES audio_track_get_key_stream(int p_track, int p_key) const;
+	Ref<Resource> audio_track_get_key_stream(int p_track, int p_key) const;
 	real_t audio_track_get_key_start_offset(int p_track, int p_key) const;
 	real_t audio_track_get_key_end_offset(int p_track, int p_key) const;
 

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -48,7 +48,7 @@ class ResourceLoaderText {
 	VariantParser::StreamFile stream;
 
 	struct ExtResource {
-		RES cache;
+		Ref<Resource> cache;
 		String path;
 		String type;
 	};
@@ -59,7 +59,7 @@ class ResourceLoaderText {
 	bool ignore_resource_parsing = false;
 
 	Map<String, ExtResource> ext_resources;
-	Map<String, RES> int_resources;
+	Map<String, Ref<Resource>> int_resources;
 
 	int resources_total = 0;
 	int resource_current = 0;
@@ -90,10 +90,10 @@ class ResourceLoaderText {
 	};
 
 	struct DummyReadData {
-		Map<RES, int> external_resources;
-		Map<String, RES> rev_external_resources;
-		Map<RES, int> resource_index_map;
-		Map<String, RES> resource_map;
+		Map<Ref<Resource>, int> external_resources;
+		Map<String, Ref<Resource>> rev_external_resources;
+		Map<Ref<Resource>, int> resource_index_map;
+		Map<String, Ref<Resource>> resource_map;
 	};
 
 	static Error _parse_sub_resource_dummys(void *p_self, VariantParser::Stream *p_stream, Ref<Resource> &r_res, int &line, String &r_err_str) { return _parse_sub_resource_dummy(static_cast<DummyReadData *>(p_self), p_stream, r_res, line, r_err_str); }
@@ -108,7 +108,7 @@ class ResourceLoaderText {
 
 	Error error = OK;
 
-	RES resource;
+	Ref<Resource> resource;
 
 	Ref<PackedScene> _parse_node_tag(VariantParser::ResourceParser &parser);
 
@@ -133,7 +133,7 @@ public:
 class ResourceFormatLoaderText : public ResourceFormatLoader {
 public:
 	static ResourceFormatLoaderText *singleton;
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions_for_type(const String &p_type, List<String> *p_extensions) const;
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
@@ -158,20 +158,20 @@ class ResourceFormatSaverTextInstance {
 	bool skip_editor = false;
 
 	struct NonPersistentKey { //for resource properties generated on the fly
-		RES base;
+		Ref<Resource> base;
 		StringName property;
 		bool operator<(const NonPersistentKey &p_key) const { return base == p_key.base ? property < p_key.property : base < p_key.base; }
 	};
 
-	Map<NonPersistentKey, RES> non_persistent_map;
+	Map<NonPersistentKey, Ref<Resource>> non_persistent_map;
 
-	Set<RES> resource_set;
-	List<RES> saved_resources;
-	Map<RES, String> external_resources;
-	Map<RES, String> internal_resources;
+	Set<Ref<Resource>> resource_set;
+	List<Ref<Resource>> saved_resources;
+	Map<Ref<Resource>, String> external_resources;
+	Map<Ref<Resource>, String> internal_resources;
 
 	struct ResourceSort {
-		RES resource;
+		Ref<Resource> resource;
 		String id;
 		bool operator<(const ResourceSort &p_right) const {
 			return id.naturalnocasecmp_to(p_right.id) < 0;
@@ -180,19 +180,19 @@ class ResourceFormatSaverTextInstance {
 
 	void _find_resources(const Variant &p_variant, bool p_main = false);
 
-	static String _write_resources(void *ud, const RES &p_resource);
-	String _write_resource(const RES &res);
+	static String _write_resources(void *ud, const Ref<Resource> &p_resource);
+	String _write_resource(const Ref<Resource> &res);
 
 public:
-	Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = 0);
+	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
 };
 
 class ResourceFormatSaverText : public ResourceFormatSaver {
 public:
 	static ResourceFormatSaverText *singleton;
-	virtual Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = 0);
-	virtual bool recognize(const RES &p_resource) const;
-	virtual void get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const;
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual bool recognize(const Ref<Resource> &p_resource) const;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 
 	ResourceFormatSaverText();
 };

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -172,7 +172,7 @@ Shader::~Shader() {
 
 ////////////
 
-RES ResourceFormatLoaderShader::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Ref<Resource> ResourceFormatLoaderShader::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	if (r_error) {
 		*r_error = ERR_FILE_CANT_OPEN;
 	}
@@ -210,7 +210,7 @@ String ResourceFormatLoaderShader::get_resource_type(const String &p_path) const
 	return "";
 }
 
-Error ResourceFormatSaverShader::save(const String &p_path, const RES &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverShader::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
 	Ref<Shader> shader = p_resource;
 	ERR_FAIL_COND_V(shader.is_null(), ERR_INVALID_PARAMETER);
 
@@ -229,7 +229,7 @@ Error ResourceFormatSaverShader::save(const String &p_path, const RES &p_resourc
 	return OK;
 }
 
-void ResourceFormatSaverShader::get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const {
+void ResourceFormatSaverShader::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
 	if (const Shader *shader = Object::cast_to<Shader>(*p_resource)) {
 		if (shader->is_text_shader()) {
 			p_extensions->push_back("gdshader");
@@ -237,6 +237,6 @@ void ResourceFormatSaverShader::get_recognized_extensions(const RES &p_resource,
 	}
 }
 
-bool ResourceFormatSaverShader::recognize(const RES &p_resource) const {
+bool ResourceFormatSaverShader::recognize(const Ref<Resource> &p_resource) const {
 	return p_resource->get_class_name() == "Shader"; //only shader, not inherited
 }

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -103,7 +103,7 @@ VARIANT_ENUM_CAST(Shader::Mode);
 
 class ResourceFormatLoaderShader : public ResourceFormatLoader {
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;
@@ -111,9 +111,9 @@ public:
 
 class ResourceFormatSaverShader : public ResourceFormatSaver {
 public:
-	virtual Error save(const String &p_path, const RES &p_resource, uint32_t p_flags = 0);
-	virtual void get_recognized_extensions(const RES &p_resource, List<String> *p_extensions) const;
-	virtual bool recognize(const RES &p_resource) const;
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
+	virtual bool recognize(const Ref<Resource> &p_resource) const;
 };
 
 #endif // SHADER_H

--- a/scene/resources/sprite_frames.cpp
+++ b/scene/resources/sprite_frames.cpp
@@ -195,7 +195,7 @@ void SpriteFrames::_set_animations(const Array &p_animations) {
 		anim.loop = d["loop"];
 		Array frames = d["frames"];
 		for (int j = 0; j < frames.size(); j++) {
-			RES res = frames[j];
+			Ref<Resource> res = frames[j];
 			anim.frames.push_back(res);
 		}
 

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -1058,7 +1058,7 @@ CompressedTexture2D::~CompressedTexture2D() {
 	}
 }
 
-RES ResourceFormatLoaderCompressedTexture2D::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Ref<Resource> ResourceFormatLoaderCompressedTexture2D::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	Ref<CompressedTexture2D> st;
 	st.instantiate();
 	Error err = st->load(p_path);
@@ -1066,7 +1066,7 @@ RES ResourceFormatLoaderCompressedTexture2D::load(const String &p_path, const St
 		*r_error = err;
 	}
 	if (err != OK) {
-		return RES();
+		return Ref<Resource>();
 	}
 
 	return st;
@@ -1416,7 +1416,7 @@ CompressedTexture3D::~CompressedTexture3D() {
 
 /////////////////////////////
 
-RES ResourceFormatLoaderCompressedTexture3D::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Ref<Resource> ResourceFormatLoaderCompressedTexture3D::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	Ref<CompressedTexture3D> st;
 	st.instantiate();
 	Error err = st->load(p_path);
@@ -1424,7 +1424,7 @@ RES ResourceFormatLoaderCompressedTexture3D::load(const String &p_path, const St
 		*r_error = err;
 	}
 	if (err != OK) {
-		return RES();
+		return Ref<Resource>();
 	}
 
 	return st;
@@ -3243,7 +3243,7 @@ CompressedTextureLayered::~CompressedTextureLayered() {
 
 /////////////////////////////////////////////////
 
-RES ResourceFormatLoaderCompressedTextureLayered::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+Ref<Resource> ResourceFormatLoaderCompressedTextureLayered::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
 	Ref<CompressedTextureLayered> ct;
 	if (p_path.get_extension().to_lower() == "ctexarray") {
 		Ref<CompressedTexture2DArray> c;
@@ -3261,14 +3261,14 @@ RES ResourceFormatLoaderCompressedTextureLayered::load(const String &p_path, con
 		if (r_error) {
 			*r_error = ERR_FILE_UNRECOGNIZED;
 		}
-		return RES();
+		return Ref<Resource>();
 	}
 	Error err = ct->load(p_path);
 	if (r_error) {
 		*r_error = err;
 	}
 	if (err != OK) {
-		return RES();
+		return Ref<Resource>();
 	}
 
 	return ct;

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -287,7 +287,7 @@ public:
 
 class ResourceFormatLoaderCompressedTexture2D : public ResourceFormatLoader {
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;
@@ -552,7 +552,7 @@ public:
 
 class ResourceFormatLoaderCompressedTextureLayered : public ResourceFormatLoader {
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;
@@ -673,7 +673,7 @@ public:
 
 class ResourceFormatLoaderCompressedTexture3D : public ResourceFormatLoader {
 public:
-	virtual RES load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
 	virtual bool handles_type(const String &p_type) const;
 	virtual String get_resource_type(const String &p_path) const;

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -421,7 +421,7 @@ DisplayServer::CursorShape DisplayServer::cursor_get_shape() const {
 	return CURSOR_ARROW;
 }
 
-void DisplayServer::cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
+void DisplayServer::cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape, const Vector2 &p_hotspot) {
 	WARN_PRINT("Custom cursor shape not supported by this display server.");
 }
 
@@ -832,7 +832,7 @@ Input::CursorShape DisplayServer::_input_get_current_cursor_shape() {
 	return (Input::CursorShape)singleton->cursor_get_shape();
 }
 
-void DisplayServer::_input_set_custom_mouse_cursor_func(const RES &p_image, Input::CursorShape p_shape, const Vector2 &p_hostspot) {
+void DisplayServer::_input_set_custom_mouse_cursor_func(const Ref<Resource> &p_image, Input::CursorShape p_shape, const Vector2 &p_hostspot) {
 	singleton->cursor_set_custom_image(p_image, (CursorShape)p_shape, p_hostspot);
 }
 

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -80,7 +80,7 @@ private:
 	static Input::MouseMode _input_get_mouse_mode();
 	static void _input_warp(const Vector2 &p_to_pos);
 	static Input::CursorShape _input_get_current_cursor_shape();
-	static void _input_set_custom_mouse_cursor_func(const RES &, Input::CursorShape, const Vector2 &p_hostspot);
+	static void _input_set_custom_mouse_cursor_func(const Ref<Resource> &, Input::CursorShape, const Vector2 &p_hostspot);
 
 protected:
 	static void _bind_methods();
@@ -409,7 +409,7 @@ public:
 	};
 	virtual void cursor_set_shape(CursorShape p_shape);
 	virtual CursorShape cursor_get_shape() const;
-	virtual void cursor_set_custom_image(const RES &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
+	virtual void cursor_set_custom_image(const Ref<Resource> &p_cursor, CursorShape p_shape = CURSOR_ARROW, const Vector2 &p_hotspot = Vector2());
 
 	virtual bool get_swap_cancel_ok();
 

--- a/servers/physics_server_2d.cpp
+++ b/servers/physics_server_2d.cpp
@@ -243,7 +243,7 @@ void PhysicsPointQueryParameters2D::_bind_methods() {
 
 ///////////////////////////////////////////////////////
 
-void PhysicsShapeQueryParameters2D::set_shape(const RES &p_shape_ref) {
+void PhysicsShapeQueryParameters2D::set_shape(const Ref<Resource> &p_shape_ref) {
 	ERR_FAIL_COND(p_shape_ref.is_null());
 	shape_ref = p_shape_ref;
 	parameters.shape_rid = p_shape_ref->get_rid();
@@ -251,7 +251,7 @@ void PhysicsShapeQueryParameters2D::set_shape(const RES &p_shape_ref) {
 
 void PhysicsShapeQueryParameters2D::set_shape_rid(const RID &p_shape) {
 	if (parameters.shape_rid != p_shape) {
-		shape_ref = RES();
+		shape_ref = Ref<Resource>();
 		parameters.shape_rid = p_shape;
 	}
 }

--- a/servers/physics_server_2d.h
+++ b/servers/physics_server_2d.h
@@ -663,7 +663,7 @@ class PhysicsShapeQueryParameters2D : public RefCounted {
 
 	PhysicsDirectSpaceState2D::ShapeParameters parameters;
 
-	RES shape_ref;
+	Ref<Resource> shape_ref;
 
 protected:
 	static void _bind_methods();
@@ -671,8 +671,8 @@ protected:
 public:
 	const PhysicsDirectSpaceState2D::ShapeParameters &get_parameters() const { return parameters; }
 
-	void set_shape(const RES &p_shape_ref);
-	RES get_shape() const { return shape_ref; }
+	void set_shape(const Ref<Resource> &p_shape_ref);
+	Ref<Resource> get_shape() const { return shape_ref; }
 
 	void set_shape_rid(const RID &p_shape);
 	RID get_shape_rid() const { return parameters.shape_rid; }

--- a/servers/physics_server_3d.cpp
+++ b/servers/physics_server_3d.cpp
@@ -262,7 +262,7 @@ void PhysicsPointQueryParameters3D::_bind_methods() {
 
 ///////////////////////////////////////////////////////
 
-void PhysicsShapeQueryParameters3D::set_shape(const RES &p_shape_ref) {
+void PhysicsShapeQueryParameters3D::set_shape(const Ref<Resource> &p_shape_ref) {
 	ERR_FAIL_COND(p_shape_ref.is_null());
 	shape_ref = p_shape_ref;
 	parameters.shape_rid = p_shape_ref->get_rid();
@@ -270,7 +270,7 @@ void PhysicsShapeQueryParameters3D::set_shape(const RES &p_shape_ref) {
 
 void PhysicsShapeQueryParameters3D::set_shape_rid(const RID &p_shape) {
 	if (parameters.shape_rid != p_shape) {
-		shape_ref = RES();
+		shape_ref = Ref<Resource>();
 		parameters.shape_rid = p_shape;
 	}
 }

--- a/servers/physics_server_3d.h
+++ b/servers/physics_server_3d.h
@@ -874,7 +874,7 @@ class PhysicsShapeQueryParameters3D : public RefCounted {
 
 	PhysicsDirectSpaceState3D::ShapeParameters parameters;
 
-	RES shape_ref;
+	Ref<Resource> shape_ref;
 
 protected:
 	static void _bind_methods();
@@ -882,8 +882,8 @@ protected:
 public:
 	const PhysicsDirectSpaceState3D::ShapeParameters &get_parameters() const { return parameters; }
 
-	void set_shape(const RES &p_shape_ref);
-	RES get_shape() const { return shape_ref; }
+	void set_shape(const Ref<Resource> &p_shape_ref);
+	Ref<Resource> get_shape() const { return shape_ref; }
 
 	void set_shape_rid(const RID &p_shape);
 	RID get_shape_rid() const { return parameters.shape_rid; }

--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -2091,7 +2091,7 @@ void MaterialStorage::global_variables_load_settings(bool p_load_textures) {
 				}
 
 				String path = value;
-				RES resource = ResourceLoader::load(path);
+				Ref<Resource> resource = ResourceLoader::load(path);
 				ERR_CONTINUE(resource.is_null());
 				value = resource;
 			}

--- a/tests/scene/test_code_edit.h
+++ b/tests/scene/test_code_edit.h
@@ -2961,7 +2961,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			/* also does not work on col 0                      */
 			code_edit->insert_text_at_caret("i");
 			code_edit->update_code_completion_options();
-			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0.", "item_0", Color(1, 0, 0), RES(), Color(1, 0, 0));
+			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_CLASS, "item_0.", "item_0", Color(1, 0, 0), Ref<Resource>(), Color(1, 0, 0));
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "item_1.", "item_1");
 			code_edit->add_code_completion_option(CodeEdit::CodeCompletionKind::KIND_VARIABLE, "item_2.", "item_2");
 
@@ -2989,7 +2989,7 @@ TEST_CASE("[SceneTree][CodeEdit] completion") {
 			CHECK(option["display_text"] == "item_0.");
 			CHECK(option["insert_text"] == "item_0");
 			CHECK(option["font_color"] == Color(1, 0, 0));
-			CHECK(option["icon"] == RES());
+			CHECK(option["icon"] == Ref<Resource>());
 			CHECK(option["default_value"] == Color(1, 0, 0));
 
 			/* Set size for mouse input. */


### PR DESCRIPTION
These typedefs don't save much typing compared to the full `Ref<Resource>` and `Ref<RefCounted>`, yet they sometimes introduce confusion among new contributors.

See https://github.com/godotengine/godot/issues/33027#issuecomment-1110387546.