### PR TITLE
[3.5] Update NavigationPolygonInstance when polygons of NavigationPolygon change

### DIFF
--- a/scene/2d/navigation_polygon.cpp
+++ b/scene/2d/navigation_polygon.cpp
@@ -498,6 +498,9 @@ void NavigationPolygonInstance::_navpoly_changed() {
 	if (is_inside_tree() && (Engine::get_singleton()->is_editor_hint() || get_tree()->is_debugging_navigation_hint())) {
 		update();
 	}
+	if (navpoly.is_valid()) {
+		Navigation2DServer::get_singleton()->region_set_navpoly(region, navpoly);
+	}
 }
 
 String NavigationPolygonInstance::get_configuration_warning() const {


### PR DESCRIPTION
This is 3.5 version of #61149

Updates NavigationPolygonInstance polygons on the NavigationServer2D when the NavigationPolygon Resource emits its changed signal due to e.g. polygons altered by script.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
