### PR TITLE
Fix incorrect keyword completion after period in shader editor

### DIFF
--- a/servers/rendering/shader_language.cpp
+++ b/servers/rendering/shader_language.cpp
@@ -5379,6 +5379,11 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 			if (tk.type == TK_CURSOR) {
 				//do nothing
 			} else if (tk.type == TK_PERIOD) {
+#ifdef DEBUG_ENABLED
+				uint32_t prev_keyword_completion_context = keyword_completion_context;
+				keyword_completion_context = CF_UNSPECIFIED;
+#endif
+
 				DataType dt = expr->get_datatype();
 				String st = expr->get_datatype_name();
 
@@ -5733,6 +5738,10 @@ ShaderLanguage::Node *ShaderLanguage::_parse_expression(BlockNode *p_block, cons
 					}
 				}
 				expr = mn;
+
+#ifdef DEBUG_ENABLED
+				keyword_completion_context = prev_keyword_completion_context;
+#endif
 
 				//todo
 				//member (period) has priority over any operator

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -503,7 +503,7 @@ public:
 		BlockNode *parent_block = nullptr;
 
 		enum BlockType {
-			BLOCK_TYPE_STANDART,
+			BLOCK_TYPE_STANDARD,
 			BLOCK_TYPE_FOR_INIT,
 			BLOCK_TYPE_FOR_CONDITION,
 			BLOCK_TYPE_FOR_EXPRESSION,
@@ -512,7 +512,7 @@ public:
 			BLOCK_TYPE_DEFAULT,
 		};
 
-		int block_type = BLOCK_TYPE_STANDART;
+		int block_type = BLOCK_TYPE_STANDARD;
 		SubClassTag block_tag = SubClassTag::TAG_GLOBAL;
 
 		struct Variable {


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/3036176/169563897-9d236298-64b8-4fb9-910e-845c261908e1.png)

After:

![image](https://user-images.githubusercontent.com/3036176/169564052-7c831c97-b9e0-4ece-a085-664b405b68d1.png)

(Also fixed typo in BlockType enum)