### PR TITLE
VCS: Change Commit list size button signal to item_selected

### DIFF
--- a/editor/plugins/version_control_editor_plugin.cpp
+++ b/editor/plugins/version_control_editor_plugin.cpp
@@ -194,7 +194,7 @@ void VersionControlEditorPlugin::_set_up() {
 	ERR_FAIL_COND_MSG(!EditorVCSInterface::get_singleton()->initialize(res_dir), "VCS was not initialized.");
 
 	_refresh_stage_area();
-	_refresh_commit_list();
+	_refresh_commit_list(commit_list_size_button->get_selected_metadata());
 	_refresh_branch_list();
 	_refresh_remote_list();
 }
@@ -240,7 +240,7 @@ String VersionControlEditorPlugin::_get_date_string_from(int64_t p_unix_timestam
 			Time::get_singleton()->get_offset_string_from_offset_minutes(p_offset_minutes));
 }
 
-void VersionControlEditorPlugin::_refresh_commit_list() {
+void VersionControlEditorPlugin::_refresh_commit_list(int p_index) {
 	CHECK_PLUGIN_INITIALIZED();
 
 	commit_list->get_root()->clear_children();
@@ -307,7 +307,7 @@ void VersionControlEditorPlugin::_commit() {
 	commit_message->set_text("");
 
 	_refresh_stage_area();
-	_refresh_commit_list();
+	_refresh_commit_list(commit_list_size_button->get_selected_metadata());
 	_refresh_branch_list();
 	_clear_diff();
 }
@@ -322,7 +322,7 @@ void VersionControlEditorPlugin::_branch_item_selected(int p_index) {
 	ScriptEditor::get_singleton()->reload_scripts();
 
 	_refresh_branch_list();
-	_refresh_commit_list();
+	_refresh_commit_list(commit_list_size_button->get_selected_metadata());
 	_refresh_stage_area();
 	_clear_diff();
 
@@ -471,7 +471,7 @@ void VersionControlEditorPlugin::_pull() {
 	EditorVCSInterface::get_singleton()->pull(remote_select->get_selected_metadata());
 	_refresh_stage_area();
 	_refresh_branch_list();
-	_refresh_commit_list();
+	_refresh_commit_list(commit_list_size_button->get_selected_metadata());
 	_clear_diff();
 	_update_opened_tabs();
 }
@@ -1277,10 +1277,10 @@ VersionControlEditorPlugin::VersionControlEditorPlugin() {
 	commit_list_size_button->add_item("10");
 	commit_list_size_button->set_item_metadata(0, 10);
 	commit_list_size_button->add_item("20");
-	commit_list_size_button->set_item_metadata(0, 20);
+	commit_list_size_button->set_item_metadata(1, 20);
 	commit_list_size_button->add_item("30");
-	commit_list_size_button->set_item_metadata(0, 30);
-	commit_list_size_button->connect("pressed", this, "_refresh_commit_list");
+	commit_list_size_button->set_item_metadata(2, 30);
+	commit_list_size_button->connect("item_selected", this, "_refresh_commit_list");
 	commit_list_hbc->add_child(commit_list_size_button);
 
 	commit_list = memnew(Tree);

--- a/editor/plugins/version_control_editor_plugin.h
+++ b/editor/plugins/version_control_editor_plugin.h
@@ -158,7 +158,7 @@ private:
 	void _discard_all();
 	void _refresh_stage_area();
 	void _refresh_branch_list();
-	void _refresh_commit_list();
+	void _refresh_commit_list(int p_index);
 	void _refresh_remote_list();
 	void _display_diff(int p_idx);
 	void _move_all(Object *p_tree);


### PR DESCRIPTION
This is in contrast to the previous signal in use - "pressed", which doesn't get emitted on simple clicks on the OptionButton to open the popup.

Also, fixes the ids using which the metadata was being set on the items on the commit list. The commit list size button items now work as expected

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
