### PR TITLE
Increase saturation of accent color on the Gray editor theme preset

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -446,7 +446,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "interface/inspector/max_array_dictionary_items_per_page", 20, "10,100,1")
 
 	// Theme
-	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/preset", "Default", "Default,Breeze Dark,Godot 2,Grey,Light,Solarized (Dark),Solarized (Light),Custom")
+	EDITOR_SETTING(Variant::STRING, PROPERTY_HINT_ENUM, "interface/theme/preset", "Default", "Default,Breeze Dark,Godot 2,Gray,Light,Solarized (Dark),Solarized (Light),Custom")
 	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_ENUM, "interface/theme/icon_and_font_color", 0, "Auto,Dark,Light")
 	EDITOR_SETTING(Variant::COLOR, PROPERTY_HINT_NONE, "interface/theme/base_color", Color(0.2, 0.23, 0.31), "")
 	EDITOR_SETTING(Variant::COLOR, PROPERTY_HINT_NONE, "interface/theme/accent_color", Color(0.41, 0.61, 0.91), "")

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -393,8 +393,8 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		preset_accent_color = Color(0.53, 0.67, 0.89);
 		preset_base_color = Color(0.24, 0.23, 0.27);
 		preset_contrast = default_contrast;
-	} else if (preset == "Grey") {
-		preset_accent_color = Color(0.72, 0.89, 1.00);
+	} else if (preset == "Gray") {
+		preset_accent_color = Color(0.44, 0.73, 0.98);
 		preset_base_color = Color(0.24, 0.24, 0.24);
 		preset_contrast = default_contrast;
 	} else if (preset == "Light") {


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/61306.

This makes activated icons easier to distinguish from non-activated icons.

This also renames the Gray editor theme preset to use US spelling.

## Preview

| Before | After |
|-|-|
| ![2022-05-23_09 47 09](https://user-images.githubusercontent.com/180032/169772458-70ac555c-b906-4417-bef5-8e3ebfd0b435.png) | ![2022-05-23_10 01 25](https://user-images.githubusercontent.com/180032/169772465-f36e94ee-a08c-4799-9a9f-f9d6d2efe3a6.png) |