### PR TITLE
[3.x] Add search methods for pool arrays

### DIFF
--- a/core/pool_vector.h
+++ b/core/pool_vector.h
@@ -373,6 +373,57 @@ public:
 		resize(s - 1);
 	}
 
+	int find(const T &p_val, int p_from = 0) const {
+		const int s = size();
+		const Read r = read();
+
+		if (p_from < 0) {
+			return -1;
+		}
+
+		for (int i = p_from; i < s; i++) {
+			if (r[i] == p_val) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	int rfind(const T &p_val, int p_from = -1) const {
+		const int s = size();
+		const Read r = read();
+
+		if (p_from < 0) {
+			p_from = s + p_from;
+		}
+		if (p_from < 0 || p_from >= s) {
+			p_from = s - 1;
+		}
+
+		for (int i = p_from; i >= 0; i--) {
+			if (r[i] == p_val) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
+	int count(const T &p_val) const {
+		const int s = size();
+		const Read r = read();
+		int amount = 0;
+		for (int i = 0; i < s; i++) {
+			if (r[i] == p_val) {
+				amount++;
+			}
+		}
+		return amount;
+	}
+
+	bool has(const T &p_val) const {
+		return find(p_val) != -1;
+	}
+
 	inline int size() const;
 	inline bool empty() const;
 	T get(int p_index) const;

--- a/core/variant_call.cpp
+++ b/core/variant_call.cpp
@@ -701,6 +701,10 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolByteArray, append_array);
 	VCALL_LOCALMEM0(PoolByteArray, invert);
 	VCALL_LOCALMEM2R(PoolByteArray, subarray);
+	VCALL_LOCALMEM2R(PoolByteArray, find);
+	VCALL_LOCALMEM2R(PoolByteArray, rfind);
+	VCALL_LOCALMEM1R(PoolByteArray, count);
+	VCALL_LOCALMEM1R(PoolByteArray, has);
 
 	VCALL_LOCALMEM0R(PoolIntArray, size);
 	VCALL_LOCALMEM0R(PoolIntArray, empty);
@@ -714,6 +718,10 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolIntArray, append);
 	VCALL_LOCALMEM1(PoolIntArray, append_array);
 	VCALL_LOCALMEM0(PoolIntArray, invert);
+	VCALL_LOCALMEM2R(PoolIntArray, find);
+	VCALL_LOCALMEM2R(PoolIntArray, rfind);
+	VCALL_LOCALMEM1R(PoolIntArray, count);
+	VCALL_LOCALMEM1R(PoolIntArray, has);
 
 	VCALL_LOCALMEM0R(PoolRealArray, size);
 	VCALL_LOCALMEM0R(PoolRealArray, empty);
@@ -727,6 +735,10 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolRealArray, append);
 	VCALL_LOCALMEM1(PoolRealArray, append_array);
 	VCALL_LOCALMEM0(PoolRealArray, invert);
+	VCALL_LOCALMEM2R(PoolRealArray, find);
+	VCALL_LOCALMEM2R(PoolRealArray, rfind);
+	VCALL_LOCALMEM1R(PoolRealArray, count);
+	VCALL_LOCALMEM1R(PoolRealArray, has);
 
 	VCALL_LOCALMEM0R(PoolStringArray, size);
 	VCALL_LOCALMEM0R(PoolStringArray, empty);
@@ -741,6 +753,10 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolStringArray, append_array);
 	VCALL_LOCALMEM0(PoolStringArray, invert);
 	VCALL_LOCALMEM1R(PoolStringArray, join);
+	VCALL_LOCALMEM2R(PoolStringArray, find);
+	VCALL_LOCALMEM2R(PoolStringArray, rfind);
+	VCALL_LOCALMEM1R(PoolStringArray, count);
+	VCALL_LOCALMEM1R(PoolStringArray, has);
 
 	VCALL_LOCALMEM0R(PoolVector2Array, size);
 	VCALL_LOCALMEM0R(PoolVector2Array, empty);
@@ -754,6 +770,10 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolVector2Array, append);
 	VCALL_LOCALMEM1(PoolVector2Array, append_array);
 	VCALL_LOCALMEM0(PoolVector2Array, invert);
