### PR TITLE
Bind EditorFileSystem::reimport_files and improve docs

### DIFF
--- a/doc/classes/EditorFileSystem.xml
+++ b/doc/classes/EditorFileSystem.xml
@@ -42,6 +42,15 @@
 				Returns [code]true[/code] of the filesystem is being scanned.
 			</description>
 		</method>
+		<method name="reimport_files">
+			<return type="void" />
+			<argument index="0" name="files" type="PackedStringArray" />
+			<description>
+				Reimports a set of files. Call this if these files or their [code].import[/code] files were directly edited by script or an external program.
+				If the file type changed or the file was newly created, use [method update_file] or [method scan].
+				[b]Note:[/b] This function blocks until the import is finished. However, the main loop iteration, including timers and [method Node._process], will occur during the import process due to progress bar updates. Avoid calls to [method reimport_files] or [method scan] while an import is in progress.
+			</description>
+		</method>
 		<method name="scan">
 			<return type="void" />
 			<description>
@@ -58,7 +67,8 @@
 			<return type="void" />
 			<argument index="0" name="path" type="String" />
 			<description>
-				Update a file information. Call this if an external program (not Godot) modified the file.
+				Add a file in an existing directory, or schedule file information to be updated on editor restart. Can be used to update text files saved by an external program.
+				This will not import the file. To reimport, call [method reimport_files] or [method scan] methods.
 			</description>
 		</method>
 		<method name="update_script_classes">

--- a/editor/editor_file_system.cpp
+++ b/editor/editor_file_system.cpp
@@ -2372,6 +2372,7 @@ void EditorFileSystem::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_filesystem_path", "path"), &EditorFileSystem::get_filesystem_path);
 	ClassDB::bind_method(D_METHOD("get_file_type", "path"), &EditorFileSystem::get_file_type);
 	ClassDB::bind_method(D_METHOD("update_script_classes"), &EditorFileSystem::update_script_classes);
+	ClassDB::bind_method(D_METHOD("reimport_files", "files"), &EditorFileSystem::reimport_files);
 
 	ADD_SIGNAL(MethodInfo("filesystem_changed"));
 	ADD_SIGNAL(MethodInfo("sources_changed", PropertyInfo(Variant::BOOL, "exist")));


### PR DESCRIPTION
reimport_files offers a way for scripts to modify imported resources directly.
For example, images, sounds or glTF documents which are written by an external program.

It is much faster than `scan`, and can allow scripts to synchronously proceed after import finishes. This also gives a nice way to modify resources without hitting the reentrancy bug #46893, since I can set a boolean to true before the call to `reimport_files` and set it to false afterwards, or simply drive the import process in a single function without using asynchronous methods.

I'm using this in Unidot-Importer to import .jpg/.png images, .gltf documents and sound files such .wav/.mp3/.ogg and it seems to be very fast and pleasant to use, both firing a signal and returning when complete.

This function was probably intended to be public, given that its name does not begin with an underscore.