### PR TITLE
corrected conditional compile of OpenXR with/without opengl3 driver

### DIFF
--- a/modules/openxr/openxr_api.cpp
+++ b/modules/openxr/openxr_api.cpp
@@ -1001,7 +1001,7 @@ bool OpenXRAPI::initialize(const String &p_rendering_driver) {
 		ERR_FAIL_V(false);
 #endif
 	} else if (p_rendering_driver == "opengl3") {
-#ifdef OPENGL3_ENABLED
+#ifdef GLES3_ENABLED
 		// graphics_extension = memnew(OpenXROpenGLExtension(this));
 		// register_extension_wrapper(graphics_extension);
 		ERR_FAIL_V_MSG(false, "OpenXR: OpenGL is not supported at this time.");


### PR DESCRIPTION
I am unable to test this code, so I am just providing this PR to notify the code owner of this issue.

Impact: code currently is never called.  After the change, code will be called if opengl3 driver is enabled.