### PR TITLE
Fix Occluder Poly gizmo warning spam

### DIFF
--- a/editor/spatial_editor_gizmos.cpp
+++ b/editor/spatial_editor_gizmos.cpp
@@ -5398,10 +5398,14 @@ void OccluderSpatialGizmo::redraw() {
 	const OccluderShapePolygon *occ_poly = get_occluder_shape_poly();
 	if (occ_poly) {
 		// main poly
-		_redraw_poly(false, occ_poly->_poly_pts_local, occ_poly->_poly_pts_local_raw);
+		if (occ_poly->_poly_pts_local_raw.size()) {
+			_redraw_poly(false, occ_poly->_poly_pts_local, occ_poly->_poly_pts_local_raw);
+		}
 
 		// hole
-		_redraw_poly(true, occ_poly->_hole_pts_local, occ_poly->_hole_pts_local_raw);
+		if (occ_poly->_hole_pts_local_raw.size()) {
+			_redraw_poly(true, occ_poly->_hole_pts_local, occ_poly->_hole_pts_local_raw);
+		}
 	}
 }
 


### PR DESCRIPTION
The call to draw the handles in the OccluderPoly was spamming errors when the hole has no points. This PR prevents trying to draw the gizmo for the hole when there are no points, which prevents the spam.

Previously the error spam looked like this when drawing a poly with no hole, it is complaining about a mesh with no vertices:
```
servers/visual_server.cpp:1065 - Condition "array_len == 0" is true.
scene/resources/mesh.cpp:797 - Condition "len == 0" is true.
scene/resources/mesh.cpp:924 - Index p_idx = 0 is out of bounds (surfaces.size() = 0).
```

## Notes
* I can't quite work out if this was a regression introduced by some changes in the gizmo handles or visual server, or if this existed since I introduced the holes but never noticed it. The spam is actually correct, I should not be creating the handles if there are none present.
* Either way it is quite a simple fix.
* This could alternatively be done in the `add_handles()` call, just returning if there are no handles to add.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
