### PR TITLE
Tweaks to improve the Project Manager display at small sizes

### DIFF
--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -161,7 +161,7 @@ EditorAbout::EditorAbout() {
 
 	TabContainer *tc = memnew(TabContainer);
 	tc->set_tab_alignment(TabBar::ALIGNMENT_CENTER);
-	tc->set_custom_minimum_size(Size2(950, 400) * EDSCALE);
+	tc->set_custom_minimum_size(Size2(400, 200) * EDSCALE);
 	tc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	vbc->add_child(tc);
 

--- a/editor/plugins/asset_library_editor_plugin.cpp
+++ b/editor/plugins/asset_library_editor_plugin.cpp
@@ -1379,6 +1379,10 @@ void EditorAssetLibrary::disable_community_support() {
 	support->get_popup()->set_item_checked(SUPPORT_COMMUNITY, false);
 }
 
+void EditorAssetLibrary::set_columns(const int p_columns) {
+	asset_items->set_columns(p_columns);
+}
+
 void EditorAssetLibrary::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("install_asset", PropertyInfo(Variant::STRING, "zip_path"), PropertyInfo(Variant::STRING, "name")));
 }
@@ -1446,6 +1450,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	search_hb2->add_child(sort);
 
 	sort->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	sort->set_clip_text(true);
 	sort->connect("item_selected", callable_mp(this, &EditorAssetLibrary::_rerun_search));
 
 	search_hb2->add_child(memnew(VSeparator));
@@ -1455,6 +1460,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 	categories->add_item(TTR("All"));
 	search_hb2->add_child(categories);
 	categories->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	categories->set_clip_text(true);
 	categories->connect("item_selected", callable_mp(this, &EditorAssetLibrary::_rerun_search));
 
 	search_hb2->add_child(memnew(VSeparator));
@@ -1468,6 +1474,7 @@ EditorAssetLibrary::EditorAssetLibrary(bool p_templates_only) {
 
 	search_hb2->add_child(repository);
 	repository->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	repository->set_clip_text(true);
 
 	search_hb2->add_child(memnew(VSeparator));
 

--- a/editor/plugins/asset_library_editor_plugin.h
+++ b/editor/plugins/asset_library_editor_plugin.h
@@ -311,6 +311,7 @@ protected:
 
 public:
 	void disable_community_support();
+	void set_columns(int p_columns);
 
 	EditorAssetLibrary(bool p_templates_only = false);
 };

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1884,6 +1884,16 @@ void ProjectManager::_notification(int p_what) {
 			if (open_templates->is_visible()) {
 				open_templates->popup_centered();
 			}
+			real_t size = get_size().x / EDSCALE;
+			asset_library->set_columns(size < 1000 ? 1 : 2);
+			// Adjust names of tabs to fit the new size.
+			if (size < 650) {
+				local_projects_hb->set_name(TTR("Local"));
+				asset_library->set_name(TTR("Asset Library"));
+			} else {
+				local_projects_hb->set_name(TTR("Local Projects"));
+				asset_library->set_name(TTR("Asset Library Projects"));
+			}
 		} break;
 
 		case NOTIFICATION_READY: {
@@ -2567,14 +2577,14 @@ ProjectManager::ProjectManager() {
 	tabs->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
 	tabs->connect("tab_changed", callable_mp(this, &ProjectManager::_on_tab_changed));
 
-	HBoxContainer *projects_hb = memnew(HBoxContainer);
-	projects_hb->set_name(TTR("Local Projects"));
-	tabs->add_child(projects_hb);
+	local_projects_hb = memnew(HBoxContainer);
+	local_projects_hb->set_name(TTR("Local Projects"));
+	tabs->add_child(local_projects_hb);
 
 	{
 		// Projects + search bar
 		VBoxContainer *search_tree_vb = memnew(VBoxContainer);
-		projects_hb->add_child(search_tree_vb);
+		local_projects_hb->add_child(search_tree_vb);
 		search_tree_vb->set_h_size_flags(Control::SIZE_EXPAND_FILL);
 
 		HBoxContainer *hb = memnew(HBoxContainer);
@@ -2630,7 +2640,7 @@ ProjectManager::ProjectManager() {
 		// Project tab side bar
 		VBoxContainer *tree_vb = memnew(VBoxContainer);
 		tree_vb->set_custom_minimum_size(Size2(120, 120));
-		projects_hb->add_child(tree_vb);
+		local_projects_hb->add_child(tree_vb);
 
 		Button *create = memnew(Button);
 		create->set_text(TTR("New Project"));

--- a/editor/project_manager.h
+++ b/editor/project_manager.h
@@ -70,6 +70,7 @@ class ProjectManager : public Control {
 	Button *erase_missing_btn = nullptr;
 	Button *about_btn = nullptr;
 
+	HBoxContainer *local_projects_hb = nullptr;
 	EditorAssetLibrary *asset_library = nullptr;
 
 	EditorFileDialog *scan_dir = nullptr;


### PR DESCRIPTION
* Change the minimum size of the About dialog to allow it to shrink to a smaller but still usable size.
* Change the names of the tabs to either verbose names or shorter names depending on the window size.
* Change the column count of the Asset Library `GridContainer` depending on the window size.
* Enable text clipping on the `OptionButton`s in the Asset Library tab to allow this menu to shrink down farther.

This PR would make sense to merge before #61211. With both of these PRs combined, we can get down to about 520px wide before things start clipping, and it's not trivial to make the Asset Library tab shrink more than that.