### PR TITLE
Portals - show gridmaps using global mode

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -74,6 +74,7 @@ bool GridMap::_set(const StringName &p_name, const Variant &p_value) {
 			bm.mesh = meshes[i];
 			ERR_CONTINUE(!bm.mesh.is_valid());
 			bm.instance = RID_PRIME(VS::get_singleton()->instance_create());
+			VS::get_singleton()->instance_set_portal_mode(bm.instance, VisualServer::InstancePortalMode::INSTANCE_PORTAL_MODE_GLOBAL);
 			VS::get_singleton()->get_singleton()->instance_set_base(bm.instance, bm.mesh->get_rid());
 			VS::get_singleton()->instance_attach_object_instance_id(bm.instance, get_instance_id());
 			if (is_inside_tree()) {
@@ -338,6 +339,7 @@ void GridMap::set_cell_item(int p_x, int p_y, int p_z, int p_item, int p_rot) {
 		if (st && st->is_debugging_collisions_hint()) {
 			g->collision_debug = RID_PRIME(VisualServer::get_singleton()->mesh_create());
 			g->collision_debug_instance = RID_PRIME(VisualServer::get_singleton()->instance_create());
+			VS::get_singleton()->instance_set_portal_mode(g->collision_debug_instance, VisualServer::InstancePortalMode::INSTANCE_PORTAL_MODE_GLOBAL);
 			VisualServer::get_singleton()->instance_set_base(g->collision_debug_instance, g->collision_debug);
 		}
 
@@ -558,6 +560,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 
 			RID instance = RID_PRIME(VS::get_singleton()->instance_create());
 			VS::get_singleton()->instance_set_base(instance, mm);
+			VS::get_singleton()->instance_set_portal_mode(instance, VisualServer::InstancePortalMode::INSTANCE_PORTAL_MODE_GLOBAL);
 
 			if (is_inside_tree()) {
 				VS::get_singleton()->instance_set_scenario(instance, get_world()->get_scenario());
@@ -1095,6 +1098,7 @@ void GridMap::make_baked_meshes(bool p_gen_lightmap_uv, float p_lightmap_uv_texe
 		BakedMesh bm;
 		bm.mesh = mesh;
 		bm.instance = RID_PRIME(VS::get_singleton()->instance_create());
+		VS::get_singleton()->instance_set_portal_mode(bm.instance, VisualServer::InstancePortalMode::INSTANCE_PORTAL_MODE_GLOBAL);
 		VS::get_singleton()->get_singleton()->instance_set_base(bm.instance, bm.mesh->get_rid());
 		VS::get_singleton()->instance_attach_object_instance_id(bm.instance, get_instance_id());
 		if (is_inside_tree()) {


### PR DESCRIPTION
Gridmaps did not previously show at all when portals were active, due to the instances being created defaulting to static mode, and not being converted during the room conversion stage.

This PR sets gridmap instances to global mode, which enables them to show up when portals are active (using frustum culling only, no occlusion).

Fixes #60833
(still needs documentation though)

## Notes
The previous state of gridmaps showing was not so much a bug as a conscious decision to deter users from using this combination. However #60833 suggests there may be use cases.

Properly supporting gridmaps would likely either involve:

1) Writing bespoke conversion code to work with the gridmap
2) Adding the ability to bake gridmaps to regular SceneTree nodes, so they could be converted as normal

(1) Would probably not be a practical approach for such a special case, so (2) would be far more reasonable.

* Setting gridmap instances to GLOBAL portal mode is somewhat of a bandaid, but is better than nothing, as it allows them to show up within a portalled scene. However there will be no occlusion culling, and the culling for GLOBAL instances isn't quite as efficient as through the BVH (the BVH is used when portals is not active, but GLOBAL instances just use `O(n)` culling).
* One danger here is that users may believe that gridmaps are fully supported with occlusion, which is not the case.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
