### PR TITLE
Define some `Theme` data structures with `using` for readability

### DIFF
--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -217,12 +217,12 @@ private:
 		NodePath focus_prev;
 
 		bool bulk_theme_override = false;
-		HashMap<StringName, Ref<Texture2D>> icon_override;
-		HashMap<StringName, Ref<StyleBox>> style_override;
-		HashMap<StringName, Ref<Font>> font_override;
-		HashMap<StringName, int> font_size_override;
-		HashMap<StringName, Color> color_override;
-		HashMap<StringName, int> constant_override;
+		Theme::ThemeIconMap icon_override;
+		Theme::ThemeStyleMap style_override;
+		Theme::ThemeFontMap font_override;
+		Theme::ThemeFontSizeMap font_size_override;
+		Theme::ThemeColorMap color_override;
+		Theme::ThemeConstantMap constant_override;
 
 	} data;
 

--- a/scene/resources/theme.cpp
+++ b/scene/resources/theme.cpp
@@ -129,42 +129,42 @@ void Theme::_get_property_list(List<PropertyInfo> *p_list) const {
 	}
 
 	// Icons.
-	for (const KeyValue<StringName, HashMap<StringName, Ref<Texture2D>>> &E : icon_map) {
+	for (const KeyValue<StringName, ThemeIconMap> &E : icon_map) {
 		for (const KeyValue<StringName, Ref<Texture2D>> &F : E.value) {
 			list.push_back(PropertyInfo(Variant::OBJECT, String() + E.key + "/icons/" + F.key, PROPERTY_HINT_RESOURCE_TYPE, "Texture2D", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL));
 		}
 	}
 
 	// Styles.
-	for (const KeyValue<StringName, HashMap<StringName, Ref<StyleBox>>> &E : style_map) {
+	for (const KeyValue<StringName, ThemeStyleMap> &E : style_map) {
 		for (const KeyValue<StringName, Ref<StyleBox>> &F : E.value) {
 			list.push_back(PropertyInfo(Variant::OBJECT, String() + E.key + "/styles/" + F.key, PROPERTY_HINT_RESOURCE_TYPE, "StyleBox", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL));
 		}
 	}
 
 	// Fonts.
-	for (const KeyValue<StringName, HashMap<StringName, Ref<Font>>> &E : font_map) {
+	for (const KeyValue<StringName, ThemeFontMap> &E : font_map) {
 		for (const KeyValue<StringName, Ref<Font>> &F : E.value) {
 			list.push_back(PropertyInfo(Variant::OBJECT, String() + E.key + "/fonts/" + F.key, PROPERTY_HINT_RESOURCE_TYPE, "Font", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_STORE_IF_NULL));
 		}
 	}
 
 	// Font sizes.
-	for (const KeyValue<StringName, HashMap<StringName, int>> &E : font_size_map) {
+	for (const KeyValue<StringName, ThemeFontSizeMap> &E : font_size_map) {
 		for (const KeyValue<StringName, int> &F : E.value) {
 			list.push_back(PropertyInfo(Variant::INT, String() + E.key + "/font_sizes/" + F.key, PROPERTY_HINT_RANGE, "0,256,1,or_greater"));
 		}
 	}
 
 	// Colors.
-	for (const KeyValue<StringName, HashMap<StringName, Color>> &E : color_map) {
+	for (const KeyValue<StringName, ThemeColorMap> &E : color_map) {
 		for (const KeyValue<StringName, Color> &F : E.value) {
-			list.push_back(PropertyInfo(Variant::INT, String() + E.key + "/colors/" + F.key));
+			list.push_back(PropertyInfo(Variant::COLOR, String() + E.key + "/colors/" + F.key));
 		}
 	}
 
 	// Constants.
-	for (const KeyValue<StringName, HashMap<StringName, int>> &E : constant_map) {
+	for (const KeyValue<StringName, ThemeConstantMap> &E : constant_map) {
 		for (const KeyValue<StringName, int> &F : E.value) {
 			list.push_back(PropertyInfo(Variant::INT, String() + E.key + "/constants/" + F.key));
 		}
@@ -407,7 +407,7 @@ void Theme::add_icon_type(const StringName &p_theme_type) {
 	if (icon_map.has(p_theme_type)) {
 		return;
 	}
-	icon_map[p_theme_type] = HashMap<StringName, Ref<Texture2D>>();
+	icon_map[p_theme_type] = ThemeIconMap();
 }
 
 void Theme::remove_icon_type(const StringName &p_theme_type) {
@@ -432,7 +432,7 @@ void Theme::remove_icon_type(const StringName &p_theme_type) {
 void Theme::get_icon_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
-	for (const KeyValue<StringName, HashMap<StringName, Ref<Texture2D>>> &E : icon_map) {
+	for (const KeyValue<StringName, ThemeIconMap> &E : icon_map) {
 		p_list->push_back(E.key);
 	}
 }
@@ -517,7 +517,7 @@ void Theme::add_stylebox_type(const StringName &p_theme_type) {
 	if (style_map.has(p_theme_type)) {
 		return;
 	}
-	style_map[p_theme_type] = HashMap<StringName, Ref<StyleBox>>();
+	style_map[p_theme_type] = ThemeStyleMap();
 }
 
 void Theme::remove_stylebox_type(const StringName &p_theme_type) {
@@ -542,7 +542,7 @@ void Theme::remove_stylebox_type(const StringName &p_theme_type) {
 void Theme::get_stylebox_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
-	for (const KeyValue<StringName, HashMap<StringName, Ref<StyleBox>>> &E : style_map) {
+	for (const KeyValue<StringName, ThemeStyleMap> &E : style_map) {
 		p_list->push_back(E.key);
 	}
 }
@@ -629,7 +629,7 @@ void Theme::add_font_type(const StringName &p_theme_type) {
 	if (font_map.has(p_theme_type)) {
 		return;
 	}
-	font_map[p_theme_type] = HashMap<StringName, Ref<Font>>();
+	font_map[p_theme_type] = ThemeFontMap();
 }
 
 void Theme::remove_font_type(const StringName &p_theme_type) {
@@ -654,7 +654,7 @@ void Theme::remove_font_type(const StringName &p_theme_type) {
 void Theme::get_font_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
-	for (const KeyValue<StringName, HashMap<StringName, Ref<Font>>> &E : font_map) {
+	for (const KeyValue<StringName, ThemeFontMap> &E : font_map) {
 		p_list->push_back(E.key);
 	}
 }
@@ -728,7 +728,7 @@ void Theme::add_font_size_type(const StringName &p_theme_type) {
 	if (font_size_map.has(p_theme_type)) {
 		return;
 	}
-	font_size_map[p_theme_type] = HashMap<StringName, int>();
+	font_size_map[p_theme_type] = ThemeFontSizeMap();
 }
 
 void Theme::remove_font_size_type(const StringName &p_theme_type) {
@@ -742,7 +742,7 @@ void Theme::remove_font_size_type(const StringName &p_theme_type) {
 void Theme::get_font_size_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
-	for (const KeyValue<StringName, HashMap<StringName, int>> &E : font_size_map) {
+	for (const KeyValue<StringName, ThemeFontSizeMap> &E : font_size_map) {
 		p_list->push_back(E.key);
 	}
 }
@@ -814,7 +814,7 @@ void Theme::add_color_type(const StringName &p_theme_type) {
 	if (color_map.has(p_theme_type)) {
 		return;
 	}
-	color_map[p_theme_type] = HashMap<StringName, Color>();
+	color_map[p_theme_type] = ThemeColorMap();
 }
 
 void Theme::remove_color_type(const StringName &p_theme_type) {
@@ -828,7 +828,7 @@ void Theme::remove_color_type(const StringName &p_theme_type) {
 void Theme::get_color_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
-	for (const KeyValue<StringName, HashMap<StringName, Color>> &E : color_map) {
+	for (const KeyValue<StringName, ThemeColorMap> &E : color_map) {
 		p_list->push_back(E.key);
 	}
 }
@@ -900,7 +900,7 @@ void Theme::add_constant_type(const StringName &p_theme_type) {
 	if (constant_map.has(p_theme_type)) {
 		return;
 	}
-	constant_map[p_theme_type] = HashMap<StringName, int>();
+	constant_map[p_theme_type] = ThemeConstantMap();
 }
 
 void Theme::remove_constant_type(const StringName &p_theme_type) {
@@ -914,7 +914,7 @@ void Theme::remove_constant_type(const StringName &p_theme_type) {
 void Theme::get_constant_type_list(List<StringName> *p_list) const {
 	ERR_FAIL_NULL(p_list);
 
-	for (const KeyValue<StringName, HashMap<StringName, int>> &E : constant_map) {
+	for (const KeyValue<StringName, ThemeConstantMap> &E : constant_map) {
 		p_list->push_back(E.key);
 	}
 }
@@ -1278,32 +1278,32 @@ void Theme::get_type_list(List<StringName> *p_list) const {
 	RBSet<StringName> types;
 
 	// Icons.
-	for (const KeyValue<StringName, HashMap<StringName, Ref<Texture2D>>> &E : icon_map) {
+	for (const KeyValue<StringName, ThemeIconMap> &E : icon_map) {
 		types.insert(E.key);
 	}
 
 	// Styles.
-	for (const KeyValue<StringName, HashMap<StringName, Ref<StyleBox>>> &E : style_map) {
+	for (const KeyValue<StringName, ThemeStyleMap> &E : style_map) {
 		types.insert(E.key);
 	}
 
 	// Fonts.
-	for (const KeyValue<StringName, HashMap<StringName, Ref<Font>>> &E : font_map) {
+	for (const KeyValue<StringName, ThemeFontMap> &E : font_map) {
 		types.insert(E.key);
 	}
 
 	// Font sizes.
-	for (const KeyValue<StringName, HashMap<StringName, int>> &E : font_size_map) {
+	for (const KeyValue<StringName, ThemeFontSizeMap> &E : font_size_map) {
 		types.insert(E.key);
 	}
 
 	// Colors.
-	for (const KeyValue<StringName, HashMap<StringName, Color>> &E : color_map) {
+	for (const KeyValue<StringName, ThemeColorMap> &E : color_map) {
 		types.insert(E.key);
 	}
 
 	// Constants.
-	for (const KeyValue<StringName, HashMap<StringName, int>> &E : constant_map) {
+	for (const KeyValue<StringName, ThemeConstantMap> &E : constant_map) {
 		types.insert(E.key);
 	}
 
@@ -1620,7 +1620,7 @@ void Theme::merge_with(const Ref<Theme> &p_other) {
 
 	// Colors.
 	{
-		for (const KeyValue<StringName, HashMap<StringName, Color>> &E : p_other->color_map) {
+		for (const KeyValue<StringName, ThemeColorMap> &E : p_other->color_map) {
 			for (const KeyValue<StringName, Color> &F : E.value) {
 				set_color(F.key, E.key, F.value);
 			}
@@ -1629,7 +1629,7 @@ void Theme::merge_with(const Ref<Theme> &p_other) {
 
 	// Constants.
 	{
-		for (const KeyValue<StringName, HashMap<StringName, int>> &E : p_other->constant_map) {
+		for (const KeyValue<StringName, ThemeConstantMap> &E : p_other->constant_map) {
 			for (const KeyValue<StringName, int> &F : E.value) {
 				set_constant(F.key, E.key, F.value);
 			}
@@ -1638,7 +1638,7 @@ void Theme::merge_with(const Ref<Theme> &p_other) {
 
 	// Fonts.
 	{
-		for (const KeyValue<StringName, HashMap<StringName, Ref<Font>>> &E : p_other->font_map) {
+		for (const KeyValue<StringName, ThemeFontMap> &E : p_other->font_map) {
 			for (const KeyValue<StringName, Ref<Font>> &F : E.value) {
 				set_font(F.key, E.key, F.value);
 			}
@@ -1647,7 +1647,7 @@ void Theme::merge_with(const Ref<Theme> &p_other) {
 
 	// Font sizes.
 	{
-		for (const KeyValue<StringName, HashMap<StringName, int>> &E : p_other->font_size_map) {
+		for (const KeyValue<StringName, ThemeFontSizeMap> &E : p_other->font_size_map) {
 			for (const KeyValue<StringName, int> &F : E.value) {
 				set_font_size(F.key, E.key, F.value);
 			}
@@ -1656,7 +1656,7 @@ void Theme::merge_with(const Ref<Theme> &p_other) {
 
 	// Icons.
 	{
-		for (const KeyValue<StringName, HashMap<StringName, Ref<Texture2D>>> &E : p_other->icon_map) {
+		for (const KeyValue<StringName, ThemeIconMap> &E : p_other->icon_map) {
 			for (const KeyValue<StringName, Ref<Texture2D>> &F : E.value) {
 				set_icon(F.key, E.key, F.value);
 			}
@@ -1665,7 +1665,7 @@ void Theme::merge_with(const Ref<Theme> &p_other) {
 
 	// Styleboxes.
 	{
-		for (const KeyValue<StringName, HashMap<StringName, Ref<StyleBox>>> &E : p_other->style_map) {
+		for (const KeyValue<StringName, ThemeStyleMap> &E : p_other->style_map) {
 			for (const KeyValue<StringName, Ref<StyleBox>> &F : E.value) {
 				set_stylebox(F.key, E.key, F.value);
 			}
@@ -1685,7 +1685,7 @@ void Theme::merge_with(const Ref<Theme> &p_other) {
 void Theme::clear() {
 	// These items need disconnecting.
 	{
-		for (const KeyValue<StringName, HashMap<StringName, Ref<Texture2D>>> &E : icon_map) {
+		for (const KeyValue<StringName, ThemeIconMap> &E : icon_map) {
 			for (const KeyValue<StringName, Ref<Texture2D>> &F : E.value) {
 				if (F.value.is_valid()) {
 					Ref<Texture2D> icon = F.value;
@@ -1696,7 +1696,7 @@ void Theme::clear() {
 	}
 
 	{
-		for (const KeyValue<StringName, HashMap<StringName, Ref<StyleBox>>> &E : style_map) {
+		for (const KeyValue<StringName, ThemeStyleMap> &E : style_map) {
 			for (const KeyValue<StringName, Ref<StyleBox>> &F : E.value) {
 				if (F.value.is_valid()) {
 					Ref<StyleBox> style = F.value;
@@ -1707,7 +1707,7 @@ void Theme::clear() {
 	}
 
 	{
-		for (const KeyValue<StringName, HashMap<StringName, Ref<Font>>> &E : font_map) {
+		for (const KeyValue<StringName, ThemeFontMap> &E : font_map) {
 			for (const KeyValue<StringName, Ref<Font>> &F : E.value) {
 				if (F.value.is_valid()) {
 					Ref<Font> font = F.value;

--- a/scene/resources/theme.h
+++ b/scene/resources/theme.h
@@ -47,6 +47,13 @@ class Theme : public Resource {
 #endif
 
 public:
+	using ThemeIconMap = HashMap<StringName, Ref<Texture2D>>;
+	using ThemeStyleMap = HashMap<StringName, Ref<StyleBox>>;
+	using ThemeFontMap = HashMap<StringName, Ref<Font>>;
+	using ThemeFontSizeMap = HashMap<StringName, int>;
+	using ThemeColorMap = HashMap<StringName, Color>;
+	using ThemeConstantMap = HashMap<StringName, int>;
+
 	enum DataType {
 		DATA_TYPE_COLOR,
 		DATA_TYPE_CONSTANT,
@@ -62,12 +69,12 @@ private:
 
 	void _emit_theme_changed(bool p_notify_list_changed = false);
 
-	HashMap<StringName, HashMap<StringName, Ref<Texture2D>>> icon_map;
-	HashMap<StringName, HashMap<StringName, Ref<StyleBox>>> style_map;
-	HashMap<StringName, HashMap<StringName, Ref<Font>>> font_map;
-	HashMap<StringName, HashMap<StringName, int>> font_size_map;
-	HashMap<StringName, HashMap<StringName, Color>> color_map;
-	HashMap<StringName, HashMap<StringName, int>> constant_map;
+	HashMap<StringName, ThemeIconMap> icon_map;
+	HashMap<StringName, ThemeStyleMap> style_map;
+	HashMap<StringName, ThemeFontMap> font_map;
+	HashMap<StringName, ThemeFontSizeMap> font_size_map;
+	HashMap<StringName, ThemeColorMap> color_map;
+	HashMap<StringName, ThemeConstantMap> constant_map;
 	HashMap<StringName, StringName> variation_map;
 	HashMap<StringName, List<StringName>> variation_base_map;
 


### PR DESCRIPTION
Following a short discussion on RC I've redefined some HashMaps used by Theme with `using` to make code for iterators more readable. It was suggested to use `typedef`s at first, but seems `using` is the way to go in future.

Made them public so `Control` can use them as well, which should make the relation between class members clearer.

Also fixes https://github.com/godotengine/godot/issues/61156, another regression from the HashMap PR.