### PR TITLE
Match NavMap and ProjectSettings with NavigationMesh defaults

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -1375,10 +1375,10 @@
 		<member name="navigation/2d/default_edge_connection_margin" type="int" setter="" getter="" default="1">
 			Default edge connection margin for 2D navigation maps. See [method NavigationServer2D.map_set_edge_connection_margin].
 		</member>
-		<member name="navigation/3d/default_cell_size" type="float" setter="" getter="" default="0.3">
+		<member name="navigation/3d/default_cell_size" type="float" setter="" getter="" default="0.25">
 			Default cell size for 3D navigation maps. See [method NavigationServer3D.map_set_cell_size].
 		</member>
-		<member name="navigation/3d/default_edge_connection_margin" type="float" setter="" getter="" default="0.3">
+		<member name="navigation/3d/default_edge_connection_margin" type="float" setter="" getter="" default="0.25">
 			Default edge connection margin for 3D navigation maps. See [method NavigationServer3D.map_set_edge_connection_margin].
 		</member>
 		<member name="network/limits/debugger/max_chars_per_second" type="int" setter="" getter="" default="32768">

--- a/modules/navigation/nav_map.h
+++ b/modules/navigation/nav_map.h
@@ -50,10 +50,10 @@ class NavMap : public NavRid {
 
 	/// To find the polygons edges the vertices are displaced in a grid where
 	/// each cell has the following cell_size.
-	real_t cell_size = 0.3;
+	real_t cell_size = 0.25;
 
 	/// This value is used to detect the near edges to connect.
-	real_t edge_connection_margin = 5.0;
+	real_t edge_connection_margin = 0.25;
 
 	bool regenerate_polygons = true;
 	bool regenerate_links = true;

--- a/scene/resources/world_3d.cpp
+++ b/scene/resources/world_3d.cpp
@@ -150,8 +150,8 @@ World3D::World3D() {
 
 	navigation_map = NavigationServer3D::get_singleton()->map_create();
 	NavigationServer3D::get_singleton()->map_set_active(navigation_map, true);
-	NavigationServer3D::get_singleton()->map_set_cell_size(navigation_map, GLOBAL_DEF("navigation/3d/default_cell_size", 0.3));
-	NavigationServer3D::get_singleton()->map_set_edge_connection_margin(navigation_map, GLOBAL_DEF("navigation/3d/default_edge_connection_margin", 0.3));
+	NavigationServer3D::get_singleton()->map_set_cell_size(navigation_map, GLOBAL_DEF("navigation/3d/default_cell_size", 0.25));
+	NavigationServer3D::get_singleton()->map_set_edge_connection_margin(navigation_map, GLOBAL_DEF("navigation/3d/default_edge_connection_margin", 0.25));
 }
 
 World3D::~World3D() {


### PR DESCRIPTION
Match `cell_size` from NavMap and ProjectSettings with NavigationMesh defaults since the NavMap edge merging requires a matching `cell_size` with the NavigationMesh to create connections without issues.

This is only for 3D that works with world units and NavigationMesh. 2D overwrites these settings with 1.0 when creating the World2D default NavMap as 2D works with pixel units and converts NavigationPolygons to a NavigationMesh with gridsize 1.0.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
