### PR TITLE
Use a typed enum for the ResourceSaverFlags parameter instead of uint32_t

### DIFF
--- a/core/core_bind.cpp
+++ b/core/core_bind.cpp
@@ -137,7 +137,7 @@ void ResourceLoader::_bind_methods() {
 
 ////// ResourceSaver //////
 
-Error ResourceSaver::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceSaver::save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags) {
 	ERR_FAIL_COND_V_MSG(p_resource.is_null(), ERR_INVALID_PARAMETER, "Can't save empty resource to path '" + String(p_path) + "'.");
 	return ::ResourceSaver::save(p_path, p_resource, p_flags);
 }

--- a/core/core_bind.h
+++ b/core/core_bind.h
@@ -94,20 +94,9 @@ protected:
 	static ResourceSaver *singleton;
 
 public:
-	enum SaverFlags {
-		FLAG_NONE = 0,
-		FLAG_RELATIVE_PATHS = 1,
-		FLAG_BUNDLE_RESOURCES = 2,
-		FLAG_CHANGE_PATH = 4,
-		FLAG_OMIT_EDITOR_PROPERTIES = 8,
-		FLAG_SAVE_BIG_ENDIAN = 16,
-		FLAG_COMPRESS = 32,
-		FLAG_REPLACE_SUBRESOURCE_PATHS = 64,
-	};
-
 	static ResourceSaver *get_singleton() { return singleton; }
 
-	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags);
+	Error save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags);
 	Vector<String> get_recognized_extensions(const Ref<Resource> &p_resource);
 
 	ResourceSaver() { singleton = this; }
@@ -715,8 +704,6 @@ public:
 
 VARIANT_ENUM_CAST(core_bind::ResourceLoader::ThreadLoadStatus);
 VARIANT_ENUM_CAST(core_bind::ResourceLoader::CacheMode);
-
-VARIANT_ENUM_CAST(core_bind::ResourceSaver::SaverFlags);
 
 VARIANT_ENUM_CAST(core_bind::OS::VideoDriver);
 VARIANT_ENUM_CAST(core_bind::OS::Weekday);

--- a/core/crypto/crypto.cpp
+++ b/core/crypto/crypto.cpp
@@ -185,7 +185,7 @@ String ResourceFormatLoaderCrypto::get_resource_type(const String &p_path) const
 	return "";
 }
 
-Error ResourceFormatSaverCrypto::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverCrypto::save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags) {
 	Error err;
 	Ref<X509Certificate> cert = p_resource;
 	Ref<CryptoKey> key = p_resource;

--- a/core/crypto/crypto.h
+++ b/core/crypto/crypto.h
@@ -125,7 +125,7 @@ public:
 
 class ResourceFormatSaverCrypto : public ResourceFormatSaver {
 public:
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags = ResourceSaverFlags::FLAG_NONE);
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 };

--- a/core/io/resource_format_binary.cpp
+++ b/core/io/resource_format_binary.cpp
@@ -1873,10 +1873,10 @@ static String _resource_get_class(Ref<Resource> p_resource) {
 	}
 }
 
-Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags) {
 	Error err;
 	Ref<FileAccess> f;
-	if (p_flags & ResourceSaver::FLAG_COMPRESS) {
+	if (p_flags & ResourceSaverFlags::FLAG_COMPRESS) {
 		Ref<FileAccessCompressed> fac;
 		fac.instantiate();
 		fac->configure("RSCC");
@@ -1888,11 +1888,11 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot create file '" + p_path + "'.");
 
-	relative_paths = p_flags & ResourceSaver::FLAG_RELATIVE_PATHS;
-	skip_editor = p_flags & ResourceSaver::FLAG_OMIT_EDITOR_PROPERTIES;
-	bundle_resources = p_flags & ResourceSaver::FLAG_BUNDLE_RESOURCES;
-	big_endian = p_flags & ResourceSaver::FLAG_SAVE_BIG_ENDIAN;
-	takeover_paths = p_flags & ResourceSaver::FLAG_REPLACE_SUBRESOURCE_PATHS;
+	relative_paths = p_flags & ResourceSaverFlags::FLAG_RELATIVE_PATHS;
+	skip_editor = p_flags & ResourceSaverFlags::FLAG_OMIT_EDITOR_PROPERTIES;
+	bundle_resources = p_flags & ResourceSaverFlags::FLAG_BUNDLE_RESOURCES;
+	big_endian = p_flags & ResourceSaverFlags::FLAG_SAVE_BIG_ENDIAN;
+	takeover_paths = p_flags & ResourceSaverFlags::FLAG_REPLACE_SUBRESOURCE_PATHS;
 
 	if (!p_path.begins_with("res://")) {
 		takeover_paths = false;
@@ -1903,7 +1903,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 
 	_find_resources(p_resource, true);
 
-	if (!(p_flags & ResourceSaver::FLAG_COMPRESS)) {
+	if (!(p_flags & ResourceSaverFlags::FLAG_COMPRESS)) {
 		//save header compressed
 		static const uint8_t header[4] = { 'R', 'S', 'R', 'C' };
 		f->store_buffer(header, 4);
@@ -2099,7 +2099,7 @@ Error ResourceFormatSaverBinaryInstance::save(const String &p_path, const Ref<Re
 	return OK;
 }
 
-Error ResourceFormatSaverBinary::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverBinary::save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags) {
 	String local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 	ResourceFormatSaverBinaryInstance saver;
 	return saver.save(local_path, p_resource, p_flags);

--- a/core/io/resource_format_binary.h
+++ b/core/io/resource_format_binary.h
@@ -167,14 +167,14 @@ public:
 		// Amount of reserved 32-bit fields in resource header
 		RESERVED_FIELDS = 11
 	};
-	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	Error save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags = ResourceSaverFlags::FLAG_NONE);
 	static void write_variant(Ref<FileAccess> f, const Variant &p_property, HashMap<Ref<Resource>, int> &resource_map, HashMap<Ref<Resource>, int> &external_resources, HashMap<StringName, int> &string_map, const PropertyInfo &p_hint = PropertyInfo());
 };
 
 class ResourceFormatSaverBinary : public ResourceFormatSaver {
 public:
 	static ResourceFormatSaverBinary *singleton;
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags = ResourceSaverFlags::FLAG_NONE);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 

--- a/core/io/resource_saver.cpp
+++ b/core/io/resource_saver.cpp
@@ -41,7 +41,7 @@ bool ResourceSaver::timestamp_on_save = false;
 ResourceSavedCallback ResourceSaver::save_callback = nullptr;
 ResourceSaverGetResourceIDForPath ResourceSaver::save_get_id_for_path = nullptr;
 
-Error ResourceFormatSaver::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaver::save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags) {
 	int64_t res;
 	if (GDVIRTUAL_CALL(_save, p_path, p_resource, p_flags, res)) {
 		return (Error)res;
@@ -75,7 +75,7 @@ void ResourceFormatSaver::_bind_methods() {
 	GDVIRTUAL_BIND(_get_recognized_extensions, "resource");
 }
 
-Error ResourceSaver::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceSaver::save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags) {
 	String extension = p_path.get_extension();
 	Error err = ERR_FILE_UNRECOGNIZED;
 

--- a/core/io/resource_saver.h
+++ b/core/io/resource_saver.h
@@ -35,6 +35,17 @@
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/script_language.h"
 
+enum ResourceSaverFlags {
+	FLAG_NONE = 0,
+	FLAG_RELATIVE_PATHS = 1,
+	FLAG_BUNDLE_RESOURCES = 2,
+	FLAG_CHANGE_PATH = 4,
+	FLAG_OMIT_EDITOR_PROPERTIES = 8,
+	FLAG_SAVE_BIG_ENDIAN = 16,
+	FLAG_COMPRESS = 32,
+	FLAG_REPLACE_SUBRESOURCE_PATHS = 64,
+};
+
 class ResourceFormatSaver : public RefCounted {
 	GDCLASS(ResourceFormatSaver, RefCounted);
 
@@ -46,7 +57,7 @@ protected:
 	GDVIRTUAL1RC(Vector<String>, _get_recognized_extensions, Ref<Resource>)
 
 public:
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags = ResourceSaverFlags::FLAG_NONE);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 
@@ -70,18 +81,7 @@ class ResourceSaver {
 	static Ref<ResourceFormatSaver> _find_custom_resource_format_saver(String path);
 
 public:
-	enum SaverFlags {
-		FLAG_NONE = 0,
-		FLAG_RELATIVE_PATHS = 1,
-		FLAG_BUNDLE_RESOURCES = 2,
-		FLAG_CHANGE_PATH = 4,
-		FLAG_OMIT_EDITOR_PROPERTIES = 8,
-		FLAG_SAVE_BIG_ENDIAN = 16,
-		FLAG_COMPRESS = 32,
-		FLAG_REPLACE_SUBRESOURCE_PATHS = 64,
-	};
-
-	static Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = (uint32_t)FLAG_NONE);
+	static Error save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags = ResourceSaverFlags::FLAG_NONE);
 	static void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions);
 	static void add_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver, bool p_at_front = false);
 	static void remove_resource_format_saver(Ref<ResourceFormatSaver> p_format_saver);
@@ -99,5 +99,15 @@ public:
 	static void add_custom_savers();
 	static void remove_custom_savers();
 };
