### PR TITLE
Fix Joint3D and Joint2D warning causing a crash

### DIFF
--- a/scene/2d/joint_2d.cpp
+++ b/scene/2d/joint_2d.cpp
@@ -50,6 +50,7 @@ void Joint2D::_disconnect_signals() {
 void Joint2D::_body_exit_tree() {
 	_disconnect_signals();
 	_update_joint(true);
+	update_configuration_warnings();
 }
 
 void Joint2D::_update_joint(bool p_only_free) {
@@ -64,7 +65,6 @@ void Joint2D::_update_joint(bool p_only_free) {
 	if (p_only_free || !is_inside_tree()) {
 		PhysicsServer2D::get_singleton()->joint_clear(joint);
 		warning = String();
-		update_configuration_warnings();
 		return;
 	}
 

--- a/scene/3d/joint_3d.cpp
+++ b/scene/3d/joint_3d.cpp
@@ -49,6 +49,7 @@ void Joint3D::_disconnect_signals() {
 void Joint3D::_body_exit_tree() {
 	_disconnect_signals();
 	_update_joint(true);
+	update_configuration_warnings();
 }
 
 void Joint3D::_update_joint(bool p_only_free) {
@@ -65,7 +66,6 @@ void Joint3D::_update_joint(bool p_only_free) {
 	if (p_only_free || !is_inside_tree()) {
 		PhysicsServer3D::get_singleton()->joint_clear(joint);
 		warning = String();
-		update_configuration_warnings();
 		return;
 	}
 


### PR DESCRIPTION
Fixes #60962. 
Fixes #55660. 
Introduced by #48242.

This PR fixes the crash, but it's hiding a worse problem.
Joint3D (the same happens for Joint2D) makes the offending `update_configuration_warnings` call when it's handling the `NOTIFICATION_EXIT_TREE` notification. The warning signal is received by SceneTreeEditor with the signal connected [here](https://github.com/godotengine/godot/blob/3568b3deeaf3fbbf9e728ff25c7d0349075f9f1a/editor/scene_tree_editor.cpp#L717). The `connect` call has the `CONNECT_DEFERRED` flag, which means the signal may be handled after the Joint3D is freed. Removing that flag doesn't trigger the crash.
As a plus, `VariantCasterAndValidate` doesn't check if the object is valid, but this may be expected.
In conclusion, any node that calls `update_configuration_warnings` and right after it's freed can cause a crash.