### PR TITLE
`EditorPropertyArray` Fix crash when drag-reordering array elements in the inspector

### DIFF
--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -607,11 +607,16 @@ void EditorPropertyArray::_reorder_button_gui_input(const Ref<InputEvent> &p_eve
 		Variant array = object->get_array();
 		int size = array.call("size");
 
-		if ((reorder_to_index == 0 && mm->get_relative().y < 0.0f) || (reorder_to_index == size - 1 && mm->get_relative().y > 0.0f)) {
+		// Cumulate the mouse delta, many small changes (dragging slowly) should result in reordering at some point.
+		reorder_mouse_y_delta += mm->get_relative().y;
+
+		// Reordering is done by moving the dragged element by +1/-1 index at a time based on the cumulated mouse delta so if
+		// already at the array bounds make sure to ignore the remaining out of bounds drag (by resetting the cumulated delta).
+		if ((reorder_to_index == 0 && reorder_mouse_y_delta < 0.0f) || (reorder_to_index == size - 1 && reorder_mouse_y_delta > 0.0f)) {
+			reorder_mouse_y_delta = 0.0f;
 			return;
 		}
 
-		reorder_mouse_y_delta += mm->get_relative().y;
 		float required_y_distance = 20.0f * EDSCALE;
 		if (ABS(reorder_mouse_y_delta) > required_y_distance) {
 			int direction = reorder_mouse_y_delta > 0.0f ? 1 : -1;


### PR DESCRIPTION
Fixes #54734.

When dragging fast the cumulated `reorder_mouse_y_delta` can get big but it wasn't being reset when dragging at the ends of the Array. At the ends only the current `InputEventMouseMotion`'s relative movement was checked meaning if dragging fast to the beginning of the Array `reorder_mouse_y_delta` could get something like -1000 and if followed by slow drag downwards it wouldn't abort early as `(reorder_to_index == 0 && mm->get_relative().y < 0.0f)` condition wouldn't be met and thus it would deduce to reorder upwards to -1 index because of that cumulated `reorder_mouse_y_delta`.