### PR TITLE
Avoid notifying editor-only property changes

### DIFF
--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -939,7 +939,9 @@ void Object::set_meta(const StringName &p_name, const Variant &p_value) {
 		if (metadata.has(p_name)) {
 			metadata.erase(p_name);
 			metadata_properties.erase("metadata/" + p_name.operator String());
-			notify_property_list_changed();
+			if (!p_name.operator String().begins_with("_")) { // Don't notify for editor-only properties.
+				notify_property_list_changed();
+			}
 		}
 		return;
 	}
@@ -951,7 +953,9 @@ void Object::set_meta(const StringName &p_name, const Variant &p_value) {
 		ERR_FAIL_COND(!p_name.operator String().is_valid_identifier());
 		Variant *V = &metadata.insert(p_name, p_value)->value;
 		metadata_properties["metadata/" + p_name.operator String()] = V;
-		notify_property_list_changed();
+		if (!p_name.operator String().begins_with("_")) { // Don't notify for editor-only properties.
+			notify_property_list_changed();
+		}
 	}
 }
 


### PR DESCRIPTION
Related issue: #61343

Ensures that Control::_set_layout_mode() only sets
"_edit_layout_mode" meta if the layout mode is LAYOUT_MODE_ANCHORS
because the alternative, LAYOUT_MODE_POSITION, is the default
value and not needed in the meta.

This fixes #61343

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
