### PR TITLE
Use a different color for GPUParticlesAttractor3D editor gizmos

### DIFF
--- a/editor/plugins/node_3d_editor_gizmos.cpp
+++ b/editor/plugins/node_3d_editor_gizmos.cpp
@@ -2993,10 +2993,15 @@ void GPUParticles3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 ////
 
 GPUParticlesCollision3DGizmoPlugin::GPUParticlesCollision3DGizmoPlugin() {
-	Color gizmo_color = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/particle_collision", Color(0.5, 0.7, 1));
-	create_material("shape_material", gizmo_color);
-	gizmo_color.a = 0.15;
-	create_material("shape_material_internal", gizmo_color);
+	Color gizmo_color_attractor = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/particle_attractor", Color(1, 0.7, 0.5));
+	create_material("shape_material_attractor", gizmo_color_attractor);
+	gizmo_color_attractor.a = 0.15;
+	create_material("shape_material_attractor_internal", gizmo_color_attractor);
+
+	Color gizmo_color_collision = EDITOR_DEF("editors/3d_gizmos/gizmo_colors/particle_collision", Color(0.5, 0.7, 1));
+	create_material("shape_material_collision", gizmo_color_collision);
+	gizmo_color_collision.a = 0.15;
+	create_material("shape_material_collision_internal", gizmo_color_collision);
 
 	create_handle_material("handles");
 }
@@ -3122,12 +3127,17 @@ void GPUParticlesCollision3DGizmoPlugin::redraw(EditorNode3DGizmo *p_gizmo) {
 
 	p_gizmo->clear();
 
-	const Ref<Material> material =
-			get_material("shape_material", p_gizmo);
-	const Ref<Material> material_internal =
-			get_material("shape_material_internal", p_gizmo);
+	Ref<Material> material;
+	Ref<Material> material_internal;
+	if (Object::cast_to<GPUParticlesAttractor3D>(cs)) {
+		material = get_material("shape_material_attractor", p_gizmo);
+		material_internal = get_material("shape_material_attractor_internal", p_gizmo);
+	} else {
+		material = get_material("shape_material_collision", p_gizmo);
+		material_internal = get_material("shape_material_collision_internal", p_gizmo);
+	}
 
-	Ref<Material> handles_material = get_material("handles");
+	const Ref<Material> handles_material = get_material("handles");
 
 	if (Object::cast_to<GPUParticlesCollisionSphere3D>(cs) || Object::cast_to<GPUParticlesAttractorSphere3D>(cs)) {
 		float r = cs->call("get_radius");


### PR DESCRIPTION
This makes attractor gizmos (orange) distinguishable from collision gizmos (blue).

**Note:** Not cherry-pickable to `3.x` as GPUParticles3D attractors and collision aren't implemented there.

## Preview

*Left: Attractor, Right: Collision*

![image](https://user-images.githubusercontent.com/180032/168499493-cf72e889-fd44-4d53-9c00-70cdcaadf240.png)