### PR TITLE
[WebRTC] Static extension registration.

### DIFF
--- a/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
+++ b/modules/webrtc/doc_classes/WebRTCPeerConnection.xml
@@ -95,6 +95,13 @@
 				Call this method frequently (e.g. in [method Node._process] or [method Node._physics_process]) to properly receive signals.
 			</description>
 		</method>
+		<method name="set_default_extension" qualifiers="static">
+			<return type="void" />
+			<argument index="0" name="extension_class" type="StringName" />
+			<description>
+				Sets the [code]extension_class[/code] as the default [WebRTCPeerConnectionExtension] returned when creating a new [WebRTCPeerConnection].
+			</description>
+		</method>
 		<method name="set_local_description">
 			<return type="int" enum="Error" />
 			<argument index="0" name="type" type="String" />

--- a/modules/webrtc/doc_classes/WebRTCPeerConnectionExtension.xml
+++ b/modules/webrtc/doc_classes/WebRTCPeerConnectionExtension.xml
@@ -62,10 +62,5 @@
 			<description>
 			</description>
 		</method>
-		<method name="make_default">
-			<return type="void" />
-			<description>
-			</description>
-		</method>
 	</methods>
 </class>

--- a/modules/webrtc/webrtc_peer_connection.cpp
+++ b/modules/webrtc/webrtc_peer_connection.cpp
@@ -32,13 +32,14 @@
 
 #ifdef JAVASCRIPT_ENABLED
 #include "webrtc_peer_connection_js.h"
-#else
-#include "webrtc_peer_connection_extension.h"
 #endif
+
+#include "webrtc_peer_connection_extension.h"
 
 StringName WebRTCPeerConnection::default_extension;
 
 void WebRTCPeerConnection::set_default_extension(const StringName &p_extension) {
+	ERR_FAIL_COND_MSG(!ClassDB::is_parent_class(p_extension, WebRTCPeerConnectionExtension::get_class_static()), vformat("Can't make %s the default WebRTC extension since it does not extend WebRTCPeerConnectionExtension.", p_extension));
 	default_extension = p_extension;
 }
 
@@ -56,6 +57,8 @@ WebRTCPeerConnection *WebRTCPeerConnection::create() {
 }
 
 void WebRTCPeerConnection::_bind_methods() {
+	ClassDB::bind_static_method(get_class_static(), D_METHOD("set_default_extension", "extension_class"), &WebRTCPeerConnectionExtension::set_default_extension);
+
 	ClassDB::bind_method(D_METHOD("initialize", "configuration"), &WebRTCPeerConnection::initialize, DEFVAL(Dictionary()));
 	ClassDB::bind_method(D_METHOD("create_data_channel", "label", "options"), &WebRTCPeerConnection::create_data_channel, DEFVAL(Dictionary()));
 	ClassDB::bind_method(D_METHOD("create_offer"), &WebRTCPeerConnection::create_offer);

--- a/modules/webrtc/webrtc_peer_connection_extension.cpp
+++ b/modules/webrtc/webrtc_peer_connection_extension.cpp
@@ -31,8 +31,6 @@
 #include "webrtc_peer_connection_extension.h"
 
 void WebRTCPeerConnectionExtension::_bind_methods() {
-	ClassDB::bind_method(D_METHOD("make_default"), &WebRTCPeerConnectionExtension::make_default);
-
 	GDVIRTUAL_BIND(_get_connection_state);
 	GDVIRTUAL_BIND(_initialize, "p_config");
 	GDVIRTUAL_BIND(_create_data_channel, "p_label", "p_config");
@@ -42,11 +40,6 @@ void WebRTCPeerConnectionExtension::_bind_methods() {
 	GDVIRTUAL_BIND(_add_ice_candidate, "p_sdp_mid_name", "p_sdp_mline_index", "p_sdp_name");
 	GDVIRTUAL_BIND(_poll);
 	GDVIRTUAL_BIND(_close);
-}
-
-void WebRTCPeerConnectionExtension::make_default() {
-	ERR_FAIL_COND_MSG(!_get_extension(), vformat("Can't make %s the default without extending it.", get_class()));
-	WebRTCPeerConnection::set_default_extension(get_class());
 }
 
 WebRTCPeerConnection::ConnectionState WebRTCPeerConnectionExtension::get_connection_state() const {

--- a/modules/webrtc/webrtc_peer_connection_extension.h
+++ b/modules/webrtc/webrtc_peer_connection_extension.h
@@ -44,8 +44,6 @@ protected:
 	static void _bind_methods();
 
 public:
-	void make_default();
-
 	virtual ConnectionState get_connection_state() const override;
 
 	virtual Error initialize(Dictionary p_config = Dictionary()) override;


### PR DESCRIPTION
Move WebRTC extension registration from `WebRTCPeerConnectionExtension` to a static method of `WebRTCPeerConnection`.

This let the official WebRTC plugin register without having to instantiate itself.