### PR TITLE
Show class icon in the documentation page header

### DIFF
--- a/editor/editor_help.cpp
+++ b/editor/editor_help.cpp
@@ -512,11 +512,22 @@ void EditorHelp::_update_doc() {
 
 	DocData::ClassDoc cd = doc->class_list[edited_class]; // Make a copy, so we can sort without worrying.
 
+	Ref<Texture2D> icon;
+	if (has_theme_icon(edited_class, SNAME("EditorIcons"))) {
+		icon = get_theme_icon(edited_class, SNAME("EditorIcons"));
+	} else if (ClassDB::class_exists(edited_class) && ClassDB::is_parent_class(edited_class, "Object")) {
+		icon = get_theme_icon(SNAME("Object"), SNAME("EditorIcons"));
+	} else {
+		icon = get_theme_icon(SNAME("ArrowRight"), SNAME("EditorIcons"));
+	}
+
 	// Class name
 	section_line.push_back(Pair<String, int>(TTR("Top"), 0));
 	class_desc->push_font(doc_title_font);
 	class_desc->push_color(title_color);
 	class_desc->add_text(TTR("Class:") + " ");
+	class_desc->add_image(icon, icon->get_width(), icon->get_height());
+	class_desc->add_text(" ");
 	class_desc->push_color(headline_color);
 	_add_text(edited_class);
 	class_desc->pop();


### PR DESCRIPTION
This PR makes documentation pages show the class icon next to the class name in the header. It uses the same method as the help search dialog to find class icons, so the icons match up.

![image](https://user-images.githubusercontent.com/67974470/168175611-1061a4bf-eb80-4e01-b2fb-d12a05a52767.png)
![image](https://user-images.githubusercontent.com/67974470/168175406-c2eb2d3f-6e1d-46c2-ad4b-9391694eb9f9.png)
![image](https://user-images.githubusercontent.com/67974470/168175113-84c6207b-8fe7-433d-8201-2b5b5b6769d9.png)
![image](https://user-images.githubusercontent.com/67974470/168175313-b579b55b-ad71-4c95-8ebe-85287f0ffe8c.png)
![image](https://user-images.githubusercontent.com/67974470/168175354-7bba8421-b53d-4d08-a265-e9186c82dffa.png)
