### PR TITLE
Rename remaining references of FSR to FSR 1.0

### DIFF
--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -2593,7 +2593,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 	}
 
 	if (can_use_effects && can_use_storage && (rb->internal_width != rb->width || rb->internal_height != rb->height)) {
-		RD::get_singleton()->draw_command_begin_label("FSR Upscale");
+		RD::get_singleton()->draw_command_begin_label("FSR 1.0 Upscale");
 
 		storage->get_effects()->fsr_upscale(rb->internal_texture, rb->upscale_texture, rb->texture, Size2i(rb->internal_width, rb->internal_height), Size2i(rb->width, rb->height), rb->fsr_sharpness);
 

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2933,7 +2933,7 @@ RenderingServer::RenderingServer() {
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/scaling_3d/mode",
 			PropertyInfo(Variant::INT,
 					"rendering/scaling_3d/mode",
-					PROPERTY_HINT_ENUM, "Bilinear (Fastest),FSR (Fast)"));
+					PROPERTY_HINT_ENUM, "Bilinear (Fastest),FSR 1.0 (Fast)"));
 
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/scaling_3d/scale",
 			PropertyInfo(Variant::FLOAT,


### PR DESCRIPTION
With [FSR 2.0](https://github.com/godotengine/godot-proposals/issues/4280) around the corner, we should avoid any ambiguity by explicitly stating the version number.