### PR TITLE
Ensure Android Java and Kotlin compile to the same version

### DIFF
--- a/platform/android/java/app/build.gradle
+++ b/platform/android/java/app/build.gradle
@@ -1,6 +1,4 @@
 // Gradle build config for Godot Engine's Android port.
-apply from: 'config.gradle'
-
 buildscript {
     apply from: 'config.gradle'
 
@@ -14,7 +12,12 @@ buildscript {
     }
 }
 
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+apply from: 'config.gradle'
 
 allprojects {
     repositories {
@@ -77,6 +80,10 @@ android {
     compileOptions {
         sourceCompatibility versions.javaVersion
         targetCompatibility versions.javaVersion
+    }
+
+    kotlinOptions {
+        jvmTarget = versions.javaVersion
     }
 
     assetPacks = [":assetPacks:installTime"]

--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -4,8 +4,9 @@ ext.versions = [
     minSdk             : 19, // Also update 'platform/android/java/lib/AndroidManifest.xml#minSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
     targetSdk          : 30, // Also update 'platform/android/java/lib/AndroidManifest.xml#targetSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
     buildTools         : '30.0.3',
-    kotlinVersion      : '1.6.10',
+    kotlinVersion      : '1.6.21',
     fragmentVersion    : '1.3.6',
+    nexusPublishVersion: '1.1.0',
     javaVersion        : 11,
     ndkVersion         : '21.4.7075529' // Also update 'platform/android/detect.py#get_project_ndk_version()' when this is updated.
 
@@ -14,7 +15,7 @@ ext.versions = [
 ext.libraries = [
     androidGradlePlugin: "com.android.tools.build:gradle:$versions.androidGradlePlugin",
     kotlinGradlePlugin : "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlinVersion",
-    kotlinStdLib       : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$versions.kotlinVersion",
+    kotlinStdLib       : "org.jetbrains.kotlin:kotlin-stdlib:$versions.kotlinVersion",
     androidxFragment   : "androidx.fragment:fragment:$versions.fragmentVersion",
 ]
 

--- a/platform/android/java/app/settings.gradle
+++ b/platform/android/java/app/settings.gradle
@@ -1,2 +1,15 @@
 // This is the root directory of the Godot custom build.
+pluginManagement {
+    apply from: 'config.gradle'
+
+    plugins {
+        id 'com.android.application' version versions.androidGradlePlugin
+        id 'org.jetbrains.kotlin.android' version versions.kotlinVersion
+    }
+    repositories {
+        gradlePluginPortal()
+        google()
+    }
+}
+
 include ':assetPacks:installTime'

--- a/platform/android/java/build.gradle
+++ b/platform/android/java/build.gradle
@@ -1,7 +1,3 @@
-apply plugin: 'io.github.gradle-nexus.publish-plugin'
-apply from: 'app/config.gradle'
-apply from: 'scripts/publish-root.gradle'
-
 buildscript {
     apply from: 'app/config.gradle'
 
@@ -16,6 +12,13 @@ buildscript {
         classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
     }
 }
+
+plugins {
+    id 'io.github.gradle-nexus.publish-plugin'
+}
+
+apply from: 'app/config.gradle'
+apply from: 'scripts/publish-root.gradle'
 
 allprojects {
     repositories {

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -1,5 +1,8 @@
 // Gradle build config for Godot Engine's Android port.
-apply plugin: 'com.android.application'
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
 
 dependencies {
     implementation libraries.kotlinStdLib
@@ -27,6 +30,10 @@ android {
     compileOptions {
         sourceCompatibility versions.javaVersion
         targetCompatibility versions.javaVersion
+    }
+
+    kotlinOptions {
+        jvmTarget = versions.javaVersion
     }
 
     buildTypes {

--- a/platform/android/java/lib/build.gradle
+++ b/platform/android/java/lib/build.gradle
@@ -1,5 +1,7 @@
-apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+plugins {
+    id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
+}
 
 ext {
     PUBLISH_VERSION = getGodotPublishVersion()
@@ -32,6 +34,10 @@ android {
     compileOptions {
         sourceCompatibility versions.javaVersion
         targetCompatibility versions.javaVersion
+    }
+
+    kotlinOptions {
+        jvmTarget = versions.javaVersion
     }
 
     buildTypes {

--- a/platform/android/java/nativeSrcsConfigs/build.gradle
+++ b/platform/android/java/nativeSrcsConfigs/build.gradle
@@ -1,6 +1,7 @@
 // Non functional android library used to provide Android Studio editor support to the project.
 plugins {
     id 'com.android.library'
+    id 'org.jetbrains.kotlin.android'
 }
 
 android {
@@ -16,6 +17,10 @@ android {
     compileOptions {
         sourceCompatibility versions.javaVersion
         targetCompatibility versions.javaVersion
+    }
+
+    kotlinOptions {
+        jvmTarget = versions.javaVersion
     }
 
     packagingOptions {

--- a/platform/android/java/settings.gradle
+++ b/platform/android/java/settings.gradle
@@ -1,4 +1,19 @@
 // Configure the root project.
+pluginManagement {
+    apply from: 'app/config.gradle'
+
+    plugins {
+        id 'com.android.application' version versions.androidGradlePlugin
+        id 'com.android.library' version versions.androidGradlePlugin
+        id 'org.jetbrains.kotlin.android' version versions.kotlinVersion
+        id 'io.github.gradle-nexus.publish-plugin' version versions.nexusPublishVersion
+    }
+    repositories {
+        gradlePluginPortal()
+        google()
+    }
+}
+
 rootProject.name = "Godot"
 
 include ':app'


### PR DESCRIPTION
Currently there is a mismatch between the Java and Kotlin classes compilation version targets. Java classes are being compiled using Java version 11, but the Kotlin classes are being compiled to be compatible with Java version 1.8.

This is the warning generated by the Gradle build:
```
'compileTemplateReleaseJavaWithJavac' task (current target is 11) and 'compileTemplateReleaseKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version.
```

This PR ensures that Java and Kotlin classes are compiled to the same Java version: 11.