### PR TITLE
Fix ParticlesMaterial collision friction/bounce at low velocity

### DIFF
--- a/scene/resources/particles_material.cpp
+++ b/scene/resources/particles_material.cpp
@@ -709,8 +709,11 @@ void ParticlesMaterial::_update_shader() {
 	if (collision_enabled) {
 		code += "	if (COLLIDED) {\n";
 		code += "		TRANSFORM[3].xyz+=COLLISION_NORMAL * COLLISION_DEPTH;\n";
-		code += "		VELOCITY -= COLLISION_NORMAL * dot(COLLISION_NORMAL, VELOCITY) * (1.0 + collision_bounce);\n";
-		code += "		VELOCITY = mix(VELOCITY,vec3(0.0),collision_friction * DELTA * 100.0);\n";
+		// Scale down bouncing if velocity is lower than twice the bounce multiplier.
+		// This prevents particles from bouncing at low amplitude forever,
+		// especially at lower Fixed Fps values (which looks odd).
+		code += "		VELOCITY -= COLLISION_NORMAL * dot(COLLISION_NORMAL, VELOCITY) * (1.0 + collision_bounce * max(0.0, min(1.0, length(VELOCITY) - 2.0 * collision_bounce)));\n";
+		code += "		VELOCITY = mix(VELOCITY, vec3(0.0), min(1.0, collision_friction * DELTA * 100.0));\n";
 		code += "	}\n";
 	}
 	if (sub_emitter_mode != SUB_EMITTER_DISABLED) {


### PR DESCRIPTION
- Scale down bounce if the particle velocity is low (relative to the bounce multiplier chosen). This prevents particles from bouncing forever at low amplitude, which looks odd.
- Don't allow the computed friction multiplier to go above 1.0. This prevents particles from spazzing out after stopping.

Particles that used to jitter all over the place now look very smooth, even when Fixed Fps is decreased to 20 (as long as interpolation is enabled).

I tested this PR on the MRPs linked in https://github.com/godotengine/godot/issues/57249 and https://github.com/godotengine/godot/issues/57197.

This closes https://github.com/godotengine/godot/issues/57249.