### PR TITLE
Tweak the default font's fake italic to better match Open Sans Italic

### DIFF
--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -1069,6 +1069,7 @@ void make_default_theme(float p_scale, Ref<Font> p_font, TextServer::SubpixelPos
 		bold_font.instantiate();
 		for (int i = 0; i < default_font->get_data_count(); i++) {
 			Ref<FontData> data = default_font->get_data(i)->duplicate();
+			// Try to match OpenSans ExtraBold.
 			data->set_embolden(1.2);
 			bold_font->add_data(data);
 		}
@@ -1076,15 +1077,17 @@ void make_default_theme(float p_scale, Ref<Font> p_font, TextServer::SubpixelPos
 		bold_italics_font.instantiate();
 		for (int i = 0; i < default_font->get_data_count(); i++) {
 			Ref<FontData> data = default_font->get_data(i)->duplicate();
+			// Try to match OpenSans ExtraBold Italic.
 			data->set_embolden(1.2);
-			data->set_transform(Transform2D(1.0, 0.4, 0.0, 1.0, 0.0, 0.0));
+			data->set_transform(Transform2D(1.0, 0.2, 0.0, 1.0, 0.0, 0.0));
 			bold_italics_font->add_data(data);
 		}
 
 		italics_font.instantiate();
 		for (int i = 0; i < default_font->get_data_count(); i++) {
 			Ref<FontData> data = default_font->get_data(i)->duplicate();
-			data->set_transform(Transform2D(1.0, 0.4, 0.0, 1.0, 0.0, 0.0));
+			// Try to match OpenSans Italic.
+			data->set_transform(Transform2D(1.0, 0.2, 0.0, 1.0, 0.0, 0.0));
 			italics_font->add_data(data);
 		}
 	}


### PR DESCRIPTION
We could get even closer to the real italic font by decreasing glyph spacing by 1 on the fake italic fonts, but I haven't figured that out yet.

**Note:** Not cherry-pickable to `3.x` as fake bold/italic isn't implemented there.

**Testing project:** https://0x0.st/oaBb.zip

## Preview

*Using the `canvas_items` stretch mode and `expand` stretch aspect.*

*Left: Fake bold/italic, Right: Real bold/italic (OpenSans ExtraBold)*

### 1024×600

| Before | After |
|-|-|
| ![2022-05-20_00 44 44](https://user-images.githubusercontent.com/180032/169420686-c6fa4df9-030a-4519-b8d8-23590ecf0db1.png) | ![2022-05-20_01 02 34](https://user-images.githubusercontent.com/180032/169420693-cafd50d9-6d41-4be7-991b-6e6b9f40194d.png) |

### 2560×1440

| Before | After |
|-|-|
| ![2022-05-20_00 44 49](https://user-images.githubusercontent.com/180032/169420689-62ab915d-5815-42ae-9916-4c9ca6787a89.png) | ![2022-05-20_01 02 24](https://user-images.githubusercontent.com/180032/169420691-27488ddf-8064-4f2e-9c6a-e3a38388c02e.png) |