### PR TITLE
Enable post process with full precision using SubViewport

### DIFF
--- a/doc/classes/RenderingServer.xml
+++ b/doc/classes/RenderingServer.xml
@@ -3185,6 +3185,15 @@
 				If [code]true[/code], rendering of a viewport's environment is disabled.
 			</description>
 		</method>
+		<method name="viewport_set_force_high_precision">
+			<return type="void" />
+			<param index="0" name="viewport" type="RID" />
+			<param index="1" name="enable" type="bool" />
+			<description>
+				If [code]true[/code] and using the Vulkan-Clustered or Vulkan-mobile renderer, high precision will be used in the 2D rendering pipeline (3D is always high precision) and [method viewport_get_texture] will return an image with the [constant Image.FORMAT_RGBAH] format.
+				Use with [method viewport_set_keep_linear] to obtain an accurate texture containing the rendering results from a frame.
+			</description>
+		</method>
 		<method name="viewport_set_fsr_sharpness">
 			<return type="void" />
 			<param index="0" name="viewport" type="RID" />
@@ -3199,6 +3208,14 @@
 			<param index="1" name="transform" type="Transform2D" />
 			<description>
 				Sets the viewport's global transformation matrix.
+			</description>
+		</method>
+		<method name="viewport_set_keep_linear">
+			<return type="void" />
+			<param index="0" name="viewport" type="RID" />
+			<param index="1" name="enable" type="bool" />
+			<description>
+				If [code]true[/code], skip linear to sRGB conversion during tonemapping. If used without [method viewport_set_force_high_precision] this can result in significant banding in the rendered output.
 			</description>
 		</method>
 		<method name="viewport_set_measure_render_time">

--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -195,6 +195,9 @@
 		<member name="disable_3d" type="bool" setter="set_disable_3d" getter="is_3d_disabled" default="false">
 			Disable 3D rendering (but keep 2D rendering).
 		</member>
+		<member name="force_high_precision" type="bool" setter="set_force_high_precision" getter="is_forced_high_precision" default="false">
+			If [code]true[/code] and using the Vulkan-Clustered or Vulkan-mobile renderer, high precision will be used in the 2D rendering pipeline (3D is always high precision) and [method get_texture] will return an image with the [constant Image.FORMAT_RGBAH] format. Use with [member keep_linear] to obtain an accurate texture containing the rendering results from a frame.
+		</member>
 		<member name="fsr_sharpness" type="float" setter="set_fsr_sharpness" getter="get_fsr_sharpness" default="0.2">
 			Determines how sharp the upscaled image will be when using the FSR upscaling mode. Sharpness halves with every whole number. Values go from 0.0 (sharpest) to 2.0. Values above 2.0 won't make a visible difference.
 			To control this property on the root viewport, set the [member ProjectSettings.rendering/scaling_3d/fsr_sharpness] project setting.
@@ -212,6 +215,10 @@
 			If [code]true[/code], the GUI controls on the viewport will lay pixel perfectly.
 		</member>
 		<member name="handle_input_locally" type="bool" setter="set_handle_input_locally" getter="is_handling_input_locally" default="true">
+		</member>
+		<member name="keep_linear" type="bool" setter="set_keep_linear" getter="is_keeping_linear" default="false">
+			If [code]true[/code], skip linear to sRGB conversion during tonemapping.
+			[b]Note:[/b] If used without [member force_high_precision] this can result in significant banding in the rendered output.
 		</member>
 		<member name="mesh_lod_threshold" type="float" setter="set_mesh_lod_threshold" getter="get_mesh_lod_threshold" default="1.0">
 			The automatic LOD bias to use for meshes rendered within the [Viewport] (this is analogous to [member ReflectionProbe.mesh_lod_threshold]). Higher values will use less detailed versions of meshes that have LOD variations generated. If set to [code]0.0[/code], automatic LOD is disabled. Increase [member mesh_lod_threshold] to improve performance at the cost of geometry detail.

