### PR TITLE
Discontinued BoneName in the Skin and BoneAttachment

### DIFF
--- a/doc/classes/BoneAttachment3D.xml
+++ b/doc/classes/BoneAttachment3D.xml
@@ -71,11 +71,8 @@
 		</method>
 	</methods>
 	<members>
-		<member name="bone_idx" type="int" setter="set_bone_idx" getter="get_bone_idx" default="-1">
+		<member name="bone" type="int" setter="set_bone" getter="get_bone" default="0">
 			The index of the attached bone.
-		</member>
-		<member name="bone_name" type="String" setter="set_bone_name" getter="get_bone_name" default="&quot;&quot;">
-			The name of the attached bone.
 		</member>
 	</members>
 </class>

--- a/doc/classes/Skeleton3D.xml
+++ b/doc/classes/Skeleton3D.xml
@@ -175,6 +175,11 @@
 				Returns the rest transform for a bone [code]bone_idx[/code].
 			</description>
 		</method>
+		<method name="get_concatenated_bone_names" qualifiers="const">
+			<return type="String" />
+			<description>
+			</description>
+		</method>
 		<method name="get_modification_stack">
 			<return type="SkeletonModificationStack3D" />
 			<description>

--- a/doc/classes/Skin.xml
+++ b/doc/classes/Skin.xml
@@ -14,13 +14,6 @@
 			<description>
 			</description>
 		</method>
-		<method name="add_named_bind">
-			<return type="void" />
-			<argument index="0" name="name" type="String" />
-			<argument index="1" name="pose" type="Transform3D" />
-			<description>
-			</description>
-		</method>
 		<method name="clear_binds">
 			<return type="void" />
 			<description>
@@ -34,12 +27,6 @@
 		</method>
 		<method name="get_bind_count" qualifiers="const">
 			<return type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="get_bind_name" qualifiers="const">
-			<return type="StringName" />
-			<argument index="0" name="bind_index" type="int" />
 			<description>
 			</description>
 		</method>
@@ -59,13 +46,6 @@
 		<method name="set_bind_count">
 			<return type="void" />
 			<argument index="0" name="bind_count" type="int" />
-			<description>
-			</description>
-		</method>
-		<method name="set_bind_name">
-			<return type="void" />
-			<argument index="0" name="bind_index" type="int" />
-			<argument index="1" name="name" type="StringName" />
 			<description>
 			</description>
 		</method>

--- a/modules/gltf/doc_classes/GLTFState.xml
+++ b/modules/gltf/doc_classes/GLTFState.xml
@@ -208,7 +208,5 @@
 		</member>
 		<member name="scene_name" type="String" setter="set_scene_name" getter="get_scene_name" default="&quot;&quot;">
 		</member>
-		<member name="use_named_skin_binds" type="bool" setter="set_use_named_skin_binds" getter="get_use_named_skin_binds" default="false">
-		</member>
 	</members>
 </class>

--- a/modules/gltf/gltf_state.cpp
+++ b/modules/gltf/gltf_state.cpp
@@ -39,8 +39,6 @@ void GLTFState::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_minor_version", "minor_version"), &GLTFState::set_minor_version);
 	ClassDB::bind_method(D_METHOD("get_glb_data"), &GLTFState::get_glb_data);
 	ClassDB::bind_method(D_METHOD("set_glb_data", "glb_data"), &GLTFState::set_glb_data);
-	ClassDB::bind_method(D_METHOD("get_use_named_skin_binds"), &GLTFState::get_use_named_skin_binds);
-	ClassDB::bind_method(D_METHOD("set_use_named_skin_binds", "use_named_skin_binds"), &GLTFState::set_use_named_skin_binds);
 	ClassDB::bind_method(D_METHOD("get_nodes"), &GLTFState::get_nodes);
 	ClassDB::bind_method(D_METHOD("set_nodes", "nodes"), &GLTFState::set_nodes);
 	ClassDB::bind_method(D_METHOD("get_buffers"), &GLTFState::get_buffers);
