### PR TITLE
Add search methods for packed arrays

### DIFF
--- a/core/templates/cowdata.h
+++ b/core/templates/cowdata.h
@@ -183,6 +183,8 @@ public:
 	}
 
 	int find(const T &p_val, int p_from = 0) const;
+	int rfind(const T &p_val, int p_from = -1) const;
+	int count(const T &p_val) const;
 
 	_FORCE_INLINE_ CowData() {}
 	_FORCE_INLINE_ ~CowData();
@@ -347,6 +349,36 @@ int CowData<T>::find(const T &p_val, int p_from) const {
 	}
 
 	return ret;
+}
+
+template <class T>
+int CowData<T>::rfind(const T &p_val, int p_from) const {
+	const int s = size();
+
+	if (p_from < 0) {
+		p_from = s + p_from;
+	}
+	if (p_from < 0 || p_from >= s) {
+		p_from = s - 1;
+	}
+
+	for (int i = p_from; i >= 0; i--) {
+		if (get(i) == p_val) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+template <class T>
+int CowData<T>::count(const T &p_val) const {
+	int amount = 0;
+	for (int i = 0; i < size(); i++) {
+		if (get(i) == p_val) {
+			amount++;
+		}
+	}
+	return amount;
 }
 
 template <class T>

--- a/core/templates/vector.h
+++ b/core/templates/vector.h
@@ -92,6 +92,8 @@ public:
 	_FORCE_INLINE_ const T &operator[](int p_index) const { return _cowdata.get(p_index); }
 	Error insert(int p_pos, T p_val) { return _cowdata.insert(p_pos, p_val); }
 	int find(const T &p_val, int p_from = 0) const { return _cowdata.find(p_val, p_from); }
+	int rfind(const T &p_val, int p_from = -1) const { return _cowdata.rfind(p_val, p_from); }
+	int count(const T &p_val) const { return _cowdata.count(p_val); }
 
 	void append_array(Vector<T> p_other);
 

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1873,6 +1873,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedByteArray, sort, sarray(), varray());
 	bind_method(PackedByteArray, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedByteArray, duplicate, sarray(), varray());
+	bind_method(PackedByteArray, find, sarray("value", "from"), varray(0));
+	bind_method(PackedByteArray, rfind, sarray("value", "from"), varray(-1));
+	bind_method(PackedByteArray, count, sarray("value"), varray());
 
 	bind_function(PackedByteArray, get_string_from_ascii, _VariantCall::func_PackedByteArray_get_string_from_ascii, sarray(), varray());
 	bind_function(PackedByteArray, get_string_from_utf8, _VariantCall::func_PackedByteArray_get_string_from_utf8, sarray(), varray());
@@ -1935,6 +1938,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedInt32Array, sort, sarray(), varray());
 	bind_method(PackedInt32Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedInt32Array, duplicate, sarray(), varray());
+	bind_method(PackedInt32Array, find, sarray("value", "from"), varray(0));
+	bind_method(PackedInt32Array, rfind, sarray("value", "from"), varray(-1));
+	bind_method(PackedInt32Array, count, sarray("value"), varray());
 
 	/* Int64 Array */
 
@@ -1955,6 +1961,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedInt64Array, sort, sarray(), varray());
 	bind_method(PackedInt64Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedInt64Array, duplicate, sarray(), varray());
+	bind_method(PackedInt64Array, find, sarray("value", "from"), varray(0));
+	bind_method(PackedInt64Array, rfind, sarray("value", "from"), varray(-1));
+	bind_method(PackedInt64Array, count, sarray("value"), varray());
 
 	/* Float32 Array */
 
@@ -1975,6 +1984,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedFloat32Array, sort, sarray(), varray());
 	bind_method(PackedFloat32Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedFloat32Array, duplicate, sarray(), varray());
+	bind_method(PackedFloat32Array, find, sarray("value", "from"), varray(0));
+	bind_method(PackedFloat32Array, rfind, sarray("value", "from"), varray(-1));
+	bind_method(PackedFloat32Array, count, sarray("value"), varray());
 
 	/* Float64 Array */
 
@@ -1995,6 +2007,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedFloat64Array, sort, sarray(), varray());
 	bind_method(PackedFloat64Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedFloat64Array, duplicate, sarray(), varray());
