### PR TITLE
[3.x] Fix signed distance field font rendering

### DIFF
--- a/drivers/gles2/rasterizer_canvas_base_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_base_gles2.cpp
@@ -58,6 +58,7 @@ void RasterizerCanvasBaseGLES2::canvas_begin() {
 	state.using_large_vertex = false;
 	state.using_modulate = false;
 
+	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_DISTANCE_FIELD, false);
 	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_ATTRIB_LIGHT_ANGLE, false);
 	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_ATTRIB_MODULATE, false);
 	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_ATTRIB_LARGE_VERTEX, false);

--- a/drivers/gles2/rasterizer_canvas_gles2.cpp
+++ b/drivers/gles2/rasterizer_canvas_gles2.cpp
@@ -1221,6 +1221,7 @@ void RasterizerCanvasGLES2::canvas_render_items_implementation(Item *p_item_list
 	ris.item_group_modulate = p_modulate;
 	ris.item_group_light = p_light;
 	ris.item_group_base_transform = p_base_transform;
+	ris.prev_distance_field = false;
 
 	state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_SKELETON, false);
 
@@ -1554,6 +1555,13 @@ bool RasterizerCanvasGLES2::try_join_item(Item *p_ci, RenderItemState &r_ris, bo
 		join = false;
 	}
 
