### PR TITLE
Improve TileMap editor layer selection button

### DIFF
--- a/editor/plugins/tiles/tile_map_editor.h
+++ b/editor/plugins/tiles/tile_map_editor.h
@@ -40,6 +40,7 @@
 #include "scene/gui/check_box.h"
 #include "scene/gui/item_list.h"
 #include "scene/gui/menu_button.h"
+#include "scene/gui/option_button.h"
 #include "scene/gui/separator.h"
 #include "scene/gui/spin_box.h"
 #include "scene/gui/split_container.h"
@@ -327,12 +328,9 @@ private:
 	// Toolbar.
 	HBoxContainer *tile_map_toolbar = nullptr;
 
-	PopupMenu *layers_selection_popup = nullptr;
-	Button *layers_selection_button = nullptr;
-	Button *toogle_highlight_selected_layer_button = nullptr;
-	void _layers_selection_button_draw();
-	void _layers_selection_button_pressed();
-	void _layers_selection_id_pressed(int p_id);
+	OptionButton *layers_selection_button = nullptr;
+	Button *toggle_highlight_selected_layer_button = nullptr;
+	void _layers_selection_item_selected(int p_index);
 
 	Button *toggle_grid_button = nullptr;
 	void _on_grid_toggled(bool p_pressed);


### PR DESCRIPTION
Changes the TileMap editor layer selection button from a fake wannabe OptionButton to a real OptionButton and fixes the docks getting pushed off the screen for very long layer names.

### Before:

Arrow overlapping the text:
![image](https://user-images.githubusercontent.com/67974470/172023828-e7cb2864-9eaa-40e0-abef-2844eb4a5fcd.png)

Here, the docks are pushed off the sides because the layer name is so long:
![image](https://user-images.githubusercontent.com/67974470/172023968-e54eaa04-be75-4323-9aff-22ad80657301.png)
![image](https://user-images.githubusercontent.com/67974470/172023980-b67c61ee-f2ea-4421-a2b5-687d6e8e22cc.png)


### After:

![image](https://user-images.githubusercontent.com/67974470/172023869-dc88aaae-7be8-410b-aeb3-cfa68073bf05.png)

A ScrollContainer prevents long layer names from pushing the docks.
![image](https://user-images.githubusercontent.com/67974470/172023692-ba029e5a-8842-4d8e-8c69-42cc1fb407b2.png)
![image](https://user-images.githubusercontent.com/67974470/172023682-8837b211-e014-4bf0-b3d0-7aea0a98b853.png)