### PR TITLE
display of large help text in visual script

### DIFF
--- a/modules/visual_script/editor/visual_script_editor.cpp
+++ b/modules/visual_script/editor/visual_script_editor.cpp
@@ -1959,15 +1959,6 @@ void VisualScriptEditor::_generic_search(Vector2 pos, bool node_centered) {
 	}
 
 	new_connect_node_select->select_from_visual_script(script, false); // do not reset text
-
-	// Ensure that the dialog fits inside the graph.
-	Size2 bounds = graph->get_global_position() + graph->get_size() - new_connect_node_select->get_size();
-	pos.x = pos.x > bounds.x ? bounds.x : pos.x;
-	pos.y = pos.y > bounds.y ? bounds.y : pos.y;
-
-	if (pos != Vector2()) {
-		new_connect_node_select->set_position(pos);
-	}
 }
 
 void VisualScriptEditor::input(const Ref<InputEvent> &p_event) {

--- a/modules/visual_script/editor/visual_script_property_selector.cpp
+++ b/modules/visual_script/editor/visual_script_property_selector.cpp
@@ -521,8 +521,17 @@ VisualScriptPropertySelector::VisualScriptPropertySelector() {
 	results_tree->connect("item_selected", callable_mp(this, &VisualScriptPropertySelector::_item_selected));
 	vbox->add_child(results_tree);
 
+	ScrollContainer *scroller = memnew(ScrollContainer);
+	scroller->set_horizontal_scroll_mode(ScrollContainer::SCROLL_MODE_DISABLED);
+	scroller->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	scroller->set_custom_minimum_size(Size2(600, 400) * EDSCALE);
+	vbox->add_child(scroller);
+
 	help_bit = memnew(EditorHelpBit);
-	vbox->add_child(help_bit);
+	help_bit->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	help_bit->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	scroller->add_child(help_bit);
+
 	help_bit->connect("request_hide", callable_mp(this, &VisualScriptPropertySelector::_hide_requested));
 	get_ok_button()->set_text(TTR("Open"));
 	get_ok_button()->set_disabled(true);


### PR DESCRIPTION
implemented vertical scroller for help text in popup
disabled broken positioning code
fixes #58121

~~Note to reviewers: I disabled some positioning code that does not work at all.  I don't know what requirements this was supposed to address, so I could not implement it.   The disabled code was pushing large windows off the screen due to incorrect calculations and was doing very bad things in multi monitor setups where screen coordinates are very different from global coordinates.~~

[edit: Akien correctly points out these calculations may have been correct in 3.x, so I could be wrong here.]
[edit: After discussion, the disabled code is being removed entirely, since it isn't required in either mode.]