### PR TITLE
Add cached GLOBAL_GET macros

### DIFF
--- a/core/project_settings.cpp
+++ b/core/project_settings.cpp
@@ -184,6 +184,7 @@ bool ProjectSettings::_set(const StringName &p_name, const Variant &p_value) {
 	// marking the project settings as dirty allows them only to be
 	// checked when dirty.
 	_dirty_this_frame = 2;
+	_version++;
 
 	if (p_value.get_type() == Variant::NIL) {
 		props.erase(p_name);

--- a/scene/3d/visual_instance.cpp
+++ b/scene/3d/visual_instance.cpp
@@ -109,7 +109,7 @@ void VisualInstance::_notification(int p_what) {
 				VisualServer::get_singleton()->instance_reset_physics_interpolation(instance);
 			}
 #if defined(DEBUG_ENABLED) && defined(TOOLS_ENABLED)
-			else if (GLOBAL_GET("debug/settings/physics_interpolation/enable_warnings")) {
+			else if (GLOBAL_GET_FAST(bool, "debug/settings/physics_interpolation/enable_warnings")) {
 				String node_name = is_inside_tree() ? String(get_path()) : String(get_name());
 				if (!_is_vi_visible()) {
 					WARN_PRINT("[Physics interpolation] NOTIFICATION_RESET_PHYSICS_INTERPOLATION only works with unhidden nodes: \"" + node_name + "\".");


### PR DESCRIPTION
Instead of querying ProjectSettings fully each time, these macros first check a static local version against ProjectSettings. If the version has changed, a static local variable is updated and returned. If the version is up to date, the cached static local variable is returned.

The idea of this PR is to decrease the cost of the rather heavyweight calls to `GLOBAL_GET` in the codebase.

I'd already added a couple of other methods previously (the `project_settings_changed` signal etc) in #53296 , and that still represents the recommended way to check project settings in bulk. But this PR adds a slightly more efficient variation of the standard `GLOBAL_GET`, which can be fine in some circumstances and requires less boiler plate.

## Notes
* If we agree on this technique I can do equivalent PR for 4.x.
* I'm a complete newbie to lambdas, and I shamelessly ripped off this approach from the `SNAME` macro in Godot 4, so could do with checking by someone who properly understands this voodoo and actually knows what they are doing.
* There's probably a few more places that might be worth using the FAST variation, but the PR is kept as simple as possible for bikeshedding.
* Tested memory use doesn't seem significantly different between the build before and after this PR (it is probably only a couple of Kb of static memory, unless the macros were used e.g. in a recursive situation).
* Welcome ideas on improvements for naming.
* This should actually be thread safe (providing the `ProjectSettings::get()` call is thread safe, which is outside the scope of this PR), despite there being no atomics etc. The only changes to `_version` are made in `_set()` which is a `_THREAD_SAFE_METHOD`. Reading only needs to detect a difference, even if the local version (in the macro) is mangled for 1 frame, the worst that can happen seems to a read of the project setting on 2 adjacent frames. So it doesn't seem worth making `_version` atomic, or having locks on `_version`.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->