### PR TITLE
[3.x] Cleanup Android C++ code

### DIFF
--- a/platform/android/android_input_handler.cpp
+++ b/platform/android/android_input_handler.cpp
@@ -154,8 +154,9 @@ void AndroidInputHandler::process_touch(int p_event, int p_pointer, const Vector
 
 				ERR_CONTINUE(idx == -1);
 
-				if (touch[i].pos == p_points[idx].pos)
+				if (touch[i].pos == p_points[idx].pos) {
 					continue; //no move unncesearily
+				}
 
 				Ref<InputEventScreenDrag> ev;
 				ev.instance();

--- a/platform/android/android_input_handler.h
+++ b/platform/android/android_input_handler.h
@@ -93,4 +93,4 @@ public:
 	void joy_connection_changed(int p_device, bool p_connected, String p_name);
 };
 
-#endif
+#endif // ANDROID_INPUT_HANDLER_H

--- a/platform/android/api/jni_singleton.h
+++ b/platform/android/api/jni_singleton.h
@@ -73,7 +73,7 @@ public:
 			return Object::call(p_method, p_args, p_argcount, r_error);
 		}
 
-		ERR_FAIL_COND_V(!instance, Variant());
+		ERR_FAIL_NULL_V(instance, Variant());
 
 		r_error.error = Variant::CallError::CALL_OK;
 

--- a/platform/android/audio_driver_opensl.cpp
+++ b/platform/android/audio_driver_opensl.cpp
@@ -56,8 +56,9 @@ void AudioDriverOpenSL::_buffer_callback(
 		}
 	}
 
-	if (mix)
+	if (mix) {
 		mutex.unlock();
+	}
 
 	const int32_t *src_buff = mixdown_buffer;
 
@@ -79,8 +80,6 @@ void AudioDriverOpenSL::_buffer_callbacks(
 	ad->_buffer_callback(queueItf);
 }
 
-AudioDriverOpenSL *AudioDriverOpenSL::s_ad = NULL;
-
 const char *AudioDriverOpenSL::get_name() const {
 	return "Android";
 }