+
+VARIANT_ENUM_CAST(ResourceSaverFlags);
+
+inline ResourceSaverFlags operator|(ResourceSaverFlags a, ResourceSaverFlags b) {
+	return (ResourceSaverFlags)((int)a | (int)b);
+}
+
+inline ResourceSaverFlags &operator|=(ResourceSaverFlags &a, ResourceSaverFlags b) {
+	return (ResourceSaverFlags &)((int &)a |= (int)b);
+}
 
 #endif // RESOURCE_SAVER_H

--- a/doc/classes/ResourceFormatSaver.xml
+++ b/doc/classes/ResourceFormatSaver.xml
@@ -30,7 +30,7 @@
 			<argument index="1" name="resource" type="Resource" />
 			<argument index="2" name="flags" type="int" />
 			<description>
-				Saves the given resource object to a file at the target [code]path[/code]. [code]flags[/code] is a bitmask composed with [enum ResourceSaver.SaverFlags] constants.
+				Saves the given resource object to a file at the target [code]path[/code]. [code]flags[/code] is a bitmask composed with [enum ResourceSaver.ResourceSaverFlags] constants.
 				Returns [constant OK] on success, or an [enum Error] constant in case of failure.
 			</description>
 		</method>

--- a/doc/classes/ResourceSaver.xml
+++ b/doc/classes/ResourceSaver.xml
@@ -21,37 +21,37 @@
 			<return type="int" enum="Error" />
 			<argument index="0" name="path" type="String" />
 			<argument index="1" name="resource" type="Resource" />
-			<argument index="2" name="flags" type="int" default="0" />
+			<argument index="2" name="flags" type="int" enum="ResourceSaverFlags" default="0" />
 			<description>
 				Saves a resource to disk to the given path, using a [ResourceFormatSaver] that recognizes the resource object.
-				The [code]flags[/code] bitmask can be specified to customize the save behavior using [enum SaverFlags] flags.
+				The [code]flags[/code] bitmask can be specified to customize the save behavior using [enum ResourceSaverFlags] flags.
 				Returns [constant OK] on success.
 			</description>
 		</method>
 	</methods>
 	<constants>
-		<constant name="FLAG_NONE" value="0" enum="SaverFlags">
+		<constant name="FLAG_NONE" value="0" enum="ResourceSaverFlags">
 			No resource saving option.
 		</constant>
-		<constant name="FLAG_RELATIVE_PATHS" value="1" enum="SaverFlags">
+		<constant name="FLAG_RELATIVE_PATHS" value="1" enum="ResourceSaverFlags">
 			Save the resource with a path relative to the scene which uses it.
 		</constant>