+	bind_method(PackedFloat64Array, find, sarray("value", "from"), varray(0));
+	bind_method(PackedFloat64Array, rfind, sarray("value", "from"), varray(-1));
+	bind_method(PackedFloat64Array, count, sarray("value"), varray());
 
 	/* String Array */
 
@@ -2015,6 +2030,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedStringArray, sort, sarray(), varray());
 	bind_method(PackedStringArray, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedStringArray, duplicate, sarray(), varray());
+	bind_method(PackedStringArray, find, sarray("value", "from"), varray(0));
+	bind_method(PackedStringArray, rfind, sarray("value", "from"), varray(-1));
+	bind_method(PackedStringArray, count, sarray("value"), varray());
 
 	/* Vector2 Array */
 
@@ -2035,6 +2053,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedVector2Array, sort, sarray(), varray());
 	bind_method(PackedVector2Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedVector2Array, duplicate, sarray(), varray());
+	bind_method(PackedVector2Array, find, sarray("value", "from"), varray(0));
+	bind_method(PackedVector2Array, rfind, sarray("value", "from"), varray(-1));
+	bind_method(PackedVector2Array, count, sarray("value"), varray());
 
 	/* Vector3 Array */
 
@@ -2055,6 +2076,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedVector3Array, sort, sarray(), varray());
 	bind_method(PackedVector3Array, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedVector3Array, duplicate, sarray(), varray());
+	bind_method(PackedVector3Array, find, sarray("value", "from"), varray(0));
+	bind_method(PackedVector3Array, rfind, sarray("value", "from"), varray(-1));
+	bind_method(PackedVector3Array, count, sarray("value"), varray());
 
 	/* Color Array */
 
