### PR TITLE
Make Input `mouse_mode` and `use_accumulated_input` properties

### DIFF
--- a/core/input/input.cpp
+++ b/core/input/input.cpp
@@ -134,7 +134,11 @@ void Input::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_custom_mouse_cursor", "image", "shape", "hotspot"), &Input::set_custom_mouse_cursor, DEFVAL(CURSOR_ARROW), DEFVAL(Vector2()));
 	ClassDB::bind_method(D_METHOD("parse_input_event", "event"), &Input::parse_input_event);
 	ClassDB::bind_method(D_METHOD("set_use_accumulated_input", "enable"), &Input::set_use_accumulated_input);
+	ClassDB::bind_method(D_METHOD("is_using_accumulated_input"), &Input::is_using_accumulated_input);
 	ClassDB::bind_method(D_METHOD("flush_buffered_events"), &Input::flush_buffered_events);
+
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "mouse_mode"), "set_mouse_mode", "get_mouse_mode");
+	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "use_accumulated_input"), "set_use_accumulated_input", "is_using_accumulated_input");
 
 	BIND_ENUM_CONSTANT(MOUSE_MODE_VISIBLE);
 	BIND_ENUM_CONSTANT(MOUSE_MODE_HIDDEN);
@@ -895,6 +899,10 @@ void Input::set_use_input_buffering(bool p_enable) {
 
 void Input::set_use_accumulated_input(bool p_enable) {
 	use_accumulated_input = p_enable;
+}
+
+bool Input::is_using_accumulated_input() {
+	return use_accumulated_input;
 }
 
 void Input::release_pressed_events() {

--- a/core/input/input.h
+++ b/core/input/input.h
@@ -326,6 +326,7 @@ public:
 	bool is_using_input_buffering();
 	void set_use_input_buffering(bool p_enable);
 	void set_use_accumulated_input(bool p_enable);
+	bool is_using_accumulated_input();
 
 	void release_pressed_events();
 

--- a/doc/classes/Input.xml
+++ b/doc/classes/Input.xml
@@ -40,7 +40,7 @@
 		<method name="flush_buffered_events">
 			<return type="void" />
 			<description>
-				Sends all input events which are in the current buffer to the game loop. These events may have been buffered as a result of accumulated input ([method set_use_accumulated_input]) or agile input flushing ([member ProjectSettings.input_devices/buffering/agile_event_flushing]).
+				Sends all input events which are in the current buffer to the game loop. These events may have been buffered as a result of accumulated input ([member use_accumulated_input]) or agile input flushing ([member ProjectSettings.input_devices/buffering/agile_event_flushing]).
 				The engine will already do this itself at key execution points (at least once per frame). However, this can be useful in advanced cases where you want precise control over the timing of event handling.
 			</description>
 		</method>
@@ -158,12 +158,6 @@
 			<return type="int" enum="MouseButton" />
 			<description>
 				Returns mouse buttons as a bitmask. If multiple mouse buttons are pressed at the same time, the bits are added together.
-			</description>
-		</method>
-		<method name="get_mouse_mode" qualifiers="const">
-			<return type="int" enum="Input.MouseMode" />
-			<description>
-				Returns the mouse mode. See the constants for more information.
 			</description>
 		</method>
 		<method name="get_vector" qualifiers="const">
@@ -338,21 +332,6 @@
 				[b]Note:[/b] This value can be immediately overwritten by the hardware sensor value on Android and iOS.
 			</description>
 		</method>
-		<method name="set_mouse_mode">
-			<return type="void" />
-			<argument index="0" name="mode" type="int" enum="Input.MouseMode" />
-			<description>
-				Sets the mouse mode. See the constants for more information.
-			</description>
-		</method>
-		<method name="set_use_accumulated_input">
-			<return type="void" />
-			<argument index="0" name="enable" type="bool" />
-			<description>
-				Enables or disables the accumulation of similar input events sent by the operating system. When input accumulation is enabled, all input events generated during a frame will be merged and emitted when the frame is done rendering. Therefore, this limits the number of input method calls per second to the rendering FPS.
-				Input accumulation is enabled by default. It can be disabled to get slightly more precise/reactive input at the cost of increased CPU usage. In applications where drawing freehand lines is required, input accumulation should generally be disabled while the user is drawing the line to get results that closely follow the actual input.
-			</description>
-		</method>
 		<method name="start_joy_vibration">
 			<return type="void" />
 			<argument index="0" name="device" type="int" />
@@ -389,6 +368,15 @@
 			</description>
 		</method>
 	</methods>
+	<members>
+		<member name="mouse_mode" type="int" setter="set_mouse_mode" getter="get_mouse_mode" enum="Input.MouseMode">
+			Controls the mouse mode. See [enum MouseMode] for more information.
+		</member>
+		<member name="use_accumulated_input" type="bool" setter="set_use_accumulated_input" getter="is_using_accumulated_input">
+			If [code]true[/code], similar input events sent by the operating system are accumulated. When input accumulation is enabled, all input events generated during a frame will be merged and emitted when the frame is done rendering. Therefore, this limits the number of input method calls per second to the rendering FPS.
+			Input accumulation can be disabled to get slightly more precise/reactive input at the cost of increased CPU usage. In applications where drawing freehand lines is required, input accumulation should generally be disabled while the user is drawing the line to get results that closely follow the actual input.
+		</member>
+	</members>
 	<signals>
 		<signal name="joy_connection_changed">
 			<argument index="0" name="device" type="int" />

--- a/doc/classes/InputEventMouseMotion.xml
+++ b/doc/classes/InputEventMouseMotion.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		Contains mouse and pen motion information. Supports relative, absolute positions and velocity. See [method Node._input].
-		[b]Note:[/b] By default, this event is only emitted once per frame rendered at most. If you need more precise input reporting, call [method Input.set_use_accumulated_input] with [code]false[/code] to make events emitted as often as possible. If you use InputEventMouseMotion to draw lines, consider implementing [url=https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm]Bresenham's line algorithm[/url] as well to avoid visible gaps in lines if the user is moving the mouse quickly.
+		[b]Note:[/b] By default, this event is only emitted once per frame rendered at most. If you need more precise input reporting, set [member Input.use_accumulated_input] to [code]false[/code] to make events emitted as often as possible. If you use InputEventMouseMotion to draw lines, consider implementing [url=https://en.wikipedia.org/wiki/Bresenham%27s_line_algorithm]Bresenham's line algorithm[/url] as well to avoid visible gaps in lines if the user is moving the mouse quickly.
 	</description>
 	<tutorials>
 		<link title="Mouse and input coordinates">$DOCS_URL/tutorials/inputs/mouse_and_input_coordinates.html</link>


### PR DESCRIPTION
Converts Input `mouse_mode` and `use_accumulated_input` from setter/getter functions to properties. Also adds a missing getter for `use_accumulated_input` (it only had a setter before).