### PR TITLE
Fix ObjectDB instances leaked on state machine when editor closes

### DIFF
--- a/editor/plugins/animation_state_machine_editor.cpp
+++ b/editor/plugins/animation_state_machine_editor.cpp
@@ -817,11 +817,11 @@ bool AnimationNodeStateMachineEditor::_create_submenu(PopupMenu *p_menu, Ref<Ani
 	Vector<Ref<AnimationNodeStateMachine>> parents = p_parents;
 
 	if (from_root) {
-		Ref<AnimationNodeStateMachine> prev = p_nodesm->get_prev_state_machine();
+		AnimationNodeStateMachine *prev = p_nodesm->get_prev_state_machine();
 
-		while (prev.is_valid()) {
+		while (prev != nullptr) {
 			parents.push_back(prev);
-			p_nodesm = prev;
+			p_nodesm = Ref<AnimationNodeStateMachine>(prev);
 			prev_path += "../";
 			prev = prev->get_prev_state_machine();
 		}

--- a/scene/animation/animation_node_state_machine.h
+++ b/scene/animation/animation_node_state_machine.h
@@ -166,7 +166,7 @@ private:
 
 	StringName playback = "playback";
 	StringName state_machine_name;
-	Ref<AnimationNodeStateMachine> prev_state_machine;
+	AnimationNodeStateMachine *prev_state_machine = nullptr;
 	bool updating_transitions = false;
 
 	Vector2 graph_offset;
@@ -174,7 +174,7 @@ private:
 	void _tree_changed();
 	void _remove_transition(const Ref<AnimationNodeStateMachineTransition> p_transition);
 	void _rename_transition(const StringName &p_name, const StringName &p_new_name);
-	bool _can_connect(const StringName &p_name, const Vector<Ref<AnimationNodeStateMachine>> p_parents = Vector<Ref<AnimationNodeStateMachine>>()) const;
+	bool _can_connect(const StringName &p_name, Vector<AnimationNodeStateMachine *> p_parents = Vector<AnimationNodeStateMachine *>());
 	StringName _get_shortest_path(const StringName &p_path) const;
 
 protected:
@@ -221,7 +221,7 @@ public:
 
 	bool can_edit_node(const StringName &p_name) const;
 
-	Ref<AnimationNodeStateMachine> get_prev_state_machine() const;
+	AnimationNodeStateMachine *get_prev_state_machine() const;
 
 	void set_graph_offset(const Vector2 &p_offset);
 	Vector2 get_graph_offset() const;


### PR DESCRIPTION
Fix this message:
```
WARNING: ObjectDB instances leaked at exit (run with --verbose for details).
     at: cleanup (core/object/object.cpp:2024)
ERROR: Resources still in use at exit (run with --verbose for details).
   at: clear (core/io/resource.cpp:479)
```

To reproduce the error, you must create at least one sub state machine before close de editor.