### PR TITLE
Fix hover being drawn twice inside `PopupMenu`s

### DIFF
--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -551,7 +551,6 @@ void PopupMenu::_notification(int p_what) {
 				}
 
 				if (i == mouse_over) {
-					hover->draw(ci, Rect2(item_ofs + Point2(-hseparation, -vseparation / 2), Size2(get_size().width - style->get_minimum_size().width + hseparation * 2, h + vseparation)));
 					hover->draw(ci, Rect2(item_ofs + Point2(0, -vseparation / 2), Size2(size.width - style->get_minimum_size().width, h + vseparation)));
 				}
 

--- a/scene/resources/default_theme/default_theme.cpp
+++ b/scene/resources/default_theme/default_theme.cpp
@@ -569,9 +569,10 @@ void fill_default_theme(Ref<Theme> &theme, const Ref<Font> &default_font, const 
 	Ref<StyleBoxTexture> style_pp = sb_expand(make_stylebox(popup_bg_png, 5, 5, 5, 5, 4, 4, 4, 4), 2, 2, 2, 2);
 
 	Ref<StyleBoxTexture> selected = make_stylebox(selection_png, 6, 6, 6, 6);
-	for (int i = 0; i < 4; i++) {
-		selected->set_expand_margin_size(Margin(i), 2 * scale);
-	}
+	selected->set_expand_margin_size(MARGIN_TOP, 2 * scale);
+	selected->set_expand_margin_size(MARGIN_BOTTOM, 2 * scale);
+	selected->set_expand_margin_size(MARGIN_LEFT, 6 * scale);
+	selected->set_expand_margin_size(MARGIN_RIGHT, 6 * scale);
 
 	theme->set_stylebox("panel", "PopupPanel", style_pp);
 


### PR DESCRIPTION
Fixes a regression introduced by #61479. It also modifies the default hover style to have the extra padding.