### PR TITLE
Physics Interpolation - add warnings to RESET_PHYSICS_INTERPOLATION

### DIFF
--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -108,6 +108,17 @@ void VisualInstance::_notification(int p_what) {
 			if (_is_vi_visible() && is_physics_interpolated()) {
 				VisualServer::get_singleton()->instance_reset_physics_interpolation(instance);
 			}
+#if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
+			else if (GLOBAL_GET("debug/settings/physics_interpolation/enable_warnings")) {
+				String node_name = is_inside_tree() ? String(get_path()) : String(get_name());
+				if (!_is_vi_visible()) {
+					WARN_PRINT("[Physics interpolation] NOTIFICATION_RESET_PHYSICS_INTERPOLATION only works with unhidden nodes: \"" + node_name + "\".");
+				}
+				if (!is_physics_interpolated()) {
+					WARN_PRINT("[Physics interpolation] NOTIFICATION_RESET_PHYSICS_INTERPOLATION only works with interpolated nodes: \"" + node_name + "\".");
+				}
+			}
+#endif
 		} break;
 		case NOTIFICATION_EXIT_WORLD: {
 			VisualServer::get_singleton()->instance_set_scenario(instance, RID());


### PR DESCRIPTION
Adds warnings when NOTIFICATION_RESET_PHYSICS_INTERPOLATION is called and has no effect due to the node being hidden or not interpolated.

## Notes
* From user testing it is clear a warning would be useful when calling `reset_physics_interpolation()` before unhiding a node, to indicate that is has no effect.
* This means I should also modify #60822 to make sure it doesn't send the notification on hidden nodes, to prevent false warnings.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
