### PR TITLE
[3.x] Allow changing `exclusive` of already popped up `Popup`

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -2051,6 +2051,11 @@ void Control::show_modal(bool p_exclusive) {
 	data.modal_frame = Engine::get_singleton()->get_frames_drawn();
 }
 
+void Control::set_modal_exclusive(bool p_exclusive) {
+	ERR_FAIL_NULL_MSG(data.MI, "Modal exclusive can be set only if the Control is already shown as modal.");
+	data.modal_exclusive = p_exclusive;
+}
+
 void Control::_modal_set_prev_focus_owner(ObjectID p_prev) {
 	data.modal_prev_focus_owner = p_prev;
 }

--- a/scene/gui/control.h
+++ b/scene/gui/control.h
@@ -250,6 +250,7 @@ protected:
 	virtual void remove_child_notify(Node *p_child);
 
 	//virtual void _window_gui_input(InputEvent p_event);
+	void set_modal_exclusive(bool p_exclusive);
 
 	bool _set(const StringName &p_name, const Variant &p_value);
 	bool _get(const StringName &p_name, Variant &r_ret) const;

--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -194,6 +194,9 @@ void Popup::_popup(const Rect2 &p_bounds, const bool p_centered) {
 
 void Popup::set_exclusive(bool p_exclusive) {
 	exclusive = p_exclusive;
+	if (popped_up) {
+		set_modal_exclusive(exclusive);
+	}
 }
 
 bool Popup::is_exclusive() const {


### PR DESCRIPTION
Fixes #43901.

I've added `Control::set_modal_exclusive()` which allows changing `modal_exclusive` for a `Control` already shown as a modal. Made it protected so the change of `Control::data.modal_exclusive` could be trigerred from `Popup::set_exclusive()`. And I'm not sure if it's needed to be public / exposed to scripting.

`3.x` only as `Popup` in `master` extends `Window` and [`Window::set_exclusive()`](https://github.com/godotengine/godot/blob/1f690f197a4fb0809afb2f59bf78e4d3d89fd847/scene/main/window.cpp#L526-L547) seems to properly propagate the value to the `DisplayServer`.

