### PR TITLE
Fix tonemapper shader to correctly apply alpha channel

### DIFF
--- a/drivers/gles3/shaders/tonemap.glsl
+++ b/drivers/gles3/shaders/tonemap.glsl
@@ -231,10 +231,10 @@ vec3 apply_fxaa(vec3 color, vec2 uv_interp, vec2 pixel_size) {
 }
 
 void main() {
-	vec3 color = textureLod(source, uv_interp, 0.0).rgb;
+	vec4 color = textureLod(source, uv_interp, 0.0);
 
 #ifdef USE_FXAA
-	color = apply_fxaa(color, uv_interp, pixel_size);
+	color.rgb = apply_fxaa(color.rgb, uv_interp, pixel_size);
 #endif
 
 	// Glow
@@ -296,18 +296,18 @@ void main() {
 #endif //USE_MULTI_TEXTURE_GLOW
 
 	glow *= glow_intensity;
-	color = apply_glow(color, glow);
+	color.rgb = apply_glow(color.rgb, glow);
 #endif
 
 	// Additional effects
 
 #ifdef USE_BCS
-	color = apply_bcs(color, bcs);
+	color.rgb = apply_bcs(color.rgb, bcs);
 #endif
 
 #ifdef USE_COLOR_CORRECTION
-	color = apply_color_correction(color, color_correction);
+	color.rgb = apply_color_correction(color.rgb, color_correction);
 #endif
 
-	frag_color = vec4(color, 1.0);
+	frag_color = color;
 }

--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1523,7 +1523,7 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 		Vector<Color> c;
 		{
 			Color cc = clear_color.srgb_to_linear();
-			if (using_separate_specular) {
+			if (using_separate_specular || render_buffer) {
 				cc.a = 0; //subsurf scatter must be 0
 			}
 			c.push_back(cc);


### PR DESCRIPTION
Changed a tone map shader to use an alpha channel from the input texture. 

This should fix a bug with `transparent_bg` in viewports:
![image](https://user-images.githubusercontent.com/3036176/168759819-15fd8476-1ade-4936-b920-ec007ab8cb5b.png)

Fix https://github.com/godotengine/godot/issues/40651

*Bugsquad edit: `master` version of https://github.com/godotengine/godot/pull/54585.*