-		<constant name="FLAG_BUNDLE_RESOURCES" value="2" enum="SaverFlags">
+		<constant name="FLAG_BUNDLE_RESOURCES" value="2" enum="ResourceSaverFlags">
 			Bundles external resources.
 		</constant>
-		<constant name="FLAG_CHANGE_PATH" value="4" enum="SaverFlags">
+		<constant name="FLAG_CHANGE_PATH" value="4" enum="ResourceSaverFlags">
 			Changes the [member Resource.resource_path] of the saved resource to match its new location.
 		</constant>
-		<constant name="FLAG_OMIT_EDITOR_PROPERTIES" value="8" enum="SaverFlags">
+		<constant name="FLAG_OMIT_EDITOR_PROPERTIES" value="8" enum="ResourceSaverFlags">
 			Do not save editor-specific metadata (identified by their [code]__editor[/code] prefix).
 		</constant>
-		<constant name="FLAG_SAVE_BIG_ENDIAN" value="16" enum="SaverFlags">
+		<constant name="FLAG_SAVE_BIG_ENDIAN" value="16" enum="ResourceSaverFlags">
 			Save as big endian (see [member File.big_endian]).
 		</constant>
-		<constant name="FLAG_COMPRESS" value="32" enum="SaverFlags">
+		<constant name="FLAG_COMPRESS" value="32" enum="ResourceSaverFlags">
 			Compress the resource on save using [constant File.COMPRESSION_ZSTD]. Only available for binary resource types.
 		</constant>
-		<constant name="FLAG_REPLACE_SUBRESOURCE_PATHS" value="64" enum="SaverFlags">
+		<constant name="FLAG_REPLACE_SUBRESOURCE_PATHS" value="64" enum="ResourceSaverFlags">
 			Take over the paths of the saved subresources (see [method Resource.take_over_path]).
 		</constant>
 	</constants>

--- a/drivers/png/resource_saver_png.cpp
+++ b/drivers/png/resource_saver_png.cpp
@@ -35,7 +35,7 @@
 #include "drivers/png/png_driver_common.h"
 #include "scene/resources/texture.h"
 
-Error ResourceSaverPNG::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceSaverPNG::save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags) {
 	Ref<ImageTexture> texture = p_resource;
 
 	ERR_FAIL_COND_V_MSG(!texture.is_valid(), ERR_INVALID_PARAMETER, "Can't save invalid texture as PNG.");

--- a/drivers/png/resource_saver_png.h
+++ b/drivers/png/resource_saver_png.h
@@ -39,7 +39,7 @@ public:
 	static Error save_image(const String &p_path, const Ref<Image> &p_img);
 	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img);
 
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags = ResourceSaverFlags::FLAG_NONE);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 

--- a/editor/editor_node.h
+++ b/editor/editor_node.h
@@ -594,9 +594,9 @@ private:
 
 	void _remove_edited_scene(bool p_change_tab = true);
 	void _remove_scene(int index, bool p_change_tab = true);
-	bool _find_and_save_resource(Ref<Resource> p_res, HashMap<Ref<Resource>, bool> &processed, int32_t flags);
-	bool _find_and_save_edited_subresources(Object *obj, HashMap<Ref<Resource>, bool> &processed, int32_t flags);
-	void _save_edited_subresources(Node *scene, HashMap<Ref<Resource>, bool> &processed, int32_t flags);
+	bool _find_and_save_resource(Ref<Resource> p_res, HashMap<Ref<Resource>, bool> &processed, ResourceSaverFlags p_flags);
+	bool _find_and_save_edited_subresources(Object *obj, HashMap<Ref<Resource>, bool> &processed, ResourceSaverFlags p_flags);
+	void _save_edited_subresources(Node *scene, HashMap<Ref<Resource>, bool> &processed, ResourceSaverFlags p_flags);
 	void _mark_unsaved_scenes();
 
 	void _find_node_types(Node *p_node, int &count_2d, int &count_3d);

