### PR TITLE
Remove font height restriction from Button

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -60,11 +60,11 @@ Size2 Button::get_minimum_size() const {
 			}
 		}
 	}
-
-	Ref<Font> font = get_theme_font(SNAME("font"));
-	float font_height = font->get_height(get_theme_font_size(SNAME("font_size")));
-
-	minsize.height = MAX(font_height, minsize.height);
+	if (!xl_text.is_empty()) {
+		Ref<Font> font = get_theme_font(SNAME("font"));
+		float font_height = font->get_height(get_theme_font_size(SNAME("font_size")));
+		minsize.height = MAX(font_height, minsize.height);
+	}
 
 	return get_theme_stylebox(SNAME("normal"))->get_minimum_size() + minsize;
 }


### PR DESCRIPTION
Possible fix #35005
The button height is determined by the text buffer, so additinally using font height is not necessary.
![godot windows tools 64_PERzIDkiyp](https://user-images.githubusercontent.com/2223172/167273790-fcd2f651-078e-469e-99ce-a004de93d9f5.gif)

