### PR TITLE
Add support for saving WebP images

### DIFF
--- a/core/io/image.cpp
+++ b/core/io/image.cpp
@@ -87,6 +87,9 @@ SaveEXRFunc Image::save_exr_func = nullptr;
 SavePNGBufferFunc Image::save_png_buffer_func = nullptr;
 SaveJPGBufferFunc Image::save_jpg_buffer_func = nullptr;
 
+SaveWebPFunc Image::save_webp_func = nullptr;
+SaveWebPBufferFunc Image::save_webp_buffer_func = nullptr;
+
 void Image::_put_pixelb(int p_x, int p_y, uint32_t p_pixel_size, uint8_t *p_data, const uint8_t *p_pixel) {
 	uint32_t ofs = (p_y * width + p_x) * p_pixel_size;
 	memcpy(p_data + ofs, p_pixel, p_pixel_size);
@@ -2320,6 +2323,24 @@ Error Image::save_exr(const String &p_path, bool p_grayscale) const {
 	return save_exr_func(p_path, Ref<Image>((Image *)this), p_grayscale);
 }
 
+Error Image::save_webp(const String &p_path, const bool p_lossy, const float p_quality) const {
+	if (save_webp_func == nullptr) {
+		return ERR_UNAVAILABLE;
+	}
+	ERR_FAIL_COND_V_MSG(p_lossy && !(0.0f <= p_quality && p_quality <= 1.0f), ERR_INVALID_PARAMETER, "The WebP lossy quality was set to " + rtos(p_quality) + ", which is not valid. WebP lossy quality must be between 0.0 and 1.0 (inclusive).");
+
+	return save_webp_func(p_path, Ref<Image>((Image *)this), p_lossy, p_quality);
+}
+
+Vector<uint8_t> Image::save_webp_to_buffer(const bool p_lossy, const float p_quality) const {
+	if (save_webp_buffer_func == nullptr) {
+		return Vector<uint8_t>();
+	}
+	ERR_FAIL_COND_V_MSG(p_lossy && !(0.0f <= p_quality && p_quality <= 1.0f), Vector<uint8_t>(), "The WebP lossy quality was set to " + rtos(p_quality) + ", which is not valid. WebP lossy quality must be between 0.0 and 1.0 (inclusive).");
+
+	return save_webp_buffer_func(Ref<Image>((Image *)this), p_lossy, p_quality);
+}
+
 int Image::get_image_data_size(int p_width, int p_height, Format p_format, bool p_mipmaps) {
 	int mm;
 	return _get_dst_image_size(p_width, p_height, p_format, mm, p_mipmaps ? -1 : 0);
@@ -3159,6 +3180,8 @@ void Image::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("save_jpg", "path", "quality"), &Image::save_jpg, DEFVAL(0.75));
 	ClassDB::bind_method(D_METHOD("save_jpg_to_buffer", "quality"), &Image::save_jpg_to_buffer, DEFVAL(0.75));
 	ClassDB::bind_method(D_METHOD("save_exr", "path", "grayscale"), &Image::save_exr, DEFVAL(false));
+	ClassDB::bind_method(D_METHOD("save_webp", "path", "lossy", "quality"), &Image::save_webp, DEFVAL(false), DEFVAL(0.75f));
+	ClassDB::bind_method(D_METHOD("save_webp_to_buffer", "lossy", "quality"), &Image::save_webp_to_buffer, DEFVAL(false), DEFVAL(0.75f));
 
 	ClassDB::bind_method(D_METHOD("detect_alpha"), &Image::detect_alpha);
 	ClassDB::bind_method(D_METHOD("is_invisible"), &Image::is_invisible);

--- a/core/io/image.h
+++ b/core/io/image.h
@@ -48,6 +48,8 @@ typedef Vector<uint8_t> (*SavePNGBufferFunc)(const Ref<Image> &p_img);
 typedef Error (*SaveJPGFunc)(const String &p_path, const Ref<Image> &p_img, float p_quality);
 typedef Vector<uint8_t> (*SaveJPGBufferFunc)(const Ref<Image> &p_img, float p_quality);
 typedef Ref<Image> (*ImageMemLoadFunc)(const uint8_t *p_png, int p_size);
+typedef Error (*SaveWebPFunc)(const String &p_path, const Ref<Image> &p_img, const bool p_lossy, const float p_quality);
+typedef Vector<uint8_t> (*SaveWebPBufferFunc)(const Ref<Image> &p_img, const bool p_lossy, const float p_quality);
 
 typedef Error (*SaveEXRFunc)(const String &p_path, const Ref<Image> &p_img, bool p_grayscale);
 
@@ -60,6 +62,8 @@ public:
 	static SaveEXRFunc save_exr_func;
 	static SavePNGBufferFunc save_png_buffer_func;
 	static SaveJPGBufferFunc save_jpg_buffer_func;
+	static SaveWebPFunc save_webp_func;
+	static SaveWebPBufferFunc save_webp_buffer_func;
 
 	enum {
 		MAX_WIDTH = (1 << 24), // force a limit somehow
@@ -289,6 +293,8 @@ public:
 	Vector<uint8_t> save_png_to_buffer() const;
 	Vector<uint8_t> save_jpg_to_buffer(float p_quality = 0.75) const;
 	Error save_exr(const String &p_path, bool p_grayscale) const;
+	Error save_webp(const String &p_path, const bool p_lossy = false, const float p_quality = 0.75f) const;
+	Vector<uint8_t> save_webp_to_buffer(const bool p_lossy = false, const float p_quality = 0.75f) const;
 
 	void create_empty(int p_width, int p_height, bool p_use_mipmaps, Format p_format) {
 		create(p_width, p_height, p_use_mipmaps, p_format);

--- a/doc/classes/Image.xml
+++ b/doc/classes/Image.xml
@@ -397,12 +397,30 @@
 			<return type="int" enum="Error" />
 			<argument index="0" name="path" type="String" />
 			<description>
-				Saves the image as a PNG file to [code]path[/code].
+				Saves the image as a PNG file to the file at [code]path[/code].
 			</description>
 		</method>
 		<method name="save_png_to_buffer" qualifiers="const">
 			<return type="PackedByteArray" />
 			<description>
+				Saves the image as a PNG file to a byte array.
+			</description>
+		</method>
+		<method name="save_webp" qualifiers="const">
+			<return type="int" enum="Error" />
+			<argument index="0" name="path" type="String" />
+			<argument index="1" name="lossy" type="bool" default="false" />
+			<argument index="2" name="quality" type="float" default="0.75" />
+			<description>
+				Saves the image as a WebP (Web Picture) file to the file at [code]path[/code]. By default it will save lossless. If [code]lossy[/code] is true, the image will be saved lossy, using the [code]quality[/code] setting between 0.0 and 1.0 (inclusive).
+			</description>
+		</method>
+		<method name="save_webp_to_buffer" qualifiers="const">
+			<return type="PackedByteArray" />
+			<argument index="0" name="lossy" type="bool" default="false" />
+			<argument index="1" name="quality" type="float" default="0.75" />
+			<description>
+				Saves the image as a WebP (Web Picture) file to a byte array. By default it will save lossless. If [code]lossy[/code] is true, the image will be saved lossy, using the [code]quality[/code] setting between 0.0 and 1.0 (inclusive).
 			</description>
 		</method>
 		<method name="set_pixel">

--- a/modules/webp/image_loader_webp.cpp
+++ b/modules/webp/image_loader_webp.cpp
@@ -34,184 +34,21 @@
 #include "core/io/marshalls.h"
 #include "core/os/os.h"
 #include "core/string/print_string.h"
+#include "webp_common.h"
 
 #include <stdlib.h>
 #include <webp/decode.h>
 #include <webp/encode.h>
 
-static Vector<uint8_t> _webp_lossy_pack(const Ref<Image> &p_image, float p_quality) {
-	ERR_FAIL_COND_V(p_image.is_null() || p_image->is_empty(), Vector<uint8_t>());
-
-	Ref<Image> img = p_image->duplicate();
-	if (img->detect_alpha()) {
-		img->convert(Image::FORMAT_RGBA8);
-	} else {
-		img->convert(Image::FORMAT_RGB8);
-	}
-
-	Size2 s(img->get_width(), img->get_height());
-	Vector<uint8_t> data = img->get_data();
-	const uint8_t *r = data.ptr();
-
-	uint8_t *dst_buff = nullptr;
-	size_t dst_size = 0;
-	if (img->get_format() == Image::FORMAT_RGB8) {
-		dst_size = WebPEncodeRGB(r, s.width, s.height, 3 * s.width, CLAMP(p_quality * 100.0, 0, 100.0), &dst_buff);
-	} else {
-		dst_size = WebPEncodeRGBA(r, s.width, s.height, 4 * s.width, CLAMP(p_quality * 100.0, 0, 100.0), &dst_buff);
-	}
-
-	ERR_FAIL_COND_V(dst_size == 0, Vector<uint8_t>());
-	Vector<uint8_t> dst;
-	dst.resize(4 + dst_size);
-	uint8_t *w = dst.ptrw();
-	w[0] = 'W';
-	w[1] = 'E';
-	w[2] = 'B';
-	w[3] = 'P';
-	memcpy(&w[4], dst_buff, dst_size);
-	WebPFree(dst_buff);
-
-	return dst;
-}
-
-static Vector<uint8_t> _webp_lossless_pack(const Ref<Image> &p_image) {
-	ERR_FAIL_COND_V(p_image.is_null() || p_image->is_empty(), Vector<uint8_t>());
-
-	int compression_level = ProjectSettings::get_singleton()->get("rendering/textures/lossless_compression/webp_compression_level");
-	compression_level = CLAMP(compression_level, 0, 9);
-
-	Ref<Image> img = p_image->duplicate();
-	if (img->detect_alpha()) {
-		img->convert(Image::FORMAT_RGBA8);
-	} else {
-		img->convert(Image::FORMAT_RGB8);
-	}
-
-	Size2 s(img->get_width(), img->get_height());
-	Vector<uint8_t> data = img->get_data();
-	const uint8_t *r = data.ptr();
-
-	// we need to use the more complex API in order to access the 'exact' flag...
-
-	WebPConfig config;
-	WebPPicture pic;
-	if (!WebPConfigInit(&config) || !WebPConfigLosslessPreset(&config, compression_level) || !WebPPictureInit(&pic)) {
-		ERR_FAIL_V(Vector<uint8_t>());
-	}
-
-	WebPMemoryWriter wrt;
-	config.exact = 1;
-	pic.use_argb = 1;
-	pic.width = s.width;
-	pic.height = s.height;
-	pic.writer = WebPMemoryWrite;
-	pic.custom_ptr = &wrt;
-	WebPMemoryWriterInit(&wrt);
-
-	bool success_import = false;
-	if (img->get_format() == Image::FORMAT_RGB8) {
-		success_import = WebPPictureImportRGB(&pic, r, 3 * s.width);
-	} else {
-		success_import = WebPPictureImportRGBA(&pic, r, 4 * s.width);
-	}
-	bool success_encode = false;
-	if (success_import) {
-		success_encode = WebPEncode(&config, &pic);
-	}
-	WebPPictureFree(&pic);
-
-	if (!success_encode) {
-		WebPMemoryWriterClear(&wrt);
-		ERR_FAIL_V_MSG(Vector<uint8_t>(), "WebP packing failed.");
-	}
-
-	// copy from wrt
-	Vector<uint8_t> dst;
-	dst.resize(4 + wrt.size);
-	uint8_t *w = dst.ptrw();
-	w[0] = 'W';
-	w[1] = 'E';
-	w[2] = 'B';
-	w[3] = 'P';
-	memcpy(&w[4], wrt.mem, wrt.size);
-	WebPMemoryWriterClear(&wrt);
-
-	return dst;
-}
-
-static Ref<Image> _webp_unpack(const Vector<uint8_t> &p_buffer) {
-	int size = p_buffer.size() - 4;
-	ERR_FAIL_COND_V(size <= 0, Ref<Image>());
-	const uint8_t *r = p_buffer.ptr();
-
-	ERR_FAIL_COND_V(r[0] != 'W' || r[1] != 'E' || r[2] != 'B' || r[3] != 'P', Ref<Image>());
-	WebPBitstreamFeatures features;
-	if (WebPGetFeatures(&r[4], size, &features) != VP8_STATUS_OK) {
-		ERR_FAIL_V_MSG(Ref<Image>(), "Error unpacking WEBP image.");
-	}
-
-	/*
-	print_line("width: "+itos(features.width));
-	print_line("height: "+itos(features.height));
-	print_line("alpha: "+itos(features.has_alpha));
-	*/
-
-	Vector<uint8_t> dst_image;
-	int datasize = features.width * features.height * (features.has_alpha ? 4 : 3);
-	dst_image.resize(datasize);
-
-	uint8_t *dst_w = dst_image.ptrw();
-
-	bool errdec = false;
-	if (features.has_alpha) {
-		errdec = WebPDecodeRGBAInto(&r[4], size, dst_w, datasize, 4 * features.width) == nullptr;
-	} else {
-		errdec = WebPDecodeRGBInto(&r[4], size, dst_w, datasize, 3 * features.width) == nullptr;
-	}
-
-	ERR_FAIL_COND_V_MSG(errdec, Ref<Image>(), "Failed decoding WebP image.");
-
-	Ref<Image> img = memnew(Image(features.width, features.height, 0, features.has_alpha ? Image::FORMAT_RGBA8 : Image::FORMAT_RGB8, dst_image));
-	return img;
-}
-
-Error webp_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p_buffer_len) {
-	ERR_FAIL_NULL_V(p_image, ERR_INVALID_PARAMETER);
-
-	WebPBitstreamFeatures features;
-	if (WebPGetFeatures(p_buffer, p_buffer_len, &features) != VP8_STATUS_OK) {
-		ERR_FAIL_V(ERR_FILE_CORRUPT);
-	}
-
-	Vector<uint8_t> dst_image;
-	int datasize = features.width * features.height * (features.has_alpha ? 4 : 3);
-	dst_image.resize(datasize);
-	uint8_t *dst_w = dst_image.ptrw();
-
-	bool errdec = false;
-	if (features.has_alpha) {
-		errdec = WebPDecodeRGBAInto(p_buffer, p_buffer_len, dst_w, datasize, 4 * features.width) == nullptr;
-	} else {
-		errdec = WebPDecodeRGBInto(p_buffer, p_buffer_len, dst_w, datasize, 3 * features.width) == nullptr;
-	}
-
-	ERR_FAIL_COND_V_MSG(errdec, ERR_FILE_CORRUPT, "Failed decoding WebP image.");
-
-	p_image->create(features.width, features.height, false, features.has_alpha ? Image::FORMAT_RGBA8 : Image::FORMAT_RGB8, dst_image);
-
-	return OK;
-}
-
 static Ref<Image> _webp_mem_loader_func(const uint8_t *p_png, int p_size) {
 	Ref<Image> img;
 	img.instantiate();
-	Error err = webp_load_image_from_buffer(img.ptr(), p_png, p_size);
+	Error err = WebPCommon::webp_load_image_from_buffer(img.ptr(), p_png, p_size);
 	ERR_FAIL_COND_V(err, Ref<Image>());
 	return img;
 }
 
-Error ImageLoaderWEBP::load_image(Ref<Image> p_image, Ref<FileAccess> f, bool p_force_linear, float p_scale) {
+Error ImageLoaderWebP::load_image(Ref<Image> p_image, Ref<FileAccess> f, bool p_force_linear, float p_scale) {
 	Vector<uint8_t> src_image;
 	uint64_t src_image_len = f->get_length();
 	ERR_FAIL_COND_V(src_image_len == 0, ERR_FILE_CORRUPT);
@@ -221,18 +58,18 @@ Error ImageLoaderWEBP::load_image(Ref<Image> p_image, Ref<FileAccess> f, bool p_
 
 	f->get_buffer(&w[0], src_image_len);
 
-	Error err = webp_load_image_from_buffer(p_image.ptr(), w, src_image_len);
+	Error err = WebPCommon::webp_load_image_from_buffer(p_image.ptr(), w, src_image_len);
 
 	return err;
 }
 
-void ImageLoaderWEBP::get_recognized_extensions(List<String> *p_extensions) const {
+void ImageLoaderWebP::get_recognized_extensions(List<String> *p_extensions) const {
 	p_extensions->push_back("webp");
 }
 
-ImageLoaderWEBP::ImageLoaderWEBP() {
+ImageLoaderWebP::ImageLoaderWebP() {
 	Image::_webp_mem_loader_func = _webp_mem_loader_func;
-	Image::webp_lossy_packer = _webp_lossy_pack;
-	Image::webp_lossless_packer = _webp_lossless_pack;
-	Image::webp_unpacker = _webp_unpack;
+	Image::webp_lossy_packer = WebPCommon::_webp_lossy_pack;
+	Image::webp_lossless_packer = WebPCommon::_webp_lossless_pack;
+	Image::webp_unpacker = WebPCommon::_webp_unpack;
 }

--- a/modules/webp/image_loader_webp.h
+++ b/modules/webp/image_loader_webp.h
@@ -33,11 +33,11 @@
 
 #include "core/io/image_loader.h"
 
-class ImageLoaderWEBP : public ImageFormatLoader {
+class ImageLoaderWebP : public ImageFormatLoader {
 public:
 	virtual Error load_image(Ref<Image> p_image, Ref<FileAccess> f, bool p_force_linear, float p_scale);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;
-	ImageLoaderWEBP();
+	ImageLoaderWebP();
 };
 
 #endif

--- a/modules/webp/resource_saver_webp.h
+++ b/modules/webp/resource_saver_webp.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  register_types.cpp                                                   */
+/*  resource_saver_webp.h                                                */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,31 +28,22 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "register_types.h"
+#ifndef RESOURCE_SAVER_WEBP_H
+#define RESOURCE_SAVER_WEBP_H
 
-#include "image_loader_webp.h"
-#include "resource_saver_webp.h"
+#include "core/io/image.h"
+#include "core/io/resource_saver.h"
 
-static ImageLoaderWebP *image_loader_webp = nullptr;
-static Ref<ResourceSaverWebP> resource_saver_webp;
+class ResourceSaverWebP : public ResourceFormatSaver {
+public:
+	static Error save_image(const String &p_path, const Ref<Image> &p_img, const bool p_lossy = false, const float p_quality = 0.75f);
+	static Vector<uint8_t> save_image_to_buffer(const Ref<Image> &p_img, const bool p_lossy = false, const float p_quality = 0.75f);
 
-void initialize_webp_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
+	virtual Error save(const String &p_path, const Ref<Resource> &p_resource, uint32_t p_flags = 0);
+	virtual bool recognize(const Ref<Resource> &p_resource) const;
+	virtual void get_recognized_extensions(const Ref<Resource> &p_resource, List<String> *p_extensions) const;
 
-	image_loader_webp = memnew(ImageLoaderWebP);
-	resource_saver_webp.instantiate();
-	ImageLoader::add_image_format_loader(image_loader_webp);
-	ResourceSaver::add_resource_format_saver(resource_saver_webp);
-}
+	ResourceSaverWebP();
+};
 
-void uninitialize_webp_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-
-	memdelete(image_loader_webp);
-	ResourceSaver::remove_resource_format_saver(resource_saver_webp);
-	resource_saver_webp.unref();
-}
+#endif // RESOURCE_SAVER_WEBP_H

--- a/modules/webp/webp_common.cpp
+++ b/modules/webp/webp_common.cpp
@@ -1,0 +1,190 @@
+/*************************************************************************/
+/*  webp_common.cpp                                                      */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2022 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2022 Godot Engine contributors (cf. AUTHORS.md).   */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "webp_common.h"
+
+#include "core/config/project_settings.h"
+#include "core/os/os.h"
+
+#include <string.h>
+#include <webp/decode.h>
+#include <webp/encode.h>
+
+namespace WebPCommon {
+Vector<uint8_t> _webp_lossy_pack(const Ref<Image> &p_image, float p_quality) {
+	ERR_FAIL_COND_V(p_image.is_null() || p_image->is_empty(), Vector<uint8_t>());
+
+	Ref<Image> img = p_image->duplicate();
+	if (img->detect_alpha()) {
+		img->convert(Image::FORMAT_RGBA8);
+	} else {
+		img->convert(Image::FORMAT_RGB8);
+	}
+
+	Size2 s(img->get_width(), img->get_height());
+	Vector<uint8_t> data = img->get_data();
+	const uint8_t *r = data.ptr();
+
+	uint8_t *dst_buff = nullptr;
+	size_t dst_size = 0;
+	if (img->get_format() == Image::FORMAT_RGB8) {
+		dst_size = WebPEncodeRGB(r, s.width, s.height, 3 * s.width, CLAMP(p_quality * 100.0f, 0.0f, 100.0f), &dst_buff);
+	} else {
+		dst_size = WebPEncodeRGBA(r, s.width, s.height, 4 * s.width, CLAMP(p_quality * 100.0f, 0.0f, 100.0f), &dst_buff);
+	}
+
+	ERR_FAIL_COND_V(dst_size == 0, Vector<uint8_t>());
+	Vector<uint8_t> dst;
+	dst.resize(dst_size);
+	uint8_t *w = dst.ptrw();
+	memcpy(w, dst_buff, dst_size);
+	WebPFree(dst_buff);
+
+	return dst;
+}
+
+Vector<uint8_t> _webp_lossless_pack(const Ref<Image> &p_image) {
+	ERR_FAIL_COND_V(p_image.is_null() || p_image->is_empty(), Vector<uint8_t>());
+
+	int compression_level = ProjectSettings::get_singleton()->get("rendering/textures/lossless_compression/webp_compression_level");
+	compression_level = CLAMP(compression_level, 0, 9);
+
+	Ref<Image> img = p_image->duplicate();
+	if (img->detect_alpha()) {
+		img->convert(Image::FORMAT_RGBA8);
+	} else {
+		img->convert(Image::FORMAT_RGB8);
+	}
+
+	Size2 s(img->get_width(), img->get_height());
+	Vector<uint8_t> data = img->get_data();
+	const uint8_t *r = data.ptr();
+
+	// we need to use the more complex API in order to access the 'exact' flag...
+
+	WebPConfig config;
+	WebPPicture pic;
+	if (!WebPConfigInit(&config) || !WebPConfigLosslessPreset(&config, compression_level) || !WebPPictureInit(&pic)) {
+		ERR_FAIL_V(Vector<uint8_t>());
+	}
+
+	WebPMemoryWriter wrt;
+	config.exact = 1;
+	pic.use_argb = 1;
+	pic.width = s.width;
+	pic.height = s.height;
+	pic.writer = WebPMemoryWrite;
+	pic.custom_ptr = &wrt;
+	WebPMemoryWriterInit(&wrt);
+
+	bool success_import = false;
+	if (img->get_format() == Image::FORMAT_RGB8) {
+		success_import = WebPPictureImportRGB(&pic, r, 3 * s.width);
+	} else {
+		success_import = WebPPictureImportRGBA(&pic, r, 4 * s.width);
+	}
+	bool success_encode = false;
+	if (success_import) {
+		success_encode = WebPEncode(&config, &pic);
+	}
+	WebPPictureFree(&pic);
+
+	if (!success_encode) {
+		WebPMemoryWriterClear(&wrt);
+		ERR_FAIL_V_MSG(Vector<uint8_t>(), "WebP packing failed.");
+	}
+
+	// copy from wrt
+	Vector<uint8_t> dst;
+	dst.resize(wrt.size);
+	uint8_t *w = dst.ptrw();
+	memcpy(w, wrt.mem, wrt.size);
+	WebPMemoryWriterClear(&wrt);
+	return dst;
+}
+
+Ref<Image> _webp_unpack(const Vector<uint8_t> &p_buffer) {
+	int size = p_buffer.size();
+	ERR_FAIL_COND_V(size <= 0, Ref<Image>());
+	const uint8_t *r = p_buffer.ptr();
+
+	// A WebP file uses a RIFF header, which starts with "RIFF____WEBP".
+	ERR_FAIL_COND_V(r[0] != 'R' || r[1] != 'I' || r[2] != 'F' || r[3] != 'F' || r[8] != 'W' || r[9] != 'E' || r[10] != 'B' || r[11] != 'P', Ref<Image>());
+	WebPBitstreamFeatures features;
+	if (WebPGetFeatures(r, size, &features) != VP8_STATUS_OK) {
+		ERR_FAIL_V_MSG(Ref<Image>(), "Error unpacking WEBP image.");
+	}
+
+	Vector<uint8_t> dst_image;
+	int datasize = features.width * features.height * (features.has_alpha ? 4 : 3);
+	dst_image.resize(datasize);
+
+	uint8_t *dst_w = dst_image.ptrw();
+
+	bool errdec = false;
+	if (features.has_alpha) {
+		errdec = WebPDecodeRGBAInto(r, size, dst_w, datasize, 4 * features.width) == nullptr;
+	} else {
+		errdec = WebPDecodeRGBInto(r, size, dst_w, datasize, 3 * features.width) == nullptr;
+	}
+
+	ERR_FAIL_COND_V_MSG(errdec, Ref<Image>(), "Failed decoding WebP image.");
+
+	Ref<Image> img = memnew(Image(features.width, features.height, 0, features.has_alpha ? Image::FORMAT_RGBA8 : Image::FORMAT_RGB8, dst_image));
+	return img;
+}
+
+Error webp_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p_buffer_len) {
+	ERR_FAIL_NULL_V(p_image, ERR_INVALID_PARAMETER);
+
+	WebPBitstreamFeatures features;
+	if (WebPGetFeatures(p_buffer, p_buffer_len, &features) != VP8_STATUS_OK) {
+		ERR_FAIL_V(ERR_FILE_CORRUPT);
+	}
+
+	Vector<uint8_t> dst_image;
+	int datasize = features.width * features.height * (features.has_alpha ? 4 : 3);
+	dst_image.resize(datasize);
+	uint8_t *dst_w = dst_image.ptrw();
+
+	bool errdec = false;
+	if (features.has_alpha) {
+		errdec = WebPDecodeRGBAInto(p_buffer, p_buffer_len, dst_w, datasize, 4 * features.width) == nullptr;
+	} else {
+		errdec = WebPDecodeRGBInto(p_buffer, p_buffer_len, dst_w, datasize, 3 * features.width) == nullptr;
+	}
+
+	ERR_FAIL_COND_V_MSG(errdec, ERR_FILE_CORRUPT, "Failed decoding WebP image.");
+
+	p_image->create(features.width, features.height, false, features.has_alpha ? Image::FORMAT_RGBA8 : Image::FORMAT_RGB8, dst_image);
+
+	return OK;
+}
+} // namespace WebPCommon

--- a/modules/webp/webp_common.h
+++ b/modules/webp/webp_common.h
@@ -1,5 +1,5 @@
 /*************************************************************************/
-/*  register_types.cpp                                                   */
+/*  webp_common.h                                                        */
 /*************************************************************************/
 /*                       This file is part of:                           */
 /*                           GODOT ENGINE                                */
@@ -28,31 +28,18 @@
 /* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
 /*************************************************************************/
 
-#include "register_types.h"
+#ifndef WEBP_COMMON_H
+#define WEBP_COMMON_H
 
-#include "image_loader_webp.h"
-#include "resource_saver_webp.h"
+#include "core/io/image.h"
 
-static ImageLoaderWebP *image_loader_webp = nullptr;
-static Ref<ResourceSaverWebP> resource_saver_webp;
+namespace WebPCommon {
+// Given an image, pack this data into a WebP file.
+Vector<uint8_t> _webp_lossy_pack(const Ref<Image> &p_image, float p_quality);
+Vector<uint8_t> _webp_lossless_pack(const Ref<Image> &p_image);
+// Given a WebP file, unpack it into an image.
+Ref<Image> _webp_unpack(const Vector<uint8_t> &p_buffer);
+Error webp_load_image_from_buffer(Image *p_image, const uint8_t *p_buffer, int p_buffer_len);
+} //namespace WebPCommon
 
-void initialize_webp_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-
-	image_loader_webp = memnew(ImageLoaderWebP);
-	resource_saver_webp.instantiate();
-	ImageLoader::add_image_format_loader(image_loader_webp);
-	ResourceSaver::add_resource_format_saver(resource_saver_webp);
-}
-
-void uninitialize_webp_module(ModuleInitializationLevel p_level) {
-	if (p_level != MODULE_INITIALIZATION_LEVEL_SCENE) {
-		return;
-	}
-
-	memdelete(image_loader_webp);
-	ResourceSaver::remove_resource_format_saver(resource_saver_webp);
-	resource_saver_webp.unref();
-}
+#endif // WEBP_COMMON_H


### PR DESCRIPTION
Godot already has code to save WebP images, but it's not exposed to the user. This PR refactors this code, adding and exposing APIs for saving WebP images.

The bulk of the saving code already existed in `image_loader_webp.cpp`, it has been moved to a new file `webp_common.cpp`, which is used by both the loader and the new file `resource_saver_webp.cpp`. This mimics the structure of the PNG code.

In addition to moving this code, this PR also fixes a bug @lyuma and @Macksaur discovered where Godot was adding an extra `WEBP` prefix that made the saved file not be a valid WebP file. This bug wasn't affecting us before because Godot only used this code to save stuff internally and then we stripped that prefix when loading internally, but it's technically a pre-existing bug that resulted in compressed textures being invalid WebPs and 4 bytes bigger than they needed to be.

The exposed methods are in the `Image` class. They mimic the API for saving PNG files, except that WebP has both lossy and lossless so there is an extra parameter for the quality setting. Passing in `true` for the `lossy` parameter will save lossy, and the quality can be set to a value between `0.0` and `1.0`. Users can write `image.save_webp("res://test.webp")` to save a lossless WebP file, or `image.save_webp("res://test.webp", true)` to save a lossy WebP file at 75% quality, or `image.save_webp("res://test.webp", true, 0.5)` to save a lossy WebP file at 50% quality.

Special thanks to @lyuma and @Macksaur. My work on this was sponsored by [The Mirror](https://www.themirror.space/).