### PR TITLE
ResourceLoader threading

### DIFF
--- a/core/io/resource_loader.h
+++ b/core/io/resource_loader.h
@@ -131,7 +131,7 @@ private:
 	struct ThreadLoadTask {
 		Thread *thread = nullptr;
 		Thread::ID loader_id = 0;
-		Semaphore *semaphore = nullptr;
+		Semaphore *semaphore = nullptr; // Semaphore to notify clients of completion, allocated if semaphore_clients > 0.
 		String local_path;
 		String remapped_path;
 		String type_hint;
@@ -144,7 +144,7 @@ private:
 		bool use_sub_threads = false;
 		bool start_next = true;
 		int requests = 0;
-		int poll_requests = 0;
+		int semaphore_clients = 0; // Number of clients waiting on the semaphore.
 		HashSet<String> sub_tasks;
 	};
 


### PR DESCRIPTION
# Summary 

These changes fix race conditions where a thread that isn't a dedicated resource loading thread (such as EditorResourcePreview and similar) loads a resource first but there is no semaphore to wait on for the result.  

The symptom is that resource loads fail and errors like cyclic reference or missing resource are reported, even though that isn't what happened.

These changes are significant and structural.  This PR has a solution with limited changes to the existing code.  I would also be happy to write a new implementation of the Loader from scratch with more clarity, if that is requested.

## Background

The code deletes Semaphore instances as soon as we can to preserve OS resources, as it did before these changes.  ~~Any load task that is completed and has no current waiting clients must not have a Semaphore or the number of those objects would scale with the total resource loads instead of the total number of threads in the system.~~. [edit: not true, as we actually vacate the “tasks” cache and go into the “ResourceCache” when done, but there will still be a ton of synchronous loads which don’t have any collisions with other client threads, so not allocating and deallocated Semaphore objects for those is probably still worth it.  In a redesign I might just maintain reusable semaphores, because their number is bounded by the number of threads in the system.]

In the previous code, a semaphore isn't even allocated in certain cases, because the code assumes that if the loader isn't a worker thread, the semaphore won't be needed.  However, this isn't true when there are other unrelated threads in the system that also call ResourceLoader::load. 

In this implementation, clients making load requests (can be any thread) are responsible for allocation and deallocation, and there is no attempt made to use the same thread to do both, since that would create a lot of complexity.  The previous code was deallocating the Semaphore from the "provider" side, after posting it.  Apparently, the lifetime of this Semaphore wasn't actually assured at the time that waiting clients wake up.  See "Limitations" below.

# Limitations

This code would not work on any platforms that require Semaphore (std::mutex and std::condition) to be allocated and deallocated on the same thread.   

I do not know if there are any such platforms targeted by Godot.
