### PR TITLE
[3.x] Fix `get_data()` for GradientTexture2D

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -2021,7 +2021,7 @@ RID GradientTexture2D::get_rid() const {
 	return texture;
 }
 
-Ref<Image> GradientTexture2D::get_image() const {
+Ref<Image> GradientTexture2D::get_data() const {
 	if (!texture.is_valid()) {
 		return Ref<Image>();
 	}

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -716,7 +716,7 @@ public:
 
 	virtual RID get_rid() const;
 	virtual bool has_alpha() const { return true; }
-	virtual Ref<Image> get_image() const;
+	virtual Ref<Image> get_data() const;
 
 	GradientTexture2D();
 	virtual ~GradientTexture2D();


### PR DESCRIPTION
Fixes `GradientTexture2D.get_data()` always returning null. 

The rename of `Texture.get_data()` to `get_image()` (https://github.com/godotengine/godot/pull/47435) was lost in the process of backporting GradientTexture2D. The function was there, but it was using the 4.0 name instead of the 3.x name and simply renaming the function fixes the issue entirely.

As a workaround, this can be used in place of `get_data()` until this PR is merged. I'm using this workaround in my own project.
```gdscript
VisualServer.texture_get_data(texture.get_rid())
```