### PR TITLE
doc: Fix typo in "reset" method description

### DIFF
--- a/doc/classes/Tween.xml
+++ b/doc/classes/Tween.xml
@@ -151,7 +151,7 @@
 			<argument index="0" name="object" type="Object" />
 			<argument index="1" name="key" type="String" default="&quot;&quot;" />
 			<description>
-				Resets a tween to its initial value (the one given, not the one before the tween), given its object and property/method pair. By default, all tweens are removed, unless [code]key[/code] is specified.
+				Resets a tween to its initial value (the one given, not the one before the tween), given its object and property/method pair. By default, all tweens are reset, unless [code]key[/code] is specified.
 			</description>
 		</method>
 		<method name="reset_all">


### PR DESCRIPTION
Change "all tweens are removed" to "all tweens are reset". Possibly this snippet was copy-pasted from the "remove" method description and not updated for "reset".

This update appears relevant only to 3.x branch.  There is no "reset" method in 4.0. There, resetting is part of the Tween "stop" method.
