### PR TITLE
Increase the editor profiler frame history default and maximum limit (3.x)

### DIFF
--- a/editor/editor_profiler.cpp
+++ b/editor/editor_profiler.cpp
@@ -80,7 +80,7 @@ void EditorProfiler::add_frame_metric(const Metric &p_metric, bool p_final) {
 
 void EditorProfiler::clear() {
 	int metric_size = EditorSettings::get_singleton()->get("debugger/profiler_frame_history_size");
-	metric_size = CLAMP(metric_size, 60, 1024);
+	metric_size = CLAMP(metric_size, 60, 10000);
 	frame_metrics.clear();
 	frame_metrics.resize(metric_size);
 	last_metric = -1;
@@ -756,7 +756,7 @@ EditorProfiler::EditorProfiler() {
 	h_split->add_child(graph);
 	graph->set_h_size_flags(SIZE_EXPAND_FILL);
 
-	int metric_size = CLAMP(int(EDITOR_DEF("debugger/profiler_frame_history_size", 600)), 60, 1024);
+	int metric_size = CLAMP(int(EDITOR_DEF("debugger/profiler_frame_history_size", 1800)), 60, 10000);
 	frame_metrics.resize(metric_size);
 	last_metric = -1;
 	hover_metric = -1;


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/61481.

The new default value (1800) allows storing 30 seconds of profiling at 60 FPS.

The new maximum value (10000) allows storing about 3 minutes of profiling at 60 FPS.

The profiler graph will scale accordingly to the chosen setting, so the default value is kept relatively low to prevent the graph from looking too squished on narrow displays.