### PR TITLE
Improve TextureRegionEditor

### DIFF
--- a/editor/plugins/texture_region_editor_plugin.cpp
+++ b/editor/plugins/texture_region_editor_plugin.cpp
@@ -83,6 +83,7 @@ void TextureRegionEditor::_region_draw() {
 	mtx.scale_basis(Vector2(draw_zoom, draw_zoom));
 
 	RS::get_singleton()->canvas_item_add_set_transform(edit_draw->get_canvas_item(), mtx);
+	edit_draw->draw_rect(Rect2(Point2(), base_tex->get_size()), Color(0.5, 0.5, 0.5, 0.5), false);
 	edit_draw->draw_texture(base_tex, Point2());
 	RS::get_singleton()->canvas_item_add_set_transform(edit_draw->get_canvas_item(), Transform2D());
 
@@ -233,6 +234,14 @@ void TextureRegionEditor::_region_draw() {
 	vscroll->set_anchor_and_offset(SIDE_BOTTOM, Control::ANCHOR_END, hscroll->is_visible() ? -hmin.height : 0);
 
 	updating_scroll = false;
+
+	if (request_center && hscroll->get_min() < 0) {
+		hscroll->set_value((hscroll->get_min() + hscroll->get_max() - hscroll->get_page()) / 2);
+		vscroll->set_value((vscroll->get_min() + vscroll->get_max() - vscroll->get_page()) / 2);
+		// This ensures that the view is updated correctly.
+		callable_bind(callable_mp(this, &TextureRegionEditor::_pan_callback), Vector2(1, 0)).call_deferred(nullptr, 0);
+		request_center = false;
+	}
 
 	if (node_ninepatch || obj_styleBox.is_valid()) {
 		float margins[4] = { 0 };
@@ -922,7 +931,8 @@ void TextureRegionEditor::edit(Object *p_obj) {
 		atlas_tex = Ref<AtlasTexture>(nullptr);
 	}
 	edit_draw->update();
-	popup_centered_ratio();
+	popup_centered_ratio(0.5);
+	request_center = true;
 }
 
 void TextureRegionEditor::_texture_changed() {

--- a/editor/plugins/texture_region_editor_plugin.h
+++ b/editor/plugins/texture_region_editor_plugin.h
@@ -71,10 +71,10 @@ class TextureRegionEditor : public AcceptDialog {
 	UndoRedo *undo_redo = nullptr;
 
 	Vector2 draw_ofs;
-	float draw_zoom;
-	bool updating_scroll;
+	float draw_zoom = 0.0;
+	bool updating_scroll = false;
 
-	int snap_mode;
+	int snap_mode = 0;
 	Vector2 snap_offset;
 	Vector2 snap_step;
 	Vector2 snap_separation;
@@ -88,15 +88,16 @@ class TextureRegionEditor : public AcceptDialog {
 	Rect2 rect;
 	Rect2 rect_prev;
 	float prev_margin = 0.0f;
-	int edited_margin;
+	int edited_margin = 0;
 	HashMap<RID, List<Rect2>> cache_map;
 	List<Rect2> autoslice_cache;
-	bool autoslice_is_dirty;
+	bool autoslice_is_dirty = false;
 
-	bool drag;
+	bool drag = false;
 	bool creating = false;
 	Vector2 drag_from;
-	int drag_index;
+	int drag_index = 0;
+	bool request_center = false;
 
 	Ref<ViewPanner> panner;
 	void _scroll_callback(Vector2 p_scroll_vec, bool p_alt);


### PR DESCRIPTION
Follow-up to #61342

- decrease the default popup size by 37.5%
- on popup: center the view on the texture
- draw a slight border around the texture
- add some missing header initialization

![image](https://user-images.githubusercontent.com/2223172/170400016-9b37d0c7-73ef-410d-bdb0-a44807fc69c4.png)
