### PR TITLE
Reorganize Region Rect Editor

### DIFF
--- a/doc/classes/EditorInspectorPlugin.xml
+++ b/doc/classes/EditorInspectorPlugin.xml
@@ -77,6 +77,7 @@
 			<return type="void" />
 			<argument index="0" name="property" type="String" />
 			<argument index="1" name="editor" type="Control" />
+			<argument index="2" name="add_to_end" type="bool" default="false" />
 			<description>
 				Adds a property editor for an individual property. The [code]editor[/code] control must extend [EditorProperty].
 			</description>

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -205,11 +205,13 @@ public:
 class EditorInspectorPlugin : public RefCounted {
 	GDCLASS(EditorInspectorPlugin, RefCounted);
 
+public:
 	friend class EditorInspector;
 	struct AddedEditor {
 		Control *property_editor = nullptr;
 		Vector<String> properties;
 		String label;
+		bool add_to_end = false;
 	};
 
 	List<AddedEditor> added_editors;
@@ -226,7 +228,7 @@ protected:
 
 public:
 	void add_custom_control(Control *control);
-	void add_property_editor(const String &p_for_property, Control *p_prop);
+	void add_property_editor(const String &p_for_property, Control *p_prop, bool p_add_to_end = false);
 	void add_property_editor_for_multiple_properties(const String &p_label, const Vector<String> &p_properties, Control *p_prop);
 
 	virtual bool can_handle(Object *p_object);

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -37,6 +37,7 @@
 #include "editor/editor_scale.h"
 #include "scene/gui/check_box.h"
 #include "scene/gui/view_panner.h"
+#include "scene/resources/texture.h"
 
 void draw_margin_line(Control *edit_draw, Vector2 from, Vector2 to) {
 	Vector2 line = (to - from).normalized() * 10;
@@ -228,8 +229,8 @@ void TextureRegionEditor::_region_draw() {
 	Size2 vmin = vscroll->get_combined_minimum_size();
 
 	// Avoid scrollbar overlapping.
-	hscroll->set_anchor_and_offset(SIDE_RIGHT, ANCHOR_END, vscroll->is_visible() ? -vmin.width : 0);
-	vscroll->set_anchor_and_offset(SIDE_BOTTOM, ANCHOR_END, hscroll->is_visible() ? -hmin.height : 0);
+	hscroll->set_anchor_and_offset(SIDE_RIGHT, Control::ANCHOR_END, vscroll->is_visible() ? -vmin.width : 0);
+	vscroll->set_anchor_and_offset(SIDE_BOTTOM, Control::ANCHOR_END, hscroll->is_visible() ? -hmin.height : 0);
 
 	updating_scroll = false;
 
@@ -817,8 +818,8 @@ void TextureRegionEditor::_notification(int p_what) {
 			zoom_reset->set_icon(get_theme_icon(SNAME("ZoomReset"), SNAME("EditorIcons")));
 			zoom_in->set_icon(get_theme_icon(SNAME("ZoomMore"), SNAME("EditorIcons")));
 
-			vscroll->set_anchors_and_offsets_preset(PRESET_RIGHT_WIDE);
-			hscroll->set_anchors_and_offsets_preset(PRESET_BOTTOM_WIDE);
+			vscroll->set_anchors_and_offsets_preset(Control::PRESET_RIGHT_WIDE);
+			hscroll->set_anchors_and_offsets_preset(Control::PRESET_BOTTOM_WIDE);
 			[[fallthrough]];
 		}
 		case EditorSettings::NOTIFICATION_EDITOR_SETTINGS_CHANGED: {
@@ -921,6 +922,7 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		atlas_tex = Ref<AtlasTexture>(nullptr);
 	}
 	edit_draw->update();
+	popup_centered_ratio();
 }
 
 void TextureRegionEditor::_texture_changed() {
@@ -977,6 +979,9 @@ Vector2 TextureRegionEditor::snap_point(Vector2 p_target) const {
 }
 
 TextureRegionEditor::TextureRegionEditor() {
+	get_ok_button()->set_text(TTR("Close"));
+	VBoxContainer *vb = memnew(VBoxContainer);
+	add_child(vb);
 	node_sprite_2d = nullptr;
 	node_sprite_3d = nullptr;
 	node_ninepatch = nullptr;
@@ -992,7 +997,7 @@ TextureRegionEditor::TextureRegionEditor() {
 	drag = false;
 
 	HBoxContainer *hb_tools = memnew(HBoxContainer);
-	add_child(hb_tools);
+	vb->add_child(hb_tools);
 	hb_tools->add_child(memnew(Label(TTR("Snap Mode:"))));
 
 	snap_mode_button = memnew(OptionButton);
@@ -1076,12 +1081,12 @@ TextureRegionEditor::TextureRegionEditor() {
 	panner->set_callbacks(callable_mp(this, &TextureRegionEditor::_scroll_callback), callable_mp(this, &TextureRegionEditor::_pan_callback), callable_mp(this, &TextureRegionEditor::_zoom_callback));
 
 	edit_draw = memnew(Panel);
-	add_child(edit_draw);
-	edit_draw->set_v_size_flags(SIZE_EXPAND_FILL);
+	vb->add_child(edit_draw);
+	edit_draw->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	edit_draw->connect("draw", callable_mp(this, &TextureRegionEditor::_region_draw));
 	edit_draw->connect("gui_input", callable_mp(this, &TextureRegionEditor::_region_input));
 	edit_draw->connect("focus_exited", callable_mp(panner.ptr(), &ViewPanner::release_pan_key));
-	edit_draw->set_focus_mode(FOCUS_CLICK);
+	edit_draw->set_focus_mode(Control::FOCUS_CLICK);
 
 	draw_zoom = 1.0;
 	edit_draw->set_clip_contents(true);
@@ -1119,88 +1124,40 @@ TextureRegionEditor::TextureRegionEditor() {
 
 	updating_scroll = false;
 	autoslice_is_dirty = true;
+
+	set_title(TTR("Region Editor"));
 }
 
-void TextureRegionEditorPlugin::edit(Object *p_object) {
-	region_editor->edit(p_object);
+////////////////////////
+
+bool EditorInspectorPluginTextureRegion::can_handle(Object *p_object) {
+	return Object::cast_to<Sprite2D>(p_object) || Object::cast_to<Sprite3D>(p_object) || Object::cast_to<NinePatchRect>(p_object) || Object::cast_to<StyleBoxTexture>(p_object) || Object::cast_to<AtlasTexture>(p_object);
 }
 
-bool TextureRegionEditorPlugin::handles(Object *p_object) const {
-	return p_object->is_class("Sprite2D") || p_object->is_class("Sprite3D") || p_object->is_class("NinePatchRect") || p_object->is_class("StyleBoxTexture") || p_object->is_class("AtlasTexture");
+void EditorInspectorPluginTextureRegion::_region_edit(Object *p_object) {
+	texture_region_editor->edit(p_object);
 }
 
-void TextureRegionEditorPlugin::_editor_visiblity_changed() {
-	manually_hidden = !region_editor->is_visible_in_tree();
-}
-
-void TextureRegionEditorPlugin::make_visible(bool p_visible) {
-	if (p_visible) {
-		texture_region_button->show();
-		bool is_node_configured = region_editor->is_stylebox() || region_editor->is_atlas_texture() || region_editor->is_ninepatch();
-		is_node_configured |= region_editor->get_sprite_2d() && region_editor->get_sprite_2d()->is_region_enabled();
-		is_node_configured |= region_editor->get_sprite_3d() && region_editor->get_sprite_3d()->is_region_enabled();
-		if ((is_node_configured && !manually_hidden) || texture_region_button->is_pressed()) {
-			EditorNode::get_singleton()->make_bottom_panel_item_visible(region_editor);
+bool EditorInspectorPluginTextureRegion::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide) {
+	if ((p_type == Variant::RECT2 || p_type == Variant::RECT2I)) {
+		if (((Object::cast_to<Sprite2D>(p_object) || Object::cast_to<Sprite3D>(p_object) || Object::cast_to<NinePatchRect>(p_object) || Object::cast_to<StyleBoxTexture>(p_object)) && p_path == "region_rect") || (Object::cast_to<AtlasTexture>(p_object) && p_path == "region")) {
+			Button *button = memnew(Button);
+			button->set_text(TTR("Edit Region"));
+			button->set_icon(texture_region_editor->get_theme_icon(SNAME("RegionEdit"), SNAME("EditorIcons")));
+			button->connect("pressed", callable_mp(this, &EditorInspectorPluginTextureRegion::_region_edit), varray(p_object));
+			add_property_editor(p_path, button, true);
 		}
-	} else {
-		if (region_editor->is_visible_in_tree()) {
-			EditorNode::get_singleton()->hide_bottom_panel();
-			manually_hidden = false;
-		}
-		texture_region_button->hide();
-		region_editor->edit(nullptr);
 	}
+	return false; //not exclusive
 }
 
-Dictionary TextureRegionEditorPlugin::get_state() const {
-	Dictionary state;
-	state["snap_offset"] = region_editor->snap_offset;
-	state["snap_step"] = region_editor->snap_step;
-	state["snap_separation"] = region_editor->snap_separation;
-	state["snap_mode"] = region_editor->snap_mode;
-	return state;
-}
-
-void TextureRegionEditorPlugin::set_state(const Dictionary &p_state) {
-	Dictionary state = p_state;
-	if (state.has("snap_step")) {
-		Vector2 s = state["snap_step"];
-		region_editor->sb_step_x->set_value(s.x);
-		region_editor->sb_step_y->set_value(s.y);
-		region_editor->snap_step = s;
-	}
-
-	if (state.has("snap_offset")) {
-		Vector2 ofs = state["snap_offset"];
-		region_editor->sb_off_x->set_value(ofs.x);
-		region_editor->sb_off_y->set_value(ofs.y);
-		region_editor->snap_offset = ofs;
-	}
-
-	if (state.has("snap_separation")) {
-		Vector2 sep = state["snap_separation"];
-		region_editor->sb_sep_x->set_value(sep.x);
-		region_editor->sb_sep_y->set_value(sep.y);
-		region_editor->snap_separation = sep;
-	}
-
-	if (state.has("snap_mode")) {
-		region_editor->_set_snap_mode(state["snap_mode"]);
-		region_editor->snap_mode_button->select(state["snap_mode"]);
-	}
-}
-
-void TextureRegionEditorPlugin::_bind_methods() {
+EditorInspectorPluginTextureRegion::EditorInspectorPluginTextureRegion() {
+	texture_region_editor = memnew(TextureRegionEditor);
+	EditorNode::get_singleton()->get_gui_base()->add_child(texture_region_editor);
 }
 
 TextureRegionEditorPlugin::TextureRegionEditorPlugin() {
-	manually_hidden = false;
-
-	region_editor = memnew(TextureRegionEditor);
-	region_editor->set_custom_minimum_size(Size2(0, 200) * EDSCALE);
-	region_editor->hide();
-	region_editor->connect("visibility_changed", callable_mp(this, &TextureRegionEditorPlugin::_editor_visiblity_changed));
-
-	texture_region_button = EditorNode::get_singleton()->add_bottom_panel_item(TTR("TextureRegion"), region_editor);
-	texture_region_button->hide();
+	Ref<EditorInspectorPluginTextureRegion> inspector_plugin;
+	inspector_plugin.instantiate();
+	add_inspector_plugin(inspector_plugin);
 }

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -41,8 +41,8 @@
 
 class ViewPanner;
 
-class TextureRegionEditor : public VBoxContainer {
-	GDCLASS(TextureRegionEditor, VBoxContainer);
+class TextureRegionEditor : public AcceptDialog {
+	GDCLASS(TextureRegionEditor, AcceptDialog);
 
 	enum SnapMode {
 		SNAP_NONE,
@@ -142,26 +142,27 @@ public:
 	TextureRegionEditor();
 };
 
+//
+
+class EditorInspectorPluginTextureRegion : public EditorInspectorPlugin {
+	GDCLASS(EditorInspectorPluginTextureRegion, EditorInspectorPlugin);
+
+	TextureRegionEditor *texture_region_editor = nullptr;
+
+	void _region_edit(Object *p_object);
+
+public:
+	virtual bool can_handle(Object *p_object) override;
+	virtual bool parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide) override;
+
+	EditorInspectorPluginTextureRegion();
+};
+
 class TextureRegionEditorPlugin : public EditorPlugin {
 	GDCLASS(TextureRegionEditorPlugin, EditorPlugin);
 
-	bool manually_hidden;
-	Button *texture_region_button = nullptr;
-	TextureRegionEditor *region_editor = nullptr;
-
-protected:
-	static void _bind_methods();
-
-	void _editor_visiblity_changed();
-
 public:
 	virtual String get_name() const override { return "TextureRegion"; }
-	bool has_main_screen() const override { return false; }
-	virtual void edit(Object *p_object) override;
-	virtual bool handles(Object *p_object) const override;
-	virtual void make_visible(bool p_visible) override;
-	void set_state(const Dictionary &p_state) override;
-	Dictionary get_state() const override;
 
 	TextureRegionEditorPlugin();
 };


### PR DESCRIPTION
**Problem**:

* Region Rect was pretty much a mythical editor. Because it was annoying for it to pop up automatically, it was hidden by default.
* Because it was hidden by default, most users have no idea it even exists.
* But because it is a transient editor, it would steal focus of other editors and annoy users unexpectedly.
* This editor only edits a sole property of objects (*region_rect*) and there is a general disconnect to it, so users have it very difficult to make the mental link of what is being edited exactly.

In general, Region Rect editor is a very weird editor, because it only edits the single *region_rect* property of objects that read a texture from a region, no other editor works quite like it.

**Solution**:

Because of the strange nature of this editor, a dedicated solution was implemented:

* As its only useful to edit a very specific property in objects, the way to access it is now from that property via a button.
* Editor has been moved to a window.
* Regions that can be edited  now display a "Edit Region" button (below the region property). Pressing it brings up the Region Rect editor.

This required a slight change in EditorInspectorPlugin to allow custom editors to be below others.

### How it looks in action:

Regions now have a button you can press to edit them:
![image](https://user-images.githubusercontent.com/6265307/169915909-3bac3242-126b-4fe5-82ba-22555775f365.png)
This opens the region editor in context, only when you need it:
![image](https://user-images.githubusercontent.com/6265307/169915928-199f682d-639a-4fe2-89df-71d3474172f7.png)

### What it fixes:

Fixes #28341
Fixes #47514
Fixes #29873 

And probably many others.