### PR TITLE
Project Manager: Fix crash on resize with assetlib disabled

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -1881,18 +1881,20 @@ void ProjectManager::_notification(int p_what) {
 		} break;
 
 		case NOTIFICATION_RESIZED: {
-			if (open_templates->is_visible()) {
+			if (open_templates && open_templates->is_visible()) {
 				open_templates->popup_centered();
 			}
-			real_t size = get_size().x / EDSCALE;
-			asset_library->set_columns(size < 1000 ? 1 : 2);
-			// Adjust names of tabs to fit the new size.
-			if (size < 650) {
-				local_projects_hb->set_name(TTR("Local"));
-				asset_library->set_name(TTR("Asset Library"));
-			} else {
-				local_projects_hb->set_name(TTR("Local Projects"));
-				asset_library->set_name(TTR("Asset Library Projects"));
+			if (asset_library) {
+				real_t size = get_size().x / EDSCALE;
+				asset_library->set_columns(size < 1000 ? 1 : 2);
+				// Adjust names of tabs to fit the new size.
+				if (size < 650) {
+					local_projects_hb->set_name(TTR("Local"));
+					asset_library->set_name(TTR("Asset Library"));
+				} else {
+					local_projects_hb->set_name(TTR("Local Projects"));
+					asset_library->set_name(TTR("Asset Library Projects"));
+				}
 			}
 		} break;
 
@@ -1900,10 +1902,6 @@ void ProjectManager::_notification(int p_what) {
 			int default_sorting = (int)EditorSettings::get_singleton()->get("project_manager/sorting_order");
 			filter_option->select(default_sorting);
 			_project_list->set_order_option(default_sorting);
-
-			if (_project_list->get_project_count() == 0 && StreamPeerSSL::is_available()) {
-				open_templates->popup_centered();
-			}
 
 			if (_project_list->get_project_count() >= 1) {
 				// Focus on the search box immediately to allow the user
@@ -1914,6 +1912,10 @@ void ProjectManager::_notification(int p_what) {
 			if (asset_library) {
 				// Removes extra border margins.
 				asset_library->add_theme_style_override("panel", memnew(StyleBoxEmpty));
+				// Suggest browsing asset library to get templates/demos.
+				if (open_templates && _project_list->get_project_count() == 0) {
+					open_templates->popup_centered();
+				}
 			}
 		} break;
 
@@ -2847,11 +2849,13 @@ ProjectManager::ProjectManager() {
 		dialog_error = memnew(AcceptDialog);
 		add_child(dialog_error);
 
-		open_templates = memnew(ConfirmationDialog);
-		open_templates->set_text(TTR("You currently don't have any projects.\nWould you like to explore official example projects in the Asset Library?"));
-		open_templates->get_ok_button()->set_text(TTR("Open Asset Library"));
-		open_templates->connect("confirmed", callable_mp(this, &ProjectManager::_open_asset_library));
-		add_child(open_templates);
+		if (asset_library) {
+			open_templates = memnew(ConfirmationDialog);
+			open_templates->set_text(TTR("You currently don't have any projects.\nWould you like to explore official example projects in the Asset Library?"));
+			open_templates->get_ok_button()->set_text(TTR("Open Asset Library"));
+			open_templates->connect("confirmed", callable_mp(this, &ProjectManager::_open_asset_library));
+			add_child(open_templates);
+		}
 
 		about = memnew(EditorAbout);
 		add_child(about);


### PR DESCRIPTION
This would crash on the Web editor:
![image](https://user-images.githubusercontent.com/4701338/170249154-0baff06e-6f77-45a6-b07b-290c9864fc9c.png)

Follow-up to #61215.