### PR TITLE
Update NavigationRegion2D when polygons of NavigationPolygon change

### DIFF
--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -509,6 +509,9 @@ void NavigationRegion2D::_navpoly_changed() {
 	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_navigation_hint())) {
 		update();
 	}
+	if (navpoly.is_valid()) {
+		NavigationServer2D::get_singleton()->region_set_navpoly(region, navpoly);
+	}
 }
 void NavigationRegion2D::_map_changed(RID p_map) {
 	if (enabled && get_world_2d()->get_navigation_map() == p_map) {


### PR DESCRIPTION
Updates `NavigationRegion2D` polygon on the NavigationServer2D when the `NavigationPolygon` Resource emits its `changed` signal due to e.g. polygons altered by script.

Region was only updated when the poly resource was set or enabled and blocked further updates while it was still the same resource or enabled state. The debug display was already connected to the signal so it updated correctly while the navigation mesh on the NavigationServer2D did not.

Fixes #18669

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
