### PR TITLE
[3.x] [Debugger] Add --debug-server CLI option.

### DIFF
--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -244,7 +244,7 @@ protected:
 	static void _bind_methods();
 
 public:
-	void start();
+	void start(int p_port = -1, const IP_Address &p_bind_address = IP_Address("*"));
 	void pause();
 	void unpause();
 	void stop();


### PR DESCRIPTION
Automatically starts the editor debug server at given `<IP>:<PORT>`.

E.g.:
```bash
# Run editor and debug server listening on any interface, port 8080
godot3 -e --path proj/proj_empty --debug-server *:8080

# Run the godot project connecting to that debug server.
godot3 --path proj/proj_empty --remote-debug 127.0.0.1:8080
```

`3.x` bits of #52226 .