### PR TITLE
Add properties to disable top/bottom cap generation in CylinderMesh

### DIFF
--- a/doc/classes/CylinderMesh.xml
+++ b/doc/classes/CylinderMesh.xml
@@ -10,7 +10,15 @@
 	</tutorials>
 	<members>
 		<member name="bottom_radius" type="float" setter="set_bottom_radius" getter="get_bottom_radius" default="0.5">
-			Bottom radius of the cylinder. If set to [code]0.0[/code], the bottom faces will not be generated, resulting in a conic shape.
+			Bottom radius of the cylinder. If set to [code]0.0[/code], the bottom faces will not be generated, resulting in a conic shape. See also [member cap_bottom].
+		</member>
+		<member name="cap_bottom" type="bool" setter="set_cap_bottom" getter="is_cap_bottom" default="true">
+			If [code]true[/code], generates a cap at the bottom of the cylinder. This can be set to [code]false[/code] to speed up generation and rendering when the cap is never seen by the camera. See also [member bottom_radius].
+			[b]Note:[/b] If [member bottom_radius] is [code]0.0[/code], cap generation is always skipped even if [member cap_bottom] is [code]true[/code].
+		</member>
+		<member name="cap_top" type="bool" setter="set_cap_top" getter="is_cap_top" default="true">
+			If [code]true[/code], generates a cap at the top of the cylinder. This can be set to [code]false[/code] to speed up generation and rendering when the cap is never seen by the camera. See also [member top_radius].
+			[b]Note:[/b] If [member top_radius] is [code]0.0[/code], cap generation is always skipped even if [member cap_top] is [code]true[/code].
 		</member>
 		<member name="height" type="float" setter="set_height" getter="get_height" default="2.0">
 			Full height of the cylinder.
@@ -22,7 +30,7 @@
 			Number of edge rings along the height of the cylinder. Changing [member rings] does not have any visual impact unless a shader or procedural mesh tool is used to alter the vertex data. Higher values result in more subdivisions, which can be used to create smoother-looking effects with shaders or procedural mesh tools (at the cost of performance). When not altering the vertex data using a shader or procedural mesh tool, [member rings] should be kept to its default value.
 		</member>
 		<member name="top_radius" type="float" setter="set_top_radius" getter="get_top_radius" default="0.5">
-			Top radius of the cylinder. If set to [code]0.0[/code], the top faces will not be generated, resulting in a conic shape.
+			Top radius of the cylinder. If set to [code]0.0[/code], the top faces will not be generated, resulting in a conic shape. See also [member cap_top].
 		</member>
 	</members>
 </class>

--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -745,10 +745,10 @@ BoxMesh::BoxMesh() {}
 */
 
 void CylinderMesh::_create_mesh_array(Array &p_arr) const {
-	create_mesh_array(p_arr, top_radius, bottom_radius, height, radial_segments, rings);
+	create_mesh_array(p_arr, top_radius, bottom_radius, height, radial_segments, rings, cap_top, cap_bottom);
 }
 
-void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float bottom_radius, float height, int radial_segments, int rings) {
+void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float bottom_radius, float height, int radial_segments, int rings, bool cap_top, bool cap_bottom) {
 	int i, j, prevrow, thisrow, point;
 	float x, y, z, u, v, radius;
 
@@ -806,7 +806,7 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 	};
 
 	// add top
