### PR TITLE
GDExtension refactor: `PropertyInfo` code reuse

### DIFF
--- a/core/extension/native_extension.cpp
+++ b/core/extension/native_extension.cpp
@@ -55,14 +55,7 @@ protected:
 	virtual PropertyInfo _gen_argument_type_info(int p_arg) const override {
 		GDNativePropertyInfo pinfo;
 		get_argument_info_func(method_userdata, p_arg, &pinfo);
-		PropertyInfo ret;
-		ret.type = Variant::Type(pinfo.type);
-		ret.name = pinfo.name;
-		ret.class_name = pinfo.class_name;
-		ret.hint = PropertyHint(pinfo.hint);
-		ret.usage = pinfo.usage;
-		ret.class_name = pinfo.class_name;
-		return ret;
+		return PropertyInfo(pinfo);
 	}
 
 public:
@@ -204,16 +197,11 @@ void NativeExtension::_register_extension_class_property(const GDNativeExtension
 	NativeExtension *self = static_cast<NativeExtension *>(p_library);
 
 	StringName class_name = p_class_name;
-	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), "Attempt to register extension class property '" + String(p_info->name) + "' for unexisting class '" + class_name + "'.");
+	String property_name = p_info->name;
+	ERR_FAIL_COND_MSG(!self->extension_classes.has(class_name), "Attempt to register extension class property '" + property_name + "' for unexisting class '" + class_name + "'.");
 
 	//Extension *extension = &self->extension_classes[class_name];
-	PropertyInfo pinfo;
-	pinfo.type = Variant::Type(p_info->type);
-	pinfo.name = p_info->name;
-	pinfo.class_name = p_info->class_name;
-	pinfo.hint = PropertyHint(p_info->hint);
-	pinfo.hint_string = p_info->hint_string;
-	pinfo.usage = p_info->usage;
+	PropertyInfo pinfo(*p_info);
 
 	ClassDB::add_property(class_name, pinfo, p_setter, p_getter);
 }
@@ -245,13 +233,7 @@ void NativeExtension::_register_extension_class_signal(const GDNativeExtensionCl
 	MethodInfo s;
 	s.name = p_signal_name;
 	for (int i = 0; i < p_argument_count; i++) {
-		PropertyInfo arg;
-		arg.type = Variant::Type(p_argument_info[i].type);
-		arg.name = p_argument_info[i].name;
-		arg.class_name = p_argument_info[i].class_name;
-		arg.hint = PropertyHint(p_argument_info[i].hint);
-		arg.hint_string = p_argument_info[i].hint_string;
-		arg.usage = p_argument_info[i].usage;
+		PropertyInfo arg(p_argument_info[i]);
 		s.arguments.push_back(arg);
 	}
 	ClassDB::add_signal(class_name, s);

--- a/core/object/object.cpp
+++ b/core/object/object.cpp
@@ -493,7 +493,7 @@ void Object::get_property_list(List<PropertyInfo> *p_list, bool p_reversed) cons
 		uint32_t pcount;
 		const GDNativePropertyInfo *pinfo = _extension->get_property_list(_extension_instance, &pcount);
 		for (uint32_t i = 0; i < pcount; i++) {
-			p_list->push_back(PropertyInfo(Variant::Type(pinfo[i].type), pinfo[i].class_name, PropertyHint(pinfo[i].hint), pinfo[i].hint_string, pinfo[i].usage, pinfo[i].class_name));
+			p_list->push_back(PropertyInfo(pinfo[i]));
 		}
 		if (_extension->free_property_list) {
 			_extension->free_property_list(_extension_instance, pinfo);

--- a/core/object/object.h
+++ b/core/object/object.h
@@ -190,6 +190,14 @@ struct PropertyInfo {
 			type(Variant::OBJECT),
 			class_name(p_class_name) {}
 
+	explicit PropertyInfo(const GDNativePropertyInfo &pinfo) :
+			type((Variant::Type)pinfo.type),
+			name(pinfo.name),
+			class_name(pinfo.class_name), // can be null
+			hint((PropertyHint)pinfo.hint),
+			hint_string(pinfo.hint_string), // can be null
+			usage(pinfo.usage) {}
+
 	bool operator==(const PropertyInfo &p_info) const {
 		return ((type == p_info.type) &&
 				(name == p_info.name) &&

--- a/core/object/script_language_extension.h
+++ b/core/object/script_language_extension.h
@@ -671,7 +671,7 @@ public:
 			uint32_t pcount;
 			const GDNativePropertyInfo *pinfo = native_info->get_property_list_func(instance, &pcount);
 			for (uint32_t i = 0; i < pcount; i++) {
-				p_list->push_back(PropertyInfo(Variant::Type(pinfo[i].type), pinfo[i].class_name, PropertyHint(pinfo[i].hint), pinfo[i].hint_string, pinfo[i].usage, pinfo[i].class_name));
+				p_list->push_back(PropertyInfo(pinfo[i]));
 			}
 			if (native_info->free_property_list_func) {
 				native_info->free_property_list_func(instance, pinfo);
@@ -716,9 +716,9 @@ public:
 				m.name = minfo[i].name;
 				m.flags = minfo[i].flags;
 				m.id = minfo[i].id;
-				m.return_val = PropertyInfo(Variant::Type(minfo[i].return_value.type), minfo[i].return_value.class_name, PropertyHint(minfo[i].return_value.hint), minfo[i].return_value.hint_string, minfo[i].return_value.usage, minfo[i].return_value.class_name);
+				m.return_val = PropertyInfo(minfo[i].return_value);
 				for (uint32_t j = 0; j < minfo[i].argument_count; j++) {
-					m.arguments.push_back(PropertyInfo(Variant::Type(minfo[i].arguments[j].type), minfo[i].arguments[j].class_name, PropertyHint(minfo[i].arguments[j].hint), minfo[i].arguments[j].hint_string, minfo[i].arguments[j].usage, minfo[i].arguments[j].class_name));
+					m.arguments.push_back(PropertyInfo(minfo[i].arguments[j]));
 				}
 				const Variant *def_values = (const Variant *)minfo[i].default_arguments;
 				for (uint32_t j = 0; j < minfo[i].default_argument_count; j++) {


### PR DESCRIPTION
Small refactor which adds a constructor
```cpp
explicit PropertyInfo(const GDNativePropertyInfo &pinfo)
```
and uses it in several places, where we need to convert the C struct to the C++ type.

In `core/object/script_language_extension.h`, the previous code passed twice `class_name`, but never `name`. The semantics change with this PR. Is my assumption that this was a mistake correct?

Two style-related points:
* I wasn't entirely sure if the constructor should take its argument by const-pointer or const-reference, as I found both styles in Godot. Let me know if you prefer taking a pointer, I'll gladly change it.
* A delegating constructor could be used instead of an initialization list, if you prefer.