### PR TITLE
Swap the meaning of `CURSOR_WAIT` and `CURSOR_BUSY`

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1194,10 +1194,10 @@
 			Show the system's cross mouse cursor when the user hovers the node.
 		</constant>
 		<constant name="CURSOR_WAIT" value="4" enum="CursorShape">
-			Show the system's wait mouse cursor, often an hourglass, when the user hovers the node.
+			Show the system's wait mouse cursor when the user hovers the node. Often an hourglass.
 		</constant>
 		<constant name="CURSOR_BUSY" value="5" enum="CursorShape">
-			Show the system's busy mouse cursor when the user hovers the node. Often an hourglass.
+			Show the system's busy mouse cursor when the user hovers the node. Often an arrow with a small hourglass.
 		</constant>
 		<constant name="CURSOR_DRAG" value="6" enum="CursorShape">
 			Show the system's drag mouse cursor, often a closed fist or a cross symbol, when the user hovers the node. It tells the user they're currently dragging an item, like a node in the Scene dock.

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -428,10 +428,10 @@
 			Cross cursor. Typically appears over regions in which a drawing operation can be performed or for selections.
 		</constant>
 		<constant name="CURSOR_WAIT" value="4" enum="CursorShape">
-			Wait cursor. Indicates that the application is busy performing an operation. This cursor shape denotes that the application is still usable during the operation.
+			Wait cursor. Indicates that the application is busy performing an operation. This cursor shape denotes that the application isn't usable during the operation (e.g. something is blocking its main thread).
 		</constant>
 		<constant name="CURSOR_BUSY" value="5" enum="CursorShape">
-			Busy cursor. Indicates that the application is busy performing an operation. This cursor shape denotes that the application isn't usable during the operation (e.g. something is blocking its main thread).
+			Busy cursor. Indicates that the application is busy performing an operation. This cursor shape denotes that the application is still usable during the operation.
 		</constant>
 		<constant name="CURSOR_DRAG" value="6" enum="CursorShape">
 			Drag cursor. Usually displayed when dragging something.

--- a/platform/javascript/display_server_javascript.cpp
+++ b/platform/javascript/display_server_javascript.cpp
@@ -244,9 +244,9 @@ const char *DisplayServerJavaScript::godot2dom_cursor(DisplayServer::CursorShape
 		case DisplayServer::CURSOR_CROSS:
 			return "crosshair";
 		case DisplayServer::CURSOR_WAIT:
-			return "progress";
-		case DisplayServer::CURSOR_BUSY:
 			return "wait";
+		case DisplayServer::CURSOR_BUSY:
+			return "progress";
 		case DisplayServer::CURSOR_DRAG:
 			return "grab";
 		case DisplayServer::CURSOR_CAN_DROP:


### PR DESCRIPTION
Fixes #61000

This PR is mainly a documentation fix: `CURSOR_WAIT` should be an hourglass (blocking) and `CURSOR_BUSY` should be an arrow with a small hourglass (non-blocking).

* Using "wait" to mean "blocking" is consistent with other APIs like [Qt](https://doc.qt.io/qt-5/qcursor.html#a-note-for-x11-users) and [CSS](https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#values).
* On Windows and Linux, the actual cursor shapes have been like this since Godot is open-sourced.
* Web platform honors the documentation, so its cursor shapes are swapped in this PR.
* UWP, macOS, and Android use the same shape for `CURSOR_WAIT` and `CURSOR_BUSY`. They are untouched.
