### PR TITLE
Change instances of "returns an empty Variant" to "returns null" in docs (3.x)

### DIFF
--- a/doc/classes/Geometry.xml
+++ b/doc/classes/Geometry.xml
@@ -189,7 +189,7 @@
 			<argument index="2" name="from_b" type="Vector2" />
 			<argument index="3" name="dir_b" type="Vector2" />
 			<description>
-				Checks if the two lines ([code]from_a[/code], [code]dir_a[/code]) and ([code]from_b[/code], [code]dir_b[/code]) intersect. If yes, return the point of intersection as [Vector2]. If no intersection takes place, returns an empty [Variant].
+				Checks if the two lines ([code]from_a[/code], [code]dir_a[/code]) and ([code]from_b[/code], [code]dir_b[/code]) intersect. If yes, return the point of intersection as [Vector2]. If no intersection takes place, returns [code]null[/code].
 				[b]Note:[/b] The lines are specified using direction vectors, not end points.
 			</description>
 		</method>
@@ -297,7 +297,7 @@
 			<argument index="2" name="from_b" type="Vector2" />
 			<argument index="3" name="to_b" type="Vector2" />
 			<description>
-				Checks if the two segments ([code]from_a[/code], [code]to_a[/code]) and ([code]from_b[/code], [code]to_b[/code]) intersect. If yes, return the point of intersection as [Vector2]. If no intersection takes place, returns an empty [Variant].
+				Checks if the two segments ([code]from_a[/code], [code]to_a[/code]) and ([code]from_b[/code], [code]to_b[/code]) intersect. If yes, return the point of intersection as [Vector2]. If no intersection takes place, returns [code]null[/code].
 			</description>
 		</method>
 		<method name="segment_intersects_sphere">

--- a/doc/classes/Node.xml
+++ b/doc/classes/Node.xml
@@ -568,7 +568,7 @@
 			<return type="Variant" />
 			<argument index="0" name="method" type="String" />
 			<description>
-				Sends a remote procedure call request for the given [code]method[/code] to peers on the network (and locally), optionally sending all additional arguments as arguments to the method called by the RPC. The call request will only be received by nodes with the same [NodePath], including the exact same node name. Behaviour depends on the RPC configuration for the given method, see [method rpc_config]. Methods are not exposed to RPCs by default. See also [method rset] and [method rset_config] for properties. Returns an empty [Variant].
+				Sends a remote procedure call request for the given [code]method[/code] to peers on the network (and locally), optionally sending all additional arguments as arguments to the method called by the RPC. The call request will only be received by nodes with the same [NodePath], including the exact same node name. Behaviour depends on the RPC configuration for the given method, see [method rpc_config]. Methods are not exposed to RPCs by default. See also [method rset] and [method rset_config] for properties. Returns [code]null[/code].
 				[b]Note:[/b] You can only safely use RPCs on clients after you received the [code]connected_to_server[/code] signal from the [SceneTree]. You also need to keep track of the connection state, either by the [SceneTree] signals like [code]server_disconnected[/code] or by checking [code]SceneTree.network_peer.get_connection_status() == CONNECTION_CONNECTED[/code].
 			</description>
 		</method>
@@ -585,14 +585,14 @@
 			<argument index="0" name="peer_id" type="int" />
 			<argument index="1" name="method" type="String" />
 			<description>
-				Sends a [method rpc] to a specific peer identified by [code]peer_id[/code] (see [method NetworkedMultiplayerPeer.set_target_peer]). Returns an empty [Variant].
+				Sends a [method rpc] to a specific peer identified by [code]peer_id[/code] (see [method NetworkedMultiplayerPeer.set_target_peer]). Returns [code]null[/code].
 			</description>
 		</method>
 		<method name="rpc_unreliable" qualifiers="vararg">
 			<return type="Variant" />
 			<argument index="0" name="method" type="String" />
 			<description>
-				Sends a [method rpc] using an unreliable protocol. Returns an empty [Variant].
+				Sends a [method rpc] using an unreliable protocol. Returns [code]null[/code].
 			</description>
 		</method>
 		<method name="rpc_unreliable_id" qualifiers="vararg">
@@ -600,7 +600,7 @@
 			<argument index="0" name="peer_id" type="int" />
 			<argument index="1" name="method" type="String" />
 			<description>
-				Sends a [method rpc] to a specific peer identified by [code]peer_id[/code] using an unreliable protocol (see [method NetworkedMultiplayerPeer.set_target_peer]). Returns an empty [Variant].
+				Sends a [method rpc] to a specific peer identified by [code]peer_id[/code] using an unreliable protocol (see [method NetworkedMultiplayerPeer.set_target_peer]). Returns [code]null[/code].
 			</description>
 		</method>
 		<method name="rset">

--- a/doc/classes/VisualServer.xml
+++ b/doc/classes/VisualServer.xml
@@ -1761,7 +1761,7 @@
 			<argument index="0" name="material" type="RID" />
 			<argument index="1" name="parameter" type="String" />
 			<description>
-				Returns the default value for the param if available. Otherwise returns an empty [Variant].
+				Returns the default value for the param if available. Returns [code]null[/code] otherwise.
 			</description>
 		</method>
 		<method name="material_get_shader" qualifiers="const">


### PR DESCRIPTION
`3.x` version of https://github.com/godotengine/godot/pull/61526.

While "returns an empty Variant" technically valid (it's constructed as `Variant()` in C++), "returns null" is more intuitive to users.

This closes https://github.com/godotengine/godot-docs/issues/5848.