### PR TITLE
Fix #61444: Executing Tree.scroll_to_item crashes Godot

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -4523,6 +4523,7 @@ Point2 Tree::get_scroll() const {
 }
 
 void Tree::scroll_to_item(TreeItem *p_item, bool p_center_on_item) {
+	ERR_FAIL_NULL(p_item);
 	if (!is_visible_in_tree() || !p_item->is_visible()) {
 		return; // Hack to work around crash in get_item_rect() if Tree is not in tree.
 	}


### PR DESCRIPTION
Hello there!

The following change fixes the crash that occurred with the specified code. Apparently the function was not checking for the nullptr case of `p_item` argument of the function `scroll_to_item`.

Including in the OR conditional works since if one of the conditionals is true, then the following ones are not executed. I've tested the fix in a Debian distro machine.

Best regards,
Marlon