### PR TITLE
Fix building VHACD with GCC 13.

### DIFF
--- a/thirdparty/vhacd/0006-fix-gcc13.patch
+++ b/thirdparty/vhacd/0006-fix-gcc13.patch
@@ -1,0 +1,15 @@
+diff --git a/thirdparty/vhacd/inc/vhacdICHull.h b/thirdparty/vhacd/inc/vhacdICHull.h
+index 132bdcfb3e..925584cf52 100644
+--- a/thirdparty/vhacd/inc/vhacdICHull.h
++++ b/thirdparty/vhacd/inc/vhacdICHull.h
+@@ -18,6 +18,10 @@
+ #include "vhacdManifoldMesh.h"
+ #include "vhacdVector.h"
+ 
++// -- GODOT start --
++#include <cstdint>
++// -- GODOT end --
++
+ namespace VHACD {
+ //!    Incremental Convex Hull algorithm (cf. http://cs.smith.edu/~orourke/books/ftp.html ).
+ enum ICHullError {

--- a/thirdparty/vhacd/inc/vhacdICHull.h
+++ b/thirdparty/vhacd/inc/vhacdICHull.h
@@ -18,6 +18,10 @@
 #include "vhacdManifoldMesh.h"
 #include "vhacdVector.h"
 
+// -- GODOT start --
+#include <cstdint>
+// -- GODOT end --
+
 namespace VHACD {
 //!    Incremental Convex Hull algorithm (cf. http://cs.smith.edu/~orourke/books/ftp.html ).
 enum ICHullError {


### PR DESCRIPTION
Fixes the following error:
```
thirdparty/vhacd/inc/vhacdICHull.h:46:31: error: 'uint32_t' does not name a type
   46 |     ICHullError Process(const uint32_t nPointsCH, const double minVolume = 0.0);
      |                               ^~~~~~~~
```

Note the upstream version of the third party library is not affected.