### PR TITLE
[3.x] Make import defaults inspector honor property style settings

### DIFF
--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -70,10 +70,15 @@ protected:
 };
 
 void ImportDefaultsEditor::_notification(int p_what) {
-	if (p_what == NOTIFICATION_PREDELETE) {
-		if (inspector) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
+			inspector->set_property_name_style(EditorPropertyNameProcessor::get_settings_style());
+		} break;
+
+		case NOTIFICATION_PREDELETE: {
 			inspector->edit(nullptr);
-		}
+		} break;
 	}
 }
 


### PR DESCRIPTION
`3.x` version of #60823

Also removed the null check around `inspector` in `NOTIFICATION_PREDELETE`. The variable is assigned in the constructor and never re-assigned anywhere else. The check does not exist on `master` either.