### PR TITLE
etcpak: Update to upstream release 1.0 (June 4, 2022)

### DIFF
--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -179,7 +179,7 @@ License: Expat
 
 Files: ./thirdparty/etcpak/
 Comment: etcpak
-Copyright: 2013-2021, Bartosz Taudul
+Copyright: 2013-2022, Bartosz Taudul
 License: BSD-3-clause
 
 Files: ./thirdparty/fonts/DroidSans*.woff2

--- a/thirdparty/README.md
+++ b/thirdparty/README.md
@@ -118,7 +118,7 @@ will limit its functionality to IPv4 only.
 ## etcpak
 
 - Upstream: https://github.com/wolfpld/etcpak
-- Version: git (f128369e64a5f4715de8125b325e4fe7debb5194, 2022)
+- Version: 1.0 (a77d5a37ddf48034cee8aeb9e8792a623c265b4c, 2022)
 - License: BSD-3-Clause
 
 Files extracted from upstream source:

--- a/thirdparty/etcpak/AUTHORS.txt
+++ b/thirdparty/etcpak/AUTHORS.txt
@@ -1,3 +1,5 @@
 Bartosz Taudul <wolf@nereid.pl>
 Daniel Jungmann <el.3d.source@gmail.com>
 Florian Penzkofer <fp@nullptr.de>
+Jae-Ho Nah <nahjaeho@gmail.com>
+Marcin Ławicki <marcin.lawicki@gmail.com>

--- a/thirdparty/etcpak/LICENSE.txt
+++ b/thirdparty/etcpak/LICENSE.txt
@@ -1,6 +1,6 @@
 etcpak, an extremely fast ETC compression utility (https://github.com/wolfpld/etcpak)
 
-Copyright (c) 2013-2021, Bartosz Taudul <wolf@nereid.pl>
+Copyright (c) 2013-2022, Bartosz Taudul <wolf@nereid.pl>
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
No change compared to our previous commit, just documentation update
and a release tag we can track.