### PR TITLE
Fix const typed array assignment

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1514,10 +1514,22 @@ void GDScriptAnalyzer::resolve_variable(GDScriptParser::VariableNode *p_variable
 void GDScriptAnalyzer::resolve_constant(GDScriptParser::ConstantNode *p_constant) {
 	GDScriptParser::DataType type;
 
+	GDScriptParser::DataType explicit_type;
+	if (p_constant->datatype_specifier != nullptr) {
+		explicit_type = resolve_datatype(p_constant->datatype_specifier);
+		explicit_type.is_meta_type = false;
+	}
+
 	if (p_constant->initializer != nullptr) {
 		reduce_expression(p_constant->initializer);
 		if (p_constant->initializer->type == GDScriptParser::Node::ARRAY) {
-			const_fold_array(static_cast<GDScriptParser::ArrayNode *>(p_constant->initializer));
+			GDScriptParser::ArrayNode *array = static_cast<GDScriptParser::ArrayNode *>(p_constant->initializer);
+			const_fold_array(array);
+
+			// Can only infer typed array if it has elements.
+			if (array->elements.size() > 0 || (p_constant->datatype_specifier != nullptr && explicit_type.has_container_element_type())) {
+				update_array_literal_element_type(explicit_type, array);
+			}
 		} else if (p_constant->initializer->type == GDScriptParser::Node::DICTIONARY) {
 			const_fold_dictionary(static_cast<GDScriptParser::DictionaryNode *>(p_constant->initializer));
 		}
@@ -1536,8 +1548,6 @@ void GDScriptAnalyzer::resolve_constant(GDScriptParser::ConstantNode *p_constant
 	}
 
 	if (p_constant->datatype_specifier != nullptr) {
-		GDScriptParser::DataType explicit_type = resolve_datatype(p_constant->datatype_specifier);
-		explicit_type.is_meta_type = false;
 		if (!is_type_compatible(explicit_type, type)) {
 			push_error(vformat(R"(Assigned value for constant "%s" has type %s which is not compatible with defined type %s.)", p_constant->identifier->name, type.to_string(), explicit_type.to_string()), p_constant->initializer);
 #ifdef DEBUG_ENABLED

--- a/modules/gdscript/tests/scripts/analyzer/typed_array_assignment.gd
+++ b/modules/gdscript/tests/scripts/analyzer/typed_array_assignment.gd
@@ -1,0 +1,2 @@
+func test():
+	const arr: Array[int] = ["Hello", "World"]

--- a/modules/gdscript/tests/scripts/analyzer/typed_array_assignment.out
+++ b/modules/gdscript/tests/scripts/analyzer/typed_array_assignment.out
@@ -1,0 +1,2 @@
+GDTEST_ANALYZER_ERROR
+Assigned value for constant "arr" has type Array[String] which is not compatible with defined type Array[int].


### PR DESCRIPTION
Fixes `const x: Array[int] = []` and `const x: Array[int] = [3,2,1]` not type checking, where int can be whatever type. Copied solution from how member constants resolve types, as they work fine.
Could add a test case to modules/gdscript/tests/scripts/parser/features/typed_arrays.gd, not sure how you guys like your tests.