### PR TITLE
Rescue orphan nodes in inherited scenes

### DIFF
--- a/scene/resources/packed_scene.cpp
+++ b/scene/resources/packed_scene.cpp
@@ -112,6 +112,7 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 		const NodeData &n = nd[i];
 
 		Node *parent = nullptr;
+		String old_parent_path;
 
 		if (i > 0) {
 			ERR_FAIL_COND_V_MSG(n.parent == -1, nullptr, vformat("Invalid scene: node %s does not specify its parent node.", snames[n.name]));
@@ -119,6 +120,8 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 #ifdef DEBUG_ENABLED
 			if (!nparent && (n.parent & FLAG_ID_IS_PATH)) {
 				WARN_PRINT(String("Parent path '" + String(node_paths[n.parent & FLAG_MASK]) + "' for node '" + String(snames[n.name]) + "' has vanished when instancing: '" + get_path() + "'.").ascii().get_data());
+				old_parent_path = String(node_paths[n.parent & FLAG_MASK]).trim_prefix("./").replace("/", "@");
+				nparent = ret_nodes[0];
 			}
 #endif
 			parent = nparent;
@@ -330,6 +333,10 @@ Node *SceneState::instantiate(GenEditState p_edit_state) const {
 						node->_set_name_nocheck(snames[n.name]);
 					}
 				}
+			}
+
+			if (!old_parent_path.is_empty()) {
+				node->_set_name_nocheck(old_parent_path + "@" + node->get_name());
 			}
 
 			if (n.owner >= 0) {


### PR DESCRIPTION
Simple fix #24817


When a node loses its parent, it will be instead added under root node, with name changed to Old@Parent@Path@Node.
![godot windows tools 64_2GwvhzchS7](https://user-images.githubusercontent.com/2223172/167320109-9c77ba0b-4c34-4094-8858-c6f8f68a362c.gif)
Adding some warning dialog would be a bit complicated, as the change is done entirely inside PackedScene. A warning is printed in the output though. This at least preserves the data, so should be sufficient solution.