### PR TITLE
[HTML5] Fix editor build. Add webgl2 imports. Workaround thread issue.

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.h
+++ b/drivers/gles3/rasterizer_storage_gles3.h
@@ -302,7 +302,7 @@ inline void RasterizerStorageGLES3::buffer_orphan_and_upload(unsigned int p_buff
 }
 
 inline String RasterizerStorageGLES3::get_framebuffer_error(GLenum p_status) {
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) && defined(GLES_OVER_GL)
 	if (p_status == GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT) {
 		return "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT";
 	} else if (p_status == GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT) {

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -574,7 +574,7 @@ public:
 };
 
 inline String TextureStorage::get_framebuffer_error(GLenum p_status) {
-#ifdef DEBUG_ENABLED
+#if defined(DEBUG_ENABLED) && defined(GLES_OVER_GL)
 	if (p_status == GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT) {
 		return "GL_FRAMEBUFFER_INCOMPLETE_ATTACHMENT";
 	} else if (p_status == GL_FRAMEBUFFER_INCOMPLETE_MISSING_ATTACHMENT) {

--- a/platform/javascript/api/javascript_tools_editor_plugin.cpp
+++ b/platform/javascript/api/javascript_tools_editor_plugin.cpp
@@ -122,7 +122,7 @@ void JavaScriptToolsEditorPlugin::_zip_file(String p_path, String p_base_path, z
 
 void JavaScriptToolsEditorPlugin::_zip_recursive(String p_path, String p_base_path, zipFile p_zip) {
 	Ref<DirAccess> dir = DirAccess::open(p_path);
-	if (!dir) {
+	if (dir.is_null()) {
 		WARN_PRINT("Unable to open directory for zipping: " + p_path);
 		return;
 	}

--- a/platform/javascript/godot_webgl2.h
+++ b/platform/javascript/godot_webgl2.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  platform_config.h                                                    */
+/*  godot_webgl2.h                                                       */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,6 +28,10 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include <alloca.h>
+#ifndef GODOT_WEBGL2_H
+#define GODOT_WEBGL2_H
 
-#define OPENGL_INCLUDE_H "platform/javascript/godot_webgl2.h"
+#include "GLES3/gl3.h"
+#include "webgl/webgl2.h"
+
+#endif

--- a/platform/javascript/js/libs/library_godot_os.js
+++ b/platform/javascript/js/libs/library_godot_os.js
@@ -305,7 +305,9 @@ const GodotOS = {
 
 	godot_js_os_hw_concurrency_get__sig: 'i',
 	godot_js_os_hw_concurrency_get: function () {
-		return navigator.hardwareConcurrency || 1;
+		// TODO Godot core needs fixing to avoid spawning too many threads (> 24).
+		const concurrency = navigator.hardwareConcurrency || 1;
+		return concurrency < 2 ? concurrency : 2;
 	},
 
 	godot_js_os_download_buffer__sig: 'viiii',


### PR DESCRIPTION
In this PR:
- Add "webgl/webgl2.h" as OpenGL include (`glGetBufferSubData`).
  Requires emscripten versions > 2.0.17 .
- Fix JS "tools" editor plugin. Needed update after file/dir access refactoring.
- Limit the returned OS cpu count to 2. (temporarily workaround issues due to godot spawning too many threads)
- Add guard for OpenGL 4 debug macros.