### PR TITLE
Mention return value of `Transform*.scaled()` and similar

### DIFF
--- a/doc/classes/Transform2D.xml
+++ b/doc/classes/Transform2D.xml
@@ -141,14 +141,14 @@
 			<return type="Transform2D" />
 			<argument index="0" name="phi" type="float" />
 			<description>
-				Rotates the transform by the given angle (in radians), using matrix multiplication.
+				Returns a copy of the transform rotated by the given [code]phi[/code] angle (in radians), using matrix multiplication.
 			</description>
 		</method>
 		<method name="scaled" qualifiers="const">
 			<return type="Transform2D" />
 			<argument index="0" name="scale" type="Vector2" />
 			<description>
-				Scales the transform by the given scale factor, using matrix multiplication.
+				Returns a copy of the transform scaled by the given [code]scale[/code] factor, using matrix multiplication.
 			</description>
 		</method>
 		<method name="set_rotation">
@@ -176,7 +176,7 @@
 			<return type="Transform2D" />
 			<argument index="0" name="offset" type="Vector2" />
 			<description>
-				Translates the transform by the given offset, relative to the transform's basis vectors.
+				Returns a copy of the transform translated by the given [code]offset[/code], relative to the transform's basis vectors.
 				Unlike [method rotated] and [method scaled], this does not use matrix multiplication.
 			</description>
 		</method>

--- a/doc/classes/Transform3D.xml
+++ b/doc/classes/Transform3D.xml
@@ -96,14 +96,14 @@
 			<argument index="0" name="axis" type="Vector3" />
 			<argument index="1" name="phi" type="float" />
 			<description>
-				Rotates the transform around the given axis by the given angle (in radians), using matrix multiplication. The axis must be a normalized vector.
+				Returns a copy of the transform rotated around the given [code]axis[/code] by the given [code]phi[/code] angle (in radians), using matrix multiplication. The [code]axis[/code] must be a normalized vector.
 			</description>
 		</method>
 		<method name="scaled" qualifiers="const">
 			<return type="Transform3D" />
 			<argument index="0" name="scale" type="Vector3" />
 			<description>
-				Scales basis and origin of the transform by the given scale factor, using matrix multiplication.
+				Returns a copy of the transform with its basis and origin scaled by the given [code]scale[/code] factor, using matrix multiplication.
 			</description>
 		</method>
 		<method name="sphere_interpolate_with" qualifiers="const">
@@ -118,7 +118,7 @@
 			<return type="Transform3D" />
 			<argument index="0" name="offset" type="Vector3" />
 			<description>
-				Translates the transform by the given offset, relative to the transform's basis vectors.
+				Returns a copy of the transform translated by the given [code]offset[/code], relative to the transform's basis vectors.
 				Unlike [method rotated] and [method scaled], this does not use matrix multiplication.
 			</description>
 		</method>


### PR DESCRIPTION
Closes https://github.com/godotengine/godot/issues/60754

This PR slightly alters the description for **Transform2D** and **Transform3D** 's `scaled()`, `rotated()` and `translated()` methods to explicitly say they return a modified copy of the Transform, taking inspiration on how similar **Vector*** methods are written.
Also surrounds a few words in those methods with `[code]` where it feels appropriate.