--- a/drivers/gles3/rasterizer_scene_gles3.cpp
+++ b/drivers/gles3/rasterizer_scene_gles3.cpp
@@ -1398,6 +1398,7 @@ void RasterizerSceneGLES3::_setup_environment(const RenderDataGLES3 *p_render_da
 
 	//time global variables
 	scene_state.ubo.time = time;
+	scene_state.ubo.keep_linear = p_render_data->keep_linear;
 
 	if (is_environment(p_render_data->environment)) {
 		RS::EnvironmentBG env_bg = environment_get_background(p_render_data->environment);
@@ -1721,6 +1722,7 @@ void RasterizerSceneGLES3::render_scene(RID p_render_buffers, const CameraData *
 			render_data.screen_mesh_lod_threshold = p_screen_mesh_lod_threshold;
 		}
 		render_data.render_info = r_render_info;
+		render_data.keep_linear = rb->keep_linear;
 	}
 
 	PagedArray<RID> empty;
@@ -2275,7 +2277,7 @@ RID RasterizerSceneGLES3::render_buffers_create() {
 	return render_buffers_owner.make_rid(rb);
 }
 
-void RasterizerSceneGLES3::render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count) {
+void RasterizerSceneGLES3::render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count, bool p_keep_linear) {
 	GLES3::TextureStorage *texture_storage = GLES3::TextureStorage::get_singleton();
 
 	RenderBuffers *rb = render_buffers_owner.get_or_null(p_render_buffers);
@@ -2291,6 +2293,7 @@ void RasterizerSceneGLES3::render_buffers_configure(RID p_render_buffers, RID p_
 	//rb->screen_space_aa = p_screen_space_aa;
 	//rb->use_debanding = p_use_debanding;
 	//rb->view_count = p_view_count;
+	rb->keep_linear = p_keep_linear;
 
 	_free_render_buffer_data(rb);
 

--- a/drivers/gles3/rasterizer_scene_gles3.h
+++ b/drivers/gles3/rasterizer_scene_gles3.h
@@ -123,6 +123,8 @@ struct RenderDataGLES3 {
 	uint32_t spot_light_count = 0;
 	uint32_t omni_light_count = 0;
 
+	bool keep_linear = false;
+
 	RendererScene::RenderInfo *render_info = nullptr;
 };
 
@@ -354,10 +356,10 @@ private:
 
 			float radiance_inverse_xform[12];
 
+			bool keep_linear = false;
 			uint32_t directional_light_count;
 			float z_far;
 			float z_near;
-			float pad1;
 
 			uint32_t fog_enabled;
 			float fog_density;
@@ -502,6 +504,7 @@ protected:
 		//uint32_t view_count = 1;
 
 		bool is_transparent = false;
+		bool keep_linear = false;
 
 		RID render_target;
 		GLuint internal_texture = 0; // Used for rendering when post effects are enabled
@@ -762,7 +765,7 @@ public:
 	}
 
 	RID render_buffers_create() override;
-	void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count) override;
+	void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count, bool p_keep_linear) override;
 	void gi_set_use_half_resolution(bool p_enable) override;
 
 	void screen_space_roughness_limiter_set_active(bool p_enable, float p_amount, float p_curve) override;

