### PR TITLE
Use the move mouse cursor shape for the inspector array reorder button

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1939,6 +1939,7 @@ void EditorInspectorArray::_setup() {
 		// Move button.
 		ae.move_texture_rect = memnew(TextureRect);
 		ae.move_texture_rect->set_stretch_mode(TextureRect::STRETCH_KEEP_CENTERED);
+		ae.move_texture_rect->set_default_cursor_shape(Control::CURSOR_MOVE);
 		if (is_inside_tree()) {
 			ae.move_texture_rect->set_texture(get_theme_icon(SNAME("TripleBar"), SNAME("EditorIcons")));
 		}


### PR DESCRIPTION
Makes inspector arrays use the move mouse cursor shape (`CURSOR_MOVE`) for the reorder button to match the array editor reorder button.

| Before | After |
---|---
| ![Godot_v4 0-alpha7_win64_yaOEQ62238](https://user-images.githubusercontent.com/67974470/168181644-b17fb037-0925-4d84-8637-2f91cda909b2.png) | ![image](https://user-images.githubusercontent.com/67974470/170362577-98b57942-de7c-4228-81e9-b782ebcc0e3d.png) |

