### PR TITLE
`Tree::get_edited` Fix in docs example code

### DIFF
--- a/doc/classes/Tree.xml
+++ b/doc/classes/Tree.xml
@@ -100,7 +100,7 @@
 				Returns the currently edited item. Can be used with [signal item_edited] to get the item that was modified.
 				[codeblock]
 				func _ready():
-				    $Tree.item_edited.connect(on_Tree_item_edited)
+				    $Tree.connect("item_edited", self, "on_Tree_item_edited")
 
 				func on_Tree_item_edited():
 				    print($Tree.get_edited()) # This item just got edited (e.g. checked).


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot-docs/issues/5768.
That example was cherry-picked in https://github.com/godotengine/godot/commit/17af75953f46d0063e229a281e355bd0bb05bbc6.