### PR TITLE
Add static methods for creating Image and ImageTexture

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -2284,6 +2284,21 @@ Error Image::load(const String &p_path) {
 	return ImageLoader::load_image(p_path, this);
 }
 
+Ref<Image> Image::load_from_file(const String &p_path) {
+#ifdef DEBUG_ENABLED
+	if (p_path.begins_with("res://") && ResourceLoader::exists(p_path)) {
+		WARN_PRINT("Loaded resource as image file, this will not work on export: '" + p_path + "'. Instead, import the image file as an Image resource and load it normally as a resource.");
+	}
+#endif
+	Ref<Image> image;
+	image.instantiate();
+	Error err = ImageLoader::load_image(p_path, image);
+	if (err != OK) {
+		ERR_FAIL_V_MSG(Ref<Image>(), vformat("Failed to load image. Error %d", err));
+	}
+	return image;
+}
+
 Error Image::save_png(const String &p_path) const {
 	if (save_png_func == nullptr) {
 		return ERR_UNAVAILABLE;
@@ -3183,6 +3198,7 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("is_empty"), &Image::is_empty);
 
 	ClassDB::bind_method(D_METHOD("load", "path"), &Image::load);
+	ClassDB::bind_static_method("Image", D_METHOD("load_from_file", "path"), &Image::load_from_file);
 	ClassDB::bind_method(D_METHOD("save_png", "path"), &Image::save_png);
 	ClassDB::bind_method(D_METHOD("save_png_to_buffer"), &Image::save_png_to_buffer);
 	ClassDB::bind_method(D_METHOD("save_jpg", "path", "quality"), &Image::save_jpg, DEFVAL(0.75));

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -290,6 +290,7 @@ public:
 	Vector<uint8_t> get_data() const;
 
 	Error load(const String &p_path);
+	static Ref<Image> load_from_file(const String &p_path);
 	Error save_png(const String &p_path) const;
 	Error save_jpg(const String &p_path, float p_quality = 0.75) const;
 	Vector<uint8_t> save_png_to_buffer() const;

--- a/doc/classes/HTTPRequest.xml
+++ b/doc/classes/HTTPRequest.xml
@@ -106,8 +106,7 @@
 		    if error != OK:
 		        push_error("Couldn't load the image.")
 
-		    var texture = ImageTexture.new()
-		    texture.create_from_image(image)
+		    var texture = ImageTexture.create_from_image(image)
 
 		    # Display the image in a TextureRect node.
 		    var texture_rect = TextureRect.new()

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -308,6 +308,13 @@
 				[b]Note:[/b] Godot's BMP module doesn't support 16-bit per pixel images. Only 1-bit, 4-bit, 8-bit, 24-bit, and 32-bit per pixel images are supported.
 			</description>
 		</method>
+		<method name="load_from_file" qualifiers="static">
+			<return type="Image" />
+			<argument index="0" name="path" type="String" />
+			<description>
+				Creates a new [Image] and loads data from the specified file.
+			</description>
+		</method>
 		<method name="load_jpg_from_buffer">
 			<return type="int" enum="Error" />
 			<argument index="0" name="buffer" type="PackedByteArray" />

--- a/doc/classes/ImageTexture.xml
+++ b/doc/classes/ImageTexture.xml
@@ -6,10 +6,8 @@
 	<description>
 		A [Texture2D] based on an [Image]. For an image to be displayed, an [ImageTexture] has to be created from it using the [method create_from_image] method:
 		[codeblock]
-		var texture = ImageTexture.new()
-		var image = Image.new()
-		image.load("res://icon.png")
-		texture.create_from_image(image)
+		var image = Image.load_from_file("res://icon.png")
+		var texture = ImageTexture.create_from_image(image)
 		$Sprite2D.texture = texture
 		[/codeblock]
 		This way, textures can be created at run-time by loading images both from within the editor and externally.
@@ -31,11 +29,11 @@
 		<link title="Importing images">$DOCS_URL/tutorials/assets_pipeline/importing_images.html</link>
 	</tutorials>
 	<methods>
-		<method name="create_from_image">
-			<return type="void" />
+		<method name="create_from_image" qualifiers="static">
+			<return type="ImageTexture" />
 			<argument index="0" name="image" type="Image" />
 			<description>
-				Initializes the texture by allocating and setting the data from an [Image].
+				Creates a new [ImageTexture] and initializes it by allocating and setting the data from an [Image].
 			</description>
 		</method>
 		<method name="get_format" qualifiers="const">

--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -312,7 +312,7 @@ void EditorProfiler::_update_plot() {
 		if (graph_texture.is_null()) {
 			graph_texture.instantiate();
 		}
-		graph_texture->create_from_image(img);
+		graph_texture->set_image(img);
 	}
 
 	graph_texture->update(img);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -306,7 +306,7 @@ void EditorVisualProfiler::_update_plot() {
 		if (graph_texture.is_null()) {
 			graph_texture.instantiate();
 		}
-		graph_texture->create_from_image(img);
+		graph_texture->set_image(img);
 	}
 
 	graph_texture->update(img);

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -4046,10 +4046,8 @@ Ref<ImageTexture> EditorNode::_load_custom_class_icon(const String &p_path) cons
 		Ref<Image> img = memnew(Image);
 		Error err = ImageLoader::load_image(p_path, img);
 		if (err == OK) {
-			Ref<ImageTexture> icon = memnew(ImageTexture);
 			img->resize(16 * EDSCALE, 16 * EDSCALE, Image::INTERPOLATE_LANCZOS);
-			icon->create_from_image(img);
-			return icon;
+			return ImageTexture::create_from_image(img);
 		}
 	}
 	return nullptr;