--- a/editor/import/resource_importer_bmfont.cpp
+++ b/editor/import/resource_importer_bmfont.cpp
@@ -72,9 +72,9 @@ Error ResourceImporterBMFont::import(const String &p_source_file, const String &
 	Error err = font->load_bitmap_font(p_source_file);
 	ERR_FAIL_COND_V_MSG(err != OK, err, "Cannot load font to file \"" + p_source_file + "\".");
 
-	int flg = ResourceSaver::SaverFlags::FLAG_BUNDLE_RESOURCES | ResourceSaver::FLAG_REPLACE_SUBRESOURCE_PATHS;
+	ResourceSaverFlags flg = ResourceSaverFlags::FLAG_BUNDLE_RESOURCES | ResourceSaverFlags::FLAG_REPLACE_SUBRESOURCE_PATHS;
 	if ((bool)p_options["compress"]) {
-		flg |= ResourceSaver::SaverFlags::FLAG_COMPRESS;
+		flg |= ResourceSaverFlags::FLAG_COMPRESS;
 	}
 
 	print_verbose("Saving to: " + p_save_path + ".fontdata");

--- a/editor/import/resource_importer_dynamic_font.cpp
+++ b/editor/import/resource_importer_dynamic_font.cpp
@@ -307,9 +307,9 @@ Error ResourceImporterDynamicFont::import(const String &p_source_file, const Str
 		TS->font_set_spacing(conf, size.x, TextServer::SPACING_GLYPH, spacing.y);
 	}
 
-	int flg = ResourceSaver::SaverFlags::FLAG_BUNDLE_RESOURCES | ResourceSaver::FLAG_REPLACE_SUBRESOURCE_PATHS;
+	ResourceSaverFlags flg = ResourceSaverFlags::FLAG_BUNDLE_RESOURCES | ResourceSaverFlags::FLAG_REPLACE_SUBRESOURCE_PATHS;
 	if ((bool)p_options["compress"]) {
-		flg |= ResourceSaver::SaverFlags::FLAG_COMPRESS;
+		flg |= ResourceSaverFlags::FLAG_COMPRESS;
 	}
 
 	print_verbose("Saving to: " + p_save_path + ".fontdata");

--- a/editor/import/resource_importer_imagefont.cpp
+++ b/editor/import/resource_importer_imagefont.cpp
@@ -148,9 +148,9 @@ Error ResourceImporterImageFont::import(const String &p_source_file, const Strin
 	font->set_ascent(0, base_size, 0.5 * chr_height);
 	font->set_descent(0, base_size, 0.5 * chr_height);
 
-	int flg = ResourceSaver::SaverFlags::FLAG_BUNDLE_RESOURCES | ResourceSaver::FLAG_REPLACE_SUBRESOURCE_PATHS;
+	ResourceSaverFlags flg = ResourceSaverFlags::FLAG_BUNDLE_RESOURCES | ResourceSaverFlags::FLAG_REPLACE_SUBRESOURCE_PATHS;
 	if ((bool)p_options["compress"]) {
-		flg |= ResourceSaver::SaverFlags::FLAG_COMPRESS;
+		flg |= ResourceSaverFlags::FLAG_COMPRESS;
 	}
 
 	print_verbose("Saving to: " + p_save_path + ".fontdata");

--- a/editor/import/resource_importer_scene.cpp
+++ b/editor/import/resource_importer_scene.cpp
@@ -1084,7 +1084,7 @@ Ref<Animation> ResourceImporterScene::_save_animation_to_file(Ref<Animation> ani
 		}
 	}
 	anim->set_path(p_save_to_path, true); // Set path to save externally.
-	Error err = ResourceSaver::save(p_save_to_path, anim, ResourceSaver::FLAG_CHANGE_PATH);
+	Error err = ResourceSaver::save(p_save_to_path, anim, ResourceSaverFlags::FLAG_CHANGE_PATH);
 	ERR_FAIL_COND_V_MSG(err != OK, anim, "Saving of animation failed: " + p_save_to_path);
 	return anim;
 }

