### PR TITLE
Misc Android editor tweaks and polishes

### DIFF
--- a/platform/android/java/app/config.gradle
+++ b/platform/android/java/app/config.gradle
@@ -1,6 +1,6 @@
 ext.versions = [
     androidGradlePlugin: '7.0.3',
-    compileSdk         : 30,
+    compileSdk         : 31,
     minSdk             : 19, // Also update 'platform/android/java/lib/AndroidManifest.xml#minSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_MIN_SDK_VERSION'
     targetSdk          : 30, // Also update 'platform/android/java/lib/AndroidManifest.xml#targetSdkVersion' & 'platform/android/export/export_plugin.cpp#DEFAULT_TARGET_SDK_VERSION'
     buildTools         : '30.0.3',

--- a/platform/android/java/editor/build.gradle
+++ b/platform/android/java/editor/build.gradle
@@ -5,6 +5,8 @@ dependencies {
     implementation libraries.kotlinStdLib
     implementation libraries.androidxFragment
     implementation project(":lib")
+
+    implementation "androidx.window:window:1.0.0"
 }
 
 android {

--- a/platform/android/java/editor/src/main/AndroidManifest.xml
+++ b/platform/android/java/editor/src/main/AndroidManifest.xml
@@ -34,6 +34,9 @@
             android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen"
             android:process=":GodotProjectManager">
 
+            <layout android:defaultHeight="@dimen/editor_default_window_height"
+                android:defaultWidth="@dimen/editor_default_window_width" />
+
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
@@ -47,6 +50,8 @@
             android:launchMode="singleTask"
             android:screenOrientation="userLandscape"
             android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
+            <layout android:defaultHeight="@dimen/editor_default_window_height"
+                android:defaultWidth="@dimen/editor_default_window_width" />
         </activity>
 
         <activity
@@ -57,6 +62,8 @@
             android:launchMode="singleTask"
             android:screenOrientation="userLandscape"
             android:theme="@android:style/Theme.Black.NoTitleBar.Fullscreen">
+            <layout android:defaultHeight="@dimen/editor_default_window_height"
+                android:defaultWidth="@dimen/editor_default_window_width" />
         </activity>
 
     </application>

--- a/platform/android/java/editor/src/main/res/values/dimens.xml
+++ b/platform/android/java/editor/src/main/res/values/dimens.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<dimen name="editor_default_window_height">600dp</dimen>
+	<dimen name="editor_default_window_width">800dp</dimen>
+</resources>

--- a/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
+++ b/platform/android/java/lib/src/org/godotengine/godot/GodotIO.java
@@ -224,12 +224,30 @@ public class GodotIO {
 	}
 
 	public int getScreenDPI() {
-		DisplayMetrics metrics = activity.getResources().getDisplayMetrics();
-		return (int)(metrics.density * 160f);
+		return activity.getResources().getDisplayMetrics().densityDpi;
 	}
 
+	/**
+	 * Returns bucketized density values.
+	 */
 	public float getScaledDensity() {
-		return activity.getResources().getDisplayMetrics().scaledDensity;
+		int densityDpi = activity.getResources().getDisplayMetrics().densityDpi;
+		float selectedScaledDensity;
+		if (densityDpi >= DisplayMetrics.DENSITY_XXXHIGH) {
+			selectedScaledDensity = 4.0f;
+		} else if (densityDpi >= DisplayMetrics.DENSITY_XXHIGH) {
+			selectedScaledDensity = 3.0f;
+		} else if (densityDpi >= DisplayMetrics.DENSITY_XHIGH) {
+			selectedScaledDensity = 2.0f;
+		} else if (densityDpi >= DisplayMetrics.DENSITY_HIGH) {
+			selectedScaledDensity = 1.5f;
+		} else if (densityDpi >= DisplayMetrics.DENSITY_MEDIUM) {
+			selectedScaledDensity = 1.0f;
+		} else {
+			selectedScaledDensity = 0.75f;
+		}
+		Log.d(TAG, "Selected scaled density: " + selectedScaledDensity);
+		return selectedScaledDensity;
 	}
 
 	public double getScreenRefreshRate(double fallback) {


### PR DESCRIPTION
- Using a bucketized approach to select the editor scale in order to avoid too high values
  - Should help address #60728
- Add default app dimensions: used on Android devices with free floating app windows to set the default app frame
- Add ability to launch the Game window in an adjacent frame when in multi window mode

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
