### PR TITLE
Check visibility of items before drawing their relationship lines

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2164,7 +2164,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 			}
 
 			// Draw relationship lines.
-			if (cache.draw_relationship_lines > 0 && (!hide_root || c->parent != root)) {
+			if (cache.draw_relationship_lines > 0 && (!hide_root || c->parent != root) && c->is_visible()) {
 				int root_ofs = children_pos.x + ((p_item->disable_folding || hide_folding) ? cache.hseparation : cache.item_margin);
 				int parent_ofs = p_pos.x + cache.item_margin;
 				Point2i root_pos = Point2i(root_ofs, children_pos.y + label_h / 2) - cache.offset + p_draw_ofs;


### PR DESCRIPTION
closes #61372 

Pretty simple fix.

Extended the demo code from the ticket to the following to do some further checking:

```
func _ready() -> void:
	var tree = $VBoxContainer/Tree as Tree
	tree.create_item().set_text(0, "Root")
	tree.create_item(tree.get_root()).set_text(0, "Child 1")
	var child2 = tree.create_item(tree.get_root())
	child2.set_text(0, "Child 2")
	tree.create_item(child2).set_text(0, "Sub-child 2")
	tree.create_item(tree.get_root()).set_text(0, "Child 3")
```

![image](https://user-images.githubusercontent.com/8000597/170497370-47cfdf40-9e2e-4b26-9f1a-ccfba3ee0b3c.png)

I also made sure that toggling the visibility of `Child 2` behaved correctly (next image is after making it visible, previous image is when it's not)

![image](https://user-images.githubusercontent.com/8000597/170497524-3f528f6c-b942-44b8-863d-7288dc120e8e.png)
