### PR TITLE
Fix display of unsupported project features in the project manager

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1401,7 +1401,7 @@ void ProjectList::create_project_item_control(int p_index) {
 		title->set_clip_text(true);
 		title_hb->add_child(title);
 
-		String unsupported_features_str = Variant(item.unsupported_features).operator String().trim_prefix("[").trim_suffix("]");
+		String unsupported_features_str = String(", ").join(item.unsupported_features);
 		int length = unsupported_features_str.length();
 		if (length > 0) {
 			Label *unsupported_label = memnew(Label(unsupported_features_str));
@@ -2207,7 +2207,7 @@ void ProjectManager::_open_selected_projects_ask() {
 			}
 		}
 		if (!unsupported_features.is_empty()) {
-			String unsupported_features_str = Variant(unsupported_features).operator String().trim_prefix("[").trim_suffix("]");
+			String unsupported_features_str = String(", ").join(unsupported_features);
 			warning_message += vformat(TTR("Warning: This project uses the following features not supported by this build of Godot:\n\n%s\n\n"), unsupported_features_str);
 		}
 		warning_message += TTR("Open anyway? Project will be modified.");


### PR DESCRIPTION
This was giving incorrect behavior as of #60609, it has now been fixed using the technique documented in #60922. This new code is much better too, it's simpler and probably faster.