### PR TITLE
Improved way of getting MethodTrack keys

### DIFF
--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -276,7 +276,7 @@ double AnimationNode::_blend_node(const StringName &p_subpath, const Vector<Stri
 	String new_path;
 	AnimationNode *new_parent;
 
-	//this is the slowest part of processing, but as strings process in powers of 2, and the paths always exist, it will not result in that many allocations
+	// This is the slowest part of processing, but as strings process in powers of 2, and the paths always exist, it will not result in that many allocations.
 	if (p_new_parent) {
 		new_parent = p_new_parent;
 		new_path = String(base_path) + String(p_subpath) + "/";
@@ -286,6 +286,9 @@ double AnimationNode::_blend_node(const StringName &p_subpath, const Vector<Stri
 		new_path = String(parent->base_path) + String(p_subpath) + "/";
 	}
 
+	// If tracks for blending don't exist for one of the animations, Rest or RESET animation is blended as init animation instead.
+	// Then, blend weight is 0 means that the init animation blend weight is 1.
+	// Therefore, the blending process must be executed even if the blend weight is 0.
 	if (!p_seek && p_optimize && !any_valid) {
 		return p_node->_pre_process(new_path, new_parent, state, 0, p_seek, p_seek_root, p_connections);
 	}
@@ -1324,12 +1327,21 @@ void AnimationTree::_process_graph(double p_delta) {
 							if (blend < CMP_EPSILON) {
 								continue; //nothing to blend
 							}
-							List<int> indices;
-							a->value_track_get_key_indices(i, time, delta, &indices, pingponged);
 
-							for (int &F : indices) {
-								Variant value = a->track_get_key_value(i, F);
+							if (seeked) {
+								int idx = a->track_find_key(i, time);
+								if (idx < 0) {
+									continue;
+								}
+								Variant value = a->track_get_key_value(i, idx);
 								t->object->set_indexed(t->subpath, value);
+							} else {
+								List<int> indices;
+								a->value_track_get_key_indices(i, time, delta, &indices, pingponged);
+								for (int &F : indices) {
+									Variant value = a->track_get_key_value(i, F);
+									t->object->set_indexed(t->subpath, value);
+								}
 							}
 						}
 
@@ -1338,20 +1350,27 @@ void AnimationTree::_process_graph(double p_delta) {
 						if (blend < CMP_EPSILON) {
 							continue; //nothing to blend
 						}
-						if (!seeked && Math::is_zero_approx(delta)) {
-							continue;
-						}
 						TrackCacheMethod *t = static_cast<TrackCacheMethod *>(track);
 
-						List<int> indices;
-
-						a->method_track_get_key_indices(i, time, delta, &indices, pingponged);
-
-						for (int &F : indices) {
-							StringName method = a->method_track_get_name(i, F);
-							Vector<Variant> params = a->method_track_get_params(i, F);
+						if (seeked) {
+							int idx = a->track_find_key(i, time);
+							if (idx < 0) {
+								continue;
+							}
+							StringName method = a->method_track_get_name(i, idx);
+							Vector<Variant> params = a->method_track_get_params(i, idx);
 							if (can_call) {
-								_call_object(t->object, method, params, true);
+								_call_object(t->object, method, params, false);
+							}
+						} else {
+							List<int> indices;
+							a->method_track_get_key_indices(i, time, delta, &indices, pingponged);
+							for (int &F : indices) {
+								StringName method = a->method_track_get_name(i, F);
+								Vector<Variant> params = a->method_track_get_params(i, F);
+								if (can_call) {
+									_call_object(t->object, method, params, true);
+								}
 							}
 						}
 					} break;


### PR DESCRIPTION
Fixed #61766. Fixed **partially** #61853.
Supersede #61836.

MethodTrack kept the old checking algorithm. In the past, `delta == 0` was used as a flag for having done a seek, but this is not necessary since `seeked` can be used. So remove it and this will be fixed #61766.

Instead, MethodTrack should get a key to not consider delta when seeking, as the same way with AudioTrack.

For example in ValueTrack:
```cpp
if (seeked) {
	int idx = a->track_find_key(i, time); // Not considering delta.
	Variant value = a->track_get_key_value(i, idx);
	t->object->set_indexed(t->subpath, value);
} else {
	List<int> indices;
	a->value_track_get_key_indices(i, time, delta, &indices, pingponged); // Considering delta.
	for (int &F : indices) {
		Variant value = a->track_get_key_value(i, F);
		t->object->set_indexed(t->subpath, value);
	}
}
```

However, this fix prevents the behavior of "firing the end key at restart" in #61853, but it does not prevent the behavior of "firing the first key twice".

To be exact, it is fired in two frames, "the seek frame" and "the playbacked next frame"; **if nothing is done in the seek frame, there could be a delay if there is user input**. In the past, that delay was a problem with ValueTrack's Discrete mode, so I fixed it in #52518.

This double firing is not as much of a problem for AudioTrack and AnimationTrack, since they are checked for double insertion into the queue by `HashSet::insert()`. For ValueTrack, even if a value is set twice, it is not a problem unless there is a signal to subscribe to it. However with MethodTrack, it is enough of a problem.

Since MethodTrack calls are only fire in one frame, and it is impossible to determine how many frames will be processed by a call, so it is not possible to create a queue. At least at both ends of pingpong, it is possible to check for duplicates in one frame so it can be avoided, but it does not solve the problem in Seek.

At the moment, a compromise is to add a check such as `if (is_processing)` to the GDScript side of the MethodTrack call to prevent multiple processing.
