### PR TITLE
Fix GridMap applying wrong NavigationRegion transform

### DIFF
--- a/modules/gridmap/grid_map.cpp
+++ b/modules/gridmap/grid_map.cpp
@@ -535,7 +535,7 @@ bool GridMap::_octant_update(const OctantKey &p_key) {
 				RID region = NavigationServer3D::get_singleton()->region_create();
 				NavigationServer3D::get_singleton()->region_set_layers(region, navigation_layers);
 				NavigationServer3D::get_singleton()->region_set_navmesh(region, navmesh);
-				NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform() * mesh_library->get_item_navmesh_transform(c.item));
+				NavigationServer3D::get_singleton()->region_set_transform(region, get_global_transform() * nm.xform);
 				NavigationServer3D::get_singleton()->region_set_map(region, get_world_3d()->get_navigation_map());
 				nm.region = region;
 			}


### PR DESCRIPTION
Fix GridMap applying wrong NavigationRegion transform.

It was only applying the global_transform of the GridMap and the custom transform of the mesh_library navmesh to the region on the NavigationServer but not the cell position so all the navigation meshes were stacked on top of each other on the NavigationServer map breaking navigation with GridMap.

Part of #61293.

Fixes #56099

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
