### PR TITLE
popup deferred hide suppressed if reopened on Windows platform

### DIFF
--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -356,6 +356,8 @@ void RenameDialog::_update_substitute() {
 }
 
 void RenameDialog::_post_popup() {
+	ConfirmationDialog::_post_popup();
+
 	EditorSelection *editor_selection = EditorNode::get_singleton()->get_editor_selection();
 	preview_node = nullptr;
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2158,7 +2158,10 @@ void DisplayServerWindows::popup_close(WindowID p_window) {
 		WindowID win_id = E->get();
 		popup_list.erase(E);
 
-		_send_window_event(windows[win_id], DisplayServerWindows::WINDOW_EVENT_CLOSE_REQUEST);
+		if (win_id != p_window) {
+			// Only request close on related windows, not this window.  We are already processing it.
+			_send_window_event(windows[win_id], DisplayServerWindows::WINDOW_EVENT_CLOSE_REQUEST);
+		}
 		E = F;
 	}
 }
@@ -2173,6 +2176,7 @@ LRESULT DisplayServerWindows::MouseProc(int code, WPARAM wParam, LPARAM lParam) 
 			case WM_NCRBUTTONDOWN:
 			case WM_NCMBUTTONDOWN:
 			case WM_LBUTTONDOWN:
+			case WM_RBUTTONDOWN:
 			case WM_MBUTTONDOWN: {
 				MOUSEHOOKSTRUCT *ms = (MOUSEHOOKSTRUCT *)lParam;
 				Point2i pos = Point2i(ms->pt.x, ms->pt.y);

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -108,11 +108,25 @@ void Popup::_close_pressed() {
 
 	_deinitialize_visible_parents();
 
-	call_deferred(SNAME("hide"));
+	// Hide after returning to process events, but only if we don't
+	// get popped up in the interim.
+	call_deferred(SNAME("_popup_conditional_hide"));
+}
+
+void Popup::_post_popup() {
+	Window::_post_popup();
+	popped_up = true;
+}
+
+void Popup::_popup_conditional_hide() {
+	if (!popped_up) {
+		hide();
+	}
 }
 
 void Popup::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("popup_hide"));
+	ClassDB::bind_method(D_METHOD("_popup_conditional_hide"), &Popup::_popup_conditional_hide);
 }
 
 Rect2i Popup::_popup_adjust_rect() const {

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -57,6 +57,10 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
+	void _popup_conditional_hide();
+
+	virtual void _post_popup() override;
+
 public:
 	Popup();
 	~Popup();


### PR DESCRIPTION
# Summary 

These changes address two problems with the way deferred close of popups is implemented on the Windows platform.

- fixes https://github.com/godotengine/godot/issues/59181
- fixes https://github.com/godotengine/godot/issues/60921
- reverts https://github.com/godotengine/godot/pull/59287

# Problem 1: call_deferred("hide") on popups causes a duplicate call_deferred("hide")

This is addressed by having the relevant notification code in DisplayServerWindows not notify the same window that is the source of the close request.

This problem most likely affects other platforms, but there don't seem to be any issues reported on other platforms, so maybe it does no harm there.  At least the X11 display manager appears to operate the same way.

# Problem 2: popup requests deferred hide of itself, but is reopened before that hide operation is executed

This happens due to the sequence of operations in the main loop.  Deferred calls and buffered input are on separate queues and therefore get out of order.  To work around this, popup will now be aware of its popped_up state even when single window mode is not used.  If a request to hide is processed after the same popup window is reopened, it won't hide.

Note that several other places in the code base also use deferred hide to close the current window, in order to pop out of the stack and process messages correctly.  The resulting reordering probably cannot be corrected centrally in the Window code, because it would change how Window works in a basic way, breaking many things.  I tried some different ways to fix it centrally, but will just create a discussion instead.  This fix just for the Popup() class addressed the existing issues.

# Problem sequence of calls

This shows the sequence of calls that happens during a right mouse click that closes a popup in one location and opens it in the other.  This figure is showing the slow case, where even with delayed input the (second) hide is processed after the reopen.  There are also timings where the input and the (first) hide happen in the same main loop iteration, but the same problems occur.

```
OS_Windows::run
    DisplayServerWindow::process_events()
        MouseProc right click
            _send_window_event WINDOW_EVENT_CLOSE_REQUEST
                Window::_propagate_window_notification NOTIFICATION_WM_CLOSE_REQUEST
                    PopupMenu::_notification
                        Popup::_notification
                            Popup::_close_pressed
                                call_deferred this->Window::hide
    Main::iteration
        Scene_tree::physics_process
            flush dispatches Window::hide
                Window::set_visible (false)
                    Window::_clear_window
                        DisplayServerWindows::delete_sub_window
                            DisplayServerWindows::popup_close
                                _send_window_event WINDOW_EVENT_CLOSE_REQUEST
                                    Window::_propagate_window_notification NOTIFICATION_WM_CLOSE_REQUEST
                                        PopupMenu::_notification
                                            Popup::_notification
                                                Popup::_close_pressed
                                                    call_deferred this->Window::hide

OS_Windows::run
    DisplayServerWindow::process_events()
        WndProc right click
            Input::parse_input_event
                buffered_events.push_back
    Main::iteration
        Input::flush_buffered_events
            long way through the gui ...
                PopupMenu::popup
                    Window::popup
                        Window::set_visible (true)
                            window set visible in new location
        Scene_tree::physics_process
            flush dispatches Window::hide from previous sequence
                Window::set_visible (false)
                    window was reused in the time we were async, close it again
```

After the changes in this PR, the sequences are intended to be as follows:

# Fixed case 1: reopened before hide executes -> don't hide at all

```
OS_Windows::run
    DisplayServerWindow::process_events()
        MouseProc right click
            _send_window_event WINDOW_EVENT_CLOSE_REQUEST
                Window::_propagate_window_notification NOTIFICATION_WM_CLOSE_REQUEST
                    PopupMenu::_notification
                        Popup::_notification
                            Popup::_close_pressed
                                popped_up = false
                                call_deferred this->Popup::_popup_conditional_hide
        WndProc right click
            Input::parse_input_event
                buffered_events.push_back
    Main::iteration
        Input::flush_buffered_events
            long way through the gui ...
                PopupMenu::popup
                    Window::popup
                        Window::set_visible (true)
                            does nothing since already visible
                        Popup::_post_popup
                            popped_up = true
        Scene_tree::physics_process
            flush dispatches Popup::_popup_conditional_hide
                popped_up == true, do nothing
```

# Fixed case2: not reopened before hide executes -> execute hide, but only once

```
OS_Windows::run
    DisplayServerWindow::process_events()
        MouseProc right click
            _send_window_event WINDOW_EVENT_CLOSE_REQUEST
                Window::_propagate_window_notification NOTIFICATION_WM_CLOSE_REQUEST
                    PopupMenu::_notification
                        Popup::_notification
                            Popup::_close_pressed
                                popped_up = false
                                call_deferred this->Popup::_popup_conditional_hide
        WndProc right click
            Input::parse_input_event
                buffered_events.push_back
    Main::iteration
        Scene_tree::physics_process
            flush dispatches Popup::_popup_conditional_hide
                popped_up == false
                Window::set_visible (false)
                    Window::_clear_window
                        DisplayServerWindows::delete_sub_window
                            DisplayServerWindows::popup_close
                                don't send close request to self, only other popups
```

# Limitations

This fix does not change the behavior of --single-window mode.  In this mode, popups already don't automatically close when you click else where. This is unchanged from the current 4.0 master, and I do not know what the intended behavior is in this mode.
