### PR TITLE
Improve architectures in OS::has_feature and make them work on MSVC

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -413,19 +413,29 @@ bool OS::has_feature(const String &p_feature) {
 	if (sizeof(void *) == 4 && p_feature == "32") {
 		return true;
 	}
-#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__)
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(__i386) || defined(__i386__) || defined(_M_IX86) || defined(_M_X64)
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
 	if (p_feature == "x86_64") {
 		return true;
 	}
-#elif (defined(__i386) || defined(__i386__))
+#elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
+	if (p_feature == "x86_32") {
+		return true;
+	}
+#endif
 	if (p_feature == "x86") {
 		return true;
 	}
-#elif defined(__aarch64__)
+#elif defined(__arm__) || defined(__aarch64__) || defined(_M_ARM) || defined(_M_ARM64)
+#if defined(__aarch64__) || defined(_M_ARM64)
 	if (p_feature == "arm64") {
 		return true;
 	}
-#elif defined(__arm__)
+#elif defined(__arm__) || defined(_M_ARM)
+	if (p_feature == "arm32") {
+		return true;
+	}
+#endif
 #if defined(__ARM_ARCH_7A__)
 	if (p_feature == "armv7a" || p_feature == "armv7") {
 		return true;
@@ -455,6 +465,19 @@ bool OS::has_feature(const String &p_feature) {
 	}
 #endif
 	if (p_feature == "ppc") {
+		return true;
+	}
+#elif defined(__wasm__)
+#if defined(__wasm64__)
+	if (p_feature == "wasm64") {
+		return true;
+	}
+#elif defined(__wasm32__)
+	if (p_feature == "wasm32") {
+		return true;
+	}
+#endif
+	if (p_feature == "wasm") {
 		return true;
 	}
 #endif


### PR DESCRIPTION
This needs testing! I have not yet tested if this works as expected.

Based on [this MSDN article](https://docs.microsoft.com/en-us/cpp/preprocessor/predefined-macros), we need to check for `_M_IX86`, `_M_X64`, `_M_ARM`, and `_M_ARM64` to detect x86 and ARM on MSVC. This should make the `x86_64`, `x86`, `arm64`, and `arm` OS features work on MSVC.

I modified the logic a bit so that `x86_32` and `arm32` are for the 32-bit versions specifically, and `x86` and `arm` will return true for both the 32-bit and 64-bit versions. I also added WebAssembly (`wasm`, `wasm32`, `wasm64`) to the list of architectures, based on the defines [here](https://stackoverflow.com/questions/71516427/is-it-possible-to-detect-wasm-compiler-in-code-via-compiler-directives). For these reasons, this PR is also an enhancement.

We should also backport some of these changes to 3.x (except leave "x86" and "arm" as they are for backwards compatibility for any 3.x projects using those to detect 32-bit versions of the architectures).