### PR TITLE
Fix zoom in callback for CanvasItemEditor to use correct numeric sign

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -1284,8 +1284,8 @@ void CanvasItemEditor::_pan_callback(Vector2 p_scroll_vec) {
 }
 
 void CanvasItemEditor::_zoom_callback(Vector2 p_scroll_vec, Vector2 p_origin, bool p_alt) {
-	zoom_widget->set_zoom_by_increments(-1, p_alt);
-	if (!Math::is_equal_approx(p_scroll_vec.y, (real_t)1.0)) {
+	zoom_widget->set_zoom_by_increments((int)SIGN(p_scroll_vec.y), p_alt);
+	if (!Math::is_equal_approx(ABS(p_scroll_vec.y), (real_t)1.0)) {
 		// Handle high-precision (analog) scrolling.
 		zoom_widget->set_zoom(zoom * ((zoom_widget->get_zoom() / zoom - 1.f) * p_scroll_vec.y + 1.f));
 	}


### PR DESCRIPTION
In commit 74bfe88267, the zoom handling code moved, but only the mouse wheel _down_ part was transferred ([original](https://github.com/godotengine/godot/commit/74bfe88267263297b43fef35fd9f32a91750d4d2#diff-eb4ce61def40bf37d0fba218d92fa230c11f78e3a56f2849cdfe0045512acc3bL1148-L1149) -> [moved](https://github.com/godotengine/godot/commit/74bfe88267263297b43fef35fd9f32a91750d4d2#diff-eb4ce61def40bf37d0fba218d92fa230c11f78e3a56f2849cdfe0045512acc3bR1201-R1202)).  As a result mouse wheel _up_ behaved improperly, not exactly reversing the effect of a mouse wheel down of equal amount.

This commit checks the sign of the vertical mouse wheel amount and uses +1 or -1 accordingly, and checks the absolute value to decide if the more precise adjustment is needed or not.

**To reproduce before this commit:**
1. open the editor
2. switch to 2D view
3. click the zoom amount in the top left to reset to 100%
4. mouse wheel down once to zoom out to the first level less than 100% (89.1% for me)
5. mouse wheel up once to try to zoom back to 100%
6. note that the zoom is not 100% (99.1% for me)
7. repeat steps 3-6 with larger mouse wheel changes to see greater error