### PR TITLE
Add tooltips to Export dialog icon buttons

### DIFF
--- a/editor/project_export.cpp
+++ b/editor/project_export.cpp
@@ -1027,10 +1027,12 @@ ProjectExportDialog::ProjectExportDialog() {
 	mc->add_child(presets);
 	presets->connect("item_selected", callable_mp(this, &ProjectExportDialog::_edit_preset));
 	duplicate_preset = memnew(Button);
+	duplicate_preset->set_tooltip(TTR("Duplicate"));
 	duplicate_preset->set_flat(true);
 	preset_hb->add_child(duplicate_preset);
 	duplicate_preset->connect("pressed", callable_mp(this, &ProjectExportDialog::_duplicate_preset));
 	delete_preset = memnew(Button);
+	delete_preset->set_tooltip(TTR("Delete"));
 	delete_preset->set_flat(true);
 	preset_hb->add_child(delete_preset);
 	delete_preset->connect("pressed", callable_mp(this, &ProjectExportDialog::_delete_preset));


### PR DESCRIPTION
The two icon buttons are currently missing tooltips.

![Peek 2022-06-10 18-36](https://user-images.githubusercontent.com/372476/173048324-275b08b5-f78e-47d8-9616-50777e169ad4.gif)
