### PR TITLE
Add basic lighting to GLES3 renderer.

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1723,13 +1723,13 @@
 		<member name="rendering/limits/global_shader_variables/buffer_size" type="int" setter="" getter="" default="65536">
 		</member>
 		<member name="rendering/limits/opengl/max_lights_per_object" type="int" setter="" getter="" default="8">
-			Max number of lights renderable per object. This is further limited by hardware support. Setting this low will slightly reduce memory usage, may decrease shader compile times, and may result in faster rendering on low-end, mobile, or web devices.
+			Max number of omnilights and spotlights renderable per object. At the default value of 8, this means that each surface can be affected by up to 8 omnilights and 8 spotlights. This is further limited by hardware support and [member rendering/limits/opengl/max_renderable_lights]. Setting this low will slightly reduce memory usage, may decrease shader compile times, and may result in faster rendering on low-end, mobile, or web devices.
 		</member>
 		<member name="rendering/limits/opengl/max_renderable_elements" type="int" setter="" getter="" default="65536">
 			Max amount of elements renderable in a frame. If more elements than this are visible per frame, they will not be drawn. Keep in mind elements refer to mesh surfaces and not meshes themselves. Setting this low will slightly reduce memory usage and may decrease shader compile times, particularly on web. For most uses, the default value is suitable, but consider lowering as much as possible on web export.
 		</member>
-		<member name="rendering/limits/opengl/max_renderable_lights" type="int" setter="" getter="" default="256">
-			Max number of lights renderable in a frame. If more lights than this number are used, they will be ignored. Setting this low will slightly reduce memory usage and may decrease shader compile times, particularly on web. For most uses, the default value is suitable, but consider lowering as much as possible on web export.
+		<member name="rendering/limits/opengl/max_renderable_lights" type="int" setter="" getter="" default="32">
+			Max number of positional lights renderable in a frame. If more lights than this number are used, they will be ignored. Setting this low will slightly reduce memory usage and may decrease shader compile times, particularly on web. For most uses, the default value is suitable, but consider lowering as much as possible on web export.
 		</member>
 		<member name="rendering/limits/spatial_indexer/threaded_cull_minimum_instances" type="int" setter="" getter="" default="1000">
 		</member>

--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -39,6 +39,19 @@
 #include "servers/rendering/shader_language.h"
 
 void RasterizerStorageGLES3::base_update_dependency(RID p_base, DependencyTracker *p_instance) {
+	if (GLES3::MeshStorage::get_singleton()->owns_mesh(p_base)) {
+		GLES3::Mesh *mesh = GLES3::MeshStorage::get_singleton()->get_mesh(p_base);
+		p_instance->update_dependency(&mesh->dependency);
+	} else if (GLES3::MeshStorage::get_singleton()->owns_multimesh(p_base)) {
+		GLES3::MultiMesh *multimesh = GLES3::MeshStorage::get_singleton()->get_multimesh(p_base);
+		p_instance->update_dependency(&multimesh->dependency);
+		if (multimesh->mesh.is_valid()) {
+			base_update_dependency(multimesh->mesh, p_instance);
+		}
+	} else if (GLES3::LightStorage::get_singleton()->owns_light(p_base)) {
+		GLES3::Light *l = GLES3::LightStorage::get_singleton()->get_light(p_base);
+		p_instance->update_dependency(&l->dependency);
+	}
 }
 
 /* VOXEL GI API */

--- a/drivers/gles3/shader_gles3.h
+++ b/drivers/gles3/shader_gles3.h
@@ -219,7 +219,10 @@ protected:
 		Version *version = version_owner.get_or_null(p_version);
 		ERR_FAIL_COND_V(!version, -1);
 		ERR_FAIL_INDEX_V(p_variant, int(version->variants.size()), -1);
-		return version->variants[p_variant].lookup_ptr(p_specialization)->uniform_location[p_which];
+		Version::Specialization *spec = version->variants[p_variant].lookup_ptr(p_specialization);
+		ERR_FAIL_COND_V(!spec, -1);
+		ERR_FAIL_INDEX_V(p_which, int(spec->uniform_location.size()), -1);
+		return spec->uniform_location[p_which];
 	}
 
 	virtual void _init() = 0;

--- a/drivers/gles3/shaders/SCsub
+++ b/drivers/gles3/shaders/SCsub
@@ -2,11 +2,18 @@
 
 Import("env")
 
