### PR TITLE
Rename profiler "Idle Time" to "Process Time"

### DIFF
--- a/core/debugger/engine_profiler.cpp
+++ b/core/debugger/engine_profiler.cpp
@@ -35,7 +35,7 @@
 void EngineProfiler::_bind_methods() {
 	GDVIRTUAL_BIND(_toggle, "enable", "options");
 	GDVIRTUAL_BIND(_add_frame, "data");
-	GDVIRTUAL_BIND(_tick, "frame_time", "idle_time", "physics_time", "physics_frame_time");
+	GDVIRTUAL_BIND(_tick, "frame_time", "process_time", "physics_time", "physics_frame_time");
 }
 
 void EngineProfiler::toggle(bool p_enable, const Array &p_array) {
@@ -46,8 +46,8 @@ void EngineProfiler::add(const Array &p_data) {
 	GDVIRTUAL_CALL(_add_frame, p_data);
 }
 
-void EngineProfiler::tick(double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
-	GDVIRTUAL_CALL(_tick, p_frame_time, p_idle_time, p_physics_time, p_physics_frame_time);
+void EngineProfiler::tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) {
+	GDVIRTUAL_CALL(_tick, p_frame_time, p_process_time, p_physics_time, p_physics_frame_time);
 }
 
 Error EngineProfiler::bind(const String &p_name) {
@@ -60,8 +60,8 @@ Error EngineProfiler::bind(const String &p_name) {
 			[](void *p_user, const Array &p_data) {
 				static_cast<EngineProfiler *>(p_user)->add(p_data);
 			},
-			[](void *p_user, double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
-				static_cast<EngineProfiler *>(p_user)->tick(p_frame_time, p_idle_time, p_physics_time, p_physics_frame_time);
+			[](void *p_user, double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) {
+				static_cast<EngineProfiler *>(p_user)->tick(p_frame_time, p_process_time, p_physics_time, p_physics_frame_time);
 			});
 	registration = p_name;
 	EngineDebugger::register_profiler(p_name, prof);

--- a/core/debugger/engine_profiler.h
+++ b/core/debugger/engine_profiler.h
@@ -48,7 +48,7 @@ protected:
 public:
 	virtual void toggle(bool p_enable, const Array &p_opts);
 	virtual void add(const Array &p_data);
-	virtual void tick(double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time);
+	virtual void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time);
 
 	Error bind(const String &p_name);
 	Error unbind();

--- a/core/debugger/local_debugger.cpp
+++ b/core/debugger/local_debugger.cpp
@@ -60,7 +60,7 @@ struct LocalDebugger::ScriptsProfiler {
 		}
 	}
 
-	void tick(double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
+	void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) {
 		frame_time = p_frame_time;
 		_print_frame_data(false);
 	}
@@ -372,8 +372,8 @@ LocalDebugger::LocalDebugger() {
 				static_cast<ScriptsProfiler *>(p_user)->toggle(p_enable, p_opts);
 			},
 			nullptr,
-			[](void *p_user, double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
-				static_cast<ScriptsProfiler *>(p_user)->tick(p_frame_time, p_idle_time, p_physics_time, p_physics_frame_time);
+			[](void *p_user, double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) {
+				static_cast<ScriptsProfiler *>(p_user)->tick(p_frame_time, p_process_time, p_physics_time, p_physics_frame_time);
 			});
 	register_profiler("scripts", scr_prof);
 }

--- a/core/debugger/remote_debugger.cpp
+++ b/core/debugger/remote_debugger.cpp
@@ -107,7 +107,7 @@ public:
 		}
 	}
 