@@ -90,7 +89,7 @@ Error AudioDriverOpenSL::init() {
 	SLEngineOption EngineOption[] = {
 		{ (SLuint32)SL_ENGINEOPTION_THREADSAFE, (SLuint32)SL_BOOLEAN_TRUE }
 	};
-	res = slCreateEngine(&sl, 1, EngineOption, 0, NULL, NULL);
+	res = slCreateEngine(&sl, 1, EngineOption, 0, nullptr, nullptr);
 	ERR_FAIL_COND_V_MSG(res != SL_RESULT_SUCCESS, ERR_INVALID_PARAMETER, "Could not initialize OpenSL.");
 
 	res = (*sl)->Realize(sl, SL_BOOLEAN_FALSE);
@@ -132,8 +131,6 @@ void AudioDriverOpenSL::start() {
 	ERR_FAIL_COND(res != SL_RESULT_SUCCESS);
 
 	SLDataLocator_AndroidSimpleBufferQueue loc_bufq = { SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE, BUFFER_COUNT };
-	//bufferQueue.locatorType = SL_DATALOCATOR_BUFFERQUEUE;
-	//bufferQueue.numBuffers = BUFFER_COUNT; /* Four buffers in our buffer queue */
 	/* Setup the format of the content in the buffer queue */
 	pcm.formatType = SL_DATAFORMAT_PCM;
 	pcm.numChannels = 2;
@@ -153,14 +150,9 @@ void AudioDriverOpenSL::start() {
 	locator_outputmix.locatorType = SL_DATALOCATOR_OUTPUTMIX;
 	locator_outputmix.outputMix = OutputMix;
 	audioSink.pLocator = (void *)&locator_outputmix;
-	audioSink.pFormat = NULL;
-	/* Initialize the context for Buffer queue callbacks */
-	//cntxt.pDataBase = (void*)&pcmData;
-	//cntxt.pData = cntxt.pDataBase;
-	//cntxt.size = sizeof(pcmData);
+	audioSink.pFormat = nullptr;
 
 	/* Create the music player */
-
 	{
 		const SLInterfaceID ids[2] = { SL_IID_BUFFERQUEUE, SL_IID_EFFECTSEND };
 		const SLboolean req[2] = { SL_BOOLEAN_TRUE, SL_BOOLEAN_TRUE };
@@ -217,9 +209,9 @@ Error AudioDriverOpenSL::capture_init_device() {
 		SL_DATALOCATOR_IODEVICE,
 		SL_IODEVICE_AUDIOINPUT,
 		SL_DEFAULTDEVICEID_AUDIOINPUT,
-		NULL
+		nullptr
 	};
-	SLDataSource recSource = { &loc_dev, NULL };
+	SLDataSource recSource = { &loc_dev, nullptr };
 
 	SLDataLocator_AndroidSimpleBufferQueue loc_bq = {
 		SL_DATALOCATOR_ANDROIDSIMPLEBUFFERQUEUE,
@@ -312,13 +304,15 @@ AudioDriver::SpeakerMode AudioDriverOpenSL::get_speaker_mode() const {
 }
 
 void AudioDriverOpenSL::lock() {
-	if (active)
+	if (active) {
 		mutex.lock();
+	}
 }
 
 void AudioDriverOpenSL::unlock() {
-	if (active)
+	if (active) {
 		mutex.unlock();
+	}
 }
 
 void AudioDriverOpenSL::finish() {
@@ -338,7 +332,4 @@ void AudioDriverOpenSL::set_pause(bool p_pause) {
 }
 
 AudioDriverOpenSL::AudioDriverOpenSL() {
-	s_ad = this;
-	pause = false;
-	active = false;
 }

--- a/platform/android/audio_driver_opensl.h
+++ b/platform/android/audio_driver_opensl.h
@@ -38,15 +38,14 @@
 #include <SLES/OpenSLES_Android.h>
 
 class AudioDriverOpenSL : public AudioDriver {
-	bool active;
+	bool active = false;
 	Mutex mutex;
 
 	enum {
-
 		BUFFER_COUNT = 2
 	};
 
-	bool pause;
+	bool pause = false;
 
 	uint32_t buffer_size;
 	int16_t *buffers[BUFFER_COUNT];
@@ -106,4 +105,4 @@ public:
 	AudioDriverOpenSL();
 };
 
-#endif // AUDIO_DRIVER_ANDROID_H
+#endif // AUDIO_DRIVER_OPENSL_H

--- a/platform/android/dir_access_jandroid.h
+++ b/platform/android/dir_access_jandroid.h
@@ -36,8 +36,6 @@
 #include <stdio.h>
 
 class DirAccessJAndroid : public DirAccess {
-	//AAssetDir* aad;
-
 	static jobject io;
 	static jclass cls;
 
@@ -46,7 +44,7 @@ class DirAccessJAndroid : public DirAccess {
 	static jmethodID _dir_close;
 	static jmethodID _dir_is_dir;
 
-	int id;
+	int id = 0;
 
 	String current_dir;
 	String current;

--- a/platform/android/export/export.cpp
+++ b/platform/android/export/export.cpp
@@ -33,11 +33,6 @@
 #include "export_plugin.h"
 
 void register_android_exporter() {
-	String exe_ext;
-	if (OS::get_singleton()->get_name() == "Windows") {
-		exe_ext = "*.exe";
-	}
-
 	EDITOR_DEF("export/android/android_sdk_path", "");
 	EditorSettings::get_singleton()->add_property_hint(PropertyInfo(Variant::STRING, "export/android/android_sdk_path", PROPERTY_HINT_GLOBAL_DIR));
 	EDITOR_DEF("export/android/debug_keystore", "");

--- a/platform/android/export/export_plugin.cpp
+++ b/platform/android/export/export_plugin.cpp
@@ -506,8 +506,8 @@ bool EditorExportPlatformAndroid::is_package_name_valid(const String &p_package,
 
 bool EditorExportPlatformAndroid::_should_compress_asset(const String &p_path, const Vector<uint8_t> &p_data) {
 	/*
-	 *  By not compressing files with little or not benefit in doing so,
-	 *  a performance gain is expected attime. Moreover, if the APK is
+	 *  By not compressing files with little or no benefit in doing so,
+	 *  a performance gain is expected at runtime. Moreover, if the APK is
 	 *  zip-aligned, assets stored as they are can be efficiently read by
 	 *  Android by memory-mapping them.
 	 */
@@ -817,11 +817,9 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 	uint32_t ofs = 8;
 
 	uint32_t string_count = 0;
-	//uint32_t styles_count = 0;
 	uint32_t string_flags = 0;
 	uint32_t string_data_offset = 0;
 
-	//uint32_t styles_offset = 0;
 	uint32_t string_table_begins = 0;
 	uint32_t string_table_ends = 0;
 	Vector<uint8_t> stable_extra;
@@ -864,10 +862,8 @@ void EditorExportPlatformAndroid::_fix_manifest(const Ref<EditorExportPreset> &p
 				int iofs = ofs + 8;
 
 				string_count = decode_uint32(&p_manifest[iofs]);
-				// iofs + 4 is `styles_count`.
 				string_flags = decode_uint32(&p_manifest[iofs + 8]);
 				string_data_offset = decode_uint32(&p_manifest[iofs + 12]);
-				// iofs + 16 is `styles_offset`.
 
 				uint32_t st_offset = iofs + 20;
 				string_table.resize(string_count);
@@ -1862,7 +1858,8 @@ Error EditorExportPlatformAndroid::run(const Ref<EditorExportPreset> &p_preset, 
 		DirAccess::remove_file_or_error(tmp_export_path); \
 		device_lock.unlock();                             \
 		return m_err;                                     \
-	}
+	}                                                     \
+	((void)0)
 
 	// Export to temporary APK before sending to device.
 	Error err = export_project_helper(p_preset, true, tmp_export_path, EXPORT_FORMAT_APK, true, p_debug_flags);
@@ -3107,7 +3104,8 @@ Error EditorExportPlatformAndroid::export_project_helper(const Ref<EditorExportP
 	{                                                        \
 		DirAccess::remove_file_or_error(tmp_unaligned_path); \
 		return m_err;                                        \
-	}
+	}                                                        \
+	((void)0)
 
 	zipFile unaligned_apk = zipOpen2(tmp_unaligned_path.utf8().get_data(), APPEND_STATUS_CREATE, nullptr, &io2);
 

--- a/platform/android/export/export_plugin.h
+++ b/platform/android/export/export_plugin.h
@@ -28,6 +28,9 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
+#ifndef ANDROID_EXPORT_PLUGIN_H
+#define ANDROID_EXPORT_PLUGIN_H
+
 #include "core/io/image_loader.h"
 #include "core/io/json.h"
 #include "core/io/marshalls.h"
@@ -254,3 +257,5 @@ public:
 
 	~EditorExportPlatformAndroid();
 };
+
+#endif // ANDROID_EXPORT_PLUGIN_H

--- a/platform/android/export/godot_plugin_config.cpp
+++ b/platform/android/export/godot_plugin_config.cpp
@@ -89,7 +89,6 @@ PluginConfigAndroid PluginConfigAndroid::resolve_prebuilt_plugin(PluginConfigAnd
 
 Vector<PluginConfigAndroid> PluginConfigAndroid::get_prebuilt_plugins(String plugins_base_dir) {
 	Vector<PluginConfigAndroid> prebuilt_plugins;
-	// prebuilt_plugins.push_back(resolve_prebuilt_plugin(MY_PREBUILT_PLUGIN, plugins_base_dir));
 	return prebuilt_plugins;
 }
 

--- a/platform/android/export/gradle_export_util.h
+++ b/platform/android/export/gradle_export_util.h
@@ -107,4 +107,4 @@ String _get_activity_tag(const Ref<EditorExportPreset> &p_preset);
 
 String _get_application_tag(const Ref<EditorExportPreset> &p_preset, bool p_has_storage_permission);
 
-#endif //GODOT_GRADLE_EXPORT_UTIL_H
+#endif // GODOT_GRADLE_EXPORT_UTIL_H

--- a/platform/android/file_access_android.cpp
+++ b/platform/android/file_access_android.cpp
@@ -31,12 +31,7 @@
 #include "file_access_android.h"
 #include "core/print_string.h"
 
-AAssetManager *FileAccessAndroid::asset_manager = NULL;
-
-/*void FileAccessAndroid::make_default() {
-
-	create_func=create_android;
-}*/
+AAssetManager *FileAccessAndroid::asset_manager = nullptr;
 
 FileAccess *FileAccessAndroid::create_android() {
 	return memnew(FileAccessAndroid);
@@ -44,17 +39,18 @@ FileAccess *FileAccessAndroid::create_android() {
 
 Error FileAccessAndroid::_open(const String &p_path, int p_mode_flags) {
 	String path = fix_path(p_path).simplify_path();
-	if (path.begins_with("/"))
+	if (path.begins_with("/")) {
 		path = path.substr(1, path.length());
-	else if (path.begins_with("res://"))
+	} else if (path.begins_with("res://")) {
 		path = path.substr(6, path.length());
+	}
 
 	ERR_FAIL_COND_V(p_mode_flags & FileAccess::WRITE, ERR_UNAVAILABLE); //can't write on android..
-	a = AAssetManager_open(asset_manager, path.utf8().get_data(), AASSET_MODE_STREAMING);
-	if (!a)
+	asset = AAssetManager_open(asset_manager, path.utf8().get_data(), AASSET_MODE_STREAMING);
+	if (!asset) {
 		return ERR_CANT_OPEN;
-	//ERR_FAIL_COND_V(!a,ERR_FILE_NOT_FOUND);
-	len = AAsset_getLength(a);
+	}
+	len = AAsset_getLength(asset);
 	pos = 0;
 	eof = false;
 
@@ -62,20 +58,21 @@ Error FileAccessAndroid::_open(const String &p_path, int p_mode_flags) {
 }
 
 void FileAccessAndroid::close() {
-	if (!a)
+	if (!asset) {
 		return;
-	AAsset_close(a);
-	a = NULL;
+	}
+	AAsset_close(asset);
+	asset = nullptr;
 }
 
 bool FileAccessAndroid::is_open() const {
-	return a != NULL;
+	return asset != nullptr;
 }
 
 void FileAccessAndroid::seek(uint64_t p_position) {
-	ERR_FAIL_COND(!a);
+	ERR_FAIL_NULL(asset);
 
-	AAsset_seek(a, p_position, SEEK_SET);
+	AAsset_seek(asset, p_position, SEEK_SET);
 	pos = p_position;
 	if (pos > len) {
 		pos = len;
@@ -86,8 +83,8 @@ void FileAccessAndroid::seek(uint64_t p_position) {
 }
 
 void FileAccessAndroid::seek_end(int64_t p_position) {
-	ERR_FAIL_COND(!a);
-	AAsset_seek(a, p_position, SEEK_END);
+	ERR_FAIL_NULL(asset);
+	AAsset_seek(asset, p_position, SEEK_END);
 	pos = len + p_position;
 }
 
@@ -110,7 +107,7 @@ uint8_t FileAccessAndroid::get_8() const {
 	}
 
 	uint8_t byte;
-	AAsset_read(a, &byte, 1);
+	AAsset_read(asset, &byte, 1);
 	pos++;
 	return byte;
 }
@@ -118,7 +115,7 @@ uint8_t FileAccessAndroid::get_8() const {
 uint64_t FileAccessAndroid::get_buffer(uint8_t *p_dst, uint64_t p_length) const {
 	ERR_FAIL_COND_V(!p_dst && p_length > 0, -1);
 
-	int r = AAsset_read(a, p_dst, p_length);
+	int r = AAsset_read(asset, p_dst, p_length);
 
 	if (pos + p_length > len) {
 		eof = true;
@@ -147,23 +144,19 @@ void FileAccessAndroid::store_8(uint8_t p_dest) {
 
 bool FileAccessAndroid::file_exists(const String &p_path) {
 	String path = fix_path(p_path).simplify_path();
-	if (path.begins_with("/"))
+	if (path.begins_with("/")) {
 		path = path.substr(1, path.length());
-	else if (path.begins_with("res://"))
+	} else if (path.begins_with("res://")) {
 		path = path.substr(6, path.length());
-
+	}
 	AAsset *at = AAssetManager_open(asset_manager, path.utf8().get_data(), AASSET_MODE_STREAMING);
 
-	if (!at)
+	if (!at) {
 		return false;
+	}
 
 	AAsset_close(at);
 	return true;
-}
-
-FileAccessAndroid::FileAccessAndroid() {
-	a = NULL;
-	eof = false;
 }
 
 FileAccessAndroid::~FileAccessAndroid() {

--- a/platform/android/file_access_android.h
+++ b/platform/android/file_access_android.h
@@ -35,46 +35,43 @@
 #include <android/asset_manager.h>
 #include <android/log.h>
 #include <stdio.h>
-//#include <android_native_app_glue.h>
 
 class FileAccessAndroid : public FileAccess {
 	static FileAccess *create_android();
-	mutable AAsset *a;
-	mutable uint64_t len;
-	mutable uint64_t pos;
-	mutable bool eof;
+	mutable AAsset *asset = nullptr;
+	mutable uint64_t len = 0;
+	mutable uint64_t pos = 0;
+	mutable bool eof = false;
+	;
 
 public:
 	static AAssetManager *asset_manager;
 
-	virtual Error _open(const String &p_path, int p_mode_flags); ///< open a file
-	virtual void close(); ///< close a file
-	virtual bool is_open() const; ///< true when file is open
+	virtual Error _open(const String &p_path, int p_mode_flags); // open a file
+	virtual void close(); // close a file
+	virtual bool is_open() const; // true when file is open
 
-	virtual void seek(uint64_t p_position); ///< seek to a given position
-	virtual void seek_end(int64_t p_position = 0); ///< seek from the end of file
-	virtual uint64_t get_position() const; ///< get position in the file
-	virtual uint64_t get_len() const; ///< get size of the file
+	virtual void seek(uint64_t p_position); // seek to a given position
+	virtual void seek_end(int64_t p_position = 0); // seek from the end of file
+	virtual uint64_t get_position() const; // get position in the file
+	virtual uint64_t get_len() const; // get size of the file
 
-	virtual bool eof_reached() const; ///< reading passed EOF
+	virtual bool eof_reached() const; // reading passed EOF
 
-	virtual uint8_t get_8() const; ///< get a byte
+	virtual uint8_t get_8() const; // get a byte
 	virtual uint64_t get_buffer(uint8_t *p_dst, uint64_t p_length) const;
 
-	virtual Error get_error() const; ///< get last error
+	virtual Error get_error() const; // get last error
 
 	virtual void flush();
-	virtual void store_8(uint8_t p_dest); ///< store a byte
+	virtual void store_8(uint8_t p_dest); // store a byte
 
-	virtual bool file_exists(const String &p_path); ///< return true if a file exists
+	virtual bool file_exists(const String &p_path); // return true if a file exists
 
 	virtual uint64_t _get_modified_time(const String &p_file) { return 0; }
 	virtual uint32_t _get_unix_permissions(const String &p_file) { return 0; }
 	virtual Error _set_unix_permissions(const String &p_file, uint32_t p_permissions) { return FAILED; }
 
-	//static void make_default();
-
-	FileAccessAndroid();
 	~FileAccessAndroid();
 };
 

--- a/platform/android/java_class_wrapper.cpp
+++ b/platform/android/java_class_wrapper.cpp
@@ -34,13 +34,14 @@
 
 bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error, Variant &ret) {
 	Map<StringName, List<MethodInfo>>::Element *M = methods.find(p_method);
-	if (!M)
+	if (!M) {
 		return false;
+	}
 
 	JNIEnv *env = get_jni_env();
-	ERR_FAIL_COND_V(env == nullptr, false);
+	ERR_FAIL_NULL_V(env, false);
 
-	MethodInfo *method = NULL;
+	MethodInfo *method = nullptr;
 	for (List<MethodInfo>::Element *E = M->get().front(); E; E = E->next()) {
 		if (!p_instance && !E->get()._static) {
 			r_error.error = Variant::CallError::CALL_ERROR_INSTANCE_IS_NULL;
@@ -68,8 +69,9 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 					//bug?
 				} break;
 				case ARG_TYPE_BOOLEAN: {
-					if (p_args[i]->get_type() != Variant::BOOL)
+					if (p_args[i]->get_type() != Variant::BOOL) {
 						arg_expected = Variant::BOOL;
+					}
 				} break;
 				case ARG_NUMBER_CLASS_BIT | ARG_TYPE_BYTE:
 				case ARG_NUMBER_CLASS_BIT | ARG_TYPE_CHAR:
@@ -81,27 +83,27 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 				case ARG_TYPE_SHORT:
 				case ARG_TYPE_INT:
 				case ARG_TYPE_LONG: {
-					if (!p_args[i]->is_num())
+					if (!p_args[i]->is_num()) {
 						arg_expected = Variant::INT;
-
+					}
 				} break;
 				case ARG_NUMBER_CLASS_BIT | ARG_TYPE_FLOAT:
 				case ARG_NUMBER_CLASS_BIT | ARG_TYPE_DOUBLE:
 				case ARG_TYPE_FLOAT:
 				case ARG_TYPE_DOUBLE: {
-					if (!p_args[i]->is_num())
+					if (!p_args[i]->is_num()) {
 						arg_expected = Variant::REAL;
-
+					}
 				} break;
 				case ARG_TYPE_STRING: {
-					if (p_args[i]->get_type() != Variant::STRING)
+					if (p_args[i]->get_type() != Variant::STRING) {
 						arg_expected = Variant::STRING;
-
+					}
 				} break;
 				case ARG_TYPE_CLASS: {
-					if (p_args[i]->get_type() != Variant::OBJECT)
+					if (p_args[i]->get_type() != Variant::OBJECT) {
 						arg_expected = Variant::OBJECT;
-					else {
+					} else {
 						Ref<Reference> ref = *p_args[i];
 						if (!ref.is_null()) {
 							if (Object::cast_to<JavaObject>(ref.ptr())) {
@@ -121,9 +123,9 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 
 				} break;
 				default: {
-					if (p_args[i]->get_type() != Variant::ARRAY)
+					if (p_args[i]->get_type() != Variant::ARRAY) {
 						arg_expected = Variant::ARRAY;
-
+					}
 				} break;
 			}
 
@@ -135,19 +137,21 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 				break;
 			}
 		}
-		if (!valid)
+		if (!valid) {
 			continue;
+		}
 
 		method = &E->get();
 		break;
 	}
 
-	if (!method)
+	if (!method) {
 		return true; //no version convinces
+	}
 
 	r_error.error = Variant::CallError::CALL_OK;
 
-	jvalue *argv = NULL;
+	jvalue *argv = nullptr;
 
 	if (method->param_types.size()) {
 		argv = (jvalue *)alloca(sizeof(jvalue) * method->param_types.size());
@@ -158,7 +162,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 		switch (method->param_types[i]) {
 			case ARG_TYPE_VOID: {
 				//can't happen
-				argv[i].l = NULL; //I hope this works
+				argv[i].l = nullptr; //I hope this works
 			} break;
 
 			case ARG_TYPE_BOOLEAN: {
@@ -268,7 +272,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 				if (jo.is_valid()) {
 					argv[i].l = jo->instance;
 				} else {
-					argv[i].l = NULL; //I hope this works
+					argv[i].l = nullptr; //I hope this works
 				}
 
 			} break;
@@ -361,7 +365,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 			} break;
 			case ARG_ARRAY_BIT | ARG_TYPE_STRING: {
 				Array arr = *p_args[i];
-				jobjectArray a = env->NewObjectArray(arr.size(), env->FindClass("java/lang/String"), NULL);
+				jobjectArray a = env->NewObjectArray(arr.size(), env->FindClass("java/lang/String"), nullptr);
 				for (int j = 0; j < arr.size(); j++) {
 					String s = arr[j];
 					jstring jStr = env->NewStringUTF(s.utf8().get_data());
@@ -373,7 +377,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 				to_free.push_back(a);
 			} break;
 			case ARG_ARRAY_BIT | ARG_TYPE_CLASS: {
-				argv[i].l = NULL;
+				argv[i].l = nullptr;
 			} break;
 		}
 	}
@@ -483,7 +487,7 @@ bool JavaClass::_call_method(JavaObject *p_instance, const StringName &p_method,
 
 Variant JavaClass::call(const StringName &p_method, const Variant **p_args, int p_argcount, Variant::CallError &r_error) {
 	Variant ret;
-	bool found = _call_method(NULL, p_method, p_args, p_argcount, r_error, ret);
+	bool found = _call_method(nullptr, p_method, p_args, p_argcount, r_error, ret);
 	if (found) {
 		return ret;
 	}
@@ -780,9 +784,9 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 
 			for (int i = 0; i < count; i++) {
 				jobject o = env->GetObjectArrayElement(arr, i);
-				if (!o)
+				if (!o) {
 					ret.push_back(Variant());
-				else {
+				} else {
 					bool val = env->CallBooleanMethod(o, JavaClassWrapper::singleton->Boolean_booleanValue);
 					ret.push_back(val);
 				}
@@ -801,9 +805,9 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 
 			for (int i = 0; i < count; i++) {
 				jobject o = env->GetObjectArrayElement(arr, i);
-				if (!o)
+				if (!o) {
 					ret.push_back(Variant());
-				else {
+				} else {
 					int val = env->CallByteMethod(o, JavaClassWrapper::singleton->Byte_byteValue);
 					ret.push_back(val);
 				}
@@ -821,9 +825,9 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 
 			for (int i = 0; i < count; i++) {
 				jobject o = env->GetObjectArrayElement(arr, i);
-				if (!o)
+				if (!o) {
 					ret.push_back(Variant());
-				else {
+				} else {
 					int val = env->CallCharMethod(o, JavaClassWrapper::singleton->Character_characterValue);
 					ret.push_back(val);
 				}
@@ -841,9 +845,9 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 
 			for (int i = 0; i < count; i++) {
 				jobject o = env->GetObjectArrayElement(arr, i);
-				if (!o)
+				if (!o) {
 					ret.push_back(Variant());
-				else {
+				} else {
 					int val = env->CallShortMethod(o, JavaClassWrapper::singleton->Short_shortValue);
 					ret.push_back(val);
 				}
@@ -861,9 +865,9 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 
 			for (int i = 0; i < count; i++) {
 				jobject o = env->GetObjectArrayElement(arr, i);
-				if (!o)
+				if (!o) {
 					ret.push_back(Variant());
-				else {
+				} else {
 					int val = env->CallIntMethod(o, JavaClassWrapper::singleton->Integer_integerValue);
 					ret.push_back(val);
 				}
@@ -881,9 +885,9 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 
 			for (int i = 0; i < count; i++) {
 				jobject o = env->GetObjectArrayElement(arr, i);
-				if (!o)
+				if (!o) {
 					ret.push_back(Variant());
-				else {
+				} else {
 					int64_t val = env->CallLongMethod(o, JavaClassWrapper::singleton->Long_longValue);
 					ret.push_back(val);
 				}
@@ -901,9 +905,9 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 
 			for (int i = 0; i < count; i++) {
 				jobject o = env->GetObjectArrayElement(arr, i);
-				if (!o)
+				if (!o) {
 					ret.push_back(Variant());
-				else {
+				} else {
 					float val = env->CallFloatMethod(o, JavaClassWrapper::singleton->Float_floatValue);
 					ret.push_back(val);
 				}
@@ -921,9 +925,9 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 
 			for (int i = 0; i < count; i++) {
 				jobject o = env->GetObjectArrayElement(arr, i);
-				if (!o)
+				if (!o) {
 					ret.push_back(Variant());
-				else {
+				} else {
 					double val = env->CallDoubleMethod(o, JavaClassWrapper::singleton->Double_doubleValue);
 					ret.push_back(val);
 				}
@@ -942,9 +946,9 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 
 			for (int i = 0; i < count; i++) {
 				jobject o = env->GetObjectArrayElement(arr, i);
-				if (!o)
+				if (!o) {
 					ret.push_back(Variant());
-				else {
+				} else {
 					String val = jstring_to_string((jstring)o, env);
 					ret.push_back(val);
 				}
@@ -962,22 +966,19 @@ bool JavaClass::_convert_object_to_variant(JNIEnv *env, jobject obj, Variant &va
 }
 
 Ref<JavaClass> JavaClassWrapper::wrap(const String &p_class) {
-	if (class_cache.has(p_class))
+	if (class_cache.has(p_class)) {
 		return class_cache[p_class];
+	}
 
 	JNIEnv *env = get_jni_env();
-	ERR_FAIL_COND_V(env == nullptr, Ref<JavaClass>());
+	ERR_FAIL_NULL_V(env, Ref<JavaClass>());
 
 	jclass bclass = env->FindClass(p_class.utf8().get_data());
-	ERR_FAIL_COND_V(!bclass, Ref<JavaClass>());
-
-	//jmethodID getDeclaredMethods = env->GetMethodID(bclass,"getDeclaredMethods", "()[Ljava/lang/reflect/Method;");
-
-	//ERR_FAIL_COND_V(!getDeclaredMethods,Ref<JavaClass>());
+	ERR_FAIL_NULL_V(bclass, Ref<JavaClass>());
 
 	jobjectArray methods = (jobjectArray)env->CallObjectMethod(bclass, getDeclaredMethods);
 
-	ERR_FAIL_COND_V(!methods, Ref<JavaClass>());
+	ERR_FAIL_NULL_V(methods, Ref<JavaClass>());
 
 	Ref<JavaClass> java_class = memnew(JavaClass);
 
@@ -1057,9 +1058,10 @@ Ref<JavaClass> JavaClassWrapper::wrap(const String &p_class) {
 			float new_likeliness = 0;
 			float existing_likeliness = 0;
 
-			if (E->get().param_types.size() != mi.param_types.size())
+			if (E->get().param_types.size() != mi.param_types.size()) {
 				continue;
-			bool valid = true;
+			}
+			bool this_valid = true;
 			for (int j = 0; j < E->get().param_types.size(); j++) {
 				Variant::Type _new;
 				float new_l;
@@ -1068,15 +1070,16 @@ Ref<JavaClass> JavaClassWrapper::wrap(const String &p_class) {
 				JavaClass::_convert_to_variant_type(E->get().param_types[j], existing, existing_l);
 				JavaClass::_convert_to_variant_type(mi.param_types[j], _new, new_l);
 				if (_new != existing) {
-					valid = false;
+					this_valid = false;
 					break;
 				}
 				new_likeliness += new_l;
 				existing_likeliness = existing_l;
 			}
 
-			if (!valid)
+			if (!this_valid) {
 				continue;
+			}
 
 			if (new_likeliness > existing_likeliness) {
 				java_class->methods[str_method].erase(E);
@@ -1087,10 +1090,11 @@ Ref<JavaClass> JavaClassWrapper::wrap(const String &p_class) {
 		}
 
 		if (!discard) {
-			if (mi._static)
+			if (mi._static) {
 				mi.method = env->GetStaticMethodID(bclass, str_method.utf8().get_data(), signature.utf8().get_data());
-			else
+			} else {
 				mi.method = env->GetMethodID(bclass, str_method.utf8().get_data(), signature.utf8().get_data());
+			}
 
 			ERR_CONTINUE(!mi.method);
 
@@ -1100,7 +1104,7 @@ Ref<JavaClass> JavaClassWrapper::wrap(const String &p_class) {
 		env->DeleteLocalRef(obj);
 		env->DeleteLocalRef(param_types);
 		env->DeleteLocalRef(return_type);
-	};
+	}
 
 	env->DeleteLocalRef(methods);
 
@@ -1118,7 +1122,7 @@ Ref<JavaClass> JavaClassWrapper::wrap(const String &p_class) {
 		int mods = env->CallIntMethod(obj, Field_getModifiers);
 		if ((mods & 0x8) && (mods & 0x10) && (mods & 0x1)) { //static final public!
 
-			jobject objc = env->CallObjectMethod(obj, Field_get, NULL);
+			jobject objc = env->CallObjectMethod(obj, Field_get, nullptr);
 			if (objc) {
 				uint32_t sig;
 				String strsig;
@@ -1145,16 +1149,16 @@ Ref<JavaClass> JavaClassWrapper::wrap(const String &p_class) {
 	return Ref<JavaClass>();
 }
 
-JavaClassWrapper *JavaClassWrapper::singleton = NULL;
+JavaClassWrapper *JavaClassWrapper::singleton = nullptr;
 
 JavaClassWrapper::JavaClassWrapper(jobject p_activity) {
 	singleton = this;
 
 	JNIEnv *env = get_jni_env();
-	ERR_FAIL_COND(env == nullptr);
+	ERR_FAIL_NULL(env);
 
-	jclass activityClass = env->FindClass("android/app/Activity");
-	jmethodID getClassLoader = env->GetMethodID(activityClass, "getClassLoader", "()Ljava/lang/ClassLoader;");
+	jclass activity = env->FindClass("android/app/Activity");
+	jmethodID getClassLoader = env->GetMethodID(activity, "getClassLoader", "()Ljava/lang/ClassLoader;");
 	classLoader = env->CallObjectMethod(p_activity, getClassLoader);
 	classLoader = (jclass)env->NewGlobalRef(classLoader);
 	jclass classLoaderClass = env->FindClass("java/lang/ClassLoader");
@@ -1164,18 +1168,18 @@ JavaClassWrapper::JavaClassWrapper(jobject p_activity) {
 	getDeclaredMethods = env->GetMethodID(bclass, "getDeclaredMethods", "()[Ljava/lang/reflect/Method;");
 	getFields = env->GetMethodID(bclass, "getFields", "()[Ljava/lang/reflect/Field;");
 	Class_getName = env->GetMethodID(bclass, "getName", "()Ljava/lang/String;");
-	//
+
 	bclass = env->FindClass("java/lang/reflect/Method");
 	getParameterTypes = env->GetMethodID(bclass, "getParameterTypes", "()[Ljava/lang/Class;");
 	getReturnType = env->GetMethodID(bclass, "getReturnType", "()Ljava/lang/Class;");
 	getName = env->GetMethodID(bclass, "getName", "()Ljava/lang/String;");
 	getModifiers = env->GetMethodID(bclass, "getModifiers", "()I");
-	///
+
 	bclass = env->FindClass("java/lang/reflect/Field");
 	Field_getName = env->GetMethodID(bclass, "getName", "()Ljava/lang/String;");
 	Field_getModifiers = env->GetMethodID(bclass, "getModifiers", "()I");
 	Field_get = env->GetMethodID(bclass, "get", "(Ljava/lang/Object;)Ljava/lang/Object;");
-	// each
+
 	bclass = env->FindClass("java/lang/Boolean");
 	Boolean_booleanValue = env->GetMethodID(bclass, "booleanValue", "()Z");
 

--- a/platform/android/java_godot_io_wrapper.cpp
+++ b/platform/android/java_godot_io_wrapper.cpp
@@ -80,7 +80,7 @@ jobject GodotIOJavaWrapper::get_instance() {
 Error GodotIOJavaWrapper::open_uri(const String &p_uri) {
 	if (_open_URI) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, ERR_UNAVAILABLE);
+		ERR_FAIL_NULL_V(env, ERR_UNAVAILABLE);
 		jstring jStr = env->NewStringUTF(p_uri.utf8().get_data());
 		return env->CallIntMethod(godot_io_instance, _open_URI, jStr) ? ERR_CANT_OPEN : OK;
 	} else {
@@ -91,7 +91,7 @@ Error GodotIOJavaWrapper::open_uri(const String &p_uri) {
 String GodotIOJavaWrapper::get_cache_dir() {
 	if (_get_cache_dir) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
+		ERR_FAIL_NULL_V(env, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_cache_dir);
 		return jstring_to_string(s, env);
 	} else {
@@ -102,7 +102,7 @@ String GodotIOJavaWrapper::get_cache_dir() {
 String GodotIOJavaWrapper::get_user_data_dir() {
 	if (_get_data_dir) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
+		ERR_FAIL_NULL_V(env, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_data_dir);
 		return jstring_to_string(s, env);
 	} else {
@@ -113,7 +113,7 @@ String GodotIOJavaWrapper::get_user_data_dir() {
 String GodotIOJavaWrapper::get_locale() {
 	if (_get_locale) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
+		ERR_FAIL_NULL_V(env, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_locale);
 		return jstring_to_string(s, env);
 	} else {
@@ -124,7 +124,7 @@ String GodotIOJavaWrapper::get_locale() {
 String GodotIOJavaWrapper::get_model() {
 	if (_get_model) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
+		ERR_FAIL_NULL_V(env, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_model);
 		return jstring_to_string(s, env);
 	} else {
@@ -135,7 +135,7 @@ String GodotIOJavaWrapper::get_model() {
 int GodotIOJavaWrapper::get_screen_dpi() {
 	if (_get_screen_DPI) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, 160);
+		ERR_FAIL_NULL_V(env, 160);
 		return env->CallIntMethod(godot_io_instance, _get_screen_DPI);
 	} else {
 		return 160;
@@ -145,7 +145,7 @@ int GodotIOJavaWrapper::get_screen_dpi() {
 float GodotIOJavaWrapper::get_scaled_density() {
 	if (_get_scaled_density) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, 1.0f);
+		ERR_FAIL_NULL_V(env, 1.0f);
 		return env->CallFloatMethod(godot_io_instance, _get_scaled_density);
 	} else {
 		return 1.0f;
@@ -168,7 +168,7 @@ float GodotIOJavaWrapper::get_screen_refresh_rate(float p_fallback) {
 void GodotIOJavaWrapper::get_window_safe_area(int (&p_rect_xywh)[4]) {
 	if (_get_window_safe_area) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
+		ERR_FAIL_NULL(env);
 		jintArray returnArray = (jintArray)env->CallObjectMethod(godot_io_instance, _get_window_safe_area);
 		ERR_FAIL_COND(env->GetArrayLength(returnArray) != 4);
 		jint *arrayBody = env->GetIntArrayElements(returnArray, JNI_FALSE);
@@ -203,7 +203,7 @@ Array GodotIOJavaWrapper::get_display_cutouts() {
 String GodotIOJavaWrapper::get_unique_id() {
 	if (_get_unique_id) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
+		ERR_FAIL_NULL_V(env, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_unique_id);
 		return jstring_to_string(s, env);
 	} else {
@@ -212,13 +212,13 @@ String GodotIOJavaWrapper::get_unique_id() {
 }
 
 bool GodotIOJavaWrapper::has_vk() {
-	return (_show_keyboard != 0) && (_hide_keyboard != 0);
+	return (_show_keyboard != nullptr) && (_hide_keyboard != nullptr);
 }
 
 void GodotIOJavaWrapper::show_vk(const String &p_existing, bool p_multiline, int p_max_input_length, int p_cursor_start, int p_cursor_end) {
 	if (_show_keyboard) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
+		ERR_FAIL_NULL(env);
 		jstring jStr = env->NewStringUTF(p_existing.utf8().get_data());
 		env->CallVoidMethod(godot_io_instance, _show_keyboard, jStr, p_multiline, p_max_input_length, p_cursor_start, p_cursor_end);
 	}
@@ -227,7 +227,7 @@ void GodotIOJavaWrapper::show_vk(const String &p_existing, bool p_multiline, int
 void GodotIOJavaWrapper::hide_vk() {
 	if (_hide_keyboard) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
+		ERR_FAIL_NULL(env);
 		env->CallVoidMethod(godot_io_instance, _hide_keyboard);
 	}
 }
@@ -235,7 +235,7 @@ void GodotIOJavaWrapper::hide_vk() {
 void GodotIOJavaWrapper::set_screen_orientation(int p_orient) {
 	if (_set_screen_orientation) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
+		ERR_FAIL_NULL(env);
 		env->CallVoidMethod(godot_io_instance, _set_screen_orientation, p_orient);
 	}
 }
@@ -243,7 +243,7 @@ void GodotIOJavaWrapper::set_screen_orientation(int p_orient) {
 int GodotIOJavaWrapper::get_screen_orientation() const {
 	if (_get_screen_orientation) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, 0);
+		ERR_FAIL_NULL_V(env, 0);
 		return env->CallIntMethod(godot_io_instance, _get_screen_orientation);
 	} else {
 		return 0;
@@ -253,7 +253,7 @@ int GodotIOJavaWrapper::get_screen_orientation() const {
 String GodotIOJavaWrapper::get_system_dir(int p_dir, bool p_shared_storage) {
 	if (_get_system_dir) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String("."));
+		ERR_FAIL_NULL_V(env, String("."));
 		jstring s = (jstring)env->CallObjectMethod(godot_io_instance, _get_system_dir, p_dir, p_shared_storage);
 		return jstring_to_string(s, env);
 	} else {

--- a/platform/android/java_godot_io_wrapper.h
+++ b/platform/android/java_godot_io_wrapper.h
@@ -89,4 +89,4 @@ public:
 	String get_system_dir(int p_dir, bool p_shared_storage);
 };
 
-#endif /* !JAVA_GODOT_IO_WRAPPER_H */
+#endif // JAVA_GODOT_IO_WRAPPER_H

--- a/platform/android/java_godot_lib_jni.h
+++ b/platform/android/java_godot_lib_jni.h
@@ -71,4 +71,4 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererResumed(JNI
 JNIEXPORT void JNICALL Java_org_godotengine_godot_GodotLib_onRendererPaused(JNIEnv *env, jclass clazz);
 }
 
-#endif /* !JAVA_GODOT_LIB_JNI_H */
+#endif // JAVA_GODOT_LIB_JNI_H

--- a/platform/android/java_godot_wrapper.cpp
+++ b/platform/android/java_godot_wrapper.cpp
@@ -96,42 +96,33 @@ jobject GodotJavaWrapper::get_activity() {
 
 jobject GodotJavaWrapper::get_member_object(const char *p_name, const char *p_class, JNIEnv *p_env) {
 	if (godot_class) {
-		if (p_env == NULL)
+		if (p_env == nullptr) {
 			p_env = get_jni_env();
-
-		ERR_FAIL_COND_V(p_env == nullptr, nullptr);
-
+		}
+		ERR_FAIL_NULL_V(p_env, nullptr);
 		jfieldID fid = p_env->GetStaticFieldID(godot_class, p_name, p_class);
 		return p_env->GetStaticObjectField(godot_class, fid);
 	} else {
-		return NULL;
+		return nullptr;
 	}
 }
 
 jobject GodotJavaWrapper::get_class_loader() {
 	if (_get_class_loader) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, nullptr);
-
+		ERR_FAIL_NULL_V(env, nullptr);
 		return env->CallObjectMethod(activity, _get_class_loader);
 	} else {
-		return NULL;
+		return nullptr;
 	}
-}
-
-void GodotJavaWrapper::gfx_init(bool gl2) {
-	// beats me what this once did, there was no code,
-	// but we're getting false if our GLES3 driver is initialised
-	// and true for our GLES2 driver
-	// Maybe we're supposed to communicate this back or store it?
 }
 
 void GodotJavaWrapper::on_video_init(JNIEnv *p_env) {
 	if (_on_video_init) {
-		if (p_env == NULL)
+		if (p_env == nullptr) {
 			p_env = get_jni_env();
-		ERR_FAIL_COND(p_env == nullptr);
-
+		}
+		ERR_FAIL_NULL(p_env);
 		p_env->CallVoidMethod(godot_instance, _on_video_init);
 	}
 }
@@ -152,49 +143,50 @@ void GodotJavaWrapper::destroy_offscreen_gl(JNIEnv *p_env) {
 
 void GodotJavaWrapper::set_offscreen_gl_current(JNIEnv *p_env, bool p_current) {
 	if (_set_offscreen_gl_current) {
-		if (p_env == NULL)
+		if (p_env == nullptr) {
 			p_env = get_jni_env();
-		ERR_FAIL_COND(p_env == nullptr);
+		}
+		ERR_FAIL_NULL(p_env);
 		p_env->CallVoidMethod(godot_instance, _set_offscreen_gl_current, p_current);
 	}
 }
 
 void GodotJavaWrapper::on_godot_setup_completed(JNIEnv *p_env) {
 	if (_on_godot_setup_completed) {
-		if (p_env == NULL) {
+		if (p_env == nullptr) {
 			p_env = get_jni_env();
 		}
-		ERR_FAIL_COND(p_env == nullptr);
+		ERR_FAIL_NULL(p_env);
 		p_env->CallVoidMethod(godot_instance, _on_godot_setup_completed);
 	}
 }
 
 void GodotJavaWrapper::on_godot_main_loop_started(JNIEnv *p_env) {
 	if (_on_godot_main_loop_started) {
-		if (p_env == NULL) {
+		if (p_env == nullptr) {
 			p_env = get_jni_env();
 		}
-		ERR_FAIL_COND(p_env == nullptr);
+		ERR_FAIL_NULL(p_env);
 		p_env->CallVoidMethod(godot_instance, _on_godot_main_loop_started);
 	}
 }
 
 void GodotJavaWrapper::restart(JNIEnv *p_env) {
 	if (_restart) {
-		if (p_env == NULL)
+		if (p_env == nullptr) {
 			p_env = get_jni_env();
-		ERR_FAIL_COND(p_env == nullptr);
-
+		}
+		ERR_FAIL_NULL(p_env);
 		p_env->CallVoidMethod(godot_instance, _restart);
 	}
 }
 
 void GodotJavaWrapper::force_quit(JNIEnv *p_env) {
 	if (_finish) {
-		if (p_env == NULL)
+		if (p_env == nullptr) {
 			p_env = get_jni_env();
-		ERR_FAIL_COND(p_env == nullptr);
-
+		}
+		ERR_FAIL_NULL(p_env);
 		p_env->CallVoidMethod(godot_instance, _finish);
 	}
 }
@@ -202,8 +194,7 @@ void GodotJavaWrapper::force_quit(JNIEnv *p_env) {
 void GodotJavaWrapper::set_keep_screen_on(bool p_enabled) {
 	if (_set_keep_screen_on) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
-
+		ERR_FAIL_NULL(env);
 		env->CallVoidMethod(godot_instance, _set_keep_screen_on, p_enabled);
 	}
 }
@@ -211,8 +202,7 @@ void GodotJavaWrapper::set_keep_screen_on(bool p_enabled) {
 void GodotJavaWrapper::alert(const String &p_message, const String &p_title) {
 	if (_alert) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
-
+		ERR_FAIL_NULL(env);
 		jstring jStrMessage = env->NewStringUTF(p_message.utf8().get_data());
 		jstring jStrTitle = env->NewStringUTF(p_title.utf8().get_data());
 		env->CallVoidMethod(godot_instance, _alert, jStrMessage, jStrTitle);
@@ -221,24 +211,21 @@ void GodotJavaWrapper::alert(const String &p_message, const String &p_title) {
 
 int GodotJavaWrapper::get_gles_version_code() {
 	JNIEnv *env = get_jni_env();
-	ERR_FAIL_COND_V(env == nullptr, 0);
-
+	ERR_FAIL_NULL_V(env, 0);
 	if (_get_GLES_version_code) {
 		return env->CallIntMethod(godot_instance, _get_GLES_version_code);
 	}
-
 	return 0;
 }
 
 bool GodotJavaWrapper::has_get_clipboard() {
-	return _get_clipboard != 0;
+	return _get_clipboard != nullptr;
 }
 
 String GodotJavaWrapper::get_clipboard() {
 	if (_get_clipboard) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
-
+		ERR_FAIL_NULL_V(env, String());
 		jstring s = (jstring)env->CallObjectMethod(godot_instance, _get_clipboard);
 		return jstring_to_string(s, env);
 	} else {
@@ -249,8 +236,7 @@ String GodotJavaWrapper::get_clipboard() {
 String GodotJavaWrapper::get_input_fallback_mapping() {
 	if (_get_input_fallback_mapping) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, String());
-
+		ERR_FAIL_NULL_V(env, String());
 		jstring fallback_mapping = (jstring)env->CallObjectMethod(godot_instance, _get_input_fallback_mapping);
 		return jstring_to_string(fallback_mapping, env);
 	} else {
@@ -259,28 +245,26 @@ String GodotJavaWrapper::get_input_fallback_mapping() {
 }
 
 bool GodotJavaWrapper::has_set_clipboard() {
-	return _set_clipboard != 0;
+	return _set_clipboard != nullptr;
 }
 
 void GodotJavaWrapper::set_clipboard(const String &p_text) {
 	if (_set_clipboard) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
-
+		ERR_FAIL_NULL(env);
 		jstring jStr = env->NewStringUTF(p_text.utf8().get_data());
 		env->CallVoidMethod(godot_instance, _set_clipboard, jStr);
 	}
 }
 
 bool GodotJavaWrapper::has_has_clipboard() {
-	return _has_clipboard != 0;
+	return _has_clipboard != nullptr;
 }
 
 bool GodotJavaWrapper::has_clipboard() {
 	if (_has_clipboard) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, false);
-
+		ERR_FAIL_NULL_V(env, false);
 		return env->CallBooleanMethod(godot_instance, _has_clipboard);
 	} else {
 		return false;
@@ -290,8 +274,7 @@ bool GodotJavaWrapper::has_clipboard() {
 bool GodotJavaWrapper::request_permission(const String &p_name) {
 	if (_request_permission) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, false);
-
+		ERR_FAIL_NULL_V(env, false);
 		jstring jStrName = env->NewStringUTF(p_name.utf8().get_data());
 		return env->CallBooleanMethod(godot_instance, _request_permission, jStrName);
 	} else {
@@ -302,8 +285,7 @@ bool GodotJavaWrapper::request_permission(const String &p_name) {
 bool GodotJavaWrapper::request_permissions() {
 	if (_request_permissions) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, false);
-
+		ERR_FAIL_NULL_V(env, false);
 		return env->CallBooleanMethod(godot_instance, _request_permissions);
 	} else {
 		return false;
@@ -314,14 +296,12 @@ Vector<String> GodotJavaWrapper::get_granted_permissions() const {
 	Vector<String> permissions_list;
 	if (_get_granted_permissions) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, permissions_list);
-
+		ERR_FAIL_NULL_V(env, permissions_list);
 		jobject permissions_object = env->CallObjectMethod(godot_instance, _get_granted_permissions);
 		jobjectArray *arr = reinterpret_cast<jobjectArray *>(&permissions_object);
 
-		int i = 0;
 		jsize len = env->GetArrayLength(*arr);
-		for (i = 0; i < len; i++) {
+		for (int i = 0; i < len; i++) {
 			jstring jstr = (jstring)env->GetObjectArrayElement(*arr, i);
 			String str = jstring_to_string(jstr, env);
 			permissions_list.push_back(str);
@@ -334,8 +314,7 @@ Vector<String> GodotJavaWrapper::get_granted_permissions() const {
 void GodotJavaWrapper::init_input_devices() {
 	if (_init_input_devices) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
-
+		ERR_FAIL_NULL(env);
 		env->CallVoidMethod(godot_instance, _init_input_devices);
 	}
 }
@@ -343,19 +322,17 @@ void GodotJavaWrapper::init_input_devices() {
 jobject GodotJavaWrapper::get_surface() {
 	if (_get_surface) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, nullptr);
-
+		ERR_FAIL_NULL_V(env, nullptr);
 		return env->CallObjectMethod(godot_instance, _get_surface);
 	} else {
-		return NULL;
+		return nullptr;
 	}
 }
 
 bool GodotJavaWrapper::is_activity_resumed() {
 	if (_is_activity_resumed) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND_V(env == nullptr, false);
-
+		ERR_FAIL_NULL_V(env, false);
 		return env->CallBooleanMethod(godot_instance, _is_activity_resumed);
 	} else {
 		return false;
@@ -365,8 +342,7 @@ bool GodotJavaWrapper::is_activity_resumed() {
 void GodotJavaWrapper::vibrate(int p_duration_ms) {
 	if (_vibrate) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
-
+		ERR_FAIL_NULL(env);
 		env->CallVoidMethod(godot_instance, _vibrate, p_duration_ms);
 	}
 }
@@ -374,8 +350,7 @@ void GodotJavaWrapper::vibrate(int p_duration_ms) {
 void GodotJavaWrapper::create_new_godot_instance(List<String> args) {
 	if (_create_new_godot_instance) {
 		JNIEnv *env = get_jni_env();
-		ERR_FAIL_COND(env == nullptr);
-
+		ERR_FAIL_NULL(env);
 		jobjectArray jargs = env->NewObjectArray(args.size(), env->FindClass("java/lang/String"), env->NewStringUTF(""));
 		for (int i = 0; i < args.size(); i++) {
 			env->SetObjectArrayElement(jargs, i, env->NewStringUTF(args[i].utf8().get_data()));

--- a/platform/android/java_godot_wrapper.h
+++ b/platform/android/java_godot_wrapper.h
@@ -48,30 +48,30 @@ private:
 	jclass godot_class;
 	jclass activity_class;
 
-	jmethodID _on_video_init = 0;
-	jmethodID _create_offscreen_gl = 0;
-	jmethodID _destroy_offscreen_gl = 0;
-	jmethodID _set_offscreen_gl_current = 0;
-	jmethodID _restart = 0;
-	jmethodID _finish = 0;
-	jmethodID _set_keep_screen_on = 0;
-	jmethodID _alert = 0;
-	jmethodID _get_GLES_version_code = 0;
-	jmethodID _get_clipboard = 0;
-	jmethodID _set_clipboard = 0;
-	jmethodID _has_clipboard = 0;
-	jmethodID _request_permission = 0;
-	jmethodID _request_permissions = 0;
-	jmethodID _get_granted_permissions = 0;
-	jmethodID _init_input_devices = 0;
-	jmethodID _get_surface = 0;
-	jmethodID _is_activity_resumed = 0;
-	jmethodID _vibrate = 0;
-	jmethodID _get_input_fallback_mapping = 0;
-	jmethodID _on_godot_setup_completed = 0;
-	jmethodID _on_godot_main_loop_started = 0;
-	jmethodID _get_class_loader = 0;
-	jmethodID _create_new_godot_instance = 0;
+	jmethodID _on_video_init = nullptr;
+	jmethodID _create_offscreen_gl = nullptr;
+	jmethodID _destroy_offscreen_gl = nullptr;
+	jmethodID _set_offscreen_gl_current = nullptr;
+	jmethodID _restart = nullptr;
+	jmethodID _finish = nullptr;
+	jmethodID _set_keep_screen_on = nullptr;
+	jmethodID _alert = nullptr;
+	jmethodID _get_GLES_version_code = nullptr;
+	jmethodID _get_clipboard = nullptr;
+	jmethodID _set_clipboard = nullptr;
+	jmethodID _has_clipboard = nullptr;
+	jmethodID _request_permission = nullptr;
+	jmethodID _request_permissions = nullptr;
+	jmethodID _get_granted_permissions = nullptr;
+	jmethodID _init_input_devices = nullptr;
+	jmethodID _get_surface = nullptr;
+	jmethodID _is_activity_resumed = nullptr;
+	jmethodID _vibrate = nullptr;
+	jmethodID _get_input_fallback_mapping = nullptr;
+	jmethodID _on_godot_setup_completed = nullptr;
+	jmethodID _on_godot_main_loop_started = nullptr;
+	jmethodID _get_class_loader = nullptr;
+	jmethodID _create_new_godot_instance = nullptr;
 
 public:
 	GodotJavaWrapper(JNIEnv *p_env, jobject p_activity, jobject p_godot_instance);
@@ -82,7 +82,6 @@ public:
 
 	jobject get_class_loader();
 
-	void gfx_init(bool gl2);
 	bool create_offscreen_gl(JNIEnv *p_env);
 	void destroy_offscreen_gl(JNIEnv *p_env);
 	void set_offscreen_gl_current(JNIEnv *p_env, bool p_current);
@@ -111,4 +110,4 @@ public:
 	void create_new_godot_instance(List<String> args);
 };
 
-#endif /* !JAVA_GODOT_WRAPPER_H */
+#endif // JAVA_GODOT_WRAPPER_H

--- a/platform/android/jni_utils.cpp
+++ b/platform/android/jni_utils.cpp
@@ -46,7 +46,7 @@ jvalret _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_a
 				env->DeleteLocalRef(bclass);
 			} else {
 				v.val.z = *p_arg;
-			};
+			}
 		} break;
 		case Variant::INT: {
 			if (force_jobject) {
@@ -61,7 +61,7 @@ jvalret _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_a
 
 			} else {
 				v.val.i = *p_arg;
-			};
+			}
 		} break;
 		case Variant::REAL: {
 			if (force_jobject) {
@@ -76,7 +76,7 @@ jvalret _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_a
 
 			} else {
 				v.val.f = *p_arg;
-			};
+			}
 		} break;
 		case Variant::STRING: {
 			String s = *p_arg;
@@ -111,7 +111,7 @@ jvalret _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_a
 				jstring str = env->NewStringUTF(String(keys[j]).utf8().get_data());
 				env->SetObjectArrayElement(jkeys, j, str);
 				env->DeleteLocalRef(str);
-			};
+			}
 
 			jmethodID set_keys = env->GetMethodID(dclass, "set_keys", "([Ljava/lang/String;)V");
 			jvalue val;
@@ -119,16 +119,16 @@ jvalret _variant_to_jvalue(JNIEnv *env, Variant::Type p_type, const Variant *p_a
 			env->CallVoidMethodA(jdict, set_keys, &val);
 			env->DeleteLocalRef(jkeys);
 
-			jobjectArray jvalues = env->NewObjectArray(keys.size(), env->FindClass("java/lang/Object"), NULL);
+			jobjectArray jvalues = env->NewObjectArray(keys.size(), env->FindClass("java/lang/Object"), nullptr);
 
 			for (int j = 0; j < keys.size(); j++) {
 				Variant var = dict[keys[j]];
-				jvalret v = _variant_to_jvalue(env, var.get_type(), &var, true);
-				env->SetObjectArrayElement(jvalues, j, v.val.l);
-				if (v.obj) {
-					env->DeleteLocalRef(v.obj);
+				jvalret valret = _variant_to_jvalue(env, var.get_type(), &var, true);
+				env->SetObjectArrayElement(jvalues, j, valret.val.l);
+				if (valret.obj) {
+					env->DeleteLocalRef(valret.obj);
 				}
-			};
+			}
 
 			jmethodID set_values = env->GetMethodID(dclass, "set_values", "([Ljava/lang/Object;)V");
 			val.l = jvalues;
@@ -182,7 +182,7 @@ String _get_class_name(JNIEnv *env, jclass cls, bool *array) {
 	if (array) {
 		jmethodID isArray = env->GetMethodID(cclass, "isArray", "()Z");
 		jboolean isarr = env->CallBooleanMethod(cls, isArray);
-		(*array) = isarr ? true : false;
+		(*array) = isarr != 0;
 	}
 	String name = jstring_to_string(clsName, env);
 	env->DeleteLocalRef(clsName);
@@ -191,7 +191,7 @@ String _get_class_name(JNIEnv *env, jclass cls, bool *array) {
 }
 
 Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
-	if (obj == NULL) {
+	if (obj == nullptr) {
 		return Variant();
 	}
 
@@ -201,7 +201,7 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 
 	if (name == "java.lang.String") {
 		return jstring_to_string((jstring)obj, env);
-	};
+	}
 
 	if (name == "[Ljava.lang.String;") {
 		jobjectArray arr = (jobjectArray)obj;
@@ -215,20 +215,20 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 		}
 
 		return sarr;
-	};
+	}
 
 	if (name == "java.lang.Boolean") {
 		jmethodID boolValue = env->GetMethodID(c, "booleanValue", "()Z");
 		bool ret = env->CallBooleanMethod(obj, boolValue);
 		return ret;
-	};
+	}
 
 	if (name == "java.lang.Integer" || name == "java.lang.Long") {
 		jclass nclass = env->FindClass("java/lang/Number");
 		jmethodID longValue = env->GetMethodID(nclass, "longValue", "()J");
 		jlong ret = env->CallLongMethod(obj, longValue);
 		return ret;
-	};
+	}
 
 	if (name == "[I") {
 		jintArray arr = (jintArray)obj;
@@ -240,7 +240,7 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 		env->GetIntArrayRegion(arr, 0, fCount, w.ptr());
 		w.release();
 		return sarr;
-	};
+	}
 
 	if (name == "[B") {
 		jbyteArray arr = (jbyteArray)obj;
@@ -252,14 +252,14 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 		env->GetByteArrayRegion(arr, 0, fCount, reinterpret_cast<signed char *>(w.ptr()));
 		w.release();
 		return sarr;
-	};
+	}
 
 	if (name == "java.lang.Float" || name == "java.lang.Double") {
 		jclass nclass = env->FindClass("java/lang/Number");
 		jmethodID doubleValue = env->GetMethodID(nclass, "doubleValue", "()D");
 		double ret = env->CallDoubleMethod(obj, doubleValue);
 		return ret;
-	};
+	}
 
 	if (name == "[D") {
 		jdoubleArray arr = (jdoubleArray)obj;
@@ -273,9 +273,9 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 			double n;
 			env->GetDoubleArrayRegion(arr, i, 1, &n);
 			w.ptr()[i] = n;
-		};
+		}
 		return sarr;
-	};
+	}
 
 	if (name == "[F") {
 		jfloatArray arr = (jfloatArray)obj;
@@ -289,9 +289,9 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 			float n;
 			env->GetFloatArrayRegion(arr, i, 1, &n);
 			w.ptr()[i] = n;
-		};
+		}
 		return sarr;
-	};
+	}
 
 	if (name == "[Ljava.lang.Object;") {
 		jobjectArray arr = (jobjectArray)obj;
@@ -306,7 +306,7 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 		}
 
 		return varr;
-	};
+	}
 
 	if (name == "java.util.HashMap" || name == "org.godotengine.godot.Dictionary") {
 		Dictionary ret;
@@ -325,10 +325,10 @@ Variant _jobject_to_variant(JNIEnv *env, jobject obj) {
 
 		for (int i = 0; i < keys.size(); i++) {
 			ret[keys[i]] = vals[i];
-		};
+		}
 
 		return ret;
-	};
+	}
 
 	env->DeleteLocalRef(c);
 
@@ -351,14 +351,15 @@ Variant::Type get_jni_type(const String &p_type) {
 		{ "[F", Variant::POOL_REAL_ARRAY },
 		{ "[Ljava.lang.String;", Variant::POOL_STRING_ARRAY },
 		{ "org.godotengine.godot.Dictionary", Variant::DICTIONARY },
-		{ NULL, Variant::NIL }
+		{ nullptr, Variant::NIL }
 	};
 
 	int idx = 0;
 
 	while (_type_to_vtype[idx].name) {
-		if (p_type == _type_to_vtype[idx].name)
+		if (p_type == _type_to_vtype[idx].name) {
 			return _type_to_vtype[idx].type;
+		}
 
 		idx++;
 	}
@@ -382,14 +383,15 @@ const char *get_jni_sig(const String &p_type) {
 		{ "[B", "[B" },
 		{ "[F", "[F" },
 		{ "[Ljava.lang.String;", "[Ljava/lang/String;" },
-		{ NULL, "V" }
+		{ nullptr, "V" }
 	};
 
 	int idx = 0;
 
 	while (_type_to_vtype[idx].name) {
-		if (p_type == _type_to_vtype[idx].name)
+		if (p_type == _type_to_vtype[idx].name) {
 			return _type_to_vtype[idx].sig;
+		}
 
 		idx++;
 	}

--- a/platform/android/net_socket_android.cpp
+++ b/platform/android/net_socket_android.cpp
@@ -32,10 +32,10 @@
 
 #include "thread_jandroid.h"
 
-jobject NetSocketAndroid::net_utils = 0;
-jclass NetSocketAndroid::cls = 0;
-jmethodID NetSocketAndroid::_multicast_lock_acquire = 0;
-jmethodID NetSocketAndroid::_multicast_lock_release = 0;
+jobject NetSocketAndroid::net_utils = nullptr;
+jclass NetSocketAndroid::cls = nullptr;
+jmethodID NetSocketAndroid::_multicast_lock_acquire = nullptr;
+jmethodID NetSocketAndroid::_multicast_lock_release = nullptr;
 
 void NetSocketAndroid::setup(jobject p_net_utils) {
 	JNIEnv *env = get_jni_env();
@@ -82,18 +82,21 @@ NetSocketAndroid::~NetSocketAndroid() {
 
 void NetSocketAndroid::close() {
 	NetSocketPosix::close();
-	if (wants_broadcast)
+	if (wants_broadcast) {
 		multicast_lock_release();
-	if (multicast_groups)
+	}
+	if (multicast_groups) {
 		multicast_lock_release();
+	}
 	wants_broadcast = false;
 	multicast_groups = 0;
 }
 
 Error NetSocketAndroid::set_broadcasting_enabled(bool p_enabled) {
 	Error err = NetSocketPosix::set_broadcasting_enabled(p_enabled);
-	if (err != OK)
+	if (err != OK) {
 		return err;
+	}
 
 	if (p_enabled != wants_broadcast) {
 		if (p_enabled) {
@@ -110,11 +113,13 @@ Error NetSocketAndroid::set_broadcasting_enabled(bool p_enabled) {
 
 Error NetSocketAndroid::join_multicast_group(const IP_Address &p_multi_address, String p_if_name) {
 	Error err = NetSocketPosix::join_multicast_group(p_multi_address, p_if_name);
-	if (err != OK)
+	if (err != OK) {
 		return err;
+	}
 
-	if (!multicast_groups)
+	if (!multicast_groups) {
 		multicast_lock_acquire();
+	}
 	multicast_groups++;
 
 	return OK;
@@ -122,14 +127,16 @@ Error NetSocketAndroid::join_multicast_group(const IP_Address &p_multi_address, 
 
 Error NetSocketAndroid::leave_multicast_group(const IP_Address &p_multi_address, String p_if_name) {
 	Error err = NetSocketPosix::leave_multicast_group(p_multi_address, p_if_name);
-	if (err != OK)
+	if (err != OK) {
 		return err;
+	}
 
 	ERR_FAIL_COND_V(multicast_groups == 0, ERR_BUG);
 
 	multicast_groups--;
-	if (!multicast_groups)
+	if (!multicast_groups) {
 		multicast_lock_release();
+	}
 
 	return OK;
 }

--- a/platform/android/net_socket_android.h
+++ b/platform/android/net_socket_android.h
@@ -74,4 +74,4 @@ public:
 	~NetSocketAndroid();
 };
 
-#endif
+#endif // NET_SOCKET_ANDROID_H

--- a/platform/android/os_android.cpp
+++ b/platform/android/os_android.cpp
@@ -91,7 +91,7 @@ const char *OS_Android::get_video_driver_name(int p_driver) const {
 		case VIDEO_DRIVER_GLES2:
 			return "GLES2";
 	}
-	ERR_FAIL_V_MSG(NULL, "Invalid video driver index: " + itos(p_driver) + ".");
+	ERR_FAIL_V_MSG(nullptr, "Invalid video driver index: " + itos(p_driver) + ".");
 }
 int OS_Android::get_audio_driver_count() const {
 	return 1;
@@ -107,9 +107,9 @@ void OS_Android::initialize_core() {
 #ifdef TOOLS_ENABLED
 	FileAccess::make_default<FileAccessUnix>(FileAccess::ACCESS_RESOURCES);
 #else
-	if (use_apk_expansion)
+	if (use_apk_expansion) {
 		FileAccess::make_default<FileAccessUnix>(FileAccess::ACCESS_RESOURCES);
-	else {
+	} else {
 		FileAccess::make_default<FileAccessAndroid>(FileAccess::ACCESS_RESOURCES);
 	}
 #endif
@@ -119,12 +119,12 @@ void OS_Android::initialize_core() {
 #ifdef TOOLS_ENABLED
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_RESOURCES);
 #else
-	if (use_apk_expansion)
+	if (use_apk_expansion) {
 		DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_RESOURCES);
-	else
+	} else {
 		DirAccess::make_default<DirAccessJAndroid>(DirAccess::ACCESS_RESOURCES);
+	}
 #endif
-
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_USERDATA);
 	DirAccess::make_default<DirAccessUnix>(DirAccess::ACCESS_FILESYSTEM);
 
@@ -132,7 +132,7 @@ void OS_Android::initialize_core() {
 }
 
 void OS_Android::set_opengl_extensions(const char *p_gl_extensions) {
-	ERR_FAIL_COND(!p_gl_extensions);
+	ERR_FAIL_NULL(p_gl_extensions);
 	gl_extensions = p_gl_extensions;
 }
 
@@ -148,7 +148,6 @@ Error OS_Android::initialize(const VideoMode &p_desired, int p_video_driver, int
 	while (true) {
 		if (use_gl3) {
 			if (RasterizerGLES3::is_viable() == OK) {
-				godot_java->gfx_init(false);
 				RasterizerGLES3::register_config();
 				RasterizerGLES3::make_current();
 				break;
@@ -164,7 +163,6 @@ Error OS_Android::initialize(const VideoMode &p_desired, int p_video_driver, int
 			}
 		} else {
 			if (RasterizerGLES2::is_viable() == OK) {
-				godot_java->gfx_init(true);
 				RasterizerGLES2::register_config();
 				RasterizerGLES2::make_current();
 				break;
@@ -199,8 +197,6 @@ Error OS_Android::initialize(const VideoMode &p_desired, int p_video_driver, int
 	input->set_use_input_buffering(true); // Needed because events will come directly from the UI thread
 	input->set_fallback_mapping(godot_java->get_input_fallback_mapping());
 
-	//power_manager = memnew(PowerAndroid);
-
 	return OK;
 }
 
@@ -226,7 +222,6 @@ GodotIOJavaWrapper *OS_Android::get_godot_io_java() {
 }
 
 void OS_Android::alert(const String &p_alert, const String &p_title) {
-	//print("ALERT: %s\n", p_alert.utf8().get_data());
 	godot_java->alert(p_alert, p_title);
 }
 
@@ -244,7 +239,7 @@ Vector<String> OS_Android::get_granted_permissions() const {
 
 Error OS_Android::open_dynamic_library(const String p_path, void *&p_library_handle, bool p_also_set_library_path) {
 	p_library_handle = dlopen(p_path.utf8().get_data(), RTLD_NOW);
-	ERR_FAIL_COND_V_MSG(!p_library_handle, ERR_CANT_OPEN, "Can't open dynamic library: " + p_path + ", error: " + dlerror() + ".");
+	ERR_FAIL_NULL_V_MSG(p_library_handle, ERR_CANT_OPEN, "Can't open dynamic library: " + p_path + ", error: " + dlerror() + ".");
 	return OK;
 }
 
@@ -320,13 +315,15 @@ bool OS_Android::can_draw() const {
 }
 
 void OS_Android::main_loop_begin() {
-	if (main_loop)
+	if (main_loop) {
 		main_loop->init();
+	}
 }
 
 bool OS_Android::main_loop_iterate(bool *r_should_swap_buffers) {
-	if (!main_loop)
+	if (!main_loop) {
 		return false;
+	}
 	uint64_t current_frames_drawn = Engine::get_singleton()->get_frames_drawn();
 	bool exit = Main::iteration();
 
@@ -348,14 +345,16 @@ void OS_Android::main_loop_end() {
 }
 
 void OS_Android::main_loop_focusout() {
-	if (main_loop)
+	if (main_loop) {
 		main_loop->notification(MainLoop::NOTIFICATION_WM_FOCUS_OUT);
+	}
 	audio_driver_android.set_pause(true);
 }
 
 void OS_Android::main_loop_focusin() {
-	if (main_loop)
+	if (main_loop) {
 		main_loop->notification(MainLoop::NOTIFICATION_WM_FOCUS_IN);
+	}
 	audio_driver_android.set_pause(false);
 }
 
@@ -385,9 +384,6 @@ bool OS_Android::has_virtual_keyboard() const {
 
 int OS_Android::get_virtual_keyboard_height() const {
 	return godot_io_java->get_vk_height();
-
-	// ERR_PRINT("Cannot obtain virtual keyboard height.");
-	// return 0;
 }
 
 void OS_Android::show_virtual_keyboard(const String &p_existing_text, const Rect2 &p_screen_rect, bool p_multiline, int p_max_input_length, int p_cursor_start, int p_cursor_end) {
@@ -395,7 +391,7 @@ void OS_Android::show_virtual_keyboard(const String &p_existing_text, const Rect
 		godot_io_java->show_vk(p_existing_text, p_multiline, p_max_input_length, p_cursor_start, p_cursor_end);
 	} else {
 		ERR_PRINT("Virtual keyboard not available");
-	};
+	}
 }
 
 void OS_Android::hide_virtual_keyboard() {
@@ -403,14 +399,7 @@ void OS_Android::hide_virtual_keyboard() {
 		godot_io_java->hide_vk();
 	} else {
 		ERR_PRINT("Virtual keyboard not available");
-	};
-}
-
-void OS_Android::init_video_mode(int p_video_width, int p_video_height) {
-	default_videomode.width = p_video_width;
-	default_videomode.height = p_video_height;
-	default_videomode.fullscreen = true;
-	default_videomode.resizable = false;
+	}
 }
 
 void OS_Android::set_display_size(Size2 p_size) {
@@ -468,9 +457,9 @@ bool OS_Android::has_clipboard() const {
 
 String OS_Android::get_model_name() const {
 	String model = godot_io_java->get_model();
-	if (model != "")
+	if (model != "") {
 		return model;
-
+	}
 	return OS_Unix::get_model_name();
 }
 
@@ -503,9 +492,9 @@ String OS_Android::get_executable_path() const {
 }
 
 String OS_Android::get_user_data_dir() const {
-	if (data_dir_cache != String())
+	if (data_dir_cache != String()) {
 		return data_dir_cache;
-
+	}
 	String data_dir = godot_io_java->get_user_data_dir();
 	if (data_dir != "") {
 		data_dir_cache = _remove_symlink(data_dir);
@@ -515,9 +504,9 @@ String OS_Android::get_user_data_dir() const {
 }
 
 String OS_Android::get_cache_path() const {
-	if (cache_dir_cache != String())
+	if (cache_dir_cache != String()) {
 		return cache_dir_cache;
-
+	}
 	String cache_dir = godot_io_java->get_cache_dir();
 	if (cache_dir != "") {
 		cache_dir_cache = _remove_symlink(cache_dir);
@@ -538,9 +527,9 @@ OS::ScreenOrientation OS_Android::get_screen_orientation() const {
 
 String OS_Android::get_unique_id() const {
 	String unique_id = godot_io_java->get_unique_id();
-	if (unique_id != "")
+	if (unique_id != "") {
 		return unique_id;
-
+	}
 	return OS::get_unique_id();
 }
 
@@ -605,11 +594,6 @@ OS_Android::OS_Android(GodotJavaWrapper *p_godot_java, GodotIOJavaWrapper *p_god
 	default_videomode.height = 600;
 	default_videomode.fullscreen = true;
 	default_videomode.resizable = false;
-
-	main_loop = NULL;
-	gl_extensions = NULL;
-	//rasterizer = NULL;
-	use_gl2 = false;
 
 	godot_java = p_godot_java;
 	godot_io_java = p_godot_io_java;

--- a/platform/android/os_android.h
+++ b/platform/android/os_android.h
@@ -42,9 +42,7 @@ class GodotJavaWrapper;
 class GodotIOJavaWrapper;
 
 class OS_Android : public OS_Unix {
-	bool use_gl2;
 	bool use_apk_expansion;
-
 	bool secondary_gl_available = false;
 
 	VisualServer *visual_server;
@@ -54,16 +52,14 @@ class OS_Android : public OS_Unix {
 
 	AudioDriverOpenSL audio_driver_android;
 
-	const char *gl_extensions;
+	const char *gl_extensions = nullptr;
 
 	InputDefault *input;
 	VideoMode default_videomode;
-	MainLoop *main_loop;
+	MainLoop *main_loop = nullptr;
 
 	GodotJavaWrapper *godot_java;
 	GodotIOJavaWrapper *godot_io_java;
-
-	//PowerAndroid *power_manager_func;
 
 	int video_driver_index;
 
@@ -173,7 +169,6 @@ public:
 	void process_gravity(const Vector3 &p_gravity);
 	void process_magnetometer(const Vector3 &p_magnetometer);
 	void process_gyroscope(const Vector3 &p_gyroscope);
-	void init_video_mode(int p_video_width, int p_video_height);
 
 	virtual bool is_joy_known(int p_device);
 	virtual String get_joy_guid(int p_device) const;
@@ -191,4 +186,4 @@ private:
 	Error create_instance(const List<String> &p_arguments, ProcessID *r_child_id);
 };
 
-#endif
+#endif // OS_ANDROID_H

--- a/platform/android/plugin/godot_plugin_jni.cpp
+++ b/platform/android/plugin/godot_plugin_jni.cpp
@@ -124,7 +124,7 @@ JNIEXPORT void JNICALL Java_org_godotengine_godot_plugin_GodotPlugin_nativeEmitS
 		variant_params[i] = _jobject_to_variant(env, j_param);
 		args[i] = &variant_params[i];
 		env->DeleteLocalRef(j_param);
-	};
+	}
 
 	singleton->emit_signal(signal_name, args, count);
 }

--- a/platform/android/string_android.h
+++ b/platform/android/string_android.h
@@ -30,6 +30,7 @@
 
 #ifndef STRING_ANDROID_H
 #define STRING_ANDROID_H
+
 #include "core/ustring.h"
 #include "thread_jandroid.h"
 #include <jni.h>

--- a/platform/android/thread_jandroid.h
+++ b/platform/android/thread_jandroid.h
@@ -38,4 +38,4 @@ void init_thread_jandroid(JavaVM *p_jvm, JNIEnv *p_env);
 void setup_android_thread();
 JNIEnv *get_jni_env();
 
-#endif
+#endif // THREAD_JANDROID_H


### PR DESCRIPTION
3.x version of #61573

Cleans up the Android C++ code including:
- Remove dead code
- Add braces around one line conditionals
- Use `ERR_FAIL_NULL(x)` instead of `ERR_FAIL_COND(x == nullptr)`
- Use `nullptr` instead of `NULL` or `0`
- Add missing header protector
- Rename variables shadowing other variables 
