### PR TITLE
Add `vshader` extension (*.tres alias) for visual shaders

### DIFF
--- a/core/config/project_settings.cpp
+++ b/core/config/project_settings.cpp
@@ -1201,6 +1201,7 @@ ProjectSettings::ProjectSettings() {
 		extensions.push_back("cs");
 	}
 	extensions.push_back("gdshader");
+	extensions.push_back("vshader");
 
 	GLOBAL_DEF("editor/run/main_run_args", "");
 

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -555,7 +555,7 @@
 			prime-run %command%
 			[/codeblock]
 		</member>
-		<member name="editor/script/search_in_file_extensions" type="PackedStringArray" setter="" getter="" default="PackedStringArray(&quot;gd&quot;, &quot;gdshader&quot;)">
+		<member name="editor/script/search_in_file_extensions" type="PackedStringArray" setter="" getter="" default="PackedStringArray(&quot;gd&quot;, &quot;gdshader&quot;, &quot;vshader&quot;)">
 			Text-based file extensions to include in the script editor's "Find in Files" feature. You can add e.g. [code]tscn[/code] if you wish to also parse your scene files, especially if you use built-in scripts which are serialized in the scene files.
 		</member>
 		<member name="editor/script/templates_search_path" type="String" setter="" getter="" default="&quot;res://script_templates&quot;">

