### PR TITLE
Push `HSV2RGB/RGB2HSV` to `ColorFunc` (from `VecFunc`) in visual shaders

### DIFF
--- a/doc/classes/VisualShaderNodeColorFunc.xml
+++ b/doc/classes/VisualShaderNodeColorFunc.xml
@@ -24,7 +24,13 @@
 			return vec3(max3, max3, max3);
 			[/codeblock]
 		</constant>
-		<constant name="FUNC_SEPIA" value="1" enum="Function">
+		<constant name="FUNC_HSV2RGB" value="1" enum="Function">
+			Converts HSV vector to RGB equivalent.
+		</constant>
+		<constant name="FUNC_RGB2HSV" value="2" enum="Function">
+			Converts RGB vector to HSV equivalent.
+		</constant>
+		<constant name="FUNC_SEPIA" value="3" enum="Function">
 			Applies sepia tone effect using the following formula:
 			[codeblock]
 			vec3 c = input;
@@ -34,7 +40,7 @@
 			return vec3(r, g, b);
 			[/codeblock]
 		</constant>
-		<constant name="FUNC_MAX" value="2" enum="Function">
+		<constant name="FUNC_MAX" value="4" enum="Function">
 			Represents the size of the [enum Function] enum.
 		</constant>
 	</constants>

--- a/doc/classes/VisualShaderNodeVectorFunc.xml
+++ b/doc/classes/VisualShaderNodeVectorFunc.xml
@@ -26,100 +26,94 @@
 		<constant name="FUNC_RECIPROCAL" value="3" enum="Function">
 			Returns [code]1/vector[/code].
 		</constant>
-		<constant name="FUNC_RGB2HSV" value="4" enum="Function">
-			Converts RGB vector to HSV equivalent.
-		</constant>
-		<constant name="FUNC_HSV2RGB" value="5" enum="Function">
-			Converts HSV vector to RGB equivalent.
-		</constant>
-		<constant name="FUNC_ABS" value="6" enum="Function">
+		<constant name="FUNC_ABS" value="4" enum="Function">
 			Returns the absolute value of the parameter.
 		</constant>
-		<constant name="FUNC_ACOS" value="7" enum="Function">
+		<constant name="FUNC_ACOS" value="5" enum="Function">
 			Returns the arc-cosine of the parameter.
 		</constant>
-		<constant name="FUNC_ACOSH" value="8" enum="Function">
+		<constant name="FUNC_ACOSH" value="6" enum="Function">
 			Returns the inverse hyperbolic cosine of the parameter.
 		</constant>
-		<constant name="FUNC_ASIN" value="9" enum="Function">
+		<constant name="FUNC_ASIN" value="7" enum="Function">
 			Returns the arc-sine of the parameter.
 		</constant>
-		<constant name="FUNC_ASINH" value="10" enum="Function">
+		<constant name="FUNC_ASINH" value="8" enum="Function">
 			Returns the inverse hyperbolic sine of the parameter.
 		</constant>
-		<constant name="FUNC_ATAN" value="11" enum="Function">
+		<constant name="FUNC_ATAN" value="9" enum="Function">
 			Returns the arc-tangent of the parameter.
 		</constant>
-		<constant name="FUNC_ATANH" value="12" enum="Function">
+		<constant name="FUNC_ATANH" value="10" enum="Function">
 			Returns the inverse hyperbolic tangent of the parameter.
 		</constant>
-		<constant name="FUNC_CEIL" value="13" enum="Function">
+		<constant name="FUNC_CEIL" value="11" enum="Function">
 			Finds the nearest integer that is greater than or equal to the parameter.
 		</constant>
-		<constant name="FUNC_COS" value="14" enum="Function">
+		<constant name="FUNC_COS" value="12" enum="Function">
 			Returns the cosine of the parameter.
 		</constant>
-		<constant name="FUNC_COSH" value="15" enum="Function">
+		<constant name="FUNC_COSH" value="13" enum="Function">
 			Returns the hyperbolic cosine of the parameter.
 		</constant>
-		<constant name="FUNC_DEGREES" value="16" enum="Function">
+		<constant name="FUNC_DEGREES" value="14" enum="Function">
 			Converts a quantity in radians to degrees.
 		</constant>
