### PR TITLE
Show list of groups in node tooltip

### DIFF
--- a/editor/scene_tree_editor.cpp
+++ b/editor/scene_tree_editor.cpp
@@ -279,15 +279,26 @@ bool SceneTreeEditor::_add_nodes(Node *p_node, TreeItem *p_parent, bool p_scroll
 			Array arr;
 			arr.push_back(num_connections);
 			msg_temp += TTRN("Node has one connection.", "Node has {num} connections.", num_connections).format(arr, "{num}");
-			msg_temp += " ";
+			if (num_groups >= 1) {
+				msg_temp += "\n";
+			}
 		}
 		if (num_groups >= 1) {
-			Array arr;
-			arr.push_back(num_groups);
-			msg_temp += TTRN("Node is in one group.", "Node is in {num} groups.", num_groups).format(arr, "{num}");
+			msg_temp += TTRN("Node is in this group:", "Node is in the following groups:", num_groups) + "\n";
+
+			List<GroupInfo> groups;
+			p_node->get_groups(&groups);
+			for (const GroupInfo &E : groups) {
+				if (E.persistent) {
+					msg_temp += String::utf8("•  ") + String(E.name) + "\n";
+				}
+			}
 		}
 		if (num_connections >= 1 || num_groups >= 1) {
-			msg_temp += "\n" + TTR("Click to show signals dock.");
+			if (num_groups < 1) {
+				msg_temp += "\n";
+			}
+			msg_temp += TTR("Click to show signals dock.");
 		}
 
 		Ref<Texture2D> icon_temp;


### PR DESCRIPTION
I hovered over button group and saw "The node is in 2 groups.". So I thought: why not list these groups?
![image](https://user-images.githubusercontent.com/2223172/168087543-401d0268-bf98-4a74-9a6f-86aa8783de81.png)
It's uncommon to have node in more than 1 group and rare to have more than 3 groups, so displaying this should be fine.