### PR TITLE
Handle AssetLib repository config error

### DIFF
--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -186,8 +186,10 @@ class EditorAssetLibrary : public PanelContainer {
 	PanelContainer *library_scroll_bg = nullptr;
 	ScrollContainer *library_scroll = nullptr;
 	VBoxContainer *library_vb = nullptr;
-	Label *library_loading = nullptr;
-	Label *library_error = nullptr;
+	Label *library_info = nullptr;
+	VBoxContainer *library_error = nullptr;
+	Label *library_error_label = nullptr;
+	Button *library_error_retry = nullptr;
 	LineEdit *filter = nullptr;
 	Timer *filter_debounce_timer = nullptr;
 	OptionButton *categories = nullptr;
@@ -291,6 +293,7 @@ class EditorAssetLibrary : public PanelContainer {
 	void _api_request(const String &p_request, RequestType p_request_type, const String &p_arguments = "");
 	void _http_request_completed(int p_status, int p_code, const PackedStringArray &headers, const PackedByteArray &p_data);
 	void _filter_debounce_timer_timeout();
+	void _request_current_config();
 	EditorAssetLibraryItemDownload *_get_asset_in_progress(int p_asset_id) const;
 
 	void _repository_changed(int p_repository_id);


### PR DESCRIPTION
Fixes #53996

* Disables related input controls when fetching repository config.
* Merges `library_loading` and `library_error` labels into a single `library_info` label:
    * `library_loading` displays a fixed "Loading" message when fetching repository config.
    * `library_info` displays a message when search result is empty.
 * Clears search result when fetching repository config (e.g. when switching the repository "site").
 * Adds a dedicated error mesage label & retry button when it fails to fetch repository config.

https://user-images.githubusercontent.com/372476/166660273-981a7305-4074-4f9e-b294-213487d0039f.mp4