-		<constant name="FUNC_EXP" value="17" enum="Function">
+		<constant name="FUNC_EXP" value="15" enum="Function">
 			Base-e Exponential.
 		</constant>
-		<constant name="FUNC_EXP2" value="18" enum="Function">
+		<constant name="FUNC_EXP2" value="16" enum="Function">
 			Base-2 Exponential.
 		</constant>
-		<constant name="FUNC_FLOOR" value="19" enum="Function">
+		<constant name="FUNC_FLOOR" value="17" enum="Function">
 			Finds the nearest integer less than or equal to the parameter.
 		</constant>
-		<constant name="FUNC_FRAC" value="20" enum="Function">
+		<constant name="FUNC_FRAC" value="18" enum="Function">
 			Computes the fractional part of the argument.
 		</constant>
-		<constant name="FUNC_INVERSE_SQRT" value="21" enum="Function">
+		<constant name="FUNC_INVERSE_SQRT" value="19" enum="Function">
 			Returns the inverse of the square root of the parameter.
 		</constant>
-		<constant name="FUNC_LOG" value="22" enum="Function">
+		<constant name="FUNC_LOG" value="20" enum="Function">
 			Natural logarithm.
 		</constant>
-		<constant name="FUNC_LOG2" value="23" enum="Function">
+		<constant name="FUNC_LOG2" value="21" enum="Function">
 			Base-2 logarithm.
 		</constant>
-		<constant name="FUNC_RADIANS" value="24" enum="Function">
+		<constant name="FUNC_RADIANS" value="22" enum="Function">
 			Converts a quantity in degrees to radians.
 		</constant>
-		<constant name="FUNC_ROUND" value="25" enum="Function">
+		<constant name="FUNC_ROUND" value="23" enum="Function">
 			Finds the nearest integer to the parameter.
 		</constant>
-		<constant name="FUNC_ROUNDEVEN" value="26" enum="Function">
+		<constant name="FUNC_ROUNDEVEN" value="24" enum="Function">
 			Finds the nearest even integer to the parameter.
 		</constant>
-		<constant name="FUNC_SIGN" value="27" enum="Function">
+		<constant name="FUNC_SIGN" value="25" enum="Function">
 			Extracts the sign of the parameter, i.e. returns [code]-1[/code] if the parameter is negative, [code]1[/code] if it's positive and [code]0[/code] otherwise.
 		</constant>
-		<constant name="FUNC_SIN" value="28" enum="Function">
+		<constant name="FUNC_SIN" value="26" enum="Function">
 			Returns the sine of the parameter.
 		</constant>
-		<constant name="FUNC_SINH" value="29" enum="Function">
+		<constant name="FUNC_SINH" value="27" enum="Function">
 			Returns the hyperbolic sine of the parameter.
 		</constant>
-		<constant name="FUNC_SQRT" value="30" enum="Function">
+		<constant name="FUNC_SQRT" value="28" enum="Function">
 			Returns the square root of the parameter.
 		</constant>
-		<constant name="FUNC_TAN" value="31" enum="Function">
+		<constant name="FUNC_TAN" value="29" enum="Function">
 			Returns the tangent of the parameter.
 		</constant>
-		<constant name="FUNC_TANH" value="32" enum="Function">
+		<constant name="FUNC_TANH" value="30" enum="Function">
 			Returns the hyperbolic tangent of the parameter.
 		</constant>
-		<constant name="FUNC_TRUNC" value="33" enum="Function">
+		<constant name="FUNC_TRUNC" value="31" enum="Function">
 			Returns a value equal to the nearest integer to the parameter whose absolute value is not larger than the absolute value of the parameter.
 		</constant>
-		<constant name="FUNC_ONEMINUS" value="34" enum="Function">
+		<constant name="FUNC_ONEMINUS" value="32" enum="Function">
 			Returns [code]1.0 - vector[/code].
 		</constant>
