### PR TITLE
Add a Fade Start property to ReflectionProbe

### DIFF
--- a/doc/classes/ReflectionProbe.xml
+++ b/doc/classes/ReflectionProbe.xml
@@ -34,6 +34,9 @@
 		<member name="enable_shadows" type="bool" setter="set_enable_shadows" getter="are_shadows_enabled" default="false">
 			If [code]true[/code], computes shadows in the reflection probe. This makes the reflection probe slower to render; you may want to disable this if using the [constant UPDATE_ALWAYS] [member update_mode].
 		</member>
+		<member name="fade_start" type="float" setter="set_fade_start" getter="get_fade_start" default="0.5">
+			The percentage of the distance from the origin at which reflections will start fading to other reflection sources (such as other [ReflectionProbe]s or the environment sky reflections). Higher values make the [ReflectionProbe] more visible, with more aggressive fading in the corners. If you have trouble with sky reflections being visible in partially indoor areas, increase [member fade_start].
+		</member>
 		<member name="intensity" type="float" setter="set_intensity" getter="get_intensity" default="1.0">
 			Defines the reflection intensity. Intensity modulates the strength of the reflection.
 		</member>

--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3150,6 +3150,14 @@
 				If [code]true[/code], computes shadows in the reflection probe. This makes the reflection much slower to compute. Equivalent to [member ReflectionProbe.enable_shadows].
 			</description>
 		</method>
+		<method name="reflection_probe_set_fade_start">
+			<return type="void" />
+			<param index="0" name="probe" type="RID" />
+			<param index="1" name="fade_start" type="float" />
+			<description>
+				Sets the percentage of the distance from the origin at which reflections will start fading to other reflection sources (such as other [ReflectionProbe]s or the environment sky reflections). Higher values make the [ReflectionProbe] more visible, with more aggressive fading in the corners. If you have trouble with sky reflections being visible in partially indoor areas, increase [method reflection_probe_set_fade_start]. Equivalent to [member ReflectionProbe.fade_start].
+			</description>
+		</method>
 		<method name="reflection_probe_set_intensity">
 			<return type="void" />
 			<param index="0" name="probe" type="RID" />

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -3398,6 +3398,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_BOX_OFFSET, probe->origin_offset, shader->version, instance_variant, spec_constants);
 						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_EXTERIOR, !probe->interior, shader->version, instance_variant, spec_constants);
 						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_INTENSITY, probe->intensity, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_INV_FADE_START, 1.0 / MAX(0.00001, 1.0 - probe->fade_start), shader->version, instance_variant, spec_constants);
 						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_AMBIENT_MODE, int(probe->ambient_mode), shader->version, instance_variant, spec_constants);
 						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_AMBIENT_COLOR, probe->ambient_color * probe->ambient_color_energy, shader->version, instance_variant, spec_constants);
 						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE1_LOCAL_MATRIX, inst->reflection_probes_local_transform_cache[0], shader->version, instance_variant, spec_constants);
@@ -3416,6 +3417,7 @@ void RasterizerSceneGLES3::_render_list_template(RenderListParameters *p_params,
 						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_BOX_OFFSET, probe->origin_offset, shader->version, instance_variant, spec_constants);
 						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_EXTERIOR, !probe->interior, shader->version, instance_variant, spec_constants);
 						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_INTENSITY, probe->intensity, shader->version, instance_variant, spec_constants);
+						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_INV_FADE_START, 1.0 / MAX(0.00001, 1.0 - probe->fade_start), shader->version, instance_variant, spec_constants);
 						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_AMBIENT_MODE, int(probe->ambient_mode), shader->version, instance_variant, spec_constants);
 						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_AMBIENT_COLOR, probe->ambient_color * probe->ambient_color_energy, shader->version, instance_variant, spec_constants);
 						material_storage->shaders.scene_shader.version_set_uniform(SceneShaderGLES3::REFPROBE2_LOCAL_MATRIX, inst->reflection_probes_local_transform_cache[1], shader->version, instance_variant, spec_constants);

