### PR TITLE
Fix optional 'default' argument to get_meta() in 3.x

### DIFF
--- a/core/object.cpp
+++ b/core/object.cpp
@@ -1062,7 +1062,6 @@ void Object::set_meta(const String &p_name, const Variant &p_value) {
 }
 
 Variant Object::get_meta(const String &p_name, const Variant &p_default) const {
-	ERR_FAIL_COND_V(!metadata.has(p_name), Variant());
 	if (!metadata.has(p_name)) {
 		if (p_default != Variant()) {
 			return p_default;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixes #61360, Remove redundant checks.