### PR TITLE
Document the correct use of NavigationAgent path functions

### DIFF
--- a/doc/classes/NavigationAgent2D.xml
+++ b/doc/classes/NavigationAgent2D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		2D Agent that is used in navigation to reach a location while avoiding static and dynamic obstacles. The dynamic obstacles are avoided using RVO collision avoidance. The agent needs navigation data to work correctly. [NavigationAgent2D] is physics safe.
+		[b]Note:[/b] After [method set_target_location] is used it is required to use the [method get_next_location] function once every physics frame to update the internal path logic of the NavigationAgent. The returned vector position from this function should be used as the next movement position for the agent's parent Node.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -24,7 +25,7 @@
 		<method name="get_nav_path" qualifiers="const">
 			<return type="PackedVector2Array" />
 			<description>
-				Returns the path from start to finish in global coordinates.
+				Returns this agent's current path from start to finish in global coordinates. The path only updates when the target location is changed or the agent requires a repath. The path array is not intended to be used in direct path movement as the agent has its own internal path logic that would get corrupted by changing the path array manually. Use the intended [method get_next_location] once every physics frame to receive the next path point for the agents movement as this function also updates the internal path logic.
 			</description>
 		</method>
 		<method name="get_nav_path_index" qualifiers="const">
@@ -36,7 +37,7 @@
 		<method name="get_next_location">
 			<return type="Vector2" />
 			<description>
-				Returns a [Vector2] in global coordinates, that can be moved to, making sure that there are no static objects in the way. If the agent does not have a navigation path, it will return the position of the agent's parent.
+				Returns the next location in global coordinates that can be moved to, making sure that there are no static objects in the way. If the agent does not have a navigation path, it will return the position of the agent's parent. The use of this function once every physics frame is required to update the internal path logic of the NavigationAgent.
 			</description>
 		</method>
 		<method name="get_rid" qualifiers="const">

--- a/doc/classes/NavigationAgent3D.xml
+++ b/doc/classes/NavigationAgent3D.xml
@@ -5,6 +5,7 @@
 	</brief_description>
 	<description>
 		3D Agent that is used in navigation to reach a location while avoiding static and dynamic obstacles. The dynamic obstacles are avoided using RVO collision avoidance. The agent needs navigation data to work correctly. [NavigationAgent3D] is physics safe.
+		[b]Note:[/b] After [method set_target_location] is used it is required to use the [method get_next_location] function once every physics frame to update the internal path logic of the NavigationAgent. The returned vector position from this function should be used as the next movement position for the agent's parent Node.
 	</description>
 	<tutorials>
 	</tutorials>
@@ -24,7 +25,7 @@
 		<method name="get_nav_path" qualifiers="const">
 			<return type="PackedVector3Array" />
 			<description>
-				Returns the path from start to finish in global coordinates.
+				Returns this agent's current path from start to finish in global coordinates. The path only updates when the target location is changed or the agent requires a repath. The path array is not intended to be used in direct path movement as the agent has its own internal path logic that would get corrupted by changing the path array manually. Use the intended [method get_next_location] once every physics frame to receive the next path point for the agents movement as this function also updates the internal path logic.
 			</description>
 		</method>
 		<method name="get_nav_path_index" qualifiers="const">
@@ -36,7 +37,7 @@
 		<method name="get_next_location">
 			<return type="Vector3" />
 			<description>
-				Returns a [Vector3] in global coordinates, that can be moved to, making sure that there are no static objects in the way. If the agent does not have a navigation path, it will return the origin of the agent's parent.
+				Returns the next location in global coordinates that can be moved to, making sure that there are no static objects in the way. If the agent does not have a navigation path, it will return the position of the agent's parent. The use of this function once every physics frame is required to update the internal path logic of the NavigationAgent.
 			</description>
 		</method>
 		<method name="get_rid" qualifiers="const">


### PR DESCRIPTION
Doc correct use of NavigationAgent `get_nav_path()` and `get_next_location()`.

Users out of old habit wanted to use the path of the NavigationAgent manually by manipulating the reached points from the path array corrupting the path. Not using the intended get_next_location() would also lead to a braindead agent that never updates its internal path logic.

Closes #59104

Makes pr #59133 obsolete that wanted to add path updates everywhere that would further corrupt the agent logic.

The intention to add a lot of path updates to each function call in the source code was ill-advised as the agent only accepts a single update call each physics frame. Multiple calls each frame would just block or corrupt the important updates.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

Bugsquad edit:

Closes: https://github.com/godotengine/godot/pull/59133