### PR TITLE
repaint tab container when changing tab visibility (fixes filesystem tab disappearing)

### DIFF
--- a/scene/gui/tab_container.cpp
+++ b/scene/gui/tab_container.cpp
@@ -727,6 +727,7 @@ void TabContainer::set_tab_hidden(int p_tab, bool p_hidden) {
 	if (!get_clip_tabs()) {
 		update_minimum_size();
 	}
+	call_deferred(SNAME("_repaint"));
 }
 
 bool TabContainer::is_tab_hidden(int p_tab) const {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/59236
Fixes https://github.com/godotengine/godot/issues/58911
Supersedes https://github.com/godotengine/godot/pull/59355

Content inside the tab container disappears when the tab is shown again.

This can be reproduced directly in the editor by changing the editor feature profile (Editor->Manage Editor Features).

![image](https://user-images.githubusercontent.com/14253836/170470091-8e25d4ad-0f4a-4685-8e31-c3bdefd83df8.png)

Alternative code:

Code:
```gdscript
func _ready() -> void:
	await get_tree().process_frame
	$TabContainer.set_tab_hidden(0, false)
```

Before:
![image](https://user-images.githubusercontent.com/14253836/170469393-04d900c9-233f-42cb-a841-6b5d535eb29c.png)
After:
![image](https://user-images.githubusercontent.com/14253836/170469611-fbf63642-118f-4d8a-a256-8b68e66b13e1.png)
