### PR TITLE
C#: Fix debugger options missing from Project Settings

### DIFF
--- a/modules/mono/mono_gd/gd_mono.cpp
+++ b/modules/mono/mono_gd/gd_mono.cpp
@@ -157,6 +157,12 @@ void gd_mono_debug_init() {
 	}
 
 #ifdef TOOLS_ENABLED
+	// Define debugger_agent settings even if we end up ignoring the current values. This makes sure
+	// they show up in Editor Settings.
+	int da_port = GLOBAL_DEF("mono/debugger_agent/port", 23685);
+	bool da_suspend = GLOBAL_DEF("mono/debugger_agent/wait_for_debugger", false);
+	int da_timeout = GLOBAL_DEF("mono/debugger_agent/wait_timeout", 3000);
+
 	if (Engine::get_singleton()->is_editor_hint() ||
 			ProjectSettings::get_singleton()->get_resource_path().empty() ||
 			Main::is_project_manager()) {
@@ -166,10 +172,6 @@ void gd_mono_debug_init() {
 
 	if (da_args.length() == 0) {
 		// Use project settings defaults for the editor player
-
-		int da_port = GLOBAL_DEF("mono/debugger_agent/port", 23685);
-		bool da_suspend = GLOBAL_DEF("mono/debugger_agent/wait_for_debugger", false);
-		int da_timeout = GLOBAL_DEF("mono/debugger_agent/wait_timeout", 3000);
 
 		da_args = String("--debugger-agent=transport=dt_socket,address=127.0.0.1:" + itos(da_port) +
 				",embedding=1,server=y,suspend=" + (da_suspend ? "y,timeout=" + itos(da_timeout) : "n"))


### PR DESCRIPTION
* Fix https://github.com/godotengine/godot/issues/61401

This reverts part of https://github.com/godotengine/godot/pull/56835, adding a comment explaining why the `GLOBAL_DEF` needs to get called.

https://github.com/godotengine/godot/pull/56835 was only applied to `3.x`, so submitting this to `3.x` as well rather than `master`.

(~~I haven't built Godot Mono for a while and my dependencies have broken, so I haven't actually built this change on my machine yet. Working on it.~~) I built it locally, and was able to enable it and attach Rider to the instance launched by the editor. 🎉