### PR TITLE
Use RenderBuffer size instead of half extents for VIEWPORT_SIZE

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1256,9 +1256,8 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 
 	//scene_state.ubo.subsurface_scatter_width = subsurface_scatter_size;
 
-	Vector2 vp_he = p_render_data->cam_projection.get_viewport_half_extents();
-	scene_state.ubo.viewport_size[0] = vp_he.x;
-	scene_state.ubo.viewport_size[1] = vp_he.y;
+	scene_state.ubo.viewport_size[0] = render_buffer->width;
+	scene_state.ubo.viewport_size[1] = render_buffer->height;
 	scene_state.ubo.directional_light_count = 0;
 	scene_state.ubo.opaque_prepass_threshold = 0.99f;
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -485,9 +485,8 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 
 	RENDER_TIMESTAMP("Setup 3D Scene");
 
-	Vector2 vp_he = p_render_data->cam_projection.get_viewport_half_extents();
-	scene_state.ubo.viewport_size[0] = vp_he.x;
-	scene_state.ubo.viewport_size[1] = vp_he.y;
+	scene_state.ubo.viewport_size[0] = render_buffer->width;
+	scene_state.ubo.viewport_size[1] = render_buffer->height;
 	scene_state.ubo.directional_light_count = 0;
 	scene_state.ubo.opaque_prepass_threshold = 0.0;
 


### PR DESCRIPTION
Fixes: https://github.com/godotengine/godot/issues/47711

This affects both the Clustered and Mobile backends. Previously the camera half extents were used. The half extents represent the width of the view area at the near plane in world space (I think) and always ended up being a very small number (less than 0.01 in either direction)

Note: the renderbuffer size is the ``internal_size`` of the RenderTarget. So when using upscaling, this will be smaller than the root viewport size. 

This change is consistent with how things work in the OpenGL3 renderer and in 3.x

