### PR TITLE
[HTML5] Disable zstd weak symbols, add missing JS signature.

### DIFF
--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -212,6 +212,8 @@ def configure(env):
             sys.exit(255)
         env.Append(CCFLAGS=["-s", "RELOCATABLE=1"])
         env.Append(LINKFLAGS=["-s", "RELOCATABLE=1"])
+        # Weak symbols are broken upstream: https://github.com/emscripten-core/emscripten/issues/12819
+        env.Append(CPPDEFINES=["ZSTD_HAVE_WEAK_SYMBOLS=0"])
         env.extra_suffix = ".gdnative" + env.extra_suffix
 
     # Reduce code size by generating less support code (e.g. skip NodeJS support).

--- a/platform/javascript/js/libs/library_godot_display.js
+++ b/platform/javascript/js/libs/library_godot_display.js
@@ -462,6 +462,7 @@ const GodotDisplay = {
 		GodotRuntime.setHeapValue(height, window.screen.height * scale, 'i32');
 	},
 
+	godot_js_display_window_size_get__sig: 'vii',
 	godot_js_display_window_size_get: function (p_width, p_height) {
 		GodotRuntime.setHeapValue(p_width, GodotConfig.canvas.width, 'i32');
 		GodotRuntime.setHeapValue(p_height, GodotConfig.canvas.height, 'i32');


### PR DESCRIPTION
Fixes javascript builds with emscripten `3.1.9`.

Regarding the `ZSTD_HAVE_WEAK_SYMBOLS`, this seems to be a regression in emcc/llvm, or maybe something that was only partially implemented and now results in https://github.com/emscripten-core/emscripten/issues/12819 with our gdnative build.