### PR TITLE
VisibilityNotifier - add max_distance feature

### DIFF
--- a/doc/classes/VisibilityNotifier.xml
+++ b/doc/classes/VisibilityNotifier.xml
@@ -23,6 +23,10 @@
 		<member name="aabb" type="AABB" setter="set_aabb" getter="get_aabb" default="AABB( -1, -1, -1, 2, 2, 2 )">
 			The VisibilityNotifier's bounding box.
 		</member>
+		<member name="max_distance" type="float" setter="set_max_distance" getter="get_max_distance" default="0.0">
+			In addition to checking whether a node is on screen or within a [Camera]'s view, VisibilityNotifier can also optionally check whether a node is within a specified maximum distance when using a [Camera] with perspective projection. This is useful for throttling the performance requirements of nodes that are far away.
+			[b]Note:[/b] This feature will be disabled if set to 0.0.
+		</member>
 	</members>
 	<signals>
 		<signal name="camera_entered">

--- a/scene/3d/visibility_notifier.h
+++ b/scene/3d/visibility_notifier.h
@@ -42,10 +42,20 @@ class VisibilityNotifier : public CullInstance {
 	Set<Camera *> cameras;
 
 	AABB aabb;
+	Vector3 _world_aabb_center;
 
 	// if using rooms and portals
 	RID _cull_instance_rid;
 	bool _in_gameplay;
+
+	bool _max_distance_active;
+	real_t _max_distance;
+	real_t _max_distance_squared;
+
+	// This is a first number of frames where distance objects
+	// are forced seen as visible, to make sure their animations
+	// and physics positions etc are something reasonable.
+	uint32_t _max_distance_leadin_counter;
 
 protected:
 	virtual void _screen_enter() {}
@@ -63,6 +73,21 @@ public:
 	void set_aabb(const AABB &p_aabb);
 	AABB get_aabb() const;
 	bool is_on_screen() const;
+
+	// This is only currently kept up to date if max_distance is active
+	const Vector3 &get_world_aabb_center() const { return _world_aabb_center; }
+
+	void set_max_distance(real_t p_max_distance);
+	real_t get_max_distance() const { return _max_distance; }
+	real_t get_max_distance_squared() const { return _max_distance_squared; }
+	bool is_max_distance_active() const { return _max_distance_active; }
+	bool inside_max_distance_leadin() {
+		if (!_max_distance_leadin_counter) {
+			return false;
+		}
+		_max_distance_leadin_counter--;
+		return true;
+	}
 
 	VisibilityNotifier();
 	~VisibilityNotifier();

--- a/scene/resources/world.cpp
+++ b/scene/resources/world.cpp
@@ -146,9 +146,11 @@ struct SpatialIndexer {
 		for (Map<Camera *, CameraData>::Element *E = cameras.front(); E; E = E->next()) {
 			pass++;
 
+			// prepare camera info
 			Camera *c = E->key();
-
+			Vector3 cam_pos = c->get_global_transform().origin;
 			Vector<Plane> planes = c->get_frustum();
+			bool cam_is_ortho = c->get_projection() == Camera::PROJECTION_ORTHOGONAL;
 
 			int culled = octree.cull_convex(planes, cull.ptrw(), cull.size());
 
@@ -159,6 +161,19 @@ struct SpatialIndexer {
 
 			for (int i = 0; i < culled; i++) {
 				//notifiers in frustum
+
+				// check and remove notifiers that have a max range
+				VisibilityNotifier &nt = *ptr[i];
+				if (nt.is_max_distance_active() && !cam_is_ortho) {
+					Vector3 offset = nt.get_world_aabb_center() - cam_pos;
+					if ((offset.length_squared() >= nt.get_max_distance_squared()) && !nt.inside_max_distance_leadin()) {
+						// unordered remove
+						cull.set(i, cull[culled - 1]);
+						culled--;
+						i--;
+						continue;
+					}
+				}
 
 				Map<VisibilityNotifier *, uint64_t>::Element *H = E->get().notifiers.find(ptr[i]);
 				if (!H) {


### PR DESCRIPTION
Enables turning off objects by distance to the camera in addition to testing whether they are in the view frustum.

![vis_notifier](https://user-images.githubusercontent.com/21999379/171035615-eb0f456b-2e7c-4ba5-83a2-6cf511de8378.png)

https://user-images.githubusercontent.com/21999379/171035285-36e5c9c7-dbb9-4a14-b5d0-891fca06be34.mp4

## Notes
* This is something I've been meaning to add since discussing with Miziziziz when testing WroughtFlesh, in an open world game, it is particularly useful option to be able to throttle animation etc by distance.
* This also works with `VisibilityEnabler` because it is derived from `VisibilityNotifier`. It can also be used to turn off `process` / `physics_process` / AI etc. 
* Works using the AABB center, so needs to keep track of this. Could be less complex using the `VisibilityNotifier` node origin, but users may place the AABB off axis.
* There is currently no hysteresis (VisibilityNotifier doesn't have hysteresis for any of the camera planes). I'm not yet sure whether it needs hysteresis, but it could easily be put in later if it proves useful.
* I've added a "first added" counter to force allow it to update initially. This ensures that animations (and possibly physics?) are allowed to update for at least a frame to ensure animation is reasonable and characters don't appear in the distance in the "T pose". This is hard coded to 1, but could possibly be exposed / changed later if it would be useful for physics.
* It might be nice if the animation picked up where it left off, as the example animation shows there can be a glitch where it re-enters range. But this is really outside the scope of the PR.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
