### PR TITLE
Disable alpha in post process when using opaque framebuffer

### DIFF
--- a/drivers/gles2/rasterizer_scene_gles2.cpp
+++ b/drivers/gles2/rasterizer_scene_gles2.cpp
@@ -3192,6 +3192,7 @@ void RasterizerSceneGLES2::_post_process(Environment *env, const CameraMatrix &p
 		}
 	}
 
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::DISABLE_ALPHA, !storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT]);
 	state.tonemap_shader.bind();
 	if (env) {
 		if (max_glow_level >= 0) {
@@ -3230,6 +3231,7 @@ void RasterizerSceneGLES2::_post_process(Environment *env, const CameraMatrix &p
 	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_MULTI_TEXTURE_GLOW, false);
 	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_BCS, false);
 	state.tonemap_shader.set_conditional(TonemapShaderGLES2::USE_COLOR_CORRECTION, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES2::DISABLE_ALPHA, false);
 }
 
 void RasterizerSceneGLES2::render_scene(const Transform &p_cam_transform, const CameraMatrix &p_cam_projection, const int p_eye, bool p_cam_ortogonal, InstanceBase **p_cull_result, int p_cull_count, RID *p_light_cull_result, int p_light_cull_count, RID *p_reflection_probe_cull_result, int p_reflection_probe_cull_count, RID p_environment, RID p_shadow_atlas, RID p_reflection_atlas, RID p_reflection_probe, int p_reflection_probe_pass) {

--- a/drivers/gles2/shaders/tonemap.glsl
+++ b/drivers/gles2/shaders/tonemap.glsl
@@ -357,4 +357,8 @@ void main() {
 #endif
 
 	gl_FragColor = color;
+
+#ifdef DISABLE_ALPHA
+	gl_FragColor.a = 1.0;
+#endif
 }

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -4001,6 +4001,7 @@ void RasterizerSceneGLES3::_post_process(Environment *env, const CameraMatrix &p
 		}
 	}
 
+	state.tonemap_shader.set_conditional(TonemapShaderGLES3::DISABLE_ALPHA, !storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_TRANSPARENT]);
 	state.tonemap_shader.set_conditional(TonemapShaderGLES3::V_FLIP, storage->frame.current_rt->flags[RasterizerStorage::RENDER_TARGET_VFLIP]);
 	state.tonemap_shader.bind();
 
@@ -4064,6 +4065,7 @@ void RasterizerSceneGLES3::_post_process(Environment *env, const CameraMatrix &p
 	state.tonemap_shader.set_conditional(TonemapShaderGLES3::USE_BCS, false);
 	state.tonemap_shader.set_conditional(TonemapShaderGLES3::USE_COLOR_CORRECTION, false);
 	state.tonemap_shader.set_conditional(TonemapShaderGLES3::V_FLIP, false);
+	state.tonemap_shader.set_conditional(TonemapShaderGLES3::DISABLE_ALPHA, false);
 }
 
 bool RasterizerSceneGLES3::_element_needs_directional_add(RenderList::Element *e) {

--- a/drivers/gles3/shaders/tonemap.glsl
+++ b/drivers/gles3/shaders/tonemap.glsl
@@ -489,4 +489,8 @@ void main() {
 #endif
 
 	frag_color = color;
+
+#ifdef DISABLE_ALPHA
+	frag_color.a = 1.0;
+#endif
 }


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/61359

This is a follow up to https://github.com/godotengine/godot/pull/61375. This way of disabling alpha is a little more robust than the other. (https://github.com/godotengine/godot/pull/61375 is fine to leave as it should have a slight performance benefit and is technically more correct).

Essentially what this PR does is ensure that the tonemap shader ignores alpha when using an opaque framebuffer which is what always happened before we extended the tonemap to allow for transparent backgrounds. 