### PR TITLE
Fix project manager display at small window sizes (3.x)

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -154,7 +154,7 @@ EditorAbout::EditorAbout() {
 	hbc->add_child(version_info_vbc);
 
 	TabContainer *tc = memnew(TabContainer);
-	tc->set_custom_minimum_size(Size2(950, 400) * EDSCALE);
+	tc->set_custom_minimum_size(Size2(400, 200) * EDSCALE);
 	tc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	vbc->add_child(tc);
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1341,6 +1341,10 @@ void EditorAssetLibrary::disable_community_support() {
 	support->get_popup()->set_item_checked(SUPPORT_COMMUNITY, false);
 }
 
+void EditorAssetLibrary::set_columns(const int p_columns) {
+	asset_items->set_columns(p_columns);
+}
+
 void EditorAssetLibrary::_bind_methods() {
 	ClassDB::bind_method("_http_request_completed", &EditorAssetLibrary::_http_request_completed);
 	ClassDB::bind_method("_select_asset", &EditorAssetLibrary::_select_asset);
@@ -1426,8 +1430,8 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	search_hb2->add_child(sort);
 
 	sort->set_h_size_flags(SIZE_EXPAND_FILL);
+	sort->set_clip_text(true);
 	sort->connect("item_selected", this, "_rerun_search");
-
 	search_hb2->add_child(memnew(VSeparator));
 
 	search_hb2->add_child(memnew(Label(TTR("Category:") + " ")));
@@ -1435,6 +1439,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	categories->add_item(TTR("All"));
 	search_hb2->add_child(categories);
 	categories->set_h_size_flags(SIZE_EXPAND_FILL);
+	categories->set_clip_text(true);
 	categories->connect("item_selected", this, "_rerun_search");
 
 	search_hb2->add_child(memnew(VSeparator));
@@ -1448,6 +1453,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	search_hb2->add_child(repository);
 	repository->set_h_size_flags(SIZE_EXPAND_FILL);
+	repository->set_clip_text(true);
 
 	search_hb2->add_child(memnew(VSeparator));
 

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -303,6 +303,7 @@ protected:
 
 public:
 	void disable_community_support();
+	void set_columns(int p_columns);
 
 	EditorAssetLibrary(bool p_templates_only = false);
 };

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1987,7 +1987,7 @@ void ProjectManager::_global_menu_action(const Variant &p_id, const Variant &p_m
 void ProjectManager::_open_selected_projects() {
 	// Show loading text to tell the user that the project manager is busy loading.
 	// This is especially important for the HTML5 project manager.
-	loading_label->set_modulate(Color(1, 1, 1));
+	loading_label->show();
 
 	const Set<String> &selected_list = _project_list->get_selected_project_keys();
 
@@ -2472,8 +2472,8 @@ ProjectManager::ProjectManager() {
 	loading_label->add_font_override("font", get_font("bold", "EditorFonts"));
 	loading_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 	sort_filters->add_child(loading_label);
-	// Hide the label but make it still take up space. This prevents reflows when showing the label.
-	loading_label->set_modulate(Color(0, 0, 0, 0));
+	// The loading label is shown later.
+	loading_label->hide();
 
 	Label *sort_label = memnew(Label);
 	sort_label->set_text(TTR("Sort:"));
@@ -2488,7 +2488,6 @@ ProjectManager::ProjectManager() {
 	project_order_filter->set_filter_size(150);
 	sort_filters->add_child(project_order_filter);
 	project_order_filter->connect("filter_changed", this, "_on_order_option_changed");
-	project_order_filter->set_custom_minimum_size(Size2(180, 10) * EDSCALE);
 
 	int projects_sorting_order = (int)EditorSettings::get_singleton()->get("project_manager/sorting_order");
 	project_order_filter->set_filter_option((ProjectListFilter::FilterOption)projects_sorting_order);
@@ -2496,7 +2495,7 @@ ProjectManager::ProjectManager() {
 	project_filter = memnew(ProjectListFilter);
 	project_filter->add_search_box();
 	project_filter->connect("filter_changed", this, "_on_filter_option_changed");
-	project_filter->set_custom_minimum_size(Size2(280, 10) * EDSCALE);
+	project_filter->set_h_size_flags(SIZE_EXPAND_FILL);
 	sort_filters->add_child(project_filter);
 
 	search_tree_vb->add_child(sort_filters);
@@ -2629,6 +2628,12 @@ ProjectManager::ProjectManager() {
 	language_btn = memnew(OptionButton);
 	language_btn->set_flat(true);
 	language_btn->set_focus_mode(Control::FOCUS_NONE);
+#ifdef ANDROID_ENABLED
+	// The language selection dropdown doesn't work on Android (as the setting isn't saved), see GH-60353.
+	// Also, the dropdown it spawns is very tall and can't be scrolled without a hardware mouse.
+	// Hiding the language selection dropdown also leaves more space for the version label to display.
+	language_btn->hide();
+#endif
 
 	Vector<String> editor_languages;
 	List<PropertyInfo> editor_settings_properties;
@@ -2705,7 +2710,7 @@ ProjectManager::ProjectManager() {
 	gui_base->add_child(ask_update_settings);
 
 	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
-	OS::get_singleton()->set_min_window_size(Size2(750, 420) * EDSCALE);
+	OS::get_singleton()->set_min_window_size(Size2(520, 350) * EDSCALE);
 
 	// Resize the bootsplash window based on editor display scale.
 	const float scale_factor = MAX(1, EDSCALE);

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1772,6 +1772,16 @@ void ProjectManager::_notification(int p_what) {
 			if (open_templates->is_visible()) {
 				open_templates->popup_centered_minsize();
 			}
+			real_t size = get_size().x / EDSCALE;
+			asset_library->set_columns(size < 1000 ? 1 : 2);
+			// Adjust names of tabs to fit the new size.
+			if (size < 650) {
+				local_projects_hb->set_name(TTR("Local"));
+				asset_library->set_name(TTR("Asset Library"));
+			} else {
+				local_projects_hb->set_name(TTR("Local Projects"));
+				asset_library->set_name(TTR("Asset Library Projects"));
+			}
 		} break;
 		case NOTIFICATION_READY: {
 			if (_project_list->get_project_count() == 0 && StreamPeerSSL::is_available()) {
@@ -2449,15 +2459,12 @@ ProjectManager::ProjectManager() {
 	tabs->set_tab_align(TabContainer::ALIGN_LEFT);
 	tabs->connect("tab_changed", this, "_on_tab_changed");
 
-	HBoxContainer *tree_hb = memnew(HBoxContainer);
-	projects_hb = tree_hb;
-
-	projects_hb->set_name(TTR("Local Projects"));
-
-	tabs->add_child(tree_hb);
+	local_projects_hb = memnew(HBoxContainer);
+	local_projects_hb->set_name(TTR("Local Projects"));
+	tabs->add_child(local_projects_hb);
 
 	VBoxContainer *search_tree_vb = memnew(VBoxContainer);
-	tree_hb->add_child(search_tree_vb);
+	local_projects_hb->add_child(search_tree_vb);
 	search_tree_vb->set_h_size_flags(SIZE_EXPAND_FILL);
 
 	HBoxContainer *sort_filters = memnew(HBoxContainer);
@@ -2507,7 +2514,7 @@ ProjectManager::ProjectManager() {
 
 	VBoxContainer *tree_vb = memnew(VBoxContainer);
 	tree_vb->set_custom_minimum_size(Size2(120, 120));
-	tree_hb->add_child(tree_vb);
+	local_projects_hb->add_child(tree_vb);
 
 	Button *open = memnew(Button);
 	open->set_text(TTR("Edit"));

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -77,7 +77,7 @@ class ProjectManager : public Control {
 	AcceptDialog *dialog_error;
 	ProjectDialog *npdialog;
 
-	HBoxContainer *projects_hb;
+	HBoxContainer *local_projects_hb;
 	TabContainer *tabs;
 	ProjectList *_project_list;
 


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/61211.

- Don't use minimum size for project order/filter controls. This also allows the filter field to become longer at large window sizes.
- Hide the loading label instead of changing its opacity. This causes a reflow during loading, but this is preferable to having the UI overflow.
- Hide the About button on Android as it will spawn a dialog that's too large to be closed on most screens.
- Hide the language dropdown on Android as it doesn't work correctly.

This allows the project manager to be displayed correctly at much lower window sizes than previously.

This partially addresses https://github.com/godotengine/godot/issues/60728. Further changes need to be made to the editor itself to reduce cases of UI elements overlapping (including preventing access to the About dialog within the editor).