### PR TITLE
Fix RenderingServerDefault usage of `has_os_feature`

### DIFF
--- a/drivers/gles3/rasterizer_storage_gles3.cpp
+++ b/drivers/gles3/rasterizer_storage_gles3.cpp
@@ -442,6 +442,10 @@ bool RasterizerStorageGLES3::free(RID p_rid) {
 }
 
 bool RasterizerStorageGLES3::has_os_feature(const String &p_feature) const {
+	if (!config) {
+		return false;
+	}
+
 	if (p_feature == "rgtc") {
 		return config->rgtc_supported;
 	}

--- a/servers/rendering/renderer_rd/renderer_storage_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_storage_rd.cpp
@@ -592,6 +592,10 @@ void RendererStorageRD::update_dirty_resources() {
 }
 
 bool RendererStorageRD::has_os_feature(const String &p_feature) const {
+	if (!RD::get_singleton()) {
+		return false;
+	}
+
 	if (p_feature == "rgtc" && RD::get_singleton()->texture_is_format_supported_for_usage(RD::DATA_FORMAT_BC5_UNORM_BLOCK, RD::TEXTURE_USAGE_SAMPLING_BIT)) {
 		return true;
 	}

--- a/servers/rendering/rendering_server_default.cpp
+++ b/servers/rendering/rendering_server_default.cpp
@@ -313,7 +313,11 @@ RID RenderingServerDefault::get_test_cube() {
 }
 
 bool RenderingServerDefault::has_os_feature(const String &p_feature) const {
-	return RSG::storage->has_os_feature(p_feature);
+	if (RSG::storage) {
+		return RSG::storage->has_os_feature(p_feature);
+	} else {
+		return false;
+	}
 }
 
 void RenderingServerDefault::set_debug_generate_wireframes(bool p_generate) {
@@ -384,6 +388,8 @@ void RenderingServerDefault::draw(bool p_swap_buffers, double frame_step) {
 
 RenderingServerDefault::RenderingServerDefault(bool p_create_thread) :
 		command_queue(p_create_thread) {
+	RenderingServer::init();
+
 	create_thread = p_create_thread;
 
 	if (!p_create_thread) {

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2821,7 +2821,9 @@ RenderingServer::RenderingServer() {
 
 	thread_pool = memnew(RendererThreadPool);
 	singleton = this;
+}
 
+void RenderingServer::init() {
 	GLOBAL_DEF_RST("rendering/textures/vram_compression/import_bptc", false);
 	GLOBAL_DEF_RST("rendering/textures/vram_compression/import_s3tc", true);
 	GLOBAL_DEF_RST("rendering/textures/vram_compression/import_etc", false);

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -1471,7 +1471,7 @@ public:
 	virtual void draw(bool p_swap_buffers = true, double frame_step = 0.0) = 0;
 	virtual void sync() = 0;
 	virtual bool has_changed() const = 0;
-	virtual void init() = 0;
+	virtual void init();
 	virtual void finish() = 0;
 
 	/* STATUS INFORMATION */


### PR DESCRIPTION
Fixes Reduz's PR https://github.com/godotengine/godot/pull/61436
Prevents crash that we were having here

(originally created this PR on reduz's fork but it gets lost there :))