### PR TITLE
Fix behavior of 'Editable Children' toggle

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -8061,6 +8061,8 @@ void Node3DEditor::_bind_methods() {
 	ClassDB::bind_method("_clear_subgizmo_selection", &Node3DEditor::_clear_subgizmo_selection);
 	ClassDB::bind_method("_refresh_menu_icons", &Node3DEditor::_refresh_menu_icons);
 
+	ClassDB::bind_method("update_all_gizmos", &Node3DEditor::update_all_gizmos);
+
 	ADD_SIGNAL(MethodInfo("transform_key_request"));
 	ADD_SIGNAL(MethodInfo("item_lock_status_changed"));
 	ADD_SIGNAL(MethodInfo("item_group_status_changed"));

--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -223,6 +223,9 @@ class SceneTreeDock : public VBoxContainer {
 	void _delete_dialog_closed();
 
 	void _toggle_editable_children_from_selection();
+
+	void _reparent_nodes_to_root(Node *p_root, const Array &p_nodes, Node *p_owner);
+	void _reparent_nodes_to_paths_with_transform_and_name(Node *p_root, const Array &p_nodes, const Array &p_paths, const Array &p_transforms, const Array &p_names, Node *p_owner);
 	void _toggle_editable_children(Node *p_node);
 
 	void _toggle_placeholder_from_selection();


### PR DESCRIPTION
Toggling 'editable_children' off in the SceneTree will now no longer result in nodes owned by the currently edited scene, but assigned as children of foreign nodes, from being accidentally lost, where they before would still be visible in the scene, but not viewable since their parents were made hidden. They will instead be moved to the root of the instance, with their global transform perserved in the case of Node2D and Node3D derivatives. The editable children toggle will now also be subject to functional undoing and redoing.

Closes #46726