### PR TITLE
[3.5] Fix TileMap texture offset for navigationmesh and collisionshapes

### DIFF
--- a/scene/2d/tile_map.cpp
+++ b/scene/2d/tile_map.cpp
@@ -568,7 +568,7 @@ void TileMap::update_dirty_quadrants() {
 				if (shape.is_valid()) {
 					if (tile_set->tile_get_tile_mode(c.id) == TileSet::SINGLE_TILE || (shapes[j].autotile_coord.x == c.autotile_coord_x && shapes[j].autotile_coord.y == c.autotile_coord_y)) {
 						Transform2D xform;
-						xform.set_origin(offset.floor());
+						xform.set_origin(offset.floor() + tile_ofs);
 
 						Vector2 shape_ofs = shapes[j].shape_transform.get_origin();
 
@@ -617,7 +617,7 @@ void TileMap::update_dirty_quadrants() {
 
 				if (navpoly.is_valid()) {
 					Transform2D xform;
-					xform.set_origin(offset.floor() + q.pos);
+					xform.set_origin(offset.floor() + q.pos + tile_ofs);
 					_fix_cell_transform(xform, c, npoly_ofs, s);
 
 					RID region = Navigation2DServer::get_singleton()->region_create();
@@ -668,7 +668,7 @@ void TileMap::update_dirty_quadrants() {
 									}
 								}
 								Transform2D navxform;
-								navxform.set_origin(offset.floor());
+								navxform.set_origin(offset.floor() + tile_ofs);
 								_fix_cell_transform(navxform, c, npoly_ofs, s);
 
 								vs->canvas_item_set_transform(debug_navigation_item, navxform);


### PR DESCRIPTION
[3.5] Fix TileMap texture offset for navigationmesh and collisionshapes.

The texture offset was not added to naypolygons or collisionshapes and their debugs.

![tileoffsets_old](https://user-images.githubusercontent.com/52464204/172682040-9ccbbb6f-a954-4e65-8ce8-b3f3befa25ea.png)

![tileoffsets](https://user-images.githubusercontent.com/52464204/172680755-6c9540b1-a316-4d61-9806-e4250473516f.png)

Fixes #43214

... tbh no idea if this fixes everything ... the old 3.x tilemap code is big headache ... but the MRP works.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
