### PR TITLE
Improve title of DependencyEditorOwners

### DIFF
--- a/editor/dependency_editor.cpp
+++ b/editor/dependency_editor.cpp
@@ -349,7 +349,7 @@ void DependencyEditorOwners::show(const String &p_path) {
 	_fill_owners(EditorFileSystem::get_singleton()->get_filesystem());
 	popup_centered_ratio(0.3);
 
-	set_title(TTR("Owners Of:") + " " + p_path.get_file());
+	set_title(vformat(TTR("Owners of: %s (Total: %d)"), p_path.get_file(), owners->get_item_count()));
 }
 
 DependencyEditorOwners::DependencyEditorOwners() {


### PR DESCRIPTION
- remove awkward `Of` capitalization
- show total owner count
![image](https://user-images.githubusercontent.com/2223172/171759161-592ed1a5-5ae1-4880-aaa1-3089732ba1ef.png)