### PR TITLE
Increase AnimationPlayer position SpinBox to fit more decimals

### DIFF
--- a/editor/plugins/animation_player_editor_plugin.cpp
+++ b/editor/plugins/animation_player_editor_plugin.cpp
@@ -1573,7 +1573,7 @@ AnimationPlayerEditor::AnimationPlayerEditor(AnimationPlayerEditorPlugin *p_plug
 
 	frame = memnew(SpinBox);
 	hb->add_child(frame);
-	frame->set_custom_minimum_size(Size2(60, 0));
+	frame->set_custom_minimum_size(Size2(80, 0) * EDSCALE);
 	frame->set_stretch_ratio(2);
 	frame->set_step(0.0001);
 	frame->set_tooltip(TTR("Animation position (in seconds)."));


### PR DESCRIPTION
Fixed UI bug in Animation Player where it appeared that pushing the up or down incrementing arrows did not increment the SpinBox value appropriately. Just needed to increase the size of the box horizontally, to display four decimal points consistently.

Before:
![before](https://user-images.githubusercontent.com/67284108/170810013-7ee1535c-a760-4d9c-8609-04537e0b6ec4.gif)

After:
![after](https://user-images.githubusercontent.com/67284108/170810020-55c93791-9f14-4be4-9706-1a0b820ad08e.gif)

