### PR TITLE
Disallow Callable, Signal and RID in export arrays

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -478,6 +478,11 @@ void EditorPropertyArray::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			change_type->clear();
 			for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+				if (i == Variant::CALLABLE || i == Variant::SIGNAL || i == Variant::RID) {
+					// These types can't be constructed or serialized properly, so skip them.
+					continue;
+				}
+
 				String type = Variant::get_type_name(Variant::Type(i));
 				change_type->add_icon_item(get_theme_icon(type, SNAME("EditorIcons")), type, i);
 			}
@@ -1127,6 +1132,11 @@ void EditorPropertyDictionary::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE: {
 			change_type->clear();
 			for (int i = 0; i < Variant::VARIANT_MAX; i++) {
+				if (i == Variant::CALLABLE || i == Variant::SIGNAL || i == Variant::RID) {
+					// These types can't be constructed or serialized properly, so skip them.
+					continue;
+				}
+
 				String type = Variant::get_type_name(Variant::Type(i));
 				change_type->add_icon_item(get_theme_icon(type, SNAME("EditorIcons")), type, i);
 			}

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -515,12 +515,12 @@ void ProjectSettingsEditor::_update_theme() {
 
 	type_box->clear();
 	for (int i = 0; i < Variant::VARIANT_MAX; i++) {
-		// There's no point in adding Nil types, and Object types
-		// can't be serialized correctly in the project settings.
-		if (i != Variant::NIL && i != Variant::OBJECT) {
-			String type = Variant::get_type_name(Variant::Type(i));
-			type_box->add_icon_item(get_theme_icon(type, SNAME("EditorIcons")), type, i);
+		if (i == Variant::NIL || i == Variant::OBJECT || i == Variant::CALLABLE || i == Variant::SIGNAL || i == Variant::RID) {
+			// These types can't be serialized properly, so skip them.
+			continue;
 		}
+		String type = Variant::get_type_name(Variant::Type(i));
+		type_box->add_icon_item(get_theme_icon(type, SNAME("EditorIcons")), type, i);
 	}
 }
 


### PR DESCRIPTION
Fixes #40019 by removing broken types from available options bruh.
I also included RID. While it doesn't crash, it can't be assigned and I don't think it can be serialized reliably.

EDIT:
Also fixes #56916