### PR TITLE
Fix an wrong behavior when selection a link in RichTextLabel

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1841,8 +1841,7 @@ void RichTextLabel::gui_input(const Ref<InputEvent> &p_event) {
 						deselect();
 					}
 				}
-
-				if (!b->is_double_click() && !scroll_updated) {
+				if (!b->is_double_click() && !scroll_updated && !selection.active) {
 					Item *c_item = nullptr;
 
 					bool outside = true;


### PR DESCRIPTION
In relation to issue: #61119 
I add a check for when select over a link. Before this PR, when we start to select text, and end over a link, it would act as if you press the link (moving as to a different page in case of Docs Help pages). With this PR, it now possible to select text even if it is a link, without issues.

It is probably possible to push this change to 3.X branch too, from a quick look, it seems the same code as in main branch.

*Bugsquad edit:*
- Fixes #61119.