@@ -5404,9 +5402,7 @@ Variant EditorNode::drag_resource(const Ref<Resource> &p_res, Control *p_from) {
 		Ref<Image> img = texture->get_image();
 		img = img->duplicate();
 		img->resize(48, 48); // meh
-		Ref<ImageTexture> resized_pic = Ref<ImageTexture>(memnew(ImageTexture));
-		resized_pic->create_from_image(img);
-		preview = resized_pic;
+		preview = ImageTexture::create_from_image(img);
 	}
 
 	drag_preview->set_texture(preview);

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -133,8 +133,7 @@ Vector<Ref<Texture2D>> EditorInterface::make_mesh_previews(const Vector<Ref<Mesh
 		Main::iteration();
 		Ref<Image> img = RS::get_singleton()->texture_2d_get(viewport_texture);
 		ERR_CONTINUE(!img.is_valid() || img->is_empty());
-		Ref<ImageTexture> it(memnew(ImageTexture));
-		it->create_from_image(img);
+		Ref<ImageTexture> it = ImageTexture::create_from_image(img);
 
 		RS::get_singleton()->free(inst);
 

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -678,7 +678,7 @@ void EditorResourcePicker::drop_data_fw(const Point2 &p_point, const Variant &p_
 					if (!texture.is_valid()) {
 						texture.instantiate();
 					}
-					texture->create_from_image(dropped_resource);
+					texture->set_image(dropped_resource);
 					dropped_resource = texture;
 					break;
 				}

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -184,7 +184,7 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 			small_image = small_image->duplicate();
 			small_image->resize(small_thumbnail_size, small_thumbnail_size, Image::INTERPOLATE_CUBIC);
 			r_small_texture.instantiate();
-			r_small_texture->create_from_image(small_image);
+			r_small_texture->set_image(small_image);
 		}
 
 		break;
@@ -300,14 +300,14 @@ void EditorResourcePreview::_iterate() {
 							cache_valid = false;
 						} else {
 							texture.instantiate();
-							texture->create_from_image(img);
+							texture->set_image(img);
 
 							if (has_small_texture) {
 								if (small_img->load(cache_base + "_small.png") != OK) {
 									cache_valid = false;
 								} else {
 									small_texture.instantiate();
-									small_texture->create_from_image(small_img);
+									small_texture->set_image(small_img);
 								}
 							}
 						}

