### PR TITLE
gdscript: use correct error for unused bind match, suppress with underscore

### DIFF
--- a/modules/gdscript/gdscript_analyzer.cpp
+++ b/modules/gdscript/gdscript_analyzer.cpp
@@ -1657,8 +1657,8 @@ void GDScriptAnalyzer::resolve_match_pattern(GDScriptParser::PatternNode *p_matc
 			p_match_pattern->bind->set_datatype(result);
 #ifdef DEBUG_ENABLED
 			is_shadowing(p_match_pattern->bind, "pattern bind");
-			if (p_match_pattern->bind->usages == 0) {
-				parser->push_warning(p_match_pattern->bind, GDScriptWarning::UNASSIGNED_VARIABLE, p_match_pattern->bind->name);
+			if (p_match_pattern->bind->usages == 0 && !String(p_match_pattern->bind->name).begins_with("_")) {
+				parser->push_warning(p_match_pattern->bind, GDScriptWarning::UNUSED_VARIABLE, p_match_pattern->bind->name);
 			}
 #endif
 			break;

--- a/modules/gdscript/tests/scripts/parser/features/match_bind_unused.gd
+++ b/modules/gdscript/tests/scripts/parser/features/match_bind_unused.gd
@@ -1,0 +1,13 @@
+# https://github.com/godotengine/godot/pull/61666
+
+func test():
+	var dict := {"key": "value"}
+	match dict:
+		{"key": var value}:
+			print(value) # used, no warning
+	match dict:
+		{"key": var value}:
+			pass # unused, warning
+	match dict:
+		{"key": var _value}:
+			pass # unused, suppressed warning from underscore

--- a/modules/gdscript/tests/scripts/parser/features/match_bind_unused.out
+++ b/modules/gdscript/tests/scripts/parser/features/match_bind_unused.out
@@ -1,0 +1,6 @@
+GDTEST_OK
+>> WARNING
+>> Line: 9
+>> UNUSED_VARIABLE
+>> The local variable 'value' is declared but never used in the block. If this is intended, prefix it with an underscore: '_value'
+value


### PR DESCRIPTION
Code:

```gd
func _ready() -> void:
	var x := {"a": "b"}
	match x:
		{"a": var a}:
			pass
	match x:
		{"a": var _a}:
			pass
```

Before:

```
W 0:00:00:0452   The variable 'a' was used but never assigned a value.
  <C++ Error>    UNASSIGNED_VARIABLE
  <Source>       scene.gd:6
W 0:00:00:0452   The variable '_a' was used but never assigned a value.
  <C++ Error>    UNASSIGNED_VARIABLE
  <Source>       scene.gd:9
```

After:

```
W 0:00:00:0451   The local variable 'a' is declared but never used in the block. If this is intended, prefix it with an underscore: '_a'
  <C++ Error>    UNUSED_VARIABLE
  <Source>       scene.gd:6
```