### PR TITLE
[Windows] Enable crash reporter on MinGW builds.

### DIFF
--- a/platform/windows/crash_handler_windows.h
+++ b/platform/windows/crash_handler_windows.h
@@ -32,13 +32,19 @@
 #define CRASH_HANDLER_WINDOWS_H
 
 #define WIN32_LEAN_AND_MEAN
+#include <excpt.h>
 #include <windows.h>
 
 // Crash handler exception only enabled with MSVC
-#if defined(DEBUG_ENABLED) && defined(MSVC)
+#if defined(DEBUG_ENABLED)
 #define CRASH_HANDLER_EXCEPTION 1
 
+#ifdef MSVC
 extern DWORD CrashHandlerException(EXCEPTION_POINTERS *ep);
+#else
+extern void CrashHandlerException(int signal);
+#endif
+
 #endif
 
 class CrashHandler {

--- a/platform/windows/detect.py
+++ b/platform/windows/detect.py
@@ -268,6 +268,8 @@ def configure_msvc(env, manual_msvc_config):
         "Avrt",
         "dwmapi",
     ]
+    if env["target"] == "debug" or env["target"] == "release_debug":
+        LIBS += ["psapi", "dbghelp"]
 
     env.AppendUnique(CPPDEFINES=["VULKAN_ENABLED"])
     if not env["use_volk"]:
@@ -438,6 +440,8 @@ def configure_mingw(env):
             "dwmapi",
         ]
     )
+    if env["target"] == "debug" or env["target"] == "release_debug":
+        env.Append(LIBS=["psapi", "dbghelp"])
 
     env.Append(CPPDEFINES=["VULKAN_ENABLED"])
     if not env["use_volk"]:

--- a/platform/windows/godot_windows.cpp
+++ b/platform/windows/godot_windows.cpp
@@ -206,7 +206,7 @@ int main(int argc, char **argv) {
 
 	// _argc and _argv are ignored
 	// we are going to use the WideChar version of them instead
-#ifdef CRASH_HANDLER_EXCEPTION
+#if defined(CRASH_HANDLER_EXCEPTION) && defined(MSVC)
 	__try {
 		return _main();
 	} __except (CrashHandlerException(GetExceptionInformation())) {


### PR DESCRIPTION
Enables crash reporter on MinGW builds, stack trace will be readable only if converted `*.pdb` symbols are provided (e.g., generated from the DWARF symbols used by GCC using this tool - https://github.com/rainers/cv2pdb).

MinGW crash log generation seems to take more time (few seconds vs instant for MSVC) and include some unnecessary frames (since snapshot is taken by our crash handler not by SEH handler).

<details>
 <summary>MSVC crash log example</summary>

```
CrashHandlerException: Program crashed
Engine version: Godot Engine v4.0.alpha.custom_build (ccb583be091d3baf55365235cb35d4487ea3e911)
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[0] core_bind::OS::crash (godot\core\core_bind.cpp:211)
[1] core_bind::OS::crash (godot\core\core_bind.cpp:211)
[2] call_with_ptr_args_helper<core_bind::OS,String const &,0> (godot\core\variant\binder_common.h:257)
[3] call_with_ptr_args<core_bind::OS,String const &> (godot\core\variant\binder_common.h:506)
[4] MethodBindT<core_bind::OS,String const &>::ptrcall (godot\core\object\method_bind.h:345)
[5] GDScriptFunction::call (godot\modules\gdscript\gdscript_vm.cpp:1952)
[6] GDScriptInstance::callp (godot\modules\gdscript\gdscript.cpp:1543)
[7] Node::_gdvirtual__process_call<0> (godot\scene\main\node.h:235)
[8] Node::_notification (godot\scene\main\node.cpp:57)
[9] Node::_notificationv (godot\scene\main\node.h:45)
[10] CanvasItem::_notificationv (godot\scene\main\canvas_item.h:45)
[11] Node2D::_notificationv (godot\scene\2d\node_2d.h:37)
[12] Object::notification (godot\core\object\object.cpp:849)
[13] SceneTree::_notify_group_pause (godot\scene\main\scene_tree.cpp:857)
[14] SceneTree::process (godot\scene\main\scene_tree.cpp:456)
[15] Main::iteration (godot\main\main.cpp:2745)
[16] OS_Windows::run (godot\platform\windows\os_windows.cpp:700)
[17] widechar_main (godot\platform\windows\godot_windows.cpp:175)
[18] _main (godot\platform\windows\godot_windows.cpp:197)
[19] main (godot\platform\windows\godot_windows.cpp:211)
[20] WinMain (godot\platform\windows\godot_windows.cpp:225)
[21] __scrt_common_main_seh (d:\a01\_work\43\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[22] BaseThreadInitThunk
-- END OF BACKTRACE --
```

</details>

<details>
 <summary>MinGW crash log example</summary>

```
CrashHandlerException: Program crashed with signal 4
Engine version: Godot Engine v4.0.alpha.custom_build (ccb583be091d3baf55365235cb35d4487ea3e911)
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[0] CrashHandlerException (godot\platform\windows\crash_handler_windows.cpp:194)
[1] CrashHandlerException (godot\platform\windows\crash_handler_windows.cpp:194)
[2] _gnu_exception_handler (C:\M\mingw-w64-crt-git\src\mingw-w64\mingw-w64-crt\crt\crt_handler.c:243)
[3] _C_specific_handler
[4] _chkstk
[5] RtlRestoreContext
[6] KiUserExceptionDispatcher
[7] crash (godot\core\core_bind.cpp:211)
[8] call_with_ptr_args_helper<__UnexistingClass, const String&, 0> (godot\.\core\variant\binder_common.h:257)
[9] call_with_ptr_args<__UnexistingClass, const String&> (godot\.\core\variant\binder_common.h:506)
[10] ptrcall (godot\.\core\object\method_bind.h:345)
[11] call (godot\modules\gdscript\gdscript_vm.cpp:1952)
[12] callp (godot\modules\gdscript\gdscript.cpp:1543)
[13] _gdvirtual__process_call<false> (godot\scene\main\node.h:235)
[14] _notification (godot\scene\main\node.cpp:57)
[15] _notificationv (godot\.\scene\main\node.h:45)
[16] _notificationv (godot\.\scene\main\canvas_item.h:45)
[17] _notificationv (godot\.\scene\2d\node_2d.h:37)
[18] notification (godot\core\object\object.cpp:849)
[19] _notify_group_pause (godot\scene\main\scene_tree.cpp:855)
[20] process (godot\scene\main\scene_tree.cpp:456)
[21] iteration (godot\main\main.cpp:2745)
[22] run (godot\platform\windows\os_windows.cpp:700)
[23] widechar_main (godot\platform\windows\godot_windows.cpp:175)
[24] _main (godot\platform\windows\godot_windows.cpp:197)
[25] main (godot\platform\windows\godot_windows.cpp:216)
[26] __tmainCRTStartup (C:\M\mingw-w64-crt-git\src\mingw-w64\mingw-w64-crt\crt\crtexe.c:323)
[27] WinMainCRTStartup (C:\M\mingw-w64-crt-git\src\mingw-w64\mingw-w64-crt\crt\crtexe.c:178)
[28] BaseThreadInitThunk
-- END OF BACKTRACE --
```

</details>