### PR TITLE
[3.x] Fix several typos in the classref

### DIFF
--- a/doc/classes/PoolByteArray.xml
+++ b/doc/classes/PoolByteArray.xml
@@ -9,7 +9,7 @@
 		[codeblock]
 		var array = [PoolByteArray()]
 		array[0].push_back(123)
-		print(array)  # [[]] (empty PoolByteArray within an empty Array)
+		print(array)  # [[]] (empty PoolByteArray within an Array)
 		[/codeblock]
 		Instead, the entire [PoolByteArray] property must be [i]reassigned[/i] with [code]=[/code] for it to be changed:
 		[codeblock]

--- a/doc/classes/PoolColorArray.xml
+++ b/doc/classes/PoolColorArray.xml
@@ -9,7 +9,7 @@
 		[codeblock]
 		var array = [PoolColorArray()]
 		array[0].push_back(Color(0.1, 0.2, 0.3, 0.4))
-		print(array)  # [[]] (empty PoolColorArray within an empty Array)
+		print(array)  # [[]] (empty PoolColorArray within an Array)
 		[/codeblock]
 		Instead, the entire [PoolColorArray] property must be [i]reassigned[/i] with [code]=[/code] for it to be changed:
 		[codeblock]

--- a/doc/classes/PoolIntArray.xml
+++ b/doc/classes/PoolIntArray.xml
@@ -9,7 +9,7 @@
 		[codeblock]
 		var array = [PoolIntArray()]
 		array[0].push_back(1234)
-		print(array)  # [[]] (empty PoolIntArray within an empty Array)
+		print(array)  # [[]] (empty PoolIntArray within an Array)
 		[/codeblock]
 		Instead, the entire [PoolIntArray] property must be [i]reassigned[/i] with [code]=[/code] for it to be changed:
 		[codeblock]

--- a/doc/classes/PoolRealArray.xml
+++ b/doc/classes/PoolRealArray.xml
@@ -9,7 +9,7 @@
 		[codeblock]
 		var array = [PoolRealArray()]
 		array[0].push_back(12.34)
-		print(array)  # [[]] (empty PoolRealArray within an empty Array)
+		print(array)  # [[]] (empty PoolRealArray within an Array)
 		[/codeblock]
 		Instead, the entire [PoolRealArray] property must be [i]reassigned[/i] with [code]=[/code] for it to be changed:
 		[codeblock]

--- a/doc/classes/PoolStringArray.xml
+++ b/doc/classes/PoolStringArray.xml
@@ -9,7 +9,7 @@
 		[codeblock]
 		var array = [PoolStringArray()]
 		array[0].push_back("hello")
-		print(array)  # [[]] (empty PoolStringArray within an empty Array)
+		print(array)  # [[]] (empty PoolStringArray within an Array)
 		[/codeblock]
 		Instead, the entire [PoolStringArray] property must be [i]reassigned[/i] with [code]=[/code] for it to be changed:
 		[codeblock]

--- a/doc/classes/PoolVector2Array.xml
+++ b/doc/classes/PoolVector2Array.xml
@@ -9,7 +9,7 @@
 		[codeblock]
 		var array = [PoolVector2Array()]
 		array[0].push_back(Vector2(12, 34))
-		print(array)  # [[]] (empty PoolVector2Array within an empty Array)
+		print(array)  # [[]] (empty PoolVector2Array within an Array)
 		[/codeblock]
 		Instead, the entire [PoolVector2Array] property must be [i]reassigned[/i] with [code]=[/code] for it to be changed:
 		[codeblock]

--- a/doc/classes/PoolVector3Array.xml
+++ b/doc/classes/PoolVector3Array.xml
@@ -9,7 +9,7 @@
 		[codeblock]
 		var array = [PoolVector3Array()]
 		array[0].push_back(Vector3(12, 34, 56))
-		print(array)  # [[]] (empty PoolVector3Array within an empty Array)
+		print(array)  # [[]] (empty PoolVector3Array within an Array)
 		[/codeblock]
 		Instead, the entire [PoolVector3Array] property must be [i]reassigned[/i] with [code]=[/code] for it to be changed:
 		[codeblock]

--- a/doc/classes/RigidBody.xml
+++ b/doc/classes/RigidBody.xml
@@ -108,7 +108,7 @@
 	</methods>
 	<members>
 		<member name="angular_damp" type="float" setter="set_angular_damp" getter="get_angular_damp" default="-1.0">
-			Damps RigidBody's rotational forces. If this value is different from -1.0 it will be added to any linear damp derived from the world or areas.
+			Damps the body's rotational forces. If this value is different from -1.0 it will be added to any angular damp derived from the world or areas.
 			See [member ProjectSettings.physics/3d/default_angular_damp] for more details about damping.
 		</member>
 		<member name="angular_velocity" type="Vector3" setter="set_angular_velocity" getter="get_angular_velocity" default="Vector3( 0, 0, 0 )">


### PR DESCRIPTION
https://github.com/godotengine/godot/blob/e9d3748e93844dc4fd4e2f83b658cb4330cef91d/doc/classes/PoolByteArray.xml#L12 `array` is not an _empty_ array.

https://github.com/godotengine/godot/blob/e9d3748e93844dc4fd4e2f83b658cb4330cef91d/doc/classes/RigidBody.xml#L110-L111

* This will be added to angular damp instead of linear damp.
* Use "the body's X" instead of "RigidBody's X" so that it's consistent with other descriptions.