### PR TITLE
Process NavigationAgent2D/3D avoidance on demand only

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -42,6 +42,7 @@
 		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
+				Returns the [RID] of this agent on the [NavigationServer2D].
 			</description>
 		</method>
 		<method name="get_target_location" qualifiers="const">
@@ -84,6 +85,9 @@
 		</method>
 	</methods>
 	<members>
+		<member name="avoidance_enabled" type="bool" setter="set_avoidance_enabled" getter="get_avoidance_enabled" default="false">
+			If [code]true[/code] the agent is registered for an RVO avoidance callback on the [NavigationServer2D]. When [method NavigationAgent2D.set_velocity] is used and the processing is completed a [code]safe_velocity[/code] Vector2 is received with a signal connection to [signal velocity_computed]. Avoidance processing with many registered agents has a significant performance cost and should only be enabled on agents that currently require it.
+		</member>
 		<member name="max_neighbors" type="int" setter="set_max_neighbors" getter="get_max_neighbors" default="10">
 			The maximum number of neighbors for the agent to consider.
 		</member>

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -42,6 +42,7 @@
 		<method name="get_rid" qualifiers="const">
 			<return type="RID" />
 			<description>
+				Returns the [RID] of this agent on the [NavigationServer3D].
 			</description>
 		</method>
 		<method name="get_target_location" qualifiers="const">
@@ -86,6 +87,9 @@
 	<members>
 		<member name="agent_height_offset" type="float" setter="set_agent_height_offset" getter="get_agent_height_offset" default="0.0">
 			The agent height offset to match the navigation mesh height.
+		</member>
+		<member name="avoidance_enabled" type="bool" setter="set_avoidance_enabled" getter="get_avoidance_enabled" default="false">
+			If [code]true[/code] the agent is registered for an RVO avoidance callback on the [NavigationServer3D]. When [method NavigationAgent3D.set_velocity] is used and the processing is completed a [code]safe_velocity[/code] Vector3 is received with a signal connection to [signal velocity_computed]. Avoidance processing with many registered agents has a significant performance cost and should only be enabled on agents that currently require it.
 		</member>
 		<member name="ignore_y" type="bool" setter="set_ignore_y" getter="get_ignore_y" default="true">
 			Ignores collisions on the Y axis. Must be true to move on a horizontal plane.

--- a/scene/2d/navigation_agent_2d.h
+++ b/scene/2d/navigation_agent_2d.h
@@ -43,6 +43,7 @@ class NavigationAgent2D : public Node {
 	RID agent;
 	RID map_before_pause;
 
+	bool avoidance_enabled = false;
 	uint32_t navigable_layers = 1;
 
 	real_t target_desired_distance = 1.0;
@@ -77,6 +78,9 @@ public:
 	RID get_rid() const {
 		return agent;
 	}
+
+	void set_avoidance_enabled(bool p_enabled);
+	bool get_avoidance_enabled() const;
 
 	void set_navigable_layers(uint32_t p_layers);
 	uint32_t get_navigable_layers() const;

--- a/scene/3d/navigation_agent_3d.cpp
+++ b/scene/3d/navigation_agent_3d.cpp
@@ -35,6 +35,9 @@
 void NavigationAgent3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_rid"), &NavigationAgent3D::get_rid);
 
+	ClassDB::bind_method(D_METHOD("set_avoidance_enabled", "enabled"), &NavigationAgent3D::set_avoidance_enabled);
+	ClassDB::bind_method(D_METHOD("get_avoidance_enabled"), &NavigationAgent3D::get_avoidance_enabled);
+
 	ClassDB::bind_method(D_METHOD("set_target_desired_distance", "desired_distance"), &NavigationAgent3D::set_target_desired_distance);
 	ClassDB::bind_method(D_METHOD("get_target_desired_distance"), &NavigationAgent3D::get_target_desired_distance);
 
@@ -88,6 +91,7 @@ void NavigationAgent3D::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_speed", PROPERTY_HINT_RANGE, "0.1,10000,0.01,suffix:m/s"), "set_max_speed", "get_max_speed");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "path_max_distance", PROPERTY_HINT_RANGE, "0.01,100,0.1,suffix:m"), "set_path_max_distance", "get_path_max_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "ignore_y"), "set_ignore_y", "get_ignore_y");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "avoidance_enabled"), "set_avoidance_enabled", "get_avoidance_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "navigable_layers", PROPERTY_HINT_LAYERS_3D_NAVIGATION), "set_navigable_layers", "get_navigable_layers");
 
 	ADD_SIGNAL(MethodInfo("path_changed"));