+	if (r_ris.prev_distance_field != p_ci->distance_field) {
+		// Break batching for SDF font rendering.
+		r_ris.prev_distance_field = p_ci->distance_field;
+		join = false;
+		r_batch_break = true;
+	}
+
 	// non rects will break the batching anyway, we don't want to record item changes, detect this
 	if (!r_batch_break && _detect_item_batch_break(r_ris, p_ci, r_batch_break)) {
 		join = false;
@@ -1568,6 +1576,12 @@ bool RasterizerCanvasGLES2::try_join_item(Item *p_ci, RenderItemState &r_ris, bo
 // Should be removed after testing phase to avoid duplicate codepaths.
 void RasterizerCanvasGLES2::_legacy_canvas_render_item(Item *p_ci, RenderItemState &r_ris) {
 	storage->info.render._2d_item_count++;
+
+	if (r_ris.prev_distance_field != p_ci->distance_field) {
+		state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_DISTANCE_FIELD, p_ci->distance_field);
+		r_ris.prev_distance_field = p_ci->distance_field;
+		r_ris.rebind_shader = true;
+	}
 
 	if (r_ris.current_clip != p_ci->final_clip_owner) {
 		r_ris.current_clip = p_ci->final_clip_owner;
@@ -1929,6 +1943,12 @@ void RasterizerCanvasGLES2::render_joined_item(const BItemJoined &p_bij, RenderI
 
 	// all the joined items will share the same state with the first item
 	Item *ci = bdata.item_refs[p_bij.first_item_ref].item;
+
+	if (r_ris.prev_distance_field != ci->distance_field) {
+		state.canvas_shader.set_conditional(CanvasShaderGLES2::USE_DISTANCE_FIELD, ci->distance_field);
+		r_ris.prev_distance_field = ci->distance_field;
+		r_ris.rebind_shader = true;
+	}
 
 	if (r_ris.current_clip != ci->final_clip_owner) {
 		r_ris.current_clip = ci->final_clip_owner;

--- a/drivers/gles2/shaders/canvas.glsl
+++ b/drivers/gles2/shaders/canvas.glsl
@@ -448,6 +448,14 @@ void main() {
 	color *= texture2D(color_texture, uv);
 #endif
 
+#ifdef USE_DISTANCE_FIELD
+	// Higher is smoother, but also more blurry. Lower is crisper, but also more aliased.
+	// TODO: Adjust automatically based on screen resolution/font size ratio.
+	const float smoothing = 0.125;
+	float dist = texture2D(color_texture, uv).a;
+	color.a = smoothstep(0.5 - smoothing, 0.5 + smoothing, dist);
+#endif
+
 #ifdef SCREEN_UV_USED
 	vec2 screen_uv = gl_FragCoord.xy * screen_pixel_size;
 #endif

--- a/drivers/gles3/rasterizer_canvas_gles3.cpp
+++ b/drivers/gles3/rasterizer_canvas_gles3.cpp
@@ -1868,6 +1868,13 @@ bool RasterizerCanvasGLES3::try_join_item(Item *p_ci, RenderItemState &r_ris, bo
 		join = false;
 	}
 
+	if (r_ris.prev_distance_field != p_ci->distance_field) {
+		// Break batching for SDF font rendering.
+		r_ris.prev_distance_field = p_ci->distance_field;
+		join = false;
+		r_batch_break = true;
+	}
+
 	// non rects will break the batching anyway, we don't want to record item changes, detect this
 	if (!r_batch_break && _detect_item_batch_break(r_ris, p_ci, r_batch_break)) {
 		join = false;

--- a/drivers/gles3/shaders/canvas.glsl
+++ b/drivers/gles3/shaders/canvas.glsl
@@ -583,16 +583,15 @@ void main() {
 
 #if !defined(COLOR_USED)
 	//default behavior, texture by color
-
-#ifdef USE_DISTANCE_FIELD
-	const float smoothing = 1.0 / 32.0;
-	float distance = textureLod(color_texture, uv, 0.0).a;
-	color.a = smoothstep(0.5 - smoothing, 0.5 + smoothing, distance) * color.a;
-#else
 	color *= texture(color_texture, uv);
-
 #endif
 
+#ifdef USE_DISTANCE_FIELD
+	// Higher is smoother, but also more blurry. Lower is crisper, but also more aliased.
+	// TODO: Adjust automatically based on screen resolution/font size ratio.
+	const float smoothing = 0.125;
+	float dist = texture(color_texture, uv, 0.0).a;
+	color.a = smoothstep(0.5 - smoothing, 0.5 + smoothing, dist);
 #endif
 
 	vec3 normal;

--- a/scene/gui/button.cpp
+++ b/scene/gui/button.cpp
@@ -279,6 +279,8 @@ void Button::_notification(int p_what) {
 
 			text_ofs.y += font->get_ascent();
 			font->draw(ci, text_ofs.floor(), xl_text, color, clip_text ? text_clip : -1);
+
+			VisualServer::get_singleton()->canvas_item_set_distance_field_mode(get_canvas_item(), font.is_valid() && font->is_distance_field_hint());
 		} break;
 	}
 }

--- a/scene/gui/dialogs.cpp
+++ b/scene/gui/dialogs.cpp
@@ -205,6 +205,8 @@ void WindowDialog::_notification(int p_what) {
 			int x = (size.x - title_font->get_string_size(xl_title).x) / 2;
 			int y = (-title_height + font_height) / 2;
 			title_font->draw(canvas, Point2(x, y), xl_title, title_color, size.x - panel->get_minimum_size().x);
+
+			VisualServer::get_singleton()->canvas_item_set_distance_field_mode(get_canvas_item(), title_font.is_valid() && title_font->is_distance_field_hint());
 		} break;
 
 		case NOTIFICATION_THEME_CHANGED:

--- a/scene/gui/item_list.cpp
+++ b/scene/gui/item_list.cpp
@@ -778,6 +778,8 @@ void ItemList::_notification(int p_what) {
 		Vector<int> line_size_cache;
 		Vector<int> line_limit_cache;
 
+		VisualServer::get_singleton()->canvas_item_set_distance_field_mode(get_canvas_item(), font.is_valid() && font->is_distance_field_hint());
+
 		if (max_text_lines) {
 			line_size_cache.resize(max_text_lines);
 			line_limit_cache.resize(max_text_lines);

--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -807,6 +807,7 @@ void LineEdit::_notification(int p_what) {
 			}
 
 			Ref<Font> font = get_font("font");
+			VisualServer::get_singleton()->canvas_item_set_distance_field_mode(get_canvas_item(), font.is_valid() && font->is_distance_field_hint());
 
 			style->draw(ci, Rect2(Point2(), size));
 

--- a/scene/gui/link_button.cpp
+++ b/scene/gui/link_button.cpp
@@ -111,6 +111,7 @@ void LinkButton::_notification(int p_what) {
 			}
 
 			Ref<Font> font = get_font("font");
+			VisualServer::get_singleton()->canvas_item_set_distance_field_mode(get_canvas_item(), font.is_valid() && font->is_distance_field_hint());
 
 			draw_string(font, Vector2(0, font->get_ascent()), xl_text, color);
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -491,6 +491,8 @@ void PopupMenu::_notification(int p_what) {
 			Ref<StyleBox> hover = get_stylebox("hover");
 			Ref<Font> font = get_font("font");
 			Ref<Font> font_separator = get_font("font_separator");
+			VisualServer::get_singleton()->canvas_item_set_distance_field_mode(get_canvas_item(), font.is_valid() && font->is_distance_field_hint());
+
 			// In Item::checkable_type enum order (less the non-checkable member)
 			Ref<Texture> check[] = { get_icon("checked"), get_icon("radio_checked") };
 			Ref<Texture> uncheck[] = { get_icon("unchecked"), get_icon("radio_unchecked") };

--- a/scene/gui/progress_bar.cpp
+++ b/scene/gui/progress_bar.cpp
@@ -53,6 +53,7 @@ void ProgressBar::_notification(int p_what) {
 		Ref<StyleBox> fg = get_stylebox("fg");
 		Ref<Font> font = get_font("font");
 		Color font_color = get_color("font_color");
+		VisualServer::get_singleton()->canvas_item_set_distance_field_mode(get_canvas_item(), font.is_valid() && font->is_distance_field_hint());
 
 		draw_style_box(bg, Rect2(Point2(), get_size()));
 		float r = get_as_ratio();

--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -1051,6 +1051,8 @@ void RichTextLabel::_notification(int p_what) {
 			bool use_outline = get_constant("shadow_as_outline");
 			Point2 shadow_ofs(get_constant("shadow_offset_x"), get_constant("shadow_offset_y"));
 
+			VisualServer::get_singleton()->canvas_item_set_distance_field_mode(get_canvas_item(), base_font.is_valid() && base_font->is_distance_field_hint());
+
 			visible_line_count = 0;
 			while (y < size.height && from_line < main->lines.size()) {
 				visible_line_count += _process_line(main, text_rect.get_position(), y, text_rect.get_size().width - scroll_w, from_line, PROCESS_DRAW, base_font, base_color, font_color_shadow, use_outline, shadow_ofs, Point2i(), nullptr, nullptr, nullptr, total_chars);

--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -282,6 +282,8 @@ void TabContainer::_notification(int p_what) {
 			Color font_color_disabled = get_color("font_color_disabled");
 			int side_margin = get_constant("side_margin");
 
+			VisualServer::get_singleton()->canvas_item_set_distance_field_mode(get_canvas_item(), font.is_valid() && font->is_distance_field_hint());
+
 			// Find out start and width of the header area.
 			int header_x = side_margin;
 			int header_width = size.width - side_margin * 2;

--- a/scene/gui/tabs.cpp
+++ b/scene/gui/tabs.cpp
@@ -244,6 +244,8 @@ void Tabs::_notification(int p_what) {
 			Color color_disabled = get_color("font_color_disabled");
 			Ref<Texture> close = get_icon("close");
 
+			VisualServer::get_singleton()->canvas_item_set_distance_field_mode(get_canvas_item(), font.is_valid() && font->is_distance_field_hint());
+
 			int h = get_size().height;
 			int w = 0;
 			int mw = 0;


### PR DESCRIPTION
This fix works in both GLES3 and GLES2. Thanks @filipworksdev for the fix :slightly_smiling_face: 

The rendering formula in the shader was adjusted to further improve the sharpness/antialiasing quality balance.

Improvements to rendering quality could be made by adjusting SDF smoothing depending on font size (relative to screen size) or performing supersampling. However, the `screen_pixel_size` uniform is only available when `SCREEN_UV` is used in the shader, and I need that to adjust SDF smoothing based on resolution.

This closes https://github.com/godotengine/godot/issues/8022.

## Preview

*The SDF texture is about 40 pixels tall.*

### 1024×600

![2022-05-20_02 41 32](https://user-images.githubusercontent.com/180032/169426238-a71c8d2a-786c-4da9-8e5f-08574116bff0.png)

### 2560×1440

![2022-05-20_02 41 36](https://user-images.githubusercontent.com/180032/169426241-6aef18b1-d993-48d0-a1b2-757171bccf2b.png)

## TODO

- [x] Fix SDF font rendering when batching is enabled and non-SDF nodes are rendered. This bug affects both GLES3 and GLES2.