### PR TITLE
Keep input event as unhandled if they go through a control set to MOU…

### DIFF
--- a/doc/classes/Control.xml
+++ b/doc/classes/Control.xml
@@ -1037,6 +1037,10 @@
 		<member name="mouse_filter" type="int" setter="set_mouse_filter" getter="get_mouse_filter" enum="Control.MouseFilter" default="0">
 			Controls whether the control will be able to receive mouse button input events through [method _gui_input] and how these events should be handled. Also controls whether the control can receive the [signal mouse_entered], and [signal mouse_exited] signals. See the constants to learn what each does.
 		</member>
+		<member name="mouse_force_pass_scroll_events" type="bool" setter="set_force_pass_scroll_events" getter="is_force_pass_scroll_events" default="true">
+			When enabled, scroll wheel events processed by [method _gui_input] will be passed to the parent control even if [member mouse_filter] is set to [constant MOUSE_FILTER_STOP]. As it defaults to true, this allows nested scrollable containers to work out of the box.
+			You should disable it on the root of your UI if you do not want scroll events to go to the [code]_unhandled_input[/code] processing.
+		</member>
 		<member name="offset_bottom" type="float" setter="set_offset" getter="get_offset" default="0.0">
 			Distance between the node's bottom edge and its parent control, based on [member anchor_bottom].
 			Offsets are often controlled by one or multiple parent [Container] nodes, so you should not modify them manually if your node is a direct child of a [Container]. Offsets update automatically when you move or resize the node.
@@ -1315,7 +1319,7 @@
 			The control will receive mouse button input events through [method _gui_input] if clicked on. And the control will receive the [signal mouse_entered] and [signal mouse_exited] signals. These events are automatically marked as handled, and they will not propagate further to other controls. This also results in blocking signals in other controls.
 		</constant>
 		<constant name="MOUSE_FILTER_PASS" value="1" enum="MouseFilter">
-			The control will receive mouse button input events through [method _gui_input] if clicked on. And the control will receive the [signal mouse_entered] and [signal mouse_exited] signals. If this control does not handle the event, the parent control (if any) will be considered, and so on until there is no more parent control to potentially handle it. This also allows signals to fire in other controls. Even if no control handled it at all, the event will still be handled automatically, so unhandled input will not be fired.
+			The control will receive mouse button input events through [method _gui_input] if clicked on. And the control will receive the [signal mouse_entered] and [signal mouse_exited] signals. If this control does not handle the event, the parent control (if any) will be considered, and so on until there is no more parent control to potentially handle it. This also allows signals to fire in other controls. If no control handled it, the event will be passed to `_unhandled_input` for further processing.
 		</constant>
 		<constant name="MOUSE_FILTER_IGNORE" value="2" enum="MouseFilter">
 			The control will not receive mouse button input events through [method _gui_input]. The control will also not receive the [signal mouse_entered] nor [signal mouse_exited] signals. This will not block other controls from receiving these events or firing the signals. Ignored events will not be handled automatically.

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -471,6 +471,13 @@ void Control::_validate_property(PropertyInfo &property) const {
 		property.hint_string = hint_string;
 	}
 
