### PR TITLE
Fix Curve2D/Curve3D baking

### DIFF
--- a/scene/resources/curve.cpp
+++ b/scene/resources/curve.cpp
@@ -632,7 +632,7 @@ Vector2 Curve2D::interpolatef(real_t p_findex) const {
 	return interpolate((int)p_findex, Math::fmod(p_findex, (real_t)1.0));
 }
 
-void Curve2D::_bake_segment2d(HashMap<real_t, Vector2> &r_bake, real_t p_begin, real_t p_end, const Vector2 &p_a, const Vector2 &p_out, const Vector2 &p_b, const Vector2 &p_in, int p_depth, int p_max_depth, real_t p_tol) const {
+void Curve2D::_bake_segment2d(RBMap<real_t, Vector2> &r_bake, real_t p_begin, real_t p_end, const Vector2 &p_a, const Vector2 &p_out, const Vector2 &p_b, const Vector2 &p_in, int p_depth, int p_max_depth, real_t p_tol) const {
 	real_t mp = p_begin + (p_end - p_begin) * 0.5;
 	Vector2 beg = _bezier_interp(p_begin, p_a, p_a + p_out, p_b + p_in, p_b);
 	Vector2 mid = _bezier_interp(mp, p_a, p_a + p_out, p_b + p_in, p_b);
@@ -954,7 +954,9 @@ PackedVector2Array Curve2D::tessellate(int p_max_stages, real_t p_tolerance) con
 	if (points.size() == 0) {
 		return tess;
 	}
-	Vector<HashMap<real_t, Vector2>> midpoints;
+
+	// The current implementation requires a sorted map.
+	Vector<RBMap<real_t, Vector2>> midpoints;
 
 	midpoints.resize(points.size() - 1);
 
@@ -1137,7 +1139,7 @@ Vector3 Curve3D::interpolatef(real_t p_findex) const {
 	return interpolate((int)p_findex, Math::fmod(p_findex, (real_t)1.0));
 }
 
-void Curve3D::_bake_segment3d(HashMap<real_t, Vector3> &r_bake, real_t p_begin, real_t p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, real_t p_tol) const {
+void Curve3D::_bake_segment3d(RBMap<real_t, Vector3> &r_bake, real_t p_begin, real_t p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, real_t p_tol) const {
 	real_t mp = p_begin + (p_end - p_begin) * 0.5;
 	Vector3 beg = _bezier_interp(p_begin, p_a, p_a + p_out, p_b + p_in, p_b);
 	Vector3 mid = _bezier_interp(mp, p_a, p_a + p_out, p_b + p_in, p_b);
@@ -1668,7 +1670,7 @@ PackedVector3Array Curve3D::tessellate(int p_max_stages, real_t p_tolerance) con
 	if (points.size() == 0) {
 		return tess;
 	}
-	Vector<HashMap<real_t, Vector3>> midpoints;
+	Vector<RBMap<real_t, Vector3>> midpoints;
 
 	midpoints.resize(points.size() - 1);
 

--- a/scene/resources/curve.h
+++ b/scene/resources/curve.h
@@ -168,7 +168,7 @@ class Curve2D : public Resource {
 
 	real_t bake_interval = 5.0;
 
-	void _bake_segment2d(HashMap<real_t, Vector2> &r_bake, real_t p_begin, real_t p_end, const Vector2 &p_a, const Vector2 &p_out, const Vector2 &p_b, const Vector2 &p_in, int p_depth, int p_max_depth, real_t p_tol) const;
+	void _bake_segment2d(RBMap<real_t, Vector2> &r_bake, real_t p_begin, real_t p_end, const Vector2 &p_a, const Vector2 &p_out, const Vector2 &p_b, const Vector2 &p_in, int p_depth, int p_max_depth, real_t p_tol) const;
 	Dictionary _get_data() const;
 	void _set_data(const Dictionary &p_data);
 
@@ -233,7 +233,7 @@ class Curve3D : public Resource {
 	real_t bake_interval = 0.2;
 	bool up_vector_enabled = true;
 
-	void _bake_segment3d(HashMap<real_t, Vector3> &r_bake, real_t p_begin, real_t p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, real_t p_tol) const;
+	void _bake_segment3d(RBMap<real_t, Vector3> &r_bake, real_t p_begin, real_t p_end, const Vector3 &p_a, const Vector3 &p_out, const Vector3 &p_b, const Vector3 &p_in, int p_depth, int p_max_depth, real_t p_tol) const;
 	Dictionary _get_data() const;
 	void _set_data(const Dictionary &p_data);
 


### PR DESCRIPTION
Fixes  #61086.
![image](https://user-images.githubusercontent.com/50084500/168622752-edcd16fc-207b-4b29-b606-aa81fea39846.png)
Looks like the midpoint map was expected to be sorted.
Regression from #60999.