### PR TITLE
Add NavigationServer2D/3D API functions to find missing RID info

### DIFF
--- a/doc/classes/NavigationServer2D.xml
+++ b/doc/classes/NavigationServer2D.xml
@@ -21,6 +21,13 @@
 				Creates the agent.
 			</description>
 		</method>
+		<method name="agent_get_map" qualifiers="const">
+			<return type="RID" />
+			<argument index="0" name="agent" type="RID" />
+			<description>
+				Returns the navigation map [RID] the requested [code]agent[/code] is currently assigned to.
+			</description>
+		</method>
 		<method name="agent_is_map_changed" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="agent" type="RID" />
@@ -123,6 +130,13 @@
 				Create a new map.
 			</description>
 		</method>
+		<method name="map_get_agents" qualifiers="const">
+			<return type="Array" />
+			<argument index="0" name="map" type="RID" />
+			<description>
+				Returns all navigation agents [RID]s that are currently assigned to the requested navigation [code]map[/code].
+			</description>
+		</method>
 		<method name="map_get_cell_size" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="map" type="RID" />
@@ -162,6 +176,13 @@
 			<argument index="4" name="layers" type="int" default="1" />
 			<description>
 				Returns the navigation path to reach the destination from the origin. [code]layers[/code] is a bitmask of all region layers that are allowed to be in the path.
+			</description>
+		</method>
+		<method name="map_get_regions" qualifiers="const">
+			<return type="Array" />
+			<argument index="0" name="map" type="RID" />
+			<description>
+				Returns all navigation regions [RID]s that are currently assigned to the requested navigation [code]map[/code].
 			</description>
 		</method>
 		<method name="map_is_active" qualifiers="const">
@@ -229,6 +250,13 @@
 			<argument index="0" name="region" type="RID" />
 			<description>
 				Returns the region's layers.
+			</description>
+		</method>
+		<method name="region_get_map" qualifiers="const">
+			<return type="RID" />
+			<argument index="0" name="region" type="RID" />
+			<description>
+				Returns the navigation map [RID] the requested [code]region[/code] is currently assigned to.
 			</description>
 		</method>
 		<method name="region_set_layers" qualifiers="const">

--- a/doc/classes/NavigationServer3D.xml
+++ b/doc/classes/NavigationServer3D.xml
@@ -21,6 +21,13 @@
 				Creates the agent.
 			</description>
 		</method>
+		<method name="agent_get_map" qualifiers="const">
+			<return type="RID" />
+			<argument index="0" name="agent" type="RID" />
+			<description>
+				Returns the navigation map [RID] the requested [code]agent[/code] is currently assigned to.
+			</description>
+		</method>
 		<method name="agent_is_map_changed" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="agent" type="RID" />
@@ -123,6 +130,13 @@
 				Create a new map.
 			</description>
 		</method>
+		<method name="map_get_agents" qualifiers="const">
+			<return type="Array" />
+			<argument index="0" name="map" type="RID" />
+			<description>
+				Returns all navigation agents [RID]s that are currently assigned to the requested navigation [code]map[/code].
+			</description>
+		</method>
 		<method name="map_get_cell_size" qualifiers="const">
 			<return type="float" />
 			<argument index="0" name="map" type="RID" />
@@ -180,6 +194,13 @@
 			<argument index="4" name="layers" type="int" default="1" />
 			<description>
 				Returns the navigation path to reach the destination from the origin. [code]layers[/code] is a bitmask of all region layers that are allowed to be in the path.
+			</description>
+		</method>
+		<method name="map_get_regions" qualifiers="const">
+			<return type="Array" />
+			<argument index="0" name="map" type="RID" />
+			<description>
+				Returns all navigation regions [RID]s that are currently assigned to the requested navigation [code]map[/code].
 			</description>
 		</method>
 		<method name="map_get_up" qualifiers="const">
@@ -279,6 +300,13 @@
 			<argument index="0" name="region" type="RID" />
 			<description>
 				Returns the region's layers.
+			</description>
+		</method>
+		<method name="region_get_map" qualifiers="const">
+			<return type="RID" />
+			<argument index="0" name="region" type="RID" />
+			<description>
+				Returns the navigation map [RID] the requested [code]region[/code] is currently assigned to.
 			</description>
 		</method>
 		<method name="region_set_layers" qualifiers="const">