--- a/drivers/gles3/shaders/scene.glsl
+++ b/drivers/gles3/shaders/scene.glsl
@@ -874,6 +874,7 @@ uniform vec3 refprobe1_box_offset;
 uniform highp mat4 refprobe1_local_matrix;
 uniform bool refprobe1_exterior;
 uniform float refprobe1_intensity;
+uniform float refprobe1_inv_fade_start;
 uniform int refprobe1_ambient_mode;
 uniform vec4 refprobe1_ambient_color;
 
@@ -887,6 +888,7 @@ uniform vec3 refprobe2_box_offset;
 uniform highp mat4 refprobe2_local_matrix;
 uniform bool refprobe2_exterior;
 uniform float refprobe2_intensity;
+uniform float refprobe2_inv_fade_start;
 uniform int refprobe2_ambient_mode;
 uniform vec4 refprobe2_ambient_color;
 
@@ -1587,7 +1589,7 @@ void reflection_process(samplerCube reflection_map,
 		vec3 normal, vec3 vertex,
 		mat4 local_matrix,
 		bool use_box_project, vec3 box_extents, vec3 box_offset,
-		bool exterior, float intensity, int ref_ambient_mode, vec4 ref_ambient_color,
+		bool exterior, float intensity, float inv_fade_start, int ref_ambient_mode, vec4 ref_ambient_color,
 		float roughness, vec3 ambient, vec3 skybox,
 		inout highp vec4 reflection_accum, inout highp vec4 ambient_accum) {
 	vec4 reflection;
@@ -1602,7 +1604,7 @@ void reflection_process(samplerCube reflection_map,
 	float blend = max(inner_pos.x, max(inner_pos.y, inner_pos.z));
 	blend = mix(length(inner_pos), blend, blend);
 	blend *= blend;
-	blend = max(0.0, 1.0 - blend);
+	blend = clamp(inv_fade_start - blend * inv_fade_start, 0.0, 1.0);
 
 	//reflect and make local
 	vec3 ref_normal = normalize(reflect(vertex, normal));
@@ -1961,14 +1963,14 @@ void main() {
 
 		reflection_process(refprobe1_texture, normal, vertex_interp, refprobe1_local_matrix,
 				refprobe1_use_box_project, refprobe1_box_extents, refprobe1_box_offset,
-				refprobe1_exterior, refprobe1_intensity, refprobe1_ambient_mode, refprobe1_ambient_color,
+				refprobe1_exterior, refprobe1_intensity, refprobe1_inv_fade_start, refprobe1_ambient_mode, refprobe1_ambient_color,
 				roughness, ambient_light, specular_light, reflection_accum, ambient_accum);
 
 #ifdef SECOND_REFLECTION_PROBE
 
 		reflection_process(refprobe2_texture, normal, vertex_interp, refprobe2_local_matrix,
 				refprobe2_use_box_project, refprobe2_box_extents, refprobe2_box_offset,
-				refprobe2_exterior, refprobe2_intensity, refprobe2_ambient_mode, refprobe2_ambient_color,
+				refprobe2_exterior, refprobe2_intensity, refprobe2_inv_fade_start, refprobe2_ambient_mode, refprobe2_ambient_color,
 				roughness, ambient_light, specular_light, reflection_accum, ambient_accum);
 
 #endif // SECOND_REFLECTION_PROBE

--- a/drivers/gles3/storage/light_storage.cpp
+++ b/drivers/gles3/storage/light_storage.cpp
@@ -454,6 +454,13 @@ void LightStorage::reflection_probe_set_intensity(RID p_probe, float p_intensity
 	reflection_probe->intensity = p_intensity;
 }
 
+void LightStorage::reflection_probe_set_fade_start(RID p_probe, float p_fade_start) {
+	ReflectionProbe *reflection_probe = reflection_probe_owner.get_or_null(p_probe);
+	ERR_FAIL_NULL(reflection_probe);
+
+	reflection_probe->fade_start = p_fade_start;
+}
+
 void LightStorage::reflection_probe_set_ambient_mode(RID p_probe, RS::ReflectionProbeAmbientMode p_mode) {
 	ReflectionProbe *reflection_probe = reflection_probe_owner.get_or_null(p_probe);
 	ERR_FAIL_NULL(reflection_probe);

--- a/drivers/gles3/storage/light_storage.h
+++ b/drivers/gles3/storage/light_storage.h
@@ -117,6 +117,7 @@ struct ReflectionProbe {
 	RS::ReflectionProbeUpdateMode update_mode = RS::REFLECTION_PROBE_UPDATE_ONCE;
 	int resolution = 256;
 	float intensity = 1.0;
+	float fade_start = 0.5;
 	RS::ReflectionProbeAmbientMode ambient_mode = RS::REFLECTION_PROBE_AMBIENT_ENVIRONMENT;
 	Color ambient_color;
 	float ambient_color_energy = 1.0;
@@ -639,6 +640,7 @@ public:
 
 	virtual void reflection_probe_set_update_mode(RID p_probe, RS::ReflectionProbeUpdateMode p_mode) override;
 	virtual void reflection_probe_set_intensity(RID p_probe, float p_intensity) override;
+	virtual void reflection_probe_set_fade_start(RID p_probe, float p_fade_start) override;
 	virtual void reflection_probe_set_ambient_mode(RID p_probe, RS::ReflectionProbeAmbientMode p_mode) override;
 	virtual void reflection_probe_set_ambient_color(RID p_probe, const Color &p_color) override;
 	virtual void reflection_probe_set_ambient_energy(RID p_probe, float p_energy) override;

--- a/scene/3d/reflection_probe.cpp
+++ b/scene/3d/reflection_probe.cpp
@@ -39,6 +39,15 @@ float ReflectionProbe::get_intensity() const {
 	return intensity;
 }
 
+void ReflectionProbe::set_fade_start(float p_fade_start) {
+	fade_start = p_fade_start;
+	RS::get_singleton()->reflection_probe_set_fade_start(probe, p_fade_start);
+}
+
+float ReflectionProbe::get_fade_start() const {
+	return fade_start;
+}
+
 void ReflectionProbe::set_ambient_mode(AmbientMode p_mode) {
 	ambient_mode = p_mode;
 	RS::get_singleton()->reflection_probe_set_ambient_mode(probe, RS::ReflectionProbeAmbientMode(p_mode));
@@ -202,6 +211,9 @@ void ReflectionProbe::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_intensity", "intensity"), &ReflectionProbe::set_intensity);
 	ClassDB::bind_method(D_METHOD("get_intensity"), &ReflectionProbe::get_intensity);
 
+	ClassDB::bind_method(D_METHOD("set_fade_start", "fade_start"), &ReflectionProbe::set_fade_start);
+	ClassDB::bind_method(D_METHOD("get_fade_start"), &ReflectionProbe::get_fade_start);
+
 	ClassDB::bind_method(D_METHOD("set_ambient_mode", "ambient"), &ReflectionProbe::set_ambient_mode);
 	ClassDB::bind_method(D_METHOD("get_ambient_mode"), &ReflectionProbe::get_ambient_mode);
 
@@ -243,6 +255,7 @@ void ReflectionProbe::_bind_methods() {
 
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "update_mode", PROPERTY_HINT_ENUM, "Once (Fast),Always (Slow)"), "set_update_mode", "get_update_mode");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "intensity", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_intensity", "get_intensity");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "fade_start", PROPERTY_HINT_RANGE, "0,1,0.01"), "set_fade_start", "get_fade_start");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "max_distance", PROPERTY_HINT_RANGE, "0,16384,0.1,or_greater,exp,suffix:m"), "set_max_distance", "get_max_distance");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "size", PROPERTY_HINT_NONE, "suffix:m"), "set_size", "get_size");
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR3, "origin_offset", PROPERTY_HINT_NONE, "suffix:m"), "set_origin_offset", "get_origin_offset");

--- a/scene/3d/reflection_probe.h
+++ b/scene/3d/reflection_probe.h
@@ -51,6 +51,7 @@ public:
 private:
 	RID probe;
 	float intensity = 1.0;
+	float fade_start = 0.5;
 	float max_distance = 0.0;
 	Vector3 size = Vector3(20, 20, 20);
 	Vector3 origin_offset = Vector3(0, 0, 0);
@@ -77,6 +78,9 @@ protected:
 public:
 	void set_intensity(float p_intensity);
 	float get_intensity() const;
+
+	void set_fade_start(float p_fade_start);
+	float get_fade_start() const;
 
 	void set_ambient_mode(AmbientMode p_mode);
 	AmbientMode get_ambient_mode() const;

--- a/servers/rendering/dummy/storage/light_storage.h
+++ b/servers/rendering/dummy/storage/light_storage.h
@@ -122,6 +122,7 @@ public:
 
 	virtual void reflection_probe_set_update_mode(RID p_probe, RS::ReflectionProbeUpdateMode p_mode) override {}
 	virtual void reflection_probe_set_intensity(RID p_probe, float p_intensity) override {}
+	virtual void reflection_probe_set_fade_start(RID p_probe, float p_fade_start) override {}
 	virtual void reflection_probe_set_ambient_mode(RID p_probe, RS::ReflectionProbeAmbientMode p_mode) override {}
 	virtual void reflection_probe_set_ambient_color(RID p_probe, const Color &p_color) override {}
 	virtual void reflection_probe_set_ambient_energy(RID p_probe, float p_energy) override {}

--- a/servers/rendering/renderer_rd/shaders/light_data_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/light_data_inc.glsl
@@ -37,15 +37,24 @@ struct LightData { //this structure needs to be as packed as possible
 struct ReflectionData {
 	highp vec3 box_extents;
 	mediump float index;
+
 	highp vec3 box_offset;
 	uint mask;
+
 	mediump vec3 ambient; // ambient color
 	mediump float intensity;
+
+	mediump float inv_fade_start;
 	bool exterior;
 	bool box_project;
 	uint ambient_mode;
+
 	float exposure_normalization;
-	//0-8 is intensity,8-9 is ambient, mode
+	float pad0;
+	float pad1;
+	float pad2;
+
+	// 0-8 is intensity, 8-9 is ambient, mode
 	highp mat4 local_matrix; // up to here for spot and omni, rest is for directional
 	// notes: for ambientblend, use distance to edge to blend between already existing global environment
 };

--- a/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
+++ b/servers/rendering/renderer_rd/shaders/scene_forward_lights_inc.glsl
@@ -919,7 +919,7 @@ void reflection_process(uint ref_index, vec3 vertex, vec3 ref_vec, vec3 normal, 
 	//make blend more rounded
 	blend = mix(length(inner_pos), blend, blend);
 	blend *= blend;
-	blend = max(0.0, 1.0 - blend);
+	blend = clamp(reflections.data[ref_index].inv_fade_start - blend * reflections.data[ref_index].inv_fade_start, 0.0, 1.0);
 
 	if (reflections.data[ref_index].intensity > 0.0) { // compute reflection
 

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.cpp
@@ -1049,6 +1049,13 @@ void LightStorage::reflection_probe_set_intensity(RID p_probe, float p_intensity
 	reflection_probe->intensity = p_intensity;
 }
 
+void LightStorage::reflection_probe_set_fade_start(RID p_probe, float p_fade_start) {
+	ReflectionProbe *reflection_probe = reflection_probe_owner.get_or_null(p_probe);
+	ERR_FAIL_NULL(reflection_probe);
+
+	reflection_probe->fade_start = p_fade_start;
+}
+
 void LightStorage::reflection_probe_set_ambient_mode(RID p_probe, RS::ReflectionProbeAmbientMode p_mode) {
 	ReflectionProbe *reflection_probe = reflection_probe_owner.get_or_null(p_probe);
 	ERR_FAIL_NULL(reflection_probe);
@@ -1247,6 +1254,13 @@ float LightStorage::reflection_probe_get_intensity(RID p_probe) const {
 	ERR_FAIL_NULL_V(reflection_probe, 0);
 
 	return reflection_probe->intensity;
+}
+
+float LightStorage::reflection_probe_get_fade_start(RID p_probe) const {
+	const ReflectionProbe *reflection_probe = reflection_probe_owner.get_or_null(p_probe);
+	ERR_FAIL_NULL_V(reflection_probe, 0);
+
+	return reflection_probe->fade_start;
 }
 
 bool LightStorage::reflection_probe_is_interior(RID p_probe) const {
@@ -1738,6 +1752,7 @@ void LightStorage::update_reflection_probe_buffer(RenderDataRD *p_render_data, c
 		reflection_ubo.mask = probe->reflection_mask;
 
 		reflection_ubo.intensity = probe->intensity;
+		reflection_ubo.inv_fade_start = 1.0 / MAX(0.00001, 1.0 - probe->fade_start);
 		reflection_ubo.ambient_mode = probe->ambient_mode;
 
 		reflection_ubo.exterior = !probe->interior;

--- a/servers/rendering/renderer_rd/storage_rd/light_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/light_storage.h
@@ -222,6 +222,7 @@ private:
 		RS::ReflectionProbeUpdateMode update_mode = RS::REFLECTION_PROBE_UPDATE_ONCE;
 		int resolution = 256;
 		float intensity = 1.0;
+		float fade_start = 0.5;
 		RS::ReflectionProbeAmbientMode ambient_mode = RS::REFLECTION_PROBE_AMBIENT_ENVIRONMENT;
 		Color ambient_color;
 		float ambient_color_energy = 1.0;
@@ -298,14 +299,23 @@ private:
 	struct ReflectionData {
 		float box_extents[3];
 		float index;
+
 		float box_offset[3];
 		uint32_t mask;
+
 		float ambient[3]; // ambient color,
 		float intensity;
+
+		float inv_fade_start;
 		uint32_t exterior;
 		uint32_t box_project;
 		uint32_t ambient_mode;
+
 		float exposure_normalization;
+		uint32_t pad0;
+		uint32_t pad1;
+		uint32_t pad2;
+
 		float local_matrix[16]; // up to here for spot and omni, rest is for directional
 	};
 
@@ -816,6 +826,7 @@ public:
 
 	virtual void reflection_probe_set_update_mode(RID p_probe, RS::ReflectionProbeUpdateMode p_mode) override;
 	virtual void reflection_probe_set_intensity(RID p_probe, float p_intensity) override;
+	virtual void reflection_probe_set_fade_start(RID p_probe, float p_fade_start) override;
 	virtual void reflection_probe_set_ambient_mode(RID p_probe, RS::ReflectionProbeAmbientMode p_mode) override;
 	virtual void reflection_probe_set_ambient_color(RID p_probe, const Color &p_color) override;
 	virtual void reflection_probe_set_ambient_energy(RID p_probe, float p_energy) override;
@@ -846,6 +857,7 @@ public:
 	virtual bool reflection_probe_renders_shadows(RID p_probe) const override;
 
 	float reflection_probe_get_intensity(RID p_probe) const;
+	float reflection_probe_get_fade_start(RID p_probe) const;
 	bool reflection_probe_is_interior(RID p_probe) const;
 	bool reflection_probe_is_box_projection(RID p_probe) const;
 	RS::ReflectionProbeAmbientMode reflection_probe_get_ambient_mode(RID p_probe) const;

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -458,6 +458,7 @@ public:
 
 	FUNC2(reflection_probe_set_update_mode, RID, ReflectionProbeUpdateMode)
 	FUNC2(reflection_probe_set_intensity, RID, float)
+	FUNC2(reflection_probe_set_fade_start, RID, float)
 	FUNC2(reflection_probe_set_ambient_color, RID, const Color &)
 	FUNC2(reflection_probe_set_ambient_energy, RID, float)
 	FUNC2(reflection_probe_set_ambient_mode, RID, ReflectionProbeAmbientMode)

--- a/servers/rendering/storage/light_storage.h
+++ b/servers/rendering/storage/light_storage.h
@@ -109,6 +109,7 @@ public:
 	virtual void reflection_probe_set_update_mode(RID p_probe, RS::ReflectionProbeUpdateMode p_mode) = 0;
 	virtual void reflection_probe_set_resolution(RID p_probe, int p_resolution) = 0;
 	virtual void reflection_probe_set_intensity(RID p_probe, float p_intensity) = 0;
+	virtual void reflection_probe_set_fade_start(RID p_probe, float p_fade_start) = 0;
 	virtual void reflection_probe_set_ambient_mode(RID p_probe, RS::ReflectionProbeAmbientMode p_mode) = 0;
 	virtual void reflection_probe_set_ambient_color(RID p_probe, const Color &p_color) = 0;
 	virtual void reflection_probe_set_ambient_energy(RID p_probe, float p_energy) = 0;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2557,6 +2557,7 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("reflection_probe_create"), &RenderingServer::reflection_probe_create);
 	ClassDB::bind_method(D_METHOD("reflection_probe_set_update_mode", "probe", "mode"), &RenderingServer::reflection_probe_set_update_mode);
 	ClassDB::bind_method(D_METHOD("reflection_probe_set_intensity", "probe", "intensity"), &RenderingServer::reflection_probe_set_intensity);
+	ClassDB::bind_method(D_METHOD("reflection_probe_set_fade_start", "probe", "fade_start"), &RenderingServer::reflection_probe_set_fade_start);
 	ClassDB::bind_method(D_METHOD("reflection_probe_set_ambient_mode", "probe", "mode"), &RenderingServer::reflection_probe_set_ambient_mode);
 	ClassDB::bind_method(D_METHOD("reflection_probe_set_ambient_color", "probe", "color"), &RenderingServer::reflection_probe_set_ambient_color);
 	ClassDB::bind_method(D_METHOD("reflection_probe_set_ambient_energy", "probe", "energy"), &RenderingServer::reflection_probe_set_ambient_energy);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -620,6 +620,7 @@ public:
 
 	virtual void reflection_probe_set_update_mode(RID p_probe, ReflectionProbeUpdateMode p_mode) = 0;
 	virtual void reflection_probe_set_intensity(RID p_probe, float p_intensity) = 0;
+	virtual void reflection_probe_set_fade_start(RID p_probe, float p_fade_start) = 0;
 
 	enum ReflectionProbeAmbientMode {
 		REFLECTION_PROBE_AMBIENT_DISABLED,


### PR DESCRIPTION
The default value of `0.5` makes reflections from ReflectionProbes more visible. This significantly reduces the notorious "sky is visible through solid objects in reflections" issue that people tend to notice when setting up reflection probes in Godot. If you set it to `1.0` in an indoor scene, the issue should be entirely prevented now, provided the probe's origin is not within solid one-sided geometry.

Please test this on more complex scenes to check if the proposed default value is actually a good idea. It may be a bit too aggressive; perhaps `0.2` would be a better fit.

To get the old behavior back, set Fade Start to `0.0`.

See https://github.com/godotengine/godot-proposals/issues/3013.

**Testing project:** [test_reflection_probes_mirage_palace.zip](https://github.com/godotengine/godot/files/12717917/test_reflection_probes_mirage_palace.zip)

## Preview

Before (Fade Start 0.0) | After (Fade Start 0.5, *default*)
-|-
![Screenshot_20230925_192235 webp](https://github.com/godotengine/godot/assets/180032/767ac19e-1f9c-4ad1-9d13-061f40148fbb) | ![Screenshot_20230925_192242 webp](https://github.com/godotengine/godot/assets/180032/562b4b91-d2db-4ae6-ab9c-33b5621a3399)

Fade Start 1.0 is meant to be used when you have a single probe cover an entire room, so it's not the best fit for this situation, but here it is anyway for comparison purposes:

After (Fade Start 0.85) | After (Fade Start 1.0)
-|-
![Screenshot_20230925_192250 webp](https://github.com/godotengine/godot/assets/180032/8ce1d7a0-f7b6-4593-96ee-34b21156152d) | ![Screenshot_20230925_192254 webp](https://github.com/godotengine/godot/assets/180032/5cf9398f-f3eb-4e25-ae31-6b3e268a95af)

## TODO

- [x] Implement in Compatibility.