### PR TITLE
[4.x] Add viewport content scale

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -681,7 +681,7 @@ void Window::_update_viewport_size() {
 
 			} break;
 			case CONTENT_SCALE_MODE_VIEWPORT: {
-				final_size = viewport_size;
+				final_size = (viewport_size / content_scale_factor).floor();
 				attach_to_screen_rect = Rect2(margin, screen_size);
 
 			} break;


### PR DESCRIPTION
This PR should make it possible to scale up content with the content scale factor when the stretch mode is set to viewport. This should fix #60801.

I am fairly certain that I had a reason why I didn't include this in #52170, but really can't remember what it was. Did some quick testing and couldn't find any obvious major problems with this. 🤷

Test project: https://github.com/Calinou/godot-demo-projects/tree/multiple-resolutions-update-to-4.0/gui/multiple_resolutions?rgh-link-date=2022-05-05T17%3A37%3A13Z