--- a/modules/navigation/godot_navigation_server.cpp
+++ b/modules/navigation/godot_navigation_server.cpp
@@ -233,6 +233,38 @@ RID GodotNavigationServer::map_get_closest_point_owner(RID p_map, const Vector3 
 	return map->get_closest_point_owner(p_point);
 }
 
+Array GodotNavigationServer::map_get_regions(RID p_map) const {
+	Array regions_rids;
+	const NavMap *map = map_owner.get_or_null(p_map);
+	ERR_FAIL_COND_V(map == nullptr, regions_rids);
+	for (NavRegion *region : map->get_regions()) {
+		regions_rids.push_back(region->get_self());
+	}
+	return regions_rids;
+}
+
+Array GodotNavigationServer::map_get_agents(RID p_map) const {
+	Array agents_rids;
+	const NavMap *map = map_owner.get_or_null(p_map);
+	ERR_FAIL_COND_V(map == nullptr, agents_rids);
+	for (RvoAgent *agent : map->get_agents()) {
+		agents_rids.push_back(agent->get_self());
+	}
+	return agents_rids;
+}
+
+RID GodotNavigationServer::region_get_map(RID p_region) const {
+	NavRegion *region = region_owner.get_or_null(p_region);
+	ERR_FAIL_COND_V(region == nullptr, RID());
+	return region->get_map()->get_self();
+}
+
+RID GodotNavigationServer::agent_get_map(RID p_agent) const {
+	RvoAgent *agent = agent_owner.get_or_null(p_agent);
+	ERR_FAIL_COND_V(agent == nullptr, RID());
+	return agent->get_map()->get_self();
+}
+
 RID GodotNavigationServer::region_create() const {
 	GodotNavigationServer *mut_this = const_cast<GodotNavigationServer *>(this);
 	MutexLock lock(mut_this->operations_mutex);

--- a/modules/navigation/godot_navigation_server.h
+++ b/modules/navigation/godot_navigation_server.h
@@ -105,8 +105,12 @@ public:
 	virtual Vector3 map_get_closest_point_normal(RID p_map, const Vector3 &p_point) const override;
 	virtual RID map_get_closest_point_owner(RID p_map, const Vector3 &p_point) const override;
 
+	virtual Array map_get_regions(RID p_map) const override;
+	virtual Array map_get_agents(RID p_map) const override;
+
 	virtual RID region_create() const override;
 	COMMAND_2(region_set_map, RID, p_region, RID, p_map);
+	virtual RID region_get_map(RID p_region) const override;
 	COMMAND_2(region_set_layers, RID, p_region, uint32_t, p_layers);
 	virtual uint32_t region_get_layers(RID p_region) const override;
 	COMMAND_2(region_set_transform, RID, p_region, Transform3D, p_transform);
@@ -118,6 +122,7 @@ public:
 
 	virtual RID agent_create() const override;
 	COMMAND_2(agent_set_map, RID, p_agent, RID, p_map);
+	virtual RID agent_get_map(RID p_agent) const override;
 	COMMAND_2(agent_set_neighbor_dist, RID, p_agent, real_t, p_dist);
 	COMMAND_2(agent_set_max_neighbors, RID, p_agent, int, p_count);
 	COMMAND_2(agent_set_time_horizon, RID, p_agent, real_t, p_time);

--- a/servers/navigation_server_2d.cpp
+++ b/servers/navigation_server_2d.cpp
@@ -170,8 +170,12 @@ void NavigationServer2D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("map_get_closest_point", "map", "to_point"), &NavigationServer2D::map_get_closest_point);
 	ClassDB::bind_method(D_METHOD("map_get_closest_point_owner", "map", "to_point"), &NavigationServer2D::map_get_closest_point_owner);
 
+	ClassDB::bind_method(D_METHOD("map_get_regions", "map"), &NavigationServer2D::map_get_regions);
+	ClassDB::bind_method(D_METHOD("map_get_agents", "map"), &NavigationServer2D::map_get_agents);
+
 	ClassDB::bind_method(D_METHOD("region_create"), &NavigationServer2D::region_create);
 	ClassDB::bind_method(D_METHOD("region_set_map", "region", "map"), &NavigationServer2D::region_set_map);
