### PR TITLE
Decrease the default idle parse delay in the script editor

### DIFF
--- a/editor/editor_settings.cpp
+++ b/editor/editor_settings.cpp
@@ -662,7 +662,7 @@ void EditorSettings::_load_defaults(Ref<ConfigFile> p_extra_config) {
 	_initial_set("text_editor/script_list/sort_members_outline_alphabetically", false);
 
 	// Completion
-	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay", 2.0, "0.1,10,0.01")
+	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/idle_parse_delay", 1.5, "0.1,10,0.01")
 	_initial_set("text_editor/completion/auto_brace_complete", true);
 	_initial_set("text_editor/completion/code_complete_enabled", true);
 	EDITOR_SETTING(Variant::FLOAT, PROPERTY_HINT_RANGE, "text_editor/completion/code_complete_delay", 0.3, "0.01,5,0.01,or_greater")


### PR DESCRIPTION
This makes errors reported 0.5 seconds faster compared to the previous default value, and is closer to other code editors' behavior such as VS Code.

In 4.0, the script editor can now report multiple errors and still has working autocompletion when there's at least one error, so this is probably less annoying than it would be in `3.x`. Therefore, I recommend not cherry-picking this to `3.x` (at least for now).

See https://github.com/godotengine/godot-proposals/discussions/4625.