### PR TITLE
Use the last component after a / in the animation name for the initial node name.

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -1018,7 +1018,11 @@ void AnimationNodeStateMachineEditor::_add_animation_type(int p_index) {
 
 	anim->set_animation(animations_to_add[p_index]);
 
-	String base_name = animations_to_add[p_index];
+	// Animations may have / characters in their names, so only keep the part
+	// after a / as the initial node name.
+	Vector<String> path = String(animations_to_add[p_index]).split("/");
+	String base_name = path.get(path.size() - 1);
+
 	int base = 1;
 	String name = base_name;
 	while (state_machine->has_node(name)) {


### PR DESCRIPTION
This PR  replaces "/" with "|" for the initial node name.  A "/" is not allowed in the node name, so when an animation which includes "/" in its name is added to a state machine, the add fails.  The "/" in the animation name is easily encountered by loading an animation library which builds the animation name as library_name/animation_name.

With the above replacement.  An animation with a "/" in the name can be added.  The initial name for the node is simply replaced.

Fixes #60959 