### PR TITLE
Fix a bug in get_node_and_resource when the property is set to null

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -2528,9 +2528,10 @@ Node *Node::get_node_and_resource(const NodePath &p_path, Ref<Resource> &r_res, 
 		int j = 0;
 		// If not p_last_is_property, we shouldn't consider the last one as part of the resource
 		for (; j < p_path.get_subname_count() - (int)p_last_is_property; j++) {
-			Variant new_res_v = j == 0 ? node->get(p_path.get_subname(j)) : r_res->get(p_path.get_subname(j));
+			bool is_valid = false;
+			Variant new_res_v = j == 0 ? node->get(p_path.get_subname(j), &is_valid) : r_res->get(p_path.get_subname(j), &is_valid);
 
-			if (new_res_v.get_type() == Variant::NIL) { // Found nothing on that path
+			if (!is_valid) { // Found nothing on that path
 				return nullptr;
 			}
 


### PR DESCRIPTION
In this project a property is set to null and `get_node_and_resource()` is unable to get it:
[get_node_and_resource_bug.zip](https://github.com/godotengine/godot/files/8702217/get_node_and_resource_bug.zip)

this is because a value of null is used to check for a failed `get()`, which is not the right way to do it.