### PR TITLE
Fix some bugs about search in code editor

### DIFF
--- a/editor/code_editor.h
+++ b/editor/code_editor.h
@@ -92,7 +92,7 @@ class FindReplaceBar : public HBoxContainer {
 	bool replace_all_mode = false;
 	bool preserve_cursor = false;
 
-	void _get_search_from(int &r_line, int &r_col);
+	void _get_search_from(int &r_line, int &r_col, bool p_is_searching_next = false);
 	void _update_results_count();
 	void _update_matches_label();
 


### PR DESCRIPTION
1. Fix #61713, Supersede #61715;
2. Fix the bug when there are consecutive matches, forward searching will skip the adjacent item;
3. Fix the bug that enable the selection-only option will affect the operations in search mode.
4. Fix #33315.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

| Before | After |
| :------: | :------: |
| ![1](https://user-images.githubusercontent.com/30386067/172355986-18778969-c724-4cde-8f29-3f31ac0df16a.gif) | ![2](https://user-images.githubusercontent.com/30386067/172356013-14886d67-ef05-4690-a94f-efda7d44a5fc.gif) |

When popup the search bar without a selection, just display the number of matches.

| Before | After |
| :------: | :------: |
| ![3](https://user-images.githubusercontent.com/30386067/172379589-a53d3967-af32-4195-8635-b8aa15a31530.gif) | ![4](https://user-images.githubusercontent.com/30386067/172377281-59fc27ee-aad1-4781-851e-55548bd04894.gif) |

**known problem**: In some extreme cases, searching forward and searching backward will give different results.

![6](https://user-images.githubusercontent.com/30386067/172377297-7a3638a7-4432-419b-b8ed-02467314c4dc.gif)



