### PR TITLE
Handle CLI arguments without a value in `OS.get_cmdline_args()` example

### DIFF
--- a/doc/classes/OS.xml
+++ b/doc/classes/OS.xml
@@ -175,6 +175,10 @@
 				    if argument.find("=") &gt; -1:
 				        var key_value = argument.split("=")
 				        arguments[key_value[0].lstrip("--")] = key_value[1]
+				    else:
+				        # Options without an argument will be present in the dictionary,
+				        # with the value set to an empty string.
+				        arguments[argument.lstrip("--")] = ""
 				[/gdscript]
 				[csharp]
 				var arguments = new Godot.Collections.Dictionary();
@@ -184,6 +188,12 @@
 				    {
 				        string[] keyValue = argument.Split("=");
 				        arguments[keyValue[0].LStrip("--")] = keyValue[1];
+				    }
+				    else
+				    {
+				        // Options without an argument will be present in the dictionary,
+				        // with the value set to an empty string.
+				        arguments[keyValue[0].LStrip("--")] = "";
 				    }
 				}
 				[/csharp]


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/60799.

Command lines such as `--host --address 127.0.0.1` are now parsed as `{"host": "", "address": "127.0.0.1"}`.

Thanks to @DatBrute for providing the code sample :slightly_smiling_face:

This closes https://github.com/godotengine/godot-docs/issues/5803.