### PR TITLE
[3.x] `PopupMenu` Fix `hover` stylebox overflowing horizontally

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -499,7 +499,7 @@ void PopupMenu::_notification(int p_what) {
 			Ref<StyleBox> labeled_separator_left = get_stylebox("labeled_separator_left");
 			Ref<StyleBox> labeled_separator_right = get_stylebox("labeled_separator_right");
 
-			style->draw(ci, Rect2(Point2(), get_size()));
+			style->draw(ci, Rect2(Point2(), size));
 			Point2 ofs = style->get_offset();
 			int vseparation = get_constant("vseparation");
 			int hseparation = get_constant("hseparation");
@@ -552,6 +552,7 @@ void PopupMenu::_notification(int p_what) {
 
 				if (i == mouse_over) {
 					hover->draw(ci, Rect2(item_ofs + Point2(-hseparation, -vseparation / 2), Size2(get_size().width - style->get_minimum_size().width + hseparation * 2, h + vseparation)));
+					hover->draw(ci, Rect2(item_ofs + Point2(0, -vseparation / 2), Size2(size.width - style->get_minimum_size().width, h + vseparation)));
 				}
 
 				item_ofs.x += items[i].h_ofs;


### PR DESCRIPTION
Fixes #43069.

Already fixed in `master` in #44905 (the rest seems unrelevant for `3.x`).

- Before (`hseparation = 60`):
![jlknQzwCbP](https://user-images.githubusercontent.com/9283098/170792417-b61369b9-e22d-48c6-a245-4efaa48a5d9a.gif)

- After (`hseparation = 60`):
![laRYXSVbxN](https://user-images.githubusercontent.com/9283098/170792428-bd056ace-d4bb-4f3b-9eb6-46da75e9f34c.gif)


