### PR TITLE
[3.x] Add globals disabled feature to GDScript class

### DIFF
--- a/modules/gdscript/doc_classes/GDScript.xml
+++ b/modules/gdscript/doc_classes/GDScript.xml
@@ -6,6 +6,61 @@
 	<description>
 		A script implemented in the GDScript programming language. The script extends the functionality of all objects that instance it.
 		[method new] creates a new instance of the script. [method Object.set_script] extends an existing object, if that object's class matches one of the script's base classes.
+		A GDScript object can also be used as standalone, isolated script to safely run code supplied by players (either as mods or part of the game mechanic) if globals are disabled for that particular script. Disabling globals means all classes, engine singletons, project autoload scripts, and even constants which are not defined in that script (such as [code]PI[/code]) will no longer be accessible, and a script with globals disabled attempting to include those will fail to compile and run. (This is set per script, not per instance.)
+		Since node classes (such as [Node]) can't be accessed if globals are disabled (and therefore inheritance such as [code]extends Node[/code] is not possible), those scripts can only be created and used from other scripts, not directly as nodes in the [SceneTree].
+		Assuming the following [code]res://user_script.gd[/code]:
+		[codeblock]
+		var my_var
+
+		func my_func(arg):
+		    print("Hello %s!" % arg)
+		[/codeblock]
+		A node in the [SceneTree] can safely run this script with globals disabled:
+		[codeblock]
+		var new_script = load("res://user_script.gd")
+		new_script.set_globals_disabled(true)
+		if new_script.reload():
+		    # Script recompiled successfully
+		    var new_script_instance = new_script.new()
+		    # Any method can be called externally,
+		    # and variables can be externally assigned
+		    new_script_instance.my_var = 42
+		    new_script_instance.my_func("world")  # prints "Hello world!"
+		else:
+		    # Pauses with an error if running from the editor,
+		    # fails silently and continues running in standalone build
+		    print("Failed to compile script")
+		[/codeblock]
+		The script doesn't need to be stored as a [code].gd[/code] file. It can be compiled from source code retrieved or generated during gameplay:
+		[codeblock]
+		var my_source_code = "func main():\n    print(\"Hello world!\")\n"
+		var new_script = GDScript.new()
+		new_script.source_code = my_source_code
+		new_script.set_globals_disabled(true)
+		if new_script.reload():
+		    new_script.new().main()
+		else:
+		    print("Failed to compile script")
+		[/codeblock]
+		[b]Note:[/b] although global names won't work in the code, a script with globals disabled [i]can access[/i] anything if given [i]explicit[/i] access through method arguments or variable assignments. As example, assuming the [code]res://test_script.gd[/code] script:
+		[codeblock]
+		var input
+
+		func do_something():
+		    if input.is_action_pressed("ui_accept"):
+		        print("Hello world!")
+		[/codeblock]
+		The [code]input[/code] local variable can be used to give the script access to the [Input] singleton:
+		[codeblock]
+		var new_script = load("res://test_script.gd")
+		new_script.set_globals_disabled(true)
+		if new_script.reload():
+		    var new_script_instance = new_script.new()
+		    new_script_instance.set("input", Input)
+		    new_script_instance.do_something()
+		[/codeblock]
+		Notice the use of [method Object.set] instead of [code]new_script_instance.input = Input[/code]. If the user script did not declare the [code]input[/code] variable, using [method Object.set] fails silently, and therefore declaring and using the variable becomes optional from the user point of view.
+		[b]Warning:[/b] since the scripts with globals disabled can access any properties and methods of objects which are explicitly given to them, critical care must be taken when exposing those objects. As example, if a node in the [SceneTree] is given, methods such as [method Node.get_node] or [method Node.get_tree] would give the script access to a large part or potentially the whole of the project. For cases like game mods (which usually need to expose running game objects and assets), an intermediate interface must be carefully designed to prevent abuse.
 	</description>
 	<tutorials>
 		<link>$DOCS_URL/tutorials/scripting/gdscript/index.html</link>
@@ -15,6 +70,12 @@
 			<return type="PoolByteArray" />
 			<description>
 				Returns byte code for the script source code.
+			</description>
+		</method>
+		<method name="is_globals_disabled">
+			<return type="bool" />
+			<description>
+				Returns [code]true[/code] if globals are disabled for this script.
 			</description>
 		</method>
 		<method name="new" qualifiers="vararg">
@@ -27,6 +88,13 @@
 				var instance = MyClass.new()
 				assert(instance.get_script() == MyClass)
 				[/codeblock]
+			</description>
+		</method>
+		<method name="set_globals_disabled">
+			<return type="void" />
+			<argument index="0" name="disabled" type="bool" />
+			<description>
+				Sets whether access to globals should be disabled for this script, including class names, engine singletons, project autoload scripts, and anything not defined in the script itself or given explicit access externally.
 			</description>
 		</method>
 	</methods>