+	if (property.name == "mouse_force_pass_scroll_events") {
+		// Disable force pass if the control is not stopping the event.
+		if (data.mouse_filter != MOUSE_FILTER_STOP) {
+			property.usage |= PROPERTY_USAGE_READ_ONLY;
+		}
+	}
+
 	// Validate which positioning properties should be displayed depending on the parent and the layout mode.
 	Node *parent_node = get_parent_control();
 	if (!parent_node) {
@@ -2931,11 +2938,20 @@ int Control::get_v_size_flags() const {
 void Control::set_mouse_filter(MouseFilter p_filter) {
 	ERR_FAIL_INDEX(p_filter, 3);
 	data.mouse_filter = p_filter;
+	notify_property_list_changed();
 	update_configuration_warnings();
 }
 
 Control::MouseFilter Control::get_mouse_filter() const {
 	return data.mouse_filter;
+}
+
+void Control::set_force_pass_scroll_events(bool p_force_pass_scroll_events) {
+	data.force_pass_scroll_events = p_force_pass_scroll_events;
+}
+
+bool Control::is_force_pass_scroll_events() const {
+	return data.force_pass_scroll_events;
 }
 
 void Control::warp_mouse(const Point2 &p_position) {
@@ -3250,6 +3266,9 @@ void Control::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_mouse_filter", "filter"), &Control::set_mouse_filter);
 	ClassDB::bind_method(D_METHOD("get_mouse_filter"), &Control::get_mouse_filter);
 
+	ClassDB::bind_method(D_METHOD("set_force_pass_scroll_events", "force_pass_scroll_events"), &Control::set_force_pass_scroll_events);
+	ClassDB::bind_method(D_METHOD("is_force_pass_scroll_events"), &Control::is_force_pass_scroll_events);
+
 	ClassDB::bind_method(D_METHOD("set_clip_contents", "enable"), &Control::set_clip_contents);
 	ClassDB::bind_method(D_METHOD("is_clipping_contents"), &Control::is_clipping_contents);
 
@@ -3331,6 +3350,7 @@ void Control::_bind_methods() {
 
 	ADD_GROUP("Mouse", "mouse_");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_filter", PROPERTY_HINT_ENUM, "Stop,Pass,Ignore"), "set_mouse_filter", "get_mouse_filter");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "mouse_force_pass_scroll_events"), "set_force_pass_scroll_events", "is_force_pass_scroll_events");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_default_cursor_shape", PROPERTY_HINT_ENUM, "Arrow,I-Beam,Pointing Hand,Cross,Wait,Busy,Drag,Can Drop,Forbidden,Vertical Resize,Horizontal Resize,Secondary Diagonal Resize,Main Diagonal Resize,Move,Vertical Split,Horizontal Split,Help"), "set_default_cursor_shape", "get_default_cursor_shape");
 
 	ADD_GROUP("Theme", "theme_");

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -190,6 +190,7 @@ private:
 		Point2 custom_minimum_size;
 
 		MouseFilter mouse_filter = MOUSE_FILTER_STOP;
+		bool force_pass_scroll_events = true;
 
 		bool clip_contents = false;
 
@@ -467,6 +468,9 @@ public:
 
 	void set_mouse_filter(MouseFilter p_filter);
 	MouseFilter get_mouse_filter() const;
+
+	void set_force_pass_scroll_events(bool p_force_pass_scroll_events);
+	bool is_force_pass_scroll_events() const;
 
 	/* SKINNING */
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -381,7 +381,7 @@ private:
 
 	bool disable_input = false;
 
-	void _gui_call_input(Control *p_control, const Ref<InputEvent> &p_input);
+	bool _gui_call_input(Control *p_control, const Ref<InputEvent> &p_input);
 	void _gui_call_notification(Control *p_control, int p_what);
 
 	void _gui_sort_roots();


### PR DESCRIPTION
I had that issue where I wanted to be able to drag&drop things onto a game view. To do so, I tried put a control set to MOUSE_FILTER_PASS on top of my world, expecting that all unhandled mouse event would end up being processed by `_unhandled_event`, turned out it wasn't the case. Basically, as soon as an event is given to a Control somewhere, the event would be considered as handled if it went through a control with MOUSE_FILTER_PASS or MOUSE_FILTER_STOP.

However, I think it is not expected that an event which went through Controls set to MOUSE_FILTER_PASS ends up as handled if it wasn't explicitly set as handled.

As a consequence, what this PR does is simply set a mouse event as handled only if it it was stopped by a control. If the event reaches the root going only through controls set to MOUSE_FILTER_PASS or MOUSE_FILTER_IGNORE (and is not set as handled explicitly), then the event is now passed to the `_unhandled_event` processing.

<details>
  <summary>Obsolete edit</summary>
while investigating this issue, I ended up with other problems that I tried to fix too:

1) There was a mistake in this line of `_gui_call_input(...)` : 
```
bool ismouse = ev.is_valid() || Object::cast_to<InputEventMouseMotion>(*p_input) != nullptr;
``` 
~~The `ev.is_valid()` part was always true, which caused all events, even keyboard ones, to be stopped while climbing up the tree if the Control had the filter set to `MOUSE_FILTER_STOP`. This does not seemed like an intended behavior.~~

2) ~~Scroll wheel events were unstoppable. It was not much of an issue when those event were not forwarded to `_unhandled_input`, but with this PR, it became quite annoying. So I removed this special case (as ScrollContainer is already set to `MOUSE_FILTER_PASS` by default anyway). It is debatable whether or not this change is welcome, as it means that we would need all containers in a hierarchy to be set as to use the `MOUSE_FILTER_IGNORE` or `MOUSE_FILTER_PASS` modes so that the event can climb up the tree. Maybe an alternative would be to add another mode, set by default, that would allow those specific events to pass? Like `MOUSE_FILTER_STOP_BUT_SCROLLS` (bad name, I have to admit ^^)? 
</details>

Alright, I had to modify a little bit the PR:
- Events that are not stopped still correctly go to `_unhandled_input`. This initial work caused issues, as scroll events were always passed, even with the `MOUSE_FILTER_STOP` filter. (I had no way to stop those events, thus scrolling in a ScrollContainer caused the event to be handled by `_unhandled_input`, and, in my case, it caused my camera to zoom in/out)
- To solve this, I added a `mouse_force_pass_scroll_events`. It allows you to still allow scroll events to be passed up the tree even when  using the `MOUSE_FILTER_STOP` filter. It is enabled by default. The property is grayed out if the mouse filter is not set to `MOUSE_FILTER_STOP` as it is useless in those other cases.
- Still fixed the bug on  that wrong line `bool ismouse = ev.is_valid() || Object::cast_to<InputEventMouseMotion>(*p_input) != nullptr;` 
