### PR TITLE
Increase saturation of accent color on the Grey editor theme preset (3.x)

### DIFF
--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -329,7 +329,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 		preset_base_color = Color(0.24, 0.23, 0.27);
 		preset_contrast = 0.25;
 	} else if (preset == "Grey") {
-		preset_accent_color = Color(0.72, 0.89, 1.0);
+		preset_accent_color = Color(0.44, 0.73, 0.98);
 		preset_base_color = Color(0.24, 0.24, 0.24);
 		preset_contrast = 0.2;
 	} else if (preset == "Light") {


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/61305.

This makes activated icons easier to distinguish from non-activated icons.

Unlike https://github.com/godotengine/godot/pull/61305, the preset isn't renamed to ensure the change is applied to existing installations.

## Preview

| Before | After |
|-|-|
| ![2022-05-23_10 20 21](https://user-images.githubusercontent.com/180032/169776350-e2329d92-d31d-4e61-8cac-9d379ceefdde.png) | ![2022-05-23_10 21 57](https://user-images.githubusercontent.com/180032/169776353-11d2dc22-1602-4752-9b1e-3400047f0c20.png) |