### PR TITLE
Fix theme propagation for children of top level controls and windows

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -719,8 +719,20 @@ void Control::_notification(int p_notification) {
 			data.parent_window = Object::cast_to<Window>(get_parent());
 			data.is_rtl_dirty = true;
 
+			if (data.theme.is_null()) {
+				if (data.parent && (data.parent->data.theme_owner || data.parent->data.theme_owner_window)) {
+					data.theme_owner = data.parent->data.theme_owner;
+					data.theme_owner_window = data.parent->data.theme_owner_window;
+					notification(NOTIFICATION_THEME_CHANGED);
+				} else if (data.parent_window && (data.parent_window->theme_owner || data.parent_window->theme_owner_window)) {
+					data.theme_owner = data.parent_window->theme_owner;
+					data.theme_owner_window = data.parent_window->theme_owner_window;
+					notification(NOTIFICATION_THEME_CHANGED);
+				}
+			}
+
 			CanvasItem *node = this;
-			Control *parent_control = nullptr;
+			bool has_parent_control = false;
 
 			while (!node->is_set_as_top_level()) {
 				CanvasItem *parent = Object::cast_to<CanvasItem>(node->get_parent());
@@ -728,22 +740,19 @@ void Control::_notification(int p_notification) {
 					break;
 				}
 
-				parent_control = Object::cast_to<Control>(parent);
+				Control *parent_control = Object::cast_to<Control>(parent);
 				if (parent_control) {
+					has_parent_control = true;
 					break;
 				}
 
 				node = parent;
 			}
 
-			if (parent_control) {
+			if (has_parent_control) {
 				// Do nothing, has a parent control.
-				if (data.theme.is_null() && parent_control->data.theme_owner) {
-					data.theme_owner = parent_control->data.theme_owner;
-					notification(NOTIFICATION_THEME_CHANGED);
-				}
 			} else {
-				//is a regular root control or top_level
+				// Is a regular root control or top_level.
 				Viewport *viewport = get_viewport();
 				ERR_FAIL_COND(!viewport);
 				data.RI = viewport->_gui_add_root_control(this);
@@ -754,7 +763,7 @@ void Control::_notification(int p_notification) {
 			if (data.parent_canvas_item) {
 				data.parent_canvas_item->connect("item_rect_changed", callable_mp(this, &Control::_size_changed));
 			} else {
-				//connect viewport
+				// Connect viewport.
 				Viewport *viewport = get_viewport();
 				ERR_FAIL_COND(!viewport);
 				viewport->connect("size_changed", callable_mp(this, &Control::_size_changed));

--- a/scene/main/window.cpp
+++ b/scene/main/window.cpp
@@ -791,6 +791,22 @@ void Window::_notification(int p_what) {
 				emit_signal(SceneStringNames::get_singleton()->visibility_changed);
 				RS::get_singleton()->viewport_set_active(get_viewport_rid(), true);
 			}
+
+			if (theme.is_null()) {
+				Control *parent_c = cast_to<Control>(get_parent());
+				if (parent_c && (parent_c->data.theme_owner || parent_c->data.theme_owner_window)) {
+					theme_owner = parent_c->data.theme_owner;
+					theme_owner_window = parent_c->data.theme_owner_window;
+					notification(NOTIFICATION_THEME_CHANGED);
+				} else {
+					Window *parent_w = cast_to<Window>(get_parent());
+					if (parent_w && (parent_w->theme_owner || parent_w->theme_owner_window)) {
+						theme_owner = parent_w->theme_owner;
+						theme_owner_window = parent_w->theme_owner_window;
+						notification(NOTIFICATION_THEME_CHANGED);
+					}
+				}
+			}
 		} break;
 
 		case NOTIFICATION_READY: {


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/36103 for `master`. The issue was in the logic that assigned theme owner. For some reason, probably in error, theme owner was never assigned if the direct parent was a control that was marked as top level. Not entirely sure, why this only affected editor plugins (at least in 3.x), but not running projects.

A further regression witnessed by @KoBeWi in the comments was because `Window` was missing this logic entirely.

I've also cleaned up related code a bit, since we don't need a node reference anymore. I'm not very happy with the theme owner / theme owner window logic that we have, and the duplication that we have. It's too convoluted for such a simple system. But I decided to focus on fixing the issue, and didn't do any refactoring.

A slightly modified repro for `master`:
[bug-theme-dialogs-4.0.zip](https://github.com/godotengine/godot/files/8810355/bug-theme-dialogs-4.0.zip)
 