### PR TITLE
Fixed recent DoF and tonemap bugs

### DIFF
--- a/drivers/gles2/shaders/tonemap.glsl
+++ b/drivers/gles2/shaders/tonemap.glsl
@@ -204,7 +204,7 @@ vec4 apply_glow(vec4 color, vec3 glow) { // apply glow using the selected blendi
 #ifndef USE_GLOW_SOFTLIGHT // softlight has no effect on black color
 	// compute the alpha from glow
 	float a = max(max(glow.r, glow.g), glow.b);
-	color.a = a + color.a * (1 - a);
+	color.a = a + color.a * (1.0 - a);
 	if (color.a == 0.0) {
 		color.rgb = vec3(0.0);
 	} else if (color.a < 1.0) {
@@ -242,10 +242,10 @@ vec4 apply_fxaa(vec4 color, vec2 uv_interp, vec2 pixel_size) {
 	vec4 rgbSE = texture2DLod(source, uv_interp + vec2(1.0, 1.0) * pixel_size, 0.0);
 	vec3 rgbM = color.rgb;
 	vec3 luma = vec3(0.299, 0.587, 0.114);
-	float lumaNW = dot(rgbNW.rgb, luma) - ((1 - rgbNW.a) / 8.0);
-	float lumaNE = dot(rgbNE.rgb, luma) - ((1 - rgbNE.a) / 8.0);
-	float lumaSW = dot(rgbSW.rgb, luma) - ((1 - rgbSW.a) / 8.0);
-	float lumaSE = dot(rgbSE.rgb, luma) - ((1 - rgbSE.a) / 8.0);
+	float lumaNW = dot(rgbNW.rgb, luma) - ((1.0 - rgbNW.a) / 8.0);
+	float lumaNE = dot(rgbNE.rgb, luma) - ((1.0 - rgbNE.a) / 8.0);
+	float lumaSW = dot(rgbSW.rgb, luma) - ((1.0 - rgbSW.a) / 8.0);
+	float lumaSE = dot(rgbSE.rgb, luma) - ((1.0 - rgbSE.a) / 8.0);
 	float lumaM = dot(rgbM, luma) - (color.a / 8.0);
 	float lumaMin = min(lumaM, min(min(lumaNW, lumaNE), min(lumaSW, lumaSE)));
 	float lumaMax = max(lumaM, max(max(lumaNW, lumaNE), max(lumaSW, lumaSE)));
@@ -267,7 +267,7 @@ vec4 apply_fxaa(vec4 color, vec2 uv_interp, vec2 pixel_size) {
 	vec4 rgbA = 0.5 * (texture2DLod(source, uv_interp + dir * (1.0 / 3.0 - 0.5), 0.0) + texture2DLod(source, uv_interp + dir * (2.0 / 3.0 - 0.5), 0.0));
 	vec4 rgbB = rgbA * 0.5 + 0.25 * (texture2DLod(source, uv_interp + dir * -0.5, 0.0) + texture2DLod(source, uv_interp + dir * 0.5, 0.0));
 
-	float lumaB = dot(rgbB.rgb, luma) - ((1 - rgbB.a) / 8.0);
+	float lumaB = dot(rgbB.rgb, luma) - ((1.0 - rgbB.a) / 8.0);
 	vec4 color_output = ((lumaB < lumaMin) || (lumaB > lumaMax)) ? rgbA : rgbB;
 	if (color_output.a == 0.0) {
 		color_output.rgb = vec3(0.0);

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3742,7 +3742,8 @@ void RasterizerSceneGLES3::_post_process(Environment *env, const CameraMatrix &p
 		if (composite_from != storage->frame.current_rt->buffers.diffuse) {
 			glEnable(GL_BLEND);
 			glBlendEquation(GL_FUNC_ADD);
-			glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+			// Alpha was used by the horizontal pass, it should not carry over.
+			glBlendFuncSeparate(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA, GL_ZERO, GL_ONE);
 
 		} else {
 			glActiveTexture(GL_TEXTURE2);

--- a/drivers/gles3/shaders/effect_blur.glsl
+++ b/drivers/gles3/shaders/effect_blur.glsl
@@ -240,7 +240,6 @@ void main() {
 	vec4 color_accum = vec4(0.0);
 
 	float max_accum = 0.0;
-	float k_accum = 0.0;
 
 	for (int i = 0; i < dof_kernel_size; i++) {
 		int int_ofs = i - dof_kernel_from;
@@ -250,7 +249,6 @@ void main() {
 		float tap_k = dof_kernel[i];
 
 		vec4 tap_color = textureLod(source_color, tap_uv, 0.0);
-		float w = tap_color.a;
 
 		float tap_depth = texture(dof_source_depth, tap_uv, 0.0).r;
 		tap_depth = tap_depth * 2.0 - 1.0;
@@ -270,14 +268,9 @@ void main() {
 
 		max_accum = max(max_accum, tap_amount * ofs_influence);
 
-		k_accum += w;
-		tap_color.rgb *= w;
 		color_accum += tap_color * tap_k;
 	}
 
-	if (k_accum > 0.0) {
-		color_accum.rgb /= k_accum / dof_kernel_size;
-	}
 	color_accum.a = max(color_accum.a, sqrt(max_accum));
 
 #ifdef DOF_NEAR_BLUR_MERGE

--- a/drivers/gles3/shaders/tonemap.glsl
+++ b/drivers/gles3/shaders/tonemap.glsl
@@ -292,7 +292,7 @@ vec4 apply_glow(vec4 color, vec3 glow) { // apply glow using the selected blendi
 #ifndef USE_GLOW_SOFTLIGHT // softlight has no effect on black color
 	// compute the alpha from glow
 	float a = max(max(glow.r, glow.g), glow.b);
-	color.a = a + color.a * (1 - a);
+	color.a = a + color.a * (1.0 - a);
 	if (color.a == 0.0) {
 		color.rgb = vec3(0.0);
 	} else if (color.a < 1.0) {
@@ -330,10 +330,10 @@ vec4 apply_fxaa(vec4 color, float exposure, vec2 uv_interp, vec2 pixel_size) {
 	vec4 rgbSE = textureLod(source, uv_interp + vec2(1.0, 1.0) * pixel_size, 0.0);
 	vec3 rgbM = color.rgb;
 	vec3 luma = vec3(0.299, 0.587, 0.114);
-	float lumaNW = dot(rgbNW.rgb * exposure, luma) - ((1 - rgbNW.a) / 8.0);
-	float lumaNE = dot(rgbNE.rgb * exposure, luma) - ((1 - rgbNE.a) / 8.0);
-	float lumaSW = dot(rgbSW.rgb * exposure, luma) - ((1 - rgbSW.a) / 8.0);
-	float lumaSE = dot(rgbSE.rgb * exposure, luma) - ((1 - rgbSE.a) / 8.0);
+	float lumaNW = dot(rgbNW.rgb * exposure, luma) - ((1.0 - rgbNW.a) / 8.0);
+	float lumaNE = dot(rgbNE.rgb * exposure, luma) - ((1.0 - rgbNE.a) / 8.0);
+	float lumaSW = dot(rgbSW.rgb * exposure, luma) - ((1.0 - rgbSW.a) / 8.0);
+	float lumaSE = dot(rgbSE.rgb * exposure, luma) - ((1.0 - rgbSE.a) / 8.0);
 	float lumaM = dot(rgbM * exposure, luma) - (color.a / 8.0);
 	float lumaMin = min(lumaM, min(min(lumaNW, lumaNE), min(lumaSW, lumaSE)));
 	float lumaMax = max(lumaM, max(max(lumaNW, lumaNE), max(lumaSW, lumaSE)));
@@ -355,7 +355,7 @@ vec4 apply_fxaa(vec4 color, float exposure, vec2 uv_interp, vec2 pixel_size) {
 	vec4 rgbA = 0.5 * exposure * (textureLod(source, uv_interp + dir * (1.0 / 3.0 - 0.5), 0.0) + textureLod(source, uv_interp + dir * (2.0 / 3.0 - 0.5), 0.0));
 	vec4 rgbB = rgbA * 0.5 + 0.25 * exposure * (textureLod(source, uv_interp + dir * -0.5, 0.0) + textureLod(source, uv_interp + dir * 0.5, 0.0));
 
-	float lumaB = dot(rgbB.rgb, luma) - ((1 - rgbB.a) / 8.0);
+	float lumaB = dot(rgbB.rgb, luma) - ((1.0 - rgbB.a) / 8.0);
 	vec4 color_output = ((lumaB < lumaMin) || (lumaB > lumaMax)) ? rgbA : rgbB;
 	if (color_output.a == 0.0) {
 		color_output.rgb = vec3(0.0);


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/61165 and fixes https://github.com/godotengine/godot/issues/61167

Both bugs introduced by https://github.com/godotengine/godot/pull/54585

The tonemapping bug comes from the ANGLE shader compiler being strictly compliant with the GLSL specification and refusing to subtract a float from an int. The solution is to just use floats.

The DoF bug is more subtle. https://github.com/godotengine/godot/pull/54585 allows some post-effects to run with a transparent background. However, DoF near overrides the alpha channel of the backbuffer to pass extra information from the horizontal pass to the vertical pass. This invalidates the alpha values the alpha channel of the buffer. The solution is to ignore alpha when writing out the vertical pass. This achieves two things:
1. the dark artifact is gone becuase the buffer maintains its alpha of 1
2. DoF will still work on a transparent VP, it just won't look totally correct as the blended alpha is ignored. 

To properly implement DoF with a transparent Viewport we will need another buffer. Since this is something that we didn't support prior to 3.5 and have had very little demand to support, I do not think we should attempt a full implementation before 3.5. If there is strong user demand for DoF with a transparent viewport then we can consider adding it in the nect release.
