### PR TITLE
tree: do not pass custom click to item edited

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -3971,16 +3971,15 @@ TreeItem *Tree::get_last_item() const {
 	return last;
 }
 
-void Tree::item_edited(int p_column, TreeItem *p_item, MouseButton p_mouse_index) {
+void Tree::item_edited(int p_column, TreeItem *p_item, MouseButton p_custom_mouse_index) {
 	edited_item = p_item;
 	edited_col = p_column;
 	if (p_item != nullptr && p_column >= 0 && p_column < p_item->cells.size()) {
 		edited_item->cells.write[p_column].dirty = true;
 	}
-	if (p_mouse_index == MouseButton::NONE) {
-		emit_signal(SNAME("item_edited"));
-	} else {
-		emit_signal(SNAME("custom_item_clicked"), p_mouse_index);
+	emit_signal(SNAME("item_edited"));
+	if (p_custom_mouse_index != MouseButton::NONE) {
+		emit_signal(SNAME("custom_item_clicked"), p_custom_mouse_index);
 	}
 }
 

--- a/scene/gui/tree.h
+++ b/scene/gui/tree.h
@@ -474,7 +474,7 @@ private:
 
 	void _notification(int p_what);
 
-	void item_edited(int p_column, TreeItem *p_item, MouseButton p_mouse_index = MouseButton::NONE);
+	void item_edited(int p_column, TreeItem *p_item, MouseButton p_custom_mouse_index = MouseButton::NONE);
 	void item_changed(int p_column, TreeItem *p_item);
 	void item_selected(int p_column, TreeItem *p_item);
 	void item_deselected(int p_column, TreeItem *p_item);


### PR DESCRIPTION
CC @trollodel, see https://github.com/godotengine/godot/pull/47665

This was preventing the `item_edited` signal from being called on `Tree` (broke editor features).