### PR TITLE
Note that NavigationObstacles should only be used if necessary and for moving objects only

### DIFF
--- a/doc/classes/NavigationObstacle2D.xml
+++ b/doc/classes/NavigationObstacle2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		2D Obstacle used in navigation for collision avoidance. The obstacle needs navigation data to work correctly. [NavigationObstacle2D] is physics safe.
+		[b]Note:[/b] Obstacles are intended as a last resort option for constantly moving objects that cannot be (re)baked to a navigation mesh efficiently.
 	</description>
 	<tutorials>
 	</tutorials>

--- a/doc/classes/NavigationObstacle3D.xml
+++ b/doc/classes/NavigationObstacle3D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		3D Obstacle used in navigation for collision avoidance. The obstacle needs navigation data to work correctly. [NavigationObstacle3D] is physics safe.
+		[b]Note:[/b] Obstacles are intended as a last resort option for constantly moving objects that cannot be (re)baked to a navigation mesh efficiently.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
Note that NavigationObstacles should only be used if necessary and for moving objects only.

Especially with static objects that can be baked it is not necessary to use this Node at all.
Should discourage the use of the obstacle avoidance in general cause it leads to awkward, uncontrollable pathmovement that users do not expect / want. It is a last resort option when everything else in the navigation toolbox does not work.

Final piece to
Closes #57967
as the node config warning is already implemented.
Closes #56854
Closes #57486

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
