### PR TITLE
Add `MeshInstance3D.face_smoothing` and `flip_faces`

### DIFF
--- a/doc/classes/MeshInstance3D.xml
+++ b/doc/classes/MeshInstance3D.xml
@@ -95,6 +95,13 @@
 		</method>
 	</methods>
 	<members>
+		<member name="face_smoothing" type="int" setter="set_face_smoothing" getter="get_face_smoothing" enum="MeshInstance3D.FaceSmoothing" default="0">
+			Which mode in which to render mesh faces.
+		</member>
+		<member name="flip_faces" type="bool" setter="set_flip_faces" getter="get_flip_faces" default="false">
+			If set, the order of the vertices in each triangle are reversed resulting in the backside of the mesh being drawn.
+			This gives the same result as using [constant BaseMaterial3D.CULL_FRONT] in [member BaseMaterial3D.cull_mode].
+		</member>
 		<member name="mesh" type="Mesh" setter="set_mesh" getter="get_mesh">
 			The [Mesh] resource for the instance.
 		</member>
@@ -105,4 +112,15 @@
 			Sets the skin to be used by this instance.
 		</member>
 	</members>
+	<constants>
+		<constant name="SMOOTHING_DEFAULT" value="0" enum="FaceSmoothing">
+			Renders the mesh with original normals.
+		</constant>
+		<constant name="SMOOTHING_FORCE_FLAT" value="1" enum="FaceSmoothing">
+			Renders the mesh with a flat shaded look.
+		</constant>
+		<constant name="SMOOTHING_FORCE_SMOOTH" value="2" enum="FaceSmoothing">
+			Renders the mesh with a smooth effect making it seem rounded.
+		</constant>
+	</constants>
 </class>

--- a/scene/3d/mesh_instance_3d.h
+++ b/scene/3d/mesh_instance_3d.h
@@ -39,6 +39,20 @@ class SkinReference;
 class MeshInstance3D : public GeometryInstance3D {
 	GDCLASS(MeshInstance3D, GeometryInstance3D);
 
+public:
+	enum FaceSmoothing {
+		SMOOTHING_DEFAULT,
+		SMOOTHING_FORCE_FLAT,
+		SMOOTHING_FORCE_SMOOTH
+	};
+
+private:
+	mutable RID visible_mesh;
+	bool flip_faces = false;
+	FaceSmoothing face_smoothing = SMOOTHING_DEFAULT;
+
+	void _update_modifiers();
+
 protected:
 	Ref<Mesh> mesh;
 	Ref<Skin> skin;
@@ -71,6 +85,12 @@ public:
 	void set_skeleton_path(const NodePath &p_skeleton);
 	NodePath get_skeleton_path();
 
+	void set_face_smoothing(FaceSmoothing p_face_smoothing);
+	FaceSmoothing get_face_smoothing() const;
+
+	void set_flip_faces(bool p_enable);
+	bool get_flip_faces() const;
+
 	int get_blend_shape_count() const;
 	int find_blend_shape_by_name(const StringName &p_name);
 	float get_blend_shape_value(int p_blend_shape) const;
@@ -97,5 +117,7 @@ public:
 	MeshInstance3D();
 	~MeshInstance3D();
 };
+
+VARIANT_ENUM_CAST(MeshInstance3D::FaceSmoothing);
 
 #endif


### PR DESCRIPTION
`MeshInstance3D.face_smoothing` is the Mesh Instance counterpart to `CSGPrimitive3D.smooth_faces`, which will be updated to have the same enum later.

`MeshInstance3D.flip_faces` serves the same purpose as `PrimitiveMesh.flip_faces` and `CSGPrimitive3D.flip_faces` but for use on other Mesh types.

Todo (later PR?):
- Tangent regeneration
- Better documentation

![image](https://i.gyazo.com/79610fd81ab6e96777bd5549c571c728.gif)
