### PR TITLE
Implement unload of PCK files

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -619,6 +619,27 @@ bool ProjectSettings::_load_resource_pack(const String &p_pack, bool p_replace_f
 	return true;
 }
 
+bool ProjectSettings::_unload_resource_pack(const String &p_pack) {
+	if (PackedData::get_singleton()->is_disabled()) {
+		return false;
+	}
+
+	bool ok = PackedData::get_singleton()->remove_pack(p_pack) == OK;
+	if (!ok) {
+		return false;
+	}
+
+	return true;
+}
+
+bool ProjectSettings::_is_pack_loaded(const String &p_pack) {
+	if (PackedData::get_singleton()->is_disabled()) {
+		return false;
+	}
+
+	return PackedData::get_singleton()->is_pack_loaded(p_pack);
+}
+
 void ProjectSettings::_convert_to_last_version(int p_from_version) {
 #ifndef DISABLE_DEPRECATED
 	if (p_from_version <= 3) {
@@ -1631,6 +1652,8 @@ void ProjectSettings::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("globalize_path", "path"), &ProjectSettings::globalize_path);
 	ClassDB::bind_method(D_METHOD("save"), &ProjectSettings::save);
 	ClassDB::bind_method(D_METHOD("load_resource_pack", "pack", "replace_files", "offset"), &ProjectSettings::load_resource_pack, DEFVAL(true), DEFVAL(0));
+	ClassDB::bind_method(D_METHOD("unload_resource_pack", "pack"), &ProjectSettings::_unload_resource_pack);
+	ClassDB::bind_method(D_METHOD("is_pack_loaded", "name"), &ProjectSettings::_is_pack_loaded);
 
 	ClassDB::bind_method(D_METHOD("save_custom", "file"), &ProjectSettings::_save_custom_bnd);
 

--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -146,6 +146,8 @@ protected:
 
 	bool load_resource_pack(const String &p_pack, bool p_replace_files, int p_offset);
 	bool _load_resource_pack(const String &p_pack, bool p_replace_files = true, int p_offset = 0, bool p_main_pack = false);
+	bool _unload_resource_pack(const String &p_pack);
+	bool _is_pack_loaded(const String &p_pack);
 
 	void _add_property_info_bind(const Dictionary &p_info);
 

--- a/core/io/file_access_pack.cpp
+++ b/core/io/file_access_pack.cpp
@@ -36,6 +36,11 @@
 #include "core/os/os.h"
 #include "core/version.h"
 
+#include "modules/modules_enabled.gen.h" // For gdscript.
+#ifdef MODULE_GDSCRIPT_ENABLED
+#include "modules/gdscript/gdscript_cache.h"
+#endif
+
 Error PackedData::add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key) {
 	for (int i = 0; i < sources.size(); i++) {
 		if (sources[i]->try_open_pack(p_path, p_replace_files, p_offset, p_decryption_key)) {
@@ -46,17 +51,71 @@ Error PackedData::add_pack(const String &p_path, bool p_replace_files, uint64_t 
 	return ERR_FILE_UNRECOGNIZED;
 }
 
+Error PackedData::remove_pack(const String &p_path) {
+	if (!is_pack_loaded(p_path)) {
+		return ERR_FILE_UNRECOGNIZED;
+	}
+
+	HashSet<PathMD5, PathMD5> reload_packs;
+	Vector<HashMap<PathMD5, PackedFile, PathMD5>::Iterator> to_remove;
+	for (HashMap<PathMD5, PackedFile, PathMD5>::Iterator E = files.begin(); E; ++E) {
+		const PackedFile &pf = E->value;
+		if (pf.pack.name != p_path) {
+			continue;
+		}
+
+		const PathMD5 &pmd5 = pf.pack.replaced_pack;
+		if (pmd5.set) {
+			reload_packs.insert(pmd5);
+		}
+
+		remove_path(pf.filepath);
+		to_remove.push_back(E);
+	}
+
+	for (const HashMap<PathMD5, PackedFile, PathMD5>::Iterator &E : to_remove) {
+		files.remove(E);
+	}
+	remove_loaded_pack(p_path);
+
+	// For reloading files unloaded by more recent packs, we simply need to reload packs with replace_files disabled.
+	for (const PathMD5 &pmd5 : reload_packs) {
+		if (!loaded_packs.has(pmd5)) {
+			continue;
+		}
+		const LoadedPackInfo &pack_info = loaded_packs[pmd5];
+		Error err = add_pack(pack_info.name, false, pack_info.offset);
+		if (err) {
+			return err;
+		}
+	}
+
+	return OK;
+}
+
 void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64_t p_ofs, uint64_t p_size, const uint8_t *p_md5, PackSource *p_src, bool p_replace_files, bool p_encrypted, bool p_bundle, bool p_delta, const String &p_salt) {
 	String simplified_path = p_path.simplify_path().trim_prefix("res://");
 	PathMD5 pmd5(simplified_path.md5_buffer());
 
+	// When running on the editor, the base files are not loaded from a main pack file.
+	// This extra check prevents packs from overriding those base files.
+#ifdef TOOLS_ENABLED
+	bool exists = files.has(pmd5) || FileAccess::exists(simplified_path);
+#else
 	bool exists = files.has(pmd5);
+#endif
+
+	PackInfo pi;
+	pi.name = p_pkg_path;
+	if (p_replace_files && exists) {
+		pi.replaced_pack = PathMD5(files[pmd5].pack.name.md5_buffer());
+	}
 
 	PackedFile pf;
 	pf.encrypted = p_encrypted;
 	pf.bundle = p_bundle;
 	pf.delta = p_delta;
-	pf.pack = p_pkg_path;
+	pf.pack = pi;
 	pf.salt = p_salt;
 	pf.offset = p_ofs;
 	pf.size = p_size;
@@ -64,6 +123,7 @@ void PackedData::add_path(const String &p_pkg_path, const String &p_path, uint64
 		pf.md5[i] = p_md5[i];
 	}
 	pf.src = p_src;
+	pf.filepath = simplified_path.replace_first("res://", "");
 
 	if (p_delta) {
 		delta_patches[pmd5].push_back(pf);
@@ -120,10 +180,54 @@ void PackedData::remove_path(const String &p_path) {
 			}
 		}
 	}
+	const String &filename = simplified_path.get_file();
+	cd->files.erase(filename);
 
-	cd->files.erase(simplified_path.get_file());
+	// Clear empty folders.
+	while (cd && cd->files.is_empty() && cd->subdirs.is_empty()) {
+		const String &name = cd->name;
+		cd = cd->parent;
+		if (cd) {
+			cd->subdirs.erase(name);
+		}
+	}
 
 	files.erase(pmd5);
+
+	String res_path = "res://" + p_path;
+
+	// Remove paths from cache.
+	if (ResourceCache::has(res_path)) {
+		ResourceCache::remove_cached_resource(res_path);
+	}
+
+	// GDScript also caches scripts internally, so they too must be removed.
+#ifdef MODULE_GDSCRIPT_ENABLED
+	if (GDScriptCache::get_cached_script(res_path).is_valid()) {
+		GDScriptCache::remove_script(res_path);
+	}
+#endif
+}
+
+void PackedData::add_loaded_pack(const String &p_path, uint64_t p_offset) {
+	if (!is_pack_loaded(p_path)) {
+		LoadedPackInfo pack_info;
+		pack_info.name = p_path;
+		pack_info.offset = p_offset;
+
+		PathMD5 pmd5(p_path.md5_buffer());
+		loaded_packs.insert(pmd5, pack_info);
+	}
+}
+
+void PackedData::remove_loaded_pack(const String &p_path) {
+	PathMD5 pmd5(p_path.md5_buffer());
+	loaded_packs.erase(pmd5);
+}
+
+bool PackedData::is_pack_loaded(const String &p_pack_path) const {
+	PathMD5 pmd5(p_pack_path.md5_buffer());
+	return loaded_packs.has(pmd5);
 }
 
 void PackedData::add_pack_source(PackSource *p_source) {
@@ -349,6 +453,8 @@ bool PackedSourcePCK::try_open_pack(const String &p_path, bool p_replace_files, 
 		f = fae;
 	}
 
+	PackedData::get_singleton()->add_loaded_pack(p_path, p_offset);
+
 	for (int i = 0; i < file_count; i++) {
 		uint32_t sl = f->get_32();
 		CharString cs;
@@ -526,14 +632,15 @@ void FileAccessPack::close() {
 FileAccessPack::FileAccessPack(const String &p_path, const PackedData::PackedFile &p_file, const Vector<uint8_t> &p_decryption_key) {
 	path = p_path;
 	pf = p_file;
+	const String &pack_name = pf.pack.name;
 	if (pf.bundle) {
 		String simplified_path = p_path.simplify_path();
 		String path_to_load = simplified_path;
 #ifdef TOOLS_ENABLED
 		if (!pf.salt.is_empty()) {
-			path_to_load = pf.pack.get_base_dir().path_join((simplified_path + pf.salt).sha256_text());
+			path_to_load = pack_name.get_base_dir().path_join((simplified_path + pf.salt).sha256_text());
 		} else {
-			path_to_load = pf.pack.get_base_dir().path_join(simplified_path.replace("res://", ""));
+			path_to_load = pack_name.get_base_dir().path_join(simplified_path.replace("res://", ""));
 		}
 #else
 		if (!pf.salt.is_empty()) {
@@ -541,11 +648,11 @@ FileAccessPack::FileAccessPack(const String &p_path, const PackedData::PackedFil
 		}
 #endif
 		f = FileAccess::open(path_to_load, FileAccess::READ | FileAccess::SKIP_PACK);
-		ERR_FAIL_COND_MSG(f.is_null(), vformat(R"(Can't open pack-referenced file "%s" from sparse pack "%s".)", simplified_path, pf.pack));
+		ERR_FAIL_COND_MSG(f.is_null(), vformat(R"(Can't open pack-referenced file "%s" from sparse pack "%s".)", simplified_path, pack_name));
 		off = 0; // For the sparse pack offset is always zero.
 	} else {
-		f = FileAccess::open(pf.pack, FileAccess::READ);
-		ERR_FAIL_COND_MSG(f.is_null(), vformat(R"(Can't open pack-referenced file "%s" from pack "%s".)", p_path, pf.pack));
+		f = FileAccess::open(pack_name, FileAccess::READ);
+		ERR_FAIL_COND_MSG(f.is_null(), vformat(R"(Can't open pack-referenced file "%s" from pack "%s".)", p_path, pack_name));
 		f->seek(pf.offset);
 		off = pf.offset;
 	}
@@ -553,7 +660,7 @@ FileAccessPack::FileAccessPack(const String &p_path, const PackedData::PackedFil
 	if (pf.encrypted) {
 		Ref<FileAccessEncrypted> fae;
 		fae.instantiate();
-		ERR_FAIL_COND_MSG(fae.is_null(), vformat(R"(Can't open encrypted pack-referenced file "%s" from pack "%s".)", p_path, pf.pack));
+		ERR_FAIL_COND_MSG(fae.is_null(), vformat(R"(Can't open encrypted pack-referenced file "%s" from pack "%s".)", p_path, pack_name));
 
 		Vector<uint8_t> key;
 #ifdef TOOLS_ENABLED
@@ -571,7 +678,7 @@ FileAccessPack::FileAccessPack(const String &p_path, const PackedData::PackedFil
 		}
 
 		Error err = fae->open_and_parse(f, key, FileAccessEncrypted::MODE_READ, false);
-		ERR_FAIL_COND_MSG(err, vformat(R"(Can't open encrypted pack-referenced file "%s" from pack "%s".)", p_path, pf.pack));
+		ERR_FAIL_COND_MSG(err, vformat(R"(Can't open encrypted pack-referenced file "%s" from pack "%s".)", p_path, pack_name));
 		f = fae;
 		off = 0;
 	}

--- a/core/io/file_access_pack.h
+++ b/core/io/file_access_pack.h
@@ -33,6 +33,7 @@
 #include "core/io/dir_access.h"
 #include "core/io/file_access.h"
 #include "core/string/print_string.h"
+#include "core/string/ustring.h"
 #include "core/templates/hash_set.h"
 #include "core/templates/list.h"
 
@@ -66,8 +67,39 @@ class PackedData {
 	friend class PackSource;
 
 public:
+	struct PathMD5 {
+		uint64_t a = 0;
+		uint64_t b = 0;
+		bool set = false;
+
+		bool operator==(const PathMD5 &p_val) const {
+			return (a == p_val.a) && (b == p_val.b);
+		}
+		bool operator!=(const PathMD5 &p_val) const {
+			return !operator==(p_val);
+		}
+		static uint32_t hash(const PathMD5 &p_val) {
+			uint32_t h = hash_murmur3_one_32(p_val.a);
+			return hash_fmix32(hash_murmur3_one_32(p_val.b, h));
+		}
+
+		PathMD5() {}
+
+		explicit PathMD5(const Vector<uint8_t> &p_buf) {
+			a = *((uint64_t *)&p_buf[0]);
+			b = *((uint64_t *)&p_buf[8]);
+			set = true;
+		}
+	};
+
+	struct PackInfo {
+		String name;
+		PathMD5 replaced_pack;
+	};
+
 	struct PackedFile {
-		String pack;
+		PackInfo pack;
+		String filepath;
 		uint64_t offset; //if offset is ZERO, the file was ERASED
 		uint64_t size;
 		uint8_t md5[16];
@@ -86,28 +118,14 @@ private:
 		HashSet<String> files;
 	};
 
-	struct PathMD5 {
-		uint64_t a = 0;
-		uint64_t b = 0;
-
-		bool operator==(const PathMD5 &p_val) const {
-			return (a == p_val.a) && (b == p_val.b);
-		}
-		static uint32_t hash(const PathMD5 &p_val) {
-			uint32_t h = hash_murmur3_one_32(p_val.a);
-			return hash_fmix32(hash_murmur3_one_32(p_val.b, h));
-		}
-
-		PathMD5() {}
-
-		explicit PathMD5(const Vector<uint8_t> &p_buf) {
-			a = *((uint64_t *)&p_buf[0]);
-			b = *((uint64_t *)&p_buf[8]);
-		}
+	struct LoadedPackInfo {
+		String name;
+		uint64_t offset;
 	};
 
 	HashMap<PathMD5, PackedFile, PathMD5> files;
 	HashMap<PathMD5, Vector<PackedFile>, PathMD5> delta_patches;
+	HashMap<PathMD5, LoadedPackInfo, PathMD5> loaded_packs;
 
 	Vector<PackSource *> sources;
 
@@ -128,11 +146,16 @@ public:
 	bool has_delta_patches(const String &p_path) const;
 	HashSet<String> get_file_paths() const;
 
+	void add_loaded_pack(const String &p_path, uint64_t p_offset);
+	void remove_loaded_pack(const String &p_path);
+	bool is_pack_loaded(const String &p_pack_path) const;
+
 	void set_disabled(bool p_disabled) { disabled = p_disabled; }
 	_FORCE_INLINE_ bool is_disabled() const { return disabled; }
 
 	static PackedData *get_singleton() { return singleton; }
 	Error add_pack(const String &p_path, bool p_replace_files, uint64_t p_offset, const Vector<uint8_t> &p_decryption_key = Vector<uint8_t>());
+	Error remove_pack(const String &p_path);
 
 	void clear();
 

--- a/core/io/file_access_patched.cpp
+++ b/core/io/file_access_patched.cpp
@@ -51,7 +51,7 @@ Error FileAccessPatched::_apply_patch() const {
 		uint64_t total_usec_start = OS::get_singleton()->get_ticks_usec();
 		uint64_t io_usec_start = OS::get_singleton()->get_ticks_usec();
 
-		Ref<FileAccess> patch_file = FileAccess::open(delta_patch.pack, FileAccess::READ, &err);
+		Ref<FileAccess> patch_file = FileAccess::open(delta_patch.pack.name, FileAccess::READ, &err);
 		ERR_FAIL_COND_V(err != OK, err);
 
 		patch_file->seek(delta_patch.offset);
@@ -73,7 +73,7 @@ Error FileAccessPatched::_apply_patch() const {
 
 		uint64_t total_usec_end = OS::get_singleton()->get_ticks_usec();
 
-		print_verbose(vformat(U"Applied delta patch to \"%s\" from \"%s\" in %d μs (%d μs I/O, %d μs decoding).", path, delta_patch.pack.get_file(), total_usec_end - total_usec_start, io_usec_end - io_usec_start, decode_usec_end - decode_usec_start));
+		print_verbose(vformat(U"Applied delta patch to \"%s\" from \"%s\" in %d μs (%d μs I/O, %d μs decoding).", path, delta_patch.pack.name.get_file(), total_usec_end - total_usec_start, io_usec_end - io_usec_start, decode_usec_end - decode_usec_start));
 	}
 
 	patched_file_data = old_file_data;

--- a/core/io/file_access_zip.cpp
+++ b/core/io/file_access_zip.cpp
@@ -177,6 +177,8 @@ bool ZipArchive::try_open_pack(const String &p_path, bool p_replace_files, uint6
 	packages.push_back(pkg);
 	int pkg_num = packages.size() - 1;
 
+	PackedData::get_singleton()->add_loaded_pack(p_path, 0);
+
 	for (uint64_t i = 0; i < gi.number_entry; i++) {
 		char filename_inzip[256];
 

--- a/core/io/resource.cpp
+++ b/core/io/resource.cpp
@@ -890,6 +890,11 @@ void ResourceCache::get_cached_resources(List<Ref<Resource>> *p_resources) {
 	}
 }
 
+void ResourceCache::remove_cached_resource(const String &p_path) {
+	MutexLock mutex_lock(lock);
+	resources.erase(p_path);
+}
+
 int ResourceCache::get_cached_resource_count() {
 	MutexLock mutex_lock(lock);
 	return resources.size();

--- a/core/io/resource.h
+++ b/core/io/resource.h
@@ -213,5 +213,6 @@ public:
 	static bool has(const String &p_path);
 	static Ref<Resource> get_ref(const String &p_path);
 	static void get_cached_resources(List<Ref<Resource>> *p_resources);
+	static void remove_cached_resource(const String &p_path);
 	static int get_cached_resource_count();
 };

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -166,6 +166,14 @@
 				[b]Note:[/b] In order to be be detected, custom settings have to be either defined with [method set_setting], or exist in the [code]project.godot[/code] file. This is especially relevant when using [method set_initial_value].
 			</description>
 		</method>
+		<method name="is_pack_loaded">
+			<return type="bool" />
+			<param index="0" name="name" type="String" />
+			<description>
+				Returns [code]true[/code] if a given .pck or .zip file is currently loaded.
+				[b]Note:[/b] A pack is considered loaded even if nothing is currently using its resources, or if all of its files have been replaced by other packs.
+			</description>
+		</method>
 		<method name="load_resource_pack">
 			<return type="bool" />
 			<param index="0" name="pack" type="String" />
@@ -268,6 +276,15 @@
 				[/csharp]
 				[/codeblocks]
 				This can also be used to erase custom project settings. To do this change the setting value to [code]null[/code].
+			</description>
+		</method>
+		<method name="unload_resource_pack">
+			<return type="bool" />
+			<param index="0" name="pack" type="String" />
+			<description>
+				Unloads a previously loaded [param pack] from the resource filesystem. Returns [code]true[/code] on success.
+				[b]Note:[/b] If this pack replaced files when it was loaded, and if the affected pack is still loaded, then all the replaced files will be restored.
+				[b]Warning:[/b] Unloading a pack can cause issues and instability if any of it's resources are still being used. Ensure nothing is still using the pack's resources when unloading it.
 			</description>
 		</method>
 	</methods>


### PR DESCRIPTION
*Implements some ideas from https://github.com/godotengine/godot-proposals/issues/2689.*

This adds the functionality to unload any manually loaded pack from `load_resource_pack`, as well as querying if a specific pack is currently loaded.

The tricky part here is handling packs that replace files. The way I implemented some scenarios may not be what's intended, so I'll describe scenarios I found to ensure the behavior is intended. I also created a small project to help me test this, so if you want to play around and test these for yourself, here are the project files:
[PCKTestingTool.zip](https://github.com/godotengine/godot/files/8749774/PCKTestingTool.zip)

> EDIT: Re-recorded video for better clarity

https://github.com/godotengine/godot/assets/6501975/9ec46608-8e3f-4e52-817c-b9c5b86304f9

On all these scenarios, there are 3 PCK files, all with different content on each scene, but with some duplicated names:
```
1.pck
└── a.tscn

2.pck
├── a.tscn
└── b.tscn

3.pck
└── b.tscn
```
## Unloading pack which replaced some files from another one
- Loading `2.pck`:
```
a.tscn -> 2.pck
b.tscn -> 2.pck
```
- Then loading `3.pck` with replacing files enabled:
```
a.tscn -> 2.pck
b.tscn -> 3.pck
```
- **When unloading `3.pck`, the files from `2.pck` that were replaced are fetched and loaded again, essentially restoring the previous state**:
```
a.tscn -> 2.pck
b.tscn -> 2.pck
```
## Unloading pack which replaced files from an unloaded package
- Loading `1.pck`:
```
a.tscn -> 1.pck
```
- Then loading `2.pck` with replacing files enabled:
```
a.tscn -> 2.pck
b.tscn -> 2.pck
```
- Then unloading `1.pck` *(nothing happens because all its files were replaced by `2.pck`)*:
```
a.tscn -> 2.pck
b.tscn -> 2.pck
```
- **When unloading `2.pck`, the files from `1.pck` could have been replaced; however, because `1.pck` has been unloaded in the meantime, none of it's files are reloaded**:
```
<empty>
```
## Unloading pack which didn't replace any existing files
- Loading `1.pck`
```
a.tscn -> 1.pck
```
- Then loading `2.pck` without replacing files:
```
a.tscn -> 1.pck
b.tscn -> 2.pck
```
- **When unloading `1.pck`, the only files remaining are the ones `2.pck` was able to load, leaving it in a partial state**:
```
b.tscn -> 2.pck
```
- **Reloading `2.pck` loads the missing files**:
```
a.tscn -> 2.pck
b.tscn -> 2.pck
```

- *Production edit: This closes https://github.com/godotengine/godot-proposals/issues/12047.*