### PR TITLE
[3.x] Properly clean `button_add_item` ref in Dict property editor

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -820,6 +820,7 @@ void EditorPropertyDictionary::update_property() {
 		if (vbox) {
 			set_bottom_editor(nullptr);
 			memdelete(vbox);
+			button_add_item = nullptr;
 			vbox = nullptr;
 		}
 		return;
@@ -1119,6 +1120,7 @@ void EditorPropertyDictionary::update_property() {
 		if (vbox) {
 			set_bottom_editor(nullptr);
 			memdelete(vbox);
+			button_add_item = nullptr;
 			vbox = nullptr;
 		}
 	}


### PR DESCRIPTION
Fixes #61186

The issue is the same as #59152 on `master`, so backporting the fix.

p.s. The array property editor does not have the add element button on `3.x`.