### PR TITLE
Fix duplication of GDNativeExtensionClassGetPropertyList definition in gdnative_interface.h

### DIFF
--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -246,8 +246,6 @@ typedef struct {
 
 typedef void *GDNativeExtensionClassLibraryPtr;
 
-typedef const GDNativePropertyInfo *(*GDNativeExtensionClassGetPropertyList)(GDExtensionClassInstancePtr p_instance, uint32_t *r_count);
-
 /* Method */
 
 typedef enum {


### PR DESCRIPTION
duplications:
https://github.com/godotengine/godot/blob/119912331cf665a3cf4d0027d658f8b52425b7c7/core/extension/gdnative_interface.h#L219
and
https://github.com/godotengine/godot/blob/119912331cf665a3cf4d0027d658f8b52425b7c7/core/extension/gdnative_interface.h#L249
