### PR TITLE
[Windows, 3.x] Remove cached icon earlier, to prevent double free crash on exit.

### DIFF
--- a/platform/windows/os_windows.cpp
+++ b/platform/windows/os_windows.cpp
@@ -1757,6 +1757,7 @@ void OS_Windows::finalize() {
 	memdelete(input);
 	touch_state.clear();
 
+	icon.unref();
 	cursors_cache.clear();
 	visual_server->finish();
 	memdelete(visual_server);


### PR DESCRIPTION
Fixes #61261
