### PR TITLE
VCS: Don't assume Commit tab will stay at default location

### DIFF
--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -410,7 +410,10 @@ void VersionControlEditorPlugin::_refresh_stage_area() {
 
 	int total_changes = status_files.size();
 	String commit_tab_title = TTR("Commit") + (total_changes > 0 ? " (" + itos(total_changes) + ")" : "");
-	dock_vbc->set_tab_title(version_commit_dock->get_index(), commit_tab_title);
+	TabContainer *dock_vbc = Object::cast_to<TabContainer>(version_commit_dock->get_parent_control());
+	if (dock_vbc) {
+		dock_vbc->set_tab_title(version_commit_dock->get_index(), commit_tab_title);
+	}
 }
 
 void VersionControlEditorPlugin::_discard_file(String p_file_path, EditorVCSInterface::ChangeType p_change) {
@@ -932,7 +935,7 @@ void VersionControlEditorPlugin::_commit_message_gui_input(const Ref<InputEvent>
 
 void VersionControlEditorPlugin::register_editor() {
 	EditorNode::get_singleton()->add_control_to_dock(EditorNode::DOCK_SLOT_RIGHT_UL, version_commit_dock);
-	dock_vbc = (TabContainer *)version_commit_dock->get_parent_control();
+	TabContainer *dock_vbc = Object::cast_to<TabContainer>(version_commit_dock->get_parent_control());
 	dock_vbc->set_tab_title(version_commit_dock->get_index(), TTR("Commit"));
 
 	ToolButton *vc = EditorNode::get_singleton()->add_bottom_panel_item(TTR("Version Control"), version_control_dock);

--- a/editor/plugins/version_control_editor_plugin.h
+++ b/editor/plugins/version_control_editor_plugin.h
@@ -98,7 +98,6 @@ private:
 	HashMap<EditorVCSInterface::ChangeType, Color> change_type_to_color;
 	HashMap<EditorVCSInterface::ChangeType, Ref<Texture>> change_type_to_icon;
 
-	TabContainer *dock_vbc;
 	VBoxContainer *version_commit_dock;
 	Tree *staged_files;
 	Tree *unstaged_files;


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Should fix https://github.com/godotengine/godot-git-plugin/issues/111

However, since I wasn't able to reproduce the exact error, I did find a different UI bug with the `VersionControlEditorPlugin` assuming the commit tab to stay at the same place. This change should mitigate the issue mentioned above.