--- a/drivers/gles3/storage/config.cpp
+++ b/drivers/gles3/storage/config.cpp
@@ -61,9 +61,11 @@ Config::Config() {
 	etc2_supported = false;
 	s3tc_supported = true;
 	rgtc_supported = true; //RGTC - core since OpenGL version 3.0
+	framebuffer_float_supported = true;
 #else
 	float_texture_supported = extensions.has("GL_ARB_texture_float") || extensions.has("GL_OES_texture_float");
 	etc2_supported = true;
+	framebuffer_float_supported = extensions.has("GL_EXT_color_buffer_float") && extensions.has("GL_EXT_color_buffer_half_float");
 #if defined(ANDROID_ENABLED) || defined(IOS_ENABLED)
 	// Some Android devices report support for S3TC but we don't expect that and don't export the textures.
 	// This could be fixed but so few devices support it that it doesn't seem useful (and makes bigger APKs).

--- a/drivers/gles3/storage/config.h
+++ b/drivers/gles3/storage/config.h
@@ -74,6 +74,7 @@ public:
 	bool rgtc_supported = false;
 	bool bptc_supported = false;
 	bool etc2_supported = false;
+	bool framebuffer_float_supported = false;
 
 	bool force_vertex_shading = false;
 

--- a/drivers/gles3/storage/texture_storage.h
+++ b/drivers/gles3/storage/texture_storage.h
@@ -353,6 +353,7 @@ struct RenderTarget {
 
 	bool is_transparent = false;
 	bool direct_to_screen = false;
+	bool force_high_precision = false;
 
 	bool used_in_frame = false;
 	RS::ViewportMSAA msaa = RS::VIEWPORT_MSAA_DISABLED;
@@ -518,6 +519,9 @@ public:
 
 	virtual RID render_target_create() override;
 	virtual void render_target_free(RID p_rid) override;
+
+	virtual void render_target_set_force_high_precision(RID p_render_target, bool p_force_high_precision) override;
+
 	virtual void render_target_set_position(RID p_render_target, int p_x, int p_y) override;
 	virtual void render_target_set_size(RID p_render_target, int p_width, int p_height, uint32_t p_view_count) override;
 	Size2i render_target_get_size(RID p_render_target);

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -2947,6 +2947,34 @@ bool Viewport::is_using_occlusion_culling() const {
 	return use_occlusion_culling;
 }
 
+void Viewport::set_keep_linear(bool p_keep_linear) {
+	if (keep_linear == p_keep_linear) {
+		return;
+	}
+	keep_linear = p_keep_linear;
+	RS::get_singleton()->viewport_set_keep_linear(viewport, p_keep_linear);
+
+	notify_property_list_changed();
+}
+
+bool Viewport::is_keeping_linear() const {
+	return keep_linear;
+}
+
+void Viewport::set_force_high_precision(bool p_force_high_precision) {
+	if (force_high_precision == p_force_high_precision) {
+		return;
+	}
+	force_high_precision = p_force_high_precision;
+	RS::get_singleton()->viewport_set_force_high_precision(viewport, force_high_precision);
+
+	notify_property_list_changed();
+}
+
+bool Viewport::is_forced_high_precision() const {
+	return force_high_precision;
+}
+
 void Viewport::set_debug_draw(DebugDraw p_debug_draw) {
 	debug_draw = p_debug_draw;
 	RS::get_singleton()->viewport_set_debug_draw(viewport, RS::ViewportDebugDraw(p_debug_draw));
@@ -3590,7 +3618,6 @@ void Viewport::_propagate_exit_world_3d(Node *p_node) {
 		_propagate_exit_world_3d(p_node->get_child(i));
 	}
 }
-
 void Viewport::set_use_xr(bool p_use_xr) {
 	use_xr = p_use_xr;
 
@@ -3689,6 +3716,12 @@ void Viewport::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_use_occlusion_culling", "enable"), &Viewport::set_use_occlusion_culling);
 	ClassDB::bind_method(D_METHOD("is_using_occlusion_culling"), &Viewport::is_using_occlusion_culling);
+
+	ClassDB::bind_method(D_METHOD("set_keep_linear", "enable"), &Viewport::set_keep_linear);
+	ClassDB::bind_method(D_METHOD("is_keeping_linear"), &Viewport::is_keeping_linear);
+
+	ClassDB::bind_method(D_METHOD("set_force_high_precision", "enable"), &Viewport::set_force_high_precision);
+	ClassDB::bind_method(D_METHOD("is_forced_high_precision"), &Viewport::is_forced_high_precision);
 
 	ClassDB::bind_method(D_METHOD("set_debug_draw", "debug_draw"), &Viewport::set_debug_draw);
 	ClassDB::bind_method(D_METHOD("get_debug_draw"), &Viewport::get_debug_draw);
@@ -3821,6 +3854,8 @@ void Viewport::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_taa"), "set_use_taa", "is_using_taa");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_debanding"), "set_use_debanding", "is_using_debanding");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_occlusion_culling"), "set_use_occlusion_culling", "is_using_occlusion_culling");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "keep_linear"), "set_keep_linear", "is_keeping_linear");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "force_high_precision"), "set_force_high_precision", "is_forced_high_precision");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "mesh_lod_threshold", PROPERTY_HINT_RANGE, "0,1024,0.1"), "set_mesh_lod_threshold", "get_mesh_lod_threshold");
 	ADD_PROPERTY(PropertyInfo(Variant::INT, "debug_draw", PROPERTY_HINT_ENUM, "Disabled,Unshaded,Overdraw,Wireframe"), "set_debug_draw", "get_debug_draw");
 #ifndef _3D_DISABLED
@@ -4145,6 +4180,7 @@ void SubViewport::_bind_methods() {
 	BIND_ENUM_CONSTANT(UPDATE_ALWAYS);
 }
 
-SubViewport::SubViewport() {}
+SubViewport::SubViewport() {
+}
 
 SubViewport::~SubViewport() {}

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -309,6 +309,9 @@ private:
 	float mesh_lod_threshold = 1.0;
 	bool use_occlusion_culling = false;
 
+	bool keep_linear = false;
+	bool force_high_precision = false;
+
 	Ref<ViewportTexture> default_texture;
 	HashSet<ViewportTexture *> viewport_textures;
 
@@ -552,6 +555,12 @@ public:
 	void set_use_occlusion_culling(bool p_us_occlusion_culling);
 	bool is_using_occlusion_culling() const;
 
+	void set_keep_linear(bool p_keep_linear);
+	bool is_keeping_linear() const;
+
+	void set_force_high_precision(bool p_force_high_precision);
+	bool is_forced_high_precision() const;
+
 	Vector2 get_camera_coords(const Vector2 &p_viewport_coords) const;
 	Vector2 get_camera_rect_size() const;
 
@@ -704,7 +713,6 @@ public:
 	bool is_using_own_world_3d() const;
 	void _propagate_enter_world_3d(Node *p_node);
 	void _propagate_exit_world_3d(Node *p_node);
-
 	void set_use_xr(bool p_use_xr);
 	bool is_using_xr();
 #endif // _3D_DISABLED

--- a/servers/rendering/dummy/rasterizer_scene_dummy.h
+++ b/servers/rendering/dummy/rasterizer_scene_dummy.h
@@ -144,7 +144,7 @@ public:
 	void set_debug_draw_mode(RS::ViewportDebugDraw p_debug_draw) override {}
 
 	RID render_buffers_create() override { return RID(); }
-	void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count) override {}
+	void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count, bool p_keep_linear) override {}
 	void gi_set_use_half_resolution(bool p_enable) override {}
 
 	void screen_space_roughness_limiter_set_active(bool p_enable, float p_amount, float p_curve) override {}

