### PR TITLE
[TextServer] Fix incorrect oversampled font scaling.

### DIFF
--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -2172,6 +2172,11 @@ void TextServerAdvanced::font_set_scale(const RID &p_font_rid, int64_t p_size, d
 	Vector2i size = _get_size(fd, p_size);
 
 	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+#ifdef MODULE_FREETYPE_ENABLED
+	if (fd->cache[size]->face) {
+		return; // Do not override scale for dynamic fonts, it's calculated automatically.
+	}
+#endif
 	fd->cache[size]->scale = p_scale;
 }
 

--- a/modules/text_server_fb/text_server_fb.cpp
+++ b/modules/text_server_fb/text_server_fb.cpp
@@ -1334,6 +1334,11 @@ void TextServerFallback::font_set_scale(const RID &p_font_rid, int64_t p_size, d
 	Vector2i size = _get_size(fd, p_size);
 
 	ERR_FAIL_COND(!_ensure_cache_for_size(fd, size));
+#ifdef MODULE_FREETYPE_ENABLED
+	if (fd->cache[size]->face) {
+		return; // Do not override scale for dynamic fonts, it's calculated automatically.
+	}
+#endif
 	fd->cache[size]->scale = p_scale;
 }
 


### PR DESCRIPTION
Scale for dynamic fonts is calculated automatically and should not be restored from imported font cache, changing it manually is intended for bitmap fonts only.

Fixes #60785