### PR TITLE
Force window position if spawned outside screen

### DIFF
--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -1251,6 +1251,15 @@ void Window::popup(const Rect2i &p_screen_rect) {
 
 	set_transient(true);
 	set_visible(true);
+
+	int screen_id = DisplayServer::get_singleton()->window_get_current_screen(get_window_id());
+	Rect2i screen_rect = DisplayServer::get_singleton()->screen_get_usable_rect(screen_id);
+	if (screen_rect != Rect2i() && !screen_rect.intersects(Rect2i(position, size))) {
+		ERR_PRINT(vformat("Window %d spawned at invalid position: %s.", get_window_id(), position));
+		// Window appeared on unavailable screen area, so force it to the center.
+		set_position(screen_rect.size / 2 - size / 2);
+	}
+
 	_post_popup();
 	notification(NOTIFICATION_POST_POPUP);
 }


### PR DESCRIPTION
Fixes #58591

After window is made visible, I assume it has its final position and screen id. Also if the target position is outside of the desktop available area, the window gets the default/closest screen id (I think). So if the window position is outside of its current screen, it's probably safe to assume that it spawned outside of the visible screen area. When this happens, I force it to the center of its screen.