--- a/servers/rendering/dummy/storage/texture_storage.h
+++ b/servers/rendering/dummy/storage/texture_storage.h
@@ -151,6 +151,7 @@ public:
 
 	virtual RID render_target_create() override { return RID(); }
 	virtual void render_target_free(RID p_rid) override {}
+	virtual void render_target_set_force_high_precision(RID p_render_target, bool p_force_high_precision) override {}
 	virtual void render_target_set_position(RID p_render_target, int p_x, int p_y) override {}
 	virtual void render_target_set_size(RID p_render_target, int p_width, int p_height, uint32_t p_view_count) override {}
 	virtual RID render_target_get_texture(RID p_render_target) override { return RID(); }

--- a/servers/rendering/renderer_rd/effects/tone_mapper.cpp
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.cpp
@@ -124,6 +124,7 @@ void ToneMapper::tonemapper(RID p_source_color, RID p_dst_framebuffer, const Ton
 
 	tonemap.push_constant.use_fxaa = p_settings.use_fxaa;
 	tonemap.push_constant.use_debanding = p_settings.use_debanding;
+	tonemap.push_constant.keep_linear = p_settings.keep_linear;
 	tonemap.push_constant.pixel_size[0] = 1.0 / p_settings.texture_size.x;
 	tonemap.push_constant.pixel_size[1] = 1.0 / p_settings.texture_size.y;
 
@@ -208,6 +209,7 @@ void ToneMapper::tonemapper(RD::DrawListID p_subpass_draw_list, RID p_source_col
 	tonemap.push_constant.use_color_correction = p_settings.use_color_correction;
 
 	tonemap.push_constant.use_debanding = p_settings.use_debanding;
+	tonemap.push_constant.keep_linear = p_settings.keep_linear;
 	tonemap.push_constant.luminance_multiplier = p_settings.luminance_multiplier;
 
 	RID default_sampler = material_storage->sampler_rd_get_default(RS::CANVAS_ITEM_TEXTURE_FILTER_LINEAR, RS::CANVAS_ITEM_TEXTURE_REPEAT_DISABLED);

--- a/servers/rendering/renderer_rd/effects/tone_mapper.h
+++ b/servers/rendering/renderer_rd/effects/tone_mapper.h
@@ -83,6 +83,8 @@ private:
 		float pixel_size[2]; //  8 - 104
 		uint32_t use_fxaa; //  4 - 108
 		uint32_t use_debanding; //  4 - 112
+		float pad[3]; //  12 - 124
+		uint32_t keep_linear; //  4 - 128
 	};
 
 	/* tonemap actually writes to a framebuffer, which is
@@ -141,6 +143,7 @@ public:
 		bool use_debanding = false;
 		Vector2i texture_size;
 		uint32_t view_count = 1;
+		bool keep_linear = false;
 	};
 
 	void tonemapper(RID p_source_color, RID p_dst_framebuffer, const TonemapSettings &p_settings);

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.cpp
@@ -2046,6 +2046,7 @@ void RendererSceneRenderRD::_render_buffers_post_process_and_tonemap(const Rende
 			tonemap.white = environment_get_white(p_render_data->environment);
 			tonemap.exposure = environment_get_exposure(p_render_data->environment);
 		}
+		tonemap.keep_linear = rb->keep_linear;
 
 		if (camfx && camfx->override_exposure_enabled) {
 			tonemap.exposure = camfx->override_exposure;
@@ -2448,7 +2449,7 @@ bool RendererSceneRenderRD::_render_buffers_can_be_storage() {
 	return true;
 }
 
-void RendererSceneRenderRD::render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RenderingServer::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count) {
+void RendererSceneRenderRD::render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RenderingServer::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count, bool p_keep_linear) {
 	RendererRD::TextureStorage *texture_storage = RendererRD::TextureStorage::get_singleton();
 	RendererRD::MaterialStorage *material_storage = RendererRD::MaterialStorage::get_singleton();
 
@@ -2488,6 +2489,7 @@ void RendererSceneRenderRD::render_buffers_configure(RID p_render_buffers, RID p
 	rb->screen_space_aa = p_screen_space_aa;
 	rb->use_taa = p_use_taa;
 	rb->use_debanding = p_use_debanding;
+	rb->keep_linear = p_keep_linear;
 	rb->view_count = p_view_count;
 
 	if (is_clustered_enabled()) {

--- a/servers/rendering/renderer_rd/renderer_scene_render_rd.h
+++ b/servers/rendering/renderer_rd/renderer_scene_render_rd.h
@@ -92,6 +92,7 @@ struct RenderDataRD {
 
 	uint32_t directional_light_count = 0;
 	bool directional_light_soft_shadows = false;
+	bool keep_linear = false;
 
 	RendererScene::RenderInfo *render_info = nullptr;
 };
@@ -460,6 +461,7 @@ private:
 		RS::ViewportScreenSpaceAA screen_space_aa = RS::VIEWPORT_SCREEN_SPACE_AA_DISABLED;
 		bool use_taa = false;
 		bool use_debanding = false;
+		bool keep_linear = false;
 		uint32_t view_count = 1;
 
 		RID render_target;
@@ -1105,7 +1107,7 @@ public:
 	virtual RD::DataFormat _render_buffers_get_color_format();
 	virtual bool _render_buffers_can_be_storage();
 	virtual RID render_buffers_create() override;
-	virtual void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count) override;
+	virtual void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count, bool p_keep_linear) override;
 	virtual void gi_set_use_half_resolution(bool p_enable) override;
 
 	RID render_buffers_get_depth_texture(RID p_render_buffers);

--- a/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
+++ b/servers/rendering/renderer_rd/shaders/effects/tonemap.glsl
@@ -81,6 +81,8 @@ layout(push_constant, std430) uniform Params {
 	vec2 pixel_size;
 	bool use_fxaa;
 	bool use_debanding;
+	vec3 pad;
+	bool keep_linear;
 }
 params;
 
@@ -469,8 +471,9 @@ void main() {
 	}
 
 	color.rgb = apply_tonemapping(color.rgb, params.white);
-
-	color.rgb = linear_to_srgb(color.rgb); // regular linear -> SRGB conversion
+	if (!params.keep_linear) {
+		color.rgb = linear_to_srgb(color.rgb); // regular linear -> SRGB conversion
+	}
 
 #ifndef SUBPASS
 	// Glow

--- a/servers/rendering/renderer_rd/storage_rd/texture_storage.h
+++ b/servers/rendering/renderer_rd/storage_rd/texture_storage.h
@@ -139,9 +139,11 @@ private:
 
 		bool is_render_target;
 		bool is_proxy;
+		bool sdf_enabled = false;
 
 		Ref<Image> image_cache_2d;
 		String path;
+		bool force_high_precision = false;
 
 		RID proxy_to;
 		Vector<RID> proxies;
@@ -261,6 +263,7 @@ private:
 		Image::Format image_format = Image::FORMAT_L8;
 
 		bool is_transparent = false;
+		bool force_high_precision = false;
 
 		bool sdf_enabled = false;
 
@@ -547,6 +550,8 @@ public:
 
 	virtual RID render_target_create() override;
 	virtual void render_target_free(RID p_rid) override;
+
+	virtual void render_target_set_force_high_precision(RID p_render_target, bool p_force_high_precision) override;
 
 	virtual void render_target_set_position(RID p_render_target, int p_x, int p_y) override;
 	virtual void render_target_set_size(RID p_render_target, int p_width, int p_height, uint32_t p_view_count) override;

--- a/servers/rendering/renderer_scene.h
+++ b/servers/rendering/renderer_scene.h
@@ -306,7 +306,7 @@ public:
 
 	virtual RID render_buffers_create() = 0;
 
-	virtual void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count) = 0;
+	virtual void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count, bool p_keep_linear) = 0;
 
 	virtual void gi_set_use_half_resolution(bool p_enable) = 0;
 

--- a/servers/rendering/renderer_scene_cull.h
+++ b/servers/rendering/renderer_scene_cull.h
@@ -1269,7 +1269,7 @@ public:
 	/* Render Buffers */
 
 	PASS0R(RID, render_buffers_create)
-	PASS13(render_buffers_configure, RID, RID, int, int, int, int, float, float, RS::ViewportMSAA, RS::ViewportScreenSpaceAA, bool, bool, uint32_t)
+	PASS14(render_buffers_configure, RID, RID, int, int, int, int, float, float, RS::ViewportMSAA, RS::ViewportScreenSpaceAA, bool, bool, uint32_t, bool)
 	PASS1(gi_set_use_half_resolution, bool)
 
 	/* Shadow Atlas */

--- a/servers/rendering/renderer_scene_render.h
+++ b/servers/rendering/renderer_scene_render.h
@@ -341,7 +341,7 @@ public:
 	virtual void set_debug_draw_mode(RS::ViewportDebugDraw p_debug_draw) = 0;
 
 	virtual RID render_buffers_create() = 0;
-	virtual void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count) = 0;
+	virtual void render_buffers_configure(RID p_render_buffers, RID p_render_target, int p_internal_width, int p_internal_height, int p_width, int p_height, float p_fsr_sharpness, float p_texture_mipmap_bias, RS::ViewportMSAA p_msaa, RS::ViewportScreenSpaceAA p_screen_space_aa, bool p_use_taa, bool p_use_debanding, uint32_t p_view_count, bool p_keep_linear) = 0;
 	virtual void gi_set_use_half_resolution(bool p_enable) = 0;
 
 	virtual void screen_space_roughness_limiter_set_active(bool p_enable, float p_amount, float p_limit) = 0;

