### PR TITLE
fix android export when export plugin files are included with whitelist

### DIFF
--- a/editor/editor_export.cpp
+++ b/editor/editor_export.cpp
@@ -862,6 +862,9 @@ Error EditorExportPlatform::export_project_files(const Ref<EditorExportPreset> &
 			}
 		}
 		for (int j = 0; j < export_plugins[i]->extra_files.size(); j++) {
+			// Remove plugin files from filter whitelist
+			paths.erase(export_plugins[i]->extra_files[j].path);
+
 			err = p_func(p_udata, export_plugins[i]->extra_files[j].path, export_plugins[i]->extra_files[j].data, 0, paths.size(), enc_in_filters, enc_ex_filters, key);
 			if (err != OK) {
 				return err;


### PR DESCRIPTION
One of my clients had an export whitelist of `*.json`. Since they also had dialogic, the export had some files (`dialogic/definitions.json`, ...) that matched the whitelist (note: I don't have experience with extra_files on export plugins).

This is a similar issue to https://github.com/godotengine/godot/issues/34525

MRP: [test1.zip](https://github.com/godotengine/godot/files/8985606/test1.zip)