### PR TITLE
[3.x] Fix export var inferring wrong type of preload

### DIFF
--- a/modules/gdscript/gdscript_parser.cpp
+++ b/modules/gdscript/gdscript_parser.cpp
@@ -4993,6 +4993,7 @@ void GDScriptParser::_parse_class(ClassNode *p_class) {
 							}
 							member._export.hint = PROPERTY_HINT_RESOURCE_TYPE;
 							member._export.hint_string = res->get_class();
+							member._export.class_name = res->get_class();
 						}
 					}
 #ifdef TOOLS_ENABLED


### PR DESCRIPTION
When assigning 'export var' to preload, the class_name for export property was not bieng set in the _parse_class() function, which caused the export's native type to be mistaken as Object when using _type_from_property() function:
```
_type_from_property(PropertyInfo p_property, ...)
{ 
        DataType ret;
        ...
        // class_name is not set, so native_type = "Object"
        ret.native_type = p_property.class_name == StringName() ? "Object" : p_property.class_name;
        ...
        return ret;
}
```
This caused a parse error when used in a script.

Setting class_name for export property in _parse_class() removed the parse error.

Fixes #61752

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
