### PR TITLE
GDScript: A few fixes for lambda issues

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -1624,6 +1624,10 @@ GDScriptParser::Node *GDScriptParser::parse_statement() {
 					case Node::AWAIT:
 						// Fine.
 						break;
+					case Node::LAMBDA:
+						// Standalone lambdas can't be used, so make this an error.
+						push_error("Standalone lambdas cannot be accessed. Consider assigning it to a variable.", expression);
+						break;
 					default:
 						push_warning(expression, GDScriptWarning::STANDALONE_EXPRESSION);
 				}

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2103,7 +2103,7 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_precedence(Precedence p_pr
 	ExpressionNode *previous_operand = (this->*prefix_rule)(nullptr, p_can_assign);
 
 	while (p_precedence <= get_rule(current.type)->precedence) {
-		if (previous_operand == nullptr || (p_stop_on_assign && current.type == GDScriptTokenizer::Token::EQUAL)) {
+		if (previous_operand == nullptr || (p_stop_on_assign && current.type == GDScriptTokenizer::Token::EQUAL) || (previous_operand->type == Node::LAMBDA && lambda_ended)) {
 			return previous_operand;
 		}
 		// Also switch multiline mode on here for infix operators.

--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -2926,6 +2926,9 @@ GDScriptParser::ExpressionNode *GDScriptParser::parse_lambda(ExpressionNode *p_p
 	current_function = function;
 
 	SuiteNode *body = alloc_node<SuiteNode>();
+	body->parent_function = current_function;
+	body->parent_block = current_suite;
+
 	SuiteNode *previous_suite = current_suite;
 	current_suite = body;
 

--- a/modules/gdscript/tests/scripts/parser/errors/lambda_standalone.gd
+++ b/modules/gdscript/tests/scripts/parser/errors/lambda_standalone.gd
@@ -1,0 +1,3 @@
+func test():
+	func standalone():
+		print("can't be accessed")

--- a/modules/gdscript/tests/scripts/parser/errors/lambda_standalone.out
+++ b/modules/gdscript/tests/scripts/parser/errors/lambda_standalone.out
@@ -1,0 +1,2 @@
+GDTEST_PARSER_ERROR
+Standalone lambdas cannot be accessed. Consider assigning it to a variable.

--- a/modules/gdscript/tests/scripts/parser/features/if_after_lambda.gd
+++ b/modules/gdscript/tests/scripts/parser/features/if_after_lambda.gd
@@ -1,0 +1,7 @@
+# https://github.com/godotengine/godot/issues/61231
+
+func test():
+	var my_lambda = func():
+		print("hello")
+	if 0 == 0:
+		my_lambda.call()

--- a/modules/gdscript/tests/scripts/parser/features/if_after_lambda.out
+++ b/modules/gdscript/tests/scripts/parser/features/if_after_lambda.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+hello

--- a/modules/gdscript/tests/scripts/parser/features/lambda_default_parameter_capture.gd
+++ b/modules/gdscript/tests/scripts/parser/features/lambda_default_parameter_capture.gd
@@ -1,0 +1,7 @@
+# https://github.com/godotengine/godot/issues/56751
+
+func test():
+	var x = "local"
+	var lambda = func(param = x):
+		print(param)
+	lambda.call()

--- a/modules/gdscript/tests/scripts/parser/features/lambda_default_parameter_capture.out
+++ b/modules/gdscript/tests/scripts/parser/features/lambda_default_parameter_capture.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+local


### PR DESCRIPTION
- Do not allow standalone lambdas. They cannot be accessed so it might be confusing especially if someone uses a named one.
- Fix issue with using `if` statement after a lambda being mistakenly recognized as a ternary operator. Fix #61231
- Fix issue when using locals as default value for lambda parameter. Fix #56751