### PR TITLE
Fix crash when editing pinned StyleBox

### DIFF
--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -3211,11 +3211,13 @@ void ThemeTypeEditor::_update_stylebox_from_leading() {
 	edited_theme->get_stylebox_list(edited_type, &names);
 	List<Ref<StyleBox>> styleboxes;
 	for (const StringName &E : names) {
-		if (E == leading_stylebox.item_name) {
+		Ref<StyleBox> sb = edited_theme->get_stylebox(E, edited_type);
+
+		// Avoid itself, stylebox can be shared between items.
+		if (sb == leading_stylebox.stylebox) {
 			continue;
 		}
 
-		Ref<StyleBox> sb = edited_theme->get_stylebox(E, edited_type);
 		if (sb->get_class() == leading_stylebox.stylebox->get_class()) {
 			styleboxes.push_back(sb);
 		}


### PR DESCRIPTION
Fixes #61053

Other theme items may be reusing the leading/pinned StyleBox. Don't propagate changes into itself.