### PR TITLE
[3.x] Cleaned up and normalized stack adjustments and addressing in the gdscript compiler

### DIFF
--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -32,6 +32,84 @@
 
 #include "gdscript.h"
 
+//#define DEBUG_CHAINED_SETGET
+#ifdef DEBUG_CHAINED_SETGET
+#include <stdio.h>
+
+static String to_string(const GDScriptCodeGenerator::Address &p_address) {
+	using AddressMode = GDScriptCodeGenerator::Address::AddressMode;
+	String str;
+	switch (p_address.mode) {
+		case AddressMode::SELF: {
+			str += "self";
+		} break;
+		case AddressMode::CLASS: {
+			str += "class";
+		} break;
+		case AddressMode::MEMBER: {
+			str += "member";
+		} break;
+		case AddressMode::CLASS_CONSTANT: {
+			str += "class_constant";
+		} break;
+		case AddressMode::LOCAL_CONSTANT: {
+			str += "local_constant";
+		} break;
+		case AddressMode::STACK: {
+			str += "stack";
+		} break;
+		case AddressMode::STACK_VARIABLE: {
+			str += "stack_variable";
+		} break;
+		case AddressMode::GLOBAL: {
+			str += "global";
+		} break;
+		case AddressMode::NAMED_GLOBAL: {
+			str += "named_global";
+		} break;
+		case AddressMode::NIL: {
+			str += "named_global";
+		} break;
+		default: {
+			str += "???"; // unknown addressing mode
+		} break;
+	}
+	str += "(";
+	str += itos(p_address.address);
+	str += ")";
+	return str;
+}
+#endif
+
+#define _ADJUST_STACK_LEVEL_OR_RETURN_V(m_codegen, m_address, m_slevel, m_bad_address_return, m_adjust_code) \
+	if (true) {                                                                                              \
+		if (!m_address) {                                                                                    \
+			return m_bad_address_return;                                                                     \
+		}                                                                                                    \
+		if (m_codegen.adjust_stack_level(m_address, m_slevel)) {                                             \
+			m_adjust_code;                                                                                   \
+		}                                                                                                    \
+	} else                                                                                                   \
+		((void)0)
+
+// if the address is a stack address that is above the current stack level then
+// adjust the stack level to be the next immediate address.
+// NOTE: if the supplied address is invalid then the calling function will return that address.
+#define ADJUST_STACK_LEVEL_OR_RETURN(m_codegen, m_address, m_slevel) \
+	_ADJUST_STACK_LEVEL_OR_RETURN_V(m_codegen, m_address, m_slevel, m_address, {})
+// if the address is a stack address that is above the current stack level then
+// adjust the stack level to be the next immediate address.
+// NOTE: if the supplied address is invalid then the calling function will return false.
+#define ADJUST_STACK_LEVEL_OR_RETURN_FALSE(m_codegen, m_address, m_slevel) \
+	_ADJUST_STACK_LEVEL_OR_RETURN_V(m_codegen, m_address, m_slevel, false, {})
+// if the address is a stack address that is above the current stack level then
+// adjust the stack level to be the next immediate address and allocate up to it for use.
+// NOTE: if the supplied address is invalid then the calling function will return.
+#define ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(m_codegen, m_address, m_slevel) \
+	_ADJUST_STACK_LEVEL_OR_RETURN_V(m_codegen, m_address, m_slevel, m_address, m_codegen.alloc_stack(m_slevel))
+
+//
+
 bool GDScriptCompiler::_is_class_member_property(CodeGen &codegen, const StringName &p_name) {
 	if (codegen.function_node && codegen.function_node->_static) {
 		return false;
@@ -77,39 +155,34 @@ void GDScriptCompiler::_set_error(const String &p_error, const GDScriptParser::N
 bool GDScriptCompiler::_create_unary_operator(CodeGen &codegen, const GDScriptParser::OperatorNode *on, Variant::Operator op, int p_stack_level) {
 	ERR_FAIL_COND_V(on->arguments.size() != 1, false);
 
-	int src_address_a = _parse_expression(codegen, on->arguments[0], p_stack_level);
-	if (src_address_a < 0) {
+	GDScriptCodeGenerator::Address src_address_a = _parse_expression(codegen, on->arguments[0], p_stack_level);
+	if (!src_address_a) {
 		return false;
 	}
 
-	codegen.opcodes.push_back(GDScriptFunction::OPCODE_OPERATOR); // perform operator
-	codegen.opcodes.push_back(op); //which operator
-	codegen.opcodes.push_back(src_address_a); // argument 1
-	codegen.opcodes.push_back(src_address_a); // argument 2 (repeated)
-	//codegen.opcodes.push_back(GDScriptFunction::ADDR_TYPE_NIL); // argument 2 (unary only takes one parameter)
+	codegen.append(GDScriptFunction::OPCODE_OPERATOR); // perform operator
+	codegen.append(op); //which operator
+	codegen.append(src_address_a); // argument 1
+	codegen.append(src_address_a); // argument 2 (repeated)
+	//codegen.append(NIL_ADDRESS); // argument 2 (unary only takes one parameter)
 	return true;
 }
 
-bool GDScriptCompiler::_create_binary_operator(CodeGen &codegen, const GDScriptParser::OperatorNode *on, Variant::Operator op, int p_stack_level, bool p_initializer, int p_index_addr) {
+bool GDScriptCompiler::_create_binary_operator(CodeGen &codegen, const GDScriptParser::OperatorNode *on, Variant::Operator op, const int p_stack_level, bool p_initializer, GDScriptCodeGenerator::Address p_index_addr) {
 	ERR_FAIL_COND_V(on->arguments.size() != 2, false);
 
-	int src_address_a = _parse_expression(codegen, on->arguments[0], p_stack_level, false, p_initializer, p_index_addr);
-	if (src_address_a < 0) {
-		return false;
-	}
-	if (src_address_a & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-		p_stack_level++; //uses stack for return, increase stack
-	}
+	int slevel = p_stack_level;
 
-	int src_address_b = _parse_expression(codegen, on->arguments[1], p_stack_level, false, p_initializer);
-	if (src_address_b < 0) {
-		return false;
-	}
+	GDScriptCodeGenerator::Address src_address_a = _parse_expression(codegen, on->arguments[0], slevel, false, p_initializer, p_index_addr);
+	ADJUST_STACK_LEVEL_OR_RETURN_FALSE(codegen, src_address_a, slevel); //uses stack for return, increase stack
 
-	codegen.opcodes.push_back(GDScriptFunction::OPCODE_OPERATOR); // perform operator
-	codegen.opcodes.push_back(op); //which operator
-	codegen.opcodes.push_back(src_address_a); // argument 1
-	codegen.opcodes.push_back(src_address_b); // argument 2 (unary only takes one parameter)
+	GDScriptCodeGenerator::Address src_address_b = _parse_expression(codegen, on->arguments[1], slevel, false, p_initializer);
+	ADJUST_STACK_LEVEL_OR_RETURN_FALSE(codegen, src_address_b, slevel); //uses stack for return, increase stack
+
+	codegen.append(GDScriptFunction::OPCODE_OPERATOR); // perform operator
+	codegen.append(op); //which operator
+	codegen.append(src_address_a); // argument 1
+	codegen.append(src_address_b); // argument 2 (unary only takes one parameter)
 	return true;
 }
 
@@ -182,7 +255,7 @@ GDScriptDataType GDScriptCompiler::_gdtype_from_datatype(const GDScriptParser::D
 	return result;
 }
 
-int GDScriptCompiler::_parse_assign_right_expression(CodeGen &codegen, const GDScriptParser::OperatorNode *p_expression, int p_stack_level, int p_index_addr) {
+GDScriptCodeGenerator::Address GDScriptCompiler::_parse_assign_right_expression(CodeGen &codegen, const GDScriptParser::OperatorNode *p_expression, int p_stack_level, GDScriptCodeGenerator::Address p_index_addr) {
 	Variant::Operator var_op = Variant::OP_MAX;
 
 	switch (p_expression->op) {
@@ -221,7 +294,7 @@ int GDScriptCompiler::_parse_assign_right_expression(CodeGen &codegen, const GDS
 			//none
 		} break;
 		default: {
-			ERR_FAIL_V(-1);
+			ERR_FAIL_V(GDScriptCodeGenerator::Address::INVALID);
 		}
 	}
 
@@ -232,16 +305,16 @@ int GDScriptCompiler::_parse_assign_right_expression(CodeGen &codegen, const GDS
 	}
 
 	if (!_create_binary_operator(codegen, p_expression, var_op, p_stack_level, initializer, p_index_addr)) {
-		return -1;
+		return GDScriptCodeGenerator::Address::INVALID;
 	}
 
-	int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-	codegen.opcodes.push_back(dst_addr); // append the stack level as destination address of the opcode
+	auto dst_addr = GDScriptCodeGenerator::StackAddress(p_stack_level);
+	codegen.append(dst_addr); // append the stack level as destination address of the opcode
 	codegen.alloc_stack(p_stack_level);
 	return dst_addr;
 }
 
-int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::Node *p_expression, int p_stack_level, bool p_root, bool p_initializer, int p_index_addr) {
+GDScriptCodeGenerator::Address GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::Node *p_expression, const int p_stack_level, bool p_root, bool p_initializer, GDScriptCodeGenerator::Address p_index_addr) {
 	switch (p_expression->type) {
 		//should parse variable declaration and adjust stack accordingly...
 		case GDScriptParser::Node::TYPE_IDENTIFIER: {
@@ -257,17 +330,16 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 
 			// TRY STACK!
 			if (!p_initializer && codegen.stack_identifiers.has(identifier)) {
-				int pos = codegen.stack_identifiers[identifier];
-				return pos | (GDScriptFunction::ADDR_TYPE_STACK_VARIABLE << GDScriptFunction::ADDR_BITS);
+				return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::STACK_VARIABLE, codegen.stack_identifiers[identifier]);
 			}
 
 			// TRY CLASS MEMBER
 			if (_is_class_member_property(codegen, identifier)) {
 				//get property
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_GET_MEMBER); // perform operator
-				codegen.opcodes.push_back(codegen.get_name_map_pos(identifier)); // argument 2 (unary only takes one parameter)
-				int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-				codegen.opcodes.push_back(dst_addr); // append the stack level as destination address of the opcode
+				codegen.append(GDScriptFunction::OPCODE_GET_MEMBER); // perform operator
+				codegen.append(codegen.get_name_map_pos(identifier)); // argument 2 (unary only takes one parameter)
+				auto dst_addr = GDScriptCodeGenerator::StackAddress(p_stack_level);
+				codegen.append(dst_addr); // append the stack level as destination address of the opcode
 				codegen.alloc_stack(p_stack_level);
 				return dst_addr;
 			}
@@ -277,8 +349,7 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 				// TRY MEMBER VARIABLES!
 				//static function
 				if (codegen.script->member_indices.has(identifier)) {
-					int idx = codegen.script->member_indices[identifier].index;
-					return idx | (GDScriptFunction::ADDR_TYPE_MEMBER << GDScriptFunction::ADDR_BITS); //argument (stack root)
+					return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::MEMBER, codegen.script->member_indices[identifier].index); // argument (stack root)
 				}
 			}
 
@@ -292,7 +363,7 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 					if (scr->constants.has(identifier)) {
 						//int idx=scr->constants[identifier];
 						int idx = codegen.get_name_map_pos(identifier);
-						return idx | (GDScriptFunction::ADDR_TYPE_CLASS_CONSTANT << GDScriptFunction::ADDR_BITS); //argument (stack root)
+						return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::CLASS_CONSTANT, idx); // argument (stack root)
 					}
 					if (scr->native.is_valid()) {
 						nc = scr->native.ptr();
@@ -312,12 +383,11 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 						if (!codegen.constant_map.has(key)) {
 							idx = codegen.constant_map.size();
 							codegen.constant_map[key] = idx;
-
 						} else {
 							idx = codegen.constant_map[key];
 						}
 
-						return idx | (GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS); //make it a local constant (faster access)
+						return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::LOCAL_CONSTANT, idx); //make it a local constant (faster access)
 					}
 				}
 
@@ -326,7 +396,7 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 
 			if (GDScriptLanguage::get_singleton()->get_global_map().has(identifier)) {
 				int idx = GDScriptLanguage::get_singleton()->get_global_map()[identifier];
-				return idx | (GDScriptFunction::ADDR_TYPE_GLOBAL << GDScriptFunction::ADDR_BITS); //argument (stack root)
+				return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::GLOBAL, idx); //argument (stack root)
 			}
 
 			/* TRY GLOBAL CLASSES */
