### PR TITLE
Fix `OptionButton` popup which unable to close after open (at pressed)

### DIFF
--- a/scene/gui/option_button.cpp
+++ b/scene/gui/option_button.cpp
@@ -185,6 +185,11 @@ void OptionButton::_selected(int p_which) {
 }
 
 void OptionButton::pressed() {
+	if (popup->is_visible()) {
+		popup->hide();
+		return;
+	}
+
 	Size2 size = get_size() * get_viewport()->get_canvas_transform().get_scale();
 	popup->set_position(get_screen_position() + Size2(0, size.height * get_global_transform().get_scale().y));
 	popup->set_size(Size2(size.width, 0));


### PR DESCRIPTION
Fix https://github.com/godotengine/godot/issues/61350
