### PR TITLE
Fix signal connections when adding libraries to AnimationPlayer

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -1344,6 +1344,10 @@ Error AnimationPlayer::add_animation_library(const StringName &p_name, const Ref
 	ald.library->connect(SNAME("animation_removed"), callable_mp(this, &AnimationPlayer::_animation_added), varray(p_name));
 	ald.library->connect(SNAME("animation_renamed"), callable_mp(this, &AnimationPlayer::_animation_renamed), varray(p_name));
 
+	for (const KeyValue<StringName, Ref<Animation>> &K : animation_libraries[insert_pos].library->animations) {
+		_ref_anim(K.value);
+	}
+
 	_animation_set_cache_update();
 
 	notify_property_list_changed();


### PR DESCRIPTION
There is an unused method in `AnimationPlayer` called `_ref_anim` which connects a signal from the animation to the animation player. There is a similar `_unref_anim` which disconnects the signal, and it _is_ called when removing an animation library, for each animation in the library.
Before animation libraries were added, `_ref_anim` was called when adding animations. As such, I assume it was supposed to be called similarly when adding animation libraries but got overlooked, so that's what this PR fixes.
Fixes #60566.