### PR TITLE
HTML5: Enable mbedTLS module for Crypto object, force disable Asset Library

### DIFF
--- a/doc/classes/Crypto.xml
+++ b/doc/classes/Crypto.xml
@@ -68,7 +68,6 @@
 		}
 		[/csharp]
 		[/codeblocks]
-		[b]Note:[/b] Not available in HTML5 exports.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/CryptoKey.xml
+++ b/doc/classes/CryptoKey.xml
@@ -6,7 +6,6 @@
 	<description>
 		The CryptoKey class represents a cryptographic key. Keys can be loaded and saved like any other [Resource].
 		They can be used to generate a self-signed [X509Certificate] via [method Crypto.generate_self_signed_certificate] and as private key in [method StreamPeerSSL.accept_stream] along with the appropriate certificate.
-		[b]Note:[/b] Not available in HTML5 exports.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/HMACContext.xml
+++ b/doc/classes/HMACContext.xml
@@ -50,7 +50,6 @@
 
 		[/csharp]
 		[/codeblocks]
-		[b]Note:[/b] Not available in HTML5 exports.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/HashingContext.xml
+++ b/doc/classes/HashingContext.xml
@@ -57,7 +57,6 @@
 		}
 		[/csharp]
 		[/codeblocks]
-		[b]Note:[/b] Not available in HTML5 exports.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/X509Certificate.xml
+++ b/doc/classes/X509Certificate.xml
@@ -6,7 +6,6 @@
 	<description>
 		The X509Certificate class represents an X509 certificate. Certificates can be loaded and saved like any other [Resource].
 		They can be used as the server certificate in [method StreamPeerSSL.accept_stream] (along with the proper [CryptoKey]), and to specify the only certificate that should be accepted when connecting to an SSL server via [method StreamPeerSSL.connect_to_stream].
-		[b]Note:[/b] Not available in HTML5 exports.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -7025,11 +7025,15 @@ EditorNode::EditorNode() {
 	ScriptTextEditor::register_editor(); // Register one for text scripts.
 	TextEditor::register_editor();
 
+	// Asset Library can't work on Web editor for now as most assets are sourced
+	// directly from GitHub which does not set CORS.
+#ifndef JAVASCRIPT_ENABLED
 	if (StreamPeerSSL::is_available()) {
 		add_editor_plugin(memnew(AssetLibraryEditorPlugin));
 	} else {
 		WARN_PRINT("Asset Library not available, as it requires SSL to work.");
 	}
+#endif
 
 	// Add interface before adding plugins.
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2773,6 +2773,9 @@ ProjectManager::ProjectManager() {
 		center_box->add_child(settings_hb);
 	}
 
+	// Asset Library can't work on Web editor for now as most assets are sourced
+	// directly from GitHub which does not set CORS.
+#ifndef JAVASCRIPT_ENABLED
 	if (StreamPeerSSL::is_available()) {
 		asset_library = memnew(EditorAssetLibrary(true));
 		asset_library->set_name(TTR("Asset Library Projects"));
@@ -2781,6 +2784,7 @@ ProjectManager::ProjectManager() {
 	} else {
 		WARN_PRINT("Asset Library not available, as it requires SSL to work.");
 	}
+#endif
 
 	{
 		// Dialogs

--- a/platform/javascript/detect.py
+++ b/platform/javascript/detect.py
@@ -48,11 +48,6 @@ def get_flags():
     return [
         ("tools", False),
         ("builtin_pcre2_with_jit", False),
-        # Disabling the mbedtls module reduces file size.
-        # The module has little use due to the limited networking functionality
-        # in this platform. For the available networking methods, the browser
-        # manages TLS.
-        ("module_mbedtls_enabled", False),
         ("vulkan", False),
     ]
 


### PR DESCRIPTION
Increases the size of the wasm by around 3% (~300-350 KiB).

This enables using the Crypto object for hashing, signing and encryption,
and therefore reduces the gap between the features of the HTML5 platform
and other platforms.

Closes https://github.com/godotengine/godot-proposals/issues/3574.