### PR TITLE
Handle backward for animation track

### DIFF
--- a/scene/animation/animation_player.cpp
+++ b/scene/animation/animation_player.cpp
@@ -764,7 +764,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 
 				if (p_seeked) {
 					//find whatever should be playing
-					int idx = a->track_find_key(i, p_time);
+					int idx = a->track_find_key(i, p_time, false, backward);
 					if (idx < 0) {
 						continue;
 					}
@@ -804,7 +804,9 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 				} else {
 					//find stuff to play
 					List<int> to_play;
-					a->track_get_key_indices_in_range(i, p_time, p_delta, &to_play, p_pingponged);
+					HashMap<StringName, real_t> duration_set;
+					// TODO Fill with duration
+					a->track_get_key_indices_in_range(&duration_set, i, p_time, p_delta, &to_play, p_pingponged);
 					if (to_play.size()) {
 						int idx = to_play.back()->get();
 
@@ -866,7 +868,7 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 
 				if (p_delta == 0 || p_seeked) {
 					//seek
-					int idx = a->track_find_key(i, p_time);
+					int idx = a->track_find_key(i, p_time, false, false);
 					if (idx < 0) {
 						continue;
 					}
@@ -900,8 +902,13 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 					}
 
 					if (player->is_playing() || p_seeked) {
-						player->play(anim_name);
-						player->seek(at_anim_pos);
+						if(backward) {
+							player->play_backwards(anim_name);
+							player->seek(at_anim_pos);
+						}else {
+							player->play(anim_name);
+							player->seek(at_anim_pos);
+						}
 						nc->animation_playing = true;
 						playing_caches.insert(nc);
 					} else {
@@ -911,7 +918,9 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 				} else {
 					//find stuff to play
 					List<int> to_play;
-					a->track_get_key_indices_in_range(i, p_time, p_delta, &to_play, p_pingponged);
+					HashMap<StringName, real_t> duration_set;
+					player->get_animation_duration_set(&duration_set);
+					a->track_get_key_indices_in_range(&duration_set, i, p_time, p_delta, &to_play, p_pingponged, backward);
 					if (to_play.size()) {
 						int idx = to_play.back()->get();
 
@@ -923,8 +932,13 @@ void AnimationPlayer::_animation_process_animation(AnimationData *p_anim, double
 								nc->animation_playing = false;
 							}
 						} else {
-							player->play(anim_name);
-							player->seek(0.0, true);
+							if(backward) {
+								player->play_backwards(anim_name);
+								// player->seek(0.0, true);
+							}else {
+								player->play(anim_name);
+								player->seek(0.0, true);
+							}
 							nc->animation_playing = true;
 							playing_caches.insert(nc);
 						}
@@ -1487,7 +1501,12 @@ void AnimationPlayer::get_animation_list(List<StringName> *p_animations) const {
 		p_animations->push_back(E);
 	}
 }
-
+void AnimationPlayer::get_animation_duration_set(HashMap<StringName, real_t> *p_animations) const {
+	for (const KeyValue<StringName, AnimationData> &E : animation_set) {
+		real_t duration = E.value.animation.ptr()->get_length();
+		p_animations->insert(E.key, duration);
+	}
+}
 void AnimationPlayer::set_blend_time(const StringName &p_animation1, const StringName &p_animation2, float p_time) {
 	ERR_FAIL_COND_MSG(!animation_set.has(p_animation1), vformat("Animation not found: %s.", p_animation1));
 	ERR_FAIL_COND_MSG(!animation_set.has(p_animation2), vformat("Animation not found: %s.", p_animation2));
@@ -1588,7 +1607,7 @@ void AnimationPlayer::play(const StringName &p_name, float p_custom_blend, float
 	}
 
 	if (get_current_animation() != p_name) {
-		_stop_playing_caches();
+		_stop_playing_caches(false);
 	}
 
 	c.current.from = &animation_set[name];
@@ -1662,7 +1681,7 @@ String AnimationPlayer::get_assigned_animation() const {
 }
 
 void AnimationPlayer::stop(bool p_reset) {
-	_stop_playing_caches();
+	_stop_playing_caches(p_reset);
 	Playback &c = playback;
 	c.blend.clear();
 	if (p_reset) {
@@ -1745,7 +1764,7 @@ void AnimationPlayer::_animation_changed() {
 	}
 }
 
-void AnimationPlayer::_stop_playing_caches() {
+void AnimationPlayer::_stop_playing_caches(bool p_reset) {
 	for (TrackNodeCache *E : playing_caches) {
 		if (E->node && E->audio_playing) {
 			E->node->call(SNAME("stop"));
@@ -1755,7 +1774,7 @@ void AnimationPlayer::_stop_playing_caches() {
 			if (!player) {
 				continue;
 			}
-			player->stop();
+			player->stop(p_reset);
 		}
 	}
 
@@ -1767,7 +1786,7 @@ void AnimationPlayer::_node_removed(Node *p_node) {
 }
 
 void AnimationPlayer::clear_caches() {
-	_stop_playing_caches();
+	_stop_playing_caches(true);
 
 	node_cache_map.clear();
 

--- a/scene/animation/animation_player.h
+++ b/scene/animation/animation_player.h
@@ -273,7 +273,7 @@ private:
 	void _animation_process(double p_delta);
 
 	void _node_removed(Node *p_node);
-	void _stop_playing_caches();
+	void _stop_playing_caches(bool p_reset = true);
 
 	// bind helpers
 	Vector<String> _get_animation_list() const {
@@ -327,6 +327,9 @@ public:
 	Ref<Animation> get_animation(const StringName &p_name) const;
 	void get_animation_list(List<StringName> *p_animations) const;
 	bool has_animation(const StringName &p_name) const;
+
+	
+	void get_animation_duration_set(HashMap<StringName, real_t> *p_animations) const;
 
 	void set_blend_time(const StringName &p_animation1, const StringName &p_animation2, float p_time);
 	float get_blend_time(const StringName &p_animation1, const StringName &p_animation2) const;

--- a/scene/animation/animation_tree.cpp
+++ b/scene/animation/animation_tree.cpp
@@ -1415,7 +1415,9 @@ void AnimationTree::_process_graph(double p_delta) {
 						} else {
 							//find stuff to play
 							List<int> to_play;
-							a->track_get_key_indices_in_range(i, time, delta, &to_play, pingponged);
+							HashMap<StringName, real_t> duration_set;
+							// TODO Fill with duration
+							a->track_get_key_indices_in_range(&duration_set, i, time, delta, &to_play, pingponged);
 							if (to_play.size()) {
 								int idx = to_play.back()->get();
 
@@ -1537,7 +1539,9 @@ void AnimationTree::_process_graph(double p_delta) {
 						} else {
 							//find stuff to play
 							List<int> to_play;
-							a->track_get_key_indices_in_range(i, time, delta, &to_play, pingponged);
+							HashMap<StringName, real_t> duration_set;
+							// TODO Fill with duration
+							a->track_get_key_indices_in_range(&duration_set, i, time, delta, &to_play, pingponged);
 							if (to_play.size()) {
 								int idx = to_play.back()->get();
 

--- a/scene/resources/animation.cpp
+++ b/scene/resources/animation.cpp
@@ -1385,7 +1385,7 @@ void Animation::track_remove_key(int p_track, int p_idx) {
 	emit_changed();
 }
 
-int Animation::track_find_key(int p_track, double p_time, bool p_exact) const {
+int Animation::track_find_key(int p_track, double p_time, bool p_exact, bool backward) const {
 	ERR_FAIL_INDEX_V(p_track, tracks.size(), -1);
 	Track *t = tracks[p_track];
 
@@ -1548,7 +1548,7 @@ int Animation::track_find_key(int p_track, double p_time, bool p_exact) const {
 		} break;
 		case TYPE_ANIMATION: {
 			AnimationTrack *at = static_cast<AnimationTrack *>(t);
-			int k = _find(at->values, p_time);
+			int k = _find(at->values, p_time, backward);
 			if (k < 0 || k >= at->values.size()) {
 				return -1;
 			}
@@ -2256,8 +2256,8 @@ int Animation::_find(const Vector<K> &p_keys, double p_time, bool p_backward) co
 
 	while (low <= high) {
 		middle = (low + high) / 2;
-
-		if (Math::is_equal_approx(p_time, (double)keys[middle].time)) { //match
+		double key_time = (double)keys[middle].time;
+		if (Math::is_equal_approx(p_time, key_time)) { //match
 			return middle;
 		} else if (p_time < keys[middle].time) {
 			high = middle - 1; //search low end of array
@@ -2730,12 +2730,12 @@ Animation::UpdateMode Animation::value_track_get_update_mode(int p_track) const 
 }
 
 template <class T>
-void Animation::_track_get_key_indices_in_range(const Vector<T> &p_array, double from_time, double to_time, List<int> *p_indices) const {
+void Animation::_track_get_key_indices_in_range(const Vector<T> &p_array, double from_time, double to_time, List<int> *p_indices, bool backward) const {
 	if (from_time != length && to_time == length) {
 		to_time = length + CMP_EPSILON; //include a little more if at the end
 	}
 
-	int to = _find(p_array, to_time);
+	int to = _find(p_array, to_time, false);
 
 	// can't really send the events == time, will be sent in the next frame.
 	// if event>=len then it will probably never be requested by the anim player.
@@ -2763,7 +2763,8 @@ void Animation::_track_get_key_indices_in_range(const Vector<T> &p_array, double
 	}
 }
 
-void Animation::track_get_key_indices_in_range(int p_track, double p_time, double p_delta, List<int> *p_indices, int p_pingponged) const {
+//void Animation::track_get_key_indices_in_range(HashMap<StringName, Ref<Animation>> animations, int p_track, double p_time, double p_delta, List<int> *p_indices, int p_pingponged, bool backward) const {
+void Animation::track_get_key_indices_in_range(HashMap<StringName, real_t> *anim_durations, int p_track, double p_time, double p_delta, List<int> *p_indices, int p_pingponged, bool backward) const {
 	ERR_FAIL_INDEX(p_track, tracks.size());
 	const Track *t = tracks[p_track];
 
@@ -3076,7 +3077,17 @@ void Animation::track_get_key_indices_in_range(int p_track, double p_time, doubl
 		} break;
 		case TYPE_ANIMATION: {
 			const AnimationTrack *an = static_cast<const AnimationTrack *>(t);
-			_track_get_key_indices_in_range(an->values, from_time, to_time, p_indices);
+			const Vector<Animation::TKey<StringName>> values = an->get_values(backward);
+			Vector<Animation::TKey<StringName>> formated_values;
+			for (int i=0; i<values.size(); i++) {
+				Animation::TKey<StringName> v = values[i];
+				if(backward) {
+					v.time = v.time + anim_durations->get(v.value);
+				}
+				formated_values.push_back(v);
+			}
+			// Mutate for backward
+			_track_get_key_indices_in_range(formated_values, from_time, to_time, p_indices, backward);
 		} break;
 	}
 }

--- a/scene/resources/animation.h
+++ b/scene/resources/animation.h
@@ -195,7 +195,7 @@ private:
 		}
 	};
 
-	/* AUDIO TRACK */
+	/* ANIMATION TRACK */
 
 	struct AnimationTrack : public Track {
 		Vector<TKey<StringName>> values;
@@ -203,6 +203,14 @@ private:
 		AnimationTrack() {
 			type = TYPE_ANIMATION;
 		}
+		const Vector<TKey<StringName>> get_values(bool backward) const{
+			if(backward) {
+				// TODO Should put time value in frame == to value of frame + duration of animation
+				return values;
+			}else {
+				return values;
+			}
+		}	
 	};
 
 	Vector<Track *> tracks;
@@ -235,7 +243,7 @@ private:
 	_FORCE_INLINE_ T _interpolate(const Vector<TKey<T>> &p_keys, double p_time, InterpolationType p_interp, bool p_loop_wrap, bool *p_ok, bool p_backward = false) const;
 
 	template <class T>
-	_FORCE_INLINE_ void _track_get_key_indices_in_range(const Vector<T> &p_array, double from_time, double to_time, List<int> *p_indices) const;
+	_FORCE_INLINE_ void _track_get_key_indices_in_range(const Vector<T> &p_array, double from_time, double to_time, List<int> *p_indices, bool backward = false) const;
 
 	_FORCE_INLINE_ void _value_track_get_key_indices_in_range(const ValueTrack *vt, double from_time, double to_time, List<int> *p_indices) const;
 	_FORCE_INLINE_ void _method_track_get_key_indices_in_range(const MethodTrack *mt, double from_time, double to_time, List<int> *p_indices) const;
@@ -396,7 +404,7 @@ public:
 	void track_set_key_transition(int p_track, int p_key_idx, real_t p_transition);
 	void track_set_key_value(int p_track, int p_key_idx, const Variant &p_value);
 	void track_set_key_time(int p_track, int p_key_idx, double p_time);
-	int track_find_key(int p_track, double p_time, bool p_exact = false) const;
+	int track_find_key(int p_track, double p_time, bool p_exact = false, bool backward = false) const;
 	void track_remove_key(int p_track, int p_idx);
 	void track_remove_key_at_time(int p_track, double p_time);
 	int track_get_key_count(int p_track) const;
@@ -462,8 +470,8 @@ public:
 
 	void copy_track(int p_track, Ref<Animation> p_to_animation);
 
-	void track_get_key_indices_in_range(int p_track, double p_time, double p_delta, List<int> *p_indices, int p_pingponged = 0) const;
-
+	//void track_get_key_indices_in_range(HashMap<StringName, Ref<Animation>> animations, int p_track, double p_time, double p_delta, List<int> *p_indices, int p_pingponged = 0, bool backward = false) const;
+	void track_get_key_indices_in_range(HashMap<StringName, real_t> *anim_durations, int p_track, double p_time, double p_delta, List<int> *p_indices, int p_pingponged = 0, bool backward = false) const;
 	void set_length(real_t p_length);
 	real_t get_length() const;
 

--- a/scene/resources/animation_library.cpp
+++ b/scene/resources/animation_library.cpp
@@ -114,6 +114,12 @@ void AnimationLibrary::get_animation_list(List<StringName> *p_animations) const 
 	}
 }
 
+void AnimationLibrary::get_animations(HashMap<StringName, Ref<Animation>> *p_animations) const {
+	for (const KeyValue<StringName, Ref<Animation>> &E : animations) {
+		p_animations->insert(E.key, E.value);
+	}
+}
+
 void AnimationLibrary::_set_data(const Dictionary &p_data) {
 	animations.clear();
 	List<Variant> keys;

--- a/scene/resources/animation_library.h
+++ b/scene/resources/animation_library.h
@@ -59,6 +59,7 @@ public:
 	bool has_animation(const StringName &p_name) const;
 	Ref<Animation> get_animation(const StringName &p_name) const;
 	void get_animation_list(List<StringName> *p_animations) const;
+	void get_animations(HashMap<StringName, Ref<Animation>> *p_animations) const;
 
 	AnimationLibrary();
 };


### PR DESCRIPTION
I was facing an issue on my project when trying to play animation track backward:
![bug_animation_before](https://user-images.githubusercontent.com/6182189/173067057-ec06282f-3100-48d4-87cf-20d9983565ec.gif)
I fixed it by using the animation length to search for position in AnimationTrack:
![bug_animation_after](https://user-images.githubusercontent.com/6182189/173067082-91faab80-c2a8-4f32-bb7d-debf9106a0eb.gif)
Before cleaning this and make the proper mege:

- [ ] Evaluate conflicts with #56645
- [ ] Fix behavior on ping pong mode with sub animation overlapping end  (See Colorer animation in gifs)
- [ ] Clear the `get_key_indices_in_range` methods
- [ ] Find proper way to access duration set when looking for position in sub animation
