### PR TITLE
Remove `UndoRedo` calls trying to call removed `EditorInspector::refresh()`

### DIFF
--- a/editor/multi_node_edit.cpp
+++ b/editor/multi_node_edit.cpp
@@ -87,8 +87,6 @@ bool MultiNodeEdit::_set_impl(const StringName &p_name, const Variant &p_value, 
 
 		ur->add_undo_property(n, name, n->get(name));
 	}
-	ur->add_do_method(InspectorDock::get_inspector_singleton(), "refresh");
-	ur->add_undo_method(InspectorDock::get_inspector_singleton(), "refresh");
 
 	ur->commit_action();
 	return true;


### PR DESCRIPTION
Fixes #61267.

`EditorInspector::refresh()` was removed in #45879. I think the removed code doesn't need to be replaced by anything as now inspector is meant to auto detect the changes and refresh itself automatically.
I've searched for `"refresh"`, haven't found any more leftovers.