--- a/editor/editor_run_native.cpp
+++ b/editor/editor_run_native.cpp
@@ -49,9 +49,7 @@ void EditorRunNative::_notification(int p_what) {
 					im->clear_mipmaps();
 					if (!im->is_empty()) {
 						im->resize(16 * EDSCALE, 16 * EDSCALE);
-						Ref<ImageTexture> small_icon;
-						small_icon.instantiate();
-						small_icon->create_from_image(im);
+						Ref<ImageTexture> small_icon = ImageTexture::create_from_image(im);
 						MenuButton *mb = memnew(MenuButton);
 						mb->get_popup()->connect("id_pressed", callable_mp(this, &EditorRunNative::run_native), varray(i));
 						mb->connect("pressed", callable_mp(this, &EditorRunNative::run_native), varray(-1, i));

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -97,7 +97,6 @@ static Ref<Texture2D> flip_icon(Ref<Texture2D> p_texture, bool p_flip_y = false,
 		return p_texture;
 	}
 
-	Ref<ImageTexture> texture(memnew(ImageTexture));
 	Ref<Image> img = p_texture->get_image();
 	ERR_FAIL_NULL_V(img, Ref<Texture2D>());
 	img = img->duplicate();
@@ -109,14 +108,12 @@ static Ref<Texture2D> flip_icon(Ref<Texture2D> p_texture, bool p_flip_y = false,
 		img->flip_x();
 	}
 
-	texture->create_from_image(img);
-	return texture;
+	return ImageTexture::create_from_image(img);
 }
 
 #ifdef MODULE_SVG_ENABLED
 // See also `generate_icon()` in `scene/resources/default_theme.cpp`.
 static Ref<ImageTexture> editor_generate_icon(int p_index, bool p_convert_color, float p_scale = EDSCALE, float p_saturation = 1.0, Dictionary p_convert_colors = Dictionary()) {
-	Ref<ImageTexture> icon = memnew(ImageTexture);
 	Ref<Image> img = memnew(Image);
 
 	// Upsample icon generation only if the editor scale isn't an integer multiplier.
@@ -129,9 +126,9 @@ static Ref<ImageTexture> editor_generate_icon(int p_index, bool p_convert_color,
 	if (p_saturation != 1.0) {
 		img->adjust_bcs(1.0, 1.0, p_saturation);
 	}
-	icon->create_from_image(img); // in this case filter really helps
 
-	return icon;
+	// In this case filter really helps.
+	return ImageTexture::create_from_image(img);
 }
 #endif
 

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -88,13 +88,7 @@ Error ResourceImporterTextureAtlas::import(const String &p_source_file, const St
 	//use an xpm because it's size independent, the editor images are vector and size dependent
 	//it's a simple hack
 	Ref<Image> broken = memnew(Image((const char **)atlas_import_failed_xpm));
-	Ref<ImageTexture> broken_texture;
-	broken_texture.instantiate();
-	broken_texture->create_from_image(broken);
-
-	String target_file = p_save_path + ".tex";
-
-	ResourceSaver::save(target_file, broken_texture);
+	ResourceSaver::save(p_save_path + ".tex", ImageTexture::create_from_image(broken));
 
 	return OK;
 }
@@ -308,9 +302,7 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 	Ref<Texture2D> cache;
 	cache = ResourceCache::get_ref(p_group_file);
 	if (!cache.is_valid()) {
-		Ref<ImageTexture> res_cache;
-		res_cache.instantiate();
-		res_cache->create_from_image(new_atlas);
+		Ref<ImageTexture> res_cache = ImageTexture::create_from_image(new_atlas);
 		res_cache->set_path(p_group_file);
 		cache = res_cache;
 	}

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -135,7 +135,7 @@ void AnimationPlayerEditor::_notification(int p_what) {
 				autoplay_reset_img->blit_rect(autoplay_img, Rect2(Point2(), icon_size), Point2());
 				autoplay_reset_img->blit_rect(reset_img, Rect2(Point2(), icon_size), Point2(icon_size.x, 0));
 				autoplay_reset_icon.instantiate();
-				autoplay_reset_icon->create_from_image(autoplay_reset_img);
+				autoplay_reset_icon->set_image(autoplay_reset_img);
 			}
 			stop->set_icon(get_theme_icon(SNAME("Stop"), SNAME("EditorIcons")));
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -165,14 +165,9 @@ void EditorAssetLibraryItemDescription::set_image(int p_type, int p_index, const
 
 						// Overlay and thumbnail need the same format for `blend_rect` to work.
 						thumbnail->convert(Image::FORMAT_RGBA8);
-
 						thumbnail->blend_rect(overlay, overlay->get_used_rect(), overlay_pos);
+						preview_images[i].button->set_icon(ImageTexture::create_from_image(thumbnail));
 
-						Ref<ImageTexture> tex;
-						tex.instantiate();
-						tex->create_from_image(thumbnail);
-
-						preview_images[i].button->set_icon(tex);
 						// Make it clearer that clicking it will open an external link
 						preview_images[i].button->set_default_cursor_shape(Control::CURSOR_POINTING_HAND);
 					} else {
@@ -790,9 +785,7 @@ void EditorAssetLibrary::_image_update(bool use_cache, bool final, const PackedB
 				} break;
 			}
 
-			Ref<ImageTexture> tex;
-			tex.instantiate();
-			tex->create_from_image(image);
+			Ref<ImageTexture> tex = ImageTexture::create_from_image(image);
 
 			obj->call("set_image", image_queue[p_queue_id].image_type, image_queue[p_queue_id].image_index, tex);
 			image_set = true;

--- a/editor/plugins/bit_map_editor_plugin.cpp
+++ b/editor/plugins/bit_map_editor_plugin.cpp
@@ -33,11 +33,7 @@
 #include "editor/editor_scale.h"
 
 void BitMapEditor::setup(const Ref<BitMap> &p_bitmap) {
-	Ref<ImageTexture> texture;
-	texture.instantiate();
-	texture->create_from_image(p_bitmap->convert_to_image());
-	texture_rect->set_texture(texture);
-
+	texture_rect->set_texture(ImageTexture::create_from_image(p_bitmap->convert_to_image()));
 	size_label->set_text(vformat(String::utf8("%s×%s"), p_bitmap->get_size().width, p_bitmap->get_size().height));
 }
 

--- a/editor/plugins/curve_editor_plugin.cpp
+++ b/editor/plugins/curve_editor_plugin.cpp
@@ -841,9 +841,5 @@ Ref<Texture2D> CurvePreviewGenerator::generate(const Ref<Resource> &p_from, cons
 
 		prev_y = y;
 	}
-
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
-
-	ptex->create_from_image(img_ref);
-	return ptex;
+	return ImageTexture::create_from_image(img_ref);
 }

--- a/editor/plugins/editor_preview_plugins.cpp
+++ b/editor/plugins/editor_preview_plugins.cpp
@@ -127,13 +127,9 @@ Ref<Texture2D> EditorTexturePreviewPlugin::generate(const Ref<Resource> &p_from,
 	}
 	Vector2i new_size_i(MAX(1, (int)new_size.x), MAX(1, (int)new_size.y));
 	img->resize(new_size_i.x, new_size_i.y, Image::INTERPOLATE_CUBIC);
-
 	post_process_preview(img);
 
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
-
-	ptex->create_from_image(img);
-	return ptex;
+	return ImageTexture::create_from_image(img);
 }
 
 EditorTexturePreviewPlugin::EditorTexturePreviewPlugin() {
@@ -171,14 +167,9 @@ Ref<Texture2D> EditorImagePreviewPlugin::generate(const Ref<Resource> &p_from, c
 		new_size = Vector2(new_size.x * p_size.y / new_size.y, p_size.y);
 	}
 	img->resize(new_size.x, new_size.y, Image::INTERPOLATE_CUBIC);
-
 	post_process_preview(img);
 
-	Ref<ImageTexture> ptex;
-	ptex.instantiate();
-
-	ptex->create_from_image(img);
-	return ptex;
+	return ImageTexture::create_from_image(img);
 }
 
 EditorImagePreviewPlugin::EditorImagePreviewPlugin() {
@@ -239,13 +230,9 @@ Ref<Texture2D> EditorBitmapPreviewPlugin::generate(const Ref<Resource> &p_from, 
 		new_size = Vector2(new_size.x * p_size.y / new_size.y, p_size.y);
 	}
 	img->resize(new_size.x, new_size.y, Image::INTERPOLATE_CUBIC);
-
 	post_process_preview(img);
 
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
-
-	ptex->create_from_image(img);
-	return ptex;
+	return ImageTexture::create_from_image(img);
 }
 
 bool EditorBitmapPreviewPlugin::generate_small_preview_automatically() const {
@@ -282,11 +269,8 @@ Ref<Texture2D> EditorPackedScenePreviewPlugin::generate_from_path(const String &
 	img.instantiate();
 	Error err = img->load(path);
 	if (err == OK) {
-		Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
-
 		post_process_preview(img);
-		ptex->create_from_image(img);
-		return ptex;
+		return ImageTexture::create_from_image(img);
 
 	} else {
 		return Ref<Texture2D>();
@@ -336,9 +320,7 @@ Ref<Texture2D> EditorMaterialPreviewPlugin::generate(const Ref<Resource> &p_from
 		int thumbnail_size = MAX(p_size.x, p_size.y);
 		img->resize(thumbnail_size, thumbnail_size, Image::INTERPOLATE_CUBIC);
 		post_process_preview(img);
-		Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
-		ptex->create_from_image(img);
-		return ptex;
+		return ImageTexture::create_from_image(img);
 	}
 
 	return Ref<Texture2D>();
@@ -591,13 +573,8 @@ Ref<Texture2D> EditorScriptPreviewPlugin::generate(const Ref<Resource> &p_from, 
 			}
 		}
 	}
-
 	post_process_preview(img);
-
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
-
-	ptex->create_from_image(img);
-	return ptex;
+	return ImageTexture::create_from_image(img);
 }
 
 EditorScriptPreviewPlugin::EditorScriptPreviewPlugin() {
@@ -676,12 +653,10 @@ Ref<Texture2D> EditorAudioStreamPreviewPlugin::generate(const Ref<Resource> &p_f
 
 	//post_process_preview(img);
 
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
 	Ref<Image> image;
 	image.instantiate();
 	image->create(w, h, false, Image::FORMAT_RGB8, img);
-	ptex->create_from_image(image);
-	return ptex;
+	return ImageTexture::create_from_image(image);
 }
 
 EditorAudioStreamPreviewPlugin::EditorAudioStreamPreviewPlugin() {
@@ -746,12 +721,9 @@ Ref<Texture2D> EditorMeshPreviewPlugin::generate(const Ref<Resource> &p_from, co
 		new_size = Vector2(new_size.x * p_size.y / new_size.y, p_size.y);
 	}
 	img->resize(new_size.x, new_size.y, Image::INTERPOLATE_CUBIC);
-
 	post_process_preview(img);
 
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
-	ptex->create_from_image(img);
-	return ptex;
+	return ImageTexture::create_from_image(img);
 }
 
 EditorMeshPreviewPlugin::EditorMeshPreviewPlugin() {
@@ -859,13 +831,9 @@ Ref<Texture2D> EditorFontPreviewPlugin::generate_from_path(const String &p_path,
 		new_size = Vector2(new_size.x * p_size.y / new_size.y, p_size.y);
 	}
 	img->resize(new_size.x, new_size.y, Image::INTERPOLATE_CUBIC);
-
 	post_process_preview(img);
 
-	Ref<ImageTexture> ptex = Ref<ImageTexture>(memnew(ImageTexture));
-	ptex->create_from_image(img);
-
-	return ptex;
+	return ImageTexture::create_from_image(img);
 }
 
 Ref<Texture2D> EditorFontPreviewPlugin::generate(const Ref<Resource> &p_from, const Size2 &p_size) const {
@@ -915,11 +883,7 @@ Ref<Texture2D> EditorGradientPreviewPlugin::generate(const Ref<Resource> &p_from
 		ptex.instantiate();
 		ptex->set_width(p_size.width * GRADIENT_PREVIEW_TEXTURE_SCALE_FACTOR * EDSCALE);
 		ptex->set_gradient(gradient);
-
-		Ref<ImageTexture> itex;
-		itex.instantiate();
-		itex->create_from_image(ptex->get_image());
-		return itex;
+		return ImageTexture::create_from_image(ptex->get_image());
 	}
 	return Ref<Texture2D>();
 }

--- a/editor/plugins/gpu_particles_2d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_2d_editor_plugin.cpp
@@ -299,12 +299,7 @@ void GPUParticles2DEditorPlugin::_generate_emission_mask() {
 
 	img.instantiate();
 	img->create(w, h, false, Image::FORMAT_RGF, texdata);
-
-	Ref<ImageTexture> imgt;
-	imgt.instantiate();
-	imgt->create_from_image(img);
-
-	pm->set_emission_point_texture(imgt);
+	pm->set_emission_point_texture(ImageTexture::create_from_image(img));
 	pm->set_emission_point_count(vpc);
 
 	if (capture_colors) {
@@ -320,10 +315,7 @@ void GPUParticles2DEditorPlugin::_generate_emission_mask() {
 
 		img.instantiate();
 		img->create(w, h, false, Image::FORMAT_RGBA8, colordata);
-
-		imgt.instantiate();
-		imgt->create_from_image(img);
-		pm->set_emission_color_texture(imgt);
+		pm->set_emission_color_texture(ImageTexture::create_from_image(img));
 	}
 
 	if (valid_normals.size()) {
@@ -343,10 +335,7 @@ void GPUParticles2DEditorPlugin::_generate_emission_mask() {
 
 		img.instantiate();
 		img->create(w, h, false, Image::FORMAT_RGF, normdata);
-
-		imgt.instantiate();
-		imgt->create_from_image(img);
-		pm->set_emission_normal_texture(imgt);
+		pm->set_emission_normal_texture(ImageTexture::create_from_image(img));
 
 	} else {
 		pm->set_emission_shape(ParticlesMaterial::EMISSION_SHAPE_POINTS);

--- a/editor/plugins/gpu_particles_3d_editor_plugin.cpp
+++ b/editor/plugins/gpu_particles_3d_editor_plugin.cpp
@@ -363,10 +363,7 @@ void GPUParticles3DEditor::_generate_emission_points() {
 	}
 
 	Ref<Image> image = memnew(Image(w, h, false, Image::FORMAT_RGBF, point_img));
-
-	Ref<ImageTexture> tex;
-	tex.instantiate();
-	tex->create_from_image(image);
+	Ref<ImageTexture> tex = ImageTexture::create_from_image(image);
 
 	Ref<ParticlesMaterial> material = node->get_process_material();
 	ERR_FAIL_COND(material.is_null());
@@ -392,12 +389,7 @@ void GPUParticles3DEditor::_generate_emission_points() {
 		}
 
 		Ref<Image> image2 = memnew(Image(w, h, false, Image::FORMAT_RGBF, point_img2));
-
-		Ref<ImageTexture> tex2;
-		tex2.instantiate();
-		tex2->create_from_image(image2);
-
-		material->set_emission_normal_texture(tex2);
+		material->set_emission_normal_texture(ImageTexture::create_from_image(image2));
 	} else {
 		material->set_emission_shape(ParticlesMaterial::EMISSION_SHAPE_POINTS);
 		material->set_emission_point_count(point_count);

--- a/editor/plugins/tiles/atlas_merging_dialog.cpp
+++ b/editor/plugins/tiles/atlas_merging_dialog.cpp
@@ -116,12 +116,8 @@ void AtlasMergingDialog::_generate_merged(Vector<Ref<TileSetAtlasSource>> p_atla
 			}
 		}
 
-		Ref<ImageTexture> output_image_texture;
-		output_image_texture.instantiate();
-		output_image_texture->create_from_image(output_image);
-
 		merged->set_name(p_atlas_sources[0]->get_name());
-		merged->set_texture(output_image_texture);
+		merged->set_texture(ImageTexture::create_from_image(output_image));
 		merged->set_texture_region_size(new_texture_region_size);
 	}
 }

--- a/editor/plugins/tiles/tiles_editor_plugin.cpp
+++ b/editor/plugins/tiles/tiles_editor_plugin.cpp
@@ -121,12 +121,9 @@ void TilesEditorPlugin::_thread() {
 				pattern_preview_done.wait();
 
 				Ref<Image> image = viewport->get_texture()->get_image();
-				Ref<ImageTexture> image_texture;
-				image_texture.instantiate();
-				image_texture->create_from_image(image);
 
 				// Find the index for the given pattern. TODO: optimize.
-				Variant args[] = { item.pattern, image_texture };
+				Variant args[] = { item.pattern, ImageTexture::create_from_image(image) };
 				const Variant *args_ptr[] = { &args[0], &args[1] };
 				Variant r;
 				Callable::CallError error;

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1167,9 +1167,7 @@ void ProjectList::load_project_icon(int p_index) {
 		Error err = img->load(item.icon.replace_first("res://", item.path + "/"));
 		if (err == OK) {
 			img->resize(default_icon->get_width(), default_icon->get_height(), Image::INTERPOLATE_LANCZOS);
-			Ref<ImageTexture> it = memnew(ImageTexture);
-			it->create_from_image(img);
-			icon = it;
+			icon = ImageTexture::create_from_image(img);
 		}
 	}
 	if (icon.is_null()) {

--- a/modules/dds/texture_loader_dds.cpp
+++ b/modules/dds/texture_loader_dds.cpp
@@ -409,9 +409,7 @@ Ref<Resource> ResourceFormatDDS::load(const String &p_path, const String &p_orig
 	}
 
 	Ref<Image> img = memnew(Image(width, height, mipmaps - 1, info.format, src_data));
-
-	Ref<ImageTexture> texture = memnew(ImageTexture);
-	texture->create_from_image(img);
+	Ref<ImageTexture> texture = ImageTexture::create_from_image(img);
 
 	if (r_error) {
 		*r_error = OK;

--- a/modules/gltf/gltf_document.cpp
+++ b/modules/gltf/gltf_document.cpp
@@ -3202,12 +3202,7 @@ Error GLTFDocument::_parse_images(Ref<GLTFState> state, const String &p_base_pat
 			state->images.push_back(Ref<Texture2D>());
 			continue;
 		}
-
-		Ref<ImageTexture> t;
-		t.instantiate();
-		t->create_from_image(img);
-
-		state->images.push_back(t);
+		state->images.push_back(ImageTexture::create_from_image(img));
 	}
 
 	print_verbose("glTF: Total images: " + itos(state->images.size()));
@@ -3428,7 +3423,7 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> state) {
 					}
 				}
 				orm_image->generate_mipmaps();
-				orm_texture->create_from_image(orm_image);
+				orm_texture->set_image(orm_image);
 				GLTFTextureIndex orm_texture_index = -1;
 				if (has_ao || has_roughness || has_metalness) {
 					orm_texture->set_name(material->get_name() + "_orm");
@@ -3476,7 +3471,7 @@ Error GLTFDocument::_serialize_materials(Ref<GLTFState> state) {
 								img->set_pixel(x, y, c);
 							}
 						}
-						tex->create_from_image(img);
+						tex->set_image(img);
 					}
 				}
 			}
