### PR TITLE
Remove engine version from visual shader

### DIFF
--- a/doc/classes/VisualShader.xml
+++ b/doc/classes/VisualShader.xml
@@ -166,10 +166,6 @@
 		</method>
 	</methods>
 	<members>
-		<member name="engine_version" type="Dictionary" setter="set_engine_version" getter="get_engine_version" default="{}">
-			The Godot version this [VisualShader] was designed for, in the form of a [Dictionary] with [code]major[/code] and [code]minor[/code] keys with integer values. Example: [code]{"major": 4, "minor": 0}[/code]
-			This is used by the editor to convert visual shaders from older Godot versions.
-		</member>
 		<member name="graph_offset" type="Vector2" setter="set_graph_offset" getter="get_graph_offset" default="Vector2(0, 0)">
 			The offset vector of the whole graph.
 		</member>

--- a/editor/plugins/visual_shader_editor_plugin.cpp
+++ b/editor/plugins/visual_shader_editor_plugin.cpp
@@ -1102,27 +1102,6 @@ void VisualShaderEditor::edit(VisualShader *p_visual_shader) {
 		if (!visual_shader->is_connected("changed", ce)) {
 			visual_shader->connect("changed", ce);
 		}
-#ifndef DISABLE_DEPRECATED
-		Dictionary engine_version = Engine::get_singleton()->get_version_info();
-		static Array components;
-		if (components.is_empty()) {
-			components.push_back("major");
-			components.push_back("minor");
-		}
-		const Dictionary vs_version = visual_shader->get_engine_version();
-		if (!vs_version.has_all(components)) {
-			visual_shader->update_engine_version(engine_version);
-			print_line(vformat(TTR("The shader (\"%s\") has been updated to correspond Godot %s.%s version."), visual_shader->get_path(), engine_version["major"], engine_version["minor"]));
-		} else {
-			for (int i = 0; i < components.size(); i++) {
-				if (vs_version[components[i]] != engine_version[components[i]]) {
-					visual_shader->update_engine_version(engine_version);
-					print_line(vformat(TTR("The shader (\"%s\") has been updated to correspond Godot %s.%s version."), visual_shader->get_path(), engine_version["major"], engine_version["minor"]));
-					break;
-				}
-			}
-		}
-#endif
 		visual_shader->set_graph_offset(graph->get_scroll_ofs() / EDSCALE);
 		_set_mode(visual_shader->get_mode());
 	} else {

--- a/editor/shader_create_dialog.cpp
+++ b/editor/shader_create_dialog.cpp
@@ -184,7 +184,6 @@ void ShaderCreateDialog::_create_new() {
 		Ref<VisualShader> visual_shader;
 		visual_shader.instantiate();
 		shader = visual_shader;
-		visual_shader->set_engine_version(Engine::get_singleton()->get_version_info());
 		visual_shader->set_mode(Shader::Mode(current_mode));
 	}
 

--- a/scene/resources/visual_shader.cpp
+++ b/scene/resources/visual_shader.cpp
@@ -712,86 +712,6 @@ VisualShader::VaryingType VisualShader::get_varying_type(const String &p_name) {
 	return varyings[p_name].type;
 }
 
-void VisualShader::set_engine_version(const Dictionary &p_engine_version) {
-	ERR_FAIL_COND(!p_engine_version.has("major"));
-	ERR_FAIL_COND(!p_engine_version.has("minor"));
-	engine_version["major"] = p_engine_version["major"];
-	engine_version["minor"] = p_engine_version["minor"];
-}
-
-Dictionary VisualShader::get_engine_version() const {
-	return engine_version;
-}
-
-#ifndef DISABLE_DEPRECATED
-
-void VisualShader::update_engine_version(const Dictionary &p_new_version) {
-	if (engine_version.is_empty()) { // before 4.0
-		for (int i = 0; i < TYPE_MAX; i++) {
-			for (KeyValue<int, Node> &E : graph[i].nodes) {
-				Ref<VisualShaderNodeInput> input = Object::cast_to<VisualShaderNodeInput>(E.value.node.ptr());
-				if (input.is_valid()) {
-					if (input->get_input_name() == "side") {
-						input->set_input_name("front_facing");
-					}
-				}
-				Ref<VisualShaderNodeExpression> expression = Object::cast_to<VisualShaderNodeExpression>(E.value.node.ptr());
-				if (expression.is_valid()) {
-					for (int j = 0; j < expression->get_input_port_count(); j++) {
-						int type = expression->get_input_port_type(j);
-						if (type > 0) { // + PORT_TYPE_SCALAR_INT + PORT_TYPE_VECTOR_2D
-							type += 2;
-						}
-						expression->set_input_port_type(j, type);
-					}
-					for (int j = 0; j < expression->get_output_port_count(); j++) {
-						int type = expression->get_output_port_type(j);
-						if (type > 0) { // + PORT_TYPE_SCALAR_INT + PORT_TYPE_VECTOR_2D
-							type += 2;
-						}
-						expression->set_output_port_type(j, type);
-					}
-				}
-				Ref<VisualShaderNodeStep> step = Object::cast_to<VisualShaderNodeStep>(E.value.node.ptr());
-				if (step.is_valid()) {
-					int op_type = int(step->get_op_type());
-					if (int(op_type) > 0) { // + OP_TYPE_VECTOR_2D + OP_TYPE_VECTOR_2D_SCALAR
-						op_type += 2;
-					}
-					step->set_op_type(VisualShaderNodeStep::OpType(op_type));
-				}
-				Ref<VisualShaderNodeSmoothStep> sstep = Object::cast_to<VisualShaderNodeSmoothStep>(E.value.node.ptr());
-				if (sstep.is_valid()) {
-					int op_type = int(sstep->get_op_type());
-					if (int(op_type) > 0) { // + OP_TYPE_VECTOR_2D + OP_TYPE_VECTOR_2D_SCALAR
-						op_type += 2;
-					}
-					sstep->set_op_type(VisualShaderNodeSmoothStep::OpType(op_type));
-				}
-				Ref<VisualShaderNodeMix> mix = Object::cast_to<VisualShaderNodeMix>(E.value.node.ptr());
-				if (mix.is_valid()) {
-					int op_type = int(mix->get_op_type());
-					if (int(op_type) > 0) { // + OP_TYPE_VECTOR_2D + OP_TYPE_VECTOR_2D_SCALAR
-						op_type += 2;
-					}
-					mix->set_op_type(VisualShaderNodeMix::OpType(op_type));
-				}
-				Ref<VisualShaderNodeCompare> compare = Object::cast_to<VisualShaderNodeCompare>(E.value.node.ptr());
-				if (compare.is_valid()) {
-					int ctype = int(compare->get_comparison_type());
-					if (int(ctype) > 0) { // + CTYPE_SCALAR_INT + CTYPE_VECTOR_2D
-						ctype += 2;
-					}
-					compare->set_comparison_type(VisualShaderNodeCompare::ComparisonType(ctype));
-				}
-			}
-		}
-	}
-	set_engine_version(p_new_version);
-}
-
-#endif /* DISABLE_DEPRECATED */
-
 void VisualShader::add_node(Type p_type, const Ref<VisualShaderNode> &p_node, const Vector2 &p_position, int p_id) {
 	ERR_FAIL_COND(p_node.is_null());
 	ERR_FAIL_COND(p_id < 2);
@@ -2628,9 +2548,6 @@ void VisualShader::_bind_methods() {
 
 	ClassDB::bind_method(D_METHOD("get_node_connections", "type"), &VisualShader::_get_node_connections);
 
-	ClassDB::bind_method(D_METHOD("set_engine_version", "version"), &VisualShader::set_engine_version);
-	ClassDB::bind_method(D_METHOD("get_engine_version"), &VisualShader::get_engine_version);
-
 	ClassDB::bind_method(D_METHOD("set_graph_offset", "offset"), &VisualShader::set_graph_offset);
 	ClassDB::bind_method(D_METHOD("get_graph_offset"), &VisualShader::get_graph_offset);
 
@@ -2641,7 +2558,6 @@ void VisualShader::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_update_shader"), &VisualShader::_update_shader);
 
 	ADD_PROPERTY(PropertyInfo(Variant::VECTOR2, "graph_offset", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_graph_offset", "get_graph_offset");
-	ADD_PROPERTY(PropertyInfo(Variant::DICTIONARY, "engine_version", PROPERTY_HINT_NONE, "", PROPERTY_USAGE_NO_EDITOR), "set_engine_version", "get_engine_version");
 
 	ADD_PROPERTY_DEFAULT("code", ""); // Inherited from Shader, prevents showing default code as override in docs.
 

--- a/scene/resources/visual_shader.h
+++ b/scene/resources/visual_shader.h
@@ -44,8 +44,6 @@ class VisualShader : public Shader {
 
 	friend class VisualShaderNodeVersionChecker;
 
-	Dictionary engine_version;
-
 public:
 	enum Type {
 		TYPE_VERTEX,
@@ -176,14 +174,6 @@ protected:
 public: // internal methods
 	void set_shader_type(Type p_type);
 	Type get_shader_type() const;
-
-public:
-	void set_engine_version(const Dictionary &p_version);
-	Dictionary get_engine_version() const;
-
-#ifndef DISABLE_DEPRECATED
-	void update_engine_version(const Dictionary &p_new_version);
-#endif /* DISABLE_DEPRECATED */
 
 	enum {
 		NODE_ID_INVALID = -1,


### PR DESCRIPTION
I'm not sure that keeping that information inside a visual shader resource and providing limited auto-converting capability to a new version (inside the engine itself) is a good idea. I think this is a specific case, and it's better to be a plugin rather than providing capability for a growing list of features to conversion for each version. And since we are breaking compatibility in 4.0 it doesn't matter.
