### PR TITLE
[3.x] Fix the missing DLL's when exporting for UWP platform

### DIFF
--- a/platform/uwp/export/export.cpp
+++ b/platform/uwp/export/export.cpp
@@ -1359,7 +1359,7 @@ public:
 		EditorNode::progress_add_task("project_files", "Project Files", 100);
 		packager.set_progress_task("project_files");
 
-		err = export_project_files(p_preset, save_appx_file, &packager);
+		err = export_project_files(p_preset, save_appx_file, &packager, copy_dynamic_libraries);
 
 		EditorNode::progress_end_task("project_files");
 
@@ -1432,6 +1432,11 @@ public:
 	}
 
 	virtual void resolve_platform_feature_priorities(const Ref<EditorExportPreset> &p_preset, Set<String> &p_features) {
+	}
+
+	static Error copy_dynamic_libraries(void *p_userdata, const SharedObject &p_so) {
+		Error err = save_appx_file(p_userdata, p_so.path, FileAccess::get_file_as_array(p_so.path), 0, 1);
+		return err;
 	}
 
 	EditorExportPlatformUWP() {


### PR DESCRIPTION
Fixes #61060 for the 3.x version, Tested on the latest commit from the 3.4 development branch.