@@ -3784,13 +3779,8 @@ void GLTFDocument::spec_gloss_to_rough_metal(Ref<GLTFSpecGloss> r_spec_gloss, Re
 	}
 	rm_img->generate_mipmaps();
 	r_spec_gloss->diffuse_img->generate_mipmaps();
-	Ref<ImageTexture> diffuse_image_texture;
-	diffuse_image_texture.instantiate();
-	diffuse_image_texture->create_from_image(r_spec_gloss->diffuse_img);
-	p_material->set_texture(BaseMaterial3D::TEXTURE_ALBEDO, diffuse_image_texture);
-	Ref<ImageTexture> rm_image_texture;
-	rm_image_texture.instantiate();
-	rm_image_texture->create_from_image(rm_img);
+	p_material->set_texture(BaseMaterial3D::TEXTURE_ALBEDO, ImageTexture::create_from_image(r_spec_gloss->diffuse_img));
+	Ref<ImageTexture> rm_image_texture = ImageTexture::create_from_image(rm_img);
 	if (has_roughness) {
 		p_material->set_texture(BaseMaterial3D::TEXTURE_ROUGHNESS, rm_image_texture);
 		p_material->set_roughness_texture_channel(BaseMaterial3D::TEXTURE_CHANNEL_GREEN);

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2381,9 +2381,7 @@ void TextServerAdvanced::font_set_texture_image(const RID &p_font_rid, const Vec
 		img->generate_mipmaps();
 	}
 
-	tex.texture = Ref<ImageTexture>();
-	tex.texture.instantiate();
-	tex.texture->create_from_image(img);
+	tex.texture = ImageTexture::create_from_image(img);
 	tex.dirty = false;
 }
 
