### PR TITLE
Typo: Change "congiruation" into "configuration" for MultiplayerSynchronizer

### DIFF
--- a/doc/classes/MultiplayerSynchronizer.xml
+++ b/doc/classes/MultiplayerSynchronizer.xml
@@ -7,7 +7,7 @@
 	<tutorials>
 	</tutorials>
 	<members>
-		<member name="congiruation" type="SceneReplicationConfig" setter="set_replication_config" getter="get_replication_config">
+		<member name="configuration" type="SceneReplicationConfig" setter="set_replication_config" getter="get_replication_config">
 		</member>
 		<member name="replication_interval" type="float" setter="set_replication_interval" getter="get_replication_interval" default="0.0">
 		</member>

--- a/scene/multiplayer/multiplayer_synchronizer.cpp
+++ b/scene/multiplayer/multiplayer_synchronizer.cpp
@@ -96,7 +96,7 @@ void MultiplayerSynchronizer::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("set_replication_config", "config"), &MultiplayerSynchronizer::set_replication_config);
 	ClassDB::bind_method(D_METHOD("get_replication_config"), &MultiplayerSynchronizer::get_replication_config);
-	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "congiruation", PROPERTY_HINT_RESOURCE_TYPE, "SceneReplicationConfig"), "set_replication_config", "get_replication_config");
+	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "configuration", PROPERTY_HINT_RESOURCE_TYPE, "SceneReplicationConfig"), "set_replication_config", "get_replication_config");
 }
 
 void MultiplayerSynchronizer::_notification(int p_what) {


### PR DESCRIPTION
Fixes #61694
