### PR TITLE
Fix project manager display at small window sizes

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2095,7 +2095,7 @@ void ProjectManager::_confirm_update_settings() {
 void ProjectManager::_open_selected_projects() {
 	// Show loading text to tell the user that the project manager is busy loading.
 	// This is especially important for the HTML5 project manager.
-	loading_label->set_modulate(Color(1, 1, 1));
+	loading_label->show();
 
 	const RBSet<String> &selected_list = _project_list->get_selected_project_keys();
 
@@ -2592,8 +2592,8 @@ ProjectManager::ProjectManager() {
 		loading_label->add_theme_font_override("font", get_theme_font(SNAME("bold"), SNAME("EditorFonts")));
 		loading_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		hb->add_child(loading_label);
-		// Hide the label but make it still take up space. This prevents reflows when showing the label.
-		loading_label->set_modulate(Color(0, 0, 0, 0));
+		// The loading label is shown later.
+		loading_label->hide();
 
 		Label *sort_label = memnew(Label);
 		sort_label->set_text(TTR("Sort:"));
@@ -2601,7 +2601,7 @@ ProjectManager::ProjectManager() {
 
 		filter_option = memnew(OptionButton);
 		filter_option->set_clip_text(true);
-		filter_option->set_custom_minimum_size(Size2(150 * EDSCALE, 10 * EDSCALE));
+		filter_option->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 		filter_option->connect("item_selected", callable_mp(this, &ProjectManager::_on_order_option_changed));
 		hb->add_child(filter_option);
 
@@ -2727,6 +2727,12 @@ ProjectManager::ProjectManager() {
 		language_btn->set_icon(get_theme_icon(SNAME("Environment"), SNAME("EditorIcons")));
 		language_btn->set_focus_mode(Control::FOCUS_NONE);
 		language_btn->connect("item_selected", callable_mp(this, &ProjectManager::_language_selected));
+#ifdef ANDROID_ENABLED
+		// The language selection dropdown doesn't work on Android (as the setting isn't saved), see GH-60353.
+		// Also, the dropdown it spawns is very tall and can't be scrolled without a hardware mouse.
+		// Hiding the language selection dropdown also leaves more space for the version label to display.
+		language_btn->hide();
+#endif
 
 		Vector<String> editor_languages;
 		List<PropertyInfo> editor_settings_properties;
@@ -2869,8 +2875,8 @@ ProjectManager::ProjectManager() {
 
 	SceneTree::get_singleton()->get_root()->connect("files_dropped", callable_mp(this, &ProjectManager::_files_dropped));
 
-	// Define a minimum window size to prevent UI elements from overlapping or being cut off
-	DisplayServer::get_singleton()->window_set_min_size(Size2(750, 420) * EDSCALE);
+	// Define a minimum window size to prevent UI elements from overlapping or being cut off.
+	DisplayServer::get_singleton()->window_set_min_size(Size2(520, 350) * EDSCALE);
 
 	// Resize the bootsplash window based on Editor display scale EDSCALE.
 	float scale_factor = MAX(1, EDSCALE);


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/61210.

- Don't use minimum size for project order/filter controls. This also allows the filter field to become longer at large window sizes.
- Hide the loading label instead of changing its opacity. This causes a reflow during loading, but this is preferable to having the UI overflow.
- Hide the About button on Android as it will spawn a dialog that's too large to be closed on most screens.
- Hide the language dropdown on Android as it doesn't work correctly.

This allows the project manager to be displayed correctly at much lower window sizes than previously.

This partially addresses https://github.com/godotengine/godot/issues/60728. Further changes need to be made to the editor itself to reduce cases of UI elements overlapping (including preventing access to the About dialog within the editor).