--- a/servers/rendering/renderer_viewport.h
+++ b/servers/rendering/renderer_viewport.h
@@ -60,7 +60,7 @@ public:
 		float scaling_3d_scale = 1.0;
 		float fsr_sharpness = 0.2f;
 		float texture_mipmap_bias = 0.0f;
-		bool fsr_enabled = false;
+		bool fsr_enabled;
 		RS::ViewportUpdateMode update_mode = RenderingServer::VIEWPORT_UPDATE_WHEN_VISIBLE;
 		RID render_target;
 		RID render_target_texture;
@@ -85,6 +85,9 @@ public:
 		bool disable_environment = false;
 		bool disable_3d = false;
 		bool measure_render_time = false;
+
+		bool keep_linear = false;
+		bool force_high_precision = false;
 
 		bool snap_2d_transforms_to_pixel = false;
 		bool snap_2d_vertices_to_pixel = false;
@@ -207,6 +210,7 @@ public:
 	RID viewport_allocate();
 	void viewport_initialize(RID p_rid);
 
+	bool viewport_is_keeping_linear(RID p_viewport) const;
 	void viewport_set_use_xr(RID p_viewport, bool p_use_xr);
 
 	void viewport_set_size(RID p_viewport, int p_width, int p_height);
@@ -255,6 +259,8 @@ public:
 	void viewport_set_use_taa(RID p_viewport, bool p_use_taa);
 	void viewport_set_use_debanding(RID p_viewport, bool p_use_debanding);
 	void viewport_set_use_occlusion_culling(RID p_viewport, bool p_use_occlusion_culling);