-	void tick(double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
+	void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) {
 		uint64_t pt = OS::get_singleton()->get_ticks_msec();
 		if (pt - last_bandwidth_time > 200) {
 			last_bandwidth_time = pt;
@@ -130,7 +130,7 @@ class RemoteDebugger::PerformanceProfiler : public EngineProfiler {
 public:
 	void toggle(bool p_enable, const Array &p_opts) {}
 	void add(const Array &p_data) {}
-	void tick(double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
+	void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) {
 		if (!performance) {
 			return;
 		}

--- a/doc/classes/EngineProfiler.xml
+++ b/doc/classes/EngineProfiler.xml
@@ -20,11 +20,11 @@
 		<method name="_tick" qualifiers="virtual">
 			<return type="void" />
 			<argument index="0" name="frame_time" type="float" />
-			<argument index="1" name="idle_time" type="float" />
+			<argument index="1" name="process_time" type="float" />
 			<argument index="2" name="physics_time" type="float" />
 			<argument index="3" name="physics_frame_time" type="float" />
 			<description>
-				Called once every engine iteration when the profiler is active with information about the current frame.
+				Called once every engine iteration when the profiler is active with information about the current frame. All time values are in seconds. Lower values represent faster processing times and are therefore considered better.
 			</description>
 		</method>
 		<method name="_toggle" qualifiers="virtual">

--- a/editor/debugger/editor_profiler.h
+++ b/editor/debugger/editor_profiler.h
@@ -49,7 +49,7 @@ public:
 
 		int frame_number = 0;
 		float frame_time = 0;
-		float idle_time = 0;
+		float process_time = 0;
 		float physics_time = 0;
 		float physics_frame_time = 0;
 

--- a/editor/debugger/script_editor_debugger.cpp
+++ b/editor/debugger/script_editor_debugger.cpp
@@ -606,7 +606,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		metric.valid = true;
 		metric.frame_number = frame.frame_number;
 		metric.frame_time = frame.frame_time;
-		metric.idle_time = frame.idle_time;
+		metric.process_time = frame.process_time;
 		metric.physics_time = frame.physics_time;
 		metric.physics_frame_time = frame.physics_frame_time;
 
@@ -627,10 +627,10 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 
 			frame_time.items.push_back(item);
 
-			item.name = "Idle Time";
-			item.total = metric.idle_time;
+			item.name = "Process Time";
+			item.total = metric.process_time;
 			item.self = item.total;
-			item.signature = "idle_time";
+			item.signature = "process_time";
 
 			frame_time.items.push_back(item);
 

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -100,7 +100,7 @@ public:
 		}
 	}
 
-	void tick(double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
+	void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) {
 		uint64_t pt = OS::get_singleton()->get_ticks_msec();
 		if (pt - last_profile_time > 100) {
 			last_profile_time = pt;

--- a/servers/debugger/servers_debugger.cpp
+++ b/servers/debugger/servers_debugger.cpp
@@ -89,7 +89,7 @@ Array ServersDebugger::ServersProfilerFrame::serialize() {
 	Array arr;
 	arr.push_back(frame_number);
 	arr.push_back(frame_time);
-	arr.push_back(idle_time);
+	arr.push_back(process_time);
 	arr.push_back(physics_time);
 	arr.push_back(physics_frame_time);
 	arr.push_back(script_time);
@@ -120,7 +120,7 @@ bool ServersDebugger::ServersProfilerFrame::deserialize(const Array &p_arr) {
 	CHECK_SIZE(p_arr, 7, "ServersProfilerFrame");
 	frame_number = p_arr[0];
 	frame_time = p_arr[1];
-	idle_time = p_arr[2];
+	process_time = p_arr[2];
 	physics_time = p_arr[3];
 	physics_frame_time = p_arr[4];
 	script_time = p_arr[5];
@@ -281,7 +281,7 @@ class ServersDebugger::ServersProfiler : public EngineProfiler {
 	ScriptsProfiler scripts_profiler;
 
 	double frame_time = 0;
-	double idle_time = 0;
+	double process_time = 0;
 	double physics_time = 0;
 	double physics_frame_time = 0;
 
@@ -289,7 +289,7 @@ class ServersDebugger::ServersProfiler : public EngineProfiler {
 		ServersDebugger::ServersProfilerFrame frame;
 		frame.frame_number = Engine::get_singleton()->get_process_frames();
 		frame.frame_time = frame_time;
-		frame.idle_time = idle_time;
+		frame.process_time = process_time;
 		frame.physics_time = physics_time;
 		frame.physics_frame_time = physics_frame_time;
 		Map<StringName, ServerInfo>::Element *E = server_data.front();
@@ -340,9 +340,9 @@ public:
 		srv.functions.push_back(fi);
 	}
 
-	void tick(double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
+	void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) {
 		frame_time = p_frame_time;
-		idle_time = p_idle_time;
+		process_time = p_process_time;
 		physics_time = p_physics_time;
 		physics_frame_time = p_physics_frame_time;
 		_send_frame_data(false);
@@ -366,7 +366,7 @@ public:
 
 	void add(const Array &p_data) {}
 
-	void tick(double p_frame_time, double p_idle_time, double p_physics_time, double p_physics_frame_time) {
+	void tick(double p_frame_time, double p_process_time, double p_physics_time, double p_physics_frame_time) {
 		Vector<RS::FrameProfileArea> profile_areas = RS::get_singleton()->get_frame_profile();
 		ServersDebugger::VisualProfilerFrame frame;
 		if (!profile_areas.size()) {

--- a/servers/debugger/servers_debugger.h
+++ b/servers/debugger/servers_debugger.h
@@ -85,7 +85,7 @@ public:
 	struct ServersProfilerFrame {
 		int frame_number = 0;
 		double frame_time = 0;
-		double idle_time = 0;
+		double process_time = 0;
 		double physics_time = 0;
 		double physics_frame_time = 0;
 		double script_time = 0;


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/60828.

References to "idle time" are progressively being replaced by "process time" throughout the engine to avoid confusion.

I tested this locally and made sure the value is still correctly reported in the profiler.

This is technically not a breaking change, so it could be backported to `3.x`. Renaming it there might cause some confusion though – but maybe less so than the current "idle time" terminology.