### PR TITLE
Fix crash on NaN offset in path_follower 2d and 3d

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -304,6 +304,7 @@ void PathFollow2D::_bind_methods() {
 }
 
 void PathFollow2D::set_offset(real_t p_offset) {
+	ERR_FAIL_COND(!isfinite(p_offset));
 	offset = p_offset;
 	if (path) {
 		if (path->get_curve().is_valid()) {

--- a/scene/3d/path_3d.cpp
+++ b/scene/3d/path_3d.cpp
@@ -397,6 +397,7 @@ void PathFollow3D::_bind_methods() {
 }
 
 void PathFollow3D::set_offset(real_t p_offset) {
+	ERR_FAIL_COND(!isfinite(p_offset));
 	prev_offset = offset;
 	offset = p_offset;
 


### PR DESCRIPTION
Setting the offset of `PathFollower2D` or `PathFollower3D` to `NaN` caused a crash.
I found this out when accidentally setting the offset to `sqrt(some_negative_number)`

(Today I learnt that casting a `NaN` float to a double actually results in a number apparently)