### PR TITLE
Improve style of inspector buttons

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -2111,9 +2111,7 @@ EditorInspectorArray::EditorInspectorArray() {
 	elements_vbox->add_theme_constant_override("separation", 0);
 	vbox->add_child(elements_vbox);
 
-	add_button = memnew(Button);
-	add_button->set_text(TTR("Add Element"));
-	add_button->set_text_alignment(HORIZONTAL_ALIGNMENT_CENTER);
+	add_button = EditorInspector::create_inspector_action_button(TTR("Add Element"));
 	add_button->connect("pressed", callable_mp(this, &EditorInspectorArray::_add_button_pressed));
 	vbox->add_child(add_button);
 
@@ -2296,6 +2294,14 @@ void EditorInspector::cleanup_plugins() {
 		inspector_plugins[i].unref();
 	}
 	inspector_plugin_count = 0;
+}
+
+Button *EditorInspector::create_inspector_action_button(const String &p_text) {
+	Button *button = memnew(Button);
+	button->set_text(p_text);
+	button->set_theme_type_variation(SNAME("InspectorActionButton"));
+	button->set_h_size_flags(SIZE_SHRINK_CENTER);
+	return button;
 }
 
 void EditorInspector::set_undo_redo(UndoRedo *p_undo_redo) {
@@ -2991,11 +2997,9 @@ void EditorInspector::update_tree() {
 	}
 
 	if (!hide_metadata) {
-		Button *add_md = memnew(Button);
-		add_md->set_text(TTR("Add Metadata"));
-		add_md->set_focus_mode(Control::FOCUS_NONE);
-		add_md->set_icon(get_theme_icon("Add", "EditorIcons"));
-		add_md->connect("pressed", callable_mp(this, &EditorInspector::_show_add_meta_dialog));
+		Button *add_md = EditorInspector::create_inspector_action_button(TTR("Add Metadata"));
+		add_md->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
+		add_md->connect(SNAME("pressed"), callable_mp(this, &EditorInspector::_show_add_meta_dialog));
 		main_vbox->add_child(add_md);
 	}
 

--- a/editor/editor_inspector.h
+++ b/editor/editor_inspector.h
@@ -533,6 +533,7 @@ public:
 	static void add_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
 	static void remove_inspector_plugin(const Ref<EditorInspectorPlugin> &p_plugin);
 	static void cleanup_plugins();
+	static Button *create_inspector_action_button(const String &p_text);
 
 	static EditorProperty *instantiate_property_editor(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide = false);
 

--- a/editor/editor_properties_array_dict.cpp
+++ b/editor/editor_properties_array_dict.cpp
@@ -264,8 +264,7 @@ void EditorPropertyArray::update_property() {
 			property_vbox->set_h_size_flags(SIZE_EXPAND_FILL);
 			vbox->add_child(property_vbox);
 
-			button_add_item = memnew(Button);
-			button_add_item->set_text(TTR("Add Element"));
+			button_add_item = EditorInspector::create_inspector_action_button(TTR("Add Element"));
 			button_add_item->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 			button_add_item->connect(SNAME("pressed"), callable_mp(this, &EditorPropertyArray::_add_element));
 			vbox->add_child(button_add_item);
@@ -1107,8 +1106,7 @@ void EditorPropertyDictionary::update_property() {
 			prop->update_property();
 
 			if (i == amount + 1) {
-				button_add_item = memnew(Button);
-				button_add_item->set_text(TTR("Add Key/Value Pair"));
+				button_add_item = EditorInspector::create_inspector_action_button(TTR("Add Key/Value Pair"));
 				button_add_item->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 				button_add_item->connect("pressed", callable_mp(this, &EditorPropertyDictionary::_add_key_value));
 				add_vbox->add_child(button_add_item);
@@ -1344,8 +1342,7 @@ void EditorPropertyLocalizableString::update_property() {
 		}
 
 		if (page_index == max_page) {
-			button_add_item = memnew(Button);
-			button_add_item->set_text(TTR("Add Translation"));
+			button_add_item = EditorInspector::create_inspector_action_button(TTR("Add Translation"));
 			button_add_item->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 			button_add_item->connect("pressed", callable_mp(this, &EditorPropertyLocalizableString::_add_locale_popup));
 			property_vbox->add_child(button_add_item);

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -728,6 +728,26 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	theme->set_color("icon_focus_color", "Button", icon_focus_color);
 	theme->set_color("icon_pressed_color", "Button", icon_pressed_color);
 
+	const float ACTION_BUTTON_EXTRA_MARGIN = 32 * EDSCALE;
+
+	theme->set_type_variation("InspectorActionButton", "Button");
+	Color color_inspector_action = dark_color_1.lerp(mono_color, 0.12);
+	color_inspector_action.a = 0.5;
+	Ref<StyleBoxFlat> style_inspector_action = style_widget->duplicate();
+	style_inspector_action->set_bg_color(color_inspector_action);
+	style_inspector_action->set_default_margin(SIDE_RIGHT, ACTION_BUTTON_EXTRA_MARGIN);
+	theme->set_stylebox("normal", "InspectorActionButton", style_inspector_action);
+	style_inspector_action = style_widget_hover->duplicate();
+	style_inspector_action->set_default_margin(SIDE_RIGHT, ACTION_BUTTON_EXTRA_MARGIN);
+	theme->set_stylebox("hover", "InspectorActionButton", style_inspector_action);
+	style_inspector_action = style_widget_pressed->duplicate();
+	style_inspector_action->set_default_margin(SIDE_RIGHT, ACTION_BUTTON_EXTRA_MARGIN);
+	theme->set_stylebox("pressed", "InspectorActionButton", style_inspector_action);
+	style_inspector_action = style_widget_disabled->duplicate();
+	style_inspector_action->set_default_margin(SIDE_RIGHT, ACTION_BUTTON_EXTRA_MARGIN);
+	theme->set_stylebox("disabled", "InspectorActionButton", style_inspector_action);
+	theme->set_constant("h_separation", "InspectorActionButton", ACTION_BUTTON_EXTRA_MARGIN);
+
 	// Variation for Editor Log filter buttons
 	theme->set_type_variation("EditorLogFilterButton", "Button");
 	// When pressed, don't tint the icons with the accent color, just leave them normal.

--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -1141,8 +1141,7 @@ void EditorInspectorPluginTextureRegion::_region_edit(Object *p_object) {
 bool EditorInspectorPluginTextureRegion::parse_property(Object *p_object, const Variant::Type p_type, const String &p_path, const PropertyHint p_hint, const String &p_hint_text, const uint32_t p_usage, const bool p_wide) {
 	if ((p_type == Variant::RECT2 || p_type == Variant::RECT2I)) {
 		if (((Object::cast_to<Sprite2D>(p_object) || Object::cast_to<Sprite3D>(p_object) || Object::cast_to<NinePatchRect>(p_object) || Object::cast_to<StyleBoxTexture>(p_object)) && p_path == "region_rect") || (Object::cast_to<AtlasTexture>(p_object) && p_path == "region")) {
-			Button *button = memnew(Button);
-			button->set_text(TTR("Edit Region"));
+			Button *button = EditorInspector::create_inspector_action_button(TTR("Edit Region"));
 			button->set_icon(texture_region_editor->get_theme_icon(SNAME("RegionEdit"), SNAME("EditorIcons")));
 			button->connect("pressed", callable_mp(this, &EditorInspectorPluginTextureRegion::_region_edit), varray(p_object));
 			add_property_editor(p_path, button, true);


### PR DESCRIPTION
This PR improves appearance of some buttons in the inspector to make them more obvious, namely Edit Region and Add Metadata.
![image](https://user-images.githubusercontent.com/2223172/170149035-17ff33b2-ed5b-4ef7-9dd2-d2c630b08549.png)
I added a new theme variation called `InspectorActionButton`, which just adds a border to the normal style (but can be easily tweaked). Could be probably added to more buttons.