--- a/editor/plugins/voxel_gi_editor_plugin.cpp
+++ b/editor/plugins/voxel_gi_editor_plugin.cpp
@@ -139,7 +139,7 @@ void VoxelGIEditorPlugin::_voxel_gi_save_path_and_bake(const String &p_path) {
 	if (voxel_gi) {
 		voxel_gi->bake();
 		ERR_FAIL_COND(voxel_gi->get_probe_data().is_null());
-		ResourceSaver::save(p_path, voxel_gi->get_probe_data(), ResourceSaver::FLAG_CHANGE_PATH);
+		ResourceSaver::save(p_path, voxel_gi->get_probe_data(), ResourceSaverFlags::FLAG_CHANGE_PATH);
 	}
 }
 

--- a/editor/scene_tree_dock.cpp
+++ b/editor/scene_tree_dock.cpp
@@ -2424,9 +2424,9 @@ void SceneTreeDock::_new_scene_from(String p_file) {
 			return;
 		}
 
-		int flg = 0;
+		ResourceSaverFlags flg = ResourceSaverFlags::FLAG_NONE;
 		if (EditorSettings::get_singleton()->get("filesystem/on_save/compress_binary_resources")) {
-			flg |= ResourceSaver::FLAG_COMPRESS;
+			flg |= ResourceSaverFlags::FLAG_COMPRESS;
 		}
 
 		err = ResourceSaver::save(p_file, sdata, flg);

--- a/editor/script_create_dialog.cpp
+++ b/editor/script_create_dialog.cpp
@@ -384,7 +384,7 @@ void ScriptCreateDialog::_create_new() {
 	} else {
 		String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());
 		scr->set_path(lpath);
-		Error err = ResourceSaver::save(lpath, scr, ResourceSaver::FLAG_CHANGE_PATH);
+		Error err = ResourceSaver::save(lpath, scr, ResourceSaverFlags::FLAG_CHANGE_PATH);
 		if (err != OK) {
 			alert->set_text(TTR("Error - Could not create script in filesystem."));
 			alert->popup_centered();

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -191,7 +191,7 @@ void ShaderCreateDialog::_create_new() {
 	if (!is_built_in) {
 		String lpath = ProjectSettings::get_singleton()->localize_path(file_path->get_text());
 		shader->set_path(lpath);
-		Error err = ResourceSaver::save(lpath, shader, ResourceSaver::FLAG_CHANGE_PATH);
+		Error err = ResourceSaver::save(lpath, shader, ResourceSaverFlags::FLAG_CHANGE_PATH);
 		if (err != OK) {
 			alert->set_text(TTR("Error - Could not create shader in filesystem."));
 			alert->popup_centered();

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -2357,7 +2357,7 @@ void ResourceFormatLoaderGDScript::get_dependencies(const String &p_path, List<S
 	}
 }
 
-Error ResourceFormatSaverGDScript::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverGDScript::save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags) {
 	Ref<GDScript> sqscr = p_resource;
 	ERR_FAIL_COND_V(sqscr.is_null(), ERR_INVALID_PARAMETER);
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -522,7 +522,7 @@ public:
 
 class ResourceFormatSaverGDScript : public ResourceFormatSaver {
 public:
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags = ResourceSaverFlags::FLAG_NONE);
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 };

--- a/modules/mono/csharp_script.cpp
+++ b/modules/mono/csharp_script.cpp
@@ -3627,7 +3627,7 @@ String ResourceFormatLoaderCSharpScript::get_resource_type(const String &p_path)
 	return p_path.get_extension().to_lower() == "cs" ? CSharpLanguage::get_singleton()->get_type() : "";
 }
 
-Error ResourceFormatSaverCSharpScript::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverCSharpScript::save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags) {
 	Ref<CSharpScript> sqscr = p_resource;
 	ERR_FAIL_COND_V(sqscr.is_null(), ERR_INVALID_PARAMETER);
 

--- a/modules/mono/csharp_script.h
+++ b/modules/mono/csharp_script.h
@@ -542,7 +542,7 @@ public:
 
 class ResourceFormatSaverCSharpScript : public ResourceFormatSaver {
 public:
-	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0) override;
+	Error save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags = ResourceSaverFlags::FLAG_NONE) override;
 	void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const override;
 	bool recognize(const Ref<Resource> &p_resource) const override;
 };