@@ -339,13 +409,13 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 
 				if (class_node->name == identifier) {
 					_set_error("Using own name in class file is not allowed (creates a cyclic reference)", p_expression);
-					return -1;
+					return GDScriptCodeGenerator::Address::INVALID;
 				}
 
 				RES res = ResourceLoader::load(ScriptServer::get_global_class_path(identifier));
 				if (res.is_null()) {
 					_set_error("Can't load global class " + String(identifier) + ", cyclic reference?", p_expression);
-					return -1;
+					return GDScriptCodeGenerator::Address::INVALID;
 				}
 
 				Variant key = res;
@@ -359,7 +429,7 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 					idx = codegen.constant_map[key];
 				}
 
-				return idx | (GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS); //make it a local constant (faster access)
+				return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::LOCAL_CONSTANT, idx); //make it a local constant (faster access)
 			}
 
 #ifdef TOOLS_ENABLED
@@ -369,15 +439,14 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 					idx = codegen.named_globals.size();
 					codegen.named_globals.push_back(identifier);
 				}
-				return idx | (GDScriptFunction::ADDR_TYPE_NAMED_GLOBAL << GDScriptFunction::ADDR_BITS);
+				return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::NAMED_GLOBAL, idx);
 			}
 #endif
 
 			//not found, error
 
 			_set_error("Identifier not found: " + String(identifier), p_expression);
-
-			return -1;
+			return GDScriptCodeGenerator::Address::INVALID;
 
 		} break;
 		case GDScriptParser::Node::TYPE_CONSTANT: {
@@ -394,86 +463,66 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 				idx = codegen.constant_map[cn->value];
 			}
 
-			return idx | (GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS); //argument (stack root)
+			return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::LOCAL_CONSTANT, idx); //argument (stack root)
 
 		} break;
 		case GDScriptParser::Node::TYPE_SELF: {
 			//return constant
 			if (codegen.function_node && codegen.function_node->_static) {
 				_set_error("'self' not present in static function!", p_expression);
-				return -1;
+				return GDScriptCodeGenerator::Address::INVALID;
 			}
-			return (GDScriptFunction::ADDR_TYPE_SELF << GDScriptFunction::ADDR_BITS);
+			return GDScriptCodeGenerator::Address::SELF;
+
 		} break;
 		case GDScriptParser::Node::TYPE_ARRAY: {
 			const GDScriptParser::ArrayNode *an = static_cast<const GDScriptParser::ArrayNode *>(p_expression);
-			Vector<int> values;
+			Vector<GDScriptCodeGenerator::Address> values;
 
 			int slevel = p_stack_level;
 
 			for (int i = 0; i < an->elements.size(); i++) {
-				int ret = _parse_expression(codegen, an->elements[i], slevel);
-				if (ret < 0) {
-					return ret;
-				}
-				if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-					slevel++;
-					codegen.alloc_stack(slevel);
-				}
-
+				auto ret = _parse_expression(codegen, an->elements[i], slevel);
+				ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(codegen, ret, slevel);
 				values.push_back(ret);
 			}
 
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_CONSTRUCT_ARRAY);
-			codegen.opcodes.push_back(values.size());
+			codegen.append(GDScriptFunction::OPCODE_CONSTRUCT_ARRAY);
+			codegen.append(values.size());
 			for (int i = 0; i < values.size(); i++) {
-				codegen.opcodes.push_back(values[i]);
+				codegen.append(values[i]);
 			}
 
-			int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-			codegen.opcodes.push_back(dst_addr); // append the stack level as destination address of the opcode
+			auto dst_addr = GDScriptCodeGenerator::StackAddress(p_stack_level);
+			codegen.append(dst_addr); // append the stack level as destination address of the opcode
 			codegen.alloc_stack(p_stack_level);
 			return dst_addr;
 
 		} break;
 		case GDScriptParser::Node::TYPE_DICTIONARY: {
 			const GDScriptParser::DictionaryNode *dn = static_cast<const GDScriptParser::DictionaryNode *>(p_expression);
-			Vector<int> values;
+			Vector<GDScriptCodeGenerator::Address> values;
 
 			int slevel = p_stack_level;
 
 			for (int i = 0; i < dn->elements.size(); i++) {
-				int ret = _parse_expression(codegen, dn->elements[i].key, slevel);
-				if (ret < 0) {
-					return ret;
-				}
-				if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-					slevel++;
-					codegen.alloc_stack(slevel);
-				}
-
+				auto ret = _parse_expression(codegen, dn->elements[i].key, slevel);
+				ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(codegen, ret, slevel);
 				values.push_back(ret);
 
 				ret = _parse_expression(codegen, dn->elements[i].value, slevel);
-				if (ret < 0) {
-					return ret;
-				}
-				if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-					slevel++;
-					codegen.alloc_stack(slevel);
-				}
-
+				ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(codegen, ret, slevel);
 				values.push_back(ret);
 			}
 
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_CONSTRUCT_DICTIONARY);
-			codegen.opcodes.push_back(dn->elements.size());
+			codegen.append(GDScriptFunction::OPCODE_CONSTRUCT_DICTIONARY);
+			codegen.append(dn->elements.size());
 			for (int i = 0; i < values.size(); i++) {
-				codegen.opcodes.push_back(values[i]);
+				codegen.append(values[i]);
 			}
 
-			int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-			codegen.opcodes.push_back(dst_addr); // append the stack level as destination address of the opcode
+			auto dst_addr = GDScriptCodeGenerator::StackAddress(p_stack_level);
+			codegen.append(dst_addr); // append the stack level as destination address of the opcode
 			codegen.alloc_stack(p_stack_level);
 			return dst_addr;
 
@@ -482,52 +531,41 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 			const GDScriptParser::CastNode *cn = static_cast<const GDScriptParser::CastNode *>(p_expression);
 
 			int slevel = p_stack_level;
-			int src_addr = _parse_expression(codegen, cn->source_node, slevel);
-			if (src_addr < 0) {
-				return src_addr;
-			}
-			if (src_addr & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-				slevel++;
-				codegen.alloc_stack(slevel);
-			}
+			auto src_addr = _parse_expression(codegen, cn->source_node, slevel);
+			ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(codegen, src_addr, slevel);
 
 			GDScriptDataType cast_type = _gdtype_from_datatype(cn->cast_type);
 
 			switch (cast_type.kind) {
 				case GDScriptDataType::BUILTIN: {
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_CAST_TO_BUILTIN);
-					codegen.opcodes.push_back(cast_type.builtin_type);
+					codegen.append(GDScriptFunction::OPCODE_CAST_TO_BUILTIN);
+					codegen.append(cast_type.builtin_type);
 				} break;
 				case GDScriptDataType::NATIVE: {
-					int class_idx;
-					if (GDScriptLanguage::get_singleton()->get_global_map().has(cast_type.native_type)) {
-						class_idx = GDScriptLanguage::get_singleton()->get_global_map()[cast_type.native_type];
-						class_idx |= (GDScriptFunction::ADDR_TYPE_GLOBAL << GDScriptFunction::ADDR_BITS); //argument (stack root)
-					} else {
+					if (!GDScriptLanguage::get_singleton()->get_global_map().has(cast_type.native_type)) {
 						_set_error("Invalid native class type '" + String(cast_type.native_type) + "'.", cn);
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_CAST_TO_NATIVE); // perform operator
-					codegen.opcodes.push_back(class_idx); // variable type
+					int class_idx = GDScriptLanguage::get_singleton()->get_global_map()[cast_type.native_type];
+					codegen.append(GDScriptFunction::OPCODE_CAST_TO_NATIVE); // perform operator
+					codegen.append(GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::GLOBAL, class_idx)); // variable type
 				} break;
 				case GDScriptDataType::SCRIPT:
 				case GDScriptDataType::GDSCRIPT: {
 					Variant script = cast_type.script_type;
-					int idx = codegen.get_constant_pos(script);
-					idx |= GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS; //make it a local constant (faster access)
-
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_CAST_TO_SCRIPT); // perform operator
-					codegen.opcodes.push_back(idx); // variable type
+					int idx = codegen.get_constant_pos(script); // make it a local constant for faster access
+					codegen.append(GDScriptFunction::OPCODE_CAST_TO_SCRIPT); // perform operator
+					codegen.append(GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::LOCAL_CONSTANT, idx)); // variable type
 				} break;
 				default: {
 					_set_error("Parser bug: unresolved data type.", cn);
-					return -1;
+					return GDScriptCodeGenerator::Address::INVALID;
 				}
 			}
 
