### PR TITLE
Use opaque rendering pipeline for alpha hash materials

### DIFF
--- a/drivers/gles3/storage/material_storage.cpp
+++ b/drivers/gles3/storage/material_storage.cpp
@@ -3234,6 +3234,9 @@ void SceneShaderData::set_code(const String &p_code) {
 
 	actions.usage_flag_pointers["ALPHA"] = &uses_alpha;
 	actions.usage_flag_pointers["ALPHA_SCISSOR_THRESHOLD"] = &uses_alpha_clip;
+	// Use alpha clip pipeline for alpha hash/dither.
+	// This prevents sorting issues inherent to alpha blending and allows such materials to cast shadows.
+	actions.usage_flag_pointers["ALPHA_HASH_SCALE"] = &uses_alpha_clip;
 	actions.render_mode_flags["depth_prepass_alpha"] = &uses_depth_pre_pass;
 
 	actions.usage_flag_pointers["SSS_STRENGTH"] = &uses_sss;

--- a/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
+++ b/servers/rendering/renderer_rd/forward_clustered/scene_shader_forward_clustered.cpp
@@ -111,6 +111,9 @@ void SceneShaderForwardClustered::ShaderData::set_code(const String &p_code) {
 
 	actions.usage_flag_pointers["ALPHA"] = &uses_alpha;
 	actions.usage_flag_pointers["ALPHA_SCISSOR_THRESHOLD"] = &uses_alpha_clip;
+	// Use alpha clip pipeline for alpha hash/dither.
+	// This prevents sorting issues inherent to alpha blending and allows such materials to cast shadows.
+	actions.usage_flag_pointers["ALPHA_HASH_SCALE"] = &uses_alpha_clip;
 	actions.render_mode_flags["depth_prepass_alpha"] = &uses_depth_pre_pass;
 
 	actions.usage_flag_pointers["SSS_STRENGTH"] = &uses_sss;

--- a/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
+++ b/servers/rendering/renderer_rd/forward_mobile/scene_shader_forward_mobile.cpp
@@ -112,6 +112,9 @@ void SceneShaderForwardMobile::ShaderData::set_code(const String &p_code) {
 
 	actions.usage_flag_pointers["ALPHA"] = &uses_alpha;
 	actions.usage_flag_pointers["ALPHA_SCISSOR_THRESHOLD"] = &uses_alpha_clip;
+	// Use alpha clip pipeline for alpha hash/dither.
+	// This prevents sorting issues inherent to alpha blending and allows such materials to cast shadows.
+	actions.usage_flag_pointers["ALPHA_HASH_SCALE"] = &uses_alpha_clip;
 	actions.render_mode_flags["depth_prepass_alpha"] = &uses_depth_pre_pass;
 
 	// actions.usage_flag_pointers["SSS_STRENGTH"] = &uses_sss;


### PR DESCRIPTION
**Note:** Recommended to be merged after https://github.com/godotengine/godot/pull/61880, as shadows will look significantly better with that PR.

This has several benefits:

- Transparency sorting issues inherent to alpha blending no longer occur.
- Alpha hash materials can now cast shadows (also works with GeometryInstance3D Transparency's property for alpha hash materials).
- Higher performance.

This closes https://github.com/godotengine/godot/issues/61882.

**Testing project:** [test_alpha_hash_1.zip](https://github.com/godotengine/godot/files/8877591/test_alpha_hash_1.zip)

## Preview (with https://github.com/godotengine/godot/pull/61880 on top)

![2022-06-10_11 03 15](https://user-images.githubusercontent.com/180032/173032766-f473582d-28b8-4686-86f0-a204545215ae.png)

![2022-06-10_11 03 23](https://user-images.githubusercontent.com/180032/173032769-388acb2d-df40-4779-aefd-d281165bd982.png)

## TODO

- [ ] Figure out if a special shadow shader `#ifdef` can be used to compute the noise pattern in shadow texture space, rather than in view space. This would prevent the shadow map when flickering when the camera moves or rotates. In the meantime, enabling FXAA, TAA or increasing shadow blur can mitigate this flickering.
  - Is such an `#ifdef` currently available? See https://github.com/godotengine/godot-proposals/issues/4443.