### PR TITLE
Add NavigationMesh debug when navmesh is added later through scripts

### DIFF
--- a/scene/3d/navigation_region_3d.cpp
+++ b/scene/3d/navigation_region_3d.cpp
@@ -131,6 +131,17 @@ void NavigationRegion3D::set_navigation_mesh(const Ref<NavigationMesh> &p_navmes
 
 	NavigationServer3D::get_singleton()->region_set_navmesh(region, p_navmesh);
 
+	if (debug_view == nullptr && is_inside_tree() && navmesh.is_valid() && get_tree()->is_debugging_navigation_hint()) {
+		MeshInstance3D *dm = memnew(MeshInstance3D);
+		dm->set_mesh(navmesh->get_debug_mesh());
+		if (is_enabled()) {
+			dm->set_material_override(get_tree()->get_debug_navigation_material());
+		} else {
+			dm->set_material_override(get_tree()->get_debug_navigation_disabled_material());
+		}
+		add_child(dm);
+		debug_view = dm;
+	}
 	if (debug_view && navmesh.is_valid()) {
 		Object::cast_to<MeshInstance3D>(debug_view)->set_mesh(navmesh->get_debug_mesh());
 	}


### PR DESCRIPTION
Add NavigationMesh debug when navmesh is added later through scripts.

Previously the meshinstance for the navigationmesh debug visuals would only be added when entering the SceneTree but not if the navigationmesh was empty. When the mesh is added later through scripts the child node meshinstance was missing so the debug visuals were not added.

Fixes #32545

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
