### PR TITLE
[3.x] Remove extra space in property editors

### DIFF
--- a/editor/editor_properties.cpp
+++ b/editor/editor_properties.cpp
@@ -156,6 +156,7 @@ void EditorPropertyMultilineText::_bind_methods() {
 
 EditorPropertyMultilineText::EditorPropertyMultilineText() {
 	HBoxContainer *hb = memnew(HBoxContainer);
+	hb->add_constant_override("separation", 0);
 	add_child(hb);
 	set_bottom_editor(hb);
 	text = memnew(TextEdit);
@@ -2346,6 +2347,7 @@ void EditorPropertyNodePath::_bind_methods() {
 
 EditorPropertyNodePath::EditorPropertyNodePath() {
 	HBoxContainer *hbc = memnew(HBoxContainer);
+	hbc->add_constant_override("separation", 0);
 	add_child(hbc);
 	assign = memnew(Button);
 	assign->set_flat(true);

--- a/editor/editor_resource_picker.cpp
+++ b/editor/editor_resource_picker.cpp
@@ -864,6 +864,8 @@ EditorResourcePicker::EditorResourcePicker() {
 	add_child(edit_menu);
 	edit_menu->connect("id_pressed", this, "_edit_menu_cbk");
 	edit_menu->connect("popup_hide", edit_button, "set_pressed", varray(false));
+
+	add_constant_override("separation", 0);
 }
 
 void EditorScriptPicker::set_create_options(Object *p_menu_node) {

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -744,14 +744,11 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 
 		sub_inspector_bg = make_flat_stylebox(dark_color_1.linear_interpolate(si_base_color, 0.08), 2, 0, 2, 2);
 
-		sub_inspector_bg->set_border_width(MARGIN_LEFT, 2);
-		sub_inspector_bg->set_border_width(MARGIN_RIGHT, 2);
-		sub_inspector_bg->set_border_width(MARGIN_BOTTOM, 2);
-		sub_inspector_bg->set_border_width(MARGIN_TOP, 2);
-		sub_inspector_bg->set_default_margin(MARGIN_LEFT, 3);
-		sub_inspector_bg->set_default_margin(MARGIN_RIGHT, 3);
-		sub_inspector_bg->set_default_margin(MARGIN_BOTTOM, 10);
-		sub_inspector_bg->set_default_margin(MARGIN_TOP, 5);
+		sub_inspector_bg->set_border_width_all(2);
+		sub_inspector_bg->set_default_margin(MARGIN_LEFT, 4 * EDSCALE);
+		sub_inspector_bg->set_default_margin(MARGIN_RIGHT, 4 * EDSCALE);
+		sub_inspector_bg->set_default_margin(MARGIN_BOTTOM, 4 * EDSCALE);
+		sub_inspector_bg->set_default_margin(MARGIN_TOP, 4 * EDSCALE);
 		sub_inspector_bg->set_border_color(si_base_color * Color(0.7, 0.7, 0.7, 0.8));
 		sub_inspector_bg->set_draw_center(true);
 


### PR DESCRIPTION
Backports the parts of https://github.com/godotengine/godot/pull/59770 that are relevant to 3.x

* Removes extra horizontal space in the NodePath, Resource, and multiline string property editors
* Makes sub-inspector margins consistent

| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/170394474-8c3f5489-0ecd-4920-a54b-f638f7fda7b5.png) | ![image](https://user-images.githubusercontent.com/67974470/170394600-0d61a2da-893a-43de-a3cc-a1da6c5d7eae.png) |