### PR TITLE
Make import defaults inspector honor property style settings

### DIFF
--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -81,6 +81,11 @@ protected:
 
 void ImportDefaultsEditor::_notification(int p_what) {
 	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
+		} break;
+
 		case NOTIFICATION_PREDELETE: {
 			inspector->edit(nullptr);
 		} break;


### PR DESCRIPTION
Make the inspector in "Import Defaults" tab honor property name style settings.