### PR TITLE
Fix richTextLabel scroll showing

### DIFF
--- a/scene/gui/rich_text_label.h
+++ b/scene/gui/rich_text_label.h
@@ -117,6 +117,10 @@ private:
 		int char_count = 0;
 
 		Line() { text_buf.instantiate(); }
+
+		_FORCE_INLINE_ float get_height(float line_separation) const {
+			return offset.y + text_buf->get_size().y + text_buf->get_line_count() * line_separation;
+		}
 	};
 
 	struct Item {
@@ -503,6 +507,8 @@ private:
 	void _update_fx(ItemFrame *p_frame, double p_delta_time);
 	void _scroll_changed(double);
 	int _find_first_line(int p_from, int p_to, int p_vofs) const;
+
+	_FORCE_INLINE_ float _calculate_line_vertical_offset(const Line &line) const;
 
 	virtual void gui_input(const Ref<InputEvent> &p_event) override;
 	virtual String get_tooltip(const Point2 &p_pos) const override;


### PR DESCRIPTION
This should fix #61324. The problem was that `_process_line_caches` function was only processing items that were newly added to  RitchTextLabel. So only if whole cache was invalidated or needed to be resized (for instance where switching windows) size of all lines was taken into account. Now for purpose of checking if scroll should appear or disappear we take into account also offset of last not invalidated line.

Small demo:
![output_scroll](https://user-images.githubusercontent.com/9964886/172060216-dc1109ab-b05f-4b20-afd2-cd6988939ba2.gif)

Worth noting that exactly same issue plagued regular RichTextLabel node, this fixes both of them.
