### PR TITLE
Fix for regression of an ImageTexture being imported

### DIFF
--- a/scene/resources/texture.cpp
+++ b/scene/resources/texture.cpp
@@ -150,6 +150,7 @@ void ImageTexture::reload_from_file() {
 bool ImageTexture::_set(const StringName &p_name, const Variant &p_value) {
 	if (p_name == "image") {
 		create_from_image(p_value);
+		return true;
 	}
 	return false;
 }
@@ -157,6 +158,7 @@ bool ImageTexture::_set(const StringName &p_name, const Variant &p_value) {
 bool ImageTexture::_get(const StringName &p_name, Variant &r_ret) const {
 	if (p_name == "image") {
 		r_ret = get_image();
+		return true;
 	}
 	return false;
 }


### PR DESCRIPTION
Someone apparently forgot to return true ...
on ImageTexture::_set/_get

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
