### PR TITLE
Add color contrast to TabContainer backgrounds in the editor

### DIFF
--- a/editor/action_map_editor.cpp
+++ b/editor/action_map_editor.cpp
@@ -644,6 +644,7 @@ InputEventConfigurationDialog::InputEventConfigurationDialog() {
 	tab_container = memnew(TabContainer);
 	tab_container->set_use_hidden_tabs_for_min_size(true);
 	tab_container->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tab_container->set_theme_type_variation("TabContainerOdd");
 	tab_container->connect("tab_selected", callable_mp(this, &InputEventConfigurationDialog::_tab_selected));
 	main_vbox->add_child(tab_container);
 

--- a/editor/editor_about.cpp
+++ b/editor/editor_about.cpp
@@ -163,6 +163,7 @@ EditorAbout::EditorAbout() {
 	tc->set_tab_alignment(TabBar::ALIGNMENT_CENTER);
 	tc->set_custom_minimum_size(Size2(400, 200) * EDSCALE);
 	tc->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	tc->set_theme_type_variation("TabContainerOdd");
 	vbc->add_child(tc);
 
 	// Authors

--- a/editor/editor_settings_dialog.cpp
+++ b/editor/editor_settings_dialog.cpp
@@ -683,6 +683,7 @@ EditorSettingsDialog::EditorSettingsDialog() {
 	undo_redo = memnew(UndoRedo);
 
 	tabs = memnew(TabContainer);
+	tabs->set_theme_type_variation("TabContainerOdd");
 	tabs->connect("tab_changed", callable_mp(this, &EditorSettingsDialog::_tabs_tab_changed));
 	add_child(tabs);
 

--- a/editor/editor_themes.cpp
+++ b/editor/editor_themes.cpp
@@ -1152,14 +1152,16 @@ Ref<Theme> create_editor_theme(const Ref<Theme> p_theme) {
 	style_content_panel->set_border_color(dark_color_2);
 	theme->set_stylebox("panel", "TabContainer", style_content_panel);
 
-	// These styleboxes can be used on tabs against the base color background (e.g. nested tabs).
+	// TabContainerOdd can be used on tabs against the base color background (e.g. nested tabs).
+	theme->set_type_variation("TabContainerOdd", "TabContainer");
+
 	Ref<StyleBoxFlat> style_tab_selected_odd = style_tab_selected->duplicate();
 	style_tab_selected_odd->set_bg_color(disabled_bg_color);
-	theme->set_stylebox("tab_selected_odd", "TabContainer", style_tab_selected_odd);
+	theme->set_stylebox("tab_selected", "TabContainerOdd", style_tab_selected_odd);
 
 	Ref<StyleBoxFlat> style_content_panel_odd = style_content_panel->duplicate();
 	style_content_panel_odd->set_bg_color(disabled_bg_color);
-	theme->set_stylebox("panel_odd", "TabContainer", style_content_panel_odd);
+	theme->set_stylebox("panel", "TabContainerOdd", style_content_panel_odd);
 
 	// This stylebox is used in 3d and 2d viewports (no borders).
 	Ref<StyleBoxFlat> style_content_panel_vp = style_content_panel->duplicate();

--- a/editor/import/dynamic_font_import_settings.cpp
+++ b/editor/import/dynamic_font_import_settings.cpp
@@ -1418,6 +1418,7 @@ DynamicFontImportSettings::DynamicFontImportSettings() {
 	main_pages->set_tab_alignment(TabBar::ALIGNMENT_CENTER);
 	main_pages->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 	main_pages->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	main_pages->set_theme_type_variation("TabContainerOdd");
 	root_vb->add_child(main_pages);
 
 	label_warn = memnew(Label);

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -1229,6 +1229,7 @@ SceneImportSettings::SceneImportSettings() {
 	data_mode = memnew(TabContainer);
 	tree_split->add_child(data_mode);
 	data_mode->set_custom_minimum_size(Size2(300 * EDSCALE, 0));
+	data_mode->set_theme_type_variation("TabContainerOdd");
 
 	property_split = memnew(HSplitContainer);
 	tree_split->add_child(property_split);

--- a/editor/plugins/theme_editor_plugin.cpp
+++ b/editor/plugins/theme_editor_plugin.cpp
@@ -1871,9 +1871,6 @@ void ThemeItemEditorDialog::_notification(int p_what) {
 			edit_items_remove_all->set_icon(get_theme_icon(SNAME("ThemeRemoveAllItems"), SNAME("EditorIcons")));
 
 			import_another_theme_button->set_icon(get_theme_icon(SNAME("Folder"), SNAME("EditorIcons")));
-
-			tc->add_theme_style_override("tab_selected", get_theme_stylebox(SNAME("tab_selected_odd"), SNAME("TabContainer")));
-			tc->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel_odd"), SNAME("TabContainer")));
 		} break;
 	}
 }
@@ -1896,6 +1893,7 @@ ThemeItemEditorDialog::ThemeItemEditorDialog(ThemeTypeEditor *p_theme_type_edito
 
 	tc = memnew(TabContainer);
 	add_child(tc);
+	tc->set_theme_type_variation("TabContainerOdd");
 
 	// Edit Items tab.
 	HSplitContainer *edit_dialog_hs = memnew(HSplitContainer);
@@ -3305,9 +3303,6 @@ void ThemeTypeEditor::_notification(int p_what) {
 			data_type_tabs->set_tab_icon(5, get_theme_icon(SNAME("StyleBoxFlat"), SNAME("EditorIcons")));
 			data_type_tabs->set_tab_icon(6, get_theme_icon(SNAME("Tools"), SNAME("EditorIcons")));
 
-			data_type_tabs->add_theme_style_override("tab_selected", get_theme_stylebox(SNAME("tab_selected_odd"), SNAME("TabContainer")));
-			data_type_tabs->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel_odd"), SNAME("TabContainer")));
-
 			type_variation_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 		} break;
 	}
@@ -3407,6 +3402,7 @@ ThemeTypeEditor::ThemeTypeEditor() {
 	main_vb->add_child(data_type_tabs);
 	data_type_tabs->set_v_size_flags(SIZE_EXPAND_FILL);
 	data_type_tabs->set_use_hidden_tabs_for_min_size(true);
+	data_type_tabs->set_theme_type_variation("TabContainerOdd");
 
 	color_items_list = _create_item_list(Theme::DATA_TYPE_COLOR);
 	constant_items_list = _create_item_list(Theme::DATA_TYPE_CONSTANT);
@@ -3589,7 +3585,7 @@ void ThemeEditor::_notification(int p_what) {
 		case NOTIFICATION_THEME_CHANGED: {
 			preview_tabs->add_theme_style_override("tab_selected", get_theme_stylebox(SNAME("ThemeEditorPreviewFG"), SNAME("EditorStyles")));
 			preview_tabs->add_theme_style_override("tab_unselected", get_theme_stylebox(SNAME("ThemeEditorPreviewBG"), SNAME("EditorStyles")));
-			preview_tabs_content->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel_odd"), SNAME("TabContainer")));
+			preview_tabs_content->add_theme_style_override("panel", get_theme_stylebox(SNAME("panel"), SNAME("TabContainerOdd")));
 
 			add_preview_button->set_icon(get_theme_icon(SNAME("Add"), SNAME("EditorIcons")));
 		} break;

--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1064,6 +1064,7 @@ ProjectExportDialog::ProjectExportDialog() {
 
 	sections = memnew(TabContainer);
 	sections->set_use_hidden_tabs_for_min_size(true);
+	sections->set_theme_type_variation("TabContainerOdd");
 	settings_vb->add_child(sections);
 	sections->set_v_size_flags(Control::SIZE_EXPAND_FILL);
 

--- a/editor/project_settings_editor.cpp
+++ b/editor/project_settings_editor.cpp
@@ -560,6 +560,7 @@ ProjectSettingsEditor::ProjectSettingsEditor(EditorData *p_data) {
 
 	tab_container = memnew(TabContainer);
 	tab_container->set_use_hidden_tabs_for_min_size(true);
+	tab_container->set_theme_type_variation("TabContainerOdd");
 	add_child(tab_container);
 
 	VBoxContainer *general_editor = memnew(VBoxContainer);

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -344,6 +344,7 @@ OpenXRActionMapEditor::OpenXRActionMapEditor() {
 	tabs = memnew(TabContainer);
 	tabs->set_h_size_flags(SIZE_EXPAND_FILL);
 	tabs->set_v_size_flags(SIZE_EXPAND_FILL);
+	tabs->set_theme_type_variation("TabContainerOdd");
 	tabs->connect("tab_changed", callable_mp(this, &OpenXRActionMapEditor::_on_tabs_tab_changed));
 	tabs->connect("tab_button_pressed", callable_mp(this, &OpenXRActionMapEditor::_on_tab_button_pressed));
 	add_child(tabs);


### PR DESCRIPTION
Makes TabContainers that are on a background with the same color as the default TabContainer background color use the "odd" style, which has a slightly darker color than the default style, to create contrast. This was already done in the Theme editor, and this PR adds it to many other TabContainers across the editor.

This is helpful in places where there are nested TabContainers:
| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/170624861-da0d2cf6-28c8-4588-8d6b-bc0713336ff0.png) | ![image](https://user-images.githubusercontent.com/67974470/170624418-48c027e7-d1c7-4926-93a1-8fc453d529fc.png) |

Or to differentiate nodes inside a tab from those outside of the tab:
| Before | After |
---|---
| ![image](https://user-images.githubusercontent.com/67974470/170624779-9d166f84-f54f-4135-903d-981df25c00cc.png) | ![image](https://user-images.githubusercontent.com/67974470/170624628-10045cf8-3270-43d4-aa7d-a0f2ee80499c.png) |
| ![image](https://user-images.githubusercontent.com/67974470/170624954-748d422c-5f09-497f-8b9a-3702b3085511.png) | ![image](https://user-images.githubusercontent.com/67974470/170624705-c5850e0c-d5c2-4f24-9ff3-faff48348e09.png) |