### PR TITLE
[WIP] Editor font cache and pre-rendering.

### DIFF
--- a/doc/classes/FontData.xml
+++ b/doc/classes/FontData.xml
@@ -561,6 +561,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="_editor_font_id" type="String" setter="_set_editor_font_id" getter="_get_editor_font_id" default="&quot;&quot;">
+			This property is used by the editor to identify the built-in font cache, and should not be changed.
+		</member>
 		<member name="antialiased" type="bool" setter="set_antialiased" getter="is_antialiased" default="true">
 			If set to [code]true[/code], font 8-bit anitialiased glyph rendering is supported and enabled.
 		</member>

--- a/editor/editor_fonts.h
+++ b/editor/editor_fonts.h
@@ -33,6 +33,74 @@
 
 #include "scene/resources/theme.h"
 
-void editor_register_fonts(Ref<Theme> p_theme);
+#include <atomic>
+
+class EditorFonts {
+	static EditorFonts *singleton;
+
+	const float embolden_strength = 0.6;
+
+	HashMap<String, Ref<FontData>> cache;
+
+	struct PreRenderRequest {
+		char32_t start = 0;
+		char32_t end = 0;
+		int size = 0;
+		Ref<FontData> data;
+
+		PreRenderRequest() {}
+		PreRenderRequest(Ref<FontData> &p_data, char32_t p_start = 0, char32_t p_end = 0, int p_size = 16) {
+			start = p_start;
+			end = p_end;
+			size = p_size;
+			data = p_data;
+		}
+	};
+
+	Vector<PreRenderRequest> pre_render_rq;
+	std::atomic<bool> pre_render_exit;
+	Thread pre_render_thread;
+
+	void stop_pre_render();
+	void start_pre_render();
+	static void _pre_render_func(void *);
+
+	struct InternalFontData {
+		const uint8_t *ptr;
+		size_t size;
+		String hash;
+
+		InternalFontData() {}
+		InternalFontData(const uint8_t *p_ptr, size_t p_size);
+	};
+	HashMap<String, InternalFontData> internal_fonts;
+
+	struct ExternalFontData {
+		PackedByteArray data;
+		String hash;
+		ExternalFontData() {}
+		ExternalFontData(const String &p_path);
+	};
+	HashMap<String, ExternalFontData> external_fonts;
+	Vector<String> fallback_list;
+
+	Ref<FontData> load_cached_font(const HashMap<String, Ref<FontData>> &p_old_cache, const String &p_id, TextServer::Hinting p_hinting, bool p_aa, bool p_autohint, TextServer::SubpixelPositioning p_font_subpixel_positioning, bool p_msdf, bool p_embolden, bool p_slanted);
+	Ref<Font> make_font(const Ref<FontData> &p_default, const Ref<FontData> &p_custom, const Vector<Ref<FontData>> &p_fallback, const String &p_variations = String());
+
+public:
+	static EditorFonts *get_singleton();
+
+	bool has_external_editor_font_data(const String &p_id) const;
+	PackedByteArray get_external_editor_font_data(const String &p_id) const;
+
+	bool has_internal_editor_font_data(const String &p_id) const;
+	const uint8_t *get_internal_editor_font_data_ptr(const String &p_id) const;
+	size_t get_internal_editor_font_data_size(const String &p_id) const;
+
+	void load_fonts(Ref<Theme> &p_theme);
+
+	EditorFonts();
+	~EditorFonts();
+};
 
 #endif

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -552,7 +552,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		editor_register_and_generate_icons(p_theme, dark_theme, thumb_size, true);
 	}
 
-	editor_register_fonts(theme);
+	EditorFonts::get_singleton()->load_fonts(theme);
 
 	// Ensure borders are visible when using an editor scale below 100%.
 	const int border_width = CLAMP(border_size, 0, 2) * MAX(1, EDSCALE);

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -82,6 +82,7 @@
 #ifdef TOOLS_ENABLED
 #include "editor/doc_data_class_path.gen.h"
 #include "editor/doc_tools.h"
+#include "editor/editor_fonts.h"
 #include "editor/editor_node.h"
 #include "editor/editor_paths.h"
 #include "editor/editor_settings.h"
