### PR TITLE
Android: Change export plugin poll to 300 ms

### DIFF
--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -373,11 +373,11 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 			ea->device_lock.unlock();
 		}
 
-		uint64_t sleep = OS::get_singleton()->get_power_state() == OS::POWERSTATE_ON_BATTERY ? 1000 : 100;
-		uint64_t wait = 3000000;
+		uint64_t sleep = 300'000;
+		uint64_t wait = 3'000'000;
 		uint64_t time = OS::get_singleton()->get_ticks_usec();
 		while (OS::get_singleton()->get_ticks_usec() - time < wait) {
-			OS::get_singleton()->delay_usec(1000 * sleep);
+			OS::get_singleton()->delay_usec(sleep);
 			if (ea->quit_request.is_set()) {
 				break;
 			}


### PR DESCRIPTION
This removes the reliance on the not-so-fully-implemented Power API,
which throws an error in the HTML5 editor.

This was already changed to 200 ms in the master branch, and here I
picked 300 ms to be consistent with the iOS export plugin. All these
thread sleeps need to be re-assessed together to be made more
consistent (and possibly configurable - and most importantly battery
preserving by default).