### PR TITLE
[TextMesh] Do not generate meshes for non-visual glyphs.

### DIFF
--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -2402,6 +2402,10 @@ void TextMesh::_create_mesh_array(Array &p_arr) const {
 
 	Vector2 offset_pre = offset;
 	for (int i = 0; i < gl_size; i++) {
+		if (glyphs[i].index == 0) {
+			offset.x += glyphs[i].advance * pixel_size * glyphs[i].repeat;
+			continue;
+		}
 		if (glyphs[i].font_rid != RID()) {
 			uint32_t hash = hash_one_uint64(glyphs[i].font_rid.get_id());
 			hash = hash_djb2_one_32(glyphs[i].index, hash);
@@ -2457,6 +2461,10 @@ void TextMesh::_create_mesh_array(Array &p_arr) const {
 	int32_t p_idx = 0;
 	int32_t i_idx = 0;
 	for (int i = 0; i < gl_size; i++) {
+		if (glyphs[i].index == 0) {
+			offset.x += glyphs[i].advance * pixel_size * glyphs[i].repeat;
+			continue;
+		}
 		if (glyphs[i].font_rid != RID()) {
 			uint32_t hash = hash_one_uint64(glyphs[i].font_rid.get_id());
 			hash = hash_djb2_one_32(glyphs[i].index, hash);


### PR DESCRIPTION
Fixes #61322

_Note: Irrelevant for `3.x`._