### PR TITLE
Re-add internal image field to ImageTexture

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -147,6 +147,24 @@ void ImageTexture::reload_from_file() {
 	}
 }
 
+bool ImageTexture::_set(const StringName &p_name, const Variant &p_value) {
+	if (p_name == "image") {
+		create_from_image(p_value);
+	}
+	return false;
+}
+
+bool ImageTexture::_get(const StringName &p_name, Variant &r_ret) const {
+	if (p_name == "image") {
+		r_ret = get_image();
+	}
+	return false;
+}
+
+void ImageTexture::_get_property_list(List<PropertyInfo> *p_list) const {
+	p_list->push_back(PropertyInfo(Variant::OBJECT, PNAME("image"), PROPERTY_HINT_RESOURCE_TYPE, "Image", PROPERTY_USAGE_STORAGE | PROPERTY_USAGE_RESOURCE_NOT_PERSISTENT));
+}
+
 void ImageTexture::create_from_image(const Ref<Image> &p_image) {
 	ERR_FAIL_COND_MSG(p_image.is_null() || p_image->is_empty(), "Invalid image");
 	w = p_image->get_width();

--- a/scene/resources/texture.h
+++ b/scene/resources/texture.h
@@ -102,6 +102,11 @@ class ImageTexture : public Texture2D {
 
 protected:
 	virtual void reload_from_file() override;
+
+	bool _set(const StringName &p_name, const Variant &p_value);
+	bool _get(const StringName &p_name, Variant &r_ret) const;
+	void _get_property_list(List<PropertyInfo> *p_list) const;
+
 	static void _bind_methods();
 
 public:


### PR DESCRIPTION
Partially reverts #61284

As it turns out, the `image` property was required for serialization (aside from the mesh mentioned in the comments, GPUParticles use it for emission mask, etc.)

This PR re-adds this property, but it's not available in the inspector; it's just stored internally. You can still assign images to texture fields thanks to #56398; I don't think there is any real use-case for editing ImageTexture internals, so it should be fine.