### PR TITLE
GDScript: Fix stack manipulation for `await`

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -279,7 +279,8 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 void GDScriptFunctionState::_clear_stack() {
 	if (state.stack_size) {
 		Variant *stack = (Variant *)state.stack.ptr();
-		for (int i = 0; i < state.stack_size; i++) {
+		// The first 3 are special addresses and not copied to the state, so we skip them here.
+		for (int i = 3; i < state.stack_size; i++) {
 			stack[i].~Variant();
 		}
 		state.stack_size = 0;
@@ -300,8 +301,6 @@ GDScriptFunctionState::GDScriptFunctionState() :
 }
 
 GDScriptFunctionState::~GDScriptFunctionState() {
-	_clear_stack();
-
 	{
 		MutexLock lock(GDScriptLanguage::singleton->lock);
 		scripts_list.remove_from_list();


### PR DESCRIPTION
The stack now contains three special addresses that should no be copied to the state, since it contains references that creates cycles. They can be recreated when the function is resumed.

This commit also removes the clearing of stack from the GDScriptFunctionState destructor, since it should be cleared when the
function exits. The state stack should only be cleared manually if the instance is freed before the state resumes (which is already being done). Otherwise this would destruct the stack twice, causing crashes.

Fixes #57126

~~Note that I still see leaks after this PR. The `SceneTreeTimer` instances created still leak. I'm still not sure why this happens nor whether it's related to this, but I prefer to publish this fix now to avoid the crashing at least. I'll keep investigating the leak, but it's not as urgent.~~ (This is now solved in this PR too).