-		<constant name="FUNC_MAX" value="35" enum="Function">
+		<constant name="FUNC_MAX" value="33" enum="Function">
 			Represents the size of the [enum Function] enum.
 		</constant>
 	</constants>

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -5027,8 +5027,8 @@ VisualShaderEditor::VisualShaderEditor() {
 	add_options.push_back(AddOption("ColorOp", "Color", "Common", "VisualShaderNodeColorOp", TTR("Color operator."), {}, VisualShaderNode::PORT_TYPE_VECTOR_3D));
 
 	add_options.push_back(AddOption("Grayscale", "Color", "Functions", "VisualShaderNodeColorFunc", TTR("Grayscale function."), { VisualShaderNodeColorFunc::FUNC_GRAYSCALE }, VisualShaderNode::PORT_TYPE_VECTOR_3D));
-	add_options.push_back(AddOption("HSV2RGB", "Color", "Functions", "VisualShaderNodeVectorFunc", TTR("Converts HSV vector to RGB equivalent."), { VisualShaderNodeVectorFunc::FUNC_HSV2RGB, VisualShaderNodeVectorFunc::OP_TYPE_VECTOR_3D }, VisualShaderNode::PORT_TYPE_VECTOR_3D));
-	add_options.push_back(AddOption("RGB2HSV", "Color", "Functions", "VisualShaderNodeVectorFunc", TTR("Converts RGB vector to HSV equivalent."), { VisualShaderNodeVectorFunc::FUNC_RGB2HSV, VisualShaderNodeVectorFunc::OP_TYPE_VECTOR_3D }, VisualShaderNode::PORT_TYPE_VECTOR_3D));
+	add_options.push_back(AddOption("HSV2RGB", "Color", "Functions", "VisualShaderNodeColorFunc", TTR("Converts HSV vector to RGB equivalent."), { VisualShaderNodeColorFunc::FUNC_HSV2RGB, VisualShaderNodeVectorFunc::OP_TYPE_VECTOR_3D }, VisualShaderNode::PORT_TYPE_VECTOR_3D));
+	add_options.push_back(AddOption("RGB2HSV", "Color", "Functions", "VisualShaderNodeColorFunc", TTR("Converts RGB vector to HSV equivalent."), { VisualShaderNodeColorFunc::FUNC_RGB2HSV, VisualShaderNodeVectorFunc::OP_TYPE_VECTOR_3D }, VisualShaderNode::PORT_TYPE_VECTOR_3D));
 	add_options.push_back(AddOption("Sepia", "Color", "Functions", "VisualShaderNodeColorFunc", TTR("Sepia function."), { VisualShaderNodeColorFunc::FUNC_SEPIA }, VisualShaderNode::PORT_TYPE_VECTOR_3D));
 
 	add_options.push_back(AddOption("Burn", "Color", "Operators", "VisualShaderNodeColorOp", TTR("Burn operator."), { VisualShaderNodeColorOp::OP_BURN }, VisualShaderNode::PORT_TYPE_VECTOR_3D));

--- a/scene/resources/visual_shader_nodes.cpp
+++ b/scene/resources/visual_shader_nodes.cpp
@@ -2608,8 +2608,6 @@ String VisualShaderNodeVectorFunc::generate_code(Shader::Mode p_mode, VisualShad
 		"", // FUNC_SATURATE
 		"-($)",
 		"1.0 / ($)",
-		"", // FUNC_RGB2HSV
-		"", // FUNC_HSV2RGB
 		"abs($)",
 		"acos($)",
 		"acosh($)",
@@ -2667,43 +2665,7 @@ String VisualShaderNodeVectorFunc::generate_code(Shader::Mode p_mode, VisualShad
 		return "	" + p_output_vars[0] + " = " + code.replace("$", p_input_vars[0]) + ";\n";
 	}
 
-	String code;
-
-	if (func == FUNC_RGB2HSV) {
-		if (op_type == OP_TYPE_VECTOR_2D) { // Not supported.
-			return "	" + p_output_vars[0] + " = vec2(0.0);\n";
-		}
-		if (op_type == OP_TYPE_VECTOR_4D) { // Not supported.
-			return "	" + p_output_vars[0] + " = vec4(0.0);\n";
-		}
-		code += "	{\n";
-		code += "		vec3 c = " + p_input_vars[0] + ";\n";
-		code += "		vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);\n";
-		code += "		vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));\n";
-		code += "		vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));\n";
-		code += "		float d = q.x - min(q.w, q.y);\n";
-		code += "		float e = 1.0e-10;\n";
-		code += "		" + p_output_vars[0] + " = vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);\n";
-		code += "	}\n";
-	} else if (func == FUNC_HSV2RGB) {
-		if (op_type == OP_TYPE_VECTOR_2D) { // Not supported.
-			return "	" + p_output_vars[0] + " = vec2(0.0);\n";
-		}
-		if (op_type == OP_TYPE_VECTOR_4D) { // Not supported.
-			return "	" + p_output_vars[0] + " = vec4(0.0);\n";
-		}
-		code += "	{\n";
-		code += "		vec3 c = " + p_input_vars[0] + ";\n";
-		code += "		vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);\n";
-		code += "		vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);\n";
-		code += "		" + p_output_vars[0] + " = c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);\n";
-		code += "	}\n";
-
-	} else {
-		code += "	" + p_output_vars[0] + " = " + String(funcs[func]).replace("$", p_input_vars[0]) + ";\n";
-	}
-
-	return code;
+	return "	" + p_output_vars[0] + " = " + String(funcs[func]).replace("$", p_input_vars[0]) + ";\n";
 }
 
 void VisualShaderNodeVectorFunc::set_op_type(OpType p_op_type) {
@@ -2733,13 +2695,6 @@ void VisualShaderNodeVectorFunc::set_function(Function p_func) {
 	if (func == p_func) {
 		return;
 	}
-	if (p_func == FUNC_RGB2HSV) {
-		simple_decl = false;
-	} else if (p_func == FUNC_HSV2RGB) {
-		simple_decl = false;
-	} else {
-		simple_decl = true;
-	}
 	func = p_func;
 	emit_changed();
 }
@@ -2754,34 +2709,16 @@ Vector<StringName> VisualShaderNodeVectorFunc::get_editable_properties() const {
 	return props;
 }
 
-String VisualShaderNodeVectorFunc::get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const {
-	bool invalid_type = false;
-
-	if (op_type == OP_TYPE_VECTOR_2D || op_type == OP_TYPE_VECTOR_4D) {
-		if (func == FUNC_RGB2HSV || func == FUNC_HSV2RGB) {
-			invalid_type = true;
-		}
-	}
-
-	if (invalid_type) {
-		return RTR("Invalid function for that type.");
-	}
-
-	return String();
-}
-
 void VisualShaderNodeVectorFunc::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_function", "func"), &VisualShaderNodeVectorFunc::set_function);
 	ClassDB::bind_method(D_METHOD("get_function"), &VisualShaderNodeVectorFunc::get_function);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "function", PROPERTY_HINT_ENUM, "Normalize,Saturate,Negate,Reciprocal,RGB2HSV,HSV2RGB,Abs,ACos,ACosH,ASin,ASinH,ATan,ATanH,Ceil,Cos,CosH,Degrees,Exp,Exp2,Floor,Frac,InverseSqrt,Log,Log2,Radians,Round,RoundEven,Sign,Sin,SinH,Sqrt,Tan,TanH,Trunc,OneMinus"), "set_function", "get_function");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "function", PROPERTY_HINT_ENUM, "Normalize,Saturate,Negate,Reciprocal,Abs,ACos,ACosH,ASin,ASinH,ATan,ATanH,Ceil,Cos,CosH,Degrees,Exp,Exp2,Floor,Frac,InverseSqrt,Log,Log2,Radians,Round,RoundEven,Sign,Sin,SinH,Sqrt,Tan,TanH,Trunc,OneMinus"), "set_function", "get_function");
 
 	BIND_ENUM_CONSTANT(FUNC_NORMALIZE);
 	BIND_ENUM_CONSTANT(FUNC_SATURATE);
 	BIND_ENUM_CONSTANT(FUNC_NEGATE);
 	BIND_ENUM_CONSTANT(FUNC_RECIPROCAL);
