### PR TITLE
Fix infinite loop when calling `Control.popup_centered_minsize()`

### DIFF
--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -206,6 +206,12 @@ void Control::set_custom_minimum_size(const Size2 &p_custom) {
 	if (p_custom == data.custom_minimum_size) {
 		return;
 	}
+
+	if (isnan(p_custom.x) || isnan(p_custom.y)) {
+		// Prevent infinite loop.
+		return;
+	}
+
 	data.custom_minimum_size = p_custom;
 	update_minimum_size();
 }


### PR DESCRIPTION
This salvages https://github.com/godotengine/godot/pull/60340. Thanks @sriramun for the original fix :slightly_smiling_face:

*Bugsquad edit:*
- Fixes #60326
- Fixes #60376