### PR TITLE
Removes start/end states from menus

### DIFF
--- a/editor/plugins/animation_blend_space_1d_editor.cpp
+++ b/editor/plugins/animation_blend_space_1d_editor.cpp
@@ -83,7 +83,7 @@ void AnimationNodeBlendSpace1DEditor::_blend_space_gui_input(const Ref<InputEven
 
 		for (const StringName &E : classes) {
 			String name = String(E).replace_first("AnimationNode", "");
-			if (name == "Animation") {
+			if (name == "Animation" || name == "StartState" || name == "EndState") {
 				continue;
 			}
 

--- a/editor/plugins/animation_blend_space_2d_editor.cpp
+++ b/editor/plugins/animation_blend_space_2d_editor.cpp
@@ -107,7 +107,7 @@ void AnimationNodeBlendSpace2DEditor::_blend_space_gui_input(const Ref<InputEven
 
 		for (const StringName &E : classes) {
 			String name = String(E).replace_first("AnimationNode", "");
-			if (name == "Animation") {
+			if (name == "Animation" || name == "StartState" || name == "EndState") {
 				continue; // nope
 			}
 			int idx = menu->get_item_count();


### PR DESCRIPTION
Removes `StartState` and `EndState` from menu of BlendSpace1D and 2D.