### PR TITLE
Cleanup Android C++ code

### DIFF
--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -88,4 +88,4 @@ public:
 	void process_key_event(int p_keycode, int p_scancode, int p_unicode_char, bool p_pressed);
 };
 
-#endif
+#endif // ANDROID_INPUT_HANDLER_H

--- a/platform/android/api/jni_singleton.h
+++ b/platform/android/api/jni_singleton.h
@@ -73,7 +73,7 @@ public:
 			return Object::callp(p_method, p_args, p_argcount, r_error);
 		}
 
-		ERR_FAIL_COND_V(!instance, Variant());
+		ERR_FAIL_NULL_V(instance, Variant());
 
 		r_error.error = Callable::CallError::CALL_OK;
 

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -80,8 +80,6 @@ void AudioDriverOpenSL::_buffer_callbacks(
 	ad->_buffer_callback(queueItf);
 }
 
-AudioDriverOpenSL *AudioDriverOpenSL::s_ad = nullptr;
-
 const char *AudioDriverOpenSL::get_name() const {
 	return "Android";
 }
@@ -133,8 +131,6 @@ void AudioDriverOpenSL::start() {
 	ERR_FAIL_COND(res != SL_RESULT_SUCCESS);
 
 	SLDataLocator_AndroidSimpleBufferQueue loc_bufq = { SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE, BUFFER_COUNT };
-	//bufferQueue.locatorType = SL_DATALOCATOR_BUFFERQUEUE;
-	//bufferQueue.numBuffers = BUFFER_COUNT; /* Four buffers in our buffer queue */
 	/* Setup the format of the content in the buffer queue */
 	pcm.formatType = SL_DATAFORMAT_PCM;
 	pcm.numChannels = 2;
@@ -155,13 +151,8 @@ void AudioDriverOpenSL::start() {
 	locator_outputmix.outputMix = OutputMix;
 	audioSink.pLocator = (void *)&locator_outputmix;
 	audioSink.pFormat = nullptr;
-	/* Initialize the context for Buffer queue callbacks */
-	//cntxt.pDataBase = (void*)&pcmData;
-	//cntxt.pData = cntxt.pDataBase;
-	//cntxt.size = sizeof(pcmData);
 
 	/* Create the music player */
-
 	{
 		const SLInterfaceID ids[2] = { SL_IID_BUFFERQUEUE, SL_IID_EFFECTSEND };
 		const SLboolean req[2] = { SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE };
@@ -341,5 +332,4 @@ void AudioDriverOpenSL::set_pause(bool p_pause) {
 }
 
 AudioDriverOpenSL::AudioDriverOpenSL() {
-	s_ad = this;
 }

--- a/platform/android/audio_driver_opensl.h
+++ b/platform/android/audio_driver_opensl.h
@@ -105,4 +105,4 @@ public:
 	AudioDriverOpenSL();
 };
 
-#endif // AUDIO_DRIVER_ANDROID_H
+#endif // AUDIO_DRIVER_OPENSL_H

--- a/platform/android/dir_access_jandroid.cpp
+++ b/platform/android/dir_access_jandroid.cpp
@@ -55,7 +55,6 @@ Error DirAccessJAndroid::list_dir_begin() {
 	if (res <= 0) {
 		return ERR_CANT_OPEN;
 	}
-
 	id = res;
 
 	return OK;
@@ -69,7 +68,6 @@ String DirAccessJAndroid::get_next() {
 	if (!str) {
 		return "";
 	}
-
 	String ret = jstring_to_string((jstring)str, env);
 	env->DeleteLocalRef((jobject)str);
 	return ret;
@@ -89,7 +87,6 @@ void DirAccessJAndroid::list_dir_end() {
 	if (id == 0) {
 		return;
 	}
-
 	JNIEnv *env = get_jni_env();
 	env->CallVoidMethod(io, _dir_close, id);
 	id = 0;
@@ -228,12 +225,9 @@ void DirAccessJAndroid::setup(jobject p_io) {
 	_dir_next = env->GetMethodID(cls, "dir_next", "(I)Ljava/lang/String;");
 	_dir_close = env->GetMethodID(cls, "dir_close", "(I)V");
 	_dir_is_dir = env->GetMethodID(cls, "dir_is_dir", "(I)Z");
-
-	//(*env)->CallVoidMethod(env,obj,aMethodID, myvar);
 }
 
 DirAccessJAndroid::DirAccessJAndroid() {
-	id = 0;
 }
 
 DirAccessJAndroid::~DirAccessJAndroid() {

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -36,8 +36,6 @@
 #include <stdio.h>
 
 class DirAccessJAndroid : public DirAccess {
-	//AAssetDir* aad;
-
 	static jobject io;
 	static jclass cls;
 
@@ -46,7 +44,7 @@ class DirAccessJAndroid : public DirAccess {
 	static jmethodID _dir_close;
 	static jmethodID _dir_is_dir;
 
-	int id;
+	int id = 0;
 
 	String current_dir;
 	String current;

--- a/platform/android/display_server_android.cpp
+++ b/platform/android/display_server_android.cpp
@@ -105,7 +105,7 @@ void DisplayServerAndroid::tts_stop() {
 
 void DisplayServerAndroid::clipboard_set(const String &p_text) {
 	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
-	ERR_FAIL_COND(!godot_java);
+	ERR_FAIL_NULL(godot_java);
 
 	if (godot_java->has_set_clipboard()) {
 		godot_java->set_clipboard(p_text);
@@ -116,7 +116,7 @@ void DisplayServerAndroid::clipboard_set(const String &p_text) {
 
 String DisplayServerAndroid::clipboard_get() const {
 	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
-	ERR_FAIL_COND_V(!godot_java, String());
+	ERR_FAIL_NULL_V(godot_java, String());
 
 	if (godot_java->has_get_clipboard()) {
 		return godot_java->get_clipboard();
@@ -127,7 +127,7 @@ String DisplayServerAndroid::clipboard_get() const {
 
 bool DisplayServerAndroid::clipboard_has() const {
 	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
-	ERR_FAIL_COND_V(!godot_java, false);
+	ERR_FAIL_NULL_V(godot_java, false);
 
 	if (godot_java->has_has_clipboard()) {
 		return godot_java->has_clipboard();
@@ -150,7 +150,7 @@ Rect2i DisplayServerAndroid::get_display_safe_area() const {
 
 void DisplayServerAndroid::screen_set_keep_on(bool p_enable) {
 	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
-	ERR_FAIL_COND(!godot_java);
+	ERR_FAIL_NULL(godot_java);
 
 	godot_java->set_keep_screen_on(p_enable);
 	keep_screen_on = p_enable;
@@ -162,14 +162,14 @@ bool DisplayServerAndroid::screen_is_kept_on() const {
 
 void DisplayServerAndroid::screen_set_orientation(DisplayServer::ScreenOrientation p_orientation, int p_screen) {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
-	ERR_FAIL_COND(!godot_io_java);
+	ERR_FAIL_NULL(godot_io_java);
 
 	godot_io_java->set_screen_orientation(p_orientation);
 }
 
 DisplayServer::ScreenOrientation DisplayServerAndroid::screen_get_orientation(int p_screen) const {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
-	ERR_FAIL_COND_V(!godot_io_java, SCREEN_LANDSCAPE);
+	ERR_FAIL_NULL_V(godot_io_java, SCREEN_LANDSCAPE);
 
 	const int orientation = godot_io_java->get_screen_orientation();
 	ERR_FAIL_INDEX_V_MSG(orientation, 7, SCREEN_LANDSCAPE, "Unrecognized screen orientation");
@@ -195,14 +195,14 @@ Rect2i DisplayServerAndroid::screen_get_usable_rect(int p_screen) const {
 
 int DisplayServerAndroid::screen_get_dpi(int p_screen) const {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
-	ERR_FAIL_COND_V(!godot_io_java, 0);
+	ERR_FAIL_NULL_V(godot_io_java, 0);
 
 	return godot_io_java->get_screen_dpi();
 }
 
 float DisplayServerAndroid::screen_get_scale(int p_screen) const {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
-	ERR_FAIL_COND_V(!godot_io_java, 1.0f);
+	ERR_FAIL_NULL_V(godot_io_java, 1.0f);
 
 	return godot_io_java->get_scaled_density();
 }
@@ -223,7 +223,7 @@ bool DisplayServerAndroid::screen_is_touchscreen(int p_screen) const {
 
 void DisplayServerAndroid::virtual_keyboard_show(const String &p_existing_text, const Rect2 &p_screen_rect, bool p_multiline, int p_max_length, int p_cursor_start, int p_cursor_end) {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
-	ERR_FAIL_COND(!godot_io_java);
+	ERR_FAIL_NULL(godot_io_java);
 
 	if (godot_io_java->has_vk()) {
 		godot_io_java->show_vk(p_existing_text, p_multiline, p_max_length, p_cursor_start, p_cursor_end);
@@ -234,7 +234,7 @@ void DisplayServerAndroid::virtual_keyboard_show(const String &p_existing_text, 
 
 void DisplayServerAndroid::virtual_keyboard_hide() {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
-	ERR_FAIL_COND(!godot_io_java);
+	ERR_FAIL_NULL(godot_io_java);
 
 	if (godot_io_java->has_vk()) {
 		godot_io_java->hide_vk();
@@ -245,7 +245,7 @@ void DisplayServerAndroid::virtual_keyboard_hide() {
 
 int DisplayServerAndroid::virtual_keyboard_get_height() const {
 	GodotIOJavaWrapper *godot_io_java = OS_Android::get_singleton()->get_godot_io_java();
-	ERR_FAIL_COND_V(!godot_io_java, 0);
+	ERR_FAIL_NULL_V(godot_io_java, 0);
 
 	return godot_io_java->get_vk_height();
 }
@@ -456,9 +456,9 @@ void DisplayServerAndroid::reset_window() {
 #if defined(VULKAN_ENABLED)
 	if (rendering_driver == "vulkan") {
 		ANativeWindow *native_window = OS_Android::get_singleton()->get_native_window();
-		ERR_FAIL_COND(!native_window);
+		ERR_FAIL_NULL(native_window);
 
-		ERR_FAIL_COND(!context_vulkan);
+		ERR_FAIL_NULL(context_vulkan);
 		VSyncMode last_vsync_mode = context_vulkan->get_vsync_mode(MAIN_WINDOW_ID);
 		context_vulkan->window_destroy(MAIN_WINDOW_ID);
 
@@ -519,7 +519,7 @@ DisplayServerAndroid::DisplayServerAndroid(const String &p_rendering_driver, Dis
 
 	if (rendering_driver == "vulkan") {
 		ANativeWindow *native_window = OS_Android::get_singleton()->get_native_window();
-		ERR_FAIL_COND(!native_window);
+		ERR_FAIL_NULL(native_window);
 
 		context_vulkan = memnew(VulkanContextAndroid);
 		if (context_vulkan->initialize() != OK) {

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -36,11 +36,6 @@
 #include "editor/editor_settings.h"
 
 void register_android_exporter() {
-	String exe_ext;
-	if (OS::get_singleton()->get_name() == "Windows") {
-		exe_ext = "*.exe";
-	}
-
 	EDITOR_DEF("export/android/android_sdk_path", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/android_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
 	EDITOR_DEF("export/android/debug_keystore", "");

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -409,7 +409,7 @@ void EditorExportPlatformAndroid::_check_for_changes_poll_thread(void *ud) {
 		List<String> args;
 		args.push_back("kill-server");
 		OS::get_singleton()->execute(adb, args);
-	};
+	}
 }
 
 String EditorExportPlatformAndroid::get_project_name(const String &p_name) const {
@@ -522,8 +522,8 @@ bool EditorExportPlatformAndroid::is_package_name_valid(const String &p_package,
 
 bool EditorExportPlatformAndroid::_should_compress_asset(const String &p_path, const Vector<uint8_t> &p_data) {
 	/*
-	 *  By not compressing files with little or not benefit in doing so,
-	 *  a performance gain is expected attime. Moreover, if the APK is
+	 *  By not compressing files with little or no benefit in doing so,
+	 *  a performance gain is expected at runtime. Moreover, if the APK is
 	 *  zip-aligned, assets stored as they are can be efficiently read by
 	 *  Android by memory-mapping them.
 	 */
@@ -833,11 +833,9 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 	uint32_t ofs = 8;
 
 	uint32_t string_count = 0;
-	//uint32_t styles_count = 0;
 	uint32_t string_flags = 0;
 	uint32_t string_data_offset = 0;
 
-	//uint32_t styles_offset = 0;
 	uint32_t string_table_begins = 0;
 	uint32_t string_table_ends = 0;
 	Vector<uint8_t> stable_extra;
@@ -878,10 +876,8 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 				int iofs = ofs + 8;
 
 				string_count = decode_uint32(&p_manifest[iofs]);
-				// iofs + 4 is `styles_count`.
 				string_flags = decode_uint32(&p_manifest[iofs + 8]);
 				string_data_offset = decode_uint32(&p_manifest[iofs + 12]);
-				// iofs + 16 is `styles_offset`.
 
 				uint32_t st_offset = iofs + 20;
 				string_table.resize(string_count);
@@ -1850,7 +1846,8 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 	{                                                     \
 		DirAccess::remove_file_or_error(tmp_export_path); \
 		return m_err;                                     \
-	}
+	}                                                     \
+	((void)0)
 
 	// Export to temporary APK before sending to device.
 	Error err = export_project_helper(p_preset, true, tmp_export_path, EXPORT_FORMAT_APK, true, p_debug_flags);
@@ -2794,7 +2791,8 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 	{                                                        \
 		DirAccess::remove_file_or_error(tmp_unaligned_path); \
 		return m_err;                                        \
-	}
+	}                                                        \
+	((void)0)
 
 	zipFile unaligned_apk = zipOpen2(tmp_unaligned_path.utf8().get_data(), APPEND_STATUS_CREATE, nullptr, &io2);
 

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -28,6 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef ANDROID_EXPORT_PLUGIN_H
+#define ANDROID_EXPORT_PLUGIN_H
+
 #include "godot_plugin_config.h"
 
 #include "core/io/zip_io.h"
@@ -234,3 +237,5 @@ public:
 
 	~EditorExportPlatformAndroid();
 };
+
+#endif // ANDROID_EXPORT_PLUGIN_H

--- a/platform/android/export/godot_plugin_config.cpp
+++ b/platform/android/export/godot_plugin_config.cpp
@@ -71,7 +71,6 @@ PluginConfigAndroid PluginConfigAndroid::resolve_prebuilt_plugin(PluginConfigAnd
 
 Vector<PluginConfigAndroid> PluginConfigAndroid::get_prebuilt_plugins(String plugins_base_dir) {
 	Vector<PluginConfigAndroid> prebuilt_plugins;
-	// prebuilt_plugins.push_back(resolve_prebuilt_plugin(MY_PREBUILT_PLUGIN, plugins_base_dir));
 	return prebuilt_plugins;
 }
 

--- a/platform/android/export/godot_plugin_config.h
+++ b/platform/android/export/godot_plugin_config.h
@@ -103,4 +103,4 @@ struct PluginConfigAndroid {
 	static String get_plugins_names(Vector<PluginConfigAndroid> plugins_configs);
 };
 
-#endif // GODOT_PLUGIN_CONFIG_H
+#endif // ANDROID_GODOT_PLUGIN_CONFIG_H

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -106,4 +106,4 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset);
 
 String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_storage_permission);
 
-#endif //GODOT_GRADLE_EXPORT_UTIL_H
+#endif // GODOT_GRADLE_EXPORT_UTIL_H

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -35,11 +35,10 @@
 #include <android/asset_manager.h>
 #include <android/log.h>
 #include <stdio.h>
-//#include <android_native_app_glue.h>
 
 class FileAccessAndroid : public FileAccess {
 	static Ref<FileAccess> create_android();
-	mutable AAsset *a = nullptr;
+	mutable AAsset *asset = nullptr;
 	mutable uint64_t len = 0;
 	mutable uint64_t pos = 0;
 	mutable bool eof = false;
@@ -49,31 +48,29 @@ class FileAccessAndroid : public FileAccess {
 public:
 	static AAssetManager *asset_manager;
 
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual bool is_open() const; ///< true when file is open
+	virtual Error _open(const String &p_path, int p_mode_flags); // open a file
+	virtual bool is_open() const; // true when file is open
 
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
-	virtual uint64_t get_length() const; ///< get size of the file
+	virtual void seek(uint64_t p_position); // seek to a given position
+	virtual void seek_end(int64_t p_position = 0); // seek from the end of file
+	virtual uint64_t get_position() const; // get position in the file
+	virtual uint64_t get_length() const; // get size of the file
 
-	virtual bool eof_reached() const; ///< reading passed EOF
+	virtual bool eof_reached() const; // reading passed EOF
 
-	virtual uint8_t get_8() const; ///< get a byte
+	virtual uint8_t get_8() const; // get a byte
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
-	virtual Error get_error() const; ///< get last error
+	virtual Error get_error() const; // get last error
 
 	virtual void flush();
-	virtual void store_8(uint8_t p_dest); ///< store a byte
+	virtual void store_8(uint8_t p_dest); // store a byte
 
-	virtual bool file_exists(const String &p_path); ///< return true if a file exists
+	virtual bool file_exists(const String &p_path); // return true if a file exists
 
 	virtual uint64_t _get_modified_time(const String &p_file) { return 0; }
 	virtual uint32_t _get_unix_permissions(const String &p_file) { return 0; }
 	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) { return FAILED; }
-
-	//static void make_default();
 
 	~FileAccessAndroid();
 };

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -40,7 +40,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 	}
 
 	JNIEnv *env = get_jni_env();
-	ERR_FAIL_COND_V(env == nullptr, false);
+	ERR_FAIL_NULL_V(env, false);
 
 	MethodInfo *method = nullptr;
 	for (MethodInfo &E : M->value) {
@@ -971,14 +971,14 @@ Ref<JavaClass> JavaClassWrapper::wrap(const String &p_class) {
 	}
 
 	JNIEnv *env = get_jni_env();
-	ERR_FAIL_COND_V(env == nullptr, Ref<JavaClass>());
+	ERR_FAIL_NULL_V(env, Ref<JavaClass>());
 
 	jclass bclass = env->FindClass(p_class.utf8().get_data());
-	ERR_FAIL_COND_V(!bclass, Ref<JavaClass>());
+	ERR_FAIL_NULL_V(bclass, Ref<JavaClass>());
 
 	jobjectArray methods = (jobjectArray)env->CallObjectMethod(bclass, getDeclaredMethods);
 
-	ERR_FAIL_COND_V(!methods, Ref<JavaClass>());
+	ERR_FAIL_NULL_V(methods, Ref<JavaClass>());
 
 	Ref<JavaClass> java_class = memnew(JavaClass);
 
@@ -1061,7 +1061,7 @@ Ref<JavaClass> JavaClassWrapper::wrap(const String &p_class) {
 			if (E->get().param_types.size() != mi.param_types.size()) {
 				continue;
 			}
-			bool valid = true;
+			bool this_valid = true;
 			for (int j = 0; j < E->get().param_types.size(); j++) {
 				Variant::Type _new;
 				float new_l;
@@ -1070,14 +1070,14 @@ Ref<JavaClass> JavaClassWrapper::wrap(const String &p_class) {
 				JavaClass::_convert_to_variant_type(E->get().param_types[j], existing, existing_l);
 				JavaClass::_convert_to_variant_type(mi.param_types[j], _new, new_l);
 				if (_new != existing) {
-					valid = false;
+					this_valid = false;
 					break;
 				}
 				new_likeliness += new_l;
 				existing_likeliness = existing_l;
 			}
 
-			if (!valid) {
+			if (!this_valid) {
 				continue;
 			}
 
@@ -1155,10 +1155,10 @@ JavaClassWrapper::JavaClassWrapper(jobject p_activity) {
 	singleton = this;
 
 	JNIEnv *env = get_jni_env();
-	ERR_FAIL_COND(env == nullptr);
+	ERR_FAIL_NULL(env);
 
-	jclass activityClass = env->FindClass("android/app/Activity");
-	jmethodID getClassLoader = env->GetMethodID(activityClass, "getClassLoader", "()Ljava/lang/ClassLoader;");
+	jclass activity = env->FindClass("android/app/Activity");
+	jmethodID getClassLoader = env->GetMethodID(activity, "getClassLoader", "()Ljava/lang/ClassLoader;");
 	classLoader = env->CallObjectMethod(p_activity, getClassLoader);
 	classLoader = (jclass)env->NewGlobalRef(classLoader);
 	jclass classLoaderClass = env->FindClass("java/lang/ClassLoader");
@@ -1168,18 +1168,18 @@ JavaClassWrapper::JavaClassWrapper(jobject p_activity) {
 	getDeclaredMethods = env->GetMethodID(bclass, "getDeclaredMethods", "()[Ljava/lang/reflect/Method;");
 	getFields = env->GetMethodID(bclass, "getFields", "()[Ljava/lang/reflect/Field;");
 	Class_getName = env->GetMethodID(bclass, "getName", "()Ljava/lang/String;");
-	//
+
 	bclass = env->FindClass("java/lang/reflect/Method");
 	getParameterTypes = env->GetMethodID(bclass, "getParameterTypes", "()[Ljava/lang/Class;");
 	getReturnType = env->GetMethodID(bclass, "getReturnType", "()Ljava/lang/Class;");
 	getName = env->GetMethodID(bclass, "getName", "()Ljava/lang/String;");
 	getModifiers = env->GetMethodID(bclass, "getModifiers", "()I");
-	///
+
 	bclass = env->FindClass("java/lang/reflect/Field");
 	Field_getName = env->GetMethodID(bclass, "getName", "()Ljava/lang/String;");
 	Field_getModifiers = env->GetMethodID(bclass, "getModifiers", "()I");
 	Field_get = env->GetMethodID(bclass, "get", "(Ljava/lang/Object;)Ljava/lang/Object;");
-	// each
+
 	bclass = env->FindClass("java/lang/Boolean");
 	Boolean_booleanValue = env->GetMethodID(bclass, "booleanValue", "()Z");
 

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -80,7 +80,7 @@ jobject GodotIOJavaWrapper::get_instance() {
 Error GodotIOJavaWrapper::open_uri(const String &p_uri) {
 	if (_open_URI) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, ERR_UNAVAILABLE);
+		ERR_FAIL_NULL_V(env, ERR_UNAVAILABLE);
 		jstring jStr = env->NewStringUTF(p_uri.utf8().get_data());
 		return env->CallIntMethod(godot_io_instance, _open_URI, jStr) ? ERR_CANT_OPEN : OK;
 	} else {
@@ -91,7 +91,7 @@ Error GodotIOJavaWrapper::open_uri(const String &p_uri) {
 String GodotIOJavaWrapper::get_cache_dir() {
 	if (_get_cache_dir) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
+		ERR_FAIL_NULL_V(env, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_cache_dir);
 		return jstring_to_string(s, env);
 	} else {
@@ -102,7 +102,7 @@ String GodotIOJavaWrapper::get_cache_dir() {
 String GodotIOJavaWrapper::get_user_data_dir() {
 	if (_get_data_dir) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
+		ERR_FAIL_NULL_V(env, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_data_dir);
 		return jstring_to_string(s, env);
 	} else {
@@ -113,7 +113,7 @@ String GodotIOJavaWrapper::get_user_data_dir() {
 String GodotIOJavaWrapper::get_locale() {
 	if (_get_locale) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
+		ERR_FAIL_NULL_V(env, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_locale);
 		return jstring_to_string(s, env);
 	} else {
@@ -124,7 +124,7 @@ String GodotIOJavaWrapper::get_locale() {
 String GodotIOJavaWrapper::get_model() {
 	if (_get_model) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
+		ERR_FAIL_NULL_V(env, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_model);
 		return jstring_to_string(s, env);
 	} else {
@@ -135,7 +135,7 @@ String GodotIOJavaWrapper::get_model() {
 int GodotIOJavaWrapper::get_screen_dpi() {
 	if (_get_screen_DPI) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, 160);
+		ERR_FAIL_NULL_V(env, 160);
 		return env->CallIntMethod(godot_io_instance, _get_screen_DPI);
 	} else {
 		return 160;
@@ -145,7 +145,7 @@ int GodotIOJavaWrapper::get_screen_dpi() {
 float GodotIOJavaWrapper::get_scaled_density() {
 	if (_get_scaled_density) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, 1.0f);
+		ERR_FAIL_NULL_V(env, 1.0f);
 		return env->CallFloatMethod(godot_io_instance, _get_scaled_density);
 	} else {
 		return 1.0f;
@@ -202,7 +202,7 @@ Rect2i GodotIOJavaWrapper::get_display_safe_area() {
 String GodotIOJavaWrapper::get_unique_id() {
 	if (_get_unique_id) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
+		ERR_FAIL_NULL_V(env, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_unique_id);
 		return jstring_to_string(s, env);
 	} else {
@@ -211,13 +211,13 @@ String GodotIOJavaWrapper::get_unique_id() {
 }
 
 bool GodotIOJavaWrapper::has_vk() {
-	return (_show_keyboard != 0) && (_hide_keyboard != 0);
+	return (_show_keyboard != nullptr) && (_hide_keyboard != nullptr);
 }
 
 void GodotIOJavaWrapper::show_vk(const String &p_existing, bool p_multiline, int p_max_input_length, int p_cursor_start, int p_cursor_end) {
 	if (_show_keyboard) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
+		ERR_FAIL_NULL(env);
 		jstring jStr = env->NewStringUTF(p_existing.utf8().get_data());
 		env->CallVoidMethod(godot_io_instance, _show_keyboard, jStr, p_multiline, p_max_input_length, p_cursor_start, p_cursor_end);
 	}
@@ -226,7 +226,7 @@ void GodotIOJavaWrapper::show_vk(const String &p_existing, bool p_multiline, int
 void GodotIOJavaWrapper::hide_vk() {
 	if (_hide_keyboard) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
+		ERR_FAIL_NULL(env);
 		env->CallVoidMethod(godot_io_instance, _hide_keyboard);
 	}
 }
@@ -234,7 +234,7 @@ void GodotIOJavaWrapper::hide_vk() {
 void GodotIOJavaWrapper::set_screen_orientation(int p_orient) {
 	if (_set_screen_orientation) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
+		ERR_FAIL_NULL(env);
 		env->CallVoidMethod(godot_io_instance, _set_screen_orientation, p_orient);
 	}
 }
@@ -242,7 +242,7 @@ void GodotIOJavaWrapper::set_screen_orientation(int p_orient) {
 int GodotIOJavaWrapper::get_screen_orientation() {
 	if (_get_screen_orientation) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, 0);
+		ERR_FAIL_NULL_V(env, 0);
 		return env->CallIntMethod(godot_io_instance, _get_screen_orientation);
 	} else {
 		return 0;
@@ -252,7 +252,7 @@ int GodotIOJavaWrapper::get_screen_orientation() {
 String GodotIOJavaWrapper::get_system_dir(int p_dir, bool p_shared_storage) {
 	if (_get_system_dir) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String("."));
+		ERR_FAIL_NULL_V(env, String("."));
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_system_dir, p_dir, p_shared_storage);
 		return jstring_to_string(s, env);
 	} else {

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -91,4 +91,4 @@ public:
 	String get_system_dir(int p_dir, bool p_shared_storage);
 };
 
-#endif /* !JAVA_GODOT_IO_WRAPPER_H */
+#endif // JAVA_GODOT_IO_WRAPPER_H

--- a/platform/android/java_godot_lib_jni.cpp
+++ b/platform/android/java_godot_lib_jni.cpp
@@ -62,7 +62,6 @@ static AndroidInputHandler *input_handler = nullptr;
 static GodotJavaWrapper *godot_java = nullptr;
 static GodotIOJavaWrapper *godot_io_java = nullptr;
 
-static bool initialized = false;
 static SafeNumeric<int> step; // Shared between UI and render threads
 
 static Size2 new_size;
@@ -80,8 +79,6 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setVirtualKeyboardHei
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *env, jclass clazz, jobject activity, jobject godot_instance, jobject p_asset_manager, jboolean p_use_apk_expansion) {
-	initialized = true;
-
 	JavaVM *jvm;
 	env->GetJavaVM(&jvm);
 
@@ -100,9 +97,6 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_initialize(JNIEnv *en
 	TTS_Android::setup(godot_java->get_member_object("tts", "Lorg/godotengine/godot/tts/GodotTTS;", env));
 
 	os_android = new OS_Android(godot_java, godot_io_java, p_use_apk_expansion);
-
-	char wd[500];
-	getcwd(wd, 500);
 
 	godot_java->on_video_init(env);
 }
@@ -144,7 +138,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_setup(JNIEnv *env, jc
 
 			for (int i = 0; i < cmdlen; i++) {
 				jstring string = (jstring)env->GetObjectArrayElement(p_cmdline, i);
-				const char *rawString = env->GetStringUTFChars(string, 0);
+				const char *rawString = env->GetStringUTFChars(string, nullptr);
 
 				cmdline[i] = rawString;
 				j_cmdline[i] = string;
@@ -436,7 +430,7 @@ JNIEXPORT jstring JNICALL Java_org_godotengine_godot_GodotLib_getGlobal(JNIEnv *
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_callobject(JNIEnv *env, jclass clazz, jlong ID, jstring method, jobjectArray params) {
 	Object *obj = ObjectDB::get_instance(ObjectID(ID));
-	ERR_FAIL_COND(!obj);
+	ERR_FAIL_NULL(obj);
 
 	int res = env->PushLocalFrame(16);
 	ERR_FAIL_COND(res != 0);
@@ -447,27 +441,26 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_callobject(JNIEnv *en
 	Variant *vlist = (Variant *)alloca(sizeof(Variant) * count);
 	Variant **vptr = (Variant **)alloca(sizeof(Variant *) * count);
 	for (int i = 0; i < count; i++) {
-		jobject obj = env->GetObjectArrayElement(params, i);
+		jobject jobj = env->GetObjectArrayElement(params, i);
 		Variant v;
-		if (obj) {
-			v = _jobject_to_variant(env, obj);
+		if (jobj) {
+			v = _jobject_to_variant(env, jobj);
 		}
 		memnew_placement(&vlist[i], Variant);
 		vlist[i] = v;
 		vptr[i] = &vlist[i];
-		env->DeleteLocalRef(obj);
+		env->DeleteLocalRef(jobj);
 	}
 
 	Callable::CallError err;
 	obj->callp(str_method, (const Variant **)vptr, count, err);
-	// something
 
 	env->PopLocalFrame(nullptr);
 }
 
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_calldeferred(JNIEnv *env, jclass clazz, jlong ID, jstring method, jobjectArray params) {
 	Object *obj = ObjectDB::get_instance(ObjectID(ID));
-	ERR_FAIL_COND(!obj);
+	ERR_FAIL_NULL(obj);
 
 	int res = env->PushLocalFrame(16);
 	ERR_FAIL_COND(res != 0);
@@ -480,16 +473,16 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_calldeferred(JNIEnv *
 	const Variant **argptrs = (const Variant **)alloca(sizeof(Variant *) * count);
 
 	for (int i = 0; i < count; i++) {
-		jobject obj = env->GetObjectArrayElement(params, i);
-		if (obj) {
-			args[i] = _jobject_to_variant(env, obj);
+		jobject jobj = env->GetObjectArrayElement(params, i);
+		if (jobj) {
+			args[i] = _jobject_to_variant(env, jobj);
 		}
-		env->DeleteLocalRef(obj);
+		env->DeleteLocalRef(jobj);
 		argptrs[i] = &args[i];
 	}
 
 	MessageQueue::get_singleton()->push_callp(obj, str_method, (const Variant **)argptrs, count);
-	// something
+
 	env->PopLocalFrame(nullptr);
 }
 

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -72,4 +72,4 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererResumed(JNI
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererPaused(JNIEnv *env, jclass clazz);
 }
 
-#endif /* !JAVA_GODOT_LIB_JNI_H */
+#endif // JAVA_GODOT_LIB_JNI_H

--- a/platform/android/java_godot_view_wrapper.cpp
+++ b/platform/android/java_godot_view_wrapper.cpp
@@ -34,7 +34,7 @@
 
 GodotJavaViewWrapper::GodotJavaViewWrapper(jobject godot_view) {
 	JNIEnv *env = get_jni_env();
-	ERR_FAIL_COND(env == nullptr);
+	ERR_FAIL_NULL(env);
 
 	_godot_view = env->NewGlobalRef(godot_view);
 
@@ -48,27 +48,27 @@ GodotJavaViewWrapper::GodotJavaViewWrapper(jobject godot_view) {
 }
 
 void GodotJavaViewWrapper::request_pointer_capture() {
-	if (_request_pointer_capture != 0) {
+	if (_request_pointer_capture != nullptr) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
+		ERR_FAIL_NULL(env);
 
 		env->CallVoidMethod(_godot_view, _request_pointer_capture);
 	}
 }
 
 void GodotJavaViewWrapper::release_pointer_capture() {
-	if (_request_pointer_capture != 0) {
+	if (_request_pointer_capture != nullptr) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
+		ERR_FAIL_NULL(env);
 
 		env->CallVoidMethod(_godot_view, _release_pointer_capture);
 	}
 }
 
 void GodotJavaViewWrapper::set_pointer_icon(int pointer_type) {
-	if (_set_pointer_icon != 0) {
+	if (_set_pointer_icon != nullptr) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
+		ERR_FAIL_NULL(env);
 
 		env->CallVoidMethod(_godot_view, _set_pointer_icon, pointer_type);
 	}
@@ -76,7 +76,7 @@ void GodotJavaViewWrapper::set_pointer_icon(int pointer_type) {
 
 GodotJavaViewWrapper::~GodotJavaViewWrapper() {
 	JNIEnv *env = get_jni_env();
-	ERR_FAIL_COND(env == nullptr);
+	ERR_FAIL_NULL(env);
 
 	env->DeleteGlobalRef(_godot_view);
 	env->DeleteGlobalRef(_cls);

--- a/platform/android/java_godot_view_wrapper.h
+++ b/platform/android/java_godot_view_wrapper.h
@@ -57,4 +57,4 @@ public:
 	~GodotJavaViewWrapper();
 };
 
-#endif //GODOT_JAVA_GODOT_VIEW_WRAPPER_H
+#endif // GODOT_JAVA_GODOT_VIEW_WRAPPER_H

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -96,9 +96,7 @@ jobject GodotJavaWrapper::get_member_object(const char *p_name, const char *p_cl
 		if (p_env == nullptr) {
 			p_env = get_jni_env();
 		}
-
-		ERR_FAIL_COND_V(p_env == nullptr, nullptr);
-
+		ERR_FAIL_NULL_V(p_env, nullptr);
 		jfieldID fid = p_env->GetStaticFieldID(godot_class, p_name, p_class);
 		return p_env->GetStaticObjectField(godot_class, fid);
 	} else {
@@ -109,8 +107,7 @@ jobject GodotJavaWrapper::get_member_object(const char *p_name, const char *p_cl
 jobject GodotJavaWrapper::get_class_loader() {
 	if (_get_class_loader) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, nullptr);
-
+		ERR_FAIL_NULL_V(env, nullptr);
 		return env->CallObjectMethod(activity, _get_class_loader);
 	} else {
 		return nullptr;
@@ -122,8 +119,7 @@ GodotJavaViewWrapper *GodotJavaWrapper::get_godot_view() {
 		return _godot_view;
 	}
 	JNIEnv *env = get_jni_env();
-	ERR_FAIL_COND_V(env == nullptr, nullptr);
-
+	ERR_FAIL_NULL_V(env, nullptr);
 	jmethodID godot_view_getter = env->GetMethodID(godot_class, "getRenderView", "()Lorg/godotengine/godot/GodotRenderView;");
 	_godot_view = new GodotJavaViewWrapper(env->CallObjectMethod(godot_instance, godot_view_getter));
 	return _godot_view;
@@ -134,8 +130,7 @@ void GodotJavaWrapper::on_video_init(JNIEnv *p_env) {
 		if (p_env == nullptr) {
 			p_env = get_jni_env();
 		}
-		ERR_FAIL_COND(p_env == nullptr);
-
+		ERR_FAIL_NULL(p_env);
 		p_env->CallVoidMethod(godot_instance, _on_video_init);
 	}
 }
@@ -154,7 +149,7 @@ void GodotJavaWrapper::on_godot_main_loop_started(JNIEnv *p_env) {
 		if (p_env == nullptr) {
 			p_env = get_jni_env();
 		}
-		ERR_FAIL_COND(p_env == nullptr);
+		ERR_FAIL_NULL(p_env);
 		p_env->CallVoidMethod(godot_instance, _on_godot_main_loop_started);
 	}
 }
@@ -164,8 +159,7 @@ void GodotJavaWrapper::restart(JNIEnv *p_env) {
 		if (p_env == nullptr) {
 			p_env = get_jni_env();
 		}
-		ERR_FAIL_COND(p_env == nullptr);
-
+		ERR_FAIL_NULL(p_env);
 		p_env->CallVoidMethod(godot_instance, _restart);
 	}
 }
@@ -175,8 +169,7 @@ void GodotJavaWrapper::force_quit(JNIEnv *p_env) {
 		if (p_env == nullptr) {
 			p_env = get_jni_env();
 		}
-		ERR_FAIL_COND(p_env == nullptr);
-
+		ERR_FAIL_NULL(p_env);
 		p_env->CallVoidMethod(godot_instance, _finish);
 	}
 }
@@ -184,8 +177,7 @@ void GodotJavaWrapper::force_quit(JNIEnv *p_env) {
 void GodotJavaWrapper::set_keep_screen_on(bool p_enabled) {
 	if (_set_keep_screen_on) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
-
+		ERR_FAIL_NULL(env);
 		env->CallVoidMethod(godot_instance, _set_keep_screen_on, p_enabled);
 	}
 }
@@ -193,8 +185,7 @@ void GodotJavaWrapper::set_keep_screen_on(bool p_enabled) {
 void GodotJavaWrapper::alert(const String &p_message, const String &p_title) {
 	if (_alert) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
-
+		ERR_FAIL_NULL(env);
 		jstring jStrMessage = env->NewStringUTF(p_message.utf8().get_data());
 		jstring jStrTitle = env->NewStringUTF(p_title.utf8().get_data());
 		env->CallVoidMethod(godot_instance, _alert, jStrMessage, jStrTitle);
@@ -203,24 +194,21 @@ void GodotJavaWrapper::alert(const String &p_message, const String &p_title) {
 
 int GodotJavaWrapper::get_gles_version_code() {
 	JNIEnv *env = get_jni_env();
-	ERR_FAIL_COND_V(env == nullptr, 0);
-
+	ERR_FAIL_NULL_V(env, 0);
 	if (_get_GLES_version_code) {
 		return env->CallIntMethod(godot_instance, _get_GLES_version_code);
 	}
-
 	return 0;
 }
 
 bool GodotJavaWrapper::has_get_clipboard() {
-	return _get_clipboard != 0;
+	return _get_clipboard != nullptr;
 }
 
 String GodotJavaWrapper::get_clipboard() {
 	if (_get_clipboard) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
-
+		ERR_FAIL_NULL_V(env, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_instance, _get_clipboard);
 		return jstring_to_string(s, env);
 	} else {
@@ -231,8 +219,7 @@ String GodotJavaWrapper::get_clipboard() {
 String GodotJavaWrapper::get_input_fallback_mapping() {
 	if (_get_input_fallback_mapping) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
-
+		ERR_FAIL_NULL_V(env, String());
 		jstring fallback_mapping = (jstring)env->CallObjectMethod(godot_instance, _get_input_fallback_mapping);
 		return jstring_to_string(fallback_mapping, env);
 	} else {
@@ -241,28 +228,26 @@ String GodotJavaWrapper::get_input_fallback_mapping() {
 }
 
 bool GodotJavaWrapper::has_set_clipboard() {
-	return _set_clipboard != 0;
+	return _set_clipboard != nullptr;
 }
 
 void GodotJavaWrapper::set_clipboard(const String &p_text) {
 	if (_set_clipboard) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
-
+		ERR_FAIL_NULL(env);
 		jstring jStr = env->NewStringUTF(p_text.utf8().get_data());
 		env->CallVoidMethod(godot_instance, _set_clipboard, jStr);
 	}
 }
 
 bool GodotJavaWrapper::has_has_clipboard() {
-	return _has_clipboard != 0;
+	return _has_clipboard != nullptr;
 }
 
 bool GodotJavaWrapper::has_clipboard() {
 	if (_has_clipboard) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, false);
-
+		ERR_FAIL_NULL_V(env, false);
 		return env->CallBooleanMethod(godot_instance, _has_clipboard);
 	} else {
 		return false;
@@ -272,8 +257,7 @@ bool GodotJavaWrapper::has_clipboard() {
 bool GodotJavaWrapper::request_permission(const String &p_name) {
 	if (_request_permission) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, false);
-
+		ERR_FAIL_NULL_V(env, false);
 		jstring jStrName = env->NewStringUTF(p_name.utf8().get_data());
 		return env->CallBooleanMethod(godot_instance, _request_permission, jStrName);
 	} else {
@@ -284,8 +268,7 @@ bool GodotJavaWrapper::request_permission(const String &p_name) {
 bool GodotJavaWrapper::request_permissions() {
 	if (_request_permissions) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, false);
-
+		ERR_FAIL_NULL_V(env, false);
 		return env->CallBooleanMethod(godot_instance, _request_permissions);
 	} else {
 		return false;
@@ -296,14 +279,12 @@ Vector<String> GodotJavaWrapper::get_granted_permissions() const {
 	Vector<String> permissions_list;
 	if (_get_granted_permissions) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, permissions_list);
-
+		ERR_FAIL_NULL_V(env, permissions_list);
 		jobject permissions_object = env->CallObjectMethod(godot_instance, _get_granted_permissions);
 		jobjectArray *arr = reinterpret_cast<jobjectArray *>(&permissions_object);
 
-		int i = 0;
 		jsize len = env->GetArrayLength(*arr);
-		for (i = 0; i < len; i++) {
+		for (int i = 0; i < len; i++) {
 			jstring jstr = (jstring)env->GetObjectArrayElement(*arr, i);
 			String str = jstring_to_string(jstr, env);
 			permissions_list.push_back(str);
@@ -316,8 +297,7 @@ Vector<String> GodotJavaWrapper::get_granted_permissions() const {
 void GodotJavaWrapper::init_input_devices() {
 	if (_init_input_devices) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
-
+		ERR_FAIL_NULL(env);
 		env->CallVoidMethod(godot_instance, _init_input_devices);
 	}
 }
@@ -325,8 +305,7 @@ void GodotJavaWrapper::init_input_devices() {
 jobject GodotJavaWrapper::get_surface() {
 	if (_get_surface) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, nullptr);
-
+		ERR_FAIL_NULL_V(env, nullptr);
 		return env->CallObjectMethod(godot_instance, _get_surface);
 	} else {
 		return nullptr;
@@ -336,8 +315,7 @@ jobject GodotJavaWrapper::get_surface() {
 bool GodotJavaWrapper::is_activity_resumed() {
 	if (_is_activity_resumed) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, false);
-
+		ERR_FAIL_NULL_V(env, false);
 		return env->CallBooleanMethod(godot_instance, _is_activity_resumed);
 	} else {
 		return false;
@@ -347,8 +325,7 @@ bool GodotJavaWrapper::is_activity_resumed() {
 void GodotJavaWrapper::vibrate(int p_duration_ms) {
 	if (_vibrate) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
-
+		ERR_FAIL_NULL(env);
 		env->CallVoidMethod(godot_instance, _vibrate, p_duration_ms);
 	}
 }
@@ -356,8 +333,7 @@ void GodotJavaWrapper::vibrate(int p_duration_ms) {
 void GodotJavaWrapper::create_new_godot_instance(List<String> args) {
 	if (_create_new_godot_instance) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
-
+		ERR_FAIL_NULL(env);
 		jobjectArray jargs = env->NewObjectArray(args.size(), env->FindClass("java/lang/String"), env->NewStringUTF(""));
 		for (int i = 0; i < args.size(); i++) {
 			env->SetObjectArrayElement(jargs, i, env->NewStringUTF(args[i].utf8().get_data()));

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -51,27 +51,27 @@ private:
 
 	GodotJavaViewWrapper *_godot_view = nullptr;
 
-	jmethodID _on_video_init = 0;
-	jmethodID _restart = 0;
-	jmethodID _finish = 0;
-	jmethodID _set_keep_screen_on = 0;
-	jmethodID _alert = 0;
-	jmethodID _get_GLES_version_code = 0;
-	jmethodID _get_clipboard = 0;
-	jmethodID _set_clipboard = 0;
-	jmethodID _has_clipboard = 0;
-	jmethodID _request_permission = 0;
-	jmethodID _request_permissions = 0;
-	jmethodID _get_granted_permissions = 0;
-	jmethodID _init_input_devices = 0;
-	jmethodID _get_surface = 0;
-	jmethodID _is_activity_resumed = 0;
-	jmethodID _vibrate = 0;
-	jmethodID _get_input_fallback_mapping = 0;
-	jmethodID _on_godot_setup_completed = 0;
-	jmethodID _on_godot_main_loop_started = 0;
-	jmethodID _get_class_loader = 0;
-	jmethodID _create_new_godot_instance = 0;
+	jmethodID _on_video_init = nullptr;
+	jmethodID _restart = nullptr;
+	jmethodID _finish = nullptr;
+	jmethodID _set_keep_screen_on = nullptr;
+	jmethodID _alert = nullptr;
+	jmethodID _get_GLES_version_code = nullptr;
+	jmethodID _get_clipboard = nullptr;
+	jmethodID _set_clipboard = nullptr;
+	jmethodID _has_clipboard = nullptr;
+	jmethodID _request_permission = nullptr;
+	jmethodID _request_permissions = nullptr;
+	jmethodID _get_granted_permissions = nullptr;
+	jmethodID _init_input_devices = nullptr;
+	jmethodID _get_surface = nullptr;
+	jmethodID _is_activity_resumed = nullptr;
+	jmethodID _vibrate = nullptr;
+	jmethodID _get_input_fallback_mapping = nullptr;
+	jmethodID _on_godot_setup_completed = nullptr;
+	jmethodID _on_godot_main_loop_started = nullptr;
+	jmethodID _get_class_loader = nullptr;
+	jmethodID _create_new_godot_instance = nullptr;
 
 public:
 	GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_godot_instance);
@@ -108,4 +108,4 @@ public:
 	void create_new_godot_instance(List<String> args);
 };
 
-#endif /* !JAVA_GODOT_WRAPPER_H */
+#endif // JAVA_GODOT_WRAPPER_H

--- a/platform/android/jni_utils.cpp
+++ b/platform/android/jni_utils.cpp
@@ -123,10 +123,10 @@ jvalret _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_a
 
 			for (int j = 0; j < keys.size(); j++) {
 				Variant var = dict[keys[j]];
-				jvalret v = _variant_to_jvalue(env, var.get_type(), &var, true);
-				env->SetObjectArrayElement(jvalues, j, v.val.l);
-				if (v.obj) {
-					env->DeleteLocalRef(v.obj);
+				jvalret valret = _variant_to_jvalue(env, var.get_type(), &var, true);
+				env->SetObjectArrayElement(jvalues, j, valret.val.l);
+				if (valret.obj) {
+					env->DeleteLocalRef(valret.obj);
 				}
 			}
 
@@ -186,7 +186,7 @@ String _get_class_name(JNIEnv *env, jclass cls, bool *array) {
 	if (array) {
 		jmethodID isArray = env->GetMethodID(cclass, "isArray", "()Z");
 		jboolean isarr = env->CallBooleanMethod(cls, isArray);
-		(*array) = isarr ? true : false;
+		(*array) = isarr != 0;
 	}
 	String name = jstring_to_string(clsName, env);
 	env->DeleteLocalRef(clsName);

--- a/platform/android/net_socket_android.cpp
+++ b/platform/android/net_socket_android.cpp
@@ -32,10 +32,10 @@
 
 #include "thread_jandroid.h"
 
-jobject NetSocketAndroid::net_utils = 0;
-jclass NetSocketAndroid::cls = 0;
-jmethodID NetSocketAndroid::_multicast_lock_acquire = 0;
-jmethodID NetSocketAndroid::_multicast_lock_release = 0;
+jobject NetSocketAndroid::net_utils = nullptr;
+jclass NetSocketAndroid::cls = nullptr;
+jmethodID NetSocketAndroid::_multicast_lock_acquire = nullptr;
+jmethodID NetSocketAndroid::_multicast_lock_release = nullptr;
 
 void NetSocketAndroid::setup(jobject p_net_utils) {
 	JNIEnv *env = get_jni_env();

--- a/platform/android/net_socket_android.h
+++ b/platform/android/net_socket_android.h
@@ -74,4 +74,4 @@ public:
 	~NetSocketAndroid();
 };
 
-#endif
+#endif // NET_SOCKET_ANDROID_H

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -76,9 +76,7 @@ public:
 };
 
 void OS_Android::alert(const String &p_alert, const String &p_title) {
-	GodotJavaWrapper *godot_java = OS_Android::get_singleton()->get_godot_java();
-	ERR_FAIL_COND(!godot_java);
-
+	ERR_FAIL_NULL(godot_java);
 	godot_java->alert(p_alert, p_title);
 }
 
@@ -106,7 +104,6 @@ void OS_Android::initialize_core() {
 		DirAccess::make_default<DirAccessJAndroid>(DirAccess::ACCESS_RESOURCES);
 	}
 #endif
-
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_USERDATA);
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_FILESYSTEM);
 
@@ -164,7 +161,7 @@ Vector<String> OS_Android::get_granted_permissions() const {
 
 Error OS_Android::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path, String *r_resolved_path) {
 	p_library_handle = dlopen(p_path.utf8().get_data(), RTLD_NOW);
-	ERR_FAIL_COND_V_MSG(!p_library_handle, ERR_CANT_OPEN, "Can't open dynamic library: " + p_path + ", error: " + dlerror() + ".");
+	ERR_FAIL_NULL_V_MSG(p_library_handle, ERR_CANT_OPEN, "Can't open dynamic library: " + p_path + ", error: " + dlerror() + ".");
 
 	if (r_resolved_path != nullptr) {
 		*r_resolved_path = p_path;
@@ -313,7 +310,7 @@ Size2i OS_Android::get_display_size() const {
 
 void OS_Android::set_opengl_extensions(const char *p_gl_extensions) {
 #if defined(GLES3_ENABLED)
-	ERR_FAIL_COND(!p_gl_extensions);
+	ERR_FAIL_NULL(p_gl_extensions);
 	gl_extensions = p_gl_extensions;
 #endif
 }

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -135,4 +135,4 @@ public:
 	~OS_Android();
 };
 
-#endif
+#endif // OS_ANDROID_H

--- a/platform/android/plugin/godot_plugin_jni.cpp
+++ b/platform/android/plugin/godot_plugin_jni.cpp
@@ -123,7 +123,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeEmitS
 		variant_params[i] = _jobject_to_variant(env, j_param);
 		args[i] = &variant_params[i];
 		env->DeleteLocalRef(j_param);
-	};
+	}
 
 	singleton->emit_signalp(StringName(signal_name), args, count);
 }

--- a/platform/android/string_android.h
+++ b/platform/android/string_android.h
@@ -30,6 +30,7 @@
 
 #ifndef STRING_ANDROID_H
 #define STRING_ANDROID_H
+
 #include "core/string/ustring.h"
 #include "thread_jandroid.h"
 #include <jni.h>

--- a/platform/android/thread_jandroid.h
+++ b/platform/android/thread_jandroid.h
@@ -38,4 +38,4 @@ void init_thread_jandroid(JavaVM *p_jvm, JNIEnv *p_env);
 void setup_android_thread();
 JNIEnv *get_jni_env();
 
-#endif
+#endif // THREAD_JANDROID_H

--- a/platform/android/tts_android.cpp
+++ b/platform/android/tts_android.cpp
@@ -35,16 +35,16 @@
 #include "string_android.h"
 #include "thread_jandroid.h"
 
-jobject TTS_Android::tts = 0;
-jclass TTS_Android::cls = 0;
+jobject TTS_Android::tts = nullptr;
+jclass TTS_Android::cls = nullptr;
 
-jmethodID TTS_Android::_is_speaking = 0;
-jmethodID TTS_Android::_is_paused = 0;
-jmethodID TTS_Android::_get_voices = 0;
-jmethodID TTS_Android::_speak = 0;
-jmethodID TTS_Android::_pause_speaking = 0;
-jmethodID TTS_Android::_resume_speaking = 0;
-jmethodID TTS_Android::_stop_speaking = 0;
+jmethodID TTS_Android::_is_speaking = nullptr;
+jmethodID TTS_Android::_is_paused = nullptr;
+jmethodID TTS_Android::_get_voices = nullptr;
+jmethodID TTS_Android::_speak = nullptr;
+jmethodID TTS_Android::_pause_speaking = nullptr;
+jmethodID TTS_Android::_resume_speaking = nullptr;
+jmethodID TTS_Android::_stop_speaking = nullptr;
 
 HashMap<int, Char16String> TTS_Android::ids;
 


### PR DESCRIPTION
Cleans up the Android C++ code including:
- Remove dead code
- Use `ERR_FAIL_NULL(x)` instead of `ERR_FAIL_COND(x == nullptr)`
- Use `nullptr` instead of `NULL` or `0`
- Add missing header protector
- Rename variables shadowing other variables
