### PR TITLE
Physics Interpolation - add interpolation mode property to node

### DIFF
--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -391,14 +391,14 @@
 		<method name="is_physics_interpolated" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if the physics interpolated flag is set for this Node (see [method set_physics_interpolated]).
+				Returns [code]true[/code] if the physics interpolated flag is set for this Node (see [member physics_interpolation_mode]).
 				[b]Note:[/b] Interpolation will only be active is both the flag is set [b]and[/b] physics interpolation is enabled within the [SceneTree]. This can be tested using [method is_physics_interpolated_and_enabled].
 			</description>
 		</method>
 		<method name="is_physics_interpolated_and_enabled" qualifiers="const">
 			<return type="bool" />
 			<description>
-				Returns [code]true[/code] if physics interpolation is enabled (see [method set_physics_interpolated]) [b]and[/b] enabled in the [SceneTree].
+				Returns [code]true[/code] if physics interpolation is enabled (see [member physics_interpolation_mode]) [b]and[/b] enabled in the [SceneTree].
 				This is a convenience version of [method is_physics_interpolated] that also checks whether physics interpolation is enabled globally.
 				See [member SceneTree.physics_interpolation] and [member ProjectSettings.physics/common/physics_interpolation].
 			</description>
@@ -660,14 +660,6 @@
 				Sets the node's network master to the peer with the given peer ID. The network master is the peer that has authority over the node on the network. Useful in conjunction with the [code]master[/code] and [code]puppet[/code] keywords. Inherited from the parent node by default, which ultimately defaults to peer ID 1 (the server). If [code]recursive[/code], the given peer is recursively set as the master for all children of this node.
 			</description>
 		</method>
-		<method name="set_physics_interpolated">
-			<return type="void" />
-			<argument index="0" name="enable" type="bool" />
-			<description>
-				Enables or disables physics interpolation per node, offering a finer grain of control than turning physics interpolation on and off globally.
-				[b]Note:[/b] This can be especially useful for [Camera]s, where custom interpolation can sometimes give superior results.
-			</description>
-		</method>
 		<method name="set_physics_process">
 			<return type="void" />
 			<argument index="0" name="enable" type="bool" />
@@ -754,6 +746,10 @@
 		</member>
 		<member name="pause_mode" type="int" setter="set_pause_mode" getter="get_pause_mode" enum="Node.PauseMode" default="0">
 			Pause mode. How the node will behave if the [SceneTree] is paused.
+		</member>
+		<member name="physics_interpolation_mode" type="int" setter="set_physics_interpolation_mode" getter="get_physics_interpolation_mode" enum="Node.PhysicsInterpolationMode" default="0">
+			Allows enabling or disabling physics interpolation per node, offering a finer grain of control than turning physics interpolation on and off globally.
+			[b]Note:[/b] This can be especially useful for [Camera]s, where custom interpolation can sometimes give superior results.
 		</member>
 		<member name="process_priority" type="int" setter="set_process_priority" getter="get_process_priority" default="0">
 			The node's priority in the execution order of the enabled processing callbacks (i.e. [constant NOTIFICATION_PROCESS], [constant NOTIFICATION_PHYSICS_PROCESS] and their internal counterparts). Nodes whose process priority value is [i]lower[/i] will have their processing callbacks executed first.
@@ -924,6 +920,15 @@
 		</constant>
 		<constant name="PAUSE_MODE_PROCESS" value="2" enum="PauseMode">
 			Continue to process regardless of the [SceneTree] pause state.
+		</constant>
+		<constant name="PHYSICS_INTERPOLATION_MODE_INHERIT" value="0" enum="PhysicsInterpolationMode">
+			Inherits physics interpolation mode from the node's parent. For the root node, it is equivalent to [constant PHYSICS_INTERPOLATION_MODE_ON]. Default.
+		</constant>
+		<constant name="PHYSICS_INTERPOLATION_MODE_OFF" value="1" enum="PhysicsInterpolationMode">
+			Turn off physics interpolation in this node and children set to [constant PHYSICS_INTERPOLATION_MODE_INHERIT].
+		</constant>
+		<constant name="PHYSICS_INTERPOLATION_MODE_ON" value="2" enum="PhysicsInterpolationMode">
+			Turn on physics interpolation in this node and children set to [constant PHYSICS_INTERPOLATION_MODE_INHERIT].
 		</constant>
 		<constant name="DUPLICATE_SIGNALS" value="1" enum="DuplicateFlags">
 			Duplicate the node's signals.

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -55,6 +55,13 @@ public:
 		PAUSE_MODE_PROCESS
 	};
 
+	enum PhysicsInterpolationMode {
+
+		PHYSICS_INTERPOLATION_MODE_INHERIT,
+		PHYSICS_INTERPOLATION_MODE_OFF,
+		PHYSICS_INTERPOLATION_MODE_ON
+	};
+
 	enum DuplicateFlags {
 
 		DUPLICATE_SIGNALS = 1,
@@ -115,7 +122,6 @@ private:
 		List<Node *>::Element *OW; // owned element
 		List<Node *> owned;
 
-		PauseMode pause_mode;
 		Node *pause_owner;
 
 		int network_master;
@@ -123,6 +129,10 @@ private:
 		Map<StringName, MultiplayerAPI::RPCMode> rpc_properties;
 
 		int process_priority;
+
+		// Keep bitpacked values together to get better packing
+		PauseMode pause_mode : 2;
+		PhysicsInterpolationMode physics_interpolation_mode : 2;
 
 		// variables used to properly sort the node when processing, ignored otherwise
 		//should move all the stuff below to bits
@@ -424,7 +434,8 @@ public:
 	bool can_process() const;
 	bool can_process_notification(int p_what) const;
 
-	void set_physics_interpolated(bool p_interpolated);
+	void set_physics_interpolation_mode(PhysicsInterpolationMode p_mode);
+	PhysicsInterpolationMode get_physics_interpolation_mode() const { return data.physics_interpolation_mode; }
 	_FORCE_INLINE_ bool is_physics_interpolated() const { return data.physics_interpolated; }
 	_FORCE_INLINE_ bool is_physics_interpolated_and_enabled() const { return is_inside_tree() && get_tree()->is_physics_interpolation_enabled() && is_physics_interpolated(); }
 	void reset_physics_interpolation();


### PR DESCRIPTION
Exposes the "interpolated" flag on nodes via a property, physics_interpolation_mode.

Mode can be INHERIT, OFF and ON. This makes it easy to turn off interpolation for nodes in the editor, versus via code.

Implements https://github.com/godotengine/godot-proposals/issues/4487

![physics_interpolation_mode](https://user-images.githubusercontent.com/21999379/167255640-84855694-7b4d-49b4-a32d-ea148940f43b.png)

## Notes
* My personal preference has always been to expose this in the editor, the proposal shows this seems to be generally supported.
* This is actually a breaking change from the earlier betas: the function used to change the setting changes from `set_physics_interpolated()` to `set_physics_interpolation_mode()`. This latter approach with the enum allows having an INHERIT mode, which is more similar to the existing Godot paradigm for inherited properties.
* The slight change in the function should not be a problem as it is easy to change in the calling code, and better to finalize this before 3.5 stable.
* We could possibly shorten the name to fit on the line in the inspector, but it doesn't seem too bad.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