+	VCALL_LOCALMEM2R(PoolVector2Array, find);
+	VCALL_LOCALMEM2R(PoolVector2Array, rfind);
+	VCALL_LOCALMEM1R(PoolVector2Array, count);
+	VCALL_LOCALMEM1R(PoolVector2Array, has);
 
 	VCALL_LOCALMEM0R(PoolVector3Array, size);
 	VCALL_LOCALMEM0R(PoolVector3Array, empty);
@@ -767,6 +787,10 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolVector3Array, append);
 	VCALL_LOCALMEM1(PoolVector3Array, append_array);
 	VCALL_LOCALMEM0(PoolVector3Array, invert);
+	VCALL_LOCALMEM2R(PoolVector3Array, find);
+	VCALL_LOCALMEM2R(PoolVector3Array, rfind);
+	VCALL_LOCALMEM1R(PoolVector3Array, count);
+	VCALL_LOCALMEM1R(PoolVector3Array, has);
 
 	VCALL_LOCALMEM0R(PoolColorArray, size);
 	VCALL_LOCALMEM0R(PoolColorArray, empty);
@@ -780,6 +804,10 @@ struct _VariantCall {
 	VCALL_LOCALMEM1(PoolColorArray, append);
 	VCALL_LOCALMEM1(PoolColorArray, append_array);
 	VCALL_LOCALMEM0(PoolColorArray, invert);
+	VCALL_LOCALMEM2R(PoolColorArray, find);
+	VCALL_LOCALMEM2R(PoolColorArray, rfind);
+	VCALL_LOCALMEM1R(PoolColorArray, count);
+	VCALL_LOCALMEM1R(PoolColorArray, has);
 
 #define VCALL_PTR0(m_type, m_method) \
 	static void _call_##m_type##_##m_method(Variant &r_ret, Variant &p_self, const Variant **p_args) { reinterpret_cast<m_type *>(p_self._data._ptr)->m_method(); }
@@ -1946,6 +1974,10 @@ void register_variant_methods() {
 	ADDFUNC1(POOL_BYTE_ARRAY, NIL, PoolByteArray, resize, INT, "idx", varray());
 	ADDFUNC0(POOL_BYTE_ARRAY, NIL, PoolByteArray, invert, varray());
 	ADDFUNC2R(POOL_BYTE_ARRAY, POOL_BYTE_ARRAY, PoolByteArray, subarray, INT, "from", INT, "to", varray());
+	ADDFUNC2R(POOL_BYTE_ARRAY, INT, PoolByteArray, find, INT, "value", INT, "from", varray(0));
+	ADDFUNC2R(POOL_BYTE_ARRAY, INT, PoolByteArray, rfind, INT, "value", INT, "from", varray(-1));
+	ADDFUNC1R(POOL_BYTE_ARRAY, INT, PoolByteArray, count, INT, "value", varray());
+	ADDFUNC1R(POOL_BYTE_ARRAY, BOOL, PoolByteArray, has, INT, "value", varray());
 
 	ADDFUNC0R(POOL_BYTE_ARRAY, STRING, PoolByteArray, get_string_from_ascii, varray());
 	ADDFUNC0R(POOL_BYTE_ARRAY, STRING, PoolByteArray, get_string_from_utf8, varray());
@@ -1965,6 +1997,10 @@ void register_variant_methods() {
 	ADDFUNC2R(POOL_INT_ARRAY, INT, PoolIntArray, insert, INT, "idx", INT, "integer", varray());
 	ADDFUNC1(POOL_INT_ARRAY, NIL, PoolIntArray, resize, INT, "idx", varray());
 	ADDFUNC0(POOL_INT_ARRAY, NIL, PoolIntArray, invert, varray());
+	ADDFUNC2R(POOL_INT_ARRAY, INT, PoolIntArray, find, INT, "value", INT, "from", varray(0));
+	ADDFUNC2R(POOL_INT_ARRAY, INT, PoolIntArray, rfind, INT, "value", INT, "from", varray(-1));
+	ADDFUNC1R(POOL_INT_ARRAY, INT, PoolIntArray, count, INT, "value", varray());
+	ADDFUNC1R(POOL_INT_ARRAY, BOOL, PoolIntArray, has, INT, "value", varray());
 
 	ADDFUNC0R(POOL_REAL_ARRAY, INT, PoolRealArray, size, varray());
 	ADDFUNC0R(POOL_REAL_ARRAY, BOOL, PoolRealArray, empty, varray());
@@ -1977,6 +2013,10 @@ void register_variant_methods() {
 	ADDFUNC2R(POOL_REAL_ARRAY, INT, PoolRealArray, insert, INT, "idx", REAL, "value", varray());
 	ADDFUNC1(POOL_REAL_ARRAY, NIL, PoolRealArray, resize, INT, "idx", varray());
 	ADDFUNC0(POOL_REAL_ARRAY, NIL, PoolRealArray, invert, varray());
+	ADDFUNC2R(POOL_REAL_ARRAY, INT, PoolRealArray, find, REAL, "value", INT, "from", varray(0));
+	ADDFUNC2R(POOL_REAL_ARRAY, INT, PoolRealArray, rfind, REAL, "value", INT, "from", varray(-1));
+	ADDFUNC1R(POOL_REAL_ARRAY, INT, PoolRealArray, count, REAL, "value", varray());
+	ADDFUNC1R(POOL_REAL_ARRAY, BOOL, PoolRealArray, has, REAL, "value", varray());
 
 	ADDFUNC0R(POOL_STRING_ARRAY, INT, PoolStringArray, size, varray());
 	ADDFUNC0R(POOL_STRING_ARRAY, BOOL, PoolStringArray, empty, varray());
@@ -1990,6 +2030,10 @@ void register_variant_methods() {
 	ADDFUNC1(POOL_STRING_ARRAY, NIL, PoolStringArray, resize, INT, "idx", varray());
 	ADDFUNC0(POOL_STRING_ARRAY, NIL, PoolStringArray, invert, varray());
 	ADDFUNC1(POOL_STRING_ARRAY, STRING, PoolStringArray, join, STRING, "delimiter", varray());
+	ADDFUNC2R(POOL_STRING_ARRAY, INT, PoolStringArray, find, STRING, "value", INT, "from", varray(0));
+	ADDFUNC2R(POOL_STRING_ARRAY, INT, PoolStringArray, rfind, STRING, "value", INT, "from", varray(-1));
+	ADDFUNC1R(POOL_STRING_ARRAY, INT, PoolStringArray, count, STRING, "value", varray());
+	ADDFUNC1R(POOL_STRING_ARRAY, BOOL, PoolStringArray, has, STRING, "value", varray());
 
 	ADDFUNC0R(POOL_VECTOR2_ARRAY, INT, PoolVector2Array, size, varray());
 	ADDFUNC0R(POOL_VECTOR2_ARRAY, BOOL, PoolVector2Array, empty, varray());
@@ -2002,6 +2046,10 @@ void register_variant_methods() {
 	ADDFUNC2R(POOL_VECTOR2_ARRAY, INT, PoolVector2Array, insert, INT, "idx", VECTOR2, "vector2", varray());
 	ADDFUNC1(POOL_VECTOR2_ARRAY, NIL, PoolVector2Array, resize, INT, "idx", varray());
 	ADDFUNC0(POOL_VECTOR2_ARRAY, NIL, PoolVector2Array, invert, varray());
+	ADDFUNC2R(POOL_VECTOR2_ARRAY, INT, PoolVector2Array, find, VECTOR2, "value", INT, "from", varray(0));
+	ADDFUNC2R(POOL_VECTOR2_ARRAY, INT, PoolVector2Array, rfind, VECTOR2, "value", INT, "from", varray(-1));
+	ADDFUNC1R(POOL_VECTOR2_ARRAY, INT, PoolVector2Array, count, VECTOR2, "value", varray());
+	ADDFUNC1R(POOL_VECTOR2_ARRAY, BOOL, PoolVector2Array, has, VECTOR2, "value", varray());
 
 	ADDFUNC0R(POOL_VECTOR3_ARRAY, INT, PoolVector3Array, size, varray());
 	ADDFUNC0R(POOL_VECTOR3_ARRAY, BOOL, PoolVector3Array, empty, varray());
@@ -2014,6 +2062,10 @@ void register_variant_methods() {
 	ADDFUNC2R(POOL_VECTOR3_ARRAY, INT, PoolVector3Array, insert, INT, "idx", VECTOR3, "vector3", varray());
 	ADDFUNC1(POOL_VECTOR3_ARRAY, NIL, PoolVector3Array, resize, INT, "idx", varray());
 	ADDFUNC0(POOL_VECTOR3_ARRAY, NIL, PoolVector3Array, invert, varray());
+	ADDFUNC2R(POOL_VECTOR3_ARRAY, INT, PoolVector3Array, find, VECTOR3, "value", INT, "from", varray(0));
+	ADDFUNC2R(POOL_VECTOR3_ARRAY, INT, PoolVector3Array, rfind, VECTOR3, "value", INT, "from", varray(-1));
+	ADDFUNC1R(POOL_VECTOR3_ARRAY, INT, PoolVector3Array, count, VECTOR3, "value", varray());
+	ADDFUNC1R(POOL_VECTOR3_ARRAY, BOOL, PoolVector3Array, has, VECTOR3, "value", varray());
 
 	ADDFUNC0R(POOL_COLOR_ARRAY, INT, PoolColorArray, size, varray());
 	ADDFUNC0R(POOL_COLOR_ARRAY, BOOL, PoolColorArray, empty, varray());
@@ -2026,6 +2078,10 @@ void register_variant_methods() {
 	ADDFUNC2R(POOL_COLOR_ARRAY, INT, PoolColorArray, insert, INT, "idx", COLOR, "color", varray());
 	ADDFUNC1(POOL_COLOR_ARRAY, NIL, PoolColorArray, resize, INT, "idx", varray());
 	ADDFUNC0(POOL_COLOR_ARRAY, NIL, PoolColorArray, invert, varray());
+	ADDFUNC2R(POOL_COLOR_ARRAY, INT, PoolColorArray, find, COLOR, "value", INT, "from", varray(0));
+	ADDFUNC2R(POOL_COLOR_ARRAY, INT, PoolColorArray, rfind, COLOR, "value", INT, "from", varray(-1));
+	ADDFUNC1R(POOL_COLOR_ARRAY, INT, PoolColorArray, count, COLOR, "value", varray());
+	ADDFUNC1R(POOL_COLOR_ARRAY, BOOL, PoolColorArray, has, COLOR, "value", varray());
 
 	//pointerbased
 

--- a/doc/classes/Array.xml
+++ b/doc/classes/Array.xml
@@ -193,7 +193,7 @@
 			<argument index="0" name="what" type="Variant" />
 			<argument index="1" name="from" type="int" default="0" />
 			<description>
-				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed.
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed. Returns [code]-1[/code] if [code]from[/code] is out of bounds.
 			</description>
 		</method>
 		<method name="find_last">
@@ -315,7 +315,7 @@
 			<argument index="0" name="what" type="Variant" />
 			<argument index="1" name="from" type="int" default="-1" />
 			<description>
-				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array.
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array. If the adjusted start index is out of bounds, this method searches from the end of the array.
 			</description>
 		</method>
 		<method name="shuffle">

--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -36,6 +36,13 @@
 				Returns a new [PoolByteArray] with the data compressed. Set the compression mode using one of [enum File.CompressionMode]'s constants.
 			</description>
 		</method>
+		<method name="count">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="decompress">
 			<return type="PoolByteArray" />
 			<argument index="0" name="buffer_size" type="int" />
@@ -67,6 +74,14 @@
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
 			</description>
 		</method>
+		<method name="find">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed. Returns [code]-1[/code] if [code]from[/code] is out of bounds.
+			</description>
+		</method>
 		<method name="get_string_from_ascii">
 			<return type="String" />
 			<description>
@@ -77,6 +92,14 @@
 			<return type="String" />
 			<description>
 				Returns a copy of the array's contents as [String]. Slower than [method get_string_from_ascii] but supports UTF-8 encoded data. Use this function if you are unsure about the source of the data. For user input this function should always be preferred.
+			</description>
+		</method>
+		<method name="has">
+			<return type="bool" />
+			<argument index="0" name="value" type="int" />
+			<description>
+				Returns [code]true[/code] if the array contains the given value.
+				[b]Note:[/b] This is equivalent to using the [code]in[/code] operator.
 			</description>
 		</method>
 		<method name="hex_encode">
@@ -119,6 +142,14 @@
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
 				[b]Note:[/b] Added elements are not automatically initialized to 0 and will contain garbage, i.e. indeterminate values.
+			</description>
+		</method>
+		<method name="rfind">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array. If the adjusted start index is out of bounds, this method searches from the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PoolColorArray.xml
+++ b/doc/classes/PoolColorArray.xml
@@ -29,6 +29,13 @@
 				Appends a [PoolColorArray] at the end of this array.
 			</description>
 		</method>
+		<method name="count">
+			<return type="int" />
+			<argument index="0" name="value" type="Color" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="empty">
 			<return type="bool" />
 			<description>
@@ -39,6 +46,22 @@
 			<argument index="0" name="color" type="Color" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find">
+			<return type="int" />
+			<argument index="0" name="value" type="Color" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed. Returns [code]-1[/code] if [code]from[/code] is out of bounds.
+			</description>
+		</method>
+		<method name="has">
+			<return type="bool" />
+			<argument index="0" name="value" type="Color" />
+			<description>
+				Returns [code]true[/code] if the array contains the given value.
+				[b]Note:[/b] This is equivalent to using the [code]in[/code] operator.
 			</description>
 		</method>
 		<method name="insert">
@@ -70,6 +93,14 @@
 			<argument index="0" name="idx" type="int" />
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+			</description>
+		</method>
+		<method name="rfind">
+			<return type="int" />
+			<argument index="0" name="value" type="Color" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array. If the adjusted start index is out of bounds, this method searches from the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PoolIntArray.xml
+++ b/doc/classes/PoolIntArray.xml
@@ -30,6 +30,13 @@
 				Appends a [PoolIntArray] at the end of this array.
 			</description>
 		</method>
+		<method name="count">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="empty">
 			<return type="bool" />
 			<description>
@@ -40,6 +47,22 @@
 			<argument index="0" name="integer" type="int" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed. Returns [code]-1[/code] if [code]from[/code] is out of bounds.
+			</description>
+		</method>
+		<method name="has">
+			<return type="bool" />
+			<argument index="0" name="value" type="int" />
+			<description>
+				Returns [code]true[/code] if the array contains the given value.
+				[b]Note:[/b] This is equivalent to using the [code]in[/code] operator.
 			</description>
 		</method>
 		<method name="insert">
@@ -72,6 +95,14 @@
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
 				[b]Note:[/b] Added elements are not automatically initialized to 0 and will contain garbage, i.e. indeterminate values.
+			</description>
+		</method>
+		<method name="rfind">
+			<return type="int" />
+			<argument index="0" name="value" type="int" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array. If the adjusted start index is out of bounds, this method searches from the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PoolRealArray.xml
+++ b/doc/classes/PoolRealArray.xml
@@ -30,6 +30,13 @@
 				Appends a [PoolRealArray] at the end of this array.
 			</description>
 		</method>
+		<method name="count">
+			<return type="int" />
+			<argument index="0" name="value" type="float" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="empty">
 			<return type="bool" />
 			<description>
@@ -40,6 +47,22 @@
 			<argument index="0" name="value" type="float" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find">
+			<return type="int" />
+			<argument index="0" name="value" type="float" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed. Returns [code]-1[/code] if [code]from[/code] is out of bounds.
+			</description>
+		</method>
+		<method name="has">
+			<return type="bool" />
+			<argument index="0" name="value" type="float" />
+			<description>
+				Returns [code]true[/code] if the array contains the given value.
+				[b]Note:[/b] This is equivalent to using the [code]in[/code] operator.
 			</description>
 		</method>
 		<method name="insert">
@@ -72,6 +95,14 @@
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
 				[b]Note:[/b] Added elements are not automatically initialized to 0 and will contain garbage, i.e. indeterminate values.
+			</description>
+		</method>
+		<method name="rfind">
+			<return type="int" />
+			<argument index="0" name="value" type="float" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array. If the adjusted start index is out of bounds, this method searches from the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PoolStringArray.xml
+++ b/doc/classes/PoolStringArray.xml
@@ -30,6 +30,13 @@
 				Appends a [PoolStringArray] at the end of this array.
 			</description>
 		</method>
+		<method name="count">
+			<return type="int" />
+			<argument index="0" name="value" type="String" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="empty">
 			<return type="bool" />
 			<description>
@@ -40,6 +47,22 @@
 			<argument index="0" name="string" type="String" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find">
+			<return type="int" />
+			<argument index="0" name="value" type="String" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed. Returns [code]-1[/code] if [code]from[/code] is out of bounds.
+			</description>
+		</method>
+		<method name="has">
+			<return type="bool" />
+			<argument index="0" name="value" type="String" />
+			<description>
+				Returns [code]true[/code] if the array contains the given value.
+				[b]Note:[/b] This is equivalent to using the [code]in[/code] operator.
 			</description>
 		</method>
 		<method name="insert">
@@ -78,6 +101,14 @@
 			<argument index="0" name="idx" type="int" />
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+			</description>
+		</method>
+		<method name="rfind">
+			<return type="int" />
+			<argument index="0" name="value" type="String" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array. If the adjusted start index is out of bounds, this method searches from the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PoolVector2Array.xml
+++ b/doc/classes/PoolVector2Array.xml
@@ -30,6 +30,13 @@
 				Appends a [PoolVector2Array] at the end of this array.
 			</description>
 		</method>
+		<method name="count">
+			<return type="int" />
+			<argument index="0" name="value" type="Vector2" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="empty">
 			<return type="bool" />
 			<description>
@@ -40,6 +47,22 @@
 			<argument index="0" name="vector2" type="Vector2" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find">
+			<return type="int" />
+			<argument index="0" name="value" type="Vector2" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed. Returns [code]-1[/code] if [code]from[/code] is out of bounds.
+			</description>
+		</method>
+		<method name="has">
+			<return type="bool" />
+			<argument index="0" name="value" type="Vector2" />
+			<description>
+				Returns [code]true[/code] if the array contains the given value.
+				[b]Note:[/b] This is equivalent to using the [code]in[/code] operator.
 			</description>
 		</method>
 		<method name="insert">
@@ -71,6 +94,14 @@
 			<argument index="0" name="idx" type="int" />
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+			</description>
+		</method>
+		<method name="rfind">
+			<return type="int" />
+			<argument index="0" name="value" type="Vector2" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array. If the adjusted start index is out of bounds, this method searches from the end of the array.
 			</description>
 		</method>
 		<method name="set">

--- a/doc/classes/PoolVector3Array.xml
+++ b/doc/classes/PoolVector3Array.xml
@@ -29,6 +29,13 @@
 				Appends a [PoolVector3Array] at the end of this array.
 			</description>
 		</method>
+		<method name="count">
+			<return type="int" />
+			<argument index="0" name="value" type="Vector3" />
+			<description>
+				Returns the number of times an element is in the array.
+			</description>
+		</method>
 		<method name="empty">
 			<return type="bool" />
 			<description>
@@ -39,6 +46,22 @@
 			<argument index="0" name="vector3" type="Vector3" />
 			<description>
 				Assigns the given value to all elements in the array. This can typically be used together with [method resize] to create an array with a given size and initialized elements.
+			</description>
+		</method>
+		<method name="find">
+			<return type="int" />
+			<argument index="0" name="value" type="Vector3" />
+			<argument index="1" name="from" type="int" default="0" />
+			<description>
+				Searches the array for a value and returns its index or [code]-1[/code] if not found. Optionally, the initial search index can be passed. Returns [code]-1[/code] if [code]from[/code] is out of bounds.
+			</description>
+		</method>
+		<method name="has">
+			<return type="bool" />
+			<argument index="0" name="value" type="Vector3" />
+			<description>
+				Returns [code]true[/code] if the array contains the given value.
+				[b]Note:[/b] This is equivalent to using the [code]in[/code] operator.
 			</description>
 		</method>
 		<method name="insert">
@@ -70,6 +93,14 @@
 			<argument index="0" name="idx" type="int" />
 			<description>
 				Sets the size of the array. If the array is grown, reserves elements at the end of the array. If the array is shrunk, truncates the array to the new size.
+			</description>
+		</method>
+		<method name="rfind">
+			<return type="int" />
+			<argument index="0" name="value" type="Vector3" />
+			<argument index="1" name="from" type="int" default="-1" />
+			<description>
+				Searches the array in reverse order. Optionally, a start search index can be passed. If negative, the start index is considered relative to the end of the array. If the adjusted start index is out of bounds, this method searches from the end of the array.
 			</description>
 		</method>
 		<method name="set">


### PR DESCRIPTION
`3.x` version of #60855

Adds the following methods to pool arrays:

* `has()`
* `count()`
* `find()`
* `rfind()`
