### PR TITLE
Fix NavigationObstacle2D/3D get_global_transform() error

### DIFF
--- a/scene/2d/navigation_obstacle_2d.cpp
+++ b/scene/2d/navigation_obstacle_2d.cpp
@@ -79,7 +79,7 @@ void NavigationObstacle2D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
-			if (parent_node2d) {
+			if (parent_node2d && parent_node2d->is_inside_tree()) {
 				NavigationServer2D::get_singleton()->agent_set_position(agent, parent_node2d->get_global_position());
 			}
 		} break;
@@ -122,13 +122,13 @@ void NavigationObstacle2D::reevaluate_agent_radius() {
 }
 
 real_t NavigationObstacle2D::estimate_agent_radius() const {
-	if (parent_node2d) {
+	if (parent_node2d && parent_node2d->is_inside_tree()) {
 		// Estimate the radius of this physics body
 		real_t radius = 0.0;
 		for (int i(0); i < parent_node2d->get_child_count(); i++) {
 			// For each collision shape
 			CollisionShape2D *cs = Object::cast_to<CollisionShape2D>(parent_node2d->get_child(i));
-			if (cs) {
+			if (cs && cs->is_inside_tree()) {
 				// Take the distance between the Body center to the shape center
 				real_t r = cs->get_transform().get_origin().length();
 				if (cs->get_shape().is_valid()) {
@@ -139,6 +139,9 @@ real_t NavigationObstacle2D::estimate_agent_radius() const {
 				r *= MAX(s.x, s.y);
 				// Takes the biggest radius
 				radius = MAX(radius, r);
+			} else if (cs && !cs->is_inside_tree()) {
+				WARN_PRINT("A CollisionShape2D of the NavigationObstacle2D parent node was not inside the SceneTree when estimating the obstacle radius."
+						   "\nMove the NavigationObstacle2D to a child position below any CollisionShape2D node of the parent node so the CollisionShape2D is already inside the SceneTree.");
 			}
 		}
 		Vector2 s = parent_node2d->get_global_scale();

--- a/scene/3d/navigation_obstacle_3d.cpp
+++ b/scene/3d/navigation_obstacle_3d.cpp
@@ -79,7 +79,7 @@ void NavigationObstacle3D::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
-			if (parent_node3d) {
+			if (parent_node3d && parent_node3d->is_inside_tree()) {
 				NavigationServer3D::get_singleton()->agent_set_position(agent, parent_node3d->get_global_transform().origin);
 
 				PhysicsBody3D *rigid = Object::cast_to<PhysicsBody3D>(get_parent());
@@ -129,13 +129,13 @@ void NavigationObstacle3D::reevaluate_agent_radius() {
 }
 
 real_t NavigationObstacle3D::estimate_agent_radius() const {
-	if (parent_node3d) {
+	if (parent_node3d && parent_node3d->is_inside_tree()) {
 		// Estimate the radius of this physics body
 		real_t radius = 0.0;
 		for (int i(0); i < parent_node3d->get_child_count(); i++) {
 			// For each collision shape
 			CollisionShape3D *cs = Object::cast_to<CollisionShape3D>(parent_node3d->get_child(i));
-			if (cs) {
+			if (cs && cs->is_inside_tree()) {
 				// Take the distance between the Body center to the shape center
 				real_t r = cs->get_transform().origin.length();
 				if (cs->get_shape().is_valid()) {
@@ -146,6 +146,9 @@ real_t NavigationObstacle3D::estimate_agent_radius() const {
 				r *= MAX(s.x, MAX(s.y, s.z));
 				// Takes the biggest radius
 				radius = MAX(radius, r);
+			} else if (cs && !cs->is_inside_tree()) {
+				WARN_PRINT("A CollisionShape3D of the NavigationObstacle3D parent node was not inside the SceneTree when estimating the obstacle radius."
+						   "\nMove the NavigationObstacle3D to a child position below any CollisionShape3D node of the parent node so the CollisionShape3D is already inside the SceneTree.");
 			}
 		}
 


### PR DESCRIPTION
Fixes NavigationObstacle2D/3D reporting a 'get_global_transform: Condition "!is_inside_tree()" error when estimating the agent radius. The collisionshapes that are lower in the SceneTree order than the obstacle node are not loaded in the SceneTree yet so the global_transform function fails. There was also the case of error spam when the parent node was not inside SceneTree.

Change makes sure that both parent as well as all collision child nodes are inside tree or else they are ignored and a config warning is printed.

Fixes #59833

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
