### PR TITLE
Implement read-only arrays

### DIFF
--- a/core/variant/array.h
+++ b/core/variant/array.h
@@ -125,6 +125,10 @@ public:
 	uint32_t get_typed_builtin() const;
 	StringName get_typed_class_name() const;
 	Variant get_typed_script() const;
+
+	void set_read_only(bool p_enable);
+	bool is_read_only() const;
+
 	Array(const Array &p_from);
 	Array();
 	~Array();

--- a/core/variant/variant_setget.cpp
+++ b/core/variant/variant_setget.cpp
@@ -624,6 +624,11 @@ struct VariantIndexedSetGet_Array {
 		PtrToArg<Variant>::encode(v[index], member);
 	}
 	static void set(Variant *base, int64_t index, const Variant *value, bool *valid, bool *oob) {
+		if (VariantGetInternalPtr<Array>::get_ptr(base)->is_read_only()) {
+			*valid = false;
+			*oob = true;
+			return;
+		}
 		int64_t size = VariantGetInternalPtr<Array>::get_ptr(base)->size();
 		if (index < 0) {
 			index += size;
@@ -638,6 +643,10 @@ struct VariantIndexedSetGet_Array {
 		*valid = true;
 	}
 	static void validated_set(Variant *base, int64_t index, const Variant *value, bool *oob) {
+		if (VariantGetInternalPtr<Array>::get_ptr(base)->is_read_only()) {
+			*oob = true;
+			return;
+		}
 		int64_t size = VariantGetInternalPtr<Array>::get_ptr(base)->size();
 		if (index < 0) {
 			index += size;


### PR DESCRIPTION
Arrays can be set as read-only and thus cannot be modified. Assigning the array will create an editable copy.

Similar to is already done to read-only dictionaries (see #61087).

Proper support in GDScript will be added in a future PR.