### PR TITLE
Only use Android fullscreen theme for splash screen

### DIFF
--- a/platform/android/java/app/res/values/themes.xml
+++ b/platform/android/java/app/res/values/themes.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-	<style name="GodotAppMainTheme" parent="@android:style/Theme.Black.NoTitleBar.Fullscreen"/>
+	<style name="GodotAppMainTheme" parent="@android:style/Theme.Black.NoTitleBar"/>
 
-	<style name="GodotAppSplashTheme" parent="@style/GodotAppMainTheme">
+	<style name="GodotAppSplashTheme" parent="@android:style/Theme.Black.NoTitleBar.Fullscreen">
 		<item name="android:windowBackground">@drawable/splash_drawable</item>
 		<item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
 	</style>


### PR DESCRIPTION
On Android, immersive mode should control whether or not the game is displayed in full screen mode or with the status bar and navigation bar showing. However, currently, with immersive mode off, only the navigation bar is shown.

This PR ensures that full screen mode is controlled by the immersive setting and not the application theme: The full screen theme is only applied to the splash screen.

Fixes #19835
Fixes #48811

Can be cherry-picked onto 3.x.
