### PR TITLE
Swap arguments of ResourceSaver.save()

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -147,9 +147,9 @@ void ResourceLoader::_bind_methods() {
 
 ////// ResourceSaver //////
 
-Error ResourceSaver::save(const String &p_path, const Ref<Resource> &p_resource, BitField<SaverFlags> p_flags) {
-	ERR_FAIL_COND_V_MSG(p_resource.is_null(), ERR_INVALID_PARAMETER, "Can't save empty resource to path '" + String(p_path) + "'.");
-	return ::ResourceSaver::save(p_path, p_resource, p_flags);
+Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path, BitField<SaverFlags> p_flags) {
+	ERR_FAIL_COND_V_MSG(p_resource.is_null(), ERR_INVALID_PARAMETER, "Can't save empty resource to path '" + p_path + "'.");
+	return ::ResourceSaver::save(p_resource, p_path, p_flags);
 }
 
 Vector<String> ResourceSaver::get_recognized_extensions(const Ref<Resource> &p_resource) {
@@ -174,7 +174,7 @@ void ResourceSaver::remove_resource_format_saver(Ref<ResourceFormatSaver> p_form
 ResourceSaver *ResourceSaver::singleton = nullptr;
 
 void ResourceSaver::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("save", "path", "resource", "flags"), &ResourceSaver::save, DEFVAL((uint32_t)FLAG_NONE));
+	ClassDB::bind_method(D_METHOD("save", "resource", "path", "flags"), &ResourceSaver::save, DEFVAL(""), DEFVAL((uint32_t)FLAG_NONE));
 	ClassDB::bind_method(D_METHOD("get_recognized_extensions", "type"), &ResourceSaver::get_recognized_extensions);
 	ClassDB::bind_method(D_METHOD("add_resource_format_saver", "format_saver", "at_front"), &ResourceSaver::add_resource_format_saver, DEFVAL(false));
 	ClassDB::bind_method(D_METHOD("remove_resource_format_saver", "format_saver"), &ResourceSaver::remove_resource_format_saver);

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -109,7 +109,7 @@ public:
 
 	static ResourceSaver *get_singleton() { return singleton; }
 
-	Error save(const String &p_path, const Ref<Resource> &p_resource, BitField<SaverFlags> p_flags);
+	Error save(const Ref<Resource> &p_resource, const String &p_path, BitField<SaverFlags> p_flags);
 	Vector<String> get_recognized_extensions(const Ref<Resource> &p_resource);
 	void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front);
 	void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);

--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -185,7 +185,7 @@ String ResourceFormatLoaderCrypto::get_resource_type(const String &p_path) const
 	return "";
 }
 
-Error ResourceFormatSaverCrypto::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverCrypto::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	Error err;
 	Ref<X509Certificate> cert = p_resource;
 	Ref<CryptoKey> key = p_resource;

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -125,7 +125,7 @@ public:
 
 class ResourceFormatSaverCrypto : public ResourceFormatSaver {
 public:
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 };

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1267,7 +1267,7 @@ Error ResourceFormatLoaderBinary::rename_dependencies(const String &p_path, cons
 		Ref<Resource> res = loader.get_resource();
 		ERR_FAIL_COND_V(!res.is_valid(), ERR_FILE_CORRUPT);
 
-		return ResourceFormatSaverBinary::singleton->save(p_path, res);
+		return ResourceFormatSaverBinary::singleton->save(res, p_path);
 	}
 
 	if (ver_format > FORMAT_VERSION || ver_major > VERSION_MAJOR) {
@@ -2204,7 +2204,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 	return OK;
 }
 
