### PR TITLE
Increase the editor profiler frame history default and maximum limit

### DIFF
--- a/editor/debugger/editor_profiler.cpp
+++ b/editor/debugger/editor_profiler.cpp
@@ -86,7 +86,7 @@ void EditorProfiler::add_frame_metric(const Metric &p_metric, bool p_final) {
 
 void EditorProfiler::clear() {
 	int metric_size = EditorSettings::get_singleton()->get("debugger/profiler_frame_history_size");
-	metric_size = CLAMP(metric_size, 60, 1024);
+	metric_size = CLAMP(metric_size, 60, 10000);
 	frame_metrics.clear();
 	frame_metrics.resize(metric_size);
 	total_metrics = 0;
@@ -660,7 +660,7 @@ EditorProfiler::EditorProfiler() {
 	h_split->add_child(graph);
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
 
-	int metric_size = CLAMP(int(EDITOR_GET("debugger/profiler_frame_history_size")), 60, 1024);
+	int metric_size = CLAMP(int(EDITOR_GET("debugger/profiler_frame_history_size")), 60, 10000);
 	frame_metrics.resize(metric_size);
 
 	EDITOR_DEF("debugger/profiler_frame_max_functions", 64);

--- a/editor/debugger/editor_visual_profiler.cpp
+++ b/editor/debugger/editor_visual_profiler.cpp
@@ -93,7 +93,7 @@ void EditorVisualProfiler::add_frame_metric(const Metric &p_metric) {
 
 void EditorVisualProfiler::clear() {
 	int metric_size = EditorSettings::get_singleton()->get("debugger/profiler_frame_history_size");
-	metric_size = CLAMP(metric_size, 60, 1024);
+	metric_size = CLAMP(metric_size, 60, 10000);
 	frame_metrics.clear();
 	frame_metrics.resize(metric_size);
 	last_metric = -1;
@@ -789,7 +789,7 @@ EditorVisualProfiler::EditorVisualProfiler() {
 	h_split->add_child(graph);
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
 
-	int metric_size = CLAMP(int(EDITOR_GET("debugger/profiler_frame_history_size")), 60, 1024);
+	int metric_size = CLAMP(int(EDITOR_GET("debugger/profiler_frame_history_size")), 60, 10000);
 	frame_metrics.resize(metric_size);
 
 	frame_delay = memnew(Timer);

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -714,7 +714,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	EDITOR_SETTING_USAGE(Variant::STRING, PROPERTY_HINT_GLOBAL_FILE, "network/ssl/editor_ssl_certificates", _SYSTEM_CERTS_PATH, "*.crt,*.pem", PROPERTY_USAGE_DEFAULT | PROPERTY_USAGE_RESTART_IF_CHANGED);
 
 	// Profiler
-	_initial_set("debugger/profiler_frame_history_size", 600);
+	EDITOR_SETTING(Variant::INT, PROPERTY_HINT_RANGE, "debugger/profiler_frame_history_size", 3600, "60,10000,1")
 
 	// HTTP Proxy
 	_initial_set("network/http_proxy/host", "");


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/61482.

The new default value (1800) allows storing 30 seconds of profiling at 60 FPS.

The new maximum value (10000) allows storing about 3 minutes of profiling at 60 FPS.

The profiler graph will scale accordingly to the chosen setting, so the default value is kept relatively low to prevent the graph from looking too squished on narrow displays. It might be possible to implement automatic scaling of the generated image according to its width (using a TextureRect node and region properties to display the texture), but this is something better left to a future pull request. This would also allow for implementing zooming on the profiler graph (both horizontal and vertical).

I did some testing and it seems to hold up OK at both the default value and maximum value.

See https://github.com/godotengine/godot-proposals/issues/2045.