### PR TITLE
Rename profiler "Idle Time" to "Process Time" (3.x)

### DIFF
--- a/core/script_debugger_local.cpp
+++ b/core/script_debugger_local.cpp
@@ -276,9 +276,9 @@ struct _ScriptDebuggerLocalProfileInfoSort {
 	}
 };
 
-void ScriptDebuggerLocal::profiling_set_frame_times(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) {
+void ScriptDebuggerLocal::profiling_set_frame_times(float p_frame_time, float p_process_time, float p_physics_time, float p_physics_frame_time) {
 	frame_time = p_frame_time;
-	idle_time = p_idle_time;
+	process_time = p_process_time;
 	physics_time = p_physics_time;
 	physics_frame_time = p_physics_frame_time;
 }
@@ -338,7 +338,7 @@ void ScriptDebuggerLocal::profiling_start() {
 	pinfo.resize(32768);
 	frame_time = 0;
 	physics_time = 0;
-	idle_time = 0;
+	process_time = 0;
 	physics_frame_time = 0;
 }
 

--- a/core/script_debugger_local.h
+++ b/core/script_debugger_local.h
@@ -36,7 +36,7 @@
 
 class ScriptDebuggerLocal : public ScriptDebugger {
 	bool profiling;
-	float frame_time, idle_time, physics_time, physics_frame_time;
+	float frame_time, process_time, physics_time, physics_frame_time;
 	uint64_t idle_accum;
 	String target_function;
 	Map<String, String> options;
@@ -58,7 +58,7 @@ public:
 
 	virtual void profiling_start();
 	virtual void profiling_end();
-	virtual void profiling_set_frame_times(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time);
+	virtual void profiling_set_frame_times(float p_frame_time, float p_process_time, float p_physics_time, float p_physics_frame_time);
 
 	ScriptDebuggerLocal();
 };

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -462,7 +462,7 @@ public:
 	virtual void add_profiling_frame_data(const StringName &p_name, const Array &p_data) = 0;
 	virtual void profiling_start() = 0;
 	virtual void profiling_end() = 0;
-	virtual void profiling_set_frame_times(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) = 0;
+	virtual void profiling_set_frame_times(float p_frame_time, float p_process_time, float p_physics_time, float p_physics_frame_time) = 0;
 
 	ScriptDebugger();
 	virtual ~ScriptDebugger() { singleton = nullptr; }

--- a/editor/editor_profiler.h
+++ b/editor/editor_profiler.h
@@ -49,7 +49,7 @@ public:
 
 		int frame_number;
 		float frame_time;
-		float idle_time;
+		float process_time;
 		float physics_time;
 		float physics_frame_time;
 

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -1004,7 +1004,7 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		metric.valid = true;
 		metric.frame_number = p_data[0];
 		metric.frame_time = p_data[1];
-		metric.idle_time = p_data[2];
+		metric.process_time = p_data[2];
 		metric.physics_time = p_data[3];
 		metric.physics_frame_time = p_data[4];
 		int frame_data_amount = p_data[6];
@@ -1027,10 +1027,10 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 
 			frame_time.items.push_back(item);
 
-			item.name = "Idle Time";
-			item.total = metric.idle_time;
+			item.name = "Process Time";
+			item.total = metric.process_time;
 			item.self = item.total;
-			item.signature = "idle_time";
+			item.signature = "process_time";
 
 			frame_time.items.push_back(item);
 

--- a/scene/debugger/script_debugger_remote.cpp
+++ b/scene/debugger/script_debugger_remote.cpp
@@ -756,11 +756,11 @@ void ScriptDebuggerRemote::_poll_events() {
 			profiler_function_signature_map.clear();
 			profiling = true;
 			frame_time = 0;
-			idle_time = 0;
+			process_time = 0;
 			physics_time = 0;
 			physics_frame_time = 0;
 
-			print_line("PROFILING ALRIGHT!");
+			print_verbose("Starting profiling.");
 
 		} else if (command == "stop_profiling") {
 			for (int i = 0; i < ScriptServer::get_language_count(); i++) {
@@ -768,7 +768,7 @@ void ScriptDebuggerRemote::_poll_events() {
 			}
 			profiling = false;
 			_send_profiling_data(false);
-			print_line("PROFILING END!");
+			print_verbose("Ending profiling.");
 		} else if (command == "start_network_profiling") {
 			multiplayer->profiling_start();
 			profiling_network = true;
@@ -875,7 +875,7 @@ void ScriptDebuggerRemote::_send_profiling_data(bool p_for_frame) {
 
 	packet_peer_stream->put_var(Engine::get_singleton()->get_idle_frames()); //total frame time
 	packet_peer_stream->put_var(frame_time); //total frame time
-	packet_peer_stream->put_var(idle_time); //idle frame time
+	packet_peer_stream->put_var(process_time); //idle frame time
 	packet_peer_stream->put_var(physics_time); //fixed frame time
 	packet_peer_stream->put_var(physics_frame_time); //fixed frame time
 
@@ -1162,9 +1162,9 @@ void ScriptDebuggerRemote::profiling_end() {
 	//ignores this, uses it via connection
 }
 
-void ScriptDebuggerRemote::profiling_set_frame_times(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time) {
+void ScriptDebuggerRemote::profiling_set_frame_times(float p_frame_time, float p_process_time, float p_physics_time, float p_physics_frame_time) {
 	frame_time = p_frame_time;
-	idle_time = p_idle_time;
+	process_time = p_process_time;
 	physics_time = p_physics_time;
 	physics_frame_time = p_physics_frame_time;
 }

--- a/scene/debugger/script_debugger_remote.h
+++ b/scene/debugger/script_debugger_remote.h
@@ -56,7 +56,7 @@ class ScriptDebuggerRemote : public ScriptDebugger {
 	Vector<MultiplayerAPI::ProfilingInfo> network_profile_info;
 
 	Map<StringName, int> profiler_function_signature_map;
-	float frame_time, idle_time, physics_time, physics_frame_time;
+	float frame_time, process_time, physics_time, physics_frame_time;
 
 	bool profiling;
 	bool profiling_network;
@@ -189,7 +189,7 @@ public:
 
 	virtual void profiling_start();
 	virtual void profiling_end();
-	virtual void profiling_set_frame_times(float p_frame_time, float p_idle_time, float p_physics_time, float p_physics_frame_time);
+	virtual void profiling_set_frame_times(float p_frame_time, float p_process_time, float p_physics_time, float p_physics_frame_time);
 
 	virtual void set_skip_breakpoints(bool p_skip_breakpoints);
 


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/60802.

References to "idle time" are progressively being replaced by "process time" throughout the engine to avoid confusion.

This also changes some debug prints to be printed only when verbose mode is enabled (like in `master`).