-			codegen.opcodes.push_back(src_addr); // source address
-			int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-			codegen.opcodes.push_back(dst_addr); // append the stack level as destination address of the opcode
+			codegen.append(src_addr); // source address
+			auto dst_addr = GDScriptCodeGenerator::StackAddress(p_stack_level);
+			codegen.append(dst_addr); // append the stack level as destination address of the opcode
 			codegen.alloc_stack(p_stack_level);
 			return dst_addr;
 
@@ -539,98 +577,78 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 			switch (on->op) {
 				//call/constructor operator
 				case GDScriptParser::OperatorNode::OP_PARENT_CALL: {
-					ERR_FAIL_COND_V(on->arguments.size() < 1, -1);
+					ERR_FAIL_COND_V(on->arguments.size() < 1, GDScriptCodeGenerator::Address::INVALID);
 
 					const GDScriptParser::IdentifierNode *in = (const GDScriptParser::IdentifierNode *)on->arguments[0];
 
-					Vector<int> arguments;
+					Vector<GDScriptCodeGenerator::Address> arguments;
 					int slevel = p_stack_level;
 					for (int i = 1; i < on->arguments.size(); i++) {
-						int ret = _parse_expression(codegen, on->arguments[i], slevel);
-						if (ret < 0) {
-							return ret;
-						}
-						if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-							slevel++;
-							codegen.alloc_stack(slevel);
-						}
+						auto ret = _parse_expression(codegen, on->arguments[i], slevel);
+						ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(codegen, ret, slevel);
 						arguments.push_back(ret);
 					}
 
 					//push call bytecode
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_CALL_SELF_BASE); // basic type constructor
+					codegen.append(GDScriptFunction::OPCODE_CALL_SELF_BASE); // basic type constructor
 
-					codegen.opcodes.push_back(codegen.get_name_map_pos(in->name)); //instance
-					codegen.opcodes.push_back(arguments.size()); //argument count
+					codegen.append(codegen.get_name_map_pos(in->name)); //instance
+					codegen.append(arguments.size()); //argument count
 					codegen.alloc_call(arguments.size());
 					for (int i = 0; i < arguments.size(); i++) {
-						codegen.opcodes.push_back(arguments[i]); //arguments
+						codegen.append(arguments[i]); //arguments
 					}
 
 				} break;
 				case GDScriptParser::OperatorNode::OP_CALL: {
 					if (on->arguments[0]->type == GDScriptParser::Node::TYPE_TYPE) {
 						//construct a basic type
-						ERR_FAIL_COND_V(on->arguments.size() < 1, -1);
+						ERR_FAIL_COND_V(on->arguments.size() < 1, GDScriptCodeGenerator::Address::INVALID);
 
 						const GDScriptParser::TypeNode *tn = (const GDScriptParser::TypeNode *)on->arguments[0];
 						int vtype = tn->vtype;
 
-						Vector<int> arguments;
+						Vector<GDScriptCodeGenerator::Address> arguments;
 						int slevel = p_stack_level;
 						for (int i = 1; i < on->arguments.size(); i++) {
-							int ret = _parse_expression(codegen, on->arguments[i], slevel);
-							if (ret < 0) {
-								return ret;
-							}
-							if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-								slevel++;
-								codegen.alloc_stack(slevel);
-							}
+							auto ret = _parse_expression(codegen, on->arguments[i], slevel);
+							ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(codegen, ret, slevel);
 							arguments.push_back(ret);
 						}
 
 						//push call bytecode
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_CONSTRUCT); // basic type constructor
-						codegen.opcodes.push_back(vtype); //instance
-						codegen.opcodes.push_back(arguments.size()); //argument count
+						codegen.append(GDScriptFunction::OPCODE_CONSTRUCT); // basic type constructor
+						codegen.append(vtype); //instance
+						codegen.append(arguments.size()); //argument count
 						codegen.alloc_call(arguments.size());
 						for (int i = 0; i < arguments.size(); i++) {
-							codegen.opcodes.push_back(arguments[i]); //arguments
+							codegen.append(arguments[i]); //arguments
 						}
 
 					} else if (on->arguments[0]->type == GDScriptParser::Node::TYPE_BUILT_IN_FUNCTION) {
 						//built in function
 
-						ERR_FAIL_COND_V(on->arguments.size() < 1, -1);
+						ERR_FAIL_COND_V(on->arguments.size() < 1, GDScriptCodeGenerator::Address::INVALID);
 
-						Vector<int> arguments;
+						Vector<GDScriptCodeGenerator::Address> arguments;
 						int slevel = p_stack_level;
 						for (int i = 1; i < on->arguments.size(); i++) {
-							int ret = _parse_expression(codegen, on->arguments[i], slevel);
-							if (ret < 0) {
-								return ret;
-							}
-
-							if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-								slevel++;
-								codegen.alloc_stack(slevel);
-							}
-
+							auto ret = _parse_expression(codegen, on->arguments[i], slevel);
+							ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(codegen, ret, slevel);
 							arguments.push_back(ret);
 						}
 
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_CALL_BUILT_IN);
-						codegen.opcodes.push_back(static_cast<const GDScriptParser::BuiltInFunctionNode *>(on->arguments[0])->function);
-						codegen.opcodes.push_back(on->arguments.size() - 1);
+						codegen.append(GDScriptFunction::OPCODE_CALL_BUILT_IN);
+						codegen.append(static_cast<const GDScriptParser::BuiltInFunctionNode *>(on->arguments[0])->function);
+						codegen.append(on->arguments.size() - 1);
 						codegen.alloc_call(on->arguments.size() - 1);
 						for (int i = 0; i < arguments.size(); i++) {
-							codegen.opcodes.push_back(arguments[i]);
+							codegen.append(arguments[i]);
 						}
 
 					} else {
 						//regular function
-						ERR_FAIL_COND_V(on->arguments.size() < 2, -1);
+						ERR_FAIL_COND_V(on->arguments.size() < 2, GDScriptCodeGenerator::Address::INVALID);
 
 						const GDScriptParser::Node *instance = on->arguments[0];
 
@@ -642,63 +660,50 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 						int slevel = p_stack_level;
 
 						for (int i = 0; i < on->arguments.size(); i++) {
-							int ret;
+							GDScriptCodeGenerator::Address ret = GDScriptCodeGenerator::Address::INVALID;
 
 							if (i == 0 && on->arguments[i]->type == GDScriptParser::Node::TYPE_SELF && codegen.function_node && codegen.function_node->_static) {
-								//static call to self
-								ret = (GDScriptFunction::ADDR_TYPE_CLASS << GDScriptFunction::ADDR_BITS);
+								ret = GDScriptCodeGenerator::Address::CLASS; // static call to self
+								arguments.push_back(codegen.address_of(ret));
 							} else if (i == 1) {
 								if (on->arguments[i]->type != GDScriptParser::Node::TYPE_IDENTIFIER) {
 									_set_error("Attempt to call a non-identifier.", on);
-									return -1;
+									return GDScriptCodeGenerator::Address::INVALID;
 								}
 								GDScriptParser::IdentifierNode *id = static_cast<GDScriptParser::IdentifierNode *>(on->arguments[i]);
-								ret = codegen.get_name_map_pos(id->name);
-
+								arguments.push_back(codegen.get_name_map_pos(id->name));
 							} else {
 								ret = _parse_expression(codegen, on->arguments[i], slevel);
-								if (ret < 0) {
-									return ret;
-								}
-								if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-									slevel++;
-									codegen.alloc_stack(slevel);
-								}
+								ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(codegen, ret, slevel);
+								arguments.push_back(codegen.address_of(ret));
 							}
-							arguments.push_back(ret);
 						}
 
-						codegen.opcodes.push_back(p_root ? GDScriptFunction::OPCODE_CALL : GDScriptFunction::OPCODE_CALL_RETURN); // perform operator
-						codegen.opcodes.push_back(on->arguments.size() - 2);
+						codegen.append(p_root ? GDScriptFunction::OPCODE_CALL : GDScriptFunction::OPCODE_CALL_RETURN); // perform operator
+						codegen.append(on->arguments.size() - 2);
 						codegen.alloc_call(on->arguments.size() - 2);
 						for (int i = 0; i < arguments.size(); i++) {
-							codegen.opcodes.push_back(arguments[i]);
+							codegen.append(arguments[i]);
 						}
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_YIELD: {
-					ERR_FAIL_COND_V(on->arguments.size() && on->arguments.size() != 2, -1);
+					ERR_FAIL_COND_V(on->arguments.size() && on->arguments.size() != 2, GDScriptCodeGenerator::Address::INVALID);
 
-					Vector<int> arguments;
+					Vector<GDScriptCodeGenerator::Address> arguments;
 					int slevel = p_stack_level;
 					for (int i = 0; i < on->arguments.size(); i++) {
-						int ret = _parse_expression(codegen, on->arguments[i], slevel);
-						if (ret < 0) {
-							return ret;
-						}
-						if ((ret >> GDScriptFunction::ADDR_BITS & GDScriptFunction::ADDR_TYPE_STACK) == GDScriptFunction::ADDR_TYPE_STACK) {
-							slevel++;
-							codegen.alloc_stack(slevel);
-						}
+						auto ret = _parse_expression(codegen, on->arguments[i], slevel);
+						ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(codegen, ret, slevel);
 						arguments.push_back(ret);
 					}
 
 					//push call bytecode
-					codegen.opcodes.push_back(arguments.size() == 0 ? GDScriptFunction::OPCODE_YIELD : GDScriptFunction::OPCODE_YIELD_SIGNAL); // basic type constructor
+					codegen.append(arguments.size() == 0 ? GDScriptFunction::OPCODE_YIELD : GDScriptFunction::OPCODE_YIELD_SIGNAL); // basic type constructor
 					for (int i = 0; i < arguments.size(); i++) {
-						codegen.opcodes.push_back(arguments[i]); //arguments
+						codegen.append(arguments[i]); //arguments
 					}
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_YIELD_RESUME);
+					codegen.append(GDScriptFunction::OPCODE_YIELD_RESUME);
 					//next will be where to place the result :)
 
 				} break;
