### PR TITLE
Fixed Issue #61553 - Populating MultimeshInstance Crash

### DIFF
--- a/editor/plugins/multimesh_editor_plugin.cpp
+++ b/editor/plugins/multimesh_editor_plugin.cpp
@@ -160,8 +160,15 @@ void MultiMeshEditor::_populate() {
 	int instance_count = populate_amount->get_value();
 
 	multimesh->set_transform_format(MultiMesh::TRANSFORM_3D);
-	multimesh->set_color_format(node->get_multimesh()->get_color_format());
-	multimesh->set_custom_data_format(node->get_multimesh()->get_custom_data_format());
+
+	if (node->get_multimesh().is_null()) {
+		multimesh->set_color_format(MultiMesh::COLOR_NONE);
+		multimesh->set_custom_data_format(MultiMesh::CUSTOM_DATA_NONE);
+	} else {
+		multimesh->set_color_format(node->get_multimesh()->get_color_format());
+		multimesh->set_custom_data_format(node->get_multimesh()->get_custom_data_format());
+	}
+
 	multimesh->set_instance_count(instance_count);
 
 	float _tilt_random = populate_tilt_random->get_value();


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
Fixed #61553  - Populating MultimeshInstance Crash as per Suggestions by [lawnjelly](https://github.com/lawnjelly) and [clayjohn](https://github.com/clayjohn). 
_populate() will now check if node has a multimesh or not, and set the new multimesh accordingly.