### PR TITLE
[3.5] Fix broken TileSet Navigation due to wrong NavigationPolygon format

### DIFF
--- a/editor/plugins/tile_set_editor_plugin.cpp
+++ b/editor/plugins/tile_set_editor_plugin.cpp
@@ -1665,16 +1665,20 @@ void TileSetEditor::_on_workspace_input(const Ref<InputEvent> &p_ie) {
 
 										w.release();
 
-										undo_redo->create_action(TTR("Edit Navigation Polygon"));
-										undo_redo->add_do_method(edited_navigation_shape.ptr(), "set_vertices", polygon);
-										undo_redo->add_undo_method(edited_navigation_shape.ptr(), "set_vertices", edited_navigation_shape->get_vertices());
-										undo_redo->add_do_method(edited_navigation_shape.ptr(), "clear_polygons");
-										undo_redo->add_undo_method(edited_navigation_shape.ptr(), "clear_polygons");
-										undo_redo->add_do_method(edited_navigation_shape.ptr(), "add_polygon", indices);
-										undo_redo->add_undo_method(edited_navigation_shape.ptr(), "add_polygon", edited_navigation_shape->get_polygon(0));
-										undo_redo->add_do_method(this, "_select_edited_shape_coord");
-										undo_redo->add_undo_method(this, "_select_edited_shape_coord");
-										undo_redo->commit_action();
+										edited_navigation_shape->clear_outlines();
+										edited_navigation_shape->add_outline(polygon);
+										edited_navigation_shape->make_polygons_from_outlines();
+										// FIXME Couldn't figure out the undo_redo quagmire
+										//undo_redo->create_action(TTR("Edit Navigation Polygon"));
+										//undo_redo->add_do_method(edited_navigation_shape.ptr(), "set_vertices", polygon);
+										//undo_redo->add_undo_method(edited_navigation_shape.ptr(), "set_vertices", edited_navigation_shape->get_vertices());
+										//undo_redo->add_do_method(edited_navigation_shape.ptr(), "clear_polygons");
+										//undo_redo->add_undo_method(edited_navigation_shape.ptr(), "clear_polygons");
+										//undo_redo->add_do_method(edited_navigation_shape.ptr(), "add_polygon", indices);
+										//undo_redo->add_undo_method(edited_navigation_shape.ptr(), "add_polygon", edited_navigation_shape->get_polygon(0));
+										//undo_redo->add_do_method(this, "_select_edited_shape_coord");
+										//undo_redo->add_undo_method(this, "_select_edited_shape_coord");
+										//undo_redo->commit_action();
 									}
 								}
 							}
