### PR TITLE
Fix errors and improve UX relating to new animation libraries

### DIFF
--- a/editor/animation_track_editor.cpp
+++ b/editor/animation_track_editor.cpp
@@ -2999,8 +2999,6 @@ void AnimationTrackEdit::gui_input(const Ref<InputEvent> &p_event) {
 					}
 				}
 
-				print_line(hovering_key_idx);
-
 				if (hovering_key_idx != previous_hovering_key_idx) {
 					// Required to draw keyframe hover feedback on the correct keyframe.
 					update();

--- a/editor/plugins/animation_library_editor.cpp
+++ b/editor/plugins/animation_library_editor.cpp
@@ -75,12 +75,16 @@ void AnimationLibraryEditor::_add_library_validate(const String &p_name) {
 		add_library_validate->set_text(error);
 		add_library_dialog->get_ok_button()->set_disabled(true);
 	} else {
-		add_library_validate->add_theme_color_override("font_color", get_theme_color(SNAME("success_color"), SNAME("Editor")));
-		if (p_name == "") {
-			add_library_validate->set_text(TTR("Global library will be created."));
+		if (adding_animation) {
+			add_library_validate->set_text(TTR("Animation name is valid."));
 		} else {
-			add_library_validate->set_text(TTR("Library name is valid."));
+			if (p_name == "") {
+				add_library_validate->set_text(TTR("Global library will be created."));
+			} else {
+				add_library_validate->set_text(TTR("Library name is valid."));
+			}
 		}
+		add_library_validate->add_theme_color_override("font_color", get_theme_color(SNAME("success_color"), SNAME("Editor")));
 		add_library_dialog->get_ok_button()->set_disabled(false);
 	}
 }
@@ -469,7 +473,7 @@ void AnimationLibraryEditor::_button_pressed(TreeItem *p_item, int p_column, int
 				int attempt = 1;
 				while (al->has_animation(name)) {
 					attempt++;
-					name = base_name + " " + itos(attempt);
+					name = base_name + " (" + itos(attempt) + ")";
 				}
 
 				UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();

--- a/editor/plugins/animation_player_editor_plugin.h
+++ b/editor/plugins/animation_player_editor_plugin.h
@@ -188,6 +188,7 @@ class AnimationPlayerEditor : public VBoxContainer {
 	void _update_animation();
 	void _update_player();
 	void _update_animation_list_icons();
+	void _update_name_dialog_library_dropdown();
 	void _blend_edited();
 
 	void _animation_player_changed(Object *p_pl);

--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1487,7 +1487,7 @@ bool AnimationPlayer::has_animation(const StringName &p_name) const {
 }
 
 Ref<Animation> AnimationPlayer::get_animation(const StringName &p_name) const {
-	ERR_FAIL_COND_V(!animation_set.has(p_name), Ref<Animation>());
+	ERR_FAIL_COND_V_MSG(!animation_set.has(p_name), Ref<Animation>(), vformat("Animation not found: %s.", p_name));
 
 	const AnimationData &data = animation_set[p_name];
 
@@ -1509,8 +1509,8 @@ void AnimationPlayer::get_animation_list(List<StringName> *p_animations) const {
 }
 
 void AnimationPlayer::set_blend_time(const StringName &p_animation1, const StringName &p_animation2, float p_time) {
-	ERR_FAIL_COND(!animation_set.has(p_animation1));
-	ERR_FAIL_COND(!animation_set.has(p_animation2));
+	ERR_FAIL_COND_MSG(!animation_set.has(p_animation1), vformat("Animation not found: %s.", p_animation1));
+	ERR_FAIL_COND_MSG(!animation_set.has(p_animation2), vformat("Animation not found: %s.", p_animation2));
 	ERR_FAIL_COND_MSG(p_time < 0, "Blend time cannot be smaller than 0.");
 
 	BlendKey bk;
@@ -1567,7 +1567,7 @@ void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float
 		name = playback.assigned;
 	}
 
-	ERR_FAIL_COND_MSG(!animation_set.has(name), "Animation not found: " + name + ".");
+	ERR_FAIL_COND_MSG(!animation_set.has(name), vformat("Animation not found: %s.", name));
 
 	Playback &c = playback;
 
@@ -1670,7 +1670,7 @@ void AnimationPlayer::set_assigned_animation(const String &p_anim) {
 	if (is_playing()) {
 		play(p_anim);
 	} else {
-		ERR_FAIL_COND(!animation_set.has(p_anim));
+		ERR_FAIL_COND_MSG(!animation_set.has(p_anim), vformat("Animation not found: %s.", p_anim));
 		playback.current.pos = 0;
 		playback.current.from = &animation_set[p_anim];
 		playback.assigned = p_anim;
@@ -1713,7 +1713,7 @@ float AnimationPlayer::get_playing_speed() const {
 void AnimationPlayer::seek(double p_time, bool p_update) {
 	if (!playback.current.from) {
 		if (playback.assigned) {
-			ERR_FAIL_COND(!animation_set.has(playback.assigned));
+			ERR_FAIL_COND_MSG(!animation_set.has(playback.assigned), vformat("Animation not found: %s.", playback.assigned));
 			playback.current.from = &animation_set[playback.assigned];
 		}
 		ERR_FAIL_COND(!playback.current.from);
@@ -1729,7 +1729,7 @@ void AnimationPlayer::seek(double p_time, bool p_update) {
 void AnimationPlayer::seek_delta(double p_time, float p_delta) {
 	if (!playback.current.from) {
 		if (playback.assigned) {
-			ERR_FAIL_COND(!animation_set.has(playback.assigned));
+			ERR_FAIL_COND_MSG(!animation_set.has(playback.assigned), vformat("Animation not found: %s.", playback.assigned));
 			playback.current.from = &animation_set[playback.assigned];
 		}
 		ERR_FAIL_COND(!playback.current.from);
@@ -1899,7 +1899,7 @@ void AnimationPlayer::_set_process(bool p_process, bool p_force) {
 }
 
 void AnimationPlayer::animation_set_next(const StringName &p_animation, const StringName &p_next) {
-	ERR_FAIL_COND(!animation_set.has(p_animation));
+	ERR_FAIL_COND_MSG(!animation_set.has(p_animation), vformat("Animation not found: %s.", p_animation));
 	animation_set[p_animation].next = p_next;
 }
 
@@ -2012,7 +2012,7 @@ Ref<AnimatedValuesBackup> AnimationPlayer::apply_reset(bool p_user_initiated) {
 	al.instantiate();
 	al->add_animation(SceneStringNames::get_singleton()->RESET, reset_anim);
 	aux_player->add_animation_library("default", al);
-	aux_player->set_assigned_animation(SceneStringNames::get_singleton()->RESET);
+	aux_player->set_assigned_animation("default/" + SceneStringNames::get_singleton()->RESET);
 	// Forcing the use of the original root because the scene where original player belongs may be not the active one
 	Node *root = get_node(get_root());
 	Ref<AnimatedValuesBackup> old_values = aux_player->backup_animated_values(root);

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -320,7 +320,7 @@ int OptionButton::get_selectable_item(bool p_from_last) const {
 			}
 		}
 	} else {
-		for (int i = get_item_count() - 1; i >= 0; i++) {
+		for (int i = get_item_count() - 1; i >= 0; i--) {
 			if (!is_item_disabled(i) && !is_item_separator(i)) {
 				return i;
 			}

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -63,7 +63,7 @@ Error AnimationLibrary::add_animation(const StringName &p_name, const Ref<Animat
 }
 
 void AnimationLibrary::remove_animation(const StringName &p_name) {
-	ERR_FAIL_COND(!animations.has(p_name));
+	ERR_FAIL_COND_MSG(!animations.has(p_name), vformat("Animation not found: %s.", p_name));
 
 	animations.erase(p_name);
 	emit_signal(SNAME("animation_removed"), p_name);
@@ -71,9 +71,9 @@ void AnimationLibrary::remove_animation(const StringName &p_name) {
 }
 
 void AnimationLibrary::rename_animation(const StringName &p_name, const StringName &p_new_name) {
-	ERR_FAIL_COND(!animations.has(p_name));
+	ERR_FAIL_COND_MSG(!animations.has(p_name), vformat("Animation not found: %s.", p_name));
 	ERR_FAIL_COND_MSG(!is_valid_animation_name(p_new_name), "Invalid animation name: '" + String(p_new_name) + "'.");
-	ERR_FAIL_COND(animations.has(p_new_name));
+	ERR_FAIL_COND_MSG(animations.has(p_new_name), vformat("Animation name \"%s\" already exists in library.", p_new_name));
 
 	animations.insert(p_new_name, animations[p_name]);
 	animations.erase(p_name);


### PR DESCRIPTION
Supersedes #61033.

A small collection of minor bugfixes and UX changes:

- Fix a bug causing an error message when a scene containing an AnimationPlayer with a reset track is saved, by correctly referencing the temporary "default" library.
- Make library dropdown in new animation window assign correct library when creating an animation. (Fixes #61031)
- Similarly allow choice of library when duplicating animation
- Make library dropdown default to library of currently selected animation
- Make library dropdown show when exactly one library exists, and it isn't [Global]. Include [Global] (create) on the dropdown in this case, which will create the [Global] library when the dialog is confirmed.

  This helps keep the UX consistent - before creating libraries, users can put animations into [Global] with the standard "New Animation" dialog. Without this change, they would lose that functionality if they created libraries. Users may not be aware that [Global] can be created by entering no name when making a library; this change will allow them to continue adding to [Global] in the way they are used to.
 
- When appending `(x)` to avoid `New Anim` name collisions, correctly check target library instead of [Global]. (Better to check _all_ libraries so that `New Anim`s always have an easily identifiable name?)
- Add parentheses when appending x when duplicating animations in the library editor, for consistency.

  I'm not sure about this change. Maybe it would be more consistent to append `(copy)`, as is done when duplicating in the animation player editor. Maybe consistency is not desirable - having slightly different behaviours might help users keep track of the history of their animations. Endlessly duplicating and reduplicating while testing the changes has probably given me a slightly warped perspective.

- Change titles and prompts to be distinct in name/rename/duplicate dialiogs.
- Fix bug in OprionButton.get_selectable_item(true) when last is not selectable. Was causing an out of bounds error if the last library in the list was empty when deleting an animation.
- Fix issues where animation wasn't found on deletion/rename by correctly prepending library name.
- Remove an extraneous print_line from animation_track_editor.
- Add messages to errors when an animation isn't found.

***

As I understand the way library names and animation names interact, there's no harm in e.g. `animation_1` and `library_1/animation_1` both existing. If so, can [this warning](https://github.com/snailrhymer/godot/blob/2c30bd3249998175d98e73a6ab7cf57a04445b18/scene/animation/animation_player.cpp#L1478) be removed?