### PR TITLE
Allow AStar2D/AStar3D zero point weight

### DIFF
--- a/core/math/a_star.cpp
+++ b/core/math/a_star.cpp
@@ -47,7 +47,7 @@ int AStar3D::get_available_point_id() const {
 
 void AStar3D::add_point(int p_id, const Vector3 &p_pos, real_t p_weight_scale) {
 	ERR_FAIL_COND_MSG(p_id < 0, vformat("Can't add a point with negative id: %d.", p_id));
-	ERR_FAIL_COND_MSG(p_weight_scale < 1, vformat("Can't add a point with weight scale less than one: %f.", p_weight_scale));
+	ERR_FAIL_COND_MSG(p_weight_scale < 0.0, vformat("Can't add a point with weight scale less than 0.0: %f.", p_weight_scale));
 
 	Point *found_pt;
 	bool p_exists = points.lookup(p_id, found_pt);
@@ -96,7 +96,7 @@ void AStar3D::set_point_weight_scale(int p_id, real_t p_weight_scale) {
 	Point *p;
 	bool p_exists = points.lookup(p_id, p);
 	ERR_FAIL_COND_MSG(!p_exists, vformat("Can't set point's weight scale. Point with id: %d doesn't exist.", p_id));
-	ERR_FAIL_COND_MSG(p_weight_scale < 1, vformat("Can't set point's weight scale less than one: %f.", p_weight_scale));
+	ERR_FAIL_COND_MSG(p_weight_scale < 0.0, vformat("Can't set point's weight scale less than 0.0: %f.", p_weight_scale));
 
 	p->weight_scale = p_weight_scale;
 }

--- a/doc/classes/AStar2D.xml
+++ b/doc/classes/AStar2D.xml
@@ -33,7 +33,7 @@
 			<argument index="1" name="position" type="Vector2" />
 			<argument index="2" name="weight_scale" type="float" default="1.0" />
 			<description>
-				Adds a new point at the given position with the given identifier. The [code]id[/code] must be 0 or larger, and the [code]weight_scale[/code] must be 1 or larger.
+				Adds a new point at the given position with the given identifier. The [code]id[/code] must be 0 or larger, and the [code]weight_scale[/code] must be 0.0 or greater.
 				The [code]weight_scale[/code] is multiplied by the result of [method _compute_cost] when determining the overall cost of traveling across a segment from a neighboring point to this point. Thus, all else being equal, the algorithm prefers points with lower [code]weight_scale[/code]s to form a path.
 				[codeblocks]
 				[gdscript]

--- a/doc/classes/AStar3D.xml
+++ b/doc/classes/AStar3D.xml
@@ -62,7 +62,7 @@
 			<argument index="1" name="position" type="Vector3" />
 			<argument index="2" name="weight_scale" type="float" default="1.0" />
 			<description>
-				Adds a new point at the given position with the given identifier. The [code]id[/code] must be 0 or larger, and the [code]weight_scale[/code] must be 1 or larger.
+				Adds a new point at the given position with the given identifier. The [code]id[/code] must be 0 or larger, and the [code]weight_scale[/code] must be 0.0 or greater.
 				The [code]weight_scale[/code] is multiplied by the result of [method _compute_cost] when determining the overall cost of traveling across a segment from a neighboring point to this point. Thus, all else being equal, the algorithm prefers points with lower [code]weight_scale[/code]s to form a path.
 				[codeblocks]
 				[gdscript]


### PR DESCRIPTION
Allow AStar2D/AStar3D zero point weight.

Limit was set to 1 which seemed like an arbitrary value as lower values down to zero can be useful for common gameplay navigation elements like teleports. Tests with official Godot AStar demo projects worked fine with 0.0 weight.

proposals [#4477](https://github.com/godotengine/godot-proposals/issues/4477)

*Bugsquad edit:*
- Closes https://github.com/godotengine/godot-proposals/issues/4477