@@ -103,7 +107,7 @@ void NavigationAgent3D::_notification(int p_what) {
 			if (agent_parent != nullptr) {
 				// place agent on navigation map first or else the RVO agent callback creation fails silently later
 				NavigationServer3D::get_singleton()->agent_set_map(get_rid(), agent_parent->get_world_3d()->get_navigation_map());
-				NavigationServer3D::get_singleton()->agent_set_callback(agent, this, "_avoidance_done");
+				set_avoidance_enabled(avoidance_enabled);
 			}
 			set_physics_process_internal(true);
 		} break;
@@ -155,6 +159,19 @@ NavigationAgent3D::NavigationAgent3D() {
 NavigationAgent3D::~NavigationAgent3D() {
 	NavigationServer3D::get_singleton()->free(agent);
 	agent = RID(); // Pointless
+}
+
+void NavigationAgent3D::set_avoidance_enabled(bool p_enabled) {
+	avoidance_enabled = p_enabled;
+	if (avoidance_enabled) {
+		NavigationServer3D::get_singleton()->agent_set_callback(agent, this, "_avoidance_done");
+	} else {
+		NavigationServer3D::get_singleton()->agent_set_callback(agent, nullptr, "_avoidance_done");
+	}
+}
+
+bool NavigationAgent3D::get_avoidance_enabled() const {
+	return avoidance_enabled;
 }
 
 void NavigationAgent3D::set_navigable_layers(uint32_t p_layers) {
@@ -283,7 +300,7 @@ TypedArray<String> NavigationAgent3D::get_configuration_warnings() const {
 	TypedArray<String> warnings = Node::get_configuration_warnings();
 
 	if (!Object::cast_to<Node3D>(get_parent())) {
-		warnings.push_back(RTR("The NavigationAgent3D can be used only under a spatial node."));
+		warnings.push_back(RTR("The NavigationAgent3D can be used only under a Node3D inheriting parent node."));
 	}
 
 	return warnings;

--- a/scene/3d/navigation_agent_3d.h
+++ b/scene/3d/navigation_agent_3d.h
@@ -43,6 +43,7 @@ class NavigationAgent3D : public Node {
 	RID agent;
 	RID map_before_pause;
 
+	bool avoidance_enabled = false;
 	uint32_t navigable_layers = 1;
 
 	real_t target_desired_distance = 1.0;
@@ -79,6 +80,9 @@ public:
 	RID get_rid() const {
 		return agent;
 	}
+
+	void set_avoidance_enabled(bool p_enabled);
+	bool get_avoidance_enabled() const;
 
 	void set_navigable_layers(uint32_t p_layers);
 	uint32_t get_navigable_layers() const;


### PR DESCRIPTION
Changes NavigationAgent avoidance callback to a toggle that is disabled by default.
Also fixes a few missing descriptions / wrong warnings.

Previously all Navigation2D/3D nodes would create callbacks for avoidance on the NavigationServer by default as soon as they enter the SceneTree even if they would never use the avoidance / connect to the avoidance signal.

Since all registered callbacks are processed by the NavigationServer RVO each physics tick this was a huge performance waste on agents that had no use for avoidance.

With this change alone my navigation test projects with 5.000 NavigationAgent3D or 40.000 NavigationAgent2D go from 4-5 fps back to 44-52 fps.

Fixes #61230