### PR TITLE
Remove viewport restrictions in 2D editor

### DIFF
--- a/editor/plugins/canvas_item_editor_plugin.cpp
+++ b/editor/plugins/canvas_item_editor_plugin.cpp
@@ -763,7 +763,7 @@ List<CanvasItem *> CanvasItemEditor::_get_edited_canvas_items(bool retrieve_lock
 	List<CanvasItem *> selection;
 	for (const KeyValue<Node *, Object *> &E : editor_selection->get_selection()) {
 		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E.key);
-		if (canvas_item && canvas_item->is_visible_in_tree() && canvas_item->get_viewport() == EditorNode::get_singleton()->get_scene_root() && (retrieve_locked || !_is_node_locked(canvas_item))) {
+		if (canvas_item && canvas_item->is_visible_in_tree() && (retrieve_locked || !_is_node_locked(canvas_item))) {
 			CanvasItemEditorSelectedItem *se = editor_selection->get_node_editor_data<CanvasItemEditorSelectedItem>(canvas_item);
 			if (se) {
 				selection.push_back(canvas_item);
@@ -4107,10 +4107,6 @@ void CanvasItemEditor::_insert_animation_keys(bool p_location, bool p_rotation, 
 			continue;
 		}
 
-		if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
-			continue;
-		}
-
 		if (Object::cast_to<Node2D>(canvas_item)) {
 			Node2D *n2d = Object::cast_to<Node2D>(canvas_item);
 
@@ -4311,9 +4307,6 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				if (!canvas_item || !canvas_item->is_inside_tree()) {
 					continue;
 				}
-				if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
-					continue;
-				}
 
 				undo_redo->add_do_method(canvas_item, "set_meta", "_edit_lock_", true);
 				undo_redo->add_undo_method(canvas_item, "remove_meta", "_edit_lock_");
@@ -4331,9 +4324,6 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			for (Node *E : selection) {
 				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E);
 				if (!canvas_item || !canvas_item->is_inside_tree()) {
-					continue;
-				}
-				if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
 					continue;
 				}
 
@@ -4355,9 +4345,6 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 				if (!canvas_item || !canvas_item->is_inside_tree()) {
 					continue;
 				}
-				if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
-					continue;
-				}
 
 				undo_redo->add_do_method(canvas_item, "set_meta", "_edit_group_", true);
 				undo_redo->add_undo_method(canvas_item, "remove_meta", "_edit_group_");
@@ -4375,9 +4362,6 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			for (Node *E : selection) {
 				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E);
 				if (!canvas_item || !canvas_item->is_inside_tree()) {
-					continue;
-				}
-				if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
 					continue;
 				}
 
@@ -4415,10 +4399,6 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			for (const KeyValue<Node *, Object *> &E : selection) {
 				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E.key);
 				if (!canvas_item || !canvas_item->is_visible_in_tree()) {
-					continue;
-				}
-
-				if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
 					continue;
 				}
 
@@ -4461,10 +4441,6 @@ void CanvasItemEditor::_popup_callback(int p_op) {
 			for (const KeyValue<Node *, Object *> &E : selection) {
 				CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E.key);
 				if (!canvas_item || !canvas_item->is_visible_in_tree()) {
-					continue;
-				}
-
-				if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
 					continue;
 				}
 
@@ -4577,9 +4553,6 @@ void CanvasItemEditor::_focus_selection(int p_op) {
 	for (const KeyValue<Node *, Object *> &E : selection) {
 		CanvasItem *canvas_item = Object::cast_to<CanvasItem>(E.key);
 		if (!canvas_item) {
-			continue;
-		}
-		if (canvas_item->get_viewport() != EditorNode::get_singleton()->get_scene_root()) {
 			continue;
 		}
 

--- a/editor/plugins/control_editor_plugin.cpp
+++ b/editor/plugins/control_editor_plugin.cpp
@@ -624,7 +624,7 @@ List<Control *> ControlEditorToolbar::_get_edited_controls(bool retrieve_locked,
 	List<Control *> selection;
 	for (const KeyValue<Node *, Object *> &E : editor_selection->get_selection()) {
 		Control *control = Object::cast_to<Control>(E.key);
-		if (control && control->is_visible_in_tree() && control->get_viewport() == EditorNode::get_singleton()->get_scene_root() && (retrieve_locked || !_is_node_locked(control))) {
+		if (control && control->is_visible_in_tree() && (retrieve_locked || !_is_node_locked(control))) {
 			selection.push_back(control);
 		}
 	}

--- a/scene/gui/control.cpp
+++ b/scene/gui/control.cpp
@@ -1417,7 +1417,7 @@ Rect2 Control::get_parent_anchorable_rect() const {
 	} else {
 #ifdef TOOLS_ENABLED
 		Node *edited_root = get_tree()->get_edited_scene_root();
-		if (edited_root && (this == edited_root || edited_root->is_ancestor_of(this))) {
+		if (edited_root && this == edited_root) {
 			parent_rect.size = Size2(ProjectSettings::get_singleton()->get("display/window/size/viewport_width"), ProjectSettings::get_singleton()->get("display/window/size/viewport_height"));
 		} else {
 			parent_rect = get_viewport()->get_visible_rect();


### PR DESCRIPTION
Attempt to solve the long-standing issue of not being able to move nodes inside another viewport.

At first glance it works great:
![godot windows tools 64_TsolVuywxr](https://user-images.githubusercontent.com/2223172/172970120-955ac4be-f264-481b-97b7-a941d9fa2f49.gif)

Things fall apart when the viewport container is moved:
![godot windows tools 64_x6XAvVYo5U](https://user-images.githubusercontent.com/2223172/172970203-282c9f1e-08b2-4ee2-94b8-7537653e8e23.gif)
Editor gizmos appear relative to the main viewport instead of the sub-viewport.

If the viewport isn't in a container, the offset doesn't appear, but the node doesn't appear either, even though you can edit it...
![godot windows tools 64_eji2P9Zq88](https://user-images.githubusercontent.com/2223172/172970458-c0ff8bf2-7d67-4f7c-8ff8-5cffb9198744.gif)

And then there is Window, which has a position offset, but doesn't display anything:
![godot windows tools 64_dSXtSZpOBw](https://user-images.githubusercontent.com/2223172/172970654-1439795d-8a5a-41bb-8f17-bed45866be2a.gif)

So with this solution, you can edit nodes inside a sub-viewport without a problem, IF the sub viewport is inside a container, which is located at (0, 0). It works in other cases too, but the node isn't displayed correctly.

The main reason I opened this PR is #60088. Dialogs were changed from Control to Window, so their content can't be edited easily. IMO it's time to do something about the viewport issue. The PR lays some foundation, and we could think of some fix for the new problems. Mainly the offset problem. Edited nodes in sub-viewport should somehow be able to offset their gizmos based on the viewport position. Not sure if this is possible.

Resolves #20619
Fixes #60088 (content doesn't display, but technically you can edit it)
Closes https://github.com/godotengine/godot-proposals/issues/2139 (I think?)