### PR TITLE
Add sky cover texture for PhysicalSkyMaterial

### DIFF
--- a/doc/classes/PhysicalSkyMaterial.xml
+++ b/doc/classes/PhysicalSkyMaterial.xml
@@ -26,14 +26,17 @@
 		<member name="mie_eccentricity" type="float" setter="set_mie_eccentricity" getter="get_mie_eccentricity" default="0.8">
 			Controls the direction of the mie scattering. A value of [code]1[/code] means that when light hits a particle it's passing through straight forward. A value of [code]-1[/code] means that all light is scatter backwards.
 		</member>
-		<member name="night_sky" type="Texture2D" setter="set_night_sky" getter="get_night_sky">
-			[Texture2D] for the night sky. This is added to the sky, so if it is bright enough, it may be visible during the day.
-		</member>
 		<member name="rayleigh_coefficient" type="float" setter="set_rayleigh_coefficient" getter="get_rayleigh_coefficient" default="2.0">
 			Controls the strength of the Rayleigh scattering. Rayleigh scattering results from light colliding with small particles. It is responsible for the blue color of the sky.
 		</member>
 		<member name="rayleigh_color" type="Color" setter="set_rayleigh_color" getter="get_rayleigh_color" default="Color(0.3, 0.405, 0.6, 1)">
 			Controls the [Color] of the Rayleigh scattering. While not physically accurate, this allows for the creation of alien-looking planets. For example, setting this to a red [Color] results in a Mars-looking atmosphere with a corresponding blue sunset.
+		</member>
+		<member name="sky_cover" type="Texture2D" setter="set_sky_cover" getter="get_sky_cover">
+			The sky cover texture to use. This texture must use an equirectangular projection (similar to [PanoramaSkyMaterial]). The texture's colors will be [i]added[/i] to the existing sky color, and will be multiplied by the atmospheric scattering color, [member exposure] and [member sky_cover_modulate]. This is mainly suited to displaying stars at night, but it can also be used to display clouds at day or night (with a non-physically-accurate look).
+		</member>
+		<member name="sky_cover_modulate" type="Color" setter="set_sky_cover_modulate" getter="get_sky_cover_modulate" default="Color(1, 1, 1, 1)">
+			The tint to apply to the [member sky_cover] texture. This can be used to change the sky cover's colors or opacity independently of the sky energy, which is useful for day/night or weather transitions. Only effective if a texture is defined in [member sky_cover].
 		</member>
 		<member name="sun_disk_scale" type="float" setter="set_sun_disk_scale" getter="get_sun_disk_scale" default="1.0">
 			Sets the size of the sun disk. Default value is based on Sol's perceived size from Earth.

--- a/scene/resources/sky_material.h
+++ b/scene/resources/sky_material.h
@@ -149,7 +149,7 @@ public:
 };
 
 //////////////////////////////////////////////////////
-/* PanoramaSkyMaterial */
+/* PhysicalSkyMaterial */
 
 class PhysicalSkyMaterial : public Material {
 	GDCLASS(PhysicalSkyMaterial, Material);
@@ -168,7 +168,8 @@ private:
 	Color ground_color;
 	float exposure = 0.0f;
 	bool use_debanding = true;
-	Ref<Texture2D> night_sky;
+	Ref<Texture2D> sky_cover;
+	Color sky_cover_modulate;
 	static void _update_shader();
 	mutable bool shader_set = false;
 
@@ -206,8 +207,11 @@ public:
 	void set_use_debanding(bool p_use_debanding);
 	bool get_use_debanding() const;
 
-	void set_night_sky(const Ref<Texture2D> &p_night_sky);
-	Ref<Texture2D> get_night_sky() const;
+	void set_sky_cover(const Ref<Texture2D> &p_sky_cover);
+	Ref<Texture2D> get_sky_cover() const;
+
+	void set_sky_cover_modulate(const Color &p_sky_cover_modulate);
+	Color get_sky_cover_modulate() const;
 
 	virtual Shader::Mode get_shader_mode() const override;
 	virtual RID get_shader_rid() const override;


### PR DESCRIPTION
Follow-up to https://github.com/godotengine/godot/pull/58018.

This replaces the previous night sky property with more flexible Sky Cover and Sky Cover Modulate properties.

Like ProceduralSkyMaterial, this is designed to be used for night sky but also static cloud covering. However, unlike ProceduralSkyMaterial, sky cover in PhysicalSkyMaterial automatically takes atmospheric scattering into account for its coloring.

**Testing project:** [test_night_sky_2.zip](https://github.com/godotengine/godot/files/8789862/test_night_sky_2.zip)

## Preview

### Dusk

![2022-05-27_23 29 59](https://user-images.githubusercontent.com/180032/170792167-73196393-8ead-4d0b-8a8f-a4ff3b45838b.png)

### Duskier

![2022-05-27_23 30 20](https://user-images.githubusercontent.com/180032/170792172-287ddea7-dac9-459b-8248-b1b32388b771.png)

### Duskiest

![2022-05-27_23 31 20](https://user-images.githubusercontent.com/180032/170792173-7c30d277-21d3-42bf-a6b8-f5757e4650d8.png)