### PR TITLE
Improve MultiplayerSynchronizer and MultiplayerSpawner editor usability

### DIFF
--- a/doc/classes/MultiplayerSpawner.xml
+++ b/doc/classes/MultiplayerSpawner.xml
@@ -13,6 +13,28 @@
 			<description>
 			</description>
 		</method>
+		<method name="add_spawnable_scene">
+			<return type="void" />
+			<argument index="0" name="path" type="String" />
+			<description>
+			</description>
+		</method>
+		<method name="clear_spawnable_scenes">
+			<return type="void" />
+			<description>
+			</description>
+		</method>
+		<method name="get_spawnable_scene" qualifiers="const">
+			<return type="String" />
+			<argument index="0" name="path" type="int" />
+			<description>
+			</description>
+		</method>
+		<method name="get_spawnable_scene_count" qualifiers="const">
+			<return type="int" />
+			<description>
+			</description>
+		</method>
 		<method name="spawn">
 			<return type="Node" />
 			<argument index="0" name="data" type="Variant" default="null" />
@@ -22,8 +44,6 @@
 	</methods>
 	<members>
 		<member name="auto_spawn" type="bool" setter="set_auto_spawning" getter="is_auto_spawning" default="false">
-		</member>
-		<member name="replication" type="PackedScene[]" setter="set_spawnable_scenes" getter="get_spawnable_scenes" default="[]">
 		</member>
 		<member name="spawn_limit" type="int" setter="set_spawn_limit" getter="get_spawn_limit" default="0">
 		</member>

--- a/doc/classes/MultiplayerSynchronizer.xml
+++ b/doc/classes/MultiplayerSynchronizer.xml
@@ -7,11 +7,11 @@
 	<tutorials>
 	</tutorials>
 	<members>
+		<member name="congiruation" type="SceneReplicationConfig" setter="set_replication_config" getter="get_replication_config">
+		</member>
 		<member name="replication_interval" type="float" setter="set_replication_interval" getter="get_replication_interval" default="0.0">
 		</member>
-		<member name="resource" type="SceneReplicationConfig" setter="set_replication_config" getter="get_replication_config">
-		</member>
-		<member name="root_path" type="NodePath" setter="set_root_path" getter="get_root_path" default="NodePath(&quot;&quot;)">
+		<member name="root_path" type="NodePath" setter="set_root_path" getter="get_root_path" default="NodePath(&quot;..&quot;)">
 		</member>
 	</members>
 </class>

--- a/doc/classes/SceneReplicationConfig.xml
+++ b/doc/classes/SceneReplicationConfig.xml
@@ -19,6 +19,12 @@
 			<description>
 			</description>
 		</method>
+		<method name="has_property" qualifiers="const">
+			<return type="bool" />
+			<argument index="0" name="path" type="NodePath" />
+			<description>
+			</description>
+		</method>
 		<method name="property_get_index" qualifiers="const">
 			<return type="int" />
 			<argument index="0" name="path" type="NodePath" />

--- a/editor/plugins/replication_editor_plugin.cpp
+++ b/editor/plugins/replication_editor_plugin.cpp
@@ -37,6 +37,129 @@
 #include "scene/gui/tree.h"
 #include "scene/multiplayer/multiplayer_synchronizer.h"
 
