### PR TITLE
ResourceImporterWAV: add 32-bit float to error message

### DIFF
--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -162,7 +162,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 			//Consider revision for engine version 3.0
 			compression_code = file->get_16();
 			if (compression_code != 1 && compression_code != 3) {
-				ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Format not supported for WAVE file (not PCM). Save WAVE files as uncompressed PCM instead.");
+				ERR_FAIL_V_MSG(ERR_INVALID_DATA, "Format not supported for WAVE file (not PCM). Save WAVE files as uncompressed PCM or 32-bit float instead.");
 			}
 
 			format_channels = file->get_16();


### PR DESCRIPTION
If a format is supported, the error message for unsupported formats should include it too.

I would also like to report that while the importer accepts 64-bit float, the audio becomes distorted.