### PR TITLE
Improve plugin dialog UX

### DIFF
--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -200,12 +200,9 @@ EditorPluginSettings::EditorPluginSettings() {
 	l->set_theme_type_variation("HeaderSmall");
 	title_hb->add_child(l);
 	title_hb->add_spacer();
-	create_plugin = memnew(Button(TTR("Create")));
+	Button *create_plugin = memnew(Button(TTR("Create New Plugin")));
 	create_plugin->connect("pressed", callable_mp(this, &EditorPluginSettings::_create_clicked));
 	title_hb->add_child(create_plugin);
-	update_list = memnew(Button(TTR("Update")));
-	update_list->connect("pressed", callable_mp(this, &EditorPluginSettings::update_plugins));
-	title_hb->add_child(update_list);
 	add_child(title_hb);
 
 	plugin_list = memnew(Tree);

--- a/editor/editor_plugin_settings.h
+++ b/editor/editor_plugin_settings.h
@@ -45,8 +45,6 @@ class EditorPluginSettings : public VBoxContainer {
 	};
 
 	PluginConfigDialog *plugin_config_dialog = nullptr;
-	Button *create_plugin = nullptr;
-	Button *update_list = nullptr;
 	Tree *plugin_list = nullptr;
 	bool updating = false;
 

--- a/editor/plugin_config_dialog.h
+++ b/editor/plugin_config_dialog.h
@@ -61,6 +61,7 @@ class PluginConfigDialog : public ConfirmationDialog {
 	void _on_cancelled();
 	void _on_language_changed(const int p_language);
 	void _on_required_text_changed(const String &p_text);
+	String _get_subfolder();
 
 	static String _to_absolute_plugin_path(const String &p_plugin_name);
 


### PR DESCRIPTION
Partially supersedes #36677
- Subfolder and script name are now optional
  - If empty, the default subfolder path will be the plugin name converted to snake_case
  - If empty, the script name will be the same as subfolder
  - Script name extension is optional and will be added based on the selected language
- Aligned labels to the right
- Removed "Update" button. The list is updated on dialog focus, so manual refresh is useless
- Changed "Create" button to "Create New Plugin"
- Misc code cleanup
![image](https://user-images.githubusercontent.com/2223172/167272205-dc449d73-ad3d-428b-b38a-a8e92c5c29ed.png)
