### PR TITLE
Add a 3D suffix to relevant physics profiler categories

### DIFF
--- a/servers/physics_3d/godot_physics_server_3d.cpp
+++ b/servers/physics_3d/godot_physics_server_3d.cpp
@@ -1671,7 +1671,7 @@ void GodotPhysicsServer3D::flush_queries() {
 		values.push_back("flush_queries");
 		values.push_back(USEC_TO_SEC(OS::get_singleton()->get_ticks_usec() - time_beg));
 
-		values.push_front("physics");
+		values.push_front("physics_3d");
 		EngineDebugger::profiler_add_frame_data("servers", values);
 	}
 #endif


### PR DESCRIPTION
2D physics categories already had a 2D suffix: "Physics 2D"

See https://github.com/godotengine/godot-proposals/issues/2045.