@@ -2688,8 +2686,7 @@ RID TextServerAdvanced::font_get_glyph_texture_rid(const RID &p_font_rid, const 
 					img->generate_mipmaps();
 				}
 				if (tex.texture.is_null()) {
-					tex.texture.instantiate();
-					tex.texture->create_from_image(img);
+					tex.texture = ImageTexture::create_from_image(img);
 				} else {
 					tex.texture->update(img);
 				}
@@ -2728,8 +2725,7 @@ Size2 TextServerAdvanced::font_get_glyph_texture_size(const RID &p_font_rid, con
 					img->generate_mipmaps();
 				}
 				if (tex.texture.is_null()) {
-					tex.texture.instantiate();
-					tex.texture->create_from_image(img);
+					tex.texture = ImageTexture::create_from_image(img);
 				} else {
 					tex.texture->update(img);
 				}
@@ -3060,8 +3056,7 @@ void TextServerAdvanced::font_draw_glyph(const RID &p_font_rid, const RID &p_can
 						img->generate_mipmaps();
 					}
 					if (tex.texture.is_null()) {
-						tex.texture.instantiate();
-						tex.texture->create_from_image(img);
+						tex.texture = ImageTexture::create_from_image(img);
 					} else {
 						tex.texture->update(img);
 					}
