### PR TITLE
Use proper indices with editor arrays

### DIFF
--- a/editor/editor_inspector.cpp
+++ b/editor/editor_inspector.cpp
@@ -1589,7 +1589,7 @@ void EditorInspectorArray::_rmb_popup_id_pressed(int p_id) {
 			break;
 		case OPTION_MOVE_DOWN:
 			if (popup_array_index_pressed < count - 1) {
-				_move_element(popup_array_index_pressed, popup_array_index_pressed + 2);
+				_move_element(popup_array_index_pressed, popup_array_index_pressed + 1);
 			}
 			break;
 		case OPTION_NEW_BEFORE:
@@ -2155,12 +2155,13 @@ Variant EditorInspectorArray::get_drag_data_fw(const Point2 &p_point, Control *p
 void EditorInspectorArray::drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) {
 	Dictionary dict = p_data;
 
-	int to_drop = dict["index"];
-	int drop_position = _drop_position();
-	if (drop_position < 0) {
-		return;
+	int current_index = dict["index"];
+	int target_index = begin_array_index + _drop_position();
+	if (target_index > current_index) {
+		// The current element will be removed, so shift the target down.
+		--target_index;
 	}
-	_move_element(to_drop, begin_array_index + drop_position);
+	_move_element(current_index, target_index);
 }
 
 bool EditorInspectorArray::can_drop_data_fw(const Point2 &p_point, const Variant &p_data, Control *p_from) const {

--- a/editor/plugins/audio_stream_randomizer_editor_plugin.cpp
+++ b/editor/plugins/audio_stream_randomizer_editor_plugin.cpp
@@ -73,7 +73,7 @@ void AudioStreamRandomizerEditorPlugin::_move_stream_array_element(Object *p_und
 	} else {
 		// Moving.
 		begin = MIN(p_from_index, p_to_pos);
-		end = MIN(MAX(p_from_index, p_to_pos) + 1, end);
+		end = MIN(MAX(p_from_index, p_to_pos), end);
 	}
 
 #define ADD_UNDO(obj, property) undo_redo_man->add_undo_property(obj, property, obj->get(property));

--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -3746,7 +3746,7 @@ void TileMapEditor::_move_tile_map_array_element(Object *p_undo_redo, Object *p_
 	} else {
 		// Moving.
 		begin = MIN(p_from_index, p_to_pos);
-		end = MIN(MAX(p_from_index, p_to_pos) + 1, end);
+		end = MIN(MAX(p_from_index, p_to_pos), end);
 	}
 
 #define ADD_UNDO(obj, property) undo_redo_man->add_undo_property(obj, property, obj->get(property));

--- a/editor/plugins/tiles/tile_set_editor.cpp
+++ b/editor/plugins/tiles/tile_set_editor.cpp
@@ -477,7 +477,7 @@ void TileSetEditor::_move_tile_set_array_element(Object *p_undo_redo, Object *p_
 	} else {
 		// Moving.
 		begin = MIN(p_from_index, p_to_pos);
-		end = MIN(MAX(p_from_index, p_to_pos) + 1, end);
+		end = MIN(MAX(p_from_index, p_to_pos), end);
 	}
 
 #define ADD_UNDO(obj, property) undo_redo_man->add_undo_property(obj, property, obj->get(property));

--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -580,14 +580,14 @@ void TileMap::add_layer(int p_to_pos) {
 
 void TileMap::move_layer(int p_layer, int p_to_pos) {
 	ERR_FAIL_INDEX(p_layer, (int)layers.size());
-	ERR_FAIL_INDEX(p_to_pos, (int)layers.size() + 1);
+	ERR_FAIL_INDEX(p_to_pos, (int)layers.size());
 
 	// Clear before shuffling layers.
 	_clear_internals();
 
 	TileMapLayer tl = layers[p_layer];
+	layers.remove_at(p_layer);
 	layers.insert(p_to_pos, tl);
-	layers.remove_at(p_to_pos < p_layer ? p_layer + 1 : p_layer);
 	_recreate_internals();
 	notify_property_list_changed();
 

--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -579,9 +579,10 @@ void TileSet::add_occlusion_layer(int p_index) {
 
 void TileSet::move_occlusion_layer(int p_from_index, int p_to_pos) {
 	ERR_FAIL_INDEX(p_from_index, occlusion_layers.size());
-	ERR_FAIL_INDEX(p_to_pos, occlusion_layers.size() + 1);
-	occlusion_layers.insert(p_to_pos, occlusion_layers[p_from_index]);
-	occlusion_layers.remove_at(p_to_pos < p_from_index ? p_from_index + 1 : p_from_index);
+	ERR_FAIL_INDEX(p_to_pos, occlusion_layers.size());
+	OcclusionLayer layer = occlusion_layers[p_from_index];
+	occlusion_layers.remove_at(p_from_index);
+	occlusion_layers.insert(p_to_pos, layer);
 	for (KeyValue<int, Ref<TileSetSource>> source : sources) {
 		source.value->move_occlusion_layer(p_from_index, p_to_pos);
 	}
@@ -642,9 +643,10 @@ void TileSet::add_physics_layer(int p_index) {
 
 void TileSet::move_physics_layer(int p_from_index, int p_to_pos) {
 	ERR_FAIL_INDEX(p_from_index, physics_layers.size());
-	ERR_FAIL_INDEX(p_to_pos, physics_layers.size() + 1);
-	physics_layers.insert(p_to_pos, physics_layers[p_from_index]);
-	physics_layers.remove_at(p_to_pos < p_from_index ? p_from_index + 1 : p_from_index);
+	ERR_FAIL_INDEX(p_to_pos, physics_layers.size());
+	PhysicsLayer layer = physics_layers[p_from_index];
+	physics_layers.remove_at(p_from_index);
+	physics_layers.insert(p_to_pos, layer);
 	for (KeyValue<int, Ref<TileSetSource>> source : sources) {
 		source.value->move_physics_layer(p_from_index, p_to_pos);
 	}
@@ -717,9 +719,10 @@ void TileSet::add_terrain_set(int p_index) {
 
 void TileSet::move_terrain_set(int p_from_index, int p_to_pos) {
 	ERR_FAIL_INDEX(p_from_index, terrain_sets.size());
-	ERR_FAIL_INDEX(p_to_pos, terrain_sets.size() + 1);
-	terrain_sets.insert(p_to_pos, terrain_sets[p_from_index]);
-	terrain_sets.remove_at(p_to_pos < p_from_index ? p_from_index + 1 : p_from_index);
+	ERR_FAIL_INDEX(p_to_pos, terrain_sets.size());
+	TerrainSet set = terrain_sets[p_from_index];
+	terrain_sets.remove_at(p_from_index);
+	terrain_sets.insert(p_to_pos, set);
 	for (KeyValue<int, Ref<TileSetSource>> source : sources) {
 		source.value->move_terrain_set(p_from_index, p_to_pos);
 	}
@@ -791,9 +794,10 @@ void TileSet::move_terrain(int p_terrain_set, int p_from_index, int p_to_pos) {
 	Vector<Terrain> &terrains = terrain_sets.write[p_terrain_set].terrains;
 
 	ERR_FAIL_INDEX(p_from_index, terrains.size());
-	ERR_FAIL_INDEX(p_to_pos, terrains.size() + 1);
-	terrains.insert(p_to_pos, terrains[p_from_index]);
-	terrains.remove_at(p_to_pos < p_from_index ? p_from_index + 1 : p_from_index);
+	ERR_FAIL_INDEX(p_to_pos, terrains.size());
+	Terrain terrain = terrains[p_from_index];
+	terrains.remove_at(p_from_index);
+	terrains.insert(p_to_pos, terrain);
 	for (KeyValue<int, Ref<TileSetSource>> source : sources) {
 		source.value->move_terrain(p_terrain_set, p_from_index, p_to_pos);
 	}
@@ -960,9 +964,10 @@ void TileSet::add_navigation_layer(int p_index) {
 
 void TileSet::move_navigation_layer(int p_from_index, int p_to_pos) {
 	ERR_FAIL_INDEX(p_from_index, navigation_layers.size());
-	ERR_FAIL_INDEX(p_to_pos, navigation_layers.size() + 1);
-	navigation_layers.insert(p_to_pos, navigation_layers[p_from_index]);
-	navigation_layers.remove_at(p_to_pos < p_from_index ? p_from_index + 1 : p_from_index);
+	ERR_FAIL_INDEX(p_to_pos, navigation_layers.size());
+	NavigationLayer layer = navigation_layers[p_from_index];
+	navigation_layers.remove_at(p_from_index);
+	navigation_layers.insert(p_to_pos, layer);
 	for (KeyValue<int, Ref<TileSetSource>> source : sources) {
 		source.value->move_navigation_layer(p_from_index, p_to_pos);
 	}
@@ -1035,9 +1040,10 @@ void TileSet::add_custom_data_layer(int p_index) {
 
 void TileSet::move_custom_data_layer(int p_from_index, int p_to_pos) {
 	ERR_FAIL_INDEX(p_from_index, custom_data_layers.size());
-	ERR_FAIL_INDEX(p_to_pos, custom_data_layers.size() + 1);
-	custom_data_layers.insert(p_to_pos, custom_data_layers[p_from_index]);
-	custom_data_layers.remove_at(p_to_pos < p_from_index ? p_from_index + 1 : p_from_index);
+	ERR_FAIL_INDEX(p_to_pos, custom_data_layers.size());
+	CustomDataLayer layer = custom_data_layers[p_from_index];
+	custom_data_layers.remove_at(p_from_index);
+	custom_data_layers.insert(p_to_pos, layer);
 	for (KeyValue<int, Ref<TileSetSource>> source : sources) {
 		source.value->move_custom_data_layer(p_from_index, p_to_pos);
 	}
@@ -4962,9 +4968,10 @@ void TileData::add_occlusion_layer(int p_to_pos) {
 
 void TileData::move_occlusion_layer(int p_from_index, int p_to_pos) {
 	ERR_FAIL_INDEX(p_from_index, occluders.size());
-	ERR_FAIL_INDEX(p_to_pos, occluders.size() + 1);
-	occluders.insert(p_to_pos, occluders[p_from_index]);
-	occluders.remove_at(p_to_pos < p_from_index ? p_from_index + 1 : p_from_index);
+	ERR_FAIL_INDEX(p_to_pos, occluders.size());
+	Ref<OccluderPolygon2D> occluder = occluders[p_from_index];
+	occluders.remove_at(p_from_index);
+	occluders.insert(p_to_pos, occluder);
 }
 
 void TileData::remove_occlusion_layer(int p_index) {
@@ -4982,9 +4989,10 @@ void TileData::add_physics_layer(int p_to_pos) {
 
 void TileData::move_physics_layer(int p_from_index, int p_to_pos) {
 	ERR_FAIL_INDEX(p_from_index, physics.size());
-	ERR_FAIL_INDEX(p_to_pos, physics.size() + 1);
-	physics.insert(p_to_pos, physics[p_from_index]);
-	physics.remove_at(p_to_pos < p_from_index ? p_from_index + 1 : p_from_index);
+	ERR_FAIL_INDEX(p_to_pos, physics.size());
+	PhysicsLayerTileData layer = physics[p_from_index];
+	physics.remove_at(p_from_index);
+	physics.insert(p_to_pos, layer);
 }
 
 void TileData::remove_physics_layer(int p_index) {
@@ -5000,7 +5008,7 @@ void TileData::add_terrain_set(int p_to_pos) {
 
 void TileData::move_terrain_set(int p_from_index, int p_to_pos) {
 	if (p_from_index == terrain_set) {
-		terrain_set = (p_from_index < p_to_pos) ? p_to_pos - 1 : p_to_pos;
+		terrain_set = p_to_pos;
 	} else {
 		if (p_from_index < terrain_set) {
 			terrain_set -= 1;
@@ -5036,7 +5044,7 @@ void TileData::move_terrain(int p_terrain_set, int p_from_index, int p_to_pos) {
 	if (terrain_set == p_terrain_set) {
 		for (int i = 0; i < 16; i++) {
 			if (p_from_index == terrain_peering_bits[i]) {
-				terrain_peering_bits[i] = (p_from_index < p_to_pos) ? p_to_pos - 1 : p_to_pos;
+				terrain_peering_bits[i] = p_to_pos;
 			} else {
 				if (p_from_index < terrain_peering_bits[i]) {
 					terrain_peering_bits[i] -= 1;
@@ -5075,9 +5083,10 @@ void TileData::add_navigation_layer(int p_to_pos) {
 
 void TileData::move_navigation_layer(int p_from_index, int p_to_pos) {
 	ERR_FAIL_INDEX(p_from_index, navigation.size());
-	ERR_FAIL_INDEX(p_to_pos, navigation.size() + 1);
-	navigation.insert(p_to_pos, navigation[p_from_index]);
-	navigation.remove_at(p_to_pos < p_from_index ? p_from_index + 1 : p_from_index);
+	ERR_FAIL_INDEX(p_to_pos, navigation.size());
+	Ref<NavigationPolygon> polygon = navigation[p_from_index];
+	navigation.remove_at(p_from_index);
+	navigation.insert(p_to_pos, polygon);
 }
 
 void TileData::remove_navigation_layer(int p_index) {
@@ -5095,9 +5104,10 @@ void TileData::add_custom_data_layer(int p_to_pos) {
 
 void TileData::move_custom_data_layer(int p_from_index, int p_to_pos) {
 	ERR_FAIL_INDEX(p_from_index, custom_data.size());
-	ERR_FAIL_INDEX(p_to_pos, custom_data.size() + 1);
-	custom_data.insert(p_to_pos, custom_data[p_from_index]);
-	custom_data.remove_at(p_to_pos < p_from_index ? p_from_index + 1 : p_from_index);
+	ERR_FAIL_INDEX(p_to_pos, custom_data.size());
+	Variant data = custom_data[p_from_index];
+	custom_data.remove_at(p_from_index);
+	custom_data.insert(p_to_pos, data);
 }
 
 void TileData::remove_custom_data_layer(int p_index) {

--- a/servers/audio/audio_stream.cpp
+++ b/servers/audio/audio_stream.cpp
@@ -417,7 +417,7 @@ void AudioStreamRandomizer::add_stream(int p_index, Ref<AudioStream> p_stream, f
 	ERR_FAIL_COND(p_index > audio_stream_pool.size());
 	PoolEntry entry{ p_stream, p_weight };
 	audio_stream_pool.insert(p_index, entry);
-	emit_signal(SNAME("changed"));
+	emit_changed();
 	notify_property_list_changed();
 }
 
@@ -425,30 +425,25 @@ void AudioStreamRandomizer::add_stream(int p_index, Ref<AudioStream> p_stream, f
 // Example: [0, 1, 2, 3], move(1, 3) => [0, 2, 1, 3]
 void AudioStreamRandomizer::move_stream(int p_index_from, int p_index_to) {
 	ERR_FAIL_INDEX(p_index_from, audio_stream_pool.size());
-	// p_index_to == audio_stream_pool.size() is valid (move to end).
-	ERR_FAIL_COND(p_index_to < 0);
-	ERR_FAIL_COND(p_index_to > audio_stream_pool.size());
-	audio_stream_pool.insert(p_index_to, audio_stream_pool[p_index_from]);
-	// If 'from' is strictly after 'to' we need to increment the index by one because of the insertion.
-	if (p_index_from > p_index_to) {
-		p_index_from++;
-	}
+	ERR_FAIL_INDEX(p_index_to, audio_stream_pool.size());
+	PoolEntry entry = audio_stream_pool[p_index_from];
 	audio_stream_pool.remove_at(p_index_from);
-	emit_signal(SNAME("changed"));
+	audio_stream_pool.insert(p_index_to, entry);
+	emit_changed();
 	notify_property_list_changed();
 }
 
 void AudioStreamRandomizer::remove_stream(int p_index) {
 	ERR_FAIL_INDEX(p_index, audio_stream_pool.size());
 	audio_stream_pool.remove_at(p_index);
-	emit_signal(SNAME("changed"));
+	emit_changed();
 	notify_property_list_changed();
 }
 
 void AudioStreamRandomizer::set_stream(int p_index, Ref<AudioStream> p_stream) {
 	ERR_FAIL_INDEX(p_index, audio_stream_pool.size());
 	audio_stream_pool.write[p_index].stream = p_stream;
-	emit_signal(SNAME("changed"));
+	emit_changed();
 }
 
 Ref<AudioStream> AudioStreamRandomizer::get_stream(int p_index) const {
@@ -459,7 +454,7 @@ Ref<AudioStream> AudioStreamRandomizer::get_stream(int p_index) const {
 void AudioStreamRandomizer::set_stream_probability_weight(int p_index, float p_weight) {
 	ERR_FAIL_INDEX(p_index, audio_stream_pool.size());
 	audio_stream_pool.write[p_index].weight = p_weight;
-	emit_signal(SNAME("changed"));
+	emit_changed();
 }
 
 float AudioStreamRandomizer::get_stream_probability_weight(int p_index) const {


### PR DESCRIPTION
Previously, the end index was relative to the array before anything was moved, leading to some weird behavior.

Specifically:

Given a generic array `[0, 1, 2, 3]`, moving `1`->`2` would have no effect and `1`->`3` would result in `[0, 2, 1, 3]`.
Now, `1`->`2` yields `[0, 2, 1, 3]` and `1`->`3` yields `[0, 2, 3, 1]`.

In summary: This makes code utilizing editor arrays much more readable. There is less weird ternaries and magic numbers.

Before:
```cpp
ERR_FAIL_INDEX(p_from_index, custom_data.size());
ERR_FAIL_INDEX(p_to_pos, custom_data.size() + 1);
custom_data.insert(p_to_pos, custom_data[p_from_index]);
custom_data.remove_at(p_to_pos < p_from_index ? p_from_index + 1 : p_from_index);
```

After:
```cpp
ERR_FAIL_INDEX(p_from_index, custom_data.size());
ERR_FAIL_INDEX(p_to_pos, custom_data.size());
Variant data = custom_data[p_from_index];
custom_data.remove_at(p_from_index);
custom_data.insert(p_to_pos, data);
```