### PR TITLE
Add overrun behavior to the PopupMenu items.

### DIFF
--- a/doc/classes/PopupMenu.xml
+++ b/doc/classes/PopupMenu.xml
@@ -528,6 +528,12 @@
 		<member name="submenu_popup_delay" type="float" setter="set_submenu_popup_delay" getter="get_submenu_popup_delay" default="0.3">
 			Sets the delay time in seconds for the submenu item to popup on mouse hovering. If the popup menu is added as a child of another (acting as a submenu), it will inherit the delay time of the parent menu item.
 		</member>
+		<member name="text_max_width" type="float" setter="set_text_max_width" getter="get_text_max_width" default="-1.0">
+			Sets width limit for the [member text_overrun_behavior].
+		</member>
+		<member name="text_overrun_behavior" type="int" setter="set_text_overrun_behavior" getter="get_text_overrun_behavior" enum="TextLine.OverrunBehavior" default="0">
+			Sets the clipping behavior when the item text exceeds [member text_max_width]. See [enum TextLine.OverrunBehavior] for a description of all modes.
+		</member>
 	</members>
 	<signals>
 		<signal name="id_focused">

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -738,12 +738,48 @@ void PopupMenu::_shape_item(int p_item) {
 			items.write[p_item].text_buf->set_direction((TextServer::Direction)items[p_item].text_direction);
 		}
 		items.write[p_item].text_buf->add_string(items.write[p_item].xl_text, font, font_size, items[p_item].opentype_features, !items[p_item].language.is_empty() ? items[p_item].language : TranslationServer::get_singleton()->get_tool_locale());
+		if (text_max_width > 0) {
+			items.write[p_item].text_buf->set_width(text_max_width);
+			items.write[p_item].text_buf->set_text_overrun_behavior(overrun_behavior);
+		}
 
 		items.write[p_item].accel_text_buf->clear();
 		items.write[p_item].accel_text_buf->set_direction(is_layout_rtl() ? TextServer::DIRECTION_RTL : TextServer::DIRECTION_LTR);
 		items.write[p_item].accel_text_buf->add_string(_get_accel_text(items.write[p_item]), font, font_size, Dictionary(), TranslationServer::get_singleton()->get_tool_locale());
 		items.write[p_item].dirty = false;
 	}
+}
+
+void PopupMenu::set_text_max_width(float p_width) {
+	if (text_max_width != p_width) {
+		text_max_width = p_width;
+		for (int i = 0; i < items.size(); i++) {
+			items.write[i].dirty = true;
+			_shape_item(i);
+		}
+		child_controls_changed();
+		control->update();
+	}
+}
+
+float PopupMenu::get_text_max_width() const {
+	return text_max_width;
+}
+
+void PopupMenu::set_text_overrun_behavior(TextLine::OverrunBehavior p_behavior) {
+	if (overrun_behavior != p_behavior) {
+		overrun_behavior = p_behavior;
+		for (int i = 0; i < items.size(); i++) {
+			items.write[i].dirty = true;
+			_shape_item(i);
+		}
+		child_controls_changed();
+		control->update();
+	}
+}
+
+TextLine::OverrunBehavior PopupMenu::get_text_overrun_behavior() const {
+	return overrun_behavior;
 }
 
 void PopupMenu::_notification(int p_what) {
@@ -1892,11 +1928,19 @@ void PopupMenu::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("set_allow_search", "allow"), &PopupMenu::set_allow_search);
 	ClassDB::bind_method(D_METHOD("get_allow_search"), &PopupMenu::get_allow_search);
 
+	ClassDB::bind_method(D_METHOD("set_text_overrun_behavior", "overrun_behavior"), &PopupMenu::set_text_overrun_behavior);
+	ClassDB::bind_method(D_METHOD("get_text_overrun_behavior"), &PopupMenu::get_text_overrun_behavior);
+
+	ClassDB::bind_method(D_METHOD("set_text_max_width", "width"), &PopupMenu::set_text_max_width);
+	ClassDB::bind_method(D_METHOD("get_text_max_width"), &PopupMenu::get_text_max_width);
+
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_item_selection"), "set_hide_on_item_selection", "is_hide_on_item_selection");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_checkable_item_selection"), "set_hide_on_checkable_item_selection", "is_hide_on_checkable_item_selection");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "hide_on_state_item_selection"), "set_hide_on_state_item_selection", "is_hide_on_state_item_selection");
 	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "submenu_popup_delay"), "set_submenu_popup_delay", "get_submenu_popup_delay");
 	ADD_PROPERTY(PropertyInfo(Variant::BOOL, "allow_search"), "set_allow_search", "get_allow_search");
+	ADD_PROPERTY(PropertyInfo(Variant::INT, "text_overrun_behavior", PROPERTY_HINT_ENUM, "Trim Nothing,Trim Characters,Trim Words,Ellipsis,Word Ellipsis"), "set_text_overrun_behavior", "get_text_overrun_behavior");
+	ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "text_max_width"), "set_text_max_width", "get_text_max_width");
 
 	ADD_ARRAY_COUNT("Items", "item_count", "set_item_count", "get_item_count", "item_");
 

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -129,6 +129,8 @@ class PopupMenu : public Popup {
 	MarginContainer *margin_container = nullptr;
 	ScrollContainer *scroll_container = nullptr;
 	Control *control = nullptr;
+	TextLine::OverrunBehavior overrun_behavior = TextLine::OVERRUN_NO_TRIMMING;
+	float text_max_width = -1.0;
 
 	void _draw_items();
 	void _draw_background();
@@ -252,6 +254,12 @@ public:
 
 	void set_allow_search(bool p_allow);
 	bool get_allow_search() const;
+
+	void set_text_overrun_behavior(TextLine::OverrunBehavior p_behavior);
+	TextLine::OverrunBehavior get_text_overrun_behavior() const;
+
+	void set_text_max_width(float p_width);
+	float get_text_max_width() const;
 
 	virtual void popup(const Rect2 &p_bounds = Rect2());
 


### PR DESCRIPTION
Add support for overrun behavior / max. width to the PopupMenu items.

![Screenshot 2022-06-07 at 17 59 29](https://user-images.githubusercontent.com/7645683/172416193-0f62a621-c578-4ed0-953a-9817f0923209.png)