@@ -706,20 +711,21 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 				//indexing operator
 				case GDScriptParser::OperatorNode::OP_INDEX:
 				case GDScriptParser::OperatorNode::OP_INDEX_NAMED: {
-					ERR_FAIL_COND_V(on->arguments.size() != 2, -1);
+					ERR_FAIL_COND_V(on->arguments.size() != 2, GDScriptCodeGenerator::Address::INVALID);
 
 					int slevel = p_stack_level;
-					bool named = (on->op == GDScriptParser::OperatorNode::OP_INDEX_NAMED);
+					bool is_named = (on->op == GDScriptParser::OperatorNode::OP_INDEX_NAMED);
+					StringName name;
 
-					int from = _parse_expression(codegen, on->arguments[0], slevel);
-					if (from < 0) {
+					auto from = _parse_expression(codegen, on->arguments[0], slevel);
+					if (!from) {
 						return from;
 					}
 
-					int index;
-					if (p_index_addr != 0) {
+					GDScriptCodeGenerator::Address index = GDScriptCodeGenerator::Address::INVALID;
+					if (p_index_addr.mode != GDScriptCodeGenerator::Address::INVALID) {
 						index = p_index_addr;
-					} else if (named) {
+					} else if (is_named) {
 						if (on->arguments[0]->type == GDScriptParser::Node::TYPE_SELF && codegen.script && codegen.function_node && !codegen.function_node->_static) {
 							GDScriptParser::IdentifierNode *identifier = static_cast<GDScriptParser::IdentifierNode *>(on->arguments[1]);
 							const Map<StringName, GDScript::MemberInfo>::Element *MI = codegen.script->member_indices.find(identifier->name);
@@ -728,261 +734,259 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 							if (MI && MI->get().getter == codegen.function_node->name) {
 								String n = static_cast<GDScriptParser::IdentifierNode *>(on->arguments[1])->name;
 								_set_error("Must use '" + n + "' instead of 'self." + n + "' in getter.", on);
-								return -1;
+								return GDScriptCodeGenerator::Address::INVALID;
 							}
 #endif
 
 							if (MI && MI->get().getter == "") {
 								// Faster than indexing self (as if no self. had been used)
-								return (MI->get().index) | (GDScriptFunction::ADDR_TYPE_MEMBER << GDScriptFunction::ADDR_BITS);
+								return GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::MEMBER, MI->get().index);
 							}
 						}
 
-						index = codegen.get_name_map_pos(static_cast<GDScriptParser::IdentifierNode *>(on->arguments[1])->name);
+						name = static_cast<GDScriptParser::IdentifierNode *>(on->arguments[1])->name;
 
 					} else {
 						if (on->arguments[1]->type == GDScriptParser::Node::TYPE_CONSTANT && static_cast<const GDScriptParser::ConstantNode *>(on->arguments[1])->value.get_type() == Variant::STRING) {
 							//also, somehow, named (speed up anyway)
-							StringName name = static_cast<const GDScriptParser::ConstantNode *>(on->arguments[1])->value;
-							index = codegen.get_name_map_pos(name);
-							named = true;
+							name = static_cast<const GDScriptParser::ConstantNode *>(on->arguments[1])->value;
+							is_named = true;
 
 						} else {
 							//regular indexing
-							if (from & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-								slevel++;
+							if (codegen.adjust_stack_level(from, slevel)) {
 								codegen.alloc_stack(slevel);
 							}
 
 							index = _parse_expression(codegen, on->arguments[1], slevel);
-							if (index < 0) {
+							if (!index) {
 								return index;
 							}
 						}
 					}
 
-					codegen.opcodes.push_back(named ? GDScriptFunction::OPCODE_GET_NAMED : GDScriptFunction::OPCODE_GET); // perform operator
-					codegen.opcodes.push_back(from); // argument 1
-					codegen.opcodes.push_back(index); // argument 2 (unary only takes one parameter)
+					codegen.append(is_named ? GDScriptFunction::OPCODE_GET_NAMED : GDScriptFunction::OPCODE_GET); // perform operator
+					codegen.append(from); // argument 1
+					codegen.append(is_named ? codegen.get_name_map_pos(name) : codegen.address_of(index)); // argument 2 (unary only takes one parameter)
 
 				} break;
 				case GDScriptParser::OperatorNode::OP_AND: {
 					// AND operator with early out on failure
 
-					int res = _parse_expression(codegen, on->arguments[0], p_stack_level);
-					if (res < 0) {
+					auto res = _parse_expression(codegen, on->arguments[0], p_stack_level);
+					if (!res) {
 						return res;
 					}
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-					codegen.opcodes.push_back(res);
+					codegen.append(GDScriptFunction::OPCODE_JUMP_IF_NOT);
+					codegen.append(res);
 					int jump_fail_pos = codegen.opcodes.size();
-					codegen.opcodes.push_back(0);
+					codegen.append(0);
 
 					res = _parse_expression(codegen, on->arguments[1], p_stack_level);
-					if (res < 0) {
+					if (!res) {
 						return res;
 					}
 
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-					codegen.opcodes.push_back(res);
+					codegen.append(GDScriptFunction::OPCODE_JUMP_IF_NOT);
+					codegen.append(res);
 					int jump_fail_pos2 = codegen.opcodes.size();
-					codegen.opcodes.push_back(0);
+					codegen.append(0);
 
 					codegen.alloc_stack(p_stack_level); //it will be used..
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_TRUE);
-					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-					codegen.opcodes.push_back(codegen.opcodes.size() + 3);
+					codegen.append(GDScriptFunction::OPCODE_ASSIGN_TRUE);
+					codegen.append(GDScriptCodeGenerator::StackAddress(p_stack_level));
+					codegen.append(GDScriptFunction::OPCODE_JUMP);
+					codegen.append(codegen.opcodes.size() + 3);
 					codegen.opcodes.write[jump_fail_pos] = codegen.opcodes.size();
 					codegen.opcodes.write[jump_fail_pos2] = codegen.opcodes.size();
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_FALSE);
-					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-					return p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
+					codegen.append(GDScriptFunction::OPCODE_ASSIGN_FALSE);
+					codegen.append(GDScriptCodeGenerator::StackAddress(p_stack_level));
+					return GDScriptCodeGenerator::StackAddress(p_stack_level);
 
 				} break;
 				case GDScriptParser::OperatorNode::OP_OR: {
 					// OR operator with early out on success
 
-					int res = _parse_expression(codegen, on->arguments[0], p_stack_level);
-					if (res < 0) {
+					auto res = _parse_expression(codegen, on->arguments[0], p_stack_level);
+					if (!res) {
 						return res;
 					}
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF);
-					codegen.opcodes.push_back(res);
+					codegen.append(GDScriptFunction::OPCODE_JUMP_IF);
+					codegen.append(res);
 					int jump_success_pos = codegen.opcodes.size();
-					codegen.opcodes.push_back(0);
+					codegen.append(0);
 
 					res = _parse_expression(codegen, on->arguments[1], p_stack_level);
-					if (res < 0) {
+					if (!res) {
 						return res;
 					}
 
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF);
-					codegen.opcodes.push_back(res);
+					codegen.append(GDScriptFunction::OPCODE_JUMP_IF);
+					codegen.append(res);
 					int jump_success_pos2 = codegen.opcodes.size();
-					codegen.opcodes.push_back(0);
+					codegen.append(0);
 
 					codegen.alloc_stack(p_stack_level); //it will be used..
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_FALSE);
-					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-					codegen.opcodes.push_back(codegen.opcodes.size() + 3);
+					codegen.append(GDScriptFunction::OPCODE_ASSIGN_FALSE);
+					codegen.append(GDScriptCodeGenerator::StackAddress(p_stack_level));
+					codegen.append(GDScriptFunction::OPCODE_JUMP);
+					codegen.append(codegen.opcodes.size() + 3);
 					codegen.opcodes.write[jump_success_pos] = codegen.opcodes.size();
 					codegen.opcodes.write[jump_success_pos2] = codegen.opcodes.size();
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_TRUE);
-					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-					return p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
+					codegen.append(GDScriptFunction::OPCODE_ASSIGN_TRUE);
+					codegen.append(GDScriptCodeGenerator::StackAddress(p_stack_level));
+					return GDScriptCodeGenerator::StackAddress(p_stack_level);
 
 				} break;
 				// ternary operators
 				case GDScriptParser::OperatorNode::OP_TERNARY_IF: {
 					// x IF a ELSE y operator with early out on failure
 
-					int res = _parse_expression(codegen, on->arguments[0], p_stack_level);
-					if (res < 0) {
+					auto res = _parse_expression(codegen, on->arguments[0], p_stack_level);
+					if (!res) {
 						return res;
 					}
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-					codegen.opcodes.push_back(res);
+					codegen.append(GDScriptFunction::OPCODE_JUMP_IF_NOT);
+					codegen.append(res);
 					int jump_fail_pos = codegen.opcodes.size();
-					codegen.opcodes.push_back(0);
+					codegen.append(0);
 
 					res = _parse_expression(codegen, on->arguments[1], p_stack_level);
-					if (res < 0) {
+					if (!res) {
 						return res;
 					}
 
 					codegen.alloc_stack(p_stack_level); //it will be used..
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN);
-					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-					codegen.opcodes.push_back(res);
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
+					codegen.append(GDScriptFunction::OPCODE_ASSIGN);
+					codegen.append(GDScriptCodeGenerator::StackAddress(p_stack_level));
+					codegen.append(res);
+					codegen.append(GDScriptFunction::OPCODE_JUMP);
 					int jump_past_pos = codegen.opcodes.size();
-					codegen.opcodes.push_back(0);
+					codegen.append(0);
 
 					codegen.opcodes.write[jump_fail_pos] = codegen.opcodes.size();
 					res = _parse_expression(codegen, on->arguments[2], p_stack_level);
-					if (res < 0) {
+					if (!res) {
 						return res;
 					}
 
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN);
-					codegen.opcodes.push_back(p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-					codegen.opcodes.push_back(res);
+					codegen.append(GDScriptFunction::OPCODE_ASSIGN);
+					codegen.append(GDScriptCodeGenerator::StackAddress(p_stack_level));
+					codegen.append(res);
 
 					codegen.opcodes.write[jump_past_pos] = codegen.opcodes.size();
 
-					return p_stack_level | GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS;
+					return GDScriptCodeGenerator::StackAddress(p_stack_level);
 
 				} break;
 				//unary operators
 				case GDScriptParser::OperatorNode::OP_NEG: {
 					if (!_create_unary_operator(codegen, on, Variant::OP_NEGATE, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_POS: {
 					if (!_create_unary_operator(codegen, on, Variant::OP_POSITIVE, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_NOT: {
 					if (!_create_unary_operator(codegen, on, Variant::OP_NOT, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_BIT_INVERT: {
 					if (!_create_unary_operator(codegen, on, Variant::OP_BIT_NEGATE, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				//binary operators (in precedence order)
 				case GDScriptParser::OperatorNode::OP_IN: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_IN, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_EQUAL: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_EQUAL, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_NOT_EQUAL: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_NOT_EQUAL, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_LESS: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_LESS, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_LESS_EQUAL: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_LESS_EQUAL, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_GREATER: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_GREATER, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_GREATER_EQUAL: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_GREATER_EQUAL, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_ADD: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_ADD, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_SUB: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_SUBTRACT, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_MUL: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_MULTIPLY, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_DIV: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_DIVIDE, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_MOD: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_MODULE, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
-				//case GDScriptParser::OperatorNode::OP_SHIFT_LEFT: { if (!_create_binary_operator(codegen,on,Variant::OP_SHIFT_LEFT,p_stack_level)) return -1;} break;
-				//case GDScriptParser::OperatorNode::OP_SHIFT_RIGHT: { if (!_create_binary_operator(codegen,on,Variant::OP_SHIFT_RIGHT,p_stack_level)) return -1;} break;
+				//case GDScriptParser::OperatorNode::OP_SHIFT_LEFT: { if (!_create_binary_operator(codegen,on,Variant::OP_SHIFT_LEFT,p_stack_level)) return GDScriptCodeGenerator::Address::INVALID;} break;
+				//case GDScriptParser::OperatorNode::OP_SHIFT_RIGHT: { if (!_create_binary_operator(codegen,on,Variant::OP_SHIFT_RIGHT,p_stack_level)) return GDScriptCodeGenerator::Address::INVALID;} break;
 				case GDScriptParser::OperatorNode::OP_BIT_AND: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_BIT_AND, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_BIT_OR: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_BIT_OR, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_BIT_XOR: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_BIT_XOR, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				//shift
 				case GDScriptParser::OperatorNode::OP_SHIFT_LEFT: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_SHIFT_LEFT, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_SHIFT_RIGHT: {
 					if (!_create_binary_operator(codegen, on, Variant::OP_SHIFT_RIGHT, p_stack_level)) {
-						return -1;
+						return GDScriptCodeGenerator::Address::INVALID;
 					}
 				} break;
 				//assignment operators
@@ -998,7 +1002,7 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 				case GDScriptParser::OperatorNode::OP_ASSIGN_BIT_XOR:
 				case GDScriptParser::OperatorNode::OP_INIT_ASSIGN:
 				case GDScriptParser::OperatorNode::OP_ASSIGN: {
-					ERR_FAIL_COND_V(on->arguments.size() != 2, -1);
+					ERR_FAIL_COND_V(on->arguments.size() != 2, GDScriptCodeGenerator::Address::INVALID);
 
 					if (on->arguments[0]->type == GDScriptParser::Node::TYPE_OPERATOR && (static_cast<GDScriptParser::OperatorNode *>(on->arguments[0])->op == GDScriptParser::OperatorNode::OP_INDEX || static_cast<GDScriptParser::OperatorNode *>(on->arguments[0])->op == GDScriptParser::OperatorNode::OP_INDEX_NAMED)) {
 						// SET (chained) MODE!
@@ -1011,7 +1015,7 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 								if (MI && MI->get().setter == codegen.function_node->name) {
 									String n = static_cast<GDScriptParser::IdentifierNode *>(inon->arguments[1])->name;
 									_set_error("Must use '" + n + "' instead of 'self." + n + "' in setter.", inon);
-									return -1;
+									return GDScriptCodeGenerator::Address::INVALID;
 								}
 							}
 						}
@@ -1052,112 +1056,152 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 						/* Chain of gets */
 
 						//get at (potential) root stack pos, so it can be returned
-						int prev_pos = _parse_expression(codegen, chain.back()->get()->arguments[0], slevel);
-						if (prev_pos < 0) {
-							return prev_pos;
-						}
-						int retval = prev_pos;
+						const auto retval = _parse_expression(codegen, chain.back()->get()->arguments[0], slevel);
+						auto prev_base = retval;
 
-						if (retval & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-							slevel++;
-							codegen.alloc_stack(slevel);
-						}
+						ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(codegen, retval, slevel);
 
-						Vector<int> setchain;
+						struct ChainInfo {
+							bool is_named = false;
+							GDScriptCodeGenerator::Address base = GDScriptCodeGenerator::Address::INVALID;
+							GDScriptCodeGenerator::Address key = GDScriptCodeGenerator::Address::INVALID;
+							StringName name;
+						};
 
-						if (assign_property != StringName()) {
-							// recover and assign at the end, this allows stuff like
-							// position.x+=2.0
-							// in Node2D
-							setchain.push_back(prev_pos);
-							setchain.push_back(codegen.get_name_map_pos(assign_property));
-							setchain.push_back(GDScriptFunction::OPCODE_SET_MEMBER);
-						}
+						List<ChainInfo> setchain;
 
 						for (List<GDScriptParser::OperatorNode *>::Element *E = chain.back(); E; E = E->prev()) {
 							if (E == chain.front()) { //ignore first
 								break;
 							}
 
-							bool named = E->get()->op == GDScriptParser::OperatorNode::OP_INDEX_NAMED;
-							int key_idx;
+							GDScriptCodeGenerator::Address key_idx = GDScriptCodeGenerator::Address::INVALID;
+							bool is_named = E->get()->op == GDScriptParser::OperatorNode::OP_INDEX_NAMED;
+							StringName name;
 
-							if (named) {
-								key_idx = codegen.get_name_map_pos(static_cast<const GDScriptParser::IdentifierNode *>(E->get()->arguments[1])->name);
-								//printf("named key %x\n",key_idx);
-
+							if (is_named) {
+								name = static_cast<const GDScriptParser::IdentifierNode *>(E->get()->arguments[1])->name;
 							} else {
-								if (prev_pos & (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS)) {
-									slevel++;
-									codegen.alloc_stack(slevel);
-								}
-
 								GDScriptParser::Node *key = E->get()->arguments[1];
 								key_idx = _parse_expression(codegen, key, slevel);
-								//printf("expr key %x\n",key_idx);
 
-								//stack was raised here if retval was stack but..
+								// if key_idx was a stack value...
+								ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(codegen, key_idx, slevel);
 							}
 
-							if (key_idx < 0) { //error
-								return key_idx;
+							auto dst_pos = GDScriptCodeGenerator::StackAddress(slevel);
+
+							codegen.append(is_named ? GDScriptFunction::OPCODE_GET_NAMED : GDScriptFunction::OPCODE_GET);
+							codegen.append(prev_base);
+							codegen.append(is_named ? codegen.get_name_map_pos(name) : codegen.address_of(key_idx));
+							codegen.append(dst_pos);
+
+#ifdef DEBUG_CHAINED_SETGET
+							if (is_named) {
+								printf("get named: src = %ls, idx = named(%d, %ls), dst = %ls\n",
+										to_string(prev_base).c_str(),
+										codegen.get_name_map_pos(name),
+										String(name).c_str(),
+										to_string(dst_pos).c_str());
+							} else {
+								printf("get: src = %ls, idx = %ls, dst = %ls\n",
+										to_string(prev_base).c_str(),
+										to_string(key_idx).c_str(),
+										to_string(dst_pos).c_str());
+							}
+#endif
+
+							setchain.push_back({ is_named, prev_base, key_idx, name });
+							prev_base = dst_pos;
+
+							// if the previous position was a stack value, save it for reuse
+							if (codegen.adjust_stack_level(prev_base, slevel)) {
+								codegen.alloc_stack(slevel);
+							}
+						}
+
+						{ // Perform the assignment.
+							GDScriptCodeGenerator::Address set_index = GDScriptCodeGenerator::Address::INVALID;
+							bool is_named = op->op == GDScriptParser::OperatorNode::OP_INDEX_NAMED;
+							StringName name;
+
+							if (is_named) {
+								name = static_cast<const GDScriptParser::IdentifierNode *>(op->arguments[1])->name;
+							} else {
+								set_index = _parse_expression(codegen, op->arguments[1], slevel);
+								ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(codegen, set_index, slevel);
 							}
 
-							codegen.opcodes.push_back(named ? GDScriptFunction::OPCODE_GET_NAMED : GDScriptFunction::OPCODE_GET);
-							codegen.opcodes.push_back(prev_pos);
-							codegen.opcodes.push_back(key_idx);
-							slevel++;
-							codegen.alloc_stack(slevel);
-							int dst_pos = (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) | slevel;
+							auto set_value = _parse_assign_right_expression(codegen, on, slevel, is_named ? GDScriptCodeGenerator::Address::INVALID : set_index);
+							if (!set_value) { //error
+								return set_value;
+							}
 
-							codegen.opcodes.push_back(dst_pos);
+							codegen.append(is_named ? GDScriptFunction::OPCODE_SET_NAMED : GDScriptFunction::OPCODE_SET);
+							codegen.append(prev_base);
+							codegen.append(is_named ? codegen.get_name_map_pos(name) : codegen.address_of(set_index));
+							codegen.append(set_value);
 
-							//add in reverse order, since it will be reverted
-
-							setchain.push_back(dst_pos);
-							setchain.push_back(key_idx);
-							setchain.push_back(prev_pos);
-							setchain.push_back(named ? GDScriptFunction::OPCODE_SET_NAMED : GDScriptFunction::OPCODE_SET);
-
-							prev_pos = dst_pos;
+#ifdef DEBUG_CHAINED_SETGET
+							if (is_named) {
+								printf("> set named: dst = %ls, idx = named(%d, %ls), val = %ls\n",
+										to_string(prev_base).c_str(),
+										codegen.get_name_map_pos(name),
+										String(name).c_str(),
+										to_string(set_value).c_str());
+							} else {
+								printf("> set: dst = %ls, idx = %ls, val = %ls\n",
+										to_string(prev_base).c_str(),
+										to_string(set_index).c_str(),
+										to_string(set_value).c_str());
+							}
+#endif
 						}
 
-						setchain.invert();
+						// Set back the values into their bases (iterate in reverse).
+						for (const List<ChainInfo>::Element *E = setchain.back(); E; E = E->prev()) {
+							const ChainInfo &info = E->get();
 
-						int set_index;
-						bool named = false;
+#ifdef DEBUG_CHAINED_SETGET
+							if (info.is_named) {
+								printf("set named: dst = %ls, idx = named(%d, %ls), val = %ls\n",
+										to_string(info.base).c_str(),
+										codegen.get_name_map_pos(info.name),
+										String(info.name).c_str(),
+										to_string(prev_base).c_str());
+							} else {
+								printf("set: dst = %ls, idx = %ls, val = %ls\n",
+										to_string(info.base).c_str(),
+										to_string(info.key).c_str(),
+										to_string(prev_base).c_str());
+							}
+#endif
 
-						if (op->op == GDScriptParser::OperatorNode::OP_INDEX_NAMED) {
-							set_index = codegen.get_name_map_pos(static_cast<const GDScriptParser::IdentifierNode *>(op->arguments[1])->name);
-							named = true;
-						} else {
-							set_index = _parse_expression(codegen, op->arguments[1], slevel + 1);
-							named = false;
+							codegen.append(info.is_named ? GDScriptFunction::OPCODE_SET_NAMED : GDScriptFunction::OPCODE_SET);
+							codegen.append(info.base);
+							codegen.append(info.is_named ? codegen.get_name_map_pos(info.name) : codegen.address_of(info.key));
+							codegen.append(prev_base);
+							prev_base = info.base;
 						}
 
-						if (set_index < 0) { //error
-							return set_index;
+						// If this is a property, also assign to it.
+						// This allows things like: position.x += 2.0
+						if (assign_property) {
+							codegen.append(GDScriptFunction::OPCODE_SET_MEMBER);
+							codegen.append(codegen.get_name_map_pos(assign_property));
+							codegen.append(retval);
+
+#ifdef DEBUG_CHAINED_SETGET
+							printf("set member: idx = named(%d, %ls), val = %ls\n",
+									codegen.get_name_map_pos(assign_property),
+									String(assign_property).c_str(),
+									to_string(retval).c_str());
+#endif
 						}
 
-						if (set_index & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-							slevel++;
-							codegen.alloc_stack(slevel);
-						}
-
-						int set_value = _parse_assign_right_expression(codegen, on, slevel + 1, named ? 0 : set_index);
-						if (set_value < 0) { //error
-							return set_value;
-						}
-
-						codegen.opcodes.push_back(named ? GDScriptFunction::OPCODE_SET_NAMED : GDScriptFunction::OPCODE_SET);
-						codegen.opcodes.push_back(prev_pos);
-						codegen.opcodes.push_back(set_index);
-						codegen.opcodes.push_back(set_value);
-
-						for (int i = 0; i < setchain.size(); i++) {
-							codegen.opcodes.push_back(setchain[i]);
-						}
-
+#ifdef DEBUG_CHAINED_SETGET
+						printf("\n");
+#endif
 						return retval;
 
 					} else if (on->arguments[0]->type == GDScriptParser::Node::TYPE_IDENTIFIER && _is_class_member_property(codegen, static_cast<GDScriptParser::IdentifierNode *>(on->arguments[0])->name)) {
@@ -1165,37 +1209,28 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 
 						int slevel = p_stack_level;
 
-						int src_address = _parse_assign_right_expression(codegen, on, slevel);
-						if (src_address < 0) {
-							return -1;
+						auto src_address = _parse_assign_right_expression(codegen, on, slevel);
+						if (!src_address) {
+							return GDScriptCodeGenerator::Address::INVALID;
 						}
 
 						StringName name = static_cast<GDScriptParser::IdentifierNode *>(on->arguments[0])->name;
 
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_SET_MEMBER);
-						codegen.opcodes.push_back(codegen.get_name_map_pos(name));
-						codegen.opcodes.push_back(src_address);
+						codegen.append(GDScriptFunction::OPCODE_SET_MEMBER);
+						codegen.append(codegen.get_name_map_pos(name));
+						codegen.append(src_address);
 
-						return GDScriptFunction::ADDR_TYPE_NIL << GDScriptFunction::ADDR_BITS;
+						return GDScriptCodeGenerator::Address::NIL;
 					} else {
 						//REGULAR ASSIGNMENT MODE!!
 
 						int slevel = p_stack_level;
 
-						int dst_address_a = _parse_expression(codegen, on->arguments[0], slevel, false, on->op == GDScriptParser::OperatorNode::OP_INIT_ASSIGN);
-						if (dst_address_a < 0) {
-							return -1;
-						}
+						auto dst_address_a = _parse_expression(codegen, on->arguments[0], slevel, false, on->op == GDScriptParser::OperatorNode::OP_INIT_ASSIGN);
+						ADJUST_AND_ALLOC_STACK_LEVEL_OR_RETURN(codegen, dst_address_a, slevel);
 
-						if (dst_address_a & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-							slevel++;
-							codegen.alloc_stack(slevel);
-						}
-
-						int src_address_b = _parse_assign_right_expression(codegen, on, slevel);
-						if (src_address_b < 0) {
-							return -1;
-						}
+						auto src_address_b = _parse_assign_right_expression(codegen, on, slevel);
+						ADJUST_STACK_LEVEL_OR_RETURN(codegen, src_address_b, slevel);
 
 						GDScriptDataType assign_type = _gdtype_from_datatype(on->arguments[0]->get_datatype());
 
@@ -1203,113 +1238,95 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 							// Typed assignment
 							switch (assign_type.kind) {
 								case GDScriptDataType::BUILTIN: {
-									codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_TYPED_BUILTIN); // perform operator
-									codegen.opcodes.push_back(assign_type.builtin_type); // variable type
-									codegen.opcodes.push_back(dst_address_a); // argument 1
-									codegen.opcodes.push_back(src_address_b); // argument 2
+									codegen.append(GDScriptFunction::OPCODE_ASSIGN_TYPED_BUILTIN); // perform operator
+									codegen.append(assign_type.builtin_type); // variable type
+									codegen.append(dst_address_a); // argument 1
+									codegen.append(src_address_b); // argument 2
 								} break;
 								case GDScriptDataType::NATIVE: {
-									int class_idx;
-									if (GDScriptLanguage::get_singleton()->get_global_map().has(assign_type.native_type)) {
-										class_idx = GDScriptLanguage::get_singleton()->get_global_map()[assign_type.native_type];
-										class_idx |= (GDScriptFunction::ADDR_TYPE_GLOBAL << GDScriptFunction::ADDR_BITS); //argument (stack root)
-									} else {
+									if (!GDScriptLanguage::get_singleton()->get_global_map().has(assign_type.native_type)) {
 										_set_error("Invalid native class type '" + String(assign_type.native_type) + "'.", on->arguments[0]);
-										return -1;
+										return GDScriptCodeGenerator::Address::INVALID;
 									}
-									codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_TYPED_NATIVE); // perform operator
-									codegen.opcodes.push_back(class_idx); // variable type
-									codegen.opcodes.push_back(dst_address_a); // argument 1
-									codegen.opcodes.push_back(src_address_b); // argument 2
+									int class_idx = GDScriptLanguage::get_singleton()->get_global_map()[assign_type.native_type];
+									codegen.append(GDScriptFunction::OPCODE_ASSIGN_TYPED_NATIVE); // perform operator
+									codegen.append(GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::GLOBAL, class_idx)); // variable type
+									codegen.append(dst_address_a); // argument 1
+									codegen.append(src_address_b); // argument 2
 								} break;
 								case GDScriptDataType::SCRIPT:
 								case GDScriptDataType::GDSCRIPT: {
 									Variant script = assign_type.script_type;
-									int idx = codegen.get_constant_pos(script);
-									idx |= GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS; //make it a local constant (faster access)
-
-									codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN_TYPED_SCRIPT); // perform operator
-									codegen.opcodes.push_back(idx); // variable type
-									codegen.opcodes.push_back(dst_address_a); // argument 1
-									codegen.opcodes.push_back(src_address_b); // argument 2
+									int idx = codegen.get_constant_pos(script); //make it a local constant for faster access
+									codegen.append(GDScriptFunction::OPCODE_ASSIGN_TYPED_SCRIPT); // perform operator
+									codegen.append(GDScriptCodeGenerator::Address(GDScriptCodeGenerator::Address::LOCAL_CONSTANT, idx)); // variable type
+									codegen.append(dst_address_a); // argument 1
+									codegen.append(src_address_b); // argument 2
 								} break;
 								default: {
 									ERR_PRINT("Compiler bug: unresolved assign.");
 
 									// Shouldn't get here, but fail-safe to a regular assignment
-									codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN); // perform operator
-									codegen.opcodes.push_back(dst_address_a); // argument 1
-									codegen.opcodes.push_back(src_address_b); // argument 2 (unary only takes one parameter)
+									codegen.append(GDScriptFunction::OPCODE_ASSIGN); // perform operator
+									codegen.append(dst_address_a); // argument 1
+									codegen.append(src_address_b); // argument 2 (unary only takes one parameter)
 								}
 							}
 						} else {
 							// Either untyped assignment or already type-checked by the parser
-							codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN); // perform operator
-							codegen.opcodes.push_back(dst_address_a); // argument 1
-							codegen.opcodes.push_back(src_address_b); // argument 2 (unary only takes one parameter)
+							codegen.append(GDScriptFunction::OPCODE_ASSIGN); // perform operator
+							codegen.append(dst_address_a); // argument 1
+							codegen.append(src_address_b); // argument 2 (unary only takes one parameter)
 						}
+
 						return dst_address_a; //if anything, returns whatever was assigned or correct stack position
 					}
 				} break;
 				case GDScriptParser::OperatorNode::OP_IS: {
-					ERR_FAIL_COND_V(on->arguments.size() != 2, false);
+					ERR_FAIL_COND_V(on->arguments.size() != 2, GDScriptCodeGenerator::Address::INVALID);
 
 					int slevel = p_stack_level;
 
-					int src_address_a = _parse_expression(codegen, on->arguments[0], slevel);
-					if (src_address_a < 0) {
-						return -1;
-					}
+					auto src_address_a = _parse_expression(codegen, on->arguments[0], slevel);
+					ADJUST_STACK_LEVEL_OR_RETURN(codegen, src_address_a, slevel); //uses stack for return, increase stack
 
-					if (src_address_a & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-						slevel++; //uses stack for return, increase stack
-					}
+					auto src_address_b = _parse_expression(codegen, on->arguments[1], slevel);
+					ADJUST_STACK_LEVEL_OR_RETURN(codegen, src_address_b, slevel); //uses stack for return, increase stack
 
-					int src_address_b = _parse_expression(codegen, on->arguments[1], slevel);
-					if (src_address_b < 0) {
-						return -1;
-					}
-
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_EXTENDS_TEST); // perform operator
-					codegen.opcodes.push_back(src_address_a); // argument 1
-					codegen.opcodes.push_back(src_address_b); // argument 2 (unary only takes one parameter)
+					codegen.append(GDScriptFunction::OPCODE_EXTENDS_TEST); // perform operator
+					codegen.append(src_address_a); // argument 1
+					codegen.append(src_address_b); // argument 2 (unary only takes one parameter)
 
 				} break;
 				case GDScriptParser::OperatorNode::OP_IS_BUILTIN: {
-					ERR_FAIL_COND_V(on->arguments.size() != 2, false);
-					ERR_FAIL_COND_V(on->arguments[1]->type != GDScriptParser::Node::TYPE_TYPE, false);
+					ERR_FAIL_COND_V(on->arguments.size() != 2, GDScriptCodeGenerator::Address::INVALID);
+					ERR_FAIL_COND_V(on->arguments[1]->type != GDScriptParser::Node::TYPE_TYPE, GDScriptCodeGenerator::Address::INVALID);
 
 					int slevel = p_stack_level;
 
-					int src_address_a = _parse_expression(codegen, on->arguments[0], slevel);
-					if (src_address_a < 0) {
-						return -1;
-					}
-
-					if (src_address_a & GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) {
-						slevel++; //uses stack for return, increase stack
-					}
+					auto src_address_a = _parse_expression(codegen, on->arguments[0], slevel);
+					codegen.adjust_stack_level(src_address_a, slevel); //uses stack for return, increase stack
 
 					const GDScriptParser::TypeNode *tn = static_cast<const GDScriptParser::TypeNode *>(on->arguments[1]);
 
-					codegen.opcodes.push_back(GDScriptFunction::OPCODE_IS_BUILTIN); // perform operator
-					codegen.opcodes.push_back(src_address_a); // argument 1
-					codegen.opcodes.push_back((int)tn->vtype); // argument 2 (unary only takes one parameter)
+					codegen.append(GDScriptFunction::OPCODE_IS_BUILTIN); // perform operator
+					codegen.append(src_address_a); // argument 1
+					codegen.append((int)tn->vtype); // argument 2 (unary only takes one parameter)
 				} break;
 				default: {
-					ERR_FAIL_V_MSG(0, "Bug in bytecode compiler, unexpected operator #" + itos(on->op) + " in parse tree while parsing expression."); //unreachable code
+					ERR_FAIL_V_MSG(GDScriptCodeGenerator::Address::INVALID, "Bug in bytecode compiler, unexpected operator #" + itos(on->op) + " in parse tree while parsing expression."); //unreachable code
 
 				} break;
 			}
 
-			int dst_addr = (p_stack_level) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-			codegen.opcodes.push_back(dst_addr); // append the stack level as destination address of the opcode
+			auto dst_addr = GDScriptCodeGenerator::StackAddress(p_stack_level);
+			codegen.append(dst_addr); // append the stack level as destination address of the opcode
 			codegen.alloc_stack(p_stack_level);
 			return dst_addr;
 		} break;
 		//TYPE_TYPE,
 		default: {
-			ERR_FAIL_V_MSG(-1, "Bug in bytecode compiler, unexpected node in parse tree while parsing expression."); //unreachable code
+			ERR_FAIL_V_MSG(GDScriptCodeGenerator::Address::INVALID, "Bug in bytecode compiler, unexpected node in parse tree while parsing expression."); //unreachable code
 		} break;
 	}
 }
@@ -1325,8 +1342,8 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 			case GDScriptParser::Node::TYPE_NEWLINE: {
 #ifdef DEBUG_ENABLED
 				const GDScriptParser::NewLineNode *nl = static_cast<const GDScriptParser::NewLineNode *>(s);
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_LINE);
-				codegen.opcodes.push_back(nl->line);
+				codegen.append(GDScriptFunction::OPCODE_LINE);
+				codegen.append(nl->line);
 				codegen.current_line = nl->line;
 #endif
 			} break;
@@ -1352,19 +1369,19 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 						op->arguments.push_back(id);
 						op->arguments.push_back(match->val_to_match);
 
-						int ret = _parse_expression(codegen, op, p_stack_level);
-						if (ret < 0) {
+						auto ret = _parse_expression(codegen, op, p_stack_level);
+						if (!ret) {
 							memdelete(id);
 							memdelete(op);
 							return ERR_PARSE_ERROR;
 						}
 
 						// break address
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-						codegen.opcodes.push_back(codegen.opcodes.size() + 3);
+						codegen.append(GDScriptFunction::OPCODE_JUMP);
+						codegen.append(codegen.opcodes.size() + 3);
 						int break_addr = codegen.opcodes.size();
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-						codegen.opcodes.push_back(0); // break addr
+						codegen.append(GDScriptFunction::OPCODE_JUMP);
+						codegen.append(0); // break addr
 
 						for (int j = 0; j < match->compiled_pattern_branches.size(); j++) {
 							GDScriptParser::MatchNode::CompiledPatternBranch branch = match->compiled_pattern_branches[j];
@@ -1373,19 +1390,19 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 							// jump unconditionally
 							// continue address
 							// compile the condition
-							int ret2 = _parse_expression(codegen, branch.compiled_pattern, p_stack_level);
-							if (ret2 < 0) {
+							auto ret2 = _parse_expression(codegen, branch.compiled_pattern, p_stack_level);
+							if (!ret2) {
 								memdelete(id);
 								memdelete(op);
 								return ERR_PARSE_ERROR;
 							}
 
-							codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF);
-							codegen.opcodes.push_back(ret2);
-							codegen.opcodes.push_back(codegen.opcodes.size() + 3);
+							codegen.append(GDScriptFunction::OPCODE_JUMP_IF);
+							codegen.append(ret2);
+							codegen.append(codegen.opcodes.size() + 3);
 							int continue_addr = codegen.opcodes.size();
-							codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-							codegen.opcodes.push_back(0);
+							codegen.append(GDScriptFunction::OPCODE_JUMP);
+							codegen.append(0);
 
 							Error err = _parse_block(codegen, branch.body, p_stack_level, p_break_addr, continue_addr);
 							if (err) {
@@ -1394,8 +1411,8 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 								return ERR_PARSE_ERROR;
 							}
 
-							codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-							codegen.opcodes.push_back(break_addr);
+							codegen.append(GDScriptFunction::OPCODE_JUMP);
+							codegen.append(break_addr);
 
 							codegen.opcodes.write[continue_addr + 1] = codegen.opcodes.size();
 						}
@@ -1408,15 +1425,15 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 					} break;
 
 					case GDScriptParser::ControlFlowNode::CF_IF: {
-						int ret2 = _parse_expression(codegen, cf->arguments[0], p_stack_level, false);
-						if (ret2 < 0) {
+						auto ret2 = _parse_expression(codegen, cf->arguments[0], p_stack_level, false);
+						if (!ret2) {
 							return ERR_PARSE_ERROR;
 						}
 
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-						codegen.opcodes.push_back(ret2);
+						codegen.append(GDScriptFunction::OPCODE_JUMP_IF_NOT);
+						codegen.append(ret2);
 						int else_addr = codegen.opcodes.size();
-						codegen.opcodes.push_back(0); //temporary
+						codegen.append(0); //temporary
 
 						Error err = _parse_block(codegen, cf->body, p_stack_level, p_break_addr, p_continue_addr);
 						if (err) {
@@ -1424,13 +1441,13 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 						}
 
 						if (cf->body_else) {
-							codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
+							codegen.append(GDScriptFunction::OPCODE_JUMP);
 							int end_addr = codegen.opcodes.size();
-							codegen.opcodes.push_back(0);
+							codegen.append(0);
 							codegen.opcodes.write[else_addr] = codegen.opcodes.size();
 
-							codegen.opcodes.push_back(GDScriptFunction::OPCODE_LINE);
-							codegen.opcodes.push_back(cf->body_else->line);
+							codegen.append(GDScriptFunction::OPCODE_LINE);
+							codegen.append(cf->body_else->line);
 							codegen.current_line = cf->body_else->line;
 
 							Error err2 = _parse_block(codegen, cf->body_else, p_stack_level, p_break_addr, p_continue_addr);
@@ -1448,115 +1465,115 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 					case GDScriptParser::ControlFlowNode::CF_FOR: {
 						int slevel = p_stack_level;
 						int iter_stack_pos = slevel;
-						int iterator_pos = (slevel++) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-						int counter_pos = (slevel++) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
-						int container_pos = (slevel++) | (GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS);
+						auto iterator_pos = GDScriptCodeGenerator::StackAddress(slevel++);
+						auto counter_pos = GDScriptCodeGenerator::StackAddress(slevel++);
+						auto container_pos = GDScriptCodeGenerator::StackAddress(slevel++);
 						codegen.alloc_stack(slevel);
 
 						codegen.push_stack_identifiers();
 						codegen.add_stack_identifier(static_cast<const GDScriptParser::IdentifierNode *>(cf->arguments[0])->name, iter_stack_pos);
 
-						int ret2 = _parse_expression(codegen, cf->arguments[1], slevel, false);
-						if (ret2 < 0) {
+						auto ret2 = _parse_expression(codegen, cf->arguments[1], slevel, false);
+						if (!ret2) {
 							return ERR_COMPILATION_FAILED;
 						}
 
 						//assign container
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSIGN);
-						codegen.opcodes.push_back(container_pos);
-						codegen.opcodes.push_back(ret2);
+						codegen.append(GDScriptFunction::OPCODE_ASSIGN);
+						codegen.append(container_pos);
+						codegen.append(ret2);
 
 						//begin loop
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_ITERATE_BEGIN);
-						codegen.opcodes.push_back(counter_pos);
-						codegen.opcodes.push_back(container_pos);
-						codegen.opcodes.push_back(codegen.opcodes.size() + 4);
-						codegen.opcodes.push_back(iterator_pos);
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP); //skip code for next
-						codegen.opcodes.push_back(codegen.opcodes.size() + 8);
+						codegen.append(GDScriptFunction::OPCODE_ITERATE_BEGIN);
+						codegen.append(counter_pos);
+						codegen.append(container_pos);
+						codegen.append(codegen.opcodes.size() + 4);
+						codegen.append(iterator_pos);
+						codegen.append(GDScriptFunction::OPCODE_JUMP); //skip code for next
+						codegen.append(codegen.opcodes.size() + 8);
 						//break loop
 						int break_pos = codegen.opcodes.size();
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP); //skip code for next
-						codegen.opcodes.push_back(0); //skip code for next
+						codegen.append(GDScriptFunction::OPCODE_JUMP); //skip code for next
+						codegen.append(0); //skip code for next
 						//next loop
 						int continue_pos = codegen.opcodes.size();
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_ITERATE);
-						codegen.opcodes.push_back(counter_pos);
-						codegen.opcodes.push_back(container_pos);
-						codegen.opcodes.push_back(break_pos);
-						codegen.opcodes.push_back(iterator_pos);
+						codegen.append(GDScriptFunction::OPCODE_ITERATE);
+						codegen.append(counter_pos);
+						codegen.append(container_pos);
+						codegen.append(break_pos);
+						codegen.append(iterator_pos);
 
 						Error err = _parse_block(codegen, cf->body, slevel, break_pos, continue_pos);
 						if (err) {
 							return err;
 						}
 
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-						codegen.opcodes.push_back(continue_pos);
+						codegen.append(GDScriptFunction::OPCODE_JUMP);
+						codegen.append(continue_pos);
 						codegen.opcodes.write[break_pos + 1] = codegen.opcodes.size();
 
 						codegen.pop_stack_identifiers();
 
 					} break;
 					case GDScriptParser::ControlFlowNode::CF_WHILE: {
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-						codegen.opcodes.push_back(codegen.opcodes.size() + 3);
+						codegen.append(GDScriptFunction::OPCODE_JUMP);
+						codegen.append(codegen.opcodes.size() + 3);
 						int break_addr = codegen.opcodes.size();
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-						codegen.opcodes.push_back(0);
+						codegen.append(GDScriptFunction::OPCODE_JUMP);
+						codegen.append(0);
 						int continue_addr = codegen.opcodes.size();
 
-						int ret2 = _parse_expression(codegen, cf->arguments[0], p_stack_level, false);
-						if (ret2 < 0) {
+						auto ret2 = _parse_expression(codegen, cf->arguments[0], p_stack_level, false);
+						if (!ret2) {
 							return ERR_PARSE_ERROR;
 						}
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_IF_NOT);
-						codegen.opcodes.push_back(ret2);
-						codegen.opcodes.push_back(break_addr);
+						codegen.append(GDScriptFunction::OPCODE_JUMP_IF_NOT);
+						codegen.append(ret2);
+						codegen.append(break_addr);
 						Error err = _parse_block(codegen, cf->body, p_stack_level, break_addr, continue_addr);
 						if (err) {
 							return err;
 						}
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-						codegen.opcodes.push_back(continue_addr);
+						codegen.append(GDScriptFunction::OPCODE_JUMP);
+						codegen.append(continue_addr);
 
 						codegen.opcodes.write[break_addr + 1] = codegen.opcodes.size();
 
 					} break;
 					case GDScriptParser::ControlFlowNode::CF_BREAK: {
-						if (p_break_addr < 0) {
+						if (!p_break_addr) {
 							_set_error("'break'' not within loop", cf);
 							return ERR_COMPILATION_FAILED;
 						}
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-						codegen.opcodes.push_back(p_break_addr);
+						codegen.append(GDScriptFunction::OPCODE_JUMP);
+						codegen.append(p_break_addr);
 
 					} break;
 					case GDScriptParser::ControlFlowNode::CF_CONTINUE: {
-						if (p_continue_addr < 0) {
+						if (!p_continue_addr) {
 							_set_error("'continue' not within loop", cf);
 							return ERR_COMPILATION_FAILED;
 						}
 
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP);
-						codegen.opcodes.push_back(p_continue_addr);
+						codegen.append(GDScriptFunction::OPCODE_JUMP);
+						codegen.append(p_continue_addr);
 
 					} break;
 					case GDScriptParser::ControlFlowNode::CF_RETURN: {
-						int ret2;
+						GDScriptCodeGenerator::Address ret2 = GDScriptCodeGenerator::Address::INVALID;
 
 						if (cf->arguments.size()) {
 							ret2 = _parse_expression(codegen, cf->arguments[0], p_stack_level, false);
-							if (ret2 < 0) {
+							if (!ret2) {
 								return ERR_PARSE_ERROR;
 							}
 
 						} else {
-							ret2 = GDScriptFunction::ADDR_TYPE_NIL << GDScriptFunction::ADDR_BITS;
+							ret2 = GDScriptCodeGenerator::Address::NIL;
 						}
 
-						codegen.opcodes.push_back(GDScriptFunction::OPCODE_RETURN);
-						codegen.opcodes.push_back(ret2);
+						codegen.append(GDScriptFunction::OPCODE_RETURN);
+						codegen.append(ret2);
 
 					} break;
 				}
@@ -1567,28 +1584,28 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 
 				const GDScriptParser::AssertNode *as = static_cast<const GDScriptParser::AssertNode *>(s);
 
-				int ret2 = _parse_expression(codegen, as->condition, p_stack_level, false);
-				if (ret2 < 0) {
+				auto ret2 = _parse_expression(codegen, as->condition, p_stack_level, false);
+				if (!ret2) {
 					return ERR_PARSE_ERROR;
 				}
 
-				int message_ret = 0;
+				GDScriptCodeGenerator::Address message_ret = GDScriptCodeGenerator::Address::NIL;
 				if (as->message) {
 					message_ret = _parse_expression(codegen, as->message, p_stack_level + 1, false);
-					if (message_ret < 0) {
+					if (!message_ret) {
 						return ERR_PARSE_ERROR;
 					}
 				}
 
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_ASSERT);
-				codegen.opcodes.push_back(ret2);
-				codegen.opcodes.push_back(message_ret);
+				codegen.append(GDScriptFunction::OPCODE_ASSERT);
+				codegen.append(ret2);
+				codegen.append(message_ret);
 #endif
 			} break;
 			case GDScriptParser::Node::TYPE_BREAKPOINT: {
 #ifdef DEBUG_ENABLED
 				// try subblocks
-				codegen.opcodes.push_back(GDScriptFunction::OPCODE_BREAKPOINT);
+				codegen.append(GDScriptFunction::OPCODE_BREAKPOINT);
 #endif
 			} break;
 			case GDScriptParser::Node::TYPE_LOCAL_VAR: {
@@ -1606,8 +1623,8 @@ Error GDScriptCompiler::_parse_block(CodeGen &codegen, const GDScriptParser::Blo
 			} break;
 			default: {
 				//expression
-				int ret2 = _parse_expression(codegen, s, p_stack_level, true);
-				if (ret2 < 0) {
+				auto ret2 = _parse_expression(codegen, s, p_stack_level, true);
+				if (!ret2) {
 					return ERR_PARSE_ERROR;
 				}
 			} break;
@@ -1659,10 +1676,10 @@ Error GDScriptCompiler::_parse_function(GDScript *p_script, const GDScriptParser
 		//parse initializer for class members
 		if (!p_func && p_class->extends_used && p_script->native.is_null()) {
 			//call implicit parent constructor
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_CALL_SELF_BASE);
-			codegen.opcodes.push_back(codegen.get_name_map_pos("_init"));
-			codegen.opcodes.push_back(0);
-			codegen.opcodes.push_back((GDScriptFunction::ADDR_TYPE_STACK << GDScriptFunction::ADDR_BITS) | 0);
+			codegen.append(GDScriptFunction::OPCODE_CALL_SELF_BASE);
+			codegen.append(codegen.get_name_map_pos("_init"));
+			codegen.append(0);
+			codegen.append(GDScriptCodeGenerator::StackAddress(0));
 		}
 		Error err = _parse_block(codegen, p_class->initializer, stack_level);
 		if (err) {
@@ -1688,7 +1705,7 @@ Error GDScriptCompiler::_parse_function(GDScript *p_script, const GDScriptParser
 
 	if (p_func) {
 		if (p_func->default_values.size()) {
-			codegen.opcodes.push_back(GDScriptFunction::OPCODE_JUMP_TO_DEF_ARGUMENT);
+			codegen.append(GDScriptFunction::OPCODE_JUMP_TO_DEF_ARGUMENT);
 			defarg_addr.push_back(codegen.opcodes.size());
 			for (int i = 0; i < p_func->default_values.size(); i++) {
 				_parse_expression(codegen, p_func->default_values[i], stack_level, true);
@@ -1712,7 +1729,7 @@ Error GDScriptCompiler::_parse_function(GDScript *p_script, const GDScriptParser
 		}
 	}
 
-	codegen.opcodes.push_back(GDScriptFunction::OPCODE_END);
+	codegen.append(GDScriptFunction::OPCODE_END);
 
 	/*
 	if (String(p_func->name)=="") { //initializer func
@@ -2204,13 +2221,11 @@ Error GDScriptCompiler::compile(const GDScriptParser *p_parser, GDScript *p_scri
 
 	p_script->_owner = nullptr;
 	Error err = _parse_class_level(p_script, static_cast<const GDScriptParser::ClassNode *>(root), p_keep_state);
-
 	if (err) {
 		return err;
 	}
 
 	err = _parse_class_blocks(p_script, static_cast<const GDScriptParser::ClassNode *>(root), p_keep_state);
-
 	if (err) {
 		return err;
 	}


### PR DESCRIPTION
I am working on extending the gdscript compiler for some personal 3.x projects and in doing so I've cleaned up some of the gdscript compiler's addressing. 4.0 does similar things here and after some discussion with @vnen we felt that it might be worthwhile to make a PR since I'm doing work in the area anyway for my benefit and it applies well to tidying up 3.x.

### What this patch is:
- strong typing for addresses (they are *not* `int`s)
- normalization of how stack addresses are obtained and incremented when generating gdscript bytecode -- consistency leads to less bugs and makes it easier to maintain
- a fix for sparse addressing in chained set/get (stack addresses are over-zealously incremented and go unused)
- a refactoring that makes sense given the direction and path 4.0 is on
- a new way to represent an `INVALID` address (only at compile time!) that is not also aliased to the special `NIL` address

### What this patch is not:
- a backport of 4.0 gdscript/compiler changes
- a functional change that changes any user-facing observable behaviour of gdscript