### PR TITLE
Assign VIEWPORT_SIZE after validating screen_size to avoid crash when using ReflectionProbe

### DIFF
--- a/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/render_forward_clustered.cpp
@@ -1288,9 +1288,6 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 	RENDER_TIMESTAMP("Setup 3D Scene");
 
 	//scene_state.ubo.subsurface_scatter_width = subsurface_scatter_size;
-
-	scene_state.ubo.viewport_size[0] = render_buffer->width;
-	scene_state.ubo.viewport_size[1] = render_buffer->height;
 	scene_state.ubo.directional_light_count = 0;
 	scene_state.ubo.opaque_prepass_threshold = 0.99f;
 
@@ -1385,6 +1382,9 @@ void RenderForwardClustered::_render_scene(RenderDataRD *p_render_data, const Co
 	} else {
 		ERR_FAIL(); //bug?
 	}
+
+	scene_state.ubo.viewport_size[0] = screen_size.x;
+	scene_state.ubo.viewport_size[1] = screen_size.y;
 
 	RD::get_singleton()->draw_command_begin_label("Render Setup");
 

--- a/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/render_forward_mobile.cpp
@@ -485,8 +485,6 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 
 	RENDER_TIMESTAMP("Setup 3D Scene");
 
-	scene_state.ubo.viewport_size[0] = render_buffer->width;
-	scene_state.ubo.viewport_size[1] = render_buffer->height;
 	scene_state.ubo.directional_light_count = 0;
 	scene_state.ubo.opaque_prepass_threshold = 0.0;
 
@@ -565,6 +563,9 @@ void RenderForwardMobile::_render_scene(RenderDataRD *p_render_data, const Color
 	} else {
 		ERR_FAIL(); //bug?
 	}
+
+	scene_state.ubo.viewport_size[0] = screen_size.x;
+	scene_state.ubo.viewport_size[1] = screen_size.y;
 
 	RD::get_singleton()->draw_command_begin_label("Render Setup");
 


### PR DESCRIPTION
Fixes: #61824

``render_buffers`` can be null when using reflection probes as they don't use render buffers. We already handle the necessary logic when assigning ``screen_size`` so just reuse it.