### PR TITLE
Made hidden ProjectSettings groups more explicit

### DIFF
--- a/core/config/project_settings.h
+++ b/core/config/project_settings.h
@@ -104,6 +104,7 @@ protected:
 	HashSet<String> custom_features;
 	HashMap<StringName, LocalVector<Pair<StringName, StringName>>> feature_overrides;
 
+	LocalVector<String> hidden_prefixes;
 	HashMap<StringName, AutoloadInfo> autoloads;
 
 	Array global_class_list;
@@ -168,6 +169,7 @@ public:
 	void set_restart_if_changed(const String &p_name, bool p_restart);
 	void set_ignore_value_in_docs(const String &p_name, bool p_ignore);
 	bool get_ignore_value_in_docs(const String &p_name) const;
+	void add_hidden_prefix(const String &p_prefix);
 
 	String get_project_data_dir_name() const;
 	String get_project_data_path() const;

--- a/editor/editor_autoload_settings.cpp
+++ b/editor/editor_autoload_settings.cpp
@@ -816,6 +816,8 @@ void EditorAutoloadSettings::_bind_methods() {
 }
 
 EditorAutoloadSettings::EditorAutoloadSettings() {
+	ProjectSettings::get_singleton()->add_hidden_prefix("autoload/");
+
 	// Make first cache
 	List<PropertyInfo> props;
 	ProjectSettings::get_singleton()->get_property_list(&props);

--- a/editor/editor_plugin_settings.cpp
+++ b/editor/editor_plugin_settings.cpp
@@ -205,6 +205,8 @@ void EditorPluginSettings::_bind_methods() {
 }
 
 EditorPluginSettings::EditorPluginSettings() {
+	ProjectSettings::get_singleton()->add_hidden_prefix("editor_plugins/");
+
 	plugin_config_dialog = memnew(PluginConfigDialog);
 	plugin_config_dialog->config("");
 	add_child(plugin_config_dialog);

--- a/editor/import_defaults_editor.cpp
+++ b/editor/import_defaults_editor.cpp
@@ -201,6 +201,8 @@ void ImportDefaultsEditor::_bind_methods() {
 }
 
 ImportDefaultsEditor::ImportDefaultsEditor() {
+	ProjectSettings::get_singleton()->add_hidden_prefix("importer_defaults/");
+
 	HBoxContainer *hb = memnew(HBoxContainer);
 	hb->add_child(memnew(Label(TTR("Importer:"))));
 	importers = memnew(OptionButton);

--- a/editor/shader_globals_editor.cpp
+++ b/editor/shader_globals_editor.cpp
@@ -424,6 +424,8 @@ void ShaderGlobalsEditor::_notification(int p_what) {
 }
 
 ShaderGlobalsEditor::ShaderGlobalsEditor() {
+	ProjectSettings::get_singleton()->add_hidden_prefix("shader_globals/");
+
 	HBoxContainer *add_menu_hb = memnew(HBoxContainer);
 	add_child(add_menu_hb);
 


### PR DESCRIPTION
Follow-up to #61751
Changes long `if` into a more clean list of prefixes.

I experimented with autoloads. At first I tried marking them as internal when added, but the problem is that this isn't saved. The properties are simply loaded with ProjectSettings resource and then re-flagged. So there is no avoiding `_get_property_list()` or `_validate_property()` without some bigger changes that just aren't worth it.