### PR TITLE
Add missing properties to default theme

### DIFF
--- a/doc/classes/GraphNode.xml
+++ b/doc/classes/GraphNode.xml
@@ -321,6 +321,9 @@
 		<theme_item name="separation" data_type="constant" type="int" default="2">
 			The vertical distance between ports.
 		</theme_item>
+		<theme_item name="title_h_offset" data_type="constant" type="int" default="0">
+			Horizontal offset of the title text.
+		</theme_item>
 		<theme_item name="title_offset" data_type="constant" type="int" default="26">
 			Vertical offset of the title text.
 		</theme_item>

--- a/doc/classes/OptionButton.xml
+++ b/doc/classes/OptionButton.xml
@@ -233,6 +233,9 @@
 		<theme_item name="font_hover_color" data_type="color" type="Color" default="Color(0.95, 0.95, 0.95, 1)">
 			Text [Color] used when the [OptionButton] is being hovered.
 		</theme_item>
+		<theme_item name="font_hover_pressed_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
+			Text [Color] used when the [OptionButton] is being hovered and pressed.
+		</theme_item>
 		<theme_item name="font_outline_color" data_type="color" type="Color" default="Color(1, 1, 1, 1)">
 			The tint of text outline of the [OptionButton].
 		</theme_item>
@@ -244,6 +247,9 @@
 		</theme_item>
 		<theme_item name="h_separation" data_type="constant" type="int" default="2">
 			The horizontal space between [OptionButton]'s icon and text.
+		</theme_item>
+		<theme_item name="modulate_arrow" data_type="constant" type="int" default="0">
+			If different than [code]0[/code], the arrow icon will be modulated to the font color.
 		</theme_item>
 		<theme_item name="outline_size" data_type="constant" type="int" default="0">
 			The size of the text outline.

--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -594,11 +594,20 @@
 		<theme_item name="checked" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the checked checkbox items.
 		</theme_item>
+		<theme_item name="checked_disabled" data_type="icon" type="Texture2D">
+			[Texture2D] icon for the checked checkbox items when they are disabled.
+		</theme_item>
 		<theme_item name="radio_checked" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the checked radio button items.
 		</theme_item>
+		<theme_item name="radio_checked_disabled" data_type="icon" type="Texture2D">
+			[Texture2D] icon for the checked radio button items when they are disabled.
+		</theme_item>
 		<theme_item name="radio_unchecked" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the unchecked radio button items.
+		</theme_item>
+		<theme_item name="radio_unchecked_disabled" data_type="icon" type="Texture2D">
+			[Texture2D] icon for the unchecked radio button items when they are disabled.
 		</theme_item>
 		<theme_item name="submenu" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the submenu arrow (for left-to-right layouts).
@@ -608,6 +617,9 @@
 		</theme_item>
 		<theme_item name="unchecked" data_type="icon" type="Texture2D">
 			[Texture2D] icon for the unchecked checkbox items.
+		</theme_item>
+		<theme_item name="unchecked_disabled" data_type="icon" type="Texture2D">
+			[Texture2D] icon for the unchecked checkbox items when they are disabled.
 		</theme_item>
 		<theme_item name="hover" data_type="style" type="StyleBox">
 			[StyleBox] displayed when the [PopupMenu] item is hovered.

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1262,7 +1262,6 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_stylebox("focus", "LineEdit", style_widget_focus);
 	theme->set_stylebox("read_only", "LineEdit", style_line_edit_disabled);
 	theme->set_icon("clear", "LineEdit", theme->get_icon(SNAME("GuiClose"), SNAME("EditorIcons")));
-	theme->set_color("read_only", "LineEdit", font_disabled_color);
 	theme->set_color("font_color", "LineEdit", font_color);
 	theme->set_color("font_selected_color", "LineEdit", mono_color);
 	theme->set_color("font_uneditable_color", "LineEdit", font_readonly_color);
@@ -1455,7 +1454,7 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_tooltip->set_bg_color(dark_color_3 * Color(0.8, 0.8, 0.8, 0.9));
 	style_tooltip->set_border_width_all(0);
 	theme->set_color("font_color", "TooltipLabel", font_hover_color);
-	theme->set_color("font_color_shadow", "TooltipLabel", Color(0, 0, 0, 0));
+	theme->set_color("font_shadow_color", "TooltipLabel", Color(0, 0, 0, 0));
 	theme->set_stylebox("panel", "TooltipPanel", style_tooltip);
 
 	// PopupPanel