-Error ResourceFormatSaverBinary::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverBinary::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	ResourceFormatSaverBinaryInstance saver;
 	return saver.save(local_path, p_resource, p_flags);

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -176,7 +176,7 @@ public:
 class ResourceFormatSaverBinary : public ResourceFormatSaver {
 public:
 	static ResourceFormatSaverBinary *singleton;
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -41,9 +41,9 @@ bool ResourceSaver::timestamp_on_save = false;
 ResourceSavedCallback ResourceSaver::save_callback = nullptr;
 ResourceSaverGetResourceIDForPath ResourceSaver::save_get_id_for_path = nullptr;
 
-Error ResourceFormatSaver::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	int64_t res;
-	if (GDVIRTUAL_CALL(_save, p_path, p_resource, p_flags, res)) {
+	if (GDVIRTUAL_CALL(_save, p_resource, p_path, p_flags, res)) {
 		return (Error)res;
 	}
 
@@ -75,8 +75,14 @@ void ResourceFormatSaver::_bind_methods() {
 	GDVIRTUAL_BIND(_get_recognized_extensions, "resource");
 }
 
-Error ResourceSaver::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
-	String extension = p_path.get_extension();
+Error ResourceSaver::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
+	String path = p_path;
+	if (path.is_empty()) {
+		path = p_resource->get_path();
+	}
+	ERR_FAIL_COND_V_MSG(p_path.is_empty(), ERR_INVALID_PARAMETER, "Can't save resource to empty path. Provide non-empty path or a Resource with non-empty resource_path.");
+
+	String extension = path.get_extension();
 	Error err = ERR_FILE_UNRECOGNIZED;
 
 	for (int i = 0; i < saver_count; i++) {
@@ -100,21 +106,21 @@ Error ResourceSaver::save(const String &p_path, const Ref<Resource> &p_resource,
 
 		String old_path = p_resource->get_path();
 
-		String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
+		String local_path = ProjectSettings::get_singleton()->localize_path(path);
 
 		Ref<Resource> rwcopy = p_resource;
 		if (p_flags & FLAG_CHANGE_PATH) {
 			rwcopy->set_path(local_path);
 		}
 
-		err = saver[i]->save(p_path, p_resource, p_flags);
+		err = saver[i]->save(p_resource, path, p_flags);
 
 		if (err == OK) {
 #ifdef TOOLS_ENABLED
 
 			((Resource *)p_resource.ptr())->set_edited(false);
 			if (timestamp_on_save) {
-				uint64_t mt = FileAccess::get_modified_time(p_path);
+				uint64_t mt = FileAccess::get_modified_time(path);
 
 				((Resource *)p_resource.ptr())->set_last_modified_time(mt);
 			}
@@ -124,8 +130,8 @@ Error ResourceSaver::save(const String &p_path, const Ref<Resource> &p_resource,
 				rwcopy->set_path(old_path);
 			}
 
-			if (save_callback && p_path.begins_with("res://")) {
-				save_callback(p_resource, p_path);
+			if (save_callback && path.begins_with("res://")) {
+				save_callback(p_resource, path);
 			}
 
 			return OK;

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -41,12 +41,12 @@ class ResourceFormatSaver : public RefCounted {
 protected:
 	static void _bind_methods();
 
-	GDVIRTUAL3R(int64_t, _save, String, Ref<Resource>, uint32_t)
+	GDVIRTUAL3R(int64_t, _save, Ref<Resource>, String, uint32_t)
 	GDVIRTUAL1RC(bool, _recognize, Ref<Resource>)
 	GDVIRTUAL1RC(Vector<String>, _get_recognized_extensions, Ref<Resource>)
 
 public:
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 
@@ -81,7 +81,7 @@ public:
 		FLAG_REPLACE_SUBRESOURCE_PATHS = 64,
 	};
 
-	static Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = (uint32_t)FLAG_NONE);
+	static Error save(const Ref<Resource> &p_resource, const String &p_path = "", uint32_t p_flags = (uint32_t)FLAG_NONE);
 	static void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions);
 	static void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front = false);
 	static void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);

--- a/doc/classes/ResourceFormatSaver.xml
+++ b/doc/classes/ResourceFormatSaver.xml
@@ -26,8 +26,8 @@
 		</method>
 		<method name="_save" qualifiers="virtual">
 			<return type="int" />
-			<argument index="0" name="path" type="String" />
-			<argument index="1" name="resource" type="Resource" />
+			<argument index="0" name="path" type="Resource" />
+			<argument index="1" name="resource" type="String" />
 			<argument index="2" name="flags" type="int" />
 			<description>
 				Saves the given resource object to a file at the target [code]path[/code]. [code]flags[/code] is a bitmask composed with [enum ResourceSaver.SaverFlags] constants.

--- a/doc/classes/ResourceSaver.xml
+++ b/doc/classes/ResourceSaver.xml
@@ -35,11 +35,11 @@
 		</method>
 		<method name="save">
 			<return type="int" enum="Error" />
-			<argument index="0" name="path" type="String" />
-			<argument index="1" name="resource" type="Resource" />
+			<argument index="0" name="resource" type="Resource" />
+			<argument index="1" name="path" type="String" default="&quot;&quot;" />
 			<argument index="2" name="flags" type="int" enum="ResourceSaver.SaverFlags" default="0" />
 			<description>
-				Saves a resource to disk to the given path, using a [ResourceFormatSaver] that recognizes the resource object.
+				Saves a resource to disk to the given path, using a [ResourceFormatSaver] that recognizes the resource object. If [code]path[/code] is empty, [ResourceSaver] will try to use [member Resource.resource_path].
 				The [code]flags[/code] bitmask can be specified to customize the save behavior using [enum SaverFlags] flags.
 				Returns [constant OK] on success.
 			</description>

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -35,7 +35,7 @@
 #include "drivers/png/png_driver_common.h"
 #include "scene/resources/texture.h"
 
-Error ResourceSaverPNG::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceSaverPNG::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	Ref<ImageTexture> texture = p_resource;
 
 	ERR_FAIL_COND_V_MSG(!texture.is_valid(), ERR_INVALID_PARAMETER, "Can't save invalid texture as PNG.");

--- a/drivers/png/resource_saver_png.h
+++ b/drivers/png/resource_saver_png.h
@@ -39,7 +39,7 @@ public:
 	static Error save_image(const String &p_path, const Ref<Image> &p_img);
 	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img);
 
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 

--- a/editor/editor_audio_buses.cpp
+++ b/editor/editor_audio_buses.cpp
@@ -1174,7 +1174,7 @@ void EditorAudioBuses::_drop_at_index(int p_bus, int p_index) {
 
 void EditorAudioBuses::_server_save() {
 	Ref<AudioBusLayout> state = AudioServer::get_singleton()->generate_bus_layout();
-	ResourceSaver::save(edited_path, state);
+	ResourceSaver::save(state, edited_path);
 }
 
 void EditorAudioBuses::_select_layout() {
@@ -1244,7 +1244,7 @@ void EditorAudioBuses::_file_dialog_callback(const String &p_string) {
 			AudioServer::get_singleton()->set_bus_layout(empty_state);
 		}
 
-		Error err = ResourceSaver::save(p_string, AudioServer::get_singleton()->generate_bus_layout());
+		Error err = ResourceSaver::save(AudioServer::get_singleton()->generate_bus_layout(), p_string);
 
 		if (err != OK) {
 			EditorNode::get_singleton()->show_warning(vformat(TTR("Error saving file: %s"), p_string));

--- a/editor/editor_node.cpp
+++ b/editor/editor_node.cpp
@@ -1225,7 +1225,7 @@ void EditorNode::save_resource_in_path(const Ref<Resource> &p_resource, const St
 	}
 
 	String path = ProjectSettings::get_singleton()->localize_path(p_path);
-	Error err = ResourceSaver::save(path, p_resource, flg | ResourceSaver::FLAG_REPLACE_SUBRESOURCE_PATHS);
+	Error err = ResourceSaver::save(p_resource, path, flg | ResourceSaver::FLAG_REPLACE_SUBRESOURCE_PATHS);
 
 	if (err != OK) {
 		if (ResourceLoader::is_imported(p_resource->get_path())) {
@@ -1448,7 +1448,7 @@ bool EditorNode::_find_and_save_resource(Ref<Resource> p_res, HashMap<Ref<Resour
 
 	if (p_res->get_path().is_resource_file()) {
 		if (changed || subchanged) {
-			ResourceSaver::save(p_res->get_path(), p_res, flags);
+			ResourceSaver::save(p_res, p_res->get_path(), flags);
 		}
 		processed[p_res] = false; // Because it's a file.
 		return false;
@@ -1679,7 +1679,7 @@ int EditorNode::_save_external_resources() {
 		if (ps.is_valid()) {
 			continue; // Do not save PackedScenes, this will mess up the editor.
 		}
-		ResourceSaver::save(res->get_path(), res, flg);
+		ResourceSaver::save(res, res->get_path(), flg);
 		saved++;
 	}
 
@@ -1750,7 +1750,7 @@ void EditorNode::_save_scene(String p_file, int idx) {
 	}
 	flg |= ResourceSaver::FLAG_REPLACE_SUBRESOURCE_PATHS;
 
-	err = ResourceSaver::save(p_file, sdata, flg);
+	err = ResourceSaver::save(sdata, p_file, flg);
 
 	// This needs to be emitted before saving external resources.
 	emit_signal(SNAME("scene_saved"), p_file);
@@ -1957,7 +1957,7 @@ void EditorNode::_dialog_action(String p_file) {
 
 			MeshLibraryEditor::update_library_file(editor_data.get_edited_scene_root(), ml, true, file_export_lib_apply_xforms->is_pressed());
 
-			Error err = ResourceSaver::save(p_file, ml);
+			Error err = ResourceSaver::save(ml, p_file);
 			if (err) {
 				show_accept(TTR("Error saving MeshLibrary!"), TTR("OK"));
 				return;

--- a/editor/editor_resource_preview.cpp
+++ b/editor/editor_resource_preview.cpp
@@ -195,9 +195,9 @@ void EditorResourcePreview::_generate_preview(Ref<ImageTexture> &r_texture, Ref<
 		if (r_texture.is_valid()) {
 			//wow it generated a preview... save cache
 			bool has_small_texture = r_small_texture.is_valid();
-			ResourceSaver::save(cache_base + ".png", r_texture);
+			ResourceSaver::save(r_texture, cache_base + ".png");
 			if (has_small_texture) {
-				ResourceSaver::save(cache_base + "_small.png", r_small_texture);
+				ResourceSaver::save(r_small_texture, cache_base + "_small.png");
 			}
 			Ref<FileAccess> f = FileAccess::open(cache_base + ".txt", FileAccess::WRITE);
 			ERR_FAIL_COND_MSG(f.is_null(), "Cannot create file '" + cache_base + ".txt'. Check user write permissions.");

--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -867,7 +867,6 @@ void EditorSettings::create() {
 		}
 
 		singleton->save_changed_setting = true;
-		singleton->config_file_path = config_file_path;
 
 		print_verbose("EditorSettings: Load OK!");
 
@@ -892,8 +891,8 @@ fail:
 	}
 
 	singleton = Ref<EditorSettings>(memnew(EditorSettings));
+	singleton->set_path(config_file_path, true);
 	singleton->save_changed_setting = true;
-	singleton->config_file_path = config_file_path;
 	singleton->_load_defaults(extra_config);
 	singleton->setup_language();
 	singleton->setup_network();
@@ -953,15 +952,10 @@ void EditorSettings::save() {
 		return;
 	}
 
-	if (singleton->config_file_path.is_empty()) {
-		ERR_PRINT("Cannot save EditorSettings config, no valid path");
-		return;
-	}
-
-	Error err = ResourceSaver::save(singleton->config_file_path, singleton);
+	Error err = ResourceSaver::save(singleton);
 
 	if (err != OK) {
-		ERR_PRINT("Error saving editor settings to " + singleton->config_file_path);
+		ERR_PRINT("Error saving editor settings to " + singleton->get_path());
 	} else {
 		singleton->changed_settings.clear();
 		print_verbose("EditorSettings: Save OK!");

--- a/editor/editor_settings.h
+++ b/editor/editor_settings.h
@@ -88,8 +88,6 @@ private:
 	mutable HashMap<String, Ref<Shortcut>> shortcuts;
 	HashMap<String, List<Ref<InputEvent>>> builtin_action_overrides;
 
-	String config_file_path;
-
 	Vector<String> favorites;
 	Vector<String> recent_dirs;
 

--- a/editor/import/resource_importer_bitmask.cpp
+++ b/editor/import/resource_importer_bitmask.cpp
@@ -103,7 +103,7 @@ Error ResourceImporterBitMap::import(const String &p_source_file, const String &
 		}
 	}
 
-	return ResourceSaver::save(p_save_path + ".res", bitmap);
+	return ResourceSaver::save(bitmap, p_save_path + ".res");
 }
 
 ResourceImporterBitMap::ResourceImporterBitMap() {

--- a/editor/import/resource_importer_bmfont.cpp
+++ b/editor/import/resource_importer_bmfont.cpp
@@ -84,7 +84,7 @@ Error ResourceImporterBMFont::import(const String &p_source_file, const String &
 	}
 
 	print_verbose("Saving to: " + p_save_path + ".fontdata");
-	err = ResourceSaver::save(p_save_path + ".fontdata", font, flg);
+	err = ResourceSaver::save(font, p_save_path + ".fontdata", flg);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save font to file \"" + p_save_path + ".res\".");
 	print_verbose("Done saving to: " + p_save_path + ".fontdata");
 	return OK;

--- a/editor/import/resource_importer_csv_translation.cpp
+++ b/editor/import/resource_importer_csv_translation.cpp
@@ -131,7 +131,7 @@ Error ResourceImporterCSVTranslation::import(const String &p_source_file, const 
 
 		String save_path = p_source_file.get_basename() + "." + translations[i]->get_locale() + ".translation";
 
-		ResourceSaver::save(save_path, xlt);
+		ResourceSaver::save(xlt, save_path);
 		if (r_gen_files) {
 			r_gen_files->push_back(save_path);
 		}

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -219,7 +219,7 @@ Error ResourceImporterDynamicFont::import(const String &p_source_file, const Str
 	}
 
 	print_verbose("Saving to: " + p_save_path + ".fontdata");
-	Error err = ResourceSaver::save(p_save_path + ".fontdata", font, flg);
+	Error err = ResourceSaver::save(font, p_save_path + ".fontdata", flg);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save font to file \"" + p_save_path + ".res\".");
 	print_verbose("Done saving to: " + p_save_path + ".fontdata");
 	return OK;

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -159,7 +159,7 @@ Error ResourceImporterImageFont::import(const String &p_source_file, const Strin
 	}
 
 	print_verbose("Saving to: " + p_save_path + ".fontdata");
-	err = ResourceSaver::save(p_save_path + ".fontdata", font, flg);
+	err = ResourceSaver::save(font, p_save_path + ".fontdata", flg);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save font to file \"" + p_save_path + ".res\".");
 	print_verbose("Done saving to: " + p_save_path + ".fontdata");
 	return OK;

--- a/editor/import/resource_importer_obj.cpp
+++ b/editor/import/resource_importer_obj.cpp
@@ -519,7 +519,7 @@ Error ResourceImporterOBJ::import(const String &p_source_file, const String &p_s
 
 	String save_path = p_save_path + ".mesh";
 
-	err = ResourceSaver::save(save_path, meshes.front()->get());
+	err = ResourceSaver::save(meshes.front()->get(), save_path);
 
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save Mesh to file '" + save_path + "'.");
 

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1224,7 +1224,7 @@ Ref<Animation> ResourceImporterScene::_save_animation_to_file(Ref<Animation> ani
 		}
 	}
 	anim->set_path(p_save_to_path, true); // Set path to save externally.
-	Error err = ResourceSaver::save(p_save_to_path, anim, ResourceSaver::FLAG_CHANGE_PATH);
+	Error err = ResourceSaver::save(anim, p_save_to_path, ResourceSaver::FLAG_CHANGE_PATH);
 	ERR_FAIL_COND_V_MSG(err != OK, anim, "Saving of animation failed: " + p_save_to_path);
 	return anim;
 }
@@ -1842,7 +1842,7 @@ void ResourceImporterScene::_generate_meshes(Node *p_node, const Dictionary &p_m
 					}
 					mesh = src_mesh_node->get_mesh()->get_mesh(existing);
 
-					ResourceSaver::save(save_to_file, mesh); //override
+					ResourceSaver::save(mesh, save_to_file); //override
 
 					mesh->set_path(save_to_file, true); //takeover existing, if needed
 
@@ -2310,14 +2310,14 @@ Error ResourceImporterScene::import(const String &p_source_file, const String &p
 		}
 
 		print_verbose("Saving animation to: " + p_save_path + ".scn");
-		err = ResourceSaver::save(p_save_path + ".res", library); //do not take over, let the changed files reload themselves
+		err = ResourceSaver::save(library, p_save_path + ".res"); //do not take over, let the changed files reload themselves
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save animation to file '" + p_save_path + ".res'.");
 
 	} else {
 		Ref<PackedScene> packer = memnew(PackedScene);
 		packer->pack(scene);
 		print_verbose("Saving scene to: " + p_save_path + ".scn");
-		err = ResourceSaver::save(p_save_path + ".scn", packer); //do not take over, let the changed files reload themselves
+		err = ResourceSaver::save(packer, p_save_path + ".scn"); //do not take over, let the changed files reload themselves
 		ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot save scene to file '" + p_save_path + ".scn'.");
 	}
 

--- a/editor/import/resource_importer_shader_file.cpp
+++ b/editor/import/resource_importer_shader_file.cpp
@@ -109,7 +109,7 @@ Error ResourceImporterShaderFile::import(const String &p_source_file, const Stri
 		}
 	}
 
-	ResourceSaver::save(p_save_path + ".res", shader_file);
+	ResourceSaver::save(shader_file, p_save_path + ".res");
 
 	return OK;
 }

--- a/editor/import/resource_importer_texture_atlas.cpp
+++ b/editor/import/resource_importer_texture_atlas.cpp
@@ -88,7 +88,7 @@ Error ResourceImporterTextureAtlas::import(const String &p_source_file, const St
 	//use an xpm because it's size independent, the editor images are vector and size dependent
 	//it's a simple hack
 	Ref<Image> broken = memnew(Image((const char **)atlas_import_failed_xpm));
-	ResourceSaver::save(p_save_path + ".tex", ImageTexture::create_from_image(broken));
+	ResourceSaver::save(ImageTexture::create_from_image(broken), p_save_path + ".tex");
 
 	return OK;
 }
@@ -386,7 +386,7 @@ Error ResourceImporterTextureAtlas::import_group_file(const String &p_group_file
 		}
 
 		String save_path = p_base_paths[E.key] + ".res";
-		ResourceSaver::save(save_path, texture);
+		ResourceSaver::save(texture, save_path);
 		idx++;
 	}
 

--- a/editor/import/resource_importer_wav.cpp
+++ b/editor/import/resource_importer_wav.cpp
@@ -531,7 +531,7 @@ Error ResourceImporterWAV::import(const String &p_source_file, const String &p_s
 	sample->set_loop_end(loop_end);
 	sample->set_stereo(format_channels == 2);
 
-	ResourceSaver::save(p_save_path + ".sample", sample);
+	ResourceSaver::save(sample, p_save_path + ".sample");
 
 	return OK;
 }

--- a/editor/import/scene_import_settings.cpp
+++ b/editor/import/scene_import_settings.cpp
@@ -1184,7 +1184,7 @@ void SceneImportSettings::_save_dir_confirm() {
 				ERR_CONTINUE(!material_map.has(id));
 				MaterialData &md = material_map[id];
 
-				Error err = ResourceSaver::save(path, md.material);
+				Error err = ResourceSaver::save(md.material, path);
 				if (err != OK) {
 					EditorNode::get_singleton()->add_io_error(TTR("Can't make material external to file, write error:") + "\n\t" + path);
 					continue;

--- a/editor/plugin_config_dialog.cpp
+++ b/editor/plugin_config_dialog.cpp
@@ -81,8 +81,8 @@ void PluginConfigDialog::_on_confirmed() {
 			template_content = templates[0].content;
 		}
 		Ref<Script> script = ScriptServer::get_language(lang_idx)->make_template(template_content, class_name, "EditorPlugin");
-		script->set_path(script_path);
-		ResourceSaver::save(script_path, script);
+		script->set_path(script_path, true);
+		ResourceSaver::save(script);
 
 		emit_signal(SNAME("plugin_ready"), script.ptr(), active_edit->is_pressed() ? _to_absolute_plugin_path(_get_subfolder()) : "");
 	} else {

--- a/editor/plugins/shader_editor_plugin.cpp
+++ b/editor/plugins/shader_editor_plugin.cpp
@@ -831,18 +831,18 @@ void ShaderEditor::save_external_data(const String &p_str) {
 
 	Ref<Shader> edited_shader = shader_editor->get_edited_shader();
 	if (edited_shader.is_valid()) {
-		ResourceSaver::save(edited_shader->get_path(), edited_shader);
+		ResourceSaver::save(edited_shader);
 	}
 	if (shader.is_valid() && shader != edited_shader) {
-		ResourceSaver::save(shader->get_path(), shader);
+		ResourceSaver::save(shader);
 	}
 
 	Ref<ShaderInclude> edited_shader_inc = shader_editor->get_edited_shader_include();
 	if (edited_shader_inc.is_valid()) {
-		ResourceSaver::save(edited_shader_inc->get_path(), edited_shader_inc);
+		ResourceSaver::save(edited_shader_inc);
 	}
 	if (shader_inc.is_valid() && shader_inc != edited_shader_inc) {
-		ResourceSaver::save(shader_inc->get_path(), shader_inc);
+		ResourceSaver::save(shader_inc);
 	}
 
 	disk_changed->hide();

--- a/editor/plugins/skeleton_3d_editor_plugin.cpp
+++ b/editor/plugins/skeleton_3d_editor_plugin.cpp
@@ -515,7 +515,7 @@ void Skeleton3DEditor::_file_selected(const String &p_file) {
 		}
 	}
 
-	Error err = ResourceSaver::save(p_file, sp);
+	Error err = ResourceSaver::save(sp, p_file);
 
 	if (err != OK) {
 		EditorNode::get_singleton()->show_warning(vformat(TTR("Error saving file: %s"), p_file));

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -139,7 +139,7 @@ void VoxelGIEditorPlugin::_voxel_gi_save_path_and_bake(const String &p_path) {
 	if (voxel_gi) {
 		voxel_gi->bake();
 		ERR_FAIL_COND(voxel_gi->get_probe_data().is_null());
-		ResourceSaver::save(p_path, voxel_gi->get_probe_data(), ResourceSaver::FLAG_CHANGE_PATH);
+		ResourceSaver::save(voxel_gi->get_probe_data(), p_path, ResourceSaver::FLAG_CHANGE_PATH);
 	}
 }
 

--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -491,7 +491,7 @@ private:
 					if (ProjectSettings::get_singleton()->save_custom(dir.plus_file("project.godot"), initial_settings, Vector<String>(), false) != OK) {
 						set_message(TTR("Couldn't create project.godot in project path."), MESSAGE_ERROR);
 					} else {
-						ResourceSaver::save(dir.plus_file("icon.png"), create_unscaled_default_project_icon());
+						ResourceSaver::save(create_unscaled_default_project_icon(), dir.plus_file("icon.png"));
 						EditorVCSInterface::create_vcs_metadata_files(EditorVCSInterface::VCSMetadata(vcs_metadata_selection->get_selected()), dir);
 					}
 				} else if (mode == MODE_INSTALL) {

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2457,7 +2457,7 @@ void SceneTreeDock::_new_scene_from(String p_file) {
 			flg |= ResourceSaver::FLAG_COMPRESS;
 		}
 
-		err = ResourceSaver::save(p_file, sdata, flg);
+		err = ResourceSaver::save(sdata, p_file, flg);
 		if (err != OK) {
 			accept->set_text(TTR("Error saving scene."));
 			accept->popup_centered();

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -385,7 +385,7 @@ void ScriptCreateDialog::_create_new() {
 	} else {
 		String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());
 		scr->set_path(lpath);
-		Error err = ResourceSaver::save(lpath, scr, ResourceSaver::FLAG_CHANGE_PATH);
+		Error err = ResourceSaver::save(scr, lpath, ResourceSaver::FLAG_CHANGE_PATH);
 		if (err != OK) {
 			alert->set_text(TTR("Error - Could not create script in filesystem."));
 			alert->popup_centered();

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -211,7 +211,7 @@ void ShaderCreateDialog::_create_new() {
 		String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());
 		shader_inc->set_path(lpath);
 
-		Error error = ResourceSaver::save(lpath, shader_inc, ResourceSaver::FLAG_CHANGE_PATH);
+		Error error = ResourceSaver::save(shader_inc, lpath, ResourceSaver::FLAG_CHANGE_PATH);
 		if (error != OK) {
 			alert->set_text(TTR("Error - Could not create shader include in filesystem."));
 			alert->popup_centered();
@@ -224,7 +224,7 @@ void ShaderCreateDialog::_create_new() {
 			String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());
 			shader->set_path(lpath);
 
-			Error error = ResourceSaver::save(lpath, shader, ResourceSaver::FLAG_CHANGE_PATH);
+			Error error = ResourceSaver::save(shader, lpath, ResourceSaver::FLAG_CHANGE_PATH);
 			if (error != OK) {
 				alert->set_text(TTR("Error - Could not create shader in filesystem."));
 				alert->popup_centered();

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2380,7 +2380,7 @@ void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<S
 	}
 }
 
-Error ResourceFormatSaverGDScript::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverGDScript::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	Ref<GDScript> sqscr = p_resource;
 	ERR_FAIL_COND_V(sqscr.is_null(), ERR_INVALID_PARAMETER);
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -524,7 +524,7 @@ public:
 
 class ResourceFormatSaverGDScript : public ResourceFormatSaver {
 public:
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 };

--- a/modules/minimp3/resource_importer_mp3.cpp
+++ b/modules/minimp3/resource_importer_mp3.cpp
@@ -128,7 +128,7 @@ Error ResourceImporterMP3::import(const String &p_source_file, const String &p_s
 	mp3_stream->set_beat_count(beat_count);
 	mp3_stream->set_bar_beats(bar_beats);
 
-	return ResourceSaver::save(p_save_path + ".mp3str", mp3_stream);
+	return ResourceSaver::save(mp3_stream, p_save_path + ".mp3str");
 }
 
 ResourceImporterMP3::ResourceImporterMP3() {

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -3630,7 +3630,7 @@ String ResourceFormatLoaderCSharpScript::get_resource_type(const String &p_path)
 	return p_path.get_extension().to_lower() == "cs" ? CSharpLanguage::get_singleton()->get_type() : "";
 }
 
-Error ResourceFormatSaverCSharpScript::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverCSharpScript::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	Ref<CSharpScript> sqscr = p_resource;
 	ERR_FAIL_COND_V(sqscr.is_null(), ERR_INVALID_PARAMETER);
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -543,7 +543,7 @@ public:
 
 class ResourceFormatSaverCSharpScript : public ResourceFormatSaver {
 public:
-	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0) override;
+	Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0) override;
 	void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/modules/openxr/editor/openxr_action_map_editor.cpp
+++ b/modules/openxr/editor/openxr_action_map_editor.cpp
@@ -258,7 +258,7 @@ void OpenXRActionMapEditor::_load_action_map(const String p_path, bool p_create_
 }
 
 void OpenXRActionMapEditor::_on_save_action_map() {
-	Error err = ResourceSaver::save(edited_path, action_map);
+	Error err = ResourceSaver::save(action_map, edited_path);
 	if (err != OK) {
 		EditorNode::get_singleton()->show_warning(vformat(TTR("Error saving file: %s"), edited_path));
 		return;

--- a/modules/openxr/openxr_interface.cpp
+++ b/modules/openxr/openxr_interface.cpp
@@ -123,7 +123,7 @@ void OpenXRInterface::_load_action_map() {
 #ifdef TOOLS_ENABLED
 			// Save our action sets so our user can
 			action_map->set_path(default_tres_name, true);
-			ResourceSaver::save(default_tres_name, action_map);
+			ResourceSaver::save(action_map, default_tres_name);
 #endif
 		}
 	}

--- a/modules/vorbis/resource_importer_ogg_vorbis.cpp
+++ b/modules/vorbis/resource_importer_ogg_vorbis.cpp
@@ -226,7 +226,7 @@ Error ResourceImporterOggVorbis::import(const String &p_source_file, const Strin
 	ogg_vorbis_stream->set_beat_count(beat_count);
 	ogg_vorbis_stream->set_bar_beats(bar_beats);
 
-	return ResourceSaver::save(p_save_path + ".oggvorbisstr", ogg_vorbis_stream);
+	return ResourceSaver::save(ogg_vorbis_stream, p_save_path + ".oggvorbisstr");
 }
 
 ResourceImporterOggVorbis::ResourceImporterOggVorbis() {

--- a/modules/webp/resource_saver_webp.cpp
+++ b/modules/webp/resource_saver_webp.cpp
@@ -35,7 +35,7 @@
 #include "scene/resources/texture.h"
 #include "webp_common.h"
 
-Error ResourceSaverWebP::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceSaverWebP::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	Ref<ImageTexture> texture = p_resource;
 
 	ERR_FAIL_COND_V_MSG(!texture.is_valid(), ERR_INVALID_PARAMETER, "Can't save invalid texture as WEBP.");

--- a/modules/webp/resource_saver_webp.h
+++ b/modules/webp/resource_saver_webp.h
@@ -39,7 +39,7 @@ public:
 	static Error save_image(const String &p_path, const Ref<Image> &p_img, const bool p_lossy = false, const float p_quality = 0.75f);
 	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img, const bool p_lossy = false, const float p_quality = 0.75f);
 
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 

--- a/platform/macos/export/export_plugin.cpp
+++ b/platform/macos/export/export_plugin.cpp
@@ -254,7 +254,7 @@ void EditorExportPlatformMacOS::_make_icon(const Ref<Image> &p_icon, Vector<uint
 			// Encode PNG icon.
 			it->set_image(copy);
 			String path = EditorPaths::get_singleton()->get_cache_dir().plus_file("icon.png");
-			ResourceSaver::save(path, it);
+			ResourceSaver::save(it, path);
 
 			{
 				Ref<FileAccess> f = FileAccess::open(path, FileAccess::READ);

--- a/scene/3d/lightmap_gi.cpp
+++ b/scene/3d/lightmap_gi.cpp
@@ -1219,7 +1219,7 @@ LightmapGI::BakeError LightmapGI::bake(Node *p_from_node, String p_image_data_pa
 	}
 
 	data->set_path(p_image_data_path);
-	Error err = ResourceSaver::save(p_image_data_path, data);
+	Error err = ResourceSaver::save(data);
 
 	if (err != OK) {
 		return BAKE_ERROR_CANT_CREATE_IMAGE;

--- a/scene/3d/occluder_instance_3d.cpp
+++ b/scene/3d/occluder_instance_3d.cpp
@@ -670,7 +670,7 @@ OccluderInstance3D::BakeError OccluderInstance3D::bake_scene(Node *p_from_node, 
 
 	occ->set_arrays(vertices, indices);
 
-	Error err = ResourceSaver::save(p_occluder_path, occ);
+	Error err = ResourceSaver::save(occ, p_occluder_path);
 
 	if (err != OK) {
 		return BAKE_ERROR_CANT_SAVE;

--- a/scene/debugger/scene_debugger.cpp
+++ b/scene/debugger/scene_debugger.cpp
@@ -299,7 +299,7 @@ void SceneDebugger::_save_node(ObjectID id, const String &p_path) {
 
 	Ref<PackedScene> ps = memnew(PackedScene);
 	ps->pack(node);
-	ResourceSaver::save(p_path, ps);
+	ResourceSaver::save(ps, p_path);
 }
 
 void SceneDebugger::_send_object_id(ObjectID p_id, int p_max_size) {

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -2211,7 +2211,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 	return OK;
 }
 
-Error ResourceFormatSaverText::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverText::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	if (p_path.ends_with(".tscn") && !Ref<PackedScene>(p_resource).is_valid()) {
 		return ERR_FILE_UNRECOGNIZED;
 	}

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -194,7 +194,7 @@ public:
 class ResourceFormatSaverText : public ResourceFormatSaver {
 public:
 	static ResourceFormatSaverText *singleton;
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -251,7 +251,7 @@ String ResourceFormatLoaderShader::get_resource_type(const String &p_path) const
 	return "";
 }
 
-Error ResourceFormatSaverShader::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverShader::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	Ref<Shader> shader = p_resource;
 	ERR_FAIL_COND_V(shader.is_null(), ERR_INVALID_PARAMETER);
 

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -117,7 +117,7 @@ public:
 
 class ResourceFormatSaverShader : public ResourceFormatSaver {
 public:
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 };

--- a/scene/resources/shader_include.cpp
+++ b/scene/resources/shader_include.cpp
@@ -113,7 +113,7 @@ String ResourceFormatLoaderShaderInclude::get_resource_type(const String &p_path
 
 // ResourceFormatSaverShaderInclude
 
-Error ResourceFormatSaverShaderInclude::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverShaderInclude::save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags) {
 	Ref<ShaderInclude> shader_inc = p_resource;
 	ERR_FAIL_COND_V(shader_inc.is_null(), ERR_INVALID_PARAMETER);
 

--- a/scene/resources/shader_include.h
+++ b/scene/resources/shader_include.h
@@ -63,7 +63,7 @@ public:
 
 class ResourceFormatSaverShaderInclude : public ResourceFormatSaver {
 public:
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const Ref<Resource> &p_resource, const String &p_path, uint32_t p_flags = 0);
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 };

--- a/tests/core/io/test_resource.h
+++ b/tests/core/io/test_resource.h
@@ -76,8 +76,8 @@ TEST_CASE("[Resource] Saving and loading") {
 	resource->set_meta("other_resource", child_resource);
 	const String save_path_binary = OS::get_singleton()->get_cache_path().plus_file("resource.res");
 	const String save_path_text = OS::get_singleton()->get_cache_path().plus_file("resource.tres");
-	ResourceSaver::save(save_path_binary, resource);
-	ResourceSaver::save(save_path_text, resource);
+	ResourceSaver::save(resource, save_path_binary);
+	ResourceSaver::save(resource, save_path_text);
 
 	const Ref<Resource> &loaded_resource_binary = ResourceLoader::load(save_path_binary);
 	CHECK_MESSAGE(


### PR DESCRIPTION
Whenever I use `ResourceSaver.save()`, I intuitively try to put the Resource as first argument and path as second, only to discover that the actual order is reversed. So I reversed that order. IMO it makes sense to put resource first, as it's more important. This also allows making the path an optional argument and saving will default to the resource's own path.