### PR TITLE
Fix custom irradiance bug in Vulkan mobile renderer

### DIFF
--- a/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_mobile.glsl
@@ -924,7 +924,7 @@ void main() {
 #endif // !USE_LIGHTMAP
 
 #if defined(CUSTOM_IRRADIANCE_USED)
-	ambient_light = mix(specular_light, custom_irradiance.rgb, custom_irradiance.a);
+	ambient_light = mix(ambient_light, custom_irradiance.rgb, custom_irradiance.a);
 #endif // CUSTOM_IRRADIANCE_USED
 #ifdef LIGHT_CLEARCOAT_USED
 


### PR DESCRIPTION
Custom irradiance should mix with ambient, not specular. This appears to be a copy/paste bug