### PR TITLE
AudioStreamPlayer3D: Only call _update_panning during _physics_process.

### DIFF
--- a/scene/3d/audio_stream_player_3d.cpp
+++ b/scene/3d/audio_stream_player_3d.cpp
@@ -273,7 +273,8 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 		case NOTIFICATION_INTERNAL_PHYSICS_PROCESS: {
 			// Update anything related to position first, if possible of course.
 			Vector<AudioFrame> volume_vector;
-			if (setplay.get() > 0 || (active.is_set() && last_mix_count != AudioServer::get_singleton()->get_mix_count())) {
+			if (setplay.get() > 0 || (active.is_set() && last_mix_count != AudioServer::get_singleton()->get_mix_count()) || force_update_panning) {
+				force_update_panning = false;
 				volume_vector = _update_panning();
 			}
 
@@ -318,6 +319,7 @@ void AudioStreamPlayer3D::_notification(int p_what) {
 	}
 }
 
+// Interacts with PhysicsServer3D, so can only be called during _physics_process
 Area3D *AudioStreamPlayer3D::_get_overriding_area() {
 	//check if any area is diverting sound into a bus
 	Ref<World3D> world_3d = get_world_3d();
@@ -356,6 +358,7 @@ Area3D *AudioStreamPlayer3D::_get_overriding_area() {
 	return nullptr;
 }
 
+// Interacts with PhysicsServer3D, so can only be called during _physics_process
 StringName AudioStreamPlayer3D::_get_actual_bus() {
 	Area3D *overriding_area = _get_overriding_area();
 	if (overriding_area && overriding_area->is_overriding_audio_bus() && !overriding_area->is_using_reverb_bus()) {
@@ -364,6 +367,7 @@ StringName AudioStreamPlayer3D::_get_actual_bus() {
 	return bus;
 }
 
+// Interacts with PhysicsServer3D, so can only be called during _physics_process
 Vector<AudioFrame> AudioStreamPlayer3D::_update_panning() {
 	Vector<AudioFrame> output_volume_vector;
 	output_volume_vector.resize(4);

--- a/scene/3d/audio_stream_player_3d.h
+++ b/scene/3d/audio_stream_player_3d.h
@@ -82,12 +82,13 @@ private:
 	int max_polyphony = 1;
 
 	uint64_t last_mix_count = -1;
+	bool force_update_panning = false;
 
 	static void _calc_output_vol(const Vector3 &source_dir, real_t tightness, Vector<AudioFrame> &output);
 
 	void _calc_reverb_vol(Area3D *area, Vector3 listener_area_pos, Vector<AudioFrame> direct_path_vol, Vector<AudioFrame> &reverb_vol);
 
-	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer3D *>(self)->_update_panning(); }
+	static void _listener_changed_cb(void *self) { reinterpret_cast<AudioStreamPlayer3D *>(self)->force_update_panning = true; }
 
 	void _set_playing(bool p_enable);
 	bool _is_active() const;


### PR DESCRIPTION
If a Viewport is changed, currently it has some chance of crashing when using a multithreaded physics server.

The error message seems to give a hint as to the problem, and indeed, `_update_panning` does physics queries, but almost always runs within `NOTIFICATION_INTERNAL_PHYSICS_PROCESS`, except for this one specific case with `_listener_changed_cb`...

So I changed `_listener_changed_cb` to set a flag to run `_update_panning` on the next physics frame, which seems to have solved the crash.

Unfortunately I wasn't able to create a MRP for this issue. The project is complex and has code which switches viewports during scene load and unload, which is what caused the following crash:

```
ERROR: Space state is inaccessible right now, wait for iteration or physics process notification.
   at: (servers\physics_3d\godot_physics_server_3d.cpp:194)
ERROR: Space state is inaccessible right now, wait for iteration or physics process notification.
   at: (servers\physics_3d\godot_physics_server_3d.cpp:194)

================================================================
CrashHandlerException: Program crashed
Engine version: Godot Engine v4.0.alpha.custom_build (460cf71c7e9b52d6ad97f6397f86ca061cb3d8e7)
Dumping the backtrace. Please include this when reporting the bug on https://github.com/godotengine/godot/issues
[0] AudioStreamPlayer3D::_get_overriding_area (S:\repo\godot-fire\scene\3d\audio_stream_player_3d.cpp:338)
[1] AudioStreamPlayer3D::_update_panning (S:\repo\godot-fire\scene\3d\audio_stream_player_3d.cpp:423)
[2] AudioStreamPlayer3D::_listener_changed_cb (S:\repo\godot-fire\scene\3d\audio_stream_player_3d.h:90)
[3] AudioServer::notify_listener_changed (S:\repo\godot-fire\servers\audio_server.cpp:1316)
[4] Viewport::_camera_3d_set (S:\repo\godot-fire\scene\main\viewport.cpp:3277)
[5] Camera3D::_notification (S:\repo\godot-fire\scene\3d\camera_3d.cpp:143)
[6] Camera3D::_notificationv (S:\repo\godot-fire\scene\3d\camera_3d.h:40)
[7] XRCamera3D::_notificationv (S:\repo\godot-fire\scene\3d\xr_nodes.h:42)
[8] Object::notification (S:\repo\godot-fire\core\object\object.cpp:898)
[9] Node3D::_notification (S:\repo\godot-fire\scene\3d\node_3d.cpp:211)
[10] Node3D::_notificationv (S:\repo\godot-fire\scene\3d\node_3d.h:52)
[11] Camera3D::_notificationv (S:\repo\godot-fire\scene\3d\camera_3d.h:40)
[12] XRCamera3D::_notificationv (S:\repo\godot-fire\scene\3d\xr_nodes.h:42)
[13] Object::notification (S:\repo\godot-fire\core\object\object.cpp:898)
[14] Node::_propagate_enter_tree (S:\repo\godot-fire\scene\main\node.cpp:215)
[15] Node::_propagate_enter_tree (S:\repo\godot-fire\scene\main\node.cpp:230)
[16] Node::_propagate_enter_tree (S:\repo\godot-fire\scene\main\node.cpp:230)
[17] Node::_set_tree (S:\repo\godot-fire\scene\main\node.cpp:2574)
[18] Node::_add_child_nocheck (S:\repo\godot-fire\scene\main\node.cpp:1127)
[19] Node::add_child (S:\repo\godot-fire\scene\main\node.cpp:1143)
[20] call_with_variant_args_dv<Node,Node *,bool,enum Node::InternalMode> (S:\repo\godot-fire\core\variant\binder_common.h:383)
[21] MethodBindT<Node,Node *,bool,enum Node::InternalMode>::call (S:\repo\godot-fire\core\object\method_bind.h:332)
[22] GDScriptFunction::call (S:\repo\godot-fire\modules\gdscript\gdscript_vm.cpp:1635)
[23] GDScriptInstance::callp (S:\repo\godot-fire\modules\gdscript\gdscript.cpp:1543)
[24] Object::callp (S:\repo\godot-fire\core\object\object.cpp:817)
[25] Variant::callp (S:\repo\godot-fire\core\variant\variant_call.cpp:1021)
[26] GDScriptFunction::call (S:\repo\godot-fire\modules\gdscript\gdscript_vm.cpp:1546)
[27] GDScriptInstance::callp (S:\repo\godot-fire\modules\gdscript\gdscript.cpp:1543)
[28] Object::callp (S:\repo\godot-fire\core\object\object.cpp:817)
[29] Variant::callp (S:\repo\godot-fire\core\variant\variant_call.cpp:1021)
[30] GDScriptFunction::call (S:\repo\godot-fire\modules\gdscript\gdscript_vm.cpp:1546)
[31] GDScriptInstance::callp (S:\repo\godot-fire\modules\gdscript\gdscript.cpp:1543)
[32] Object::callp (S:\repo\godot-fire\core\object\object.cpp:817)
[33] Variant::callp (S:\repo\godot-fire\core\variant\variant_call.cpp:1021)
[34] GDScriptFunction::call (S:\repo\godot-fire\modules\gdscript\gdscript_vm.cpp:1546)
[35] GDScriptInstance::callp (S:\repo\godot-fire\modules\gdscript\gdscript.cpp:1543)
[36] Object::callp (S:\repo\godot-fire\core\object\object.cpp:817)
[37] Variant::callp (S:\repo\godot-fire\core\variant\variant_call.cpp:1021)
[38] GDScriptFunction::call (S:\repo\godot-fire\modules\gdscript\gdscript_vm.cpp:1529)
[39] GDScriptInstance::callp (S:\repo\godot-fire\modules\gdscript\gdscript.cpp:1543)
[40] Node::_call_input (S:\repo\godot-fire\scene\main\node.cpp:2739)
[41] SceneTree::_call_input_pause (S:\repo\godot-fire\scene\main\scene_tree.cpp:893)
[42] Viewport::push_input (S:\repo\godot-fire\scene\main\viewport.cpp:2740)
[43] Window::_window_input (S:\repo\godot-fire\scene\main\window.cpp:974)
[44] CallableCustomMethodPointer<Window,Ref<InputEvent> const &>::call (S:\repo\godot-fire\core\object\callable_method_pointer.h:104)
[45] Callable::call (S:\repo\godot-fire\core\variant\callable.cpp:51)
[46] DisplayServerWindows::_dispatch_input_event (S:\repo\godot-fire\platform\windows\display_server_windows.cpp:2077)
[47] Input::_parse_input_event_impl (S:\repo\godot-fire\core\input\input.cpp:658)
[48] Input::parse_input_event (S:\repo\godot-fire\core\input\input.cpp:875)
[49] DisplayServerWindows::_process_key_events (S:\repo\godot-fire\platform\windows\display_server_windows.cpp:3341)
[50] DisplayServerWindows::process_events (S:\repo\godot-fire\platform\windows\display_server_windows.cpp:1784)
[51] OS_Windows::run (S:\repo\godot-fire\platform\windows\os_windows.cpp:777)
[52] widechar_main (S:\repo\godot-fire\platform\windows\godot_windows.cpp:175)
[53] _main (S:\repo\godot-fire\platform\windows\godot_windows.cpp:199)
[54] main (S:\repo\godot-fire\platform\windows\godot_windows.cpp:211)
[55] __scrt_common_main_seh (D:\agent\_work\9\s\src\vctools\crt\vcstartup\src\startup\exe_common.inl:288)
[56] BaseThreadInitThunk
-- END OF BACKTRACE --
================================================================
```

*Bugsquad edit:*
- Fixes https://github.com/godotengine/godot/issues/55844