### PR TITLE
CI: Update Emscripten to 3.1.10

### DIFF
--- a/.github/workflows/javascript_builds.yml
+++ b/.github/workflows/javascript_builds.yml
@@ -6,7 +6,7 @@ env:
   # Only used for the cache key. Increment version to force clean build.
   GODOT_BASE_BRANCH: master
   SCONSFLAGS: verbose=yes warnings=extra werror=yes debug_symbols=no
-  EM_VERSION: 2.0.27
+  EM_VERSION: 3.1.10
   EM_CACHE_FOLDER: "emsdk-cache"
 
 concurrency:

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -635,8 +635,6 @@ Error ResourceLoaderBinary::load() {
 		return error;
 	}
 
-	int stage = 0;
-
 	for (int i = 0; i < external_resources.size(); i++) {
 		String path = external_resources[i].path;
 
@@ -674,8 +672,6 @@ Error ResourceLoaderBinary::load() {
 				}
 			}
 		}
-
-		stage++;
 	}
 
 	for (int i = 0; i < internal_resources.size(); i++) {
@@ -700,7 +696,6 @@ Error ResourceLoaderBinary::load() {
 				Ref<Resource> cached = ResourceCache::get(path);
 				if (cached.is_valid()) {
 					//already loaded, don't do anything
-					stage++;
 					error = OK;
 					internal_index_cache[path] = cached;
 					continue;
@@ -817,7 +812,6 @@ Error ResourceLoaderBinary::load() {
 #ifdef TOOLS_ENABLED
 		res->set_edited(false);
 #endif
-		stage++;
 
 		if (progress) {
 			*progress = (i + 1) / float(internal_resources.size());

--- a/core/math/delaunay_3d.h
+++ b/core/math/delaunay_3d.h
@@ -323,7 +323,6 @@ public:
 				E = N;
 			}
 
-			uint32_t good_triangles = 0;
 			for (uint32_t j = 0; j < triangles.size(); j++) {
 				if (triangles[j].bad) {
 					continue;
@@ -360,11 +359,8 @@ public:
 						}
 					}
 				}
-
-				good_triangles++;
 			}
 
-			//print_line("at point " + itos(i) + "/" + itos(point_count) + " simplices added " + itos(good_triangles) + "/" + itos(simplex_list.size()) + " - triangles: " + itos(triangles.size()));
 			triangles.clear();
 			triangles_inserted.clear();
 		}

--- a/core/math/quick_hull.cpp
+++ b/core/math/quick_hull.cpp
@@ -384,7 +384,6 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 			if (O->get().plane.is_equal_approx(f.plane)) {
 				//merge and delete edge and contiguous face, while repointing edges (uuugh!)
 				int ois = O->get().indices.size();
-				int merged = 0;
 
 				for (int j = 0; j < ois; j++) {
 					//search a
@@ -399,7 +398,6 @@ Error QuickHull::build(const Vector<Vector3> &p_points, Geometry3D::MeshData &r_
 							if (idx != a) {
 								f.indices.insert(i + 1, idx);
 								i++;
-								merged++;
 							}
 							Edge e2(idx, idxn);
 

--- a/modules/csg/csg.cpp
+++ b/modules/csg/csg.cpp
@@ -1387,13 +1387,13 @@ void CSGBrushOperation::update_faces(const CSGBrush &p_brush_a, const int p_face
 	}
 
 	// Ensure B has points either side of or in the plane of A.
-	int in_plane_count = 0, over_count = 0, under_count = 0;
+	int over_count = 0, under_count = 0;
 	Plane plane_a(vertices_a[0], vertices_a[1], vertices_a[2]);
 	ERR_FAIL_COND_MSG(plane_a.normal == Vector3(), "Couldn't form plane from Brush A face.");
 
 	for (int i = 0; i < 3; i++) {
 		if (plane_a.has_point(vertices_b[i])) {
-			in_plane_count++;
+			// In plane.
 		} else if (plane_a.is_point_over(vertices_b[i])) {
 			over_count++;
 		} else {
@@ -1406,7 +1406,6 @@ void CSGBrushOperation::update_faces(const CSGBrush &p_brush_a, const int p_face
 	}
 
 	// Ensure A has points either side of or in the plane of B.
-	in_plane_count = 0;
 	over_count = 0;
 	under_count = 0;
 	Plane plane_b(vertices_b[0], vertices_b[1], vertices_b[2]);
@@ -1414,7 +1413,7 @@ void CSGBrushOperation::update_faces(const CSGBrush &p_brush_a, const int p_face
 
 	for (int i = 0; i < 3; i++) {
 		if (plane_b.has_point(vertices_a[i])) {
-			in_plane_count++;
+			// In plane.
 		} else if (plane_b.is_point_over(vertices_a[i])) {
 			over_count++;
 		} else {

--- a/modules/svg/image_loader_svg.cpp
+++ b/modules/svg/image_loader_svg.cpp
@@ -94,7 +94,7 @@ void ImageLoaderSVG::create_image_from_string(Ref<Image> p_image, String p_strin
 		ERR_FAIL_MSG("ImageLoaderSVG can't create image.");
 	}
 
-	res = sw_canvas->push(move(picture));
+	res = sw_canvas->push(std::move(picture));
 	if (res != tvg::Result::Success) {
 		memfree(buffer);
 		ERR_FAIL_MSG("ImageLoaderSVG can't create image.");

--- a/modules/vorbis/audio_stream_ogg_vorbis.cpp
+++ b/modules/vorbis/audio_stream_ogg_vorbis.cpp
@@ -350,7 +350,6 @@ void AudioStreamOGGVorbis::maybe_update_info() {
 	vorbis_info_init(&info);
 	vorbis_comment_init(&comment);
 
-	int packet_count = 0;
 	Ref<OGGPacketSequencePlayback> packet_sequence_playback = packet_sequence->instance_playback();
 
 	for (int i = 0; i < 3; i++) {
@@ -369,8 +368,6 @@ void AudioStreamOGGVorbis::maybe_update_info() {
 
 		err = vorbis_synthesis_headerin(&info, &comment, packet);
 		ERR_FAIL_COND_MSG(err != 0, "Error parsing header packet " + itos(i) + ": " + itos(err));
-
-		packet_count++;
 	}
 
 	packet_sequence->set_sampling_rate(info.rate);

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -318,12 +318,11 @@ void LightmapGI::_find_meshes_and_lights(Node *p_at_node, Vector<MeshesFound> &m
 int LightmapGI::_bsp_get_simplex_side(const Vector<Vector3> &p_points, const LocalVector<BSPSimplex> &p_simplices, const Plane &p_plane, uint32_t p_simplex) const {
 	int over = 0;
 	int under = 0;
-	int coplanar = 0;
 	const BSPSimplex &s = p_simplices[p_simplex];
 	for (int i = 0; i < 4; i++) {
 		const Vector3 v = p_points[s.vertices[i]];
-		if (p_plane.has_point(v)) { //coplanar
-			coplanar++;
+		if (p_plane.has_point(v)) {
+			// Coplanar.
 		} else if (p_plane.is_point_over(v)) {
 			over++;
 		} else {

--- a/scene/3d/voxelizer.cpp
+++ b/scene/3d/voxelizer.cpp
@@ -592,7 +592,6 @@ void Voxelizer::_fixup_plot(int p_idx, int p_level) {
 		bake_cells.write[p_idx].albedo[2] = 0;
 
 		float alpha_average = 0;
-		int children_found = 0;
 
 		for (int i = 0; i < 8; i++) {
 			uint32_t child = bake_cells[p_idx].children[i];
@@ -603,8 +602,6 @@ void Voxelizer::_fixup_plot(int p_idx, int p_level) {
 
 			_fixup_plot(child, p_level + 1);
 			alpha_average += bake_cells[child].alpha;
-
-			children_found++;
 		}
 
 		bake_cells.write[p_idx].alpha = alpha_average / 8.0;

--- a/scene/resources/polygon_path_finder.cpp
+++ b/scene/resources/polygon_path_finder.cpp
@@ -137,7 +137,7 @@ Vector<Vector2> PolygonPathFinder::find_path(const Vector2 &p_from, const Vector
 	Edge ignore_to_edge(-1, -1);
 
 	if (!_is_point_inside(from)) {
-		float closest_dist = 1e20;
+		float closest_dist = 1e20f;
 		Vector2 closest_point;
 
 		for (Set<Edge>::Element *E = edges.front(); E; E = E->next()) {
@@ -161,7 +161,7 @@ Vector<Vector2> PolygonPathFinder::find_path(const Vector2 &p_from, const Vector
 	};
 
 	if (!_is_point_inside(to)) {
-		float closest_dist = 1e20;
+		float closest_dist = 1e20f;
 		Vector2 closest_point;
 
 		for (Set<Edge>::Element *E = edges.front(); E; E = E->next()) {
@@ -489,7 +489,7 @@ bool PolygonPathFinder::is_point_inside(const Vector2 &p_point) const {
 }
 
 Vector2 PolygonPathFinder::get_closest_point(const Vector2 &p_point) const {
-	float closest_dist = 1e20;
+	float closest_dist = 1e20f;
 	Vector2 closest_point;
 
 	for (Set<Edge>::Element *E = edges.front(); E; E = E->next()) {
@@ -508,7 +508,7 @@ Vector2 PolygonPathFinder::get_closest_point(const Vector2 &p_point) const {
 		}
 	}
 
-	ERR_FAIL_COND_V(closest_dist == 1e20, Vector2());
+	ERR_FAIL_COND_V(Math::is_equal_approx(closest_dist, 1e20f), Vector2());
 
 	return closest_point;
 }

--- a/servers/rendering/renderer_viewport.cpp
+++ b/servers/rendering/renderer_viewport.cpp
@@ -226,8 +226,6 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 	}
 
 	if (!p_viewport->disable_2d) {
-		int i = 0;
-
 		Map<Viewport::CanvasKey, Viewport::CanvasData *> canvas_map;
 
 		Rect2 clip_rect(0, 0, p_viewport->size.x, p_viewport->size.y);
@@ -238,13 +236,13 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 		RendererCanvasRender::Light *directional_lights_with_shadow = nullptr;
 
 		if (p_viewport->sdf_active) {
-			//process SDF
+			// Process SDF.
 
 			Rect2 sdf_rect = RSG::texture_storage->render_target_get_sdf_rect(p_viewport->render_target);
 
 			RendererCanvasRender::LightOccluderInstance *occluders = nullptr;
 
-			//make list of occluders
+			// Make list of occluders.
 			for (KeyValue<RID, Viewport::CanvasData> &E : p_viewport->canvas_map) {
 				RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E.value.canvas);
 				Transform2D xf = _canvas_get_transform(p_viewport, canvas, &E.value, clip_rect.size);
@@ -265,14 +263,13 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 			RSG::canvas_render->render_sdf(p_viewport->render_target, occluders);
 			RSG::texture_storage->render_target_mark_sdf_enabled(p_viewport->render_target, true);
 
-			p_viewport->sdf_active = false; // if used, gets set active again
+			p_viewport->sdf_active = false; // If used, gets set active again.
 		} else {
 			RSG::texture_storage->render_target_mark_sdf_enabled(p_viewport->render_target, false);
 		}
 
 		Rect2 shadow_rect;
 
-		int light_count = 0;
 		int shadow_count = 0;
 		int directional_light_count = 0;
 
@@ -282,7 +279,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 
 			Transform2D xf = _canvas_get_transform(p_viewport, canvas, &E.value, clip_rect.size);
 
-			//find lights in canvas
+			// Find lights in canvas.
 
 			for (Set<RendererCanvasRender::Light *>::Element *F = canvas->lights.front(); F; F = F->next()) {
 				RendererCanvasRender::Light *cl = F->get();
@@ -298,12 +295,10 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 					if (clip_rect.intersects_transformed(cl->xform_cache, cl->rect_cache)) {
 						cl->filter_next_ptr = lights;
 						lights = cl;
-						//						cl->texture_cache = nullptr;
 						Transform2D scale;
 						scale.scale(cl->rect_cache.size);
 						scale.columns[2] = cl->rect_cache.position;
 						cl->light_shader_xform = cl->xform * scale;
-						//cl->light_shader_pos = cl->xform_cache[2];
 						if (cl->use_shadow) {
 							cl->shadows_next_ptr = lights_with_shadow;
 							if (lights_with_shadow == nullptr) {
@@ -314,11 +309,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 							lights_with_shadow = cl;
 							cl->radius_cache = cl->rect_cache.size.length();
 						}
-
-						light_count++;
 					}
-
-					//guess this is not needed, but keeping because it may be
 				}
 			}
 
@@ -433,8 +424,7 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 
 				RENDER_TIMESTAMP("> Render DirectionalLight2D Shadows");
 
-				//make list of occluders
-				int occ_cullded = 0;
+				// Make list of occluders.
 				for (KeyValue<RID, Viewport::CanvasData> &E : p_viewport->canvas_map) {
 					RendererCanvasCull::Canvas *canvas = static_cast<RendererCanvasCull::Canvas *>(E.value.canvas);
 					Transform2D xf = _canvas_get_transform(p_viewport, canvas, &E.value, clip_rect.size);
@@ -452,7 +442,6 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 						if (F->get()->aabb_cache.intersects_filled_polygon(xf_points, point_count)) {
 							F->get()->next = occluders;
 							occluders = F->get();
-							occ_cullded++;
 						}
 					}
 				}
@@ -504,7 +493,6 @@ void RendererViewport::_draw_viewport(Viewport *p_viewport) {
 			if (RSG::canvas->was_sdf_used()) {
 				p_viewport->sdf_active = true;
 			}
-			i++;
 
 			if (scenario_draw_canvas_bg && E.key.get_layer() >= scenario_canvas_max_layer) {
 				if (!can_draw_3d) {


### PR DESCRIPTION
That's the version that we'll (tentatively) use for future 3.x and 4.0
builds.

Cf. https://github.com/godotengine/build-containers/pull/104

Fix `-Wunused-but-set-variable`, `-Wunqualified-std-cast-call`, and
`-Wliteral-range` warnings.