### PR TITLE
[3.x] Use float when calculating `Label3D` line height

### DIFF
--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -414,7 +414,7 @@ Ref<TriangleMesh> Label3D::generate_triangle_mesh() const {
 		const_cast<Label3D *>(this)->regenerate_word_cache();
 	}
 
-	int font_h = font->get_height() + line_spacing;
+	float font_h = font->get_height() + line_spacing;
 	real_t space_w = font->get_char_size(' ').width;
 	float total_h = line_count * font_h;
 
@@ -640,7 +640,7 @@ void Label3D::_shape() {
 
 	// Generate surfaces and materials.
 
-	int font_h = font->get_height() + line_spacing;
+	float font_h = font->get_height() + line_spacing;
 	real_t space_w = font->get_char_size(' ').width;
 	float total_h = line_count * font_h;
 


### PR DESCRIPTION
The position of rendered text is currently affected by the line spacing even if there's only one line in the text.

This is because the line height is stored in `int` but the Y offset for vertical centering uses float.

Vanilla `Label` is fine because its line spacing is integral.