### PR TITLE
[3.x] Mark node groups as dirty for every children if parent is moved

### DIFF
--- a/scene/main/node.cpp
+++ b/scene/main/node.cpp
@@ -417,11 +417,7 @@ void Node::move_child(Node *p_child, int p_pos) {
 	for (int i = motion_from; i <= motion_to; i++) {
 		data.children[i]->notification(NOTIFICATION_MOVED_IN_PARENT);
 	}
-	for (const Map<StringName, GroupData>::Element *E = p_child->data.grouped.front(); E; E = E->next()) {
-		if (E->get().group) {
-			E->get().group->changed = true;
-		}
-	}
+	p_child->_propagate_groups_dirty();
 
 	data.blocked--;
 }
@@ -432,6 +428,18 @@ void Node::raise() {
 	}
 
 	data.parent->move_child(this, data.parent->data.children.size() - 1);
+}
+
+void Node::_propagate_groups_dirty() {
+	for (const Map<StringName, GroupData>::Element *E = data.grouped.front(); E; E = E->next()) {
+		if (E->get().group) {
+			E->get().group->changed = true;
+		}
+	}
+
+	for (int i = 0; i < data.children.size(); i++) {
+		data.children[i]->_propagate_groups_dirty();
+	}
 }
 
 void Node::add_child_notify(Node *p_child) {

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -199,6 +199,7 @@ private:
 	void _propagate_physics_interpolated(bool p_interpolated);
 	void _print_stray_nodes();
 	void _propagate_pause_owner(Node *p_owner);
+	void _propagate_groups_dirty();
 	Array _get_node_and_resource(const NodePath &p_path);
 
 	void _duplicate_signals(const Node *p_original, Node *p_copy) const;


### PR DESCRIPTION
Backport of https://github.com/godotengine/godot/pull/61577.

As much as I wish it for 3.5, it's probably too risky. But maybe 3.5.1?