### PR TITLE
Change instances of "returns an empty Variant" to "returns null" in docs

### DIFF
--- a/doc/classes/Geometry2D.xml
+++ b/doc/classes/Geometry2D.xml
@@ -118,7 +118,7 @@
 			<argument index="2" name="from_b" type="Vector2" />
 			<argument index="3" name="dir_b" type="Vector2" />
 			<description>
-				Checks if the two lines ([code]from_a[/code], [code]dir_a[/code]) and ([code]from_b[/code], [code]dir_b[/code]) intersect. If yes, return the point of intersection as [Vector2]. If no intersection takes place, returns an empty [Variant].
+				Checks if the two lines ([code]from_a[/code], [code]dir_a[/code]) and ([code]from_b[/code], [code]dir_b[/code]) intersect. If yes, return the point of intersection as [Vector2]. If no intersection takes place, returns [code]null[/code].
 				[b]Note:[/b] The lines are specified using direction vectors, not end points.
 			</description>
 		</method>
@@ -195,7 +195,7 @@
 			<argument index="2" name="from_b" type="Vector2" />
 			<argument index="3" name="to_b" type="Vector2" />
 			<description>
-				Checks if the two segments ([code]from_a[/code], [code]to_a[/code]) and ([code]from_b[/code], [code]to_b[/code]) intersect. If yes, return the point of intersection as [Vector2]. If no intersection takes place, returns an empty [Variant].
+				Checks if the two segments ([code]from_a[/code], [code]to_a[/code]) and ([code]from_b[/code], [code]to_b[/code]) intersect. If yes, return the point of intersection as [Vector2]. If no intersection takes place, returns [code]null[/code].
 			</description>
 		</method>
 		<method name="triangulate_delaunay">

--- a/doc/classes/Geometry3D.xml
+++ b/doc/classes/Geometry3D.xml
@@ -81,7 +81,7 @@
 			<argument index="3" name="b" type="Vector3" />
 			<argument index="4" name="c" type="Vector3" />
 			<description>
-				Tests if the 3D ray starting at [code]from[/code] with the direction of [code]dir[/code] intersects the triangle specified by [code]a[/code], [code]b[/code] and [code]c[/code]. If yes, returns the point of intersection as [Vector3]. If no intersection takes place, an empty [Variant] is returned.
+				Tests if the 3D ray starting at [code]from[/code] with the direction of [code]dir[/code] intersects the triangle specified by [code]a[/code], [code]b[/code] and [code]c[/code]. If yes, returns the point of intersection as [Vector3]. If no intersection takes place, returns [code]null[/code].
 			</description>
 		</method>
 		<method name="segment_intersects_convex">
@@ -121,7 +121,7 @@
 			<argument index="3" name="b" type="Vector3" />
 			<argument index="4" name="c" type="Vector3" />
 			<description>
-				Tests if the segment ([code]from[/code], [code]to[/code]) intersects the triangle [code]a[/code], [code]b[/code], [code]c[/code]. If yes, returns the point of intersection as [Vector3]. If no intersection takes place, an empty [Variant] is returned.
+				Tests if the segment ([code]from[/code], [code]to[/code]) intersects the triangle [code]a[/code], [code]b[/code], [code]c[/code]. If yes, returns the point of intersection as [Vector3]. If no intersection takes place, returns [code]null[/code].
 			</description>
 		</method>
 	</methods>

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -625,7 +625,7 @@
 			<return type="void" />
 			<argument index="0" name="method" type="StringName" />
 			<description>
-				Sends a remote procedure call request for the given [code]method[/code] to peers on the network (and locally), optionally sending all additional arguments as arguments to the method called by the RPC. The call request will only be received by nodes with the same [NodePath], including the exact same node name. Behaviour depends on the RPC configuration for the given method, see [method rpc_config]. Methods are not exposed to RPCs by default. Returns an empty [Variant].
+				Sends a remote procedure call request for the given [code]method[/code] to peers on the network (and locally), optionally sending all additional arguments as arguments to the method called by the RPC. The call request will only be received by nodes with the same [NodePath], including the exact same node name. Behaviour depends on the RPC configuration for the given method, see [method rpc_config]. Methods are not exposed to RPCs by default. Returns [code]null[/code].
 				[b]Note:[/b] You can only safely use RPCs on clients after you received the [code]connected_to_server[/code] signal from the [MultiplayerAPI]. You also need to keep track of the connection state, either by the [MultiplayerAPI] signals like [code]server_disconnected[/code] or by checking [code]get_multiplayer().peer.get_connection_status() == CONNECTION_CONNECTED[/code].
 			</description>
 		</method>
@@ -645,7 +645,7 @@
 			<argument index="0" name="peer_id" type="int" />
 			<argument index="1" name="method" type="StringName" />
 			<description>
-				Sends a [method rpc] to a specific peer identified by [code]peer_id[/code] (see [method MultiplayerPeer.set_target_peer]). Returns an empty [Variant].
+				Sends a [method rpc] to a specific peer identified by [code]peer_id[/code] (see [method MultiplayerPeer.set_target_peer]). Returns [code]null[/code].
 			</description>
 		</method>
 		<method name="set_display_folded">


### PR DESCRIPTION
`master` version of https://github.com/godotengine/godot/pull/61527.

While "returns an empty Variant" technically valid (it's constructed as `Variant()` in C++), "returns null" is more intuitive to users.

This closes https://github.com/godotengine/godot-docs/issues/5848.