### PR TITLE
Rename `CameraEffects` to `CameraEffects3D`

### DIFF
--- a/doc/classes/Camera3D.xml
+++ b/doc/classes/Camera3D.xml
@@ -159,8 +159,8 @@
 		<member name="doppler_tracking" type="int" setter="set_doppler_tracking" getter="get_doppler_tracking" enum="Camera3D.DopplerTracking" default="0">
 			If not [constant DOPPLER_TRACKING_DISABLED], this camera will simulate the [url=https://en.wikipedia.org/wiki/Doppler_effect]Doppler effect[/url] for objects changed in particular [code]_process[/code] methods. See [enum DopplerTracking] for possible values.
 		</member>
-		<member name="effects" type="CameraEffects" setter="set_effects" getter="get_effects">
-			The [CameraEffects] to use for this camera.
+		<member name="effects" type="CameraEffects3D" setter="set_effects" getter="get_effects">
+			The [CameraEffects3D] to use for this camera.
 		</member>
 		<member name="environment" type="Environment" setter="set_environment" getter="get_environment">
 			The [Environment] to use for this camera.

--- a/doc/classes/CameraEffects3D.xml
+++ b/doc/classes/CameraEffects3D.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<class name="CameraEffects" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
+<class name="CameraEffects3D" inherits="Resource" version="4.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../class.xsd">
 	<brief_description>
 		Contains camera-specific effects such as depth of field and exposure override.
 	</brief_description>

--- a/doc/classes/World3D.xml
+++ b/doc/classes/World3D.xml
@@ -10,7 +10,7 @@
 		<link title="Ray-casting">$DOCS_URL/tutorials/physics/ray-casting.html</link>
 	</tutorials>
 	<members>
-		<member name="camera_effects" type="CameraEffects" setter="set_camera_effects" getter="get_camera_effects">
+		<member name="camera_effects" type="CameraEffects3D" setter="set_camera_effects" getter="get_camera_effects">
 		</member>
 		<member name="direct_space_state" type="PhysicsDirectSpaceState3D" setter="" getter="get_direct_space_state">
 			Direct access to the world's physics 3D space state. Used for querying current and potential collisions.

--- a/doc/classes/WorldEnvironment.xml
+++ b/doc/classes/WorldEnvironment.xml
@@ -15,7 +15,7 @@
 		<link title="Third Person Shooter Demo">https://godotengine.org/asset-library/asset/678</link>
 	</tutorials>
 	<members>
-		<member name="camera_effects" type="CameraEffects" setter="set_camera_effects" getter="get_camera_effects">
+		<member name="camera_effects" type="CameraEffects3D" setter="set_camera_effects" getter="get_camera_effects">
 		</member>
 		<member name="environment" type="Environment" setter="set_environment" getter="get_environment">
 			The [Environment] resource used by this [WorldEnvironment], defining the default properties.

--- a/scene/3d/camera_3d.cpp
+++ b/scene/3d/camera_3d.cpp
@@ -402,7 +402,7 @@ Ref<Environment> Camera3D::get_environment() const {
 	return environment;
 }
 
-void Camera3D::set_effects(const Ref<CameraEffects> &p_effects) {
+void Camera3D::set_effects(const Ref<CameraEffects3D> &p_effects) {
 	effects = p_effects;
 	if (effects.is_valid()) {
 		RS::get_singleton()->camera_set_camera_effects(camera, effects->get_rid());
@@ -412,7 +412,7 @@ void Camera3D::set_effects(const Ref<CameraEffects> &p_effects) {
 	_update_camera_mode();
 }
 
-Ref<CameraEffects> Camera3D::get_effects() const {
+Ref<CameraEffects3D> Camera3D::get_effects() const {
 	return effects;
 }
 
@@ -500,7 +500,7 @@ void Camera3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "keep_aspect", PROPERTY_HINT_ENUM, "Keep Width,Keep Height"), "set_keep_aspect_mode", "get_keep_aspect_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "cull_mask", PROPERTY_HINT_LAYERS_3D_RENDER), "set_cull_mask", "get_cull_mask");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "environment", PROPERTY_HINT_RESOURCE_TYPE, "Environment"), "set_environment", "get_environment");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "effects", PROPERTY_HINT_RESOURCE_TYPE, "CameraEffects"), "set_effects", "get_effects");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "effects", PROPERTY_HINT_RESOURCE_TYPE, "CameraEffects3D"), "set_effects", "get_effects");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "h_offset", PROPERTY_HINT_NONE, "suffix:m"), "set_h_offset", "get_h_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "v_offset", PROPERTY_HINT_NONE, "suffix:m"), "set_v_offset", "get_v_offset");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "doppler_tracking", PROPERTY_HINT_ENUM, "Disabled,Idle,Physics"), "set_doppler_tracking", "get_doppler_tracking");

