### PR TITLE
Prevent error emitting when clicking on empty space on `EditorFileDialog`

### DIFF
--- a/editor/editor_file_dialog.cpp
+++ b/editor/editor_file_dialog.cpp
@@ -529,7 +529,7 @@ void EditorFileDialog::_multi_selected(int p_item, bool p_selected) {
 	get_ok_button()->set_disabled(_is_open_should_be_disabled());
 }
 
-void EditorFileDialog::_items_clear_selection(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index) {
+void EditorFileDialog::_items_clear_selection(const Vector2 &p_pos, MouseButton p_mouse_button_index) {
 	if (p_mouse_button_index != MouseButton::LEFT) {
 		return;
 	}

--- a/editor/editor_file_dialog.h
+++ b/editor/editor_file_dialog.h
@@ -165,7 +165,7 @@ private:
 
 	void _item_selected(int p_item);
 	void _multi_selected(int p_item, bool p_selected);
-	void _items_clear_selection(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index);
+	void _items_clear_selection(const Vector2 &p_pos, MouseButton p_mouse_button_index);
 	void _item_dc_selected(int p_item);
 
 	void _item_list_item_rmb_clicked(int p_item, const Vector2 &p_pos, MouseButton p_mouse_button_index);


### PR DESCRIPTION
Prevents error when user clicking on empty space in that dialog, e.g.:

![editor_file_dialog_bug](https://user-images.githubusercontent.com/3036176/167539408-1d8d9786-363f-4e15-a779-056f18669a86.gif)