@@ -2808,11 +2812,14 @@ void TileSetEditor::draw_polygon_shapes() {
 							colors.push_back(c_bg);
 						}
 					} else {
-						PoolVector<Vector2> vertices = shape->get_vertices();
-						for (int j = 0; j < shape->get_polygon(0).size(); j++) {
-							polygon.push_back(vertices[shape->get_polygon(0)[j]] + anchor);
-							colors.push_back(c_bg);
+						for (int outline_idx = 0; outline_idx < shape->get_outline_count(); outline_idx++) {
+							PoolVector<Vector2> outline_vertices = shape->get_outline(outline_idx);
+							for (int vertex_idx = 0; vertex_idx < outline_vertices.size(); vertex_idx++) {
+								polygon.push_back(outline_vertices[vertex_idx] + anchor);
+							}
 						}
+						colors.resize(polygon.size());
+						colors.fill(c_bg);
 					}
 					workspace->draw_polygon(polygon, colors);
 
@@ -2856,11 +2863,14 @@ void TileSetEditor::draw_polygon_shapes() {
 								colors.push_back(c_bg);
 							}
 						} else {
-							PoolVector<Vector2> vertices = shape->get_vertices();
-							for (int j = 0; j < shape->get_polygon(0).size(); j++) {
-								polygon.push_back(vertices[shape->get_polygon(0)[j]] + anchor);
-								colors.push_back(c_bg);
+							for (int outline_idx = 0; outline_idx < shape->get_outline_count(); outline_idx++) {
+								PoolVector<Vector2> outline_vertices = shape->get_outline(outline_idx);
+								for (int vertex_idx = 0; vertex_idx < outline_vertices.size(); vertex_idx++) {
+									polygon.push_back(outline_vertices[vertex_idx] + anchor);
+								}
 							}
+							colors.resize(polygon.size());
+							colors.fill(c_bg);
 						}
 						workspace->draw_polygon(polygon, colors);
 
@@ -2982,8 +2992,9 @@ void TileSetEditor::close_shape(const Vector2 &shape_anchor) {
 		}
 
 		w.release();
-		shape->set_vertices(polygon);
-		shape->add_polygon(indices);
+		shape->clear_outlines();
+		shape->add_outline(polygon);
+		shape->make_polygons_from_outlines();
 
 		undo_redo->create_action(TTR("Create Navigation Polygon"));
 		if (tileset->tile_get_tile_mode(get_current_tile()) == TileSet::AUTO_TILE || tileset->tile_get_tile_mode(get_current_tile()) == TileSet::ATLAS_TILE) {
@@ -3037,10 +3048,10 @@ void TileSetEditor::select_coord(const Vector2 &coord) {
 		} else if (edit_mode == EDITMODE_NAVIGATION) {
 			current_shape.resize(0);
 			if (edited_navigation_shape.is_valid()) {
-				if (edited_navigation_shape->get_polygon_count() > 0) {
-					PoolVector<Vector2> vertices = edited_navigation_shape->get_vertices();
-					for (int i = 0; i < edited_navigation_shape->get_polygon(0).size(); i++) {
-						current_shape.push_back(vertices[edited_navigation_shape->get_polygon(0)[i]] + current_tile_region.position);
+				for (int outline_idx = 0; outline_idx < edited_navigation_shape->get_outline_count(); outline_idx++) {
+					PoolVector<Vector2> outline_vertices = edited_navigation_shape->get_outline(outline_idx);
+					for (int vertex_inx = 0; vertex_inx < outline_vertices.size(); vertex_inx++) {
+						current_shape.push_back(outline_vertices[vertex_inx] + current_tile_region.position);
 					}
 				}
 			}
@@ -3090,10 +3101,10 @@ void TileSetEditor::select_coord(const Vector2 &coord) {
 		} else if (edit_mode == EDITMODE_NAVIGATION) {
 			current_shape.resize(0);
 			if (edited_navigation_shape.is_valid()) {
-				if (edited_navigation_shape->get_polygon_count() > 0) {
-					PoolVector<Vector2> vertices = edited_navigation_shape->get_vertices();
-					for (int i = 0; i < edited_navigation_shape->get_polygon(0).size(); i++) {
-						current_shape.push_back(vertices[edited_navigation_shape->get_polygon(0)[i]] + shape_anchor);
+				for (int outline_idx = 0; outline_idx < edited_navigation_shape->get_outline_count(); outline_idx++) {
+					PoolVector<Vector2> outline_vertices = edited_navigation_shape->get_outline(outline_idx);
+					for (int vertex_inx = 0; vertex_inx < outline_vertices.size(); vertex_inx++) {
+						current_shape.push_back(outline_vertices[vertex_inx] + shape_anchor);
 					}
 				}
 			}


### PR DESCRIPTION
This is targeting 3.5 to fix very old and persistent 2D navigation bugs in 3.x TileSets.
The entire tileeditor has a full rework in Godot 4.0 that, as far as I am aware, has not copied this issue over to Godot 4.0.

Since this pr would change how NavigationPolygon resources are created and stored by TileSets this would be a breaking change to old navigation tilesets but imo necessary for at least 3.5 with the new NavigationServer introduced.

TileSets created and stored NavigationPolyons in a format that did not work for Navigation or if fixed displayed the NavigationPolygon wrong in the TileSetEditor. This problem was not so noticeable on simple square grids but as soon as users would try to create more complex shapes around corners the navigation polygon would break and navigation would create ugly paths.

![tilsetpolygon](https://user-images.githubusercontent.com/52464204/169671349-1dafa2ee-9aa3-47e1-9c9d-bc526dd5ab6a.png)

I was able to get the TileSet navigation with not simple square shapes working again for the NavigationServer in 3.5 and also make it display correct in the Editor. I might have missed something as 2D and especially the TileEditor is not my forte and I could not figure out some parts e.g. the undo_redo part at FIXME that I commented out so help is welcome.

![tilesetnavbug](https://user-images.githubusercontent.com/52464204/169671375-53569132-1eda-421a-a35f-42794a608f44.png)


Still, not everything is solved for 2D tileset navigation with this. There seems to be a lot of issues in the outdated 2D NavigationServer 3.5 backport related to 2D edge merging that were fixed by groud in Godot 4.0 e.g. I could barely get same edges to merge but not different, shorter edges while the same NavigationPolygon work perfectly in Godot 4.0 but this should be a different topic.

Fixes #30883
Fixes #41349
Fixes #45045
Fixes #43079
and a ton of other duplicates and 2D navigation issues that I randomly sighted but forgot to bookmark while digging through old 2D navigation issues.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