--- a/scene/3d/camera_3d.h
+++ b/scene/3d/camera_3d.h
@@ -33,7 +33,7 @@
 
 #include "scene/3d/node_3d.h"
 #include "scene/3d/velocity_tracker_3d.h"
-#include "scene/resources/camera_effects.h"
+#include "scene/resources/camera_effects_3d.h"
 #include "scene/resources/environment.h"
 
 class Camera3D : public Node3D {
@@ -81,7 +81,7 @@ private:
 	uint32_t layers = 0xfffff;
 
 	Ref<Environment> environment;
-	Ref<CameraEffects> effects;
+	Ref<CameraEffects3D> effects;
 
 	// void _camera_make_current(Node *p_camera);
 	friend class Viewport;
@@ -158,8 +158,8 @@ public:
 	void set_environment(const Ref<Environment> &p_environment);
 	Ref<Environment> get_environment() const;
 
-	void set_effects(const Ref<CameraEffects> &p_effects);
-	Ref<CameraEffects> get_effects() const;
+	void set_effects(const Ref<CameraEffects3D> &p_effects);
+	Ref<CameraEffects3D> get_effects() const;
 
 	void set_keep_aspect_mode(KeepAspect p_aspect);
 	KeepAspect get_keep_aspect_mode() const;

--- a/scene/3d/world_environment.cpp
+++ b/scene/3d/world_environment.cpp
@@ -79,7 +79,7 @@ void WorldEnvironment::_update_current_camera_effects() {
 	if (first) {
 		get_viewport()->find_world_3d()->set_camera_effects(first->camera_effects);
 	} else {
-		get_viewport()->find_world_3d()->set_camera_effects(Ref<CameraEffects>());
+		get_viewport()->find_world_3d()->set_camera_effects(Ref<CameraEffects3D>());
 	}
 
 	get_tree()->call_group_flags(SceneTree::GROUP_CALL_DEFERRED, "_world_camera_effects_" + itos(get_viewport()->find_world_3d()->get_scenario().get_id()), "update_configuration_warnings");
@@ -110,7 +110,7 @@ Ref<Environment> WorldEnvironment::get_environment() const {
 	return environment;
 }
 
-void WorldEnvironment::set_camera_effects(const Ref<CameraEffects> &p_camera_effects) {
+void WorldEnvironment::set_camera_effects(const Ref<CameraEffects3D> &p_camera_effects) {
 	if (camera_effects == p_camera_effects) {
 		return;
 	}
@@ -131,7 +131,7 @@ void WorldEnvironment::set_camera_effects(const Ref<CameraEffects> &p_camera_eff
 	}
 }
 
-Ref<CameraEffects> WorldEnvironment::get_camera_effects() const {
+Ref<CameraEffects3D> WorldEnvironment::get_camera_effects() const {
 	return camera_effects;
 }
 
@@ -139,7 +139,7 @@ TypedArray<String> WorldEnvironment::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!environment.is_valid() && !camera_effects.is_valid()) {
-		warnings.push_back(RTR("To have any visible effect, WorldEnvironment requires its \"Environment\" property to contain an Environment, its \"Camera Effects\" property to contain a CameraEffects resource, or both."));
+		warnings.push_back(RTR("To have any visible effect, WorldEnvironment requires its \"Environment\" property to contain an Environment, its \"Camera Effects\" property to contain a CameraEffects3D resource, or both."));
 	}
 
 	if (!is_inside_tree()) {
@@ -164,7 +164,7 @@ void WorldEnvironment::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_camera_effects", "env"), &WorldEnvironment::set_camera_effects);
 	ClassDB::bind_method(D_METHOD("get_camera_effects"), &WorldEnvironment::get_camera_effects);
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "camera_effects", PROPERTY_HINT_RESOURCE_TYPE, "CameraEffects"), "set_camera_effects", "get_camera_effects");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "camera_effects", PROPERTY_HINT_RESOURCE_TYPE, "CameraEffects3D"), "set_camera_effects", "get_camera_effects");
 }
 
 WorldEnvironment::WorldEnvironment() {

--- a/scene/3d/world_environment.h
+++ b/scene/3d/world_environment.h
@@ -32,14 +32,14 @@
 #define SCENARIO_FX_H
 
 #include "scene/main/node.h"
-#include "scene/resources/camera_effects.h"
+#include "scene/resources/camera_effects_3d.h"
 #include "scene/resources/environment.h"
 
 class WorldEnvironment : public Node {
 	GDCLASS(WorldEnvironment, Node);
 
 	Ref<Environment> environment;
-	Ref<CameraEffects> camera_effects;
+	Ref<CameraEffects3D> camera_effects;
 
 	void _update_current_environment();
 	void _update_current_camera_effects();
@@ -52,8 +52,8 @@ public:
 	void set_environment(const Ref<Environment> &p_environment);
 	Ref<Environment> get_environment() const;
 
-	void set_camera_effects(const Ref<CameraEffects> &p_camera_effects);
-	Ref<CameraEffects> get_camera_effects() const;
+	void set_camera_effects(const Ref<CameraEffects3D> &p_camera_effects);
+	Ref<CameraEffects3D> get_camera_effects() const;
 
 	TypedArray<String> get_configuration_warnings() const override;
 

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -144,7 +144,7 @@
 #include "scene/resources/audio_stream_sample.h"
 #include "scene/resources/bit_map.h"
 #include "scene/resources/box_shape_3d.h"
-#include "scene/resources/camera_effects.h"
+#include "scene/resources/camera_effects_3d.h"
 #include "scene/resources/capsule_shape_2d.h"
 #include "scene/resources/capsule_shape_3d.h"
 #include "scene/resources/circle_shape_2d.h"
@@ -813,7 +813,7 @@ void register_scene_types() {
 	GDREGISTER_CLASS(PhysicsMaterial);
 	GDREGISTER_CLASS(World3D);
 	GDREGISTER_CLASS(Environment);
-	GDREGISTER_CLASS(CameraEffects);
+	GDREGISTER_CLASS(CameraEffects3D);
 	GDREGISTER_CLASS(World2D);
 	GDREGISTER_VIRTUAL_CLASS(Texture);
 	GDREGISTER_VIRTUAL_CLASS(Texture2D);

--- a/scene/resources/camera_effects_3d.cpp
+++ b/scene/resources/camera_effects_3d.cpp
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  camera_effects.cpp                                                   */
+/*  camera_effects_3d.cpp                                                */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,82 +28,82 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "camera_effects.h"
+#include "camera_effects_3d.h"
 
 #include "servers/rendering_server.h"
 
-RID CameraEffects::get_rid() const {
+RID CameraEffects3D::get_rid() const {
 	return camera_effects;
 }
 
 // DOF blur
 
-void CameraEffects::set_dof_blur_far_enabled(bool p_enabled) {
+void CameraEffects3D::set_dof_blur_far_enabled(bool p_enabled) {
 	dof_blur_far_enabled = p_enabled;
 	_update_dof_blur();
 	notify_property_list_changed();
 }
 
-bool CameraEffects::is_dof_blur_far_enabled() const {
+bool CameraEffects3D::is_dof_blur_far_enabled() const {
 	return dof_blur_far_enabled;
 }
 
-void CameraEffects::set_dof_blur_far_distance(float p_distance) {
+void CameraEffects3D::set_dof_blur_far_distance(float p_distance) {
 	dof_blur_far_distance = p_distance;
 	_update_dof_blur();
 }
 
-float CameraEffects::get_dof_blur_far_distance() const {
+float CameraEffects3D::get_dof_blur_far_distance() const {
 	return dof_blur_far_distance;
 }
 
-void CameraEffects::set_dof_blur_far_transition(float p_distance) {
+void CameraEffects3D::set_dof_blur_far_transition(float p_distance) {
 	dof_blur_far_transition = p_distance;
 	_update_dof_blur();
 }
 
-float CameraEffects::get_dof_blur_far_transition() const {
+float CameraEffects3D::get_dof_blur_far_transition() const {
 	return dof_blur_far_transition;
 }
 
-void CameraEffects::set_dof_blur_near_enabled(bool p_enabled) {
+void CameraEffects3D::set_dof_blur_near_enabled(bool p_enabled) {
 	dof_blur_near_enabled = p_enabled;
 	_update_dof_blur();
 	notify_property_list_changed();
 }
 
-bool CameraEffects::is_dof_blur_near_enabled() const {
+bool CameraEffects3D::is_dof_blur_near_enabled() const {
 	return dof_blur_near_enabled;
 }
 
-void CameraEffects::set_dof_blur_near_distance(float p_distance) {
+void CameraEffects3D::set_dof_blur_near_distance(float p_distance) {
 	dof_blur_near_distance = p_distance;
 	_update_dof_blur();
 }
 
-float CameraEffects::get_dof_blur_near_distance() const {
+float CameraEffects3D::get_dof_blur_near_distance() const {
 	return dof_blur_near_distance;
 }
 
-void CameraEffects::set_dof_blur_near_transition(float p_distance) {
+void CameraEffects3D::set_dof_blur_near_transition(float p_distance) {
 	dof_blur_near_transition = p_distance;
 	_update_dof_blur();
 }
 
-float CameraEffects::get_dof_blur_near_transition() const {
+float CameraEffects3D::get_dof_blur_near_transition() const {
 	return dof_blur_near_transition;
 }
 
-void CameraEffects::set_dof_blur_amount(float p_amount) {
+void CameraEffects3D::set_dof_blur_amount(float p_amount) {
 	dof_blur_amount = p_amount;
 	_update_dof_blur();
 }
 
-float CameraEffects::get_dof_blur_amount() const {
+float CameraEffects3D::get_dof_blur_amount() const {
 	return dof_blur_amount;
 }
 
-void CameraEffects::_update_dof_blur() {
+void CameraEffects3D::_update_dof_blur() {
 	RS::get_singleton()->camera_effects_set_dof_blur(
 			camera_effects,
 			dof_blur_far_enabled,
@@ -117,26 +117,26 @@ void CameraEffects::_update_dof_blur() {
 
 // Custom exposure
 
-void CameraEffects::set_override_exposure_enabled(bool p_enabled) {
+void CameraEffects3D::set_override_exposure_enabled(bool p_enabled) {
 	override_exposure_enabled = p_enabled;
 	_update_override_exposure();
 	notify_property_list_changed();
 }
 
-bool CameraEffects::is_override_exposure_enabled() const {
+bool CameraEffects3D::is_override_exposure_enabled() const {
 	return override_exposure_enabled;
 }
 
-void CameraEffects::set_override_exposure(float p_exposure) {
+void CameraEffects3D::set_override_exposure(float p_exposure) {
 	override_exposure = p_exposure;
 	_update_override_exposure();
 }
 
-float CameraEffects::get_override_exposure() const {
+float CameraEffects3D::get_override_exposure() const {
 	return override_exposure;
 }
 
-void CameraEffects::_update_override_exposure() {
+void CameraEffects3D::_update_override_exposure() {
 	RS::get_singleton()->camera_effects_set_custom_exposure(
 			camera_effects,
 			override_exposure_enabled,
@@ -145,7 +145,7 @@ void CameraEffects::_update_override_exposure() {
 
 // Private methods, constructor and destructor
 
-void CameraEffects::_validate_property(PropertyInfo &property) const {
+void CameraEffects3D::_validate_property(PropertyInfo &property) const {
 	if ((!dof_blur_far_enabled && (property.name == "dof_blur_far_distance" || property.name == "dof_blur_far_transition")) ||
 			(!dof_blur_near_enabled && (property.name == "dof_blur_near_distance" || property.name == "dof_blur_near_transition")) ||
 			(!override_exposure_enabled && property.name == "override_exposure")) {
@@ -153,25 +153,25 @@ void CameraEffects::_validate_property(PropertyInfo &property) const {
 	}
 }
 
-void CameraEffects::_bind_methods() {
+void CameraEffects3D::_bind_methods() {
 	// DOF blur
 
-	ClassDB::bind_method(D_METHOD("set_dof_blur_far_enabled", "enabled"), &CameraEffects::set_dof_blur_far_enabled);
-	ClassDB::bind_method(D_METHOD("is_dof_blur_far_enabled"), &CameraEffects::is_dof_blur_far_enabled);
-	ClassDB::bind_method(D_METHOD("set_dof_blur_far_distance", "distance"), &CameraEffects::set_dof_blur_far_distance);
-	ClassDB::bind_method(D_METHOD("get_dof_blur_far_distance"), &CameraEffects::get_dof_blur_far_distance);
-	ClassDB::bind_method(D_METHOD("set_dof_blur_far_transition", "distance"), &CameraEffects::set_dof_blur_far_transition);
-	ClassDB::bind_method(D_METHOD("get_dof_blur_far_transition"), &CameraEffects::get_dof_blur_far_transition);
+	ClassDB::bind_method(D_METHOD("set_dof_blur_far_enabled", "enabled"), &CameraEffects3D::set_dof_blur_far_enabled);
+	ClassDB::bind_method(D_METHOD("is_dof_blur_far_enabled"), &CameraEffects3D::is_dof_blur_far_enabled);
+	ClassDB::bind_method(D_METHOD("set_dof_blur_far_distance", "distance"), &CameraEffects3D::set_dof_blur_far_distance);
+	ClassDB::bind_method(D_METHOD("get_dof_blur_far_distance"), &CameraEffects3D::get_dof_blur_far_distance);
+	ClassDB::bind_method(D_METHOD("set_dof_blur_far_transition", "distance"), &CameraEffects3D::set_dof_blur_far_transition);
+	ClassDB::bind_method(D_METHOD("get_dof_blur_far_transition"), &CameraEffects3D::get_dof_blur_far_transition);
 
-	ClassDB::bind_method(D_METHOD("set_dof_blur_near_enabled", "enabled"), &CameraEffects::set_dof_blur_near_enabled);
-	ClassDB::bind_method(D_METHOD("is_dof_blur_near_enabled"), &CameraEffects::is_dof_blur_near_enabled);
-	ClassDB::bind_method(D_METHOD("set_dof_blur_near_distance", "distance"), &CameraEffects::set_dof_blur_near_distance);
-	ClassDB::bind_method(D_METHOD("get_dof_blur_near_distance"), &CameraEffects::get_dof_blur_near_distance);
-	ClassDB::bind_method(D_METHOD("set_dof_blur_near_transition", "distance"), &CameraEffects::set_dof_blur_near_transition);
-	ClassDB::bind_method(D_METHOD("get_dof_blur_near_transition"), &CameraEffects::get_dof_blur_near_transition);
+	ClassDB::bind_method(D_METHOD("set_dof_blur_near_enabled", "enabled"), &CameraEffects3D::set_dof_blur_near_enabled);
+	ClassDB::bind_method(D_METHOD("is_dof_blur_near_enabled"), &CameraEffects3D::is_dof_blur_near_enabled);
+	ClassDB::bind_method(D_METHOD("set_dof_blur_near_distance", "distance"), &CameraEffects3D::set_dof_blur_near_distance);
+	ClassDB::bind_method(D_METHOD("get_dof_blur_near_distance"), &CameraEffects3D::get_dof_blur_near_distance);
+	ClassDB::bind_method(D_METHOD("set_dof_blur_near_transition", "distance"), &CameraEffects3D::set_dof_blur_near_transition);
+	ClassDB::bind_method(D_METHOD("get_dof_blur_near_transition"), &CameraEffects3D::get_dof_blur_near_transition);
 
-	ClassDB::bind_method(D_METHOD("set_dof_blur_amount", "amount"), &CameraEffects::set_dof_blur_amount);
-	ClassDB::bind_method(D_METHOD("get_dof_blur_amount"), &CameraEffects::get_dof_blur_amount);
+	ClassDB::bind_method(D_METHOD("set_dof_blur_amount", "amount"), &CameraEffects3D::set_dof_blur_amount);
+	ClassDB::bind_method(D_METHOD("get_dof_blur_amount"), &CameraEffects3D::get_dof_blur_amount);
 
 	ADD_GROUP("DOF Blur", "dof_blur_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "dof_blur_far_enabled"), "set_dof_blur_far_enabled", "is_dof_blur_far_enabled");
@@ -184,23 +184,23 @@ void CameraEffects::_bind_methods() {
 
 	// Override exposure
 
-	ClassDB::bind_method(D_METHOD("set_override_exposure_enabled", "enabled"), &CameraEffects::set_override_exposure_enabled);
-	ClassDB::bind_method(D_METHOD("is_override_exposure_enabled"), &CameraEffects::is_override_exposure_enabled);
-	ClassDB::bind_method(D_METHOD("set_override_exposure", "exposure"), &CameraEffects::set_override_exposure);
-	ClassDB::bind_method(D_METHOD("get_override_exposure"), &CameraEffects::get_override_exposure);
+	ClassDB::bind_method(D_METHOD("set_override_exposure_enabled", "enabled"), &CameraEffects3D::set_override_exposure_enabled);
+	ClassDB::bind_method(D_METHOD("is_override_exposure_enabled"), &CameraEffects3D::is_override_exposure_enabled);
+	ClassDB::bind_method(D_METHOD("set_override_exposure", "exposure"), &CameraEffects3D::set_override_exposure);
+	ClassDB::bind_method(D_METHOD("get_override_exposure"), &CameraEffects3D::get_override_exposure);
 
 	ADD_GROUP("Override Exposure", "override_");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "override_exposure_enabled"), "set_override_exposure_enabled", "is_override_exposure_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "override_exposure", PROPERTY_HINT_RANGE, "0,16,0.01"), "set_override_exposure", "get_override_exposure");
 }
 
-CameraEffects::CameraEffects() {
+CameraEffects3D::CameraEffects3D() {
 	camera_effects = RS::get_singleton()->camera_effects_create();
 
 	_update_dof_blur();
 	_update_override_exposure();
 }
 
-CameraEffects::~CameraEffects() {
+CameraEffects3D::~CameraEffects3D() {
 	RS::get_singleton()->free(camera_effects);
 }

--- a/scene/resources/camera_effects_3d.h
+++ b/scene/resources/camera_effects_3d.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  camera_effects.h                                                     */
+/*  camera_effects_3d.h                                                  */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -34,8 +34,8 @@
 #include "core/io/resource.h"
 #include "core/templates/rid.h"
 
-class CameraEffects : public Resource {
-	GDCLASS(CameraEffects, Resource);
+class CameraEffects3D : public Resource {
+	GDCLASS(CameraEffects3D, Resource);
 
 private:
 	RID camera_effects;
@@ -88,8 +88,8 @@ public:
 	void set_override_exposure(float p_exposure);
 	float get_override_exposure() const;
 
-	CameraEffects();
-	~CameraEffects();
+	CameraEffects3D();
+	~CameraEffects3D();
 };
 
 #endif // CAMERA_EFFECTS_H

--- a/scene/resources/world_3d.cpp
+++ b/scene/resources/world_3d.cpp
@@ -99,7 +99,7 @@ Ref<Environment> World3D::get_fallback_environment() const {
 	return fallback_environment;
 }
 
-void World3D::set_camera_effects(const Ref<CameraEffects> &p_camera_effects) {
+void World3D::set_camera_effects(const Ref<CameraEffects3D> &p_camera_effects) {
 	camera_effects = p_camera_effects;
 	if (camera_effects.is_valid()) {
 		RS::get_singleton()->scenario_set_camera_effects(scenario, camera_effects->get_rid());
@@ -108,7 +108,7 @@ void World3D::set_camera_effects(const Ref<CameraEffects> &p_camera_effects) {
 	}
 }
 
-Ref<CameraEffects> World3D::get_camera_effects() const {
+Ref<CameraEffects3D> World3D::get_camera_effects() const {
 	return camera_effects;
 }
 
@@ -129,7 +129,7 @@ void World3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_direct_space_state"), &World3D::get_direct_space_state);
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "environment", PROPERTY_HINT_RESOURCE_TYPE, "Environment"), "set_environment", "get_environment");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "fallback_environment", PROPERTY_HINT_RESOURCE_TYPE, "Environment"), "set_fallback_environment", "get_fallback_environment");
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "camera_effects", PROPERTY_HINT_RESOURCE_TYPE, "CameraEffects"), "set_camera_effects", "get_camera_effects");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "camera_effects", PROPERTY_HINT_RESOURCE_TYPE, "CameraEffects3D"), "set_camera_effects", "get_camera_effects");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "space", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_space");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "navigation_map", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_navigation_map");
 	ADD_PROPERTY(PropertyInfo(Variant::RID, "scenario", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE), "", "get_scenario");

--- a/scene/resources/world_3d.h
+++ b/scene/resources/world_3d.h
@@ -32,7 +32,7 @@
 #define WORLD_3D_H
 
 #include "core/io/resource.h"
-#include "scene/resources/camera_effects.h"
+#include "scene/resources/camera_effects_3d.h"
 #include "scene/resources/environment.h"
 #include "servers/physics_server_3d.h"
 #include "servers/rendering_server.h"
@@ -51,7 +51,7 @@ private:
 
 	Ref<Environment> environment;
 	Ref<Environment> fallback_environment;
-	Ref<CameraEffects> camera_effects;
+	Ref<CameraEffects3D> camera_effects;
 
 	RBSet<Camera3D *> cameras;
 
@@ -74,8 +74,8 @@ public:
 	void set_fallback_environment(const Ref<Environment> &p_environment);
 	Ref<Environment> get_fallback_environment() const;
 
-	void set_camera_effects(const Ref<CameraEffects> &p_camera_effects);
-	Ref<CameraEffects> get_camera_effects() const;
+	void set_camera_effects(const Ref<CameraEffects3D> &p_camera_effects);
+	Ref<CameraEffects3D> get_camera_effects() const;
 
 	_FORCE_INLINE_ const RBSet<Camera3D *> &get_cameras() const { return cameras; }
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -1365,7 +1365,7 @@ RID RendererSceneRenderRD::camera_effects_allocate() {
 	return camera_effects_owner.allocate_rid();
 }
 void RendererSceneRenderRD::camera_effects_initialize(RID p_rid) {
-	camera_effects_owner.initialize_rid(p_rid, CameraEffects());
+	camera_effects_owner.initialize_rid(p_rid, CameraEffects3D());
 }
 
 void RendererSceneRenderRD::camera_effects_set_dof_blur_quality(RS::DOFBlurQuality p_quality, bool p_use_jitter) {
@@ -1378,7 +1378,7 @@ void RendererSceneRenderRD::camera_effects_set_dof_blur_bokeh_shape(RS::DOFBokeh
 }
 
 void RendererSceneRenderRD::camera_effects_set_dof_blur(RID p_camera_effects, bool p_far_enable, float p_far_distance, float p_far_transition, bool p_near_enable, float p_near_distance, float p_near_transition, float p_amount) {
-	CameraEffects *camfx = camera_effects_owner.get_or_null(p_camera_effects);
+	CameraEffects3D *camfx = camera_effects_owner.get_or_null(p_camera_effects);
 	ERR_FAIL_COND(!camfx);
 
 	camfx->dof_blur_far_enabled = p_far_enable;
@@ -1393,7 +1393,7 @@ void RendererSceneRenderRD::camera_effects_set_dof_blur(RID p_camera_effects, bo
 }
 
 void RendererSceneRenderRD::camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) {
-	CameraEffects *camfx = camera_effects_owner.get_or_null(p_camera_effects);
+	CameraEffects3D *camfx = camera_effects_owner.get_or_null(p_camera_effects);
 	ERR_FAIL_COND(!camfx);
 
 	camfx->override_exposure_enabled = p_enable;
@@ -2382,7 +2382,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 
 	RendererSceneEnvironmentRD *env = environment_owner.get_or_null(p_render_data->environment);
 	// Glow and override exposure (if enabled).
-	CameraEffects *camfx = camera_effects_owner.get_or_null(p_render_data->camera_effects);
+	CameraEffects3D *camfx = camera_effects_owner.get_or_null(p_render_data->camera_effects);
 
 	bool can_use_effects = rb->width >= 8 && rb->height >= 8;
 	bool can_use_storage = _render_buffers_can_be_storage();
@@ -2612,7 +2612,7 @@ void RendererSceneRenderRD::_post_process_subpass(RID p_source_texture, RID p_fr
 
 	RendererSceneEnvironmentRD *env = environment_owner.get_or_null(p_render_data->environment);
 	// Override exposure (if enabled).
-	CameraEffects *camfx = camera_effects_owner.get_or_null(p_render_data->camera_effects);
+	CameraEffects3D *camfx = camera_effects_owner.get_or_null(p_render_data->camera_effects);
 
 	bool can_use_effects = rb->width >= 8 && rb->height >= 8;
 

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -432,7 +432,7 @@ private:
 
 	/* CAMERA EFFECTS */
 
-	struct CameraEffects {
+	struct CameraEffects3D {
 		bool dof_blur_far_enabled = false;
 		float dof_blur_far_distance = 10;
 		float dof_blur_far_transition = 5;
@@ -454,7 +454,7 @@ private:
 	float sss_scale = 0.05;
 	float sss_depth_scale = 0.01;
 
-	mutable RID_Owner<CameraEffects, true> camera_effects_owner;
+	mutable RID_Owner<CameraEffects3D, true> camera_effects_owner;
 
 	/* RENDER BUFFERS */
 
@@ -1123,7 +1123,7 @@ public:
 	virtual void camera_effects_set_custom_exposure(RID p_camera_effects, bool p_enable, float p_exposure) override;
 
 	bool camera_effects_uses_dof(RID p_camera_effects) {
-		CameraEffects *camfx = camera_effects_owner.get_or_null(p_camera_effects);
+		CameraEffects3D *camfx = camera_effects_owner.get_or_null(p_camera_effects);
 
 		return camfx && (camfx->dof_blur_near_enabled || camfx->dof_blur_far_enabled) && camfx->dof_blur_amount > 0.0;
 	}


### PR DESCRIPTION
**Do not merge**

This PR renames [`CameraEffects`](https://docs.godotengine.org/en/latest/classes/class_cameraeffects.html) to `CameraEffects3D`.

* ~~It is only used in 3D (via WorldEnvironment or Camera3D), the suffix helps clarify this.~~ Clayjohn said it's only used in 3D but according to Holly some parts are used in 2D.
* The suffix also clarifies that it's meant to be used with nodes, not a physical camera like with `CameraFeed`.
* If we ever add a `CameraEffects2D`, then the suffix would also help distinguish it in this case.
