### PR TITLE
Fix issue with overlaping text label text

### DIFF
--- a/scene/gui/rich_text_label.cpp
+++ b/scene/gui/rich_text_label.cpp
@@ -821,17 +821,18 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 			off.y += line_spacing;
 		}
 
-		RID rid = l.text_buf->get_line_rid(line);
 		if (p_ofs.y + off.y >= ctrl_size.height) {
 			break;
 		}
-		if (p_ofs.y + off.y + TS->shaped_text_get_size(rid).y <= 0) {
-			off.y += TS->shaped_text_get_size(rid).y;
+
+		const Size2 line_size = l.text_buf->get_line_size(line);
+		if (p_ofs.y + off.y + line_size.y <= 0) {
+			off.y += line_size.y;
 			continue;
 		}
 
 		float width = l.text_buf->get_width();
-		float length = TS->shaped_text_get_width(rid);
+		float length = line_size.x;
 
 		// Draw line.
 		line_count++;
@@ -874,6 +875,7 @@ int RichTextLabel::_draw_line(ItemFrame *p_frame, int p_line, const Vector2 &p_o
 			}
 		}
 
+		RID rid = l.text_buf->get_line_rid(line);
 		//draw_rect(Rect2(p_ofs + off, TS->shaped_text_get_size(rid)), Color(1,0,0), false, 2); //DEBUG_RECTS
 
 		off.y += TS->shaped_text_get_ascent(rid);


### PR DESCRIPTION
Fixes https://github.com/godotengine/godot/issues/55004 .

Before:
![before](https://user-images.githubusercontent.com/9964886/172917754-32736039-1b44-48c1-8d37-f4e3650adef0.png)

After:
![after](https://user-images.githubusercontent.com/9964886/172917776-7907e5e6-535c-4025-9cf1-f3c4b98838bc.png)

Previously there was mismatch between sizing in various places in this file (and my guess is there still are mismatches), this part in particular was using text server size function, which did not take into account spacing. Using function `get_line_size` on `text_buf` fixes this, it uses `TS` internally anyways and takes into account spacing.

I tested various standard usages of RichTextLabel, not only in console, and it seems to be working. 