### PR TITLE
[3.x] Fix LineEdit clear button for asymmetric stylebox

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -742,7 +742,7 @@ bool LineEdit::_is_over_clear_button(const Point2 &p_pos) const {
 		return false;
 	}
 	Ref<Texture> icon = Control::get_icon("clear");
-	int x_ofs = get_stylebox("normal")->get_offset().x;
+	int x_ofs = get_stylebox("normal")->get_margin(MARGIN_RIGHT);
 	return p_pos.x > get_size().width - icon->get_width() - x_ofs;
 }
 


### PR DESCRIPTION
`3.x` version of #61495