### PR TITLE
[3.x] Fix crash on NaN offset in path_follower 2d and 3d

### DIFF
--- a/scene/2d/path_2d.cpp
+++ b/scene/2d/path_2d.cpp
@@ -312,6 +312,7 @@ void PathFollow2D::_bind_methods() {
 }
 
 void PathFollow2D::set_offset(float p_offset) {
+	ERR_FAIL_COND(!isfinite(p_offset));
 	offset = p_offset;
 	if (path) {
 		if (path->get_curve().is_valid()) {

--- a/scene/3d/path.cpp
+++ b/scene/3d/path.cpp
@@ -320,6 +320,7 @@ void PathFollow::_bind_methods() {
 }
 
 void PathFollow::set_offset(float p_offset) {
+	ERR_FAIL_COND(!isfinite(p_offset));
 	delta_offset = p_offset - offset;
 	offset = p_offset;
 


### PR DESCRIPTION
3.x version of #61590