### PR TITLE
Update viewport when toggling TileMap grid

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.cpp
+++ b/editor/plugins/tiles/tile_map_editor.cpp
@@ -3428,6 +3428,7 @@ void TileMapEditor::_notification(int p_what) {
 
 void TileMapEditor::_on_grid_toggled(bool p_pressed) {
 	EditorSettings::get_singleton()->set("editors/tiles_editor/display_grid", p_pressed);
+	CanvasItemEditor::get_singleton()->update_viewport();
 }
 
 void TileMapEditor::_layers_selection_button_draw() {


### PR DESCRIPTION
Makes the viewport update when toggling the grid visibility button in the TileMap editor. Before, the grid would still be visible/invisible until something else caused the viewport to redraw.