### PR TITLE
Fix `Viewport.own_world_3d` documentation

### DIFF
--- a/doc/classes/Viewport.xml
+++ b/doc/classes/Viewport.xml
@@ -227,7 +227,7 @@
 			The multisample anti-aliasing mode. A higher number results in smoother edges at the cost of significantly worse performance. A value of 2 or 4 is best unless targeting very high-end systems. See also bilinear scaling 3d [member scaling_3d_mode] for supersampling, which provides higher quality but is much more expensive.
 		</member>
 		<member name="own_world_3d" type="bool" setter="set_use_own_world_3d" getter="is_using_own_world_3d" default="false">
-			If [code]true[/code], the viewport will use the [World3D] defined in [member world_3d].
+			If [code]true[/code], the viewport will use a unique copy of the [World3D] defined in [member world_3d].
 		</member>
 		<member name="physics_object_picking" type="bool" setter="set_physics_object_picking" getter="get_physics_object_picking" default="false">
 			If [code]true[/code], the objects rendered by viewport become subjects of mouse picking process.

--- a/scene/main/viewport.cpp
+++ b/scene/main/viewport.cpp
@@ -3458,8 +3458,8 @@ void Viewport::_own_world_3d_changed() {
 	_update_audio_listener_3d();
 }
 
-void Viewport::set_use_own_world_3d(bool p_world_3d) {
-	if (p_world_3d == own_world_3d.is_valid()) {
+void Viewport::set_use_own_world_3d(bool p_use_own_world_3d) {
+	if (p_use_own_world_3d == own_world_3d.is_valid()) {
 		return;
 	}
 
@@ -3467,17 +3467,17 @@ void Viewport::set_use_own_world_3d(bool p_world_3d) {
 		_propagate_exit_world_3d(this);
 	}
 
-	if (!p_world_3d) {
-		own_world_3d = Ref<World3D>();
-		if (world_3d.is_valid()) {
-			world_3d->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
-		}
-	} else {
+	if (p_use_own_world_3d) {
 		if (world_3d.is_valid()) {
 			own_world_3d = world_3d->duplicate();
 			world_3d->connect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
 		} else {
 			own_world_3d = Ref<World3D>(memnew(World3D));
+		}
+	} else {
+		own_world_3d = Ref<World3D>();
+		if (world_3d.is_valid()) {
+			world_3d->disconnect(CoreStringNames::get_singleton()->changed, callable_mp(this, &Viewport::_own_world_3d_changed));
 		}
 	}
 

--- a/scene/main/viewport.h
+++ b/scene/main/viewport.h
@@ -676,7 +676,7 @@ public:
 	Ref<World3D> get_world_3d() const;
 	Ref<World3D> find_world_3d() const;
 	void _own_world_3d_changed();
-	void set_use_own_world_3d(bool p_world_3d);
+	void set_use_own_world_3d(bool p_use_own_world_3d);
 	bool is_using_own_world_3d() const;
 	void _propagate_enter_world_3d(Node *p_node);
 	void _propagate_exit_world_3d(Node *p_node);


### PR DESCRIPTION
Also refactored `set_own_world_3d()` a bit:

* Fixed the parameter name. (It's not a world.)
* Swapped the `if/else` block so the condition won't need negation. (Easier to read.)