### PR TITLE
Fix `AnimatedSprite` doesn't emit `animation_finished` when changing playback direction

### DIFF
--- a/scene/2d/animated_sprite_2d.cpp
+++ b/scene/2d/animated_sprite_2d.cpp
@@ -388,6 +388,7 @@ void AnimatedSprite2D::play(const StringName &p_animation, const bool p_backward
 		}
 	}
 
+	is_over = false;
 	set_playing(true);
 }
 


### PR DESCRIPTION
Fixes #61078

The `is_over` here is preventing the signal from being triggered.

https://github.com/godotengine/godot/blob/c41f62c3df85fd71539ae09bd97964e5e367d897/scene/2d/animated_sprite_2d.cpp#L189-L192

It will be reset to `false` in `_reset_timeout()`. When calling `play()` in `animation_finished`, `set_playing()` will be called, but it will return immediately as the `playing` state is not changed. So the `is_over` is still `true`.

https://github.com/godotengine/godot/blob/c41f62c3df85fd71539ae09bd97964e5e367d897/scene/2d/animated_sprite_2d.cpp#L368-L375

I think it makes sense to always reset `is_over` to `false` in `play()`.