### PR TITLE
[macOS / iOS] Fix text-to-speech build with older macOS / iOS SDK.

### DIFF
--- a/drivers/coreaudio/audio_driver_coreaudio.h
+++ b/drivers/coreaudio/audio_driver_coreaudio.h
@@ -35,9 +35,9 @@
 
 #include "servers/audio_server.h"
 
-#include <AudioUnit/AudioUnit.h>
+#import <AudioUnit/AudioUnit.h>
 #ifdef OSX_ENABLED
-#include <CoreAudio/AudioHardware.h>
+#import <CoreAudio/AudioHardware.h>
 #endif
 
 class AudioDriverCoreAudio : public AudioDriver {

--- a/drivers/coremidi/midi_driver_coremidi.cpp
+++ b/drivers/coremidi/midi_driver_coremidi.cpp
@@ -34,8 +34,8 @@
 
 #include "core/string/print_string.h"
 
-#include <CoreAudio/HostTime.h>
-#include <CoreServices/CoreServices.h>
+#import <CoreAudio/HostTime.h>
+#import <CoreServices/CoreServices.h>
 
 void MIDIDriverCoreMidi::read(const MIDIPacketList *packet_list, void *read_proc_ref_con, void *src_conn_ref_con) {
 	MIDIPacket *packet = const_cast<MIDIPacket *>(packet_list->packet);

--- a/drivers/coremidi/midi_driver_coremidi.h
+++ b/drivers/coremidi/midi_driver_coremidi.h
@@ -36,7 +36,7 @@
 #include "core/os/midi_driver.h"
 #include "core/templates/vector.h"
 
-#include <CoreMIDI/CoreMIDI.h>
+#import <CoreMIDI/CoreMIDI.h>
 #include <stdio.h>
 
 class MIDIDriverCoreMidi : public MIDIDriver {

--- a/modules/mono/utils/osx_utils.cpp
+++ b/modules/mono/utils/osx_utils.cpp
@@ -34,8 +34,8 @@
 
 #include "core/string/print_string.h"
 
-#include <CoreFoundation/CoreFoundation.h>
-#include <CoreServices/CoreServices.h>
+#import <CoreFoundation/CoreFoundation.h>
+#import <CoreServices/CoreServices.h>
 
 bool osx_is_app_bundle_installed(const String &p_bundle_id) {
 	CFStringRef bundle_id = CFStringCreateWithCString(nullptr, p_bundle_id.utf8(), kCFStringEncodingUTF8);

--- a/platform/iphone/tts_ios.h
+++ b/platform/iphone/tts_ios.h
@@ -31,7 +31,11 @@
 #ifndef TTS_IOS_H
 #define TTS_IOS_H
 
-#include <AVFAudio/AVSpeechSynthesis.h>
+#if __has_include(<AVFAudio/AVSpeechSynthesis.h>)
+#import <AVFAudio/AVSpeechSynthesis.h>
+#else
+#import <AVFoundation/AVFoundation.h>
+#endif
 
 #include "core/string/ustring.h"
 #include "core/templates/list.h"

--- a/platform/osx/dir_access_osx.mm
+++ b/platform/osx/dir_access_osx.mm
@@ -34,8 +34,8 @@
 
 #include <errno.h>
 
-#include <AppKit/NSWorkspace.h>
-#include <Foundation/Foundation.h>
+#import <AppKit/NSWorkspace.h>
+#import <Foundation/Foundation.h>
 
 String DirAccessOSX::fix_unicode_name(const char *p_name) const {
 	String fname;

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -45,10 +45,11 @@
 #include "platform/osx/vulkan_context_osx.h"
 #endif // VULKAN_ENABLED
 
-#include <AppKit/AppKit.h>
-#include <AppKit/NSCursor.h>
-#include <ApplicationServices/ApplicationServices.h>
-#include <CoreVideo/CoreVideo.h>
+#import <AppKit/AppKit.h>
+#import <AppKit/NSCursor.h>
+#import <ApplicationServices/ApplicationServices.h>
+#import <CoreVideo/CoreVideo.h>
+#import <Foundation/Foundation.h>
 
 #undef BitMap
 #undef CursorShape

--- a/platform/osx/display_server_osx.mm
+++ b/platform/osx/display_server_osx.mm
@@ -45,12 +45,12 @@
 #include "main/main.h"
 #include "scene/resources/texture.h"
 
-#include <Carbon/Carbon.h>
-#include <Cocoa/Cocoa.h>
-#include <IOKit/IOCFPlugIn.h>
-#include <IOKit/IOKitLib.h>
-#include <IOKit/hid/IOHIDKeys.h>
-#include <IOKit/hid/IOHIDLib.h>
+#import <Carbon/Carbon.h>
+#import <Cocoa/Cocoa.h>
+#import <IOKit/IOCFPlugIn.h>
+#import <IOKit/IOKitLib.h>
+#import <IOKit/hid/IOHIDKeys.h>
+#import <IOKit/hid/IOHIDLib.h>
 
 #if defined(GLES3_ENABLED)
 #include "drivers/gles3/rasterizer_gles3.h"
@@ -146,7 +146,7 @@ DisplayServerOSX::WindowID DisplayServerOSX::_create_window(WindowMode p_mode, V
 			[wd.window_object setTabbingMode:NSWindowTabbingModeDisallowed];
 		}
 
-		CALayer *layer = [wd.window_view layer];
+		CALayer *layer = [(NSView *)wd.window_view layer];
 		if (layer) {
 			layer.contentsScale = scale;
 		}
@@ -174,7 +174,7 @@ DisplayServerOSX::WindowID DisplayServerOSX::_create_window(WindowMode p_mode, V
 	wd.size.width = contentRect.size.width * scale;
 	wd.size.height = contentRect.size.height * scale;
 
-	CALayer *layer = [wd.window_view layer];
+	CALayer *layer = [(NSView *)wd.window_view layer];
 	if (layer) {
 		layer.contentsScale = scale;
 	}
@@ -209,16 +209,16 @@ void DisplayServerOSX::_update_window_style(WindowData p_wd) {
 
 	if (borderless_full) {
 		// If the window covers up the screen set the level to above the main menu and hide on deactivate.
-		[p_wd.window_object setLevel:NSMainMenuWindowLevel + 1];
-		[p_wd.window_object setHidesOnDeactivate:YES];
+		[(NSWindow *)p_wd.window_object setLevel:NSMainMenuWindowLevel + 1];
+		[(NSWindow *)p_wd.window_object setHidesOnDeactivate:YES];
 	} else {
 		// Reset these when our window is not a borderless window that covers up the screen.
 		if (p_wd.on_top && !p_wd.fullscreen) {
-			[p_wd.window_object setLevel:NSFloatingWindowLevel];
+			[(NSWindow *)p_wd.window_object setLevel:NSFloatingWindowLevel];
 		} else {
-			[p_wd.window_object setLevel:NSNormalWindowLevel];
+			[(NSWindow *)p_wd.window_object setLevel:NSNormalWindowLevel];
 		}
-		[p_wd.window_object setHidesOnDeactivate:NO];
+		[(NSWindow *)p_wd.window_object setHidesOnDeactivate:NO];
 	}
 }
 
@@ -234,7 +234,7 @@ void DisplayServerOSX::_set_window_per_pixel_transparency_enabled(bool p_enabled
 			[wd.window_object setBackgroundColor:[NSColor clearColor]];
 			[wd.window_object setOpaque:NO];
 			[wd.window_object setHasShadow:NO];
-			CALayer *layer = [wd.window_view layer];
+			CALayer *layer = [(NSView *)wd.window_view layer];
 			if (layer) {
 				[layer setBackgroundColor:[NSColor clearColor].CGColor];
 				[layer setOpaque:NO];
@@ -249,7 +249,7 @@ void DisplayServerOSX::_set_window_per_pixel_transparency_enabled(bool p_enabled
 			[wd.window_object setBackgroundColor:[NSColor colorWithCalibratedWhite:1 alpha:1]];
 			[wd.window_object setOpaque:YES];
 			[wd.window_object setHasShadow:YES];
-			CALayer *layer = [wd.window_view layer];
+			CALayer *layer = [(NSView *)wd.window_view layer];
 			if (layer) {
 				[layer setBackgroundColor:[NSColor colorWithCalibratedWhite:1 alpha:1].CGColor];
 				[layer setOpaque:YES];
@@ -2256,7 +2256,7 @@ void DisplayServerOSX::window_set_mode(WindowMode p_mode, WindowID p_window) {
 		} break;
 		case WINDOW_MODE_EXCLUSIVE_FULLSCREEN:
 		case WINDOW_MODE_FULLSCREEN: {
-			[wd.window_object setLevel:NSNormalWindowLevel];
+			[(NSWindow *)wd.window_object setLevel:NSNormalWindowLevel];
 			_set_window_per_pixel_transparency_enabled(true, p_window);
 			if (wd.resize_disabled) { // Restore resize disabled.
 				[wd.window_object setStyleMask:[wd.window_object styleMask] & ~NSWindowStyleMaskResizable];
@@ -2380,9 +2380,9 @@ void DisplayServerOSX::window_set_flag(WindowFlags p_flag, bool p_enabled, Windo
 				return;
 			}
 			if (p_enabled) {
-				[wd.window_object setLevel:NSFloatingWindowLevel];
+				[(NSWindow *)wd.window_object setLevel:NSFloatingWindowLevel];
 			} else {
-				[wd.window_object setLevel:NSNormalWindowLevel];
+				[(NSWindow *)wd.window_object setLevel:NSNormalWindowLevel];
 			}
 		} break;
 		case WINDOW_FLAG_TRANSPARENT: {
@@ -2423,7 +2423,7 @@ bool DisplayServerOSX::window_get_flag(WindowFlags p_flag, WindowID p_window) co
 			if (wd.fullscreen) {
 				return wd.on_top;
 			} else {
-				return [wd.window_object level] == NSFloatingWindowLevel;
+				return [(NSWindow *)wd.window_object level] == NSFloatingWindowLevel;
 			}
 		} break;
 		case WINDOW_FLAG_TRANSPARENT: {

--- a/platform/osx/gl_manager_osx_legacy.h
+++ b/platform/osx/gl_manager_osx_legacy.h
@@ -38,9 +38,9 @@
 #include "core/templates/local_vector.h"
 #include "servers/display_server.h"
 
-#include <AppKit/AppKit.h>
-#include <ApplicationServices/ApplicationServices.h>
-#include <CoreVideo/CoreVideo.h>
+#import <AppKit/AppKit.h>
+#import <ApplicationServices/ApplicationServices.h>
+#import <CoreVideo/CoreVideo.h>
 
 class GLManager_OSX {
 public:

--- a/platform/osx/joypad_osx.h
+++ b/platform/osx/joypad_osx.h
@@ -32,13 +32,13 @@
 #define JOYPADOSX_H
 
 #ifdef MACOS_10_0_4
-#include <IOKit/hidsystem/IOHIDUsageTables.h>
+#import <IOKit/hidsystem/IOHIDUsageTables.h>
 #else
-#include <Kernel/IOKit/hidsystem/IOHIDUsageTables.h>
+#import <Kernel/IOKit/hidsystem/IOHIDUsageTables.h>
 #endif
-#include <ForceFeedback/ForceFeedback.h>
-#include <ForceFeedback/ForceFeedbackConstants.h>
-#include <IOKit/hid/IOHIDLib.h>
+#import <ForceFeedback/ForceFeedback.h>
+#import <ForceFeedback/ForceFeedbackConstants.h>
+#import <IOKit/hid/IOHIDLib.h>
 
 #include "core/input/input.h"
 

--- a/platform/osx/key_mapping_osx.mm
+++ b/platform/osx/key_mapping_osx.mm
@@ -30,8 +30,8 @@
 
 #include "key_mapping_osx.h"
 
-#include <Carbon/Carbon.h>
-#include <Cocoa/Cocoa.h>
+#import <Carbon/Carbon.h>
+#import <Cocoa/Cocoa.h>
 
 bool KeyMappingOSX::is_numpad_key(unsigned int key) {
 	static const unsigned int table[] = {

--- a/platform/osx/tts_osx.h
+++ b/platform/osx/tts_osx.h
@@ -37,8 +37,13 @@
 #include "core/variant/array.h"
 #include "servers/display_server.h"
 
-#include <AVFAudio/AVSpeechSynthesis.h>
-#include <AppKit/AppKit.h>
+#import <AppKit/AppKit.h>
+
+#if __has_include(<AVFAudio/AVSpeechSynthesis.h>)
+#import <AVFAudio/AVSpeechSynthesis.h>
+#else
+#import <AVFoundation/AVFoundation.h>
+#endif
 
 @interface TTS_OSX : NSObject <AVSpeechSynthesizerDelegate> {
 	// AVSpeechSynthesizer

--- a/platform/osx/vulkan_context_osx.h
+++ b/platform/osx/vulkan_context_osx.h
@@ -32,7 +32,7 @@
 #define VULKAN_DEVICE_OSX_H
 
 #include "drivers/vulkan/vulkan_context.h"
-#include <AppKit/AppKit.h>
+#import <AppKit/AppKit.h>
 
 class VulkanContextOSX : public VulkanContext {
 	virtual const char *_get_platform_surface_extension() const;


### PR DESCRIPTION
Seems like `AVFAudio` framework, which is independent in the latest SDKs, was part of `AVFoundation`.

- Add `__has_include` check for `AVFAudio` include.
- Add some explicit casts to avoid conflicts.
- Change all `include`s to `import`s for consistency.

Fixes #60872