### PR TITLE
Fix crash when reimporting AtlasTextures

### DIFF
--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2078,6 +2078,7 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 	EditorProgress pr("reimport", TTR("(Re)Importing Assets"), p_files.size());
 
 	Vector<ImportFile> reimport_files;
+	Set<String> file_paths_already_seen;
 
 	Set<String> groups_to_reimport;
 
@@ -2099,11 +2100,12 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 		} else if (!group_file.is_empty()) {
 			//it's a group file, add group to import and skip this file
 			groups_to_reimport.insert(group_file);
-		} else {
+		} else if (!file_paths_already_seen.has(file)) {
 			//it's a regular file
 			ImportFile ifile;
 			ifile.path = file;
 			ResourceFormatImporter::get_singleton()->get_import_order_threads_and_importer(file, ifile.order, ifile.threaded, ifile.importer);
+			file_paths_already_seen.insert(file);
 			reimport_files.push_back(ifile);
 		}
 

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2123,6 +2123,11 @@ void EditorFileSystem::reimport_files(const Vector<String> &p_files) {
 
 	int from = 0;
 	for (int i = 0; i < reimport_files.size(); i++) {
+		if (groups_to_reimport.has(reimport_files[i].path)) {
+			// Skip reimporting files that are in groups, as they will be reimported anyways
+			continue;
+		}
+
 		if (use_threads && reimport_files[i].threaded) {
 			if (i + 1 == reimport_files.size() || reimport_files[i + 1].importer != reimport_files[from].importer) {
 				if (from - i == 0) {


### PR DESCRIPTION
The crash was caused by the reimport_files function trying to reimport the same atlas file multiple times using multithreading, which caused deadlocks and hung the editor.
This fix prevents files from being added to the `reimport_files` array if they are already present inside of it.

Fixes #54817

Note : I have only tested this fix on a sample project. This could potentially break more complex projects, but I'm not enough familiar with the godot import system to tell if that is the case. Someone knowledgable with that system should review this before merging.

Additionaly, I don't know if files that are both as key in `groups_to_reimport` and in the `reimport_files` array should be reimported when handling the `reimport_files`array. I left it as is, but maybe these files end up being reimported twice.
