### PR TITLE
Decrease SphereShape3D's default radius to 0.5 to match primitive mesh

### DIFF
--- a/doc/classes/SphereShape3D.xml
+++ b/doc/classes/SphereShape3D.xml
@@ -11,7 +11,7 @@
 		<link title="3D Physics Tests Demo">https://godotengine.org/asset-library/asset/675</link>
 	</tutorials>
 	<members>
-		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="1.0">
+		<member name="radius" type="float" setter="set_radius" getter="get_radius" default="0.5">
 			The sphere's radius. The shape's diameter is double the radius.
 		</member>
 	</members>

--- a/scene/resources/sphere_shape_3d.cpp
+++ b/scene/resources/sphere_shape_3d.cpp
@@ -83,5 +83,5 @@ void SphereShape3D::_bind_methods() {
 
 SphereShape3D::SphereShape3D() :
 		Shape3D(PhysicsServer3D::get_singleton()->shape_create(PhysicsServer3D::SHAPE_SPHERE)) {
-	set_radius(1.0);
+	set_radius(0.5);
 }

--- a/scene/resources/sphere_shape_3d.h
+++ b/scene/resources/sphere_shape_3d.h
@@ -35,7 +35,7 @@
 
 class SphereShape3D : public Shape3D {
 	GDCLASS(SphereShape3D, Shape3D);
-	float radius = 1.0f;
+	float radius = 0.5f;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
[The SphereMesh primitive mesh's size was recently decreased](https://github.com/godotengine/godot/pull/59321), but unlike other primitive meshes, the sphere shape's radius wasn't adjusted accordingly.

**Testing project:** https://0x0.st/oaVG.zip <sub>(link expires in April 2023)</sub>