### PR TITLE
Update last min size when `Control` becomes visible

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -836,6 +836,7 @@ void Control::_notification(int p_notification) {
 				}
 			} else {
 				data.minimum_size_valid = false;
+				_update_minimum_size();
 				_size_changed();
 			}
 		} break;


### PR DESCRIPTION
Fixes #61073

When the control is not visible in tree, its `data.last_minimum_size` won't be updated. So after hiding the control, changing its min size, and showing the control again, later updates to the min size might incorrectly skip the size update.

This PR adds a min size update when the control becomes visible.
