### PR TITLE
Fix incorrect aspect ratio of terrain polygon in tile set editor

### DIFF
--- a/scene/resources/tile_set.cpp
+++ b/scene/resources/tile_set.cpp
@@ -2072,8 +2072,9 @@ Vector<Point2> TileSet::_get_half_offset_corner_or_side_terrain_bit_polygon(Vect
 		}
 	} else {
 		if (p_offset_axis == TileSet::TILE_OFFSET_AXIS_VERTICAL) {
+			Vector2 ratio = Vector2((float)p_size.x / (float)p_size.y, (float)p_size.y / (float)p_size.x);
 			for (int i = 0; i < point_list.size(); i++) {
-				point_list.write[i] = Vector2(point_list[i].y, point_list[i].x);
+				point_list.write[i] = Vector2(point_list[i].y, point_list[i].x) * ratio;
 			}
 		}
 		switch (p_bit) {
@@ -2203,8 +2204,9 @@ Vector<Point2> TileSet::_get_half_offset_corner_terrain_bit_polygon(Vector2i p_s
 		}
 	} else {
 		if (p_offset_axis == TileSet::TILE_OFFSET_AXIS_VERTICAL) {
+			Vector2 ratio = Vector2((float)p_size.x / (float)p_size.y, (float)p_size.y / (float)p_size.x);
 			for (int i = 0; i < point_list.size(); i++) {
-				point_list.write[i] = Vector2(point_list[i].y, point_list[i].x);
+				point_list.write[i] = Vector2(point_list[i].y, point_list[i].x) * ratio;
 			}
 		}
 		switch (p_bit) {
@@ -2298,8 +2300,9 @@ Vector<Point2> TileSet::_get_half_offset_side_terrain_bit_polygon(Vector2i p_siz
 		}
 	} else {
 		if (p_offset_axis == TileSet::TILE_OFFSET_AXIS_VERTICAL) {
+			Vector2 ratio = Vector2((float)p_size.x / (float)p_size.y, (float)p_size.y / (float)p_size.x);
 			for (int i = 0; i < point_list.size(); i++) {
-				point_list.write[i] = Vector2(point_list[i].y, point_list[i].x);
+				point_list.write[i] = Vector2(point_list[i].y, point_list[i].x) * ratio;
 			}
 		}
 		switch (p_bit) {


### PR DESCRIPTION
Fixed the terrain polygon using an incorrect aspect ratio when using a vertical offset on Half-Offset Square or Hexagon tile shape.

<details>
<summary><h1>Current</h1></summary>

<details>
<summary><h2>Hexagon</h2></summary>

![image](https://user-images.githubusercontent.com/60494981/171951024-7c0c6661-5a46-4da4-94e3-a5a008ca3089.png)

</details>

<details>
<summary><h2>Half-Offset Square</h2></summary>

![image](https://user-images.githubusercontent.com/60494981/171950878-3723b4e9-3a1a-433d-ad77-72756003c691.png)

</details>
</details>
<details>
<summary><h1>With Changes</h1></summary>

<details>
<summary><h2>Hexagon</h2></summary>

![image](https://user-images.githubusercontent.com/60494981/171951203-536327de-a262-4f51-adb9-1b3d253ba95d.png)

</details>

<details>
<summary><h2>Half-Offset Square</h2></summary>

![image](https://user-images.githubusercontent.com/60494981/171951246-c28fc32d-a7e4-473b-b09e-37ab2d801eec.png)

</details>

</details>