### PR TITLE
Implements blackboard system to animation tree

### DIFF
--- a/doc/classes/AnimationNode.xml
+++ b/doc/classes/AnimationNode.xml
@@ -174,6 +174,11 @@
 				Emitted by nodes that inherit from this class and that have an internal tree when one of their nodes changes. The nodes that emit this signal are [AnimationNodeBlendSpace1D], [AnimationNodeBlendSpace2D], [AnimationNodeStateMachine], and [AnimationNodeBlendTree].
 			</description>
 		</signal>
+		<signal name="tree_root_changed">
+			<argument index="0" name="node" type="Object" />
+			<description>
+			</description>
+		</signal>
 	</signals>
 	<constants>
 		<constant name="FILTER_IGNORE" value="0" enum="FilterAction">

--- a/doc/classes/AnimationNodeBlendSpace1D.xml
+++ b/doc/classes/AnimationNodeBlendSpace1D.xml
@@ -15,9 +15,10 @@
 	<methods>
 		<method name="add_blend_point">
 			<return type="void" />
-			<argument index="0" name="node" type="AnimationRootNode" />
-			<argument index="1" name="pos" type="float" />
-			<argument index="2" name="at_index" type="int" default="-1" />
+			<argument index="0" name="name" type="StringName" />
+			<argument index="1" name="node" type="AnimationRootNode" />
+			<argument index="2" name="pos" type="float" />
+			<argument index="3" name="at_index" type="int" default="-1" />
 			<description>
 				Adds a new point that represents a [code]node[/code] on the virtual axis at a given position set by [code]pos[/code]. You can insert it at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code], the point is inserted at the end of the blend points array.
 			</description>
@@ -26,6 +27,12 @@
 			<return type="int" />
 			<description>
 				Returns the number of points on the blend axis.
+			</description>
+		</method>
+		<method name="get_blend_point_name" qualifiers="const">
+			<return type="StringName" />
+			<argument index="0" name="point" type="int" />
+			<description>
 			</description>
 		</method>
 		<method name="get_blend_point_node" qualifiers="const">
@@ -47,6 +54,13 @@
 			<argument index="0" name="point" type="int" />
 			<description>
 				Removes the point at index [code]point[/code] from the blend axis.
+			</description>
+		</method>
+		<method name="set_blend_point_name">
+			<return type="void" />
+			<argument index="0" name="point" type="int" />
+			<argument index="1" name="name" type="StringName" />
+			<description>
 			</description>
 		</method>
 		<method name="set_blend_point_node">

--- a/doc/classes/AnimationNodeBlendSpace2D.xml
+++ b/doc/classes/AnimationNodeBlendSpace2D.xml
@@ -15,9 +15,10 @@
 	<methods>
 		<method name="add_blend_point">
 			<return type="void" />
-			<argument index="0" name="node" type="AnimationRootNode" />
-			<argument index="1" name="pos" type="Vector2" />
-			<argument index="2" name="at_index" type="int" default="-1" />
+			<argument index="0" name="name" type="StringName" />
+			<argument index="1" name="node" type="AnimationRootNode" />
+			<argument index="2" name="pos" type="Vector2" />
+			<argument index="3" name="at_index" type="int" default="-1" />
 			<description>
 				Adds a new point that represents a [code]node[/code] at the position set by [code]pos[/code]. You can insert it at a specific index using the [code]at_index[/code] argument. If you use the default value for [code]at_index[/code], the point is inserted at the end of the blend points array.
 			</description>
@@ -36,6 +37,12 @@
 			<return type="int" />
 			<description>
 				Returns the number of points in the blend space.
+			</description>
+		</method>
+		<method name="get_blend_point_name" qualifiers="const">
+			<return type="StringName" />
+			<argument index="0" name="point" type="int" />
+			<description>
 			</description>
 		</method>
 		<method name="get_blend_point_node" qualifiers="const">
@@ -78,6 +85,13 @@
 			<argument index="0" name="triangle" type="int" />
 			<description>
 				Removes the triangle at index [code]triangle[/code] from the blend space.
+			</description>
+		</method>
+		<method name="set_blend_point_name">
+			<return type="void" />
+			<argument index="0" name="point" type="int" />
+			<argument index="1" name="name" type="StringName" />
+			<description>
 			</description>
 		</method>
 		<method name="set_blend_point_node">