-	BIND_ENUM_CONSTANT(FUNC_RGB2HSV);
-	BIND_ENUM_CONSTANT(FUNC_HSV2RGB);
 	BIND_ENUM_CONSTANT(FUNC_ABS);
 	BIND_ENUM_CONSTANT(FUNC_ACOS);
 	BIND_ENUM_CONSTANT(FUNC_ACOSH);
@@ -2872,6 +2809,25 @@ String VisualShaderNodeColorFunc::generate_code(Shader::Mode p_mode, VisualShade
 			code += "		" + p_output_vars[0] + " = vec3(max2, max2, max2);\n";
 			code += "	}\n";
 			break;
+		case FUNC_HSV2RGB:
+			code += "	{\n";
+			code += "		vec3 c = " + p_input_vars[0] + ";\n";
+			code += "		vec4 K = vec4(1.0, 2.0 / 3.0, 1.0 / 3.0, 3.0);\n";
+			code += "		vec3 p = abs(fract(c.xxx + K.xyz) * 6.0 - K.www);\n";
+			code += "		" + p_output_vars[0] + " = c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);\n";
+			code += "	}\n";
+			break;
+		case FUNC_RGB2HSV:
+			code += "	{\n";
+			code += "		vec3 c = " + p_input_vars[0] + ";\n";
+			code += "		vec4 K = vec4(0.0, -1.0 / 3.0, 2.0 / 3.0, -1.0);\n";
+			code += "		vec4 p = mix(vec4(c.bg, K.wz), vec4(c.gb, K.xy), step(c.b, c.g));\n";
+			code += "		vec4 q = mix(vec4(p.xyw, c.r), vec4(c.r, p.yzx), step(p.x, c.r));\n";
+			code += "		float d = q.x - min(q.w, q.y);\n";
+			code += "		float e = 1.0e-10;\n";
+			code += "		" + p_output_vars[0] + " = vec3(abs(q.z + (q.w - q.y) / (6.0 * d + e)), d / (q.x + e), q.x);\n";
+			code += "	}\n";
+			break;
 		case FUNC_SEPIA:
 			code += "	{\n";
 			code += "		vec3 c = " + p_input_vars[0] + ";\n";
@@ -2911,9 +2867,11 @@ void VisualShaderNodeColorFunc::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_function", "func"), &VisualShaderNodeColorFunc::set_function);
 	ClassDB::bind_method(D_METHOD("get_function"), &VisualShaderNodeColorFunc::get_function);
 
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "function", PROPERTY_HINT_ENUM, "Grayscale,Sepia"), "set_function", "get_function");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "function", PROPERTY_HINT_ENUM, "Grayscale,HSV2RGB,RGB2HSV,Sepia"), "set_function", "get_function");
 
 	BIND_ENUM_CONSTANT(FUNC_GRAYSCALE);
