### PR TITLE
Mark node groups as dirty for every children if parent is moved

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -384,11 +384,7 @@ void Node::_move_child(Node *p_child, int p_pos, bool p_ignore_end) {
 	for (int i = motion_from; i <= motion_to; i++) {
 		data.children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
 	}
-	for (const KeyValue<StringName, GroupData> &E : p_child->data.grouped) {
-		if (E.value.group) {
-			E.value.group->changed = true;
-		}
-	}
+	p_child->_propagate_groups_dirty();
 
 	data.blocked--;
 }
@@ -405,6 +401,18 @@ void Node::raise() {
 		data.parent->move_child(this, data.parent->data.internal_children_back - 1);
 	} else {
 		data.parent->move_child(this, data.parent->get_child_count(false) - 1);
+	}
+}
+
+void Node::_propagate_groups_dirty() {
+	for (const KeyValue<StringName, GroupData> &E : data.grouped) {
+		if (E.value.group) {
+			E.value.group->changed = true;
+		}
+	}
+
+	for (int i = 0; i < data.children.size(); i++) {
+		data.children[i]->_propagate_groups_dirty();
 	}
 }
 

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -174,6 +174,7 @@ private:
 	void _propagate_after_exit_tree();
 	void _print_orphan_nodes();
 	void _propagate_process_owner(Node *p_owner, int p_pause_notification, int p_enabled_notification);
+	void _propagate_groups_dirty();
 	Array _get_node_and_resource(const NodePath &p_path);
 
 	void _duplicate_signals(const Node *p_original, Node *p_copy) const;


### PR DESCRIPTION
I think it's finally time to fix https://github.com/godotengine/godot/issues/33449 — my first bug report in Godot 🎉 

As this is a core change, and it involves propagating a call through all child branches, I'm not entirely sure if it's the best solution, but it's the one that's straightforward and does what is required.

Here's the repro project updated for current master:
[bug-move_child-doesnt-update-4.0.zip](https://github.com/godotengine/godot/files/8808156/bug-move_child-doesnt-update-4.0.zip)

PS. A backport for `3.x`: https://github.com/godotengine/godot/pull/61578