### PR TITLE
Use physical keys for numpad emulation in the 3D editor

### DIFF
--- a/editor/plugins/spatial_editor_plugin.cpp
+++ b/editor/plugins/spatial_editor_plugin.cpp
@@ -2042,7 +2042,7 @@ void SpatialEditorViewport::_sinput(const Ref<InputEvent> &p_event) {
 		}
 
 		if (EditorSettings::get_singleton()->get("editors/3d/navigation/emulate_numpad")) {
-			const uint32_t code = k->get_scancode();
+			const uint32_t code = k->get_physical_scancode();
 			if (code >= KEY_0 && code <= KEY_9) {
 				k->set_scancode(code - KEY_0 + KEY_KP_0);
 			}


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/58024.

This makes numpad emulation work on non-QWERTY keyboard layouts more reliably. Tested on Linux with an AZERTY keyboard layout (fr-oss).