-	if (top_radius > 0.0) {
+	if (cap_top && top_radius > 0.0) {
 		y = height * 0.5;
 
 		thisrow = point;
@@ -842,7 +842,7 @@ void CylinderMesh::create_mesh_array(Array &p_arr, float top_radius, float botto
 	};
 
 	// add bottom
-	if (bottom_radius > 0.0) {
+	if (cap_bottom && bottom_radius > 0.0) {
 		y = height * -0.5;
 
 		thisrow = point;
@@ -897,11 +897,19 @@ void CylinderMesh::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_rings", "rings"), &CylinderMesh::set_rings);
 	ClassDB::bind_method(D_METHOD("get_rings"), &CylinderMesh::get_rings);
 
+	ClassDB::bind_method(D_METHOD("set_cap_top", "cap_top"), &CylinderMesh::set_cap_top);
+	ClassDB::bind_method(D_METHOD("is_cap_top"), &CylinderMesh::is_cap_top);
+
+	ClassDB::bind_method(D_METHOD("set_cap_bottom", "cap_bottom"), &CylinderMesh::set_cap_bottom);
+	ClassDB::bind_method(D_METHOD("is_cap_bottom"), &CylinderMesh::is_cap_bottom);
+
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "top_radius", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater,suffix:m"), "set_top_radius", "get_top_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "bottom_radius", PROPERTY_HINT_RANGE, "0,100,0.001,or_greater,suffix:m"), "set_bottom_radius", "get_bottom_radius");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "height", PROPERTY_HINT_RANGE, "0.001,100,0.001,or_greater,suffix:m"), "set_height", "get_height");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "radial_segments", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_radial_segments", "get_radial_segments");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "rings", PROPERTY_HINT_RANGE, "1,100,1,or_greater"), "set_rings", "get_rings");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cap_top"), "set_cap_top", "is_cap_top");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "cap_bottom"), "set_cap_bottom", "is_cap_bottom");
 }
 
 void CylinderMesh::set_top_radius(const float p_radius) {
@@ -947,6 +955,24 @@ void CylinderMesh::set_rings(const int p_rings) {
 
 int CylinderMesh::get_rings() const {
 	return rings;
+}
+
+void CylinderMesh::set_cap_top(bool p_cap_top) {
+	cap_top = p_cap_top;
+	_request_update();
+}
+
+bool CylinderMesh::is_cap_top() const {
+	return cap_top;
+}
+
+void CylinderMesh::set_cap_bottom(bool p_cap_bottom) {
+	cap_bottom = p_cap_bottom;
+	_request_update();
+}
+
+bool CylinderMesh::is_cap_bottom() const {
+	return cap_bottom;
 }
 
 CylinderMesh::CylinderMesh() {}

--- a/scene/resources/primitive_meshes.h
+++ b/scene/resources/primitive_meshes.h
@@ -183,13 +183,15 @@ private:
 	float height = 2.0;
 	int radial_segments = 64;
 	int rings = 4;
+	bool cap_top = true;
+	bool cap_bottom = true;
 
 protected:
 	static void _bind_methods();
 	virtual void _create_mesh_array(Array &p_arr) const override;
 
 public:
-	static void create_mesh_array(Array &p_arr, float top_radius, float bottom_radius, float height, int radial_segments = 64, int rings = 4);
+	static void create_mesh_array(Array &p_arr, float top_radius, float bottom_radius, float height, int radial_segments = 64, int rings = 4, bool cap_top = true, bool cap_bottom = true);
 
 	void set_top_radius(const float p_radius);
 	float get_top_radius() const;
@@ -205,6 +207,12 @@ public:
 
 	void set_rings(const int p_rings);
 	int get_rings() const;
+
+	void set_cap_top(bool p_cap_top);
+	bool is_cap_top() const;
+
+	void set_cap_bottom(bool p_cap_bottom);
+	bool is_cap_bottom() const;
 
 	CylinderMesh();
 };


### PR DESCRIPTION
This closes https://github.com/godotengine/godot-proposals/issues/4560.

**Testing project:** https://0x0.st/oaah.zip

I've also tried to add a similar property to SphereMesh (when enabling the hemisphere property), but couldn't figure it out due to how its cap is generated. It's just a flattened version of sphere vertices, which is less efficient to generate and render:

![2022-05-20_00 23 15](https://user-images.githubusercontent.com/180032/169414472-44ad3826-7cdd-44f7-9180-db417a8942c3.png)

Normals on the edge also look beveled, which looks nice but doesn't occur in other primitive meshes (so it's inconsistent).

## Preview

![2022-05-20_00 23 41](https://user-images.githubusercontent.com/180032/169414478-1db934db-d81b-48a3-84fb-6e8a0e6874c2.png)