### PR TITLE
[GLES3] Sky fixes

### DIFF
--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -855,7 +855,7 @@ void RasterizerSceneGLES3::_setup_sky(Environment *p_env, RID p_render_buffers, 
 
 			if (light_data_dirty) {
 				glBindBufferBase(GL_UNIFORM_BUFFER, SKY_DIRECTIONAL_LIGHT_UNIFORM_LOCATION, sky_globals.directional_light_buffer);
-				glBufferSubData(GL_UNIFORM_BUFFER, 0, sizeof(DirectionalLightData) * sky_globals.directional_light_count, sky_globals.directional_lights);
+				glBufferData(GL_UNIFORM_BUFFER, sizeof(DirectionalLightData) * sky_globals.max_directional_lights, sky_globals.directional_lights, GL_STREAM_DRAW);
 				glBindBuffer(GL_UNIFORM_BUFFER, 0);
 
 				DirectionalLightData *temp = sky_globals.last_frame_directional_lights;

--- a/drivers/gles3/shaders/cubemap_filter.glsl
+++ b/drivers/gles3/shaders/cubemap_filter.glsl
@@ -141,7 +141,7 @@ void main() {
 	vec3 N = texelCoordToVec(uv, face_id);
 
 #ifdef MODE_DIRECT_WRITE
-	frag_color = vec4(textureCubeLod(source_cube, N, 0.0).rgb, 1.0);
+	frag_color = vec4(textureLod(source_cube, N, 0.0).rgb, 1.0);
 #else
 
 	vec4 sum = vec4(0.0);
@@ -171,7 +171,7 @@ void main() {
 
 			float mipLevel = roughness == 0.0 ? 0.0 : 0.5 * log2(solid_angle_sample / solid_angle_texel);
 
-			vec3 val = textureCubeLod(source_cube, L, mipLevel).rgb;
+			vec3 val = textureLod(source_cube, L, mipLevel).rgb;
 			// Mix using linear
 			val = srgb_to_linear(val);
 

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -812,7 +812,7 @@ vec4 fog_process(vec3 vertex) {
 		// mip_level always reads from the second mipmap and higher so the fog is always slightly blurred
 		float mip_level = mix(1.0 / MAX_ROUGHNESS_LOD, 1.0, 1.0 - (abs(vertex.z) - scene_data.z_near) / (scene_data.z_far - scene_data.z_near));
 
-		sky_fog_color = textureCubeLod(radiance_map, cube_view, mip_level * RADIANCE_MAX_LOD).rgb;
+		sky_fog_color = textureLod(radiance_map, cube_view, mip_level * RADIANCE_MAX_LOD).rgb;
 
 		fog_color = mix(fog_color, sky_fog_color, scene_data.fog_aerial_perspective);
 	}
@@ -1031,7 +1031,7 @@ void main() {
 #endif
 		float horizon = min(1.0 + dot(ref_vec, normal), 1.0);
 		ref_vec = scene_data.radiance_inverse_xform * ref_vec;
-		specular_light = textureCubeLod(radiance_map, ref_vec, roughness * RADIANCE_MAX_LOD).rgb;
+		specular_light = textureLod(radiance_map, ref_vec, roughness * RADIANCE_MAX_LOD).rgb;
 		specular_light = srgb_to_linear(specular_light);
 		specular_light *= horizon * horizon;
 		specular_light *= scene_data.ambient_light_color_energy.a;
@@ -1052,7 +1052,7 @@ void main() {
 #ifdef USE_RADIANCE_MAP
 		if (scene_data.use_ambient_cubemap) {
 			vec3 ambient_dir = scene_data.radiance_inverse_xform * normal;
-			vec3 cubemap_ambient = textureCubeLod(radiance_map, ambient_dir, RADIANCE_MAX_LOD).rgb;
+			vec3 cubemap_ambient = textureLod(radiance_map, ambient_dir, RADIANCE_MAX_LOD).rgb;
 			cubemap_ambient = srgb_to_linear(cubemap_ambient);
 			ambient_light = mix(ambient_light, cubemap_ambient * scene_data.ambient_light_color_energy.a, scene_data.ambient_color_sky_mix);
 		}


### PR DESCRIPTION
Fix sky updating when DirectionalLight mode changed and shader compatibility for certain drivers

When DirectionalLight changed from Sky only or Sky and Light to Light only, it was still appearing in the sky. This came from the fact that the only portion of the DirectionalLight buffer that was updated was for active lights, if active lights went down to 0, the buffer never got cleared.

textureCubeLod is a legacy function that is deprecated in OpenGL 3.3 /ES 3.0, some drivers do not support using it in the core profile.
