### PR TITLE
added info on microphone sample format

### DIFF
--- a/doc/classes/AudioEffectCapture.xml
+++ b/doc/classes/AudioEffectCapture.xml
@@ -5,7 +5,7 @@
 	</brief_description>
 	<description>
 		AudioEffectCapture is an AudioEffect which copies all audio frames from the attached audio effect bus into its internal ring buffer.
-		Application code should consume these audio frames from this ring buffer using [method get_buffer] and process it as needed, for example to capture data from a microphone, implement application defined effects, or to transmit audio over the network.
+		Application code should consume these audio frames from this ring buffer using [method get_buffer] and process it as needed, for example to capture data from a microphone, implement application defined effects, or to transmit audio over the network. When capturing audio data from a microphone, the format of the samples will be stereo 32-bit floating point PCM.
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
<!--
Pull requests should always be made for the `master` branch first, as that's
where development happens and the source of all future stable release branches.

Relevant fixes are cherry-picked for stable branches as needed.

Do not create a pull request for stable branches unless the change is already
available in the `master` branch and it cannot be easily cherry-picked.
Alternatively, if the change is only relevant for that branch (e.g. rendering
fixes for the 3.2 branch).
-->

After some discussions on Discord, it seems reasonable to add this info to the documentation. While AudioStreamSample has a get_format method, AudioStreamMicrophone does not, and empirically I found that the sample format was 32-bit floating point PCM. I believe that this is also consistent with what I am reading in the code here:

permalink off master: https://github.com/godotengine/godot/blob/d120b099f528673fb6aebaa5d9cff0fa91a774d0/servers/audio/audio_stream.cpp#L269

I find this information useful as I have been using AudioEffectCapture to stream raw audio from the microphone to ASR services for speech-enhanced games, and while the use-cases which require this low-level sample format knowledge might be limited, this is at least one use-case.

(P.S. I originally mistakenly made this PR to the docs repo here: https://github.com/godotengine/godot-docs/pull/5868)