### PR TITLE
Renamed Vector2 and Vector3 GDScript INF to INFINITY

### DIFF
--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -2116,7 +2116,7 @@ static void _register_variant_builtin_methods() {
 
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ZERO", Vector3(0, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "ONE", Vector3(1, 1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR3, "INF", Vector3(INFINITY, INFINITY, INFINITY));
+	_VariantCall::add_variant_constant(Variant::VECTOR3, "INFINITY", Vector3(INFINITY, INFINITY, INFINITY));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "LEFT", Vector3(-1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "RIGHT", Vector3(1, 0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR3, "UP", Vector3(0, 1, 0));
@@ -2145,7 +2145,7 @@ static void _register_variant_builtin_methods() {
 
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "ZERO", Vector2(0, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "ONE", Vector2(1, 1));
-	_VariantCall::add_variant_constant(Variant::VECTOR2, "INF", Vector2(INFINITY, INFINITY));
+	_VariantCall::add_variant_constant(Variant::VECTOR2, "INFINITY", Vector2(INFINITY, INFINITY));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "LEFT", Vector2(-1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "RIGHT", Vector2(1, 0));
 	_VariantCall::add_variant_constant(Variant::VECTOR2, "UP", Vector2(0, -1));

--- a/doc/classes/Vector2.xml
+++ b/doc/classes/Vector2.xml
@@ -340,7 +340,7 @@
 		<constant name="ONE" value="Vector2(1, 1)">
 			One vector, a vector with all components set to [code]1[/code].
 		</constant>
-		<constant name="INF" value="Vector2(inf, inf)">
+		<constant name="INFINITY" value="Vector2(inf, inf)">
 			Infinity vector, a vector with all components set to [constant @GDScript.INF].
 		</constant>
 		<constant name="LEFT" value="Vector2(-1, 0)">

--- a/doc/classes/Vector3.xml
+++ b/doc/classes/Vector3.xml
@@ -335,7 +335,7 @@
 		<constant name="ONE" value="Vector3(1, 1, 1)">
 			One vector, a vector with all components set to [code]1[/code].
 		</constant>
-		<constant name="INF" value="Vector3(inf, inf, inf)">
+		<constant name="INFINITY" value="Vector3(inf, inf, inf)">
 			Infinity vector, a vector with all components set to [constant @GDScript.INF].
 		</constant>
 		<constant name="LEFT" value="Vector3(-1, 0, 0)">


### PR DESCRIPTION
Renamed the GDScript  Vector2 and Vector3 INF constant to INFINITY to avoid overlap with global INF constant and prevent errors/actually make it work.

Closes #61643 
*Bugsquad edit:*
- Works around https://github.com/godotengine/godot/issues/45139
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
