### PR TITLE
For multinode editing, immediate refresh after undo/redo.

### DIFF
--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -87,8 +87,13 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 
 		ur->add_undo_property(n, name, n->get(name));
 	}
-	ur->add_do_method(InspectorDock::get_inspector_singleton(), "refresh");
-	ur->add_undo_method(InspectorDock::get_inspector_singleton(), "refresh");
+	if (name == "script") {
+		ur->add_do_method(InspectorDock::get_inspector_singleton(), "_edit_request_change", this, "scripts");
+		ur->add_undo_method(InspectorDock::get_inspector_singleton(), "_edit_request_change", this, "scripts");
+	} else {
+		ur->add_do_method(InspectorDock::get_inspector_singleton(), "_edit_request_change", this, name);
+		ur->add_undo_method(InspectorDock::get_inspector_singleton(), "_edit_request_change", this, name);
+	}
 
 	ur->commit_action();
 	return true;


### PR DESCRIPTION
Before, for multiple nodes editing, undo/redo will print an error:
```
ERROR: Error calling UndoRedo method operation 'refresh': 'EditorInspector::refresh': Method not found.
   at: _process_operation_list (core/object/undo_redo.cpp:326)
```

This patch will fix it, and immediately refresh the corresponding property display in the Inspector.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
**Known problem:** For editing of multiple nodes, if the number of nodes is reduced and then perform a undo-redo action, the refresh of display in the Inspector may not be immediate, and the refresh interval is related to `docks/property_editor/auto_refresh_interval`.