### PR TITLE
Enable nearest filtering in shrunk 3D viewport

### DIFF
--- a/editor/plugins/node_3d_editor_plugin.cpp
+++ b/editor/plugins/node_3d_editor_plugin.cpp
@@ -414,6 +414,7 @@ void Node3DEditorViewport::cancel_transform() {
 void Node3DEditorViewport::_update_shrink() {
 	bool shrink = view_menu->get_popup()->is_item_checked(view_menu->get_popup()->get_item_index(VIEW_HALF_RESOLUTION));
 	subviewport_container->set_stretch_shrink(shrink ? 2 : 1);
+	subviewport_container->set_texture_filter(shrink ? TEXTURE_FILTER_NEAREST : TEXTURE_FILTER_PARENT_NODE);
 }
 
 float Node3DEditorViewport::get_znear() const {


### PR DESCRIPTION
Fixes #45081 (see https://github.com/godotengine/godot/issues/45081#issuecomment-1146649139)