### PR TITLE
GDScript: Fix stack overflow when using multiple `await`

### DIFF
--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -270,6 +270,8 @@ Variant GDScriptFunctionState::resume(const Variant &p_arg) {
 		if (EngineDebugger::is_active()) {
 			GDScriptLanguage::get_singleton()->exit_function();
 		}
+
+		_clear_stack();
 #endif
 	}
 


### PR DESCRIPTION
This fixes a regression caused by #61003. I tested this PR with the example #57126 and could not reproduce the crash nor the leak, so I assume I didn't undo the fix. 

Fixes #61130