+	BIND_ENUM_CONSTANT(FUNC_HSV2RGB);
+	BIND_ENUM_CONSTANT(FUNC_RGB2HSV);
 	BIND_ENUM_CONSTANT(FUNC_SEPIA);
 	BIND_ENUM_CONSTANT(FUNC_MAX);
 }

--- a/scene/resources/visual_shader_nodes.h
+++ b/scene/resources/visual_shader_nodes.h
@@ -1039,8 +1039,6 @@ public:
 		FUNC_SATURATE,
 		FUNC_NEGATE,
 		FUNC_RECIPROCAL,
-		FUNC_RGB2HSV,
-		FUNC_HSV2RGB,
 		FUNC_ABS,
 		FUNC_ACOS,
 		FUNC_ACOSH,
@@ -1095,7 +1093,6 @@ public:
 	Function get_function() const;
 
 	virtual Vector<StringName> get_editable_properties() const override;
-	String get_warning(Shader::Mode p_mode, VisualShader::Type p_type) const override;
 
 	VisualShaderNodeVectorFunc();
 };
@@ -1112,6 +1109,8 @@ class VisualShaderNodeColorFunc : public VisualShaderNode {
 public:
 	enum Function {
 		FUNC_GRAYSCALE,
+		FUNC_HSV2RGB,
+		FUNC_RGB2HSV,
 		FUNC_SEPIA,
 		FUNC_MAX,
 	};


### PR DESCRIPTION
By the logic, these sub-functions should be placed in that node instead of `VectorFunc`:

![image](https://user-images.githubusercontent.com/3036176/167242592-01e9eb8b-8cff-4b7c-b370-5a22a8d601f1.png)
