### PR TITLE
Handle drawing of relationship lines better to take in to account invisible children

### DIFF
--- a/scene/gui/tree.cpp
+++ b/scene/gui/tree.cpp
@@ -2169,7 +2169,7 @@ int Tree::draw_item(const Point2i &p_pos, const Point2 &p_draw_ofs, const Size2 
 				int parent_ofs = p_pos.x + cache.item_margin;
 				Point2i root_pos = Point2i(root_ofs, children_pos.y + label_h / 2) - cache.offset + p_draw_ofs;
 
-				if (c->get_first_child() != nullptr) {
+				if (c->get_visible_child_count() > 0) {
 					root_pos -= Point2i(cache.arrow->get_width(), 0);
 				}
 


### PR DESCRIPTION
While working on the backport of the related TreeItem (cf. #61372) visibility changes I noticed an issue

When the relationship lines are activated, if a node has no visible children the line going to it will be drawn short...

With visible child:
![image](https://user-images.githubusercontent.com/8000597/171201539-20886ba9-0307-4c83-9918-818fd570d837.png)
Setting child to be invisble:
![image](https://user-images.githubusercontent.com/8000597/171202215-fa137df8-ff45-464e-8ef6-28915f58bf75.png)

The check was just checking that there was a child, however now we need to determine if there are any visible children.
To do this I am just checking at the total number of visible children is > 0. This is just the simplest way of doing it, however it's probably not as performant as say having a new function like `get_first_visible_child()`. Not sure if we'd want to add something like that (either as a public or private method), or just go with this approach.

After the fix:
![image](https://user-images.githubusercontent.com/8000597/171204093-898acd52-4c38-48cd-a06a-d8949e067305.png)
