### PR TITLE
Improve stack overflow error message in GDScript and VisualScript

### DIFF
--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -368,7 +368,7 @@ public:
 
 		if (_debug_call_stack_pos >= _debug_max_call_stack) {
 			//stack overflow
-			_debug_error = "Stack Overflow (Stack Size: " + itos(_debug_max_call_stack) + ")";
+			_debug_error = vformat("Stack overflow (stack size: %s). Check for infinite recursion in your script.", _debug_max_call_stack);
 			EngineDebugger::get_script_debugger()->debug(this);
 			return;
 		}

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -1582,7 +1582,7 @@ Variant VisualScriptInstance::_call_internal(const StringName &p_method, void *p
 
 					if (!found) {
 						r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
-						error_str = RTR("Found sequence bit but not the node in the stack, report bug!");
+						error_str = RTR("Found sequence bit but not the node in the stack (please report).");
 						error = true;
 						break;
 					}
@@ -1594,7 +1594,7 @@ Variant VisualScriptInstance::_call_internal(const StringName &p_method, void *p
 					// Check for stack overflow.
 					if (flow_stack_pos + 1 >= flow_max) {
 						r_error.error = Callable::CallError::CALL_ERROR_INVALID_METHOD;
-						error_str = RTR("Stack overflow with stack depth:") + " " + itos(output);
+						error_str = vformat(RTR("Stack overflow (stack size: %s). Check for infinite recursion in your script."), output);
 						error = true;
 						break;
 					}

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -522,7 +522,7 @@ public:
 
 		if (_debug_call_stack_pos >= _debug_max_call_stack) {
 			// Stack overflow.
-			_debug_error = "Stack Overflow (Stack Size: " + itos(_debug_max_call_stack) + ")";
+			_debug_error = vformat("Stack overflow (stack size: %s). Check for infinite recursion in your script.", _debug_max_call_stack);
 			EngineDebugger::get_script_debugger()->debug(this);
 			return;
 		}
@@ -545,7 +545,7 @@ public:
 		}
 
 		if (_debug_call_stack_pos == 0) {
-			_debug_error = "Stack Underflow (Engine Bug)";
+			_debug_error = "Stack underflow (engine bug), please report.";
 			EngineDebugger::get_script_debugger()->debug(this);
 			return;
 		}


### PR DESCRIPTION
Stack overflow errors are generally the result of infinite recursion within a script. "Stack overflow" on its own might not mean much to someone not versed in computer science, so it's useful to have a more user-friendly explanation available.

This PR can be remade for `3.x` if desired.

I had the idea to change this while looking at https://github.com/godotengine/godot/issues/61494 :slightly_smiling_face: