### PR TITLE
Fix enclosed GraphNodes calculation of GraphEdit comment nodes

### DIFF
--- a/scene/gui/graph_edit.cpp
+++ b/scene/gui/graph_edit.cpp
@@ -508,8 +508,9 @@ void GraphEdit::_notification(int p_what) {
 
 void GraphEdit::_update_comment_enclosed_nodes_list(GraphNode *p_node, HashMap<StringName, Vector<GraphNode *>> &p_comment_enclosed_nodes) {
 	Rect2 comment_node_rect = p_node->get_rect();
-	Vector<GraphNode *> enclosed_nodes;
+	comment_node_rect.size *= zoom;
 
+	Vector<GraphNode *> enclosed_nodes;
 	for (int i = 0; i < get_child_count(); i++) {
 		GraphNode *gn = Object::cast_to<GraphNode>(get_child(i));
 		if (!gn || gn->is_selected()) {
@@ -517,6 +518,8 @@ void GraphEdit::_update_comment_enclosed_nodes_list(GraphNode *p_node, HashMap<S
 		}
 
 		Rect2 node_rect = gn->get_rect();
+		node_rect.size *= zoom;
+
 		bool included = comment_node_rect.encloses(node_rect);
 		if (included) {
 			enclosed_nodes.push_back(gn);


### PR DESCRIPTION
Fixes the issue where the zoom level was not taken into account when determining the enclosed nodes of a comment node.
Split from https://github.com/godotengine/godot/pull/61414.
**Issue:**
![before](https://user-images.githubusercontent.com/50084500/171618685-bb5825fe-41af-4ddd-aef2-b0e390253f74.gif)

**This PR:**
![after](https://user-images.githubusercontent.com/50084500/171618067-eb6950b8-a6f9-4630-ac87-45aae1629965.gif)

