### PR TITLE
use ERR_FAIL_INDEX when preferred

### DIFF
--- a/core/templates/bin_sorted_array.h
+++ b/core/templates/bin_sorted_array.h
@@ -61,7 +61,7 @@ public:
 	}
 
 	uint64_t move(uint64_t p_idx, uint64_t p_bin) {
-		ERR_FAIL_COND_V(p_idx >= array.size(), -1);
+		ERR_FAIL_UNSIGNED_INDEX_V(p_idx, array.size(), -1);
 
 		uint64_t current_bin = bin_limits.size() - 1;
 		while (p_idx > bin_limits[current_bin]) {
@@ -113,7 +113,7 @@ public:
 	}
 
 	void remove_at(uint64_t p_idx) {
-		ERR_FAIL_COND(p_idx >= array.size());
+		ERR_FAIL_UNSIGNED_INDEX(p_idx, array.size());
 		uint64_t new_idx = move(p_idx, 0);
 		uint64_t swap_idx = array.size() - 1;
 

--- a/modules/openxr/editor/openxr_action_editor.cpp
+++ b/modules/openxr/editor/openxr_action_editor.cpp
@@ -63,8 +63,7 @@ void OpenXRActionEditor::_on_action_localized_name_changed(const String p_new_te
 }
 
 void OpenXRActionEditor::_on_item_selected(int p_idx) {
-	ERR_FAIL_COND(p_idx < 0);
-	ERR_FAIL_COND(p_idx >= OpenXRAction::OPENXR_ACTION_MAX);
+	ERR_FAIL_INDEX(p_idx, OpenXRAction::OPENXR_ACTION_MAX);
 
 	action->set_action_type(OpenXRAction::ActionType(p_idx));
 }

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -281,7 +281,7 @@ void TileSet::TerrainsPattern::set_terrains_from_array(Array p_terrains) {
 	int in_array_index = 0;
 	for (int i = 0; i < TileSet::CELL_NEIGHBOR_MAX; i++) {
 		if (is_valid_bit[i]) {
-			ERR_FAIL_COND(in_array_index >= p_terrains.size());
+			ERR_FAIL_INDEX(in_array_index, p_terrains.size());
 			set_terrain(TileSet::CellNeighbor(i), p_terrains[in_array_index]);
 			in_array_index++;
 		}

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -387,9 +387,11 @@ void AudioStreamRandomizer::add_stream(int p_index) {
 	notify_property_list_changed();
 }
 
+// p_index_to is relative to the array prior to the removal of from.
+// Example: [0, 1, 2, 3], move(1, 3) => [0, 2, 1, 3]
 void AudioStreamRandomizer::move_stream(int p_index_from, int p_index_to) {
-	ERR_FAIL_COND(p_index_from < 0);
-	ERR_FAIL_COND(p_index_from >= audio_stream_pool.size());
+	ERR_FAIL_INDEX(p_index_from, audio_stream_pool.size());
+	// p_index_to == audio_stream_pool.size() is valid (move to end).
 	ERR_FAIL_COND(p_index_to < 0);
 	ERR_FAIL_COND(p_index_to > audio_stream_pool.size());
 	audio_stream_pool.insert(p_index_to, audio_stream_pool[p_index_from]);
@@ -403,36 +405,31 @@ void AudioStreamRandomizer::move_stream(int p_index_from, int p_index_to) {
 }
 
 void AudioStreamRandomizer::remove_stream(int p_index) {
-	ERR_FAIL_COND(p_index < 0);
-	ERR_FAIL_COND(p_index >= audio_stream_pool.size());
+	ERR_FAIL_INDEX(p_index, audio_stream_pool.size());
 	audio_stream_pool.remove_at(p_index);
 	emit_signal(SNAME("changed"));
 	notify_property_list_changed();
 }
 
 void AudioStreamRandomizer::set_stream(int p_index, Ref<AudioStream> p_stream) {
-	ERR_FAIL_COND(p_index < 0);
-	ERR_FAIL_COND(p_index >= audio_stream_pool.size());
+	ERR_FAIL_INDEX(p_index, audio_stream_pool.size());
 	audio_stream_pool.write[p_index].stream = p_stream;
 	emit_signal(SNAME("changed"));
 }
 
 Ref<AudioStream> AudioStreamRandomizer::get_stream(int p_index) const {
-	ERR_FAIL_COND_V(p_index < 0, nullptr);
-	ERR_FAIL_COND_V(p_index >= audio_stream_pool.size(), nullptr);
+	ERR_FAIL_INDEX_V(p_index, audio_stream_pool.size(), nullptr);
 	return audio_stream_pool[p_index].stream;
 }
 
 void AudioStreamRandomizer::set_stream_probability_weight(int p_index, float p_weight) {
-	ERR_FAIL_COND(p_index < 0);
-	ERR_FAIL_COND(p_index >= audio_stream_pool.size());
+	ERR_FAIL_INDEX(p_index, audio_stream_pool.size());
 	audio_stream_pool.write[p_index].weight = p_weight;
 	emit_signal(SNAME("changed"));
 }
 
 float AudioStreamRandomizer::get_stream_probability_weight(int p_index) const {
-	ERR_FAIL_COND_V(p_index < 0, 0);
-	ERR_FAIL_COND_V(p_index >= audio_stream_pool.size(), 0);
+	ERR_FAIL_INDEX_V(p_index, audio_stream_pool.size(), 0);
 	return audio_stream_pool[p_index].weight;
 }
 

--- a/servers/physics_3d/godot_soft_body_3d.cpp
+++ b/servers/physics_3d/godot_soft_body_3d.cpp
@@ -429,33 +429,33 @@ uint32_t GodotSoftBody3D::get_node_count() const {
 }
 
 real_t GodotSoftBody3D::get_node_inv_mass(uint32_t p_node_index) const {
-	ERR_FAIL_COND_V(p_node_index >= nodes.size(), 0.0);
+	ERR_FAIL_UNSIGNED_INDEX_V(p_node_index, nodes.size(), 0.0);
 	return nodes[p_node_index].im;
 }
 
 Vector3 GodotSoftBody3D::get_node_position(uint32_t p_node_index) const {
-	ERR_FAIL_COND_V(p_node_index >= nodes.size(), Vector3());
+	ERR_FAIL_UNSIGNED_INDEX_V(p_node_index, nodes.size(), Vector3());
 	return nodes[p_node_index].x;
 }
 
 Vector3 GodotSoftBody3D::get_node_velocity(uint32_t p_node_index) const {
-	ERR_FAIL_COND_V(p_node_index >= nodes.size(), Vector3());
+	ERR_FAIL_UNSIGNED_INDEX_V(p_node_index, nodes.size(), Vector3());
 	return nodes[p_node_index].v;
 }
 
 Vector3 GodotSoftBody3D::get_node_biased_velocity(uint32_t p_node_index) const {
-	ERR_FAIL_COND_V(p_node_index >= nodes.size(), Vector3());
+	ERR_FAIL_UNSIGNED_INDEX_V(p_node_index, nodes.size(), Vector3());
 	return nodes[p_node_index].bv;
 }
 
 void GodotSoftBody3D::apply_node_impulse(uint32_t p_node_index, const Vector3 &p_impulse) {
-	ERR_FAIL_COND(p_node_index >= nodes.size());
+	ERR_FAIL_UNSIGNED_INDEX(p_node_index, nodes.size());
 	Node &node = nodes[p_node_index];
 	node.v += p_impulse * node.im;
 }
 
 void GodotSoftBody3D::apply_node_bias_impulse(uint32_t p_node_index, const Vector3 &p_impulse) {
-	ERR_FAIL_COND(p_node_index >= nodes.size());
+	ERR_FAIL_UNSIGNED_INDEX(p_node_index, nodes.size());
 	Node &node = nodes[p_node_index];
 	node.bv += p_impulse * node.im;
 }
@@ -465,7 +465,7 @@ uint32_t GodotSoftBody3D::get_face_count() const {
 }
 
 void GodotSoftBody3D::get_face_points(uint32_t p_face_index, Vector3 &r_point_1, Vector3 &r_point_2, Vector3 &r_point_3) const {
-	ERR_FAIL_COND(p_face_index >= faces.size());
+	ERR_FAIL_UNSIGNED_INDEX(p_face_index, faces.size());
 	const Face &face = faces[p_face_index];
 	r_point_1 = face.n[0]->x;
 	r_point_2 = face.n[1]->x;
@@ -473,7 +473,7 @@ void GodotSoftBody3D::get_face_points(uint32_t p_face_index, Vector3 &r_point_1,
 }
 
 Vector3 GodotSoftBody3D::get_face_normal(uint32_t p_face_index) const {
-	ERR_FAIL_COND_V(p_face_index >= faces.size(), Vector3());
+	ERR_FAIL_UNSIGNED_INDEX_V(p_face_index, faces.size(), Vector3());
 	return faces[p_face_index].normal;
 }
 

--- a/servers/text_server.cpp
+++ b/servers/text_server.cpp
@@ -75,7 +75,7 @@ void TextServerManager::remove_interface(const Ref<TextServer> &p_interface) {
 		};
 	};
 
-	ERR_FAIL_COND(idx == -1);
+	ERR_FAIL_COND_MSG(idx == -1, "Interface not found.");
 	print_verbose("TextServer: Removed interface \"" + p_interface->get_name() + "\"");
 	emit_signal(SNAME("interface_removed"), p_interface->get_name());
 	interfaces.remove_at(idx);
@@ -99,7 +99,7 @@ Ref<TextServer> TextServerManager::find_interface(const String &p_name) const {
 		};
 	};
 
-	ERR_FAIL_COND_V(idx == -1, nullptr);
+	ERR_FAIL_COND_V_MSG(idx == -1, nullptr, "Interface not found.");
 	return interfaces[idx];
 }
 

--- a/servers/xr_server.cpp
+++ b/servers/xr_server.cpp
@@ -184,7 +184,7 @@ void XRServer::remove_interface(const Ref<XRInterface> &p_interface) {
 		};
 	};
 
-	ERR_FAIL_COND(idx == -1);
+	ERR_FAIL_COND_MSG(idx == -1, "Interface not found.");
 
 	print_verbose("XR: Removed interface" + p_interface->get_name());
 
@@ -211,7 +211,7 @@ Ref<XRInterface> XRServer::find_interface(const String &p_name) const {
 		};
 	};
 
-	ERR_FAIL_COND_V(idx == -1, nullptr);
+	ERR_FAIL_COND_V_MSG(idx == -1, nullptr, "Interface not found.");
 
 	return interfaces[idx];
 };


### PR DESCRIPTION
Changes most clear instances where ERR_FAIL_INDEX(_V_MSG) is intended.

~~SoftBody has been tested and it works the same as it did before (despite being a bit buggy, see GodotPhysics bug tracker)~~

~~This only partially uses ERR_FAIL_INDEX, since I did not want to mix too many changes with my SoftBody simplifications.~~

Edit: Softbody changes are in my branch `archive/soft-body-cleanup`. There were additional errors and I wasn't sure if it was my fault or an underlying SoftBody issue. Assuming most of the code will be cleaned up when it is refactored.

Thanks @ kleonc for the idea.