@@ -125,6 +126,9 @@ static PhysicsServer3D *physics_server_3d = nullptr;
 static PhysicsServer2D *physics_server_2d = nullptr;
 static NavigationServer3D *navigation_server_3d = nullptr;
 static NavigationServer2D *navigation_server_2d = nullptr;
+#ifdef TOOLS_ENABLED
+static EditorFonts *ed_font_cache = nullptr;
+#endif
 // We error out if setup2() doesn't turn this true
 static bool _start_success = false;
 
@@ -1613,6 +1617,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	if (editor || project_manager || cmdline_tool) {
 		EditorPaths::create();
 	}
+	if (editor || project_manager) {
+		ed_font_cache = memnew(EditorFonts);
+	}
 #endif
 
 	/* Initialize Input */
@@ -2876,8 +2883,12 @@ void Main::cleanup(bool p_force) {
 #ifdef TOOLS_ENABLED
 	NativeExtensionManager::get_singleton()->deinitialize_extensions(NativeExtension::INITIALIZATION_LEVEL_EDITOR);
 	uninitialize_modules(MODULE_INITIALIZATION_LEVEL_EDITOR);
-	EditorNode::unregister_editor_types();
 
+	if (ed_font_cache) {
+		memdelete(ed_font_cache);
+	}
+
+	EditorNode::unregister_editor_types();
 #endif
 
 	ImageLoader::cleanup();

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -247,16 +247,17 @@ class TextServerAdvanced : public TextServerExtension {
 		PackedByteArray data;
 		const uint8_t *data_ptr;
 		size_t data_size;
-		mutable ThreadWorkPool work_pool;
 
 		~FontDataAdvanced() {
-			work_pool.finish();
 			for (const KeyValue<Vector2i, FontDataForSizeAdvanced *> &E : cache) {
 				memdelete(E.value);
 			}
 			cache.clear();
 		}
 	};
+
+	Mutex work_pool_mutex;
+	mutable ThreadWorkPool work_pool;
 
 	_FORCE_INLINE_ FontTexturePosition find_texture_pos_for_glyph(FontDataForSizeAdvanced *p_data, int p_color_size, Image::Format p_image_format, int p_width, int p_height, bool p_msdf) const;
 #ifdef MODULE_MSDFGEN_ENABLED

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -210,16 +210,16 @@ class TextServerFallback : public TextServerExtension {
 		const uint8_t *data_ptr;
 		size_t data_size;
 
-		mutable ThreadWorkPool work_pool;
-
 		~FontDataFallback() {
-			work_pool.finish();
 			for (const KeyValue<Vector2i, FontDataForSizeFallback *> &E : cache) {
 				memdelete(E.value);
 			}
 			cache.clear();
 		}
 	};
+
+	Mutex work_pool_mutex;
+	mutable ThreadWorkPool work_pool;
 
 	_FORCE_INLINE_ FontTexturePosition find_texture_pos_for_glyph(FontDataForSizeFallback *p_data, int p_color_size, Image::Format p_image_format, int p_width, int p_height, bool p_msdf) const;
 #ifdef MODULE_MSDFGEN_ENABLED

--- a/scene/resources/font.h
+++ b/scene/resources/font.h
@@ -47,6 +47,7 @@ class FontData : public Resource {
 	const uint8_t *data_ptr = nullptr;
 	size_t data_size = 0;
 	PackedByteArray data;
+	String editor_font_id;
 
 	bool antialiased = true;
 	bool mipmaps = false;
@@ -87,6 +88,9 @@ public:
 	Error load_dynamic_font(const String &p_path);
 
 	// Font source data.
+	virtual void _set_editor_font_id(const String &p_id);
+	virtual String _get_editor_font_id() const;
+
 	virtual void set_data_ptr(const uint8_t *p_data, size_t p_size);
 	virtual void set_data(const PackedByteArray &p_data);
 	virtual PackedByteArray get_data() const;


### PR DESCRIPTION
- Adds caching of rasterized font glyphs to the editor (all glyphs rasterized during editor runtime are saved  on exit, and reloaded on next start).
- Adds ability to pre-render font glyphs in the background thread on editor.
- Adds MSDF fonts to the editor theme, and Latin glyphs pre-rendering for these fonts (for testing, these fonts currently aren't used).

It's not very useful for the normal fonts, but might be is we start using MSDF fonts in the editor, see #60463.