### PR TITLE
Expose the current animation tree and player to AnimationNode

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -127,6 +127,18 @@
 				Gets the value of a parameter. Parameters are custom local memory used for your nodes, given a resource can be reused in multiple trees.
 			</description>
 		</method>
+		<method name="get_player" qualifiers="const">
+			<return type="AnimationPlayer" />
+			<description>
+				Gets the [AnimationPlayer] referenced by the [AnimationTree] currently processing this node. Returns [code]null[/code] when called outside of [method _process], as multiple trees may reference a single [AnimationNode] resource.
+			</description>
+		</method>
+		<method name="get_tree" qualifiers="const">
+			<return type="AnimationTree" />
+			<description>
+				Gets the [AnimationTree] currently processing this node. Returns [code]null[/code] when called outside of [method _process], as multiple trees may reference a single [AnimationNode] resource.
+			</description>
+		</method>
 		<method name="is_path_filtered" qualifiers="const">
 			<return type="bool" />
 			<argument index="0" name="path" type="NodePath" />

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -403,6 +403,18 @@ Ref<AnimationNode> AnimationNode::get_child_by_name(const StringName &p_name) {
 	return Ref<AnimationNode>();
 }
 
+AnimationTree *AnimationNode::get_tree() const {
+	ERR_FAIL_NULL_V_EDMSG(state, nullptr, "get_tree() called outside of _process()");
+
+	return state->tree;
+}
+
+AnimationPlayer *AnimationNode::get_player() const {
+	ERR_FAIL_NULL_V_EDMSG(state, nullptr, "get_player() called outside of _process()");
+
+	return state->player;
+}
+
 void AnimationNode::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_input_count"), &AnimationNode::get_input_count);
 	ClassDB::bind_method(D_METHOD("get_input_name", "input"), &AnimationNode::get_input_name);
@@ -425,6 +437,9 @@ void AnimationNode::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_parameter", "name", "value"), &AnimationNode::set_parameter);
 	ClassDB::bind_method(D_METHOD("get_parameter", "name"), &AnimationNode::get_parameter);
+
+	ClassDB::bind_method(D_METHOD("get_tree"), &AnimationNode::get_tree);
+	ClassDB::bind_method(D_METHOD("get_player"), &AnimationNode::get_player);
 
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "filter_enabled", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_filter_enabled", "is_filter_enabled");
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "filters", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR | PROPERTY_USAGE_INTERNAL), "_set_filters", "_get_filters");

--- a/scene/animation/animation_tree.h
+++ b/scene/animation/animation_tree.h
@@ -154,6 +154,9 @@ public:
 
 	virtual Ref<AnimationNode> get_child_by_name(const StringName &p_name);
 
+	AnimationTree *get_tree() const;
+	AnimationPlayer *get_player() const;
+
 	AnimationNode();
 };
 


### PR DESCRIPTION
Exposes the `tree` and `player` members of `AnimationNode::State` available in C++ to scripts, enabling their use in custom nodes.

Without this various obtuse and potentially problematic workarounds are required.

For example, with this patch, the following code can be changed from this (which has undesired side effects):

```gdscript
# seek the animation to its beginning, which will cause `blend_node` to
# return its length
duration = blend_node(animation_node_name, animation_node, 0.0, true, false,
	0.0, AnimationNode.FILTER_IGNORE, true)
```

To the more obvious and direct form:

```gdscript
duration = get_player().get_animation(animation_name).length
```

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
