### PR TITLE
[Editor] Fix GDExtension GNU/Linux export.

### DIFF
--- a/platform/linuxbsd/export/export.cpp
+++ b/platform/linuxbsd/export/export.cpp
@@ -44,7 +44,7 @@ void register_linuxbsd_exporter() {
 	platform->set_name("Linux/X11");
 	platform->set_extension("x86_32");
 	platform->set_extension("x86_64", "binary_format/64_bits");
-	platform->set_os_name("LinuxBSD");
+	platform->set_os_name("Linux");
 	platform->set_chmod_flags(0755);
 
 	EditorExport::get_singleton()->add_export_platform(platform);


### PR DESCRIPTION
In this PR:
- Report when a GDExtension is skipped due to malformed config file or missing library.
- Change `EditorExportPlatformLinuxBSD` os_name to `Linux`:
  This is in line with what's reported by the `OS` class on GNU/Linux, and is required by the extension exporter to identify the correct library to export.
  For BSD, we should either finish splitting the platform (into platform/bsd) or register a separate exporter with OS name BSD and proper templates detection.