### PR TITLE
Expose get_mesh() for NavigationPolygon Resources

### DIFF
--- a/doc/classes/NavigationPolygon.xml
+++ b/doc/classes/NavigationPolygon.xml
@@ -80,6 +80,12 @@
 				Clears the array of polygons, but it doesn't clear the array of outlines and vertices.
 			</description>
 		</method>
+		<method name="get_mesh">
+			<return type="NavigationMesh" />
+			<description>
+				Returns the [NavigationMesh] resulting from this navigation polygon. This navmesh can be used to update the navmesh of a region with the [method NavigationServer3D.region_set_navmesh] API directly (as 2D uses the 3D server behind the scene).
+			</description>
+		</method>
 		<method name="get_outline" qualifiers="const">
 			<return type="PackedVector2Array" />
 			<argument index="0" name="idx" type="int" />

--- a/scene/2d/navigation_region_2d.cpp
+++ b/scene/2d/navigation_region_2d.cpp
@@ -331,6 +331,7 @@ void NavigationPolygon::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_polygon_count"), &NavigationPolygon::get_polygon_count);
 	ClassDB::bind_method(D_METHOD("get_polygon", "idx"), &NavigationPolygon::get_polygon);
 	ClassDB::bind_method(D_METHOD("clear_polygons"), &NavigationPolygon::clear_polygons);
+	ClassDB::bind_method(D_METHOD("get_mesh"), &NavigationPolygon::get_mesh);
 
 	ClassDB::bind_method(D_METHOD("add_outline", "outline"), &NavigationPolygon::add_outline);
 	ClassDB::bind_method(D_METHOD("add_outline_at_index", "outline", "index"), &NavigationPolygon::add_outline_at_index);


### PR DESCRIPTION
Expose `get_mesh()` function for NavigationPolygon resource for scripting.

This function is required to receive the NavigationMesh resource used for NavigationrRegion2D Nodes to update their region on the NavigationServer3D (as 2D uses the 3D server behind the scene). Can also be used to bake navmesh for 2D with some workarounds.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
