### PR TITLE
Add EditorInterface.get_selected_paths()

### DIFF
--- a/doc/classes/EditorInterface.xml
+++ b/doc/classes/EditorInterface.xml
@@ -48,6 +48,12 @@
 				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
+		<method name="get_current_directory" qualifiers="const">
+			<return type="String" />
+			<description>
+				Returns the current directory being viewed in the [FileSystemDock]. If a file is selected, its base directory will be returned using [method String.get_base_dir] instead.
+			</description>
+		</method>
 		<method name="get_current_path" qualifiers="const">
 			<return type="String" />
 			<description>
@@ -131,10 +137,10 @@
 				[b]Warning:[/b] Removing and freeing this node will render a part of the editor useless and may cause a crash.
 			</description>
 		</method>
-		<method name="get_selected_path" qualifiers="const">
-			<return type="String" />
+		<method name="get_selected_paths" qualifiers="const">
+			<return type="PackedStringArray" />
 			<description>
-				Returns the path of the directory currently selected in the [FileSystemDock]. If a file is selected, its base directory will be returned using [method String.get_base_dir] instead.
+				Returns an array containing the paths of the currently selected files (and directories) in the [FileSystemDock].
 			</description>
 		</method>
 		<method name="get_selection">

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -5763,7 +5763,7 @@ void EditorNode::_global_menu_new_window(const Variant &p_tag) {
 }
 
 void EditorNode::_dropped_files(const Vector<String> &p_files) {
-	String to_path = ProjectSettings::get_singleton()->globalize_path(FileSystemDock::get_singleton()->get_selected_path());
+	String to_path = ProjectSettings::get_singleton()->globalize_path(FileSystemDock::get_singleton()->get_current_directory());
 
 	_add_dropped_files_recursive(p_files, to_path);
 

--- a/editor/editor_plugin.cpp
+++ b/editor/editor_plugin.cpp
@@ -243,12 +243,16 @@ void EditorInterface::select_file(const String &p_file) {
 	FileSystemDock::get_singleton()->select_file(p_file);
 }
 
-String EditorInterface::get_selected_path() const {
-	return FileSystemDock::get_singleton()->get_selected_path();
+Vector<String> EditorInterface::get_selected_paths() const {
+	return FileSystemDock::get_singleton()->get_selected_paths();
 }
 
 String EditorInterface::get_current_path() const {
 	return FileSystemDock::get_singleton()->get_current_path();
+}
+
+String EditorInterface::get_current_directory() const {
+	return FileSystemDock::get_singleton()->get_current_directory();
 }
 
 void EditorInterface::inspect_object(Object *p_obj, const String &p_for_property, bool p_inspector_only) {
@@ -368,8 +372,9 @@ void EditorInterface::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_editor_main_screen"), &EditorInterface::get_editor_main_screen);
 	ClassDB::bind_method(D_METHOD("make_mesh_previews", "meshes", "preview_size"), &EditorInterface::_make_mesh_previews);
 	ClassDB::bind_method(D_METHOD("select_file", "file"), &EditorInterface::select_file);
-	ClassDB::bind_method(D_METHOD("get_selected_path"), &EditorInterface::get_selected_path);
+	ClassDB::bind_method(D_METHOD("get_selected_paths"), &EditorInterface::get_selected_paths);
 	ClassDB::bind_method(D_METHOD("get_current_path"), &EditorInterface::get_current_path);
+	ClassDB::bind_method(D_METHOD("get_current_directory"), &EditorInterface::get_current_directory);
 	ClassDB::bind_method(D_METHOD("get_file_system_dock"), &EditorInterface::get_file_system_dock);
 	ClassDB::bind_method(D_METHOD("get_editor_paths"), &EditorInterface::get_editor_paths);
 	ClassDB::bind_method(D_METHOD("get_command_palette"), &EditorInterface::get_command_palette);

--- a/editor/editor_plugin.h
+++ b/editor/editor_plugin.h
@@ -94,8 +94,9 @@ public:
 	EditorCommandPalette *get_command_palette() const;
 
 	void select_file(const String &p_file);
-	String get_selected_path() const;
+	Vector<String> get_selected_paths() const;
 	String get_current_path() const;
+	String get_current_directory() const;
 
 	void inspect_object(Object *p_obj, const String &p_for_property = String(), bool p_inspector_only = false);
 

--- a/editor/filesystem_dock.cpp
+++ b/editor/filesystem_dock.cpp
@@ -512,16 +512,20 @@ void FileSystemDock::_tree_multi_selected(Object *p_item, int p_column, bool p_s
 	}
 }
 
-String FileSystemDock::get_selected_path() const {
+Vector<String> FileSystemDock::get_selected_paths() const {
+	return _tree_get_selected(false);
+}
+
+String FileSystemDock::get_current_path() const {
+	return path;
+}
+
+String FileSystemDock::get_current_directory() const {
 	if (path.ends_with("/")) {
 		return path;
 	} else {
 		return path.get_base_dir();
 	}
-}
-
-String FileSystemDock::get_current_path() const {
-	return path;
 }
 
 void FileSystemDock::_set_current_path_text(const String &p_path) {
@@ -1727,7 +1731,7 @@ void FileSystemDock::_move_operation_confirm(const String &p_to_path, bool p_ove
 	}
 }
 
-Vector<String> FileSystemDock::_tree_get_selected(bool remove_self_inclusion) {
+Vector<String> FileSystemDock::_tree_get_selected(bool remove_self_inclusion) const {
 	// Build a list of selected items with the active one at the first position.
 	Vector<String> selected_strings;
 

--- a/editor/filesystem_dock.h
+++ b/editor/filesystem_dock.h
@@ -297,12 +297,12 @@ private:
 
 	void _update_display_mode(bool p_force = false);
 
-	Vector<String> _tree_get_selected(bool remove_self_inclusion = true);
+	Vector<String> _tree_get_selected(bool remove_self_inclusion = true) const;
 
 	bool _is_file_type_disabled_by_feature_profile(const StringName &p_class);
 
 	void _feature_profile_changed();
-	Vector<String> _remove_self_included_paths(Vector<String> selected_strings);
+	static Vector<String> _remove_self_included_paths(Vector<String> selected_strings);
 
 private:
 	static FileSystemDock *singleton;
@@ -315,9 +315,11 @@ protected:
 	static void _bind_methods();
 
 public:
-	String get_selected_path() const;
+	Vector<String> get_selected_paths() const;
 
 	String get_current_path() const;
+	String get_current_directory() const;
+
 	void navigate_to_path(const String &p_path);
 	void focus_on_filter();
 

--- a/editor/project_converter_3_to_4.cpp
+++ b/editor/project_converter_3_to_4.cpp
@@ -366,6 +366,7 @@ static const char *gdscript_function_renames[][2] = {
 	{ "get_scancode", "get_keycode" }, // InputEventKey
 	{ "get_scancode_string", "get_keycode_string" }, // OS
 	{ "get_scancode_with_modifiers", "get_keycode_with_modifiers" }, // InputEventKey
+	{ "get_selected_path", "get_current_directory" }, // EditorInterface
 	{ "get_shift", "is_shift_pressed" }, // InputEventWithModifiers
 	{ "get_size_override", "get_size_2d_override" }, // SubViewport
 	{ "get_slide_count", "get_slide_collision_count" }, // CharacterBody2D, CharacterBody3D


### PR DESCRIPTION
Exposes the selected paths in the editor filesystem dock.
Implements this proposal : https://github.com/godotengine/godot-proposals/issues/2424