--- a/scene/resources/resource_format_text.cpp
+++ b/scene/resources/resource_format_text.cpp
@@ -1675,7 +1675,7 @@ static String _resource_get_class(Ref<Resource> p_resource) {
 	}
 }
 
-Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags) {
 	if (p_path.ends_with(".tscn")) {
 		packed_scene = p_resource;
 	}
@@ -1687,10 +1687,10 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 
 	local_path = ProjectSettings::get_singleton()->localize_path(p_path);
 
-	relative_paths = p_flags & ResourceSaver::FLAG_RELATIVE_PATHS;
-	skip_editor = p_flags & ResourceSaver::FLAG_OMIT_EDITOR_PROPERTIES;
-	bundle_resources = p_flags & ResourceSaver::FLAG_BUNDLE_RESOURCES;
-	takeover_paths = p_flags & ResourceSaver::FLAG_REPLACE_SUBRESOURCE_PATHS;
+	relative_paths = p_flags & ResourceSaverFlags::FLAG_RELATIVE_PATHS;
+	skip_editor = p_flags & ResourceSaverFlags::FLAG_OMIT_EDITOR_PROPERTIES;
+	bundle_resources = p_flags & ResourceSaverFlags::FLAG_BUNDLE_RESOURCES;
+	takeover_paths = p_flags & ResourceSaverFlags::FLAG_REPLACE_SUBRESOURCE_PATHS;
 	if (!p_path.begins_with("res://")) {
 		takeover_paths = false;
 	}
@@ -2040,7 +2040,7 @@ Error ResourceFormatSaverTextInstance::save(const String &p_path, const Ref<Reso
 	return OK;
 }
 
-Error ResourceFormatSaverText::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverText::save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags) {
 	if (p_path.ends_with(".tscn") && !Ref<PackedScene>(p_resource).is_valid()) {
 		return ERR_FILE_UNRECOGNIZED;
 	}

--- a/scene/resources/resource_format_text.h
+++ b/scene/resources/resource_format_text.h
@@ -184,13 +184,13 @@ class ResourceFormatSaverTextInstance {
 	String _write_resource(const Ref<Resource> &res);
 
 public:
-	Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	Error save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags = ResourceSaverFlags::FLAG_NONE);
 };
 
 class ResourceFormatSaverText : public ResourceFormatSaver {
 public:
 	static ResourceFormatSaverText *singleton;
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags = ResourceSaverFlags::FLAG_NONE);
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 

--- a/scene/resources/shader.cpp
+++ b/scene/resources/shader.cpp
@@ -210,7 +210,7 @@ String ResourceFormatLoaderShader::get_resource_type(const String &p_path) const
 	return "";
 }
 
-Error ResourceFormatSaverShader::save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags) {
+Error ResourceFormatSaverShader::save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags) {
 	Ref<Shader> shader = p_resource;
 	ERR_FAIL_COND_V(shader.is_null(), ERR_INVALID_PARAMETER);
 

--- a/scene/resources/shader.h
+++ b/scene/resources/shader.h
@@ -111,7 +111,7 @@ public:
 
 class ResourceFormatSaverShader : public ResourceFormatSaver {
 public:
-	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, ResourceSaverFlags p_flags = ResourceSaverFlags::FLAG_NONE);
 	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 	virtual bool recognize(const Ref<Resource> &p_resource) const;
 };


### PR DESCRIPTION
I saw a parameter called `uint32_t p_flags` and I wasn't sure what it did, so I decided to change this to be typed with the enum it's using. This enum was actually defined twice, one in `core_bind.h`, so I defined it outside the class instead. This PR also fixes some places where it was `flags` instead of `p_flags`.