### PR TITLE
Document that NavigationAgent height offset is mostly a placebo

### DIFF
--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -86,7 +86,7 @@
 	</methods>
 	<members>
 		<member name="agent_height_offset" type="float" setter="set_agent_height_offset" getter="get_agent_height_offset" default="0.0">
-			The agent height offset to match the navigation mesh height.
+			The NavigationAgent height offset is subtracted from the y-axis value of any vector path position for this NavigationAgent. The NavigationAgent height offset does not change or influence the navigation mesh or pathfinding query result. Additional navigation maps that use regions with navigation meshes that the developer baked with appropriate agent radius or height values are required to support different-sized agents.
 		</member>
 		<member name="avoidance_enabled" type="bool" setter="set_avoidance_enabled" getter="get_avoidance_enabled" default="false">
 			If [code]true[/code] the agent is registered for an RVO avoidance callback on the [NavigationServer3D]. When [method NavigationAgent3D.set_velocity] is used and the processing is completed a [code]safe_velocity[/code] Vector3 is received with a signal connection to [signal velocity_computed]. Avoidance processing with many registered agents has a significant performance cost and should only be enabled on agents that currently require it.


### PR DESCRIPTION
NavigationAgent height-offset property leads users to the assumption that it can be used to support pathfinding for different sized agents. This is not the case.

In fact the only thing this property does it that is substracts this value from the y-axis of any position in the path for this agent which by itself ... is not worth much. Both baked navmesh and returned pathpoints have no reliable height above surface so it is more or less a placebo property with questionable usefulness.

Fixes #57084


<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
