### PR TITLE
Add script templates for EditorScenePostImport

### DIFF
--- a/modules/gdscript/editor/script_templates/EditorScenePostImport/basic_import_script.gd
+++ b/modules/gdscript/editor/script_templates/EditorScenePostImport/basic_import_script.gd
@@ -1,0 +1,11 @@
+# meta-description: Basic import script template
+@tool
+extends EditorScenePostImport
+
+
+# Called by the editor when a scene has this script set as the import script in the import tab.
+func _post_import(scene: Node) -> Object:
+	# Modify the contents of the scene upon import. For example, setting up LODs:
+#	(scene.get_node(^"HighPolyMesh") as MeshInstance3D).draw_distance_end = 5.0
+#	(scene.get_node(^"LowPolyMesh") as MeshInstance3D).draw_distance_begin = 5.0
+	return scene # Return the modified root node when you're done.

--- a/modules/gdscript/editor/script_templates/EditorScenePostImport/no_comments.gd
+++ b/modules/gdscript/editor/script_templates/EditorScenePostImport/no_comments.gd
@@ -1,0 +1,7 @@
+# meta-description: Basic import script template (no comments)
+@tool
+extends EditorScenePostImport
+
+
+func _post_import(scene: Node) -> Object:
+	return scene

--- a/modules/mono/editor/script_templates/EditorScenePostImport/basic_import_script.cs
+++ b/modules/mono/editor/script_templates/EditorScenePostImport/basic_import_script.cs
@@ -1,0 +1,18 @@
+// meta-description: Basic import script template
+
+#if TOOLS
+using _BINDINGS_NAMESPACE_;
+using System;
+
+[Tool]
+public partial class _CLASS_ : _BASE_
+{
+    public override Object _PostImport(Node scene)
+    {
+        // Modify the contents of the scene upon import. For example, setting up LODs:
+//      scene.GetNode<MeshInstance3D>("HighPolyMesh").DrawDistanceEnd = 5.0
+//      scene.GetNode<MeshInstance3D>("LowPolyMesh").DrawDistanceBegin = 5.0
+        return scene // Return the modified root node when you're done.
+    }
+}
+#endif

--- a/modules/mono/editor/script_templates/EditorScenePostImport/no_comments.cs
+++ b/modules/mono/editor/script_templates/EditorScenePostImport/no_comments.cs
@@ -1,0 +1,15 @@
+// meta-description: Basic import script template (no comments)
+
+#if TOOLS
+using _BINDINGS_NAMESPACE_;
+using System;
+
+[Tool]
+public partial class _CLASS_ : _BASE_
+{
+    public override Object _PostImport(Node scene)
+    {
+        return scene
+    }
+}
+#endif


### PR DESCRIPTION
I got a bit tired of accidentally writing `post_import` instead of `_post_import` or forgetting `@tool`. So, I started copy-pasting from existing scripts. And even then, I accidentally didn't copy the `@tool` part once and wondered why it didn't work.
I figured there should just be a script template. I added a basic template with some comments describing its use and some commented-out example code that sets draw distances, and also a no comments script that omits the comments.