### PR TITLE
Remove image property of ImageTexture

### DIFF
--- a/doc/classes/Texture2D.xml
+++ b/doc/classes/Texture2D.xml
@@ -106,7 +106,8 @@
 		<method name="get_image" qualifiers="const">
 			<return type="Image" />
 			<description>
-				Returns an [Image] that is a copy of data from this [Texture2D]. [Image]s can be accessed and manipulated directly.
+				Returns an [Image] that is a copy of data from this [Texture2D] (a new [Image] is created each time). [Image]s can be accessed and manipulated directly.
+				[b]Note:[/b] This will fetch the texture data from the GPU, which might cause performance problems when overused.
 			</description>
 		</method>
 		<method name="get_size" qualifiers="const">

--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -147,38 +147,6 @@ void ImageTexture::reload_from_file() {
 	}
 }
 
-bool ImageTexture::_set(const StringName &p_name, const Variant &p_value) {
-	if (p_name == "image") {
-		create_from_image(p_value);
-	} else if (p_name == "size") {
-		Size2 s = p_value;
-		w = s.width;
-		h = s.height;
-		RenderingServer::get_singleton()->texture_set_size_override(texture, w, h);
-	} else {
-		return false;
-	}
-
-	return true;
-}
-
-bool ImageTexture::_get(const StringName &p_name, Variant &r_ret) const {
-	if (p_name == "image") {
-		r_ret = get_image();
-	} else if (p_name == "size") {
-		r_ret = Size2(w, h);
-	} else {
-		return false;
-	}
-
-	return true;
-}
-
-void ImageTexture::_get_property_list(List<PropertyInfo> *p_list) const {
-	p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("image"), PROPERTY_HINT_RESOURCE_TYPE, "Image", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT));
-	p_list->push_back(PropertyInfo(Variant::VECTOR2, PNAME("size"), PROPERTY_HINT_NONE, ""));
-}
-
 void ImageTexture::create_from_image(const Ref<Image> &p_image) {
 	ERR_FAIL_COND_MSG(p_image.is_null() || p_image->is_empty(), "Invalid image");
 	w = p_image->get_width();

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -102,11 +102,6 @@ class ImageTexture : public Texture2D {
 
 protected:
 	virtual void reload_from_file() override;
-
-	bool _set(const StringName &p_name, const Variant &p_value);
-	bool _get(const StringName &p_name, Variant &r_ret) const;
-	void _get_property_list(List<PropertyInfo> *p_list) const;
-
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
Closes #25209
I removed the `image` and `size` properties, as they were acting unexpectedly and weren't even documented.

Someone from @godotengine/rendering should probably confirm whether the added description note is true.