### PR TITLE
[3.x] Automatically stretch ViewportContainer when window is set to `STRETCH_MODE_2D`

### DIFF
--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -45,6 +45,9 @@ Size2 ViewportContainer::get_minimum_size() const {
 		}
 
 		Size2 minsize = c->get_size();
+		if (c->is_size_override_enabled()) {
+			minsize = c->get_size_override();
+		}
 		ms.width = MAX(ms.width, minsize.width);
 		ms.height = MAX(ms.height, minsize.height);
 	}
@@ -81,10 +84,23 @@ void ViewportContainer::set_stretch_shrink(int p_shrink) {
 			continue;
 		}
 
-		c->set_size(get_size() / shrink);
+		set_child_viewport_size(c);
 	}
 
 	update();
+}
+
+void ViewportContainer::set_child_viewport_size(Viewport *child_viewport) {
+	Size2 normal_size = get_size() / shrink;
+	if (get_tree()->get_stretch_mode() == SceneTree::STRETCH_MODE_2D) {
+		Viewport *parent_viewport = get_viewport();
+		Size2 screen_stretch = parent_viewport->get_size() / parent_viewport->get_size_override();
+		child_viewport->set_size(normal_size * screen_stretch);
+		child_viewport->set_size_override_stretch(true);
+		child_viewport->set_size_override(true, normal_size);
+	} else {
+		child_viewport->set_size(normal_size);
+	}
 }
 
 int ViewportContainer::get_stretch_shrink() const {
@@ -103,7 +119,7 @@ void ViewportContainer::_notification(int p_what) {
 				continue;
 			}
 
-			c->set_size(get_size() / shrink);
+			set_child_viewport_size(c);
 		}
 	}
 

--- a/scene/gui/viewport_container.cpp
+++ b/scene/gui/viewport_container.cpp
@@ -108,7 +108,7 @@ int ViewportContainer::get_stretch_shrink() const {
 }
 
 void ViewportContainer::_notification(int p_what) {
-	if (p_what == NOTIFICATION_RESIZED) {
+	if (p_what == NOTIFICATION_RESIZED || p_what == NOTIFICATION_READY) {
 		if (!stretch) {
 			return;
 		}

--- a/scene/gui/viewport_container.h
+++ b/scene/gui/viewport_container.h
@@ -38,6 +38,7 @@ class ViewportContainer : public Container {
 
 	bool stretch;
 	int shrink;
+	void set_child_viewport_size(Viewport *child_viewport);
 
 protected:
 	void _notification(int p_what);

--- a/scene/main/scene_tree.cpp
+++ b/scene/main/scene_tree.cpp
@@ -1344,6 +1344,10 @@ void SceneTree::set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, c
 	_update_root_rect();
 }
 
+SceneTree::StretchMode SceneTree::get_stretch_mode() {
+	return stretch_mode;
+}
+
 void SceneTree::set_edited_scene_root(Node *p_node) {
 #ifdef TOOLS_ENABLED
 	edited_scene_root = p_node;

--- a/scene/main/scene_tree.h
+++ b/scene/main/scene_tree.h
@@ -376,6 +376,7 @@ public:
 	bool has_group(const StringName &p_identifier) const;
 
 	void set_screen_stretch(StretchMode p_mode, StretchAspect p_aspect, const Size2 &p_minsize, real_t p_scale = 1.0);
+	StretchMode get_stretch_mode();
 
 	void set_use_font_oversampling(bool p_oversampling);
 	bool is_using_font_oversampling() const;


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/61301

This PR is for 3.x, but the issue is also present in 4.x. 

In 4.X, due to stretch_mode being associated with the new Window type, I think there should be some way to access the current Window from CanvasItems, but I'm not sure it exists?
