### PR TITLE
Single-window mode popups and edited scene windows fixes.

### DIFF
--- a/scene/gui/popup.cpp
+++ b/scene/gui/popup.cpp
@@ -108,9 +108,7 @@ void Popup::_close_pressed() {
 
 	_deinitialize_visible_parents();
 
-	// Hide after returning to process events, but only if we don't
-	// get popped up in the interim.
-	call_deferred(SNAME("_popup_conditional_hide"));
+	call_deferred(SNAME("hide"));
 }
 
 void Popup::_post_popup() {
@@ -118,15 +116,8 @@ void Popup::_post_popup() {
 	popped_up = true;
 }
 
-void Popup::_popup_conditional_hide() {
-	if (!popped_up) {
-		hide();
-	}
-}
-
 void Popup::_bind_methods() {
 	ADD_SIGNAL(MethodInfo("popup_hide"));
-	ClassDB::bind_method(D_METHOD("_popup_conditional_hide"), &Popup::_popup_conditional_hide);
 }
 
 Rect2i Popup::_popup_adjust_rect() const {

--- a/scene/gui/popup.h
+++ b/scene/gui/popup.h
@@ -48,8 +48,6 @@ class Popup : public Window {
 	void _initialize_visible_parents();
 	void _deinitialize_visible_parents();
 
-	void _parent_focused();
-
 protected:
 	void _close_pressed();
 	virtual Rect2i _popup_adjust_rect() const override;
@@ -57,7 +55,7 @@ protected:
 	void _notification(int p_what);
 	static void _bind_methods();
 
-	void _popup_conditional_hide();
+	virtual void _parent_focused();
 
 	virtual void _post_popup() override;
 

--- a/scene/gui/popup_menu.cpp
+++ b/scene/gui/popup_menu.cpp
@@ -243,6 +243,29 @@ void PopupMenu::_activate_submenu(int p_over, bool p_by_keyboard) {
 	}
 }
 
+void PopupMenu::_parent_focused() {
+	if (is_embedded()) {
+		Point2 mouse_pos_adjusted;
+		Window *window_parent = Object::cast_to<Window>(get_parent()->get_viewport());
+		while (window_parent) {
+			if (!window_parent->is_embedded()) {
+				mouse_pos_adjusted += window_parent->get_position();
+				break;
+			}
+
+			window_parent = Object::cast_to<Window>(window_parent->get_parent()->get_viewport());
+		}
+
+		Rect2 safe_area = DisplayServer::get_singleton()->window_get_popup_safe_rect(get_window_id());
+		Point2 pos = DisplayServer::get_singleton()->mouse_get_position() - mouse_pos_adjusted;
+		if (safe_area == Rect2i() || !safe_area.has_point(pos)) {
+			Popup::_parent_focused();
+		} else {
+			grab_focus();
+		}
+	}
+}
+
 void PopupMenu::_submenu_timeout() {
 	if (mouse_over == submenu_over) {
 		_activate_submenu(mouse_over);

--- a/scene/gui/popup_menu.h
+++ b/scene/gui/popup_menu.h
@@ -148,6 +148,8 @@ public:
 	// this value should be updated to reflect the new size.
 	static const int ITEM_PROPERTY_SIZE = 10;
 
+	virtual void _parent_focused() override;
+
 	void add_item(const String &p_label, int p_id = -1, Key p_accel = Key::NONE);
 	void add_icon_item(const Ref<Texture2D> &p_icon, const String &p_label, int p_id = -1, Key p_accel = Key::NONE);
 	void add_check_item(const String &p_label, int p_id = -1, Key p_accel = Key::NONE);


### PR DESCRIPTION
- Fix single-window mode popup not closing when OptionBox is clicked.
- Fix single-window mode submenus closing when parent menu item, that was used to open it is clicked (using same safe-area logic as platform specific code).
- Disallow windows that are part of an edited scene from being set as exclusive or popup to prevent it from locking up the editor.

Fixes #61350