@@ -87,7 +85,6 @@ void GLTFState::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "major_version"), "set_major_version", "get_major_version"); // int
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "minor_version"), "set_minor_version", "get_minor_version"); // int
 	ADD_PROPERTY(PropertyInfo(Variant::PACKED_BYTE_ARRAY, "glb_data"), "set_glb_data", "get_glb_data"); // Vector<uint8_t>
-	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_named_skin_binds"), "set_use_named_skin_binds", "get_use_named_skin_binds"); // bool
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "nodes", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_EDITOR), "set_nodes", "get_nodes"); // Vector<Ref<GLTFNode>>
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "buffers"), "set_buffers", "get_buffers"); // Vector<Vector<uint8_t>
 	ADD_PROPERTY(PropertyInfo(Variant::ARRAY, "buffer_views", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_INTERNAL | PROPERTY_USAGE_EDITOR), "set_buffer_views", "get_buffer_views"); // Vector<Ref<GLTFBufferView>>
@@ -139,14 +136,6 @@ Vector<uint8_t> GLTFState::get_glb_data() {
 
 void GLTFState::set_glb_data(Vector<uint8_t> p_glb_data) {
 	glb_data = p_glb_data;
-}
-
-bool GLTFState::get_use_named_skin_binds() {
-	return use_named_skin_binds;
-}
-
-void GLTFState::set_use_named_skin_binds(bool p_use_named_skin_binds) {
-	use_named_skin_binds = p_use_named_skin_binds;
 }
 
 Array GLTFState::get_nodes() {

--- a/modules/gltf/gltf_state.h
+++ b/modules/gltf/gltf_state.h
@@ -59,7 +59,6 @@ class GLTFState : public Resource {
 	int minor_version = 0;
 	Vector<uint8_t> glb_data;
 
-	bool use_named_skin_binds = false;
 	bool discard_meshes_and_materials = false;
 
 	Vector<Ref<GLTFNode>> nodes;
@@ -107,9 +106,6 @@ public:
 
 	Vector<uint8_t> get_glb_data();
 	void set_glb_data(Vector<uint8_t> p_glb_data);
-
-	bool get_use_named_skin_binds();
-	void set_use_named_skin_binds(bool p_use_named_skin_binds);
 
 	bool get_discard_meshes_and_materials();
 	void set_discard_meshes_and_materials(bool p_discard_meshes_and_materials);

--- a/scene/3d/bone_attachment_3d.h
+++ b/scene/3d/bone_attachment_3d.h
@@ -37,8 +37,7 @@ class BoneAttachment3D : public Node3D {
 	GDCLASS(BoneAttachment3D, Node3D);
 
 	bool bound = false;
-	String bone_name;
-	int bone_idx = -1;
+	int bone = 0;
 
 	bool override_pose = false;
 	int override_mode = 0;
@@ -72,11 +71,8 @@ protected:
 public:
 	virtual TypedArray<String> get_configuration_warnings() const override;
 
-	void set_bone_name(const String &p_name);
-	String get_bone_name() const;
-
-	void set_bone_idx(const int &p_idx);
-	int get_bone_idx() const;
+	void set_bone(const int &p_idx);
+	int get_bone() const;
 
 	void set_override_pose(bool p_override);
 	bool get_override_pose() const;

--- a/scene/3d/skeleton_3d.cpp
+++ b/scene/3d/skeleton_3d.cpp
@@ -277,24 +277,7 @@ void Skeleton3D::_notification(int p_what) {
 
 				if (E->skeleton_version != version) {
 					for (uint32_t i = 0; i < bind_count; i++) {
-						StringName bind_name = skin->get_bind_name(i);
-
-						if (bind_name != StringName()) {
-							// Bind name used, use this.
-							bool found = false;
-							for (int j = 0; j < len; j++) {
-								if (bonesptr[j].name == bind_name) {
-									E->skin_bone_indices_ptrs[i] = j;
-									found = true;
-									break;
-								}
-							}
-
-							if (!found) {
-								ERR_PRINT("Skin bind #" + itos(i) + " contains named bind '" + String(bind_name) + "' but Skeleton3D has no bone by that name.");
-								E->skin_bone_indices_ptrs[i] = 0;
-							}
-						} else if (skin->get_bind_bone(i) >= 0) {
+						if (skin->get_bind_bone(i) >= 0) {
 							int bind_index = skin->get_bind_bone(i);
 							if (bind_index >= len) {
 								ERR_PRINT("Skin bind #" + itos(i) + " contains bone index bind: " + itos(bind_index) + " , which is greater than the skeleton bone count: " + itos(len) + ".");
@@ -540,6 +523,15 @@ void Skeleton3D::set_bone_name(int p_bone, const String &p_name) {
 	}
 
 	bones.write[p_bone].name = p_name;
+}
+
+String Skeleton3D::get_concatenated_bone_names() const {
+	String bns;
+	const int bone_size = bones.size();
+	for (int i = 0; i < bone_size; i++) {
+		bns = bns + (i == 0 ? bones[i].name : "," + bones[i].name);
+	}
+	return bns;
 }
 
 bool Skeleton3D::is_bone_parent_of(int p_bone, int p_parent_bone_id) const {
@@ -1208,6 +1200,7 @@ void Skeleton3D::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("find_bone", "name"), &Skeleton3D::find_bone);
 	ClassDB::bind_method(D_METHOD("get_bone_name", "bone_idx"), &Skeleton3D::get_bone_name);
 	ClassDB::bind_method(D_METHOD("set_bone_name", "bone_idx", "name"), &Skeleton3D::set_bone_name);
+	ClassDB::bind_method(D_METHOD("get_concatenated_bone_names"), &Skeleton3D::get_concatenated_bone_names);
 
 	ClassDB::bind_method(D_METHOD("get_bone_parent", "bone_idx"), &Skeleton3D::get_bone_parent);
 	ClassDB::bind_method(D_METHOD("set_bone_parent", "bone_idx", "parent_idx"), &Skeleton3D::set_bone_parent);

--- a/scene/3d/skeleton_3d.h
+++ b/scene/3d/skeleton_3d.h
@@ -182,6 +182,7 @@ public:
 	int find_bone(const String &p_name) const;
 	String get_bone_name(int p_bone) const;
 	void set_bone_name(int p_bone, const String &p_name);
+	String get_concatenated_bone_names() const;
 
 	bool is_bone_parent_of(int p_bone_id, int p_parent_bone_id) const;
 

--- a/scene/resources/skin.cpp
+++ b/scene/resources/skin.cpp
@@ -45,23 +45,6 @@ void Skin::add_bind(int p_bone, const Transform3D &p_pose) {
 	set_bind_pose(index, p_pose);
 }
 
-void Skin::add_named_bind(const String &p_name, const Transform3D &p_pose) {
-	uint32_t index = bind_count;
-	set_bind_count(bind_count + 1);
-	set_bind_name(index, p_name);
-	set_bind_pose(index, p_pose);
-}
-
-void Skin::set_bind_name(int p_index, const StringName &p_name) {
-	ERR_FAIL_INDEX(p_index, bind_count);
-	bool notify_change = (binds_ptr[p_index].name != StringName()) != (p_name != StringName());
-	binds_ptr[p_index].name = p_name;
-	emit_changed();
-	if (notify_change) {
-		notify_property_list_changed();
-	}
-}
-
 void Skin::set_bind_bone(int p_index, int p_bone) {
 	ERR_FAIL_INDEX(p_index, bind_count);
 	binds_ptr[p_index].bone = p_bone;
@@ -96,9 +79,6 @@ bool Skin::_set(const StringName &p_name, const Variant &p_value) {
 		if (what == "bone") {
 			set_bind_bone(index, p_value);
 			return true;
-		} else if (what == "name") {
-			set_bind_name(index, p_value);
-			return true;
 		} else if (what == "pose") {
 			set_bind_pose(index, p_value);
 			return true;
@@ -118,9 +98,6 @@ bool Skin::_get(const StringName &p_name, Variant &r_ret) const {
 		if (what == "bone") {
 			r_ret = get_bind_bone(index);
 			return true;
-		} else if (what == "name") {
-			r_ret = get_bind_name(index);
-			return true;
 		} else if (what == "pose") {
 			r_ret = get_bind_pose(index);
 			return true;
@@ -133,8 +110,7 @@ void Skin::_get_property_list(List<PropertyInfo> *p_list) const {
 	p_list->push_back(PropertyInfo(Variant::INT, PNAME("bind_count"), PROPERTY_HINT_RANGE, "0,16384,1,or_greater"));
 	for (int i = 0; i < get_bind_count(); i++) {
 		const String prefix = vformat("%s/%d/", PNAME("bind"), i);
-		p_list->push_back(PropertyInfo(Variant::STRING_NAME, prefix + PNAME("name")));
-		p_list->push_back(PropertyInfo(Variant::INT, prefix + PNAME("bone"), PROPERTY_HINT_RANGE, "0,16384,1,or_greater", get_bind_name(i) != StringName() ? PROPERTY_USAGE_NO_EDITOR : PROPERTY_USAGE_DEFAULT));
+		p_list->push_back(PropertyInfo(Variant::INT, prefix + PNAME("bone"), PROPERTY_HINT_RANGE, "0,16384,1,or_greater"));
 		p_list->push_back(PropertyInfo(Variant::TRANSFORM3D, prefix + PNAME("pose")));
 	}
 }
@@ -144,13 +120,9 @@ void Skin::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_bind_count"), &Skin::get_bind_count);
 
 	ClassDB::bind_method(D_METHOD("add_bind", "bone", "pose"), &Skin::add_bind);
-	ClassDB::bind_method(D_METHOD("add_named_bind", "name", "pose"), &Skin::add_named_bind);
 
 	ClassDB::bind_method(D_METHOD("set_bind_pose", "bind_index", "pose"), &Skin::set_bind_pose);
 	ClassDB::bind_method(D_METHOD("get_bind_pose", "bind_index"), &Skin::get_bind_pose);
-
-	ClassDB::bind_method(D_METHOD("set_bind_name", "bind_index", "name"), &Skin::set_bind_name);
-	ClassDB::bind_method(D_METHOD("get_bind_name", "bind_index"), &Skin::get_bind_name);
 
 	ClassDB::bind_method(D_METHOD("set_bind_bone", "bind_index", "bone"), &Skin::set_bind_bone);
 	ClassDB::bind_method(D_METHOD("get_bind_bone", "bind_index"), &Skin::get_bind_bone);

--- a/scene/resources/skin.h
+++ b/scene/resources/skin.h
@@ -38,7 +38,6 @@ class Skin : public Resource {
 
 	struct Bind {
 		int bone = -1;
-		StringName name;
 		Transform3D pose;
 	};
 
@@ -60,20 +59,13 @@ public:
 	inline int get_bind_count() const { return bind_count; }
 
 	void add_bind(int p_bone, const Transform3D &p_pose);
-	void add_named_bind(const String &p_name, const Transform3D &p_pose);
 
 	void set_bind_bone(int p_index, int p_bone);
 	void set_bind_pose(int p_index, const Transform3D &p_pose);
-	void set_bind_name(int p_index, const StringName &p_name);
 
 	inline int get_bind_bone(int p_index) const {
 		ERR_FAIL_INDEX_V(p_index, bind_count, -1);
 		return binds_ptr[p_index].bone;
-	}
-
-	inline StringName get_bind_name(int p_index) const {
-		ERR_FAIL_INDEX_V(p_index, bind_count, StringName());
-		return binds_ptr[p_index].name;
 	}
 
 	inline Transform3D get_bind_pose(int p_index) const {


### PR DESCRIPTION
This is part of implementing Importer retarget https://github.com/godotengine/godot-proposals/issues/4510. In PostImporter, if Skin stores the BoneName individually from Skeleton, we need to rewrite them all when we rename the Bone.

In Animation, it makes sense to use BoneName because of the possibility of sharing. In other cases, the BoneName should not be retained and only the BoneIdx should be retained. So this PR discontinues BoneName in the Skin.

Perhaps a same fix may be needed for SkeletonModification later. Thus, I implemented `Skeleton3D::get_concatenated_bone_names()` in case the BoneIdx needs to be changed in some Object. This is helpful to generate a hint for the BoneIdx enum on the EditorPlugin.