### PR TITLE
Fix typo for TAA resolve shader in `COPYRIGHT.txt`

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -132,7 +132,7 @@ Copyright: 2016, Intel Corporation
 License: Expat
 
 Files: ./servers/rendering/renderer_rd/shaders/taa_resolve.glsl
-Comment: Temporal Anti-Aliasing reslove implementation
+Comment: Temporal Anti-Aliasing resolve implementation
 Copyright: 2016, Panos Karabelas
 License: Expat
 


### PR DESCRIPTION
See https://github.com/godotengine/godot/pull/61319#pullrequestreview-998706068.