--- a/modules/gdscript/gdscript.cpp
+++ b/modules/gdscript/gdscript.cpp
@@ -719,6 +719,8 @@ void GDScript::_bind_methods() {
 	ClassDB::bind_vararg_method(METHOD_FLAGS_DEFAULT, "new", &GDScript::_new, MethodInfo("new"));
 
 	ClassDB::bind_method(D_METHOD("get_as_byte_code"), &GDScript::get_as_byte_code);
+	ClassDB::bind_method(D_METHOD("is_globals_disabled"), &GDScript::is_globals_disabled);
+	ClassDB::bind_method(D_METHOD("set_globals_disabled", "disabled"), &GDScript::set_globals_disabled);
 }
 
 Vector<uint8_t> GDScript::get_as_byte_code() const {
@@ -910,6 +912,7 @@ GDScript::GDScript() :
 	_base = nullptr;
 	_owner = nullptr;
 	tool = false;
+	globals_disabled = false;
 #ifdef TOOLS_ENABLED
 	source_changed_cache = false;
 	placeholder_fallback_enabled = false;

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -56,6 +56,7 @@ class GDScript : public Script {
 	GDCLASS(GDScript, Script);
 	bool tool;
 	bool valid;
+	bool globals_disabled;
 
 	struct MemberInfo {
 		int index;
@@ -146,6 +147,9 @@ protected:
 	static void _bind_methods();
 
 public:
+	bool is_globals_disabled() { return globals_disabled; }
+	void set_globals_disabled(bool p_disabled) { globals_disabled = p_disabled; }
+
 	virtual bool is_valid() const { return valid; }
 
 	bool inherits_script(const Ref<Script> &p_script) const;

--- a/modules/gdscript/gdscript_compiler.cpp
+++ b/modules/gdscript/gdscript_compiler.cpp
@@ -324,54 +324,56 @@ int GDScriptCompiler::_parse_expression(CodeGen &codegen, const GDScriptParser::
 				owner = owner->_owner;
 			}
 
-			if (GDScriptLanguage::get_singleton()->get_global_map().has(identifier)) {
-				int idx = GDScriptLanguage::get_singleton()->get_global_map()[identifier];
-				return idx | (GDScriptFunction::ADDR_TYPE_GLOBAL << GDScriptFunction::ADDR_BITS); //argument (stack root)
-			}
-
-			/* TRY GLOBAL CLASSES */
-
-			if (ScriptServer::is_global_class(identifier)) {
-				const GDScriptParser::ClassNode *class_node = codegen.class_node;
-				while (class_node->owner) {
-					class_node = class_node->owner;
+			if (!codegen.script->is_globals_disabled()) {
+				if (GDScriptLanguage::get_singleton()->get_global_map().has(identifier)) {
+					int idx = GDScriptLanguage::get_singleton()->get_global_map()[identifier];
+					return idx | (GDScriptFunction::ADDR_TYPE_GLOBAL << GDScriptFunction::ADDR_BITS); //argument (stack root)
 				}
 
-				if (class_node->name == identifier) {
-					_set_error("Using own name in class file is not allowed (creates a cyclic reference)", p_expression);
-					return -1;
+				/* TRY GLOBAL CLASSES */
+
+				if (ScriptServer::is_global_class(identifier)) {
+					const GDScriptParser::ClassNode *class_node = codegen.class_node;
+					while (class_node->owner) {
+						class_node = class_node->owner;
+					}
+
+					if (class_node->name == identifier) {
+						_set_error("Using own name in class file is not allowed (creates a cyclic reference)", p_expression);
+						return -1;
+					}
+
+					RES res = ResourceLoader::load(ScriptServer::get_global_class_path(identifier));
+					if (res.is_null()) {
+						_set_error("Can't load global class " + String(identifier) + ", cyclic reference?", p_expression);
+						return -1;
+					}
+
+					Variant key = res;
+					int idx;
+
+					if (!codegen.constant_map.has(key)) {
+						idx = codegen.constant_map.size();
+						codegen.constant_map[key] = idx;
+
+					} else {
+						idx = codegen.constant_map[key];
+					}
+
+					return idx | (GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS); //make it a local constant (faster access)
 				}
-
-				RES res = ResourceLoader::load(ScriptServer::get_global_class_path(identifier));
-				if (res.is_null()) {
-					_set_error("Can't load global class " + String(identifier) + ", cyclic reference?", p_expression);
-					return -1;
-				}
-
-				Variant key = res;
-				int idx;
-
-				if (!codegen.constant_map.has(key)) {
-					idx = codegen.constant_map.size();
-					codegen.constant_map[key] = idx;
-
-				} else {
-					idx = codegen.constant_map[key];
-				}
-
-				return idx | (GDScriptFunction::ADDR_TYPE_LOCAL_CONSTANT << GDScriptFunction::ADDR_BITS); //make it a local constant (faster access)
-			}
 
 #ifdef TOOLS_ENABLED
-			if (GDScriptLanguage::get_singleton()->get_named_globals_map().has(identifier)) {
-				int idx = codegen.named_globals.find(identifier);
-				if (idx == -1) {
-					idx = codegen.named_globals.size();
-					codegen.named_globals.push_back(identifier);
+				if (GDScriptLanguage::get_singleton()->get_named_globals_map().has(identifier)) {
+					int idx = codegen.named_globals.find(identifier);
+					if (idx == -1) {
+						idx = codegen.named_globals.size();
+						codegen.named_globals.push_back(identifier);
+					}
+					return idx | (GDScriptFunction::ADDR_TYPE_NAMED_GLOBAL << GDScriptFunction::ADDR_BITS);
 				}
-				return idx | (GDScriptFunction::ADDR_TYPE_NAMED_GLOBAL << GDScriptFunction::ADDR_BITS);
-			}
 #endif
+			}
 
 			//not found, error
 


### PR DESCRIPTION
Some games and apps involve players typing their own code, which is then interpreted/executed as part of the process.

One example is games where the player is expected to write logic as part of the game mechanic (control robots, hack into fictional systems, etc). There is an entire game genre based on this (https://en.wikipedia.org/wiki/Programming_game).

Another example is games which can be customized by players (mods), including writing script code (e.g. enemy AI).

In the projects I have worked so far with this mechanic, I had to design a scripting language and write my own interpreter (I have seen others trying the same as well). Due to having to write the interpreter, the scripting was rudimentary (sequential) and my players complained they wanted usual programming features like branching, loops, functions, local variables, etc, and were frustrated by the lack of.

GDScript could be used to implement in-game programming with a very functional, complex, stable and user friendly language, and it comes with a compiler for free, zero dev effort. However, due to the access to the engine globals, this comes with severe issues. Players could:

- Break the game behaviour
- Call `OS` and damage something in their computer
- Call `ResourceSaver` and steal assets
- In multiplayer games (or with leaderboards), print to console server confidential credentials

And if players are meant to share scripts (e.g. mods), hell is unleashed with anything from "delete all hdd" pranks to trojan horse attacks.

Therefore, so far using GDScript to power in-game general purpose scripting is "a nice thing you can't have".

This PR adds a feature to the `GDScript` class allowing to disable globals, per script. All game scripts behave as usual by default, but an individual script can have a flag set so that specific script won't have access to any engine globals, including class names, singletons and constants, becoming detached from the game system. It still _can access_ anything if access is _explicitly given_, via variables or method arguments.

The code below demonstrates how to use the new `set_globals_disabled` method.

Assuming a file `res://user_script.gd` (or a String assigned via `GDScript.source_code`), which is meant to be isolated:

```swift
var my_var

func my_func(arg):
    print("Hello %s!" % arg)
```

A node can safely run this script with globals disabled:

```swift
var new_script = load("res://user_script.gd")
new_script.set_globals_disabled(true)
if new_script.reload():
    # Script recompiled successfully
    var new_script_instance = new_script.new()
    # Any method can be called externally,
    # and variables can be externally assigned
    new_script_instance.my_var = 42
    new_script_instance.my_func("world")  # prints "Hello world!"
else:
    # Pauses with an error if running from the editor,
    # fails silently and continues running in standalone build
    print("Failed to compile script")
```

An example to give explicit access to something, assuming the `res://test_script.gd` script:

```swift
var input

func do_something():
    if input.is_action_pressed("ui_accept"):
        print("Hello world!")
```

The `input` local variable can be used to give the script access to the `Input` singleton:

```swift
var new_script = load("res://test_script.gd")
new_script.set_globals_disabled(true)
if new_script.reload():
    var new_script_instance = new_script.new()
    new_script_instance.set("input", Input) # Fails silently if user doesn't want to declare or use `var input`
    new_script_instance.do_something()
```

Function arguments also work with external objects. The following script would work even with globals disabled, if `ai_search_player` is called externally providing the `KinematicBody` arguments:

```swift
func ai_search_player(my_kinematic_body, player_kinematic_body):
    player_distance = (player_body.global_transform.origin - my_body.global_transform.origin).length()
```

For mod systems where a subset of the engine functionality should be exposed, access to an interface node can be given to the isolated script (like the `input` example), that node having a selection of methods an properties as required in the modding system. In other words, that node would work like a master singleton for the isolated script.