-env.Depends("#drivers/gles3/shaders/copy.glsl.gen.h", "#core/math/basis.h")
-env.Depends("#drivers/gles3/shaders/copy.glsl.gen.h", "#core/math/transform_2d.h")
-
 if "GLES3_GLSL" in env["BUILDERS"]:
+    # find all include files
+    gl_include_files = [str(f) for f in Glob("*_inc.glsl")]
+
+    # find all shader code(all glsl files excluding our include files)
+    glsl_files = [str(f) for f in Glob("*.glsl") if str(f) not in gl_include_files]
+
+    # make sure we recompile shaders if include files change
+    env.Depends([f + ".gen.h" for f in glsl_files], gl_include_files)
+
     env.GLES3_GLSL("canvas.glsl")
     env.GLES3_GLSL("copy.glsl")
     env.GLES3_GLSL("scene.glsl")
     env.GLES3_GLSL("sky.glsl")
+    env.GLES3_GLSL("cubemap_filter.glsl")

--- a/drivers/gles3/shaders/cubemap_filter.glsl
+++ b/drivers/gles3/shaders/cubemap_filter.glsl
@@ -1,136 +1,102 @@
 /* clang-format off */
-[vertex]
+#[modes]
 
-#ifdef USE_GLES_OVER_GL
-#define lowp
-#define mediump
-#define highp
-#else
-precision highp float;
-precision highp int;
-#endif
+mode_default =
+mode_copy = #define MODE_DIRECT_WRITE
 
-layout(location = 0) in highp vec2 vertex;
+#[specializations]
+
+#[vertex]
+
+layout(location = 0) in highp vec2 vertex_attrib;
 /* clang-format on */
-layout(location = 4) in highp vec2 uv;
 
 out highp vec2 uv_interp;
 
 void main() {
-	uv_interp = uv;
-	gl_Position = vec4(vertex, 0, 1);
+	uv_interp = vertex_attrib;
+	gl_Position = vec4(uv_interp, 0.0, 1.0);
 }
 
 /* clang-format off */
-[fragment]
+#[fragment]
 
-#ifdef USE_GLES_OVER_GL
-#define lowp
-#define mediump
-#define highp
-#else
-#if defined(USE_HIGHP_PRECISION)
-precision highp float;
-precision highp int;
-#else
-precision mediump float;
-precision mediump int;
-#endif
 
-#endif
+#define M_PI 3.14159265359
 
-#ifdef USE_SOURCE_PANORAMA
-uniform sampler2D source_panorama; //texunit:0
-#else
 uniform samplerCube source_cube; //texunit:0
-#endif
+
 /* clang-format on */
 
 uniform int face_id;
 uniform float roughness;
+uniform float face_size;
+uniform int sample_count;
+
+//Todo, profile on low end hardware to see if fixed loop is faster
+#ifdef USE_FIXED_SAMPLES
+#define FIXED_SAMPLE_COUNT 32
+#endif
+
 in highp vec2 uv_interp;
 
 uniform sampler2D radical_inverse_vdc_cache; // texunit:1
 
+layout(location = 0) out vec4 frag_color;
+
 #define M_PI 3.14159265359
 
