### PR TITLE
Prevent blank command prompts from spawning when building a mono project

### DIFF
--- a/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Build/BuildSystem.cs
@@ -63,6 +63,7 @@ namespace GodotTools.Build
             startInfo.RedirectStandardOutput = true;
             startInfo.RedirectStandardError = true;
             startInfo.UseShellExecute = false;
+            startInfo.CreateNoWindow = true;
 
             if (UsingMonoMsBuildOnWindows)
             {

--- a/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
+++ b/modules/mono/editor/GodotTools/GodotTools/Utils/OS.cs
@@ -184,7 +184,8 @@ namespace GodotTools.Utils
             {
                 RedirectStandardOutput = true,
                 RedirectStandardError = true,
-                UseShellExecute = false
+                UseShellExecute = false,
+                CreateNoWindow = true
             };
 
             using (Process process = Process.Start(startInfo))


### PR DESCRIPTION
When building a mono solution or opening a script in an external editor a short-lived blank command prompt is displayed. I've made these hidden since they don't appear to provide any actual use.

Since im unsure if this affects other platforms besides windows here is an example of what it used to look like
![Godot_4_TnyvJZNHSI](https://user-images.githubusercontent.com/7606171/167965633-ace43255-304e-4385-8a70-11551fd03482.gif)
