### PR TITLE
Make the string representations of floats and ints clearly distinguishable

### DIFF
--- a/core/math/plane.cpp
+++ b/core/math/plane.cpp
@@ -175,5 +175,5 @@ bool Plane::is_equal_approx(const Plane &p_plane) const {
 }
 
 Plane::operator String() const {
-	return "[N: " + normal.operator String() + ", D: " + String::num_real(d, false) + "]";
+	return "[N: " + normal.operator String() + ", D: " + String::num_real(d, true) + "]";
 }

--- a/core/math/quaternion.cpp
+++ b/core/math/quaternion.cpp
@@ -202,7 +202,7 @@ Quaternion Quaternion::cubic_slerp(const Quaternion &p_b, const Quaternion &p_pr
 }
 
 Quaternion::operator String() const {
-	return "(" + String::num_real(x, false) + ", " + String::num_real(y, false) + ", " + String::num_real(z, false) + ", " + String::num_real(w, false) + ")";
+	return "(" + String::num_real(x, true) + ", " + String::num_real(y, true) + ", " + String::num_real(z, true) + ", " + String::num_real(w, true) + ")";
 }
 
 Vector3 Quaternion::get_axis() const {

--- a/core/math/vector2.cpp
+++ b/core/math/vector2.cpp
@@ -190,7 +190,7 @@ bool Vector2::is_equal_approx(const Vector2 &p_v) const {
 }
 
 Vector2::operator String() const {
-	return "(" + String::num_real(x, false) + ", " + String::num_real(y, false) + ")";
+	return "(" + String::num_real(x, true) + ", " + String::num_real(y, true) + ")";
 }
 
 Vector2::operator Vector2i() const {

--- a/core/math/vector3.cpp
+++ b/core/math/vector3.cpp
@@ -138,7 +138,7 @@ bool Vector3::is_equal_approx(const Vector3 &p_v) const {
 }
 
 Vector3::operator String() const {
-	return "(" + String::num_real(x, false) + ", " + String::num_real(y, false) + ", " + String::num_real(z, false) + ")";
+	return "(" + String::num_real(x, true) + ", " + String::num_real(y, true) + ", " + String::num_real(z, true) + ")";
 }
 
 Vector3::operator Vector3i() const {

--- a/core/string/ustring.cpp
+++ b/core/string/ustring.cpp
@@ -1425,7 +1425,11 @@ String String::num(double p_num, int p_decimals) {
 				if (buf[z] == '0') {
 					buf[z] = 0;
 				} else if (buf[z] == '.') {
-					buf[z] = 0;
+					if (z == 254) {
+						buf[z] = 0;
+					} else {
+						buf[z + 1] = '0';
+					}
 					break;
 				} else {
 					break;

--- a/tests/core/math/test_aabb.h
+++ b/tests/core/math/test_aabb.h
@@ -48,7 +48,7 @@ TEST_CASE("[AABB] Constructor methods") {
 
 TEST_CASE("[AABB] String conversion") {
 	CHECK_MESSAGE(
-			String(AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 5, 6))) == "[P: (-1.5, 2, -2.5), S: (4, 5, 6)]",
+			String(AABB(Vector3(-1.5, 2, -2.5), Vector3(4, 5, 6))) == "[P: (-1.5, 2, -2.5), S: (4.0, 5.0, 6.0)]",
 			"The string representation should match the expected value.");
 }
 

--- a/tests/core/math/test_color.h
+++ b/tests/core/math/test_color.h
@@ -140,7 +140,7 @@ TEST_CASE("[Color] Conversion methods") {
 			cyan.to_rgba64() == 0x0000'ffff'ffff'ffff,
 			"The returned 64-bit BGR number should match the expected value.");
 	CHECK_MESSAGE(
-			String(cyan) == "(0, 1, 1, 1)",
+			String(cyan) == "(0.0, 1.0, 1.0, 1.0)",
 			"The string representation should match the expected value.");
 }
 

--- a/tests/core/math/test_rect2.h
+++ b/tests/core/math/test_rect2.h
@@ -57,7 +57,7 @@ TEST_CASE("[Rect2] Constructor methods") {
 TEST_CASE("[Rect2] String conversion") {
 	// Note: This also depends on the Vector2 string representation.
 	CHECK_MESSAGE(
-			String(Rect2(0, 100, 1280, 720)) == "[P: (0, 100), S: (1280, 720)]",
+			String(Rect2(0, 100, 1280, 720)) == "[P: (0.0, 100.0), S: (1280.0, 720.0)]",
 			"The string representation should match the expected value.");
 }
 


### PR DESCRIPTION
meant to supersede #45303
addresses proposal https://github.com/godotengine/godot-proposals/issues/1693
related to #42809

45303 was great but did not cover all types. also it applied the change to a test-case for Rect2i which I think wasn't intentional.
this should take care of everything:


```swift
print("-------------- float:")
var a: float = 6
print(a)
print([a])
print({"a": a})
print(Vector2(a, a))
print(Vector3(a, a, a))
print(Rect2(a, a, a, a))
print(Color(a, a, a, a))
print(Plane(a, a, a, a))
print(Quaternion(a, a, a, a))
print(AABB(Vector3(a, a, a), Vector3(a, a, a)))
print(Basis(Vector3(a, a, a), Vector3(a, a, a), Vector3(a, a, a)))
print(Transform2D(Vector2(a, a), Vector2(a, a), Vector2(a, a)))
print(Transform3D(Vector3(a, a, a), Vector3(a, a, a), Vector3(a, a, a), Vector3(a, a, a)))
print(PackedFloat32Array([a, a, a]))
print(PackedFloat64Array([a, a, a]))
print(PackedVector2Array([Vector2(a, a)]))
print(PackedVector3Array([Vector3(a, a, a)]))
print(PackedColorArray([Color(a, a, a, a)]))

print("-------------- int still shows as int:")
var b: int = 6
print(b)
print([b])
print({"b": b})
print(Vector2i(b, b))
print(Vector3i(b, b, b))
print(Rect2i(b, b, b, b))
print(PackedInt32Array([b, b, b]))
print(PackedInt64Array([b, b, b]))
```
```
-------------- float:
6.0
[6.0]
{"a":6.0}
(6.0, 6.0)
(6.0, 6.0, 6.0)
[P: (6.0, 6.0), S: (6.0, 6.0)]
(6.0, 6.0, 6.0, 6.0)
[N: (6.0, 6.0, 6.0), D: 6.0]
(6.0, 6.0, 6.0, 6.0)
[P: (6.0, 6.0, 6.0), S: (6.0, 6.0, 6.0)]
[X: (6.0, 6.0, 6.0), Y: (6.0, 6.0, 6.0), Z: (6.0, 6.0, 6.0)]
[X: (6.0, 6.0), Y: (6.0, 6.0), O: (6.0, 6.0)]
[X: (6.0, 6.0, 6.0), Y: (6.0, 6.0, 6.0), Z: (6.0, 6.0, 6.0), O: (6.0, 6.0, 6.0)]
[6.0, 6.0, 6.0]
[6.0, 6.0, 6.0]
[(6.0, 6.0)]
[(6.0, 6.0, 6.0)]
[(6.0, 6.0, 6.0, 6.0)]
-------------- int still shows as int:
6
[6]
{"b":6}
(6, 6)
(6, 6, 6)
[P: (6, 6), S: (6, 6)]
[6, 6, 6]
[6, 6, 6]
```