### PR TITLE
Redraw selected 3D gizmo on deselect

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -8126,7 +8126,13 @@ void Node3DEditorPlugin::edit(Object *p_object) {
 }
 
 bool Node3DEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("Node3D");
+	if (p_object->is_class("Node3D")) {
+		return true;
+	} else {
+		// This ensures that gizmos are cleared when selecting a non-Node3D node.
+		const_cast<Node3DEditorPlugin *>(this)->edit((Object *)nullptr);
+		return false;
+	}
 }
 
 Dictionary Node3DEditorPlugin::get_state() const {


### PR DESCRIPTION
Fixes #13849
This solution is one big hack and I'm wondering how reliable it is (it assumes that `handles()` is called whenever you try to edit a new object), but it's at least "safe", i.e. local to the relevant part of the code (unlike #21831).

A more proper solution would be keeping track of plugins that successfully edited an object (i.e. returned true with `handles()`) and add an `unedit()` method (or just `edit(null)`) called when that plugin can no longer handle an object. But that requires more work and there doesn't seem to be much demand for it.