### PR TITLE
Update checked based on the variant type of the value

### DIFF
--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -151,7 +151,7 @@ public:
 	void set_doc_path(const String &p_doc_path);
 
 	virtual void update_property();
-	void update_revert_and_pin_status();
+	void update_editor_property_status();
 
 	virtual bool use_keying_next() const;
 


### PR DESCRIPTION
In `EditorProperty::update_revert_and_pin_status`, if `checkable` is `true`, update `checked` based on the variant type of the value, and rename the function as `EditorProperty::update_editor_property_status`.

This patch can fix #55455.

**Known problems:** 
1. Unable to check Checkbox for properties of type `Object` when it is unchecked. This is probably because during value store/fetch, the `nullptr` (variant type is `Variant::OBJECT`) eventually becomes `Variant()` (variant type is `Variant::NIL`).
2. For theme overrides, click the revert icon will uncheck the Checkbox. This is probably because `EditorPropertyRevert::get_property_revert_value` returns `Variant()`.
