### PR TITLE
Refactor shader hints

### DIFF
--- a/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
+++ b/servers/rendering/renderer_rd/storage_rd/material_storage.cpp
@@ -1150,7 +1150,7 @@ void MaterialData::update_textures(const HashMap<StringName, Variant> &p_paramet
 				p_textures[k++] = rd_texture;
 			}
 		} else {
-			bool srgb = p_use_linear_color && p_texture_uniforms[i].hint == ShaderLanguage::ShaderNode::Uniform::HINT_SOURCE_COLOR;
+			bool srgb = p_use_linear_color && p_texture_uniforms[i].use_color;
 
 			for (int j = 0; j < textures.size(); j++) {
 				Texture *tex = TextureStorage::get_singleton()->get_texture(textures[j]);

--- a/servers/rendering/shader_compiler.cpp
+++ b/servers/rendering/shader_compiler.cpp
@@ -571,6 +571,7 @@ String ShaderCompiler::_dump_node_code(const SL::Node *p_node, int p_level, Gene
 					texture.name = uniform_name;
 					texture.hint = uniform.hint;
 					texture.type = uniform.type;
+					texture.use_color = uniform.use_color;
 					texture.filter = uniform.filter;
 					texture.repeat = uniform.repeat;
 					texture.global = uniform.scope == ShaderLanguage::ShaderNode::Uniform::SCOPE_GLOBAL;

--- a/servers/rendering/shader_compiler.h
+++ b/servers/rendering/shader_compiler.h
@@ -61,6 +61,7 @@ public:
 			StringName name;
 			ShaderLanguage::DataType type;
 			ShaderLanguage::ShaderNode::Uniform::Hint hint;
+			bool use_color = false;
 			ShaderLanguage::TextureFilter filter;
 			ShaderLanguage::TextureRepeat repeat;
 			bool global;

--- a/servers/rendering/shader_language.h
+++ b/servers/rendering/shader_language.h
@@ -681,6 +681,7 @@ public:
 			Vector<ConstantNode::Value> default_value;
 			Scope scope = SCOPE_LOCAL;
 			Hint hint = HINT_NONE;
+			bool use_color = false;
 			TextureFilter filter = FILTER_DEFAULT;
 			TextureRepeat repeat = REPEAT_DEFAULT;
 			float hint_range[3];
@@ -756,6 +757,9 @@ public:
 	static DataPrecision get_token_precision(TokenType p_type);
 	static String get_precision_name(DataPrecision p_type);
 	static String get_datatype_name(DataType p_type);
+	static String get_uniform_hint_name(ShaderNode::Uniform::Hint p_hint);
+	static String get_texture_filter_name(TextureFilter p_filter);
+	static String get_texture_repeat_name(TextureRepeat p_repeat);
 	static bool is_token_nonvoid_datatype(TokenType p_type);
 	static bool is_token_operator(TokenType p_type);
 	static bool is_token_operator_assign(TokenType p_type);


### PR DESCRIPTION
Fix incorrect overriding of albedo color (`source_color`) hint by `hint_default_white/black` e.g.:

```
uniform sampler2D test : hint_default_black, source_color; // the texture is not black by default, since source_color overrides the hint_default_black
```
This should fix https://github.com/godotengine/godot/pull/60803#issuecomment-1141522170
> The replacement for hint_black_albedo, source_color, hint_default_black doesn't work, as the uniform only stores the most recent hint.

I also added check to avoid duplicating and redefinition of hints:
```
uniform float testScalar : repeat_enable; // incorrect hint 
uniform sampler2D test : hint_default_white, hint_default_white; // duplicating
uniform sampler2D test2 : hint_default_white, hint_default_black; // redefinition
```

And did some further refactoring (changed if/else to single switch) and renamed `uniform2` to `uniform`.