### PR TITLE
[3.x] Improve architectures in OS::has_feature and make it work on MSVC

### DIFF
--- a/core/os/os.cpp
+++ b/core/os/os.cpp
@@ -668,19 +668,25 @@ bool OS::has_feature(const String &p_feature) {
 	if (sizeof(void *) == 4 && p_feature == "32") {
 		return true;
 	}
-#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__)
+#if defined(__x86_64) || defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
 	if (p_feature == "x86_64") {
 		return true;
 	}
-#elif (defined(__i386) || defined(__i386__))
+#elif defined(__i386) || defined(__i386__) || defined(_M_IX86)
+	if (p_feature == "x86_32") {
+		return true;
+	}
 	if (p_feature == "x86") {
 		return true;
 	}
-#elif defined(__aarch64__)
+#elif defined(__aarch64__) || defined(_M_ARM64)
 	if (p_feature == "arm64") {
 		return true;
 	}
-#elif defined(__arm__)
+#elif defined(__arm__) || defined(_M_ARM)
+	if (p_feature == "arm32") {
+		return true;
+	}
 #if defined(__ARM_ARCH_7A__)
 	if (p_feature == "armv7a" || p_feature == "armv7") {
 		return true;
@@ -710,6 +716,19 @@ bool OS::has_feature(const String &p_feature) {
 	}
 #endif
 	if (p_feature == "ppc") {
+		return true;
+	}
+#elif defined(__wasm__)
+#if defined(__wasm64__)
+	if (p_feature == "wasm64") {
+		return true;
+	}
+#elif defined(__wasm32__)
+	if (p_feature == "wasm32") {
+		return true;
+	}
+#endif
+	if (p_feature == "wasm") {
 		return true;
 	}
 #endif


### PR DESCRIPTION
This is the same as #61732 except it doesn't change the behavior of the existing `x86` and `arm` defines (in 3.x and in this PR, they will only be true for 32-bit).

Note: wasm64 is for future-proofing, it doesn't exist yet even in master. Inevitably it will come eventually. I don't know if wasm64 support will be backported to 3.x when it does come to master, but it doesn't hurt to leave this code in here.

3.4 backport (assuming we want to backport further): https://github.com/aaronfranke/godot/tree/3.4-arch-os-feature