### PR TITLE
[Label3D, 4.x] Monitor default theme font changes, to prevent use of invalid materials.

### DIFF
--- a/scene/3d/label_3d.cpp
+++ b/scene/3d/label_3d.cpp
@@ -788,6 +788,11 @@ Ref<Font> Label3D::get_font() const {
 }
 
 Ref<Font> Label3D::_get_font_or_default() const {
+	if (theme_font.is_valid()) {
+		theme_font->disconnect(CoreStringNames::get_singleton()->changed, Callable(const_cast<Label3D *>(this), "_font_changed"));
+		theme_font.unref();
+	}
+
 	if (font_override.is_valid() && font_override->get_data_count() > 0) {
 		return font_override;
 	}
@@ -799,7 +804,12 @@ Ref<Font> Label3D::_get_font_or_default() const {
 
 		for (const StringName &E : theme_types) {
 			if (Theme::get_project_default()->has_theme_item(Theme::DATA_TYPE_FONT, "font", E)) {
-				return Theme::get_project_default()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
+				Ref<Font> f = Theme::get_project_default()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
+				if (f.is_valid()) {
+					theme_font = f;
+					theme_font->connect(CoreStringNames::get_singleton()->changed, Callable(const_cast<Label3D *>(this), "_font_changed"));
+				}
+				return f;
 			}
 		}
 	}
@@ -811,13 +821,23 @@ Ref<Font> Label3D::_get_font_or_default() const {
 
 		for (const StringName &E : theme_types) {
 			if (Theme::get_default()->has_theme_item(Theme::DATA_TYPE_FONT, "font", E)) {
-				return Theme::get_default()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
+				Ref<Font> f = Theme::get_default()->get_theme_item(Theme::DATA_TYPE_FONT, "font", E);
+				if (f.is_valid()) {
+					theme_font = f;
+					theme_font->connect(CoreStringNames::get_singleton()->changed, Callable(const_cast<Label3D *>(this), "_font_changed"));
+				}
+				return f;
 			}
 		}
 	}
 
 	// If they don't exist, use any type to return the default/empty value.
-	return Theme::get_default()->get_theme_item(Theme::DATA_TYPE_FONT, "font", StringName());
+	Ref<Font> f = Theme::get_default()->get_theme_item(Theme::DATA_TYPE_FONT, "font", StringName());
+	if (f.is_valid()) {
+		theme_font = f;
+		theme_font->connect(CoreStringNames::get_singleton()->changed, Callable(const_cast<Label3D *>(this), "_font_changed"));
+	}
+	return f;
 }
 
 void Label3D::set_font_size(int p_size) {

--- a/scene/3d/label_3d.h
+++ b/scene/3d/label_3d.h
@@ -96,6 +96,7 @@ private:
 
 	int font_size = 16;
 	Ref<Font> font_override;
+	mutable Ref<Font> theme_font;
 	Color modulate = Color(1, 1, 1, 1);
 	Point2 lbl_offset;
 	int outline_render_priority = -1;


### PR DESCRIPTION
Same as #61320 for `4.x`.

Fixes https://github.com/godotengine/godot/issues/61308