### PR TITLE
Remove duplicate Android sensor listener registrations

### DIFF
--- a/platform/android/java/lib/src/org/godotengine/godot/Godot.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/Godot.java
@@ -463,13 +463,9 @@ public class Godot extends Fragment implements SensorEventListener, IDownloaderC
 		tts = new GodotTTS(activity);
 		mSensorManager = (SensorManager)activity.getSystemService(Context.SENSOR_SERVICE);
 		mAccelerometer = mSensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER);
-		mSensorManager.registerListener(this, mAccelerometer, SensorManager.SENSOR_DELAY_GAME);
 		mGravity = mSensorManager.getDefaultSensor(Sensor.TYPE_GRAVITY);
-		mSensorManager.registerListener(this, mGravity, SensorManager.SENSOR_DELAY_GAME);
 		mMagnetometer = mSensorManager.getDefaultSensor(Sensor.TYPE_MAGNETIC_FIELD);
-		mSensorManager.registerListener(this, mMagnetometer, SensorManager.SENSOR_DELAY_GAME);
 		mGyroscope = mSensorManager.getDefaultSensor(Sensor.TYPE_GYROSCOPE);
-		mSensorManager.registerListener(this, mGyroscope, SensorManager.SENSOR_DELAY_GAME);
 
 		GodotLib.initialize(activity, this, activity.getAssets(), use_apk_expansion);
 


### PR DESCRIPTION
Currently, on Android, sensor listeners are being registered twice first: in `initializeGodot()`, which is called by `onCreate()`: https://github.com/godotengine/godot/blob/3fb1f258bea0ca733af8ac133a686cf63e23069f/platform/android/java/lib/src/org/godotengine/godot/Godot.java#L465-L472
and a second time in `onResume()`:
https://github.com/godotengine/godot/blob/3fb1f258bea0ca733af8ac133a686cf63e23069f/platform/android/java/lib/src/org/godotengine/godot/Godot.java#L696-L699
As defined in the [Android activity lifecycle](https://developer.android.com/guide/components/activities/activity-lifecycle#alc), `onResume()` always follows `onCreate()` so the listeners are being registered twice for no reason.

They're being unregistered in `onPause()`:
https://github.com/godotengine/godot/blob/3fb1f258bea0ca733af8ac133a686cf63e23069f/platform/android/java/lib/src/org/godotengine/godot/Godot.java#L657
Therefore, they need to be included in `onResume()`. However, we can safely remove them from `initializeGodot()`.

Note: The early registration prevented #22644 from working.

Can be cherry-picked onto 3.x.