+	ClassDB::bind_method(D_METHOD("region_get_map", "region"), &NavigationServer2D::region_get_map);
 	ClassDB::bind_method(D_METHOD("region_set_layers", "region", "layers"), &NavigationServer2D::region_set_layers);
 	ClassDB::bind_method(D_METHOD("region_get_layers", "region"), &NavigationServer2D::region_get_layers);
 	ClassDB::bind_method(D_METHOD("region_set_transform", "region", "transform"), &NavigationServer2D::region_set_transform);
@@ -182,6 +186,7 @@ void NavigationServer2D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("agent_create"), &NavigationServer2D::agent_create);
 	ClassDB::bind_method(D_METHOD("agent_set_map", "agent", "map"), &NavigationServer2D::agent_set_map);
+	ClassDB::bind_method(D_METHOD("agent_get_map", "agent"), &NavigationServer2D::agent_get_map);
 	ClassDB::bind_method(D_METHOD("agent_set_neighbor_dist", "agent", "dist"), &NavigationServer2D::agent_set_neighbor_dist);
 	ClassDB::bind_method(D_METHOD("agent_set_max_neighbors", "agent", "count"), &NavigationServer2D::agent_set_max_neighbors);
 	ClassDB::bind_method(D_METHOD("agent_set_time_horizon", "agent", "time"), &NavigationServer2D::agent_set_time_horizon);
@@ -207,6 +212,14 @@ NavigationServer2D::NavigationServer2D() {
 NavigationServer2D::~NavigationServer2D() {
 	singleton = nullptr;
 }
+
+Array FORWARD_1_C(map_get_regions, RID, p_map, rid_to_rid);
+
+Array FORWARD_1_C(map_get_agents, RID, p_map, rid_to_rid);
+
+RID FORWARD_1_C(region_get_map, RID, p_region, rid_to_rid);
+
+RID FORWARD_1_C(agent_get_map, RID, p_agent, rid_to_rid);
 
 RID FORWARD_0_C(map_create);
 

--- a/servers/navigation_server_2d.h
+++ b/servers/navigation_server_2d.h
@@ -80,11 +80,15 @@ public:
 	virtual Vector2 map_get_closest_point(RID p_map, const Vector2 &p_point) const;
 	virtual RID map_get_closest_point_owner(RID p_map, const Vector2 &p_point) const;
 
+	virtual Array map_get_regions(RID p_map) const;
+	virtual Array map_get_agents(RID p_map) const;
+
 	/// Creates a new region.
 	virtual RID region_create() const;
 
 	/// Set the map of this region.
 	virtual void region_set_map(RID p_region, RID p_map) const;
+	virtual RID region_get_map(RID p_region) const;
 
 	/// Set the region's layers
 	virtual void region_set_layers(RID p_region, uint32_t p_layers) const;
@@ -106,6 +110,7 @@ public:
 
 	/// Put the agent in the map.
 	virtual void agent_set_map(RID p_agent, RID p_map) const;
+	virtual RID agent_get_map(RID p_agent) const;
 
 	/// The maximum distance (center point to
 	/// center point) to other agents this agent

--- a/servers/navigation_server_3d.cpp
+++ b/servers/navigation_server_3d.cpp
@@ -48,8 +48,12 @@ void NavigationServer3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("map_get_closest_point_normal", "map", "to_point"), &NavigationServer3D::map_get_closest_point_normal);
 	ClassDB::bind_method(D_METHOD("map_get_closest_point_owner", "map", "to_point"), &NavigationServer3D::map_get_closest_point_owner);
 
+	ClassDB::bind_method(D_METHOD("map_get_regions", "map"), &NavigationServer3D::map_get_regions);
+	ClassDB::bind_method(D_METHOD("map_get_agents", "map"), &NavigationServer3D::map_get_agents);
+
 	ClassDB::bind_method(D_METHOD("region_create"), &NavigationServer3D::region_create);
 	ClassDB::bind_method(D_METHOD("region_set_map", "region", "map"), &NavigationServer3D::region_set_map);