+	void viewport_set_keep_linear(RID p_viewport, bool p_keep_linear);
+	void viewport_set_force_high_precision(RID p_viewport, bool p_force_high_precision);
 	void viewport_set_occlusion_rays_per_thread(int p_rays_per_thread);
 	void viewport_set_occlusion_culling_build_quality(RS::ViewportOcclusionCullingBuildQuality p_quality);
 	void viewport_set_mesh_lod_threshold(RID p_viewport, float p_pixels);

--- a/servers/rendering/rendering_server_default.h
+++ b/servers/rendering/rendering_server_default.h
@@ -624,6 +624,8 @@ public:
 	FUNC2(viewport_set_use_taa, RID, bool)
 	FUNC2(viewport_set_use_debanding, RID, bool)
 	FUNC2(viewport_set_use_occlusion_culling, RID, bool)
+	FUNC2(viewport_set_keep_linear, RID, bool)
+	FUNC2(viewport_set_force_high_precision, RID, bool)
 	FUNC1(viewport_set_occlusion_rays_per_thread, int)
 	FUNC1(viewport_set_occlusion_culling_build_quality, ViewportOcclusionCullingBuildQuality)
 	FUNC2(viewport_set_mesh_lod_threshold, RID, float)

--- a/servers/rendering/storage/texture_storage.h
+++ b/servers/rendering/storage/texture_storage.h
@@ -125,6 +125,7 @@ public:
 	virtual RID render_target_create() = 0;
 	virtual void render_target_free(RID p_rid) = 0;
 
