### PR TITLE
Fix global AnimationLibrary name validation

### DIFF
--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -55,7 +55,7 @@ void AnimationLibraryEditor::_add_library_validate(const String &p_name) {
 		ERR_FAIL_COND(al.is_null());
 		if (p_name == "") {
 			error = TTR("Animation name can't be empty.");
-		} else if (!AnimationLibrary::is_valid_name(p_name)) {
+		} else if (!AnimationLibrary::is_valid_animation_name(p_name)) {
 			error = TTR("Animation name contains invalid characters: '/', ':', ',' or '['.");
 		} else if (al->has_animation(p_name)) {
 			error = TTR("Animation with the same name already exists.");
@@ -63,7 +63,7 @@ void AnimationLibraryEditor::_add_library_validate(const String &p_name) {
 	} else {
 		if (p_name == "" && bool(player->call("has_animation_library", ""))) {
 			error = TTR("Enter a library name.");
-		} else if (!AnimationLibrary::is_valid_name(p_name)) {
+		} else if (!AnimationLibrary::is_valid_library_name(p_name)) {
 			error = TTR("Library name contains invalid characters: '/', ':', ',' or '['.");
 		} else if (bool(player->call("has_animation_library", p_name))) {
 			error = TTR("Library with the same name already exists.");
@@ -256,7 +256,7 @@ void AnimationLibraryEditor::_load_file(String p_path) {
 				}
 			}
 
-			String name = AnimationLibrary::validate_name(p_path.get_file().get_basename());
+			String name = AnimationLibrary::validate_library_name(p_path.get_file().get_basename());
 
 			int attempt = 1;
 

--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -427,7 +427,7 @@ void AnimationPlayerEditor::_animation_name_edited() {
 	player->stop();
 
 	String new_name = name->get_text();
-	if (!AnimationLibrary::is_valid_name(new_name)) {
+	if (!AnimationLibrary::is_valid_animation_name(new_name)) {
 		error_dialog->set_text(TTR("Invalid animation name!"));
 		error_dialog->popup_centered();
 		return;

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -30,15 +30,15 @@
 
 #include "animation_library.h"
 
-bool AnimationLibrary::is_valid_name(const String &p_name) {
+bool AnimationLibrary::is_valid_animation_name(const String &p_name) {
 	return !(p_name.is_empty() || p_name.contains("/") || p_name.contains(":") || p_name.contains(",") || p_name.contains("["));
 }
 
-String AnimationLibrary::validate_name(const String &p_name) {
-	if (p_name.is_empty()) {
-		return "_"; // Should always return a valid name.
-	}
+bool AnimationLibrary::is_valid_library_name(const String &p_name) {
+	return !(p_name.contains("/") || p_name.contains(":") || p_name.contains(",") || p_name.contains("["));
+}
 
+String AnimationLibrary::validate_library_name(const String &p_name) {
 	String name = p_name;
 	const char *characters = "/:,[";
 	for (const char *p = characters; *p; p++) {
@@ -48,7 +48,7 @@ String AnimationLibrary::validate_name(const String &p_name) {
 }
 
 Error AnimationLibrary::add_animation(const StringName &p_name, const Ref<Animation> &p_animation) {
-	ERR_FAIL_COND_V_MSG(!is_valid_name(p_name), ERR_INVALID_PARAMETER, "Invalid animation name: '" + String(p_name) + "'.");
+	ERR_FAIL_COND_V_MSG(!is_valid_animation_name(p_name), ERR_INVALID_PARAMETER, "Invalid animation name: '" + String(p_name) + "'.");
 	ERR_FAIL_COND_V(p_animation.is_null(), ERR_INVALID_PARAMETER);
 
 	if (animations.has(p_name)) {
@@ -72,7 +72,7 @@ void AnimationLibrary::remove_animation(const StringName &p_name) {
 
 void AnimationLibrary::rename_animation(const StringName &p_name, const StringName &p_new_name) {
 	ERR_FAIL_COND(!animations.has(p_name));
-	ERR_FAIL_COND_MSG(!is_valid_name(p_new_name), "Invalid animation name: '" + String(p_new_name) + "'.");
+	ERR_FAIL_COND_MSG(!is_valid_animation_name(p_new_name), "Invalid animation name: '" + String(p_new_name) + "'.");
 	ERR_FAIL_COND(animations.has(p_new_name));
 
 	animations.insert(p_new_name, animations[p_name]);

--- a/scene/resources/animation_library.h
+++ b/scene/resources/animation_library.h
@@ -49,8 +49,9 @@ protected:
 	static void _bind_methods();
 
 public:
-	static bool is_valid_name(const String &p_name);
-	static String validate_name(const String &p_name);
+	static bool is_valid_animation_name(const String &p_name);
+	static bool is_valid_library_name(const String &p_name);
+	static String validate_library_name(const String &p_name);
 
 	Error add_animation(const StringName &p_name, const Ref<Animation> &p_animation);
 	void remove_animation(const StringName &p_name);


### PR DESCRIPTION
In #60369, I used `is_valid_name()` for both animation name and library name. However, empty string is a valid name used for the global Animation Library. So currently, if you remove the global library, the only way to get it back is to create a new animation in the AnimationPlayer editor :(

This PR splits that validation function into `is_valid_animation_name()` and `is_valid_library_name()`.