### PR TITLE
Add missing comma in custom enum property hint

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -3565,6 +3565,7 @@ bool GDScriptParser::export_annotations(const AnnotationNode *p_annotation, Node
 				for (const KeyValue<StringName, int> &E : export_type.enum_values) {
 					if (!first) {
 						enum_hint_string += ",";
+					} else {
 						first = false;
 					}
 					enum_hint_string += E.key.operator String().capitalize().xml_escape();


### PR DESCRIPTION
Fixing an issue that was causing : #60980 and maybe other issue related to enums.
Property hint in string format was missing the `,` to separate each value due to a small error on the first boolean handling.