+	virtual void render_target_set_force_high_precision(RID p_render_target, bool p_force_high_precision) = 0;
 	virtual void render_target_set_position(RID p_render_target, int p_x, int p_y) = 0;
 	virtual void render_target_set_size(RID p_render_target, int p_width, int p_height, uint32_t p_view_count) = 0;
 	virtual RID render_target_get_texture(RID p_render_target) = 0;

--- a/servers/rendering_server.cpp
+++ b/servers/rendering_server.cpp
@@ -2209,6 +2209,8 @@ void RenderingServer::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("viewport_set_use_taa", "viewport", "enable"), &RenderingServer::viewport_set_use_taa);
 	ClassDB::bind_method(D_METHOD("viewport_set_use_debanding", "viewport", "enable"), &RenderingServer::viewport_set_use_debanding);
 	ClassDB::bind_method(D_METHOD("viewport_set_use_occlusion_culling", "viewport", "enable"), &RenderingServer::viewport_set_use_occlusion_culling);
+	ClassDB::bind_method(D_METHOD("viewport_set_keep_linear", "viewport", "enable"), &RenderingServer::viewport_set_keep_linear);
+	ClassDB::bind_method(D_METHOD("viewport_set_force_high_precision", "viewport", "enable"), &RenderingServer::viewport_set_force_high_precision);
 	ClassDB::bind_method(D_METHOD("viewport_set_occlusion_rays_per_thread", "rays_per_thread"), &RenderingServer::viewport_set_occlusion_rays_per_thread);
 	ClassDB::bind_method(D_METHOD("viewport_set_occlusion_culling_build_quality", "quality"), &RenderingServer::viewport_set_occlusion_culling_build_quality);
 

