### PR TITLE
[3.x] Fix empty space after project sort options

### DIFF
--- a/editor/project_manager.cpp
+++ b/editor/project_manager.cpp
@@ -2490,10 +2490,9 @@ ProjectManager::ProjectManager() {
 	project_order_filter = memnew(ProjectListFilter);
 	project_order_filter->add_filter_option();
 	project_order_filter->_setup_filters(sort_filter_titles);
-	project_order_filter->set_filter_size(150);
+	project_order_filter->set_filter_size(180);
 	sort_filters->add_child(project_order_filter);
 	project_order_filter->connect("filter_changed", this, "_on_order_option_changed");
-	project_order_filter->set_custom_minimum_size(Size2(180, 10) * EDSCALE);
 	const int projects_sorting_order = (int)EditorSettings::get_singleton()->get("project_manager/sorting_order");
 	project_order_filter->set_filter_option((ProjectListFilter::FilterOption)projects_sorting_order);
 


### PR DESCRIPTION
The min size of `ProjectListFilter` is larger than its content (the `OptionButton`), thus the 30px empty space.

Since `ProjectListFilter` is an `HBoxContainer`, we only need to set the `OptionButton`'s minimum size.

![ksnip_20220604-000238](https://user-images.githubusercontent.com/372476/171905877-f16cb360-fe1c-46ac-b3e5-bccb8db16e08.png)
