### PR TITLE
Updating node properties in multi-scene inheritance 

### DIFF
--- a/editor/editor_data.cpp
+++ b/editor/editor_data.cpp
@@ -569,6 +569,17 @@ bool EditorData::_find_updated_instances(Node *p_root, Node *p_node, HashSet<Str
 
 			checked_paths.insert(path);
 		}
+
+		// look for changes in parent of parent inherited and so on
+		// check if matches any of the open edited scenes
+		for (int i = 0; i < edited_scene.size(); i++) {
+			if (path == edited_scene[i].path) {
+				bool found = check_and_update_scene(i);
+				if (found) {
+					return true;
+				}
+			}
+		}
 	}
 
 	for (int i = 0; i < p_node->get_child_count(); i++) {


### PR DESCRIPTION
Opening as a draft to write down the different problems I'm finding about this issue.

This issue affects both opened and closed scenes. Making changes in a level 1 scene before opening a previously closed level 3 scene does not affect the same changes.
As far as I can tell this is happening in two places:

1. `EditorData::_find_updated_instances` is only checking the immediate scene it inherits from
2. When packing a scene to instantiate, `SceneState::_parse_node` is overwriting default values from the inherited scene with its own previous values, but only if the inheritance is more than one level.
    * For some reason, `PropertyUtils::get_property_default_value` is unable to find the value from the scene it inherits from, possibly due to construction of `states_stack`. This means one level inheritance  is working fine because the following block tells it to not update the property when being instantiated (whether it's intended or not, I don't know).

https://github.com/godotengine/godot/blob/396def9b66c476f7834604adb7136ca903ed01be/scene/resources/packed_scene.cpp#L554-L560

Current commit has a fix for 1) but only works if all inherited scenes are open. I haven't found a way to traverse back the inheritance tree that works with checking modified time. This was the attempt at going back the inheritance tree. Since `SceneState` that the node scene saves is unique and the modified time value is pulled from the scene file when instantiating a node from the `SceneState`, checking modified time didn't work.

```cpp
bool EditorData::_find_updated_instances(Node *p_root, Node *p_node, Set<String> &checked_paths) {
	Ref<SceneState> ss;

	if (p_node == p_root) {
		ss = p_node->get_scene_inherited_state();
	} else if (!p_node->get_scene_file_path().is_empty()) {
		ss = p_node->get_scene_instance_state();
	}

	if (ss.is_valid()) {
		String path = ss->get_path();

		if (!checked_paths.has(path)) {
			uint64_t modified_time = FileAccess::get_modified_time(path);
			if (modified_time != ss->get_last_modified_time()) {
				return true; //external scene changed
			}

			checked_paths.insert(path);
		}

		Node *p = ss->instantiate(SceneState::GEN_EDIT_STATE_MAIN);
		bool found = _find_updated_instances(p, p, checked_paths);
		memdelete(p);
		if (found) {
			return true;
		}
	}

	for (int i = 0; i < p_node->get_child_count(); i++) {
		bool found = _find_updated_instances(p_root, p_node->get_child(i), checked_paths);
		if (found) {
			return true;
		}
	}

	return false;
}
```

Working on a fix for #60846