+void ReplicationEditor::_pick_node_filter_text_changed(const String &p_newtext) {
+	TreeItem *root_item = pick_node->get_scene_tree()->get_scene_tree()->get_root();
+
+	Vector<Node *> select_candidates;
+	Node *to_select = nullptr;
+
+	String filter = pick_node->get_filter_line_edit()->get_text();
+
+	_pick_node_select_recursive(root_item, filter, select_candidates);
+
+	if (!select_candidates.is_empty()) {
+		for (int i = 0; i < select_candidates.size(); ++i) {
+			Node *candidate = select_candidates[i];
+
+			if (((String)candidate->get_name()).to_lower().begins_with(filter.to_lower())) {
+				to_select = candidate;
+				break;
+			}
+		}
+
+		if (!to_select) {
+			to_select = select_candidates[0];
+		}
+	}
+
+	pick_node->get_scene_tree()->set_selected(to_select);
+}
+
+void ReplicationEditor::_pick_node_select_recursive(TreeItem *p_item, const String &p_filter, Vector<Node *> &p_select_candidates) {
+	if (!p_item) {
+		return;
+	}
+
+	NodePath np = p_item->get_metadata(0);
+	Node *node = get_node(np);
+
+	if (!p_filter.is_empty() && ((String)node->get_name()).findn(p_filter) != -1) {
+		p_select_candidates.push_back(node);
+	}
+
+	TreeItem *c = p_item->get_first_child();
+
+	while (c) {
+		_pick_node_select_recursive(c, p_filter, p_select_candidates);
+		c = c->get_next();
+	}
+}
+
+void ReplicationEditor::_pick_node_filter_input(const Ref<InputEvent> &p_ie) {
+	Ref<InputEventKey> k = p_ie;
+
+	if (k.is_valid()) {
+		switch (k->get_keycode()) {
+			case Key::UP:
+			case Key::DOWN:
+			case Key::PAGEUP:
+			case Key::PAGEDOWN: {
+				pick_node->get_scene_tree()->get_scene_tree()->gui_input(k);
+				pick_node->get_filter_line_edit()->accept_event();
+			} break;
+			default:
+				break;
+		}
+	}
+}
+
+void ReplicationEditor::_pick_node_selected(NodePath p_path) {
+	Node *root = current->get_node(current->get_root_path());
+	ERR_FAIL_COND(!root);
+	Node *node = get_node(p_path);
+	ERR_FAIL_COND(!node);
+	NodePath path_to = root->get_path_to(node);
+	adding_node_path = path_to;
+	prop_selector->select_property_from_instance(node);
+}
+
+void ReplicationEditor::_pick_new_property() {
+	if (current == nullptr) {
+		EditorNode::get_singleton()->show_warning(TTR("Select a replicator node in order to pick a property to add to it."));
+		return;
+	}
+	Node *root = current->get_node(current->get_root_path());
+	if (!root) {
+		EditorNode::get_singleton()->show_warning(TTR("Not possible to add a new property to synchronize without a root."));
+		return;
+	}
+	pick_node->popup_scenetree_dialog();
+	pick_node->get_filter_line_edit()->clear();
+	pick_node->get_filter_line_edit()->grab_focus();
+}
+
+void ReplicationEditor::_add_sync_property(String p_path) {
+	config = current->get_replication_config();
+
+	if (config.is_valid() && config->has_property(p_path)) {
+		EditorNode::get_singleton()->show_warning(TTR("Property is already being synchronized."));
+		return;
+	}
+
+	UndoRedo *undo_redo = EditorNode::get_singleton()->get_undo_redo();
+	undo_redo->create_action(TTR("Add property to synchronizer"));
+
+	if (config.is_null()) {
+		config.instantiate();
+		current->set_replication_config(config);
+		undo_redo->add_do_method(current, "set_replication_config", config);
+		undo_redo->add_undo_method(current, "set_replication_config", Ref<SceneReplicationConfig>());
+		_update_config();
+	}
+
+	undo_redo->add_do_method(config.ptr(), "add_property", p_path);
+	undo_redo->add_undo_method(config.ptr(), "remove_property", p_path);
+	undo_redo->add_do_method(this, "_update_config");
+	undo_redo->add_undo_method(this, "_update_config");
+	undo_redo->commit_action();
+}
+
+void ReplicationEditor::_pick_node_property_selected(String p_name) {
+	String adding_prop_path = String(adding_node_path) + ":" + p_name;
+
+	_add_sync_property(adding_prop_path);
+}
+
 /// ReplicationEditor
 ReplicationEditor::ReplicationEditor() {
 	set_v_size_flags(SIZE_EXPAND_FILL);
@@ -56,16 +179,44 @@ ReplicationEditor::ReplicationEditor() {
 	vb->set_v_size_flags(SIZE_EXPAND_FILL);
 	add_child(vb);
 
+	pick_node = memnew(SceneTreeDialog);
+	add_child(pick_node);
+	pick_node->register_text_enter(pick_node->get_filter_line_edit());
+	pick_node->set_title(TTR("Pick a node to synchronize:"));
+	pick_node->connect("selected", callable_mp(this, &ReplicationEditor::_pick_node_selected));
+	pick_node->get_filter_line_edit()->connect("text_changed", callable_mp(this, &ReplicationEditor::_pick_node_filter_text_changed));
+	pick_node->get_filter_line_edit()->connect("gui_input", callable_mp(this, &ReplicationEditor::_pick_node_filter_input));
+
+	prop_selector = memnew(PropertySelector);
+	add_child(prop_selector);
+	prop_selector->connect("selected", callable_mp(this, &ReplicationEditor::_pick_node_property_selected));
+
 	HBoxContainer *hb = memnew(HBoxContainer);
 	vb->add_child(hb);
+
+	add_pick_button = memnew(Button);
+	add_pick_button->connect("pressed", callable_mp(this, &ReplicationEditor::_pick_new_property));
+	add_pick_button->set_text(TTR("Add property to sync.."));
+	hb->add_child(add_pick_button);
+	VSeparator *vs = memnew(VSeparator);
+	vs->set_custom_minimum_size(Size2(30 * EDSCALE, 0));
+	hb->add_child(vs);
+	hb->add_child(memnew(Label(TTR("Path:"))));
 	np_line_edit = memnew(LineEdit);
 	np_line_edit->set_placeholder(":property");
 	np_line_edit->set_h_size_flags(SIZE_EXPAND_FILL);
 	hb->add_child(np_line_edit);
-	add_button = memnew(Button);
-	add_button->connect("pressed", callable_mp(this, &ReplicationEditor::_add_pressed));
-	add_button->set_text(TTR("Add"));
-	hb->add_child(add_button);
+	add_from_path_button = memnew(Button);
+	add_from_path_button->connect("pressed", callable_mp(this, &ReplicationEditor::_add_pressed));
+	add_from_path_button->set_text(TTR("Add from path"));
+	hb->add_child(add_from_path_button);
+	vs = memnew(VSeparator);
+	vs->set_custom_minimum_size(Size2(30 * EDSCALE, 0));
+	hb->add_child(vs);
+	pin = memnew(Button);
+	pin->set_flat(true);
+	pin->set_toggle_mode(true);
+	hb->add_child(pin);
 
 	tree = memnew(Tree);
 	tree->set_hide_root(true);
@@ -85,12 +236,79 @@ ReplicationEditor::ReplicationEditor() {
 	tree->connect("item_edited", callable_mp(this, &ReplicationEditor::_tree_item_edited));
 	tree->set_v_size_flags(SIZE_EXPAND_FILL);
 	vb->add_child(tree);
+
+	drop_label = memnew(Label);
+	drop_label->set_text(TTR("Add properties using the buttons above or\ndrag them them from the inspector and drop them here."));
+	drop_label->set_horizontal_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	drop_label->set_vertical_alignment(VERTICAL_ALIGNMENT_CENTER);
+	tree->add_child(drop_label);
+	drop_label->set_anchors_and_offsets_preset(Control::PRESET_WIDE);
+
+	tree->set_drag_forwarding(this);
 }
 
 void ReplicationEditor::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_config"), &ReplicationEditor::_update_config);
 	ClassDB::bind_method(D_METHOD("_update_checked", "property", "column", "checked"), &ReplicationEditor::_update_checked);
+	ClassDB::bind_method("_can_drop_data_fw", &ReplicationEditor::_can_drop_data_fw);
+	ClassDB::bind_method("_drop_data_fw", &ReplicationEditor::_drop_data_fw);
+
 	ADD_SIGNAL(MethodInfo("keying_changed"));
+}
+
+bool ReplicationEditor::_can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {
+	Dictionary d = p_data;
+	if (!d.has("type")) {
+		return false;
+	}
+	String t = d["type"];
+	if (t != "obj_property") {
+		return false;
+	}
+	Object *obj = d["object"];
+	if (!obj) {
+		return false;
+	}
+	Node *node = Object::cast_to<Node>(obj);
+	if (!node) {
+		return false;
+	}
+
+	return true;
+}
+
+void ReplicationEditor::_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
+	if (current == nullptr) {
+		EditorNode::get_singleton()->show_warning(TTR("Select a replicator node in order to pick a property to add to it."));
+		return;
+	}
+	Node *root = current->get_node(current->get_root_path());
+	if (!root) {
+		EditorNode::get_singleton()->show_warning(TTR("Not possible to add a new property to synchronize without a root."));
+		return;
+	}
+
+	Dictionary d = p_data;
+	if (!d.has("type")) {
+		return;
+	}
+	String t = d["type"];
+	if (t != "obj_property") {
+		return;
+	}
+	Object *obj = d["object"];
+	if (!obj) {
+		return;
+	}
+	Node *node = Object::cast_to<Node>(obj);
+	if (!node) {
+		return;
+	}
+
+	String path = root->get_path_to(node);
+	path += ":" + String(d["property"]);
+
+	_add_sync_property(path);
 }
 
 void ReplicationEditor::_notification(int p_what) {
@@ -98,6 +316,8 @@ void ReplicationEditor::_notification(int p_what) {
 		case NOTIFICATION_ENTER_TREE:
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
 			add_theme_style_override("panel", EditorNode::get_singleton()->get_gui_base()->get_theme_stylebox(SNAME("panel"), SNAME("Panel")));
+			add_pick_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+			pin->set_icon(get_theme_icon(SNAME("Pin"), SNAME("EditorIcons")));
 		} break;
 
 		case NOTIFICATION_VISIBILITY_CHANGED: {
@@ -236,11 +456,15 @@ void ReplicationEditor::_update_config() {
 	deleting = NodePath();
 	tree->clear();
 	tree->create_item();
+	drop_label->set_visible(true);
 	if (!config.is_valid()) {
 		update_keying();
 		return;
 	}
 	TypedArray<NodePath> props = config->get_properties();
+	if (props.size()) {
+		drop_label->set_visible(false);
+	}
 	for (int i = 0; i < props.size(); i++) {
 		const NodePath path = props[i];
 		_add_property(path, config->property_get_spawn(path), config->property_get_sync(path));
@@ -341,7 +565,9 @@ void ReplicationEditor::property_keyed(const String &p_property) {
 /// ReplicationEditorPlugin
 ReplicationEditorPlugin::ReplicationEditorPlugin() {
 	repl_editor = memnew(ReplicationEditor);
-	EditorNode::get_singleton()->add_bottom_panel_item(TTR("Replication"), repl_editor);
+	button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Replication"), repl_editor);
+	button->hide();
+	repl_editor->get_pin()->connect("pressed", callable_mp(this, &ReplicationEditorPlugin::_pinned));
 }
 
 ReplicationEditorPlugin::~ReplicationEditorPlugin() {
@@ -378,6 +604,17 @@ void ReplicationEditorPlugin::_node_removed(Node *p_node) {
 		if (repl_editor->is_visible_in_tree()) {
 			EditorNode::get_singleton()->hide_bottom_panel();
 		}
+		button->hide();
+		repl_editor->get_pin()->set_pressed(false);
+	}
+}
+
+void ReplicationEditorPlugin::_pinned() {
+	if (!repl_editor->get_pin()->is_pressed()) {
+		if (repl_editor->is_visible_in_tree()) {
+			EditorNode::get_singleton()->hide_bottom_panel();
+		}
+		button->hide();
 	}
 }
 
@@ -391,6 +628,14 @@ bool ReplicationEditorPlugin::handles(Object *p_object) const {
 
 void ReplicationEditorPlugin::make_visible(bool p_visible) {
 	if (p_visible) {
+		//editor->hide_animation_player_editors();
+		//editor->animation_panel_make_visible(true);
+		button->show();
 		EditorNode::get_singleton()->make_bottom_panel_item_visible(repl_editor);
+	} else if (!repl_editor->get_pin()->is_pressed()) {
+		if (repl_editor->is_visible_in_tree()) {
+			EditorNode::get_singleton()->hide_bottom_panel();
+		}
+		button->hide();
 	}
 }

--- a/editor/plugins/replication_editor_plugin.h
+++ b/editor/plugins/replication_editor_plugin.h
@@ -34,6 +34,10 @@
 #include "editor/editor_plugin.h"
 #include "scene/resources/scene_replication_config.h"
 
+#include "editor/editor_spin_slider.h"
+#include "editor/property_editor.h"
+#include "editor/property_selector.h"
+
 class ConfirmationDialog;
 class MultiplayerSynchronizer;
 class Tree;
@@ -46,13 +50,22 @@ private:
 
 	AcceptDialog *error_dialog = nullptr;
 	ConfirmationDialog *delete_dialog = nullptr;
-	Button *add_button = nullptr;
+	Button *add_pick_button = nullptr;
+	Button *add_from_path_button = nullptr;
 	LineEdit *np_line_edit = nullptr;
+
+	Label *drop_label = nullptr;
 
 	Ref<SceneReplicationConfig> config;
 	NodePath deleting;
 	Tree *tree = nullptr;
 	bool keying = false;
+
+	PropertySelector *prop_selector = nullptr;
+	SceneTreeDialog *pick_node = nullptr;
+	NodePath adding_node_path;
+
+	Button *pin = nullptr;
 
 	Ref<Texture2D> _get_class_icon(const Node *p_node);
 
@@ -63,6 +76,19 @@ private:
 	void _update_config();
 	void _dialog_closed(bool p_confirmed);
 	void _add_property(const NodePath &p_property, bool p_spawn = true, bool p_sync = true);
+
+	void _pick_node_filter_text_changed(const String &p_newtext);
+	void _pick_node_select_recursive(TreeItem *p_item, const String &p_filter, Vector<Node *> &p_select_candidates);
+	void _pick_node_filter_input(const Ref<InputEvent> &p_ie);
+	void _pick_node_selected(NodePath p_path);
+
+	void _pick_new_property();
+	void _pick_node_property_selected(String p_name);
+
+	bool _can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const;
+	void _drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from);
+
+	void _add_sync_property(String p_path);
 
 protected:
 	static void _bind_methods();
@@ -76,6 +102,7 @@ public:
 	MultiplayerSynchronizer *get_current() const { return current; }
 	void property_keyed(const String &p_property);
 
+	Button *get_pin() { return pin; }
 	ReplicationEditor();
 	~ReplicationEditor() {}
 };
@@ -84,11 +111,14 @@ class ReplicationEditorPlugin : public EditorPlugin {
 	GDCLASS(ReplicationEditorPlugin, EditorPlugin);
 
 private:
+	Button *button = nullptr;
 	ReplicationEditor *repl_editor = nullptr;
 
 	void _node_removed(Node *p_node);
 	void _keying_changed();
 	void _property_keyed(const String &p_keyed, const Variant &p_value, bool p_advance);
+
+	void _pinned();
 
 protected:
 	void _notification(int p_what);

--- a/scene/multiplayer/multiplayer_synchronizer.cpp
+++ b/scene/multiplayer/multiplayer_synchronizer.cpp
@@ -96,7 +96,7 @@ void MultiplayerSynchronizer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_replication_config", "config"), &MultiplayerSynchronizer::set_replication_config);
 	ClassDB::bind_method(D_METHOD("get_replication_config"), &MultiplayerSynchronizer::get_replication_config);
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "resource", PROPERTY_HINT_RESOURCE_TYPE, "SceneReplicationConfig"), "set_replication_config", "get_replication_config");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "congiruation", PROPERTY_HINT_RESOURCE_TYPE, "SceneReplicationConfig"), "set_replication_config", "get_replication_config");
 }
 
 void MultiplayerSynchronizer::_notification(int p_what) {

--- a/scene/multiplayer/multiplayer_synchronizer.h
+++ b/scene/multiplayer/multiplayer_synchronizer.h
@@ -40,7 +40,7 @@ class MultiplayerSynchronizer : public Node {
 
 private:
 	Ref<SceneReplicationConfig> replication_config;
-	NodePath root_path;
+	NodePath root_path = NodePath(".."); // Start with parent, like with AnimationPlayer.
 	uint64_t interval_msec = 0;
 
 	static Object *_get_prop_target(Object *p_obj, const NodePath &p_prop);

--- a/scene/multiplayer/scene_replication_interface.cpp
+++ b/scene/multiplayer/scene_replication_interface.cpp
@@ -167,7 +167,7 @@ Error SceneReplicationInterface::_send_spawn(Node *p_node, MultiplayerSpawner *p
 	uint32_t nid = rep_state->ensure_net_id(oid);
 
 	// Prepare custom arg and scene_id
-	uint8_t scene_id = p_spawner->get_spawn_id(oid);
+	uint8_t scene_id = p_spawner->find_spawnable_scene_index_from_object(oid);
 	bool is_custom = scene_id == MultiplayerSpawner::INVALID_ID;
 	Variant spawn_arg = p_spawner->get_spawn_argument(oid);
 	int spawn_arg_size = 0;

--- a/scene/resources/scene_replication_config.cpp
+++ b/scene/resources/scene_replication_config.cpp
@@ -124,6 +124,15 @@ void SceneReplicationConfig::remove_property(const NodePath &p_path) {
 	properties.erase(p_path);
 }
 
+bool SceneReplicationConfig::has_property(const NodePath &p_path) const {
+	for (int i = 0; i < properties.size(); i++) {
+		if (properties[i].name == p_path) {
+			return true;
+		}
+	}
+	return false;
+}
+
 int SceneReplicationConfig::property_get_index(const NodePath &p_path) const {
 	for (int i = 0; i < properties.size(); i++) {
 		if (properties[i].name == p_path) {
@@ -178,6 +187,7 @@ void SceneReplicationConfig::property_set_sync(const NodePath &p_path, bool p_en
 void SceneReplicationConfig::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_properties"), &SceneReplicationConfig::get_properties);
 	ClassDB::bind_method(D_METHOD("add_property", "path", "index"), &SceneReplicationConfig::add_property, DEFVAL(-1));
+	ClassDB::bind_method(D_METHOD("has_property", "path"), &SceneReplicationConfig::has_property);
 	ClassDB::bind_method(D_METHOD("remove_property", "path"), &SceneReplicationConfig::remove_property);
 	ClassDB::bind_method(D_METHOD("property_get_index", "path"), &SceneReplicationConfig::property_get_index);
 	ClassDB::bind_method(D_METHOD("property_get_spawn", "path"), &SceneReplicationConfig::property_get_spawn);

--- a/scene/resources/scene_replication_config.h
+++ b/scene/resources/scene_replication_config.h
@@ -73,6 +73,7 @@ public:
 
 	void add_property(const NodePath &p_path, int p_index = -1);
 	void remove_property(const NodePath &p_path);
+	bool has_property(const NodePath &p_path) const;
 
 	int property_get_index(const NodePath &p_path) const;
 	bool property_get_spawn(const NodePath &p_path);


### PR DESCRIPTION
**Synchronizer**:

* Made the editor transient (not visible on the bottom until you select the right node) since its not needed most of the time.
* Add a button to add properties (which lets you select node and property)
* Add ability to drag properties and drop them to the editor.
* Added the ability to pin the editor, in case dragging properties from other nodes is desired.

Before:
![image](https://user-images.githubusercontent.com/6265307/169723335-b83d2962-affd-4a6f-9fdd-9bbc60976d6b.png)
After:
![image](https://user-images.githubusercontent.com/6265307/169723345-4a96d88d-1a6e-4df4-a8d6-959a499ea451.png)
Pushing "Add property to sync" pops up a dialog:
![image](https://user-images.githubusercontent.com/6265307/169723591-dc7e0205-4fdd-4b6c-8470-83c0a05a805d.png)
After selecting the node, you can visually select the property:
![image](https://user-images.githubusercontent.com/6265307/169723633-be384669-f984-42fe-8530-289e89d4cb61.png)
Alternative, just drag the property:
![drag_prop](https://user-images.githubusercontent.com/6265307/169723940-52f86f84-c79f-459e-8662-4ca825a6b082.gif)


**Spawner**:

* Changed the UI to use the array editor, which is more user friendly.
* Changed to store only paths to scenes, and not scenes by themselves. This improves resource usage on the editor (where loading the scenes themselves is not needed).

Preview:
![image](https://user-images.githubusercontent.com/6265307/169797824-de53bfc7-3c6a-4ad4-a7b1-f2d843fc18b1.png)
