### PR TITLE
Hide redundant categories from project settings

### DIFF
--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -250,6 +250,11 @@ void SectionedInspector::update_category_list() {
 			continue;
 		}
 
+		// Filter out unnecessary ProjectSettings sections, as they already have their dedicated tabs.
+		if (pi.name.begins_with("autoload") || pi.name.begins_with("editor_plugins") || pi.name.begins_with("shader_globals")) {
+			continue;
+		}
+
 		if (!filter.is_empty() && !_property_path_matches(pi.name, filter, name_style)) {
 			continue;
 		}


### PR DESCRIPTION
Salvage of #39670 with some extras. Aside from Autoloads, it hides Editor Plugins and Shader Globals:
![image](https://user-images.githubusercontent.com/2223172/170605279-f1c46ea3-5cbb-4c6e-a0e7-7370182f460c.png)
(they have their own tabs too)

Fixes #39639
Fixes #24453