### PR TITLE
Fix tree button icon not centered vertically

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -1754,19 +1754,16 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			for (int j = p_item->cells[i].buttons.size() - 1; j >= 0; j--) {
 				Ref<Texture2D> b = p_item->cells[i].buttons[j].texture;
 				Size2 s = b->get_size() + cache.button_pressed->get_minimum_size();
-				if (s.height < label_h) {
-					s.height = label_h;
-				}
 
 				Point2i o = Point2i(ofs + w - s.width, p_pos.y) - cache.offset + p_draw_ofs;
 
 				if (cache.click_type == Cache::CLICK_BUTTON && cache.click_item == p_item && cache.click_column == i && cache.click_index == j && !p_item->cells[i].buttons[j].disabled) {
-					//being pressed
+					// Being pressed.
 					Point2 od = o;
 					if (rtl) {
 						od.x = get_size().width - od.x - s.x;
 					}
-					cache.button_pressed->draw(get_canvas_item(), Rect2(od, s));
+					cache.button_pressed->draw(get_canvas_item(), Rect2(od.x, od.y, s.width, MAX(s.height, label_h)));
 				}
 
 				o.y += (label_h - s.height) / 2;


### PR DESCRIPTION
Fixes #60859

The issue was a long-existing regression of #30009: `s` is the size of that button including the pressed background stylebox. The size was used to draw the stylebox and center the icon. That fix set `s` to be at least the same height as the tree item in order to adjust the stylebox, but it effectively also canceled the vertical centering.

This PR makes the height adjustment only applied when drawing the background stylebox.