### PR TITLE
Fix GraphEdit layering

### DIFF
--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -396,8 +396,6 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 	Ref<VisualShaderNodeGroupBase> group_node = Object::cast_to<VisualShaderNodeGroupBase>(vsnode.ptr());
 	bool is_group = !group_node.is_null();
 
-	bool is_comment = false;
-
 	Ref<VisualShaderNodeExpression> expression_node = Object::cast_to<VisualShaderNodeExpression>(group_node.ptr());
 	bool is_expression = !expression_node.is_null();
 	String expression = "";
@@ -409,8 +407,6 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 
 	// Create graph node.
 	GraphNode *node = memnew(GraphNode);
-	graph->add_child(node);
-	node->set_theme(vstheme);
 	editor->_update_created_node(node);
 	register_link(p_type, p_id, vsnode.ptr(), node);
 
@@ -449,7 +445,6 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 	if (is_resizable) {
 		Ref<VisualShaderNodeComment> comment_node = Object::cast_to<VisualShaderNodeComment>(vsnode.ptr());
 		if (comment_node.is_valid()) {
-			is_comment = true;
 			node->set_comment(true);
 
 			Label *comment_label = memnew(Label);
@@ -460,6 +455,9 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		}
 		editor->call_deferred(SNAME("_set_node_size"), (int)p_type, p_id, size);
 	}
+
+	graph->add_child(node);
+	node->set_theme(vstheme);
 
 	Ref<VisualShaderNodeParticleEmit> emit = vsnode;
 	if (emit.is_valid()) {
@@ -1017,10 +1015,6 @@ void VisualShaderGraphPlugin::add_node(VisualShader::Type p_type, int p_id) {
 		expression_box->set_draw_line_numbers(true);
 
 		expression_box->connect("focus_exited", callable_mp(editor, &VisualShaderEditor::_expression_focus_out).bind(expression_box, p_id));
-	}
-
-	if (is_comment) {
-		graph->move_child(node, 0); // to prevents a bug where comment node overlaps its content
 	}
 }
 

--- a/scene/gui/graph_edit.h
+++ b/scene/gui/graph_edit.h
@@ -186,15 +186,22 @@ private:
 	PackedVector2Array get_connection_line(const Vector2 &p_from, const Vector2 &p_to);
 	void _draw_connection_line(CanvasItem *p_where, const Vector2 &p_from, const Vector2 &p_to, const Color &p_color, const Color &p_to_color, float p_width, float p_zoom);
 
+	void _reorder_comment_nodes(GraphNode *p_node);
+
 	void _graph_node_selected(Node *p_gn);
 	void _graph_node_deselected(Node *p_gn);
 	void _graph_node_raised(Node *p_gn);
+	void _graph_node_resized(Vector2 p_new_minsize, Node *p_gn);
 	void _graph_node_moved(Node *p_gn);
 	void _graph_node_slot_updated(int p_index, Node *p_gn);
 
 	void _update_scroll();
 	void _scroll_moved(double);
 	virtual void gui_input(const Ref<InputEvent> &p_ev) override;
+
+	// This separates the children in two layers to ensure the order
+	// of both background nodes (e.g comment nodes) and foreground nodes.
+	int background_nodes_separator_idx = 0;
 
 	Control *connections_layer = nullptr;
 	GraphEditFilter *top_layer = nullptr;


### PR DESCRIPTION
This PR fixes/improves the ordering of comment nodes as children of GraphEdit as well as the position of the connections layer.
Split from #61414.

Detailed changes:
- the order of comment nodes is now calculated similar to a 2D BVH: when a comment node encloses other comment nodes, the index of the enclosing node is kept below
   - the order is updated when resizing a comment node
- the connections layer is now kept between the comment nodes and the normal graph (due to technical limitations it is no longer an internal node)

**Before:**
![before](https://user-images.githubusercontent.com/50084500/172429674-1c34c11a-0d9b-48d4-8699-9511e9a5e495.png)

**This PR:**
![after](https://user-images.githubusercontent.com/50084500/172429694-2a0690ce-f7c5-428f-957d-82a52ab48f3c.png)
