### PR TITLE
Fix errors when materials attached to 3d object are not freed

### DIFF
--- a/scene/3d/visual_instance_3d.cpp
+++ b/scene/3d/visual_instance_3d.cpp
@@ -496,3 +496,12 @@ void GeometryInstance3D::_bind_methods() {
 GeometryInstance3D::GeometryInstance3D() {
 	//RS::get_singleton()->instance_geometry_set_baked_light_texture_index(get_instance(),0);
 }
+
+GeometryInstance3D::~GeometryInstance3D() {
+	if (material_overlay.is_valid()) {
+		set_material_overlay(Ref<Material>());
+	}
+	if (material_override.is_valid()) {
+		set_material_override(Ref<Material>());
+	}
+}

--- a/scene/3d/visual_instance_3d.h
+++ b/scene/3d/visual_instance_3d.h
@@ -188,6 +188,7 @@ public:
 
 	TypedArray<String> get_configuration_warnings() const override;
 	GeometryInstance3D();
+	virtual ~GeometryInstance3D();
 };
 
 VARIANT_ENUM_CAST(GeometryInstance3D::ShadowCastingSetting);


### PR DESCRIPTION
I've detected that calling `queue_free` on 3d-geometry would emit errors if either `material_override` or `material_overlay` are established:
![mat_bug](https://user-images.githubusercontent.com/3036176/170429328-71bc08a2-807f-4cd8-af51-3703e0bb376e.gif)

Error is: 
```
E 0:00:01:0668   RendererRD::MaterialStorage::material_update_dependency: Condition "!material" is true.
  <C++ Source>   servers\rendering\renderer_rd\storage_rd\material_storage.cpp:2631 @ RendererRD::MaterialStorage::material_update_dependency()
```


Setting them to null in the destructor solves that problem. 

Test project:
[MaterialBug.zip](https://github.com/godotengine/godot/files/8776789/MaterialBug.zip)
 