### PR TITLE
Ensure focus when dropping to script editor

### DIFF
--- a/editor/plugins/script_text_editor.cpp
+++ b/editor/plugins/script_text_editor.cpp
@@ -1524,6 +1524,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 		te->set_caret_line(row);
 		te->set_caret_column(col);
 		te->insert_text_at_caret(res->get_path());
+		te->grab_focus();
 	}
 
 	if (d.has("type") && (String(d["type"]) == "files" || String(d["type"]) == "files_and_dirs")) {
@@ -1546,6 +1547,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 		te->set_caret_line(row);
 		te->set_caret_column(col);
 		te->insert_text_at_caret(text_to_drop);
+		te->grab_focus();
 	}
 
 	if (d.has("type") && String(d["type"]) == "nodes") {
@@ -1619,6 +1621,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 		te->set_caret_line(row);
 		te->set_caret_column(col);
 		te->insert_text_at_caret(text_to_drop);
+		te->grab_focus();
 	}
 
 	if (d.has("type") && String(d["type"]) == "obj_property") {
@@ -1627,6 +1630,7 @@ void ScriptTextEditor::drop_data_fw(const Point2 &p_point, const Variant &p_data
 		te->set_caret_line(row);
 		te->set_caret_column(col);
 		te->insert_text_at_caret(text_to_drop);
+		te->grab_focus();
 	}
 }
 


### PR DESCRIPTION
This improves usability by making sure actions subsequent to drop
are performed within the script editor. For example, dropping a
node from the scene tree to the script editor and attempting undo
will now undo the drop instead of performing an undo in the scene
tree.

Fixes #61465

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
