### PR TITLE
Add GLOBAL_DEF_INTERNAL to hide specific settings

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -62,6 +62,7 @@ protected:
 		int order = 0;
 		bool persist = false;
 		bool basic = false;
+		bool internal = false;
 		Variant variant;
 		Variant initial;
 		bool hide_from_editor = false;
@@ -141,6 +142,7 @@ public:
 
 	void set_initial_value(const String &p_name, const Variant &p_value);
 	void set_as_basic(const String &p_name, bool p_basic);
+	void set_as_internal(const String &p_name, bool p_internal);
 	void set_restart_if_changed(const String &p_name, bool p_restart);
 	void set_ignore_value_in_docs(const String &p_name, bool p_ignore);
 	bool get_ignore_value_in_docs(const String &p_name) const;
@@ -191,8 +193,8 @@ public:
 	~ProjectSettings();
 };
 
-//not a macro any longer
-Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false);
+// Not a macro any longer.
+Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restart_if_changed = false, bool p_ignore_value_in_docs = false, bool p_basic = false, bool p_internal = false);
 #define GLOBAL_DEF(m_var, m_value) _GLOBAL_DEF(m_var, m_value)
 #define GLOBAL_DEF_RST(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true)
 #define GLOBAL_DEF_NOVAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true)
@@ -203,5 +205,7 @@ Variant _GLOBAL_DEF(const String &p_var, const Variant &p_default, bool p_restar
 #define GLOBAL_DEF_RST_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, false, true)
 #define GLOBAL_DEF_NOVAL_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, true, true)
 #define GLOBAL_DEF_RST_NOVAL_BASIC(m_var, m_value) _GLOBAL_DEF(m_var, m_value, true, true, true)
+
+#define GLOBAL_DEF_INTERNAL(m_var, m_value) _GLOBAL_DEF(m_var, m_value, false, false, false, true)
 
 #endif // PROJECT_SETTINGS_H

--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -216,6 +216,9 @@
 		<member name="application/config/description" type="String" setter="" getter="" default="&quot;&quot;">
 			The project's description, displayed as a tooltip in the Project Manager when hovering the project.
 		</member>
+		<member name="application/config/features" type="PackedStringArray" setter="" getter="">
+			List of internal features associated with the project, like [code]Double Precision[/code] or [code]C#[/code]. Not to be confused with feature tags.
+		</member>
 		<member name="application/config/icon" type="String" setter="" getter="" default="&quot;&quot;">
 			Icon used for the project, set when project loads. Exporters will also use this icon when possible.
 		</member>
@@ -810,6 +813,12 @@
 		</member>
 		<member name="internationalization/locale/test" type="String" setter="" getter="" default="&quot;&quot;">
 			If non-empty, this locale will be used when running the project from the editor.
+		</member>
+		<member name="internationalization/locale/translation_remaps" type="PackedStringArray" setter="" getter="">
+			Locale-dependent resource remaps. Edit them in the "Localization" tab of Project Settings editor.
+		</member>
+		<member name="internationalization/locale/translations" type="PackedStringArray" setter="" getter="">
+			List of translation files available in the project. Edit them in the "Localization" tab of Project Settings editor.
 		</member>
 		<member name="internationalization/pseudolocalization/double_vowels" type="bool" setter="" getter="" default="false">
 			Double vowels in strings during pseudolocalization to simulate the lengthening of text due to localization.

--- a/editor/editor_sectioned_inspector.cpp
+++ b/editor/editor_sectioned_inspector.cpp
@@ -250,11 +250,6 @@ void SectionedInspector::update_category_list() {
 			continue;
 		}
 
-		// Filter out unnecessary ProjectSettings sections, as they already have their dedicated tabs.
-		if (pi.name.begins_with("autoload") || pi.name.begins_with("editor_plugins") || pi.name.begins_with("shader_globals")) {
-			continue;
-		}
-
 		if (!filter.is_empty() && !_property_path_matches(pi.name, filter, name_style)) {
 			continue;
 		}


### PR DESCRIPTION
I discovered this line:
https://github.com/godotengine/godot/blob/4d2ecde3e22e2503715b0cec612dd8b767dce77a/core/config/project_settings.cpp#L347
which is probably the best way to filter out properties from Project Settings. For unknown reason though, it was checking `/something` instead of `something/` for some settings (which also caused autoloads to not be hidden previously, which was then patched somewhere else). There was also `export/` filter, which was probably unused since `export_presets.cfg` was added. And then there is `remap/` and `locale/` filter. It wasn't working, but seems like locale group has some settings that should be visible, so I removed this and only hidden 2 settings from that group (but maybe there is more settings that could be hidden).

Resolves #58456
Alternative to #61450