### PR TITLE
[3.x] Fix sign comparison error in platform/osx/os_osx.mm

### DIFF
--- a/platform/osx/os_osx.mm
+++ b/platform/osx/os_osx.mm
@@ -1079,7 +1079,7 @@ static int translateKey(unsigned int key) {
 }
 
 // Translates a Godot keycode back to a OSX keycode
-static unsigned int unmapKey(int key) {
+static unsigned int unmapKey(unsigned int key) {
 	for (int i = 0; i <= 126; i++) {
 		if (_osx_to_godot_table[i] == key) {
 			return i;


### PR DESCRIPTION
Compiling with latest clang on macOS 10.14.6 with dev=yes produces this error:

```
godot3/platform/osx/os_osx.mm:1084: error: comparison of integers of different signs: 'const unsigned int' and 'int' [-Werror,-Wsign-compare]
platform/osx/os_osx.mm:1084:30: error: comparison of integers of different signs: 'const unsigned int' and 'int' [-Werror,-Wsign-compare]
                if (_osx_to_godot_table[i] == key) {
                    ~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~
```

This error is not present in 4.0/master.
