### PR TITLE
Fix OpenXR initialisation by implementing a callback into DisplayServer

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1621,6 +1621,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 
 	/* Initialize Display Server */
 
+	// Make sure any pre-setup for our chosen rendering driver is done such as setting up our Vulkan Hooks.
+	DisplayServer::call_rendering_driver_setup_callbacks(rendering_driver);
+
 	{
 		String display_driver = DisplayServer::get_create_function_name(display_driver_idx);
 
@@ -2015,10 +2018,6 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	MAIN_PRINT("Main: Done");
 
 	return OK;
-}
-
-String Main::get_rendering_driver_name() {
-	return rendering_driver;
 }
 
 // everything the main loop needs to know about frame timings

--- a/main/main.h
+++ b/main/main.h
@@ -50,7 +50,6 @@ public:
 	static int test_entrypoint(int argc, char *argv[], bool &tests_need_run);
 	static Error setup(const char *execpath, int argc, char *argv[], bool p_second_phase = true);
 	static Error setup2(Thread::ID p_main_tid_override = 0);
-	static String get_rendering_driver_name();
 #ifdef TESTS_ENABLED
 	static Error test_setup();
 	static void test_cleanup();

--- a/servers/display_server.cpp
+++ b/servers/display_server.cpp
@@ -35,6 +35,7 @@
 #include "servers/display_server_headless.h"
 
 DisplayServer *DisplayServer::singleton = nullptr;
+Vector<Callable> DisplayServer::rendering_driver_setup_callbacks;
 
 bool DisplayServer::hidpi_allowed = false;
 

--- a/servers/display_server.h
+++ b/servers/display_server.h
@@ -43,10 +43,28 @@ class DisplayServer : public Object {
 
 	static DisplayServer *singleton;
 	static bool hidpi_allowed;
+	static Vector<Callable> rendering_driver_setup_callbacks;
 
 public:
 	_FORCE_INLINE_ static DisplayServer *get_singleton() {
 		return singleton;
+	}
+
+	// TODO move this somewhere so we can bind the method and make it callable from externals...
+	_FORCE_INLINE_ static void register_rendering_driver_setup_callback(const Callable &p_callback) {
+		rendering_driver_setup_callbacks.push_back(p_callback);
+	}
+
+	_FORCE_INLINE_ static void call_rendering_driver_setup_callbacks(const String &p_rendering_driver_name) {
+		for (int i = 0; i < rendering_driver_setup_callbacks.size(); i++) {
+			Variant rendering_driver_name = p_rendering_driver_name;
+			Variant ret;
+
+			const Variant *params[1] = { &rendering_driver_name };
+			Callable::CallError err;
+
+			rendering_driver_setup_callbacks[i].call(params, 1, ret, err);
+		}
 	}
 
 	enum WindowMode {


### PR DESCRIPTION
Alternative to #60996 as discussed with Reduz, not sure yet if this is how it should be.

This implementation does not require the introduction of new initialization levels. Instead the OpenXR module can register a callback with the `DisplayServer` that performs the setup logic it needs to do.

`DisplayServer` was chosen as this class also sets up the Vulkan or OpenGL renderer, which is the whole reason we need to perform this step with the OpenXR module. 
