### PR TITLE
Make `Mesh::generate_triangle_mesh()` handle `PRIMITIVE_TRIANGLE_STRIP`

### DIFF
--- a/doc/classes/Mesh.xml
+++ b/doc/classes/Mesh.xml
@@ -123,7 +123,7 @@
 		<method name="generate_triangle_mesh" qualifiers="const">
 			<return type="TriangleMesh" />
 			<description>
-				Generate a [TriangleMesh] from the mesh.
+				Generate a [TriangleMesh] from the mesh. Considers only surfaces using one of these primitive types: [constant PRIMITIVE_TRIANGLES], [constant PRIMITIVE_TRIANGLE_STRIP].
 			</description>
 		</method>
 		<method name="get_aabb" qualifiers="const">


### PR DESCRIPTION
Enhacement: makes `Mesh::generate_triangle_mesh()` handle `PRIMITIVE_TRIANGLE_STRIP` (besides already supported `PRIMITIVE_TRIANGLES`).

Bugfix: now `Mesh::generate_triangle_mesh()` ignores surfaces with incorrect vertex/index count and shows an error for each such surface. Previously it was checking only the total amount of vertices/indices (sum of counts) so for example it wouldn't error out when having 2 surfaces with 1 and 2 vertices respectively, it would incorrectly deduce it's 1 triangle (1+2=3 vertices/indices).

Fixes #61552.