### PR TITLE
[3.x] Fix incorrect encoding used in `_error_handler` functions

### DIFF
--- a/editor/editor_log.cpp
+++ b/editor/editor_log.cpp
@@ -45,9 +45,9 @@ void EditorLog::_error_handler(void *p_self, const char *p_func, const char *p_f
 
 	String err_str;
 	if (p_errorexp && p_errorexp[0]) {
-		err_str = p_errorexp;
+		err_str = String::utf8(p_errorexp);
 	} else {
-		err_str = String(p_file) + ":" + itos(p_line) + " - " + String(p_error);
+		err_str = String::utf8(p_file) + ":" + itos(p_line) + " - " + String::utf8(p_error);
 	}
 
 	if (p_type == ERR_HANDLER_WARNING) {

--- a/editor/rename_dialog.cpp
+++ b/editor/rename_dialog.cpp
@@ -470,7 +470,7 @@ String RenameDialog::_substitute(const String &subject, const Node *node, int co
 
 void RenameDialog::_error_handler(void *p_self, const char *p_func, const char *p_file, int p_line, const char *p_error, const char *p_errorexp, ErrorHandlerType p_type) {
 	RenameDialog *self = (RenameDialog *)p_self;
-	String source_file(p_file);
+	String source_file = String::utf8(p_file);
 
 	// Only show first error that is related to "regex"
 	if (self->has_errors || source_file.find("regex") < 0) {
@@ -479,9 +479,9 @@ void RenameDialog::_error_handler(void *p_self, const char *p_func, const char *
 
 	String err_str;
 	if (p_errorexp && p_errorexp[0]) {
-		err_str = p_errorexp;
+		err_str = String::utf8(p_errorexp);
 	} else {
-		err_str = p_error;
+		err_str = String::utf8(p_error);
 	}
 
 	self->has_errors = true;

--- a/scene/debugger/script_debugger_remote.cpp
+++ b/scene/debugger/script_debugger_remote.cpp
@@ -484,7 +484,7 @@ void ScriptDebuggerRemote::_err_handler(void *ud, const char *p_func, const char
 	}
 
 	ScriptDebuggerRemote *sdr = (ScriptDebuggerRemote *)ud;
-	sdr->send_error(p_func, p_file, p_line, p_err, p_descr, p_type, si);
+	sdr->send_error(String::utf8(p_func), String::utf8(p_file), p_line, String::utf8(p_err), String::utf8(p_descr), p_type, si);
 }
 
 bool ScriptDebuggerRemote::_parse_live_edit(const Array &p_command) {


### PR DESCRIPTION
Backports #54784

The debugger panel currently only shows ASCII characters for `push_error()` and `push_warning()` calls.