### PR TITLE
GDScript: Don't show redundant await warning on unknown types

### DIFF
--- a/modules/gdscript/tests/scripts/analyzer/features/await_with_signals_no_warning.gd
+++ b/modules/gdscript/tests/scripts/analyzer/features/await_with_signals_no_warning.gd
@@ -1,0 +1,12 @@
+# https://github.com/godotengine/godot/issues/54589
+# https://github.com/godotengine/godot/issues/56265
+
+extends Resource
+
+func test():
+	print("okay")
+	await self.changed
+	await unknown(self)
+
+func unknown(arg):
+	await arg.changed

--- a/modules/gdscript/tests/scripts/analyzer/features/await_with_signals_no_warning.out
+++ b/modules/gdscript/tests/scripts/analyzer/features/await_with_signals_no_warning.out
@@ -1,0 +1,2 @@
+GDTEST_OK
+okay


### PR DESCRIPTION
Also avoid it when the type is known to be a signal.

Fix #54589
Fix #56265
Fix #58156