### PR TITLE
Optimized Mesh Merging

### DIFF
--- a/core/local_vector.h
+++ b/core/local_vector.h
@@ -33,6 +33,7 @@
 
 #include "core/error_macros.h"
 #include "core/os/memory.h"
+#include "core/pool_vector.h"
 #include "core/sort_array.h"
 #include "core/vector.h"
 
@@ -240,6 +241,17 @@ public:
 		return ret;
 	}
 
+	operator PoolVector<T>() const {
+		PoolVector<T> pl;
+		if (size()) {
+			pl.resize(size());
+			typename PoolVector<T>::Write w = pl.write();
+			T *dest = w.ptr();
+			memcpy(dest, data, sizeof(T) * count);
+		}
+		return pl;
+	}
+
 	Vector<uint8_t> to_byte_array() const { //useful to pass stuff to gpu or variant
 		Vector<uint8_t> ret;
 		ret.resize(count * sizeof(T));
@@ -255,6 +267,19 @@ public:
 			data[i] = p_from.data[i];
 		}
 	}
+	LocalVector(const Vector<T> &p_from) {
+		resize(p_from.size());
+		for (U i = 0; i < count; i++) {
+			data[i] = p_from[i];
+		}
+	}
+	LocalVector(const PoolVector<T> &p_from) {
+		resize(p_from.size());
+		typename PoolVector<T>::Read r = p_from.read();
+		for (U i = 0; i < count; i++) {
+			data[i] = r[i];
+		}
+	}
 	inline LocalVector &operator=(const LocalVector &p_from) {
 		resize(p_from.size());
 		for (U i = 0; i < p_from.count; i++) {
@@ -266,6 +291,14 @@ public:
 		resize(p_from.size());
 		for (U i = 0; i < count; i++) {
 			data[i] = p_from[i];
+		}
+		return *this;
+	}
+	inline LocalVector &operator=(const PoolVector<T> &p_from) {
+		resize(p_from.size());
+		typename PoolVector<T>::Read r = p_from.read();
+		for (U i = 0; i < count; i++) {
+			data[i] = r[i];
 		}
 		return *this;
 	}

--- a/scene/3d/mesh_instance.h
+++ b/scene/3d/mesh_instance.h
@@ -98,9 +98,9 @@ private:
 	// merging
 	bool _merge_meshes(Vector<MeshInstance *> p_list, bool p_use_global_space, bool p_check_compatibility);
 	bool _is_mergeable_with(const MeshInstance &p_other) const;
-	void _merge_into_mesh_data(const MeshInstance &p_mi, const Transform &p_dest_tr_inv, int p_surface_id, PoolVector<Vector3> &r_verts, PoolVector<Vector3> &r_norms, PoolVector<real_t> &r_tangents, PoolVector<Color> &r_colors, PoolVector<Vector2> &r_uvs, PoolVector<Vector2> &r_uv2s, PoolVector<int> &r_inds);
-	bool _ensure_indices_valid(PoolVector<int> &r_indices, const PoolVector<Vector3> &p_verts) const;
-	bool _check_for_valid_indices(const PoolVector<int> &p_inds, const PoolVector<Vector3> &p_verts, LocalVector<int, int32_t> *r_inds) const;
+	void _merge_into_mesh_data(const MeshInstance &p_mi, const Transform &p_dest_tr_inv, int p_surface_id, LocalVector<Vector3> &r_verts, LocalVector<Vector3> &r_norms, LocalVector<real_t> &r_tangents, LocalVector<Color> &r_colors, LocalVector<Vector2> &r_uvs, LocalVector<Vector2> &r_uv2s, LocalVector<int> &r_inds);
+	bool _ensure_indices_valid(LocalVector<int> &r_indices, const PoolVector<Vector3> &p_verts) const;
+	bool _check_for_valid_indices(const LocalVector<int> &p_inds, const PoolVector<Vector3> &p_verts, LocalVector<int> *r_inds) const;
 	bool _triangle_is_degenerate(const Vector3 &p_a, const Vector3 &p_b, const Vector3 &p_c, real_t p_epsilon) const;
 	void _merge_log(String p_string) const;
 


### PR DESCRIPTION
Changes from PoolVector to LocalVector and pre-reserving vectors rather than push_back.

Tests show more than factor of 3 speedup for merging 200,000 boxes.

## Notes
* `LocalVector` is generally more efficient than `PoolVector` for single threaded operations.
* Although mesh merging is already available through rooms & portals and the `MeshInstance::merge_meshes()` function,  it may be exposed further in 3.6 so it makes sense to make it as fast as possible, especially for use at runtime at level load, rather than pre-baking.

### Side issue - copy initialization in LocalVector
I noticed that both when assigning a `Vector` to `LocalVector` and also for assigning `PoolVector`, it seems to have to be done as two expression as follows, rather than `LocalVector blah = PoolVector(foo);`. I just copied the code for assigning `Vector`, but it would be nice if this can be solved:
```
	LocalVector<Vector3> normals;
	normals = PoolVector<Vector3>(arrays[VS::ARRAY_NORMAL]);
```
If you try it as a single expression there is a compile error.

EDIT: Solved the above, the problem was this needs copy initialization rather than assignment operator overload. `LocalVector` needed an operator `LocalVector::LocalVector(const PoolVector<T> &p_from)`. I've also added one for `LocalVector::LocalVector(const Vector<T> &p_from)` as I had previously noted this expression didn't work. The PR is now changed to use this short form rather than the longer form assignment quoted above.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
