### PR TITLE
Physics Interpolation - Flush transforms after physics tick

### DIFF
--- a/core/os/main_loop.h
+++ b/core/os/main_loop.h
@@ -68,6 +68,7 @@ public:
 
 	virtual void init();
 	virtual bool iteration(float p_time);
+	virtual void iteration_end() {}
 	virtual bool idle(float p_time);
 	virtual void finish();
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -2257,6 +2257,8 @@ bool Main::iteration() {
 
 		message_queue->flush();
 
+		OS::get_singleton()->get_main_loop()->iteration_end();
+
 		physics_process_ticks = MAX(physics_process_ticks, OS::get_singleton()->get_ticks_usec() - physics_begin); // keep the largest one for reference
 		physics_process_max = MAX(OS::get_singleton()->get_ticks_usec() - physics_begin, physics_process_max);
 		Engine::get_singleton()->_physics_frames++;

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -525,6 +525,14 @@ void SceneTree::client_physics_interpolation_remove_spatial(SelfList<Spatial> *p
 	_client_physics_interpolation._spatials_list.remove(p_elem);
 }
 
+void SceneTree::iteration_end() {
+	// When physics interpolation is active, we want all pending transforms
+	// to be flushed to the VisualServer before finishing a physics tick.
+	if (_physics_interpolation_enabled) {
+		flush_transform_notifications();
+	}
+}
+
 bool SceneTree::iteration(float p_time) {
 	root_lock++;
 

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -306,6 +306,7 @@ public:
 	virtual void init();
 
 	virtual bool iteration(float p_time);
+	virtual void iteration_end();
 	virtual bool idle(float p_time);
 
 	virtual void finish();


### PR DESCRIPTION
Leftover transforms from the physics tick were being flushed during idle, which was causing problems for physics interpolation.

This PR flushes the transforms at the end of the physics tick when physics interpolation is active.

Fixes #60735

## Explanation
The physics server is updated in the physics tick _after_ `_physics_process` has been called. When objects move due to the physics there are a lot of calls to functions like `RigidBody::_direct_state_changed`, which call `set_global_transform()`.

`set_global_transform()` sets the transform in the Node, but _does not_ update the VisualServer immediately. Instead notifications are posted to do this, so sending the transform to the `VisualServer` is deferred.

Flushing of the transforms to the `VisualServer` happens in `SceneTree::flush_transform_notifications()` which is called in a few places:

* At the start of `_physics_process`
* After `_physics_process` (but before the physics server tick is run)
* Before `idle`
* After `idle`

This creates a snag, the transforms changed as a result of the physics server tick are _not flushed on time_. If there are e.g. 2 physics ticks, the transforms for tick 1 are sent at the start of tick 2. And the transforms for tick 2 are not sent until the start of `idle`, when the engine is no longer _in physics_ (according to the flag).

```
	for (int iters = 0; iters < advance.physics_steps; ++iters) {
		// FLUSHES BEFORE AND AFTER "iteration"
		if (OS::get_singleton()->get_main_loop()->iteration(frame_slice * time_scale)) {
			exit = true;
			Engine::get_singleton()->_in_physics = false;
			break;
		}

		PhysicsServer::get_singleton()->step(frame_slice * time_scale);
		Physics2DServer::get_singleton()->step(frame_slice * time_scale);

		// STILL NEEDS A FLUSH to send the transforms from the physics
	}
```

This is something that just about works, but now we have strict checks in the warning that the `VisualServer::set_transform()` is called in the correct place, it is flagging this as a problem.

By adding an extra flush _after_ the physics server tick the transforms are sent in a timely fashion:
This both:
1) Gets rid of the warning
2) Ensures that the transforms are up to date in the VisualServer. While them being out of sync is something that could be "got away with" when using it purely for rendering, it is more important that it is kept up to date so that the transforms for interpolation are correct.

## Notes
* This should not be more expensive than the current state without it, as it just flushing a queue of transforms (it either does them immediately as in this PR, or it effectively does them a few lines of code later). The same number of transforms is sent.
* There are also a few variations on this we could alternatively use, but it probably makes little difference (this PR version is the most "correct"):
1) We could flush the physics tick _only_ after the physics server (and eliminate the call before the physics server tick)
2) We could do an extra flush after all the physics tick had run, (instead of?) before the idle, and have the `in physics` flag set
3) We could do the same even when `physics interpolation` is not active, as it logically does seem to be a better place to flush. However I've done this only for `physics interpolation` in the interest of protecting against regressions in non-interpolated mode, at least to start with. (If it ain't broke.. :grin: )

Incidentally it isn't crucial if the flush is called "too many times", as if the queue is empty is will do nothing. So we can happily e.g. have a flush at the end of the physics ticks and before the idle, even if one was redundant, to guard against bugs.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