--- a/servers/rendering_server.h
+++ b/servers/rendering_server.h
@@ -891,6 +891,8 @@ public:
 	virtual void viewport_set_mesh_lod_threshold(RID p_viewport, float p_pixels) = 0;
 
 	virtual void viewport_set_use_occlusion_culling(RID p_viewport, bool p_use_occlusion_culling) = 0;
+	virtual void viewport_set_keep_linear(RID p_viewport, bool p_keep_linear) = 0;
+	virtual void viewport_set_force_high_precision(RID p_viewport, bool p_force_high_precision) = 0;
 	virtual void viewport_set_occlusion_rays_per_thread(int p_rays_per_thread) = 0;
 
 	enum ViewportOcclusionCullingBuildQuality {


### PR DESCRIPTION
Fixes #54122

I was facing #54122 when trying to port a post effect i did in 3.4.4
This quick fix make the subviewport keep the `DATA_FORMAT_R16G16B16A16_SFLOAT` precision and disable tonemapping and linearization in the tonemapper shader.

The current implementation i did looks really bad but i'll try to clean it later.

- [x] Introduce a `keep_linear_3d` checkbox in SubViewport parameters
- [x] Pass the `keep_linear_3d` through SubViewports property  to the render target
- [x] Documentation (buffer format, disabled tonemapping...)

**Edit**:
I made a quick test project for this feature : 
[TestShaderPostProcess.zip](https://github.com/godotengine/godot/files/9020096/TestShaderPostProcess.zip)
Each cube is using the same shader that has a `float` uniform that is put into the color value.
Cube value of main scene are (-1.0, 0.0, 0.5, 1.0, 50.0).
Post process is simply putting a random color based on retrieved color value.
Base result (both `keep_linear` and `force_high_precision` disabled)
![image](https://user-images.githubusercontent.com/6182189/176686828-aadbc956-7dfb-4be2-8613-96d7b4c4e9bb.png)
Result with both flag enabled (Vulkan):
![image](https://user-images.githubusercontent.com/6182189/176686945-9b003ae2-0fe6-4024-b781-a5e07e582ce4.png)

