### PR TITLE
Fix script editor opening when external editor is configured for C#

### DIFF
--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -2305,7 +2305,7 @@ void EditorNode::_edit_current(bool p_skip_foreign) {
 		if (main_plugin) {
 			// Special case if use of external editor is true.
 			Resource *current_res = Object::cast_to<Resource>(current_obj);
-			if (main_plugin->get_name() == "Script" && current_obj->is_class("VisualScript") && current_res && !current_res->is_built_in() && (bool(EditorSettings::get_singleton()->get("text_editor/external/use_external_editor")) || overrides_external_editor(current_obj))) {
+			if (main_plugin->get_name() == "Script" && !current_obj->is_class("VisualScript") && current_res && !current_res->is_built_in() && (bool(EditorSettings::get_singleton()->get("text_editor/external/use_external_editor")) || overrides_external_editor(current_obj))) {
 				if (!changing_scene) {
 					main_plugin->edit(current_obj);
 				}


### PR DESCRIPTION
Fixes #61015

Currently the built-in script editor will always open even if an external editor is configured for C#.

It appears that this issue was introduced when a condition was changed to use `current_obj->is_class("VisualScript")` opposed to the previous `current_obj->get_class_name() != StringName("VisualScript")`. Negating the result once again prevents the built-in script editor from opening.