@@ -2075,6 +2099,9 @@ static void _register_variant_builtin_methods() {
 	bind_method(PackedColorArray, sort, sarray(), varray());
 	bind_method(PackedColorArray, bsearch, sarray("value", "before"), varray(true));
 	bind_method(PackedColorArray, duplicate, sarray(), varray());
+	bind_method(PackedColorArray, find, sarray("value", "from"), varray(0));
+	bind_method(PackedColorArray, rfind, sarray("value", "from"), varray(-1));
+	bind_method(PackedColorArray, count, sarray("value"), varray());
 
 	/* Register constants */
 

--- a/doc/classes/PackedByteArray.xml
+++ b/doc/classes/PackedByteArray.xml
@@ -61,6 +61,13 @@
 				Returns a new [PackedByteArray] with the data compressed. Set the compression mode using one of [enum File.CompressionMode]'s constants.
 			</description>
 		</method>
+		<method name="count" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="decode_double" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="byte_offset" type="int" />
@@ -257,6 +264,14 @@
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
 			</description>
 		</method>
+		<method name="find" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed.
+			</description>
+		</method>
 		<method name="get_string_from_ascii" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -350,6 +365,14 @@
 			<return type="void" />
 			<description>
 				Reverses the order of the elements in the array.
+			</description>
+		</method>
+		<method name="rfind" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedColorArray.xml
+++ b/doc/classes/PackedColorArray.xml
@@ -54,6 +54,13 @@
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
+		<method name="count" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="Color" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="duplicate">
 			<return type="PackedColorArray" />
 			<description>
@@ -65,6 +72,14 @@
 			<argument index="0" name="value" type="Color" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="Color" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed.
 			</description>
 		</method>
 		<method name="has" qualifiers="const">
@@ -113,6 +128,14 @@
 			<return type="void" />
 			<description>
 				Reverses the order of the elements in the array.
+			</description>
+		</method>
+		<method name="rfind" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="Color" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedFloat32Array.xml
+++ b/doc/classes/PackedFloat32Array.xml
@@ -55,6 +55,13 @@
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
+		<method name="count" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="float" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="duplicate">
 			<return type="PackedFloat32Array" />
 			<description>
@@ -66,6 +73,14 @@
 			<argument index="0" name="value" type="float" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="float" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed.
 			</description>
 		</method>
 		<method name="has" qualifiers="const">
@@ -114,6 +129,14 @@
 			<return type="void" />
 			<description>
 				Reverses the order of the elements in the array.
+			</description>
+		</method>
+		<method name="rfind" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="float" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedFloat64Array.xml
+++ b/doc/classes/PackedFloat64Array.xml
@@ -55,6 +55,13 @@
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
+		<method name="count" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="float" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="duplicate">
 			<return type="PackedFloat64Array" />
 			<description>
@@ -66,6 +73,14 @@
 			<argument index="0" name="value" type="float" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="float" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed.
 			</description>
 		</method>
 		<method name="has" qualifiers="const">
@@ -114,6 +129,14 @@
 			<return type="void" />
 			<description>
 				Reverses the order of the elements in the array.
+			</description>
+		</method>
+		<method name="rfind" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="float" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedInt32Array.xml
+++ b/doc/classes/PackedInt32Array.xml
@@ -55,6 +55,13 @@
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
+		<method name="count" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="duplicate">
 			<return type="PackedInt32Array" />
 			<description>
@@ -66,6 +73,14 @@
 			<argument index="0" name="value" type="int" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed.
 			</description>
 		</method>
 		<method name="has" qualifiers="const">
@@ -114,6 +129,14 @@
 			<return type="void" />
 			<description>
 				Reverses the order of the elements in the array.
+			</description>
+		</method>
+		<method name="rfind" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedInt64Array.xml
+++ b/doc/classes/PackedInt64Array.xml
@@ -55,6 +55,13 @@
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
+		<method name="count" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="duplicate">
 			<return type="PackedInt64Array" />
 			<description>
@@ -66,6 +73,14 @@
 			<argument index="0" name="value" type="int" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed.
 			</description>
 		</method>
 		<method name="has" qualifiers="const">
@@ -114,6 +129,14 @@
 			<return type="void" />
 			<description>
 				Reverses the order of the elements in the array.
+			</description>
+		</method>
+		<method name="rfind" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedStringArray.xml
+++ b/doc/classes/PackedStringArray.xml
@@ -55,6 +55,13 @@
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
+		<method name="count" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="String" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="duplicate">
 			<return type="PackedStringArray" />
 			<description>
@@ -66,6 +73,14 @@
 			<argument index="0" name="value" type="String" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="String" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed.
 			</description>
 		</method>
 		<method name="has" qualifiers="const">
@@ -114,6 +129,14 @@
 			<return type="void" />
 			<description>
 				Reverses the order of the elements in the array.
+			</description>
+		</method>
+		<method name="rfind" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="String" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedVector2Array.xml
+++ b/doc/classes/PackedVector2Array.xml
@@ -55,6 +55,13 @@
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
+		<method name="count" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="Vector2" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="duplicate">
 			<return type="PackedVector2Array" />
 			<description>
@@ -66,6 +73,14 @@
 			<argument index="0" name="value" type="Vector2" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="Vector2" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed.
 			</description>
 		</method>
 		<method name="has" qualifiers="const">
@@ -114,6 +129,14 @@
 			<return type="void" />
 			<description>
 				Reverses the order of the elements in the array.
+			</description>
+		</method>
+		<method name="rfind" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="Vector2" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PackedVector3Array.xml
+++ b/doc/classes/PackedVector3Array.xml
@@ -54,6 +54,13 @@
 				[b]Note:[/b] Calling [method bsearch] on an unsorted array results in unexpected behavior.
 			</description>
 		</method>
+		<method name="count" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="Vector3" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="duplicate">
 			<return type="PackedVector3Array" />
 			<description>
@@ -65,6 +72,14 @@
 			<argument index="0" name="value" type="Vector3" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="Vector3" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed.
 			</description>
 		</method>
 		<method name="has" qualifiers="const">
@@ -113,6 +128,14 @@
 			<return type="void" />
 			<description>
 				Reverses the order of the elements in the array.
+			</description>
+		</method>
+		<method name="rfind" qualifiers="const">
+			<return type="int" />
+			<argument index="0" name="value" type="Vector3" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
 			</description>
 		</method>
 		<method name="set">


### PR DESCRIPTION
Adds the following methods to packed arrays:

* `count()`
* `find()`
* `rfind()`

They are useful because:

* `remove_at()` requires an index. Currently, only `bsearch()` provides an index and it requires to sort the array first.
* `Array` already provides these methods.