### PR TITLE
Print messages when textures are detected as used in 3D/normal/roughness

### DIFF
--- a/editor/import/resource_importer_texture.cpp
+++ b/editor/import/resource_importer_texture.cpp
@@ -104,24 +104,30 @@ void ResourceImporterTexture::update_imports() {
 			bool changed = false;
 
 			if (E.value.flags & MAKE_NORMAL_FLAG && int(cf->get_value("params", "compress/normal_map")) == 0) {
+				print_line(vformat("%s: Texture detected as used as a normal map in 3D. Enabling red-green texture compression to reduce memory usage (blue channel is discarded).", String(E.key)));
 				cf->set_value("params", "compress/normal_map", 1);
 				changed = true;
 			}
 
 			if (E.value.flags & MAKE_ROUGHNESS_FLAG && int(cf->get_value("params", "roughness/mode")) == 0) {
+				print_line(vformat("%s: Texture detected as used as a roughness map in 3D. Enabling roughness limiter based on the detected associated normal map at %s.", String(E.key), E.value.normal_path_for_roughness));
 				cf->set_value("params", "roughness/mode", E.value.channel_for_roughness + 2);
 				cf->set_value("params", "roughness/src_normal", E.value.normal_path_for_roughness);
 				changed = true;
 			}
 
 			if (E.value.flags & MAKE_3D_FLAG && bool(cf->get_value("params", "detect_3d/compress_to"))) {
-				int compress_to = cf->get_value("params", "detect_3d/compress_to");
+				const int compress_to = cf->get_value("params", "detect_3d/compress_to");
+				String compress_string;
 				cf->set_value("params", "detect_3d/compress_to", 0);
 				if (compress_to == 1) {
 					cf->set_value("params", "compress/mode", COMPRESS_VRAM_COMPRESSED);
+					compress_string = "VRAM Compressed (S3TC/ETC/BPTC)";
 				} else if (compress_to == 2) {
 					cf->set_value("params", "compress/mode", COMPRESS_BASIS_UNIVERSAL);
+					compress_string = "Basis Universal";
 				}
+				print_line(vformat("%s: Texture detected as used in 3D. Enabling mipmap generation and setting the texture compression mode to %s.", String(E.key), compress_string));
 				cf->set_value("params", "mipmaps/generate", true);
 				changed = true;
 			}


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/62004.

This detection automatically changes some import options, so it's important that users are aware of this.

**Testing project:** [test_material_detect_3d.zip](https://github.com/godotengine/godot/files/8791210/test_material_detect_3d.zip)

## Preview

***Note:** [Normal map, ambient occlusion map and height map are all detected to be used as a roughness map](https://github.com/godotengine/godot/issues/61498), which is incorrect. The roughness map is not detected as being used as a roughness map.*

```
res://ambientcg/Bricks079_2K_Color.jpg: Texture detected as used in 3D. Enabling mipmap generation and setting the texture compression mode to VRAM Compressed (S3TC/ETC/BPTC).
res://ambientcg/Bricks079_2K_Roughness.jpg: Texture detected as used in 3D. Enabling mipmap generation and setting the texture compression mode to VRAM Compressed (S3TC/ETC/BPTC).
res://ambientcg/Bricks079_2K_NormalGL.jpg: Texture detected as used as a normal map in 3D. Enabling red-green texture compression to reduce memory usage (blue channel is discarded).
res://ambientcg/Bricks079_2K_NormalGL.jpg: Texture detected as used as a roughness map in 3D. Enabling roughness limiter based on the detected associated normal map at res://ambientcg/Bricks079_2K_NormalGL.jpg.
res://ambientcg/Bricks079_2K_NormalGL.jpg: Texture detected as used in 3D. Enabling mipmap generation and setting the texture compression mode to VRAM Compressed (S3TC/ETC/BPTC).
res://ambientcg/Bricks079_2K_AmbientOcclusion.jpg: Texture detected as used as a roughness map in 3D. Enabling roughness limiter based on the detected associated normal map at res://ambientcg/Bricks079_2K_NormalGL.jpg.
res://ambientcg/Bricks079_2K_AmbientOcclusion.jpg: Texture detected as used in 3D. Enabling mipmap generation and setting the texture compression mode to VRAM Compressed (S3TC/ETC/BPTC).
res://ambientcg/Bricks079_2K_Displacement.jpg: Texture detected as used as a roughness map in 3D. Enabling roughness limiter based on the detected associated normal map at res://ambientcg/Bricks079_2K_NormalGL.jpg.
res://ambientcg/Bricks079_2K_Displacement.jpg: Texture detected as used in 3D. Enabling mipmap generation and setting the texture compression mode to VRAM Compressed (S3TC/ETC/BPTC).
```