### PR TITLE
[3.x] Swap the meaning of `CURSOR_WAIT` and `CURSOR_BUSY`

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -975,10 +975,10 @@
 			Show the system's cross mouse cursor when the user hovers the node.
 		</constant>
 		<constant name="CURSOR_WAIT" value="4" enum="CursorShape">
-			Show the system's wait mouse cursor, often an hourglass, when the user hovers the node.
+			Show the system's wait mouse cursor when the user hovers the node. Often an hourglass.
 		</constant>
 		<constant name="CURSOR_BUSY" value="5" enum="CursorShape">
-			Show the system's busy mouse cursor when the user hovers the node. Often an hourglass.
+			Show the system's busy mouse cursor when the user hovers the node. Often an arrow with a small hourglass.
 		</constant>
 		<constant name="CURSOR_DRAG" value="6" enum="CursorShape">
 			Show the system's drag mouse cursor, often a closed fist or a cross symbol, when the user hovers the node. It tells the user they're currently dragging an item, like a node in the Scene dock.

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -450,10 +450,10 @@
 			Cross cursor. Typically appears over regions in which a drawing operation can be performed or for selections.
 		</constant>
 		<constant name="CURSOR_WAIT" value="4" enum="CursorShape">
-			Wait cursor. Indicates that the application is busy performing an operation. This cursor shape denotes that the application is still usable during the operation.
+			Wait cursor. Indicates that the application is busy performing an operation. This cursor shape denotes that the application isn't usable during the operation (e.g. something is blocking its main thread).
 		</constant>
 		<constant name="CURSOR_BUSY" value="5" enum="CursorShape">
-			Busy cursor. Indicates that the application is busy performing an operation. This cursor shape denotes that the application isn't usable during the operation (e.g. something is blocking its main thread).
+			Busy cursor. Indicates that the application is busy performing an operation. This cursor shape denotes that the application is still usable during the operation.
 		</constant>
 		<constant name="CURSOR_DRAG" value="6" enum="CursorShape">
 			Drag cursor. Usually displayed when dragging something.

--- a/platform/javascript/os_javascript.cpp
+++ b/platform/javascript/os_javascript.cpp
@@ -334,9 +334,9 @@ static const char *godot2dom_cursor(OS::CursorShape p_shape) {
 		case OS::CURSOR_CROSS:
 			return "crosshair";
 		case OS::CURSOR_WAIT:
-			return "progress";
-		case OS::CURSOR_BUSY:
 			return "wait";
+		case OS::CURSOR_BUSY:
+			return "progress";
 		case OS::CURSOR_DRAG:
 			return "grab";
 		case OS::CURSOR_CAN_DROP:


### PR DESCRIPTION
`3.x` version of #61020

Note that the actual cursor shapes are untouched except on the Web platform.