### PR TITLE
Only switch to node when not dragging it

### DIFF
--- a/editor/scene_tree_dock.h
+++ b/editor/scene_tree_dock.h
@@ -105,7 +105,6 @@ class SceneTreeDock : public VBoxContainer {
 
 	Vector<ObjectID> subresources;
 
-	bool restore_script_editor_on_drag = false;
 	bool reset_create_dialog = false;
 
 	int current_option = 0;
@@ -172,6 +171,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _do_create(Node *p_parent);
 	Node *scene_root = nullptr;
 	Node *edited_scene = nullptr;
+	Node *pending_click_select = nullptr;
 
 	VBoxContainer *create_root_dialog = nullptr;
 	String selected_favorite_root;
@@ -198,6 +198,7 @@ class SceneTreeDock : public VBoxContainer {
 	void _load_request(const String &p_path);
 	void _script_open_request(const Ref<Script> &p_script);
 	void _push_item(Object *p_object);
+	void _handle_select(Node *p_node);
 
 	bool _cyclical_dependency_exists(const String &p_target_scene_path, Node *p_desired_node);
 	bool _track_inherit(const String &p_target_scene_path, Node *p_desired_node);


### PR DESCRIPTION
Normally when you click node in the scene tree, the inspector will switch immediately. I changed it so that it only switches when you release the mouse button, but only if you didn't start dragging the nodes.
Also removed a hack that forcefully switched to script editor when drag started (it was quite brilliant though. I just repurposed its code :v)
Also removed the Alt hack added in #55761

Closes #39539
Fixes #33704
Supersedes #40438

https://user-images.githubusercontent.com/2223172/169104356-e39714e4-659f-4019-b25f-41a240854c81.mp4