@@ -3139,8 +3134,7 @@ void TextServerAdvanced::font_draw_glyph_outline(const RID &p_font_rid, const RI
 						img->generate_mipmaps();
 					}
 					if (tex.texture.is_null()) {
-						tex.texture.instantiate();
-						tex.texture->create_from_image(img);
+						tex.texture = ImageTexture::create_from_image(img);
 					} else {
 						tex.texture->update(img);
 					}

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -1493,9 +1493,7 @@ void TextServerFallback::font_set_texture_image(const RID &p_font_rid, const Vec
 		img->generate_mipmaps();
 	}
 
-	tex.texture = Ref<ImageTexture>();
-	tex.texture.instantiate();
-	tex.texture->create_from_image(img);
+	tex.texture = ImageTexture::create_from_image(img);
 	tex.dirty = false;
 }
 
@@ -1786,8 +1784,7 @@ RID TextServerFallback::font_get_glyph_texture_rid(const RID &p_font_rid, const 
 					img->generate_mipmaps();
 				}
 				if (tex.texture.is_null()) {
-					tex.texture.instantiate();
-					tex.texture->create_from_image(img);
+					tex.texture = ImageTexture::create_from_image(img);
 				} else {
 					tex.texture->update(img);
 				}
@@ -1826,8 +1823,7 @@ Size2 TextServerFallback::font_get_glyph_texture_size(const RID &p_font_rid, con
 					img->generate_mipmaps();
 				}
 				if (tex.texture.is_null()) {
-					tex.texture.instantiate();
-					tex.texture->create_from_image(img);
+					tex.texture = ImageTexture::create_from_image(img);
 				} else {
 					tex.texture->update(img);
 				}
@@ -2140,8 +2136,7 @@ void TextServerFallback::font_draw_glyph(const RID &p_font_rid, const RID &p_can
 						img->generate_mipmaps();
 					}
 					if (tex.texture.is_null()) {
-						tex.texture.instantiate();
-						tex.texture->create_from_image(img);
+						tex.texture = ImageTexture::create_from_image(img);
 					} else {
 						tex.texture->update(img);
 					}
@@ -2219,8 +2214,7 @@ void TextServerFallback::font_draw_glyph_outline(const RID &p_font_rid, const RI
 						img->generate_mipmaps();
 					}
 					if (tex.texture.is_null()) {
-						tex.texture.instantiate();
-						tex.texture->create_from_image(img);
+						tex.texture = ImageTexture::create_from_image(img);
 					} else {
 						tex.texture->update(img);
 					}

