### PR TITLE
[3.x] Fix mismatched font outline size hint

### DIFF
--- a/scene/resources/dynamic_font.cpp
+++ b/scene/resources/dynamic_font.cpp
@@ -1076,7 +1076,7 @@ void DynamicFont::_bind_methods() {
 
 	ADD_GROUP("Settings", "");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "size", PROPERTY_HINT_RANGE, "1,1024,1"), "set_size", "get_size");
-	ADD_PROPERTY(PropertyInfo(Variant::INT, "outline_size", PROPERTY_HINT_RANGE, "0,1024,1"), "set_outline_size", "get_outline_size");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "outline_size", PROPERTY_HINT_RANGE, "0,255,1"), "set_outline_size", "get_outline_size");
 	ADD_PROPERTY(PropertyInfo(Variant::COLOR, "outline_color"), "set_outline_color", "get_outline_color");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_mipmaps"), "set_use_mipmaps", "get_use_mipmaps");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_filter"), "set_use_filter", "get_use_filter");


### PR DESCRIPTION
The outline size of `DynamicFont` has a hard limit of 255.

https://github.com/godotengine/godot/blob/a3c4cca71255d8222e9d220516ddf75ea4634c72/scene/resources/dynamic_font.cpp#L774-L778

However, the `outline_size` property uses 1024 as the upper limit, so dragging this property up in the Inspector may produce errors like this:

```
ERROR: Condition "p_size < 0 || p_size > (255)" is true.
  at: set_outline_size (scene/resources/dynamic_font.cpp:778)
```