### PR TITLE
Cache script icons in editor

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -3405,6 +3405,9 @@ void EditorNode::_remove_edited_scene(bool p_change_tab) {
 }
 
 void EditorNode::_remove_scene(int index, bool p_change_tab) {
+	// Clear icon cache in case some scripts are no longer needed.
+	script_icon_cache.clear();
+
 	if (editor_data.get_edited_scene() == index) {
 		// Scene to remove is current scene.
 		_remove_edited_scene(p_change_tab);
@@ -4055,7 +4058,7 @@ void EditorNode::_pick_main_scene_custom_action(const String &p_custom_action_na
 	}
 }
 
-Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String &p_fallback) const {
+Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String &p_fallback) {
 	ERR_FAIL_COND_V(!p_object || !gui_base, nullptr);
 
 	Ref<Script> script = p_object->get_script();
@@ -4063,13 +4066,14 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 		script = p_object;
 	}
 
-	if (script.is_valid()) {
+	if (script.is_valid() && !script_icon_cache.has(script)) {
 		Ref<Script> base_script = script;
 		while (base_script.is_valid()) {
 			StringName name = EditorNode::get_editor_data().script_class_get_name(base_script->get_path());
 			String icon_path = EditorNode::get_editor_data().script_class_get_icon_path(name);
 			Ref<ImageTexture> icon = _load_custom_class_icon(icon_path);
 			if (icon.is_valid()) {
+				script_icon_cache[script] = icon;
 				return icon;
 			}
 
@@ -4079,12 +4083,18 @@ Ref<Texture2D> EditorNode::get_object_icon(const Object *p_object, const String 
 				const Vector<EditorData::CustomType> &types = EditorNode::get_editor_data().get_custom_types()[base];
 				for (int i = 0; i < types.size(); ++i) {
 					if (types[i].script == base_script && types[i].icon.is_valid()) {
+						script_icon_cache[script] = types[i].icon;
 						return types[i].icon;
 					}
 				}
 			}
 			base_script = base_script->get_base_script();
 		}
+
+		// If no icon found, cache it as null.
+		script_icon_cache[script] = Ref<Texture>();
+	} else if (script.is_valid() && script_icon_cache.has(script) && script_icon_cache[script].is_valid()) {
+		return script_icon_cache[script];
 	}
 
 	// TODO: Should probably be deprecated in 4.x.

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -478,6 +478,7 @@ private:
 	PrintHandlerList print_handler;
 
 	Map<String, Ref<Texture2D>> icon_type_cache;
+	Map<Ref<Script>, Ref<Texture>> script_icon_cache;
 
 	static EditorBuildCallback build_callbacks[MAX_BUILD_CALLBACKS];
 	static EditorPluginInitializeCallback plugin_init_callbacks[MAX_INIT_CALLBACKS];
@@ -795,7 +796,7 @@ public:
 	Ref<Theme> get_editor_theme() const { return theme; }
 	Ref<Script> get_object_custom_type_base(const Object *p_object) const;
 	StringName get_object_custom_type_name(const Object *p_object) const;
-	Ref<Texture2D> get_object_icon(const Object *p_object, const String &p_fallback = "Object") const;
+	Ref<Texture2D> get_object_icon(const Object *p_object, const String &p_fallback = "Object");
 	Ref<Texture2D> get_class_icon(const String &p_class, const String &p_fallback = "Object") const;
 
 	void show_accept(const String &p_text, const String &p_title);


### PR DESCRIPTION
Fixes #60127

This ensures that each script is parsed only once in search of the icon when updating scene tree. It makes loading scenes and especially editing **much** faster. It introduces a small issue that when you change script icon, it won't properly refresh until cache is cleared (right now it's cleared when any scene is closed). But this is a very minor issue compared to what this fixes.

I originally made this PR for 3.x branch, I couldn't reproduce the issue in master, as I don't have a "complex" enough 4.0 project. But I at least tested that it doesn't break anything.

Here's the original 3.x patch for easier cherry-picking: [0001-Cache-script-icons-in-editor.patch.txt](https://github.com/godotengine/godot/files/8631206/0001-Cache-script-icons-in-editor.patch.txt)