--- a/modules/theora/video_stream_theora.cpp
+++ b/modules/theora/video_stream_theora.cpp
@@ -331,7 +331,7 @@ void VideoStreamPlaybackTheora::set_file(const String &p_file) {
 		Ref<Image> img;
 		img.instantiate();
 		img->create(w, h, false, Image::FORMAT_RGBA8);
-		texture->create_from_image(img);
+		texture->set_image(img);
 
 	} else {
 		/* tear down the partial theora setup */

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -3118,13 +3118,8 @@ void EditorExportPlatformAndroid::resolve_platform_feature_priorities(const Ref<
 }
 
 EditorExportPlatformAndroid::EditorExportPlatformAndroid() {
-	Ref<Image> img = memnew(Image(_android_logo));
-	logo.instantiate();
-	logo->create_from_image(img);
-
-	img = Ref<Image>(memnew(Image(_android_run_icon)));
-	run_icon.instantiate();
-	run_icon->create_from_image(img);
+	logo = ImageTexture::create_from_image(memnew(Image(_android_logo)));
+	run_icon = ImageTexture::create_from_image(memnew(Image(_android_run_icon)));
 
 	devices_changed.set();
 	plugins_changed.set();

--- a/platform/iphone/export/export_plugin.cpp
+++ b/platform/iphone/export/export_plugin.cpp
@@ -1838,12 +1838,8 @@ bool EditorExportPlatformIOS::can_export(const Ref<EditorExportPreset> &p_preset
 }
 
 EditorExportPlatformIOS::EditorExportPlatformIOS() {
-	Ref<Image> img = memnew(Image(_iphone_logo));
-	logo.instantiate();
-	logo->create_from_image(img);
-
+	logo = ImageTexture::create_from_image(memnew(Image(_iphone_logo)));
 	plugins_changed.set();
-
 	check_for_changes_thread.start(_check_for_changes_poll_thread, this);
 }
 

--- a/platform/javascript/export/export_plugin.cpp
+++ b/platform/javascript/export/export_plugin.cpp
@@ -661,13 +661,8 @@ EditorExportPlatformJavaScript::EditorExportPlatformJavaScript() {
 	server.instantiate();
 	server_thread.start(_server_thread_poll, this);
 
-	Ref<Image> img = memnew(Image(_javascript_logo));
-	logo.instantiate();
-	logo->create_from_image(img);
-
-	img = Ref<Image>(memnew(Image(_javascript_run_icon)));
-	run_icon.instantiate();
-	run_icon->create_from_image(img);
+	logo = ImageTexture::create_from_image(memnew(Image(_javascript_logo)));
+	run_icon = ImageTexture::create_from_image(memnew(Image(_javascript_run_icon)));
 
 	Ref<Theme> theme = EditorNode::get_singleton()->get_editor_theme();
 	if (theme.is_valid()) {

--- a/platform/linuxbsd/export/export.cpp
+++ b/platform/linuxbsd/export/export.cpp
@@ -35,12 +35,7 @@
 void register_linuxbsd_exporter() {
 	Ref<EditorExportPlatformLinuxBSD> platform;
 	platform.instantiate();
-
-	Ref<Image> img = memnew(Image(_linuxbsd_logo));
-	Ref<ImageTexture> logo;
-	logo.instantiate();
-	logo->create_from_image(img);
-	platform->set_logo(logo);
+	platform->set_logo(ImageTexture::create_from_image(memnew(Image(_linuxbsd_logo))));
 	platform->set_name("Linux/X11");
 	platform->set_extension("x86_32");
 	platform->set_extension("x86_64", "binary_format/64_bits");

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -1178,10 +1178,7 @@ Ref<Texture2D> DisplayServerOSX::global_menu_get_item_icon(const String &p_menu_
 			GodotMenuItem *obj = [menu_item representedObject];
 			if (obj) {
 				if (obj->img.is_valid()) {
-					Ref<ImageTexture> txt;
-					txt.instantiate();
-					txt->create_from_image(obj->img);
-					return txt;
+					return ImageTexture::create_from_image(obj->img);
 				}
 			}
 		}

--- a/platform/osx/export/export_plugin.cpp
+++ b/platform/osx/export/export_plugin.cpp
@@ -252,7 +252,7 @@ void EditorExportPlatformOSX::_make_icon(const Ref<Image> &p_icon, Vector<uint8_
 
 		if (icon_infos[i].is_png) {
 			// Encode PNG icon.
-			it->create_from_image(copy);
+			it->set_image(copy);
 			String path = EditorPaths::get_singleton()->get_cache_dir().plus_file("icon.png");
 			ResourceSaver::save(path, it);
 
@@ -1666,9 +1666,7 @@ bool EditorExportPlatformOSX::can_export(const Ref<EditorExportPreset> &p_preset
 }
 
 EditorExportPlatformOSX::EditorExportPlatformOSX() {
-	Ref<Image> img = memnew(Image(_osx_logo));
-	logo.instantiate();
-	logo->create_from_image(img);
+	logo = ImageTexture::create_from_image(memnew(Image(_osx_logo)));
 }
 
 EditorExportPlatformOSX::~EditorExportPlatformOSX() {

--- a/platform/uwp/export/export_plugin.cpp
+++ b/platform/uwp/export/export_plugin.cpp
@@ -503,7 +503,5 @@ void EditorExportPlatformUWP::resolve_platform_feature_priorities(const Ref<Edit
 }
 
 EditorExportPlatformUWP::EditorExportPlatformUWP() {
-	Ref<Image> img = memnew(Image(_uwp_logo));
-	logo.instantiate();
-	logo->create_from_image(img);
+	logo = ImageTexture::create_from_image(memnew(Image(_uwp_logo)));
 }

--- a/platform/windows/export/export.cpp
+++ b/platform/windows/export/export.cpp
@@ -48,12 +48,7 @@ void register_windows_exporter() {
 
 	Ref<EditorExportPlatformWindows> platform;
 	platform.instantiate();
-
-	Ref<Image> img = memnew(Image(_windows_logo));
-	Ref<ImageTexture> logo;
-	logo.instantiate();
-	logo->create_from_image(img);
-	platform->set_logo(logo);
+	platform->set_logo(ImageTexture::create_from_image(memnew(Image(_windows_logo))));
 	platform->set_name("Windows Desktop");
 	platform->set_os_name("Windows");
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -76,7 +76,6 @@ static Ref<StyleBoxFlat> sb_expand(Ref<StyleBoxFlat> p_sbox, float p_left, float
 
 // See also `editor_generate_icon()` in `editor/editor_themes.cpp`.
 static Ref<ImageTexture> generate_icon(int p_index) {
-	Ref<ImageTexture> icon = memnew(ImageTexture);
 	Ref<Image> img = memnew(Image);
 
 #ifdef MODULE_SVG_ENABLED
@@ -87,9 +86,8 @@ static Ref<ImageTexture> generate_icon(int p_index) {
 	ImageLoaderSVG img_loader;
 	img_loader.create_image_from_string(img, default_theme_icons_sources[p_index], scale, upsample, false);
 #endif
-	icon->create_from_image(img);
 
-	return icon;
+	return ImageTexture::create_from_image(img);
 }
 
 static Ref<StyleBox> make_empty_stylebox(float p_margin_left = -1, float p_margin_top = -1, float p_margin_right = -1, float p_margin_bottom = -1) {

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -139,7 +139,7 @@ void ImageTexture::reload_from_file() {
 	img.instantiate();
 
 	if (ImageLoader::load_image(path, img) == OK) {
-		create_from_image(img);
+		set_image(img);
 	} else {
 		Resource::reload_from_file();
 		notify_property_list_changed();
@@ -149,7 +149,7 @@ void ImageTexture::reload_from_file() {
 
 bool ImageTexture::_set(const StringName &p_name, const Variant &p_value) {
 	if (p_name == "image") {
-		create_from_image(p_value);
+		set_image(p_value);
 		return true;
 	}
 	return false;
@@ -167,7 +167,16 @@ void ImageTexture::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("image"), PROPERTY_HINT_RESOURCE_TYPE, "Image", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT));
 }
 
-void ImageTexture::create_from_image(const Ref<Image> &p_image) {
+Ref<ImageTexture> ImageTexture::create_from_image(const Ref<Image> &p_image) {
+	ERR_FAIL_COND_V_MSG(p_image.is_null() || p_image->is_empty(), Ref<ImageTexture>(), "Invalid image");
+
+	Ref<ImageTexture> image_texture;
+	image_texture.instantiate();
+	image_texture->set_image(p_image);
+	return image_texture;
+}
+
+void ImageTexture::set_image(const Ref<Image> &p_image) {
 	ERR_FAIL_COND_MSG(p_image.is_null() || p_image->is_empty(), "Invalid image");
 	w = p_image->get_width();
 	h = p_image->get_height();
@@ -311,7 +320,7 @@ void ImageTexture::set_path(const String &p_path, bool p_take_over) {
 }
 
 void ImageTexture::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("create_from_image", "image"), &ImageTexture::create_from_image);
+	ClassDB::bind_static_method("ImageTexture", D_METHOD("create_from_image", "image"), &ImageTexture::create_from_image);
 	ClassDB::bind_method(D_METHOD("get_format"), &ImageTexture::get_format);
 
 	ClassDB::bind_method(D_METHOD("update", "image"), &ImageTexture::update);

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -110,7 +110,8 @@ protected:
 	static void _bind_methods();
 
 public:
-	void create_from_image(const Ref<Image> &p_image);
+	void set_image(const Ref<Image> &p_image);
+	static Ref<ImageTexture> create_from_image(const Ref<Image> &p_image);
 
 	Image::Format get_format() const;
 

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -1809,11 +1809,8 @@ Vector<Vector<Ref<Texture2D>>> TileSet::generate_terrains_icons(Size2i p_size) {
 				image->create(1, 1, false, Image::FORMAT_RGBA8);
 				image->set_pixel(0, 0, get_terrain_color(terrain_set, terrain));
 			}
-			Ref<ImageTexture> icon;
-			icon.instantiate();
-			icon->create_from_image(image);
+			Ref<ImageTexture> icon = ImageTexture::create_from_image(image);
 			icon->set_size_override(p_size);
-
 			output.write[terrain_set].write[terrain] = icon;
 		}
 	}
@@ -4594,7 +4591,7 @@ void TileSetAtlasSource::_update_padded_texture() {
 	if (!padded_texture.is_valid()) {
 		padded_texture.instantiate();
 	}
-	padded_texture->create_from_image(image);
+	padded_texture->set_image(image);
 	emit_changed();
 }
 

--- a/scene/resources/visual_shader_particle_nodes.cpp
+++ b/scene/resources/visual_shader_particle_nodes.cpp
@@ -470,7 +470,7 @@ void VisualShaderNodeParticleMeshEmitter::_update_texture(const Vector<Vector2> 
 		image->set_pixel(i, 0, Color(v.x, v.y, 0));
 	}
 	if (r_texture->get_width() != p_array.size() || p_array.size() == 0) {
-		r_texture->create_from_image(image);
+		r_texture->set_image(image);
 	} else {
 		r_texture->update(image);
 	}
@@ -491,7 +491,7 @@ void VisualShaderNodeParticleMeshEmitter::_update_texture(const Vector<Vector3> 
 		image->set_pixel(i, 0, Color(v.x, v.y, v.z));
 	}
 	if (r_texture->get_width() != p_array.size() || p_array.size() == 0) {
-		r_texture->create_from_image(image);
+		r_texture->set_image(image);
 	} else {
 		r_texture->update(image);
 	}
@@ -511,7 +511,7 @@ void VisualShaderNodeParticleMeshEmitter::_update_texture(const Vector<Color> &p
 		image->set_pixel(i, 0, p_array[i]);
 	}
 	if (r_texture->get_width() != p_array.size() || p_array.size() == 0) {
-		r_texture->create_from_image(image);
+		r_texture->set_image(image);
 	} else {
 		r_texture->update(image);
 	}


### PR DESCRIPTION
Implements #23782
Originally I said that it wouldn't be so useful, but then I actually had to use Image/ImageTexture a bit more. Whenever you create ImageTexture, you immediately assign an image. It gets old fast, so having a shorthand is helpful.

I didn't stop here though. Seems like `ImageTexture.create_from_image()` is used a lot in core, so I replaced all usage by the new static method. Diff numbers say it well how it simplifies the code.

What changed:
- `ImageTexture.create_from_image()` is now static
  - seems like non-static version of this method is needed in core (it has a few uses), so I added `set_image()`. It's not exposed
- Added `Image.load_from_file()`, which creates Image and loads data
  - I didn't replace `load()`, because sometimes it's necessary get the loading error
    - although I opened a [proposal](https://github.com/godotengine/godot-proposals/issues/4490) that would allow it

Now it's possible to e.g. assign a dynamically loaded texture in one line:
```GDScript
$Sprite.texture = ImageTexture.create_from_image(Image.load(path))
```
It saves lots of typing.