### PR TITLE
Fix description about `SceneTreeTimer` auto free

### DIFF
--- a/doc/classes/SceneTreeTimer.xml
+++ b/doc/classes/SceneTreeTimer.xml
@@ -22,7 +22,7 @@
 		}
 		[/csharp]
 		[/codeblocks]
-		The timer will be automatically freed after its time elapses, so be aware that any reference you might have kept to it will become invalid.
+		The timer will be dereferenced after its time elapses. To preserve the timer, you can keep a reference to it. See [RefCounted].
 	</description>
 	<tutorials>
 	</tutorials>


### PR DESCRIPTION
After time out, any existing reference to that `SceneTreeTimer` will still be valid as it's ref-counted.

For cherry-pick: `RefCounted` -> `Reference`.