### PR TITLE
Automatically disable threaded NavigationMesh bake on unsupported OS

### DIFF
--- a/doc/classes/NavigationRegion3D.xml
+++ b/doc/classes/NavigationRegion3D.xml
@@ -14,7 +14,7 @@
 			<return type="void" />
 			<argument index="0" name="on_thread" type="bool" default="true" />
 			<description>
-				Bakes the [NavigationMesh]. If [code]on_thread[/code] is set to [code]true[/code] (default), the baking is done on a separate thread. Baking on separate thread is useful because navigation baking is not a cheap operation. When it is completed, it automatically sets the new [NavigationMesh]. Please note that baking on separate thread may be very slow if geometry is parsed from meshes as async access to each mesh involves heavy synchronization.
+				Bakes the [NavigationMesh]. If [code]on_thread[/code] is set to [code]true[/code] (default), the baking is done on a separate thread. Baking on separate thread is useful because navigation baking is not a cheap operation. When it is completed, it automatically sets the new [NavigationMesh]. Please note that baking on separate thread may be very slow if geometry is parsed from meshes as async access to each mesh involves heavy synchronization. Also, please note that baking on a separate thread is automatically disabled on operating systems that cannot use threads (such as HTML5 with threads disabled).
 			</description>
 		</method>
 		<method name="get_region_rid" qualifiers="const">

--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -171,7 +171,12 @@ void NavigationRegion3D::bake_navigation_mesh(bool p_on_thread) {
 	BakeThreadsArgs *args = memnew(BakeThreadsArgs);
 	args->nav_region = this;
 
-	if (p_on_thread) {
+	if (p_on_thread && !OS::get_singleton()->can_use_threads()) {
+		WARN_PRINT("NavigationMesh bake 'on_thread' will be disabled as the current OS does not support multiple threads."
+				   "\nAs a fallback the navigation mesh will bake on the main thread which can cause framerate issues.");
+	}
+
+	if (p_on_thread && OS::get_singleton()->can_use_threads()) {
 		bake_thread.start(_bake_navigation_mesh, args);
 	} else {
 		_bake_navigation_mesh(args);


### PR DESCRIPTION
Automatically disables threaded NavigationMesh bake with fallback to single-thread when OS does not support multiple-threads.

Fixes #58098