### PR TITLE
Force unsigned behaviour for bitfield enums

### DIFF
--- a/core/math/transform_interpolator.h
+++ b/core/math/transform_interpolator.h
@@ -50,7 +50,7 @@ class Transform;
 
 class TransformInterpolator {
 public:
-	enum Method {
+	enum Method : unsigned int {
 		INTERP_LERP,
 		INTERP_SLERP,
 		INTERP_SCALED_SLERP,

--- a/scene/main/node.h
+++ b/scene/main/node.h
@@ -48,14 +48,18 @@ class Node : public Object {
 	OBJ_CATEGORY("Nodes");
 
 public:
-	enum PauseMode {
+	// N.B. Any enum stored as a bitfield should
+	// be specified as UNSIGNED to work around
+	// some compilers trying to store it as signed,
+	// and requiring 1 more bit than necessary.
+	enum PauseMode : unsigned int {
 
 		PAUSE_MODE_INHERIT,
 		PAUSE_MODE_STOP,
 		PAUSE_MODE_PROCESS
 	};
 
-	enum PhysicsInterpolationMode {
+	enum PhysicsInterpolationMode : unsigned int {
 
 		PHYSICS_INTERPOLATION_MODE_INHERIT,
 		PHYSICS_INTERPOLATION_MODE_OFF,


### PR DESCRIPTION
Some compilers (notably MSVC) were using signed values for bitfield enums. This was causing problems where 2 bits were used to store 4 or less enum values, where they were being treated as negative numbers.

This PR explicitly requests these enums to be treated as unsigned values.

Problem can be reproduced here: https://godbolt.org/z/Kqqdsehc6

## Notes
* I had inadvertently caused this bug in #60858, by storing `PauseMode` in 2 bits.
* Alternative approach is to add an extra bit to account for this compiler behaviour, but forcing unsigned is probably a better fix.
* The `TransformInterpolator::Method` actually already has an extra bit so is not susceptible, but have changed this too as a "just in case".
* We will have to watch for this bug in future when using bitfield enums.
* Embree also uses bitfield enums, but either uses more bits than necessary, or adds an extra bit (presumably to prevent the problem).

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
