### PR TITLE
[GDExtension] Expose Variant, NodePath and StringName hash functions.

### DIFF
--- a/core/extension/gdnative_interface.cpp
+++ b/core/extension/gdnative_interface.cpp
@@ -230,6 +230,16 @@ static void gdnative_variant_iter_get(const GDNativeVariantPtr p_self, GDNativeV
 }
 
 /// Variant functions.
+static GDNativeInt gdnative_variant_hash(const GDNativeVariantPtr p_self) {
+	const Variant *self = (const Variant *)p_self;
+	return self->hash();
+}
+
+static GDNativeInt gdnative_variant_recursive_hash(const GDNativeVariantPtr p_self, GDNativeInt p_recursion_count) {
+	const Variant *self = (const Variant *)p_self;
+	return self->recursive_hash(p_recursion_count);
+}
+
 static GDNativeBool gdnative_variant_hash_compare(const GDNativeVariantPtr p_self, const GDNativeVariantPtr p_other) {
 	const Variant *self = (const Variant *)p_self;
 	const Variant *other = (const Variant *)p_other;
@@ -944,6 +954,8 @@ void gdnative_setup_interface(GDNativeInterface *p_interface) {
 	gdni.variant_iter_init = gdnative_variant_iter_init;
 	gdni.variant_iter_next = gdnative_variant_iter_next;
 	gdni.variant_iter_get = gdnative_variant_iter_get;
+	gdni.variant_hash = gdnative_variant_hash;
+	gdni.variant_recursive_hash = gdnative_variant_recursive_hash;
 	gdni.variant_hash_compare = gdnative_variant_hash_compare;
 	gdni.variant_booleanize = gdnative_variant_booleanize;
 	gdni.variant_sub = gdnative_variant_sub;

--- a/core/extension/gdnative_interface.h
+++ b/core/extension/gdnative_interface.h
@@ -413,6 +413,8 @@ typedef struct {
 	GDNativeBool (*variant_iter_init)(const GDNativeVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeBool *r_valid);
 	GDNativeBool (*variant_iter_next)(const GDNativeVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeBool *r_valid);
 	void (*variant_iter_get)(const GDNativeVariantPtr p_self, GDNativeVariantPtr r_iter, GDNativeVariantPtr r_ret, GDNativeBool *r_valid);
+	GDNativeInt (*variant_hash)(const GDNativeVariantPtr p_self);
+	GDNativeInt (*variant_recursive_hash)(const GDNativeVariantPtr p_self, GDNativeInt p_recursion_count);
 	GDNativeBool (*variant_hash_compare)(const GDNativeVariantPtr p_self, const GDNativeVariantPtr p_other);
 	GDNativeBool (*variant_booleanize)(const GDNativeVariantPtr p_self);
 	void (*variant_sub)(const GDNativeVariantPtr p_a, const GDNativeVariantPtr p_b, GDNativeVariantPtr r_dst);

--- a/core/variant/variant_call.cpp
+++ b/core/variant/variant_call.cpp
@@ -1472,6 +1472,10 @@ static void _register_variant_builtin_methods() {
 	bind_static_method(String, chr, sarray("char"), varray());
 	bind_static_method(String, humanize_size, sarray("size"), varray());
 
+	/* StringName */
+
+	bind_method(StringName, hash, sarray(), varray());
+
 	/* Vector2 */
 
 	bind_method(Vector2, angle, sarray(), varray());
@@ -1684,6 +1688,7 @@ static void _register_variant_builtin_methods() {
 	bind_method(NodePath, get_name_count, sarray(), varray());
 	bind_method(NodePath, get_name, sarray("idx"), varray());
 	bind_method(NodePath, get_subname_count, sarray(), varray());
+	bind_method(NodePath, hash, sarray(), varray());
 	bind_method(NodePath, get_subname, sarray("idx"), varray());
 	bind_method(NodePath, get_concatenated_subnames, sarray(), varray());
 	bind_method(NodePath, get_as_property_path, sarray(), varray());

--- a/doc/classes/NodePath.xml
+++ b/doc/classes/NodePath.xml
@@ -157,6 +157,12 @@
 				For example, [code]"Path2D/PathFollow2D/Sprite2D:texture:load_path"[/code] has 2 subnames.
 			</description>
 		</method>
+		<method name="hash" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the 32-bit hash value representing the [NodePath]'s contents.
+			</description>
+		</method>
 		<method name="is_absolute" qualifiers="const">
 			<return type="bool" />
 			<description>

--- a/doc/classes/StringName.xml
+++ b/doc/classes/StringName.xml
@@ -32,6 +32,14 @@
 			</description>
 		</constructor>
 	</constructors>
+	<methods>
+		<method name="hash" qualifiers="const">
+			<return type="int" />
+			<description>
+				Returns the 32-bit hash value representing the [StringName]'s contents.
+			</description>
+		</method>
+	</methods>
 	<operators>
 		<operator name="operator !=">
 			<return type="bool" />

--- a/modules/text_server_adv/text_server_adv.cpp
+++ b/modules/text_server_adv/text_server_adv.cpp
@@ -1329,7 +1329,7 @@ _FORCE_INLINE_ bool TextServerAdvanced::_ensure_cache_for_size(FontDataAdvanced 
 		fd->underline_position = (-FT_MulFix(fd->face->underline_position, fd->face->size->metrics.y_scale) / 64.0) / fd->oversampling * fd->scale;
 		fd->underline_thickness = (FT_MulFix(fd->face->underline_thickness, fd->face->size->metrics.y_scale) / 64.0) / fd->oversampling * fd->scale;
 
-		hb_font_set_synthetic_slant(fd->hb_handle, p_font_data->transform.columns[0][1]);
+		hb_font_set_synthetic_slant(fd->hb_handle, p_font_data->transform[0][1]);
 
 		if (!p_font_data->face_init) {
 			// Get style flags and name.
@@ -3272,7 +3272,7 @@ void TextServerAdvanced::font_set_global_oversampling(double p_oversampling) {
 int64_t TextServerAdvanced::_convert_pos(const String &p_utf32, const Char16String &p_utf16, int64_t p_pos) const {
 	int64_t limit = p_pos;
 	if (p_utf32.length() != p_utf16.length()) {
-		const UChar *data = p_utf16.ptr();
+		const UChar *data = p_utf16.get_data();
 		for (int i = 0; i < p_pos; i++) {
 			if (U16_IS_LEAD(data[i])) {
 				limit--;
@@ -5591,7 +5591,7 @@ PackedInt32Array TextServerAdvanced::string_get_word_breaks(const String &p_stri
 
 	HashSet<int> breaks;
 	UErrorCode err = U_ZERO_ERROR;
-	UBreakIterator *bi = ubrk_open(UBRK_LINE, p_language.ascii().get_data(), (const UChar *)utf16.ptr(), utf16.length(), &err);
+	UBreakIterator *bi = ubrk_open(UBRK_LINE, p_language.ascii().get_data(), (const UChar *)utf16.get_data(), utf16.length(), &err);
 	if (U_FAILURE(err)) {
 		// No data loaded - use fallback.
 		for (int i = 0; i < p_string.length(); i++) {

--- a/modules/text_server_adv/text_server_adv.h
+++ b/modules/text_server_adv/text_server_adv.h
@@ -67,8 +67,8 @@
 #include <godot_cpp/classes/ref.hpp>
 
 #include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/templates/rid_owner.hpp>
-#include <godot_cpp/templates/set.hpp>
 #include <godot_cpp/templates/thread_work_pool.hpp>
 #include <godot_cpp/templates/vector.hpp>
 

--- a/modules/text_server_fb/text_server_fb.h
+++ b/modules/text_server_fb/text_server_fb.h
@@ -67,8 +67,8 @@
 #include <godot_cpp/classes/ref.hpp>
 
 #include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/templates/hash_set.hpp>
 #include <godot_cpp/templates/rid_owner.hpp>
-#include <godot_cpp/templates/set.hpp>
 #include <godot_cpp/templates/thread_work_pool.hpp>
 #include <godot_cpp/templates/vector.hpp>
 


### PR DESCRIPTION
Exposes hash functions required to use new HashMap/HashSet in the godot-cpp (fixes TextServer GDExtension build).
