### PR TITLE
Disable add button when action name is invalid

### DIFF
--- a/editor/action_map_editor.h
+++ b/editor/action_map_editor.h
@@ -171,10 +171,13 @@ private:
 
 	HBoxContainer *add_hbox = nullptr;
 	LineEdit *add_edit = nullptr;
+	Button *add_button = nullptr;
 
 	void _event_config_confirmed();
 
 	void _add_action_pressed();
+	void _add_edit_text_changed(const String &p_name);
+	String _check_new_action_name(const String &p_name);
 	bool _has_action(const String &p_name) const;
 	void _add_action(const String &p_name);
 	void _action_edited();


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
More than once I've gone to hit the add button assuming it'll pull up a window where I enter in the new action name without thinking about it 😆

https://user-images.githubusercontent.com/50304111/166604538-8552622d-7730-4e4e-984e-878709ff86c6.mp4


The new behavior better mirrors what 3.x does:
![image](https://user-images.githubusercontent.com/50304111/166604481-ab19141c-1ad2-44f8-90d3-304e345ea375.png)