### PR TITLE
Remove arbitrary NavigationMesh bake property limits

### DIFF
--- a/doc/classes/NavigationMesh.xml
+++ b/doc/classes/NavigationMesh.xml
@@ -73,25 +73,25 @@
 		</method>
 	</methods>
 	<members>
-		<member name="agent/height" type="float" setter="set_agent_height" getter="get_agent_height" default="2.0">
+		<member name="agent/height" type="float" setter="set_agent_height" getter="get_agent_height" default="1.5">
 			The minimum floor to ceiling height that will still allow the floor area to be considered walkable.
 			[b]Note:[/b] While baking, this value will be rounded up to the nearest multiple of [member cell/height].
 		</member>
-		<member name="agent/max_climb" type="float" setter="set_agent_max_climb" getter="get_agent_max_climb" default="0.9">
+		<member name="agent/max_climb" type="float" setter="set_agent_max_climb" getter="get_agent_max_climb" default="0.25">
 			The minimum ledge height that is considered to still be traversable.
 			[b]Note:[/b] While baking, this value will be rounded down to the nearest multiple of [member cell/height].
 		</member>
 		<member name="agent/max_slope" type="float" setter="set_agent_max_slope" getter="get_agent_max_slope" default="45.0">
 			The maximum slope that is considered walkable, in degrees.
 		</member>
-		<member name="agent/radius" type="float" setter="set_agent_radius" getter="get_agent_radius" default="1.0">
+		<member name="agent/radius" type="float" setter="set_agent_radius" getter="get_agent_radius" default="0.5">
 			The distance to erode/shrink the walkable area of the heightfield away from obstructions.
 			[b]Note:[/b] While baking, this value will be rounded up to the nearest multiple of [member cell/size].
 		</member>
-		<member name="cell/height" type="float" setter="set_cell_height" getter="get_cell_height" default="0.2">
+		<member name="cell/height" type="float" setter="set_cell_height" getter="get_cell_height" default="0.25">
 			The Y axis cell size to use for fields.
 		</member>
-		<member name="cell/size" type="float" setter="set_cell_size" getter="get_cell_size" default="0.3">
+		<member name="cell/size" type="float" setter="set_cell_size" getter="get_cell_size" default="0.25">
 			The XZ plane cell size to use for fields.
 		</member>
 		<member name="detail/sample_distance" type="float" setter="set_detail_sample_distance" getter="get_detail_sample_distance" default="6.0">
@@ -137,7 +137,7 @@
 			Any regions with a size smaller than this will be merged with larger regions if possible.
 			[b]Note:[/b] This value will be squared to calculate the number of cells. For example, a value of 20 will set the number of cells to 400.
 		</member>
-		<member name="region/min_size" type="float" setter="set_region_min_size" getter="get_region_min_size" default="8.0">
+		<member name="region/min_size" type="float" setter="set_region_min_size" getter="get_region_min_size" default="2.0">
 			The minimum size of a region for it to be created.
 			[b]Note:[/b] This value will be squared to calculate the minimum number of cells allowed to form isolated island areas. For example, a value of 8 will set the number of cells to 64.
 		</member>

--- a/scene/resources/navigation_mesh.cpp
+++ b/scene/resources/navigation_mesh.cpp
@@ -492,12 +492,12 @@ void NavigationMesh::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "geometry/source_geometry_mode", PROPERTY_HINT_ENUM, "Navmesh Children, Group With Children, Group Explicit"), "set_source_geometry_mode", "get_source_geometry_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::STRING, "geometry/source_group_name"), "set_source_group_name", "get_source_group_name");
 
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell/size", PROPERTY_HINT_RANGE, "0.1,1.0,0.01,or_greater"), "set_cell_size", "get_cell_size");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell/height", PROPERTY_HINT_RANGE, "0.1,1.0,0.01,or_greater"), "set_cell_height", "get_cell_height");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent/height", PROPERTY_HINT_RANGE, "0.1,5.0,0.01,or_greater"), "set_agent_height", "get_agent_height");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent/radius", PROPERTY_HINT_RANGE, "0.1,5.0,0.01,or_greater"), "set_agent_radius", "get_agent_radius");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent/max_climb", PROPERTY_HINT_RANGE, "0.1,5.0,0.01,or_greater"), "set_agent_max_climb", "get_agent_max_climb");
-	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent/max_slope", PROPERTY_HINT_RANGE, "0.0,90.0,0.1"), "set_agent_max_slope", "get_agent_max_slope");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell/size", PROPERTY_HINT_RANGE, "0.01,500.0,0.01,or_greater"), "set_cell_size", "get_cell_size");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "cell/height", PROPERTY_HINT_RANGE, "0.01,500.0,0.01,or_greater"), "set_cell_height", "get_cell_height");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent/height", PROPERTY_HINT_RANGE, "0.0,500.0,0.01,or_greater"), "set_agent_height", "get_agent_height");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent/radius", PROPERTY_HINT_RANGE, "0.0,500.0,0.01,or_greater"), "set_agent_radius", "get_agent_radius");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent/max_climb", PROPERTY_HINT_RANGE, "0.0,500.0,0.01,or_greater"), "set_agent_max_climb", "get_agent_max_climb");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "agent/max_slope", PROPERTY_HINT_RANGE, "0.02,90.0,0.01"), "set_agent_max_slope", "get_agent_max_slope");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "region/min_size", PROPERTY_HINT_RANGE, "0.0,150.0,0.01,or_greater"), "set_region_min_size", "get_region_min_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "region/merge_size", PROPERTY_HINT_RANGE, "0.0,150.0,0.01,or_greater"), "set_region_merge_size", "get_region_merge_size");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "edge/max_length", PROPERTY_HINT_RANGE, "0.0,50.0,0.01,or_greater"), "set_edge_max_length", "get_edge_max_length");

--- a/scene/resources/navigation_mesh.h
+++ b/scene/resources/navigation_mesh.h
@@ -88,13 +88,13 @@ public:
 	};
 
 protected:
-	float cell_size = 0.3f;
-	float cell_height = 0.2f;
-	float agent_height = 2.0f;
-	float agent_radius = 1.0f;
-	float agent_max_climb = 0.9f;
+	float cell_size = 0.25f;
+	float cell_height = 0.25f;
+	float agent_height = 1.5f;
+	float agent_radius = 0.5f;
+	float agent_max_climb = 0.25f;
 	float agent_max_slope = 45.0f;
-	float region_min_size = 8.0f;
+	float region_min_size = 2.0f;
 	float region_merge_size = 20.0f;
 	float edge_max_length = 12.0f;
 	float edge_max_error = 1.3f;


### PR DESCRIPTION
Lowers or nearly removes the slider limits and steps from NavigationMesh resources.

This change is a precursor to fix multiple open GridMap navigation issues that all seem to boil down to wrong stored navmesh resources and (re)baking parameters. The new NavigationServer in Godot 4.0 and 3.5 is far to reliant on proper settings for (re)bakes to not fail vertex and edge merges between navmeshes and GridMaps are the most affected by this.

Also changes some default values to better work with realistic unit sizes and grids so new navigation users can have a better first time experience before diving into detailed settings.