### PR TITLE
Make `auto_accept_quit` and `quit_on_go_back` properties

### DIFF
--- a/doc/classes/SceneTree.xml
+++ b/doc/classes/SceneTree.xml
@@ -177,14 +177,6 @@
 				Returns [constant OK] on success, [constant ERR_UNCONFIGURED] if no [member current_scene] was defined yet, [constant ERR_CANT_OPEN] if [member current_scene] cannot be loaded into a [PackedScene], or [constant ERR_CANT_CREATE] if the scene cannot be instantiated.
 			</description>
 		</method>
-		<method name="set_auto_accept_quit">
-			<return type="void" />
-			<argument index="0" name="enabled" type="bool" />
-			<description>
-				If [code]true[/code], the application automatically accepts quitting. Enabled by default.
-				For mobile platforms, see [method set_quit_on_go_back].
-			</description>
-		</method>
 		<method name="set_group">
 			<return type="void" />
 			<argument index="0" name="group" type="StringName" />
@@ -214,16 +206,12 @@
 				Sets a custom [MultiplayerAPI] with the given [code]root_path[/code] (controlling also the relative subpaths), or override the default one if [code]root_path[/code] is empty.
 			</description>
 		</method>
-		<method name="set_quit_on_go_back">
-			<return type="void" />
-			<argument index="0" name="enabled" type="bool" />
-			<description>
-				If [code]true[/code], the application quits automatically on going back (e.g. on Android). Enabled by default.
-				To handle 'Go Back' button when this option is disabled, use [constant DisplayServer.WINDOW_EVENT_GO_BACK_REQUEST].
-			</description>
-		</method>
 	</methods>
 	<members>
+		<member name="auto_accept_quit" type="bool" setter="set_auto_accept_quit" getter="is_auto_accept_quit" default="true">
+			If [code]true[/code], the application automatically accepts quitting.
+			For mobile platforms, see [member quit_on_go_back].
+		</member>
 		<member name="current_scene" type="Node" setter="set_current_scene" getter="get_current_scene">
 			The current scene.
 		</member>
@@ -244,6 +232,10 @@
 			If [code]true[/code], the [SceneTree] is paused. Doing so will have the following behavior:
 			- 2D and 3D physics will be stopped. This includes signals and collision detection.
 			- [method Node._process], [method Node._physics_process] and [method Node._input] will not be called anymore in nodes.
+		</member>
+		<member name="quit_on_go_back" type="bool" setter="set_quit_on_go_back" getter="is_quit_on_go_back" default="true">
+			If [code]true[/code], the application quits automatically on going back (e.g. on Android).
+			To handle 'Go Back' button when this option is disabled, use [constant DisplayServer.WINDOW_EVENT_GO_BACK_REQUEST].
 		</member>
 		<member name="root" type="Window" setter="" getter="get_root">
 			The [SceneTree]'s root [Window].

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -627,8 +627,16 @@ void SceneTree::_notification(int p_notification) {
 	}
 }
 
+bool SceneTree::is_auto_accept_quit() const {
+	return accept_quit;
+}
+
 void SceneTree::set_auto_accept_quit(bool p_enable) {
 	accept_quit = p_enable;
+}
+
+bool SceneTree::is_quit_on_go_back() const {
+	return quit_on_go_back;
 }
 
 void SceneTree::set_quit_on_go_back(bool p_enable) {
@@ -1192,7 +1200,9 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_root"), &SceneTree::get_root);
 	ClassDB::bind_method(D_METHOD("has_group", "name"), &SceneTree::has_group);
 
+	ClassDB::bind_method(D_METHOD("is_auto_accept_quit"), &SceneTree::is_auto_accept_quit);
 	ClassDB::bind_method(D_METHOD("set_auto_accept_quit", "enabled"), &SceneTree::set_auto_accept_quit);
+	ClassDB::bind_method(D_METHOD("is_quit_on_go_back"), &SceneTree::is_quit_on_go_back);
 	ClassDB::bind_method(D_METHOD("set_quit_on_go_back", "enabled"), &SceneTree::set_quit_on_go_back);
 
 	ClassDB::bind_method(D_METHOD("set_debug_collisions_hint", "enable"), &SceneTree::set_debug_collisions_hint);
@@ -1255,6 +1265,8 @@ void SceneTree::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_multiplayer_poll_enabled", "enabled"), &SceneTree::set_multiplayer_poll_enabled);
 	ClassDB::bind_method(D_METHOD("is_multiplayer_poll_enabled"), &SceneTree::is_multiplayer_poll_enabled);
 
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "auto_accept_quit"), "set_auto_accept_quit", "is_auto_accept_quit");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "quit_on_go_back"), "set_quit_on_go_back", "is_quit_on_go_back");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_collisions_hint"), "set_debug_collisions_hint", "is_debugging_collisions_hint");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "debug_navigation_hint"), "set_debug_navigation_hint", "is_debugging_navigation_hint");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "paused"), "set_pause", "is_paused");

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -269,7 +269,10 @@ public:
 
 	virtual void finalize() override;
 
+	bool is_auto_accept_quit() const;
 	void set_auto_accept_quit(bool p_enable);
+
+	bool is_quit_on_go_back() const;
 	void set_quit_on_go_back(bool p_enable);
 
 	void quit(int p_exit_code = EXIT_SUCCESS);


### PR DESCRIPTION
`SceneTree` provided setters for these two properties but not getters.

This PR adds the missing getters and exposes them as properties.