### PR TITLE
Tweak minsize of editor ColorPickerButtons

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -2752,7 +2752,13 @@ void EditorPropertyColor::_picker_opening() {
 	last_color = picker->get_pick_color();
 }
 
-void EditorPropertyColor::_bind_methods() {
+void EditorPropertyColor::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			picker->set_custom_minimum_size(Size2(0, get_theme_constant(SNAME("color_picker_button_height"), SNAME("Editor"))));
+		} break;
+	}
 }
 
 void EditorPropertyColor::update_property() {

--- a/editor/editor_properties.h
+++ b/editor/editor_properties.h
@@ -667,7 +667,7 @@ class EditorPropertyColor : public EditorProperty {
 
 protected:
 	virtual void _set_read_only(bool p_read_only) override;
-	static void _bind_methods();
+	void _notification(int p_what);
 
 public:
 	virtual void update_property() override;

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -535,6 +535,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_constant("scale", "Editor", EDSCALE);
 	theme->set_constant("thumb_size", "Editor", thumb_size);
 	theme->set_constant("dark_theme", "Editor", dark_theme);
+	theme->set_constant("color_picker_button_height", "Editor", 28 * EDSCALE);
 
 	// Register icons + font
 

--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -6949,6 +6949,10 @@ void Node3DEditor::_update_theme() {
 
 	sun_title->add_theme_font_override("font", get_theme_font(SNAME("title_font"), SNAME("Window")));
 	environ_title->add_theme_font_override("font", get_theme_font(SNAME("title_font"), SNAME("Window")));
+
+	sun_color->set_custom_minimum_size(Size2(0, get_theme_constant(SNAME("color_picker_button_height"), SNAME("Editor"))));
+	environ_sky_color->set_custom_minimum_size(Size2(0, get_theme_constant(SNAME("color_picker_button_height"), SNAME("Editor"))));
+	environ_ground_color->set_custom_minimum_size(Size2(0, get_theme_constant(SNAME("color_picker_button_height"), SNAME("Editor"))));
 }
 
 void Node3DEditor::_notification(int p_what) {

--- a/editor/plugins/theme_editor_preview.cpp
+++ b/editor/plugins/theme_editor_preview.cpp
@@ -269,6 +269,15 @@ ThemeEditorPreview::ThemeEditorPreview() {
 	picker_overlay->connect("mouse_exited", callable_mp(this, &ThemeEditorPreview::_reset_picker_overlay));
 }
 
+void DefaultThemeEditorPreview::_notification(int p_what) {
+	switch (p_what) {
+		case NOTIFICATION_ENTER_TREE:
+		case NOTIFICATION_THEME_CHANGED: {
+			test_color_picker_button->set_custom_minimum_size(Size2(0, get_theme_constant(SNAME("color_picker_button_height"), SNAME("Editor"))));
+		} break;
+	}
+}
+
 DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 	Panel *main_panel = memnew(Panel);
 	preview_content->add_child(main_panel);
@@ -343,7 +352,8 @@ DefaultThemeEditorPreview::DefaultThemeEditorPreview() {
 	test_option_button->add_item(TTR("Many"));
 	test_option_button->add_item(TTR("Options"));
 	first_vb->add_child(test_option_button);
-	first_vb->add_child(memnew(ColorPickerButton));
+	test_color_picker_button = memnew(ColorPickerButton);
+	first_vb->add_child(test_color_picker_button);
 
 	VBoxContainer *second_vb = memnew(VBoxContainer);
 	second_vb->set_h_size_flags(SIZE_EXPAND_FILL);

--- a/editor/plugins/theme_editor_preview.h
+++ b/editor/plugins/theme_editor_preview.h
@@ -38,6 +38,8 @@
 #include "scene/gui/scroll_container.h"
 #include "scene/resources/theme.h"
 
+class ColorPickerButton;
+
 class ThemeEditorPreview : public VBoxContainer {
 	GDCLASS(ThemeEditorPreview, VBoxContainer);
 
@@ -86,6 +88,11 @@ public:
 
 class DefaultThemeEditorPreview : public ThemeEditorPreview {
 	GDCLASS(DefaultThemeEditorPreview, ThemeEditorPreview);
+
+	ColorPickerButton *test_color_picker_button = nullptr;
+
+protected:
+	void _notification(int p_what);
 
 public:
 	DefaultThemeEditorPreview();


### PR DESCRIPTION
Follow-up to #60867
I set the size to twice the default font size and it looks the same as before:
![image](https://user-images.githubusercontent.com/2223172/168906826-f013469d-38ab-4239-9438-989f00ae12f5.png)
On bigger editor font sizes the buttons automatically adjust, on smaller sizes they are bigger than text.