--- a/editor/plugins/texture_editor_plugin.cpp
+++ b/editor/plugins/texture_editor_plugin.cpp
@@ -137,7 +137,7 @@ TexturePreview::TexturePreview(Ref<Texture2D> p_texture, bool p_show_metadata) {
 
 		// It's okay that these colors are static since the grid color is static too.
 		metadata_label->add_theme_color_override("font_color", Color::named("white"));
-		metadata_label->add_theme_color_override("font_color_shadow", Color::named("black"));
+		metadata_label->add_theme_color_override("font_shadow_color", Color::named("black"));
 
 		metadata_label->add_theme_font_size_override("font_size", 14 * EDSCALE);
 		metadata_label->add_theme_color_override("font_outline_color", Color::named("black"));

--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -74,6 +74,9 @@ void OptionButton::_notification(int p_what) {
 					case DRAW_HOVER:
 						clr = get_theme_color(SNAME("font_hover_color"));
 						break;
+					case DRAW_HOVER_PRESSED:
+						clr = get_theme_color(SNAME("font_hover_pressed_color"));
+						break;
 					case DRAW_DISABLED:
 						clr = get_theme_color(SNAME("font_disabled_color"));
 						break;

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -513,9 +513,9 @@ void PopupMenu::_draw_items() {
 	bool rtl = control->is_layout_rtl();
 	Ref<StyleBox> style = get_theme_stylebox(SNAME("panel"));
 	Ref<StyleBox> hover = get_theme_stylebox(SNAME("hover"));
-	// In Item::checkable_type enum order (less the non-checkable member).
-	Ref<Texture2D> check[] = { get_theme_icon(SNAME("checked")), get_theme_icon(SNAME("radio_checked")) };
-	Ref<Texture2D> uncheck[] = { get_theme_icon(SNAME("unchecked")), get_theme_icon(SNAME("radio_unchecked")) };
+	// In Item::checkable_type enum order (less the non-checkable member), with disabled repeated at the end.
+	Ref<Texture2D> check[] = { get_theme_icon(SNAME("checked")), get_theme_icon(SNAME("radio_checked")), get_theme_icon(SNAME("checked_disabled")), get_theme_icon(SNAME("radio_checked_disabled")) };
+	Ref<Texture2D> uncheck[] = { get_theme_icon(SNAME("unchecked")), get_theme_icon(SNAME("radio_unchecked")), get_theme_icon(SNAME("unchecked_disabled")), get_theme_icon(SNAME("radio_unchecked_disabled")) };
 	Ref<Texture2D> submenu;
 	if (rtl) {
 		submenu = get_theme_icon(SNAME("submenu_mirrored"));
@@ -558,7 +558,11 @@ void PopupMenu::_draw_items() {
 
 	float check_ofs = 0.0;
 	if (has_check) {
-		check_ofs = MAX(get_theme_icon(SNAME("checked"))->get_width(), get_theme_icon(SNAME("radio_checked"))->get_width()) + hseparation;
+		for (int i = 0; i < 4; i++) {
+			check_ofs = MAX(check_ofs, check[i]->get_width());
+			check_ofs = MAX(check_ofs, uncheck[i]->get_width());
+		}
+		check_ofs += hseparation;
 	}
 
 	Point2 ofs = Point2();
@@ -620,7 +624,8 @@ void PopupMenu::_draw_items() {
 
 		// Checkboxes
 		if (items[i].checkable_type && !items[i].separator) {
-			Texture2D *icon = (items[i].checked ? check[items[i].checkable_type - 1] : uncheck[items[i].checkable_type - 1]).ptr();
+			int disabled = int(items[i].disabled) * 2;
+			Texture2D *icon = (items[i].checked ? check[items[i].checkable_type - 1 + disabled] : uncheck[items[i].checkable_type - 1 + disabled]).ptr();
 			if (rtl) {
 				icon->draw(ci, Size2(control->get_size().width - item_ofs.x - icon->get_width(), item_ofs.y) + Point2(0, Math::floor((h - icon->get_height()) / 2.0)), icon_color);
 			} else {

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -224,6 +224,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("font_color", "OptionButton", control_font_color);
 	theme->set_color("font_pressed_color", "OptionButton", control_font_pressed_color);
 	theme->set_color("font_hover_color", "OptionButton", control_font_hover_color);
+	theme->set_color("font_hover_pressed_color", "OptionButton", control_font_pressed_color);
 	theme->set_color("font_focus_color", "OptionButton", control_font_focus_color);
 	theme->set_color("font_disabled_color", "OptionButton", control_font_disabled_color);
 	theme->set_color("font_outline_color", "OptionButton", Color(1, 1, 1));
@@ -231,6 +232,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_constant("h_separation", "OptionButton", 2 * scale);
 	theme->set_constant("arrow_margin", "OptionButton", 4 * scale);
 	theme->set_constant("outline_size", "OptionButton", 0);
+	theme->set_constant("modulate_arrow", "OptionButton", false);
 
 	// MenuButton
 
@@ -644,9 +646,13 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_stylebox("labeled_separator_right", "PopupMenu", separator_horizontal);
 
 	theme->set_icon("checked", "PopupMenu", icons["checked"]);
+	theme->set_icon("checked_disabled", "PopupMenu", icons["checked"]);
 	theme->set_icon("unchecked", "PopupMenu", icons["unchecked"]);
+	theme->set_icon("unchecked_disabled", "PopupMenu", icons["unchecked"]);
 	theme->set_icon("radio_checked", "PopupMenu", icons["radio_checked"]);
+	theme->set_icon("radio_checked_disabled", "PopupMenu", icons["radio_checked"]);
 	theme->set_icon("radio_unchecked", "PopupMenu", icons["radio_unchecked"]);
+	theme->set_icon("radio_unchecked_disabled", "PopupMenu", icons["radio_unchecked"]);
 	theme->set_icon("submenu", "PopupMenu", icons["popup_menu_arrow_right"]);
 	theme->set_icon("submenu_mirrored", "PopupMenu", icons["popup_menu_arrow_left"]);
 
@@ -703,6 +709,7 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	theme->set_color("resizer_color", "GraphNode", control_font_color);
 	theme->set_constant("separation", "GraphNode", 2 * scale);
 	theme->set_constant("title_offset", "GraphNode", 26 * scale);
+	theme->set_constant("title_h_offset", "GraphNode", 0);
 	theme->set_constant("close_offset", "GraphNode", 22 * scale);
 	theme->set_constant("close_h_offset", "GraphNode", 22 * scale);
 	theme->set_constant("port_offset", "GraphNode", 0);


### PR DESCRIPTION
- added functional theme properties that existed in editor theme, but not default theme: GraphEdit `title_h_offset`, OptionButton `modulate_arrow`
- removed unused properties: LineEdit `read_only`, TooltipLabel `font_color_shadow`
- fixed `modulate_arrow` displaying wrong color for DRAW_HOVER_PRESSED
- implemented missing disabled icons in PopupMenu (and added them to default theme)

Resolves #33370