### PR TITLE
Fix GridMap Navigation transform changes and debug

### DIFF
--- a/modules/gridmap/grid_map.h
+++ b/modules/gridmap/grid_map.h
@@ -98,6 +98,7 @@ class GridMap : public Node3D {
 		struct NavMesh {
 			RID region;
 			Transform3D xform;
+			RID navmesh_debug_instance;
 		};
 
 		struct MultimeshInstance {


### PR DESCRIPTION
Fix GridMap navigation transforms and debug.

GridMap did not update the transforms of navigation regions if the GridMap Node was moved.
GridMap with baked NavigationMesh did not create visuals for navigation debug at all.
GridMap clear() function was stuck in an RID delete loop with error spam from NavigationServer.

Part of #61293 and proposal [#4507](https://github.com/godotengine/godot-proposals/issues/4507)

Fixes #32244
Fixes #27216
Fixes #17118 since the doc is already merged now.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
