### PR TITLE
Add regression test for gdscript valid function signature

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/features/function_match_parent_signature_with_default_dict_void.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/function_match_parent_signature_with_default_dict_void.gd
@@ -1,0 +1,14 @@
+func test():
+	var instance := Parent.new()
+	instance.my_function({"a": 1})
+	instance = Child.new()
+	instance.my_function({"a": 1})
+	print("No failure")
+
+class Parent:
+	func my_function(_par1: Dictionary = {}) -> void:
+		pass
+
+class Child extends Parent:
+	func my_function(_par1: Dictionary = {}) -> void:
+		pass

--- a/modules/gdscript/tests/scripts/analyzer/features/function_match_parent_signature_with_default_dict_void.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/function_match_parent_signature_with_default_dict_void.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+No failure


### PR DESCRIPTION
Previously, there was an issue where the gdscript analyzer incorrectly raised a validation error for code that had a default Dictionary, Array, or custom type.

Context: This is the test case that I used to confirm that https://github.com/godotengine/godot/issues/58856 no longer exists in master.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
