### PR TITLE
[Net] Fix TCPServer and WSLClient status after "poll" refactoring.

### DIFF
--- a/core/io/stream_peer_tcp.cpp
+++ b/core/io/stream_peer_tcp.cpp
@@ -81,7 +81,7 @@ void StreamPeerTCP::accept_socket(Ref<NetSocket> p_sock, IPAddress p_host, uint1
 	_sock->set_blocking_enabled(false);
 
 	timeout = OS::get_singleton()->get_ticks_msec() + (((uint64_t)GLOBAL_GET("network/limits/tcp/connect_timeout_seconds")) * 1000);
-	status = STATUS_CONNECTING;
+	status = STATUS_CONNECTED;
 
 	peer_host = p_host;
 	peer_port = p_port;

--- a/modules/websocket/wsl_client.h
+++ b/modules/websocket/wsl_client.h
@@ -52,14 +52,13 @@ private:
 	Ref<WSLPeer> _peer;
 	Ref<StreamPeerTCP> _tcp;
 	Ref<StreamPeer> _connection;
+	ConnectionStatus _status = CONNECTION_DISCONNECTED;
 
 	CharString _request;
 	int _requested = 0;
 
 	uint8_t _resp_buf[WSL_MAX_HEADER_SIZE];
 	int _resp_pos = 0;
-
-	String _response;
 
 	String _key;
 	String _host;


### PR DESCRIPTION
The whole websocket module needs some more work, and be split like ENet/WebRTC into pure protocol class and the Multiplayer implementation, but it's better done in a separate PR as it involves much more code changes.

This fixes the regressions in the meantime. Fixes #60664 .