### PR TITLE
Fix GridMap not adding custom mesh offsets to NavigationMesh generation

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -970,7 +970,7 @@ Array GridMap::get_meshes() const {
 		xform.set_origin(cellpos * cell_size + ofs);
 		xform.basis.scale(Vector3(cell_scale, cell_scale, cell_scale));
 
-		meshes.push_back(xform);
+		meshes.push_back(xform * mesh_library->get_item_mesh_transform(id));
 		meshes.push_back(mesh);
 	}
 


### PR DESCRIPTION
Fix GridMap not adding custom mesh offsets to NavigationMesh generation.

Fixes #61344

@akien-mga 
Tested with 3.5 also and same code works as cherry.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