-#ifdef LOW_QUALITY
-
-#define SAMPLE_COUNT 64
-
-#else
-
-#define SAMPLE_COUNT 512
-
-#endif
-
-#ifdef USE_SOURCE_PANORAMA
-
-vec4 texturePanorama(sampler2D pano, vec3 normal) {
-	vec2 st = vec2(
-			atan(normal.x, normal.z),
-			acos(normal.y));
-
-	if (st.x < 0.0)
-		st.x += M_PI * 2.0;
-
-	st /= vec2(M_PI * 2.0, M_PI);
-
-	return textureLod(pano, st, 0.0);
+// Don't include tonemap_inc.glsl because all we want is these functions, we don't want the uniforms
+vec3 linear_to_srgb(vec3 color) {
+	return max(vec3(1.055) * pow(color, vec3(0.416666667)) - vec3(0.055), vec3(0.0));
 }
 
-#endif
+vec3 srgb_to_linear(vec3 color) {
+	return color * (color * (color * 0.305306011 + 0.682171111) + 0.012522878);
+}
 
 vec3 texelCoordToVec(vec2 uv, int faceID) {
 	mat3 faceUvVectors[6];
 
 	// -x
-	faceUvVectors[0][0] = vec3(0.0, 0.0, 1.0); // u -> +z
-	faceUvVectors[0][1] = vec3(0.0, -1.0, 0.0); // v -> -y
-	faceUvVectors[0][2] = vec3(-1.0, 0.0, 0.0); // -x face
+	faceUvVectors[1][0] = vec3(0.0, 0.0, 1.0); // u -> +z
+	faceUvVectors[1][1] = vec3(0.0, -1.0, 0.0); // v -> -y
+	faceUvVectors[1][2] = vec3(-1.0, 0.0, 0.0); // -x face
 
 	// +x
-	faceUvVectors[1][0] = vec3(0.0, 0.0, -1.0); // u -> -z
-	faceUvVectors[1][1] = vec3(0.0, -1.0, 0.0); // v -> -y
-	faceUvVectors[1][2] = vec3(1.0, 0.0, 0.0); // +x face
+	faceUvVectors[0][0] = vec3(0.0, 0.0, -1.0); // u -> -z
+	faceUvVectors[0][1] = vec3(0.0, -1.0, 0.0); // v -> -y
+	faceUvVectors[0][2] = vec3(1.0, 0.0, 0.0); // +x face
 
 	// -y
-	faceUvVectors[2][0] = vec3(1.0, 0.0, 0.0); // u -> +x
-	faceUvVectors[2][1] = vec3(0.0, 0.0, -1.0); // v -> -z
-	faceUvVectors[2][2] = vec3(0.0, -1.0, 0.0); // -y face
+	faceUvVectors[3][0] = vec3(1.0, 0.0, 0.0); // u -> +x
+	faceUvVectors[3][1] = vec3(0.0, 0.0, -1.0); // v -> -z
+	faceUvVectors[3][2] = vec3(0.0, -1.0, 0.0); // -y face
 
 	// +y
-	faceUvVectors[3][0] = vec3(1.0, 0.0, 0.0); // u -> +x
-	faceUvVectors[3][1] = vec3(0.0, 0.0, 1.0); // v -> +z
-	faceUvVectors[3][2] = vec3(0.0, 1.0, 0.0); // +y face
+	faceUvVectors[2][0] = vec3(1.0, 0.0, 0.0); // u -> +x
+	faceUvVectors[2][1] = vec3(0.0, 0.0, 1.0); // v -> +z
+	faceUvVectors[2][2] = vec3(0.0, 1.0, 0.0); // +y face
 
 	// -z
-	faceUvVectors[4][0] = vec3(-1.0, 0.0, 0.0); // u -> -x
-	faceUvVectors[4][1] = vec3(0.0, -1.0, 0.0); // v -> -y
-	faceUvVectors[4][2] = vec3(0.0, 0.0, -1.0); // -z face
+	faceUvVectors[5][0] = vec3(-1.0, 0.0, 0.0); // u -> -x
+	faceUvVectors[5][1] = vec3(0.0, -1.0, 0.0); // v -> -y
+	faceUvVectors[5][2] = vec3(0.0, 0.0, -1.0); // -z face
 
 	// +z
-	faceUvVectors[5][0] = vec3(1.0, 0.0, 0.0); // u -> +x
-	faceUvVectors[5][1] = vec3(0.0, -1.0, 0.0); // v -> -y
-	faceUvVectors[5][2] = vec3(0.0, 0.0, 1.0); // +z face
+	faceUvVectors[4][0] = vec3(1.0, 0.0, 0.0); // u -> +x
+	faceUvVectors[4][1] = vec3(0.0, -1.0, 0.0); // v -> -y
+	faceUvVectors[4][2] = vec3(0.0, 0.0, 1.0); // +z face
 
 	// out = u * s_faceUv[0] + v * s_faceUv[1] + s_faceUv[2].
-	vec3 result;
-	for (int i = 0; i < 6; i++) {
-		if (i == faceID) {
-			result = (faceUvVectors[i][0] * uv.x) + (faceUvVectors[i][1] * uv.y) + faceUvVectors[i][2];
-			break;
-		}
-	}
+	vec3 result = (faceUvVectors[faceID][0] * uv.x) + (faceUvVectors[faceID][1] * uv.y) + faceUvVectors[faceID][2];
 	return normalize(result);
 }
 
-vec3 ImportanceSampleGGX(vec2 Xi, float Roughness, vec3 N) {
-	float a = Roughness * Roughness; // DISNEY'S ROUGHNESS [see Burley'12 siggraph]
-
+vec3 ImportanceSampleGGX(vec2 xi, float roughness4) {
 	// Compute distribution direction
-	float Phi = 2.0 * M_PI * Xi.x;
-	float CosTheta = sqrt((1.0 - Xi.y) / (1.0 + (a * a - 1.0) * Xi.y));
+	float Phi = 2.0 * M_PI * xi.x;
+	float CosTheta = sqrt((1.0 - xi.y) / (1.0 + (roughness4 - 1.0) * xi.y));
 	float SinTheta = sqrt(1.0 - CosTheta * CosTheta);
 
 	// Convert to spherical direction
@@ -139,12 +105,26 @@ vec3 ImportanceSampleGGX(vec2 Xi, float Roughness, vec3 N) {
 	H.y = SinTheta * sin(Phi);
 	H.z = CosTheta;
 
-	vec3 UpVector = abs(N.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
-	vec3 TangentX = normalize(cross(UpVector, N));
-	vec3 TangentY = cross(N, TangentX);
+	return H;
+}
 
-	// Tangent to world space
-	return TangentX * H.x + TangentY * H.y + N * H.z;
+float DistributionGGX(float NdotH, float roughness4) {
+	float NdotH2 = NdotH * NdotH;
+	float denom = (NdotH2 * (roughness4 - 1.0) + 1.0);
+	denom = M_PI * denom * denom;
+
+	return roughness4 / denom;
+}
+
+// https://graphicrants.blogspot.com.au/2013/08/specular-brdf-reference.html
+float GGX(float NdotV, float a) {
+	float k = a / 2.0;
+	return NdotV / (NdotV * (1.0 - k) + k);
+}
+
+// https://graphicrants.blogspot.com.au/2013/08/specular-brdf-reference.html
+float G_Smith(float a, float nDotV, float nDotL) {
+	return GGX(nDotL, a * a) * GGX(nDotV, a * a);
 }
 
 float radical_inverse_VdC(int i) {
@@ -155,60 +135,54 @@ vec2 Hammersley(int i, int N) {
 	return vec2(float(i) / float(N), radical_inverse_VdC(i));
 }
 
-uniform bool z_flip;
-
-layout(location = 0) out vec4 frag_color;
-
 void main() {
 	vec3 color = vec3(0.0);
-
-	vec2 uv = (uv_interp * 2.0) - 1.0;
+	vec2 uv = uv_interp;
 	vec3 N = texelCoordToVec(uv, face_id);
 
-#ifdef USE_DIRECT_WRITE
-
-#ifdef USE_SOURCE_PANORAMA
-
-	frag_color = vec4(texturePanorama(source_panorama, N).rgb, 1.0);
-#else
-
-	frag_color = vec4(textureCube(source_cube, N).rgb, 1.0);
-#endif //USE_SOURCE_PANORAMA
-
+#ifdef MODE_DIRECT_WRITE
+	frag_color = vec4(textureCubeLod(source_cube, N, 0.0).rgb, 1.0);
 #else
 
 	vec4 sum = vec4(0.0);
+	float solid_angle_texel = 4.0 * M_PI / (6.0 * face_size * face_size);
+	float roughness2 = roughness * roughness;
+	float roughness4 = roughness2 * roughness2;
+	vec3 UpVector = abs(N.z) < 0.999 ? vec3(0.0, 0.0, 1.0) : vec3(1.0, 0.0, 0.0);
+	mat3 T;
+	T[0] = normalize(cross(UpVector, N));
+	T[1] = cross(N, T[0]);
+	T[2] = N;
 
-	for (int sample_num = 0; sample_num < SAMPLE_COUNT; sample_num++) {
-		vec2 xi = Hammersley(sample_num, SAMPLE_COUNT);
+	for (int sample_num = 0; sample_num < sample_count; sample_num++) {
+		vec2 xi = Hammersley(sample_num, sample_count);
 
-		vec3 H = ImportanceSampleGGX(xi, roughness, N);
-		vec3 V = N;
-		vec3 L = (2.0 * dot(V, H) * H - V);
+		vec3 H = T * ImportanceSampleGGX(xi, roughness4);
+		float NdotH = dot(N, H);
+		vec3 L = (2.0 * NdotH * H - N);
 
 		float NdotL = clamp(dot(N, L), 0.0, 1.0);
 
 		if (NdotL > 0.0) {
+			float D = DistributionGGX(NdotH, roughness4);
+			float pdf = D * NdotH / (4.0 * NdotH) + 0.0001;
 
-#ifdef USE_SOURCE_PANORAMA
-			vec3 val = texturePanorama(source_panorama, L).rgb;
-#else
-			vec3 val = textureCubeLod(source_cube, L, 0.0).rgb;
-#endif
-			//mix using Linear, to approximate high end back-end
-			val = mix(pow((val + vec3(0.055)) * (1.0 / (1.0 + 0.055)), vec3(2.4)), val * (1.0 / 12.92), vec3(lessThan(val, vec3(0.04045))));
+			float solid_angle_sample = 1.0 / (float(sample_count) * pdf + 0.0001);
+
+			float mipLevel = roughness == 0.0 ? 0.0 : 0.5 * log2(solid_angle_sample / solid_angle_texel);
+
+			vec3 val = textureCubeLod(source_cube, L, mipLevel).rgb;
+			// Mix using linear
+			val = srgb_to_linear(val);
 
 			sum.rgb += val * NdotL;
-
 			sum.a += NdotL;
 		}
 	}
 
 	sum /= sum.a;
 
-	vec3 a = vec3(0.055);
-	sum.rgb = mix((vec3(1.0) + a) * pow(sum.rgb, vec3(1.0 / 2.4)) - a, 12.92 * sum.rgb, vec3(lessThan(sum.rgb, vec3(0.0031308))));
-
+	sum.rgb = linear_to_srgb(sum.rgb);
 	frag_color = vec4(sum.rgb, 1.0);
 #endif
 }

--- a/drivers/gles3/shaders/stdlib_inc.glsl
+++ b/drivers/gles3/shaders/stdlib_inc.glsl
@@ -42,11 +42,11 @@ vec2 unpackSnorm2x16(uint p) {
 
 uint packUnorm4x8(vec4 v) {
 	uvec4 uv = uvec4(round(clamp(v, vec4(0.0), vec4(1.0)) * 255.0));
-	return uv.x | uv.y << uint(8) | uv.z << uint(16) | uv.w << uint(24);
+	return uv.x | (uv.y << uint(8)) | (uv.z << uint(16)) | (uv.w << uint(24));
 }
 
 vec4 unpackUnorm4x8(uint p) {
-	return vec4(float(p & uint(0xffff)), float((p >> uint(8)) & uint(0xffff)), float((p >> uint(16)) & uint(0xffff)), float(p >> uint(24))) * 0.00392156862; // 1.0 / 255.0
+	return vec4(float(p & uint(0xff)), float((p >> uint(8)) & uint(0xff)), float((p >> uint(16)) & uint(0xff)), float(p >> uint(24))) * 0.00392156862; // 1.0 / 255.0
 }
 
 uint packSnorm4x8(vec4 v) {
@@ -55,6 +55,6 @@ uint packSnorm4x8(vec4 v) {
 }
 
 vec4 unpackSnorm4x8(uint p) {
-	vec4 v = vec4(float(p & uint(0xffff)), float((p >> uint(8)) & uint(0xffff)), float((p >> uint(16)) & uint(0xffff)), float(p >> uint(24)));
+	vec4 v = vec4(float(p & uint(0xff)), float((p >> uint(8)) & uint(0xff)), float((p >> uint(16)) & uint(0xff)), float(p >> uint(24)));
 	return clamp((v - vec4(127.0)) * vec4(0.00787401574), vec4(-1.0), vec4(1.0));
 }

--- a/drivers/gles3/shaders/tonemap_inc.glsl
+++ b/drivers/gles3/shaders/tonemap_inc.glsl
@@ -92,11 +92,19 @@ vec3 tonemap_reinhard(vec3 color, float p_white) {
 	return (p_white * color + color) / (color * p_white + p_white);
 }
 
+// This expects 0-1 range input.
 vec3 linear_to_srgb(vec3 color) {
-	//if going to srgb, clamp from 0 to 1.
-	color = clamp(color, vec3(0.0), vec3(1.0));
-	const vec3 a = vec3(0.055f);
-	return mix((vec3(1.0f) + a) * pow(color.rgb, vec3(1.0f / 2.4f)) - a, 12.92f * color.rgb, lessThan(color.rgb, vec3(0.0031308f)));
+	//color = clamp(color, vec3(0.0), vec3(1.0));
+	//const vec3 a = vec3(0.055f);
+	//return mix((vec3(1.0f) + a) * pow(color.rgb, vec3(1.0f / 2.4f)) - a, 12.92f * color.rgb, lessThan(color.rgb, vec3(0.0031308f)));
+	// Approximation from http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
+	return max(vec3(1.055) * pow(color, vec3(0.416666667)) - vec3(0.055), vec3(0.0));
+}
+
+// This expects 0-1 range input, outside that range it behaves poorly.
+vec3 srgb_to_linear(vec3 color) {
+	// Approximation from http://chilliant.blogspot.com/2012/08/srgb-approximations-for-hlsl.html
+	return color * (color * (color * 0.305306011 + 0.682171111) + 0.012522878);
 }
 
 #define TONEMAPPER_LINEAR 0

--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -1024,6 +1024,7 @@ MaterialData::~MaterialData() {
 
 	if (uniform_buffer) {
 		glDeleteBuffers(1, &uniform_buffer);
+		uniform_buffer = 0;
 	}
 }
 
@@ -1677,9 +1678,6 @@ ShaderCompiler::DefaultIdentifierActions actions;
 	//shaders.copy.initialize();
 	//shaders.copy_version = shaders.copy.version_create(); //TODO
 	//shaders.copy.version_bind_shader(shaders.copy_version, CopyShaderGLES3::MODE_COPY_SECTION);
-	//shaders.cubemap_filter.init();
-	//bool ggx_hq = GLOBAL_GET("rendering/quality/reflections/high_quality_ggx");
-	//shaders.cubemap_filter.set_conditional(CubemapFilterShaderGLES3::LOW_QUALITY, !ggx_hq);
 }
 
 MaterialStorage::~MaterialStorage() {
@@ -3133,6 +3131,7 @@ GLES3::ShaderData *GLES3::_create_sky_shader_func() {
 // Sky material
 
 void SkyMaterialData::update_parameters(const HashMap<StringName, Variant> &p_parameters, bool p_uniform_dirty, bool p_textures_dirty) {
+	uniform_set_updated = true;
 	return update_parameters_internal(p_parameters, p_uniform_dirty, p_textures_dirty, shader_data->uniforms, shader_data->ubo_offsets.ptr(), shader_data->texture_uniforms, shader_data->default_texture_params, shader_data->ubo_size);
 }
 

--- a/drivers/gles3/storage/material_storage.h
+++ b/drivers/gles3/storage/material_storage.h
@@ -45,6 +45,7 @@
 #include "drivers/gles3/shaders/copy.glsl.gen.h"
 
 #include "../shaders/canvas.glsl.gen.h"
+#include "../shaders/cubemap_filter.glsl.gen.h"
 #include "../shaders/scene.glsl.gen.h"
 #include "../shaders/sky.glsl.gen.h"
 
@@ -56,6 +57,7 @@ struct Shaders {
 	CanvasShaderGLES3 canvas_shader;
 	SkyShaderGLES3 sky_shader;
 	SceneShaderGLES3 scene_shader;
+	CubemapFilterShaderGLES3 cubemap_filter_shader;
 
 	ShaderCompiler compiler_canvas;
 	ShaderCompiler compiler_scene;
@@ -241,6 +243,7 @@ ShaderData *_create_sky_shader_func();
 
 struct SkyMaterialData : public MaterialData {
 	SkyShaderData *shader_data = nullptr;
+	bool uniform_set_updated = false;
 
 	virtual void set_render_priority(int p_priority) {}
 	virtual void set_next_pass(RID p_pass) {}
@@ -457,8 +460,6 @@ private:
 	mutable RID_Owner<Material, true> material_owner;
 
 	SelfList<Material>::List material_update_list;
-
-	//static void _material_uniform_set_erased(void *p_material);
 
 public:
 	static MaterialStorage *get_singleton();

--- a/drivers/gles3/storage/mesh_storage.cpp
+++ b/drivers/gles3/storage/mesh_storage.cpp
@@ -570,24 +570,29 @@ void MeshStorage::mesh_clear(RID p_mesh) {
 
 		if (s.vertex_buffer != 0) {
 			glDeleteBuffers(1, &s.vertex_buffer);
+			s.vertex_buffer = 0;
 		}
 
 		if (s.version_count != 0) {
 			for (uint32_t j = 0; j < s.version_count; j++) {
 				glDeleteVertexArrays(1, &s.versions[j].vertex_array);
+				s.versions[j].vertex_array = 0;
 			}
 		}
 
 		if (s.attribute_buffer != 0) {
 			glDeleteBuffers(1, &s.attribute_buffer);
+			s.attribute_buffer = 0;
 		}
 
 		if (s.skin_buffer != 0) {
 			glDeleteBuffers(1, &s.skin_buffer);
+			s.skin_buffer = 0;
 		}
 
 		if (s.index_buffer != 0) {
 			glDeleteBuffers(1, &s.index_buffer);
+			s.index_buffer = 0;
 		}
 		memdelete(mesh->surfaces[i]);
 	}
@@ -804,17 +809,20 @@ void MeshStorage::_mesh_instance_clear(MeshInstance *mi) {
 		if (mi->surfaces[i].version_count != 0) {
 			for (uint32_t j = 0; j < mi->surfaces[i].version_count; j++) {
 				glDeleteVertexArrays(1, &mi->surfaces[i].versions[j].vertex_array);
+				mi->surfaces[i].versions[j].vertex_array = 0;
 			}
 			memfree(mi->surfaces[i].versions);
 		}
 		if (mi->surfaces[i].vertex_buffer != 0) {
 			glDeleteBuffers(1, &mi->surfaces[i].vertex_buffer);
+			mi->surfaces[i].vertex_buffer = 0;
 		}
 	}
 	mi->surfaces.clear();
 
 	if (mi->blend_weights_buffer != 0) {
 		glDeleteBuffers(1, &mi->blend_weights_buffer);
+		mi->blend_weights_buffer = 0;
 	}
 	mi->blend_weights.clear();
 	mi->weights_dirty = false;

--- a/drivers/gles3/storage/texture_storage.cpp
+++ b/drivers/gles3/storage/texture_storage.cpp
@@ -554,7 +554,7 @@ Ref<Image> TextureStorage::_get_gl_image_and_format(const Ref<Image> &p_image, I
 		} break;
 		*/
 		default: {
-			ERR_FAIL_V(Ref<Image>());
+			ERR_FAIL_V_MSG(Ref<Image>(), "Image Format: " + itos(p_format) + " is not supported by the OpenGL3 Renderer");
 		}
 	}
 
@@ -968,7 +968,7 @@ void TextureStorage::texture_set_data(RID p_texture, const Ref<Image> &p_image, 
 
 	Image::Format real_format;
 	Ref<Image> img = _get_gl_image_and_format(p_image, p_image->get_format(), 0, real_format, format, internal_format, type, compressed, texture->resize_to_po2);
-
+	ERR_FAIL_COND(img.is_null());
 	if (texture->resize_to_po2) {
 		if (p_image->is_compressed()) {
 			ERR_PRINT("Texture '" + texture->path + "' is required to be a power of 2 because it uses either mipmaps or repeat, so it was decompressed. This will hurt performance and memory usage.");
@@ -1325,6 +1325,7 @@ void TextureStorage::_update_render_target(RenderTarget *rt) {
 
 	rt->color_internal_format = rt->flags[RENDER_TARGET_TRANSPARENT] ? GL_RGBA8 : GL_RGB10_A2;
 	rt->color_format = GL_RGBA;
+	rt->color_type = rt->flags[RENDER_TARGET_TRANSPARENT] ? GL_BYTE : GL_UNSIGNED_INT_2_10_10_10_REV;
 	rt->image_format = Image::FORMAT_RGBA8;
 
 	glDisable(GL_SCISSOR_TEST);

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -249,7 +249,10 @@ struct Texture {
 				[[fallthrough]];
 			case RS::CANVAS_ITEM_TEXTURE_FILTER_NEAREST_WITH_MIPMAPS: {
 				pmag = GL_NEAREST;
-				if (config->use_nearest_mip_filter) {
+				if (mipmaps <= 1) {
+					pmin = GL_NEAREST;
+					max_lod = 0;
+				} else if (config->use_nearest_mip_filter) {
 					pmin = GL_NEAREST_MIPMAP_NEAREST;
 				} else {
 					pmin = GL_NEAREST_MIPMAP_LINEAR;
@@ -261,9 +264,11 @@ struct Texture {
 				[[fallthrough]];
 			case RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR_WITH_MIPMAPS: {
 				pmag = GL_LINEAR;
-				if (config->use_nearest_mip_filter) {
+				if (mipmaps <= 1) {
+					pmin = GL_LINEAR;
+					max_lod = 0;
+				} else if (config->use_nearest_mip_filter) {
 					pmin = GL_LINEAR_MIPMAP_NEAREST;
-
 				} else {
 					pmin = GL_LINEAR_MIPMAP_LINEAR;
 				}

--- a/scene/resources/material.cpp
+++ b/scene/resources/material.cpp
@@ -1788,8 +1788,6 @@ void BaseMaterial3D::_validate_property(PropertyInfo &property) const {
 
 	_validate_high_end("refraction", property);
 	_validate_high_end("subsurf_scatter", property);
-	_validate_high_end("anisotropy", property);
-	_validate_high_end("clearcoat", property);
 	_validate_high_end("heightmap", property);
 
 	if (property.name.begins_with("particles_anim_") && billboard_mode != BILLBOARD_PARTICLES) {

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -3006,8 +3006,8 @@ RenderingServer::RenderingServer() {
 	// OpenGL limits
 	GLOBAL_DEF_RST("rendering/limits/opengl/max_renderable_elements", 65536);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/opengl/max_renderable_elements", PropertyInfo(Variant::INT, "rendering/limits/opengl/max_renderable_elements", PROPERTY_HINT_RANGE, "1024,65536,1"));
-	GLOBAL_DEF_RST("rendering/limits/opengl/max_renderable_lights", 256);
-	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/opengl/max_renderable_lights", PropertyInfo(Variant::INT, "rendering/limits/opengl/max_renderable_lights", PROPERTY_HINT_RANGE, "16,4096,1"));
+	GLOBAL_DEF_RST("rendering/limits/opengl/max_renderable_lights", 32);
+	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/opengl/max_renderable_lights", PropertyInfo(Variant::INT, "rendering/limits/opengl/max_renderable_lights", PROPERTY_HINT_RANGE, "2,256,1"));
 	GLOBAL_DEF_RST("rendering/limits/opengl/max_lights_per_object", 8);
 	ProjectSettings::get_singleton()->set_custom_property_info("rendering/limits/opengl/max_lights_per_object", PropertyInfo(Variant::INT, "rendering/limits/opengl/max_lights_per_object", PROPERTY_HINT_RANGE, "2,1024,1"));
 


### PR DESCRIPTION
This includes all three light types and IBL, but does not include shadows or any form of GI.

Following [reduz' proposal](https://github.com/godotengine/godot-proposals/issues/3959), We have two types of lighting, forward and additive. This PR implements forward lighting only. Forward lighting is used for lights without shadows. It takes place in linear space and can be done in a single pass. To do the calculations in linear space, inputs are converted from sRGB into linear space before the lighting pass and then tonemapped and converted back to sRGB to store in the framebuffer. This will introduce an inconsistency between lights with shadows and those without. But it is unavoidable. 

For performance sake, the default maximum number of lights per-scene (32) and per-surface (8) is low, but these limits are configurable. 

IBL is implemented much as it is in the Mobile renderer. Cubemap arrays are not an option, so the radiance map is generated directly into a mipmapped cubemap. In the future, I would like to explore a "realtime" mode that renders the full cubemap in a single pass, but using only a single GGX sample per pixel per frame and accumulates over multiple frames. in 32 frames it would have the quality of our current high-quality mode. 

I have left a few TODOs for the future, mostly related to performance profiling that needs to be done once we are closer to feature completion. 

_Multiple lights supported_
![Screenshot from 2022-05-16 12-31-24](https://user-images.githubusercontent.com/16521339/168669768-ada03559-b24b-4088-97f9-6eda75cd118b.png)

_Basic PBR lighting looks as expected with materials_
![Screenshot from 2022-05-16 12-32-00](https://user-images.githubusercontent.com/16521339/168669775-56fe9fe4-ebe2-4a8a-ba97-3eafaef81128.png)