--- a/editor/plugins/animation_blend_space_1d_editor.h
+++ b/editor/plugins/animation_blend_space_1d_editor.h
@@ -62,6 +62,7 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	SpinBox *min_value = nullptr;
 
 	HBoxContainer *edit_hb = nullptr;
+	LineEdit *edit_name = nullptr;
 	SpinBox *edit_value = nullptr;
 	Button *open_editor = nullptr;
 
@@ -102,9 +103,12 @@ class AnimationNodeBlendSpace1DEditor : public AnimationTreeNodeEditorPlugin {
 	void _add_animation_type(int p_index);
 
 	void _tool_switch(int p_tool);
+	void _update_edited_point_name();
 	void _update_edited_point_pos();
 	void _update_tool_erase();
 	void _erase_selected();
+	void _edit_name_focus_out();
+	void _edit_name_changed(const String &p_name);
 	void _edit_point_pos(double);
 	void _open_editor();
 

--- a/editor/plugins/animation_blend_space_2d_editor.h
+++ b/editor/plugins/animation_blend_space_2d_editor.h
@@ -67,6 +67,7 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	SpinBox *min_y_value = nullptr;
 
 	HBoxContainer *edit_hb = nullptr;
+	LineEdit *edit_name = nullptr;
 	SpinBox *edit_x = nullptr;
 	SpinBox *edit_y = nullptr;
 	Button *open_editor = nullptr;
@@ -111,9 +112,12 @@ class AnimationNodeBlendSpace2DEditor : public AnimationTreeNodeEditorPlugin {
 	void _add_animation_type(int p_index);
 
 	void _tool_switch(int p_tool);
+	void _update_edited_point_name();
 	void _update_edited_point_pos();
 	void _update_tool_erase();
 	void _erase_selected();
+	void _edit_name_focus_out();
+	void _edit_name_changed(const String &p_name);
 	void _edit_point_pos(double);
 	void _open_editor();
 

--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -45,6 +45,7 @@
 #include "scene/gui/tree.h"
 #include "scene/main/viewport.h"
 #include "scene/main/window.h"
+#include "scene/scene_string_names.h"
 
 bool AnimationNodeStateMachineEditor::can_edit(const Ref<AnimationNode> &p_node) {
 	Ref<AnimationNodeStateMachine> ansm = p_node;
@@ -620,7 +621,7 @@ void AnimationNodeStateMachineEditor::_ungroup_selected_nodes() {
 			Vector2 group_position = state_machine->get_node_position(E);
 			StringName group_name = E;
 
-			List<AnimationNode::ChildNode> nodes;
+			List<Ref<AnimationNode>> nodes;
 			group_sm->get_child_nodes(&nodes);
 
 			Vector<NodeUR> nodes_ur;
@@ -631,16 +632,16 @@ void AnimationNodeStateMachineEditor::_ungroup_selected_nodes() {
 
 			// Move all child nodes to current state machine
 			for (int i = 0; i < nodes.size(); i++) {
-				if (!group_sm->can_edit_node(nodes[i].name)) {
+				if (!group_sm->can_edit_node(nodes[i]->node_name)) {
 					continue;
 				}
 
-				Vector2 node_position = group_sm->get_node_position(nodes[i].name);
+				Vector2 node_position = group_sm->get_node_position(nodes[i]->node_name);
 
 				NodeUR new_node;
-				new_node.name = nodes[i].name;
+				new_node.name = nodes[i]->node_name;
 				new_node.position = node_position;
-				new_node.node = nodes[i].node;
+				new_node.node = nodes[i];
 
 				nodes_ur.push_back(new_node);
 			}
@@ -1344,7 +1345,7 @@ void AnimationNodeStateMachineEditor::_state_machine_draw() {
 			}
 		}
 
-		StringName fullpath = AnimationTreeEditor::get_singleton()->get_base_path() + String(tl.advance_condition_name);
+		StringName fullpath = String(SceneStringNames::get_singleton()->parameters_base_path) + String(tl.advance_condition_name);
 		if (tl.advance_condition_name != StringName() && bool(AnimationTreeEditor::get_singleton()->get_tree()->get(fullpath))) {
 			tl.advance_condition_state = true;
 			tl.auto_advance = true;
@@ -1614,7 +1615,7 @@ void AnimationNodeStateMachineEditor::_notification(int p_what) {
 					break;
 				}
 
-				bool acstate = transition_lines[i].advance_condition_name != StringName() && bool(AnimationTreeEditor::get_singleton()->get_tree()->get(AnimationTreeEditor::get_singleton()->get_base_path() + String(transition_lines[i].advance_condition_name)));
+				bool acstate = transition_lines[i].advance_condition_name != StringName() && bool(AnimationTreeEditor::get_singleton()->get_tree()->get(String(SceneStringNames::get_singleton()->parameters_base_path) + String(transition_lines[i].advance_condition_name)));
 
 				if (transition_lines[i].advance_condition_state != acstate) {
 					state_machine_draw->update();

--- a/scene/animation/animation_blend_space_1d.h
+++ b/scene/animation/animation_blend_space_1d.h
@@ -41,7 +41,6 @@ class AnimationNodeBlendSpace1D : public AnimationRootNode {
 	};
 
 	struct BlendPoint {
-		StringName name;
 		Ref<AnimationRootNode> node;
 		float position = 0.0;
 	};
@@ -56,11 +55,11 @@ class AnimationNodeBlendSpace1D : public AnimationRootNode {
 
 	String value_label = "value";
 
-	void _add_blend_point(int p_index, const Ref<AnimationRootNode> &p_node);
+	void _add_blend_point(int p_index, Ref<AnimationRootNode> p_node);
 
 	void _tree_changed();
 
-	StringName blend_position = "blend_position";
+	StringName blend_position = "blend1d_position";
 
 protected:
 	virtual void _validate_property(PropertyInfo &property) const override;
@@ -70,14 +69,16 @@ public:
 	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
+	virtual void get_child_nodes(List<Ref<AnimationNode>> *r_child_nodes) override;
 
-	void add_blend_point(const Ref<AnimationRootNode> &p_node, float p_position, int p_at_index = -1);
+	void add_blend_point(const StringName &p_name, Ref<AnimationRootNode> p_node, float p_position, int p_at_index = -1);
 	void set_blend_point_position(int p_point, float p_position);
-	void set_blend_point_node(int p_point, const Ref<AnimationRootNode> &p_node);
+	void set_blend_point_node(int p_point, Ref<AnimationRootNode> p_node);
+	void set_blend_point_name(int p_point, const StringName &p_name);
 
 	float get_blend_point_position(int p_point) const;
 	Ref<AnimationRootNode> get_blend_point_node(int p_point) const;
+	StringName get_blend_point_name(int p_point) const;
 	void remove_blend_point(int p_point);
 	int get_blend_point_count() const;
 

--- a/scene/animation/animation_blend_space_2d.h
+++ b/scene/animation/animation_blend_space_2d.h
@@ -49,7 +49,6 @@ protected:
 	};
 
 	struct BlendPoint {
-		StringName name;
 		Ref<AnimationRootNode> node;
 		Vector2 position;
 	};
@@ -63,7 +62,7 @@ protected:
 
 	Vector<BlendTriangle> triangles;
 
-	StringName blend_position = "blend_position";
+	StringName blend_position = "blend2d_position";
 	StringName closest = "closest";
 	StringName length_internal = "length_internal";
 	Vector2 max_space = Vector2(1, 1);
@@ -73,7 +72,7 @@ protected:
 	String y_label = "y";
 	BlendMode blend_mode = BLEND_MODE_INTERPOLATED;
 
-	void _add_blend_point(int p_index, const Ref<AnimationRootNode> &p_node);
+	void _add_blend_point(int p_index, Ref<AnimationRootNode> p_node);
 	void _set_triangles(const Vector<int> &p_triangles);
 	Vector<int> _get_triangles() const;
 
@@ -95,13 +94,15 @@ public:
 	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
 	virtual Variant get_parameter_default_value(const StringName &p_parameter) const override;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
+	virtual void get_child_nodes(List<Ref<AnimationNode>> *r_child_nodes) override;
 
-	void add_blend_point(const Ref<AnimationRootNode> &p_node, const Vector2 &p_position, int p_at_index = -1);
+	void add_blend_point(const StringName &p_name, Ref<AnimationRootNode> p_node, const Vector2 &p_position, int p_at_index = -1);
 	void set_blend_point_position(int p_point, const Vector2 &p_position);
-	void set_blend_point_node(int p_point, const Ref<AnimationRootNode> &p_node);
+	void set_blend_point_node(int p_point, Ref<AnimationRootNode> p_node);
+	void set_blend_point_name(int p_point, const StringName &p_name);
 	Vector2 get_blend_point_position(int p_point) const;
 	Ref<AnimationRootNode> get_blend_point_node(int p_point) const;
+	StringName get_blend_point_name(int p_point) const;
 	void remove_blend_point(int p_point);
 	int get_blend_point_count() const;
 

--- a/scene/animation/animation_blend_tree.cpp
+++ b/scene/animation/animation_blend_tree.cpp
@@ -180,7 +180,12 @@ AnimationNodeAnimation::AnimationNodeAnimation() {
 ////////////////////////////////////////////////////////
 
 void AnimationNodeOneShot::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::BOOL, active));
+	PropertyInfo pinfo = PropertyInfo(Variant::BOOL, String(node_name) + "/" + active);
+
+	if (r_list->find(pinfo) == nullptr) {
+		r_list->push_back(pinfo);
+	}
+
 	r_list->push_back(PropertyInfo(Variant::BOOL, prev_active, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
 	r_list->push_back(PropertyInfo(Variant::FLOAT, time, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
 	r_list->push_back(PropertyInfo(Variant::FLOAT, remaining, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
@@ -254,7 +259,7 @@ bool AnimationNodeOneShot::has_filter() const {
 }
 
 double AnimationNodeOneShot::process(double p_time, bool p_seek, bool p_seek_root) {
-	bool active = get_parameter(this->active);
+	bool active = tree_root->get_parameter(String(node_name) + "/" + this->active);
 	bool prev_active = get_parameter(this->prev_active);
 	double time = get_parameter(this->time);
 	double remaining = get_parameter(this->remaining);
@@ -269,7 +274,7 @@ double AnimationNodeOneShot::process(double p_time, bool p_seek, bool p_seek_roo
 			time_to_restart -= p_time;
 			if (time_to_restart < 0) {
 				//restart
-				set_parameter(this->active, true);
+				tree_root->set_parameter(String(node_name) + "/" + this->active, true);
 				active = true;
 			}
 			set_parameter(this->time_to_restart, time_to_restart);
@@ -328,7 +333,7 @@ double AnimationNodeOneShot::process(double p_time, bool p_seek, bool p_seek_roo
 		time += p_time;
 		remaining = os_rem;
 		if (remaining <= 0) {
-			set_parameter(this->active, false);
+			tree_root->set_parameter(String(node_name) + "/" + this->active, false);
 			set_parameter(this->prev_active, false);
 			if (autorestart) {
 				float restart_sec = autorestart_delay + Math::randf() * autorestart_random_delay;
@@ -399,7 +404,11 @@ AnimationNodeOneShot::AnimationNodeOneShot() {
 ////////////////////////////////////////////////
 
 void AnimationNodeAdd2::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::FLOAT, add_amount, PROPERTY_HINT_RANGE, "0,1,0.01"));
+	PropertyInfo pinfo = PropertyInfo(Variant::FLOAT, String(node_name) + "/" + add_amount, PROPERTY_HINT_RANGE, "0,1,0.01");
+
+	if (r_list->find(pinfo) == nullptr) {
+		r_list->push_back(pinfo);
+	}
 }
 
 Variant AnimationNodeAdd2::get_parameter_default_value(const StringName &p_parameter) const {
@@ -423,7 +432,7 @@ bool AnimationNodeAdd2::has_filter() const {
 }
 
 double AnimationNodeAdd2::process(double p_time, bool p_seek, bool p_seek_root) {
-	double amount = get_parameter(add_amount);
+	double amount = tree_root->get_parameter(String(node_name) + "/" + add_amount);
 	double rem0 = blend_input(0, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, !sync);
 	blend_input(1, p_time, p_seek, p_seek_root, amount, FILTER_PASS, !sync);
 
@@ -445,7 +454,11 @@ AnimationNodeAdd2::AnimationNodeAdd2() {
 ////////////////////////////////////////////////
 
 void AnimationNodeAdd3::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::FLOAT, add_amount, PROPERTY_HINT_RANGE, "-1,1,0.01"));
+	PropertyInfo pinfo = PropertyInfo(Variant::FLOAT, String(node_name) + "/" + add_amount, PROPERTY_HINT_RANGE, "-1,1,0.01");
+
+	if (r_list->find(pinfo) == nullptr) {
+		r_list->push_back(pinfo);
+	}
 }
 
 Variant AnimationNodeAdd3::get_parameter_default_value(const StringName &p_parameter) const {
@@ -469,7 +482,7 @@ bool AnimationNodeAdd3::has_filter() const {
 }
 
 double AnimationNodeAdd3::process(double p_time, bool p_seek, bool p_seek_root) {
-	double amount = get_parameter(add_amount);
+	double amount = tree_root->get_parameter(String(node_name) + "/" + add_amount);
 	blend_input(0, p_time, p_seek, p_seek_root, MAX(0, -amount), FILTER_PASS, !sync);
 	double rem0 = blend_input(1, p_time, p_seek, p_seek_root, 1.0, FILTER_IGNORE, !sync);
 	blend_input(2, p_time, p_seek, p_seek_root, MAX(0, amount), FILTER_PASS, !sync);
@@ -493,7 +506,11 @@ AnimationNodeAdd3::AnimationNodeAdd3() {
 /////////////////////////////////////////////
 
 void AnimationNodeBlend2::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::FLOAT, blend_amount, PROPERTY_HINT_RANGE, "0,1,0.01"));
+	PropertyInfo pinfo = PropertyInfo(Variant::FLOAT, String(node_name) + "/" + blend_amount, PROPERTY_HINT_RANGE, "0,1,0.01");
+
+	if (r_list->find(pinfo) == nullptr) {
+		r_list->push_back(pinfo);
+	}
 }
 
 Variant AnimationNodeBlend2::get_parameter_default_value(const StringName &p_parameter) const {
@@ -505,7 +522,7 @@ String AnimationNodeBlend2::get_caption() const {
 }
 
 double AnimationNodeBlend2::process(double p_time, bool p_seek, bool p_seek_root) {
-	double amount = get_parameter(blend_amount);
+	double amount = tree_root->get_parameter(String(node_name) + "/" + blend_amount);
 
 	double rem0 = blend_input(0, p_time, p_seek, p_seek_root, 1.0 - amount, FILTER_BLEND, !sync);
 	double rem1 = blend_input(1, p_time, p_seek, p_seek_root, amount, FILTER_PASS, !sync);
@@ -540,7 +557,11 @@ AnimationNodeBlend2::AnimationNodeBlend2() {
 //////////////////////////////////////
 
 void AnimationNodeBlend3::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::FLOAT, blend_amount, PROPERTY_HINT_RANGE, "-1,1,0.01"));
+	PropertyInfo pinfo = PropertyInfo(Variant::FLOAT, String(node_name) + "/" + blend_amount, PROPERTY_HINT_RANGE, "-1,1,0.01");
+
+	if (r_list->find(pinfo) == nullptr) {
+		r_list->push_back(pinfo);
+	}
 }
 
 Variant AnimationNodeBlend3::get_parameter_default_value(const StringName &p_parameter) const {
@@ -560,7 +581,7 @@ bool AnimationNodeBlend3::is_using_sync() const {
 }
 
 double AnimationNodeBlend3::process(double p_time, bool p_seek, bool p_seek_root) {
-	double amount = get_parameter(blend_amount);
+	double amount = tree_root->get_parameter(String(node_name) + "/" + blend_amount);
 	double rem0 = blend_input(0, p_time, p_seek, p_seek_root, MAX(0, -amount), FILTER_IGNORE, !sync);
 	double rem1 = blend_input(1, p_time, p_seek, p_seek_root, 1.0 - ABS(amount), FILTER_IGNORE, !sync);
 	double rem2 = blend_input(2, p_time, p_seek, p_seek_root, MAX(0, amount), FILTER_IGNORE, !sync);
@@ -585,7 +606,11 @@ AnimationNodeBlend3::AnimationNodeBlend3() {
 /////////////////////////////////
 
 void AnimationNodeTimeScale::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::FLOAT, scale, PROPERTY_HINT_RANGE, "-32,32,0.01,or_lesser,or_greater"));
+	PropertyInfo pinfo = PropertyInfo(Variant::FLOAT, String(node_name) + "/" + scale, PROPERTY_HINT_RANGE, "-32,32,0.01,or_lesser,or_greater");
+
+	if (r_list->find(pinfo) == nullptr) {
+		r_list->push_back(pinfo);
+	}
 }
 
 Variant AnimationNodeTimeScale::get_parameter_default_value(const StringName &p_parameter) const {
@@ -597,7 +622,8 @@ String AnimationNodeTimeScale::get_caption() const {
 }
 
 double AnimationNodeTimeScale::process(double p_time, bool p_seek, bool p_seek_root) {
-	double scale = get_parameter(this->scale);
+	double scale = tree_root->get_parameter(String(node_name) + "/" + this->scale);
+
 	if (p_seek) {
 		return blend_input(0, p_time, true, p_seek_root, 1.0, FILTER_IGNORE, false);
 	} else {
@@ -615,7 +641,11 @@ AnimationNodeTimeScale::AnimationNodeTimeScale() {
 ////////////////////////////////////
 
 void AnimationNodeTimeSeek::get_parameter_list(List<PropertyInfo> *r_list) const {
-	r_list->push_back(PropertyInfo(Variant::FLOAT, seek_pos, PROPERTY_HINT_RANGE, "-1,3600,0.01,or_greater"));
+	PropertyInfo pinfo = PropertyInfo(Variant::FLOAT, String(node_name) + "/" + seek_pos, PROPERTY_HINT_RANGE, "-1,3600,0.01,or_greater");
+
+	if (r_list->find(pinfo) == nullptr) {
+		r_list->push_back(pinfo);
+	}
 }
 
 Variant AnimationNodeTimeSeek::get_parameter_default_value(const StringName &p_parameter) const {
@@ -627,12 +657,12 @@ String AnimationNodeTimeSeek::get_caption() const {
 }
 
 double AnimationNodeTimeSeek::process(double p_time, bool p_seek, bool p_seek_root) {
-	double seek_pos = get_parameter(this->seek_pos);
+	double seek_pos = tree_root->get_parameter(String(node_name) + "/" + this->seek_pos);
 	if (p_seek) {
 		return blend_input(0, p_time, true, p_seek_root, 1.0, FILTER_IGNORE, false);
 	} else if (seek_pos >= 0) {
 		double ret = blend_input(0, seek_pos, true, true, 1.0, FILTER_IGNORE, false);
-		set_parameter(this->seek_pos, -1.0); //reset
+		tree_root->set_parameter(String(node_name) + "/" + this->seek_pos, -1.0); //reset
 		return ret;
 	} else {
 		return blend_input(0, p_time, false, p_seek_root, 1.0, FILTER_IGNORE, false);
@@ -657,7 +687,12 @@ void AnimationNodeTransition::get_parameter_list(List<PropertyInfo> *r_list) con
 		anims += inputs[i].name;
 	}
 
-	r_list->push_back(PropertyInfo(Variant::INT, current, PROPERTY_HINT_ENUM, anims));
+	PropertyInfo pinfo = PropertyInfo(Variant::INT, String(node_name) + "/" + current, PROPERTY_HINT_ENUM, anims);
+
+	if (r_list->find(pinfo) == nullptr) {
+		r_list->push_back(pinfo);
+	}
+
 	r_list->push_back(PropertyInfo(Variant::INT, prev_current, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
 	r_list->push_back(PropertyInfo(Variant::INT, prev, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
 	r_list->push_back(PropertyInfo(Variant::FLOAT, time, PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NONE));
@@ -728,7 +763,7 @@ float AnimationNodeTransition::get_cross_fade_time() const {
 }
 
 double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_seek_root) {
-	int current = get_parameter(this->current);
+	int current = tree_root->get_parameter(String(node_name) + "/" + this->current);
 	int prev = get_parameter(this->prev);
 	int prev_current = get_parameter(this->prev_current);
 
@@ -764,7 +799,7 @@ double AnimationNodeTransition::process(double p_time, bool p_seek, bool p_seek_
 		}
 
 		if (inputs[current].auto_advance && rem <= xfade) {
-			set_parameter(this->current, (current + 1) % enabled_inputs);
+			tree_root->set_parameter(String(node_name) + "/" + this->current, (current + 1) % enabled_inputs);
 		}
 
 	} else { // cross-fading from prev to current
@@ -854,14 +889,43 @@ AnimationNodeOutput::AnimationNodeOutput() {
 }
 
 ///////////////////////////////////////////////////////
+void AnimationNodeBlendTree::get_parameter_list(List<PropertyInfo> *r_list) const {
+	if (tree_root == nullptr) {
+		for (const KeyValue<StringName, Node> &E : nodes) {
+			Ref<AnimationNode> anode = E.value.node;
+
+			anode->get_parameter_list(r_list);
+		}
+
+		for (PropertyInfo &E : *r_list) {
+			if (E.usage == PROPERTY_USAGE_NONE || E.usage & PROPERTY_USAGE_DO_NOT_SHARE_ON_DUPLICATE) {
+				r_list->erase(E);
+			}
+		}
+	}
+}
+
 void AnimationNodeBlendTree::add_node(const StringName &p_name, Ref<AnimationNode> p_node, const Vector2 &p_position) {
 	ERR_FAIL_COND(nodes.has(p_name));
 	ERR_FAIL_COND(p_node.is_null());
 	ERR_FAIL_COND(p_name == SceneStringNames::get_singleton()->output);
 	ERR_FAIL_COND(String(p_name).contains("/"));
 
+	Ref<AnimationRootNode> arnode = p_node;
+
+	if (arnode.is_valid()) {
+		if (tree_root == nullptr) {
+			arnode->tree_root = this;
+		} else {
+			arnode->tree_root = tree_root;
+		}
+	}
+
+	connect("tree_root_changed", callable_mp(p_node.ptr(), &AnimationNode::_tree_root_changed), varray(), CONNECT_REFERENCE_COUNTED);
+
 	Node n;
 	n.node = p_node;
+	n.node->node_name = p_name;
 	n.position = p_position;
 	n.connections.resize(n.node->get_input_count());
 	nodes[p_name] = n;
@@ -899,7 +963,7 @@ Vector2 AnimationNodeBlendTree::get_node_position(const StringName &p_node) cons
 	return nodes[p_node].position;
 }
 
-void AnimationNodeBlendTree::get_child_nodes(List<ChildNode> *r_child_nodes) {
+void AnimationNodeBlendTree::get_child_nodes(List<Ref<AnimationNode>> *r_child_nodes) {
 	Vector<StringName> ns;
 
 	for (const KeyValue<StringName, Node> &E : nodes) {
@@ -909,10 +973,7 @@ void AnimationNodeBlendTree::get_child_nodes(List<ChildNode> *r_child_nodes) {
 	ns.sort_custom<StringName::AlphCompare>();
 
 	for (int i = 0; i < ns.size(); i++) {
-		ChildNode cn;
-		cn.name = ns[i];
-		cn.node = nodes[cn.name].node;
-		r_child_nodes->push_back(cn);
+		r_child_nodes->push_back(nodes[ns[i]].node);
 	}
 }
 
@@ -959,6 +1020,7 @@ void AnimationNodeBlendTree::rename_node(const StringName &p_name, const StringN
 	nodes[p_name].node->disconnect("changed", callable_mp(this, &AnimationNodeBlendTree::_node_changed));
 
 	nodes[p_new_name] = nodes[p_name];
+	nodes[p_new_name].node->node_name = p_new_name;
 	nodes.erase(p_name);
 
 	//rename connections

--- a/scene/animation/animation_blend_tree.h
+++ b/scene/animation/animation_blend_tree.h
@@ -148,7 +148,7 @@ VARIANT_ENUM_CAST(AnimationNodeOneShot::MixMode)
 class AnimationNodeAdd2 : public AnimationNode {
 	GDCLASS(AnimationNodeAdd2, AnimationNode);
 
-	StringName add_amount = PNAME("add_amount");
+	StringName add_amount = PNAME("add2_amount");
 	bool sync = false;
 
 protected:
@@ -172,7 +172,7 @@ public:
 class AnimationNodeAdd3 : public AnimationNode {
 	GDCLASS(AnimationNodeAdd3, AnimationNode);
 
-	StringName add_amount = PNAME("add_amount");
+	StringName add_amount = PNAME("add3_amount");
 	bool sync = false;
 
 protected:
@@ -196,7 +196,7 @@ public:
 class AnimationNodeBlend2 : public AnimationNode {
 	GDCLASS(AnimationNodeBlend2, AnimationNode);
 
-	StringName blend_amount = PNAME("blend_amount");
+	StringName blend_amount = PNAME("blend2_amount");
 	bool sync = false;
 
 protected:
@@ -219,7 +219,7 @@ public:
 class AnimationNodeBlend3 : public AnimationNode {
 	GDCLASS(AnimationNodeBlend3, AnimationNode);
 
-	StringName blend_amount = PNAME("blend_amount");
+	StringName blend_amount = PNAME("blend3_amount");
 	bool sync;
 
 protected:
@@ -382,6 +382,8 @@ public:
 		//no need to check for cycles due to tree topology
 	};
 
+	virtual void get_parameter_list(List<PropertyInfo> *r_list) const override;
+
 	void add_node(const StringName &p_name, Ref<AnimationNode> p_node, const Vector2 &p_position = Vector2());
 	Ref<AnimationNode> get_node(const StringName &p_name) const;
 	void remove_node(const StringName &p_name);
@@ -393,7 +395,7 @@ public:
 	void set_node_position(const StringName &p_node, const Vector2 &p_position);
 	Vector2 get_node_position(const StringName &p_node) const;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
+	virtual void get_child_nodes(List<Ref<AnimationNode>> *r_child_nodes) override;
 
 	void connect_node(const StringName &p_input_node, int p_input_index, const StringName &p_output_node);
 	void disconnect_node(const StringName &p_node, int p_input_index);

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -177,7 +177,6 @@ private:
 	Vector<Transition> transitions;
 
 	StringName playback = "playback";
-	StringName state_machine_name;
 	AnimationNodeStateMachine *prev_state_machine = nullptr;
 	bool updating_transitions = false;
 
@@ -218,7 +217,7 @@ public:
 	void set_node_position(const StringName &p_name, const Vector2 &p_position);
 	Vector2 get_node_position(const StringName &p_name) const;
 
-	virtual void get_child_nodes(List<ChildNode> *r_child_nodes) override;
+	virtual void get_child_nodes(List<Ref<AnimationNode>> *r_child_nodes) override;
 
 	bool has_transition(const StringName &p_from, const StringName &p_to) const;
 	bool has_local_transition(const StringName &p_from, const StringName &p_to) const;


### PR DESCRIPTION
This is my proposal for the blackboard system, it's quite simple and I think the workflow works very well.

May fix https://github.com/godotengine/godot-proposals/issues/3352,

# Changes:
<details>
<summary>before, conditions everywhere:</summary>

https://user-images.githubusercontent.com/1387165/171962137-3e94b78a-0d95-48d9-9b91-c6beb0cb96c0.mp4
</details>

<details>
<summary>after, conditions only at the root:</summary>

https://user-images.githubusercontent.com/1387165/171962139-f4d6aded-4b69-496c-b020-5ad34d2a365a.mp4
</details>

<details>
<summary>Works with blend tree and blend spaces:</summary>

https://user-images.githubusercontent.com/1387165/173208227-f36f3b75-01f8-4ecf-8984-513cb2f8b8b3.mp4
</details>

<details>
<summary>Adds blend point name to blend spaces:</summary>

https://user-images.githubusercontent.com/1387165/177066631-d4543475-43e7-467d-b3e4-f29241cce4f2.mp4
</details>


<details>
<summary>Makes the name of visible properties unique:</summary>
That way there is no conflict with the variables. (eg: blend position can be float or vector2, add_amount depending on the node can have a range of 0..1 or -1..1).

![Screenshot from 2022-07-03 22-38-53](https://user-images.githubusercontent.com/1387165/177066984-d48a7a8d-dff7-41e0-9349-9d88ef413a7a.png)
</details>