### PR TITLE
Tweak the disabled files text color in FileDialog for readability

### DIFF
--- a/doc/classes/FileDialog.xml
+++ b/doc/classes/FileDialog.xml
@@ -130,7 +130,7 @@
 		<theme_item name="file_icon_modulate" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The color modulation applied to the file icon.
 		</theme_item>
-		<theme_item name="files_disabled" data_type="color" type="Color" default="Color(0, 0, 0, 0.7)">
+		<theme_item name="files_disabled" data_type="color" type="Color" default="Color(1, 1, 1, 0.25)">
 			The color tint for disabled files (when the [FileDialog] is used in open folder mode).
 		</theme_item>
 		<theme_item name="folder_icon_modulate" data_type="color" type="Color" default="Color(1, 1, 1, 1)">

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -605,7 +605,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_icon("file", "FileDialog", icons["file"]);
 	theme->set_color("folder_icon_modulate", "FileDialog", Color(1, 1, 1));
 	theme->set_color("file_icon_modulate", "FileDialog", Color(1, 1, 1));
-	theme->set_color("files_disabled", "FileDialog", Color(0, 0, 0, 0.7));
+	theme->set_color("files_disabled", "FileDialog", Color(1, 1, 1, 0.25));
 
 	// Popup
 


### PR DESCRIPTION
Contrast rate is still fairly low, but the text needs to be easy enough to distinguish from non-disabled items.

This partially addresses https://github.com/godotengine/godot-proposals/issues/4566.

## Preview

| Before | After |
|-|-|
| ![image](https://user-images.githubusercontent.com/180032/169545959-dd7fe5e5-9b10-4170-80ed-6c09485aaecd.png) | ![image](https://user-images.githubusercontent.com/180032/169545992-3df79b10-103d-475f-a51f-8ba36e97997f.png) |