### PR TITLE
Fix setting line edit caret after double and triple click

### DIFF
--- a/scene/gui/line_edit.cpp
+++ b/scene/gui/line_edit.cpp
@@ -312,7 +312,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 						selection.end = text.length();
 						selection.double_click = true;
 						last_dblclk = 0;
-						caret_column = selection.begin;
+						set_caret_column(selection.begin);
 						if (!pass && DisplayServer::get_singleton()->has_feature(DisplayServer::FEATURE_CLIPBOARD_PRIMARY)) {
 							DisplayServer::get_singleton()->clipboard_set_primary(text);
 						}
@@ -327,7 +327,7 @@ void LineEdit::gui_input(const Ref<InputEvent> &p_event) {
 								selection.begin = words[i];
 								selection.end = words[i + 1];
 								selection.double_click = true;
-								caret_column = selection.end;
+								set_caret_column(selection.end);
 								break;
 							}
 						}


### PR DESCRIPTION
This fixes bug in line edit that is caused by double/tripple clicking line edit with context longer than line edit size.

What was happening before:
![before_carets](https://user-images.githubusercontent.com/9964886/172955116-f2ce42bc-0ff9-4bc7-9a2f-4ea6d05d82c5.gif)

Fixed version:
![after_carets](https://user-images.githubusercontent.com/9964886/172955155-22c249c6-25f6-4f95-a283-e78377cbb2db.gif)

