### PR TITLE
[3.5] Backport default World navigation maps

### DIFF
--- a/doc/classes/ProjectSettings.xml
+++ b/doc/classes/ProjectSettings.xml
@@ -990,6 +990,18 @@
 			The policy to use for unhandled Mono (C#) exceptions. The default "Terminate Application" exits the project as soon as an unhandled exception is thrown. "Log Error" logs an error message to the console instead, and will not interrupt the project execution when an unhandled exception is thrown.
 			[b]Note:[/b] The unhandled exception policy is always set to "Log Error" in the editor, which also includes C# [code]tool[/code] scripts running within the editor as well as editor plugin code.
 		</member>
+		<member name="navigation/2d/default_cell_size" type="int" setter="" getter="" default="1">
+			Default cell size for 2D navigation maps. See [method Navigation2DServer.map_set_cell_size].
+		</member>
+		<member name="navigation/2d/default_edge_connection_margin" type="int" setter="" getter="" default="1">
+			Default edge connection margin for 2D navigation maps. See [method Navigation2DServer.map_set_edge_connection_margin].
+		</member>
+		<member name="navigation/3d/default_cell_size" type="float" setter="" getter="" default="0.25">
+			Default cell size for 3D navigation maps. See [method NavigationServer.map_set_cell_size].
+		</member>
+		<member name="navigation/3d/default_edge_connection_margin" type="float" setter="" getter="" default="0.25">
+			Default edge connection margin for 3D navigation maps. See [method NavigationServer.map_set_edge_connection_margin].
+		</member>
 		<member name="network/limits/debugger_stdout/max_chars_per_second" type="int" setter="" getter="" default="2048">
 			Maximum amount of characters allowed to send as output from the debugger. Over this value, content is dropped. This helps not to stall the debugger connection.
 		</member>

--- a/doc/classes/World.xml
+++ b/doc/classes/World.xml
@@ -21,6 +21,9 @@
 		<member name="fallback_environment" type="Environment" setter="set_fallback_environment" getter="get_fallback_environment">
 			The World's fallback_environment will be used if the World's [Environment] fails or is missing.
 		</member>
+		<member name="navigation_map" type="RID" setter="" getter="get_navigation_map">
+			The [RID] of this world's navigation map. Used by the [NavigationServer].
+		</member>
 		<member name="scenario" type="RID" setter="" getter="get_scenario">
 			The World's visual scenario.
 		</member>

--- a/doc/classes/World2D.xml
+++ b/doc/classes/World2D.xml
@@ -18,6 +18,9 @@
 		<member name="direct_space_state" type="Physics2DDirectSpaceState" setter="" getter="get_direct_space_state">
 			Direct access to the world's physics 2D space state. Used for querying current and potential collisions. When using multi-threaded physics, access is limited to [code]_physics_process(delta)[/code] in the main thread.
 		</member>
+		<member name="navigation_map" type="RID" setter="" getter="get_navigation_map">
+			The [RID] of this world's navigation map. Used by the [Navigation2DServer].
+		</member>
 		<member name="space" type="RID" setter="" getter="get_space">
 			The [RID] of this world's physics space resource. Used by the [Physics2DServer] for 2D physics, treating it as both a space and an area.
 		</member>

--- a/scene/resources/world.cpp
+++ b/scene/resources/world.cpp
@@ -35,6 +35,7 @@
 #include "scene/3d/camera.h"
 #include "scene/3d/visibility_notifier.h"
 #include "scene/scene_string_names.h"
+#include "servers/navigation_server.h"
 
 struct SpatialIndexer {
 	Octree<VisibilityNotifier> octree;
@@ -245,6 +246,10 @@ RID World::get_scenario() const {
 	return scenario;
 }
 
+RID World::get_navigation_map() const {
+	return navigation_map;
+}
+
 void World::set_environment(const Ref<Environment> &p_environment) {
 	if (environment == p_environment) {
 		return;
@@ -296,6 +301,7 @@ void World::get_camera_list(List<Camera *> *r_cameras) {
 void World::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_space"), &World::get_space);
 	ClassDB::bind_method(D_METHOD("get_scenario"), &World::get_scenario);
+	ClassDB::bind_method(D_METHOD("get_navigation_map"), &World::get_navigation_map);
 	ClassDB::bind_method(D_METHOD("set_environment", "env"), &World::set_environment);
 	ClassDB::bind_method(D_METHOD("get_environment"), &World::get_environment);
 	ClassDB::bind_method(D_METHOD("set_fallback_environment", "env"), &World::set_fallback_environment);
@@ -305,6 +311,7 @@ void World::_bind_methods() {
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "fallback_environment", PROPERTY_HINT_RESOURCE_TYPE, "Environment"), "set_fallback_environment", "get_fallback_environment");
 	ADD_PROPERTY(PropertyInfo(Variant::_RID, "space", PROPERTY_HINT_NONE, "", 0), "", "get_space");
 	ADD_PROPERTY(PropertyInfo(Variant::_RID, "scenario", PROPERTY_HINT_NONE, "", 0), "", "get_scenario");
+	ADD_PROPERTY(PropertyInfo(Variant::_RID, "navigation_map", PROPERTY_HINT_NONE, "", 0), "", "get_navigation_map");
 	ADD_PROPERTY(PropertyInfo(Variant::OBJECT, "direct_space_state", PROPERTY_HINT_RESOURCE_TYPE, "PhysicsDirectSpaceState", 0), "", "get_direct_space_state");
 }
 
@@ -320,6 +327,11 @@ World::World() {
 	PhysicsServer::get_singleton()->area_set_param(space, PhysicsServer::AREA_PARAM_ANGULAR_DAMP, GLOBAL_DEF("physics/3d/default_angular_damp", 0.1));
 	ProjectSettings::get_singleton()->set_custom_property_info("physics/3d/default_angular_damp", PropertyInfo(Variant::REAL, "physics/3d/default_angular_damp", PROPERTY_HINT_RANGE, "-1,100,0.001,or_greater"));
 
+	navigation_map = NavigationServer::get_singleton()->map_create();
+	NavigationServer::get_singleton()->map_set_active(navigation_map, true);
+	NavigationServer::get_singleton()->map_set_cell_size(navigation_map, GLOBAL_DEF("navigation/3d/default_cell_size", 0.25));
+	NavigationServer::get_singleton()->map_set_edge_connection_margin(navigation_map, GLOBAL_DEF("navigation/3d/default_edge_connection_margin", 0.25));
+
 #ifdef _3D_DISABLED
 	indexer = NULL;
 #else
@@ -330,6 +342,7 @@ World::World() {
 World::~World() {
 	PhysicsServer::get_singleton()->free(space);
 	VisualServer::get_singleton()->free(scenario);
+	NavigationServer::get_singleton()->free(navigation_map);
 
 #ifndef _3D_DISABLED
 	memdelete(indexer);

--- a/scene/resources/world.h
+++ b/scene/resources/world.h
@@ -47,6 +47,8 @@ class World : public Resource {
 private:
 	RID space;
 	RID scenario;
+	RID navigation_map;
+
 	SpatialIndexer *indexer;
 	Ref<Environment> environment;
 	Ref<Environment> fallback_environment;
@@ -70,6 +72,7 @@ protected:
 public:
 	RID get_space() const;
 	RID get_scenario() const;
+	RID get_navigation_map() const;
 
 	void set_environment(const Ref<Environment> &p_environment);
 	Ref<Environment> get_environment() const;

--- a/scene/resources/world_2d.h
+++ b/scene/resources/world_2d.h
@@ -44,6 +44,7 @@ class World2D : public Resource {
 
 	RID canvas;
 	RID space;
+	RID navigation_map;
 
 	SpatialIndexer2D *indexer;
 
@@ -65,6 +66,7 @@ protected:
 public:
 	RID get_canvas();
 	RID get_space();
+	RID get_navigation_map();
 
 	Physics2DDirectSpaceState *get_direct_space_state();
 


### PR DESCRIPTION
Backports from Godot 4.0 the default navigation maps created with each World resource.

Some first-time setup fails with certain navigation related nodes  if no map is set which makes procedual navigation in Godot 3.5 problematic. This allows the same placement flexiblity as in Godot 4.0 and also makes navigation tutorials more compatible.

Godot 3.5 still uses the old Navigation/Navigation2D nodes for compatibility but having a certain node structure as hard requirement to place navigation related nodes makes is very restricting and limits navigation gameplay.

If this gets merged NavigationRegions, NavigationAgents and NavigationObstacles will be adjusted in followup PRs.

The idea is that nodes that use a navigation map, e.g. regions, agents and obstacles, should use the Navigation/Navigation2D node parent if found and if not should use the default world navigation map as a fallback.

<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
