### PR TITLE
Tweak TextMesh decomposition error message to mention self-intersecting lines

### DIFF
--- a/scene/resources/primitive_meshes.cpp
+++ b/scene/resources/primitive_meshes.cpp
@@ -2339,18 +2339,18 @@ void TextMesh::_generate_glyph_mesh_data(uint32_t p_hash, const Glyph &p_gl) con
 	//Decompose and triangulate.
 	List<TPPLPoly> out_poly;
 	if (tpart.ConvexPartition_HM(&in_poly, &out_poly) == 0) {
-		ERR_FAIL_MSG("Convex decomposing failed!");
+		ERR_FAIL_MSG("Convex decomposing failed. Make sure the font doesn't contain self-intersecting lines, as these are not supported in TextMesh.");
 	}
 	List<TPPLPoly> out_tris;
 	for (List<TPPLPoly>::Element *I = out_poly.front(); I; I = I->next()) {
 		if (tpart.Triangulate_OPT(&(I->get()), &out_tris) == 0) {
-			ERR_FAIL_MSG("Triangulation failed!");
+			ERR_FAIL_MSG("Triangulation failed. Make sure the font doesn't contain self-intersecting lines, as these are not supported in TextMesh.");
 		}
 	}
 
 	for (List<TPPLPoly>::Element *I = out_tris.front(); I; I = I->next()) {
 		TPPLPoly &tp = I->get();
-		ERR_FAIL_COND(tp.GetNumPoints() != 3); // Trianges only.
+		ERR_FAIL_COND(tp.GetNumPoints() != 3); // Triangles only.
 
 		for (int i = 0; i < 3; i++) {
 			gl_data.triangles.push_back(Vector2(tp.GetPoint(i).x, tp.GetPoint(i).y));


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/61366.

See https://github.com/godotengine/godot/issues/61323.