--- a/editor/editor_asset_installer.cpp
+++ b/editor/editor_asset_installer.cpp
@@ -112,6 +112,7 @@ void EditorAssetInstaller::open(const String &p_path, int p_depth) {
 		extension_guess["glb"] = tree->get_theme_icon(SNAME("PackedScene"), SNAME("EditorIcons"));
 
 		extension_guess["gdshader"] = tree->get_theme_icon(SNAME("Shader"), SNAME("EditorIcons"));
+		extension_guess["vshader"] = tree->get_theme_icon(SNAME("VisualShader"), SNAME("EditorIcons"));
 		extension_guess["gd"] = tree->get_theme_icon(SNAME("GDScript"), SNAME("EditorIcons"));
 		if (Engine::get_singleton()->has_singleton("GodotSharp")) {
 			extension_guess["cs"] = tree->get_theme_icon(SNAME("CSharpScript"), SNAME("EditorIcons"));

--- a/editor/plugins/script_editor_plugin.cpp
+++ b/editor/plugins/script_editor_plugin.cpp
@@ -48,6 +48,7 @@
 #include "editor/find_in_files.h"
 #include "editor/node_dock.h"
 #include "editor/plugins/shader_editor_plugin.h"
+#include "editor/plugins/visual_shader_editor_plugin.h"
 #include "modules/visual_script/editor/visual_script_editor.h"
 #include "scene/main/window.h"
 #include "scene/scene_string_names.h"
@@ -3542,14 +3543,20 @@ void ScriptEditor::_on_replace_in_files_requested(String text) {
 void ScriptEditor::_on_find_in_files_result_selected(String fpath, int line_number, int begin, int end) {
 	if (ResourceLoader::exists(fpath)) {
 		Ref<Resource> res = ResourceLoader::load(fpath);
+		String ext = fpath.get_extension();
 
-		if (fpath.get_extension() == "gdshader") {
+		if (ext == "gdshader") {
 			ShaderEditorPlugin *shader_editor = Object::cast_to<ShaderEditorPlugin>(EditorNode::get_singleton()->get_editor_data().get_editor("Shader"));
 			shader_editor->edit(res.ptr());
 			shader_editor->make_visible(true);
 			shader_editor->get_shader_editor()->goto_line_selection(line_number - 1, begin, end);
 			return;
-		} else if (fpath.get_extension() == "tscn") {
+		} else if (ext == "vshader") {
+			VisualShaderEditorPlugin *vshader_editor = Object::cast_to<VisualShaderEditorPlugin>(EditorNode::get_singleton()->get_editor_data().get_editor("VisualShader"));
+			vshader_editor->edit(res.ptr());
+			vshader_editor->make_visible(true);
+			return;
+		} else if (ext == "tscn") {
 			EditorNode::get_singleton()->load_scene(fpath);
 			return;
 		} else {

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -89,7 +89,8 @@ void ShaderCreateDialog::_update_language_info() {
 			data.extensions.push_back("gdshader");
 			data.default_extension = "gdshader";
 		} else {
-			data.default_extension = "tres";
+			data.extensions.push_back("vshader");
+			data.default_extension = "vshader";
 		}
 		data.extensions.push_back("res");
 		data.extensions.push_back("tres");

--- a/scene/register_scene_types.cpp
+++ b/scene/register_scene_types.cpp
@@ -270,6 +270,9 @@ static Ref<ResourceFormatLoaderCompressedTexture3D> resource_loader_texture_3d;
 static Ref<ResourceFormatSaverShader> resource_saver_shader;
 static Ref<ResourceFormatLoaderShader> resource_loader_shader;
 
+static Ref<ResourceFormatSaverVisualShader> resource_saver_vshader;
+static Ref<ResourceFormatLoaderVisualShader> resource_loader_vshader;
+
 void register_scene_types() {
 	SceneStringNames::create();
 
@@ -297,6 +300,12 @@ void register_scene_types() {
 
 	resource_loader_shader.instantiate();
 	ResourceLoader::add_resource_format_loader(resource_loader_shader, true);
+
+	resource_saver_vshader.instantiate();
+	ResourceSaver::add_resource_format_saver(resource_saver_vshader, true);
+
+	resource_loader_vshader.instantiate();
+	ResourceLoader::add_resource_format_loader(resource_loader_vshader, true);
 
 	OS::get_singleton()->yield(); // may take time to init
 
@@ -1171,6 +1180,12 @@ void unregister_scene_types() {
 
 	ResourceLoader::remove_resource_format_loader(resource_loader_shader);
 	resource_loader_shader.unref();
+
+	ResourceSaver::remove_resource_format_saver(resource_saver_vshader);
+	resource_saver_vshader.unref();
+
+	ResourceLoader::remove_resource_format_loader(resource_loader_vshader);
+	resource_loader_vshader.unref();
 
 	// StandardMaterial3D is not initialised when 3D is disabled, so it shouldn't be cleaned up either
 #ifndef _3D_DISABLED

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -31,6 +31,7 @@
 #include "visual_shader.h"
 
 #include "core/templates/vmap.h"
+#include "scene/resources/resource_format_text.h"
 #include "servers/rendering/shader_types.h"
 #include "visual_shader_nodes.h"
 #include "visual_shader_particle_nodes.h"
@@ -2692,6 +2693,43 @@ VisualShader::VisualShader() {
 
 		graph[i].nodes[NODE_ID_OUTPUT].position = Vector2(400, 150);
 	}
+}
+
+///////////////////////////////////////////////////////////
+
+Ref<Resource> ResourceFormatLoaderVisualShader::load(const String &p_path, const String &p_original_path, Error *r_error, bool p_use_sub_threads, float *r_progress, CacheMode p_cache_mode) {
+	return ResourceFormatLoaderText::singleton->load(p_path, p_original_path, r_error, p_use_sub_threads, r_progress, p_cache_mode);
+}
+
+void ResourceFormatLoaderVisualShader::get_recognized_extensions(List<String> *p_extensions) const {
+	p_extensions->push_back("vshader");
+}
+
+bool ResourceFormatLoaderVisualShader::handles_type(const String &p_type) const {
+	return p_type == "VisualShader";
+}
+
+String ResourceFormatLoaderVisualShader::get_resource_type(const String &p_path) const {
+	String el = p_path.get_extension().to_lower();
+	if (el == "vshader") {
+		return "VisualShader";
+	}
+	return "";
+}
+
+Error ResourceFormatSaverVisualShader::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+	return ResourceFormatSaverText::singleton->save(p_path, p_resource, p_flags);
+}
+
+void ResourceFormatSaverVisualShader::get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const {
+	const VisualShader *vshader = Object::cast_to<VisualShader>(*p_resource);
+	if (vshader) {
+		p_extensions->push_back("vshader");
+	}
+}
+
+bool ResourceFormatSaverVisualShader::recognize(const Ref<Resource> &p_resource) const {
+	return p_resource->get_class_name() == "VisualShader";
 }
 
 ///////////////////////////////////////////////////////////

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -250,6 +250,21 @@ VARIANT_ENUM_CAST(VisualShader::VaryingType)
 ///
 ///
 
+class ResourceFormatLoaderVisualShader : public ResourceFormatLoader {
+public:
+	virtual Ref<Resource> load(const String &p_path, const String &p_original_path = "", Error *r_error = nullptr, bool p_use_sub_threads = false, float *r_progress = nullptr, CacheMode p_cache_mode = CACHE_MODE_REUSE) override;
+	virtual void get_recognized_extensions(List<String> *p_extensions) const override;
+	virtual bool handles_type(const String &p_type) const override;
+	virtual String get_resource_type(const String &p_path) const override;
+};
+
+class ResourceFormatSaverVisualShader : public ResourceFormatSaver {
+public:
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0) override;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
+	virtual bool recognize(const Ref<Resource> &p_resource) const override;
+};
+
 class VisualShaderNode : public Resource {
 	GDCLASS(VisualShaderNode, Resource);
 


### PR DESCRIPTION
I think it is not a bad idea to add a separate extension for visual shaders simply to make it different from common resources:

![image](https://user-images.githubusercontent.com/3036176/170957130-901b930f-aae3-42c9-ab54-6fda63949d90.png)

