### PR TITLE
Rename Basis `get_axis` to `get_column`, remove redundant methods

### DIFF
--- a/core/math/basis.cpp
+++ b/core/math/basis.cpp
@@ -73,9 +73,9 @@ void Basis::invert() {
 void Basis::orthonormalize() {
 	// Gram-Schmidt Process
 
-	Vector3 x = get_axis(0);
-	Vector3 y = get_axis(1);
-	Vector3 z = get_axis(2);
+	Vector3 x = get_column(0);
+	Vector3 y = get_column(1);
+	Vector3 z = get_column(2);
 
 	x.normalize();
 	y = (y - x * (x.dot(y)));
@@ -83,9 +83,9 @@ void Basis::orthonormalize() {
 	z = (z - x * (x.dot(z)) - y * (y.dot(z)));
 	z.normalize();
 
-	set_axis(0, x);
-	set_axis(1, y);
-	set_axis(2, z);
+	set_column(0, x);
+	set_column(1, y);
+	set_column(2, z);
 }
 
 Basis Basis::orthonormalized() const {
@@ -260,7 +260,7 @@ Basis Basis::scaled_orthogonal(const Vector3 &p_scale) const {
 	Basis b;
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {
-			dots[j] += s[i] * abs(m.get_axis(i).normalized().dot(b.get_axis(j)));
+			dots[j] += s[i] * abs(m.get_column(i).normalized().dot(b.get_column(j)));
 		}
 	}
 	m.scale_local(Vector3(1, 1, 1) + dots);
@@ -708,9 +708,9 @@ bool Basis::operator!=(const Basis &p_matrix) const {
 }
 
 Basis::operator String() const {
-	return "[X: " + get_axis(0).operator String() +
-			", Y: " + get_axis(1).operator String() +
-			", Z: " + get_axis(2).operator String() + "]";
+	return "[X: " + get_column(0).operator String() +
+			", Y: " + get_column(1).operator String() +
+			", Z: " + get_column(2).operator String() + "]";
 }
 
 Quaternion Basis::get_quaternion() const {
@@ -1107,6 +1107,6 @@ Basis Basis::looking_at(const Vector3 &p_target, const Vector3 &p_up) {
 	Vector3 v_y = v_z.cross(v_x);
 
 	Basis basis;
-	basis.set(v_x, v_y, v_z);
+	basis.set_columns(v_x, v_y, v_z);
 	return basis;
 }

--- a/core/math/basis.h
+++ b/core/math/basis.h
@@ -58,17 +58,6 @@ struct _NO_DISCARD_ Basis {
 
 	void from_z(const Vector3 &p_z);
 
-	_FORCE_INLINE_ Vector3 get_axis(int p_axis) const {
-		// get actual basis axis column (we store transposed as rows for performance)
-		return Vector3(rows[0][p_axis], rows[1][p_axis], rows[2][p_axis]);
-	}
-	_FORCE_INLINE_ void set_axis(int p_axis, const Vector3 &p_value) {
-		// get actual basis axis column (we store transposed as rows for performance)
-		rows[0][p_axis] = p_value.x;
-		rows[1][p_axis] = p_value.y;
-		rows[2][p_axis] = p_value.z;
-	}
-
 	void rotate(const Vector3 &p_axis, real_t p_phi);
 	Basis rotated(const Vector3 &p_axis, real_t p_phi) const;
 
@@ -186,26 +175,26 @@ struct _NO_DISCARD_ Basis {
 		rows[2][1] = zy;
 		rows[2][2] = zz;
 	}
-	_FORCE_INLINE_ void set(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z) {
-		set_axis(0, p_x);
-		set_axis(1, p_y);
-		set_axis(2, p_z);
-	}
-	_FORCE_INLINE_ Vector3 get_column(int i) const {
-		return Vector3(rows[0][i], rows[1][i], rows[2][i]);
+	_FORCE_INLINE_ void set_columns(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z) {
+		set_column(0, p_x);
+		set_column(1, p_y);
+		set_column(2, p_z);
 	}
 
-	_FORCE_INLINE_ Vector3 get_row(int i) const {
-		return Vector3(rows[i][0], rows[i][1], rows[i][2]);
+	_FORCE_INLINE_ Vector3 get_column(int p_index) const {
+		// Get actual basis axis column (we store transposed as rows for performance).
+		return Vector3(rows[0][p_index], rows[1][p_index], rows[2][p_index]);
 	}
+
+	_FORCE_INLINE_ void set_column(int p_index, const Vector3 &p_value) {
+		// Set actual basis axis column (we store transposed as rows for performance).
+		rows[0][p_index] = p_value.x;
+		rows[1][p_index] = p_value.y;
+		rows[2][p_index] = p_value.z;
+	}
+
 	_FORCE_INLINE_ Vector3 get_main_diagonal() const {
 		return Vector3(rows[0][0], rows[1][1], rows[2][2]);
-	}
-
-	_FORCE_INLINE_ void set_row(int i, const Vector3 &p_row) {
-		rows[i][0] = p_row.x;
-		rows[i][1] = p_row.y;
-		rows[i][2] = p_row.z;
 	}
 
 	_FORCE_INLINE_ void set_zero() {

--- a/core/math/transform_2d.h
+++ b/core/math/transform_2d.h
@@ -58,15 +58,6 @@ struct _NO_DISCARD_ Transform2D {
 	const Vector2 &operator[](int p_idx) const { return columns[p_idx]; }
 	Vector2 &operator[](int p_idx) { return columns[p_idx]; }
 
-	_FORCE_INLINE_ Vector2 get_axis(int p_axis) const {
-		ERR_FAIL_INDEX_V(p_axis, 3, Vector2());
-		return columns[p_axis];
-	}
-	_FORCE_INLINE_ void set_axis(int p_axis, const Vector2 &p_vec) {
-		ERR_FAIL_INDEX(p_axis, 3);
-		columns[p_axis] = p_vec;
-	}
-
 	void invert();
 	Transform2D inverse() const;
 

--- a/core/math/transform_3d.cpp
+++ b/core/math/transform_3d.cpp
@@ -194,9 +194,9 @@ Transform3D Transform3D::operator*(const real_t p_val) const {
 }
 
 Transform3D::operator String() const {
-	return "[X: " + basis.get_axis(0).operator String() +
-			", Y: " + basis.get_axis(1).operator String() +
-			", Z: " + basis.get_axis(2).operator String() +
+	return "[X: " + basis.get_column(0).operator String() +
+			", Y: " + basis.get_column(1).operator String() +
+			", Z: " + basis.get_column(2).operator String() +
 			", O: " + origin.operator String() + "]";
 }
 
@@ -207,9 +207,9 @@ Transform3D::Transform3D(const Basis &p_basis, const Vector3 &p_origin) :
 
 Transform3D::Transform3D(const Vector3 &p_x, const Vector3 &p_y, const Vector3 &p_z, const Vector3 &p_origin) :
 		origin(p_origin) {
-	basis.set_axis(0, p_x);
-	basis.set_axis(1, p_y);
-	basis.set_axis(2, p_z);
+	basis.set_column(0, p_x);
+	basis.set_column(1, p_y);
+	basis.set_column(2, p_z);
 }
 
 Transform3D::Transform3D(real_t xx, real_t xy, real_t xz, real_t yx, real_t yy, real_t yz, real_t zx, real_t zy, real_t zz, real_t ox, real_t oy, real_t oz) {

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -790,7 +790,7 @@ INDEXED_SETGET_STRUCT_BULTIN_NUMERIC(Quaternion, double, real_t, 4)
 INDEXED_SETGET_STRUCT_BULTIN_NUMERIC(Color, double, float, 4)
 
 INDEXED_SETGET_STRUCT_BULTIN_ACCESSOR(Transform2D, Vector2, .columns, 3)
-INDEXED_SETGET_STRUCT_BULTIN_FUNC(Basis, Vector3, set_axis, get_axis, 3)
+INDEXED_SETGET_STRUCT_BULTIN_FUNC(Basis, Vector3, set_column, get_column, 3)
 
 INDEXED_SETGET_STRUCT_TYPED_NUMERIC(PackedByteArray, int64_t, uint8_t)
 INDEXED_SETGET_STRUCT_TYPED_NUMERIC(PackedInt32Array, int64_t, int32_t)

--- a/core/variant/variant_setget.h
+++ b/core/variant/variant_setget.h
@@ -308,9 +308,9 @@ SETGET_NUMBER_STRUCT(Quaternion, double, y)
 SETGET_NUMBER_STRUCT(Quaternion, double, z)
 SETGET_NUMBER_STRUCT(Quaternion, double, w)
 
-SETGET_STRUCT_FUNC_INDEX(Basis, Vector3, x, set_axis, get_axis, 0)
-SETGET_STRUCT_FUNC_INDEX(Basis, Vector3, y, set_axis, get_axis, 1)
-SETGET_STRUCT_FUNC_INDEX(Basis, Vector3, z, set_axis, get_axis, 2)
+SETGET_STRUCT_FUNC_INDEX(Basis, Vector3, x, set_column, get_column, 0)
+SETGET_STRUCT_FUNC_INDEX(Basis, Vector3, y, set_column, get_column, 1)
+SETGET_STRUCT_FUNC_INDEX(Basis, Vector3, z, set_column, get_column, 2)
 
 SETGET_STRUCT(Transform3D, Basis, basis)
 SETGET_STRUCT(Transform3D, Vector3, origin)

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -638,7 +638,7 @@ void RasterizerSceneGLES3::render_scene(RID p_render_buffers, const CameraData *
 
 		// this should be the same for all cameras..
 		render_data.lod_distance_multiplier = p_camera_data->main_projection.get_lod_multiplier();
-		render_data.lod_camera_plane = Plane(-p_camera_data->main_transform.basis.get_axis(Vector3::AXIS_Z), p_camera_data->main_transform.get_origin());
+		render_data.lod_camera_plane = Plane(-p_camera_data->main_transform.basis.get_column(Vector3::AXIS_Z), p_camera_data->main_transform.get_origin());
 
 		if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_DISABLE_LOD) {
 			render_data.screen_mesh_lod_threshold = 0.0;

--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -200,9 +200,9 @@ void MultiMeshEditor::_populate() {
 
 		Basis post_xform;
 
-		post_xform.rotate(xform.basis.get_axis(1), -Math::random(-_rotate_random, _rotate_random) * Math_PI);
-		post_xform.rotate(xform.basis.get_axis(2), -Math::random(-_tilt_random, _tilt_random) * Math_PI);
-		post_xform.rotate(xform.basis.get_axis(0), -Math::random(-_tilt_random, _tilt_random) * Math_PI);
+		post_xform.rotate(xform.basis.get_column(1), -Math::random(-_rotate_random, _rotate_random) * Math_PI);
+		post_xform.rotate(xform.basis.get_column(2), -Math::random(-_tilt_random, _tilt_random) * Math_PI);
+		post_xform.rotate(xform.basis.get_column(0), -Math::random(-_tilt_random, _tilt_random) * Math_PI);
 
 		xform.basis = post_xform * xform.basis;
 		//xform.basis.orthonormalize();

--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -589,7 +589,7 @@ void EditorNode3DGizmo::handles_intersect_ray(Camera3D *p_camera, const Vector2 
 	Transform3D camera_xform = p_camera->get_global_transform();
 	Transform3D t = spatial_node->get_global_transform();
 	if (billboard_handle) {
-		t.set_look_at(t.origin, t.origin - camera_xform.basis.get_axis(2), camera_xform.basis.get_axis(1));
+		t.set_look_at(t.origin, t.origin - camera_xform.basis.get_column(2), camera_xform.basis.get_column(1));
 	}
 
 	float min_d = 1e20;
@@ -665,7 +665,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 		Transform3D orig_camera_transform = p_camera->get_camera_transform();
 
 		if (!orig_camera_transform.origin.is_equal_approx(t.origin) &&
-				ABS(orig_camera_transform.basis.get_axis(Vector3::AXIS_Z).dot(Vector3(0, 1, 0))) < 0.99) {
+				ABS(orig_camera_transform.basis.get_column(Vector3::AXIS_Z).dot(Vector3(0, 1, 0))) < 0.99) {
 			p_camera->look_at(t.origin);
 		}
 
@@ -689,13 +689,13 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 	}
 
 	if (collision_segments.size()) {
-		Plane camp(-p_camera->get_transform().basis.get_axis(2).normalized(), p_camera->get_transform().origin);
+		Plane camp(-p_camera->get_transform().basis.get_column(2).normalized(), p_camera->get_transform().origin);
 
 		int vc = collision_segments.size();
 		const Vector3 *vptr = collision_segments.ptr();
 		Transform3D t = spatial_node->get_global_transform();
 		if (billboard_handle) {
-			t.set_look_at(t.origin, t.origin - p_camera->get_transform().basis.get_axis(2), p_camera->get_transform().basis.get_axis(1));
+			t.set_look_at(t.origin, t.origin - p_camera->get_transform().basis.get_column(2), p_camera->get_transform().basis.get_column(1));
 		}
 
 		Vector3 cp;
@@ -742,7 +742,7 @@ bool EditorNode3DGizmo::intersect_ray(Camera3D *p_camera, const Point2 &p_point,
 		Transform3D gt = spatial_node->get_global_transform();
 
 		if (billboard_handle) {
-			gt.set_look_at(gt.origin, gt.origin - p_camera->get_transform().basis.get_axis(2), p_camera->get_transform().basis.get_axis(1));
+			gt.set_look_at(gt.origin, gt.origin - p_camera->get_transform().basis.get_column(2), p_camera->get_transform().basis.get_column(1));
 		}
 
 		Transform3D ai = gt.affine_inverse();
@@ -1319,7 +1319,7 @@ void Light3DGizmoPlugin::set_handle(const EditorNode3DGizmo *p_gizmo, int p_id, 
 
 			light->set_param(Light3D::PARAM_RANGE, d);
 		} else if (Object::cast_to<OmniLight3D>(light)) {
-			Plane cp = Plane(p_camera->get_transform().basis.get_axis(2), gt.origin);
+			Plane cp = Plane(p_camera->get_transform().basis.get_column(2), gt.origin);
 
 			Vector3 inters;
 			if (cp.intersects_ray(ray_from, ray_dir, &inters)) {
@@ -4832,7 +4832,7 @@ Basis JointGizmosDrawer::look_body(const Transform3D &p_joint_transform, const T
 	v_y.normalize();
 
 	Basis base;
-	base.set(v_x, v_y, v_z);
+	base.set_columns(v_x, v_y, v_z);
 
 	// Absorb current joint transform
 	base = p_joint_transform.basis.inverse() * base;
@@ -4857,7 +4857,7 @@ Basis JointGizmosDrawer::look_body_toward_x(const Transform3D &p_joint_transform
 	const Vector3 &p_eye(p_joint_transform.origin);
 	const Vector3 &p_target(p_body_transform.origin);
 
-	const Vector3 p_front(p_joint_transform.basis.get_axis(0));
+	const Vector3 p_front(p_joint_transform.basis.get_column(0));
 
 	Vector3 v_x, v_y, v_z;
 
@@ -4876,7 +4876,7 @@ Basis JointGizmosDrawer::look_body_toward_x(const Transform3D &p_joint_transform
 	v_x.normalize();
 
 	Basis base;
-	base.set(v_x, v_y, v_z);
+	base.set_columns(v_x, v_y, v_z);
 
 	// Absorb current joint transform
 	base = p_joint_transform.basis.inverse() * base;
@@ -4888,7 +4888,7 @@ Basis JointGizmosDrawer::look_body_toward_y(const Transform3D &p_joint_transform
 	const Vector3 &p_eye(p_joint_transform.origin);
 	const Vector3 &p_target(p_body_transform.origin);
 
-	const Vector3 p_up(p_joint_transform.basis.get_axis(1));
+	const Vector3 p_up(p_joint_transform.basis.get_column(1));
 
 	Vector3 v_x, v_y, v_z;
 
@@ -4907,7 +4907,7 @@ Basis JointGizmosDrawer::look_body_toward_y(const Transform3D &p_joint_transform
 	v_y.normalize();
 
 	Basis base;
-	base.set(v_x, v_y, v_z);
+	base.set_columns(v_x, v_y, v_z);
 
 	// Absorb current joint transform
 	base = p_joint_transform.basis.inverse() * base;
@@ -4919,7 +4919,7 @@ Basis JointGizmosDrawer::look_body_toward_z(const Transform3D &p_joint_transform
 	const Vector3 &p_eye(p_joint_transform.origin);
 	const Vector3 &p_target(p_body_transform.origin);
 
-	const Vector3 p_lateral(p_joint_transform.basis.get_axis(2));
+	const Vector3 p_lateral(p_joint_transform.basis.get_column(2));
 
 	Vector3 v_x, v_y, v_z;
 
@@ -4938,7 +4938,7 @@ Basis JointGizmosDrawer::look_body_toward_z(const Transform3D &p_joint_transform
 	v_x.normalize();
 
 	Basis base;
-	base.set(v_x, v_y, v_z);
+	base.set_columns(v_x, v_y, v_z);
 
 	// Absorb current joint transform
 	base = p_joint_transform.basis.inverse() * base;

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -159,7 +159,7 @@ void ViewportRotationControl::_get_sorted_axis(Vector<Axis2D> &r_axis) {
 	const Basis camera_basis = viewport->to_camera_transform(viewport->cursor).get_basis().inverse();
 
 	for (int i = 0; i < 3; ++i) {
-		Vector3 axis_3d = camera_basis.get_axis(i);
+		Vector3 axis_3d = camera_basis.get_column(i);
 		Vector2i axis_vector = Vector2(axis_3d.x, -axis_3d.y) * radius;
 
 		if (Math::abs(axis_3d.z) < 1.0) {
@@ -440,7 +440,7 @@ Vector3 Node3DEditorViewport::_get_ray_pos(const Vector2 &p_pos) const {
 }
 
 Vector3 Node3DEditorViewport::_get_camera_normal() const {
-	return -_get_camera_transform().basis.get_axis(2);
+	return -_get_camera_transform().basis.get_column(2);
 }
 
 Vector3 Node3DEditorViewport::_get_ray(const Vector2 &p_pos) const {
@@ -983,7 +983,7 @@ bool Node3DEditorViewport::_transform_gizmo_select(const Vector2 &p_screenpos, b
 		real_t col_d = 1e20;
 
 		for (int i = 0; i < 3; i++) {
-			const Vector3 grabber_pos = gt.origin + gt.basis.get_axis(i).normalized() * gizmo_scale * (GIZMO_ARROW_OFFSET + (GIZMO_ARROW_SIZE * 0.5));
+			const Vector3 grabber_pos = gt.origin + gt.basis.get_column(i).normalized() * gizmo_scale * (GIZMO_ARROW_OFFSET + (GIZMO_ARROW_SIZE * 0.5));
 			const real_t grabber_radius = gizmo_scale * GIZMO_ARROW_SIZE;
 
 			Vector3 r;
@@ -1003,15 +1003,15 @@ bool Node3DEditorViewport::_transform_gizmo_select(const Vector2 &p_screenpos, b
 			col_d = 1e20;
 
 			for (int i = 0; i < 3; i++) {
-				Vector3 ivec2 = gt.basis.get_axis((i + 1) % 3).normalized();
-				Vector3 ivec3 = gt.basis.get_axis((i + 2) % 3).normalized();
+				Vector3 ivec2 = gt.basis.get_column((i + 1) % 3).normalized();
+				Vector3 ivec3 = gt.basis.get_column((i + 2) % 3).normalized();
 
 				// Allow some tolerance to make the plane easier to click,
 				// even if the click is actually slightly outside the plane.
 				const Vector3 grabber_pos = gt.origin + (ivec2 + ivec3) * gizmo_scale * (GIZMO_PLANE_SIZE + GIZMO_PLANE_DST * 0.6667);
 
 				Vector3 r;
-				Plane plane(gt.basis.get_axis(i).normalized(), gt.origin);
+				Plane plane(gt.basis.get_column(i).normalized(), gt.origin);
 
 				if (plane.intersects_ray(ray_pos, ray, &r)) {
 					const real_t dist = r.distance_to(grabber_pos);
@@ -1064,7 +1064,7 @@ bool Node3DEditorViewport::_transform_gizmo_select(const Vector2 &p_screenpos, b
 			float col_d = 1e20;
 
 			for (int i = 0; i < 3; i++) {
-				Plane plane(gt.basis.get_axis(i).normalized(), gt.origin);
+				Plane plane(gt.basis.get_column(i).normalized(), gt.origin);
 				Vector3 r;
 				if (!plane.intersects_ray(ray_pos, ray, &r)) {
 					continue;
@@ -1103,7 +1103,7 @@ bool Node3DEditorViewport::_transform_gizmo_select(const Vector2 &p_screenpos, b
 		float col_d = 1e20;
 
 		for (int i = 0; i < 3; i++) {
-			const Vector3 grabber_pos = gt.origin + gt.basis.get_axis(i).normalized() * gizmo_scale * GIZMO_SCALE_OFFSET;
+			const Vector3 grabber_pos = gt.origin + gt.basis.get_column(i).normalized() * gizmo_scale * GIZMO_SCALE_OFFSET;
 			const real_t grabber_radius = gizmo_scale * GIZMO_ARROW_SIZE;
 
 			Vector3 r;
@@ -1123,15 +1123,15 @@ bool Node3DEditorViewport::_transform_gizmo_select(const Vector2 &p_screenpos, b
 			col_d = 1e20;
 
 			for (int i = 0; i < 3; i++) {
-				const Vector3 ivec2 = gt.basis.get_axis((i + 1) % 3).normalized();
-				const Vector3 ivec3 = gt.basis.get_axis((i + 2) % 3).normalized();
+				const Vector3 ivec2 = gt.basis.get_column((i + 1) % 3).normalized();
+				const Vector3 ivec3 = gt.basis.get_column((i + 2) % 3).normalized();
 
 				// Allow some tolerance to make the plane easier to click,
 				// even if the click is actually slightly outside the plane.
 				const Vector3 grabber_pos = gt.origin + (ivec2 + ivec3) * gizmo_scale * (GIZMO_PLANE_SIZE + GIZMO_PLANE_DST * 0.6667);
 
 				Vector3 r;
-				Plane plane(gt.basis.get_axis(i).normalized(), gt.origin);
+				Plane plane(gt.basis.get_column(i).normalized(), gt.origin);
 
 				if (plane.intersects_ray(ray_pos, ray, &r)) {
 					const real_t dist = r.distance_to(grabber_pos);
@@ -3389,8 +3389,8 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 		return;
 	}
 
-	const Vector3 camz = -camera_xform.get_basis().get_axis(2).normalized();
-	const Vector3 camy = -camera_xform.get_basis().get_axis(1).normalized();
+	const Vector3 camz = -camera_xform.get_basis().get_column(2).normalized();
+	const Vector3 camy = -camera_xform.get_basis().get_column(1).normalized();
 	const Plane p = Plane(camz, camera_xform.origin);
 	const real_t gizmo_d = MAX(Math::abs(p.distance_to(xform.origin)), CMP_EPSILON);
 	const real_t d0 = camera->unproject_position(camera_xform.origin + camz * gizmo_d).y;
@@ -3424,8 +3424,8 @@ void Node3DEditorViewport::update_transform_gizmo_view() {
 
 	for (int i = 0; i < 3; i++) {
 		Transform3D axis_angle = Transform3D();
-		if (xform.basis.get_axis(i).normalized().dot(xform.basis.get_axis((i + 1) % 3).normalized()) < 1.0) {
-			axis_angle = axis_angle.looking_at(xform.basis.get_axis(i).normalized(), xform.basis.get_axis((i + 1) % 3).normalized());
+		if (xform.basis.get_column(i).normalized().dot(xform.basis.get_column((i + 1) % 3).normalized()) < 1.0) {
+			axis_angle = axis_angle.looking_at(xform.basis.get_column(i).normalized(), xform.basis.get_column((i + 1) % 3).normalized());
 		}
 		axis_angle.basis.scale(scale);
 		axis_angle.origin = xform.origin;
@@ -4087,30 +4087,30 @@ void Node3DEditorViewport::update_transform(Point2 p_mousepos, bool p_shift) {
 					plane = Plane(_get_camera_normal(), _edit.center);
 					break;
 				case TRANSFORM_X_AXIS:
-					motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(0).normalized();
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(0).normalized();
 					plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
 					break;
 				case TRANSFORM_Y_AXIS:
-					motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(1).normalized();
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(1).normalized();
 					plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
 					break;
 				case TRANSFORM_Z_AXIS:
-					motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(2).normalized();
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(2).normalized();
 					plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
 					break;
 				case TRANSFORM_YZ:
-					motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(2).normalized() + spatial_editor->get_gizmo_transform().basis.get_axis(1).normalized();
-					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(0).normalized(), _edit.center);
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(2).normalized() + spatial_editor->get_gizmo_transform().basis.get_column(1).normalized();
+					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_column(0).normalized(), _edit.center);
 					plane_mv = true;
 					break;
 				case TRANSFORM_XZ:
-					motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(2).normalized() + spatial_editor->get_gizmo_transform().basis.get_axis(0).normalized();
-					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(1).normalized(), _edit.center);
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(2).normalized() + spatial_editor->get_gizmo_transform().basis.get_column(0).normalized();
+					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_column(1).normalized(), _edit.center);
 					plane_mv = true;
 					break;
 				case TRANSFORM_XY:
-					motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(0).normalized() + spatial_editor->get_gizmo_transform().basis.get_axis(1).normalized();
-					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(2).normalized(), _edit.center);
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(0).normalized() + spatial_editor->get_gizmo_transform().basis.get_column(1).normalized();
+					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_column(2).normalized(), _edit.center);
 					plane_mv = true;
 					break;
 			}
@@ -4209,27 +4209,27 @@ void Node3DEditorViewport::update_transform(Point2 p_mousepos, bool p_shift) {
 					plane = Plane(_get_camera_normal(), _edit.center);
 					break;
 				case TRANSFORM_X_AXIS:
-					motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(0).normalized();
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(0).normalized();
 					plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
 					break;
 				case TRANSFORM_Y_AXIS:
-					motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(1).normalized();
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(1).normalized();
 					plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
 					break;
 				case TRANSFORM_Z_AXIS:
-					motion_mask = spatial_editor->get_gizmo_transform().basis.get_axis(2).normalized();
+					motion_mask = spatial_editor->get_gizmo_transform().basis.get_column(2).normalized();
 					plane = Plane(motion_mask.cross(motion_mask.cross(_get_camera_normal())).normalized(), _edit.center);
 					break;
 				case TRANSFORM_YZ:
-					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(0).normalized(), _edit.center);
+					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_column(0).normalized(), _edit.center);
 					plane_mv = true;
 					break;
 				case TRANSFORM_XZ:
-					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(1).normalized(), _edit.center);
+					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_column(1).normalized(), _edit.center);
 					plane_mv = true;
 					break;
 				case TRANSFORM_XY:
-					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_axis(2).normalized(), _edit.center);
+					plane = Plane(spatial_editor->get_gizmo_transform().basis.get_column(2).normalized(), _edit.center);
 					plane_mv = true;
 					break;
 			}
@@ -6469,7 +6469,7 @@ void Node3DEditor::_init_grid() {
 
 		if (orthogonal) {
 			camera_distance = camera->get_size() / 2.0;
-			Vector3 camera_direction = -camera->get_global_transform().get_basis().get_axis(2);
+			Vector3 camera_direction = -camera->get_global_transform().get_basis().get_column(2);
 			Plane grid_plane = Plane(normal);
 			Vector3 intersection;
 			if (grid_plane.intersects_ray(camera_position, camera_direction, &intersection)) {
@@ -7338,7 +7338,7 @@ void Node3DEditor::clear() {
 
 void Node3DEditor::_sun_direction_draw() {
 	sun_direction->draw_rect(Rect2(Vector2(), sun_direction->get_size()), Color(1, 1, 1, 1));
-	Vector3 z_axis = preview_sun->get_transform().basis.get_axis(Vector3::AXIS_Z);
+	Vector3 z_axis = preview_sun->get_transform().basis.get_column(Vector3::AXIS_Z);
 	z_axis = get_editor_viewport(0)->camera->get_camera_transform().basis.xform_inv(z_axis);
 	sun_direction_material->set_shader_param("sun_direction", Vector3(z_axis.x, -z_axis.y, z_axis.z));
 	Color color = sun_color->get_pick_color() * sun_energy->get_value();

--- a/editor/plugins/path_3d_editor_plugin.cpp
+++ b/editor/plugins/path_3d_editor_plugin.cpp
@@ -102,7 +102,7 @@ void Path3DGizmo::set_handle(int p_id, bool p_secondary, Camera3D *p_camera, con
 
 	// Setting curve point positions
 	if (!p_secondary) {
-		const Plane p = Plane(p_camera->get_transform().basis.get_axis(2), gt.xform(original));
+		const Plane p = Plane(p_camera->get_transform().basis.get_column(2), gt.xform(original));
 
 		Vector3 inters;
 
@@ -126,7 +126,7 @@ void Path3DGizmo::set_handle(int p_id, bool p_secondary, Camera3D *p_camera, con
 
 	Vector3 base = c->get_point_position(idx);
 
-	Plane p(p_camera->get_transform().basis.get_axis(2), gt.xform(original));
+	Plane p(p_camera->get_transform().basis.get_column(2), gt.xform(original));
 
 	Vector3 inters;
 
@@ -396,7 +396,7 @@ EditorPlugin::AfterGUIInput Path3DEditorPlugin::forward_spatial_gui_input(Camera
 				} else {
 					origin = gt.xform(c->get_point_position(c->get_point_count() - 1));
 				}
-				Plane p(p_camera->get_transform().basis.get_axis(2), origin);
+				Plane p(p_camera->get_transform().basis.get_column(2), origin);
 				Vector3 ray_from = p_camera->project_ray_origin(mbpos);
 				Vector3 ray_dir = p_camera->project_ray_normal(mbpos);
 

--- a/editor/plugins/polygon_3d_editor_plugin.cpp
+++ b/editor/plugins/polygon_3d_editor_plugin.cpp
@@ -117,7 +117,7 @@ EditorPlugin::AfterGUIInput Polygon3DEditor::forward_spatial_gui_input(Camera3D 
 	Transform3D gt = node->get_global_transform();
 	Transform3D gi = gt.affine_inverse();
 	float depth = _get_depth() * 0.5;
-	Vector3 n = gt.basis.get_axis(2).normalized();
+	Vector3 n = gt.basis.get_column(2).normalized();
 	Plane p(n, gt.origin + n * depth);
 
 	Ref<InputEventMouseButton> mb = p_event;

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -1336,9 +1336,9 @@ CSGBrushOperation::Build2DFaces::Build2DFaces(const CSGBrush &p_brush, int p_fac
 
 	plane = Plane(points_3D[0], points_3D[1], points_3D[2]);
 	to_3D.origin = points_3D[0];
-	to_3D.basis.set_axis(2, plane.normal);
-	to_3D.basis.set_axis(0, (points_3D[1] - points_3D[2]).normalized());
-	to_3D.basis.set_axis(1, to_3D.basis.get_axis(0).cross(to_3D.basis.get_axis(2)).normalized());
+	to_3D.basis.set_column(2, plane.normal);
+	to_3D.basis.set_column(0, (points_3D[1] - points_3D[2]).normalized());
+	to_3D.basis.set_column(1, to_3D.basis.get_column(0).cross(to_3D.basis.get_column(2)).normalized());
 	to_2D = to_3D.affine_inverse();
 
 	Face2D face;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -360,9 +360,9 @@ static Transform3D _arr_to_xform(const Array &p_array) {
 	ERR_FAIL_COND_V(p_array.size() != 16, Transform3D());
 
 	Transform3D xform;
-	xform.basis.set_axis(Vector3::AXIS_X, Vector3(p_array[0], p_array[1], p_array[2]));
-	xform.basis.set_axis(Vector3::AXIS_Y, Vector3(p_array[4], p_array[5], p_array[6]));
-	xform.basis.set_axis(Vector3::AXIS_Z, Vector3(p_array[8], p_array[9], p_array[10]));
+	xform.basis.set_column(Vector3::AXIS_X, Vector3(p_array[0], p_array[1], p_array[2]));
+	xform.basis.set_column(Vector3::AXIS_Y, Vector3(p_array[4], p_array[5], p_array[6]));
+	xform.basis.set_column(Vector3::AXIS_Z, Vector3(p_array[8], p_array[9], p_array[10]));
 	xform.set_origin(Vector3(p_array[12], p_array[13], p_array[14]));
 
 	return xform;
@@ -371,17 +371,17 @@ static Transform3D _arr_to_xform(const Array &p_array) {
 static Vector<real_t> _xform_to_array(const Transform3D p_transform) {
 	Vector<real_t> array;
 	array.resize(16);
-	Vector3 axis_x = p_transform.get_basis().get_axis(Vector3::AXIS_X);
+	Vector3 axis_x = p_transform.get_basis().get_column(Vector3::AXIS_X);
 	array.write[0] = axis_x.x;
 	array.write[1] = axis_x.y;
 	array.write[2] = axis_x.z;
 	array.write[3] = 0.0f;
-	Vector3 axis_y = p_transform.get_basis().get_axis(Vector3::AXIS_Y);
+	Vector3 axis_y = p_transform.get_basis().get_column(Vector3::AXIS_Y);
 	array.write[4] = axis_y.x;
 	array.write[5] = axis_y.y;
 	array.write[6] = axis_y.z;
 	array.write[7] = 0.0f;
-	Vector3 axis_z = p_transform.get_basis().get_axis(Vector3::AXIS_Z);
+	Vector3 axis_z = p_transform.get_basis().get_column(Vector3::AXIS_Z);
 	array.write[8] = axis_z.x;
 	array.write[9] = axis_z.y;
 	array.write[10] = axis_z.z;
@@ -1960,20 +1960,20 @@ GLTFAccessorIndex GLTFDocument::_encode_accessor_as_xform(Ref<GLTFState> state, 
 	for (int i = 0; i < p_attribs.size(); i++) {
 		Transform3D attrib = p_attribs[i];
 		Basis basis = attrib.get_basis();
-		Vector3 axis_0 = basis.get_axis(Vector3::AXIS_X);
+		Vector3 axis_0 = basis.get_column(Vector3::AXIS_X);
 
 		attribs.write[i * element_count + 0] = Math::snapped(axis_0.x, CMP_NORMALIZE_TOLERANCE);
 		attribs.write[i * element_count + 1] = Math::snapped(axis_0.y, CMP_NORMALIZE_TOLERANCE);
 		attribs.write[i * element_count + 2] = Math::snapped(axis_0.z, CMP_NORMALIZE_TOLERANCE);
 		attribs.write[i * element_count + 3] = 0.0;
 
-		Vector3 axis_1 = basis.get_axis(Vector3::AXIS_Y);
+		Vector3 axis_1 = basis.get_column(Vector3::AXIS_Y);
 		attribs.write[i * element_count + 4] = Math::snapped(axis_1.x, CMP_NORMALIZE_TOLERANCE);
 		attribs.write[i * element_count + 5] = Math::snapped(axis_1.y, CMP_NORMALIZE_TOLERANCE);
 		attribs.write[i * element_count + 6] = Math::snapped(axis_1.z, CMP_NORMALIZE_TOLERANCE);
 		attribs.write[i * element_count + 7] = 0.0;
 
-		Vector3 axis_2 = basis.get_axis(Vector3::AXIS_Z);
+		Vector3 axis_2 = basis.get_column(Vector3::AXIS_Z);
 		attribs.write[i * element_count + 8] = Math::snapped(axis_2.x, CMP_NORMALIZE_TOLERANCE);
 		attribs.write[i * element_count + 9] = Math::snapped(axis_2.y, CMP_NORMALIZE_TOLERANCE);
 		attribs.write[i * element_count + 10] = Math::snapped(axis_2.z, CMP_NORMALIZE_TOLERANCE);
@@ -2105,9 +2105,9 @@ Vector<Basis> GLTFDocument::_decode_accessor_as_basis(Ref<GLTFState> state, cons
 	ERR_FAIL_COND_V(attribs.size() % 9 != 0, ret);
 	ret.resize(attribs.size() / 9);
 	for (int i = 0; i < ret.size(); i++) {
-		ret.write[i].set_axis(0, Vector3(attribs[i * 9 + 0], attribs[i * 9 + 1], attribs[i * 9 + 2]));
-		ret.write[i].set_axis(1, Vector3(attribs[i * 9 + 3], attribs[i * 9 + 4], attribs[i * 9 + 5]));
-		ret.write[i].set_axis(2, Vector3(attribs[i * 9 + 6], attribs[i * 9 + 7], attribs[i * 9 + 8]));
+		ret.write[i].set_column(0, Vector3(attribs[i * 9 + 0], attribs[i * 9 + 1], attribs[i * 9 + 2]));
+		ret.write[i].set_column(1, Vector3(attribs[i * 9 + 3], attribs[i * 9 + 4], attribs[i * 9 + 5]));
+		ret.write[i].set_column(2, Vector3(attribs[i * 9 + 6], attribs[i * 9 + 7], attribs[i * 9 + 8]));
 	}
 	return ret;
 }
@@ -2123,9 +2123,9 @@ Vector<Transform3D> GLTFDocument::_decode_accessor_as_xform(Ref<GLTFState> state
 	ERR_FAIL_COND_V(attribs.size() % 16 != 0, ret);
 	ret.resize(attribs.size() / 16);
 	for (int i = 0; i < ret.size(); i++) {
-		ret.write[i].basis.set_axis(0, Vector3(attribs[i * 16 + 0], attribs[i * 16 + 1], attribs[i * 16 + 2]));
-		ret.write[i].basis.set_axis(1, Vector3(attribs[i * 16 + 4], attribs[i * 16 + 5], attribs[i * 16 + 6]));
-		ret.write[i].basis.set_axis(2, Vector3(attribs[i * 16 + 8], attribs[i * 16 + 9], attribs[i * 16 + 10]));
+		ret.write[i].basis.set_column(0, Vector3(attribs[i * 16 + 0], attribs[i * 16 + 1], attribs[i * 16 + 2]));
+		ret.write[i].basis.set_column(1, Vector3(attribs[i * 16 + 4], attribs[i * 16 + 5], attribs[i * 16 + 6]));
+		ret.write[i].basis.set_column(2, Vector3(attribs[i * 16 + 8], attribs[i * 16 + 9], attribs[i * 16 + 10]));
 		ret.write[i].set_origin(Vector3(attribs[i * 16 + 12], attribs[i * 16 + 13], attribs[i * 16 + 14]));
 	}
 	return ret;

--- a/modules/mobile_vr/mobile_vr_interface.cpp
+++ b/modules/mobile_vr/mobile_vr_interface.cpp
@@ -175,9 +175,9 @@ void MobileVRInterface::set_position_from_sensors() {
 	if (has_gyro) {
 		// start with applying our gyro (do NOT smooth our gyro!)
 		Basis rotate;
-		rotate.rotate(orientation.get_axis(0), gyro.x * delta_time);
-		rotate.rotate(orientation.get_axis(1), gyro.y * delta_time);
-		rotate.rotate(orientation.get_axis(2), gyro.z * delta_time);
+		rotate.rotate(orientation.get_column(0), gyro.x * delta_time);
+		rotate.rotate(orientation.get_column(1), gyro.y * delta_time);
+		rotate.rotate(orientation.get_column(2), gyro.z * delta_time);
 		orientation = rotate * orientation;
 
 		tracking_state = XRInterface::XR_NORMAL_TRACKING;

--- a/modules/raycast/raycast_occlusion_cull.cpp
+++ b/modules/raycast/raycast_occlusion_cull.cpp
@@ -85,7 +85,7 @@ void RaycastOcclusionCull::RaycastHZBuffer::update_camera_rays(const Transform3D
 	td.z_near = p_cam_projection.get_z_near();
 	td.z_far = p_cam_projection.get_z_far() * 1.05f;
 	td.camera_pos = p_cam_transform.origin;
-	td.camera_dir = -p_cam_transform.basis.get_axis(2);
+	td.camera_dir = -p_cam_transform.basis.get_column(2);
 	td.camera_orthogonal = p_cam_orthogonal;
 
 	CameraMatrix inv_camera_matrix = p_cam_projection.inverse();
@@ -548,7 +548,7 @@ void RaycastOcclusionCull::buffer_update(RID p_buffer, const Transform3D &p_cam_
 	buffer.update_camera_rays(p_cam_transform, p_cam_projection, p_cam_orthogonal, p_thread_pool);
 
 	scenario.raycast(buffer.camera_rays, buffer.camera_ray_masks.ptr(), buffer.camera_rays_tile_count, p_thread_pool);
-	buffer.sort_rays(-p_cam_transform.basis.get_axis(2), p_cam_orthogonal);
+	buffer.sort_rays(-p_cam_transform.basis.get_column(2), p_cam_orthogonal);
 	buffer.update_mips();
 }
 

--- a/scene/2d/cpu_particles_2d.cpp
+++ b/scene/2d/cpu_particles_2d.cpp
@@ -788,8 +788,8 @@ void CPUParticles2D::_particles_process(double p_delta) {
 					if (emission_shape == EMISSION_SHAPE_DIRECTED_POINTS && emission_normals.size() == pc) {
 						Vector2 normal = emission_normals.get(random_idx);
 						Transform2D m2;
-						m2.set_axis(0, normal);
-						m2.set_axis(1, normal.orthogonal());
+						m2.columns[0] = normal;
+						m2.columns[1] = normal.orthogonal();
 						p.velocity = m2.basis_xform(p.velocity);
 					}
 

--- a/scene/2d/gpu_particles_2d.cpp
+++ b/scene/2d/gpu_particles_2d.cpp
@@ -114,8 +114,8 @@ void GPUParticles2D::set_use_local_coordinates(bool p_enable) {
 void GPUParticles2D::_update_particle_emission_transform() {
 	Transform2D xf2d = get_global_transform();
 	Transform3D xf;
-	xf.basis.set_axis(0, Vector3(xf2d.get_axis(0).x, xf2d.get_axis(0).y, 0));
-	xf.basis.set_axis(1, Vector3(xf2d.get_axis(1).x, xf2d.get_axis(1).y, 0));
+	xf.basis.set_column(0, Vector3(xf2d.columns[0].x, xf2d.columns[0].y, 0));
+	xf.basis.set_column(1, Vector3(xf2d.columns[1].x, xf2d.columns[1].y, 0));
 	xf.set_origin(Vector3(xf2d.get_origin().x, xf2d.get_origin().y, 0));
 
 	RS::get_singleton()->particles_set_emission_transform(particles, xf);
@@ -346,8 +346,8 @@ void GPUParticles2D::_validate_property(PropertyInfo &property) const {
 
 void GPUParticles2D::emit_particle(const Transform2D &p_transform2d, const Vector2 &p_velocity2d, const Color &p_color, const Color &p_custom, uint32_t p_emit_flags) {
 	Transform3D transform;
-	transform.basis.set_axis(0, Vector3(p_transform2d.get_axis(0).x, p_transform2d.get_axis(0).y, 0));
-	transform.basis.set_axis(1, Vector3(p_transform2d.get_axis(1).x, p_transform2d.get_axis(1).y, 0));
+	transform.basis.set_column(0, Vector3(p_transform2d.columns[0].x, p_transform2d.columns[0].y, 0));
+	transform.basis.set_column(1, Vector3(p_transform2d.columns[1].x, p_transform2d.columns[1].y, 0));
 	transform.set_origin(Vector3(p_transform2d.get_origin().x, p_transform2d.get_origin().y, 0));
 	Vector3 velocity = Vector3(p_velocity2d.x, p_velocity2d.y, 0);
 

--- a/scene/3d/area_3d.cpp
+++ b/scene/3d/area_3d.cpp
@@ -175,7 +175,7 @@ void Area3D::_initialize_wind() {
 		Node3D *p_wind_source = Object::cast_to<Node3D>(get_node(wind_source_path));
 		ERR_FAIL_NULL(p_wind_source);
 		Transform3D global_transform = p_wind_source->get_transform();
-		wind_direction = -global_transform.basis.get_axis(Vector3::AXIS_Z).normalized();
+		wind_direction = -global_transform.basis.get_column(Vector3::AXIS_Z).normalized();
 		wind_source = global_transform.origin;
 		temp_magnitude = wind_force_magnitude;
 	}

--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -447,7 +447,7 @@ Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 
 		if (emission_angle_enabled) {
 			Vector3 listenertopos = global_pos - listener_node->get_global_transform().origin;
-			float c = listenertopos.normalized().dot(get_global_transform().basis.get_axis(2).normalized()); //it's z negative
+			float c = listenertopos.normalized().dot(get_global_transform().basis.get_column(2).normalized()); //it's z negative
 			float angle = Math::rad2deg(Math::acos(c));
 			if (angle > emission_angle) {
 				db_att -= -emission_angle_filter_attenuation_db;

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -144,8 +144,8 @@ void Camera3D::_notification(int p_what) {
 
 Transform3D Camera3D::get_camera_transform() const {
 	Transform3D tr = get_global_transform().orthonormalized();
-	tr.origin += tr.basis.get_axis(1) * v_offset;
-	tr.origin += tr.basis.get_axis(0) * h_offset;
+	tr.origin += tr.basis.get_column(1) * v_offset;
+	tr.origin += tr.basis.get_column(0) * h_offset;
 	return tr;
 }
 
@@ -307,7 +307,7 @@ Vector3 Camera3D::project_ray_origin(const Point2 &p_pos) const {
 
 bool Camera3D::is_position_behind(const Vector3 &p_pos) const {
 	Transform3D t = get_global_transform();
-	Vector3 eyedir = -t.basis.get_axis(2).normalized();
+	Vector3 eyedir = -t.basis.get_column(2).normalized();
 	return eyedir.dot(p_pos - t.origin) < near;
 }
 

--- a/scene/3d/cpu_particles_3d.cpp
+++ b/scene/3d/cpu_particles_3d.cpp
@@ -833,8 +833,8 @@ void CPUParticles3D::_particles_process(double p_delta) {
 							Vector3 normal = emission_normals.get(random_idx);
 							Vector2 normal_2d(normal.x, normal.y);
 							Transform2D m2;
-							m2.set_axis(0, normal_2d);
-							m2.set_axis(1, normal_2d.orthogonal());
+							m2.columns[0] = normal_2d;
+							m2.columns[1] = normal_2d.orthogonal();
 							Vector2 velocity_2d(p.velocity.x, p.velocity.y);
 							velocity_2d = m2.basis_xform(velocity_2d);
 							p.velocity.x = velocity_2d.x;
@@ -845,9 +845,9 @@ void CPUParticles3D::_particles_process(double p_delta) {
 							Vector3 tangent = v0.cross(normal).normalized();
 							Vector3 bitangent = tangent.cross(normal).normalized();
 							Basis m3;
-							m3.set_axis(0, tangent);
-							m3.set_axis(1, bitangent);
-							m3.set_axis(2, normal);
+							m3.set_column(0, tangent);
+							m3.set_column(1, bitangent);
+							m3.set_column(2, normal);
 							p.velocity = m3.xform(p.velocity);
 						}
 					}
@@ -1068,33 +1068,33 @@ void CPUParticles3D::_particles_process(double p_delta) {
 		if (particle_flags[PARTICLE_FLAG_DISABLE_Z]) {
 			if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
 				if (p.velocity.length() > 0.0) {
-					p.transform.basis.set_axis(1, p.velocity.normalized());
+					p.transform.basis.set_column(1, p.velocity.normalized());
 				} else {
-					p.transform.basis.set_axis(1, p.transform.basis.get_axis(1));
+					p.transform.basis.set_column(1, p.transform.basis.get_column(1));
 				}
-				p.transform.basis.set_axis(0, p.transform.basis.get_axis(1).cross(p.transform.basis.get_axis(2)).normalized());
-				p.transform.basis.set_axis(2, Vector3(0, 0, 1));
+				p.transform.basis.set_column(0, p.transform.basis.get_column(1).cross(p.transform.basis.get_column(2)).normalized());
+				p.transform.basis.set_column(2, Vector3(0, 0, 1));
 
 			} else {
-				p.transform.basis.set_axis(0, Vector3(Math::cos(p.custom[0]), -Math::sin(p.custom[0]), 0.0));
-				p.transform.basis.set_axis(1, Vector3(Math::sin(p.custom[0]), Math::cos(p.custom[0]), 0.0));
-				p.transform.basis.set_axis(2, Vector3(0, 0, 1));
+				p.transform.basis.set_column(0, Vector3(Math::cos(p.custom[0]), -Math::sin(p.custom[0]), 0.0));
+				p.transform.basis.set_column(1, Vector3(Math::sin(p.custom[0]), Math::cos(p.custom[0]), 0.0));
+				p.transform.basis.set_column(2, Vector3(0, 0, 1));
 			}
 
 		} else {
 			//orient particle Y towards velocity
 			if (particle_flags[PARTICLE_FLAG_ALIGN_Y_TO_VELOCITY]) {
 				if (p.velocity.length() > 0.0) {
-					p.transform.basis.set_axis(1, p.velocity.normalized());
+					p.transform.basis.set_column(1, p.velocity.normalized());
 				} else {
-					p.transform.basis.set_axis(1, p.transform.basis.get_axis(1).normalized());
+					p.transform.basis.set_column(1, p.transform.basis.get_column(1).normalized());
 				}
-				if (p.transform.basis.get_axis(1) == p.transform.basis.get_axis(0)) {
-					p.transform.basis.set_axis(0, p.transform.basis.get_axis(1).cross(p.transform.basis.get_axis(2)).normalized());
-					p.transform.basis.set_axis(2, p.transform.basis.get_axis(0).cross(p.transform.basis.get_axis(1)).normalized());
+				if (p.transform.basis.get_column(1) == p.transform.basis.get_column(0)) {
+					p.transform.basis.set_column(0, p.transform.basis.get_column(1).cross(p.transform.basis.get_column(2)).normalized());
+					p.transform.basis.set_column(2, p.transform.basis.get_column(0).cross(p.transform.basis.get_column(1)).normalized());
 				} else {
-					p.transform.basis.set_axis(2, p.transform.basis.get_axis(0).cross(p.transform.basis.get_axis(1)).normalized());
-					p.transform.basis.set_axis(0, p.transform.basis.get_axis(1).cross(p.transform.basis.get_axis(2)).normalized());
+					p.transform.basis.set_column(2, p.transform.basis.get_column(0).cross(p.transform.basis.get_column(1)).normalized());
+					p.transform.basis.set_column(0, p.transform.basis.get_column(1).cross(p.transform.basis.get_column(2)).normalized());
 				}
 			} else {
 				p.transform.basis.orthonormalize();
@@ -1159,7 +1159,7 @@ void CPUParticles3D::_update_particle_data_buffer() {
 			ERR_FAIL_NULL(get_viewport());
 			Camera3D *c = get_viewport()->get_camera_3d();
 			if (c) {
-				Vector3 dir = c->get_global_transform().basis.get_axis(2); //far away to close
+				Vector3 dir = c->get_global_transform().basis.get_column(2); //far away to close
 
 				if (local_coords) {
 					// will look different from Particles in editor as this is based on the camera in the scenetree

--- a/scene/3d/gpu_particles_collision_3d.cpp
+++ b/scene/3d/gpu_particles_collision_3d.cpp
@@ -594,8 +594,8 @@ void GPUParticlesCollisionHeightField3D::_notification(int p_what) {
 				Camera3D *cam = get_viewport()->get_camera_3d();
 				if (cam) {
 					Transform3D xform = get_global_transform();
-					Vector3 x_axis = xform.basis.get_axis(Vector3::AXIS_X).normalized();
-					Vector3 z_axis = xform.basis.get_axis(Vector3::AXIS_Z).normalized();
+					Vector3 x_axis = xform.basis.get_column(Vector3::AXIS_X).normalized();
+					Vector3 z_axis = xform.basis.get_column(Vector3::AXIS_Z).normalized();
 					float x_len = xform.basis.get_scale().x;
 					float z_len = xform.basis.get_scale().z;
 

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -887,13 +887,13 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 			Color linear_color = light->get_color().srgb_to_linear();
 			if (Object::cast_to<DirectionalLight3D>(light)) {
 				DirectionalLight3D *l = Object::cast_to<DirectionalLight3D>(light);
-				lightmapper->add_directional_light(light->get_bake_mode() == Light3D::BAKE_STATIC, -xf.basis.get_axis(Vector3::AXIS_Z).normalized(), linear_color, l->get_param(Light3D::PARAM_ENERGY), l->get_param(Light3D::PARAM_SIZE));
+				lightmapper->add_directional_light(light->get_bake_mode() == Light3D::BAKE_STATIC, -xf.basis.get_column(Vector3::AXIS_Z).normalized(), linear_color, l->get_param(Light3D::PARAM_ENERGY), l->get_param(Light3D::PARAM_SIZE));
 			} else if (Object::cast_to<OmniLight3D>(light)) {
 				OmniLight3D *l = Object::cast_to<OmniLight3D>(light);
 				lightmapper->add_omni_light(light->get_bake_mode() == Light3D::BAKE_STATIC, xf.origin, linear_color, l->get_param(Light3D::PARAM_ENERGY), l->get_param(Light3D::PARAM_RANGE), l->get_param(Light3D::PARAM_ATTENUATION), l->get_param(Light3D::PARAM_SIZE));
 			} else if (Object::cast_to<SpotLight3D>(light)) {
 				SpotLight3D *l = Object::cast_to<SpotLight3D>(light);
-				lightmapper->add_spot_light(light->get_bake_mode() == Light3D::BAKE_STATIC, xf.origin, -xf.basis.get_axis(Vector3::AXIS_Z).normalized(), linear_color, l->get_param(Light3D::PARAM_ENERGY), l->get_param(Light3D::PARAM_RANGE), l->get_param(Light3D::PARAM_ATTENUATION), l->get_param(Light3D::PARAM_SPOT_ANGLE), l->get_param(Light3D::PARAM_SPOT_ATTENUATION), l->get_param(Light3D::PARAM_SIZE));
+				lightmapper->add_spot_light(light->get_bake_mode() == Light3D::BAKE_STATIC, xf.origin, -xf.basis.get_column(Vector3::AXIS_Z).normalized(), linear_color, l->get_param(Light3D::PARAM_ENERGY), l->get_param(Light3D::PARAM_RANGE), l->get_param(Light3D::PARAM_ATTENUATION), l->get_param(Light3D::PARAM_SPOT_ANGLE), l->get_param(Light3D::PARAM_SPOT_ATTENUATION), l->get_param(Light3D::PARAM_SIZE));
 			}
 		}
 		for (int i = 0; i < probes_found.size(); i++) {

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -146,7 +146,7 @@ void PathFollow3D::_update_transform(bool p_update_xyz_rot) {
 		Vector3 sideways = up.cross(forward).normalized();
 		up = forward.cross(sideways).normalized();
 
-		t.basis.set(sideways, up, forward);
+		t.basis.set_columns(sideways, up, forward);
 		t.basis.scale_local(scale);
 
 		t.origin = pos + sideways * h_offset + up * v_offset;

--- a/scene/3d/physics_body_3d.cpp
+++ b/scene/3d/physics_body_3d.cpp
@@ -991,7 +991,7 @@ TypedArray<String> RigidDynamicBody3D::get_configuration_warnings() const {
 
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
-	if (ABS(t.basis.get_axis(0).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(1).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(2).length() - 1.0) > 0.05) {
+	if (ABS(t.basis.get_column(0).length() - 1.0) > 0.05 || ABS(t.basis.get_column(1).length() - 1.0) > 0.05 || ABS(t.basis.get_column(2).length() - 1.0) > 0.05) {
 		warnings.push_back(RTR("Size changes to RigidDynamicBody will be overridden by the physics engine when running.\nChange the size in children collision shapes instead."));
 	}
 

--- a/scene/3d/soft_dynamic_body_3d.cpp
+++ b/scene/3d/soft_dynamic_body_3d.cpp
@@ -382,7 +382,7 @@ TypedArray<String> SoftDynamicBody3D::get_configuration_warnings() const {
 	}
 
 	Transform3D t = get_transform();
-	if ((ABS(t.basis.get_axis(0).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(1).length() - 1.0) > 0.05 || ABS(t.basis.get_axis(2).length() - 1.0) > 0.05)) {
+	if ((ABS(t.basis.get_column(0).length() - 1.0) > 0.05 || ABS(t.basis.get_column(1).length() - 1.0) > 0.05 || ABS(t.basis.get_column(2).length() - 1.0) > 0.05)) {
 		warnings.push_back(RTR("Size changes to SoftDynamicBody3D will be overridden by the physics engine when running.\nChange the size in children collision shapes instead."));
 	}
 

--- a/scene/3d/vehicle_body_3d.cpp
+++ b/scene/3d/vehicle_body_3d.cpp
@@ -90,8 +90,8 @@ void VehicleWheel3D::_notification(int p_what) {
 			cb->wheels.push_back(this);
 
 			m_chassisConnectionPointCS = get_transform().origin;
-			m_wheelDirectionCS = -get_transform().basis.get_axis(Vector3::AXIS_Y).normalized();
-			m_wheelAxleCS = get_transform().basis.get_axis(Vector3::AXIS_X).normalized();
+			m_wheelDirectionCS = -get_transform().basis.get_column(Vector3::AXIS_Y).normalized();
+			m_wheelAxleCS = get_transform().basis.get_column(Vector3::AXIS_X).normalized();
 		} break;
 
 		case NOTIFICATION_EXIT_TREE: {
@@ -684,7 +684,7 @@ void VehicleBody3D::_update_friction(PhysicsDirectBodyState3D *s) {
 
 				Basis wheelBasis0 = wheelInfo.m_worldTransform.basis; //get_global_transform().basis;
 
-				m_axle.write[i] = wheelBasis0.get_axis(Vector3::AXIS_X);
+				m_axle.write[i] = wheelBasis0.get_column(Vector3::AXIS_X);
 				//m_axle[i] = wheelInfo.m_raycastInfo.m_wheelAxleWS;
 
 				const Vector3 &surfNormalWS = wheelInfo.m_raycastInfo.m_contactNormalWS;

--- a/scene/3d/xr_nodes.cpp
+++ b/scene/3d/xr_nodes.cpp
@@ -577,7 +577,7 @@ Plane XRAnchor3D::get_plane() const {
 	Vector3 location = get_position();
 	Basis orientation = get_transform().basis;
 
-	Plane plane(orientation.get_axis(1).normalized(), location);
+	Plane plane(orientation.get_column(1).normalized(), location);
 
 	return plane;
 }

--- a/scene/resources/importer_mesh.cpp
+++ b/scene/resources/importer_mesh.cpp
@@ -1023,7 +1023,7 @@ Error ImporterMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, 
 
 	// Keep only the scale
 	Basis basis = p_base_transform.get_basis();
-	Vector3 scale = Vector3(basis.get_axis(0).length(), basis.get_axis(1).length(), basis.get_axis(2).length());
+	Vector3 scale = Vector3(basis.get_column(0).length(), basis.get_column(1).length(), basis.get_column(2).length());
 
 	Transform3D transform;
 	transform.scale(scale);

--- a/scene/resources/mesh.cpp
+++ b/scene/resources/mesh.cpp
@@ -1827,7 +1827,7 @@ Error ArrayMesh::lightmap_unwrap_cached(const Transform3D &p_base_transform, flo
 
 	// Keep only the scale
 	Basis basis = p_base_transform.get_basis();
-	Vector3 scale = Vector3(basis.get_axis(0).length(), basis.get_axis(1).length(), basis.get_axis(2).length());
+	Vector3 scale = Vector3(basis.get_column(0).length(), basis.get_column(1).length(), basis.get_column(2).length());
 
 	Transform3D transform;
 	transform.scale(scale);

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -5548,9 +5548,9 @@ Transform3D VisualShaderNodeTransformUniform::get_default_value() const {
 String VisualShaderNodeTransformUniform::generate_global(Shader::Mode p_mode, VisualShader::Type p_type, int p_id) const {
 	String code = _get_qual_str() + "uniform mat4 " + get_uniform_name();
 	if (default_value_enabled) {
-		Vector3 row0 = default_value.basis.get_row(0);
-		Vector3 row1 = default_value.basis.get_row(1);
-		Vector3 row2 = default_value.basis.get_row(2);
+		Vector3 row0 = default_value.basis.rows[0];
+		Vector3 row1 = default_value.basis.rows[1];
+		Vector3 row2 = default_value.basis.rows[2];
 		Vector3 origin = default_value.origin;
 		code += " = mat4(" + vformat("vec4(%.6f, %.6f, %.6f, 0.0)", row0.x, row0.y, row0.z) + vformat(", vec4(%.6f, %.6f, %.6f, 0.0)", row1.x, row1.y, row1.z) + vformat(", vec4(%.6f, %.6f, %.6f, 0.0)", row2.x, row2.y, row2.z) + vformat(", vec4(%.6f, %.6f, %.6f, 1.0)", origin.x, origin.y, origin.z) + ")";
 	}

--- a/servers/physics_2d/godot_body_pair_2d.cpp
+++ b/servers/physics_2d/godot_body_pair_2d.cpp
@@ -203,7 +203,7 @@ bool GodotBodyPair2D::_test_ccd(real_t p_step, GodotBody2D *p_A, int p_shape_A, 
 
 	// Check one-way collision based on motion direction.
 	if (p_A->get_shape(p_shape_A)->allows_one_way_collision() && p_B->is_shape_set_as_one_way_collision(p_shape_B)) {
-		Vector2 direction = p_xform_B.get_axis(1).normalized();
+		Vector2 direction = p_xform_B.columns[1].normalized();
 		if (direction.dot(mnormal) < CMP_EPSILON) {
 			collided = false;
 			oneway_disabled = true;
@@ -300,7 +300,7 @@ bool GodotBodyPair2D::setup(real_t p_step) {
 
 	if (!prev_collided) {
 		if (shape_B_ptr->allows_one_way_collision() && A->is_shape_set_as_one_way_collision(shape_A)) {
-			Vector2 direction = xform_A.get_axis(1).normalized();
+			Vector2 direction = xform_A.columns[1].normalized();
 			bool valid = false;
 			for (int i = 0; i < contact_count; i++) {
 				Contact &c = contacts[i];
@@ -318,7 +318,7 @@ bool GodotBodyPair2D::setup(real_t p_step) {
 		}
 
 		if (shape_A_ptr->allows_one_way_collision() && B->is_shape_set_as_one_way_collision(shape_B)) {
-			Vector2 direction = xform_B.get_axis(1).normalized();
+			Vector2 direction = xform_B.columns[1].normalized();
 			bool valid = false;
 			for (int i = 0; i < contact_count; i++) {
 				Contact &c = contacts[i];

--- a/servers/physics_2d/godot_space_2d.cpp
+++ b/servers/physics_2d/godot_space_2d.cpp
@@ -633,7 +633,7 @@ bool GodotSpace2D::test_body_motion(GodotBody2D *p_body, const PhysicsServer2D::
 					Transform2D col_obj_shape_xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
 
 					if (body_shape->allows_one_way_collision() && col_obj->is_shape_set_as_one_way_collision(shape_idx)) {
-						cbk.valid_dir = col_obj_shape_xform.get_axis(1).normalized();
+						cbk.valid_dir = col_obj_shape_xform.columns[1].normalized();
 
 						real_t owc_margin = col_obj->get_shape_one_way_collision_margin(shape_idx);
 						cbk.valid_depth = MAX(owc_margin, margin); //user specified, but never less than actual margin or it won't work
@@ -788,7 +788,7 @@ bool GodotSpace2D::test_body_motion(GodotBody2D *p_body, const PhysicsServer2D::
 				//test initial overlap
 				if (GodotCollisionSolver2D::solve(body_shape, body_shape_xform, Vector2(), against_shape, col_obj_shape_xform, Vector2(), nullptr, nullptr, nullptr, 0)) {
 					if (body_shape->allows_one_way_collision() && col_obj->is_shape_set_as_one_way_collision(col_shape_idx)) {
-						Vector2 direction = col_obj_shape_xform.get_axis(1).normalized();
+						Vector2 direction = col_obj_shape_xform.columns[1].normalized();
 						if (motion_normal.dot(direction) < 0) {
 							continue;
 						}
@@ -838,7 +838,7 @@ bool GodotSpace2D::test_body_motion(GodotBody2D *p_body, const PhysicsServer2D::
 					cbk.amount = 0;
 					cbk.passed = 0;
 					cbk.ptr = cd;
-					cbk.valid_dir = col_obj_shape_xform.get_axis(1).normalized();
+					cbk.valid_dir = col_obj_shape_xform.columns[1].normalized();
 
 					cbk.valid_depth = 10e20;
 
@@ -929,7 +929,7 @@ bool GodotSpace2D::test_body_motion(GodotBody2D *p_body, const PhysicsServer2D::
 				Transform2D col_obj_shape_xform = col_obj->get_transform() * col_obj->get_shape_transform(shape_idx);
 
 				if (body_shape->allows_one_way_collision() && col_obj->is_shape_set_as_one_way_collision(shape_idx)) {
-					rcd.valid_dir = col_obj_shape_xform.get_axis(1).normalized();
+					rcd.valid_dir = col_obj_shape_xform.columns[1].normalized();
 
 					real_t owc_margin = col_obj->get_shape_one_way_collision_margin(shape_idx);
 					rcd.valid_depth = MAX(owc_margin, margin); //user specified, but never less than actual margin or it won't work

--- a/servers/physics_3d/godot_collision_solver_3d.cpp
+++ b/servers/physics_3d/godot_collision_solver_3d.cpp
@@ -94,7 +94,7 @@ bool GodotCollisionSolver3D::solve_separation_ray(const GodotShape3D *p_shape_A,
 	const GodotSeparationRayShape3D *ray = static_cast<const GodotSeparationRayShape3D *>(p_shape_A);
 
 	Vector3 from = p_transform_A.origin;
-	Vector3 to = from + p_transform_A.basis.get_axis(2) * (ray->get_length() + p_margin);
+	Vector3 to = from + p_transform_A.basis.get_column(2) * (ray->get_length() + p_margin);
 	Vector3 support_A = to;
 
 	Transform3D ai = p_transform_B.affine_inverse();
@@ -252,7 +252,7 @@ bool GodotCollisionSolver3D::solve_soft_body(const GodotShape3D *p_shape_A, cons
 		// Calculate AABB for internal concave shape query (in local space).
 		AABB local_aabb;
 		for (int i = 0; i < 3; i++) {
-			Vector3 axis(p_transform_A.basis.get_axis(i));
+			Vector3 axis(p_transform_A.basis.get_column(i));
 			real_t axis_scale = 1.0 / axis.length();
 
 			real_t smin = soft_body_aabb.position[i];
@@ -333,7 +333,7 @@ bool GodotCollisionSolver3D::solve_concave(const GodotShape3D *p_shape_A, const 
 
 	AABB local_aabb;
 	for (int i = 0; i < 3; i++) {
-		Vector3 axis(p_transform_B.basis.get_axis(i));
+		Vector3 axis(p_transform_B.basis.get_column(i));
 		real_t axis_scale = 1.0 / axis.length();
 		axis *= axis_scale;
 
@@ -542,7 +542,7 @@ bool GodotCollisionSolver3D::solve_distance(const GodotShape3D *p_shape_A, const
 
 		AABB local_aabb;
 		for (int i = 0; i < 3; i++) {
-			Vector3 axis(p_transform_B.basis.get_axis(i));
+			Vector3 axis(p_transform_B.basis.get_column(i));
 			real_t axis_scale = ((real_t)1.0) / axis.length();
 			axis *= axis_scale;
 

--- a/servers/physics_3d/godot_collision_solver_3d_sat.cpp
+++ b/servers/physics_3d/godot_collision_solver_3d_sat.cpp
@@ -792,7 +792,7 @@ static void _collision_sphere_box(const GodotShape3D *p_a, const Transform3D &p_
 	// test faces
 
 	for (int i = 0; i < 3; i++) {
-		Vector3 axis = p_transform_b.basis.get_axis(i).normalized();
+		Vector3 axis = p_transform_b.basis.get_column(i).normalized();
 
 		if (!separator.test_axis(axis)) {
 			return;
@@ -819,7 +819,7 @@ static void _collision_sphere_box(const GodotShape3D *p_a, const Transform3D &p_
 	// test edges
 
 	for (int i = 0; i < 3; i++) {
-		Vector3 axis = point_axis.cross(p_transform_b.basis.get_axis(i)).cross(p_transform_b.basis.get_axis(i)).normalized();
+		Vector3 axis = point_axis.cross(p_transform_b.basis.get_column(i)).cross(p_transform_b.basis.get_column(i)).normalized();
 
 		if (!separator.test_axis(axis)) {
 			return;
@@ -842,7 +842,7 @@ static void _collision_sphere_capsule(const GodotShape3D *p_a, const Transform3D
 
 	//capsule sphere 1, sphere
 
-	Vector3 capsule_axis = p_transform_b.basis.get_axis(1) * (capsule_B->get_height() * 0.5 - capsule_B->get_radius());
+	Vector3 capsule_axis = p_transform_b.basis.get_column(1) * (capsule_B->get_height() * 0.5 - capsule_B->get_radius());
 
 	Vector3 capsule_ball_1 = p_transform_b.origin + capsule_axis;
 
@@ -883,7 +883,7 @@ static void _collision_sphere_cylinder(const GodotShape3D *p_a, const Transform3
 	}
 
 	// Cylinder B end caps.
-	Vector3 cylinder_B_axis = p_transform_b.basis.get_axis(1).normalized();
+	Vector3 cylinder_B_axis = p_transform_b.basis.get_column(1).normalized();
 	if (!separator.test_axis(cylinder_B_axis)) {
 		return;
 	}
@@ -897,8 +897,8 @@ static void _collision_sphere_cylinder(const GodotShape3D *p_a, const Transform3
 
 	// Closest point to cylinder caps.
 	const Vector3 &sphere_center = p_transform_a.origin;
-	Vector3 cyl_axis = p_transform_b.basis.get_axis(1);
-	Vector3 cap_axis = p_transform_b.basis.get_axis(0);
+	Vector3 cyl_axis = p_transform_b.basis.get_column(1);
+	Vector3 cap_axis = p_transform_b.basis.get_column(0);
 	real_t height_scale = cyl_axis.length();
 	real_t cap_dist = cylinder_B->get_height() * 0.5 * height_scale;
 	cyl_axis /= height_scale;
@@ -1063,7 +1063,7 @@ static void _collision_box_box(const GodotShape3D *p_a, const Transform3D &p_tra
 	// test faces of A
 
 	for (int i = 0; i < 3; i++) {
-		Vector3 axis = p_transform_a.basis.get_axis(i).normalized();
+		Vector3 axis = p_transform_a.basis.get_column(i).normalized();
 
 		if (!separator.test_axis(axis)) {
 			return;
@@ -1073,7 +1073,7 @@ static void _collision_box_box(const GodotShape3D *p_a, const Transform3D &p_tra
 	// test faces of B
 
 	for (int i = 0; i < 3; i++) {
-		Vector3 axis = p_transform_b.basis.get_axis(i).normalized();
+		Vector3 axis = p_transform_b.basis.get_column(i).normalized();
 
 		if (!separator.test_axis(axis)) {
 			return;
@@ -1083,7 +1083,7 @@ static void _collision_box_box(const GodotShape3D *p_a, const Transform3D &p_tra
 	// test combined edges
 	for (int i = 0; i < 3; i++) {
 		for (int j = 0; j < 3; j++) {
-			Vector3 axis = p_transform_a.basis.get_axis(i).cross(p_transform_b.basis.get_axis(j));
+			Vector3 axis = p_transform_a.basis.get_column(i).cross(p_transform_b.basis.get_column(j));
 
 			if (Math::is_zero_approx(axis.length_squared())) {
 				continue;
@@ -1129,14 +1129,14 @@ static void _collision_box_box(const GodotShape3D *p_a, const Transform3D &p_tra
 
 		for (int i = 0; i < 3; i++) {
 			//a ->b
-			Vector3 axis_a = p_transform_a.basis.get_axis(i);
+			Vector3 axis_a = p_transform_a.basis.get_column(i);
 
 			if (!separator.test_axis(axis_ab.cross(axis_a).cross(axis_a).normalized())) {
 				return;
 			}
 
 			//b ->a
-			Vector3 axis_b = p_transform_b.basis.get_axis(i);
+			Vector3 axis_b = p_transform_b.basis.get_column(i);
 
 			if (!separator.test_axis(axis_ab.cross(axis_b).cross(axis_b).normalized())) {
 				return;
@@ -1160,20 +1160,20 @@ static void _collision_box_capsule(const GodotShape3D *p_a, const Transform3D &p
 
 	// faces of A
 	for (int i = 0; i < 3; i++) {
-		Vector3 axis = p_transform_a.basis.get_axis(i).normalized();
+		Vector3 axis = p_transform_a.basis.get_column(i).normalized();
 
 		if (!separator.test_axis(axis)) {
 			return;
 		}
 	}
 
-	Vector3 cyl_axis = p_transform_b.basis.get_axis(1).normalized();
+	Vector3 cyl_axis = p_transform_b.basis.get_column(1).normalized();
 
 	// edges of A, capsule cylinder
 
 	for (int i = 0; i < 3; i++) {
 		// cylinder
-		Vector3 box_axis = p_transform_a.basis.get_axis(i);
+		Vector3 box_axis = p_transform_a.basis.get_column(i);
 		Vector3 axis = box_axis.cross(cyl_axis);
 		if (Math::is_zero_approx(axis.length_squared())) {
 			continue;
@@ -1196,7 +1196,7 @@ static void _collision_box_capsule(const GodotShape3D *p_a, const Transform3D &p
 				he.z *= (k * 2 - 1);
 				Vector3 point = p_transform_a.origin;
 				for (int l = 0; l < 3; l++) {
-					point += p_transform_a.basis.get_axis(l) * he[l];
+					point += p_transform_a.basis.get_column(l) * he[l];
 				}
 
 				//Vector3 axis = (point - cyl_axis * cyl_axis.dot(point)).normalized();
@@ -1212,7 +1212,7 @@ static void _collision_box_capsule(const GodotShape3D *p_a, const Transform3D &p
 	// capsule balls, edges of A
 
 	for (int i = 0; i < 2; i++) {
-		Vector3 capsule_axis = p_transform_b.basis.get_axis(1) * (capsule_B->get_height() * 0.5 - capsule_B->get_radius());
+		Vector3 capsule_axis = p_transform_b.basis.get_column(1) * (capsule_B->get_height() * 0.5 - capsule_B->get_radius());
 
 		Vector3 sphere_pos = p_transform_b.origin + ((i == 0) ? capsule_axis : -capsule_axis);
 
@@ -1234,7 +1234,7 @@ static void _collision_box_capsule(const GodotShape3D *p_a, const Transform3D &p
 		// test edges of A
 
 		for (int j = 0; j < 3; j++) {
-			Vector3 axis = point_axis.cross(p_transform_a.basis.get_axis(j)).cross(p_transform_a.basis.get_axis(j)).normalized();
+			Vector3 axis = point_axis.cross(p_transform_a.basis.get_column(j)).cross(p_transform_a.basis.get_column(j)).normalized();
 
 			if (!separator.test_axis(axis)) {
 				return;
@@ -1258,14 +1258,14 @@ static void _collision_box_cylinder(const GodotShape3D *p_a, const Transform3D &
 
 	// Faces of A.
 	for (int i = 0; i < 3; i++) {
-		Vector3 axis = p_transform_a.basis.get_axis(i).normalized();
+		Vector3 axis = p_transform_a.basis.get_column(i).normalized();
 
 		if (!separator.test_axis(axis)) {
 			return;
 		}
 	}
 
-	Vector3 cyl_axis = p_transform_b.basis.get_axis(1).normalized();
+	Vector3 cyl_axis = p_transform_b.basis.get_column(1).normalized();
 
 	// Cylinder end caps.
 	{
@@ -1276,7 +1276,7 @@ static void _collision_box_cylinder(const GodotShape3D *p_a, const Transform3D &
 
 	// Edges of A, cylinder lateral surface.
 	for (int i = 0; i < 3; i++) {
-		Vector3 box_axis = p_transform_a.basis.get_axis(i);
+		Vector3 box_axis = p_transform_a.basis.get_column(i);
 		Vector3 axis = box_axis.cross(cyl_axis);
 		if (Math::is_zero_approx(axis.length_squared())) {
 			continue;
@@ -1300,7 +1300,7 @@ static void _collision_box_cylinder(const GodotShape3D *p_a, const Transform3D &
 				Vector3 &point = vertices_A[i * 2 * 2 + j * 2 + k];
 				point = p_transform_a.origin;
 				for (int l = 0; l < 3; l++) {
-					point += p_transform_a.basis.get_axis(l) * extent[l];
+					point += p_transform_a.basis.get_column(l) * extent[l];
 				}
 			}
 		}
@@ -1380,7 +1380,7 @@ static void _collision_box_convex_polygon(const GodotShape3D *p_a, const Transfo
 
 	// faces of A
 	for (int i = 0; i < 3; i++) {
-		Vector3 axis = p_transform_a.basis.get_axis(i).normalized();
+		Vector3 axis = p_transform_a.basis.get_column(i).normalized();
 
 		if (!separator.test_axis(axis)) {
 			return;
@@ -1401,7 +1401,7 @@ static void _collision_box_convex_polygon(const GodotShape3D *p_a, const Transfo
 
 	// A<->B edges
 	for (int i = 0; i < 3; i++) {
-		Vector3 e1 = p_transform_a.basis.get_axis(i);
+		Vector3 e1 = p_transform_a.basis.get_column(i);
 
 		for (int j = 0; j < edge_count; j++) {
 			Vector3 e2 = p_transform_b.basis.xform(vertices[edges[j].a]) - p_transform_b.basis.xform(vertices[edges[j].b]);
@@ -1438,7 +1438,7 @@ static void _collision_box_convex_polygon(const GodotShape3D *p_a, const Transfo
 
 			for (int i = 0; i < 3; i++) {
 				//a ->b
-				Vector3 axis_a = p_transform_a.basis.get_axis(i);
+				Vector3 axis_a = p_transform_a.basis.get_column(i);
 
 				if (!separator.test_axis(axis_ab.cross(axis_a).cross(axis_a).normalized())) {
 					return;
@@ -1456,7 +1456,7 @@ static void _collision_box_convex_polygon(const GodotShape3D *p_a, const Transfo
 					he.z *= (k * 2 - 1);
 					Vector3 point = p_transform_a.origin;
 					for (int l = 0; l < 3; l++) {
-						point += p_transform_a.basis.get_axis(l) * he[l];
+						point += p_transform_a.basis.get_column(l) * he[l];
 					}
 
 					for (int e = 0; e < edge_count; e++) {
@@ -1497,7 +1497,7 @@ static void _collision_box_face(const GodotShape3D *p_a, const Transform3D &p_tr
 
 	// faces of A
 	for (int i = 0; i < 3; i++) {
-		Vector3 axis = p_transform_a.basis.get_axis(i).normalized();
+		Vector3 axis = p_transform_a.basis.get_column(i).normalized();
 		if (axis.dot(normal) < 0.0) {
 			axis *= -1.0;
 		}
@@ -1513,7 +1513,7 @@ static void _collision_box_face(const GodotShape3D *p_a, const Transform3D &p_tr
 		Vector3 e = vertex[i] - vertex[(i + 1) % 3];
 
 		for (int j = 0; j < 3; j++) {
-			Vector3 axis = e.cross(p_transform_a.basis.get_axis(j)).normalized();
+			Vector3 axis = e.cross(p_transform_a.basis.get_column(j)).normalized();
 			if (axis.dot(normal) < 0.0) {
 				axis *= -1.0;
 			}
@@ -1550,7 +1550,7 @@ static void _collision_box_face(const GodotShape3D *p_a, const Transform3D &p_tr
 
 			for (int i = 0; i < 3; i++) {
 				//a ->b
-				Vector3 axis_a = p_transform_a.basis.get_axis(i);
+				Vector3 axis_a = p_transform_a.basis.get_column(i);
 
 				Vector3 axis = axis_ab.cross(axis_a).cross(axis_a).normalized();
 				if (axis.dot(normal) < 0.0) {
@@ -1573,7 +1573,7 @@ static void _collision_box_face(const GodotShape3D *p_a, const Transform3D &p_tr
 					he.z *= (k * 2 - 1);
 					Vector3 point = p_transform_a.origin;
 					for (int l = 0; l < 3; l++) {
-						point += p_transform_a.basis.get_axis(l) * he[l];
+						point += p_transform_a.basis.get_column(l) * he[l];
 					}
 
 					for (int e = 0; e < 3; e++) {
@@ -1623,8 +1623,8 @@ static void _collision_capsule_capsule(const GodotShape3D *p_a, const Transform3
 
 	// some values
 
-	Vector3 capsule_A_axis = p_transform_a.basis.get_axis(1) * (capsule_A->get_height() * 0.5 - capsule_A->get_radius());
-	Vector3 capsule_B_axis = p_transform_b.basis.get_axis(1) * (capsule_B->get_height() * 0.5 - capsule_B->get_radius());
+	Vector3 capsule_A_axis = p_transform_a.basis.get_column(1) * (capsule_A->get_height() * 0.5 - capsule_A->get_radius());
+	Vector3 capsule_B_axis = p_transform_b.basis.get_column(1) * (capsule_B->get_height() * 0.5 - capsule_B->get_radius());
 
 	Vector3 capsule_A_ball_1 = p_transform_a.origin + capsule_A_axis;
 	Vector3 capsule_A_ball_2 = p_transform_a.origin - capsule_A_axis;
@@ -1686,14 +1686,14 @@ static void _collision_capsule_cylinder(const GodotShape3D *p_a, const Transform
 	}
 
 	// Cylinder B end caps.
-	Vector3 cylinder_B_axis = p_transform_b.basis.get_axis(1).normalized();
+	Vector3 cylinder_B_axis = p_transform_b.basis.get_column(1).normalized();
 	if (!separator.test_axis(cylinder_B_axis)) {
 		return;
 	}
 
 	// Cylinder edge against capsule balls.
 
-	Vector3 capsule_A_axis = p_transform_a.basis.get_axis(1);
+	Vector3 capsule_A_axis = p_transform_a.basis.get_column(1);
 
 	Vector3 capsule_A_ball_1 = p_transform_a.origin + capsule_A_axis * (capsule_A->get_height() * 0.5 - capsule_A->get_radius());
 	Vector3 capsule_A_ball_2 = p_transform_a.origin - capsule_A_axis * (capsule_A->get_height() * 0.5 - capsule_A->get_radius());
@@ -1772,7 +1772,7 @@ static void _collision_capsule_convex_polygon(const GodotShape3D *p_a, const Tra
 	for (int i = 0; i < edge_count; i++) {
 		// cylinder
 		Vector3 edge_axis = p_transform_b.basis.xform(vertices[edges[i].a]) - p_transform_b.basis.xform(vertices[edges[i].b]);
-		Vector3 axis = edge_axis.cross(p_transform_a.basis.get_axis(1)).normalized();
+		Vector3 axis = edge_axis.cross(p_transform_a.basis.get_column(1)).normalized();
 
 		if (!separator.test_axis(axis)) {
 			return;
@@ -1784,7 +1784,7 @@ static void _collision_capsule_convex_polygon(const GodotShape3D *p_a, const Tra
 	for (int i = 0; i < 2; i++) {
 		// edges of B, capsule cylinder
 
-		Vector3 capsule_axis = p_transform_a.basis.get_axis(1) * (capsule_A->get_height() * 0.5 - capsule_A->get_radius());
+		Vector3 capsule_axis = p_transform_a.basis.get_column(1) * (capsule_A->get_height() * 0.5 - capsule_A->get_radius());
 
 		Vector3 sphere_pos = p_transform_a.origin + ((i == 0) ? capsule_axis : -capsule_axis);
 
@@ -1824,7 +1824,7 @@ static void _collision_capsule_face(const GodotShape3D *p_a, const Transform3D &
 
 	// edges of B, capsule cylinder
 
-	Vector3 capsule_axis = p_transform_a.basis.get_axis(1) * (capsule_A->get_height() * 0.5 - capsule_A->get_radius());
+	Vector3 capsule_axis = p_transform_a.basis.get_column(1) * (capsule_A->get_height() * 0.5 - capsule_A->get_radius());
 
 	for (int i = 0; i < 3; i++) {
 		// edge-cylinder
@@ -1895,8 +1895,8 @@ static void _collision_cylinder_cylinder(const GodotShape3D *p_a, const Transfor
 
 	SeparatorAxisTest<GodotCylinderShape3D, GodotCylinderShape3D, withMargin> separator(cylinder_A, p_transform_a, cylinder_B, p_transform_b, p_collector, p_margin_a, p_margin_b);
 
-	Vector3 cylinder_A_axis = p_transform_a.basis.get_axis(1);
-	Vector3 cylinder_B_axis = p_transform_b.basis.get_axis(1);
+	Vector3 cylinder_A_axis = p_transform_a.basis.get_column(1);
+	Vector3 cylinder_B_axis = p_transform_b.basis.get_column(1);
 
 	if (!separator.test_previous_axis()) {
 		return;
@@ -1983,7 +1983,7 @@ static void _collision_cylinder_face(const GodotShape3D *p_a, const Transform3D 
 		return;
 	}
 
-	Vector3 cyl_axis = p_transform_a.basis.get_axis(1).normalized();
+	Vector3 cyl_axis = p_transform_a.basis.get_column(1).normalized();
 	if (cyl_axis.dot(normal) < 0.0) {
 		cyl_axis *= -1.0;
 	}

--- a/servers/physics_3d/godot_shape_3d.cpp
+++ b/servers/physics_3d/godot_shape_3d.cpp
@@ -662,7 +662,7 @@ GodotCapsuleShape3D::GodotCapsuleShape3D() {}
 /********** CYLINDER *************/
 
 void GodotCylinderShape3D::project_range(const Vector3 &p_normal, const Transform3D &p_transform, real_t &r_min, real_t &r_max) const {
-	Vector3 cylinder_axis = p_transform.basis.get_axis(1).normalized();
+	Vector3 cylinder_axis = p_transform.basis.get_column(1).normalized();
 	real_t axis_dot = cylinder_axis.dot(p_normal);
 
 	Vector3 local_normal = p_transform.basis.xform_inv(p_normal);

--- a/servers/physics_3d/joints/godot_cone_twist_joint_3d.cpp
+++ b/servers/physics_3d/joints/godot_cone_twist_joint_3d.cpp
@@ -147,8 +147,8 @@ bool GodotConeTwistJoint3D::setup(real_t p_timestep) {
 	Vector3 b1Axis1, b1Axis2, b1Axis3;
 	Vector3 b2Axis1, b2Axis2;
 
-	b1Axis1 = A->get_transform().basis.xform(this->m_rbAFrame.basis.get_axis(0));
-	b2Axis1 = B->get_transform().basis.xform(this->m_rbBFrame.basis.get_axis(0));
+	b1Axis1 = A->get_transform().basis.xform(this->m_rbAFrame.basis.get_column(0));
+	b2Axis1 = B->get_transform().basis.xform(this->m_rbBFrame.basis.get_column(0));
 
 	real_t swing1 = real_t(0.), swing2 = real_t(0.);
 
@@ -158,7 +158,7 @@ bool GodotConeTwistJoint3D::setup(real_t p_timestep) {
 
 	// Get Frame into world space
 	if (m_swingSpan1 >= real_t(0.05f)) {
-		b1Axis2 = A->get_transform().basis.xform(this->m_rbAFrame.basis.get_axis(1));
+		b1Axis2 = A->get_transform().basis.xform(this->m_rbAFrame.basis.get_column(1));
 		//swing1  = btAtan2Fast( b2Axis1.dot(b1Axis2),b2Axis1.dot(b1Axis1) );
 		swx = b2Axis1.dot(b1Axis1);
 		swy = b2Axis1.dot(b1Axis2);
@@ -169,7 +169,7 @@ bool GodotConeTwistJoint3D::setup(real_t p_timestep) {
 	}
 
 	if (m_swingSpan2 >= real_t(0.05f)) {
-		b1Axis3 = A->get_transform().basis.xform(this->m_rbAFrame.basis.get_axis(2));
+		b1Axis3 = A->get_transform().basis.xform(this->m_rbAFrame.basis.get_column(2));
 		//swing2 = btAtan2Fast( b2Axis1.dot(b1Axis3),b2Axis1.dot(b1Axis1) );
 		swx = b2Axis1.dot(b1Axis1);
 		swy = b2Axis1.dot(b1Axis3);
@@ -199,7 +199,7 @@ bool GodotConeTwistJoint3D::setup(real_t p_timestep) {
 
 	// Twist limits
 	if (m_twistSpan >= real_t(0.)) {
-		Vector3 b2Axis22 = B->get_transform().basis.xform(this->m_rbBFrame.basis.get_axis(1));
+		Vector3 b2Axis22 = B->get_transform().basis.xform(this->m_rbBFrame.basis.get_column(1));
 		Quaternion rotationArc = Quaternion(b2Axis1, b1Axis1);
 		Vector3 TwistRef = rotationArc.xform(b2Axis22);
 		real_t twist = atan2fast(TwistRef.dot(b1Axis3), TwistRef.dot(b1Axis2));

--- a/servers/physics_3d/joints/godot_generic_6dof_joint_3d.cpp
+++ b/servers/physics_3d/joints/godot_generic_6dof_joint_3d.cpp
@@ -249,8 +249,8 @@ void GodotGeneric6DOFJoint3D::calculateAngleInfo() {
 	// easier to take the euler rate expression for d(angle[2])/dt with respect
 	// to the components of w and set that to 0.
 
-	Vector3 axis0 = m_calculatedTransformB.basis.get_axis(0);
-	Vector3 axis2 = m_calculatedTransformA.basis.get_axis(2);
+	Vector3 axis0 = m_calculatedTransformB.basis.get_column(0);
+	Vector3 axis2 = m_calculatedTransformA.basis.get_column(2);
 
 	m_calculatedAxis[1] = axis2.cross(axis0);
 	m_calculatedAxis[0] = m_calculatedAxis[1].cross(axis2);
@@ -345,9 +345,9 @@ bool GodotGeneric6DOFJoint3D::setup(real_t p_timestep) {
 	for (i = 0; i < 3; i++) {
 		if (m_linearLimits.enable_limit[i] && m_linearLimits.isLimited(i)) {
 			if (m_useLinearReferenceFrameA) {
-				normalWorld = m_calculatedTransformA.basis.get_axis(i);
+				normalWorld = m_calculatedTransformA.basis.get_column(i);
 			} else {
-				normalWorld = m_calculatedTransformB.basis.get_axis(i);
+				normalWorld = m_calculatedTransformB.basis.get_column(i);
 			}
 
 			buildLinearJacobian(
@@ -388,9 +388,9 @@ void GodotGeneric6DOFJoint3D::solve(real_t p_timestep) {
 			jacDiagABInv = real_t(1.) / m_jacLinear[i].getDiagonal();
 
 			if (m_useLinearReferenceFrameA) {
-				linear_axis = m_calculatedTransformA.basis.get_axis(i);
+				linear_axis = m_calculatedTransformA.basis.get_column(i);
 			} else {
-				linear_axis = m_calculatedTransformB.basis.get_axis(i);
+				linear_axis = m_calculatedTransformB.basis.get_column(i);
 			}
 
 			m_linearLimits.solveLinearAxis(

--- a/servers/physics_3d/joints/godot_hinge_joint_3d.cpp
+++ b/servers/physics_3d/joints/godot_hinge_joint_3d.cpp
@@ -92,16 +92,16 @@ GodotHingeJoint3D::GodotHingeJoint3D(GodotBody3D *rbA, GodotBody3D *rbB, const V
 	m_rbAFrame.origin = pivotInA;
 
 	// since no frame is given, assume this to be zero angle and just pick rb transform axis
-	Vector3 rbAxisA1 = rbA->get_transform().basis.get_axis(0);
+	Vector3 rbAxisA1 = rbA->get_transform().basis.get_column(0);
 
 	Vector3 rbAxisA2;
 	real_t projection = axisInA.dot(rbAxisA1);
 	if (projection >= 1.0f - CMP_EPSILON) {
-		rbAxisA1 = -rbA->get_transform().basis.get_axis(2);
-		rbAxisA2 = rbA->get_transform().basis.get_axis(1);
+		rbAxisA1 = -rbA->get_transform().basis.get_column(2);
+		rbAxisA2 = rbA->get_transform().basis.get_column(1);
 	} else if (projection <= -1.0f + CMP_EPSILON) {
-		rbAxisA1 = rbA->get_transform().basis.get_axis(2);
-		rbAxisA2 = rbA->get_transform().basis.get_axis(1);
+		rbAxisA1 = rbA->get_transform().basis.get_column(2);
+		rbAxisA2 = rbA->get_transform().basis.get_column(1);
 	} else {
 		rbAxisA2 = axisInA.cross(rbAxisA1);
 		rbAxisA1 = rbAxisA2.cross(axisInA);
@@ -171,11 +171,11 @@ bool GodotHingeJoint3D::setup(real_t p_step) {
 	Vector3 jointAxis0local;
 	Vector3 jointAxis1local;
 
-	plane_space(m_rbAFrame.basis.get_axis(2), jointAxis0local, jointAxis1local);
+	plane_space(m_rbAFrame.basis.get_column(2), jointAxis0local, jointAxis1local);
 
 	Vector3 jointAxis0 = A->get_transform().basis.xform(jointAxis0local);
 	Vector3 jointAxis1 = A->get_transform().basis.xform(jointAxis1local);
-	Vector3 hingeAxisWorld = A->get_transform().basis.xform(m_rbAFrame.basis.get_axis(2));
+	Vector3 hingeAxisWorld = A->get_transform().basis.xform(m_rbAFrame.basis.get_column(2));
 
 	memnew_placement(
 			&m_jacAng[0],
@@ -226,7 +226,7 @@ bool GodotHingeJoint3D::setup(real_t p_step) {
 	}
 
 	//Compute K = J*W*J' for hinge axis
-	Vector3 axisA = A->get_transform().basis.xform(m_rbAFrame.basis.get_axis(2));
+	Vector3 axisA = A->get_transform().basis.xform(m_rbAFrame.basis.get_column(2));
 	m_kHinge = 1.0f / (A->compute_angular_impulse_denominator(axisA) + B->compute_angular_impulse_denominator(axisA));
 
 	return true;
@@ -271,8 +271,8 @@ void GodotHingeJoint3D::solve(real_t p_step) {
 		///solve angular part
 
 		// get axes in world space
-		Vector3 axisA = A->get_transform().basis.xform(m_rbAFrame.basis.get_axis(2));
-		Vector3 axisB = B->get_transform().basis.xform(m_rbBFrame.basis.get_axis(2));
+		Vector3 axisA = A->get_transform().basis.xform(m_rbAFrame.basis.get_column(2));
+		Vector3 axisB = B->get_transform().basis.xform(m_rbBFrame.basis.get_column(2));
 
 		const Vector3 &angVelA = A->get_angular_velocity();
 		const Vector3 &angVelB = B->get_angular_velocity();
@@ -384,9 +384,9 @@ static _FORCE_INLINE_ real_t atan2fast(real_t y, real_t x) {
 }
 
 real_t GodotHingeJoint3D::get_hinge_angle() {
-	const Vector3 refAxis0 = A->get_transform().basis.xform(m_rbAFrame.basis.get_axis(0));
-	const Vector3 refAxis1 = A->get_transform().basis.xform(m_rbAFrame.basis.get_axis(1));
-	const Vector3 swingAxis = B->get_transform().basis.xform(m_rbBFrame.basis.get_axis(1));
+	const Vector3 refAxis0 = A->get_transform().basis.xform(m_rbAFrame.basis.get_column(0));
+	const Vector3 refAxis1 = A->get_transform().basis.xform(m_rbAFrame.basis.get_column(1));
+	const Vector3 swingAxis = B->get_transform().basis.xform(m_rbBFrame.basis.get_column(1));
 
 	return atan2fast(swingAxis.dot(refAxis0), swingAxis.dot(refAxis1));
 }

--- a/servers/physics_3d/joints/godot_slider_joint_3d.cpp
+++ b/servers/physics_3d/joints/godot_slider_joint_3d.cpp
@@ -102,7 +102,7 @@ bool GodotSliderJoint3D::setup(real_t p_step) {
 	m_calculatedTransformB = B->get_transform() * m_frameInB;
 	m_realPivotAInW = m_calculatedTransformA.origin;
 	m_realPivotBInW = m_calculatedTransformB.origin;
-	m_sliderAxis = m_calculatedTransformA.basis.get_axis(0); // along X
+	m_sliderAxis = m_calculatedTransformA.basis.get_column(0); // along X
 	m_delta = m_realPivotBInW - m_realPivotAInW;
 	m_projPivotInW = m_realPivotAInW + m_sliderAxis.dot(m_delta) * m_sliderAxis;
 	m_relPosA = m_projPivotInW - A->get_transform().origin;
@@ -111,7 +111,7 @@ bool GodotSliderJoint3D::setup(real_t p_step) {
 	int i;
 	//linear part
 	for (i = 0; i < 3; i++) {
-		normalWorld = m_calculatedTransformA.basis.get_axis(i);
+		normalWorld = m_calculatedTransformA.basis.get_column(i);
 		memnew_placement(
 				&m_jacLin[i],
 				GodotJacobianEntry3D(
@@ -130,7 +130,7 @@ bool GodotSliderJoint3D::setup(real_t p_step) {
 	testLinLimits();
 	// angular part
 	for (i = 0; i < 3; i++) {
-		normalWorld = m_calculatedTransformA.basis.get_axis(i);
+		normalWorld = m_calculatedTransformA.basis.get_column(i);
 		memnew_placement(
 				&m_jacAng[i],
 				GodotJacobianEntry3D(
@@ -141,7 +141,7 @@ bool GodotSliderJoint3D::setup(real_t p_step) {
 						B->get_inv_inertia()));
 	}
 	testAngLimits();
-	Vector3 axisA = m_calculatedTransformA.basis.get_axis(0);
+	Vector3 axisA = m_calculatedTransformA.basis.get_column(0);
 	m_kAngle = real_t(1.0) / (A->compute_angular_impulse_denominator(axisA) + B->compute_angular_impulse_denominator(axisA));
 	// clear accumulator for motors
 	m_accumulatedLinMotorImpulse = real_t(0.0);
@@ -206,8 +206,8 @@ void GodotSliderJoint3D::solve(real_t p_step) {
 	}
 	// angular
 	// get axes in world space
-	Vector3 axisA = m_calculatedTransformA.basis.get_axis(0);
-	Vector3 axisB = m_calculatedTransformB.basis.get_axis(0);
+	Vector3 axisA = m_calculatedTransformA.basis.get_column(0);
+	Vector3 axisB = m_calculatedTransformB.basis.get_column(0);
 
 	const Vector3 &angVelA = A->get_angular_velocity();
 	const Vector3 &angVelB = B->get_angular_velocity();
@@ -297,14 +297,14 @@ void GodotSliderJoint3D::calculateTransforms() {
 	m_calculatedTransformB = B->get_transform() * m_frameInB;
 	m_realPivotAInW = m_calculatedTransformA.origin;
 	m_realPivotBInW = m_calculatedTransformB.origin;
-	m_sliderAxis = m_calculatedTransformA.basis.get_axis(0); // along X
+	m_sliderAxis = m_calculatedTransformA.basis.get_column(0); // along X
 	m_delta = m_realPivotBInW - m_realPivotAInW;
 	m_projPivotInW = m_realPivotAInW + m_sliderAxis.dot(m_delta) * m_sliderAxis;
 	Vector3 normalWorld;
 	int i;
 	//linear part
 	for (i = 0; i < 3; i++) {
-		normalWorld = m_calculatedTransformA.basis.get_axis(i);
+		normalWorld = m_calculatedTransformA.basis.get_column(i);
 		m_depth[i] = m_delta.dot(normalWorld);
 	}
 }
@@ -335,9 +335,9 @@ void GodotSliderJoint3D::testAngLimits() {
 	m_angDepth = real_t(0.);
 	m_solveAngLim = false;
 	if (m_lowerAngLimit <= m_upperAngLimit) {
-		const Vector3 axisA0 = m_calculatedTransformA.basis.get_axis(1);
-		const Vector3 axisA1 = m_calculatedTransformA.basis.get_axis(2);
-		const Vector3 axisB0 = m_calculatedTransformB.basis.get_axis(1);
+		const Vector3 axisA0 = m_calculatedTransformA.basis.get_column(1);
+		const Vector3 axisA1 = m_calculatedTransformA.basis.get_column(2);
+		const Vector3 axisB0 = m_calculatedTransformB.basis.get_column(1);
 		real_t rot = atan2fast(axisB0.dot(axisA1), axisB0.dot(axisA0));
 		if (rot < m_lowerAngLimit) {
 			m_angDepth = rot - m_lowerAngLimit;

--- a/servers/rendering/renderer_rd/cluster_builder_rd.h
+++ b/servers/rendering/renderer_rd/cluster_builder_rd.h
@@ -289,11 +289,11 @@ public:
 				e.touches_near = min_d < z_near;
 			} else {
 				//contains camera inside light
-				Plane base_plane(-xform.basis.get_axis(Vector3::AXIS_Z), xform.origin);
+				Plane base_plane(-xform.basis.get_column(Vector3::AXIS_Z), xform.origin);
 				float dist = base_plane.distance_to(Vector3());
 				if (dist >= 0 && dist < radius) {
 					//inside, check angle
-					float angle = Math::rad2deg(Math::acos((-xform.origin.normalized()).dot(-xform.basis.get_axis(Vector3::AXIS_Z))));
+					float angle = Math::rad2deg(Math::acos((-xform.origin.normalized()).dot(-xform.basis.get_column(Vector3::AXIS_Z))));
 					e.touches_near = angle < p_spot_aperture * 1.05; //overfit aperture a little due to cone overfit
 				} else {
 					e.touches_near = false;

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -977,7 +977,7 @@ void RenderForwardClustered::_fill_render_list(RenderListType p_render_list, con
 	}
 	uint32_t lightmap_captures_used = 0;
 
-	Plane near_plane = Plane(-p_render_data->cam_transform.basis.get_axis(Vector3::AXIS_Z), p_render_data->cam_transform.origin);
+	Plane near_plane = Plane(-p_render_data->cam_transform.basis.get_column(Vector3::AXIS_Z), p_render_data->cam_transform.origin);
 	near_plane.d += p_render_data->cam_projection.get_z_near();
 	float z_max = p_render_data->cam_projection.get_z_far() - p_render_data->cam_projection.get_z_near();
 
@@ -1984,9 +1984,9 @@ void RenderForwardClustered::_render_sdfgi(RID p_render_buffers, const Vector3i 
 		fb_size.y = p_size[up_axis];
 
 		render_data.cam_transform.origin = center + axis * half_extents;
-		render_data.cam_transform.basis.set_axis(0, right);
-		render_data.cam_transform.basis.set_axis(1, up);
-		render_data.cam_transform.basis.set_axis(2, axis);
+		render_data.cam_transform.basis.set_column(0, right);
+		render_data.cam_transform.basis.set_column(1, up);
+		render_data.cam_transform.basis.set_column(2, axis);
 
 		//print_line("pass: " + itos(i) + " xform " + render_data.cam_transform);
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -1341,7 +1341,7 @@ void RenderForwardMobile::_fill_render_list(RenderListType p_render_list, const 
 	}
 	uint32_t lightmap_captures_used = 0;
 
-	Plane near_plane(-p_render_data->cam_transform.basis.get_axis(Vector3::AXIS_Z), p_render_data->cam_transform.origin);
+	Plane near_plane(-p_render_data->cam_transform.basis.get_column(Vector3::AXIS_Z), p_render_data->cam_transform.origin);
 	near_plane.d += p_render_data->cam_projection.get_z_near();
 	float z_max = p_render_data->cam_projection.get_z_far() - p_render_data->cam_projection.get_z_near();
 

--- a/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_gi_rd.cpp
@@ -1469,7 +1469,7 @@ void RendererSceneGIRD::SDFGI::pre_process_gi(const Transform3D &p_transform, Re
 				continue;
 			}
 
-			Vector3 dir = -li->transform.basis.get_axis(Vector3::AXIS_Z);
+			Vector3 dir = -li->transform.basis.get_column(Vector3::AXIS_Z);
 			dir.y *= y_mult;
 			dir.normalize();
 			lights[idx].direction[0] = dir.x;
@@ -1508,7 +1508,7 @@ void RendererSceneGIRD::SDFGI::pre_process_gi(const Transform3D &p_transform, Re
 				continue;
 			}
 
-			Vector3 dir = -li->transform.basis.get_axis(Vector3::AXIS_Z);
+			Vector3 dir = -li->transform.basis.get_column(Vector3::AXIS_Z);
 			//faster to not do this here
 			//dir.y *= y_mult;
 			//dir.normalize();
@@ -1946,7 +1946,7 @@ void RendererSceneGIRD::SDFGI::render_static_lights(RID p_render_buffers, uint32
 
 				lights[idx].type = RSG::light_storage->light_get_type(li->light);
 
-				Vector3 dir = -li->transform.basis.get_axis(Vector3::AXIS_Z);
+				Vector3 dir = -li->transform.basis.get_column(Vector3::AXIS_Z);
 				if (lights[idx].type == RS::LIGHT_DIRECTIONAL) {
 					dir.y *= y_mult; //only makes sense for directional
 					dir.normalize();
@@ -2416,7 +2416,7 @@ void RendererSceneGIRD::VoxelGIInstance::update(bool p_update_light_instances, c
 				Transform3D xform = p_scene_render->light_instance_get_base_transform(light_instance);
 
 				Vector3 pos = to_probe_xform.xform(xform.origin);
-				Vector3 dir = to_probe_xform.basis.xform(-xform.basis.get_axis(2)).normalized();
+				Vector3 dir = to_probe_xform.basis.xform(-xform.basis.get_column(2)).normalized();
 
 				l.position[0] = pos.x;
 				l.position[1] = pos.y;
@@ -2593,17 +2593,17 @@ void RendererSceneGIRD::VoxelGIInstance::update(bool p_update_light_instances, c
 				Transform3D xform;
 				xform.set_look_at(center - aabb.size * 0.5 * render_dir, center, up_dir);
 
-				Vector3 x_dir = xform.basis.get_axis(0).abs();
+				Vector3 x_dir = xform.basis.get_column(0).abs();
 				int x_axis = int(Vector3(0, 1, 2).dot(x_dir));
-				Vector3 y_dir = xform.basis.get_axis(1).abs();
+				Vector3 y_dir = xform.basis.get_column(1).abs();
 				int y_axis = int(Vector3(0, 1, 2).dot(y_dir));
-				Vector3 z_dir = -xform.basis.get_axis(2);
+				Vector3 z_dir = -xform.basis.get_column(2);
 				int z_axis = int(Vector3(0, 1, 2).dot(z_dir.abs()));
 
 				Rect2i rect(aabb.position[x_axis], aabb.position[y_axis], aabb.size[x_axis], aabb.size[y_axis]);
-				bool x_flip = bool(Vector3(1, 1, 1).dot(xform.basis.get_axis(0)) < 0);
-				bool y_flip = bool(Vector3(1, 1, 1).dot(xform.basis.get_axis(1)) < 0);
-				bool z_flip = bool(Vector3(1, 1, 1).dot(xform.basis.get_axis(2)) > 0);
+				bool x_flip = bool(Vector3(1, 1, 1).dot(xform.basis.get_column(0)) < 0);
+				bool y_flip = bool(Vector3(1, 1, 1).dot(xform.basis.get_column(1)) < 0);
+				bool z_flip = bool(Vector3(1, 1, 1).dot(xform.basis.get_column(2)) > 0);
 
 				CameraMatrix cm;
 				cm.set_orthogonal(-rect.size.width / 2, rect.size.width / 2, -rect.size.height / 2, rect.size.height / 2, 0.0001, aabb.size[z_axis]);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -3280,7 +3280,7 @@ void RendererSceneRenderRD::_setup_lights(const PagedArray<RID> &p_lights, const
 	r_directional_light_count = 0;
 	r_positional_light_count = 0;
 
-	Plane camera_plane(-p_camera_transform.basis.get_axis(Vector3::AXIS_Z).normalized(), p_camera_transform.origin);
+	Plane camera_plane(-p_camera_transform.basis.get_column(Vector3::AXIS_Z).normalized(), p_camera_transform.origin);
 
 	cluster.omni_light_count = 0;
 	cluster.spot_light_count = 0;
@@ -3753,7 +3753,7 @@ void RendererSceneRenderRD::_setup_decals(const PagedArray<RID> &p_decals, const
 		Transform3D to_decal_xform = (p_camera_inverse_xform * di->transform * scale_xform * uv_xform).affine_inverse();
 		RendererStorageRD::store_transform(to_decal_xform, dd.xform);
 
-		Vector3 normal = xform.basis.get_axis(Vector3::AXIS_Y).normalized();
+		Vector3 normal = xform.basis.get_column(Vector3::AXIS_Y).normalized();
 		normal = p_camera_inverse_xform.basis.xform(normal); //camera is normalized, so fine
 
 		dd.normal[0] = normal.x;
@@ -4824,7 +4824,7 @@ void RendererSceneRenderRD::_pre_opaque_render(RenderDataRD *p_render_data, bool
 	render_state.shadows.clear();
 	render_state.directional_shadows.clear();
 
-	Plane camera_plane(-p_render_data->cam_transform.basis.get_axis(Vector3::AXIS_Z), p_render_data->cam_transform.origin);
+	Plane camera_plane(-p_render_data->cam_transform.basis.get_column(Vector3::AXIS_Z), p_render_data->cam_transform.origin);
 	float lod_distance_multiplier = p_render_data->cam_projection.get_lod_multiplier();
 	{
 		for (int i = 0; i < render_state.render_shadow_count; i++) {
@@ -5020,7 +5020,7 @@ void RendererSceneRenderRD::render_scene(RID p_render_buffers, const CameraData 
 
 		// this should be the same for all cameras..
 		render_data.lod_distance_multiplier = p_camera_data->main_projection.get_lod_multiplier();
-		render_data.lod_camera_plane = Plane(-p_camera_data->main_transform.basis.get_axis(Vector3::AXIS_Z), p_camera_data->main_transform.get_origin());
+		render_data.lod_camera_plane = Plane(-p_camera_data->main_transform.basis.get_column(Vector3::AXIS_Z), p_camera_data->main_transform.get_origin());
 
 		if (get_debug_draw_mode() == RS::VIEWPORT_DEBUG_DRAW_DISABLE_LOD) {
 			render_data.screen_mesh_lod_threshold = 0.0;
@@ -5339,7 +5339,7 @@ void RendererSceneRenderRD::render_particle_collider_heightfield(RID p_collider,
 	cam_pos.y += extents.y;
 
 	Transform3D cam_xform;
-	cam_xform.set_look_at(cam_pos, cam_pos - p_transform.basis.get_axis(Vector3::AXIS_Y), -p_transform.basis.get_axis(Vector3::AXIS_Z).normalized());
+	cam_xform.set_look_at(cam_pos, cam_pos - p_transform.basis.get_column(Vector3::AXIS_Y), -p_transform.basis.get_column(Vector3::AXIS_Z).normalized());
 
 	RID fb = particles_storage->particles_collision_get_heightfield_framebuffer(p_collider);
 

--- a/servers/rendering/renderer_scene_cull.cpp
+++ b/servers/rendering/renderer_scene_cull.cpp
@@ -2065,9 +2065,9 @@ void RendererSceneCull::_light_instance_setup_directional_shadow(int p_shadow_in
 
 		Transform3D transform = light_transform; //discard scale and stabilize light
 
-		Vector3 x_vec = transform.basis.get_axis(Vector3::AXIS_X).normalized();
-		Vector3 y_vec = transform.basis.get_axis(Vector3::AXIS_Y).normalized();
-		Vector3 z_vec = transform.basis.get_axis(Vector3::AXIS_Z).normalized();
+		Vector3 x_vec = transform.basis.get_column(Vector3::AXIS_X).normalized();
+		Vector3 y_vec = transform.basis.get_column(Vector3::AXIS_Y).normalized();
+		Vector3 z_vec = transform.basis.get_column(Vector3::AXIS_Z).normalized();
 		//z_vec points against the camera, like in default opengl
 
 		real_t x_min = 0.f, x_max = 0.f;
@@ -2721,7 +2721,7 @@ void RendererSceneCull::_scene_cull(CullData &cull_data, InstanceCullResult &cul
 							cull_data.cull->lock.lock();
 							RSG::particles_storage->particles_request_process(idata.base_rid);
 							cull_data.cull->lock.unlock();
-							RSG::particles_storage->particles_set_view_axis(idata.base_rid, -cull_data.cam_transform.basis.get_axis(2).normalized(), cull_data.cam_transform.basis.get_axis(1).normalized());
+							RSG::particles_storage->particles_set_view_axis(idata.base_rid, -cull_data.cam_transform.basis.get_column(2).normalized(), cull_data.cam_transform.basis.get_column(1).normalized());
 							//particles visible? request redraw
 							RenderingServerDefault::redraw_request();
 						}
@@ -3082,7 +3082,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 
 				Transform3D cam_xf = p_camera_data->main_transform;
 				float zn = p_camera_data->main_projection.get_z_near();
-				Plane p(-cam_xf.basis.get_axis(2), cam_xf.origin + cam_xf.basis.get_axis(2) * -zn); //camera near plane
+				Plane p(-cam_xf.basis.get_column(2), cam_xf.origin + cam_xf.basis.get_column(2) * -zn); //camera near plane
 
 				// near plane half width and height
 				Vector2 vp_half_extents = p_camera_data->main_projection.get_viewport_half_extents();
@@ -3094,7 +3094,7 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 						//get two points parallel to near plane
 						Vector3 points[2] = {
 							ins->transform.origin,
-							ins->transform.origin + cam_xf.basis.get_axis(0) * radius
+							ins->transform.origin + cam_xf.basis.get_column(0) * radius
 						};
 
 						if (!p_camera_data->is_orthogonal) {
@@ -3118,11 +3118,11 @@ void RendererSceneCull::_render_scene(const RendererSceneRender::CameraData *p_c
 						float w = radius * Math::sin(Math::deg2rad(angle));
 						float d = radius * Math::cos(Math::deg2rad(angle));
 
-						Vector3 base = ins->transform.origin - ins->transform.basis.get_axis(2).normalized() * d;
+						Vector3 base = ins->transform.origin - ins->transform.basis.get_column(2).normalized() * d;
 
 						Vector3 points[2] = {
 							base,
-							base + cam_xf.basis.get_axis(0) * w
+							base + cam_xf.basis.get_column(0) * w
 						};
 
 						if (!p_camera_data->is_orthogonal) {

--- a/servers/rendering/renderer_scene_render.cpp
+++ b/servers/rendering/renderer_scene_render.cpp
@@ -65,7 +65,7 @@ void RendererSceneRender::CameraData::set_multiview_camera(uint32_t p_view_count
 	Vector3 y = n0.cross(n1).normalized();
 	Vector3 x = y.cross(z).normalized();
 	y = z.cross(x).normalized();
-	main_transform.basis.set(x, y, z);
+	main_transform.basis.set_columns(x, y, z);
 
 	// 3. create a horizon plane with one of the eyes and the up vector as normal.
 	Plane horizon(y, p_transforms[0].origin);

--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -131,13 +131,13 @@ void XRServer::center_on_hmd(RotationMode p_rotation_mode, bool p_keep_height) {
 	// remove our tilt
 	if (p_rotation_mode == 1) {
 		// take the Y out of our Z
-		new_reference_frame.basis.set_axis(2, Vector3(new_reference_frame.basis.rows[0][2], 0.0, new_reference_frame.basis.rows[2][2]).normalized());
+		new_reference_frame.basis.set_column(2, Vector3(new_reference_frame.basis.rows[0][2], 0.0, new_reference_frame.basis.rows[2][2]).normalized());
 
 		// Y is straight up
-		new_reference_frame.basis.set_axis(1, Vector3(0.0, 1.0, 0.0));
+		new_reference_frame.basis.set_column(1, Vector3(0.0, 1.0, 0.0));
 
 		// and X is our cross reference
-		new_reference_frame.basis.set_axis(0, new_reference_frame.basis.get_axis(1).cross(new_reference_frame.basis.get_axis(2)).normalized());
+		new_reference_frame.basis.set_column(0, new_reference_frame.basis.get_column(1).cross(new_reference_frame.basis.get_column(2)).normalized());
 	} else if (p_rotation_mode == 2) {
 		// remove our rotation, we're only interesting in centering on position
 		new_reference_frame.basis = Basis();

--- a/tests/core/math/test_basis.h
+++ b/tests/core/math/test_basis.h
@@ -164,9 +164,9 @@ void test_rotation(Vector3 deg_original_euler, RotOrder rot_order) {
 
 	Basis res = to_rotation.inverse() * rotation_from_computed_euler;
 
-	CHECK_MESSAGE((res.get_axis(0) - Vector3(1.0, 0.0, 0.0)).length() <= 0.1, vformat("Fail due to X %s\n", String(res.get_axis(0))).utf8().ptr());
-	CHECK_MESSAGE((res.get_axis(1) - Vector3(0.0, 1.0, 0.0)).length() <= 0.1, vformat("Fail due to Y %s\n", String(res.get_axis(1))).utf8().ptr());
-	CHECK_MESSAGE((res.get_axis(2) - Vector3(0.0, 0.0, 1.0)).length() <= 0.1, vformat("Fail due to Z %s\n", String(res.get_axis(2))).utf8().ptr());
+	CHECK_MESSAGE((res.get_column(0) - Vector3(1.0, 0.0, 0.0)).length() <= 0.1, vformat("Fail due to X %s\n", String(res.get_column(0))).utf8().ptr());
+	CHECK_MESSAGE((res.get_column(1) - Vector3(0.0, 1.0, 0.0)).length() <= 0.1, vformat("Fail due to Y %s\n", String(res.get_column(1))).utf8().ptr());
+	CHECK_MESSAGE((res.get_column(2) - Vector3(0.0, 0.0, 1.0)).length() <= 0.1, vformat("Fail due to Z %s\n", String(res.get_column(2))).utf8().ptr());
 
 	// Double check `to_rotation` decomposing with XYZ rotation order.
 	const Vector3 euler_xyz_from_rotation = to_rotation.get_euler(Basis::EULER_ORDER_XYZ);
@@ -175,9 +175,9 @@ void test_rotation(Vector3 deg_original_euler, RotOrder rot_order) {
 
 	res = to_rotation.inverse() * rotation_from_xyz_computed_euler;
 
-	CHECK_MESSAGE((res.get_axis(0) - Vector3(1.0, 0.0, 0.0)).length() <= 0.1, vformat("Double check with XYZ rot order failed, due to X %s\n", String(res.get_axis(0))).utf8().ptr());
-	CHECK_MESSAGE((res.get_axis(1) - Vector3(0.0, 1.0, 0.0)).length() <= 0.1, vformat("Double check with XYZ rot order failed, due to Y %s\n", String(res.get_axis(1))).utf8().ptr());
-	CHECK_MESSAGE((res.get_axis(2) - Vector3(0.0, 0.0, 1.0)).length() <= 0.1, vformat("Double check with XYZ rot order failed, due to Z %s\n", String(res.get_axis(2))).utf8().ptr());
+	CHECK_MESSAGE((res.get_column(0) - Vector3(1.0, 0.0, 0.0)).length() <= 0.1, vformat("Double check with XYZ rot order failed, due to X %s\n", String(res.get_column(0))).utf8().ptr());
+	CHECK_MESSAGE((res.get_column(1) - Vector3(0.0, 1.0, 0.0)).length() <= 0.1, vformat("Double check with XYZ rot order failed, due to Y %s\n", String(res.get_column(1))).utf8().ptr());
+	CHECK_MESSAGE((res.get_column(2) - Vector3(0.0, 0.0, 1.0)).length() <= 0.1, vformat("Double check with XYZ rot order failed, due to Z %s\n", String(res.get_column(2))).utf8().ptr());
 
 	INFO(vformat("Rotation order: %s\n.", get_rot_order_name(rot_order)).utf8().ptr());
 	INFO(vformat("Original Rotation: %s\n", String(deg_original_euler)).utf8().ptr());


### PR DESCRIPTION
This is a follow-up to #60627 that was requested by @reduz when discussing it.

* Basis: Unify `get_axis` and `get_column` to `get_column` (they do the same thing)
* Basis: Unify `set_axis` and `set_column` to `set_column` (they do the same thing)
* Basis: Rename `set` to `set_columns`
* Basis: Remove `get_row` and `set_row` since it's not needed now that `elements` was renamed to `rows`
* Transform2D: Remove `get_axis` (`get_column`) since it's not needed now that `elements` was renamed to `columns`