### PR TITLE
Add support for saving lightmap as multiple images

### DIFF
--- a/scene/3d/lightmap_gi.h
+++ b/scene/3d/lightmap_gi.h
@@ -61,6 +61,8 @@ class LightmapGIData : public Resource {
 	Array _get_user_data() const;
 	void _set_probe_data(const Dictionary &p_data);
 	Dictionary _get_probe_data() const;
+	void _set_light_textures_data(const Array &p_data);
+	Array _get_light_textures_data() const;
 
 protected:
 	static void _bind_methods();


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->
`master` port of #58102.

Needs to be tested on a really large scene for the "roll-over to multiple textures" limit to be reached. I have only tested by hardcoding `slices_per_texture = 1`, but in theory, should work just fine for the general case too.

~~Also, currently there is lightmap texture data duplication as both the individual textures and the combined texture co-exist. Need to figure out a way around it. (This only happens when the texture data cannot be contained in a single `Image`; so no overhead until the roll-over limit is reached).~~ ✅
