### PR TITLE
Fix button icon expansion calculation with empty text

### DIFF
--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -258,7 +258,8 @@ void Button::_notification(int p_what) {
 
 				if (expand_icon) {
 					Size2 _size = get_size() - style->get_offset() * 2;
-					_size.width -= get_theme_constant(SNAME("h_separation")) + icon_ofs_region;
+					int icon_text_separation = text.is_empty() ? 0 : get_theme_constant(SNAME("h_separation"));
+					_size.width -= icon_text_separation + icon_ofs_region;
 					if (!clip_text && icon_align_rtl_checked != HORIZONTAL_ALIGNMENT_CENTER) {
 						_size.width -= text_buf->get_size().width;
 					}


### PR DESCRIPTION
This PR fixes an issue with the "expand icon"-mode of `Button` noticed by @Vhati in https://github.com/godotengine/godot/issues/35005#issuecomment-1023315635.
When the button text is empty the h_separation value is still used for the icon expansion calculations, which results in visual gaps on the right (or left with rtl) side:

Before:
![grafik](https://user-images.githubusercontent.com/50084500/167716557-b1af2198-50bb-4e59-aa35-150150c8ec7b.png)
After:
![Screenshot 2022-05-10 222035](https://user-images.githubusercontent.com/50084500/167716594-edb48eb3-fd81-4947-b142-c09843707385.png)