+	ClassDB::bind_method(D_METHOD("region_get_map", "region"), &NavigationServer3D::region_get_map);
 	ClassDB::bind_method(D_METHOD("region_set_layers", "region", "layers"), &NavigationServer3D::region_set_layers);
 	ClassDB::bind_method(D_METHOD("region_get_layers", "region"), &NavigationServer3D::region_get_layers);
 	ClassDB::bind_method(D_METHOD("region_set_transform", "region", "transform"), &NavigationServer3D::region_set_transform);
@@ -61,6 +65,7 @@ void NavigationServer3D::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("agent_create"), &NavigationServer3D::agent_create);
 	ClassDB::bind_method(D_METHOD("agent_set_map", "agent", "map"), &NavigationServer3D::agent_set_map);
+	ClassDB::bind_method(D_METHOD("agent_get_map", "agent"), &NavigationServer3D::agent_get_map);
 	ClassDB::bind_method(D_METHOD("agent_set_neighbor_dist", "agent", "dist"), &NavigationServer3D::agent_set_neighbor_dist);
 	ClassDB::bind_method(D_METHOD("agent_set_max_neighbors", "agent", "count"), &NavigationServer3D::agent_set_max_neighbors);
 	ClassDB::bind_method(D_METHOD("agent_set_time_horizon", "agent", "time"), &NavigationServer3D::agent_set_time_horizon);

--- a/servers/navigation_server_3d.h
+++ b/servers/navigation_server_3d.h
@@ -91,11 +91,15 @@ public:
 	virtual Vector3 map_get_closest_point_normal(RID p_map, const Vector3 &p_point) const = 0;
 	virtual RID map_get_closest_point_owner(RID p_map, const Vector3 &p_point) const = 0;
 
+	virtual Array map_get_regions(RID p_map) const = 0;
+	virtual Array map_get_agents(RID p_map) const = 0;
+
 	/// Creates a new region.
 	virtual RID region_create() const = 0;
 
 	/// Set the map of this region.
 	virtual void region_set_map(RID p_region, RID p_map) const = 0;
+	virtual RID region_get_map(RID p_region) const = 0;
 
 	/// Set the region's layers
 	virtual void region_set_layers(RID p_region, uint32_t p_layers) const = 0;
@@ -120,6 +124,7 @@ public:
 
 	/// Put the agent in the map.
 	virtual void agent_set_map(RID p_agent, RID p_map) const = 0;
+	virtual RID agent_get_map(RID p_agent) const = 0;
 
 	/// The maximum distance (center point to
 	/// center point) to other agents this agent


### PR DESCRIPTION
Utility functions for NavigationServer2D/3D to find missing RID information when working with NavigationServer API directly.
e.g. from map to regions and agents, from agent or region to map, from region to map and agents and so on ....

Requirement to work with NavigationServer API exklusive without SceneTree nodes and when juggling agents and regions between multiple navigation maps. Godot 4.0 currently requires to keep track on all rids from scene start or give up as some rid info can not be obtained later.

small test gdscript:
``` gdscript
var waiting_for_navigationserver_sync : bool = true
func navigationserver_api_test():
	# Arrays will always return empty in _ready() and on first frame(s)
	# NavigationRegions and NavigationAgents queue up to register with threaded NavigationServer in _ready()
	# Afterwards NavigationServer needs a physics tick to sync regions and agents and flush queue
	var map : RID = get_world_3d().get_navigation_map()
	var map_get_agents : Array = NavigationServer3D.map_get_agents(map)
	var map_get_regions : Array = NavigationServer3D.map_get_regions(map)
	if waiting_for_navigationserver_sync and map_get_agents != [] and map_get_regions != []:
		waiting_for_navigationserver_sync = false
		print("map_get_agents")
		print(map_get_agents)
		print("map_get_regions")
		print(map_get_regions)
		var agent_map : RID = NavigationServer3D.agent_get_map(map_get_agents[0])
		print("agent_get_map")
		print(agent_map)
		var region_map : RID = NavigationServer3D.region_get_map(map_get_regions[0])
		print("region_get_map")
		print(region_map)
```

Could be a 3.5 cherry but this issue is more pressing in Godot 4.0 cause in 3.5 it is still possible to add multiple Navigation Nodes each creating a new navmap and agents and regions can be in theory swapped as node children in the SceneTree if all the reparent bugs are fixed.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
