### PR TITLE
[3.x] Allow ScrollBar params of a ScrollContainer to be modified from _ready()

### DIFF
--- a/scene/gui/scroll_container.h
+++ b/scene/gui/scroll_container.h
@@ -70,6 +70,7 @@ protected:
 
 	void _gui_input(const Ref<InputEvent> &p_gui_input);
 	void _gui_focus_changed(Control *p_control);
+	void _update_dimensions();
 	void _notification(int p_what);
 
 	void _scroll_moved(float);


### PR DESCRIPTION
Cherrypicks b8610dbd3159985f007deb0424a64df386832d07
Fixes https://github.com/godotengine/godot/issues/48057
https://github.com/godotengine/godot/issues/48057#issuecomment-826025680 is a separate issue

I don't know if this is the _best™️_ way to fix this or not because the scroll container code is kinda old and messy, but _it does fix it_, and it makes the 3.x code more like the master branch, so it's probably good.
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
