### PR TITLE
Remove mouse events that closed the popup from queue, to fix pop-up reopening.

### DIFF
--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -295,7 +295,7 @@ protected:
 	void _window_changed(XEvent *event);
 
 public:
-	void mouse_process_popups();
+	bool mouse_process_popups();
 	void popup_open(WindowID p_window);
 	void popup_close(WindowID p_window);
 

--- a/platform/osx/display_server_osx.h
+++ b/platform/osx/display_server_osx.h
@@ -208,7 +208,7 @@ public:
 	void push_to_key_event_buffer(const KeyEvent &p_event);
 	void update_im_text(const Point2i &p_selection, const String &p_text);
 	void set_last_focused_window(WindowID p_window);
-	void mouse_process_popups(bool p_close = false);
+	bool mouse_process_popups(bool p_close = false);
 	void popup_open(WindowID p_window);
 	void popup_close(WindowID p_window);
 	void set_is_resizing(bool p_is_resizing);

--- a/platform/osx/godot_application.mm
+++ b/platform/osx/godot_application.mm
@@ -37,6 +37,11 @@
 - (void)sendEvent:(NSEvent *)event {
 	DisplayServerOSX *ds = (DisplayServerOSX *)DisplayServer::get_singleton();
 	if (ds) {
+		if ([event type] == NSEventTypeLeftMouseDown || [event type] == NSEventTypeRightMouseDown || [event type] == NSEventTypeOtherMouseDown) {
+			if (ds->mouse_process_popups()) {
+				return;
+			}
+		}
 		ds->send_event(event);
 	}
 

--- a/platform/windows/display_server_windows.cpp
+++ b/platform/windows/display_server_windows.cpp
@@ -2199,6 +2199,7 @@ LRESULT DisplayServerWindows::MouseProc(int code, WPARAM wParam, LPARAM lParam) 
 				}
 				if (C) {
 					_send_window_event(windows[C->get()], DisplayServerWindows::WINDOW_EVENT_CLOSE_REQUEST);
+					return 1;
 				}
 			} break;
 		}


### PR DESCRIPTION
Consume events that close the popup, instead of passing it to the underlying window, to prevent re-opening of popup or unexpected click.

Fixes #61350