### PR TITLE
Add StreamPeerSSL.get_stream

### DIFF
--- a/core/io/stream_peer_ssl.cpp
+++ b/core/io/stream_peer_ssl.cpp
@@ -60,6 +60,7 @@ void StreamPeerSSL::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("accept_stream", "stream", "private_key", "certificate", "chain"), &StreamPeerSSL::accept_stream, DEFVAL(Ref<X509Certificate>()));
 	ClassDB::bind_method(D_METHOD("connect_to_stream", "stream", "validate_certs", "for_hostname", "valid_certificate"), &StreamPeerSSL::connect_to_stream, DEFVAL(false), DEFVAL(String()), DEFVAL(Ref<X509Certificate>()));
 	ClassDB::bind_method(D_METHOD("get_status"), &StreamPeerSSL::get_status);
+	ClassDB::bind_method(D_METHOD("get_stream"), &StreamPeerSSL::get_stream);
 	ClassDB::bind_method(D_METHOD("disconnect_from_stream"), &StreamPeerSSL::disconnect_from_stream);
 	ClassDB::bind_method(D_METHOD("set_blocking_handshake_enabled", "enabled"), &StreamPeerSSL::set_blocking_handshake_enabled);
 	ClassDB::bind_method(D_METHOD("is_blocking_handshake_enabled"), &StreamPeerSSL::is_blocking_handshake_enabled);

--- a/core/io/stream_peer_ssl.h
+++ b/core/io/stream_peer_ssl.h
@@ -61,6 +61,7 @@ public:
 	virtual Error accept_stream(Ref<StreamPeer> p_base, Ref<CryptoKey> p_key, Ref<X509Certificate> p_cert, Ref<X509Certificate> p_ca_chain = Ref<X509Certificate>()) = 0;
 	virtual Error connect_to_stream(Ref<StreamPeer> p_base, bool p_validate_certs = false, const String &p_for_hostname = String(), Ref<X509Certificate> p_valid_cert = Ref<X509Certificate>()) = 0;
 	virtual Status get_status() const = 0;
+	virtual Ref<StreamPeer> get_stream() const = 0;
 
 	virtual void disconnect_from_stream() = 0;
 

--- a/doc/classes/StreamPeerSSL.xml
+++ b/doc/classes/StreamPeerSSL.xml
@@ -44,6 +44,12 @@
 				Returns the status of the connection. See [enum Status] for values.
 			</description>
 		</method>
+		<method name="get_stream" qualifiers="const">
+			<return type="StreamPeer" />
+			<description>
+				Returns the underlying [StreamPeer] connection, used in [method accept_stream] or [method connect_to_stream].
+			</description>
+		</method>
 		<method name="poll">
 			<return type="void" />
 			<description>

--- a/modules/mbedtls/stream_peer_mbedtls.cpp
+++ b/modules/mbedtls/stream_peer_mbedtls.cpp
@@ -298,6 +298,10 @@ StreamPeerMbedTLS::Status StreamPeerMbedTLS::get_status() const {
 	return status;
 }
 
+Ref<StreamPeer> StreamPeerMbedTLS::get_stream() const {
+	return base;
+}
+
 StreamPeerSSL *StreamPeerMbedTLS::_create_func() {
 	return memnew(StreamPeerMbedTLS);
 }

--- a/modules/mbedtls/stream_peer_mbedtls.h
+++ b/modules/mbedtls/stream_peer_mbedtls.h
@@ -57,6 +57,7 @@ public:
 	virtual Error accept_stream(Ref<StreamPeer> p_base, Ref<CryptoKey> p_key, Ref<X509Certificate> p_cert, Ref<X509Certificate> p_ca_chain = Ref<X509Certificate>());
 	virtual Error connect_to_stream(Ref<StreamPeer> p_base, bool p_validate_certs = false, const String &p_for_hostname = String(), Ref<X509Certificate> p_valid_cert = Ref<X509Certificate>());
 	virtual Status get_status() const;
+	virtual Ref<StreamPeer> get_stream() const;
 
 	virtual void disconnect_from_stream();
 


### PR DESCRIPTION
There was no way to print the host of a StreamPeerSSL, for example for debugging or logging error messages.

Currently, it might be possible to store the original stream passed into `connect_to_stream`, but keeping track of two values is prone to error, and makes writing GDScript harder.