### PR TITLE
Physics Interpolation - Reset on adding child to SceneTree

### DIFF
--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -101,6 +101,15 @@ void VisualInstance::_notification(int p_what) {
 				if (!_is_using_identity_transform()) {
 					Transform gt = get_global_transform();
 					VisualServer::get_singleton()->instance_set_transform(instance, gt);
+
+					// For instance when first adding to the tree, when the previous transform is
+					// unset, to prevent streaking from the origin.
+					if (_is_physics_interpolation_reset_requested()) {
+						if (_is_vi_visible()) {
+							_notification(NOTIFICATION_RESET_PHYSICS_INTERPOLATION);
+						}
+						_set_physics_interpolation_reset_requested(false);
+					}
 				}
 			}
 		} break;

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -151,6 +151,9 @@ private:
 		// is switched on.
 		bool physics_interpolated : 1;
 
+		// We can auto-reset physics interpolation when e.g. adding a node for the first time
+		bool physics_interpolation_reset_requested : 1;
+
 		// Most nodes need not be interpolated in the scene tree, physics interpolation
 		// is normally only needed in the VisualServer. However if we need to read the
 		// interpolated transform of a node in the SceneTree, it is necessary to duplicate
@@ -197,6 +200,7 @@ private:
 	void _propagate_exit_tree();
 	void _propagate_after_exit_branch(bool p_exiting_tree);
 	void _propagate_physics_interpolated(bool p_interpolated);
+	void _propagate_physics_interpolation_reset_requested();
 	void _print_stray_nodes();
 	void _propagate_pause_owner(Node *p_owner);
 	Array _get_node_and_resource(const NodePath &p_path);
@@ -243,6 +247,8 @@ protected:
 	void _set_name_nocheck(const StringName &p_name);
 	void _set_physics_interpolated_client_side(bool p_enable);
 	bool _is_physics_interpolated_client_side() const { return data.physics_interpolated_client_side; }
+	void _set_physics_interpolation_reset_requested(bool p_enable);
+	bool _is_physics_interpolation_reset_requested() const { return data.physics_interpolation_reset_requested; }
 	void _set_use_identity_transform(bool p_enable);
 	bool _is_using_identity_transform() const { return data.use_identity_transform; }
 


### PR DESCRIPTION
For convenience, branches added to the SceneTree now have physics interpolation reset after the first update of the transform to the VisualServer.

## Notes
* This isn't a bug fix, the instructions are currently to call teleport (`reset_physics_interpolation`) when first adding, however it is a quality of life improvement and reduces boiler plate code.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
