### PR TITLE
Change Server initialization order

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -411,8 +411,6 @@ Error Main::test_setup() {
 	initialize_modules(MODULE_INITIALIZATION_LEVEL_CORE);
 	register_core_extensions();
 
-	preregister_server_types();
-
 	register_core_singletons();
 
 	/** INITIALIZE SERVERS **/
@@ -1598,7 +1596,9 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 		tsman->add_interface(ts);
 	}
 
-	preregister_server_types();
+	register_server_types();
+	initialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
+	NativeExtensionManager::get_singleton()->initialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SERVERS);
 
 	// Print engine name and version
 	print_line(String(VERSION_NAME) + " v" + get_full_version_string() + " - " + String(VERSION_WEBSITE));
@@ -1762,10 +1762,6 @@ Error Main::setup2(Thread::ID p_main_tid_override) {
 	if (allow_focus_steal_pid) {
 		DisplayServer::get_singleton()->enable_for_stealing_focus(allow_focus_steal_pid);
 	}
-
-	register_server_types();
-	initialize_modules(MODULE_INITIALIZATION_LEVEL_SERVERS);
-	NativeExtensionManager::get_singleton()->initialize_extensions(NativeExtension::INITIALIZATION_LEVEL_SERVERS);
 
 	MAIN_PRINT("Main: Load Boot Image");
 

--- a/servers/register_server_types.cpp
+++ b/servers/register_server_types.cpp
@@ -107,7 +107,7 @@ static bool has_server_feature_callback(const String &p_feature) {
 	return false;
 }
 
-void preregister_server_types() {
+void register_server_types() {
 	shader_types = memnew(ShaderTypes);
 
 	GDREGISTER_CLASS(TextServerManager);
@@ -119,9 +119,7 @@ void preregister_server_types() {
 	GDREGISTER_NATIVE_STRUCT(CaretInfo, "Rect2 leading_caret;Rect2 trailing_caret;TextServer::Direction leading_direction;TextServer::Direction trailing_direction");
 
 	Engine::get_singleton()->add_singleton(Engine::Singleton("TextServerManager", TextServerManager::get_singleton(), "TextServerManager"));
-}
 
-void register_server_types() {
 	OS::get_singleton()->set_has_server_feature_callback(has_server_feature_callback);
 
 	GDREGISTER_ABSTRACT_CLASS(DisplayServer);

--- a/servers/register_server_types.h
+++ b/servers/register_server_types.h
@@ -31,7 +31,6 @@
 #ifndef REGISTER_SERVER_TYPES_H
 #define REGISTER_SERVER_TYPES_H
 
-void preregister_server_types();
 void register_server_types();
 void unregister_server_types();
 


### PR DESCRIPTION
* Registration of server classes happened after Display initialization.
* This made no sense in practice and avoided the registration of custom server drivers (like custom XR server, custom Rendering server, custom XR server).
* Initialization moved to _before_ Display.
