### PR TITLE
Remove extra nested groups in TileSet

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -3264,16 +3264,10 @@ void TileSet::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "uv_clipping"), "set_uv_clipping", "is_uv_clipping");
 	ADD_ARRAY("occlusion_layers", "occlusion_layer_");
 
-	ADD_GROUP("Physics", "");
+	ADD_GROUP("", "");
 	ADD_ARRAY("physics_layers", "physics_layer_");
-
-	ADD_GROUP("Terrains", "");
 	ADD_ARRAY("terrain_sets", "terrain_set_");
-
-	ADD_GROUP("Navigation", "");
 	ADD_ARRAY("navigation_layers", "navigation_layer_");
-
-	ADD_GROUP("Custom Data", "");
 	ADD_ARRAY("custom_data_layers", "custom_data_layer_");
 
 	// -- Enum binding --


### PR DESCRIPTION
Removes extra nested groups in TileSet so that layers can be accessed with less clicks.

This does have the consequence of moving the Rendering group to the bottom, since groups are always at the bottom and arrays aren't technically groups. If this is a problem, then it can be fixed by removing the Rendering group and having the UV Clipping property and Occlusion Layers array outside of a group.

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/168179832-0ccc88ee-275e-4d06-91e9-17b16be0b8af.png) | ![image](https://user-images.githubusercontent.com/67974470/168188946-b84176c1-de99-4f4c-a3fb-d1a2c2b081bd.png) |