### PR TITLE
SCons: Don't enable any `-Werror=return-type` outside `werror=yes`

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -622,10 +622,6 @@ if selected_platform in platform_list:
                     env.Append(CCFLAGS=["-Wno-error=return-type"])
             elif methods.using_clang(env) or methods.using_emcc(env):
                 env.Append(CXXFLAGS=["-Wno-error=#warnings"])
-        else:  # Always enable those errors.
-            # False positives in our error macros, see GH-58747.
-            if not (methods.using_gcc(env) and cc_version_major >= 12):
-                env.Append(CCFLAGS=["-Werror=return-type"])
 
     if hasattr(detect, "get_program_suffix"):
         suffix = "." + detect.get_program_suffix()


### PR DESCRIPTION
We shouldn't presume that future compilers will not have false positives or
find new occurrences of this warning, which would break compiling old versions
of the engine without passing custom `CXXFLAGS`.

Follow-up to #60652.

We still have several CI builds and contributors using `werror=yes` so we should catch those bugs even without this default.